### PR TITLE
DAOS-623 build: Update el 9 dockerfile for new option.

### DIFF
--- a/utils/docker/Dockerfile.el.9
+++ b/utils/docker/Dockerfile.el.9
@@ -141,8 +141,8 @@ USER daos_server:daos_server
 ARG DEPS_JOBS=1
 
 RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                            \
-        scons --build-deps=yes --jobs $DEPS_JOBS PREFIX=/opt/daos   \
-              TARGET_TYPE=$DAOS_TARGET_TYPE --deps-only &&          \
+        scons --build-deps=only --jobs $DEPS_JOBS PREFIX=/opt/daos  \
+              TARGET_TYPE=$DAOS_TARGET_TYPE &&                      \
         ([ "$DAOS_KEEP_BUILD" != "no" ] || /bin/rm -rf build *.gz); \
     }
 USER root:root


### PR DESCRIPTION
A conflict between two PRs meant that the el9 dockerfile was
added using a option just as it was renamed to something else.
Update the dockerfile to the new name.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
