### PR TITLE
DAOS-11006 obj: fix coverity issues

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -608,9 +608,9 @@ shard_task_abort(tse_task_t *task, void *arg)
 	int	rc = *((int *)arg);
 
 	tse_task_list_del(task);
-	tse_task_decref(task);
 	tse_task_complete(task, rc);
 
+	tse_task_decref(task);
 	return 0;
 }
 

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -45,8 +45,6 @@ static void
 gen_maps(int num_domains, int nodes_per_domain, int vos_per_target,
 	 struct pool_map **po_map, struct pl_map **pl_map)
 {
-	*po_map = NULL;
-	*pl_map = NULL;
 	gen_pool_and_placement_map(num_domains, nodes_per_domain,
 				   vos_per_target, PL_TYPE_JUMP_MAP,
 				   po_map, pl_map);

--- a/src/placement/tests/pl_bench.c
+++ b/src/placement/tests/pl_bench.c
@@ -261,6 +261,8 @@ benchmark_placement(int argc, char **argv, uint32_t num_domains,
 	}
 
 	free_pool_and_placement_map(pool_map, pl_map);
+	D_FREE(obj_table);
+	D_FREE(layout_table);
 }
 
 void
@@ -397,9 +399,13 @@ benchmark_add_data_movement(int argc, char **argv, uint32_t num_domains,
 			/* Pad +1 for "ideal" */
 			num_map_types++;
 
+			if (map_types != NULL)
+				D_FREE(map_types);
 			D_ALLOC_ARRAY(map_types, num_map_types);
 			D_ASSERT(map_types != NULL);
 
+			if (map_keys != NULL)
+				D_FREE(map_keys);
 			D_ALLOC_ARRAY(map_keys, num_map_types);
 			D_ASSERT(map_keys != NULL);
 

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -524,9 +524,11 @@ plt_spare_tgts_get(uuid_t pl_uuid, daos_obj_id_t oid, uint32_t *failed_tgts,
 	D_ASSERT(pl_map != NULL);
 	dc_obj_fetch_md(oid, &md);
 	md.omd_ver = *po_ver;
-	*spare_cnt = pl_obj_find_rebuild(pl_map, &md, NULL, *po_ver,
-					 spare_tgt_ranks, shard_ids,
-					 spare_max_nr);
+	rc = pl_obj_find_rebuild(pl_map, &md, NULL, *po_ver,
+				 spare_tgt_ranks, shard_ids,
+				 spare_max_nr);
+	D_ASSERT(rc >= 0);
+	*spare_cnt = rc;
 	D_PRINT("spare_cnt %d for version %d -\n", *spare_cnt, *po_ver);
 	for (i = 0; i < *spare_cnt; i++)
 		D_PRINT("shard %d, spare target rank %d\n",


### PR DESCRIPTION
DAOS-10943 src/placement/tests/pl_bench.c
DAOS-10971 src/placement/tests/place_obj_common.c
DAOS-10955 src/placement/tests/jump_map_place_obj.c
DAOS-11006 fix coverity warning in shard_task_abort

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>