### PR TITLE
DAOS-10820 control: Set system name in set engine log masks RPC (#9471)

### DIFF
--- a/src/control/cmd/dmg/server.go
+++ b/src/control/cmd/dmg/server.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -51,10 +51,14 @@ func (cmd *serverSetLogMasksCmd) Execute(_ []string) (errOut error) {
 	}
 	req.SetHostList(cmd.hostlist)
 
+	cmd.log.Debugf("set log masks request: %+v", req)
+
 	resp, err := control.SetEngineLogMasks(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
 		return err // control api returned an error, disregard response
 	}
+
+	cmd.log.Debugf("set log masks response: %+v", resp)
 
 	if cmd.jsonOutputEnabled() {
 		return cmd.outputJSON(resp, resp.Errors())

--- a/src/control/lib/control/server.go
+++ b/src/control/lib/control/server.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/server/engine"
 )
@@ -21,7 +22,7 @@ import (
 // request.
 type SetEngineLogMasksReq struct {
 	unaryRequest
-	Masks string
+	Masks string `json:"masks"`
 }
 
 // SetEngineLogMasksResp contains the results of a set engine log level
@@ -40,12 +41,19 @@ func SetEngineLogMasks(ctx context.Context, rpcClient UnaryInvoker, req *SetEngi
 		return nil, err
 	}
 
+	pbReq := new(ctlpb.SetLogMasksReq)
+	if err := convert.Types(req, pbReq); err != nil {
+		return nil, err
+	}
+	pbReq.Sys = req.getSystem(rpcClient)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
-		return ctlpb.NewCtlSvcClient(conn).SetEngineLogMasks(ctx, &ctlpb.SetLogMasksReq{Masks: req.Masks})
+		return ctlpb.NewCtlSvcClient(conn).SetEngineLogMasks(ctx, pbReq)
 	})
+	rpcClient.Debugf("DAOS set engine log masks request: %+v", pbReq)
 
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
+		rpcClient.Debugf("failed to invoke set engine log masks RPC: %s", err)
 		return nil, err
 	}
 
@@ -58,5 +66,6 @@ func SetEngineLogMasks(ctx context.Context, rpcClient UnaryInvoker, req *SetEngi
 		}
 	}
 
+	rpcClient.Debugf("DAOS set engine log masks response: %+v", resp)
 	return resp, nil
 }

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -389,6 +389,8 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 		return nil, errors.New("nil request")
 	}
 
+	svc.log.Debugf("CtlSvc.SetEngineLogMasks dispatch, req:%+v\n", req)
+
 	var errs []string
 
 	for idx, ei := range svc.harness.Instances() {
@@ -428,5 +430,9 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 		return nil, errors.New(strings.Join(errs, ", "))
 	}
 
-	return new(ctlpb.SetLogMasksResp), nil
+	resp := new(ctlpb.SetLogMasksResp)
+
+	svc.log.Debugf("CtlSvc.SetEngineLogMasks dispatch, resp:%+v\n", resp)
+
+	return resp, nil
 }

--- a/src/tests/ftest/control/dmg_server_set_logmasks.py
+++ b/src/tests/ftest/control/dmg_server_set_logmasks.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+
+from control_test_base import ControlTestBase
+
+class DmgServerSetLogmasksTest(ControlTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test Class Description:
+    Verify the server set-logmasks function of the dmg tool.
+    :avocado: recursive
+    """
+
+    def test_dmg_server_set_logmasks(self):
+        """
+        JIRA ID: DAOS-10900
+        Test Description: Test that server set-logmasks command completes successfully.
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=basic,control,dmg
+        :avocado: tags=test_dmg_server_set_logmasks
+        """
+        result = self.dmg.server_set_logmasks()
+
+        status = result["status"]
+        self.assertEqual(status, 0, "bad return status")

--- a/src/tests/ftest/control/dmg_server_set_logmasks.yaml
+++ b/src/tests/ftest/control/dmg_server_set_logmasks.yaml
@@ -1,0 +1,8 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+timeout: 120
+server_config:
+  name: daos_server

--- a/src/tests/ftest/control/dmg_storage_scan_scm.py
+++ b/src/tests/ftest/control/dmg_storage_scan_scm.py
@@ -26,7 +26,7 @@ class DmgStorageScanSCMTest(ControlTestBase):
     --verbose.
     :avocado: recursive
     """
-    def verify_storage_scam_scm(self, storage_dict):
+    def verify_storage_scan_scm(self, storage_dict):
         """Main test component.
 
         Args:
@@ -79,4 +79,4 @@ class DmgStorageScanSCMTest(ControlTestBase):
         :avocado: tags=hw,small
         :avocado: tags=control,dmg_storage_scan_scm
         """
-        self.verify_dmg_storage_scan(self.verify_storage_scam_scm)
+        self.verify_dmg_storage_scan(self.verify_storage_scan_scm)

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -444,6 +444,26 @@ class DmgCommand(DmgCommandBase):
         # }
         return self._get_json_result(("storage", "query", "usage"))
 
+    def server_set_logmasks(self):
+        """Set engine log-masks at runtime.
+
+        Raises:
+            CommandFailure: if the dmg server set logmasks command fails.
+
+        Returns:
+            dict: the dmg json command output converted to a python dictionary
+
+        """
+        # Example JSON output:
+        # {
+        #   "response": {
+        #     "host_errors": {}
+        #   },
+        #   "error": null,
+        #   "status": 0
+        # }
+        return self._get_json_result(("server", "set-logmasks"))
+
     def pool_create(self, scm_size, uid=None, gid=None, nvme_size=None,
                     target_list=None, svcn=None, acl_file=None, size=None,
                     tier_ratio=None, properties=None, label=None, nranks=None):

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -79,6 +79,8 @@ class DmgCommandBase(YamlCommand):
             self.sub_command_class = self.StorageSubCommand()
         elif self.sub_command.value == "system":
             self.sub_command_class = self.SystemSubCommand()
+        elif self.sub_command.value == "server":
+            self.sub_command_class = self.ServerSubCommand()
         elif self.sub_command.value == "cont":
             self.sub_command_class = self.ContSubCommand()
         elif self.sub_command.value == "config":
@@ -571,6 +573,28 @@ class DmgCommandBase(YamlCommand):
                 """Create a dmg system erase command object."""
                 super().__init__(
                     "/run/dmg/system/erase/*", "erase")
+
+    class ServerSubCommand(CommandWithSubCommand):
+        """Defines an object for the dmg server sub command."""
+
+        def __init__(self):
+            """Create a dmg server subcommand object."""
+            super().__init__("/run/dmg/server/*", "server")
+
+        def get_sub_command_class(self):
+            # pylint: disable=redefined-variable-type
+            """Get the dmg server sub command object."""
+            if self.sub_command.value == "set-logmasks":
+                self.sub_command_class = self.SetLogmasksSubCommand()
+            else:
+                self.sub_command_class = None
+
+        class SetLogmasksSubCommand(CommandWithParameters):
+            """Defines an object for the dmg server set-logmasks command."""
+
+            def __init__(self):
+                """Create a dmg server set-logmasks command object."""
+                super().__init__("/run/dmg/server/set-logmasks/*", "set-logmasks")
 
     class TelemetrySubCommand(CommandWithSubCommand):
         """Defines an object for the dmg telemetry sub command."""


### PR DESCRIPTION
Set system name in RPC message when setting engine log masks to avoid
interoperability check failures.

Add ftest to sanity check that the dmg server set-logmasks returns with
success to avoid regressions.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>