### PR TITLE
DAOS-10954 test: Fix for CID 21969

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -503,7 +503,7 @@ dmg_pool_create(const char *dmg_config_file,
 		if (tmp_fd < 0) {
 			D_ERROR("failed to generate unique label: %s\n",
 				strerror(errno));
-			D_GOTO(out, rc = d_errno2der(errno));
+			D_GOTO(out_cmd, rc = d_errno2der(errno));
 		}
 		close(tmp_fd);
 		unlink(path);


### PR DESCRIPTION
Free args if mkstemp() fails.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>

Required-githooks: true
