### PR TITLE
DAOS-10499 test: Re-test the nvme pool capacity.

### DIFF
--- a/src/tests/ftest/nvme/pool_capacity.yaml
+++ b/src/tests/ftest/nvme/pool_capacity.yaml
@@ -36,7 +36,7 @@ ior:
     ior_test_sequence:
     #   - [scmsize, nvmesize, transfersize, blocksize, PASS/FAIL(Expected) ]
     #    The values are set to be in the multiples of 10.
-    #    Values are appx GB.
+    #    Values are appx GB
         - [4000000000, 18000000000, 1000000, 500000000, PASS]          #[4G, 18G, 1M, 512M, PASS]
         - [4000000000, 18000000000, 1000000, 3000000000, FAIL]         #[4G, 18G, 1M, 3G, FAIL]
         - [300000000000, 550000000000, 1000000000, 8000000000, PASS]          #[300G, 550G, 1G, 8G, PASS]


### PR DESCRIPTION
Skip-unit-tests: true
Test-tag: nvme_pool_capacity

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>