### PR TITLE
DAOS-11192 test: Increased subprocess pattern check timeout

### DIFF
--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -342,7 +342,7 @@ class IorCommand(ExecutableCommand):
             logger.info(metric)
         logger.info("\n")
 
-    def check_ior_subprocess_status(self, sub_process, command, pattern_timeout=10):
+    def check_ior_subprocess_status(self, sub_process, command, pattern_timeout=20):
         """Verify the status of the command started as a subprocess.
 
         Continually search the subprocess output for a pattern (self.pattern)


### PR DESCRIPTION
Increased subprocess pattern check timeout

Quick-Functional: true
Test-tag: ior_crash
Test-repeat: 10

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>