### PR TITLE
CART-89 bug: Fix provider settings

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -441,7 +441,7 @@ out:
 }
 
 static int
-prov_settings_apply(crt_provider_t prov, bool primary, crt_init_options_t *opt)
+prov_settings_apply(bool primary, crt_provider_t prov, crt_init_options_t *opt)
 {
 	char	*srx_env;
 	int	rc = 0;


### PR DESCRIPTION
- Fix a bug that caused provider settings (like sep override) to
not take effect due to mixed arguments

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>