### PR TITLE
DAOS-10524 rebuild: master leader changing during rebuild

### DIFF
--- a/src/container/srv_oi_table.c
+++ b/src/container/srv_oi_table.c
@@ -44,6 +44,7 @@ struct oit_scan_args {
 	daos_key_t		oa_dkey;
 	daos_epoch_t		oa_epoch;
 	daos_obj_id_t		oa_oit_id;
+	daos_obj_id_t		oa_pre_id;
 	d_iov_t			oa_iov;
 	int			oa_hash;
 	/** sgl for OID each bucket */
@@ -106,6 +107,17 @@ cont_iter_obj_cb(daos_handle_t ch, vos_iter_entry_t *ent, vos_iter_type_t type,
 	oid = ent->ie_oid.id_pub;
 	if (daos_oid_is_oit(oid))
 		return 0; /* ignore IOT object */
+
+	/* There might be some objects, which has same oid.id_pub, but different
+	 * id_shard, so let's compare with the previous oid to avoid duplicate
+	 * oid. Because these same oid will be put together in OI table, so only
+	 * check the previous OID should be safe here.
+	 */
+	if (daos_oid_cmp(oa->oa_pre_id, oid) == 0) {
+		D_DEBUG(DB_TRACE, "skip duplicate OID="DF_UOID"\n", DP_UOID(ent->ie_oid));
+		return 0;
+	}
+	oa->oa_pre_id = oid;
 
 	D_DEBUG(DB_TRACE, "enumerate OID="DF_OID"\n", DP_OID(oid));
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -504,7 +504,6 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	if (ent->ie_dtx_flags & DTE_ORPHAN)
 		return 0;
 
-	/* The entry to be discarded, in spite of it is the (old) leader or not. */
 	if (ent->ie_dtx_ver < dra->discard_version) {
 		D_ALLOC_PTR(dre);
 		if (dre == NULL)

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -36,12 +36,13 @@ typedef enum {
 			  "Unknown")
 
 int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
-			uint32_t rebuild_gen, struct pool_target_id_list *tgts,
+			uint32_t rebuild_gen, daos_epoch_t stable_eph,
+			struct pool_target_id_list *tgts,
 			daos_rebuild_opc_t rebuild_op, uint64_t delay_sec);
 int ds_rebuild_query(uuid_t pool_uuid,
 		     struct daos_rebuild_status *status);
 int ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop);
 void ds_rebuild_leader_stop_all(void);
-void ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen);
-void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen);
+void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen,
+		      uint64_t term);
 #endif

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -235,6 +235,10 @@ pl_obj_layout_contains(struct pool_map *map, struct pl_obj_layout *layout,
 	D_ASSERT(layout != NULL);
 
 	for (i = 0; i < layout->ol_nr; i++) {
+		if (layout->ol_shards[i].po_rebuilding ||
+		    layout->ol_shards[i].po_reintegrating ||
+		    layout->ol_shards[i].po_target == -1)
+			continue;
 		rc = pool_map_find_target(map, layout->ol_shards[i].po_target,
 					  &target);
 		if (rc != 0 && target->ta_comp.co_rank == rank &&

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5452,7 +5452,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	D_DEBUG(DB_MD, "map ver %u/%u\n", map_version ? *map_version : -1,
 		tgt_map_ver);
 	if (tgt_map_ver != 0) {
-		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver, 0,
+		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver, 0, 0,
 					 &target_list, op, delay);
 		if (rc != 0) {
 			D_ERROR("rebuild fails rc: "DF_RC"\n", DP_RC(rc));
@@ -5602,7 +5602,7 @@ pool_extend_internal(uuid_t pool_uuid, struct rsvc_hint *hint, uint32_t nnodes,
 	}
 
 	/* Schedule an extension rebuild for those targets */
-	rc = ds_rebuild_schedule(svc->ps_pool, *map_version_p, 0, &tgts,
+	rc = ds_rebuild_schedule(svc->ps_pool, *map_version_p, 0, 0, &tgts,
 				 RB_OP_EXTEND, 2);
 	if (rc != 0) {
 		D_ERROR("failed to schedule extend rc: "DF_RC"\n", DP_RC(rc));

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -881,7 +881,7 @@ ds_pool_stop(uuid_t uuid)
 	ds_pool_tgt_ec_eph_query_abort(pool);
 	pool_fetch_hdls_ult_abort(pool);
 
-	ds_rebuild_abort(pool->sp_uuid, -1, -1);
+	ds_rebuild_abort(pool->sp_uuid, -1, -1, -1);
 	ds_migrate_stop(pool, -1);
 	ds_pool_put(pool); /* held by ds_pool_start */
 	ds_pool_put(pool);

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -82,6 +82,8 @@ struct rebuild_tgt_pool_tracker {
 	 */
 	uint64_t		rt_rebuild_fence;
 
+	uint32_t		rt_leader_rank;
+
 	/* Global dtx resync version */
 	uint32_t		rt_global_dtx_resync_version;
 	unsigned int		rt_lead_puller_running:1,
@@ -126,6 +128,7 @@ struct rebuild_global_pool_tracker {
 	uint32_t	rgt_servers_number;
 
 	uint32_t	rgt_rebuild_gen;
+
 	/* The term of the current rebuild leader */
 	uint64_t	rgt_leader_term;
 
@@ -200,6 +203,7 @@ struct rebuild_task {
 	uuid_t				dst_pool_uuid;
 	struct pool_target_id_list	dst_tgts;
 	daos_rebuild_opc_t		dst_rebuild_op;
+	daos_epoch_t			dst_stable_eph;
 	uint64_t			dst_schedule_time;
 	uint32_t			dst_map_ver;
 	uint32_t			dst_rebuild_gen;
@@ -215,6 +219,8 @@ struct rebuild_pool_tls {
 	uint64_t	rebuild_pool_obj_count;
 	uint64_t	rebuild_pool_reclaim_obj_count;
 	unsigned int	rebuild_pool_ver;
+	uint32_t	rebuild_pool_gen;
+	uint64_t	rebuild_pool_leader_term;
 	int		rebuild_pool_status;
 	unsigned int	rebuild_pool_scanning:1,
 			rebuild_pool_scan_done:1;
@@ -280,7 +286,7 @@ void rpt_get(struct rebuild_tgt_pool_tracker *rpt);
 void rpt_put(struct rebuild_tgt_pool_tracker *rpt);
 
 struct rebuild_pool_tls *
-rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver);
+rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver, uint32_t gen);
 
 struct pool_map *rebuild_pool_map_get(struct ds_pool *pool);
 void rebuild_pool_map_put(struct pool_map *map);
@@ -356,4 +362,7 @@ rebuild_notify_ras_start(uuid_t *pool, uint32_t map_ver, char *op_str);
 
 int
 rebuild_notify_ras_end(uuid_t *pool, uint32_t map_ver, char *op_str, int op_rc);
+
+void rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version,
+			 uint32_t rebuild_gen, uint64_t term);
 #endif /* __REBUILD_INTERNAL_H_ */

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -186,12 +186,11 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			return 0;
 		}
 
-		D_DEBUG(DB_REBUILD, DF_UUID"/%u/%u rebuild status gsd/gd %d/%d"
-			" stable eph "DF_U64" resync ver %u\n",
+		D_DEBUG(DB_REBUILD, DF_UUID"/%u/%u/"DF_U64" gsd/gd/stable/ver %d/%d/"DF_X64"/%u\n",
 			DP_UUID(src_iv->riv_pool_uuid), src_iv->riv_ver,
-			src_iv->riv_rebuild_gen, dst_iv->riv_global_scan_done,
-			dst_iv->riv_global_done, dst_iv->riv_stable_epoch,
-			dst_iv->riv_global_dtx_resyc_version);
+			src_iv->riv_rebuild_gen, src_iv->riv_leader_term,
+			dst_iv->riv_global_scan_done, dst_iv->riv_global_done,
+			dst_iv->riv_stable_epoch, dst_iv->riv_global_dtx_resyc_version);
 
 		if (rpt->rt_stable_epoch == 0)
 			rpt->rt_stable_epoch = dst_iv->riv_stable_epoch;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -200,7 +200,8 @@ rebuild_objects_send_ult(void *data)
 	unsigned int			*shards = NULL;
 	int				rc = 0;
 
-	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
+	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+				      rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
 
 	D_ALLOC_ARRAY(oids, REBUILD_SEND_LIMIT);
@@ -264,7 +265,8 @@ rebuild_scan_done(void *data)
 	struct rebuild_tgt_pool_tracker *rpt = data;
 	struct rebuild_pool_tls *tls;
 
-	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
+	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+				      rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
 
 	tls->rebuild_pool_scanning = 0;
@@ -285,7 +287,8 @@ rebuild_object_insert(struct rebuild_tgt_pool_tracker *rpt,
 	d_iov_t			val_iov;
 	int			rc;
 
-	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
+	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+				      rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
 	D_ASSERT(daos_handle_is_valid(tls->rebuild_tree_hdl));
 
@@ -556,15 +559,18 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 		pl_obj_layout_free(layout);
 		if (!still_needed) {
 			struct rebuild_pool_tls *tls;
+			daos_epoch_range_t	discard_epr;
 
-			tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid,
-						      rpt->rt_rebuild_ver);
+			tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+						      rpt->rt_rebuild_gen);
 			D_ASSERT(tls != NULL);
 			tls->rebuild_pool_reclaim_obj_count++;
 			D_DEBUG(DB_REBUILD, "deleting object "DF_UOID
 				" which is not reachable on rank %u tgt %u",
 				DP_UOID(oid), myrank, mytarget);
 
+			discard_epr.epr_hi = rpt->rt_stable_epoch;
+			discard_epr.epr_lo = 0;
 			/*
 			 * It's possible this object might still be being
 			 * accessed elsewhere - retry until until it is possible
@@ -573,7 +579,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 			do {
 				/* Inform the iterator and delete the object */
 				*acts |= VOS_ITER_CB_DELETE;
-				rc = vos_obj_delete(param->ip_hdl, oid);
+				rc = vos_discard(param->ip_hdl, &oid, &discard_epr, NULL, NULL);
 				if (rc == -DER_BUSY || rc == -DER_INPROGRESS) {
 					D_DEBUG(DB_REBUILD,
 						"got "DF_RC
@@ -750,7 +756,8 @@ rebuild_scanner(void *data)
 	struct umem_attr		uma;
 	int				rc = 0;
 
-	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
+	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+				      rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
 
 	if (rebuild_status_match(rpt, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN |
@@ -776,12 +783,14 @@ rebuild_scanner(void *data)
 		D_GOTO(out, rc);
 	}
 
-	rpt_get(rpt);
-	rc = dss_ult_create(rebuild_objects_send_ult, rpt, DSS_XS_SELF,
-			    0, 0, &ult_send);
-	if (rc != 0) {
-		rpt_put(rpt);
-		D_GOTO(out, rc);
+	if (rpt->rt_rebuild_op != RB_OP_RECLAIM) {
+		rpt_get(rpt);
+		rc = dss_ult_create(rebuild_objects_send_ult, rpt, DSS_XS_SELF,
+				    0, 0, &ult_send);
+		if (rc != 0) {
+			rpt_put(rpt);
+			D_GOTO(out, rc);
+		}
 	}
 
 	child = ds_pool_child_lookup(rpt->rt_pool_uuid);
@@ -856,7 +865,8 @@ rebuild_scan_leader(void *data)
 	D_DEBUG(DB_REBUILD, DF_UUID" sent objects to initiator: "DF_RC"\n",
 		DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
 out:
-	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
+	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+				      rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
 	if (tls->rebuild_pool_status == 0 && rc != 0)
 		tls->rebuild_pool_status = rc;
@@ -878,9 +888,10 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	rsi = crt_req_get(rpc);
 	D_ASSERT(rsi != NULL);
 
-	D_DEBUG(DB_REBUILD, "%d scan rebuild for "DF_UUID" ver %d gen %u\n",
+	D_DEBUG(DB_REBUILD, "%d/"DF_UUID" scan ver %d gen %u leader %u term "DF_U64" op:%s\n",
 		dss_get_module_info()->dmi_tgt_id, DP_UUID(rsi->rsi_pool_uuid),
-		rsi->rsi_rebuild_ver, rsi->rsi_rebuild_gen);
+		rsi->rsi_rebuild_ver, rsi->rsi_rebuild_gen, rsi->rsi_master_rank,
+		rsi->rsi_leader_term, RB_OP_STR(rsi->rsi_rebuild_op));
 
 	/* If PS leader has been changed, and rebuild version is also increased
 	 * due to adding new failure targets for rebuild, let's abort previous
@@ -897,12 +908,13 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		}
 	}
 
-	/* check if the rebuild is already started */
+	/* check if the rebuild with different leader is already started */
 	rpt = rpt_lookup(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver, rsi->rsi_rebuild_gen);
 	if (rpt != NULL) {
 		if (rpt->rt_global_done) {
-			D_WARN("the previous rebuild " DF_UUID "/%d is not cleanup yet\n",
-			       DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver);
+			D_WARN("the previous rebuild "DF_UUID"/%d/"DF_U64"/%p is not cleanup yet\n",
+			       DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver,
+			       rsi->rsi_leader_term, rpt);
 			D_GOTO(out, rc = -DER_BUSY);
 		}
 
@@ -911,8 +923,9 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 			  "rsi_rebuild_ver %d != rt_rebuild_ver %d\n",
 			  rsi->rsi_rebuild_ver, rpt->rt_rebuild_ver);
 
-		D_DEBUG(DB_REBUILD, DF_UUID" already started.\n",
-			DP_UUID(rsi->rsi_pool_uuid));
+		D_DEBUG(DB_REBUILD, DF_UUID" already started, req "DF_U64" master %u/"DF_U64"\n",
+			DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_leader_term, rsi->rsi_master_rank,
+			rpt->rt_leader_term);
 
 		/* Ignore the rebuild trigger request if it comes from
 		 * an old or same leader.
@@ -920,27 +933,20 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		if (rsi->rsi_leader_term <= rpt->rt_leader_term)
 			D_GOTO(out, rc = 0);
 
-		if (rpt->rt_pool->sp_iv_ns != NULL &&
-		    rpt->rt_pool->sp_iv_ns->iv_master_rank !=
-					rsi->rsi_master_rank) {
+		if (rpt->rt_leader_rank != rsi->rsi_master_rank) {
 			D_DEBUG(DB_REBUILD, DF_UUID" master rank"
 				" %d -> %d term "DF_U64" -> "DF_U64"\n",
 				DP_UUID(rpt->rt_pool_uuid),
-				rpt->rt_pool->sp_iv_ns->iv_master_rank,
-				rsi->rsi_master_rank,
-				rpt->rt_leader_term,
-				rsi->rsi_leader_term);
+				rpt->rt_leader_rank, rsi->rsi_master_rank,
+				rpt->rt_leader_term, rsi->rsi_leader_term);
 			/* re-report the #rebuilt cnt next time */
 			rpt->rt_re_report = 1;
-			/* Update master rank */
-			ds_pool_iv_ns_update(rpt->rt_pool,
-					     rsi->rsi_master_rank);
 
-			/* If this is the old leader, then also stop the rebuild
-			 * tracking ULT.
-			 */
-			ds_rebuild_leader_stop(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver,
-					       rsi->rsi_rebuild_gen);
+			rpt->rt_leader_rank = rsi->rsi_master_rank;
+
+			/* If this is the old leader, then also stop the rebuild tracking ULT. */
+			rebuild_leader_stop(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver,
+					    rsi->rsi_rebuild_gen, rpt->rt_leader_term);
 		}
 
 		rpt->rt_leader_term = rsi->rsi_leader_term;
@@ -948,7 +954,8 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		D_GOTO(out, rc = 0);
 	}
 
-	tls = rebuild_pool_tls_lookup(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver);
+	tls = rebuild_pool_tls_lookup(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver,
+				      rsi->rsi_rebuild_gen);
 	if (tls != NULL) {
 		D_WARN("the previous rebuild "DF_UUID"/%d is not cleanup yet\n",
 		       DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -46,7 +46,7 @@ rebuild_pool_map_put(struct pool_map *map)
 }
 
 struct rebuild_pool_tls *
-rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver)
+rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver, uint32_t gen)
 {
 	struct rebuild_tls *tls = rebuild_tls_get();
 	struct rebuild_pool_tls *pool_tls;
@@ -57,8 +57,8 @@ rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver)
 	d_list_for_each_entry(pool_tls, &tls->rebuild_pool_list,
 			      rebuild_pool_list) {
 		if (uuid_compare(pool_tls->rebuild_pool_uuid, pool_uuid) == 0 &&
-		    (ver == (unsigned int)(-1) ||
-		     ver == pool_tls->rebuild_pool_ver)) {
+		    (ver == (unsigned int)(-1) || ver == pool_tls->rebuild_pool_ver) &&
+		    (gen == (uint32_t)(-1) || gen == pool_tls->rebuild_pool_gen)) {
 			found = pool_tls;
 			break;
 		}
@@ -69,12 +69,12 @@ rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver)
 
 static struct rebuild_pool_tls *
 rebuild_pool_tls_create(uuid_t pool_uuid, uuid_t poh_uuid, uuid_t coh_uuid,
-			unsigned int ver)
+			unsigned int ver, uint32_t gen)
 {
 	struct rebuild_pool_tls *rebuild_pool_tls;
 	struct rebuild_tls *tls = rebuild_tls_get();
 
-	rebuild_pool_tls = rebuild_pool_tls_lookup(pool_uuid, ver);
+	rebuild_pool_tls = rebuild_pool_tls_lookup(pool_uuid, ver, gen);
 	D_ASSERT(rebuild_pool_tls == NULL);
 
 	D_ALLOC_PTR(rebuild_pool_tls);
@@ -82,6 +82,7 @@ rebuild_pool_tls_create(uuid_t pool_uuid, uuid_t poh_uuid, uuid_t coh_uuid,
 		return NULL;
 
 	rebuild_pool_tls->rebuild_pool_ver = ver;
+	rebuild_pool_tls->rebuild_pool_gen = gen;
 	uuid_copy(rebuild_pool_tls->rebuild_pool_uuid, pool_uuid);
 	rebuild_pool_tls->rebuild_pool_scanning = 1;
 	rebuild_pool_tls->rebuild_pool_scan_done = 0;
@@ -386,8 +387,8 @@ dss_rebuild_check_one(void *data)
 	if (is_current_tgt_unavail(rpt))
 		return 0;
 
-	pool_tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid,
-					   rpt->rt_rebuild_ver);
+	pool_tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+					   rpt->rt_rebuild_gen);
 	D_ASSERTF(pool_tls != NULL, DF_UUID" ver %d\n",
 		   DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver);
 
@@ -425,7 +426,8 @@ rebuild_tgt_query(struct rebuild_tgt_pool_tracker *rpt,
 	if (rc)
 		D_GOTO(out, rc);
 
-	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
+	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+				      rpt->rt_rebuild_gen);
 	if (tls != NULL && tls->rebuild_pool_status)
 		status->status = tls->rebuild_pool_status;
 
@@ -546,10 +548,15 @@ rebuild_leader_status_notify(struct rebuild_global_pool_tracker *rgt, struct ds_
 	iv.riv_rebuild_gen	= rgt->rgt_rebuild_gen;
 	iv.riv_seconds          = rgt->rgt_status.rs_seconds;
 	iv.riv_stable_epoch	= rgt->rgt_stable_epoch;
-	iv.riv_global_dtx_resyc_version = rebuild_get_global_dtx_resync_ver(rgt);
+	rgt->rgt_dtx_resync_version = iv.riv_global_dtx_resyc_version =
+				rebuild_get_global_dtx_resync_ver(rgt);
+	iv.riv_dtx_resyc_version = pool->sp_dtx_resync_version;
 
-	D_DEBUG(DB_REBUILD, "rebuild IV %u final "DF_UUID"/%u : %d\n",
-		op, DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver, rgt->rgt_status.rs_errno);
+
+	D_DEBUG(DB_REBUILD, DF_UUID "/%u/%u op: %s dtx %u scan_gd/gd/abort %u/%u/%u: %d\n",
+		DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver, rgt->rgt_rebuild_gen,
+		RB_OP_STR(op), iv.riv_global_dtx_resyc_version, iv.riv_global_scan_done,
+		iv.riv_global_done, rgt->rgt_abort, rgt->rgt_status.rs_errno);
 
 	rc = rebuild_iv_update(pool->sp_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
 			       CRT_IV_SYNC_LAZY, true);
@@ -571,7 +578,7 @@ enum {
  * its own rebuild status by IV.
  */
 static void
-rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
+rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 			    struct rebuild_global_pool_tracker *rgt)
 {
 	double			last_print = 0;
@@ -595,44 +602,42 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 
 	while (1) {
 		struct daos_rebuild_status	*rs = &rgt->rgt_status;
-		struct pool_target		*targets;
 		char				sbuf[RBLD_SBUF_LEN];
-		unsigned int			failed_tgts_cnt;
 		double				now;
 		char				*str;
+		d_rank_list_t			excluded = { 0 };
+		int				i;
 
-		rc = pool_map_find_failed_tgts(pool->sp_map, &targets,
-					       &failed_tgts_cnt);
+		ABT_rwlock_rdlock(pool->sp_lock);
+		rc = map_ranks_init(pool->sp_map,
+				    PO_COMP_ST_UP | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
+				    &excluded);
 		if (rc != 0) {
-			D_ERROR("failed to create failed tgt list: "DF_RC"\n",
-				DP_RC(rc));
-			break;
+			D_INFO(DF_UUID": get rank list: %d\n", DP_UUID(pool->sp_uuid), rc);
+			ABT_rwlock_unlock(pool->sp_lock);
+			goto sleep;
 		}
 
-		if (targets != NULL) {
+		for (i = 0; i < excluded.rl_nr; i++) {
 			struct pool_domain *dom;
-			int i;
 
-			for (i = 0; i < failed_tgts_cnt; i++) {
-				dom = pool_map_find_node_by_rank(pool->sp_map,
-						targets[i].ta_comp.co_rank);
+			dom = pool_map_find_node_by_rank(pool->sp_map, excluded.rl_ranks[i]);
+			D_ASSERT(dom != NULL);
 
-				D_ASSERT(dom != NULL);
-				D_DEBUG(DB_REBUILD, "rank %d/%x.\n",
-					dom->do_comp.co_rank,
-					dom->do_comp.co_status);
-				if (pool_component_unavail(&dom->do_comp, false))
-					rebuild_leader_set_status(rgt, dom->do_comp.co_rank,
-								  -1, SCAN_DONE | PULL_DONE);
-			}
-			D_FREE(targets);
+			/* If the rank is being scheduled after reintegration
+			 * start, let's skip the rank, i.e. set it DONE.
+			 */
+			if (dom->do_comp.co_status == PO_COMP_ST_UP &&
+			    dom->do_comp.co_in_ver < rgt->rgt_rebuild_ver)
+				continue;
+
+			D_INFO(DF_UUID" exclude rank %d/%x.\n", DP_UUID(pool->sp_uuid),
+			       dom->do_comp.co_rank, dom->do_comp.co_status);
+			rebuild_leader_set_status(rgt, dom->do_comp.co_rank,
+						  -1, SCAN_DONE | PULL_DONE);
 		}
-
-		if (myrank != pool->sp_iv_ns->iv_master_rank &&
-		    pool->sp_iv_ns->iv_master_rank != -1)
-			D_DEBUG(DB_REBUILD, DF_UUID" leader is being changed"
-				" %u->%u.\n", DP_UUID(pool->sp_uuid), myrank,
-				pool->sp_iv_ns->iv_master_rank);
+		ABT_rwlock_unlock(pool->sp_lock);
+		map_ranks_fini(&excluded);
 
 		if (!rgt->rgt_abort && !is_rebuild_global_done(rgt) &&
 		    myrank == pool->sp_iv_ns->iv_master_rank)
@@ -654,13 +659,14 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 		rs->rs_seconds =
 			(d_timeus_secdiff(0) - rgt->rgt_time_start) / 1e6;
 		snprintf(sbuf, RBLD_SBUF_LEN,
-			 "%s [%s] (pool "DF_UUID" ver=%u, toberb_obj="
-			 DF_U64", rb_obj="DF_U64", rec="DF_U64", size="DF_U64
+			 "%s [%s] (pool "DF_UUID" leader %u term "DF_U64" dtx gl %u ver=%u,"
+			 "gen %u toberb_obj=" DF_U64", rb_obj="DF_U64", rec="DF_U64", size="DF_U64
 			 " done %d status %d/%d epoch "DF_U64" duration=%d secs)\n",
-			 RB_OP_STR(op), str, DP_UUID(pool->sp_uuid), map_ver,
-			 rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr,
-			 rs->rs_size, rs->rs_state, rs->rs_errno,
-			 rs->rs_fail_rank, rgt->rgt_stable_epoch, rs->rs_seconds);
+			 RB_OP_STR(op), str, DP_UUID(pool->sp_uuid), myrank,
+			 rgt->rgt_leader_term, rgt->rgt_dtx_resync_version, rgt->rgt_rebuild_ver,
+			 rgt->rgt_rebuild_gen, rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr,
+			 rs->rs_size, rs->rs_state, rs->rs_errno, rs->rs_fail_rank,
+			 rgt->rgt_stable_epoch, rs->rs_seconds);
 
 		D_INFO("%s", sbuf);
 		if (rs->rs_state == DRS_COMPLETED || rebuild_gst.rg_abort ||
@@ -675,7 +681,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver, uint32_t op,
 			last_print = now;
 			D_PRINT("%s", sbuf);
 		}
-
+sleep:
 		sched_req_sleep(rgt->rgt_ult, RBLD_CHECK_INTV);
 	}
 
@@ -701,7 +707,8 @@ rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 }
 
 static int
-rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver,
+rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t rebuild_gen,
+				   uint64_t leader_term, daos_epoch_t stable_eph,
 				   struct rebuild_global_pool_tracker **p_rgt)
 {
 	struct rebuild_global_pool_tracker *rgt;
@@ -738,6 +745,10 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver,
 	uuid_copy(rgt->rgt_pool_uuid, pool->sp_uuid);
 	rgt->rgt_rebuild_ver = ver;
 	rgt->rgt_status.rs_version = ver;
+	rgt->rgt_leader_term = leader_term;
+	rgt->rgt_rebuild_gen = rebuild_gen;
+	rgt->rgt_time_start = d_timeus_secdiff(0);
+	rgt->rgt_stable_epoch = stable_eph;
 	d_list_add(&rgt->rgt_list, &rebuild_gst.rg_global_tracker_list);
 	*p_rgt = rgt;
 	rgt->rgt_refcount = 1;
@@ -785,36 +796,33 @@ rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver, uns
 static int
 rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 		uint32_t rebuild_gen, uint64_t leader_term,
+		daos_epoch_t stable_eph,
 		struct pool_target_id_list *tgts,
 		daos_rebuild_opc_t rebuild_op,
 		struct rebuild_global_pool_tracker **rgt)
 {
 	pool_comp_state_t	match_status;
-	unsigned int		master_rank;
 	int			rc;
 
 	D_DEBUG(DB_REBUILD, "pool "DF_UUID" create rebuild iv, op=%s\n",
 		DP_UUID(pool->sp_uuid), RB_OP_STR(rebuild_op));
 
 	/* Update pool iv ns for the pool */
-	crt_group_rank(pool->sp_group, &master_rank);
-	ds_pool_iv_ns_update(pool, master_rank);
-
-	rc = rebuild_global_pool_tracker_create(pool, rebuild_ver, rgt);
+	rc = rebuild_global_pool_tracker_create(pool, rebuild_ver, rebuild_gen, leader_term,
+						stable_eph, rgt);
 	if (rc) {
 		D_ERROR("rebuild_global_pool_tracker create failed: rc %d\n",
 			rc);
 		return rc;
 	}
 
-	(*rgt)->rgt_leader_term = leader_term;
-	(*rgt)->rgt_rebuild_gen = rebuild_gen;
-	(*rgt)->rgt_time_start = d_timeus_secdiff(0);
+	if (rebuild_op == RB_OP_RECLAIM)
+		return 0;
+
 	D_ASSERT(rebuild_op == RB_OP_FAIL ||
 		 rebuild_op == RB_OP_DRAIN ||
 		 rebuild_op == RB_OP_REINT ||
-		 rebuild_op == RB_OP_EXTEND ||
-		 rebuild_op == RB_OP_RECLAIM);
+		 rebuild_op == RB_OP_EXTEND);
 	match_status = (rebuild_op == RB_OP_FAIL ? PO_COMP_ST_DOWN :
 			rebuild_op == RB_OP_DRAIN ? PO_COMP_ST_DRAIN :
 			rebuild_op == RB_OP_REINT ? PO_COMP_ST_UP :
@@ -866,26 +874,68 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
  * rebuild.
  */
 static int
-rebuild_scan_broadcast(struct ds_pool *pool,
-		       struct rebuild_global_pool_tracker *rgt,
-		       struct pool_target_id_list *tgts_failed,
-		       daos_rebuild_opc_t rebuild_op)
+rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker *rgt,
+		       struct pool_target_id_list *tgts_failed, daos_rebuild_opc_t rebuild_op)
 {
 	struct rebuild_scan_in	*rsi;
 	struct rebuild_scan_out	*rso;
+	d_rank_list_t		*excluded = NULL;
 	crt_rpc_t		*rpc;
 	int			rc;
 
-	/* Send rebuild RPC to all targets of the pool to initialize rebuild.
-	 * XXX this should be idempotent as well as query and fini.
+	/* There might be some other ranks being queued for reintegration,
+	 * but not included in this reintegration, so let's exclude those
+	 * ranks from this reintegration.
 	 */
+	D_DEBUG(DB_REBUILD, "rebuild op %d\n", rebuild_op);
+	if (rebuild_op == RB_OP_REINT || rebuild_op == RB_OP_EXTEND ||
+	    rebuild_op == RB_OP_RECLAIM) {
+		d_rank_list_t	up_ranks = { 0 };
+		int		i;
+		int		nr = 0;
+
+		ABT_rwlock_rdlock(pool->sp_lock);
+		rc = map_ranks_init(pool->sp_map, PO_COMP_ST_UP, &up_ranks);
+		ABT_rwlock_unlock(pool->sp_lock);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to create rank list: %d\n",
+				DP_UUID(pool->sp_uuid), rc);
+			return rc;
+		}
+
+		D_DEBUG(DB_REBUILD, "up_ranks %d\n", up_ranks.rl_nr);
+		excluded = d_rank_list_alloc(up_ranks.rl_nr);
+		/* exclude ranks which is scheduled after the current
+		 * reintegraion started.
+		 */
+		if (excluded == NULL) {
+			map_ranks_fini(&up_ranks);
+			return -DER_NOMEM;
+		}
+
+		for (i = 0; i < up_ranks.rl_nr; i++) {
+			struct pool_domain *dom;
+
+			dom = pool_map_find_node_by_rank(pool->sp_map, up_ranks.rl_ranks[i]);
+			D_ASSERT(dom != NULL);
+			D_DEBUG(DB_REBUILD, "rank %u ver %u rebuild %u\n",
+				up_ranks.rl_ranks[i], dom->do_comp.co_in_ver, rgt->rgt_rebuild_ver);
+			if (dom->do_comp.co_in_ver < rgt->rgt_rebuild_ver)
+				continue;
+
+			excluded->rl_ranks[nr++] = up_ranks.rl_ranks[i];
+		}
+		excluded->rl_nr = nr;
+		map_ranks_fini(&up_ranks);
+	}
+
 	rc = ds_pool_bcast_create(dss_get_module_info()->dmi_ctx,
 				  pool, DAOS_REBUILD_MODULE,
 				  REBUILD_OBJECTS_SCAN, DAOS_REBUILD_VERSION,
-				  &rpc, NULL, NULL);
+				  &rpc, NULL, excluded);
 	if (rc != 0) {
 		D_ERROR("pool map broad cast failed: rc "DF_RC"\n", DP_RC(rc));
-		return rc;
+		D_GOTO(out, rc);
 	}
 
 	rsi = crt_req_get(rpc);
@@ -907,12 +957,24 @@ rebuild_scan_broadcast(struct ds_pool *pool,
 		rc = rso->rso_status;
 
 	rgt->rgt_init_scan = 1;
-	rgt->rgt_stable_epoch = rso->rso_stable_epoch;
-
+	if (rgt->rgt_stable_epoch == 0) {
+		rgt->rgt_stable_epoch = rso->rso_stable_epoch;
+	} else {
+		/* If initial rebuild/reintegration failed, the retry will keep
+		 * the same stable epoch to make sure reclaim only delete the data
+		 * before stable epoch, but keep the inflight data.
+		 */
+		D_ASSERTF(rgt->rgt_stable_epoch <= rso->rso_stable_epoch,
+			  "stable epoch "DF_X64" > collect epoch "DF_X64"\n",
+			  rgt->rgt_stable_epoch, rso->rso_stable_epoch);
+	}
 	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID": "DF_RC" got stable epoch "
 		DF_U64"\n", DP_UUID(rsi->rsi_pool_uuid), DP_RC(rc),
 		rgt->rgt_stable_epoch);
 	crt_req_decref(rpc);
+out:
+	if (excluded)
+		d_rank_list_free(excluded);
 	return rc;
 }
 
@@ -1020,10 +1082,8 @@ rebuild_debug_print_queue()
 					     "%u ",
 					     task->dst_tgts.pti_ids[i].pti_id);
 		}
-
-		D_DEBUG(DB_REBUILD, "  " DF_UUID " op=%s ver=%u tgts=%s\n",
-			DP_UUID(task->dst_pool_uuid),
-			RB_OP_STR(task->dst_rebuild_op),
+		D_DEBUG(DB_REBUILD, DF_UUID" op=%s ver=%u tgts=%s\n",
+			DP_UUID(task->dst_pool_uuid), RB_OP_STR(task->dst_rebuild_op),
 			task->dst_map_ver, tgts_buf);
 	}
 }
@@ -1042,7 +1102,7 @@ rebuild_debug_print_queue()
  * Other return value indicates an error.
  */
 static int
-rebuild_try_merge_tgts(const uuid_t pool_uuid, uint32_t map_ver,
+rebuild_try_merge_tgts(struct ds_pool *pool, uint32_t map_ver,
 		       daos_rebuild_opc_t rebuild_op,
 		       struct pool_target_id_list *tgts)
 {
@@ -1061,7 +1121,7 @@ rebuild_try_merge_tgts(const uuid_t pool_uuid, uint32_t map_ver,
 	 * complete.
 	 */
 	d_list_for_each_entry(task, &rebuild_gst.rg_queue_list, dst_list) {
-		if (uuid_compare(task->dst_pool_uuid, pool_uuid) != 0)
+		if (uuid_compare(task->dst_pool_uuid, pool->sp_uuid) != 0)
 			/* This task isn't for this pool - don't consider it */
 			continue;
 
@@ -1083,8 +1143,8 @@ rebuild_try_merge_tgts(const uuid_t pool_uuid, uint32_t map_ver,
 		return 0;
 
 	D_DEBUG(DB_REBUILD, "("DF_UUID" ver=%u) id %u merge to task %p op=%s\n",
-		DP_UUID(pool_uuid), map_ver,
-		tgts->pti_ids[0].pti_id, merge_task, RB_OP_STR(rebuild_op));
+		DP_UUID(pool->sp_uuid), map_ver, tgts->pti_ids[0].pti_id, merge_task,
+		RB_OP_STR(rebuild_op));
 
 	/* Merge the failed ranks to existing rebuild task */
 	rc = pool_target_id_list_merge(&merge_task->dst_tgts, tgts);
@@ -1098,7 +1158,7 @@ rebuild_try_merge_tgts(const uuid_t pool_uuid, uint32_t map_ver,
 	}
 
 	D_PRINT("%s [queued] ("DF_UUID" ver=%u) id %u\n",
-		RB_OP_STR(rebuild_op), DP_UUID(pool_uuid), map_ver,
+		RB_OP_STR(rebuild_op), DP_UUID(pool->sp_uuid), map_ver,
 		tgts->pti_ids[0].pti_id);
 
 	/* Print out the current queue to the debug log */
@@ -1112,16 +1172,15 @@ rebuild_try_merge_tgts(const uuid_t pool_uuid, uint32_t map_ver,
  * to find out the impacted objects.
  */
 static int
-rebuild_leader_start(struct ds_pool *pool, uint32_t rebuild_ver,
-		     uint32_t rebuild_gen, struct pool_target_id_list *tgts,
-		     daos_rebuild_opc_t rebuild_op,
+rebuild_leader_start(struct ds_pool *pool, struct rebuild_task *task,
 		     struct rebuild_global_pool_tracker **p_rgt)
 {
 	uint64_t	leader_term;
 	int		rc;
 
 	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID", rebuild version=%u/%u, op=%s\n",
-		DP_UUID(pool->sp_uuid), rebuild_ver, rebuild_gen, RB_OP_STR(rebuild_op));
+		DP_UUID(pool->sp_uuid), task->dst_map_ver, task->dst_rebuild_gen,
+		RB_OP_STR(task->dst_rebuild_op));
 
 	rc = ds_pool_svc_term_get(pool->sp_uuid, &leader_term);
 	if (rc) {
@@ -1130,21 +1189,76 @@ rebuild_leader_start(struct ds_pool *pool, uint32_t rebuild_ver,
 		D_GOTO(out, rc);
 	}
 
-	rc = rebuild_prepare(pool, rebuild_ver, rebuild_gen, leader_term, tgts, rebuild_op,
-			     p_rgt);
+	rc = rebuild_prepare(pool, task->dst_map_ver, task->dst_rebuild_gen,
+			     leader_term, task->dst_stable_eph, &task->dst_tgts,
+			     task->dst_rebuild_op, p_rgt);
 	if (rc) {
 		D_ERROR("rebuild prepare failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
 	/* broadcast scan RPC to all targets */
-	rc = rebuild_scan_broadcast(pool, *p_rgt, tgts, rebuild_op);
+	rc = rebuild_scan_broadcast(pool, *p_rgt, &task->dst_tgts, task->dst_rebuild_op);
 	if (rc) {
 		D_ERROR("object scan failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
 out:
+	return rc;
+}
+
+static int
+rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
+			       struct rebuild_global_pool_tracker *rgt)
+{
+	int rc;
+
+	if (rgt == NULL) {
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
+					 0, &task->dst_tgts, task->dst_rebuild_op, 5);
+		return rc;
+	}
+
+	/* If current job failed */
+	if (!is_rebuild_global_done(rgt) || rgt->rgt_status.rs_errno != 0) {
+		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
+		if (task->dst_rebuild_op == RB_OP_RECLAIM) {
+			rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
+						 rgt->rgt_stable_epoch, &task->dst_tgts,
+						 RB_OP_RECLAIM, 5);
+			return rc;
+		}
+
+		/* Schedule reclaim to clean up current op */
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
+					 rgt->rgt_stable_epoch, &task->dst_tgts, RB_OP_RECLAIM, 5);
+		if (rc)
+			return rc;
+
+		/* Then retry */
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
+					 rgt->rgt_stable_epoch, &task->dst_tgts,
+					 task->dst_rebuild_op, 5);
+		return rc;
+	}
+
+	/* Schedule reclaim for reintegrate/extend/upgrade to cleanup stale object */
+	if (task->dst_rebuild_op == RB_OP_REINT || task->dst_rebuild_op == RB_OP_EXTEND) {
+		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
+					 rgt->rgt_stable_epoch, &task->dst_tgts, RB_OP_RECLAIM, 5);
+		if (rc != 0)
+			D_ERROR("reschedule reclaim, "DF_UUID" failed: "DF_RC"\n",
+				DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+	}
+
+	/* Update the rebuild complete status. */
+	rc = rebuild_status_completed_update(task->dst_pool_uuid, &rgt->rgt_status);
+	if (rc != 0)
+		D_ERROR("rebuild_status_completed_update, "DF_UUID" failed: "DF_RC"\n",
+			DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+
 	return rc;
 }
 
@@ -1184,8 +1298,7 @@ rebuild_task_ult(void *arg)
 		RB_OP_STR(task->dst_rebuild_op), DP_UUID(task->dst_pool_uuid),
 		task->dst_map_ver);
 
-	rc = rebuild_leader_start(pool, task->dst_map_ver, task->dst_rebuild_gen,
-				  &task->dst_tgts, task->dst_rebuild_op, &rgt);
+	rc = rebuild_leader_start(pool, task, &rgt);
 	if (rc != 0) {
 		if (rc == -DER_CANCELED ||
 		    (rc == -DER_NOTLEADER &&
@@ -1224,8 +1337,7 @@ rebuild_task_ult(void *arg)
 	}
 
 	/* Wait until rebuild finished */
-	rebuild_leader_status_check(pool, task->dst_map_ver,
-				    task->dst_rebuild_op, rgt);
+	rebuild_leader_status_check(pool, task->dst_rebuild_op, rgt);
 done:
 	if (!is_rebuild_global_done(rgt)) {
 		D_DEBUG(DB_REBUILD, DF_UUID" rebuild is not done: "DF_RC"\n",
@@ -1286,44 +1398,7 @@ iv_stop:
 	}
 
 try_reschedule:
-	if (rgt == NULL || !is_rebuild_global_done(rgt) ||
-	    rgt->rgt_status.rs_errno != 0 ||
-	    task->dst_rebuild_op == RB_OP_REINT || task->dst_rebuild_op == RB_OP_EXTEND) {
-		daos_rebuild_opc_t opc = task->dst_rebuild_op;
-		int ret;
-
-		/* NB: we can not skip the rebuild of the target,
-		 * otherwise it will lose data and also mess the
-		 * rebuild sequence, which has to be done by failure
-		 * sequence order.
-		 */
-		if (rgt)
-			rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
-
-		/* If reintegrate succeeds, schedule reclaim */
-		if (rgt && is_rebuild_global_done(rgt) &&
-		    rgt->rgt_status.rs_errno == 0 &&
-		    (opc == RB_OP_REINT || opc == RB_OP_EXTEND))
-			opc = RB_OP_RECLAIM;
-
-		ret = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-					  &task->dst_tgts, opc, 5);
-		if (ret != 0)
-			D_ERROR("reschedule "DF_RC" opc %u\n", DP_RC(ret), opc);
-		else
-			D_DEBUG(DB_REBUILD, DF_UUID" reschedule opc %u\n",
-				DP_UUID(pool->sp_uuid), opc);
-	} else {
-		int ret;
-
-		/* Update the rebuild complete status. */
-		ret = rebuild_status_completed_update(task->dst_pool_uuid,
-						     &rgt->rgt_status);
-		if (ret != 0)
-			D_ERROR("rebuild_status_completed_update, "DF_UUID" "
-				"failed: "DF_RC"\n",
-				DP_UUID(task->dst_pool_uuid), DP_RC(ret));
-	}
+	rebuild_task_complete_schedule(task, pool, rgt);
 output:
 	rc = rebuild_notify_ras_end(&task->dst_pool_uuid, task->dst_map_ver,
 				    RB_OP_STR(task->dst_rebuild_op),
@@ -1452,18 +1527,19 @@ rpt_abort(struct rebuild_tgt_pool_tracker *rpt)
 }
 
 void
-ds_rebuild_abort(uuid_t pool_uuid, unsigned int ver, unsigned int gen)
+ds_rebuild_abort(uuid_t pool_uuid, unsigned int ver, unsigned int gen, uint64_t term)
 {
 	struct rebuild_tgt_pool_tracker *rpt;
 	struct rebuild_tgt_pool_tracker	*tmp;
 
-	ds_rebuild_leader_stop(pool_uuid, ver, gen);
+	rebuild_leader_stop(pool_uuid, ver, gen, term);
 
 	/* Only stream 0 will access the list */
 	d_list_for_each_entry_safe(rpt, tmp, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
 		if (uuid_compare(rpt->rt_pool_uuid, pool_uuid) == 0 &&
 		    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
-		    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen))
+		    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen) &&
+		    (term == (uint64_t)(-1) || rpt->rt_leader_term == term))
 			rpt_abort(rpt);
 	}
 }
@@ -1476,6 +1552,8 @@ rgt_leader_stop(struct rebuild_global_pool_tracker *rgt)
 		DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver);
 	rgt->rgt_abort = 1;
 
+	/* Remove it from the rgt list to avoid stopping rgt duplicately */
+	d_list_del(&rgt->rgt_list);
 	/* Since the rpt will be destroyed after signal rt_done_cond,
 	 * so we have to use another lock here.
 	 */
@@ -1491,7 +1569,8 @@ rgt_leader_stop(struct rebuild_global_pool_tracker *rgt)
 
 /* If this is called on non-leader node, it will do nothing */
 void
-ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int ver, unsigned int gen)
+rebuild_leader_stop(const uuid_t pool_uuid, unsigned int ver, unsigned int gen,
+		    uint64_t term)
 {
 	struct rebuild_global_pool_tracker	*rgt;
 	struct rebuild_global_pool_tracker	*rgt_tmp;
@@ -1512,7 +1591,8 @@ ds_rebuild_leader_stop(const uuid_t pool_uuid, unsigned int ver, unsigned int ge
 				   rgt_list) {
 		if (uuid_compare(rgt->rgt_pool_uuid, pool_uuid) == 0 &&
 		    (ver == (unsigned int)(-1) || rgt->rgt_rebuild_ver == ver) &&
-		    (gen == (unsigned int)(-1) || rgt->rgt_rebuild_gen == gen))
+		    (gen == (unsigned int)(-1) || rgt->rgt_rebuild_gen == gen) &&
+		    (term == (uint64_t)(-1) || rgt->rgt_leader_term == term))
 			rgt_leader_stop(rgt);
 	}
 }
@@ -1570,13 +1650,13 @@ rebuild_print_list_update(const uuid_t uuid, const uint32_t map_ver,
  */
 int
 ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen,
-		    struct pool_target_id_list *tgts,
+		    daos_epoch_t stable_eph, struct pool_target_id_list *tgts,
 		    daos_rebuild_opc_t rebuild_op, uint64_t delay_sec)
 {
 	struct rebuild_task	*new_task;
 	struct rebuild_task	*task;
 	d_list_t		*inserted_pos;
-	int			rc;
+	int			rc = 0;
 	uint64_t		cur_ts = 0;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
@@ -1587,10 +1667,12 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen
 		return 0;
 	}
 
-	/* Check if the pool already in the queue list */
-	rc = rebuild_try_merge_tgts(pool->sp_uuid, map_ver, rebuild_op, tgts);
-	if (rc)
-		return rc == 1 ? 0 : rc;
+	if (tgts != NULL && tgts->pti_number > 0) {
+		/* Check if the pool already in the queue list */
+		rc = rebuild_try_merge_tgts(pool, map_ver, rebuild_op, tgts);
+		if (rc)
+			return rc == 1 ? 0 : rc;
+	}
 
 	/* No existing task was found - allocate a new one and use it */
 	D_ALLOC_PTR(new_task);
@@ -1603,13 +1685,15 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen
 	new_task->dst_map_ver = map_ver;
 	new_task->dst_rebuild_gen = rebuild_gen;
 	new_task->dst_rebuild_op = rebuild_op;
+	new_task->dst_stable_eph = stable_eph;
 	uuid_copy(new_task->dst_pool_uuid, pool->sp_uuid);
 	D_INIT_LIST_HEAD(&new_task->dst_list);
 
-	/* TODO: Merge everything for reclaim */
-	rc = pool_target_id_list_merge(&new_task->dst_tgts, tgts);
-	if (rc)
-		D_GOTO(free, rc);
+	if (tgts != NULL && tgts->pti_number > 0) {
+		rc = pool_target_id_list_merge(&new_task->dst_tgts, tgts);
+		if (rc)
+			D_GOTO(free, rc);
+	}
 
 	rebuild_print_list_update(pool->sp_uuid, map_ver, rebuild_op, tgts);
 
@@ -1625,6 +1709,11 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen
 		if (new_task->dst_map_ver > task->dst_map_ver)
 			continue;
 
+		if (new_task->dst_rebuild_op != RB_OP_RECLAIM &&
+		    new_task->dst_map_ver == task->dst_map_ver &&
+		    new_task->dst_rebuild_gen > task->dst_rebuild_gen)
+			continue;
+
 		inserted_pos = &task->dst_list;
 		break;
 	}
@@ -1632,9 +1721,6 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen
 
 	/* Print out the current queue to the debug log */
 	rebuild_debug_print_queue();
-
-	D_DEBUG(DB_REBUILD, "rebuild queue "DF_UUID" ver=%u, gen=%u, op=%s",
-		DP_UUID(pool->sp_uuid), map_ver, rebuild_gen, RB_OP_STR(rebuild_op));
 
 	if (!rebuild_gst.rg_rebuild_running) {
 		rc = ABT_cond_create(&rebuild_gst.rg_stop_cond);
@@ -1676,10 +1762,10 @@ regenerate_task_internal(struct ds_pool *pool, struct pool_target *tgts,
 
 		if (rebuild_op == RB_OP_FAIL || rebuild_op == RB_OP_DRAIN)
 			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_fseq, 0,
-						 &id_list, rebuild_op, 0);
+						 0, &id_list, rebuild_op, 0);
 		else
 			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_in_ver, 0,
-						 &id_list, rebuild_op, 0);
+						 0, &id_list, rebuild_op, 0);
 
 		if (rc) {
 			D_ERROR(DF_UUID" schedule op %d ver %d failed: "
@@ -1755,8 +1841,8 @@ rebuild_fini_one(void *arg)
 	struct rebuild_pool_tls		*pool_tls;
 	struct ds_pool_child		*dpc;
 
-	pool_tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid,
-					   rpt->rt_rebuild_ver);
+	pool_tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+					   rpt->rt_rebuild_gen);
 	if (pool_tls == NULL)
 		return 0;
 
@@ -1819,8 +1905,8 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	ABT_mutex_unlock(rpt->rt_lock);
 
 	/* destroy the rebuild pool tls on XS 0 */
-	pool_tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid,
-					   rpt->rt_rebuild_ver);
+	pool_tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
+					   rpt->rt_rebuild_gen);
 	if (pool_tls != NULL)
 		rebuild_pool_tls_destroy(pool_tls);
 
@@ -1927,7 +2013,7 @@ rebuild_tgt_status_check_ult(void *arg)
 		if (!rpt->rt_global_done) {
 			struct ds_iv_ns *ns = rpt->rt_pool->sp_iv_ns;
 
-			iv.riv_master_rank = ns->iv_master_rank;
+			iv.riv_master_rank = rpt->rt_leader_rank;
 			iv.riv_rank = rpt->rt_rank;
 			iv.riv_ver = rpt->rt_rebuild_ver;
 			iv.riv_rebuild_gen = rpt->rt_rebuild_gen;
@@ -2010,8 +2096,8 @@ rebuild_prepare_one(void *data)
 	int				 rc = 0;
 
 	pool_tls = rebuild_pool_tls_create(rpt->rt_pool_uuid, rpt->rt_poh_uuid,
-					   rpt->rt_coh_uuid,
-					   rpt->rt_rebuild_ver);
+					   rpt->rt_coh_uuid, rpt->rt_rebuild_ver,
+					   rpt->rt_rebuild_gen);
 	if (pool_tls == NULL)
 		return -DER_NOMEM;
 
@@ -2026,7 +2112,7 @@ rebuild_prepare_one(void *data)
 	D_ASSERT(rpt->rt_rebuild_fence != 0);
 	dpc->spc_rebuild_fence = rpt->rt_rebuild_fence;
 	D_DEBUG(DB_REBUILD, "open local container "DF_UUID"/"DF_UUID
-		" rebuild eph "DF_U64" "DF_RC"\n", DP_UUID(rpt->rt_pool_uuid),
+		" rebuild eph "DF_X64" "DF_RC"\n", DP_UUID(rpt->rt_pool_uuid),
 		DP_UUID(rpt->rt_coh_uuid), rpt->rt_rebuild_fence, DP_RC(rc));
 
 	ds_pool_child_put(dpc);
@@ -2035,8 +2121,8 @@ rebuild_prepare_one(void *data)
 }
 
 static int
-rpt_create(struct ds_pool *pool, uint32_t pm_ver, uint64_t leader_term,
-	   uint32_t rebuild_gen, uint32_t tgts_num,
+rpt_create(struct ds_pool *pool, uint32_t master_rank, uint32_t pm_ver,
+	   uint64_t leader_term, uint32_t rebuild_gen, uint32_t tgts_num,
 	   struct rebuild_tgt_pool_tracker **p_rpt)
 {
 	struct rebuild_tgt_pool_tracker	*rpt;
@@ -2071,6 +2157,7 @@ rpt_create(struct ds_pool *pool, uint32_t pm_ver, uint64_t leader_term,
 	rpt->rt_tgts_num = tgts_num;
 	crt_group_rank(pool->sp_group, &rank);
 	rpt->rt_rank = rank;
+	rpt->rt_leader_rank = master_rank;
 
 	rpt->rt_refcount = 1;
 	*p_rpt = rpt;
@@ -2127,8 +2214,9 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 		D_GOTO(out, rc);
 
 	/* Create rpt for the target */
-	rc = rpt_create(pool, rsi->rsi_rebuild_ver, rsi->rsi_leader_term,
-			rsi->rsi_rebuild_gen, rsi->rsi_tgts_num, &rpt);
+	rc = rpt_create(pool, rsi->rsi_master_rank, rsi->rsi_rebuild_ver,
+			rsi->rsi_leader_term, rsi->rsi_rebuild_gen,
+			rsi->rsi_tgts_num, &rpt);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -2156,8 +2244,8 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 		D_GOTO(out, rc);
 
 	pool_tls = rebuild_pool_tls_create(rpt->rt_pool_uuid, rpt->rt_poh_uuid,
-					   rpt->rt_coh_uuid,
-					   rpt->rt_rebuild_ver);
+					   rpt->rt_coh_uuid, rpt->rt_rebuild_ver,
+					   rpt->rt_rebuild_gen);
 	if (pool_tls == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -408,13 +408,6 @@ check_object:
 		goto failed;
 	}
 
-	if (obj->obj_discard && intent == DAOS_INTENT_UPDATE) {
-		/** Cleanup before assert so unit test that triggers doesn't corrupt the state */
-		vos_obj_release(occ, obj, false);
-		rc = -DER_UPDATE_AGAIN;
-		goto failed;
-	}
-
 	if ((flags & VOS_OBJ_DISCARD) || intent == DAOS_INTENT_KILL || intent == DAOS_INTENT_PUNCH)
 		goto out;
 


### PR DESCRIPTION
1. add dst max version to rebuild task, any further pool
map update after max version will be ignored during reintegration.

2. Do not need broadcast the ranks which is being queued to
be reintegrated after the current reintegration start.

3. add rebuild_generation to rpt and tls lookup.

4. add more debug message or infomation to the rebuild process.

5. various minor fixes for master changing during rebuild.

6. reclaim the object if rebuild fails

Signed-off-by: Di Wang <di.wang@intel.com>