### PR TITLE
DAOS-11165 test: fix pylint in same_key_different_value

### DIFF
--- a/src/tests/ftest/object/same_key_different_value.py
+++ b/src/tests/ftest/object/same_key_different_value.py
@@ -1,15 +1,12 @@
-#!/usr/bin/python3
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 
 
-import traceback
-
 from apricot import TestWithServers
-from pydaos.raw import DaosContainer, DaosApiError
+from pydaos.raw import DaosApiError
 
 
 class SameKeyDifferentValue(TestWithServers):
@@ -20,20 +17,9 @@ class SameKeyDifferentValue(TestWithServers):
     """
     def setUp(self):
         super().setUp()
-        self.prepare_pool()
-
-        try:
-            # create a container
-            self.container = DaosContainer(self.context)
-            self.container.create(self.pool.pool.handle)
-
-            # now open it
-            self.container.open()
-
-        except DaosApiError as excpn:
-            self.log.info(excpn)
-            self.log.info(traceback.format_exc())
-            self.fail("Test failed during setup.\n")
+        self.pool = self.get_pool()
+        self.container = self.get_container(self.pool)
+        self.container.open()
 
     def test_single_to_array_value(self):
         """
@@ -52,8 +38,10 @@ class SameKeyDifferentValue(TestWithServers):
                Trigger aggregation
                Insert same akey,dkey under same object with array value
                Result: should either pass or return -1001 ERR
-        :avocado: tags=all,daily_regression,object,samekeydifferentvalue
-        :avocado: tags=singletoarray,vm,small
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=samekeydifferentvalue,singletoarray,test_single_to_array_value
         """
 
         # define akey,dkey, single value data and array value data
@@ -71,13 +59,12 @@ class SameKeyDifferentValue(TestWithServers):
         for i in range(3):
             try:
                 # create an object and write single value data into it
-                obj = self.container.write_an_obj(single_value_data,
-                                                  len(single_value_data)+1,
-                                                  dkey, akey, obj_cls=1)
+                obj = self.container.container.write_an_obj(
+                    single_value_data, len(single_value_data) + 1, dkey, akey, obj_cls=1)
 
                 # read the data back and make sure its correct
-                read_back_data = self.container.read_an_obj(
-                    len(single_value_data)+1, dkey, akey, obj)
+                read_back_data = self.container.container.read_an_obj(
+                    len(single_value_data) + 1, dkey, akey, obj)
                 if single_value_data != read_back_data.value:
                     self.log.info("wrote data: %s", single_value_data)
                     self.log.info("read data:  %s", read_back_data.value)
@@ -87,47 +74,40 @@ class SameKeyDifferentValue(TestWithServers):
                 if i == 0:
                     try:
                         # write array value data to same keys, expected to fail
-                        self.container.write_an_array_value(array_value_data,
-                                                            dkey, akey, obj,
-                                                            obj_cls=1)
+                        self.container.container.write_an_array_value(
+                            array_value_data, dkey, akey, obj, obj_cls=1)
 
                         # above line is expected to return an error,
                         # if not fail the test
-                        self.fail("Array value write to existing single value"
-                                  + " key should have failed\n")
+                        self.fail(
+                            "Array value write to existing single value key should have failed")
 
                     # should fail with -1001 ERR
-                    except DaosApiError as excp:
-                        if "-1001" not in str(excp):
-                            self.log.info(excp)
-                            self.fail("Should have failed with -1001 error"
-                                      + " message, but it did not\n")
+                    except DaosApiError as error:
+                        if "-1001" not in str(error):
+                            self.log.error(error)
+                            self.fail("Expected write to fail with -1001")
 
                 # test case 2 and 3
-                elif i == 1 or 2:
+                else:
                     try:
                         # punch the keys
                         obj.punch_akeys(0, dkey, [akey])
                         obj.punch_dkeys(0, [dkey])
 
-                        if aggregation is True:
+                        if aggregation:
                             # trigger aggregation
-                            self.container.aggregate(self.container.coh, 0)
+                            self.container.container.aggregate(self.container.container.coh, 0)
 
-                        # write to the same set of keys under same object
-                        # with array value type
-                        self.container.write_an_array_value(array_value_data,
-                                                            dkey, akey, obj,
-                                                            obj_cls=1)
+                        # write to the same set of keys under same object with array value type
+                        self.container.container.write_an_array_value(
+                            array_value_data, dkey, akey, obj, obj_cls=1)
 
-                    # above write of array value should either succeed
-                    # or fail with -1001 ERR
-                    except DaosApiError as excp:
-                        if "-1001" not in str(excp):
-                            self.log.info(excp)
-                            self.fail("Should have failed with -1001 error"
-                                      + " message or the write should have"
-                                      + " been successful, but it did not\n")
+                    # above write of array value should either succeed or fail with -1001 ERR
+                    except DaosApiError as error:
+                        if "-1001" not in str(error):
+                            self.log.error(error)
+                            self.fail("Expected write to either succeed or fail with -1001")
 
                     # change the value of aggregation to test Test Case 3
                     aggregation = True
@@ -137,7 +117,8 @@ class SameKeyDifferentValue(TestWithServers):
 
             # catch the exception if test fails to write to an object
             # or fails to punch the written object
-            except DaosApiError as excp:
+            except DaosApiError as error:
+                self.log.error(error)
                 self.fail("Failed to write to akey/dkey or punch the object")
 
     def test_array_to_single_value(self):
@@ -157,8 +138,10 @@ class SameKeyDifferentValue(TestWithServers):
                Trigger aggregation
                Insert same akey,dkey under same object with single value
                Result: should either pass or return -1001 ERR
-        :avocado: tags=all,daily_regression,object,samekeydifferentvalue
-        :avocado: tags=arraytosingle,vm,small
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=samekeydifferentvalue,arraytosingle,test_array_to_single_value
         """
 
         # define akey,dkey, single value data and array value data
@@ -176,63 +159,58 @@ class SameKeyDifferentValue(TestWithServers):
         for i in range(3):
             try:
                 # create an object and write array value data into it
-                obj = self.container.write_an_array_value(array_value_data,
-                                                          dkey, akey,
-                                                          obj_cls=1)
+                obj = self.container.container.write_an_array_value(
+                    array_value_data, dkey, akey, obj_cls=1)
                 # read the data back and make sure its correct
                 length = len(array_value_data[0])
-                read_back_data = self.container.read_an_array(
+                read_back_data = self.container.container.read_an_array(
                     len(array_value_data), length + 1, dkey, akey, obj)
 
                 for j in range(3):
-                    if (array_value_data[j][0:length-1] !=
-                            read_back_data[j][0:length-1]):
+                    if array_value_data[j][0:length - 1] != read_back_data[j][0:length - 1]:
                         self.log.info("Written Data: %s", array_value_data[j])
                         self.log.info("Read Data:    %s", read_back_data[j])
-                        self.fail("Data mismatch\n")
+                        self.fail("Data mismatch")
                 # test case 1
                 if i == 0:
                     try:
                         # write single value data to same keys, expected to fail
-                        self.container.write_an_obj(single_value_data,
-                                                    len(single_value_data)+1,
-                                                    dkey, akey, obj, obj_cls=1)
+                        self.container.container.write_an_obj(
+                            single_value_data, len(single_value_data) + 1,
+                            dkey, akey, obj, obj_cls=1)
                         # above line is expected to return an error,
                         # if not fail the test
                         self.fail("Single value write to existing array value"
                                   + " key should have failed\n")
 
                     # should fail with -1001 ERR
-                    except DaosApiError as excp:
-                        if "-1001" not in str(excp):
-                            self.log.info(excp)
-                            self.fail("Should have failed with -1001 error"
-                                      + " message, but it did not\n")
+                    except DaosApiError as error:
+                        if "-1001" not in str(error):
+                            self.log.error(error)
+                            self.fail("Expected write to fail with -1001")
 
                 # test case 2 and 3
-                elif i == 1 or 2:
+                else:
                     try:
                         # punch the keys
                         obj.punch_akeys(0, dkey, [akey])
                         obj.punch_dkeys(0, [dkey])
 
-                        if aggregation is True:
+                        if aggregation:
                             # trigger aggregation
-                            self.container.aggregate(self.container.coh, 0)
+                            self.container.container.aggregate(self.container.container.coh, 0)
 
                         # write to the same set of keys under same object
                         # with single value type
-                        self.container.write_an_obj(single_value_data,
-                                                    len(single_value_data)+1,
-                                                    dkey, akey, obj, obj_cls=1)
+                        self.container.container.write_an_obj(
+                            single_value_data, len(single_value_data) + 1,
+                            dkey, akey, obj, obj_cls=1)
                     # above write of array value should either succeed
                     # or fail with -1001 ERR
-                    except DaosApiError as excp:
-                        if "-1001" not in str(excp):
-                            self.log.info(excp)
-                            self.fail("Should have failed with -1001 error"
-                                      + " message or the write should have"
-                                      + " been successful, but it did not\n")
+                    except DaosApiError as error:
+                        if "-1001" not in str(error):
+                            self.log.error(error)
+                            self.fail("Expected write to either succeed or fail with -1001")
 
                     # change the value of aggregation to test Test Case 3
                     aggregation = True
@@ -242,5 +220,6 @@ class SameKeyDifferentValue(TestWithServers):
 
             # catch the exception if test fails to write to an object
             # or fails to punch the written object
-            except DaosApiError as excp:
+            except DaosApiError as error:
+                self.log.error(error)
                 self.fail("Failed to write to akey/dkey or punch the object")

--- a/src/tests/ftest/object/same_key_different_value.yaml
+++ b/src/tests/ftest/object/same_key_different_value.yaml
@@ -9,3 +9,5 @@ pool:
   name: daos_server
   scm_size: 160000000
   control_method: dmg
+container:
+  control_method: daos

--- a/utils/cq/daos_pylint.py
+++ b/utils/cq/daos_pylint.py
@@ -388,6 +388,10 @@ sys.path.append('site_scons')"""
         if scons and msg.symbol != 'consider-using-f-string':
             vals['category'] = 'error'
 
+        # Flag some serious warnings as errors
+        if ftest and msg.symbol in ('condition-evals-to-constant'):
+            vals['category'] = 'error'
+
         types[vals['category']] += 1
         symbols[msg.symbol] += 1
 

--- a/utils/cq/daos_pylint.py
+++ b/utils/cq/daos_pylint.py
@@ -389,7 +389,7 @@ sys.path.append('site_scons')"""
             vals['category'] = 'error'
 
         # Flag some serious warnings as errors
-        if ftest and msg.symbol in ('condition-evals-to-constant'):
+        if msg.symbol in ('condition-evals-to-constant'):
             vals['category'] = 'error'
 
         types[vals['category']] += 1


### PR DESCRIPTION
Test-tag: samekeydifferentvalue
Skip-unit-tests: true
Skip-fault-injection-test: true

- Fix current and future pylint and flake warnings.
- Misc cleanup.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>