### PR TITLE
DAOS-6530 test: remove feature tags from dfuse_find_perf (#9715)

### DIFF
--- a/src/tests/ftest/dfuse/find.py
+++ b/src/tests/ftest/dfuse/find.py
@@ -16,14 +16,14 @@ from exception_utils import CommandFailure
 from io_utilities import DirTree
 
 
-class Cmd(DfuseTestBase):
+class DfuseFind(DfuseTestBase):
     # pylint: disable=too-few-public-methods,too-many-ancestors
-    """Base FindCmd test class.
+    """Base DfuseFind test class.
 
     :avocado: recursive
     """
 
-    def test_find(self):
+    def test_dfuse_find(self):
         """Jira ID: DAOS-5563.
 
         Test Description:
@@ -36,13 +36,13 @@ class Cmd(DfuseTestBase):
             files found is not equal to the number of files created.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,medium
         :avocado: tags=daosio,dfuse
-        :avocado: tags=findcmd
+        :avocado: tags=dfuse_find,test_dfuse_find
         """
         self._test_findcmd()
 
-    def test_find_perf(self):
+    def test_dfuse_find_perf(self):
         """Jira ID: DAOS-5563.
 
         Test Description:
@@ -54,9 +54,8 @@ class Cmd(DfuseTestBase):
             challenger performance.
 
         :avocado: tags=all,manual
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=daosio,dfuse
-        :avocado: tags=findcmd_perf
+        :avocado: tags=hw,medium
+        :avocado: tags=dfuse_find,test_dfuse_find_perf
         """
         # Number of repetitions each test will run.
         samples = self.params.get("samples", '/run/perf/*')
@@ -94,8 +93,8 @@ class Cmd(DfuseTestBase):
         needles = self.params.get("needles", '/run/find_cmd/*')
         temp_dfs_path = ""
 
-        dfuses = list()
-        containers = list()
+        dfuses = []
+        containers = []
 
         self.add_pool(connect=False)
 
@@ -107,30 +106,20 @@ class Cmd(DfuseTestBase):
             challenger_path = self._generate_temp_path_name(
                 challenger_path, "test_")
 
-        def _run_test(test_root, dir_tree_paths):
-
+        def _run_find_test(test_root, dir_tree_paths):
             self._create_dir_forest(
-                dir_tree_paths,
-                height,
-                subdirs_per_node,
-                files_per_node,
-                needles)
+                dir_tree_paths, height, subdirs_per_node, files_per_node, needles)
 
-            test_stats = self._run_test(
-                test_root, samples, cont_count, needles)
-
-            return test_stats
+            return self._run_find_test(test_root, samples, cont_count, needles)
 
         try:
-            mount_dirs = self._setup_containers(
-                dfs_path, cont_count, dfuses, containers)
+            mount_dirs = self._setup_containers(dfs_path, cont_count, dfuses, containers)
 
-            daos_stats = _run_test(dfs_path, mount_dirs)
+            daos_stats = _run_find_test(dfs_path, mount_dirs)
 
             if challenger_path:
-                challenger_dirs = self._setup_challenger(
-                    challenger_path, cont_count)
-                challenger_stats = _run_test(challenger_path, challenger_dirs)
+                challenger_dirs = self._setup_challenger(challenger_path, cont_count)
+                challenger_stats = _run_find_test(challenger_path, challenger_dirs)
 
         except CommandFailure as error:
             self.log.error("FindCmd Test Failed: %s", str(error))
@@ -169,14 +158,12 @@ class Cmd(DfuseTestBase):
         challenger_max_time, _, _ = challenger_stats.get_stat(tag)
 
         if daos_max_time >= challenger_max_time:
-            self.log.error(
-                "Impossible, DAOS is slower running '%s' tag", tag)
+            self.log.error("Impossible, DAOS is slower running '%s' tag", tag)
             self.fail("Test was expected to pass but it failed")
         else:
-            self.log.info(
-                "DAOS is equal or faster running '%s' tag", tag)
+            self.log.info("DAOS is equal or faster running '%s' tag", tag)
 
-    def _run_test(self, test_path, samples, containers, needles):
+    def _run_find_test(self, test_path, samples, containers, needles):
         """
         Perform the actual test, run find(1) to locate the needle files in
         the directory forest. If the number of files located does not match
@@ -188,25 +175,20 @@ class Cmd(DfuseTestBase):
         def _search_needles(file_name, sample_tag, expected_res):
             self.log.info("Searching pattern: %s", file_name)
             self.log.info("Number of expecting results: %d", expected_res)
-            cmd = "find {0} -name {1} | wc -l | grep {2}".format(test_path,
-                                                                  file_name,
-                                                                  expected_res)
-            profiler.run(self._run_cmd,
-                         sample_tag,
-                         cmd)
+            cmd = "find {} -name {} | wc -l | grep {}".format(test_path, file_name, expected_res)
+            profiler.run(self._run_cmd, sample_tag, cmd)
 
         self.log.info("Sampling path: %s", test_path)
 
         for i in range(samples):
-            self.log.info(
-                "Running sample number %d of %d", i + 1, samples)
+            self.log.info("Running sample number %d of %d", i + 1, samples)
 
-            prefix = random.randrange(containers - 1) #nosec
-            suffix = random.randrange(needles - 1) #nosec
+            prefix = random.randrange(containers - 1)  # nosec
+            suffix = random.randrange(needles - 1)  # nosec
             file_name = "t{:05d}_*_{:05d}.needle".format(prefix, suffix)
             _search_needles(file_name, "unique_file", 1)
 
-            number = random.randrange(needles - 1) #nosec
+            number = random.randrange(needles - 1)  # nosec
             file_name = "*_{:05d}.needle".format(number)
             _search_needles(file_name, "same_suffix", containers)
 
@@ -225,23 +207,15 @@ class Cmd(DfuseTestBase):
             cont_dir = "{}_daos_dfuse_{}".format(self.pool.uuid, count)
             mount_dir = os.path.join(dfs_path, cont_dir)
             self.log.info(
-                "Creating container Pool UUID: %s Con UUID: %s",
-                self.pool, self.container)
-            self.start_dfuse(
-                self.hostlist_clients, self.pool, self.container, mount_dir)
+                "Creating container Pool UUID: %s Con UUID: %s", self.pool, self.container)
+            self.start_dfuse(self.hostlist_clients, self.pool, self.container, mount_dir)
             dfuses.append(self.dfuse)
             containers.append(self.container)
             mount_dirs.append(self.dfuse.mount_dir.value)
 
         return mount_dirs
 
-    def _create_dir_forest(
-            self,
-            paths,
-            height,
-            subdirs,
-            files_per_node,
-            needles):
+    def _create_dir_forest(self, paths, height, subdirs, files_per_node, needles):
         """Create a directory tree on each path listed in the paths variable"""
 
         remote_pythonpath = ":".join(sys.path)
@@ -255,7 +229,7 @@ class Cmd(DfuseTestBase):
                 path, height, subdirs, files_per_node, needles, prefix)
             dir_tree_cmd = "PYTHONPATH={} python3 {} {}".format(
                 remote_pythonpath, os.path.abspath(__file__), remote_args)
-            self._run_cmd("{0}".format(dir_tree_cmd))
+            self._run_cmd(dir_tree_cmd)
 
     def _run_cmd(self, cmd):
         ret_code = general_utils.pcmd(self.hostlist_clients, cmd, timeout=180)
@@ -263,8 +237,7 @@ class Cmd(DfuseTestBase):
             error_hosts = NodeSet(
                 ",".join([str(v) for k, v in list(ret_code.items()) if k != 0]))
             raise CommandFailure(
-                "Error running '{}' on the following hosts: {}".format(
-                    cmd, error_hosts))
+                "Error running '{}' on the following hosts: {}".format(cmd, error_hosts))
 
     def _teardown_dfuse(self, dfuses):
         """Unmount all the containers that were created for the test"""
@@ -313,11 +286,7 @@ def _populate_dir_tree():
 
     print("Populating: {0}".format(path))
 
-    dir_tree = DirTree(
-        path,
-        height,
-        subdirs_per_node,
-        files_per_node)
+    dir_tree = DirTree(path, height, subdirs_per_node, files_per_node)
     dir_tree.set_needles_prefix(prefix)
     dir_tree.set_number_of_needles(needles)
     tree_path = dir_tree.create()


### PR DESCRIPTION
Test-tag: dfuse_find,-manual
Skip-unit-tests: true
Skip-fault-injection-test: true

test_dfuse_find_perf is not ready to run in CI, so remove feature tags
so it doesn't fail when accidentally triggered.

Also misc cleanup.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>