### PR TITLE
DAOS-10816 utils: Add install-dev.sh script

### DIFF
--- a/utils/scripts/install-dev.sh
+++ b/utils/scripts/install-dev.sh
@@ -6,7 +6,7 @@
 # Requirements:
 # - Run as a non-root user with sudo access.
 
-if [ `whoami` == "root" ]; then
+if [ "$(whoami)" == "root" ]; then
 	echo "Run this script as the non-root user you will use to build DAOS"
 	exit 1
 fi
@@ -23,12 +23,7 @@ case "$distro" in
 esac
 
 # Install dependencies from the OS repos.
-SCRIPT_DIR="$(dirname -- "$(readlink -f "$BASH_SOURCE")")"
-sudo "$SCRIPT_DIR/install-$distro.sh"
-
-if [ $? -ne 0 ]; then
-	exit $?
-fi
-
+SCRIPT_DIR="$(dirname "$(realpath -e "$BASH_SOURCE")")"
+sudo "$SCRIPT_DIR/install-$distro.sh" && \
 # Install user dependencies
 python3 -m pip install -r "$SCRIPT_DIR/../../requirements.txt"

--- a/utils/scripts/install-dev.sh
+++ b/utils/scripts/install-dev.sh
@@ -25,5 +25,13 @@ esac
 # Install dependencies from the OS repos.
 SCRIPT_DIR="$(dirname "$(realpath -e "${BASH_SOURCE[0]}")")"
 sudo "$SCRIPT_DIR/install-$distro.sh"
+
 # Install user dependencies
+VENV_DIR="$HOME/.venvs/daosbuild"
+python3 -m venv "$VENV_DIR"
+source "$VENV_DIR/bin/activate"
 python3 -m pip install -r "$SCRIPT_DIR/../../requirements.txt"
+
+echo "=> Add the following line to your .bashrc or similar to ensure you are using"\
+	"this Python virtualenv for your session:"
+echo "source \"$VENV_DIR/bin/activate\""

--- a/utils/scripts/install-dev.sh
+++ b/utils/scripts/install-dev.sh
@@ -23,7 +23,7 @@ case "$distro" in
 esac
 
 # Install dependencies from the OS repos.
-SCRIPT_DIR="$(dirname "$(realpath -e "$BASH_SOURCE")")"
+SCRIPT_DIR="$(dirname "$(realpath -e "${BASH_SOURCE[0]}")")"
 sudo "$SCRIPT_DIR/install-$distro.sh" && \
 # Install user dependencies
 python3 -m pip install -r "$SCRIPT_DIR/../../requirements.txt"

--- a/utils/scripts/install-dev.sh
+++ b/utils/scripts/install-dev.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script sets up a new development node with all dependencies needed to
+# build DAOS from source.
+
+# Requirements:
+# - Run as a non-root user with sudo access.
+
+if [ `whoami` == "root" ]; then
+	echo "Run this script as the non-root user you will use to build DAOS"
+	exit 1
+fi
+
+distro=$1
+case "$distro" in
+	centos7 | el8 | leap15 | ubuntu)
+		echo "Setting up node for $distro...";;
+
+	*)
+		echo "Invalid distro option: \"$distro\""
+		echo "syntax: $0 <el8|leap15|ubuntu|centos7>"
+		exit 1
+esac
+
+# Install dependencies from the OS repos.
+SCRIPT_DIR="$(dirname -- "$(readlink -f "$BASH_SOURCE")")"
+sudo "$SCRIPT_DIR/install-$distro.sh"
+
+if [ $? -ne 0 ]; then
+	exit $?
+fi
+
+# Install user dependencies
+python3 -m pip install -r "$SCRIPT_DIR/../../requirements.txt"

--- a/utils/scripts/install-dev.sh
+++ b/utils/scripts/install-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ue
 
 # This script sets up a new development node with all dependencies needed to
 # build DAOS from source.
@@ -24,6 +24,6 @@ esac
 
 # Install dependencies from the OS repos.
 SCRIPT_DIR="$(dirname "$(realpath -e "${BASH_SOURCE[0]}")")"
-sudo "$SCRIPT_DIR/install-$distro.sh" && \
+sudo "$SCRIPT_DIR/install-$distro.sh"
 # Install user dependencies
 python3 -m pip install -r "$SCRIPT_DIR/../../requirements.txt"


### PR DESCRIPTION
Added a script for developers setting up a new environment, to
install both system packages and user-level Python modules needed
to build DAOS.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>