### PR TITLE
DAOS-10399 object: yield on initiating bulk transfers

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -309,6 +309,8 @@ obj_bulk_bypass(d_sg_list_t *sgl, crt_bulk_op_t bulk_op)
 	}
 }
 
+#define MAX_BULK_IOVS	1024
+
 static int
 bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 		  off_t remote_off, crt_bulk_op_t bulk_op, bool bulk_bind,
@@ -321,7 +323,7 @@ bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 	unsigned int		local_off;
 	unsigned int		iov_idx = 0;
 	size_t			remote_size;
-	int			rc;
+	int			rc, bulk_iovs = 0;
 
 	if (remote_bulk == NULL) {
 		D_ERROR("Remote bulk is NULL\n");
@@ -391,6 +393,7 @@ bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 				length += sgl->sg_iovs[iov_idx].iov_len;
 				iov_idx++;
 			};
+			bulk_iovs += 1;
 		} else {
 			start = iov_idx;
 			sgl_sent.sg_iovs = &sgl->sg_iovs[start];
@@ -406,11 +409,15 @@ bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 				length += sgl->sg_iovs[iov_idx].iov_len;
 				iov_idx++;
 
+				/* Don't create bulk handle with too many IOVs */
+				if ((iov_idx - start) >= MAX_BULK_IOVS)
+					break;
 			};
 			D_ASSERT(iov_idx > start);
 
 			local_off = 0;
 			sgl_sent.sg_nr = sgl_sent.sg_nr_out = iov_idx - start;
+			bulk_iovs += sgl_sent.sg_nr;
 
 			rc = crt_bulk_create(rpc->cr_ctx, &sgl_sent, bulk_perm,
 					     &local_bulk);
@@ -460,6 +467,12 @@ bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 			break;
 		}
 		remote_off += length;
+
+		/* Give cart progress a chance to complete some inflight bulk transfers */
+		if (bulk_iovs >= MAX_BULK_IOVS) {
+			bulk_iovs = 0;
+			ABT_thread_yield();
+		}
 	}
 
 	return rc;


### PR DESCRIPTION
To avoid resource being exhausted in network stack layers, yield needs
be called on initiating every 1k IOVs bulk transfers, so that cart
progress will be able to kick in to complete some inflight bulk transfers.

Test-tag: pr hdf5testsuite

Signed-off-by: Niu Yawei <yawei.niu@intel.com>