### PR TITLE
DAOS-10960 pool,container,rsvc: fix Coverity issues

### DIFF
--- a/src/common/rsvc.c
+++ b/src/common/rsvc.c
@@ -248,8 +248,8 @@ rsvc_client_complete_rpc(struct rsvc_client *client, const crt_endpoint_t *ep,
 	 * indentation level, please.
 	 */
 	if (rc_crt == -DER_INVAL) {
-		D_DEBUG(DB_MD, "group-id %s does not exist for rank %u: rc_crt=%d\n",
-			ep->ep_grp->cg_grpid, ep->ep_rank, rc_crt);
+		D_DEBUG(DB_MD, "cart invalid argument for rank %u: rc_crt=%d\n",
+			ep->ep_rank, rc_crt);
 		rsvc_client_process_error(client, rc_crt, ep);
 		return RSVC_CLIENT_PROCEED;
 	} else if (rc_crt == -DER_OOG) {

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -3615,7 +3615,12 @@ ds_pool_extend(uuid_t pool_uuid, int ntargets, const d_rank_list_t *rank_list, i
 rechoose:
 
 	ep.ep_grp = NULL; /* primary group */
-	rsvc_client_choose(&client, &ep);
+	rc = rsvc_client_choose(&client, &ep);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": cannot find pool service: "DF_RC"\n",
+			DP_UUID(pool_uuid), DP_RC(rc));
+		goto out_client;
+	}
 
 	rc = pool_req_create(info->dmi_ctx, &ep, POOL_EXTEND, &rpc);
 	if (rc != 0) {
@@ -3678,7 +3683,12 @@ ds_pool_target_update_state(uuid_t pool_uuid, d_rank_list_t *ranks,
 
 rechoose:
 	ep.ep_grp = NULL; /* primary group */
-	rsvc_client_choose(&client, &ep);
+	rc = rsvc_client_choose(&client, &ep);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": cannot find pool service: "DF_RC"\n",
+			DP_UUID(pool_uuid), DP_RC(rc));
+		goto out_client;
+	}
 
 	switch (state) {
 	case PO_COMP_ST_DOWN:


### PR DESCRIPTION
Cherry-pick of the same change on master branch to release/2.2 branch.

Issue 1: explicit null dereference

rsvc_client_complete_rpc() when rc_crt is -DER_INVAL in a debug log
dereferences ep->ep_grp that may be NULL. Remove that part of the
log message.

from src/pool/srv_pool.c callers, should fix:
CID: 105938, 105927, 105888, 105870, 105862, 105844, 105830, 105829
CID: 105815

from src/container/srv_container.c callers, should fix:
CID: 105873

Issue 2: unchecked return value of rsvc_client_choose()
Add error return value checks.
Addresses issues in ds_pool_extend() and ds_pool_target_update_state():
CID: 105812, 105847

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

Required-githooks: true