### PR TITLE
DAOS-10881 test: Skip tearDown pool destroy when not needed. (#9518)

### DIFF
--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -32,8 +32,9 @@ class DmgSystemCleanupTest(TestWithServers):
         Test Description: Test dmg system cleanup.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small,dmg
-        :avocado: tags=control,dmg_system_cleanup
+        :avocado: tags=vm
+        :avocado: tags=control,dmg
+        :avocado: tags=dmg_system_cleanup,test_dmg_system_cleanup_one_host
         """
         # Print out where this is running
         hostname = gethostname().split(".")[0]
@@ -85,6 +86,8 @@ class DmgSystemCleanupTest(TestWithServers):
         expected_count = {pool.uuid.lower(): 6 for pool in self.pool}
 
         # Clear pool and container list to avoid trying to destroy them.
+        for pool in self.pool:
+            pool.skip_cleanup()
         self.pool = []
         self.container = []
 

--- a/src/tests/ftest/fault_injection/pool.py
+++ b/src/tests/ftest/fault_injection/pool.py
@@ -21,14 +21,12 @@ class PoolServicesFaultInjection(TestWithServers):
         super().__init__(*args, **kwargs)
         self.failed_requests = 0
         self.object_class = None
-        self.container_namespace = None
         self.number_servers = 0
 
     def setUp(self):
         super().setUp()
         self.failed_requests = 0
         self.object_class = self.params.get("object_class", "/run/*")
-        self.container_namespace = self.params.get("container", "/run/*")
         self.number_servers = len(self.hostlist_servers) - 1
 
     def look_missed_request(self, cmd_stderr, msg=b"MS request error"):
@@ -46,8 +44,7 @@ class PoolServicesFaultInjection(TestWithServers):
         Look for missed requests shown by daos command.
         """
         # Get and write into container
-        self.container = self.get_container(self.pool,
-                                            namespace=self.container_namespace)
+        self.container = self.get_container(self.pool)
         self.look_missed_request(self.container.daos.result.stderr)
 
         # This is done through IOR
@@ -114,16 +111,16 @@ class PoolServicesFaultInjection(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
+        :avocado: tags=fault_injection,pool,faults
         :avocado: tags=pool_with_faults,test_pool_services
         """
         failed_commands = 0
         dmg_command = self.get_dmg_command()
-        pool_namespace = self.params.get("pool", "/run/*")
         number_pools = self.params.get("number_pools", "/run/*")
         for _ in range(number_pools):
             try:
                 # Create pool
-                self.pool = self.get_pool(namespace=pool_namespace)
+                self.pool = self.get_pool()
                 self.look_missed_request(self.pool.dmg.result.stderr)
 
                 # Container section

--- a/src/tests/ftest/server/dynamic_start_stop.py
+++ b/src/tests/ftest/server/dynamic_start_stop.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -76,7 +76,10 @@ class DynamicStartStop(TestWithServers):
         4. Stop two of the remaining added servers - Multiple stop.
         5. Stop one of the original servers - Stopping with pool.
 
-        :avocado: tags=all,hw,large,server,full_regression,dynamic_start_stop
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,large
+        :avocado: tags=server
+        :avocado: tags=dynamic_start_stop,test_dynamic_server_addition
         """
         self.add_pool()
 
@@ -101,4 +104,4 @@ class DynamicStartStop(TestWithServers):
         self.stop_server_ranks([1])
 
         # Stopping newly added server and destroy pool causes -1006. DAOS-5606
-        self.pool = None
+        self.pool.skip_cleanup()

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -221,7 +221,7 @@ class TestPool(TestDaosApiBase):
         """
         try:
             return self.pool.get_uuid_str()
-        except AttributeError:
+        except (AttributeError, TypeError):
             return None
         except IndexError:
             return self.pool.uuid


### PR DESCRIPTION
Fix dmg_system_cleanup.py and dynamic_start_stop.py to avoid destroying
pools during tearDown when not needed.

Also fix fault_injection/pool.py namespace specification.

Skip-unit-tests: true
Test-tag: test_dmg_system_cleanup_one_host test_pool_services ec_ior_hard_online_rebuild bad_connect create_max_pool

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>