### PR TITLE
DAOS-10927 test: pool/create_all_hw.py failing to init SPDK

### DIFF
--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -93,9 +93,8 @@ func (cmd *storagePrepareCmd) prepNvme(prep nvmePrepFn, iommuEnabled bool) error
 	case cmd.DisableVFIO:
 		cmd.Info("VMD not enabled because VFIO disabled in command options")
 	case !iommuEnabled:
-		cmd.Info("VMD not enabled because IOMMU disabled on platform")
+		cmd.Info("VMD not enabled because IOMMU disabled on system")
 	default:
-		// If none of the cases above match, set enable VMD flag in request.
 		req.EnableVMD = true
 	}
 

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -90,7 +90,6 @@ const (
 	BdevNoDevicesMatchFilter
 	BdevAccelEngineUnknown
 	BdevAccelOptionUnknown
-	BdevConfigTypeMismatch
 )
 
 // DAOS system fault codes

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -520,7 +520,7 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 			ec.LegacyStorage = engine.LegacyStorage{}
 		}
 
-		if ec.Storage.Tiers.HaveBdevs() {
+		if ec.Storage.Tiers.CfgHasBdevs() {
 			cfgHasBdevs = true
 			if ec.TargetCount == 0 {
 				return errors.Errorf("engine %d: Target count cannot be zero if "+

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -466,19 +466,6 @@ func TestConfig_BdevValidation(t *testing.T) {
 				),
 			expCls: storage.ClassFile,
 		},
-		"mix of emulated and non-emulated device classes": {
-			cfg: baseValidConfig().
-				WithStorage(
-					storage.NewTierConfig().
-						WithStorageClass("nvme").
-						WithBdevDeviceList(test.MockPCIAddr(1)),
-					storage.NewTierConfig().
-						WithStorageClass("file").
-						WithBdevFileSize(10).
-						WithBdevDeviceList("bdev1", "bdev2"),
-				),
-			expErr: errors.New("mix of emulated and non-emulated NVMe"),
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			test.CmpErr(t, tc.expErr, tc.cfg.Validate())

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -41,22 +41,26 @@ type resolveTCPFn func(string, string) (*net.TCPAddr, error)
 
 const scanMinHugePageCount = 128
 
-func getBdevDevicesFromCfgs(bdevCfgs storage.TierConfigs) *storage.BdevDeviceList {
+func engineCfgGetBdevs(engineCfg *engine.Config) *storage.BdevDeviceList {
 	bdevs := []string{}
-	for _, bc := range bdevCfgs {
+	for _, bc := range engineCfg.Storage.Tiers.BdevConfigs() {
 		bdevs = append(bdevs, bc.Bdev.DeviceList.Devices()...)
 	}
 
 	return storage.MustNewBdevDeviceList(bdevs...)
 }
 
-func getBdevCfgsFromSrvCfg(cfg *config.Server) storage.TierConfigs {
-	bdevCfgs := []*storage.TierConfig{}
+func cfgGetBdevs(cfg *config.Server) *storage.BdevDeviceList {
+	bdevs := []string{}
 	for _, engineCfg := range cfg.Engines {
-		bdevCfgs = append(bdevCfgs, engineCfg.Storage.Tiers.BdevConfigs()...)
+		bdevs = append(bdevs, engineCfgGetBdevs(engineCfg).Devices()...)
 	}
 
-	return bdevCfgs
+	return storage.MustNewBdevDeviceList(bdevs...)
+}
+
+func cfgHasBdevs(cfg *config.Server) bool {
+	return cfgGetBdevs(cfg).Len() != 0
 }
 
 func cfgGetReplicas(cfg *config.Server, resolver resolveTCPFn) ([]*net.TCPAddr, error) {
@@ -195,27 +199,26 @@ func getEngineNUMANodes(log logging.Logger, engineCfgs []*engine.Config) []strin
 	return nodes
 }
 
-// Prepare bdev storage. Assumes validation has already been performed on server config. Hugepages
-// are required for both emulated (AIO devices) and real NVMe bdevs. VFIO and IOMMU are not
-// required for emulated file launchedNVMe.
 func prepBdevStorage(srv *server, iommuEnabled bool) error {
 	defer srv.logDuration(track("time to prepare bdev storage"))
 
-	if srv.cfg.DisableHugepages {
-		srv.log.Debugf("skip nvme prepare as disable_hugepages: true in config")
+	hasBdevs := cfgHasBdevs(srv.cfg)
+
+	if hasBdevs {
+		// Perform these checks to avoid even trying a prepare if the system isn't
+		// configured properly.
+		if srv.runningUser.Username != "root" {
+			if srv.cfg.DisableVFIO {
+				return FaultVfioDisabled
+			}
+
+			if !iommuEnabled {
+				return FaultIommuDisabled
+			}
+		}
+	} else if srv.cfg.DisableHugepages {
+		srv.log.Debugf("skip nvme prepare as no bdevs in cfg and disable_hugepages: true in config")
 		return nil
-	}
-
-	bdevCfgs := getBdevCfgsFromSrvCfg(srv.cfg)
-
-	// Perform these checks only if non-emulated NVMe is used and user is unprivileged.
-	if bdevCfgs.HaveRealNVMe() && srv.runningUser.Username != "root" {
-		if srv.cfg.DisableVFIO {
-			return FaultVfioDisabled
-		}
-		if !iommuEnabled {
-			return FaultIommuDisabled
-		}
 	}
 
 	prepReq := storage.BdevPrepareRequest{
@@ -229,15 +232,12 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 	case !srv.cfg.DisableVMD && srv.cfg.DisableVFIO:
 		srv.log.Info("VMD not enabled because VFIO disabled in config")
 	case !srv.cfg.DisableVMD && !iommuEnabled:
-		srv.log.Info("VMD not enabled because IOMMU disabled on platform")
-	case !srv.cfg.DisableVMD && bdevCfgs.HaveEmulatedNVMe():
-		srv.log.Info("VMD not enabled because emulated NVMe devices found in config")
+		srv.log.Info("VMD not enabled because IOMMU disabled on system")
 	default:
-		// If no case above matches, set enable VMD flag in request otherwise leave false.
 		prepReq.EnableVMD = !srv.cfg.DisableVMD
 	}
 
-	if bdevCfgs.HaveBdevs() {
+	if hasBdevs {
 		// The NrHugepages config value is a total for all engines. Distribute allocation
 		// of hugepages equally across each engine's numa node (as validation ensures that
 		// TargetsCount is equal for each engine).
@@ -291,7 +291,7 @@ func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
 	}
 
 	nvmeScanResp, err := srv.ctlSvc.NvmeScan(storage.BdevScanRequest{
-		DeviceList:  getBdevDevicesFromCfgs(getBdevCfgsFromSrvCfg(srv.cfg)),
+		DeviceList:  cfgGetBdevs(srv.cfg),
 		BypassCache: true, // init cache on first scan
 	})
 	if err != nil {
@@ -310,7 +310,7 @@ func updateMemValues(srv *server, ei *EngineInstance, getHugePageInfo common.Get
 	ei.RLock()
 	engineCfg := ei.runner.GetConfig()
 	engineIdx := engineCfg.Index
-	if getBdevDevicesFromCfgs(engineCfg.Storage.Tiers.BdevConfigs()).Len() == 0 {
+	if engineCfgGetBdevs(engineCfg).Len() == 0 {
 		srv.log.Debugf("skipping mem check on engine %d, no bdevs", engineIdx)
 		ei.RUnlock()
 		return nil

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -179,29 +179,9 @@ func (tc *TierConfig) WithBdevBusidRange(rangeStr string) *TierConfig {
 
 type TierConfigs []*TierConfig
 
-func (tcs TierConfigs) HaveBdevs() bool {
+func (tcs TierConfigs) CfgHasBdevs() bool {
 	for _, bc := range tcs.BdevConfigs() {
 		if bc.Bdev.DeviceList.Len() > 0 {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (tcs TierConfigs) HaveRealNVMe() bool {
-	for _, bc := range tcs.BdevConfigs() {
-		if bc.Bdev.DeviceList.Len() > 0 && bc.Class == ClassNvme {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (tcs TierConfigs) HaveEmulatedNVMe() bool {
-	for _, bc := range tcs.BdevConfigs() {
-		if bc.Bdev.DeviceList.Len() > 0 && bc.Class != ClassNvme {
 			return true
 		}
 	}
@@ -218,7 +198,7 @@ func (tcs TierConfigs) Validate() error {
 	return nil
 }
 
-func (tcs TierConfigs) ScmConfigs() (out TierConfigs) {
+func (tcs TierConfigs) ScmConfigs() (out []*TierConfig) {
 	for _, cfg := range tcs {
 		if cfg.IsSCM() {
 			out = append(out, cfg)
@@ -228,7 +208,7 @@ func (tcs TierConfigs) ScmConfigs() (out TierConfigs) {
 	return
 }
 
-func (tcs TierConfigs) BdevConfigs() (out TierConfigs) {
+func (tcs TierConfigs) BdevConfigs() (out []*TierConfig) {
 	for _, cfg := range tcs {
 		if cfg.IsBdev() {
 			out = append(out, cfg)
@@ -739,10 +719,6 @@ func (c *Config) Validate() error {
 		return nil
 	}
 	c.ConfigOutputPath = filepath.Join(scmCfgs[0].Scm.MountPoint, BdevOutConfName)
-
-	if c.Tiers.HaveRealNVMe() && c.Tiers.HaveEmulatedNVMe() {
-		return FaultBdevConfigTypeMismatch
-	}
 
 	fbc := bdevCfgs[0]
 

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -38,12 +38,6 @@ func FaultScmNamespacesNrMismatch(nrExpPerNUMA, nrNUMA, nrExisting uint) *fault.
 			"required number of PMem regions")
 }
 
-// FaultBdevConfigTypeMismatch represents an error where an incompatible mix of emulated and
-// non-emulated NVMe devices are present in the storage config.
-var FaultBdevConfigTypeMismatch = storageFault(code.BdevConfigTypeMismatch,
-	"A mix of emulated and non-emulated NVMe devices are specified in config",
-	"Change config tiers to specify either emulated or non-emulated NVMe devices, but not a mix of both")
-
 // FaultBdevNotFound creates a Fault for the case where no NVMe storage devices
 // match expected PCI addresses.
 func FaultBdevNotFound(bdevs ...string) *fault.Fault {

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -236,6 +236,8 @@ func (p *Provider) UpdateScmFirmware(req ScmFirmwareUpdateRequest) (*ScmFirmware
 
 // PrepareBdevs attempts to configure NVMe devices to be usable by DAOS.
 func (p *Provider) PrepareBdevs(req BdevPrepareRequest) (*BdevPrepareResponse, error) {
+	p.log.Debugf("calling bdev storage provider prep: %+v", req)
+
 	resp, err := p.bdev.Prepare(req)
 
 	p.Lock()


### PR DESCRIPTION
See if failures occur when DAOS-10473 change reverted.

*** DO NOT LAND ***

Quick-build: true
Skip-unit-tests: true
Skip-func-test-vm: true
Test-tag: hw,large,pool,pool_create_all

Revert "DAOS-10473 control: Do not require IOMMU for emulated NVMe (#9272)"

This reverts commit e23c00ca6626dd18a430b69b165f438c3dcbe08d.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

Required-githooks: true