### PR TITLE
DAOS-10500 test: Make nvme/health more flexible (#9346)

### DIFF
--- a/src/tests/ftest/nvme/health.py
+++ b/src/tests/ftest/nvme/health.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from __future__ import division
-import os
 
 from nvme_utils import ServerFillUp, get_device_ids
 from dmg_utils import DmgCommand
@@ -21,9 +20,10 @@ class NvmeHealth(ServerFillUp):
         """Jira ID: DAOS-4722.
 
         Test Description: Test Health monitor for large number of pools.
-        Use Case: This tests will create the 40 number of pools and verify the
-                  dmg list-pools, device-health and nvme-health works for all
-                  pools.
+        Use Case: This test creates many pools and verifies the following command behavior:
+            dmg storage query list-pools
+            dmg storage query device-health
+            dmg storage scan --nvme-health
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
@@ -32,26 +32,35 @@ class NvmeHealth(ServerFillUp):
         """
         # pylint: disable=attribute-defined-outside-init
         # pylint: disable=too-many-branches
-        no_of_pools = self.params.get("number_of_pools", '/run/pool/*')
-        pool_capacity = self.params.get("pool_used_percentage", '/run/pool/*')
-        pool_capacity = pool_capacity / 100
-        storage = self.get_max_storage_sizes()
+        max_num_pools = self.params.get("max_num_pools", '/run/pool/*')
+        total_pool_percentage = self.params.get("total_pool_percentage", '/run/pool/*') / 100
+        min_nvme_per_target = self.params.get("min_nvme_per_target", '/run/pool/*')
+        targets_per_engine = self.server_managers[0].get_config_value("targets")
 
-        #Create the pool from available of storage space
-        single_pool_nvme_size = int((storage[1] * pool_capacity)/no_of_pools)
-        single_pool_scm_size = int((storage[0] * pool_capacity)/no_of_pools)
+        # Calculate the space per engine based on the percentage to use
+        space_per_engine = self.get_max_storage_sizes()
+        scm_per_engine = int(space_per_engine[0] * total_pool_percentage)
+        nvme_per_engine = int(space_per_engine[1] * total_pool_percentage)
 
+        # Calculate the potential number of pools and use up to the max from config
+        potential_num_pools = int((nvme_per_engine / (min_nvme_per_target * targets_per_engine)))
+        actual_num_pools = min(max_num_pools, potential_num_pools)
+
+        # Split available space across the number of pools to be created
+        scm_per_pool = int(scm_per_engine / actual_num_pools)
+        nvme_per_pool = int(nvme_per_engine / actual_num_pools)
+
+        # Create the pools
         self.pool = []
-        # Create the Large number of pools
-        for _pool in range(no_of_pools):
+        for _pool in range(actual_num_pools):
             self.log.info("-- Creating pool number = %s", _pool)
             self.pool.append(self.get_pool(create=False))
-            self.pool[-1].scm_size.update(single_pool_scm_size, "scm_size")
-            self.pool[-1].nvme_size.update(single_pool_nvme_size, "nvme_size")
+            self.pool[-1].scm_size.update(scm_per_pool, "scm_size")
+            self.pool[-1].nvme_size.update(nvme_per_pool, "nvme_size")
             self.pool[-1].create()
 
         # initialize the dmg command
-        self.dmg = DmgCommand(os.path.join(self.prefix, "bin"))
+        self.dmg = DmgCommand(self.bin)
         self.dmg.get_params(self)
         self.dmg.insecure.update(
             self.server_managers[0].get_config_value("allow_insecure"),
@@ -77,16 +86,15 @@ class NvmeHealth(ServerFillUp):
         device_ids = get_device_ids(self.dmg, self.hostlist_servers)
 
         # Get the device health
-        for host in device_ids:
+        for host, dev_list in device_ids.items():
             self.dmg.hostlist = host
-            for _dev in device_ids[host]:
+            for _dev in dev_list:
                 try:
                     result = self.dmg.storage_query_device_health(_dev)
                 except CommandFailure as error:
                     self.fail("dmg get device states failed {}".format(error))
                 if 'State:NORMAL' not in result.stdout_text:
-                    self.fail("device {} on host {} is not NORMAL"
-                              .format(_dev, host))
+                    self.fail("device {} on host {} is not NORMAL".format(_dev, host))
 
         # Get the nvme-health
         try:

--- a/src/tests/ftest/nvme/health.yaml
+++ b/src/tests/ftest/nvme/health.yaml
@@ -10,6 +10,7 @@ server_config:
   name: daos_server
   servers:
     0:
+      targets: 8
       pinned_numa_node: 0
       nr_xs_helpers: 1
       fabric_iface: ib0
@@ -21,6 +22,7 @@ server_config:
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
     1:
+      targets: 8
       pinned_numa_node: 1
       nr_xs_helpers: 1
       fabric_iface: ib1
@@ -43,5 +45,6 @@ pool:
     mode: 146
     name: daos_server
     control_method: dmg
-    number_of_pools: 40
-    pool_used_percentage: 90
+    max_num_pools: 40
+    total_pool_percentage: 95
+    min_nvme_per_target: 1073741824 # 1 GiB


### PR DESCRIPTION
Test-tag: nvme_health mdtest_small
Skip-unit-tests: true
Skip-fault-injection-test: true

To account for nodes with reduced nvme space, create UP TO 40 pools
instead of exactly 40 pools.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>