### PR TITLE
DAOS-10473 control: Do not require IOMMU for emulated NVMe (#9272)

### DIFF
--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -747,7 +747,7 @@ physical NVMe devices only.
 !!! warning
     If upgrading from DAOS 2.0 to a greater version, the old 'enable_vmd' server config file
     parameter is no longer honoured and instead should be removed (or replaced by
-    `disable_vmd: true` if VMD is to be explicitly disabled.
+    `disable_vmd: true` if VMD is to be explicitly disabled).
 
     Otherwise 'daos_server' may fail config validation and not start after an update from 2.0 to a
     greater version.

--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -108,8 +108,9 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 		case cmd.DisableVFIO:
 			cmd.log.Info("VMD not enabled because VFIO disabled in command options")
 		case !iommuEnabled:
-			cmd.log.Info("VMD not enabled because IOMMU disabled on system")
+			cmd.log.Info("VMD not enabled because IOMMU disabled on platform")
 		default:
+			// If none of the cases above match, set enable VMD flag in request.
 			req.EnableVMD = true
 		}
 

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -85,6 +85,7 @@ const (
 	BdevNotFound
 	BdevDuplicatesInDeviceList
 	BdevNoDevicesMatchFilter
+	BdevConfigTypeMismatch
 )
 
 // DAOS system fault codes

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -517,7 +517,7 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 			ec.LegacyStorage = engine.LegacyStorage{}
 		}
 
-		if ec.Storage.Tiers.CfgHasBdevs() {
+		if ec.Storage.Tiers.HaveBdevs() {
 			cfgHasBdevs = true
 			if ec.TargetCount == 0 {
 				return errors.Errorf("engine %d: Target count cannot be zero if "+

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -466,6 +466,19 @@ func TestConfig_BdevValidation(t *testing.T) {
 				),
 			expCls: storage.ClassFile,
 		},
+		"mix of emulated and non-emulated device classes": {
+			cfg: baseValidConfig().
+				WithStorage(
+					storage.NewTierConfig().
+						WithStorageClass("nvme").
+						WithBdevDeviceList(test.MockPCIAddr(1)),
+					storage.NewTierConfig().
+						WithStorageClass("file").
+						WithBdevFileSize(10).
+						WithBdevDeviceList("bdev1", "bdev2"),
+				),
+			expErr: errors.New("mix of emulated and non-emulated NVMe"),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			test.CmpErr(t, tc.expErr, tc.cfg.Validate())

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -40,26 +40,22 @@ type resolveTCPFn func(string, string) (*net.TCPAddr, error)
 
 const scanMinHugePageCount = 128
 
-func engineCfgGetBdevs(engineCfg *engine.Config) *storage.BdevDeviceList {
+func getBdevDevicesFromCfgs(bdevCfgs storage.TierConfigs) *storage.BdevDeviceList {
 	bdevs := []string{}
-	for _, bc := range engineCfg.Storage.Tiers.BdevConfigs() {
+	for _, bc := range bdevCfgs {
 		bdevs = append(bdevs, bc.Bdev.DeviceList.Devices()...)
 	}
 
 	return storage.MustNewBdevDeviceList(bdevs...)
 }
 
-func cfgGetBdevs(cfg *config.Server) *storage.BdevDeviceList {
-	bdevs := []string{}
+func getBdevCfgsFromSrvCfg(cfg *config.Server) storage.TierConfigs {
+	bdevCfgs := []*storage.TierConfig{}
 	for _, engineCfg := range cfg.Engines {
-		bdevs = append(bdevs, engineCfgGetBdevs(engineCfg).Devices()...)
+		bdevCfgs = append(bdevCfgs, engineCfg.Storage.Tiers.BdevConfigs()...)
 	}
 
-	return storage.MustNewBdevDeviceList(bdevs...)
-}
-
-func cfgHasBdevs(cfg *config.Server) bool {
-	return cfgGetBdevs(cfg).Len() != 0
+	return bdevCfgs
 }
 
 func cfgGetReplicas(cfg *config.Server, resolver resolveTCPFn) ([]*net.TCPAddr, error) {
@@ -198,26 +194,27 @@ func getEngineNUMANodes(log logging.Logger, engineCfgs []*engine.Config) []strin
 	return nodes
 }
 
+// Prepare bdev storage. Assumes validation has already been performed on server config. Hugepages
+// are required for both emulated (AIO devices) and real NVMe bdevs. VFIO and IOMMU are not
+// required for emulated NVMe.
 func prepBdevStorage(srv *server, iommuEnabled bool) error {
 	defer srv.logDuration(track("time to prepare bdev storage"))
 
-	hasBdevs := cfgHasBdevs(srv.cfg)
-
-	if hasBdevs {
-		// Perform these checks to avoid even trying a prepare if the system isn't
-		// configured properly.
-		if srv.runningUser.Username != "root" {
-			if srv.cfg.DisableVFIO {
-				return FaultVfioDisabled
-			}
-
-			if !iommuEnabled {
-				return FaultIommuDisabled
-			}
-		}
-	} else if srv.cfg.DisableHugepages {
-		srv.log.Debugf("skip nvme prepare as no bdevs in cfg and disable_hugepages: true in config")
+	if srv.cfg.DisableHugepages {
+		srv.log.Debugf("skip nvme prepare as disable_hugepages: true in config")
 		return nil
+	}
+
+	bdevCfgs := getBdevCfgsFromSrvCfg(srv.cfg)
+
+	// Perform these checks only if non-emulated NVMe is used and user is unprivileged.
+	if bdevCfgs.HaveRealNVMe() && srv.runningUser.Username != "root" {
+		if srv.cfg.DisableVFIO {
+			return FaultVfioDisabled
+		}
+		if !iommuEnabled {
+			return FaultIommuDisabled
+		}
 	}
 
 	prepReq := storage.BdevPrepareRequest{
@@ -231,12 +228,15 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 	case !srv.cfg.DisableVMD && srv.cfg.DisableVFIO:
 		srv.log.Info("VMD not enabled because VFIO disabled in config")
 	case !srv.cfg.DisableVMD && !iommuEnabled:
-		srv.log.Info("VMD not enabled because IOMMU disabled on system")
+		srv.log.Info("VMD not enabled because IOMMU disabled on platform")
+	case !srv.cfg.DisableVMD && bdevCfgs.HaveEmulatedNVMe():
+		srv.log.Info("VMD not enabled because emulated NVMe devices found in config")
 	default:
+		// If no case above matches, set enable VMD flag in request otherwise leave false.
 		prepReq.EnableVMD = !srv.cfg.DisableVMD
 	}
 
-	if hasBdevs {
+	if bdevCfgs.HaveBdevs() {
 		// The NrHugepages config value is a total for all engines. Distribute allocation
 		// of hugepages equally across each engine's numa node (as validation ensures that
 		// TargetsCount is equal for each engine).
@@ -290,7 +290,7 @@ func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
 	}
 
 	nvmeScanResp, err := srv.ctlSvc.NvmeScan(storage.BdevScanRequest{
-		DeviceList:  cfgGetBdevs(srv.cfg),
+		DeviceList:  getBdevDevicesFromCfgs(getBdevCfgsFromSrvCfg(srv.cfg)),
 		BypassCache: true, // init cache on first scan
 	})
 	if err != nil {
@@ -309,7 +309,7 @@ func updateMemValues(srv *server, ei *EngineInstance, getHugePageInfo common.Get
 	ei.RLock()
 	engineCfg := ei.runner.GetConfig()
 	engineIdx := engineCfg.Index
-	if engineCfgGetBdevs(engineCfg).Len() == 0 {
+	if getBdevDevicesFromCfgs(engineCfg.Storage.Tiers.BdevConfigs()).Len() == 0 {
 		srv.log.Debugf("skipping mem check on engine %d, no bdevs", engineIdx)
 		ei.RUnlock()
 		return nil

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -241,11 +241,18 @@ func TestServer_prepBdevStorage(t *testing.T) {
 		return storage.NewTierConfig().WithStorageClass(storage.ClassNvme.String()).
 			WithBdevDeviceList(test.MockPCIAddr(int32(i)))
 	}
+	nonNvmeTier := func() *storage.TierConfig {
+		return storage.NewTierConfig().WithStorageClass(storage.ClassFile.String()).
+			WithBdevFileSize(10).WithBdevDeviceList("bdev1", "bdev2")
+	}
 	scmEngine := func(i int) *engine.Config {
 		return basicEngineCfg(i).WithStorage(scmTier(i)).WithTargetCount(8)
 	}
 	nvmeEngine := func(i int) *engine.Config {
 		return basicEngineCfg(i).WithStorage(scmTier(i), nvmeTier(i)).WithTargetCount(16)
+	}
+	nonNvmeEngine := func(i int) *engine.Config {
+		return basicEngineCfg(i).WithStorage(scmTier(i), nonNvmeTier()).WithTargetCount(16)
 	}
 
 	for name, tc := range map[string]struct {
@@ -284,6 +291,21 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expMemSize:      16384,
 			expHugePageSize: 2,
 		},
+		"non-nvme bdevs; vfio disabled": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithDisableVFIO(true).
+					WithEngines(nonNvmeEngine(0))
+			},
+			hugePagesFree: 8192,
+			expPrepCall: &storage.BdevPrepareRequest{
+				HugePageCount: 8194,
+				HugeNodes:     "0",
+				TargetUser:    username,
+				DisableVFIO:   true,
+			},
+			expMemSize:      16384,
+			expHugePageSize: 2,
+		},
 		"iommu disabled": {
 			iommuDisabled: true,
 			srvCfgExtra: func(sc *config.Server) *config.Server {
@@ -302,6 +324,20 @@ func TestServer_prepBdevStorage(t *testing.T) {
 				HugePageCount: 8194,
 				HugeNodes:     "0",
 				TargetUser:    "root",
+			},
+			expMemSize:      16384,
+			expHugePageSize: 2,
+		},
+		"non-nvme bdevs; iommu disabled": {
+			iommuDisabled: true,
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithEngines(nonNvmeEngine(0))
+			},
+			hugePagesFree: 8192,
+			expPrepCall: &storage.BdevPrepareRequest{
+				HugePageCount: 8194,
+				HugeNodes:     "0",
+				TargetUser:    username,
 			},
 			expMemSize:      16384,
 			expHugePageSize: 2,
@@ -455,7 +491,7 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expMemChkErr: errors.New("could not find hugepage info"),
 		},
 		// prepare will continue even if reset fails
-		"reset fails; 2 engines": {
+		"reset fails": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
 				return sc.WithNrHugePages(16384).
 					WithEngines(nvmeEngine(0), nvmeEngine(1)).
@@ -478,7 +514,8 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expMemSize:      16384,
 			expHugePageSize: 2,
 		},
-		"2 engines; vmd disabled": {
+		// VMD not enabled in prepare request.
+		"vmd disabled": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
 				return sc.WithNrHugePages(16384).
 					WithEngines(nvmeEngine(0), nvmeEngine(1)).
@@ -488,6 +525,21 @@ func TestServer_prepBdevStorage(t *testing.T) {
 			expPrepCall: &storage.BdevPrepareRequest{
 				HugePageCount: 8194,
 				HugeNodes:     "0,1",
+				TargetUser:    username,
+			},
+			expMemSize:      16384,
+			expHugePageSize: 2,
+		},
+		// VMD not enabled in prepare request.
+		"non-nvme bdevs; vmd enabled": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithNrHugePages(8192).
+					WithEngines(nonNvmeEngine(0))
+			},
+			hugePagesFree: 8194,
+			expPrepCall: &storage.BdevPrepareRequest{
+				HugePageCount: 8194,
+				HugeNodes:     "0",
 				TargetUser:    username,
 			},
 			expMemSize:      16384,
@@ -583,9 +635,8 @@ func TestServer_prepBdevStorage(t *testing.T) {
 	}
 }
 
-// TestServer_scanBdevStorage validates that an error it returned in the case that a SSD is not
-// found and doesn't return an error if SPDK fails to init. Emulated NVMe (SPDK AIO mode) should
-// also be covered.
+// TestServer_scanBdevStorage validates that an error is returned in the case that a SSD is not
+// found and doesn't return an error if SPDK fails to init.
 func TestServer_scanBdevStorage(t *testing.T) {
 	for name, tc := range map[string]struct {
 		disableHugepages bool

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -14,6 +14,12 @@ import (
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
 
+// FaultBdevConfigTypeMismatch represents an error where an incompatible mix of emulated and
+// non-emulated NVMe devices are present in the storage config.
+var FaultBdevConfigTypeMismatch = storageFault(code.BdevConfigTypeMismatch,
+	"A mix of emulated and non-emulated NVMe devices are specified in config",
+	"Change config tiers to specify either emulated or non-emulated NVMe devices, but not a mix of both")
+
 // FaultBdevNotFound creates a Fault for the case where no NVMe storage devices
 // match expected PCI addresses.
 func FaultBdevNotFound(bdevs ...string) *fault.Fault {


### PR DESCRIPTION
Apply the following NVMe emulation related changes:
- If AIO is being used for NVMe emulation, don't require IOMMU and/or
  VFIO to be enabled.
- Disallow the use of emulated and non-emulated NVMe in the same engine
  config.
- Disable VMD if NVMe emulation is being used.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>