### PR TITLE
CART-89 multiprovider: Fix issues, add new api

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -223,9 +223,9 @@ crt_context_provider_create(crt_context_t *crt_ctx, crt_provider_t provider, boo
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	sep_mode = crt_provider_is_sep(provider);
-	cur_ctx_num = crt_provider_get_cur_ctx_num(provider);
-	max_ctx_num = crt_provider_get_max_ctx_num(provider);
+	sep_mode = crt_provider_is_sep(primary, provider);
+	cur_ctx_num = crt_provider_get_cur_ctx_num(primary, provider);
+	max_ctx_num = crt_provider_get_max_ctx_num(primary, provider);
 
 	if (sep_mode &&
 	    cur_ctx_num >= max_ctx_num) {
@@ -248,7 +248,7 @@ crt_context_provider_create(crt_context_t *crt_ctx, crt_provider_t provider, boo
 	ctx->cc_primary = primary;
 	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
 
-	rc = crt_hg_ctx_init(&ctx->cc_hg_ctx, provider, cur_ctx_num);
+	rc = crt_hg_ctx_init(&ctx->cc_hg_ctx, provider, cur_ctx_num, primary);
 
 	if (rc != 0) {
 		D_ERROR("crt_hg_ctx_init() failed, " DF_RC "\n", DP_RC(rc));
@@ -268,10 +268,10 @@ crt_context_provider_create(crt_context_t *crt_ctx, crt_provider_t provider, boo
 
 	ctx->cc_idx = cur_ctx_num;
 
-	ctx_list = crt_provider_get_ctx_list(provider);
+	ctx_list = crt_provider_get_ctx_list(primary, provider);
 
 	d_list_add_tail(&ctx->cc_link, ctx_list);
-	crt_provider_inc_cur_ctx_num(provider);
+	crt_provider_inc_cur_ctx_num(primary, provider);
 
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 
@@ -654,7 +654,7 @@ crt_context_destroy(crt_context_t crt_ctx, int force)
 	}
 
 	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
-	crt_provider_dec_cur_ctx_num(provider);
+	crt_provider_dec_cur_ctx_num(ctx->cc_primary, provider);
 	d_list_del(&ctx->cc_link);
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 
@@ -714,7 +714,7 @@ crt_rank_abort(d_rank_t rank)
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
 
 	/* TODO: Do we need to handle secondary providers? */
-	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_primary_prov);
+	ctx_list = crt_provider_get_ctx_list(true, crt_gdata.cg_primary_prov);
 	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		rc = 0;
 		D_MUTEX_LOCK(&ctx->cc_mutex);
@@ -1257,28 +1257,38 @@ crt_context_lookup_locked(int ctx_idx)
 {
 	struct crt_context	*ctx;
 	d_list_t		*ctx_list;
+	int			i;
 
-	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_primary_prov);
+	ctx_list = crt_provider_get_ctx_list(true, crt_gdata.cg_primary_prov);
 
 	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		if (ctx->cc_idx == ctx_idx)
 			return ctx;
 	}
 
+	for (i = 0; i < crt_gdata.cg_num_secondary_provs; i++) {
+		ctx_list = crt_provider_get_ctx_list(false, crt_gdata.cg_secondary_provs[i]);
+
+		d_list_for_each_entry(ctx, ctx_list, cc_link) {
+			if (ctx->cc_idx == ctx_idx) {
+				return ctx;
+			}
+		}
+	}
 	return NULL;
 }
 
-/* TODO: Need per-provider call */
 crt_context_t
 crt_context_lookup(int ctx_idx)
 {
 	struct crt_context	*ctx;
 	bool			found = false;
+	int			i;
 	d_list_t		*ctx_list;
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
 
-	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_primary_prov);
+	ctx_list = crt_provider_get_ctx_list(true, crt_gdata.cg_primary_prov);
 
 	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		if (ctx->cc_idx == ctx_idx) {
@@ -1286,7 +1296,22 @@ crt_context_lookup(int ctx_idx)
 			break;
 		}
 	}
+
+	if (!found) {
+		for (i = 0; i < crt_gdata.cg_num_secondary_provs; i++) {
+			ctx_list = crt_provider_get_ctx_list(false, crt_gdata.cg_secondary_provs[i]);
+
+			d_list_for_each_entry(ctx, ctx_list, cc_link) {
+				if (ctx->cc_idx == ctx_idx) {
+					found = true;
+					break;
+				}
+			}
+		}
+	}
+
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
+
 
 	return (found == true) ? ctx : NULL;
 }
@@ -1308,6 +1333,26 @@ crt_context_idx(crt_context_t crt_ctx, int *ctx_idx)
 
 out:
 	return rc;
+}
+
+int
+crt_self_uri_get_secondary(int secondary_idx, char **uri)
+{
+	char *addr;
+
+	if (secondary_idx != 0) {
+		D_ERROR("Only index=0 supported for now\n");
+		return -DER_NONEXIST;
+	}
+
+	addr = crt_gdata.cg_prov_gdata_secondary[secondary_idx].cpg_addr;
+
+	D_STRNDUP(*uri, addr, CRT_ADDR_STR_MAX_LEN - 1);
+
+	if (!*uri)
+		return -DER_NOMEM;
+
+	return DER_SUCCESS;
 }
 
 int
@@ -1344,7 +1389,7 @@ crt_context_num(int *ctx_num)
 		return -DER_INVAL;
 	}
 
-	*ctx_num = crt_gdata.cg_prov_gdata[crt_gdata.cg_primary_prov].cpg_ctx_num;
+	*ctx_num = crt_gdata.cg_prov_gdata_primary.cpg_ctx_num;
 	return 0;
 }
 
@@ -1356,7 +1401,7 @@ crt_context_empty(int provider, int locked)
 	if (locked == 0)
 		D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
 
-	rc = d_list_empty(&crt_gdata.cg_prov_gdata[provider].cpg_ctx_list);
+	rc = d_list_empty(&crt_gdata.cg_prov_gdata_primary.cpg_ctx_list);
 
 	if (locked == 0)
 		D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -1293,23 +1293,22 @@ crt_context_lookup(int ctx_idx)
 	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		if (ctx->cc_idx == ctx_idx) {
 			found = true;
-			break;
+			D_GOTO(unlock, 0);
 		}
 	}
 
-	if (!found) {
-		for (i = 0; i < crt_gdata.cg_num_secondary_provs; i++) {
-			ctx_list = crt_provider_get_ctx_list(false, crt_gdata.cg_secondary_provs[i]);
+	for (i = 0; i < crt_gdata.cg_num_secondary_provs; i++) {
+		ctx_list = crt_provider_get_ctx_list(false, crt_gdata.cg_secondary_provs[i]);
 
-			d_list_for_each_entry(ctx, ctx_list, cc_link) {
-				if (ctx->cc_idx == ctx_idx) {
-					found = true;
-					break;
-				}
+		d_list_for_each_entry(ctx, ctx_list, cc_link) {
+			if (ctx->cc_idx == ctx_idx) {
+				found = true;
+				break;
 			}
 		}
 	}
 
+unlock:
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 
 

--- a/src/cart/crt_ctl.c
+++ b/src/cart/crt_ctl.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -204,9 +204,9 @@ crt_hdlr_ctl_ls(crt_rpc_t *rpc_req)
 	/* TODO: Need to derive provider from rpc struct */
 	provider = crt_gdata.cg_primary_prov;
 
-	ctx_list = crt_provider_get_ctx_list(provider);
+	ctx_list = crt_provider_get_ctx_list(true, provider);
 
-	out_args->cel_ctx_num = crt_provider_get_cur_ctx_num(provider);
+	out_args->cel_ctx_num = crt_provider_get_cur_ctx_num(true, provider);
 
 	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		str_size = CRT_ADDR_STR_MAX_LEN;

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -865,7 +865,7 @@ crt_grp_lc_addr_insert(struct crt_grp_priv *passed_grp_priv,
 
 	D_ASSERT(crt_ctx != NULL);
 
-	if (crt_provider_is_sep(crt_ctx->cc_hg_ctx.chc_provider))
+	if (crt_provider_is_sep(true, crt_ctx->cc_hg_ctx.chc_provider))
 		tag = 0;
 
 	grp_priv = passed_grp_priv;
@@ -937,7 +937,7 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx,
 	provider = crt_gdata.cg_primary_prov;
 
 	/* TODO: Derive from context */
-	if (crt_provider_is_sep(provider))
+	if (crt_provider_is_sep(true, provider))
 		tag = 0;
 
 	default_grp_priv = grp_priv;
@@ -1904,8 +1904,7 @@ crt_group_config_save(crt_group_t *grp, bool forall)
 
 	rank = grp_priv->gp_self;
 
-	/* TODO: Per provider address needs to be stored in future */
-	addr = crt_gdata.cg_prov_gdata[crt_gdata.cg_primary_prov].cpg_addr;
+	addr = crt_gdata.cg_prov_gdata_primary.cpg_addr;
 
 	grpid = grp_priv->gp_pub.cg_grpid;
 	filename = crt_grp_attach_info_filename(grp_priv);
@@ -2531,7 +2530,7 @@ crt_rank_self_set(d_rank_t rank)
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
 
-	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_primary_prov);
+	ctx_list = crt_provider_get_ctx_list(true, crt_gdata.cg_primary_prov);
 
 	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		hg_class =  ctx->cc_hg_ctx.chc_hgcla;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -745,7 +745,7 @@ crt_hg_class_init(int provider, int idx, bool primary, hg_class_t **ret_hg_class
 	D_DEBUG(DB_NET, "New context(idx:%d), listen address: %s.\n",
 		idx, addr_str);
 
-	/* If address for this provider isnt filled yet*/
+	/* If address for this provider isn't filled yet*/
 	if (prov_data->cpg_addr[0] == '\0')
 		strncpy(prov_data->cpg_addr, addr_str, str_size);
 

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -100,7 +100,7 @@ struct crt_hg_context {
 /* crt_hg.c */
 int crt_hg_init(void);
 int crt_hg_fini(void);
-int crt_hg_ctx_init(struct crt_hg_context *hg_ctx, int provider, int idx);
+int crt_hg_ctx_init(struct crt_hg_context *hg_ctx, int provider, int idx, bool primary);
 int crt_hg_ctx_fini(struct crt_hg_context *hg_ctx);
 int crt_hg_req_create(struct crt_hg_context *hg_ctx,
 		      struct crt_rpc_priv *rpc_priv);
@@ -126,15 +126,16 @@ int crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data);
 
 bool crt_provider_is_contig_ep(int provider);
 bool crt_provider_is_port_based(int provider);
-bool crt_provider_is_sep(int provider);
-void crt_provider_set_sep(int provider, bool enable);
-int crt_provider_get_cur_ctx_num(int provider);
-void crt_provider_inc_cur_ctx_num(int provider);
-void crt_provider_dec_cur_ctx_num(int provider);
 char *crt_provider_name_get(int provider);
-
-int crt_provider_get_max_ctx_num(int provider);
-d_list_t *crt_provider_get_ctx_list(int provider);
+bool crt_provider_is_sep(bool primary, int provider);
+void crt_provider_set_sep(bool primary, int provider, bool enable);
+int crt_provider_get_cur_ctx_num(bool primary, int provider);
+void crt_provider_inc_cur_ctx_num(bool primary, int provider);
+void crt_provider_dec_cur_ctx_num(bool primary, int provider);
+int crt_provider_get_max_ctx_num(bool primary, int provider);
+d_list_t *crt_provider_get_ctx_list(bool primary, int provider);
+struct crt_na_config*
+crt_provider_get_na_config(bool primary, int provider);
 
 static inline int
 crt_hgret_2_der(int hg_ret)

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -53,7 +53,8 @@ dump_opt(crt_init_options_t *opt)
 }
 
 static int
-crt_na_config_init(bool primary, crt_provider_t provider, char *interface, char *domain, char *port);
+crt_na_config_init(bool primary, crt_provider_t provider,
+		   char *interface, char *domain, char *port);
 
 /* Workaround for CART-890 */
 static void
@@ -1008,7 +1009,8 @@ out:
 }
 
 static int
-crt_na_config_init(bool primary, crt_provider_t provider, char *interface, char *domain, char *port_str)
+crt_na_config_init(bool primary, crt_provider_t provider,
+		   char *interface, char *domain, char *port_str)
 {
 	struct crt_na_config		*na_cfg;
 	int				rc = 0;

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -60,6 +60,7 @@ struct crt_prov_gdata {
 				cpg_inited		: 1;
 };
 
+#define MAX_NUM_SECONDARY_PROVS 2
 
 /* CaRT global data */
 struct crt_gdata {
@@ -69,7 +70,10 @@ struct crt_gdata {
 	int			*cg_secondary_provs;
 
 	/** Provider specific data */
-	struct crt_prov_gdata	cg_prov_gdata[CRT_PROV_COUNT];
+	struct crt_prov_gdata	cg_prov_gdata_primary;
+
+	/** */
+	struct crt_prov_gdata	*cg_prov_gdata_secondary;
 
 	/** global timeout value (second) for all RPCs */
 	uint32_t		cg_timeout;
@@ -289,6 +293,6 @@ struct crt_opc_map {
 };
 
 
-void crt_na_config_fini(int provider);
+void crt_na_config_fini(bool primary, int provider);
 
 #endif /* __CRT_INTERNAL_TYPES_H__ */

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -742,7 +742,7 @@ static void crt_swim_update_last_unpack_hlc(struct crt_swim_membs *csm)
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
 
-	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_primary_prov);
+	ctx_list = crt_provider_get_ctx_list(true, crt_gdata.cg_primary_prov);
 	d_list_for_each_entry(ctx, ctx_list, cc_link) {
 		uint64_t hlc = ctx->cc_last_unpack_hlc;
 

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -2080,6 +2080,22 @@ crt_group_rank_remove(crt_group_t *group, d_rank_t rank);
  */
 int crt_self_uri_get(int tag, char **uri);
 
+
+/**
+ * Retrieve a secondary uri of self for the specified tag.
+ * The uri must be freed by the user using D_FREE().
+ *
+ * \param[in] idx               Secondary provider index
+ * \param[out] uri              Returned uri string This is a NULL terminated
+ *                              string of size up to CRT_ADDR_STR_MAX_LEN
+ *                              (including the trailing NULL). Must be freed by
+ *                              the user.
+ *
+ * \return                      DER_SUCCESS on success, negative value
+ *                              on failure.
+ */
+int crt_self_uri_get_secondary(int idx, char **uri);
+
 /**
  * Retrieve incarnation of self.
  *

--- a/src/tests/ftest/cart/dual_provider_server.c
+++ b/src/tests/ftest/cart/dual_provider_server.c
@@ -263,7 +263,9 @@ int main(int argc, char **argv)
 			D_ERROR("crt_context_uri_get(%d) failed; rc=%d\n", i, rc);
 			error_exit();
 		}
+
 		printf("Secondary context[%d] uri=%s\n", i, uri);
+		D_FREE(uri);
 
 		rc = pthread_create(&secondary_progress_thread[i], 0,
 				    progress_fn, &secondary_ctx[i]);
@@ -278,6 +280,7 @@ int main(int argc, char **argv)
 
 	printf("Secondary uri for context0 = %s\n", uri);
 
+	D_FREE(uri);
 
 	rc = crt_proto_register(&my_proto_fmt);
 	if (rc != 0) {

--- a/src/tests/ftest/cart/dual_provider_server.c
+++ b/src/tests/ftest/cart/dual_provider_server.c
@@ -272,6 +272,13 @@ int main(int argc, char **argv)
 		}
 	}
 
+	rc = crt_self_uri_get_secondary(0, &uri);
+	if (rc != 0)
+		error_exit();
+
+	printf("Secondary uri for context0 = %s\n", uri);
+
+
 	rc = crt_proto_register(&my_proto_fmt);
 	if (rc != 0) {
 		D_ERROR("crt_proto_register() failed; rc=%d\n", rc);


### PR DESCRIPTION
- New API added to query secondary provider uri:
	crt_self_uri_get_secondary()

- Fixed internal bug where provider info was stored per provider type
rather than per provider instance. This would prevent/clash in situations
when the same provider is used as a primary and a secondary

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>