### PR TITLE
DAOS-623 build: Improve the preprocessing steps

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,3 +13,4 @@ exclude =
     build,
     install
 max-line-length: 100
+ignore=W503

--- a/.flake8-scons
+++ b/.flake8-scons
@@ -13,4 +13,4 @@ exclude =
     install
 filename=*/SConscript, SConstruct
 max-line-length: 100
-ignore=F821,F841
+ignore=F821,F841,W503

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -160,14 +160,10 @@ def generate(env):
     # Workaround for SCons issue #2757.   Avoid using Configure for internal headers
     check_header = Builder(action='$CCCOM', emitter=_ch_emitter)
 
-    try:
-        env["BUILDERS"]["Preprocess"]
-    except KeyError:
+    if not env["BUILDERS"].get("Preprocess", False):
         env.Append(BUILDERS={"Preprocess": preprocess})
 
-    try:
-        env["BUILDERS"]["CheckHeader"]
-    except KeyError:
+    if not env["BUILDERS"].get("CheckHeader", False):
         env.Append(BUILDERS={"CheckHeader": check_header})
 
 

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -161,12 +161,12 @@ def generate(env):
     check_header = Builder(action='$CCCOM', emitter=_ch_emitter)
 
     try:
-        pp_builder = env["BUILDERS"]["Preprocess"]
+        env["BUILDERS"]["Preprocess"]
     except KeyError:
         env.Append(BUILDERS={"Preprocess": preprocess})
 
     try:
-        pp_builder = env["BUILDERS"]["CheckHeader"]
+        env["BUILDERS"]["CheckHeader"]
     except KeyError:
         env.Append(BUILDERS={"CheckHeader": check_header})
 

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -96,8 +96,7 @@ def _find_indent():
 def _pp_gen(source, target, env, indent):
     """generate commands for preprocessor builder"""
     action = []
-    nenv = env.Clone()
-    cccom = nenv.subst("$CCCOM").replace(" -o ", " ")
+    cccom = env.subst("$CCCOM").replace(" -o ", " ")
     for src, tgt in zip(source, target):
         if indent:
             action.append(f'{cccom} -E -P {src} | {indent} > {tgt}')
@@ -122,7 +121,7 @@ def _preprocess_emitter(source, target, env):
                 continue
             if mod != "":
                 prefix = prefix + "_" + mod
-        newtarget = os.path.join(dirname, f'{prefix}{base}_{ext}')
+        newtarget = os.path.join(dirname, f'{prefix}{base}_pp{ext}')
         target.append(newtarget)
     return target, source
 

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -160,8 +160,15 @@ def generate(env):
     # Workaround for SCons issue #2757.   Avoid using Configure for internal headers
     check_header = Builder(action='$CCCOM', emitter=_ch_emitter)
 
-    env.Append(BUILDERS={"Preprocess": preprocess})
-    env.Append(BUILDERS={"CheckHeader": check_header})
+    try:
+        pp_builder = env["BUILDERS"]["Preprocess"]
+    except KeyError:
+        env.Append(BUILDERS={"Preprocess": preprocess})
+
+    try:
+        pp_builder = env["BUILDERS"]["CheckHeader"]
+    except KeyError:
+        env.Append(BUILDERS={"CheckHeader": check_header})
 
 
 def exists(_env):

--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -20,7 +20,6 @@ def parse_pp(env, pp_targets):
     results = []
     scope = r"'/struct [^ ]*_\(in\|out\) {/,/};/p'"
     sed_e = r"-e 's/\s\s*/ /g' -e 's/};struct /};\nstruct /g'"
-    tgts = ""
     for tgt in pp_targets:
         fname = f"{tgt.abspath}_grep"
         cmd = f"sed -n {scope} $SOURCE | tr -d '\\n' | sed {sed_e} > $TARGET"

--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 """Build CaRT components"""
-
-import os
 from datetime import date
 import daos_build
 import SCons.Action
@@ -43,12 +41,11 @@ def consolidate_pp(env, parsed_targets):
     sd = {'@YEAR@': year}
     preamble = env.Substfile('macro_prefix.h_in', SUBST_DICT=sd)
     parsed_sources = [x.abspath for x in parsed_targets]
-    cmd = (f"cat {preamble[0].abspath} > $TARGET; cat {' '.join(parsed_sources)}" +
-           f" | grep -v {grepv} | sort -u | sed {sed_d} >> $TARGET")
+    cmd = (f"cat {preamble[0].abspath} > $TARGET; cat {' '.join(parsed_sources)}"
+           + f" | grep -v {grepv} | sort -u | sed {sed_d} >> $TARGET")
     header = env.Command('_structures_from_macros.h', preamble + parsed_targets, cmd)
     env.AddPostAction(header, SCons.Action.Action(copy_header, None))
     return header
-
 
 
 def scons():

--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -5,6 +5,7 @@
 """Build CaRT components"""
 
 import os
+from datetime import date
 import daos_build
 import SCons.Action
 
@@ -16,36 +17,38 @@ SRC = ['crt_bulk.c', 'crt_context.c', 'crt_corpc.c',
        'crt_tree_knomial.c', 'crt_hlc.c', 'crt_hlct.c']
 
 
-# pylint: disable=unused-argument
-def macro_expand(target, source, env):
-    """Function for PostAction"""
+def parse_pp(env, pp_targets):
+    """Use command builder to process each preprocessed file"""
+    results = []
     scope = r"'/struct [^ ]*_\(in\|out\) {/,/};/p'"
     sed_e = r"-e 's/\s\s*/ /g' -e 's/};struct /};\nstruct /g'"
+    tgts = ""
+    for tgt in pp_targets:
+        fname = f"{tgt.abspath}_grep"
+        cmd = f"sed -n {scope} $SOURCE | tr -d '\\n' | sed {sed_e} > $TARGET"
+        results.extend(env.Command(fname, tgt, cmd))
+    return results
+
+
+def copy_header(**kw):
+    """Copy the target file to source directory"""
+    Execute(Copy(Dir("src/cart").srcnode().abspath, kw['target'][0].abspath))
+
+
+def consolidate_pp(env, parsed_targets):
+    """Consolidate parsed headers"""
     sed_d = r"-e 's/\([{;]\) /\1\t/g' -e 's/\([{;]\)/\1\n/g'"
     grepv = r"'struct sockaddr_in {'"
-    tgts = ""
-    for tgt in target:
-        tgts += "%s_grep " % tgt.abspath
-        os.system("sed -n %s %s | tr -d '\\n' | sed %s > %s_grep"
-                  % (scope, tgt.abspath, sed_e, tgt.abspath))
-    h_name = "src/cart/_structures_from_macros_.h"
-    h_file = os.path.join(Dir('#').abspath, h_name)
-    with open(h_file, "w") as outfile:
-        outfile.write("/* Automatically generated with structures\n"
-                      " * expanded from CRT_RPC_DECLARE() macros\n *\n")
-        with open("LICENSE", "r") as infile:
-            for line in infile.readlines():
-                if line == "\n":
-                    outfile.write(" *\n")
-                else:
-                    outfile.write(" * " + line)
-            infile.close()
-        outfile.write(" */\n\n")
-        outfile.close()
-    if tgts != "":
-        os.system("cat %s | grep -v %s | sort -u | sed %s >> %s"
-                  % (tgts, grepv, sed_d, h_file))
-# pylint: enable=unused-argument
+    year = date.today().year
+    sd = {'@YEAR@': year}
+    preamble = env.Substfile('macro_prefix.h_in', SUBST_DICT=sd)
+    parsed_sources = [x.abspath for x in parsed_targets]
+    cmd = (f"cat {preamble[0].abspath} > $TARGET; cat {' '.join(parsed_sources)}" +
+           f" | grep -v {grepv} | sort -u | sed {sed_d} >> $TARGET")
+    header = env.Command('_structures_from_macros.h', preamble + parsed_targets, cmd)
+    env.AddPostAction(header, SCons.Action.Action(copy_header, None))
+    return header
+
 
 
 def scons():
@@ -77,11 +80,15 @@ def scons():
     compiler = env.get('COMPILER').lower()
     if compiler != 'covc':
         pp_env = denv.Clone()
+        pp_files = []
+        for src in SRC:
+            # Some day, the preprocess builder should be fixed so it can do multiple commands
+            # in parallel but until then, just submit them one at a time
+            pp_files.extend(pp_env.Preprocess(src))
+        parsed_files = parse_pp(pp_env, pp_files)
+        header = consolidate_pp(pp_env, parsed_files)
 
-        pp_files = pp_env.Preprocess(SRC)
-        pp_env.AddPostAction(pp_files, SCons.Action.Action(macro_expand, None))
-
-        Depends(cart_targets, pp_files)
+        Depends(cart_targets, header)
 
     cart_lib = daos_build.library(denv, 'cart', [cart_targets, swim_targets],
                                   SHLIBVERSION=CART_VERSION)

--- a/src/cart/macro_prefix.h_in
+++ b/src/cart/macro_prefix.h_in
@@ -1,0 +1,7 @@
+/* Automatically generated with structures expanded from CRT_RPC_DECLARE() macros
+ *
+ * (C) Copyright 2016-@YEAR@ Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+

--- a/utils/sl/fake_scons/SCons/Script/__init__.py
+++ b/utils/sl/fake_scons/SCons/Script/__init__.py
@@ -309,11 +309,13 @@ class Configure():
     def Finish(self):
         """Fake finish"""
 
+
 class Literal():
     """Fake Literal"""
 
     def __init__(self, *_args, **_kw):
         """constructor"""
+
 
 class Dir():
     """Fake Dir"""
@@ -325,80 +327,101 @@ class Dir():
         """Fake srcnode"""
         return self
 
+
 class File():
     """Fake File"""
 
+
 def VariantDir(*_args, **_kw):
     """Fake VariantDir"""
+
 
 def AddOption(*_args, **_kw):
     """Fake AddOption"""
     return True
 
+
 def GetOption(*_args, **_kw):
     """Fake GetOption"""
     return []
 
+
 def SetOption(*_args, **_kw):
     """Fake SetOption"""
     return True
+
 
 class Help():
     """Fake Help"""
     def __init__(self, *_args, **_kw):
         """constructor"""
 
+
 def Glob(*_args):
     """Fake Glob"""
     return []
+
 
 def Split(*_args):
     """Fake Split"""
     return []
 
+
 def Exit(status):
     """Fake Exit"""
     sys.exit(status)
 
+
 def Import(*_args):
     """Fake Import"""
+
 
 def Export(*_args):
     """Fake Export"""
 
+
 def Default(*_args):
     """Fake Default"""
+
 
 def Delete(*_args, **_kw):
     """Fake Delete"""
     return ["fake"]
 
+
 def AlwaysBuild(*_args):
     """Fake AlwaysBuild"""
+
 
 def Copy(*_args, **_kw):
     """Fake Copy"""
     return ["fake"]
 
+
 def Command(*_args, **_kw):
     """Fake Command"""
     return ["fake"]
+
 
 def Execute(*_args, **_kw):
     """Fake Execute"""
     return ["fake"]
 
+
 def Builder(*_args, **_kw):
     """Fake Builder"""
     return ["fake"]
+
 
 def WhereIs(path):
     """Fake WhereIs"""
     return ''
 
+
 def Platform():
     """Fake Platform"""
     return ''
+
 
 def Depends(*_args, **_kw):
     """Fake Depends"""

--- a/utils/sl/fake_scons/SCons/Script/__init__.py
+++ b/utils/sl/fake_scons/SCons/Script/__init__.py
@@ -384,6 +384,10 @@ def Command(*_args, **_kw):
     """Fake Command"""
     return ["fake"]
 
+def Execute(*_args, **_kw):
+    """Fake Execute"""
+    return ["fake"]
+
 def Builder(*_args, **_kw):
     """Fake Builder"""
     return ["fake"]
@@ -411,6 +415,7 @@ __all__ = ['DefaultEnvironment',
            'Configure',
            'GetOption',
            'SetOption',
+           'Execute',
            'Depends',
            'Platform',
            'Literal',


### PR DESCRIPTION
A couple of things were causing the preprocessing step in cart
to generate _structures_from_macros.h to be slow

1. The Preprocessor builder currently doesn't support building
   multiple items in parallel so it's better to call it one file
   at a time.
2. Use Command builders for intermediate steps so they don't need
   to be repeated

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

Required-githooks: true