### PR TITLE
DAOS-9873 control: Adjust permissions on mounted SCM filesystem (#8124)

### DIFF
--- a/src/control/server/storage/scm/mocks.go
+++ b/src/control/server/storage/scm/mocks.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -34,6 +34,7 @@ type (
 		MountErr        error
 		UnmountErr      error
 		MkfsErr         error
+		ChmodErr        error
 		GetfsStr        string
 		GetfsErr        error
 		SourceToTarget  map[string]string
@@ -112,6 +113,10 @@ func (msp *MockSysProvider) Unmount(target string, _ int) error {
 
 func (msp *MockSysProvider) Mkfs(_, _ string, _ bool) error {
 	return msp.cfg.MkfsErr
+}
+
+func (msp *MockSysProvider) Chmod(string, os.FileMode) error {
+	return msp.cfg.ChmodErr
 }
 
 func (msp *MockSysProvider) Getfs(_ string) (string, error) {

--- a/src/control/server/storage/scm/provider_test.go
+++ b/src/control/server/storage/scm/provider_test.go
@@ -616,6 +616,7 @@ func TestProvider_Format(t *testing.T) {
 		mountErr        error
 		unmountErr      error
 		mkfsErr         error
+		chmodErr        error
 		request         *storage.ScmFormatRequest
 		expResponse     *storage.ScmFormatResponse
 		expErr          error
@@ -743,6 +744,16 @@ func TestProvider_Format(t *testing.T) {
 			},
 			alreadyMounted: true,
 			unmountErr:     errors.New("unmount failed"),
+		},
+		"ramdisk: format succeeds, chmod fails": {
+			request: &storage.ScmFormatRequest{
+				Mountpoint: goodMountPoint,
+				Ramdisk: &storage.RamdiskParams{
+					Size: 1,
+				},
+			},
+			chmodErr: errors.New("chmod failed"),
+			expErr:   errors.New("chmod failed"),
 		},
 		"ramdisk: already mounted; reformat; mount fails": {
 			request: &storage.ScmFormatRequest{
@@ -900,6 +911,17 @@ func TestProvider_Format(t *testing.T) {
 			getFsStr: fsTypeNone,
 			mountErr: errors.New("mount failed"),
 		},
+		"dcpm: format succeeds, chmod fails": {
+			request: &storage.ScmFormatRequest{
+				Mountpoint: goodMountPoint,
+				Dcpm: &storage.DcpmParams{
+					Device: goodDevice,
+				},
+			},
+			getFsStr: fsTypeNone,
+			chmodErr: errors.New("chmod failed"),
+			expErr:   errors.New("chmod failed"),
+		},
 		"dcpm: missing device": {
 			request: &storage.ScmFormatRequest{
 				Mountpoint: goodMountPoint,
@@ -962,6 +984,7 @@ func TestProvider_Format(t *testing.T) {
 				GetfsStr:      tc.getFsStr,
 				GetfsErr:      tc.getFsErr,
 				MkfsErr:       tc.mkfsErr,
+				ChmodErr:      tc.chmodErr,
 				MountErr:      tc.mountErr,
 				UnmountErr:    tc.unmountErr,
 			}

--- a/src/tests/ftest/control/super_block_versioning.py
+++ b/src/tests/ftest/control/super_block_versioning.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -32,7 +32,7 @@ class SuperBlockVersioning(TestWithServers):
         # Check that the superblock file exists under the scm_mount dir.
         scm_mount = self.server_managers[0].get_config_value("scm_mount")
         fname = os.path.join(scm_mount, "superblock")
-        check_result = check_file_exists(self.hostlist_servers, fname)
+        check_result = check_file_exists(self.hostlist_servers, fname, sudo=True)
         if not check_result[0]:
             self.fail("{}: {} not found".format(check_result[1], fname))
 

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -583,7 +583,8 @@ def pcmd(hosts, command, verbose=True, timeout=None, expect_rc=0):
     return exit_status
 
 
-def check_file_exists(hosts, filename, user=None, directory=False):
+def check_file_exists(hosts, filename, user=None, directory=False,
+                      sudo=False):
     """Check if a specified file exist on each specified hosts.
 
     If specified, verify that the file exists and is owned by the user.
@@ -592,6 +593,8 @@ def check_file_exists(hosts, filename, user=None, directory=False):
         hosts (list): list of hosts
         filename (str): file to check for the existence of on each host
         user (str, optional): owner of the file. Defaults to None.
+        sudo (bool, optional): whether to run the command via sudo. Defaults to
+            False.
 
     Returns:
         (bool, NodeSet): A tuple of:
@@ -607,6 +610,9 @@ def check_file_exists(hosts, filename, user=None, directory=False):
         command = "test -O {0} && test -d {0}".format(filename)
     elif directory:
         command = "test -d '{0}'".format(filename)
+
+    if sudo:
+        command = "sudo " + command
 
     task = run_task(hosts, command)
     for ret_code, node_list in task.iter_retcodes():
@@ -718,7 +724,7 @@ def check_pool_files(log, hosts, uuid):
     log.info("Checking for pool data on %s", NodeSet.fromlist(hosts))
     pool_files = [uuid, "superblock"]
     for filename in ["/mnt/daos/{}".format(item) for item in pool_files]:
-        result = check_file_exists(hosts, filename)
+        result = check_file_exists(hosts, filename, sudo=True)
         if not result[0]:
             log.error("%s: %s not found", result[1], filename)
             status = False


### PR DESCRIPTION
Set the mounted SCM filesystem's root permissions to match the
underlying mountpoint's permissions. Adjust avocado code to
use sudo when looking into SCM.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
