### PR TITLE
DAOS-11056 test: Check for rebuild status to complete.

### DIFF
--- a/src/tests/ftest/erasurecode/online_rebuild_single.py
+++ b/src/tests/ftest/erasurecode/online_rebuild_single.py
@@ -64,3 +64,5 @@ class EcodOnlineRebuildSingle(ErasureCodeSingle):
         # EC data was written with +2 parity so after killing Two servers data
         # should be intact and no data corruption observed.
         self.start_online_single_operation("READ", parity=2)
+        # Wait for rebuild to complete
+        self.pool.wait_for_rebuild(False)


### PR DESCRIPTION
Test-tag: ec_online_rebuild_single
Test-repeat: 10

Summary
- Presently, test fails to destroy the container/pool intermittently with DER_BUSY/DER_TIMEOUT status. 
- We need to make sure rebuild is not happening when we try to destroy container/pool. Once rebuild is done, pool/container destroy should work fine. 

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>