### PR TITLE
DAOS-10882 test: Include cmocka.xml results for dfs_test (#9674)

### DIFF
--- a/src/tests/ftest/daos_test/dfs.yaml
+++ b/src/tests/ftest/daos_test/dfs.yaml
@@ -6,7 +6,7 @@ hosts:
 timeout: 4000
 timeouts:
   test_daos_dfs_unit: 2000
-  test_daos_dfs_parallel: 2000
+  test_daos_dfs_parallel: 2060
   test_daos_dfs_sys: 90
 pool:
   scm_size: 8G

--- a/src/tests/ftest/scripts/post_process_xml.sh
+++ b/src/tests/ftest/scripts/post_process_xml.sh
@@ -58,14 +58,18 @@ for file in "${FILES[@]}"; do
 
         if ! grep "<testcase classname" "$file" >/dev/null; then
             if ! SUITE=$(grep "testsuite " "$file" | \
-                grep -Po "name=\"\K.*(?=\" time=)"); then
+                grep -Po "name=\"\K.*(?=\" time=)" | uniq); then
                 echo "Failed to process XML $file. Cannot determine SUITE."
             else
-                sed -i \
-                "s/case name/case classname=\"${COMP}.${SUITE}\" name/" "$file"
-            fi
+		for suite_name in ${SUITE}; do
+                    sed -i \
+                    "s/case name/case classname=\"${COMP}.${suite_name}\" name/" "$file"
+                done
+	    fi
         else
             sed -i "s/case classname=\"/case classname=\"${COMP}./" "$file"
         fi
+        sed -i "/<\/testsuites>/,/<testsuites>/ d" "$file"
+        echo "</testsuites>" >> "$file"
     fi
 done

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -6,12 +6,12 @@
 """
 
 import os
-import write_host_file
 
 from avocado import fail_on
 from avocado.utils import process
 from apricot import TestWithServers
-from general_utils import get_log_file
+from general_utils import get_log_file, get_clush_command, run_command, log_task
+from command_utils_base import EnvironmentVariables
 from command_utils import ExecutableCommand
 from exception_utils import CommandFailure
 from agent_utils import include_local_host
@@ -20,6 +20,7 @@ from test_utils_pool import POOL_TIMEOUT_INCREMENT
 
 
 class DaosCoreBase(TestWithServers):
+    # pylint: disable=too-many-nested-blocks
     """Runs the daos_test subtests with multiple servers.
 
     :avocado: recursive
@@ -29,6 +30,7 @@ class DaosCoreBase(TestWithServers):
         """Initialize the DaosCoreBase object."""
         super().__init__(*args, **kwargs)
         self.subtest_name = None
+        self.using_local_host = False
 
     def setUp(self):
         """Set up before each test."""
@@ -44,8 +46,7 @@ class DaosCoreBase(TestWithServers):
         # and create a new self.hostfile_clients.
         if not self.hostlist_clients:
             self.hostlist_clients = include_local_host(self.hostlist_clients)
-            self.hostfile_clients = write_host_file.write_host_file(
-                self.hostlist_clients, self.workdir, None)
+            self.using_local_host = True
 
     def get_test_param(self, name, default=None):
         """Get the test-specific test yaml parameter value.
@@ -112,8 +113,9 @@ class DaosCoreBase(TestWithServers):
         num_clients = self.get_test_param("num_clients")
         if num_clients is None:
             num_clients = self.params.get("num_clients", '/run/daos_tests/*')
+
         scm_size = self.params.get("scm_size", '/run/pool/*')
-        nvme_size = self.params.get("nvme_size", '/run/pool/*')
+        nvme_size = self.params.get("nvme_size", '/run/pool/*', 0)
         args = self.get_test_param("args", "")
         stopped_ranks = self.get_test_param("stopped_ranks", [])
         pools_created = self.get_test_param("pools_created", 1)
@@ -125,34 +127,37 @@ class DaosCoreBase(TestWithServers):
                 get_log_file("daosCA/certs"), self.hostlist_clients)
             dmg.copy_configuration(self.hostlist_clients)
 
-        cmd = " ".join(
-            [
-                "-x", "=".join(["D_LOG_FILE", get_log_file(self.client_log)]),
-                "--map-by node", "-x", "D_LOG_MASK=DEBUG",
-                "-x", "DD_MASK=mgmt,io,md,epc,rebuild",
-                "-x", "COVFILE=/tmp/test.cov",
-                self.daos_test,
-                "-n", dmg_config_file,
-                "".join(["-", subtest]),
-                str(args)
-            ]
-        )
+        # For tests running locally place the cmocka results directly into the avocado
+        # job-results/*/test-results/*/data/ directory (self.outputdir).  For remotely
+        # running tests, place the cmocka results in a 'cmocka' subdirectory in the
+        # DAOS_TEST_LOG_DIR directory.  These files will then need to be copied back to
+        # this host after the test runs.
+        cmocka_dir = self.outputdir
+        if not self.using_local_host:
+            cmocka_dir = os.path.join(self.test_dir, "cmocka")
+            log_task(
+                include_local_host(self.hostlist_clients), " ".join(["mkdir", "-p", cmocka_dir]))
 
+        # Set up the daos test command and environment settings
+        cmd = " ".join([self.daos_test, "-n", dmg_config_file, "".join(["-", subtest]), str(args)])
+        env = EnvironmentVariables({
+            "D_LOG_FILE": get_log_file(self.client_log),
+            "D_LOG_MASK": "DEBUG",
+            "DD_MASK": "mgmt,io,md,epc,rebuild",
+            "COVFILE": "/tmp/test.cov",
+            "CMOCKA_XML_FILE": os.path.join(cmocka_dir, "%g_cmocka_results.xml"),
+            "CMOCKA_MESSAGE_OUTPUT": "xml",
+            "POOL_SCM_SIZE": str(scm_size),
+            "POOL_NVME_SIZE": str(nvme_size),
+        })
+
+        # Assign the test to run
         job_cmd = ExecutableCommand(namespace=None, command=cmd)
         job = get_job_manager(self, "Orterun", job_cmd, mpi_type="openmpi")
-        # Assign the test to run
-        job.hostfile.update(self.hostfile_clients)
-        job.processes.update(num_clients)
+        job.assign_hosts(self.hostlist_clients, self.workdir, None)
+        job.assign_processes(num_clients)
+        job.assign_environment(env)
         job_str = str(job)
-
-        env = {}
-        env['CMOCKA_XML_FILE'] = os.path.join(self.outputdir,
-                                              "%g_cmocka_results.xml")
-        env['CMOCKA_MESSAGE_OUTPUT'] = "xml"
-        env['POOL_SCM_SIZE'] = "{}".format(scm_size)
-        if not nvme_size:
-            nvme_size = 0
-        env['POOL_NVME_SIZE'] = "{}".format(nvme_size)
 
         # Update the expected status for each ranks that will be stopped by this
         # test to avoid a false failure during tearDown().
@@ -169,16 +174,42 @@ class DaosCoreBase(TestWithServers):
                         rank, ["Stopped", "Excluded"])
 
         try:
-            process.run(job_str, env=env)
+            process.run(job_str)
         except process.CmdError as result:
             if result.result.exit_status != 0:
                 # fake a JUnit failure output
-                self.create_results_xml(self.subtest_name, result,
-                                        "Failed to run {}.".format(
-                    self.daos_test))
+                self.create_results_xml(
+                    self.subtest_name, result, "Failed to run {0}.".format(self.daos_test))
                 self.fail(
                     "{0} failed with return code={1}.\n".format(
                         job_str, result.result.exit_status))
+        finally:
+            if not self.using_local_host:
+                # List any remote cmocka files
+                self.log.debug("Remote %s directories:", cmocka_dir)
+                ls_command = "ls -alR {0}".format(cmocka_dir)
+                clush_ls_command = "{0} {1}".format(
+                    get_clush_command(self.hostlist_clients, "-B -S"), ls_command)
+                log_task(self.hostlist_clients, clush_ls_command)
+
+                # Copy any remote cmocka files back to this host
+                command = "{0} --rcopy {1} --dest {1}".format(
+                    get_clush_command(self.hostlist_clients), cmocka_dir)
+                try:
+                    run_command(command)
+
+                finally:
+                    self.log.debug("Local %s directory after clush:", cmocka_dir)
+                    run_command(ls_command)
+                    # Move local files to the avocado test variant data directory
+                    for cmocka_node_dir in os.listdir(cmocka_dir):
+                        cmocka_node_path = os.path.join(cmocka_dir, cmocka_node_dir)
+                        if os.path.isdir(cmocka_node_path):
+                            for cmocka_file in os.listdir(cmocka_node_path):
+                                cmocka_file_path = os.path.join(cmocka_node_path, cmocka_file)
+                                if "_cmocka_results." in cmocka_file:
+                                    command = "mv {0} {1}".format(cmocka_file_path, self.outputdir)
+                                    run_command(command)
 
     def create_results_xml(self, testname, result, error_message="Test failed to start up"):
         """Create a JUnit result.xml file for the failed command.

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -383,9 +383,28 @@ def display_task(task):
 
     Args:
         task (Task): a ClusterShell.Task.Task object for the executed command
+
+    Returns:
+        bool: if the command returned an 0 exit status on every host
+
     """
     log = getLogger()
     return check_task(task, log)
+
+
+def log_task(hosts, command, timeout=None):
+    """Display the output of the command executed on each host in parallel.
+
+    Args:
+        hosts (list): list of hosts
+        command (str): the command to run in parallel
+        timeout (int, optional): command timeout in seconds. Defaults to None.
+
+    Returns:
+        bool: if the command returned an 0 exit status on every host
+
+    """
+    return display_task(run_task(hosts, command, timeout, True))
 
 
 def run_pcmd(hosts, command, verbose=True, timeout=None, expect_rc=0):
@@ -500,6 +519,7 @@ def colate_results(command, results):
                         containing output, exit status, and interrupted
                         status common to each group of hosts (see run_pcmd()'s
                         return for details)
+
     Returns:
         str: a string colating run_pcmd()'s results
 
@@ -784,7 +804,6 @@ def dump_engines_stacks(hosts, verbose=True, timeout=60, added_filter=None):
         added_filter (str, optional): negative filter to better identify
             engines.
 
-
     Returns:
         dict: a dictionary of return codes keys and accompanying NodeSet
             values indicating which hosts yielded the return code.
@@ -834,7 +853,6 @@ def stop_processes(hosts, pattern, verbose=True, timeout=60, added_filter=None):
         added_filter (str, optional): negative filter to better identify
             processes.
 
-
     Returns:
         dict: a dictionary of return codes keys and accompanying NodeSet
             values indicating which hosts yielded the return code.
@@ -881,6 +899,7 @@ def get_partition_hosts(partition, reservation=None):
     Args:
         partition (str): name of the partition
         reservation (str): name of reservation
+
     Returns:
         list: list of hosts in the specified partition
 


### PR DESCRIPTION
Description:
Cherry pick daos-10882 to release_2.2
modified:   src/tests/ftest/daos_test/dfs.yaml
modified:   src/tests/ftest/scripts/post_process_xml.sh
modified:   src/tests/ftest/util/daos_core_base.py
modified:   src/tests/ftest/util/general_utils.py
Skip-unit-tests: true
Test-tag: dfs_test dfuse_test daos_test
Signed-off-by: Ding Ho ding-hwa.ho@intel.com
* Set the CMOCKA* environment variables correctly to ensure cmocka results
are generated in the expected location to correctly log any test errors.
(Add codes to verify cmocka_result.xml file exists before scp them)
* Update post_process_xml.sh to handle multiple testsuite entries

Signed-off-by: Ding Ho ding-hwa.ho@intel.com