### PR TITLE
DAOS-10803 test: Update the object class and RF. (#7690)

### DIFF
--- a/src/tests/ftest/osa/offline_reintegration.yaml
+++ b/src/tests/ftest/osa/offline_reintegration.yaml
@@ -99,9 +99,8 @@ mdtest:
   depth: 0
 test_obj_class:
   oclass:
-    - RP_4G1
-    - S1
-    - EC_2P1G1
+    - RP_3G6
+    - EC_3P1G1
 loop_test:
   iterations: 3
 aggregation:

--- a/src/tests/ftest/osa/offline_reintegration.yaml
+++ b/src/tests/ftest/osa/offline_reintegration.yaml
@@ -100,7 +100,6 @@ mdtest:
 test_obj_class:
   oclass:
     - RP_3G6
-    - EC_3P1G1
 loop_test:
   iterations: 3
 aggregation:

--- a/src/tests/ftest/osa/offline_reintegration.yaml
+++ b/src/tests/ftest/osa/offline_reintegration.yaml
@@ -60,8 +60,8 @@ pool:
 container:
   type: POSIX
   control_method: daos
-  oclass: RP_2G1
-  properties: cksum:crc64,cksum_size:16384,srv_cksum:on,rf:1
+  oclass: RP_3G6
+  properties: cksum:crc64,cksum_size:16384,srv_cksum:on,rf:2
 ior:
   clientslots:
     slots: 48
@@ -72,8 +72,8 @@ ior:
     write_flags: "-w -F -k -G 1"
     read_flags: "-F -r -R -k -G 1"
     api: DFS
-    dfs_oclass: RP_2G1
-    dfs_dir_oclass: RP_2G1
+    dfs_oclass: RP_3G6
+    dfs_dir_oclass: RP_3G6
   ior_test_sequence:
   #   - [scmsize, nvmesize, transfersize, blocksize]
   #    The values are set to be in the multiples of 10.
@@ -87,8 +87,8 @@ mdtest:
   test_dir: "/"
   iteration: 1
   dfs_destroy: False
-  dfs_oclass: RP_2G1
-  dfs_dir_oclass: RP_2G1
+  dfs_oclass: RP_3G6
+  dfs_dir_oclass: RP_3G6
   manager: "MPICH"
   flags: "-u"
   wr_size:
@@ -99,8 +99,6 @@ mdtest:
   depth: 0
 test_obj_class:
   oclass:
-    - RP_2G8
-    - RP_3G6
     - RP_4G1
     - S1
     - EC_2P1G1


### PR DESCRIPTION
# Description

Backport of the patch 747fd6d updating the object class and RF for
offline_reintegration.

The oclass RP_2G8 is not adapted for the test
osa/offline_reintegration.py:offline_reintegration_oclass.  Indeed, some
shards of the ior test file could be lost during the process of the many
cycles of rebuild/reintegration. These lost shards, could eventually
makes the fds_open call of ior to fail.

More details on this issue are available in the DAOS-9313 ticket.