### PR TITLE
DAOS-10869 test: fix passwdlessssh index error (#9785)

### DIFF
--- a/src/tests/ftest/deployment/critical_integration.py
+++ b/src/tests/ftest/deployment/critical_integration.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2018-2022 Intel Corporation.
 
@@ -100,7 +99,10 @@ class CriticalIntegrationWithoutServers(TestWithoutServers):
         libfabric_version_cmd = "clush -S -b -w {} {}/fi_info --version".format(
             all_nodes, libfabric_path)
         libfabric_output = run_command(libfabric_version_cmd)
-        same_libfab_nodes = libfabric_output.stdout_text.split('\n')[1].split('(')[1][:-1]
+        if len(all_nodes) == 1:
+            same_libfab_nodes = 1
+        else:
+            same_libfab_nodes = libfabric_output.stdout_text.split('\n')[1].split('(')[1][:-1]
         libfabric_version = libfabric_output.stdout_text.split('\n')[3].split(' ')[1]
 
         result_libfabric_version = int(same_libfab_nodes) == len(all_nodes)


### PR DESCRIPTION
Test-tag: passwdlessssh_versioncheck
Skip-unit-tests: true
Skip-fault-injection-test: true

Fix possible index out of range error

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>