### PR TITLE
DAOS-9902 API: To support empty contain labels

### DIFF
--- a/src/client/serialize/daos_serialize.c
+++ b/src/client/serialize/daos_serialize.c
@@ -152,7 +152,7 @@ serialize_str(hid_t file_id, struct daos_prop_entry *entry, const char *prop_str
 	hid_t	attr_dspace = 0;
 	hid_t	usr_attr = 0;
 
-	if (entry == NULL || entry->dpe_str == NULL) {
+	if (entry == NULL) {
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
@@ -162,7 +162,7 @@ serialize_str(hid_t file_id, struct daos_prop_entry *entry, const char *prop_str
 		D_ERROR("failed to create datatype\n");
 		D_GOTO(out, rc = -DER_MISC);
 	}
-	status = H5Tset_size(attr_dtype, strlen(entry->dpe_str) + 1);
+	status = H5Tset_size(attr_dtype, (entry->dpe_str ? strlen(entry->dpe_str) : 0) + 1);
 	if (status < 0) {
 		D_ERROR("failed to set datatype size\n");
 		D_GOTO(out, rc = -DER_MISC);
@@ -184,7 +184,7 @@ serialize_str(hid_t file_id, struct daos_prop_entry *entry, const char *prop_str
 		D_ERROR("failed to create attribute\n");
 		D_GOTO(out, rc = -DER_MISC);
 	}
-	status = H5Awrite(usr_attr, attr_dtype, entry->dpe_str);
+	status = H5Awrite(usr_attr, attr_dtype, entry->dpe_str ? entry->dpe_str : "");
 	if (status < 0) {
 		rc = -DER_IO;
 		D_ERROR("failed to write attribute "DF_RC"\n", DP_RC(rc));
@@ -786,17 +786,21 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop, uint64_
 		if (rc != 0) {
 			D_GOTO(out, rc);
 		}
-		rc = daos_cont_open(poh, label, DAOS_COO_RW, &coh, &cont_info, NULL);
-		if (rc == -DER_NONEXIST) {
-			/* label doesn't already exist so deserialize */
-			deserialize_label = true;
+		if (label[0]) {
+			rc = daos_cont_open(poh, label, DAOS_COO_RW, &coh, &cont_info, NULL);
+			if (rc == -DER_NONEXIST) {
+				/* label doesn't already exist so deserialize */
+				deserialize_label = true;
+				close_cont = false;
+				/* reset rc */
+				rc = 0;
+			} else if (rc != 0) {
+				D_GOTO(out, rc);
+			}  else {
+				D_PRINT("Container label already exists in pool and cannot be set\n");
+			}
+		} else {
 			close_cont = false;
-			/* reset rc */
-			rc = 0;
-		} else if (rc != 0) {
-			D_GOTO(out, rc);
-		}  else {
-			D_PRINT("Container label already exists in pool and cannot be set\n");
 		}
 	}
 
@@ -1044,6 +1048,9 @@ deserialize_props(daos_handle_t poh, hid_t file_id, daos_prop_t **_prop, uint64_
 			D_GOTO(out, rc);
 	}
 	*_prop = prop;
+	if (prop->dpp_nr > prop_num) {
+		prop->dpp_nr = prop_num;
+	}
 out:
 	/* close container after checking if label exists in pool */
 	if (close_cont)

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -512,11 +512,13 @@ daos_prop_entry_copy(struct daos_prop_entry *entry,
 	switch (entry->dpe_type) {
 	case DAOS_PROP_PO_LABEL:
 	case DAOS_PROP_CO_LABEL:
-		D_STRNDUP(entry_dup->dpe_str, entry->dpe_str,
-			  DAOS_PROP_LABEL_MAX_LEN);
-		if (entry_dup->dpe_str == NULL) {
-			D_ERROR("failed to dup label.\n");
-			return -DER_NOMEM;
+		if (entry->dpe_str) {
+			D_STRNDUP(entry_dup->dpe_str, entry->dpe_str,
+				  DAOS_PROP_LABEL_MAX_LEN);
+			if (entry_dup->dpe_str == NULL) {
+				D_ERROR("failed to dup label.\n");
+				return -DER_NOMEM;
+			}
 		}
 		break;
 	case DAOS_PROP_PO_ACL:
@@ -552,7 +554,7 @@ daos_prop_entry_copy(struct daos_prop_entry *entry,
 	case DAOS_PROP_CO_ROOTS:
 		rc = daos_prop_entry_dup_co_roots(entry_dup, entry);
 		if (rc) {
-			D_ERROR("failed to dup roots "DF_RC"\n", DP_RC(rc));
+			D_ERROR("failed to dup roots\n");
 			return rc;
 		}
 		break;

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -57,7 +57,7 @@ static struct daos_prop_co_roots dummy_roots;
 struct daos_prop_entry cont_prop_entries_default_v0[CONT_PROP_NUM_V0] = {
 	{
 		.dpe_type	= DAOS_PROP_CO_LABEL,
-		.dpe_str	= "container_label_not_set",
+		.dpe_str	= DEFAULT_CONT_LABEL,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
 		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,
@@ -123,7 +123,7 @@ struct daos_prop_entry cont_prop_entries_default_v0[CONT_PROP_NUM_V0] = {
 struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 	{
 		.dpe_type	= DAOS_PROP_CO_LABEL,
-		.dpe_str	= "container_label_not_set",
+		.dpe_str	= DEFAULT_CONT_LABEL,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
 		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -151,6 +151,7 @@ extern daos_prop_t cont_prop_default_v0;
 #define CONT_PROP_NUM_V0 20
 #define CONT_PROP_NUM	(DAOS_PROP_CO_MAX - DAOS_PROP_CO_MIN - 1)
 
+#define DEFAULT_CONT_LABEL "container_label_not_set"
 /**
  * Initialize the default container properties.
  *

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -211,6 +211,7 @@ type containerCreateCmd struct {
 	ACLFile     string               `long:"acl-file" short:"A" description:"input file containing ACL"`
 	User        string               `long:"user" short:"u" description:"user who will own the container (username@[domain])"`
 	Group       string               `long:"group" short:"g" description:"group who will own the container (group@[domain])"`
+	ContFlag    ContainerID          `long:"cont" short:"c" description:"container UUID (optional)"`
 }
 
 func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
@@ -219,6 +220,13 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 		return err
 	}
 	defer deallocCmdArgs()
+
+	if cmd.ContFlag.HasUUID() {
+		cmd.contUUID = cmd.ContFlag.UUID
+		if err := copyUUID(&ap.c_uuid, cmd.contUUID); err != nil {
+			return err
+		}
+	}
 
 	if cmd.PoolID().Empty() {
 		if cmd.Path == "" {
@@ -660,7 +668,7 @@ func printContainerInfo(out io.Writer, ci *containerInfo, verbose bool) error {
 	rows := []txtfmt.TableRow{
 		{"Container UUID": ci.ContainerUUID.String()},
 	}
-	if ci.ContainerLabel != "" && ci.ContainerLabel != labelNotSetStr {
+	if ci.ContainerLabel != "" {
 		rows = append(rows, txtfmt.TableRow{"Container Label": ci.ContainerLabel})
 	}
 	rows = append(rows, txtfmt.TableRow{"Container Type": ci.Type})

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -112,7 +112,7 @@ var propHdlrs = propHdlrMap{
 				return propNotFound(name)
 			}
 			if C.get_dpe_str(e) == nil {
-				return labelNotSetStr
+				return ""
 			}
 			return strValStringer(e, name)
 		},
@@ -598,7 +598,6 @@ var propHdlrs = propHdlrMap{
 const (
 	maxNameLen     = 20 // arbitrary; came from C code
 	maxValueLen    = C.DAOS_PROP_LABEL_MAX_LEN
-	labelNotSetStr = "container_label_not_set"
 )
 
 type entryHdlr func(*propHdlr, *C.struct_daos_prop_entry, string) error
@@ -1103,6 +1102,8 @@ func printProperties(out io.Writer, header string, props ...*property) {
 			if len(titles) == 1 {
 				titles = append(titles, valueTitle)
 			}
+		} else {
+			row[valueTitle] = " "
 		}
 		table = append(table, row)
 	}


### PR DESCRIPTION
PR-repos: mpifileutils-pkg@PR-27
Test-tag: PR,container,datamover,-fs_copy,-cont_clone

Signed-off-by: Lei Huang <lei.huang@intel.com>