### PR TITLE
DAOS-11166 dtx: Fix compiler error

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -518,7 +518,7 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	} else {
 		/* For pool map refresh. */
 		/* Leader: do nothing. */
-		if (ent->ie_dtx_flags & DTE_LEADER && !dra->for_discard)
+		if ((ent->ie_dtx_flags & DTE_LEADER) && dra->resync_version != dra->discard_version)
 			return 0;
 
 		/* Non-leader: handle the DTX with old version. */


### PR DESCRIPTION
Two patches landed that had an unseen build conflict.
#9614 and #9196 

Fix the compilation error

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

Required-githooks: true