### PR TITLE
DAOS-11236 object: do not log DER_TX_RESTART as error

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3883,10 +3883,10 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			rc = 0;
 
 		if (rc != 0) {
-			D_ERROR("Failed to set read TS for obj "DF_UOID
-				", DTX "DF_DTI": "DF_RC"\n",
-				DP_UOID(dcsr->dcsr_oid),
-				DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
+			D_CDEBUG(rc != -DER_INPROGRESS && rc != -DER_TX_RESTART,
+				 DLOG_ERR, DB_IO, "Failed to set read TS for obj "
+				 DF_UOID", DTX "DF_DTI": "DF_RC"\n", DP_UOID(dcsr->dcsr_oid),
+				 DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
 			goto out;
 		}
 	}


### PR DESCRIPTION
It is normal that the CPD RPC handler detects DTX conflict
with other transactions. Under such case, it will generate
some log messages that should not use D_ERROR().

Signed-off-by: Fan Yong <fan.yong@intel.com>