### PR TITLE
DAOS-6322 test: Re-enable test_dmg_system_reformat (#7849)

### DIFF
--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -4,7 +4,10 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import time
+
 from avocado.core.exceptions import TestFail
+from command_utils_base import CommandFailure
 from pool_test_base import PoolTestBase
 
 
@@ -17,7 +20,6 @@ class DmgSystemReformatTest(PoolTestBase):
 
     :avocado: recursive
     """
-
     def test_dmg_system_reformat(self):
         """
         JIRA ID: DAOS-5415
@@ -58,21 +60,28 @@ class DmgSystemReformatTest(PoolTestBase):
             self.fail("Issues performing system erase: {}".format(
                 self.get_dmg_command().result.stderr_text))
 
-        # To verify that we are using the membership information instead of the
-        # dmg config explicit hostlist
-        # Uncomment below after DAOS-5979 is resolved
-        # self.assertTrue(
-        #     self.server_managers[-1].dmg.set_config_value("hostlist", None))
-
         self.log.info("Perform dmg storage format on all system ranks:")
-        self.get_dmg_command().storage_format(force=True)
-        if self.get_dmg_command().result.exit_status != 0:
-            self.fail("Issues performing storage format --force: {}".format(
-                self.get_dmg_command().result.stderr_text))
+
+        # Calling storage format after system stop too soon would fail, so
+        # wait 10 sec and retry up to 4 times.
+        count = 0
+        while count < 4:
+            try:
+                self.get_dmg_command().storage_format(force=True)
+                if self.get_dmg_command().result.exit_status != 0:
+                    self.fail(
+                        "Issues performing storage format --force: {}".format(
+                            self.get_dmg_command().result.stderr_text))
+                break
+            except CommandFailure as error:
+                self.log.info(
+                    "Storage format failed. Wait 10 sec and retry. %s", error)
+                count += 1
+                time.sleep(10)
 
         # Check that engine starts up again
         self.log.info("<SERVER> Waiting for the engines to start")
-        self.server_managers[-1].detect_engine_start(host_qty=2)
+        self.server_managers[-1].detect_engine_start()
 
         # Check that we have cleared storage by checking pool list
         if self.get_dmg_command().get_pool_list_uuids():
@@ -80,8 +89,8 @@ class DmgSystemReformatTest(PoolTestBase):
                 self.get_dmg_command().result.stdout_text))
 
         # Create last pool now that memory has been wiped.
-        self.add_pool_qty(1)
+        self.add_pool_qty(quantity=1, connect=False)
 
         # Lastly, verify that last created pool is in the list
         pool_uuids = self.get_dmg_command().get_pool_list_uuids()
-        self.assertEqual(pool_uuids[0], self.pool[-1].uuid)
+        self.assertEqual(pool_uuids[0].lower(), self.pool[-1].uuid.lower())

--- a/src/tests/ftest/control/dmg_system_reformat.yaml
+++ b/src/tests/ftest/control/dmg_system_reformat.yaml
@@ -1,11 +1,9 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers:
     - server-A
   test_clients:
     - client-B
-timeout: 150
+timeout: 300
 server_config:
   name: daos_server
   servers:

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -359,18 +359,18 @@ class DaosServerManager(SubprocessManager):
                 "Failed to start servers before format: {}".format(
                     error)) from error
 
-    def detect_engine_start(self, host_qty=None):
+    def detect_engine_start(self, hosts_qty=None):
         """Detect when all the engines have started.
 
         Args:
-            host_qty (int): number of servers expected to have been started.
+            hosts_qty (int): number of servers expected to have been started.
 
         Raises:
             ServerFailed: if there was an error starting the servers after
                 formatting.
 
         """
-        if host_qty is None:
+        if hosts_qty is None:
             hosts_qty = len(self._hosts)
 
         if self.detect_start_via_dmg:


### PR DESCRIPTION
Remove skipForTicket("DAOS-6004")
Fixed typo in detect_engine_start()
Calling storage format after system stop too soon would fail.
Wait 10 sec and retry up to 4 times.
Removed detect_engine_start() argument to use all hosts.

Skip-unit-tests: true
Test-tag: dmg_system_reformat

Signed-off-by: Makito Kano <makito.kano@intel.com>