### PR TITLE
DAOS-10596 test: Increase the csum_basic test timeout (#9010)

### DIFF
--- a/src/tests/ftest/checksum/csum_basic.yaml
+++ b/src/tests/ftest/checksum/csum_basic.yaml
@@ -1,10 +1,8 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 hosts:
- test_servers:
-  - server-A
- test_clients:
-  - client-B
+ test_servers: 1
+ test_clients: 1
 timeout: 100
 server_config:
  name: daos_server

--- a/src/tests/ftest/checksum/csum_basic.yaml
+++ b/src/tests/ftest/checksum/csum_basic.yaml
@@ -1,9 +1,11 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 hosts:
- test_servers: 1
- test_clients: 1
-timeout: 60
+ test_servers:
+  - server-A
+ test_clients:
+  - client-B
+timeout: 100
 server_config:
  name: daos_server
 pool:


### PR DESCRIPTION
Test-tag: basic_checksum_object
Test-repeat: 10

Increase the test timeout due intermittent failures noticed under VM.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>