### PR TITLE
DAOS-9989 test: FIx enabling provider-testing branches

### DIFF
--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -193,8 +193,8 @@ set_local_repo() {
     version=${version%%.*}
     if [ "$repo_server" = "artifactory" ] &&
        [ -z "$(rpm_test_version)" ] &&
-       { [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]] ||
-         [[ ${CHANGE_TARGET:-$BRANCH_NAME} != provider-testing* ]]; }; then
+       [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]] &&
+       [[ ${CHANGE_TARGET:-$BRANCH_NAME} != provider-testing* ]]; then
         # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
         # used for daos packages
         dnf -y config-manager \


### PR DESCRIPTION
Fix allowing provider-testing branches to use pre-built daos RPMs.

Skip-unit-tests: true
Test-tag: test_always_passes

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>