### PR TITLE
CART-89 multiprovider: Add new api to query original src provider

### DIFF
--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -523,6 +523,8 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 						rpc_priv->crp_pub.cr_ep.ep_rank
 						);
 			hdr->cch_dst_tag = rpc_priv->crp_pub.cr_ep.ep_tag;
+
+			hdr->cch_src_is_primary = rpc_priv->crp_src_is_primary;
 
 			if (crt_is_service()) {
 				hdr->cch_src_rank =

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -98,7 +98,9 @@ struct crt_gdata {
 				/** whether it is a client or server */
 				cg_server		: 1,
 				/** whether scalable endpoint is enabled */
-				cg_use_sensors		: 1;
+				cg_use_sensors		: 1,
+				/** whether we are on a primary provider */
+				cg_provider_is_primary	: 1;
 
 	ATOMIC uint64_t		cg_rpcid; /* rpc id */
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1607,6 +1607,14 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx,
 	rpc_priv->crp_hdl_reuse = NULL;
 	rpc_priv->crp_srv = srv_flag;
 	rpc_priv->crp_ul_retry = 0;
+
+
+	if (srv_flag) {
+		rpc_priv->crp_src_is_primary = ctx->cc_primary;
+	} else {
+		rpc_priv->crp_src_is_primary = crt_gdata.cg_provider_is_primary;
+	}
+
 	/**
 	 * initialized to 1, so user can call crt_req_decref to destroy new req
 	 */
@@ -1807,6 +1815,28 @@ crt_req_src_rank_get(crt_rpc_t *rpc, d_rank_t *rank)
 
 	*rank = rpc_priv->crp_req_hdr.cch_src_rank;
 
+out:
+	return rc;
+}
+
+int
+crt_req_src_provider_is_primary(crt_rpc_t *req, bool *result)
+{
+	struct crt_rpc_priv	*rpc_priv = NULL;
+	int			rc = 0;
+
+	if (req == NULL) {
+		D_ERROR("req is NULL\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (result == NULL) {
+		D_ERROR("result is NULL\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	rpc_priv = container_of(req, struct crt_rpc_priv, crp_pub);
+	*result = rpc_priv->crp_req_hdr.cch_src_is_primary;
 out:
 	return rc;
 }

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -67,6 +67,10 @@ struct crt_common_hdr {
 	d_rank_t	cch_src_rank;
 	/* tag to which rpc request was sent to */
 	uint32_t	cch_dst_tag;
+	/* flags */
+	/* indicates whether rpc originator intended to send on a primary ctx */
+	uint32_t	cch_src_is_primary : 1;
+
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */
 	uint32_t	cch_rc;
 };
@@ -176,7 +180,10 @@ struct crt_rpc_priv {
 				/* 1 if RPC fails HLC epsilon check */
 				crp_fail_hlc:1,
 				/* RPC completed flag */
-				crp_completed:1;
+				crp_completed:1,
+				/* RPC originated from a primary provider */
+				crp_src_is_primary:1;
+
 	uint32_t		crp_refcount;
 	struct crt_opc_info	*crp_opc_info;
 	/* corpc info, only valid when (crp_coll == 1) */

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -429,6 +429,18 @@ int
 crt_req_src_rank_get(crt_rpc_t *req, d_rank_t *rank);
 
 /**
+ * Return whether originator runs from a primary provider or not
+ *
+ * \param[in] req              Pointer to RPC request
+ * \param[out] result          Returned result
+ *
+ * \return                     DER_SUCCESS on success or error
+ *                             on failure
+ */
+int
+crt_req_src_provider_is_primary(crt_rpc_t *req, bool *result);
+
+/**
  * Return destination rank
  *
  * \param[in] req              Pointer to RPC request


### PR DESCRIPTION
    Add new api to query whether the originators provider was primary
    or secondary.
    For server originators, this will depend on the context on which rpc
    was allocated as server can support both a primary and a secondary
    context.
    For client originators, this will depend on CRT_SECONDARY_PROVIDER
    envariable. If set it will indicate that the client cluster is
    using a secondary provider.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>