### PR TITLE
DAOS-10661 control: Use DB replica addr for JoinReq

### DIFF
--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -115,8 +115,19 @@ func (svc *mgmtSvc) LeaderQuery(ctx context.Context, req *mgmtpb.LeaderQueryReq)
 	return resp, nil
 }
 
-// getPeerListenAddr combines peer ip from supplied context with input port.
+// getPeerListenAddr provides the resolved TCP address where the peer server is listening.
 func getPeerListenAddr(ctx context.Context, listenAddrStr string) (*net.TCPAddr, error) {
+	ipAddr, portStr, err := net.SplitHostPort(listenAddrStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "get listening port")
+	}
+
+	if ipAddr != "0.0.0.0" {
+		// If the peer gave us an explicit IP address, just use it.
+		return net.ResolveTCPAddr("tcp", listenAddrStr)
+	}
+
+	// If we got 0.0.0.0, we may be able to harvest the remote IP from the context.
 	p, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("peer details not found in context")
@@ -125,12 +136,6 @@ func getPeerListenAddr(ctx context.Context, listenAddrStr string) (*net.TCPAddr,
 	tcpAddr, ok := p.Addr.(*net.TCPAddr)
 	if !ok {
 		return nil, errors.Errorf("peer address (%s) not tcp", p.Addr)
-	}
-
-	// what port is the input address listening on?
-	_, portStr, err := net.SplitHostPort(listenAddrStr)
-	if err != nil {
-		return nil, errors.Wrap(err, "get listening port")
 	}
 
 	// resolve combined IP/port address

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -392,19 +392,26 @@ func TestServer_MgmtSvc_getPeerListenAddr(t *testing.T) {
 	}{
 		"no peer": {
 			ctx:    context.Background(),
+			addr:   "0.0.0.0:1234",
 			expErr: errors.New("peer details not found in context"),
 		},
-		"bad input address": {
+		"no input address": {
 			ctx:    peer.NewContext(context.Background(), &peer.Peer{Addr: defaultAddr}),
 			expErr: errors.New("get listening port: missing port in address"),
 		},
 		"non tcp address": {
 			ctx:    peer.NewContext(context.Background(), &peer.Peer{Addr: ipAddr}),
+			addr:   "0.0.0.0:1234",
 			expErr: errors.New("peer address (127.0.0.1) not tcp"),
 		},
 		"normal operation": {
 			ctx:     peer.NewContext(context.Background(), &peer.Peer{Addr: defaultAddr}),
 			addr:    "0.0.0.0:15001",
+			expAddr: combinedAddr,
+		},
+		"specific addr": {
+			ctx:     peer.NewContext(context.Background(), &peer.Peer{Addr: defaultAddr}),
+			addr:    combinedAddr.String(),
 			expAddr: combinedAddr,
 		},
 	} {

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -247,7 +247,16 @@ func (srv *server) setCoreDumpFilter() error {
 func (srv *server) initNetwork() error {
 	defer srv.logDuration(track("time to init network"))
 
-	ctlAddr, listener, err := createListener(srv.cfg.ControlPort, net.ResolveTCPAddr, net.Listen)
+	ctlAddr, err := getControlAddr(ctlAddrParams{
+		port:           srv.cfg.ControlPort,
+		replicaAddrSrc: srv.sysdb,
+		resolveAddr:    net.ResolveTCPAddr,
+	})
+	if err != nil {
+		return err
+	}
+
+	listener, err := createListener(ctlAddr, net.Listen)
 	if err != nil {
 		return err
 	}

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -758,3 +758,81 @@ func TestServer_getNetDevClass(t *testing.T) {
 		})
 	}
 }
+
+type mockReplicaAddrSrc struct {
+	replicaAddrResult *net.TCPAddr
+	replicaAddrErr    error
+}
+
+func (m *mockReplicaAddrSrc) ReplicaAddr() (*net.TCPAddr, error) {
+	return m.replicaAddrResult, m.replicaAddrErr
+}
+
+func TestServerUtils_getControlAddr(t *testing.T) {
+	testTCPAddr := &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 1234,
+	}
+
+	for name, tc := range map[string]struct {
+		params  ctlAddrParams
+		expAddr *net.TCPAddr
+		expErr  error
+	}{
+		"success (not a replica)": {
+			params: ctlAddrParams{
+				port: testTCPAddr.Port,
+				replicaAddrSrc: &mockReplicaAddrSrc{
+					replicaAddrErr: errors.New("not a replica"),
+				},
+				resolveAddr: func(net, addr string) (*net.TCPAddr, error) {
+					test.AssertEqual(t, "tcp", net, "")
+					test.AssertEqual(t, "[0.0.0.0]:1234", addr, "")
+					return testTCPAddr, nil
+				},
+			},
+			expAddr: testTCPAddr,
+		},
+		"success (replica)": {
+			params: ctlAddrParams{
+				port: testTCPAddr.Port,
+				replicaAddrSrc: &mockReplicaAddrSrc{
+					replicaAddrResult: testTCPAddr,
+				},
+				resolveAddr: func(net, addr string) (*net.TCPAddr, error) {
+					test.AssertEqual(t, "tcp", net, "")
+					test.AssertEqual(t, "[127.0.0.1]:1234", addr, "")
+					return testTCPAddr, nil
+				},
+			},
+			expAddr: testTCPAddr,
+		},
+		"resolve fails": {
+			params: ctlAddrParams{
+				resolveAddr: func(_, _ string) (*net.TCPAddr, error) {
+					return nil, errors.New("mock resolve")
+				},
+			},
+			expErr: errors.New("mock resolve"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.params.resolveAddr == nil {
+				tc.params.resolveAddr = func(_, _ string) (*net.TCPAddr, error) {
+					return testTCPAddr, nil
+				}
+			}
+
+			if tc.params.replicaAddrSrc == nil {
+				tc.params.replicaAddrSrc = &mockReplicaAddrSrc{
+					replicaAddrErr: errors.New("not a replica"),
+				}
+			}
+
+			addr, err := getControlAddr(tc.params)
+
+			test.CmpErr(t, tc.expErr, err)
+			test.AssertEqual(t, tc.expAddr.String(), addr.String(), "")
+		})
+	}
+}


### PR DESCRIPTION
Replicas sending a Join request need to report the same ControlAddr
as the management service DB includes in its replica list. Without
this, on systems with multiple IP addresses on the same subnet,
the MS can fail to recognize itself and other nodes as replicas.

Features: control

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>