### PR TITLE
DAOS-3985 control: Specify control interface

### DIFF
--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -116,7 +116,8 @@ func TestAuto_ConfigWrite(t *testing.T) {
 		defaultEngineLogFile  = "/tmp/daos_engine"
 		defaultControlLogFile = "/tmp/daos_server.log"
 
-		expOut = `port: 10001
+		expOut = `control_iface: ""
+port: 10001
 transport_config:
   allow_insecure: false
   client_cert_dir: /etc/daos/certs/clients

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -164,6 +164,7 @@ const (
 	ServerConfigInsufficientHugePages
 	ServerConfigNrHugepagesOutOfRange
 	ServerConfigHugepagesDisabled
+	ServerConfigBadControlIface
 )
 
 // SPDK library bindings codes

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -216,6 +216,15 @@ func FaultConfigInsufficientHugePages(min, req int) *fault.Fault {
 	)
 }
 
+// FaultConfigBadControlIface creates a fault describing a bad control plane network interface.
+func FaultConfigBadControlIface(iface string) *fault.Fault {
+	return serverConfigFault(
+		code.ServerConfigBadControlIface,
+		fmt.Sprintf("requested control interface %q is not valid", iface),
+		"update the 'control_iface' parameter with a valid network interface",
+	)
+}
+
 func serverConfigFault(code code.Code, desc, res string) *fault.Fault {
 	return &fault.Fault{
 		Domain:      "serverconfig",

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -116,8 +116,19 @@ func (svc *mgmtSvc) LeaderQuery(ctx context.Context, req *mgmtpb.LeaderQueryReq)
 	return resp, nil
 }
 
-// getPeerListenAddr combines peer ip from supplied context with input port.
+// getPeerListenAddr provides the resolved TCP address where the peer server is listening.
 func getPeerListenAddr(ctx context.Context, listenAddrStr string) (*net.TCPAddr, error) {
+	ipAddr, portStr, err := net.SplitHostPort(listenAddrStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "get listening port")
+	}
+
+	if ipAddr != "0.0.0.0" {
+		// If the peer gave us an explicit IP address, just use it.
+		return net.ResolveTCPAddr("tcp", listenAddrStr)
+	}
+
+	// If we got 0.0.0.0, we may be able to harvest the remote IP from the context.
 	p, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("peer details not found in context")
@@ -126,12 +137,6 @@ func getPeerListenAddr(ctx context.Context, listenAddrStr string) (*net.TCPAddr,
 	tcpAddr, ok := p.Addr.(*net.TCPAddr)
 	if !ok {
 		return nil, errors.Errorf("peer address (%s) not tcp", p.Addr)
-	}
-
-	// what port is the input address listening on?
-	_, portStr, err := net.SplitHostPort(listenAddrStr)
-	if err != nil {
-		return nil, errors.Wrap(err, "get listening port")
 	}
 
 	// resolve combined IP/port address

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -393,19 +393,26 @@ func TestServer_MgmtSvc_getPeerListenAddr(t *testing.T) {
 	}{
 		"no peer": {
 			ctx:    context.Background(),
+			addr:   "0.0.0.0:1234",
 			expErr: errors.New("peer details not found in context"),
 		},
-		"bad input address": {
+		"no input address": {
 			ctx:    peer.NewContext(context.Background(), &peer.Peer{Addr: defaultAddr}),
 			expErr: errors.New("get listening port: missing port in address"),
 		},
 		"non tcp address": {
 			ctx:    peer.NewContext(context.Background(), &peer.Peer{Addr: ipAddr}),
+			addr:   "0.0.0.0:1234",
 			expErr: errors.New("peer address (127.0.0.1) not tcp"),
 		},
 		"normal operation": {
 			ctx:     peer.NewContext(context.Background(), &peer.Peer{Addr: defaultAddr}),
 			addr:    "0.0.0.0:15001",
+			expAddr: combinedAddr,
+		},
+		"specific addr": {
+			ctx:     peer.NewContext(context.Background(), &peer.Peer{Addr: defaultAddr}),
+			addr:    combinedAddr.String(),
 			expAddr: combinedAddr,
 		},
 	} {

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -256,7 +256,17 @@ func (srv *server) setCoreDumpFilter() error {
 func (srv *server) initNetwork() error {
 	defer srv.logDuration(track("time to init network"))
 
-	ctlAddr, listener, err := createListener(srv.cfg.ControlPort, net.ResolveTCPAddr, net.Listen)
+	ctlAddr, err := getControlAddr(ctlAddrParams{
+		iface:         srv.cfg.ControlInterface,
+		port:          srv.cfg.ControlPort,
+		getIfaceAddrs: getNetInterfaceAddrs,
+		resolveAddr:   net.ResolveTCPAddr,
+	})
+	if err != nil {
+		return err
+	}
+
+	listener, err := createListener(ctlAddr, net.Listen)
 	if err != nil {
 		return err
 	}

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -104,19 +104,63 @@ func writeCoreDumpFilter(log logging.Logger, path string, filter uint8) error {
 	return err
 }
 
-func createListener(ctlPort int, resolver resolveTCPFn, listener netListenFn) (*net.TCPAddr, net.Listener, error) {
-	ctlAddr, err := resolver("tcp", fmt.Sprintf("0.0.0.0:%d", ctlPort))
+func getNetInterfaceAddrs(ifaceName string) ([]net.Addr, error) {
+	iface, err := net.InterfaceByName(ifaceName)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "unable to resolve daos_server control address")
+		return nil, err
 	}
 
+	return iface.Addrs()
+}
+
+type ctlAddrParams struct {
+	iface         string
+	port          int
+	getIfaceAddrs func(string) ([]net.Addr, error)
+	resolveAddr   resolveTCPFn
+}
+
+func getControlAddr(params ctlAddrParams) (*net.TCPAddr, error) {
+	ipStr := "0.0.0.0"
+	if params.iface != "" {
+		addrs, err := params.getIfaceAddrs(params.iface)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting interface addresses")
+		}
+
+		for _, addr := range addrs {
+			switch t := addr.(type) {
+			case *net.IPNet:
+				// FIXME: At the moment the control plane makes some assumptions
+				// about the address being IPv4.
+				if ip4 := t.IP.To4(); ip4 != nil {
+					ipStr = ip4.String()
+					break
+				}
+			}
+		}
+
+		if ipStr == "0.0.0.0" {
+			return nil, errors.Errorf("no usable IPv4 addresses found on interface %s", params.iface)
+		}
+	}
+
+	ctlAddr, err := params.resolveAddr("tcp", fmt.Sprintf("[%s]:%d", ipStr, params.port))
+	if err != nil {
+		return nil, errors.Wrap(err, "resolving control address")
+	}
+
+	return ctlAddr, nil
+}
+
+func createListener(ctlAddr *net.TCPAddr, listener netListenFn) (net.Listener, error) {
 	// Create and start listener on management network.
-	lis, err := listener("tcp4", ctlAddr.String())
+	lis, err := listener("tcp", fmt.Sprintf("0.0.0.0:%d", ctlAddr.Port))
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "unable to listen on management interface")
+		return nil, errors.Wrap(err, "unable to listen on management interface")
 	}
 
-	return ctlAddr, lis, nil
+	return lis, nil
 }
 
 // updateFabricEnvars adjusts the engine fabric configuration.

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -83,6 +83,13 @@
 #provider: ofi+verbs;ofi_rxm
 #
 #
+## Control plane network interface
+## Use a specific network interface for communications with this control plane
+## server.
+#
+#control_iface: eth0
+#
+#
 ## CART: Whether to enable share address in the network stack
 ## (also known as scalable endpoint)
 ## parameters shared with client.


### PR DESCRIPTION
- Allow the admin to specify the network interface that the
  control plane server should use for network communications
  in the server config file.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>