### PR TITLE
DAOS-11029 tse/dfs: bug fix in tse or dfs about task

### DIFF
--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -76,7 +76,7 @@ struct tse_task_private {
 	 */
 	uint16_t			 dtp_stack_top;
 	uint16_t			 dtp_embed_top;
-	/* generation of the task, +1 every time when task re-init */
+	/* generation of the task, +1 every time when task re-init or add dependent task */
 	ATOMIC uint32_t			 dtp_generation;
 	char				 dtp_buf[TSE_TASK_ARG_LEN];
 };


### PR DESCRIPTION
1. fix a tse bug of dep task check in tse_task_complete_callback
   In tse_task_complete_callback() it checks if new dep task added in
   task's completion callback, by check dtp_dep_cnt. But a problem
   is the dep task possibly be scheduled/executed immediately and be
   completed even before checking parent task' dtp_dep_cnt, that
   could cause parent task be completed 2 times.
   This patch fixes it by adding generation of parent task.
2. take extra refcount in tse_task_complete_callback
3. fix a bug in dfs adjust_array_size_cb()
   original code possibly create+schedule multiple dep tasks in
   adjust_array_size_cb(), that may cause firstly scheduled dep task
   complete immediately and then complete parent task, but still
   possible add more other dep tasks cause trouble in race condition.
   This patch fixes it by add dep tasks to task list and schedule/abort
   them all together.
   got some hints form Zhao Zhen <zp_8483@163.com> when debug it.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>