### PR TITLE
DAOS-623 git: Fix .gitignore after name change of generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,7 @@ test/tool/build/
 foo
 foo2
 foo.o
-src/cart/_structures_from_macros_.h
-src/cart/src/cart/_structures_from_macros_.h
+src/cart/_structures_from_macros.h
 dnt.*.memcheck
 utils/.daos_server.active.yml
 nlt-errors.json


### PR DESCRIPTION
_structures_from_macros_.h was inadvertently changed to
_structures_from_macros.h so update the file and remove
the obsolete entry.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

Required-githooks: true