### PR TITLE
DAOS-9599_2 chk: pool cleanup for CR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,11 +244,9 @@ pipeline {
                                    password: GITHUB_USER_PSW,
                                    ignored_files: "src/control/vendor/*:" +
                                                   "*.pb-c.[ch]:" +
-                                                  "src/chk/chk_internal.h:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:" +
                                                   "src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:" +
                                                   "src/client/java/daos-java/src/main/native/include/daos_jni_common.h:" +
-                                                  "src/mgmt/rpc.h:" +
                                                   "*.crt:" +
                                                   "*.pem:" +
                                                   "*_test.go:" +

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -755,6 +755,62 @@ out:
 	return rc;
 }
 
+static int
+chk_engine_bad_pool_label(struct chk_pool_rec *cpr, struct pool_svc *svc)
+{
+	struct chk_instance		*ins = cpr->cpr_ins;
+	struct chk_bookmark		*cbk = &cpr->cpr_bk;
+	struct chk_report_unit		 cru;
+	Chk__CheckInconsistClass	 cla;
+	Chk__CheckInconsistAction	 act;
+	int				 result = 0;
+	int				 rc = 0;
+
+	cla = CHK__CHECK_INCONSIST_CLASS__CIC_POOL_BAD_LABEL;
+	act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS;
+	cbk->cb_statistics.cs_total++;
+	cpr->cpr_dirty = 1;
+
+	if (ins->ci_prop.cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
+		cbk->cb_statistics.cs_repaired++;
+	} else {
+		result = ds_pool_svc_update_label(svc, cpr->cpr_label);
+		if (result != 0)
+			cbk->cb_statistics.cs_failed++;
+		else
+			cbk->cb_statistics.cs_repaired++;
+	}
+
+	cru.cru_gen = cbk->cb_gen;
+	cru.cru_cla = cla;
+	cru.cru_act = act;
+	cru.cru_target = 0;
+	cru.cru_rank = dss_self_rank();
+	cru.cru_option_nr = 0;
+	cru.cru_detail_nr = 0;
+	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
+	cru.cru_cont = NULL;
+	cru.cru_obj = NULL;
+	cru.cru_dkey = NULL;
+	cru.cru_akey = NULL;
+	cru.cru_msg = "Check engine detects corrupted pool label";
+	cru.cru_options = NULL;
+	cru.cru_details = NULL;
+	cru.cru_result = result;
+
+	rc = chk_engine_report(&cru, NULL);
+
+	D_CDEBUG(result != 0 || rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_ENGINE" detects corrupted label for pool "
+		 DF_UUIDF", action %u (no interact), MS label %s, handle_rc %d, report_rc %d\n",
+		 DP_ENGINE(ins), DP_UUID(cpr->cpr_uuid), act,
+		 cpr->cpr_label != NULL ? cpr->cpr_label : "(null)", result, rc);
+
+	chk_engine_post_repair(ins, &result);
+
+	return result;
+}
+
 static void
 chk_engine_pool_ult(void *args)
 {
@@ -807,6 +863,9 @@ again:
 	if (rc == 0)
 		rc = chk_engine_find_dangling_pm(cpr, map, &version);
 
+	if (rc == 0 && cpr->cpr_delay_label)
+		rc = chk_engine_bad_pool_label(cpr, svc);
+
 	if (cpr->cpr_dirty) {
 		cpr->cpr_dirty = 0;
 
@@ -818,6 +877,12 @@ again:
 		 */
 		rc1 = ds_pool_svc_flush_map(svc, map, version);
 	}
+
+	/*
+	 * Cleanup all old connections. It is no matter even if we cannot evict some
+	 * old connections. That is also independent from former check phases result.
+	 */
+	ds_pool_svc_evict_all(svc);
 
 out:
 	if (map != NULL)

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -289,6 +289,8 @@ int ds_pool_target_status_check(struct ds_pool *pool, uint32_t id,
 				uint8_t matched_status, struct pool_target **p_tgt);
 int ds_pool_svc_load_map(struct pool_svc *svc, struct pool_map **map);
 int ds_pool_svc_flush_map(struct pool_svc *svc, struct pool_map *map, uint32_t version);
+int ds_pool_svc_update_label(struct pool_svc *svc, const char *label);
+int ds_pool_svc_evict_all(struct pool_svc *svc);
 void ds_pool_disable_exclude(void);
 void ds_pool_enable_exclude(void);
 


### PR DESCRIPTION
That mainly includes the following:

1. Handle the inconsistent pool label (based on former comparing result
   with management service) if decide to trust MS known pool label.

2. Revoking all pool connections recorded in the pool service.

Signed-off-by: Fan Yong <fan.yong@intel.com>