### PR TITLE
DAOS-10204 dtx: handle per akey based conditional

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2417,18 +2417,6 @@ out:
 	return rc;
 }
 
-static int
-shard_task_abort(tse_task_t *task, void *arg)
-{
-	int	rc = *((int *)arg);
-
-	tse_task_list_del(task);
-	tse_task_decref(task);
-	tse_task_complete(task, rc);
-
-	return 0;
-}
-
 static void
 shard_auxi_set_param(struct shard_auxi_args *shard_arg, uint32_t map_ver,
 		     uint32_t shard, uint32_t tgt_id, struct dtx_epoch *epoch,

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -600,6 +600,18 @@ obj_ptr2hdl(struct dc_object *obj)
 	return oh;
 }
 
+static inline int
+shard_task_abort(tse_task_t *task, void *arg)
+{
+	int	rc = *((int *)arg);
+
+	tse_task_list_del(task);
+	tse_task_decref(task);
+	tse_task_complete(task, rc);
+
+	return 0;
+}
+
 static inline void
 dc_io_epoch_set(struct dtx_epoch *epoch)
 {

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -2567,6 +2567,50 @@ dc_tx_check_update(uint64_t flags, int result)
 }
 
 static int
+dc_tx_per_akey_existence_sub_cb(tse_task_t *task, void *data)
+{
+	struct dc_tx_check_existence_cb_args	*args = data;
+
+	D_ASSERT(args->opc == DAOS_OBJ_RPC_UPDATE);
+	D_ASSERT(args->flags & DAOS_COND_PER_AKEY);
+	D_ASSERT(args->tmp_iods != NULL);
+	D_ASSERT(args->tmp_iod_nr == 1);
+
+	task->dt_result = dc_tx_check_update(args->tmp_iods->iod_flags, task->dt_result);
+
+	daos_iov_free(&args->tmp_iods->iod_name);
+	D_FREE(args->tmp_iods);
+
+	return 0;
+}
+
+static int
+dc_tx_per_akey_existence_parent_cb(tse_task_t *task, void *data)
+{
+	struct dc_tx_check_existence_cb_args	*args = data;
+	struct dc_object			*obj = NULL;
+	struct dc_tx				*tx = args->tx;
+	int					 rc = task->dt_result;
+
+	D_ASSERT(args->opc == DAOS_OBJ_RPC_UPDATE);
+	D_ASSERT(args->flags & DAOS_COND_PER_AKEY);
+
+	if (rc == 0) {
+		obj = obj_hdl2ptr(args->oh);
+		D_MUTEX_LOCK(&tx->tx_lock);
+		rc = dc_tx_add_update(tx, &obj, args->flags, args->dkey, args->nr,
+				      args->iods_or_akeys, args->sgls);
+		D_MUTEX_UNLOCK(&tx->tx_lock);
+		obj_decref(obj);
+	}
+
+	/* Drop the reference that is held via dc_tx_attach(). */
+	dc_tx_decref(tx);
+
+	return rc;
+}
+
+static int
 dc_tx_check_existence_cb(tse_task_t *task, void *data)
 {
 	struct dc_tx_check_existence_cb_args	*args = data;
@@ -2575,26 +2619,14 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 	int					 rc = 0;
 	int					 i;
 
-
 	obj = obj_hdl2ptr(args->oh);
 	D_MUTEX_LOCK(&tx->tx_lock);
 
 	switch (args->opc) {
 	case DAOS_OBJ_RPC_UPDATE:
-		if (args->flags & DAOS_COND_PER_AKEY) {
-			D_ASSERT(args->tmp_iods != NULL);
-
-			for (i = 0; i < args->tmp_iod_nr; i++) {
-				rc = dc_tx_check_update(args->tmp_iods[i].iod_flags,
-							task->dt_result);
-				if (rc != 0)
-					D_GOTO(out, rc);
-			}
-		} else {
-			rc = dc_tx_check_update(args->flags, task->dt_result);
-			if (rc != 0)
-				D_GOTO(out, rc);
-		}
+		rc = dc_tx_check_update(args->flags, task->dt_result);
+		if (rc != 0)
+			D_GOTO(out, rc);
 
 		rc = dc_tx_add_update(tx, &obj, args->flags,
 				      args->dkey, args->nr,
@@ -2646,6 +2678,117 @@ out:
 }
 
 static int
+dc_tx_per_akey_existence_task(enum obj_rpc_opc opc, daos_handle_t oh, struct dc_tx *tx,
+			      uint64_t flags, daos_key_t *dkey, uint32_t nr, void *iods_or_akeys,
+			      d_sg_list_t *sgls, tse_task_t *parent)
+{
+	struct dc_tx_check_existence_cb_args	 cb_args = { 0 };
+	daos_iod_t				*in_iods = iods_or_akeys;
+	daos_iod_t				*iods = NULL;
+	tse_task_t				*task = NULL;
+	d_list_t				 task_list;
+	int					 rc;
+	int					 i;
+
+	D_INIT_LIST_HEAD(&task_list);
+
+	cb_args.opc		= opc;
+	cb_args.tx		= tx;
+	cb_args.oh		= oh;
+	cb_args.flags		= flags;
+	cb_args.dkey		= dkey;
+	cb_args.nr		= nr;
+	cb_args.iods_or_akeys	= iods_or_akeys;
+	cb_args.sgls		= sgls;
+
+	/* XXX: individual sub-task for checking each akey's existence independently. */
+
+	for (i = 0; i < nr; i++) {
+		if (!(in_iods[i].iod_flags & (DAOS_COND_AKEY_INSERT | DAOS_COND_AKEY_UPDATE)))
+			continue;
+
+		D_ALLOC_ARRAY(iods, 1);
+		if (iods == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		rc = daos_iov_copy(&iods->iod_name, &in_iods[i].iod_name);
+		if (rc != 0)
+			goto out;
+
+		iods->iod_flags = in_iods[i].iod_flags;
+		cb_args.tmp_iod_nr = 1;
+		cb_args.tmp_iods = iods;
+
+		rc = dc_obj_fetch_task_create(oh, dc_tx_ptr2hdl(tx), DAOS_COND_AKEY_FETCH, dkey, 1,
+					      DIOF_CHECK_EXISTENCE, iods, NULL, NULL, NULL, NULL,
+					      NULL, tse_task2sched(parent), &task);
+		if (rc != 0)
+			goto out;
+
+		rc = tse_task_register_comp_cb(task, dc_tx_per_akey_existence_sub_cb,
+					       &cb_args, sizeof(cb_args));
+		if (rc != 0)
+			goto out;
+
+		/* decref and delete from head at shard_task_remove */
+		tse_task_addref(task);
+		tse_task_list_add(task, &task_list);
+
+		iods = NULL;
+
+		rc = dc_task_depend(parent, 1, &task);
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	if (rc == 0) {
+		if (unlikely(d_list_empty(&task_list))) {
+			struct dc_object	*obj;
+
+			obj_hdl2ptr(oh);
+			D_MUTEX_LOCK(&tx->tx_lock);
+			rc = dc_tx_add_update(tx, &obj, flags, dkey, nr, iods_or_akeys, sgls);
+			D_MUTEX_UNLOCK(&tx->tx_lock);
+			obj_decref(obj);
+
+			/* Drop the reference that is held via dc_tx_attach(). */
+			dc_tx_decref(tx);
+		} else {
+			rc = tse_task_register_comp_cb(parent, dc_tx_per_akey_existence_parent_cb,
+						       &cb_args, sizeof(cb_args));
+			if (rc != 0)
+				goto fail;
+
+			tse_task_list_sched(&task_list, true);
+
+			/*
+			 * Return positive value to notify the sponsor to not call
+			 * complete() the task until the checking existence callback.
+			 */
+			rc = 1;
+		}
+	} else {
+		if (iods != NULL) {
+			if (task != NULL)
+				dc_task_decref(task);
+
+			daos_iov_free(&iods->iod_name);
+			D_FREE(iods);
+		}
+
+fail:
+		tse_task_list_traverse(&task_list, shard_task_abort, &rc);
+		parent->dt_result = rc;
+
+		/* Drop the reference that is held via dc_tx_attach(). */
+		dc_tx_decref(tx);
+	}
+
+	return rc;
+}
+
+static int
 dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 			   struct dc_tx *tx, uint64_t flags, daos_key_t *dkey,
 			   uint32_t nr, void *iods_or_akeys, d_sg_list_t *sgls,
@@ -2690,33 +2833,7 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 			cb_args.tmp_iod_nr = nr;
 			cb_args.tmp_iods = iods;
 		} else {
-			if (flags & DAOS_COND_PER_AKEY) {
-				daos_iod_t	*in_iods = iods_or_akeys;
-				int		 j;
-
-				D_ALLOC_ARRAY(iods, nr);
-				if (iods == NULL)
-					D_GOTO(out, rc = -DER_NOMEM);
-
-				for (i = 0, j = 0; i < nr; i++) {
-					if (!(in_iods[i].iod_flags & (DAOS_COND_AKEY_INSERT |
-								      DAOS_COND_AKEY_UPDATE)))
-						continue;
-
-					rc = daos_iov_copy(&iods[j].iod_name, &in_iods[i].iod_name);
-					if (rc != 0)
-						goto out;
-
-					iods[j++].iod_flags = in_iods[i].iod_flags;
-				}
-
-				D_ASSERT(j > 0);
-
-				api_flags = DAOS_COND_AKEY_FETCH;
-				cb_args.tmp_iod_nr = j;
-				cb_args.tmp_iods = iods;
-				nr = j;
-			} else if (flags & (DAOS_COND_AKEY_INSERT | DAOS_COND_AKEY_UPDATE)) {
+			if (flags & (DAOS_COND_AKEY_INSERT | DAOS_COND_AKEY_UPDATE)) {
 				iods = iods_or_akeys;
 				api_flags = DAOS_COND_AKEY_FETCH;
 			} else {
@@ -2737,17 +2854,17 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 	if (rc != 0)
 		goto out;
 
-	rc = dc_task_depend(parent, 1, &task);
-	if (rc != 0) {
-		D_ERROR("Fail to add dep on check existence task: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
-	}
-
 	rc = tse_task_register_comp_cb(task, dc_tx_check_existence_cb,
 				       &cb_args, sizeof(cb_args));
 	if (rc != 0) {
 		D_ERROR("Fail to add CB for check existence task: "DF_RC"\n",
+			DP_RC(rc));
+		goto out;
+	}
+
+	rc = dc_task_depend(parent, 1, &task);
+	if (rc != 0) {
+		D_ERROR("Fail to add dep on check existence task: "DF_RC"\n",
 			DP_RC(rc));
 		goto out;
 	}
@@ -2794,8 +2911,7 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 		if (up->flags & (DAOS_COND_DKEY_INSERT |
 				 DAOS_COND_DKEY_UPDATE |
 				 DAOS_COND_AKEY_INSERT |
-				 DAOS_COND_AKEY_UPDATE |
-				 DAOS_COND_PER_AKEY)) {
+				 DAOS_COND_AKEY_UPDATE)) {
 			D_MUTEX_UNLOCK(&tx->tx_lock);
 
 			if (obj != NULL)
@@ -2804,6 +2920,19 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 			return dc_tx_check_existence_task(opc, up->oh, tx,
 						up->flags, up->dkey, up->nr,
 						up->iods, up->sgls, task);
+		}
+
+		if (up->flags & DAOS_COND_PER_AKEY) {
+			D_MUTEX_UNLOCK(&tx->tx_lock);
+
+			if (up->nr == 0 || up->iods == NULL)
+				D_GOTO(out, rc = -DER_INVAL);
+
+			if (obj != NULL)
+				obj_decref(obj);
+
+			return dc_tx_per_akey_existence_task(opc, up->oh, tx, up->flags, up->dkey,
+							     up->nr, up->iods, up->sgls, task);
 		}
 
 		rc = dc_tx_add_update(tx, &obj, up->flags, up->dkey,


### PR DESCRIPTION
 modification

If a distributed transaction contains per akey based modification,
then we need to check every related akey's existence via each own
sub-task independently. Each one is a conditional akey fetch task.

Signed-off-by: Fan Yong <fan.yong@intel.com>