### PR TITLE
DAOS-11134 control: Add leadership check to doGroupUpdate()

### DIFF
--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -191,8 +191,8 @@ func (svc *mgmtSvc) joinLoop(parent context.Context) {
 					svc.log.Errorf("sync GroupUpdate failed: %s", err)
 					continue
 				}
+				groupUpdateNeeded = false
 			}
-			groupUpdateNeeded = false
 		case <-groupUpdateTimer.C:
 			if !groupUpdateNeeded {
 				continue
@@ -363,6 +363,11 @@ func (svc *mgmtSvc) doGroupUpdate(ctx context.Context, forced bool) error {
 			Uri:  uri,
 		})
 		rankSet.Add(rank)
+	}
+
+	// Final check to make sure we're still leader.
+	if err := svc.sysdb.CheckLeader(); err != nil {
+		return err
 	}
 
 	svc.log.Debugf("group update request: version: %d, ranks: %s", req.MapVersion, rankSet)

--- a/src/control/system/raft/raft.go
+++ b/src/control/system/raft/raft.go
@@ -332,7 +332,10 @@ func (db *Database) submitRaftUpdate(data []byte) error {
 		// signal some callers to retry the operation on the
 		// new leader.
 		if IsRaftLeadershipError(err) {
-			return system.ErrRaftUnavail
+			return &system.ErrNotLeader{
+				LeaderHint: db.leaderHint(),
+				Replicas:   db.cfg.stringReplicas(db.getReplica()),
+			}
 		}
 
 		return err


### PR DESCRIPTION
In rare circumstances, this method could be called after
leadership is lost but before the worker loop is exited.
Add a final check for leadership before invoking the group
update dRPC in order to avoid trying to make the group
update on a non-leader replica.

Also fixes a bug where a sync group update could be followed
by an unnecessary async group update.

Features: control

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>

Required-githooks: true
