### PR TITLE
DAOS-10739 test: Disable daos-build test on 2.2.

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -43,7 +43,7 @@ class DaosBuild(DfuseTestBase):
             Create Posix container
             Mount dfuse
             Checkout and build DAOS sources.
-        :avocado: tags=all,daily_regression
+        :avocado: tags=all
         :avocado: tags=vm
         :avocado: tags=daosio,dfuse
         :avocado: tags=dfusedaosbuild


### PR DESCRIPTION
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
