### PR TITLE
DAOS-10843 test: move ior_intercept_multi_client to HW Large (#9378)

### DIFF
--- a/src/tests/ftest/ior/intercept_multi_client.py
+++ b/src/tests/ftest/ior/intercept_multi_client.py
@@ -28,8 +28,8 @@ class IorInterceptMultiClient(IorInterceptTestBase):
             Verify performance with DFUSE + IL is similar to DFS.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,large
         :avocado: tags=daosio,dfuse,il,ior,ior_intercept
-        :avocado: tags=ior_intercept_multi_client
+        :avocado: tags=ior_intercept_multi_client,test_ior_intercept_multi_client
         """
         self.run_il_perf_check()

--- a/src/tests/ftest/ior/intercept_multi_client.yaml
+++ b/src/tests/ftest/ior/intercept_multi_client.yaml
@@ -1,10 +1,14 @@
 hosts:
     test_servers:
         - server-A
+        - server-B
     test_clients:
         - client-A
         - client-B
         - client-C
+        - client-D
+        - client-E
+        - client-F
 timeout: 1000
 server_config:
   engines_per_host: 2

--- a/src/tests/ftest/util/ior_intercept_test_base.py
+++ b/src/tests/ftest/util/ior_intercept_test_base.py
@@ -55,13 +55,16 @@ class IorInterceptTestBase(IorTestBase):
         # Verify write and read performance are within the thresholds.
         # Since Min can have a lot of variance, don't check Min or Mean.
         # Ideally, we might want to look at the Std Dev to ensure the results are admissible.
+        # Log the provider for debugging.
+        server_provider = self.server_managers[0].get_config_value("provider")
+        self.log.info("Provider:           %s", server_provider)
+
         dfs_max_write = float(dfs_perf[0][IorMetrics.Max_MiB])
         dfuse_max_write = float(dfuse_perf[0][IorMetrics.Max_MiB])
         actual_write_x = percent_change(dfs_max_write, dfuse_max_write)
         self.log.info("DFS Max Write:      %.2f", dfs_max_write)
         self.log.info("DFUSE IL Max Write: %.2f", dfuse_max_write)
         self.log.info("Percent Diff:       %.2f%%", actual_write_x * 100)
-        self.assertLessEqual(abs(actual_write_x), write_x, "Max Write Diff too large")
 
         dfs_max_read = float(dfs_perf[1][IorMetrics.Max_MiB])
         dfuse_max_read = float(dfuse_perf[1][IorMetrics.Max_MiB])
@@ -69,4 +72,6 @@ class IorInterceptTestBase(IorTestBase):
         self.log.info("DFS Max Read:      %.2f", dfs_max_read)
         self.log.info("DFUSE IL Max Read: %.2f", dfuse_max_read)
         self.log.info("Percent Diff:      %.2f%%", actual_read_x * 100)
+
+        self.assertLessEqual(abs(actual_write_x), write_x, "Max Write Diff too large")
         self.assertLessEqual(abs(actual_read_x), read_x, "Max Read Diff too large")


### PR DESCRIPTION
Test-tag: ior_intercept_multi_client
Skip-unit-tests: true
Skip-fault-injection-test: true

- Move ior_intercept_multi_client to HW Large
  - Some Medium clusters use TCP, which is unstable
  - Large clusters all have MLX / Verbs
  - Improve logging

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>