### PR TITLE
DAOS-8870 pool: Allow srv_hdls in TGT_QUERY_MAP (#7082)

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -892,8 +892,6 @@ int ds_get_pool_svc_ranks(uuid_t pool_uuid, d_rank_list_t **svc_ranks);
 int ds_pool_find_bylabel(d_const_string_t label, uuid_t pool_uuid,
 			 d_rank_list_t **svc_ranks);
 
-bool is_pool_from_srv(uuid_t pool_uuid, uuid_t poh_uuid);
-
 struct sys_db;
 typedef int (*sys_db_trav_cb_t)(struct sys_db *db, char *table, d_iov_t *key,
 				void *args);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1645,6 +1645,9 @@ map_refresh_cb(tse_task_t *task, void *varg)
 		pool->dp_map_sz = out->tmo_map_buf_size;
 		reinit = true;
 		goto out;
+	} else if (rc == -DER_AGAIN) {
+		reinit = true;
+		goto out;
 	} else if (rc != 0) {
 		D_ERROR(DF_UUID": failed to fetch pool map: "DF_RC"\n",
 			DP_UUID(pool->dp_pool), DP_RC(rc));

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -119,6 +119,7 @@ void ds_pool_rsvc_class_register(void);
 void ds_pool_rsvc_class_unregister(void);
 int ds_pool_start_all(void);
 int ds_pool_stop_all(void);
+int ds_pool_hdl_is_from_srv(struct ds_pool *pool, uuid_t hdl);
 void ds_pool_create_handler(crt_rpc_t *rpc);
 void ds_pool_connect_handler(crt_rpc_t *rpc);
 void ds_pool_disconnect_handler(crt_rpc_t *rpc);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2928,6 +2928,8 @@ out:
 	return rc;
 }
 
+static bool is_pool_from_srv(uuid_t pool_uuid, uuid_t poh_uuid);
+
 /* CaRT RPC handler for pool container listing
  * Requires a pool handle (except for rebuild).
  */
@@ -6272,11 +6274,40 @@ out_svc:
 	return rc;
 }
 
-bool
+/**
+ * Is \a hdl a "server handle" for \a pool?
+ *
+ * \param[in]	pool	pool
+ * \param[in]	hdl	pool handle UUID
+ *
+ * \return	1	yes
+ *		0	no
+ *		<0	error from the IV fetch
+ */
+int
+ds_pool_hdl_is_from_srv(struct ds_pool *pool, uuid_t hdl)
+{
+	uuid_t	srv_hdl;
+	int	rc;
+
+	/*
+	 * Use the cached value if available. (Not sure if this cache could be
+	 * stale...)
+	 */
+	if (!uuid_is_null(pool->sp_srv_pool_hdl))
+		return uuid_compare(pool->sp_srv_pool_hdl, hdl) == 0;
+
+	rc = ds_pool_iv_srv_hdl_fetch(pool, &srv_hdl, NULL);
+	if (rc != 0)
+		return rc;
+
+	return uuid_compare(srv_hdl, hdl) == 0;
+}
+
+static bool
 is_pool_from_srv(uuid_t pool_uuid, uuid_t poh_uuid)
 {
 	struct ds_pool	*pool;
-	uuid_t		hdl_uuid;
 	int		rc;
 
 	pool = ds_pool_lookup(pool_uuid);
@@ -6286,14 +6317,14 @@ is_pool_from_srv(uuid_t pool_uuid, uuid_t poh_uuid)
 		return false;
 	}
 
-	rc = ds_pool_iv_srv_hdl_fetch(pool, &hdl_uuid, NULL);
+	rc = ds_pool_hdl_is_from_srv(pool, poh_uuid);
 	ds_pool_put(pool);
-	if (rc) {
+	if (rc < 0) {
 		D_ERROR(DF_UUID" fetch srv hdl: %d\n", DP_UUID(pool_uuid), rc);
 		return false;
 	}
 
-	return !uuid_compare(poh_uuid, hdl_uuid);
+	return rc ? true : false;
 }
 
 int ds_pool_svc_upgrade(uuid_t pool_uuid, d_rank_list_t *ranks)

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1521,42 +1521,77 @@ ds_pool_tgt_query_map_handler(crt_rpc_t *rpc)
 {
 	struct pool_tgt_query_map_in   *in = crt_req_get(rpc);
 	struct pool_tgt_query_map_out  *out = crt_reply_get(rpc);
-	struct ds_pool_hdl	       *hdl;
 	struct ds_pool		       *pool;
 	struct pool_buf		       *buf;
 	unsigned int			version;
 	int				rc;
 
-	D_DEBUG(DB_TRACE, DF_UUID": handling rpc %p\n",
-		DP_UUID(in->tmi_op.pi_uuid), rpc);
+	D_DEBUG(DB_TRACE, DF_UUID": handling rpc %p: hdl="DF_UUID"\n",
+		DP_UUID(in->tmi_op.pi_uuid), rpc, DP_UUID(in->tmi_op.pi_hdl));
 
-	hdl = ds_pool_hdl_lookup(in->tmi_op.pi_hdl);
-	if (hdl == NULL) {
-		rc = -DER_NO_HDL;
-		goto out;
+	/* Validate the pool handle and get the ds_pool object. */
+	if (daos_rpc_from_client(rpc)) {
+		struct ds_pool_hdl *hdl;
+
+		hdl = ds_pool_hdl_lookup(in->tmi_op.pi_hdl);
+		if (hdl == NULL) {
+			D_ERROR(DF_UUID": cannot find pool handle "DF_UUID"\n",
+				DP_UUID(in->tmi_op.pi_uuid), DP_UUID(in->tmi_op.pi_hdl));
+			rc = -DER_NO_HDL;
+			goto out;
+		}
+		ds_pool_get(hdl->sph_pool);
+		pool = hdl->sph_pool;
+		ds_pool_hdl_put(hdl);
+	} else {
+		/*
+		 * See the comment on validating the pool handle in
+		 * ds_pool_query_handler.
+		 */
+		pool = ds_pool_lookup(in->tmi_op.pi_uuid);
+		if (pool == NULL) {
+			D_ERROR(DF_UUID": failed to look up pool\n", DP_UUID(in->tmi_op.pi_uuid));
+			rc = -DER_NONEXIST;
+			goto out;
+		}
+		rc = ds_pool_hdl_is_from_srv(pool, in->tmi_op.pi_hdl);
+		if (rc < 0) {
+			D_CDEBUG(rc == -DER_NOTLEADER, DLOG_DBG, DLOG_ERR,
+				 DF_UUID": failed to check server pool handle "DF_UUID": "DF_RC"\n",
+				 DP_UUID(in->tmi_op.pi_uuid), DP_UUID(in->tmi_op.pi_hdl),
+				 DP_RC(rc));
+			if (rc == -DER_NOTLEADER)
+				rc = -DER_AGAIN;
+			goto out_pool;
+		} else if (!rc) {
+			D_ERROR(DF_UUID": cannot find server pool handle "DF_UUID"\n",
+				DP_UUID(in->tmi_op.pi_uuid), DP_UUID(in->tmi_op.pi_hdl));
+			rc = -DER_NO_HDL;
+			goto out_pool;
+		}
 	}
 
 	/* Inefficient; better invent some zero-copy IV APIs. */
-	pool = hdl->sph_pool;
 	ABT_rwlock_rdlock(pool->sp_lock);
 	version = (pool->sp_map == NULL ? 0 : pool_map_get_version(pool->sp_map));
 	if (version <= in->tmi_map_version) {
 		rc = 0;
 		ABT_rwlock_unlock(pool->sp_lock);
-		goto out_hdl;
+		goto out_version;
 	}
 	rc = pool_buf_extract(pool->sp_map, &buf);
 	ABT_rwlock_unlock(pool->sp_lock);
 	if (rc != 0)
-		goto out_hdl;
+		goto out_version;
 
 	rc = ds_pool_transfer_map_buf(buf, version, rpc, in->tmi_map_bulk,
 				      &out->tmo_map_buf_size);
 
 	D_FREE(buf);
-out_hdl:
+out_version:
 	out->tmo_op.po_map_version = version;
-	ds_pool_hdl_put(hdl);
+out_pool:
+	ds_pool_put(pool);
 out:
 	out->tmo_op.po_rc = rc;
 	D_DEBUG(DB_TRACE, DF_UUID": replying rpc %p: "DF_RC"\n",


### PR DESCRIPTION
ds_pool_tgt_query_map_handler misses (due to my ignorance) the case
where an engine may go through the map_refresh code to refresh a
"client-copy" of the pool map during a rebuild job. This patch fixes the
issue by following the handling "server handles" in
ds_pool_query_handler. Also,

  - Extract a new ds_pool_hdl_is_from_srv API for
    ds_pool_tgt_query_map_handler, to avoid looking up the ds_pool
    object twice.
  - Handle -DER_NOTLEADER from ds_pool_hdl_is_from_srv in
    ds_pool_tgt_query_map_handler and resulting -DER_AGAIN in
    map_refresh_cb.
  - Remove the is_pool_from_srv declaration from daos_engine.h.

Signed-off-by: Li Wei <wei.g.li@intel.com>