### PR TITLE
DAOS-11239 control: Stub SPDK library interface in go unit tests

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -50,6 +50,7 @@ def get_build_tags(benv):
     if is_firmware_mgmt_build(benv):
         tags.append("firmware")
     tags.append("ucx")
+    tags.append("spdk")
     return "-tags {}".format(','.join(tags))
 
 

--- a/src/control/lib/ipmctl/nvm.go
+++ b/src/control/lib/ipmctl/nvm.go
@@ -7,14 +7,6 @@
 // Package ipmctl provides Go bindings for libipmctl Native Management API
 package ipmctl
 
-// CGO_CFLAGS & CGO_LDFLAGS env vars can be used
-// to specify additional dirs.
-
-/*
-
-#include "nvm_management.h"
-*/
-import "C"
 import (
 	"github.com/daos-stack/daos/src/control/logging"
 )

--- a/src/control/lib/ipmctl/nvm_ctest_linux_amd64.go
+++ b/src/control/lib/ipmctl/nvm_ctest_linux_amd64.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2022 Intel Corporation.
+// (C) Copyright 2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/control/lib/ipmctl/nvm_linux_amd64.go
+++ b/src/control/lib/ipmctl/nvm_linux_amd64.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2022 Intel Corporation.
+// (C) Copyright 2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/control/lib/ipmctl/nvm_stubs.go
+++ b/src/control/lib/ipmctl/nvm_stubs.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2022 Intel Corporation.
+// (C) Copyright 2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -9,38 +9,29 @@
 // Package ipmctl provides Go bindings for libipmctl Native Management API
 package ipmctl
 
-// CGO_CFLAGS & CGO_LDFLAGS env vars can be used
-// to specify additional dirs.
-
-/*
-
-#include "nvm_management.h"
-*/
-import "C"
-
 import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
+
+// DeviceDiscovery struct represents Go equivalent of C.struct_device_discovery
+// from nvm_management.h (NVM API) as reported by "go tool cgo -godefs nvm.go"
+type DeviceDiscovery struct{}
 
 // Init verifies library version is compatible with this application code.
 func (n *NvmMgmt) Init(log logging.Logger) error {
 	return nil
 }
 
-func getDevices(log logging.Logger, devs *C.struct_device_discovery, count C.NVM_UINT8) C.int {
-	return 0
-}
-
 // GetModules queries number of PMem modules and retrieves device_discovery structs for each before
 // converting to Go DeviceDiscovery structs.
-func (n *NvmMgmt) GetModules(log logging.Logger) (devices []DeviceDiscovery, err error) {
-	return
+func (n *NvmMgmt) GetModules(log logging.Logger) ([]DeviceDiscovery, error) {
+	return nil, nil
 }
 
 // GetRegions queries number of PMem regions and retrieves region structs for each before
 // converting to Go PMemRegion structs.
-func (n *NvmMgmt) GetRegions(log logging.Logger) (regions []PMemRegion, err error) {
-	return
+func (n *NvmMgmt) GetRegions(log logging.Logger) ([]PMemRegion, error) {
+	return nil, nil
 }
 
 // DeleteConfigGoals removes any pending but not yet applied PMem configuration goals.
@@ -49,8 +40,8 @@ func (n *NvmMgmt) DeleteConfigGoals(log logging.Logger) error {
 }
 
 // GetFirmwareInfo fetches the firmware revision and other information from the device
-func (n *NvmMgmt) GetFirmwareInfo(uid DeviceUID) (fw DeviceFirmwareInfo, err error) {
-	return
+func (n *NvmMgmt) GetFirmwareInfo(uid DeviceUID) (DeviceFirmwareInfo, error) {
+	return nil, nil
 }
 
 // UpdateFirmware updates the firmware on the device

--- a/src/control/lib/ipmctl/nvm_types.go
+++ b/src/control/lib/ipmctl/nvm_types.go
@@ -39,48 +39,6 @@ func (p PartNumber) String() string {
 	return bytes2String(p[:])
 }
 
-// DeviceDiscovery struct represents Go equivalent of C.struct_device_discovery
-// from nvm_management.h (NVM API) as reported by "go tool cgo -godefs nvm.go"
-type DeviceDiscovery struct {
-	All_properties_populated uint8
-	Pad_cgo_0                [3]byte
-	Device_handle            [4]byte
-	Physical_id              uint16
-	Vendor_id                uint16
-	Device_id                uint16
-	Revision_id              uint16
-	Channel_pos              uint16
-	Channel_id               uint16
-	Memory_controller_id     uint16
-	Socket_id                uint16
-	Node_controller_id       uint16
-	Pad_cgo_1                [2]byte
-	Memory_type              uint32
-	Dimm_sku                 uint32
-	Manufacturer             [2]uint8
-	Serial_number            [4]uint8
-	Subsystem_vendor_id      uint16
-	Subsystem_device_id      uint16
-	Subsystem_revision_id    uint16
-	Manufacturing_info_valid uint8
-	Manufacturing_location   uint8
-	Manufacturing_date       uint16
-	Part_number              PartNumber
-	Fw_revision              Version
-	Fw_api_version           Version
-	Pad_cgo_2                [5]byte
-	Capacity                 uint64
-	Interface_format_codes   [9]uint16
-	Security_capabilities    _Ctype_struct_device_security_capabilities
-	Device_capabilities      _Ctype_struct_device_capabilities
-	Uid                      DeviceUID
-	Lock_state               uint32
-	Manageability            uint32
-	Controller_revision_id   uint16
-	Reserved                 [48]uint8
-	Pad_cgo_3                [6]byte
-}
-
 // PMemRegionType represents PMem region type.
 type PMemRegionType uint32
 

--- a/src/control/lib/ipmctl/nvm_types_linux_amd64.go
+++ b/src/control/lib/ipmctl/nvm_types_linux_amd64.go
@@ -1,0 +1,51 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build linux && amd64
+// +build linux,amd64
+
+package ipmctl
+
+// DeviceDiscovery struct represents Go equivalent of C.struct_device_discovery
+// from nvm_management.h (NVM API) as reported by "go tool cgo -godefs nvm.go"
+type DeviceDiscovery struct {
+	All_properties_populated uint8
+	Pad_cgo_0                [3]byte
+	Device_handle            [4]byte
+	Physical_id              uint16
+	Vendor_id                uint16
+	Device_id                uint16
+	Revision_id              uint16
+	Channel_pos              uint16
+	Channel_id               uint16
+	Memory_controller_id     uint16
+	Socket_id                uint16
+	Node_controller_id       uint16
+	Pad_cgo_1                [2]byte
+	Memory_type              uint32
+	Dimm_sku                 uint32
+	Manufacturer             [2]uint8
+	Serial_number            [4]uint8
+	Subsystem_vendor_id      uint16
+	Subsystem_device_id      uint16
+	Subsystem_revision_id    uint16
+	Manufacturing_info_valid uint8
+	Manufacturing_location   uint8
+	Manufacturing_date       uint16
+	Part_number              PartNumber
+	Fw_revision              Version
+	Fw_api_version           Version
+	Pad_cgo_2                [5]byte
+	Capacity                 uint64
+	Interface_format_codes   [9]uint16
+	Security_capabilities    _Ctype_struct_device_security_capabilities
+	Device_capabilities      _Ctype_struct_device_capabilities
+	Uid                      DeviceUID
+	Lock_state               uint32
+	Manageability            uint32
+	Controller_revision_id   uint16
+	Reserved                 [48]uint8
+	Pad_cgo_3                [6]byte
+}

--- a/src/control/lib/spdk/nvme.go
+++ b/src/control/lib/spdk/nvme.go
@@ -6,30 +6,8 @@
 
 package spdk
 
-// CGO_CFLAGS & CGO_LDFLAGS env vars can be used
-// to specify additional dirs.
-
-/*
-#cgo CFLAGS: -I .
-#cgo LDFLAGS: -L . -lnvme_control
-#cgo LDFLAGS: -lspdk_env_dpdk -lspdk_nvme -lspdk_vmd -lspdk_util
-#cgo LDFLAGS: -lrte_mempool -lrte_mempool_ring -lrte_bus_pci
-
-#include "stdlib.h"
-#include "daos_srv/control.h"
-#include "spdk/stdinc.h"
-#include "spdk/string.h"
-#include "spdk/env.h"
-#include "spdk/nvme.h"
-#include "include/nvme_control.h"
-#include "include/nvme_control_common.h"
-*/
-import "C"
-
 import (
 	"os"
-	"strings"
-	"unsafe"
 
 	"github.com/pkg/errors"
 
@@ -38,7 +16,13 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
-const lockfilePathPrefix = "/var/tmp/spdk_pci_lock_"
+// FormatResult struct mirrors C.struct_wipe_res_t and describes the results of a format operation
+// on an NVMe controller namespace.
+type FormatResult struct {
+	CtrlrPCIAddr string
+	NsID         uint32
+	Err          error
+}
 
 // Nvme is the interface that provides SPDK NVMe functionality.
 type Nvme interface {
@@ -53,20 +37,9 @@ type Nvme interface {
 // NvmeImpl is an implementation of the Nvme interface.
 type NvmeImpl struct{}
 
-// FormatResult struct mirrors C.struct_wipe_res_t
-// and describes the results of a format operation
-// on an NVMe controller namespace.
-type FormatResult struct {
-	CtrlrPCIAddr string
-	NsID         uint32
-	Err          error
-}
+const lockfilePathPrefix = "/var/tmp/spdk_pci_lock_"
 
 type remFunc func(name string) error
-
-func realRemove(name string) error {
-	return os.Remove(name)
-}
 
 // cleanLockfiles removes SPDK lockfiles after binding operations.
 func cleanLockfiles(log logging.Logger, remove remFunc, pciAddrs ...string) error {
@@ -112,26 +85,6 @@ func ctrlrPCIAddresses(ctrlrs storage.NvmeControllers) []string {
 	return pciAddrs
 }
 
-// Discover NVMe devices, including NVMe devices behind VMDs if enabled,
-// accessible by SPDK on a given host.
-//
-// Calls C.nvme_discover which returns pointers to single linked list of
-// ctrlr_t structs. These are converted and returned as Controller slices
-// containing any Namespace and DeviceHealth structs.
-// Afterwards remove lockfile for each discovered device.
-func (n *NvmeImpl) Discover(log logging.Logger) (storage.NvmeControllers, error) {
-	if n == nil {
-		return nil, errors.New("nil NvmeImpl")
-	}
-
-	ctrlrs, err := collectCtrlrs(C.nvme_discover(), "NVMe Discover(): C.nvme_discover")
-
-	pciAddrs := ctrlrPCIAddresses(ctrlrs)
-	log.Debugf("discovered nvme ssds: %v", pciAddrs)
-
-	return ctrlrs, wrapCleanError(err, cleanLockfiles(log, realRemove, pciAddrs...))
-}
-
 func resultPCIAddresses(results []*FormatResult) []string {
 	pciAddrs := make([]string, 0, len(results))
 	for _, r := range results {
@@ -139,203 +92,4 @@ func resultPCIAddresses(results []*FormatResult) []string {
 	}
 
 	return common.DedupeStringSlice(pciAddrs)
-}
-
-// Format devices available through SPDK, destructive operation!
-//
-// Attempt wipe of each controller namespace's LBA-0.
-// Afterwards remove lockfile for each formatted device.
-func (n *NvmeImpl) Format(log logging.Logger) ([]*FormatResult, error) {
-	if n == nil {
-		return nil, errors.New("nil NvmeImpl")
-	}
-
-	results, err := collectFormatResults(C.nvme_wipe_namespaces(),
-		"NVMe Format(): C.nvme_wipe_namespaces()")
-
-	pciAddrs := resultPCIAddresses(results)
-	log.Debugf("formatted nvme ssds: %v", pciAddrs)
-
-	return results, wrapCleanError(err, cleanLockfiles(log, realRemove, pciAddrs...))
-}
-
-// Update updates the firmware image via SPDK in a given slot on the device.
-//
-// Afterwards remove lockfile for the updated device.
-func (n *NvmeImpl) Update(log logging.Logger, ctrlrPciAddr string, path string, slot int32) error {
-	if n == nil {
-		return errors.New("nil NvmeImpl")
-	}
-
-	csPath := C.CString(path)
-	defer C.free(unsafe.Pointer(csPath))
-
-	csPci := C.CString(ctrlrPciAddr)
-	defer C.free(unsafe.Pointer(csPci))
-
-	_, err := collectCtrlrs(C.nvme_fwupdate(csPci, csPath, C.uint(slot)),
-		"NVMe Update(): C.nvme_fwupdate")
-
-	return wrapCleanError(err, cleanLockfiles(log, realRemove, ctrlrPciAddr))
-}
-
-// c2GoController is a private translation function.
-func c2GoController(ctrlr *C.struct_ctrlr_t) *storage.NvmeController {
-	return &storage.NvmeController{
-		Model:    C.GoString(&ctrlr.model[0]),
-		Serial:   C.GoString(&ctrlr.serial[0]),
-		PciAddr:  C.GoString(&ctrlr.pci_addr[0]),
-		FwRev:    C.GoString(&ctrlr.fw_rev[0]),
-		SocketID: int32(ctrlr.socket_id),
-	}
-}
-
-// c2GoDeviceHealth is a private translation function.
-func c2GoDeviceHealth(hs *C.struct_nvme_stats) *storage.NvmeHealth {
-	return &storage.NvmeHealth{
-		TempWarnTime:            uint32(hs.warn_temp_time),
-		TempCritTime:            uint32(hs.crit_temp_time),
-		CtrlBusyTime:            uint64(hs.ctrl_busy_time),
-		PowerCycles:             uint64(hs.power_cycles),
-		PowerOnHours:            uint64(hs.power_on_hours),
-		UnsafeShutdowns:         uint64(hs.unsafe_shutdowns),
-		MediaErrors:             uint64(hs.media_errs),
-		ErrorLogEntries:         uint64(hs.err_log_entries),
-		Temperature:             uint32(hs.temperature),
-		TempWarn:                bool(hs.temp_warn),
-		AvailSpareWarn:          bool(hs.avail_spare_warn),
-		ReliabilityWarn:         bool(hs.dev_reliability_warn),
-		ReadOnlyWarn:            bool(hs.read_only_warn),
-		VolatileWarn:            bool(hs.volatile_mem_warn),
-		ProgFailCntNorm:         uint8(hs.program_fail_cnt_norm),
-		ProgFailCntRaw:          uint64(hs.program_fail_cnt_raw),
-		EraseFailCntNorm:        uint8(hs.erase_fail_cnt_norm),
-		EraseFailCntRaw:         uint64(hs.erase_fail_cnt_raw),
-		WearLevelingCntNorm:     uint8(hs.wear_leveling_cnt_norm),
-		WearLevelingCntMin:      uint16(hs.wear_leveling_cnt_min),
-		WearLevelingCntMax:      uint16(hs.wear_leveling_cnt_max),
-		WearLevelingCntAvg:      uint16(hs.wear_leveling_cnt_avg),
-		EndtoendErrCntRaw:       uint64(hs.endtoend_err_cnt_raw),
-		CrcErrCntRaw:            uint64(hs.crc_err_cnt_raw),
-		MediaWearRaw:            uint64(hs.media_wear_raw),
-		HostReadsRaw:            uint64(hs.host_reads_raw),
-		WorkloadTimerRaw:        uint64(hs.workload_timer_raw),
-		ThermalThrottleStatus:   uint8(hs.thermal_throttle_status),
-		ThermalThrottleEventCnt: uint64(hs.thermal_throttle_event_cnt),
-		RetryBufferOverflowCnt:  uint64(hs.retry_buffer_overflow_cnt),
-		PllLockLossCnt:          uint64(hs.pll_lock_loss_cnt),
-		NandBytesWritten:        uint64(hs.nand_bytes_written),
-		HostBytesWritten:        uint64(hs.host_bytes_written),
-	}
-}
-
-// c2GoNamespace is a private translation function.
-func c2GoNamespace(ns *C.struct_ns_t) *storage.NvmeNamespace {
-	return &storage.NvmeNamespace{
-		ID:   uint32(ns.id),
-		Size: uint64(ns.size),
-	}
-}
-
-// c2GoFormatResult is a private translation function.
-func c2GoFormatResult(fmtResult *C.struct_wipe_res_t) *FormatResult {
-	var err error
-	if fmtResult.rc != 0 {
-		err = rc2err(C.GoString(&fmtResult.info[0]), fmtResult.rc)
-	}
-
-	return &FormatResult{
-		CtrlrPCIAddr: C.GoString(&fmtResult.ctrlr_pci_addr[0]),
-		NsID:         uint32(fmtResult.ns_id),
-		Err:          err,
-	}
-}
-
-// clean deallocates memory in return structure and frees the pointer.
-func clean(retPtr *C.struct_ret_t) {
-	C.clean_ret(retPtr)
-	C.free(unsafe.Pointer(retPtr))
-}
-
-// checkRet returns fault if ret_t struct input is nil or rc is non-zero.
-func checkRet(retPtr *C.struct_ret_t, msgFail string) error {
-	if retPtr == nil {
-		return FaultBindingRetNull(msgFail)
-	}
-
-	if retPtr.rc != 0 {
-		var msgs []string
-
-		if msgFail != "" {
-			msgs = append(msgs, msgFail)
-		}
-
-		msgInfo := C.GoString(&retPtr.info[0])
-		if msgInfo != "" {
-			msgs = append(msgs, msgInfo)
-		}
-
-		msgErrno := C.GoString(C.spdk_strerror(-retPtr.rc))
-		if msgErrno != "" {
-			msgs = append(msgs, msgErrno)
-		}
-
-		return FaultBindingFailed(int(retPtr.rc), strings.Join(msgs, ": "))
-	}
-
-	return nil
-}
-
-// collectCtrlrs parses return struct to collect slice of nvme.Controller.
-func collectCtrlrs(retPtr *C.struct_ret_t, msgFail string) (storage.NvmeControllers, error) {
-	defer clean(retPtr)
-
-	if err := checkRet(retPtr, msgFail); err != nil {
-		return nil, err
-	}
-
-	var ctrlrs storage.NvmeControllers
-	ctrlrPtr := retPtr.ctrlrs
-	for ctrlrPtr != nil {
-		ctrlr := c2GoController(ctrlrPtr)
-
-		if nsPtr := ctrlrPtr.nss; nsPtr != nil {
-			for nsPtr != nil {
-				ctrlr.Namespaces = append(ctrlr.Namespaces,
-					c2GoNamespace(nsPtr))
-				nsPtr = nsPtr.next
-			}
-		}
-
-		healthPtr := ctrlrPtr.stats
-		if healthPtr == nil {
-			return ctrlrs, errors.Wrapf(FaultCtrlrNoHealth, "ctrlr %s", ctrlr.PciAddr)
-		}
-		ctrlr.HealthStats = c2GoDeviceHealth(healthPtr)
-
-		ctrlrs = append(ctrlrs, ctrlr)
-
-		ctrlrPtr = ctrlrPtr.next
-	}
-
-	return ctrlrs, nil
-}
-
-// collectFormatResults parses return struct to collect slice of
-// nvme.FormatResult.
-func collectFormatResults(retPtr *C.struct_ret_t, msgFail string) ([]*FormatResult, error) {
-	defer clean(retPtr)
-
-	if err := checkRet(retPtr, msgFail); err != nil {
-		return nil, err
-	}
-
-	var fmtResults []*FormatResult
-	fmtResult := retPtr.wipe_results
-	for fmtResult != nil {
-		fmtResults = append(fmtResults, c2GoFormatResult(fmtResult))
-		fmtResult = fmtResult.next
-	}
-
-	return fmtResults, nil
 }

--- a/src/control/lib/spdk/nvme_default.go
+++ b/src/control/lib/spdk/nvme_default.go
@@ -1,0 +1,263 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build spdk
+// +build spdk
+
+package spdk
+
+// CGO_CFLAGS & CGO_LDFLAGS env vars can be used
+// to specify additional dirs.
+
+/*
+#cgo CFLAGS: -I .
+#cgo LDFLAGS: -L . -lnvme_control
+#cgo LDFLAGS: -lspdk_env_dpdk -lspdk_nvme -lspdk_vmd -lspdk_util
+#cgo LDFLAGS: -lrte_mempool -lrte_mempool_ring -lrte_bus_pci
+
+#include "stdlib.h"
+#include "daos_srv/control.h"
+#include "spdk/stdinc.h"
+#include "spdk/string.h"
+#include "spdk/env.h"
+#include "spdk/nvme.h"
+#include "include/nvme_control.h"
+#include "include/nvme_control_common.h"
+*/
+import "C"
+
+import (
+	"os"
+	"strings"
+	"unsafe"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/server/storage"
+)
+
+func realRemove(name string) error {
+	return os.Remove(name)
+}
+
+// Discover NVMe devices, including NVMe devices behind VMDs if enabled,
+// accessible by SPDK on a given host.
+//
+// Calls C.nvme_discover which returns pointers to single linked list of
+// ctrlr_t structs. These are converted and returned as Controller slices
+// containing any Namespace and DeviceHealth structs.
+// Afterwards remove lockfile for each discovered device.
+func (n *NvmeImpl) Discover(log logging.Logger) (storage.NvmeControllers, error) {
+	if n == nil {
+		return nil, errors.New("nil NvmeImpl")
+	}
+
+	ctrlrs, err := collectCtrlrs(C.nvme_discover(), "NVMe Discover(): C.nvme_discover")
+
+	pciAddrs := ctrlrPCIAddresses(ctrlrs)
+	log.Debugf("discovered nvme ssds: %v", pciAddrs)
+
+	return ctrlrs, wrapCleanError(err, cleanLockfiles(log, realRemove, pciAddrs...))
+}
+
+// Format devices available through SPDK, destructive operation!
+//
+// Attempt wipe of each controller namespace's LBA-0.
+// Afterwards remove lockfile for each formatted device.
+func (n *NvmeImpl) Format(log logging.Logger) ([]*FormatResult, error) {
+	if n == nil {
+		return nil, errors.New("nil NvmeImpl")
+	}
+
+	results, err := collectFormatResults(C.nvme_wipe_namespaces(),
+		"NVMe Format(): C.nvme_wipe_namespaces()")
+
+	pciAddrs := resultPCIAddresses(results)
+	log.Debugf("formatted nvme ssds: %v", pciAddrs)
+
+	return results, wrapCleanError(err, cleanLockfiles(log, realRemove, pciAddrs...))
+}
+
+// Update updates the firmware image via SPDK in a given slot on the device.
+//
+// Afterwards remove lockfile for the updated device.
+func (n *NvmeImpl) Update(log logging.Logger, ctrlrPciAddr string, path string, slot int32) error {
+	if n == nil {
+		return errors.New("nil NvmeImpl")
+	}
+
+	csPath := C.CString(path)
+	defer C.free(unsafe.Pointer(csPath))
+
+	csPci := C.CString(ctrlrPciAddr)
+	defer C.free(unsafe.Pointer(csPci))
+
+	_, err := collectCtrlrs(C.nvme_fwupdate(csPci, csPath, C.uint(slot)),
+		"NVMe Update(): C.nvme_fwupdate")
+
+	return wrapCleanError(err, cleanLockfiles(log, realRemove, ctrlrPciAddr))
+}
+
+// c2GoController is a private translation function.
+func c2GoController(ctrlr *C.struct_ctrlr_t) *storage.NvmeController {
+	return &storage.NvmeController{
+		Model:    C.GoString(&ctrlr.model[0]),
+		Serial:   C.GoString(&ctrlr.serial[0]),
+		PciAddr:  C.GoString(&ctrlr.pci_addr[0]),
+		FwRev:    C.GoString(&ctrlr.fw_rev[0]),
+		SocketID: int32(ctrlr.socket_id),
+	}
+}
+
+// c2GoDeviceHealth is a private translation function.
+func c2GoDeviceHealth(hs *C.struct_nvme_stats) *storage.NvmeHealth {
+	return &storage.NvmeHealth{
+		TempWarnTime:            uint32(hs.warn_temp_time),
+		TempCritTime:            uint32(hs.crit_temp_time),
+		CtrlBusyTime:            uint64(hs.ctrl_busy_time),
+		PowerCycles:             uint64(hs.power_cycles),
+		PowerOnHours:            uint64(hs.power_on_hours),
+		UnsafeShutdowns:         uint64(hs.unsafe_shutdowns),
+		MediaErrors:             uint64(hs.media_errs),
+		ErrorLogEntries:         uint64(hs.err_log_entries),
+		Temperature:             uint32(hs.temperature),
+		TempWarn:                bool(hs.temp_warn),
+		AvailSpareWarn:          bool(hs.avail_spare_warn),
+		ReliabilityWarn:         bool(hs.dev_reliability_warn),
+		ReadOnlyWarn:            bool(hs.read_only_warn),
+		VolatileWarn:            bool(hs.volatile_mem_warn),
+		ProgFailCntNorm:         uint8(hs.program_fail_cnt_norm),
+		ProgFailCntRaw:          uint64(hs.program_fail_cnt_raw),
+		EraseFailCntNorm:        uint8(hs.erase_fail_cnt_norm),
+		EraseFailCntRaw:         uint64(hs.erase_fail_cnt_raw),
+		WearLevelingCntNorm:     uint8(hs.wear_leveling_cnt_norm),
+		WearLevelingCntMin:      uint16(hs.wear_leveling_cnt_min),
+		WearLevelingCntMax:      uint16(hs.wear_leveling_cnt_max),
+		WearLevelingCntAvg:      uint16(hs.wear_leveling_cnt_avg),
+		EndtoendErrCntRaw:       uint64(hs.endtoend_err_cnt_raw),
+		CrcErrCntRaw:            uint64(hs.crc_err_cnt_raw),
+		MediaWearRaw:            uint64(hs.media_wear_raw),
+		HostReadsRaw:            uint64(hs.host_reads_raw),
+		WorkloadTimerRaw:        uint64(hs.workload_timer_raw),
+		ThermalThrottleStatus:   uint8(hs.thermal_throttle_status),
+		ThermalThrottleEventCnt: uint64(hs.thermal_throttle_event_cnt),
+		RetryBufferOverflowCnt:  uint64(hs.retry_buffer_overflow_cnt),
+		PllLockLossCnt:          uint64(hs.pll_lock_loss_cnt),
+		NandBytesWritten:        uint64(hs.nand_bytes_written),
+		HostBytesWritten:        uint64(hs.host_bytes_written),
+	}
+}
+
+// c2GoNamespace is a private translation function.
+func c2GoNamespace(ns *C.struct_ns_t) *storage.NvmeNamespace {
+	return &storage.NvmeNamespace{
+		ID:   uint32(ns.id),
+		Size: uint64(ns.size),
+	}
+}
+
+// c2GoFormatResult is a private translation function.
+func c2GoFormatResult(fmtResult *C.struct_wipe_res_t) *FormatResult {
+	var err error
+	if fmtResult.rc != 0 {
+		err = rc2err(C.GoString(&fmtResult.info[0]), fmtResult.rc)
+	}
+
+	return &FormatResult{
+		CtrlrPCIAddr: C.GoString(&fmtResult.ctrlr_pci_addr[0]),
+		NsID:         uint32(fmtResult.ns_id),
+		Err:          err,
+	}
+}
+
+// clean deallocates memory in return structure and frees the pointer.
+func clean(retPtr *C.struct_ret_t) {
+	C.clean_ret(retPtr)
+	C.free(unsafe.Pointer(retPtr))
+}
+
+// checkRet returns fault if ret_t struct input is nil or rc is non-zero.
+func checkRet(retPtr *C.struct_ret_t, msgFail string) error {
+	if retPtr == nil {
+		return FaultBindingRetNull(msgFail)
+	}
+
+	if retPtr.rc != 0 {
+		var msgs []string
+
+		if msgFail != "" {
+			msgs = append(msgs, msgFail)
+		}
+
+		msgInfo := C.GoString(&retPtr.info[0])
+		if msgInfo != "" {
+			msgs = append(msgs, msgInfo)
+		}
+
+		msgErrno := C.GoString(C.spdk_strerror(-retPtr.rc))
+		if msgErrno != "" {
+			msgs = append(msgs, msgErrno)
+		}
+
+		return FaultBindingFailed(int(retPtr.rc), strings.Join(msgs, ": "))
+	}
+
+	return nil
+}
+
+// collectCtrlrs parses return struct to collect slice of nvme.Controller.
+func collectCtrlrs(retPtr *C.struct_ret_t, msgFail string) (storage.NvmeControllers, error) {
+	defer clean(retPtr)
+
+	if err := checkRet(retPtr, msgFail); err != nil {
+		return nil, err
+	}
+
+	var ctrlrs storage.NvmeControllers
+	ctrlrPtr := retPtr.ctrlrs
+	for ctrlrPtr != nil {
+		ctrlr := c2GoController(ctrlrPtr)
+
+		if nsPtr := ctrlrPtr.nss; nsPtr != nil {
+			for nsPtr != nil {
+				ctrlr.Namespaces = append(ctrlr.Namespaces,
+					c2GoNamespace(nsPtr))
+				nsPtr = nsPtr.next
+			}
+		}
+
+		healthPtr := ctrlrPtr.stats
+		if healthPtr == nil {
+			return ctrlrs, errors.Wrapf(FaultCtrlrNoHealth, "ctrlr %s", ctrlr.PciAddr)
+		}
+		ctrlr.HealthStats = c2GoDeviceHealth(healthPtr)
+
+		ctrlrs = append(ctrlrs, ctrlr)
+
+		ctrlrPtr = ctrlrPtr.next
+	}
+
+	return ctrlrs, nil
+}
+
+// collectFormatResults parses return struct to collect slice of
+// nvme.FormatResult.
+func collectFormatResults(retPtr *C.struct_ret_t, msgFail string) ([]*FormatResult, error) {
+	defer clean(retPtr)
+
+	if err := checkRet(retPtr, msgFail); err != nil {
+		return nil, err
+	}
+
+	var fmtResults []*FormatResult
+	fmtResult := retPtr.wipe_results
+	for fmtResult != nil {
+		fmtResults = append(fmtResults, c2GoFormatResult(fmtResult))
+		fmtResult = fmtResult.next
+	}
+
+	return fmtResults, nil
+}

--- a/src/control/lib/spdk/nvme_stub.go
+++ b/src/control/lib/spdk/nvme_stub.go
@@ -1,0 +1,29 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build !spdk
+// +build !spdk
+
+package spdk
+
+import (
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/server/storage"
+)
+
+// Discover NVMe devices.
+func (n *NvmeImpl) Discover(log logging.Logger) (storage.NvmeControllers, error) {
+	return nil, nil
+}
+
+// Format devices available through SPDK.
+func (n *NvmeImpl) Format(log logging.Logger) ([]*FormatResult, error) {
+	return nil, nil
+}
+
+// Update updates the firmware image via SPDK in a given slot on the device.
+func (n *NvmeImpl) Update(log logging.Logger, ctrlrPciAddr string, path string, slot int32) error {
+	return nil
+}

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -7,46 +7,7 @@
 // Package spdk provides Go bindings for SPDK
 package spdk
 
-// CGO_CFLAGS & CGO_LDFLAGS env vars can be used
-// to specify additional dirs.
-
-/*
-#cgo CFLAGS: -I .
-#cgo LDFLAGS: -L . -lnvme_control
-#cgo LDFLAGS: -lspdk_util -lspdk_log -lspdk_env_dpdk -lspdk_nvme -lspdk_vmd
-#cgo LDFLAGS: -lrte_mempool -lrte_mempool_ring -lrte_bus_pci
-
-#include "stdlib.h"
-#include "daos_srv/control.h"
-#include "spdk/stdinc.h"
-#include "spdk/string.h"
-#include "spdk/log.h"
-#include "spdk/env.h"
-#include "spdk/nvme.h"
-#include "spdk/vmd.h"
-#include "include/nvme_control.h"
-#include "include/nvme_control_common.h"
-
-static char **makeCStringArray(int size) {
-        return calloc(sizeof(char*), size);
-}
-
-static void setArrayString(char **a, char *s, int n) {
-        a[n] = s;
-}
-
-static void freeCStringArray(char **a, int size) {
-        int i;
-        for (i = 0; i < size; i++)
-                free(a[i]);
-        free(a);
-}
-*/
-import "C"
-
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/hardware"
@@ -61,16 +22,6 @@ type Env interface {
 
 // EnvImpl is a an implementation of the Env interface.
 type EnvImpl struct{}
-
-// rc2err returns error from label and rc.
-func rc2err(label string, rc C.int) error {
-	msgErrno := C.GoString(C.spdk_strerror(-rc))
-
-	if msgErrno != "" {
-		return fmt.Errorf("%s: %s (rc=%d)", label, msgErrno, rc)
-	}
-	return fmt.Errorf("%s: rc=%d", label, rc)
-}
 
 // EnvOptions describe parameters to be used when initializing a processes
 // SPDK environment.
@@ -95,74 +46,4 @@ func (eo *EnvOptions) sanitizeAllowList(log logging.Logger) error {
 	eo.PCIAllowList = newSet
 
 	return nil
-}
-
-// InitSPDKEnv initializes the SPDK environment.
-//
-// SPDK relies on an abstraction around the local environment
-// named env that handles memory allocation and PCI device operations.
-// The library must be initialized first.
-func (ei *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
-	if ei == nil {
-		return errors.New("nil EnvImpl")
-	}
-	if opts == nil {
-		return errors.New("nil EnvOptions")
-	}
-	if opts.PCIAllowList == nil {
-		opts.PCIAllowList = hardware.MustNewPCIAddressSet()
-	}
-
-	log.Debugf("spdk init go opts: %+v", opts)
-
-	// Only print error and more severe to stderr.
-	C.spdk_log_set_print_level(C.SPDK_LOG_ERROR)
-
-	if err := opts.sanitizeAllowList(log); err != nil {
-		return errors.Wrap(err, "sanitizing PCI include list")
-	}
-
-	// Build C array in Go from opts.PCIAllowList []string
-	cAllowList := C.makeCStringArray(C.int(opts.PCIAllowList.Len()))
-	defer C.freeCStringArray(cAllowList, C.int(opts.PCIAllowList.Len()))
-
-	for i, s := range opts.PCIAllowList.Strings() {
-		C.setArrayString(cAllowList, C.CString(s), C.int(i))
-	}
-
-	envCtx := C.dpdk_cli_override_opts
-
-	retPtr := C.daos_spdk_init(0, envCtx, C.ulong(opts.PCIAllowList.Len()),
-		cAllowList)
-	defer clean(retPtr)
-
-	if err := checkRet(retPtr, "daos_spdk_init()"); err != nil {
-		return err
-	}
-
-	if opts.EnableVMD {
-		if rc := C.spdk_vmd_init(); rc != 0 {
-			return rc2err("spdk_vmd_init()", rc)
-		}
-	}
-
-	return nil
-}
-
-// FiniSPDKEnv initializes the SPDK environment.
-func (ei *EnvImpl) FiniSPDKEnv(log logging.Logger, opts *EnvOptions) {
-	if ei == nil {
-		return
-	}
-	if opts == nil {
-		return
-	}
-
-	log.Debugf("spdk fini go opts: %+v", opts)
-
-	if opts.EnableVMD {
-		C.spdk_vmd_fini()
-	}
-
-	C.spdk_env_fini()
 }

--- a/src/control/lib/spdk/spdk_default.go
+++ b/src/control/lib/spdk/spdk_default.go
@@ -1,0 +1,136 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build spdk
+// +build spdk
+
+// Package spdk provides Go bindings for SPDK
+package spdk
+
+// CGO_CFLAGS & CGO_LDFLAGS env vars can be used
+// to specify additional dirs.
+
+/*
+#cgo CFLAGS: -I .
+#cgo LDFLAGS: -L . -lnvme_control
+#cgo LDFLAGS: -lspdk_util -lspdk_log -lspdk_env_dpdk -lspdk_nvme -lspdk_vmd
+#cgo LDFLAGS: -lrte_mempool -lrte_mempool_ring -lrte_bus_pci
+
+#include "stdlib.h"
+#include "daos_srv/control.h"
+#include "spdk/stdinc.h"
+#include "spdk/string.h"
+#include "spdk/log.h"
+#include "spdk/env.h"
+#include "spdk/nvme.h"
+#include "spdk/vmd.h"
+#include "include/nvme_control.h"
+#include "include/nvme_control_common.h"
+
+static char **makeCStringArray(int size) {
+        return calloc(sizeof(char*), size);
+}
+
+static void setArrayString(char **a, char *s, int n) {
+        a[n] = s;
+}
+
+static void freeCStringArray(char **a, int size) {
+        int i;
+        for (i = 0; i < size; i++)
+                free(a[i]);
+        free(a);
+}
+*/
+import "C"
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+// rc2err returns error from label and rc.
+func rc2err(label string, rc C.int) error {
+	msgErrno := C.GoString(C.spdk_strerror(-rc))
+
+	if msgErrno != "" {
+		return fmt.Errorf("%s: %s (rc=%d)", label, msgErrno, rc)
+	}
+	return fmt.Errorf("%s: rc=%d", label, rc)
+}
+
+// InitSPDKEnv initializes the SPDK environment.
+//
+// SPDK relies on an abstraction around the local environment
+// named env that handles memory allocation and PCI device operations.
+// The library must be initialized first.
+func (ei *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
+	if ei == nil {
+		return errors.New("nil EnvImpl")
+	}
+	if opts == nil {
+		return errors.New("nil EnvOptions")
+	}
+	if opts.PCIAllowList == nil {
+		opts.PCIAllowList = hardware.MustNewPCIAddressSet()
+	}
+
+	log.Debugf("spdk init go opts: %+v", opts)
+
+	// Only print error and more severe to stderr.
+	C.spdk_log_set_print_level(C.SPDK_LOG_ERROR)
+
+	if err := opts.sanitizeAllowList(log); err != nil {
+		return errors.Wrap(err, "sanitizing PCI include list")
+	}
+
+	// Build C array in Go from opts.PCIAllowList []string
+	cAllowList := C.makeCStringArray(C.int(opts.PCIAllowList.Len()))
+	defer C.freeCStringArray(cAllowList, C.int(opts.PCIAllowList.Len()))
+
+	for i, s := range opts.PCIAllowList.Strings() {
+		C.setArrayString(cAllowList, C.CString(s), C.int(i))
+	}
+
+	envCtx := C.dpdk_cli_override_opts
+
+	retPtr := C.daos_spdk_init(0, envCtx, C.ulong(opts.PCIAllowList.Len()),
+		cAllowList)
+	defer clean(retPtr)
+
+	if err := checkRet(retPtr, "daos_spdk_init()"); err != nil {
+		return err
+	}
+
+	if opts.EnableVMD {
+		if rc := C.spdk_vmd_init(); rc != 0 {
+			return rc2err("spdk_vmd_init()", rc)
+		}
+	}
+
+	return nil
+}
+
+// FiniSPDKEnv initializes the SPDK environment.
+func (ei *EnvImpl) FiniSPDKEnv(log logging.Logger, opts *EnvOptions) {
+	if ei == nil {
+		return
+	}
+	if opts == nil {
+		return
+	}
+
+	log.Debugf("spdk fini go opts: %+v", opts)
+
+	if opts.EnableVMD {
+		C.spdk_vmd_fini()
+	}
+
+	C.spdk_env_fini()
+}

--- a/src/control/lib/spdk/spdk_stub.go
+++ b/src/control/lib/spdk/spdk_stub.go
@@ -1,0 +1,24 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build !spdk
+// +build !spdk
+
+// Package spdk provides Go bindings for SPDK
+package spdk
+
+import (
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+// InitSPDKEnv initializes the SPDK environment.
+func (ei *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
+	return nil
+}
+
+// FiniSPDKEnv initializes the SPDK environment.
+func (ei *EnvImpl) FiniSPDKEnv(log logging.Logger, opts *EnvOptions) {
+	return
+}


### PR DESCRIPTION
Provide stubbing for the SPDK C library interface so that go does not
link to the actual library unless the spdk build flag is provided.

Also tidy stubbing of the libipmctl C library interface.

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>