### PR TITLE
DAOS-10967 vos: coverity issue fix (#9681)

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -3893,7 +3893,7 @@ evt_drain(daos_handle_t toh, int *credits, bool *destroyed)
 	if (rc)
 		goto out;
 
-	if (tcx->tc_creds_on)
+	if (credits)
 		*credits = tcx->tc_creds;
 out:
 	rc = evt_tx_end(tcx, rc);


### PR DESCRIPTION
Addresses CID: 21837

changes the coding style to make coverity checker happy

(cherry picked from commit 0f7ac96357f16c422183a3b2fc7654bceea72681)
Signed-off-by: Liang Zhen <liang.zhen@intel.com>