### PR TITLE
DAOS-11376 test: Bump timeout for test_dfuse_daos_build_wb

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -104,7 +104,7 @@ class DaosBuild(DfuseTestBase):
         cache_time = '60m'
         # Timeout.  This is per command so up to double this or more as there are two scons
         # commands which can both take a long time.
-        build_time = 10
+        build_time = 15
 
         self.load_dfuse(self.hostlist_clients)
 


### PR DESCRIPTION
Test-tag: test_dfuse_daos_build_wb
Test-repeat: 10

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
