### PR TITLE
DAOS-11187 dtx: properly handle DTX commit failure

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -831,16 +831,19 @@ out:
 
 log:
 	if (rc != 0 || rc1 != 0 || rc2 != 0) {
-		D_ERROR("Failed to commit DTXs "DF_DTI", count %d: rc %d %d %d, %s committed\n",
-			DP_DTI(&dtes[0]->dte_xid), count, rc, rc1, rc2,
+		D_ERROR("Some failure during commit DTX entries "DF_DTI", epoch "
+			DF_X64", count %d: rc %d %d %d, %s committed\n",
+			DP_DTI(&dtes[0]->dte_xid), epoch, count, rc, rc1, rc2,
 			committed > 0 ? "partial" : "nothing");
 
-		if (epoch != 0 && committed == 0) {
-			D_ASSERT(count == 1);
+		if (epoch != 0) {
+			if (committed == 0) {
+				D_ASSERT(count == 1);
 
-			dtx_abort(cont, dtes[0], epoch);
-		} else {
-			rc = rc1 = rc2 = 0;
+				dtx_abort(cont, dtes[0], epoch);
+			} else {
+				rc = rc1 = rc2 = 0;
+			}
 		}
 	} else {
 		D_DEBUG(DB_IO, "Commit DTXs " DF_DTI", count %d\n",


### PR DESCRIPTION
When close the container, the DTX logic will try to flush
committable ones. Such DTX commit may hit failures. If we
hide related failures inside dtx_commit, it will misguide
the dtx_flush_on_close() logic as to the DTX flush may be
assert for related undeletable DTX entries.

Signed-off-by: Fan Yong <fan.yong@intel.com>