### PR TITLE
DAOS-7652 dfuse: Allow True/False for dfuse cache settings.

### DIFF
--- a/docs/user/filesystem.md
+++ b/docs/user/filesystem.md
@@ -289,27 +289,27 @@ To selectively control caching within a container the following container
 attributes should be used, if any attribute is set then the rest are assumed
 to be set to 0 or off, except dentry-dir-time which defaults to dentry-time
 
-| **Attribute name**    | **Description**                                                  |
-| --------------------- | ---------------------------------------------------------------- |
-| dfuse-attr-time       | How long file attributes are cached                              |
-| dfuse-dentry-time     | How long directory entries are cached                            |
-| dfuse-dentry-dir-time | How long dentries are cached, if the entry is itself a directory |
-| dfuse-ndentry-time    | How long negative dentries are cached                            |
-| dfuse-data-cache      | Data caching enabled for this file ("on"/"off")                  |
-| dfuse-direct-io-disable | Force use of page cache for this container ("on"/"off")        |
+| **Attribute name**      | **Description**                                                        |
+| ----------------------- | ---------------------------------------------------------------------- |
+| dfuse-attr-time         | How long file attributes are cached                                    |
+| dfuse-dentry-time       | How long directory entries are cached                                  |
+| dfuse-dentry-dir-time   | How long dentries are cached, if the entry is itself a directory       |
+| dfuse-ndentry-time      | How long negative dentries are cached                                  |
+| dfuse-data-cache        | Data caching enabled for this file ("on"/"true"/"off"/"false")         |
+| dfuse-direct-io-disable | Force use of page cache for this container ("on"/"true"/"off"/"false") |
 
 For metadata caching attributes specify the duration that the cache should be
 valid for, specified in seconds or with a 's', 'm', 'h' or 'd' suffix for seconds,
 minutes, hours or days.
 
-dfuse-data-cache should be set to "on", or "off" if set, any other value will
+dfuse-data-cache should be set to "on", "true", "off" or "false" if set, other values will
 log an error, and result in the cache being off.  The O\_DIRECT flag for open
 files will be honoured with this option enabled, files which do not set
 O\_DIRECT will be cached.
 
 dfuse-direct-io-disable will enable data caching, similar to dfuse-data-cache,
-however if this is set to "on" then the O\_DIRECT flag will be ignored, and all
-files will use the page cache.  This default value for this is "off".
+however if this is enabled then the O\_DIRECT flag will be ignored, and all
+files will use the page cache.  This default value for this is disabled.
 
 With no options specified attr and dentry timeouts will be 1 second, dentry-dir
 and ndentry timeouts will be 5 seconds, and data caching will be enabled.

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -560,6 +560,26 @@ cont_attr_names[ATTR_COUNT] = {"dfuse-attr-time",
  */
 #define ATTR_VALUE_LEN 128
 
+static bool
+dfuse_char_enabled(char *addr, size_t len)
+{
+	if (strncasecmp(addr, "on", len) == 0)
+		return true;
+	if (strncasecmp(addr, "true", len) == 0)
+		return true;
+	return false;
+}
+
+static bool
+dfuse_char_disabled(char *addr, size_t len)
+{
+	if (strncasecmp(addr, "off", len) == 0)
+		return true;
+	if (strncasecmp(addr, "false", len) == 0)
+		return true;
+	return false;
+}
+
 /* Setup caching attributes for a container.
  *
  * These are read from pool attributes, or can be overwritten on the command
@@ -572,16 +592,16 @@ cont_attr_names[ATTR_COUNT] = {"dfuse-attr-time",
 static int
 dfuse_cont_get_cache(struct dfuse_cont *dfc)
 {
-	size_t		sizes[ATTR_COUNT];
-	char		*buff;
-	char		*buff_addrs[ATTR_COUNT];
-	int		rc;
-	int		i;
-	unsigned int	value;
-	bool		have_dentry = false;
-	bool		have_dentry_dir = false;
-	bool		have_dio = false;
-	bool		have_cache_off = false;
+	size_t       sizes[ATTR_COUNT];
+	char        *buff;
+	char        *buff_addrs[ATTR_COUNT];
+	int          rc;
+	int          i;
+	unsigned int value;
+	bool         have_dentry     = false;
+	bool         have_dentry_dir = false;
+	bool         have_dio        = false;
+	bool         have_cache_off  = false;
 
 	D_ALLOC(buff, ATTR_VALUE_LEN * ATTR_COUNT);
 
@@ -600,8 +620,8 @@ dfuse_cont_get_cache(struct dfuse_cont *dfc)
 		/* none of the cache related attrs are present */
 		D_GOTO(out, rc = ENODATA);
 	} else if (rc != -DER_SUCCESS) {
-		DFUSE_TRA_WARNING(dfc, "Failed to load values for all cache "
-				  "related attrs" DF_RC, DP_RC(rc));
+		DFUSE_TRA_WARNING(dfc, "Failed to load values for all cache related attrs" DF_RC,
+				  DP_RC(rc));
 		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 
@@ -622,46 +642,43 @@ dfuse_cont_get_cache(struct dfuse_cont *dfc)
 			*(buff_addrs[i] + sizes[i]) = '\0';
 
 		if (i == ATTR_DATA_CACHE_INDEX) {
-			if (strncmp(buff_addrs[i], "on", sizes[i]) == 0) {
+			if (dfuse_char_enabled(buff_addrs[i], sizes[i])) {
 				dfc->dfc_data_caching = true;
-			} else if (strncmp(buff_addrs[i], "off",
-				   sizes[i]) == 0) {
+				DFUSE_TRA_INFO(dfc, "setting '%s' is enabled", cont_attr_names[i]);
+			} else if (dfuse_char_disabled(buff_addrs[i], sizes[i])) {
 				have_cache_off = true;
 				dfc->dfc_data_caching = false;
+				DFUSE_TRA_INFO(dfc, "setting '%s' is disabled", cont_attr_names[i]);
 			} else {
-				DFUSE_TRA_WARNING(dfc,
-						  "Failed to parse '%s' for '%s'",
-						  buff_addrs[i],
-						  cont_attr_names[i]);
+				DFUSE_TRA_WARNING(dfc, "Failed to parse '%s' for '%s'",
+						  buff_addrs[i], cont_attr_names[i]);
 				dfc->dfc_data_caching = false;
 			}
 			continue;
 		}
 		if (i == ATTR_DIRECT_IO_DISABLE_INDEX) {
-			if (strncmp(buff_addrs[i], "on", sizes[i]) == 0) {
+			if (dfuse_char_enabled(buff_addrs[i], sizes[i])) {
 				have_dio = true;
 				dfc->dfc_direct_io_disable = true;
-			} else if (strncmp(buff_addrs[i], "off",
-				   sizes[i]) == 0) {
+				DFUSE_TRA_INFO(dfc, "setting '%s' is enabled", cont_attr_names[i]);
+			} else if (dfuse_char_disabled(buff_addrs[i], sizes[i])) {
 				dfc->dfc_direct_io_disable = false;
+				DFUSE_TRA_INFO(dfc, "setting '%s' is disabled", cont_attr_names[i]);
 			} else {
-				DFUSE_TRA_WARNING(dfc,
-						  "Failed to parse '%s' for '%s'",
-						  buff_addrs[i],
-						  cont_attr_names[i]);
-				dfc->dfc_data_caching = false;
+				DFUSE_TRA_WARNING(dfc, "Failed to parse '%s' for '%s'",
+						  buff_addrs[i], cont_attr_names[i]);
+				dfc->dfc_direct_io_disable = false;
 			}
 			continue;
 		}
 
 		rc = dfuse_parse_time(buff_addrs[i], sizes[i], &value);
 		if (rc != 0) {
-			DFUSE_TRA_WARNING(dfc, "Failed to parse '%s' for '%s'",
-					  buff_addrs[i], cont_attr_names[i]);
+			DFUSE_TRA_WARNING(dfc, "Failed to parse '%s' for '%s'", buff_addrs[i],
+					  cont_attr_names[i]);
 			continue;
 		}
-		DFUSE_TRA_INFO(dfc, "setting '%s' is %u",
-			       cont_attr_names[i], value);
+		DFUSE_TRA_INFO(dfc, "setting '%s' is %u seconds", cont_attr_names[i], value);
 		if (i == ATTR_TIME_INDEX) {
 			dfc->dfc_attr_timeout = value;
 		} else if (i == ATTR_DENTRY_INDEX) {

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -540,25 +540,21 @@ err:
 
 #define ATTR_COUNT 6
 
-char const *const
-cont_attr_names[ATTR_COUNT] = {"dfuse-attr-time",
-			       "dfuse-dentry-time",
-			       "dfuse-dentry-dir-time",
-			       "dfuse-ndentry-time",
-			       "dfuse-data-cache",
-			       "dfuse-direct-io-disable"};
+char const *const cont_attr_names[ATTR_COUNT] = {
+    "dfuse-attr-time",    "dfuse-dentry-time", "dfuse-dentry-dir-time",
+    "dfuse-ndentry-time", "dfuse-data-cache",  "dfuse-direct-io-disable"};
 
-#define ATTR_TIME_INDEX		0
-#define ATTR_DENTRY_INDEX	1
-#define ATTR_DENTRY_DIR_INDEX	2
-#define ATTR_NDENTRY_INDEX	3
-#define ATTR_DATA_CACHE_INDEX	4
-#define ATTR_DIRECT_IO_DISABLE_INDEX	5
+#define ATTR_TIME_INDEX              0
+#define ATTR_DENTRY_INDEX            1
+#define ATTR_DENTRY_DIR_INDEX        2
+#define ATTR_NDENTRY_INDEX           3
+#define ATTR_DATA_CACHE_INDEX        4
+#define ATTR_DIRECT_IO_DISABLE_INDEX 5
 
 /* Attribute values are of the form "120M", so the buffer does not need to be
  * large.
  */
-#define ATTR_VALUE_LEN 128
+#define ATTR_VALUE_LEN               128
 
 static bool
 dfuse_char_enabled(char *addr, size_t len)
@@ -609,12 +605,12 @@ dfuse_cont_get_cache(struct dfuse_cont *dfc)
 		return ENOMEM;
 
 	for (i = 0; i < ATTR_COUNT; i++) {
-		sizes[i] = ATTR_VALUE_LEN - 1;
+		sizes[i]      = ATTR_VALUE_LEN - 1;
 		buff_addrs[i] = buff + i * ATTR_VALUE_LEN;
 	}
 
 	rc = daos_cont_get_attr(dfc->dfs_coh, ATTR_COUNT, cont_attr_names,
-				(void * const*)buff_addrs, sizes, NULL);
+				(void *const *)buff_addrs, sizes, NULL);
 
 	if (rc == -DER_NONEXIST) {
 		/* none of the cache related attrs are present */
@@ -646,7 +642,7 @@ dfuse_cont_get_cache(struct dfuse_cont *dfc)
 				dfc->dfc_data_caching = true;
 				DFUSE_TRA_INFO(dfc, "setting '%s' is enabled", cont_attr_names[i]);
 			} else if (dfuse_char_disabled(buff_addrs[i], sizes[i])) {
-				have_cache_off = true;
+				have_cache_off        = true;
 				dfc->dfc_data_caching = false;
 				DFUSE_TRA_INFO(dfc, "setting '%s' is disabled", cont_attr_names[i]);
 			} else {
@@ -658,7 +654,7 @@ dfuse_cont_get_cache(struct dfuse_cont *dfc)
 		}
 		if (i == ATTR_DIRECT_IO_DISABLE_INDEX) {
 			if (dfuse_char_enabled(buff_addrs[i], sizes[i])) {
-				have_dio = true;
+				have_dio                   = true;
 				dfc->dfc_direct_io_disable = true;
 				DFUSE_TRA_INFO(dfc, "setting '%s' is enabled", cont_attr_names[i]);
 			} else if (dfuse_char_disabled(buff_addrs[i], sizes[i])) {
@@ -682,10 +678,10 @@ dfuse_cont_get_cache(struct dfuse_cont *dfc)
 		if (i == ATTR_TIME_INDEX) {
 			dfc->dfc_attr_timeout = value;
 		} else if (i == ATTR_DENTRY_INDEX) {
-			have_dentry = true;
+			have_dentry             = true;
 			dfc->dfc_dentry_timeout = value;
 		} else if (i == ATTR_DENTRY_DIR_INDEX) {
-			have_dentry_dir = true;
+			have_dentry_dir             = true;
 			dfc->dfc_dentry_dir_timeout = value;
 		} else if (i == ATTR_NDENTRY_INDEX) {
 			dfc->dfc_ndentry_timeout = value;
@@ -728,12 +724,12 @@ out:
 void
 dfuse_set_default_cont_cache_values(struct dfuse_cont *dfc)
 {
-	dfc->dfc_attr_timeout = 1;
-	dfc->dfc_dentry_timeout = 1;
+	dfc->dfc_attr_timeout       = 1;
+	dfc->dfc_dentry_timeout     = 1;
 	dfc->dfc_dentry_dir_timeout = 5;
-	dfc->dfc_ndentry_timeout = 1;
-	dfc->dfc_data_caching = true;
-	dfc->dfc_direct_io_disable = false;
+	dfc->dfc_ndentry_timeout    = 1;
+	dfc->dfc_data_caching       = true;
+	dfc->dfc_direct_io_disable  = false;
 }
 
 /* Open a cont by label.

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -761,7 +761,10 @@ class DaosServer():
         ret = self._agent.wait(timeout=5)
         print(f'rc from agent is {ret}')
         self._agent = None
-        os.unlink(join(self.agent_dir, 'daos_agent.sock'))
+        try:
+            os.unlink(join(self.agent_dir, 'daos_agent.sock'))
+        except FileNotFoundError:
+            pass
 
     def stop(self, wf):
         """Stop a previously started DAOS server"""

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -3366,21 +3366,23 @@ def run_in_fg(server, conf):
     if not container:
         container = create_cont(conf, pool.uuid, label=label, ctype="POSIX")
 
+        # Only set the container cache attributes when the container is initially created so they
+        # can be modified later.
+        cont_attrs = OrderedDict()
+        cont_attrs['dfuse-data-cache'] = False
+        cont_attrs['dfuse-attr-time'] = 60
+        cont_attrs['dfuse-dentry-time'] = 60
+        cont_attrs['dfuse-ndentry-time'] = 60
+        cont_attrs['dfuse-direct-io-disable'] = False
+
+        for key, value in cont_attrs.items():
+            run_daos_cmd(conf, ['container', 'set-attr', pool.label, container,
+                                '--attr', key, '--value', str(value)],
+                         show_stdout=True)
+
     dfuse = DFuse(server, conf, pool=pool.uuid, caching=True, wbcache=False)
     dfuse.log_flush = True
     dfuse.start()
-
-    cont_attrs = OrderedDict()
-    cont_attrs['dfuse-data-cache'] = False
-    cont_attrs['dfuse-attr-time'] = 60
-    cont_attrs['dfuse-dentry-time'] = 60
-    cont_attrs['dfuse-ndentry-time'] = 60
-    cont_attrs['dfuse-direct-io-disable'] = False
-
-    for key, value in cont_attrs.items():
-        run_daos_cmd(conf, ['container', 'set-attr', pool.label, container,
-                            '--attr', key, '--value', str(value)],
-                     show_stdout=True)
 
     t_dir = join(dfuse.dir, container)
 


### PR DESCRIPTION
Allow True/False as well as on/off and ignore case for dfuse
cache attributes.
Ensure all attribute settings are logged.
Correct an error when an invalid setting was used for direct-io-disable.

This makes it more user friendly, as well as allowing Python True/False
values to be set without translating into on/off.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
