### PR TITLE
DAOS-10863 control: Log warning for single access point

### DIFF
--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -460,6 +460,9 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 		return FaultConfigBadAccessPoints
 	case len(cfg.AccessPoints)%2 == 0:
 		return FaultConfigEvenAccessPoints
+	case len(cfg.AccessPoints) == 1:
+		log.Infof("WARNING: Configuration includes only one access point. This is provides no redundancy " +
+			"in the event of an access point failure.")
 	}
 
 	switch {


### PR DESCRIPTION
While using a single access point is allowed, it provides no
redundancy. This log message provides a warning for the admin.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>