### PR TITLE
DAOS-10157 test: Increase timeout for erasurecode/rebuild_disabled_si…

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -7,7 +7,7 @@ hosts:
     10_server:
       test_servers: server-[1-5]
   test_clients: 1
-timeout: 250
+timeout: 400
 setup:
   # Test variants use different server counts, so ensure servers are stopped after each run
   start_agents_once: False


### PR DESCRIPTION
…ngle.py (#8537)

Default RPC timeout was changed, so the test takes longer.
Increase the timeout to incorporate this change.

Skip-unit-tests: true
Test-repeat: 10
Test-tag: ec_disabled_rebuild_single
Signed-off-by: Makito Kano <makito.kano@intel.com>