### PR TITLE
DAOS-9827 test: datamover: use get_container (#9768)

### DIFF
--- a/src/tests/ftest/datamover/copy_procs.py
+++ b/src/tests/ftest/datamover/copy_procs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -45,8 +45,8 @@ class DmvrCopyProcs(DataMoverTestBase):
         """
         # Create pool and containers
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
-        cont2 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
+        cont2 = self.get_container(pool1)
 
         # Get the varying number of processes
         procs_list = self.params.get("processes", "/run/dcp/copy_procs/*")

--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -60,7 +60,7 @@ class DmvrDstCreate(DataMoverTestBase):
         pool1.connect(2)
 
         # Create a source cont
-        cont1 = self.create_cont(pool1, cont_type=cont_type)
+        cont1 = self.get_container(pool1, type=cont_type)
 
         # Create source data
         src_props = self.write_cont(cont1)

--- a/src/tests/ftest/datamover/large_dir.py
+++ b/src/tests/ftest/datamover/large_dir.py
@@ -48,7 +48,7 @@ class DmvrLargeDir(DataMoverTestBase):
 
         # create pool and cont1
         pool = self.create_pool()
-        cont1 = self.create_cont(pool)
+        cont1 = self.get_container(pool)
 
         # run mdtest to create data in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
@@ -57,7 +57,7 @@ class DmvrLargeDir(DataMoverTestBase):
             flags=mdtest_flags[0])
 
         # create cont2
-        cont2 = self.create_cont(pool)
+        cont2 = self.get_container(pool)
 
         # copy from daos cont1 to cont2
         self.run_datamover(
@@ -74,7 +74,7 @@ class DmvrLargeDir(DataMoverTestBase):
             "POSIX", posix_path)
 
         # create cont3
-        cont3 = self.create_cont(pool)
+        cont3 = self.get_container(pool)
 
         # copy from posix file system to daos cont3
         self.run_datamover(

--- a/src/tests/ftest/datamover/large_file.py
+++ b/src/tests/ftest/datamover/large_file.py
@@ -43,13 +43,13 @@ class DmvrPosixLargeFile(DataMoverTestBase):
 
         # create pool and cont
         pool = self.create_pool()
-        cont1 = self.create_cont(pool)
+        cont1 = self.get_container(pool)
 
         # create initial data in cont1
         self.run_ior_with_params("DAOS", self.ior_cmd.test_file.value, pool, cont1)
 
         # create cont2
-        cont2 = self.create_cont(pool)
+        cont2 = self.get_container(pool)
 
         # copy from daos cont1 to cont2
         self.run_datamover(
@@ -66,7 +66,7 @@ class DmvrPosixLargeFile(DataMoverTestBase):
             "POSIX", posix_path)
 
         # create cont3
-        cont3 = self.create_cont(pool)
+        cont3 = self.get_container(pool)
 
         # copy from posix file system to daos cont3
         self.run_datamover(

--- a/src/tests/ftest/datamover/negative.py
+++ b/src/tests/ftest/datamover/negative.py
@@ -4,8 +4,11 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from data_mover_test_base import DataMoverTestBase
+
 from os.path import join
+import uuid
+
+from data_mover_test_base import DataMoverTestBase
 
 
 class DmvrNegativeTest(DataMoverTestBase):
@@ -61,10 +64,11 @@ class DmvrNegativeTest(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Create a test container
-        cont1 = self.create_cont(pool1, True, pool1, uns_cont)
+        cont1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        cont1 = self.get_container(pool1, path=cont1_path)
 
         # Create test files
         self.run_ior_with_params("POSIX", self.posix_test_file)
@@ -123,7 +127,7 @@ class DmvrNegativeTest(DataMoverTestBase):
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
         # (3) Bad parameter: UUID, UNS, or POSIX path does not exist.
-        fake_uuid = str(self.gen_uuid())
+        fake_uuid = str(uuid.UUID(int=0))
         self.run_datamover(
             self.test_id + " (invalid source pool)",
             "DAOS_UUID", "/", fake_uuid, cont1,
@@ -131,7 +135,6 @@ class DmvrNegativeTest(DataMoverTestBase):
             expected_rc=1,
             expected_output="DER_NONEXIST")
 
-        fake_uuid = str(self.gen_uuid())
         self.run_datamover(
             self.test_id + " (invalid source cont)",
             "DAOS_UUID", "/", pool1, fake_uuid,
@@ -139,7 +142,6 @@ class DmvrNegativeTest(DataMoverTestBase):
             expected_rc=1,
             expected_output="DER_NONEXIST")
 
-        fake_uuid = str(self.gen_uuid())
         self.run_datamover(
             self.test_id + " (invalid dest pool)",
             "POSIX", self.posix_local_test_paths[0], None, None,
@@ -203,11 +205,10 @@ class DmvrNegativeTest(DataMoverTestBase):
 
         # Create pool and containers
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create source file
-        self.run_ior_with_params("DAOS_UUID", self.daos_test_file,
-                                 pool1, cont1)
+        self.run_ior_with_params("DAOS_UUID", self.daos_test_file, pool1, cont1)
 
         # Use a really long filename
         dst_path = join(self.posix_local_test_paths[0], "d"*300)

--- a/src/tests/ftest/datamover/negative_space.py
+++ b/src/tests/ftest/datamover/negative_space.py
@@ -41,7 +41,7 @@ class DmvrNegativeSpaceTest(DataMoverTestBase):
 
         # Create destination test pool and container
         dst_pool = self.create_pool()
-        dst_cont = self.create_cont(dst_pool)
+        dst_cont = self.get_container(dst_pool)
         dst_daos_path = "/"
 
         # Try to copy, and expect a proper error message.

--- a/src/tests/ftest/datamover/obj_large_posix.py
+++ b/src/tests/ftest/datamover/obj_large_posix.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -39,7 +39,7 @@ class DmvrObjLargePosix(DataMoverTestBase):
 
         # Create pool1 and cont1
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create a large directory in cont1
         self.mdtest_cmd.write_bytes.update(file_size)

--- a/src/tests/ftest/datamover/obj_small.py
+++ b/src/tests/ftest/datamover/obj_small.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -62,7 +62,7 @@ class DmvrObjSmallTest(DataMoverTestBase):
         pool1.connect(2)
 
         # Create cont1
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create dataset in cont1
         obj_list = self.dataset_gen(

--- a/src/tests/ftest/datamover/posix_meta_entry.py
+++ b/src/tests/ftest/datamover/posix_meta_entry.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -65,7 +65,7 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # Create 1 source container with test data
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
         daos_src_path = self.new_daos_test_path(False)
         dfuse_src_path = "{}/{}/{}{}".format(
             self.dfuse.mount_dir.value, pool1.uuid, cont1.uuid, daos_src_path)

--- a/src/tests/ftest/datamover/posix_preserve_props.py
+++ b/src/tests/ftest/datamover/posix_preserve_props.py
@@ -61,7 +61,7 @@ class DmvrPreserveProps(DataMoverTestBase):
         self.preserve_props_path = join(self.tmp, "cont_props.h5")
 
         # Create a source cont
-        cont1 = self.create_cont(pool1, cont_type=cont_type)
+        cont1 = self.get_container(pool1, type=cont_type)
 
         # Create source data
         src_props = self.write_cont(cont1)

--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -54,17 +54,18 @@ class DmvrPosixSubsets(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # create dfuse containers to test copying to dfuse subdirectories
-        dfuse_cont1 = self.create_cont(pool1)
-        dfuse_cont2 = self.create_cont(pool1)
+        dfuse_cont1 = self.get_container(pool1)
+        dfuse_cont2 = self.get_container(pool1)
         dfuse_cont1_dir = join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont1.uuid)
         # destination directory should be created by program
         dfuse_cont2_dir = self.new_posix_test_path(create=False,
             parent=join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont2.uuid))
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Create a testing container
-        container1 = self.create_cont(pool1, True, pool1, uns_cont)
+        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        container1 = self.get_container(pool1, path=container1_path)
 
         # Create some source directories in the container
         sub_dir = self.new_daos_test_path(False)

--- a/src/tests/ftest/datamover/posix_symlinks.py
+++ b/src/tests/ftest/datamover/posix_symlinks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -61,20 +61,23 @@ class DmvrPosixSymlinks(DataMoverTestBase):
         pool1 = self.create_pool()
 
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Test links that point forward
-        container1 = self.create_cont(pool1, True, pool1, uns_cont)
+        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        container1 = self.get_container(pool1, path=container1_path)
         self.run_dm_posix_symlinks_fun(
             pool1, container1, self.create_links_forward, "forward")
 
         # Test links that point backward
-        container2 = self.create_cont(pool1, True, pool1, uns_cont)
+        container2_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns2')
+        container2 = self.get_container(pool1, path=container2_path)
         self.run_dm_posix_symlinks_fun(
             pool1, container2, self.create_links_backward, "backward")
 
         # Test a mix of forward and backward links
-        container3 = self.create_cont(pool1, True, pool1, uns_cont)
+        container3_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns3')
+        container3 = self.get_container(pool1, path=container3_path)
         self.run_dm_posix_symlinks_fun(
             pool1, container3, self.create_links_mixed, "mixed")
 

--- a/src/tests/ftest/datamover/posix_types.py
+++ b/src/tests/ftest/datamover/posix_types.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -70,12 +70,15 @@ class DmvrPosixTypesTest(DataMoverTestBase):
         pool2 = self.create_pool()
 
         # Create a special container to hold UNS entries
-        uns_cont = self.create_cont(pool1)
+        uns_cont = self.get_container(pool1)
 
         # Create all other containers
-        container1 = self.create_cont(pool1, True, pool1, uns_cont)
-        container2 = self.create_cont(pool1, True, pool1, uns_cont)
-        container3 = self.create_cont(pool2, True, pool1, uns_cont)
+        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        container1 = self.get_container(pool1, path=container1_path)
+        container2_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns2')
+        container2 = self.get_container(pool1, path=container2_path)
+        container3_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns3')
+        container3 = self.get_container(pool2, path=container3_path)
 
         # Create each source location
         p1_c1 = ["/", pool1, container1]

--- a/src/tests/ftest/datamover/serial_large_posix.py
+++ b/src/tests/ftest/datamover/serial_large_posix.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -43,7 +43,7 @@ class DmvrSerialLargePosix(DataMoverTestBase):
 
         # Create pool1 and cont1
         pool1 = self.create_pool()
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create a large directory in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
@@ -55,7 +55,7 @@ class DmvrSerialLargePosix(DataMoverTestBase):
         pool2 = self.create_pool()
 
         # Use dfuse as a shared intermediate for serialize + deserialize
-        dfuse_cont = self.create_cont(pool1)
+        dfuse_cont = self.get_container(pool1)
         self.start_dfuse(self.dfuse_hosts, pool1, dfuse_cont)
         self.serial_tmp_dir = self.dfuse.mount_dir.value
 

--- a/src/tests/ftest/datamover/serial_small.py
+++ b/src/tests/ftest/datamover/serial_small.py
@@ -60,7 +60,7 @@ class DmvrSerialSmall(DataMoverTestBase):
         pool1.connect(2)
 
         # Create cont1
-        cont1 = self.create_cont(pool1)
+        cont1 = self.get_container(pool1)
 
         # Create dataset in cont1
         obj_list = self.dataset_gen(

--- a/src/tests/ftest/deployment/basic_checkout.py
+++ b/src/tests/ftest/deployment/basic_checkout.py
@@ -124,5 +124,10 @@ class BasicCheckoutDm(DataMoverTestBase):
         self.ior_cmd.namespace = "/run/ior_dm/*"
         self.ior_cmd.get_params(self)
         self.ppn = self.params.get("ppn", '/run/ior_dm/client_processes/*')
-        #run datamover
-        self.run_dm_activities_with_ior("FS_COPY", True)
+
+        # create pool and container
+        pool = self.create_pool()
+        cont = self.get_container(pool, oclass=self.ior_cmd.dfs_oclass.value)
+
+        # run datamover
+        self.run_dm_activities_with_ior("FS_COPY", pool, cont, True)

--- a/src/tests/ftest/deployment/io_sys_admin.py
+++ b/src/tests/ftest/deployment/io_sys_admin.py
@@ -97,15 +97,14 @@ class IoSysAdmin(DataMoverTestBase, FileCountTestBase):
                 self.fail("Aggregation did not complete as expected")
 
             time.sleep(60)
-            returned_space = (self.get_free_space()[1] -
-                              nvme_free_space_before_snap_destroy)
+            returned_space = (self.get_free_space()[1] - nvme_free_space_before_snap_destroy)
             counter += 1
 
         self.log.info("#####Starting FS_COPY Test")
-        self.run_dm_activities_with_ior("FS_COPY", pool=self.pool)
+        self.run_dm_activities_with_ior("FS_COPY", self.pool, self.container[-1])
         self.log.info("#####Starting DCP Test")
-        self.run_dm_activities_with_ior("DCP", pool=self.pool)
+        self.run_dm_activities_with_ior("DCP", self.pool, self.container[-1])
         self.log.info("#####Starting DSERIAL Test")
-        self.run_dm_activities_with_ior("DSERIAL", pool=self.pool)
+        self.run_dm_activities_with_ior("DSERIAL", self.pool, self.container[-1])
         self.log.info("#####Completed all Datamover tests")
         self.container.pop(0)


### PR DESCRIPTION
Test-tag: datamover
Skip-unit-tests: true
Skip-fault-injection-test: true

- Replace DataMoverTestBase.create_cont with
  TestWithServers.get_container
- Remove DataMoverTestBase.gen_uuid

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>