### PR TITLE
DAOS-11281 tests: Update pool/svc.py expectations

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -154,11 +154,9 @@ Pool created with 6.00% SCM/NVMe ratio
 ```
 
 This created a pool with UUID 8a05bf3a-a088-4a77-bb9f-df989fce7cc8,
-with pool service redundancy enabled by default
-(pool service replicas on ranks 1-5).
-
-If no redundancy is desired, use --nsvc=1 in order to specify that only
-a single pool service replica should be created.
+with pool service redundancy enabled by default (pool service replicas on ranks
+1-5). If no redundancy is desired, use `--properties=svc_rf:0` to set the pool
+service redundancy property to 0 (or `--nsvc=1`).
 
 Note that it is difficult to determine the usable space by the user, and
 currently we cannot provide the precise value. The usable space depends not only

--- a/src/tests/ftest/pool/svc.yaml
+++ b/src/tests/ftest/pool/svc.yaml
@@ -15,17 +15,17 @@ pool:
   pool_query_timeout: 30
 svc_params_mux: !mux
   svc_params_none:
-    svc_params: [None, 3]
+    svc_params: [None, 4]
   svc_params_0:
-    svc_params: [0, 3]
+    svc_params: [0, 4]
   svc_params_1:
     svc_params: [1, 1]
   svc_params_2:
-    svc_params: [2, 2]
+    svc_params: [2, 1]
   svc_params_3:
     svc_params: [3, 3]
   svc_params_4:
-    svc_params: [4, 4]
+    svc_params: [4, 3]
   svc_params_5:
     svc_params: [5, 4]
   svc_params_6:


### PR DESCRIPTION
Pull request #9119 has changed the default number of PS replicas from 3
to 5 via the new pool property svc_rf. It has also disallowed the
specification of even numbers of PS replicas. This patch updates the
expectations of the pool/svc.py tests to reflect those changes.

The old rule that avoids rank 0 when selecting PS ranks causes the
maximum number of PS ranks to be 4, instead of 5, for 5-rank pools that
include rank 0. The plan is to remove that rule via the deployment of
multiple MS replicas in testing. Hence, we simply expect 4 PS ranks for
svc_params_none, svc_params_0, and svc_params_5 in this patch.

Test-tag: pool_svc
Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true