### PR TITLE
DAOS-9595 chk: consolidate pool membership

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -339,10 +339,12 @@ pipeline {
                                    password: GITHUB_USER_PSW,
                                    ignored_files: 'src/control/vendor/*:' +
                                                   '*.pb-c.h:' +
+                                                  'src/chk/chk_internal.h:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:' +
                                                   /* groovylint-disable-next-line LineLength */
                                                   'src/client/java/daos-java/src/main/native/include/daos_jni_common.h:' +
+                                                  'src/mgmt/rpc.h:' +
                                                   '*.crt:' +
                                                   '*.pem:' +
                                                   '*_test.go:' +

--- a/src/chk/SConscript
+++ b/src/chk/SConscript
@@ -1,5 +1,6 @@
 # pylint: disable=consider-using-f-string
-"""Build chk library"""
+# pylint: disable-next=wrong-spelling-in-comment
+"""Build check library"""
 import daos_build
 
 def scons():

--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -64,11 +64,17 @@ chk_pool_alloc(struct btr_instance *tins, d_iov_t *key_iov, d_iov_t *val_iov,
 
 	if (cpb->cpb_data != NULL) {
 		D_ALLOC_PTR(cps);
-		if (cps == NULL) {
-			D_FREE(cpr);
+		if (cps == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
-		}
 	}
+
+	rc = ABT_mutex_create(&cpr->cpr_mutex);
+	if (rc != 0)
+		D_GOTO(out, rc = dss_abterr2der(rc));
+
+	rc = ABT_cond_create(&cpr->cpr_cond);
+	if (rc != 0)
+		D_GOTO(out, rc = dss_abterr2der(rc));
 
 	D_INIT_LIST_HEAD(&cpr->cpr_shard_list);
 	cpr->cpr_shard_nr = 0;
@@ -95,6 +101,15 @@ chk_pool_alloc(struct btr_instance *tins, d_iov_t *key_iov, d_iov_t *val_iov,
 	}
 
 out:
+	if (rc != 0 && cpr != NULL) {
+		if (cpr->cpr_mutex != ABT_MUTEX_NULL)
+			ABT_mutex_free(&cpr->cpr_mutex);
+		if (cpr->cpr_cond != ABT_COND_NULL)
+			ABT_cond_free(&cpr->cpr_cond);
+		D_FREE(cps);
+		D_FREE(cpr);
+	}
+
 	return rc;
 }
 

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -1635,6 +1635,92 @@ chk_leader_handle_pools_svc(struct chk_sched_args *csa)
 	return rc;
 }
 
+static int
+chk_leader_pool_mbs_one(struct chk_instance *ins, struct chk_pool_rec *cpr)
+{
+	struct rsvc_client	 client = { 0 };
+	crt_endpoint_t		 ep = { 0 };
+	struct rsvc_hint	 hint = { 0 };
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+	d_rank_list_t		*ps_ranks = NULL;
+	struct chk_pool_shard	*cps;
+	struct ds_pool_clue	*clue;
+	int			 rc = 0;
+	int			 rc1;
+	int			 i = 0;
+
+	D_ASSERT(cpr->cpr_mbs == NULL);
+
+	D_ALLOC_ARRAY(cpr->cpr_mbs, cpr->cpr_shard_nr);
+	if (cpr->cpr_mbs == NULL)
+		D_GOTO(out_post, rc = -DER_NOMEM);
+
+	d_list_for_each_entry(cps, &cpr->cpr_shard_list, cps_link) {
+		clue = cps->cps_data;
+		D_ASSERT(i < cpr->cpr_shard_nr);
+
+		cpr->cpr_mbs[i].cpm_rank = cps->cps_rank;
+		cpr->cpr_mbs[i].cpm_tgt_nr = clue->pc_tgt_nr;
+		cpr->cpr_mbs[i].cpm_tgt_status = clue->pc_tgt_status;
+		i++;
+	}
+
+	ps_ranks = chk_leader_cpr2ranklist(cpr, true);
+	if (ps_ranks == NULL)
+		D_GOTO(out_post, rc = -DER_NOMEM);
+
+	rc = rsvc_client_init(&client, ps_ranks);
+	d_rank_list_free(ps_ranks);
+
+	if (rc != 0)
+		goto out_post;
+
+again:
+	rc = rsvc_client_choose(&client, &ep);
+	if (rc != 0)
+		goto out_client;
+
+	rc = chk_pool_mbs_remote(ep.ep_rank, cbk->cb_gen, cpr->cpr_uuid, cpr->cpr_label,
+				 cpr->cpr_delay_label ? CMF_REPAIR_LABEL : 0,
+				 cpr->cpr_shard_nr, cpr->cpr_mbs, &hint);
+
+	rc1 = rsvc_client_complete_rpc(&client, &ep, rc, rc, &hint);
+	if (rc1 == RSVC_CLIENT_RECHOOSE ||
+	    (rc1 == RSVC_CLIENT_PROCEED && daos_rpc_retryable_rc(rc))) {
+		dss_sleep(RECHOOSE_SLEEP_MS);
+		goto again;
+	}
+
+out_client:
+	rsvc_client_fini(&client);
+
+out_post:
+	if (rc != 0)
+		cpr->cpr_skip = 1;
+
+	chk_leader_post_repair(ins, cpr->cpr_uuid, &rc, false, true);
+
+	return rc;
+}
+
+static int
+chk_leader_pool_mbs(struct chk_sched_args *csa)
+{
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
+	int			 rc = 0;
+
+	d_list_for_each_entry_safe(cpr, tmp, &csa->csa_list, cpr_link) {
+		if (!cpr->cpr_skip) {
+			rc = chk_leader_pool_mbs_one(csa->csa_ins, cpr);
+			if (rc != 0)
+				break;
+		}
+	}
+
+	return rc;
+}
+
 static void
 chk_leader_sched(void *args)
 {
@@ -1738,6 +1824,12 @@ handle:
 		 */
 		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS;
 		chk_bk_update_leader(cbk);
+	}
+
+	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS) {
+		rc = chk_leader_pool_mbs(csa);
+		if (rc != 0)
+			D_GOTO(out, bcast = true);
 	}
 
 	while (ins->ci_sched_running) {
@@ -1856,8 +1948,8 @@ chk_leader_start_prepare(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *r
 		goto init;
 	}
 
-	/* Drop dryrun flags needs to reset. */
-	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN && !(*flags & CHK__CHECK_FLAG__CF_DRYRUN)) {
+	/* For dryrun mode, restart from the beginning since we did not record former repairing. */
+	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
 		*flags |= CHK__CHECK_FLAG__CF_RESET;
 		goto init;
 	}
@@ -1916,6 +2008,7 @@ chk_leader_dup_clue(struct ds_pool_clue **tgt, struct ds_pool_clue *src)
 {
 	struct ds_pool_clue		*clue = NULL;
 	struct ds_pool_svc_clue		*svc = NULL;
+	uint32_t			*status = NULL;
 	char				*label = NULL;
 	int				 rc = 0;
 
@@ -1943,9 +2036,18 @@ chk_leader_dup_clue(struct ds_pool_clue **tgt, struct ds_pool_clue *src)
 	if (rc != 0)
 		goto out;
 
+	if (src->pc_tgt_status != NULL) {
+		D_ALLOC_ARRAY(status, src->pc_tgt_nr);
+		if (status == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		memcpy(status, src->pc_tgt_status, sizeof(*status) * src->pc_tgt_nr);
+	}
+
 	memcpy(clue, src, sizeof(*clue));
 	clue->pc_svc_clue = svc;
 	clue->pc_label = label;
+	clue->pc_tgt_status = status;
 
 out:
 	if (rc != 0) {
@@ -1954,6 +2056,8 @@ out:
 			D_FREE(svc);
 		}
 
+		D_FREE(status);
+		D_FREE(label);
 		D_FREE(clue);
 	} else {
 		*tgt = clue;

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -461,6 +461,47 @@ out:
 	return rc;
 }
 
+int
+chk_pool_mbs_remote(d_rank_t rank, uint64_t gen, uuid_t uuid, char *label, uint32_t flags,
+		    uint32_t mbs_nr, struct chk_pool_mbs *mbs_array, struct rsvc_hint *hint)
+{
+	crt_rpc_t		*req;
+	struct chk_pool_mbs_in	*cpmi;
+	struct chk_pool_mbs_out	*cpmo;
+	int			 rc;
+
+	rc = chk_sg_rpc_prepare(rank, CHK_POOL_MBS, &req);
+	if (rc != 0)
+		goto out;
+
+	cpmi = crt_req_get(req);
+	cpmi->cpmi_gen = gen;
+	uuid_copy(cpmi->cpmi_pool, uuid);
+	cpmi->cpmi_flags = flags;
+	cpmi->cpmi_label = label;
+	cpmi->cpmi_targets.ca_count = mbs_nr;
+	cpmi->cpmi_targets.ca_arrays = mbs_array;
+
+	rc = dss_rpc_send(req);
+	if (rc != 0)
+		goto out;
+
+	cpmo = crt_reply_get(req);
+	rc = cpmo->cpmo_status;
+	*hint = cpmo->cpmo_hint;
+
+out:
+	if (req != NULL)
+		crt_req_decref(req);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "Sent pool ("DF_UUIDF") members and label %s to rank %u with gen "
+		 DF_X64": "DF_RC"\n",
+		 DP_UUID(uuid), label != NULL ? label : "(null)", rank, gen, DP_RC(rc));
+
+	return rc;
+}
+
 int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int result,
 		      d_rank_t rank, uint32_t target, uuid_t *pool, uuid_t *cont,
 		      daos_unit_oid_t *obj, daos_key_t *dkey, daos_key_t *akey, char *msg,
@@ -769,6 +810,7 @@ static int
 crt_proc_struct_ds_pool_clue(crt_proc_t proc, crt_proc_op_t proc_op, struct ds_pool_clue *clue)
 {
 	int	rc;
+	int	i;
 
 	rc = crt_proc_uuid_t(proc, proc_op, &clue->pc_uuid);
 	if (unlikely(rc != 0))
@@ -790,10 +832,18 @@ crt_proc_struct_ds_pool_clue(crt_proc_t proc, crt_proc_op_t proc_op, struct ds_p
 	if (unlikely(rc != 0))
 		return rc;
 
-	if (clue->pc_rc > 0) {
-		if (FREEING(proc_op))
-			goto out;
+	rc = crt_proc_uint32_t(proc, proc_op, &clue->pc_tgt_nr);
+	if (unlikely(rc != 0))
+		return rc;
 
+	rc = crt_proc_uint32_t(proc, proc_op, &clue->pc_padding);
+	if (unlikely(rc != 0))
+		return rc;
+
+	if (FREEING(proc_op))
+		goto out;
+
+	if (clue->pc_rc > 0) {
 		if (DECODING(proc_op)) {
 			D_ALLOC_PTR(clue->pc_svc_clue);
 			if (clue->pc_svc_clue == NULL)
@@ -806,9 +856,6 @@ crt_proc_struct_ds_pool_clue(crt_proc_t proc, crt_proc_op_t proc_op, struct ds_p
 	}
 
 	if (clue->pc_label_len > 0) {
-		if (FREEING(proc_op))
-			goto out;
-
 		if (DECODING(proc_op)) {
 			D_ALLOC(clue->pc_label, clue->pc_label_len + 1);
 			if (clue->pc_label == NULL)
@@ -820,6 +867,20 @@ crt_proc_struct_ds_pool_clue(crt_proc_t proc, crt_proc_op_t proc_op, struct ds_p
 			goto out;
 	}
 
+	if (clue->pc_tgt_nr > 0) {
+		if (DECODING(proc_op)) {
+			D_ALLOC_ARRAY(clue->pc_tgt_status, clue->pc_tgt_nr);
+			if (clue->pc_tgt_status == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		for (i = 0; i < clue->pc_tgt_nr; i++) {
+			rc = crt_proc_uint32_t(proc, proc_op, &clue->pc_tgt_status[i]);
+			if (unlikely(rc != 0))
+				goto out;
+		}
+	}
+
 out:
 	if (unlikely(rc != 0 && DECODING(proc_op)) || FREEING(proc_op))
 		ds_pool_clue_fini(clue);
@@ -827,10 +888,70 @@ out:
 	return rc;
 }
 
+static int
+crt_proc_struct_chk_pool_mbs(crt_proc_t proc, crt_proc_op_t proc_op, struct chk_pool_mbs *mbs)
+{
+	int	rc;
+	int	i;
+
+	rc = crt_proc_d_rank_t(proc, proc_op, &mbs->cpm_rank);
+	if (unlikely(rc != 0))
+		return rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &mbs->cpm_tgt_nr);
+	if (unlikely(rc != 0))
+		return rc;
+
+	if (FREEING(proc_op))
+		goto out;
+
+	if (mbs->cpm_tgt_nr > 0) {
+		if (DECODING(proc_op)) {
+			D_ALLOC_ARRAY(mbs->cpm_tgt_status, mbs->cpm_tgt_nr);
+			if (mbs->cpm_tgt_status == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		for (i = 0; i < mbs->cpm_tgt_nr; i++) {
+			rc = crt_proc_uint32_t(proc, proc_op, &mbs->cpm_tgt_status[i]);
+			if (unlikely(rc != 0))
+				goto out;
+		}
+	}
+
+out:
+	if (unlikely(rc != 0 && DECODING(proc_op)) || FREEING(proc_op))
+		D_FREE(mbs->cpm_tgt_status);
+
+	return rc;
+}
+
+static int
+crt_proc_struct_rsvc_hint(crt_proc_t proc, crt_proc_op_t proc_op,
+			  struct rsvc_hint *hint)
+{
+	int rc;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &hint->sh_flags);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &hint->sh_rank);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &hint->sh_term);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
+
 CRT_RPC_DEFINE(chk_start, DAOS_ISEQ_CHK_START, DAOS_OSEQ_CHK_START);
 CRT_RPC_DEFINE(chk_stop, DAOS_ISEQ_CHK_STOP, DAOS_OSEQ_CHK_STOP);
 CRT_RPC_DEFINE(chk_query, DAOS_ISEQ_CHK_QUERY, DAOS_OSEQ_CHK_QUERY);
 CRT_RPC_DEFINE(chk_mark, DAOS_ISEQ_CHK_MARK, DAOS_OSEQ_CHK_MARK);
 CRT_RPC_DEFINE(chk_act, DAOS_ISEQ_CHK_ACT, DAOS_OSEQ_CHK_ACT);
+CRT_RPC_DEFINE(chk_pool_mbs, DAOS_ISEQ_CHK_POOL_MBS, DAOS_OSEQ_CHK_POOL_MBS);
 CRT_RPC_DEFINE(chk_report, DAOS_ISEQ_CHK_REPORT, DAOS_OSEQ_CHK_REPORT);
 CRT_RPC_DEFINE(chk_rejoin, DAOS_ISEQ_CHK_REJOIN, DAOS_OSEQ_CHK_REJOIN);

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -130,6 +130,23 @@ ds_chk_act_hdlr(crt_rpc_t *rpc)
 }
 
 static void
+ds_chk_pool_mbs_hdlr(crt_rpc_t *rpc)
+{
+	struct chk_pool_mbs_in	*cpmi = crt_req_get(rpc);
+	struct chk_pool_mbs_out	*cpmo = crt_reply_get(rpc);
+	int			 rc;
+
+	rc = chk_engine_pool_mbs(cpmi->cpmi_gen, cpmi->cpmi_pool, cpmi->cpmi_label,
+				 cpmi->cpmi_flags, cpmi->cpmi_targets.ca_count,
+				 cpmi->cpmi_targets.ca_arrays, &cpmo->cpmo_hint);
+
+	cpmo->cpmo_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check pool mbs: "DF_RC"\n", DP_RC(rc));
+}
+
+static void
 ds_chk_report_hdlr(crt_rpc_t *rpc)
 {
 	struct chk_report_in	*cri = crt_req_get(rpc);

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -413,6 +413,7 @@ pool_buf_attach(struct pool_buf *buf, struct pool_component *comps,
 			buf->pb_domain_nr++;
 
 		buf->pb_comps[nr] = comps[0];
+		buf->pb_comps[nr].co_flags &= ~PO_COMPF_CHK_DONE;
 
 		D_DEBUG(DB_TRACE, "nr %d %s\n", nr,
 			pool_comp_type2str(comps[0].co_type));
@@ -2332,7 +2333,7 @@ pmap_comp_failed(struct pool_component *comp)
 {
 	return (comp->co_status == PO_COMP_ST_DOWN) ||
 	       (comp->co_status == PO_COMP_ST_DOWNOUT &&
-		comp->co_flags == PO_COMPF_DOWN2OUT);
+		comp->co_flags & PO_COMPF_DOWN2OUT);
 }
 
 static bool
@@ -2873,6 +2874,18 @@ pool_map_set_version(struct pool_map *map, uint32_t version)
 
 	map->po_version = version;
 	return 0;
+}
+
+/**
+ * Bump the pool map version.
+ */
+uint32_t
+pool_map_bump_version(struct pool_map *map)
+{
+	map->po_version++;
+	D_DEBUG(DB_TRACE, "Bump pool map to version %u\n", map->po_version);
+
+	return map->po_version;
 }
 
 int

--- a/src/ddb/tests/SConscript
+++ b/src/ddb/tests/SConscript
@@ -1,6 +1,6 @@
+# pylint: disable-next=wrong-spelling-in-comment
 """Build tests"""
 import daos_build
-import os
 
 def scons():
     """Execute build"""

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -61,7 +61,11 @@ enum pool_component_flags {
 	 * indicate when in status PO_COMP_ST_DOWNOUT, it is changed from
 	 * PO_COMP_ST_DOWN (rather than from PO_COMP_ST_DRAIN).
 	 */
-	PO_COMPF_DOWN2OUT	= 1,
+	PO_COMPF_DOWN2OUT	= (1 << 0),
+	/**
+	 * The component has been processed by DAOS check, only in DRAM.
+	 */
+	PO_COMPF_CHK_DONE	= (1 << 1),
 };
 
 #define co_in_ver	co_out_ver
@@ -240,6 +244,7 @@ void pool_map_print(struct pool_map *map);
 
 int  pool_map_set_version(struct pool_map *map, uint32_t version);
 uint32_t pool_map_get_version(struct pool_map *map);
+uint32_t pool_map_bump_version(struct pool_map *map);
 
 int pool_map_get_failed_cnt(struct pool_map *map, uint32_t domain);
 

--- a/src/include/daos/rsvc.h
+++ b/src/include/daos/rsvc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -13,6 +13,8 @@
 #define DAOS_RSVC_H
 
 #include <daos_types.h>
+
+#define RECHOOSE_SLEEP_MS 250
 
 /** Flags in rsvc_hint::sh_flags (opaque) */
 enum rsvc_hint_flag {

--- a/src/include/daos_srv/daos_mgmt_srv.h
+++ b/src/include/daos_srv/daos_mgmt_srv.h
@@ -35,5 +35,7 @@ int
 ds_mgmt_tgt_pool_exist(uuid_t uuid, char **path);
 int
 ds_mgmt_tgt_pool_destroy(uuid_t pool_uuid, d_rank_list_t *ranks);
+int
+ds_mgmt_tgt_pool_shard_destroy(uuid_t pool_uuid, int shard_idx, d_rank_t rank);
 
 #endif /* __MGMT_SRV_H__ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -25,6 +25,9 @@
 #include <daos_srv/policy.h>
 #include <daos_srv/rdb.h>
 
+/*, Wrap of pool service (opaque) */
+struct ds_pool_svc;
+
 /*
  * Pool object
  *
@@ -264,6 +267,8 @@ int ds_pool_svc_check_evict(uuid_t pool_uuid, d_rank_list_t *ranks,
 
 int ds_pool_target_status_check(struct ds_pool *pool, uint32_t id,
 				uint8_t matched_status, struct pool_target **p_tgt);
+int ds_pool_svc_load_map(struct ds_pool_svc *ds_svc, struct pool_map **map);
+int ds_pool_svc_flush_map(struct ds_pool_svc *ds_svc, struct pool_map *map);
 void ds_pool_disable_exclude(void);
 void ds_pool_enable_exclude(void);
 
@@ -326,6 +331,12 @@ enum ds_pool_dir {
 	DS_POOL_DIR_ZOMBIE
 };
 
+enum ds_pool_tgt_status {
+	DS_POOL_TGT_NONEXIST,
+	DS_POOL_TGT_EMPTY,
+	DS_POOL_TGT_NORMAL
+};
+
 /**
  * Pool clue
  *
@@ -334,13 +345,16 @@ enum ds_pool_dir {
  * pc_svc_clue field is valid only if pc_rc is positive value.
  */
 struct ds_pool_clue {
-	uuid_t				pc_uuid;
-	d_rank_t			pc_rank;
-	enum ds_pool_dir		pc_dir;
-	int				pc_rc;
-	uint32_t			pc_label_len;
-	struct ds_pool_svc_clue	       *pc_svc_clue;
-	char			       *pc_label;
+	uuid_t				 pc_uuid;
+	d_rank_t			 pc_rank;
+	enum ds_pool_dir		 pc_dir;
+	int				 pc_rc;
+	uint32_t			 pc_label_len;
+	uint32_t			 pc_tgt_nr;
+	uint32_t			 pc_padding;
+	struct ds_pool_svc_clue		*pc_svc_clue;
+	char				*pc_label;
+	uint32_t			*pc_tgt_status;
 };
 
 void ds_pool_clue_init(uuid_t uuid, enum ds_pool_dir dir, struct ds_pool_clue *clue);
@@ -365,5 +379,9 @@ void ds_pool_clues_fini(struct ds_pool_clues *clues);
 void ds_pool_clues_print(struct ds_pool_clues *clues);
 
 int ds_pool_check_svc_clues(struct ds_pool_clues *clues, int *advice_out);
+
+int ds_pool_svc_lookup_leader(uuid_t uuid, struct ds_pool_svc **ds_svcp, struct rsvc_hint *hint);
+
+void ds_pool_svc_put_leader(struct ds_pool_svc *ds_svc);
 
 #endif /* __DAOS_SRV_POOL_H__ */

--- a/src/mgmt/rpc.c
+++ b/src/mgmt/rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -43,6 +43,9 @@ CRT_RPC_DEFINE(mgmt_tgt_map_update, DAOS_ISEQ_MGMT_TGT_MAP_UPDATE,
 
 CRT_RPC_DEFINE(mgmt_get_bs_state, DAOS_ISEQ_MGMT_GET_BS_STATE,
 	       DAOS_OSEQ_MGMT_GET_BS_STATE)
+
+CRT_RPC_DEFINE(mgmt_tgt_shard_destroy, DAOS_ISEQ_MGMT_TGT_SHARD_DESTROY,
+	       DAOS_OSEQ_MGMT_TGT_SHARD_DESTROY)
 
 /* Define for cont_rpcs[] array population below.
  * See MGMT_PROTO_*_RPC_LIST macro definition

--- a/src/mgmt/rpc.h
+++ b/src/mgmt/rpc.h
@@ -18,7 +18,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos_rpc.h.
  */
-#define DAOS_MGMT_VERSION 2
+#define DAOS_MGMT_VERSION 3
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
@@ -64,7 +64,10 @@
 		&ds_mgmt_hdlr_tgt_map_update_co_ops),			\
 	X(MGMT_TGT_MARK,						\
 		0, &CQF_mgmt_mark,					\
-		ds_mgmt_tgt_mark_hdlr, NULL)
+		ds_mgmt_tgt_mark_hdlr, NULL),				\
+	X(MGMT_TGT_SHARD_DESTROY,					\
+		0, &CQF_mgmt_tgt_shard_destroy,				\
+		ds_mgmt_hdlr_tgt_shard_destroy, NULL)
 
 
 
@@ -213,5 +216,17 @@ CRT_RPC_DECLARE(mgmt_mark, DAOS_ISEQ_MGMT_MARK, DAOS_OSEQ_MGMT_MARK)
 
 CRT_RPC_DECLARE(mgmt_get_bs_state, DAOS_ISEQ_MGMT_GET_BS_STATE,
 		DAOS_OSEQ_MGMT_GET_BS_STATE)
+
+#define DAOS_ISEQ_MGMT_TGT_SHARD_DESTROY /* input fields */		\
+	((uuid_t)		(tsdi_pool_uuid)	CRT_VAR)	\
+	((int32_t)		(tsdi_shard_idx)	CRT_VAR)	\
+	((uint32_t)		(tsdi_padding)		CRT_VAR)
+
+#define DAOS_OSEQ_MGMT_TGT_SHARD_DESTROY /* output fields */		\
+	((int32_t)		(tsdo_rc)		CRT_VAR)	\
+	((uint32_t)		(tsdo_padding)		CRT_VAR)
+
+CRT_RPC_DECLARE(mgmt_tgt_shard_destroy, DAOS_ISEQ_MGMT_TGT_SHARD_DESTROY,
+		DAOS_OSEQ_MGMT_TGT_SHARD_DESTROY)
 
 #endif /* __MGMT_RPC_H__ */

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -145,6 +145,7 @@ int ds_mgmt_tgt_setup(void);
 void ds_mgmt_tgt_cleanup(void);
 void ds_mgmt_hdlr_tgt_create(crt_rpc_t *rpc_req);
 void ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *rpc_req);
+void ds_mgmt_hdlr_tgt_shard_destroy(crt_rpc_t *rpc_req);
 int ds_mgmt_tgt_create_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 				  void *priv);
 int ds_mgmt_tgt_create_post_reply(crt_rpc_t *rpc, void *priv);

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -669,3 +669,51 @@ ds_mgmt_pool_get_prop(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 out:
 	return rc;
 }
+
+/**
+ * Destroy the specified pool shard on the specified storage rank
+ */
+int
+ds_mgmt_tgt_pool_shard_destroy(uuid_t pool_uuid, int shard_idx, d_rank_t rank)
+{
+	crt_rpc_t				*req = NULL;
+	struct mgmt_tgt_shard_destroy_in	*tsdi;
+	struct mgmt_tgt_shard_destroy_out	*tsdo;
+	crt_endpoint_t				 tgt_ep;
+	crt_opcode_t				 opc;
+	int					 rc;
+
+	tgt_ep.ep_grp = NULL;
+	tgt_ep.ep_rank = rank;
+	tgt_ep.ep_tag = daos_rpc_tag(DAOS_REQ_CHK, 0);
+
+	opc = DAOS_RPC_OPCODE(MGMT_TGT_SHARD_DESTROY, DAOS_MGMT_MODULE,
+			      DAOS_MGMT_VERSION);
+
+	rc = crt_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep, opc, &req);
+	if (rc != 0)
+		goto out;
+
+	tsdi = crt_req_get(req);
+	D_ASSERT(tsdi != NULL);
+
+	uuid_copy(tsdi->tsdi_pool_uuid, pool_uuid);
+	tsdi->tsdi_shard_idx = shard_idx;
+
+	rc = dss_rpc_send(req);
+	if (rc != 0)
+		goto out;
+
+	tsdo = crt_reply_get(req);
+	rc = tsdo->tsdo_rc;
+
+out:
+	if (req != NULL)
+		crt_req_decref(req);
+
+	if (rc != 0)
+		D_ERROR("Failed to destroy pool "DF_UUIDF" shard %u on rank %u: "DF_RC"\n",
+			DP_UUID(pool_uuid), shard_idx, rank, DP_RC(rc));
+
+	return rc;
+}

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -1219,3 +1219,43 @@ ds_mgmt_tgt_map_update_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 	out_result->tm_rc += out_source->tm_rc;
 	return 0;
 }
+
+/**
+ * RPC handler for pool shard destroy
+ */
+void
+ds_mgmt_hdlr_tgt_shard_destroy(crt_rpc_t *req)
+{
+	struct mgmt_tgt_shard_destroy_in	*tsdi;
+	struct mgmt_tgt_shard_destroy_out	*tsdo;
+	char					*path = NULL;
+	int					 rc = 0;
+
+	tsdi = crt_req_get(req);
+	tsdo = crt_reply_get(req);
+
+	/*
+	 * The being destroyed one must be down or downout, or not in the pool map.
+	 * It is the RPC sponsor (PS leader)'s duty to guarantee that. Need not to
+	 * stop the pool service.
+	 */
+
+	rc = ds_mgmt_tgt_file(tsdi->tsdi_pool_uuid, VOS_FILE, &tsdi->tsdi_shard_idx, &path);
+	if (rc == 0) {
+		rc = unlink(path);
+		if (rc < 0) {
+			if (errno == ENOENT)
+				rc = 0;
+			else
+				rc = daos_errno2der(errno);
+		}
+
+		D_FREE(path);
+	}
+
+	D_DEBUG(DB_MGMT, "Processed rpc %p to destroy pool "DF_UUIDF" shard %u: "DF_RC"\n",
+		req, DP_UUID(tsdi->tsdi_pool_uuid), tsdi->tsdi_shard_idx, DP_RC(rc));
+
+	tsdo->tsdo_rc = rc;
+	crt_reply_send(req);
+}

--- a/src/pool/srv_pool_map.c
+++ b/src/pool/srv_pool_map.c
@@ -198,7 +198,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 			D_DEBUG(DB_MD, "change "DF_TARGET" to DOWNOUT %p\n",
 				DP_TARGET(target), map);
 			if (target->ta_comp.co_status == PO_COMP_ST_DOWN)
-				target->ta_comp.co_flags = PO_COMPF_DOWN2OUT;
+				target->ta_comp.co_flags |= PO_COMPF_DOWN2OUT;
 			target->ta_comp.co_status = PO_COMP_ST_DOWNOUT;
 			target->ta_comp.co_out_ver = ++(*version);
 			if (print_changes)
@@ -276,7 +276,7 @@ ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 					target->ta_comp.co_fseq;
 			} else if (opc == POOL_EXCLUDE_OUT) {
 				dom->do_comp.co_status = PO_COMP_ST_DOWNOUT;
-				dom->do_comp.co_flags = PO_COMPF_DOWN2OUT;
+				dom->do_comp.co_flags |= PO_COMPF_DOWN2OUT;
 				dom->do_comp.co_out_ver =
 					target->ta_comp.co_out_ver;
 			} else


### PR DESCRIPTION
When DAOS check start, all involved check engines will report their
known pools' information, including the pool service replicas, pool
label and related storage allocation, to the check leader via reply.

After the pool list consolidation in the pass_1, for each pool, the
check leader will send related pool information to its pool service
leaders via new RPC - CHK_POOL_MBS.

On the check engine side, the pool service leader compares the pool
map with these information pushed from the check leader and handles
the following cases:

1. An target has some allocated storage but does not appear in the
   pool map. Under such case, the associated space will be deleted
   from the engine by default.

2. An target has some allocated storage and is marked as "DOWN" or
   "DOWNOUT" in the pool map. For this case, the administrator can
   decide to either remove or leave it there.

3. An target is referenced in the pool map ("NEW", "UP", "UPIN" or
   "DRAIN"), but no storage is actually allocated on this engine.
   Under such case, the entry for the target in the pool map will
   be marked as "DOWN" (for the "UP", "UPIN" or "DRAIN" entry) or
   "DOWNOUT" (for the "NEW" entry).

Temporarily skip code format check against src/chk/chk_internal.h
and src/mgmt/rpc.h to avoid fake warning messages.

Signed-off-by: Fan Yong <fan.yong@intel.com>