### PR TITLE
DAOS-10354 dfuse: Check thread id in interception library destructor. (#9103)

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -12,6 +12,8 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -41,6 +43,7 @@ struct ioil_pool {
 struct ioil_global {
 	pthread_mutex_t	iog_lock;
 	d_list_t	iog_pools_head;
+	pid_t           iog_init_tid;
 	bool		iog_initialized;
 	bool		iog_no_daos;
 	bool		iog_daos_init;
@@ -300,6 +303,8 @@ ioil_init(void)
 
 	DFUSE_TRA_ROOT(&ioil_iog, "il");
 
+	ioil_iog.iog_init_tid = syscall(SYS_gettid);
+
 	/* Get maximum number of file descriptors */
 	rc = getrlimit(RLIMIT_NOFILE, &rlimit);
 	if (rc != 0) {
@@ -351,7 +356,13 @@ ioil_fini(void)
 {
 	struct ioil_pool *pool, *pnext;
 	struct ioil_cont *cont, *cnext;
-	int rc;
+	int               rc;
+	pid_t             tid = syscall(SYS_gettid);
+
+	if (tid != ioil_iog.iog_init_tid) {
+		DFUSE_TRA_INFO(&ioil_iog, "Ignoring destructor from alternate thread");
+		return;
+	}
 
 	ioil_iog.iog_initialized = false;
 


### PR DESCRIPTION
Only run the destructor if run in the same thread id as the constructor.
some programs, at least sh, run lightweight threads so can end up
calling the destructor more times than the constructor, so to avoid
deadlocks save the tid in the constructor and only run the destructor
if it matches.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>