### PR TITLE
DAOS-11115 test: dm_posix_meta_entry: don't check mtime

### DIFF
--- a/src/tests/ftest/datamover/posix_meta_entry.py
+++ b/src/tests/ftest/datamover/posix_meta_entry.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 '''
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -6,6 +5,7 @@
 '''
 from os.path import join
 from data_mover_test_base import DataMoverTestBase
+from duns_utils import format_path
 
 
 class DmvrPosixMetaEntry(DataMoverTestBase):
@@ -20,12 +20,13 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
 
     def test_dm_posix_meta_entry_dcp(self):
         """JIRA id: DAOS-6390
+           JIRA id: DAOS-11115
         Test Description:
-            Verifies that POSIX metadata is preserved for dcp.
+            Verify POSIX metadata is preserved for dcp.
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp,dfuse
-        :avocado: tags=dm_posix_meta_entry,dm_posix_meta_entry_dcp
+        :avocado: tags=dm_posix_meta_entry,dm_posix_meta_entry_dcp,test_dm_posix_meta_entry_dcp
         """
         self.run_dm_posix_meta_entry("DCP")
 
@@ -61,13 +62,13 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
         self.start_dfuse(self.dfuse_hosts)
 
         # Create 1 pool
-        pool1 = self.create_pool()
+        pool1 = self.get_pool()
 
         # Create 1 source container with test data
         cont1 = self.create_cont(pool1)
         daos_src_path = self.new_daos_test_path(False)
-        dfuse_src_path = "{}/{}/{}{}".format(
-            self.dfuse.mount_dir.value, pool1.uuid, cont1.uuid, daos_src_path)
+        dfuse_src_path = join(
+            self.dfuse.mount_dir.value, pool1.uuid, cont1.uuid, daos_src_path.lstrip('/'))
         self.create_data(dfuse_src_path)
 
         # Create 1 source posix path with test data
@@ -79,37 +80,31 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
         # For DAOS, cont1 is used as the source and destination.
         # DAOS -> DAOS
         daos_dst_path = self.new_daos_test_path(False)
-        dfuse_dst_path = "{}/{}/{}{}".format(
-            self.dfuse.mount_dir.value, pool1.uuid, cont1.uuid, daos_dst_path)
+        dfuse_dst_path = join(
+            self.dfuse.mount_dir.value, pool1.uuid, cont1.uuid, daos_dst_path.lstrip('/'))
         self.run_datamover(
             test_desc + "(DAOS->DAOS)",
-            "DAOS", daos_src_path, pool1, cont1,
-            "DAOS", daos_dst_path, pool1, cont1)
-        self.compare_data(
-            dfuse_src_path, dfuse_dst_path,
-            cmp_times=preserve_on, cmp_xattr=preserve_on)
+            src_path=format_path(pool1, cont1, daos_src_path),
+            dst_path=format_path(pool1, cont1, daos_dst_path))
+        self.compare_data(dfuse_src_path, dfuse_dst_path, cmp_xattr=preserve_on)
 
         # DAOS -> POSIX
         posix_dst_path = self.new_posix_test_path(create=False, parent=self.workdir)
         self.run_datamover(
             test_desc + "(DAOS->POSIX)",
-            "DAOS", daos_src_path, pool1, cont1,
-            "POSIX", posix_dst_path)
-        self.compare_data(
-            dfuse_src_path, posix_dst_path,
-            cmp_times=preserve_on, cmp_xattr=preserve_on)
+            src_path=format_path(pool1, cont1, daos_src_path),
+            dst_path=posix_dst_path)
+        self.compare_data(dfuse_src_path, posix_dst_path, cmp_xattr=preserve_on)
 
         # POSIX -> DAOS
         daos_dst_path = self.new_daos_test_path(False)
-        dfuse_dst_path = "{}/{}/{}{}".format(
-            self.dfuse.mount_dir.value, pool1.uuid, cont1.uuid, daos_dst_path)
+        dfuse_dst_path = join(
+            self.dfuse.mount_dir.value, pool1.uuid, cont1.uuid, daos_dst_path.lstrip('/'))
         self.run_datamover(
             test_desc + "(POSIX->DAOS)",
-            "POSIX", posix_src_path, None, None,
-            "DAOS", daos_dst_path, pool1, cont1)
-        self.compare_data(
-            posix_src_path, dfuse_dst_path,
-            cmp_times=preserve_on, cmp_xattr=preserve_on)
+            src_path=posix_src_path,
+            dst_path=format_path(pool1, cont1, daos_dst_path))
+        self.compare_data(posix_src_path, dfuse_dst_path, cmp_xattr=preserve_on)
 
     def create_data(self, path):
         """Create the test data.
@@ -140,24 +135,18 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
         ]
         self.execute_cmd_list(cmd_list)
 
-    def compare_data(self, path1, path2, cmp_filetype=True,
-                     cmp_perms=True, cmp_owner=True, cmp_times=False,
+    def compare_data(self, path1, path2, cmp_filetype=True, cmp_perms=True, cmp_owner=True,
                      cmp_xattr=False):
         """Compare the test data.
 
         Args:
             path1 (str): The left-hand side to compare.
             path2 (str): The right-hand side to compare.
-            cmp_filetype (bool, optional): Whether to compare the file-type.
+            cmp_filetype (bool, optional): Whether to compare the file-type. Default is True.
+            cmp_perms (bool, optional): Whether to compare the permissions. Default is True.
+            cmp_owner (bool, optional): Whether to compare the user and group ownership.
                 Default is True.
-            cmp_perms (bool, optional): Whether to compare the permissions.
-                Default is True.
-            cmp_owner (bool, optional): Whether to compare the user and group
-                ownership. Default is True.
-            cmp_times (bool, optional): Whether to compare mtime.
-                Default is False.
-            cmp_xattr (bool, optional): Whether to compare xattrs.
-                Default is False.
+            cmp_xattr (bool, optional): Whether to compare xattrs. Default is False.
         """
         self.log.info("compare_data('%s', '%s')", path1, path2)
 
@@ -170,8 +159,6 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
         if cmp_owner:
             field_printf += "Group Name: %G\\n"
             field_printf += "User Name: %U\\n"
-        if cmp_times:
-            field_printf += "mtime: %Y\\n"
 
         # Diff the fields for each entry
         for entry in ["dir1", "dir1/file1", "dir1/link1"]:
@@ -179,19 +166,15 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
             entry2 = join(path2, entry)
             if field_printf:
                 # Use stat to get perms, etc.
-                stat_cmd1 = "stat --printf '{}' '{}'".format(
-                    field_printf, entry1)
-                stat_cmd2 = "stat --printf '{}' '{}'".format(
-                    field_printf, entry2)
-                diff_cmd = "diff <({} 2>&1) <({} 2>&1)".format(
-                    stat_cmd1, stat_cmd2)
+                stat_cmd1 = "stat --printf '{}' '{}'".format(field_printf, entry1)
+                stat_cmd2 = "stat --printf '{}' '{}'".format(field_printf, entry2)
+                diff_cmd = "diff <({} 2>&1) <({} 2>&1)".format(stat_cmd1, stat_cmd2)
                 self.execute_cmd(diff_cmd)
             if cmp_xattr:
                 # Use getfattr to get the xattrs
                 xattr_cmd1 = "getfattr -d -h '{}'".format(entry1)
                 xattr_cmd2 = "getfattr -d -h '{}'".format(entry2)
-                diff_cmd = "diff -I '^#' <({} 2>&1) <({} 2>&1)".format(
-                    xattr_cmd1, xattr_cmd2)
+                diff_cmd = "diff -I '^#' <({} 2>&1) <({} 2>&1)".format(xattr_cmd1, xattr_cmd2)
                 self.execute_cmd(diff_cmd)
 
     def execute_cmd_list(self, cmd_list):


### PR DESCRIPTION
Test-tag: test_dm_posix_meta_entry_dcp
Skip-unit-tests: true
Skip-fault-injection-test: true

- Don't verify mtime, since it's not expected to be correct
- General test cleanup

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>