### PR TITLE
DAOS-10592 test: rebuild_disabled: restart servers

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_disabled.py
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.py
@@ -1,11 +1,11 @@
-#!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import time
 from ec_utils import ErasureCodeIor, check_aggregation_status
+
 
 class EcodDisabledRebuild(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -24,9 +24,9 @@ class EcodDisabledRebuild(ErasureCodeIor):
                   kill single server, verify all IOR read data and verified.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_disabled_rebuild,rebuild
-        :avocado: tags=ec_disabled_rebuild_array
+        :avocado: tags=ec_disabled_rebuild_array,test_ec_degrade
 
         """
         # Disabled pool Rebuild
@@ -42,8 +42,7 @@ class EcodDisabledRebuild(ErasureCodeIor):
 
         # Kill the last server rank and wait for 20 seconds, Rebuild is disabled
         # so data should not be rebuild
-        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log,
-                                           force=True)
+        self.server_managers[0].stop_ranks([self.server_count - 1], self.d_log, force=True)
         time.sleep(20)
 
         # Read IOR data and verify for different EC object and different sizes
@@ -52,8 +51,7 @@ class EcodDisabledRebuild(ErasureCodeIor):
 
         # Kill the another server rank and wait for 20 seconds,Rebuild will
         # not happens because i's disabled.Read/verify data with Parity 2.
-        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
-                                           force=True)
+        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log, force=True)
         time.sleep(20)
 
         # Read IOR data and verify for different EC object and different sizes

--- a/src/tests/ftest/erasurecode/rebuild_disabled.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.yaml
@@ -7,6 +7,8 @@ hosts:
     10_server:
       test_servers: server-[1-5]
   test_clients: 3
+setup:
+  start_servers_once: False
 timeout: 3500
 server_config:
   engines_per_host: 2


### PR DESCRIPTION
Test-tag: test_ec_degrade
Test-repeat: 2
Skip-unit-tests: true
Skip-fault-injection-test: true

- Restart servers between runs since mux is used
- Misc cleanup

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>