### PR TITLE
DAOS-9881 doc: re-add python venv instructions

### DIFF
--- a/docs/QSG/build_from_scratch.md
+++ b/docs/QSG/build_from_scratch.md
@@ -1,6 +1,7 @@
 # Build from scratch
 
-The following instructions describe how to build DAOS from source code. The following steps are required:
+The following instructions describe how to build DAOS from source code. This
+includes the following steps:
 
 1. Download Source Code
 2. Install Prerequisites
@@ -15,7 +16,7 @@ Download DAOS source code using the following command:
 
 The DAOS repository is hosted on [GitHub](https://github.com/daos-stack/daos).
 
-To checkout the 2.2 development branch, simply run:
+To checkout the 2.4 development branch, simply run:
 
 ```
 $ git clone --recurse-submodules https://github.com/daos-stack/daos.git
@@ -28,27 +29,24 @@ below) and initializes all the submodules automatically.
 ## Install Prerequisites
 
 To build DAOS and its dependencies, several software packages must be installed
-on the system. This includes scons, libuuid, cmocka, ipmctl, and several other
-packages usually available on all the Linux distributions. Moreover, a Go
-version of at least 1.10 is required.
+on the system. This includes libuuid, cmocka, Go, and several other packages
+usually available on all the Linux distributions.
 
-Some DAOS tests use MPI. The DAOS build process uses the environment modules
+Some DAOS tests also use MPI. The DAOS build process uses the environment modules
 package to detect the presence of MPI. If none is found, the build will skip
 building those tests.
+
+In addition some python packages are required, which can be installed via the
+Linux distribution or installed by [pip](https://pip.pypa.io/en/stable/) after
+the source code is available.
 
 Scripts to install all the required packages are provided for each supported
 distribution.
 
-### EL (including CentOS)
+### RHEL and Clones
 
-On CentOS7, please run the following command from the DAOS tree as root or via
-sudo.
-
-```bash
-$ ./utils/scripts/install-centos7.sh
-```
-
-For EL8, the following script must be used instead:
+For RHEL8-compatible distributions (e.g. Rocky Linux 8 or AlmaLinux 8), please
+run the following command from the DAOS tree as root or via sudo:
 
 ```bash
 $ ./utils/scripts/install-el8.sh
@@ -62,13 +60,31 @@ For openSUSE, the following command should be executed as root or via sudo:
 $ ./utils/scripts/install-leap15.sh
 ```
 
-### Unbuntu
+### Ubuntu
 
 As for Ubuntu, please run the following script as the root user or via sudo:
 
 ```bash
-$ ./utils/scripts/install-ubuntu20.sh
+$ ./utils/scripts/install-ubuntu.sh
 ```
+
+### Python Packages
+
+Python packages required to build and test DAOS can be installed via a python
+[virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/)
+or system wide.
+
+To install a virtual environment for building DAOS use the following commands, this will only need
+to be done once, for a new shell only the `source venv/bin/activate` command will be required.
+Alternatively the packages can be installed via pip as root which will install onto PATH, or as
+the user outside of a virtual environment, in which case `~/.local/bin` will need to be added to
+PATH.
+
+ ```bash
+ $ python3 -m venv venv
+ $ source venv/bin/activate
+ $ python3 -m pip install -f requirements.txt
+ ```
 
 ## Build DAOS
 
@@ -76,7 +92,7 @@ Once all prerequisites installed and the sources are downloaded,
 DAOS can be built via the following command:
 
 ```bash
-$ scons-3 --config=force --build-deps=yes install
+$ scons --config=force --build-deps=yes install
 ```
 
 By default, DAOS and its dependencies are installed under the `install`
@@ -86,7 +102,7 @@ command line (e.g., PREFIX=/usr/local).
 
 !!! note
     Several parameters can be set (e.g., COMPILER=clang or COMPILER=icc) on the
-    scons command line. Please see `scons-3 --help` for all the possible options.
+    scons command line. Please see `scons --help` for all the possible options.
     Those options are also saved for future compilations.
 
 ## Environment setup

--- a/docs/QSG/docker.md
+++ b/docs/QSG/docker.md
@@ -198,8 +198,7 @@ $ docker exec daos-admin dmg -i storage format
 ```
 
 Upon successful completion of the format, the storage engine is started, and pools
-can be created using the daos admin tool.  For more advanced configurations and usage refer to the
-section [DAOS Tour](https://docs.daos.io/v2.2/QSG/tour/).
+can be created using the daos admin tool.
 
 
 ### Via docker-compose

--- a/docs/QSG/setup_rhel.md
+++ b/docs/QSG/setup_rhel.md
@@ -1,15 +1,14 @@
 # DAOS Set-Up on RHEL and Clones
 
+The following instructions detail how to install, set up and start DAOS servers and clients on
+two or more nodes.
+This document includes instructions for RHEL8-compatible distributions. This includes
+RHEL8, Rocky Linux and AlmaLinux.
 
-The following instructions detail how to install, set up and start DAOS servers and clients on two or more nodes.
-This document includes instructions for EL8 and CentOS 7.
-The process is identical for CentOS Linux 7 and EL 8,
-except for the location of the DAOS RPM repository.
 For setup instructions on OpenSuse, refer to
 [OpenSuse setup](setup_suse.md).
 
-For more details reference the [DAOS administration guide](https://docs.daos.io/v2.2/admin/hardware/).
-
+For more details reference the [DAOS administration guide](https://docs.daos.io/v2.4/admin/hardware/).
 
 ## Requirements
 
@@ -28,7 +27,7 @@ All nodes must have:
     commands in parallel)
 
 In addition the server nodes should also have
-[IOMMU enabled](https://docs.daos.io/v2.2/admin/predeployment_check/#enable-iommu-optional).
+[IOMMU enabled](https://docs.daos.io/v2.4/admin/predeployment_check/#enable-iommu-optional).
 
 For the use of the commands outlined on this page the following shell
 variables will need to be defined:
@@ -62,17 +61,9 @@ based upon their role.  Admin and client nodes require the installation
 of the daos-client RPM and the server nodes require the installation of the
 daos-server RPM.
 
-1. Configure access to the [DAOS package repository](https://packages.daos.io/v2.0/),
-   using the subdirectory that matches the EL/CentOS version of the nodes:
+1. Configure access to the [DAOS package repository](https://packages.daos.io/v2.4/):
 
-	**For CentOS7:**
-
-		pdsh -w $ALL_NODES 'sudo wget -O /etc/yum.repos.d/daos-packages.repo https://packages.daos.io/v2.0/CentOS7/packages/x86_64/daos_packages.repo'
-
-
-	**For EL8:**
-
-		pdsh -w $ALL_NODES 'sudo wget -O /etc/yum.repos.d/daos-packages.repo https://packages.daos.io/v2.0/EL8/packages/x86_64/daos_packages.repo'
+		pdsh -w $ALL_NODES 'sudo wget -O /etc/yum.repos.d/daos-packages.repo https://packages.daos.io/v2.4/EL8/packages/x86_64/daos_packages.repo'
 
 
 2. Import GPG key on all nodes:
@@ -190,7 +181,7 @@ Server nodes require the following certificate files:
 -   A copy of the Client certificate (client.crt) owned by the
     daos_server user
 
-See [Certificate Configuration](https://docs.daos.io/v2.2/admin/deployment/#certificate-configuration)
+See [Certificate Configuration](https://docs.daos.io/v2.4/admin/deployment/#certificate-configuration)
 for more information.
 
 !!! note

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -296,19 +296,18 @@ To build the Docker image directly from GitHub, run the following command:
 
 ```bash
 $ docker build https://github.com/daos-stack/daos.git#master \
-        -f utils/docker/Dockerfile.centos.7 -t daos
+        -f utils/docker/Dockerfile.el.8 -t daos
 ```
 
 or from a local tree:
 
 ```bash
-$ docker build  . -f utils/docker/Dockerfile.centos.7 -t daos
+$ docker build  . -f utils/docker/Dockerfile.el.8 -t daos
 ```
-
-This creates a CentOS 7 image, fetches the latest DAOS version from GitHub,
+This creates a Rocky Linux 8 image, fetches the latest DAOS version from GitHub,
 builds it, and installs it in the image.
-For Ubuntu and other Linux distributions, replace Dockerfile.centos.7 with
-Dockerfile.ubuntu.20.04 and the appropriate version of interest.
+For Ubuntu and other Linux distributions, replace Dockerfile.el.8 with
+Dockerfile.ubuntu or the appropriate version of interest.
 
 ### Simple Docker Setup
 


### PR DESCRIPTION
Doc changes from PR 8816 (commit 6a422f5edade3a1de4ea0885e915c826850b154a)
were made to the wrong file and then deleted in PR 9422 (commit
cf420e9786d2168d096fc63a4ae786754ea25263).

Add pip/venv instructions to the QSG/installation section.

Also clean up references to CentOS 7 in the documentation.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>