### PR TITLE
DAOS-10255 test: adjust minimum containers expectation again (#9162)

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -66,7 +66,7 @@ class ObjectMetadata(TestWithServers):
     """
 
     # Minimum number of containers that should be able to be created
-    CREATED_CONTAINERS_MIN = 2900
+    CREATED_CONTAINERS_MIN = 2500
 
     # Number of created containers that should not be possible
     CREATED_CONTAINERS_LIMIT = 3500


### PR DESCRIPTION
Cherry-pick of PR 9162 master commit b7d669d to reelease/2.2.

Significantly reduce the test's expectation of the minimum number of
containers that can be created in a pool, since frequent changes to
metadata layouts have an impact that triggers test failures. And since
the tests are currently designed to fill the metadata  on purpose,
rather than expect a specific quantity.

Quick-Functional: true
Test-tag: metadata_fillup metadata_der_nospace pool_create_all_one_hw

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>