### PR TITLE
DAOS-11180 dtx: re-index committed DTX entries for DTX_CHECK

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -650,12 +650,11 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	D_INIT_LIST_HEAD(&dra.tables.drh_list);
 	dra.tables.drh_count = 0;
 
-	if (dra.discard_version != dra.resync_version) {
-		/*
-		 * For non-discard case, trigger DTX reindex. That will avoid DTX_CHECK from
-		 * others being blocked. It is harmless even if (committed) DTX entries have
-		 * already been re-indexed.
-		 */
+	/*
+	 * Trigger DTX reindex. That will avoid DTX_CHECK from others being blocked.
+	 * It is harmless even if (committed) DTX entries have already been re-indexed.
+	 */
+	if (!dtx_cont_opened(cont)) {
 		rc = start_dtx_reindex_ult(cont);
 		if (rc != 0) {
 			D_ERROR(DF_UUID": Failed to trigger DTX reindex, ver %u/%u: "DF_RC"\n",

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -219,12 +219,19 @@ dtx_handler(crt_rpc_t *rpc)
 
 		rc = vos_dtx_check(cont->sc_hdl, din->di_dtx_array.ca_arrays,
 				   NULL, NULL, NULL, NULL, false);
-		if (rc == DTX_ST_INITED)
+		if (rc == DTX_ST_INITED) {
 			/* For DTX_CHECK, non-ready one is equal to non-exist. Do not directly
 			 * return 'DTX_ST_INITED' to avoid interoperability trouble if related
 			 * request is from old server.
 			 */
 			rc = -DER_NONEXIST;
+		} else if (rc == -DER_INPROGRESS && !dtx_cont_opened(cont)) {
+			/* Trigger DTX re-index for subsequent (retry) DTX_CHECK. */
+			rc1 = start_dtx_reindex_ult(cont);
+			if (rc1 != 0)
+				D_ERROR(DF_UUID": Failed to trigger DTX reindex: "DF_RC"\n",
+					DP_UUID(cont->sc_uuid), DP_RC(rc));
+		}
 
 		break;
 	case DTX_REFRESH:


### PR DESCRIPTION
If the DTX_CHECK RPC handler hits -DER_INPROGRESS failure on some
target, then it means that the committed DTX entries on such target
are not re-indexed. Under such case, we need to trigger DTX re-index
on the target for subsequent (retry) DTX_CHECK RPC. Otherwise, it may
cause more DTX_CHECK RPCs to be retried (for ever), as to related DTX
resync cannot complete on some DTX leaders.

Signed-off-by: Fan Yong <fan.yong@intel.com>