### PR TITLE
DAOS-623 cq: Remove legacy D_FREE_PTR macro.

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -711,6 +711,7 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov, void *arg)
 
 	if (direct_scm_access(biod, biov)) {
 		struct umem_instance *umem = biod->bd_ctxt->bic_umem;
+
 		bio_iov_set_raw_buf(biov,
 				    umem_off2ptr(umem, bio_iov2raw_off(biov)));
 		return 0;
@@ -1380,7 +1381,6 @@ bio_read(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov)
 	return bio_rw(ioctxt, addr, iov, false);
 }
 
-
 int
 bio_write(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov)
 {
@@ -1464,7 +1464,7 @@ free_copy_desc(struct bio_copy_desc *copy_desc)
 		bio_iod_free(copy_desc->bcd_iod_src);
 	if (copy_desc->bcd_iod_dst)
 		bio_iod_free(copy_desc->bcd_iod_dst);
-	D_FREE_PTR(copy_desc);
+	D_FREE(copy_desc);
 }
 
 static struct bio_copy_desc *

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -97,7 +97,7 @@ crt_epi_destroy(struct crt_ep_inflight *epi)
 	/* crt_list_del_init(&epi->epi_link); */
 	D_MUTEX_DESTROY(&epi->epi_mutex);
 
-	D_FREE_PTR(epi);
+	D_FREE(epi);
 }
 
 static int
@@ -206,7 +206,7 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 	rc = crt_context_init(ctx);
 	if (rc != 0) {
 		D_ERROR("crt_context_init() failed, " DF_RC "\n", DP_RC(rc));
-		D_FREE_PTR(ctx);
+		D_FREE(ctx);
 		D_GOTO(out, rc);
 	}
 
@@ -296,7 +296,6 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 			swim_period_set(swim_period_get() * 2);
 			csm->csm_ctx->sc_default_ping_timeout *= 2;
 		}
-
 	}
 
 	*crt_ctx = (crt_context_t)ctx;
@@ -583,6 +582,7 @@ crt_context_destroy(crt_context_t crt_ctx, int force)
 	D_MUTEX_UNLOCK(&ctx->cc_mutex);
 
 	int provider = ctx->cc_hg_ctx.chc_provider;
+
 	rc = crt_hg_ctx_fini(&ctx->cc_hg_ctx);
 	if (rc) {
 		D_ERROR("crt_hg_ctx_fini failed rc: %d.\n", rc);
@@ -1018,9 +1018,7 @@ crt_context_req_track(struct crt_rpc_priv *rpc_priv)
 	RPC_ADDREF(rpc_priv);
 
 	if (crt_gdata.cg_credit_ep_ctx != 0 &&
-	    (epi->epi_req_num - epi->epi_reply_num) >=
-	     crt_gdata.cg_credit_ep_ctx) {
-
+	    (epi->epi_req_num - epi->epi_reply_num) >= crt_gdata.cg_credit_ep_ctx) {
 		if (rpc_priv->crp_opc_info->coi_queue_front) {
 			d_list_add(&rpc_priv->crp_epi_link,
 					&epi->epi_req_waitq);
@@ -1168,10 +1166,7 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 	D_MUTEX_UNLOCK(&epi->epi_mutex);
 
 	/* re-submit the rpc req */
-	while ((tmp_rpc = d_list_pop_entry(&submit_list,
-					    struct crt_rpc_priv,
-					    crp_tmp_link))) {
-
+	while ((tmp_rpc = d_list_pop_entry(&submit_list, struct crt_rpc_priv, crp_tmp_link))) {
 		rc = crt_req_send_internal(tmp_rpc);
 		if (rc == 0)
 			continue;

--- a/src/cart/crt_self_test_client.c
+++ b/src/cart/crt_self_test_client.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -759,7 +759,7 @@ static void free_g_data(void)
 				 * Free and zero the actual pointer, not
 				 * the local copy
 				 */
-				D_FREE_PTR(g_data->cb_args_ptrs[alloc_idx]);
+				D_FREE(g_data->cb_args_ptrs[alloc_idx]);
 			}
 		}
 

--- a/src/cart/crt_self_test_service.c
+++ b/src/cart/crt_self_test_service.c
@@ -121,7 +121,7 @@ static void free_session(struct st_session **session)
 		D_FREE(free_entry->buf);
 		if (free_entry->bulk_hdl != CRT_BULK_NULL)
 			crt_bulk_free(free_entry->bulk_hdl);
-		D_FREEfree_entry);
+		D_FREE(free_entry);
 
 		free_entry = (*session)->buf_list;
 	}

--- a/src/cart/crt_self_test_service.c
+++ b/src/cart/crt_self_test_service.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -121,14 +121,14 @@ static void free_session(struct st_session **session)
 		D_FREE(free_entry->buf);
 		if (free_entry->bulk_hdl != CRT_BULK_NULL)
 			crt_bulk_free(free_entry->bulk_hdl);
-		D_FREE_PTR(free_entry);
+		D_FREEfree_entry);
 
 		free_entry = (*session)->buf_list;
 	}
 
 	D_SPIN_DESTROY(&(*session)->buf_list_lock);
 
-	D_FREE_PTR(*session);
+	D_FREE(*session);
 }
 
 static inline void

--- a/src/common/profile.c
+++ b/src/common/profile.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -33,7 +33,7 @@ profile_chunk_destroy(struct daos_profile_chunk *chunk)
 {
 	d_list_del(&chunk->dpc_chunk_list);
 	D_FREE(chunk->dpc_chunks);
-	D_FREE_PTR(chunk);
+	D_FREE(chunk);
 }
 
 static struct daos_profile_chunk *
@@ -67,7 +67,7 @@ profile_alloc(int op_cnt)
 
 	D_ALLOC_ARRAY(dp->dp_ops, op_cnt);
 	if (dp->dp_ops == NULL) {
-		D_FREE_PTR(dp);
+		D_FREE(dp);
 		return NULL;
 	}
 	dp->dp_ops_cnt = op_cnt;
@@ -99,7 +99,7 @@ daos_profile_destroy(struct daos_profile *dp)
 	if (dp->dp_dir_path)
 		D_FREE(dp->dp_dir_path);
 
-	D_FREE_PTR(dp);
+	D_FREE(dp);
 }
 
 static int

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -150,7 +150,7 @@ dtx_free_dbca(struct dtx_batched_cont_args *dbca)
 		D_FREE(dbpa);
 	}
 
-	D_FREE_PTR(dbca);
+	D_FREE(dbca);
 	ds_cont_child_put(cont);
 }
 
@@ -1970,7 +1970,7 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	rc = ABT_future_create(dlh->dlh_normal_sub_cnt + 1, dtx_comp_cb, &dlh->dlh_future);
 	if (rc != ABT_SUCCESS) {
 		D_ERROR("ABT_future_create failed (1): "DF_RC"\n", DP_RC(rc));
-		D_FREE_PTR(ult_arg);
+		D_FREE(ult_arg);
 		return dss_abterr2der(rc);
 	}
 
@@ -2023,7 +2023,7 @@ exec:
 	rc = ABT_future_create(dlh->dlh_delay_sub_cnt + 1, dtx_comp_cb, &dlh->dlh_future);
 	if (rc != ABT_SUCCESS) {
 		D_ERROR("ABT_future_create failed (3): "DF_RC"\n", DP_RC(rc));
-		D_FREE_PTR(ult_arg);
+		D_FREE(ult_arg);
 		return dss_abterr2der(rc);
 	}
 

--- a/src/dtx/dtx_cos.c
+++ b/src/dtx/dtx_cos.c
@@ -122,7 +122,7 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	D_ALLOC_PTR(dcrc);
 	if (dcrc == NULL) {
-		D_FREE_PTR(dcr);
+		D_FREE(dcr);
 		return -DER_NOMEM;
 	}
 
@@ -169,7 +169,7 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		d_list_del(&dcrc->dcrc_lo_link);
 		d_list_del(&dcrc->dcrc_gl_committable);
 		dtx_entry_put(dcrc->dcrc_dte);
-		D_FREE_PTR(dcrc);
+		D_FREE(dcrc);
 		dec++;
 	}
 	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_prio_list,
@@ -177,7 +177,7 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		d_list_del(&dcrc->dcrc_lo_link);
 		d_list_del(&dcrc->dcrc_gl_committable);
 		dtx_entry_put(dcrc->dcrc_dte);
-		D_FREE_PTR(dcrc);
+		D_FREE(dcrc);
 		dec++;
 	}
 	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_expcmt_list,
@@ -185,10 +185,10 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		d_list_del(&dcrc->dcrc_lo_link);
 		d_list_del(&dcrc->dcrc_gl_committable);
 		dtx_entry_put(dcrc->dcrc_dte);
-		D_FREE_PTR(dcrc);
+		D_FREE(dcrc);
 		dec++;
 	}
-	D_FREE_PTR(dcr);
+	D_FREE(dcr);
 
 	cont->sc_dtx_committable_count -= dec;
 
@@ -437,7 +437,7 @@ dtx_del_cos(struct ds_cont_child *cont, struct dtx_id *xid,
 		d_list_del(&dcrc->dcrc_gl_committable);
 		d_list_del(&dcrc->dcrc_lo_link);
 		dtx_entry_put(dcrc->dcrc_dte);
-		D_FREE_PTR(dcrc);
+		D_FREE(dcrc);
 
 		cont->sc_dtx_committable_count--;
 		dcr->dcr_prio_count--;
@@ -453,7 +453,7 @@ dtx_del_cos(struct ds_cont_child *cont, struct dtx_id *xid,
 		d_list_del(&dcrc->dcrc_gl_committable);
 		d_list_del(&dcrc->dcrc_lo_link);
 		dtx_entry_put(dcrc->dcrc_dte);
-		D_FREE_PTR(dcrc);
+		D_FREE(dcrc);
 
 		cont->sc_dtx_committable_count--;
 		dcr->dcr_reg_count--;
@@ -469,7 +469,7 @@ dtx_del_cos(struct ds_cont_child *cont, struct dtx_id *xid,
 		d_list_del(&dcrc->dcrc_gl_committable);
 		d_list_del(&dcrc->dcrc_lo_link);
 		dtx_entry_put(dcrc->dcrc_dte);
-		D_FREE_PTR(dcrc);
+		D_FREE(dcrc);
 
 		cont->sc_dtx_committable_count--;
 		dcr->dcr_expcmt_count--;

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -788,5 +788,5 @@ dtx_resync_ult(void *data)
 	pool->sp_dtx_resync_version = arg->version;
 out_put:
 	ds_pool_put(pool);
-	D_FREE_PTR(arg);
+	D_FREE(arg);
 }

--- a/src/gurt/examples/telem_consumer_example.c
+++ b/src/gurt/examples/telem_consumer_example.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -136,8 +136,8 @@ void read_metrics(struct d_tm_context *ctx, struct d_tm_node_t *root,
 		if (show_meta)
 			d_tm_print_metadata(desc, units, D_TM_STANDARD,
 					    stdout);
-		D_FREE_PTR(desc);
-		D_FREE_PTR(units);
+		D_FREE(desc);
+		D_FREE(units);
 
 		if (node->dtn_type != D_TM_DIRECTORY)
 			printf("\n");

--- a/src/gurt/heap.c
+++ b/src/gurt/heap.c
@@ -217,7 +217,7 @@ d_binheap_create(uint32_t feats, uint32_t count, void *priv,
 	rc = d_binheap_create_inplace(feats, count, priv, ops, bh_created);
 	if (rc != 0) {
 		D_ERROR("d_binheap_create() failed, " DF_RC "\n", DP_RC(rc));
-		D_FREE_PTR(bh_created);
+		D_FREE(bh_created);
 		return rc;
 	}
 
@@ -254,7 +254,6 @@ d_binheap_destroy_inplace(struct d_binheap *h)
 
 	if (n > 0) {
 		for (idx0 = 0; idx0 < DBH_SIZE && n > 0; idx0++) {
-
 			for (idx1 = 0; idx1 < DBH_SIZE && n > 0; idx1++) {
 				D_FREE(h->d_bh_nodes3[idx0][idx1]);
 				n -= DBH_SIZE;
@@ -280,7 +279,7 @@ d_binheap_destroy(struct d_binheap *h)
 	}
 
 	d_binheap_destroy_inplace(h);
-	D_FREE_PTR(h);
+	D_FREE(h);
 }
 
 /**
@@ -296,11 +295,11 @@ static struct d_binheap_node **
 d_binheap_pointer(struct d_binheap *h, uint32_t idx)
 {
 	if (idx < DBH_SIZE)
-		return &(h->d_bh_nodes1[idx]);
+		return &h->d_bh_nodes1[idx];
 
 	idx -= DBH_SIZE;
 	if (idx < DBH_SIZE * DBH_SIZE)
-		return &(h->d_bh_nodes2[idx >> DBH_SHIFT][idx & DBH_MASK]);
+		return &h->d_bh_nodes2[idx >> DBH_SHIFT][idx & DBH_MASK];
 
 	idx -= DBH_SIZE * DBH_SIZE;
 	return &(h->d_bh_nodes3[idx >> (2 * DBH_SHIFT)]

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1258,8 +1258,8 @@ d_tm_print_node(struct d_tm_context *ctx, struct d_tm_node_t *node, int level,
 
 		d_tm_print_metadata(desc, units, format, stream);
 	}
-	D_FREE_PTR(desc);
-	D_FREE_PTR(units);
+	D_FREE(desc);
+	D_FREE(units);
 
 	if (node->dtn_type != D_TM_DIRECTORY)
 		fprintf(stream, "\n");
@@ -1355,7 +1355,7 @@ d_tm_print_my_children(struct d_tm_context *ctx, struct d_tm_node_t *node,
 
 		d_tm_print_my_children(ctx, node, level + 1, filter,
 				       fullpath, format, opt_fields, stream);
-		D_FREE_PTR(fullpath);
+		D_FREE(fullpath);
 		node = node->dtn_sibling;
 		node = conv_ptr(shmem, node);
 	}
@@ -1551,7 +1551,6 @@ d_tm_set_counter(struct d_tm_node_t *metric, uint64_t value)
 void
 d_tm_inc_counter(struct d_tm_node_t *metric, uint64_t value)
 {
-
 	if (unlikely(metric == NULL))
 		return;
 
@@ -3144,7 +3143,6 @@ list_children(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 
 out:
 	return rc;
-
 }
 
 /**
@@ -3174,7 +3172,7 @@ d_tm_list_subdirs(struct d_tm_context *ctx, struct d_tm_nodeList_t **head,
 	struct d_tm_nodeList_t	*cur = NULL;
 
 	/** add +1 to max_depth to account for the root node */
-	rc = list_children(ctx, head, node, D_TM_DIRECTORY, 0, max_depth+1, 1);
+	rc = list_children(ctx, head, node, D_TM_DIRECTORY, 0, max_depth + 1, 1);
 	if (rc != DER_SUCCESS)
 		return rc;
 
@@ -3233,7 +3231,7 @@ d_tm_list_free(struct d_tm_nodeList_t *nodeList)
 
 	while (nodeList) {
 		head = nodeList->dtnl_next;
-		D_FREE_PTR(nodeList);
+		D_FREE(nodeList);
 		nodeList = head;
 	}
 }

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -286,7 +286,6 @@ char *d_realpath(const char *path, char *resolved_path);
 #define D_ALLOC_NZ(ptr, size)	D_ALLOC_CORE_NZ(ptr, size, 1)
 #define D_ALLOC_PTR_NZ(ptr)	D_ALLOC_NZ(ptr, sizeof(*ptr))
 #define D_ALLOC_ARRAY_NZ(ptr, count) D_ALLOC_CORE_NZ(ptr, sizeof(*ptr), count)
-#define D_FREE_PTR(ptr)		D_FREE(ptr)
 
 #define D_GOTO(label, rc)			\
 	do {					\

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -216,7 +216,7 @@ dc_tx_free(struct d_hlink *hlink)
 	D_FREE(tx->tx_req_cache);
 	dc_pool_put(tx->tx_pool);
 	D_MUTEX_DESTROY(&tx->tx_lock);
-	D_FREE_PTR(tx);
+	D_FREE(tx);
 }
 
 static struct d_hlink_ops tx_h_ops = {
@@ -292,7 +292,7 @@ dc_tx_alloc(daos_handle_t coh, daos_epoch_t epoch, uint64_t flags,
 	rc = D_MUTEX_INIT(&tx->tx_lock, NULL);
 	if (rc != 0) {
 		D_FREE(tx->tx_req_cache);
-		D_FREE_PTR(tx);
+		D_FREE(tx);
 		return rc;
 	}
 
@@ -1737,7 +1737,6 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 	tx->tx_head.dcs_type = DCST_HEAD;
 	tx->tx_head.dcs_nr = 1;
 	tx->tx_head.dcs_buf = dcsh;
-
 
 	/* XXX: Currently, we only pack single DTX per CPD RPC, then elect
 	 *	the first targets in the dispatch list as the leader.

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -440,7 +440,7 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 	d_list_for_each_entry_safe(f_shard, tmp, extended_list, fs_list) {
 		if (grp_map_is_set(grp_map, grp_map_idx, f_shard->fs_tgt_id)) {
 			d_list_del_init(&f_shard->fs_list);
-			D_FREE_PTR(f_shard);
+			D_FREE(f_shard);
 			continue;
 		}
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -127,7 +127,7 @@ vts_dtx_end(struct dtx_handle *dth)
 	vos_dtx_rsrvd_fini(dth);
 	vos_dtx_detach(dth);
 	D_FREE(dth->dth_dte.dte_mbs);
-	D_FREE_PTR(dth);
+	D_FREE(dth);
 }
 
 static void
@@ -857,7 +857,7 @@ dtx_18(void **state)
 static int
 dtx_tst_teardown(void **state)
 {
-	test_args_reset((struct io_test_args *) *state, VPOOL_SIZE);
+	test_args_reset((struct io_test_args *)*state, VPOOL_SIZE);
 	return 0;
 }
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -363,7 +363,7 @@ dtx_cmt_ent_free(struct btr_instance *tins, struct btr_record *rec,
 	D_ASSERT(dce != NULL);
 
 	rec->rec_off = UMOFF_NULL;
-	D_FREE_PTR(dce);
+	D_FREE(dce);
 
 	return 0;
 }

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -49,7 +49,7 @@ dtx_iter_fini(struct vos_iterator *iter)
 	if (oiter->oit_cont != NULL)
 		vos_cont_decref(oiter->oit_cont);
 
-	D_FREE_PTR(oiter);
+	D_FREE(oiter);
 	return rc;
 }
 


### PR DESCRIPTION
- Skip-func-hw-test: true Skip-func-test: true Quick-Functional: true Test-tag: dfuse
- Skip-func-hw-test: true Skip-func-test: true Quick-Functional: true Test-tag: dfuse Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
- Change free calls.
- Skip-func-hw-test: true Skip-func-test: true Quick-Functional: true Test-tag: dfuse
