### PR TITLE
DAOS-8918 container: Fix key conflict with pool MD (#8824)

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -186,55 +186,7 @@ static void cont_svc_ec_agg_leader_stop(struct cont_svc *svc);
 int
 ds_cont_svc_step_up(struct cont_svc *svc)
 {
-	struct rdb_tx	tx;
-	d_iov_t		value;
-	uint32_t	version;
-	int		rc;
-
-	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
-	if (rc != 0)
-		goto out;
-	ABT_rwlock_rdlock(svc->cs_lock);
-
-	/* Check the layout version. */
-	d_iov_set(&value, &version, sizeof(version));
-	rc = rdb_tx_lookup(&tx, &svc->cs_root, &ds_cont_prop_version, &value);
-	if (rc == -DER_NONEXIST) {
-		ds_notify_ras_eventf(RAS_CONT_DF_INCOMPAT, RAS_TYPE_INFO,
-				     RAS_SEV_ERROR, NULL /* hwid */,
-				     NULL /* rank */, NULL /* inc */,
-				     NULL /* jobid */,
-				     &svc->cs_pool_uuid, NULL /* cont */,
-				     NULL /* objid */, NULL /* ctlop */,
-				     NULL /* data */,
-				     "incompatible layout version");
-		rc = -DER_DF_INCOMPT;
-		goto out_lock;
-	} else if (rc != 0) {
-		D_ERROR(DF_UUID": failed to look up layout version: "DF_RC"\n",
-			DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
-		goto out_lock;
-	}
-	if (version < DS_CONT_MD_VERSION_LOW || version > DS_CONT_MD_VERSION) {
-		ds_notify_ras_eventf(RAS_CONT_DF_INCOMPAT, RAS_TYPE_INFO,
-				     RAS_SEV_ERROR, NULL /* hwid */,
-				     NULL /* rank */, NULL /* inc */,
-				     NULL /* jobid */,
-				     &svc->cs_pool_uuid, NULL /* cont */,
-				     NULL /* objid */, NULL /* ctlop */,
-				     NULL /* data */,
-				     "incompatible layout version: %u not in "
-				     "[%u, %u]", version,
-				     DS_CONT_MD_VERSION_LOW,
-				     DS_CONT_MD_VERSION);
-		rc = -DER_DF_INCOMPT;
-	}
-
-out_lock:
-	ABT_rwlock_unlock(svc->cs_lock);
-	rdb_tx_end(&tx);
-	if (rc != 0)
-		goto out;
+	int rc;
 
 	D_ASSERT(svc->cs_pool == NULL);
 	svc->cs_pool = ds_pool_lookup(svc->cs_pool_uuid);
@@ -245,7 +197,6 @@ out_lock:
 		D_ERROR(DF_UUID": start ec agg leader failed: "DF_RC"\n",
 			DP_UUID(svc->cs_pool_uuid), DP_RC(rc));
 
-out:
 	return rc;
 }
 
@@ -317,18 +268,8 @@ int
 ds_cont_init_metadata(struct rdb_tx *tx, const rdb_path_t *kvs,
 		      const uuid_t pool_uuid)
 {
-	d_iov_t			value;
-	uint32_t		version = DS_CONT_MD_VERSION;
 	struct rdb_kvs_attr	attr;
 	int			rc;
-
-	d_iov_set(&value, &version, sizeof(version));
-	rc = rdb_tx_update(tx, kvs, &ds_cont_prop_version, &value);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to initialize layout version: %d\n",
-			DP_UUID(pool_uuid), rc);
-		return rc;
-	}
 
 	attr.dsa_class = RDB_KVS_GENERIC;
 	attr.dsa_order = 16;

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -13,7 +13,6 @@
 #include "srv_layout.h"
 
 /* Root KVS */
-RDB_STRING_KEY(ds_cont_prop_, version);
 RDB_STRING_KEY(ds_cont_prop_, cuuids);
 RDB_STRING_KEY(ds_cont_prop_, conts);
 RDB_STRING_KEY(ds_cont_prop_, cont_handles);

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -23,7 +23,7 @@
  *       ... (more container property KVSs)
  *     Container handle KVS (GENERIC)
  *
- * The version of the whole layout is stored in ds_cont_prop_version.
+ * The version of the whole layout is defined by ds_pool_prop_version.
  */
 
 #ifndef __CONTAINER_SRV_LAYOUT_H__
@@ -31,23 +31,27 @@
 
 #include <daos_types.h>
 
-/* Default layout version */
-#define DS_CONT_MD_VERSION 7
-
-/* Lowest compatible layout version */
-#define DS_CONT_MD_VERSION_LOW 4
-
 /*
  * Root KVS (RDB_KVS_GENERIC)
  *
  * All keys are strings. Value types are specified for each key below.
  *
- * ds_cont_prop_version stores the version of the whole layout.
+ * IMPORTANT! Please add new keys to this KVS like this:
+ *
+ *   extern d_iov_t ds_cont_prop_new_key;	comment_on_value_type
+ *
+ *   Note 1. The "new_key" name in ds_cont_prop_new_key must not appear in the
+ *   root KVS in src/pool/srv_layout.h, that is, there must not be a
+ *   ds_pool_prop_new_key, because the two root KVSs are the same RDB KVS.
+ *
+ *   Note 2. The comment_on_value_type shall focus on the value type only;
+ *   usage shall be described above in this comment following existing
+ *   examples. If the value is another KVS, its type shall be the KVS name.
  */
-extern d_iov_t ds_cont_prop_version;		/* uint32_t */
 extern d_iov_t ds_cont_prop_cuuids;		/* container UUIDs KVS */
 extern d_iov_t ds_cont_prop_conts;		/* container KVS */
 extern d_iov_t ds_cont_prop_cont_handles;	/* container handle KVS */
+/* Please read the IMPORTANT notes above before adding new keys. */
 
 /*
  * Container UUIDs KVS (RDB_KVS_GENERIC)
@@ -66,6 +70,14 @@ extern d_iov_t ds_cont_prop_cont_handles;	/* container handle KVS */
  * Container property KVS (RDB_KVS_GENERIC)
  *
  * All keys are strings. Value types are specified for each key below.
+ *
+ * IMPORTANT! Please add new keys to this KVS like this:
+ *
+ *   extern d_iov_t ds_cont_prop_new_key;	comment_on_value_type
+ *
+ *   Note. The comment_on_value_type shall focus on the value type only;
+ *   usage shall be described above in this comment following existing
+ *   examples. If the value is another KVS, its type shall be the KVS name.
  */
 extern d_iov_t ds_cont_prop_ghce;		/* uint64_t */
 extern d_iov_t ds_cont_prop_alloced_oid;	/* uint64_t */
@@ -82,7 +94,7 @@ extern d_iov_t ds_cont_prop_redun_lvl;		/* uint64_t */
 extern d_iov_t ds_cont_prop_snapshot_max;	/* uint64_t */
 extern d_iov_t ds_cont_prop_compress;		/* uint64_t */
 extern d_iov_t ds_cont_prop_encrypt;		/* uint64_t */
-extern d_iov_t ds_cont_prop_acl;		/* struct daos_acl */
+extern d_iov_t ds_cont_prop_acl;		/* daos_acl */
 extern d_iov_t ds_cont_prop_owner;		/* string */
 extern d_iov_t ds_cont_prop_owner_group;	/* string */
 extern d_iov_t ds_cont_prop_nsnapshots;		/* uint32_t */
@@ -90,11 +102,12 @@ extern d_iov_t ds_cont_prop_snapshots;		/* snapshot KVS */
 extern d_iov_t ds_cont_prop_co_status;		/* uint64_t */
 extern d_iov_t ds_cont_attr_user;		/* user attribute KVS */
 extern d_iov_t ds_cont_prop_handles;		/* handle index KVS */
-extern d_iov_t ds_cont_prop_roots;		/* container first citizens */
-extern d_iov_t ds_cont_prop_ec_cell_sz;		/* cell size of EC */
-extern d_iov_t ds_cont_prop_ec_pda;		/* uint32 */
-extern d_iov_t ds_cont_prop_rp_pda;		/* uint32 */
-extern d_iov_t ds_cont_prop_cont_global_version;/* uint32 */
+extern d_iov_t ds_cont_prop_roots;		/* daos_prop_co_roots */
+extern d_iov_t ds_cont_prop_ec_cell_sz;		/* uint64_t */
+extern d_iov_t ds_cont_prop_ec_pda;		/* uint64_t */
+extern d_iov_t ds_cont_prop_rp_pda;		/* uint64_t */
+extern d_iov_t ds_cont_prop_cont_global_version;/* uint32_t */
+/* Please read the IMPORTANT notes above before adding new keys. */
 
 /*
  * Snapshot KVS (RDB_KVS_INTEGER)

--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -34,12 +34,24 @@
 /*
  * Root KVS (RDB_KVS_GENERIC): pool properties
  *
- * ds_pool_prop_version stores the version of the whole layout.
+ * The ds_pool_prop_version property stores the version of the whole layout,
+ * including that of the container metadata..
  *
- * The pool map is stored in pool_buf format. Because version and target UUID
- * are absent from pool_buf, they have to be stored in ds_pool_prop_map_version
- * and ds_pool_prop_map_uuids, respectively. The target UUIDs are stored in
- * target ID order.
+ * The ds_pool_prop_map_buffer property stores the pool map in pool_buf format,
+ * because version is absent from pool_buf, it has to be stored separately in
+ * ds_pool_prop_map_version.
+ *
+ * IMPORTANT! Please add new keys to this KVS like this:
+ *
+ *   extern d_iov_t ds_pool_prop_new_key;	comment_on_value_type
+ *
+ *   Note 1. The "new_key" name in ds_pool_prop_new_key must not appear in the
+ *   root KVS in src/container/srv_layout.h, that is, there must not be a
+ *   ds_cont_prop_new_key, because the two root KVSs are the same RDB KVS.
+ *
+ *   Note 2. The comment_on_value_type shall focus on the value type only;
+ *   usage shall be described above in this comment following existing
+ *   examples. If the value is another KVS, its type shall be the KVS name.
  */
 extern d_iov_t ds_pool_prop_version;		/* uint32_t */
 extern d_iov_t ds_pool_prop_map_version;	/* uint32_t */
@@ -54,16 +66,16 @@ extern d_iov_t ds_pool_prop_owner_group;	/* string */
 extern d_iov_t ds_pool_prop_connectable;	/* uint32_t */
 extern d_iov_t ds_pool_prop_nhandles;		/* uint32_t */
 extern d_iov_t ds_pool_prop_handles;		/* pool handle KVS */
-extern d_iov_t ds_pool_prop_ec_cell_sz;		/* pool EC cell size */
-extern d_iov_t ds_pool_prop_redun_fac;		/* pool redundancy factor */
+extern d_iov_t ds_pool_prop_ec_cell_sz;		/* uint64_t */
+extern d_iov_t ds_pool_prop_redun_fac;		/* uint64_t */
 extern d_iov_t ds_pool_prop_ec_pda;		/* uint32_t */
 extern d_iov_t ds_pool_prop_rp_pda;		/* uint32_t */
 extern d_iov_t ds_pool_attr_user;		/* pool user attributes KVS */
-extern d_iov_t ds_pool_prop_policy;		/* tiering policy uint32_t */
-extern d_iov_t ds_pool_prop_global_version;	/* global pool status */
-extern d_iov_t ds_pool_prop_upgrade_status;	/* upgrade status */
-/* Target upgrade global version */
-extern d_iov_t ds_pool_prop_upgrade_global_version;
+extern d_iov_t ds_pool_prop_policy;		/* string (tiering policy) */
+extern d_iov_t ds_pool_prop_global_version;	/* uint32_t */
+extern d_iov_t ds_pool_prop_upgrade_status;	/* uint32_t */
+extern d_iov_t ds_pool_prop_upgrade_global_version;/* uint32_t */
+/* Please read the IMPORTANT notes above before adding new keys. */
 
 /*
  * Pool handle KVS (RDB_KVS_GENERIC)


### PR DESCRIPTION
The ds_cont_prop_version key conflicts with ds_pool_prop_version. The
two keys refer to the same value in the root RDB KVS. This patch removes
ds_cont_prop_version to avoid future confusions, for using separate
versions for pool and container metadata would be an overkill currently.

The patch also includes some layout-related fixes and improvements:

  - Remove ds_cont_prop_ghce and ds_cont_prop_ghpce, for these were
    deprecated long ago and have not been read since.

  - Fix the value type comments for ds_cont_prop_ec_pda and
    ds-cont_prop_rp_pda.

  - Improve the consistency of value type comments.

How to add layout-version-dependent code to src/container is left to
further discussions (e.g., by exporting and using ds_pool_prop_version
and/or ds_pool_prop_global_version?).

Signed-off-by: Li Wei <wei.g.li@intel.com>