### PR TITLE
DAOS-11193 object: Properly handle object existence check result

### DIFF
--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -3192,7 +3192,7 @@ dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task)
 
 	rc = dc_tx_attach(dc_tx_ptr2hdl(tx), obj, opc, task);
 	obj = NULL;
-	if (rc != 0) {
+	if (rc < 0) {
 		D_ERROR("Fail to attach TX for opc %u: "DF_RC"\n",
 			opc, DP_RC(rc));
 		goto out;


### PR DESCRIPTION
The dc_tx_convert() shares the logic for object existence check
with regular transactional update/punch. For the latter case,
the logic for object existence check returns positive value to
related task sponsor to indicate that do not complete the task
until the checking existence callback. The dc_tx_convert() needs
to follow the same API instead of regarding such positive return
value as failure case.

Signed-off-by: Fan Yong <fan.yong@intel.com>