### PR TITLE
DAOS-10435 IV: add update and sync epoch for pool IV.

### DIFF
--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -82,6 +82,7 @@ struct pool_iv_conns {
 struct pool_iv_key {
 	uuid_t		pik_uuid;
 	uint32_t	pik_entry_size; /* IV entry size */
+	daos_epoch_t	pik_eph;
 };
 
 struct pool_iv_hdl {

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -695,6 +695,8 @@ pool_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		   d_sg_list_t *src, void **priv)
 {
 	struct pool_iv_entry	*src_iv = src->sg_iovs[0].iov_buf;
+	struct pool_iv_key	*ent_pool_key = key2priv(&entry->iv_key);
+	struct pool_iv_key	*pool_key = key2priv(key);
 	struct ds_pool		*pool;
 	d_rank_t		rank;
 	int			rc;
@@ -711,6 +713,16 @@ pool_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 
 	if (rank != entry->ns->iv_master_rank)
 		D_GOTO(out_put, rc = -DER_IVCB_FORWARD);
+
+	if (ent_pool_key->pik_eph > pool_key->pik_eph && pool_key->pik_eph != 0) {
+		/* If incoming key/eph is older than the current entry/key, then it means
+		 * incoming update request is stale, especially for LAZY/asynchronous/retry
+		 * cases, see iv_op().
+		 */
+		D_DEBUG(DB_MD, "current entry eph "DF_U64" > "DF_U64"\n",
+			ent_pool_key->pik_eph, pool_key->pik_eph);
+		D_GOTO(out_put, rc);
+	}
 
 	D_DEBUG(DB_TRACE, DF_UUID "rank %d master rank %d\n",
 		DP_UUID(entry->ns->iv_pool_uuid), rank,
@@ -749,6 +761,8 @@ pool_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	}
 
 	rc = pool_iv_ent_copy(key, &entry->iv_value, src_iv, true);
+	if (rc == 0)
+		ent_pool_key->pik_eph = pool_key->pik_eph;
 out_put:
 	D_DEBUG(DB_MD, DF_UUID": key %u rc %d\n",
 		DP_UUID(entry->ns->iv_pool_uuid), key->class_id, rc);
@@ -814,6 +828,8 @@ static int
 pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		    d_sg_list_t *src, int ref_rc, void **priv)
 {
+	struct pool_iv_key	*pool_key = key2priv(key);
+	struct pool_iv_key	*ent_pool_key = key2priv(&entry->iv_key);
 	struct pool_iv_entry	*src_iv;
 	struct ds_pool		*pool = 0;
 	int			rc = 0;
@@ -822,6 +838,16 @@ pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	if (pool == NULL) {
 		D_WARN("No pool "DF_UUID"\n", DP_UUID(entry->ns->iv_pool_uuid));
 		D_GOTO(out_put, rc = 0);
+	}
+
+	if (ent_pool_key->pik_eph > pool_key->pik_eph && pool_key->pik_eph != 0) {
+		/* If incoming key/eph is older than the current entry/key, then it means
+		 * incoming update request is stale, especially for LAZY/asynchronous/retry
+		 * cases, see iv_op().
+		 */
+		D_DEBUG(DB_MD, "current entry eph "DF_U64" > "DF_U64"\n",
+			ent_pool_key->pik_eph, pool_key->pik_eph);
+		D_GOTO(out_put, rc);
 	}
 
 	if (src == NULL) {
@@ -881,7 +907,8 @@ pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 
 update_iv_cache:
 	rc = pool_iv_ent_copy(key, &entry->iv_value, src_iv, true);
-
+	if (rc == 0)
+		ent_pool_key->pik_eph = pool_key->pik_eph;
 out_put:
 	D_DEBUG(DB_MD, DF_UUID": key %u rc %d\n",
 		DP_UUID(entry->ns->iv_pool_uuid), key->class_id, rc);
@@ -1013,6 +1040,7 @@ pool_iv_update(void *ns, int class_id, uuid_t key_uuid,
 	key.class_id = class_id;
 	pool_key = (struct pool_iv_key *)key.key_buf;
 	pool_key->pik_entry_size = pool_iv_len;
+	pool_key->pik_eph = crt_hlc_get();
 	uuid_copy(pool_key->pik_uuid, key_uuid);
 
 	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0, retry);


### PR DESCRIPTION
Assume these IV update process.

1. pool service start, IV prop update asynchronously.
2. set property.
3. pool IV update asynchronously.

Since 1 and 3 are asynchrnously, especially if 1 needs to
retry, then 1 might arrive later than 3 for one engine, so
adding epoch to pool IV key, and if the incoming IV update epoch
is older than the current epoch of the entry, let's ignore
the update.

Test-tag: pr offline_reintegration_with_rf offline_reintegration_oclass
ec_offline_rebuild_array ec_offline_rebuild_agg_disabled
ec_offline_rebuild_agg_default ec_offline_agg_during_rebuild

Signed-off-by: Di Wang <di.wang@intel.com>