### PR TITLE
DAOS-10820 control: Set system name in set engine log masks RPC (#9471)

### DIFF
--- a/src/control/cmd/dmg/server.go
+++ b/src/control/cmd/dmg/server.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -51,10 +51,14 @@ func (cmd *serverSetLogMasksCmd) Execute(_ []string) (errOut error) {
 	}
 	req.SetHostList(cmd.hostlist)
 
+	cmd.Debugf("set log masks request: %+v", req)
+
 	resp, err := control.SetEngineLogMasks(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
 		return err // control api returned an error, disregard response
 	}
+
+	cmd.Debugf("set log masks response: %+v", resp)
 
 	if cmd.jsonOutputEnabled() {
 		return cmd.outputJSON(resp, resp.Errors())

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -406,6 +406,8 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 		return nil, errors.New("nil request")
 	}
 
+	svc.log.Debugf("CtlSvc.SetEngineLogMasks dispatch, req:%+v\n", req)
+
 	var errs []string
 
 	for idx, ei := range svc.harness.Instances() {
@@ -445,5 +447,9 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 		return nil, errors.New(strings.Join(errs, ", "))
 	}
 
-	return new(ctlpb.SetLogMasksResp), nil
+	resp := new(ctlpb.SetLogMasksResp)
+
+	svc.log.Debugf("CtlSvc.SetEngineLogMasks dispatch, resp:%+v\n", resp)
+
+	return resp, nil
 }

--- a/src/tests/ftest/control/dmg_server_set_logmasks.py
+++ b/src/tests/ftest/control/dmg_server_set_logmasks.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+
+from control_test_base import ControlTestBase
+
+class DmgServerSetLogmasksTest(ControlTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test Class Description:
+    Verify the server set-logmasks function of the dmg tool.
+    :avocado: recursive
+    """
+
+    def test_dmg_server_set_logmasks(self):
+        """
+        JIRA ID: DAOS-10900
+        Test Description: Test that server set-logmasks command completes successfully.
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=basic,control,dmg
+        :avocado: tags=test_dmg_server_set_logmasks
+        """
+        result = self.dmg.server_set_logmasks()
+
+        status = result["status"]
+        self.assertEqual(status, 0, "bad return status")

--- a/src/tests/ftest/control/dmg_server_set_logmasks.yaml
+++ b/src/tests/ftest/control/dmg_server_set_logmasks.yaml
@@ -1,0 +1,8 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+timeout: 120
+server_config:
+  name: daos_server

--- a/src/tests/ftest/control/dmg_storage_scan_scm.py
+++ b/src/tests/ftest/control/dmg_storage_scan_scm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -27,7 +27,7 @@ class DmgStorageScanSCMTest(ControlTestBase):
     --verbose.
     :avocado: recursive
     """
-    def verify_storage_scam_scm(self, storage_dict):
+    def verify_storage_scan_scm(self, storage_dict):
         """Main test component.
 
         Args:
@@ -80,4 +80,4 @@ class DmgStorageScanSCMTest(ControlTestBase):
         :avocado: tags=hw,small
         :avocado: tags=control,dmg_storage_scan_scm
         """
-        self.verify_dmg_storage_scan(self.verify_storage_scam_scm)
+        self.verify_dmg_storage_scan(self.verify_storage_scan_scm)

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -370,6 +370,26 @@ class DmgCommand(DmgCommandBase):
 
         """
         return self._get_result(("storage", "scan"), nvme_health=True)
+
+    def server_set_logmasks(self):
+        """Set engine log-masks at runtime.
+
+        Raises:
+            CommandFailure: if the dmg server set logmasks command fails.
+
+        Returns:
+            dict: the dmg json command output converted to a python dictionary
+
+        """
+        # Example JSON output:
+        # {
+        #   "response": {
+        #     "host_errors": {}
+        #   },
+        #   "error": null,
+        #   "status": 0
+        # }
+        return self._get_json_result(("server", "set-logmasks"))
 
     def pool_create(self, scm_size, uid=None, gid=None, nvme_size=None,
                     target_list=None, svcn=None, acl_file=None, size=None,

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -80,6 +80,8 @@ class DmgCommandBase(YamlCommand):
             self.sub_command_class = self.StorageSubCommand()
         elif self.sub_command.value == "system":
             self.sub_command_class = self.SystemSubCommand()
+        elif self.sub_command.value == "server":
+            self.sub_command_class = self.ServerSubCommand()
         elif self.sub_command.value == "cont":
             self.sub_command_class = self.ContSubCommand()
         elif self.sub_command.value == "config":
@@ -558,6 +560,28 @@ class DmgCommandBase(YamlCommand):
                 """Create a dmg system erase command object."""
                 super().__init__(
                     "/run/dmg/system/erase/*", "erase")
+
+    class ServerSubCommand(CommandWithSubCommand):
+        """Defines an object for the dmg server sub command."""
+
+        def __init__(self):
+            """Create a dmg server subcommand object."""
+            super().__init__("/run/dmg/server/*", "server")
+
+        def get_sub_command_class(self):
+            # pylint: disable=redefined-variable-type
+            """Get the dmg server sub command object."""
+            if self.sub_command.value == "set-logmasks":
+                self.sub_command_class = self.SetLogmasksSubCommand()
+            else:
+                self.sub_command_class = None
+
+        class SetLogmasksSubCommand(CommandWithParameters):
+            """Defines an object for the dmg server set-logmasks command."""
+
+            def __init__(self):
+                """Create a dmg server set-logmasks command object."""
+                super().__init__("/run/dmg/server/set-logmasks/*", "set-logmasks")
 
     class TelemetrySubCommand(CommandWithSubCommand):
         """Defines an object for the dmg telemetry sub command."""


### PR DESCRIPTION
Set system name in RPC message when setting engine log masks to avoid
interoperability check failures.

Add ftest to sanity check that the dmg server set-logmasks returns with
success to avoid regressions.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>