### PR TITLE
DAOS-9785 vos: ignore RT_OVERLAP_INCLUDED array remove

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2579,6 +2579,14 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 				 * change while we decide how to handle this
 				 * properly.
 				 */
+				if (range_overlap == RT_OVERLAP_INCLUDED &&
+				    rect->rc_minor_epc == EVT_MINOR_EPC_MAX) {
+					D_DEBUG(DB_IO, "Ignore RT_OVERLAP_INCLUDED array remove "
+						DF_RECT" and "DF_RECT"\n", DP_RECT(rect),
+						DP_RECT(&rtmp));
+					rc = 0;
+					goto out;
+				}
 				if (range_overlap != RT_OVERLAP_SAME) {
 					D_ERROR("Same epoch partial "
 						"overwrite not supported:"


### PR DESCRIPTION
In EC aggregation observed such failure:
src/vos/evtree.c:2587 evt_ent_array_fill() Same epoch partial overwrite
not supported:ef000-effff@ae980b150f00000.65535-INF overlaps with
e0000-effff@ae980b150f00000.65535-INF
It finally cause EC aggregation failed and cannot go ahead -
src/object/srv_ec_aggregate.c:825 agg_update_vos() array_remove fails:
DER_NO_PERM(-1001): 'Operation not permitted'
src/object/srv_ec_aggregate.c:1846 agg_process_stripe() agg_update_vos
failed: DER_NO_PERM(-1001): 'Operation not permitted'
src/container/srv_target.c:486 cont_aggregate_interval()
6747145e/ec47b424: VOS aggregate failed. DER_NO_PERM(-1001): 'Operation
not permitted'

For array remove, the RT_OVERLAP_INCLUDED range @same_epoch should be
safe to ignore to avoid failure in that case.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>