### PR TITLE
DAOS-9898 tests: Add ior/mdtest-easy to basic_checkout.py  (#9397)

### DIFF
--- a/src/tests/ftest/deployment/basic_checkout.yaml
+++ b/src/tests/ftest/deployment/basic_checkout.yaml
@@ -29,19 +29,79 @@ server_config:
           scm_list: ["/dev/pmem1"]
           scm_mount: /mnt/daos1
 pool:
-    mode: 146
-    name: daos_server
-    scm_size: 25G
-    nvme_size: 250G
-    control_method: dmg
+  mode: 146
+  name: daos_server
+  size: 50%
+  control_method: dmg
+  properties: ec_cell_sz:128KiB
 container:
     type: POSIX
     properties: cksum:crc16,cksum_size:16384,srv_cksum:on
     control_method: daos
+
+# ior easy
+ior_easy: &ior_easy_base
+  client_processes:
+    ppn: 16
+  write_flags: "-w -C -e -g -G 27 -k -Q 1 -v"
+  read_flags: "-r -R -C -e -g -G 27 -k -Q 1 -v"
+  block_size: '150G'
+  sw_deadline: 30
+  sw_wearout: 1
+  sw_status_file: "/var/tmp/daos_testing/stoneWallingStatusFile"
+ior_dfs_sx:
+  <<: *ior_easy_base
+  api: DFS
+  dfs_oclass: SX
+  dfs_chunk: 1MiB
+  transfer_size: 1MiB
+ior_dfs_ec_8p2gx:
+  <<: *ior_easy_base
+  api: DFS
+  dfs_oclass: EC_8P2GX
+  dfs_chunk: 8MiB
+  transfer_size: 8MiB
+ior_dfs_ec_16p2gx:
+  <<: *ior_easy_base
+  api: DFS
+  dfs_oclass: EC_16P2GX
+  dfs_chunk: 16MiB
+  transfer_size: 16MiB
+
+# mdtest easy
+mdtest_easy: &mdtest_easy_base
+  client_processes:
+    ppn: 16
+  test_dir: "/"
+  manager: "MPICH"
+  flags: "-C -T -r -F -P -G 27 -N 1 -Y -v -u -L"
+  api: "DFS"
+  read_bytes: 0
+  write_bytes: 0
+  num_of_files_dirs: 100000000
+  stonewall_timer: 30
+  stonewall_statusfile: "/var/tmp/daos_testing/stoneWallingStatusFile"
+  dfs_destroy: False
+mdtest_dfs_s1:
+  <<: *mdtest_easy_base
+  dfs_oclass: S1
+  dfs_dir_oclass: SX
+  dfs_chunk: 1MiB
+mdtest_dfs_ec_8p2g1:
+  <<: *mdtest_easy_base
+  dfs_oclass: EC_8P2G1
+  dfs_dir_oclass: RP_3GX
+  dfs_chunk: 8MiB
+mdtest_dfs_ec_16p2g1:
+  <<: *mdtest_easy_base
+  dfs_oclass: EC_16P2G1
+  dfs_dir_oclass: RP_3GX
+  dfs_chunk: 16MiB
+
+# ior small
 ior:
     client_processes:
-        ppn_8:
-          ppn: 8
+          ppn: 16
     test_file: daos:testFile
     repetitions: 2
     dfs_destroy: False
@@ -81,8 +141,7 @@ ior:
 ior_dm:
       client_processes:
         fs_copy: 10
-        ppn_8:
-          ppn: 8
+        ppn: 16
       api: DFS
       flags: "-w -F -k"
       signature: "5"
@@ -94,8 +153,7 @@ ior_dm:
 
 mdtest:
   client_processes:
-    ppn_8:
-      ppn: 8
+    ppn: 16
   test_dir: "/"
   iteration: 1
   dfs_destroy: True

--- a/src/tests/ftest/util/performance_test_base.py
+++ b/src/tests/ftest/util/performance_test_base.py
@@ -301,7 +301,7 @@ class PerformanceTestBase(IorTestBase, MdtestBase):
 
     def run_performance_ior(self, namespace=None, use_intercept=True, stop_delay_write=None,
                             stop_delay_read=None, num_iterations=1,
-                            restart_between_iterations=True):
+                            restart_between_iterations=True, use_stonewalling_read=False):
         """Run an IOR performance test.
 
         Write and Read are ran separately.
@@ -396,8 +396,12 @@ class PerformanceTestBase(IorTestBase, MdtestBase):
 
             self.log.info("Running IOR read (%s)", str(iteration))
             self.ior_cmd.flags.update(read_flags)
-            self.ior_cmd.sw_wearout.update(None)
-            self.ior_cmd.sw_deadline.update(None)
+            if use_stonewalling_read:
+                self.ior_cmd.sw_wearout.update(write_sw_wearout)
+                self.ior_cmd.sw_deadline.update(write_sw_deadline)
+            else:
+                self.ior_cmd.sw_wearout.update(None)
+                self.ior_cmd.sw_deadline.update(None)
             self._run_performance_ior_single(stop_rank_read_s, intercept)
 
             # Manually stop dfuse after ior read completes


### PR DESCRIPTION
As part of this pr performance_test_base.py is moved from
ftest/performance dir to ftest/util.
Adding ior-easy and mdtest-easy scenarios to the test script
Separating ior-small and mdtest-small from the basiccheckout
sanity test.

Test-tag: basiccheckout performance,-manual

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>