### PR TITLE
DAOS-10215 container: handle DAOS_PROP_CO_REDUN_LVL cont property

### DIFF
--- a/src/common/cont_props.c
+++ b/src/common/cont_props.c
@@ -17,7 +17,7 @@ daos_props_2cont_props(daos_prop_t *props, struct cont_props *cont_prop)
 		return;
 	}
 
-	/* input props should cover needed entries, see ds_get_cont_props() */
+	/* input props should cover needed entries, see ds_cont_get_props() */
 	if (daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP) == NULL	     ||
 	    daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP_THRESHOLD) == NULL ||
 	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_SERVER_VERIFY)
@@ -26,6 +26,7 @@ daos_props_2cont_props(daos_prop_t *props, struct cont_props *cont_prop)
 	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_CHUNK_SIZE) == NULL ||
 	    daos_prop_entry_get(props, DAOS_PROP_CO_COMPRESS) == NULL	     ||
 	    daos_prop_entry_get(props, DAOS_PROP_CO_ENCRYPT) == NULL	     ||
+	    daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_LVL) == NULL	     ||
 	    daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_FAC) == NULL	     ||
 	    daos_prop_entry_get(props, DAOS_PROP_CO_ALLOCED_OID) == NULL     ||
 	    daos_prop_entry_get(props, DAOS_PROP_CO_EC_CELL_SZ) == NULL	     ||
@@ -58,6 +59,7 @@ daos_props_2cont_props(daos_prop_t *props, struct cont_props *cont_prop)
 		daos_cont_encrypt_prop_is_enabled(cont_prop->dcp_encrypt_type);
 
 	/** redundancy */
+	cont_prop->dcp_redun_lvl	= daos_cont_prop2redunlvl(props);
 	cont_prop->dcp_redun_fac	= daos_cont_prop2redunfac(props);
 	/** EC cell size */
 	cont_prop->dcp_ec_cell_sz	= daos_cont_prop2ec_cell_sz(props);
@@ -205,7 +207,7 @@ daos_cont_prop2encrypt(daos_prop_t *props)
 	return prop == NULL ? false : prop->dpe_val != DAOS_PROP_CO_ENCRYPT_OFF;
 }
 
-/** Get the redundancy factor from a containers properites. */
+/** Get the redundancy factor from a containers properties. */
 uint32_t
 daos_cont_prop2redunfac(daos_prop_t *props)
 {
@@ -215,7 +217,7 @@ daos_cont_prop2redunfac(daos_prop_t *props)
 	return prop == NULL ? DAOS_PROP_CO_REDUN_RF0 : (uint32_t)prop->dpe_val;
 }
 
-/** Get the redundancy level from a containers properites. */
+/** Get the redundancy level from a containers properties. */
 uint32_t
 daos_cont_prop2redunlvl(daos_prop_t *props)
 {
@@ -225,7 +227,7 @@ daos_cont_prop2redunlvl(daos_prop_t *props)
 	return prop == NULL ? DAOS_PROP_CO_REDUN_RANK : (uint32_t)prop->dpe_val;
 }
 
-/** Get the EC cell size from a containers properites. */
+/** Get the EC cell size from a containers properties. */
 uint32_t
 daos_cont_prop2ec_cell_sz(daos_prop_t *props)
 {

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -2218,7 +2218,7 @@ struct pmap_fail_ver {
 struct pmap_fail_node {
 	struct pmap_fail_ver	 pf_ver_inline[PMAP_FAIL_INLINE_NR];
 	struct pmap_fail_ver	*pf_vers;
-	uint32_t		 pf_co_rank;
+	uint32_t		 pf_co_id;
 	uint32_t		 pf_ver_total;	/* capacity of pf_vers array */
 	uint32_t		 pf_ver_nr;	/* #valid items */
 	uint32_t		 pf_down:1,	/* with DOWN tgt */
@@ -2499,7 +2499,7 @@ pmap_node_check(struct pool_domain *node_dom, struct pmap_fail_stat *fstat)
 	if (fnode == NULL || fnode->pf_ver_nr == 0)
 		return 0;
 
-	fnode->pf_co_rank = node_dom->do_comp.co_rank;
+	fnode->pf_co_id = node_dom->do_comp.co_id;
 	daos_array_sort(fnode->pf_vers, fnode->pf_ver_nr, false,
 			&pmap_fver_sort_ops);
 	pmap_fail_ver_merge(fnode);
@@ -2603,24 +2603,24 @@ fail:
  * Check if #concurrent_failures exceeds RF since pool map version \a last_ver.
  */
 int
-pool_map_rf_verify(struct pool_map *map, uint32_t last_ver, uint32_t rf)
+pool_map_rf_verify(struct pool_map *map, uint32_t last_ver, uint32_t rlvl, uint32_t rf)
 {
 	struct pool_domain	*node_doms;
 	struct pool_domain	*node_dom;
 	struct pmap_fail_stat	 fstat;
 	int			 node_nr, i;
+	int			 com_type;
 	int			 rc = 0;
 
 	pmap_fail_stat_init(&fstat, last_ver, rf);
-	node_nr = pool_map_find_domain(map, PO_COMP_TP_RANK, PO_COMP_ID_ALL,
-				       &node_doms);
+	com_type = rlvl == DAOS_PROP_CO_REDUN_NODE ? PO_COMP_TP_NODE : PO_COMP_TP_RANK;
+	node_nr = pool_map_find_domain(map, com_type, PO_COMP_ID_ALL, &node_doms);
 	D_ASSERT(node_nr >= 0);
 	if (node_nr == 0)
 		return -DER_INVAL;
 
 	for (i = 0; i < node_nr; i++) {
 		node_dom = &node_doms[i];
-		D_ASSERT(node_dom->do_children == NULL);
 		rc = pmap_node_check(node_dom, &fstat);
 		if (rc)
 			goto out;

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -772,6 +772,7 @@ cont_open_complete(tse_task_t *task, void *data)
 		D_GOTO(out, rc = 0);
 
 	uuid_copy(arg->coa_info->ci_uuid, cont->dc_uuid);
+	arg->coa_info->ci_redun_lvl = cont->dc_props.dcp_redun_lvl;
 	arg->coa_info->ci_redun_fac = cont->dc_props.dcp_redun_fac;
 
 	arg->coa_info->ci_nsnapshots = out->coo_snap_count;
@@ -835,6 +836,7 @@ dc_cont_open_internal(tse_task_t *task, const char *label, struct dc_pool *pool)
 				  DAOS_CO_QUERY_PROP_CSUM_CHUNK |
 				  DAOS_CO_QUERY_PROP_DEDUP |
 				  DAOS_CO_QUERY_PROP_DEDUP_THRESHOLD |
+				  DAOS_CO_QUERY_PROP_REDUN_LVL |
 				  DAOS_CO_QUERY_PROP_REDUN_FAC |
 				  DAOS_CO_QUERY_PROP_EC_CELL_SZ |
 				  DAOS_CO_QUERY_PROP_EC_PDA |
@@ -1162,6 +1164,7 @@ cont_query_complete(tse_task_t *task, void *data)
 
 	uuid_copy(arg->cqa_info->ci_uuid, cont->dc_uuid);
 
+	arg->cqa_info->ci_redun_lvl = cont->dc_props.dcp_redun_lvl;
 	arg->cqa_info->ci_redun_fac = cont->dc_props.dcp_redun_fac;
 
 	arg->cqa_info->ci_nsnapshots = out->cqo_snap_count;
@@ -1932,6 +1935,7 @@ struct dc_cont_glob {
 	uint32_t	dcg_compress_type;
 	uint32_t	dcg_csum_chunksize;
 	uint32_t        dcg_dedup_th;
+	uint32_t	dcg_redun_lvl;
 	uint32_t	dcg_redun_fac;
 	uint32_t	dcg_ec_cell_sz;
 	uint32_t	dcg_ec_pda;
@@ -2015,6 +2019,7 @@ dc_cont_l2g(daos_handle_t coh, d_iov_t *glob)
 	cont_glob->dcg_dedup_th		= cont->dc_props.dcp_dedup_size;
 	cont_glob->dcg_compress_type	= cont->dc_props.dcp_compress_type;
 	cont_glob->dcg_encrypt_type	= cont->dc_props.dcp_encrypt_type;
+	cont_glob->dcg_redun_lvl	= cont->dc_props.dcp_redun_lvl;
 	cont_glob->dcg_redun_fac	= cont->dc_props.dcp_redun_fac;
 	cont_glob->dcg_ec_cell_sz	= cont->dc_props.dcp_ec_cell_sz;
 	cont_glob->dcg_ec_pda		= cont->dc_props.dcp_ec_pda;
@@ -2104,6 +2109,7 @@ dc_cont_g2l(daos_handle_t poh, struct dc_cont_glob *cont_glob,
 	cont->dc_props.dcp_dedup_verify  = cont_glob->dcg_dedup_verify;
 	cont->dc_props.dcp_compress_type = cont_glob->dcg_compress_type;
 	cont->dc_props.dcp_encrypt_type	 = cont_glob->dcg_encrypt_type;
+	cont->dc_props.dcp_redun_lvl	 = cont_glob->dcg_redun_lvl;
 	cont->dc_props.dcp_redun_fac	 = cont_glob->dcg_redun_fac;
 	cont->dc_props.dcp_ec_cell_sz	 = cont_glob->dcg_ec_cell_sz;
 	cont->dc_props.dcp_ec_pda	 = cont_glob->dcg_ec_pda;
@@ -3115,6 +3121,22 @@ dc_cont_hdl2pool_hdl(daos_handle_t coh)
 	ph = dc->dc_pool_hdl;
 	dc_cont_put(dc);
 	return ph;
+}
+
+int
+dc_cont_hdl2redunlvl(daos_handle_t coh)
+{
+	struct dc_cont	*dc;
+	int		 rc;
+
+	dc = dc_hdl2cont(coh);
+	if (dc == NULL)
+		return -DER_NO_HDL;
+
+	rc = dc->dc_props.dcp_redun_lvl;
+	dc_cont_put(dc);
+
+	return rc;
 }
 
 int

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -90,7 +90,7 @@ ds_cont_get_props(struct cont_props *cont_props, uuid_t pool_uuid,
 	/* The provided prop entry types should cover the types used in
 	 * daos_props_2cont_props().
 	 */
-	props = daos_prop_alloc(13);
+	props = daos_prop_alloc(14);
 	if (props == NULL)
 		return -DER_NOMEM;
 
@@ -107,6 +107,7 @@ ds_cont_get_props(struct cont_props *cont_props, uuid_t pool_uuid,
 	props->dpp_entries[10].dpe_type = DAOS_PROP_CO_EC_PDA;
 	props->dpp_entries[11].dpe_type = DAOS_PROP_CO_RP_PDA;
 	props->dpp_entries[12].dpe_type = DAOS_PROP_CO_GLOBAL_VERSION;
+	props->dpp_entries[13].dpe_type = DAOS_PROP_CO_REDUN_LVL;
 
 	rc = cont_iv_prop_fetch(pool_uuid, cont_uuid, props);
 	if (rc == DER_SUCCESS)
@@ -2459,6 +2460,7 @@ cont_rf_check(struct ds_pool *ds_pool, struct ds_cont_child *cont_child)
 	int				rc = 0;
 
 	rc = ds_pool_rf_verify(ds_pool, cont_child->sc_status_pm_ver,
+			       cont_child->sc_props.dcp_redun_lvl,
 			       cont_child->sc_props.dcp_redun_fac);
 	if (rc != 0 && rc != -DER_RF)
 		goto out;

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -529,7 +529,18 @@ var propHdlrs = propHdlrMap{
 	C.DAOS_PROP_ENTRY_REDUN_LVL: {
 		C.DAOS_PROP_CO_REDUN_LVL,
 		"Redundancy Level",
-		nil, nil,
+		func(h *propHdlr, e *C.struct_daos_prop_entry, v string) error {
+			vh, err := h.valHdlrs.get("rf_lvl", v)
+			if err != nil {
+				return err
+			}
+
+			return vh(e, v)
+		},
+		valHdlrMap{
+			"1": setDpeVal(C.DAOS_PROP_CO_REDUN_RANK),
+			"2": setDpeVal(C.DAOS_PROP_CO_REDUN_NODE),
+		},
 		func(e *C.struct_daos_prop_entry, name string) string {
 			if e == nil {
 				return propNotFound(name)
@@ -539,11 +550,13 @@ var propHdlrs = propHdlrMap{
 			switch lvl {
 			case C.DAOS_PROP_CO_REDUN_RANK:
 				return fmt.Sprintf("rank (%d)", lvl)
+			case C.DAOS_PROP_CO_REDUN_NODE:
+				return fmt.Sprintf("node (%d)", lvl)
 			default:
 				return fmt.Sprintf("(%d)", lvl)
 			}
 		},
-		true,
+		false,
 	},
 	C.DAOS_PROP_ENTRY_SNAPSHOT_MAX: {
 		C.DAOS_PROP_CO_SNAPSHOT_MAX,

--- a/src/include/daos/cont_props.h
+++ b/src/include/daos/cont_props.h
@@ -43,6 +43,7 @@ struct cont_props {
 	uint32_t	 dcp_compress_type;
 	uint16_t	 dcp_csum_type;
 	uint16_t	 dcp_encrypt_type;
+	uint32_t	 dcp_redun_lvl;
 	uint32_t	 dcp_redun_fac;
 	uint32_t	 dcp_ec_cell_sz;
 	uint32_t	 dcp_ec_pda;

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -27,8 +27,8 @@ int dc_cont_hdl2uuid(daos_handle_t coh, uuid_t *hdl_uuid, uuid_t *con_uuid);
 daos_handle_t dc_cont_hdl2pool_hdl(daos_handle_t coh);
 struct daos_csummer *dc_cont_hdl2csummer(daos_handle_t coh);
 struct cont_props dc_cont_hdl2props(daos_handle_t coh);
+int dc_cont_hdl2redunlvl(daos_handle_t coh);
 int dc_cont_hdl2redunfac(daos_handle_t coh);
-int dc_cont_get_redunc(daos_handle_t poh, daos_prop_t *prop);
 
 int dc_cont_local2global(daos_handle_t coh, d_iov_t *glob);
 int dc_cont_global2local(daos_handle_t poh, d_iov_t glob,

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -133,11 +133,10 @@ typedef struct {
 struct daos_obj_md {
 	daos_obj_id_t		omd_id;
 	uint32_t		omd_ver;
-	uint32_t		omd_padding;
-	union {
-		uint32_t	omd_split;
-		uint64_t	omd_loff;
-	};
+	/* Fault domain level - PO_COMP_TP_RANK, or PO_COMP_TP_RANK. If it is zero then will
+	 * use pl_map's default value PL_DEFAULT_DOMAIN (PO_COMP_TP_RANK).
+	 */
+	uint32_t		omd_fdom_lvl;
 };
 
 /** object shard metadata stored in each container shard */

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -366,7 +366,7 @@ pool_target_down(struct pool_target *tgt)
 	return (status == PO_COMP_ST_DOWN);
 }
 
-int pool_map_rf_verify(struct pool_map *map, uint32_t last_ver, uint32_t rf);
+int pool_map_rf_verify(struct pool_map *map, uint32_t last_ver, uint32_t rlvl, uint32_t rf);
 pool_comp_state_t pool_comp_str2state(const char *name);
 const char *pool_comp_state2str(pool_comp_state_t state);
 

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -55,8 +55,10 @@ typedef struct {
 	uint32_t		ci_redun_fac;
 	/** Number of snapshots */
 	uint32_t		ci_nsnapshots;
+	/** Redundancy level */
+	uint32_t		ci_redun_lvl;
 	/** Container information pad (not used) */
-	uint64_t		ci_pad[2];
+	uint32_t		ci_pad[3];
 	/* TODO: add more members, e.g., size, # objects, uid, gid... */
 } daos_cont_info_t;
 

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -359,7 +359,10 @@ enum {
  */
 enum {
 	DAOS_PROP_CO_REDUN_MIN	= 1,
-	DAOS_PROP_CO_REDUN_RANK	= 1, /** hard-coded */
+	/* server rank (engine) level */
+	DAOS_PROP_CO_REDUN_RANK	= 1,
+	/* server node level */
+	DAOS_PROP_CO_REDUN_NODE	= 2,
 	DAOS_PROP_CO_REDUN_MAX	= 254,
 };
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -276,13 +276,13 @@ int dsc_pool_close(daos_handle_t ph);
  * pool map device status.
  */
 static inline int
-ds_pool_rf_verify(struct ds_pool *pool, uint32_t last_ver, uint32_t rf)
+ds_pool_rf_verify(struct ds_pool *pool, uint32_t last_ver, uint32_t rlvl, uint32_t rf)
 {
 	int	rc = 0;
 
 	ABT_rwlock_rdlock(pool->sp_lock);
 	if (last_ver < pool_map_get_version(pool->sp_map))
-		rc = pool_map_rf_verify(pool->sp_map, last_ver, rf);
+		rc = pool_map_rf_verify(pool->sp_map, last_ver, rlvl, rf);
 	ABT_rwlock_unlock(pool->sp_lock);
 
 	return rc;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2289,6 +2289,7 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 	struct daos_obj_md	 md = { 0 };
 	struct pl_map		*map;
 	struct daos_oclass_attr  oca;
+	struct cont_props	 props;
 	int			 rc = 0;
 
 	/** We should have filtered it if it isn't EC */
@@ -2302,8 +2303,10 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
+	props = dc_cont_hdl2props(info->api_cont_hdl);
 	md.omd_id = entry->ie_oid.id_pub;
 	md.omd_ver = agg_param->ap_pool_info.api_pool->sp_map_version;
+	md.omd_fdom_lvl = props.dcp_redun_lvl;
 	rc = pl_obj_place(map, &md, DAOS_OO_RO, NULL, &agg_entry->ae_obj_layout);
 
 out:

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -39,8 +39,10 @@ enum PL_OP_TYPE {
  * Contains information related to object layout size.
  */
 struct jm_obj_placement {
-	unsigned int    jmop_grp_size;
-	unsigned int    jmop_grp_nr;
+	unsigned int		jmop_grp_size;
+	unsigned int		jmop_grp_nr;
+	pool_comp_type_t	jmop_fdom_lvl;
+	uint32_t		jmop_dom_nr;
 };
 
 /**
@@ -170,14 +172,17 @@ jm_obj_placement_get(struct pl_jump_map *jmap, struct daos_obj_md *md,
 
 	if (md->omd_fdom_lvl == 0 || md->omd_fdom_lvl == jmap->jmp_redundant_dom) {
 		dom_nr = jmap->jmp_domain_nr;
+		jmop->jmop_fdom_lvl = jmap->jmp_redundant_dom;
 	} else {
 		D_ASSERT(md->omd_fdom_lvl == PO_COMP_TP_RANK ||
 			 md->omd_fdom_lvl == PO_COMP_TP_NODE);
 		rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, md->omd_fdom_lvl,
 					  PO_COMP_ID_ALL, NULL);
 		D_ASSERT(rc > 0);
+		jmop->jmop_fdom_lvl = md->omd_fdom_lvl;
 		dom_nr = rc;
 	}
+	jmop->jmop_dom_nr = dom_nr;
 	rc = op_get_grp_size(dom_nr, &jmop->jmop_grp_size, oid);
 	if (rc)
 		return rc;
@@ -329,7 +334,7 @@ static void
 get_target(struct pool_domain *curr_dom, struct pool_target **target,
 	   uint64_t obj_key, uint8_t *dom_used, uint8_t *dom_occupied,
 	   uint8_t *dom_cur_grp_used, uint8_t *tgts_used, int shard_num,
-	   uint32_t allow_status)
+	   uint32_t allow_status, pool_comp_type_t fdom_lvl)
 {
 	int                     range_set;
 	uint8_t                 found_target = 0;
@@ -350,7 +355,7 @@ retry:
 		num_doms = get_num_domains(curr_dom, allow_status);
 
 		/* If choosing target (lowest fault domain level) */
-		if (curr_dom->do_children == NULL) {
+		if (curr_dom->do_children == NULL || curr_dom->do_comp.co_type == fdom_lvl) {
 			uint32_t        fail_num = 0;
 			uint32_t        dom_id;
 			uint32_t        start_tgt;
@@ -608,10 +613,9 @@ obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 
 			D_ASSERT(dgu != NULL);
 			rebuild_key = crc(key, f_shard->fs_shard_idx);
-			get_target(root, &spare_tgt, crc(key, rebuild_key),
-				   dom_used, dom_occupied,
-				   dgu->dgu_used, tgts_used,
-				   shard_id, allow_status);
+			get_target(root, &spare_tgt, crc(key, rebuild_key), dom_used, dom_occupied,
+				   dgu->dgu_used, tgts_used, shard_id, allow_status,
+				   jmop->jmop_fdom_lvl);
 			D_ASSERT(spare_tgt != NULL);
 			D_DEBUG(DB_PL, "Trying new target: "DF_TARGET"\n",
 				DP_TARGET(spare_tgt));
@@ -825,7 +829,7 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 			} else {
 				get_target(root, &target, key, dom_used,
 					   dom_occupied, dom_cur_grp_used,
-					   tgts_used, k, allow_status);
+					   tgts_used, k, allow_status, jmop->jmop_fdom_lvl);
 			}
 
 			if (target == NULL) {

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -343,7 +343,11 @@ static pthread_rwlock_t		pl_rwlock = PTHREAD_RWLOCK_INITIALIZER;
 /** hash table for placement maps */
 static struct d_hash_table	pl_htable;
 
-/** XXX should be fetched from property */
+/**
+ * The default value for pl_map_init_attr when creating pool pl_map, later when placing object
+ * will based on container's DAOS_PROP_CO_REDUN_LVL property to set the fault domain level for
+ * that object's layout calculating.
+ */
 #define PL_DEFAULT_DOMAIN	PO_COMP_TP_RANK
 
 static void

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -184,10 +184,10 @@ object_class_is_verified(void **state)
 	free_pool_and_placement_map(po_map, pl_map);
 	/*
 	 * ---------------------------------------------------------
-	 * With 2 domains, 2 nodes each, 2 targets each = 8 targets
+	 * With 2 domains, 1 nodes each, 4 targets each = 8 targets
 	 * ---------------------------------------------------------
 	 */
-	gen_maps(2, 2, 2, &po_map, &pl_map);
+	gen_maps(2, 1, 4, &po_map, &pl_map);
 	/* even though it's 8 total, still need a domain for each replica */
 	assert_invalid_param(pl_map, OC_RP_4G2);
 

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -604,7 +604,7 @@ gen_pool_and_placement_map(int num_domains, int nodes_per_domain,
 
 	mia.ia_type         = pl_type;
 	mia.ia_ring.ring_nr = 1;
-	mia.ia_ring.domain  = PO_COMP_TP_NODE;
+	mia.ia_ring.domain  = PO_COMP_TP_RANK;
 
 	rc = pl_map_create(*po_map_out, &mia, pl_map_out);
 	assert_success(rc);
@@ -691,7 +691,7 @@ gen_pool_and_placement_map_non_standard(int num_domains,
 
 	mia.ia_type         = pl_type;
 	mia.ia_ring.ring_nr = 1;
-	mia.ia_ring.domain  = PO_COMP_TP_NODE;
+	mia.ia_ring.domain  = PO_COMP_TP_RANK;
 
 	rc = pl_map_create(*po_map_out, &mia, pl_map_out);
 	assert_success(rc);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -322,6 +322,7 @@ rebuild_object_insert(struct rebuild_tgt_pool_tracker *rpt,
 struct rebuild_scan_arg {
 	struct rebuild_tgt_pool_tracker *rpt;
 	uuid_t				co_uuid;
+	struct cont_props		co_props;
 	int				snapshot_cnt;
 	uint32_t			yield_freq;
 };
@@ -517,6 +518,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	dc_obj_fetch_md(oid.id_pub, &md);
 	crt_group_rank(rpt->rt_pool->sp_group, &myrank);
 	md.omd_ver = rpt->rt_rebuild_ver;
+	md.omd_fdom_lvl = arg->co_props.dcp_redun_lvl;
 
 	if (rpt->rt_rebuild_op == RB_OP_FAIL ||
 	    rpt->rt_rebuild_op == RB_OP_DRAIN ||
@@ -692,7 +694,16 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	rc = ds_cont_fetch_snaps(rpt->rt_pool->sp_iv_ns, entry->ie_couuid, NULL,
 				 &snapshot_cnt);
 	if (rc) {
-		D_ERROR("ds_cont_fetch_snaps failed: "DF_RC"\n", DP_RC(rc));
+		D_ERROR("Container "DF_UUID", ds_cont_fetch_snaps failed: "DF_RC"\n",
+			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		vos_cont_close(coh);
+		return rc;
+	}
+
+	rc = ds_cont_get_props(&arg->co_props, rpt->rt_pool->sp_uuid, entry->ie_couuid);
+	if (rc) {
+		D_ERROR("Container "DF_UUID", ds_cont_get_props failed: "DF_RC"\n",
+			DP_UUID(entry->ie_couuid), DP_RC(rc));
 		vos_cont_close(coh);
 		return rc;
 	}

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -11,6 +11,7 @@
 #define D_LOGFAC	DD_FAC(tests)
 #include "daos_test.h"
 #include "daos_iotest.h"
+#include <daos/placement.h>
 
 #define TEST_MAX_ATTR_LEN	(128)
 
@@ -2499,6 +2500,288 @@ co_api_compat(void **state)
 }
 
 static int
+nrank_per_node_get(struct pool_map *poolmap)
+{
+	struct pool_domain	*dom;
+	int			 rc;
+
+	rc = pool_map_find_domain(poolmap, PO_COMP_TP_NODE, PO_COMP_ID_ALL, &dom);
+	print_message("system with %d domains of PO_COMP_TP_NODE, %d RANKs per NODE\n",
+		      rc, dom->do_comp.co_nr);
+
+	return dom->do_comp.co_nr;
+}
+
+static int
+ranks_on_same_node(struct pool_map *poolmap, int src_rank, int *ranks)
+{
+	struct pool_domain	*node_doms;
+	struct pool_domain	*rank_doms;
+	struct pool_domain	*node_d, *rank_d;
+	int			 nnodes, nrank_per_node;
+	int			 i, j, k;
+	int			 rc;
+
+	rc = pool_map_find_domain(poolmap, PO_COMP_TP_NODE, PO_COMP_ID_ALL, &node_doms);
+	nnodes = rc;
+	nrank_per_node = node_doms->do_comp.co_nr;
+
+	for (i = 0; i < nnodes; i++) {
+		node_d = node_doms + i;
+		assert_int_equal(node_d->do_comp.co_nr, nrank_per_node);
+		rank_doms = node_d->do_children;
+		for (j = 0; j < nrank_per_node; j++) {
+			rank_d = rank_doms + j;
+			if (rank_d->do_comp.co_rank != src_rank)
+				continue;
+			for (k = 0; k < nrank_per_node; k++) {
+				rank_d = rank_doms + k;
+				ranks[k] = rank_d->do_comp.co_rank;
+				if (ranks[k] != src_rank)
+					print_message("rank %d on same node of rank %d\n",
+						      ranks[k], src_rank);
+			}
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+static void
+co_redun_lvl(void **state)
+{
+#define STACK_BUF_LEN	(128)
+	test_arg_t		*arg0 = *state;
+	test_arg_t		*arg = NULL;
+	daos_obj_id_t		 oid;
+	daos_handle_t		 coh, oh, coh_g2l;
+	d_iov_t			 ghdl = { NULL, 0, 0 };
+	daos_prop_t		*prop = NULL;
+	struct daos_prop_entry	*entry;
+	struct daos_co_status	 stat = { 0 };
+	daos_cont_info_t	 info = { 0 };
+	struct pl_map		*plmap = NULL;
+	struct pool_map		*poolmap = NULL;
+	daos_obj_id_t		 io_oid;
+	daos_handle_t		 io_oh;
+	d_iov_t			 dkey;
+	char			 stack_buf[STACK_BUF_LEN];
+	d_sg_list_t		 sgl;
+	d_iov_t			 sg_iov;
+	daos_iod_t		 iod;
+	daos_recx_t		 recx;
+	int			 nrank_per_node, ndom;
+	int			 ranks[3];
+	int			 i, rc;
+
+	if (!test_runable(arg0, 8))
+		skip();
+
+	print_message("create container with properties, and query/verify.\n");
+	rc = test_setup((void **)&arg, SETUP_POOL_CONNECT, arg0->multi_rank,
+			SMALL_POOL_SIZE, 0, NULL);
+	assert_int_equal(rc, 0);
+
+	prop = daos_prop_alloc(2);
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_NODE;
+	prop->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	prop->dpp_entries[1].dpe_val = DAOS_PROP_CO_REDUN_RF1;
+
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL, prop);
+	assert_int_equal(rc, 0);
+
+	/* test 1 - cont rf and obj redundancy */
+	print_message("verify cont rf is set and can be queried ...\n");
+	if (arg->myrank == 0) {
+		rc = daos_cont_query(arg->coh, &info, NULL, NULL);
+		assert_rc_equal(rc, 0);
+		assert_int_equal(info.ci_redun_lvl, DAOS_PROP_CO_REDUN_NODE);
+		assert_int_equal(info.ci_redun_fac, DAOS_PROP_CO_REDUN_RF1);
+	}
+	par_barrier(PAR_COMM_WORLD);
+
+	oid = daos_test_oid_gen(arg->coh, OC_SX, 0, 0, arg->myrank);
+	plmap = pl_map_find(arg->pool.pool_uuid, oid);
+	poolmap = plmap->pl_poolmap;
+
+	ndom = pool_map_find_domain(poolmap, PO_COMP_TP_NODE, PO_COMP_ID_ALL, NULL);
+	nrank_per_node = nrank_per_node_get(poolmap);
+	print_message("system with ndom %d, nrank_per_node %d\n", ndom, nrank_per_node);
+
+	/* CI test's ftest/daos_test/suite.yaml with 2 ranks per node */
+	if (nrank_per_node != 2)
+		goto out;
+	rc = ranks_on_same_node(poolmap, 7, ranks);
+	assert_rc_equal(rc, 0);
+	for (i = 5; i > 0; i++) {
+		if (i != ranks[0] && i != ranks[1]) {
+			ranks[2] = i;
+			break;
+		}
+	}
+
+	print_message("verify cont rf and obj open ...\n");
+	oid = daos_test_oid_gen(arg->coh, OC_SX, 0, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
+
+	oid = daos_test_oid_gen(arg->coh, OC_EC_2P1G1, 0, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	oid = daos_test_oid_gen(arg->coh, OC_RP_3G1, 0, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_obj_close(oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	/* test 2 - cont rf and pool map */
+	print_message("verify cont rf and pool map ...\n");
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_STATUS;
+	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
+	assert_rc_equal(rc, 0);
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
+	daos_prop_val_2_co_status(entry->dpe_val, &stat);
+	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_HEALTHY);
+
+	/* exclude two engined on same node, as redun_lvl set as DAOS_PROP_CO_REDUN_NODE,
+	 * should not cause RF broken.
+	 */
+	if (arg->myrank == 0) {
+		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC,
+				      DAOS_REBUILD_DELAY | DAOS_FAIL_ALWAYS, 0, NULL);
+		daos_exclude_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[0]);
+		daos_exclude_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[1]);
+	}
+	par_barrier(PAR_COMM_WORLD);
+	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
+	assert_rc_equal(rc, 0);
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
+	daos_prop_val_2_co_status(entry->dpe_val, &stat);
+	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_HEALTHY);
+	rc = daos_cont_open(arg->pool.poh, arg->co_str, arg->cont_open_flags,
+			    &coh, &arg->co_info, NULL);
+	assert_rc_equal(rc, 0);
+	rc = daos_cont_close(coh, NULL);
+	assert_rc_equal(rc, 0);
+
+	/* IO testing */
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+	dts_buf_render(stack_buf, STACK_BUF_LEN);
+	d_iov_set(&sg_iov, stack_buf, STACK_BUF_LEN);
+	sgl.sg_nr	= 1;
+	sgl.sg_nr_out	= 1;
+	sgl.sg_iovs	= &sg_iov;
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	recx.rx_idx = 0;
+	recx.rx_nr  = STACK_BUF_LEN;
+	iod.iod_size	= 1;
+	iod.iod_nr	= 1;
+	iod.iod_recxs	= &recx;
+	iod.iod_type	= DAOS_IOD_ARRAY;
+
+	if (ndom < 5) {
+		print_message("OC_EC_4P1G1 obj layout create should fail if ndom < 5\n");
+		io_oid = daos_test_oid_gen(arg->coh, OC_EC_4P1G1, 0, 0, arg->myrank);
+		/* grp_size > ndom, should fail in dc_obj_open()->obj_layout_create */
+		rc = daos_obj_open(arg->coh, io_oid, 0, &io_oh, NULL);
+		assert_rc_equal(rc, -DER_INVAL);
+	}
+
+	print_message("obj update should success before RF broken\n");
+	io_oid = daos_test_oid_gen(arg->coh, OC_EC_2P2G1, 0, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, io_oid, 0, &io_oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			     NULL);
+	assert_rc_equal(rc, 0);
+
+	/* exclude one more rank on another NODE dom */
+	if (arg->myrank == 0)
+		daos_exclude_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[2]);
+	par_barrier(PAR_COMM_WORLD);
+	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
+	assert_rc_equal(rc, 0);
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
+	daos_prop_val_2_co_status(entry->dpe_val, &stat);
+	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_UNCLEAN);
+	rc = daos_cont_open(arg->pool.poh, arg->co_str, arg->cont_open_flags, &coh, NULL, NULL);
+	assert_rc_equal(rc, -DER_RF);
+	print_message("obj update should fail after RF broken\n");
+	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, -DER_RF);
+	print_message("obj fetch should fail after RF broken\n");
+	rc = daos_obj_fetch(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL, NULL);
+	assert_rc_equal(rc, -DER_RF);
+
+	if (arg->myrank == 0) {
+		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+		test_rebuild_wait(&arg, 1);
+		daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[2]);
+		daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[1]);
+		daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[0]);
+		test_rebuild_wait(&arg, 1);
+	}
+	par_barrier(PAR_COMM_WORLD);
+
+	print_message("obj update should success after re-integrate\n");
+	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, 0);
+
+	rc = daos_obj_close(io_oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	/* clear the UNCLEAN status */
+	rc = daos_cont_status_clear(arg->coh, NULL);
+	assert_rc_equal(rc, 0);
+
+	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
+	assert_rc_equal(rc, 0);
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
+	daos_prop_val_2_co_status(entry->dpe_val, &stat);
+	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_HEALTHY);
+
+out:
+	print_message("cont prop should be able to query for g2l handle\n");
+	rc = daos_cont_open(arg->pool.poh, arg->co_str, arg->cont_open_flags,
+			    &coh, NULL, NULL);
+	assert_rc_equal(rc, 0);
+
+	rc = daos_cont_local2global(coh, &ghdl);
+	assert_rc_equal(rc, 0);
+	ghdl.iov_buf = malloc(ghdl.iov_buf_len);
+	ghdl.iov_len = ghdl.iov_buf_len;
+	rc = daos_cont_local2global(coh, &ghdl);
+	assert_rc_equal(rc, 0);
+
+	rc = daos_cont_global2local(arg->pool.poh, ghdl, &coh_g2l);
+	assert_rc_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		rc = daos_cont_query(coh_g2l, &info, NULL, NULL);
+		assert_rc_equal(rc, 0);
+		assert_int_equal(info.ci_redun_lvl, DAOS_PROP_CO_REDUN_NODE);
+		assert_int_equal(info.ci_redun_fac, DAOS_PROP_CO_REDUN_RF1);
+	}
+
+	rc = daos_cont_close(coh_g2l, NULL);
+	assert_int_equal(rc, 0);
+	free(ghdl.iov_buf);
+
+	rc = daos_cont_close(coh, NULL);
+	assert_rc_equal(rc, 0);
+
+	if (plmap != NULL)
+		pl_map_decref(plmap);
+	daos_prop_free(prop);
+	test_teardown((void **)&arg);
+}
+
+static int
 co_setup_sync(void **state)
 {
 	async_disable(state);
@@ -2575,6 +2858,8 @@ static const struct CMUnitTest co_tests[] = {
 	  test_case_teardown},
 	{ "CONT26: container API compat",
 	  co_api_compat, NULL, test_case_teardown},
+	{ "CONT27: container REDUN_LVL and RF test",
+	  co_redun_lvl, NULL, test_case_teardown},
 };
 
 int


### PR DESCRIPTION
Handle DAOS_PROP_CO_REDUN_LVL cont property, which can be set as
DAOS_PROP_CO_REDUN_RANK/DAOS_PROP_CO_REDUN_NODE when
container create.
Can create container with rf_lvl parameter by cmd line, such as -
"daos cont create --pool= --properties=rf_lvl:2 ...", or in C code passing
DAOS_PROP_CO_REDUN_LVL type property to daos_cont_create().
With related changes in placement, container RF check, and property
handling.
Change "struct daos_obj_md" to add md_fdom_lvl parameter.
Add a test case to verify it.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>