### PR TITLE
DAOS-1452 test: ensure ULTs stacks are dumped when needed (#7768)

### DIFF
--- a/src/tests/ftest/server/daos_server_dump.py
+++ b/src/tests/ftest/server/daos_server_dump.py
@@ -7,8 +7,9 @@
 from __future__ import print_function
 
 from apricot import TestWithServers
-from general_utils import pcmd, stop_processes
+from general_utils import pcmd, dump_engines_stacks
 
+import time
 
 class DaosServerDumpTest(TestWithServers):
     """Daos server dump tests.
@@ -25,30 +26,17 @@ class DaosServerDumpTest(TestWithServers):
         self.start_servers_once = False
         self.setup_start_agents = False
 
-    def test_daos_server_dump_basic(self):
-        """JIRA ID: DAOS-1452.
+    def tearDown(self):
+        """Tear down after each test case."""
+        super().tearDown()
 
-        Test Description: Test engine ULT stacks dump.
+        # force test status !!
+        # use mangling trick described at
+        # https://stackoverflow.com/questions/3385317/private-variables-and-methods-in-python
+        # to do so
+        self._Test__status = 'PASS'
 
-        :avocado: tags=all,daily_regression
-        :avocado: tags=vm
-        :avocado: tags=control,server_start,basic
-        :avocado: tags=daos_server_dump_test,test_daos_server_dump_basic
-        """
-
-        ret_codes = stop_processes(self.hostlist_servers, r"daos_engine",
-                           added_filter=r"'\<(grep|defunct)\>'",
-                           dump_ult_stacks=True)
-        if 1 in ret_codes:
-            print(
-                "Stopped daos_engine processes on {}".format(
-                    str(ret_codes[1])))
-        if 0 in ret_codes:
-            print(
-                "No daos_engine processes found on {}".format(
-                    str(ret_codes[0])))
-
-        # XXX may need to check for one file per engine...
+        # DAOS-1452 may need to check for one file per engine...
         ret_codes = pcmd(self.hostlist_servers, r"ls /tmp/daos_dump*.txt")
         # Report any failures
         if len(ret_codes) > 1 or 0 not in ret_codes:
@@ -56,12 +44,81 @@ class DaosServerDumpTest(TestWithServers):
                 "{}: rc={}".format(val, key)
                 for key, val in ret_codes.items() if key != 0
             ]
-            self.fail(
+            print(
                 "no ULT stacks dump found on following hosts: {}".format(
                 ", ".join(failed)))
+            self._Test__status = 'FAIL'
+
+    def test_daos_server_dump_basic(self):
+        """JIRA ID: DAOS-1452.
+
+        Test Description: Test engine ULT stacks dump (basic).
+
+        :avocado: tags=all
+        :avocado: tags=daos_server_dump_tests,test_daos_server_dump_basic
+        """
+
+        ret_codes = dump_engines_stacks(self.hostlist_servers,
+                           added_filter=r"'\<(grep|defunct)\>'")
+        # at this time there is no way to know when Argobots ULTs stacks
+        # has completed, see DAOS-1452/DAOS-9942.
+        if 1 in ret_codes:
+            print(
+                "Dumped daos_engine stacks on {}".format(
+                    str(ret_codes[1])))
+        if 0 in ret_codes:
+            self.fail(
+                "No daos_engine processes found on {}".format(
+                    str(ret_codes[0])))
 
         self.log.info("Test passed!")
 
-        # set stopped servers state to make teardown happy
+    def test_daos_server_dump_on_error(self):
+        """JIRA ID: DAOS-1452.
+
+        Test Description: Test engine ULT stacks dump (error case).
+
+        :avocado: tags=all
+        :avocado: tags=daos_server_dump_tests,test_daos_server_dump_on_error
+        """
+
+        self.log.info("Forcing test error!")
+        self.error()
+
+    def test_daos_server_dump_on_fail(self):
+        """JIRA ID: DAOS-1452.
+
+        Test Description: Test engine ULT stacks dump (failure case).
+
+        :avocado: tags=all
+        :avocado: tags=daos_server_dump_tests,test_daos_server_dump_on_fail
+        """
+
+        self.log.info("Forcing test failure!")
+        self.fail()
+
+    def test_daos_server_dump_on_timeout(self):
+        """JIRA ID: DAOS-1452.
+
+        Test Description: Test engine ULT stacks dump (timeout case).
+
+        :avocado: tags=all
+        :avocado: tags=daos_server_dump_tests,test_daos_server_dump_on_timeout
+        """
+
+        self.log.info("Sleeping to trigger test timeout!")
+        time.sleep(30)
+
+    def test_daos_server_dump_on_unexpected_engine_status(self):
+        """JIRA ID: DAOS-1452.
+
+        Test Description: Test engine ULT stacks dump (unexpected engine status case).
+
+        :avocado: tags=all
+        :avocado: tags=daos_server_dump_tests,test_daos_server_dump_on_unexpected_engine_status
+        """
+
+        self.log.info("Forcing servers expected state to make teardown unhappy!")
+        # set stopped servers expected state to make teardown unhappy
         self.server_managers[0].update_expected_states(
             None, ["stopped", "excluded", "errored"])

--- a/src/tests/ftest/server/daos_server_dump.yaml
+++ b/src/tests/ftest/server/daos_server_dump.yaml
@@ -9,6 +9,8 @@ hosts:
     - server-E
     - server-F
 timeout: 140
+timeouts:
+  test_daos_server_dump_on_timeout: 30
 server_config:
   name: daos_server
   servers:

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -27,7 +27,8 @@ from dmg_utils import get_dmg_command
 from fault_config_utils import FaultInjection
 from general_utils import \
     get_partition_hosts, stop_processes, get_default_config_file, pcmd, get_file_listing, \
-    DaosTestError, run_command, get_avocado_config_value, set_avocado_config_value
+    DaosTestError, run_command, get_avocado_config_value, set_avocado_config_value \
+    dump_engines_stacks
 from logger_utils import TestLogger
 from pydaos.raw import DaosContext, DaosLog, DaosApiError
 from server_utils import DaosServerManager
@@ -697,6 +698,8 @@ class TestWithServers(TestWithoutServers):
         # self.debug = False
         # self.config = None
         self.job_manager = None
+        # whether engines ULT stacks have been already dumped
+        self.dumped_engines_stacks = False
         self.label_generator = LabelGenerator()
 
     def setUp(self):
@@ -1359,8 +1362,46 @@ class TestWithServers(TestWithoutServers):
             errors.append("Error removing temporary test files")
         return errors
 
+    def dump_engines_stacks(self, message):
+        """Dump the engines ULT stacks.
+
+        Args:
+            message (str): reason for dumping the ULT stacks. Defaults to None.
+        """
+        if self.dumped_engines_stacks is False:
+            self.dumped_engines_stacks = True
+            self.log.info("%s, dumping ULT stacks", message)
+            dump_engines_stacks(self.hostlist_servers)
+
+    def report_timeout(self):
+        """Dump ULTs stacks if this test case was timed out."""
+        super().report_timeout()
+        if self.timeout is not None and self.time_elapsed > self.timeout:
+            # dump engines ULT stacks upon test timeout
+            self.dump_engines_stacks("Test has timed-out")
+
+    def fail(self, message=None):
+        """Dump engines ULT stacks upon test failure."""
+        self.dump_engines_stacks("Test has failed")
+        super().fail(message)
+
+    def error(self, message=None):
+        """Dump engines ULT stacks upon test error."""
+        self.dump_engines_stacks("Test has errored")
+        super().error(message)
+
     def tearDown(self):
         """Tear down after each test case."""
+
+        # dump engines ULT stacks upon test failure
+        # check of Avocado test status during teardown is presently useless
+        # and about same behavior has been implemented by adding both fail()
+        # error() method above, to overload the methods of Avocado base Test
+        # class (see DAOS-1452/DAOS-9941 and Avocado issue #5217 with
+        # associated PR-5224)
+        if self.status is not None and self.status != 'PASS' and self.status != 'SKIP':
+            self.dump_engines_stacks("Test status is {}".format(self.status))
+
         # Report whether or not the timeout has expired
         self.report_timeout()
 
@@ -1583,6 +1624,8 @@ class TestWithServers(TestWithoutServers):
                 errors.append(
                     "ERROR: At least one multi-variant server was not found in "
                     "its expected state; stopping all servers")
+                # dump engines stacks if not already done
+                self.dump_engines_stacks("Some engine not in expected state")
             self.test_log.info(
                 "Stopping %s group(s) of servers", len(self.server_managers))
             errors.extend(self._stop_managers(self.server_managers, "servers"))

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -804,7 +804,7 @@ class DaosServerManager(SubprocessManager):
         """Forcibly terminate any server process running on hosts."""
         regex = self.manager.job.command_regex
         # Try to dump all server's ULTs stacks before kill.
-        result = stop_processes(self._hosts, regex, dump_ult_stacks=True)
+        result = stop_processes(self._hosts, regex)
         if 0 in result and len(result) == 1:
             print("No remote {} server processes killed (none found), done.".format(regex))
         else:


### PR DESCRIPTION
Address issues with dumping ULTs stacks upon failure/timeout
during CI tests. Add test case to verify this functionality.
Please note that those tests are not run for now since they
report legitimate errors.

Change-Id: Idac4adf8e5403500a789ceb9f4d5a30b96a457a2
Test-tag: pr,test_daos_server_dump_basic
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>