### PR TITLE
DAOS-11191 test: Increase osa/dmg_negative_test.py timeout. (#9054)

### DIFF
--- a/src/tests/ftest/osa/dmg_negative_test.yaml
+++ b/src/tests/ftest/osa/dmg_negative_test.yaml
@@ -7,7 +7,7 @@ hosts:
 # other than hosts.
 extra_servers:
   test_servers: server-3
-timeout: 1200
+timeout: 1800
 skip_add_log_msg: True
 server_config:
   name: daos_server
@@ -66,4 +66,3 @@ test_sequence:
     - ["0", "1,2", "Pass"]
     - ["4", "0,2", "Pass"]
     - ["5", "1,2", "Pass"]
-


### PR DESCRIPTION
Skip-unit-tests: true
Test-tag: osa_dmg_negative_test
Test-repeat: 10

The osa/dmg_negative_test.py tests is taking around 18-19 minutes. There is
possibility the test crosses 20 minutes on some clusters. The timeout seems to
on borderline. Increasing the test timeout from 1200 to 1800 (to be on safe side).

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>