### PR TITLE
DAOS-9873 test: Fix more pool tests (#9322)

### DIFF
--- a/src/tests/ftest/pool/dynamic_server_pool.py
+++ b/src/tests/ftest/pool/dynamic_server_pool.py
@@ -55,15 +55,13 @@ class DynamicServerPool(TestWithServers):
             uuid_to_ranks (str to list of int dictionary): UUID to rank list
                 dictionary.
         """
-        RC_SUCCESS = 0
         errors = []
         for pool in self.pool:
             # Note that we don't check mapping between rank and hostname, but it
             # appears that self.hostlist_servers[0] is always rank0, 1 is rank1,
             # and the extra server we'll be adding will be rank2.
             for rank, host in enumerate(hosts):
-                rc = check_for_pool(host, pool.uuid.lower())
-                pool_exists_on_host = rc == RC_SUCCESS
+                pool_exists_on_host = check_for_pool(host, pool.uuid.lower())
                 # If this rank is in the rank list, there should be the
                 # UUID-named directory; i.e., pool_exist_on_host is True.
                 pool_expected = rank in uuid_to_ranks[pool.uuid.lower()]
@@ -100,7 +98,8 @@ class DynamicServerPool(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
-        :avocado: tags=control,dynamic_server_pool
+        :avocado: tags=pool,control
+        :avocado: tags=dynamic_server_pool
         """
         # Create a pool on rank0.
         self.create_pool_with_ranks(ranks=[0], tl_update=True)

--- a/src/tests/ftest/pool/multi_server_create_delete.py
+++ b/src/tests/ftest/pool/multi_server_create_delete.py
@@ -1,15 +1,15 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2017-2021 Intel Corporation.
+  (C) Copyright 2017-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
 from apricot import TestWithServers
-import check_for_pool
+from check_for_pool import check_for_pool
 
 
-RESULT_PASS = "PASS" # nosec
+RESULT_PASS = "PASS"  # nosec
 RESULT_FAIL = "FAIL"
 
 
@@ -76,14 +76,12 @@ class MultiServerCreateDeleteTest(TestWithServers):
                     "Test was expected to fail but it passed at pool create.")
             if '0' in tgtlist:
                 # check_for_pool checks if the uuid directory exists in host1
-                exists = check_for_pool.check_for_pool(host1, self.pool.uuid)
-                if exists != 0:
+                if not check_for_pool(host1, self.pool.uuid):
                     self.fail(
                         "Pool {0} not found on host {1}.\n".format(
                             self.pool.uuid, host1))
             if '1' in tgtlist:
-                exists = check_for_pool.check_for_pool(host2, self.pool.uuid)
-                if exists != 0:
+                if not check_for_pool(host2, self.pool.uuid):
                     self.fail(
                         "Pool {0} not found on host {1}.\n".format(
                             self.pool.uuid, host2))
@@ -105,14 +103,12 @@ class MultiServerCreateDeleteTest(TestWithServers):
                     self.fail("Test was expected to fail but it passed at " +
                               "pool create.")
                 if '0' in tgtlist:
-                    exists = check_for_pool.check_for_pool(host1, uuid)
-                    if exists == 0:
+                    if check_for_pool(host1, self.pool.uuid):
                         self.fail(
                             "Pool {0} found on host {1} after destroy.".format(
                                 uuid, host1))
                 if '1' in tgtlist:
-                    exists = check_for_pool.check_for_pool(host2, uuid)
-                    if exists == 0:
+                    if check_for_pool(host2, self.pool.uuid):
                         self.fail(
                             "Pool {0} found on host {1} after destroy.".format(
                                 uuid, host2))

--- a/src/tests/ftest/util/check_for_pool.py
+++ b/src/tests/ftest/util/check_for_pool.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2017-2021 Intel Corporation.
+  (C) Copyright 2017-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
 
-from general_utils import run_command
+from general_utils import run_command, check_file_exists
 
 
 def check_for_pool(host, uuid):
@@ -17,16 +17,16 @@ def check_for_pool(host, uuid):
         uuid: Pool uuid to check if exists
 
     Returns:
-        int: subprocess return code
+        bool: True if pool folder exists, False otherwise
 
     """
-    cmd = "/usr/bin/ssh {} test -e /mnt/daos/{}".format(host, uuid)
-    result = run_command(cmd, raise_exception=False)
-    if result.exit_status == 0:
-        print("{} exists".format(uuid))
+    pool_dir = "/mnt/daos/{}".format(uuid)
+    result = check_file_exists([host], pool_dir, directory=True, sudo=True)
+    if result[0]:
+        print("{} exists on {}".format(pool_dir, host))
     else:
-        print("{} does not exist".format(uuid))
-    return result.exit_status
+        print("{} does not exist on {}".format(pool_dir, host))
+    return result[0]
 
 
 def cleanup_pools(hosts):
@@ -37,4 +37,4 @@ def cleanup_pools(hosts):
 
     """
     for host in hosts:
-        run_command("/usr/bin/ssh {} rm -rf /mnt/daos/*".format(host))
+        run_command("/usr/bin/ssh {} sudo rm -rf /mnt/daos/*".format(host))

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -614,7 +614,7 @@ def check_file_exists(hosts, filename, user=None, directory=False,
     if sudo:
         command = "sudo " + command
 
-    task = run_task(hosts, command)
+    task = run_task(hosts, command, verbose=True)
     for ret_code, node_list in task.iter_retcodes():
         if ret_code != 0:
             missing_file.add(NodeSet.fromlist(node_list))


### PR DESCRIPTION
The following tests were using the check_for_pool() helper
which did not use sudo when looking into SCM:
  pool/multi_server_create_delete.py
  pool/dynamic_server_pool.py

Fix the check_for_pool() helper to use the sudo-aware
check_file_exists() helper, and to return a friendlier
bool value instead of a return code.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>