### PR TITLE
DAOS-9865 test: Increase tearDown() timeout for pool destroy (#8721)

### DIFF
--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -20,6 +20,7 @@ class DmgSystemReformatTest(PoolTestBase):
 
     :avocado: recursive
     """
+
     def test_dmg_system_reformat(self):
         """
         JIRA ID: DAOS-5415
@@ -50,7 +51,9 @@ class DmgSystemReformatTest(PoolTestBase):
             self.fail("Detected issues performing a system stop: {}".format(
                 self.get_dmg_command().result.stderr_text))
 
-        # Remove pools
+        # Remove pools and disable removing pools that about to be removed by formatting
+        for pool in self.pool:
+            pool.skip_cleanup()
         self.pool = []
 
         # Perform a dmg system erase to allow the dmg storage format to succeed

--- a/src/tests/ftest/daos_test/dfs.yaml
+++ b/src/tests/ftest/daos_test/dfs.yaml
@@ -65,3 +65,7 @@ daos_tests:
     test_daos_dfs_unit: 1
     test_daos_dfs_parallel: 32
     test_daos_dfs_sys: 1
+  pools_created:
+    test_daos_dfs_unit: 2
+    test_daos_dfs_parallel: 2
+    test_daos_dfs_sys: 1

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -120,3 +120,8 @@ daos_tests:
     test_rebuild_27: ["random"]
     test_rebuild_28: [7]
     test_rebuild_29: ["random"]
+  pools_created:
+    test_rebuild_0to10: 16
+    test_rebuild_12to15: 5
+    test_rebuild_18: 5
+    test_rebuild_28: 2

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -177,3 +177,13 @@ daos_tests:
   stopped_ranks:
     test_daos_degraded_mode: [5, 6, 7]
     test_daos_oid_allocator: [6, 7]
+  pools_created:
+    test_daos_management: 4
+    test_daos_pool: 9
+    test_daos_container: 17
+    test_daos_distributed_tx: 5
+    test_daos_rebuild_simple: 21
+    test_daos_drain_simple: 8
+    test_daos_extend_simple: 5
+    test_daos_rebuild_ec: 43
+    test_daos_degraded_ec: 29

--- a/src/tests/ftest/harness/advanced.py
+++ b/src/tests/ftest/harness/advanced.py
@@ -8,7 +8,8 @@ from random import choice
 from re import findall
 
 from apricot import TestWithServers
-from general_utils import run_pcmd
+from general_utils import run_pcmd, get_avocado_config_value
+from test_utils_pool import POOL_TIMEOUT_INCREMENT
 
 
 class HarnessAdvancedTest(TestWithServers):
@@ -72,8 +73,55 @@ class HarnessAdvancedTest(TestWithServers):
         This test can be run in any CI stage: vm, small, medium, large
 
         :avocado: tags=all
-        :avocado: tags=hw,small,medium,ib2,large
+        :avocado: tags=hw,small,medium,large
         :avocado: tags=harness,harness_advanced_test,core_files
         :avocado: tags=test_core_files_hw
         """
         self.test_core_files()
+
+    def test_pool_timeout(self):
+        """Test to verify tearDown() timeout setting for timed out tests.
+
+        Adding a pool should increase the runner.timeout.after_interrupted,
+        runner.timeout.process_alive, and runner.timeout.process_died timeouts by 200 seconds each.
+
+        :avocado: tags=all
+        :avocado: tags=harness,harness_advanced_test,pool_timeout
+        :avocado: tags=test_pool_timeout
+        """
+        namespace = "runner.timeout"
+        timeouts = {"after_interrupted": [], "process_alive": [], "process_died": []}
+
+        self.log.info("Before creating pools:")
+        for key in sorted(timeouts):
+            timeouts[key].append(get_avocado_config_value(namespace, key))
+            self.log.info("    %s.%s = %s", namespace, key, timeouts[key][0])
+
+        self.add_pool(create=True, connect=True)
+        self.add_pool(create=True, connect=False)
+        self.add_pool(create=False)
+
+        self.log.info("After creating pools:")
+        for key in sorted(timeouts):
+            timeouts[key].append(get_avocado_config_value(namespace, key))
+            self.log.info("    %s.%s = %s", namespace, key, timeouts[key][1])
+
+        for key in sorted(timeouts):
+            self.assertEqual(
+                int(timeouts[key][1]) - int(timeouts[key][0]), POOL_TIMEOUT_INCREMENT * 3,
+                "Incorrect {}.{} value detected after adding 3 pools".format(namespace, key))
+
+        self.log.info("Test passed")
+
+    def test_pool_timeout_hw(self):
+        """Test to verify tearDown() timeout setting for timed out tests.
+
+        Adding a pool should increase the runner.timeout.after_interrupted,
+        runner.timeout.process_alive, and runner.timeout.process_died timeouts by 200 seconds each.
+
+        :avocado: tags=all
+        :avocado: tags=hw,small,medium,large
+        :avocado: tags=harness,harness_advanced_test,pool_timeout
+        :avocado: tags=test_pool_timeout_hw
+        """
+        self.test_pool_timeout()

--- a/src/tests/ftest/harness/advanced.yaml
+++ b/src/tests/ftest/harness/advanced.yaml
@@ -3,3 +3,6 @@ hosts:
     - server-A
     - server-B
 timeout: 120
+pool:
+  size: 2G
+  control_method: dmg

--- a/src/tests/ftest/nvme/pool_exclude.py
+++ b/src/tests/ftest/nvme/pool_exclude.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -9,8 +9,7 @@ import random
 import threading
 import re
 
-from test_utils_pool import TestPool
-from test_utils_base import LabelGenerator
+from test_utils_pool import add_pool
 from osa_utils import OSAUtils
 from write_host_file import write_host_file
 
@@ -52,7 +51,6 @@ class NvmePoolExclude(OSAUtils):
                            Defaults to None
         """
         # Create a pool
-        label_generator = LabelGenerator()
         pool = {}
 
         if oclass is None:
@@ -63,11 +61,7 @@ class NvmePoolExclude(OSAUtils):
         rank_list = list(range(1, exclude_servers))
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.dmg_command,
-                label_generator=label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         for val in range(0, num_pool):

--- a/src/tests/ftest/osa/dmg_negative_test.py
+++ b/src/tests/ftest/osa/dmg_negative_test.py
@@ -5,7 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from osa_utils import OSAUtils
-from test_utils_pool import TestPool
+from test_utils_pool import add_pool
 
 
 class OSADmgNegativeTest(OSAUtils):
@@ -66,10 +66,7 @@ class OSADmgNegativeTest(OSAUtils):
         pool_uuid = []
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.dmg_command,
-                label_generator=self.label_generator)
-            pool[val].get_params(self)
+            pool[val] = add_pool(self, create=False, connect=False)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /
                                            num_pool)
@@ -99,7 +96,7 @@ class OSADmgNegativeTest(OSAUtils):
                     output = self.dmg_command.pool_extend(self.pool.uuid, rank)
                     self.log.info(output)
                     self.validate_results(expected_result, output.stdout_text)
-                if (extend is False and rank in ["4","5"]):
+                if (extend is False and rank in ["4", "5"]):
                     continue
                 # Exclude a rank, target
                 output = self.dmg_command.pool_exclude(self.pool.uuid,

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import random
 from osa_utils import OSAUtils
 from daos_utils import DaosCommand
-from test_utils_pool import TestPool
+from test_utils_pool import add_pool
 from nvme_utils import ServerFillUp
 from write_host_file import write_host_file
 
@@ -55,11 +55,7 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
         t_string = "{},{}".format(target_list[0], target_list[1])
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=self.label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             self.pool = pool[val]
             self.pool.set_property("reclaim", "disabled")
             test_seq = self.ior_test_sequence[0]

--- a/src/tests/ftest/osa/offline_extend.py
+++ b/src/tests/ftest/osa/offline_extend.py
@@ -1,13 +1,12 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from osa_utils import OSAUtils
 from daos_utils import DaosCommand
-from test_utils_pool import TestPool
-from test_utils_base import LabelGenerator
+from test_utils_pool import add_pool
 from dmg_utils import check_system_query_status
 from apricot import skipForTicket
 
@@ -45,7 +44,6 @@ class OSAOfflineExtend(OSAUtils):
             oclass (list) : list of daos object class (eg: "RP_2G8")
         """
         # Create a pool
-        label_generator = LabelGenerator()
         pool = {}
         if oclass is None:
             oclass = []
@@ -59,11 +57,7 @@ class OSAOfflineExtend(OSAUtils):
                 index = val
             else:
                 index = 0
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             self.pool = pool[val]
             test_seq = self.ior_test_sequence[0]
             self.pool.set_property("reclaim", "disabled")

--- a/src/tests/ftest/osa/offline_parallel_test.py
+++ b/src/tests/ftest/osa/offline_parallel_test.py
@@ -12,8 +12,7 @@ from osa_utils import OSAUtils
 from daos_utils import DaosCommand
 from dmg_utils import check_system_query_status
 from exception_utils import CommandFailure
-from test_utils_pool import TestPool
-from test_utils_base import LabelGenerator
+from test_utils_pool import add_pool
 from apricot import skipForTicket
 import queue
 
@@ -86,7 +85,6 @@ class OSAOfflineParallelTest(OSAUtils):
             oclass (str) : Daos object class (RP_2G1,etc)
         """
         # Create a pool
-        label_generator = LabelGenerator()
         pool = {}
         pool_uuid = []
         target_list = []
@@ -104,11 +102,7 @@ class OSAOfflineParallelTest(OSAUtils):
 
         test_seq = self.ior_test_sequence[0]
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             self.pool = pool[val]
             pool_uuid.append(self.pool.uuid)
             # Use only pool UUID while running the test.

--- a/src/tests/ftest/osa/offline_reintegration.py
+++ b/src/tests/ftest/osa/offline_reintegration.py
@@ -8,7 +8,7 @@ import random
 from osa_utils import OSAUtils
 from daos_utils import DaosCommand
 from nvme_utils import ServerFillUp
-from test_utils_pool import TestPool
+from test_utils_pool import add_pool
 from write_host_file import write_host_file
 
 
@@ -61,11 +61,7 @@ class OSAOfflineReintegration(OSAUtils, ServerFillUp):
         # Exclude ranks [0, 3, 4]
         rank = [0, 3, 4]
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=self.label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             self.pool = pool[val]
             self.pool.set_property("reclaim", "disabled")
             test_seq = self.ior_test_sequence[0]

--- a/src/tests/ftest/osa/online_extend.py
+++ b/src/tests/ftest/osa/online_extend.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import time
 import threading
 
-from test_utils_pool import TestPool
+from test_utils_pool import add_pool
 from write_host_file import write_host_file
 from daos_racer_utils import DaosRacerCommand
 from dmg_utils import check_system_query_status
@@ -77,11 +77,7 @@ class OSAOnlineExtend(OSAUtils):
             time.sleep(30)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=self.label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         # Extend the pool_uuid, rank and targets

--- a/src/tests/ftest/osa/online_reintegration.py
+++ b/src/tests/ftest/osa/online_reintegration.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -8,8 +8,7 @@ import time
 import random
 import threading
 
-from test_utils_pool import TestPool
-from test_utils_base import LabelGenerator
+from test_utils_pool import add_pool
 from write_host_file import write_host_file
 from daos_racer_utils import DaosRacerCommand
 from osa_utils import OSAUtils
@@ -71,7 +70,6 @@ class OSAOnlineReintegration(OSAUtils):
             oclass = self.ior_cmd.dfs_oclass.value
         test_seq = self.ior_test_sequence[0]
         # Create a pool
-        label_generator = LabelGenerator()
         pool = {}
         exclude_servers = (len(self.hostlist_servers) * 2) - 1
 
@@ -85,11 +83,7 @@ class OSAOnlineReintegration(OSAUtils):
             time.sleep(30)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(
-                context=self.context, dmg_command=self.get_dmg_command(),
-                label_generator=label_generator)
-            pool[val].get_params(self)
-            pool[val].create()
+            pool[val] = add_pool(self, connect=False)
             pool[val].set_property("reclaim", "disabled")
 
         # Exclude and reintegrate the pool_uuid, rank and targets

--- a/src/tests/ftest/pool/evict.py
+++ b/src/tests/ftest/pool/evict.py
@@ -215,6 +215,7 @@ class EvictTests(TestWithServers):
 
             # 10. Check that we were able to obtain the UUID of the non-evicted pools.
             if pool_info:
+                pool.connected = False
                 if c_uuid_to_str(pool_info.pi_uuid) == pool.uuid:
                     self.log.info(
                         "Pool # %d UUID matches pool_info.pi_uuid %s", index, pool.uuid)

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -68,9 +68,9 @@ unset OFI_INTERFACE
 # shellcheck disable=SC2153
 export D_LOG_FILE="$TEST_TAG_DIR/daos.log"
 
-# The dmg pool destroy can take up to 3 minutes to timeout.  To help ensure
-# that the avocado test tearDown method is run long enough to account for this
-# use a 240 second timeout when running tearDown after the test has timed out.
+# Give the avocado test tearDown method a minimum of 120 seconds to complete when the test process
+# has timed out.  The test harness will increment this timeout based upon the number of pools
+# created in the test to account for pool destroy command timeouts.
 mkdir -p ~/.config/avocado/
 cat <<EOF > ~/.config/avocado/avocado.conf
 [datadir.paths]
@@ -81,7 +81,9 @@ data_dir = $logs_prefix/ftest/avocado/data
 loglevel = DEBUG
 
 [runner.timeout]
-process_died = 240
+after_interrupted = 120
+process_alive = 120
+process_died = 120
 
 [sysinfo.collectibles]
 files = \$HOME/.config/avocado/sysinfo/files

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -18,6 +18,7 @@ class DaosServerTest(TestWithServers):
 
     :avocado: recursive
     """
+
     @fail_on(ServerFailed)
     @fail_on(CommandFailure)
     def restart_daos_server(self, force=True):
@@ -32,6 +33,8 @@ class DaosServerTest(TestWithServers):
         self.server_managers[0].prepare()
         self.log.info("=Restart daos_server, detect_format_ready().")
         self.server_managers[0].detect_format_ready()
+        for pool in self.pool:
+            pool.skip_cleanup()
         self.log.info("=Restart daos_server, dmg storage_format.")
         self.server_managers[0].dmg.storage_format(force)
         self.log.info("=Restart daos_server, detect_engine_start().")
@@ -107,7 +110,6 @@ class DaosServerTest(TestWithServers):
         self.log.info("(5)Verify after server restarted.")
         self.verify_pool_list()
 
-        self.pool = None
         self.container = None
 
     def test_engine_restart(self):

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -26,13 +26,13 @@ from distro_utils import detect
 from dmg_utils import get_dmg_command
 from fault_config_utils import FaultInjection
 from general_utils import \
-    get_partition_hosts, stop_processes, \
-    get_default_config_file, pcmd, get_file_listing, DaosTestError, run_command
+    get_partition_hosts, stop_processes, get_default_config_file, pcmd, get_file_listing, \
+    DaosTestError, run_command, get_avocado_config_value, set_avocado_config_value
 from logger_utils import TestLogger
 from pydaos.raw import DaosContext, DaosLog, DaosApiError
 from server_utils import DaosServerManager
 from test_utils_container import TestContainer
-from test_utils_pool import TestPool, LabelGenerator
+from test_utils_pool import LabelGenerator, add_pool, POOL_NAMESPACE
 from write_host_file import write_host_file
 from job_manager_utils import get_job_manager
 
@@ -128,6 +128,10 @@ class Test(avocadoTest):
         self.prefix = None
         self.ofi_prefix = None
         self.cancel_file = os.path.join(os.sep, "scratch", "CI-skip-list-release-2.2")
+
+        # List of methods to call during tearDown to cleanup after the steps
+        # Use the register_cleanup() method to add methods with optional arguments
+        self._cleanup_methods = []
 
         # Current CI stage name
         self._stage_name = os.environ.get("STAGE_NAME", None)
@@ -395,6 +399,61 @@ class Test(avocadoTest):
         except DaosTestError as error:
             errors.append("Error removing temporary test files: {}".format(error))
         return errors
+
+    def _cleanup(self):
+        """Run all the the cleanup methods from last to first.
+
+        Returns:
+            list: a list of error strings to report at the end of tearDown().
+
+        """
+        errors = []
+        while self._cleanup_methods:
+            try:
+                cleanup = self._cleanup_methods.pop()
+                errors.extend(cleanup["method"](**cleanup["kwargs"]))
+            except Exception as error:      # pylint: disable=broad-except
+                kwargs_str = ", ".join(
+                    ["=".join([str(key), str(value)]) for key, value in cleanup["kwargs"].items()])
+                errors.append(
+                    "Unhandled exception when calling {}({}): {}".format(
+                        str(cleanup["method"]), kwargs_str, str(error)))
+        return errors
+
+    def register_cleanup(self, method, **kwargs):
+        """Add a method call to the list of cleanup methods to run in tearDown().
+
+        Args:
+            method (str): method to call with the kwargs
+        """
+        self._cleanup_methods.append({"method": method, "kwargs": kwargs})
+        kwargs_str = ", ".join(["=".join([str(key), str(value)]) for key, value in kwargs.items()])
+        self.log.debug("Register: Adding calling %s(%s) during tearDown()", method, kwargs_str)
+
+    def increment_timeout(self, increment):
+        """Increase the avocado runner timeout configuration settings by the provided value.
+
+        Increase the various runner timeout configuration values to ensure tearDown is given enough
+        time to perform all of its steps.
+
+        Args:
+            increment (int): number of additional seconds by which to increase the timeout.
+        """
+        namespace = "runner.timeout"
+        for key in ("after_interrupted", "process_alive", "process_died"):
+            section = ".".join([namespace, key])
+
+            # Get the existing value
+            try:
+                value = int(get_avocado_config_value(namespace, key))
+            except (TypeError, ValueError) as error:
+                self.log.debug("Unable to obtain the %s setting: %s", section, str(error))
+                continue
+
+            # Update the setting with the incremented value
+            self.log.debug(
+                "Incrementing %s from %s to %s seconds", section, value, value + increment)
+            set_avocado_config_value(namespace, key, value + increment)
 
     def tearDown(self):
         """Tear down after each test case."""
@@ -1276,8 +1335,8 @@ class TestWithServers(TestWithoutServers):
         # Destroy any containers first
         self._teardown_errors.extend(self.destroy_containers(self.container))
 
-        # Destroy any pools next
-        self._teardown_errors.extend(self.destroy_pools(self.pool))
+        # Destroy any pools next - eventually this call will encompass all teardown steps
+        self._teardown_errors.extend(self._cleanup())
 
         # Stop the agents
         self._teardown_errors.extend(self.stop_agents())
@@ -1593,16 +1652,16 @@ class TestWithServers(TestWithoutServers):
 
         This sequence is common for a lot of the container tests.
         """
-        self.add_pool(None, True, True, 0)
+        self.add_pool(POOL_NAMESPACE, True, True, 0)
 
-    def get_pool(self, namespace=None, create=True, connect=True, index=0):
+    def get_pool(self, namespace=POOL_NAMESPACE, create=True, connect=True, index=0, **params):
         """Get a test pool object.
 
         This method defines the common test pool creation sequence.
 
         Args:
             namespace (str, optional): namespace for TestPool parameters in the
-                test yaml file. Defaults to None.
+                test yaml file. Defaults to POOL_NAMESPACE.
             create (bool, optional): should the pool be created. Defaults to
                 True.
             connect (bool, optional): should the pool be connected. Defaults to
@@ -1613,37 +1672,25 @@ class TestWithServers(TestWithoutServers):
             TestPool: the created test pool object.
 
         """
-        pool = TestPool(
-            context=self.context, dmg_command=self.get_dmg_command(index),
-            label_generator=self.label_generator,
-            crt_timeout=self.server_managers[index].get_config_value("crt_timeout"))
-        if namespace is not None:
-            pool.namespace = namespace
-        pool.get_params(self)
-        if create:
-            pool.create()
-        if create and connect:
-            pool.connect()
-        return pool
+        return add_pool(self, namespace, create, connect, index, **params)
 
-    def add_pool(self, namespace=None, create=True, connect=True, index=0):
+    def add_pool(self, namespace=POOL_NAMESPACE, create=True, connect=True, index=0, **params):
         """Add a pool to the test case.
 
         This method defines the common test pool creation sequence.
 
         Args:
             namespace (str, optional): namespace for TestPool parameters in the
-                test yaml file. Defaults to None.
+                test yaml file. Defaults to POOL_NAMESPACE.
             create (bool, optional): should the pool be created. Defaults to
                 True.
             connect (bool, optional): should the pool be connected. Defaults to
                 True.
             index (int, optional): Server index for dmg command. Defaults to 0.
         """
-        self.pool = self.get_pool(namespace, create, connect, index)
+        self.pool = self.get_pool(namespace, create, connect, index, **params)
 
-    def add_pool_qty(self, quantity, namespace=None, create=True, connect=True,
-                     index=0):
+    def add_pool_qty(self, quantity, namespace=POOL_NAMESPACE, create=True, connect=True, index=0):
         """Add multiple pools to the test case.
 
         This method requires self.pool to be defined as a list.  If self.pool is
@@ -1652,7 +1699,7 @@ class TestWithServers(TestWithoutServers):
         Args:
             quantity (int): number of pools to create
             namespace (str, optional): namespace for TestPool parameters in the
-                test yaml file. Defaults to None.
+                test yaml file. Defaults to POOL_NAMESPACE.
             create (bool, optional): should the pool be created. Defaults to
                 True.
             connect (bool, optional): should the pool be connected. Defaults to
@@ -1666,9 +1713,7 @@ class TestWithServers(TestWithoutServers):
         if self.pool is None:
             self.pool = []
         if not isinstance(self.pool, list):
-            self.fail(
-                "add_pool_qty(): self.pool must be a list: {}".format(
-                    type(self.pool)))
+            self.fail("add_pool_qty(): self.pool must be a list: {}".format(type(self.pool)))
         for _ in range(quantity):
             self.pool.append(self.get_pool(namespace, create, connect, index))
 

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -302,6 +302,14 @@ class ObjectWithParameters():
         for name in self.get_param_names():
             getattr(self, name).get_yaml_value(name, test, self.namespace)
 
+    def update_params(self, **params):
+        """Update each of provided parameter name and value pairs."""
+        for name, value in params.items():
+            try:
+                getattr(self, name).update(value, name)
+            except AttributeError as error:
+                raise CommandFailure("Unknown parameter: {}".format(name)) from error
+
 
 class CommandWithParameters(ObjectWithParameters):
     """A class for command with parameters."""
@@ -661,6 +669,7 @@ class EnvironmentVariables(dict):
             export_str = "".join([export_str, separator])
         return export_str
 
+
 class PositionalParameter(BasicParameter):
     """Parameter that defines position.
 
@@ -681,9 +690,7 @@ class PositionalParameter(BasicParameter):
 
     @property
     def position(self):
-        """Position property that defines the position of the parameter.
-
-        """
+        """Position property that defines the position of the parameter."""
         return self._position
 
     def __lt__(self, other):
@@ -703,6 +710,7 @@ class PositionalParameter(BasicParameter):
 
         """
         return self.position
+
 
 class CommandWithPositionalParameters(CommandWithParameters):
     """Command that uses positional parameters.

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -16,6 +16,7 @@ from command_utils import ExecutableCommand
 from exception_utils import CommandFailure
 from agent_utils import include_local_host
 from job_manager_utils import get_job_manager
+from test_utils_pool import POOL_TIMEOUT_INCREMENT
 
 
 class DaosCoreBase(TestWithServers):
@@ -115,6 +116,8 @@ class DaosCoreBase(TestWithServers):
         nvme_size = self.params.get("nvme_size", '/run/pool/*')
         args = self.get_test_param("args", "")
         stopped_ranks = self.get_test_param("stopped_ranks", [])
+        pools_created = self.get_test_param("pools_created", 1)
+        self.increment_timeout(POOL_TIMEOUT_INCREMENT * pools_created)
         dmg = self.get_dmg_command()
         dmg_config_file = dmg.yaml.filename
         if self.hostlist_clients:

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -19,6 +19,8 @@ from getpass import getuser
 from importlib import import_module
 from socket import gethostname
 
+from avocado.core.settings import settings
+from avocado.core.version import MAJOR
 from avocado.utils import process
 from ClusterShell.Task import task_self
 from ClusterShell.NodeSet import NodeSet, NodeSetParseError
@@ -1397,8 +1399,12 @@ def get_primary_group(user=None):
     """
     if user is None:
         user = getuser()
-    gid = pwd.getpwnam(user).pw_gid
-    return grp.getgrgid(gid).gr_name
+    try:
+        gid = pwd.getpwnam(user).pw_gid
+        return grp.getgrgid(gid).gr_name
+    except KeyError:
+        # User may not exist on this host, e.g. daos_server, so just return the user name
+        return user
 
 
 def get_journalctl(hosts, since, until, journalctl_type):
@@ -1422,3 +1428,34 @@ def get_journalctl(hosts, since, until, journalctl_type):
     results = get_host_data(hosts=hosts, command=command, text="journalctl", error=err)
 
     return results
+
+
+def get_avocado_config_value(section, key):
+    """Get an avocado configuration value.
+
+    Args:
+        section (str): the configuration section, e.g. 'runner.timeout'
+        key (str): the configuration key, e.g. 'process_died'
+
+    Returns:
+        object: the value of the requested config key in the specified section
+
+    """
+    if int(MAJOR) >= 82:
+        config = settings.as_dict()
+        return config.get(".".join([section, key]))
+    return settings.get_value(section, key)     # pylint: disable=no-member
+
+
+def set_avocado_config_value(section, key, value):
+    """Set an avocado configuration value.
+
+    Args:
+        section (str): the configuration section, e.g. 'runner.timeout'
+        key (str): the configuration key, e.g. 'process_died'
+        value (object): the value to set
+    """
+    if int(MAJOR) >= 82:
+        settings.update_option(".".join([section, key]), value)
+    else:
+        settings.config.set(section, key, str(value))

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -10,7 +10,7 @@ import ctypes
 import json
 
 from test_utils_base import TestDaosApiBase, LabelGenerator
-from avocado import fail_on
+from avocado import fail_on, TestFail
 from command_utils import BasicParameter
 from exception_utils import CommandFailure
 from pydaos.raw import (DaosApiError, DaosPool, c_uuid_to_str, daos_cref)
@@ -18,13 +18,84 @@ from general_utils import check_pool_files, DaosTestError
 from server_utils_base import ServerFailed, AutosizeCancel
 from dmg_utils import DmgCommand
 
+POOL_NAMESPACE = "/run/pool/*"
+POOL_TIMEOUT_INCREMENT = 200
+
+
+def add_pool(test, namespace=POOL_NAMESPACE, create=True, connect=True, index=0, **params):
+    """Add a new TestPool object to the test.
+
+    Args:
+        test (Test): the test to which the pool will be added
+        namespace (str, optional): TestPool parameters path in the test yaml file. Defaults to
+            POOL_NAMESPACE.
+        create (bool, optional): should the pool be created. Defaults to True.
+        connect (bool, optional): should the pool be connected. Defaults to True.
+        index (int, optional): Server index for dmg command. Defaults to 0.
+
+    Returns:
+        TestPool: the new pool object
+
+    """
+    pool = TestPool(
+        namespace=namespace, context=test.context, dmg_command=test.get_dmg_command(index),
+        label_generator=test.label_generator)
+    pool.get_params(test)
+    if params:
+        pool.update_params(**params)
+    if create:
+        pool.create()
+    if create and connect:
+        pool.connect()
+
+    # Add a step to remove this pool when the test completes and ensure their is enough time for the
+    # pool destroy to be attempted - accounting for a possible dmg command timeout
+    test.increment_timeout(POOL_TIMEOUT_INCREMENT)
+    test.register_cleanup(remove_pool, test=test, pool=pool)
+
+    return pool
+
+
+def remove_pool(test, pool):
+    """Remove the requested pool from the test.
+
+    Args:
+        test (Test): the test from which to destroy the pool
+        pool (TestPool): the pool to destroy
+
+    Returns:
+        list: a list of any errors detected when removing the pool
+
+    """
+    error_list = []
+    test.test_log.info("Destroying pool %s", pool.identifier)
+
+    # Ensure exceptions are raised for any failed command
+    exit_status_exception = None
+    if pool.dmg is not None:
+        exit_status_exception = pool.dmg.exit_status_exception
+        pool.dmg.exit_status_exception = True
+
+    # Attempt to destroy the pool
+    try:
+        pool.destroy(force=1, disconnect=1)
+    except (DaosApiError, TestFail) as error:
+        test.test_log.info("  {}".format(error))
+        error_list.append("Error destroying pool {}: {}".format(pool.identifier, error))
+
+    # Restore raising exceptions for any failed command
+    if exit_status_exception is False:
+        pool.dmg.exit_status_exception = exit_status_exception
+
+    return error_list
+
 
 class TestPool(TestDaosApiBase):
     # pylint: disable=too-many-public-methods
     """A class for functional testing of DaosPools objects."""
 
     def __init__(self, context, dmg_command, cb_handler=None,
-                 label_generator=None, crt_timeout=None):
+                 label_generator=None, crt_timeout=None, namespace=POOL_NAMESPACE):
         # pylint: disable=unused-argument
         """Initialize a TestPool object.
 
@@ -44,8 +115,9 @@ class TestPool(TestDaosApiBase):
                 provided in order to call create(). Defaults to None.
             crt_timeout (str, optional): value to use for the CRT_TIMEOUT when running pydaos
                 commands. Defaults to None.
+            namespace (str, optional): path to test yaml parameters. Defaults to POOL_NAMESPACE.
         """
-        super().__init__("/run/pool/*", cb_handler, crt_timeout)
+        super().__init__(namespace, cb_handler, crt_timeout)
         self.context = context
         self.uid = os.geteuid()
         self.gid = os.getegid()
@@ -147,10 +219,12 @@ class TestPool(TestDaosApiBase):
             str: pool UUID
 
         """
-        uuid = None
-        if self.pool and self.pool.uuid:
-            uuid = self.pool.get_uuid_str()
-        return uuid
+        try:
+            return self.pool.get_uuid_str()
+        except AttributeError:
+            return None
+        except IndexError:
+            return self.pool.uuid
 
     @uuid.setter
     def uuid(self, value):
@@ -200,6 +274,15 @@ class TestPool(TestDaosApiBase):
         if not isinstance(value, DmgCommand):
             raise TypeError("Invalid 'dmg' object type: {}".format(type(value)))
         self._dmg = value
+
+    def skip_cleanup(self):
+        """Prevent pool from being removed during cleanup.
+
+        Useful for corner case tests where the pool no longer exists due to a storage format.
+        """
+        self.connected = False
+        if self.pool:
+            self.pool.attached = False
 
     @fail_on(CommandFailure)
     @fail_on(DaosApiError)
@@ -398,10 +481,11 @@ class TestPool(TestDaosApiBase):
     def evict(self):
         """Evict all pool connections to a DAOS pool."""
         if self.pool:
-            self.log.info(
-                "Evict all pool connections for pool: %s", self.identifier)
-
-            self.dmg.pool_evict(self.identifier)
+            self.log.info("Evict all pool connections for pool: %s", self.identifier)
+            try:
+                self.dmg.pool_evict(self.identifier)
+            finally:
+                self.connected = False
 
     @fail_on(DaosApiError)
     def get_info(self):
@@ -610,7 +694,8 @@ class TestPool(TestDaosApiBase):
             verbose (bool, optional): whether to display the rebuild data. Defaults to True.
 
         Returns:
-            [type]: [description]
+            str: the rebuild state
+
         """
         self.set_query_data()
         try:


### PR DESCRIPTION
Dynamically increase the avocado runner.timeout.* values by 200 seconds
for each pool created in the test to allow for enough time for each pool
destroy during test cleanup when the test times out.

Skip-func-test-el7: false
Skip-func-test-leap15: false
Skip-unit-tests: true
Test-tag: pr daily_regression pool_timeout osa,-offline_drain_with_less_pool_space,-offline_reintegrate_with_less_pool_space
Allow-unstable-test: true

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>