### PR TITLE
DAOS-10816 build: Update install_ubuntu.sh

### DIFF
--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -40,6 +40,7 @@ apt-get install \
     libyaml-dev \
     locales \
     maven \
+    meson \
     numactl \
     openjdk-8-jdk \
     patchelf \
@@ -47,6 +48,7 @@ apt-get install \
     pkg-config \
     python3-dev \
     python3-venv \
+    python3-pyelftools \
     uuid-dev \
     valgrind \
     yasm


### PR DESCRIPTION
Added meson and pyelftools to the list of packages to be installed.
These two are required when building dependencies (--build-deps=yes)
for DAOS developers.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>