### PR TITLE
DAOS-8943 vea: optimize aging frag flushing

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -996,13 +996,13 @@ nvme_rw(struct bio_desc *biod, struct bio_rsrvd_region *rg)
 		D_ASSERT(biod->bd_type < BIO_IOD_TYPE_GETBUF);
 		if (biod->bd_type == BIO_IOD_TYPE_UPDATE)
 			spdk_blob_io_write(blob, channel, payload,
-					   page2io_unit(biod->bd_ctxt, pg_idx),
-					   page2io_unit(biod->bd_ctxt, rw_cnt),
+					   page2io_unit(biod->bd_ctxt, pg_idx, BIO_DMA_PAGE_SZ),
+					   page2io_unit(biod->bd_ctxt, rw_cnt, BIO_DMA_PAGE_SZ),
 					   rw_completion, biod);
 		else
 			spdk_blob_io_read(blob, channel, payload,
-					  page2io_unit(biod->bd_ctxt, pg_idx),
-					  page2io_unit(biod->bd_ctxt, rw_cnt),
+					  page2io_unit(biod->bd_ctxt, pg_idx, BIO_DMA_PAGE_SZ),
+					  page2io_unit(biod->bd_ctxt, rw_cnt, BIO_DMA_PAGE_SZ),
 					  rw_completion, biod);
 
 		pg_cnt -= rw_cnt;

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -441,9 +441,9 @@ is_blob_valid(struct bio_io_context *ctxt)
 }
 
 static inline uint64_t
-page2io_unit(struct bio_io_context *ctxt, uint64_t page)
+page2io_unit(struct bio_io_context *ctxt, uint64_t page, uint32_t pg_sz)
 {
-	return page * (BIO_DMA_PAGE_SZ / ctxt->bic_io_unit);
+	return page * (pg_sz / ctxt->bic_io_unit);
 }
 
 enum {

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -532,6 +532,17 @@ int bio_ioctxt_close(struct bio_io_context *ctxt, bool skip_blob);
  */
 int bio_blob_unmap(struct bio_io_context *ctxt, uint64_t off, uint64_t len);
 
+/*
+ * Unmap (TRIM) a SGL consists of freed extents.
+ *
+ * \param[IN] ctxt	I/O context
+ * \param[IN] unmap_sgl	The SGL to be unmapped (offset & length are in blocks)
+ * \param[IN] blk_sz	Block size
+ *
+ * \returns		Zero on success, negative value on error
+ */
+int bio_blob_unmap_sgl(struct bio_io_context *ctxt, d_sg_list_t *unmap_sgl, uint32_t blk_sz);
+
 /**
  * Write to per VOS instance blob.
  *

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -120,6 +120,7 @@ struct ds_pool_child {
 	struct ds_pool		*spc_pool;
 	uuid_t			spc_uuid;	/* pool UUID */
 	struct sched_request	*spc_gc_req;	/* Track GC ULT */
+	struct sched_request	*spc_flush_req;	/* Dedicated VEA flush ULT */
 	struct sched_request	*spc_scrubbing_req; /* Track scrubbing ULT*/
 	d_list_t		spc_cont_list;
 

--- a/src/include/daos_srv/vea.h
+++ b/src/include/daos_srv/vea.h
@@ -72,14 +72,15 @@ struct vea_unmap_context {
 	/**
 	 * Unmap (TRIM) the extent being freed.
 	 *
-	 * \param off [IN]         Offset in bytes
-	 * \param len [IN]         Length in bytes
-	 * \param data [IN]        Block device opaque data
+	 * \param unmap_sgl [IN]    SGL to be unmapped (offset & len are in blocks)
+	 * \param blk_sz    [IN]    Block size
+	 * \param data      [IN]    Block device opaque data
 	 *
 	 * \return                 Zero on success, negative value on error
 	 */
-	int (*vnc_unmap)(uint64_t off, uint64_t cnt, void *data);
+	int (*vnc_unmap)(d_sg_list_t *unmap_sgl, uint32_t blk_sz, void *data);
 	void *vnc_data;
+	bool vnc_ext_flush;
 };
 
 /* Free space tracking information on SCM */
@@ -298,13 +299,14 @@ int vea_query(struct vea_space_info *vsi, struct vea_attr *attr,
 /**
  * Flushing the free frags in aging buffer
  *
- * \param vsi       [IN]	In-memory compound index
- * \param force     [IN]	Force flush all frags no matter if they are expired
+ * \param vsi        [IN]	In-memory compound index
+ * \param force      [IN]	Force flush no matter if there is qualified extent
+ * \param nr_flush   [IN]	Flush at most @nr_flush frags
+ * \param nr_flushed [OUT]	How many frags are actually flushed (optional)
  *
- * \return			0:	Nothing to be flushed;
- *				1:	Some Frags need be flushed;
+ * \return			Zero on success; Appropriated negative value on error
  */
-int vea_flush(struct vea_space_info *vsi, bool force);
+int vea_flush(struct vea_space_info *vsi, bool force, uint32_t nr_flush, uint32_t *nr_flushed);
 
 /**
  * Free metrcis

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1147,6 +1147,9 @@ vos_pool_ctl(daos_handle_t poh, enum vos_pool_opc opc, void *param);
 int
 vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 	    void *yield_arg);
+int
+vos_flush_pool(daos_handle_t poh, bool force, uint32_t nr_flush, uint32_t *nr_flushed);
+
 bool
 vos_gc_pool_idle(daos_handle_t poh);
 

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -81,6 +81,8 @@ enum vos_pool_open_flags {
 	VOS_POF_SMALL	= (1 << 0),
 	/** Exclusive (-DER_BUSY if already opened) */
 	VOS_POF_EXCL	= (1 << 1),
+	/** Caller does VEA flush periodically */
+	VOS_POF_EXTERNAL_FLUSH	= (1 << 3),
 };
 
 enum vos_oi_attr {

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -55,6 +55,22 @@ stop_gc_ult(struct ds_pool_child *child)
 	child->spc_gc_req = NULL;
 }
 
+static void
+stop_flush_ult(struct ds_pool_child *child)
+{
+	D_ASSERT(child != NULL);
+	/* Flush ULT is not started */
+	if (child->spc_flush_req == NULL)
+		return;
+
+	D_DEBUG(DB_MGMT, DF_UUID"[%d]: Stopping Flush ULT\n",
+		DP_UUID(child->spc_uuid), dss_get_module_info()->dmi_tgt_id);
+
+	sched_req_wait(child->spc_flush_req, true);
+	sched_req_put(child->spc_flush_req);
+	child->spc_flush_req = NULL;
+}
+
 struct ds_pool_child *
 ds_pool_child_lookup(const uuid_t uuid)
 {
@@ -90,6 +106,7 @@ ds_pool_child_put(struct ds_pool_child *child)
 
 		/* only stop gc ULT when all ops ULTs are done */
 		stop_gc_ult(child);
+		stop_flush_ult(child);
 
 		vos_pool_close(child->spc_hdl);
 		dss_module_fini_metrics(DAOS_TGT_TAG, child->spc_metrics);
@@ -190,6 +207,68 @@ start_gc_ult(struct ds_pool_child *child)
 	return 0;
 }
 
+static void
+flush_ult(void *arg)
+{
+	struct ds_pool_child	*child = (struct ds_pool_child *)arg;
+	struct dss_module_info	*dmi = dss_get_module_info();
+	uint32_t		 sleep_ms, nr_flushed, nr_flush = 6000;
+	int			 rc;
+
+	D_DEBUG(DB_MGMT, DF_UUID"[%d]: Flush ULT started\n",
+		DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
+
+	D_ASSERT(child->spc_flush_req != NULL);
+
+	while (!dss_ult_exiting(child->spc_flush_req)) {
+		rc = vos_flush_pool(child->spc_hdl, false, nr_flush, &nr_flushed);
+		if (rc < 0) {
+			D_ERROR(DF_UUID"[%d]: Flush pool failed. "DF_RC"\n",
+				DP_UUID(child->spc_uuid), dmi->dmi_tgt_id, DP_RC(rc));
+			sleep_ms = 2000;
+		} else if (rc) {	/* This pool doesn't have NVMe partition */
+			sleep_ms = 60000;
+		} else if (sched_req_space_check(child->spc_flush_req) == SCHED_SPACE_PRESS_NONE) {
+			sleep_ms = 5000;
+		} else {
+			sleep_ms = (nr_flushed < nr_flush) ? 1000 : 0;
+		}
+
+		if (dss_ult_exiting(child->spc_flush_req))
+			break;
+
+		if (sleep_ms)
+			sched_req_sleep(child->spc_flush_req, sleep_ms);
+		else
+			sched_req_yield(child->spc_flush_req);
+	}
+
+	D_DEBUG(DB_MGMT, DF_UUID"[%d]: Flush ULT stopped\n",
+		DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
+}
+
+static int
+start_flush_ult(struct ds_pool_child *child)
+{
+	struct dss_module_info	*dmi = dss_get_module_info();
+	struct sched_req_attr	 attr;
+
+	D_ASSERT(child != NULL);
+	D_ASSERT(child->spc_flush_req == NULL);
+
+	sched_req_attr_init(&attr, SCHED_REQ_GC, &child->spc_uuid);
+	attr.sra_flags = SCHED_REQ_FL_NO_DELAY;
+
+	child->spc_flush_req = sched_create_ult(&attr, flush_ult, child, 0);
+	if (child->spc_flush_req == NULL) {
+		D_ERROR(DF_UUID"[%d]: Failed to create flush ULT.\n",
+			DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
+		return -DER_NOMEM;
+	}
+
+	return 0;
+}
+
 struct pool_child_lookup_arg {
 	struct ds_pool *pla_pool;
 	void	       *pla_uuid;
@@ -237,7 +316,7 @@ pool_child_add_one(void *varg)
 		goto out_metrics;
 
 	D_ASSERT(child->spc_metrics[DAOS_VOS_MODULE] != NULL);
-	rc = vos_pool_open_metrics(path, arg->pla_uuid, VOS_POF_EXCL,
+	rc = vos_pool_open_metrics(path, arg->pla_uuid, VOS_POF_EXCL | VOS_POF_EXTERNAL_FLUSH,
 				   child->spc_metrics[DAOS_VOS_MODULE], &child->spc_hdl);
 
 	D_FREE(path);
@@ -264,9 +343,13 @@ pool_child_add_one(void *varg)
 	if (rc != 0)
 		goto out_eventual;
 
-	rc = ds_start_scrubbing_ult(child);
+	rc = start_flush_ult(child);
 	if (rc != 0)
 		goto out_gc;
+
+	rc = ds_start_scrubbing_ult(child);
+	if (rc != 0)
+		goto out_flush;
 
 	d_list_add(&child->spc_list, &tls->dt_pool_list);
 
@@ -281,6 +364,8 @@ out_list:
 	d_list_del_init(&child->spc_list);
 	ds_cont_child_stop_all(child);
 	ds_stop_scrubbing_ult(child);
+out_flush:
+	stop_flush_ult(child);
 out_gc:
 	stop_gc_ult(child);
 out_eventual:

--- a/src/vea/tests/vea_stress.c
+++ b/src/vea/tests/vea_stress.c
@@ -737,7 +737,7 @@ vs_setup_pool(void)
 	struct umem_attr	 uma = { 0 };
 	PMEMoid			 root;
 	void			*root_addr;
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	struct vea_attr		 attr;
 	struct vea_stat		 stat;
 	uint64_t		 load_time;
@@ -806,8 +806,6 @@ vs_setup_pool(void)
 	}
 
 	load_time = daos_wallclock_secs();
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&vs_pool->vsp_umm, &vs_pool->vsp_txd, vs_pool->vsp_vsd, &unmap_ctxt,
 		      NULL, &vs_pool->vsp_vsi);
 	if (rc) {

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -77,11 +77,9 @@ static void
 ut_load(void **state)
 {
 	struct vea_ut_args *args = *state;
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	int rc;
 
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&args->vua_umm, &args->vua_txd, args->vua_md, &unmap_ctxt,
 		      NULL, &args->vua_vsi);
 	assert_rc_equal(rc, 0);
@@ -336,7 +334,7 @@ ut_free(void **state)
 	struct vea_resrvd_ext *ext;
 	d_list_t *r_list;
 	uint64_t blk_off;
-	uint32_t blk_cnt;
+	uint32_t blk_cnt, nr_flushed;
 	int rc;
 
 	r_list = &args->vua_alloc_list;
@@ -361,7 +359,9 @@ ut_free(void **state)
 	vea_dump(args->vua_vsi, false);
 
 	/* call vea_flush to trigger free extents migration */
-	vea_flush(args->vua_vsi, true);
+	rc = vea_flush(args->vua_vsi, true, UINT32_MAX, &nr_flushed);
+	assert_rc_equal(rc, 0);
+	assert_true(nr_flushed > 0);
 
 	r_list = &args->vua_alloc_list;
 	d_list_for_each_entry(ext, r_list, vre_link) {
@@ -537,7 +537,7 @@ ut_reserve_special(void **state)
 	d_list_t *r_list;
 	uint32_t hdr_blks = 1;
 	uint64_t capacity = 2UL << 30; /* 2GB, 0.5M 4k blocks in total */
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	uint32_t blk_sz = 0; /* use the default size */
 	int rc;
 
@@ -547,8 +547,6 @@ ut_reserve_special(void **state)
 			hdr_blks, capacity, NULL, NULL, false);
 	assert_rc_equal(rc, 0);
 
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&args.vua_umm, &args.vua_txd, args.vua_md, &unmap_ctxt,
 		      NULL, &args.vua_vsi);
 	assert_rc_equal(rc, 0);
@@ -669,7 +667,7 @@ ut_inval_params_load(void **state)
 	uint32_t block_size = 0; /* use the default size */
 	uint32_t header_blocks = 1;
 	uint64_t capacity = ((VEA_LARGE_EXT_MB * 2) << 20); /* 128 MB */
-	struct vea_unmap_context unmap_ctxt = {0};
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	int rc;
 
 	ut_setup(&args);
@@ -715,7 +713,7 @@ ut_inval_params_reserve(void **state)
 	uint32_t block_size = 0; /* use the default size */
 	uint32_t header_blocks = 1;
 	uint64_t capacity = ((VEA_LARGE_EXT_MB * 2) << 20); /* 128 MB */
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	d_list_t *r_list;
 	int rc;
 
@@ -725,8 +723,6 @@ ut_inval_params_reserve(void **state)
 			header_blocks, capacity, NULL, NULL, false);
 	assert_rc_equal(rc, 0);
 
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&args.vua_umm, &args.vua_txd, args.vua_md, &unmap_ctxt,
 		      NULL, &args.vua_vsi);
 	assert_rc_equal(rc, 0);
@@ -751,7 +747,7 @@ ut_inval_params_cancel(void **state)
 	uint32_t block_size = 0; /* use the default size */
 	uint32_t header_blocks = 1;
 	uint64_t capacity = ((VEA_LARGE_EXT_MB * 2) << 20); /* 128 MB */
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	d_list_t *r_list;
 	int rc;
 
@@ -761,8 +757,6 @@ ut_inval_params_cancel(void **state)
 			header_blocks, capacity, NULL, NULL, false);
 	assert_rc_equal(rc, 0);
 
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&args.vua_umm, &args.vua_txd, args.vua_md, &unmap_ctxt,
 		      NULL, &args.vua_vsi);
 	assert_rc_equal(rc, 0);
@@ -783,7 +777,7 @@ ut_inval_params_tx_publish(void **state)
 	uint32_t block_size = 0; /* use the default size */
 	uint32_t header_blocks = 1;
 	uint64_t capacity = ((VEA_LARGE_EXT_MB * 2) << 20); /* 128 MB */
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	d_list_t *r_list;
 	int rc;
 
@@ -793,8 +787,6 @@ ut_inval_params_tx_publish(void **state)
 			header_blocks, capacity, NULL, NULL, false);
 	assert_rc_equal(rc, 0);
 
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&args.vua_umm, &args.vua_txd, args.vua_md, &unmap_ctxt,
 		      NULL, &args.vua_vsi);
 	assert_rc_equal(rc, 0);
@@ -825,7 +817,7 @@ ut_inval_params_free(void **state)
 	uint32_t header_blocks = 1;
 	uint64_t block_offset = 0;
 	uint64_t capacity = ((VEA_LARGE_EXT_MB * 2) << 20); /* 128 MB */
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	d_list_t *r_list;
 	int rc;
 
@@ -835,8 +827,6 @@ ut_inval_params_free(void **state)
 			header_blocks, capacity, NULL, NULL, false);
 	assert_rc_equal(rc, 0);
 
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&args.vua_umm, &args.vua_txd, args.vua_md, &unmap_ctxt,
 		      NULL, &args.vua_vsi);
 	assert_rc_equal(rc, 0);
@@ -911,7 +901,7 @@ static void
 ut_free_invalid_space(void **state)
 {
 	struct vea_ut_args args;
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	struct vea_hint_context *h_ctxt;
 	struct vea_resrvd_ext *fake_ext;
 	d_list_t *r_list;
@@ -927,8 +917,6 @@ ut_free_invalid_space(void **state)
 			header_blocks, capacity, NULL, NULL, false);
 	assert_int_equal(rc, 0);
 
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&args.vua_umm, &args.vua_txd, args.vua_md, &unmap_ctxt,
 		      NULL, &args.vua_vsi);
 	assert_int_equal(rc, 0);
@@ -979,7 +967,7 @@ static void
 ut_interleaved_ops(void **state)
 {
 	struct vea_ut_args args;
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	struct vea_hint_context *h_ctxt;
 	d_list_t *r_list_a;
 	d_list_t *r_list_b;
@@ -995,8 +983,6 @@ ut_interleaved_ops(void **state)
 			header_blocks, capacity, NULL, NULL, false);
 	assert_int_equal(rc, 0);
 
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&args.vua_umm, &args.vua_txd, args.vua_md, &unmap_ctxt,
 		      NULL, &args.vua_vsi);
 	assert_int_equal(rc, 0);
@@ -1149,7 +1135,7 @@ static void
 ut_fragmentation(void **state)
 {
 	struct vea_ut_args args;
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = { 0 };
 	struct vea_resrvd_ext *ext, *copy;
 	struct vea_resrvd_ext *tmp_ext;
 	d_list_t *r_list;
@@ -1168,8 +1154,6 @@ ut_fragmentation(void **state)
 			header_blocks, capacity, NULL, NULL, false);
 	assert_rc_equal(rc, 0);
 
-	unmap_ctxt.vnc_unmap = NULL;
-	unmap_ctxt.vnc_data = NULL;
 	rc = vea_load(&args.vua_umm, &args.vua_txd, args.vua_md, &unmap_ctxt,
 		      NULL, &args.vua_vsi);
 	assert_rc_equal(rc, 0);

--- a/src/vea/vea_internal.h
+++ b/src/vea/vea_internal.h
@@ -43,7 +43,6 @@ struct vea_entry {
 
 #define VEA_LARGE_EXT_MB	64	/* Large extent threshold in MB */
 #define VEA_HINT_OFF_INVAL	0	/* Invalid hint offset */
-#define VEA_MIGRATE_INTVL	10	/* Seconds */
 
 /* Value entry of sized free extent tree (vfc_size_btr) */
 struct vea_sized_class {
@@ -128,9 +127,9 @@ struct vea_space_info {
 	uint64_t			 vsi_stat[STAT_MAX];
 	/* Metrics */
 	struct vea_metrics		*vsi_metrics;
-	/* Last aggregation time */
-	uint32_t			 vsi_agg_time;
-	bool				 vsi_agg_scheduled;
+	/* Last aging buffer flush timestamp */
+	uint32_t			 vsi_flush_time;
+	bool				 vsi_flush_scheduled;
 };
 
 static inline uint32_t
@@ -175,13 +174,16 @@ int reserve_vector(struct vea_space_info *vsi, uint32_t blk_cnt,
 int persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe);
 
 /* vea_free.c */
+#define MAX_FLUSH_FRAGS	256
 void free_class_remove(struct vea_space_info *vsi, struct vea_entry *entry);
 int free_class_add(struct vea_space_info *vsi, struct vea_entry *entry);
 int compound_free(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 		  unsigned int flags);
 int persistent_free(struct vea_space_info *vsi, struct vea_free_extent *vfe);
 int aggregated_free(struct vea_space_info *vsi, struct vea_free_extent *vfe);
-void migrate_free_exts(struct vea_space_info *vsi, bool add_tx_cb);
+int trigger_aging_flush(struct vea_space_info *vsi, bool force,
+			uint32_t nr_flush, uint32_t *nr_flushed);
+int schedule_aging_flush(struct vea_space_info *vsi);
 
 /* vea_hint.c */
 void hint_get(struct vea_hint_context *hint, uint64_t *off);


### PR DESCRIPTION
1. Instead of triggering aging frags flush in vea_reserve() and vea_free()
   internally, using a dedicated ULT to do flush externally, there are two
   advantages of external flush:

   - GC & Aggregation ULT won't be blocked on waiting for the NVMe unmap
     completion;
   - It's easier to control the flush rate and other parameters according
     to space pressure;

   Standalone VOS still uses internal flush triggered in vea_reserve() and
   vea_free().

2. Use the new BIO API bio_blob_unmap_sgl() to unmap multiple freed frags
   in parallel, that could reduce the total unmap latency;

3. Stop merging the aging frag when it reached a size threshold, otherwise,
   the frag could be constantly merged with newly freed frag and stay in
   the aging buffer for too long;

4. Adjust flush parameters to make the frags being flushed more promptly;

Signed-off-by: Niu Yawei <yawei.niu@intel.com>