### PR TITLE
DAOS-11167 test: Update bullseye_generate_report.sh with test.cov path

### DIFF
--- a/ci/bullseye_generate_report.sh
+++ b/ci/bullseye_generate_report.sh
@@ -6,12 +6,12 @@ if [ ! -d '/opt/BullseyeCoverage/bin' ]; then
   echo 'Bullseye not found.'
   exit 1
 fi
-export COVFILE="$WORKSPACE/test.cov"
+export COVFILE="$DAOS_BASE/test.cov"
 export PATH="/opt/BullseyeCoverage/bin:$PATH"
 
-mv "$WORKSPACE/test.cov_1" "$COVFILE"
-if [ -e "$WORKSPACE/test.cov_2" ]; then
-  covmerge --no-banner --file "$COVFILE" "$WORKSPACE"/test.cov_*
+mv "$DAOS_BASE/test.cov_1" "$COVFILE"
+if [ -e "$DAOS_BASE/test.cov_2" ]; then
+  covmerge --no-banner --file "$COVFILE" "$DAOS_BASE"/test.cov_*
 fi
 
 if [ -e "$COVFILE" ]; then


### PR DESCRIPTION
Update bullseye_generate_report.sh with correct env
Skip-fnbullseye: false
Skip-bullseye: false
Skip-unit-tests: true
Skip-python-bandit: true
Allow-unstable-test: true
Skip-build-ubuntu20-rpm: true
Test-tag: container
Signed-off-by: Ding Ho ding-hwa.ho@intel.com