### PR TITLE
DAOS-11054 test: Bump memcheck stage timeout to 45 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -607,7 +607,7 @@ pipeline {
                         label params.CI_UNIT_VM1_LABEL
                     }
                     steps {
-                        unitTest timeout_time: 35,
+                        unitTest timeout_time: 45,
                                  ignore_failure: true,
                                  inst_repos: prRepos(),
                                  inst_rpms: unitPackages()


### PR DESCRIPTION
We are close to the limit for this stage, bump it up a bit to
avoid frequent intermittent failures.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

Required-githooks: true