### PR TITLE
DAOS-10448 test: reduce SCM size in create_all_vm/other tests (#9291)

### DIFF
--- a/src/tests/ftest/container/query_properties.yaml
+++ b/src/tests/ftest/container/query_properties.yaml
@@ -5,7 +5,7 @@ hosts:
 timeout: 100
 
 pool:
-  scm_size: 10G
+  scm_size: 1G
   control_method: dmg
 
 container:

--- a/src/tests/ftest/control/dmg_telemetry_basic.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_basic.yaml
@@ -10,9 +10,9 @@ timeouts:
 server_config:
   name: daos_server
   servers:
-    scm_size: 16
+    scm_size: 4
 pool:
-  scm_size: 8G
+  scm_size: 2G
   control_method: dmg
 container:
   control_method: daos

--- a/src/tests/ftest/pool/create_all_vm.yaml
+++ b/src/tests/ftest/pool/create_all_vm.yaml
@@ -15,7 +15,7 @@ server_config:
     0:
       scm_class: ram
       scm_mount: /mnt/daos
-      scm_size: 8
+      scm_size: 4
 pool:
   name: daos_server
   control_method: dmg

--- a/src/tests/ftest/telemetry/dkey_akey_enum_punch.yaml
+++ b/src/tests/ftest/telemetry/dkey_akey_enum_punch.yaml
@@ -11,5 +11,5 @@ server_config:
       targets: 8
 
 pool:
-  scm_size: 10G
+  scm_size: 1G
   control_method: dmg


### PR DESCRIPTION
Cherry-pick of PR 9291 master commit c03a05623 to release/2.2 branch.

Before this change, in virtual machine (VM)-based testing of the
pool create_all tests, intermittent failures were seen due to
slow/laggy performance on the VM nodes. This resulted in RPC timeouts
in daos_engine during pool create/destroy operations. This is not a
a new phenomenon. Previously it has been seen with other VM-based tests,
requiring a smaller scm_size setting to alleviate memory pressure.

With this change, the scm_size parameter is reduced in this test
and in the following tests (and addressing the associated tickets):
- container/query_properties (DAOS-10487)
- telemetry/dkey_akey_enum_punch (DAOS-10487)
- control/dmg_telemetry_basic (DAOS-10528)

Longer term for create_all_vm, it may be better to eliiminate it,
relying instead on the nearly-identical pool/create_all_hw.py tests.

Quick-Functional: true
Test-tag: pool_create_all,vm test_with_telemetry_basic container,query_properties dkey_akey_enum_punch tgt_dkey_akey_punch pool_tgt_dkey_akey_punch
Test-repeat: 10

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>