### PR TITLE
DAOS-11164 pool: also save credentials in pool handle db

### DIFF
--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -83,6 +83,14 @@ struct pool_hdl {
 	uint64_t	ph_flags;
 	uint64_t	ph_sec_capas;
 	char		ph_machine[MAXHOSTNAMELEN+1];
+	size_t		ph_cred_len;
+	char		ph_cred[];
+};
+
+/* old format (<= version 2.0) */
+struct pool_hdl_v20 {
+	uint64_t	ph_flags;
+	uint64_t	ph_sec_capas;
 };
 
 /*

--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -88,7 +88,7 @@ struct pool_hdl {
 };
 
 /* old format (<= version 2.0) */
-struct pool_hdl_v20 {
+struct pool_hdl_v0 {
 	uint64_t	ph_flags;
 	uint64_t	ph_sec_capas;
 };

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2570,7 +2570,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc, int handler_version)
 	/* XXX may be can check pool version to avoid allocating too much ? */
 	D_ALLOC(hdl, sizeof(*hdl) + in->pci_cred.iov_len);
 	if (hdl == NULL)
-		D_GOTO(out_map_version, rc = ENOMEM);
+		D_GOTO(out_map_version, rc = -DER_NOMEM);
 
 	hdl->ph_flags = in->pci_flags;
 	hdl->ph_sec_capas = sec_capas;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -98,17 +98,6 @@ static int
 find_hdls_to_evict(struct rdb_tx *tx, struct pool_svc *svc, uuid_t **hdl_uuids,
 		   size_t *hdl_uuids_size, int *n_hdl_uuids, char *machine);
 
-static size_t
-pool_hdl_size(struct pool_svc *svc)
-{
-	/* return old size if pool is from version <= 2.0 */
-	if (svc->ps_global_version != 0)
-		return sizeof(struct pool_hdl);
-	else
-		return sizeof(((struct pool_hdl *)0)->ph_flags) +
-		       sizeof(((struct pool_hdl *)0)->ph_sec_capas);
-}
-
 static struct pool_svc *
 pool_svc_obj(struct ds_rsvc *rsvc)
 {
@@ -2337,7 +2326,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc, int handler_version)
 	struct rdb_tx			tx;
 	d_iov_t				key;
 	d_iov_t				value;
-	struct pool_hdl			hdl = {0};
+	struct pool_hdl			*hdl = NULL;
 	uint32_t			nhandles;
 	int				skip_update = 0;
 	int				rc;
@@ -2387,10 +2376,12 @@ ds_pool_connect_handler(crt_rpc_t *rpc, int handler_version)
 
 	/* Check existing pool handles. */
 	d_iov_set(&key, in->pci_op.pi_hdl, sizeof(uuid_t));
-	d_iov_set(&value, &hdl, sizeof(hdl));
+	d_iov_set(&value, NULL, 0);
 	rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
 	if (rc == 0) {
-		if (hdl.ph_flags == in->pci_flags) {
+		/* found it */
+		hdl = value.iov_buf;
+		if (hdl->ph_flags == in->pci_flags) {
 			/*
 			 * The handle already exists; only do the pool map
 			 * transfer.
@@ -2552,13 +2543,13 @@ ds_pool_connect_handler(crt_rpc_t *rpc, int handler_version)
 			 * If there is a non-exclusive handle, then all handles
 			 * are non-exclusive.
 			 */
-			d_iov_set(&value, &hdl, sizeof(hdl));
+			d_iov_set(&value, NULL, 0);
 			rc = rdb_tx_fetch(&tx, &svc->ps_handles,
 					  RDB_PROBE_FIRST, NULL /* key_in */,
 					  NULL /* key_out */, &value);
 			if (rc != 0)
 				D_GOTO(out_map_version, rc);
-			if (hdl.ph_flags & DAOS_PC_EX)
+			if (((struct pool_hdl *)value.iov_buf)->ph_flags & DAOS_PC_EX)
 				D_GOTO(out_map_version, rc = -DER_BUSY);
 		}
 	}
@@ -2576,13 +2567,26 @@ ds_pool_connect_handler(crt_rpc_t *rpc, int handler_version)
 		D_GOTO(out_map_version, rc);
 	}
 
-	hdl.ph_flags = in->pci_flags;
-	hdl.ph_sec_capas = sec_capas;
-	strncpy(hdl.ph_machine, machine, MAXHOSTNAMELEN);
+	/* handle did not exist so create it */
+	/* XXX may be can check pool version to avoid allocating too much ? */
+	D_ALLOC(hdl, sizeof(*hdl) + in->pci_cred.iov_len);
+	if (hdl == NULL)
+		D_GOTO(out_map_version, rc = ENOMEM);
+
+	hdl->ph_flags = in->pci_flags;
+	hdl->ph_sec_capas = sec_capas;
+	/* XXX may be can check pool version to avoid initializing 3 following hdl fields ? */
+	strncpy(hdl->ph_machine, machine, MAXHOSTNAMELEN);
+	hdl->ph_cred_len = in->pci_cred.iov_len;
+	memcpy(&hdl->ph_cred[0], in->pci_cred.iov_buf, in->pci_cred.iov_len);
 
 	nhandles++;
 	d_iov_set(&key, in->pci_op.pi_hdl, sizeof(uuid_t));
-	d_iov_set(&value, &hdl, pool_hdl_size(svc));
+	d_iov_set(&value, hdl, svc->ps_global_version != 0 ?
+				sizeof(struct pool_hdl) + hdl->ph_cred_len :
+				sizeof(struct pool_hdl_v20));
+	D_DEBUG(DB_MD, "writing a pool connect handle in db, size %zu, pool version %u\n",
+		value.iov_len, svc->ps_global_version);
 	rc = rdb_tx_update(&tx, &svc->ps_handles, &key, &value);
 	if (rc != 0)
 		D_GOTO(out_map_version, rc);
@@ -2607,6 +2611,8 @@ out_map_version:
 	out->pco_op.po_map_version = ds_pool_get_version(svc->ps_pool);
 	if (map_buf)
 		D_FREE(map_buf);
+	if (hdl)
+		D_FREE(hdl);
 	D_FREE(machine);
 out_lock:
 	ABT_rwlock_unlock(svc->ps_lock);
@@ -2743,7 +2749,6 @@ ds_pool_disconnect_handler(crt_rpc_t *rpc)
 	struct rdb_tx			tx;
 	d_iov_t			key;
 	d_iov_t			value;
-	struct pool_hdl			hdl = {0};
 	int				rc;
 
 	D_DEBUG(DB_MD, DF_UUID ": processing rpc: %p hdl=" DF_UUID "\n",
@@ -2761,7 +2766,7 @@ ds_pool_disconnect_handler(crt_rpc_t *rpc)
 	ABT_rwlock_wrlock(svc->ps_lock);
 
 	d_iov_set(&key, pdi->pdi_op.pi_hdl, sizeof(uuid_t));
-	d_iov_set(&value, &hdl, pool_hdl_size(svc));
+	d_iov_set(&value, NULL, 0);
 	rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
@@ -3043,7 +3048,6 @@ ds_pool_list_cont_handler(crt_rpc_t *rpc)
 	struct rdb_tx			 tx;
 	d_iov_t				 key;
 	d_iov_t				 value;
-	struct pool_hdl			 hdl = {0};
 	int				 rc;
 
 	D_DEBUG(DB_MD, DF_UUID ": processing rpc: %p hdl=" DF_UUID "\n",
@@ -3071,7 +3075,7 @@ ds_pool_list_cont_handler(crt_rpc_t *rpc)
 		if (!is_pool_from_srv(in->plci_op.pi_uuid,
 				      in->plci_op.pi_hdl)) {
 			d_iov_set(&key, in->plci_op.pi_hdl, sizeof(uuid_t));
-			d_iov_set(&value, &hdl, pool_hdl_size(svc));
+			d_iov_set(&value, NULL, 0);
 			rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
 			if (rc == -DER_NONEXIST)
 				rc = -DER_NO_HDL;
@@ -3137,7 +3141,6 @@ ds_pool_query_handler(crt_rpc_t *rpc, bool return_pool_ver)
 	struct rdb_tx		  tx;
 	d_iov_t			  key;
 	d_iov_t			  value;
-	struct pool_hdl		  hdl = {0};
 	int			  rc;
 	struct daos_prop_entry	 *entry;
 
@@ -3169,7 +3172,7 @@ ds_pool_query_handler(crt_rpc_t *rpc, bool return_pool_ver)
 	if (daos_rpc_from_client(rpc) &&
 	    !is_pool_from_srv(in->pqi_op.pi_uuid, in->pqi_op.pi_hdl)) {
 		d_iov_set(&key, in->pqi_op.pi_hdl, sizeof(uuid_t));
-		d_iov_set(&value, &hdl, pool_hdl_size(svc));
+		d_iov_set(&value, NULL, 0);
 		rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
 		if (rc != 0) {
 			if (rc == -DER_NONEXIST)
@@ -5739,7 +5742,6 @@ validate_hdls_to_evict(struct rdb_tx *tx, struct pool_svc *svc,
 	int		rc = 0;
 	d_iov_t		key;
 	d_iov_t		value;
-	struct pool_hdl	hdl = {0};
 
 	if (hdl_list == NULL || n_hdl_list == 0) {
 		return -DER_INVAL;
@@ -5752,7 +5754,7 @@ validate_hdls_to_evict(struct rdb_tx *tx, struct pool_svc *svc,
 
 	for (i = 0; i < n_hdl_list; i++) {
 		d_iov_set(&key, hdl_list[i], sizeof(uuid_t));
-		d_iov_set(&value, &hdl, pool_hdl_size(svc));
+		d_iov_set(&value, NULL, 0);
 		rc = rdb_tx_lookup(tx, &svc->ps_handles, &key, &value);
 
 		if (rc == 0) {


### PR DESCRIPTION
credentials must be saved to be accessible in situations like when
if the pool leader is switched or all servers restart.
So save them in pool handle db.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>