### PR TITLE
DAOS-10871 build: Fix aarch64 build SPDK error (#10871)

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -364,7 +364,9 @@ def define_components(reqs):
     # it has also failed with sandybridge.
     # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
     dist = distro.linux_distribution()
-    if dist[0] == 'CentOS Linux' and dist[1] == '7':
+    if ARM_PLATFORM:
+        spdk_arch = 'native'
+    elif dist[0] == 'CentOS Linux' and dist[1] == '7':
         spdk_arch = 'native'
     elif dist[0] == 'Ubuntu' and dist[1] == '20.04':
         spdk_arch = 'nehalem'


### PR DESCRIPTION
When build the dependent component SPDK in aarch64 platform, an error is
reported because the incorrect march=haswell. When is ARM platform, set
march to native.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>