### PR TITLE
DAOS-10828 build: remove requires mercury from DAOS spec

### DIFF
--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.0.3
-Release:       5%{?relval}%{?dist}
+Release:       6%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -133,10 +133,6 @@ BuildRequires: libpsm_infinipath1
 %endif
 Requires: protobuf-c
 Requires: openssl
-# This should only be temporary until we can get a stable upstream release
-# of mercury, at which time the autoprov shared library version should
-# suffice
-Requires: mercury >= %{mercury_version}, mercury < %{mercury_max_version}
 
 %description
 The Distributed Asynchronous Object Storage (DAOS) is an open-source
@@ -164,7 +160,6 @@ Requires: ipmctl > 02.00.00.3816
 # When 1.11.2 is released, we can change this to >= 1.11.2
 Requires: libpmemobj = 1.11.0-3%{?dist}
 %endif
-Requires: mercury >= %{mercury_version}, mercury < %{mercury_max_version}
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Requires: libfabric >= %{libfabric_version}
@@ -177,7 +172,6 @@ This is the package needed to run a DAOS server
 %package client
 Summary: The DAOS client
 Requires: %{name}%{?_isa} = %{version}-%{release}
-Requires: mercury >= %{mercury_version}, mercury < %{mercury_max_version}
 Requires: libfabric >= %{libfabric_version}
 %if (0%{?rhel} >= 8)
 Requires: fuse3 >= 3
@@ -529,6 +523,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a meta-package
 
 %changelog
+* Thu Jul 14 2022 Jerome Soumagne <jerome.soumagne@intel.com> 2.0.3-6
+- Remove requires mercury and let dependencies be resolved automatically
+
 * Thu Jul 07 2022 Johann Lombardi <johann.lombardi@intel.com> 2.0.3-5
 - Version bump to 2.0.3 (rc4)
 


### PR DESCRIPTION
Let autodependency tracking do its job instead