### PR TITLE
 DAOS-10525 objects: enable online reintegration

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -985,16 +985,8 @@ obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
 	D_DEBUG(DB_TRACE, DF_OID" query shard %u\n",
 		DP_OID(obj->cob_md.omd_id), shard);
 	rc = obj_shard_open(obj, shard, map_ver, &obj_shard);
-	/* Disable inflight I/O during reintegration for the moment */
-	if (rc == 0 &&
-	    obj_auxi->opc == DAOS_OBJ_RPC_UPDATE && obj_shard->do_reintegrating) {
-		D_ERROR(DF_OID" shard is being reintegrated: %d\n",
-			DP_OID(obj->cob_md.omd_id), -DER_IO);
-		D_GOTO(close, rc = -DER_IO);
-	}
-
 	if (rc != 0) {
-		D_ERROR(DF_OID" obj_shard_open %u, rc "DF_RC".\n",
+		D_DEBUG(DB_IO, DF_OID" obj_shard_open %u, rc "DF_RC".\n",
 			DP_OID(obj->cob_md.omd_id), shard, DP_RC(rc));
 		D_GOTO(out, rc);
 	}

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1120,6 +1120,13 @@ rebuild_try_merge_tgts(struct ds_pool *pool, uint32_t map_ver,
 			/* This task isn't for this pool - don't consider it */
 			continue;
 
+		/* Do not merge reclaim rebuild job */
+		if (task->dst_rebuild_op == RB_OP_RECLAIM)
+			continue;
+
+		/* Since the queue is sorted by map version, so we only need compare
+		 * the first non-reclaim job.
+		 */
 		if (task->dst_rebuild_op != rebuild_op)
 			/* Found a different operation. If we had found a task
 			 * to merge to before this, clear it, as that is no

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -108,13 +108,8 @@ daos_tests:
     test_rebuild_28: -s3 -u subtests="28"
     test_rebuild_29: -s5 -u subtests="29"
   stopped_ranks:
-    test_rebuild_22: [7]
-    test_rebuild_23: [7]
-    test_rebuild_24: [7]
-    test_rebuild_25: [5, 6, 7]
     test_rebuild_26: ["random"]
     test_rebuild_27: ["random"]
-    test_rebuild_28: [7]
     test_rebuild_29: ["random"]
   pools_created:
     test_rebuild_0to10: 16

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -27,7 +27,7 @@ timeouts:
     test_daos_extend_simple: 500
     test_daos_oid_allocator: 640
     test_daos_checksum: 500
-    test_daos_rebuild_ec: 3600
+    test_daos_rebuild_ec: 4800
     test_daos_aggregate_ec: 200
     test_daos_degraded_ec: 1900
     test_daos_dedup: 220

--- a/src/tests/suite/daos_base_tx.c
+++ b/src/tests/suite/daos_base_tx.c
@@ -821,7 +821,7 @@ dtx_20(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 
-	reintegrate_single_pool_rank(arg, rank);
+	reintegrate_single_pool_rank(arg, rank, false);
 
 	D_FREE(fetch_buf);
 	D_FREE(update_buf);

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -2638,7 +2638,7 @@ dtx_36(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 
-	reintegrate_single_pool_rank(arg, kill_rank);
+	reintegrate_single_pool_rank(arg, kill_rank, false);
 
 	dtx_fini_req_akey(reqs, akeys, 2, DTX_NC_CNT);
 }
@@ -2770,7 +2770,7 @@ dtx_37(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 
-	reintegrate_single_pool_rank(arg, kill_rank);
+	reintegrate_single_pool_rank(arg, kill_rank, false);
 
 	dtx_fini_req_akey(&req, akeys, 1, DTX_NC_CNT);
 }
@@ -2943,7 +2943,7 @@ dtx_38(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 
-	reintegrate_single_pool_rank(arg, kill_ranks[0]);
+	reintegrate_single_pool_rank(arg, kill_ranks[0], false);
 
 	dtx_fini_req_akey(reqs, akeys, 2, DTX_NC_CNT);
 }
@@ -3020,7 +3020,7 @@ dtx_39(void **state)
 		ioreq_fini(&req);
 	}
 
-	reintegrate_single_pool_rank(arg, kill_rank);
+	reintegrate_single_pool_rank(arg, kill_rank, false);
 }
 
 static void

--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -57,6 +57,8 @@ drain_dkeys(void **state)
 			      DAOS_TX_NONE, &req);
 	}
 
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oid;
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 
 	for (i = 0; i < KEY_NR; i++) {
@@ -72,6 +74,8 @@ drain_dkeys(void **state)
 		/** Verify data consistency */
 		assert_string_equal(buf, "data");
 	}
+
+	reintegrate_inflight_io_verify(arg);
 	ioreq_fini(&req);
 }
 
@@ -104,6 +108,8 @@ drain_akeys(void **state)
 			      DAOS_TX_NONE, &req);
 	}
 
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oid;
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	for (i = 0; i < KEY_NR; i++) {
 		char akey[32] = {0};
@@ -118,6 +124,7 @@ drain_akeys(void **state)
 		/** Verify data consistency */
 		assert_string_equal(buf, "data");
 	}
+	reintegrate_inflight_io_verify(arg);
 
 	ioreq_fini(&req);
 }
@@ -154,6 +161,8 @@ drain_indexes(void **state)
 	}
 
 	/* Drain rank 1 */
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oid;
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	for (i = 0; i < KEY_NR; i++) {
 		char	key[32] = {0};
@@ -170,6 +179,7 @@ drain_indexes(void **state)
 		}
 	}
 
+	reintegrate_inflight_io_verify(arg);
 	ioreq_fini(&req);
 }
 
@@ -210,6 +220,8 @@ drain_snap_update_keys(void **state)
 		insert_single("dkey", akey, 0, "data", 1, DAOS_TX_NONE, &req);
 	}
 
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oid;
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 
 	for (i = 0; i < 5; i++) {
@@ -234,13 +246,15 @@ drain_snap_update_keys(void **state)
 	number = 10;
 	memset(&anchor, 0, sizeof(anchor));
 	enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf, buf_len, &req);
-	assert_int_equal(number, 6);
+	assert_int_equal(number, 10);
 
 	number = 10;
 	memset(&anchor, 0, sizeof(anchor));
 	enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
 		       buf, buf_len, &req);
 	assert_int_equal(number, 5);
+
+	reintegrate_inflight_io_verify(arg);
 
 	ioreq_fini(&req);
 }
@@ -296,6 +310,8 @@ drain_snap_punch_keys(void **state)
 		punch_akey("dkey", akey, DAOS_TX_NONE, &req);
 	}
 
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oid;
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 
 	for (i = 0; i < 5; i++) {
@@ -321,13 +337,14 @@ drain_snap_punch_keys(void **state)
 	memset(&anchor, 0, sizeof(anchor));
 	enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf,
 		       buf_len, &req);
-	assert_int_equal(number, 1);
+	assert_int_equal(number, 10);
 
 	number = 10;
 	memset(&anchor, 0, sizeof(anchor));
 	enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
 		       buf, buf_len, &req);
 	assert_int_equal(number, 5);
+	reintegrate_inflight_io_verify(arg);
 
 	ioreq_fini(&req);
 }
@@ -370,6 +387,8 @@ drain_multiple(void **state)
 		}
 	}
 
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oid;
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	for (i = 0; i < 10; i++) {
 		char	dkey[32] = {0};
@@ -391,6 +410,7 @@ drain_multiple(void **state)
 			}
 		}
 	}
+	reintegrate_inflight_io_verify(arg);
 
 	ioreq_fini(&req);
 }
@@ -427,6 +447,8 @@ drain_large_rec(void **state)
 			      &req);
 	}
 
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oid;
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 	memset(v_buffer, 'a', 5000);
 	for (i = 0; i < KEY_NR; i++) {
@@ -438,6 +460,8 @@ drain_large_rec(void **state)
 			      &req);
 		assert_memory_equal(v_buffer, buffer, 5000);
 	}
+
+	reintegrate_inflight_io_verify(arg);
 
 	ioreq_fini(&req);
 }
@@ -461,9 +485,12 @@ drain_objects(void **state)
 	}
 
 	rebuild_io(arg, oids, OBJ_NR);
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oids[0];
 	drain_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 
 	rebuild_io_validate(arg, oids, OBJ_NR);
+	reintegrate_inflight_io_verify(arg);
 }
 
 /** create a new pool/container for each test */
@@ -478,11 +505,11 @@ static const struct CMUnitTest drain_tests[] = {
 	 drain_multiple, rebuild_small_sub_setup, test_teardown},
 	{"DRAIN5: drain large rec single index",
 	 drain_large_rec, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN7: drain keys with multiple snapshots",
+	{"DRAIN6: drain keys with multiple snapshots",
 	 drain_snap_update_keys, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN8: drain keys/punch with multiple snapshots",
+	{"DRAIN7: drain keys/punch with multiple snapshots",
 	 drain_snap_punch_keys, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN9: drain multiple objects",
+	{"DRAIN8: drain multiple objects",
 	 drain_objects, rebuild_sub_setup, test_teardown},
 };
 

--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -192,7 +192,7 @@ extend_objects(void **state)
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
 
-	if (!test_runable(arg, 4))
+	if (!test_runable(arg, 3))
 		return;
 
 	for (i = 0; i < OBJ_NR; i++) {
@@ -210,8 +210,6 @@ extend_objects(void **state)
 	for (i = 0; i < OBJ_NR; i++) {
 		char buffer[16];
 
-		oids[i] = daos_test_oid_gen(arg->coh, DAOS_OC_TINY_RW, 0,
-					    0, arg->myrank);
 		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
 		memset(buffer, 0, 16);
 		lookup_single("dkey", "akey", 0, buffer, 16,

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -187,6 +187,7 @@ ioreq_iod_recxs_set(struct ioreq *req, int idx, daos_size_t size,
 		iod->iod_recxs = recxs;
 	} else {
 		iod->iod_nr = 1;
+		iod->iod_recxs = NULL;
 	}
 }
 

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -133,7 +133,7 @@ rebuild_retry_for_stale_pool(void **state)
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 
-	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
@@ -164,7 +164,7 @@ rebuild_drop_obj(void **state)
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 
-	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
@@ -230,7 +230,7 @@ rebuild_multiple_pools(void **state)
 	rebuild_io_verify(args[0], oids, OBJ_NR);
 	rebuild_io_verify(args[1], oids, OBJ_NR);
 
-	reintegrate_pools_ranks(args, 2, ranks_to_kill, 1);
+	reintegrate_pools_ranks(args, 2, ranks_to_kill, 1, false);
 	rebuild_io_verify(args[0], oids, OBJ_NR);
 	rebuild_io_verify(args[1], oids, OBJ_NR);
 
@@ -470,7 +470,7 @@ rebuild_iv_tgt_fail(void **state)
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 
-	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
@@ -540,7 +540,7 @@ rebuild_send_objects_fail(void **state)
 				     0, NULL);
 	par_barrier(PAR_COMM_WORLD);
 
-	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
 }
 
@@ -678,6 +678,9 @@ rebuild_offline_pool_connect_internal(void **state, unsigned int fail_loc)
 	arg->rebuild_cb = NULL;
 
 	rebuild_io_verify(arg, oids, OBJ_NR);
+
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], true);
+	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
 static void
@@ -719,6 +722,9 @@ rebuild_offline(void **state)
 	arg->rebuild_pre_cb = NULL;
 	arg->rebuild_post_cb = NULL;
 
+	rebuild_io_verify(arg, oids, OBJ_NR);
+
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], true);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
@@ -875,7 +881,7 @@ rebuild_nospace(void **state)
 	arg->rebuild_cb = NULL;
 	rebuild_io_verify(arg, oids, OBJ_NR);
 
-	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], false);
 	rebuild_io_verify(arg, oids, OBJ_NR);
 }
 
@@ -950,7 +956,6 @@ rebuild_multiple_tgts(void **state)
 	par_barrier(PAR_COMM_WORLD);
 }
 
-#if 0
 static int
 rebuild_io_cb(void *arg)
 {
@@ -974,7 +979,6 @@ rebuild_io_post_cb(void *arg)
 
 	return 0;
 }
-#endif
 
 static void
 rebuild_master_failure(void **state)
@@ -1053,7 +1057,11 @@ rebuild_master_failure(void **state)
 	print_message("svc leader changed from %d to %d, should get same "
 		      "rebuild status (memcmp result %d).\n", pinfo.pi_leader,
 		      pinfo_new.pi_leader, rc);
+
 	assert_int_equal(rc, 0);
+
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], true);
+	rebuild_io_verify(arg, oids, 10 * OBJ_NR);
 }
 
 static void
@@ -1078,21 +1086,20 @@ rebuild_multiple_failures(void **state)
 	/* prepare the data */
 	rebuild_io(arg, oids, OBJ_NR);
 
-#if 0
 	/* Remove this inflight IO temporarily XXX */
 	arg->rebuild_cb = rebuild_io_cb;
 	arg->rebuild_cb_arg = cb_arg_oids;
 	/* Disable data validation because of DAOS-2915. */
 	arg->rebuild_post_cb = rebuild_io_post_cb;
-#else
-	arg->rebuild_post_cb = NULL;
-#endif
+
 	arg->rebuild_post_cb_arg = cb_arg_oids;
 
 	rebuild_pools_ranks(&arg, 1, ranks_to_kill, MAX_KILLS, true);
 
 	arg->rebuild_cb = NULL;
 	arg->rebuild_post_cb = NULL;
+
+	reintegrate_pools_ranks(&arg, 1, ranks_to_kill, MAX_KILLS, true);
 }
 
 static void
@@ -1293,6 +1300,9 @@ rebuild_kill_rank_during_rebuild(void **state)
 	sleep(2);
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
 			 arg->pool.alive_svc, ranks_to_kill[0]);
+
+	sleep(10);
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0], true);
 }
 
 static void
@@ -1327,6 +1337,9 @@ rebuild_kill_PS_leader_during_rebuild(void **state)
 	}
 	sleep(2);
 	rebuild_single_pool_rank(arg, leader, true);
+
+	sleep(5);
+	reintegrate_single_pool_rank(arg, leader, true);
 }
 
 /** create a new pool/container for each test */

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -54,9 +54,15 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 
 static void
 rebuild_reint_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
-		int tgt_idx)
+		  int tgt_idx, bool restart)
 {
 	int i;
+
+	if (restart) {
+		daos_start_server(args[0], args[0]->pool.pool_uuid,
+				  args[0]->group, args[0]->pool.alive_svc, rank);
+		sleep(10);
+	}
 
 	for (i = 0; i < args_cnt; i++) {
 		if (!args[i]->pool.destroyed)
@@ -136,8 +142,8 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 						kill);
 				break;
 			case RB_OP_TYPE_REINT:
-				rebuild_reint_tgt(args, args_cnt, ranks[i],
-						tgts ? tgts[i] : -1);
+				rebuild_reint_tgt(args, args_cnt, ranks[i], tgts ? tgts[i] : -1,
+						  kill);
 				break;
 			case RB_OP_TYPE_ADD:
 				rebuild_extend_tgt(args, args_cnt, ranks[i],
@@ -185,9 +191,9 @@ rebuild_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill)
 }
 
 void
-reintegrate_single_pool_rank_no_disconnect(test_arg_t *arg, d_rank_t failed_rank)
+reintegrate_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool restart)
 {
-	rebuild_targets(&arg, 1, &failed_rank, NULL, 1, false, RB_OP_TYPE_REINT);
+	rebuild_targets(&arg, 1, &failed_rank, NULL, 1, restart, RB_OP_TYPE_REINT);
 }
 
 void
@@ -333,58 +339,16 @@ void
 reintegrate_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 			       int failed_tgt)
 {
-	/* XXX: Disconnecting and reconnecting is necessary for the time being
-	 * while reintegration only supports "offline" mode and without
-	 * incremental reintegration. Disconnecting from the pool allows the
-	 * containers to be deleted before reintegration occurs
-	 *
-	 * Once incremental reintegration support is added, this should be
-	 * removed
-	 */
-	rebuild_pool_disconnect_internal(arg);
 	rebuild_targets(&arg, 1, &failed_rank, &failed_tgt, 1, false,
 			RB_OP_TYPE_REINT);
-	rebuild_pool_connect_internal(arg);
-}
-
-void
-reintegrate_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank)
-{
-
-	/* XXX: Disconnecting and reconnecting is necessary for the time being
-	 * while reintegration only supports "offline" mode and without
-	 * incremental reintegration. Disconnecting from the pool allows the
-	 * containers to be deleted before reintegration occurs
-	 *
-	 * Once incremental reintegration support is added, this should be
-	 * removed
-	 */
-	rebuild_pool_disconnect_internal(arg);
-	rebuild_targets(&arg, 1, &failed_rank, NULL, 1, false,
-			RB_OP_TYPE_REINT);
-	rebuild_pool_connect_internal(arg);
 }
 
 void
 reintegrate_pools_ranks(test_arg_t **args, int args_cnt, d_rank_t *failed_ranks,
-			int ranks_nr)
+			int ranks_nr, bool restart)
 {
-	int i;
-
-	/* XXX: Disconnecting and reconnecting is necessary for the time being
-	 * while reintegration only supports "offline" mode and without
-	 * incremental reintegration. Disconnecting from the pool allows the
-	 * containers to be deleted before reintegration occurs
-	 *
-	 * Once incremental reintegration support is added, this should be
-	 * removed
-	 */
-	for (i = 0; i < args_cnt; i++)
-		rebuild_pool_disconnect_internal(args[i]);
 	rebuild_targets(args, args_cnt, failed_ranks, NULL, ranks_nr,
-			false, RB_OP_TYPE_REINT);
-	for (i = 0; i < args_cnt; i++)
-		rebuild_pool_connect_internal(args[i]);
+			restart, RB_OP_TYPE_REINT);
 }
 
 
@@ -915,6 +879,110 @@ dfs_ec_rebuild_io(void **state, int *shards, int shards_nr)
 	while (idx > 0)
 		rebuild_add_back_tgts(arg, ranks[--idx], NULL, 1);
 #endif
+}
+
+int
+reintegrate_inflight_io(void *data)
+{
+	test_arg_t	*arg = data;
+	daos_obj_id_t	oid = *(daos_obj_id_t *)arg->rebuild_cb_arg;
+	char		single_data[LARGE_SINGLE_VALUE_SIZE];
+	struct ioreq	req;
+	int		i;
+
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	for (i = 0; i < 5; i++) {
+		char	key[64];
+		daos_recx_t recx;
+		char	buf[DATA_SIZE];
+
+		req.iod_type = DAOS_IOD_SINGLE;
+		sprintf(key, "d_inflight_%d", i);
+		insert_single(key, "a_key", 0, "data", strlen("data") + 1,
+			      DAOS_TX_NONE, &req);
+
+		sprintf(key, "d_inflight_1M_%d", i);
+		recx.rx_idx = 0;
+		recx.rx_nr = DATA_SIZE;
+		memset(buf, 'a' + i, DATA_SIZE);
+		req.iod_type = DAOS_IOD_ARRAY;
+		insert_recxs(key, "a_key_1M", 1, DAOS_TX_NONE, &recx, 1,
+			     buf, DATA_SIZE, &req);
+
+		req.iod_type = DAOS_IOD_SINGLE;
+		memset(single_data, 'a' + i, LARGE_SINGLE_VALUE_SIZE);
+		sprintf(key, "d_inflight_single_small_%d", i);
+		insert_single(key, "a_key", 0, single_data,
+			      SMALL_SINGLE_VALUE_SIZE, DAOS_TX_NONE, &req);
+
+		sprintf(key, "d_inflight_single_large_%d",  i);
+		insert_single(key, "a_key", 0, single_data,
+			      LARGE_SINGLE_VALUE_SIZE, DAOS_TX_NONE, &req);
+
+	}
+	ioreq_fini(&req);
+	if (arg->myrank == 0)
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0,
+				      NULL);
+	return 0;
+}
+
+int
+reintegrate_inflight_io_verify(void *data)
+{
+	test_arg_t	*arg = data;
+	daos_obj_id_t	oid;
+	char		single_data[LARGE_SINGLE_VALUE_SIZE];
+	char		verify_single_data[LARGE_SINGLE_VALUE_SIZE];
+	char		*buf;
+	char		*verify_buf;
+	struct ioreq	req;
+	int		i;
+
+	buf = malloc(DATA_SIZE);
+	verify_buf = malloc(DATA_SIZE);
+	oid = *(daos_obj_id_t *)arg->rebuild_cb_arg;
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	for (i = 0; i < 5; i++) {
+		char	key[64];
+		daos_recx_t recx;
+
+		sprintf(key, "d_inflight_%d", i);
+		memset(buf, 0, DATA_SIZE);
+		req.iod_type = DAOS_IOD_SINGLE;
+		lookup_single(key, "a_key", 0, buf, strlen("data") + 1,
+			      DAOS_TX_NONE, &req);
+		assert_memory_equal(buf, "data", strlen("data"));
+
+		sprintf(key, "d_inflight_1M_%d", i);
+		recx.rx_idx = 0;
+		recx.rx_nr = DATA_SIZE;
+		memset(verify_buf, 'a' + i, DATA_SIZE);
+		memset(buf, 0, DATA_SIZE);
+		req.iod_type = DAOS_IOD_ARRAY;
+		lookup_recxs(key, "a_key_1M", 1, DAOS_TX_NONE, &recx, 1,
+			     buf, DATA_SIZE, &req);
+		assert_memory_equal(buf, verify_buf, DATA_SIZE);
+
+		req.iod_type = DAOS_IOD_SINGLE;
+		memset(verify_single_data, 'a' + i, LARGE_SINGLE_VALUE_SIZE);
+		memset(single_data, 0, LARGE_SINGLE_VALUE_SIZE);
+		sprintf(key, "d_inflight_single_small_%d", i);
+		lookup_single(key, "a_key", 0, single_data,
+			      SMALL_SINGLE_VALUE_SIZE, DAOS_TX_NONE, &req);
+		assert_memory_equal(single_data, verify_single_data, SMALL_SINGLE_VALUE_SIZE);
+
+		sprintf(key, "d_inflight_single_large_%d",  i);
+		memset(single_data, 0, LARGE_SINGLE_VALUE_SIZE);
+		lookup_single(key, "a_key", 0, single_data,
+			      LARGE_SINGLE_VALUE_SIZE, DAOS_TX_NONE, &req);
+		assert_memory_equal(single_data, verify_single_data, LARGE_SINGLE_VALUE_SIZE);
+
+	}
+	ioreq_fini(&req);
+	free(buf);
+	free(verify_buf);
+	return 0;
 }
 
 /* Create a new pool for the sub_test */

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -37,6 +37,9 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 	if (oclass == OC_EC_4P2G1 && !test_runable(arg, 8))
 		return;
 
+	if (svc_nreplicas < 5)
+		return;
+
 	oid = daos_test_oid_gen(arg->coh, oclass, 0, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 
@@ -52,39 +55,31 @@ rebuild_ec_internal(void **state, daos_oclass_id_t oclass, int kill_data_nr,
 	get_killing_rank_by_oid(arg, oid, kill_data_nr, kill_parity_nr,
 				kill_ranks, &kill_ranks_num);
 
-	rebuild_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num, false);
+	rebuild_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num, true);
+
+	arg->rebuild_cb = reintegrate_inflight_io;
+	arg->rebuild_cb_arg = &oid;
+	reintegrate_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num, true);
+
+	arg->rebuild_cb = NULL;
+	arg->rebuild_cb_arg = NULL;
+	ioreq_fini(&req);
 
 	/*
-	 * let's kill another 2 data node to do degrade fetch, so to
-	 * verify degrade fetch is correct.
+	 * let's kill extra data node to verify parity is correct.
 	 */
 	if (oclass == OC_EC_2P1G1) {
 		get_killing_rank_by_oid(arg, oid, 1, 0, extra_kill_ranks, NULL);
-		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, false);
+		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, true);
 	} else { /* oclass OC_EC_4P2G1 */
 		get_killing_rank_by_oid(arg, oid, 2, 0, extra_kill_ranks, NULL);
-		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2, false);
+		rebuild_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2, true);
 	}
 
-	if (write_type == PARTIAL_UPDATE)
-		verify_ec_partial(&req, arg->index, 0);
-	else if (write_type == FULL_UPDATE)
-		verify_ec_full(&req, arg->index, 0);
-	else if (write_type == FULL_PARTIAL_UPDATE)
-		verify_ec_full_partial(&req, arg->index, 0);
-	else if (write_type == PARTIAL_FULL_UPDATE)
-		verify_ec_full(&req, arg->index, 0);
-	ioreq_fini(&req);
-
-	print_message("daos_obj_verify ...\n");
-	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
-	assert_int_equal(rc, 0);
-
-	reintegrate_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num);
 	if (oclass == OC_EC_2P1G1)
-		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1);
+		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 1, true);
 	else /* oclass OC_EC_4P2G1 */
-		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2);
+		reintegrate_pools_ranks(&arg, 1, &extra_kill_ranks[0], 2, true);
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	if (write_type == PARTIAL_UPDATE)
@@ -158,7 +153,7 @@ rebuild_mixed_stripes(void **state)
 	free(verify_data);
 	ioreq_fini(&req);
 
-	reintegrate_pools_ranks(&arg, 1, &rank, 1);
+	reintegrate_pools_ranks(&arg, 1, &rank, 1, false);
 }
 
 static void
@@ -251,7 +246,7 @@ rebuild_ec_multi_stripes(void **state)
 	}
 
 	ioreq_fini(&req);
-	reintegrate_pools_ranks(&arg, 1, &rank, 1);
+	reintegrate_pools_ranks(&arg, 1, &rank, 1, false);
 }
 
 static int
@@ -875,7 +870,7 @@ rebuild_ec_parity_multi_group(void **state)
 	rank = get_rank_by_oid_shard(arg, oid, 9);
 	rebuild_single_pool_rank(arg, rank, false);
 
-	reintegrate_single_pool_rank(arg, rank);
+	reintegrate_single_pool_rank(arg, rank, false);
 	ioreq_fini(&req);
 }
 
@@ -936,7 +931,7 @@ rebuild_ec_snapshot(void **state, daos_oclass_id_t oclass, int shard)
 		assert_int_equal(rc, 0);
 	}
 
-	reintegrate_single_pool_rank(arg, rank);
+	reintegrate_single_pool_rank(arg, rank, false);
 	free(data);
 	free(verify_data);
 	ioreq_fini(&req);

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -29,66 +29,24 @@
 
 #define DATA_SIZE	(1048576 * 2 + 512)
 
-#if 0
-/* Disable inflight IO due to DAOS-8775 for 2.0, and re-enable it until inflight I/O
- * during reintegrated are supported.
- */
-static int
-reintegrate_inflight_io(void *data)
-{
-	test_arg_t	*arg = data;
-	daos_obj_id_t	oid = *(daos_obj_id_t *)arg->rebuild_cb_arg;
-	struct ioreq	req;
-	int		i;
-
-	rebuild_pool_connect_internal(arg);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-	for (i = 0; i < 5; i++) {
-		char	key[32];
-		daos_recx_t recx;
-		char	buf[DATA_SIZE];
-
-		sprintf(key, "d_inflight_%d", i);
-		insert_single(key, "a_key", 0, "data", strlen("data") + 1,
-			      DAOS_TX_NONE, &req);
-
-		sprintf(key, "d_inflight_1M_%d", i);
-		recx.rx_idx = 0;
-		recx.rx_nr = DATA_SIZE;
-		memset(buf, 'a', DATA_SIZE);
-		insert_recxs(key, "a_key_1M", 1, DAOS_TX_NONE, &recx, 1,
-			     buf, DATA_SIZE, &req);
-	}
-	ioreq_fini(&req);
-	rebuild_pool_disconnect_internal(arg);
-	if (arg->myrank == 0)
-		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0,
-				      NULL);
-	return 0;
-}
-#endif
-
 static void
 reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 			     d_rank_t rank, int tgt)
 {
 	daos_obj_id_t inflight_oid;
 
-#if 0
-	/* Disable it due to DAOS-7420 */
 	if (oid != NULL) {
 		inflight_oid = *oid;
 	} else {
-#endif
-	inflight_oid = daos_test_oid_gen(arg->coh,
+		inflight_oid = daos_test_oid_gen(arg->coh,
 					 DAOS_OC_R3S_SPEC_RANK, 0,
 					 0, arg->myrank);
-	inflight_oid = dts_oid_set_rank(inflight_oid, rank);
+		inflight_oid = dts_oid_set_rank(inflight_oid, rank);
+	}
 
-#if 0
 	arg->rebuild_cb = reintegrate_inflight_io;
 	arg->rebuild_cb_arg = &inflight_oid;
-#endif
+
 	/* To make sure the IO will be done before reintegration is done */
 	if (arg->myrank == 0)
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -97,8 +55,6 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 	arg->rebuild_cb = NULL;
 	arg->rebuild_cb_arg = NULL;
 
-#if 0
-	/* Disable it due to DAOS-7420 */
 	if (oid == NULL) {
 		int rc;
 
@@ -106,7 +62,6 @@ reintegrate_with_inflight_io(test_arg_t *arg, daos_obj_id_t *oid,
 		if (rc != 0)
 			assert_rc_equal(rc, -DER_NOSYS);
 	}
-#endif
 }
 
 static void
@@ -1226,7 +1181,7 @@ rebuild_with_dfs_open_create_punch(void **state)
 
 	rank = get_rank_by_oid_shard(arg, oid, 0);
 	rebuild_single_pool_rank(arg, rank, false);
-	reintegrate_single_pool_rank_no_disconnect(arg, rank);
+	reintegrate_single_pool_rank(arg, rank, false);
 
 	for (i = 0; i < 20; i++) {
 		sprintf(filename, "degrade_file_%d", i);

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -376,6 +376,8 @@ int run_daos_degrade_simple_ec_test(int rank, int size, int *sub_tests,
 				    int sub_tests_size);
 void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);
+void daos_start_server(test_arg_t *arg, const uuid_t pool_uuid,
+		       const char *grp, d_rank_list_t *svc, d_rank_t rank);
 struct daos_acl *get_daos_acl_with_owner_perms(uint64_t perms);
 daos_prop_t *get_daos_prop_with_owner_acl_perms(uint64_t perms,
 						uint32_t prop_type);
@@ -444,16 +446,14 @@ void dfs_ec_rebuild_io(void **state, int *shards, int shards_nr);
 void rebuild_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 				int failed_tgt, bool kill);
 void rebuild_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill);
-void reintegrate_single_pool_rank_no_disconnect(test_arg_t *arg, d_rank_t failed_rank);
+void reintegrate_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool restart);
 void rebuild_pools_ranks(test_arg_t **args, int args_cnt,
 		d_rank_t *failed_ranks, int ranks_nr, bool kill);
 
 void reintegrate_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
-		int failed_tgt);
-void reintegrate_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank);
-void reintegrate_pools_ranks(test_arg_t **args, int args_cnt,
-		d_rank_t *failed_ranks,  int ranks_nr);
-
+				    int failed_tgt);
+void reintegrate_pools_ranks(test_arg_t **args, int args_cnt, d_rank_t *failed_ranks,
+			     int ranks_nr, bool restart);
 void drain_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 				int failed_tgt, bool kill);
 void drain_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill);
@@ -509,6 +509,8 @@ void make_buffer(char *buffer, char start, int total);
 
 bool oid_is_ec(daos_obj_id_t oid, struct daos_oclass_attr **attr);
 uint32_t test_ec_get_parity_off(daos_key_t *dkey, struct daos_oclass_attr *oca);
+int reintegrate_inflight_io(void *data);
+int reintegrate_inflight_io_verify(void *data);
 
 static inline void
 daos_test_print(int rank, char *message)

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -960,6 +960,30 @@ daos_reint_server(const uuid_t pool_uuid, const char *grp,
 }
 
 void
+daos_start_server(test_arg_t *arg, const uuid_t pool_uuid,
+		  const char *grp, d_rank_list_t *svc, d_rank_t rank)
+{
+	char	dmg_cmd[DTS_CFG_MAX];
+	int	rc;
+
+	if (d_rank_in_rank_list(svc, rank))
+		svc->rl_nr++;
+
+	print_message("\tstart rank %d (svc->rl_nr %d)!\n", rank, svc->rl_nr);
+
+	/* build and invoke dmg cmd to stop the server */
+	dts_create_config(dmg_cmd, "dmg system start -r %d", rank);
+	if (arg->dmg_config != NULL)
+		dts_append_config(dmg_cmd, " -o %s", arg->dmg_config);
+
+	rc = system(dmg_cmd);
+	print_message(" %s rc %#x\n", dmg_cmd, rc);
+	assert_rc_equal(rc, 0);
+
+	daos_cont_status_clear(arg->coh, NULL);
+}
+
+void
 daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid,
 		 const char *grp, d_rank_list_t *svc, d_rank_t rank)
 {


### PR DESCRIPTION
Enable online reintegration.

Add inflight I/O for rebuild, EC rebuild and drain test.

minor fixes in extend test.

Signed-off-by: Di Wang <di.wang@intel.com>