### PR TITLE
DAOS-10748 bio: handle huge chunk alloc failure

### DIFF
--- a/src/bio/bio_bulk.c
+++ b/src/bio/bio_bulk.c
@@ -370,7 +370,7 @@ bulk_grp_grow(struct bio_dma_buffer *bdb, struct bio_bulk_group *bbg,
 		goto populate;
 
 	/* Grow DMA buffer when not reaching DMA upper bound */
-	if (bdb->bdb_tot_cnt < bio_chk_cnt_max) {
+	if (!dma_buffer_full(bdb)) {
 		rc = dma_buffer_grow(bdb, 1);
 		if (rc == 0)
 			goto populate;


### PR DESCRIPTION
- Huge chunk should honor the DMA buffer upper bound as well;
- Unused bulk cache and unused chunks will be reclaimed to satisfy
  huge chunk allocation when there isn't sufficient DMA buffer;
- If huge chunk allocation fails due to DMA buffer exhausted by
  inflight IOs, retry after prior IO completes;

Signed-off-by: Niu Yawei <yawei.niu@intel.com>