### PR TITLE
DAOS-11007 cart: Convert return codes from hg to daos on rpc completion.

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1165,17 +1165,14 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 		return rc;
 	}
 
-	RPC_TRACE(DB_TRACE, rpc_priv, "entered, hg_cbinfo->ret %d.\n",
-		  hg_cbinfo->ret);
+	RPC_TRACE(DB_TRACE, rpc_priv, "entered, hg_cbinfo->ret %d.\n", hg_cbinfo->ret);
 	switch (hg_cbinfo->ret) {
 	case HG_SUCCESS:
 		state = RPC_STATE_COMPLETED;
 		break;
 	case HG_CANCELED:
-		if (!CRT_RANK_PRESENT(rpc_pub->cr_ep.ep_grp,
-				     rpc_pub->cr_ep.ep_rank)) {
-			RPC_TRACE(DB_NET, rpc_priv,
-				  "request target excluded\n");
+		if (!CRT_RANK_PRESENT(rpc_pub->cr_ep.ep_grp, rpc_pub->cr_ep.ep_rank)) {
+			RPC_TRACE(DB_NET, rpc_priv, "request target excluded\n");
 			rc = -DER_EXCLUDED;
 		} else if (crt_req_timedout(rpc_priv)) {
 			RPC_TRACE(DB_NET, rpc_priv, "request timedout\n");
@@ -1189,11 +1186,10 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 		hg_ret = hg_cbinfo->ret;
 		break;
 	default:
-		state = RPC_STATE_COMPLETED;
-		rc = -DER_HG;
+		state  = RPC_STATE_COMPLETED;
+		rc     = crt_hgret_2_der(hg_cbinfo->ret);
 		hg_ret = hg_cbinfo->ret;
-		RPC_TRACE(DB_NET, rpc_priv,
-			  "hg_cbinfo->ret: %d.\n", hg_cbinfo->ret);
+		RPC_TRACE(DB_NET, rpc_priv, "hg_cbinfo->ret: %d.\n", hg_cbinfo->ret);
 		break;
 	}
 
@@ -1206,8 +1202,7 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 		rpc_priv->crp_state = RPC_STATE_REPLY_RECVED;
 		if (rpc_priv->crp_opc_info->coi_no_reply == 0) {
 			/* HG_Free_output in crt_hg_req_destroy */
-			hg_ret = HG_Get_output(hg_cbinfo->info.forward.handle,
-					       &rpc_pub->cr_output);
+			hg_ret = HG_Get_output(hg_cbinfo->info.forward.handle, &rpc_pub->cr_output);
 			if (hg_ret == HG_SUCCESS) {
 				rpc_priv->crp_output_got = 1;
 				rc = rpc_priv->crp_reply_hdr.cch_rc;


### PR DESCRIPTION
Catch another case where a hg return code is being passed as DER_HG
rather than converting to a daos error code where possible.

This allows the stack to identify non-recoverable failures better
and to correctly abort or handle errors rather than spinning.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
