### PR TITLE
DAOS-10399 tests: Remove 10-sec crt_timeout default

### DIFF
--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -107,7 +107,6 @@ class DaosServerYamlParameters(YamlParameters):
         log_dir = os.environ.get("DAOS_TEST_LOG_DIR", "/tmp")
 
         self.provider = BasicParameter(None, default_provider)
-        self.crt_timeout = BasicParameter(None, 10)
         self.hyperthreads = BasicParameter(None, False)
         self.socket_dir = BasicParameter(None, "/var/run/daos_server")
         # Auto-calculate if unset or set to zero


### PR DESCRIPTION
Remove the 10-second default value for crt_timeout.

Signed-off-by: Li Wei <wei.g.li@intel.com>