### PR TITLE
DAOS-11073 control: Don't remove pool label during destroy

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -183,7 +183,8 @@ func (r *poolRequest) getDeadline() time.Time {
 	if !r.deadline.IsZero() {
 		return r.deadline
 	}
-	return time.Now().Add(DefaultPoolTimeout)
+	r.SetTimeout(DefaultPoolTimeout)
+	return r.deadline
 }
 
 func (r *poolRequest) canRetry(reqErr error, try uint) bool {

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -501,16 +501,16 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 	}
 	svc.log.Debugf("MgmtSvc.PoolDestroy dispatch, req:%+v\n", req)
 
-	uuid, err := svc.resolvePoolID(req.Id)
+	poolUUID, err := svc.resolvePoolID(req.Id)
 	if err != nil {
 		return nil, err
 	}
 
-	ps, err := svc.sysdb.FindPoolServiceByUUID(uuid)
+	ps, err := svc.sysdb.FindPoolServiceByUUID(poolUUID)
 	if err != nil {
 		return nil, err
 	}
-	req.SetUUID(uuid)
+	req.SetUUID(poolUUID)
 
 	resp := &mgmtpb.PoolDestroyResp{}
 	inCleanupMode := false
@@ -539,19 +539,13 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 		ds := daos.Status(evresp.Status)
 		svc.log.Debugf("MgmtSvc.PoolDestroy drpc.MethodPoolEvict, evresp:%+v\n", evresp)
 
-		// If the destroy request is being forced, we should additionally zap the label
-		// so the entry doesn't prevent a new pool with the same label from being created.
-		if req.Force {
-			ps.PoolLabel = ""
-		}
-
 		// If the request is being forced, or the evict request did not fail
 		// due to the pool being busy, then transition to the destroying state
 		// and persist the update(s).
 		if req.Force || ds != daos.Busy {
 			ps.State = system.PoolServiceStateDestroying
 			if err := svc.sysdb.UpdatePoolService(ps); err != nil {
-				return nil, errors.Wrapf(err, "failed to update pool %s", uuid)
+				return nil, errors.Wrapf(err, "failed to update pool %s", poolUUID)
 			}
 		}
 
@@ -588,13 +582,13 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 			// Otherwise, we've done all we can to try to recover.
 			resp.Status = int32(daos.Success)
 		}
-		if err := svc.sysdb.RemovePoolService(uuid); err != nil {
+		if err := svc.sysdb.RemovePoolService(poolUUID); err != nil {
 			// In rare cases, there may be a race between pool cleanup handlers.
 			// As we know the service entry existed when we started this handler,
 			// if the attempt to remove it now fails because it doesn't exist,
 			// then there's nothing else to do.
 			if !system.IsPoolNotFound(err) {
-				return nil, errors.Wrapf(err, "failed to remove pool %s", uuid)
+				return nil, errors.Wrapf(err, "failed to remove pool %s", poolUUID)
 			}
 		}
 	default:

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -586,12 +586,6 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			CreationRankStr: system.MustCreateRankSet("0-7").String(),
 		},
 	}
-	svcWithLabel := func(in *system.PoolService, label string) (out *system.PoolService) {
-		out = new(system.PoolService)
-		*out = *in
-		out.PoolLabel = label
-		return
-	}
 	svcWithState := func(in *system.PoolService, state system.PoolServiceState) (out *system.PoolService) {
 		out = new(system.PoolService)
 		*out = *in
@@ -703,7 +697,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			expResp: &mgmtpb.PoolDestroyResp{
 				Status: int32(daos.MiscError),
 			},
-			expSvc: svcWithLabel(svcWithState(testPoolService, system.PoolServiceStateDestroying), ""),
+			expSvc: svcWithState(testPoolService, system.PoolServiceStateDestroying),
 		},
 		"already destroying, destroy dRPC fails due to engine error": {
 			req: &mgmtpb.PoolDestroyReq{Id: mockUUID},


### PR DESCRIPTION
As part of the work done for DAOS-8237, the pool destroy RPC
handler removed the pool service label if the request was
forced. This seemed like a usability enhancement, in that
a forced destroy would always succeed from the perspective
of the admin, particularly in the case of wanting to reuse
the label. In cases where the pool was left in a destroying
state, the idea was that it would eventually be cleaned up
as part of pool creation or leadership step-up.

In hindsight, that change was probably a bad idea in that it
hides problems with the pool destroy flow at the engine level
and could lead to resource leaks. Better to leave the label
intact on the pool service so that it's clear to the admin
that the pool isn't really destroyed yet. The next challenge
is in figuring out how to convey to the admin why the pool
can't be destroyed, even if the force flag has been set.

Features: pool

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>

Required-githooks: true
