### PR TITLE
DAOS-10601 client: fix daos_event_abort corruption issue (#9175)

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -476,8 +476,7 @@ daos_event_complete(struct daos_event *ev, int rc)
 		D_MUTEX_LOCK(&eqx->eqx_lock);
 	}
 
-	if (evx->evx_status == DAOS_EVS_READY ||
-	    evx->evx_status == DAOS_EVS_COMPLETED ||
+	if (evx->evx_status == DAOS_EVS_READY || evx->evx_status == DAOS_EVS_COMPLETED ||
 	    evx->evx_status == DAOS_EVS_ABORTED)
 		goto out;
 
@@ -511,8 +510,7 @@ ev_progress_cb(void *arg)
 		return 1;
 
 	/** Event is still in-flight */
-	if (evx->evx_status != DAOS_EVS_COMPLETED &&
-	    evx->evx_status != DAOS_EVS_ABORTED)
+	if (evx->evx_status != DAOS_EVS_COMPLETED && evx->evx_status != DAOS_EVS_ABORTED)
 		return 0;
 
 	/** If there are children in flight, then return in-flight */
@@ -542,11 +540,10 @@ ev_progress_cb(void *arg)
 	}
 
 	/*
-	 * Check again if the event is still in completed/aborted state, then
-	 * remove it from the event queue.
+	 * Check again if the event is still in completed state, then remove it from the event
+	 * queue.
 	 */
-	if (evx->evx_status == DAOS_EVS_COMPLETED ||
-	    evx->evx_status == DAOS_EVS_ABORTED) {
+	if (evx->evx_status == DAOS_EVS_COMPLETED || evx->evx_status == DAOS_EVS_ABORTED) {
 		struct daos_eq *eq = daos_eqx2eq(eqx);
 
 		evx->evx_status = DAOS_EVS_READY;
@@ -797,46 +794,15 @@ out:
 	return count;
 }
 
-static void
-daos_event_abort_one(struct daos_event_private *evx)
-{
-	if (evx->evx_status != DAOS_EVS_RUNNING)
-		return;
-
-	/* NB: ev::ev_error will be set by daos_event_complete(),
-	 * so user can decide to not set error if operation has already
-	 * finished while trying to abort */
-	/* NB: always set ev_status to DAOS_EVS_ABORTED even w/o callback,
-	 * so aborted parent event can be marked as COMPLETE right after
-	 * completion all launched events other than completion of all
-	 * children. See daos_parent_event_can_complete for details. */
-	evx->evx_status = DAOS_EVS_ABORTED;
-	daos_event_complete_cb(evx, -DER_CANCELED);
-}
-
-static void
+static int
 daos_event_abort_locked(struct daos_eq_private *eqx,
 			struct daos_event_private *evx)
 {
-	struct daos_event_private *child;
+	if (evx->evx_status != DAOS_EVS_RUNNING)
+		return -DER_NO_PERM;
 
-	D_ASSERT(evx->evx_status == DAOS_EVS_RUNNING);
-
-	daos_event_abort_one(evx);
-	/* abort all children if he has */
-	d_list_for_each_entry(child, &evx->evx_child, evx_link)
-		daos_event_abort_one(child);
-
-	/* if aborted event is not a child event, move it to the
-	 * head of launched list */
-	if (evx->evx_parent == NULL && eqx != NULL) {
-		struct daos_eq *eq = daos_eqx2eq(eqx);
-
-		d_list_del(&evx->evx_link);
-		d_list_add(&evx->evx_link, &eq->eq_comp);
-		eq->eq_n_running--;
-		eq->eq_n_comp++;
-	}
+	/** Since we don't support task and RPC abort, this is a no-op for now */
+	return 0;
 }
 
 int
@@ -893,7 +859,11 @@ daos_eq_destroy(daos_handle_t eqh, int flags)
 	/* abort all launched events */
 	d_list_for_each_entry_safe(evx, tmp, &eq->eq_running, evx_link) {
 		D_ASSERT(evx->evx_parent == NULL);
-		daos_event_abort_locked(eqx, evx);
+		rc = daos_event_abort_locked(eqx, evx);
+		if (rc) {
+			D_ERROR("Failed to abort event\n");
+			goto out;
+		}
 	}
 
 	D_ASSERT(d_list_empty(&eq->eq_running));
@@ -1102,15 +1072,14 @@ daos_event_fini(struct daos_event *ev)
 		tmp = d_list_entry(evx->evx_child.next,
 				   struct daos_event_private, evx_link);
 		D_ASSERTF(tmp->evx_status == DAOS_EVS_READY ||
-			 tmp->evx_status == DAOS_EVS_COMPLETED ||
-			 tmp->evx_status == DAOS_EVS_ABORTED,
+			  tmp->evx_status == DAOS_EVS_COMPLETED ||
+			  tmp->evx_status == DAOS_EVS_ABORTED,
 			 "EV %p status: %d\n", tmp, tmp->evx_status);
 
 		if (tmp->evx_status != DAOS_EVS_READY &&
 		    tmp->evx_status != DAOS_EVS_COMPLETED &&
 		    tmp->evx_status != DAOS_EVS_ABORTED) {
-			D_ERROR("Child event %p launched: %d\n",
-				daos_evx2ev(tmp), tmp->evx_status);
+			D_ERROR("Child event %p launched: %d\n", daos_evx2ev(tmp), tmp->evx_status);
 			rc = -DER_INVAL;
 			goto out;
 		}
@@ -1204,6 +1173,7 @@ daos_event_abort(struct daos_event *ev)
 {
 	struct daos_event_private	*evx = daos_ev2evx(ev);
 	struct daos_eq_private		*eqx = NULL;
+	int				rc;
 
 	if (daos_handle_is_valid(evx->evx_eqh)) {
 		eqx = daos_eq_lookup(evx->evx_eqh);
@@ -1216,7 +1186,7 @@ daos_event_abort(struct daos_event *ev)
 		D_MUTEX_LOCK(&evx->evx_lock);
 	}
 
-	daos_event_abort_locked(eqx, evx);
+	rc = daos_event_abort_locked(eqx, evx);
 
 	if (eqx != NULL) {
 		D_MUTEX_UNLOCK(&eqx->eqx_lock);
@@ -1225,7 +1195,7 @@ daos_event_abort(struct daos_event *ev)
 		D_MUTEX_UNLOCK(&evx->evx_lock);
 	}
 
-	return 0;
+	return rc;
 }
 
 int

--- a/src/client/api/tests/eq_tests.c
+++ b/src/client/api/tests/eq_tests.c
@@ -56,7 +56,7 @@ static daos_handle_t	my_eqh;
 static int
 eq_test_1()
 {
-	struct daos_event	*ep;
+	struct daos_event	*ep[4];
 	struct daos_event	ev;
 	struct daos_event	abort_ev;
 	daos_handle_t		eqh;
@@ -85,7 +85,10 @@ eq_test_1()
 	rc = daos_event_launch(&abort_ev);
 	D_ASSERT(rc == 0);
 
-	daos_event_abort(&abort_ev);
+	rc = daos_event_abort(&abort_ev);
+	D_ASSERT(rc == 0);
+
+	daos_event_complete(&abort_ev, 0);
 
 	print_message("Destroy non-empty EQ\n");
 	rc = daos_eq_destroy(eqh, 0);
@@ -94,8 +97,9 @@ eq_test_1()
 		goto out;
 	}
 
-	rc = daos_eq_poll(eqh, 0, 0, 1, &ep);
-	if (rc != 1) {
+	/** drain EQ, should get back 2 */
+	rc = daos_eq_poll(eqh, 0, 0, 4, ep);
+	if (rc != 2) {
 		print_error("Failed to drain EQ: %d\n", rc);
 		goto out;
 	}

--- a/src/include/daos_event.h
+++ b/src/include/daos_event.h
@@ -231,8 +231,9 @@ int
 daos_event_parent_barrier(struct daos_event *ev);
 
 /**
- * Try to abort operations associated with this event.
- * If \a ev is a parent event, this call will abort all child operations.
+ * Try to abort operations associated with this event. The user is still required to wait or poll on
+ * the event after this call.
+ * This currently does not abort any internal DAOS operation and is effectively a no-op.
  *
  * \param ev [IN]	Event (operation) to abort
  *

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -505,7 +505,7 @@ dfs_test_syml_follow(void **state)
 }
 
 static int
-dfs_test_file_gen(const char *name, daos_size_t chunk_size,
+dfs_test_file_gen(const char *name, daos_size_t chunk_size, daos_oclass_id_t cid,
 		  daos_size_t file_size)
 {
 	dfs_obj_t	*obj;
@@ -527,7 +527,7 @@ dfs_test_file_gen(const char *name, daos_size_t chunk_size,
 	sgl.sg_iovs = &iov;
 
 	rc = dfs_open(dfs_mt, NULL, name, S_IFREG | S_IWUSR | S_IRUSR,
-		      O_RDWR | O_CREAT, OC_S1, chunk_size, NULL, &obj);
+		      O_RDWR | O_CREAT, cid, chunk_size, NULL, &obj);
 	assert_int_equal(rc, 0);
 
 	rc = dfs_punch(dfs_mt, obj, 10, DFS_MAX_FSIZE);
@@ -654,8 +654,8 @@ dfs_test_read_shared_file(void **state)
 
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	sprintf(name, "MTA_file_%d\n", arg->myrank);
-	rc = dfs_test_file_gen(name, chunk_size, file_size);
+	sprintf(name, "MTA_file_%d", arg->myrank);
+	rc = dfs_test_file_gen(name, chunk_size, OC_S1, file_size);
 	assert_int_equal(rc, 0);
 
 	/* usr barrier to all threads start at the same time and start
@@ -1037,6 +1037,94 @@ dfs_test_compat(void **state)
 	assert_int_equal(rc, EINVAL);
 }
 
+
+#define NUM_ABORTS 64
+#define IO_SIZE_2 1048576
+
+static void
+dfs_test_async_io(void **state)
+{
+	test_arg_t		*arg = *state;
+	char			name[16];
+	dfs_obj_t		*obj;
+	int			i, j;
+	int			rc;
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	sprintf(name, "file_async_%d", arg->myrank);
+	rc = dfs_test_file_gen(name, 0, OC_SX, IO_SIZE_2 * NUM_IOS);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_open(dfs_mt, NULL, name, S_IFREG, O_RDONLY, 0, 0, NULL, &obj);
+	assert_int_equal(rc, 0);
+
+	struct daos_event	evs[NUM_IOS];
+	d_sg_list_t		sgls[NUM_IOS];
+	d_iov_t			iovs[NUM_IOS];
+	daos_size_t		read_sizes[NUM_IOS];
+	char			*bufs[NUM_IOS];
+
+	for (i = 0; i < NUM_IOS; i++) {
+		rc = daos_event_init(&evs[i], arg->eq, NULL);
+		assert_rc_equal(rc, 0);
+
+		D_ALLOC(bufs[i], IO_SIZE_2);
+		D_ASSERT(bufs[i] != NULL);
+
+		d_iov_set(&iovs[i], bufs[i], IO_SIZE_2);
+		sgls[i].sg_nr = 1;
+		sgls[i].sg_nr_out = 1;
+		sgls[i].sg_iovs = &iovs[i];
+	}
+
+	for (j = 0; j < NUM_ABORTS; j++) {
+		for (i = 0; i < NUM_IOS; i++) {
+			bool flag;
+			daos_event_t *ev = &evs[i];
+
+			rc = daos_event_test(ev, DAOS_EQ_NOWAIT, &flag);
+			assert_int_equal(rc, 0);
+
+			if (!flag) {
+				rc = daos_event_abort(ev);
+				assert_int_equal(rc, 0);
+
+				rc = daos_event_test(ev, DAOS_EQ_WAIT, &flag);
+				assert_int_equal(rc, 0);
+			}
+			D_ASSERT(flag == true);
+
+			rc = daos_event_fini(ev);
+			assert_int_equal(rc, 0);
+			rc = daos_event_init(ev, arg->eq, NULL);
+			assert_int_equal(rc, 0);
+
+			rc = dfs_read(dfs_mt, obj, &sgls[i], 0, &read_sizes[i], ev);
+			assert_int_equal(rc, 0);
+		}
+	}
+
+	for (i = 0; i < NUM_IOS; i++) {
+		bool flag;
+
+		rc = daos_event_test(&evs[i], DAOS_EQ_WAIT, &flag);
+		assert_int_equal(rc, 0);
+		D_ASSERT(flag == true);
+		daos_event_fini(&evs[i]);
+		evs[i].ev_error = INT_MAX;
+		evs[i].ev_private.space[0] = ULONG_MAX;
+		D_FREE(bufs[i]);
+		D_ASSERT(read_sizes[i] == IO_SIZE_2);
+	}
+
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+
+	dfs_test_rm(name);
+	MPI_Barrier(MPI_COMM_WORLD);
+}
+
 static const struct CMUnitTest dfs_unit_tests[] = {
 	{ "DFS_UNIT_TEST1: DFS mount / umount",
 	  dfs_test_mount, async_disable, test_case_teardown},
@@ -1062,6 +1150,8 @@ static const struct CMUnitTest dfs_unit_tests[] = {
 	  dfs_test_rename, async_disable, test_case_teardown},
 	{ "DFS_UNIT_TEST12: DFS API compat",
 	  dfs_test_compat, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST13: async IO",
+	  dfs_test_async_io, async_disable, test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
daos_event_abort() was marking the event as aborted, however the DAOS
internal task is not aborted, and currently there is no way to abort
that. So later if a user progresses (through test or poll) that aborted
event, the event API frees the event and marks it as ready to initialized
since it was aborted before, but the DAOS internal task is still not done.

When the DAOS task finally progresses, it can cause corruption because the
user might have resused the event, or even reused the buffers that were passed
to the event.

Since we do not support cancellations of internal DAOS tasks and RPCs, change
the abort implementation to just be a no-op for now which would cause a test or poll
on the event to wait till the internal task is completed to avoid such corruption issues.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>