### PR TITLE
DAOS-10739 test: Improve failure reporting in daos_build test.

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -134,7 +134,7 @@ class DaosBuild(DfuseTestBase):
 
             self.log.info(cmd_ret['stdout'])
 
-            if cmd_ret['exit_status'] == 0:
+            if cmd_ret['exit_status'] in (0, None):
                 continue
 
             fail_type = 'Failure to build'

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -134,7 +134,7 @@ class DaosBuild(DfuseTestBase):
 
             self.log.info(cmd_ret['stdout'])
 
-            if cmd_ret['exis_status'] == 0:
+            if cmd_ret['exit_status'] == 0:
                 continue
 
             fail_type = 'Failure to build'

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -124,7 +124,8 @@ class DaosBuild(DfuseTestBase):
             if cmd.startswith('scons'):
                 timeout = build_time * 60
             start = time.time()
-            ret_code = general_utils.run_pcmd(self.hostlist_clients, command, timeout, 0)
+            ret_code = general_utils.run_pcmd(self.hostlist_clients, command, verbose=True,
+                                              timeout=timeout, expect_rc=0)
             elapsed = time.time() - start
             self.log.info('Ran in {} seconds\n'.format(elapsed))
             assert len(ret_code) == 1


### PR DESCRIPTION
Remove try/except from test but fail directly.
Log how log commands took.
Log stdout on failure.
Mark failure to build and timeout differently.
Mark if failure was in interception test.

Skip-func-vm-test-leap15: False
Skip-func-test-leap15: False
Test-tag: dfusedaosbuild
Test-repeat: 2

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
