### PR TITLE
DAOS-623 test: Extend test server startup timeouts for ucx

### DIFF
--- a/src/tests/ftest/harness/setup.py
+++ b/src/tests/ftest/harness/setup.py
@@ -22,8 +22,8 @@ class HarnessSetupTest(TestWithServers):
         :avocado: tags=hw,large
         :avocado: tags=harness,harness_setup_test,test_setup
         """
-        self.assertEqual(self.server_managers[0].storage_prepare_timeout.value, 60,
+        self.assertEqual(self.server_managers[0].storage_prepare_timeout.value, 180,
                          "FAILED: storage prepare was not set correctly from the yaml")
-        self.assertEqual(self.server_managers[0].storage_format_timeout.value, 60,
+        self.assertEqual(self.server_managers[0].storage_format_timeout.value, 240,
                          "FAILED: storage format was not set correctly from the yaml")
         self.log.info("Test passed!")

--- a/src/tests/ftest/harness/setup.yaml
+++ b/src/tests/ftest/harness/setup.yaml
@@ -17,5 +17,5 @@ server_config:
     bdev_class: nvme
     bdev_list: ["aaaa:aa:aa.a"]
 server_manager:
-  storage_prepare_timeout: 60
-  storage_format_timeout: 60
+  storage_prepare_timeout: 180
+  storage_format_timeout: 240

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -33,6 +33,9 @@ ET.SubElement = SubElement
 ET.tostring = tostring
 
 DEFAULT_DAOS_TEST_LOG_DIR = "/var/tmp/daos_testing"
+DAOS_STORAGE_PREPARE_TIMEOUT = 40
+DAOS_STORAGE_FORMAT_TIMEOUT = 40
+
 YAML_KEYS = OrderedDict(
     [
         ("test_servers", "test_servers"),
@@ -368,6 +371,19 @@ def set_provider_environment(interface, args):
             sys.exit(1)
 
         print("  Found {} provider for {}".format(provider, interface))
+
+    # Use extended timeouts for server start detection when using ucx
+    timeout_multiplier = 5 if "ucx" in provider else 1
+
+    # Update env definitions
+    os.environ["CRT_PHY_ADDR_STR"] = provider
+    os.environ["DAOS_STORAGE_FORMAT_TIMEOUT"] = str(DAOS_STORAGE_FORMAT_TIMEOUT * timeout_multiplier)
+    os.environ["DAOS_STORAGE_PREPARE_TIMEOUT"] = str(DAOS_STORAGE_PREPARE_TIMEOUT * timeout_multiplier)
+    for name in ("CRT_PHY_ADDR_STR", "DAOS_STORAGE_FORMAT_TIMEOUT", "DAOS_STORAGE_PREPARE_TIMEOUT"):
+        try:
+            print("Testing with {}={}".format(name, os.environ[name]))
+        except KeyError:
+            print("Testing with {} unset".format(name))
 
     # Update env definitions
     os.environ["CRT_PHY_ADDR_STR"] = provider

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -127,8 +127,10 @@ class DaosServerManager(SubprocessManager):
         self.detect_start_via_dmg = False
 
         # Parameters to set storage prepare and format timeout
-        self.storage_prepare_timeout = BasicParameter(None, 40)
-        self.storage_format_timeout = BasicParameter(None, 40)
+        default_prepare_timeout = os.environ.get("DAOS_STORAGE_PREPARE_TIMEOUT", "40")
+        default_format_timeout = os.environ.get("DAOS_STORAGE_FORMAT_TIMEOUT", "40")
+        self.storage_prepare_timeout = BasicParameter(None, int(default_prepare_timeout))
+        self.storage_format_timeout = BasicParameter(None, int(default_format_timeout))
 
     def get_params(self, test):
         """Get values for all of the command params from the yaml file.


### PR DESCRIPTION
Add the ability to override the default server storage prepare and
format timeouts for all tests with environment variables.  Launch.py
will use these environment variables to extend the server timeouts
when testing with the ucx provider.

Skip-unit-tests: true
Test-provider: ucx+dc_x
Test-tag: harness_setup_test

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>