### PR TITLE
DAOS-10895 ddb: Improve help

### DIFF
--- a/src/ddb/README.md
+++ b/src/ddb/README.md
@@ -4,39 +4,7 @@
 
 The DAOS Debug Tool (ddb) allows a user to navigate through a file in the VOS
 format. It is similar to debugfs for ext2/3/4 and offers both a command line and
-interactive shell mode. Key features that will be supported are:
-
-### Parsing a VOS file:
-
-- Printing the VOS 'superblock'
-- listing containers, objects, dkeys, akeys, and records
-- dumping content of a value
-- dumping content of ilogs
-- iterating over the dtx committed and active tables
-
-### Altering a VOS file, including:
-
-- deleting containers, objects, dkeys, akeys, or records
-- changing/inserting new value
-- processing/removing ilogs
-- clearing the dtx committed table
-
-## Current State
-
-ddb is very much in development. Currently the interactive mode and the '-R'
-option with a single command work relatively well.
-
-Status of commands:
-- quit - done for interactive mode. Not applicable for other modes
-- ls - done
-- dump_value - done
-- dump_ilog - done, but not tested real well besides simple happy paths.
-- dump_superblock - done
-- dump_dtx - done
-- rm - done
-- load - done
-- rm_ilog - not started
-- rm_dtx - not started
+interactive shell mode.
 
 ## Design
 
@@ -79,3 +47,158 @@ VOS api.
 This layer will adapt the needs of the ddb commands to the current VOS API
 implementation, making the VOS interaction a bit nicer for ddb.
 
+# Help and Usage
+
+```
+$ ddb -h
+The DAOS Debug Tool (ddb) allows a user to navigate through and modify
+a file in the VOS format. It offers both a command line and interactive
+shell mode. If the '-R' or '-f' options are not provided, then it will
+run in interactive mode. In order to modify the file, the '-w' option
+must be included.
+
+Many of the commands take a vos tree path. The format for this path
+is [cont]/[obj]/[dkey]/[akey]/[recx]. The container is the container
+uuid. The object is the object id.  The keys parts currently only
+support string keys and must be surrounded with a single quote (') unless
+using indexes (explained later). The recx for array values is the
+format {lo-hi}. To make it easier to navigate the tree, indexes can be
+used instead of the path part. The index is in the format [i]
+
+Usage:
+ddb [path] [options]
+
+    [path]
+	The path to the vos file to open. This should be an absolute
+	path to the pool shard. Part of the path is used to
+	determine what the pool uuid is. If a path is not provided
+	initially, the open command can be used later to open the
+	vos file.
+
+Options:
+   -w, --write_mode
+	Open the vos file in write mode. This allows for modifying
+	the vos file with the load,
+	commit_ilog, etc commands.
+   -R, --run_cmd <cmd>
+	Execute the single command <cmd>, then exit.
+   -f, --file_cmd <path>
+	The path to a file container a list of ddb commands, one
+	command per line, then exit.
+   -h, --help
+	Show tool usage.
+Commands:
+   help              Show help message for all the commands.
+   quit              Quit interactive mode
+   ls                List containers, objects, dkeys, akeys, and values
+   open              Opens the vos file at <path>
+   close             Close the currently opened vos pool shard
+   dump_superblock   Dump the pool superblock information
+   dump_value        Dump a value to a file
+   rm                Remove a branch of the VOS tree.
+   load              Load a value to a vos path.
+   dump_ilog         Dump the ilog
+   commit_ilog       Process the ilog
+   rm_ilog           Remove all the ilog entries
+   dump_dtx          Dump the dtx tables
+   clear_cmt_dtx     Clear the dtx committed table
+   smd_sync          Restore the SMD file with backup from blob
+
+```
+
+```
+$ ddb -R help
+help
+	Show help message for all the commands.
+
+quit
+	Quit interactive mode
+
+ls [path]
+	List containers, objects, dkeys, akeys, and values
+    [path]
+	Optional, list contents of the provided path
+Options:
+    -r, --recursive
+	Recursively list the contents of the path
+
+open <path>
+	Opens the vos file at <path>
+    <path>
+	The path to the vos file to open. This should be an absolute
+	path to the pool shard. Part of the path is used to
+	determine what the pool uuid is.
+Options:
+    -w, --write_mode
+	Open the vos file in write mode. This allows for modifying
+	the vos file with the load, commit_ilog, etc commands.
+
+close
+	Close the currently opened vos pool shard
+
+dump_superblock
+	Dump the pool superblock information
+
+dump_value <path> <dst>
+	Dump a value to a file
+    <path>
+	The vos tree path to dump. Should be a complete path
+	including the akey and if the value is an array value it
+	should include the extent.
+    <dst>
+	The file path to dump the value to.
+
+rm <path>
+	Remove a branch of the VOS tree. The branch can be anything
+	from a container and everything under it, to a single value.
+    <path>
+	The vos tree path to remove.
+
+load <src> <dst>
+	Load a value to a vos path. This can be used to update the
+	value of an existing key, or create a new key.
+    <src>
+	The source file path that contains the data for the value to
+	load.
+    <dst>
+	The destination vos tree path to the value where the data
+	will be loaded. If the path currently exists, then the
+	destination path must match the value type, meaning, if the
+	value type is an array, then the path must include the recx,
+	otherwise, it must not.
+
+dump_ilog <path>
+	Dump the ilog
+    <path>
+	The vos tree path to an object, dkey, or akey.
+
+commit_ilog <path>
+	Process the ilog
+    <path>
+	The vos tree path to an object, dkey, or akey.
+
+rm_ilog <path>
+	Remove all the ilog entries
+    <path>
+	The vos tree path to an object, dkey, or akey.
+
+dump_dtx <path>
+	Dump the dtx tables
+    <path>
+	The vos tree path to a container.
+Options:
+    -a, --active
+	Only dump entries from the active table
+    -c, --committed
+	Only dump entries from the committed table
+
+clear_cmt_dtx <path>
+	Clear the dtx committed table
+    <path>
+	The vos tree path to a container.
+
+smd_sync
+	Restore the SMD file with backup from blob
+
+
+```

--- a/src/ddb/ddb_cmd_options.h
+++ b/src/ddb/ddb_cmd_options.h
@@ -34,7 +34,7 @@ struct ls_options {
 
 struct open_options {
 	bool write_mode;
-	char *vos_pool_shard;
+	char *path;
 };
 
 struct dump_value_options {
@@ -107,5 +107,8 @@ int ddb_run_rm_ilog(struct ddb_ctx *ctx, struct rm_ilog_options *opt);
 int ddb_run_dump_dtx(struct ddb_ctx *ctx, struct dump_dtx_options *opt);
 int ddb_run_clear_cmt_dtx(struct ddb_ctx *ctx, struct clear_cmt_dtx_options *opt);
 int ddb_run_smd_sync(struct ddb_ctx *ctx);
+
+void ddb_program_help(struct ddb_ctx *ctx);
+void ddb_commands_help(struct ddb_ctx *ctx);
 
 #endif /* __DDB_RUN_CMDS_H */

--- a/src/ddb/ddb_commands.c
+++ b/src/ddb/ddb_commands.c
@@ -14,6 +14,15 @@
 #define ilog_path_required_error_message "Path to object, dkey, or akey required\n"
 
 int
+ddb_run_help(struct ddb_ctx *ctx)
+{
+	ddb_commands_help(ctx);
+
+	return 0;
+}
+
+
+int
 ddb_run_quit(struct ddb_ctx *ctx)
 {
 	ctx->dc_should_quit = true;
@@ -23,7 +32,7 @@ ddb_run_quit(struct ddb_ctx *ctx)
 int
 ddb_run_open(struct ddb_ctx *ctx, struct open_options *opt)
 {
-	return dv_pool_open(opt->vos_pool_shard, &ctx->dc_poh);
+	return dv_pool_open(opt->path, &ctx->dc_poh);
 }
 
 int ddb_run_close(struct ddb_ctx *ctx)

--- a/src/ddb/ddb_parse.c
+++ b/src/ddb/ddb_parse.c
@@ -100,13 +100,14 @@ ddb_parse_program_args(struct ddb_ctx *ctx, uint32_t argc, char **argv, struct p
 		{ "write_mode", no_argument, NULL,	'w' },
 		{ "run_cmd", required_argument, NULL,	'R' },
 		{ "cmd_file", required_argument, NULL,	'f' },
+		{ "help", required_argument, NULL,	'h' },
 		{ NULL }
 	};
 	int		index = 0, opt;
 
 	optind = 0; /* Reinitialize getopt */
 	opterr = 0;
-	while ((opt = getopt_long(argc, argv, "wR:f:", program_options, &index)) != -1) {
+	while ((opt = getopt_long(argc, argv, "wR:f:h", program_options, &index)) != -1) {
 		switch (opt) {
 		case 'w':
 			pa->pa_write_mode = true;
@@ -116,6 +117,9 @@ ddb_parse_program_args(struct ddb_ctx *ctx, uint32_t argc, char **argv, struct p
 			break;
 		case 'f':
 			pa->pa_cmd_file = optarg;
+			break;
+		case 'h':
+			pa->pa_get_help = true;
 			break;
 		case '?':
 			ddb_errorf(ctx, "'%c'(0x%x) is unknown\n", optopt, optopt);

--- a/src/ddb/ddb_parse.h
+++ b/src/ddb/ddb_parse.h
@@ -19,6 +19,7 @@ struct program_args {
 	char *pa_r_cmd_run;
 	char *pa_pool_path;
 	bool  pa_write_mode;
+	bool  pa_get_help;
 };
 
 struct vos_file_parts {

--- a/src/ddb/tests/ddb_cmd_options_tests.c
+++ b/src/ddb/tests/ddb_cmd_options_tests.c
@@ -86,17 +86,17 @@ open_options_parsing(void **state)
 	struct open_options	*options = &info.dci_cmd_option.dci_open;
 
 	/* test invalid arguments and options */
-	test_run_inval_cmd("open", "vos_pool_shard", "extra"); /* too many argument */
+	test_run_inval_cmd("open", "path", "extra"); /* too many argument */
 	test_run_inval_cmd("open", "-z"); /* invalid option */
 
 	/* test all arguments */
-	test_run_cmd(&info, "open", "vos_pool_shard");
-	assert_non_null(options->vos_pool_shard);
+	test_run_cmd(&info, "open", "path");
+	assert_non_null(options->path);
 	assert_false(options->write_mode);
 
 	/* test all options and arguments */
-	test_run_cmd(&info, "open", "-w", "vos_pool_shard");
-	assert_non_null(options->vos_pool_shard);
+	test_run_cmd(&info, "open", "-w", "path");
+	assert_non_null(options->path);
 	assert_true(options->write_mode);
 }
 

--- a/src/ddb/tests/ddb_commands_tests.c
+++ b/src/ddb/tests/ddb_commands_tests.c
@@ -347,7 +347,7 @@ dcv_suit_teardown(void **state)
 #define TEST(test) { #test, test, NULL, NULL }
 
 int
-dvc_tests_run()
+ddb_commands_tests_run()
 {
 	const struct CMUnitTest tests[] = {
 		TEST(quit_cmd_tests),

--- a/src/ddb/tests/ddb_main_tests.c
+++ b/src/ddb/tests/ddb_main_tests.c
@@ -225,6 +225,13 @@ option_f_and_option_R_is_invalid_tests(void **state)
 	assert_invalid_main(tctx->dvt_pmem_file, "-R", "ls", "-f", "file_path");
 }
 
+static void
+get_help_tests(void **state)
+{
+	assert_main("-R", "help");
+	assert_main("-h");
+}
+
 static int
 ddb_main_suit_setup(void **state)
 {
@@ -254,7 +261,7 @@ ddb_main_suit_teardown(void **state)
 
 #define TEST(x) { #x, x, NULL, NULL }
 int
-ddb_main_tests()
+ddb_main_tests_run()
 {
 	static const struct CMUnitTest tests[] = {
 		TEST(interactive_mode_tests),
@@ -262,6 +269,7 @@ ddb_main_tests()
 		TEST(only_modify_with_option_w_tests),
 		TEST(run_many_commands_with_option_f_tests),
 		TEST(option_f_and_option_R_is_invalid_tests),
+		TEST(get_help_tests),
 	};
 
 	return cmocka_run_group_tests_name("DDB CLI tests", tests, ddb_main_suit_setup,

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -597,9 +597,9 @@ int main(int argc, char *argv[])
 #endif
 		RUN_TEST_SUIT('a', ddb_parse_tests_run);
 		RUN_TEST_SUIT('b', ddb_cmd_options_tests_run);
-		RUN_TEST_SUIT('c', dv_tests_run);
-		RUN_TEST_SUIT('d', dvc_tests_run);
-		RUN_TEST_SUIT('e', ddb_main_tests);
+		RUN_TEST_SUIT('c', ddb_vos_tests_run);
+		RUN_TEST_SUIT('d', ddb_commands_tests_run);
+		RUN_TEST_SUIT('e', ddb_main_tests_run);
 		RUN_TEST_SUIT('f', ddb_commands_print_tests_run);
 
 done:

--- a/src/ddb/tests/ddb_test_driver.h
+++ b/src/ddb/tests/ddb_test_driver.h
@@ -42,9 +42,9 @@ int ddb_test_setup_vos(void **state);
 int ddb_teardown_vos(void **state);
 
 int ddb_parse_tests_run(void);
-int dv_tests_run(void);
-int dvc_tests_run(void);
-int ddb_main_tests(void);
+int ddb_vos_tests_run(void);
+int ddb_commands_tests_run(void);
+int ddb_main_tests_run(void);
 int ddb_cmd_options_tests_run(void);
 int ddb_commands_print_tests_run(void);
 

--- a/src/ddb/tests/ddb_vos_tests.c
+++ b/src/ddb/tests/ddb_vos_tests.c
@@ -1045,7 +1045,7 @@ const struct CMUnitTest dv_test_cases[] = {
 };
 
 int
-dv_tests_run()
+ddb_vos_tests_run()
 {
 	return cmocka_run_group_tests_name("DDB VOS Interface Tests", dv_test_cases,
 					   dv_suit_setup, dv_suit_teardown);


### PR DESCRIPTION
- Added help option and help command to ddb.
- Renamed main test functions to be consistent.
- Updated readme to include output from help options.
- Provide list of commands when incorrect command is used.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>

Skip-func-test: true