### PR TITLE
DAOS-9989 test: Enable regular weekly tcp testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,12 +70,6 @@ pipeline {
         string(name: 'TestTag',
                defaultValue: 'full_regression',
                description: 'Test-tag to use for the weekly Functional Hardware Small/Medium/Large stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
-        string(name: 'TestTagTCP',
-               defaultValue: 'pr daily_regression',
-               description: 'Test-tag to use for the Functional Hardware Small/Medium/Large TCP stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
-        string(name: 'TestTagUCX',
-               defaultValue: 'pr daily_regression',
-               description: 'Test-tag to use for the Functional Hardware Small/Medium/Large UCX stages of this run (i.e. pr, daily_regression, full_regression, etc.)')
         string(name: 'BaseBranch',
                defaultValue: base_branch,
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
@@ -97,24 +91,6 @@ pipeline {
         booleanParam(name: 'CI_large_TEST',
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Large test stage')
-        booleanParam(name: 'CI_small_tcp_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Small TCP test stage')
-        booleanParam(name: 'CI_medium_tcp_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Medium TCP test stage')
-        booleanParam(name: 'CI_large_tcp_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Large TCP test stage')
-        booleanParam(name: 'CI_small_ucx_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Small UCX test stage')
-        booleanParam(name: 'CI_medium_ucx_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Medium UCX test stage')
-        booleanParam(name: 'CI_large_ucx_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Large UCX test stage')
         string(name: 'CI_FUNCTIONAL_VM9_LABEL',
                defaultValue: 'ci_vm9',
                description: 'Label to use for 9 VM functional tests')
@@ -127,24 +103,6 @@ pipeline {
         string(name: 'CI_NVME_9_LABEL',
                defaultValue: 'ci_nvme9',
                description: 'Label to use for 9 node Functional Hardware Large stage')
-        string(name: 'CI_HW_SMALL_TCP_LABEL',
-               defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node Functional Hardware Small TCP stage')
-        string(name: 'CI_HW_MEDIUM_TCP_LABEL',
-               defaultValue: 'ci_nvme5',
-               description: 'Label to use for 5 node Functional Hardware Medium TCP stage')
-        string(name: 'CI_HW_LARGE_TCP_LABEL',
-               defaultValue: 'ci_nvme9',
-               description: 'Label to use for 9 node Functional Hardware Large TCP stage')
-        string(name: 'CI_HW_SMALL_UCX_LABEL',
-               defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node Functional Hardware Small UCX stage')
-        string(name: 'CI_HW_MEDIUM_UCX_LABEL',
-               defaultValue: 'ci_nvme5',
-               description: 'Label to use for 5 node Functional Hardware Medium UCX stage')
-        string(name: 'CI_HW_LARGE_UCX_LABEL',
-               defaultValue: 'ci_nvme9',
-               description: 'Label to use for 9 node Functional Hardware Large UCX stage')
     }
 
     stages {
@@ -309,150 +267,6 @@ pipeline {
                         }
                     }
                 } // stage('Functional_Hardware_Large')
-                stage('Functional Hardware Small TCP') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 2 node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_SMALL_TCP_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Small TCP')
-                stage('Functional Hardware Medium TCP') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 4 node cluster with 2 IB/node + 1 test control node
-                        label params.CI_HW_MEDIUM_TCP_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Medium TCP')
-                stage('Functional Hardware Large TCP') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 8+ node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_LARGE_TCP_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Large TCP')
-                stage('Functional Hardware Small UCX') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 2 node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_SMALL_UCX_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Small UCX')
-                stage('Functional Hardware Medium UCX') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 4 node cluster with 2 IB/node + 1 test control node
-                        label params.CI_HW_MEDIUM_UCX_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Medium UCX')
-                stage('Functional Hardware Large UCX') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 8+ node cluster with 1 IB/node + 1 test control node
-                        label params.CI_HW_LARGE_UCX_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: env.BaseBranch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version, "tests-internal"),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional Hardware Large UCX')
             } // parallel
         } // stage('Test')
     } //stages


### PR DESCRIPTION
Remove the weekly tcp/ucx test stages from the weekly-testing branch as
they are being moved to their own provider-testing-* branches.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>