### PR TITLE
DAOS-11180 dtx: trigger DTX reindex before DTX resync

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1460,37 +1460,28 @@ dtx_reindex_ult(void *arg)
 	struct ds_cont_child		*cont	= arg;
 	struct dss_module_info		*dmi	= dss_get_module_info();
 	uint64_t			 hint	= 0;
-	int				 rc;
+	int				 rc	= 0;
 
-	D_DEBUG(DB_ANY, DF_CONT": starting DTX reindex ULT on xstream %d\n",
-		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+	D_INFO(DF_CONT": starting DTX reindex ULT on xstream %d, ver %u\n",
+	       DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id, dtx_cont2ver(cont));
 
 	while (!cont->sc_dtx_reindex_abort && !dss_xstream_exiting(dmi->dmi_xstream)) {
 		rc = vos_dtx_cmt_reindex(cont->sc_hdl, &hint);
-		if (rc < 0) {
-			D_ERROR(DF_UUID": DTX reindex failed: "DF_RC"\n",
-				DP_UUID(cont->sc_uuid), DP_RC(rc));
-			goto out;
-		}
-
-		if (rc > 0) {
-			D_DEBUG(DB_ANY, DF_CONT": DTX reindex done\n",
-				DP_CONT(NULL, cont->sc_uuid));
-			goto out;
-		}
+		if (rc != 0)
+			break;
 
 		ABT_thread_yield();
 	}
 
-	D_DEBUG(DB_ANY, DF_CONT": stopping DTX reindex ULT on stream %d\n",
-		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+	D_CDEBUG(rc < 0, DLOG_ERR, DLOG_INFO,
+		 DF_CONT": stopping DTX reindex ULT on stream %d, ver %u: rc = %d\n",
+		 DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id, dtx_cont2ver(cont), rc);
 
-out:
 	cont->sc_dtx_reindex = 0;
 	ds_cont_child_put(cont);
 }
 
-static int
+int
 start_dtx_reindex_ult(struct ds_cont_child *cont)
 {
 	int rc;
@@ -1513,10 +1504,14 @@ start_dtx_reindex_ult(struct ds_cont_child *cont)
 	return rc;
 }
 
-static void
+void
 stop_dtx_reindex_ult(struct ds_cont_child *cont)
 {
 	if (!cont->sc_dtx_reindex || dtx_cont_opened(cont))
+		return;
+
+	/* Do not stop DTX reindex if DTX resync is still in-progress. */
+	if (cont->sc_dtx_resyncing)
 		return;
 
 	cont->sc_dtx_reindex_abort = 1;

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -162,6 +162,12 @@ dtx_cont_opened(struct ds_cont_child *cont)
 	return cont->sc_open > 0;
 }
 
+static inline uint32_t
+dtx_cont2ver(struct ds_cont_child *cont)
+{
+	return cont->sc_pool->spc_pool->sp_map_version;
+}
+
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;
 extern btr_ops_t dtx_btr_cos_ops;
@@ -170,6 +176,8 @@ extern btr_ops_t dtx_btr_cos_ops;
 int dtx_handle_reinit(struct dtx_handle *dth);
 void dtx_batched_commit(void *arg);
 void dtx_aggregation_main(void *arg);
+int start_dtx_reindex_ult(struct ds_cont_child *cont);
+void stop_dtx_reindex_ult(struct ds_cont_child *cont);
 
 /* dtx_cos.c */
 int dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -504,29 +504,7 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	if (ent->ie_dtx_flags & DTE_ORPHAN)
 		return 0;
 
-	if (dra->resync_all) {
-		/* For open container. */
-		if (ent->ie_dtx_flags & DTE_LEADER) {
-			/* Leader: handle the DTX that happened before current DTX resync. */
-			if (ent->ie_epoch < dra->epoch)
-				return 0;
-		} else {
-			/* Non-leader: handle the DTX with old version. */
-			if (ent->ie_dtx_ver >= dra->resync_version)
-				return 0;
-		}
-	} else {
-		/* For pool map refresh. */
-		/* Leader: do nothing. */
-		if (ent->ie_dtx_flags & DTE_LEADER)
-			return 0;
-
-		/* Non-leader: handle the DTX with old version. */
-		if (ent->ie_dtx_ver >= dra->resync_version)
-			return 0;
-	}
-
-	/* The entry to be discarded. */
+	/* The entry to be discarded, in spite of it is the (old) leader or not. */
 	if (ent->ie_dtx_ver < dra->discard_version) {
 		D_ALLOC_PTR(dre);
 		if (dre == NULL)
@@ -536,13 +514,30 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 		goto out;
 	}
 
-	/* For discard case, skip new added entry. */
+	/* Current DTX resync is only for discarding old DTX entries. */
 	if (dra->resync_version == dra->discard_version)
 		return 0;
 
-	/* For non-discard case, skip unprepared entry. */
+	/* Skip unprepared entry which version is at least not older than discard version. */
 	if (ent->ie_dtx_tgt_cnt == 0)
 		return 0;
+
+	if (ent->ie_dtx_flags & DTE_LEADER) {
+		/* Pool map refresh, non-discard case, I am still the leader, do nothing. */
+		if (!dra->resync_all)
+			return 0;
+
+		/*
+		 * Open container, old committable DTX entries are not in the CoS cache.
+		 * Then handle the DTX entries with old epoch (dtx_epoch < resync_epoch).
+		 */
+		if (ent->ie_epoch > dra->epoch)
+			return 0;
+	} else {
+		/* Leader switch only can happen for old DTX entries (dtx_ver < resync_ver). */
+		if (ent->ie_dtx_ver >= dra->resync_version)
+			return 0;
+	}
 
 	D_ASSERT(ent->ie_dtx_mbs_dsize > 0);
 
@@ -656,6 +651,19 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	D_INIT_LIST_HEAD(&dra.tables.drh_list);
 	dra.tables.drh_count = 0;
 
+	/*
+	 * Trigger DTX reindex. That will avoid DTX_CHECK from others being blocked.
+	 * It is harmless even if (committed) DTX entries have already been re-indexed.
+	 */
+	if (!dtx_cont_opened(cont)) {
+		rc = start_dtx_reindex_ult(cont);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": Failed to trigger DTX reindex, ver %u/%u: "DF_RC"\n",
+				DP_UUID(cont->sc_uuid), dra.discard_version, ver, DP_RC(rc));
+			goto fail;
+		}
+	}
+
 	D_INFO("Start DTX resync scan for "DF_UUID"/"DF_UUID" with version %u\n",
 	       DP_UUID(po_uuid), DP_UUID(co_uuid), ver);
 
@@ -674,12 +682,16 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	D_INFO("Stop DTX resync scan for "DF_UUID"/"DF_UUID" with version %u: rc = %d\n",
 	       DP_UUID(po_uuid), DP_UUID(co_uuid), ver, rc);
 
+fail:
 	ABT_mutex_lock(cont->sc_mutex);
 	cont->sc_dtx_resyncing = 0;
 	ABT_cond_broadcast(cont->sc_dtx_resync_cond);
 	ABT_mutex_unlock(cont->sc_mutex);
 
 out:
+	if (!dtx_cont_opened(cont))
+		stop_dtx_reindex_ult(cont);
+
 	ds_cont_child_put(cont);
 	return rc > 0 ? 0 : rc;
 }

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -219,14 +219,19 @@ dtx_handler(crt_rpc_t *rpc)
 
 		rc = vos_dtx_check(cont->sc_hdl, din->di_dtx_array.ca_arrays,
 				   NULL, NULL, NULL, NULL, false);
-		if (rc == -DER_NONEXIST && cont->sc_dtx_reindex)
-			rc = -DER_INPROGRESS;
-		else if (rc == DTX_ST_INITED)
+		if (rc == DTX_ST_INITED) {
 			/* For DTX_CHECK, non-ready one is equal to non-exist. Do not directly
 			 * return 'DTX_ST_INITED' to avoid interoperability trouble if related
 			 * request is from old server.
 			 */
 			rc = -DER_NONEXIST;
+		} else if (rc == -DER_INPROGRESS && !dtx_cont_opened(cont)) {
+			/* Trigger DTX re-index for subsequent (retry) DTX_CHECK. */
+			rc1 = start_dtx_reindex_ult(cont);
+			if (rc1 != 0)
+				D_ERROR(DF_UUID": Failed to trigger DTX reindex: "DF_RC"\n",
+					DP_UUID(cont->sc_uuid), DP_RC(rc));
+		}
 
 		break;
 	case DTX_REFRESH:


### PR DESCRIPTION
master-commit: 8daa893750b6ca5d4a34c8ff080471a565f0d5f6

During DTX resync, the new DTX leader will send DTX_CHECK RPC
to other alive DTX participant(s) to query related DTX status.
If related DTX entry does not exist on the non-leader and DTX
reindex on such non-leader is not completed yet, then the non
leader will reply to the new leader with -DER_INPROGRESS that
will cause the new leader to retry the DTX_CHECK RPC sometime
later. But if DTX reindex is not triggerred on the non-leader,
then the new leader will retry for ever. So the patch triggers
DTX reindex before DTX resync scanning.

The patch also adjusts the logic of filter DTX entries when
DTX resync to avoid skipping some DTX entries.

It also contains the fixes from PR#9938:

If the DTX_CHECK RPC handler hits -DER_INPROGRESS failure on some
target, then it means that the committed DTX entries on such target
are not re-indexed. Under such case, we need to trigger DTX re-index
on the target for subsequent (retry) DTX_CHECK RPC. Otherwise, it may
cause more DTX_CHECK RPCs to be retried (for ever), as to related DTX
resync cannot complete on some DTX leaders.

Signed-off-by: Fan Yong <fan.yong@intel.com>