### PR TITLE
DAOS-5579 doc: switch doc URLs in mkdocs.yml to https

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,10 +50,10 @@ markdown_extensions:
 nav:
     - Intro:
         - 'Home': 'index.md'
-        - 'Community Wiki': 'http://wiki.daos.io/'
-        - 'Community Roadmap': 'http://wiki.daos.io/spaces/DC/pages/4836661105/Roadmap'
+        - 'Community Wiki': 'https://wiki.daos.io/'
+        - 'Community Roadmap': 'https://wiki.daos.io/spaces/DC/pages/4836661105/Roadmap'
         - 'Community Mailing list': 'https://daos.groups.io/g/daos'
-        - 'Issue tracker': 'http://jira.daos.io/'
+        - 'Issue tracker': 'https://jira.daos.io/'
     - Release Information:
         - 'Release Notes v1.2': 'release/release_notes.md'
         - 'Support Matrix v1.2': 'release/support_matrix.md'


### PR DESCRIPTION
switch doc URLs in mkdocs.yml from http to https

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>