### PR TITLE
DAOS-11175 control: Add prefix to notice logging

### DIFF
--- a/src/control/cmd/daos_server/start.go
+++ b/src/control/cmd/daos_server/start.go
@@ -45,7 +45,7 @@ func (cmd *startCmd) setCLIOverrides() error {
 		cmd.config.ControlPort = int(cmd.Port)
 	}
 	if cmd.MountPath != "" {
-		cmd.Info("NOTICE: -s, --storage is deprecated")
+		cmd.Notice("-s, --storage is deprecated")
 		if len(cmd.config.Engines) < 1 {
 			return errors.New("config has zero engines")
 		}

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -264,7 +264,7 @@ type nvmeSetFaultyCmd struct {
 // Execute is run when nvmeSetFaultyCmd activates
 // Set the SMD device state of the given device to "FAULTY"
 func (cmd *nvmeSetFaultyCmd) Execute(_ []string) error {
-	cmd.Notice("WARNING: This command will permanently mark the device as unusable!")
+	cmd.Notice("This command will permanently mark the device as unusable!")
 	if !cmd.Force {
 		if cmd.jsonOutputEnabled() {
 			return errors.New("Cannot use --json without --force")
@@ -298,7 +298,7 @@ type nvmeReplaceCmd struct {
 // Replace a hot-removed device with a newly plugged device, or reuse a FAULTY device
 func (cmd *nvmeReplaceCmd) Execute(_ []string) error {
 	if cmd.OldDevUUID == cmd.NewDevUUID {
-		cmd.Notice("WARNING: Attempting to reuse a previously set FAULTY device!")
+		cmd.Notice("Attempting to reuse a previously set FAULTY device!")
 	}
 
 	// TODO: Implement no-reint flag option

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -1272,7 +1272,7 @@ func GetMaxPoolSize(ctx context.Context, log logging.Logger, rpcClient UnaryInvo
 		for _, nvmeController := range hostStorage.NvmeDevices {
 			for _, smdDevice := range nvmeController.SmdDevices {
 				if !smdDevice.NvmeState.IsNormal() {
-					log.Noticef("WARNING: SMD device %s (instance %d, ctrlr %s) "+
+					log.Noticef("SMD device %s (instance %d, ctrlr %s) "+
 						"not usable (device state %q)",
 						smdDevice.UUID, smdDevice.Rank, smdDevice.TrAddr,
 						smdDevice.NvmeState.String())

--- a/src/control/logging/notice.go
+++ b/src/control/logging/notice.go
@@ -22,7 +22,7 @@ func NewCommandLineNoticeLogger(output io.Writer) *DefaultNoticeLogger {
 	return &DefaultNoticeLogger{
 		baseLogger{
 			dest: output,
-			log:  log.New(output, "", emptyLogFlags),
+			log:  log.New(output, "NOTICE: ", emptyLogFlags),
 		},
 	}
 }

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -473,7 +473,7 @@ func (cfg *Server) Validate(log logging.Logger, hugePageSize int) (err error) {
 	case len(cfg.AccessPoints)%2 == 0:
 		return FaultConfigEvenAccessPoints
 	case len(cfg.AccessPoints) == 1:
-		log.Noticef("WARNING: Configuration includes only one access point. This provides no redundancy " +
+		log.Noticef("Configuration includes only one access point. This provides no redundancy " +
 			"in the event of an access point failure.")
 	}
 

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -280,7 +280,7 @@ func (c *ControlService) adjustScmSize(resp *ctlpb.ScanScmResp) {
 				scmNamespace.Mount.GetPath(), humanize.Bytes(mdBytes), mdBytes)
 			scmNamespace.Mount.AvailBytes -= mdBytes
 		} else {
-			c.log.Noticef("WARNING: Adjusting available size to 0 Bytes of SCM device %q: "+
+			c.log.Noticef("Adjusting available size to 0 Bytes of SCM device %q: "+
 				"old available size %s (%d Bytes), metadata size %s (%d Bytes)",
 				scmNamespace.Mount.GetPath(),
 				humanize.Bytes(availBytes), availBytes,

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -2754,7 +2754,7 @@ func TestServer_adjustScmSize(t *testing.T) {
 			},
 			output: ExpectedOutput{
 				availableBytes: []uint64{0},
-				message:        "WARNING: Adjusting available size to 0 Bytes of SCM device",
+				message:        "Adjusting available size to 0 Bytes of SCM device",
 			},
 		},
 	} {


### PR DESCRIPTION
- Added a prefix to notice messages on the command line output.
- Removed "WARNING" prefix from messages that are now notice level.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>