### PR TITLE
DAOS-10595 build: Update SPDK to v22.01.1 (#9063)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.1.103-3) unstable; urgency=medium
+  [ Tom Nabarro ]
+  * Update SPDK dependency requirement to greater than or equal to 22.01.1.
+
+ -- Tom Nabarro <Tom Nabarro <tom.nabarro@intel.com>  Fri, 15 Jul 2022 12:43:00 -0400
+
 daos (2.1.103-2) unstable; urgency=medium
   [ Jerome Soumagne ]
   * Update to mercury 2.2.0rc6

--- a/debian/control
+++ b/debian/control
@@ -22,13 +22,12 @@ Build-Depends: debhelper (>= 10),
                libfuse3-dev,
                libprotobuf-c-dev,
                libjson-c-dev,
-               libisal-dev,
-               dpdk-dev (<<21.11),
+               dpdk-dev (>= 21.11.1),
                libisal-crypto-dev,
                libcunit1-dev,
                golang-go,
                libboost-dev,
-               libspdk-dev (>=21.07), libspdk-dev (<<22),
+               libspdk-dev (>= 22.01.1),
                libipmctl-dev,
                libraft-dev (= 0.9.1-1401.gc18bcb8),
                python3-tabulate,
@@ -180,7 +179,7 @@ Section: net
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}, openmpi-bin,
-         ipmctl (>02.00.00.3816), libfabric (>= 1.14.0-1)
+         ipmctl (>02.00.00.3816), libfabric (>= 1.14.0-1), spdk-tools (>= 22.01.1)
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for
  massively distributed Non Volatile Memory (NVM). DAOS takes advantage

--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -9,8 +9,34 @@
 #include <spdk/thread.h>
 #include "bio_internal.h"
 #include <daos_srv/smd.h>
+#include <spdk/string.h>
+#include <spdk/likely.h>
 #include <spdk/env.h>
 #include <spdk/vmd.h>
+
+enum led_action {
+	LED_ACTION_SET,
+	LED_ACTION_GET,
+	LED_ACTION_RESET,
+	LED_ACTION_NOP,
+};
+
+struct led_opts {
+	struct spdk_pci_addr	pci_addr;
+	bool			all_devices;
+	bool			finished;
+	enum led_action		action;
+	enum spdk_vmd_led_state	led_state;
+	int			status;
+};
+
+static const char *g_led_states[] = {
+	[SPDK_VMD_LED_STATE_OFF]	= "off",
+	[SPDK_VMD_LED_STATE_IDENTIFY]	= "identify",
+	[SPDK_VMD_LED_STATE_FAULT]	= "fault",
+	[SPDK_VMD_LED_STATE_REBUILD]	= "rebuild",
+	[SPDK_VMD_LED_STATE_UNKNOWN]	= "unknown",
+};
 
 static int
 revive_dev(struct bio_xs_context *xs_ctxt, struct bio_bdev *d_bdev)
@@ -510,8 +536,8 @@ fill_in_traddr(struct bio_dev_info *b_info, char *dev_name)
 	}
 
 	rc = spdk_bdev_dump_info_json(bdev, json);
-	if (rc) {
-		D_ERROR("Failed to dump config from SPDK bdev. %d\n", rc);
+	if (rc != 0) {
+		D_ERROR("Failed to dump config from SPDK bdev (%s)\n", spdk_strerror(-rc));
 		rc = daos_errno2der(-rc);
 	}
 
@@ -544,7 +570,7 @@ alloc_dev_info(uuid_t dev_id, char *dev_name, struct smd_dev_info *s_info)
 
 	if (dev_name != NULL) {
 		rc = fill_in_traddr(info, dev_name);
-		if (rc) {
+		if (rc != 0) {
 			bio_free_dev_info(info);
 			return NULL;
 		}
@@ -666,18 +692,116 @@ out:
 	return rc;
 }
 
+static void
+led_device_action(void *ctx, struct spdk_pci_device *pci_device)
+{
+	struct led_opts		*opts = ctx;
+	enum spdk_vmd_led_state	 cur_led_state;
+	char			 addr_buf[128];
+	int			 rc;
+
+	if (opts->status != 0)
+		return;
+	if (opts->finished)
+		return;
+
+	if (strcmp(spdk_pci_device_get_type(pci_device), "vmd") != 0) {
+		D_ERROR("Found unexpected non-VMD device type\n");
+		opts->status = -DER_NOTAPPLICABLE;
+		return;
+	}
+
+	if (!opts->all_devices) {
+		if (spdk_pci_addr_compare(&opts->pci_addr, &pci_device->addr) != 0)
+			return;
+		opts->finished = true;
+	}
+
+	rc = spdk_pci_addr_fmt(addr_buf, sizeof(addr_buf), &pci_device->addr);
+	if (rc != 0) {
+		D_ERROR("Failed to format VMD's PCI address (%s)\n", spdk_strerror(-rc));
+		opts->status = -DER_INVAL;
+		return;
+	}
+
+	/* First check the current state of the VMD LED */
+	rc = spdk_vmd_get_led_state(pci_device, &cur_led_state);
+	if (spdk_unlikely(rc != 0)) {
+		D_ERROR("Failed to retrieve the state of the LED on %s (%s)\n", addr_buf,
+			spdk_strerror(-rc));
+		opts->status = -DER_NOSYS;
+		return;
+	}
+
+	D_DEBUG(DB_MGMT, "LED on %s: %s\n", addr_buf, g_led_states[cur_led_state]);
+
+	switch (opts->action) {
+	case LED_ACTION_GET:
+		opts->led_state = cur_led_state;
+		return;
+
+	case LED_ACTION_SET:
+		D_DEBUG(DB_MGMT, "Setting VMD device %s LED state to %s\n", addr_buf,
+			g_led_states[opts->led_state]);
+		break;
+
+	case LED_ACTION_RESET:
+		/* If the current state of a device is FAULTY we do not want to reset */
+		if (cur_led_state == SPDK_VMD_LED_STATE_FAULT) {
+			D_DEBUG(DB_MGMT, "ignoring LED reset on %s as state is %s\n",
+				addr_buf, g_led_states[cur_led_state]);
+			opts->led_state = cur_led_state;
+			return;
+		}
+		D_DEBUG(DB_MGMT, "Resetting VMD device %s LED state to %s\n", addr_buf,
+			g_led_states[opts->led_state]);
+		break;
+
+	default:
+		D_ERROR("Unrecognized LED action requested\n");
+		opts->status = -DER_INVAL;
+		return;
+	}
+
+	if (cur_led_state == opts->led_state) {
+		D_DEBUG(DB_MGMT, "VMD device %s LED state already in state %s\n", addr_buf,
+			g_led_states[opts->led_state]);
+		return;
+	}
+
+	/* Set the LED to the new state */
+	rc = spdk_vmd_set_led_state(pci_device, opts->led_state);
+	if (spdk_unlikely(rc != 0)) {
+		D_ERROR("Failed to set the VMD LED state on %s (%s)\n", addr_buf,
+			spdk_strerror(-rc));
+		opts->status = -DER_NOSYS;
+		return;
+	}
+
+	rc = spdk_vmd_get_led_state(pci_device, &cur_led_state);
+	if (rc != 0) {
+		D_ERROR("Failed to get the VMD LED state (%s)\n", spdk_strerror(-rc));
+		opts->status = -DER_NOSYS;
+		return;
+	}
+
+	/* Verify the correct state is set */
+	if (cur_led_state != opts->led_state) {
+		D_ERROR("Unexpected LED state on %s, want %s got %s\n", addr_buf,
+			g_led_states[opts->led_state], g_led_states[cur_led_state]);
+		opts->status = -DER_INVAL;
+	}
+}
+
 int
 bio_set_led_state(struct bio_xs_context *xs_ctxt, uuid_t dev_uuid,
-		  const char *led_state, bool reset)
+		  const char *led_state_str, bool reset)
 {
-	struct spdk_pci_addr	pci_addr;
-	struct spdk_pci_device *pci_device;
 	struct bio_bdev	       *bio_dev;
 	struct bio_dev_info	b_info = { 0 };
-	enum spdk_vmd_led_state current_led_state;
-	int			new_led_state;
+	struct led_opts		opts = { 0 };
+	int			led_state;
 	int			rc = 0;
-	bool			found = false;
 
 	D_ASSERT(is_init_xstream(xs_ctxt));
 
@@ -688,115 +812,71 @@ bio_set_led_state(struct bio_xs_context *xs_ctxt, uuid_t dev_uuid,
 		return -DER_NONEXIST;
 	}
 
+	/* Init LED context state */
+	opts.all_devices = false;
+	opts.finished = false;
+	opts.led_state = SPDK_VMD_LED_STATE_UNKNOWN;
+	opts.status = 0;
+
 	/* LED will be reset to the original saved state */
+	opts.action = LED_ACTION_SET;
 	if (reset) {
-		new_led_state = bio_dev->bb_led_state;
-		D_GOTO(skip_led_str, rc = 0);
+		opts.action = LED_ACTION_RESET;
+		opts.led_state = bio_dev->bb_led_state;
+		goto skip_led_str;
 	}
 
-	if (led_state == NULL)
+	if (led_state_str == NULL)
 		return -DER_INVAL;
 
 	/* Determine SPDK LED state based on led_state string */
-	if (strcasecmp(led_state, "identify") == 0) {
-		new_led_state = SPDK_VMD_LED_STATE_IDENTIFY;
-	} else if (strcasecmp(led_state, "on") == 0) {
-		new_led_state = SPDK_VMD_LED_STATE_FAULT;
-	} else if (strcasecmp(led_state, "fault") == 0) {
-		new_led_state = SPDK_VMD_LED_STATE_FAULT;
-	} else if (strcasecmp(led_state, "off") == 0) {
-		new_led_state = SPDK_VMD_LED_STATE_OFF;
-	} else {
-		D_ERROR("LED state is not valid or supported\n");
-		return -DER_NOSYS;
-	}
-
-skip_led_str:
-	rc = fill_in_traddr(&b_info, bio_dev->bb_name);
-	if (rc) {
-		D_ERROR("Unable to get traddr for device:%s\n",
-			bio_dev->bb_name);
-		return -DER_INVAL;
-	}
-
-
-	if (spdk_pci_addr_parse(&pci_addr, b_info.bdi_traddr)) {
-		D_ERROR("Unable to parse PCI address: %s\n", b_info.bdi_traddr);
-		D_GOTO(free_traddr, rc = -DER_INVAL);
-	}
-
-	for (pci_device = spdk_pci_get_first_device(); pci_device != NULL;
-	     pci_device = spdk_pci_get_next_device(pci_device)) {
-		if (spdk_pci_addr_compare(&pci_addr, &pci_device->addr) == 0) {
-			found = true;
+	for (led_state = SPDK_VMD_LED_STATE_OFF;
+	     led_state <= SPDK_VMD_LED_STATE_REBUILD;
+	     led_state++) {
+		if (strcmp(led_state_str, g_led_states[led_state]) == 0) {
+			opts.led_state = (enum spdk_vmd_led_state)led_state;
 			break;
 		}
 	}
 
-	if (found) {
-		if (strcmp(spdk_pci_device_get_type(pci_device), "vmd") != 0) {
-			D_DEBUG(DB_MGMT, "%s is not a VMD device\n",
-				b_info.bdi_traddr);
-			D_GOTO(free_traddr, rc = -DER_NOSYS);
-		}
-	} else {
-		D_ERROR("Unable to set led state, VMD device not found\n");
+skip_led_str:
+	if (opts.led_state == SPDK_VMD_LED_STATE_UNKNOWN) {
+		D_ERROR("LED state is not valid or supported\n");
+		return -DER_INVAL;
+	}
+
+	rc = fill_in_traddr(&b_info, bio_dev->bb_name);
+	if (rc != 0) {
+		D_ERROR("Unable to get traddr for device %s\n", bio_dev->bb_name);
+		return -DER_INVAL;
+	}
+
+	rc = spdk_pci_addr_parse(&opts.pci_addr, b_info.bdi_traddr);
+	if (rc != 0) {
+		D_ERROR("Unable to parse PCI address for device %s (%s)\n", b_info.bdi_traddr,
+			spdk_strerror(-rc));
 		D_GOTO(free_traddr, rc = -DER_INVAL);
 	}
 
-	/* First check the current state of the VMD LED */
-	rc = spdk_vmd_get_led_state(pci_device, &current_led_state);
-	if (rc) {
-		D_ERROR("Failed to get the VMD LED state\n");
-		D_GOTO(free_traddr, rc = -DER_INVAL);
+	spdk_pci_for_each_device(&opts, led_device_action);
+
+	if (opts.status != 0) {
+		D_ERROR("Setting LED state failed\n");
+		D_GOTO(free_traddr, rc = opts.status);
+	}
+	if (!opts.all_devices && !opts.finished) {
+		D_ERROR("Device with traddr %s could not be found\n", b_info.bdi_traddr);
+		D_GOTO(free_traddr, rc = -DER_NONEXIST);
 	}
 
-	/* If the current state of a device is FAULTY we do not want to reset */
-	if ((current_led_state == SPDK_VMD_LED_STATE_FAULT) && reset)
-		D_GOTO(state_set, rc);
+	/* Update current LED state after action */
+	bio_dev->bb_led_state = opts.led_state;
 
-	if (!reset)
-		D_DEBUG(DB_MGMT, "Setting VMD device:%s LED state to %s(%d)\n",
-			b_info.bdi_traddr, led_state, new_led_state);
-	else
-		D_DEBUG(DB_MGMT, "Resetting VMD device:%s LED state to %d\n",
-			b_info.bdi_traddr, bio_dev->bb_led_state);
-
-	/* Save the current state in bio_bdev, will be restored by init xs */
-	if (!reset)
-		bio_dev->bb_led_state = current_led_state;
-
-	if (current_led_state == new_led_state)
-		D_GOTO(state_set, rc);
-
-	/* Set the LED to the new state */
-	rc = spdk_vmd_set_led_state(pci_device, new_led_state);
-	if (rc) {
-		D_ERROR("Failed to set LED state to %s\n", led_state);
-		D_GOTO(free_traddr, rc = -DER_INVAL);
-	}
-
-	rc = spdk_vmd_get_led_state(pci_device, &current_led_state);
-	if (rc) {
-		D_ERROR("Failed to get the VMD LED state\n");
-	} else {
-		/* Verify the correct state is set */
-		if (current_led_state != new_led_state)
-			D_ERROR("LED of device:%s is in an unexpected state:"
-				"%d\n", b_info.bdi_traddr, current_led_state);
-	}
-
-state_set:
-	if (!reset && (current_led_state != SPDK_VMD_LED_STATE_OFF)) {
-		/*
-		 * Init the start time for the LED for a new event.
-		 */
+	if (!reset && (opts.led_state != SPDK_VMD_LED_STATE_OFF)) {
+		/* Init the start time for the LED for a new event. */
 		bio_dev->bb_led_start_time = d_timeus_secdiff(0);
 	} else {
-		/*
-		 * Reset the LED start time to indicate a LED event has
-		 * completed.
-		 */
+		/* Reset the LED start time to indicate a LED event has completed. */
 		bio_dev->bb_led_start_time = 0;
 	}
 

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -39,6 +39,11 @@ struct bio_dev_list_msg_arg {
 	int				 rc;
 };
 
+/* Used for getting vendor ID from PCI device */
+struct vid_opts {
+	struct spdk_pci_addr		 pci_addr;
+	uint16_t			 vid;
+};
 
 /* Collect space utilization for blobstore */
 static void
@@ -967,6 +972,16 @@ bio_export_vendor_health_stats(struct bio_blobstore *bb, char *bdev_name)
 }
 
 
+static void
+get_vendor_id(void *ctx, struct spdk_pci_device *pci_device)
+{
+	struct vid_opts *opts = ctx;
+
+	if (spdk_pci_addr_compare(&opts->pci_addr, &pci_device->addr) == 0) {
+		opts->vid = spdk_pci_device_get_vendor_id(pci_device);
+	}
+}
+
 /*
  * Set the PCI Vendor ID for the NVMe SSD. This is used to determine if
  * Intel SMART stats will be monitored (vendor specific).
@@ -975,9 +990,7 @@ void
 bio_set_vendor_id(struct bio_blobstore *bb, char *bdev_name)
 {
 	struct bio_dev_info		 binfo = { 0 };
-	struct spdk_pci_addr		 pci_addr;
-	struct spdk_pci_device		*pci_device;
-	uint16_t			 vid = 0;
+	struct vid_opts			 opts = { 0 };
 	int				 rc;
 
 	rc = fill_in_traddr(&binfo, bdev_name);
@@ -986,19 +999,19 @@ bio_set_vendor_id(struct bio_blobstore *bb, char *bdev_name)
 		return;
 	}
 
-	if (spdk_pci_addr_parse(&pci_addr, binfo.bdi_traddr)) {
+	if (spdk_pci_addr_parse(&opts.pci_addr, binfo.bdi_traddr)) {
 		D_ERROR("Unable to parse PCI address: %s\n", binfo.bdi_traddr);
 		goto free_traddr;
 	}
 
-	for (pci_device = spdk_pci_get_first_device(); pci_device != NULL;
-	     pci_device = spdk_pci_get_next_device(pci_device)) {
-		if (spdk_pci_addr_compare(&pci_addr, &pci_device->addr) == 0) {
-			vid = spdk_pci_device_get_vendor_id(pci_device);
-			break;
-		}
-	}
-	bb->bb_dev_health.bdh_vendor_id = vid;
+	opts.vid = 0;
+
+	spdk_pci_for_each_device(&opts, get_vendor_id);
+
+	if (opts.vid == 0)
+		D_ERROR("No vendor ID retrieved for device at address: %s\n", binfo.bdi_traddr);
+
+	bb->bb_dev_health.bdh_vendor_id = opts.vid;
 
 free_traddr:
 	D_FREE(binfo.bdi_traddr);

--- a/src/control/server/storage/bdev/backend_vmd.go
+++ b/src/control/server/storage/bdev/backend_vmd.go
@@ -83,13 +83,15 @@ func mapVMDToBackingAddrs(foundCtrlrs storage.NvmeControllers) (map[string]*hard
 	return vmds, nil
 }
 
-// substVMDAddrs replaces VMD PCI addresses in input device list with the PCI
-// addresses of the backing devices behind the VMD.
+// substVMDAddrs replaces VMD endpoint PCI addresses in input device list with the PCI
+// addresses of the backing devices behind the VMD endpoint.
 //
 // Return new device list with PCI addresses of devices behind the VMD.
+//
+// Add addresses that are not VMD endpoints to the output list.
 func substVMDAddrs(inPCIAddrs *hardware.PCIAddressSet, foundCtrlrs storage.NvmeControllers) (*hardware.PCIAddressSet, error) {
 	if len(foundCtrlrs) == 0 {
-		return nil, nil
+		return inPCIAddrs, nil
 	}
 
 	vmds, err := mapVMDToBackingAddrs(foundCtrlrs)
@@ -97,7 +99,8 @@ func substVMDAddrs(inPCIAddrs *hardware.PCIAddressSet, foundCtrlrs storage.NvmeC
 		return nil, err
 	}
 
-	// swap input vmd addresses with respective backing addresses
+	// Swap any input VMD endpoint addresses with respective backing device addresses.
+	// inAddr entries that are already backing device addresses will be added to output list.
 	outPCIAddrs := new(hardware.PCIAddressSet)
 	for _, inAddr := range inPCIAddrs.Addresses() {
 		toAdd := []*hardware.PCIAddress{inAddr}
@@ -114,12 +117,16 @@ func substVMDAddrs(inPCIAddrs *hardware.PCIAddressSet, foundCtrlrs storage.NvmeC
 	return outPCIAddrs, nil
 }
 
-// substituteVMDAddresses wraps around substVMDAddrs and takes a BdevScanResponse
-// reference along with a logger.
+// substituteVMDAddresses wraps around substVMDAddrs to substitute VMD addresses with the relevant
+// backing device addresses.
+// Function takes a BdevScanResponse reference to derive address map and a logger.
 func substituteVMDAddresses(log logging.Logger, inPCIAddrs *hardware.PCIAddressSet, bdevCache *storage.BdevScanResponse) (*hardware.PCIAddressSet, error) {
+	if inPCIAddrs == nil {
+		return nil, errors.New("nil input PCIAddressSet")
+	}
 	if bdevCache == nil || len(bdevCache.Controllers) == 0 {
 		log.Debugf("no bdev cache to find vmd backing devices (devs: %v)", inPCIAddrs)
-		return nil, nil
+		return inPCIAddrs, nil
 	}
 
 	msg := fmt.Sprintf("vmd detected, processing addresses (input %v, existing %v)",

--- a/src/control/server/storage/bdev/backend_vmd_test.go
+++ b/src/control/server/storage/bdev/backend_vmd_test.go
@@ -73,6 +73,20 @@ func TestBackend_substituteVMDAddresses(t *testing.T) {
 				"850505:0d:00.0", "850505:0f:00.0", "850505:11:00.0",
 				"850505:14:00.0"),
 		},
+		"input vmd backing devices": {
+			inAddrs: addrListFromStrings(vmdBackingAddr2, vmdBackingAddr1),
+			bdevCache: &storage.BdevScanResponse{
+				Controllers: ctrlrsFromPCIAddrs(vmdBackingAddr1, vmdBackingAddr2,
+					"850505:07:00.0", "850505:09:00.0", "850505:0b:00.0",
+					"850505:0d:00.0", "850505:0f:00.0", "850505:11:00.0",
+					"850505:14:00.0"),
+			},
+			expOutAddrs: addrListFromStrings(vmdBackingAddr1, vmdBackingAddr2),
+		},
+		"input vmd backing devices; no cache": {
+			inAddrs:     addrListFromStrings(vmdBackingAddr2, vmdBackingAddr1),
+			expOutAddrs: addrListFromStrings(vmdBackingAddr1, vmdBackingAddr2),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(name)

--- a/utils/build.config
+++ b/utils/build.config
@@ -6,7 +6,7 @@ ARGOBOTS = v1.1
 PMDK = 1.11.0
 ISAL = v2.30.0
 ISAL_CRYPTO = v2.23.0
-SPDK = v21.07
+SPDK = v22.01.1
 OFI = v1.15.1
 OPENPA = v1.0.4
 MERCURY = v2.2.0rc6
@@ -15,5 +15,5 @@ PROTOBUFC = v1.3.3
 UCX=v1.12.1
 
 [patch_versions]
-spdk=https://github.com/spdk/spdk/commit/690783a3ae82ebe58c00d643520a66103d66d540.diff,https://github.com/spdk/spdk/commit/65425be69a0882ac283fb489aa151d7df06c52ad.diff,https://raw.githubusercontent.com/daos-stack/spdk/a546fbfcca8ef7069c376e8c922cd3138317f362/0003-blob-chunk-clear-operations-in-IU-aligned-chunks.patch,https://github.com/spdk/spdk/commit/148a9ab0c06346f9fec109a1df00651c1f5a0499.diff,https://github.com/spdk/spdk/commit/086223c029389329b7a4f38ec0f9a30be83849bf.diff,https://github.com/spdk/spdk/commit/a827fd7eeca67209d4c0aaad9a3ed55692e7e36e.diff,https://github.com/spdk/spdk/commit/038f5b2e1b07f840e610ca206902a90661c6a28f.diff,https://github.com/spdk/spdk/commit/6c3fdade83cdf48182b7c2c3561ca7dd269d5aa9.diff,https://github.com/spdk/spdk/commit/b0aba3fcd5aceceea530a702922153bc75664978.diff,https://github.com/spdk/spdk/commit/91aee82d74696bb70284c794db0b2b9aef4bb9ec.diff,dpdk^https://github.com/spdk/dpdk/commit/22e79be44fd5609b7f43236d8be9b68303e99e81.diff
+spdk=https://github.com/spdk/spdk/commit/b0aba3fcd5aceceea530a702922153bc75664978.diff
 pmdk=https://raw.githubusercontent.com/daos-stack/pmdk/master/DAOS_8273.patch

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.1.103
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -74,7 +74,7 @@ BuildRequires: liblz4-devel
 BuildRequires: protobuf-c-devel
 BuildRequires: lz4-devel
 %endif
-BuildRequires: spdk-devel >= 21.07, spdk-devel < 22
+BuildRequires: spdk-devel >= 22.01.1
 %if (0%{?rhel} >= 7)
 BuildRequires: libisa-l-devel
 BuildRequires: libisa-l_crypto-devel
@@ -162,7 +162,7 @@ to optimize performance and cost.
 %package server
 Summary: The DAOS server
 Requires: %{name}%{?_isa} = %{version}-%{release}
-Requires: spdk-tools >= 21.07, spdk-tools < 22
+Requires: spdk-tools >= 22.01.1
 Requires: ndctl
 # needed to set PMem configuration goals in BIOS through control-plane
 %if (0%{?suse_version} >= 1500)
@@ -572,6 +572,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Fri Jul 15 2022 Tom Nabarro <tom.nabarro@intel.com> 2.1.103-3
+- Update SPDK dependency requirement to greater than or equal to 22.01.1.
+
 * Mon Jun 27 2022 Jerome Soumagne <jerome.soumagne@intel.com> 2.1.103-2
 - Update to mercury 2.2.0rc6
 


### PR DESCRIPTION
Update DAOS source build SPDK version and patches in utils/build.config.
Update SPDK pinned version requirements in utils/rpms/daos.spec.
Resolve API breakages resulting from SPDK version change.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>