### PR TITLE
DAOS-10833 object: keep the same epoch for replicate rebuild

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -62,6 +62,8 @@ struct migrate_one {
 	 * avoid parity corruption.
 	*/
 	daos_iod_t		*mo_iods_from_parity;
+	daos_epoch_t		**mo_iods_update_ephs_from_parity;
+
 
 	daos_iod_t		*mo_punch_iods;
 
@@ -812,11 +814,12 @@ migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 		      struct ds_cont_child *ds_cont,
 		      unsigned char *buffer, daos_off_t offset,
 		      daos_size_t size, daos_iod_t *iod,
-		      unsigned char *p_bufs[], struct daos_csummer *csummer)
+		      unsigned char *p_bufs[], struct daos_csummer *csummer, bool encode)
 {
 	struct daos_oclass_attr	*oca = &mrone->mo_oca;
 	daos_size_t		 stride_nr = obj_ec_stripe_rec_nr(oca);
 	daos_size_t		 cell_nr = obj_ec_cell_rec_nr(oca);
+	daos_size_t		split_size;
 	daos_recx_t		 tmp_recx;
 	d_iov_t			 tmp_iov;
 	d_sg_list_t		 tmp_sgl;
@@ -824,19 +827,20 @@ migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 	struct dcs_iod_csums	*iod_csums = NULL;
 	int			rc = 0;
 
+	split_size = encode ? stride_nr : cell_nr;
 	tmp_sgl.sg_nr = tmp_sgl.sg_nr_out = 1;
 	while (size > 0) {
-		if (offset % stride_nr != 0)
-			write_nr =
-			  min(roundup(offset, stride_nr) - offset, size);
+		if (offset % split_size != 0)
+			write_nr = min(roundup(offset, split_size) - offset, size);
 		else
-			write_nr = min(stride_nr, size);
+			write_nr = min(split_size, size);
 
 		if (write_nr == stride_nr) {
 			unsigned int shard;
 
 			shard = mrone->mo_oid.id_shard % obj_ec_tgt_nr(oca);
 
+			D_ASSERT(encode);
 			D_ASSERT(shard >= obj_ec_data_tgt_nr(oca));
 			shard -= obj_ec_data_tgt_nr(oca);
 			D_ASSERT(shard < obj_ec_parity_tgt_nr(oca));
@@ -890,8 +894,9 @@ out:
 }
 
 static int
-migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
-			    struct ds_cont_child *ds_cont)
+__migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
+			      daos_iod_t *iods, daos_epoch_t **ephs, uint32_t iods_num,
+			      struct ds_cont_child *ds_cont, bool encode)
 {
 	d_sg_list_t	 sgls[DSS_ENUM_UNPACK_MAX_IODS];
 	d_iov_t		 iov[DSS_ENUM_UNPACK_MAX_IODS] = { 0 };
@@ -904,9 +909,9 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 	int		 i;
 	int		 rc;
 
-	D_ASSERT(mrone->mo_iod_num <= DSS_ENUM_UNPACK_MAX_IODS);
-	for (i = 0; i < mrone->mo_iod_num; i++) {
-		size = daos_iods_len(&mrone->mo_iods[i], 1);
+	D_ASSERT(iods_num <= DSS_ENUM_UNPACK_MAX_IODS);
+	for (i = 0; i < iods_num; i++) {
+		size = daos_iods_len(&iods[i], 1);
 		D_ALLOC(data, size);
 		if (data == NULL)
 			D_GOTO(out, rc =-DER_NOMEM);
@@ -917,13 +922,11 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 		sgls[i].sg_iovs = &iov[i];
 	}
 
-	D_DEBUG(DB_REBUILD,
-		DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_U64"\n",
-		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
-		mrone->mo_iod_num, mrone->mo_epoch);
+	D_DEBUG(DB_REBUILD, DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_U64"\n",
+		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey), iods_num, mrone->mo_epoch);
 
-	rc = mrone_obj_fetch(mrone, oh, sgls, mrone->mo_iods, mrone->mo_iod_num,
-			     mrone->mo_epoch, DIOF_FOR_MIGRATION, NULL);
+	rc = mrone_obj_fetch(mrone, oh, sgls, iods, iods_num, mrone->mo_epoch, DIOF_FOR_MIGRATION,
+			     NULL);
 	if (rc) {
 		D_ERROR("migrate dkey "DF_KEY" failed: "DF_RC"\n",
 			DP_KEY(&mrone->mo_dkey), DP_RC(rc));
@@ -931,45 +934,42 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 	}
 
 	csummer = dsc_cont2csummer(dc_obj_hdl2cont_hdl(oh));
-	for (i = 0; i < mrone->mo_iod_num; i++) {
-		daos_iod_t	*iod;
-		int		j;
+	for (i = 0; i < iods_num; i++) {
 		daos_off_t	offset;
 		daos_iod_t	tmp_iod;
-		daos_epoch_t	*iod_ephs = mrone->mo_iods_update_ephs[i];
 		daos_epoch_t	parity_eph;
+		int		j;
 
-		iod = &mrone->mo_iods[i];
-		offset = iod->iod_recxs[0].rx_idx;
-		size = iod->iod_recxs[0].rx_nr;
-		parity_eph = iod_ephs[0];
-		tmp_iod = *iod;
+		offset = iods[i].iod_recxs[0].rx_idx;
+		size = iods[i].iod_recxs[0].rx_nr;
+		parity_eph = ephs[i][0];
+		tmp_iod = iods[i];
 		ptr = iov[i].iov_buf;
-		for (j = 1; j < iod->iod_nr; j++) {
-			daos_recx_t	*recx = &iod->iod_recxs[j];
+		for (j = 1; j < iods[i].iod_nr; j++) {
+			daos_recx_t	*recx = &iods[i].iod_recxs[j];
 
 			if (offset + size == recx->rx_idx) {
 				size += recx->rx_nr;
-				parity_eph = iod_ephs[j];
+				parity_eph = max(ephs[i][j], parity_eph);
 				continue;
 			}
 
 			rc = migrate_update_parity(mrone, parity_eph, ds_cont, ptr, offset,
-						   size, &tmp_iod, p_bufs, csummer);
+						   size, &tmp_iod, p_bufs, csummer, encode);
 			if (rc)
 				D_GOTO(out, rc);
-			ptr += size * iod->iod_size;
+			ptr += size * iods[i].iod_size;
 			offset = recx->rx_idx;
 			size = recx->rx_nr;
-			parity_eph = iod_ephs[j];
+			parity_eph = ephs[i][j];
 		}
 
 		if (size > 0)
 			rc = migrate_update_parity(mrone, parity_eph, ds_cont, ptr, offset,
-						   size, &tmp_iod, p_bufs, csummer);
+						   size, &tmp_iod, p_bufs, csummer, encode);
 	}
 out:
-	for (i = 0; i < mrone->mo_iod_num; i++) {
+	for (i = 0; i < iods_num; i++) {
 		if (iov[i].iov_buf)
 			D_FREE(iov[i].iov_buf);
 	}
@@ -977,6 +977,33 @@ out:
 	for (i = 0; i < p; i++) {
 		if (p_bufs[i] != NULL)
 			D_FREE(p_bufs[i]);
+	}
+
+	return rc;
+}
+
+static int
+migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
+			    struct ds_cont_child *ds_cont)
+{
+	int rc = 0;
+
+	/* If it is parity recxs from another replica, then let's encode it anyway */
+	if (mrone->mo_iods_num_from_parity > 0) {
+		rc = __migrate_fetch_update_parity(mrone, oh, mrone->mo_iods_from_parity,
+						   mrone->mo_iods_update_ephs_from_parity,
+						   mrone->mo_iods_num_from_parity, ds_cont,
+						   true);
+
+		if (rc)
+			return rc;
+	}
+
+	/* Otherwise, keep it as replicate recx */
+	if (mrone->mo_iod_num > 0) {
+		rc = __migrate_fetch_update_parity(mrone, oh, mrone->mo_iods,
+						   mrone->mo_iods_update_ephs,
+						   mrone->mo_iod_num, ds_cont, false);
 	}
 
 	return rc;
@@ -1261,6 +1288,7 @@ static int
 migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 			  struct ds_cont_child *ds_cont)
 {
+	int i;
 	int rc = 0;
 
 	if (obj_shard_is_ec_parity(mrone->mo_oid, &mrone->mo_oca))
@@ -1286,12 +1314,25 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 			D_GOTO(out, rc);
 	}
 
-	if (mrone->mo_iod_num > 0) {
-		rc = __migrate_fetch_update_bulk(mrone, oh, mrone->mo_iods,
-						 mrone->mo_iod_num, mrone->mo_epoch,
-						 DIOF_FOR_MIGRATION, ds_cont);
-		if (rc > 0)
-			D_GOTO(out, rc);
+	/* The data, rebuilt from replication, needs to keep the same epoch during rebuild,
+	 * otherwise it may mess up the relationship between parity epoch and data epoch,
+	 * which may cause data corruption during degraded fetch. Since VOS update does not support
+	 * multiple epoch, so it can only do fetch/update recx each time.
+	 */
+	for (i = 0; i < mrone->mo_iod_num; i++) {
+		daos_iod_t	iod;
+		int		j;
+
+		for (j = 0; j < mrone->mo_iods[i].iod_nr; j++) {
+			iod = mrone->mo_iods[i];
+			iod.iod_nr = 1;
+			iod.iod_recxs = &mrone->mo_iods[i].iod_recxs[j];
+			rc = __migrate_fetch_update_bulk(mrone, oh, &iod, 1,
+							 mrone->mo_iods_update_ephs[i][j],
+							 DIOF_FOR_MIGRATION, ds_cont);
+			if (rc > 0)
+				D_GOTO(out, rc);
+		}
 	}
 out:
 	return rc;
@@ -1514,6 +1555,14 @@ migrate_one_destroy(struct migrate_one *mrone)
 				D_FREE(mrone->mo_iods_update_ephs[i]);
 		}
 		D_FREE(mrone->mo_iods_update_ephs);
+	}
+
+	if (mrone->mo_iods_update_ephs_from_parity) {
+		for (i = 0; i < mrone->mo_iod_alloc_num; i++) {
+			if (mrone->mo_iods_update_ephs_from_parity[i])
+				D_FREE(mrone->mo_iods_update_ephs_from_parity[i]);
+		}
+		D_FREE(mrone->mo_iods_update_ephs_from_parity);
 	}
 
 	if (mrone->mo_iods)
@@ -1820,11 +1869,12 @@ rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t *ephs, d_sg
 				if (parity_nr > 0) {
 					/* Once there are replicate extents, let's add parity */
 					rc = migrate_insert_recxs_sgl(
-								mrone->mo_iods_from_parity, NULL,
-								&mrone->mo_iods_num_from_parity,
-								iod, &iod->iod_recxs[start],
-								&ephs[start], parity_nr,
-								mrone->mo_sgls, sgl);
+							mrone->mo_iods_from_parity,
+							mrone->mo_iods_update_ephs_from_parity,
+							&mrone->mo_iods_num_from_parity,
+							iod, &iod->iod_recxs[start],
+							&ephs[start], parity_nr,
+							mrone->mo_sgls, sgl);
 					if (rc)
 						D_GOTO(out, rc);
 					start = i;
@@ -1839,7 +1889,8 @@ rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t *ephs, d_sg
 
 
 		if (parity_nr > 0) {
-			rc = migrate_insert_recxs_sgl(mrone->mo_iods_from_parity, NULL,
+			rc = migrate_insert_recxs_sgl(mrone->mo_iods_from_parity,
+						      mrone->mo_iods_update_ephs_from_parity,
 						      &mrone->mo_iods_num_from_parity, iod,
 						      &iod->iod_recxs[start],
 						      &ephs[start], parity_nr,
@@ -2029,6 +2080,10 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dss_enum_unpack_io *io)
 		D_ALLOC_ARRAY(mrone->mo_iods_from_parity, iod_eph_total);
 		if (mrone->mo_iods_from_parity == NULL)
 			D_GOTO(free, rc = -DER_NOMEM);
+
+		D_ALLOC_ARRAY(mrone->mo_iods_update_ephs_from_parity, iod_eph_total);
+		if (mrone->mo_iods_update_ephs_from_parity == NULL)
+			D_GOTO(free, rc = -DER_NOMEM);
 	}
 
 	mrone->mo_epoch = arg->epr.epr_hi;
@@ -2155,7 +2210,7 @@ migrate_enum_unpack_cb(struct dss_enum_unpack_io *io, void *data)
 		} else {
 			/* parity shard */
 			rc = obj_recx_ec2_daos(&arg->oc_attr, io->ui_oid.id_shard,
-					       &iod->iod_recxs, ephs, &iod->iod_nr, true);
+					       &iod->iod_recxs, ephs, &iod->iod_nr, false);
 			if (rc != 0)
 				return rc;
 		}

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -14,7 +14,7 @@ timeouts:
     test_daos_degraded_mode: 450
     test_daos_management: 110
     test_daos_pool: 120
-    test_daos_container: 250
+    test_daos_container: 450
     test_daos_epoch: 125
     test_daos_verify_consistency: 105
     test_daos_io: 290


### PR DESCRIPTION
replicate data needs to keep the same epoch during rebuild,
otherwise it will mess up its relationship with parity epoch,
and cause data corruption during rebuild.

Features: rebuild
Signed-off-by: Di Wang <di.wang@intel.com>