### PR TITLE
DAOS-11030 mpi: fix build error when the mpi is not installed

### DIFF
--- a/src/utils/wrap/mpi/SConscript
+++ b/src/utils/wrap/mpi/SConscript
@@ -27,7 +27,6 @@ def scons():
 
     env.AppendUnique(LIBPATH=[Dir('.')])
     base_env.AppendUnique(LIBPATH=[Dir('.')])
-    base_env_mpi.AppendUnique(LIBPATH=[Dir('.')])
     daos_build.add_build_rpath(env)
     daos_build.add_build_rpath(base_env)
     if base_env_mpi:


### PR DESCRIPTION
without mpi install, the base_env_mpi is null, compile error:
AttributeError: 'NoneType' object has no attribute 'AppendUnique'
In addition, there is base_env_mpi.AppendUnique(LIBPATH=[Dir('.') at
line 33.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>