### PR TITLE
DAOS-10748 bio: missed error code in bulk_map_one() (#9265)

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -1187,7 +1187,7 @@ flush_one(struct bio_desc *biod, struct bio_iov *biov, void *arg)
 	if (bio_addr_is_hole(&biov->bi_addr))
 		return 0;
 
-	if (biov->bi_addr.ba_type != DAOS_MEDIA_SCM)
+	if (!direct_scm_access(biod, biov))
 		return 0;
 
 	D_ASSERT(bio_iov2raw_buf(biov) != NULL);

--- a/src/bio/bio_bulk.c
+++ b/src/bio/bio_bulk.c
@@ -680,7 +680,7 @@ done:
 	biod->bd_bulk_hdls[biod->bd_bulk_cnt] = hdl;
 	biod->bd_bulk_cnt++;
 
-	return 0;
+	return rc;
 }
 
 void


### PR DESCRIPTION
bulk_map_one() mistakenly ignored the error code returned from
dma_map_one(), that could result in bio_iod_prep() succeeds even
when it actually fails in dma_map_one().

flush_one() can skip pmem flush when it's not direct SCM access
(DMA buffer is used for SCM bulk transfer by default).

Signed-off-by: Niu Yawei <yawei.niu@intel.com>