### PR TITLE
DAOS-9928 engine: incorporate new Cart API

### DIFF
--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -519,12 +519,6 @@ dss_srv_handler(void *arg)
 			goto crt_destroy;
 		}
 		dx->dx_ctx_id = dmi->dmi_ctx_id;
-
-		if (dx->dx_ctx_id != 0) {
-			D_ERROR("Invalid secondary context ID: %d\n", dx->dx_ctx_id);
-			rc = -DER_INVAL;
-			goto crt_destroy;
-		}
 	} else if (dx->dx_comm) {
 		/* create private transport context */
 		rc = crt_context_create(&dmi->dmi_ctx);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -265,14 +265,22 @@ obj_bulk_args_init(struct obj_bulk_args *args)
 static void *
 rpc2orig_ctx(crt_rpc_t *rpc, bool *is_primary)
 {
+	int	rc;
+
 	/*
 	 * TODO:
-	 * - Use new Cart API to query the original provider is primary or secondary
-	 *   through RPC;
-	 * - Use new Cart API to query if remote bulk is originally from secondary or
-	 *   primary (for forwarded bulk transfer);
+	 * For forwarded RPC (server always uses primary context to create forward RPC),
+	 * we need some new cart API to query if the RPC is originated from a secondary
+	 * client, considering multiple secondary contexts need be supported, the new
+	 * API may need to return context ID as well. Then IO engine will be able to get
+	 * the proper secondary context by 'is_primary' and 'context id'.
 	 */
-	*is_primary = true;
+	rc = crt_req_src_provider_is_primary(rpc, is_primary);
+	if (rc) {
+		D_ERROR("Failed to query provider info. "DF_RC"\n", DP_RC(rc));
+		*is_primary = true;
+	}
+
 	return rpc->cr_ctx;
 }
 


### PR DESCRIPTION
Incorporate the new Cart API crt_req_src_provider_is_primary(), so
that secondary bulk transfer could be supported now. Forwarded
secondary RPC is still not supported yet, it requires additional
new Cart API.

Removed improper assumption on the context ID for secondary context,
since engine may have multiple secondary contexts.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>