### PR TITLE
DAOS-11186 tests: Bump crt_timeout for boundary.py

### DIFF
--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -3,9 +3,12 @@ hosts:
 timeout: 3600
 server_config:
   name: daos_server
+  crt_timeout: 60
   servers:
     scm_size: 600
     targets: 1
+    env_vars:
+      - DAOS_MD_CAP=1024
 pool:
   name: daos_server
   scm_size: 200M


### PR DESCRIPTION
The 10-s crt_timeout seems to be too short for boundary.py, which works
with 20,000 or 30,000 containers. See the Jira ticket for the numbers.
This patch bumps the crt_timeout used by boundary.py to 60 s.

In addition, this test requires a larger DAOS_MD_CAP value that seems to
be provided by some special weekly settings. In order to make the test
work in non-weekly settings, this patch adds the DAOS_MD_CAP value
explicitly.

Test-tag: container_boundary
Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true