### PR TITLE
DAOS-9644 doc: clarify default engine logfile in server.yml (#9436)

### DIFF
--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -227,13 +227,13 @@
 #
 ## Enable daos_admin (privileged helper) logging.
 #
-## default: disabled (errors only to control plane log)
+## default: disabled (errors only to control_log_file)
 #helper_log_file: /tmp/daos_admin.log
 #
 #
 ## Enable daos_firmware (privileged helper) logging.
 #
-## default: disabled (errors only to control plane log)
+## default: disabled (errors only to control_log_file)
 #firmware_helper_log_file: /tmp/daos_firmware.log
 #
 #
@@ -329,7 +329,7 @@
 #
 #  # Force specific path for DAOS debug logs.
 #
-#  # default: /tmp/daos.log
+#  # default: engine log goes to control_log_file
 #  log_file: /tmp/daos_engine.0.log
 #
 #  # Pass specific environment variables to the engine process.
@@ -469,7 +469,7 @@
 #
 #  # Force specific path for DAOS debug logs.
 #
-#  # default: /tmp/daos.log
+#  # default: engine log goes to control_log_file
 #  log_file: /tmp/daos_engine.1.log
 #
 #  # Pass specific environment variables to the engine process.


### PR DESCRIPTION
clarify default engine logfile in daos_server.yml

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>