### PR TITLE
DAOS-9989 test: Enable regular weekly tcp testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@DAOS-9989") _
 
 // Should try to figure this out automatically
 /* groovylint-disable-next-line CompileStatic, VariableName */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
              env.BRANCH_NAME == 'release/1.2' ? 'TZ=America/Toronto\n0 12 * * *\n' : '' +
              /* groovylint-disable-next-line AddEmptyString */
              env.BRANCH_NAME.startsWith('weekly-testing') ? 'H 0 * * 6\n' : '' +
-             env.BRANCH_NAME.startsWith('provider-testing') ? 'H 14 * * 4' : '')
+             env.BRANCH_NAME.startsWith('provider-testing') ? 'H 2 * * 6' : '')
     }
 
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,8 @@ String sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceA
 
 // bail out of branch builds that are not on a whitelist
 if (!env.CHANGE_ID &&
-    (!env.BRANCH_NAME.startsWith('weekly-testing') &&
+    (!env.BRANCH_NAME.startsWith('provider-testing') &&
+     !env.BRANCH_NAME.startsWith('weekly-testing') &&
      !env.BRANCH_NAME.startsWith('release/') &&
      env.BRANCH_NAME != 'master')) {
    currentBuild.result = 'SUCCESS'
@@ -43,7 +44,9 @@ pipeline {
         cron(env.BRANCH_NAME == 'master' ? 'TZ=America/Toronto\n0 0 * * *\n' : '' +
              /* groovylint-disable-next-line AddEmptyString */
              env.BRANCH_NAME == 'release/1.2' ? 'TZ=America/Toronto\n0 12 * * *\n' : '' +
-             env.BRANCH_NAME.startsWith('weekly-testing') ? 'H 0 * * 6' : '')
+             /* groovylint-disable-next-line AddEmptyString */
+             env.BRANCH_NAME.startsWith('weekly-testing') ? 'H 0 * * 6\n' : '' +
+             env.BRANCH_NAME.startsWith('provider-testing') ? 'H 14 * * 4' : '')
     }
 
     environment {
@@ -68,83 +71,32 @@ pipeline {
                defaultValue: getPriority(),
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
-               defaultValue: 'full_regression',
-               description: 'Test-tag to use for the weekly Functional Hardware Small/Medium/Large stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
-        string(name: 'TestTagTCP',
                defaultValue: 'pr daily_regression',
-               description: 'Test-tag to use for the Functional Hardware Small/Medium/Large TCP stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
-        string(name: 'TestTagUCX',
-               defaultValue: 'pr daily_regression',
-               description: 'Test-tag to use for the Functional Hardware Small/Medium/Large UCX stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
+               description: 'Test-tag to use for the Functional Hardware Small/Medium/Large stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'TestProvider',
+               defaultValue: 'ofi+tcp',
+               description: 'Provider to use for the Functional Hardware Small/Medium/Large stages of this run (i.e. ofi+tcp)')
         string(name: 'BaseBranch',
                defaultValue: base_branch,
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
-        booleanParam(name: 'CI_FUNCTIONAL_el8_TEST',
-                     defaultValue: true,
-                     description: 'Run the Functional on EL 8 test stage')
-        booleanParam(name: 'CI_FUNCTIONAL_leap15_TEST',
-                     defaultValue: true,
-                     description: 'Run the Functional on Leap 15 test stage')
-        booleanParam(name: 'CI_FUNCTIONAL_ubuntu20_TEST',
-                     defaultValue: false,
-                     description: 'Run the Functional on Ubuntu 20 test stage')
         booleanParam(name: 'CI_small_TEST',
                      defaultValue: true,
-                     description: 'Run the CI Functional Hardware Small test stage')
+                     description: 'Run the Small Cluster CI tests')
         booleanParam(name: 'CI_medium_TEST',
                      defaultValue: true,
-                     description: 'Run the CI Functional Hardware Medium test stage')
+                     description: 'Run the Medium Cluster CI tests')
         booleanParam(name: 'CI_large_TEST',
                      defaultValue: true,
-                     description: 'Run the CI Functional Hardware Large test stage')
-        booleanParam(name: 'CI_small_tcp_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Small TCP test stage')
-        booleanParam(name: 'CI_medium_tcp_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Medium TCP test stage')
-        booleanParam(name: 'CI_large_tcp_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Large TCP test stage')
-        booleanParam(name: 'CI_small_ucx_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Small UCX test stage')
-        booleanParam(name: 'CI_medium_ucx_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Medium UCX test stage')
-        booleanParam(name: 'CI_large_ucx_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Large UCX test stage')
-        string(name: 'CI_FUNCTIONAL_VM9_LABEL',
-               defaultValue: 'ci_vm9',
-               description: 'Label to use for 9 VM functional tests')
+                     description: 'Run the Large Cluster CI tests')
         string(name: 'CI_NVME_3_LABEL',
                defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node Functional Hardware Small stage')
+               description: 'Label to use for 3 node NVMe tests')
         string(name: 'CI_NVME_5_LABEL',
                defaultValue: 'ci_nvme5',
-               description: 'Label to use for 5 node Functional Hardware Medium stage')
+               description: 'Label to use for 5 node NVMe tests')
         string(name: 'CI_NVME_9_LABEL',
                defaultValue: 'ci_nvme9',
-               description: 'Label to use for 9 node Functional Hardware Large stage')
-        string(name: 'CI_HW_SMALL_TCP_LABEL',
-               defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node Functional Hardware Small TCP stage')
-        string(name: 'CI_HW_MEDIUM_TCP_LABEL',
-               defaultValue: 'ci_nvme5',
-               description: 'Label to use for 5 node Functional Hardware Medium TCP stage')
-        string(name: 'CI_HW_LARGE_TCP_LABEL',
-               defaultValue: 'ci_nvme9',
-               description: 'Label to use for 9 node Functional Hardware Large TCP stage')
-        string(name: 'CI_HW_SMALL_UCX_LABEL',
-               defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node Functional Hardware Small UCX stage')
-        string(name: 'CI_HW_MEDIUM_UCX_LABEL',
-               defaultValue: 'ci_nvme5',
-               description: 'Label to use for 5 node Functional Hardware Medium UCX stage')
-        string(name: 'CI_HW_LARGE_UCX_LABEL',
-               defaultValue: 'ci_nvme9',
-               description: 'Label to use for 9 node Functional Hardware Large UCX stage')
+               description: 'Label to use for 9 node NVMe tests')
     }
 
     stages {
@@ -168,75 +120,6 @@ pipeline {
                 expression { !skipStage() }
             }
             parallel {
-                 stage('Functional on CentOS 8') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        label params.CI_FUNCTIONAL_VM9_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional on CentOS 8')
-                stage('Functional on Leap 15') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        label params.CI_FUNCTIONAL_VM9_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    } // post
-                } // stage('Functional on Leap 15')
-                stage('Functional on Ubuntu 20.04') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        label params.CI_FUNCTIONAL_VM9_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    } // post
-                } // stage('Functional on Ubuntu 20.04')
                 stage('Functional Hardware Small') {
                     when {
                         beforeAgent true
@@ -309,150 +192,6 @@ pipeline {
                         }
                     }
                 } // stage('Functional_Hardware_Large')
-                stage('Functional Hardware Small TCP') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 2 node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_SMALL_TCP_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Small TCP')
-                stage('Functional Hardware Medium TCP') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 4 node cluster with 2 IB/node + 1 test control node
-                        label params.CI_HW_MEDIUM_TCP_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Medium TCP')
-                stage('Functional Hardware Large TCP') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 8+ node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_LARGE_TCP_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Large TCP')
-                stage('Functional Hardware Small UCX') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 2 node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_SMALL_UCX_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Small UCX')
-                stage('Functional Hardware Medium UCX') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 4 node cluster with 2 IB/node + 1 test control node
-                        label params.CI_HW_MEDIUM_UCX_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Medium UCX')
-                stage('Functional Hardware Large UCX') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 8+ node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_LARGE_UCX_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Large UCX')
             } // parallel
         } // stage('Test')
     } //stages

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,19 @@ pipeline {
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
                defaultValue: "full_regression",
-               description: 'Test-tag to use for this run (i.e pr, daily_regression, full_regression, etc.')
+               description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'CI_FUNCTIONAL_VM9_LABEL',
+               defaultValue: 'ci_vm9',
+               description: 'Label to use for 9 VM functional tests')
+        string(name: 'CI_NVME_3_LABEL',
+               defaultValue: 'ci_nvme3',
+               description: 'Label to use for 3 node NVMe tests')
+        string(name: 'CI_NVME_5_LABEL',
+               defaultValue: 'ci_nvme5',
+               description: 'Label to use for 5 node NVMe tests')
+        string(name: 'CI_NVME_9_LABEL',
+               defaultValue: 'ci_nvme9',
+               description: 'Label to use for 9 node NVMe tests')
     }
 
     stages {
@@ -93,7 +105,7 @@ pipeline {
                         expression { ! skipStage() }
                     }
                     agent {
-                        label 'ci_vm9'
+                        label params.CI_FUNCTIONAL_VM9_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -116,7 +128,7 @@ pipeline {
                         expression { ! skipStage() }
                     }
                     agent {
-                        label 'ci_vm9'
+                        label params.CI_FUNCTIONAL_VM9_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -139,7 +151,7 @@ pipeline {
                         expression { ! skipStage() }
                     }
                     agent {
-                        label 'ci_vm9'
+                        label params.CI_FUNCTIONAL_VM9_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -163,7 +175,7 @@ pipeline {
                     }
                     agent {
                         // 2 node cluster with 1 IB/node + 1 test control node
-                        label 'ci_nvme3'
+                        label params.CI_NVME_3_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -187,7 +199,7 @@ pipeline {
                     }
                     agent {
                         // 4 node cluster with 2 IB/node + 1 test control node
-                        label 'ci_nvme5'
+                        label params.CI_NVME_5_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -211,7 +223,7 @@ pipeline {
                     }
                     agent {
                         // 8+ node cluster with 1 IB/node + 1 test control node
-                        label 'ci_nvme9'
+                        label params.CI_NVME_9_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,238 +19,9 @@ String base_branch = "master"
 // For master, this is just some wildly high number
 next_version = "1000"
 
-boolean doc_only_change() {
-    if (cachedCommitPragma(pragma: 'Doc-only') == 'true') {
-        return true
-    }
-
-    /* Automatic Doc-only discover not really valid for the weekly-testing
-     * branch, and ends up requiring ci/doc_only_change.sh which is not available
-     * when needed since the change to master is not done yet when this is
-     * evaluated.  Additionally, maintaining ci/doc_only_change.sh on this branch
-     * is just not worthwhile.
-     */
-    return false
-}
-
-boolean release_candidate() {
-    return !sh(label: "Determine if building (a PR of) an RC",
-              script: "git diff-index --name-only HEAD^ | grep -q TAG && " +
-                      "grep -i '[0-9]rc[0-9]' TAG",
-              returnStatus: true)
-}
-
-def scons_faults_args() {
-    // The default build will have BUILD_TYPE=dev; fault injection enabled
-    if ((cachedCommitPragma(pragma: 'faults-enabled', def_val: 'true') == 'true') && !release_candidate()) {
-        return "BUILD_TYPE=dev"
-    } else {
-        return "BUILD_TYPE=release"
-    }
-}
-
-def skip_stage(String stage, boolean def_val = false) {
-    String value = 'false'
-    if (def_val) {
-        value = 'true'
-    }
-    return cachedCommitPragma(pragma: 'Skip-' + stage,
-                              def_val: value) == 'true'
-}
-
-boolean quickbuild() {
-    return cachedCommitPragma(pragma: 'Quick-build') == 'true'
-}
-
-String get_daos_packages() {
-    Map stage_info = parseStageInfo()
-    return get_daos_packages(stage_info['target'])
-}
-
-String get_daos_packages(String distro) {
-    String pkgs
-    if (env.TEST_RPMS == 'true') {
-        pkgs = "daos{,-{client,tests,server}}"
-    } else {
-        pkgs = "daos{,-client}"
-    }
-    if (distro.startsWith('ubuntu20')) {
-        return pkgs + "=" + daos_packages_version(distro)
-    }
-    return pkgs + "-" + daos_packages_version(distro)
-}
-
-String pr_repos(String distro) {
-    String repos = ""
-    if (distro == 'centos7') {
-        repos = cachedCommitPragma(pragma: 'PR-repos-el7')
-    } else if (distro == 'leap15') {
-        repos = cachedCommitPragma(pragma: 'PR-repos-leap15')
-    } else if (distro.startsWith('ubuntu20')) {
-        repos = cachedCommitPragma(pragma: 'PR-repos-ubuntu20', cache: commit_pragma_cache)
-    } else {
-       error 'pr_repos not implemented for ' + distro
-    }
-    return repos + ' ' + cachedCommitPragma(pragma: 'PR-repos')
-}
-
-String daos_repo() {
-    if (target_branch.startsWith("weekly-testing") ||
-        rpm_test_version() == '') {
-        return ""
-    }
-    return "daos@${env.BRANCH_NAME}:${env.BUILD_NUMBER}"
-}
-
-String hw_distro_target() {
-    if (env.STAGE_NAME.contains('Hardware')) {
-        if (env.STAGE_NAME.contains('Small')) {
-            return hw_distro('small')
-        }
-        if (env.STAGE_NAME.contains('Medium')) {
-            return hw_distro('medium')
-        }
-        if (env.STAGE_NAME.contains('Large')) {
-            return hw_distro('large')
-        }
-    }
-    Map stage_info = parseStageInfo()
-    return stage_info['target']
-}
-
-String daos_repos() {
-    String target = hw_distro_target()
-    return daos_repos(target)
-}
-
-String daos_repos(String distro) {
-    return pr_repos(distro) + ' ' + daos_repo()
-}
-
-commit_pragma_cache = [:]
-def cachedCommitPragma(Map config) {
-
-    if (commit_pragma_cache[config['pragma']]) {
-        return commit_pragma_cache[config['pragma']]
-    }
-
-    commit_pragma_cache[config['pragma']] = commitPragma(config)
-
-    return commit_pragma_cache[config['pragma']]
-
-}
-
-String rpm_dist(String distro) {
-    if (distro == "centos7") {
-        return ".el7"
-    } else if (distro == "leap15") {
-        return ".suse.lp152"
-    } else {
-        error("Don't know what the RPM %{dist} is for ${distro}")
-    }
-}
-String daos_latest_version(String next_version) {
-            String v = sh(label: "Get RPM packages version",
-                          script: '''repoquery --repofrompath=daos,https://repo.dc.hpdd.intel.com/repository/daos-stack-el-7-x86_64-stable-local/ \
-                                               --repoid daos --qf %{version}-%{release} --whatprovides 'daos(x86-64) < ''' + next_version + '''' |
-                                         rpmdev-sort | tail -1''',
-                          returnStdout: true).trim()
-            return v[0..<v .lastIndexOf('.')]
-}
-
-rpm_version_cache = ""
-String daos_packages_version(String distro) {
-    // for weekly-test:
-    if (target_branch.startsWith("weekly-testing")) {
-        if (rpm_version_cache != "" && rpm_version_cache != "locked") {
-            return rpm_version_cache + rpm_dist(distro)
-        }
-        if (rpm_version_cache == "") {
-            // no cached value and nobody's getting it
-            rpm_version_cache = "locked"
-            rpm_version_cache = daos_latest_version(next_version)
-        } else {
-            // somebody else is getting it, wait for them
-            Integer i = 30
-            while (rpm_version_cache == "locked" && i-- > 0) {
-                sleep(10)
-            }
-            if (rpm_version_cache == "locked") {
-                rpm_version_cache = daos_latest_version(next_version)
-            }
-        }
-        return rpm_version_cache + rpm_dist(distro)
-    /* what's the query to get the higest 1.0.x package?
-    } else if (target_branch == "weekly-testing-1.x") {
-        return "release/0.9"
-    */
-    } else {
-        // commit pragma has highest priority
-        // TODO: this should actually be determined from the PR-repos artifacts
-        String version = rpm_test_version()
-        if (version != "") {
-            return version + rpm_dist(distro)
-        }
-
-        // use the stash after that
-        unstash distro + '-rpm-version'
-        version = readFile(distro + '-rpm-version').trim()
-        if (version != "") {
-            return version
-        }
-
-        error "Don't know how to determine package version for " + distro
-    }
-}
-
-String hw_distro(String size) {
-    // Possible values:
-    //'leap15
-    //'centos7
-    return cachedCommitPragma(pragma: 'Func-hw-test-' + size + '-distro',
-                              def_val: cachedCommitPragma(pragma: 'Func-hw-test-distro',
-                                                          def_val: 'centos7'))
-}
-
-String functional_packages() {
-    String target = hw_distro_target()
-    return functional_packages(target)
-}
-
-String functional_packages(String distro) {
-    String daos_pkgs = get_daos_packages(distro)
-    String pkgs = " openmpi3 hwloc ndctl fio " +
-                  "patchutils ior-hpc-daos-1 " +
-                  "romio-tests-daos-1 " +
-                  "testmpio " +
-                  "mpi4py-tests " +
-                  "hdf5-mpich-tests " +
-                  "hdf5-openmpi3-tests " +
-                  "hdf5-vol-daos-mpich2-tests-daos-1 " +
-                  "hdf5-vol-daos-openmpi3-tests-daos-1 " +
-                  "MACSio-mpich " +
-                  "MACSio-openmpi3 " +
-                  "mpifileutils-mpich-daos-1 "
-    if (distro == "leap15") {
-        if (quickbuild()) {
-            pkgs += " spdk-tools"
-        }
-        return daos_pkgs + pkgs
-    } else if (distro == "centos7") {
-        if (quickbuild()) {
-            pkgs += " spdk_tools"
-        }
-        // need to exclude openmpi until we remove it from the repo
-        return  "--exclude openmpi " + daos_pkgs + pkgs
-    } else if (distro.startsWith('ubuntu20')) {
-        return daos_pkgs + " openmpi-bin ndctl fio"
-    } else {
-        error 'functional_packages not implemented for ' + stage_info['target']
-    }
-}
-
 // Don't define this as a type or it loses it's global scope
 target_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
+def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
 
 // bail out of branch builds that are not on a whitelist
 if (!env.CHANGE_ID &&
@@ -261,89 +32,23 @@ if (!env.CHANGE_ID &&
    return
 }
 
-// Default priority is 3, lower is better.
-// The parameter for a job is set using the script/Jenkinsfile from the
-// previous build of that job, so the first build of any PR will always
-// run at default because Jenkins sees it as a new job, but subsequent
-// ones will use the value from here.
-// The advantage therefore is not to change the priority of PRs, but to
-// change the master branch itself to run at lower priority, resulting
-// in faster time-to-result for PRs.
-
-String get_priority() {
-    if (env.BRANCH_NAME == 'master' ||
-        env.BRANCH_NAME == 'weekly-testing') {
-        string p = '2'
-    } else {
-        string p = ''
-    }
-    echo "Build priority set to " + p == '' ? 'default' : p
-    return p
-}
-
-String rpm_test_version() {
-    return cachedCommitPragma(pragma: 'RPM-test-version')
-}
-
-boolean skip_ftest(String distro) {
-    return distro == 'ubuntu20' ||
-           skip_stage('func-test') ||
-           skip_stage('func-test-vm') ||
-           ! tests_in_stage('vm') ||
-           skip_stage('func-test-' + distro)
-}
-
-boolean tests_in_stage(String size) {
-    if (env.BRANCH_NAME.startsWith('weekly-testing')) {
-        /* This doesn't actually work on weekly-ltestin branches due to a lack
-         * src/test/ftest/launch.py (and friends).  We could probably just
-         * check that out from the branch we are testing against (i.e. master,
-         * release/*, etc.) but let's save that for another day
-         */
-        return true
-    }
-
-    Map stage_info = parseStageInfo()
-    return sh(label: "Get test list for ${size}",
-              script: """cd src/tests/ftest
-                         ./launch.py --list """ + stage_info['test_tag'],
-              returnStatus: true) == 0
-}
-
-boolean skip_ftest_hw(String size) {
-    return env.DAOS_STACK_CI_HARDWARE_SKIP == 'true' ||
-           skip_stage('func-test') ||
-           skip_stage('func-hw-test') ||
-           skip_stage('func-hw-test-' + size) ||
-           ! tests_in_stage(size) ||
-           (env.BRANCH_NAME == 'master' && ! startedByTimer())
-}
-
-boolean skip_testing_stage() {
-    return  env.NO_CI_TESTING == 'true' ||
-            (skip_stage('build') &&
-             rpm_test_version() == '') ||
-            doc_only_change() ||
-            skip_stage('test') ||
-            (env.BRANCH_NAME.startsWith('weekly-testing') &&
-             ! startedByTimer() &&
-             ! startedByUser())
-}
-
 pipeline {
     agent { label 'lightweight' }
 
     triggers {
-        cron(env.BRANCH_NAME == 'master' ? 'TZ=America/Toronto\n0 0,12 * * *\n' : '' +
+        cron(env.BRANCH_NAME == 'master' ? 'TZ=America/Toronto\n0 0 * * *\n' : '' +
+             env.BRANCH_NAME == 'release/1.2' ? 'TZ=America/Toronto\n0 12 * * *\n' : '' +
              env.BRANCH_NAME.startsWith('weekly-testing') ? 'H 0 * * 6' : '')
     }
 
     environment {
+        BULLSEYE = credentials('bullseye_license_key')
         GITHUB_USER = credentials('daos-jenkins-review-posting')
         SSH_KEY_ARGS = "-ici_key"
         CLUSH_ARGS = "-o$SSH_KEY_ARGS"
-        TEST_RPMS = "true"
-        SCONS_FAULTS_ARGS = scons_faults_args()
+        TEST_RPMS = cachedCommitPragma(pragma: 'RPM-test', def_val: 'true')
+        COVFN_DISABLED = cachedCommitPragma(pragma: 'Skip-fnbullseye', def_val: 'true')
+        SCONS_FAULTS_ARGS = sconsFaultsArgs()
     }
 
     options {
@@ -354,11 +59,11 @@ pipeline {
 
     parameters {
         string(name: 'BuildPriority',
-               defaultValue: get_priority(),
+               defaultValue: getPriority(),
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
                defaultValue: "full_regression",
-               description: 'Test-tag to use for this run')
+               description: 'Test-tag to use for this run (i.e pr, daily_regression, full_regression, etc.')
     }
 
     stages {
@@ -379,13 +84,13 @@ pipeline {
         stage('Test') {
             when {
                 beforeAgent true
-                expression { ! skip_testing_stage() }
+                expression { ! skipStage() }
             }
             parallel {
                 stage('Functional on CentOS 7') {
                     when {
                         beforeAgent true
-                        expression { ! skip_ftest('el7') }
+                        expression { ! skipStage() }
                     }
                     agent {
                         label 'ci_vm9'
@@ -395,8 +100,8 @@ pipeline {
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
                                     branch: base_branch,
                                     withSubmodules: true
-                        functionalTest inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages(),
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -408,7 +113,7 @@ pipeline {
                 stage('Functional on Leap 15') {
                     when {
                         beforeAgent true
-                        expression { ! skip_ftest('leap15') }
+                        expression { ! skipStage() }
                     }
                     agent {
                         label 'ci_vm9'
@@ -418,8 +123,8 @@ pipeline {
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
                                     branch: base_branch,
                                     withSubmodules: true
-                        functionalTest inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages(),
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -431,7 +136,7 @@ pipeline {
                 stage('Functional on Ubuntu 20.04') {
                     when {
                         beforeAgent true
-                        expression { ! skip_ftest('ubuntu20') }
+                        expression { ! skipStage() }
                     }
                     agent {
                         label 'ci_vm9'
@@ -441,8 +146,8 @@ pipeline {
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
                                     branch: base_branch,
                                     withSubmodules: true
-                        functionalTest inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages(),
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -451,10 +156,10 @@ pipeline {
                         }
                     } // post
                 } // stage('Functional on Ubuntu 20.04')
-                stage('Functional_Hardware_Small') {
+                stage('Functional Hardware Small') {
                     when {
                         beforeAgent true
-                        expression { ! skip_ftest_hw('small') }
+                        expression { ! skipStage() }
                     }
                     agent {
                         // 2 node cluster with 1 IB/node + 1 test control node
@@ -465,9 +170,8 @@ pipeline {
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
                                     branch: base_branch,
                                     withSubmodules: true
-                        functionalTest target: hw_distro_target(),
-                                       inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages(),
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -476,10 +180,10 @@ pipeline {
                         }
                     }
                 } // stage('Functional_Hardware_Small')
-                stage('Functional_Hardware_Medium') {
+                stage('Functional Hardware Medium') {
                     when {
                         beforeAgent true
-                        expression { ! skip_ftest_hw('medium') }
+                        expression { ! skipStage() }
                     }
                     agent {
                         // 4 node cluster with 2 IB/node + 1 test control node
@@ -490,9 +194,8 @@ pipeline {
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
                                     branch: base_branch,
                                     withSubmodules: true
-                        functionalTest target: hw_distro_target(),
-                                       inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages(),
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -501,10 +204,10 @@ pipeline {
                         }
                     }
                 } // stage('Functional_Hardware_Medium')
-                stage('Functional_Hardware_Large') {
+                stage('Functional Hardware Large') {
                     when {
                         beforeAgent true
-                        expression { ! skip_ftest_hw('large') }
+                        expression { ! skipStage() }
                     }
                     agent {
                         // 8+ node cluster with 1 IB/node + 1 test control node
@@ -515,9 +218,8 @@ pipeline {
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
                                     branch: base_branch,
                                     withSubmodules: true
-                        functionalTest target: hw_distro_target(),
-                                       inst_repos: daos_repos(),
-                                       inst_rpms: functional_packages(),
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {


### PR DESCRIPTION
Create a new provider-testing-tcp branch to run the pr+daily tagged tests in the Functional Hardware test stages with the ofi+tcp provider on a weekly cadence.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>