### PR TITLE
DAOS-9595 chk: handle inconsistent pool label

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -339,7 +339,7 @@ chk_ranks_dump(uint32_t rank_nr, d_rank_t *ranks)
 }
 
 void
-chk_pools_dump(uint32_t pool_nr, uuid_t pools[])
+chk_pools_dump(int pool_nr, uuid_t pools[])
 {
 	char	 buf[256];
 	char	*ptr = buf;
@@ -371,6 +371,23 @@ chk_pools_dump(uint32_t pool_nr, uuid_t pools[])
 	D_INFO("%s\n", buf);
 }
 
+int
+chk_pool_filter(uuid_t uuid, void *arg)
+{
+	struct chk_pool_filter_args	*cpfa = arg;
+	int				 i;
+
+	if (cpfa->cpfa_pool_nr <= 0)
+		return 0;
+
+	for (i = 0; i < cpfa->cpfa_pool_nr; i++) {
+		if (uuid_compare(uuid, cpfa->cpfa_pools[i]) == 0)
+			return 0;
+	}
+
+	return 1;
+}
+
 void
 chk_stop_sched(struct chk_instance *ins)
 {
@@ -385,7 +402,7 @@ chk_stop_sched(struct chk_instance *ins)
 
 int
 chk_prop_prepare(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		 struct chk_policy *policies, uint32_t pool_nr, uuid_t pools[],
+		 struct chk_policy *policies, int pool_nr, uuid_t pools[],
 		 uint32_t flags, int phase, d_rank_t leader,
 		 struct chk_property *prop, d_rank_list_t **rlist)
 {

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -204,8 +204,8 @@ chk_sg_rpc_prepare(d_rank_t rank, crt_opcode_t opc, crt_rpc_t **req)
 
 int
 chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
-		 uint32_t policy_nr, struct chk_policy *policies, uint32_t pool_nr,
-		 uuid_t pools[], uint32_t flags, int32_t phase, d_rank_t leader,
+		 uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
+		 uuid_t pools[], uint32_t flags, int phase, d_rank_t leader,
 		 chk_co_rpc_cb_t start_cb, void *args)
 {
 	struct chk_co_rpc_priv	 ccrp;
@@ -276,7 +276,7 @@ out:
 }
 
 int
-chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
 		chk_co_rpc_cb_t stop_cb, void *args)
 {
 	struct chk_co_rpc_priv	 ccrp;
@@ -320,14 +320,14 @@ out:
 		crt_req_decref(req);
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "Rank %u stop DAOS check with gen "DF_X64", pool_nr %u: "DF_RC"\n",
+		 "Rank %u stop DAOS check with gen "DF_X64", pool_nr %d: "DF_RC"\n",
 		 dss_self_rank(), gen, pool_nr, DP_RC(rc));
 
 	return rc;
 }
 
 int
-chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
 		 chk_co_rpc_cb_t query_cb, void *args)
 {
 	struct chk_co_rpc_priv	 ccrp;
@@ -379,7 +379,7 @@ out:
 		crt_req_decref(req);
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "Rank %u query DAOS check with gen "DF_X64", pool_nr %u: "DF_RC"\n",
+		 "Rank %u query DAOS check with gen "DF_X64", pool_nr %d: "DF_RC"\n",
 		 dss_self_rank(), gen, pool_nr, DP_RC(rc));
 
 	return rc;
@@ -461,7 +461,7 @@ out:
 	return rc;
 }
 
-int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int32_t result,
+int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int result,
 		      d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont,
 		      daos_unit_oid_t *obj, daos_key_t *dkey, daos_key_t *akey, char *msg,
 		      uint32_t option_nr, uint32_t *options, uint32_t detail_nr, d_sg_list_t *details,

--- a/src/chk/chk_upcall.c
+++ b/src/chk/chk_upcall.c
@@ -102,7 +102,7 @@ out:
 }
 
 int
-chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int32_t result,
+chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int result,
 		  d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont, daos_unit_oid_t *obj,
 		  daos_key_t *dkey, daos_key_t *akey, char *msg, uint32_t option_nr,
 		  uint32_t *options, uint32_t detail_nr, d_sg_list_t *details)

--- a/src/engine/drpc_ras.c
+++ b/src/engine/drpc_ras.c
@@ -438,6 +438,11 @@ out_req:
 	return rc;
 }
 
+/*
+ * XXX: Register the pool information on MS via DRPC_METHOD_CHK_REG_POOL:
+ *	if the pool does not exist, then add it on MS; otherwise, refresh
+ *	the pool service replicas and label information.
+ */
 int
 ds_chk_regpool_upcall(uint64_t seq, uuid_t uuid, char *label, d_rank_list_t *svcreps)
 {

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -74,12 +74,12 @@ typedef int (*chk_query_pool_cb_t)(struct chk_query_pool_shard *shard, uint32_t 
 typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy *policies, int cnt, uint32_t flags);
 
 int chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		     struct chk_policy *policies, uint32_t pool_nr, uuid_t pools[],
-		     uint32_t flags, int32_t phase);
+		     struct chk_policy *policies, int pool_nr, uuid_t pools[],
+		     uint32_t flags, int phase);
 
-int chk_leader_stop(uint32_t pool_nr, uuid_t pools[]);
+int chk_leader_stop(int pool_nr, uuid_t pools[]);
 
-int chk_leader_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+int chk_leader_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		     chk_query_pool_cb_t pool_cb, void *buf);
 
 int chk_leader_prop(chk_prop_cb_t prop_cb, void *buf);

--- a/src/mgmt/srv_chk.c
+++ b/src/mgmt/srv_chk.c
@@ -15,7 +15,7 @@
 
 int
 ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		    Mgmt__CheckInconsistPolicy **policies, uint32_t pool_nr, uuid_t pools[],
+		    Mgmt__CheckInconsistPolicy **policies, int32_t pool_nr, uuid_t pools[],
 		    uint32_t flags, int32_t phase)
 {
 	struct chk_policy *ply = NULL;
@@ -42,13 +42,13 @@ out:
 }
 
 int
-ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[])
+ds_mgmt_check_stop(int32_t pool_nr, uuid_t pools[])
 {
 	return chk_leader_stop(pool_nr, pools);
 }
 
 int
-ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+ds_mgmt_check_query(int32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		    chk_query_pool_cb_t pool_cb, void *buf)
 {
 	return chk_leader_query(pool_nr, pools, head_cb, pool_cb, buf);

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -112,10 +112,10 @@ int ds_mgmt_cont_set_owner(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 
 /** srv_chk.c */
 int ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-			Mgmt__CheckInconsistPolicy **policies, uint32_t pool_nr, uuid_t pools[],
-			uint32_t flags, int32_t phase);
-int ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[]);
-int ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+			Mgmt__CheckInconsistPolicy **policies, int pool_nr, uuid_t pools[],
+			uint32_t flags, int phase);
+int ds_mgmt_check_stop(int pool_nr, uuid_t pools[]);
+int ds_mgmt_check_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 			chk_query_pool_cb_t pool_cb, void *buf);
 int ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf);
 int ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all);

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -582,20 +582,20 @@ mock_ds_mgmt_pool_upgrade_setup(void)
 
 int
 ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		    Mgmt__CheckInconsistPolicy **policies, uint32_t pool_nr, uuid_t pools[],
-		    uint32_t flags, int32_t phase)
+		    Mgmt__CheckInconsistPolicy **policies, int pool_nr, uuid_t pools[],
+		    uint32_t flags, int phase)
 {
 	return 0;
 }
 
 int
-ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[])
+ds_mgmt_check_stop(int pool_nr, uuid_t pools[])
 {
 	return 0;
 }
 
 int
-ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+ds_mgmt_check_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		    chk_query_pool_cb_t pool_cb, void *buf)
 {
 	return 0;


### PR DESCRIPTION
The pool label is mainly used by MS to lookup pool UUID by label.
The PS recorded pool label is some kind of the backup. So if the
MS known pool label does not match the pool label recorded by PS,
then trust MS as long as MS known pool label is not NULL. Related
repair will not happen on check leader, instead, it will be done
on the PS leader during CHK__CHECK_SCAN_PHASE__CSP_POOL_CLEANUP.

If the admin wants to recover pool label on MS with the pool info
on PS, then it will use DRPC_METHOD_CHK_REG_POOL drpc upcall.

The patch also contains some other fixes:

1. Only handle dangling pool within the given pools check list.

2. Some code cleanup for "uint32_t" and "int32_t" usage in chk.

Signed-off-by: Fan Yong <fan.yong@intel.com>