### PR TITLE
DAOS-10829 pool: fix a bug of pmap_fail_node not inited/zeroed (#9331)

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -2243,11 +2243,10 @@ struct pmap_fail_stat {
 static void
 pmap_fail_node_init(struct pmap_fail_node *fnode)
 {
+	memset(fnode, 0, sizeof(*fnode));
 	fnode->pf_vers = fnode->pf_ver_inline;
 	fnode->pf_ver_total = PMAP_FAIL_INLINE_NR;
 	fnode->pf_ver_nr = 0;
-	memset(fnode->pf_vers, 0,
-	       sizeof(struct pmap_fail_ver) * fnode->pf_ver_total);
 }
 
 static void
@@ -2295,6 +2294,7 @@ pmap_fail_node_get(struct pmap_fail_stat *fstat)
 
 	D_ASSERT(fstat->pf_node_nr < fstat->pf_node_total);
 	fnode = &fstat->pf_nodes[fstat->pf_node_nr++];
+	pmap_fail_node_init(fnode);
 	return fnode;
 }
 


### PR DESCRIPTION
in pool_map_rf_verify() the pmap_fail_node not comopletly inited/zeroed, that
possibly cause problem as the memory in stack may with non-zero data
(pf_down/pf_new_fail possibly is 1 in extreme case).

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>