### PR TITLE
DAOS-10873 cq: Fix the date githook on OS X.

### DIFF
--- a/utils/githooks/pre-commit.d/10-update-copyright
+++ b/utils/githooks/pre-commit.d/10-update-copyright
@@ -55,7 +55,7 @@ for file in $files; do
 		git reset "$file" || (echo "Unable to un-stage $file" && exit 1)
 		if [ $os == 'Linux' ]
 		then
-			sed -i '' -re "s/$regex/\1Copyright $y1-$year \8/" "$file"
+			sed -i -re "s/$regex/\1Copyright $y1-$year \8/" "$file"
 		else
 			sed -i '' -re "s/$regex/\1Copyright $y1-$year \8/" "$file"
 		fi

--- a/utils/githooks/pre-commit.d/10-update-copyright
+++ b/utils/githooks/pre-commit.d/10-update-copyright
@@ -53,7 +53,7 @@ for file in $files; do
 		errors=$((errors + 1))
 	elif [[ $y1 -ne $year && $year -ne $y2 ]] ; then
 		git reset "$file" || (echo "Unable to un-stage $file" && exit 1)
-		if [ $os == 'Linux' ]
+		if [ "$os" == 'Linux' ]
 		then
 			sed -i -re "s/$regex/\1Copyright $y1-$year \8/" "$file"
 		else

--- a/utils/githooks/pre-commit.d/10-update-copyright
+++ b/utils/githooks/pre-commit.d/10-update-copyright
@@ -2,6 +2,12 @@
 
 # A git hook to validate and correct the copyright date in source files.
 
+if [ -e .git/MERGE_HEAD ]
+then
+    echo Merge commit
+    exit 0
+fi
+
 regex='(^[[:blank:]]*[\*/]*.*)((Copyright[[:blank:]]*)([0-9]{4})(-([0-9]{4}))?)([[:blank:]]*(Intel.*$))'
 year=$(date +%Y)
 errors=0
@@ -33,6 +39,8 @@ targets=(
     '.env'
 )
 
+os=$(uname -s)
+
 files=${files:-$(git diff --diff-filter=AM --name-only --cached -- "${targets[@]}")}
 for file in $files; do
 	if [[ "$file" == *vendor* ]] || [[ "$file" == *pb.go ]] || \
@@ -45,7 +53,13 @@ for file in $files; do
 		errors=$((errors + 1))
 	elif [[ $y1 -ne $year && $year -ne $y2 ]] ; then
 		git reset "$file" || (echo "Unable to un-stage $file" && exit 1)
-		sed -i -re "s/$regex/\1Copyright $y1-$year \8/" "$file" || exit 1
+		if [ $os == 'Linux' ]
+		then
+			sed -i '' -re "s/$regex/\1Copyright $y1-$year \8/" "$file"
+		else
+			sed -i '' -re "s/$regex/\1Copyright $y1-$year \8/" "$file"
+		fi
+
 		git add "$file" || (echo "Unable to re-stage $file" && exit 1)
 	fi
 done


### PR DESCRIPTION
Use the correct sed options, and do not run the hook on merge
commits.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
