### PR TITLE
DAOS-11291 test: rebuild/container_rf.py:RbldContRfTest.test_rebuild_with_container_rf - tearDown timeout

### DIFF
--- a/src/tests/ftest/rebuild/container_rf.yaml
+++ b/src/tests/ftest/rebuild/container_rf.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 6
   test_clients: 1
-timeout: 360
+timeout: 480
 server_config:
   name: daos_server
   servers:


### PR DESCRIPTION
Description: increase container_rf testtime with 120 sec

Test-tag: test_rebuild_with_container_rf
Test-repeat: 10
Signed-off-by: Ding Ho ding-hwa.ho@intel.com