### PR TITLE
DO NOT LAND

### DIFF
--- a/src/tests/ftest/control/config_generate_run.py
+++ b/src/tests/ftest/control/config_generate_run.py
@@ -20,6 +20,7 @@ class ConfigGenerateRun(TestWithServers):
 
     :avocado: recursive
     """
+
     def test_config_generate_run(self):
         """Run daos_server with generated server config file.
 


### PR DESCRIPTION
Verifying configuration changes to wolf-[110-111] allow the
control/config_generate_*.py tests to pass.

Skip-unit-tests: true
Test-tag: config_generate_entries

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>