### PR TITLE
DAOS-9979 test: Enable regular weekly ucx testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 #!/usr/bin/groovy
+/* groovylint-disable DuplicateStringLiteral, NestedBlockDepth */
 /* Copyright (C) 2019-2021 Intel Corporation
  * All rights reserved.
  *
@@ -15,19 +16,21 @@
 //@Library(value="pipeline-lib@your_branch") _
 
 // Should try to figure this out automatically
-String base_branch = "master"
+/* groovylint-disable-next-line CompileStatic, VariableName */
+String base_branch = 'master'
 // For master, this is just some wildly high number
-next_version = "1000"
+next_version = '1000'
 
 // Don't define this as a type or it loses it's global scope
 target_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
-def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
+/* groovylint-disable-next-line UnusedVariable, VariableName */
+String sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
 
 // bail out of branch builds that are not on a whitelist
 if (!env.CHANGE_ID &&
-    (!env.BRANCH_NAME.startsWith("weekly-testing") &&
-     !env.BRANCH_NAME.startsWith("release/") &&
-     env.BRANCH_NAME != "master")) {
+    (!env.BRANCH_NAME.startsWith('weekly-testing') &&
+     !env.BRANCH_NAME.startsWith('release/') &&
+     env.BRANCH_NAME != 'master')) {
    currentBuild.result = 'SUCCESS'
    return
 }
@@ -36,7 +39,9 @@ pipeline {
     agent { label 'lightweight' }
 
     triggers {
+        /* groovylint-disable-next-line AddEmptyString */
         cron(env.BRANCH_NAME == 'master' ? 'TZ=America/Toronto\n0 0 * * *\n' : '' +
+             /* groovylint-disable-next-line AddEmptyString */
              env.BRANCH_NAME == 'release/1.2' ? 'TZ=America/Toronto\n0 12 * * *\n' : '' +
              env.BRANCH_NAME.startsWith('weekly-testing') ? 'H 0 * * 6' : '')
     }
@@ -44,7 +49,7 @@ pipeline {
     environment {
         BULLSEYE = credentials('bullseye_license_key')
         GITHUB_USER = credentials('daos-jenkins-review-posting')
-        SSH_KEY_ARGS = "-ici_key"
+        SSH_KEY_ARGS = '-ici_key'
         CLUSH_ARGS = "-o$SSH_KEY_ARGS"
         TEST_RPMS = cachedCommitPragma(pragma: 'RPM-test', def_val: 'true')
         COVFN_DISABLED = cachedCommitPragma(pragma: 'Skip-fnbullseye', def_val: 'true')
@@ -59,11 +64,15 @@ pipeline {
 
     parameters {
         string(name: 'BuildPriority',
+               /* groovylint-disable-next-line UnnecessaryGetter */
                defaultValue: getPriority(),
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
-               defaultValue: "full_regression",
+               defaultValue: 'full_regression',
                description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'BaseBranch',
+               defaultValue: base_branch,
+               description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
         string(name: 'CI_FUNCTIONAL_VM9_LABEL',
                defaultValue: 'ci_vm9',
                description: 'Label to use for 9 VM functional tests')
@@ -96,13 +105,13 @@ pipeline {
         stage('Test') {
             when {
                 beforeAgent true
-                expression { ! skipStage() }
+                expression { !skipStage() }
             }
             parallel {
                 stage('Functional on CentOS 7') {
                     when {
                         beforeAgent true
-                        expression { ! skipStage() }
+                        expression { !skipStage() }
                     }
                     agent {
                         label params.CI_FUNCTIONAL_VM9_LABEL
@@ -110,7 +119,7 @@ pipeline {
                     steps {
                         // Need to get back onto base_branch for ci/
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: base_branch,
+                                    branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),
@@ -125,7 +134,7 @@ pipeline {
                 stage('Functional on CentOS 8') {
                     when {
                         beforeAgent true
-                        expression { ! skipStage() }
+                        expression { !skipStage() }
                     }
                     agent {
                         label params.CI_FUNCTIONAL_VM9_LABEL
@@ -133,7 +142,7 @@ pipeline {
                     steps {
                         // Need to get back onto base_branch for ci/
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: base_branch,
+                                    branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),
@@ -148,7 +157,7 @@ pipeline {
                 stage('Functional on Leap 15') {
                     when {
                         beforeAgent true
-                        expression { ! skipStage() }
+                        expression { !skipStage() }
                     }
                     agent {
                         label params.CI_FUNCTIONAL_VM9_LABEL
@@ -156,7 +165,7 @@ pipeline {
                     steps {
                         // Need to get back onto base_branch for ci/
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: base_branch,
+                                    branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),
@@ -171,7 +180,7 @@ pipeline {
                 stage('Functional on Ubuntu 20.04') {
                     when {
                         beforeAgent true
-                        expression { ! skipStage() }
+                        expression { !skipStage() }
                     }
                     agent {
                         label params.CI_FUNCTIONAL_VM9_LABEL
@@ -179,7 +188,7 @@ pipeline {
                     steps {
                         // Need to get back onto base_branch for ci/
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: base_branch,
+                                    branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),
@@ -194,7 +203,7 @@ pipeline {
                 stage('Functional Hardware Small') {
                     when {
                         beforeAgent true
-                        expression { ! skipStage() }
+                        expression { !skipStage() }
                     }
                     agent {
                         // 2 node cluster with 1 IB/node + 1 test control node
@@ -203,7 +212,7 @@ pipeline {
                     steps {
                         // Need to get back onto base_branch for ci/
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: base_branch,
+                                    branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),
@@ -218,7 +227,7 @@ pipeline {
                 stage('Functional Hardware Medium') {
                     when {
                         beforeAgent true
-                        expression { ! skipStage() }
+                        expression { !skipStage() }
                     }
                     agent {
                         // 4 node cluster with 2 IB/node + 1 test control node
@@ -227,7 +236,7 @@ pipeline {
                     steps {
                         // Need to get back onto base_branch for ci/
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: base_branch,
+                                    branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),
@@ -242,7 +251,7 @@ pipeline {
                 stage('Functional Hardware Large') {
                     when {
                         beforeAgent true
-                        expression { ! skipStage() }
+                        expression { !skipStage() }
                     }
                     agent {
                         // 8+ node cluster with 1 IB/node + 1 test control node
@@ -251,7 +260,7 @@ pipeline {
                     steps {
                         // Need to get back onto base_branch for ci/
                         checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: base_branch,
+                                    branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
                                        inst_rpms: functionalPackages(1, next_version),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -145,7 +145,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -168,7 +168,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -191,7 +191,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -215,7 +215,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -239,7 +239,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {
@@ -263,7 +263,7 @@ pipeline {
                                     branch: env.BaseBranch,
                                     withSubmodules: true
                         functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
                                        test_function: 'runTestFunctionalV2'
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,22 +69,82 @@ pipeline {
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
                defaultValue: 'full_regression',
-               description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
+               description: 'Test-tag to use for the weekly Functional Hardware Small/Medium/Large stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'TestTagTCP',
+               defaultValue: 'pr daily_regression',
+               description: 'Test-tag to use for the Functional Hardware Small/Medium/Large TCP stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'TestTagUCX',
+               defaultValue: 'pr daily_regression',
+               description: 'Test-tag to use for the Functional Hardware Small/Medium/Large UCX stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
         string(name: 'BaseBranch',
                defaultValue: base_branch,
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
+        booleanParam(name: 'CI_FUNCTIONAL_el8_TEST',
+                     defaultValue: true,
+                     description: 'Run the Functional on EL 8 test stage')
+        booleanParam(name: 'CI_FUNCTIONAL_leap15_TEST',
+                     defaultValue: true,
+                     description: 'Run the Functional on Leap 15 test stage')
+        booleanParam(name: 'CI_FUNCTIONAL_ubuntu20_TEST',
+                     defaultValue: false,
+                     description: 'Run the Functional on Ubuntu 20 test stage')
+        booleanParam(name: 'CI_small_TEST',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Small test stage')
+        booleanParam(name: 'CI_medium_TEST',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Medium test stage')
+        booleanParam(name: 'CI_large_TEST',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Large test stage')
+        booleanParam(name: 'CI_small_tcp_TEST',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Small TCP test stage')
+        booleanParam(name: 'CI_medium_tcp_TEST',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Medium TCP test stage')
+        booleanParam(name: 'CI_large_tcp_TEST',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Large TCP test stage')
+        booleanParam(name: 'CI_small_ucx_TEST',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Small UCX test stage')
+        booleanParam(name: 'CI_medium_ucx_TEST',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Medium UCX test stage')
+        booleanParam(name: 'CI_large_ucx_TEST',
+                     defaultValue: true,
+                     description: 'Run the CI Functional Hardware Large UCX test stage')
         string(name: 'CI_FUNCTIONAL_VM9_LABEL',
                defaultValue: 'ci_vm9',
                description: 'Label to use for 9 VM functional tests')
         string(name: 'CI_NVME_3_LABEL',
                defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node NVMe tests')
+               description: 'Label to use for 3 node Functional Hardware Small stage')
         string(name: 'CI_NVME_5_LABEL',
                defaultValue: 'ci_nvme5',
-               description: 'Label to use for 5 node NVMe tests')
+               description: 'Label to use for 5 node Functional Hardware Medium stage')
         string(name: 'CI_NVME_9_LABEL',
                defaultValue: 'ci_nvme9',
-               description: 'Label to use for 9 node NVMe tests')
+               description: 'Label to use for 9 node Functional Hardware Large stage')
+        string(name: 'CI_HW_SMALL_TCP_LABEL',
+               defaultValue: 'ci_nvme3',
+               description: 'Label to use for 3 node Functional Hardware Small TCP stage')
+        string(name: 'CI_HW_MEDIUM_TCP_LABEL',
+               defaultValue: 'ci_nvme5',
+               description: 'Label to use for 5 node Functional Hardware Medium TCP stage')
+        string(name: 'CI_HW_LARGE_TCP_LABEL',
+               defaultValue: 'ci_nvme9',
+               description: 'Label to use for 9 node Functional Hardware Large TCP stage')
+        string(name: 'CI_HW_SMALL_UCX_LABEL',
+               defaultValue: 'ci_nvme3',
+               description: 'Label to use for 3 node Functional Hardware Small UCX stage')
+        string(name: 'CI_HW_MEDIUM_UCX_LABEL',
+               defaultValue: 'ci_nvme5',
+               description: 'Label to use for 5 node Functional Hardware Medium UCX stage')
+        string(name: 'CI_HW_LARGE_UCX_LABEL',
+               defaultValue: 'ci_nvme9',
+               description: 'Label to use for 9 node Functional Hardware Large UCX stage')
     }
 
     stages {
@@ -108,30 +168,7 @@ pipeline {
                 expression { !skipStage() }
             }
             parallel {
-                stage('Functional on CentOS 7') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        label params.CI_FUNCTIONAL_VM9_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional on CentOS 7')
-                stage('Functional on CentOS 8') {
+                 stage('Functional on CentOS 8') {
                     when {
                         beforeAgent true
                         expression { !skipStage() }
@@ -272,6 +309,150 @@ pipeline {
                         }
                     }
                 } // stage('Functional_Hardware_Large')
+                stage('Functional Hardware Small TCP') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 2 node cluster with 1 IB/node + 1 test control node
+                        label params.CI_HW_SMALL_TCP_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Small TCP')
+                stage('Functional Hardware Medium TCP') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 4 node cluster with 2 IB/node + 1 test control node
+                        label params.CI_HW_MEDIUM_TCP_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Medium TCP')
+                stage('Functional Hardware Large TCP') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 8+ node cluster with 1 IB/node + 1 test control node
+                        label params.CI_HW_LARGE_TCP_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Large TCP')
+                stage('Functional Hardware Small UCX') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 2 node cluster with 1 IB/node + 1 test control node
+                        label params.CI_HW_SMALL_UCX_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Small UCX')
+                stage('Functional Hardware Medium UCX') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 4 node cluster with 2 IB/node + 1 test control node
+                        label params.CI_HW_MEDIUM_UCX_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Medium UCX')
+                stage('Functional Hardware Large UCX') {
+                    when {
+                        beforeAgent true
+                        expression { !skipStage() }
+                    }
+                    agent {
+                        // 8+ node cluster with 1 IB/node + 1 test control node
+                        label params.CI_HW_LARGE_UCX_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: env.BaseBranch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional Hardware Large UCX')
             } // parallel
         } // stage('Test')
     } //stages

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@DAOS-9989") _
 
 // Should try to figure this out automatically
 /* groovylint-disable-next-line CompileStatic, VariableName */
@@ -89,13 +90,13 @@ pipeline {
                      defaultValue: true,
                      description: 'Run the Large Cluster CI tests')
         string(name: 'CI_NVME_3_LABEL',
-               defaultValue: 'ci_nvme3',
+               defaultValue: 'ci_ofed3',
                description: 'Label to use for 3 node NVMe tests')
         string(name: 'CI_NVME_5_LABEL',
-               defaultValue: 'ci_nvme5',
+               defaultValue: 'ci_ofed5',
                description: 'Label to use for 5 node NVMe tests')
         string(name: 'CI_NVME_9_LABEL',
-               defaultValue: 'ci_nvme9',
+               defaultValue: 'ci_ofed9',
                description: 'Label to use for 9 node NVMe tests')
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,19 @@ pipeline {
                description: 'Priority of this build.  DO NOT USE WITHOUT PERMISSION.')
         string(name: 'TestTag',
                defaultValue: "full_regression",
-               description: 'Test-tag to use for this run (i.e pr, daily_regression, full_regression, etc.')
+               description: 'Test-tag to use for this run (i.e. pr, daily_regression, full_regression, etc.)')
+        string(name: 'CI_FUNCTIONAL_VM9_LABEL',
+               defaultValue: 'ci_vm9',
+               description: 'Label to use for 9 VM functional tests')
+        string(name: 'CI_NVME_3_LABEL',
+               defaultValue: 'ci_nvme3',
+               description: 'Label to use for 3 node NVMe tests')
+        string(name: 'CI_NVME_5_LABEL',
+               defaultValue: 'ci_nvme5',
+               description: 'Label to use for 5 node NVMe tests')
+        string(name: 'CI_NVME_9_LABEL',
+               defaultValue: 'ci_nvme9',
+               description: 'Label to use for 9 node NVMe tests')
     }
 
     stages {
@@ -93,7 +105,7 @@ pipeline {
                         expression { ! skipStage() }
                     }
                     agent {
-                        label 'ci_vm9'
+                        label params.CI_FUNCTIONAL_VM9_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -116,7 +128,7 @@ pipeline {
                         expression { ! skipStage() }
                     }
                     agent {
-                        label 'ci_vm9'
+                        label params.CI_FUNCTIONAL_VM9_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -139,7 +151,7 @@ pipeline {
                         expression { ! skipStage() }
                     }
                     agent {
-                        label 'ci_vm9'
+                        label params.CI_FUNCTIONAL_VM9_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -163,7 +175,7 @@ pipeline {
                     }
                     agent {
                         // 2 node cluster with 1 IB/node + 1 test control node
-                        label 'ci_nvme3'
+                        label params.CI_NVME_3_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -187,7 +199,7 @@ pipeline {
                     }
                     agent {
                         // 4 node cluster with 2 IB/node + 1 test control node
-                        label 'ci_nvme5'
+                        label params.CI_NVME_5_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/
@@ -211,7 +223,7 @@ pipeline {
                     }
                     agent {
                         // 8+ node cluster with 1 IB/node + 1 test control node
-                        label 'ci_nvme9'
+                        label params.CI_NVME_9_LABEL
                     }
                     steps {
                         // Need to get back onto base_branch for ci/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,6 +122,29 @@ pipeline {
                         }
                     }
                 } // stage('Functional on CentOS 7')
+                stage('Functional on CentOS 8') {
+                    when {
+                        beforeAgent true
+                        expression { ! skipStage() }
+                    }
+                    agent {
+                        label params.CI_FUNCTIONAL_VM9_LABEL
+                    }
+                    steps {
+                        // Need to get back onto base_branch for ci/
+                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
+                                    branch: base_branch,
+                                    withSubmodules: true
+                        functionalTest inst_repos: daosRepos(),
+                                       inst_rpms: functionalPackages(1, next_version),
+                                       test_function: 'runTestFunctionalV2'
+                    }
+                    post {
+                        always {
+                            functionalTestPostV2()
+                        }
+                    }
+                } // stage('Functional on CentOS 8')
                 stage('Functional on Leap 15') {
                     when {
                         beforeAgent true


### PR DESCRIPTION
Create a new provider-testing-ucx branch to run pr+daily tagged tests in
the Functional Hardware test stages with the ucx+dc_x provider on a
weekly cadence.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>