### PR TITLE
DAOS-10870 dtx: handle active DTX entry update properly

### DIFF
--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -278,6 +278,9 @@ extern "C" {
 	/** No service available */					\
 	ACTION(DER_NO_SERVICE,		(DER_ERR_DAOS_BASE + 39),	\
 	       No service available)					\
+	/** The TX ID may be reused. */					\
+	ACTION(DER_TX_ID_REUSED,	(DER_ERR_DAOS_BASE + 40),	\
+	       TX ID may be reused)					\
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -107,6 +107,8 @@ struct obj_auxi_args {
 	crt_bulk_t			*bulks;
 	uint32_t			 iod_nr;
 	uint32_t			 initial_shard;
+	uint32_t			 retry_cnt;
+	uint32_t			 padding;
 	d_list_t			 shard_task_head;
 	struct obj_reasb_req		 reasb_req;
 	struct obj_auxi_tgt_list	*failed_tgt_list;
@@ -1918,6 +1920,7 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 			D_GOTO(err, rc);
 		}
 		*io_task_reinited = true;
+		obj_auxi->retry_cnt++;
 	} else if (obj_auxi->spec_shard || obj_auxi->spec_group) {
 		/* If the RPC sponsor specifies shard or group, we will NOT
 		 * reschedule the IO, but not prevent the pool map refresh.
@@ -3174,19 +3177,21 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		}
 	}
 
+	/*
+	 * We mark the RPC as RESEND although @io_retry does not
+	 * guarantee that the RPC has ever been sent. It may cause
+	 * some overhead on server side, but no correctness issues.
+	 *
+	 * On the other hand, the client may resend the RPC to new
+	 * shard if leader switched. That is why the resend logic
+	 * is handled at object layer rather than shard layer.
+	 */
+	if (obj_auxi->io_retry)
+		obj_auxi->flags |= ORF_RESEND;
+
 	/* for retried obj IO, reuse the previous shard tasks and resched it */
 	if (obj_auxi->io_retry && obj_auxi->args_initialized &&
 	    !obj_auxi->new_shard_tasks) {
-		/* We mark the RPC as RESEND although @io_retry does not
-		 * guarantee that the RPC has ever been sent. It may cause
-		 * some overhead on server side, but no correctness issues.
-		 *
-		 * On the other hand, the client may resend the RPC to new
-		 * shard if leader switched. That is why the resend logic
-		 * is handled at object layer rather than shard layer.
-		 */
-		obj_auxi->flags |= ORF_RESEND;
-
 		/* if with shard task list, reuse it and re-schedule */
 		if (!d_list_empty(task_list)) {
 			struct shard_task_reset_arg reset_arg;
@@ -4661,6 +4666,45 @@ obj_comp_cb(tse_task_t *task, void *data)
 		}
 		if (!obj_auxi->ec_in_recov)
 			obj_ec_fail_info_reset(&obj_auxi->reasb_req);
+	}
+
+	if (unlikely(task->dt_result == -DER_TX_ID_REUSED)) {
+		D_ASSERT(daos_handle_is_inval(obj_auxi->th));
+
+		if (obj_auxi->retry_cnt != 0)
+			/* XXX: it is must because miss to set "RESEND" flag, that is bug. */
+			D_ASSERTF(0,
+				  "Miss 'RESEND' flag (%x) when resend the RPC for task %p: %u\n",
+				  obj_auxi->flags, task, obj_auxi->retry_cnt);
+
+		/* For non-retry case, restart TX with new TX ID. */
+		switch (obj_auxi->opc) {
+		case DAOS_OBJ_RPC_UPDATE: {
+			struct shard_rw_args	*rw_arg = &obj_auxi->rw_args;
+
+			D_INFO("DTX ID "DF_DTI" for update is reused, re-generate\n",
+			       DP_DTI(&rw_arg->dti));
+			daos_dti_gen(&rw_arg->dti, false);
+			obj_auxi->io_retry = 1;
+			break;
+		}
+		case DAOS_OBJ_RPC_PUNCH:
+			/* fall through */
+		case DAOS_OBJ_RPC_PUNCH_DKEYS:
+			/* fall through */
+		case DAOS_OBJ_RPC_PUNCH_AKEYS: {
+			struct shard_punch_args	*punch_arg = &obj_auxi->p_args;
+
+			D_INFO("DTX ID "DF_DTI" for punch (%u) is reused, re-generate\n",
+			       DP_DTI(&punch_arg->pa_dti), obj_auxi->opc);
+			daos_dti_gen(&punch_arg->pa_dti, false);
+			obj_auxi->io_retry = 1;
+			break;
+		}
+		default:
+			D_ASSERTF(0, "Unexpected opc %u for '-DER_TX_ID_REUSED'\n", obj_auxi->opc);
+			break;
+		}
 	}
 
 	if ((!obj_auxi->no_retry || task->dt_result == -DER_FETCH_AGAIN) &&

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -156,8 +156,6 @@ struct obj_reasb_req {
 	uint32_t			 orr_tgt_nr;
 	/* number of targets that with IOM handled */
 	uint32_t			 orr_iom_tgt_nr;
-	/* number of iom extends */
-	uint32_t			 orr_iom_nr;
 	struct daos_oclass_attr		*orr_oca;
 	struct obj_ec_codec		*orr_codec;
 	pthread_mutex_t			 orr_mutex;
@@ -171,6 +169,8 @@ struct obj_reasb_req {
 	/* parity recx list (to compare parity ext/epoch when data recovery) */
 	struct daos_recx_ep_list	*orr_parity_lists;
 	uint32_t			 orr_parity_list_nr;
+	/* number of iom extends */
+	uint32_t			 orr_iom_nr;
 	/* #iods of IO req */
 	uint32_t			 orr_iod_nr;
 	/* for data recovery flag */

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -320,11 +320,20 @@ dtx_act_ent_update(struct btr_instance *tins, struct btr_record *rec,
 	dae_old = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 
 	D_ASSERT(dae_old != dae_new);
-	D_ASSERTF(dae_old->dae_aborted,
-		  "NOT allow to update act DTX entry for "DF_DTI
-		  " from epoch "DF_X64" to "DF_X64"\n",
-		  DP_DTI(&DAE_XID(dae_old)),
-		  DAE_EPOCH(dae_old), DAE_EPOCH(dae_new));
+
+	if (unlikely(!dae_old->dae_aborted)) {
+		/*
+		 * XXX: There are two possible reasons for that:
+		 *
+		 *	1. Client resent the RPC but without set 'RESEND' flag.
+		 *	2. Client reused the DTX ID for different modifications.
+		 *
+		 *	Currently, the 1st case is more suspected.
+		 */
+		D_ERROR("The TX ID "DF_DTI" may be reused for epoch "DF_X64" vs "DF_X64"\n",
+			DP_DTI(&DAE_XID(dae_old)), DAE_EPOCH(dae_old), DAE_EPOCH(dae_new));
+		return -DER_TX_ID_REUSED;
+	}
 
 	rec->rec_off = umem_ptr2off(&tins->ti_umm, dae_new);
 	dtx_evict_lid(cont, dae_old);


### PR DESCRIPTION
master-commit: dcec65eed3f4181711b7c3e626f2b07f2e1399ea

For any transaction, the DTX entry in the active DTX table is unique.
So when we allocate new DTX entry in the active DTX table, we should
not hit the entry with the same DTX ID. If that happened, then there
may be two possible cases:

1. Client resent the RPC but without set 'RESEND' flag.
2. Client reused the DTX ID for different modifications.

Currently, the 1st case is more suspected which is DAOS client logic
bug, need to be fixed correspondingly. If it is the 2nd case, we can
re-generate new TX ID.

Signed-off-by: Fan Yong <fan.yong@intel.com>