### PR TITLE
DAOS-12080 test: interoperability test DAOS upgrade from 2.0 to 2.2 a…

### DIFF
--- a/src/tests/ftest/system/updown_grade.py
+++ b/src/tests/ftest/system/updown_grade.py
@@ -1,0 +1,356 @@
+#!/usr/bin/python3
+'''
+  (C) Copyright 2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+'''
+import traceback
+import random
+import base64
+import time
+
+from general_utils import get_random_bytes
+from pydaos.raw import DaosApiError
+from daos_utils import DaosCommand
+from agent_utils import include_local_host
+from general_utils import pcmd, run_pcmd
+from command_utils_base import CommandFailure
+from ior_test_base import IorTestBase
+
+# pylint: disable = global-variable-not-assigned, global-statement
+class UpgradeDowngradeTest(IorTestBase):
+    """
+    Tests DAOS container attribute get/set/list.
+    :avocado: recursive
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize a ContainerAttributeTest object."""
+        super().__init__(*args, **kwargs)
+        self.expected_cont_uuid = None
+        self.daos_cmd = None
+
+    @staticmethod
+    def create_data_set(num_attributes):
+        """Create the large attribute dictionary.
+
+        Args:
+            num_attributes: number of attributes to be created on container.
+        Returns:
+            dict: a large attribute dictionary
+
+        """
+        data_set = {}
+        for index in range(num_attributes):
+            size = random.randint(1, 10) #nosec
+            key = str(index).encode("utf-8")
+            data_set[key] = get_random_bytes(size)
+        return data_set
+
+    def verify_list_attr(self, indata, attributes_list):
+        """
+        Verify the length of the Attribute names
+
+        Args:
+            indata: Dict used to set attr
+            attributes_list: List obtained from list attr
+        """
+        length = 0
+        for key in indata.keys():
+            length += len(key)
+
+        size = 0
+        for attr in attributes_list:
+            size += len(attr)
+
+        self.log.info("Verifying list_attr output:")
+        self.log.info("  set_attr names:  %s", list(indata.keys()))
+        self.log.info("  set_attr size:   %s", length)
+        self.log.info("  list_attr names: %s", attributes_list)
+        self.log.info("  list_attr size:  %s", size)
+
+        if length != size:
+            self.fail(
+                "FAIL: Size is not matching for Names in list attr, Expected "
+                "len={} and received len={}".format(length, size))
+        # verify the Attributes names in list_attr retrieve
+        for key in list(indata.keys()):
+            found = False
+            for attr in attributes_list:
+                if key.decode() == attr:
+                    found = True
+                    break
+            if not found:
+                self.fail(
+                    "FAIL: Name does not match after list attr, Expected "
+                    "buf={} and received buf={}".format(key, attributes_list))
+
+    def verify_get_attr(self, indata, outdata):
+        """
+        verify the Attributes value after get_attr
+
+        Args:
+             indata: In data item of container get_attr.
+             outdata: Out data from container get_attr.
+        """
+        decoded = {}
+        for key, val in outdata.items():
+            if isinstance(val, bytes):
+                decoded[key.decode()] = val
+            else:
+                decoded[key] = base64.b64decode(val)
+
+        self.log.info("Verifying get_attr output:")
+        self.log.info("  get_attr data: %s", indata)
+        self.log.info("  set_attr data: %s", decoded)
+
+        for attr, value in indata.items():
+            if value != decoded.get(attr.decode(), None):
+                self.fail(
+                    "FAIL: Value does not match after get({}), Expected "
+                    "val={} and received val={}".format(attr, value,
+                                        decoded.get(attr.decode(), None)))
+
+    def check_result(self, result):
+        """check for command result, raise failure when error cncountered
+
+        Args:
+             result(dict): dictionary of result to check.
+        """
+        self.log.info("--check_result, result= %s", result)
+        if result[0]['exit_status'] != 0:
+            self.fail("##Error detected from check_result")
+        else:
+            self.log.info("--check_result passed")
+
+    def show_daos_version(self, all_hosts, hosts_client):
+        """show daos version
+
+        Args:
+            all_hosts (list of String): all hosts.
+            hosts_client (list of String): client hosts to show daos and dmg version.
+        """
+        result = run_pcmd(all_hosts, "rpm -qa | grep daos")
+        result = run_pcmd(hosts_client, "dmg version")
+        result = run_pcmd(hosts_client, "daos version")
+
+    def updowngrade(self, hosts, updown, rpms):
+        """Upgrade downgrade hosts
+
+        Args:
+            hosts (list of String): test hosts.
+            updown (String): upgrade or downgrade
+            rpms (list of String): full path of RPMs to be upgrade or downgrade
+        """
+        cmds = []
+        for rpm in rpms:
+            cmds.append("sudo yum {} -y {}".format(updown, rpm))
+        cmds.append("sudo ipcrm -a")
+        cmds.append("sudo ipcs")
+        self.log.info("==upgrade_downgrading on hosts: %s", hosts)
+        for cmd in cmds:
+            self.log.info("==cmd= %s", cmd)
+            result = run_pcmd(hosts, cmd)
+        self.log.info("==sleeping 5 seconds")
+        time.sleep(5)
+        self.log.info("==pcmd yum upgrade/downgrade result= %s", result)
+
+    def daos_ver_after_upgraded(self, host):
+        """To display daos and dmg version, and check for error.
+
+        Args:
+            host (String): test host.
+        """
+        cmds = [
+                "daos version",
+                "dmg version",
+                "daos pool query 'TestLabel_1'",
+                ]
+        for cmd in cmds:
+            self.log.info("==cmd= %s", cmd)
+            result = pcmd(host, cmd, False)
+            if 0 not in result or len(result) > 1:
+                failed = []
+                for item, value in list(result.items()):
+                    if item != 0:
+                        failed.extend(value)
+                raise CommandFailure("##Error occurred running '{}' on {}".format(
+                    cmd, host))
+            self.log.info("==>%s result= %s", cmd, result)
+
+
+    def test_upgrade_downgrade(self):
+        """
+        Test ID: DAOS-10274: DAOS interoperability test user interface test
+                 DAOS-10275: DAOS interoperability test system and pool upgrade basic
+                 DAOS-10280: DAOS upgrade from 2.0 to 2.2 and downgrade back to 2.0
+        Test description:
+                 (1)Show rpm, dmg and daos versions on all hosts
+                 (2)Create pool containers and attributes, setup and run IOR
+                 (3)Dmg system stop
+                 (4)Upgrade RPMs to specified version
+                 (5)Restart servers
+                 (6)Restart agent
+                    verify pool and container attributes
+                    verify IOR data integrity and data of symlink after upgraded
+                 (7)Dmg pool get-prop after RPMs upgraded before Pool upgraded
+                 (8)Dmg pool upgrade and get-prop after RPMs upgraded
+                 (9)Create new pool after rpms Upgraded
+                 (10)Downgrade and cleanup
+                 (11)Restart servers and agent
+        :avocado: tags=interop, not_run_on_CI
+        :avocado: tags=upgrade_downgrade
+        """
+        #(1)Setup
+        hosts_client = self.hostlist_clients
+        hosts_server = self.hostlist_servers
+        all_hosts = include_local_host(hosts_server)
+        upgd_rpms =  self.params.get("upgrade_rpms", '/run/interop/*')
+        downgd_rpms =  self.params.get("downgrade_rpms", '/run/interop/*')
+        num_attributes = self.params.get("num_attributes", '/run/attrtests/*')
+        self.log.info("(1)==Show rpm, dmg and daos versions on all hosts.")
+        self.show_daos_version(all_hosts, hosts_client)
+
+        #(2)Create pool containers and attributes
+        self.log.info("(2)==Create pool containers and attributes.")
+        self.add_pool(connect=False)
+        self.add_container(self.pool)
+        self.container.open()
+        self.daos_cmd = DaosCommand(self.bin)
+        attr_dict = self.create_data_set(num_attributes)
+
+        try:
+            self.container.container.set_attr(data=attr_dict)
+            data = self.daos_cmd.container_list_attrs(
+                pool=self.pool.uuid,
+                cont=self.container.uuid,
+                verbose=False)
+            self.verify_list_attr(attr_dict, data['response'])
+
+            data = self.daos_cmd.container_list_attrs(
+                pool=self.pool.uuid,
+                cont=self.container.uuid,
+                verbose=True)
+            self.verify_get_attr(attr_dict, data['response'])
+        except DaosApiError as excep:
+            print(excep)
+            print(traceback.format_exc())
+            self.fail("Test was expected to pass but it failed.\n")
+        self.container.close()
+        self.pool.disconnect()
+
+        #IOR before upgrade
+        self.log.info("(2.1)==Setup and run IOR.")
+        result = run_pcmd(hosts_client, "mkdir -p /tmp/daos_dfuse1")
+        ior_timeout = self.params.get("ior_timeout", '/run/ior/*')
+        iorflags_write = self.params.get("write_flg", '/run/ior/iorflags/')
+        dfuse_mount_dir = self.params.get("mount_dir", "/run/dfuse/*")
+        dfs_oclass = self.params.get("dfs_oclass", '/run/ior/*')
+        self.ior_cmd.dfs_oclass.update(dfs_oclass)
+        self.ior_cmd.flags.update(iorflags_write)
+        self.run_ior_with_pool(
+            timeout=ior_timeout, create_pool=False, create_cont=False, stop_dfuse=False)
+        result = run_pcmd(hosts_client, "cd /tmp/daos_dfuse1/")
+        result = run_pcmd(hosts_client, "ls -l /tmp/daos_dfuse1/testfile")
+        result = run_pcmd(hosts_client, "cp /tmp/daos_dfuse1/testfile /tmp/testfile_sav")
+        result = run_pcmd(hosts_client, "cp /tmp/daos_dfuse1/testfile /tmp/testfile_sav2")
+        result = run_pcmd(
+            hosts_client, "ln -vs /tmp/testfile_sav2 /tmp/daos_dfuse1/symlink_testfile")
+        result = run_pcmd(hosts_client, "diff /tmp/daos_dfuse1/testfile /tmp/testfile_sav")
+        self.check_result(result)
+        result = run_pcmd(hosts_client, "ls -l /tmp/daos_dfuse1/symlink_testfile")
+        self.check_result(result)
+        self.container.close()
+        self.pool.disconnect()
+        result = run_pcmd(hosts_client, "fusermount3 -u /tmp/daos_dfuse1")
+        self.check_result(result)
+
+        #(3)dmg system stop
+        self.log.info("(3)==Dmg system stop.")
+        self.get_dmg_command().system_stop()
+        errors = []
+        errors.extend(self._stop_managers(self.server_managers, "servers"))
+        errors.extend(self._stop_managers(self.agent_managers, "agents"))
+
+        #(4)Upgrade
+        self.log.info("(4)==Upgrade RPMs to .")
+        self.updowngrade(all_hosts, "upgrade", upgd_rpms)
+
+        #(5)Restart servers
+        self.log.info("(5)==Restart servers.")
+        self.restart_servers()
+
+        #(6)Verification after upgraded
+        self.log.info("(6)==verify pool and container attributes after upgraded.")
+        #   Restart agent
+        self.log.info("(6.1)====Restarting rel_2.2 agent after upgrade.")
+        self._start_manager_list("agent", self.agent_managers)
+        self.show_daos_version(all_hosts, hosts_client)
+
+        self.get_dmg_command().pool_list(verbose=True)
+        self.get_dmg_command().pool_query(pool='TestLabel_1')
+        self.get_daos_command().pool_query(pool='TestLabel_1')
+
+        #   Verify pool container attributes
+        self.log.info("(6.2)====Verifying container attributes after upgrade.")
+        data = self.daos_cmd.container_list_attrs(
+            pool=self.pool.uuid,
+            cont=self.container.uuid,
+            verbose=True)
+        self.verify_get_attr(attr_dict, data['response'])
+        self.daos_ver_after_upgraded(hosts_client)
+
+        #   Verify IOR data and symlink
+        self.log.info("(6.3)====Verifying container IOR data and symlink.")
+        result = run_pcmd(
+            hosts_client,
+            "dfuse --mountpoint /tmp/daos_dfuse1 --pool TestLabel_1 --container {0}".format(
+                self.container))
+        self.check_result(result)
+        result = run_pcmd(hosts_client, "diff /tmp/daos_dfuse1/testfile /tmp/testfile_sav")
+        self.check_result(result)
+        result = run_pcmd(
+            hosts_client, "diff /tmp/daos_dfuse1/symlink_testfile /tmp/testfile_sav2")
+        self.check_result(result)
+
+        #(7)Dmg pool get-prop
+        self.log.info("(7)==Dmg pool get-prop after RPMs upgraded before Pool upgraded")
+        result = run_pcmd(hosts_client, "dmg pool get-prop TestLabel_1")
+        self.check_result(result)
+
+        #(8)Pool property verification after upgraded
+        self.log.info("(8)==Dmg pool upgrade and get-prop after RPMs upgraded")
+        result = run_pcmd(hosts_client, "dmg pool upgrade TestLabel_1")
+        self.check_result(result)
+        result = run_pcmd(hosts_client, "dmg pool get-prop TestLabel_1")
+        self.check_result(result)
+
+        #(9)Create new pool
+        self.log.info("(9)==Create new pool after rpms Upgraded")
+        self.add_pool(connect=False)
+        self.get_dmg_command().pool_list(verbose=True)
+        self.get_dmg_command().pool_query(pool='TestLabel_2')
+        self.get_daos_command().pool_query(pool='TestLabel_2')
+        result = run_pcmd(hosts_client, "dmg pool get-prop TestLabel_2")
+        self.check_result(result)
+
+        #(10)Downgrade and cleanup
+        self.log.info("(10)==Downgrade and cleanup.")
+        result = run_pcmd(hosts_client, "fusermount3 -u /tmp/daos_dfuse1")
+        self.check_result(result)
+        self.container.close()
+        self.pool.disconnect()
+        self.get_dmg_command().system_stop()
+        errors = []
+        errors.extend(self._stop_managers(self.server_managers, "servers"))
+        errors.extend(self._stop_managers(self.agent_managers, "agents"))
+        self.updowngrade(all_hosts, "downgrade", downgd_rpms)
+
+        #(11)Restart server and agent for the cleanup
+        self.log.info("(11)==Restart 2.0 servers and agent.")
+        self.restart_servers()
+        self._start_manager_list("agent", self.agent_managers)
+        self.show_daos_version(all_hosts, hosts_client)
+
+        #self.container.destroy()
+        #()destroy container hang  --- DAOS-10395

--- a/src/tests/ftest/system/updown_grade.yaml
+++ b/src/tests/ftest/system/updown_grade.yaml
@@ -1,0 +1,70 @@
+# change host names to your reserved nodes, the
+# required quantity is indicated by the placeholders
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+    - server-E
+    - server-F
+    - server-G
+    - server-H
+    - server-I
+    - server-J
+  test_clients:
+    - client-A
+timeout: 750
+server_config:
+  name: daos_server
+  engines_per_host: 1
+  servers:
+    0:
+      targets: 1
+      log_mask: DEBUG
+      env_vars:
+        - DD_MASK=mgmt,md,dsms,any  #DD_MASK=all
+        - D_LOG_FLUSH=DEBUG
+pool:
+  control_method: dmg
+  mode: 511
+  scm_size: 1G
+  name: daos_server
+container:
+  control_method: daos
+  type: POSIX
+  properties: rf:1
+attrtests:
+  num_attributes: 20
+  name_handles:
+    validlongname:
+      name:
+        - "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABC"
+        - PASS
+  value_handles:
+    validvalue:
+      value:
+        - "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyz"
+        - PASS
+dfuse:
+    mount_dir: "/tmp/daos_dfuse1/"
+    disable_caching: True
+ior:
+    ior_timeout: 120
+    client_processes:
+        np: 2
+    repetitions: 1
+    test_file: daos:/testFile
+    api: POSIX   #DFS
+    dfs_oclass: "RP_2GX"  #"EC_4P2GX" #"EC_2P2GX" #"EC_2P1GX"  #"RP_2GX"  #"EC_8P2GX"x
+    transfer_size: '1M'
+    block_size: '128M'
+    iorflags:
+        write_flg: "-w -W -k -G 1 -i 1"   #"-C -k -e -w -g -G 27 -Q 1 -vv"
+        read_flg: "-C -k -e -r -R -g -G 27 -Q 1 -vv"
+interop:
+#    upgrade_rpms: ["/home/dinghwah/RPM/2.0.3.rc3/x86_64/daos-2.0.3-3.el8.x86_64.rpm"]
+    upgrade_rpms: ["/home/dinghwah/RPM/2.2.0-tb1/daos-2.1.101-1.7969.g7eb7fd43.el8.x86_64.rpm"]
+    downgrade_rpms: ["/home/dinghwah/RPM/2.0.2-2-GA/daos-2.0.2-2.el8.x86_64.rpm",
+                     "/home/dinghwah/RPM/2.0.2-2-GA/mercury-2.1.0_rc4-5.el8.x86_64.rpm"
+                    ]


### PR DESCRIPTION
interoperability test DAOS upgrade from 2.0 to 2.2 and downgrade back to 2.0

Description:
  (1)Show rpm, dmg and daos versions on all hosts
  (2)Create pool containers and attributes, setup and run IOR
  (3)Dmg system stop
  (4)Upgrade RPMs to specified version
  (5)Restart servers
  (6)Restart agent
     verify pool and container attributes
     verify IOR data integrity and data of symlink after upgraded
  (7)Dmg pool get-prop after RPMs upgraded before Pool upgraded
  (8)Dmg pool upgrade and get-prop after RPMs upgraded
  (9)Create new pool after rpms Upgraded
  (10)Downgrade and cleanup
  (11)Restart servers and agent
Test-tag: upgrade_downgrade
Signed-off-by: Ding Ho ding-hwa.ho@intel.com