### PR TITLE
DAOS-10039 doc: improve pool create documentation (#9443)

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -1,37 +1,123 @@
 # Pool Operations
 
-A DAOS pool is a storage reservation that can span any storage nodes in a
-DAOS system and is managed by the administrator. The amount of space allocated
-to a pool is decided at creation time and can eventually be expanded through the
-management interface or the `dmg` utility.
+A DAOS pool is a storage reservation that can span any number of storage engines in a
+DAOS system. Pools are managed by the administrator. The amount of space allocated
+to a pool is decided at creation time with the `dmg pool create` command.
+Pools can be expanded at a later time with the `dmg pool expand` command
+that adds additional engine ranks to the existing pool's storage allocation.
+The DAOS management API also provides these capabilities.
+
 
 ## Pool Basics
 
+The `dmg pool` command is the main administrative tool to manage pools.
+Its subcommands can be grouped into the following areas:
+
+* Commands to create, list, query, extend, and destroy a pool.
+  These are the basic functions to manage the storage allocation in a pool.
+
+* Commands to list and set pool properties,
+  and commands to set and list Access Control Lists (ACLs) for a pool.
+
+* Commands to manage failures and other non-standard scenarios.
+  This includes draining, excluding and re-integrating targets,
+  and evicting client connections to a pool.
+
+* An upgrade command to upgrade a pool's format version
+  after a DAOS software upgrade.
+
 ### Creating a Pool
 
-A DAOS pool can be created and destroyed through the `dmg` utility.
+A DAOS pool can be created through the `dmg pool create` command.
+The mandatory parameters that are needed for the creation of a pool
+are the pool label, and a specification of the size of the storage
+allocation.
+
+The pool label must consist of alphanumeric characters, colon (`:`),
+period (`.`), hyphen (`-`) or underscore (`_`).
+The maximum length of a pool label is 127 characters.
+Labels that can be parsed as a UUID (e.g. 123e4567-e89b-12d3-a456-426614174000)
+are forbidden. Pool labels must be unique across the DAOS system.
+
+A pool's size is determined by two factors: How many storage engines are
+participating in the storage allocation, and how much capacity in each
+storage tier is allocated (the latter can be specified either on a per-engine
+basis, or as the total for the pool across all participating engines).
+The same amount of storage will be allocated on each of the participating
+storage engines. If one or more of those engines do not have sufficient free
+space for the requested capacity, the pool creation will fail.
+
+If neither the `--nranks` nor the `--ranks` option is used,
+then the pool will span all storage engines of the DAOS system.
+To limit the pool to only a subset of the engines, those two options
+can be used to specify either the desired number of engines,
+or an explicit list of engine ranks to be used for this pool.
+
+The capacity of the pool can be specified in three different ways:
+
+1. The `--scm-size` parameter (and optionally `--nvme-size`) can
+   be used to specify the SCM capacity (and optionally the NVMe
+   capacity) _per storage engine_ in **Bytes**.
+   The minimum SCM size is 16 MiB per **target**, so for a storage
+   engine with 16 targets the minimum is `--scm-size=256MiB`.
+   The NVMe size can be zero. If it is non-zero then the minimum
+   NVMe size is 1 GiB per **target**, so for a storage engine
+   with 16 targets the minimum non-zero NVMe size is
+   `--nvme-size=16GiB`.
+   To derive the total pool capacity, these per-engine capacities
+   have to be multiplied by the number of participating engines.
+
+2. The `--size` option can be used to specify the _total_ pool
+   capacity in **Bytes**. This value denotes the sum of the SCM
+   and NVMe capacities. The relative contributions of the SCM and
+   NVMe storage tiers to the total pool size are determined by the
+   `--tier-ratio` parameter.
+   By default this ratio is `6,94`, so for a pool of size 100TB
+   there will be 6TB of SCM and 94 TB of NVMe storage.
+   An SCM-only pool can be created by using `--tier-ratio 100,0`.
+
+3. The `--size` option can be used to specify the _total_ pool
+   capacity as a **percentage of the currently free capacity**.
+   In this case, the tier ratio will be ignored. For example,
+   requesting `--size=100%` will allocate 100% of the free SCM
+   capacity and 100% of the free NVMe capacity to the pool,
+   regardless of the ratio of those two free capacity values.
+
+   * This implies that it is not possible to create an SCM-only
+     pool by using a percentage size (unless there is no NVMe
+     storage in the system at all, and all pools are SCM-only).
+
+   * If the amount of free space is different across the
+     participating engines, then the _minimum_ free space is
+     used to calculate the space that is allocated per engine.
+
+   * Because the percentage numbers refer to currently free
+     space and not total space, the absolute size of a pool
+     created with `--size=percentage%` will be impacted by other
+     concurrent pool create operations. The command output will
+     always list the total capacities in addiiton to the
+     requested percentage.
+
+!!! note
+    The suffixes "M", "MB", "G", "GB", "T" or "TB" denote base-10
+    capacities, whereas "MiB", "GiB" or "TiB" denote base-2.
+    So in the first example above, specifying `--scm-size=256GB`
+    would fail as 256 GB is smaller than the minimum 256 GiB.
+
+Examples:
 
 To create a pool labeled `tank`:
 ```bash
-$ dmg pool create --size=<N>TB tank
+$ dmg pool create --size=${N}TB tank
 ```
 
 This command creates a pool labeled `tank` distributed across the DAOS servers
-with a target size on each server that is comprised of N * 0.94 TB of NVMe storage
-and N * 0.06 TB (i.e., 6% of NVMe) of SCM storage. The default SCM:NVMe ratio
-may be adjusted at pool creation time as described below.
+with a target size on each server that is comprised of $N * 0.94 TB of NVMe storage
+and $N * 0.06 TB of SCM storage. The default SCM:NVMe ratio
+may be adjusted at pool creation time as described above.
 
 The UUID allocated to the newly created pool is printed to stdout
 as well as the pool service replica ranks.
-
-!!! note
-    The --scm-size and --nvme-size options still exist, but should be
-    considered deprecated and will likely be removed in a future release.
-
-The label must consist of alphanumeric characters, colon (':'), period ('.'),
-hyphen ('-') or underscore ('\_'). The maximum length is set to 127 characters.
-Labels that can be parsed as UUID (e.g. 123e4567-e89b-12d3-a456-426614174000)
-are forbidden.
 
 ```bash
 $ dmg pool create --help
@@ -56,7 +142,7 @@ The typical output of this command is as follows:
 
 ```bash
 $ dmg pool create --size 50GB tank
-Creating DAOS pool with automatic storage allocation: 50 GB NVMe + 6.00% SCM
+Creating DAOS pool with automatic storage allocation: 50 GB total, 6,94 tier ratio
 Pool created with 6.00% SCM/NVMe ratio
 -----------------------------------------
   UUID                 : 8a05bf3a-a088-4a77-bb9f-df989fce7cc8
@@ -74,20 +160,15 @@ with pool service redundancy enabled by default
 If no redundancy is desired, use --nsvc=1 in order to specify that only
 a single pool service replica should be created.
 
-The -t option allows defining the ratio between SCM and NVMe SSD space.
-The default value is 6%, which means the space provided after --size
-will be distributed as follows:
-- 6% is allocated on SCM (i.e., 3GB in the example above)
-- 94% is allocated on NVMe SSD (i.e., 47GB in the example above)
-
 Note that it is difficult to determine the usable space by the user, and
 currently we cannot provide the precise value. The usable space depends not only
 on pool size, but also on number of targets, target size, object class,
 storage redundancy factor, etc.
 
+
 ### Listing Pools
 
-To see a list of the pools in your DAOS system:
+To see a list of the pools in the DAOS system:
 
 ```bash
 $ dmg pool list
@@ -101,9 +182,9 @@ with the following information for each pool:
 - the total pool size
 - the percentage of used space (i.e., 100 * used space  / total space)
 - the imbalance percentage indicating whether data distribution across
-  the difference storage nodes is well balanced. 0% means that there is
+  the difference storage targets is well balanced. 0% means that there is
   no imbalance and 100% means that out-of-space errors might be returned
-  by some storage nodes while space is still available on others.
+  by some storage targets while space is still available on others.
 - the number of disabled targets (0 here) and the number of targets that
   the pool was originally configured with (total).
 
@@ -127,13 +208,12 @@ $ dmg pool destroy tank
 Pool-destroy command succeeded
 ```
 
-The label can be replaced with the pool UUID.
+The pool's UUID can be used instead of the pool label.
 
 ### Querying a Pool
 
 The pool query operation retrieves information (i.e., the number of targets,
-space usage, rebuild status, property list, and more) about a created pool. It
-is integrated into the dmg utility.
+space usage, rebuild status, property list, and more) about an existing pool.
 
 To query a pool labeled `tank`:
 
@@ -141,7 +221,7 @@ To query a pool labeled `tank`:
 $ dmg pool query tank
 ```
 
-The label can be replaced with the pool UUID.
+The pool's UUID can be used instead of the pool label.
 Below is the output for a pool created with SCM space only.
 
 ```bash
@@ -166,8 +246,8 @@ NB: the Versioning Object Store (VOS) may reserve a portion of the
 SCM and NVMe allocations to mitigate against fragmentation and for background
 operations (e.g., aggregation, garbage collection). The amount of storage
 set aside depends on the size of the target and may take up 2+ GB.
-Therefore, Out of space conditions may occur even while pool query may not
-show min approaching zero.
+Therefore, out of space conditions may occur even while pool query may not
+show the minimum free space approaching zero.
 
 The example below shows a rebuild in progress and NVMe space allocated.
 
@@ -197,7 +277,8 @@ $ dmg pool evict tank
 Pool-evict command succeeded
 ```
 
-The label can be replaced with the pool UUID.
+The pool's UUID can be used instead of the pool label.
+
 
 ## Pool Properties
 
@@ -276,15 +357,15 @@ Three options are supported:
 
 ### Self-healing Policy (self\_heal)
 
-This property defines whether a failing node is automatically evicted from the
+This property defines whether a failing engine is automatically evicted from the
 pool. Once excluded, the self-healing mechanism will be triggered to restore
-the pool data redundancy on the surviving storage nodes.
+the pool data redundancy on the surviving storage engines.
 Two options are supported: "exclude" (default strategy) and "rebuild".
 
 ### Reserved Space for Rebuilds (space\_rb)
 
 This property defines the percentage of total space reserved on each storage
-node for self-healing purpose. The reserved space cannot be consumed by
+engine for self-healing purpose. The reserved space cannot be consumed by
 applications. Valid values are 0% to 100%, the default is 0%.
 When setting this property, specifying the percentage symbol is optional:
 `space_rb:2%` and `space_rb:2` both specify two percent of storage capacity.
@@ -298,6 +379,7 @@ The default is 1MiB.
 When setting this property, the cell size can be specified in Bytes
 (as a number with no suffix), with a base-10 suffix like `k` or `MB`,
 or with a base-2 suffix like `ki` or `MiB`.
+
 
 ## Access Control Lists
 
@@ -325,9 +407,13 @@ inside, regardless of their permissions on those containers.
 
 ### Ownership
 
-Pool ownership conveys no special privileges for access control decisions. All
-desired privileges of the owner-user (`OWNER@`) and owner-group (`GROUP@`) must
-be explicitly defined by an administrator in the pool ACL.
+By default, the `dmg pool create` command will use the current user and current
+group to set the pool's owner-user and owner-group. This default can be changed
+with the `--user` and `--group` options.
+
+Pool ownership conveys no special privileges for access control decisions.
+All desired privileges of the owner-user (`OWNER@`) and owner-group (`GROUP@`)
+must be explicitly defined by an administrator in the pool ACL.
 
 ### ACL at Pool Creation
 
@@ -452,7 +538,7 @@ surviving engine.
 
 An operator can exclude one or more engines or targets from a specific DAOS pool
 using the rank the target resides, as well as the target idx on that rank.
-If a target idx list is not provided, all targets on the rank will be excluded.
+If a target idx list is not provided, all targets on the engine rank will be excluded.
 
 To exclude a target from a pool:
 
@@ -463,10 +549,10 @@ $ dmg pool exclude --rank=${rank} --target-idx=${idx1},${idx2},${idx3} <pool_lab
 The pool target exclude command accepts 2 parameters:
 
 * The engine rank of the target(s) to be excluded.
-* The target Indices of the targets to be excluded from that rank (optional).
+* The target indices of the targets to be excluded from that engine rank (optional).
 
 Upon successful manual exclusion, the self-healing mechanism will be triggered
-to restore redundancy on the remaining engines/targets.
+to restore redundancy on the remaining engines.
 
 ### Drain
 
@@ -489,7 +575,7 @@ $ dmg pool drain --rank=${rank} --target-idx=${idx1},${idx2},${idx3} $DAOS_POOL
 The pool target drain command accepts 2 parameters:
 
 * The engine rank of the target(s) to be drained.
-* The target Indices of the targets to be drained from that rank (optional).
+* The target indices of the targets to be drained from that engine rank (optional).
 
 ### Reintegration
 
@@ -497,7 +583,7 @@ After an engine failure and exclusion, an operator can fix the underlying issue
 and reintegrate the affected engines or targets to restore the pool to its
 original state.
 The operator can either reintegrate specific targets for an engine rank by
-supplying a target idx list, or reintegrate an entire rank by omitting the list.
+supplying a target idx list, or reintegrate an entire engine rank by omitting the list.
 
 ```
 $ dmg pool reintegrate $DAOS_POOL --rank=${rank} --target-idx=${idx1},${idx2},${idx3}
@@ -507,7 +593,7 @@ The pool reintegrate command accepts 3 parameters:
 
 * The label or UUID of the pool that the targets will be reintegrated into.
 * The engine rank of the affected targets.
-* The target indices of the targets to be reintegrated on that rank (optional).
+* The target indices of the targets to be reintegrated on that engine rank (optional).
 
 When rebuild is triggered it will list the operations and their related engines/targets
 by their engine rank and target index.
@@ -538,7 +624,7 @@ $ dmg pool reintegrate $DAOS_POOL --rank=5 --target-idx=0,1
 
 ### Addition & Space Rebalancing
 
-Full Support for online target addition and automatic space rebalancing is
+Full support for online target addition and automatic space rebalancing is
 planned for a future release and will be documented here once available.
 
 Until then the following command(s) are placeholders and offer limited


### PR DESCRIPTION
improve pool create documentation, explaining the three ways
to specify pool capacity (per engine in Bytes, global in Bytes,
global as a percentage of free capacity).

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>