### PR TITLE
DAOS-10798 test: Fix superblock version test

### DIFF
--- a/src/tests/ftest/control/super_block_versioning.py
+++ b/src/tests/ftest/control/super_block_versioning.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -32,7 +32,7 @@ class SuperBlockVersioning(TestWithServers):
         # Check that the superblock file exists under the scm_mount dir.
         scm_mount = self.server_managers[0].get_config_value("scm_mount")
         fname = os.path.join(scm_mount, "superblock")
-        check_result = check_file_exists(self.hostlist_servers, fname)
+        check_result = check_file_exists(self.hostlist_servers, fname, sudo=True)
         if not check_result[0]:
             self.fail("{}: {} not found".format(check_result[1], fname))
 


### PR DESCRIPTION
This test needs to use sudo when examining the contents
of SCM.

Test-tag: pr ds_versioning

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>

Required-githooks: true
