### PR TITLE
DAOS-11155 test: Increase pool size for container/multiple_delete.py

### DIFF
--- a/src/tests/ftest/container/multiple_delete.py
+++ b/src/tests/ftest/container/multiple_delete.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -11,8 +10,7 @@ from general_utils import DaosTestError
 class MultipleContainerDelete(IorTestBase):
     # pylint: disable=too-many-ancestors
     """Test class Description:
-       Test that multiple container create/delete reclaims
-       the pool space without leak.
+       Test that multiple container create/delete reclaims the pool space without leak.
 
     :avocado: recursive
     """
@@ -28,7 +26,7 @@ class MultipleContainerDelete(IorTestBase):
             Capture the pool space.
             Create a POSIX container and fill it with IOR DFS Api
             Delete the container and repeat the above steps 50 times.
-            Verify both the SCM and SSD pool spaces are recovered
+            Verify both the SCM and NVMe pool spaces are recovered
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
@@ -47,29 +45,28 @@ class MultipleContainerDelete(IorTestBase):
                 self.server_group, self.pool, self.container.uuid)
             # If the transfer size is less than 4K, the objects are
             # inserted into SCM and anything greater goes to SSD
-            self.run_ior_with_pool()
+            self.run_ior_with_pool(create_cont=False)
             self.container.destroy()
             scm_fs, ssd_fs = self.get_pool_space()
-            out.append("iter = {}, scm = {}, ssd = {}".format(
-                i+1, scm_fs, ssd_fs))
+            out.append("iter = {}, scm = {}, ssd = {}".format(i+1, scm_fs, ssd_fs))
 
         self.log.info("Initial Free Space")
-        self.log.info("SCM = %d, SSD = %d", initial_scm_fs, initial_ssd_fs)
+        self.log.info("SCM = %d, NVMe = %d", initial_scm_fs, initial_ssd_fs)
         self.log.info("Free space after each cont create/del iteration")
         self.log.info("\n".join(out))
         final_scm_fs, final_ssd_fs = self.get_pool_space()
         self.log.info("Final free Space after all iters")
-        self.log.info("SCM = %d, SSD = %d", final_scm_fs, final_ssd_fs)
+        self.log.info("SCM = %d, NVMe = %d", final_scm_fs, final_ssd_fs)
 
-        self.log.info("Verifying SSD space is recovered")
+        self.log.info("Verifying NVMe space is recovered")
         try:
             self.pool.check_free_space(expected_nvme=initial_ssd_fs)
         except DaosTestError as error:
-            self.fail("SSD space is not recovered after 50 "
+            self.fail("NVMe space is not recovered after 50 "
                       "create-write-destroy iterations {}".format(error))
 
         self.log.info("Verifying SCM space is recovered")
-        self.log.info("%d == %d", final_scm_fs, initial_scm_fs)
+        self.log.info("%d (Final) == %d (Initial)", final_scm_fs, initial_scm_fs)
         # Uncomment the below verification once DAOS-8643 is fixed
         # self.assertTrue(final_scm_fs == initial_scm_fs)
 

--- a/src/tests/ftest/container/multiple_delete.yaml
+++ b/src/tests/ftest/container/multiple_delete.yaml
@@ -19,10 +19,8 @@ server_config:
         scm_list: ["/dev/pmem0"]
 
 pool:
-    mode: 146 # 146 is RW
     name: daos_server
-    scm_size: 4000000000
-    nvme_size: 40000000000
+    size: 10%
     control_method: dmg
 
 container:
@@ -33,13 +31,14 @@ ior:
     client_processes:
         np_2:
             np: 2
-    test_dir: "/"
+    test_dir: /
     test_file: /testFile
     repetitions: 1
     dfs_destroy: False
     iorflags:
-        flags: "-v -w -k"
+        flags: -v -w -k
     api: DFS
-    transfer_size: '1M'
-    block_size: '1G'
-    dfs_oclass: "EC_2P2G1"
+    transfer_size: 1M
+    block_size: 1G
+    dfs_oclass: EC_2P2G1
+    dfs_dir_oclass: EC_2P2G1


### PR DESCRIPTION
Pool size was too small; 44GB/rank with 8 targets.
We write 2GB of data with IOR and that could get
out of space, so increse the size to 10%, which
is about 320GB(SCM) + 320GB(NVMe)/rank in this
configuration.

Don't create a new container during IOR run because
we have already created before running it.

Refactor the code.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: multi_container_delete agent_failure_basic
Signed-off-by: Makito Kano <makito.kano@intel.com>