### PR TITLE
DAOS-9820 test: make large datamover tests more configurable (#8662)

### DIFF
--- a/src/tests/ftest/datamover/large_dir.py
+++ b/src/tests/ftest/datamover/large_dir.py
@@ -37,9 +37,9 @@ class DmvrLargeDir(DataMoverTestBase):
         self.set_tool(tool)
 
         # Get the number of mdtest processes
-        self.mdtest_processes = self.params.get(
-            self.tool.lower(), "/run/mdtest/client_processes/*")
-        if not self.mdtest_processes:
+        self.mdtest_np = self.params.get(self.tool.lower(), "/run/mdtest/client_processes/*")
+        self.mdtest_ppn = self.params.get(self.tool.lower(), "/run/mdtest/client_ppn/*")
+        if self.mdtest_np is None and self.mdtest_ppn is None:
             self.fail("Failed to get mdtest processes for {}".format(tool))
 
         # test params
@@ -65,7 +65,7 @@ class DmvrLargeDir(DataMoverTestBase):
             "DAOS", "/", pool, cont1,
             "DAOS", "/", pool, cont2)
 
-        posix_path = self.new_posix_test_path(parent=self.workdir)
+        posix_path = self.new_posix_test_path()
 
         # copy from daos cont2 to posix file system
         self.run_datamover(
@@ -97,7 +97,7 @@ class DmvrLargeDir(DataMoverTestBase):
             Copy a very large directory between daos POSIX containers and
             an external POSIX file system using dcp.
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large
+        :avocado: tags=hw,medium,ib2
         :avocado: tags=datamover,mfu,mfu_dcp,dfs,mdtest
         :avocado: tags=dm_large_dir,dm_large_dir_dcp
         """

--- a/src/tests/ftest/datamover/large_dir.yaml
+++ b/src/tests/ftest/datamover/large_dir.yaml
@@ -3,52 +3,66 @@ hosts:
     - server-A
     - server-B
     - server-C
-    - server-D
-    - server-E
-    - server-F
-    - server-G
   test_clients:
-    - client-F
+    - client-A
 timeout: 420
 server_config:
+  engines_per_host: 2
   name: daos_server
   servers:
-    log_mask: ERR
-    bdev_class: nvme
-    bdev_list: ["0000:81:00.0"]
-    scm_class: dcpm
-    scm_list: ["/dev/pmem0"]
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      log_mask: ERR
+      bdev_class: nvme
+      bdev_list: ["aaaa:aa:aa.a"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      log_mask: ERR
+      bdev_class: nvme
+      bdev_list: ["bbbb:bb:bb.b"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
 pool:
   mode: 146
   name: daos_server
-  scm_size: 95%
-  nvme_size: 90%
+  size: 95%
   svcn: 1
   control_method: dmg
 container:
   type: POSIX
   control_method: daos
 mdtest:
-  client_processes:
-    dcp: 30
+  client_ppn:
+    dcp: 32
   api: DFS
   test_dir: "/"
   dfs_destroy: False
   manager: "MPICH"
-  mux_dataset: !mux
-    many_files:                # total 15K files for dcp
-      num_of_files_dirs: 500
-      mdtest_flags:
-        - "-F -C"
-        - "-F -E"
-    many_files_and_dirs:       # total 15K files and 15K dirs for dcp
-      num_of_files_dirs: 500
-      mdtest_flags:
-        - "-C"
-        - "-E"
-      depth: 4
-      branching_factor: 4
+  dfs_oclass: EC_4P2G1
+  dfs_dir_oclass: RP_3GX
+  num_of_files_dirs: 500 # total 16K files and 16K dirs for dcp
+  mdtest_flags:
+    - "-C"
+    - "-E"
+  depth: 4
+  branching_factor: 4
   bytes: 4096
 dcp:
+  bufsize: 4M
+  chunksize: 128M
   client_processes:
-    np: 16
+    ppn: 32
+datamover:
+  posix_root: "self.workdir"

--- a/src/tests/ftest/datamover/large_file.py
+++ b/src/tests/ftest/datamover/large_file.py
@@ -36,8 +36,9 @@ class DmvrPosixLargeFile(DataMoverTestBase):
         self.set_tool(tool)
 
         # Get the number of ior processes
-        self.ior_processes = self.params.get(self.tool.lower(), "/run/ior/client_processes/*")
-        if not self.ior_processes:
+        self.ior_np = self.params.get(self.tool.lower(), "/run/ior/client_processes/*")
+        self.ior_ppn = self.params.get(self.tool.lower(), "/run/ior/client_ppn/*")
+        if self.ior_np is None and self.ior_ppn is None:
             self.fail("Failed to get ior processes for {}".format(self.tool))
 
         # create pool and cont
@@ -56,7 +57,7 @@ class DmvrPosixLargeFile(DataMoverTestBase):
             "DAOS", "/", pool, cont1,
             "DAOS", "/", pool, cont2)
 
-        posix_path = self.new_posix_test_path(parent=self.workdir)
+        posix_path = self.new_posix_test_path()
 
         # copy from daos cont2 to posix file system
         self.run_datamover(
@@ -87,7 +88,7 @@ class DmvrPosixLargeFile(DataMoverTestBase):
             Copy a very large file between daos POSIX containers and
             an external POSIX file system using dcp.
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large
+        :avocado: tags=hw,medium,ib2
         :avocado: tags=datamover,mfu,mfu_dcp,dfs,ior
         :avocado: tags=dm_large_file,dm_large_file_dcp
         """
@@ -99,7 +100,7 @@ class DmvrPosixLargeFile(DataMoverTestBase):
             Copy a very large file between daos POSIX containers and
             an external POSIX file system using daos filesystem copy.
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large
+        :avocado: tags=hw,medium,ib2
         :avocado: tags=datamover,daos_fs_copy,dfs,ior
         :avocado: tags=dm_large_file,dm_large_file_fs_copy
         """

--- a/src/tests/ftest/datamover/large_file.yaml
+++ b/src/tests/ftest/datamover/large_file.yaml
@@ -3,33 +3,48 @@ hosts:
     - server-A
     - server-B
     - server-C
-    - server-D
-    - server-E
-    - server-F
-    - server-G
   test_clients:
-    - client-F
+    - client-A
 timeout: 420
 server_config:
+  engines_per_host: 2
   name: daos_server
   servers:
-    log_mask: ERR
-    bdev_class: nvme
-    bdev_list: ["0000:81:00.0"]
-    scm_class: dcpm
-    scm_list: ["/dev/pmem0"]
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31317
+      log_file: daos_server0.log
+      log_mask: ERR
+      bdev_class: nvme
+      bdev_list: ["aaaa:aa:aa.a"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      log_mask: ERR
+      bdev_class: nvme
+      bdev_list: ["bbbb:bb:bb.b"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
 pool:
   mode: 146
   name: daos_server
-  scm_size: 95%
-  nvme_size: 90%
+  size: 95%
   svcn: 1
   control_method: dmg
 container:
   type: POSIX
   control_method: daos
 ior:
-  client_processes:
+  client_ppn:
     dcp: 20
     fs_copy: 10
   api: DFS
@@ -37,11 +52,13 @@ ior:
   dfs_destroy: False
   test_file: /testFile
   signature: 5
-  transfer_size: '1M'
+  transfer_size: 4M
   block_size: '1G'        # aggregate of 20G for dcp and 10G for fs_copy
-  dfs_oclass: "EC_4P1GX"
+  dfs_oclass: EC_4P2GX
 dcp:
-  bufsize: "64MB"
-  chunksize: "128MB"
+  bufsize: 4M
+  chunksize: 128M
   client_processes:
-    np: 16
+    ppn: 32
+datamover:
+  posix_root: "self.workdir"

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -46,6 +46,15 @@ class BasicParameter():
         """
         return str(self.value) if self.value is not None else ""
 
+    def __repr__(self):
+        """Convert this BasicParameter into a string representation.
+
+        Returns:
+            str: raw string representation of the parameter's value
+
+        """
+        return str(self._value) if self._value is not None else ""
+
     @property
     def value(self):
         """Get the value of this setting.
@@ -243,6 +252,39 @@ class LogParameter(FormattedParameter):
         super().update(value, name, append)
         self._add_directory()
         self.log.debug("  Added the directory: %s => %s", name, self.value)
+
+
+class MappedParameter(BasicParameter):
+    """A class for parameters whose values are read from a yaml file."""
+
+    def __init__(self, value, default=None, yaml_key=None, mapping=None):
+        """Create a MappedParameter object.
+
+        In addition to BasicParameter usage, a mapping can be supplied to replace
+        values from the yaml. This is useful, for example, when the value is a python reference.
+
+        Args:
+            value (object): initial value for the parameter
+            default (object, optional): default value. Defaults to None.
+            yaml_key (str, optional): the yaml key name to use when finding the
+                value to assign from the test yaml file. Default is None which
+                will use the object's variable name as the yaml key.
+            mapping (dict, optional): dict of values to replace. Default is None,
+                which replaces nothing.
+        """
+        super().__init__(value, default, yaml_key)
+        self._mapping = mapping or {}
+
+    @BasicParameter.value.getter
+    def value(self):
+        # pylint: disable=invalid-overridden-method
+        """Get the value of this parameter.
+
+        Returns:
+            object: mapped value currently assigned to the parameter
+
+        """
+        return self._mapping.get(self._value, super().value)
 
 
 class ObjectWithParameters():

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -20,6 +20,7 @@ import uuid
 import re
 import ctypes
 from general_utils import create_string_buffer
+from command_utils_base import MappedParameter
 
 
 class DataMoverTestBase(IorTestBase, MdtestBase):
@@ -28,7 +29,9 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
 
     Optional yaml config values:
         datamover/posix_root (str): path to POSIX filesystem.
-        datamover/tool (list): list of env vars to set for IOR/MDTest.
+        datamover/tool (list): default datamover tool to use.
+        datamover/np (int): default processes for all tools.
+        datamover/ppn (int): default processes-per-client for all tools.
 
     Sample Use Case:
         # Create test file
@@ -40,8 +43,8 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         # Copy from DAOS to POSIX
         run_datamover(
             "some test description",
-            "DAOS", "/testFile", pool1, cont1,
-            "POSIX", "/some/posix/path/testFile")
+            src_path="daos://pool1/cont1/testFile",
+            dst_path="/some/posix/path/testFile")
 
         # Verify destination file
         run_ior_with_params("POSIX", "/some/posix/path/testFile", flags="-r -R")
@@ -73,19 +76,29 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         self.ddeserialize_cmd = None
         self.fs_copy_cmd = None
         self.cont_clone_cmd = None
-        self.ior_processes = None
-        self.mdtest_processes = None
-        self.dcp_processes = None
-        self.dsync_processes = None
-        self.dserialize_processes = None
-        self.ddeserialize_processes = None
         self.pool = []
         self.container = []
         self.uuids = []
         self.dfuse_hosts = None
         self.num_run_datamover = 0  # Number of times run_datamover was called
         self.job_manager = None
-        self.posix_root = None
+
+        # Override processes and np from IorTestBase and MdtestBase to use "datamover" namespace.
+        # Define processes and np for each datamover tool, which defaults to the "datamover" one.
+        self.processes = None
+        self.ppn = None
+        self.ior_np = None
+        self.ior_ppn = None
+        self.mdtest_np = None
+        self.mdtest_ppn = None
+        self.dcp_np = None
+        self.dsync_np = None
+        self.dserialize_np = None
+        self.ddeserialize_np = None
+
+        # Root directory for POSIX paths
+        posix_root_map = {'self.workdir': self.workdir, 'self.tmp': self.tmp}
+        self.posix_root = MappedParameter(None, mapping=posix_root_map) # default will be self.tmp
 
         # Temp directory for serialize/deserialize
         self.serial_tmp_dir = self.tmp
@@ -114,23 +127,24 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         # initialize daos_cmd
         self.daos_cmd = self.get_daos_command()
 
-        # Get the processes for each explicitly
-        # This is needed because both IorTestBase and MdtestBase
-        # define self.processes
-        self.ior_processes = self.params.get(
-            "np", '/run/ior/client_processes/*')
-        self.mdtest_processes = self.params.get(
-            "np", '/run/mdtest/client_processes/*')
-        self.dcp_processes = self.params.get(
-            "np", "/run/dcp/client_processes/*", 1)
-        self.dsync_processes = self.params.get(
-            "np", "/run/dsync/client_processes/*", 1)
-        self.dserialize_processes = self.params.get(
-            "np", "/run/dserialize/client_processes/*", 1)
-        self.ddeserialize_processes = self.params.get(
-            "np", "/run/ddeserialize/client_processes/*", 1)
+        # Get the processes and np for all datamover tools, as well as for individual tools.
+        self.processes = self.params.get("np", '/run/datamover/*', 1)
+        self.ppn = self.params.get("ppn", '/run/datamover/*', 1)
+        self.ior_np = self.params.get("np", '/run/ior/client_processes/*', 1)
+        self.ior_ppn = self.params.get("ppn", '/run/ior/client_processes/*', None)
+        self.mdtest_np = self.params.get("np", '/run/mdtest/client_processes/*', 1)
+        self.mdtest_ppn = self.params.get("ppn", '/run/mdtest/client_processes/*', None)
+        self.dcp_np = self.params.get("np", "/run/dcp/*", self.processes)
+        self.dcp_ppn = self.params.get("ppn", "/run/dcp/*", self.ppn)
+        self.dsync_np = self.params.get("np", "/run/dsync/*", self.processes)
+        self.dsync_ppn = self.params.get("ppn", "/run/dsync/*", self.ppn)
+        self.dserialize_np = self.params.get("np", "/run/dserialize/*", self.processes)
+        self.dserialize_ppn = self.params.get("ppn", "/run/dserialize/*", self.ppn)
+        self.ddeserialize_np = self.params.get("np", "/run/ddeserialize/*", self.processes)
+        self.ddeserialize_ppn = self.params.get("ppn", "/run/ddeserialize/*", self.ppn)
 
-        self.posix_root = self.params.get("posix_root", "/run/datamover/*", self.tmp)
+        self.posix_root.update_default(self.tmp)
+        self.posix_root.get_yaml_value("posix_root", self, "/run/datamover/*")
 
         tool = self.params.get("tool", "/run/datamover/*")
         if tool:
@@ -254,9 +268,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         method = self.get_test_info()["method"]
         dir_name = "{}{}".format(method, len(self.posix_local_test_paths))
 
-        if parent is None:
-            parent = self.posix_root
-        path = join(parent, dir_name)
+        path = join(parent or self.posix_root.value, dir_name)
 
         # Add to the list of posix paths
         if shared:
@@ -864,10 +876,11 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                 Defaults to False.
 
         """
+        self.ppn = self.ior_ppn
+        self.processes = self.ior_np
         self.set_ior_params(param_type, path, pool, cont, path_suffix, flags, display)
-        self.run_ior(self.get_ior_job_manager_command(), self.ior_processes,
-                     display_space=(display_space and bool(pool)),
-                     pool=pool)
+        self.run_ior(self.get_ior_job_manager_command(), self.processes, pool=pool,
+                     display_space=(display_space and bool(pool)))
 
     def set_mdtest_params(self, param_type, path, pool=None, cont=None, flags=None, display=True):
         """Set the mdtest params.
@@ -923,9 +936,10 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             display (bool, optional): print updated params. Defaults to True.
 
         """
+        self.ppn = self.mdtest_ppn
+        self.processes = self.mdtest_np
         self.set_mdtest_params(param_type, path, pool, cont, flags, display)
-        self.run_mdtest(self.get_mdtest_job_manager_command(self.manager),
-                        self.mdtest_processes,
+        self.run_mdtest(self.get_mdtest_job_manager_command(self.manager), self.processes,
                         display_space=(bool(pool)), pool=pool)
 
     def run_diff(self, src, dst, deref=False):
@@ -968,7 +982,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             expected_output (list, optional): substrings expected in stdout
             expected_err (list, optional): substrings expected in stderr
             processes (int, optional): number of mpi processes.
-                defaults to self.dcp_processes
+                Defaults to np for corresponding tool.
 
         Returns:
             The result "run" object
@@ -1001,27 +1015,33 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         if test_desc is not None:
             self.log.info("Running %s: %s", self.tool, test_desc)
 
+        ppn = None
         try:
             if self.tool == "DCP":
                 if not processes:
-                    processes = self.dcp_processes
+                    processes = self.dcp_np
+                    ppn = self.dcp_ppn
                 # If we expect an rc other than 0, don't fail
                 self.dcp_cmd.exit_status_exception = (expected_rc == 0)
-                result = self.dcp_cmd.run(processes, self.job_manager)
+                result = self.dcp_cmd.run(processes, self.job_manager, ppn)
             elif self.tool == "DSYNC":
                 if not processes:
-                    processes = self.dsync_processes
+                    processes = self.dsync_np
+                    ppn = self.dsync_ppn
                 # If we expect an rc other than 0, don't fail
                 self.dsync_cmd.exit_status_exception = (expected_rc == 0)
-                result = self.dsync_cmd.run(processes, self.job_manager)
+                result = self.dsync_cmd.run(processes, self.job_manager, ppn)
             elif self.tool == "DSERIAL":
                 if processes:
                     processes1 = processes2 = processes
+                    ppn1 = ppn2 = None
                 else:
-                    processes1 = self.dserialize_processes
-                    processes2 = self.ddeserialize_processes
-                result = self.dserialize_cmd.run(processes1, self.job_manager)
-                result = self.ddeserialize_cmd.run(processes2, self.job_manager)
+                    processes1 = self.dserialize_np
+                    ppn1 = self.dserialize_ppn
+                    processes2 = self.ddeserialize_np
+                    ppn2 = self.ddeserialize_ppn
+                result = self.dserialize_cmd.run(processes1, self.job_manager, ppn1)
+                result = self.ddeserialize_cmd.run(processes2, self.job_manager, ppn2)
             elif self.tool == "FS_COPY":
                 result = self.fs_copy_cmd.run()
             elif self.tool == "CONT_CLONE":

--- a/src/tests/ftest/util/data_mover_utils.py
+++ b/src/tests/ftest/util/data_mover_utils.py
@@ -82,17 +82,17 @@ class MfuCommandBase(ExecutableCommand):
         param_names.sort(key=self.__param_sort)
         return param_names
 
-    def run(self, processes, job_manager):
+    def run(self, processes, job_manager, ppn=None):
         # pylint: disable=arguments-differ
         """Run the MpiFileUtils command.
 
         Args:
-            processes: Number of processes for the command.
-            job_manager: Job manager variable to set/assign
+            processes (int): Number of processes for the command.
+            job_manager (JobManager): Job manager variable to set/assign
+            ppn (int, optional): client processes per node for the command.
 
         Returns:
-            CmdResult: Object that contains exit status, stdout, and other
-                information.
+            CmdResult: Object that contains exit status, stdout, and other information.
 
         Raises:
             CommandFailure: In case run command fails.
@@ -103,7 +103,11 @@ class MfuCommandBase(ExecutableCommand):
         # Get job manager cmd
         job_manager = Mpirun(self, mpi_type="mpich")
         job_manager.assign_hosts(self.hosts, self.tmp)
-        job_manager.assign_processes(processes)
+        if ppn is None:
+            job_manager.assign_processes(processes)
+        else:
+            job_manager.ppn.update(ppn, 'mpirun.ppn')
+            job_manager.processes.update(None, 'mpirun.np')
         job_manager.exit_status_exception = self.exit_status_exception
 
         # Run the command


### PR DESCRIPTION
Test-tag: datamover,-iosysadmin,-dm_posix_meta_entry
Skip-unit-tests: true
Skip-fault-injection-test: true

- Add `KeywordParameter` class that accepts a mapping of replaced values
- `data_mover_test_base`
  - Support ppn for various datamover utils
  - Use `KeywordParameter` for `posix_root`
- `large_dir` and `large_file`
  - Specify ppn instead of np
  - Dual-engine and move to HW Medium
  - Specify posix_root in the yaml
- `large_dir`
  - Remove duplicate variants in favor of the larger
  - Use EC object class by default, similar to `large_file`

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>