### PR TITLE
DAOS-10872 control: Fix aarch64 build control errors (#10872) 

### DIFF
--- a/src/control/lib/telemetry/counter.go
+++ b/src/control/lib/telemetry/counter.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/counter_test.go
+++ b/src/control/lib/telemetry/counter_test.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/duration.go
+++ b/src/control/lib/telemetry/duration.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/duration_test.go
+++ b/src/control/lib/telemetry/duration_test.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-1-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/gauge.go
+++ b/src/control/lib/telemetry/gauge.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/gauge_test.go
+++ b/src/control/lib/telemetry/gauge_test.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/promexp/collector.go
+++ b/src/control/lib/telemetry/promexp/collector.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/promexp/collector_test.go
+++ b/src/control/lib/telemetry/promexp/collector_test.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/snapshot.go
+++ b/src/control/lib/telemetry/snapshot.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/snapshot_test.go
+++ b/src/control/lib/telemetry/snapshot_test.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-1-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/telemetry.go
+++ b/src/control/lib/telemetry/telemetry.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/test_helpers.go
+++ b/src/control/lib/telemetry/test_helpers.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/timestamp.go
+++ b/src/control/lib/telemetry/timestamp.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/lib/telemetry/timestamp_test.go
+++ b/src/control/lib/telemetry/timestamp_test.go
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-1-Clause-Patent
 //
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux && (amd64 || arm64)
+// +build linux
+// +build amd64 arm64
 
 //
 

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -66,7 +66,7 @@ func (w *spdkWrapper) suppressOutput() (restore restoreFn, err error) {
 		return
 	}
 
-	if err = syscall.Dup2(int(devNull.Fd()), syscall.Stdout); err != nil {
+	if err = Dup2(int(devNull.Fd()), syscall.Stdout); err != nil {
 		return
 	}
 
@@ -77,7 +77,7 @@ func (w *spdkWrapper) suppressOutput() (restore restoreFn, err error) {
 		if err := devNull.Close(); err != nil {
 			panic(err)
 		}
-		if err := syscall.Dup2(realStdout, syscall.Stdout); err != nil {
+		if err := Dup2(realStdout, syscall.Stdout); err != nil {
 			panic(err)
 		}
 	}

--- a/src/control/server/storage/bdev/syscall_amd64.go
+++ b/src/control/server/storage/bdev/syscall_amd64.go
@@ -1,0 +1,18 @@
+//
+// (C) Copyright 2019-2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+//go:build linux && amd64
+// +build linux,amd64
+
+package bdev
+
+import (
+	"syscall"
+)
+
+func Dup2(oldfd, newfd int) error {
+	return syscall.Dup2(oldfd, newfd)
+}

--- a/src/control/server/storage/bdev/syscall_arm64.go
+++ b/src/control/server/storage/bdev/syscall_arm64.go
@@ -1,0 +1,18 @@
+//
+// (C) Copyright 2019-2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+//go:build linux && arm64
+// +build linux,arm64
+
+package bdev
+
+import (
+	"syscall"
+)
+
+func Dup2(oldfd, newfd int) error {
+	return syscall.Dup3(oldfd, newfd, 0)
+}


### PR DESCRIPTION
go:build support both amd64 and arm64.
Dup2 function is added to support both amd64 and arm64.