### PR TITLE
DAOS-10968 VOS: error handling fix (#9679)

### DIFF
--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -642,17 +642,18 @@ vos_obj_del_key(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
 		toh = obj->obj_toh;
 	}
 
-	key_tree_delete(obj, toh, key);
+	rc = key_tree_delete(obj, toh, key);
 	if (rc) {
 		D_ERROR("delete key error: "DF_RC"\n", DP_RC(rc));
-		goto out_tx;
+		goto out_tree;
 	}
+	/* fall through */
+out_tree:
+	if (akey)
+		key_tree_release(toh, false);
 out_tx:
 	rc = umem_tx_end(umm, rc);
 out:
-	if (akey)
-		key_tree_release(toh, false);
-
 	vos_obj_release(occ, obj, true);
 	return rc;
 }


### PR DESCRIPTION
- fix error handling in vos_obj_del_key()
- check returned value from key_tree_delete()

(cherry picked from commit a4420a15036ee31a286cf12707841ed10f0d1af2)
Signed-off-by: Liang Zhen <liang.zhen@intel.com>