### PR TITLE
DAOS-11035 dtx: fix some DXT related issues

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1364,8 +1364,7 @@ ds_dtx_resync(void *arg)
 	int				 rc;
 
 	rc = dtx_resync(ddra->pool->spc_hdl, ddra->pool->spc_uuid,
-			ddra->co_uuid, ddra->pool->spc_map_version,
-			false, true);
+			ddra->co_uuid, ddra->pool->spc_map_version, false);
 	if (rc != 0)
 		D_WARN("Fail to resync some DTX(s) for the pool/cont "
 		       DF_UUID"/"DF_UUID" that may affect subsequent "

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -778,6 +778,7 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_verified = 0;
 	dth->dth_aborted = 0;
 	dth->dth_already = 0;
+	dth->dth_need_validation = 0;
 
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_cnt;
@@ -1028,6 +1029,8 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 			     (flags & DTX_FOR_MIGRATION) ? true : false, false,
 			     (flags & DTX_RESEND) ? true : false,
 			     (flags & DTX_PREPARED) ? true : false, dth);
+	if (rc == 0 && sub_modification_cnt > 0)
+		rc = vos_dtx_attach(dth, false, (flags & DTX_PREPARED) ? true : false);
 
 	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, leader "
 		DF_UOID", dti_cos_cnt %d, flags %x: "DF_RC"\n",
@@ -1100,7 +1103,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 	if (daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
 
-	if (dth->dth_pinned || dth->dth_prepared) {
+	if (dth->dth_need_validation) {
 		/* During waiting for bulk data transfer or other non-leaders, the DTX
 		 * status may be changes by others (such as DTX resync or DTX refresh)
 		 * by race. Let's check it.
@@ -1346,6 +1349,8 @@ dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 			     (flags & DTX_FOR_MIGRATION) ? true : false,
 			     (flags & DTX_IGNORE_UNCOMMITTED) ? true : false,
 			     (flags & DTX_RESEND) ? true : false, false, dth);
+	if (rc == 0 && sub_modification_cnt > 0)
+		rc = vos_dtx_attach(dth, false, false);
 
 	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, "
 		"dti_cos_cnt %d, flags %x: "DF_RC"\n",

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -39,7 +39,6 @@ struct dtx_resync_args {
 	daos_epoch_t		 epoch;
 	uint32_t		 resync_version;
 	uint32_t		 discard_version;
-	uint32_t		 resync_all:1;
 };
 
 static inline void
@@ -407,9 +406,6 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		mbs = dre->dre_dte.dte_mbs;
 		D_ASSERT(mbs->dm_tgt_cnt > 0);
 
-		if (mbs->dm_dte_flags & DTE_LEADER)
-			goto commit;
-
 		rc = dtx_is_leader(pool, dra, dre);
 		if (rc <= 0) {
 			if (rc < 0)
@@ -521,22 +517,13 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	if (ent->ie_dtx_tgt_cnt == 0)
 		return 0;
 
-	if (ent->ie_dtx_flags & DTE_LEADER) {
-		/* Pool map refresh, non-discard case, I am still the leader, do nothing. */
-		if (!dra->resync_all)
-			return 0;
-
-		/*
-		 * Open container, old committable DTX entries are not in the CoS cache.
-		 * Then handle the DTX entries with old epoch (dtx_epoch < resync_epoch).
-		 */
-		if (ent->ie_epoch > dra->epoch)
-			return 0;
-	} else {
-		/* Leader switch only can happen for old DTX entries (dtx_ver < resync_ver). */
-		if (ent->ie_dtx_ver >= dra->resync_version)
-			return 0;
-	}
+	/*
+	 * Current DTX resync may be shared by pool map refresh and container open. If it is
+	 * sponsored by pool map refresh, then it is possible that resync version is smaller
+	 * than some DTX entries that also need to be resynced. So here, we only trust epoch.
+	 */
+	if (ent->ie_epoch > dra->epoch)
+		return 0;
 
 	D_ASSERT(ent->ie_dtx_mbs_dsize > 0);
 
@@ -572,8 +559,7 @@ out:
 }
 
 int
-dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
-	   bool block, bool resync_all)
+dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, bool block)
 {
 	struct ds_cont_child		*cont = NULL;
 	struct ds_pool			*pool;
@@ -643,10 +629,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	dra.cont = cont;
 	dra.resync_version = ver;
 	dra.epoch = crt_hlc_get();
-	if (resync_all)
-		dra.resync_all = 1;
-	else
-		dra.resync_all = 0;
 	D_INIT_LIST_HEAD(&dra.tables.drh_list);
 	dra.tables.drh_count = 0;
 
@@ -716,8 +698,7 @@ container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	uuid_copy(scan_arg->co_uuid, entry->ie_couuid);
-	rc = dtx_resync(iter_param->ip_hdl, arg->pool_uuid, entry->ie_couuid,
-			arg->version, true, false);
+	rc = dtx_resync(iter_param->ip_hdl, arg->pool_uuid, entry->ie_couuid, arg->version, true);
 	if (rc)
 		D_ERROR(DF_UUID" dtx resync failed: rc %d\n",
 			DP_UUID(arg->pool_uuid), rc);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -820,7 +820,7 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 
 out:
 	rc2 = dtx_rpc_post(&head, tree_hdl, &dra, &helper, rc);
-	if (rc2 > 0 || rc2 == -DER_NONEXIST)
+	if (rc2 > 0 || rc2 == -DER_NONEXIST || rc2 == -DER_EXCLUDED)
 		rc2 = 0;
 
 	if (dtis != &dti)

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -87,6 +87,8 @@ struct dtx_handle {
 					 dth_aborted:1,
 					 /* The modification is done by others. */
 					 dth_already:1,
+					 /* Need validation on leader before commit/committable. */
+					 dth_need_validation:1,
 					 /* Ignore other uncommitted DTXs. */
 					 dth_ignore_uncommitted:1;
 
@@ -310,8 +312,7 @@ struct dtx_scan_args {
 	uint32_t	version;
 };
 
-int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
-	       uint32_t ver, bool block, bool resync_all);
+int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, bool block);
 void dtx_resync_ult(void *arg);
 
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -42,9 +42,10 @@ vos_dtx_rsrvd_fini(struct dtx_handle *dth);
  *
  * \param dth		[IN]	The dtx handle
  * \param persistent	[IN]	Save the DTX entry in persistent storage if set.
+ * \param exist		[IN]	Related DTX entry exists or not.
  */
 int
-vos_dtx_attach(struct dtx_handle *dth, bool persistent);
+vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist);
 
 /**
  * Detach the DTX entry from the DTX handle.

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -69,6 +69,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_verified = 0;
 	dth->dth_aborted = 0;
 	dth->dth_already = 0;
+	dth->dth_need_validation = 0;
 
 	dth->dth_dti_cos_count = 0;
 	dth->dth_dti_cos = NULL;

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -186,9 +186,10 @@ dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 out:
 	D_DEBUG(DB_IO,
 		"%s hit uncommitted DTX "DF_DTI" at %d: dth %p (dist %s), lid=%d, flags %x/%x, "
-		"may need %s retry.\n", hit_again ? "Repeat" : "First", DP_DTI(&DAE_XID(dae)), pos,
-		dth, dth != NULL && dth->dth_dist ? "yes" : "no", DAE_LID(dae),
-		DAE_FLAGS(dae), DAE_MBS_FLAGS(dae), s_try ? "server" : "client");
+		"ver %u/%u, may need %s retry.\n", hit_again ? "Repeat" : "First",
+		DP_DTI(&DAE_XID(dae)), pos, dth, dth != NULL && dth->dth_dist ? "yes" : "no",
+		DAE_LID(dae), DAE_FLAGS(dae), DAE_MBS_FLAGS(dae), DAE_VER(dae),
+		dth != NULL ? dth->dth_ver : 0, s_try ? "server" : "client");
 
 	return -DER_INPROGRESS;
 }
@@ -1229,15 +1230,16 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		return ALB_UNAVAILABLE;
 	}
 
-	/* For rebuild fetch, if hit non-committed DTX, has to ask the
-	 * sponsor to wait and retry, otherwise, the new in-rebuilding
-	 * target may miss some data.
-	 * Under such case, DTX resync on related leader server is not
-	 * finished yet. The DTX entry may be stale, need refresh with
-	 * the leader.
+	/*
+	 * Up layer rebuild logic guarantees that the rebuild scan will not be
+	 * triggered until DTX resync has been done on all related targets. So
+	 * here, if rebuild logic hits non-committed DTX entry, it must be for
+	 * new IO that version is not older than rebuild, then it is invisible
+	 * to rebuild. Related new IO corresponding to such non-committed DTX
+	 * has already been sent to the in-rebuilding target.
 	 */
 	if (intent == DAOS_INTENT_MIGRATION)
-		return dtx_inprogress(dae, dth, false, true, 6);
+		return ALB_UNAVAILABLE;
 
 	if (intent == DAOS_INTENT_DEFAULT) {
 		if (!(DAE_FLAGS(dae) & DTE_LEADER) ||
@@ -1402,7 +1404,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		return 0;
 	}
 
-	if (dth->dth_pinned && !dth->dth_verified) {
+	if (dth->dth_need_validation && !dth->dth_verified) {
 		rc = vos_dtx_validation(dth);
 		switch (rc) {
 		case DTX_ST_INITED:
@@ -1793,7 +1795,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 		if (mbs != NULL)
 			dae->dae_maybe_shared = 1;
 
-		if (dae->dae_dbd == NULL)
+		if (dae->dae_dbd == NULL || dae->dae_dth != NULL)
 			return -DER_INPROGRESS;
 
 		if (epoch != NULL) {
@@ -2758,27 +2760,42 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 }
 
 int
-vos_dtx_attach(struct dtx_handle *dth, bool persistent)
+vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist)
 {
 	struct vos_container	*cont;
 	struct umem_instance	*umm = NULL;
 	struct vos_dtx_blob_df	*dbd = NULL;
 	struct vos_dtx_cmt_ent	*dce = NULL;
+	struct vos_dtx_act_ent	*dae;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	bool			 began = false;
 	int			 rc = 0;
 
 	if (!dtx_is_valid_handle(dth))
 		return 0;
 
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
 	if (dth->dth_ent != NULL) {
 		if (!persistent || dth->dth_active)
 			return 0;
 	} else {
 		D_ASSERT(dth->dth_pinned == 0);
-	}
 
-	cont = vos_hdl2cont(dth->dth_coh);
-	D_ASSERT(cont != NULL);
+		if (exist) {
+			d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
+			d_iov_set(&riov, NULL, 0);
+			rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+			if (rc != 0)
+				goto out;
+
+			dae = riov.iov_buf;
+			dth->dth_ent = dae;
+			dth->dth_need_validation = dae->dae_need_validation;
+		}
+	}
 
 	if (persistent) {
 		struct vos_cont_df	*cont_df;
@@ -2804,16 +2821,16 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent)
 	if (dth->dth_ent == NULL) {
 		rc = vos_dtx_alloc(dbd, dth);
 	} else if (dbd != NULL) {
-		struct vos_dtx_act_ent	*dae = dth->dth_ent;
-
 		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
+		dae = dth->dth_ent;
 		dae->dae_df_off = cont->vc_cont_df->cd_dtx_active_tail +
 			offsetof(struct vos_dtx_blob_df, dbd_active_data) +
 			sizeof(struct vos_dtx_act_ent_df) * dbd->dbd_index;
 		dae->dae_dbd = dbd;
 	}
 
+out:
 	if (rc == 0) {
 		if (persistent) {
 			dth->dth_active = 1;
@@ -2821,10 +2838,7 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent)
 		} else {
 			dth->dth_pinned = 1;
 		}
-	}
-
-out:
-	if (rc != 0) {
+	} else {
 		if (dth->dth_ent != NULL) {
 			dth->dth_pinned = 0;
 			vos_dtx_cleanup_internal(dth);
@@ -2837,8 +2851,7 @@ out:
 	if (began) {
 		rc = umem_tx_end(umm, rc);
 		if (dce != NULL) {
-			struct vos_dtx_act_ent	*dae = dth->dth_ent;
-
+			dae = dth->dth_ent;
 			vos_dtx_post_handle(cont, &dae, &dce, 1,
 					    false, rc != 0 ? true : false);
 			dth->dth_ent = NULL;

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -132,7 +132,8 @@ dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t next /
 		dae = rec_iov.iov_buf;
 	}
 
-	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted) {
+	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+	       dae->dae_dth != NULL) {
 		if (oiter->oit_linear) {
 			if (dae->dae_link.next ==
 			    &oiter->oit_cont->vc_dtx_act_list) {
@@ -203,7 +204,8 @@ dtx_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 				 sizeof(struct vos_dtx_act_ent));
 			dae = rec_iov.iov_buf;
 		}
-	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted);
+	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+		 dae->dae_dth != NULL);
 
 out:
 	return rc;
@@ -242,6 +244,16 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	D_ASSERT(!dae->dae_committable);
 	D_ASSERT(!dae->dae_committed);
 	D_ASSERT(!dae->dae_aborted);
+	D_ASSERT(dae->dae_dth == NULL);
+
+	/*
+	 * The DTX entry is returned via the iteration. The upper layer caller, for DTX resync
+	 * or DTX cleanup, may abort it sometime later. Before being aborted, it may re-attach
+	 * to some DTX handle for handling resent request. Then there is race between them. So
+	 * before become committable or being committed by RPC handler, needs to check whether
+	 * it has been aborted or not.
+	 */
+	dae->dae_need_validation = 1;
 
 	it_entry->ie_epoch = DAE_EPOCH(dae);
 	it_entry->ie_dtx_xid = DAE_XID(dae);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -326,6 +326,8 @@ struct vos_dtx_act_ent {
 					 dae_committed:1,
 					 dae_aborted:1,
 					 dae_maybe_shared:1,
+					 /* Need validation on leader before commit/committable. */
+					 dae_need_validation:1,
 					 dae_prepared:1;
 };
 


### PR DESCRIPTION
It includes the following fixes:

1. Skip new non-committed DTX when check visibility for rebuild

Up layer rebuild logic guarantees that the rebuild scan will not be
triggered until DTX resync has been done on all related targets. So
here, if rebuild logic hits non-committed DTX entry, it must be for
new IO that version is not older than rebuild, then it is invisible
to rebuild. Related new IO corresponding to such non-committed DTX
has already been sent to the in-rebuilding target.

2. Skip new DTX during DTX resync

Even if current target was the DTX leader, but if the version of
the DTX is older than DTX resync version, we still need to resync
it. Because its sponsor may be dead (if not dead, then skip it).

3. Pin DTX entry in DRAM when DTX start

Originally, we pin the DTX entry in DRAM conditionally before ULT
yield. But it is relative complex to forecast whether the ULT may
yield or not. This patch much simplifies related logic and avoids
missing some corner cases.

4. Validate DTX entry before become committable or being committed

If the DTX entry is returned via the iteration. The upper layer caller,
for DTX resync or DTX cleanup, may abort it sometime later. Before being
aborted, it may attach to some DTX handle for handling resent request.
Then there is race between them. So before become committable or being
committed by RPC handler, needs to check whether it has been aborted or
not.

5. Unify DTX resync for pool map refresh and container open

That will simplify DTX resync logic, cleanup confused parameter
"resync_all", and avoid missing to handle some DTX entry if need
DTX resync for both cases by race.

Signed-off-by: Fan Yong <fan.yong@intel.com>