### PR TITLE
DAOS-10899 test: use expected variable to do assert checking (#10899)

### DIFF
--- a/src/tests/suite/daos_epoch.c
+++ b/src/tests/suite/daos_epoch.c
@@ -222,7 +222,7 @@ test_snapshots(void **argp)
 	uuid_unparse(co_uuid, uuid_str);
 	MUST(cont_open(arg, uuid_str, DAOS_COO_RW | DAOS_COO_NOSLIP, &coh));
 	assert_int_equal(arg->co_info.ci_nsnapshots, 0);
-	assert_int_equal(cinfo.ci_lsnapshot, 0);
+	assert_int_equal(arg->co_info.ci_lsnapshot, 0);
 
 	oid = daos_test_oid_gen(arg->coh, OC_RP_XSF, 0, 0, arg->myrank);
 	print_message("OID: "DF_OID"\n", DP_OID(oid));
@@ -353,7 +353,7 @@ test_snapshots(void **argp)
 		      snaps[snap_count-1]);
 	MUST(cont_open(arg, uuid_str, DAOS_COO_RW | DAOS_COO_NOSLIP, &coh));
 	assert_int_equal(arg->co_info.ci_nsnapshots, (snap_count-1));
-	assert_int_equal(cinfo.ci_lsnapshot, snaps[snap_count-1]);
+	assert_int_equal(arg->co_info.ci_lsnapshot, snaps[snap_count-1]);
 	MUST(cont_close(arg, coh));
 
 	MUST(cont_destroy(arg, uuid_str));


### PR DESCRIPTION
The test case expecte to check with arg->co_info.ci_lsnapshot.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>