### PR TITLE
DAOS-10845 packaging: do not ship UCX packages

### DIFF
--- a/.rpmignore
+++ b/.rpmignore
@@ -8,19 +8,23 @@ centos7/daos-firmware*.rpm
 centos7/daos-serialize*.rpm
 centos7/daos-server-tests-openmpi*.rpm
 centos7/daos-tests-internal*.rpm
+centos7/ucx*.rpm
 
 el8/daos-client-tests-openmpi*.rpm
 el8/daos-firmware*.rpm
 el8/daos-serialize*.rpm
 el8/daos-server-tests-openmpi*.rpm
 el8/daos-tests-internal*.rpm
+el8/ucx*.rpm
 
 leap15/daos-client-tests-openmpi*.rpm
 leap15/daos-firmware*.rpm
 leap15/daos-serialize*.rpm
 leap15/daos-server-tests-openmpi*.rpm
 leap15/daos-tests-internal*.rpm
+leap15/ucx*.rpm
 
 ubuntu20.04/daos-*.deb
 ubuntu20.04/libdaos*.deb
+ubuntu20.04/ucx*.deb
 

--- a/.rpmignore
+++ b/.rpmignore
@@ -22,7 +22,7 @@ leap15/daos-firmware*.rpm
 leap15/daos-serialize*.rpm
 leap15/daos-server-tests-openmpi*.rpm
 leap15/daos-tests-internal*.rpm
-leap15/ucx*.rpm
+leap15/openucx*.rpm
 
 ubuntu20.04/daos-*.deb
 ubuntu20.04/libdaos*.deb


### PR DESCRIPTION
do not ship UCX packages - added ucx to .rpmignore
(we use the MOFED-provided UCX)

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>