### PR TITLE
DAOS-623 build: Fix a compiler warning

### DIFF
--- a/src/utils/wrap/mpi/SConscript
+++ b/src/utils/wrap/mpi/SConscript
@@ -1,12 +1,16 @@
 """Build mpi abstraction libraries"""
 import daos_build
+import compiler_setup
 
 
 def build_dpar(env, mpi_env):
     """Build MPI abstraction library"""
 
-    serial_lib = daos_build.library(env, 'dpar', ['dpar_stub.c'], LIBS=['pthread', 'dl'])
-    env.Install('$PREFIX/lib64/', serial_lib)
+    senv = env.Clone()
+    compiler_setup.base_setup(senv)
+
+    serial_lib = daos_build.library(senv, 'dpar', ['dpar_stub.c'], LIBS=['pthread', 'dl'])
+    senv.Install('$PREFIX/lib64/', serial_lib)
 
     if not mpi_env:
         return

--- a/src/utils/wrap/mpi/dpar_stub.c
+++ b/src/utils/wrap/mpi/dpar_stub.c
@@ -139,7 +139,7 @@ par_init(int *argc, char ***argv)
 int
 par_fini(void)
 {
-	int	rc;
+	int	rc = 0;
 
 	if (stubs.ps_fini)
 		rc = stubs.ps_fini();


### PR DESCRIPTION
dpar serial library wasn't using compiler flags.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

Required-githooks: true