### PR TITLE
DAOS-11214 githooks: Fix commit cancellations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ docs/doxygen/
 venv
 .yamllint
 utils/githooks/*.d/*-user-*
+.prepare-commit-msg
+.pre-commit

--- a/utils/githooks/commit-msg.d/10-watermark
+++ b/utils/githooks/commit-msg.d/10-watermark
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-if ! grep 'Required-githooks: true' "$1"; then
-    echo 'Required-githooks: true' >> "$1"
-fi

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -47,11 +47,7 @@ def run_check():
         sys.exit(0)
 
     hooks = find_hooks()
-    missing = False
-    for hook in hooks:
-        if not check_if_run(hook):
-            missing = True
-    if missing:
+    if not all(list(map(check_if_run, hooks))):
         sys.exit(0)
 
     with open(sys.argv[1], "w") as commit_msg:

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -21,7 +21,7 @@ def find_hooks():
             continue
         if not fname.endswith('.d'):
             continue
-        if not os.path.isdir(os.path.join("utils/githooks")):
+        if not os.path.isdir(os.path.join("utils/githooks", fname)):
             continue
         hooks.append(fname[:-2])
     return hooks

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -32,7 +32,8 @@ def run_check():
     empty_commit = True
     msg = []
     with open(sys.argv[1], "r") as commit_msg:
-        for line in commit_msg.readlines():
+        msg = commit_msg.readlines()
+        for line in msg:
             if line.startswith("Required-githooks: true"):
                 sys.exit(0)
             elif line.startswith("Signed-off-by"):
@@ -53,20 +54,16 @@ def run_check():
     if missing:
         sys.exit(0)
 
-    msg = []
-    with open(sys.argv[1], "r") as commit_msg:
+    with open(sys.argv[1], "w") as commit_msg:
         hook_emitted = False
-        for line in commit_msg.readlines():
+        for line in msg:
             if not hook_emitted:
                 if line.startswith("Signed-off-by"):
-                    msg.append("Required-githooks: true\n\n")
+                    commit_msg.write("Required-githooks: true\n\n")
                     hook_emitted = True
                 elif line.startswith("#"):
-                    msg.append("Required-githooks: true\n\n")
+                    commit_msg.write("Required-githooks: true\n\n")
                     hook_emitted = True
-            msg.append(line)
-    with open(sys.argv[1], "w") as commit_msg:
-        for line in msg:
             commit_msg.write(line)
 
 

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -14,7 +14,7 @@ def check_if_run(name):
 
 
 def find_hooks():
-    """Find the required githooks"""
+    """Find the required git hooks"""
     hooks = []
     for fname in os.listdir('utils/githooks'):
         if fname == "commit-msg.d":

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Add watermark to commit message"""
-import re, sys, os
+import os
+import sys
 
 def check_if_run(name):
     """Check existence of a file, removes file"""
@@ -26,6 +27,7 @@ def find_hooks():
 def run_check():
     """Run the checks for the required commit hooks"""
     empty_commit = True
+    msg = []
     with open(sys.argv[1], "r") as commit_msg:
         for line in commit_msg.readlines():
             if line.startswith("Required-githooks: true"):
@@ -44,7 +46,7 @@ def run_check():
     missing = False
     for hook in hooks:
         if not check_if_run(hook):
-             missing = True
+            missing = True
     if missing:
         sys.exit(0)
 
@@ -65,6 +67,4 @@ def run_check():
             commit_msg.write(line)
 
 if __name__ == "__main__":
-   run_check()
-
-
+    run_check()

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -40,6 +40,8 @@ def run_check():
                 continue
             elif line.strip() == "":
                 continue
+            elif line.startswith("# ------------------------ >8 ------------------------"):
+                break
             elif line.startswith("#"):
                 continue
             empty_commit = False

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Add watermark to commit message"""
+import re, sys, os
+
+def check_if_run(name):
+    """Check existence of a file, removes file"""
+    if not os.path.exists(f".{name}"):
+        print(f"Required githook {name} is not installed. See utils/githooks/README.md")
+        return False
+    os.remove(f".{name}")
+    return True
+
+def find_hooks():
+    """Find the required githooks"""
+    hooks = []
+    for fname in os.listdir('utils/githooks'):
+        if fname == "commit-msg.d":
+            continue
+        if not fname.endswith('.d'):
+            continue
+        if not os.path.isdir(os.path.join("utils/githooks")):
+            continue
+        hooks.append(fname[:-2])
+    return hooks
+
+def run_check():
+    """Run the checks for the required commit hooks"""
+    empty_commit = True
+    with open(sys.argv[1], "r") as commit_msg:
+        for line in commit_msg.readlines():
+            if line.startswith("Required-githooks: true"):
+                sys.exit(0)
+            elif line.startswith("Signed-off-by"):
+                continue
+            elif line.strip() == "":
+                continue
+            elif line.startswith("#"):
+                break
+            empty_commit = False
+    if empty_commit:
+        sys.exit(0)
+
+    hooks = find_hooks()
+    missing = False
+    for hook in hooks:
+        if not check_if_run(hook):
+             missing = True
+    if missing:
+        sys.exit(0)
+
+    msg = []
+    with open(sys.argv[1], "r") as commit_msg:
+        hook_emitted = False
+        for line in commit_msg.readlines():
+            if not hook_emitted:
+                if line.startswith("Signed-off-by"):
+                    msg.append("Required-githooks: true\n\n")
+                    hook_emitted = True
+                elif line.startswith("#"):
+                    msg.append("Required-githooks: true\n\n")
+                    hook_emitted = True
+            msg.append(line)
+    with open(sys.argv[1], "w") as commit_msg:
+        for line in msg:
+            commit_msg.write(line)
+
+if __name__ == "__main__":
+   run_check()
+
+

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -47,7 +47,6 @@ def run_check():
         sys.exit(0)
 
     hooks = find_hooks()
-    print(f"hooks = {hooks}")
     if not all(list(map(check_if_run, hooks))):
         sys.exit(0)
 

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+
 def check_if_run(name):
     """Check existence of a file, removes file"""
     if not os.path.exists(f".{name}"):
@@ -10,6 +11,7 @@ def check_if_run(name):
         return False
     os.remove(f".{name}")
     return True
+
 
 def find_hooks():
     """Find the required githooks"""
@@ -23,6 +25,7 @@ def find_hooks():
             continue
         hooks.append(fname[:-2])
     return hooks
+
 
 def run_check():
     """Run the checks for the required commit hooks"""
@@ -65,6 +68,7 @@ def run_check():
     with open(sys.argv[1], "w") as commit_msg:
         for line in msg:
             commit_msg.write(line)
+
 
 if __name__ == "__main__":
     run_check()

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -41,7 +41,7 @@ def run_check():
             elif line.strip() == "":
                 continue
             elif line.startswith("#"):
-                break
+                continue
             empty_commit = False
     if empty_commit:
         sys.exit(0)
@@ -64,4 +64,5 @@ def run_check():
 
 
 if __name__ == "__main__":
+    print("Checking that required hooks ran")
     run_check()

--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -47,6 +47,7 @@ def run_check():
         sys.exit(0)
 
     hooks = find_hooks()
+    print(f"hooks = {hooks}")
     if not all(list(map(check_if_run, hooks))):
         sys.exit(0)
 

--- a/utils/githooks/pre-commit
+++ b/utils/githooks/pre-commit
@@ -1,19 +1,20 @@
 #!/bin/bash
 set -eu
 
-hook=$(basename $0)
+hook=${0##*/}
 rm -f ".${hook}"
 
 run-parts() {
     local dir="$1"
     shift
 
-    for i in $(LC_ALL=C; echo ${dir%/}/*[^~,]); do
+    for i in $(LC_ALL=C; echo "${dir%/}"/*[^~,]); do
         # don't run vim .swp files
         [ "${i%.sw?}" != "${i}" ] && continue
         $i "$@"
     done
 }
 
-run-parts utils/githooks/${0##*/}.d "$@" 1>&2
+run-parts utils/githooks/"${hook}".d "$@" 1>&2
+
 touch ".${hook}"

--- a/utils/githooks/pre-commit
+++ b/utils/githooks/pre-commit
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu
 
+rm -f .pre-commit
+
 run-parts() {
     local dir="$1"
     shift
@@ -13,3 +15,4 @@ run-parts() {
 }
 
 run-parts utils/githooks/${0##*/}.d "$@" 1>&2
+touch .pre-commit

--- a/utils/githooks/pre-commit
+++ b/utils/githooks/pre-commit
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -eu
 
-rm -f .pre-commit
+hook=$(basename $0)
+rm -f ".${hook}"
 
 run-parts() {
     local dir="$1"
@@ -15,4 +16,4 @@ run-parts() {
 }
 
 run-parts utils/githooks/${0##*/}.d "$@" 1>&2
-touch .pre-commit
+touch ".${hook}"

--- a/utils/githooks/prepare-commit-msg
+++ b/utils/githooks/prepare-commit-msg
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -eu
 
-rm -f .prepare-commit-msg
+hook=${0##*/}
+rm -f ".${hook}"
 
 run-parts() {
     local dir="$1"
@@ -14,6 +15,6 @@ run-parts() {
     done
 }
 
-run-parts utils/githooks/"${0##*/}".d "$@" 1>&2
+run-parts utils/githooks/"${hook}".d "$@" 1>&2
 
-touch .prepare-commit-msg
+touch ".${hook}"

--- a/utils/githooks/prepare-commit-msg
+++ b/utils/githooks/prepare-commit-msg
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu
 
+rm -f .prepare-commit-msg
+
 run-parts() {
     local dir="$1"
     shift
@@ -13,3 +15,5 @@ run-parts() {
 }
 
 run-parts utils/githooks/"${0##*/}".d "$@" 1>&2
+
+touch .prepare-commit-msg


### PR DESCRIPTION
A few problems exist with the exisitng githook.  It doesn't
handle commit cancellations
It also doesn't work with git commit -v
Use python instead as it makes it a little simpler
Also, it adds slightly more robust check that the githooks actually
ran.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>