### PR TITLE
DAOS-11116 rebuild: refine overlapped rebuild insert handling

### DIFF
--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -281,6 +281,9 @@ extern "C" {
 	/** The TX ID may be reused. */					\
 	ACTION(DER_TX_ID_REUSED,	(DER_ERR_DAOS_BASE + 40),	\
 	       TX ID may be reused)					\
+	/** recx overlapped (only used for rebuild IO) */		\
+	ACTION(DER_RECX_OVERLAP,	(DER_ERR_DAOS_BASE + 41),	\
+	       IO recx overlapped)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -638,6 +638,12 @@ migrate_csum_calc(struct daos_csummer *csummer, struct migrate_one *mrone, daos_
 #define MAX_BUF_SIZE		2048
 #define CSUM_BUF_SIZE		256
 
+static int
+migrate_update_rc(int rc)
+{
+	return (rc == -DER_RECX_OVERLAP) ? 0 : rc;
+}
+
 /**
  * allocate the memory for the iods_csums and unpack the csum_iov into the
  * into the iods_csums.
@@ -744,6 +750,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 				    mrone->mo_min_epoch, mrone->mo_version,
 				    0, &mrone->mo_dkey, iod_cnt, &iods[start],
 				    iod_csums, &sgls[start]);
+		rc = migrate_update_rc(rc);
 		daos_csummer_free_ic(csummer, &iod_csums);
 		if (rc) {
 			D_ERROR("migrate failed: "DF_RC"\n", DP_RC(rc));
@@ -767,6 +774,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 				    0, &mrone->mo_dkey, iod_cnt,
 				    &mrone->mo_iods[start], iod_csums,
 				    &sgls[start]);
+		rc = migrate_update_rc(rc);
 		if (rc) {
 			D_ERROR("migrate failed: "DF_RC"\n", DP_RC(rc));
 			D_GOTO(out, rc);
@@ -881,6 +889,7 @@ migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 				    parity_eph, mrone->mo_version,
 				    0, &mrone->mo_dkey, 1, iod, iod_csums,
 				    &tmp_sgl);
+		rc = migrate_update_rc(rc);
 		if (rc != 0)
 			D_GOTO(out, rc);
 
@@ -1144,6 +1153,7 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 			    mrone->mo_min_epoch, mrone->mo_version,
 			    update_flags, &mrone->mo_dkey, mrone->mo_iod_num,
 			    mrone->mo_iods, iod_csums, sgls);
+	rc = migrate_update_rc(rc);
 out:
 	for (i = 0; i < mrone->mo_iod_num; i++) {
 		if (iov[i].iov_buf)
@@ -1277,6 +1287,7 @@ post:
 end:
 	rc1 = vos_update_end(ioh, mrone->mo_version, &mrone->mo_dkey, rc, NULL,
 			     NULL);
+	rc1 = migrate_update_rc(rc1);
 	daos_csummer_free_ic(csummer, &iod_csums);
 	daos_iov_free(&csum_iov);
 	if (rc == 0)
@@ -1397,6 +1408,7 @@ migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 				    mrone->mo_version, 0, &mrone->mo_dkey,
 				    mrone->mo_punch_iod_num,
 				    mrone->mo_punch_iods, NULL, NULL);
+		rc = migrate_update_rc(rc);
 		D_DEBUG(DB_REBUILD, DF_UOID" mrone %p punch %d eph "DF_U64
 			" records: "DF_RC"\n", DP_UOID(mrone->mo_oid), mrone,
 			mrone->mo_punch_iod_num, mrone->mo_rec_punch_eph,

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2578,14 +2578,20 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 				 * place so I did it this way to minimize
 				 * change while we decide how to handle this
 				 * properly.
+				 * RT_OVERLAP_INCLUDED is possible when vos aggregation
+				 * merged exts between retried rebuild, returned
+				 * DER_RECX_OVERLAP for that case.
 				 */
 				if (range_overlap != RT_OVERLAP_SAME) {
-					D_ERROR("Same epoch partial "
-						"overwrite not supported:"
-						DF_RECT" overlaps with "DF_RECT
-						"\n", DP_RECT(rect),
-						DP_RECT(&rtmp));
-					rc = -DER_NO_PERM;
+					if (range_overlap == RT_OVERLAP_INCLUDED)
+						rc = -DER_RECX_OVERLAP;
+					else
+						rc = -DER_NO_PERM;
+					D_CDEBUG(rc == -DER_NO_PERM, DLOG_ERR, DB_IO,
+						 "Same epoch partial overwrite not supported:"
+						 DF_RECT" overlaps with "DF_RECT", range_overlap %d"
+						 ", "DF_RC"\n", DP_RECT(rect), DP_RECT(&rtmp),
+						 range_overlap, DP_RC(rc));
 					goto out;
 				}
 				break; /* we can update the record in place */


### PR DESCRIPTION
Define new err code DER_RECX_OVERLAP, it will be returned by
evt_ent_array_fill() for overlapped range RT_OVERLAP_INCLUDED
or RT_OVERLAP_INCLUDES, that is possibly when VOS aggregation
merges exts between rebuild retry. And rebuild update will
ignore that err code so need not retry again for that case.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>