### PR TITLE
DAOS-10085 doc: Add syslog delivery failure to troubleshooting (#9220)

### DIFF
--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -432,6 +432,46 @@ Verify if you're using Infiniband for `fabric_iface`: in the server config. The 
 		$ dmg pool destroy --pool=$DAOS_POOL --force
 		Pool-destroy command succeeded
 
+## Syslog
+
+[`RAS events`](https://docs.daos.io/v2.2/admin/administration/#ras-events) are printed to the Syslog
+by 'daos_server' processes via the Go standard library API.
+If no Syslog daemon is configured on the host, errors will be printed to the 'daos_server' log file:
+
+```
+ERROR: failed to create syslogger with priority 30 (severity=ERROR, facility=DAEMON): Unix syslog delivery error
+```
+
+These errors will not prevent DAOS from running as expected but indicate that no Syslog messages
+will be delivered.
+
+'rsyslog' is the Syslog daemon shipped with most operating systems and to check if the service is
+running under systemd run the following command:
+
+```
+# sudo systemctl status rsyslog
+● rsyslog.service - System Logging Service
+   Loaded: loaded (/usr/lib/systemd/system/rsyslog.service; enabled; vendor preset: enabled)
+   Active: active (running) since Mon 2022-05-23 16:12:31 UTC; 1 weeks 1 days ago
+     Docs: man:rsyslogd(8)
+           https://www.rsyslog.com/doc/
+ Main PID: 1962 (rsyslogd)
+    Tasks: 3 (limit: 1648282)
+   Memory: 5.0M
+   CGroup: /system.slice/rsyslog.service
+           └─1962 /usr/sbin/rsyslogd -n
+
+May 23 16:12:31 wolf-164.wolf.hpdd.intel.com systemd[1]: Starting System Logging Service...
+May 23 16:12:31 wolf-164.wolf.hpdd.intel.com rsyslogd[1962]: [origin software="rsyslogd" swVersion="8.21>
+May 23 16:12:31 wolf-164.wolf.hpdd.intel.com systemd[1]: Started System Logging Service.
+May 23 16:12:31 wolf-164.wolf.hpdd.intel.com rsyslogd[1962]: imjournal: journal files changed, reloading>
+May 29 03:18:01 wolf-164.wolf.hpdd.intel.com rsyslogd[1962]: [origin software="rsyslogd" swVersion="8.21>
+```
+
+To configure a Syslog daemon to resolve the delivery errors and receive messages from 'daos_server'
+consult the relevant operating system specific documentation for installing and/or enabling a syslog
+server package e.g. 'rsyslog'.
+
 ## Bug Report
 
 Bugs should be reported through our issue tracker[^1] with a test case

--- a/src/control/lib/control/event.go
+++ b/src/control/lib/control/event.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -159,8 +159,8 @@ func newEventLogger(logBasic logging.Logger, newSyslogger newSysloggerFn) *Event
 	} {
 		sl, err := newSyslogger(sev.SyslogPriority(), flags)
 		if err != nil {
-			logBasic.Errorf("failed to create syslogger with priority %s: %s",
-				sev.SyslogPriority(), err)
+			logBasic.Errorf("failed to create syslogger with priority %d (severity=%s,"+
+				" facility=DAEMON): %s", sev.SyslogPriority(), sev, err)
 			continue
 		}
 		el.sysloggers[sev] = sl


### PR DESCRIPTION
Describe the daos_server error printed when no syslog daemon is
configured and how to resolve it in the troubleshooting guide.

Also fixes a formatting issue in an error message.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>