### PR TITLE
DAOS-11419 object: oclass_id2name return oclass name even if not pred…

### DIFF
--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -94,11 +94,27 @@ daos_oclass_id2name(daos_oclass_id_t oc_id, char *str)
 		strcpy(str, "UNKNOWN");
 		return -1;
 	}
-	if (nr_grps == oc->oc_grp_nr)
+	if (nr_grps == oc->oc_grp_nr) {
 		strcpy(str, oc->oc_name);
-	else
-	/* update oc_name according to nr_grps */
-		strcpy(str, "UNKNOWN");
+	} else {
+		/** update oclass name with group number */
+		char *p = oc->oc_name;
+		int i = 0;
+
+		while (p[i] != 'G') {
+			str[i] = p[i];
+			i++;
+		}
+		str[i++] = 'G';
+		p = &str[i];
+		str[i++] = 0;
+		i = snprintf(p, MAX_OBJ_CLASS_NAME_LEN - strlen(str), "%u", nr_grps);
+		if (i < 0) {
+			D_ERROR("Failed to encode object class name\n");
+			strcpy(str, "UNKNOWN");
+			return -1;
+		}
+	}
 	return 0;
 }
 


### PR DESCRIPTION
…efined

daos_oclass_id2name returns "UNKNOWN" oclass name for ones that have a group
number that is not MAX or 1. This patch fixes the name to append the group
number to the object class if it's not predefined.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>