### PR TITLE
DAOS-8403 dfuse: Force IL to use backoff for pool handle.

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -471,7 +471,7 @@ ioil_fetch_pool_handle(int fd, struct dfuse_hs_reply *hs_reply,
 		return ENOMEM;
 
 	/* Max size of ioctl is 16k */
-	if (hs_reply->fsr_pool_size >= (16 * 1024)) {
+	if (hs_reply->fsr_pool_size >= (16)) {
 		char fname[NAME_LEN];
 
 		cmd = _IOC(_IOC_READ, DFUSE_IOCTL_TYPE,

--- a/src/client/dfuse/ops/ioctl.c
+++ b/src/client/dfuse/ops/ioctl.c
@@ -85,6 +85,13 @@ handle_size_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 
 	hs_reply.fsr_pool_size = iov.iov_buf_len;
 
+#if 1
+	/* Tell the caller that the pool size is large to force it into the back-off code of using
+	 * a file to communicate this data
+	 */
+	hs_reply.fsr_pool_size = (16 * 1024);
+#endif
+
 	rc = daos_cont_local2global(oh->doh_ie->ie_dfs->dfs_coh, &iov);
 	if (rc)
 		D_GOTO(err, rc = daos_der2errno(rc));

--- a/src/client/dfuse/ops/ioctl.c
+++ b/src/client/dfuse/ops/ioctl.c
@@ -85,13 +85,6 @@ handle_size_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 
 	hs_reply.fsr_pool_size = iov.iov_buf_len;
 
-#if 1
-	/* Tell the caller that the pool size is large to force it into the back-off code of using
-	 * a file to communicate this data
-	 */
-	hs_reply.fsr_pool_size = (16 * 1024);
-#endif
-
 	rc = daos_cont_local2global(oh->doh_ie->ie_dfs->dfs_coh, &iov);
 	if (rc)
 		D_GOTO(err, rc = daos_der2errno(rc));


### PR DESCRIPTION
Have dfuse tell the IL that the pool handle is large so the
il will back-off to using a file-based method of reading this.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
