### PR TITLE
DAOS-10138 githooks: Fix commit cancellations

### DIFF
--- a/utils/githooks/commit-msg.d/10-watermark
+++ b/utils/githooks/commit-msg.d/10-watermark
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-if ! grep 'Required-githooks: true' "$1"; then
+if grep -q '[[:alpha:]]' "$1" && ! grep -q 'Required-githooks: true' "$1"; then
     echo 'Required-githooks: true' >> "$1"
 fi


### PR DESCRIPTION
A naive fix to restore the ability to abort a "git commit" by deleting
_every_ line when editing the commit message.

Additionally, fix the noise from grep invocations by adding "-q".

Doc-only: true
Signed-off-by: Li Wei <wei.g.li@intel.com>