### PR TITLE
DAOS-11383 rebuild: abort the stale rebuild job

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -65,6 +65,12 @@ struct ds_pool {
 	uint32_t		sp_stopping:1,
 				sp_fetch_hdls:1,
 				sp_need_discard:1;
+
+	/* pool_uuid + map version + leader term + rebuild generation define a
+	 * rebuild job.
+	 */
+	uint32_t		sp_rebuild_gen;
+
 	int			sp_reintegrating;
 	/** path to ephemeral metrics */
 	char			sp_path[D_TM_MAX_NAME_LEN];

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -36,7 +36,7 @@ typedef enum {
 			  "Unknown")
 
 int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
-			uint32_t rebuild_gen, daos_epoch_t stable_eph,
+			daos_epoch_t stable_eph,
 			struct pool_target_id_list *tgts,
 			daos_rebuild_opc_t rebuild_op, uint64_t delay_sec);
 int ds_rebuild_query(uuid_t pool_uuid,

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5637,7 +5637,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	D_DEBUG(DB_MD, "map ver %u/%u\n", map_version ? *map_version : -1,
 		tgt_map_ver);
 	if (tgt_map_ver != 0) {
-		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver, 0, rebuild_eph,
+		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver, rebuild_eph,
 					 &target_list, op, delay);
 		if (rc != 0) {
 			D_ERROR("rebuild fails rc: "DF_RC"\n", DP_RC(rc));
@@ -5779,7 +5779,7 @@ pool_extend_internal(uuid_t pool_uuid, struct rsvc_hint *hint, uint32_t nnodes,
 	}
 
 	/* Schedule an extension rebuild for those targets */
-	rc = ds_rebuild_schedule(svc->ps_pool, *map_version_p, 0, extend_eph, &tgts,
+	rc = ds_rebuild_schedule(svc->ps_pool, *map_version_p, extend_eph, &tgts,
 				 RB_OP_EXTEND, 2);
 	if (rc != 0) {
 		D_ERROR("failed to schedule extend rc: "DF_RC"\n", DP_RC(rc));

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -217,7 +217,6 @@ struct rebuild_task {
 	daos_epoch_t			dst_reclaim_eph;
 	uint64_t			dst_schedule_time;
 	uint32_t			dst_map_ver;
-	uint32_t			dst_rebuild_gen;
 };
 
 /* Per pool structure in TLS to check pool rebuild status

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -968,10 +968,13 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	 */
 	d_list_for_each_entry(rpt, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
 		if (uuid_compare(rpt->rt_pool_uuid, rsi->rsi_pool_uuid) == 0 &&
-		    rpt->rt_rebuild_ver < rsi->rsi_rebuild_ver) {
-			D_INFO(DF_UUID" rebuild %u/"DF_U64" < incoming rebuild %u/"DF_U64"\n",
-			       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver,
-			       rpt->rt_leader_term, rsi->rsi_rebuild_ver,
+		    ((rpt->rt_rebuild_ver < rsi->rsi_rebuild_ver) ||
+		    (rpt->rt_rebuild_op == rsi->rsi_rebuild_op &&
+		     rpt->rt_rebuild_ver == rsi->rsi_rebuild_ver &&
+		     rpt->rt_rebuild_gen < rsi->rsi_rebuild_gen))) {
+			D_INFO(DF_UUID" %s %u/"DF_U64" < incoming rebuild %u/"DF_U64"\n",
+			       DP_UUID(rpt->rt_pool_uuid), RB_OP_STR(rpt->rt_rebuild_op),
+			       rpt->rt_rebuild_ver, rpt->rt_leader_term, rsi->rsi_rebuild_ver,
 			       rsi->rsi_leader_term);
 			rpt->rt_abort = 1;
 		}

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1178,10 +1178,6 @@ rebuild_leader_start(struct ds_pool *pool, struct rebuild_task *task,
 	uint64_t	leader_term;
 	int		rc;
 
-	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID", rebuild version=%u/%u, op=%s\n",
-		DP_UUID(pool->sp_uuid), task->dst_map_ver, task->dst_rebuild_gen,
-		RB_OP_STR(task->dst_rebuild_op));
-
 	rc = ds_pool_svc_term_get(pool->sp_uuid, &leader_term);
 	if (rc) {
 		D_ERROR("Get pool service term failed: "DF_RC"\n",
@@ -1189,13 +1185,17 @@ rebuild_leader_start(struct ds_pool *pool, struct rebuild_task *task,
 		D_GOTO(out, rc);
 	}
 
-	rc = rebuild_prepare(pool, task->dst_map_ver, task->dst_rebuild_gen,
+	rc = rebuild_prepare(pool, task->dst_map_ver, ++pool->sp_rebuild_gen,
 			     leader_term, task->dst_reclaim_eph, &task->dst_tgts,
 			     task->dst_rebuild_op, p_rgt);
 	if (rc) {
 		D_ERROR("rebuild prepare failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
+
+	D_INFO("rebuild "DF_UUID", rebuild version=%u/%u, op=%s\n",
+	       DP_UUID(pool->sp_uuid), task->dst_map_ver, pool->sp_rebuild_gen,
+	       RB_OP_STR(task->dst_rebuild_op));
 
 	/* broadcast scan RPC to all targets */
 	rc = rebuild_scan_broadcast(pool, *p_rgt, &task->dst_tgts, task->dst_rebuild_op);
@@ -1216,9 +1216,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 	int rc1;
 
 	if (rgt == NULL) {
-		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-					 task->dst_reclaim_eph, &task->dst_tgts,
-					 task->dst_rebuild_op, 5);
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver, task->dst_reclaim_eph,
+					 &task->dst_tgts, task->dst_rebuild_op, 5);
 		return rc;
 	}
 
@@ -1226,7 +1225,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		/* If current job failed */
 		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
 		if (task->dst_rebuild_op == RB_OP_RECLAIM) {
-			rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
+			rc = ds_rebuild_schedule(pool, task->dst_map_ver,
 						 rgt->rgt_stable_epoch, &task->dst_tgts,
 						 RB_OP_RECLAIM, 5);
 			return rc;
@@ -1234,7 +1233,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 
 		/* Schedule reclaim to clean up current op, if scan/migrate already start */
 		if (rgt->rgt_init_scan) {
-			rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
+			rc = ds_rebuild_schedule(pool, task->dst_map_ver,
 						 rgt->rgt_stable_epoch, &task->dst_tgts,
 						 RB_OP_RECLAIM, 5);
 			if (rc)
@@ -1243,14 +1242,14 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			/* Let's keep go ahead to retry anyway. */
 		}
 		/* Then retry */
-		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver,
 					 rgt->rgt_stable_epoch, &task->dst_tgts,
 					 task->dst_rebuild_op, 5);
 	} else if (task->dst_rebuild_op == RB_OP_REINT || task->dst_rebuild_op == RB_OP_EXTEND) {
 		/* Otherwise schedule reclaim for reintegrate/extend/upgrade. */
 		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
-		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-					 rgt->rgt_reclaim_epoch, &task->dst_tgts, RB_OP_RECLAIM, 5);
+		rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_reclaim_epoch,
+					 &task->dst_tgts, RB_OP_RECLAIM, 5);
 		if (rc != 0)
 			D_ERROR("reschedule reclaim, "DF_UUID" failed: "DF_RC"\n",
 				DP_UUID(task->dst_pool_uuid), DP_RC(rc));
@@ -1578,8 +1577,7 @@ rebuild_leader_stop(const uuid_t pool_uuid, unsigned int ver, unsigned int gen,
 	d_list_for_each_entry_safe(task, task_tmp, &rebuild_gst.rg_queue_list,
 				   dst_list) {
 		if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0 &&
-		    (ver == (unsigned int)(-1) || task->dst_map_ver == ver) &&
-		    (gen == (unsigned int)(-1) || task->dst_rebuild_gen == gen))
+		    (ver == (unsigned int)(-1) || task->dst_map_ver == ver))
 			rebuild_task_destroy(task);
 	}
 
@@ -1646,7 +1644,7 @@ rebuild_print_list_update(const uuid_t uuid, const uint32_t map_ver,
  * pool.
  */
 int
-ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen,
+ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 		    daos_epoch_t reclaim_eph, struct pool_target_id_list *tgts,
 		    daos_rebuild_opc_t rebuild_op, uint64_t delay_sec)
 {
@@ -1680,7 +1678,6 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen
 
 	new_task->dst_schedule_time = cur_ts + delay_sec;
 	new_task->dst_map_ver = map_ver;
-	new_task->dst_rebuild_gen = rebuild_gen;
 	new_task->dst_rebuild_op = rebuild_op;
 	new_task->dst_reclaim_eph = reclaim_eph;
 	uuid_copy(new_task->dst_pool_uuid, pool->sp_uuid);
@@ -1707,9 +1704,11 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen
 		if (new_task->dst_map_ver > task->dst_map_ver)
 			continue;
 
+		/* Reclaim task should always be put to the first, i.e. executed
+		 * before any other tasks with same version.
+		 */
 		if (new_task->dst_rebuild_op != RB_OP_RECLAIM &&
-		    new_task->dst_map_ver == task->dst_map_ver &&
-		    new_task->dst_rebuild_gen > task->dst_rebuild_gen)
+		    new_task->dst_map_ver == task->dst_map_ver)
 			continue;
 
 		inserted_pos = &task->dst_list;
@@ -1760,10 +1759,10 @@ regenerate_task_internal(struct ds_pool *pool, struct pool_target *tgts,
 		id_list.pti_number = 1;
 
 		if (rebuild_op == RB_OP_FAIL || rebuild_op == RB_OP_DRAIN)
-			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_fseq, 0,
+			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_fseq,
 						 eph, &id_list, rebuild_op, 0);
 		else
-			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_in_ver, 0,
+			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_in_ver,
 						 eph, &id_list, rebuild_op, 0);
 
 		if (rc) {
@@ -2056,14 +2055,14 @@ rebuild_tgt_status_check_ult(void *arg)
 			}
 		}
 
-		D_INFO("ver %d obj "DF_U64" rec "DF_U64" size "
-			DF_U64" scan done %d pull done %d scan gl done %d"
-			" gl done %d abort %u status %d\n",
-			rpt->rt_rebuild_ver, iv.riv_obj_count,
-			iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done,
-			iv.riv_pull_done, rpt->rt_global_scan_done,
-			rpt->rt_global_done, rpt->rt_abort, iv.riv_status);
-
+		D_INFO(DF_UUID" ver %d gen %u obj "DF_U64" rec "DF_U64" size "
+		       DF_U64" scan done %d pull done %d scan gl done %d"
+		       " gl done %d status %d abort %s\n",
+		       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver,
+		       rpt->rt_pool->sp_rebuild_gen,
+		       iv.riv_obj_count, iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done,
+		       iv.riv_pull_done, rpt->rt_global_scan_done,
+		       rpt->rt_global_done, iv.riv_status, rpt->rt_abort ? "yes" : "no");
 		if (rpt->rt_global_done || rpt->rt_abort)
 			break;
 


### PR DESCRIPTION
Abort the stale rebuild job once it receive the
rebuild job with higher rebuild generation.

Signed-off-by: Di Wang <di.wang@intel.com>