### PR TITLE
DAOS-623 build: Remove indirect link for isal

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -276,7 +276,7 @@ def define_components(reqs):
     define_ompi(reqs)
 
     reqs.define('isal',
-                retriever=GitRepoRetriever('https://github.com/01org/isa-l.git'),
+                retriever=GitRepoRetriever('https://github.com/intel/isa-l.git'),
                 commands=[['./autogen.sh'],
                           ['./configure', '--prefix=$ISAL_PREFIX', '--libdir=$ISAL_PREFIX/lib'],
                           ['make'],


### PR DESCRIPTION
The url resolves from 01org to intel and may be causing some
issues in CI.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>