### PR TITLE
DAOS-11318 bio: one bulk handle per DMA chunk

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -36,8 +36,6 @@ struct bio_bulk_args {
 struct bio_bulk_hdl {
 	/* Link to bbg_idle_bulks */
 	d_list_t		 bbh_link;
-	/* Bulk handle used by upper layer caller */
-	void			*bbh_bulk;
 	/* DMA chunk the hdl localted on */
 	struct bio_dma_chunk	*bbh_chunk;
 	/* Page offset (4k pages) within the chunk */
@@ -83,6 +81,7 @@ struct bio_dma_chunk {
 	/* == Bulk handle caching related fields == */
 	struct bio_bulk_group	*bdc_bulk_grp;
 	struct bio_bulk_hdl	*bdc_bulks;
+	void			*bdc_bulk_hdl;	/* Bulk handle used by upper layer caller */
 	unsigned int		 bdc_bulk_cnt;
 	unsigned int		 bdc_bulk_idle;
 };

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -387,12 +387,11 @@ bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 			iov_idx++;
 			cached_bulk = true;
 
-			/* Check if following IOVs are sharing same bulk handle */
+			/* Check if following IOVs are contiguous and from same bulk handle */
 			while (iov_idx < sgl->sg_nr_out &&
 			       sgl->sg_iovs[iov_idx].iov_buf != NULL &&
-			       vos_iod_bulk_at(ioh, sgl_idx, iov_idx,
-						&tmp_off) == local_bulk) {
-				D_ASSERT(tmp_off == 0);
+			       vos_iod_bulk_at(ioh, sgl_idx, iov_idx, &tmp_off) == local_bulk &&
+			       tmp_off == local_off) {
 				length += sgl->sg_iovs[iov_idx].iov_len;
 				iov_idx++;
 			};


### PR DESCRIPTION
Mercury is able to support concurrent bulk transfers against single
bulk handle, so the server bulk cache could be improved to create
single bulk handle per DMA chunk, and all bulk transfers over the
same chunk will share the same handle.

With this change, fewer handles will be created and more importantly,
bulk chunk depopulate/populate doesn't need to destroy/create handles
anymore, that'll be helpful for dealing with the potential bulk cache
thrashing problem caused by complex IO patterns.

Minor fix to BIO metrics to count only the non-empty bulk groups.

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>