### PR TITLE
DAOS-11175 control: Add Notice log level

### DIFF
--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -264,7 +264,7 @@ type nvmeSetFaultyCmd struct {
 // Execute is run when nvmeSetFaultyCmd activates
 // Set the SMD device state of the given device to "FAULTY"
 func (cmd *nvmeSetFaultyCmd) Execute(_ []string) error {
-	cmd.Info("WARNING: This command will permanently mark the device as unusable!")
+	cmd.Notice("WARNING: This command will permanently mark the device as unusable!")
 	if !cmd.Force {
 		if cmd.jsonOutputEnabled() {
 			return errors.New("Cannot use --json without --force")
@@ -298,7 +298,7 @@ type nvmeReplaceCmd struct {
 // Replace a hot-removed device with a newly plugged device, or reuse a FAULTY device
 func (cmd *nvmeReplaceCmd) Execute(_ []string) error {
 	if cmd.OldDevUUID == cmd.NewDevUUID {
-		cmd.Info("WARNING: Attempting to reuse a previously set FAULTY device!")
+		cmd.Notice("WARNING: Attempting to reuse a previously set FAULTY device!")
 	}
 
 	// TODO: Implement no-reint flag option

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -1271,7 +1271,7 @@ func GetMaxPoolSize(ctx context.Context, log logging.Logger, rpcClient UnaryInvo
 		for _, nvmeController := range hostStorage.NvmeDevices {
 			for _, smdDevice := range nvmeController.SmdDevices {
 				if !smdDevice.NvmeState.IsNormal() {
-					log.Infof("WARNING: SMD device %s (instance %d, ctrlr %s) "+
+					log.Noticef("WARNING: SMD device %s (instance %d, ctrlr %s) "+
 						"not usable (device state %q)",
 						smdDevice.UUID, smdDevice.Rank, smdDevice.TrAddr,
 						smdDevice.NvmeState.String())

--- a/src/control/logging/defaults.go
+++ b/src/control/logging/defaults.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -30,6 +30,9 @@ func NewCommandLineLogger() *LeveledLogger {
 		infoLoggers: []InfoLogger{
 			NewCommandLineInfoLogger(os.Stdout),
 		},
+		noticeLoggers: []NoticeLogger{
+			NewCommandLineNoticeLogger(os.Stderr),
+		},
 		errorLoggers: []ErrorLogger{
 			NewCommandLineErrorLogger(os.Stderr),
 		},
@@ -53,6 +56,9 @@ func NewCombinedLogger(prefix string, output io.Writer) *LeveledLogger {
 		},
 		infoLoggers: []InfoLogger{
 			NewInfoLogger(prefix, output),
+		},
+		noticeLoggers: []NoticeLogger{
+			NewNoticeLogger(prefix, output),
 		},
 		errorLoggers: []ErrorLogger{
 			NewErrorLogger(prefix, output),

--- a/src/control/logging/json.go
+++ b/src/control/logging/json.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -101,6 +101,9 @@ type (
 	jsonInfo interface {
 		WithJSONOutput() InfoLogger
 	}
+	jsonNotice interface {
+		WithJSONOutput() NoticeLogger
+	}
 	jsonError interface {
 		WithJSONOutput() ErrorLogger
 	}
@@ -114,6 +117,7 @@ func (ll *LeveledLogger) WithJSONOutput() *LeveledLogger {
 
 	var debugLoggers []DebugLogger
 	var infoLoggers []InfoLogger
+	var noticeLoggers []NoticeLogger
 	var errorLoggers []ErrorLogger
 
 	for _, l := range ll.debugLoggers {
@@ -133,6 +137,15 @@ func (ll *LeveledLogger) WithJSONOutput() *LeveledLogger {
 		}
 	}
 	ll.infoLoggers = infoLoggers
+
+	for _, l := range ll.noticeLoggers {
+		if jsonLogger, ok := l.(jsonNotice); ok {
+			if nl, ok := jsonLogger.WithJSONOutput().(NoticeLogger); ok {
+				noticeLoggers = append(noticeLoggers, nl)
+			}
+		}
+	}
+	ll.noticeLoggers = noticeLoggers
 
 	for _, l := range ll.errorLoggers {
 		if jsonLogger, ok := l.(jsonError); ok {
@@ -166,6 +179,18 @@ func (l *DefaultInfoLogger) WithJSONOutput() InfoLogger {
 			dest:   l.dest,
 			prefix: l.prefix,
 			log:    NewJSONFormatter(l.dest, "INFO", l.prefix, infoLogFlags),
+		},
+	}
+}
+
+// WithJSONOutput switches the logger's output to use structured
+// JSON formatting.
+func (l *DefaultNoticeLogger) WithJSONOutput() NoticeLogger {
+	return &DefaultNoticeLogger{
+		baseLogger{
+			dest:   l.dest,
+			prefix: l.prefix,
+			log:    NewJSONFormatter(l.dest, "NOTICE", l.prefix, noticeLogFlags),
 		},
 	}
 }

--- a/src/control/logging/level.go
+++ b/src/control/logging/level.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -16,6 +16,8 @@ const (
 	LogLevelDisabled LogLevel = iota
 	// LogLevelError emits messages at ERROR or higher
 	LogLevelError
+	// LogLevelNotice emits messages at NOTICE or higher
+	LogLevelNotice
 	// LogLevelInfo emits messages at INFO or higher
 	LogLevelInfo
 	// LogLevelDebug emits messages at DEBUG or higher
@@ -23,6 +25,7 @@ const (
 
 	strDisabled = "DISABLED"
 	strError    = "ERROR"
+	strNotice   = "NOTICE"
 	strInfo     = "INFO"
 	strDebug    = "DEBUG"
 )
@@ -49,6 +52,8 @@ func (ll *LogLevel) SetString(in string) error {
 		level = LogLevelDisabled
 	case strings.EqualFold(in, strError):
 		level = LogLevelError
+	case strings.EqualFold(in, strNotice):
+		level = LogLevelNotice
 	case strings.EqualFold(in, strInfo):
 		level = LogLevelInfo
 	case strings.EqualFold(in, strDebug):
@@ -67,6 +72,8 @@ func (ll LogLevel) String() string {
 		return strDisabled
 	case LogLevelError:
 		return strError
+	case LogLevelNotice:
+		return strNotice
 	case LogLevelInfo:
 		return strInfo
 	case LogLevelDebug:

--- a/src/control/logging/level_test.go
+++ b/src/control/logging/level_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -19,6 +19,7 @@ func TestLogLevelToString(t *testing.T) {
 		"Zero Value": {expected: "DISABLED"},
 		"Disabled":   {expected: "DISABLED", level: logging.LogLevelDisabled},
 		"Error":      {expected: "ERROR", level: logging.LogLevelError},
+		"Notice":     {expected: "NOTICE", level: logging.LogLevelNotice},
 		"Info":       {expected: "INFO", level: logging.LogLevelInfo},
 		"Debug":      {expected: "DEBUG", level: logging.LogLevelDebug},
 		"Unknown":    {expected: "UNKNOWN", level: logging.LogLevel(42)},
@@ -43,6 +44,8 @@ func TestLogLevelFromString(t *testing.T) {
 		"disabled":  {expected: logging.LogLevelDisabled},
 		"Error":     {expected: logging.LogLevelError},
 		"error":     {expected: logging.LogLevelError},
+		"Notice":    {expected: logging.LogLevelNotice},
+		"notice":    {expected: logging.LogLevelNotice},
 		"Info":      {expected: logging.LogLevelInfo},
 		"info":      {expected: logging.LogLevelInfo},
 		"Debug":     {expected: logging.LogLevelDebug},

--- a/src/control/logging/logger.go
+++ b/src/control/logging/logger.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -18,6 +18,8 @@ type (
 		Debug(msg string)
 		InfoLogger
 		Info(msg string)
+		NoticeLogger
+		Notice(msg string)
 		ErrorLogger
 		Error(msg string)
 	}
@@ -32,6 +34,12 @@ type (
 	// by Info loggers.
 	InfoLogger interface {
 		Infof(format string, args ...interface{})
+	}
+
+	// NoticeLogger defines an interface to be implemented
+	// by Notice loggers.
+	NoticeLogger interface {
+		Noticef(format string, args ...interface{})
 	}
 
 	// ErrorLogger defines an interface to be implemented
@@ -52,10 +60,11 @@ type (
 	LeveledLogger struct {
 		sync.RWMutex
 
-		level        LogLevel
-		debugLoggers []DebugLogger
-		infoLoggers  []InfoLogger
-		errorLoggers []ErrorLogger
+		level         LogLevel
+		debugLoggers  []DebugLogger
+		infoLoggers   []InfoLogger
+		noticeLoggers []NoticeLogger
+		errorLoggers  []ErrorLogger
 	}
 
 	baseLogger struct {
@@ -83,6 +92,8 @@ func (ll *LeveledLogger) ClearLevel(level LogLevel) {
 		ll.debugLoggers = nil
 	case LogLevelInfo:
 		ll.infoLoggers = nil
+	case LogLevelNotice:
+		ll.noticeLoggers = nil
 	case LogLevelError:
 		ll.errorLoggers = nil
 	default:
@@ -108,6 +119,13 @@ func (ll *LeveledLogger) WithDebugLogger(newLogger DebugLogger) *LeveledLogger {
 // the logger as part of a chained method call.
 func (ll *LeveledLogger) WithInfoLogger(newLogger InfoLogger) *LeveledLogger {
 	ll.AddInfoLogger(newLogger)
+	return ll
+}
+
+// WithNoticeLogger adds the specified Notice logger to
+// the logger as part of a chained method call.
+func (ll *LeveledLogger) WithNoticeLogger(newLogger NoticeLogger) *LeveledLogger {
+	ll.AddNoticeLogger(newLogger)
 	return ll
 }
 
@@ -173,6 +191,35 @@ func (ll *LeveledLogger) Infof(format string, args ...interface{}) {
 
 	for _, l := range loggers {
 		l.Infof(format, args...)
+	}
+}
+
+// AddNoticeLogger adds the specified Notice logger to the logger.
+func (ll *LeveledLogger) AddNoticeLogger(newLogger NoticeLogger) {
+	ll.Lock()
+	defer ll.Unlock()
+	ll.noticeLoggers = append(ll.noticeLoggers, newLogger)
+}
+
+// Notice emits an unformatted message at Notice level, if
+// the logger is configured to do so.
+func (ll *LeveledLogger) Notice(msg string) {
+	ll.Noticef("%s", msg)
+}
+
+// Noticef emits a formatted message at Notice level, if
+// the logger is configured to do so.
+func (ll *LeveledLogger) Noticef(format string, args ...interface{}) {
+	if ll.Level() < LogLevelNotice {
+		return
+	}
+
+	ll.RLock()
+	loggers := ll.noticeLoggers
+	ll.RUnlock()
+
+	for _, l := range loggers {
+		l.Noticef(format, args...)
 	}
 }
 

--- a/src/control/logging/logging_test.go
+++ b/src/control/logging/logging_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -102,6 +102,10 @@ func TestLogging_StandardFormat(t *testing.T) {
 			expected: regexp.MustCompile(`^testPrefix INFO \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} test\n$`)},
 		"Infof": {fmtFn: logger.Infof, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},
 			expected: regexp.MustCompile(`^testPrefix INFO \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} test: 42\n$`)},
+		"Notice": {fn: logger.Notice, fnInput: "test",
+			expected: regexp.MustCompile(`^testPrefix NOTICE \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} test\n$`)},
+		"Noticef": {fmtFn: logger.Noticef, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},
+			expected: regexp.MustCompile(`^testPrefix NOTICE \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} test: 42\n$`)},
 		"Error": {fn: logger.Error, fnInput: "test",
 			expected: regexp.MustCompile(`^testPrefix ERROR \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} test\n$`)},
 		"Errorf": {fmtFn: logger.Errorf, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},
@@ -150,6 +154,10 @@ func TestLogging_JSONFormat(t *testing.T) {
 			expected: regexp.MustCompile(`^\{\"level\":\"INFO\",\"time\":\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+Z]\d{0,4}\",\"extra\":\"testPrefix\",\"message\":\"test\"\}\n$`)},
 		"Infof": {fmtFn: logger.Infof, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},
 			expected: regexp.MustCompile(`^\{\"level\":\"INFO\",\"time\":\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+Z]\d{0,4}\",\"extra\":\"testPrefix\",\"message\":\"test: 42\"\}\n$`)},
+		"Notice": {fn: logger.Notice, fnInput: "test",
+			expected: regexp.MustCompile(`^\{\"level\":\"NOTICE\",\"time\":\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+Z]\d{0,4}\",\"extra\":\"testPrefix\",\"message\":\"test\"\}\n$`)},
+		"Noticef": {fmtFn: logger.Noticef, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},
+			expected: regexp.MustCompile(`^\{\"level\":\"NOTICE\",\"time\":\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+Z]\d{0,4}\",\"extra\":\"testPrefix\",\"message\":\"test: 42\"\}\n$`)},
 		"Error": {fn: logger.Error, fnInput: "test",
 			expected: regexp.MustCompile(`^\{\"level\":\"ERROR\",\"time\":\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+Z]\d{0,4}\",\"extra\":\"testPrefix\",\"message\":\"test\"\}\n$`)},
 		"Errorf": {fmtFn: logger.Errorf, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},
@@ -187,6 +195,9 @@ func TestLogging_MultipleFormats(t *testing.T) {
 		WithInfoLogger(
 			logging.NewInfoLogger("testPrefix", &jsonBuf).WithJSONOutput(),
 		).
+		WithNoticeLogger(
+			logging.NewNoticeLogger("testPrefix", &jsonBuf).WithJSONOutput(),
+		).
 		WithErrorLogger(
 			logging.NewErrorLogger("testPrefix", &jsonBuf).WithJSONOutput(),
 		)
@@ -212,6 +223,12 @@ func TestLogging_MultipleFormats(t *testing.T) {
 		"Infof": {fmtFn: logger.Infof, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},
 			expectedStd:  regexp.MustCompile(`^testPrefix INFO \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} test: 42\n$`),
 			expectedJSON: regexp.MustCompile(`^\{\"level\":\"INFO\",\"time\":\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+Z]\d{0,4}\",\"extra\":\"testPrefix\",\"message\":\"test: 42\"\}\n$`)},
+		"Notice": {fn: logger.Notice, fnInput: "test",
+			expectedStd:  regexp.MustCompile(`^testPrefix NOTICE \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} test\n$`),
+			expectedJSON: regexp.MustCompile(`^\{\"level\":\"NOTICE\",\"time\":\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+Z]\d{0,4}\",\"extra\":\"testPrefix\",\"message\":\"test\"\}\n$`)},
+		"Noticef": {fmtFn: logger.Noticef, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},
+			expectedStd:  regexp.MustCompile(`^testPrefix NOTICE \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} test: 42\n$`),
+			expectedJSON: regexp.MustCompile(`^\{\"level\":\"NOTICE\",\"time\":\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+Z]\d{0,4}\",\"extra\":\"testPrefix\",\"message\":\"test: 42\"\}\n$`)},
 		"Error": {fn: logger.Error, fnInput: "test",
 			expectedStd:  regexp.MustCompile(`^testPrefix ERROR \d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} test\n$`),
 			expectedJSON: regexp.MustCompile(`^\{\"level\":\"ERROR\",\"time\":\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+Z]\d{0,4}\",\"extra\":\"testPrefix\",\"message\":\"test\"\}\n$`)},
@@ -258,18 +275,26 @@ func TestLogging_LogLevels(t *testing.T) {
 		fnInput  string
 		expected *regexp.Regexp
 	}{
-		"Disabled-Debug": {setLevel: logging.LogLevelDisabled, fn: logger.Debug, fnInput: "test", expected: regexp.MustCompile(`^$`)},
-		"Disabled-Info":  {setLevel: logging.LogLevelDisabled, fn: logger.Info, fnInput: "test", expected: regexp.MustCompile(`^$`)},
-		"Disabled-Error": {setLevel: logging.LogLevelDisabled, fn: logger.Error, fnInput: "test", expected: regexp.MustCompile(`^$`)},
-		"Debug-Debug":    {setLevel: logging.LogLevelDebug, fn: logger.Debug, fnInput: "test", expected: regexp.MustCompile(`test`)},
-		"Debug-Info":     {setLevel: logging.LogLevelDebug, fn: logger.Info, fnInput: "test", expected: regexp.MustCompile(`test`)},
-		"Debug-Error":    {setLevel: logging.LogLevelDebug, fn: logger.Error, fnInput: "test", expected: regexp.MustCompile(`test`)},
-		"Info-Debug":     {setLevel: logging.LogLevelInfo, fn: logger.Debug, fnInput: "test", expected: regexp.MustCompile(`^$`)},
-		"Info-Info":      {setLevel: logging.LogLevelInfo, fn: logger.Info, fnInput: "test", expected: regexp.MustCompile(`test`)},
-		"Info-Error":     {setLevel: logging.LogLevelInfo, fn: logger.Error, fnInput: "test", expected: regexp.MustCompile(`test`)},
-		"Error-Debug":    {setLevel: logging.LogLevelError, fn: logger.Debug, fnInput: "test", expected: regexp.MustCompile(`^$`)},
-		"Error-Info":     {setLevel: logging.LogLevelError, fn: logger.Info, fnInput: "test", expected: regexp.MustCompile(`^$`)},
-		"Error-Error":    {setLevel: logging.LogLevelError, fn: logger.Error, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Disabled-Debug":  {setLevel: logging.LogLevelDisabled, fn: logger.Debug, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Disabled-Info":   {setLevel: logging.LogLevelDisabled, fn: logger.Info, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Disabled-Notice": {setLevel: logging.LogLevelDisabled, fn: logger.Notice, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Disabled-Error":  {setLevel: logging.LogLevelDisabled, fn: logger.Error, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Debug-Debug":     {setLevel: logging.LogLevelDebug, fn: logger.Debug, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Debug-Info":      {setLevel: logging.LogLevelDebug, fn: logger.Info, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Debug-Notice":    {setLevel: logging.LogLevelDebug, fn: logger.Notice, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Debug-Error":     {setLevel: logging.LogLevelDebug, fn: logger.Error, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Info-Debug":      {setLevel: logging.LogLevelInfo, fn: logger.Debug, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Info-Info":       {setLevel: logging.LogLevelInfo, fn: logger.Info, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Info-Notice":     {setLevel: logging.LogLevelInfo, fn: logger.Notice, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Info-Error":      {setLevel: logging.LogLevelInfo, fn: logger.Error, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Notice-Debug":    {setLevel: logging.LogLevelNotice, fn: logger.Debug, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Notice-Info":     {setLevel: logging.LogLevelNotice, fn: logger.Info, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Notice-Notice":   {setLevel: logging.LogLevelNotice, fn: logger.Notice, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Notice-Error":    {setLevel: logging.LogLevelNotice, fn: logger.Error, fnInput: "test", expected: regexp.MustCompile(`test`)},
+		"Error-Debug":     {setLevel: logging.LogLevelError, fn: logger.Debug, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Error-Info":      {setLevel: logging.LogLevelError, fn: logger.Info, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Error-Notice":    {setLevel: logging.LogLevelError, fn: logger.Notice, fnInput: "test", expected: regexp.MustCompile(`^$`)},
+		"Error-Error":     {setLevel: logging.LogLevelError, fn: logger.Error, fnInput: "test", expected: regexp.MustCompile(`test`)},
 	}
 
 	for name, tc := range tests {

--- a/src/control/logging/notice.go
+++ b/src/control/logging/notice.go
@@ -1,0 +1,58 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+const noticeLogFlags = log.LstdFlags
+
+// NewCommandLineNoticeLogger returns a NoticeLogger configured
+// for outputting unadorned notice messages (i.e. no
+// timestamps, source info, etc); typically used for CLI
+// utility logging.
+func NewCommandLineNoticeLogger(output io.Writer) *DefaultNoticeLogger {
+	return &DefaultNoticeLogger{
+		baseLogger{
+			dest: output,
+			log:  log.New(output, "", emptyLogFlags),
+		},
+	}
+}
+
+// NewNoticeLogger returns NoticeLogger configured for outputting
+// notice messages with standard formatting (e.g. to stderr,
+// logfile, etc.)
+func NewNoticeLogger(prefix string, output io.Writer) *DefaultNoticeLogger {
+	loggerPrefix := "NOTICE "
+	if prefix != "" {
+		loggerPrefix = prefix + " " + loggerPrefix
+	}
+	return &DefaultNoticeLogger{
+		baseLogger{
+			dest:   output,
+			prefix: prefix,
+			log:    log.New(output, loggerPrefix, noticeLogFlags),
+		},
+	}
+}
+
+// DefaultNoticeLogger implements the NoticeLogger interface.
+type DefaultNoticeLogger struct {
+	baseLogger
+}
+
+// Noticef emits a formatted notice message.
+func (l *DefaultNoticeLogger) Noticef(format string, args ...interface{}) {
+	out := fmt.Sprintf(format, args...)
+	if err := l.log.Output(logOutputDepth, out); err != nil {
+		fmt.Fprintf(os.Stderr, "logger Noticef() failed: %s\n", err)
+	}
+}

--- a/src/control/logging/syslog_test.go
+++ b/src/control/logging/syslog_test.go
@@ -43,6 +43,7 @@ func TestSyslogOutput(t *testing.T) {
 	}
 	debugStr := randString("DEBUG", 8)
 	infoStr := randString("INFO", 8)
+	noticeStr := randString("NOTICE", 8)
 	errorStr := randString("ERROR", 8)
 
 	logger := logging.NewStdoutLogger("testPrefix").
@@ -66,6 +67,10 @@ func TestSyslogOutput(t *testing.T) {
 			expected: regexp.MustCompile(fmt.Sprintf(`\n[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2} [\w\.\-]+ [^:]+: %s\n`, infoStr))},
 		"Infof": {prio: syslog.LOG_INFO, fmtFn: logger.Infof, fmtFnFmt: fmt.Sprintf("%s: %%d", infoStr), fmtFnArgs: []interface{}{42},
 			expected: regexp.MustCompile(fmt.Sprintf(`\n[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2} [\w\.\-]+ [^:]+: %s: 42\n`, infoStr))},
+		"Notice": {prio: syslog.LOG_INFO, fn: logger.Notice, fnInput: noticeStr,
+			expected: regexp.MustCompile(fmt.Sprintf(`\n[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2} [\w\.\-]+ [^:]+: %s\n`, noticeStr))},
+		"Noticef": {prio: syslog.LOG_INFO, fmtFn: logger.Noticef, fmtFnFmt: fmt.Sprintf("%s: %%d", noticeStr), fmtFnArgs: []interface{}{42},
+			expected: regexp.MustCompile(fmt.Sprintf(`\n[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2} [\w\.\-]+ [^:]+: %s: 42\n`, noticeStr))},
 		"Error": {prio: syslog.LOG_ERR, fn: logger.Error, fnInput: errorStr,
 			expected: regexp.MustCompile(fmt.Sprintf(`\n[A-Za-z]{3} \d{2} \d{2}:\d{2}:\d{2} [\w\.\-]+ [^:]+: %s\n`, errorStr))},
 		"Errorf": {prio: syslog.LOG_ERR, fmtFn: logger.Errorf, fmtFnFmt: fmt.Sprintf("%s: %%d", errorStr), fmtFnArgs: []interface{}{42},

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -473,7 +473,7 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 	case len(cfg.AccessPoints)%2 == 0:
 		return FaultConfigEvenAccessPoints
 	case len(cfg.AccessPoints) == 1:
-		log.Infof("WARNING: Configuration includes only one access point. This provides no redundancy " +
+		log.Noticef("WARNING: Configuration includes only one access point. This provides no redundancy " +
 			"in the event of an access point failure.")
 	}
 
@@ -493,7 +493,7 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 
 		ls := ec.LegacyStorage
 		if ls.WasDefined() {
-			log.Infof("engine %d: Legacy storage configuration detected. Please "+
+			log.Noticef("engine %d: Legacy storage configuration detected. Please "+
 				"migrate to new-style storage configuration.", idx)
 			var tierCfgs storage.TierConfigs
 			if ls.ScmClass != storage.ClassNone {

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -280,7 +280,7 @@ func (c *ControlService) adjustScmSize(resp *ctlpb.ScanScmResp) {
 				scmNamespace.Mount.GetPath(), humanize.Bytes(mdBytes), mdBytes)
 			scmNamespace.Mount.AvailBytes -= mdBytes
 		} else {
-			c.log.Infof("WARNING: Adjusting available size to 0 Bytes of SCM device %q: "+
+			c.log.Noticef("WARNING: Adjusting available size to 0 Bytes of SCM device %q: "+
 				"old available size %s (%d Bytes), metadata size %s (%d Bytes)",
 				scmNamespace.Mount.GetPath(),
 				humanize.Bytes(availBytes), availBytes,

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -183,7 +183,7 @@ func getEngineNUMANodes(log logging.Logger, engineCfgs []*engine.Config) []strin
 	for _, ec := range engineCfgs {
 		nn := fmt.Sprintf("%d", ec.Storage.NumaNodeIndex)
 		if nodeMap[nn] {
-			log.Infof("Multiple engines assigned to NUMA node %s, "+
+			log.Noticef("Multiple engines assigned to NUMA node %s, "+
 				"allocating all hugepages on this node.", nn)
 			nodes = []string{nn}
 			break

--- a/src/control/server/telemetry.go
+++ b/src/control/server/telemetry.go
@@ -116,7 +116,7 @@ func startPrometheusExporter(ctx context.Context, log logging.Logger, port int, 
 		timedCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 		if err := srv.Shutdown(timedCtx); err != nil {
-			log.Infof("HTTP server didn't shut down within timeout: %s", err.Error())
+			log.Noticef("HTTP server didn't shut down within timeout: %s", err.Error())
 		}
 	}, nil
 }


### PR DESCRIPTION
The Notice log level is between Info and Error. It is suitable for
messages that indicate a sub-optimal or degraded condition that  will
not prevent the system from functioning correctly.

- Add Notice/Noticef methods to logger.
- In syslog, Notice messages are included in syslog level "INFO".
- Update some existing Info level messages to Notice level.

Test-tag: pr control config_generate_run

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>