### PR TITLE
DAOS-9671 tests: Disable test_cont_rw temporarily

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -2331,9 +2331,10 @@ class posix_tests():
         os.close(fd)
         print(ps)
 
-        with open(join(dfuse.dir, 'rw_dir', 'new_file'), 'r') as fd:
-            data = fd.read()
-            print(data)
+#       temporarily disable the test of reading file to avoid the issue from fuse kernel
+#        with open(join(dfuse.dir, 'rw_dir', 'new_file'), 'r') as fd:
+#            data = fd.read()
+#            print(data)
 
         if dfuse.stop():
             self.fatal_errors = True


### PR DESCRIPTION
Skip-func-hw-test: true

Until the issue is fixed in fuse kernel.

Signed-off-by: Lei Huang <lei.huang@intel.com>