### PR TITLE
DAOS-10929 container: fix size of cont_global_version value (#9545)

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -641,11 +641,17 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop,
 					   &value);
 			break;
 		case DAOS_PROP_CO_GLOBAL_VERSION:
-			d_iov_set(&value, &entry->dpe_val,
-				  sizeof(entry->dpe_val));
-			rc = rdb_tx_update(tx, kvs,
-					   &ds_cont_prop_cont_global_version,
-					   &value);
+			/* type of the property in rdb is uint32_t */
+			if (entry->dpe_val <= UINT_MAX) {
+				uint32_t cont_ver = (uint32_t)entry->dpe_val;
+
+				d_iov_set(&value, &cont_ver, sizeof(cont_ver));
+				rc = rdb_tx_update(tx, kvs,
+						   &ds_cont_prop_cont_global_version, &value);
+				D_DEBUG(DB_MD, "wrote cont_global_version = %u\n", cont_ver);
+			} else {
+				rc = -DER_INVAL;
+			}
 			break;
 		case DAOS_PROP_CO_OWNER:
 			d_iov_set(&value, entry->dpe_str,
@@ -2412,12 +2418,16 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_GLOBAL_VERSION) {
-		d_iov_set(&value, &val, sizeof(val));
-		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_cont_global_version,
-				   &value);
-		if (rc == -DER_NONEXIST)
+		/* type of the property in rdb is uint32_t */
+		uint32_t cont_ver;
+
+		d_iov_set(&value, &cont_ver, sizeof(cont_ver));
+		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_cont_global_version, &value);
+		if (rc == 0)
+			val = cont_ver;
+		else if (rc == -DER_NONEXIST)
 			val = 0;
-		else  if (rc != 0)
+		else
 			D_GOTO(out, rc);
 		D_ASSERT(idx < nr);
 		prop->dpp_entries[idx].dpe_type = DAOS_PROP_CO_GLOBAL_VERSION;


### PR DESCRIPTION
Cherry pick of master PR 9545 to release/2.2 branch.

Before this change, when a new container was created, the metadata
rdb value for key ds_cont_prop_cont_global_version was written as
a 64-bit value in cont_prop_write(). However, the intent for this
recently-added key is a uint32_t typed value. Also, an inconsistency
exists with the pool/container layout upgrade code, upgrade_cont_cb()
writing the value as uint32_t. This results in some containers with
64-bit version values, and others with 32-bit values.

With this change, the cont_prop_write() and cont_prop_read() functions
are changed to write and read a 32-bit cont_global_version value in rdb,
to agree with the upgrade_cont_cb() code.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

Required-githooks: true
Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>