### PR TITLE
DAOS-10822 pool: Get actual cart group ranks on create

### DIFF
--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -585,6 +585,30 @@ out:
 	return rc;
 }
 
+/**
+ * Create a ranged string representation of a rank list.
+ *
+ * \param[in]  rank_list	the rank list to represent
+ *
+ * \return			a ranged string (caller must free)
+ */
+char *
+d_rank_list_to_str(d_rank_list_t *rank_list)
+{
+	char			*str;
+	bool			 truncated = false;
+	d_rank_range_list_t	*range_list;
+
+	range_list = d_rank_range_list_create_from_ranks(rank_list);
+	if (range_list == NULL)
+		return NULL;
+	str = d_rank_range_list_str(range_list, &truncated);
+
+	d_rank_range_list_free(range_list);
+
+	return str;
+}
+
 d_rank_list_t *
 uint32_array_to_rank_list(uint32_t *ints, size_t len)
 {

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -407,6 +407,7 @@ int d_rank_list_append(d_rank_list_t *rank_list, d_rank_t rank);
 int d_rank_list_dump(d_rank_list_t *rank_list, d_string_t name, int name_len);
 d_rank_list_t *uint32_array_to_rank_list(uint32_t *ints, size_t len);
 int rank_list_to_uint32_array(d_rank_list_t *rl, uint32_t **ints, size_t *len);
+char *d_rank_list_to_str(d_rank_list_t *rank_list);
 
 d_rank_range_list_t *d_rank_range_list_alloc(uint32_t size);
 d_rank_range_list_t *d_rank_range_list_realloc(d_rank_range_list_t *range_list, uint32_t size);

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -167,31 +167,46 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 		    daos_prop_t *prop, uint32_t svc_nr, d_rank_list_t **svcp,
 		    int domains_nr, uint32_t *domains)
 {
-	d_rank_list_t			*filtered_targets = NULL;
 	d_rank_list_t			*pg_ranks = NULL;
-	uint32_t			pg_size;
+	d_rank_list_t			*pg_targets = NULL;
 	int				rc;
 	int				rc_cleanup;
 
 	/* Sanity check targets versus cart's current primary group members.
 	 * If any targets not in PG, flag error before MGMT_TGT_ corpcs fail.
 	 */
-	rc = crt_group_size(NULL, &pg_size);
+	rc = crt_group_ranks_get(NULL, &pg_ranks);
 	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
-	pg_ranks = d_rank_list_alloc(pg_size);
-	if (pg_ranks == NULL) {
-		rc = -DER_NOMEM;
+
+	rc = d_rank_list_dup(&pg_targets, targets);
+	if (rc != 0)
 		D_GOTO(out, rc);
-	}
-	rc = d_rank_list_dup(&filtered_targets, targets);
-	if (rc) {
-		rc = -DER_NOMEM;
-		D_GOTO(out, rc);
-	}
-	/* Remove any targets not found in pg_ranks */
-	d_rank_list_filter(pg_ranks, filtered_targets, false /* exclude */);
-	if (!d_rank_list_identical(filtered_targets, targets)) {
-		D_ERROR("some ranks not found in cart primary group\n");
+
+	/* The pg_ranks and targets lists should overlap perfectly.
+	 * If not, fail early to avoid expensive corpc failures.
+	 */
+	d_rank_list_filter(pg_ranks, pg_targets, false /* exclude */);
+	if (!d_rank_list_identical(pg_targets, targets)) {
+		char *pg_str, *tgt_str;
+
+		pg_str = d_rank_list_to_str(pg_ranks);
+		if (pg_str == NULL) {
+			rc = -DER_NOMEM;
+			D_GOTO(out, rc);
+		}
+
+		tgt_str = d_rank_list_to_str(targets);
+		if (tgt_str == NULL) {
+			D_FREE(pg_str);
+			rc = -DER_NOMEM;
+			D_GOTO(out, rc);
+		}
+
+		D_ERROR(DF_UUID": targets (%s) contains ranks not in pg (%s)\n",
+			DP_UUID(pool_uuid), tgt_str, pg_str);
+
+		D_FREE(pg_str);
+		D_FREE(tgt_str);
 		D_GOTO(out, rc = -DER_OOG);
 	}
 
@@ -230,7 +245,7 @@ out_svcp:
 				DF_RC"\n", DP_UUID(pool_uuid), DP_RC(rc));
 	}
 out:
-	d_rank_list_free(filtered_targets);
+	d_rank_list_free(pg_targets);
 	d_rank_list_free(pg_ranks);
 	D_DEBUG(DB_MGMT, "create pool "DF_UUID": "DF_RC"\n", DP_UUID(pool_uuid),
 		DP_RC(rc));


### PR DESCRIPTION
Previously, the code was simply generating the group
rank list based on the group size, resulting in intermittent
create failures when the actual group differed from the
generated group.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>