### PR TITLE
DAOS-11031 control: Clean hugepages on engine startup (#9625)

### DIFF
--- a/src/control/server/instance_exec.go
+++ b/src/control/server/instance_exec.go
@@ -112,9 +112,9 @@ func (ei *EngineInstance) finishStartup(ctx context.Context, ready *srvpb.Notify
 	return nil
 }
 
-// publishInstanceExitFn returns onInstanceExitFn which will publish an exit
+// createPublishInstanceExitFunc returns onInstanceExitFn which will publish an exit
 // event using the provided publish function.
-func publishInstanceExitFn(publishFn func(*events.RASEvent), hostname string) onInstanceExitFn {
+func createPublishInstanceExitFunc(publish func(*events.RASEvent), hostname string) onInstanceExitFn {
 	return func(_ context.Context, engineIdx uint32, rank system.Rank, exitErr error, exPid uint64) error {
 		if exitErr == nil {
 			return errors.New("expected non-nil exit error")
@@ -124,7 +124,7 @@ func publishInstanceExitFn(publishFn func(*events.RASEvent), hostname string) on
 			common.ExitStatus(exitErr.Error()), exPid)
 
 		// set forwardable if there is a rank for the MS to operate on
-		publishFn(evt.WithForwardable(!rank.Equals(system.NilRank)))
+		publish(evt.WithForwardable(!rank.Equals(system.NilRank)))
 
 		return nil
 	}

--- a/src/control/server/instance_exec_test.go
+++ b/src/control/server/instance_exec_test.go
@@ -81,7 +81,7 @@ func TestIOEngineInstance_exit(t *testing.T) {
 			}
 
 			hn, _ := os.Hostname()
-			engine.OnInstanceExit(publishInstanceExitFn(fakePublish, hn))
+			engine.OnInstanceExit(createPublishInstanceExitFunc(fakePublish, hn))
 
 			engine.exit(context.Background(), exitErr)
 

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -47,14 +47,14 @@ func (ei *EngineInstance) NotifyStorageReady() {
 	}()
 }
 
-// publishFormatRequiredFn returns onAwaitFormatFn which will publish an
+// createPublishFormatRequiredFunc returns onAwaitFormatFn which will publish an
 // event using the provided publish function to indicate that host is awaiting
 // storage format.
-func publishFormatRequiredFn(publishFn func(*events.RASEvent), hostname string) onAwaitFormatFn {
+func createPublishFormatRequiredFunc(publish func(*events.RASEvent), hostname string) onAwaitFormatFn {
 	return func(_ context.Context, engineIdx uint32, formatType string) error {
 		evt := events.NewEngineFormatRequiredEvent(hostname, engineIdx, formatType).
 			WithRank(uint32(system.NilRank))
-		publishFn(evt)
+		publish(evt)
 
 		return nil
 	}

--- a/src/control/server/instance_storage_test.go
+++ b/src/control/server/instance_storage_test.go
@@ -355,7 +355,7 @@ func TestIOEngineInstance_awaitStorageReady(t *testing.T) {
 			tly1 := newTally(engine.storageReady)
 
 			hn, _ := os.Hostname()
-			engine.OnAwaitFormat(publishFormatRequiredFn(tly1.fakePublish, hn))
+			engine.OnAwaitFormat(createPublishFormatRequiredFunc(tly1.fakePublish, hn))
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
 			defer cancel()

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -58,10 +58,10 @@ func getBdevCfgsFromSrvCfg(cfg *config.Server) storage.TierConfigs {
 	return bdevCfgs
 }
 
-func cfgGetReplicas(cfg *config.Server, resolver resolveTCPFn) ([]*net.TCPAddr, error) {
+func cfgGetReplicas(cfg *config.Server, resolve resolveTCPFn) ([]*net.TCPAddr, error) {
 	var dbReplicas []*net.TCPAddr
 	for _, ap := range cfg.AccessPoints {
-		apAddr, err := resolver("tcp", ap)
+		apAddr, err := resolve("tcp", ap)
 		if err != nil {
 			return nil, config.FaultConfigBadAccessPoints
 		}
@@ -124,9 +124,9 @@ func getControlAddr(params ctlAddrParams) (*net.TCPAddr, error) {
 	return ctlAddr, nil
 }
 
-func createListener(ctlAddr *net.TCPAddr, listener netListenFn) (net.Listener, error) {
+func createListener(ctlAddr *net.TCPAddr, listen netListenFn) (net.Listener, error) {
 	// Create and start listener on management network.
-	lis, err := listener("tcp4", fmt.Sprintf("0.0.0.0:%d", ctlAddr.Port))
+	lis, err := listen("tcp4", fmt.Sprintf("0.0.0.0:%d", ctlAddr.Port))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to listen on management interface")
 	}
@@ -302,48 +302,6 @@ func scanBdevStorage(srv *server) (*storage.BdevScanResponse, error) {
 	return nvmeScanResp, nil
 }
 
-// Minimum recommended number of hugepages has already been calculated and set in config so verify
-// we have enough free hugepage memory to satisfy this requirement before setting mem_size and
-// hugepage_size parameters for engine.
-func updateMemValues(srv *server, ei *EngineInstance, getHugePageInfo common.GetHugePageInfoFn) error {
-	ei.RLock()
-	engineCfg := ei.runner.GetConfig()
-	engineIdx := engineCfg.Index
-	if getBdevDevicesFromCfgs(engineCfg.Storage.Tiers.BdevConfigs()).Len() == 0 {
-		srv.log.Debugf("skipping mem check on engine %d, no bdevs", engineIdx)
-		ei.RUnlock()
-		return nil
-	}
-	ei.RUnlock()
-
-	// Retrieve up-to-date hugepage info to check that we got the requested number of hugepages.
-	hpi, err := getHugePageInfo()
-	if err != nil {
-		return err
-	}
-
-	// Calculate mem_size per I/O engine (in MB) from number of hugepages required per engine.
-	nrPagesRequired := srv.cfg.NrHugepages / len(srv.cfg.Engines)
-	pageSizeMb := hpi.PageSizeKb >> 10
-	memSizeReqMb := nrPagesRequired * pageSizeMb
-	memSizeFreeMb := hpi.Free * pageSizeMb
-
-	// Fail if free hugepage mem is not enough to sustain average I/O workload (~1GB).
-	if memSizeFreeMb < memSizeReqMb {
-		srv.log.Errorf("huge page info: %+v", *hpi)
-
-		return FaultInsufficientFreeHugePageMem(int(engineIdx), memSizeReqMb, memSizeFreeMb,
-			nrPagesRequired, hpi.Free)
-	}
-	srv.log.Debugf("Per-engine MemSize:%dMB, HugepageSize:%dMB", memSizeReqMb, pageSizeMb)
-
-	// Set engine mem_size and hugepage_size (MiB) values based on hugepage info.
-	ei.setMemSize(memSizeReqMb)
-	ei.setHugePageSz(pageSizeMb)
-
-	return nil
-}
-
 func setDaosHelperEnvs(cfg *config.Server, setenv func(k, v string) error) error {
 	if cfg.HelperLogFile != "" {
 		if err := setenv(pbin.DaosAdminLogFileEnvVar, cfg.HelperLogFile); err != nil {
@@ -360,38 +318,71 @@ func setDaosHelperEnvs(cfg *config.Server, setenv func(k, v string) error) error
 	return nil
 }
 
-func cleanEngineHugePagesFn(log logging.Logger, username string, svc *ControlService) onInstanceExitFn {
-	return func(ctx context.Context, engineIdx uint32, _ system.Rank, _ error, exPid uint64) error {
-		msg := fmt.Sprintf("cleaning engine %d (pid %d) hugepages after exit", engineIdx, exPid)
+// Minimum recommended number of hugepages has already been calculated and set in config so verify
+// we have enough free hugepage memory to satisfy this requirement before setting mem_size and
+// hugepage_size parameters for engine.
+func updateMemValues(srv *server, engine *EngineInstance, getHugePageInfo common.GetHugePageInfoFn) error {
+	engine.RLock()
+	ec := engine.runner.GetConfig()
+	ei := ec.Index
 
-		prepReq := storage.BdevPrepareRequest{
-			CleanHugePagesOnly: true,
-			CleanHugePagesPID:  exPid,
-			TargetUser:         username,
-		}
-
-		resp, err := svc.NvmePrepare(prepReq)
-		if err != nil {
-			err = errors.Wrap(err, msg)
-			log.Errorf(err.Error())
-			return err
-		}
-
-		log.Debugf("%s, %d removed", msg, resp.NrHugePagesRemoved)
-
+	if getBdevDevicesFromCfgs(ec.Storage.Tiers.BdevConfigs()).Len() == 0 {
+		srv.log.Debugf("skipping mem check on engine %d, no bdevs", ei)
+		engine.RUnlock()
 		return nil
 	}
+	engine.RUnlock()
+
+	// Retrieve up-to-date hugepage info to check that we got the requested number of hugepages.
+	hpi, err := getHugePageInfo()
+	if err != nil {
+		return err
+	}
+
+	// Calculate mem_size per I/O engine (in MB) from number of hugepages required per engine.
+	nrPagesRequired := srv.cfg.NrHugepages / len(srv.cfg.Engines)
+	pageSizeMb := hpi.PageSizeKb >> 10
+	memSizeReqMb := nrPagesRequired * pageSizeMb
+	memSizeFreeMb := hpi.Free * pageSizeMb
+
+	// Fail if free hugepage mem is not enough to sustain average I/O workload (~1GB).
+	if memSizeFreeMb < memSizeReqMb {
+		srv.log.Errorf("huge page info: %+v", *hpi)
+		return FaultInsufficientFreeHugePageMem(int(ei), memSizeReqMb, memSizeFreeMb,
+			nrPagesRequired, hpi.Free)
+	}
+	srv.log.Debugf("Per-engine MemSize:%dMB, HugepageSize:%dMB", memSizeReqMb, pageSizeMb)
+
+	// Set engine mem_size and hugepage_size (MiB) values based on hugepage info.
+	engine.setMemSize(memSizeReqMb)
+	engine.setHugePageSz(pageSizeMb)
+
+	return nil
+}
+
+func cleanEngineHugePages(srv *server, engineIdx uint32) error {
+	msg := fmt.Sprintf("engine %d: cleaning hugepages before starting", engineIdx)
+
+	req := storage.BdevPrepareRequest{
+		CleanHugePagesOnly: true,
+	}
+
+	resp, err := srv.ctlSvc.NvmePrepare(req)
+	if err != nil {
+		return errors.Wrap(err, msg)
+	}
+
+	srv.log.Debugf("%s, %d removed", msg, resp.NrHugePagesRemoved)
+
+	return nil
 }
 
 func registerEngineEventCallbacks(srv *server, engine *EngineInstance, allStarted *sync.WaitGroup) {
 	// Register callback to publish engine process exit events.
-	engine.OnInstanceExit(publishInstanceExitFn(srv.pubSub.Publish, srv.hostname))
-
-	// Register callback to clear hugepages used by engine process after it has exited.
-	engine.OnInstanceExit(cleanEngineHugePagesFn(srv.log, srv.runningUser.Username, srv.ctlSvc))
+	engine.OnInstanceExit(createPublishInstanceExitFunc(srv.pubSub.Publish, srv.hostname))
 
 	// Register callback to publish engine format requested events.
-	engine.OnAwaitFormat(publishFormatRequiredFn(srv.pubSub.Publish, srv.hostname))
+	engine.OnAwaitFormat(createPublishFormatRequiredFunc(srv.pubSub.Publish, srv.hostname))
 
 	var onceReady sync.Once
 	engine.OnReady(func(_ context.Context) error {
@@ -400,19 +391,27 @@ func registerEngineEventCallbacks(srv *server, engine *EngineInstance, allStarte
 		onceReady.Do(func() {
 			allStarted.Done()
 		})
-
 		return nil
 	})
 
+	engine.RLock()
+	engineIdx := engine.runner.GetConfig().Index
+	engine.RUnlock()
+
 	// Register callback to update engine cfg mem_size after format.
 	engine.OnStorageReady(func(_ context.Context) error {
-		// Retrieve up-to-date hugepage info to evaluate and assign available memory.
+		// Attempt to remove unused hugepages, log error only.
+		if err := cleanEngineHugePages(srv, engineIdx); err != nil {
+			srv.log.Errorf(err.Error())
+		}
+
+		// Update engine memory related config parameters before starting.
 		return errors.Wrap(updateMemValues(srv, engine, common.GetHugePageInfo),
 			"updating engine memory parameters")
 	})
 }
 
-func configureFirstEngine(ctx context.Context, engine *EngineInstance, sysdb *system.Database, joinFn systemJoinFn) {
+func configureFirstEngine(ctx context.Context, engine *EngineInstance, sysdb *system.Database, join systemJoinFn) {
 	if !sysdb.IsReplica() {
 		return
 	}
@@ -447,7 +446,7 @@ func configureFirstEngine(ctx context.Context, engine *EngineInstance, sysdb *sy
 			sb.Rank = system.NewRankPtr(0)
 		}
 
-		return joinFn(ctx, req)
+		return join(ctx, req)
 	}
 }
 

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -352,7 +352,6 @@ type (
 		HugePageCount      int
 		HugeNodes          string
 		CleanHugePagesOnly bool
-		CleanHugePagesPID  uint64
 		PCIAllowList       string
 		PCIBlockList       string
 		TargetUser         string

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -9,11 +9,9 @@ package bdev
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
+	"regexp"
 	"sort"
-	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -25,8 +23,8 @@ import (
 )
 
 const (
-	hugePageDir    = "/dev/hugepages"
-	hugePagePrefix = "spdk"
+	hugePageDir         = "/dev/hugepages"
+	spdkHugepagePattern = `spdk_pid([0-9]+)map`
 )
 
 type (
@@ -41,12 +39,12 @@ type (
 		script  *spdkSetupScript
 	}
 
-	removeFn     func(string) error
-	userLookupFn func(string) (*user.User, error)
-	vmdDetectFn  func() (*hardware.PCIAddressSet, error)
-	hpCleanFn    func(string, string, string) (uint, error)
-	writeConfFn  func(logging.Logger, *storage.BdevWriteConfigRequest) error
-	restoreFn    func()
+	statFn      func(string) (os.FileInfo, error)
+	removeFn    func(string) error
+	vmdDetectFn func() (*hardware.PCIAddressSet, error)
+	hpCleanFn   func(string) (uint, error)
+	writeConfFn func(logging.Logger, *storage.BdevWriteConfigRequest) error
+	restoreFn   func()
 )
 
 // suppressOutput is a horrible, horrible hack necessitated by the fact that
@@ -113,9 +111,24 @@ func defaultBackend(log logging.Logger) *spdkBackend {
 	return newBackend(log, defaultScriptRunner(log))
 }
 
-// hugePageWalkFunc returns a filepath.WalkFunc that will remove any file whose
-// name begins with prefix and owner has uid equal to tgtUID.
-func hugePageWalkFunc(hugePageDir, prefix, tgtUID string, remove removeFn, count *uint) filepath.WalkFunc {
+func isPIDActive(pidStr string, stat statFn) (bool, error) {
+	filename := fmt.Sprintf("/proc/%s", pidStr)
+
+	if _, err := stat(filename); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+// createHugePageWalkFunc returns a filepath.WalkFunc that will remove any file whose
+// name begins with prefix and encoded pid is inactive.
+func createHugePageWalkFunc(hugePageDir string, stat statFn, remove removeFn, count *uint) filepath.WalkFunc {
+	re := regexp.MustCompile(spdkHugepagePattern)
+
 	return func(path string, info os.FileInfo, err error) error {
 		switch {
 		case err != nil:
@@ -127,16 +140,16 @@ func hugePageWalkFunc(hugePageDir, prefix, tgtUID string, remove removeFn, count
 				return nil
 			}
 			return filepath.SkipDir // skip subdirectories
-		case !strings.HasPrefix(info.Name(), prefix):
-			return nil // skip files without prefix
 		}
 
-		stat, ok := info.Sys().(*syscall.Stat_t)
-		if !ok || stat == nil {
-			return errors.New("stat missing for file")
+		matches := re.FindStringSubmatch(info.Name())
+		if len(matches) != 2 {
+			return nil // skip files not matching expected pattern
 		}
-		if strconv.Itoa(int(stat.Uid)) != tgtUID {
-			return nil // skip not owned by target user
+		// PID string will be the first submatch at index 1 of the match results.
+
+		if isActive, err := isPIDActive(matches[1], stat); err != nil || isActive {
+			return err // skip files created by an existing process (isActive == true)
 		}
 
 		if err := remove(path); err != nil {
@@ -150,32 +163,23 @@ func hugePageWalkFunc(hugePageDir, prefix, tgtUID string, remove removeFn, count
 
 // cleanHugePages removes hugepage files with pathPrefix that are owned by the user with username
 // tgtUsr by processing directory tree with filepath.WalkFunc returned from hugePageWalkFunc.
-func cleanHugePages(hugePageDir, prefix, tgtUID string) (count uint, _ error) {
+func cleanHugePages(hugePageDir string) (count uint, _ error) {
 	return count, filepath.Walk(hugePageDir,
-		hugePageWalkFunc(hugePageDir, prefix, tgtUID, os.Remove, &count))
+		createHugePageWalkFunc(hugePageDir, os.Stat, os.Remove, &count))
 }
 
 // prepare receives function pointers for external interfaces.
-func (sb *spdkBackend) prepare(req storage.BdevPrepareRequest, userLookup userLookupFn, vmdDetect vmdDetectFn, hpClean hpCleanFn) (*storage.BdevPrepareResponse, error) {
+func (sb *spdkBackend) prepare(req storage.BdevPrepareRequest, vmdDetect vmdDetectFn, hpClean hpCleanFn) (*storage.BdevPrepareResponse, error) {
 	resp := &storage.BdevPrepareResponse{}
 
-	usr, err := userLookup(req.TargetUser)
-	if err != nil {
-		return resp, errors.Wrapf(err, "lookup on local host")
-	}
-
-	// Remove hugepages matching file name beginning with prefix and owned by the target user.
-	hpPrefix := hugePagePrefix
-	if req.CleanHugePagesPID != 0 {
-		// If a pid is supplied then include in the prefix.
-		hpPrefix = fmt.Sprintf("%s_pid%dmap", hpPrefix, req.CleanHugePagesPID)
-	}
-	nrRemoved, err := hpClean(hugePageDir, hpPrefix, usr.Uid)
-	if err != nil {
-		return resp, errors.Wrapf(err, "clean spdk hugepages")
-	}
-	resp.NrHugePagesRemoved = nrRemoved
 	if req.CleanHugePagesOnly {
+		// Remove hugepages created by an inactive SPDK process.
+		nrRemoved, err := hpClean(hugePageDir)
+		if err != nil {
+			return resp, errors.Wrapf(err, "clean spdk hugepages")
+		}
+		resp.NrHugePagesRemoved = nrRemoved
+
 		return resp, nil
 	}
 
@@ -243,7 +247,7 @@ func (sb *spdkBackend) Reset(req storage.BdevPrepareRequest) error {
 // bdev_include and bdev_exclude list filters provided in the server config file.
 func (sb *spdkBackend) Prepare(req storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error) {
 	sb.log.Debugf("spdk backend prepare (script call): %+v", req)
-	return sb.prepare(req, user.Lookup, DetectVMD, cleanHugePages)
+	return sb.prepare(req, DetectVMD, cleanHugePages)
 }
 
 // groomDiscoveredBdevs ensures that for a non-empty device list, restrict output controller data


### PR DESCRIPTION
The previous approach to cleanup hugepages created by SPDK running in
engine process was to remove in a callback triggered on engine exit.
The criteria for hugepage file removal was that file owner matched the
running user UID and the PID encoded in the filename matched that of the
exited engine process.

This approach will not always remove all hugepages created by DAOS
processes, for example in the case where daos_server is sent SIGKILL or
when different users execute daos_server.

A more aggressive approach is implemented in this PR whereby, on
completion of engine storage format, a callback is triggered which removes
all hugepages created by SPDK that belong to a no-longer-active process
(identified by PID encoded in the filename).

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>