### PR TITLE
DAOS-11029 tse/dfs: bug fix in tse or dfs about task

### DIFF
--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -2047,8 +2047,8 @@ err:
 }
 
 static int
-punch_extent(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
-	     daos_off_t record_i, daos_size_t num_records, tse_task_t *task)
+punch_extent(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val, daos_off_t record_i,
+	     daos_size_t num_records, tse_task_t *task, d_list_t *task_list)
 {
 	daos_obj_update_t	*io_arg;
 	daos_iod_t		*iod;
@@ -2058,8 +2058,7 @@ punch_extent(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 	tse_task_t		*io_task = NULL;
 	int			rc;
 
-	D_DEBUG(DB_IO, "Punching (%zu, %zu) in Key %zu\n",
-		record_i + 1, num_records, dkey_val);
+	D_DEBUG(DB_IO, "Punching (%zu, %zu) in Key %zu\n", record_i + 1, num_records, dkey_val);
 
 	D_ALLOC_PTR(params);
 	if (params == NULL)
@@ -2104,9 +2103,9 @@ punch_extent(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 	if (rc)
 		D_GOTO(err, rc);
 
-	rc = tse_task_schedule(io_task, false);
-	if (rc)
-		D_GOTO(err, rc);
+	/* decref in adjust_array_size_task_process() */
+	tse_task_addref(io_task);
+	tse_task_list_add(io_task, task_list);
 
 	return rc;
 err:
@@ -2202,8 +2201,8 @@ out:
 }
 
 static int
-check_record(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
-	     daos_off_t record_i, daos_size_t cell_size, tse_task_t *task)
+check_record(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val, daos_off_t record_i,
+	     daos_size_t cell_size, tse_task_t *task, d_list_t *task_list)
 {
 	daos_obj_fetch_t	*io_arg;
 	daos_iod_t		*iod;
@@ -2261,11 +2260,11 @@ check_record(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 	if (rc)
 		D_GOTO(err, rc);
 
-	rc = tse_task_schedule(io_task, false);
-	if (rc)
-		D_GOTO(err, rc);
-
+	/* decref in adjust_array_size_task_process() */
+	tse_task_addref(io_task);
+	tse_task_list_add(io_task, task_list);
 	return rc;
+
 err:
 	D_FREE(params);
 	if (io_task)
@@ -2274,7 +2273,7 @@ err:
 }
 
 static int
-add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props)
+add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props, d_list_t *task_list)
 {
 	daos_obj_update_t	*io_arg;
 	daos_iod_t		*iod;
@@ -2336,11 +2335,11 @@ add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props)
 	if (rc)
 		D_GOTO(err, rc);
 
-	rc = tse_task_schedule(io_task, false);
-	if (rc)
-		D_GOTO(err, rc);
-
+	/* decref in adjust_array_size_task_process() */
+	tse_task_addref(io_task);
+	tse_task_list_add(io_task, task_list);
 	return rc;
+
 err:
 	D_FREE(params);
 	if (io_task)
@@ -2349,19 +2348,37 @@ err:
 }
 
 static int
+adjust_array_size_task_process(tse_task_t *task, void *arg)
+{
+	int	rc = *((int *)arg);
+
+	tse_task_list_del(task);
+
+	if (rc == 0)
+		tse_task_schedule(task, false);
+	else
+		tse_task_complete(task, rc);
+
+	tse_task_decref(task);
+	return 0;
+}
+
+static int
 adjust_array_size_cb(tse_task_t *task, void *data)
 {
 	daos_obj_list_dkey_t	*args = daos_task_get_args(task);
 	struct set_size_props	*props = *((struct set_size_props **)data);
 	char			*ptr;
-	uint32_t		i;
-	int			rc = task->dt_result;
+	d_list_t		 task_list;
+	uint32_t		 i;
+	int			 rc = task->dt_result;
 
 	if (rc != 0) {
 		D_ERROR("Array DKEY enumermation Failed "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
 
+	D_INIT_LIST_HEAD(&task_list);
 	for (ptr = props->buf, i = 0; i < props->nr; i++) {
 		daos_size_t dkey_val;
 
@@ -2388,22 +2405,18 @@ adjust_array_size_cb(tse_task_t *task, void *data)
 				D_ASSERT(props->record_i + 1 <
 					 props->chunk_size);
 				/** Punch all records above record_i */
-				D_DEBUG(DB_IO, "Punch extent in key "DF_U64"\n",
-					dkey_val);
-				rc = punch_extent(args->oh, args->th,
-						  dkey_val, props->record_i,
-						  props->num_records,
-						  props->ptask);
+				D_DEBUG(DB_IO, "Punch extent in key "DF_U64"\n", dkey_val);
+				rc = punch_extent(args->oh, args->th, dkey_val, props->record_i,
+						  props->num_records, props->ptask, &task_list);
 				if (rc)
-					return rc;
+					goto out;
 			}
 
 			/** Check record_i if exists, add one if it doesn't */
-			rc = check_record(args->oh, args->th, dkey_val,
-					  props->record_i, props->cell_size,
-					  props->ptask);
+			rc = check_record(args->oh, args->th, dkey_val, props->record_i,
+					  props->cell_size, props->ptask, &task_list);
 			if (rc)
-				return rc;
+				goto out;
 		}
 		continue;
 	}
@@ -2418,15 +2431,13 @@ adjust_array_size_cb(tse_task_t *task, void *data)
 					   adjust_array_size_cb, &props,
 					   sizeof(props));
 		if (rc)
-			return rc;
+			goto out;
 
 		rc = tse_task_reinit(task);
-		if (rc) {
+		if (rc)
 			D_ERROR("FAILED to reinit task\n");
-			return rc;
-		}
 
-		return rc;
+		goto out;
 	}
 
 	/** if array is smaller, write a record at the new size */
@@ -2435,10 +2446,13 @@ adjust_array_size_cb(tse_task_t *task, void *data)
 			props->dkey_val, (int)props->record_i);
 
 		/** no need to check the record, we know it's not there */
-		rc = add_record(args->oh, args->th, props);
+		rc = add_record(args->oh, args->th, props, &task_list);
 		if (rc)
-			return rc;
+			goto out;
 	}
+
+out:
+	tse_task_list_traverse(&task_list, adjust_array_size_task_process, &rc);
 	return rc;
 }
 

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2243,11 +2243,10 @@ struct pmap_fail_stat {
 static void
 pmap_fail_node_init(struct pmap_fail_node *fnode)
 {
+	memset(fnode, 0, sizeof(*fnode));
 	fnode->pf_vers = fnode->pf_ver_inline;
 	fnode->pf_ver_total = PMAP_FAIL_INLINE_NR;
 	fnode->pf_ver_nr = 0;
-	memset(fnode->pf_vers, 0,
-	       sizeof(struct pmap_fail_ver) * fnode->pf_ver_total);
 }
 
 static void
@@ -2295,6 +2294,7 @@ pmap_fail_node_get(struct pmap_fail_stat *fstat)
 
 	D_ASSERT(fstat->pf_node_nr < fstat->pf_node_total);
 	fnode = &fstat->pf_nodes[fstat->pf_node_nr++];
+	pmap_fail_node_init(fnode);
 	return fnode;
 }
 

--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -74,7 +74,7 @@ struct tse_task_private {
 	 */
 	uint16_t			 dtp_stack_top;
 	uint16_t			 dtp_embed_top;
-	/* generation of the task, +1 every time when task re-init */
+	/* generation of the task, +1 every time when task re-init or add dependent task */
 	ATOMIC uint32_t			 dtp_generation;
 	char				 dtp_buf[TSE_TASK_ARG_LEN];
 };


### PR DESCRIPTION
1. fix a tse bug of dep task check in tse_task_complete_callback
   In tse_task_complete_callback() it checks if new dep task added in
   task's completion callback, by check dtp_dep_cnt. But a problem
   is the dep task possibly be scheduled/executed immediately and be
   completed even before checking parent task' dtp_dep_cnt, that
   could cause parent task be completed 2 times.
   This patch fixes it by adding generation of parent task.
2. take extra refcount in tse_task_complete_callback
3. fix a bug in dfs adjust_array_size_cb()
   original code possibly create+schedule multiple dep tasks in
   adjust_array_size_cb(), that may cause firstly scheduled dep task
   complete immediately and then complete parent task, but still
   possible add more other dep tasks cause trouble in race condition.
   This patch fixes it by add dep tasks to task list and schedule/abort
   them all together.
   got some hints form Zhao Zhen <zp_8483@163.com> when debug it.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>