### PR TITLE
DAOS-10012 control: Correct yaml path printed when missing (#9209)

### DIFF
--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -104,10 +104,8 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 
 		if cfgCmd, ok := cmd.(cfgLoader); ok {
 			if opts.ConfigPath == "" {
-				defaultConfigPath := path.Join(build.ConfigDir, defaultConfigFile)
-				if _, err := os.Stat(defaultConfigPath); err == nil {
-					opts.ConfigPath = defaultConfigPath
-				}
+				log.Debugf("Using build config directory %q", build.ConfigDir)
+				opts.ConfigPath = path.Join(build.ConfigDir, defaultConfigFile)
 			}
 
 			if err := cfgCmd.loadConfig(opts.ConfigPath); err != nil {
@@ -121,7 +119,8 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 				}
 			}
 		} else if opts.ConfigPath != "" {
-			return errors.Errorf("DAOS Server config has been supplied but this command will not use it")
+			return errors.Errorf("DAOS Server config filepath has been supplied but " +
+				"this command will not use it")
 		}
 
 		if err := cmd.Execute(cmdArgs); err != nil {

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -313,8 +313,9 @@ func (cfg *Server) Load() error {
 	}
 
 	if err = yaml.UnmarshalStrict(bytes, cfg); err != nil {
-		return errors.WithMessage(err, "parse failed; config contains invalid "+
-			"parameters and may be out of date, see server config examples")
+		return errors.WithMessagef(err, "parse of %q failed; config contains invalid "+
+			"parameters and may be out of date, see server config examples",
+			cfg.Path)
 	}
 
 	// propagate top-level settings to server configs


### PR DESCRIPTION
Currently if no path is specified in commandline when daos_server is
run and the default path is empty, no path is passed to LoadConfig()
and SetPath() attempts to resolve a new adjacent path. This is confusing
as it will list the derived path as missing rather than the default path.

Pass the default path directly to LoadConfig() to avoid this confusion.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>