### PR TITLE
DAOS-11030 mpi: fix build error when the mpi is not installed

### DIFF
--- a/site_scons/site_tools/extra/__init__.py
+++ b/site_scons/site_tools/extra/__init__.py
@@ -1,3 +1,4 @@
+"""SCons Tools for useful features"""
 # Copyright 2018-2022 Intel Corporation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -18,7 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-"""SCons Tools for useful features"""
 
 
 # pylint: disable=unused-import

--- a/src/utils/wrap/mpi/SConscript
+++ b/src/utils/wrap/mpi/SConscript
@@ -27,7 +27,6 @@ def scons():
 
     env.AppendUnique(LIBPATH=[Dir('.')])
     base_env.AppendUnique(LIBPATH=[Dir('.')])
-    base_env_mpi.AppendUnique(LIBPATH=[Dir('.')])
     daos_build.add_build_rpath(env)
     daos_build.add_build_rpath(base_env)
     if base_env_mpi:


### PR DESCRIPTION
Correct pylint issues introduced by a recent conflict.

Co-authored-by: Chunsong Feng <fengchunsong@huawei.com>
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
