### PR TITLE
DAOS-10612 pool, container: simplify layout versioning (#9055)

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -3477,7 +3477,7 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	uint64_t			 pda;
 	int				 rc;
 	bool				 upgraded = false;
-	uint32_t			 global_ver;
+	uint32_t			 global_ver = 0;
 	daos_prop_t			*prop = NULL;
 	struct daos_prop_entry		*entry;
 	(void)val;
@@ -3518,6 +3518,21 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	rc = cont_prop_read(ap->tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop, false);
 	if (rc)
 		goto out;
+
+	global_ver = DS_POOL_GLOBAL_VERSION;
+	rc = rdb_tx_update(ap->tx, &cont->c_prop,
+			   &ds_cont_prop_cont_global_version, &value);
+	if (rc) {
+		D_ERROR("failed to upgrade container global version pool/cont: "DF_CONTF"\n",
+			DP_CONT(ap->pool_uuid, cont_uuid));
+		goto out;
+	}
+	upgraded = true;
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_GLOBAL_VERSION);
+	D_ASSERT(entry != NULL);
+	D_ASSERT(daos_prop_is_set(entry) == false);
+	entry->dpe_flags &= ~DAOS_PROP_ENTRY_NOT_SET;
+	entry->dpe_val = global_ver;
 
 	d_iov_set(&value, &pda, sizeof(pda));
 	rc = rdb_tx_lookup(ap->tx, &cont->c_prop,

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -23,7 +23,7 @@
  *       ... (more container property KVSs)
  *     Container handle KVS (GENERIC)
  *
- * The version of the whole layout is defined by ds_pool_prop_version.
+ * The version of the whole layout is defined by ds_pool_prop_global_version.
  */
 
 #ifndef __CONTAINER_SRV_LAYOUT_H__

--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -17,7 +17,7 @@
  *       Pool handle KVS (GENERIC)
  *       Pool user attribute KVS (GENERIC)
  *
- * The version of the whole layout is stored in ds_pool_prop_version.
+ * The version of the whole layout is stored in ds_pool_prop_global_version.
  */
 
 #ifndef __POOL_SRV_LAYOUT_H__
@@ -25,17 +25,11 @@
 
 #include <daos_types.h>
 
-/* Default layout version */
-#define DS_POOL_MD_VERSION 7
-
-/* Lowest compatible layout version */
-#define DS_POOL_MD_VERSION_LOW 4
-
 /*
  * Root KVS (RDB_KVS_GENERIC): pool properties
  *
- * The ds_pool_prop_version property stores the version of the whole layout,
- * including that of the container metadata..
+ * The ds_pool_prop_global_version property stores the version of the whole
+ * layout, including that of the container metadata..
  *
  * The ds_pool_prop_map_buffer property stores the pool map in pool_buf format,
  * because version is absent from pool_buf, it has to be stored separately in
@@ -53,7 +47,6 @@
  *   usage shall be described above in this comment following existing
  *   examples. If the value is another KVS, its type shall be the KVS name.
  */
-extern d_iov_t ds_pool_prop_version;		/* uint32_t */
 extern d_iov_t ds_pool_prop_map_version;	/* uint32_t */
 extern d_iov_t ds_pool_prop_map_buffer;		/* pool_buf */
 extern d_iov_t ds_pool_prop_label;		/* string */

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -458,7 +458,6 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs, uint32_t nnodes, co
 		   const d_rank_list_t *ranks, daos_prop_t *prop, uint32_t ndomains,
 		   const uint32_t *domains)
 {
-	uint32_t		version = DS_POOL_MD_VERSION;
 	struct pool_buf	       *map_buf;
 	uint32_t		map_version = 1;
 	uint32_t		connectable;
@@ -468,14 +467,6 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs, uint32_t nnodes, co
 	int			ntargets = nnodes * dss_tgt_nr;
 	uint32_t		upgrade_global_version = DS_POOL_GLOBAL_VERSION;
 	int			rc;
-
-	/* Initialize the layout version. */
-	d_iov_set(&value, &version, sizeof(version));
-	rc = rdb_tx_update(tx, kvs, &ds_pool_prop_version, &value);
-	if (rc != 0) {
-		D_ERROR("failed to update version, "DF_RC"\n", DP_RC(rc));
-		goto out;
-	}
 
 	/* Generate the pool buffer. */
 	rc = gen_pool_buf(NULL /* map */, &map_buf, map_version, ndomains, nnodes, ntargets,
@@ -1195,8 +1186,8 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf,
 {
 	struct rdb_tx	tx;
 	d_iov_t		value;
+	uint32_t	global_version;
 	bool		version_exists = false;
-	uint32_t	version, global_version;
 	int		rc;
 
 	rc = rdb_tx_begin(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term, &tx);
@@ -1205,8 +1196,8 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf,
 	ABT_rwlock_rdlock(svc->ps_lock);
 
 	/* Check the layout version. */
-	d_iov_set(&value, &version, sizeof(version));
-	rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_version, &value);
+	d_iov_set(&value, &global_version, sizeof(global_version));
+	rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_global_version, &value);
 	if (rc == -DER_NONEXIST) {
 		/*
 		 * This DB may be new or incompatible. Check the existence of
@@ -1222,7 +1213,12 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf,
 		goto out_lock;
 	}
 	version_exists = true;
-	if (version < DS_POOL_MD_VERSION_LOW || version > DS_POOL_MD_VERSION) {
+
+	/**
+	 * downgrading the DAOS software of an upgraded pool report
+	 * a proper RAS error.
+	 */
+	if (global_version > DS_POOL_GLOBAL_VERSION) {
 		ds_notify_ras_eventf(RAS_POOL_DF_INCOMPAT, RAS_TYPE_INFO,
 				     RAS_SEV_ERROR, NULL /* hwid */,
 				     NULL /* rank */, NULL /* inc */,
@@ -1230,10 +1226,9 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf,
 				     &svc->ps_uuid, NULL /* cont */,
 				     NULL /* objid */, NULL /* ctlop */,
 				     NULL /* data */,
-				     "incompatible layout version: %u not in "
-				     "[%u, %u]", version,
-				     DS_POOL_MD_VERSION_LOW,
-				     DS_POOL_MD_VERSION);
+				     "incompatible layout version: %u larger than "
+				     "%u", global_version,
+				     DS_POOL_GLOBAL_VERSION);
 		rc = -DER_DF_INCOMPT;
 		goto out_lock;
 	}
@@ -1256,45 +1251,10 @@ check_map:
 		}
 		goto out_lock;
 	}
-	if (!version_exists) {
-		/* This DB is not new and uses a layout that lacks a version. */
-		ds_notify_ras_eventf(RAS_POOL_DF_INCOMPAT, RAS_TYPE_INFO,
-				     RAS_SEV_ERROR, NULL /* hwid */,
-				     NULL /* rank */, NULL /* inc */,
-				     NULL /* jobid */,
-				     &svc->ps_uuid, NULL /* cont */,
-				     NULL /* objid */, NULL /* ctlop */,
-				     NULL /* data */,
-				     "incompatible layout version");
-		rc = -DER_DF_INCOMPT;
-		goto out_lock;
-	}
 
-	d_iov_set(&value, &global_version, sizeof(global_version));
-	rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_global_version, &value);
-	if (rc == -DER_NONEXIST)
-		global_version = 0;
-	else if (rc)
-		goto out_lock;
-
-	/**
-	 * downgrading the DAOS software of an upgraded pool report
-	 * a proper RAS error.
-	 */
-	if (global_version > DS_POOL_GLOBAL_VERSION) {
-		ds_notify_ras_eventf(RAS_POOL_DF_INCOMPAT, RAS_TYPE_INFO,
-				     RAS_SEV_ERROR, NULL /* hwid */,
-				     NULL /* rank */, NULL /* inc */,
-				     NULL /* jobid */,
-				     &svc->ps_uuid, NULL /* cont */,
-				     NULL /* objid */, NULL /* ctlop */,
-				     NULL /* data */,
-				     "incompatible layout version: %u larger than "
-				     "%u", global_version,
-				     DS_POOL_GLOBAL_VERSION);
-		rc = -DER_DF_INCOMPT;
-		goto out_lock;
-	}
+	if (!version_exists)
+		/* This could also be a 1.x pool, which we assume nobody cares. */
+		D_DEBUG(DB_MD, DF_UUID": assuming 2.0\n", DP_UUID(svc->ps_uuid));
 
 	rc = pool_prop_read(&tx, svc, DAOS_PO_QUERY_PROP_ALL, prop);
 	if (rc != 0)


### PR DESCRIPTION
1. Remove ds_pool_prop_version, ds_pool_prop_global_version
could be used to replace its function.

2. Bump container's global version upon pool upgrading.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>