### PR TITLE
DAOS-10861 tests: Reducing requirements for VM tests

### DIFF
--- a/src/tests/ftest/checksum/csum_basic.py
+++ b/src/tests/ftest/checksum/csum_basic.py
@@ -63,8 +63,9 @@ class CsumContainerValidation(TestWithServers):
         Test Description: Write Avocado Test to verify single data after
                           pool/container disconnect/reconnect.
         :avocado: tags=all,daily_regression
+        :avocado: vm
         :avocado: tags=checksum
-        :avocado: tags=basic_checksum_object
+        :avocado: tags=basic_checksum_object,test_single_object_with_checksum
         """
         self.d_log.info("Writing the Single Dataset")
         record_index = 0

--- a/src/tests/ftest/checksum/csum_basic.yaml
+++ b/src/tests/ftest/checksum/csum_basic.yaml
@@ -7,7 +7,10 @@ hosts:
   - client-B
 timeout: 100
 server_config:
- name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
     createmode:
         mode_RW:

--- a/src/tests/ftest/container/api_basic_attribute.yaml
+++ b/src/tests/ftest/container/api_basic_attribute.yaml
@@ -6,6 +6,9 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/container/async.py
+++ b/src/tests/ftest/container/async.py
@@ -39,7 +39,10 @@ class ContainerAsync(TestWithServers):
         The negative case is more like a test of the API implementation rather
         than DAOS itself.
 
-        :avocado: tags=all,full_regression,container,cont_create_async
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=cont_create_async,test_create_async
         """
         self.add_pool()
         ph = self.pool.pool.handle

--- a/src/tests/ftest/container/async.yaml
+++ b/src/tests/ftest/container/async.yaml
@@ -2,6 +2,11 @@ hosts:
   test_servers:
     - server-A
 timeout: 240
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   control_method: dmg
   scm_size: 1G

--- a/src/tests/ftest/container/auto_oc_selection.py
+++ b/src/tests/ftest/container/auto_oc_selection.py
@@ -32,7 +32,7 @@ class AutoOCSelectionTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container
-        :avocado: tags=oc_selection
+        :avocado: tags=oc_selection,test_oc_selection
         """
         self.add_pool()
 

--- a/src/tests/ftest/container/auto_oc_selection.yaml
+++ b/src/tests/ftest/container/auto_oc_selection.yaml
@@ -6,6 +6,11 @@ hosts:
     - server-D
     - server-E
 timeout: 180
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   scm_size: 1G
   control_method: dmg

--- a/src/tests/ftest/container/basic_snapshot.py
+++ b/src/tests/ftest/container/basic_snapshot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -45,7 +45,10 @@ class BasicSnapshot(TestWithServers):
             Verify the snapshot is still available and the contents remain in
             their original state.
 
-        :avocado: tags=all,daily_regression,snap,basicsnap
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=snap,basicsnap,test_basic_snapshot
         """
         # Set up the pool and container.
         try:

--- a/src/tests/ftest/container/basic_snapshot.yaml
+++ b/src/tests/ftest/container/basic_snapshot.yaml
@@ -6,7 +6,10 @@ hosts:
     - server-A
     - server-B
 server_config:
-    name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
     mode: 511
     name: daos_server

--- a/src/tests/ftest/container/close.py
+++ b/src/tests/ftest/container/close.py
@@ -23,7 +23,7 @@ class ContainerCloseTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=smoke,container
-        :avocado: tags=container_close
+        :avocado: tags=container_close,test_container_close
         """
         self.container = []
         saved_coh = None

--- a/src/tests/ftest/container/close.yaml
+++ b/src/tests/ftest/container/close.yaml
@@ -3,7 +3,10 @@ hosts:
     - server-A
 timeout: 60
 server_config:
-    name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/container/create.py
+++ b/src/tests/ftest/container/create.py
@@ -25,7 +25,10 @@ class CreateContainerTest(TestWithServers):
 
         Test Description: valid and invalid container creation and close.
 
-        :avocado: tags=all,container,tiny,smoke,full_regression,containercreate
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=container,smoke
+        :avocado: tags=container_create,test_container_create
         """
         expected_results = []
 

--- a/src/tests/ftest/container/create.yaml
+++ b/src/tests/ftest/container/create.yaml
@@ -6,6 +6,9 @@ hosts:
 timeout: 100
 server_config:
    name: daos_server
+   servers:
+      targets: 4
+      nr_xs_helpers: 0
 pool:
    mode: 511
    name: daos_server

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -25,7 +25,7 @@ class ContainerDestroyTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container,smoke
-        :avocado: tags=container_destroy
+        :avocado: tags=container_destroy,test_container_destroy
         """
         expected_for_param = []
         change_result_uuid = self.params.get(

--- a/src/tests/ftest/container/destroy.yaml
+++ b/src/tests/ftest/container/destroy.yaml
@@ -6,6 +6,9 @@ timeout: 60
 
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 
 pool:
   scm_size: 1G

--- a/src/tests/ftest/container/global_handle.py
+++ b/src/tests/ftest/container/global_handle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -74,8 +74,9 @@ class GlobalHandle(TestWithServers):
         Test Description: Use a pool handle in another process.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=tiny
-        :avocado: tags=container,global_handle,container_global_handle
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=global_handle,container_global_handle,test_global_handle
         """
         # initialize a python pool object then create the underlying
         # daos storage and connect to it

--- a/src/tests/ftest/container/global_handle.yaml
+++ b/src/tests/ftest/container/global_handle.yaml
@@ -6,6 +6,9 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/container/list.py
+++ b/src/tests/ftest/container/list.py
@@ -61,8 +61,9 @@ class ListContainerTest(TestWithServers):
             See test cases in the class description.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=container,list_containers
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=list_containers,test_list_containers
         """
         expected_uuids1 = []
         self.pool = []

--- a/src/tests/ftest/container/list.yaml
+++ b/src/tests/ftest/container/list.yaml
@@ -4,6 +4,9 @@ hosts:
 timeout: 140
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   control_method: dmg
   size: 300MB

--- a/src/tests/ftest/container/open.py
+++ b/src/tests/ftest/container/open.py
@@ -46,7 +46,7 @@ class OpenContainerTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container
-        :avocado: tags=container_open
+        :avocado: tags=container_open,test_container_open
         """
         self.pool = []
         self.container = []

--- a/src/tests/ftest/container/open.yaml
+++ b/src/tests/ftest/container/open.yaml
@@ -4,6 +4,9 @@ hosts:
 timeout: 50
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/container/query_attribute.py
+++ b/src/tests/ftest/container/query_attribute.py
@@ -46,8 +46,9 @@ class ContainerQueryAttributeTest(TestWithServers):
             Test container query, set-attr, get-attr, and list-attrs.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=container,cont_query_attr
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=cont_query_attr,test_container_query_attr
         """
         # Create a pool and a container.
         self.add_pool()
@@ -157,8 +158,9 @@ class ContainerQueryAttributeTest(TestWithServers):
             Test daos container list-attrs with 50 attributes.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=container,cont_list_attrs
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=cont_list_attrs,test_list_attrs_long
         """
         # Create a pool and a container.
         self.add_pool()

--- a/src/tests/ftest/container/query_attribute.yaml
+++ b/src/tests/ftest/container/query_attribute.yaml
@@ -6,6 +6,7 @@ server_config:
   name: daos_server
   servers:
     targets: 8
+    nr_xs_helpers: 0
 pool:
   scm_size: 1G
   control_method: dmg

--- a/src/tests/ftest/container/query_properties.py
+++ b/src/tests/ftest/container/query_properties.py
@@ -36,7 +36,7 @@ class QueryPropertiesTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container
-        :avocado: tags=query_properties
+        :avocado: tags=query_properties,test_query_properties
         """
         errors = []
 

--- a/src/tests/ftest/container/query_properties.yaml
+++ b/src/tests/ftest/container/query_properties.yaml
@@ -4,6 +4,12 @@ hosts:
 
 timeout: 100
 
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+
 pool:
   scm_size: 1G
   control_method: dmg

--- a/src/tests/ftest/container/rf_enforcement.py
+++ b/src/tests/ftest/container/rf_enforcement.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -41,9 +41,10 @@ class ContRfEnforce(ContRedundancyFactor):
             write io verification.
 
         :avocado: tags=all,full_regression
+        :avocado: tags=vm
         :avocado: tags=container
-        :avocado: tags=container_rf
-        :avocado: tags=cont_rf_oclass_enforcement
+        :avocado: tags=container_rf,cont_rf_oclass_enforcement
+        :avocado: tags=test_container_redundancy_factor_oclass_enforcement
         """
         self.mode = "cont_rf_enforcement"
         self.execute_cont_rf_test()

--- a/src/tests/ftest/container/rf_enforcement.yaml
+++ b/src/tests/ftest/container/rf_enforcement.yaml
@@ -13,6 +13,7 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    nr_xs_helpers: 0
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/container/simple_create_delete.py
+++ b/src/tests/ftest/container/simple_create_delete.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -24,7 +24,10 @@ class SimpleCreateDeleteTest(TestWithServers):
     def test_container_basics(self):
         """Test basic container create/destroy/open/close/query.
 
-        :avocado: tags=all,container,pr,daily_regression,medium,basecont
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=basecont,test_container_basics
         """
         # Create a pool
         self.log.info("Create a pool")

--- a/src/tests/ftest/container/simple_create_delete.yaml
+++ b/src/tests/ftest/container/simple_create_delete.yaml
@@ -6,6 +6,9 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -144,8 +144,10 @@ class Snapshot(TestWithServers):
                 (6)Verify snap_list bad parameter behavior.
 
         Use Cases: Combinations with minimum 1 client and 1 server.
-        :avocado: tags=all,small,smoke,daily_regression,snap,snapshot_negative,
-        :avocado: tags=snapshotcreate_negative
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=container,smoke
+        :avocado: tags=snap,snapshot_negative,snapshotcreate_negative,test_snapshot_negativecases
         """
 
         # DAOS-1322 Create a new container, verify snapshot state as expected
@@ -320,7 +322,11 @@ class Snapshot(TestWithServers):
         Use Cases: Require 1 client and 1 server to run snapshot test.
                    1 pool and 1 container is used, num_of_snapshot defined
                    in the snapshot.yaml will be performed and verified.
-        :avocado: tags=all,small,smoke,snap,snapshots,full_regression
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=container,smoke
+        :avocado: tags=snap,snapshots,test_snapshots
         """
 
         test_data = []

--- a/src/tests/ftest/container/snapshot.yaml
+++ b/src/tests/ftest/container/snapshot.yaml
@@ -7,7 +7,10 @@ faults:
     no_faults:
       fault_list: []
 server_config:
-   name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
     name: daos_server
     scm_size: 1G

--- a/src/tests/ftest/control/daos_agent_config.py
+++ b/src/tests/ftest/control/daos_agent_config.py
@@ -34,9 +34,9 @@ class DaosAgentConfigTest(TestWithServers):
         on the system.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=small,agent_start,basic
-        :avocado: tags=control,daos_agent_config_test
-        :avocado: tags=test_daos_agent_config_basic
+        :avocado: tags=vm
+        :avocado: tags=control,basic
+        :avocado: tags=agent_start,daos_agent_config_test,test_daos_agent_config_basic
         """
         # Setup the agents
         self.add_agent_manager()

--- a/src/tests/ftest/control/daos_agent_config.yaml
+++ b/src/tests/ftest/control/daos_agent_config.yaml
@@ -8,6 +8,9 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/control/daos_control_config.py
+++ b/src/tests/ftest/control/daos_control_config.py
@@ -24,7 +24,10 @@ class DaosControlConfigTest(TestWithServers):
         Test Description: Test dmg tool executes with variant positive and
         negative inputs to its configuration file.
 
-        :avocado: tags=all,small,control,daily_regression,control_start,basic
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,basic
+        :avocado: tags=control_start,test_daos_control_config_basic
         """
         # Get the input to verify
         c_val = self.params.get("config_val", "/run/control_config_val/*/")

--- a/src/tests/ftest/control/daos_control_config.yaml
+++ b/src/tests/ftest/control/daos_control_config.yaml
@@ -8,6 +8,9 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/control/daos_object_query.py
+++ b/src/tests/ftest/control/daos_object_query.py
@@ -38,9 +38,11 @@ class DaosObjectQuery(TestWithServers):
     def test_object_query(self):
         """JIRA ID: DAOS-4694
         Test Description: Test daos object query.
+
         :avocado: tags=all,full_regression
+        :avocado: tags=vm
         :avocado: tags=control
-        :avocado: tags=daos_object_query
+        :avocado: tags=daos_object_query,test_object_query
         """
         daos_cmd = DaosCommand(self.bin)
         errors = []

--- a/src/tests/ftest/control/daos_object_query.yaml
+++ b/src/tests/ftest/control/daos_object_query.yaml
@@ -7,6 +7,9 @@ hosts:
 timeout: 80
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
 pool:
     name: daos_server
     scm_size: 4G

--- a/src/tests/ftest/control/daos_snapshot.py
+++ b/src/tests/ftest/control/daos_snapshot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -97,7 +97,10 @@ class DaosSnapshotTest(TestWithServers):
         Use Cases:
             See test cases in the class description.
 
-        :avocado: tags=all,small,control,full_regression,daos_snapshot
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=control
+        :avocado: tags=daos_snapshot,test_create_list_delete
         """
         self.prepare_pool_container()
 
@@ -127,7 +130,10 @@ class DaosSnapshotTest(TestWithServers):
         Use Cases:
             See class description.
 
-        :avocado: tags=all,small,container,full_regression,daos_snapshot_range
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=daos_snapshot_range,test_epcrange
         """
         self.prepare_pool_container()
 

--- a/src/tests/ftest/control/daos_snapshot.yaml
+++ b/src/tests/ftest/control/daos_snapshot.yaml
@@ -4,6 +4,9 @@ hosts:
 timeout: 400
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   scm_size: 1G
   control_method: dmg

--- a/src/tests/ftest/control/dmg_nvme_scan_test.py
+++ b/src/tests/ftest/control/dmg_nvme_scan_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -31,7 +31,11 @@ class DmgNvmeScanTest(TestWithServers):
         JIRA ID: DAOS-2485
         Test Description: Test basic dmg functionality to scan the nvme storage.
         on the system.
-        :avocado: tags=all,tiny,daily_regression,dmg,nvme_scan,basic
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,basic,dmg
+        :avocado: tags=nvme_scan,test_dmg_nvme_scan_basic
         """
         # Create dmg command
         dmg = DmgCommand(os.path.join(self.prefix, "bin"))

--- a/src/tests/ftest/control/dmg_nvme_scan_test.yaml
+++ b/src/tests/ftest/control/dmg_nvme_scan_test.yaml
@@ -7,6 +7,9 @@ timeout: 60
 server_config:
   name: daos_server
   port: 10001
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 dmg:
   dmg_sub_command: storage
   storage:

--- a/src/tests/ftest/control/dmg_pool_evict.py
+++ b/src/tests/ftest/control/dmg_pool_evict.py
@@ -32,8 +32,9 @@ class DmgPoolEvictTest(TestWithServers):
         Test Description: Test dmg pool evict.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=control,dmg_pool_evict
+        :avocado: tags=vm
+        :avocado: tags=control
+        :avocado: tags=dmg_pool_evict,test_dmg_pool_evict
         """
         # Create 2 pools and create a container in each pool.
         self.pool = []

--- a/src/tests/ftest/control/dmg_pool_evict.yaml
+++ b/src/tests/ftest/control/dmg_pool_evict.yaml
@@ -4,6 +4,9 @@ hosts:
 timeout: 140
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
 pool:
     control_method: dmg
     scm_size: 1GB

--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -35,7 +35,7 @@ class DmgPoolQueryRanks(ControlTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dmg,control,pool_query,pool_query_ranks
-        :avocado: tags=pool_query_ranks_basic
+        :avocado: tags=pool_query_ranks_basic,test_pool_query_ranks_basic
         """
         self.log.info("Basic tests of pool query with ranks state")
 
@@ -75,7 +75,7 @@ class DmgPoolQueryRanks(ControlTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dmg,control,pool_query,pool_query_ranks
-        :avocado: tags=pool_query_ranks_error
+        :avocado: tags=pool_query_ranks_error,test_pool_query_ranks_error
         """
         self.log.info("Tests of pool query with incompatible options")
 
@@ -99,7 +99,7 @@ class DmgPoolQueryRanks(ControlTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dmg,control,pool_query,pool_query_ranks
-        :avocado: tags=pool_query_ranks_mgmt
+        :avocado: tags=pool_query_ranks_mgmt,test_pool_query_ranks_mgmt
         """
         self.log.info("Tests of pool query with ranks state when playing with ranks")
 

--- a/src/tests/ftest/control/dmg_pool_query_ranks.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.yaml
@@ -14,6 +14,8 @@ server_config:
       scm_class: ram
       scm_mount: /mnt/daos
       scm_size: 6
+      targets: 4
+      nr_xs_helpers: 0
 pool:
   name: daos_server
   control_method: dmg

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -32,8 +32,9 @@ class DmgSystemCleanupTest(TestWithServers):
         Test Description: Test dmg system cleanup.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small,dmg
-        :avocado: tags=control,dmg_system_cleanup
+        :avocado: tags=vm
+        :avocado: tags=control,dmg
+        :avocado: tags=dmg_system_cleanup,test_dmg_system_cleanup_one_host
         """
         # Print out where this is running
         hostname = gethostname().split(".")[0]

--- a/src/tests/ftest/control/dmg_system_cleanup.yaml
+++ b/src/tests/ftest/control/dmg_system_cleanup.yaml
@@ -4,6 +4,9 @@ hosts:
 timeout: 600
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
 pool:
     control_method: dmg
     scm_size: 1GB

--- a/src/tests/ftest/control/dmg_system_leader_query.py
+++ b/src/tests/ftest/control/dmg_system_leader_query.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2021 Intel Corporation.
+  (C) Copyright 2021-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -28,7 +28,11 @@ class DmgSystemLeaderQueryTest(ControlTestBase):
         JIRA ID: DAOS-4822
         Test Description: Test that system leader-query command reports leader
             consistently regardless of which server is queried.
-        :avocado: tags=all,basic,daily_regression,dmg,system_leader_query
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,basic,dmg
+        :avocado: tags=system_leader_query,test_dmg_system_leader_query
         """
         last_result = None
         for host in self.hosts:

--- a/src/tests/ftest/control/dmg_system_leader_query.yaml
+++ b/src/tests/ftest/control/dmg_system_leader_query.yaml
@@ -6,3 +6,6 @@ hosts:
 timeout: 120
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0

--- a/src/tests/ftest/control/dmg_telemetry_basic.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_basic.yaml
@@ -11,6 +11,8 @@ server_config:
   name: daos_server
   servers:
     scm_size: 4
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   scm_size: 2G
   control_method: dmg

--- a/src/tests/ftest/control/dmg_telemetry_io_basic.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_basic.py
@@ -92,7 +92,7 @@ class TestWithTelemetryIOBasic(IorTestBase, TestWithTelemetry):
         :avocado: tags=vm
         :avocado: tags=control,telemetry
         :avocado: tags=test_with_telemetry_basic,test_io_telemetry
-        :avocado: tags=test_io_telemetry_basic
+        :avocado: tags=test_io_telemetry_basic,test_io_telmetry_metrics_basic
 
         """
         block_sizes = self.params.get("block_sizes", "/run/*")

--- a/src/tests/ftest/control/dmg_telemetry_io_basic.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_io_basic.yaml
@@ -9,6 +9,7 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    nr_xs_helpers: 0
 pool:
   name: daos_server
   scm_size: 1G

--- a/src/tests/ftest/control/ms_failover.py
+++ b/src/tests/ftest/control/ms_failover.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-(C) Copyright 2021 Intel Corporation.
+(C) Copyright 2021-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -123,7 +123,9 @@ class ManagementServiceFailover(TestWithServers):
             Test that the MS leader resigns on dRPC failure and that a new
             leader is elected.
 
-        :avocado: tags=all,pr,daily_regression,control,ms_failover
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control
         :avocado: tags=ms_failover
         """
         replicas = self.launch_servers()

--- a/src/tests/ftest/control/ms_failover.yaml
+++ b/src/tests/ftest/control/ms_failover.yaml
@@ -15,6 +15,8 @@ server_config:
     log_mask: DEBUG,MEM=ERR
     env_vars:
       - DD_MASK=mgmt
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   mode: 146
   scm_size: 1073741824

--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -299,6 +299,7 @@ class ManagementServiceResilience(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=control,ms_resilience,ms_retained_quorum_N_1
+        :avocado: test_ms_resilience_1
         """
         # Run test cases
         self.verify_retained_quorum(1)
@@ -313,6 +314,7 @@ class ManagementServiceResilience(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=control,ms_resilience,ms_retained_quorum_N_2
+        :avocado: test_ms_resilience_2
         """
         # Run test cases
         self.verify_retained_quorum(2)
@@ -329,6 +331,7 @@ class ManagementServiceResilience(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=control,ms_resilience,ms_regained_quorum_N_1
+        :avocado: test_ms_resilience_3
         """
         # Run test case
         self.verify_regained_quorum(1)
@@ -345,6 +348,7 @@ class ManagementServiceResilience(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=control,ms_resilience,ms_regained_quorum_N_2
+        :avocado: test_ms_resilience_4
         """
         # Run test case
         self.verify_regained_quorum(2)

--- a/src/tests/ftest/control/ms_resilience.yaml
+++ b/src/tests/ftest/control/ms_resilience.yaml
@@ -15,6 +15,8 @@ server_config:
     log_mask: DEBUG,MEM=ERR
     env_vars:
       - DD_MASK=mgmt
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   mode: 146
   scm_size: 1073741824

--- a/src/tests/ftest/control/super_block_versioning.py
+++ b/src/tests/ftest/control/super_block_versioning.py
@@ -27,7 +27,10 @@ class SuperBlockVersioning(TestWithServers):
         Test Description:
             Basic test to verify that superblock file is versioned.
 
-        :avocado: tags=all,tiny,daily_regression,ds_versioning,basic
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,basic
+        :avocado: tags=ds_versioning,test_super_block_version_basic
         """
         # Check that the superblock file exists under the scm_mount dir.
         scm_mount = self.server_managers[0].get_config_value("scm_mount")

--- a/src/tests/ftest/control/super_block_versioning.yaml
+++ b/src/tests/ftest/control/super_block_versioning.yaml
@@ -4,3 +4,7 @@ hosts:
   test_servers:
     - server-A
 timeout: 60
+server_config:
+  servers:
+    targets: 4
+    nr_xs_helpers: 0

--- a/src/tests/ftest/control/version.py
+++ b/src/tests/ftest/control/version.py
@@ -23,7 +23,7 @@ class DAOSVersion(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=control
-        :avocado: tags=version_number
+        :avocado: tags=version_number,test_version
         """
         errors = []
 

--- a/src/tests/ftest/control/version.yaml
+++ b/src/tests/ftest/control/version.yaml
@@ -2,5 +2,9 @@ hosts:
   test_servers:
     - server-A
 timeout: 60
+server_config:
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
 pool:
   control_method: dmg

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -440,7 +440,7 @@ class DaosServerYamlParameters(YamlParameters):
             #       AIO /tmp/aiofile AIO1 4096
             self.scm_mount = BasicParameter(None, "/mnt/daos")
             self.scm_class = BasicParameter(None, "ram")
-            self.scm_size = BasicParameter(None, 16)
+            self.scm_size = BasicParameter(None, 4)
             self.scm_list = BasicParameter(None)
             self.bdev_class = BasicParameter(None)
             self.bdev_list = BasicParameter(None)


### PR DESCRIPTION
Reducing the allocated amount of SCM space (tmpfs) being used in the VMs
and removing helper xstreams and reducing the number of targets to 4x.

Skip-unit-tests: true
Test-tag: vm

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>