### PR TITLE
DAOS-10348 object: clone sub requests for CPD RPC

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -178,6 +178,8 @@ struct daos_obj_layout {
 enum daos_tgt_flags {
 	/* When leader forward IO RPC to non-leaders, delay the target until the others replied. */
 	DTF_DELAY_FORWARD	= (1 << 0),
+	/* When leader forward IO RPC to non-leaders, reassemble related sub request. */
+	DTF_REASSEMBLE_REQ	= (1 << 1),
 };
 
 /** to identify each obj shard's target */

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -158,7 +158,7 @@ enum obj_rpc_flags {
 	ORF_CPD_LEADER		= (1 << 9),
 	/* Bulk data transfer for CPD RPC. */
 	ORF_CPD_BULK		= (1 << 10),
-	/* Contain EC split req, only used on CPD leader locally. */
+	/* Contain EC split req, only used on CPD leader locally. Obsolete - DAOS-10348. */
 	ORF_HAS_EC_SPLIT	= (1 << 11),
 	/* Checking the existence of the object/key. */
 	ORF_CHECK_EXISTENCE	= (1 << 12),

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1019,6 +1019,7 @@ struct dc_tx_req_group {
 	uint32_t			 dtrg_read_cnt;
 	uint32_t			 dtrg_write_cnt;
 	uint32_t			 dtrg_slot_cnt;
+	uint8_t				 dtrg_flags; /* see daos_tgt_flags */
 	struct daos_cpd_req_idx		*dtrg_req_idx;
 };
 
@@ -1161,6 +1162,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 	int			 start;
 	int			 rc = 0;
 	int			 idx;
+	uint8_t			 tgt_flags = 0;
 
 	if (d_list_empty(dtr_list))
 		leader_dtr = NULL;
@@ -1186,6 +1188,8 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 				D_GOTO(out, rc = -DER_NOMEM);
 
 			dcu->dcu_start_shard = start;
+			if (dcu->dcu_iod_array.oia_oiods != NULL)
+				tgt_flags = DTF_REASSEMBLE_REQ;
 		}
 	}
 
@@ -1232,6 +1236,11 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 			  shard->do_target_id, dtrg_nr);
 
 		dtrg = &dtrgs[shard->do_target_id];
+
+		dtrg->dtrg_flags |= tgt_flags;
+		if (unlikely(shard->do_shard != idx))
+			dtrg->dtrg_flags |= DTF_REASSEMBLE_REQ;
+
 		if (dtrg->dtrg_req_idx == NULL) {
 			/* dtrg->dtrg_req_idx will be released by caller. */
 			D_ALLOC_ARRAY(dtrg->dtrg_req_idx, DTX_SUB_REQ_DEF);
@@ -1694,6 +1703,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 	shard_tgts[0].st_rank = dtrgs[leader_dtrg_idx].dtrg_rank;
 	shard_tgts[0].st_tgt_id = leader_dtrg_idx;
 	shard_tgts[0].st_tgt_idx = dtrgs[leader_dtrg_idx].dtrg_tgt_idx;
+	shard_tgts[0].st_flags = dtrgs[leader_dtrg_idx].dtrg_flags;
 
 	for (i = 0, j = 1; i < tgt_cnt; i++) {
 		if (dtrgs[i].dtrg_req_idx == NULL || i == leader_dtrg_idx)
@@ -1712,6 +1722,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		shard_tgts[j].st_rank = dtrgs[i].dtrg_rank;
 		shard_tgts[j].st_tgt_id = i;
 		shard_tgts[j].st_tgt_idx = dtrgs[i].dtrg_tgt_idx;
+		shard_tgts[j].st_flags = dtrgs[i].dtrg_flags;
 		j++;
 	}
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4399,9 +4399,6 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 				DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
 			break;
 		}
-
-		if (dcu->dcu_ec_split_req != NULL)
-			*flags |= ORF_HAS_EC_SPLIT;
 	}
 
 	return rc;


### PR DESCRIPTION
master-commit: 02c6ccdfdb152ebd5facb885a4ad2f92c325791e

For OSA case, more than one object shards may reside on the same
DAOS target. So daos_cpd_disp_ent::dcde_write_cnt may be not the
real count of update sub requests. When dispatch CPD RPC, we need
to clone related sub requests to avoid sending some irrelevant sub
request to the remote DAOS target. During the clone operation, we
need to avoid copying the same sub request that are for the same
object's different but co-located shards repeatedly.

Signed-off-by: Fan Yong <fan.yong@intel.com>