### PR TITLE
DAOS-9827 test: unified container create (#8082)

### DIFF
--- a/src/tests/ftest/container/auto_oc_selection.py
+++ b/src/tests/ftest/container/auto_oc_selection.py
@@ -74,16 +74,10 @@ class AutoOCSelectionTest(TestWithServers):
             oclass = prop_oclass[1]
             failure_expected = prop_oclass[2]
 
-            self.container.append(
-                self.get_container(pool=self.pool, create=False))
-            self.container[-1].properties.update(properties)
-            self.container[-1].oclass.update(oclass)
-
             try:
-                self.log.info(
-                    "Create container with RF = %s, OC = %s", properties,
-                    oclass)
-                self.container[-1].create()
+                self.log.info("Creating container with RF = %s, OC = %s", properties, oclass)
+                self.container.append(
+                    self.get_container(pool=self.pool, properties=properties, oclass=oclass))
                 if failure_expected:
                     msg = ("Container create succeeded with invalid RF-OC "
                            "pair! RF = {}, OC = {}".format(properties, oclass))

--- a/src/tests/ftest/control/dmg_telemetry_basic.py
+++ b/src/tests/ftest/control/dmg_telemetry_basic.py
@@ -33,10 +33,7 @@ class TestWithTelemetryBasic(TestWithTelemetry):
         Args:
             posix (bool): Whether or not to create a posix container
         """
-        self.container.append(self.get_container(self.pool, create=False))
-        self.container[-1].type.update(
-            "POSIX" if posix else None, "container.type")
-        self.container[-1].create()
+        self.container.append(self.get_container(self.pool, type=("POSIX" if posix else None)))
         self.metrics["create_count"][self.pool_leader_host] += 1
         self.metrics["open_count"][self.pool_leader_host] += 1
         self.metrics["close_count"][self.pool_leader_host] += 1

--- a/src/tests/ftest/io/parallel_io.py
+++ b/src/tests/ftest/io/parallel_io.py
@@ -40,16 +40,6 @@ class ParallelIo(FioBase, IorTestBase):
         """Create a TestPool object to use with ior."""
         self.pool.append(self.get_pool(connect=False))
 
-    # pylint: disable=arguments-differ
-    def create_cont(self, pool):
-        """Create a TestContainer object to be used to create container.
-
-        Args:
-            pool (TestPool): TestPool object type for which container
-                             needs to be created
-        """
-        self.container.append(self.get_container(pool))
-
     def stat_bfree(self, path):
         """Get stat bfree.
 
@@ -147,8 +137,7 @@ class ParallelIo(FioBase, IorTestBase):
         self.create_pool()
         self.start_dfuse(self.hostlist_clients, self.pool[0], None)
         # create multiple containers
-        for _ in range(self.cont_count):
-            self.create_cont(self.pool[0])
+        self.add_container_qty(self.cont_count, self.pool[0])
 
         # check if all the created containers can be accessed and perform
         # io on each container using fio in parallel
@@ -259,8 +248,7 @@ class ParallelIo(FioBase, IorTestBase):
         # different times and get appended in the self.container variable in
         # unorderly manner, causing problems during the write process.
         for _, pool in enumerate(self.pool):
-            for _ in range(self.cont_count):
-                self.create_cont(pool)
+            self.add_container_qty(self.cont_count, pool)
 
         # Try to access each dfuse mounted container using ls. Once it is
         # accessed successfully, go ahead and perform io on that location

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1356,15 +1356,15 @@ class TestWithServers(TestWithoutServers):
             # dump engines ULT stacks upon test timeout
             self.dump_engines_stacks("Test has timed-out")
 
-    def fail(self, message=None):
+    def fail(self, msg=None):
         """Dump engines ULT stacks upon test failure."""
         self.dump_engines_stacks("Test has failed")
-        super().fail(message)
+        super().fail(msg)
 
-    def error(self, message=None):
+    def error(self, msg=None):
         """Dump engines ULT stacks upon test error."""
         self.dump_engines_stacks("Test has errored")
-        super().error(message)
+        super().error(msg)
 
     def tearDown(self):
         """Tear down after each test case."""
@@ -1774,26 +1774,38 @@ class TestWithServers(TestWithoutServers):
         for _ in range(quantity):
             self.pool.append(self.get_pool(namespace, create, connect, index))
 
-    def get_container(self, pool, namespace=None, create=True):
-        """Get a test container object.
+    @fail_on(AttributeError)
+    def get_container(self, pool, namespace=None, create=True, **kwargs):
+        """Create a TestContainer object.
 
         Args:
             pool (TestPool): pool in which to create the container.
             namespace (str, optional): namespace for TestContainer parameters in
                 the test yaml file. Defaults to None.
-            create (bool, optional): should the container be created. Defaults
-                to True.
+            create (bool, optional): should the container be created. Defaults to True.
+            kwargs (dict): name/value of attributes for which to call update(value, name).
+                See TestContainer for available attributes.
 
         Returns:
-            TestContainer: the created test container object.
+            TestContainer: the created container.
+
+        Raises:
+            AttributeError: if an attribute does not exist or does not have an update() method.
 
         """
+        # Create a container with params from the config
         container = TestContainer(pool, daos_command=self.get_daos_command())
         if namespace is not None:
             container.namespace = namespace
         container.get_params(self)
+
+        # Set passed params
+        for name, value in kwargs.items():
+            getattr(container, name).update(value, name=name)
+
         if create:
             container.create()
+
         return container
 
     def add_container(self, pool, namespace=None, create=True):
@@ -1808,7 +1820,7 @@ class TestWithServers(TestWithoutServers):
             create (bool, optional): should the container be created. Defaults
                 to True.
         """
-        self.container = self.get_container(pool, namespace, create)
+        self.container = self.get_container(pool=pool, namespace=namespace, create=create)
 
     def add_container_qty(self, quantity, pool, namespace=None, create=True):
         """Add multiple containers to the test case.
@@ -1835,7 +1847,8 @@ class TestWithServers(TestWithoutServers):
                 "add_container_qty(): self.container must be a list: {}".format(
                     type(self.container)))
         for _ in range(quantity):
-            self.container.append(self.get_container(pool, namespace, create))
+            self.container.append(
+                self.get_container(pool=pool, namespace=namespace, create=create))
 
     def start_additional_servers(self, additional_servers, index=0,
                                  access_points=None):

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -385,7 +385,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             when dfuse was not started for a specific pool/container.
 
         """
-        container = self.get_container(pool, create=False)
+        params = {}
 
         if use_dfuse_uns:
             path = str(self.dfuse.mount_dir.value)
@@ -394,15 +394,14 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             if dfuse_uns_cont:
                 path = join(path, dfuse_uns_cont.uuid)
             path = join(path, "uns{}".format(str(len(self.container))))
-            container.path.update(path)
+            params["path"] = path
 
         if cont_type:
-            container.type.update(cont_type)
+            params["type"] = cont_type
         if oclass:
-            container.oclass.update(oclass)
+            params["oclass"] = oclass
 
-        # Create container
-        container.create()
+        container = self.get_container(pool, **params)
 
         # Save container and uuid
         self.container.append(container)

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -14,8 +14,6 @@ from ior_utils import IorCommand
 from exception_utils import CommandFailure
 from job_manager_utils import get_job_manager
 from general_utils import pcmd, get_random_string
-from daos_utils import DaosCommand
-from test_utils_container import TestContainer
 
 
 class IorTestBase(DfuseTestBase):
@@ -64,23 +62,25 @@ class IorTestBase(DfuseTestBase):
         Args:
             chunk_size (str, optional): container chunk size. Defaults to None.
             properties (str, optional): additional properties to append. Defaults to None.
+        Returns:
+            TestContainer: the created container.
 
         """
-        # Get container params
-        self.container = TestContainer(
-            self.pool, daos_command=DaosCommand(self.bin))
-        self.container.get_params(self)
+        params = {}
 
-        # update container oclass
+        # Set container oclass to match ior oclass
         if self.ior_cmd.dfs_oclass:
-            self.container.oclass.update(self.ior_cmd.dfs_oclass.value)
+            params["oclass"] = self.ior_cmd.dfs_oclass.value
 
         # update container chunk size
-        if chunk_size:
-            self.container.chunk_size.update(chunk_size)
+        if chunk_size is not None:
+            params["chunk_size"] = chunk_size
+
+        # create container from params
+        self.container = self.get_container(self.pool, create=False, **params)
 
         # append container properties
-        if properties:
+        if properties is not None:
             current_properties = self.container.properties.value
             if current_properties:
                 new_properties = current_properties + "," + properties
@@ -90,6 +90,7 @@ class IorTestBase(DfuseTestBase):
 
         # create container
         self.container.create()
+        return self.container
 
     def display_pool_space(self, pool=None):
         """Display the current pool space.


### PR DESCRIPTION
Test-tag: pr daily_regression oc_selection test_with_telemetry_basic parallelio multipoolparallelio datamover,pr datamover,daily_regression ior,pr ior,daily_regression
Skip-unit-tests: true
Skip-fault-injection-test: true

- Add generic kwargs to `get_container` that accepts any param.
- Update some tests to pass params this way

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>