### PR TITLE
DAOS-10870 dtx: handle active DTX entry update properly

### DIFF
--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -277,7 +277,10 @@ extern "C" {
 	       One or more control plane components are incompatible)	\
 	/** No service available */					\
 	ACTION(DER_NO_SERVICE,		(DER_ERR_DAOS_BASE + 39),	\
-	       No service available)
+	       No service available)					\
+	/** The TX ID may be reused. */				\
+	ACTION(DER_TX_ID_REUSED,	(DER_ERR_DAOS_BASE + 40),	\
+	       TX ID may be reused)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -386,7 +386,7 @@ struct obj_auxi_args {
 	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 flags;
 	uint32_t			 specified_shard;
-	/* 64-bits alignment, bitmap for retry next replicas. */
+	uint32_t			 retry_cnt;
 	struct obj_req_tgts		 req_tgts;
 	d_sg_list_t			*sgls_dup;
 	crt_bulk_t			*bulks;

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -320,11 +320,20 @@ dtx_act_ent_update(struct btr_instance *tins, struct btr_record *rec,
 	dae_old = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 
 	D_ASSERT(dae_old != dae_new);
-	D_ASSERTF(dae_old->dae_aborted,
-		  "NOT allow to update act DTX entry for "DF_DTI
-		  " from epoch "DF_X64" to "DF_X64"\n",
-		  DP_DTI(&DAE_XID(dae_old)),
-		  DAE_EPOCH(dae_old), DAE_EPOCH(dae_new));
+
+	if (unlikely(!dae_old->dae_aborted)) {
+		/*
+		 * XXX: There are two possible reasons for that:
+		 *
+		 *	1. Client resent the RPC but without set 'RESEND' flag.
+		 *	2. Client reused the DTX ID for different modifications.
+		 *
+		 *	Currently, the 1st case is more suspected.
+		 */
+		D_ERROR("The TX ID "DF_DTI" may be reused for epoch "DF_X64" vs "DF_X64"\n",
+			DP_DTI(&DAE_XID(dae_old)), DAE_EPOCH(dae_old), DAE_EPOCH(dae_new));
+		return -DER_TX_ID_REUSED;
+	}
 
 	rec->rec_off = umem_ptr2off(&tins->ti_umm, dae_new);
 	dtx_evict_lid(cont, dae_old);


### PR DESCRIPTION
For any transaction, the DTX entry in the active DTX table is unique.
So when we allocate new DTX entry in the active DTX table, we should
not hit the entry with the same DTX ID. If that happened, then there
may be two possible cases:

1. Client resent the RPC but without set 'RESEND' flag.
2. Client reused the DTX ID for different modifications.

Currently, the 1st case is more suspected which is DAOS client logic
bug, need to be fixed correspondingly. If it is the 2nd case, we can
re-generate new TX ID.

Signed-off-by: Fan Yong <fan.yong@intel.com>