### PR TITLE
DAOS-7821 build: Adjust pylint to work with distro pkg

### DIFF
--- a/utils/cq/daos_pylint.py
+++ b/utils/cq/daos_pylint.py
@@ -10,7 +10,11 @@ import subprocess  # nosec
 import argparse
 from pylint.lint import Run
 from pylint.reporters.collecting_reporter import CollectingReporter
-from pylint.lint import pylinter
+
+try:
+    from pylint.lint import pylinter
+except ImportError:
+    import pylint.lint as pylinter
 
 # Pylint checking for the DAOS project.
 


### PR DESCRIPTION
The el8 version of pylint has the manager in a different
place.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
