### PR TITLE
DAOS-11231 dtx: handle dependency during task conversion

### DIFF
--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -247,6 +247,7 @@ tse_task_decref(tse_task_t *task)
 		return;
 
 	D_ASSERT(d_list_empty(&dtp->dtp_dep_list));
+	D_ASSERT(d_list_empty(&dtp->dtp_comp_cb_list));
 
 	/*
 	 * MSC - since we require user to allocate task, maybe we should have

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -76,7 +76,9 @@ struct dc_tx {
 	uint64_t		 tx_flags;
 	uint32_t		 tx_fixed_epoch:1, /** epoch is specified. */
 				 tx_retry:1, /** Retry the commit RPC. */
-				 tx_set_resend:1; /** Set 'resend' flag. */
+				 tx_set_resend:1, /** Set 'resend' flag. */
+				 tx_for_convert:1,
+				 tx_has_cond:1;
 	/** Transaction status (OPEN, COMMITTED, etc.), see dc_tx_status. */
 	enum dc_tx_status	 tx_status;
 	/** The rank for the server on which the TX leader resides. */
@@ -227,6 +229,12 @@ static void
 dc_tx_decref(struct dc_tx *tx)
 {
 	daos_hhash_link_putref(&tx->tx_hlink);
+}
+
+static void
+dc_tx_addref(struct dc_tx *tx)
+{
+	daos_hhash_link_getref(&tx->tx_hlink);
 }
 
 static struct dc_tx *
@@ -1874,6 +1882,14 @@ out:
 		tx->tx_status = TX_FAILED;
 	else if (rc != 0)
 		tx->tx_status = TX_ABORTED;
+
+	/* Unlock for dc_tx_commit held. */
+	D_MUTEX_UNLOCK(&tx->tx_lock);
+	/* -1 for dc_tx_commit() held */
+	dc_tx_decref(tx);
+
+	tse_task_complete(task, rc);
+
 	return rc;
 }
 
@@ -1916,10 +1932,7 @@ dc_tx_commit(tse_task_t *task)
 		D_GOTO(out_tx, rc = 0);
 	}
 
-	rc = dc_tx_commit_trigger(task, tx, args);
-	if (rc)
-		D_GOTO(out_tx, rc);
-	return rc;
+	return dc_tx_commit_trigger(task, tx, args);
 
 out_tx:
 	D_MUTEX_UNLOCK(&tx->tx_lock);
@@ -2557,10 +2570,13 @@ fail:
 	return rc;
 }
 
+static int dc_tx_convert_post(struct dc_tx *tx, tse_task_t *task, enum obj_rpc_opc opc, int result);
+
 struct dc_tx_check_existence_cb_args {
 	enum obj_rpc_opc	opc;
 	struct dc_tx		*tx;
 	daos_handle_t		oh;
+	tse_task_t		*task;
 	uint64_t		flags;
 	daos_key_t		*dkey;
 	uint64_t		nr;
@@ -2627,6 +2643,9 @@ dc_tx_per_akey_existence_parent_cb(tse_task_t *task, void *data)
 		obj_decref(obj);
 	}
 
+	if (tx->tx_for_convert)
+		rc = dc_tx_convert_post(tx, args->task, args->opc, rc);
+
 	/* Drop the reference that is held via dc_tx_attach(). */
 	dc_tx_decref(tx);
 
@@ -2688,6 +2707,9 @@ out:
 		D_FREE(args->tmp_iods);
 	}
 
+	if (tx->tx_for_convert)
+		rc = dc_tx_convert_post(tx, args->task, args->opc, rc);
+
 	/* The errno will be auto propagated to the dependent task. */
 	task->dt_result = rc;
 
@@ -2715,9 +2737,13 @@ dc_tx_per_akey_existence_task(enum obj_rpc_opc opc, daos_handle_t oh, struct dc_
 
 	D_INIT_LIST_HEAD(&task_list);
 
+	if (nr == 0 || iods_or_akeys == NULL)
+		D_GOTO(fail, rc = -DER_INVAL);
+
 	cb_args.opc		= opc;
 	cb_args.tx		= tx;
 	cb_args.oh		= oh;
+	cb_args.task		= parent;
 	cb_args.flags		= flags;
 	cb_args.dkey		= dkey;
 	cb_args.nr		= nr;
@@ -2753,13 +2779,21 @@ dc_tx_per_akey_existence_task(enum obj_rpc_opc opc, daos_handle_t oh, struct dc_
 		if (rc != 0)
 			goto out;
 
+		iods = NULL;
+
 		/* decref and delete from head at shard_task_remove */
 		tse_task_addref(task);
 		tse_task_list_add(task, &task_list);
 
-		iods = NULL;
-
 		rc = dc_task_depend(parent, 1, &task);
+
+		/*
+		 * The task is in the task_list, then even if to be aborted, it will be handled
+		 * via tse_task_list_traverse(shard_task_abort), do NOT need to explicitly call
+		 * tse_task_complete()/dc_task_decref(), so reset it as NULL before "goto out".
+		 */
+		task = NULL;
+
 		if (rc != 0)
 			goto out;
 	}
@@ -2774,6 +2808,9 @@ out:
 			rc = dc_tx_add_update(tx, &obj, flags, dkey, nr, iods_or_akeys, sgls);
 			D_MUTEX_UNLOCK(&tx->tx_lock);
 			obj_decref(obj);
+
+			if (tx->tx_for_convert)
+				rc = dc_tx_convert_post(tx, parent, opc, rc);
 
 			/* Drop the reference that is held via dc_tx_attach(). */
 			dc_tx_decref(tx);
@@ -2792,17 +2829,18 @@ out:
 			rc = 1;
 		}
 	} else {
-		if (iods != NULL) {
-			if (task != NULL)
-				dc_task_decref(task);
+		if (task != NULL)
+			tse_task_complete(task, rc);
 
+		if (iods != NULL) {
 			daos_iov_free(&iods->iod_name);
 			D_FREE(iods);
 		}
 
 fail:
 		tse_task_list_traverse(&task_list, shard_task_abort, &rc);
-		parent->dt_result = rc;
+		if (tx->tx_for_convert)
+			rc = dc_tx_convert_post(tx, parent, opc, rc);
 
 		/* Drop the reference that is held via dc_tx_attach(). */
 		dc_tx_decref(tx);
@@ -2827,6 +2865,7 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 	cb_args.opc		= opc;
 	cb_args.tx		= tx;
 	cb_args.oh		= oh;
+	cb_args.task		= parent;
 	cb_args.flags		= flags;
 	cb_args.dkey		= dkey;
 	cb_args.nr		= nr;
@@ -2901,7 +2940,7 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 
 out:
 	if (task != NULL)
-		dc_task_decref(task);
+		tse_task_complete(task, rc);
 
 	if (iods != NULL && iods != iods_or_akeys) {
 		for (i = 0; i < nr; i++)
@@ -2909,6 +2948,9 @@ out:
 
 		D_FREE(iods);
 	}
+
+	if (tx->tx_for_convert)
+		rc = dc_tx_convert_post(tx, parent, opc, rc);
 
 	/* Drop the reference that is held via dc_tx_attach(). */
 	dc_tx_decref(tx);
@@ -2925,7 +2967,7 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 
 	rc = dc_tx_check(th, obj_is_modification_opc(opc) ? true : false, &tx);
 	if (rc != 0)
-		goto out;
+		goto out_obj;
 
 	switch (opc) {
 	case DAOS_OBJ_RPC_UPDATE: {
@@ -2935,6 +2977,7 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 				 DAOS_COND_DKEY_UPDATE |
 				 DAOS_COND_AKEY_INSERT |
 				 DAOS_COND_AKEY_UPDATE)) {
+			tx->tx_has_cond = 1;
 			D_MUTEX_UNLOCK(&tx->tx_lock);
 
 			if (obj != NULL)
@@ -2946,10 +2989,8 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 		}
 
 		if (up->flags & DAOS_COND_PER_AKEY) {
+			tx->tx_has_cond = 1;
 			D_MUTEX_UNLOCK(&tx->tx_lock);
-
-			if (up->nr == 0 || up->iods == NULL)
-				D_GOTO(out, rc = -DER_INVAL);
 
 			if (obj != NULL)
 				obj_decref(obj);
@@ -2976,6 +3017,7 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 		daos_obj_punch_t	*pu = dc_task_get_args(task);
 
 		if (pu->flags & DAOS_COND_PUNCH) {
+			tx->tx_has_cond = 1;
 			D_MUTEX_UNLOCK(&tx->tx_lock);
 
 			if (obj != NULL)
@@ -2993,6 +3035,7 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 		daos_obj_punch_t	*pu = dc_task_get_args(task);
 
 		if (pu->flags & DAOS_COND_PUNCH) {
+			tx->tx_has_cond = 1;
 			D_MUTEX_UNLOCK(&tx->tx_lock);
 
 			if (obj != NULL)
@@ -3056,9 +3099,11 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 	}
 
 	D_MUTEX_UNLOCK(&tx->tx_lock);
+
+	/* -1 for dc_tx_check() held */
 	dc_tx_decref(tx);
 
-out:
+out_obj:
 	if (obj != NULL)
 		obj_decref(obj);
 
@@ -3165,77 +3210,83 @@ out:
 	return rc;
 }
 
+static int
+dc_tx_convert_post(struct dc_tx *tx, tse_task_t *task, enum obj_rpc_opc opc, int result)
+{
+	struct tx_convert_cb_args	 conv_args = { .conv_tx = tx,
+						       .conv_task = task,
+						       .conv_opc = opc };
+	daos_tx_commit_t		*cmt_args;
+	tse_task_t			*cmt_task = NULL;
+	int				 rc = 0;
+
+	if (result != 0)
+		D_GOTO(out, rc = result);
+
+	rc = dc_task_create(dc_tx_commit, tse_task2sched(task), NULL, &cmt_task);
+	if (rc != 0) {
+		D_ERROR("Fail to create tx convert commit task for opc %u: "DF_RC"\n",
+			opc, DP_RC(rc));
+		goto out;
+	}
+
+	cmt_args = dc_task_get_args(cmt_task);
+	cmt_args->th = dc_tx_ptr2hdl(tx);
+	cmt_args->flags = 0;
+
+	rc = tse_task_register_comp_cb(cmt_task, dc_tx_convert_cb, &conv_args, sizeof(conv_args));
+	if (rc != 0) {
+		D_ERROR("Fail to add CB for TX convert task commit: "DF_RC"\n", DP_RC(rc));
+		goto out;
+	}
+
+	rc = dc_task_depend(task, 1, &cmt_task);
+	if (rc != 0) {
+		D_ERROR("Fail to add dep for TX convert task on commit: "DF_RC"\n", DP_RC(rc));
+		goto out;
+	}
+
+	return dc_task_schedule(cmt_task, true);
+
+out:
+	if (cmt_task != NULL)
+		tse_task_complete(cmt_task, rc);
+
+	tse_task_complete(task, rc);
+	dc_tx_close_internal(tx);
+
+	return rc;
+}
+
 int
 dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task)
 {
-	struct tx_convert_cb_args	 conv = { 0 };
-	daos_tx_commit_t		*args;
-	tse_task_t			*tx_task = NULL;
-	struct dc_tx			*tx = NULL;
-	int				 rc = 0;
+	struct dc_tx	*tx = NULL;
+	int		 rc = 0;
 
 	D_ASSERT(obj != NULL);
+	D_ASSERTF(task->dt_result == 0, "Unexpected initial task result %d\n", task->dt_result);
 
 	rc = dc_tx_alloc(obj->cob_coh, 0, DAOS_TF_ZERO_COPY, &tx);
 	if (rc != 0) {
-		D_ERROR("Fail to open TX for opc %u: "DF_RC"\n",
-			opc, DP_RC(rc));
+		D_ERROR("Fail to open convert TX for opc %u: "DF_RC"\n", opc, DP_RC(rc));
 		goto out;
 	}
 
+	/* Hold another reference on TX to avoid being freed duing dc_tx_attach(). */
+	dc_tx_addref(tx);
+	tx->tx_for_convert = 1;
 	rc = dc_tx_attach(dc_tx_ptr2hdl(tx), obj, opc, task);
-	obj = NULL;
-	if (rc < 0) {
-		D_ERROR("Fail to attach TX for opc %u: "DF_RC"\n",
-			opc, DP_RC(rc));
-		goto out;
-	}
 
-	rc = dc_task_create(dc_tx_commit, tse_task2sched(task), NULL, &tx_task);
-	if (rc != 0) {
-		D_ERROR("Fail to create tx convert task for opc %u: "DF_RC"\n",
-			opc, DP_RC(rc));
-		goto out;
-	}
-
-	args = dc_task_get_args(tx_task);
-	args->th = dc_tx_ptr2hdl(tx);
-	args->flags = 0;
-
-	rc = dc_task_depend(task, 1, &tx_task);
-	if (rc != 0) {
-		D_ERROR("Fail to add dep on TX convert task: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
-	}
-
-	conv.conv_tx = tx;
-	conv.conv_task = task;
-	conv.conv_opc = opc;
-	task = NULL;
-
-	rc = tse_task_register_comp_cb(tx_task, dc_tx_convert_cb, &conv,
-				       sizeof(conv));
-	if (rc != 0) {
-		D_ERROR("Fail to add CB for TX convert task: "DF_RC"\n",
-			DP_RC(rc));
-		goto out;
-	}
-
-	return dc_task_schedule(tx_task, true);
+	if (!tx->tx_has_cond)
+		rc = dc_tx_convert_post(tx, task, opc, rc);
 
 out:
-	if (tx_task != NULL)
-		tse_task_complete(tx_task, rc);
-
-	if (task != NULL)
-		tse_task_complete(task, rc);
-
 	if (tx != NULL)
-		dc_tx_close_internal(tx);
-
-	if (obj != NULL)
-		obj_decref(obj);
+		/* -1 for above dc_tx_addref(). */
+		dc_tx_decref(tx);
+	else
+		tse_task_complete(task, rc);
 
 	return rc;
 }

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -2036,7 +2036,7 @@ dc_pool_abandon_map_refresh_task(tse_task_t *task)
 
 	d_backoff_seq_fini(&arg->mra_backoff_seq);
 	dc_pool_put(arg->mra_pool);
-	tse_task_decref(task);
+	tse_task_complete(task, -DER_CANCELED);
 }
 
 struct pool_lc_arg {


### PR DESCRIPTION
For the task that need to be handled via distributed transaction,
the client side IO logic will convert it to a transactional task.
During dc_tx_convert(), the original task maybe freed because of
the dependency on the sub-task(s) for existence check inside the
dc_tx_attach(). That will cause the "task" to become invalid for
subsequent process for the conversion.

To avoid above bad case, the patch moves the TX commit logic for
task conversion into related existence check callback before the
TX release.

Signed-off-by: Fan Yong <fan.yong@intel.com>