### PR TITLE
DAOS-10607 rebuild: put rebuild obj cache by tgt id

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -744,8 +744,8 @@ struct tree_cache_root {
 };
 
 int
-obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
-		d_iov_t *val_iov);
+obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, uint64_t tgt_id,
+		daos_unit_oid_t oid, d_iov_t *val_iov);
 int
 obj_tree_destroy(daos_handle_t btr_hdl);
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -102,7 +102,6 @@ struct iter_cont_arg {
 	uuid_t			cont_hdl_uuid;
 	struct tree_cache_root	*cont_root;
 	unsigned int		yield_freq;
-	unsigned int		obj_cnt;
 	uint64_t		*snaps;
 	uint32_t		snap_cnt;
 	uint32_t		version;
@@ -156,8 +155,8 @@ out:
 }
 
 static int
-container_tree_create(daos_handle_t toh, uuid_t uuid,
-		      struct tree_cache_root **rootp)
+obj_tree_create(daos_handle_t toh, void *key, size_t key_size,
+		uint32_t class, uint64_t feats, struct tree_cache_root **rootp)
 {
 	d_iov_t			key_iov;
 	d_iov_t			val_iov;
@@ -166,7 +165,7 @@ container_tree_create(daos_handle_t toh, uuid_t uuid,
 	struct tree_cache_root	*tmp_root;
 	int			rc;
 
-	d_iov_set(&key_iov, uuid, sizeof(uuid_t));
+	d_iov_set(&key_iov, key, key_size);
 	d_iov_set(&val_iov, &root, sizeof(root));
 	rc = dbtree_update(toh, &key_iov, &val_iov);
 	if (rc)
@@ -181,15 +180,14 @@ container_tree_create(daos_handle_t toh, uuid_t uuid,
 
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
-	rc = dbtree_create_inplace(DBTREE_CLASS_NV, BTR_FEAT_DIRECT_KEY, 32,
-				   &uma, &tmp_root->btr_root, &tmp_root->root_hdl);
+	rc = dbtree_create_inplace(class, feats, 32, &uma, &tmp_root->btr_root,
+				   &tmp_root->root_hdl);
 	if (rc) {
 		D_ERROR("failed to create rebuild tree: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
 	*rootp = tmp_root;
-
 out:
 	if (rc < 0)
 		dbtree_delete(toh, BTR_PROBE_EQ, &key_iov, NULL);
@@ -236,7 +234,7 @@ obj_tree_lookup(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
 }
 
 int
-obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
+obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, uint64_t tgt_id, daos_unit_oid_t oid,
 		d_iov_t *val_iov)
 {
 	struct tree_cache_root	*cont_root = NULL;
@@ -255,9 +253,13 @@ obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
 			return rc;
 		}
 
-		D_DEBUG(DB_TRACE, "Create cont "DF_UUID" tree\n",
-			DP_UUID(co_uuid));
-		rc = container_tree_create(toh, co_uuid, &cont_root);
+		D_DEBUG(DB_TRACE, "Create cont "DF_UUID" tree\n", DP_UUID(co_uuid));
+		if (tgt_id != (uint64_t)(-1))
+			rc = obj_tree_create(toh, co_uuid, sizeof(uuid_t), DBTREE_CLASS_IV,
+					     BTR_FEAT_UINT_KEY, &cont_root);
+		else
+			rc = obj_tree_create(toh, co_uuid, sizeof(uuid_t), DBTREE_CLASS_NV,
+					     BTR_FEAT_DIRECT_KEY, &cont_root);
 		if (rc) {
 			D_ERROR("tree_create cont "DF_UUID" failed: "DF_RC"\n",
 				DP_UUID(co_uuid), DP_RC(rc));
@@ -265,6 +267,31 @@ obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
 		}
 	} else {
 		cont_root = tmp_iov.iov_buf;
+	}
+
+	/* Then try to insert the object under the container */
+	if (tgt_id != (uint64_t)(-1)) {
+		d_iov_set(&key_iov, &tgt_id, sizeof(tgt_id));
+		d_iov_set(&tmp_iov, NULL, 0);
+		rc = dbtree_lookup(cont_root->root_hdl, &key_iov, &tmp_iov);
+		if (rc < 0) {
+			if (rc != -DER_NONEXIST) {
+				D_ERROR("lookup tgt "DF_U64" failed: "DF_RC"\n",
+					tgt_id, DP_RC(rc));
+				return rc;
+			}
+
+			D_DEBUG(DB_TRACE, "Create tgt "DF_U64" tree\n", tgt_id);
+			rc = obj_tree_create(cont_root->root_hdl, &tgt_id, sizeof(tgt_id),
+					     DBTREE_CLASS_NV, BTR_FEAT_DIRECT_KEY, &cont_root);
+			if (rc) {
+				D_ERROR("tree_create tgt "DF_U64" failed: "DF_RC"\n",
+					tgt_id, DP_RC(rc));
+				return rc;
+			}
+		} else {
+			cont_root = tmp_iov.iov_buf;
+		}
 	}
 
 	/* Then try to insert the object under the container */
@@ -283,9 +310,9 @@ obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
 		return rc;
 	}
 	cont_root->count++;
-	D_DEBUG(DB_TRACE, "insert "DF_UOID"/"DF_UUID" in"
-		" cont_root %p count %d\n", DP_UOID(oid),
-		DP_UUID(co_uuid), cont_root, cont_root->count);
+	D_DEBUG(DB_TRACE, "insert "DF_UOID"/"DF_UUID"/"DF_U64" in"
+		" root %p count %d\n", DP_UOID(oid),
+		DP_UUID(co_uuid), tgt_id, cont_root, cont_root->count);
 
 	return rc;
 }
@@ -2814,7 +2841,7 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 	val.tgt_idx = tgt_idx;
 
 	d_iov_set(&val_iov, &val, sizeof(struct migrate_obj_val));
-	rc = obj_tree_insert(toh, cont_arg->cont_uuid, oid, &val_iov);
+	rc = obj_tree_insert(toh, cont_arg->cont_uuid, -1, oid, &val_iov);
 	D_DEBUG(DB_REBUILD, "Insert "DF_UUID"/"DF_UUID"/"DF_UOID": ver %u "
 		"generated "DF_U64" "DF_RC"\n", DP_UUID(tls->mpt_pool_uuid),
 		DP_UUID(cont_arg->cont_uuid), DP_UOID(oid), tls->mpt_version,
@@ -2911,7 +2938,6 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 	}
 
 	arg.yield_freq	= DEFAULT_YIELD_FREQ;
-	arg.obj_cnt	= root->count;
 	arg.cont_root	= root;
 	arg.snaps	= snapshots;
 	arg.snap_cnt	= snap_cnt;
@@ -3112,7 +3138,7 @@ migrate_try_obj_insert(struct migrate_pool_tls *tls, uuid_t co_uuid,
 		return rc;
 	}
 
-	rc = obj_tree_insert(toh, co_uuid, oid, &val_iov);
+	rc = obj_tree_insert(toh, co_uuid, -1, oid, &val_iov);
 
 	return rc;
 }

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -273,7 +273,8 @@ struct rebuild_iv {
 
 };
 
-#define DEFAULT_YIELD_FREQ	128
+#define SCAN_YIELD_FREQ		4096
+#define SCAN_OBJ_YIELD_CNT	128
 
 extern struct dss_module_key rebuild_module_key;
 static inline struct rebuild_tls *
@@ -365,4 +366,6 @@ rebuild_notify_ras_end(uuid_t *pool, uint32_t map_ver, char *op_str, int op_rc);
 
 void rebuild_leader_stop(const uuid_t pool_uuid, unsigned int version,
 			 uint32_t rebuild_gen, uint64_t term);
+int
+rebuild_obj_tree_destroy(daos_handle_t btr_hdl);
 #endif /* __REBUILD_INTERNAL_H_ */

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -36,14 +36,13 @@ struct rebuild_send_arg {
 	uuid_t				cont_uuid;
 	unsigned int			*shards;
 	int				count;
-	int				tgt_id;
+	unsigned int			tgt_id;
 };
 
 struct rebuild_obj_val {
 	daos_epoch_t    eph;
 	daos_epoch_t	punched_eph;
 	uint32_t	shard;
-	uint32_t        tgt_id;
 };
 
 static int
@@ -60,13 +59,6 @@ rebuild_obj_fill_buf(daos_handle_t ih, d_iov_t *key_iov,
 	int			count = arg->count;
 	int			rc;
 
-	if (arg->tgt_id != -1 && arg->tgt_id != obj_val->tgt_id) {
-		D_DEBUG(DB_REBUILD, "Current tgt id %d, entry id %d\n",
-			arg->tgt_id, obj_val->tgt_id);
-		return 0;
-	}
-
-	arg->tgt_id = obj_val->tgt_id;
 	D_ASSERT(count < REBUILD_SEND_LIMIT);
 	oids[count] = *oid;
 	ephs[count] = obj_val->eph;
@@ -104,7 +96,6 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 
 	/* re-init the send argument to fill the object buffer */
 	arg->count = 0;
-	arg->tgt_id = -1;
 	rc = dbtree_iterate(root->root_hdl, DAOS_INTENT_MIGRATION, false,
 			    rebuild_obj_fill_buf, arg);
 	if (rc < 0 || arg->count == 0) {
@@ -134,33 +125,19 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 		/* otherwise let's retry */
 		D_DEBUG(DB_REBUILD, DF_UUID" retry send object to tgt_id %d\n",
 			DP_UUID(rpt->rt_pool_uuid), arg->tgt_id);
-		ABT_thread_yield();
+		dss_sleep(0);
 	}
 out:
 	return rc;
 }
 
 static int
-rebuild_cont_send_cb(daos_handle_t ih, d_iov_t *key_iov,
-		     d_iov_t *val_iov, void *data)
+obj_tree_destroy_current_probe(daos_handle_t ih, daos_handle_t cur_hdl, d_iov_t *key_iov)
 {
-	struct rebuild_send_arg	*arg = data;
-	struct tree_cache_root	*root;
-	int			rc;
+	int rc;
 
-	uuid_copy(arg->cont_uuid, *(uuid_t *)key_iov->iov_buf);
-	root = val_iov->iov_buf;
-	while (!dbtree_is_empty(root->root_hdl)) {
-		rc = rebuild_obj_send_cb(root, arg);
-		if (rc < 0) {
-			D_ERROR("rebuild_obj_send_cb failed: "DF_RC"\n",
-				DP_RC(rc));
-			return rc;
-		}
-	}
-
-	rc = dbtree_destroy(root->root_hdl, NULL);
-	if (rc) {
+	rc = dbtree_destroy(cur_hdl, NULL);
+	if (rc && rc != -DER_NO_HDL) {
 		D_ERROR("dbtree_destroy failed: "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
@@ -185,6 +162,90 @@ rebuild_cont_send_cb(daos_handle_t ih, d_iov_t *key_iov,
 	if (rc == -DER_NONEXIST)
 		return 1;
 
+	return rc;
+}
+
+static int
+tgt_tree_destory_cb(daos_handle_t ih, d_iov_t *key_iov,
+		    d_iov_t *val_iov, void *data)
+{
+	struct tree_cache_root *root = val_iov->iov_buf;
+
+	return obj_tree_destroy(root->root_hdl);
+}
+
+int
+rebuild_obj_tree_destroy(daos_handle_t btr_hdl)
+{
+	int	rc;
+
+	rc = dbtree_iterate(btr_hdl, DAOS_INTENT_PUNCH, false,
+			    tgt_tree_destory_cb, NULL);
+	if (rc) {
+		D_ERROR("dbtree iterate failed: "DF_RC"\n", DP_RC(rc));
+		goto out;
+	}
+
+	rc = dbtree_destroy(btr_hdl, NULL);
+out:
+	return rc;
+}
+
+static int
+rebuild_tgt_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *data)
+{
+	struct rebuild_send_arg	*arg = data;
+	d_iov_t			save_key_iov;
+	struct tree_cache_root	*root;
+	uint64_t		tgt_id;
+	int			ret;
+	int			rc = 0;
+
+	tgt_id = *(uint64_t *)key_iov->iov_buf;
+	arg->tgt_id = (unsigned int)tgt_id;
+	root = val_iov->iov_buf;
+	while (!dbtree_is_empty(root->root_hdl)) {
+		rc = rebuild_obj_send_cb(root, arg);
+		if (rc < 0) {
+			D_ERROR("rebuild_obj_send_cb failed: "DF_RC"\n",
+				DP_RC(rc));
+			break;
+		}
+	}
+
+	d_iov_set(&save_key_iov, &tgt_id, sizeof(tgt_id));
+	ret = obj_tree_destroy_current_probe(ih, root->root_hdl, &save_key_iov);
+	if (rc == 0)
+		rc = ret;
+	return rc;
+}
+
+static int
+rebuild_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
+		     d_iov_t *val_iov, void *data)
+{
+	struct rebuild_send_arg	*arg = data;
+	struct tree_cache_root	*root;
+	d_iov_t			save_key_iov;
+	int			ret;
+	int			rc = 0;
+
+	uuid_copy(arg->cont_uuid, *(uuid_t *)key_iov->iov_buf);
+	root = val_iov->iov_buf;
+	while (!dbtree_is_empty(root->root_hdl)) {
+		rc = dbtree_iterate(root->root_hdl, DAOS_INTENT_MIGRATION, false,
+				    rebuild_tgt_iter_cb, arg);
+		if (rc < 0) {
+			D_ERROR("rebuild_tgt_send_cb failed: "DF_RC"\n",
+				DP_RC(rc));
+			break;
+		}
+	}
+
+	d_iov_set(&save_key_iov, arg->cont_uuid, sizeof(uuid_t));
+	ret = obj_tree_destroy_current_probe(ih, root->root_hdl, &save_key_iov);
+	if (rc == 0)
+		rc = ret;
 	return rc;
 }
 
@@ -234,12 +295,12 @@ rebuild_objects_send_ult(void *data)
 
 		/* walk through the rebuild tree and send the rebuild objects */
 		rc = dbtree_iterate(tls->rebuild_tree_hdl, DAOS_INTENT_MIGRATION,
-				    false, rebuild_cont_send_cb, &arg);
+				    false, rebuild_cont_iter_cb, &arg);
 		if (rc < 0) {
 			D_ERROR("dbtree iterate failed: "DF_RC"\n", DP_RC(rc));
 			break;
 		}
-		ABT_thread_yield();
+		dss_sleep(0);
 	}
 
 	D_DEBUG(DB_REBUILD, DF_UUID"/%d objects send finish\n",
@@ -296,10 +357,9 @@ rebuild_object_insert(struct rebuild_tgt_pool_tracker *rpt,
 	val.eph = epoch;
 	val.punched_eph = punched_epoch;
 	val.shard = shard;
-	val.tgt_id = tgt_id;
 	d_iov_set(&val_iov, &val, sizeof(struct rebuild_obj_val));
 	oid.id_shard = shard; /* Convert the OID to rebuilt one */
-	rc = obj_tree_insert(tls->rebuild_tree_hdl, co_uuid, oid, &val_iov);
+	rc = obj_tree_insert(tls->rebuild_tree_hdl, co_uuid, tgt_id, oid, &val_iov);
 	if (rc == -DER_EXIST) {
 		/* If there is reintegrate being restarted due to the failure, then
 		 * it might put multiple shards into the same VOS target, because
@@ -327,6 +387,7 @@ struct rebuild_scan_arg {
 	struct cont_props		co_props;
 	int				snapshot_cnt;
 	uint32_t			yield_freq;
+	int32_t				obj_yield_cnt;
 };
 
 /**
@@ -589,7 +650,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 						DP_RC(rc), DP_UOID(oid));
 					/* Busy - inform iterator and yield */
 					*acts |= VOS_ITER_CB_YIELD;
-					ABT_thread_yield();
+					dss_sleep(0);
 				}
 			} while (rc == -DER_BUSY || rc == -DER_INPROGRESS);
 
@@ -641,6 +702,8 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 
 		if (rc)
 			D_GOTO(out, rc);
+
+		arg->obj_yield_cnt--;
 	}
 
 out:
@@ -653,10 +716,11 @@ out:
 	if (map != NULL)
 		pl_map_decref(map);
 
-	if (--arg->yield_freq == 0) {
+	if (--arg->yield_freq == 0 || arg->obj_yield_cnt <= 0) {
 		D_DEBUG(DB_REBUILD, DF_UUID" rebuild yield: %d\n",
 			DP_UUID(rpt->rt_pool_uuid), rc);
-		arg->yield_freq = DEFAULT_YIELD_FREQ;
+		arg->yield_freq = SCAN_YIELD_FREQ;
+		arg->obj_yield_cnt = SCAN_OBJ_YIELD_CNT;
 		if (rc == 0)
 			dss_sleep(0);
 		*acts |= VOS_ITER_CB_YIELD;
@@ -800,7 +864,8 @@ rebuild_scanner(void *data)
 	param.ip_hdl = child->spc_hdl;
 	param.ip_flags = VOS_IT_FOR_MIGRATION;
 	arg.rpt = rpt;
-	arg.yield_freq = DEFAULT_YIELD_FREQ;
+	arg.yield_freq = SCAN_YIELD_FREQ;
+	arg.obj_yield_cnt = SCAN_OBJ_YIELD_CNT;
 	if (!rebuild_status_match(rpt, PO_COMP_ST_UP)) {
 		rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchor,
 				 rebuild_container_scan_cb, NULL, &arg, NULL);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -104,7 +104,7 @@ rebuild_pool_tls_destroy(struct rebuild_pool_tls *tls)
 	D_DEBUG(DB_REBUILD, "TLS destroy for "DF_UUID" ver %d\n",
 		DP_UUID(tls->rebuild_pool_uuid), tls->rebuild_pool_ver);
 	if (daos_handle_is_valid(tls->rebuild_tree_hdl))
-		obj_tree_destroy(tls->rebuild_tree_hdl);
+		rebuild_obj_tree_destroy(tls->rebuild_tree_hdl);
 	d_list_del(&tls->rebuild_pool_list);
 	D_FREE(tls);
 }


### PR DESCRIPTION
Store scan objects target id, so it does not need excessive
iteration when sending the objects to the new target.

Signed-off-by: Di Wang <di.wang@intel.com>