### PR TITLE
DAOS-11042: Enhanced umem interfaces to abstract pmdk calls

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -2212,7 +2212,7 @@ dbtree_feats_set(struct btr_root *root, struct umem_instance *umm, uint64_t feat
 		if (rc != 0)
 			return rc;
 		rc = umem_tx_xadd_ptr(umm, &root->tr_feats, sizeof(root->tr_feats),
-				      POBJ_XADD_NO_SNAPSHOT);
+				      UMEM_XADD_NO_SNAPSHOT);
 	}
 #endif
 

--- a/src/common/btree_class.c
+++ b/src/common/btree_class.c
@@ -27,7 +27,7 @@ btr_check_tx(struct btr_attr *attr)
 		return BTR_NO_TX;
 
 #ifdef DAOS_PMEM_BUILD
-	if (pmemobj_tx_stage() == TX_STAGE_WORK)
+	if (umem_tx_inprogress())
 		return BTR_IN_TX;
 #endif
 	return BTR_SUPPORT_TX;

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -14,6 +14,9 @@
 
 #include <daos/common.h>
 #include <daos/mem.h>
+#ifdef DAOS_PMEM_BUILD
+#include <libpmemobj.h>
+#endif
 
 #define UMEM_TX_DATA_MAGIC	(0xc01df00d)
 
@@ -28,6 +31,209 @@ struct umem_tx_stage_item {
 };
 
 #ifdef DAOS_PMEM_BUILD
+/** Sets up global settings for the pmem objects.
+ *
+ *  \return	0 on success, non-zero on failure.
+ */
+int
+umempobj_settings_init(void)
+{
+	int					rc;
+	enum pobj_arenas_assignment_type	atype;
+
+	atype = POBJ_ARENAS_ASSIGNMENT_GLOBAL;
+
+	rc = pmemobj_ctl_set(NULL, "heap.arenas_assignment_type", &atype);
+	if (rc != 0)
+		D_ERROR("Could not configure PMDK for global arena: %s\n",
+			strerror(errno));
+	return rc;
+}
+
+/* Persistent object allocator functions */
+/** Create a persistent memory object.
+ *
+ *  \param	path[IN]		Name of the memory pool file
+ *  \param	layout_name[IN]		Unique name for the layout
+ *  \param	flags[IN]		Additional flags
+ *  \param	poolsize[IN]		Size of the pool
+ *  \param	mode[IN]		Permission for creating the object
+ *
+ *  \return	A pointer to the pool, NULL if creation fails.
+ */
+struct umem_pool *
+umempobj_create(const char *path, const char *layout_name, int flags,
+		size_t poolsize, mode_t mode)
+{
+	PMEMobjpool     *pop;
+	int              enabled = 1;
+	int              rc;
+
+	pop = pmemobj_create(path, layout_name, poolsize, mode);
+	if (!pop) {
+		D_ERROR("Failed to create pool %s, size="DF_U64": %s\n",
+			path, poolsize, pmemobj_errormsg());
+		return NULL;
+	}
+	if (flags & UMEMPOBJ_ENABLE_STATS) {
+		rc = pmemobj_ctl_set(pop, "stats.enabled", &enabled);
+		if (rc) {
+			D_ERROR("Enable SCM usage statistics failed. "DF_RC"\n",
+				DP_RC(rc));
+			rc = umem_tx_errno(rc);
+			pmemobj_close(pop);
+			pop = NULL;
+		}
+	}
+	return ((struct umem_pool *)pop);
+}
+
+/** Open the given persistent memory object.
+ *
+ *  \param	path[IN]		Name of the memory pool file
+ *  \param	layout_name[IN]		Name of the layout [PMDK]
+ *  \param	flags[IN]		Additional flags
+ *
+ *  \return	A pointer to the pool, NULL if creation fails.
+ */
+struct umem_pool *
+umempobj_open(const char *path, const char *layout_name, int flags)
+{
+	PMEMobjpool     *pop;
+	int              enabled = 1;
+	int              rc;
+
+	pop = pmemobj_open(path, layout_name);
+	if (!pop) {
+		D_ERROR("Error in opening the pool %s: %s\n",
+			path, pmemobj_errormsg());
+		return NULL;
+	}
+	if (flags & UMEMPOBJ_ENABLE_STATS) {
+		rc = pmemobj_ctl_set(pop, "stats.enabled", &enabled);
+		if (rc) {
+			D_ERROR("Enable SCM usage statistics failed. "DF_RC"\n",
+				DP_RC(rc));
+			rc = umem_tx_errno(rc);
+			pmemobj_close(pop);
+			pop = NULL;
+		}
+	}
+	return ((struct umem_pool *)pop);
+}
+
+/** Close the pmem object.
+ *
+ *  \param	ph_p[IN]		pointer to the pool object.
+ */
+void
+umempobj_close(struct umem_pool *ph_p)
+{
+	PMEMobjpool *pop = (PMEMobjpool *)ph_p;
+
+	pmemobj_close(pop);
+}
+
+/** Obtain the root memory address for the pmem object.
+ *
+ *  \param	ph_p[IN]		Pointer to the persistent object.
+ *  \param	size[IN]		size of the structure that root is
+ *					pointing to.
+ *
+ *  \return	A memory pointer to the pool's root location.
+ */
+void *
+umempobj_get_rootptr(struct umem_pool *ph_p, size_t size)
+{
+	PMEMobjpool *pop = (PMEMobjpool *)ph_p;
+	PMEMoid root;
+	void *rootp;
+
+	root = pmemobj_root(pop, size);
+	rootp = pmemobj_direct(root);
+	return rootp;
+}
+
+/** Obtain the usage statistics for the pmem object
+ *
+ *  \param	pool[IN]		Pointer to the persistent object.
+ *  \param	curr_allocated[IN|OUT]	Total bytes currently allocated
+ *
+ *  \return	zero on success and non-zero on failure.
+ */
+int
+umempobj_get_heapusage(struct umem_pool *ph_p, daos_size_t *curr_allocated)
+{
+	int rc;
+	PMEMobjpool *pop = (PMEMobjpool *)ph_p;
+
+	rc = pmemobj_ctl_get(pop, "stats.heap.curr_allocated",
+			     curr_allocated);
+	return rc;
+}
+
+/** Log fragmentation related info for the pool.
+ *
+ *  \param	pool[IN]		Pointer to the persistent object.
+ *
+ */
+void
+umempobj_log_fraginfo(struct umem_pool *ph_p)
+{
+	daos_size_t scm_used, scm_active;
+	PMEMobjpool *pop = (PMEMobjpool *)ph_p;
+
+	pmemobj_ctl_get(pop, "stats.heap.run_allocated", &scm_used);
+	pmemobj_ctl_get(pop, "stats.heap.run_active", &scm_active);
+
+	D_ERROR("Fragmentation info, run_allocated: "
+	  DF_U64", run_active: "DF_U64"\n", scm_used, scm_active);
+}
+
+/** Create a slab within the pool.
+ *
+ *  \param	pool[IN]		Pointer to the persistent object.
+ *  \param	slab[IN]		Slab description
+ *
+ *  \return	zero on success, non-zero on failure.
+ */
+int
+umempobj_set_slab_desc(struct umem_pool *ph_p, struct umem_slab_desc *slab)
+{
+	int rc;
+	struct pobj_alloc_class_desc pmemslab;
+	PMEMobjpool *pop = (PMEMobjpool *)ph_p;
+
+	pmemslab.unit_size = slab->unit_size;
+	pmemslab.alignment = 0;
+	pmemslab.units_per_block = 1000;
+	pmemslab.header_type = POBJ_HEADER_NONE;
+	pmemslab.class_id = slab->class_id;
+	rc = pmemobj_ctl_set(pop, "heap.alloc_class.new.desc", &pmemslab);
+	/* update with the new slab id */
+	slab->class_id = pmemslab.class_id;
+	return rc;
+}
+
+static inline uint64_t
+umem_slab_flags(struct umem_instance *umm, unsigned int slab_id)
+{
+	D_ASSERT(slab_id < UMM_SLABS_CNT);
+	return POBJ_CLASS_ID(umm->umm_slabs[slab_id].class_id);
+}
+
+bool
+umem_tx_none(void)
+{
+	return (pmemobj_tx_stage() == TX_STAGE_NONE);
+}
+
+bool
+umem_tx_inprogress(void)
+{
+	return (pmemobj_tx_stage() == TX_STAGE_WORK);
+}
+
 /** Convert an offset to an id.   No invalid flags will be maintained
  *  in the conversion.
  *
@@ -97,10 +303,18 @@ pmem_tx_free(struct umem_instance *umm, umem_off_t umoff)
 }
 
 static umem_off_t
-pmem_tx_alloc(struct umem_instance *umm, size_t size, uint64_t flags,
-	      unsigned int type_num)
+pmem_tx_alloc(struct umem_instance *umm, size_t size, int slab_id,
+	      uint64_t flags, unsigned int type_num)
 {
-	return umem_id2off(umm, pmemobj_tx_xalloc(size, type_num, flags));
+	uint64_t pflags = 0;
+
+	if (flags & UMEM_FLAG_ZERO)
+		pflags |= POBJ_FLAG_ZERO;
+	if (flags & UMEM_FLAG_NO_FLUSH)
+		pflags |= POBJ_FLAG_NO_FLUSH;
+	if (slab_id != SLAB_ID_ANY)
+		pflags |= umem_slab_flags(umm, slab_id);
+	return umem_id2off(umm, pmemobj_tx_xalloc(size, type_num, pflags));
 }
 
 static int
@@ -118,9 +332,13 @@ pmem_tx_xadd(struct umem_instance *umm, umem_off_t umoff, uint64_t offset,
 	     size_t size, uint64_t flags)
 {
 	int	rc;
+	uint64_t pflags = 0;
+
+	if (flags & UMEM_XADD_NO_SNAPSHOT)
+		pflags |= POBJ_XADD_NO_SNAPSHOT;
 
 	rc = pmemobj_tx_xadd_range(umem_off2id(umm, umoff), offset, size,
-				   flags);
+				   pflags);
 	return rc ? umem_tx_errno(rc) : 0;
 }
 
@@ -230,14 +448,14 @@ static int
 pmem_tx_begin(struct umem_instance *umm, struct umem_tx_stage_data *txd)
 {
 	int rc;
+	PMEMobjpool *pop = (PMEMobjpool *)umm->umm_pool;
 
 	if (txd != NULL) {
 		D_ASSERT(txd->txd_magic == UMEM_TX_DATA_MAGIC);
-		rc = pmemobj_tx_begin(umm->umm_pool, NULL, TX_PARAM_CB,
-				      pmem_stage_callback, txd, TX_PARAM_NONE);
+		rc = pmemobj_tx_begin(pop, NULL, TX_PARAM_CB, pmem_stage_callback,
+				      txd, TX_PARAM_NONE);
 	} else {
-		rc = pmemobj_tx_begin(umm->umm_pool, NULL,
-				      TX_PARAM_NONE);
+		rc = pmemobj_tx_begin(pop, NULL, TX_PARAM_NONE);
 	}
 
 	if (rc != 0) {
@@ -266,23 +484,27 @@ static void
 pmem_defer_free(struct umem_instance *umm, umem_off_t off,
 		struct pobj_action *act)
 {
+	PMEMobjpool *pop = (PMEMobjpool *)umm->umm_pool;
 	PMEMoid	id = umem_off2id(umm, off);
 
-	pmemobj_defer_free(umm->umm_pool, id, act);
+	pmemobj_defer_free(pop, id, act);
 }
 
 static umem_off_t
 pmem_reserve(struct umem_instance *umm, struct pobj_action *act, size_t size,
 	     unsigned int type_num)
 {
-	return umem_id2off(umm,
-			   pmemobj_reserve(umm->umm_pool, act, size, type_num));
+	PMEMobjpool *pop = (PMEMobjpool *)umm->umm_pool;
+
+	return umem_id2off(umm, pmemobj_reserve(pop, act, size, type_num));
 }
 
 static void
 pmem_cancel(struct umem_instance *umm, struct pobj_action *actv, int actv_cnt)
 {
-	pmemobj_cancel(umm->umm_pool, actv, actv_cnt);
+	PMEMobjpool *pop = (PMEMobjpool *)umm->umm_pool;
+
+	pmemobj_cancel(pop, actv, actv_cnt);
 }
 
 static int
@@ -293,6 +515,49 @@ pmem_tx_publish(struct umem_instance *umm, struct pobj_action *actv,
 
 	rc = pmemobj_tx_publish(actv, actv_cnt);
 	return rc ? umem_tx_errno(rc) : 0;
+}
+
+static void *
+pmem_atomic_copy(struct umem_instance *umm, void *dest, const void *src,
+		 size_t len)
+{
+	PMEMobjpool *pop = (PMEMobjpool *)umm->umm_pool;
+
+	return pmemobj_memcpy_persist(pop, dest, src, len);
+}
+
+static umem_off_t
+pmem_atomic_alloc(struct umem_instance *umm, size_t size,
+		  unsigned int type_num)
+{
+	PMEMoid oid;
+	PMEMobjpool *pop = (PMEMobjpool *)umm->umm_pool;
+	int rc;
+
+	rc = pmemobj_alloc(pop, &oid, size, type_num, NULL, NULL);
+	if (rc)
+		return UMOFF_NULL;
+	return umem_id2off(umm, oid);
+}
+
+static int
+pmem_atomic_free(struct umem_instance *umm, umem_off_t umoff)
+{
+	if (!UMOFF_IS_NULL(umoff)) {
+		PMEMoid oid;
+
+		oid = umem_off2id(umm, umoff);
+		pmemobj_free(&oid);
+	}
+	return 0;
+}
+
+static void
+pmem_atomic_flush(struct umem_instance *umm, void *addr, size_t len)
+{
+	PMEMobjpool *pop = (PMEMobjpool *)umm->umm_pool;
+
+	pmemobj_flush(pop, addr, len);
 }
 
 static int
@@ -310,17 +575,17 @@ pmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 		return -DER_INVAL;
 
 	switch (stage) {
-	case TX_STAGE_ONCOMMIT:
+	case UMEM_STAGE_ONCOMMIT:
 		pvec = &txd->txd_commit_vec;
 		cnt = &txd->txd_commit_cnt;
 		cnt_max = &txd->txd_commit_max;
 		break;
-	case TX_STAGE_ONABORT:
+	case UMEM_STAGE_ONABORT:
 		pvec = &txd->txd_abort_vec;
 		cnt = &txd->txd_abort_cnt;
 		cnt_max = &txd->txd_abort_max;
 		break;
-	case TX_STAGE_NONE:
+	case UMEM_STAGE_NONE:
 		pvec = &txd->txd_end_vec;
 		cnt = &txd->txd_end_cnt;
 		cnt_max = &txd->txd_end_max;
@@ -371,6 +636,10 @@ static umem_ops_t	pmem_ops = {
 	.mo_defer_free		= pmem_defer_free,
 	.mo_cancel		= pmem_cancel,
 	.mo_tx_publish		= pmem_tx_publish,
+	.mo_atomic_copy		= pmem_atomic_copy,
+	.mo_atomic_alloc	= pmem_atomic_alloc,
+	.mo_atomic_free		= pmem_atomic_free,
+	.mo_atomic_flush	= pmem_atomic_flush,
 	.mo_tx_add_callback	= pmem_tx_add_callback,
 };
 
@@ -402,10 +671,10 @@ vmem_free(struct umem_instance *umm, umem_off_t umoff)
 }
 
 umem_off_t
-vmem_alloc(struct umem_instance *umm, size_t size, uint64_t flags,
-	   unsigned int type_num)
+vmem_alloc(struct umem_instance *umm, size_t size, int slab_id,
+	   uint64_t flags, unsigned int type_num)
 {
-	return (uint64_t)((flags & VMEM_FLAG_ZERO) ?
+	return (uint64_t)((flags & UMEM_FLAG_ZERO) ?
 			  calloc(1, size) : malloc(size));
 }
 
@@ -420,9 +689,9 @@ vmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 	 * vmem doesn't support transaction, so we just execute the commit
 	 * callback & end callback instantly and drop the abort callback.
 	 */
-	if (stage == VT_STAGE_ONCOMMIT || stage == VT_STAGE_NONE)
+	if (stage == UMEM_STAGE_ONCOMMIT || stage == UMEM_STAGE_NONE)
 		cb(data, false);
-	else if (stage == VT_STAGE_ONABORT)
+	else if (stage == UMEM_STAGE_ONABORT)
 		cb(data, true);
 	else
 		return -DER_INVAL;
@@ -473,6 +742,7 @@ set_offsets(struct umem_instance *umm)
 #ifdef DAOS_PMEM_BUILD
 	char		*root;
 	PMEMoid		 root_oid;
+	PMEMobjpool *pop = (PMEMobjpool *)umm->umm_pool;
 #endif
 	if (umm->umm_id == UMEM_CLASS_VMEM) {
 		umm->umm_base = 0;
@@ -481,7 +751,7 @@ set_offsets(struct umem_instance *umm)
 	}
 
 #ifdef DAOS_PMEM_BUILD
-	root_oid = pmemobj_root(umm->umm_pool, 0);
+	root_oid = pmemobj_root(pop, 0);
 	D_ASSERTF(!OID_IS_NULL(root_oid),
 		  "You must call pmemobj_root before umem_class_init\n");
 
@@ -525,7 +795,7 @@ umem_class_init(struct umem_attr *uma, struct umem_instance *umm)
 		-DER_NOMEM : -DER_NOSPACE;
 #ifdef DAOS_PMEM_BUILD
 	memcpy(umm->umm_slabs, uma->uma_slabs,
-	       sizeof(struct pobj_alloc_class_desc) * UMM_SLABS_CNT);
+	       sizeof(struct umem_slab_desc) * UMM_SLABS_CNT);
 #endif
 
 	set_offsets(umm);
@@ -611,3 +881,141 @@ umem_fini_txd(struct umem_tx_stage_data *txd)
 		txd->txd_end_max = 0;
 	}
 }
+
+#ifdef	DAOS_PMEM_BUILD
+struct umem_rsrvd_act {
+	unsigned int		rs_actv_cnt;
+	unsigned int		rs_actv_at;
+	struct pobj_action	rs_actv[0];
+
+};
+
+int
+umem_rsrvd_act_cnt(struct umem_rsrvd_act *rsrvd_act)
+{
+	if (rsrvd_act == NULL)
+		return 0;
+	return rsrvd_act->rs_actv_at;
+}
+
+int
+umem_rsrvd_act_alloc(struct umem_rsrvd_act **rsrvd_act, int cnt)
+{
+	size_t size;
+
+	size = sizeof(struct umem_rsrvd_act) +
+		sizeof(struct pobj_action) * cnt;
+	D_ALLOC(*rsrvd_act, size);
+	if (*rsrvd_act == NULL)
+		return -DER_NOMEM;
+
+	(*rsrvd_act)->rs_actv_cnt = cnt;
+	return 0;
+}
+
+int
+umem_rsrvd_act_realloc(struct umem_rsrvd_act **rsrvd_act, int max_cnt)
+{
+	if (*rsrvd_act == NULL ||
+	    (*rsrvd_act)->rs_actv_cnt < max_cnt) {
+		struct umem_rsrvd_act    *tmp_rsrvd_act;
+		size_t                   size;
+
+		size = sizeof(struct umem_rsrvd_act) *
+			sizeof(struct pobj_action) * max_cnt;
+
+		D_REALLOC_Z(tmp_rsrvd_act, *rsrvd_act, size);
+		if (tmp_rsrvd_act == NULL)
+			return -DER_NOMEM;
+
+		*rsrvd_act = tmp_rsrvd_act;
+		(*rsrvd_act)->rs_actv_cnt = max_cnt;
+	}
+	return 0;
+}
+
+int
+umem_rsrvd_act_free(struct umem_rsrvd_act **rsrvd_act)
+{
+	D_FREE(*rsrvd_act);
+	return 0;
+}
+
+umem_off_t
+umem_reserve(struct umem_instance *umm, struct umem_rsrvd_act *rsrvd_act,
+	     size_t size)
+{
+	if (umm->umm_ops->mo_reserve) {
+		struct pobj_action	*act;
+		umem_off_t		 off;
+
+		D_ASSERT(rsrvd_act != NULL);
+		D_ASSERT(rsrvd_act->rs_actv_cnt > rsrvd_act->rs_actv_at);
+
+		act = &rsrvd_act->rs_actv[rsrvd_act->rs_actv_at];
+		off = umm->umm_ops->mo_reserve(umm, act, size,
+					       UMEM_TYPE_ANY);
+		if (!UMOFF_IS_NULL(off))
+			rsrvd_act->rs_actv_at++;
+		D_ASSERTF(umem_off2flags(off) == 0,
+			  "Invalid assumption about allocnot using flag bits");
+		D_DEBUG(DB_MEM,
+			"reserve %s umoff=" UMOFF_PF " size=%zu base=" DF_X64
+			" pool_uuid_lo=" DF_X64 "\n",
+			(umm)->umm_name, UMOFF_P(off), (size_t)(size),
+			(umm)->umm_base, (umm)->umm_pool_uuid_lo);
+		return off;
+	}
+	return UMOFF_NULL;
+}
+
+void
+umem_defer_free(struct umem_instance *umm, umem_off_t off,
+		struct umem_rsrvd_act *rsrvd_act)
+{
+	D_ASSERT(rsrvd_act->rs_actv_at < rsrvd_act->rs_actv_cnt);
+	D_DEBUG(DB_MEM,
+		"Defer free %s umoff=" UMOFF_PF "base=" DF_X64
+		" pool_uuid_lo=" DF_X64 "\n",
+		(umm)->umm_name, UMOFF_P(off), (umm)->umm_base,
+		(umm)->umm_pool_uuid_lo);
+	if (umm->umm_ops->mo_defer_free) {
+		struct pobj_action      *act;
+
+		act = &rsrvd_act->rs_actv[rsrvd_act->rs_actv_at];
+		umm->umm_ops->mo_defer_free(umm, off, act);
+		rsrvd_act->rs_actv_at++;
+	} else {
+		/** Go ahead and free immediately.  The purpose of this
+		 * function is to allow reserve/publish pair to execute
+		 * on commit
+		 */
+		umem_free(umm, off);
+	}
+}
+
+void
+umem_cancel(struct umem_instance *umm, struct umem_rsrvd_act *rsrvd_act)
+{
+	if (rsrvd_act == NULL || rsrvd_act->rs_actv_at == 0)
+		return;
+	D_ASSERT(rsrvd_act->rs_actv_at <= rsrvd_act->rs_actv_cnt);
+	if (umm->umm_ops->mo_cancel)
+		umm->umm_ops->mo_cancel(umm, rsrvd_act->rs_actv, rsrvd_act->rs_actv_at);
+	rsrvd_act->rs_actv_at = 0;
+}
+
+int
+umem_tx_publish(struct umem_instance *umm, struct umem_rsrvd_act *rsrvd_act)
+{
+	int rc = 0;
+
+	if (rsrvd_act == NULL || rsrvd_act->rs_actv_at == 0)
+		return 0;
+	D_ASSERT(rsrvd_act->rs_actv_at <= rsrvd_act->rs_actv_cnt);
+	if (umm->umm_ops->mo_tx_publish)
+		rc = umm->umm_ops->mo_tx_publish(umm, rsrvd_act->rs_actv, rsrvd_act->rs_actv_at);
+	rsrvd_act->rs_actv_at = 0;
+	return rc;
+}
+#endif

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -722,7 +722,7 @@ static inline void
 bio_yield(void)
 {
 #ifdef DAOS_PMEM_BUILD
-	D_ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
+	D_ASSERT(umem_tx_none());
 #endif
 	ABT_thread_yield();
 }

--- a/src/vea/tests/vea_stress.c
+++ b/src/vea/tests/vea_stress.c
@@ -584,7 +584,7 @@ vs_stop_run(struct vea_stress_pool *vs_pool, int rc)
 		last_print_ts ? now - last_print_ts : 0);
 	last_print_ts = now;
 
-	ret = pmemobj_ctl_get(vs_pool->vsp_umm.umm_pool, "stats.heap.curr_allocated", &heap_bytes);
+	ret = umempobj_get_heapusage(vs_pool->vsp_umm.umm_pool, &heap_bytes);
 	if (ret) {
 		fprintf(stderr, "failed to get heap usage\n");
 		return stop;
@@ -724,7 +724,7 @@ vs_teardown_pool(struct vea_stress_pool *vs_pool)
 		vea_unload(vs_pool->vsp_vsi);
 
 	if (vs_pool->vsp_umm.umm_pool != NULL)
-		pmemobj_close(vs_pool->vsp_umm.umm_pool);
+		umempobj_close(vs_pool->vsp_umm.umm_pool);
 
 	umem_fini_txd(&vs_pool->vsp_txd);
 	D_FREE(vs_pool);
@@ -735,13 +735,12 @@ vs_setup_pool(void)
 {
 	struct vea_stress_pool	*vs_pool;
 	struct umem_attr	 uma = { 0 };
-	PMEMoid			 root;
 	void			*root_addr;
 	struct vea_unmap_context unmap_ctxt = { 0 };
 	struct vea_attr		 attr;
 	struct vea_stat		 stat;
 	uint64_t		 load_time;
-	int			 rc, enable_stats = 1;
+	int			 rc;
 
 	D_ALLOC(vs_pool, vs_arg_size());
 	if (vs_pool == NULL) {
@@ -759,29 +758,25 @@ vs_setup_pool(void)
 
 	uma.uma_id = UMEM_CLASS_PMEM;
 	if (loading_test) {
-		uma.uma_pool = pmemobj_open(pool_file, "vea_stress");
+		uma.uma_pool = umempobj_open(pool_file, "vea_stress",
+					     UMEMPOBJ_ENABLE_STATS);
 		if (uma.uma_pool == NULL) {
-			fprintf(stderr, "failed to open pmemobj pool\n");
+			fprintf(stderr, "failed to open pobj pool\n");
 			goto error;
 		}
 	} else {
 		unlink(pool_file);
-		uma.uma_pool = pmemobj_create(pool_file, "vea_stress", heap_size, 0666);
+		uma.uma_pool = umempobj_create(pool_file, "vea_stress",
+				    UMEMPOBJ_ENABLE_STATS, heap_size, 0666);
 		if (uma.uma_pool == NULL) {
-			fprintf(stderr, "failed to create pmemobj pool\n");
+			fprintf(stderr, "failed to create pobj pool\n");
 			goto error;
 		}
 	}
 
-	rc = pmemobj_ctl_set(uma.uma_pool, "stats.enabled", &enable_stats);
-	if (rc) {
-		fprintf(stderr, "failed to enable pmemobj stats\n");
-		goto error;
-	}
-
-	root = pmemobj_root(uma.uma_pool, vs_root_size());
-	if (OID_IS_NULL(root)) {
-		fprintf(stderr, "failed to get pmemobj pool root\n");
+	root_addr = umempobj_get_rootptr(uma.uma_pool, vs_root_size());
+	if (root_addr == NULL) {
+		fprintf(stderr, "failed to get pobj pool root\n");
 		goto error;
 	}
 
@@ -792,7 +787,6 @@ vs_setup_pool(void)
 	}
 	uma.uma_pool = NULL;
 
-	root_addr = pmemobj_direct(root);
 	vs_pool->vsp_vsd = root_addr;
 	root_addr += sizeof(struct vea_space_df);
 
@@ -836,7 +830,7 @@ vs_setup_pool(void)
 	return vs_pool;
 error:
 	if (uma.uma_pool != NULL)
-		pmemobj_close(uma.uma_pool);
+		umempobj_close(uma.uma_pool);
 	vs_teardown_pool(vs_pool);
 	return NULL;
 }

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -405,7 +405,6 @@ ut_setup(struct vea_ut_args *test_args)
 {
 	daos_size_t pool_size = (50 << 20); /* 50MB */
 	struct umem_attr uma = {0};
-	PMEMoid root;
 	void *root_addr;
 	int rc, i;
 
@@ -415,17 +414,17 @@ ut_setup(struct vea_ut_args *test_args)
 	unlink(pool_file);
 
 	uma.uma_id = UMEM_CLASS_PMEM;
-	uma.uma_pool = pmemobj_create(pool_file, "vea_ut",
+	uma.uma_pool = umempobj_create(pool_file, "vea_ut", 0,
 					     pool_size, 0666);
 	if (uma.uma_pool == NULL) {
 		fprintf(stderr, "create pmemobj pool error\n");
 		return -1;
 	}
 
-	root = pmemobj_root(uma.uma_pool,
+	root_addr = umempobj_get_rootptr(uma.uma_pool,
 			    sizeof(struct vea_space_df) +
 			    sizeof(struct vea_hint_df) * IO_STREAM_CNT);
-	if (OID_IS_NULL(root)) {
+	if (root_addr == NULL) {
 		fprintf(stderr, "get root error\n");
 		rc = -1;
 		goto error;
@@ -438,7 +437,6 @@ ut_setup(struct vea_ut_args *test_args)
 	}
 
 
-	root_addr = pmemobj_direct(root);
 	test_args->vua_md = root_addr;
 	root_addr += sizeof(struct vea_space_df);
 
@@ -455,7 +453,7 @@ ut_setup(struct vea_ut_args *test_args)
 	umem_init_txd(&test_args->vua_txd);
 	return 0;
 error:
-	pmemobj_close(uma.uma_pool);
+	umempobj_close(uma.uma_pool);
 	test_args->vua_umm.umm_pool = NULL;
 
 	return rc;
@@ -507,7 +505,7 @@ ut_teardown(struct vea_ut_args *test_args)
 	}
 
 	if (test_args->vua_umm.umm_pool != NULL) {
-		pmemobj_close(test_args->vua_umm.umm_pool);
+		umempobj_close(test_args->vua_umm.umm_pool);
 		test_args->vua_umm.umm_pool = NULL;
 	}
 	umem_fini_txd(&test_args->vua_txd);

--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -249,7 +249,7 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 	uint64_t *blk_off, found_end, vfe_end;
 	int rc, opc = BTR_PROBE_LE;
 
-	D_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK ||
+	D_ASSERT(umem_tx_inprogress() ||
 		 vsi->vsi_umem->umm_id == UMEM_CLASS_VMEM);
 	D_ASSERT(vfe->vfe_blk_off != VEA_HINT_OFF_INVAL);
 	D_ASSERT(vfe->vfe_blk_cnt > 0);

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -479,7 +479,7 @@ flush_internal(struct vea_space_info *vsi, bool force, uint32_t cur_time, d_sg_l
 	d_iov_t			*unmap_iov;
 	int			 i, rc = 0;
 
-	D_ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
+	D_ASSERT(umem_tx_none());
 	D_ASSERT(unmap_sgl->sg_nr_out == 0);
 
 	d_list_for_each_entry_safe(entry, tmp, &vsi->vsi_agg_lru, ve_link) {
@@ -571,7 +571,7 @@ trigger_aging_flush(struct vea_space_info *vsi, bool force, uint32_t nr_flush,
 	int		 rc;
 
 	D_ASSERT(nr_flush > 0);
-	if (pmemobj_tx_stage() != TX_STAGE_NONE) {
+	if (!umem_tx_none()) {
 		rc = -DER_INVAL;
 		goto out;
 	}
@@ -637,7 +637,7 @@ schedule_aging_flush(struct vea_space_info *vsi)
 	 * Perform the flush in transaction end callback, since the flush operation
 	 * could yield on blob unmap.
 	 */
-	rc = umem_tx_add_callback(vsi->vsi_umem, vsi->vsi_txd, TX_STAGE_NONE,
+	rc = umem_tx_add_callback(vsi->vsi_umem, vsi->vsi_txd, UMEM_STAGE_NONE,
 				  flush_end_cb, vsi);
 	if (rc) {
 		D_ERROR("Add transaction end callback error "DF_RC"\n", DP_RC(rc));

--- a/src/vea/vea_hint.c
+++ b/src/vea/vea_hint.c
@@ -76,7 +76,7 @@ hint_tx_publish(struct umem_instance *umm, struct vea_hint_context *hint,
 {
 	int	rc;
 
-	D_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK ||
+	D_ASSERT(umem_tx_inprogress() ||
 		 umm->umm_id == UMEM_CLASS_VMEM);
 
 	if (hint == NULL)

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -3922,7 +3922,7 @@ evt_feats_set(struct evt_root *root, struct umem_instance *umm, uint64_t feats)
 		if (rc != 0)
 			return rc;
 		rc = umem_tx_xadd_ptr(umm, &root->tr_feats, sizeof(root->tr_feats),
-				      POBJ_XADD_NO_SNAPSHOT);
+				      UMEM_XADD_NO_SNAPSHOT);
 	}
 
 	if (rc == 0)

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include <setjmp.h>
 #include <cmocka.h>
 #include <daos/common.h>
 #include <daos/object.h>

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -176,7 +176,7 @@ vos_tx_publish(struct dtx_handle *dth, bool publish)
 {
 	struct vos_container	*cont = vos_hdl2cont(dth->dth_coh);
 	struct dtx_rsrvd_uint	*dru;
-	struct vos_rsrvd_scm	*scm;
+	struct umem_rsrvd_act	*scm;
 	int			 rc;
 	int			 i;
 
@@ -255,7 +255,7 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm)
 
 int
 vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
-	   struct vos_rsrvd_scm **rsrvd_scmp, d_list_t *nvme_exts,
+	   struct umem_rsrvd_act **rsrvd_scmp, d_list_t *nvme_exts,
 	   bool started, int err)
 {
 	struct dtx_handle	*dth = dth_in;

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -54,7 +54,7 @@ dtx_memcpy_nodrain(struct umem_instance *umm, void *dest, const void *src,
 		   size_t size)
 {
 	if (DAOS_ON_VALGRIND)
-		umem_tx_xadd_ptr(umm, dest, size, POBJ_XADD_NO_SNAPSHOT);
+		umem_tx_xadd_ptr(umm, dest, size, UMEM_XADD_NO_SNAPSHOT);
 
 	pmem_memcpy_nodrain(dest, src, size);
 }
@@ -2460,7 +2460,7 @@ vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch)
 		       obj->obj_sync_epoch, epoch, DP_UOID(oid));
 
 		obj->obj_sync_epoch = epoch;
-		pmemobj_memcpy_persist(vos_cont2umm(cont)->umm_pool,
+		umem_atomic_copy(vos_cont2umm(cont),
 				       &obj->obj_df->vo_sync, &epoch,
 				       sizeof(obj->obj_df->vo_sync));
 	}

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -463,8 +463,8 @@ gc_bin_add_item(struct umem_instance *umm, struct vos_gc_bin_df *bin,
 	 */
 	it = &bag->bag_items[bag->bag_item_last];
 	if (DAOS_ON_VALGRIND)
-		umem_tx_xadd_ptr(umm, it, sizeof(*it), POBJ_XADD_NO_SNAPSHOT);
-	pmemobj_memcpy_persist(umm->umm_pool, it, item, sizeof(*it));
+		umem_tx_xadd_ptr(umm, it, sizeof(*it), UMEM_XADD_NO_SNAPSHOT);
+	umem_atomic_copy(umm, it, item, sizeof(*it));
 
 	last = bag->bag_item_last + 1;
 	if (last == bin->bin_bag_size)

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -317,7 +317,7 @@ vos_ilog_ts_ignore(struct umem_instance *umm, struct ilog_df *ilog)
 		return;
 
 	umem_tx_xadd_ptr(umm, ilog_ts_idx_get(ilog), sizeof(int),
-			 POBJ_XADD_NO_SNAPSHOT);
+			 UMEM_XADD_NO_SNAPSHOT);
 }
 
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1083,13 +1083,6 @@ void
 vos_evt_desc_cbs_init(struct evt_desc_cbs *cbs, struct vos_pool *pool,
 		      daos_handle_t coh);
 
-/* Reserve SCM through umem_reserve() for a PMDK transaction */
-struct vos_rsrvd_scm {
-	unsigned int		rs_actv_cnt;
-	unsigned int		rs_actv_at;
-	struct pobj_action	rs_actv[0];
-};
-
 int
 vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm);
 
@@ -1109,7 +1102,7 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm);
  */
 int
 vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
-	   struct vos_rsrvd_scm **rsrvd_scmp, d_list_t *nvme_exts, bool started,
+	   struct umem_rsrvd_act **rsrvd_actp, d_list_t *nvme_exts, bool started,
 	   int err);
 
 /* vos_obj.c */
@@ -1140,10 +1133,10 @@ void
 vos_dedup_invalidate(struct vos_pool *pool);
 
 umem_off_t
-vos_reserve_scm(struct vos_container *cont, struct vos_rsrvd_scm *rsrvd_scm,
+vos_reserve_scm(struct vos_container *cont, struct umem_rsrvd_act *rsrvd_scm,
 		daos_size_t size);
 int
-vos_publish_scm(struct vos_container *cont, struct vos_rsrvd_scm *rsrvd_scm,
+vos_publish_scm(struct vos_container *cont, struct umem_rsrvd_act *rsrvd_scm,
 		bool publish);
 int
 vos_reserve_blocks(struct vos_container *cont, d_list_t *rsrvd_nvme,
@@ -1309,8 +1302,7 @@ vos_slab_alloc(struct umem_instance *umm, int size, int slab_id)
 		  umem_slab_registered(umm, slab_id),
 		  slab_id, size, umem_slab_usize(umm, slab_id));
 
-	return umem_alloc_verb(umm, umem_slab_flags(umm, slab_id) |
-					POBJ_FLAG_ZERO, size);
+	return umem_alloc_verb(umm, slab_id, UMEM_FLAG_ZERO, size);
 }
 
 /* vos_space.c */

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -19,6 +19,7 @@
 #include "vos_internal.h"
 #include "evt_priv.h"
 #include "vos_policy.h"
+#include <daos/mem.h>
 
 /** I/O context */
 struct vos_io_context {
@@ -45,7 +46,7 @@ struct vos_io_context {
 	unsigned int		 ic_sgl_at;
 	unsigned int		 ic_iov_at;
 	/** reserved SCM extents */
-	struct vos_rsrvd_scm	*ic_rsrvd_scm;
+	struct umem_rsrvd_act	*ic_rsrvd_scm;
 	/** reserved offsets for SCM update */
 	umem_off_t		*ic_umoffs;
 	unsigned int		 ic_umoffs_cnt;
@@ -516,8 +517,8 @@ static void
 vos_ioc_reserve_fini(struct vos_io_context *ioc)
 {
 	if (ioc->ic_rsrvd_scm != NULL) {
-		D_ASSERT(ioc->ic_rsrvd_scm->rs_actv_at == 0);
-		D_FREE(ioc->ic_rsrvd_scm);
+		D_ASSERT(umem_rsrvd_act_cnt(ioc->ic_rsrvd_scm) == 0);
+		umem_rsrvd_act_free(&ioc->ic_rsrvd_scm);
 	}
 
 	D_ASSERT(d_list_empty(&ioc->ic_blk_exts));
@@ -528,8 +529,7 @@ vos_ioc_reserve_fini(struct vos_io_context *ioc)
 static int
 vos_ioc_reserve_init(struct vos_io_context *ioc, struct dtx_handle *dth)
 {
-	struct vos_rsrvd_scm	*scm;
-	size_t			 size;
+	struct umem_rsrvd_act	*scm;
 	int			 total_acts = 0;
 	int			 i;
 
@@ -549,25 +549,20 @@ vos_ioc_reserve_init(struct vos_io_context *ioc, struct dtx_handle *dth)
 	if (vos_ioc2umm(ioc)->umm_ops->mo_reserve == NULL)
 		return 0;
 
-	size = sizeof(*ioc->ic_rsrvd_scm) +
-		sizeof(struct pobj_action) * total_acts;
-	D_ALLOC(ioc->ic_rsrvd_scm, size);
+	umem_rsrvd_act_alloc(&ioc->ic_rsrvd_scm, total_acts);
 	if (ioc->ic_rsrvd_scm == NULL)
 		return -DER_NOMEM;
-
-	ioc->ic_rsrvd_scm->rs_actv_cnt = total_acts;
 
 	if (!dtx_is_valid_handle(dth) || dth->dth_deferred == NULL)
 		return 0;
 
 	/** Reserve enough space for any deferred actions */
-	D_ALLOC(scm, size);
+	umem_rsrvd_act_alloc(&scm, total_acts);
 	if (scm == NULL) {
 		D_FREE(ioc->ic_rsrvd_scm);
 		return -DER_NOMEM;
 	}
 
-	scm->rs_actv_cnt = total_acts;
 	dth->dth_deferred[dth->dth_deferred_cnt++] = scm;
 
 	return 0;
@@ -1928,7 +1923,7 @@ vos_recx2irec_size(daos_size_t rsize, struct dcs_csum_info *csum)
 }
 
 umem_off_t
-vos_reserve_scm(struct vos_container *cont, struct vos_rsrvd_scm *rsrvd_scm,
+vos_reserve_scm(struct vos_container *cont, struct umem_rsrvd_act *rsrvd_scm,
 		daos_size_t size)
 {
 	umem_off_t	umoff;
@@ -1936,16 +1931,7 @@ vos_reserve_scm(struct vos_container *cont, struct vos_rsrvd_scm *rsrvd_scm,
 	D_ASSERT(size > 0);
 
 	if (vos_cont2umm(cont)->umm_ops->mo_reserve != NULL) {
-		struct pobj_action *act;
-
-		D_ASSERT(rsrvd_scm != NULL);
-		D_ASSERT(rsrvd_scm->rs_actv_cnt > rsrvd_scm->rs_actv_at);
-
-		act = &rsrvd_scm->rs_actv[rsrvd_scm->rs_actv_at];
-
-		umoff = umem_reserve(vos_cont2umm(cont), act, size);
-		if (!UMOFF_IS_NULL(umoff))
-			rsrvd_scm->rs_actv_at++;
+		umoff = umem_reserve(vos_cont2umm(cont), rsrvd_scm, size);
 	} else {
 		umoff = umem_alloc(vos_cont2umm(cont), size);
 	}
@@ -2004,16 +1990,8 @@ reserve_space(struct vos_io_context *ioc, uint16_t media, daos_size_t size,
 
 		now = daos_gettime_coarse();
 		if (now - ioc->ic_cont->vc_io_nospc_ts > VOS_NOSPC_ERROR_INTVL) {
-			daos_size_t	scm_used = 0, scm_active = 0;
-
-			rc = pmemobj_ctl_get(vos_cont2pool(ioc->ic_cont)->vp_umm.umm_pool,
-					     "stats.heap.run_allocated", &scm_used);
-
-			rc = pmemobj_ctl_get(vos_cont2pool(ioc->ic_cont)->vp_umm.umm_pool,
-					     "stats.heap.run_active", &scm_active);
-
-			D_ERROR("Reserve "DF_U64" from SCM failed, run_allocated: "
-				""DF_U64", run_active: "DF_U64"\n", size, scm_used, scm_active);
+			D_ERROR("Reserve "DF_U64" from SCM failed\n", size);
+			umempobj_log_fraginfo(vos_cont2pool(ioc->ic_cont)->vp_umm.umm_pool);
 			ioc->ic_cont->vc_io_nospc_ts = now;
 		}
 		return -DER_NOSPACE;
@@ -2225,24 +2203,16 @@ dkey_update_begin(struct vos_io_context *ioc)
 }
 
 int
-vos_publish_scm(struct vos_container *cont, struct vos_rsrvd_scm *rsrvd_scm,
+vos_publish_scm(struct vos_container *cont, struct umem_rsrvd_act *rsrvd_scm,
 		bool publish)
 {
 	int	rc = 0;
 
-	if (rsrvd_scm == NULL || rsrvd_scm->rs_actv_at == 0)
-		return 0;
-
-	D_ASSERT(rsrvd_scm->rs_actv_at <= rsrvd_scm->rs_actv_cnt);
-
 	if (publish)
-		rc = umem_tx_publish(vos_cont2umm(cont), rsrvd_scm->rs_actv,
-				     rsrvd_scm->rs_actv_at);
+		rc = umem_tx_publish(vos_cont2umm(cont), rsrvd_scm);
 	else
-		umem_cancel(vos_cont2umm(cont), rsrvd_scm->rs_actv,
-			    rsrvd_scm->rs_actv_at);
+		umem_cancel(vos_cont2umm(cont), rsrvd_scm);
 
-	rsrvd_scm->rs_actv_at = 0;
 	return rc;
 }
 
@@ -2378,7 +2348,7 @@ abort:
 		if (DAOS_ON_VALGRIND)
 			err = umem_tx_xadd_ptr(umem, &ioc->ic_obj->obj_df->vo_max_write,
 					       sizeof(ioc->ic_obj->obj_df->vo_max_write),
-					       POBJ_XADD_NO_SNAPSHOT);
+					       UMEM_XADD_NO_SNAPSHOT);
 		if (err == 0)
 			ioc->ic_obj->obj_df->vo_max_write = ioc->ic_epr.epr_hi;
 	}
@@ -2602,33 +2572,6 @@ vos_set_io_csum(daos_handle_t ioh, struct dcs_iod_csums *csums)
 }
 
 /*
- * XXX Dup these two helper functions for this moment, implement
- * non-transactional umem_alloc/free() later.
- */
-static inline umem_off_t
-umem_id2off(const struct umem_instance *umm, PMEMoid oid)
-{
-	if (OID_IS_NULL(oid))
-		return UMOFF_NULL;
-
-	return oid.off;
-}
-
-static inline PMEMoid
-umem_off2id(const struct umem_instance *umm, umem_off_t umoff)
-{
-	PMEMoid	oid;
-
-	if (UMOFF_IS_NULL(umoff))
-		return OID_NULL;
-
-	oid.pool_uuid_lo = umm->umm_pool_uuid_lo;
-	oid.off = umem_off2offset(umoff);
-
-	return oid;
-}
-
-/*
  * Check if the dedup data is identical to the RDMA data in a temporal
  * allocated DRAM extent, if memcmp fails, allocate a new SCM extent and
  * update it's address in VOS tree, otherwise, keep using the original
@@ -2640,7 +2583,7 @@ vos_dedup_verify(daos_handle_t ioh)
 	struct vos_io_context	*ioc;
 	struct bio_sglist	*bsgl, *bsgl_dup;
 	int			 i, j, rc;
-	PMEMoid			 oid;
+	umem_off_t		 off;
 
 	D_ASSERT(daos_handle_is_valid(ioh));
 	ioc = vos_ioh2ioc(ioh);
@@ -2695,24 +2638,23 @@ vos_dedup_verify(daos_handle_t ioh)
 			 * - Deal with SCM leak on tx commit failure or server
 			 *   crash;
 			 */
-			rc = pmemobj_alloc(vos_ioc2umm(ioc)->umm_pool, &oid,
-					   bio_iov2len(biov), UMEM_TYPE_ANY,
-					   NULL, NULL);
-			if (rc) {
+			off = umem_atomic_alloc(vos_ioc2umm(ioc),
+						bio_iov2len(biov),
+						UMEM_TYPE_ANY);
+			if (off == UMOFF_NULL) {
 				D_ERROR("Failed to alloc "DF_U64" bytes SCM\n",
 					bio_iov2len(biov));
 				goto error;
 			}
 
-			biov->bi_addr.ba_off = umem_id2off(vos_ioc2umm(ioc),
-							   oid);
+			biov->bi_addr.ba_off = off;
 			biov->bi_buf = umem_off2ptr(vos_ioc2umm(ioc),
 						bio_iov2off(biov));
 			BIO_ADDR_CLEAR_DEDUP(&biov->bi_addr);
 
-			pmemobj_memcpy_persist(vos_ioc2umm(ioc)->umm_pool,
-					       biov->bi_buf, biov_dup->bi_buf,
-					       bio_iov2len(biov));
+			umem_atomic_copy(vos_ioc2umm(ioc),
+					 biov->bi_buf, biov_dup->bi_buf,
+					 bio_iov2len(biov));
 
 			/* For error cleanup */
 			biov_dup->bi_addr.ba_off = biov->bi_addr.ba_off;
@@ -2733,9 +2675,8 @@ error:
 			if (bio_iov2off(biov_dup) == UMOFF_NULL)
 				continue;
 
-			oid = umem_off2id(vos_ioc2umm(ioc),
-					  bio_iov2off(biov_dup));
-			pmemobj_free(&oid);
+			umem_atomic_free(vos_ioc2umm(ioc),
+					 bio_iov2off(biov_dup));
 			biov_dup->bi_addr.ba_off = UMOFF_NULL;
 		}
 	}

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -12,7 +12,6 @@
 
 #ifndef _VOS_LAYOUT_H
 #define _VOS_LAYOUT_H
-#include <libpmemobj.h>
 #include <daos/btree.h>
 #include <daos_srv/evtree.h>
 #include <daos_srv/vos_types.h>
@@ -21,15 +20,8 @@
 #include <daos_srv/dtx_srv.h>
 #include "ilog.h"
 
-/**
- * Typed Layout named using Macros from libpmemobj
- * for root object.  We don't need to define the TOIDs for
- * other VOS structures because VOS uses umem_off_t for internal
- * pointers rather than using typed allocations.
- */
-POBJ_LAYOUT_BEGIN(vos_pool_layout);
-POBJ_LAYOUT_ROOT(vos_pool_layout, struct vos_pool_df);
-POBJ_LAYOUT_END(vos_pool_layout);
+/** Layout name for vos pool */
+#define VOS_POOL_LAYOUT         "vos_pool_layout"
 
 struct vos_gc_bin_df {
 	/** address of the first(oldest) bag */

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -498,7 +498,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 					rc = umem_tx_xadd_ptr(vos_cont2umm(cont),
 							      &obj->obj_df->vo_max_write,
 							      sizeof(obj->obj_df->vo_max_write),
-							      POBJ_XADD_NO_SNAPSHOT);
+							      UMEM_XADD_NO_SNAPSHOT);
 				if (rc == 0)
 					obj->obj_df->vo_max_write = epr.epr_hi;
 			}

--- a/src/vos/vos_space.c
+++ b/src/vos/vos_space.c
@@ -125,8 +125,7 @@ vos_space_query(struct vos_pool *pool, struct vos_pool_space *vps, bool slow)
 	NVME_SYS(vps) = POOL_NVME_SYS(pool);
 
 	/* Query SCM used space */
-	rc = pmemobj_ctl_get(pool->vp_umm.umm_pool,
-			     "stats.heap.curr_allocated", &scm_used);
+	rc = umempobj_get_heapusage(pool->vp_umm.umm_pool, &scm_used);
 	if (rc) {
 		rc = umem_tx_errno(rc);
 		D_ERROR("Query pool:"DF_UUID" SCM space failed. "DF_RC"\n",

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -510,7 +510,7 @@ svt_rec_alloc_common(struct btr_instance *tins, struct btr_record *rec,
 
 	D_ASSERT(!UMOFF_IS_NULL(rbund->rb_off));
 	rc = umem_tx_xadd(&tins->ti_umm, rbund->rb_off, vos_irec_msize(rbund),
-			  POBJ_XADD_NO_SNAPSHOT);
+			  UMEM_XADD_NO_SNAPSHOT);
 	if (rc != 0)
 		return rc;
 
@@ -582,8 +582,7 @@ svt_rec_free_internal(struct btr_instance *tins, struct btr_record *rec,
 	struct vos_irec_df	*irec = vos_rec2irec(tins, rec);
 	bio_addr_t		*addr = &irec->ir_ex_addr;
 	struct dtx_handle	*dth = NULL;
-	struct vos_rsrvd_scm	*rsrvd_scm;
-	struct pobj_action	*act;
+	struct umem_rsrvd_act	*rsrvd_scm;
 	int			 i;
 
 	if (UMOFF_IS_NULL(rec->rec_off))
@@ -619,11 +618,8 @@ svt_rec_free_internal(struct btr_instance *tins, struct btr_record *rec,
 	i = dth->dth_op_seq - 1;
 	rsrvd_scm = dth->dth_deferred[i];
 	D_ASSERT(rsrvd_scm != NULL);
-	D_ASSERT(rsrvd_scm->rs_actv_at < rsrvd_scm->rs_actv_cnt);
 
-	act = &rsrvd_scm->rs_actv[rsrvd_scm->rs_actv_at];
-	umem_defer_free(&tins->ti_umm, rec->rec_off, act);
-	rsrvd_scm->rs_actv_at++;
+	umem_defer_free(&tins->ti_umm, rec->rec_off, rsrvd_scm);
 
 	cancel_nvme_exts(addr, dth);
 


### PR DESCRIPTION
This commit addresses two stories. DAOS-11041 enhances the umem
interfaces to cover all the pmemobj interfaces DAOS currently
uses. DAOS-11042 makes use of the new interfaces in other modules.

Signed-off-by: Sherin T George <sherin-t.george@hpe.com>