### PR TITLE
DAOS-11381 control: Optimize Prometheus metrics exporter (#9983)

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -41,11 +41,12 @@ def is_firmware_mgmt_build(benv):
 
 def get_build_tags(benv):
     "Get custom go build tags."
-    tags = []
+    tags = ["ucx"]
     if is_firmware_mgmt_build(benv):
         tags.append("firmware")
-    tags.append("ucx")
-    return "-tags {}".format(','.join(tags))
+    if not is_release_build(benv):
+        tags.append("pprof")
+    return f"-tags {','.join(tags)}"
 
 def is_release_build(benv):
     "Check whether this build is for release."

--- a/src/control/cmd/dmg/telemetry.go
+++ b/src/control/cmd/dmg/telemetry.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -347,12 +347,10 @@ func (cmd *metricsListCmd) Execute(args []string) error {
 		return cmd.outputJSON(resp, err)
 	}
 
-	var b strings.Builder
-	err = pretty.PrintMetricsListResp(&b, resp)
+	err = pretty.PrintMetricsListResp(cmd.writer, resp)
 	if err != nil {
 		return err
 	}
-	cmd.log.Info(b.String())
 	return nil
 }
 
@@ -409,11 +407,9 @@ func (cmd *metricsQueryCmd) Execute(args []string) error {
 		return cmd.outputJSON(resp, err)
 	}
 
-	var b strings.Builder
-	err = pretty.PrintMetricsQueryResp(&b, resp)
+	err = pretty.PrintMetricsQueryResp(cmd.writer, resp)
 	if err != nil {
 		return err
 	}
-	cmd.log.Info(b.String())
 	return nil
 }

--- a/src/control/lib/control/pprof.go
+++ b/src/control/lib/control/pprof.go
@@ -1,0 +1,29 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build pprof
+// +build pprof
+
+package control
+
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+const (
+	DefaultPProfPort = "6060"
+)
+
+// StartPProf starts the profiling server.
+func StartPProf(log logging.Logger) {
+	go func() {
+		http.ListenAndServe(":"+DefaultPProfPort, nil)
+	}()
+
+	log.Debugf("profiling service started on port %s", DefaultPProfPort)
+}

--- a/src/control/lib/control/pprof_stub.go
+++ b/src/control/lib/control/pprof_stub.go
@@ -1,0 +1,15 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+//go:build !pprof
+// +build !pprof
+
+package control
+
+import "github.com/daos-stack/daos/src/control/logging"
+
+func StartPProf(log logging.Logger) {
+	log.Debug("profiling is disabled for this build")
+}

--- a/src/control/lib/telemetry/promexp/collector.go
+++ b/src/control/lib/telemetry/promexp/collector.go
@@ -170,73 +170,124 @@ func sanitizeMetricName(in string) string {
 	}, strings.TrimLeft(in, "/"))
 }
 
-func parseNameSubstr(labels labelMap, name string, matchRE string, replacement string, assignLabels func(labelMap, []string)) string {
-	re := regexp.MustCompile(matchRE)
-	matches := re.FindStringSubmatch(name)
-	if len(matches) > 0 {
-		assignLabels(labels, matches)
-
-		if strings.HasSuffix(matches[0], "_") {
-			replacement += "_"
-		}
-		name = re.ReplaceAllString(name, replacement)
+func matchLabel(labels labelMap, input, match, label string) bool {
+	if !strings.HasPrefix(input, match) {
+		return false
 	}
 
-	return name
+	splitStr := strings.SplitN(input, "_", 2)
+	if len(splitStr) == 2 {
+		labels[label] = splitStr[1]
+		return true
+	}
+	return false
 }
 
+func appendName(cur, name string) string {
+	if cur == "" {
+		return name
+	}
+	return cur + "_" + name
+}
+
+// extractLabels takes a "/"-separated DAOS metric name in order to
+// create a normalized Prometheus name and label map.
+//
+// NB: Prometheus metric names should follow best practices as
+// outlined at https://prometheus.io/docs/practices/naming/
+//
+// In particular, a metric name should describe the measurement,
+// not the entity the measurement is about. In other words, if 4
+// different entities share the same measurement, then there should
+// be a single metric with a label that distinguishes between
+// individual measurement values.
+//
+// Good: pool_started_at {pool="00000000-1111-2222-3333-4444444444"}
+// Bad: pool_00000000_1111_2222_3333_4444444444_started_at
 func extractLabels(in string) (labels labelMap, name string) {
-	name = sanitizeMetricName(in)
-
 	labels = make(labelMap)
-
-	// Clean up metric names and parse out useful labels
-
-	ID_re := regexp.MustCompile(`ID_+(\d+)_?`)
-	name = ID_re.ReplaceAllString(name, "")
-
-	name = extractLatencySize(labels, name, "fetch")
-	name = extractLatencySize(labels, name, "update")
-
-	name = parseNameSubstr(labels, name, `_?xs_(\d+)`, "",
-		func(labels labelMap, matches []string) {
-			labels["xstream"] = matches[1]
-		})
-
-	name = parseNameSubstr(labels, name, `_?tgt_(\d+)`, "",
-		func(labels labelMap, matches []string) {
-			labels["target"] = matches[1]
-		})
-
-	name = parseNameSubstr(labels, name, `_?ctx_(\d+)`, "",
-		func(labels labelMap, matches []string) {
-			labels["context"] = matches[1]
-		})
-
-	name = parseNameSubstr(labels, name, `net_+(\d+)`, "net",
-		func(labels labelMap, matches []string) {
-			labels["rank"] = matches[1]
-		})
-
-	getHexRE := func(numDigits int) string {
-		return strings.Repeat(`[[:xdigit:]]`, numDigits)
+	compsIdx := 0
+	comps := strings.Split(in, string(telemetry.PathSep))
+	if len(comps) == 0 {
+		return labels, in
 	}
-	uuid_re := fmt.Sprintf("%s_%s_%s_%s_%s", getHexRE(8), getHexRE(4), getHexRE(4),
-		getHexRE(4), getHexRE(12))
 
-	name = parseNameSubstr(labels, name, `pool_+(`+uuid_re+`)`, "pool",
-		func(labels labelMap, matches []string) {
-			labels["pool"] = strings.Replace(matches[1], "_", "-", -1)
-		})
+	if strings.HasPrefix(comps[compsIdx], "ID") {
+		if len(comps) == 1 {
+			return labels, ""
+		}
+		compsIdx++
+	}
+
+	switch comps[compsIdx] {
+	case "pool":
+		name = "pool"
+		compsIdx++
+		labels["pool"] = comps[compsIdx]
+		compsIdx++
+		switch comps[compsIdx] {
+		case "ops":
+			compsIdx++
+			name += "_ops_" + comps[compsIdx]
+			compsIdx++
+		}
+	case "io":
+		name = "io"
+		compsIdx++
+		switch comps[compsIdx] {
+		case "latency":
+			compsIdx++
+			name += "_latency_" + comps[compsIdx]
+			compsIdx++
+			labels["size"] = comps[compsIdx]
+			compsIdx++
+		case "ops":
+			compsIdx++
+			name += "_ops_" + comps[compsIdx]
+			compsIdx++
+		default:
+			name += "_" + comps[compsIdx]
+			compsIdx++
+		}
+	case "net":
+		compsIdx++
+		if comps[compsIdx] == "uri" {
+			compsIdx++
+			name = "net_uri_" + comps[compsIdx]
+			compsIdx++
+			break
+		}
+
+		name = "net"
+		labels["provider"] = comps[compsIdx]
+		compsIdx++
+	case "nvme":
+		name = "nvme"
+		compsIdx++
+		labels["device"] = comps[compsIdx]
+		compsIdx++
+	}
+
+	for {
+		if len(comps) == compsIdx {
+			break
+		}
+
+		switch {
+		case matchLabel(labels, comps[compsIdx], "tgt_", "target"):
+			compsIdx++
+		case matchLabel(labels, comps[compsIdx], "xs_", "xstream"):
+			compsIdx++
+		case matchLabel(labels, comps[compsIdx], "ctx_", "context"):
+			compsIdx++
+		default:
+			name = appendName(name, comps[compsIdx])
+			compsIdx++
+		}
+	}
+
+	name = sanitizeMetricName(name)
 	return
-}
-
-func extractLatencySize(labels labelMap, name, latencyType string) string {
-	return parseNameSubstr(labels, name, `_+latency_+`+latencyType+`_+((?:GT)?[0-9]+[A-Z]?B)`,
-		"_latency_"+latencyType,
-		func(labels labelMap, matches []string) {
-			labels["size"] = matches[1]
-		})
 }
 
 func (es *EngineSource) Collect(log logging.Logger, ch chan<- *rankMetric) {
@@ -367,8 +418,8 @@ func newRankMetric(log logging.Logger, rank uint32, m telemetry.Metric) *rankMet
 	var name string
 	rm.labels, name = extractLabels(m.FullPath())
 	rm.labels["rank"] = fmt.Sprintf("%d", rm.rank)
+	rm.baseName = "engine_" + name
 
-	rm.baseName = strings.Join([]string{"engine", name}, "_")
 	desc := m.Desc()
 
 	switch rm.metric.Type() {
@@ -391,6 +442,9 @@ func newRankMetric(log logging.Logger, rank uint32, m telemetry.Metric) *rankMet
 
 func (c *Collector) isIgnored(name string) bool {
 	for _, re := range c.ignoredMetrics {
+		// TODO: We may want to look into removing the use of regexp here
+		// in favor of a less-flexible but more efficient approach.
+		// For the moment, use of ignored metrics should be avoided if possible.
 		if re.MatchString(name) {
 			return true
 		}

--- a/src/control/lib/telemetry/promexp/collector_test.go
+++ b/src/control/lib/telemetry/promexp/collector_test.go
@@ -518,87 +518,119 @@ func TestPromExp_extractLabels(t *testing.T) {
 		expName   string
 		expLabels labelMap
 	}{
-		"empty": {},
-		"nothing to change": {
-			input:   "goodname",
-			expName: "goodname",
+		"empty": {
+			expLabels: labelMap{},
 		},
-		"fix spaces": {
-			input:   "a fine name",
-			expName: "a_fine_name",
+		"ID stripped": {
+			input:     "ID: 123",
+			expLabels: labelMap{},
 		},
-		"ID": {
-			input:   "ID: 2_stat",
-			expName: "stat",
+		"net_uri_lookup_self": {
+			input:     "ID: 1/net/uri/lookup_self",
+			expName:   "net_uri_lookup_self",
+			expLabels: labelMap{},
 		},
-		"io latency B": {
-			input:   "io_latency_fetch_16B",
+		"net_provider_req_timeout": {
+			input:   "ID: 0/net/ofi+tcp;ofi_rxm/req_timeout/ctx_0",
+			expName: "net_req_timeout",
+			expLabels: labelMap{
+				"provider": "ofi+tcp;ofi_rxm",
+				"context":  "0",
+			},
+		},
+		"dmabuff_queued_reqs": {
+			input:   "ID: 0/dmabuff/queued_reqs/tgt_6",
+			expName: "dmabuff_queued_reqs",
+			expLabels: labelMap{
+				"target": "6",
+			},
+		},
+		"sched_total_time": {
+			input:   "ID: 0/sched/total_time/xs_3",
+			expName: "sched_total_time",
+			expLabels: labelMap{
+				"xstream": "3",
+			},
+		},
+		"io latency fetch": {
+			input:   "ID: 2/io/latency/fetch/16B",
 			expName: "io_latency_fetch",
 			expLabels: labelMap{
 				"size": "16B",
 			},
 		},
-		"io latency KB": {
-			input:   "io_latency_update_128KB",
+		"io latency update": {
+			input:   "ID: /io/latency/update/128KB",
 			expName: "io_latency_update",
 			expLabels: labelMap{
 				"size": "128KB",
 			},
 		},
-		"io latency MB": {
-			input:   "io_latency_update_256MB",
-			expName: "io_latency_update",
-			expLabels: labelMap{
-				"size": "256MB",
-			},
-		},
 		"io latency >size": {
-			input:   "io_latency_update_GT4MB",
+			input:   "ID: 1/io/latency/update/GT4MB",
 			expName: "io_latency_update",
 			expLabels: labelMap{
 				"size": "GT4MB",
 			},
 		},
-		"net rank": {
-			input:   "net_15_stat",
-			expName: "net_stat",
+		"io_dtx_committable": {
+			input:   "ID: 0/io/dtx/committable/tgt_5",
+			expName: "io_dtx_committable",
 			expLabels: labelMap{
-				"rank": "15",
+				"target": "5",
 			},
 		},
-		"pool UUID": {
-			input:   "pool_11111111_2222_3333_4444_555555555555_info",
-			expName: "pool_info",
+		"io_ops_update_active": {
+			input:   "ID: 0/io/ops/update_active/tgt_2",
+			expName: "io_ops_update_active",
+			expLabels: labelMap{
+				"target": "2",
+			},
+		},
+		"io_ops_tgt_punch_latency": {
+			input:   "ID: 0/io/ops/tgt_punch/latency/tgt_2",
+			expName: "io_ops_tgt_punch_latency",
+			expLabels: labelMap{
+				"target": "2",
+			},
+		},
+		"pool_started_at": {
+			input:   "ID: 0/pool/11111111-2222-3333-4444-555555555555/started_at",
+			expName: "pool_started_at",
 			expLabels: labelMap{
 				"pool": "11111111-2222-3333-4444-555555555555",
 			},
 		},
-		"target": {
-			input:   "io_update_latency_tgt_1",
-			expName: "io_update_latency",
+		"pool_ops_tgt_dkey_punch": {
+			input:   "ID: 0/pool/11111111-2222-3333-4444-555555555555/ops/tgt_dkey_punch/tgt_7",
+			expName: "pool_ops_tgt_dkey_punch",
 			expLabels: labelMap{
-				"target": "1",
+				"pool":   "11111111-2222-3333-4444-555555555555",
+				"target": "7",
 			},
 		},
-		"context": {
-			input:   "failed_addr_ctx_1",
-			expName: "failed_addr",
+		"pool_tgt_scrubber_corruption_total": {
+			input:   "ID: 1/pool/86eacd2c-eceb-4054-8621-017f4f661fe2/tgt_5/scrubber/corruption/total",
+			expName: "pool_scrubber_corruption_total",
 			expLabels: labelMap{
-				"context": "1",
+				"pool":   "86eacd2c-eceb-4054-8621-017f4f661fe2",
+				"target": "5",
+			},
+		},
+		"nvme_vendor_host_reads_raw": {
+			input:   "ID: 1/nvme/d70505:05:00.0/vendor/host_reads_raw",
+			expName: "nvme_vendor_host_reads_raw",
+			expLabels: labelMap{
+				"device": "d70505:05:00.0",
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			labels, name := extractLabels(tc.input)
 
-			test.AssertEqual(t, tc.expName, name, "")
-			test.AssertEqual(t, len(tc.expLabels), len(labels), "wrong number of labels")
-			for key, val := range labels {
-				expVal, exists := tc.expLabels[key]
-				if !exists {
-					t.Fatalf("key %q was not expected", key)
-				}
-				test.AssertEqual(t, expVal, val, "incorrect value")
+			test.AssertEqual(t, name, tc.expName, "")
+			if diff := cmp.Diff(labels, tc.expLabels); diff != "" {
+				t.Errorf("labels mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/src/control/lib/telemetry/telemetry.go
+++ b/src/control/lib/telemetry/telemetry.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -49,7 +50,7 @@ const (
 	BadIntVal   = int64(BadUintVal >> 1)
 	BadDuration = time.Duration(BadIntVal)
 
-	pathSep = '/'
+	PathSep = filepath.Separator
 )
 
 type (
@@ -171,7 +172,7 @@ func (mb *metricBase) FullPath() string {
 		return "<nil>"
 	}
 
-	return mb.Path() + string(pathSep) + mb.Name()
+	return mb.Path() + string(PathSep) + mb.Name()
 }
 
 func (mb *metricBase) fillMetadata() {
@@ -351,13 +352,13 @@ func (s *Schema) Prune() {
 
 func splitId(id string) (string, string) {
 	i := len(id) - 1
-	for i >= 0 && id[i] != pathSep {
+	for i >= 0 && id[i] != PathSep {
 		i--
 	}
 
 	name := id[i+1:]
 	// Trim trailing separator.
-	if id[i] == pathSep {
+	if id[i] == PathSep {
 		i--
 	}
 
@@ -406,24 +407,26 @@ func NewSchema() *Schema {
 
 }
 
-func visit(hdl *handle, s *Schema, node *C.struct_d_tm_node_t, pathComps []string, out chan<- Metric) {
+func visit(hdl *handle, s *Schema, node *C.struct_d_tm_node_t, pathComps string, out chan<- Metric) {
 	var next *C.struct_d_tm_node_t
 
 	if node == nil {
 		return
 	}
 	name := C.GoString(C.d_tm_get_name(hdl.ctx, node))
-	id := strings.Join(append(pathComps, name), string(pathSep))
+	id := pathComps + string(PathSep) + name
+	if len(pathComps) == 0 {
+		id = name
+	}
 
 	cType := node.dtn_type
-
-	switch {
-	case cType == C.D_TM_DIRECTORY:
+	switch cType {
+	case C.D_TM_DIRECTORY:
 		next = C.d_tm_get_child(hdl.ctx, node)
 		if next != nil {
-			visit(hdl, s, next, append(pathComps, name), out)
+			visit(hdl, s, next, id, out)
 		}
-	case cType == C.D_TM_LINK:
+	case C.D_TM_LINK:
 		next = C.d_tm_follow_link(hdl.ctx, node)
 		if next != nil {
 			// link leads to a directory with the same name
@@ -457,8 +460,7 @@ func CollectMetrics(ctx context.Context, s *Schema, out chan<- Metric) error {
 	}
 
 	node := hdl.root
-	var pathComps []string
-	visit(hdl, s, node, pathComps, out)
+	visit(hdl, s, node, "", out)
 
 	return nil
 }

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -430,6 +430,9 @@ func (srv *server) start(ctx context.Context, shutdown context.CancelFunc) error
 	}()
 	defer srv.grpcServer.Stop()
 
+	// noop on release builds
+	control.StartPProf(srv.log)
+
 	srv.log.Infof("%s v%s (pid %d) listening on %s", build.ControlPlaneName,
 		build.DaosVersion, os.Getpid(), srv.ctlAddr)
 

--- a/src/control/server/telemetry.go
+++ b/src/control/server/telemetry.go
@@ -27,12 +27,7 @@ func regPromEngineSources(ctx context.Context, log logging.Logger, engines []Eng
 		return nil
 	}
 
-	opts := &promexp.CollectorOpts{
-		Ignores: []string{
-			`.*_ID_(\d+)_rank`,
-		},
-	}
-	c, err := promexp.NewCollector(log, opts)
+	c, err := promexp.NewCollector(log, &promexp.CollectorOpts{})
 	if err != nil {
 		return err
 	}

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -369,61 +369,61 @@ class TelemetryUtils():
         ENGINE_IO_OPS_TGT_UPDATE_ACTIVE_METRICS +\
         ENGINE_IO_OPS_UPDATE_ACTIVE_METRICS
     ENGINE_NET_METRICS = [
-        "engine_net_<provider>_failed_addr",
-        "engine_net_<provider>_req_timeout",
-        "engine_net_<provider>_uri_lookup_timeout",
+        "engine_net_failed_addr",
+        "engine_net_req_timeout",
+        "engine_net_uri_lookup_timeout",
         "engine_net_uri_lookup_other",
         "engine_net_uri_lookup_self"]
     ENGINE_RANK_METRICS = [
         "engine_rank"]
     ENGINE_NVME_HEALTH_METRICS = [
-        "engine_nvme_<id>_commands_data_units_written",
-        "engine_nvme_<id>_commands_data_units_read",
-        "engine_nvme_<id>_commands_host_write_cmds",
-        "engine_nvme_<id>_commands_host_read_cmds",
-        "engine_nvme_<id>_commands_media_errs",
-        "engine_nvme_<id>_commands_read_errs",
-        "engine_nvme_<id>_commands_write_errs",
-        "engine_nvme_<id>_commands_unmap_errs",
-        "engine_nvme_<id>_commands_checksum_mismatch",
-        "engine_nvme_<id>_power_cycles",
-        "engine_nvme_<id>_commands_ctrl_busy_time",
-        "engine_nvme_<id>_power_on_hours",
-        "engine_nvme_<id>_unsafe_shutdowns"]
+        "engine_nvme_commands_data_units_written",
+        "engine_nvme_commands_data_units_read",
+        "engine_nvme_commands_host_write_cmds",
+        "engine_nvme_commands_host_read_cmds",
+        "engine_nvme_commands_media_errs",
+        "engine_nvme_commands_read_errs",
+        "engine_nvme_commands_write_errs",
+        "engine_nvme_commands_unmap_errs",
+        "engine_nvme_commands_checksum_mismatch",
+        "engine_nvme_power_cycles",
+        "engine_nvme_commands_ctrl_busy_time",
+        "engine_nvme_power_on_hours",
+        "engine_nvme_unsafe_shutdowns"]
     ENGINE_NVME_TEMP_METRICS = [
-        "engine_nvme_<id>_temp_current"]
+        "engine_nvme_temp_current"]
     ENGINE_NVME_TEMP_TIME_METRICS = [
-        "engine_nvme_<id>_temp_warn_time",
-        "engine_nvme_<id>_temp_crit_time"]
+        "engine_nvme_temp_warn_time",
+        "engine_nvme_temp_crit_time"]
     ENGINE_NVME_RELIABILITY_METRICS = [
-        "engine_nvme_<id>_reliability_avail_spare",
-        "engine_nvme_<id>_reliability_avail_spare_threshold"]
+        "engine_nvme_reliability_avail_spare",
+        "engine_nvme_reliability_avail_spare_threshold"]
     ENGINE_NVME_CRIT_WARN_METRICS = [
-        "engine_nvme_<id>_reliability_avail_spare_warn",
-        "engine_nvme_<id>_reliability_reliability_warn",
-        "engine_nvme_<id>_temp_warn",
-        "engine_nvme_<id>_read_only_warn",
-        "engine_nvme_<id>_volatile_mem_warn"]
+        "engine_nvme_reliability_avail_spare_warn",
+        "engine_nvme_reliability_reliability_warn",
+        "engine_nvme_temp_warn",
+        "engine_nvme_read_only_warn",
+        "engine_nvme_volatile_mem_warn"]
     ENGINE_NVME_INTEL_VENDOR_METRICS = [
-        "engine_nvme_<id>_vendor_program_fail_cnt_norm",
-        "engine_nvme_<id>_vendor_program_fail_cnt_raw",
-        "engine_nvme_<id>_vendor_erase_fail_cnt_norm",
-        "engine_nvme_<id>_vendor_erase_fail_cnt_raw",
-        "engine_nvme_<id>_vendor_wear_leveling_cnt_norm",
-        "engine_nvme_<id>_vendor_wear_leveling_cnt_min",
-        "engine_nvme_<id>_vendor_wear_leveling_cnt_max",
-        "engine_nvme_<id>_vendor_wear_leveling_cnt_avg",
-        "engine_nvme_<id>_vendor_endtoend_err_cnt_raw",
-        "engine_nvme_<id>_vendor_crc_err_cnt_raw",
-        "engine_nvme_<id>_vendor_media_wear_raw",
-        "engine_nvme_<id>_vendor_host_reads_raw",
-        "engine_nvme_<id>_vendor_crc_workload_timer_raw",
-        "engine_nvme_<id>_vendor_thermal_throttle_status_raw",
-        "engine_nvme_<id>_vendor_thermal_throttle_event_cnt",
-        "engine_nvme_<id>_vendor_retry_buffer_overflow_cnt",
-        "engine_nvme_<id>_vendor_pll_lock_loss_cnt",
-        "engine_nvme_<id>_vendor_nand_bytes_written",
-        "engine_nvme_<id>_vendor_host_bytes_written"]
+        "engine_nvme_vendor_program_fail_cnt_norm",
+        "engine_nvme_vendor_program_fail_cnt_raw",
+        "engine_nvme_vendor_erase_fail_cnt_norm",
+        "engine_nvme_vendor_erase_fail_cnt_raw",
+        "engine_nvme_vendor_wear_leveling_cnt_norm",
+        "engine_nvme_vendor_wear_leveling_cnt_min",
+        "engine_nvme_vendor_wear_leveling_cnt_max",
+        "engine_nvme_vendor_wear_leveling_cnt_avg",
+        "engine_nvme_vendor_endtoend_err_cnt_raw",
+        "engine_nvme_vendor_crc_err_cnt_raw",
+        "engine_nvme_vendor_media_wear_raw",
+        "engine_nvme_vendor_host_reads_raw",
+        "engine_nvme_vendor_crc_workload_timer_raw",
+        "engine_nvme_vendor_thermal_throttle_status_raw",
+        "engine_nvme_vendor_thermal_throttle_event_cnt",
+        "engine_nvme_vendor_retry_buffer_overflow_cnt",
+        "engine_nvme_vendor_pll_lock_loss_cnt",
+        "engine_nvme_vendor_nand_bytes_written",
+        "engine_nvme_vendor_host_bytes_written"]
     ENGINE_NVME_METRICS = ENGINE_NVME_HEALTH_METRICS +\
         ENGINE_NVME_TEMP_METRICS +\
         ENGINE_NVME_TEMP_TIME_METRICS +\
@@ -457,31 +457,18 @@ class TelemetryUtils():
         all_metrics_names = list(self.ENGINE_EVENT_METRICS)
         all_metrics_names.extend(self.ENGINE_SCHED_METRICS)
         all_metrics_names.extend(self.ENGINE_IO_METRICS)
+        all_metrics_names.extend(self.ENGINE_NET_METRICS)
         all_metrics_names.extend(self.ENGINE_RANK_METRICS)
         all_metrics_names.extend(self.ENGINE_DMABUFF_METRICS)
         if with_pools:
             all_metrics_names.extend(self.ENGINE_POOL_METRICS)
             all_metrics_names.extend(self.ENGINE_CONTAINER_METRICS)
 
-        # Add engine network metrics for the configured provider
-        try:
-            provider = re.sub("[+;]", "_", server.manager.job.get_config_value("provider"))
-            if provider == "ofi_tcp":
-                provider = "ofi_tcp_ofi_rxm"
-            elif provider == "ofi_verbs":
-                provider = "ofi_verbs_ofi_rxm"
-        except TypeError:
-            provider = "ofi_tcp_ofi_rxm"
-        net_metrics = [name.replace("<provider>", provider) for name in self.ENGINE_NET_METRICS]
-        all_metrics_names.extend(net_metrics)
-
-        # Add NVMe metrics for any NVMe devices configured for this server
+        # Add the NVMe metrics if the test is run on a hardware cluster.
         for nvme_list in server.manager.job.get_engine_values("bdev_list"):
-            for nvme in nvme_list if nvme_list is not None else []:
-                # Replace the '<id>' placeholder with the actual NVMe ID
-                nvme_id = nvme.replace(":", "_").replace(".", "_")
-                nvme_metrics = [name.replace("<id>", nvme_id) for name in self.ENGINE_NVME_METRICS]
-                all_metrics_names.extend(nvme_metrics)
+            if nvme_list and len(nvme_list) > 0:
+                all_metrics_names.extend(self.ENGINE_NVME_METRICS)
+                break
 
         return all_metrics_names
 
@@ -736,15 +723,6 @@ class TelemetryUtils():
         data = {}
         if specific_metrics is None:
             specific_metrics = self.ENGINE_NVME_METRICS
-
-        # Add NVMe metrics for any NVMe devices configured for this server
-        for nvme_list in server.manager.job.get_engine_values("bdev_list"):
-            for nvme in nvme_list if nvme_list is not None else []:
-                # Replace the '<id>' placeholder with the actual NVMe ID
-                nvme_id = nvme.replace(":", "_").replace(".", "_")
-                specific_metrics = [
-                    name.replace("<id>", nvme_id)
-                    for name in specific_metrics]
 
         info = self.get_metrics(",".join(specific_metrics))
         self.log.info("NVMe Telemetry Information")


### PR DESCRIPTION
The older implementation used regexps for picking out labels,
but this was highly inefficient with large numbers of pools.

Also fixes a couple of bugs in the prometheus naming scheme:
  - Network provider name should be a label value, not part of the metric name
  - NVMe device address should be a label value, not part of the metric name

Features: telemetry

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
