### PR TITLE
DAOS-11296 engine: Reduce size of stack used by print_backtrace (#9951)

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1025,23 +1025,26 @@ daos_register_sighand(int signo, void (*handler) (int, siginfo_t *, void *))
 	return 0;
 }
 
+#define PRINT_ERROR(...)                                                                           \
+	do {                                                                                       \
+		fprintf(stderr, __VA_ARGS__);                                                      \
+		D_ERROR(__VA_ARGS__);                                                              \
+	} while (0)
+
+/** This should be safe on Linux since tls is allocated on thread creation */
+#define MAX_BT_ENTRIES 256
+static __thread void *bt[MAX_BT_ENTRIES];
+
 static void
 print_backtrace(int signo, siginfo_t *info, void *p)
 {
-	void	*bt[128];
-	int	 bt_size, i, rc;
+	int   bt_size, rc;
 
-	/* since we mainly handle fatal signals here, flush the log to not
-	 * risk losing any debug traces
-	 */
-	d_log_sync();
-
-	fprintf(stderr, "*** Process %d received signal %d ***\n", getpid(),
-		signo);
+	PRINT_ERROR("*** Process %d received signal %d ***\n", getpid(), signo);
 
 	if (info != NULL) {
-		fprintf(stderr, "Associated errno: %s (%d)\n",
-			strerror(info->si_errno), info->si_errno);
+		PRINT_ERROR("Associated errno: %s (%d)\n", strerror(info->si_errno),
+			    info->si_errno);
 
 		/* XXX we could get more signal/fault specific details from
 		 * info->si_code decode
@@ -1050,27 +1053,29 @@ print_backtrace(int signo, siginfo_t *info, void *p)
 		switch (signo) {
 		case SIGILL:
 		case SIGFPE:
-			fprintf(stderr, "Failing at address: %p\n",
-				info->si_addr);
+			PRINT_ERROR("Failing at address: %p\n", info->si_addr);
 			break;
 		case SIGSEGV:
 		case SIGBUS:
-			fprintf(stderr, "Failing for address: %p\n",
-				info->si_addr);
+			PRINT_ERROR("Failing for address: %p\n", info->si_addr);
 			break;
 		}
 	} else {
-		fprintf(stderr, "siginfo is NULL, additional information "
-			"unavailable\n");
+		PRINT_ERROR("siginfo is NULL, additional information unavailable\n");
 	}
 
-	bt_size = backtrace(bt, 128);
-	if (bt_size >= 128)
-		fprintf(stderr, "backtrace may have been truncated\n");
+	/* since we mainly handle fatal signals here, flush the log to not
+	 * risk losing any debug traces
+	 */
+	d_log_sync();
 
-	/* start at 1 to forget about me! */
-	for (i = 1; i < bt_size; i++)
-		backtrace_symbols_fd(&bt[i], 1, fileno(stderr));
+	bt_size = backtrace(bt, MAX_BT_ENTRIES);
+	if (bt_size == MAX_BT_ENTRIES)
+		fprintf(stderr, "backtrace may have been truncated\n");
+	if (bt_size > 1) /* start at 1 to ignore this frame */
+		backtrace_symbols_fd(&bt[1], bt_size - 1, fileno(stderr));
+	else
+		fprintf(stderr, "No useful backtrace available");
 
 	/* re-register old handler */
 	rc = sigaction(signo, &old_handlers[signo], NULL);


### PR DESCRIPTION
Assuming this can be run from the context of a limited stack ULT, we
need to be careful how much stack space we use.  Reduce it from 1024
to 256 which still gives us a max of 32 entries.
Also clean up the code a bit and print when we don't get a stacktrace
at all.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>