### PR TITLE
CART-89 multiprov: Auto-tag replacement for secondary providers

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -251,7 +251,8 @@ crt_internal_rpc_register(bool server)
 		return rc;
 	}
 
-	/* TODO: The self-test protocols should not be registered on the client
+	/*
+	 * TODO: The self-test protocols should not be registered on the client
 	 * by default.
 	 */
 
@@ -480,8 +481,9 @@ crt_rpc_priv_set_ep(struct crt_rpc_priv *rpc_priv, crt_endpoint_t *tgt_ep)
 	} else {
 		rpc_priv->crp_pub.cr_ep.ep_grp = tgt_ep->ep_grp;
 	}
-	rpc_priv->crp_pub.cr_ep.ep_rank = tgt_ep->ep_rank;
+
 	rpc_priv->crp_pub.cr_ep.ep_tag = tgt_ep->ep_tag;
+	rpc_priv->crp_pub.cr_ep.ep_rank = tgt_ep->ep_rank;
 	rpc_priv->crp_have_ep = 1;
 }
 
@@ -524,6 +526,7 @@ crt_req_create_internal(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep,
 
 	if (tgt_ep != NULL) {
 		rc = check_ep(tgt_ep, &grp_priv);
+
 		if (rc != 0)
 			D_GOTO(out, rc);
 
@@ -1104,6 +1107,7 @@ crt_req_ep_lc_lookup(struct crt_rpc_priv *rpc_priv, bool *uri_exists)
 	crt_phy_addr_t		 uri = NULL;
 	int			 rc = 0;
 	crt_phy_addr_t		 base_addr = NULL;
+	int			 dst_tag;
 
 	req = &rpc_priv->crp_pub;
 	ctx = req->cr_ctx;
@@ -1112,22 +1116,32 @@ crt_req_ep_lc_lookup(struct crt_rpc_priv *rpc_priv, bool *uri_exists)
 	*uri_exists = false;
 	grp_priv = crt_grp_pub2priv(tgt_ep->ep_grp);
 
+	dst_tag = tgt_ep->ep_tag;
+
+	if (!crt_gdata.cg_provider_is_primary) {
+		/*
+		 * TODO: Add API to set number of destination tags
+ 		 * for the secondary provider
+ 		 */
+		dst_tag = 0;
+	}
+
 	crt_grp_lc_lookup(grp_priv, ctx->cc_idx,
-			  tgt_ep->ep_rank, tgt_ep->ep_tag, &base_addr,
+			  tgt_ep->ep_rank, dst_tag, &base_addr,
 			  &rpc_priv->crp_hg_addr);
 
 	if (base_addr == NULL && rpc_priv->crp_hg_addr == NULL) {
 		if (crt_req_is_self(rpc_priv)) {
-			rc = crt_self_uri_get(tgt_ep->ep_tag, &uri);
+			rc = crt_self_uri_get(dst_tag, &uri);
 			if (rc != DER_SUCCESS) {
 				D_ERROR("crt_self_uri_get(tag: %d) failed, "
-					"rc %d\n", tgt_ep->ep_tag, rc);
+					"rc %d\n", dst_tag, rc);
 				D_GOTO(out, rc);
 			}
 
 			rc = crt_grp_lc_uri_insert(grp_priv,
 						   tgt_ep->ep_rank,
-						   tgt_ep->ep_tag, base_addr);
+						   dst_tag, base_addr);
 			if (rc != 0)
 				D_GOTO(out, rc);
 
@@ -1155,7 +1169,7 @@ crt_req_ep_lc_lookup(struct crt_rpc_priv *rpc_priv, bool *uri_exists)
 	if (base_addr == NULL && !crt_is_service()) {
 		D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
 		if (tgt_ep->ep_rank == grp_priv->gp_psr_rank &&
-		    tgt_ep->ep_tag == 0) {
+		    dst_tag == 0) {
 			D_STRNDUP(uri, grp_priv->gp_psr_phy_addr,
 				  CRT_ADDR_STR_MAX_LEN);
 			D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
@@ -1701,6 +1715,10 @@ crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 		if (pri_root == self_rank)
 			skip_check = true;
 	}
+
+	/* Skip check for secondary provider clients */
+	if (!rpc_priv->crp_req_hdr.cch_src_is_primary)
+		skip_check = true;
 
 	if ((self_rank != rpc_priv->crp_req_hdr.cch_dst_rank) ||
 	    (crt_ctx->cc_idx != rpc_priv->crp_req_hdr.cch_dst_tag)) {

--- a/src/tests/ftest/cart/dual_provider_client.c
+++ b/src/tests/ftest/cart/dual_provider_client.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
 	int			num_remote_tags;
 	bool			use_primary = true;
 
-	while ((c = getopt(argc, argv, "i:p:d:s")) != -1) {
+	while ((c = getopt(argc, argv, "i:p:d:c:s")) != -1) {
 		switch (c) {
 		case 'i':
 			arg_interface = optarg;

--- a/src/tests/ftest/cart/dual_provider_common.h
+++ b/src/tests/ftest/cart/dual_provider_common.h
@@ -118,7 +118,8 @@ handler_ping(crt_rpc_t *rpc)
 	crt_context_t		*ctx;
 	int			rc = 0;
 	bool			primary_origin = false;
-
+	int			my_tag;
+	uint32_t		hdr_dst_tag;
 
 	input = crt_req_get(rpc);
 	output = crt_reply_get(rpc);
@@ -128,7 +129,6 @@ handler_ping(crt_rpc_t *rpc)
 
 	ctx = rpc->cr_ctx;
 
-
 	rc = crt_req_src_provider_is_primary(rpc, &primary_origin);
 
 	if (rc != 0) {
@@ -136,8 +136,21 @@ handler_ping(crt_rpc_t *rpc)
 		error_exit();
 	}
 
-	DBG_PRINT("RPC arived on a %s context; origin was %s\n",
+	rc = crt_req_dst_tag_get(rpc, &hdr_dst_tag);
+	if (rc != 0) {
+		D_ERROR("crt_req_dst_tag_get() failed; rc=%d\n", rc);
+		error_exit();
+	}
+
+	rc = crt_context_idx(rpc->cr_ctx, &my_tag);
+	if (rc != 0) {
+		D_ERROR("crt_context_idx() failed; rc=%d\n", rc);
+		error_exit();
+	}
+
+	DBG_PRINT("RPC arived on a %s context (idx=%d intended_tag=%d); origin was %s\n",
 		  crt_context_is_primary(ctx) ? "primary" : "secondary",
+		  my_tag, hdr_dst_tag,
 		  primary_origin ? "primary" : "secondary");
 
 	/* TODO: Change this to rank == 2 when bulk support is added */


### PR DESCRIPTION
- When the client is secondary, we do not want to use target endpoint
information for deciding which secondary tag to send rpc to.
Instead we send it to secondary tag=0. In future API will be added
to control total number of server tags, and instead of 0 a random
tag will be chosen.

intended destination tag is present in the rpc header and available
to be retrieved via apis.

- test updated to try new apis and test behavior

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>