### PR TITLE
DAOS-11077 DFS: change mtime/atime/ctime in inode to store hlc

### DIFF
--- a/src/cart/crt_hlc.c
+++ b/src/cart/crt_hlc.c
@@ -120,6 +120,18 @@ int crt_hlc2timespec(uint64_t hlc, struct timespec *ts)
 	return 0;
 }
 
+int crt_timespec2hlc(struct timespec ts, uint64_t *hlc)
+{
+	uint64_t nsec;
+
+	if (hlc == NULL)
+		return -DER_INVAL;
+
+	nsec = (ts.tv_sec - CRT_HLC_START_SEC) * NSEC_PER_SEC + ts.tv_nsec;
+	*hlc = crt_nsec2hlc(nsec);
+	return 0;
+}
+
 uint64_t crt_unixnsec2hlc(uint64_t unixnsec)
 {
 	uint64_t start = CRT_HLC_START_SEC * NSEC_PER_SEC;

--- a/src/client/dfs/README.md
+++ b/src/client/dfs/README.md
@@ -86,6 +86,7 @@ Directory Object
         uid: user identifier
         gid: group identifier
         size: symlink size (0 for files/dirs)
+        object HLC: internal timestamp used to track max epoch of a file
     A-key "x:xattr1"	// extended attribute name (if any)
     A-key "x:xattr2"	// extended attribute name (if any)
 ~~~~~~

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -545,6 +545,17 @@ int
 crt_hlc2timespec(uint64_t hlc, struct timespec *ts);
 
 /**
+ * Return HLC from timespec
+ *
+ * \param[in]	ts	timespec struct
+ * \param[out]	hlc	HLC timestamp
+ *
+ * \return		DER_SUCCESS on success, negative value if error
+ */
+int
+crt_timespec2hlc(struct timespec ts, uint64_t *hlc);
+
+/**
  * Return the HLC timestamp of unixnsec in hlc.
  *
  * \param[in] unixnsec         Unix nanosecond timestamp

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1412,7 +1412,6 @@ dfs_test_mtime(void **state)
 	assert_int_equal(prev_ts.tv_sec, stbuf.st_mtim.tv_sec);
 	assert_int_equal(prev_ts.tv_nsec, stbuf.st_mtim.tv_nsec);
 
-	printf("reset mtime ...\n");
 	/** reset the mtime on the file to the first timestamp */
 	memset(&stbuf, 0, sizeof(stbuf));
 	stbuf.st_mtim.tv_sec = first_ts.tv_sec;
@@ -1427,7 +1426,6 @@ dfs_test_mtime(void **state)
 	assert_int_equal(first_ts.tv_sec, stbuf.st_mtim.tv_sec);
 	assert_int_equal(first_ts.tv_nsec, stbuf.st_mtim.tv_nsec);
 
-	printf("punch ...\n");
 	/** truncate the file */
 	rc = dfs_punch(dfs_mt, file, 0, DFS_MAX_FSIZE);
 	assert_int_equal(rc, 0);


### PR DESCRIPTION
Using HLC converted from timespec allows for nsec precision.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>