### PR TITLE
DAOS-10495 control: Allow fanout RPCs to report progress (#8955)

### DIFF
--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -111,8 +111,8 @@ func (cmd *systemQueryCmd) Execute(_ []string) (errOut error) {
 		return err
 	}
 	req := new(control.SystemQueryReq)
-	req.Hosts.ReplaceSet(hostSet)
-	req.Ranks.ReplaceSet(rankSet)
+	req.Hosts.Replace(hostSet)
+	req.Ranks.Replace(rankSet)
 
 	resp, err := control.SystemQuery(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
@@ -173,8 +173,8 @@ func (cmd *systemStopCmd) Execute(_ []string) (errOut error) {
 		return err
 	}
 	req := &control.SystemStopReq{Force: cmd.Force}
-	req.Hosts.ReplaceSet(hostSet)
-	req.Ranks.ReplaceSet(rankSet)
+	req.Hosts.Replace(hostSet)
+	req.Ranks.Replace(rankSet)
 
 	resp, err := control.SystemStop(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
@@ -217,8 +217,8 @@ func (cmd *systemStartCmd) Execute(_ []string) (errOut error) {
 		return err
 	}
 	req := new(control.SystemStartReq)
-	req.Hosts.ReplaceSet(hostSet)
-	req.Ranks.ReplaceSet(rankSet)
+	req.Hosts.Replace(hostSet)
+	req.Ranks.Replace(rankSet)
 
 	resp, err := control.SystemStart(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {

--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -17,11 +17,28 @@ import (
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/hostlist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
 func TestDmg_SystemCommands(t *testing.T) {
+	withRanks := func(req control.UnaryRequest, ranks ...system.Rank) control.UnaryRequest {
+		if rs, ok := req.(interface{ SetRanks(*system.RankSet) }); ok {
+			rs.SetRanks(system.RankSetFromRanks(ranks))
+		}
+
+		return req
+	}
+
+	withHosts := func(req control.UnaryRequest, hosts ...string) control.UnaryRequest {
+		if rs, ok := req.(interface{ SetHosts(*hostlist.HostSet) }); ok {
+			rs.SetHosts(hostlist.MustCreateSet(strings.Join(hosts, ",")))
+		}
+
+		return req
+	}
+
 	runCmdTests(t, []cmdTest{
 		{
 			"system query with no arguments",
@@ -35,7 +52,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system query with single rank",
 			"system query --ranks 0",
 			strings.Join([]string{
-				`*control.SystemQueryReq-{"Sys":"","HostList":null,"Ranks":"0","Hosts":"","FailOnUnavailable":false}`,
+				printRequest(t, withRanks(&control.SystemQueryReq{}, 0)),
 			}, " "),
 			nil,
 		},
@@ -43,7 +60,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system query with multiple ranks",
 			"system query --ranks 0,2,4-8",
 			strings.Join([]string{
-				`*control.SystemQueryReq-{"Sys":"","HostList":null,"Ranks":"[0,2,4-8]","Hosts":"","FailOnUnavailable":false}`,
+				printRequest(t, withRanks(&control.SystemQueryReq{}, 0, 2, 4, 5, 6, 7, 8)),
 			}, " "),
 			nil,
 		},
@@ -57,7 +74,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system query with single host",
 			"system query --rank-hosts foo-0",
 			strings.Join([]string{
-				`*control.SystemQueryReq-{"Sys":"","HostList":null,"Ranks":"","Hosts":"foo-0","FailOnUnavailable":false}`,
+				printRequest(t, withHosts(&control.SystemQueryReq{}, "foo-0")),
 			}, " "),
 			nil,
 		},
@@ -65,7 +82,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system query with multiple hosts",
 			"system query --rank-hosts bar9,foo-[0-100]",
 			strings.Join([]string{
-				`*control.SystemQueryReq-{"Sys":"","HostList":null,"Ranks":"","Hosts":"bar9,foo-[0-100]","FailOnUnavailable":false}`,
+				printRequest(t, withHosts(&control.SystemQueryReq{}, "foo-[0-100]", "bar9")),
 			}, " "),
 			nil,
 		},
@@ -109,7 +126,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system stop with single rank",
 			"system stop --ranks 0",
 			strings.Join([]string{
-				`*control.SystemStopReq-{"Sys":"","HostList":null,"Ranks":"0","Hosts":"","Force":false}`,
+				printRequest(t, withRanks(&control.SystemStopReq{}, 0)),
 			}, " "),
 			nil,
 		},
@@ -117,7 +134,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system stop with multiple ranks",
 			"system stop --ranks 0,1,4",
 			strings.Join([]string{
-				`*control.SystemStopReq-{"Sys":"","HostList":null,"Ranks":"[0-1,4]","Hosts":"","Force":false}`,
+				printRequest(t, withRanks(&control.SystemStopReq{}, 0, 1, 4)),
 			}, " "),
 			nil,
 		},
@@ -125,7 +142,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system stop with multiple hosts",
 			"system stop --rank-hosts bar9,foo-[0-100]",
 			strings.Join([]string{
-				`*control.SystemStopReq-{"Sys":"","HostList":null,"Ranks":"","Hosts":"bar9,foo-[0-100]","Force":false}`,
+				printRequest(t, withHosts(&control.SystemStopReq{}, "foo-[0-100]", "bar9")),
 			}, " "),
 			nil,
 		},
@@ -153,7 +170,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system start with single rank",
 			"system start --ranks 0",
 			strings.Join([]string{
-				`*control.SystemStartReq-{"Sys":"","HostList":null,"Ranks":"0","Hosts":""}`,
+				printRequest(t, withRanks(&control.SystemStartReq{}, 0)),
 			}, " "),
 			nil,
 		},
@@ -161,7 +178,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system start with multiple ranks",
 			"system start --ranks 0,1,4",
 			strings.Join([]string{
-				`*control.SystemStartReq-{"Sys":"","HostList":null,"Ranks":"[0-1,4]","Hosts":""}`,
+				printRequest(t, withRanks(&control.SystemStartReq{}, 0, 1, 4)),
 			}, " "),
 			nil,
 		},
@@ -169,7 +186,7 @@ func TestDmg_SystemCommands(t *testing.T) {
 			"system start with multiple hosts",
 			"system start --rank-hosts bar9,foo-[0-100]",
 			strings.Join([]string{
-				`*control.SystemStartReq-{"Sys":"","HostList":null,"Ranks":"","Hosts":"bar9,foo-[0-100]"}`,
+				printRequest(t, withHosts(&control.SystemStartReq{}, "foo-[0-100]", "bar9")),
 			}, " "),
 			nil,
 		},

--- a/src/control/lib/control/request.go
+++ b/src/control/lib/control/request.go
@@ -62,6 +62,10 @@ type (
 		getTimeout() time.Duration
 	}
 
+	hostResponseReporter interface {
+		reportResponse(*HostResponse)
+	}
+
 	// UnaryRequest defines an interface to be implemented by
 	// unary request types (1 response to 1 request).
 	UnaryRequest interface {

--- a/src/control/lib/control/response.go
+++ b/src/control/lib/control/response.go
@@ -36,6 +36,10 @@ type (
 	// HostResponseChan defines a channel of *HostResponse items returned
 	// from asynchronous unary RPC invokers.
 	HostResponseChan chan *HostResponse
+
+	// HostResponseReport defines the function signature for a callback
+	// invoked when a host response is received.
+	HostResponseReportFn func(*HostResponse)
 )
 
 // HostErrorsResp is a response type containing a HostErrorsMap.

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -49,6 +49,14 @@ type sysRequest struct {
 	Hosts hostlist.HostSet
 }
 
+func (req *sysRequest) SetRanks(ranks *system.RankSet) {
+	req.Ranks.Replace(ranks)
+}
+
+func (req *sysRequest) SetHosts(hosts *hostlist.HostSet) {
+	req.Hosts.Replace(hosts)
+}
+
 type sysResponse struct {
 	AbsentRanks system.RankSet   `json:"-"`
 	AbsentHosts hostlist.HostSet `json:"-"`
@@ -63,8 +71,8 @@ func (resp *sysResponse) getAbsentHostsRanks(inHosts, inRanks string) error {
 	if err != nil {
 		return err
 	}
-	resp.AbsentHosts.ReplaceSet(ahs)
-	resp.AbsentRanks.ReplaceSet(ars)
+	resp.AbsentHosts.Replace(ahs)
+	resp.AbsentRanks.Replace(ars)
 
 	return nil
 }
@@ -585,8 +593,19 @@ func LeaderQuery(ctx context.Context, rpcClient UnaryInvoker, req *LeaderQueryRe
 // RanksReq contains the parameters for a system ranks request.
 type RanksReq struct {
 	unaryRequest
-	Ranks string
-	Force bool
+	respReportCb HostResponseReportFn
+	Ranks        string
+	Force        bool
+}
+
+func (r *RanksReq) reportResponse(resp *HostResponse) {
+	if r.respReportCb != nil && resp != nil {
+		r.respReportCb(resp)
+	}
+}
+
+func (r *RanksReq) SetReportCb(cb HostResponseReportFn) {
+	r.respReportCb = cb
 }
 
 // RanksResp contains the response from a system ranks request.
@@ -598,6 +617,13 @@ type RanksResp struct {
 // addHostResponse is responsible for validating the given HostResponse
 // and adding its results to the RanksResp.
 func (srr *RanksResp) addHostResponse(hr *HostResponse) (err error) {
+	if hr.Error != nil {
+		if err = srr.addHostError(hr.Addr, hr.Error); err != nil {
+			return
+		}
+		return
+	}
+
 	pbResp, ok := hr.Message.(interface{ GetResults() []*sharedpb.RankResult })
 	if !ok {
 		return errors.Errorf("unable to unpack message: %+v", hr.Message)
@@ -605,10 +631,7 @@ func (srr *RanksResp) addHostResponse(hr *HostResponse) (err error) {
 
 	memberResults := make(system.MemberResults, 0)
 	if err := convert.Types(pbResp.GetResults(), &memberResults); err != nil {
-		if srr.HostErrors == nil {
-			srr.HostErrors = make(HostErrorsMap)
-		}
-		return srr.HostErrors.Add(hr.Addr, err)
+		return srr.addHostError(hr.Addr, errors.Wrap(err, "type conversion failed"))
 	}
 
 	srr.RankResults = append(srr.RankResults, memberResults...)
@@ -620,26 +643,27 @@ func (srr *RanksResp) addHostResponse(hr *HostResponse) (err error) {
 // parameter and unpacks host responses and errors into a RanksResp,
 // returning RanksResp's reference.
 func invokeRPCFanout(ctx context.Context, rpcClient UnaryInvoker, req *RanksReq) (*RanksResp, error) {
-	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
+	resps, err := rpcClient.InvokeUnaryRPCAsync(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
 	rr := new(RanksResp)
-	for _, hostResp := range ur.Responses {
-		if hostResp.Error != nil {
-			if err := rr.addHostError(hostResp.Addr, hostResp.Error); err != nil {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case hr := <-resps:
+			if hr == nil {
+				return rr, nil
+			}
+
+			req.reportResponse(hr)
+			if err := rr.addHostResponse(hr); err != nil {
 				return nil, err
 			}
-			continue
-		}
-
-		if err := rr.addHostResponse(hostResp); err != nil {
-			return nil, err
 		}
 	}
-
-	return rr, nil
 }
 
 // PrepShutdownRanks concurrently performs prep shutdown ranks across all hosts

--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -530,15 +530,15 @@ func TestControl_getResetRankErrors(t *testing.T) {
 func TestControl_SystemQuery(t *testing.T) {
 	testHS := hostlist.MustCreateSet("foo-[1-23]")
 	testReqHS := new(SystemQueryReq)
-	testReqHS.Hosts.ReplaceSet(testHS)
+	testReqHS.Hosts.Replace(testHS)
 	testRespHS := new(SystemQueryResp)
-	testRespHS.AbsentHosts.ReplaceSet(testHS)
+	testRespHS.AbsentHosts.Replace(testHS)
 
 	testRS := system.MustCreateRankSet("1-23")
 	testReqRS := new(SystemQueryReq)
-	testReqRS.Ranks.ReplaceSet(testRS)
+	testReqRS.Ranks.Replace(testRS)
 	testRespRS := new(SystemQueryResp)
-	testRespRS.AbsentRanks.ReplaceSet(testRS)
+	testRespRS.AbsentRanks.Replace(testRS)
 
 	fdStrs := []string{"/one/two", "/three", "/four/five/six", ""}
 	fds := make([]*system.FaultDomain, len(fdStrs))
@@ -685,9 +685,9 @@ func TestControl_SystemQueryRespErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resp := new(SystemQueryResp)
 			ahs := hostlist.MustCreateSet(tc.absentHosts)
-			resp.AbsentHosts.ReplaceSet(ahs)
+			resp.AbsentHosts.Replace(ahs)
 			ars := system.MustCreateRankSet(tc.absentRanks)
-			resp.AbsentRanks.ReplaceSet(ars)
+			resp.AbsentRanks.Replace(ars)
 
 			test.CmpErr(t, tc.expErr, resp.Errors())
 		})
@@ -697,15 +697,15 @@ func TestControl_SystemQueryRespErrors(t *testing.T) {
 func TestControl_SystemStart(t *testing.T) {
 	testHS := hostlist.MustCreateSet("foo-[1-23]")
 	testReqHS := new(SystemStartReq)
-	testReqHS.Hosts.ReplaceSet(testHS)
+	testReqHS.Hosts.Replace(testHS)
 	testRespHS := new(SystemStartResp)
-	testRespHS.AbsentHosts.ReplaceSet(testHS)
+	testRespHS.AbsentHosts.Replace(testHS)
 
 	testRS := system.MustCreateRankSet("1-23")
 	testReqRS := new(SystemStartReq)
-	testReqRS.Ranks.ReplaceSet(testRS)
+	testReqRS.Ranks.Replace(testRS)
 	testRespRS := new(SystemStartResp)
-	testRespRS.AbsentRanks.ReplaceSet(testRS)
+	testRespRS.AbsentRanks.Replace(testRS)
 
 	for name, tc := range map[string]struct {
 		req     *SystemStartReq
@@ -855,9 +855,9 @@ func TestControl_SystemStartRespErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resp := new(SystemStartResp)
 			ahs := hostlist.MustCreateSet(tc.absentHosts)
-			resp.AbsentHosts.ReplaceSet(ahs)
+			resp.AbsentHosts.Replace(ahs)
 			ars := system.MustCreateRankSet(tc.absentRanks)
-			resp.AbsentRanks.ReplaceSet(ars)
+			resp.AbsentRanks.Replace(ars)
 			resp.Results = tc.results
 
 			test.CmpErr(t, tc.expErr, resp.Errors())
@@ -868,15 +868,15 @@ func TestControl_SystemStartRespErrors(t *testing.T) {
 func TestControl_SystemStop(t *testing.T) {
 	testHS := hostlist.MustCreateSet("foo-[1-23]")
 	testReqHS := new(SystemStopReq)
-	testReqHS.Hosts.ReplaceSet(testHS)
+	testReqHS.Hosts.Replace(testHS)
 	testRespHS := new(SystemStopResp)
-	testRespHS.AbsentHosts.ReplaceSet(testHS)
+	testRespHS.AbsentHosts.Replace(testHS)
 
 	testRS := system.MustCreateRankSet("1-23")
 	testReqRS := new(SystemStopReq)
-	testReqRS.Ranks.ReplaceSet(testRS)
+	testReqRS.Ranks.Replace(testRS)
 	testRespRS := new(SystemStopResp)
-	testRespRS.AbsentRanks.ReplaceSet(testRS)
+	testRespRS.AbsentRanks.Replace(testRS)
 
 	for name, tc := range map[string]struct {
 		req     *SystemStopReq
@@ -1026,9 +1026,9 @@ func TestControl_SystemStopRespErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resp := new(SystemStopResp)
 			ahs := hostlist.MustCreateSet(tc.absentHosts)
-			resp.AbsentHosts.ReplaceSet(ahs)
+			resp.AbsentHosts.Replace(ahs)
 			ars := system.MustCreateRankSet(tc.absentRanks)
-			resp.AbsentRanks.ReplaceSet(ars)
+			resp.AbsentRanks.Replace(ars)
 			resp.Results = tc.results
 
 			test.CmpErr(t, tc.expErr, resp.Errors())

--- a/src/control/lib/hostlist/hostset.go
+++ b/src/control/lib/hostlist/hostset.go
@@ -116,9 +116,9 @@ func (hs *HostSet) Delete(stringHosts string) (int, error) {
 	return int(hs.list.hostCount - startCount), nil
 }
 
-// ReplaceSet replaces this HostSet with the contents
+// Replace replaces this HostSet with the contents
 // of the supplied HostSet.
-func (hs *HostSet) ReplaceSet(other *HostSet) {
+func (hs *HostSet) Replace(other *HostSet) {
 	hs.initList()
 
 	if other == nil {
@@ -133,8 +133,8 @@ func (hs *HostSet) ReplaceSet(other *HostSet) {
 	hs.list.ReplaceList(other.list)
 }
 
-// MergeSet merges the supplied HostSet into this one.
-func (hs *HostSet) MergeSet(other *HostSet) error {
+// Merge merges the supplied HostSet into this one.
+func (hs *HostSet) Merge(other *HostSet) error {
 	hs.initList()
 
 	if other == nil {

--- a/src/control/lib/hostlist/hostset_test.go
+++ b/src/control/lib/hostlist/hostset_test.go
@@ -178,7 +178,7 @@ func TestHostSet_MergeSet(t *testing.T) {
 	}
 	expCount := a.Count() + b.Count() - 1
 
-	if err := a.MergeSet(b); err != nil {
+	if err := a.Merge(b); err != nil {
 		t.Fatal(err)
 	}
 
@@ -188,7 +188,7 @@ func TestHostSet_MergeSet(t *testing.T) {
 	}
 }
 
-func TestHostSet_ReplaceSet(t *testing.T) {
+func TestHostSet_Replace(t *testing.T) {
 	a, err := hostlist.CreateSet("host[1-8]")
 	if err != nil {
 		t.Fatal(err)
@@ -198,7 +198,7 @@ func TestHostSet_ReplaceSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	a.ReplaceSet(b)
+	a.Replace(b)
 	if a.String() != b.String() {
 		t.Fatalf("%s != %s", a, b)
 	}

--- a/src/control/lib/hostlist/numericlist.go
+++ b/src/control/lib/hostlist/numericlist.go
@@ -7,14 +7,113 @@
 package hostlist
 
 import (
+	"fmt"
 	"unicode"
 
 	"github.com/pkg/errors"
 )
 
-// CreateNumericList creates a special HostList that contains numeric entries
-// and ranges only (no hostname prefixes) from the supplied string representation.
-func CreateNumericList(stringRanges string) (*HostList, error) {
+// NumericList implements a subset of the HostList interface and is designed
+// for use with lists of numbers.
+type NumericList struct {
+	hl *HostList
+}
+
+// Add adds the supplied numeric entry to the NumericList.
+func (nl *NumericList) Add(i uint) {
+	nl.hl.Lock()
+	defer nl.hl.Unlock()
+
+	nl.hl.pushRange(&hostRange{lo: i, hi: i, width: 1, isRange: true})
+}
+
+// Delete removes the supplied numeric entry from the NumericList. No-op if
+// the entry is not present.
+func (nl *NumericList) Delete(i uint) {
+	nl.hl.Lock()
+	defer nl.hl.Unlock()
+
+	for idx, hr := range nl.hl.ranges {
+		_, found := hr.containsHost(&hostName{number: i, hasNumber: true})
+		if !found {
+			continue
+		}
+
+		if hr.count() == 1 {
+			if err := nl.hl.deleteRangeAt(idx); err != nil {
+				panic(fmt.Sprintf("internal error: %s", err))
+			}
+			return
+		}
+
+		new, err := hr.deleteHost(i)
+		if err != nil {
+			panic(fmt.Sprintf("internal error: %s", err))
+		}
+		nl.hl.hostCount--
+
+		if new != nil {
+			nl.hl.insertRangeAt(idx, new)
+		}
+		return
+	}
+}
+
+// Slice returns a slice of the numeric entries in the NumericList.
+func (nl *NumericList) Slice() (out []uint) {
+	nl.hl.RLock()
+	defer nl.hl.RUnlock()
+
+	for _, hr := range nl.hl.ranges {
+		for i := hr.lo; i <= hr.hi; i++ {
+			out = append(out, i)
+		}
+	}
+
+	return
+}
+
+// Uniq sorts and removes duplicate entries from the NumericList.
+func (nl *NumericList) Uniq() {
+	nl.hl.Uniq()
+}
+
+func (nl *NumericList) String() string {
+	return nl.hl.String()
+}
+
+func (nl *NumericList) RangedString() string {
+	return nl.hl.RangedString()
+}
+
+// Count returns the number of numeric entries in the NumericList.
+func (nl *NumericList) Count() int {
+	return nl.hl.Count()
+}
+
+// Merge merges the contents of this NumericList with those of the other NumericList.
+func (nl *NumericList) Merge(other *NumericList) {
+	nl.hl.PushList(other.hl)
+}
+
+// Replace replaces the contents of this NumericList with those from the other NumericList.
+func (nl *NumericList) Replace(other *NumericList) {
+	nl.hl.ReplaceList(other.hl)
+}
+
+// NewNumericList creates an initialized NumericList with
+// optional starting values.
+func NewNumericList(values ...uint) *NumericList {
+	nl := &NumericList{hl: &HostList{}}
+	for _, v := range values {
+		nl.Add(v)
+	}
+	return nl
+}
+
+// CreateNumericList creates a NumericList that contains numeric entries
+// and ranges from the supplied string representation.
+func CreateNumericList(stringRanges string) (*NumericList, error) {
 	for _, r := range stringRanges {
 		if unicode.IsSpace(r) {
 			return nil, errors.New("unexpected whitespace character(s)")
@@ -24,19 +123,66 @@ func CreateNumericList(stringRanges string) (*HostList, error) {
 		}
 	}
 
-	return parseBracketedHostList(stringRanges, outerRangeSeparators,
+	hl, err := parseBracketedHostList(stringRanges, outerRangeSeparators,
 		rangeOperator, true)
+	if err != nil {
+		return nil, err
+	}
+	return &NumericList{hl: hl}, nil
 }
 
-// CreateNumericSet creates a special HostSet containing numeric entries
-// and ranges only (no hostname prefixes) from the supplied string representation.
-func CreateNumericSet(stringRanges string) (*HostSet, error) {
-	hl, err := CreateNumericList(stringRanges)
+// NumericSet is a special case of a NumericList that contains unique numeric
+// entries.
+type NumericSet struct {
+	NumericList
+}
+
+// Add adds the supplied numeric entry to the NumericSet.
+func (ns *NumericSet) Add(i uint) {
+	ns.NumericList.Add(i)
+	ns.Uniq()
+}
+
+// Delete removes the supplied numeric entry from the NumericSet. No-op if
+// the entry is not present.
+func (ns *NumericSet) Delete(i uint) {
+	ns.NumericList.Delete(i)
+	ns.Uniq()
+}
+
+// Merge merges the contents of this NumericSet with those of the other NumericSet.
+func (ns *NumericSet) Merge(other *NumericSet) {
+	ns.hl.PushList(other.hl)
+	ns.Uniq()
+}
+
+// Replace replaces the contents of this NumericSet with those from the other NumericSet.
+func (ns *NumericSet) Replace(other *NumericSet) {
+	ns.hl.ReplaceList(other.hl)
+	ns.Uniq()
+}
+
+// NewNumericSet creates an initialized NumericSet with optional
+// starting values.
+func NewNumericSet(values ...uint) *NumericSet {
+	ns := &NumericSet{NumericList: NumericList{hl: &HostList{}}}
+	for _, v := range values {
+		ns.NumericList.Add(v)
+	}
+	ns.Uniq()
+
+	return ns
+}
+
+// CreateNumericSet creates a NumericSet containing unique numeric entries
+// and ranges from the supplied string representation.
+func CreateNumericSet(stringRanges string) (*NumericSet, error) {
+	nl, err := CreateNumericList(stringRanges)
 	if err != nil {
 		return nil, errors.Wrapf(err,
 			"creating numeric set from %q", stringRanges)
 	}
-	hl.Uniq()
+	nl.Uniq()
 
-	return &HostSet{list: hl}, nil
+	return &NumericSet{NumericList: NumericList{hl: nl.hl}}, nil
 }

--- a/src/control/lib/hostlist/numericlist_test.go
+++ b/src/control/lib/hostlist/numericlist_test.go
@@ -13,6 +13,77 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
 )
 
+func TestHostList_NumericList(t *testing.T) {
+	uints := func(input ...uint) []uint {
+		return input
+	}
+
+	for name, tc := range map[string]struct {
+		startList   []uint
+		addList     []uint
+		delList     []uint
+		expOut      string
+		expFinalOut string
+		expCount    int
+		expErr      error
+	}{
+		"add to and delete from empty list": {
+			startList:   uints(),
+			addList:     uints(0, 2, 5),
+			expOut:      "[0,2,5]",
+			delList:     uints(2),
+			expFinalOut: "[0,5]",
+			expCount:    2,
+		},
+		"add to and delete from existing list": {
+			startList:   uints(1, 3, 4),
+			addList:     uints(0, 2, 5),
+			expOut:      "[1,3-4,0,2,5]",
+			delList:     uints(4),
+			expFinalOut: "[1,3,0,2,5]",
+			expCount:    5,
+		},
+		"add dupes": {
+			addList:     uints(1, 1, 1),
+			expOut:      "[1,1,1]",
+			expFinalOut: "[1,1,1]",
+			expCount:    3,
+		},
+		"delete one dupe": {
+			startList:   uints(1, 1, 1),
+			expOut:      "[1,1,1]",
+			delList:     uints(1),
+			expFinalOut: "[1,1]",
+			expCount:    2,
+		},
+		"delete non-existent no-op": {
+			startList:   uints(1, 3, 4),
+			expOut:      "[1,3-4]",
+			delList:     uints(5),
+			expFinalOut: "[1,3-4]",
+			expCount:    3,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			nl := hostlist.NewNumericList(tc.startList...)
+			for _, i := range tc.addList {
+				nl.Add(i)
+			}
+			cmpOut(t, tc.expOut, nl.String())
+
+			for _, i := range tc.delList {
+				nl.Delete(i)
+			}
+			cmpOut(t, tc.expFinalOut, nl.String())
+
+			gotCount := nl.Count()
+			if gotCount != tc.expCount {
+				t.Fatalf("expected count to be %d; got %d", tc.expCount, gotCount)
+			}
+		})
+	}
+}
+
 func TestHostList_CreateNumericList(t *testing.T) {
 	for name, tc := range map[string]struct {
 		startList    string
@@ -49,6 +120,71 @@ func TestHostList_CreateNumericList(t *testing.T) {
 			gotCount := hl.Count()
 			if gotCount != tc.expUniqCount {
 				t.Fatalf("expected count to be %d; got %d", tc.expUniqCount, gotCount)
+			}
+		})
+	}
+}
+
+func TestHostList_NumericSet(t *testing.T) {
+	uints := func(input ...uint) []uint {
+		return input
+	}
+
+	for name, tc := range map[string]struct {
+		startList   []uint
+		addList     []uint
+		delList     []uint
+		expOut      string
+		expFinalOut string
+		expCount    int
+		expErr      error
+	}{
+		"add to and delete from empty set": {
+			startList:   uints(),
+			addList:     uints(0, 2, 5),
+			expOut:      "[0,2,5]",
+			delList:     uints(2),
+			expFinalOut: "[0,5]",
+			expCount:    2,
+		},
+		"add to and delete from existing set": {
+			startList:   uints(1, 3, 4),
+			addList:     uints(0, 2, 5),
+			expOut:      "[0-5]",
+			delList:     uints(4),
+			expFinalOut: "[0-3,5]",
+			expCount:    5,
+		},
+		"delete non-existent no-op": {
+			startList:   uints(1, 3, 4),
+			expOut:      "[1,3-4]",
+			delList:     uints(5),
+			expFinalOut: "[1,3-4]",
+			expCount:    3,
+		},
+		"test dupes": {
+			startList:   uints(1, 1, 1),
+			addList:     uints(1, 1, 1),
+			expOut:      "1",
+			expFinalOut: "1",
+			expCount:    1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			nl := hostlist.NewNumericSet(tc.startList...)
+			for _, i := range tc.addList {
+				nl.Add(i)
+			}
+			cmpOut(t, tc.expOut, nl.String())
+
+			for _, i := range tc.delList {
+				nl.Delete(i)
+			}
+			cmpOut(t, tc.expFinalOut, nl.String())
+
+			gotCount := nl.Count()
+			if gotCount != tc.expCount {
+				t.Fatalf("expected count to be %d; got %d", tc.expCount, gotCount)
 			}
 		})
 	}

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -11,6 +11,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
 	"time"
 
@@ -520,6 +523,27 @@ func (svc *mgmtSvc) rpcFanout(ctx context.Context, req *fanoutRequest, resp *fan
 	ranksReq := &control.RanksReq{
 		Ranks: req.Ranks.String(), Force: req.Force,
 	}
+
+	funcName := func(i interface{}) string {
+		return filepath.Base(runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name())
+	}
+
+	waiting := system.RankSetFromRanks(req.Ranks.Ranks())
+	finished := system.MustCreateRankSet("")
+	ranksReq.SetReportCb(func(hr *control.HostResponse) {
+		rs, ok := hr.Message.(interface{ GetResults() []*sharedpb.RankResult })
+		if !ok {
+			svc.log.Errorf("unexpected message type in HostResponse: %T", hr.Message)
+			return
+		}
+
+		for _, rr := range rs.GetResults() {
+			waiting.Delete(system.Rank(rr.Rank))
+			finished.Add(system.Rank(rr.Rank))
+		}
+
+		svc.log.Infof("%s: finished: %s; waiting: %s", funcName(req.Method), finished, waiting)
+	})
 
 	// Not strictly necessary but helps with debugging.
 	dl, ok := ctx.Deadline()


### PR DESCRIPTION
Callers may set a reporting callback to be invoked as
HostResponse replies are received. This commit just adds
info-level logging to display finished/waiting ranks,
but the mechanism could be extended for more sophisticated
progress updates sent back to control clients.

Also adds new NumericList/NumericSet types to the hostlist
library to be used as a more efficient/capable basis for
the system.RankSet type.

Features: control

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>