### PR TITLE
DAOS-9595 chk: consolidate pool membership

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,9 +244,11 @@ pipeline {
                                    password: GITHUB_USER_PSW,
                                    ignored_files: "src/control/vendor/*:" +
                                                   "*.pb-c.[ch]:" +
+                                                  "src/chk/chk_internal.h:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:" +
                                                   "src/client/java/daos-java/src/main/native/include/daos_jni_common.h:" +
+                                                  "src/mgmt/rpc.h:" +
                                                   "*.crt:" +
                                                   "*.pem:" +
                                                   "*_test.go:" +

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -231,24 +231,603 @@ out:
 	return rc;
 }
 
+static inline void
+chk_engine_post_repair(struct chk_instance *ins, int *result)
+{
+	if (!(ins->ci_prop.cp_flags & CHK__CHECK_FLAG__CF_FAILOUT))
+		*result = 0;
+}
+
+static int
+chk_engine_pm_orphan(struct chk_pool_rec *cpr, d_rank_t rank, int index)
+{
+	struct chk_instance		*ins = cpr->cpr_ins;
+	struct chk_property		*prop = &ins->ci_prop;
+	struct chk_bookmark		*cbk = &cpr->cpr_bk;
+	d_rank_list_t			 ranks = { 0 };
+	struct chk_report_unit		 cru;
+	Chk__CheckInconsistClass	 cla;
+	Chk__CheckInconsistAction	 act;
+	char				 msg[160] = { 0 };
+	uint32_t			 options[2];
+	uint32_t			 option_nr = 0;
+	int				 decision = -1;
+	int				 result = 0;
+	int				 rc = 0;
+
+	if (index < 0)
+		cla = CHK__CHECK_INCONSIST_CLASS__CIC_ENGINE_NONEXIST_IN_MAP;
+	else
+		cla = CHK__CHECK_INCONSIST_CLASS__CIC_ENGINE_DOWN_IN_MAP;
+	act = prop->cp_policies[cla];
+	cbk->cb_statistics.cs_total++;
+	cpr->cpr_dirty = 1;
+
+	switch (act) {
+	case CHK__CHECK_INCONSIST_ACTION__CIA_DEFAULT:
+		/*
+		 * If the rank does not exists in the pool map, then destroy the orphan pool rank
+		 * to release space by default.
+		 *
+		 * XXX: Currently, we does not support to add the orphan pool rank into the pool
+		 *	map. If want to add them, it can be done via pool extend after DAOS check.
+		 *
+		 * Fall through.
+		 */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS:
+		/* Fall through. */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD:
+		if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
+			cbk->cb_statistics.cs_repaired++;
+		} else {
+			if (index < 0) {
+				ranks.rl_ranks = &rank;
+				ranks.rl_nr = 1;
+				result = ds_mgmt_tgt_pool_destroy(cpr->cpr_uuid, &ranks);
+			} else {
+				result = ds_mgmt_tgt_pool_shard_destroy(cpr->cpr_uuid, index, rank);
+			}
+			if (result != 0)
+				cbk->cb_statistics.cs_failed++;
+			else
+				cbk->cb_statistics.cs_repaired++;
+		}
+		break;
+	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
+		/* Report the inconsistency without repair. */
+		cbk->cb_statistics.cs_ignored++;
+		break;
+	default:
+		/*
+		 * If the specified action is not applicable to the inconsistency,
+		 * then switch to interaction mode for the decision from admin.
+		 *
+		 * Fall through.
+		 */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
+		options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
+		options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+		option_nr = 2;
+		break;
+	}
+
+report:
+	cru.cru_gen = cbk->cb_gen;
+	cru.cru_cla = cla;
+	cru.cru_act = option_nr != 0 ? CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT : act;
+	cru.cru_target = 0;
+	cru.cru_rank = dss_self_rank();
+	cru.cru_option_nr = option_nr;
+	cru.cru_detail_nr = 0;
+	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
+	cru.cru_cont = NULL;
+	cru.cru_obj = NULL;
+	cru.cru_dkey = NULL;
+	cru.cru_akey = NULL;
+	snprintf(msg, 159, "Check engine detects orphan %s entry in pool map for "
+		 DF_UUIDF", rank %u, index %d",
+		 index < 0 ? "rank" : "shard", DP_UUID(cpr->cpr_uuid), rank, index);
+	cru.cru_msg = msg;
+	cru.cru_options = options;
+	cru.cru_details = NULL;
+	cru.cru_result = result;
+
+	rc = chk_engine_report(&cru, &decision);
+
+	D_CDEBUG(result != 0 || rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_ENGINE" detects orphan %s entry in pool map for "
+		 DF_UUIDF", rank %u, index %d, action %u (%s), handle_rc %d, "
+		 "report_rc %d, decision %d\n",
+		 DP_ENGINE(ins), index < 0 ? "rank" : "shard", DP_UUID(cpr->cpr_uuid), rank,
+		 index, act, option_nr ? "need interact" : "no interact", result, rc, decision);
+
+	if (rc != 0 && option_nr > 0) {
+		cbk->cb_statistics.cs_failed++;
+		result = rc;
+	}
+
+	if (result != 0 || option_nr == 0)
+		goto out;
+
+	option_nr = 0;
+
+	switch (decision) {
+	default:
+		D_ERROR(DF_ENGINE" got invalid decision %d for orphan %s entry in pool map "
+			"for pool "DF_UUIDF", rank %u, index %d. Ignore the inconsistency.\n",
+			DP_ENGINE(ins), decision, index < 0 ? "rank" : "shard",
+			DP_UUID(cpr->cpr_uuid), rank, index);
+		/*
+		 * Invalid option, ignore the inconsistency.
+		 *
+		 * Fall through.
+		 */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+		cbk->cb_statistics.cs_ignored++;
+		break;
+	case CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
+		if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
+			cbk->cb_statistics.cs_repaired++;
+		} else {
+			if (index < 0) {
+				ranks.rl_ranks = &rank;
+				ranks.rl_nr = 1;
+				result = ds_mgmt_tgt_pool_destroy(cpr->cpr_uuid, &ranks);
+			} else {
+				result = ds_mgmt_tgt_pool_shard_destroy(cpr->cpr_uuid, index, rank);
+			}
+			if (result != 0)
+				cbk->cb_statistics.cs_failed++;
+			else
+				cbk->cb_statistics.cs_repaired++;
+		}
+		break;
+	}
+
+	goto report;
+
+out:
+	chk_engine_post_repair(ins, &result);
+
+	return result;
+}
+
+static int
+chk_engine_pm_dangling(struct chk_pool_rec *cpr, struct pool_component *comp,
+		       uint32_t *version, uint32_t status)
+{
+	struct chk_instance		*ins = cpr->cpr_ins;
+	struct chk_property		*prop = &ins->ci_prop;
+	struct chk_bookmark		*cbk = &cpr->cpr_bk;
+	struct chk_report_unit		 cru;
+	Chk__CheckInconsistClass	 cla;
+	Chk__CheckInconsistAction	 act;
+	char				 msg[160] = { 0 };
+	uint32_t			 options[2];
+	uint32_t			 option_nr = 0;
+	int				 decision = -1;
+	int				 result = 0;
+	int				 rc = 0;
+
+	D_ASSERTF(status == PO_COMP_ST_DOWNOUT || status == PO_COMP_ST_DOWN,
+		  "Unexpected pool map status %u\n", status);
+
+	cla = CHK__CHECK_INCONSIST_CLASS__CIC_ENGINE_HAS_NO_STORAGE;
+	act = prop->cp_policies[cla];
+	cbk->cb_statistics.cs_total++;
+	cpr->cpr_dirty = 1;
+
+	switch (act) {
+	case CHK__CHECK_INCONSIST_ACTION__CIA_DEFAULT:
+		/*
+		 * If the target does not has storage on the engine, then mark it as 'DOWN' or
+		 * 'DOWNOUT' in the pool map by default.
+		 *
+		 * Fall through.
+		 */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET:
+		/* For dryrun mode, we will not persistently store the change in subsequent step. */
+		comp->co_status = status;
+		comp->co_fseq = ++(*version);
+		cbk->cb_statistics.cs_repaired++;
+		break;
+	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
+		/* Report the inconsistency without repair. */
+		cbk->cb_statistics.cs_ignored++;
+		break;
+	default:
+		/*
+		 * If the specified action is not applicable to the inconsistency,
+		 * then switch to interaction mode for the decision from admin.
+		 *
+		 * Fall through.
+		 */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
+		options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET;
+		options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+		option_nr = 2;
+		break;
+	}
+
+report:
+	cru.cru_gen = cbk->cb_gen;
+	cru.cru_cla = cla;
+	cru.cru_act = option_nr != 0 ? CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT : act;
+	cru.cru_target = 0;
+	cru.cru_rank = dss_self_rank();
+	cru.cru_option_nr = option_nr;
+	cru.cru_detail_nr = 0;
+	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
+	cru.cru_cont = NULL;
+	cru.cru_obj = NULL;
+	cru.cru_dkey = NULL;
+	cru.cru_akey = NULL;
+	snprintf(msg, 159, "Check engine detects dangling %s entry in pool map for pool "
+		 DF_UUIDF", rank %u, index %u",
+		 comp->co_type == PO_COMP_TP_RANK ? "rank" : "target",
+		 DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index);
+	cru.cru_msg = msg;
+	cru.cru_options = options;
+	cru.cru_details = NULL;
+	cru.cru_result = result;
+
+	rc = chk_engine_report(&cru, &decision);
+
+	D_CDEBUG(result != 0 || rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_ENGINE" detects dangling %s entry in pool map for pool "
+		 DF_UUIDF" rank %u, index %u, action %u (%s), handle_rc %d, report_rc %d, "
+		 "decision %d\n",
+		 DP_ENGINE(ins), comp->co_type == PO_COMP_TP_RANK ? "rank" : "target",
+		 DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index, act,
+		 option_nr ? "need interact" : "no interact", result, rc, decision);
+
+	if (rc != 0 && option_nr > 0) {
+		cbk->cb_statistics.cs_failed++;
+		result = rc;
+	}
+
+	if (result != 0 || option_nr == 0)
+		goto out;
+
+	option_nr = 0;
+
+	switch (decision) {
+	default:
+		D_ERROR(DF_ENGINE" got invalid decision %d for dangling %s entry in pool map "
+			"for pool "DF_UUIDF", rank %u, index %u. Ignore the inconsistency.\n",
+			DP_ENGINE(ins), decision,
+			comp->co_type == PO_COMP_TP_RANK ? "rank" : "target",
+			DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index);
+		/*
+		 * Invalid option, ignore the inconsistency.
+		 *
+		 * Fall through.
+		 */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+		cbk->cb_statistics.cs_ignored++;
+		break;
+	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
+		/* For dryrun mode, we will not persistently store the change in subsequent step. */
+		comp->co_status = status;
+		comp->co_fseq = ++(*version);
+		cbk->cb_statistics.cs_repaired++;
+		break;
+	}
+
+	goto report;
+
+out:
+	chk_engine_post_repair(ins, &result);
+
+	return result;
+}
+
+static int
+chk_engine_pm_unknown_target(struct chk_pool_rec *cpr, struct pool_component *comp)
+{
+	struct chk_instance		*ins = cpr->cpr_ins;
+	struct chk_bookmark		*cbk = &cpr->cpr_bk;
+	struct chk_report_unit		 cru;
+	Chk__CheckInconsistClass	 cla;
+	Chk__CheckInconsistAction	 act;
+	char				 msg[256] = { 0 };
+	int				 rc;
+
+	cla = CHK__CHECK_INCONSIST_CLASS__CIC_UNKNOWN;
+	act = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+	cbk->cb_statistics.cs_total++;
+	cbk->cb_statistics.cs_ignored++;
+	cpr->cpr_dirty = 1;
+
+	cru.cru_gen = cbk->cb_gen;
+	cru.cru_cla = cla;
+	cru.cru_act = act;
+	cru.cru_target = 0;
+	cru.cru_rank = dss_self_rank();
+	cru.cru_option_nr = 0;
+	cru.cru_detail_nr = 0;
+	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
+	cru.cru_cont = NULL;
+	cru.cru_obj = NULL;
+	cru.cru_dkey = NULL;
+	cru.cru_akey = NULL;
+	snprintf(msg, 255, "Check engine detects unknown target entry in pool map for pool "
+		 DF_UUIDF", rank %u, index %u, status %u, skip.\n"
+		 "You can change its status via DAOS debug tool if it is not for downgrade case.",
+		 DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index, comp->co_status);
+	cru.cru_msg = msg;
+	cru.cru_options = NULL;
+	cru.cru_details = NULL;
+	cru.cru_result = 0;
+
+	rc = chk_engine_report(&cru, NULL);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_ENGINE" detects unknown target entry in pool map for pool "DF_UUIDF", rank %u, "
+		 "target %u, action %u (no interact), handle_rc 0, report_rc %d, decision 0\n",
+		 DP_ENGINE(ins), DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index, act, rc);
+
+	return 0;
+}
+
+static int
+chk_engine_pool_mbs_one(struct chk_pool_rec *cpr, struct pool_map *map, struct chk_pool_mbs *mbs,
+			uint32_t *version)
+{
+	struct pool_domain	*dom;
+	struct pool_component	*comp;
+	int			 i;
+	int			 rc = 0;
+	bool			 unknown;
+
+	dom = pool_map_find_node_by_rank(map, mbs->cpm_rank);
+	if (dom == NULL) {
+		D_ASSERT(mbs->cpm_rank != dss_self_rank());
+
+		rc = chk_engine_pm_orphan(cpr, mbs->cpm_rank, -1);
+		goto out;
+	}
+
+	for (i = 0; i < dom->do_target_nr; i++) {
+		comp = &dom->do_targets[i].ta_comp;
+		unknown = false;
+
+		switch (comp->co_status) {
+		case PO_COMP_ST_DOWN:
+			/*
+			 * XXX: In the future, we may support to add the target (if exist) back.
+			 *
+			 * Fall through.
+			 */
+		case PO_COMP_ST_DOWNOUT:
+			if (comp->co_index < mbs->cpm_tgt_nr &&
+			    (mbs->cpm_tgt_status[comp->co_index] == DS_POOL_TGT_EMPTY ||
+			     mbs->cpm_tgt_status[comp->co_index] == DS_POOL_TGT_NORMAL))
+				rc = chk_engine_pm_orphan(cpr, mbs->cpm_rank, comp->co_index);
+			/*
+			 * Otherwise if the down/downout entry only exists in pool map,
+			 * then it is useless, do nothing.
+			 */
+			break;
+		case PO_COMP_ST_NEW:
+			if (comp->co_index >= mbs->cpm_tgt_nr ||
+			    mbs->cpm_tgt_status[comp->co_index] == DS_POOL_TGT_NONEXIST ||
+			    mbs->cpm_tgt_status[comp->co_index] == DS_POOL_TGT_EMPTY)
+				/* Dangling new entry in pool map, directly mark as 'DOWNOUT'. */
+				rc = chk_engine_pm_dangling(cpr, comp, version,
+							    PO_COMP_ST_DOWNOUT);
+			break;
+		default:
+			D_WARN(DF_ENGINE" hit knownn pool target status %u for "DF_UUIDF
+			       " with rank %u, index %u, ID %u\n",
+			       DP_ENGINE(cpr->cpr_ins), comp->co_status, DP_UUID(cpr->cpr_uuid),
+			       mbs->cpm_rank, comp->co_index, comp->co_id);
+			unknown = true;
+			/* Fall through. */
+		case PO_COMP_ST_UP:
+			/* Fall through. */
+		case PO_COMP_ST_UPIN:
+			/* Fall through. */
+		case PO_COMP_ST_DRAIN:
+			if (comp->co_index >= mbs->cpm_tgt_nr ||
+			    mbs->cpm_tgt_status[comp->co_index] == DS_POOL_TGT_NONEXIST ||
+			    mbs->cpm_tgt_status[comp->co_index] == DS_POOL_TGT_EMPTY)
+				/*
+				 * Some data may be on the lost target, mark as 'DOWN' that
+				 * will be handled via rebuild in subsequent process.
+				 */
+				rc = chk_engine_pm_dangling(cpr, comp, version, PO_COMP_ST_DOWN);
+			else if (mbs->cpm_tgt_status[comp->co_index] == DS_POOL_TGT_NORMAL &&
+				 unknown)
+				/*
+				 * XXX: The unknown status maybe because of downgraded from new
+				 *	layout? It is better to keep it there with reporting it
+				 *	to admin who can adjust the status via DAOS debug tool.
+				 */
+				rc = chk_engine_pm_unknown_target(cpr, comp);
+			break;
+		}
+
+		if (rc != 0)
+			goto out;
+
+		/*
+		 * Set the target status as DS_POOL_TGT_NONEXIST in
+		 * DRAM to bypass the subsequent orphan entry check.
+		 */
+		if (comp->co_index < mbs->cpm_tgt_nr)
+			mbs->cpm_tgt_status[comp->co_index] = DS_POOL_TGT_NONEXIST;
+
+		comp->co_flags |= PO_COMPF_CHK_DONE;
+	}
+
+	dom->do_comp.co_flags |= PO_COMPF_CHK_DONE;
+
+	for (i = 0; i < mbs->cpm_tgt_nr; i++) {
+		if (mbs->cpm_tgt_status[i] == DS_POOL_TGT_EMPTY ||
+		    mbs->cpm_tgt_status[i] == DS_POOL_TGT_NORMAL) {
+			rc = chk_engine_pm_orphan(cpr, mbs->cpm_rank, i);
+			if (rc != 0)
+				goto out;
+		}
+	}
+
+out:
+	return rc;
+}
+
+static int
+chk_engine_find_dangling_pm(struct chk_pool_rec *cpr, struct pool_map *map, uint32_t *version)
+{
+	struct pool_domain	*doms = NULL;
+	struct pool_component	*r_comp;
+	struct pool_component	*t_comp;
+	int			 rank_nr;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+	bool			 down = false;
+
+	rank_nr = pool_map_find_nodes(map, PO_COMP_ID_ALL, &doms);
+	if (rank_nr <= 0)
+		D_GOTO(out, rc = rank_nr);
+
+	for (i = 0; i < rank_nr; i++) {
+		r_comp = &doms[i].do_comp;
+		if (r_comp->co_flags & PO_COMPF_CHK_DONE ||
+		    r_comp->co_status == PO_COMP_ST_DOWN || r_comp->co_status == PO_COMP_ST_DOWNOUT)
+			continue;
+
+		for (j = 0; j < doms[i].do_target_nr; j++) {
+			t_comp = &doms[i].do_targets[j].ta_comp;
+
+			switch (t_comp->co_status) {
+			case PO_COMP_ST_DOWN:
+				down = true;
+				break;
+			case PO_COMP_ST_DOWNOUT:
+				/* Do nothing. */
+				break;
+			case PO_COMP_ST_NEW:
+				/* Dangling new entry in pool map, directly mark as 'DOWNOUT'. */
+				rc = chk_engine_pm_dangling(cpr, t_comp, version,
+							    PO_COMP_ST_DOWNOUT);
+				break;
+			default:
+				D_WARN(DF_ENGINE" hit knownn pool target status %u for "DF_UUIDF
+				       " with rank %u, index %u, ID %u\n", DP_ENGINE(cpr->cpr_ins),
+				       t_comp->co_status, DP_UUID(cpr->cpr_uuid),
+				       t_comp->co_rank, t_comp->co_index, t_comp->co_id);
+				/* Fall through. */
+			case PO_COMP_ST_UP:
+				/* Fall through. */
+			case PO_COMP_ST_UPIN:
+				/* Fall through. */
+			case PO_COMP_ST_DRAIN:
+				down = true;
+				/*
+				 * Some data may be on the lost target, mark as 'DOWN' that
+				 * will be handled via rebuild in subsequent process.
+				 */
+				rc = chk_engine_pm_dangling(cpr, t_comp, version, PO_COMP_ST_DOWN);
+				break;
+			}
+
+			if (rc != 0)
+				goto out;
+
+			t_comp->co_flags |= PO_COMPF_CHK_DONE;
+		}
+
+		rc = chk_engine_pm_dangling(cpr, r_comp, version,
+					    down ? PO_COMP_ST_DOWN : PO_COMP_ST_DOWNOUT);
+		if (rc != 0)
+			goto out;
+
+		r_comp->co_flags |= PO_COMPF_CHK_DONE;
+	}
+
+out:
+	return rc;
+}
+
 static void
 chk_engine_pool_ult(void *args)
 {
 	struct chk_pool_rec	*cpr = args;
+	struct chk_instance	*ins = cpr->cpr_ins;
 	struct chk_bookmark	*cbk = &cpr->cpr_bk;
+	struct pool_svc		*svc = NULL;
+	struct pool_map		*map = NULL;
+	uint32_t		 version;
+	int			 i;
 	int			 rc = 0;
+	int			 rc1 = 0;
 
-#if 0
-	/* TBD: Drive the check since phase CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS. */
+	rc = pool_svc_lookup_leader(cpr->cpr_uuid, &svc, NULL);
+	if (rc != 0)
+		/*
+		 * XXX: Before the phase of CHK__CHECK_SCAN_PHASE__CSP_OBJ_SCRUB, the PS
+		 *	leader drives the check on engine. Current one is not PS leader.
+		 */
+		D_GOTO(out, rc = 0);
 
-	while (!cpr->cpr_stop && cpr->cpr_ins->ci_sched_running) {
-		dss_sleep(300);
+	ABT_mutex_lock(cpr->cpr_mutex);
+
+again:
+	if (cpr->cpr_stop || !ins->ci_sched_running) {
+		ABT_mutex_unlock(cpr->cpr_mutex);
+		goto out;
 	}
-#endif
+
+	if (cpr->cpr_mbs == NULL) {
+		ABT_cond_wait(cpr->cpr_cond, cpr->cpr_mutex);
+		goto again;
+	}
+
+	ABT_mutex_unlock(cpr->cpr_mutex);
+
+	rc = ds_pool_svc_load_map(svc, &map);
+	if (rc != 0)
+		goto out;
+
+	version = pool_map_get_version(map);
+
+	for (i = 0; i < cpr->cpr_shard_nr; i++) {
+		rc = chk_engine_pool_mbs_one(cpr, map, &cpr->cpr_mbs[i], &version);
+		if (rc != 0)
+			break;
+	}
+
+	/* Lookup for dangling entry in the pool map. */
+	if (rc == 0)
+		rc = chk_engine_find_dangling_pm(cpr, map, &version);
+
+	if (cpr->cpr_dirty) {
+		cpr->cpr_dirty = 0;
+
+		chk_bk_update_pool(cbk, cpr->cpr_uuid);
+
+		/*
+		 * Flush the pool map to persistent storage (if not under dryrun mode)
+		 * and distribute the pool map to other pool shards.
+		 */
+		rc1 = ds_pool_svc_flush_map(svc, map, version);
+	}
+
+out:
+	if (map != NULL)
+		pool_map_decref(map);
+	if (svc != NULL)
+		pool_svc_put_leader(svc);
 
 	cpr->cpr_done = 1;
 	cbk->cb_phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
-	if (rc != 0)
+	if (rc != 0 || rc1 != 0)
 		cbk->cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_FAILED;
 	else
 		cbk->cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKED;
@@ -278,7 +857,7 @@ chk_engine_sched(void *args)
 	D_INFO(DF_ENGINE" on rank %u start at the phase %u\n",
 	       DP_ENGINE(ins), myrank, cbk->cb_phase);
 
-	if (cbk->cb_phase >= CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
+	if (cbk->cb_phase > CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
 		rc = chk_engine_setup_pools(ins, true);
 		if (rc != 0)
 			goto out;
@@ -491,8 +1070,8 @@ chk_engine_start_prepare(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *r
 	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_COMPLETED)
 		D_GOTO(out, rc = 1);
 
-	/* Drop dryrun flags needs to reset. */
-	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN && !(flags & CHK__CHECK_FLAG__CF_DRYRUN)) {
+	/* For dryrun mode, restart from the beginning since we did not record former repairing. */
+	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
 		if (!reset)
 			D_GOTO(out, rc = -DER_NOT_RESUME);
 
@@ -814,8 +1393,7 @@ chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 	if (rc != 0)
 		goto out_pool;
 
-	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_PREPARE ||
-	    cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
+	if (cbk->cb_phase <= CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS) {
 		cpfa.cpfa_pool_hdl = ins->ci_pool_hdl;
 		rc = ds_pool_clues_init(chk_pool_filter, &cpfa, clues);
 		if (rc != 0)
@@ -1243,6 +1821,65 @@ out:
 		 DF_ENGINE" on rank %u takes action for seq "
 		 DF_X64" with gen "DF_X64", class %u, action %u, flags %x: "DF_RC"\n",
 		 DP_ENGINE(ins), dss_self_rank(), seq, gen, cla, act, flags, DP_RC(rc));
+
+	return rc;
+}
+
+int
+chk_engine_pool_mbs(uint64_t gen, uuid_t uuid, const char *label, uint32_t flags,
+		    uint32_t mbs_nr, struct chk_pool_mbs *mbs_array, struct rsvc_hint *hint)
+{
+	struct chk_instance	*ins = chk_engine;
+	struct chk_pool_rec	*cpr = NULL;
+	struct pool_svc		*svc = NULL;
+	d_iov_t			 riov;
+	d_iov_t			 kiov;
+	int			 rc;
+
+	rc = pool_svc_lookup_leader(uuid, &svc, hint);
+	if (rc != 0)
+		goto out;
+
+	d_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, uuid, sizeof(uuid_t));
+	rc = dbtree_lookup(ins->ci_pool_hdl, &kiov, &riov);
+	if (rc != 0)
+		goto out;
+
+	cpr = (struct chk_pool_rec *)riov.iov_buf;
+	ABT_mutex_lock(cpr->cpr_mutex);
+
+	/* XXX: resent RPC. */
+	if (unlikely(cpr->cpr_mbs != NULL))
+		goto unlock;
+
+	D_ALLOC_ARRAY(cpr->cpr_mbs, mbs_nr);
+	if (cpr->cpr_mbs == NULL)
+		D_GOTO(unlock, rc = -DER_NOMEM);
+
+	memcpy(cpr->cpr_mbs, mbs_array, sizeof(*mbs_array) * mbs_nr);
+	cpr->cpr_shard_nr = mbs_nr;
+
+	if (flags & CMF_REPAIR_LABEL) {
+		rc = chk_dup_label(&cpr->cpr_label, label, label != NULL ? strlen(label) : 0);
+		if (rc != 0)
+			goto unlock;
+
+		cpr->cpr_delay_label = 1;
+	}
+
+unlock:
+	if (rc != 0) {
+		D_FREE(cpr->cpr_mbs);
+		cpr->cpr_shard_nr = 0;
+		cpr->cpr_stop = 1;
+	}
+
+	ABT_cond_broadcast(cpr->cpr_cond);
+	ABT_mutex_unlock(cpr->cpr_mutex);
+out:
+	if (svc != NULL)
+		pool_svc_put_leader(svc);
 
 	return rc;
 }

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -130,6 +130,23 @@ ds_chk_act_hdlr(crt_rpc_t *rpc)
 }
 
 static void
+ds_chk_pool_mbs_hdlr(crt_rpc_t *rpc)
+{
+	struct chk_pool_mbs_in	*cpmi = crt_req_get(rpc);
+	struct chk_pool_mbs_out	*cpmo = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_engine_pool_mbs(cpmi->cpmi_gen, cpmi->cpmi_pool, cpmi->cpmi_label,
+				 cpmi->cpmi_flags, cpmi->cpmi_targets.ca_count,
+				 cpmi->cpmi_targets.ca_arrays, &cpmo->cpmo_hint);
+
+	cpmo->cpmo_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check pool mbs: "DF_RC"\n", DP_RC(rc));
+}
+
+static void
 ds_chk_report_hdlr(crt_rpc_t *rpc)
 {
 	struct chk_report_in	*cri = crt_req_get(rpc);

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -413,6 +413,7 @@ pool_buf_attach(struct pool_buf *buf, struct pool_component *comps,
 			buf->pb_domain_nr++;
 
 		buf->pb_comps[nr] = comps[0];
+		buf->pb_comps[nr].co_flags &= ~PO_COMPF_CHK_DONE;
 
 		D_DEBUG(DB_TRACE, "nr %d %s\n", nr,
 			pool_comp_type2str(comps[0].co_type));
@@ -2332,7 +2333,7 @@ pmap_comp_failed(struct pool_component *comp)
 {
 	return (comp->co_status == PO_COMP_ST_DOWN) ||
 	       (comp->co_status == PO_COMP_ST_DOWNOUT &&
-		comp->co_flags == PO_COMPF_DOWN2OUT);
+		comp->co_flags & PO_COMPF_DOWN2OUT);
 }
 
 static bool

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -61,7 +61,11 @@ enum pool_component_flags {
 	 * indicate when in status PO_COMP_ST_DOWNOUT, it is changed from
 	 * PO_COMP_ST_DOWN (rather than from PO_COMP_ST_DRAIN).
 	 */
-	PO_COMPF_DOWN2OUT	= 1,
+	PO_COMPF_DOWN2OUT	= (1 << 0),
+	/**
+	 * The component has been processed by DAOS check, only in DRAM.
+	 */
+	PO_COMPF_CHK_DONE	= (1 << 1),
 };
 
 #define co_in_ver	co_out_ver

--- a/src/include/daos/rsvc.h
+++ b/src/include/daos/rsvc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -13,6 +13,8 @@
 #define DAOS_RSVC_H
 
 #include <daos_types.h>
+
+#define RECHOOSE_SLEEP_MS 250
 
 /** Flags in rsvc_hint::sh_flags (opaque) */
 enum rsvc_hint_flag {

--- a/src/include/daos_srv/daos_mgmt_srv.h
+++ b/src/include/daos_srv/daos_mgmt_srv.h
@@ -35,5 +35,7 @@ int
 ds_mgmt_tgt_pool_exist(uuid_t uuid, char **path);
 int
 ds_mgmt_tgt_pool_destroy(uuid_t pool_uuid, d_rank_list_t *ranks);
+int
+ds_mgmt_tgt_pool_shard_destroy(uuid_t pool_uuid, int shard_idx, d_rank_t rank);
 
 #endif /* __MGMT_SRV_H__ */

--- a/src/mgmt/rpc.c
+++ b/src/mgmt/rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -43,6 +43,9 @@ CRT_RPC_DEFINE(mgmt_tgt_map_update, DAOS_ISEQ_MGMT_TGT_MAP_UPDATE,
 
 CRT_RPC_DEFINE(mgmt_get_bs_state, DAOS_ISEQ_MGMT_GET_BS_STATE,
 	       DAOS_OSEQ_MGMT_GET_BS_STATE)
+
+CRT_RPC_DEFINE(mgmt_tgt_shard_destroy, DAOS_ISEQ_MGMT_TGT_SHARD_DESTROY,
+	       DAOS_OSEQ_MGMT_TGT_SHARD_DESTROY)
 
 /* Define for cont_rpcs[] array population below.
  * See MGMT_PROTO_*_RPC_LIST macro definition

--- a/src/mgmt/rpc.h
+++ b/src/mgmt/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -64,7 +64,10 @@
 		&ds_mgmt_hdlr_tgt_map_update_co_ops),			\
 	X(MGMT_TGT_MARK,						\
 		0, &CQF_mgmt_mark,					\
-		ds_mgmt_tgt_mark_hdlr, NULL)
+		ds_mgmt_tgt_mark_hdlr, NULL),				\
+	X(MGMT_TGT_SHARD_DESTROY,					\
+		0, &CQF_mgmt_tgt_shard_destroy,				\
+		ds_mgmt_hdlr_tgt_shard_destroy, NULL)
 
 
 
@@ -213,5 +216,17 @@ CRT_RPC_DECLARE(mgmt_mark, DAOS_ISEQ_MGMT_MARK, DAOS_OSEQ_MGMT_MARK)
 
 CRT_RPC_DECLARE(mgmt_get_bs_state, DAOS_ISEQ_MGMT_GET_BS_STATE,
 		DAOS_OSEQ_MGMT_GET_BS_STATE)
+
+#define DAOS_ISEQ_MGMT_TGT_SHARD_DESTROY /* input fields */		\
+	((uuid_t)		(tsdi_pool_uuid)	CRT_VAR)	\
+	((int32_t)		(tsdi_shard_idx)	CRT_VAR)	\
+	((uint32_t)		(tsdi_padding)		CRT_VAR)
+
+#define DAOS_OSEQ_MGMT_TGT_SHARD_DESTROY /* output fields */		\
+	((int32_t)		(tsdo_rc)		CRT_VAR)	\
+	((uint32_t)		(tsdo_padding)		CRT_VAR)
+
+CRT_RPC_DECLARE(mgmt_tgt_shard_destroy, DAOS_ISEQ_MGMT_TGT_SHARD_DESTROY,
+		DAOS_OSEQ_MGMT_TGT_SHARD_DESTROY)
 
 #endif /* __MGMT_RPC_H__ */

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -146,6 +146,7 @@ int ds_mgmt_tgt_setup(void);
 void ds_mgmt_tgt_cleanup(void);
 void ds_mgmt_hdlr_tgt_create(crt_rpc_t *rpc_req);
 void ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *rpc_req);
+void ds_mgmt_hdlr_tgt_shard_destroy(crt_rpc_t *rpc_req);
 int ds_mgmt_tgt_create_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 				  void *priv);
 int ds_mgmt_tgt_create_post_reply(crt_rpc_t *rpc, void *priv);

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -124,9 +124,11 @@ out:
 void
 ds_pool_clue_init(uuid_t uuid, enum ds_pool_dir dir, struct ds_pool_clue *clue)
 {
-	char	       *path;
-	struct stat	st;
-	int		rc;
+	char		*path = NULL;
+	char		*file = NULL;
+	struct stat	 st;
+	int		 rc;
+	int		 i;
 
 	memset(clue, 0, sizeof(*clue));
 	uuid_copy(clue->pc_uuid, uuid);
@@ -160,6 +162,41 @@ ds_pool_clue_init(uuid_t uuid, enum ds_pool_dir dir, struct ds_pool_clue *clue)
 		}
 		goto out_path;
 	}
+
+	D_ALLOC_ARRAY(clue->pc_tgt_status, dss_tgt_nr);
+	if (clue->pc_tgt_status == NULL) {
+		D_ERROR(DF_UUIDF": failed to allocate service clue for shards status\n",
+			DP_UUID(uuid));
+		D_GOTO(out_path, rc = -DER_NOMEM);
+	}
+
+	for (i = 0; i < dss_tgt_nr; i++) {
+		rc = ds_mgmt_tgt_file(uuid, VOS_FILE, &i, &file);
+		if (file == NULL) {
+			D_ERROR(DF_UUIDF": failed to allocate file name for shards status %d\n",
+				DP_UUID(uuid), i);
+			D_GOTO(out_path, rc = -DER_NOMEM);
+		}
+
+		rc = stat(file, &st);
+		D_FREE(file);
+		if (rc != 0) {
+			if (errno == ENOENT) {
+				clue->pc_tgt_status[i] = DS_POOL_TGT_NONEXIST;
+			}  else {
+				rc = daos_errno2der(errno);
+				D_ERROR(DF_UUIDF": failed to stat target %d: %d\n",
+					DP_UUID(uuid), i, rc);
+				D_GOTO(out_path, rc);
+			}
+		} else {
+			if (st.st_size > 0)
+				clue->pc_tgt_status[i] = DS_POOL_TGT_NORMAL;
+			else
+				clue->pc_tgt_status[i] = DS_POOL_TGT_EMPTY;
+		}
+	}
+	clue->pc_tgt_nr = dss_tgt_nr;
 
 	D_ALLOC(clue->pc_svc_clue, sizeof(*clue->pc_svc_clue));
 	if (clue->pc_svc_clue == NULL) {
@@ -198,6 +235,7 @@ ds_pool_clue_fini(struct ds_pool_clue *clue)
 		D_FREE(clue->pc_svc_clue);
 	}
 	D_FREE(clue->pc_label);
+	D_FREE(clue->pc_tgt_status);
 }
 
 /* Argument for glance_at_one */

--- a/src/pool/srv_pool_map.c
+++ b/src/pool/srv_pool_map.c
@@ -188,7 +188,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 			D_DEBUG(DB_MD, "change "DF_TARGET" to DOWNOUT %p\n",
 				DP_TARGET(target), map);
 			if (target->ta_comp.co_status == PO_COMP_ST_DOWN)
-				target->ta_comp.co_flags = PO_COMPF_DOWN2OUT;
+				target->ta_comp.co_flags |= PO_COMPF_DOWN2OUT;
 			target->ta_comp.co_status = PO_COMP_ST_DOWNOUT;
 			target->ta_comp.co_out_ver = ++(*version);
 			if (print_changes)
@@ -266,7 +266,7 @@ ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 					target->ta_comp.co_fseq;
 			} else if (opc == POOL_EXCLUDE_OUT) {
 				dom->do_comp.co_status = PO_COMP_ST_DOWNOUT;
-				dom->do_comp.co_flags = PO_COMPF_DOWN2OUT;
+				dom->do_comp.co_flags |= PO_COMPF_DOWN2OUT;
 				dom->do_comp.co_out_ver =
 					target->ta_comp.co_out_ver;
 			} else


### PR DESCRIPTION
When DAOS check start, all involved check engines will report their
known pools' information, including the pool service replicas, pool
label and related storage allocation, to the check leader via reply.

After the pool list consolidation in the pass_1, for each pool, the
check leader will send related pool information to its pool service
leaders via new RPC - CHK_POOL_MBS.

On the check engine side, the pool service leader compares the pool
map with these information pushed from the check leader and handles
the following cases:

1. An target has some allocated storage but does not appear in the
   pool map. Under such case, the associated space will be deleted
   from the engine by default.

2. An target has some allocated storage and is marked as "DOWN" or
   "DOWNOUT" in the pool map. For this case, the administrator can
   decide to either remove or leave it there.

3. An target is referenced in the pool map ("NEW", "UP", "UPIN" or
   "DRAIN"), but no storage is actually allocated on this engine.
   Under such case, the entry for the target in the pool map will
   be marked as "DOWN" (for the "UP", "UPIN" or "DRAIN" entry) or
   "DOWNOUT" (for the "NEW" entry).

Temporarily skip code format check against src/chk/chk_internal.h
and src/mgmt/rpc.h to avoid fake warning messages.

Signed-off-by: Fan Yong <fan.yong@intel.com>