### PR TITLE
DAOS-10831 obj: Fix a bug in EC degraded fetch's data recovery

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2176,16 +2176,21 @@ obj_ec_stripe_list_add(struct daos_recx_ep_list *stripe_list,
 			continue;
 		}
 		if (recx_ep->re_ep != stripe_recx->re_ep) {
-			D_ERROR("overlapped recx with different shadow epoch, "
+			D_DEBUG(DB_IO, "overlapped recx with different shadow epoch, "
 				"["DF_U64", "DF_U64"]@"DF_X64", "
 				"["DF_U64", "DF_U64"]@"DF_X64"\n",
 				recx_ep->re_recx.rx_idx, recx_ep->re_recx.rx_nr,
 				recx_ep->re_ep, stripe_recx->re_recx.rx_idx,
 				stripe_recx->re_recx.rx_nr, stripe_recx->re_ep);
-			return -DER_PROTO;
+			/* It is possible that different shard fetches go to different parity
+			 * shards, they got recov_lists with different parity epoch in the case
+			 * vos aggregation happens asynchronously on different parity shards
+			 * that may merge adjacent parity exts to lower epoch. So here can
+			 * just take higher epoch for data recovery.
+			 */
+			recx_ep->re_ep = max(recx_ep->re_ep, stripe_recx->re_ep);
 		}
-		start = min(recx_ep->re_recx.rx_idx,
-			    stripe_recx->re_recx.rx_idx);
+		start = min(recx_ep->re_recx.rx_idx, stripe_recx->re_recx.rx_idx);
 		recx_ep->re_recx.rx_nr =
 			max(recx_ep->re_recx.rx_idx + recx_ep->re_recx.rx_nr,
 			    stripe_recx->re_recx.rx_idx +


### PR DESCRIPTION
It is possible that different shard fetches go to different parity
shards, they got recov_lists with different parity epoch in the case
vos aggregation happens asynchronously on different parity shards
that may merge adjacent parity exts to lower epoch.
In obj_ec_stripe_list_add() for that case can take higher epoch for
data recovery.

Master branch PR: #9384

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>