### PR TITLE
DAOS-10927 test: pool/create_all_hw.py failing to init SPDK

### DIFF
--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -236,6 +236,8 @@ func (p *Provider) UpdateScmFirmware(req ScmFirmwareUpdateRequest) (*ScmFirmware
 
 // PrepareBdevs attempts to configure NVMe devices to be usable by DAOS.
 func (p *Provider) PrepareBdevs(req BdevPrepareRequest) (*BdevPrepareResponse, error) {
+	p.log.Debugf("calling bdev storage provider prep: %+v", req)
+
 	resp, err := p.bdev.Prepare(req)
 
 	p.Lock()

--- a/src/tests/ftest/pool/create_all_hw.yaml
+++ b/src/tests/ftest/pool/create_all_hw.yaml
@@ -20,7 +20,7 @@ server_config:
     0:
       targets_count: !mux
         1_target:
-          targets: 2
+          targets: 1
         2_targets:
           targets: 2
         3_targets:

--- a/src/tests/ftest/pool/create_all_hw.yaml
+++ b/src/tests/ftest/pool/create_all_hw.yaml
@@ -20,7 +20,7 @@ server_config:
     0:
       targets_count: !mux
         1_target:
-          targets: 1
+          targets: 2
         2_targets:
           targets: 2
         3_targets:


### PR DESCRIPTION
See if failures occur when bumping number of targets from 1 to 2.

*** DO NOT LAND ***

Quick-build: true
Skip-unit-tests: true
Skip-func-test-vm: true
Test-tag: hw,large,pool,pool_create_all

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

Required-githooks: true