### PR TITLE
DAOS-10756 event: only thread private event owner changes status of e…

### DIFF
--- a/src/client/api/client_internal.h
+++ b/src/client/api/client_internal.h
@@ -56,6 +56,8 @@ struct daos_event_private {
 	unsigned int		is_barrier:1;
 	/** flag to indicate whether to convert DER to errno */
 	unsigned int		is_errno:1;
+	/** flag to indicate whether even is thread private */
+	unsigned int		is_th_private:1;
 
 	unsigned int		evx_flags;
 	daos_ev_status_t	evx_status;


### PR DESCRIPTION
…vent

Change the progress on the thread private event for only the event owner
to change the status of the event.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>