### PR TITLE
DAOS-10301 test: Wait for dmg completion (#9889)

### DIFF
--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2021 Intel Corporation.
+// (C) Copyright 2018-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -95,10 +95,12 @@ func outputJSON(out io.Writer, in interface{}, cmdErr error) error {
 		Status   int         `json:"status"`
 	}{in, errStr, status}, "", "  ")
 	if err != nil {
+		fmt.Fprintf(out, "unable to marshal json: %s\n", err.Error())
 		return err
 	}
 
 	if _, err = out.Write(append(data, []byte("\n")...)); err != nil {
+		fmt.Fprintf(out, "unable to write json: %s\n", err.Error())
 		return err
 	}
 
@@ -158,6 +160,7 @@ type cliOptions struct {
 	HostList       string         `short:"l" long:"host-list" description:"A comma separated list of addresses <ipv4addr/hostname> to connect to"`
 	Insecure       bool           `short:"i" long:"insecure" description:"Have dmg attempt to connect without certificates"`
 	Debug          bool           `short:"d" long:"debug" description:"Enable debug output"`
+	LogFile        string         `long:"log-file" description:"Log command output to the specified file"`
 	JSON           bool           `short:"j" long:"json" description:"Enable JSON output"`
 	JSONLogs       bool           `short:"J" long:"json-logging" description:"Enable JSON-formatted log output"`
 	ConfigPath     string         `short:"o" long:"config-path" description:"Client config file path"`
@@ -215,6 +218,24 @@ and access control settings, along with system wide operations.`
 
 		if !opts.AllowProxy {
 			common.ScrubProxyVariables()
+		}
+
+		if opts.LogFile != "" {
+			f, err := common.AppendFile(opts.LogFile)
+			if err != nil {
+				return errors.WithMessage(err, "create log file")
+			}
+			defer f.Close()
+
+			log.Debugf("%s logging to file %s",
+				os.Args[0], opts.LogFile)
+
+			// Create an additional set of loggers which append everything
+			// to the specified file.
+			log = log.
+				WithErrorLogger(logging.NewErrorLogger("dmg", f)).
+				WithInfoLogger(logging.NewInfoLogger("dmg", f)).
+				WithDebugLogger(logging.NewDebugLogger(f))
 		}
 
 		if opts.Debug {

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -352,6 +352,7 @@ func (cmd *PoolDestroyCmd) Execute(args []string) error {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
 
+	cmd.ctlInvoker.Debugf("Pool-destroy command %s", msg)
 	cmd.log.Infof("Pool-destroy command %s\n", msg)
 
 	return err

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -293,7 +293,7 @@ func PoolDestroy(ctx context.Context, rpcClient UnaryInvoker, req *PoolDestroyRe
 		})
 	})
 
-	rpcClient.Debugf("Destroy DAOS pool request: %v\n", req)
+	rpcClient.Debugf("Destroy DAOS pool request: %+v\n", req)
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -303,7 +303,7 @@ func PoolDestroy(ctx context.Context, rpcClient UnaryInvoker, req *PoolDestroyRe
 	if err != nil {
 		return errors.Wrap(err, "pool destroy failed")
 	}
-	rpcClient.Debugf("Destroy DAOS pool response: %s\n", msResp)
+	rpcClient.Debugf("Destroy DAOS pool response: %+v\n", msResp)
 
 	return nil
 }

--- a/src/tests/ftest/daos_test/suite.py
+++ b/src/tests/ftest/daos_test/suite.py
@@ -57,6 +57,12 @@ class DaosCoreTest(DaosCoreBase):
         :avocado: tags=daos_test,daos_core_test,test_daos_pool
         """
         self.run_subtest()
+        try:
+            with open("/tmp/suite_dmg.log", 'r') as dmg_log:
+                log_data = dmg_log.readlines()
+                self.add_test_data("suite_pool_dmg.log", log_data)
+        except IOError as error:
+            print("unable to move dmg log:", error)
 
     def test_daos_container(self):
         """Jira ID: DAOS-1568

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -129,7 +129,7 @@ class DaosCoreBase(TestWithServers):
             [
                 "-x", "=".join(["D_LOG_FILE", get_log_file(self.client_log)]),
                 "--map-by node", "-x", "D_LOG_MASK=DEBUG",
-                "-x", "DD_MASK=mgmt,io,md,epc,rebuild",
+                "-x", "DD_MASK=mgmt,io,md,epc,rebuild,test",
                 "-x", "COVFILE=/tmp/test.cov",
                 self.daos_test,
                 "-n", dmg_config_file,

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -1171,11 +1171,12 @@ get_server_config(char *host, char *server_config_file)
 }
 
 int verify_server_log_mask(char *host, char *server_config_file,
-			   char *log_mask){
+			   char *log_mask) {
 	char	command[256];
 	size_t	len = 0;
 	size_t	read;
 	char	*line = NULL;
+	int	rc = 0;
 
 	snprintf(command, sizeof(command),
 		 "ssh %s cat %s", host, server_config_file);
@@ -1191,14 +1192,17 @@ int verify_server_log_mask(char *host, char *server_config_file,
 				print_message(
 					"Expected log_mask = %s, Found %s\n ",
 					log_mask, line);
-				return -DER_INVAL;
+				D_GOTO(out, rc = -DER_INVAL);
 			}
 		}
+
+		D_FREE(line);
 	}
 
+out:
 	pclose(fp);
-	free(line);
-	return 0;
+	D_FREE(line);
+	return rc;
 }
 
 int get_log_file(char *host, char *server_config_file,
@@ -1254,6 +1258,7 @@ int verify_state_in_log(char *host, char *log_file, char *state)
 			if (strstr(line, state) != NULL) {
 				print_message("Found state %s in Log file %s\n",
 					      state, pch);
+				pclose(fp);
 				goto out;
 			}
 		}


### PR DESCRIPTION
- In daos_test, ensure dmg completes before we read output
  from stdout.
- Add optional dmg command line parameter to log to a file.
  This isn't a config option -- we don't want to log unless
  the user decides to do so.
- Improve debug logging for tests_dmg_helpers.c functions. This
  includes output from stderr.
- Add missing pclose calls to other test helper functions.
- Ensure DB_TEST logging is included in client test log.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>