### PR TITLE
DAOS-11179 test: Reduce target,increase block size.

### DIFF
--- a/src/tests/ftest/scrubber/csum_fault.yaml
+++ b/src/tests/ftest/scrubber/csum_fault.yaml
@@ -7,6 +7,7 @@ setup:
 server_config:
   name: daos_server
   engines_per_host: 2
+  targets: 8
   servers:
     0:
       pinned_numa_node: 0
@@ -47,8 +48,8 @@ dmg:
 pool:
   mode: 146
   name: daos_server
-  scm_size: 6000000000
-  nvme_size: 54000000000
+  scm_size: 6G
+  nvme_size: 54G
   svcn: 4
   control_method: dmg
   rebuild_timeout: 120
@@ -74,7 +75,7 @@ ior:
       - DFS
     transfer_block_size:
       - [256B, 2M]
-      - [1M, 512M]
+      - [1M, 2G]
     obj_class:
       - RP_2GX
 faults:

--- a/src/tests/ftest/scrubber/target_auto_eviction.yaml
+++ b/src/tests/ftest/scrubber/target_auto_eviction.yaml
@@ -7,6 +7,7 @@ setup:
 server_config:
   name: daos_server
   engines_per_host: 2
+  targets: 8
   servers:
     0:
       pinned_numa_node: 0
@@ -69,7 +70,7 @@ ior:
   flags: "-v -W -w -r -R"
   api: DFS
   transfer_size: 1M
-  block_size: 512M
+  block_size: 2G
   dfs_oclass: RP_2GX
   dfs_dir_oclass: RP_2GX
 faults:


### PR DESCRIPTION
Test-tag: test_scrubber_csum_fault test_scrubber_target_auto_eviction
Test-repeat: 15

Summary: The fault is not getting injected at random intervals.
Trying to reduce the target and increase IOR block size to see
if it has some effect.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>