### PR TITLE
CART-89 multi_prov: new api, fixes

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -1335,12 +1335,23 @@ out:
 }
 
 int
+crt_get_nr_secondary_providers(void)
+{
+	return crt_gdata.cg_num_secondary_provs;
+}
+
+int
 crt_self_uri_get_secondary(int secondary_idx, char **uri)
 {
 	char *addr;
 
 	if (secondary_idx != 0) {
 		D_ERROR("Only index=0 supported for now\n");
+		return -DER_NONEXIST;
+	}
+
+	if ((crt_gdata.cg_prov_gdata_secondary == NULL) ||
+	   (secondary_idx >= crt_gdata.cg_num_secondary_provs)) {
 		return -DER_NONEXIST;
 	}
 

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -1351,7 +1351,7 @@ crt_self_uri_get_secondary(int secondary_idx, char **uri)
 	}
 
 	if ((crt_gdata.cg_prov_gdata_secondary == NULL) ||
-	   (secondary_idx >= crt_gdata.cg_num_secondary_provs)) {
+	    (secondary_idx >= crt_gdata.cg_num_secondary_provs)) {
 		return -DER_NONEXIST;
 	}
 

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -2097,6 +2097,14 @@ int crt_self_uri_get(int tag, char **uri);
 int crt_self_uri_get_secondary(int idx, char **uri);
 
 /**
+ * Returns number of secondary providers initialized.
+ *
+ * \return                      Number of secondary providers.
+ */
+int
+crt_get_nr_secondary_providers(void);
+
+/**
  * Retrieve incarnation of self.
  *
  * \param[out] incarnation      Returned incarnation

--- a/src/tests/ftest/network/cart_self_test.py
+++ b/src/tests/ftest/network/cart_self_test.py
@@ -55,7 +55,8 @@ class CartSelfTest(TestWithServers):
     def setUp(self):
         """Set up each test case."""
         super().setUp()
-        share_addr = self.params.get("share_addr", "/run/test_params/*")
+        # Most providers (tcp, verbs) don't support SEP mode
+        share_addr = 0
 
         # Configure the daos server
         self.add_server_manager()

--- a/src/tests/ftest/network/cart_self_test.yaml
+++ b/src/tests/ftest/network/cart_self_test.yaml
@@ -25,9 +25,3 @@ self_test:
       message_sizes: "\"0 b1048576\""
     large_io_bulk_get:
       message_sizes: "\"b1048576 0\""
-test_params:
-  share_addr_mux: !mux
-    on:
-      share_addr: 1
-    off:
-      share_addr: 0


### PR DESCRIPTION
- New API crt_get_nr_secondary_providers() added.
Returns number of secondary providers initialized by CART.

- crt_self_uri_get_secondary() fixed to return -DER_NONEXIST
when no secondary providers are initialized

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>