### PR TITLE
DAOS-11192 test: Increased subprocess pattern check timeout (#9811)

### DIFF
--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -341,7 +341,7 @@ class IorCommand(ExecutableCommand):
             logger.info(metric)
         logger.info("\n")
 
-    def check_ior_subprocess_status(self, sub_process, command, pattern_timeout=10):
+    def check_ior_subprocess_status(self, sub_process, command, pattern_timeout=30):
         """Verify the status of the command started as a subprocess.
 
         Continually search the subprocess output for a pattern (self.pattern)


### PR DESCRIPTION
Increased pattern check timeout to 30 secs from 10 secs

Quick-Functional: true
Test-tag: ior_crash
Test-repeat: 10

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>