### PR TITLE
DAOS-10215 container: set default fault domain level on NODE

### DIFF
--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -145,7 +145,7 @@ struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 		.dpe_val	= DAOS_PROP_CO_REDUN_RF0,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_REDUN_LVL,
-		.dpe_val	= DAOS_PROP_CO_REDUN_RANK,
+		.dpe_val	= DAOS_PROP_CO_REDUN_NODE,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_SNAPSHOT_MAX,
 		.dpe_val	= 0, /* No limitation */

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -244,14 +244,14 @@ static void debug_print_allow_status(uint32_t allow_status)
 }
 
 static inline uint32_t
-get_num_domains(struct pool_domain *curr_dom, uint32_t allow_status)
+get_num_domains(struct pool_domain *curr_dom, uint32_t allow_status, pool_comp_type_t fdom_lvl)
 {
 	struct pool_domain *next_dom;
 	struct pool_target *next_target;
 	uint32_t num_dom;
 	uint8_t status;
 
-	if (curr_dom->do_children == NULL)
+	if (curr_dom->do_children == NULL || curr_dom->do_comp.co_type == fdom_lvl)
 		num_dom = curr_dom->do_target_nr;
 	else
 		num_dom = curr_dom->do_child_nr;
@@ -259,16 +259,7 @@ get_num_domains(struct pool_domain *curr_dom, uint32_t allow_status)
 	if (allow_status & PO_COMP_ST_NEW)
 		return num_dom;
 
-	if (curr_dom->do_children != NULL) {
-		next_dom = &curr_dom->do_children[num_dom - 1];
-		status = next_dom->do_comp.co_status;
-
-		while (num_dom - 1 > 0 && status == PO_COMP_ST_NEW) {
-			num_dom--;
-			next_dom = &curr_dom->do_children[num_dom - 1];
-			status = next_dom->do_comp.co_status;
-		}
-	} else {
+	if (curr_dom->do_children == NULL || curr_dom->do_comp.co_type == fdom_lvl) {
 		next_target = &curr_dom->do_targets[num_dom - 1];
 		status = next_target->ta_comp.co_status;
 
@@ -276,6 +267,15 @@ get_num_domains(struct pool_domain *curr_dom, uint32_t allow_status)
 			num_dom--;
 			next_target = &curr_dom->do_targets[num_dom - 1];
 			status = next_target->ta_comp.co_status;
+		}
+	} else {
+		next_dom = &curr_dom->do_children[num_dom - 1];
+		status = next_dom->do_comp.co_status;
+
+		while (num_dom - 1 > 0 && status == PO_COMP_ST_NEW) {
+			num_dom--;
+			next_dom = &curr_dom->do_children[num_dom - 1];
+			status = next_dom->do_comp.co_status;
 		}
 	}
 
@@ -352,7 +352,7 @@ retry:
 		uint32_t        num_doms;
 
 		/* Retrieve number of nodes in this domain */
-		num_doms = get_num_domains(curr_dom, allow_status);
+		num_doms = get_num_domains(curr_dom, allow_status, fdom_lvl);
 
 		/* If choosing target (lowest fault domain level) */
 		if (curr_dom->do_children == NULL || curr_dom->do_comp.co_type == fdom_lvl) {
@@ -1031,12 +1031,24 @@ jump_map_print(struct pl_map *map)
 static int
 jump_map_query(struct pl_map *map, struct pl_map_attr *attr)
 {
-	struct pl_jump_map   *jmap = pl_map2jmap(map);
+	struct pl_jump_map	*jmap = pl_map2jmap(map);
+	struct pool_map		*pool_map = map->pl_poolmap;
+	int			 rc;
 
 	attr->pa_type	   = PL_TYPE_JUMP_MAP;
 	attr->pa_target_nr = jmap->jmp_target_nr;
-	attr->pa_domain_nr = jmap->jmp_domain_nr;
-	attr->pa_domain    = jmap->jmp_redundant_dom;
+
+	if (attr->pa_domain <= 0 || attr->pa_domain == jmap->jmp_redundant_dom ||
+	    attr->pa_domain > PO_COMP_TP_MAX) {
+		attr->pa_domain_nr = jmap->jmp_domain_nr;
+		attr->pa_domain    = jmap->jmp_redundant_dom;
+	} else {
+		rc = pool_map_find_domain(pool_map, attr->pa_domain, PO_COMP_ID_ALL, NULL);
+		if (rc < 0)
+			return rc;
+		attr->pa_domain_nr = rc;
+	}
+
 	return 0;
 }
 

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -348,7 +348,7 @@ static struct d_hash_table	pl_htable;
  * will based on container's DAOS_PROP_CO_REDUN_LVL property to set the fault domain level for
  * that object's layout calculating.
  */
-#define PL_DEFAULT_DOMAIN	PO_COMP_TP_RANK
+#define PL_DEFAULT_DOMAIN	PO_COMP_TP_NODE
 
 static void
 pl_map_attr_init(struct pool_map *po_map, pl_map_type_t type,
@@ -578,6 +578,16 @@ pl_map_version(struct pl_map *map)
 	return map->pl_poolmap ? pool_map_get_version(map->pl_poolmap) : 0;
 }
 
+/**
+ * Query pl_map_attr, the attr->pa_domain is an input&output parameter.
+ * if (attr->pa_domain <= 0 || attr->pa_domain > PO_COMP_TP_MAX) the returned attr->pa_domain is
+ * the pl_map's default fault domain level and attr->pa_domain_nr is the domain number of that
+ * fault domain level;
+ * if (attr->pa_domain > 0 && attr->pa_domain <= PO_COMP_TP_MAX) the returned attr->pa_domain_nr
+ * is the domain number of that specific input fault domain level;
+ * To support the case that different container with different fault domain level, but they share
+ * the same pool map and pl_map.
+ */
 int
 pl_map_query(uuid_t po_uuid, struct pl_map_attr *attr)
 {
@@ -588,7 +598,6 @@ pl_map_query(uuid_t po_uuid, struct pl_map_attr *attr)
 	if (!map)
 		return -DER_ENOENT;
 
-	memset(attr, 0, sizeof(*attr));
 	if (map->pl_ops->o_query != NULL)
 		rc = map->pl_ops->o_query(map, attr);
 	else

--- a/src/tests/ftest/datamover/dst_create.yaml
+++ b/src/tests/ftest/datamover/dst_create.yaml
@@ -11,8 +11,7 @@ pool:
     control_method: dmg
 container:
     control_method: daos
-    properties:
-        - compression:lz4
+    properties: compression:lz4
 ior:
     client_processes:
         np: 1

--- a/src/tests/ftest/datamover/posix_preserve_props.yaml
+++ b/src/tests/ftest/datamover/posix_preserve_props.yaml
@@ -12,8 +12,7 @@ pool:
 container:
     type: POSIX
     control_method: daos
-    properties:
-        - compression:lz4
+    properties: compression:lz4
 ior:
     client_processes:
         np: 1

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -89,6 +89,12 @@ class DaosCommand(DaosCommandBase):
             CommandFailure: if the daos container create command fails.
 
         """
+        # Default to RANK fault domain (rf_lvl:1) when not specified
+        if properties:
+            if 'rf_lvl' not in properties:
+                properties += ',rf_lvl:1'
+        else:
+            properties = 'rf_lvl:1'
         return self._get_json_result(
             ("container", "create"), pool=pool, sys_name=sys_name,
             cont=cont, path=path, type=cont_type, oclass=oclass,

--- a/src/tests/suite/daos_aggregate_ec.c
+++ b/src/tests/suite/daos_aggregate_ec.c
@@ -125,7 +125,7 @@ ec_setup_cont_obj(struct ec_agg_test_ctx *ctx, daos_oclass_id_t oclass)
 	int	rc;
 	daos_prop_t *props;
 
-	props = daos_prop_alloc(3);
+	props = daos_prop_alloc(4);
 	assert_non_null(props);
 	props->dpp_entries[0].dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
 	props->dpp_entries[0].dpe_val = TEST_EC_CELL_SZ;
@@ -133,6 +133,8 @@ ec_setup_cont_obj(struct ec_agg_test_ctx *ctx, daos_oclass_id_t oclass)
 	props->dpp_entries[1].dpe_val = DAOS_PROP_CO_CSUM_CRC32;
 	props->dpp_entries[2].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
 	props->dpp_entries[2].dpe_val = DAOS_PROP_CO_CSUM_SV_ON;
+	props->dpp_entries[3].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	props->dpp_entries[3].dpe_val = DAOS_PROP_CO_REDUN_RANK;
 
 	rc = daos_cont_create(ctx->poh, &ctx->uuid, props, NULL);
 	daos_prop_free(props);

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4279,7 +4279,7 @@ oclass_auto_setting(void **state)
 	daos_handle_t		coh;
 	char			str[37];
 	daos_pool_info_t	info = {0};
-	struct pl_map_attr	attr;
+	struct pl_map_attr	attr = {0};
 	daos_oclass_id_t	ecidx, ecid1;
 	daos_prop_t             *prop = NULL;
 	enum daos_otype_t	feat_kv, feat_array, feat_byte_array;

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -685,11 +685,13 @@ dfs_ec_check_size_internal(void **state, unsigned fail_loc)
 	int		rc;
 	dfs_attr_t	attr = {};
 
-	attr.da_props = daos_prop_alloc(1);
+	attr.da_props = daos_prop_alloc(2);
 	assert_non_null(attr.da_props);
 	attr.da_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
 	attr.da_props->dpp_entries[0].dpe_val = 1 << 15;
-	rc = dfs_cont_create(arg->pool.poh, &co_uuid, NULL, &co_hdl, &dfs_mt);
+	attr.da_props->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	attr.da_props->dpp_entries[1].dpe_val = DAOS_PROP_CO_REDUN_RANK;
+	rc = dfs_cont_create(arg->pool.poh, &co_uuid, &attr, &co_hdl, &dfs_mt);
 	daos_prop_free(attr.da_props);
 
 	assert_int_equal(rc, 0);
@@ -1109,11 +1111,13 @@ ec_punch_check_size(void **state)
 	int		rc;
 	dfs_attr_t	attr = {};
 
-	attr.da_props = daos_prop_alloc(1);
+	attr.da_props = daos_prop_alloc(2);
 	assert_non_null(attr.da_props);
 	attr.da_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
 	attr.da_props->dpp_entries[0].dpe_val = 1 << 15;
-	rc = dfs_cont_create(arg->pool.poh, &co_uuid, NULL, &co_hdl, &dfs_mt);
+	attr.da_props->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	attr.da_props->dpp_entries[1].dpe_val = DAOS_PROP_CO_REDUN_RANK;
+	rc = dfs_cont_create(arg->pool.poh, &co_uuid, &attr, &co_hdl, &dfs_mt);
 	daos_prop_free(attr.da_props);
 	assert_int_equal(rc, 0);
 	printf("Created DFS Container "DF_UUIDF"\n", DP_UUID(co_uuid));

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -827,10 +827,12 @@ dfs_ec_rebuild_io(void **state, int *shards, int shards_nr)
 
 	dfs_attr_t attr = {};
 
-	attr.da_props = daos_prop_alloc(1);
+	attr.da_props = daos_prop_alloc(2);
 	assert_non_null(attr.da_props);
 	attr.da_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
 	attr.da_props->dpp_entries[0].dpe_val = 1 << 15;
+	attr.da_props->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	attr.da_props->dpp_entries[1].dpe_val = DAOS_PROP_CO_REDUN_RANK;
 
 	rc = dfs_cont_create(arg->pool.poh, &co_uuid, &attr, &co_hdl,
 			     &dfs_mt);

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -552,8 +552,15 @@ dfs_ec_seq_fail(void **state, int *shards, int shards_nr)
 	int		i;
 	int		rc;
 
-	rc = dfs_cont_create(arg->pool.poh, &co_uuid, NULL, &co_hdl,
-			     &dfs_mt);
+	dfs_attr_t attr = {};
+
+	attr.da_props = daos_prop_alloc(1);
+	assert_non_null(attr.da_props);
+	attr.da_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	attr.da_props->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RANK;
+
+	rc = dfs_cont_create(arg->pool.poh, &co_uuid, &attr, &co_hdl, &dfs_mt);
+	daos_prop_free(attr.da_props);
 	assert_int_equal(rc, 0);
 	printf("Created DFS Container "DF_UUIDF"\n", DP_UUID(co_uuid));
 

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1196,7 +1196,15 @@ rebuild_with_dfs_open_create_punch(void **state)
 	if (!test_runable(arg, 6))
 		return;
 
-	rc = dfs_cont_create(arg->pool.poh, &co_uuid, NULL, &co_hdl, &dfs_mt);
+	dfs_attr_t attr = {};
+
+	attr.da_props = daos_prop_alloc(1);
+	assert_non_null(attr.da_props);
+	attr.da_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	attr.da_props->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RANK;
+
+	rc = dfs_cont_create(arg->pool.poh, &co_uuid, &attr, &co_hdl, &dfs_mt);
+	daos_prop_free(attr.da_props);
 	assert_int_equal(rc, 0);
 	printf("Created DFS Container "DF_UUIDF"\n", DP_UUID(co_uuid));
 

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -209,7 +209,34 @@ test_setup_cont_create(void **state, daos_prop_t *co_prop)
 	int rc = 0;
 
 	if (arg->myrank == 0) {
-		if (!co_prop || daos_prop_entry_get(co_prop, DAOS_PROP_CO_LABEL) == NULL) {
+		daos_prop_t	*redun_lvl_prop = NULL;
+		daos_prop_t	*merged_props = NULL;
+
+		/* create container with redun_lvl on RANK */
+		if (!co_prop || daos_prop_entry_get(co_prop, DAOS_PROP_CO_REDUN_LVL) == NULL) {
+			redun_lvl_prop = daos_prop_alloc(1);
+			if (redun_lvl_prop == NULL) {
+				D_ERROR("failed to allocate prop\n");
+				return -DER_NOMEM;
+			}
+			redun_lvl_prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+			redun_lvl_prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RANK;
+
+			if (co_prop) {
+				merged_props = daos_prop_merge(co_prop, redun_lvl_prop);
+				if (merged_props == NULL) {
+					D_ERROR("failed to merge cont_prop and redun_lvl_prop\n");
+					daos_prop_free(redun_lvl_prop);
+					return -DER_NOMEM;
+				}
+				co_prop = merged_props;
+			} else {
+				co_prop = redun_lvl_prop;
+			}
+		}
+
+		D_ASSERT(co_prop != NULL);
+		if (daos_prop_entry_get(co_prop, DAOS_PROP_CO_LABEL) == NULL) {
 			char cont_label[32];
 			static int cont_idx;
 
@@ -221,6 +248,9 @@ test_setup_cont_create(void **state, daos_prop_t *co_prop)
 			print_message("setup: creating container\n");
 			rc = daos_cont_create(arg->pool.poh, &arg->co_uuid, co_prop, NULL);
 		}
+
+		daos_prop_free(redun_lvl_prop);
+		daos_prop_free(merged_props);
 
 		if (rc) {
 			print_message("daos_cont_create failed, rc: %d\n", rc);

--- a/src/tests/suite/dfs_par_test.c
+++ b/src/tests/suite/dfs_par_test.c
@@ -60,10 +60,12 @@ test_cond_helper(test_arg_t *arg, int rf)
 	if (arg->myrank == 0) {
 		dfs_attr_t attr = {};
 
-		attr.da_props = daos_prop_alloc(1);
+		attr.da_props = daos_prop_alloc(2);
 		assert_non_null(attr.da_props);
 		attr.da_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 		attr.da_props->dpp_entries[0].dpe_val = rf;
+		attr.da_props->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+		attr.da_props->dpp_entries[1].dpe_val = DAOS_PROP_CO_REDUN_RANK;
 
 		rc = dfs_cont_create(arg->pool.poh, &cuuid, &attr, &coh, &dfs);
 		assert_int_equal(rc, 0);
@@ -886,11 +888,12 @@ dfs_setup(void **state)
 		else
 			print_message("Running DFS Parallel tests with DTX disabled\n");
 
-		attr.da_props = daos_prop_alloc(1);
+		attr.da_props = daos_prop_alloc(2);
 		assert_non_null(attr.da_props);
-		attr.da_props->dpp_entries[0].dpe_type =
-					DAOS_PROP_CO_EC_CELL_SZ;
+		attr.da_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
 		attr.da_props->dpp_entries[0].dpe_val = 1 << 15;
+		attr.da_props->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+		attr.da_props->dpp_entries[1].dpe_val = DAOS_PROP_CO_REDUN_RANK;
 
 		rc = dfs_cont_create(arg->pool.poh, &co_uuid, &attr, &co_hdl, &dfs_mt);
 		daos_prop_free(attr.da_props);

--- a/src/utils/daos_autotest.c
+++ b/src/utils/daos_autotest.c
@@ -223,7 +223,7 @@ pconnect(void)
 
 	/** gather domain_nr for poh */
 	struct dc_pool		*pool;
-	struct pl_map_attr	attr;
+	struct pl_map_attr	attr = {0};
 
 	pool = dc_hdl2pool(poh);
 	D_ASSERT(pool);


### PR DESCRIPTION
1) set the default fault domain level when create container
   (DAOS_PROP_CO_REDUN_LVL property) as DAOS_PROP_CO_REDUN_NODE.
   In test code still create container on RANK fault domain lvl.
2) get container's dcp_redun_lvl for daos_obj_generate_oid().
3) change pl_map_query() to check input parameter of attr->pa_domain
   so can get different domain_nr for different containers (as
   fault domain lvl may be different).
   and fix a bug in get_num_domains().

Features: dm_dst_create

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>