### PR TITLE
DAOS-623 misc: Allow githooks to be temporarily disabled

### DIFF
--- a/utils/githooks/commit-msg
+++ b/utils/githooks/commit-msg
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eu
 
+if [ -n "${NO_COMMIT_MSG:=""}" ]; then
+    exit 0
+fi
+
 run-parts() {
     local dir="$1"
     shift

--- a/utils/githooks/commit-msg.d/10-watermark
+++ b/utils/githooks/commit-msg.d/10-watermark
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Don't mess with an empty commit message
+if [[ $(grep -v '^[[:space:]]*#' "$1" | wc -c | cut -f1 -d' ') == "0" ]]; then
+    exit 0
+fi
+
 if ! grep 'Required-githooks: true' "$1"; then
     echo 'Required-githooks: true' >> "$1"
 fi
+

--- a/utils/githooks/pre-commit
+++ b/utils/githooks/pre-commit
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eu
 
+if [ -n "${NO_PRE_COMMIT:=""}" ]; then
+    exit 0
+fi
+
 run-parts() {
     local dir="$1"
     shift

--- a/utils/githooks/prepare-commit-msg
+++ b/utils/githooks/prepare-commit-msg
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eu
 
+if [ -n "${NO_PREPARE_COMMIT_MSG:=""}" ]; then
+    exit 0
+fi
+
 run-parts() {
     local dir="$1"
     shift


### PR DESCRIPTION
Restores previous behavior where githooks may be bypassed
for commits where the hook behavior is not desirable (e.g.
merge commits).

Required-githooks: true
Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
