### PR TITLE
DAOS-11063 vos: check and reset NONEXIST in iter_next and probe

### DIFF
--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -850,17 +850,16 @@ next:
 			VOS_TX_TRACE_FAIL(rc,
 					  "failed to iterate next (type=%d): "
 					  DF_RC"\n", type, DP_RC(rc));
+			if (rc == -DER_NONEXIST) {
+				daos_anchor_set_eof(anchor);
+				rc = 0;
+			}
 			break;
 		} else {
 			rc = advance_stage(type, rc, param, anchors, anchor,
 					   &stage, VOS_ITER_STAGE_FILTER, &probe_flags);
 			JUMP_TO_STAGE(rc, next, probe, out);
 		}
-	}
-
-	if (rc == -DER_NONEXIST) {
-		daos_anchor_set_eof(anchor);
-		rc = 0;
 	}
 out:
 	if (rc >= 0)


### PR DESCRIPTION
Only reset nonexist error after iter_next and probe, to keep the
return value from other callback in vos_iterate_interal().

Signed-off-by: Di Wang <di.wang@intel.com>