### PR TITLE
DAOS-10664 daos: [daos cont get-acl --path] cmd to work

### DIFF
--- a/src/control/cmd/daos/acl.go
+++ b/src/control/cmd/daos/acl.go
@@ -237,7 +237,13 @@ type containerGetACLCmd struct {
 }
 
 func (cmd *containerGetACLCmd) Execute(args []string) error {
-	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RO, nil)
+	ap, deallocCmdArgs, err := allocCmdArgs(cmd.Logger)
+	if err != nil {
+		return err
+	}
+	defer deallocCmdArgs()
+
+	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RO, ap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix a miss in Go code that was preventing [daos cont get-acl --path]
cmd to work, failing with "ERROR: daos: ap cannot be nil with --path"
error message, due to no cmd args struct passed.

Change-Id: Iff96a5311b22b7abd15bcb43d4d7046be9afe61c
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>