### PR TITLE
DAOS-10352 dtx: limited DTX batched commit ULTs

### DIFF
--- a/docs/admin/env_variables.md
+++ b/docs/admin/env_variables.md
@@ -46,6 +46,10 @@ Environment variables in this section only apply to the server side.
 |DAOS\_SCHED\_RELAX\_MODE|The mode of CPU relaxing on idle. "disabled":disable relaxing; "net":wait on network request for INTVL; "sleep":sleep for INTVL. STRING. Default to "net"|
 |DAOS\_SCHED\_RELAX\_INTVL|CPU relax interval in milliseconds. INTEGER. Default to 1 ms.|
 |DAOS\_STRICT\_SHUTDOWN|Use the strict mode when shutting down engines. BOOL. Default to 0. In the strict mode, when certain resource leaks are detected, for instance, the engine will raise an assertion failure.|
+|DAOS\_DTX\_AGG\_THD\_CNT|DTX aggregation count threshold. The valid range is [2^20, 2^24]. The default value is 2^19*7.|
+|DAOS\_DTX\_AGG\_THD\_AGE|DTX aggregation age threshold in seconds. The valid range is [210, 1830]. The default value is 630.|
+|DAOS\_DTX\_RPC\_HELPER\_THD|DTX RPC helper threshold. The valid range is [18, unlimited). The default value is 513.|
+|DAOS\_DTX\_BATCHED\_ULT\_MAX|The max count of DTX batched commit ULTs. The valid range is [0, unlimited). 0 means to commit DTX synchronously. The default value is 32.|
 
 ## Server and Client environment variables
 

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -22,6 +22,8 @@ uint32_t dtx_agg_thd_cnt_up;
 uint32_t dtx_agg_thd_cnt_lo;
 uint32_t dtx_agg_thd_age_up;
 uint32_t dtx_agg_thd_age_lo;
+uint32_t dtx_batched_ult_max;
+
 
 struct dtx_batched_pool_args {
 	/* Link to dss_module_info::dmi_dtx_batched_pool_list. */
@@ -470,11 +472,14 @@ static void
 dtx_batched_commit_one(void *arg)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
+	struct dtx_tls			*tls = dtx_tls_get();
 	struct dtx_batched_cont_args	*dbca = arg;
 	struct ds_cont_child		*cont = dbca->dbca_cont;
 
 	if (dbca->dbca_commit_req == NULL)
 		goto out;
+
+	tls->dt_batched_ult_cnt++;
 
 	/* dbca->dbca_reg_gen != cont->sc_dtx_batched_gen means someone reopen the container. */
 	while (!dss_ult_exiting(dbca->dbca_commit_req) &&
@@ -518,6 +523,7 @@ dtx_batched_commit_one(void *arg)
 	}
 
 	dbca->dbca_commit_done = 1;
+	tls->dt_batched_ult_cnt--;
 
 out:
 	dtx_put_dbca(dbca);
@@ -527,6 +533,7 @@ void
 dtx_batched_commit(void *arg)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
+	struct dtx_tls			*tls = dtx_tls_get();
 	struct dtx_batched_cont_args	*dbca;
 	struct sched_req_attr		 attr;
 	uuid_t				 anonym_uuid;
@@ -572,6 +579,7 @@ dtx_batched_commit(void *arg)
 		}
 
 		if (dtx_cont_opened(cont) && dbca->dbca_commit_req == NULL &&
+		    (dtx_batched_ult_max != 0 && tls->dt_batched_ult_cnt < dtx_batched_ult_max) &&
 		    ((stat.dtx_committable_count > DTX_THRESHOLD_COUNT) ||
 		     (stat.dtx_oldest_committable_time != 0 &&
 		      dtx_hlc_age2sec(stat.dtx_oldest_committable_time) >=
@@ -1120,7 +1128,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 		D_ASSERT(0);
 	}
 
-	if ((!dth->dth_active && dth->dth_dist) || dth->dth_prepared) {
+	if ((!dth->dth_active && dth->dth_dist) || dth->dth_prepared || dtx_batched_ult_max == 0) {
 		/* We do not know whether some other participants have
 		 * some active entry for this DTX, consider distributed
 		 * transaction case, the other participants may execute

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -127,8 +127,21 @@ extern uint32_t dtx_agg_thd_age_up;
  */
 extern uint32_t dtx_agg_thd_age_lo;
 
+/* The default count of DTX batched commit ULTs. */
+#define DTX_BATCHED_ULT_DEF	32
+
+/*
+ * Ideally, dedicated DXT batched commit ULT for each opened container is the most simple model.
+ * But it may be burden for the engine if opened containers become more and more on the target.
+ * So it is necessary to restrict the count of DTX batched commit ULTs on the target. It can be
+ * adjusted via the environment "DAOS_DTX_BATCHED_ULT_MAX" when load the module.
+ *
+ * Zero:		disable DTX batched commit, all DTX will be committed synchronously.
+ * Others:		the max count of DXT batched commit ULTs.
+ */
+extern uint32_t dtx_batched_ult_max;
+
 /* The threshold for using helper ULT when handle DTX RPC. */
-#define DTX_RPC_HELPER_THD_MAX	(~0U)
 #define DTX_RPC_HELPER_THD_MIN	18
 #define DTX_RPC_HELPER_THD_DEF	(DTX_THRESHOLD_COUNT + 1)
 
@@ -146,6 +159,7 @@ struct dtx_pool_metrics {
 struct dtx_tls {
 	struct d_tm_node_t	*dt_committable;
 	uint64_t		 dt_agg_gen;
+	uint32_t		 dt_batched_ult_cnt;
 };
 
 extern struct dss_module_key dtx_module_key;

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -350,67 +350,45 @@ out:
 static int
 dtx_init(void)
 {
-	const char	*str;
-	int		 rc;
+	int	rc;
 
-	str = getenv("DTX_AGG_THD_CNT");
-	if (str != NULL) {
-		dtx_agg_thd_cnt_up = atoi(str);
-		if (dtx_agg_thd_cnt_up < DTX_AGG_THD_CNT_MIN ||
-		    dtx_agg_thd_cnt_up > DTX_AGG_THD_CNT_MAX) {
-			D_WARN("Invalid DTX aggregation count threshold %d, "
-			       "the valid range is [%d, %d], use the "
-			       "default value %d\n",
-			       dtx_agg_thd_cnt_up, DTX_AGG_THD_CNT_MIN,
-			       DTX_AGG_THD_CNT_MAX, DTX_AGG_THD_CNT_DEF);
-			dtx_agg_thd_cnt_up = DTX_AGG_THD_CNT_DEF;
-		}
-	} else {
+	dtx_agg_thd_cnt_up = DTX_AGG_THD_CNT_DEF;
+	d_getenv_int("DAOS_DTX_AGG_THD_CNT", &dtx_agg_thd_cnt_up);
+	if (dtx_agg_thd_cnt_up < DTX_AGG_THD_CNT_MIN || dtx_agg_thd_cnt_up > DTX_AGG_THD_CNT_MAX) {
+		D_WARN("Invalid DTX aggregation count threshold %u, the valid range is [%u, %u], "
+		       "use the default value %u\n", dtx_agg_thd_cnt_up, DTX_AGG_THD_CNT_MIN,
+		       DTX_AGG_THD_CNT_MAX, DTX_AGG_THD_CNT_DEF);
 		dtx_agg_thd_cnt_up = DTX_AGG_THD_CNT_DEF;
 	}
 
 	dtx_agg_thd_cnt_lo = dtx_agg_thd_cnt_up * 6 / 7;
+	D_INFO("Set DTX aggregation count threshold as %u (entries)\n", dtx_agg_thd_cnt_up);
 
-	D_INFO("Set DTX aggregation count threshold as %d (entries)\n",
-	       dtx_agg_thd_cnt_up);
-
-	str = getenv("DTX_AGG_THD_AGE");
-	if (str != NULL) {
-		dtx_agg_thd_age_up = atoi(str);
-		if (dtx_agg_thd_age_up < DTX_AGG_THD_AGE_MIN ||
-		    dtx_agg_thd_age_up > DTX_AGG_THD_AGE_MAX) {
-			D_WARN("Invalid DTX aggregation age threshold %d, "
-			       "the valid range is [%d, %d], use the "
-			       "default value %d\n",
-			       dtx_agg_thd_age_up, DTX_AGG_THD_AGE_MIN,
-			       DTX_AGG_THD_AGE_MAX, DTX_AGG_THD_AGE_DEF);
-			dtx_agg_thd_age_up = DTX_AGG_THD_AGE_DEF;
-		}
-	} else {
+	dtx_agg_thd_age_up = DTX_AGG_THD_AGE_DEF;
+	d_getenv_int("DAOS_DTX_AGG_THD_AGE", &dtx_agg_thd_age_up);
+	if (dtx_agg_thd_age_up < DTX_AGG_THD_AGE_MIN || dtx_agg_thd_age_up > DTX_AGG_THD_AGE_MAX) {
+		D_WARN("Invalid DTX aggregation age threshold %u, the valid range is [%u, %u], "
+		       "use the default value %u\n", dtx_agg_thd_age_up, DTX_AGG_THD_AGE_MIN,
+		       DTX_AGG_THD_AGE_MAX, DTX_AGG_THD_AGE_DEF);
 		dtx_agg_thd_age_up = DTX_AGG_THD_AGE_DEF;
 	}
 
 	dtx_agg_thd_age_lo = dtx_agg_thd_age_up - 30;
+	D_INFO("Set DTX aggregation time threshold as %u (seconds)\n", dtx_agg_thd_age_up);
 
-	D_INFO("Set DTX aggregation time threshold as %d (seconds)\n",
-	       dtx_agg_thd_age_up);
-
-	str = getenv("DTX_RPC_HELPER_THD");
-	if (str != NULL) {
-		dtx_rpc_helper_thd = atoi(str);
-		if (dtx_rpc_helper_thd == 0) {
-			dtx_rpc_helper_thd = DTX_RPC_HELPER_THD_MAX;
-		} else if (dtx_rpc_helper_thd < DTX_RPC_HELPER_THD_MIN) {
-			D_WARN("Invalid DTX RPC helper threshold %u, the valid range is "
-			       "[%u, unlimited), 0 is for unlimited, use the default value %u\n",
-			       dtx_rpc_helper_thd, DTX_RPC_HELPER_THD_MIN, DTX_RPC_HELPER_THD_DEF);
-			dtx_rpc_helper_thd = DTX_RPC_HELPER_THD_DEF;
-		}
-	} else {
+	dtx_rpc_helper_thd = DTX_RPC_HELPER_THD_DEF;
+	d_getenv_int("DAOS_DTX_RPC_HELPER_THD", &dtx_rpc_helper_thd);
+	if (dtx_rpc_helper_thd < DTX_RPC_HELPER_THD_MIN) {
+		D_WARN("Invalid DTX RPC helper threshold %u, the valid range is [%u, unlimited), "
+		       "use the default value %u\n",
+		       dtx_rpc_helper_thd, DTX_RPC_HELPER_THD_MIN, DTX_RPC_HELPER_THD_DEF);
 		dtx_rpc_helper_thd = DTX_RPC_HELPER_THD_DEF;
 	}
-
 	D_INFO("Set DTX RPC helper threshold as %u\n", dtx_rpc_helper_thd);
+
+	dtx_batched_ult_max = DTX_BATCHED_ULT_DEF;
+	d_getenv_int("DAOS_DTX_BATCHED_ULT_MAX", &dtx_batched_ult_max);
+	D_INFO("Set the max count of DTX batched commit ULTs as %d\n", dtx_batched_ult_max);
 
 	rc = dbtree_class_register(DBTREE_CLASS_DTX_CF,
 				   BTR_FEAT_UINT_KEY | BTR_FEAT_DYNAMIC_ROOT,


### PR DESCRIPTION
Ideally, dedicated DXT batched commit ULT for each opened container
is the most simple model. But it may be burden for the engine if
opened containers become more and more on the target. So it is
necessary to restrict the count for DTX batched commit ULTs on the
target. It can be adjusted via the environment "DTX_BATCHED_ULT_MAX"
when load the module. "0" means unlimited.

Signed-off-by: Fan Yong <fan.yong@intel.com>