### PR TITLE
DAOS-10608 test: Run vfio-pci workaround fix between tests (#9271)

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1261,8 +1261,9 @@ def run_tests(test_files, tag_filter, args):
 
             # Stop any agents or servers running via systemd
             if not args.disable_stop_daos:
-                return_code |= stop_daos_agent_services(test_file["py"], args)
-                return_code |= stop_daos_server_service(test_file["py"], args)
+                return_code |= stop_daos_agent_services(test_file, args)
+                return_code |= stop_daos_server_service(test_file, args)
+                return_code |= reset_server_storage(test_file, args)
 
             # Optionally store all of the server and client config files
             # and archive remote logs and report big log files, if any.
@@ -2111,7 +2112,7 @@ def stop_daos_agent_services(test_file, args):
     """Stop any daos_agent.service running on the hosts running servers.
 
     Args:
-        test_file (str): the test python file
+        test_file (dict): a dictionary of the test script/yaml file
         args (argparse.Namespace): command line arguments for this program
 
     Returns:
@@ -2119,23 +2120,22 @@ def stop_daos_agent_services(test_file, args):
 
     """
     service = "daos_agent.service"
-    print("-" * 80)
-    print("Verifying {} after running '{}'".format(service, test_file))
-    if args.test_clients:
-        hosts = list(args.test_clients)
-    else:
-        hosts = list(args.test_servers)
+    client_hosts = get_hosts_from_yaml(test_file["yaml"], args, YAML_KEYS["test_clients"])
     local_host = socket.gethostname().split(".")[0]
-    if local_host not in hosts:
-        hosts.append(local_host)
-    return stop_service(hosts, service)
+    if local_host not in client_hosts:
+        client_hosts.append(local_host)
+    print("-" * 80)
+    print(
+        "Verifying {} on {} after running '{}'".format(
+            service, NodeSet.fromlist(client_hosts), test_file["py"]))
+    return stop_service(client_hosts, service)
 
 
 def stop_daos_server_service(test_file, args):
     """Stop any daos_server.service running on the hosts running servers.
 
     Args:
-        test_file (str): the test python file
+        test_file (dict): a dictionary of the test script/yaml file
         args (argparse.Namespace): command line arguments for this program
 
     Returns:
@@ -2143,9 +2143,12 @@ def stop_daos_server_service(test_file, args):
 
     """
     service = "daos_server.service"
+    server_hosts = get_hosts_from_yaml(test_file["yaml"], args, YAML_KEYS["test_servers"])
     print("-" * 80)
-    print("Verifying {} after running '{}'".format(service, test_file))
-    return stop_service(list(args.test_servers), service)
+    print(
+        "Verifying {} on {} after running '{}'".format(
+            service, NodeSet.fromlist(server_hosts), test_file["py"]))
+    return stop_service(server_hosts, service)
 
 
 def stop_service(hosts, service):
@@ -2251,6 +2254,41 @@ def indent_text(indent, text):
     if isinstance(text, (list, tuple)):
         return "\n".join(["{}{}".format(" " * indent, line) for line in text])
     return " " * indent + str(text)
+
+
+def reset_server_storage(test_file, args):
+    """Reset the server storage for the hosts that ran servers in the test.
+
+    This is a workaround to enable binding devices back to nvme or vfio-pci after they are unbound
+    from vfio-pci to nvme.  This should resolve the "NVMe not found" error seen when attempting to
+    start daos engines in the test.
+
+    Args:
+        test_file (dict): a dictionary of the test script/yaml file
+        args (argparse.Namespace): command line arguments for this program
+
+    Returns:
+        int: status code: 0 = success, 512 = failure
+
+    """
+    server_hosts = get_hosts_from_yaml(test_file["yaml"], args, YAML_KEYS["test_servers"])
+    print("-" * 80)
+    if server_hosts:
+        commands = [
+            "if lspci | grep -i nvme",
+            "then daos_server storage prepare -n --reset && " +
+            "sudo rmmod vfio_pci && sudo modprobe vfio_pci",
+            "fi"]
+        print(
+            "Resetting server storage on {} after running '{}'".format(
+                NodeSet.fromlist(server_hosts), test_file["py"]))
+        if not spawn_commands(server_hosts, "bash -c '{}'".format(";".join(commands)), timeout=600):
+            print(indent_text(2, "Ignoring any errors from these workaround commands"))
+    else:
+        print(
+            "Skipping resetting server storage after running '{}' - no server hosts".format(
+                test_file["py"]))
+    return 0
 
 
 def main():


### PR DESCRIPTION
Adding running the vfio-pci binding fix workaround commands between
running avocado test files on the hosts that were used by the test to
run the daos_server command.

Also update the stopping of server and clients to limit commands to
hosts only used by the test to run servers and clients, respectively.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>