### PR TITLE
DAOS-9599 chk: handle inconsistent pool label

### DIFF
--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -34,11 +34,6 @@ struct chk_traverse_pools_args {
 	uint32_t			 ctpa_status;
 };
 
-struct chk_engine_clues_args {
-	uint32_t			 ceca_pool_nr;
-	uuid_t				*ceca_pools;
-};
-
 struct chk_query_pool_args {
 	struct chk_instance		*cqpa_ins;
 	uint32_t			 cqpa_cap;
@@ -444,7 +439,7 @@ out:
 static int
 chk_engine_start_prepare(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *ranks,
 			 uint32_t policy_nr, struct chk_policy *policies,
-			 uint32_t pool_nr, uuid_t pools[], uint64_t gen, int phase,
+			 int pool_nr, uuid_t pools[], uint64_t gen, int phase,
 			 uint32_t flags, d_rank_t leader, d_rank_list_t **rlist)
 {
 	struct chk_bookmark	*cbk = &ins->ci_bk;
@@ -681,27 +676,10 @@ out:
 	return rc;
 }
 
-static int
-chk_engine_clues_filter(uuid_t uuid, void *arg)
-{
-	struct chk_engine_clues_args	*ceca = arg;
-	int				 i;
-
-	if (ceca->ceca_pool_nr == 0)
-		return 0;
-
-	for (i = 0; i < ceca->ceca_pool_nr; i++) {
-		if (uuid_compare(uuid, ceca->ceca_pools[i]) == 0)
-			return 0;
-	}
-
-	return 1;
-}
-
 int
 chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
-		 uint32_t policy_nr, struct chk_policy *policies, uint32_t pool_nr,
-		 uuid_t pools[], uint32_t flags, int32_t exp_phase, d_rank_t leader,
+		 uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
+		 uuid_t pools[], uint32_t flags, int exp_phase, d_rank_t leader,
 		 uint32_t *cur_phase, struct ds_pool_clues *clues)
 {
 	struct chk_instance		*ins = chk_engine;
@@ -711,7 +689,7 @@ chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 	struct chk_pool_rec		*cpr;
 	struct chk_pool_rec		*tmp;
 	struct chk_traverse_pools_args	 ctpa = { 0 };
-	struct chk_engine_clues_args	 ceca = { 0 };
+	struct chk_pool_filter_args	 cpfa = { 0 };
 	struct umem_attr		 uma = { 0 };
 	uuid_t				 dummy_pool;
 	d_rank_t			 myrank = dss_self_rank();
@@ -838,9 +816,8 @@ chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 
 	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_PREPARE ||
 	    cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
-		ceca.ceca_pool_nr = pool_nr;
-		ceca.ceca_pools = pools;
-		rc = ds_pool_clues_init(chk_engine_clues_filter, &ceca, clues);
+		cpfa.cpfa_pool_hdl = ins->ci_pool_hdl;
+		rc = ds_pool_clues_init(chk_pool_filter, &cpfa, clues);
 		if (rc != 0)
 			goto out_bk;
 	}
@@ -880,7 +857,7 @@ out_log:
 	ins->ci_starting = 0;
 
 	if (rc == 0) {
-		D_INFO(DF_ENGINE" started on rank %u with %u ranks, %u pools, "
+		D_INFO(DF_ENGINE" started on rank %u with %u ranks, %d pools, "
 		       "flags %x, phase %d, leader %u\n",
 		       DP_ENGINE(ins), myrank, rank_nr, pool_nr, flags, exp_phase, leader);
 
@@ -893,7 +870,7 @@ out_log:
 	} else if (rc > 0) {
 		*cur_phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
 	} else if (rc != -DER_ALREADY) {
-		D_ERROR(DF_ENGINE" failed to start on rank %u with %u ranks, %u pools, flags %x, "
+		D_ERROR(DF_ENGINE" failed to start on rank %u with %u ranks, %d pools, flags %x, "
 			"phase %d, leader %u, gen "DF_X64": "DF_RC"\n", DP_ENGINE(ins), myrank,
 			rank_nr, pool_nr, flags, exp_phase, leader, gen, DP_RC(rc));
 	}
@@ -904,7 +881,7 @@ out_log:
 }
 
 int
-chk_engine_stop(uint64_t gen, uint32_t pool_nr, uuid_t pools[])
+chk_engine_stop(uint64_t gen, int pool_nr, uuid_t pools[])
 {
 	struct chk_instance	*ins = chk_engine;
 	struct chk_property	*prop = &ins->ci_prop;
@@ -954,7 +931,7 @@ out:
 	ins->ci_stopping = 0;
 
 	if (rc == 0) {
-		D_INFO(DF_ENGINE" stopped on rank %u with %u pools\n",
+		D_INFO(DF_ENGINE" stopped on rank %u with %d pools\n",
 		       DP_ENGINE(ins), dss_self_rank(), pool_nr > 0 ? pool_nr : prop->cp_pool_nr);
 
 		if (pool_nr > 0)
@@ -964,7 +941,7 @@ out:
 	} else if (rc == -DER_ALREADY) {
 		rc = 1;
 	} else if (rc < 0) {
-		D_ERROR(DF_ENGINE" failed to stop on rank %u with %u pools, "
+		D_ERROR(DF_ENGINE" failed to stop on rank %u with %d pools, "
 			"gen "DF_X64": "DF_RC"\n", DP_ENGINE(ins), dss_self_rank(),
 			pool_nr > 0 ? pool_nr : prop->cp_pool_nr, gen, DP_RC(rc));
 	}
@@ -1127,7 +1104,7 @@ out:
 }
 
 int
-chk_engine_query(uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+chk_engine_query(uint64_t gen, int pool_nr, uuid_t pools[],
 		 uint32_t *shard_nr, struct chk_query_pool_shard **shards)
 {
 	struct chk_instance		*ins = chk_engine;
@@ -1165,7 +1142,7 @@ log:
 	}
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG,
-		 DF_ENGINE" on rank %u handle query for %u pools :"DF_RC"\n",
+		 DF_ENGINE" on rank %u handle query for %d pools :"DF_RC"\n",
 		 DP_ENGINE(ins), dss_self_rank(), pool_nr, DP_RC(rc));
 
 out:

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -378,6 +378,7 @@ struct chk_pool_rec {
 				 cpr_done:1,
 				 cpr_skip:1,
 				 cpr_healthy:1,
+				 cpr_delay_label:1,
 				 cpr_exist_on_ms:1;
 	int			 cpr_advice;
 	uint32_t		 cpr_phase;
@@ -386,6 +387,7 @@ struct chk_pool_rec {
 	struct ds_pool_clues	 cpr_clues;
 	struct chk_bookmark	 cpr_bk;
 	struct chk_instance	*cpr_ins;
+	char			*cpr_label;
 	int			 cpr_refs;
 };
 
@@ -424,6 +426,12 @@ struct chk_report_unit {
 	uint32_t		 cru_result;
 };
 
+struct chk_pool_filter_args {
+	daos_handle_t		 cpfa_pool_hdl;
+	int32_t			 cpfa_pool_nr;
+	uuid_t			*cpfa_pools;
+};
+
 extern struct crt_proto_format	chk_proto_fmt;
 
 extern struct crt_corpc_ops	chk_start_co_ops;
@@ -440,12 +448,16 @@ extern btr_ops_t		chk_rank_ops;
 
 void chk_ranks_dump(uint32_t rank_nr, d_rank_t *ranks);
 
-void chk_pools_dump(uint32_t pool_nr, uuid_t pools[]);
+void chk_pools_dump(int pool_nr, uuid_t pools[]);
+
+int chk_pool_filter(uuid_t uuid, void *arg);
+
+int chk_dup_label(char **tgt, const char *src, size_t len);
 
 void chk_stop_sched(struct chk_instance *ins);
 
 int chk_prop_prepare(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		     struct chk_policy *policies, uint32_t pool_nr, uuid_t pools[],
+		     struct chk_policy *policies, int pool_nr, uuid_t pools[],
 		     uint32_t flags, int phase, d_rank_t leader,
 		     struct chk_property *prop, d_rank_list_t **rlist);
 
@@ -469,13 +481,13 @@ void chk_ins_fini(struct chk_instance *ins);
 /* chk_engine.c */
 
 int chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
-		     uint32_t policy_nr, struct chk_policy *policies, uint32_t pool_nr,
-		     uuid_t pools[], uint32_t flags, int32_t exp_phase, d_rank_t leader,
+		     uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
+		     uuid_t pools[], uint32_t flags, int exp_phase, d_rank_t leader,
 		     uint32_t *cur_phase, struct ds_pool_clues *clues);
 
-int chk_engine_stop(uint64_t gen, uint32_t pool_nr, uuid_t pools[]);
+int chk_engine_stop(uint64_t gen, int pool_nr, uuid_t pools[]);
 
-int chk_engine_query(uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+int chk_engine_query(uint64_t gen, int pool_nr, uuid_t pools[],
 		     uint32_t *shard_nr, struct chk_query_pool_shard **shards);
 
 int chk_engine_mark_rank_dead(uint64_t gen, d_rank_t rank, uint32_t version);
@@ -524,14 +536,14 @@ void chk_leader_fini(void);
 /* chk_rpc.c */
 
 int chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
-		     uint32_t policy_nr, struct chk_policy *policies, uint32_t pool_nr,
-		     uuid_t pools[], uint32_t flags, int32_t phase, d_rank_t leader,
+		     uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
+		     uuid_t pools[], uint32_t flags, int phase, d_rank_t leader,
 		     chk_co_rpc_cb_t start_cb, void *args);
 
-int chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+int chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
 		    chk_co_rpc_cb_t stop_cb, void *args);
 
-int chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+int chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
 		     chk_co_rpc_cb_t query_cb, void *args);
 
 int chk_mark_remote(d_rank_list_t *rank_list, uint64_t gen, d_rank_t rank, uint32_t version);
@@ -539,7 +551,7 @@ int chk_mark_remote(d_rank_list_t *rank_list, uint64_t gen, d_rank_t rank, uint3
 int chk_act_remote(d_rank_list_t *rank_list, uint64_t gen, uint64_t seq, uint32_t cla,
 		   uint32_t act, d_rank_t rank, bool for_all);
 
-int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int32_t result,
+int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int result,
 		      d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont,
 		      daos_unit_oid_t *obj, daos_key_t *dkey, daos_key_t *akey, char *msg,
 		      uint32_t option_nr, uint32_t *options, uint32_t detail_nr,
@@ -549,7 +561,7 @@ int chk_rejoin_remote(d_rank_t leader, uint64_t gen, d_rank_t rank, uint32_t pha
 
 /* chk_updcall.c */
 
-int chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int32_t result,
+int chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int result,
 		      d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont,
 		      daos_unit_oid_t *obj, daos_key_t *dkey, daos_key_t *akey, char *msg,
 		      uint32_t option_nr, uint32_t *options, uint32_t detail_nr,
@@ -711,6 +723,7 @@ chk_pool_put(struct chk_pool_rec *cpr)
 		d_list_del(&cpr->cpr_link);
 		D_ASSERT(cpr->cpr_thread == ABT_THREAD_NULL);
 		D_ASSERT(cpr->cpr_started == 0);
+		D_FREE(cpr->cpr_label);
 		D_FREE(cpr);
 	}
 }

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -417,6 +417,24 @@ chk_pool_in_zombie(struct chk_pool_rec *cpr)
 }
 
 static int
+chk_pool_has_err(struct chk_pool_rec *cpr)
+{
+	struct chk_pool_shard	*cps;
+	struct ds_pool_clue	*clue;
+	int			 rc = 0;
+
+	d_list_for_each_entry(cps, &cpr->cpr_shard_list, cps_link) {
+		clue = cps->cps_data;
+		if (clue->pc_rc < 0) {
+			rc = clue->pc_rc;
+			break;
+		}
+	}
+
+	return rc;
+}
+
+static int
 chk_leader_destroy_pool(struct chk_pool_rec *cpr, uint64_t seq, bool dereg)
 {
 	d_rank_list_t	*ranks = NULL;
@@ -919,7 +937,6 @@ chk_leader_no_quorum_pool(struct chk_pool_rec *cpr)
 	struct chk_instance		*ins = cpr->cpr_ins;
 	struct chk_property		*prop = &ins->ci_prop;
 	struct chk_bookmark		*cbk = &ins->ci_bk;
-	d_rank_list_t			*ranks = NULL;
 	struct ds_pool_clue		*clue;
 	char				*strs[3];
 	char				 suggested[128] = { 0 };
@@ -936,6 +953,13 @@ chk_leader_no_quorum_pool(struct chk_pool_rec *cpr)
 	int				 decision = -1;
 	int				 result = 0;
 	int				 rc = 0;
+
+	result = chk_pool_has_err(cpr);
+	if (result != 0) {
+		D_WARN(DF_LEADER" some engine failed to report information for pool "
+		       DF_UUIDF", skip it\n", DP_LEADER(ins), DP_UUID(cpr->cpr_uuid));
+		goto out;
+	}
 
 	cla = CHK__CHECK_INCONSIST_CLASS__CIC_POOL_LESS_SVC_WITHOUT_QUORUM;
 	act = prop->cp_policies[cla];
@@ -1010,7 +1034,8 @@ chk_leader_no_quorum_pool(struct chk_pool_rec *cpr)
 				goto report;
 
 			clue = chk_leader_locate_pool_clue(cpr);
-			result = ds_chk_regpool_upcall(seq, cpr->cpr_uuid, clue->pc_label, ranks);
+			result = ds_chk_regpool_upcall(seq, cpr->cpr_uuid, clue->pc_label,
+						       clue->pc_svc_clue->psc_db_clue.bcl_replicas);
 			if (result != 0) {
 				cbk->cb_statistics.cs_failed++;
 				/* Skip the pool if failed to register to MS. */
@@ -1107,7 +1132,7 @@ report:
 
 	if (rc != 0 && option_nr > 0) {
 		cbk->cb_statistics.cs_failed++;
-		/* Skip the corrupted if failed to interact with admin for further action. */
+		/* Skip the corrupted pool if failed to interact with admin for further action. */
 		cpr->cpr_skip = 1;
 		result = rc;
 	}
@@ -1157,19 +1182,30 @@ ignore:
 		act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 		if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
 			cbk->cb_statistics.cs_repaired++;
-		} else {
-			clue = chk_leader_locate_pool_clue(cpr);
-			result = ds_chk_regpool_upcall(seq, cpr->cpr_uuid, clue->pc_label, ranks);
-			if (result != 0) {
-				cbk->cb_statistics.cs_failed++;
-				/* Skip the pool if failed to register to MS. */
-				cpr->cpr_skip = 1;
-			}
 			/*
-			 * XXX: For result == 0 case, it still cannot be regarded as repaired.
-			 *	We need to start the PS under DICTATE mode in subsequent step.
+			 * Under dryrun mode, we cannot start the PS with DICTATE
+			 * mode, then have to skip it.
 			 */
+			cpr->cpr_skip = 1;
+			break;
 		}
+
+		result = chk_leader_reset_pool_svc(cpr);
+		if (result != 0 || cpr->cpr_exist_on_ms)
+			break;
+
+		clue = chk_leader_locate_pool_clue(cpr);
+		result = ds_chk_regpool_upcall(seq, cpr->cpr_uuid, clue->pc_label,
+					       clue->pc_svc_clue->psc_db_clue.bcl_replicas);
+		if (result != 0) {
+			cbk->cb_statistics.cs_failed++;
+			/* Skip the pool if failed to register to MS. */
+			cpr->cpr_skip = 1;
+		}
+		/*
+		 * XXX: For result == 0 case, it still cannot be regarded as repaired.
+		 *	We need to start the PS under DICTATE mode in subsequent step.
+		 */
 		break;
 	}
 
@@ -1182,7 +1218,6 @@ out:
 	 * pool record and bookmark.
 	 */
 	chk_leader_post_repair(ins, cpr->cpr_uuid, &result, true, cpr->cpr_skip ? true : false);
-	d_rank_list_free(ranks);
 
 	return result;
 }
@@ -1277,9 +1312,224 @@ out:
 }
 
 static int
+chk_leader_handle_pool_label(struct chk_pool_rec *cpr, struct ds_pool_clue *clue,
+			     struct chk_list_pool *clp)
+{
+	struct chk_instance		*ins = cpr->cpr_ins;
+	struct chk_property		*prop = &ins->ci_prop;
+	struct chk_bookmark		*cbk = &ins->ci_bk;
+	char				*strs[3];
+	char				 suggested[128] = { 0 };
+	d_iov_t				 iovs[3];
+	d_sg_list_t			 sgl;
+	d_sg_list_t			*details = NULL;
+	struct chk_report_unit		 cru;
+	Chk__CheckInconsistClass	 cla;
+	Chk__CheckInconsistAction	 act;
+	uint64_t			 seq = 0;
+	uint32_t			 options[3];
+	uint32_t			 option_nr = 0;
+	uint32_t			 detail_nr = 0;
+	int				 decision = -1;
+	int				 result = 0;
+	int				 rc = 0;
+
+	cla = CHK__CHECK_INCONSIST_CLASS__CIC_POOL_BAD_LABEL;
+	act = prop->cp_policies[cla];
+
+	switch (act) {
+	case CHK__CHECK_INCONSIST_ACTION__CIA_DEFAULT:
+		/*
+		 * The pool label is mainly used by MS to lookup pool UUID by label.
+		 * The PS recorded label info is just some kind of backup. So trust
+		 * the label info on MS if exist.
+		 */
+		if (clp->clp_label == NULL)
+			goto try_ps;
+
+		/* Fall through. */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS:
+		result = chk_dup_label(&cpr->cpr_label, clp->clp_label,
+				       clp->clp_label != NULL ? strlen(clp->clp_label) : 0);
+		if (result != 0) {
+			cbk->cb_statistics.cs_total++;
+			cbk->cb_statistics.cs_failed++;
+			goto report;
+		}
+
+		/* Delay pool label update on PS until CHK__CHECK_SCAN_PHASE__CSP_POOL_CLEANUP. */
+		cpr->cpr_delay_label = 1;
+		goto out;
+	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS:
+
+try_ps:
+		cbk->cb_statistics.cs_total++;
+		seq = ++(ins->ci_seq);
+		if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
+			cbk->cb_statistics.cs_repaired++;
+		} else {
+			result = ds_chk_regpool_upcall(seq, cpr->cpr_uuid, clue->pc_label,
+						       clue->pc_svc_clue->psc_db_clue.bcl_replicas);
+			if (result != 0)
+				cbk->cb_statistics.cs_failed++;
+			else
+				cbk->cb_statistics.cs_repaired++;
+		}
+		break;
+	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
+		cbk->cb_statistics.cs_total++;
+		/* Report the inconsistency without repair. */
+		cbk->cb_statistics.cs_ignored++;
+		break;
+	default:
+		/*
+		 * If the specified action is not applicable to the inconsistency,
+		 * then switch to interaction mode for the decision from admin.
+		 *
+		 * Fall through.
+		 */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
+		if (clp->clp_label == NULL) {
+			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
+			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS;
+			snprintf(suggested, 127,
+				 "Inconsistenct pool label: (null) (MS) vs %s (PS), "
+				 "Trust PS pool label [suggested]", clue->pc_label);
+			strs[1] = "Trust MS pool label.";
+		} else {
+			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS;
+			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
+			snprintf(suggested, 127,
+				 "Inconsistenct pool label: (%s) (MS) vs %s (PS), "
+				 "Trust MS pool label [suggested]", clp->clp_label,
+				 clue->pc_label != NULL ? clue->pc_label : "(null)");
+			strs[1] = "Trust PS pool label.";
+		}
+
+		options[2] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+		option_nr = 3;
+
+		strs[0] = suggested;
+		strs[2] = "Keep the inconsistent pool label, repair nothing.";
+
+		d_iov_set(&iovs[0], strs[0], strlen(strs[0]));
+		d_iov_set(&iovs[1], strs[1], strlen(strs[1]));
+		d_iov_set(&iovs[2], strs[2], strlen(strs[2]));
+
+		sgl.sg_nr = 3;
+		sgl.sg_nr_out = 0;
+		sgl.sg_iovs = iovs;
+
+		details = &sgl;
+		detail_nr = 1;
+		break;
+	}
+
+report:
+	cru.cru_gen = cbk->cb_gen;
+	cru.cru_cla = cla;
+	cru.cru_act = option_nr != 0 ? CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT : act;
+	cru.cru_target = 0;
+	cru.cru_rank = dss_self_rank();
+	cru.cru_option_nr = option_nr;
+	cru.cru_detail_nr = detail_nr;
+	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
+	cru.cru_cont = NULL;
+	cru.cru_obj = NULL;
+	cru.cru_dkey = NULL;
+	cru.cru_akey = NULL;
+	cru.cru_msg = "Check leader detects corrupted pool label";
+	cru.cru_options = options;
+	cru.cru_details = details;
+	cru.cru_result = result;
+
+	rc = chk_leader_report(&cru, &seq, &decision);
+
+	D_CDEBUG(result != 0 || rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_LEADER" detects corrupted label for pool "DF_UUIDF", action %u (%s), seq "
+		 DF_X64", MS label %s, PS label %s, handle_rc %d, report_rc %d, decision %d\n",
+		 DP_LEADER(ins), DP_UUID(cpr->cpr_uuid), act,
+		 option_nr ? "need interact" : "no interact", seq,
+		 clp->clp_label != NULL ? clp->clp_label : "(null)",
+		 clue->pc_label != NULL ? clue->pc_label : "(null)", result, rc, decision);
+
+	if (rc != 0 && option_nr > 0) {
+		cbk->cb_statistics.cs_total++;
+		cbk->cb_statistics.cs_failed++;
+		/* It is unnecessary to skip the pool if failed to handle label inconsistency. */
+		result = rc;
+	}
+
+	if (result != 0 || option_nr == 0)
+		goto out;
+
+	option_nr = 0;
+
+	switch (decision) {
+	default:
+		D_ERROR(DF_LEADER" got invalid decision %d for corrupted pool label"
+			DF_UUIDF" with seq "DF_X64". Ignore the inconsistency.\n",
+			DP_LEADER(ins), decision, DP_UUID(cpr->cpr_uuid), seq);
+		/*
+		 * Invalid option, ignore the inconsistency.
+		 *
+		 * Fall through.
+		 */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+		cbk->cb_statistics.cs_total++;
+		cbk->cb_statistics.cs_ignored++;
+		/* It is unnecessary to skip the pool if ignore label inconsistency. */
+		break;
+	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS;
+		result = chk_dup_label(&cpr->cpr_label, clp->clp_label,
+				       clp->clp_label != NULL ? strlen(clp->clp_label) : 0);
+		if (result != 0) {
+			cbk->cb_statistics.cs_total++;
+			cbk->cb_statistics.cs_failed++;
+			goto report;
+		}
+
+		/* Delay pool label update on PS until CHK__CHECK_SCAN_PHASE__CSP_POOL_CLEANUP. */
+		cpr->cpr_delay_label = 1;
+		goto out;
+	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
+		cbk->cb_statistics.cs_total++;
+		seq = ++(ins->ci_seq);
+		if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
+			cbk->cb_statistics.cs_repaired++;
+		} else {
+			result = ds_chk_regpool_upcall(seq, cpr->cpr_uuid, clue->pc_label,
+						       clue->pc_svc_clue->psc_db_clue.bcl_replicas);
+			if (result != 0)
+				cbk->cb_statistics.cs_failed++;
+			else
+				cbk->cb_statistics.cs_repaired++;
+		}
+		break;
+	}
+
+	goto report;
+
+out:
+	/*
+	 * If decide to delay pool label update on PS until CHK__CHECK_SCAN_PHASE__CSP_POOL_CLEANUP,
+	 * then it is unnecessary to update the leader bookmark.
+	 */
+	chk_leader_post_repair(ins, cpr->cpr_uuid, &result,
+			       cpr->cpr_delay_label ? false : true, false);
+
+	return result;
+}
+
+static int
 chk_leader_handle_pools_list(struct chk_sched_args *csa)
 {
+	struct chk_pool_filter_args	 cpfa = { 0 };
 	struct chk_property		*prop = &csa->csa_ins->ci_prop;
+	struct ds_pool_clue		*clue = NULL;
 	struct chk_list_pool		*clp = NULL;
 	struct chk_pool_rec		*cpr;
 	struct chk_pool_rec		*tmp;
@@ -1296,47 +1546,65 @@ chk_leader_handle_pools_list(struct chk_sched_args *csa)
 		goto out;
 	}
 
+	cpfa.cpfa_pool_hdl = DAOS_HDL_INVAL;
+	cpfa.cpfa_pool_nr = prop->cp_pool_nr;
+	cpfa.cpfa_pools = prop->cp_pools;
+
 	/* Firstly, handle dangling pool(s) based on the comparison between engines and MS. */
 	for (i = 0; i < clp_nr; i++) {
+		/* Skip it the pool that is not in the check list. */
+		if (chk_pool_filter(clp[i].clp_uuid, &cpfa) != 0)
+			continue;
+
 		d_iov_set(&riov, NULL, 0);
-		d_iov_set(&kiov, &clp[i].clp_uuid, sizeof(uuid_t));
+		d_iov_set(&kiov, clp[i].clp_uuid, sizeof(uuid_t));
 		rc = dbtree_lookup(csa->csa_hdl, &kiov, &riov);
 		if (rc == 0) {
 			cpr = (struct chk_pool_rec *)riov.iov_buf;
-			/*
-			 * As for whether pool service replicas and pool label match MS or not,
-			 * they will be handled in subsequent pass.
-			 */
 			cpr->cpr_exist_on_ms = 1;
-			continue;
-		}
 
-		if (rc == -DER_NONEXIST) {
-			rc = chk_leader_dangling_pool(csa->csa_ins, clp[i].clp_uuid);
+			rc = chk_leader_handle_pool_clues(cpr);
 			if (rc != 0)
 				goto out;
+
+			if (cpr->cpr_skip)
+				continue;
+
+			clue = chk_leader_locate_pool_clue(cpr);
+			if ((clue->pc_label == NULL && clp->clp_label == NULL) ||
+			    (clue->pc_label != NULL && clp->clp_label != NULL &&
+			     strcmp(clue->pc_label, clp->clp_label) == 0))
+				continue;
+
+			rc = chk_leader_handle_pool_label(cpr, clue, &clp[i]);
+		} else if (rc == -DER_NONEXIST) {
+			rc = chk_leader_dangling_pool(csa->csa_ins, clp[i].clp_uuid);
+		} else {
+			D_ERROR("Failed to verify pool "DF_UUIDF" existence with %s: "DF_RC"\n",
+				DP_UUID(clp[i].clp_uuid), (prop->cp_flags &
+				CHK__CHECK_FLAG__CF_FAILOUT) ? "failout" : "continue", DP_RC(rc));
+			if (!(prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT))
+				rc = 0;
 		}
 
-		D_ERROR("Failed to verify pool "DF_UUIDF" existence with %s: "DF_RC"\n",
-			DP_UUID(clp[i].clp_uuid), (prop->cp_flags &
-			CHK__CHECK_FLAG__CF_FAILOUT) ? "failout" : "continue", DP_RC(rc));
-
-		if (prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT)
+		if (rc != 0)
 			goto out;
 	}
 
-	rc = 0;
-
 	d_list_for_each_entry_safe(cpr, tmp, &csa->csa_list, cpr_link) {
+		if (cpr->cpr_exist_on_ms || cpr->cpr_skip)
+			continue;
+
 		rc = chk_leader_handle_pool_clues(cpr);
 		if (rc != 0)
 			goto out;
 
-		if (!cpr->cpr_exist_on_ms && !cpr->cpr_skip) {
-			rc = chk_leader_orphan_pool(cpr);
-			if (rc != 0)
-				goto out;
-		}
+		if (cpr->cpr_skip)
+			continue;
+
+		rc = chk_leader_orphan_pool(cpr);
+		if (rc != 0)
+			goto out;
 	}
 
 out:
@@ -1530,7 +1798,7 @@ out:
 static int
 chk_leader_start_prepare(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *ranks,
 			 uint32_t policy_nr, struct chk_policy *policies,
-			 uint32_t pool_nr, uuid_t pools[], int phase,
+			 int pool_nr, uuid_t pools[], int phase,
 			 uint32_t *flags, d_rank_list_t **rlist)
 {
 	struct chk_property	*prop = &ins->ci_prop;
@@ -1671,13 +1939,9 @@ chk_leader_dup_clue(struct ds_pool_clue **tgt, struct ds_pool_clue *src)
 		}
 	}
 
-	if (src->pc_label != NULL) {
-		D_ALLOC(label, src->pc_label_len + 1);
-		if (label == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		memcpy(label, src->pc_label, src->pc_label_len);
-	}
+	rc = chk_dup_label(&label, src->pc_label, src->pc_label_len);
+	if (rc != 0)
+		goto out;
 
 	memcpy(clue, src, sizeof(*clue));
 	clue->pc_svc_clue = svc;
@@ -1761,7 +2025,7 @@ out:
 int
 chk_leader_start(uint32_t rank_nr, d_rank_t *ranks,
 		 uint32_t policy_nr, struct chk_policy *policies,
-		 uint32_t pool_nr, uuid_t pools[], uint32_t flags, int32_t phase)
+		 int pool_nr, uuid_t pools[], uint32_t flags, int phase)
 {
 	struct chk_instance	*ins = chk_leader;
 	struct chk_property	*prop = &ins->ci_prop;
@@ -1909,7 +2173,7 @@ out_log:
 	ins->ci_starting = 0;
 
 	if (rc == 0) {
-		D_INFO("Leader %s check on %u ranks for %u pools with "
+		D_INFO("Leader %s check on %u ranks for %d pools with "
 		       "flags %x, phase %d, leader %u, gen "DF_X64"\n",
 		       (flags & CHK__CHECK_FLAG__CF_RESET) ? "start" : "restart",
 		       rank_nr, pool_nr, flags, phase, myrank, cbk->cb_gen);
@@ -1921,7 +2185,7 @@ out_log:
 		else if (prop->cp_pool_nr > 0)
 			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
 	} else if (rc != -DER_ALREADY) {
-		D_ERROR("Leader failed to start check on %u ranks for %u pools with "
+		D_ERROR("Leader failed to start check on %u ranks for %d pools with "
 			"flags %x, phase %d, leader %u, gen "DF_X64": "DF_RC"\n",
 			rank_nr, pool_nr, flags, phase, myrank, cbk->cb_gen, DP_RC(rc));
 	}
@@ -1947,7 +2211,7 @@ chk_leader_stop_cb(void *args, uint32_t rank, uint32_t phase, int result, void *
 }
 
 int
-chk_leader_stop(uint32_t pool_nr, uuid_t pools[])
+chk_leader_stop(int pool_nr, uuid_t pools[])
 {
 	struct chk_instance	*ins = chk_leader;
 	struct chk_property	*prop = &ins->ci_prop;
@@ -2003,7 +2267,7 @@ out:
 	ins->ci_stopping = 0;
 
 	if (rc == 0) {
-		D_INFO("Leader stopped check with gen "DF_X64" for %u pools\n",
+		D_INFO("Leader stopped check with gen "DF_X64" for %d pools\n",
 		       cbk->cb_gen, pool_nr > 0 ? pool_nr : prop->cp_pool_nr);
 
 		if (pool_nr > 0)
@@ -2011,7 +2275,7 @@ out:
 		else if (prop->cp_pool_nr > 0)
 			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
 	} else {
-		D_ERROR("Leader failed to stop check with gen "DF_X64" for %u pools: "DF_RC"\n",
+		D_ERROR("Leader failed to stop check with gen "DF_X64" for %d pools: "DF_RC"\n",
 			cbk->cb_gen, pool_nr > 0 ? pool_nr : prop->cp_pool_nr, DP_RC(rc));
 	}
 
@@ -2102,7 +2366,7 @@ out:
 }
 
 int
-chk_leader_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+chk_leader_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		 chk_query_pool_cb_t pool_cb, void *buf)
 {
 	struct chk_instance	*ins = chk_leader;
@@ -2159,7 +2423,7 @@ chk_leader_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 out:
 	chk_csa_put(csa);
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "Leader query check with gen "DF_X64" for %u pools: "DF_RC"\n",
+		 "Leader query check with gen "DF_X64" for %d pools: "DF_RC"\n",
 		 cbk->cb_gen, pool_nr, DP_RC(rc));
 	return rc;
 }

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -204,8 +204,8 @@ chk_sg_rpc_prepare(d_rank_t rank, crt_opcode_t opc, crt_rpc_t **req)
 
 int
 chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
-		 uint32_t policy_nr, struct chk_policy *policies, uint32_t pool_nr,
-		 uuid_t pools[], uint32_t flags, int32_t phase, d_rank_t leader,
+		 uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
+		 uuid_t pools[], uint32_t flags, int phase, d_rank_t leader,
 		 chk_co_rpc_cb_t start_cb, void *args)
 {
 	struct chk_co_rpc_priv	 ccrp;
@@ -276,7 +276,7 @@ out:
 }
 
 int
-chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
 		chk_co_rpc_cb_t stop_cb, void *args)
 {
 	struct chk_co_rpc_priv	 ccrp;
@@ -320,14 +320,14 @@ out:
 		crt_req_decref(req);
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "Rank %u stop DAOS check with gen "DF_X64", pool_nr %u: "DF_RC"\n",
+		 "Rank %u stop DAOS check with gen "DF_X64", pool_nr %d: "DF_RC"\n",
 		 dss_self_rank(), gen, pool_nr, DP_RC(rc));
 
 	return rc;
 }
 
 int
-chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t pool_nr, uuid_t pools[],
+chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
 		 chk_co_rpc_cb_t query_cb, void *args)
 {
 	struct chk_co_rpc_priv	 ccrp;
@@ -379,7 +379,7 @@ out:
 		crt_req_decref(req);
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "Rank %u query DAOS check with gen "DF_X64", pool_nr %u: "DF_RC"\n",
+		 "Rank %u query DAOS check with gen "DF_X64", pool_nr %d: "DF_RC"\n",
 		 dss_self_rank(), gen, pool_nr, DP_RC(rc));
 
 	return rc;
@@ -461,7 +461,7 @@ out:
 	return rc;
 }
 
-int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int32_t result,
+int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int result,
 		      d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont,
 		      daos_unit_oid_t *obj, daos_key_t *dkey, daos_key_t *akey, char *msg,
 		      uint32_t option_nr, uint32_t *options, uint32_t detail_nr, d_sg_list_t *details,

--- a/src/chk/chk_upcall.c
+++ b/src/chk/chk_upcall.c
@@ -102,7 +102,7 @@ out:
 }
 
 int
-chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int32_t result,
+chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int result,
 		  d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont, daos_unit_oid_t *obj,
 		  daos_key_t *dkey, daos_key_t *akey, char *msg, uint32_t option_nr,
 		  uint32_t *options, uint32_t detail_nr, d_sg_list_t *details)

--- a/src/engine/drpc_ras.c
+++ b/src/engine/drpc_ras.c
@@ -438,6 +438,11 @@ out_req:
 	return rc;
 }
 
+/*
+ * XXX: Register the pool information on MS via DRPC_METHOD_CHK_REG_POOL:
+ *	if the pool does not exist, then add it on MS; otherwise, refresh
+ *	the pool service replicas and label information.
+ */
 int
 ds_chk_regpool_upcall(uint64_t seq, uuid_t uuid, char *label, d_rank_list_t *svcreps)
 {

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -513,6 +513,9 @@ daos_label_is_valid(const char *label)
 /* default policy string */
 #define DAOS_PROP_POLICYSTR_DEFAULT	"type=io_size"
 
+/* For the case of no label is set for the pool. */
+#define DAOS_PROP_NO_PO_LABEL		"pool_label_not_set"
+
 /** daos properties, for pool or container */
 typedef struct {
 	/** number of entries */

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -74,12 +74,12 @@ typedef int (*chk_query_pool_cb_t)(struct chk_query_pool_shard *shard, uint32_t 
 typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy *policies, int cnt, uint32_t flags);
 
 int chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		     struct chk_policy *policies, uint32_t pool_nr, uuid_t pools[],
-		     uint32_t flags, int32_t phase);
+		     struct chk_policy *policies, int pool_nr, uuid_t pools[],
+		     uint32_t flags, int phase);
 
-int chk_leader_stop(uint32_t pool_nr, uuid_t pools[]);
+int chk_leader_stop(int pool_nr, uuid_t pools[]);
 
-int chk_leader_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+int chk_leader_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		     chk_query_pool_cb_t pool_cb, void *buf);
 
 int chk_leader_prop(chk_prop_cb_t prop_cb, void *buf);

--- a/src/mgmt/srv_chk.c
+++ b/src/mgmt/srv_chk.c
@@ -15,7 +15,7 @@
 
 int
 ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		    Mgmt__CheckInconsistPolicy **policies, uint32_t pool_nr, uuid_t pools[],
+		    Mgmt__CheckInconsistPolicy **policies, int32_t pool_nr, uuid_t pools[],
 		    uint32_t flags, int32_t phase)
 {
 	struct chk_policy *ply = NULL;
@@ -42,13 +42,13 @@ out:
 }
 
 int
-ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[])
+ds_mgmt_check_stop(int32_t pool_nr, uuid_t pools[])
 {
 	return chk_leader_stop(pool_nr, pools);
 }
 
 int
-ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+ds_mgmt_check_query(int32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		    chk_query_pool_cb_t pool_cb, void *buf)
 {
 	return chk_leader_query(pool_nr, pools, head_cb, pool_cb, buf);

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -112,10 +112,10 @@ int ds_mgmt_cont_set_owner(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 
 /** srv_chk.c */
 int ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-			Mgmt__CheckInconsistPolicy **policies, uint32_t pool_nr, uuid_t pools[],
-			uint32_t flags, int32_t phase);
-int ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[]);
-int ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+			Mgmt__CheckInconsistPolicy **policies, int pool_nr, uuid_t pools[],
+			uint32_t flags, int phase);
+int ds_mgmt_check_stop(int pool_nr, uuid_t pools[]);
+int ds_mgmt_check_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 			chk_query_pool_cb_t pool_cb, void *buf);
 int ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf);
 int ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all);

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -582,20 +582,20 @@ mock_ds_mgmt_pool_upgrade_setup(void)
 
 int
 ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		    Mgmt__CheckInconsistPolicy **policies, uint32_t pool_nr, uuid_t pools[],
-		    uint32_t flags, int32_t phase)
+		    Mgmt__CheckInconsistPolicy **policies, int pool_nr, uuid_t pools[],
+		    uint32_t flags, int phase)
 {
 	return 0;
 }
 
 int
-ds_mgmt_check_stop(uint32_t pool_nr, uuid_t pools[])
+ds_mgmt_check_stop(int pool_nr, uuid_t pools[])
 {
 	return 0;
 }
 
 int
-ds_mgmt_check_query(uint32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+ds_mgmt_check_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 		    chk_query_pool_cb_t pool_cb, void *buf)
 {
 	return 0;

--- a/src/pool/srv_layout.c
+++ b/src/pool/srv_layout.c
@@ -44,7 +44,7 @@ RDB_STRING_KEY(ds_pool_attr_, user);
 struct daos_prop_entry pool_prop_entries_default[DAOS_PROP_PO_NUM] = {
 	{
 		.dpe_type	= DAOS_PROP_PO_LABEL,
-		.dpe_str	= "pool_label_not_set",
+		.dpe_str	= DAOS_PROP_NO_PO_LABEL,
 	}, {
 		.dpe_type	= DAOS_PROP_PO_SPACE_RB,
 		.dpe_val	= 0,

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -67,12 +67,16 @@ pool_glance(uuid_t uuid, char *path, struct ds_pool_clue *clue_out)
 			D_GOTO(out_root, rc = -DER_IO);
 		}
 
-		D_ALLOC(clue_out->pc_label, value.iov_len + 1);
-		if (clue_out->pc_label == NULL)
-			D_GOTO(out_root, rc = -DER_NOMEM);
+		if (memcmp(DAOS_PROP_NO_PO_LABEL, value.iov_buf, value.iov_len) == 0) {
+			clue_out->pc_label_len = 0;
+		} else {
+			D_ALLOC(clue_out->pc_label, value.iov_len + 1);
+			if (clue_out->pc_label == NULL)
+				D_GOTO(out_root, rc = -DER_NOMEM);
 
-		clue_out->pc_label_len = value.iov_len;
-		memcpy(clue_out->pc_label, value.iov_buf, value.iov_len);
+			clue_out->pc_label_len = value.iov_len;
+			memcpy(clue_out->pc_label, value.iov_buf, value.iov_len);
+		}
 	} else if (rc == -DER_NONEXIST) {
 		clue_out->pc_label_len = 0;
 	} else {


### PR DESCRIPTION
The pool label is mainly used by MS to lookup pool UUID by label.
The PS recorded pool label is some kind of the backup. So if the
MS known pool label does not match the pool label recorded by PS,
then trust MS as long as MS known pool label is not NULL. Related
repair will not happen on check leader, instead, it will be done
on the PS leader during CHK__CHECK_SCAN_PHASE__CSP_POOL_CLEANUP.

If the admin wants to recover pool label on MS with the pool info
on PS, then it will use DRPC_METHOD_CHK_REG_POOL drpc upcall.

The patch also contains some other fixes:

1. Only handle dangling pool within the given pools check list.

2. Some code cleanup for "uint32_t" and "int32_t" usage in chk.

Signed-off-by: Fan Yong <fan.yong@intel.com>

Required-githooks: true