### PR TITLE
DAOS-10861 tests: Re-enable NVME pool capacity tests

### DIFF
--- a/src/tests/ftest/checksum/csum_basic.py
+++ b/src/tests/ftest/checksum/csum_basic.py
@@ -63,8 +63,9 @@ class CsumContainerValidation(TestWithServers):
         Test Description: Write Avocado Test to verify single data after
                           pool/container disconnect/reconnect.
         :avocado: tags=all,daily_regression
+        :avocado: vm
         :avocado: tags=checksum
-        :avocado: tags=basic_checksum_object
+        :avocado: tags=basic_checksum_object,test_single_object_with_checksum
         """
         self.d_log.info("Writing the Single Dataset")
         record_index = 0

--- a/src/tests/ftest/checksum/csum_basic.yaml
+++ b/src/tests/ftest/checksum/csum_basic.yaml
@@ -5,7 +5,11 @@ hosts:
  test_clients: 1
 timeout: 100
 server_config:
- name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
     createmode:
         mode_RW:

--- a/src/tests/ftest/container/api_basic_attribute.py
+++ b/src/tests/ftest/container/api_basic_attribute.py
@@ -148,7 +148,7 @@ class ContainerAPIBasicAttributeTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container,container_attribute
-        :avocado: tags=container_api_basic_attribute_sync
+        :avocado: tags=container_api_basic_attribute_sync,test_basic_attribute_sync
         """
         self.prepare_attribute_test()
 
@@ -215,7 +215,7 @@ class ContainerAPIBasicAttributeTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container,container_attribute
-        :avocado: tags=container_api_basic_attribute_async
+        :avocado: tags=container_api_basic_attribute_async,test_basic_attribute_async
         """
         self.prepare_attribute_test()
 

--- a/src/tests/ftest/container/api_basic_attribute.yaml
+++ b/src/tests/ftest/container/api_basic_attribute.yaml
@@ -5,6 +5,10 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/container/async.py
+++ b/src/tests/ftest/container/async.py
@@ -39,7 +39,10 @@ class ContainerAsync(TestWithServers):
         The negative case is more like a test of the API implementation rather
         than DAOS itself.
 
-        :avocado: tags=all,full_regression,container,cont_create_async
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=cont_create_async,test_create_async
         """
         self.add_pool()
         ph = self.pool.pool.handle

--- a/src/tests/ftest/container/async.yaml
+++ b/src/tests/ftest/container/async.yaml
@@ -1,6 +1,12 @@
 hosts:
   test_servers: 1
 timeout: 240
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   scm_size: 1G

--- a/src/tests/ftest/container/auto_oc_selection.py
+++ b/src/tests/ftest/container/auto_oc_selection.py
@@ -32,7 +32,7 @@ class AutoOCSelectionTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container
-        :avocado: tags=oc_selection
+        :avocado: tags=oc_selection,test_oc_selection
         """
         self.add_pool()
 

--- a/src/tests/ftest/container/auto_oc_selection.yaml
+++ b/src/tests/ftest/container/auto_oc_selection.yaml
@@ -1,6 +1,12 @@
 hosts:
   test_servers: 5
 timeout: 180
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   scm_size: 1G
   control_method: dmg

--- a/src/tests/ftest/container/basic_snapshot.py
+++ b/src/tests/ftest/container/basic_snapshot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -45,7 +45,10 @@ class BasicSnapshot(TestWithServers):
             Verify the snapshot is still available and the contents remain in
             their original state.
 
-        :avocado: tags=all,daily_regression,snap,basicsnap
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=container,snap,snapshot
+        :avocado: tags=basicsnap,test_basic_snapshot
         """
         # Set up the pool and container.
         try:

--- a/src/tests/ftest/container/basic_snapshot.yaml
+++ b/src/tests/ftest/container/basic_snapshot.yaml
@@ -4,16 +4,19 @@ timeout: 120
 hosts:
   test_servers: 2
 server_config:
-    name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
-    mode: 511
     name: daos_server
     control_method: dmg
     scm_size_mux: !mux
         size1gb:
-            scm_size: 1073741824
-        size7gb:
-            scm_size: 7516192768
+            scm_size: 1G
+        size3gb:
+            scm_size: 3G
 object_class: !mux
     OC_S1:
         obj_class: OC_S1

--- a/src/tests/ftest/container/close.py
+++ b/src/tests/ftest/container/close.py
@@ -23,7 +23,7 @@ class ContainerCloseTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=smoke,container
-        :avocado: tags=container_close
+        :avocado: tags=container_close,test_container_close
         """
         self.container = []
         saved_coh = None

--- a/src/tests/ftest/container/close.yaml
+++ b/src/tests/ftest/container/close.yaml
@@ -2,7 +2,11 @@ hosts:
   test_servers: 1
 timeout: 60
 server_config:
-    name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/container/create.py
+++ b/src/tests/ftest/container/create.py
@@ -25,7 +25,10 @@ class CreateContainerTest(TestWithServers):
 
         Test Description: valid and invalid container creation and close.
 
-        :avocado: tags=all,container,tiny,smoke,full_regression,containercreate
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=container,smoke
+        :avocado: tags=container_create,test_container_create
         """
         expected_results = []
 

--- a/src/tests/ftest/container/create.yaml
+++ b/src/tests/ftest/container/create.yaml
@@ -5,6 +5,10 @@ hosts:
 timeout: 100
 server_config:
    name: daos_server
+   servers:
+      targets: 4
+      nr_xs_helpers: 0
+      scm_size: 4
 pool:
    mode: 511
    name: daos_server

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -25,7 +25,7 @@ class ContainerDestroyTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container,smoke
-        :avocado: tags=container_destroy
+        :avocado: tags=container_destroy,test_container_destroy
         """
         expected_for_param = []
         change_result_uuid = self.params.get(

--- a/src/tests/ftest/container/destroy.yaml
+++ b/src/tests/ftest/container/destroy.yaml
@@ -5,6 +5,10 @@ timeout: 60
 
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 
 pool:
   scm_size: 1G

--- a/src/tests/ftest/container/global_handle.py
+++ b/src/tests/ftest/container/global_handle.py
@@ -72,8 +72,9 @@ class GlobalHandle(TestWithServers):
         """Test Description: Use a pool handle in another process.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=tiny
-        :avocado: tags=container,global_handle,container_global_handle
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=global_handle,container_global_handle,test_global_handle
         """
         # initialize a python pool object then create the underlying
         # daos storage and connect to it

--- a/src/tests/ftest/container/global_handle.yaml
+++ b/src/tests/ftest/container/global_handle.yaml
@@ -5,6 +5,10 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/container/list.py
+++ b/src/tests/ftest/container/list.py
@@ -61,8 +61,9 @@ class ListContainerTest(TestWithServers):
             See test cases in the class description.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=container,list_containers
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=list_containers,test_list_containers
         """
         expected_uuids1 = []
         self.pool = []

--- a/src/tests/ftest/container/list.yaml
+++ b/src/tests/ftest/container/list.yaml
@@ -3,6 +3,10 @@ hosts:
 timeout: 140
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   size: 300MB

--- a/src/tests/ftest/container/open.py
+++ b/src/tests/ftest/container/open.py
@@ -46,7 +46,7 @@ class OpenContainerTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container
-        :avocado: tags=container_open
+        :avocado: tags=container_open,test_container_open
         """
         self.pool = []
         self.container = []

--- a/src/tests/ftest/container/open.yaml
+++ b/src/tests/ftest/container/open.yaml
@@ -3,6 +3,10 @@ hosts:
 timeout: 50
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/container/query_attribute.py
+++ b/src/tests/ftest/container/query_attribute.py
@@ -46,8 +46,9 @@ class ContainerQueryAttributeTest(TestWithServers):
             Test container query, set-attr, get-attr, and list-attrs.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=container,cont_query_attr
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=cont_query_attr,test_container_query_attr
         """
         # Create a pool and a container.
         self.add_pool()
@@ -157,8 +158,9 @@ class ContainerQueryAttributeTest(TestWithServers):
             Test daos container list-attrs with 50 attributes.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=container,cont_list_attrs
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=cont_list_attrs,test_list_attrs_long
         """
         # Create a pool and a container.
         self.add_pool()

--- a/src/tests/ftest/container/query_attribute.yaml
+++ b/src/tests/ftest/container/query_attribute.yaml
@@ -5,6 +5,8 @@ server_config:
   name: daos_server
   servers:
     targets: 8
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   scm_size: 1G
   control_method: dmg

--- a/src/tests/ftest/container/query_properties.py
+++ b/src/tests/ftest/container/query_properties.py
@@ -36,7 +36,7 @@ class QueryPropertiesTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container
-        :avocado: tags=query_properties
+        :avocado: tags=query_properties,test_query_properties
         """
         errors = []
 

--- a/src/tests/ftest/container/query_properties.yaml
+++ b/src/tests/ftest/container/query_properties.yaml
@@ -3,6 +3,13 @@ hosts:
 
 timeout: 100
 
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
+
 pool:
   scm_size: 1G
   control_method: dmg

--- a/src/tests/ftest/container/rf_enforcement.py
+++ b/src/tests/ftest/container/rf_enforcement.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -41,9 +41,10 @@ class ContRfEnforce(ContRedundancyFactor):
             write io verification.
 
         :avocado: tags=all,full_regression
+        :avocado: tags=vm
         :avocado: tags=container
-        :avocado: tags=container_rf
-        :avocado: tags=cont_rf_oclass_enforcement
+        :avocado: tags=container_rf,cont_rf_oclass_enforcement
+        :avocado: tags=test_container_redundancy_factor_oclass_enforcement
         """
         self.mode = "cont_rf_enforcement"
         self.execute_cont_rf_test()

--- a/src/tests/ftest/container/rf_enforcement.yaml
+++ b/src/tests/ftest/container/rf_enforcement.yaml
@@ -6,6 +6,8 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/container/simple_create_delete.py
+++ b/src/tests/ftest/container/simple_create_delete.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -24,7 +24,10 @@ class SimpleCreateDeleteTest(TestWithServers):
     def test_container_basics(self):
         """Test basic container create/destroy/open/close/query.
 
-        :avocado: tags=all,container,pr,daily_regression,medium,basecont
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=basecont,test_container_basics
         """
         # Create a pool
         self.log.info("Create a pool")

--- a/src/tests/ftest/container/simple_create_delete.yaml
+++ b/src/tests/ftest/container/simple_create_delete.yaml
@@ -5,6 +5,10 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -140,8 +140,10 @@ class Snapshot(TestWithServers):
                 (6)Verify snap_list bad parameter behavior.
 
         Use Cases: Combinations with minimum 1 client and 1 server.
-        :avocado: tags=all,small,smoke,daily_regression,snap,snapshot_negative,
-        :avocado: tags=snapshotcreate_negative
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=container,smoke,snap,snapshot
+        :avocado: tags=snapshot_negative,snapshotcreate_negative,test_snapshot_negativecases
         """
 
         # DAOS-1322 Create a new container, verify snapshot state as expected
@@ -315,7 +317,11 @@ class Snapshot(TestWithServers):
         Use Cases: Require 1 client and 1 server to run snapshot test.
                    1 pool and 1 container is used, num_of_snapshot defined
                    in the snapshot.yaml will be performed and verified.
-        :avocado: tags=all,small,smoke,snap,snapshots,full_regression
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=container,smoke,snap,snapshot
+        :avocado: tags=snapshots,test_snapshots
         """
 
         test_data = []

--- a/src/tests/ftest/container/snapshot.yaml
+++ b/src/tests/ftest/container/snapshot.yaml
@@ -5,7 +5,11 @@ faults:
     no_faults:
       fault_list: []
 server_config:
-   name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
     name: daos_server
     scm_size: 1G

--- a/src/tests/ftest/control/daos_agent_config.py
+++ b/src/tests/ftest/control/daos_agent_config.py
@@ -34,9 +34,9 @@ class DaosAgentConfigTest(TestWithServers):
         on the system.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=small,agent_start,basic
-        :avocado: tags=control,daos_agent_config_test
-        :avocado: tags=test_daos_agent_config_basic
+        :avocado: tags=vm
+        :avocado: tags=control,basic
+        :avocado: tags=agent_start,daos_agent_config_test,test_daos_agent_config_basic
         """
         # Setup the agents
         self.add_agent_manager()

--- a/src/tests/ftest/control/daos_agent_config.yaml
+++ b/src/tests/ftest/control/daos_agent_config.yaml
@@ -6,6 +6,10 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/control/daos_control_config.py
+++ b/src/tests/ftest/control/daos_control_config.py
@@ -24,7 +24,10 @@ class DaosControlConfigTest(TestWithServers):
         Test Description: Test dmg tool executes with variant positive and
         negative inputs to its configuration file.
 
-        :avocado: tags=all,small,control,daily_regression,control_start,basic
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,basic
+        :avocado: tags=control_start,test_daos_control_config_basic
         """
         # Get the input to verify
         c_val = self.params.get("config_val", "/run/control_config_val/*/")

--- a/src/tests/ftest/control/daos_control_config.yaml
+++ b/src/tests/ftest/control/daos_control_config.yaml
@@ -6,6 +6,10 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/control/daos_object_query.py
+++ b/src/tests/ftest/control/daos_object_query.py
@@ -38,9 +38,11 @@ class DaosObjectQuery(TestWithServers):
     def test_object_query(self):
         """JIRA ID: DAOS-4694
         Test Description: Test daos object query.
+
         :avocado: tags=all,full_regression
+        :avocado: tags=vm
         :avocado: tags=control
-        :avocado: tags=daos_object_query
+        :avocado: tags=daos_object_query,test_object_query
         """
         daos_cmd = DaosCommand(self.bin)
         errors = []

--- a/src/tests/ftest/control/daos_object_query.yaml
+++ b/src/tests/ftest/control/daos_object_query.yaml
@@ -3,9 +3,13 @@ hosts:
 timeout: 80
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     name: daos_server
-    scm_size: 4G
+    scm_size: 3G
     control_method: dmg
 container:
     control_method: daos

--- a/src/tests/ftest/control/daos_snapshot.py
+++ b/src/tests/ftest/control/daos_snapshot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -97,7 +97,10 @@ class DaosSnapshotTest(TestWithServers):
         Use Cases:
             See test cases in the class description.
 
-        :avocado: tags=all,small,control,full_regression,daos_snapshot
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=control,snap,snapshot
+        :avocado: tags=daos_snapshot,test_create_list_delete
         """
         self.prepare_pool_container()
 
@@ -127,7 +130,10 @@ class DaosSnapshotTest(TestWithServers):
         Use Cases:
             See class description.
 
-        :avocado: tags=all,small,container,full_regression,daos_snapshot_range
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=container,snap,snapshot
+        :avocado: tags=daos_snapshot_range,test_epcrange
         """
         self.prepare_pool_container()
 

--- a/src/tests/ftest/control/daos_snapshot.yaml
+++ b/src/tests/ftest/control/daos_snapshot.yaml
@@ -3,6 +3,10 @@ hosts:
 timeout: 400
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   scm_size: 1G
   control_method: dmg

--- a/src/tests/ftest/control/dmg_nvme_scan_test.py
+++ b/src/tests/ftest/control/dmg_nvme_scan_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -31,7 +31,11 @@ class DmgNvmeScanTest(TestWithServers):
         JIRA ID: DAOS-2485
         Test Description: Test basic dmg functionality to scan the nvme storage.
         on the system.
-        :avocado: tags=all,tiny,daily_regression,dmg,nvme_scan,basic
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,basic,dmg
+        :avocado: tags=nvme_scan,test_dmg_nvme_scan_basic
         """
         # Create dmg command
         dmg = DmgCommand(os.path.join(self.prefix, "bin"))

--- a/src/tests/ftest/control/dmg_nvme_scan_test.yaml
+++ b/src/tests/ftest/control/dmg_nvme_scan_test.yaml
@@ -6,6 +6,10 @@ timeout: 60
 server_config:
   name: daos_server
   port: 10001
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 dmg:
   dmg_sub_command: storage
   storage:

--- a/src/tests/ftest/control/dmg_pool_evict.py
+++ b/src/tests/ftest/control/dmg_pool_evict.py
@@ -32,8 +32,9 @@ class DmgPoolEvictTest(TestWithServers):
         Test Description: Test dmg pool evict.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=control,dmg_pool_evict
+        :avocado: tags=vm
+        :avocado: tags=control
+        :avocado: tags=dmg_pool_evict,test_dmg_pool_evict
         """
         # Create 2 pools and create a container in each pool.
         self.pool = []

--- a/src/tests/ftest/control/dmg_pool_evict.yaml
+++ b/src/tests/ftest/control/dmg_pool_evict.yaml
@@ -3,6 +3,10 @@ hosts:
 timeout: 140
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     control_method: dmg
     scm_size: 1GB

--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -35,7 +35,7 @@ class DmgPoolQueryRanks(ControlTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dmg,control,pool_query,pool_query_ranks
-        :avocado: tags=pool_query_ranks_basic
+        :avocado: tags=pool_query_ranks_basic,test_pool_query_ranks_basic
         """
         self.log.info("Basic tests of pool query with ranks state")
 
@@ -75,7 +75,7 @@ class DmgPoolQueryRanks(ControlTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dmg,control,pool_query,pool_query_ranks
-        :avocado: tags=pool_query_ranks_error
+        :avocado: tags=pool_query_ranks_error,test_pool_query_ranks_error
         """
         self.log.info("Tests of pool query with incompatible options")
 
@@ -99,7 +99,7 @@ class DmgPoolQueryRanks(ControlTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dmg,control,pool_query,pool_query_ranks
-        :avocado: tags=pool_query_ranks_mgmt
+        :avocado: tags=pool_query_ranks_mgmt,test_pool_query_ranks_mgmt
         """
         self.log.info("Tests of pool query with ranks state when playing with ranks")
 

--- a/src/tests/ftest/control/dmg_pool_query_ranks.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.yaml
@@ -8,6 +8,8 @@ server_config:
   name: daos_server
   servers:
     0:
+      targets: 4
+      nr_xs_helpers: 0
       scm_class: ram
       scm_mount: /mnt/daos
       scm_size: 6

--- a/src/tests/ftest/control/dmg_system_cleanup.yaml
+++ b/src/tests/ftest/control/dmg_system_cleanup.yaml
@@ -3,6 +3,10 @@ hosts:
 timeout: 600
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     control_method: dmg
     scm_size: 1GB

--- a/src/tests/ftest/control/dmg_system_leader_query.py
+++ b/src/tests/ftest/control/dmg_system_leader_query.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2021 Intel Corporation.
+  (C) Copyright 2021-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -28,7 +28,11 @@ class DmgSystemLeaderQueryTest(ControlTestBase):
         JIRA ID: DAOS-4822
         Test Description: Test that system leader-query command reports leader
             consistently regardless of which server is queried.
-        :avocado: tags=all,basic,daily_regression,dmg,system_leader_query
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,basic,dmg
+        :avocado: tags=system_leader_query,test_dmg_system_leader_query
         """
         last_result = None
         for host in self.hosts:

--- a/src/tests/ftest/control/dmg_system_leader_query.yaml
+++ b/src/tests/ftest/control/dmg_system_leader_query.yaml
@@ -3,3 +3,7 @@ hosts:
 timeout: 120
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4

--- a/src/tests/ftest/control/dmg_telemetry_basic.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_basic.yaml
@@ -7,6 +7,8 @@ timeouts:
 server_config:
   name: daos_server
   servers:
+    targets: 4
+    nr_xs_helpers: 0
     scm_size: 4
 pool:
   scm_size: 2G

--- a/src/tests/ftest/control/dmg_telemetry_io_basic.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_basic.py
@@ -92,7 +92,7 @@ class TestWithTelemetryIOBasic(IorTestBase, TestWithTelemetry):
         :avocado: tags=vm
         :avocado: tags=control,telemetry
         :avocado: tags=test_with_telemetry_basic,test_io_telemetry
-        :avocado: tags=test_io_telemetry_basic
+        :avocado: tags=test_io_telemetry_basic,test_io_telmetry_metrics_basic
 
         """
         block_sizes = self.params.get("block_sizes", "/run/*")

--- a/src/tests/ftest/control/dmg_telemetry_io_basic.yaml
+++ b/src/tests/ftest/control/dmg_telemetry_io_basic.yaml
@@ -6,6 +6,8 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   name: daos_server
   scm_size: 1G

--- a/src/tests/ftest/control/ms_failover.py
+++ b/src/tests/ftest/control/ms_failover.py
@@ -123,7 +123,9 @@ class ManagementServiceFailover(TestWithServers):
             Test that the MS leader resigns on dRPC failure and that a new
             leader is elected.
 
-        :avocado: tags=all,pr,daily_regression,control,ms_failover
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control
         :avocado: tags=ms_failover
         """
         replicas = self.launch_servers()

--- a/src/tests/ftest/control/ms_failover.yaml
+++ b/src/tests/ftest/control/ms_failover.yaml
@@ -7,6 +7,9 @@ daos_server:
   pattern_timeout: 60
 server_config:
   servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
     log_mask: DEBUG,MEM=ERR
     env_vars:
       - DD_MASK=mgmt

--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -303,6 +303,7 @@ class ManagementServiceResilience(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=control,ms_resilience,ms_retained_quorum_N_1
+        :avocado: tags=test_ms_resilience_1
         """
         # Run test cases
         self.verify_retained_quorum(1)
@@ -317,6 +318,7 @@ class ManagementServiceResilience(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=control,ms_resilience,ms_retained_quorum_N_2
+        :avocado: tags=test_ms_resilience_2
         """
         # Run test cases
         self.verify_retained_quorum(2)
@@ -333,6 +335,7 @@ class ManagementServiceResilience(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=control,ms_resilience,ms_regained_quorum_N_1
+        :avocado: tags=test_ms_resilience_3
         """
         # Run test case
         self.verify_regained_quorum(1)
@@ -349,6 +352,7 @@ class ManagementServiceResilience(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=control,ms_resilience,ms_regained_quorum_N_2
+        :avocado: tags=test_ms_resilience_4
         """
         # Run test case
         self.verify_regained_quorum(2)

--- a/src/tests/ftest/control/ms_resilience.yaml
+++ b/src/tests/ftest/control/ms_resilience.yaml
@@ -7,6 +7,9 @@ daos_server:
   pattern_timeout: 60
 server_config:
   servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
     log_mask: DEBUG,MEM=ERR
     env_vars:
       - DD_MASK=mgmt

--- a/src/tests/ftest/control/super_block_versioning.py
+++ b/src/tests/ftest/control/super_block_versioning.py
@@ -27,7 +27,10 @@ class SuperBlockVersioning(TestWithServers):
         Test Description:
             Basic test to verify that superblock file is versioned.
 
-        :avocado: tags=all,tiny,daily_regression,ds_versioning,basic
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=control,basic
+        :avocado: tags=ds_versioning,test_super_block_version_basic
         """
         # Check that the superblock file exists under the scm_mount dir.
         scm_mount = self.server_managers[0].get_config_value("scm_mount")

--- a/src/tests/ftest/control/super_block_versioning.yaml
+++ b/src/tests/ftest/control/super_block_versioning.yaml
@@ -3,3 +3,8 @@
 hosts:
   test_servers: 1
 timeout: 60
+server_config:
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4

--- a/src/tests/ftest/control/version.py
+++ b/src/tests/ftest/control/version.py
@@ -23,7 +23,7 @@ class DAOSVersion(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=control
-        :avocado: tags=version_number
+        :avocado: tags=version_number,test_version
         """
         errors = []
 

--- a/src/tests/ftest/control/version.yaml
+++ b/src/tests/ftest/control/version.yaml
@@ -1,5 +1,10 @@
 hosts:
   test_servers: 1
 timeout: 60
+server_config:
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg

--- a/src/tests/ftest/daos_test/dfuse.py
+++ b/src/tests/ftest/daos_test/dfuse.py
@@ -27,7 +27,7 @@ class DaosCoreTestDfuse(DfuseTestBase):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=dfuse,dfuse_test
-        :avocado: tags=dfuse_unit
+        :avocado: tags=dfuse_unit,test_daos_dfuse_unit
         """
         self.daos_test = os.path.join(self.bin, 'dfuse_test')
 

--- a/src/tests/ftest/daos_test/dfuse.yaml
+++ b/src/tests/ftest/daos_test/dfuse.yaml
@@ -7,6 +7,10 @@ pool:
   control_method: dmg
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -252,6 +252,7 @@ class DmvrDstCreate(DataMoverTestBase):
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp,dfs,ior
         :avocado: tags=dm_dst_create,dm_dst_create_dcp_posix_dfs
+        :avocado: tags=test_dm_dst_create_dcp_posix_dfs
         """
         self.run_dm_dst_create("DCP", "POSIX", "DFS", True)
 
@@ -267,6 +268,7 @@ class DmvrDstCreate(DataMoverTestBase):
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp
         :avocado: tags=dm_dst_create,dm_dst_create_dcp_posix_daos
+        :avocado: tags=test_dm_dst_create_dcp_posix_daos
         """
         self.run_dm_dst_create("DCP", "POSIX", "DAOS", True)
 
@@ -282,6 +284,7 @@ class DmvrDstCreate(DataMoverTestBase):
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp
         :avocado: tags=dm_dst_create,dm_dst_create_dcp_unknown_daos
+        :avocado: tags=test_dm_dst_create_dcp_unknown_daos
         """
         self.run_dm_dst_create("DCP", None, "DAOS", True)
 
@@ -297,5 +300,6 @@ class DmvrDstCreate(DataMoverTestBase):
         :avocado: tags=vm
         :avocado: tags=datamover,daos_fs_copy,dfs,ior
         :avocado: tags=dm_dst_create,dm_dst_create_fs_copy_posix_dfs
+        :avocado: tags=test_dm_dst_create_fs_copy_posix_dfs
         """
         self.run_dm_dst_create("FS_COPY", "POSIX", "DFS", False)

--- a/src/tests/ftest/datamover/dst_create.yaml
+++ b/src/tests/ftest/datamover/dst_create.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 120
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/datamover/negative.py
+++ b/src/tests/ftest/datamover/negative.py
@@ -53,7 +53,7 @@ class DmvrNegativeTest(DataMoverTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp,dfuse,dfs,ior
-        :avocado: tags=dm_negative,dm_bad_params_dcp
+        :avocado: tags=dm_negative,dm_bad_params_dcp,test_dm_bad_params_dcp
         """
         self.set_tool("DCP")
 

--- a/src/tests/ftest/datamover/negative.yaml
+++ b/src/tests/ftest/datamover/negative.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 300
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 6
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/datamover/obj_small.py
+++ b/src/tests/ftest/datamover/obj_small.py
@@ -116,7 +116,7 @@ class DmvrObjSmallTest(DataMoverTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp
-        :avocado: tags=dm_obj_small,dm_obj_small_dcp
+        :avocado: tags=dm_obj_small,dm_obj_small_dcp,test_dm_obj_small_dcp
         """
         self.run_dm_obj_small("DCP")
 
@@ -128,6 +128,6 @@ class DmvrObjSmallTest(DataMoverTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=datamover,daos_cont_clone
-        :avocado: tags=dm_obj_small,dm_obj_small_cont_clone
+        :avocado: tags=dm_obj_small,dm_obj_small_cont_clone,test_dm_obj_small_cont_clone
         """
         self.run_dm_obj_small("CONT_CLONE")

--- a/src/tests/ftest/datamover/obj_small.yaml
+++ b/src/tests/ftest/datamover/obj_small.yaml
@@ -6,6 +6,10 @@ timeouts:
     test_dm_obj_small_cont_clone: 90
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/datamover/posix_meta_entry.py
+++ b/src/tests/ftest/datamover/posix_meta_entry.py
@@ -26,6 +26,7 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp,dfuse
         :avocado: tags=dm_posix_meta_entry,dm_posix_meta_entry_dcp
+        :avocado: tags=test_dm_posix_meta_entry_dcp
         """
         self.run_dm_posix_meta_entry("DCP")
 

--- a/src/tests/ftest/datamover/posix_meta_entry.yaml
+++ b/src/tests/ftest/datamover/posix_meta_entry.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 120
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/datamover/posix_preserve_props.py
+++ b/src/tests/ftest/datamover/posix_preserve_props.py
@@ -238,5 +238,6 @@ class DmvrPreserveProps(DataMoverTestBase):
         :avocado: tags=vm
         :avocado: tags=datamover,daos_fs_copy,dfs,ior,hdf5
         :avocado: tags=dm_preserve_props,dm_preserve_props_fs_copy_posix_dfs
+        :avocado: tags=test_dm_preserve_props_fs_copy_posix_dfs
         """
         self.run_dm_preserve_props("FS_COPY", "POSIX", "DFS")

--- a/src/tests/ftest/datamover/posix_preserve_props.yaml
+++ b/src/tests/ftest/datamover/posix_preserve_props.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 120
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -159,6 +159,7 @@ class DmvrPosixSubsets(DataMoverTestBase):
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp,dfuse,dfs,ior
         :avocado: tags=dm_posix_subsets,dm_posix_subsets_dcp
+        :avocado: tags=test_dm_posix_subsets_dcp
         """
         self.run_dm_posix_subsets("DCP")
 
@@ -171,5 +172,6 @@ class DmvrPosixSubsets(DataMoverTestBase):
         :avocado: tags=vm
         :avocado: tags=datamover,daos_fs_copy,dfuse,dfs,ior
         :avocado: tags=dm_posix_subsets,dm_posix_subsets_fs_copy
+        :avocado: tags=test_dm_posix_subsets_fs_copy
         """
         self.run_dm_posix_subsets("FS_COPY")

--- a/src/tests/ftest/datamover/posix_subsets.yaml
+++ b/src/tests/ftest/datamover/posix_subsets.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 120
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/datamover/posix_symlinks.py
+++ b/src/tests/ftest/datamover/posix_symlinks.py
@@ -24,7 +24,7 @@ class DmvrPosixSymlinks(DataMoverTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp,dfuse,dfs
-        :avocado: tags=dm_posix_symlinks,dm_posix_symlinks_dcp
+        :avocado: tags=dm_posix_symlinks,dm_posix_symlinks_dcp,test_dm_posix_symlinks
         """
         self.run_dm_posix_symlinks("DCP")
 

--- a/src/tests/ftest/datamover/posix_symlinks.yaml
+++ b/src/tests/ftest/datamover/posix_symlinks.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 120
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/datamover/posix_types.py
+++ b/src/tests/ftest/datamover/posix_types.py
@@ -232,7 +232,7 @@ class DmvrPosixTypesTest(DataMoverTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp,dfuse,dfs,ior
-        :avocado: tags=dm_posix_types,dm_posix_types_dcp
+        :avocado: tags=dm_posix_types,dm_posix_types_dcp,test_dm_posix_types_dcp
         """
         self.run_dm_posix_types("DCP")
 
@@ -244,7 +244,7 @@ class DmvrPosixTypesTest(DataMoverTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dsync,dfuse,dfs,ior
-        :avocado: tags=dm_posix_types,dm_posix_types_dsync
+        :avocado: tags=dm_posix_types,dm_posix_types_dsync,test_dm_posix_types_dsync
         """
         self.run_dm_posix_types("DSYNC")
 
@@ -257,6 +257,6 @@ class DmvrPosixTypesTest(DataMoverTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=datamover,daos_fs_copy,dfuse,dfs,ior
-        :avocado: tags=dm_posix_types,dm_posix_types_fs_copy
+        :avocado: tags=dm_posix_types,dm_posix_types_fs_copy,test_dm_posix_types_fs_copy
         """
         self.run_dm_posix_types("FS_COPY")

--- a/src/tests/ftest/datamover/posix_types.yaml
+++ b/src/tests/ftest/datamover/posix_types.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 270
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/datamover/serial_small.py
+++ b/src/tests/ftest/datamover/serial_small.py
@@ -102,6 +102,6 @@ class DmvrSerialSmall(DataMoverTestBase):
         :avocado: tags=all,pr
         :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_serialize,mfu_deserialize,hdf5
-        :avocado: tags=dm_serial_small,dm_serial_small_dserialize
+        :avocado: tags=dm_serial_small,dm_serial_small_dserialize,test_dm_serial_small_dserialize
         """
         self.run_dm_serial_small("DSERIAL")

--- a/src/tests/ftest/datamover/serial_small.yaml
+++ b/src/tests/ftest/datamover/serial_small.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 180
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/dfuse/container_type.py
+++ b/src/tests/ftest/dfuse/container_type.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -29,9 +29,9 @@ class DfuseContainerCheck(DfuseTestBase):
             Create container of type POSIX.
             Try to mount to dfuse and check the behavior.
         :avocado: tags=all,full_regression
-        :avocado: tags=small
+        :avocado: tags=vm
         :avocado: tags=dfuse
-        :avocado: tags=dfusecontainercheck
+        :avocado: tags=dfusecontainercheck,test_dfuse_container_check
         """
         # get test params for cont and pool count
         cont_types = self.params.get("cont_types", '/run/container/*')

--- a/src/tests/ftest/dfuse/container_type.yaml
+++ b/src/tests/ftest/dfuse/container_type.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 240
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 146
   name: daos_server

--- a/src/tests/ftest/dfuse/daos_build.yaml
+++ b/src/tests/ftest/dfuse/daos_build.yaml
@@ -9,6 +9,7 @@ server_config:
   servers:
     targets: 4
     nr_xs_helpers: 0
+    scm_size: 8
 pool:
   size: 5GiB
   control_method: dmg

--- a/src/tests/ftest/dfuse/enospace.py
+++ b/src/tests/ftest/dfuse/enospace.py
@@ -34,7 +34,7 @@ class Enospace(DfuseTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=daosio,dfuse
-        :avocado: tags=dfuseenospace
+        :avocado: tags=dfuseenospace,test_enospace
         """
         # Create a pool, container and start dfuse.
         self.add_pool(connect=False)

--- a/src/tests/ftest/dfuse/enospace.yaml
+++ b/src/tests/ftest/dfuse/enospace.yaml
@@ -3,6 +3,10 @@ hosts:
 timeout: 120
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   size: 128MiB
   control_method: dmg

--- a/src/tests/ftest/dfuse/posix_stat.py
+++ b/src/tests/ftest/dfuse/posix_stat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -32,9 +32,9 @@ class POSIXStatTest(IorTestBase):
         time.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
+        :avocado: tags=vm
         :avocado: tags=dfuse
-        :avocado: tags=stat_parameters
+        :avocado: tags=stat_parameters,test_stat_parameters
         """
         block_sizes = self.params.get("block_sizes", "/run/*")
         error_list = []

--- a/src/tests/ftest/dfuse/posix_stat.yaml
+++ b/src/tests/ftest/dfuse/posix_stat.yaml
@@ -2,6 +2,12 @@ hosts:
   test_servers: 2
   test_clients: 1
 timeout: 600
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   name: daos_server
   scm_size: 1G

--- a/src/tests/ftest/dtx/basic.py
+++ b/src/tests/ftest/dtx/basic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -30,7 +30,10 @@ class BasicTxTest(TestWithServers):
         Not a good test at this point, need to redesign when tx is fully
         working.
 
-        :avocado: tags=all,container,tx,small,smoke,daily_regression,basictx
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=container,smoke,tx
+        :avocado: tags=basictx,test_tx_basics
         """
         # initialize a python pool object then create the underlying
         # daos storage and connect to the pool

--- a/src/tests/ftest/dtx/basic.yaml
+++ b/src/tests/ftest/dtx/basic.yaml
@@ -17,7 +17,11 @@ faults: !mux
     no_faults:
       fault_list: []
 server_config:
-   name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/fault_domain/fault_domain.py
+++ b/src/tests/ftest/fault_domain/fault_domain.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -34,7 +34,8 @@ class FaultDomain(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
-        :avocado: tags=fault_domain,fault_domain_different_domains
+        :avocado: tags=fault_domain
+        :avocado: tags=fault_domain_different_domains,test_pools_in_different_domains
         """
         test_passed = True
         rank = None

--- a/src/tests/ftest/fault_domain/fault_domain.yaml
+++ b/src/tests/ftest/fault_domain/fault_domain.yaml
@@ -11,6 +11,8 @@ fault_path:
 server_config:
   name: daos_server
   servers:
+    targets: 4
+    nr_xs_helpers: 0
     scm_size: 10
 number_pools: 5
 pool_0:

--- a/src/tests/ftest/mpiio/llnl_mpi4py.py
+++ b/src/tests/ftest/mpiio/llnl_mpi4py.py
@@ -28,8 +28,9 @@ class LlnlMpi4py(MpiioTests):
         test_nb_readwrite, test_rdwr, test_readwrite
 
         :avocado: tags=all,pr,daily_regression
-        :avocado: tags=large
+        :avocado: tags=vm
         :avocado: tags=mpiio,smoke,mpich,llnl
+        :avocado: tags=test_llnl
         """
         test_repo = self.params.get("llnl", '/run/test_repo/')
         self.run_test(test_repo, "llnl")
@@ -46,8 +47,9 @@ class LlnlMpi4py(MpiioTests):
         testIReadIWriteAll, testReadWriteAllBeginEnd
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=large
+        :avocado: tags=vm
         :avocado: tags=mpiio,mpich,mpi4py
+        :avocado: tags=test_mpi4py
         """
         test_repo = self.params.get("mpi4py", '/run/test_repo/')
         self.run_test(test_repo, "mpi4py")

--- a/src/tests/ftest/mpiio/llnl_mpi4py.yaml
+++ b/src/tests/ftest/mpiio/llnl_mpi4py.yaml
@@ -4,6 +4,10 @@ hosts:
 timeout: 180
 server_config:
     name: daos_server
+    servers:
+        targets: 4
+        nr_xs_helpers: 0
+        scm_size: 4
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/network/cart_self_test.py
+++ b/src/tests/ftest/network/cart_self_test.py
@@ -88,7 +88,10 @@ class CartSelfTest(TestWithServers):
     def test_self_test(self):
         """Run a few CaRT self-test scenarios.
 
-        :avocado: tags=all,pr,daily_regression,smoke,unittest,tiny,cartselftest
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=network,smoke
+        :avocado: tags=unittest,cartselftest,test_self_test
         """
         # Setup the orterun command
         orterun = get_job_manager(self, "Orterun", self.SelfTest(self.bin), mpi_type="openmpi")

--- a/src/tests/ftest/network/cart_self_test.yaml
+++ b/src/tests/ftest/network/cart_self_test.yaml
@@ -13,6 +13,10 @@ daos_server:
   pattern_timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 self_test:
   repetitions: 1000
   endpoint: 0:0

--- a/src/tests/ftest/nvme/pool_capacity.yaml
+++ b/src/tests/ftest/nvme/pool_capacity.yaml
@@ -36,7 +36,7 @@ ior:
     ior_test_sequence:
     #   - [scmsize, nvmesize, transfersize, blocksize, PASS/FAIL(Expected) ]
     #    The values are set to be in the multiples of 10.
-    #    Values are appx GB.
+    #    Values are appx GB
         - [4000000000, 18000000000, 1000000, 500000000, PASS]          #[4G, 18G, 1M, 512M, PASS]
         - [4000000000, 18000000000, 1000000, 3000000000, FAIL]         #[4G, 18G, 1M, 3G, FAIL]
         - [300000000000, 550000000000, 1000000000, 8000000000, PASS]          #[300G, 550G, 1G, 8G, PASS]

--- a/src/tests/ftest/object/array.py
+++ b/src/tests/ftest/object/array.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2017-2021 Intel Corporation.
+  (C) Copyright 2017-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -31,7 +31,10 @@ class ArrayObjTest(TestWithServers):
         Test Description: Writes an array to an object and then reads it
         back and verifies it.
 
-        :avocado: tags=all,smoke,daily_regression,object,tiny,basicobject
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=object,smoke
+        :avocado: tags=basicobject,test_array_obj
         """
         self.prepare_pool()
 

--- a/src/tests/ftest/object/array.yaml
+++ b/src/tests/ftest/object/array.yaml
@@ -5,6 +5,10 @@ hosts:
 timeout: 60
 server_config:
      name: daos_server
+     servers:
+          targets: 4
+          nr_xs_helpers: 0
+          scm_size: 4
 pool:
      control_method: dmg
      mode: 511

--- a/src/tests/ftest/object/create_many_dkeys.py
+++ b/src/tests/ftest/object/create_many_dkeys.py
@@ -91,9 +91,9 @@ class CreateManyDkeys(TestWithServers):
                    2. space reclamation after destroy
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
+        :avocado: tags=vm
         :avocado: tags=object
-        :avocado: tags=many_dkeys
+        :avocado: tags=many_dkeys,test_many_dkeys
         """
         self.prepare_pool()
         no_of_dkeys = self.params.get("number_of_dkeys", '/run/dkeys/')

--- a/src/tests/ftest/object/create_many_dkeys.yaml
+++ b/src/tests/ftest/object/create_many_dkeys.yaml
@@ -5,10 +5,13 @@ hosts:
 timeout: 3600
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
-  mode: 511
   name: daos_server
-  scm_size: 8000000000
+  scm_size: 3G
   control_method: dmg
 dkeys:
   number_of_dkeys: 1000000

--- a/src/tests/ftest/object/fetch_bad_param.py
+++ b/src/tests/ftest/object/fetch_bad_param.py
@@ -64,9 +64,11 @@ class ObjFetchBadParam(TestWithServers):
 
         Test Description: Pass a bogus object handle, should return bad handle.
 
-        :avocado: tags=all,object,full_regression,small,objbadhandle
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objbadhandle,test_bad_handle
         """
-
         try:
             # trash the handle and read again
             saved_oh = self.obj.obj_handle
@@ -93,7 +95,10 @@ class ObjFetchBadParam(TestWithServers):
 
         Test Description: Pass null pointers for various fetch parameters.
 
-        :avocado: tags=all,object,full_regression,small,objfetchnull
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objfetchnull,test_null_ptrs
         """
         try:
             # now try it with a bad dkey, expecting this to fail with -1003

--- a/src/tests/ftest/object/fetch_bad_param.yaml
+++ b/src/tests/ftest/object/fetch_bad_param.yaml
@@ -4,6 +4,10 @@ timeouts:
    test_null_ptrs: 240
 server_config:
    name: daos_server
+   servers:
+      targets: 4
+      nr_xs_helpers: 0
+      scm_size: 4
 pool:
    mode: 511
    name: daos_server

--- a/src/tests/ftest/object/integrity.py
+++ b/src/tests/ftest/object/integrity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -80,9 +80,10 @@ class ObjectDataValidation(TestWithServers):
         Test Description:
             Write Avocado Test to verify commit tx and close tx
                           bad parameter behavior.
-        :avocado: tags=all,full_regression,small
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
         :avocado: tags=object,objectvalidation
-        :avocado: tags=invalid_tx
+        :avocado: tags=invalid_tx,test_invalid_tx_commit_close
 
         """
         self.d_log.info("==Writing the Single Dataset for negative test...")
@@ -187,9 +188,10 @@ class ObjectDataValidation(TestWithServers):
         Test ID: DAOS-707
         Test Description: Write Avocado Test to verify single data after
                           pool/container disconnect/reconnect.
-        :avocado: tags=all,full_regression,small
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
         :avocado: tags=object,objectvalidation
-        :avocado: tags=single_object
+        :avocado: tags=single_object,test_single_object_validation
         """
         self.d_log.info("Writing the Single Dataset")
         record_index = 0
@@ -242,9 +244,10 @@ class ObjectDataValidation(TestWithServers):
         Test ID: DAOS-707
         Test Description: Write Avocado Test to verify Array data after
                           pool/container disconnect/reconnect.
-        :avocado: tags=all,full_regression,small
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
         :avocado: tags=object,objectvalidation
-        :avocado: tags=array_object
+        :avocado: tags=array_object,test_array_object_validation
         """
         self.d_log.info("Writing the Array Dataset")
         record_index = 0

--- a/src/tests/ftest/object/integrity.yaml
+++ b/src/tests/ftest/object/integrity.yaml
@@ -3,11 +3,14 @@ hosts:
 #JIRA-3132 tmp update timeout from 2400 to 4800
 timeout: 4800
 server_config:
-   name: daos_server
-pool:
-  mode: 511
   name: daos_server
-  scm_size: 8000000000
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
+pool:
+  name: daos_server
+  scm_size: 3G
   control_method: dmg
 array_size:
   size: 10

--- a/src/tests/ftest/object/open_bad_param.py
+++ b/src/tests/ftest/object/open_bad_param.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -66,7 +66,10 @@ class ObjOpenBadParam(TestWithServers):
 
         Test Description: Attempt to open a garbage object handle.
 
-        :avocado: tags=all,object,full_regression,tiny,objopenbadhandle
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objopenbadhandle,test_bad_obj_handle
         """
         saved_handle = self.obj.obj_handle
         self.obj.obj_handle = 8675309
@@ -88,7 +91,10 @@ class ObjOpenBadParam(TestWithServers):
         Test Description: Attempt to open an object with a garbage container
                           handle.
 
-        :avocado: tags=all,object,full_regression,tiny,objopenbadcont
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objopenbadcont,test_invalid_container_handle
         """
         saved_coh = self.container.coh
         self.container.coh = 8675309
@@ -110,7 +116,10 @@ class ObjOpenBadParam(TestWithServers):
         Test Description: Attempt to open an object in a container with
                           a closed handle.
 
-        :avocado: tags=all,object,full_regression,tiny,objopenclosedcont
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objopenclosedcont,test_closed_container_handle
         """
         self.container.close()
 
@@ -132,7 +141,10 @@ class ObjOpenBadParam(TestWithServers):
                           to open an object that's had its handle set to
                           be the same as a valid pool handle.
 
-        :avocado: tags=all,object,full_regression,tiny,objopenbadpool
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objopenbadpool,test_pool_handle_as_obj_handle
         """
         saved_oh = self.obj.obj_handle
         self.obj.obj_handle = self.pool.pool.handle
@@ -154,7 +166,10 @@ class ObjOpenBadParam(TestWithServers):
         Test Description: Attempt to open an object in a container with
                           an empty ranklist.
 
-        :avocado: tags=all,object,full_regression,tiny,objopennullrl
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objopennullrl,test_null_ranklist
         """
         # null rl
         saved_rl = self.obj.tgt_rank_list
@@ -176,7 +191,10 @@ class ObjOpenBadParam(TestWithServers):
         Test Description: Attempt to open an object in a container with
                           null object id.
 
-        :avocado: tags=all,object,full_regression,tiny,objopennulloid
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objopennulloid,test_null_oid
         """
         # null oid
         saved_oid = self.obj.c_oid
@@ -198,7 +216,10 @@ class ObjOpenBadParam(TestWithServers):
         Test Description: Attempt to open an object in a container with
                           null tgt.
 
-        :avocado: tags=all,object,full_regression,tiny,objopennulltgts
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objopennulltgts,test_null_tgts
         """
         # null tgts
         saved_ctgts = self.obj.c_tgts
@@ -219,7 +240,11 @@ class ObjOpenBadParam(TestWithServers):
 
         Test Description: Attempt to open an object in a container with
                           null object attributes.
-        :avocado: tags=all,object,full_regression,tiny,objopennullattr
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objopennullattr,test_null_attrs
         """
         # null attr
         saved_attr = self.obj.attr

--- a/src/tests/ftest/object/open_bad_param.yaml
+++ b/src/tests/ftest/object/open_bad_param.yaml
@@ -2,6 +2,10 @@ hosts:
   test_servers: 1
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/object/punch_test.py
+++ b/src/tests/ftest/object/punch_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -17,6 +17,7 @@ class PunchTest(TestWithServers):
     Simple test to verify the 3 different punch calls.
     :avocado: recursive
     """
+
     def setUp(self):
         super().setUp()
         self.prepare_pool()
@@ -37,9 +38,11 @@ class PunchTest(TestWithServers):
         """
         The most basic test of the dkey punch function.
 
-        :avocado: tags=all,object,daily_regression,small,dkeypunch
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=dkeypunch,test_dkey_punch
         """
-
         try:
             # create an object and write some data into it
             thedata = b"a string that I want to stuff into an object"
@@ -92,9 +95,11 @@ class PunchTest(TestWithServers):
         """
         The most basic test of the akey punch function.
 
-        :avocado: tags=all,object,daily_regression,small,akeypunch
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=akeypunch,test_akey_punch
         """
-
         try:
             # create an object and write some data into it
             dkey = b"this is the dkey"
@@ -146,9 +151,11 @@ class PunchTest(TestWithServers):
         The most basic test of the object punch function.  Really similar
         to above except the whole object is deleted.
 
-        :avocado: tags=all,object,daily_regression,small,objpunch
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objpunch,test_obj_punch
         """
-
         try:
 
             # create an object and write some data into it

--- a/src/tests/ftest/object/punch_test.yaml
+++ b/src/tests/ftest/object/punch_test.yaml
@@ -3,6 +3,10 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/object/same_key_different_value.py
+++ b/src/tests/ftest/object/same_key_different_value.py
@@ -15,6 +15,7 @@ class SameKeyDifferentValue(TestWithServers):
     passed to same akey and dkey.
     :avocado: recursive
     """
+
     def setUp(self):
         super().setUp()
         self.pool = self.get_pool()

--- a/src/tests/ftest/object/same_key_different_value.yaml
+++ b/src/tests/ftest/object/same_key_different_value.yaml
@@ -3,6 +3,10 @@ hosts:
 timeout: 180
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/object/update_bad_param.py
+++ b/src/tests/ftest/object/update_bad_param.py
@@ -19,6 +19,7 @@ class ObjUpdateBadParam(TestWithServers):
     Pass an assortment of bad parameters to the daos_obj_update function.
     :avocado: recursive
     """
+
     def setUp(self):
         super().setUp()
         self.plog = logging.getLogger("progress")
@@ -41,11 +42,11 @@ class ObjUpdateBadParam(TestWithServers):
 
         Test Description: Pass a bogus object handle, should return bad handle.
 
-        :avocado: tags=all,full_regression,small
-        :avocado: tags=object,objupdatebadparam
-        :avocado: tags=objbadhand
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objbadhand,objupdatebadparam,test_bad_handle
         """
-
         try:
             # create an object and write some data into it
             thedata = b"a string that I want to stuff into an object"
@@ -77,11 +78,11 @@ class ObjUpdateBadParam(TestWithServers):
 
         Test Description: Pass a dkey and an akey that is null.
 
-        :avocado: tags=all,full_regression,small
-        :avocado: tags=object,objupdatebadparam
-        :avocado: tags=objupdatenull
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=object
+        :avocado: tags=objupdatenull,objupdatebadparam,test_null_values
         """
-
         # data used in the test
         thedata = b"a string that I want to stuff into an object"
         thedatasize = len(thedata) + 1

--- a/src/tests/ftest/object/update_bad_param.yaml
+++ b/src/tests/ftest/object/update_bad_param.yaml
@@ -2,6 +2,10 @@ hosts:
   test_servers: 2
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/pool/api_attribute.py
+++ b/src/tests/ftest/pool/api_attribute.py
@@ -109,7 +109,7 @@ class PoolAPIAttributeTest(TestWithServers):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_attribute
-        :avocado: tags=large_pool_attribute
+        :avocado: tags=large_pool_attribute,test_pool_large_attributes
         """
         self.add_pool()
         attr_dict = self.create_data_set()
@@ -138,7 +138,7 @@ class PoolAPIAttributeTest(TestWithServers):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_attribute
-        :avocado: tags=sync_pool_attribute
+        :avocado: tags=sync_pool_attribute,test_pool_attributes
         """
         self.add_pool()
         expected_for_param = []
@@ -214,7 +214,7 @@ class PoolAPIAttributeTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_attribute
-        :avocado: tags=async_pool_attribute
+        :avocado: tags=async_pool_attribute,test_pool_attribute_async
         """
         self.add_pool()
 

--- a/src/tests/ftest/pool/api_attribute.yaml
+++ b/src/tests/ftest/pool/api_attribute.yaml
@@ -5,6 +5,10 @@ hosts:
 timeout: 90
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -22,7 +22,7 @@ class BadConnectTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool
-        :avocado: tags=bad_connect
+        :avocado: tags=bad_connect,test_connect
         """
         self.add_pool(connect=False)
 

--- a/src/tests/ftest/pool/bad_connect.yaml
+++ b/src/tests/ftest/pool/bad_connect.yaml
@@ -1,10 +1,14 @@
-server_config:
-  name: daos_server
-
 hosts:
   test_servers: 1
 
 timeout: 700
+
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 
 pool:
   control_method: dmg

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -26,8 +26,9 @@ class BadEvictTest(TestWithServers):
             Pass bad parameters to the pool evict clients call.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=tiny
-        :avocado: tags=pool,bad_evict
+        :avocado: tags=vm
+        :avocado: tags=pool
+        :avocado: tags=bad_evict,test_evict
         """
         # Accumulate a list of pass/fail indicators representing what is
         # expected for each parameter then "and" them to determine the

--- a/src/tests/ftest/pool/bad_evict.yaml
+++ b/src/tests/ftest/pool/bad_evict.yaml
@@ -1,24 +1,28 @@
-server_config:
-   name: daos_server
 hosts:
   test_servers: 1
 timeout: 650
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511
   scm_size: 1073741824
   name: daos_server
 evicttests:
-   UUID: !mux
-     gooduuid:
-          uuid:
-             - VALID
-             - PASS
-     nulluuid:
-          uuid:
-             - NULL
-             - FAIL
-     baduuid:
-          uuid:
-             - JUNK
-             - FAIL
+  UUID: !mux
+    gooduuid:
+      uuid:
+        - VALID
+        - PASS
+    nulluuid:
+      uuid:
+        - NULL
+        - FAIL
+    baduuid:
+      uuid:
+        - JUNK
+        - FAIL

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -29,7 +29,7 @@ class BadQueryTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool
-        :avocado: tags=bad_query
+        :avocado: tags=bad_query,test_query
         """
         # Accumulate a list of pass/fail indicators representing what is
         # expected for each parameter then "and" them to determine the

--- a/src/tests/ftest/pool/bad_query.yaml
+++ b/src/tests/ftest/pool/bad_query.yaml
@@ -1,22 +1,26 @@
 # Note that stuff that is commented out represents tests that presently
 # fail and will be uncommented as the daos code is fixed
-server_config:
-   name: daos_server
 hosts:
   test_servers: 1
 timeout: 150
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511
   scm_size: 1GB
   name: daos_server
 querytests:
-   handles: !mux
-     goodhandle:
-          handle:
-             - VALID
-             - PASS
-     badhandle:
-          handle:
-             - 0
-             - FAIL
+  handles: !mux
+    goodhandle:
+      handle:
+        - VALID
+        - PASS
+    badhandle:
+      handle:
+        - 0
+        - FAIL

--- a/src/tests/ftest/pool/create_all_vm.py
+++ b/src/tests/ftest/pool/create_all_vm.py
@@ -57,7 +57,7 @@ class PoolCreateAllVmTests(PoolCreateAllTestBase):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_create_all
-        :avocado: tags=pool_create_all_one_vm
+        :avocado: tags=pool_create_all_one_vm,test_one_pool
         """
         self.log.info("Test  basic pool creation with full storage")
 
@@ -90,7 +90,7 @@ class PoolCreateAllVmTests(PoolCreateAllTestBase):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_create_all
-        :avocado: tags=pool_create_all_recycle_vm
+        :avocado: tags=pool_create_all_recycle_vm,test_recycle_pools
         """
         self.log.info("Test pool creation and destruction")
 
@@ -171,7 +171,7 @@ class PoolCreateAllVmTests(PoolCreateAllTestBase):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_create_all
-        :avocado: tags=pool_create_all_two_vm
+        :avocado: tags=pool_create_all_two_vm,test_two_pools
         """
         self.log.info("Test pool creation of two pools with 50% and 100% of the available storage")
 

--- a/src/tests/ftest/pool/create_all_vm.yaml
+++ b/src/tests/ftest/pool/create_all_vm.yaml
@@ -8,6 +8,8 @@ server_config:
   name: daos_server
   servers:
     0:
+      targets: 4
+      nr_xs_helpers: 0
       scm_class: ram
       scm_mount: /mnt/daos
       scm_size: 4

--- a/src/tests/ftest/pool/destroy.py
+++ b/src/tests/ftest/pool/destroy.py
@@ -168,7 +168,7 @@ class DestroyTests(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_destroy
-        :avocado: tags=pool_destroy_single
+        :avocado: tags=pool_destroy_single,test_destroy_single
         """
         hostlist_servers = self.hostlist_servers[:1]
         setname = self.params.get("setname", '/run/setnames/validsetname/')
@@ -182,7 +182,7 @@ class DestroyTests(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_destroy
-        :avocado: tags=pool_destroy_multi
+        :avocado: tags=pool_destroy_multi,test_destroy_multi
         """
         hostlist_servers = self.hostlist_servers[:2]
         setname = self.params.get("setname", '/run/setnames/validsetname/')
@@ -199,7 +199,7 @@ class DestroyTests(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_destroy
-        :avocado: tags=pool_destroy_single_loop
+        :avocado: tags=pool_destroy_single_loop,test_destroy_single_loop
         """
         hostlist_servers = self.hostlist_servers[:1]
 
@@ -224,7 +224,7 @@ class DestroyTests(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_destroy
-        :avocado: tags=pool_destroy_multi_loop
+        :avocado: tags=pool_destroy_multi_loop,test_destroy_multi_loop
         """
         hostlist_servers = self.hostlist_servers[:6]
 
@@ -249,7 +249,7 @@ class DestroyTests(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_destroy
-        :avocado: tags=pool_destroy_invalid_uuid
+        :avocado: tags=pool_destroy_invalid_uuid,test_destroy_invalid_uuid
         """
         hostlist_servers = self.hostlist_servers[:1]
         setname = self.params.get("setname", '/run/setnames/validsetname/')
@@ -284,7 +284,7 @@ class DestroyTests(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_destroy
-        :avocado: tags=pool_destroy_invalid_label
+        :avocado: tags=pool_destroy_invalid_label,test_destroy_invalid_label
         """
         hostlist_servers = self.hostlist_servers[:1]
         setname = self.params.get("setname", '/run/setnames/validsetname/')
@@ -344,7 +344,7 @@ class DestroyTests(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_destroy
-        :avocado: tags=pool_destroy_wrong_group
+        :avocado: tags=pool_destroy_wrong_group,test_destroy_wrong_group
         """
         server_group_a = self.server_group + "_a"
         server_group_b = self.server_group + "_b"
@@ -417,7 +417,7 @@ class DestroyTests(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_destroy
-        :avocado: tags=pool_destroy_connected
+        :avocado: tags=pool_destroy_connected,test_destroy_connected
         """
         hostlist_servers = self.hostlist_servers[0:1]
 
@@ -467,7 +467,7 @@ class DestroyTests(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_destroy
-        :avocado: tags=pool_force_destroy_connected
+        :avocado: tags=pool_force_destroy_connected,test_forcedestroy_connected
         """
         hostlist_servers = self.hostlist_servers[0:1]
 

--- a/src/tests/ftest/pool/destroy.yaml
+++ b/src/tests/ftest/pool/destroy.yaml
@@ -6,6 +6,10 @@ setup:
   start_servers_once: False
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 timeout: 360
 pool:
   name: daos_server

--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -30,8 +30,9 @@ class DestroyRebuild(TestWithServers):
             Verifying that a pool can be destroyed during rebuild.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=medium
-        :avocado: tags=pool,destroy_pool_rebuild
+        :avocado: tags=vm
+        :avocado: tags=pool,rebuild
+        :avocado: tags=destroy_pool_rebuild,test_destroy_while_rebuilding
         """
         # Get the test parameters
         targets = self.params.get("targets", "/run/server_config/servers/*")

--- a/src/tests/ftest/pool/destroy_rebuild.yaml
+++ b/src/tests/ftest/pool/destroy_rebuild.yaml
@@ -8,6 +8,8 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/pool/dynamic_server_pool.py
+++ b/src/tests/ftest/pool/dynamic_server_pool.py
@@ -101,7 +101,7 @@ class DynamicServerPool(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,control
-        :avocado: tags=dynamic_server_pool
+        :avocado: tags=dynamic_server_pool,test_dynamic_server_pool
         """
         # Create a pool on rank0.
         self.create_pool_with_ranks(ranks=[0], tl_update=True)

--- a/src/tests/ftest/pool/dynamic_server_pool.yaml
+++ b/src/tests/ftest/pool/dynamic_server_pool.yaml
@@ -9,6 +9,10 @@ extra_servers:
 timeout: 135 # 1.5 times of measured time.
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   scm_size: 1G
   control_method: dmg

--- a/src/tests/ftest/pool/evict.py
+++ b/src/tests/ftest/pool/evict.py
@@ -109,7 +109,7 @@ class EvictTests(TestWithServers):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_evict
-        :avocado: tags=pool_evict_basic
+        :avocado: tags=pool_evict_basic,test_evict
         """
         # Do not use self.pool. It will cause -1002 error when disconnecting.
         pools = []

--- a/src/tests/ftest/pool/evict.yaml
+++ b/src/tests/ftest/pool/evict.yaml
@@ -3,6 +3,10 @@ hosts:
 
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 6
 
 timeout: 170
 

--- a/src/tests/ftest/pool/global_handle.py
+++ b/src/tests/ftest/pool/global_handle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -55,8 +55,9 @@ class GlobalHandle(TestWithServers):
         Test Description: Use a pool handle in another process.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=tiny
-        :avocado: tags=pool,global_handle,pool_global_handle
+        :avocado: tags=vm
+        :avocado: tags=pool,global_handle
+        :avocado: tags=pool_global_handle,test_global_handle
         """
         # initialize a python pool object then create the underlying
         # daos storage

--- a/src/tests/ftest/pool/global_handle.yaml
+++ b/src/tests/ftest/pool/global_handle.yaml
@@ -5,6 +5,10 @@ hosts:
 timeout: 60
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/pool/info.py
+++ b/src/tests/ftest/pool/info.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -27,8 +27,9 @@ class InfoTests(TestWithServers):
             Verify pool query.
 
         :avocado: tags=all,daily_regression,
-        :avocado: tags=tiny
-        :avocado: tags=pool,smoke,info_test
+        :avocado: tags=vm
+        :avocado: tags=pool,smoke
+        :avocado: tags=info_test,test_pool_info_query
         """
         # Get the test params
         permissions = self.params.get("permissions", "/run/test/*")

--- a/src/tests/ftest/pool/info.yaml
+++ b/src/tests/ftest/pool/info.yaml
@@ -5,9 +5,10 @@ server_config:
   name: daos_server
   servers:
     targets: 1
+    nr_xs_helpers: 0
+    scm_size: 5
 pool:
-  createset:
-    name: daos_server
+  name: daos_server
   control_method: dmg
   createsize: !mux
     size1gb:

--- a/src/tests/ftest/pool/label.py
+++ b/src/tests/ftest/pool/label.py
@@ -112,7 +112,7 @@ class Label(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_label
-        :avocado: tags=create_valid_labels
+        :avocado: tags=create_valid_labels,test_valid_labels
         """
         self.pool = []
         errors = []
@@ -140,7 +140,7 @@ class Label(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_label
-        :avocado: tags=create_invalid_labels
+        :avocado: tags=create_invalid_labels,test_invalid_labels
         """
         self.pool = []
         errors = []
@@ -166,7 +166,7 @@ class Label(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_label
-        :avocado: tags=duplicate_label_create
+        :avocado: tags=duplicate_label_create,test_duplicate_create
         """
         self.pool = []
         label = "TestLabel"
@@ -194,7 +194,7 @@ class Label(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_label
-        :avocado: tags=duplicate_label_destroy
+        :avocado: tags=duplicate_label_destroy,test_duplicate_destroy
         """
         self.pool = []
 
@@ -220,7 +220,7 @@ class Label(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool,pool_label
-        :avocado: tags=label_update
+        :avocado: tags=label_update,test_label_update
         """
         self.pool = []
 

--- a/src/tests/ftest/pool/label.yaml
+++ b/src/tests/ftest/pool/label.yaml
@@ -3,6 +3,12 @@ hosts:
 timeout: 900
 setup:
   start_servers_once: False
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   scm_size: 1G

--- a/src/tests/ftest/pool/list_pools.py
+++ b/src/tests/ftest/pool/list_pools.py
@@ -77,7 +77,10 @@ class ListPoolsTest(TestWithServers):
             output list matches the output returned when the pools were
             created.
 
-        :avocado: tags=all,large,pool,full_regression,list_pools
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=pool
+        :avocado: tags=list_pools,test_list_pools
         """
         ranks = list(range(len(self.hostlist_servers)))
 

--- a/src/tests/ftest/pool/list_pools.yaml
+++ b/src/tests/ftest/pool/list_pools.yaml
@@ -4,7 +4,9 @@ timeout: 600
 server_config:
   name: daos_server
   servers:
-    targets: 8
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 6
 pool:
   control_method: dmg
-  size: 1G
+  size: 512M

--- a/src/tests/ftest/pool/multi_server_create_delete.py
+++ b/src/tests/ftest/pool/multi_server_create_delete.py
@@ -33,9 +33,9 @@ class MultiServerCreateDeleteTest(TestWithServers):
         Destroy the pool and verify that the directory is deleted.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
+        :avocado: tags=vm
         :avocado: tags=pool,multitarget
-        :avocado: tags=multiserver_create_delete
+        :avocado: tags=multiserver_create_delete,test_create
         """
         # Accumulate a list of pass/fail indicators representing what is
         # expected for each parameter then "and" them to determine the

--- a/src/tests/ftest/pool/multi_server_create_delete.yaml
+++ b/src/tests/ftest/pool/multi_server_create_delete.yaml
@@ -5,6 +5,10 @@ timeout: 240
 
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 
 pool:
   control_method: dmg

--- a/src/tests/ftest/pool/pda.py
+++ b/src/tests/ftest/pool/pda.py
@@ -47,7 +47,7 @@ class PoolPDAProperty(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pool
-        :avocado: tags=pool_pda_property
+        :avocado: tags=pool_pda_property,test_pda_pool_property
         """
 
         # Create the pool with default

--- a/src/tests/ftest/pool/pda.yaml
+++ b/src/tests/ftest/pool/pda.yaml
@@ -1,21 +1,27 @@
 hosts:
   test_servers: 1
 timeout: 90
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
-    name: daos_server
-    control_method: dmg
-    scm_size: 1G
+  name: daos_server
+  control_method: dmg
+  scm_size: 1G
 pool_1:
-    name: daos_server
-    control_method: dmg
-    scm_size: 1G
-    properties: ec_pda:2,rp_pda:4
+  name: daos_server
+  control_method: dmg
+  scm_size: 1G
+  properties: ec_pda:2,rp_pda:4
 container:
-    type: POSIX
-    control_method: daos
+  type: POSIX
+  control_method: daos
 container_1:
-    type: POSIX
-    pda_properties:
-      - 3       # ec_pda
-      - 5       # rp_pda
-    control_method: daos
+  type: POSIX
+  pda_properties:
+    - 3       # ec_pda
+    - 5       # rp_pda
+  control_method: daos

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -30,7 +30,9 @@ class Permission(TestWithServers):
             permission levels.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=pool,permission,file_modification
+        :avocado: tags=vm
+        :avocado: tags=pool
+        :avocado: tags=permission,file_modification,test_file_modification
         """
         # parameter used for pool connect
         permissions = self.params.get("perm", '/run/createtests/permissions/*')

--- a/src/tests/ftest/pool/permission.yaml
+++ b/src/tests/ftest/pool/permission.yaml
@@ -10,22 +10,26 @@ hosts:
   test_servers: 2
 timeout: 300
 server_config:
-    name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
-    control_method: dmg
-    scm_size: 1000000000
-    name: daos_server
+  control_method: dmg
+  scm_size: 1000000000
+  name: daos_server
 createtests:
-    permissions: !mux
-        perm_RO:
-           perm: 0
-           exp_result: FAIL
-        perm_RW:
-           perm: 1
-           exp_result: PASS
-        perm_EX:
-           perm: 2
-           exp_result: PASS
-        perm_invalid:
-           perm: 777
-           exp_result: FAIL
+  permissions: !mux
+    perm_RO:
+      perm: 0
+      exp_result: FAIL
+    perm_RW:
+      perm: 1
+      exp_result: PASS
+    perm_EX:
+      perm: 2
+      exp_result: PASS
+    perm_invalid:
+      perm: 777
+      exp_result: FAIL

--- a/src/tests/ftest/pool/query_attribute.py
+++ b/src/tests/ftest/pool/query_attribute.py
@@ -39,8 +39,9 @@ class QueryAttributeTest(TestWithServers):
             Test query, set-attr, list-attr, and get-attr commands.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=pool,pool_query_attr
+        :avocado: tags=vm
+        :avocado: tags=pool,pool_query
+        :avocado: tags=pool_query_attr,test_query_attr
         """
         errors = []
         daos_cmd = self.get_daos_command()

--- a/src/tests/ftest/pool/query_attribute.yaml
+++ b/src/tests/ftest/pool/query_attribute.yaml
@@ -5,6 +5,8 @@ server_config:
   name: daos_server
   servers:
     targets: 8
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   scm_size: 1000000000
   control_method: dmg

--- a/src/tests/ftest/pool/svc.py
+++ b/src/tests/ftest/pool/svc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -63,8 +63,9 @@ class PoolSvc(TestWithServers):
         """Test svc arg during pool create.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=medium
-        :avocado: tags=pool,pool_svc,test_pool_svc,svc
+        :avocado: tags=vm
+        :avocado: tags=pool,svc
+        :avocado: tags=pool_svc,test_pool_svc
         :avocado: tags=DAOS_5610
         """
         # parameter used in pool create

--- a/src/tests/ftest/pool/svc.yaml
+++ b/src/tests/ftest/pool/svc.yaml
@@ -1,28 +1,32 @@
 hosts:
   test_servers: 5
 server_config:
-    name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 timeout: 200
 pool:
-    control_method: dmg
-    mode: 146
-    name: daos_server
-    scm_size: 134217728
-    pool_query_timeout: 30
+  control_method: dmg
+  mode: 146
+  name: daos_server
+  scm_size: 134217728
+  pool_query_timeout: 30
 svc_params_mux: !mux
-    svc_params_none:
-        svc_params: [None, 3]
-    svc_params_0:
-        svc_params: [0, 3]
-    svc_params_1:
-        svc_params: [1, 1]
-    svc_params_2:
-        svc_params: [2, 2]
-    svc_params_3:
-        svc_params: [3, 3]
-    svc_params_4:
-        svc_params: [4, 4]
-    svc_params_5:
-        svc_params: [5, 4]
-    svc_params_6:
-        svc_params: [6, 0]
+  svc_params_none:
+    svc_params: [None, 3]
+  svc_params_0:
+    svc_params: [0, 3]
+  svc_params_1:
+    svc_params: [1, 1]
+  svc_params_2:
+    svc_params: [2, 2]
+  svc_params_3:
+    svc_params: [3, 3]
+  svc_params_4:
+    svc_params: [4, 4]
+  svc_params_5:
+    svc_params: [5, 4]
+  svc_params_6:
+    svc_params: [6, 0]

--- a/src/tests/ftest/pool/uuid_corner_case.py
+++ b/src/tests/ftest/pool/uuid_corner_case.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -30,8 +30,9 @@ class UUIDCornerCase(TestWithServers):
         Test Description: Create with a label, destroy with UUID.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=small
-        :avocado: tags=pool,uuid_corner_case,create_label_destroy_uuid
+        :avocado: tags=vm
+        :avocado: tags=pool,uuid,label
+        :avocado: tags=uuid_corner_case,create_label_destroy_uuid,test_create_label_destroy_uuid
         """
         # Create with a label - Default.
         self.add_pool(connect=False)

--- a/src/tests/ftest/pool/uuid_corner_case.yaml
+++ b/src/tests/ftest/pool/uuid_corner_case.yaml
@@ -3,6 +3,10 @@ hosts:
 timeout: 240
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   name: daos_server
   scm_size: 1G

--- a/src/tests/ftest/rebuild/basic.py
+++ b/src/tests/ftest/rebuild/basic.py
@@ -137,7 +137,7 @@ class RbldBasic(TestWithServers):
             single pool rebuild, single client, various record/object counts
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=vm,large
+        :avocado: tags=vm
         :avocado: tags=rebuild
         :avocado: tags=pool,rebuild_tests,test_simple_rebuild
         """
@@ -153,7 +153,7 @@ class RbldBasic(TestWithServers):
             multipool rebuild, single client, various object and record counts
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=vm,large
+        :avocado: tags=vm
         :avocado: tags=rebuild
         :avocado: tags=pool,rebuild_tests,test_multipool_rebuild
         """

--- a/src/tests/ftest/rebuild/basic.yaml
+++ b/src/tests/ftest/rebuild/basic.yaml
@@ -7,6 +7,8 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/rebuild/cascading_failures.py
+++ b/src/tests/ftest/rebuild/cascading_failures.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -97,8 +97,10 @@ class RbldCascadingFailures(RebuildTestBase):
         Use Cases:
             Verify rebuild with multiple server failures.
 
-        :avocado: tags=all,large,full_regression,rebuild
-        :avocado: tags=multitarget,simultaneous
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=rebuild
+        :avocado: tags=multitarget,simultaneous,test_simultaneous_failures
         """
         self.mode = "simultaneous"
         self.execute_rebuild_test()
@@ -117,8 +119,10 @@ class RbldCascadingFailures(RebuildTestBase):
         Use Cases:
             Verify rebuild with multiple server failures.
 
-        :avocado: tags=all,large,full_regression,rebuild
-        :avocado: tags=multitarget,sequential
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=rebuild
+        :avocado: tags=multitarget,sequential,test_sequential_failures
         """
         self.mode = "sequential"
         self.execute_rebuild_test()
@@ -137,8 +141,10 @@ class RbldCascadingFailures(RebuildTestBase):
         Use Cases:
             Verify rebuild with multiple server failures.
 
-        :avocado: tags=all,large,full_regression,rebuild
-        :avocado: tags=multitarget,cascading
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=rebuild
+        :avocado: tags=multitarget,cascading,test_cascading_failures
         """
         self.mode = "cascading"
         self.execute_rebuild_test()

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -6,6 +6,8 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/rebuild/container_rf.py
+++ b/src/tests/ftest/rebuild/container_rf.py
@@ -42,9 +42,9 @@ class RbldContRfTest(ContRedundancyFactor):
             Verify container RF with rebuild with multiple server failures.
 
         :avocado: tags=all,full_regression
+        :avocado: tags=vm
         :avocado: tags=container,rebuild
-        :avocado: tags=container_rf
-        :avocado: tags=rebuild_container_rf
+        :avocado: tags=container_rf,rebuild_container_rf,test_rebuild_with_container_rf
         """
         self.mode = "cont_rf_with_rebuild"
         self.execute_cont_rf_test()

--- a/src/tests/ftest/rebuild/container_rf.yaml
+++ b/src/tests/ftest/rebuild/container_rf.yaml
@@ -6,6 +6,8 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/rebuild/delete_objects.py
+++ b/src/tests/ftest/rebuild/delete_objects.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -87,8 +87,9 @@ class RbldDeleteObjects(RebuildTestBase):
             foo
 
         :avocado: tags=all,full_regression
-        :avocado: tags=large
-        :avocado: tags=rebuild,delete_objects,rebuilddeleteobject
+        :avocado: tags=vm
+        :avocado: tags=rebuild
+        :avocado: tags=delete_objects,rebuilddeleteobject,test_rebuild_delete_objects
         """
         self.punch_type = "object"
         self.execute_rebuild_test()
@@ -106,8 +107,9 @@ class RbldDeleteObjects(RebuildTestBase):
             foo
 
         :avocado: tags=all,full_regression
-        :avocado: tags=large
-        :avocado: tags=rebuild,delete_objects,rebuilddeleterecord
+        :avocado: tags=vm
+        :avocado: tags=rebuild
+        :avocado: tags=delete_objects,rebuilddeleterecord,test_rebuild_delete_records
         """
         self.punch_type = "record"
         self.execute_rebuild_test()

--- a/src/tests/ftest/rebuild/delete_objects.yaml
+++ b/src/tests/ftest/rebuild/delete_objects.yaml
@@ -6,6 +6,8 @@ server_config:
   name: daos_server
   servers:
     targets: 1
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/rebuild/read_array.py
+++ b/src/tests/ftest/rebuild/read_array.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -54,6 +54,8 @@ class RbldReadArrayTest(RebuildTestBase):
             numbers of rebuild targets and no available rebuild targets.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=vm,large,rebuild,rebuildreadarray
+        :avocado: tags=vm
+        :avocado: tags=rebuild
+        :avocado: tags=rebuildreadarray,test_read_array_during_rebuild
         """
         self.execute_rebuild_test()

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -4,11 +4,14 @@ hosts:
 timeout: 240
 server_config:
   name: daos_server
-  servers: !mux
-    1_target:
-      targets: 1
-    2_targets:
-      targets: 2
+  servers:
+    targets_count: !mux
+      1_target:
+        targets: 1
+      2_targets:
+        targets: 2
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/rebuild/with_io.py
+++ b/src/tests/ftest/rebuild/with_io.py
@@ -31,7 +31,10 @@ class RbldWithIO(TestWithServers):
             single pool, single client performing continuous read/write/verify
             sequence while failure/rebuild is triggered in another process
 
-        :avocado: tags=all,pool,rebuild,daily_regression,medium,rebuildwithio
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=pool,rebuild
+        :avocado: tags=rebuildwithio,test_rebuild_with_io
         """
         # Get the test params
         self.add_pool(create=False)

--- a/src/tests/ftest/rebuild/with_io.yaml
+++ b/src/tests/ftest/rebuild/with_io.yaml
@@ -7,6 +7,8 @@ server_config:
   name: daos_server
   servers:
     targets: 2
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/security/cont_acl.py
+++ b/src/tests/ftest/security/cont_acl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -56,6 +56,7 @@ class DaosContainterSecurityTest(ContSecurityTestBase, PoolSecurityTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=security,container_acl,cont_user_sec,cont_group_sec,cont_sec
+        :avocado: tags=test_container_user_acl
         """
 
         #(1)Setup

--- a/src/tests/ftest/security/cont_acl.yaml
+++ b/src/tests/ftest/security/cont_acl.yaml
@@ -7,6 +7,10 @@ timeout: 1200
 server_config:
   name: daos_server
   port: 10001
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   name: daos_server
   scm_size: 138374182

--- a/src/tests/ftest/security/cont_create_acl.py
+++ b/src/tests/ftest/security/cont_create_acl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -16,6 +16,7 @@ class CreateContainterACLTest(ContSecurityTestBase):
 
     :avocado: recursive
     """
+
     def test_container_basics(self):
         """Test basic container create/destroy/open/close/query.
 
@@ -28,8 +29,10 @@ class CreateContainterACLTest(ContSecurityTestBase):
                file passed.
             7. Remove all files created
 
-        :avocado: tags=all,daily_regression,security,container_acl
-        :avocado: tags=cont_create_acl
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_create_acl,test_container_basics
         """
         acl_args = {"tmp_dir": self.tmp,
                     "user": self.current_user,

--- a/src/tests/ftest/security/cont_create_acl.yaml
+++ b/src/tests/ftest/security/cont_create_acl.yaml
@@ -6,6 +6,10 @@ timeout: 60
 server_config:
   name: daos_server
   port: 10001
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -18,6 +18,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
 
     :avocado: recursive
     """
+
     def setUp(self):
         """Set up each test case."""
         super().setUp()
@@ -41,8 +42,10 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container delete command performs as
             expected with invalid inputs.
 
-        :avocado: tags=all,daily_regression,security,container_acl
-        :avocado: tags=cont_delete_acl_inputs
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_delete_acl_inputs,test_acl_delete_invalid_inputs
         """
         # Get list of invalid ACL principal values
         invalid_principals = self.params.get("invalid_principals", "/run/*")

--- a/src/tests/ftest/security/cont_delete_acl.yaml
+++ b/src/tests/ftest/security/cont_delete_acl.yaml
@@ -6,6 +6,10 @@ hosts:
 timeout: 100
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/security/cont_get_acl.py
+++ b/src/tests/ftest/security/cont_get_acl.py
@@ -21,6 +21,7 @@ class GetContainerACLTest(ContSecurityTestBase):
 
     :avocado: recursive
     """
+
     def setUp(self):
         """Set up each test case."""
         super().setUp()
@@ -37,8 +38,10 @@ class GetContainerACLTest(ContSecurityTestBase):
             expected with valid inputs and verify that we can't overwrite
             an already existing file when using the --outfile argument.
 
-        :avocado: tags=all,pr,daily_regression,security,container_acl
-        :avocado: tags=cont_get_acl_inputs
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_get_acl_inputs,test_get_acl_valid
         """
         test_errs = []
         for verbose in [True, False]:
@@ -81,8 +84,10 @@ class GetContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container get-acl command doesn't
             get ACL information without permission.
 
-        :avocado: tags=all,daily_regression,security,container_acl
-        :avocado: tags=cont_get_acl_noperms
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_get_acl_noperms,test_no_user_permissions
         """
         # Let's give access to the pool to the root user
         self.get_dmg_command().pool_update_acl(

--- a/src/tests/ftest/security/cont_get_acl.yaml
+++ b/src/tests/ftest/security/cont_get_acl.yaml
@@ -6,6 +6,10 @@ hosts:
 timeout: 100
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/security/cont_overwrite_acl.py
+++ b/src/tests/ftest/security/cont_overwrite_acl.py
@@ -21,6 +21,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
 
     :avocado: recursive
     """
+
     def setUp(self):
         """Set up each test case."""
         super().setUp()
@@ -41,8 +42,10 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
             expected with invalid inputs in command line and within ACL file
             provided.
 
-        :avocado: tags=all,daily_regression,security,container_acl
-        :avocado: tags=cont_overwrite_acl_inputs
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_overwrite_acl_inputs,test_acl_overwrite_invalid_inputs
         """
         # Get list of invalid ACL principal values
         invalid_acl_filename = self.params.get("invalid_acl_filename", "/run/*")
@@ -77,8 +80,10 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
             expected with invalid inputs in command line and within ACL file
             provided.
 
-        :avocado: tags=all,daily_regression,security,container_acl
-        :avocado: tags=cont_overwrite_acl_file
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_overwrite_acl_file,test_overwrite_invalid_acl_file
         """
         invalid_file_content = self.params.get(
             "invalid_acl_file_content", "/run/*")

--- a/src/tests/ftest/security/cont_overwrite_acl.yaml
+++ b/src/tests/ftest/security/cont_overwrite_acl.yaml
@@ -6,6 +6,10 @@ hosts:
 timeout: 120
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/security/cont_update_acl.py
+++ b/src/tests/ftest/security/cont_update_acl.py
@@ -39,8 +39,10 @@ class UpdateContainerACLTest(ContSecurityTestBase):
             expected with valid and invalid inputs in command line for the
             --entry and --acl-file options.
 
-        :avocado: tags=all,daily_regression,security,container_acl
-        :avocado: tags=cont_update_acl_inputs
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_update_acl_inputs,test_acl_update_invalid_inputs
         """
         # Get lists of invalid
         invalid_entries = self.params.get("invalid_acl_entries", "/run/*")
@@ -85,8 +87,10 @@ class UpdateContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container update command performs as
             expected with invalid values within ACL file.
 
-        :avocado: tags=all,daily_regression,security,container_acl
-        :avocado: tags=cont_update_invalid_acl
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_update_invalid_acl,test_update_invalid_acl
         """
         invalid_file_content = self.params.get(
             "invalid_acl_file_content", "/run/*")
@@ -122,8 +126,10 @@ class UpdateContainerACLTest(ContSecurityTestBase):
             expected when adding an ACL file that contains principals that are
             currently in the ACL.
 
-        :avocado: tags=all,daily_regression,security,container_acl
-        :avocado: tags=cont_update_acl
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_update_acl,test_update_acl_file
         """
         path_to_file = os.path.join(self.tmp, self.acl_filename)
 
@@ -173,8 +179,10 @@ class UpdateContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container update command fails with
             no permission -1001 when user doesn't have the right permissions.
 
-        :avocado: tags=all,daily_regression,security,container_acl
-        :avocado: tags=cont_update_acl_noperms
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=security,container_acl
+        :avocado: tags=cont_update_acl_noperms,test_no_user_permissions
         """
         valid_file_content = self.params.get("valid_acl_file", "/run/*")
         path_to_file = os.path.join(self.tmp, self.acl_filename)

--- a/src/tests/ftest/security/cont_update_acl.yaml
+++ b/src/tests/ftest/security/cont_update_acl.yaml
@@ -6,6 +6,10 @@ hosts:
 timeout: 120
 server_config:
   name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
   mode: 511

--- a/src/tests/ftest/security/pool_acl.py
+++ b/src/tests/ftest/security/pool_acl.py
@@ -41,7 +41,11 @@ class DaosRunPoolSecurityTest(PoolSecurityTestBase):
             verify pool user and group read, write, read-write and none
             permissions enforcement with all forms of input under different
             test scenarios
-        :avocado: tags=all,full_regression,security,pool_acl,sec_acl
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=security,pool
+        :avocado: tags=pool_acl,sec_acl,test_daos_pool_acl_enforcement
         """
         user_uid = os.geteuid()
         user_gid = os.getegid()

--- a/src/tests/ftest/security/pool_acl.yaml
+++ b/src/tests/ftest/security/pool_acl.yaml
@@ -5,6 +5,10 @@ timeout: 600
 server_config:
   name: daos_server
   port: 10001
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
 # Uncomment following to force the use of certificates

--- a/src/tests/ftest/security/pool_connect_init.py
+++ b/src/tests/ftest/security/pool_connect_init.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -31,8 +31,9 @@ class PoolSecurityTest(TestWithServers):
            Above 3 testcases are defined in the yaml file.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=small
-        :avocado: tags=pool,sec_basic,security
+        :avocado: tags=vm
+        :avocado: tags=pool,security
+        :avocado: tags=sec_basic,test_pool_connect
         """
         der_no_permission = "RC: -1001"
         user_uid = os.geteuid()

--- a/src/tests/ftest/security/pool_connect_init.yaml
+++ b/src/tests/ftest/security/pool_connect_init.yaml
@@ -2,7 +2,11 @@ hosts:
  test_servers: 1
 timeout: 60
 server_config:
-   name: daos_server
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 # Uncomment following to force the use of certificates
 # regardless of the launch.py --insecure setting.
 #   transport_config:

--- a/src/tests/ftest/security/pool_groups.py
+++ b/src/tests/ftest/security/pool_groups.py
@@ -38,7 +38,11 @@ class DaosRunPoolSecurityTest(PoolSecurityTestBase):
             acl permission, verify pool user and group read, write, read-write
             and none permissions enforcement with all forms of input under
             different test scenarios
-        :avocado: tags=all,full_regression,security,pool_acl,sec_acl_groups
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=security,pool
+        :avocado: tags=pool_acl,sec_acl_groups,test_daos_pool_acl_groups
         '''
         user_gid = os.getegid()
         current_group = grp.getgrgid(user_gid)[0]

--- a/src/tests/ftest/security/pool_groups.yaml
+++ b/src/tests/ftest/security/pool_groups.yaml
@@ -5,6 +5,10 @@ timeout: 600
 server_config:
   name: daos_server
   port: 10001
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   control_method: dmg
 pool_acl:

--- a/src/tests/ftest/telemetry/dkey_akey_enum_punch.py
+++ b/src/tests/ftest/telemetry/dkey_akey_enum_punch.py
@@ -206,7 +206,7 @@ class DkeyAkeyEnumPunch(TestWithTelemetry):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=telemetry
-        :avocado: tags=dkey_akey_enum_punch
+        :avocado: tags=dkey_akey_enum_punch,test_dkey_akey_enum_punch
         """
         self.add_pool()
 
@@ -339,7 +339,7 @@ class DkeyAkeyEnumPunch(TestWithTelemetry):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=telemetry
-        :avocado: tags=pool_tgt_dkey_akey_punch
+        :avocado: tags=pool_tgt_dkey_akey_punch,test_pool_tgt_dkey_akey_punch
         """
         self.add_pool()
 
@@ -425,7 +425,7 @@ class DkeyAkeyEnumPunch(TestWithTelemetry):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=telemetry
-        :avocado: tags=tgt_dkey_akey_punch
+        :avocado: tags=tgt_dkey_akey_punch,test_tgt_dkey_akey_punch
         """
         self.add_pool()
 

--- a/src/tests/ftest/telemetry/dkey_akey_enum_punch.yaml
+++ b/src/tests/ftest/telemetry/dkey_akey_enum_punch.yaml
@@ -7,6 +7,8 @@ server_config:
   servers:
     0:
       targets: 8
+      nr_xs_helpers: 0
+      scm_size: 4
 
 pool:
   scm_size: 1G

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -141,11 +141,11 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
             For RF=0 the sum should be exactly equal to the expected workload
             and for RF=2 (with RP_2GX) sum should be double the size of
             workload for write but same for read.
+
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=telemetry
-        :avocado: tags=telemetry_pool_metrics
-
+        :avocado: tags=telemetry_pool_metrics,test_telemetry_pool_metrics
         """
         # test parameters
         self.threshold_percent = self.params.get("threshold_percent",

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.yaml
@@ -2,6 +2,12 @@ hosts:
   test_servers: 4
   test_clients: 1
 timeout: 240
+server_config:
+  name: daos_server
+  servers:
+    targets: 4
+    nr_xs_helpers: 0
+    scm_size: 4
 pool:
   name: daos_server
   scm_size: 1G


### PR DESCRIPTION
Skip-unit-tests: true
Test-tag: nvme_pool_capacity

Reducing the allocated amount of SCM space (tmpfs) being used in the VMs
and removing helper xstreams and reducing the number of targets to 4x.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>