### PR TITLE
DAOS-10820 control: Set system name in set engine log masks RPC

### DIFF
--- a/src/control/cmd/dmg/server.go
+++ b/src/control/cmd/dmg/server.go
@@ -51,10 +51,14 @@ func (cmd *serverSetLogMasksCmd) Execute(_ []string) (errOut error) {
 	}
 	req.SetHostList(cmd.hostlist)
 
+	cmd.Debugf("set log masks request: %+v", req)
+
 	resp, err := control.SetEngineLogMasks(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
 		return err // control api returned an error, disregard response
 	}
+
+	cmd.Debugf("set log masks reponse: %+v", resp)
 
 	if cmd.jsonOutputEnabled() {
 		return cmd.outputJSON(resp, resp.Errors())

--- a/src/control/lib/control/server.go
+++ b/src/control/lib/control/server.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/server/engine"
 )
@@ -21,7 +22,7 @@ import (
 // request.
 type SetEngineLogMasksReq struct {
 	unaryRequest
-	Masks string
+	Masks string `json:"masks"`
 }
 
 // SetEngineLogMasksResp contains the results of a set engine log level
@@ -40,12 +41,19 @@ func SetEngineLogMasks(ctx context.Context, rpcClient UnaryInvoker, req *SetEngi
 		return nil, err
 	}
 
+	pbReq := new(ctlpb.SetLogMasksReq)
+	if err := convert.Types(req, pbReq); err != nil {
+		return nil, err
+	}
+	pbReq.Sys = req.getSystem(rpcClient)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
-		return ctlpb.NewCtlSvcClient(conn).SetEngineLogMasks(ctx, &ctlpb.SetLogMasksReq{Masks: req.Masks})
+		return ctlpb.NewCtlSvcClient(conn).SetEngineLogMasks(ctx, pbReq)
 	})
+	rpcClient.Debugf("DAOS set engine log masks request: %+v", pbReq)
 
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
+		rpcClient.Debugf("failed to invoke set engine log masks RPC: %s", err)
 		return nil, err
 	}
 
@@ -58,5 +66,6 @@ func SetEngineLogMasks(ctx context.Context, rpcClient UnaryInvoker, req *SetEngi
 		}
 	}
 
+	rpcClient.Debugf("DAOS set engine log masks response: %+v", resp)
 	return resp, nil
 }

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -390,6 +390,8 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 		return nil, errors.New("nil request")
 	}
 
+	svc.log.Debugf("CtlSvc.SetEngineLogMasks dispatch, req:%+v\n", req)
+
 	var errs []string
 
 	for idx, ei := range svc.harness.Instances() {
@@ -429,5 +431,9 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 		return nil, errors.New(strings.Join(errs, ", "))
 	}
 
-	return new(ctlpb.SetLogMasksResp), nil
+	resp := new(ctlpb.SetLogMasksResp)
+
+	svc.log.Debugf("CtlSvc.SetEngineLogMasks dispatch, resp:%+v\n", resp)
+
+	return resp, nil
 }


### PR DESCRIPTION
Set system name in RPC message when setting engine log masks to avoid
interoperability check failures.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>
Required-githooks: true