### PR TITLE
DAOS-11289 build: Fix compiler warning on amd64 clang

### DIFF
--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -1355,6 +1355,7 @@ test_evt_find_internal(void **state)
 	struct evt_entry_in	 entry = {0};
 	struct evt_entry	 *ent;
 	struct evt_filter	 filter = {0};
+	char                     *value;
 	EVT_ENT_ARRAY_LG_PTR(ent_array);
 	bio_addr_t		 addr;
 	int			 rc;
@@ -1430,12 +1431,16 @@ test_evt_find_internal(void **state)
 			addr = ent->en_addr;
 			strcpy(buf, " ");
 			punched = bio_addr_is_hole(&addr);
-			D_PRINT("Find rect "DF_ENT" width=%d val=%.*s\n",
-			DP_ENT(ent),
-			(int)evt_extent_width(&ent->en_sel_ext),
-			punched ? 4 : (int)evt_extent_width(&ent->en_sel_ext),
-			punched ? "None" : (char *)utest_off2ptr(arg->ta_utx,
-								 addr.ba_off));
+			if (punched) {
+				D_PRINT("Find rect " DF_ENT " (punch)\n", DP_ENT(ent));
+			} else {
+				/** Must have a valid address if the extent isn't punched */
+				value = utest_off2ptr(arg->ta_utx, addr.ba_off);
+				D_ASSERT(value != NULL);
+				D_PRINT("Find rect " DF_ENT " width=%d val=%.*s\n", DP_ENT(ent),
+					(int)evt_extent_width(&ent->en_sel_ext),
+					(int)evt_extent_width(&ent->en_sel_ext), value);
+			}
 			punched ? strcpy(buf, "None") :
 			strncpy(buf,
 				(char *)utest_off2ptr(arg->ta_utx, addr.ba_off),


### PR DESCRIPTION
The compiler erroneously is flagging a NULL pointer where
the value can't be NULL.  Work around the issue by adding
an assertion in the appropriate case.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>