### PR TITLE
DAOS-11146 client: refine lock handling in d_hhash_link_insert()

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -555,7 +555,8 @@ daos_hhash_init_feats(uint32_t feats)
 		D_GOTO(unlock, rc = 0);
 	}
 
-	rc = d_hhash_create(feats, D_HHASH_BITS, &daos_ht.dht_hhash);
+	/* D_HASH_FT_NO_KEYINIT_LOCK for optimized link_insert perf */
+	rc = d_hhash_create(feats | D_HASH_FT_NO_KEYINIT_LOCK, D_HHASH_BITS, &daos_ht.dht_hhash);
 	if (rc == 0) {
 		D_ASSERT(daos_ht.dht_hhash != NULL);
 		daos_ht_ref = 1;

--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -519,14 +519,16 @@ d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *link,
 			 void *arg)
 {
 	struct d_hash_bucket	*bucket;
-	uint32_t	 idx;
-	uint32_t	 nr = 1U << htable->ht_bits;
-	bool		 need_lock = !(htable->ht_feats & D_HASH_FT_NOLOCK);
+	uint32_t		 idx;
+	uint32_t		 nr = 1U << htable->ht_bits;
+	bool			 need_lock = !(htable->ht_feats & D_HASH_FT_NOLOCK);
+	bool			 need_keyinit_lock;
 
 	if (htable->ht_ops->hop_key_init == NULL)
 		return -DER_INVAL;
 
-	if (need_lock) {
+	need_keyinit_lock = !(htable->ht_feats & D_HASH_FT_NO_KEYINIT_LOCK);
+	if (need_lock && need_keyinit_lock) {
 		/* Lock all buckets because of unknown key yet */
 		for (idx = 0; idx < nr; idx++) {
 			ch_bucket_lock(htable, idx, false);
@@ -537,16 +539,23 @@ d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *link,
 
 	/* has no key, hash table should have provided key generator */
 	ch_key_init(htable, link, arg);
-
 	idx = ch_rec_hash(htable, link);
 	bucket = &htable->ht_buckets[idx];
+
+	if (need_lock && !need_keyinit_lock)
+		ch_bucket_lock(htable, idx, false);
+
 	ch_rec_insert_addref(htable, bucket, link);
 
 	if (need_lock) {
-		for (idx = 0; idx < nr; idx++) {
+		if (!need_keyinit_lock) {
 			ch_bucket_unlock(htable, idx, false);
-			if (htable->ht_feats & D_HASH_FT_GLOCK)
-				break;
+		} else {
+			for (idx = 0; idx < nr; idx++) {
+				ch_bucket_unlock(htable, idx, false);
+				if (htable->ht_feats & D_HASH_FT_GLOCK)
+					break;
+			}
 		}
 	}
 	return 0;
@@ -1006,7 +1015,7 @@ d_hash_table_debug(struct d_hash_table *htable)
  ******************************************************************************/
 
 struct d_hhash {
-	uint64_t		ch_cookie;
+	ATOMIC uint64_t		ch_cookie;
 	struct d_hash_table	ch_htable;
 	/* server-side uses D_HTYPE_PTR handle */
 	bool			ch_ptrtype;
@@ -1073,10 +1082,11 @@ hh_op_key_init(struct d_hash_table *htable, d_list_t *link, void *arg)
 	struct d_hhash	*hhash;
 	struct d_hlink	*hlink = link2hlink(link);
 	int		 type  = *(int *)arg;
+	uint64_t	 cookie;
 
 	hhash = container_of(htable, struct d_hhash, ch_htable);
-	hlink->hl_key = ((hhash->ch_cookie++) << D_HTYPE_BITS)
-			| (type & D_HTYPE_MASK);
+	cookie = atomic_fetch_add_relaxed(&hhash->ch_cookie, 1);
+	hlink->hl_key = (cookie << D_HTYPE_BITS) | (type & D_HTYPE_MASK);
 }
 
 static uint32_t
@@ -1154,7 +1164,7 @@ d_hhash_create(uint32_t feats, uint32_t bits, struct d_hhash **hhash_pp)
 		D_GOTO(out, rc);
 	}
 
-	hhash->ch_cookie  = 1ULL;
+	atomic_store_relaxed(&hhash->ch_cookie, 1);
 	hhash->ch_ptrtype = false;
 out:
 	*hhash_pp = hhash;
@@ -1205,8 +1215,6 @@ d_uhash_link_empty(struct d_ulink *ulink)
 void
 d_hhash_link_insert(struct d_hhash *hhash, struct d_hlink *hlink, int type)
 {
-	bool need_lock = !(hhash->ch_htable.ht_feats & D_HASH_FT_NOLOCK);
-
 	D_ASSERT(hlink->hl_link.rl_initialized);
 
 	/* check if handle type fits in allocated bits */
@@ -1215,34 +1223,15 @@ d_hhash_link_insert(struct d_hhash *hhash, struct d_hlink *hlink, int type)
 		  type, D_HTYPE_BITS);
 
 	if (d_hhash_is_ptrtype(hhash)) {
-		uint64_t ptr_key = (uintptr_t)hlink;
-		uint32_t nr = 1U << hhash->ch_htable.ht_bits;
-		uint32_t idx = 0;
+		uint64_t		 ptr_key = (uintptr_t)hlink;
 
 		D_ASSERTF(type == D_HTYPE_PTR, "direct/ptr-based htable can "
 			  "only contain D_HTYPE_PTR type entries");
 		D_ASSERTF(d_hhash_key_isptr(ptr_key), "hlink ptr %p is invalid "
 			  "D_HTYPE_PTR type", hlink);
 
-		if (need_lock) {
-			/* Lock all buckets to emulate proper hlink lock */
-			for (idx = 0; idx < nr; idx++) {
-				ch_bucket_lock(&hhash->ch_htable, idx, false);
-				if (hhash->ch_htable.ht_feats & D_HASH_FT_GLOCK)
-					break;
-			}
-		}
-
-		ch_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 		hlink->hl_key = ptr_key;
-
-		if (need_lock) {
-			for (idx = 0; idx < nr; idx++) {
-				ch_bucket_unlock(&hhash->ch_htable, idx, false);
-				if (hhash->ch_htable.ht_feats & D_HASH_FT_GLOCK)
-					break;
-			}
-		}
+		ch_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 	} else {
 		D_ASSERTF(type != D_HTYPE_PTR, "PTR type key being inserted "
 			  "in a non ptr-based htable.\n");

--- a/src/include/gurt/hash.h
+++ b/src/include/gurt/hash.h
@@ -197,13 +197,19 @@ enum d_hash_feats {
 	 * The found in bucket item is moved on top of the list.
 	 * So, next search for it will be much faster.
 	 */
-	D_HASH_FT_LRU		= (1 << 4),
+	D_HASH_FT_LRU			= (1 << 4),
+
+	/**
+	 * Need not take lock for ch_key_init.
+	 * Only valid when without D_HASH_FT_NOLOCK feat bit set.
+	 */
+	D_HASH_FT_NO_KEYINIT_LOCK	= (1 << 5),
 
 	/**
 	 * Use Global Table Lock instead of per bucket locking.
 	 * TODO: should be removed when all will use per bucket locking.
 	 */
-	D_HASH_FT_GLOCK		= (1 << 15),
+	D_HASH_FT_GLOCK			= (1 << 15),
 };
 
 union d_hash_lock {

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4753,6 +4753,39 @@ io_tx_convert(void **state)
 	ioreq_fini(&req);
 }
 
+static void
+obj_open_perf(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	daos_handle_t	*oh;
+	uint64_t	start_usec, end_usec;
+	float		opens_per_sec;
+	int		i, nr, rc;
+
+	nr = 10000;
+	D_ALLOC_ARRAY(oh, nr);
+	assert_non_null(oh);
+
+	start_usec = daos_getutime();
+	for (i = 0; i < nr; i++) {
+		oid = daos_test_oid_gen(arg->coh, dts_obj_class, 0, 0, arg->myrank);
+		rc = daos_obj_open(arg->coh, oid, 0, &oh[i], NULL);
+		assert_rc_equal(rc, 0);
+	}
+	end_usec = daos_getutime();
+	opens_per_sec = (nr * 1000.0 * 1000) / (end_usec - start_usec);
+
+	print_message("opens per second %.2f (total #obj_opens %d)\n", opens_per_sec, nr);
+
+	for (i = 0; i < nr; i++) {
+		rc = daos_obj_close(oh[i], NULL);
+		assert_rc_equal(rc, 0);
+	}
+
+	D_FREE(oh);
+}
+
 static const struct CMUnitTest io_tests[] = {
 	{ "IO1: simple update/fetch/verify",
 	  io_simple, async_disable, test_case_teardown},
@@ -4848,6 +4881,7 @@ static const struct CMUnitTest io_tests[] = {
 	  enum_recxs_with_aggregation, async_disable, test_case_teardown},
 	{ "IO46: tx convert",
 	  io_tx_convert, async_disable, test_case_teardown},
+	{ "IO47: obj_open perf", obj_open_perf, async_disable, test_case_teardown},
 };
 
 int


### PR DESCRIPTION
Refine d_hhash_link_insert() -
1. for PTR type handle hash table, need not take any extra lock
2. for non-PTR type, refine d_hash_rec_insert_anonym()
   add feat bit D_HASH_FT_NO_KEYINIT_LOCK set that for d_hhash
   to avoid take all buckets' lock

Addd a simple test fo obj_open perf, by testing on boro obj_open
per second increased from 427.36 OPs/S to 313038.03 OPs/S.
(./daos_test -i -u 46, only one engine and client is enough)

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>