### PR TITLE
DAOS-10806 test: fix a bug for setting reclaim policy (#9307)

### DIFF
--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -2394,14 +2394,14 @@ delet_container_during_aggregation(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_pool_info_t pinfo;
-	int		i;
-	int		rc;
+	int		 i;
+	int		 rc;
 
 	/* Prepare records */
 	oid = daos_test_oid_gen(arg->coh, OC_SX, 0, 0, arg->myrank);
 
 	print_message("Initial Pool Query\n");
-	pool_storage_info(state, &pinfo);
+	pool_storage_info(arg, &pinfo);
 
 	/* Aggregation will be Hold */
 	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -2418,7 +2418,7 @@ delet_container_during_aggregation(void **state)
 	 * Aggregation will be ready to run by this time
 	 */
 	for (i = 0; i <= 5; i++) {
-		pool_storage_info(state, &pinfo);
+		pool_storage_info(arg, &pinfo);
 		sleep(5);
 	}
 
@@ -2430,7 +2430,7 @@ delet_container_during_aggregation(void **state)
 	assert_rc_equal(rc, 0);
 
 	/* Run Pool query at the end */
-	pool_storage_info(state, &pinfo);
+	pool_storage_info(arg, &pinfo);
 }
 
 static void

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -150,7 +150,7 @@ obj_teardown(void **state);
 
 int io_conf_run(test_arg_t *arg, const char *io_conf);
 
-int pool_storage_info(void **state, daos_pool_info_t *pinfo);
+int pool_storage_info(test_arg_t *arg, daos_pool_info_t *pinfo);
 
 /* below list the structure defined for epoch io testing */
 


### PR DESCRIPTION
set_pool_reclaim_strategy() does not work as DAOS_PROP_PO_RECLAIM is a
pool property rather than user attribute, so daos_pool_set_attr will not
work.
And if the test case need to compare pool space usage better to generate
separate pool rather than reuse the shared pool.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>