### PR TITLE
DAOS-11296 engine: Reduce the size of the stack used by print_backtrace

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -214,6 +214,7 @@ def define_mercury(reqs):
                 pkgconfig='mercury',
                 requires=['boost', 'ofi', 'ucx'] + libs,
                 out_of_src_build=True,
+                patch_rpath=['lib'],
                 package='mercury-devel' if inst(reqs, 'mercury') else None)
 
 


### PR DESCRIPTION
Assuming this can be run from the context of a limited stack ULT, we
need to be careful how much stack space we use.  Reduce it from 1024
to 256 which still gives us a max of 32 entries.
Also clean up the code a bit and print when we don't get a stacktrace
at all.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>