### PR TITLE
DAOS-11248 build: don't ship daos-mofed shim RPM (#9934)

### DIFF
--- a/.rpmignore
+++ b/.rpmignore
@@ -5,6 +5,7 @@
 
 centos7/daos-client-tests-openmpi*.rpm
 centos7/daos-firmware*.rpm
+centos7/daos-mofed*.rpm
 centos7/daos-serialize*.rpm
 centos7/daos-server-tests-openmpi*.rpm
 centos7/daos-tests-internal*.rpm
@@ -12,6 +13,7 @@ centos7/ucx*.rpm
 
 el8/daos-client-tests-openmpi*.rpm
 el8/daos-firmware*.rpm
+el8/daos-mofed*.rpm
 el8/daos-serialize*.rpm
 el8/daos-server-tests-openmpi*.rpm
 el8/daos-tests-internal*.rpm
@@ -19,6 +21,7 @@ el8/ucx*.rpm
 
 leap15/daos-client-tests-openmpi*.rpm
 leap15/daos-firmware*.rpm
+leap15/daos-mofed*.rpm
 leap15/daos-serialize*.rpm
 leap15/daos-server-tests-openmpi*.rpm
 leap15/daos-tests-internal*.rpm


### PR DESCRIPTION
add daos-mofed* to .rpmignore

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>