### PR TITLE
DAOS-11265 test: Wait 1 min after bringing up the network in deployme…

### DIFF
--- a/src/tests/ftest/deployment/network_failure.py
+++ b/src/tests/ftest/deployment/network_failure.py
@@ -13,6 +13,7 @@ from general_utils import report_errors, run_pcmd
 from command_utils_base import CommandFailure
 from job_manager_utils import get_job_manager
 from network_utils import update_network_interface
+from dmg_utils import check_system_query_status
 
 
 class NetworkFailureTest(IorTestBase):
@@ -400,6 +401,21 @@ class NetworkFailureTest(IorTestBase):
             command = "sudo ip link set {} {}".format(self.interface, "up")
             self.log.debug("## Call %s on %s", command, self.network_down_host)
             time.sleep(20)
+
+        # Some ranks may be excluded after bringing up the network, so wait until they
+        # are up (joined).
+        server_crashed = True
+        for _ in range(6):
+            time.sleep(10)
+            if check_system_query_status(self.get_dmg_command().system_query()):
+                self.log.info("All ranks are joined after bringing up the interface.")
+                server_crashed = False
+                break
+            self.log.info("One or more servers crashed. Check system query again.")
+
+        if server_crashed:
+            msg = "One or more servers crashed after bringing up the network interface!"
+            errors.append(msg)
 
         self.log.info("########## Errors ##########")
         report_errors(test=self, errors=errors)

--- a/src/tests/ftest/deployment/network_failure.py
+++ b/src/tests/ftest/deployment/network_failure.py
@@ -402,8 +402,8 @@ class NetworkFailureTest(IorTestBase):
             self.log.debug("## Call %s on %s", command, self.network_down_host)
             time.sleep(20)
 
-        # Some ranks may be excluded after bringing up the network, so wait until they
-        # are up (joined).
+        # Some ranks may be excluded after bringing up the network interface, so wait
+        # until they are up (joined).
         server_crashed = True
         for _ in range(6):
             time.sleep(10)


### PR DESCRIPTION
…nt/network_failure.py

After bringing up the network, check system query and
verify that all ranks are joined. If not, wait 10 sec
and try again. Repeat this for up to 1 min.

Test-tag: network_failure_isolation
Skip-unit-tests: true
Skip-fault-injection-test: true
Test-repeat: 5
Required-githooks: true

Signed-off-by: Makito Kano <makito.kano@intel.com>