### PR TITLE
DAOS-10999 coverity: Use of 32-bit time_t

### DIFF
--- a/src/common/tests_lib.c
+++ b/src/common/tests_lib.c
@@ -39,7 +39,7 @@ dts_unit_oid_gen(enum daos_otype_t type, uint32_t shard)
 {
 	daos_unit_oid_t	uoid;
 
-	uoid.id_pub	= dts_oid_gen(time(NULL));
+	uoid.id_pub	= dts_oid_gen((unsigned int)(time(NULL) & 0xFFFFFFFFUL));
 	daos_obj_set_oid(&uoid.id_pub, type, DTS_OCLASS_DEF, shard + 1, 0);
 	uoid.id_shard	= shard;
 	uoid.id_pad_32	= 0;

--- a/src/tests/ftest/cart/utest/utest_hlc.c
+++ b/src/tests/ftest/cart/utest/utest_hlc.c
@@ -173,7 +173,7 @@ init_tests(void **state)
 	unsigned int seed;
 
 	/* Seed the random number generator once per test run */
-	seed = time(NULL);
+	seed = (unsigned int)(time(NULL) & 0xFFFFFFFFUL);
 	fprintf(stdout, "Seeding this test run with seed=%u\n", seed);
 	srand(seed);
 

--- a/src/vea/tests/vea_stress.c
+++ b/src/vea/tests/vea_stress.c
@@ -947,7 +947,7 @@ int main(int argc, char **argv)
 	char			*endp;
 	int			 i, rc;
 
-	rand_seed = time(0);
+	rand_seed = (unsigned int)(time(NULL) & 0xFFFFFFFFUL);
 	memset(pool_file, 0, sizeof(pool_file));
 	while ((rc = getopt_long(argc, argv, "C:c:d:f:H:lo:s:h", long_ops, NULL)) != -1) {
 		switch (rc) {


### PR DESCRIPTION
Fix for three tickets, DAOS-11005, DAOS-11003 and DAOS-10999

Signed-off-by: Lei Huang <lei.huang@intel.com>