### PR TITLE
DAOS-11121 build: don't ship mercury-ucx with DAOS 2.0

### DIFF
--- a/.rpmignore
+++ b/.rpmignore
@@ -8,6 +8,7 @@ centos7/daos-firmware*.rpm
 centos7/daos-serialize*.rpm
 centos7/daos-server-tests-openmpi*.rpm
 centos7/daos-tests-internal*.rpm
+centos7/mercury-ucx*.rpm
 centos7/ucx*.rpm
 
 el8/daos-client-tests-openmpi*.rpm
@@ -15,6 +16,7 @@ el8/daos-firmware*.rpm
 el8/daos-serialize*.rpm
 el8/daos-server-tests-openmpi*.rpm
 el8/daos-tests-internal*.rpm
+el8/mercury-ucx*.rpm
 el8/ucx*.rpm
 
 leap15/daos-client-tests-openmpi*.rpm
@@ -22,9 +24,11 @@ leap15/daos-firmware*.rpm
 leap15/daos-serialize*.rpm
 leap15/daos-server-tests-openmpi*.rpm
 leap15/daos-tests-internal*.rpm
+leap15/mercury-ucx*.rpm
 leap15/openucx*.rpm
 
 ubuntu20.04/daos-*.deb
 ubuntu20.04/libdaos*.deb
+ubuntu20.04/mercury-ucx*.deb
 ubuntu20.04/ucx*.deb
 


### PR DESCRIPTION
add mercury-ucx to .rpmignore

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>