### PR TITLE
DAOS-10916 object: some refine related with EC obj aggregation

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_disabled.py
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.py
@@ -37,7 +37,7 @@ class EcodDisabledRebuild(ErasureCodeIor):
         self.ior_write_dataset()
 
         # Verify if Aggregation is getting started
-        if not any(check_aggregation_status(self.pool).values()):
+        if not any(check_aggregation_status(self.pool, attempt=60).values()):
             self.fail("Aggregation failed to start..")
 
         # Kill the last server rank and wait for 20 seconds, Rebuild is disabled

--- a/src/tests/ftest/erasurecode/rebuild_disabled.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.yaml
@@ -62,7 +62,7 @@ ior:
   chunk_block_transfer_sizes:
    # [ChunkSize, BlocksSize, TransferSize]
    - [32M, 128M, 8M]       # Full Striped
-   - [32M, 128M, 2K]       # Partial Striped
+   - [32M, 32M, 4K]       # Partial Striped
   objectclass:
    dfs_oclass_list:
     #- [EC_Object_Class, Minimum number of servers]

--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeFio, check_aggregation_status
-from apricot import skipForTicket
 
 class EcodFioRebuild(ErasureCodeFio):
     # pylint: disable=too-many-ancestors
@@ -65,7 +64,6 @@ class EcodFioRebuild(ErasureCodeFio):
             # Read and verify the original data.
             self.fio_cmd.run()
 
-    @skipForTicket("DAOS-8870")
     def test_ec_online_rebuild_fio(self):
         """Jira ID: DAOS-7320.
 
@@ -88,7 +86,6 @@ class EcodFioRebuild(ErasureCodeFio):
         """
         self.execution('on-line')
 
-    @skipForTicket("DAOS-8640")
     def test_ec_offline_rebuild_fio(self):
         """Jira ID: DAOS-7320.
 

--- a/src/tests/ftest/erasurecode/rebuild_fio.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_fio.yaml
@@ -66,7 +66,7 @@ fio:
     verify_pattern: '0xabcdabcd'
     do_verify: 1
     iodepth: 10
-    size: 133MB
+    size: 33MB
     read_write: !mux
       write_read:
         rw: 'write'

--- a/src/tests/ftest/util/ec_utils.py
+++ b/src/tests/ftest/util/ec_utils.py
@@ -61,6 +61,8 @@ def check_aggregation_status(pool, quick_check=True, attempt=20):
                 # Return immediately once aggregation starts for quick check
                 if quick_check:
                     return agg_status
+            else:
+                initial_usage[storage_type] = current_usage[storage_type]
         time.sleep(5)
     return agg_status
 

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -880,9 +880,9 @@ class TestPool(TestDaosApiBase):
         """
         daos_space = self.get_pool_daos_space()
         pool_percent = {'scm': round(float(daos_space["s_free"][0]) /
-                                     float(daos_space["s_total"][0]) * 100, 2),
+                                     float(daos_space["s_total"][0]) * 100, 4),
                         'nvme': round(float(daos_space["s_free"][1]) /
-                                      float(daos_space["s_total"][1]) * 100, 2)}
+                                      float(daos_space["s_total"][1]) * 100, 4)}
         return pool_percent
 
     def get_pool_rebuild_status(self):

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2568,6 +2568,14 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 				if (rc < 0)
 					D_GOTO(out, rc);
 
+				if (range_overlap == RT_OVERLAP_INCLUDED &&
+				    rect->rc_minor_epc == EVT_MINOR_EPC_MAX) {
+					D_ERROR("Ignore RT_OVERLAP_INCLUDED array remove "
+						DF_RECT" and "DF_RECT"\n", DP_RECT(rect),
+						DP_RECT(&rtmp));
+					rc = 0;
+					goto out;
+				}
 				/* NB: This is temporary to allow full overwrite
 				 * in same epoch to avoid breaking rebuild.
 				 * Without some sequence number and client


### PR DESCRIPTION
1. For array remove, the RT_OVERLAP_INCLUDED range @same_epoch should be
   safe to ignore to avoid failure in that case.
2. a few refine for test script

Test-tag: pr ec_online_rebuild_fio ec_offline_rebuild_fio ec_disabled_rebuild_array

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>