### PR TITLE
DAOS-10953 test: Detect issue with remove in unit test code (#9613)

### DIFF
--- a/src/common/tests/utest_common.c
+++ b/src/common/tests/utest_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -82,7 +82,7 @@ utest_pmem_create(const char *name, size_t pool_size, size_t root_size,
 
 	rc = pmemobj_ctl_set(ctx->uc_uma.uma_pool, "stats.enabled", &enabled);
 	if (rc) {
-		perror("Enable SCM usage statistics failed. rc:%d\n");
+		perror("Enable SCM usage statistics failed.");
 		goto free_ctx;
 	}
 
@@ -120,7 +120,8 @@ end:
 	return 0;
 destroy:
 	pmemobj_close(ctx->uc_uma.uma_pool);
-	remove(ctx->uc_pool_name);
+	if (remove(ctx->uc_pool_name) != 0)
+		D_ERROR("Failed to remove %s: %s\n", ctx->uc_pool_name, strerror(errno));
 free_ctx:
 	D_FREE(ctx);
 	return rc;
@@ -207,9 +208,12 @@ end:
 		return 0;
 
 	pmemobj_close(utx->uc_uma.uma_pool);
-	remove(utx->uc_pool_name);
+	if (remove(utx->uc_pool_name) != 0) {
+		D_ERROR("Failed to remove %s: %s\n", utx->uc_pool_name, strerror(errno));
+		rc = -DER_IO;
+	}
 	D_FREE(utx);
-	return 0;
+	return rc;
 }
 
 void *

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1215,6 +1215,7 @@ conflicting_rw_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 	if (!empty) {
 		char	pp[L_COUNT + 1] = "coda";
 
+		D_ASSERT(strlen(rp) <= L_COUNT);
 		memcpy(pp, rp, strlen(rp));
 		print_message("  update(%s, "DF_X64") before %s(%s, "
 			      DF_X64"): ", pp, re - 1, r->o_name, rp, re);
@@ -1477,8 +1478,8 @@ uncertainty_check_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 		char		pp[L_COUNT + 1] = "coda";
 		daos_epoch_t	pe = ae - 1;
 
-		D_ASSERT(strnlen(wp, L_COUNT) <= sizeof(pp) - 1);
-		memcpy(pp, wp, strnlen(wp, L_COUNT));
+		D_ASSERT(strlen(wp) <= L_COUNT);
+		memcpy(pp, wp, strlen(wp));
 		print_message("  update(%s, "DF_U64") (expect DER_SUCCESS): ",
 			      pp, pe);
 		rc = update_f(arg, NULL /* txh */, pp, pe);


### PR DESCRIPTION
Addresses CID: 21874, 21952
Rather than ignoring return value of remove, print an error if
it fails and return an error to the caller.
Fix an issue checkpatch saw in same code
Add an assertion for 21748. This doesn't clear coverity issue but I believe it is a
false positive with this change.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>