### PR TITLE
DAOS-3916 control: Add daos.HLC type

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -717,11 +717,13 @@ func printContainerInfo(out io.Writer, ci *containerInfo, verbose bool) error {
 	if verbose {
 		rows = append(rows, []txtfmt.TableRow{
 			{"Pool UUID": ci.PoolUUID.String()},
-			{"Number of snapshots": fmt.Sprintf("%d", *ci.NumSnapshots)},
-			{"Latest Persistent Snapshot": fmt.Sprintf("%#x", *ci.LatestSnapshot)},
 			{"Container redundancy factor": fmt.Sprintf("%d", *ci.RedundancyFactor)},
+			{"Number of snapshots": fmt.Sprintf("%d", *ci.NumSnapshots)},
 		}...)
 
+		if *ci.LatestSnapshot != 0 {
+			rows = append(rows, txtfmt.TableRow{"Latest Persistent Snapshot": fmt.Sprintf("%#x (%s)", *ci.LatestSnapshot, daos.HLC(*ci.LatestSnapshot))})
+		}
 		if ci.ObjectClass != "" {
 			rows = append(rows, txtfmt.TableRow{"Object Class": ci.ObjectClass})
 		}
@@ -765,7 +767,6 @@ func newContainerInfo(poolUUID, contUUID *uuid.UUID) *containerInfo {
 	ci.LatestSnapshot = (*uint64)(&ci.dci.ci_lsnapshot)
 	ci.RedundancyFactor = (*uint32)(&ci.dci.ci_redun_fac)
 	ci.NumSnapshots = (*uint32)(&ci.dci.ci_nsnapshots)
-
 	return ci
 }
 

--- a/src/control/lib/daos/hlc.go
+++ b/src/control/lib/daos/hlc.go
@@ -1,0 +1,56 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package daos
+
+/*
+#cgo LDFLAGS: -lgurt
+
+#include <cart/api.h>
+*/
+import "C"
+
+import (
+	"time"
+
+	"github.com/daos-stack/daos/src/control/common"
+)
+
+type (
+	// HLC is a high-resolution clock.
+	HLC uint64
+)
+
+// Nanoseconds returns the HLC represented as the number of nanoseconds since the Unix epoch.
+func (hlc HLC) Nanoseconds() int64 {
+	return int64(C.crt_hlc2unixnsec(C.uint64_t(hlc)))
+}
+
+func (hlc HLC) String() string {
+	return hlc.ToTime().String()
+}
+
+func (hlc HLC) ToTime() time.Time {
+	return time.Unix(0, hlc.Nanoseconds())
+}
+
+func (hlc HLC) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + common.FormatTime(hlc.ToTime()) + `"`), nil
+}
+
+func (hlc *HLC) UnmarshalJSON(b []byte) error {
+	t, err := common.ParseTime(string(b))
+	if err != nil {
+		return err
+	}
+	*hlc = NewHLC(t.UnixNano())
+	return nil
+}
+
+// NewHLC creates a new HLC from the given number of nanoseconds since the Unix epoch.
+func NewHLC(nsec int64) HLC {
+	return HLC(C.crt_unixnsec2hlc(C.uint64_t(nsec)))
+}

--- a/src/control/lib/daos/hlc_test.go
+++ b/src/control/lib/daos/hlc_test.go
@@ -1,0 +1,70 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package daos_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+)
+
+func TestDaos_HLC(t *testing.T) {
+	now := time.Now().Truncate(0)
+
+	for name, tc := range map[string]struct {
+		in      int64
+		expDate string
+	}{
+		"zero": {
+			in:      0,
+			expDate: "2021-01-01 00:00:00 +0000 UTC", // HLC epoch is 2021-01-01
+		},
+		"now": {
+			in:      now.UnixNano(),
+			expDate: now.String(),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			hlc := daos.NewHLC(tc.in)
+			test.AssertEqual(t, tc.expDate, hlc.String(), "not equal")
+		})
+	}
+}
+
+func TestDaos_HLC_JSON(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+	nowJS := common.FormatTime(now)
+
+	for name, tc := range map[string]struct {
+		in      string
+		expDate string
+	}{
+		"now": {
+			in:      nowJS,
+			expDate: now.String(),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var hlc daos.HLC
+
+			err := hlc.UnmarshalJSON([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			test.AssertEqual(t, tc.expDate, hlc.String(), "not equal")
+
+			b, err := hlc.MarshalJSON()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			test.AssertEqual(t, `"`+tc.in+`"`, string(b), "not equal")
+		})
+	}
+}

--- a/src/control/lib/daos/status_test.go
+++ b/src/control/lib/daos/status_test.go
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
+
 package daos_test
 
 import (
@@ -14,7 +15,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/daos"
 )
 
-func Testdaos_Status(t *testing.T) {
+func TestDaos_Status(t *testing.T) {
 	for name, tc := range map[string]struct {
 		in     int32
 		expErr error
@@ -38,7 +39,7 @@ func Testdaos_Status(t *testing.T) {
 	}
 }
 
-func Testdaos_Error(t *testing.T) {
+func TestDaos_Error(t *testing.T) {
 	// Light test to make sure the error stringer works as expected.
 	for ds, expStr := range map[daos.Status]string{
 		daos.Success:        "DER_SUCCESS(0): Success",


### PR DESCRIPTION
Provide a Go type wrapper for cart HLC values. Handles
conversion into human-readable timestamps.

Updates `daos cont query` to display a human-readable
timestamp in addition to the HLC for the LatestSnapshot
field.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
