### PR TITLE
DAOS-9602 chk: verify container label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,7 +341,6 @@ pipeline {
                         checkPatch user: GITHUB_USER_USR,
                                    password: GITHUB_USER_PSW,
                                    ignored_files: 'src/control/vendor/*:' +
-                                                  'src/chk/chk_internal.h:' +
                                                   '*.pb-c.[ch]:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:' +

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -76,6 +76,12 @@ struct chk_cont_bundle {
 	uuid_t				 ccb_uuid;
 };
 
+struct chk_cont_label_cb_args {
+	struct chk_cont_list_aggregator	*cclca_aggregator;
+	struct cont_svc			*cclca_svc;
+	struct chk_pool_rec		*cclca_cpr;
+};
+
 static int
 chk_cont_hkey_size(void)
 {
@@ -1105,6 +1111,271 @@ out:
 	return result;
 }
 
+static daos_prop_t *
+chk_engine_build_label_prop(d_iov_t *label)
+{
+	daos_prop_t	*prop;
+
+	prop = daos_prop_alloc(1);
+	if (prop != NULL) {
+		prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
+		D_STRNDUP(prop->dpp_entries[0].dpe_str, label->iov_buf, label->iov_len);
+		if (prop->dpp_entries[0].dpe_str == NULL) {
+			daos_prop_free(prop);
+			prop = NULL;
+		}
+	}
+
+	return prop;
+}
+
+static int
+chk_engine_cont_set_label(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr,
+			  struct cont_svc *svc, d_iov_t *label)
+{
+	struct chk_instance		*ins = cpr->cpr_ins;
+	struct chk_property		*prop = &ins->ci_prop;
+	struct chk_bookmark		*cbk = &cpr->cpr_bk;
+	daos_prop_t			*prop_in = NULL;
+	struct chk_report_unit		 cru = { 0 };
+	Chk__CheckInconsistClass	 cla;
+	Chk__CheckInconsistAction	 act;
+	char				 msg[320] = { 0 };
+	uint32_t			 options[2];
+	uint32_t			 option_nr = 0;
+	int				 decision = -1;
+	int				 result = 0;
+	int				 rc = 0;
+
+	cla = CHK__CHECK_INCONSIST_CLASS__CIC_CONT_BAD_LABEL;
+	act = prop->cp_policies[cla];
+	cbk->cb_statistics.cs_total++;
+
+	if (label != NULL) {
+		switch (act) {
+		case CHK__CHECK_INCONSIST_ACTION__CIA_DEFAULT:
+			/*
+			 * If the container label in the container service (cont_svc::cs_uuids)
+			 * exists but does not match the label in the container property, then
+			 * trust the container service and reset the one in container property
+			 * by default.
+			 *
+			 * Fall through.
+			 */
+		case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS:
+			if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
+				cbk->cb_statistics.cs_repaired++;
+			} else {
+				prop_in = chk_engine_build_label_prop(label);
+				if (prop_in == NULL)
+					D_GOTO(out, result = -DER_NOMEM);
+
+				result = ds_cont_set_label(svc, ccr->ccr_uuid, prop_in, false);
+				if (result != 0)
+					cbk->cb_statistics.cs_failed++;
+				else
+					cbk->cb_statistics.cs_repaired++;
+			}
+			break;
+		case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
+			/* Report the inconsistency without repair. */
+			cbk->cb_statistics.cs_ignored++;
+			break;
+		default:
+			/*
+			 * If the specified action is not applicable to the inconsistency,
+			 * then switch to interaction mode for the decision from admin.
+			 *
+			 * Fall through.
+			 */
+		case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
+			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
+			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+			option_nr = 2;
+			break;
+		}
+	} else {
+		switch (act) {
+		case CHK__CHECK_INCONSIST_ACTION__CIA_DEFAULT:
+			/*
+			 * If the container label in the container service (cont_svc::cs_uuids)
+			 * does not exists, but the one in the container property is there, then
+			 * trust the label in container property and add it to container service
+			 * by default.
+			 *
+			 * Fall through.
+			 */
+		case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET:
+			if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
+				cbk->cb_statistics.cs_repaired++;
+			} else {
+				result = ds_cont_set_label(svc, ccr->ccr_uuid,
+							   ccr->ccr_label_prop, true);
+				if (result != 0)
+					cbk->cb_statistics.cs_failed++;
+				else
+					cbk->cb_statistics.cs_repaired++;
+			}
+			break;
+		case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
+			/* Report the inconsistency without repair. */
+			cbk->cb_statistics.cs_ignored++;
+			break;
+		default:
+			/*
+			 * If the specified action is not applicable to the inconsistency,
+			 * then switch to interaction mode for the decision from admin.
+			 *
+			 * Fall through.
+			 */
+		case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
+			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET;
+			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+			option_nr = 2;
+			break;
+		}
+	}
+
+report:
+	cru.cru_gen = cbk->cb_gen;
+	cru.cru_cla = cla;
+	cru.cru_act = option_nr != 0 ? CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT : act;
+	cru.cru_rank = dss_self_rank();
+	cru.cru_option_nr = option_nr;
+	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
+	cru.cru_cont = (uuid_t *)&ccr->ccr_uuid;
+	snprintf(msg, 319,
+		 "Check engine detects inconsistent container label: SVC %s vs property %s",
+		 label != NULL ? (char *)label->iov_buf : "(null)", ccr->ccr_label_prop != NULL ?
+		 (char *)ccr->ccr_label_prop->dpp_entries[0].dpe_str : "(null)");
+	cru.cru_msg = msg;
+	cru.cru_options = options;
+	cru.cru_result = result;
+
+	rc = chk_engine_report(&cru, &decision);
+
+	D_CDEBUG(result != 0 || rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_ENGINE" detects inconsistent container label for "DF_UUIDF"/"DF_UUIDF
+		 ": %s vs %s, action %u (%s), handle_rc %d, report_rc %d, decision %d\n",
+		 DP_ENGINE(ins), DP_UUID(cpr->cpr_uuid), DP_UUID(ccr->ccr_uuid),
+		 label != NULL ? (char *)label->iov_buf : "(null)", ccr->ccr_label_prop != NULL ?
+		 (char *)ccr->ccr_label_prop->dpp_entries[0].dpe_str : "(null)", act,
+		 option_nr ? "need interact" : "no interact", result, rc, decision);
+
+	if (rc != 0 && option_nr > 0) {
+		cbk->cb_statistics.cs_failed++;
+		result = rc;
+	}
+
+	if (result != 0 || option_nr == 0)
+		goto out;
+
+	option_nr = 0;
+
+	switch (decision) {
+
+ignore:
+	default:
+		D_ERROR(DF_ENGINE" got invalid decision %d for inconsistent container label for "
+			DF_UUIDF"/"DF_UUIDF". Ignore the inconsistency.\n",
+			DP_ENGINE(ins), decision, DP_UUID(cpr->cpr_uuid), DP_UUID(ccr->ccr_uuid));
+		/*
+		 * Invalid option, ignore the inconsistency.
+		 *
+		 * Fall through.
+		 */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
+		cbk->cb_statistics.cs_ignored++;
+		break;
+	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS:
+		if (label == NULL)
+			goto ignore;
+
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
+		if (!(prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN)) {
+			prop_in = chk_engine_build_label_prop(label);
+			if (prop_in == NULL)
+				D_GOTO(out, result = -DER_NOMEM);
+		}
+
+		/* Fall through. */
+	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET:
+		act = decision;
+		if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
+			cbk->cb_statistics.cs_repaired++;
+		} else {
+			result = ds_cont_set_label(svc, ccr->ccr_uuid,
+						   prop_in != NULL ? prop_in : ccr->ccr_label_prop,
+						   prop_in != NULL ? false : true);
+			if (result != 0)
+				cbk->cb_statistics.cs_failed++;
+			else
+				cbk->cb_statistics.cs_repaired++;
+		}
+		break;
+	}
+
+	goto report;
+
+out:
+#if 0
+	/*
+	 * It is not fatal even if failed to repair inconsistent container label,
+	 * then do not skip current container for subsequent DAOS check.
+	 */
+	ccr->ccr_skip = 0;
+#endif
+
+	if (prop_in != NULL)
+		daos_prop_free(prop_in);
+
+	chk_engine_post_repair(ins, &result);
+
+	return result;
+}
+
+static int
+chk_engine_cont_label_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *arg)
+{
+	struct chk_cont_label_cb_args	*cclca = arg;
+	struct chk_cont_rec		*ccr;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
+	int				 rc = 0;
+	bool				 failout;
+
+	if (cclca->cclca_cpr->cpr_ins->ci_prop.cp_flags & CHK__CHECK_FLAG__CF_FAILOUT)
+		failout = true;
+	else
+		failout = false;
+
+	d_iov_set(&kiov, val->iov_buf, val->iov_len);
+	d_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cclca->cclca_aggregator->ccla_toh, &kiov, &riov);
+	if (rc == -DER_NONEXIST)
+		/*
+		 * The container only exists in the container service RDB, but not on
+		 * any pool shard yet. It will be created on related pool shards when
+		 * be opened next time.
+		 */
+		D_GOTO(out, rc = 0);
+
+	if (rc != 0)
+		D_GOTO(out, rc = (failout ? rc : 0));
+
+	ccr = riov.iov_buf;
+	ccr->ccr_label_checked = 1;
+
+	if (ccr->ccr_label_prop == NULL ||
+	    strncmp(key->iov_buf, ccr->ccr_label_prop->dpp_entries[0].dpe_str,
+		    DAOS_PROP_LABEL_MAX_LEN) != 0)
+		rc = chk_engine_cont_set_label(cclca->cclca_cpr, ccr, cclca->cclca_svc, key);
+
+out:
+	return rc;
+}
+
 static int
 chk_engine_cont_cleanup(struct chk_pool_rec *cpr, struct ds_pool_svc *ds_svc,
 			struct chk_cont_list_aggregator *aggregator)
@@ -1112,6 +1383,7 @@ chk_engine_cont_cleanup(struct chk_pool_rec *cpr, struct ds_pool_svc *ds_svc,
 	struct chk_instance		*ins = cpr->cpr_ins;
 	struct cont_svc			*svc;
 	struct chk_cont_rec		*ccr;
+	struct chk_cont_label_cb_args	 cclca = { 0 };
 	int				 rc = 0;
 	bool				 failout;
 
@@ -1143,6 +1415,21 @@ chk_engine_cont_cleanup(struct chk_pool_rec *cpr, struct ds_pool_svc *ds_svc,
 		rc = chk_engine_cont_orphan(cpr, ccr, svc);
 		if (rc != 0)
 			goto out;
+	}
+
+	cclca.cclca_aggregator = aggregator;
+	cclca.cclca_svc = svc;
+	cclca.cclca_cpr = cpr;
+	rc = ds_cont_iterate_labels(svc, chk_engine_cont_label_cb, &cclca);
+	if (rc != 0)
+		goto out;
+
+	d_list_for_each_entry(ccr, &aggregator->ccla_list, ccr_link) {
+		if (!ccr->ccr_label_checked && ccr->ccr_label_prop != NULL) {
+			rc = chk_engine_cont_set_label(cpr, ccr, svc, NULL);
+			if (rc != 0)
+				goto out;
+		}
 	}
 
 out:

--- a/src/chk/chk_vos.c
+++ b/src/chk/chk_vos.c
@@ -291,7 +291,9 @@ chk_traverse_pools(sys_db_trav_cb_t cb, void *args)
 	int	rc;
 
 	rc = chk_db_traverse(cb, args);
-	if (rc < 0)
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+	else if (rc < 0)
 		D_ERROR("Failed to traverse pools on rank %u for pause: "DF_RC"\n",
 			dss_self_rank(), DP_RC(rc));
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -236,7 +236,7 @@ ds_cont_bcast_create(crt_context_t ctx, struct cont_svc *svc,
 		     crt_opcode_t opcode, crt_rpc_t **rpc)
 {
 	return ds_pool_bcast_create(ctx, svc->cs_pool, DAOS_CONT_MODULE, opcode,
-				    DAOS_CONT_VERSION, rpc, NULL, NULL);
+				    DAOS_CONT_VERSION, rpc, NULL, NULL, NULL);
 }
 
 void

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -58,7 +58,7 @@ static struct daos_prop_co_roots dummy_roots;
 struct daos_prop_entry cont_prop_entries_default_v0[CONT_PROP_NUM_V0] = {
 	{
 		.dpe_type	= DAOS_PROP_CO_LABEL,
-		.dpe_str	= "container_label_not_set",
+		.dpe_str	= DAOS_PROP_NO_CO_LABEL,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
 		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,
@@ -124,7 +124,7 @@ struct daos_prop_entry cont_prop_entries_default_v0[CONT_PROP_NUM_V0] = {
 struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 	{
 		.dpe_type	= DAOS_PROP_CO_LABEL,
-		.dpe_str	= "container_label_not_set",
+		.dpe_str	= DAOS_PROP_NO_CO_LABEL,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
 		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,

--- a/src/include/daos/btree_class.h
+++ b/src/include/daos/btree_class.h
@@ -113,4 +113,9 @@ extern btr_ops_t dbtree_recx_ops;
  */
 #define DBTREE_CLASS_CHK_PA (DBTREE_DSM_BEGIN + 10)
 
+/**
+ * DAOS check container tree, the key is container uuid
+ */
+#define DBTREE_CLASS_CHK_CONT (DBTREE_DSM_BEGIN + 11)
+
 #endif /* __DAOS_SRV_BTREE_CLASS_H__ */

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -564,6 +564,9 @@ daos_label_is_valid(const char *label)
 /* For the case of no label is set for the pool. */
 #define DAOS_PROP_NO_PO_LABEL		"pool_label_not_set"
 
+/* For the case of no label is set for the container. */
+#define DAOS_PROP_NO_CO_LABEL		"container_label_not_set"
+
 /** daos properties, for pool or container */
 typedef struct {
 	/** number of entries */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -257,4 +257,8 @@ int ds_cont_ec_eph_delete(struct ds_pool *pool, uuid_t cont_uuid, int tgt_idx);
 
 void ds_cont_ec_timestamp_update(struct ds_cont_child *cont);
 
+int ds_cont_existence_check(struct cont_svc *svc, uuid_t uuid, daos_prop_t **prop);
+
+int ds_cont_destroy_orphan(struct cont_svc *svc, uuid_t uuid);
+
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -261,4 +261,8 @@ int ds_cont_existence_check(struct cont_svc *svc, uuid_t uuid, daos_prop_t **pro
 
 int ds_cont_destroy_orphan(struct cont_svc *svc, uuid_t uuid);
 
+int ds_cont_iterate_labels(struct cont_svc *svc, rdb_iterate_cb_t cb, void *arg);
+
+int ds_cont_set_label(struct cont_svc *svc, uuid_t uuid, daos_prop_t *prop_in, bool for_svc);
+
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -272,6 +272,7 @@ int ds_pool_svc_flush_map(struct ds_pool_svc *ds_svc, struct pool_map *map);
 int ds_pool_svc_update_label(struct ds_pool_svc *ds_svc, const char *label);
 int ds_pool_svc_evict_all(struct ds_pool_svc *ds_svc);
 struct ds_pool *ds_pool_svc2pool(struct ds_pool_svc *ds_svc);
+struct cont_svc *ds_pool_ps2cs(struct ds_pool_svc *ds_svc);
 void ds_pool_disable_exclude(void);
 void ds_pool_enable_exclude(void);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -158,7 +158,7 @@ void ds_pool_child_put(struct ds_pool_child *child);
 int ds_pool_bcast_create(crt_context_t ctx, struct ds_pool *pool,
 			 enum daos_module_id module, crt_opcode_t opcode,
 			 uint32_t version, crt_rpc_t **rpc, crt_bulk_t bulk_hdl,
-			 d_rank_list_t *excluded_list);
+			 d_rank_list_t *excluded_list, void *priv);
 
 int ds_pool_map_buf_get(uuid_t uuid, d_iov_t *iov, uint32_t *map_ver);
 
@@ -271,6 +271,7 @@ int ds_pool_svc_load_map(struct ds_pool_svc *ds_svc, struct pool_map **map);
 int ds_pool_svc_flush_map(struct ds_pool_svc *ds_svc, struct pool_map *map);
 int ds_pool_svc_update_label(struct ds_pool_svc *ds_svc, const char *label);
 int ds_pool_svc_evict_all(struct ds_pool_svc *ds_svc);
+struct ds_pool *ds_pool_svc2pool(struct ds_pool_svc *ds_svc);
 void ds_pool_disable_exclude(void);
 void ds_pool_enable_exclude(void);
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1945,7 +1945,7 @@ bcast_create(crt_context_t ctx, struct pool_svc *svc, crt_opcode_t opcode,
 	     crt_bulk_t bulk_hdl, crt_rpc_t **rpc)
 {
 	return ds_pool_bcast_create(ctx, svc->ps_pool, DAOS_POOL_MODULE, opcode,
-				    DAOS_POOL_VERSION, rpc, bulk_hdl, NULL);
+				    DAOS_POOL_VERSION, rpc, bulk_hdl, NULL, NULL);
 }
 
 /**
@@ -7184,4 +7184,10 @@ out_lock:
 	rdb_tx_end(&tx);
 out:
 	return rc;
+}
+
+struct ds_pool *
+ds_pool_svc2pool(struct ds_pool_svc *ds_svc)
+{
+	return pool_ds2svc(ds_svc)->ps_pool;
 }

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7191,3 +7191,9 @@ ds_pool_svc2pool(struct ds_pool_svc *ds_svc)
 {
 	return pool_ds2svc(ds_svc)->ps_pool;
 }
+
+struct cont_svc *
+ds_pool_ps2cs(struct ds_pool_svc *ds_svc)
+{
+	return pool_ds2svc(ds_svc)->ps_cont_svc;
+}

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -68,7 +68,7 @@ pool_glance(uuid_t uuid, char *path, struct ds_pool_clue *clue_out)
 			D_GOTO(out_root, rc = -DER_IO);
 		}
 
-		if (memcmp(DAOS_PROP_NO_PO_LABEL, value.iov_buf, value.iov_len) == 0) {
+		if (strncmp(DAOS_PROP_NO_PO_LABEL, value.iov_buf, value.iov_len) == 0) {
 			clue_out->pc_label_len = 0;
 		} else {
 			D_ALLOC(clue_out->pc_label, value.iov_len + 1);

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -79,7 +79,7 @@ int
 ds_pool_bcast_create(crt_context_t ctx, struct ds_pool *pool,
 		     enum daos_module_id module, crt_opcode_t opcode,
 		     uint32_t version, crt_rpc_t **rpc, crt_bulk_t bulk_hdl,
-		     d_rank_list_t *excluded_list)
+		     d_rank_list_t *excluded_list, void *priv)
 {
 	d_rank_list_t	excluded;
 	crt_opcode_t		opc;
@@ -106,7 +106,7 @@ ds_pool_bcast_create(crt_context_t ctx, struct ds_pool *pool,
 	opc = DAOS_RPC_OPCODE(opcode, module, version);
 	rc = crt_corpc_req_create(ctx, pool->sp_group,
 			  excluded.rl_nr == 0 ? NULL : &excluded,
-			  opc, bulk_hdl/* co_bulk_hdl */, NULL /* priv */,
+			  opc, bulk_hdl/* co_bulk_hdl */, priv,
 			  0 /* flags */, crt_tree_topo(CRT_TREE_KNOMIAL, 32),
 			  rpc);
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -932,7 +932,7 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 	rc = ds_pool_bcast_create(dss_get_module_info()->dmi_ctx,
 				  pool, DAOS_REBUILD_MODULE,
 				  REBUILD_OBJECTS_SCAN, DAOS_REBUILD_VERSION,
-				  &rpc, NULL, excluded);
+				  &rpc, NULL, excluded, NULL);
 	if (rc != 0) {
 		D_ERROR("pool map broad cast failed: rc "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);


### PR DESCRIPTION
If the container label in the container service (cont_svc::cs_uuids)
exists but does not match the label in the container property, then
trust the container service and reset the one in container property.

If the container label in the container service (cont_svc::cs_uuids)
does not exists, but the one in the container property is there, then
trust the label in container property and add it to container service.

Signed-off-by: Fan Yong <fan.yong@intel.com>