### PR TITLE
DAOS-11092 bio: restrict inflight ios

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -1062,9 +1062,7 @@ nvme_rw(struct bio_desc *biod, struct bio_rsrvd_region *rg)
 	pg_cnt -= pg_idx;
 
 	while (pg_cnt > 0) {
-		/* NVMe poll needs be scheduled */
-		if (bio_need_nvme_poll(xs_ctxt))
-			bio_yield();
+		drain_inflight_ios(xs_ctxt);
 
 		biod->bd_inflights++;
 		xs_ctxt->bxc_blob_rw++;

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -508,6 +508,7 @@ extern bool		bio_spdk_inited;
 extern unsigned int	bio_chk_sz;
 extern unsigned int	bio_chk_cnt_max;
 extern unsigned int	bio_numa_node;
+extern unsigned int	bio_spdk_max_unmap_cnt;
 int xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights,
 		       uint64_t timeout);
 void bio_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev,
@@ -529,6 +530,7 @@ void setup_bio_bdev(void *arg);
 void destroy_bio_bdev(struct bio_bdev *d_bdev);
 void replace_bio_bdev(struct bio_bdev *old_dev, struct bio_bdev *new_dev);
 bool bypass_health_collect(void);
+void drain_inflight_ios(struct bio_xs_context *ctxt);
 
 /* bio_buffer.c */
 void dma_buffer_destroy(struct bio_dma_buffer *buf);

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -37,6 +37,8 @@
 #define BIO_BS_MAX_CHANNEL_OPS	(4096)
 /* Schedule a NVMe poll when so many blob IOs queued for an io channel */
 #define BIO_BS_POLL_WATERMARK	(2048)
+/* Stop issuing new IO when queued blob IOs reach a threshold */
+#define BIO_BS_STOP_WATERMARK	(4000)
 
 /* Chunk size of DMA buffer in pages */
 unsigned int bio_chk_sz;
@@ -52,6 +54,8 @@ bool bio_scm_rdma;
 bool bio_spdk_inited;
 /* SPDK subsystem fini timeout */
 unsigned int bio_spdk_subsys_timeout = 9000;	/* ms */
+/* How many blob unmap calls can be called in a row */
+unsigned int bio_spdk_max_unmap_cnt = 32;
 
 struct bio_nvme_data {
 	ABT_mutex		 bd_mutex;
@@ -202,6 +206,11 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 	d_getenv_int("DAOS_SPDK_SUBSYS_TIMEOUT", &bio_spdk_subsys_timeout);
 	D_INFO("SPDK subsystem fini timeout is %u ms\n", bio_spdk_subsys_timeout);
 
+	d_getenv_int("DAOS_SPDK_MAX_UNMAP_CNT", &bio_spdk_max_unmap_cnt);
+	if (bio_spdk_max_unmap_cnt == 0)
+		bio_spdk_max_unmap_cnt = UINT32_MAX;
+	D_INFO("SPDK batch blob unmap call count is %u\n", bio_spdk_max_unmap_cnt);
+
 	/* Hugepages disabled */
 	if (mem_size == 0) {
 		D_INFO("Set per-xstream DMA buffer upper bound to %u %uMB chunks\n",
@@ -341,6 +350,20 @@ bio_need_nvme_poll(struct bio_xs_context *ctxt)
 	if (ctxt == NULL)
 		return false;
 	return ctxt->bxc_blob_rw > BIO_BS_POLL_WATERMARK;
+}
+
+void
+drain_inflight_ios(struct bio_xs_context *ctxt)
+{
+	if (ctxt == NULL || ctxt->bxc_blob_rw <= BIO_BS_POLL_WATERMARK)
+		return;
+
+	do {
+		if (ctxt->bxc_self_polling)
+			spdk_thread_poll(ctxt->bxc_thread, 0, 0);
+		else
+			bio_yield();
+	} while (ctxt->bxc_blob_rw >= BIO_BS_STOP_WATERMARK);
 }
 
 struct common_cp_arg {


### PR DESCRIPTION
Stop issuing new NVMe I/O when the per-xstream inflight IOs reachs
a threshold.

Confine the number of batched blob unmap calls in bio_blob_unmap_sgl()
to workaroud the mysterious segfault. The default max unmap count is
set to 32, and it can be configured through DAOS_SPDK_MAX_UNMAP_CNT.

Test-tag: pr ec_aggregation_default ec_aggregation_time ec_online_rebuild_mdtest

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>