### PR TITLE
DAOS-10743 dtx: not rollback partially committed DTX

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -496,7 +496,7 @@ dtx_batched_commit_one(void *arg)
 			break;
 		}
 
-		rc = dtx_commit(cont, dtes, dcks, cnt);
+		rc = dtx_commit(cont, dtes, dcks, cnt, 0);
 		dtx_free_committable(dtes, dcks, cnt);
 		if (rc != 0) {
 			D_WARN("Fail to batched commit %d entries for "DF_UUID": "DF_RC"\n",
@@ -1241,13 +1241,13 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 sync:
 	if (dth->dth_sync) {
 		dte = &dth->dth_dte;
-		rc = dtx_commit(cont, &dte, NULL, 1);
-		if (rc != 0) {
+		rc = dtx_commit(cont, &dte, NULL, 1, dth->dth_epoch);
+		if (rc != 0)
 			D_ERROR(DF_UUID": Fail to sync commit DTX "DF_DTI
 				": "DF_RC"\n", DP_UUID(cont->sc_uuid),
 				DP_DTI(&dth->dth_xid), DP_RC(rc));
-			D_GOTO(abort, result = rc);
-		}
+
+		D_GOTO(out, result = rc);
 	}
 
 abort:
@@ -1443,7 +1443,7 @@ dtx_flush_on_close(struct dss_module_info *dmi, struct dtx_batched_cont_args *db
 			  (unsigned long)total,
 			  (unsigned long)stat.dtx_committable_count);
 
-		rc = dtx_commit(cont, dtes, dcks, cnt);
+		rc = dtx_commit(cont, dtes, dcks, cnt, 0);
 		dtx_free_committable(dtes, dcks, cnt);
 	}
 
@@ -2064,7 +2064,7 @@ dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 			break;
 		}
 
-		rc = dtx_commit(cont, dtes, dcks, cnt);
+		rc = dtx_commit(cont, dtes, dcks, cnt, 0);
 		dtx_free_committable(dtes, dcks, cnt);
 		if (rc < 0) {
 			D_ERROR("Fail to commit dtx: "DF_RC"\n", DP_RC(rc));

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -50,7 +50,7 @@ enum dtx_operation {
 /* DTX RPC output fields */
 #define DAOS_OSEQ_DTX							\
 	((int32_t)		(do_status)		CRT_VAR)	\
-	((int32_t)		(do_pad)		CRT_VAR)	\
+	((int32_t)		(do_misc)		CRT_VAR)	\
 	((int32_t)		(do_sub_rets)		CRT_ARRAY)
 
 CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
@@ -184,7 +184,7 @@ uint64_t dtx_cos_oldest(struct ds_cont_child *cont);
 
 /* dtx_rpc.c */
 int dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
-	       struct dtx_cos_key *dcks, int count);
+	       struct dtx_cos_key *dcks, int count, daos_epoch_t epoch);
 int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
 	      daos_epoch_t epoch);
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -112,7 +112,7 @@ next:
 	}
 
 	if (j > 0) {
-		rc = dtx_commit(cont, dtes, dcks, j);
+		rc = dtx_commit(cont, dtes, dcks, j, 0);
 		if (rc < 0)
 			D_ERROR("Failed to commit the DTXs: rc = "DF_RC"\n",
 				DP_RC(rc));

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -140,6 +140,7 @@ dtx_handler(crt_rpc_t *rpc)
 	struct dtx_cos_key	 dcks[DTX_REFRESH_MAX] = { 0 };
 	uint32_t		 vers[DTX_REFRESH_MAX] = { 0 };
 	uint32_t		 opc = opc_get(rpc->cr_opc);
+	uint32_t		 committed = 0;
 	int			*ptr;
 	int			 count = DTX_YIELD_CYCLE;
 	int			 i = 0;
@@ -171,7 +172,9 @@ dtx_handler(crt_rpc_t *rpc)
 
 			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
 			rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count, NULL);
-			if (rc == 0 && rc1 < 0)
+			if (rc1 > 0)
+				committed += rc1;
+			else if (rc == 0 && rc1 < 0)
 				rc = rc1;
 
 			i += count;
@@ -296,6 +299,8 @@ out:
 		(int)din->di_dtx_array.ca_count, din->di_epoch, DP_RC(rc));
 
 	dout->do_status = rc;
+	/* For DTX_COMMIT, it is the count of real committed DTX entries. */
+	dout->do_misc = committed;
 	rc = crt_reply_send(rpc);
 	if (rc != 0)
 		D_ERROR("send reply failed for DTX rpc %u: rc = "DF_RC"\n", opc,
@@ -330,7 +335,7 @@ out:
 		/* Commit the DTX after replied the original refresh request to
 		 * avoid further query the same DTX.
 		 */
-		rc = dtx_commit(cont, pdte, dcks, j);
+		rc = dtx_commit(cont, pdte, dcks, j, 0);
 		if (rc < 0)
 			D_WARN("Failed to commit DTX "DF_DTI", count %d: "
 			       DF_RC"\n", DP_DTI(&dtes[0].dte_xid), j,


### PR DESCRIPTION
For DAOS two-phase-commit based transaction model, during DTX commit,
as long as one participant successfully commit the DTX locally, then
regardless whether the other participants commit successfully or not,
such DTX will be regarded as 'committed' globally. Under such case,
even if some participants failed to commit related DTX locally, we
still cannot rollback the partially committed DTX via DTX_ABORT,
unless all participants totally failed to commit related DTX.

Signed-off-by: Fan Yong <fan.yong@intel.com>