### PR TITLE
DAOS-10534 test: improve nvme/fault.py (#8982)

### DIFF
--- a/src/tests/ftest/nvme/fault.yaml
+++ b/src/tests/ftest/nvme/fault.yaml
@@ -5,7 +5,7 @@ hosts:
   test_clients:
     - client-C
     - client-D
-timeout: 7200
+timeout: 3600
 server_config:
   engines_per_host: 2
   name: daos_server
@@ -52,27 +52,16 @@ container:
     control_method: daos
     properties: rf:1
 ior:
-  api: "DFS"
+  api: DFS
   client_processes:
     np: 16
   dfs_destroy: False
-  iorflags:
-      flags: "-w -F -r -R -k -G 1"
+  flags: "-w -F -r -R -k -G 1"
   test_file: /testFile
   transfersize_blocksize:
       nvme_transfer_size: 16777216 #16M
-  dfs_oclass: "RP_2G1"
-  dfs_dir_oclass: "RP_2G1"
+  dfs_oclass: RP_2G1
 faulttests:
-  pool_capacity:
-    10_Percent:
-      percentage: 10
-  no_of_servers:
-    single:
-      count: 1
-  no_of_drives:
-    single:
-      count: 1
-  no_of_pools:
-    single:
-      count: 1
+  pool_capacity: 15
+  no_of_servers: 1
+  no_of_drives: 1

--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -56,7 +56,6 @@ class ServerFillUp(IorTestBase):
     def __init__(self, *args, **kwargs):
         """Initialize a IorTestBase object."""
         super().__init__(*args, **kwargs)
-        self.no_of_pools = 1
         self.capacity = 1
         self.no_of_servers = 1
         self.no_of_drives = 1
@@ -149,8 +148,8 @@ class ServerFillUp(IorTestBase):
             for line in output.stdout_text.splitlines():
                 if 'WARNING' in line and self.fail_on_warning:
                     self.result.append("FAIL-IOR command issued warnings.")
-        except (CommandFailure, TestFail):
-            self.result.append("FAIL")
+        except (CommandFailure, TestFail) as error:
+            self.result.append("FAIL - {}".format(error))
 
     def calculate_ior_block_size(self):
         """Calculate IOR Block size to fill up the Server.


### PR DESCRIPTION
Test-tag: nvme_fault pr,hw,medium
Skip-unit-tests: true
Skip-fault-injection-test: true

Improve nvme/fault.py
- Increase capacity to 15% to avoid IOR finishing before setting the
  device faulty
- Simplify yaml params
- Remove unused params
- More logging

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>