### PR TITLE
DAOS-10525 object: use max epoch for parity rebuild

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -922,7 +922,7 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 
 			if (offset + size == recx->rx_idx) {
 				size += recx->rx_nr;
-				parity_eph = iod_ephs[j];
+				parity_eph = max(parity_eph, iod_ephs[j]);
 				continue;
 			}
 


### PR DESCRIPTION
Use max epoch from all data shards for parity rebuild.

Signed-off-by: Di Wang <di.wang@intel.com>