### PR TITLE
DAOS-11295 gurt: increase DD_ENV_MAX_LEN

### DIFF
--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -34,7 +34,7 @@ static d_dbug_t DB_OPT8;
 static d_dbug_t DB_OPT9;
 static d_dbug_t DB_OPT10;
 
-#define DBG_ENV_MAX_LEN	(32)
+#define DBG_ENV_MAX_LEN	(128)
 
 #define DBG_DICT_ENTRY(bit, name, longname)				\
 	{ .db_bit = bit, .db_name = name, .db_name_size = sizeof(name),	\


### PR DESCRIPTION
Increase DD_ENV_MAX_LEN to 128 to avoid DD_MASK
exceed the maximum size.

Signed-off-by: Di Wang <di.wang@intel.com>