### PR TITLE
DAOS-9201 API: Remove compatibility code for daos_cont_create()

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1371,9 +1371,9 @@ dfs_get_sb_layout(daos_key_t *dkey, daos_iod_t *iods[], int *akey_count,
 	return 0;
 }
 
-static int
-dfs_cont_create_int(daos_handle_t poh, uuid_t *cuuid, bool uuid_is_set, uuid_t in_uuid,
-		    dfs_attr_t *attr, daos_handle_t *_coh, dfs_t **_dfs)
+int
+dfs_cont_create(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr,
+		daos_handle_t *_coh, dfs_t **_dfs)
 {
 	daos_handle_t		coh, super_oh;
 	struct dfs_entry	entry = {0};
@@ -1473,10 +1473,7 @@ dfs_cont_create_int(daos_handle_t poh, uuid_t *cuuid, bool uuid_is_set, uuid_t i
 	prop->dpp_entries[prop->dpp_nr - 1].dpe_type = DAOS_PROP_CO_LAYOUT_TYPE;
 	prop->dpp_entries[prop->dpp_nr - 1].dpe_val = DAOS_PROP_CO_LAYOUT_POSIX;
 
-	if (uuid_is_set)
-		rc = daos_cont_create(poh, in_uuid, prop, NULL);
-	else
-		rc = daos_cont_create(poh, cuuid, prop, NULL);
+	rc = daos_cont_create(poh, cuuid, prop, NULL);
 	if (rc) {
 		D_ERROR("daos_cont_create() failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_prop, rc = daos_der2errno(rc));
@@ -1563,44 +1560,6 @@ err_prop:
 	return rc;
 }
 
-/** Disable backward compat code */
-#undef dfs_cont_create
-
-/** Kept for backward ABI compatibility when a UUID is provided by the caller */
-int
-dfs_cont_create(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr, daos_handle_t *coh, dfs_t **dfs)
-{
-	const unsigned char     *uuid = (const unsigned char *)cuuid;
-	uuid_t			co_uuid;
-
-	if (!daos_uuid_valid(uuid))
-		return EINVAL;
-
-	uuid_copy(co_uuid, uuid);
-	return dfs_cont_create_int(poh, cuuid, true, co_uuid, attr, coh, dfs);
-}
-
-/** API version for when the uuid is required to be passed in. */
-int
-dfs_cont_create1(daos_handle_t poh, const uuid_t cuuid, dfs_attr_t *attr, daos_handle_t *coh,
-		 dfs_t **dfs)
-{
-	uuid_t *u = (uuid_t *)((unsigned char *)cuuid);
-
-	return dfs_cont_create(poh, u, attr, coh, dfs);
-}
-
-/*
- * Real latest & greatest implementation of container create. Used by anyone including the
- * daos_fs.h header file.
- */
-int
-dfs_cont_create2(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr, daos_handle_t *coh,
-		 dfs_t **dfs)
-{
-	return dfs_cont_create_int(poh, cuuid, false, NULL, attr, coh, dfs);
-}
-
 int
 dfs_cont_create_with_label(daos_handle_t poh, const char *label, dfs_attr_t *attr,
 			   uuid_t *cuuid, daos_handle_t *coh, dfs_t **dfs)
@@ -1636,9 +1595,9 @@ dfs_cont_create_with_label(daos_handle_t poh, const char *label, dfs_attr_t *att
 	if (cuuid == NULL) {
 		uuid_t u;
 
-		rc = dfs_cont_create_int(poh, &u, false, NULL, attr, coh, dfs);
+		rc = dfs_cont_create(poh, &u, attr, coh, dfs);
 	} else {
-		rc = dfs_cont_create_int(poh, cuuid, false, NULL, attr, coh, dfs);
+		rc = dfs_cont_create(poh, cuuid, attr, coh, dfs);
 	}
 	attr->da_props = orig;
 	daos_prop_free(merged_props);

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -676,8 +676,6 @@ create_cont(daos_handle_t poh, struct duns_attr_t *attrp, bool create_with_label
 		if (create_with_label)
 			rc = dfs_cont_create_with_label(poh, attrp->da_cont, &dfs_attr,
 							&attrp->da_cuuid, NULL, NULL);
-		else if (!uuid_is_null(attrp->da_cuuid))
-			rc = dfs_cont_create(poh, attrp->da_cuuid, &dfs_attr, NULL, NULL);
 		else
 			rc = dfs_cont_create(poh, &attrp->da_cuuid, &dfs_attr, NULL, NULL);
 	} else {
@@ -705,8 +703,6 @@ create_cont(daos_handle_t poh, struct duns_attr_t *attrp, bool create_with_label
 		if (create_with_label)
 			rc = daos_cont_create_with_label(poh, attrp->da_cont, prop,
 							 &attrp->da_cuuid, NULL);
-		else if (!uuid_is_null(attrp->da_cuuid))
-			rc = daos_cont_create(poh, attrp->da_cuuid, prop, NULL);
 		else
 			rc = daos_cont_create(poh, &attrp->da_cuuid, prop, NULL);
 		if (rc)

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -13,7 +13,6 @@ from .. import pydaos_shim
 
 import ctypes
 import threading
-import uuid
 import os
 import inspect
 import sys
@@ -1464,16 +1463,10 @@ class DaosContainer():
         return conversion.c_uuid_to_str(self.uuid)
 
     # pylint: disable=too-many-branches
-    def create(self, poh, con_uuid=None, con_prop=None, cb_func=None):
+    def create(self, poh, con_prop=None, cb_func=None):
         """Send a container creation request to the daos server group."""
         # create a random uuid if none is provided
         self.uuid = (ctypes.c_ubyte * 16)()
-        if con_uuid is None:
-            conversion.c_uuid(uuid.uuid4(), self.uuid)
-        elif con_uuid == "NULLPTR":
-            self.uuid = None
-        else:
-            conversion.c_uuid(con_uuid, self.uuid)
         self.poh = poh
         if con_prop is not None:
             self.cont_input_values = con_prop
@@ -1554,10 +1547,9 @@ class DaosContainer():
         # create synchronously, if its there then run it in a thread
         if cb_func is None:
             if self.cont_prop is None:
-                ret = func(self.poh, self.uuid, None, None)
+                ret = func(self.poh, ctypes.byref(self.uuid), None, None)
             else:
-                ret = func(self.poh, self.uuid, ctypes.byref(self.cont_prop),
-                           None)
+                ret = func(self.poh, ctypes.byref(self.uuid), ctypes.byref(self.cont_prop), None)
             if ret != 0:
                 self.uuid = (ctypes.c_ubyte * 1)(0)
                 raise DaosApiError(
@@ -1566,9 +1558,9 @@ class DaosContainer():
         else:
             event = daos_cref.DaosEvent()
             if self.cont_prop is None:
-                params = [self.poh, self.uuid, None, event]
+                params = [self.poh, ctypes.byref(self.uuid), None, event]
             else:
-                params = [self.poh, self.uuid, ctypes.byref(self.cont_prop),
+                params = [self.poh, ctypes.byref(self.uuid), ctypes.byref(self.cont_prop),
                           None, event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
@@ -1583,12 +1575,12 @@ class DaosContainer():
         # caller can override pool handle and uuid
         if poh is not None:
             self.poh = poh
-        if con_uuid is not None:
-            conversion.c_uuid(con_uuid, self.uuid)
-
         if self.uuid is None:
-            raise DaosApiError("Container uuid is None.")
-        uuid_str = self.get_uuid_str()
+            raise DaosApiError("Fail to destroy a container with uuid as none.")
+        if con_uuid is None:
+            uuid_str = self.get_uuid_str()
+        else:
+            uuid_str = str(con_uuid)
 
         c_force = ctypes.c_uint(force)
 

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -552,7 +552,7 @@ daos_prop_entry_copy(struct daos_prop_entry *entry,
 	case DAOS_PROP_CO_ROOTS:
 		rc = daos_prop_entry_dup_co_roots(entry_dup, entry);
 		if (rc) {
-			D_ERROR("failed to dup roots\n");
+			D_ERROR("failed to dup roots "DF_RC"\n", DP_RC(rc));
 			return rc;
 		}
 		break;

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -211,7 +211,6 @@ type containerCreateCmd struct {
 	ACLFile     string               `long:"acl-file" short:"A" description:"input file containing ACL"`
 	User        string               `long:"user" short:"u" description:"user who will own the container (username@[domain])"`
 	Group       string               `long:"group" short:"g" description:"group who will own the container (group@[domain])"`
-	ContFlag    ContainerID          `long:"cont" short:"c" description:"container UUID (optional)"`
 }
 
 func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
@@ -220,13 +219,6 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 		return err
 	}
 	defer deallocCmdArgs()
-
-	if cmd.ContFlag.HasUUID() {
-		cmd.contUUID = cmd.ContFlag.UUID
-		if err := copyUUID(&ap.c_uuid, cmd.contUUID); err != nil {
-			return err
-		}
-	}
 
 	if cmd.PoolID().Empty() {
 		if cmd.Path == "" {

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -16,6 +16,8 @@
 #define daos_cont_open daos_cont_open2
 /** Please ignore (code for back-compatibility) */
 #define daos_cont_destroy daos_cont_destroy2
+/** Please ignore (code for back-compatibility) */
+#define daos_cont_create daos_cont_create2
 
 #if defined(__cplusplus)
 extern "C" {
@@ -661,55 +663,7 @@ int
 daos_cont_destroy_snap(daos_handle_t coh, daos_epoch_range_t epr,
 		       daos_event_t *ev);
 
-/**
- * Backward compatibility code.
- * Please don't use directly
- */
-int
-daos_cont_create2(daos_handle_t poh, uuid_t *uuid, daos_prop_t *cont_prop, daos_event_t *ev);
-/**
- * Backward compatibility code.
- * Please don't use directly
- */
-int
-daos_cont_create1(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop, daos_event_t *ev);
-
 #if defined(__cplusplus)
 }
-
-#define daos_cont_create daos_cont_create_cpp
-static inline int
-daos_cont_create_cpp(daos_handle_t poh, uuid_t *uuid, daos_prop_t *cont_prop, daos_event_t *ev)
-{
-	return daos_cont_create2(poh, uuid, cont_prop, ev);
-}
-
-static inline int
-daos_cont_create_cpp(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop, daos_event_t *ev)
-{
-	return daos_cont_create1(poh, uuid, cont_prop, ev);
-}
-#else
-
-/**
- * for backward compatility, support old api where a const uuid_t was required to be passed in for
- * the container to be created.
- */
-#define daos_cont_create(poh, co, ...)					\
-	({								\
-		int _ret;						\
-		uuid_t *_u;						\
-		if (d_is_uuid(co)) {					\
-			_u = (uuid_t *)((unsigned char *)(co));		\
-			_ret = daos_cont_create((poh), _u,		\
-						__VA_ARGS__);		\
-		} else {						\
-			_u = (uuid_t *)(co);				\
-			_ret = daos_cont_create2((poh), _u,		\
-						 __VA_ARGS__);		\
-		}							\
-		_ret;							\
-	})
-
 #endif /* __cplusplus */
 #endif /* __DAOS_CONT_H__ */

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -1010,57 +1010,7 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name);
 int
 dfs_listxattr(dfs_t *dfs, dfs_obj_t *obj, char *list, daos_size_t *size);
 
-/**
- * Backward compatibility code.
- * Please don't use directly
- */
-int
-dfs_cont_create2(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr, daos_handle_t *coh,
-		 dfs_t **dfs);
-/**
- * Backward compatibility code.
- * Please don't use directly
- */
-int
-dfs_cont_create1(daos_handle_t poh, const uuid_t cuuid, dfs_attr_t *attr, daos_handle_t *coh,
-		 dfs_t **dfs);
-
 #if defined(__cplusplus)
 }
-
-#define dfs_cont_create dfs_cont_create_cpp
-static inline int
-dfs_cont_create_cpp(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr, daos_handle_t *coh,
-		    dfs_t **dfs)
-{
-	return dfs_cont_create2(poh, cuuid, attr, coh, dfs);
-}
-
-static inline int
-dfs_cont_create_cpp(daos_handle_t poh, const uuid_t cuuid, dfs_attr_t *attr, daos_handle_t *coh,
-		    dfs_t **dfs)
-{
-	return dfs_cont_create1(poh, cuuid, attr, coh, dfs);
-};
-#else
-/**
- * for backward compatibility, support old api where a const uuid_t was required to be passed in for
- * the container to be created.
- */
-#define dfs_cont_create(poh, co, ...)					\
-	({								\
-		int _ret;						\
-		uuid_t *_u;						\
-		if (d_is_uuid(co)) {					\
-			_u = (uuid_t *)((unsigned char *)(co));		\
-			_ret = dfs_cont_create((poh), _u, __VA_ARGS__);	\
-		} else {						\
-			_u = (uuid_t *)(co);				\
-			_ret = dfs_cont_create2((poh), _u, __VA_ARGS__); \
-		}							\
-		_ret;							\
-	})
-
-
 #endif /* __cplusplus */
 #endif /* __DAOS_FS_H__ */

--- a/src/tests/ftest/container/async.py
+++ b/src/tests/ftest/container/async.py
@@ -64,8 +64,7 @@ class ContainerAsync(TestWithServers):
             # calls wait, but we're using DaosContainer, so we need to manually
             # call it.
             self.pool.destroy(1)
-            self.container[1].container.create(
-                poh=ph, con_uuid=None, cb_func=cbh2.callback)
+            self.container[1].container.create(poh=ph, cb_func=cbh2.callback)
             cbh2.wait()
             self.assertTrue(
                 cbh2.ret_code is not None and cbh2.ret_code != RC_SUCCESS,

--- a/src/tests/ftest/container/create.py
+++ b/src/tests/ftest/container/create.py
@@ -7,7 +7,6 @@
 
 
 import traceback
-import uuid
 
 from apricot import TestWithServers
 from pydaos.raw import DaosContainer, DaosApiError
@@ -28,7 +27,6 @@ class CreateContainerTest(TestWithServers):
 
         :avocado: tags=all,container,tiny,smoke,full_regression,containercreate
         """
-        contuuid = None
         expected_results = []
 
         # setup the pool
@@ -42,14 +40,6 @@ class CreateContainerTest(TestWithServers):
             poh = handleparam
             expected_results.append('FAIL')
 
-        # maybe use a good UUID, maybe not
-        uuidparam = self.params.get("uuid", "/uuids/*")
-        expected_results.append(uuidparam[1])
-        if uuidparam[0] == 'NULLPTR':
-            contuuid = 'NULLPTR'
-        else:
-            contuuid = uuid.UUID(uuidparam[0])
-
         should_fail = False
         for result in expected_results:
             if result == 'FAIL':
@@ -58,16 +48,9 @@ class CreateContainerTest(TestWithServers):
 
         try:
             self.container = DaosContainer(self.context)
-            self.container.create(poh, contuuid)
 
-            # check UUID is the specified one
-            if (uuidparam[0]).upper() != self.container.get_uuid_str().upper():
-                print("uuidparam[0] is {}, uuid_str is {}".format(
-                    uuidparam[0], self.container.get_uuid_str()))
-                self.fail("Container UUID differs from specified at create\n")
-
-            if should_fail:
-                self.fail("Test was expected to fail but it passed.\n")
+            if self.container.uuid is None:
+                self.fail("Container uuid is None.")
 
         except DaosApiError as excep:
             print(excep)

--- a/src/tests/ftest/container/create.yaml
+++ b/src/tests/ftest/container/create.yaml
@@ -14,12 +14,8 @@ pool:
 uuids: !mux
    perfect:
      uuid:
-       - 0cf3086e-daa3-44a7-a5d4-cba9d639bf19
+       - VALID
        - PASS
-   broken:
-     uuid:
-       - NULLPTR
-       - FAIL
 poolhandle: !mux
    goodone:
        handle: VALID

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -8,7 +8,7 @@ import traceback
 import uuid
 
 from apricot import TestWithServers
-from pydaos.raw import DaosApiError, conversion
+from pydaos.raw import DaosApiError
 
 
 class ContainerDestroyTest(TestWithServers):
@@ -78,11 +78,10 @@ class ContainerDestroyTest(TestWithServers):
         else:
             poh = self.pool.pool.handle
 
+        con_uuid = None
         # Update container UUID used during destroy based on the variant.
         if change_uuid:
             con_uuid = uuid.uuid4()
-        else:
-            con_uuid = uuid.UUID(self.container.uuid)
 
         try:
             self.container.container.destroy(force=force, poh=poh, con_uuid=con_uuid)
@@ -96,10 +95,6 @@ class ContainerDestroyTest(TestWithServers):
             # here before getting to tearDown. To do so, set uuid and poh in the
             # DaosContainer instance. Then call destroy on the TestContainer instance.
             self.container.container.poh = self.pool.pool.handle
-            con_uuid = uuid.UUID(self.container.uuid)
-            # Use conversion.c_uuid() to set the correct UUID into uuid.
-            conversion.c_uuid(con_uuid, self.container.container.uuid)
-
             self.container.destroy()
 
         if expected_result == 'PASS' and not passed:

--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -43,10 +43,8 @@ class DmvrDstCreate(DataMoverTestBase):
             Create pool1.
             Create POSIX cont1 in pool1.
             Create small dataset in cont1.
-            Copy cont1 to a new cont in pool1, with a supplied UUID.
             Copy cont1 to a new cont in pool1, without a supplied UUID.
             Create pool2.
-            Copy cont1 to a new cont in pool2, with a supplied UUID.
             Copy cont1 to a new cont in pool2, without a supplied UUID.
             For each copy, very container properties and user attributes.
             Repeat, but with container type Unknown.
@@ -67,15 +65,6 @@ class DmvrDstCreate(DataMoverTestBase):
         # Create source data
         src_props = self.write_cont(cont1)
 
-        cont2_uuid = self.gen_uuid()
-        self.run_datamover(
-            self.test_id + " cont1 to cont2 (same pool) (supplied cont)",
-            "DAOS", "/", pool1, cont1,
-            "DAOS", "/", pool1, cont2_uuid)
-        cont2 = self.get_cont(pool1, cont2_uuid)
-        cont2.type.update(cont1.type.value, "type")
-        self.verify_cont(cont2, api, check_props, src_props)
-
         result = self.run_datamover(
             self.test_id + " cont1 to cont3 (same pool) (empty cont)",
             "DAOS", "/", pool1, cont1,
@@ -88,15 +77,6 @@ class DmvrDstCreate(DataMoverTestBase):
         # Create another pool
         pool2 = self.create_pool()
         pool2.connect(2)
-
-        cont4_uuid = self.gen_uuid()
-        self.run_datamover(
-            self.test_id + " cont1 to cont4 (different pool) (supplied cont)",
-            "DAOS", "/", pool1, cont1,
-            "DAOS", "/", pool2, cont4_uuid)
-        cont4 = self.get_cont(pool2, cont4_uuid)
-        cont4.type.update(cont1.type.value, "type")
-        self.verify_cont(cont4, api, check_props, src_props)
 
         result = self.run_datamover(
             self.test_id + " cont1 to cont5 (different pool) (empty cont)",
@@ -113,15 +93,6 @@ class DmvrDstCreate(DataMoverTestBase):
             posix_path = join(self.new_posix_test_path(), self.test_file)
             self.run_ior_with_params(
                 "POSIX", posix_path, flags=self.ior_flags[0])
-
-            cont6_uuid = self.gen_uuid()
-            self.run_datamover(
-                self.test_id + " posix to cont6 (supplied cont)",
-                "POSIX", posix_path, None, None,
-                "DAOS", "/", pool1, cont6_uuid)
-            cont6 = self.get_cont(pool1, cont6_uuid)
-            cont6.type.update(cont1.type.value, "type")
-            self.verify_cont(cont6, api, False)
 
             result = self.run_datamover(
                 self.test_id + " posix to cont7 (empty cont)",

--- a/src/tests/ftest/datamover/obj_large_posix.py
+++ b/src/tests/ftest/datamover/obj_large_posix.py
@@ -47,14 +47,12 @@ class DmvrObjLargePosix(DataMoverTestBase):
             "DAOS", "/", pool1, cont1,
             flags=mdtest_flags[0])
 
-        # Generate a uuid for cont2
-        cont2_uuid = self.gen_uuid()
-
         # Clone cont1 to cont2
-        self.run_datamover(
+        result = self.run_datamover(
             self.test_id + " (cont1 to cont2)",
             "DAOS", None, pool1, cont1,
-            "DAOS", None, pool1, cont2_uuid)
+            "DAOS", None, pool1, None)
+        cont2_uuid = self.parse_create_cont_uuid(result.stdout_text)
 
         # Update mdtest params, read back and verify data from cont2
         self.mdtest_cmd.read_bytes.update(file_size)

--- a/src/tests/ftest/datamover/obj_small.py
+++ b/src/tests/ftest/datamover/obj_small.py
@@ -70,14 +70,12 @@ class DmvrObjSmallTest(DataMoverTestBase):
             self.num_objs, self.num_dkeys, self.num_akeys_single,
             self.num_akeys_array, self.akey_sizes, self.akey_extents)
 
-        # Generate a uuid for cont2
-        cont2_uuid = self.gen_uuid()
-
         # Clone cont1 to a new cont2 in pool1
-        self.run_datamover(
+        result = self.run_datamover(
             self.test_id + " (cont1->cont2) (same pool)",
             "DAOS_UUID", None, pool1, cont1,
-            "DAOS_UUID", None, pool1, cont2_uuid)
+            "DAOS_UUID", None, pool1, None)
+        cont2_uuid = self.parse_create_cont_uuid(result.stdout_text)
 
         # Verify data in cont2
         cont2 = self.get_cont(pool1, cont2_uuid)
@@ -90,14 +88,12 @@ class DmvrObjSmallTest(DataMoverTestBase):
         pool2 = self.create_pool()
         pool2.connect(2)
 
-        # Generate a uuid for cont3
-        cont3_uuid = self.gen_uuid()
-
         # Clone cont1 to a new cont3 in pool2
-        self.run_datamover(
+        result = self.run_datamover(
             self.test_id + " (cont1->cont3) (different pool)",
             "DAOS_UUID", None, pool1, cont1,
-            "DAOS_UUID", None, pool2, cont3_uuid)
+            "DAOS_UUID", None, pool2, None)
+        cont3_uuid = self.parse_create_cont_uuid(result.stdout_text)
 
         # Verify data in cont3
         cont3 = self.get_cont(pool2, cont3_uuid)

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -268,9 +268,6 @@ class DaosCommandBase(CommandWithSubCommand):
                 #   --acl-file=PATH
                 #           input file containing ACL
                 self.acl_file = FormattedParameter("--acl-file={}", None)
-                #    -c, --cont=<UUID>
-                #           container UUID (optional)
-                self.cont = FormattedParameter("--cont={}")
                 #     -l, --label=<container label>
                 self.label = FormattedParameter("--label={}")
 

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1030,41 +1030,22 @@ static void
 dfs_test_compat(void **state)
 {
 	test_arg_t	*arg = *state;
-	uuid_t		uuid1;
-	uuid_t		uuid2;
+	uuid_t		uuid;
 	daos_handle_t	coh;
 	dfs_t		*dfs;
 	int		rc;
 	char		uuid_str[37];
 
-	uuid_generate(uuid1);
-	uuid_clear(uuid2);
+	uuid_clear(uuid);
 
 	if (arg->myrank != 0)
 		return;
 
-	print_message("creating DFS container with set uuid "DF_UUIDF" ...\n", DP_UUID(uuid1));
-	rc = dfs_cont_create(arg->pool.poh, uuid1, NULL, NULL, NULL);
-	assert_int_equal(rc, 0);
-	print_message("Created POSIX Container "DF_UUIDF"\n", DP_UUID(uuid1));
-	uuid_unparse(uuid1, uuid_str);
-	rc = daos_cont_open(arg->pool.poh, uuid_str, DAOS_COO_RW, &coh, NULL, NULL);
-	assert_rc_equal(rc, 0);
-	rc = dfs_mount(arg->pool.poh, coh, O_RDWR, &dfs);
-	assert_int_equal(rc, 0);
-	rc = dfs_umount(dfs);
-	assert_int_equal(rc, 0);
-	rc = daos_cont_close(coh, NULL);
-	assert_rc_equal(rc, 0);
-	rc = daos_cont_destroy(arg->pool.poh, uuid_str, 1, NULL);
-	assert_rc_equal(rc, 0);
-	print_message("Destroyed POSIX Container "DF_UUIDF"\n", DP_UUID(uuid1));
-
 	print_message("creating DFS container with a uuid pointer (not set by caller) ...\n");
-	rc = dfs_cont_create(arg->pool.poh, &uuid2, NULL, NULL, NULL);
+	rc = dfs_cont_create(arg->pool.poh, &uuid, NULL, NULL, NULL);
 	assert_int_equal(rc, 0);
-	print_message("Created POSIX Container "DF_UUIDF"\n", DP_UUID(uuid2));
-	uuid_unparse(uuid2, uuid_str);
+	print_message("Created POSIX Container "DF_UUIDF"\n", DP_UUID(uuid));
+	uuid_unparse(uuid, uuid_str);
 	rc = daos_cont_open(arg->pool.poh, uuid_str, DAOS_COO_RW, &coh, NULL, NULL);
 	assert_rc_equal(rc, 0);
 	rc = dfs_mount(arg->pool.poh, coh, O_RDWR, &dfs);
@@ -1075,7 +1056,7 @@ dfs_test_compat(void **state)
 	assert_rc_equal(rc, 0);
 	rc = daos_cont_destroy(arg->pool.poh, uuid_str, 1, NULL);
 	assert_rc_equal(rc, 0);
-	print_message("Destroyed POSIX Container "DF_UUIDF"\n", DP_UUID(uuid2));
+	print_message("Destroyed POSIX Container "DF_UUIDF"\n", DP_UUID(uuid));
 
 	print_message("creating DFS container with a NULL pointer, should fail ...\n");
 	rc = dfs_cont_create(arg->pool.poh, NULL, NULL, &coh, &dfs);

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -574,17 +574,11 @@ cont_create_hdlr(struct cmd_args_s *ap)
 		attr.da_props = ap->props;
 		attr.da_mode = ap->mode;
 
-		if (uuid_is_null(ap->c_uuid))
-			rc = dfs_cont_create(ap->pool, &ap->c_uuid, &attr, NULL, NULL);
-		else
-			rc = dfs_cont_create(ap->pool, ap->c_uuid, &attr, NULL, NULL);
+		rc = dfs_cont_create(ap->pool, &ap->c_uuid, &attr, NULL, NULL);
 		if (rc)
 			rc = daos_errno2der(rc);
 	} else {
-		if (uuid_is_null(ap->c_uuid))
-			rc = daos_cont_create(ap->pool, &ap->c_uuid, ap->props, NULL);
-		else
-			rc = daos_cont_create(ap->pool, ap->c_uuid, ap->props, NULL);
+		rc = daos_cont_create(ap->pool, &ap->c_uuid, ap->props, NULL);
 	}
 
 	if (rc != 0) {
@@ -1960,16 +1954,7 @@ dm_connect(struct cmd_args_s *ap,
 
 			if (ca->cont_layout == DAOS_PROP_CO_LAYOUT_POSIX) {
 				attr.da_props = props;
-				if (dst_cont_passed) {
-					rc = uuid_parse(ca->dst_cont, cuuid);
-					if (rc)
-						D_GOTO(err, rc);
-					rc = dfs_cont_create(ca->dst_poh, cuuid, &attr, NULL, NULL);
-				} else {
-					rc = dfs_cont_create(ca->dst_poh, &cuuid, &attr,
-							     NULL, NULL);
-					uuid_unparse(cuuid, ca->dst_cont);
-				}
+				rc = dfs_cont_create(ca->dst_poh, &cuuid, &attr, NULL, NULL);
 				if (rc != 0) {
 					rc = daos_errno2der(rc);
 					DH_PERROR_DER(ap, rc,
@@ -1977,25 +1962,14 @@ dm_connect(struct cmd_args_s *ap,
 					D_GOTO(err, rc);
 				}
 			} else {
-				if (dst_cont_passed) {
-					rc = uuid_parse(ca->dst_cont, cuuid);
-					if (rc == 0)
-						rc = daos_cont_create(ca->dst_poh, cuuid, props,
-								      NULL);
-					else
-						rc = daos_cont_create_with_label(ca->dst_poh,
-										 ca->dst_cont,
-										 props, NULL, NULL);
-				} else {
-					rc = daos_cont_create(ca->dst_poh, &cuuid, props, NULL);
-					uuid_unparse(cuuid, ca->dst_cont);
-				}
+				rc = daos_cont_create(ca->dst_poh, &cuuid, props, NULL);
 				if (rc != 0) {
 					DH_PERROR_DER(ap, rc,
 						      "failed to create destination container");
 					D_GOTO(err, rc);
 				}
 			}
+			uuid_unparse(cuuid, ca->dst_cont);
 			rc = daos_cont_open(ca->dst_poh, ca->dst_cont, DAOS_COO_RW, &ca->dst_coh,
 					    dst_cont_info, NULL);
 			if (rc != 0) {

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1398,7 +1398,6 @@ def run_daos_cmd(conf,
 
 def create_cont(conf,
                 pool=None,
-                cont=None,
                 ctype=None,
                 label=None,
                 path=None,
@@ -1420,9 +1419,6 @@ def create_cont(conf,
 
     if ctype:
         cmd.extend(['--type', ctype])
-
-    if cont:
-        cmd.extend(['--cont', cont])
 
     def _create_cont():
         """Helper function for create_cont"""
@@ -2493,9 +2489,8 @@ class posix_tests():
 
         # Create a new container within it using UNS
         uns_path = join(dfuse.dir, 'ep0')
-        uns_container = str(uuid.uuid4())
         print('Inserting entry point')
-        create_cont(conf, pool=pool, cont=uns_container, path=uns_path)
+        uns_container = create_cont(conf, pool=pool, path=uns_path)
         print(os.stat(uns_path))
         print(os.listdir(dfuse.dir))
 
@@ -2520,11 +2515,9 @@ class posix_tests():
         uns_path = join(dfuse.dir, pool, container, 'ep0', 'ep')
         second_path = join(dfuse.dir, pool, uns_container)
 
-        uns_container_2 = str(uuid.uuid4())
-
         # Make a link within the new container.
         print('Inserting entry point')
-        create_cont(conf, pool=pool, cont=uns_container_2, path=uns_path)
+        uns_container_2 = create_cont(conf, pool=pool, path=uns_path)
 
         # List the root container again.
         print(os.listdir(join(dfuse.dir, pool, container)))
@@ -2601,9 +2594,8 @@ class posix_tests():
 
         # Create a new container within it using UNS
         uns_path = join(dfuse.dir, 'ep1')
-        uns_container = str(uuid.uuid4())
         print('Inserting entry point')
-        create_cont(conf, pool=pool, cont=uns_container, path=uns_path)
+        uns_container = create_cont(conf, pool=pool, path=uns_path)
 
         print(os.stat(uns_path))
         print(os.listdir(dfuse.dir))
@@ -2753,17 +2745,18 @@ class posix_tests():
 
         # Now create a container uuid and do an object based copy.
         # The daos command will create the target container on demand.
-        container = str(uuid.uuid4())
         cmd = ['container',
                'clone',
                '--src',
                'daos://{}/{}'.format(self.pool.uuid, self.container),
                '--dst',
-               'daos://{}/{}'.format(self.pool.uuid, container)]
+               'daos://{}/'.format(self.pool.uuid)]
         rc = run_daos_cmd(self.conf, cmd)
         print(rc)
         assert rc.returncode == 0
-        destroy_container(self.conf, self.pool.id(), container)
+        lineresult = rc.stdout.decode('utf-8').splitlines()
+        assert len(lineresult) == 2
+        destroy_container(self.conf, self.pool.id(), lineresult[1][-36:])
 
 class nlt_stdout_wrapper():
     """Class for capturing stdout from threads"""


### PR DESCRIPTION
Port the changes of removing compatibility code for daos_cont_create() to 2.2.

Features: container
Test-tag: pr container dm_dst_create dm_obj_small basiccheckout_dm

Signed-off-by: Lei Huang <lei.huang@intel.com>