### PR TITLE
DAOS-10892 control: Add backward compatibility for enable_vmd param (…

### DIFF
--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -187,6 +187,7 @@ hyperthreads: false
 		WithFabricProvider("ofi+verbs").
 		WithAccessPoints("hostX:10002").
 		WithNrHugePages(6144).
+		WithDisableVMD(false).
 		WithEngines(
 			engine.MockConfig().
 				WithTargetCount(defaultTargetCount).

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -160,6 +160,7 @@ const (
 	ServerConfigInsufficientHugePages
 	ServerConfigNrHugepagesOutOfRange
 	ServerConfigHugepagesDisabled
+	ServerConfigVMDSettingDuplicate
 )
 
 // SPDK library bindings codes

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -722,7 +722,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 	baseConfig := func(provider string) *config.Server {
 		return config.DefaultServer().
 			WithControlLogFile(defaultControlLogFile).
-			WithFabricProvider(provider)
+			WithFabricProvider(provider).
+			WithDisableVMD(false)
 	}
 
 	for name, tc := range map[string]struct {

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -95,6 +95,11 @@ var (
 		"hugepages cannot be disabled if bdevs have been specified in config",
 		"remove nr_hugepages parameter from config to have the value automatically calculated",
 	)
+	FaultConfigVMDSettingDuplicate = serverConfigFault(
+		code.ServerConfigVMDSettingDuplicate,
+		"enable_vmd and disable_vmd parameters both specified in config",
+		"remove legacy enable_vmd parameter from config",
+	)
 )
 
 func FaultConfigDuplicateFabric(curIdx, seenIdx int) *fault.Fault {

--- a/src/control/server/config/server_legacy.go
+++ b/src/control/server/config/server_legacy.go
@@ -1,0 +1,48 @@
+//
+// (C) Copyright 2020-2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package config
+
+import "github.com/daos-stack/daos/src/control/server/engine"
+
+// ServerLegacy describes old configuration options that should be supported for backward
+// compatibility and may be deprecated in future releases.
+// See utils/config/daos_server.yml for parameter descriptions.
+type ServerLegacy struct {
+	// Detect outdated "enable_vmd" config parameter and direct users to update config file.
+	EnableVMD *bool `yaml:"enable_vmd,omitempty"`
+	// Detect outdated "servers" config, to direct users to change their config file.
+	Servers []*engine.Config `yaml:"servers,omitempty"`
+}
+
+// WithEnableVMD can be used to set the state of VMD functionality,
+// if not enabled then VMD devices will not be used if they exist.
+func (sl *ServerLegacy) WithEnableVMD(enabled bool) *ServerLegacy {
+	sl.EnableVMD = &enabled
+	return sl
+}
+
+func updateVMDSetting(legacyCfg ServerLegacy, srvCfg *Server) error {
+	switch {
+	case legacyCfg.EnableVMD == nil:
+		return nil // Legacy VMD setting not used.
+	case srvCfg.DisableVMD != nil:
+		return FaultConfigVMDSettingDuplicate // Both legacy and current settings used.
+	default:
+		disable := !(*legacyCfg.EnableVMD)
+		srvCfg.DisableVMD = &disable
+		return nil
+	}
+}
+
+// parseLegacyConfig takes server config raw bytes and updates the provided server config struct.
+func updateFromLegacyParams(srvCfg *Server) error {
+	if err := updateVMDSetting(srvCfg.Legacy, srvCfg); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -1016,6 +1016,31 @@ func TestServerConfig_Parsing(t *testing.T) {
 			},
 			expValidateErr: FaultConfigHugepagesDisabled,
 		},
+		"legacy vmd enable": {
+			inTxt:  "disable_vmd: true",
+			outTxt: "enable_vmd: true",
+			expCheck: func(c *Server) error {
+				if *c.DisableVMD != false {
+					return errors.Errorf("expected vmd to be not disabled")
+				}
+				return nil
+			},
+		},
+		"legacy vmd disable": {
+			inTxt:  "disable_vmd: true",
+			outTxt: "enable_vmd: false",
+			expCheck: func(c *Server) error {
+				if *c.DisableVMD != true {
+					return errors.Errorf("expected vmd to be disabled")
+				}
+				return nil
+			},
+		},
+		"legacy vmd disable; current vmd enable": {
+			inTxt:       "disable_vfio: true",
+			outTxt:      "enable_vmd: true",
+			expParseErr: FaultConfigVMDSettingDuplicate,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -224,16 +224,21 @@ func prepBdevStorage(srv *server, iommuEnabled bool) error {
 		DisableVFIO:  srv.cfg.DisableVFIO,
 	}
 
+	enableVMD := true
+	if srv.cfg.DisableVMD != nil && *srv.cfg.DisableVMD {
+		enableVMD = false
+	}
+
 	switch {
-	case !srv.cfg.DisableVMD && srv.cfg.DisableVFIO:
+	case enableVMD && srv.cfg.DisableVFIO:
 		srv.log.Info("VMD not enabled because VFIO disabled in config")
-	case !srv.cfg.DisableVMD && !iommuEnabled:
+	case enableVMD && !iommuEnabled:
 		srv.log.Info("VMD not enabled because IOMMU disabled on platform")
-	case !srv.cfg.DisableVMD && bdevCfgs.HaveEmulatedNVMe():
+	case enableVMD && bdevCfgs.HaveEmulatedNVMe():
 		srv.log.Info("VMD not enabled because emulated NVMe devices found in config")
 	default:
 		// If no case above matches, set enable VMD flag in request otherwise leave false.
-		prepReq.EnableVMD = !srv.cfg.DisableVMD
+		prepReq.EnableVMD = enableVMD
 	}
 
 	if bdevCfgs.HaveBdevs() {


### PR DESCRIPTION
…#9531)

Add backward compatibility for enable_vmd server config parameter

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>