### PR TITLE
DAOS-11381 control: Optimize Prometheus metrics exporter

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -46,11 +46,11 @@ def is_firmware_mgmt_build(benv):
 
 def get_build_tags(benv):
     "Get custom go build tags."
-    tags = []
+    tags = ["ucx", "spdk"]
     if is_firmware_mgmt_build(benv):
         tags.append("firmware")
-    tags.append("ucx")
-    tags.append("spdk")
+    if not is_release_build(benv):
+        tags.append("pprof")
     return "-tags {}".format(','.join(tags))
 
 

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -51,7 +51,7 @@ def get_build_tags(benv):
         tags.append("firmware")
     if not is_release_build(benv):
         tags.append("pprof")
-    return "-tags {}".format(','.join(tags))
+    return f"-tags {','.join(tags)}"
 
 
 def is_release_build(benv):

--- a/src/control/cmd/dmg/telemetry.go
+++ b/src/control/cmd/dmg/telemetry.go
@@ -347,12 +347,10 @@ func (cmd *metricsListCmd) Execute(args []string) error {
 		return cmd.outputJSON(resp, err)
 	}
 
-	var b strings.Builder
-	err = pretty.PrintMetricsListResp(&b, resp)
+	err = pretty.PrintMetricsListResp(cmd.writer, resp)
 	if err != nil {
 		return err
 	}
-	cmd.Info(b.String())
 	return nil
 }
 
@@ -409,11 +407,9 @@ func (cmd *metricsQueryCmd) Execute(args []string) error {
 		return cmd.outputJSON(resp, err)
 	}
 
-	var b strings.Builder
-	err = pretty.PrintMetricsQueryResp(&b, resp)
+	err = pretty.PrintMetricsQueryResp(cmd.writer, resp)
 	if err != nil {
 		return err
 	}
-	cmd.Info(b.String())
 	return nil
 }

--- a/src/control/lib/control/pprof.go
+++ b/src/control/lib/control/pprof.go
@@ -1,0 +1,29 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build pprof
+// +build pprof
+
+package control
+
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+const (
+	DefaultPProfPort = "6060"
+)
+
+// StartPProf starts the profiling server.
+func StartPProf(log logging.Logger) {
+	go func() {
+		http.ListenAndServe(":"+DefaultPProfPort, nil)
+	}()
+
+	log.Debugf("profiling service started on port %s", DefaultPProfPort)
+}

--- a/src/control/lib/control/pprof_stub.go
+++ b/src/control/lib/control/pprof_stub.go
@@ -1,0 +1,15 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build !pprof
+// +build !pprof
+
+package control
+
+import "github.com/daos-stack/daos/src/control/logging"
+
+func StartPProf(log logging.Logger) {
+	log.Debug("profiling is disabled for this build")
+}

--- a/src/control/lib/telemetry/promexp/collector.go
+++ b/src/control/lib/telemetry/promexp/collector.go
@@ -191,10 +191,24 @@ func appendName(cur, name string) string {
 	return cur + "_" + name
 }
 
+// extractLabels takes a "/"-separated DAOS metric name in order to
+// create a normalized Prometheus name and label map.
+//
+// NB: Prometheus metric names should follow best practices as
+// outlined at https://prometheus.io/docs/practices/naming/
+//
+// In particular, a metric name should describe the measurement,
+// not the entity the measurement is about. In other words, if 4
+// different entities share the same measurement, then there should
+// be a single metric with a label that distinguishes between
+// individual measurement values.
+//
+// Good: pool_started_at {pool="00000000-1111-2222-3333-4444444444"}
+// Bad: pool_00000000_1111_2222_3333_4444444444_started_at
 func extractLabels(in string) (labels labelMap, name string) {
 	labels = make(labelMap)
 	compsIdx := 0
-	comps := strings.Split(in, "/")
+	comps := strings.Split(in, string(telemetry.PathSep))
 	if len(comps) == 0 {
 		return labels, in
 	}
@@ -247,6 +261,11 @@ func extractLabels(in string) (labels labelMap, name string) {
 
 		name = "net"
 		labels["provider"] = comps[compsIdx]
+		compsIdx++
+	case "nvme":
+		name = "nvme"
+		compsIdx++
+		labels["device"] = comps[compsIdx]
 		compsIdx++
 	}
 

--- a/src/control/lib/telemetry/promexp/collector_test.go
+++ b/src/control/lib/telemetry/promexp/collector_test.go
@@ -610,12 +610,19 @@ func TestPromExp_extractLabels(t *testing.T) {
 				"target": "7",
 			},
 		},
-		"pool_tgt_scrubber_corruption": {
+		"pool_tgt_scrubber_corruption_total": {
 			input:   "ID: 1/pool/86eacd2c-eceb-4054-8621-017f4f661fe2/tgt_5/scrubber/corruption/total",
 			expName: "pool_scrubber_corruption_total",
 			expLabels: labelMap{
 				"pool":   "86eacd2c-eceb-4054-8621-017f4f661fe2",
 				"target": "5",
+			},
+		},
+		"nvme_vendor_host_reads_raw": {
+			input:   "ID: 1/nvme/d70505:05:00.0/vendor/host_reads_raw",
+			expName: "nvme_vendor_host_reads_raw",
+			expLabels: labelMap{
+				"device": "d70505:05:00.0",
 			},
 		},
 	} {

--- a/src/control/lib/telemetry/telemetry.go
+++ b/src/control/lib/telemetry/telemetry.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -50,7 +51,7 @@ const (
 	BadIntVal   = int64(BadUintVal >> 1)
 	BadDuration = time.Duration(BadIntVal)
 
-	pathSep = '/'
+	PathSep = filepath.Separator
 )
 
 type (
@@ -172,7 +173,7 @@ func (mb *metricBase) FullPath() string {
 		return "<nil>"
 	}
 
-	return mb.Path() + string(pathSep) + mb.Name()
+	return mb.Path() + string(PathSep) + mb.Name()
 }
 
 func (mb *metricBase) fillMetadata() {
@@ -352,13 +353,13 @@ func (s *Schema) Prune() {
 
 func splitId(id string) (string, string) {
 	i := len(id) - 1
-	for i >= 0 && id[i] != pathSep {
+	for i >= 0 && id[i] != PathSep {
 		i--
 	}
 
 	name := id[i+1:]
 	// Trim trailing separator.
-	if id[i] == pathSep {
+	if id[i] == PathSep {
 		i--
 	}
 
@@ -407,24 +408,26 @@ func NewSchema() *Schema {
 
 }
 
-func visit(hdl *handle, s *Schema, node *C.struct_d_tm_node_t, pathComps []string, out chan<- Metric) {
+func visit(hdl *handle, s *Schema, node *C.struct_d_tm_node_t, pathComps string, out chan<- Metric) {
 	var next *C.struct_d_tm_node_t
 
 	if node == nil {
 		return
 	}
 	name := C.GoString(C.d_tm_get_name(hdl.ctx, node))
-	id := strings.Join(append(pathComps, name), string(pathSep))
+	id := pathComps + string(PathSep) + name
+	if len(pathComps) == 0 {
+		id = name
+	}
 
 	cType := node.dtn_type
-
-	switch {
-	case cType == C.D_TM_DIRECTORY:
+	switch cType {
+	case C.D_TM_DIRECTORY:
 		next = C.d_tm_get_child(hdl.ctx, node)
 		if next != nil {
-			visit(hdl, s, next, append(pathComps, name), out)
+			visit(hdl, s, next, id, out)
 		}
-	case cType == C.D_TM_LINK:
+	case C.D_TM_LINK:
 		next = C.d_tm_follow_link(hdl.ctx, node)
 		if next != nil {
 			// link leads to a directory with the same name
@@ -458,8 +461,7 @@ func CollectMetrics(ctx context.Context, s *Schema, out chan<- Metric) error {
 	}
 
 	node := hdl.root
-	var pathComps []string
-	visit(hdl, s, node, pathComps, out)
+	visit(hdl, s, node, "", out)
 
 	return nil
 }

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -439,6 +439,9 @@ func (srv *server) start(ctx context.Context, shutdown context.CancelFunc) error
 	}()
 	defer srv.grpcServer.Stop()
 
+	// noop on release builds
+	control.StartPProf(srv.log)
+
 	srv.log.Infof("%s v%s (pid %d) listening on %s", build.ControlPlaneName,
 		build.DaosVersion, os.Getpid(), srv.ctlAddr)
 

--- a/src/control/server/telemetry.go
+++ b/src/control/server/telemetry.go
@@ -27,12 +27,7 @@ func regPromEngineSources(ctx context.Context, log logging.Logger, engines []Eng
 		return nil
 	}
 
-	opts := &promexp.CollectorOpts{
-		Ignores: []string{
-			`.*_ID_(\d+)_rank`,
-		},
-	}
-	c, err := promexp.NewCollector(log, opts)
+	c, err := promexp.NewCollector(log, &promexp.CollectorOpts{})
 	if err != nil {
 		return err
 	}

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -66,9 +66,9 @@ class TelemetryUtils():
         'engine_pool_scrubber_csums_current',
         'engine_pool_scrubber_csums_prev',
         'engine_pool_scrubber_csums_total',
-        'engine_pool_scrubber_butes_scrubbed_current',
-        'engine_pool_scrubber_butes_scrubbed_prev',
-        'engine_pool_scrubber_butes_scrubbed_total',
+        'engine_pool_scrubber_bytes_scrubbed_current',
+        'engine_pool_scrubber_bytes_scrubbed_prev',
+        'engine_pool_scrubber_bytes_scrubbed_total',
         'engine_pool_scrubber_last_duration',
         'engine_pool_scrubber_last_duration_max',
         'engine_pool_scrubber_last_duration_mean',
@@ -386,9 +386,9 @@ class TelemetryUtils():
         ENGINE_IO_OPS_TGT_UPDATE_ACTIVE_METRICS +\
         ENGINE_IO_OPS_UPDATE_ACTIVE_METRICS
     ENGINE_NET_METRICS = [
-        "engine_net_<provider>_failed_addr",
-        "engine_net_<provider>_req_timeout",
-        "engine_net_<provider>_uri_lookup_timeout",
+        "engine_net_failed_addr",
+        "engine_net_req_timeout",
+        "engine_net_uri_lookup_timeout",
         "engine_net_uri_lookup_other",
         "engine_net_uri_lookup_self"]
     ENGINE_RANK_METRICS = [
@@ -479,18 +479,6 @@ class TelemetryUtils():
         if with_pools:
             all_metrics_names.extend(self.ENGINE_POOL_METRICS)
             all_metrics_names.extend(self.ENGINE_CONTAINER_METRICS)
-
-        # Add engine network metrics for the configured provider
-        try:
-            provider = re.sub("[+;]", "_", server.manager.job.get_config_value("provider"))
-            if provider == "ofi_tcp":
-                provider = "ofi_tcp_ofi_rxm"
-            elif provider == "ofi_verbs":
-                provider = "ofi_verbs_ofi_rxm"
-        except TypeError:
-            provider = "ofi_tcp_ofi_rxm"
-        net_metrics = [name.replace("<provider>", provider) for name in self.ENGINE_NET_METRICS]
-        all_metrics_names.extend(net_metrics)
 
         # Add NVMe metrics for any NVMe devices configured for this server
         for nvme_list in server.manager.job.get_engine_values("bdev_list"):

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -394,53 +394,53 @@ class TelemetryUtils():
     ENGINE_RANK_METRICS = [
         "engine_rank"]
     ENGINE_NVME_HEALTH_METRICS = [
-        "engine_nvme_<id>_commands_data_units_written",
-        "engine_nvme_<id>_commands_data_units_read",
-        "engine_nvme_<id>_commands_host_write_cmds",
-        "engine_nvme_<id>_commands_host_read_cmds",
-        "engine_nvme_<id>_commands_media_errs",
-        "engine_nvme_<id>_commands_read_errs",
-        "engine_nvme_<id>_commands_write_errs",
-        "engine_nvme_<id>_commands_unmap_errs",
-        "engine_nvme_<id>_commands_checksum_mismatch",
-        "engine_nvme_<id>_power_cycles",
-        "engine_nvme_<id>_commands_ctrl_busy_time",
-        "engine_nvme_<id>_power_on_hours",
-        "engine_nvme_<id>_unsafe_shutdowns"]
+        "engine_nvme_commands_data_units_written",
+        "engine_nvme_commands_data_units_read",
+        "engine_nvme_commands_host_write_cmds",
+        "engine_nvme_commands_host_read_cmds",
+        "engine_nvme_commands_media_errs",
+        "engine_nvme_commands_read_errs",
+        "engine_nvme_commands_write_errs",
+        "engine_nvme_commands_unmap_errs",
+        "engine_nvme_commands_checksum_mismatch",
+        "engine_nvme_power_cycles",
+        "engine_nvme_commands_ctrl_busy_time",
+        "engine_nvme_power_on_hours",
+        "engine_nvme_unsafe_shutdowns"]
     ENGINE_NVME_TEMP_METRICS = [
-        "engine_nvme_<id>_temp_current"]
+        "engine_nvme_temp_current"]
     ENGINE_NVME_TEMP_TIME_METRICS = [
-        "engine_nvme_<id>_temp_warn_time",
-        "engine_nvme_<id>_temp_crit_time"]
+        "engine_nvme_temp_warn_time",
+        "engine_nvme_temp_crit_time"]
     ENGINE_NVME_RELIABILITY_METRICS = [
-        "engine_nvme_<id>_reliability_avail_spare",
-        "engine_nvme_<id>_reliability_avail_spare_threshold"]
+        "engine_nvme_reliability_avail_spare",
+        "engine_nvme_reliability_avail_spare_threshold"]
     ENGINE_NVME_CRIT_WARN_METRICS = [
-        "engine_nvme_<id>_reliability_avail_spare_warn",
-        "engine_nvme_<id>_reliability_reliability_warn",
-        "engine_nvme_<id>_temp_warn",
-        "engine_nvme_<id>_read_only_warn",
-        "engine_nvme_<id>_volatile_mem_warn"]
+        "engine_nvme_reliability_avail_spare_warn",
+        "engine_nvme_reliability_reliability_warn",
+        "engine_nvme_temp_warn",
+        "engine_nvme_read_only_warn",
+        "engine_nvme_volatile_mem_warn"]
     ENGINE_NVME_INTEL_VENDOR_METRICS = [
-        "engine_nvme_<id>_vendor_program_fail_cnt_norm",
-        "engine_nvme_<id>_vendor_program_fail_cnt_raw",
-        "engine_nvme_<id>_vendor_erase_fail_cnt_norm",
-        "engine_nvme_<id>_vendor_erase_fail_cnt_raw",
-        "engine_nvme_<id>_vendor_wear_leveling_cnt_norm",
-        "engine_nvme_<id>_vendor_wear_leveling_cnt_min",
-        "engine_nvme_<id>_vendor_wear_leveling_cnt_max",
-        "engine_nvme_<id>_vendor_wear_leveling_cnt_avg",
-        "engine_nvme_<id>_vendor_endtoend_err_cnt_raw",
-        "engine_nvme_<id>_vendor_crc_err_cnt_raw",
-        "engine_nvme_<id>_vendor_media_wear_raw",
-        "engine_nvme_<id>_vendor_host_reads_raw",
-        "engine_nvme_<id>_vendor_crc_workload_timer_raw",
-        "engine_nvme_<id>_vendor_thermal_throttle_status_raw",
-        "engine_nvme_<id>_vendor_thermal_throttle_event_cnt",
-        "engine_nvme_<id>_vendor_retry_buffer_overflow_cnt",
-        "engine_nvme_<id>_vendor_pll_lock_loss_cnt",
-        "engine_nvme_<id>_vendor_nand_bytes_written",
-        "engine_nvme_<id>_vendor_host_bytes_written"]
+        "engine_nvme_vendor_program_fail_cnt_norm",
+        "engine_nvme_vendor_program_fail_cnt_raw",
+        "engine_nvme_vendor_erase_fail_cnt_norm",
+        "engine_nvme_vendor_erase_fail_cnt_raw",
+        "engine_nvme_vendor_wear_leveling_cnt_norm",
+        "engine_nvme_vendor_wear_leveling_cnt_min",
+        "engine_nvme_vendor_wear_leveling_cnt_max",
+        "engine_nvme_vendor_wear_leveling_cnt_avg",
+        "engine_nvme_vendor_endtoend_err_cnt_raw",
+        "engine_nvme_vendor_crc_err_cnt_raw",
+        "engine_nvme_vendor_media_wear_raw",
+        "engine_nvme_vendor_host_reads_raw",
+        "engine_nvme_vendor_crc_workload_timer_raw",
+        "engine_nvme_vendor_thermal_throttle_status_raw",
+        "engine_nvme_vendor_thermal_throttle_event_cnt",
+        "engine_nvme_vendor_retry_buffer_overflow_cnt",
+        "engine_nvme_vendor_pll_lock_loss_cnt",
+        "engine_nvme_vendor_nand_bytes_written",
+        "engine_nvme_vendor_host_bytes_written"]
     ENGINE_NVME_METRICS = ENGINE_NVME_HEALTH_METRICS +\
         ENGINE_NVME_TEMP_METRICS +\
         ENGINE_NVME_TEMP_TIME_METRICS +\
@@ -479,14 +479,6 @@ class TelemetryUtils():
         if with_pools:
             all_metrics_names.extend(self.ENGINE_POOL_METRICS)
             all_metrics_names.extend(self.ENGINE_CONTAINER_METRICS)
-
-        # Add NVMe metrics for any NVMe devices configured for this server
-        for nvme_list in server.manager.job.get_engine_values("bdev_list"):
-            for nvme in nvme_list if nvme_list is not None else []:
-                # Replace the '<id>' placeholder with the actual NVMe ID
-                nvme_id = nvme.replace(":", "_").replace(".", "_")
-                nvme_metrics = [name.replace("<id>", nvme_id) for name in self.ENGINE_NVME_METRICS]
-                all_metrics_names.extend(nvme_metrics)
 
         return all_metrics_names
 
@@ -741,15 +733,6 @@ class TelemetryUtils():
         data = {}
         if specific_metrics is None:
             specific_metrics = self.ENGINE_NVME_METRICS
-
-        # Add NVMe metrics for any NVMe devices configured for this server
-        for nvme_list in server.manager.job.get_engine_values("bdev_list"):
-            for nvme in nvme_list if nvme_list is not None else []:
-                # Replace the '<id>' placeholder with the actual NVMe ID
-                nvme_id = nvme.replace(":", "_").replace(".", "_")
-                specific_metrics = [
-                    name.replace("<id>", nvme_id)
-                    for name in specific_metrics]
 
         info = self.get_metrics(",".join(specific_metrics))
         self.log.info("NVMe Telemetry Information")

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -474,11 +474,18 @@ class TelemetryUtils():
         all_metrics_names = list(self.ENGINE_EVENT_METRICS)
         all_metrics_names.extend(self.ENGINE_SCHED_METRICS)
         all_metrics_names.extend(self.ENGINE_IO_METRICS)
+        all_metrics_names.extend(self.ENGINE_NET_METRICS)
         all_metrics_names.extend(self.ENGINE_RANK_METRICS)
         all_metrics_names.extend(self.ENGINE_DMABUFF_METRICS)
         if with_pools:
             all_metrics_names.extend(self.ENGINE_POOL_METRICS)
             all_metrics_names.extend(self.ENGINE_CONTAINER_METRICS)
+
+        # Add the NVMe metrics if the test is run on a hardware cluster.
+        for nvme_list in server.manager.job.get_engine_values("bdev_list"):
+            if nvme_list and len(nvme_list) > 0:
+                all_metrics_names.extend(self.ENGINE_NVME_METRICS)
+                break
 
         return all_metrics_names
 


### PR DESCRIPTION
The older implementation used regexps for picking out labels,
but this was highly inefficient with large numbers of pools.

Also fixes a couple of bugs in the prometheus naming scheme:
  * Network provider name should be a label value, not part of the metric name
  * NVMe device address should be a label value, not part of the metric name

Features: telemetry
Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
