### PR TITLE
DAOS-10727 ftest: Set provider as tcp for many_dkeys

### DIFF
--- a/src/tests/ftest/object/create_many_dkeys.yaml
+++ b/src/tests/ftest/object/create_many_dkeys.yaml
@@ -7,6 +7,7 @@ hosts:
 timeout: 3600
 server_config:
   name: daos_server
+  provider: ofi+tcp;ofi_rxm
 pool:
   mode: 511
   name: daos_server


### PR DESCRIPTION
ofi+sockets seems having performance issue in CI with libfabric 1.15.1. tcp works fine in previous tests.