### PR TITLE
DAOS-3985 control: Specify control interface

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -159,6 +159,7 @@ const (
 	ServerConfigInsufficientHugePages
 	ServerConfigNrHugepagesOutOfRange
 	ServerConfigHugepagesDisabled
+	ServerConfigBadControlIface
 )
 
 // SPDK library bindings codes

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -216,6 +216,15 @@ func FaultConfigInsufficientHugePages(min, req int) *fault.Fault {
 	)
 }
 
+// FaultConfigBadControlIface creates a fault describing a bad control plane network interface.
+func FaultConfigBadControlIface(iface string) *fault.Fault {
+	return serverConfigFault(
+		code.ServerConfigBadControlIface,
+		fmt.Sprintf("requested control interface %q is not valid", iface),
+		"update the 'control_iface' parameter with a valid network interface",
+	)
+}
+
 func serverConfigFault(code code.Code, desc, res string) *fault.Fault {
 	return &fault.Fault{
 		Domain:      "serverconfig",

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -38,8 +38,9 @@ const (
 // See utils/config/daos_server.yml for parameter descriptions.
 type Server struct {
 	// control-specific
-	ControlPort     int                       `yaml:"port"`
-	TransportConfig *security.TransportConfig `yaml:"transport_config"`
+	ControlInterface string                    `yaml:"control_iface,omitempty"`
+	ControlPort      int                       `yaml:"port"`
+	TransportConfig  *security.TransportConfig `yaml:"transport_config"`
 	// Detect outdated "servers" config, to direct users to change their config file
 	Servers             []*engine.Config       `yaml:"servers,omitempty"`
 	Engines             []*engine.Config       `yaml:"engines"`
@@ -176,6 +177,12 @@ func (cfg *Server) WithEngines(engineList ...*engine.Config) *Server {
 // WithAccessPoints sets the access point list.
 func (cfg *Server) WithAccessPoints(aps ...string) *Server {
 	cfg.AccessPoints = aps
+	return cfg
+}
+
+// WithControlPort sets the network interface for control plane communications.
+func (cfg *Server) WithControlInterface(iface string) *Server {
+	cfg.ControlInterface = iface
 	return cfg
 }
 
@@ -428,6 +435,10 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 			"\"engines\" instead")
 	}
 
+	if err := cfg.validateControlIface(log); err != nil {
+		return err
+	}
+
 	log.Debugf("vfio=%v hotplug=%v vmd=%v requested in config", !cfg.DisableVFIO,
 		cfg.EnableHotplug, !cfg.DisableVMD)
 
@@ -567,6 +578,20 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 		if err := cfg.validateMultiServerConfig(log); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (cfg *Server) validateControlIface(log logging.Logger) error {
+	if cfg.ControlInterface == "" {
+		return nil
+	}
+
+	_, err := net.InterfaceByName(cfg.ControlInterface)
+	if err != nil {
+		log.Errorf("unable to find network interface %q: %s", err.Error())
+		return FaultConfigBadControlIface(cfg.ControlInterface)
 	}
 
 	return nil

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -392,19 +392,26 @@ func TestServer_MgmtSvc_getPeerListenAddr(t *testing.T) {
 	}{
 		"no peer": {
 			ctx:    context.Background(),
+			addr:   "0.0.0.0:1234",
 			expErr: errors.New("peer details not found in context"),
 		},
-		"bad input address": {
+		"no input address": {
 			ctx:    peer.NewContext(context.Background(), &peer.Peer{Addr: defaultAddr}),
 			expErr: errors.New("get listening port: missing port in address"),
 		},
 		"non tcp address": {
 			ctx:    peer.NewContext(context.Background(), &peer.Peer{Addr: ipAddr}),
+			addr:   "0.0.0.0:1234",
 			expErr: errors.New("peer address (127.0.0.1) not tcp"),
 		},
 		"normal operation": {
 			ctx:     peer.NewContext(context.Background(), &peer.Peer{Addr: defaultAddr}),
 			addr:    "0.0.0.0:15001",
+			expAddr: combinedAddr,
+		},
+		"specific addr": {
+			ctx:     peer.NewContext(context.Background(), &peer.Peer{Addr: defaultAddr}),
+			addr:    combinedAddr.String(),
 			expAddr: combinedAddr,
 		},
 	} {

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -247,7 +247,17 @@ func (srv *server) setCoreDumpFilter() error {
 func (srv *server) initNetwork() error {
 	defer srv.logDuration(track("time to init network"))
 
-	ctlAddr, listener, err := createListener(srv.cfg.ControlPort, net.ResolveTCPAddr, net.Listen)
+	ctlAddr, err := getControlAddr(ctlAddrParams{
+		iface:         srv.cfg.ControlInterface,
+		port:          srv.cfg.ControlPort,
+		getIfaceAddrs: getNetInterfaceAddrs,
+		resolveAddr:   net.ResolveTCPAddr,
+	})
+	if err != nil {
+		return err
+	}
+
+	listener, err := createListener(ctlAddr, net.Listen)
 	if err != nil {
 		return err
 	}

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -83,6 +83,15 @@
 #provider: ofi+verbs;ofi_rxm
 #
 #
+## Control plane network interface
+## Optional. Use a specific network interface for communications with this
+## control plane server.
+## This parameter should be set if the machine has multiple interfaces
+## connected the management network.
+#
+#control_iface: eth0
+#
+#
 ## CART: Whether to enable share address in the network stack
 ## (also known as scalable endpoint)
 ## parameters shared with client.


### PR DESCRIPTION
- Allow the admin to specify the network interface that the
  control plane server should use for network communications
  in the server config file.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>