### PR TITLE
DAOS-11007 cart: a few refine of err code handling

### DIFF
--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -172,6 +172,7 @@ crt_hgret_2_der(int hg_ret)
 	case HG_INVALID_ARG:
 		return -DER_INVAL;
 	case HG_MSGSIZE:
+	case HG_OVERFLOW:
 		return -DER_OVERFLOW;
 	case HG_NOMEM:
 		return -DER_NOMEM;
@@ -179,6 +180,11 @@ crt_hgret_2_der(int hg_ret)
 		return -DER_CANCELED;
 	case HG_BUSY:
 		return -DER_BUSY;
+	case HG_PROTOCOL_ERROR:
+		return -DER_PROTO;
+	case HG_PERMISSION:
+	case HG_ACCESS:
+		return -DER_NO_PERM;
 	default:
 		return -DER_HG;
 	};

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -599,9 +599,7 @@ daos_der2errno(int err)
 static inline bool
 daos_crt_network_error(int err)
 {
-	return err == -DER_HG || err == -DER_ADDRSTR_GEN ||
-	       err == -DER_PMIX || err == -DER_UNREG ||
-	       err == -DER_UNREACH || err == -DER_CANCELED ||
+	return err == -DER_HG || err == -DER_UNREACH || err == -DER_CANCELED ||
 	       err == -DER_NOREPLY || err == -DER_OOG;
 }
 


### PR DESCRIPTION
Refine crt_hgret_2_der() and daos_crt_network_error() a little bit
for err code handling.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>