### PR TITLE
DAOS-10813 control: Add block device details to topology (#9313)

### DIFF
--- a/src/control/lib/hardware/hwloc/bindings.go
+++ b/src/control/lib/hardware/hwloc/bindings.go
@@ -91,6 +91,11 @@ hwloc_obj_t node_get_child(hwloc_obj_t node, int idx)
 	}
 	return child;
 }
+
+const char * node_get_subtype(hwloc_obj_t node)
+{
+	return node->subtype;
+}
 #else
 int topo_setFlags(hwloc_topology_t topology)
 {
@@ -116,12 +121,18 @@ hwloc_obj_t node_get_child(hwloc_obj_t node, int idx)
 {
 	return node->children[idx];
 }
+
+const char * node_get_subtype(hwloc_obj_t node)
+{
+	return "";
+}
 #endif
 */
 import "C"
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"unsafe"
 
@@ -372,6 +383,17 @@ func (o *object) objType() int {
 	return int(o.cObj._type)
 }
 
+func (o *object) objSubTypeString() string {
+	o.topo.RLock()
+	defer o.topo.RUnlock()
+
+	typeStr := C.GoString(C.node_get_subtype(o.cObj))
+	if typeStr == "" {
+		typeStr = "unknown"
+	}
+	return typeStr
+}
+
 func (o *object) objTypeString() string {
 	switch o.objType() {
 	case objTypeNUMANode:
@@ -452,6 +474,69 @@ func (o *object) pciAddr() (*hardware.PCIAddress, error) {
 	}
 	return hardware.NewPCIAddress(fmt.Sprintf("%04x:%02x:%02x.%01x", pciDevAttr.domain, pciDevAttr.bus,
 		pciDevAttr.dev, pciDevAttr._func))
+}
+
+func (o *object) blockDevice() (*hardware.BlockDevice, error) {
+	o.topo.RLock()
+	defer o.topo.RUnlock()
+
+	devType, err := o.osDevType()
+	if err != nil {
+		return nil, err
+	}
+	if devType != osDevTypeBlock {
+		return nil, errors.Errorf("device %q is not a block device", o.name())
+	}
+
+	bd := &hardware.BlockDevice{
+		Name: o.name(),
+		Type: o.objSubTypeString(),
+	}
+	// https://www.open-mpi.org/projects/hwloc/doc/v2.7.0/a00365.php (OS Device Information)
+	stringFields := map[string]*string{
+		"LinuxDeviceID": &bd.LinuxDeviceID,
+		"Vendor":        &bd.Vendor,
+		"Model":         &bd.Model,
+		"Revision":      &bd.Revision,
+		"SerialNumber":  &bd.SerialNumber,
+	}
+	uint64Fields := map[string]*uint64{
+		"Size":       &bd.Size,
+		"SectorSize": &bd.SectorSize,
+	}
+
+	getVal := func(key string) string {
+		keyStr := C.CString(key)
+		defer C.free(unsafe.Pointer(keyStr))
+		cVal := C.hwloc_obj_get_info_by_name(o.cObj, keyStr)
+		if cVal == nil {
+			return ""
+		}
+		return C.GoString(cVal)
+	}
+
+	for key, ptr := range stringFields {
+		goVal := getVal(key)
+		if goVal == "" {
+			continue
+		}
+
+		*ptr = goVal
+	}
+
+	for key, ptr := range uint64Fields {
+		goVal := getVal(key)
+		if goVal == "" {
+			continue
+		}
+		size, err := strconv.ParseUint(goVal, 10, 64)
+		if err != nil {
+			return nil, errors.Errorf("device %q has invalid size %q", o.name(), goVal)
+		}
+		*ptr = size
+	}
+
+	return bd, nil
 }
 
 func (o *object) linkSpeed() (float64, error) {

--- a/src/control/lib/hardware/hwloc/provider_test.go
+++ b/src/control/lib/hardware/hwloc/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common/test"
@@ -76,6 +77,15 @@ func TestHwloc_Cleanup(t *testing.T) {
 	}
 }
 
+func hwlocVersion() (major, minor, patch uint) {
+	apiVersion := (&api{}).runtimeVersion()
+	major = apiVersion >> 16
+	minor = (apiVersion & 0xf00) >> 8
+	patch = apiVersion & 0x00f
+
+	return
+}
+
 func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
 	testdataDir := filepath.Join(filepath.Dir(filename), "testdata")
@@ -85,6 +95,371 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 		hwlocXMLFile string
 		expResult    *hardware.Topology
 	}{
+		"tds-0002": {
+			hwlocXMLFile: filepath.Join(testdataDir, "tds-0002.xml"),
+			expResult: &hardware.Topology{
+				NUMANodes: map[uint]*hardware.NUMANode{
+					0: hardware.MockNUMANode(0, 26).
+						WithPCIBuses(
+							[]*hardware.PCIBus{
+								hardware.NewPCIBus(0, 0, 2),
+								hardware.NewPCIBus(0, 3, 5),
+								hardware.NewPCIBus(0, 9, 0xb),
+								hardware.NewPCIBus(0, 0x7c, 0x7c),
+								hardware.NewPCIBus(0, 0x7d, 0x7d),
+							},
+						).
+						WithDevices(
+							[]*hardware.PCIDevice{
+								{
+									Name:    "sdb",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:00:11.5"),
+								},
+								{
+									Name:    "sda",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:00:11.5"),
+								},
+								{
+									Name:      "ens259f0",
+									Type:      hardware.DeviceTypeNetInterface,
+									PCIAddr:   *hardware.MustNewPCIAddress("0000:04:00.0"),
+									LinkSpeed: 7.876923084259033,
+								},
+								{
+									Name:      "ens259f1",
+									Type:      hardware.DeviceTypeNetInterface,
+									PCIAddr:   *hardware.MustNewPCIAddress("0000:04:00.1"),
+									LinkSpeed: 7.876923084259033,
+								},
+								{
+									Name:      "hsn0",
+									Type:      hardware.DeviceTypeNetInterface,
+									PCIAddr:   *hardware.MustNewPCIAddress("0000:0a:00.0"),
+									LinkSpeed: 31.507692337036133,
+								},
+								{
+									Name:    "nvme0n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:7c:00.5"),
+								},
+								{
+									Name:    "nvme3n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:7c:00.5"),
+								},
+								{
+									Name:    "nvme2n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:7c:00.5"),
+								},
+								{
+									Name:    "nvme1n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:7c:00.5"),
+								},
+								{
+									Name:    "nvme6n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:7d:00.5"),
+								},
+								{
+									Name:    "nvme5n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:7d:00.5"),
+								},
+								{
+									Name:    "nvme4n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:7d:00.5"),
+								},
+								{
+									Name:    "nvme7n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:7d:00.5"),
+								},
+							},
+						).
+						WithBlockDevices(
+							[]*hardware.BlockDevice{
+								{
+									Name:          "sdb",
+									Type:          "Disk",
+									Size:          468851544,
+									SectorSize:    512,
+									LinuxDeviceID: "8:16",
+									Model:         "LVM PV mak7fx-KZd1-BqaJ-VODO-GudX-kbdj-h86bq6 on /dev/sdb",
+									Revision:      "XC311132",
+									SerialNumber:  "BTYH10910CEU480K",
+								},
+								{
+									Name:          "sda",
+									Type:          "Disk",
+									Size:          468851544,
+									SectorSize:    512,
+									LinuxDeviceID: "8:0",
+									Model:         "LVM PV 0IfIxC-S3jO-PW2h-h1a2-5dT8-T2y7-AsiZi5 on /dev/sda",
+									Revision:      "XC311132",
+									SerialNumber:  "BTYH10930Y18480K",
+								},
+								{
+									Name:          "nvme0n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:1",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R511648",
+								},
+								{
+									Name:          "nvme3n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:8",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R510280",
+								},
+								{
+									Name:          "nvme2n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:4",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R511669",
+								},
+								{
+									Name:          "nvme1n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:0",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R510279",
+								},
+								{
+									Name:          "nvme6n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:7",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R516328",
+								},
+								{
+									Name:          "nvme5n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:6",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R516079",
+								},
+								{
+									Name:          "nvme4n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:9",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R516306",
+								},
+								{
+									Name:          "nvme7n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:10",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R516341",
+								},
+								{
+									Name:          "pmem0",
+									Type:          "NVDIMM",
+									Size:          4186568704,
+									SectorSize:    512,
+									LinuxDeviceID: "259:16",
+								},
+							},
+						),
+					1: hardware.MockNUMANode(1, 26, 26).
+						WithPCIBuses(
+							[]*hardware.PCIBus{
+								hardware.NewPCIBus(0, 0x81, 0x81),
+								hardware.NewPCIBus(0, 0x82, 0x84),
+								hardware.NewPCIBus(0, 0xfa, 0xfa),
+							},
+						).
+						WithDevices(
+							[]*hardware.PCIDevice{
+								{
+									Name:      "hsn1",
+									Type:      hardware.DeviceTypeNetInterface,
+									PCIAddr:   *hardware.MustNewPCIAddress("0000:83:00.0"),
+									LinkSpeed: 31.507692337036133,
+								},
+								{
+									Name:    "nvme11n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:81:00.5"),
+								},
+								{
+									Name:    "nvme9n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:81:00.5"),
+								},
+								{
+									Name:    "nvme10n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:81:00.5"),
+								},
+								{
+									Name:    "nvme8n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:81:00.5"),
+								},
+								{
+									Name:    "nvme15n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:fa:00.5"),
+								},
+								{
+									Name:    "nvme14n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:fa:00.5"),
+								},
+								{
+									Name:    "nvme13n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:fa:00.5"),
+								},
+								{
+									Name:    "nvme12n1",
+									Type:    hardware.DeviceTypeBlock,
+									PCIAddr: *hardware.MustNewPCIAddress("0000:fa:00.5"),
+								},
+							},
+						).
+						WithBlockDevices(
+							[]*hardware.BlockDevice{
+								{
+									Name:          "nvme11n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:11",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R510293",
+								},
+								{
+									Name:          "nvme9n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:13",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R511639",
+								},
+								{
+									Name:          "nvme10n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:5",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R511666",
+								},
+								{
+									Name:          "nvme8n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:12",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R510298",
+								},
+								{
+									Name:          "nvme15n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:15",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R510256",
+								},
+								{
+									Name:          "nvme14n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:2",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R510311",
+								},
+								{
+									Name:          "nvme13n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:14",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R510281",
+								},
+								{
+									Name:          "nvme12n1",
+									Type:          "Disk",
+									Size:          15000928256,
+									SectorSize:    512,
+									LinuxDeviceID: "259:3",
+									Vendor:        "Samsung",
+									Model:         "SAMSUNG MZWLR15THALA-00007",
+									Revision:      "MPK92B5Q",
+									SerialNumber:  "S6EXNE0R511647",
+								},
+								{
+									Name:          "pmem1",
+									Type:          "NVDIMM",
+									Size:          4186568704,
+									SectorSize:    512,
+									LinuxDeviceID: "259:17",
+								},
+							},
+						),
+				},
+			},
+		},
 		"boro-84": {
 			hwlocXMLFile: filepath.Join(testdataDir, "boro-84.xml"),
 			expResult: &hardware.Topology{
@@ -133,6 +508,18 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 									Name:    "sda",
 									Type:    hardware.DeviceTypeBlock,
 									PCIAddr: *hardware.MustNewPCIAddress("0000:00:11.5"),
+								},
+							},
+						).
+						WithBlockDevices(
+							[]*hardware.BlockDevice{
+								{
+									Name:          "sda",
+									Type:          "Disk",
+									LinuxDeviceID: "8:0",
+									Model:         "INTEL_SSDSCKKI256G8",
+									Revision:      "LHF001D",
+									SerialNumber:  "BTLA80121CE5256J",
 								},
 							},
 						),
@@ -189,6 +576,18 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 									Name:    "sda",
 									Type:    hardware.DeviceTypeBlock,
 									PCIAddr: *hardware.MustNewPCIAddress("0000:00:11.5"),
+								},
+							},
+						).
+						WithBlockDevices(
+							[]*hardware.BlockDevice{
+								{
+									Name:          "sda",
+									Type:          "Disk",
+									LinuxDeviceID: "8:0",
+									Model:         "INTEL_SSDSCKKI256G8",
+									Revision:      "LHF001D",
+									SerialNumber:  "BTLA80230PFN256J",
 								},
 							},
 						),
@@ -272,6 +671,26 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 									PCIAddr: *hardware.MustNewPCIAddress("0000:00:1f.2"),
 								},
 							},
+						).
+						WithBlockDevices(
+							[]*hardware.BlockDevice{
+								{
+									Name:          "sda",
+									Type:          "Disk",
+									LinuxDeviceID: "8:0",
+									Model:         "TS64GMTS400",
+									Revision:      "N1126I",
+									SerialNumber:  "C196500679",
+								},
+								{
+									Name:          "sdb",
+									Type:          "Disk",
+									LinuxDeviceID: "8:16",
+									Model:         "TS64GMTS400",
+									Revision:      "N1126I",
+									SerialNumber:  "C307450241",
+								},
+							},
 						),
 					1: hardware.MockNUMANode(1, 8, 8).
 						WithPCIBuses(
@@ -336,6 +755,26 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 										PCIAddr: *hardware.MustNewPCIAddress("0000:00:1f.2"),
 									},
 								},
+							).
+							WithBlockDevices(
+								[]*hardware.BlockDevice{
+									{
+										Name:          "sda",
+										Type:          "Disk",
+										LinuxDeviceID: "8:0",
+										Model:         "CentOS_Linux_7-0_SSD",
+										Revision:      "F.ZDSG90",
+										SerialNumber:  "RSQDEVQ5RVR45EJJ1V33",
+									},
+									{
+										Name:          "sr0",
+										Type:          "Removable Media Device",
+										LinuxDeviceID: "11:0",
+										Model:         "Virtual_DVD-ROM__1_",
+										Revision:      "FWR1",
+										SerialNumber:  "-_31415B265",
+									},
+								},
 							)
 						return node
 					}(),
@@ -356,12 +795,23 @@ func TestHwlocProvider_GetTopology_Samples(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
+			hwlocMajor, _, _ := hwlocVersion()
 			result, err := provider.GetTopology(ctx)
 			if err != nil {
-				t.Fatal(err)
+				t.Skipf("failed to load %s with hwloc %d.x: %s", tc.hwlocXMLFile, hwlocMajor, err)
 			}
 
-			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+			cmpOpts := []cmp.Option{
+				cmpopts.IgnoreFields(hardware.BlockDevice{}, "BackingDevice"),
+				cmpopts.IgnoreFields(hardware.PCIDevice{}, "BlockDevice"),
+			}
+
+			if hwlocMajor < 2 {
+				// hwloc 1.x doesn't add the secondary type field
+				cmpOpts = append(cmpOpts, cmpopts.IgnoreFields(hardware.BlockDevice{}, "Type"))
+			}
+
+			if diff := cmp.Diff(tc.expResult, result, cmpOpts...); diff != "" {
 				t.Errorf("(-want, +got)\n%s\n", diff)
 			}
 		})

--- a/src/control/lib/hardware/hwloc/testdata/tds-0002.xml
+++ b/src/control/lib/hardware/hwloc/testdata/tds-0002.xml
@@ -1,0 +1,1039 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0x000000ff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x000000ff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x000000ff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003" gp_index="1">
+    <info name="DMIProductName" value="M50CYP2SBSTD"/>
+    <info name="DMIProductVersion" value="LCY2208LRAXXZ07"/>
+    <info name="DMIBoardVendor" value="Intel Corporation"/>
+    <info name="DMIBoardName" value="M50CYP2SBSTD"/>
+    <info name="DMIBoardVersion" value="K42381-351"/>
+    <info name="DMIBoardAssetTag" value="Base Board Asset Tag"/>
+    <info name="DMIChassisVendor" value="..............................."/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value=".................."/>
+    <info name="DMIChassisAssetTag" value="...................."/>
+    <info name="DMIBIOSVendor" value="Intel Corporation"/>
+    <info name="DMIBIOSVersion" value="SE5C620.86B.01.01.0005.CDS01.2202160810"/>
+    <info name="DMIBIOSDate" value="02/16/2022"/>
+    <info name="DMISysVendor" value="Intel Corporation"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="5.3.18-59.37-default"/>
+    <info name="OSVersion" value="#1 SMP Mon Nov 22 12:29:04 UTC 2021 (d10168e)"/>
+    <info name="HostName" value="daos-0002"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.4.1"/>
+    <info name="ProcessName" value="lstopo-no-graphics"/>
+    <object type="Package" os_index="0" cpuset="0x00003fff,0xfff00000,0x03ffffff" complete_cpuset="0x00003fff,0xfff00000,0x03ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
+      <info name="CPUVendor" value="GenuineIntel"/>
+      <info name="CPUFamilyNumber" value="6"/>
+      <info name="CPUModelNumber" value="106"/>
+      <info name="CPUModel" value="Intel(R) Xeon(R) Gold 5320 CPU @ 2.20GHz"/>
+      <info name="CPUStepping" value="6"/>
+      <object type="NUMANode" os_index="0" cpuset="0x00003fff,0xfff00000,0x03ffffff" complete_cpuset="0x00003fff,0xfff00000,0x03ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="318" local_memory="269743038464">
+        <page_type size="4096" count="65855234"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" cpuset="0x00003fff,0xfff00000,0x03ffffff" complete_cpuset="0x00003fff,0xfff00000,0x03ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="40894464" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" cpuset="0x00100000,0x00000001" complete_cpuset="0x00100000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00100000,0x00000001" complete_cpuset="0x00100000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00100000,0x00000001" complete_cpuset="0x00100000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00100000,0x00000001" complete_cpuset="0x00100000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="4"/>
+                <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="266"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00200000,0x00000002" complete_cpuset="0x00200000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00200000,0x00000002" complete_cpuset="0x00200000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00200000,0x00000002" complete_cpuset="0x00200000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="12" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00200000,0x00000002" complete_cpuset="0x00200000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9">
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10"/>
+                <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="267"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00400000,0x00000004" complete_cpuset="0x00400000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="18" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00400000,0x00000004" complete_cpuset="0x00400000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00400000,0x00000004" complete_cpuset="0x00400000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00400000,0x00000004" complete_cpuset="0x00400000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14">
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15"/>
+                <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="268"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00800000,0x00000008" complete_cpuset="0x00800000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00800000,0x00000008" complete_cpuset="0x00800000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00800000,0x00000008" complete_cpuset="0x00800000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00800000,0x00000008" complete_cpuset="0x00800000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19">
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20"/>
+                <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="269"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x01000000,0x00000010" complete_cpuset="0x01000000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x01000000,0x00000010" complete_cpuset="0x01000000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x01000000,0x00000010" complete_cpuset="0x01000000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x01000000,0x00000010" complete_cpuset="0x01000000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="24">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25"/>
+                <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="270"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x02000000,0x00000020" complete_cpuset="0x02000000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x02000000,0x00000020" complete_cpuset="0x02000000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x02000000,0x00000020" complete_cpuset="0x02000000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x02000000,0x00000020" complete_cpuset="0x02000000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29">
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="30"/>
+                <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="271"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x04000000,0x00000040" complete_cpuset="0x04000000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x04000000,0x00000040" complete_cpuset="0x04000000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="36" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x04000000,0x00000040" complete_cpuset="0x04000000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x04000000,0x00000040" complete_cpuset="0x04000000,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34">
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35"/>
+                <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="272"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x08000000,0x00000080" complete_cpuset="0x08000000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x08000000,0x00000080" complete_cpuset="0x08000000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x08000000,0x00000080" complete_cpuset="0x08000000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="42" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x08000000,0x00000080" complete_cpuset="0x08000000,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39">
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40"/>
+                <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="273"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x10000000,0x00000100" complete_cpuset="0x10000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="48" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x10000000,0x00000100" complete_cpuset="0x10000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x10000000,0x00000100" complete_cpuset="0x10000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x10000000,0x00000100" complete_cpuset="0x10000000,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45"/>
+                <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="274"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x20000000,0x00000200" complete_cpuset="0x20000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x20000000,0x00000200" complete_cpuset="0x20000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x20000000,0x00000200" complete_cpuset="0x20000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x20000000,0x00000200" complete_cpuset="0x20000000,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49">
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50"/>
+                <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="275"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x40000000,0x00000400" complete_cpuset="0x40000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x40000000,0x00000400" complete_cpuset="0x40000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x40000000,0x00000400" complete_cpuset="0x40000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x40000000,0x00000400" complete_cpuset="0x40000000,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="54">
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55"/>
+                <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="276"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x80000000,0x00000800" complete_cpuset="0x80000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x80000000,0x00000800" complete_cpuset="0x80000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="61" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x80000000,0x00000800" complete_cpuset="0x80000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="62" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x80000000,0x00000800" complete_cpuset="0x80000000,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="59">
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="60"/>
+                <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="277"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000001,,0x00001000" complete_cpuset="0x00000001,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="68" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000001,,0x00001000" complete_cpuset="0x00000001,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="66" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000001,,0x00001000" complete_cpuset="0x00000001,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="67" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00000001,,0x00001000" complete_cpuset="0x00000001,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="64">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65"/>
+                <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="278"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000002,,0x00002000" complete_cpuset="0x00000002,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="73" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000002,,0x00002000" complete_cpuset="0x00000002,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000002,,0x00002000" complete_cpuset="0x00000002,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="72" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00000002,,0x00002000" complete_cpuset="0x00000002,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="69">
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70"/>
+                <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="279"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000004,,0x00004000" complete_cpuset="0x00000004,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="78" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000004,,0x00004000" complete_cpuset="0x00000004,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000004,,0x00004000" complete_cpuset="0x00000004,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00000004,,0x00004000" complete_cpuset="0x00000004,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="74">
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75"/>
+                <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="280"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000008,,0x00008000" complete_cpuset="0x00000008,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000008,,0x00008000" complete_cpuset="0x00000008,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000008,,0x00008000" complete_cpuset="0x00000008,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00000008,,0x00008000" complete_cpuset="0x00000008,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="79">
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="80"/>
+                <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="281"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000010,,0x00010000" complete_cpuset="0x00000010,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="88" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000010,,0x00010000" complete_cpuset="0x00000010,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="86" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000010,,0x00010000" complete_cpuset="0x00000010,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="87" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00000010,,0x00010000" complete_cpuset="0x00000010,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="84">
+                <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="85"/>
+                <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="282"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000020,,0x00020000" complete_cpuset="0x00000020,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="93" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000020,,0x00020000" complete_cpuset="0x00000020,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="91" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000020,,0x00020000" complete_cpuset="0x00000020,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="92" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00000020,,0x00020000" complete_cpuset="0x00000020,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="89">
+                <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="90"/>
+                <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="283"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000040,,0x00040000" complete_cpuset="0x00000040,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="98" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000040,,0x00040000" complete_cpuset="0x00000040,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="96" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000040,,0x00040000" complete_cpuset="0x00000040,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="97" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00000040,,0x00040000" complete_cpuset="0x00000040,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="94">
+                <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="95"/>
+                <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="284"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000080,,0x00080000" complete_cpuset="0x00000080,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="103" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000080,,0x00080000" complete_cpuset="0x00000080,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="101" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000080,,0x00080000" complete_cpuset="0x00000080,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="102" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00000080,,0x00080000" complete_cpuset="0x00000080,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="99">
+                <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="100"/>
+                <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="285"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000100,,0x00100000" complete_cpuset="0x00000100,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="108" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000100,,0x00100000" complete_cpuset="0x00000100,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="106" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000100,,0x00100000" complete_cpuset="0x00000100,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="107" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00000100,,0x00100000" complete_cpuset="0x00000100,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="104">
+                <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="105"/>
+                <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="286"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000200,,0x00200000" complete_cpuset="0x00000200,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="113" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000200,,0x00200000" complete_cpuset="0x00000200,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="111" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000200,,0x00200000" complete_cpuset="0x00000200,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="112" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00000200,,0x00200000" complete_cpuset="0x00000200,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="109">
+                <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="110"/>
+                <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="287"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000400,,0x00400000" complete_cpuset="0x00000400,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="118" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000400,,0x00400000" complete_cpuset="0x00000400,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="116" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000400,,0x00400000" complete_cpuset="0x00000400,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="117" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00000400,,0x00400000" complete_cpuset="0x00000400,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="114">
+                <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="115"/>
+                <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="288"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000800,,0x00800000" complete_cpuset="0x00000800,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="123" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000800,,0x00800000" complete_cpuset="0x00000800,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="121" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000800,,0x00800000" complete_cpuset="0x00000800,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="122" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00000800,,0x00800000" complete_cpuset="0x00000800,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="119">
+                <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="120"/>
+                <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="289"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00001000,,0x01000000" complete_cpuset="0x00001000,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="128" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00001000,,0x01000000" complete_cpuset="0x00001000,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="126" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00001000,,0x01000000" complete_cpuset="0x00001000,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="127" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="24" cpuset="0x00001000,,0x01000000" complete_cpuset="0x00001000,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="124">
+                <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="125"/>
+                <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="290"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00002000,,0x02000000" complete_cpuset="0x00002000,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="133" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00002000,,0x02000000" complete_cpuset="0x00002000,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="131" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00002000,,0x02000000" complete_cpuset="0x00002000,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="132" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="25" cpuset="0x00002000,,0x02000000" complete_cpuset="0x00002000,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="129">
+                <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="130"/>
+                <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="291"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="336" bridge_type="0-1" depth="0" bridge_pci="0000:[00-02]">
+        <object type="PCIDev" gp_index="323" pci_busid="0000:00:11.5" pci_type="0106 [8086:a1d2] [8086:7270] 0a" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C620 Series Chipset Family SSATA Controller [AHCI mode]"/>
+          <object type="OSDev" gp_index="347" name="sdb" subtype="Disk" osdev_type="0">
+            <info name="Size" value="468851544"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="8:16"/>
+            <info name="Model" value="LVM PV mak7fx-KZd1-BqaJ-VODO-GudX-kbdj-h86bq6 on /dev/sdb"/>
+            <info name="Revision" value="XC311132"/>
+            <info name="SerialNumber" value="BTYH10910CEU480K"/>
+          </object>
+          <object type="OSDev" gp_index="359" name="sda" subtype="Disk" osdev_type="0">
+            <info name="Size" value="468851544"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="8:0"/>
+            <info name="Model" value="LVM PV 0IfIxC-S3jO-PW2h-h1a2-5dT8-T2y7-AsiZi5 on /dev/sda"/>
+            <info name="Revision" value="XC311132"/>
+            <info name="SerialNumber" value="BTYH10930Y18480K"/>
+          </object>
+        </object>
+        <object type="PCIDev" gp_index="320" pci_busid="0000:00:17.0" pci_type="0106 [8086:a182] [8086:7270] 0a" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C620 Series Chipset Family SATA Controller [AHCI mode]"/>
+        </object>
+        <object type="Bridge" gp_index="321" bridge_type="1-1" depth="1" bridge_pci="0000:[01-02]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:a193] [8086:7270] fa" pci_link_speed="0.500000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C620 Series Chipset Family PCI Express Root Port #4"/>
+          <object type="Bridge" gp_index="328" bridge_type="1-1" depth="2" bridge_pci="0000:[02-02]" pci_busid="0000:01:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 04" pci_link_speed="0.500000">
+            <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+            <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+            <object type="PCIDev" gp_index="324" pci_busid="0000:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+              <info name="PCIDevice" value="ASPEED Graphics Family"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="337" bridge_type="0-1" depth="0" bridge_pci="0000:[03-05]">
+        <object type="Bridge" gp_index="333" bridge_type="1-1" depth="1" bridge_pci="0000:[04-05]" pci_busid="0000:03:04.0" pci_type="0604 [8086:347c] [8086:0000] 04" pci_link_speed="7.876923">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <object type="PCIDev" gp_index="335" pci_busid="0000:04:00.0" pci_type="0200 [8086:15ff] [8086:000c] 02" pci_link_speed="7.876923">
+            <info name="PCISlot" value="259"/>
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="Ethernet Controller X710 for 10GBASE-T"/>
+            <object type="OSDev" gp_index="365" name="ens259f0" osdev_type="2">
+              <info name="Address" value="b4:96:91:a5:f2:00"/>
+            </object>
+          </object>
+          <object type="PCIDev" gp_index="327" pci_busid="0000:04:00.1" pci_type="0200 [8086:15ff] [8086:0000] 02" pci_link_speed="7.876923">
+            <info name="PCISlot" value="259"/>
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="Ethernet Controller X710 for 10GBASE-T"/>
+            <object type="OSDev" gp_index="367" name="ens259f1" osdev_type="2">
+              <info name="Address" value="b4:96:91:a5:f2:01"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="338" bridge_type="0-1" depth="0" bridge_pci="0000:[09-0b]">
+        <object type="Bridge" gp_index="331" bridge_type="1-1" depth="1" bridge_pci="0000:[0a-0b]" pci_busid="0000:09:02.0" pci_type="0604 [8086:347a] [8086:0000] 04" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <object type="PCIDev" gp_index="329" pci_busid="0000:0a:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCISlot" value="787"/>
+            <info name="PCIVendor" value="Cray Inc"/>
+            <object type="OSDev" gp_index="364" name="hsn0" osdev_type="2">
+              <info name="Address" value="02:00:00:00:00:6f"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="339" bridge_type="0-1" depth="0" bridge_pci="0000:[7c-7c]">
+        <object type="PCIDev" gp_index="325" pci_busid="0000:7c:00.5" pci_type="0104 [8086:28c0] [8086:0000] 04" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Volume Management Device NVMe RAID Controller"/>
+          <object type="OSDev" gp_index="345" name="nvme0n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:1"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R511648"/>
+          </object>
+          <object type="OSDev" gp_index="346" name="nvme3n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:8"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R510280"/>
+          </object>
+          <object type="OSDev" gp_index="353" name="nvme2n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:4"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R511669"/>
+          </object>
+          <object type="OSDev" gp_index="358" name="nvme1n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:0"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R510279"/>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="340" bridge_type="0-1" depth="0" bridge_pci="0000:[7d-7d]">
+        <object type="PCIDev" gp_index="322" pci_busid="0000:7d:00.5" pci_type="0104 [8086:28c0] [8086:0000] 04" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Volume Management Device NVMe RAID Controller"/>
+          <object type="OSDev" gp_index="348" name="nvme6n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:7"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R516328"/>
+          </object>
+          <object type="OSDev" gp_index="354" name="nvme5n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:6"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R516079"/>
+          </object>
+          <object type="OSDev" gp_index="360" name="nvme4n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:9"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R516306"/>
+          </object>
+          <object type="OSDev" gp_index="361" name="nvme7n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:10"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R516341"/>
+          </object>
+        </object>
+      </object>
+      <object type="OSDev" gp_index="363" name="pmem0" subtype="NVDIMM" osdev_type="0">
+        <info name="Size" value="4186568704"/>
+        <info name="SectorSize" value="512"/>
+        <info name="LinuxDeviceID" value="259:16"/>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0x000000ff,0xffffc000,0x000fffff,0xfc000000" complete_cpuset="0x000000ff,0xffffc000,0x000fffff,0xfc000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="135">
+      <info name="CPUVendor" value="GenuineIntel"/>
+      <info name="CPUFamilyNumber" value="6"/>
+      <info name="CPUModelNumber" value="106"/>
+      <info name="CPUModel" value="Intel(R) Xeon(R) Gold 5320 CPU @ 2.20GHz"/>
+      <info name="CPUStepping" value="6"/>
+      <object type="NUMANode" os_index="1" cpuset="0x000000ff,0xffffc000,0x000fffff,0xfc000000" complete_cpuset="0x000000ff,0xffffc000,0x000fffff,0xfc000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="319" local_memory="270531129344">
+        <page_type size="4096" count="66047639"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" cpuset="0x000000ff,0xffffc000,0x000fffff,0xfc000000" complete_cpuset="0x000000ff,0xffffc000,0x000fffff,0xfc000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="140" cache_size="40894464" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" cpuset="0x00004000,,0x04000000" complete_cpuset="0x00004000,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="139" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00004000,,0x04000000" complete_cpuset="0x00004000,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="137" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00004000,,0x04000000" complete_cpuset="0x00004000,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="138" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00004000,,0x04000000" complete_cpuset="0x00004000,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="134">
+                <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="136"/>
+                <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="292"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00008000,,0x08000000" complete_cpuset="0x00008000,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="145" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00008000,,0x08000000" complete_cpuset="0x00008000,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="143" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00008000,,0x08000000" complete_cpuset="0x00008000,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="144" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00008000,,0x08000000" complete_cpuset="0x00008000,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="141">
+                <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="142"/>
+                <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="293"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00010000,,0x10000000" complete_cpuset="0x00010000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="150" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00010000,,0x10000000" complete_cpuset="0x00010000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="148" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00010000,,0x10000000" complete_cpuset="0x00010000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="149" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00010000,,0x10000000" complete_cpuset="0x00010000,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="146">
+                <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="147"/>
+                <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="294"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00020000,,0x20000000" complete_cpuset="0x00020000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="155" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00020000,,0x20000000" complete_cpuset="0x00020000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="153" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00020000,,0x20000000" complete_cpuset="0x00020000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="154" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00020000,,0x20000000" complete_cpuset="0x00020000,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="151">
+                <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="152"/>
+                <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="295"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00040000,,0x40000000" complete_cpuset="0x00040000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="160" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00040000,,0x40000000" complete_cpuset="0x00040000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="158" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00040000,,0x40000000" complete_cpuset="0x00040000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="159" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00040000,,0x40000000" complete_cpuset="0x00040000,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="156">
+                <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="157"/>
+                <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="296"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00080000,,0x80000000" complete_cpuset="0x00080000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="165" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00080000,,0x80000000" complete_cpuset="0x00080000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="163" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00080000,,0x80000000" complete_cpuset="0x00080000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="164" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00080000,,0x80000000" complete_cpuset="0x00080000,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="161">
+                <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="162"/>
+                <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="297"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00100000,0x00000001,0x0" complete_cpuset="0x00100000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="170" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00100000,0x00000001,0x0" complete_cpuset="0x00100000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="168" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00100000,0x00000001,0x0" complete_cpuset="0x00100000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="169" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00100000,0x00000001,0x0" complete_cpuset="0x00100000,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="166">
+                <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="167"/>
+                <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="298"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00200000,0x00000002,0x0" complete_cpuset="0x00200000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="175" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00200000,0x00000002,0x0" complete_cpuset="0x00200000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="173" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00200000,0x00000002,0x0" complete_cpuset="0x00200000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="174" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00200000,0x00000002,0x0" complete_cpuset="0x00200000,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="171">
+                <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="172"/>
+                <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="299"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00400000,0x00000004,0x0" complete_cpuset="0x00400000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="180" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00400000,0x00000004,0x0" complete_cpuset="0x00400000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="178" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00400000,0x00000004,0x0" complete_cpuset="0x00400000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="179" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00400000,0x00000004,0x0" complete_cpuset="0x00400000,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="176">
+                <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="177"/>
+                <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="300"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00800000,0x00000008,0x0" complete_cpuset="0x00800000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="185" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00800000,0x00000008,0x0" complete_cpuset="0x00800000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="183" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00800000,0x00000008,0x0" complete_cpuset="0x00800000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="184" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00800000,0x00000008,0x0" complete_cpuset="0x00800000,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="181">
+                <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="182"/>
+                <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="301"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x01000000,0x00000010,0x0" complete_cpuset="0x01000000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="190" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x01000000,0x00000010,0x0" complete_cpuset="0x01000000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="188" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x01000000,0x00000010,0x0" complete_cpuset="0x01000000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="189" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x01000000,0x00000010,0x0" complete_cpuset="0x01000000,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="186">
+                <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="187"/>
+                <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="302"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x02000000,0x00000020,0x0" complete_cpuset="0x02000000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="195" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x02000000,0x00000020,0x0" complete_cpuset="0x02000000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="193" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x02000000,0x00000020,0x0" complete_cpuset="0x02000000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="194" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x02000000,0x00000020,0x0" complete_cpuset="0x02000000,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="191">
+                <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="192"/>
+                <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="303"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x04000000,0x00000040,0x0" complete_cpuset="0x04000000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="200" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x04000000,0x00000040,0x0" complete_cpuset="0x04000000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="198" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x04000000,0x00000040,0x0" complete_cpuset="0x04000000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="199" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x04000000,0x00000040,0x0" complete_cpuset="0x04000000,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="196">
+                <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="197"/>
+                <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="304"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x08000000,0x00000080,0x0" complete_cpuset="0x08000000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="205" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x08000000,0x00000080,0x0" complete_cpuset="0x08000000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="203" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x08000000,0x00000080,0x0" complete_cpuset="0x08000000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="204" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x08000000,0x00000080,0x0" complete_cpuset="0x08000000,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="201">
+                <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="202"/>
+                <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="305"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x10000000,0x00000100,0x0" complete_cpuset="0x10000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="210" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x10000000,0x00000100,0x0" complete_cpuset="0x10000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="208" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x10000000,0x00000100,0x0" complete_cpuset="0x10000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="209" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x10000000,0x00000100,0x0" complete_cpuset="0x10000000,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="206">
+                <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="207"/>
+                <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="306"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x20000000,0x00000200,0x0" complete_cpuset="0x20000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="215" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x20000000,0x00000200,0x0" complete_cpuset="0x20000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="213" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x20000000,0x00000200,0x0" complete_cpuset="0x20000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="214" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x20000000,0x00000200,0x0" complete_cpuset="0x20000000,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="211">
+                <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="212"/>
+                <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="307"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x40000000,0x00000400,0x0" complete_cpuset="0x40000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="220" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x40000000,0x00000400,0x0" complete_cpuset="0x40000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="218" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x40000000,0x00000400,0x0" complete_cpuset="0x40000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="219" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x40000000,0x00000400,0x0" complete_cpuset="0x40000000,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="216">
+                <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="217"/>
+                <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="308"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x80000000,0x00000800,0x0" complete_cpuset="0x80000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="225" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x80000000,0x00000800,0x0" complete_cpuset="0x80000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="223" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x80000000,0x00000800,0x0" complete_cpuset="0x80000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="224" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x80000000,0x00000800,0x0" complete_cpuset="0x80000000,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="221">
+                <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="222"/>
+                <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="309"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000001,,0x00001000,0x0" complete_cpuset="0x00000001,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="230" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000001,,0x00001000,0x0" complete_cpuset="0x00000001,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="228" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000001,,0x00001000,0x0" complete_cpuset="0x00000001,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="229" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00000001,,0x00001000,0x0" complete_cpuset="0x00000001,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="226">
+                <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="227"/>
+                <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="310"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000002,,0x00002000,0x0" complete_cpuset="0x00000002,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="235" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000002,,0x00002000,0x0" complete_cpuset="0x00000002,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="233" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000002,,0x00002000,0x0" complete_cpuset="0x00000002,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="234" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00000002,,0x00002000,0x0" complete_cpuset="0x00000002,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="231">
+                <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="232"/>
+                <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="311"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000004,,0x00004000,0x0" complete_cpuset="0x00000004,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="240" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000004,,0x00004000,0x0" complete_cpuset="0x00000004,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="238" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000004,,0x00004000,0x0" complete_cpuset="0x00000004,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="239" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00000004,,0x00004000,0x0" complete_cpuset="0x00000004,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="236">
+                <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="237"/>
+                <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="312"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000008,,0x00008000,0x0" complete_cpuset="0x00000008,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="245" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000008,,0x00008000,0x0" complete_cpuset="0x00000008,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="243" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000008,,0x00008000,0x0" complete_cpuset="0x00000008,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="244" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00000008,,0x00008000,0x0" complete_cpuset="0x00000008,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="241">
+                <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="242"/>
+                <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="313"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000010,,0x00010000,0x0" complete_cpuset="0x00000010,,0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="250" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000010,,0x00010000,0x0" complete_cpuset="0x00000010,,0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="248" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000010,,0x00010000,0x0" complete_cpuset="0x00000010,,0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="249" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00000010,,0x00010000,0x0" complete_cpuset="0x00000010,,0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="246">
+                <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="247"/>
+                <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="314"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000020,,0x00020000,0x0" complete_cpuset="0x00000020,,0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="255" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000020,,0x00020000,0x0" complete_cpuset="0x00000020,,0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="253" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000020,,0x00020000,0x0" complete_cpuset="0x00000020,,0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="254" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00000020,,0x00020000,0x0" complete_cpuset="0x00000020,,0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="251">
+                <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="252"/>
+                <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="315"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000040,,0x00040000,0x0" complete_cpuset="0x00000040,,0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="260" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000040,,0x00040000,0x0" complete_cpuset="0x00000040,,0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="258" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000040,,0x00040000,0x0" complete_cpuset="0x00000040,,0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="259" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="24" cpuset="0x00000040,,0x00040000,0x0" complete_cpuset="0x00000040,,0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="256">
+                <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="257"/>
+                <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="316"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" cpuset="0x00000080,,0x00080000,0x0" complete_cpuset="0x00000080,,0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="265" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L1Cache" cpuset="0x00000080,,0x00080000,0x0" complete_cpuset="0x00000080,,0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="263" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" cpuset="0x00000080,,0x00080000,0x0" complete_cpuset="0x00000080,,0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="264" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="25" cpuset="0x00000080,,0x00080000,0x0" complete_cpuset="0x00000080,,0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="261">
+                <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="262"/>
+                <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="317"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="341" bridge_type="0-1" depth="0" bridge_pci="0000:[81-81]">
+        <object type="PCIDev" gp_index="334" pci_busid="0000:81:00.5" pci_type="0104 [8086:28c0] [8086:0000] 04" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Volume Management Device NVMe RAID Controller"/>
+          <object type="OSDev" gp_index="349" name="nvme11n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:11"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R510293"/>
+          </object>
+          <object type="OSDev" gp_index="350" name="nvme9n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:13"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R511639"/>
+          </object>
+          <object type="OSDev" gp_index="355" name="nvme10n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:5"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R511666"/>
+          </object>
+          <object type="OSDev" gp_index="356" name="nvme8n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:12"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R510298"/>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="342" bridge_type="0-1" depth="0" bridge_pci="0000:[82-84]">
+        <object type="Bridge" gp_index="332" bridge_type="1-1" depth="1" bridge_pci="0000:[83-84]" pci_busid="0000:82:02.0" pci_type="0604 [8086:347a] [8086:0000] 04" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <object type="PCIDev" gp_index="326" pci_busid="0000:83:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCISlot" value="801"/>
+            <info name="PCIVendor" value="Cray Inc"/>
+            <object type="OSDev" gp_index="366" name="hsn1" osdev_type="2">
+              <info name="Address" value="02:00:00:00:00:5f"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="343" bridge_type="0-1" depth="0" bridge_pci="0000:[fa-fa]">
+        <object type="PCIDev" gp_index="330" pci_busid="0000:fa:00.5" pci_type="0104 [8086:28c0] [8086:0000] 04" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Volume Management Device NVMe RAID Controller"/>
+          <object type="OSDev" gp_index="344" name="nvme15n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:15"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R510256"/>
+          </object>
+          <object type="OSDev" gp_index="351" name="nvme14n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:2"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R510311"/>
+          </object>
+          <object type="OSDev" gp_index="357" name="nvme13n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:14"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R510281"/>
+          </object>
+          <object type="OSDev" gp_index="362" name="nvme12n1" subtype="Disk" osdev_type="0">
+            <info name="Size" value="15000928256"/>
+            <info name="SectorSize" value="512"/>
+            <info name="LinuxDeviceID" value="259:3"/>
+            <info name="Vendor" value="Samsung"/>
+            <info name="Model" value="SAMSUNG MZWLR15THALA-00007"/>
+            <info name="Revision" value="MPK92B5Q"/>
+            <info name="SerialNumber" value="S6EXNE0R511647"/>
+          </object>
+        </object>
+      </object>
+      <object type="OSDev" gp_index="352" name="pmem1" subtype="NVDIMM" osdev_type="0">
+        <info name="Size" value="4186568704"/>
+        <info name="SectorSize" value="512"/>
+        <info name="LinuxDeviceID" value="259:17"/>
+      </object>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="2" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="4">0 1 </indexes>
+    <u64values length="12">10 20 20 10 </u64values>
+  </distances2>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <memattr name="Bandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="318" value="1790" initiator_cpuset="0x00003fff,0xfff00000,0x03ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="319" value="1790" initiator_cpuset="0x000000ff,0xffffc000,0x000fffff,0xfc000000"/>
+  </memattr>
+  <memattr name="Latency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="318" value="7600" initiator_cpuset="0x00003fff,0xfff00000,0x03ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="319" value="7600" initiator_cpuset="0x000000ff,0xffffc000,0x000fffff,0xfc000000"/>
+  </memattr>
+  <cpukind cpuset="0x000000ff,0xffffffff,0xffffffff,0xffffffff">
+    <info name="FrequencyMaxMHz" value="3400"/>
+    <info name="FrequencyBaseMHz" value="2200"/>
+  </cpukind>
+</topology>

--- a/src/control/lib/hardware/mocks.go
+++ b/src/control/lib/hardware/mocks.go
@@ -87,6 +87,17 @@ func (n *NUMANode) WithCPUCores(cores []CPUCore) *NUMANode {
 	return n
 }
 
+// WithBlockDevices is a convenience function to add a set of block devices to a node.
+// NB: If AddBlockDevice fails, a panic will ensue.
+func (n *NUMANode) WithBlockDevices(devices []*BlockDevice) *NUMANode {
+	for _, dev := range devices {
+		if err := n.AddBlockDevice(dev); err != nil {
+			panic(err)
+		}
+	}
+	return n
+}
+
 // GetMockFabricScannerConfig gets a FabricScannerConfig for testing.
 func GetMockFabricScannerConfig() *FabricScannerConfig {
 	return &FabricScannerConfig{

--- a/src/control/lib/hardware/pretty.go
+++ b/src/control/lib/hardware/pretty.go
@@ -46,6 +46,20 @@ func PrintTopology(t *Topology, output io.Writer) error {
 			}
 		}
 
+		if len(numaNode.BlockDevices) > 0 {
+			var sectionPrinted bool
+			for _, blockDev := range numaNode.BlockDevices {
+				// Skip PCI-backed devices; they were already printed.
+				if blockDev.BackingDevice != nil {
+					continue
+				}
+				if !sectionPrinted {
+					fmt.Fprintln(ew, "  Non-PCI block devices:")
+					sectionPrinted = true
+				}
+				fmt.Fprintf(ew, "    %s\n", blockDev)
+			}
+		}
 	}
 
 	if len(t.VirtualDevices) > 0 {


### PR DESCRIPTION
The hwloc library provides quite a bit of information about
block devices; make this available. Also adds support for
non-PCI (e.g. PMEM) devices.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>