### PR TITLE
DAOS-10655 obj: fix possible dead loop for degraded fetch again (#9504)

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -339,7 +339,7 @@ cont_child_aggregate(struct ds_cont_child *cont, cont_aggregate_cb_t agg_cb,
 	adjust_upper_bound(cont, param->ap_vos_agg, &epoch_max);
 
 	if (epoch_min >= epoch_max) {
-		D_DEBUG(DB_EPC, "epoch min "DF_X64" > max "DF_X64"\n", epoch_min, epoch_max);
+		D_DEBUG(DB_EPC, "epoch min "DF_X64" >= max "DF_X64"\n", epoch_min, epoch_max);
 		return 0;
 	}
 

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -249,14 +249,6 @@ char *d_realpath(const char *path, char *resolved_path);
 			 (oldcount) * sizeof(*(oldptr)),		\
 					     sizeof(*(oldptr)), count)
 
-#define D_REALLOC_NZ(newptr, oldptr, size)				\
-	D_REALLOC_COMMON(newptr, oldptr, size, size, 1)
-
-#define D_REALLOC_ARRAY_NZ(newptr, oldptr, count)			\
-	D_REALLOC_COMMON(newptr, oldptr,				\
-			 (count) * sizeof(*(oldptr)),			\
-			 sizeof(*(oldptr)), count)
-
 /** realloc macros that do not clear the new memory */
 #define D_REALLOC_NZ(newptr, oldptr, size)				\
 	D_REALLOC_COMMON(newptr, oldptr, size, size, 1)

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -397,7 +397,7 @@ CRT_RPC_DECLARE(obj_ec_agg, DAOS_ISEQ_OBJ_EC_AGG, DAOS_OSEQ_OBJ_EC_AGG)
 	((daos_key_t)		(er_dkey)		CRT_VAR)	\
 	((daos_iod_t)		(er_iod)		CRT_VAR)	\
 	((struct dcs_iod_csums)	(er_iod_csums)		CRT_ARRAY)	\
-	((uint64_t)		(er_epoch)		CRT_VAR)	\
+	((daos_epoch_range_t)	(er_epoch_range)	CRT_VAR)	\
 	((uint64_t)		(er_stripenum)		CRT_VAR)	\
 	((crt_bulk_t)		(er_bulk)		CRT_VAR)	\
 	((uint32_t)		(er_map_ver)		CRT_VAR)

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -91,8 +91,8 @@ struct ec_agg_stripe {
 	daos_epoch_t	as_hi_epoch;    /* highest epoch  in stripe          */
 	d_list_t	as_dextents;    /* list of stripe's data extents     */
 	daos_off_t	as_stripe_fill; /* amount of stripe covered by data  */
+	uint64_t	as_offset;      /* start offset in stripe            */
 	unsigned int	as_extent_cnt;  /* number of replica extents         */
-	unsigned int	as_offset;      /* start offset in stripe            */
 	bool		as_has_holes;   /* stripe includes holes             */
 };
 
@@ -437,23 +437,23 @@ out:
 /* Determines if an extent overlaps a cell.
  */
 static bool
-agg_overlap(unsigned int estart, unsigned int elen, unsigned int cell,
-	    unsigned int k, unsigned int len, daos_off_t stripenum)
+agg_overlap(uint64_t estart, uint64_t elen, unsigned int cell_idx,
+	    unsigned int k, unsigned int len, uint64_t stripenum)
 {
-	daos_off_t cell_start = k * len * stripenum + len * cell;
+	daos_recx_t	recx, cell_recx;
 
-	estart += k * len * stripenum;
-	if (cell_start <= estart && estart < cell_start + len)
-		return true;
-	if (estart <= cell_start && cell_start < estart + elen)
-		return true;
-	return false;
+	recx.rx_idx		= estart + k * len * stripenum;
+	recx.rx_nr		= elen;
+	cell_recx.rx_idx	= k * len * stripenum + len * cell_idx;
+	cell_recx.rx_nr		= len;
+
+	return DAOS_RECX_PTR_OVERLAP(&recx, &cell_recx);
 }
 
 static unsigned int
-agg_count_cells(uint8_t *fcbit_map, uint8_t *tbit_map, unsigned int estart,
-		unsigned int elen, unsigned int k, unsigned int len,
-		unsigned int stripenum, unsigned int *full_cell_cnt)
+agg_count_cells(uint8_t *fcbit_map, uint8_t *tbit_map, uint64_t estart,
+		uint64_t elen, unsigned int k, unsigned int len,
+		uint64_t stripenum, unsigned int *full_cell_cnt)
 {
 	unsigned int i, cell_cnt = 0;
 
@@ -1139,11 +1139,11 @@ agg_process_partial_stripe(struct ec_agg_entry *entry)
 	uint8_t			 tbit_map[OBJ_TGT_BITMAP_LEN] = {0};
 	unsigned int		 len = ec_age2cs(entry);
 	unsigned int		 k = ec_age2k(entry);
-	unsigned long            ss;
 	unsigned int		 i, full_cell_cnt = 0;
 	unsigned int		 cell_cnt = 0;
-	unsigned int		 estart, elen = 0;
-	unsigned int		 eend = 0;
+	uint64_t		 ss;
+	uint64_t		 estart, elen = 0;
+	uint64_t		 eend = 0;
 	bool			 has_old_replicas = false;
 	int			 tid, rc = 0;
 
@@ -1167,8 +1167,7 @@ agg_process_partial_stripe(struct ec_agg_entry *entry)
 		}
 		if (extent->ae_recx.rx_idx - ss > eend) {
 			cell_cnt += agg_count_cells(fcbit_map, tbit_map, estart,
-						    elen, k, len, entry->
-						    ae_cur_stripe.as_stripenum,
+						    elen, k, len, entry->ae_cur_stripe.as_stripenum,
 						    &full_cell_cnt);
 			estart = extent->ae_recx.rx_idx - ss;
 			elen = 0;
@@ -1240,7 +1239,7 @@ out:
 
 /* Sends the generated parity and the stripe number to the peer
  * parity target. Handler writes the parity and deletes the replicas
- * for the stripe.  Has to be extended to support p > 2.
+ * for the stripe.
  */
 static void
 agg_peer_update_ult(void *arg)
@@ -1618,12 +1617,11 @@ agg_process_holes_ult(void *arg)
 		ec_rep_in->er_dkey = entry->ae_dkey;
 		ec_rep_in->er_iod = *iod;
 		ec_rep_in->er_iod_csums.ca_arrays = stripe_ud->asu_iod_csums;
-		ec_rep_in->er_iod_csums.ca_count =
-			stripe_ud->asu_iod_csums == NULL ? 0 : 1;
+		ec_rep_in->er_iod_csums.ca_count = stripe_ud->asu_iod_csums == NULL ? 0 : 1;
 		ec_rep_in->er_stripenum = entry->ae_cur_stripe.as_stripenum;
-		ec_rep_in->er_epoch = entry->ae_cur_stripe.as_hi_epoch;
-		ec_rep_in->er_map_ver =
-			agg_param->ap_pool_info.api_pool->sp_map_version;
+		ec_rep_in->er_epoch_range.epr_lo = agg_param->ap_epr.epr_lo;
+		ec_rep_in->er_epoch_range.epr_hi = entry->ae_cur_stripe.as_hi_epoch;
+		ec_rep_in->er_map_ver = agg_param->ap_pool_info.api_pool->sp_map_version;
 		ec_rep_in->er_bulk = bulk_hdl;
 		rc = dss_rpc_send(rpc);
 		if (rc) {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -163,7 +163,10 @@ obj_rw_reply(crt_rpc_t *rpc, int status, uint64_t epoch,
 		orwo->orw_epoch = dss_get_start_epoch() -
 				  crt_hlc_epsilon_get() * 3;
 	} else {
-		orwo->orw_epoch = epoch;
+		/* orwo->orw_epoch possibly updated in obj_ec_recov_need_try_again(), reply
+		 * the max so client can fetch from that epoch.
+		 */
+		orwo->orw_epoch = max(epoch, orwo->orw_epoch);
 	}
 
 	D_DEBUG(DB_IO, "rpc %p opc %d send reply, pmv %d, epoch "DF_X64
@@ -1210,7 +1213,8 @@ daos_iod_recx_dup(daos_iod_t *iods, uint32_t iod_nr, daos_iod_t **iods_dup_ptr)
 }
 
 static bool
-obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_io_context *ioc)
+obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_rw_out *orwo,
+			    struct obj_io_context *ioc)
 {
 	D_ASSERT(orw->orw_flags & ORF_EC_RECOV);
 
@@ -1224,8 +1228,10 @@ obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_io_context *ioc)
 	 */
 	if ((orw->orw_flags & ORF_EC_RECOV_SNAP) == 0 &&
 	    (orw->orw_flags & ORF_FOR_MIGRATION) == 0 &&
-	    orw->orw_epoch < ioc->ioc_coc->sc_ec_agg_eph_boundry)
+	    orw->orw_epoch < ioc->ioc_coc->sc_ec_agg_eph_boundry) {
+		orwo->orw_epoch = ioc->ioc_coc->sc_ec_agg_eph_boundry;
 		return true;
+	}
 
 	return false;
 }
@@ -1360,7 +1366,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			fetch_flags |= VOS_OF_FETCH_RECX_LIST;
 		}
 		if (unlikely(ec_recov &&
-			     obj_ec_recov_need_try_again(orw, ioc))) {
+			     obj_ec_recov_need_try_again(orw, orwo, ioc))) {
 			rc = -DER_FETCH_AGAIN;
 			D_DEBUG(DB_IO, DF_UOID" "DF_X64"<"DF_X64
 				" ec_recov needs redo, "DF_RC".\n",
@@ -2015,7 +2021,6 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 	struct dcs_iod_csums	*iod_csums;
 	struct bio_desc		*biod;
 	daos_recx_t		 recx = { 0 };
-	daos_epoch_range_t	 epoch_range = { 0 };
 	struct obj_io_context	 ioc;
 	daos_handle_t		 ioh = DAOS_HDL_INVAL;
 	int			 rc;
@@ -2040,9 +2045,8 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 	dkey = (daos_key_t *)&oer->er_dkey;
 	iod = (daos_iod_t *)&oer->er_iod;
 	iod_csums = oer->er_iod_csums.ca_arrays;
-	rc = vos_update_begin(ioc.ioc_coc->sc_hdl, oer->er_oid,
-			      oer->er_epoch, 0, dkey, 1, iod, iod_csums,
-			      0, &ioh, NULL);
+	rc = vos_update_begin(ioc.ioc_coc->sc_hdl, oer->er_oid, oer->er_epoch_range.epr_hi, 0,
+			      dkey, 1, iod, iod_csums, 0, &ioh, NULL);
 	if (rc) {
 		D_ERROR(DF_UOID" Update begin failed: "DF_RC"\n",
 			DP_UOID(oer->er_oid), DP_RC(rc));
@@ -2073,12 +2077,10 @@ end:
 			DP_UOID(oer->er_oid), DP_RC(rc));
 		goto out;
 	}
-	epoch_range.epr_lo = 0ULL;
-	epoch_range.epr_hi = oer->er_epoch;
 	recx.rx_nr = obj_ioc2ec_cs(&ioc);
 	recx.rx_idx = (oer->er_stripenum * recx.rx_nr) | PARITY_INDICATOR;
-	rc = vos_obj_array_remove(ioc.ioc_coc->sc_hdl, oer->er_oid,
-				  &epoch_range, dkey, &iod->iod_name, &recx);
+	rc = vos_obj_array_remove(ioc.ioc_coc->sc_hdl, oer->er_oid, &oer->er_epoch_range, dkey,
+				  &iod->iod_name, &recx);
 out:
 	obj_rw_reply(rpc, rc, 0, &ioc);
 	obj_ioc_end(&ioc, rc);


### PR DESCRIPTION
1. Fix a problem when reply orwo->orw_epoch
   When the sc_ec_agg_eph_boundry moved ahead, should reply that epoch to
   client rather than original fetch epoch, so client can take that higher
   epoch to fetch again, rather than use the original epoch that may cause
   dead loop.
2. Fix a bug in ds_obj_ec_rep_handler
   the vos_obj_array_remove() is used to remove the parity ext, but it
   used incorrect epoch range that possibly cause parity epoch mismatch
   on different parity shards. That also possible cause dead loop.

And a few other small refines.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>