### PR TITLE
DAOS-10887 test: Increased set of parameters in widely_striped.py (#9827)

### DIFF
--- a/src/tests/ftest/rebuild/widely_striped.yaml
+++ b/src/tests/ftest/rebuild/widely_striped.yaml
@@ -3,15 +3,20 @@
 hosts:
   test_servers: 7
   test_clients: 1
-timeout: 500
+timeout: 1200
 server_config:
   name: daos_server
+  crt_timeout: 60
   servers:
     targets: 8
     bdev_class: nvme
     bdev_list: ["0000:81:00.0","0000:da:00.0"]
     scm_class: dcpm
     scm_list: ["/dev/pmem0"]
+    env_vars:
+      - SWIM_PROTOCOL_PERIOD_LEN=2000
+      - SWIM_SUSPECT_TIMEOUT=19000
+      - SWIM_PING_TIMEOUT=1900
 testparams:
   ranks:
     rank_to_kill:
@@ -23,10 +28,10 @@ pool:
   name: daos_server
   scm_size: 10G
   nvme_size: 60G
-  svcn: 1
+  svcn: 5
   control_method: dmg
-  rebuild_timeout: 120
-  pool_query_timeout: 30
+  rebuild_timeout: 240
+  pool_query_timeout: 60
 container:
   type: POSIX
   control_method: daos


### PR DESCRIPTION
Increased following set of parameters ignorer to get the test passing.

Test timeout increased more than double.
Cart Timeout increased from 10 secs to 60 secs
Swim Timeouts needed to be bumped. Using following values:
env_vars:

SWIM_PROTOCOL_PERIOD_LEN=2000
SWIM_SUSPECT_TIMEOUT=19000
SWIM_PING_TIMEOUT=1900
Service Replicas Increased from 1 to 5
Rebuild Timeout doubled
Pool Query Timeout doubled

Quick-Functional: true
Test-tag: rebuild_widely_striped

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>