### PR TITLE
DAOS-7821 cq: Update daos_pylint handling of fake_scons.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -10,7 +10,7 @@ import daos_build
 import compiler_setup
 from prereq_tools import PreReqComponent
 import stack_analyzer
-# pylint: disable=reimported,ungrouped-imports
+# pylint: disable=reimported
 
 if sys.version_info.major < 3:
     print(""""Python 2.7 is no longer supported in the DAOS build.

--- a/site_scons/build_info/__init__.py
+++ b/site_scons/build_info/__init__.py
@@ -22,4 +22,4 @@
 """Module for getting information about a build"""
 
 # pylint: disable=wildcard-import
-from .base import * # noqa: F403,F401
+from .base import *  # noqa: F403,F401

--- a/site_scons/build_info/base.py
+++ b/site_scons/build_info/base.py
@@ -21,8 +21,6 @@
 # -*- coding: utf-8 -*-
 """Classes for building external prerequisite components"""
 
-from __future__ import print_function
-
 import os
 import sys
 import datetime

--- a/site_scons/daos_build.py
+++ b/site_scons/daos_build.py
@@ -66,7 +66,7 @@ def add_rpaths(env, install_off, set_cgo_ld, is_bin):
 
 
 def add_build_rpath(env, pathin="."):
-    """Add a build directory with -Wl,-rpath-link"""
+    """Add a build directory to rpath"""
     path = Dir(pathin).path
     env.AppendUnique(LINKFLAGS=["-Wl,-rpath-link=%s" % path])
     env.AppendENVPath("CGO_LDFLAGS", "-Wl,-rpath-link=%s" % path, sep=" ")

--- a/site_scons/prereq_tools/__init__.py
+++ b/site_scons/prereq_tools/__init__.py
@@ -22,4 +22,4 @@
 """Tools for prebuilding external components from a SCons script"""
 
 # pylint: disable=wildcard-import
-from .base import * # noqa: F403,F401
+from .base import *  # noqa: F403,F401

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -500,9 +500,9 @@ def check_flag_helper(context, compiler, ext, flag):
         context.env.Replace(CFLAGS=['-O2'])
     elif compiler in ["gcc", "g++"]:
         # remove -no- for test
-        # There is a issue here when mpicc is a wrapper around gcc, in that we can pass '-Wno'
+        # There is a issue here when mpicc is a wrapper around gcc, in that we can pass -Wno
         # options to the compiler even if it doesn't understand them but.  This would be tricky
-        # to fix gcc only complains about unknown '-Wno' warning options if the compile Fails
+        # to fix gcc only complains about unknown -Wno warning options if the compile Fails
         # for other reasons anyway.
         test_flag = flag.replace("-Wno-", "-W")
         flags = ["-Werror", test_flag]

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -500,9 +500,9 @@ def check_flag_helper(context, compiler, ext, flag):
         context.env.Replace(CFLAGS=['-O2'])
     elif compiler in ["gcc", "g++"]:
         # remove -no- for test
-        # There is a issue here when mpicc is a wrapper around gcc, in that we can pass -Wno-
+        # There is a issue here when mpicc is a wrapper around gcc, in that we can pass '-Wno'
         # options to the compiler even if it doesn't understand them but.  This would be tricky
-        # to fix gcc only complains about unknown -Wno- warning options if the compile Fails
+        # to fix gcc only complains about unknown '-Wno' warning options if the compile Fails
         # for other reasons anyway.
         test_flag = flag.replace("-Wno-", "-W")
         flags = ["-Werror", test_flag]
@@ -581,9 +581,9 @@ def ensure_dir_exists(dirname, dry_run):
     if not os.path.isdir(dirname):
         raise IOError(errno.ENOTDIR, 'Not a directory', dirname)
 
+
 # pylint: disable=too-many-public-methods
-
-
+# pylint: disable-next=function-redefined
 class PreReqComponent():
     """A class for defining and managing external components required
        by a project.
@@ -592,7 +592,7 @@ class PreReqComponent():
     to allow compilation from from multiple systems in one source tree
     """
 
-# pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches
 
     def __init__(self, env, variables, config_file=None, arch=None):
         self.__defined = {}

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -28,7 +28,6 @@
 # pylint: disable=exec-used
 # pylint: disable=too-many-statements
 # pylint: disable=too-many-lines
-from __future__ import absolute_import, division, print_function
 import os
 import traceback
 import hashlib
@@ -1481,7 +1480,7 @@ class _Component():
         if path and "PKG_CONFIG_PATH" not in env["ENV"]:
             env["ENV"]["PKG_CONFIG_PATH"] = path
         if (not self.use_installed and self.component_prefix is not None
-                                   and not self.component_prefix == "/usr"):
+           and not self.component_prefix == "/usr"):
             path_found = False
             for path in ["lib", "lib64"]:
                 config = os.path.join(self.component_prefix, path, "pkgconfig")

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -499,10 +499,11 @@ def check_flag_helper(context, compiler, ext, flag):
         # bug in older scons, need CFLAGS to exist, -O2 is default.
         context.env.Replace(CFLAGS=['-O2'])
     elif compiler in ["gcc", "g++"]:
+        # pylint: disable=wrong-spelling-in-comment
         # remove -no- for test
-        # There is a issue here when mpicc is a wrapper around gcc, in that we can pass -Wno
+        # There is a issue here when mpicc is a wrapper around gcc, in that we can pass -Wno-
         # options to the compiler even if it doesn't understand them but.  This would be tricky
-        # to fix gcc only complains about unknown -Wno warning options if the compile Fails
+        # to fix gcc only complains about unknown -Wno- warning options if the compile Fails
         # for other reasons anyway.
         test_flag = flag.replace("-Wno-", "-W")
         flags = ["-Werror", test_flag]

--- a/site_scons/prereq_tools/mocked_tests.py
+++ b/site_scons/prereq_tools/mocked_tests.py
@@ -64,6 +64,7 @@ UnitTests = namedtuple('UnitTests',
 
 
 def build_mock_unit_tests(env, src_list=None, **kwargs):
+    # pylint: disable=wrong-spelling-in-docstring
     """
     Call in place of Program with the same parameters other than the executable
     name and the source files.

--- a/site_scons/prereq_tools/mocked_tests.py
+++ b/site_scons/prereq_tools/mocked_tests.py
@@ -30,6 +30,7 @@ from collections import namedtuple
 
 # pylint: disable=too-few-public-methods
 
+
 class TestFunction():
     """
     A simple store for tracking information about a specific test. Tied heavily
@@ -110,6 +111,7 @@ def _parse_unit_tests(line, test_functions):
                          names[1].strip(),
                          names[2].strip()))
 
+
 def _parse_global_setup(line, global_setups):
     """parse global setup"""
     name = re.match("GLOBAL_SETUP\\(([a-zA-Z0-9_ ]*)\\)", line)
@@ -124,6 +126,7 @@ def _parse_global_teardowns(line, global_teardowns):
 
     if name is not None:
         global_teardowns.append(name.group(1))
+
 
 def _get_source_and_tests(env, source_list):
     """get source and tests"""
@@ -237,7 +240,7 @@ int (*global_teardown_functions[])(void **state) = {%s};
 
     try:
         with open('cmocka_tests.c', 'r') as original_test_source_file:
-            original_test_source = original_test_source_file.read(1024*1024)
+            original_test_source = original_test_source_file.read(1024 * 1024)
     except IOError:
         original_test_source = ""
 
@@ -249,8 +252,8 @@ int (*global_teardown_functions[])(void **state) = {%s};
                                              'c_source',
                                              '*')):
         c_dest_path = path.basename(c_source_file)
-        if ((path.isfile(c_dest_path) is False) or
-                (path.getmtime(c_source_file) > path.getmtime(c_dest_path))):
+        if ((path.isfile(c_dest_path) is False)
+           or (path.getmtime(c_source_file) > path.getmtime(c_dest_path))):
             shutil.copy(c_source_file, c_dest_path)
 
     for c_source_file in [path.basename(file_name)

--- a/site_scons/site_tools/doneapi.py
+++ b/site_scons/site_tools/doneapi.py
@@ -6,17 +6,13 @@ Hack to support oneapi version of Intel compilers
 import sys
 import os
 
-# TODO: Should these be in fake_scons
-# pylint: disable=no-name-in-module
-# pylint: disable=import-error
 import SCons.Tool.gcc
 import SCons.Util
-# pylint: enable=import-error
-# pylint: enable=no-name-in-module
 import SCons.Warnings
 import SCons.Errors
 
 
+# pylint: disable=too-few-public-methods
 class DetectCompiler():
     """Find oneapi compiler"""
 
@@ -53,7 +49,6 @@ def generate(env):
     """Add Builders and construction variables for Intel Oneapi C++C++ compiler
     to an Environment.
     """
-    # pylint: disable=no-member
     SCons.Tool.gcc.generate(env)
 
     detector = DetectCompiler()

--- a/site_scons/site_tools/extra/__init__.py
+++ b/site_scons/site_tools/extra/__init__.py
@@ -22,4 +22,5 @@
 # SOFTWARE.
 #
 
+# pylint: disable=unused-import
 from .extra import generate, exists  # noqa: F401

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -138,7 +138,7 @@ def generate(env):
     indent = _find_indent()
 
     # pylint: disable-next=unused-argument
-    def __pp_gen(source, target, env, for_signature):
+    def _pp_gen(source, target, env, for_signature):
         """generate commands for preprocessor builder"""
         action = []
         cccom = env.subst("$CCCOM").replace(" -o ", " ")
@@ -150,7 +150,7 @@ def generate(env):
         return action
 
     # Only handle C for now
-    preprocess = Builder(generator=__pp_gen, emitter=_preprocess_emitter)
+    preprocess = Builder(generator=_pp_gen, emitter=_preprocess_emitter)
     # Workaround for SCons issue #2757.   Avoid using Configure for internal headers
     check_header = Builder(action='$CCCOM', emitter=_ch_emitter)
 

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -93,18 +93,6 @@ def _find_indent():
     return f'{indent} --style={style}'
 
 
-def _pp_gen(source, target, env, indent):
-    """generate commands for preprocessor builder"""
-    action = []
-    cccom = env.subst("$CCCOM").replace(" -o ", " ")
-    for src, tgt in zip(source, target):
-        if indent:
-            action.append(f'{cccom} -E -P {src} | {indent} > {tgt}')
-        else:
-            action.append(f'{cccom} -E -P {src} > {tgt}')
-    return action
-
-
 def _preprocess_emitter(source, target, env):
     """generate target list for preprocessor builder"""
     target = []
@@ -149,13 +137,20 @@ def generate(env):
 
     indent = _find_indent()
 
-    # In order to pass the indent function to the generator and only execute _find_indent
-    # once, we create a lambda function to wrap our own that takes indent as argument.
-    pp_generator = lambda source, target, env, for_signature: _pp_gen(source, target, env,  # noqa
-                                                                      indent)  # noqa
+    # pylint: disable-next=unused-argument
+    def __pp_gen(source, target, env, for_signature):
+        """generate commands for preprocessor builder"""
+        action = []
+        cccom = env.subst("$CCCOM").replace(" -o ", " ")
+        for src, tgt in zip(source, target):
+            if indent:
+                action.append(f'{cccom} -E -P {src} | {indent} > {tgt}')
+            else:
+                action.append(f'{cccom} -E -P {src} > {tgt}')
+        return action
 
     # Only handle C for now
-    preprocess = Builder(generator=pp_generator, emitter=_preprocess_emitter)
+    preprocess = Builder(generator=__pp_gen, emitter=_preprocess_emitter)
     # Workaround for SCons issue #2757.   Avoid using Configure for internal headers
     check_header = Builder(action='$CCCOM', emitter=_ch_emitter)
 

--- a/site_scons/site_tools/protoc/__init__.py
+++ b/site_scons/site_tools/protoc/__init__.py
@@ -136,8 +136,8 @@ def generate(env, **_kwargs):
         PYTHON_SUFFIX='_pb2_grpc.py',
         GO_SUFFIX='.pb.go',
         PROTO_SUFFIX='.proto',
-        PYTHON_COM='python -m grpc_tools.protoc -I$PROTO_INCLUDES ' +
-        '--python_out=$GTARGET_DIR --grpc_python_out=$GTARGET_DIR $SOURCE',
+        PYTHON_COM='python -m grpc_tools.protoc -I$PROTO_INCLUDES '
+        + '--python_out=$GTARGET_DIR --grpc_python_out=$GTARGET_DIR $SOURCE',
         PYTHON_COMSTR='',
         GO_COM='$PROTOC -I$PROTO_INCLUDES $SOURCE --go_out=plugins=grpc:$GTARGET_DIR',
         GO_COMSTR=''

--- a/utils/cq/daos_pylint.py
+++ b/utils/cq/daos_pylint.py
@@ -520,7 +520,7 @@ def main():
             parser.print_usage()
             sys.exit(1)
     elif all_files.file_count() == 0:
-        print('You must specify input file')
+        print('You must specify at least one input file')
         parser.print_usage()
         sys.exit(1)
     else:

--- a/utils/sl/fake_scons/SCons/Action/__init__.py
+++ b/utils/sl/fake_scons/SCons/Action/__init__.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 """Fake Action class"""
 
-# pylint: disable=too-few-public-methods
+
 class Action():
     """Fake Action"""
 

--- a/utils/sl/fake_scons/SCons/Subst/__init__.py
+++ b/utils/sl/fake_scons/SCons/Subst/__init__.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 """Fake scons environment shutting up pylint on SCons files"""
 
-# pylint: disable=too-few-public-methods
+
 class Literal():
     """Fake Literal"""
 

--- a/utils/sl/fake_scons/SCons/Tool/gcc/__init__.py
+++ b/utils/sl/fake_scons/SCons/Tool/gcc/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 022 Intel Corporation
+# Copyright 2022 Intel Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/utils/sl/fake_scons/SCons/Tool/gcc/__init__.py
+++ b/utils/sl/fake_scons/SCons/Tool/gcc/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 022 Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Fake scons environment shutting up pylint on SCons files"""
+
+
+def generate(_):
+    """Fake generate"""


### PR DESCRIPTION
Handle fake_scons as it's own class with specific requirments.
This means it's tested more strictly, and we can disable specific
checks for it.
Update daos_pylint to accept directories on the command line.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
