### PR TITLE
DAOS-11116 rebuild: refine overlapped rebuild insert handling

### DIFF
--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -275,7 +275,13 @@ extern "C" {
 	       One or more control plane components are incompatible)	\
 	/** No service available */					\
 	ACTION(DER_NO_SERVICE,		(DER_ERR_DAOS_BASE + 39),	\
-	       No service available)
+	       No service available)					\
+	/** The TX ID may be reused. */					\
+	ACTION(DER_TX_ID_REUSED,	(DER_ERR_DAOS_BASE + 40),	\
+	       TX ID may be reused)					\
+	/** recx overlapped (only used for rebuild IO) */		\
+	ACTION(DER_RECX_OVERLAP,	(DER_ERR_DAOS_BASE + 41),	\
+	       IO recx overlapped)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2540,14 +2540,20 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 				 * place so I did it this way to minimize
 				 * change while we decide how to handle this
 				 * properly.
+				 * RT_OVERLAP_INCLUDED is possible when vos aggregation
+				 * merged exts between retried rebuild, return
+				 * DER_RECX_OVERLAP for that case.
 				 */
 				if (range_overlap != RT_OVERLAP_SAME) {
-					D_ERROR("Same epoch partial "
-						"overwrite not supported:"
-						DF_RECT" overlaps with "DF_RECT
-						"\n", DP_RECT(rect),
-						DP_RECT(&rtmp));
-					rc = -DER_NO_PERM;
+					if (range_overlap == RT_OVERLAP_INCLUDED)
+						rc = -DER_RECX_OVERLAP;
+					else
+						rc = -DER_NO_PERM;
+					D_CDEBUG(rc == -DER_NO_PERM, DLOG_ERR, DB_IO,
+						 "Same epoch partial overwrite not supported:"
+						 DF_RECT" overlaps with "DF_RECT", range_overlap %d"
+						 ", "DF_RC"\n", DP_RECT(rect), DP_RECT(&rtmp),
+						 range_overlap, DP_RC(rc));
 					goto out;
 				}
 				break; /* we can update the record in place */


### PR DESCRIPTION
Define new err code DER_RECX_OVERLAP, it will be returned by
evt_ent_array_fill() for overlapped range RT_OVERLAP_INCLUDED
or RT_OVERLAP_INCLUDES, that is possibly when VOS aggregation
merges exts between rebuild retry. And rebuild update will
ignore that err code so need not retry again for that case.

Test-tag: ec_offline_agg_during_rebuild

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>