### PR TITLE
DAOS-11226 object: Fix dc_tx_get_epoch races

### DIFF
--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -53,6 +53,10 @@ d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
  * can be used for IOs in this container that need to be committed
  * transactionally.
  *
+ * Invoking operations of one TX with events from multiple event queues,
+ * including with NULL events from multiple threads, is not currently
+ * supported.
+ *
  * \param[in]	coh	Container handle.
  * \param[out]	th	Returned transaction handle.
  * \param[in]	flags	Transaction flags (DAOS_TF_RDONLY, etc.).

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2706,8 +2706,8 @@ shard_io_task(tse_task_t *task)
 	/*
 	 * If this task belongs to a TX, and if the epoch we got earlier
 	 * doesn't contain a "chosen" TX epoch, then we may need to reinit the
-	 * task. (See dc_tx_get_epoch.) Because tse_task_reinit is less
-	 * practical in the middle of a task, we do it here at the beginning of
+	 * task via dc_tx_get_epoch. Because tse_task_reinit is less practical
+	 * in the middle of a task, we do it here at the beginning of
 	 * shard_io_task.
 	 */
 	th = shard_auxi->obj_auxi->th;
@@ -2716,9 +2716,9 @@ shard_io_task(tse_task_t *task)
 		if (rc < 0) {
 			tse_task_complete(task, rc);
 			return rc;
+		} else if (rc == DC_TX_GE_REINITED) {
+			return 0;
 		}
-		if (rc == DC_TX_GE_REINIT)
-			return tse_task_reinit(task);
 	}
 
 	return shard_io(task, shard_auxi);
@@ -6203,9 +6203,9 @@ shard_query_key_task(tse_task_t *task)
 		if (rc < 0) {
 			tse_task_complete(task, rc);
 			return rc;
+		} else if (rc == DC_TX_GE_REINITED) {
+			return 0;
 		}
-		if (rc == DC_TX_GE_REINIT)
-			return tse_task_reinit(task);
 	}
 
 	rc = obj_shard_open(obj, args->kqa_auxi.shard, args->kqa_auxi.map_ver,

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -805,7 +805,7 @@ dc_tx_hdl2epoch_and_pmv(daos_handle_t th, struct dtx_epoch *epoch,
 enum dc_tx_get_epoch_rc {
 	DC_TX_GE_CHOSEN,
 	DC_TX_GE_CHOOSING,
-	DC_TX_GE_REINIT
+	DC_TX_GE_REINITED
 };
 
 int

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -40,7 +40,7 @@ dtx_0(void **state)
 	 * Trigger a fan-out at the beginning of a TX to test the wait in
 	 * dc_tx_get_epoch.
 	 */
-	print_message("DTX0: EV fetch against EC obj\n");
+	print_message("DTX0: SV fetch against EC obj\n");
 
 	if (!test_runable(arg, 3))
 		skip();
@@ -3070,7 +3070,7 @@ dtx_sub_teardown(void **state)
 }
 
 static const struct CMUnitTest dtx_tests[] = {
-	{"DTX0: EV fetch against EC obj",
+	{"DTX0: SV fetch against EC obj",
 	 dtx_0, NULL, test_case_teardown},
 	{"DTX1: multiple SV update against the same obj",
 	 dtx_1, NULL, test_case_teardown},


### PR DESCRIPTION
A race similar to the one described by the Jira ticket affects
dc_tx_get_epoch. This patch moves the tse_task_reinit call inside
tx_lock, so that dc_tx_get_epoch knows that the epoch task has not run
its completion callback complete_epoch_task yet.

If the tse_task_reinit call fails, this patch makes sure that we
complete the task.

Due to tse limitations, we can't support invoking operations of one TX
from multiple tse_sched objects. This patch adds a note to the
documentation of daos_tx_open.

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true