### PR TITLE
DAOS-10932 oid: Change trace to MD for oid alloc

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1806,9 +1806,9 @@ cont_oid_alloc_complete(tse_task_t *task, void *data)
 		D_GOTO(out, rc);
 	}
 
-	D_DEBUG(DB_MD, DF_CONT": OID ALLOC: using hdl="DF_UUID"\n",
-		 DP_CONT(pool->dp_pool, cont->dc_uuid),
-		 DP_UUID(cont->dc_cont_hdl));
+	D_DEBUG(DB_MD, DF_CONT": OID ALLOC: using hdl="DF_UUID" oid "DF_U64"/"DF_U64"\n",
+		DP_CONT(pool->dp_pool, cont->dc_uuid), DP_UUID(cont->dc_cont_hdl),
+		out->oid, arg->num_oids);
 
 	if (arg->oid)
 		*arg->oid = out->oid;
@@ -1866,9 +1866,9 @@ dc_cont_alloc_oids(tse_task_t *task)
 	pool = dc_hdl2pool(cont->dc_pool_hdl);
 	D_ASSERT(pool != NULL);
 
-	D_DEBUG(DB_MD, DF_CONT": oid allocate: hdl="DF_UUID"\n",
-		DP_CONT(pool->dp_pool_hdl, cont->dc_uuid),
-		DP_UUID(cont->dc_cont_hdl));
+	D_DEBUG(DB_MD, DF_CONT": oid allocate: hdl="DF_UUID" num "DF_U64"\n",
+		DP_CONT(pool->dp_pool_hdl, cont->dc_uuid), DP_UUID(cont->dc_cont_hdl),
+		args->num_oids);
 
 	/** randomly select a rank from the pool map */
 	ep.ep_grp = pool->dp_sys->sy_group;

--- a/src/container/oid_iv.c
+++ b/src/container/oid_iv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -84,7 +84,7 @@ oid_iv_ent_refresh(struct ds_iv_entry *iv_entry, struct ds_iv_key *key,
 
 	D_ASSERT(priv);
 	num_oids = priv->num_oids;
-	D_DEBUG(DB_TRACE, "%u: ON REFRESH %zu\n", dss_self_rank(), num_oids);
+	D_DEBUG(DB_MD, "%u: ON REFRESH %zu\n", dss_self_rank(), num_oids);
 	D_ASSERT(num_oids != 0);
 
 	entry = iv_entry->iv_value.sg_iovs[0].iov_buf;
@@ -107,6 +107,7 @@ oid_iv_ent_refresh(struct ds_iv_entry *iv_entry, struct ds_iv_key *key,
 
 	/** Set the number of oids to what was asked for. */
 	oids->num_oids = num_oids;
+	D_DEBUG(DB_MD, "%u: ON REFRESH %zu/%zu\n", dss_self_rank(), oids->oid, oids->num_oids);
 
 out:
 	ABT_mutex_unlock(entry->lock);
@@ -135,7 +136,7 @@ oid_iv_ent_update(struct ds_iv_entry *ns_entry, struct ds_iv_key *iv_key,
 	num_oids = oids->num_oids;
 
 	D_DEBUG(DB_TRACE, "%u: ON UPDATE, num_oids = %zu\n", myrank, num_oids);
-	D_DEBUG(DB_TRACE, "%u: ENTRY NUM OIDS = %zu, oid = %" PRIu64 "\n",
+	D_DEBUG(DB_MD, "%u: ENTRY NUM OIDS = %zu, oid = %" PRIu64 "\n",
 		myrank, avail->num_oids, avail->oid);
 
 	if (ns_entry->ns->iv_master_rank == myrank) {
@@ -150,8 +151,7 @@ oid_iv_ent_update(struct ds_iv_entry *ns_entry, struct ds_iv_key *iv_key,
 		}
 		oids->oid = avail->oid;
 		oids->num_oids = num_oids;
-		D_DEBUG(DB_TRACE, "%u: ROOT MAX_OID = %"PRIu64"\n", myrank,
-			avail->oid);
+		D_DEBUG(DB_MD, "%u: ROOT MAX_OID = %"PRIu64"\n", myrank, avail->oid);
 		priv->num_oids = 0;
 		ABT_mutex_unlock(entry->lock);
 		return 0;


### PR DESCRIPTION
Change a few TRACE message to MD for debugging
OID allocation.

Signed-off-by: Di Wang <di.wang@intel.com>