### PR TITLE
DAOS-10891 tests: fix incorrect assert in check_oclass (#10891)

### DIFF
--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4236,7 +4236,7 @@ check_oclass(daos_handle_t coh, int domain_nr, daos_oclass_hints_t hints,
 		if (nr == 1 || nr == 2) {
 			if (domain_nr >= 18)
 				assert_int_equal(attr->u.ec.e_k, 16);
-			if (domain_nr >= 10)
+			else if (domain_nr >= 10)
 				assert_int_equal(attr->u.ec.e_k, 8);
 			else if (domain_nr >= 6)
 				assert_int_equal(attr->u.ec.e_k, 4);
@@ -4245,7 +4245,7 @@ check_oclass(daos_handle_t coh, int domain_nr, daos_oclass_hints_t hints,
 		} else if (nr == 3) {
 			if (domain_nr >= 20)
 				assert_int_equal(attr->u.ec.e_k, 16);
-			if (domain_nr >= 12)
+			else if (domain_nr >= 12)
 				assert_int_equal(attr->u.ec.e_k, 8);
 			else if (domain_nr >= 8)
 				assert_int_equal(attr->u.ec.e_k, 4);


### PR DESCRIPTION
If the domain_nr is bigger then 18, it will do two assert. The first
assert_int_equal(attr->u.ec.e_k, 16) is passed, and fail at the second
assert_int_equal(attr->u.ec.e_k, 8). Mondify to do only one assert.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>