### PR TITLE
DAOS-9827 test: datamover: use get_container

### DIFF
--- a/src/tests/ftest/datamover/copy_procs.py
+++ b/src/tests/ftest/datamover/copy_procs.py
@@ -45,8 +45,8 @@ class DmvrCopyProcs(DataMoverTestBase):
         """
         # Create pool and containers
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
-        cont2 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
+        cont2 = self.get_container(pool1)
 
         # Get the varying number of processes
         procs_list = self.params.get("processes", "/run/dcp/copy_procs/*")

--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -60,7 +60,7 @@ class DmvrDstCreate(DataMoverTestBase):
         pool1.connect(2)
 
         # Create a source cont
-        cont1 = self.create_cont(pool1, cont_type=cont_type)
+        cont1 = self.get_container(pool1, type=cont_type)
 
         # Create source data
         src_props = self.write_cont(cont1)

--- a/src/tests/ftest/datamover/large_dir.py
+++ b/src/tests/ftest/datamover/large_dir.py
@@ -49,7 +49,7 @@ class DmvrLargeDir(DataMoverTestBase):
 
         # create pool and cont1
         pool = self.create_pool()
-        cont1 = self.create_cont(pool)
+        cont1 = self.get_container(pool)
 
         # run mdtest to create data in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
@@ -58,7 +58,7 @@ class DmvrLargeDir(DataMoverTestBase):
             flags=mdtest_flags[0])
 
         # create cont2
-        cont2 = self.create_cont(pool)
+        cont2 = self.get_container(pool)
 
         # copy from daos cont1 to cont2
         self.run_datamover(
@@ -75,7 +75,7 @@ class DmvrLargeDir(DataMoverTestBase):
             "POSIX", posix_path)
 
         # create cont3
-        cont3 = self.create_cont(pool)
+        cont3 = self.get_container(pool)
 
         # copy from posix file system to daos cont3
         self.run_datamover(

--- a/src/tests/ftest/datamover/large_file.py
+++ b/src/tests/ftest/datamover/large_file.py
@@ -44,13 +44,13 @@ class DmvrPosixLargeFile(DataMoverTestBase):
 
         # create pool and cont
         pool = self.create_pool()
-        cont1 = self.create_cont(pool)
+        cont1 = self.get_container(pool)
 
         # create initial data in cont1
         self.run_ior_with_params("DAOS", self.ior_cmd.test_file.value, pool, cont1)
 
         # create cont2
-        cont2 = self.create_cont(pool)
+        cont2 = self.get_container(pool)
 
         # copy from daos cont1 to cont2
         self.run_datamover(
@@ -67,7 +67,7 @@ class DmvrPosixLargeFile(DataMoverTestBase):
             "POSIX", posix_path)
 
         # create cont3
-        cont3 = self.create_cont(pool)
+        cont3 = self.get_container(pool)
 
         # copy from posix file system to daos cont3
         self.run_datamover(

--- a/src/tests/ftest/datamover/negative_space.py
+++ b/src/tests/ftest/datamover/negative_space.py
@@ -41,7 +41,7 @@ class DmvrNegativeSpaceTest(DataMoverTestBase):
 
         # Create destination test pool and container
         dst_pool = self.create_pool()
-        dst_cont = self.create_cont(dst_pool)
+        dst_cont = self.get_container(dst_pool)
         dst_daos_path = "/"
 
         # Try to copy, and expect a proper error message.

--- a/src/tests/ftest/datamover/obj_large_posix.py
+++ b/src/tests/ftest/datamover/obj_large_posix.py
@@ -39,7 +39,7 @@ class DmvrObjLargePosix(DataMoverTestBase):
 
         # Create pool1 and cont1
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create a large directory in cont1
         self.mdtest_cmd.write_bytes.update(file_size)

--- a/src/tests/ftest/datamover/obj_small.py
+++ b/src/tests/ftest/datamover/obj_small.py
@@ -62,7 +62,7 @@ class DmvrObjSmallTest(DataMoverTestBase):
         pool1.connect(2)
 
         # Create cont1
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create dataset in cont1
         obj_list = self.dataset_gen(

--- a/src/tests/ftest/datamover/posix_meta_entry.py
+++ b/src/tests/ftest/datamover/posix_meta_entry.py
@@ -64,7 +64,7 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # Create 1 source container with test data
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
         daos_src_path = self.new_daos_test_path(False)
         dfuse_src_path = "{}/{}/{}{}".format(
             self.dfuse.mount_dir.value, pool1.uuid, cont1.uuid, daos_src_path)

--- a/src/tests/ftest/datamover/posix_preserve_props.py
+++ b/src/tests/ftest/datamover/posix_preserve_props.py
@@ -61,7 +61,7 @@ class DmvrPreserveProps(DataMoverTestBase):
         self.preserve_props_path = join(self.tmp, "cont_props.h5")
 
         # Create a source cont
-        cont1 = self.create_cont(pool1, cont_type=cont_type)
+        cont1 = self.get_container(pool1, type=cont_type)
 
         # Create source data
         src_props = self.write_cont(cont1)

--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -55,18 +55,19 @@ class DmvrPosixSubsets(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # create dfuse containers to test copying to dfuse subdirectories
-        dfuse_cont1 = self.create_cont(pool1)
-        dfuse_cont2 = self.create_cont(pool1)
+        dfuse_cont1 = self.get_container(pool1)
+        dfuse_cont2 = self.get_container(pool1)
         dfuse_cont1_dir = join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont1.uuid)
         # destination directory should be created by program
         dfuse_cont2_dir = self.new_posix_test_path(
             create=False,
             parent=join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont2.uuid))
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Create a testing container
-        container1 = self.create_cont(pool1, True, pool1, uns_cont)
+        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        container1 = self.get_container(pool1, path=container1_path)
 
         # Create some source directories in the container
         sub_dir = self.new_daos_test_path(False)

--- a/src/tests/ftest/datamover/posix_symlinks.py
+++ b/src/tests/ftest/datamover/posix_symlinks.py
@@ -61,20 +61,23 @@ class DmvrPosixSymlinks(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Test links that point forward
-        container1 = self.create_cont(pool1, True, pool1, uns_cont)
+        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        container1 = self.get_container(pool1, path=container1_path)
         self.run_dm_posix_symlinks_fun(
             pool1, container1, self.create_links_forward, "forward")
 
         # Test links that point backward
-        container2 = self.create_cont(pool1, True, pool1, uns_cont)
+        container2_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns2')
+        container2 = self.get_container(pool1, path=container2_path)
         self.run_dm_posix_symlinks_fun(
             pool1, container2, self.create_links_backward, "backward")
 
         # Test a mix of forward and backward links
-        container3 = self.create_cont(pool1, True, pool1, uns_cont)
+        container3_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns3')
+        container3 = self.get_container(pool1, path=container3_path)
         self.run_dm_posix_symlinks_fun(
             pool1, container3, self.create_links_mixed, "mixed")
 

--- a/src/tests/ftest/datamover/posix_types.py
+++ b/src/tests/ftest/datamover/posix_types.py
@@ -70,12 +70,15 @@ class DmvrPosixTypesTest(DataMoverTestBase):
         pool2 = self.create_pool()
 
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Create all other containers
-        container1 = self.create_cont(pool1, True, pool1, uns_cont)
-        container2 = self.create_cont(pool1, True, pool1, uns_cont)
-        container3 = self.create_cont(pool2, True, pool1, uns_cont)
+        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        container1 = self.get_container(pool1, path=container1_path)
+        container2_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns2')
+        container2 = self.get_container(pool1, path=container2_path)
+        container3_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns3')
+        container3 = self.get_container(pool2, path=container3_path)
 
         # Create each source location
         p1_c1 = ["/", pool1, container1]

--- a/src/tests/ftest/datamover/serial_large_posix.py
+++ b/src/tests/ftest/datamover/serial_large_posix.py
@@ -43,7 +43,7 @@ class DmvrSerialLargePosix(DataMoverTestBase):
 
         # Create pool1 and cont1
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create a large directory in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
@@ -55,7 +55,7 @@ class DmvrSerialLargePosix(DataMoverTestBase):
         pool2 = self.create_pool()
 
         # Use dfuse as a shared intermediate for serialize + deserialize
-        dfuse_cont = self.create_cont(pool1)
+        dfuse_cont = self.get_container(pool1)
         self.start_dfuse(self.dfuse_hosts, pool1, dfuse_cont)
         self.serial_tmp_dir = self.dfuse.mount_dir.value
 

--- a/src/tests/ftest/datamover/serial_small.py
+++ b/src/tests/ftest/datamover/serial_small.py
@@ -60,7 +60,7 @@ class DmvrSerialSmall(DataMoverTestBase):
         pool1.connect(2)
 
         # Create cont1
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create dataset in cont1
         obj_list = self.dataset_gen(

--- a/src/tests/ftest/deployment/basic_checkout.py
+++ b/src/tests/ftest/deployment/basic_checkout.py
@@ -124,5 +124,10 @@ class BasicCheckoutDm(DataMoverTestBase):
         self.ior_cmd.namespace = "/run/ior_dm/*"
         self.ior_cmd.get_params(self)
         self.ppn = self.params.get("ppn", '/run/ior_dm/client_processes/*')
-        #run datamover
-        self.run_dm_activities_with_ior("FS_COPY", True)
+
+        # create pool and container
+        pool = self.create_pool()
+        cont = self.get_container(pool, oclass=self.ior_cmd.dfs_oclass.value)
+
+        # run datamover
+        self.run_dm_activities_with_ior("FS_COPY", pool, cont, True)

--- a/src/tests/ftest/deployment/io_sys_admin.py
+++ b/src/tests/ftest/deployment/io_sys_admin.py
@@ -97,15 +97,14 @@ class IoSysAdmin(DataMoverTestBase, FileCountTestBase):
                 self.fail("Aggregation did not complete as expected")
 
             time.sleep(60)
-            returned_space = (self.get_free_space()[1] -
-                              nvme_free_space_before_snap_destroy)
+            returned_space = (self.get_free_space()[1] - nvme_free_space_before_snap_destroy)
             counter += 1
 
         self.log.info("#####Starting FS_COPY Test")
-        self.run_dm_activities_with_ior("FS_COPY", pool=self.pool)
+        self.run_dm_activities_with_ior("FS_COPY", self.pool, self.container[-1])
         self.log.info("#####Starting DCP Test")
-        self.run_dm_activities_with_ior("DCP", pool=self.pool)
+        self.run_dm_activities_with_ior("DCP", self.pool, self.container[-1])
         self.log.info("#####Starting DSERIAL Test")
-        self.run_dm_activities_with_ior("DSERIAL", pool=self.pool)
+        self.run_dm_activities_with_ior("DSERIAL", self.pool, self.container[-1])
         self.log.info("#####Completed all Datamover tests")
         self.container.pop(0)

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -1,13 +1,11 @@
-#!/usr/bin/python
 """
 (C) Copyright 2018-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import os
 
+import os
 from os.path import join
-import uuid
 import re
 import ctypes
 from exception_utils import CommandFailure
@@ -77,8 +75,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         self.fs_copy_cmd = None
         self.cont_clone_cmd = None
         self.pool = []
-        self.container = []
-        self.uuids = []
         self.dfuse_hosts = None
         self.num_run_datamover = 0  # Number of times run_datamover was called
         self.job_manager = None
@@ -351,63 +347,10 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         # Continue using the uuid until there are tests for both uuid and label
         pool.use_label = False
 
-        # Save the pool and uuid
+        # Save the pool
         self.pool.append(pool)
-        self.uuids.append(str(pool.uuid))
 
         return pool
-
-    def create_cont(self, pool, use_dfuse_uns=False, dfuse_uns_pool=None, dfuse_uns_cont=None,
-                    cont_type=None, oclass=None):
-        # pylint: disable=arguments-differ
-        """Create a TestContainer object.
-
-        Args:
-            pool (TestPool): pool to create the container in.
-            use_dfuse_uns (bool, optional): whether to create a UNS path in the dfuse mount.
-                Default is False.
-            dfuse_uns_pool (TestPool, optional): pool in the
-                dfuse mount for which to create a UNS path.
-                Default assumes dfuse is running for a specific pool.
-            dfuse_uns_cont (TestContainer, optional): container in the
-                dfuse mount for which to create a UNS path.
-                Default assumes dfuse is running for a specific container.
-            cont_type (str, optional): the container type.
-
-        Returns:
-            TestContainer: the container object
-
-        Note about uns path:
-            These are only created within a dfuse mount.
-            The full UNS path will be created as:
-            <dfuse.mount_dir>/[pool_uuid]/[cont_uuid]/<dir_name>
-            dfuse_uns_pool and dfuse_uns_cont should only be supplied
-            when dfuse was not started for a specific pool/container.
-
-        """
-        params = {}
-
-        if use_dfuse_uns:
-            path = str(self.dfuse.mount_dir.value)
-            if dfuse_uns_pool:
-                path = join(path, dfuse_uns_pool.uuid)
-            if dfuse_uns_cont:
-                path = join(path, dfuse_uns_cont.uuid)
-            path = join(path, "uns{}".format(str(len(self.container))))
-            params["path"] = path
-
-        if cont_type:
-            params["type"] = cont_type
-        if oclass:
-            params["oclass"] = oclass
-
-        container = self.get_container(pool, **params)
-
-        # Save container and uuid
-        self.container.append(container)
-        self.uuids.append(str(container.uuid))
-
-        return container
 
     def get_cont(self, pool, cont_uuid):
         """Get an existing container.
@@ -430,23 +373,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         container.uuid = container.container.get_uuid_str()
         container.container.poh = pool.pool.handle
 
-        # Save container and uuid
-        self.container.append(container)
-        self.uuids.append(str(container.uuid))
-
         return container
-
-    def gen_uuid(self):
-        """Generate a unique uuid.
-
-        Returns:
-            str: a unique uuid
-
-        """
-        new_uuid = str(uuid.uuid4())
-        while new_uuid in self.uuids:
-            new_uuid = str(uuid.uuid4())
-        return new_uuid
 
     def parse_create_cont_uuid(self, output):
         """Parse a uuid from some output.
@@ -1068,49 +995,39 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
 
         return result
 
-    def run_dm_activities_with_ior(self, tool, create_dataset=False, pool=None, cont=None):
+    def run_dm_activities_with_ior(self, tool, pool, cont, create_dataset=False):
         """Generic method to perform various datamover activities
            using ior
         Args:
-            tool(str): specify the tool name to be used
-            create_dataset(bool): boolean to create initial set of
-                                  data using ior. Defaults to False.
-            pool(TestPool): Pool object. Defaults to None
-            cont(TestContainer): Container object. Defaults to None
+            tool (str): specify the tool name to be used
+            pool (TestPool): source pool object
+            cont (TestContainer): source container object
+            create_dataset (bool): boolean to create initial set of
+                                   data using ior. Defaults to False.
         """
         # Set the tool to use
         self.set_tool(tool)
 
         if create_dataset:
-            # create initial datasets
-            if not pool:
-                pool = self.create_pool()
-            cont = self.create_cont(pool, oclass=self.ior_cmd.dfs_oclass.value)
-
-            # update and run ior on container 1
+            # create initial datasets with ior
             self.run_ior_with_params("DAOS", self.ior_cmd.test_file.value, pool, cont)
-        else:
-            if not pool:
-                pool = self.pool[0]
-            if not cont:
-                cont = self.container[-1]
 
         # create cont2
-        cont2 = self.create_cont(pool, oclass=self.ior_cmd.dfs_oclass.value)
+        cont2 = self.get_container(pool, oclass=self.ior_cmd.dfs_oclass.value)
 
         # perform various datamover activities
         if tool == 'CONT_CLONE':
-            read_back_cont = self.gen_uuid()
-            self.run_datamover(
+            result = self.run_datamover(
                 self.test_id + " (cont to cont2)",
                 src_path=format_path(pool, cont),
-                dst_path=format_path(pool, read_back_cont))
+                dst_path=format_path(pool))
+            read_back_cont = self.parse_create_cont_uuid(result.stdout_text)
             read_back_pool = pool
         elif tool == 'DSERIAL':
             # Create pool2
             pool2 = self.get_pool()
             # Use dfuse as a shared intermediate for serialize + deserialize
-            dfuse_cont = self.create_cont(pool, oclass=self.ior_cmd.dfs_oclass.value)
+            dfuse_cont = self.get_container(pool, oclass=self.ior_cmd.dfs_oclass.value)
             self.start_dfuse(self.dfuse_hosts, pool, dfuse_cont)
             self.serial_tmp_dir = self.dfuse.mount_dir.value
 
@@ -1142,7 +1059,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                 dst_path=posix_path)
 
             # create cont3
-            cont3 = self.create_cont(pool, oclass=self.ior_cmd.dfs_oclass.value)
+            cont3 = self.get_container(pool, oclass=self.ior_cmd.dfs_oclass.value)
 
             # copy from posix file system to daos cont3
             self.run_datamover(


### PR DESCRIPTION
Test-tag: datamover

- Replace DataMoverTestBase.create_cont with
  TestWithServers.get_container
- Remove DataMoverTestBase.gen_uuid

Required-githooks: true
Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>