### PR TITLE
DAOS-11227 client: allow tse_task_add_dependent for different scheduler

### DIFF
--- a/src/common/tests/sched.c
+++ b/src/common/tests/sched.c
@@ -1220,6 +1220,133 @@ out:
 	return rc;
 }
 
+static int
+test_10_task_body(tse_task_t *task)
+{
+	tse_task_complete(task, 0);
+	return 0;
+}
+
+static int
+sched_test_10()
+{
+	pthread_t	th_1, th_2;
+	tse_sched_t	sched_1, sched_2;
+	tse_task_t	**tasks = NULL;
+	bool		flag;
+	int		ntask = 100;
+	int		i, rc;
+
+	TSE_TEST_ENTRY("10", "cross scheduler task dependency test");
+
+	D_ALLOC_ARRAY(tasks, ntask * 2);
+	if (tasks == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	stop_progress = 0;
+	print_message("Init Scheduler\n");
+	rc = tse_sched_init(&sched_1, NULL, 0);
+	if (rc != 0) {
+		print_error("Failed to init scheduler: %d\n", rc);
+		D_GOTO(out, rc);
+	}
+	rc = tse_sched_init(&sched_2, NULL, 0);
+	if (rc != 0) {
+		print_error("Failed to init scheduler: %d\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	print_message("Creating progress thread..\n");
+
+	rc = pthread_create(&th_1, NULL, th_sched_progress, &sched_1);
+	if (rc != 0) {
+		print_error("Failed to create pthread: %d\n", rc);
+		D_GOTO(out, rc);
+	}
+	rc = pthread_create(&th_2, NULL, th_sched_progress, &sched_2);
+	if (rc != 0) {
+		print_error("Failed to create pthread: %d\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	for (i = 0; i < ntask * 2; i++) {
+		if (i < ntask)
+			rc = tse_task_create(test_10_task_body, &sched_1, NULL, &tasks[i]);
+		else
+			rc = tse_task_create(test_10_task_body, &sched_2, NULL, &tasks[i]);
+		if (rc != 0) {
+			print_error("Failed to create task: %d\n", rc);
+			D_GOTO(out, rc);
+		}
+	}
+
+	for (i = 0; i < ntask; i++) {
+		rc = tse_task_register_deps(tasks[i], 1, &tasks[i + ntask]);
+		if (rc != 0) {
+			print_error("Failed to register task Deps: %d\n", rc);
+			D_GOTO(out, rc);
+		}
+	}
+
+	for (i = 0; i < ntask * 2; i++) {
+		rc = tse_task_schedule(tasks[i], false);
+		if (rc != 0) {
+			print_error("Failed to schedule task: %d\n", rc);
+			D_GOTO(out, rc);
+		}
+	}
+
+	do {
+		flag = tse_sched_check_complete(&sched_2);
+		if (flag)
+			printf("sched not empty, sleeping\n");
+		sleep(1);
+	} while (!flag);
+	do {
+		flag = tse_sched_check_complete(&sched_1);
+		if (flag)
+			printf("sched not empty, sleeping\n");
+		sleep(1);
+	} while (!flag);
+
+	stop_progress = true;
+	rc = pthread_join(th_1, NULL);
+	if (rc != 0) {
+		print_error("Failed pthread_join: %d\n", rc);
+		D_GOTO(out, rc);
+	}
+	rc = pthread_join(th_2, NULL);
+	if (rc != 0) {
+		print_error("Failed pthread_join: %d\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	print_message("COMPLETE Scheduler\n");
+	tse_sched_addref(&sched_1);
+	tse_sched_complete(&sched_1, 0, false);
+	tse_sched_addref(&sched_2);
+	tse_sched_complete(&sched_2, 0, false);
+
+	print_message("Check scheduler is empty\n");
+	flag = tse_sched_check_complete(&sched_1);
+	tse_sched_decref(&sched_1);
+	if (!flag) {
+		print_error("Scheduler should not have in-flight tasks\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+	flag = tse_sched_check_complete(&sched_2);
+	tse_sched_decref(&sched_2);
+	if (!flag) {
+		print_error("Scheduler should not have in-flight tasks\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+out:
+	D_FREE(tasks);
+	TSE_TEST_EXIT(rc);
+	return rc;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -1281,6 +1408,12 @@ main(int argc, char **argv)
 	rc = sched_test_9();
 	if (rc != 0) {
 		print_error("SCHED TEST 9 failed: %d\n", rc);
+		test_fail++;
+	}
+
+	rc = sched_test_10();
+	if (rc != 0) {
+		print_error("SCHED TEST 10 failed: %d\n", rc);
 		test_fail++;
 	}
 

--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -627,9 +627,11 @@ tse_task_post_process(tse_task_t *task)
 	/* Check dependent list */
 	D_MUTEX_LOCK(&dsp->dsp_lock);
 	while (!d_list_empty(&dtp->dtp_dep_list)) {
-		struct tse_task_link	*tlink;
-		tse_task_t		*task_tmp;
-		struct tse_task_private	*dtp_tmp;
+		struct tse_task_link		*tlink;
+		tse_task_t			*task_tmp;
+		struct tse_task_private		*dtp_tmp;
+		struct tse_sched_private	*dsp_tmp;
+		bool				 diff_sched;
 
 		tlink = d_list_entry(dtp->dtp_dep_list.next,
 				     struct tse_task_link, tl_link);
@@ -642,12 +644,19 @@ tse_task_post_process(tse_task_t *task)
 		if (task_tmp->dt_result == 0 && !dtp_tmp->dtp_no_propagate)
 			task_tmp->dt_result = task->dt_result;
 
+		dsp_tmp = dtp_tmp->dtp_sched;
+		diff_sched = dsp != dsp_tmp;
+
+		if (diff_sched) {
+			D_MUTEX_UNLOCK(&dsp->dsp_lock);
+			D_MUTEX_LOCK(&dsp_tmp->dsp_lock);
+		}
 		/* see if the dependent task is ready to be scheduled */
 		D_ASSERT(dtp_tmp->dtp_dep_cnt > 0);
 		dtp_tmp->dtp_dep_cnt--;
 		D_DEBUG(DB_TRACE, "daos task %p dep_cnt %d\n", dtp_tmp,
 			dtp_tmp->dtp_dep_cnt);
-		if (!dsp->dsp_cancelling && dtp_tmp->dtp_dep_cnt == 0 &&
+		if (!dsp_tmp->dsp_cancelling && dtp_tmp->dtp_dep_cnt == 0 &&
 		    dtp_tmp->dtp_running) {
 			bool done;
 
@@ -661,9 +670,9 @@ tse_task_post_process(tse_task_t *task)
 			 * block.
 			 */
 			/** release lock for CB */
-			D_MUTEX_UNLOCK(&dsp->dsp_lock);
+			D_MUTEX_UNLOCK(&dsp_tmp->dsp_lock);
 			done = tse_task_complete_callback(task_tmp);
-			D_MUTEX_LOCK(&dsp->dsp_lock);
+			D_MUTEX_LOCK(&dsp_tmp->dsp_lock);
 
 			/*
 			 * task reinserted itself in scheduler by
@@ -675,11 +684,15 @@ tse_task_post_process(tse_task_t *task)
 				continue;
 			}
 
-			tse_task_complete_locked(dtp_tmp, dsp);
+			tse_task_complete_locked(dtp_tmp, dsp_tmp);
 		}
 
 		/* -1 for tlink (addref by add_dependent) */
 		tse_task_decref_free_locked(task_tmp);
+		if (diff_sched) {
+			D_MUTEX_UNLOCK(&dsp_tmp->dsp_lock);
+			D_MUTEX_LOCK(&dsp->dsp_lock);
+		}
 	}
 
 	D_ASSERT(dsp->dsp_inflight > 0);
@@ -878,16 +891,12 @@ tse_task_complete(tse_task_t *task, int ret)
 static int
 tse_task_add_dependent(tse_task_t *task, tse_task_t *dep)
 {
-	struct tse_task_private  *dtp = tse_task2priv(task);
-	struct tse_task_private  *dep_dtp = tse_task2priv(dep);
-	struct tse_task_link	  *tlink;
+	struct tse_task_private	*dtp = tse_task2priv(task);
+	struct tse_task_private	*dep_dtp = tse_task2priv(dep);
+	struct tse_task_link	*tlink;
+	bool			 diff_sched;
 
 	D_ASSERT(task != dep);
-
-	if (dtp->dtp_sched != dep_dtp->dtp_sched) {
-		D_ERROR("Two tasks should belong to the same scheduler.\n");
-		return -DER_NO_PERM;
-	}
 
 	if (dtp->dtp_completed) {
 		D_ERROR("Can't add a dependency for a completed task (%p)\n",
@@ -899,6 +908,8 @@ tse_task_add_dependent(tse_task_t *task, tse_task_t *dep)
 	if (dep_dtp->dtp_completed)
 		return 0;
 
+	diff_sched = dtp->dtp_sched != dep_dtp->dtp_sched;
+
 	D_ALLOC_PTR(tlink);
 	if (tlink == NULL)
 		return -DER_NOMEM;
@@ -906,15 +917,19 @@ tse_task_add_dependent(tse_task_t *task, tse_task_t *dep)
 	D_DEBUG(DB_TRACE, "Add dependent %p ---> %p\n", dep, task);
 
 	D_MUTEX_LOCK(&dtp->dtp_sched->dsp_lock);
-
 	tse_task_addref_locked(dtp);
 	tlink->tl_task = task;
-
-	d_list_add_tail(&tlink->tl_link, &dep_dtp->dtp_dep_list);
 	dtp->dtp_dep_cnt++;
 	dtp_generation_inc(dtp);
-
+	if (!diff_sched)
+		d_list_add_tail(&tlink->tl_link, &dep_dtp->dtp_dep_list);
 	D_MUTEX_UNLOCK(&dtp->dtp_sched->dsp_lock);
+
+	if (diff_sched) {
+		D_MUTEX_LOCK(&dep_dtp->dtp_sched->dsp_lock);
+		d_list_add_tail(&tlink->tl_link, &dep_dtp->dtp_dep_list);
+		D_MUTEX_UNLOCK(&dep_dtp->dtp_sched->dsp_lock);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Allow tse_task_add_dependent() if task/dep_task belong to different
scheduler. To support two use cases -
1) map_refresh(), different IO tasks (may with different scheduler)
   caused pool map refresh, new map_refresh task may depend on
   inflight dp_map_task on different scheduler
2) dc_tx_get_epoch(), if TX's IO tasks created on different scheduler.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>