### PR TITLE
DAOS-623 build: Allow build to complete without MPI installed.

### DIFF
--- a/src/client/dfs/SConscript
+++ b/src/client/dfs/SConscript
@@ -1,6 +1,7 @@
 """Build FUSE client"""
 import daos_build
 
+
 def configure_lustre(denv):
     """Do Lustre configure checks"""
     if GetOption('help') or GetOption('clean'):
@@ -25,6 +26,7 @@ def configure_lustre(denv):
         print("Not building with Lustre bindings.")
     return conf.Finish()
 
+
 def scons():
     """Execute build"""
     Import('env')
@@ -47,6 +49,7 @@ def scons():
 
     duns = daos_build.library(denv, 'duns', 'duns.c', LIBS=libraries)
     denv.Install('$PREFIX/lib64/', duns)
+
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/client/dfs/SConscript
+++ b/src/client/dfs/SConscript
@@ -5,7 +5,7 @@ def configure_lustre(denv):
     """Do Lustre configure checks"""
     if GetOption('help') or GetOption('clean'):
         return denv
-    #If Lustre installed build a Lustre-aware libduns
+    # If Lustre installed build a Lustre-aware libduns
     conf = Configure(denv)
     gotversion = False
     if not conf.CheckLibWithHeader('lustreapi', 'linux/lustre/lustre_user.h',

--- a/src/client/dfuse/test/SConscript
+++ b/src/client/dfuse/test/SConscript
@@ -4,11 +4,11 @@ import daos_build
 IOIL_TEST_SRC = ['test_ioil.c']
 IOIL_BUILD_STATIC = False
 
+
 def build_static_tests(env):
     """build the static interception library"""
 
-    #This code requires a full static chain or some major
-    #linker magic.  Disabled for now.
+    # This code requires a full static chain or some major linker magic.  Disabled for now.
     if IOIL_BUILD_STATIC:
         to_build = env.get('libioil')
         if to_build in ('none', 'shared'):

--- a/src/gurt/tests/SConscript
+++ b/src/gurt/tests/SConscript
@@ -19,9 +19,9 @@ def scons():
     Import('env', 'prereqs', 'gurt_targets')
     # pylint: enable=too-many-locals
 
-    #Use full path to wrap_cmocka.h for configure test.  Since standalone
-    #cmocka header can't be included without including other headers,
-    #this test can't be generalized
+    # Use full path to wrap_cmocka.h for configure test.  Since standalone
+    # cmocka header can't be included without including other headers,
+    # this test can't be generalized
     wrap_cmocka = os.path.join(Dir('.').srcnode().abspath, 'wrap_cmocka.h')
     prereqs.define('cmockawrap', headers=[wrap_cmocka], libs=['cmocka'],
                    package='libcmocka-devel')

--- a/src/gurt/tests/SConscript
+++ b/src/gurt/tests/SConscript
@@ -10,6 +10,7 @@ import daos_build
 TEST_SRC = ['test_gurt.c',
             'test_gurt_telem_producer.c']
 
+
 def scons():
     """Scons function"""
     if GetOption('help'):
@@ -50,6 +51,7 @@ def scons():
         tests.append(testprog)
 
     Default(tests)
+
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/utils/wrap/mpi/SConscript
+++ b/src/utils/wrap/mpi/SConscript
@@ -16,7 +16,7 @@ def build_dpar(env, mpi_env):
 
 def scons():
     """Execute build"""
-    Import('base_env', 'base_env_mpi', 'prereqs')
+    Import('env', 'base_env', 'base_env_mpi', 'prereqs')
 
     if not prereqs.test_requested():
         return
@@ -24,9 +24,11 @@ def scons():
     if not base_env_mpi:
         return
 
-    base_env.AppendUnique(LIBPATH=[Dir('.')])
+    env.AppendUnique(LIBPATH=[Dir('.')])
+#    base_env.AppendUnique(LIBPATH=[Dir('.')])
     base_env_mpi.AppendUnique(LIBPATH=[Dir('.')])
-    daos_build.add_build_rpath(base_env)
+    daos_build.add_build_rpath(env)
+#    daos_build.add_build_rpath(base_env)
     daos_build.add_build_rpath(base_env_mpi)
 
     build_dpar(base_env, base_env_mpi)

--- a/src/utils/wrap/mpi/SConscript
+++ b/src/utils/wrap/mpi/SConscript
@@ -30,7 +30,7 @@ def scons():
     base_env_mpi.AppendUnique(LIBPATH=[Dir('.')])
     daos_build.add_build_rpath(env)
     daos_build.add_build_rpath(base_env)
-    if base_mpi_env:
+    if base_env_mpi:
         base_env_mpi.AppendUnique(LIBPATH=[Dir('.')])
         daos_build.add_build_rpath(base_env_mpi)
 

--- a/src/utils/wrap/mpi/SConscript
+++ b/src/utils/wrap/mpi/SConscript
@@ -24,7 +24,9 @@ def scons():
     if not base_env_mpi:
         return
 
+    base_env.AppendUnique(LIBPATH=[Dir('.')])
     base_env_mpi.AppendUnique(LIBPATH=[Dir('.')])
+    daos_build.add_build_rpath(base_env)
     daos_build.add_build_rpath(base_env_mpi)
 
     build_dpar(base_env, base_env_mpi)

--- a/src/utils/wrap/mpi/SConscript
+++ b/src/utils/wrap/mpi/SConscript
@@ -8,28 +8,23 @@ def build_dpar(env, mpi_env):
     serial_lib = daos_build.library(env, 'dpar', ['dpar_stub.c'], LIBS=['pthread', 'dl'])
     env.Install('$PREFIX/lib64/', serial_lib)
 
-    if mpi_env is None:
-        return
-
     denv = mpi_env.Clone()
 
     mpi_lib = daos_build.library(denv, 'dpar_mpi', ['dpar_mpi.c'])
     denv.Install('$PREFIX/lib64/', mpi_lib)
-    return
 
 
 def scons():
     """Execute build"""
-    Import('env', 'base_env', 'base_env_mpi', 'prereqs')
+    Import('base_env', 'base_env_mpi', 'prereqs')
 
     if not prereqs.test_requested():
         return
 
-    env.AppendUnique(LIBPATH=[Dir('.')])
-    base_env.AppendUnique(LIBPATH=[Dir('.')])
+    if not base_env_mpi:
+        return
+
     base_env_mpi.AppendUnique(LIBPATH=[Dir('.')])
-    daos_build.add_build_rpath(env)
-    daos_build.add_build_rpath(base_env)
     daos_build.add_build_rpath(base_env_mpi)
 
     build_dpar(base_env, base_env_mpi)

--- a/src/utils/wrap/mpi/SConscript
+++ b/src/utils/wrap/mpi/SConscript
@@ -8,10 +8,14 @@ def build_dpar(env, mpi_env):
     serial_lib = daos_build.library(env, 'dpar', ['dpar_stub.c'], LIBS=['pthread', 'dl'])
     env.Install('$PREFIX/lib64/', serial_lib)
 
+    if not mpi_env:
+        return
+
     denv = mpi_env.Clone()
 
     mpi_lib = daos_build.library(denv, 'dpar_mpi', ['dpar_mpi.c'])
     denv.Install('$PREFIX/lib64/', mpi_lib)
+    return
 
 
 def scons():
@@ -21,15 +25,14 @@ def scons():
     if not prereqs.test_requested():
         return
 
-    if not base_env_mpi:
-        return
-
     env.AppendUnique(LIBPATH=[Dir('.')])
-#    base_env.AppendUnique(LIBPATH=[Dir('.')])
+    base_env.AppendUnique(LIBPATH=[Dir('.')])
     base_env_mpi.AppendUnique(LIBPATH=[Dir('.')])
     daos_build.add_build_rpath(env)
-#    daos_build.add_build_rpath(base_env)
-    daos_build.add_build_rpath(base_env_mpi)
+    daos_build.add_build_rpath(base_env)
+    if base_mpi_env:
+        base_env_mpi.AppendUnique(LIBPATH=[Dir('.')])
+        daos_build.add_build_rpath(base_env_mpi)
 
     build_dpar(base_env, base_env_mpi)
 


### PR DESCRIPTION
A recent change caused the build to crash if a mpi compiler is
installed, change this so that it works as before and mpi is optional.

Do not setup rpath or cpppath for the mpi directory, the core daos
libraries should not need this as it's an optional component.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
