### PR TITLE
DAOS-11218 control: Make some dmg pool commands synchronous

### DIFF
--- a/src/control/cmd/dmg/json_test.go
+++ b/src/control/cmd/dmg/json_test.go
@@ -99,9 +99,9 @@ func TestDmg_JsonOutput(t *testing.T) {
 			case "pool get-prop":
 				testArgs = append(testArgs, test.MockUUID(), "label")
 			case "pool extend":
-				testArgs = append(testArgs, test.MockUUID(), "--ranks", "0")
+				testArgs = append(testArgs, test.MockUUID(), "--ranks", "0", "--async")
 			case "pool exclude", "pool drain", "pool reintegrate":
-				testArgs = append(testArgs, test.MockUUID(), "--rank", "0")
+				testArgs = append(testArgs, test.MockUUID(), "--rank", "0", "--async")
 			case "pool query-targets":
 				testArgs = append(testArgs, test.MockUUID(), "--rank", "0", "--target-idx", "1,3,5,7")
 			case "container set-owner":

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2022 Intel Corporation.
+// (C) Copyright 2018-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -133,6 +133,10 @@ type cmdLogger interface {
 type baseCmd struct {
 	cmdutil.NoArgsCmd
 	cmdutil.LogCmd
+}
+
+type asyncCmd struct {
+	Async bool `short:"a" long:"async" description:"Run command asynchronously (do not wait for completion)"`
 }
 
 // cmdConfigSetter is an interface for setting the control config on a command

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -444,6 +444,7 @@ func (cmd *PoolDestroyCmd) Execute(args []string) error {
 // PoolEvictCmd is the struct representing the command to evict a DAOS pool.
 type PoolEvictCmd struct {
 	poolCmd
+	asyncCmd
 }
 
 // Execute is run when PoolEvictCmd subcommand is activated
@@ -451,6 +452,7 @@ func (cmd *PoolEvictCmd) Execute(args []string) error {
 	msg := "succeeded"
 
 	req := &control.PoolEvictReq{ID: cmd.PoolID().String()}
+	req.Async = cmd.Async
 
 	err := control.PoolEvict(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
@@ -465,6 +467,7 @@ func (cmd *PoolEvictCmd) Execute(args []string) error {
 // PoolExcludeCmd is the struct representing the command to exclude a DAOS target.
 type PoolExcludeCmd struct {
 	poolCmd
+	asyncCmd
 	Rank      uint32 `long:"rank" required:"1" description:"Engine rank of the targets to be excluded"`
 	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be excluded from the rank"`
 }
@@ -479,6 +482,7 @@ func (cmd *PoolExcludeCmd) Execute(args []string) error {
 	}
 
 	req := &control.PoolExcludeReq{ID: cmd.PoolID().String(), Rank: ranklist.Rank(cmd.Rank), Targetidx: idxlist}
+	req.Async = cmd.Async
 
 	err := control.PoolExclude(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
@@ -493,6 +497,7 @@ func (cmd *PoolExcludeCmd) Execute(args []string) error {
 // PoolDrainCmd is the struct representing the command to Drain a DAOS target.
 type PoolDrainCmd struct {
 	poolCmd
+	asyncCmd
 	Rank      uint32 `long:"rank" required:"1" description:"Engine rank of the targets to be drained"`
 	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be drained on the rank"`
 }
@@ -508,6 +513,7 @@ func (cmd *PoolDrainCmd) Execute(args []string) error {
 	}
 
 	req := &control.PoolDrainReq{ID: cmd.PoolID().String(), Rank: ranklist.Rank(cmd.Rank), Targetidx: idxlist}
+	req.Async = cmd.Async
 
 	err := control.PoolDrain(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
@@ -522,6 +528,7 @@ func (cmd *PoolDrainCmd) Execute(args []string) error {
 // PoolExtendCmd is the struct representing the command to Extend a DAOS pool.
 type PoolExtendCmd struct {
 	poolCmd
+	asyncCmd
 	RankList ui.RankSetFlag `long:"ranks" required:"1" description:"Comma-separated list of ranks to add to the pool"`
 }
 
@@ -532,6 +539,7 @@ func (cmd *PoolExtendCmd) Execute(args []string) error {
 	req := &control.PoolExtendReq{
 		ID: cmd.PoolID().String(), Ranks: cmd.RankList.Ranks(),
 	}
+	req.Async = cmd.Async
 
 	err := control.PoolExtend(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
@@ -546,6 +554,7 @@ func (cmd *PoolExtendCmd) Execute(args []string) error {
 // PoolReintegrateCmd is the struct representing the command to Add a DAOS target.
 type PoolReintegrateCmd struct {
 	poolCmd
+	asyncCmd
 	Rank      uint32 `long:"rank" required:"1" description:"Engine rank of the targets to be reintegrated"`
 	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be reintegrated into the rank"`
 }
@@ -561,6 +570,7 @@ func (cmd *PoolReintegrateCmd) Execute(args []string) error {
 	}
 
 	req := &control.PoolReintegrateReq{ID: cmd.PoolID().String(), Rank: ranklist.Rank(cmd.Rank), Targetidx: idxlist}
+	req.Async = cmd.Async
 
 	err := control.PoolReintegrate(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -397,7 +397,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Exclude a target with single target idx",
-			"pool exclude 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1",
+			"pool exclude 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1 --async",
 			strings.Join([]string{
 				printRequest(t, &control.PoolExcludeReq{
 					ID:        "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -409,7 +409,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Exclude a target with multiple idx",
-			"pool exclude 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1,2,3",
+			"pool exclude 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1,2,3 --async",
 			strings.Join([]string{
 				printRequest(t, &control.PoolExcludeReq{
 					ID:        "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -421,7 +421,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Exclude a target with no idx given",
-			"pool exclude 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0",
+			"pool exclude 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --async",
 			strings.Join([]string{
 				printRequest(t, &control.PoolExcludeReq{
 					ID:        "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -433,7 +433,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Drain a target with single target idx",
-			"pool drain 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1",
+			"pool drain 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1 --async",
 			strings.Join([]string{
 				printRequest(t, &control.PoolDrainReq{
 					ID:        "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -445,7 +445,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Drain a target with multiple idx",
-			"pool drain 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1,2,3",
+			"pool drain 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1,2,3 --async",
 			strings.Join([]string{
 				printRequest(t, &control.PoolDrainReq{
 					ID:        "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -457,7 +457,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Drain a target with no idx given",
-			"pool drain 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0",
+			"pool drain 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --async",
 			strings.Join([]string{
 				printRequest(t, &control.PoolDrainReq{
 					ID:        "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -476,7 +476,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Extend a pool with a single rank",
-			fmt.Sprintf("pool extend 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --ranks=1"),
+			fmt.Sprintf("pool extend 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --ranks=1 --async"),
 			strings.Join([]string{
 				printRequest(t, &control.PoolExtendReq{
 					ID:    "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -487,7 +487,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Extend a pool with multiple ranks",
-			fmt.Sprintf("pool extend 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --ranks=1,2,3"),
+			fmt.Sprintf("pool extend 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --ranks=1,2,3 --async"),
 			strings.Join([]string{
 				printRequest(t, &control.PoolExtendReq{
 					ID:    "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -498,7 +498,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Reintegrate a target with single target idx",
-			"pool reintegrate 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1",
+			"pool reintegrate 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1 --async",
 			strings.Join([]string{
 				printRequest(t, &control.PoolReintegrateReq{
 					ID:        "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -510,7 +510,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Reintegrate a target with multiple idx",
-			"pool reintegrate 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1,2,3",
+			"pool reintegrate 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1,2,3 --async",
 			strings.Join([]string{
 				printRequest(t, &control.PoolReintegrateReq{
 					ID:        "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
@@ -522,7 +522,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Reintegrate a target with no idx given",
-			"pool reintegrate 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0",
+			"pool reintegrate 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --async",
 			strings.Join([]string{
 				printRequest(t, &control.PoolReintegrateReq{
 					ID:        "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -41,6 +41,9 @@ const (
 	PoolCreateTimeout = 10 * time.Minute // be generous for large pools
 	// DefaultPoolTimeout is the default timeout for a pool request.
 	DefaultPoolTimeout = daos.DefaultCartTimeout * 3
+	// poolQueryRetryInterval is the amount of time to wait between
+	// retries when querying for pool information.
+	poolQueryRetryInterval = 1 * time.Second
 )
 
 // checkUUID is a helper function for validating that the supplied
@@ -854,6 +857,38 @@ func PoolGetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetPropRe
 	return resp, nil
 }
 
+func waitForPoolState(ctx context.Context, rpcClient UnaryInvoker, poolID string, chkFn func(*PoolQueryResp) (bool, error)) error {
+	startedAt := time.Now()
+	for {
+		pqr, err := PoolQuery(ctx, rpcClient, &PoolQueryReq{ID: poolID})
+		if err != nil {
+			return errors.Wrap(err, "pool query in waitForPoolState() failed")
+		}
+		ok, err := chkFn(pqr)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			rpcClient.Debug("Pool not yet in expected state, waiting...")
+			time.Sleep(poolQueryRetryInterval)
+			continue
+		}
+		rpcClient.Debugf("Pool is in expected state, took %s\n", time.Since(startedAt))
+		break
+	}
+
+	return nil
+}
+
+func waitForRebuildComplete(ctx context.Context, rpcClient UnaryInvoker, poolID string) error {
+	return waitForPoolState(ctx, rpcClient, poolID, func(pqr *PoolQueryResp) (bool, error) {
+		if pqr.Rebuild == nil {
+			return false, errors.New("pool rebuild not set")
+		}
+		return pqr.Rebuild.State == PoolRebuildStateDone, nil
+	})
+}
+
 // PoolExcludeReq struct contains request
 type PoolExcludeReq struct {
 	poolRequest
@@ -882,6 +917,10 @@ func PoolExclude(ctx context.Context, rpcClient UnaryInvoker, req *PoolExcludeRe
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
+	}
+
+	if ur.getMSError() == nil && !req.isAsync() {
+		return waitForRebuildComplete(ctx, rpcClient, req.ID)
 	}
 
 	return errors.Wrap(ur.getMSError(), "pool exclude failed")
@@ -915,6 +954,10 @@ func PoolDrain(ctx context.Context, rpcClient UnaryInvoker, req *PoolDrainReq) e
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
+	}
+
+	if ur.getMSError() == nil && !req.isAsync() {
+		return waitForRebuildComplete(ctx, rpcClient, req.ID)
 	}
 
 	return errors.Wrap(ur.getMSError(), "pool drain failed")
@@ -956,6 +999,10 @@ func PoolExtend(ctx context.Context, rpcClient UnaryInvoker, req *PoolExtendReq)
 		return err
 	}
 
+	if ur.getMSError() == nil && !req.isAsync() {
+		return waitForRebuildComplete(ctx, rpcClient, req.ID)
+	}
+
 	return errors.Wrap(ur.getMSError(), "pool extend failed")
 }
 
@@ -988,6 +1035,10 @@ func PoolReintegrate(ctx context.Context, rpcClient UnaryInvoker, req *PoolReint
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
+	}
+
+	if ur.getMSError() == nil && !req.isAsync() {
+		return waitForRebuildComplete(ctx, rpcClient, req.ID)
 	}
 
 	return errors.Wrap(ur.getMSError(), "pool reintegrate failed")

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -266,9 +266,18 @@ func TestControl_PoolDrain(t *testing.T) {
 				Targetidx: []uint32{1, 2, 3},
 			},
 			mic: &MockInvokerConfig{
-				UnaryResponse: MockMSResponse("host1", nil,
-					&mgmtpb.PoolDrainResp{},
-				),
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", nil,
+						&mgmtpb.PoolDrainResp{},
+					),
+					MockMSResponse("host1", nil,
+						&mgmtpb.PoolQueryResp{
+							Rebuild: &mgmtpb.PoolRebuildStatus{
+								State: mgmtpb.PoolRebuildStatus_DONE,
+							},
+						},
+					),
+				},
 			},
 		},
 	} {

--- a/src/control/lib/control/request.go
+++ b/src/control/lib/control/request.go
@@ -73,6 +73,7 @@ type (
 		deadliner
 		retryer
 		unaryRPCGetter
+		isAsync() bool
 	}
 )
 
@@ -87,11 +88,20 @@ type request struct {
 	deadline time.Time
 	Sys      string // DAOS system name
 	HostList []string
+	Async    bool `json:"-"`
 }
 
 // SetSystem sets the request's system name.
 func (r *request) SetSystem(name string) {
 	r.Sys = name
+}
+
+// isAsync returns true if the request is asynchronous
+// from the user perspective, i.e. returns immediately
+// regardless of whether or not the request is considered
+// complete.
+func (r *request) isAsync() bool {
+	return r.Async
 }
 
 // getSystem returns the system name set on the request or that returned by the

--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -39,6 +39,11 @@ type testRequest struct {
 	Deadline time.Time
 	Timeout  time.Duration
 	Sys      string
+	Async    bool
+}
+
+func (r *testRequest) isAsync() bool {
+	return r.Async
 }
 
 func (tr *testRequest) isMSRequest() bool {


### PR DESCRIPTION
The following pool commands are now synchronous (i.e. wait
until rebuild has completed) by default:
  * dmg pool exclude
  * dmg pool drain
  * dmg pool extend
  * dmg pool reintegrate

If desired, the --async flag can be supplied to restore
the previous behavior where the command returns immediately
after the initial RPC completes.

Features: pool osa nvme_osa

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
