### PR TITLE
DAOS-11241 obj: add EC full-stripe and partial update metrics

### DIFF
--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -759,15 +759,4 @@ void obj_ec_recov_data(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 int obj_ec_get_degrade(struct obj_reasb_req *reasb_req, uint16_t fail_tgt_idx,
 		       uint32_t *parity_tgt_idx, bool ignore_fail_tgt_idx);
 
-/* srv_ec.c */
-struct obj_rw_in;
-int obj_ec_rw_req_split(daos_unit_oid_t oid, uint64_t dkey_hash,
-			struct obj_iod_array *iod_array,
-			uint32_t iod_nr, uint32_t start_shard,
-			uint32_t max_shard, uint32_t leader_id,
-			void *tgt_map, uint32_t map_size, struct daos_oclass_attr *oca,
-			uint32_t tgt_nr, struct daos_shard_tgt *tgts,
-			struct obj_ec_split_req **split_req);
-void obj_ec_split_req_fini(struct obj_ec_split_req *req);
-
 #endif /* __OBJ_EC_H__ */

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -38,19 +38,84 @@ obj_ec_is_valid_tgt(struct daos_cpd_ec_tgts *tgt_map, uint32_t map_size,
 	return false;
 }
 
+static void
+obj_ec_metrics_process(daos_iod_t *iod, struct obj_io_desc *oiod, struct daos_oclass_attr *oca,
+		       struct obj_pool_metrics *opm)
+{
+	struct obj_shard_iod	*siod;
+	daos_recx_t		*recx, *recx0;
+	uint32_t		 cell_size, nr;
+	uint32_t		 i, j;
+
+	if (iod->iod_type == DAOS_IOD_SINGLE) {
+		if (iod->iod_size == DAOS_REC_ANY)
+			return;
+		if (iod->iod_size <= OBJ_EC_SINGV_EVENDIST_SZ(obj_ec_data_tgt_nr(oca)))
+			d_tm_inc_counter(opm->opm_update_ec_partial, 1);
+		else
+			d_tm_inc_counter(opm->opm_update_ec_full, 1);
+
+		return;
+	}
+
+	/* only when IOD with all full-stripe update, count for opm_update_ec_full.
+	 * if the iod with all partial update, or mixed with partial update and full-stripe update
+	 * count for opm_update_ec_partial.
+	 */
+	if (oiod->oiod_nr < obj_ec_tgt_nr(oca)) {
+		d_tm_inc_counter(opm->opm_update_ec_partial, 1);
+		return;
+	}
+
+	cell_size = obj_ec_cell_rec_nr(oca);
+	nr = 0;
+	for (i = 0; i < obj_ec_tgt_nr(oca); i++) {
+		siod = &oiod->oiod_siods[i];
+		if (i == 0) {
+			nr = siod->siod_nr;
+			for (j = 0; j < nr; j++) {
+				D_ASSERT(siod->siod_idx + j < iod->iod_nr);
+				recx = &iod->iod_recxs[siod->siod_idx + j];
+				if (recx->rx_idx % cell_size != 0 ||
+				    recx->rx_nr % cell_size != 0) {
+					d_tm_inc_counter(opm->opm_update_ec_partial, 1);
+					return;
+				}
+			}
+			continue;
+		}
+		D_ASSERT(nr > 0);
+		if (siod->siod_nr != nr) {
+			d_tm_inc_counter(opm->opm_update_ec_partial, 1);
+			return;
+		}
+		for (j = 0; j < nr; j++) {
+			D_ASSERT(siod->siod_idx + j < iod->iod_nr);
+			recx0 = &iod->iod_recxs[j];
+			recx = &iod->iod_recxs[siod->siod_idx + j];
+			if ((recx->rx_nr != recx0->rx_nr) ||
+			    ((recx->rx_idx & (~PARITY_INDICATOR)) !=
+			     (recx0->rx_idx & (~PARITY_INDICATOR)))) {
+			d_tm_inc_counter(opm->opm_update_ec_partial, 1);
+			return;
+			}
+		}
+	}
+
+	d_tm_inc_counter(opm->opm_update_ec_full, 1);
+}
+
 /**
  * Split EC obj read/write request.
  * For object update, client sends update request to leader, the leader needs to
  * split it for different targets before dispatch.
  */
 int
-obj_ec_rw_req_split(daos_unit_oid_t oid, uint64_t dkey_hash,
-		    struct obj_iod_array *iod_array,
-		    uint32_t iod_nr, uint32_t start_shard, uint32_t max_shard,
-		    uint32_t leader_id, void *tgt_map, uint32_t map_size,
-		    struct daos_oclass_attr *oca, uint32_t tgt_nr,
-		    struct daos_shard_tgt *tgts,
-		    struct obj_ec_split_req **split_req)
+obj_ec_rw_req_split(daos_unit_oid_t oid, uint64_t dkey_hash, struct obj_iod_array *iod_array,
+		    uint32_t iod_nr, uint32_t start_shard, uint32_t max_shard, uint32_t leader_id,
+		    void *tgt_map, uint32_t map_size, struct daos_oclass_attr *oca, uint32_t tgt_nr,
+		    struct daos_shard_tgt *tgts, struct obj_ec_split_req **split_req,
+		    struct obj_pool_metrics *opm)
 {
 	daos_iod_t		*iod;
 	daos_iod_t		*iods = iod_array->oia_iods;
@@ -169,6 +234,8 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, uint64_t dkey_hash,
 		int	idx;
 
 		iod = &iods[i];
+		if (opm != NULL)
+			obj_ec_metrics_process(iod, &oiods[i], oca, opm);
 		if (with_csums) {
 			D_ASSERT(split_iod_csums != NULL);
 

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -122,6 +122,10 @@ struct obj_pool_metrics {
 	struct d_tm_node_t	*opm_update_resent;
 	/** Total number of retry update operations (type = counter) */
 	struct d_tm_node_t	*opm_update_retry;
+	/** Total number of EC full-stripe update operations (type = counter) */
+	struct d_tm_node_t	*opm_update_ec_full;
+	/** Total number of EC partial update operations (type = counter) */
+	struct d_tm_node_t	*opm_update_ec_partial;
 };
 
 struct obj_tls {
@@ -280,4 +284,14 @@ obj_dtx_need_refresh(struct dtx_handle *dth, int rc)
 /* obj_enum.c */
 int
 fill_oid(daos_unit_oid_t oid, struct ds_obj_enum_arg *arg);
+
+/* srv_ec.c */
+struct obj_rw_in;
+int obj_ec_rw_req_split(daos_unit_oid_t oid, uint64_t dkey_hash, struct obj_iod_array *iod_array,
+			uint32_t iod_nr, uint32_t start_shard, uint32_t max_shard,
+			uint32_t leader_id, void *tgt_map, uint32_t map_size,
+			struct daos_oclass_attr *oca, uint32_t tgt_nr, struct daos_shard_tgt *tgts,
+			struct obj_ec_split_req **split_req, struct obj_pool_metrics *opm);
+void obj_ec_split_req_fini(struct obj_ec_split_req *req);
+
 #endif /* __DAOS_OBJ_SRV_INTENRAL_H__ */

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -282,6 +282,22 @@ obj_metrics_alloc(const char *path, int tgt_id)
 		D_WARN("Failed to create bytes update counter: "DF_RC"\n",
 		       DP_RC(rc));
 
+	/** Total number of EC full-stripe update operations, of type counter */
+	rc = d_tm_add_metric(&metrics->opm_update_ec_full, D_TM_COUNTER,
+			     "total number of EC sull-stripe updates", "updates",
+			     "%s/EC_update/full_stripe/tgt_%u", path, tgt_id);
+	if (rc)
+		D_WARN("Failed to create EC full stripe update counter: "DF_RC"\n",
+		       DP_RC(rc));
+
+	/** Total number of EC partial update operations, of type counter */
+	rc = d_tm_add_metric(&metrics->opm_update_ec_partial, D_TM_COUNTER,
+			     "total number of EC sull-partial updates", "updates",
+			     "%s/EC_update/partial/tgt_%u", path, tgt_id);
+	if (rc)
+		D_WARN("Failed to create EC partial update counter: "DF_RC"\n",
+		       DP_RC(rc));
+
 	return metrics;
 }
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2601,7 +2601,7 @@ again2:
 					 ioc.ioc_ec_rotate_parity ? orw->orw_dkey_hash : 0,
 					 &orw->orw_iod_array, orw->orw_nr, orw->orw_start_shard,
 					 orw->orw_tgt_max, PO_COMP_ID_ALL, NULL, 0, &ioc.ioc_oca,
-					 tgt_cnt, tgts, &split_req);
+					 tgt_cnt, tgts, &split_req, opm);
 		if (rc != 0) {
 			D_ERROR(DF_UOID": obj_ec_rw_req_split failed, rc %d.\n",
 				DP_UOID(orw->orw_oid), rc);
@@ -2671,10 +2671,6 @@ again2:
 		 * the restart to the RPC client.
 		 */
 		if (opc == DAOS_OBJ_RPC_UPDATE) {
-			struct obj_pool_metrics	*m;
-
-			m = ioc.ioc_coc->sc_pool->spc_metrics[DAOS_OBJ_MODULE];
-
 			/*
 			 * Only standalone updates use this RPC. Retry with
 			 * newer epoch.
@@ -2682,7 +2678,7 @@ again2:
 			orw->orw_epoch = crt_hlc_get();
 			orw->orw_flags &= ~ORF_RESEND;
 			flags = 0;
-			d_tm_inc_counter(m->opm_update_restart, 1);
+			d_tm_inc_counter(opm->opm_update_restart, 1);
 			goto again2;
 		}
 
@@ -4413,8 +4409,8 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 					 ioc->ioc_ec_rotate_parity ? dcsr->dcsr_dkey_hash : 0,
 					 &dcu->dcu_iod_array, dcsr->dcsr_nr,
 					 dcu->dcu_start_shard, 0, ddt->ddt_id,
-					 dcu->dcu_ec_tgts, dcsr->dcsr_ec_tgt_nr,
-					 NULL, tgt_cnt, tgts, &dcu->dcu_ec_split_req);
+					 dcu->dcu_ec_tgts, dcsr->dcsr_ec_tgt_nr, NULL,
+					 tgt_cnt, tgts, &dcu->dcu_ec_split_req, NULL);
 		if (rc != 0) {
 			D_ERROR("obj_ec_rw_req_split failed for obj "
 				DF_UOID", DTX "DF_DTI": "DF_RC"\n",


### PR DESCRIPTION
add EC full-stripe and partial update metrics on dtx leader node.
path - pool -> EC_update -> full_stripe/partial.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>