### PR TITLE
DAOS-9599 chk: pool cleanup for CR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -347,7 +347,6 @@ pipeline {
                                                   'src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:' +
                                                   /* groovylint-disable-next-line LineLength */
                                                   'src/client/java/daos-java/src/main/native/include/daos_jni_common.h:' +
-                                                  'src/mgmt/rpc.h:' +
                                                   '*.crt:' +
                                                   '*.pem:' +
                                                   '*_test.go:' +

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -594,7 +594,7 @@ chk_leader_dangling_pool(struct chk_instance *ins, uuid_t uuid)
 {
 	struct chk_property		*prop = &ins->ci_prop;
 	struct chk_bookmark		*cbk = &ins->ci_bk;
-	struct chk_report_unit		 cru;
+	struct chk_report_unit		 cru = { 0 };
 	Chk__CheckInconsistClass	 cla;
 	Chk__CheckInconsistAction	 act;
 	uint64_t			 seq = 0;
@@ -651,18 +651,11 @@ report:
 	cru.cru_gen = cbk->cb_gen;
 	cru.cru_cla = cla;
 	cru.cru_act = option_nr != 0 ? CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT : act;
-	cru.cru_target = 0;
 	cru.cru_rank = dss_self_rank();
 	cru.cru_option_nr = option_nr;
-	cru.cru_detail_nr = 0;
 	cru.cru_pool = (uuid_t *)&uuid;
-	cru.cru_cont = NULL;
-	cru.cru_obj = NULL;
-	cru.cru_dkey = NULL;
-	cru.cru_akey = NULL;
 	cru.cru_msg = "Check leader detects dangling pool";
 	cru.cru_options = options;
-	cru.cru_details = NULL;
 	cru.cru_result = result;
 
 	rc = chk_leader_report(&cru, &seq, &decision);
@@ -726,7 +719,7 @@ chk_leader_orphan_pool(struct chk_pool_rec *cpr)
 	struct chk_property		*prop = &ins->ci_prop;
 	struct chk_bookmark		*cbk = &ins->ci_bk;
 	struct ds_pool_clue		*clue;
-	struct chk_report_unit		 cru;
+	struct chk_report_unit		 cru = { 0 };
 	Chk__CheckInconsistClass	 cla;
 	Chk__CheckInconsistAction	 act;
 	uint64_t			 seq = 0;
@@ -825,18 +818,11 @@ report:
 	cru.cru_gen = cbk->cb_gen;
 	cru.cru_cla = cla;
 	cru.cru_act = option_nr != 0 ? CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT : act;
-	cru.cru_target = 0;
 	cru.cru_rank = dss_self_rank();
 	cru.cru_option_nr = option_nr;
-	cru.cru_detail_nr = 0;
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
-	cru.cru_cont = NULL;
-	cru.cru_obj = NULL;
-	cru.cru_dkey = NULL;
-	cru.cru_akey = NULL;
 	cru.cru_msg = "Check leader detects orphan pool";
 	cru.cru_options = options;
-	cru.cru_details = NULL;
 	cru.cru_result = result;
 
 	rc = chk_leader_report(&cru, &seq, &decision);
@@ -943,7 +929,7 @@ chk_leader_no_quorum_pool(struct chk_pool_rec *cpr)
 	d_iov_t				 iovs[3];
 	d_sg_list_t			 sgl;
 	d_sg_list_t			*details = NULL;
-	struct chk_report_unit		 cru;
+	struct chk_report_unit		 cru = { 0 };
 	Chk__CheckInconsistClass	 cla;
 	Chk__CheckInconsistAction	 act;
 	uint64_t			 seq = 0;
@@ -1108,15 +1094,10 @@ report:
 	cru.cru_gen = cbk->cb_gen;
 	cru.cru_cla = cla;
 	cru.cru_act = option_nr != 0 ? CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT : act;
-	cru.cru_target = 0;
 	cru.cru_rank = dss_self_rank();
 	cru.cru_option_nr = option_nr;
 	cru.cru_detail_nr = detail_nr;
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
-	cru.cru_cont = NULL;
-	cru.cru_obj = NULL;
-	cru.cru_dkey = NULL;
-	cru.cru_akey = NULL;
 	cru.cru_msg = "Check leader detects corrupted pool without quorum";
 	cru.cru_options = options;
 	cru.cru_details = details;
@@ -1323,7 +1304,7 @@ chk_leader_handle_pool_label(struct chk_pool_rec *cpr, struct ds_pool_clue *clue
 	d_iov_t				 iovs[3];
 	d_sg_list_t			 sgl;
 	d_sg_list_t			*details = NULL;
-	struct chk_report_unit		 cru;
+	struct chk_report_unit		 cru = { 0 };
 	Chk__CheckInconsistClass	 cla;
 	Chk__CheckInconsistAction	 act;
 	uint64_t			 seq = 0;
@@ -1429,15 +1410,10 @@ report:
 	cru.cru_gen = cbk->cb_gen;
 	cru.cru_cla = cla;
 	cru.cru_act = option_nr != 0 ? CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT : act;
-	cru.cru_target = 0;
 	cru.cru_rank = dss_self_rank();
 	cru.cru_option_nr = option_nr;
 	cru.cru_detail_nr = detail_nr;
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
-	cru.cru_cont = NULL;
-	cru.cru_obj = NULL;
-	cru.cru_dkey = NULL;
-	cru.cru_akey = NULL;
 	cru.cru_msg = "Check leader detects corrupted pool label";
 	cru.cru_options = options;
 	cru.cru_details = details;

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -269,6 +269,8 @@ int ds_pool_target_status_check(struct ds_pool *pool, uint32_t id,
 				uint8_t matched_status, struct pool_target **p_tgt);
 int ds_pool_svc_load_map(struct ds_pool_svc *ds_svc, struct pool_map **map);
 int ds_pool_svc_flush_map(struct ds_pool_svc *ds_svc, struct pool_map *map);
+int ds_pool_svc_update_label(struct ds_pool_svc *ds_svc, const char *label);
+int ds_pool_svc_evict_all(struct ds_pool_svc *ds_svc);
 void ds_pool_disable_exclude(void);
 void ds_pool_enable_exclude(void);
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7071,15 +7071,115 @@ ds_pool_svc_flush_map(struct ds_pool_svc *ds_svc, struct pool_map *map)
 		 * has already been updated.
 		 */
 		rdb_resign(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term);
+	} else {
+		ds_rsvc_request_map_dist(&svc->ps_rsvc);
+
+		pool_svc_reconfigure_replicas(svc, svc_rf, map);
 	}
-
-	ds_rsvc_request_map_dist(&svc->ps_rsvc);
-
-	pool_svc_reconfigure_replicas(svc, svc_rf, map);
 
 out_buf:
 	pool_buf_free(buf);
 out_lock:
+	ABT_rwlock_unlock(svc->ps_lock);
+	rdb_tx_end(&tx);
+out:
+	return rc;
+}
+
+int
+ds_pool_svc_update_label(struct ds_pool_svc *ds_svc, const char *label)
+{
+	struct pool_svc		*svc = pool_ds2svc(ds_svc);
+	daos_prop_t		*prop = NULL;
+	struct rdb_tx		 tx = { 0 };
+	int			 rc = 0;
+
+	prop = daos_prop_alloc(1);
+	if (prop == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_PO_LABEL;
+	if (label != NULL) {
+		D_STRNDUP(prop->dpp_entries[0].dpe_str, label, strlen(label));
+		if (prop->dpp_entries[0].dpe_str == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		prop->dpp_entries[0].dpe_flags = DAOS_PROP_ENTRY_NOT_SET;
+		prop->dpp_entries[0].dpe_str = NULL;
+	}
+
+	rc = rdb_tx_begin(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term, &tx);
+	if (rc != 0) {
+		D_ERROR("Failed to begin TX for updating pool "DF_UUIDF" label %s: "DF_RC"\n",
+			DP_UUID(svc->ps_uuid), label != NULL ? label : "(null)", DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	ABT_rwlock_wrlock(svc->ps_lock);
+
+	rc = pool_prop_write(&tx, &svc->ps_root, prop);
+	if (rc != 0) {
+		D_ERROR("Failed to updating pool "DF_UUIDF" label %s: "DF_RC"\n",
+			DP_UUID(svc->ps_uuid), label != NULL ? label : "(null)", DP_RC(rc));
+		D_GOTO(out_lock, rc);
+	}
+
+	rc = rdb_tx_commit(&tx);
+	if (rc != 0)
+		D_ERROR("Failed to commit TX for updating pool "DF_UUIDF" label %s: "DF_RC"\n",
+			DP_UUID(svc->ps_uuid), label != NULL ? label : "(null)", DP_RC(rc));
+
+out_lock:
+	ABT_rwlock_unlock(svc->ps_lock);
+	rdb_tx_end(&tx);
+out:
+	daos_prop_free(prop);
+	return rc;
+}
+
+int
+ds_pool_svc_evict_all(struct ds_pool_svc *ds_svc)
+{
+	struct pool_svc		*svc = pool_ds2svc(ds_svc);
+	struct pool_metrics	*metrics;
+	uuid_t			*hdl_uuids = NULL;
+	struct rdb_tx		 tx = { 0 };
+	size_t			 hdl_uuids_size = 0;
+	int			 n_hdl_uuids = 0;
+	int			 rc = 0;
+
+	rc = rdb_tx_begin(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term, &tx);
+	if (rc != 0) {
+		D_ERROR("Failed to begin TX for evict pool "DF_UUIDF" connections: "DF_RC"\n",
+			DP_UUID(svc->ps_uuid), DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	ABT_rwlock_wrlock(svc->ps_lock);
+
+	rc = find_hdls_to_evict(&tx, svc, &hdl_uuids, &hdl_uuids_size, &n_hdl_uuids, NULL);
+	if (rc != 0) {
+		D_ERROR("Failed to find hdls for evict pool "DF_UUIDF" connections: "DF_RC"\n",
+			DP_UUID(svc->ps_uuid), DP_RC(rc));
+		D_GOTO(out_lock, rc);
+	}
+
+	if (n_hdl_uuids > 0) {
+		rc = pool_disconnect_hdls(&tx, svc, hdl_uuids, n_hdl_uuids,
+					  dss_get_module_info()->dmi_ctx);
+		if (rc != 0)
+			D_GOTO(out_lock, rc);
+
+		metrics = svc->ps_pool->sp_metrics[DAOS_POOL_MODULE];
+		d_tm_inc_counter(metrics->evict_total, n_hdl_uuids);
+		rc = rdb_tx_commit(&tx);
+		if (rc != 0)
+			D_ERROR("Failed to commit TX for evict pool "DF_UUIDF" connections: "
+				DF_RC"\n", DP_UUID(svc->ps_uuid), DP_RC(rc));
+	}
+
+out_lock:
+	D_FREE(hdl_uuids);
 	ABT_rwlock_unlock(svc->ps_lock);
 	rdb_tx_end(&tx);
 out:


### PR DESCRIPTION
That mainly includes the following:

1. Handle the inconsistent pool label (based on former comparing result
   with management service) if decide to trust MS known pool label.

2. Revoking all pool connections recorded in the pool service.

Some code cleanup.

signed-off-by: Fan Yong <fan.yong@intel.com>