### PR TITLE
DAOS-10835 test: enable D_LOG_FILE_APPEND_PID in the client (#9399)

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -201,6 +201,7 @@ def set_test_environment(args):
             os.environ["DAOS_TEST_LOG_DIR"] = DEFAULT_DAOS_TEST_LOG_DIR
         os.environ["D_LOG_FILE"] = os.path.join(
             os.environ["DAOS_TEST_LOG_DIR"], "daos.log")
+        os.environ["D_LOG_FILE_APPEND_PID"] = "1"
 
         # Assign the default value for transport configuration insecure mode
         os.environ["DAOS_INSECURE_MODE"] = str(args.insecure_mode)


### PR DESCRIPTION
So rpc logs won't be messed up to make cart_logparse work.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>