### PR TITLE
DAOS-11201 test: Always restart servers when mux'ing server hosts (#9…

### DIFF
--- a/src/tests/ftest/erasurecode/offline_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/offline_rebuild.yaml
@@ -8,6 +8,10 @@ hosts:
       test_servers: server-[1-6]
   test_clients: 2
 timeout: 1200
+setup:
+  # Test variants use different server counts, so ensure servers are stopped after each run
+  start_agents_once: False
+  start_servers_once: False
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/erasurecode/rebuild_disabled.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.yaml
@@ -8,6 +8,10 @@ hosts:
       test_servers: server-[1-5]
   test_clients: 3
 timeout: 3500
+setup:
+  # Test variants use different server counts, so ensure servers are stopped after each run
+  start_agents_once: False
+  start_servers_once: False
 server_config:
   engines_per_host: 2
   name: daos_server

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -8,6 +8,10 @@ hosts:
       test_servers: server-[1-5]
   test_clients: 1
 timeout: 250
+setup:
+  # Test variants use different server counts, so ensure servers are stopped after each run
+  start_agents_once: False
+  start_servers_once: False
 server_config:
   engines_per_host: 2
   name: daos_server


### PR DESCRIPTION
…857)

Any test that runs multiple test variants with a different set of server
hosts should start and stop the servers between each test variant.

Skip-unit-tests: true
Test-tag: ec_offline_rebuild_array ec_disabled_rebuild_array ec_disabled_rebuild_single

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>