### PR TITLE
DAOS-11423 object: remove obj_ec_rw_req_split

### DIFF
--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -508,6 +508,19 @@ obj_io_desc_fini(struct obj_io_desc *oiod)
 	D_FREE(oiod->oiod_siods);
 }
 
+static inline struct obj_shard_iod *
+obj_shard_iod_get(struct obj_io_desc *oiod, uint32_t tgt)
+{
+	int i;
+
+	for (i = 0; i < oiod->oiod_nr; i++) {
+		if (oiod->oiod_siods[i].siod_tgt_idx == tgt)
+			return &oiod->oiod_siods[i];
+	}
+
+	return NULL;
+}
+
 /* translate the queried VOS shadow list to daos extents */
 static inline void
 obj_shadow_list_vos2daos(uint32_t nr, struct daos_recx_ep_list *lists,

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -712,6 +712,7 @@ struct dc_object *obj_hdl2ptr(daos_handle_t oh);
 struct obj_io_context {
 	struct ds_cont_hdl	*ioc_coh;
 	struct ds_cont_child	*ioc_coc;
+	crt_rpc_t		*ioc_rpc;
 	struct daos_oclass_attr	 ioc_oca;
 	daos_handle_t		 ioc_vos_coh;
 	uint32_t		 ioc_layout_ver;

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -17,30 +17,9 @@
 #include "obj_rpc.h"
 #include "srv_internal.h"
 
-static inline bool
-obj_ec_is_valid_tgt(struct daos_cpd_ec_tgts *tgt_map, uint32_t map_size,
-		    uint32_t id, uint32_t *shard)
-{
-	int	i;
-
-	/* XXX: The distributed transaction may contains the updates of
-	 *	multiple EC objects that share the same forward targets
-	 *	array. So for some update of EC object, the targets may
-	 *	be unordered. So checking the bitmap may be inefficient.
-	 */
-	for (i = 0; i < map_size; i++) {
-		if (tgt_map[i].dcet_tgt_id == id) {
-			*shard = tgt_map[i].dcet_shard_idx;
-			return true;
-		}
-	}
-
-	return false;
-}
-
 static void
-obj_ec_metrics_process(daos_iod_t *iod, struct obj_io_desc *oiod, struct daos_oclass_attr *oca,
-		       struct obj_pool_metrics *opm)
+_obj_ec_metrics_process(daos_iod_t *iod, struct obj_io_desc *oiod, struct daos_oclass_attr *oca,
+			struct obj_pool_metrics *opm)
 {
 	struct obj_shard_iod	*siod;
 	daos_recx_t		*recx, *recx0;
@@ -105,215 +84,24 @@ obj_ec_metrics_process(daos_iod_t *iod, struct obj_io_desc *oiod, struct daos_oc
 	d_tm_inc_counter(opm->opm_update_ec_full, 1);
 }
 
-/**
- * Split EC obj read/write request.
- * For object update, client sends update request to leader, the leader needs to
- * split it for different targets before dispatch.
- */
-int
-obj_ec_rw_req_split(daos_unit_oid_t oid, uint32_t start_tgt,
-		    struct obj_iod_array *iod_array,
-		    uint32_t iod_nr, uint32_t start_shard, uint32_t max_shard,
-		    uint32_t leader_id, void *tgt_map, uint32_t map_size,
-		    struct daos_oclass_attr *oca, uint32_t tgt_nr,
-		    struct daos_shard_tgt *tgts, struct obj_ec_split_req **split_req,
-		    struct obj_pool_metrics *opm)
-{
-	daos_iod_t		*iod;
-	daos_iod_t		*iods = iod_array->oia_iods;
-	struct obj_io_desc	*oiods = iod_array->oia_oiods;
-	struct obj_ec_split_req	*req;
-	daos_iod_t		*split_iod, *split_iods;
-	struct obj_shard_iod	*siod;
-	struct obj_tgt_oiod	*tgt_oiod, *tgt_oiods = NULL;
-	struct dcs_iod_csums	*iod_csum = NULL;
-	struct dcs_iod_csums	*iod_csums = iod_array->oia_iod_csums;
-	struct dcs_iod_csums	*split_iod_csum = NULL;
-	struct dcs_iod_csums	*split_iod_csums;
-	uint32_t		 i, tgt_max_idx;
-	daos_size_t		 req_size, iods_size;
-	daos_size_t		 csums_size = 0, singv_ci_size = 0;
-	uint8_t			 tgt_bit_map[OBJ_TGT_BITMAP_LEN] = {0};
-	bool			 with_csums = (iod_csums != NULL);
-	void			*buf = NULL;
-	uint32_t		 tgt_idx;
-	uint32_t		 leader;
-	int			 count = 0;
-	int			 rc = 0;
-
-	D_ASSERT(oiods != NULL);
-	/* as we select the last parity node as leader, and for any update
-	 * there must be a siod (the last siod) for leader except for singv.
-	 */
-	D_ASSERT((oiods[0].oiod_flags & OBJ_SIOD_SINGV) ||
-		 oiods[0].oiod_nr >= 2);
-
-	if (oca == NULL)
-		oca = daos_oclass_attr_find(oid.id_pub, NULL);
-	D_ASSERT(oca != NULL);
-
-	if (tgt_map != NULL)
-		tgt_max_idx = 0;
-	else
-		tgt_max_idx = max_shard;
-
-	req_size = roundup(sizeof(struct obj_ec_split_req), 8);
-	iods_size = roundup(sizeof(daos_iod_t) * iod_nr, 8);
-	if (with_csums) {
-		csums_size = roundup(sizeof(struct dcs_iod_csums) * iod_nr, 8);
-		singv_ci_size = roundup(sizeof(struct dcs_csum_info) * iod_nr,
-					8);
-	}
-	D_ALLOC(buf, req_size + iods_size + csums_size + singv_ci_size);
-	if (buf == NULL)
-		return -DER_NOMEM;
-
-	req = buf;
-	req->osr_iods = buf + req_size;
-	if (with_csums) {
-		req->osr_iod_csums = buf + req_size + iods_size;
-		req->osr_singv_cis = buf + req_size + iods_size + csums_size;
-	}
-	req->osr_start_shard = start_shard;
-
-	for (i = 0; i < tgt_nr; i++) {
-		if (tgt_map != NULL) {
-			if (!obj_ec_is_valid_tgt(tgt_map, map_size,
-						 tgts[i].st_tgt_id, &tgt_idx))
-				continue;
-
-			D_ASSERTF(tgt_idx >= start_shard, "i %d, tgt_idx %d, start_shard %d\n",
-				  i, tgt_idx, start_shard);
-
-			tgt_idx -= start_shard;
-			if (tgt_max_idx < tgt_idx)
-				tgt_max_idx = tgt_idx;
-		} else {
-			if (tgts[i].st_rank == DAOS_TGT_IGNORE)
-				continue;
-			D_ASSERTF(tgts[i].st_shard_id >= start_shard,
-				  "i %d, st_shard_id %d, start_shard %d\n", i,
-				  tgts[i].st_shard_id, start_shard);
-			tgt_idx = tgts[i].st_shard_id - start_shard;
-			D_ASSERTF(tgt_idx <= tgt_max_idx, "tgt_idx %u tgt_max_idx %u\n",
-				  tgt_idx, tgt_max_idx);
-		}
-
-		if (isclr(tgt_bit_map, tgt_idx)) {
-			setbit(tgt_bit_map, tgt_idx);
-			count++;
-		}
-	}
-
-	if (tgt_map != NULL) {
-		/* NB: if there is inflight I/O during reintegration, then multiple
-		 * shards(map_size) might write the same data(iod/count), so count
-		 * might be smaller than  map_size.
-		 */
-		/* If leader is not any EC shard, neither parity nor data,
-		 * then temporarily set leader as tgt_max_idx, that is not
-		 * important since current server will not take part in EC
-		 * update, the temporary leader is only for split handling.
-		 */
-		if (!obj_ec_is_valid_tgt(tgt_map, map_size, leader_id, &leader))
-			leader = tgt_max_idx;
-		else
-			leader = leader % obj_ec_tgt_nr(oca);
-	} else {
-		D_ASSERT(leader_id == PO_COMP_ID_ALL);
-
-		leader = oid.id_shard % obj_ec_tgt_nr(oca);
-		if (isclr(tgt_bit_map, leader)) {
-			setbit(tgt_bit_map, leader);
-			count++;
-		}
-	}
-
-	tgt_oiods = obj_ec_tgt_oiod_init(oiods, iod_nr, tgt_bit_map,
-					 tgt_max_idx, count, start_tgt, oca);
-	if (tgt_oiods == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	req->osr_tgt_oiods = tgt_oiods;
-	tgt_oiod = obj_ec_tgt_oiod_get(tgt_oiods, count, leader);
-	D_ASSERT(tgt_oiod != NULL && tgt_oiod->oto_tgt_idx == leader);
-
-	req->osr_offs = tgt_oiod->oto_offs;
-	split_iods = req->osr_iods;
-	split_iod_csums = req->osr_iod_csums;
-
-	for (i = 0; i < iod_nr; i++) {
-		int	idx;
-
-		iod = &iods[i];
-		if (opm != NULL)
-			obj_ec_metrics_process(iod, &oiods[i], oca, opm);
-		if (with_csums) {
-			D_ASSERT(split_iod_csums != NULL);
-
-			split_iod_csum = &split_iod_csums[i];
-			iod_csum = &iod_csums[i];
-			*split_iod_csum = *iod_csum;
-		}
-
-		split_iod = &split_iods[i];
-		split_iod->iod_name = iod->iod_name;
-		split_iod->iod_type = iod->iod_type;
-		split_iod->iod_size = iod->iod_size;
-
-		if (tgt_oiod->oto_oiods[i].oiod_flags & OBJ_SIOD_SINGV) {
-			D_ASSERT(iod->iod_type == DAOS_IOD_SINGLE);
-
-			idx = 0;
-			split_iod->iod_nr = 1;
-			if (with_csums) {
-				struct dcs_csum_info	*ci, *split_ci;
-
-				D_ASSERT(split_iod_csum->ic_nr == 1);
-				ci = &split_iod_csum->ic_data[0];
-				if (ci->cs_nr > 1) {
-					/* evenly distributed singv */
-					D_ASSERT(ci->cs_nr == tgt_max_idx + 1);
-					split_ci = &req->osr_singv_cis[i];
-					*split_ci = *ci;
-					split_iod_csum->ic_data = split_ci;
-					split_ci->cs_nr = 1;
-					split_ci->cs_csum +=
-						obj_ec_shard_off_by_start(leader, oca, start_tgt) *
-						ci->cs_len;
-					split_ci->cs_buf_len = ci->cs_len;
-				}
-			}
-		} else {
-			siod = &tgt_oiod->oto_oiods[i].oiod_siods[0];
-			split_iod->iod_nr = siod->siod_nr;
-			idx = siod->siod_idx;
-			if (with_csums) {
-				split_iod_csum->ic_data =
-					&iod_csum->ic_data[idx];
-				split_iod_csum->ic_nr = siod->siod_nr;
-			}
-		}
-		if (iod->iod_recxs != NULL)
-			split_iod->iod_recxs = &iod->iod_recxs[idx];
-	}
-
-	*split_req = req;
-
-out:
-	if (rc) {
-		if (buf != NULL)
-			D_FREE(buf);
-		obj_ec_tgt_oiod_fini(tgt_oiods);
-	}
-	return rc;
-}
-
 void
-obj_ec_split_req_fini(struct obj_ec_split_req *req)
+obj_ec_metrics_process(struct obj_iod_array *iod_array, struct obj_io_context *ioc)
 {
-	if (req == NULL)
+	struct obj_pool_metrics *opm;
+	int			i;
+
+	D_ASSERT(ioc->ioc_opc == DAOS_OBJ_RPC_UPDATE);
+	if (iod_array->oia_iods == NULL || !daos_oclass_is_ec(&ioc->ioc_oca))
 		return;
-	obj_ec_tgt_oiod_fini(req->osr_tgt_oiods);
-	D_FREE(req);
+
+	opm = ioc->ioc_coc->sc_pool->spc_metrics[DAOS_OBJ_MODULE];
+	for (i = 0; i < iod_array->oia_oiod_nr; i++) {
+		daos_iod_t		*iod;
+		struct obj_io_desc	*oiod;
+
+		iod = &iod_array->oia_iods[i];
+		oiod = &iod_array->oia_oiods[i];
+
+		_obj_ec_metrics_process(iod, oiod, &ioc->ioc_oca, opm);
+	}
 }

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -421,11 +421,6 @@ fill_oid(daos_unit_oid_t oid, struct ds_obj_enum_arg *arg);
 
 /* srv_ec.c */
 struct obj_rw_in;
-int obj_ec_rw_req_split(daos_unit_oid_t oid, uint32_t start_tgt, struct obj_iod_array *iod_array,
-			uint32_t iod_nr, uint32_t start_shard, uint32_t max_shard,
-			uint32_t leader_id, void *tgt_map, uint32_t map_size,
-			struct daos_oclass_attr *oca, uint32_t tgt_nr, struct daos_shard_tgt *tgts,
-			struct obj_ec_split_req **split_req, struct obj_pool_metrics *opm);
-void obj_ec_split_req_fini(struct obj_ec_split_req *req);
+void obj_ec_metrics_process(struct obj_iod_array *iod_array, struct obj_io_context *ioc);
 
 #endif /* __DAOS_OBJ_SRV_INTENRAL_H__ */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -769,13 +769,11 @@ obj_set_reply_nrs(crt_rpc_t *rpc, daos_handle_t ioh, d_sg_list_t *echo_sgl)
 }
 
 static void
-obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
+obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *iod, uint64_t *off)
 {
 	struct obj_rw_in	*orw = crt_req_get(rpc);
 	struct obj_rw_out	*orwo = crt_reply_get(rpc);
 	struct obj_tls		*tls;
-	daos_iod_t		*iod;
-	uint64_t		*off;
 	d_sg_list_t		*p_sgl;
 	crt_bulk_op_t		bulk_op;
 	bool			bulk_bind;
@@ -808,8 +806,6 @@ obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
 
 	/* Only support 1 iod now */
 	D_ASSERT(orw->orw_iod_array.oia_iod_nr == 1);
-	iod = split_iods == NULL ? orw->orw_iod_array.oia_iods : split_iods;
-	off = split_offs == NULL ? orw->orw_iod_array.oia_offs : split_offs;
 
 	tls = obj_tls_get();
 	p_sgl = &tls->ot_echo_sgl;
@@ -1318,12 +1314,11 @@ obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_rw_out *orwo,
 
 static int
 obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
-		      daos_iod_t *split_iods, struct dcs_iod_csums *split_csums,
-		      uint64_t *split_offs, struct dtx_handle *dth)
+		      daos_iod_t *iods, struct dcs_iod_csums *iod_csums,
+		      uint64_t *offs, uint32_t iods_nr, struct dtx_handle *dth)
 {
 	struct obj_rw_in		*orw = crt_req_get(rpc);
 	struct obj_rw_out		*orwo = crt_reply_get(rpc);
-	struct dcs_iod_csums		*iod_csums;
 	uint32_t			tag = dss_get_module_info()->dmi_tgt_id;
 	daos_handle_t			ioh = DAOS_HDL_INVAL;
 	struct bio_desc			*biod;
@@ -1335,8 +1330,6 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	bool				spec_fetch = false;
 	bool				iod_converted = false;
 	struct daos_recx_ep_list	*recov_lists = NULL;
-	daos_iod_t			*iods;
-	uint64_t			*offs;
 	uint64_t			 cond_flags;
 	uint64_t			 sched_seq = sched_cur_seq();
 	daos_iod_t			*iods_dup = NULL; /* for EC deg fetch */
@@ -1346,22 +1339,15 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	int				rc = 0;
 
 	create_map = orw->orw_flags & ORF_CREATE_MAP;
-
-	iods = split_iods == NULL ? orw->orw_iod_array.oia_iods : split_iods;
-	offs = split_offs == NULL ? orw->orw_iod_array.oia_offs : split_offs;
-	iod_csums = split_csums == NULL ? orw->orw_iod_array.oia_iod_csums :
-					 split_csums;
-
 	if (daos_obj_is_echo(orw->orw_oid.id_pub) ||
 	    (daos_io_bypass & IOBP_TARGET)) {
-		obj_echo_rw(rpc, split_iods, split_offs);
+		obj_echo_rw(rpc, iods, offs);
 		D_GOTO(out, rc = 0);
 	}
 
 	rc = csum_verify_keys(ioc->ioc_coc->sc_csummer, &orw->orw_dkey,
 			      orw->orw_dkey_csum, &orw->orw_iod_array,
 			      &orw->orw_oid);
-
 	if (rc != 0) {
 		D_ERROR(DF_C_UOID_DKEY"verify_keys error: "DF_RC"\n",
 			DP_C_UOID_DKEY(orw->orw_oid, &orw->orw_dkey),
@@ -1370,6 +1356,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			obj_log_csum_err();
 		return rc;
 	}
+
 	dkey = (daos_key_t *)&orw->orw_dkey;
 	D_DEBUG(DB_IO,
 		"opc %d oid "DF_UOID" dkey "DF_KEY" tag %d epc "DF_X64" flags %x.\n",
@@ -1386,7 +1373,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	if (obj_rpc_is_update(rpc)) {
 		obj_singv_ec_rw_filter(orw->orw_oid, &ioc->ioc_oca, tgt_off,
 				       iods, offs, orw->orw_epoch, orw->orw_flags,
-				       orw->orw_nr, true, false, NULL);
+				       iods_nr, true, false, NULL);
 		bulk_op = CRT_BULK_GET;
 
 		/** Fault injection - corrupt data from network */
@@ -1407,7 +1394,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 		rc = vos_update_begin(ioc->ioc_vos_coh, orw->orw_oid,
 			      orw->orw_epoch, cond_flags, dkey,
-			      orw->orw_nr, iods, iod_csums,
+			      iods_nr, iods, iod_csums,
 			      ioc->ioc_coc->sc_props.dcp_dedup_size,
 			      &ioh, dth);
 		if (rc) {
@@ -1469,7 +1456,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			/* Copy the iods to make it reentrant, as the
 			 * obj_fetch_shadow() possibly change the iod.
 			 */
-			rc = daos_iod_recx_dup(iods, orw->orw_nr, &iods_dup);
+			rc = daos_iod_recx_dup(iods, iods_nr, &iods_dup);
 			if (rc != 0) {
 				D_ERROR(DF_UOID ": iod_recx_dup failed: " DF_RC "\n",
 					DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -1480,7 +1467,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			iods = iods_dup;
 
 			rc = obj_fetch_shadow(ioc, orw->orw_oid, orw->orw_epoch, cond_flags, dkey,
-					      orw->orw_dkey_hash, orw->orw_nr, iods,
+					      orw->orw_dkey_hash, iods_nr, iods,
 					      orw->orw_tgt_idx, dth, &shadows);
 			if (rc) {
 				D_ERROR(DF_UOID" Fetch shadow failed: "DF_RC
@@ -1503,9 +1490,9 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 		time = daos_get_ntime();
 		rc = vos_fetch_begin(ioc->ioc_vos_coh, orw->orw_oid,
-				     orw->orw_epoch, dkey, orw->orw_nr, iods,
+				     orw->orw_epoch, dkey, iods_nr, iods,
 				     cond_flags | fetch_flags, shadows, &ioh, dth);
-		daos_recx_ep_list_free(shadows, orw->orw_nr);
+		daos_recx_ep_list_free(shadows, iods_nr);
 		if (rc) {
 			D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_NONEXIST ||
 				 rc == -DER_TX_RESTART, DB_IO, DLOG_ERR,
@@ -1519,15 +1506,15 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		if (get_parity_list) {
 			parity_list = vos_ioh2recx_list(ioh);
 			if (parity_list != NULL) {
-				daos_recx_ep_list_set(parity_list, orw->orw_nr,
+				daos_recx_ep_list_set(parity_list, iods_nr,
 						      ioc->ioc_coc->sc_ec_agg_eph_boundry, 0);
-				daos_recx_ep_list_merge(parity_list, orw->orw_nr);
+				daos_recx_ep_list_merge(parity_list, iods_nr);
 				orwo->orw_rels.ca_arrays = parity_list;
-				orwo->orw_rels.ca_count = orw->orw_nr;
+				orwo->orw_rels.ca_count = iods_nr;
 			}
 		}
 
-		rc = obj_set_reply_sizes(rpc, iods, orw->orw_nr);
+		rc = obj_set_reply_sizes(rpc, iods, iods_nr);
 		if (rc != 0)
 			goto out;
 
@@ -1551,7 +1538,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 		rc = obj_singv_ec_rw_filter(orw->orw_oid, &ioc->ioc_oca, tgt_off,
 					    iods, offs, orw->orw_epoch, orw->orw_flags,
-					    orw->orw_nr, false, ec_deg_fetch, &recov_lists);
+					    iods_nr, false, ec_deg_fetch, &recov_lists);
 		if (rc != 0) {
 			D_ERROR(DF_UOID" obj_singv_ec_rw_filter failed: "
 				DF_RC".\n", DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -1575,11 +1562,11 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			} else {
 				recov_epoch = vos_agg_epoch;
 			}
-			daos_recx_ep_list_set(recov_lists, orw->orw_nr,
+			daos_recx_ep_list_set(recov_lists, iods_nr,
 					      recov_epoch, recov_snap);
-			daos_recx_ep_list_merge(recov_lists, orw->orw_nr);
+			daos_recx_ep_list_merge(recov_lists, iods_nr);
 			orwo->orw_rels.ca_arrays = recov_lists;
-			orwo->orw_rels.ca_count = orw->orw_nr;
+			orwo->orw_rels.ca_count = iods_nr;
 		}
 	}
 
@@ -1623,7 +1610,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 		rc = obj_bulk_transfer(rpc, bulk_op, bulk_bind,
 				       orw->orw_bulks.ca_arrays, offs,
-				       ioh, NULL, orw->orw_nr, NULL, ioc->ioc_coh);
+				       ioh, NULL, iods_nr, NULL, ioc->ioc_coh);
 		if (rc == 0) {
 			bio_iod_flush(biod);
 
@@ -1639,7 +1626,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 				rc = dss_sleep(3100);
 		}
 	} else if (orw->orw_sgls.ca_arrays != NULL) {
-		rc = bio_iod_copy(biod, orw->orw_sgls.ca_arrays, orw->orw_nr);
+		rc = bio_iod_copy(biod, orw->orw_sgls.ca_arrays, iods_nr);
 	}
 
 	if (rc) {
@@ -1680,7 +1667,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		 * client-side dc_rw_cb_csum_verify() may not work.
 		 */
 		if (iod_converted)
-			obj_iod_recx_daos2vos(orw->orw_nr, iods, &ioc->ioc_oca);
+			obj_iod_recx_daos2vos(iods_nr, iods, &ioc->ioc_oca);
 
 		rc = obj_fetch_create_maps(rpc, biod, iods);
 	}
@@ -1721,21 +1708,162 @@ out:
 
 	rc = obj_rw_complete(rpc, ioc, ioh, rc, dth);
 	if (iods_dup != NULL)
-		daos_iod_recx_free(iods_dup, orw->orw_nr);
+		daos_iod_recx_free(iods_dup, iods_nr);
 	return unlikely(rc == -DER_ALREADY) ? 0 : rc;
 }
 
+/* Extract local iods/offs/csums by orw_oid.id_shard from @orw */
 static int
-obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
-	     daos_iod_t *split_iods, struct dcs_iod_csums *split_csums,
-	     uint64_t *split_offs, struct dtx_handle *dth)
+obj_get_iods_offs_by_oid(daos_unit_oid_t uoid, struct obj_iod_array *iod_array,
+			 struct daos_oclass_attr *oca, uint64_t dkey_hash,
+			 uint32_t layout_ver, daos_iod_t **iods,
+			 uint64_t **offs, struct dcs_iod_csums **csums, uint32_t *nr)
 {
-	int	rc;
-	int	count = 0;
+	struct obj_shard_iod	*siod;
+	uint32_t		local_tgt;
+	uint32_t		oiod_nr;
+	int			i;
+	int 			idx = 0;
+	int			rc = 0;
 
+	oiod_nr = iod_array->oia_oiod_nr;
+	D_ASSERT(oiod_nr > 0);
+	if (oiod_nr > 1 || *iods == NULL) {
+		D_ALLOC_ARRAY(*iods, oiod_nr);
+		if (*iods == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		D_ALLOC_ARRAY(*offs, oiod_nr);
+		if (*offs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		if (csums != NULL) {
+			D_ALLOC_ARRAY(*csums, oiod_nr);
+			if (*csums == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+			for (i = 0; i < oiod_nr &&
+			     iod_array->oia_iods[i].iod_type == DAOS_IOD_SINGLE; i++) {
+				D_ALLOC_PTR((*csums)[i].ic_data);
+				if ((*csums)[i].ic_data == NULL)
+					D_GOTO(out, rc = -DER_NOMEM);
+			}
+		}
+	}
+
+	local_tgt = uoid.id_shard % obj_ec_tgt_nr(oca);
+	for (i = 0; i < oiod_nr; i++) {
+		daos_iod_t		*iod_parent;
+		struct dcs_iod_csums	*iod_pcsum = NULL;
+		struct obj_io_desc	*oiod;
+
+		iod_parent = &iod_array->oia_iods[i];
+		oiod = &iod_array->oia_oiods[i];
+		if (iod_parent->iod_type == DAOS_IOD_ARRAY) {
+			siod = obj_shard_iod_get(oiod, local_tgt);
+			if (siod == NULL)
+				continue;
+		}
+
+		memcpy(&(*iods)[idx], iod_parent, sizeof(daos_iod_t));
+		if (csums != NULL) {
+			iod_pcsum = &iod_array->oia_iod_csums[i];
+			memcpy(&(*csums)[idx].ic_akey, &iod_pcsum->ic_akey,
+			       sizeof(struct dcs_csum_info));
+			(*csums)[idx].ic_nr = iod_pcsum->ic_nr;
+		}
+
+		if ((*iods)[idx].iod_type == DAOS_IOD_ARRAY) {
+			siod = obj_shard_iod_get(oiod, local_tgt);
+			D_ASSERTF(siod != NULL, "local_tgt %u\n", local_tgt);
+			(*offs)[idx] = siod->siod_off;
+			(*iods)[idx].iod_recxs = &iod_parent->iod_recxs[siod->siod_idx];
+			(*iods)[idx].iod_nr = siod->siod_nr;
+			if (csums != NULL) {
+				(*csums)[i].ic_data = &iod_pcsum->ic_data[siod->siod_idx];
+				(*csums)[i].ic_nr = siod->siod_nr;
+			}
+		} else {
+			if (iod_parent->iod_recxs != NULL)
+				(*iods)[idx].iod_recxs = &iod_parent->iod_recxs[0];
+			else
+				(*iods)[idx].iod_recxs = NULL;
+			(*iods)[idx].iod_nr = 1;
+			if (csums != NULL) {
+				struct dcs_csum_info	*ci, *split_ci;
+
+				D_ASSERT(iod_pcsum->ic_nr == 1);
+				ci = &iod_pcsum->ic_data[0];
+				split_ci = (*csums)[idx].ic_data;
+				*split_ci = *ci;
+				if (ci->cs_nr > 1) {
+					/* evenly distributed singv */
+					split_ci->cs_nr = 1;
+					split_ci->cs_csum +=
+					obj_ec_shard_off_by_layout_ver(layout_ver, dkey_hash,
+								       oca, local_tgt) * ci->cs_len;
+					split_ci->cs_buf_len = ci->cs_len;
+				}
+			}
+		}
+		idx++;
+	}
+	if (nr)
+		*nr = idx;
+out:
+	return rc;
+}
+
+static int
+obj_get_iods_offs(daos_unit_oid_t uoid, struct obj_iod_array *iod_array,
+		  struct daos_oclass_attr *oca, uint64_t dkey_hash,
+		  uint32_t layout_ver, daos_iod_t **iods,
+		  uint64_t **offs, struct dcs_iod_csums **p_csums,
+		  struct dcs_csum_info *csum_info, uint32_t *nr)
+{
+	int rc;
+
+	if (iod_array->oia_oiods == NULL) {
+		*iods = iod_array->oia_iods;
+		*offs = iod_array->oia_offs;
+		*p_csums = iod_array->oia_iod_csums;
+		if (nr)
+			*nr = iod_array->oia_iod_nr;
+		return 0;
+	}
+
+	if (iod_array->oia_iod_csums != NULL)
+		(*p_csums)->ic_data = csum_info;
+	else
+		*p_csums = NULL;
+
+	rc = obj_get_iods_offs_by_oid(uoid, iod_array, oca, dkey_hash, layout_ver, iods, offs,
+				      iod_array->oia_iod_csums == NULL ? NULL : p_csums, nr);
+
+	return rc;
+}
+
+static int
+obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc, struct dtx_handle *dth)
+{
+	struct obj_rw_in	*orw = crt_req_get(rpc);
+	daos_iod_t		iod = { 0 };
+	daos_iod_t		*iods = &iod;
+	struct dcs_iod_csums	csum = { 0 };
+	struct dcs_csum_info	csum_info = { 0 };
+	struct dcs_iod_csums	*csums = &csum;
+	uint64_t		off = 0;
+	uint64_t		*offs = &off;
+	uint32_t		nr = 0;
+	int			rc;
+	int			count = 0;
+
+	rc = obj_get_iods_offs(orw->orw_oid, &orw->orw_iod_array, &ioc->ioc_oca,
+			       orw->orw_dkey_hash, ioc->ioc_layout_ver, &iods,
+			       &offs, &csums, &csum_info, &nr);
+	if (rc != 0)
+		D_GOTO(out, rc);
 again:
-	rc = obj_local_rw_internal(rpc, ioc, split_iods, split_csums,
-				   split_offs, dth);
+	rc = obj_local_rw_internal(rpc, ioc, iods, csums, offs, nr, dth);
 	if (dth != NULL && obj_dtx_need_refresh(dth, rc)) {
 		if (unlikely(++count % 10 == 3)) {
 			struct dtx_share_peer	*dsp;
@@ -1750,6 +1878,22 @@ again:
 		rc = dtx_refresh(dth, ioc->ioc_coc);
 		if (rc == -DER_AGAIN)
 			goto again;
+	}
+
+out:
+	if (iods != NULL && iods != &iod && iods != orw->orw_iod_array.oia_iods)
+		D_FREE(iods);
+	if (offs != NULL && offs != &off && offs != orw->orw_iod_array.oia_offs)
+		D_FREE(offs);
+	if (csums != NULL && csums != &csum && csums != orw->orw_iod_array.oia_iod_csums) {
+		int i;
+
+		for (i = 0; i < orw->orw_iod_array.oia_oiod_nr &&
+		     orw->orw_iod_array.oia_iods[i].iod_type == DAOS_IOD_SINGLE; i++) {
+			if (csums[i].ic_data != NULL)
+				D_FREE(csums[i].ic_data);
+		}
+		D_FREE(csums);
 	}
 
 	return rc;
@@ -1786,7 +1930,7 @@ obj_capa_check(struct ds_cont_hdl *coh, bool is_write, bool is_agg_migrate)
  * will be returned to \a ioc::ioc_coc.
  */
 static int
-obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
+obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, crt_rpc_t *rpc,
 	     struct obj_io_context *ioc)
 {
 	struct ds_cont_hdl   *coh;
@@ -1795,8 +1939,8 @@ obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
 
 	D_ASSERT(ioc != NULL);
 	memset(ioc, 0, sizeof(*ioc));
-	ioc->ioc_opc = opc;
-
+	ioc->ioc_rpc = rpc;
+	ioc->ioc_opc = opc_get(rpc->cr_opc);
 	rc = ds_cont_find_hdl(pool_uuid, coh_uuid, &coh);
 	if (rc) {
 		if (rc == -DER_NONEXIST)
@@ -1879,14 +2023,14 @@ obj_ioc_fini(struct obj_io_context *ioc, int err)
  */
 static int
 obj_ioc_begin_lite(uint32_t rpc_map_ver, uuid_t pool_uuid,
-		   uuid_t coh_uuid, uuid_t cont_uuid, uint32_t opc,
-		   struct obj_io_context *ioc)
+		   uuid_t coh_uuid, uuid_t cont_uuid,
+		   crt_rpc_t *rpc, struct obj_io_context *ioc)
 {
 	struct obj_tls		*tls;
 	struct ds_pool_child	*poc;
 	int			rc;
 
-	rc = obj_ioc_init(pool_uuid, coh_uuid, cont_uuid, opc, ioc);
+	rc = obj_ioc_init(pool_uuid, coh_uuid, cont_uuid, rpc, ioc);
 	if (rc)
 		return rc;
 
@@ -1932,7 +2076,7 @@ obj_ioc_begin_lite(uint32_t rpc_map_ver, uuid_t pool_uuid,
 		/* For distributed transaction, restart the DTX if using
 		 * stale pool map.
 		 */
-		if (opc == DAOS_OBJ_RPC_CPD)
+		if (opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_CPD)
 			D_GOTO(out, rc = -DER_TX_RESTART);
 
 		D_GOTO(out, rc = -DER_STALE);
@@ -1944,7 +2088,7 @@ out:
 	dss_rpc_cntr_enter(DSS_RC_OBJ);
 	/** increment active request counter and start the chrono */
 	tls = obj_tls_get();
-	d_tm_inc_gauge(tls->ot_op_active[opc], 1);
+	d_tm_inc_gauge(tls->ot_op_active[opc_get(rpc->cr_opc)], 1);
 	ioc->ioc_start_time = daos_get_ntime();
 	ioc->ioc_began = 1;
 	return rc;
@@ -1955,6 +2099,7 @@ obj_update_sensors(struct obj_io_context *ioc, int err)
 {
 	struct obj_tls		*tls = obj_tls_get();
 	struct obj_pool_metrics	*opm;
+	struct obj_rw_in	*orw;
 	struct d_tm_node_t	*lat;
 	uint32_t		opc = ioc->ioc_opc;
 	uint64_t		time;
@@ -1978,6 +2123,10 @@ obj_update_sensors(struct obj_io_context *ioc, int err)
 	case DAOS_OBJ_RPC_UPDATE:
 		d_tm_inc_counter(opm->opm_update_bytes, ioc->ioc_io_size);
 		lat = tls->ot_update_lat[lat_bucket(ioc->ioc_io_size)];
+		orw = crt_req_get(ioc->ioc_rpc);
+		if (orw->orw_iod_array.oia_iods != NULL)
+			obj_ec_metrics_process(&orw->orw_iod_array, ioc);
+
 		break;
 	case DAOS_OBJ_RPC_TGT_UPDATE:
 		d_tm_inc_counter(opm->opm_update_bytes, ioc->ioc_io_size);
@@ -2063,13 +2212,14 @@ obj_inflight_io_check(struct ds_cont_child *child, uint32_t opc, uint32_t flags)
 /* Various check before access VOS */
 static int
 obj_ioc_begin(daos_obj_id_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
-	      uuid_t coh_uuid, uuid_t cont_uuid, uint32_t opc, uint32_t flags,
+	      uuid_t coh_uuid, uuid_t cont_uuid, crt_rpc_t *rpc, uint32_t flags,
 	      struct obj_io_context *ioc)
 {
+	uint32_t	opc = opc_get(rpc->cr_opc);
 	int		rc;
 
 	rc = obj_ioc_begin_lite(rpc_map_ver, pool_uuid, coh_uuid, cont_uuid,
-			      opc, ioc);
+				rpc, ioc);
 	if (rc != 0)
 		return rc;
 
@@ -2122,7 +2272,7 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(oer->er_oid.id_pub, oer->er_map_ver,
 			   oer->er_pool_uuid, oer->er_coh_uuid,
-			   oer->er_cont_uuid, opc_get(rpc->cr_opc), 0, &ioc);
+			   oer->er_cont_uuid, rpc, 0, &ioc);
 	if (rc)	{
 		D_ERROR("ioc_begin failed: "DF_RC"\n", DP_RC(rc));
 		goto out;
@@ -2200,7 +2350,7 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(oea->ea_oid.id_pub, oea->ea_map_ver,
 			   oea->ea_pool_uuid, oea->ea_coh_uuid,
-			   oea->ea_cont_uuid, opc_get(rpc->cr_opc), 0, &ioc);
+			   oea->ea_cont_uuid, rpc, 0, &ioc);
 
 	if (rc)	{
 		D_ERROR("ioc_begin failed: "DF_RC"\n", DP_RC(rc));
@@ -2298,8 +2448,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(orw->orw_oid.id_pub, orw->orw_map_ver,
 			   orw->orw_pool_uuid, orw->orw_co_hdl,
-			   orw->orw_co_uuid, opc_get(rpc->cr_opc),
-			   orw->orw_flags, &ioc);
+			   orw->orw_co_uuid, rpc, orw->orw_flags, &ioc);
 	if (rc)
 		goto out;
 
@@ -2394,8 +2543,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	/* RPC may be resent during current update bulk data transfer.
 	 * Pre-allocate DTX entry for handling resend under such case.
 	 */
-
-	rc = obj_local_rw(rpc, &ioc, NULL, NULL, NULL, dth);
+	rc = obj_local_rw(rpc, &ioc, dth);
 	if (rc != 0)
 		D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
 			 (rc == -DER_EXIST &&
@@ -2415,17 +2563,13 @@ out:
 
 static int
 obj_tgt_update(struct dtx_leader_handle *dlh, void *arg, int idx,
-		  dtx_sub_comp_cb_t comp_cb)
+	       dtx_sub_comp_cb_t comp_cb)
 {
 	struct ds_obj_exec_arg	*exec_arg = arg;
 
 	/* handle local operation */
 	if (idx == -1) {
 		struct obj_rw_in	*orw = crt_req_get(exec_arg->rpc);
-		struct obj_ec_split_req	*split_req = exec_arg->args;
-		daos_iod_t		*iods;
-		struct dcs_iod_csums	*csums;
-		uint64_t		*offs;
 		int			 rc = 0;
 
 		if (DAOS_FAIL_CHECK(DAOS_DTX_LEADER_ERROR))
@@ -2462,21 +2606,7 @@ obj_tgt_update(struct dtx_leader_handle *dlh, void *arg, int idx,
 		 *	on the server. That should be avoided. So pre-allocating
 		 *	DTX entry before bulk data transfer is necessary.
 		 */
-
-		orw = crt_req_get(exec_arg->rpc);
-
-		if (split_req != NULL) {
-			iods = split_req->osr_iods;
-			offs = split_req->osr_offs;
-			csums = split_req->osr_iod_csums;
-		} else {
-			iods = NULL;
-			offs = NULL;
-			csums = NULL;
-		}
-
-		rc = obj_local_rw(exec_arg->rpc, exec_arg->ioc, iods, csums,
-				  offs, &dlh->dlh_handle);
+		rc = obj_local_rw(exec_arg->rpc, exec_arg->ioc, &dlh->dlh_handle);
 		if (rc != 0)
 			D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
 				 (rc == -DER_EXIST && (orw->orw_api_flags &
@@ -2489,7 +2619,6 @@ obj_tgt_update(struct dtx_leader_handle *dlh, void *arg, int idx,
 comp:
 		if (comp_cb != NULL)
 			comp_cb(dlh, idx, rc);
-
 		return rc;
 	}
 
@@ -2541,7 +2670,6 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	uint32_t			flags = 0;
 	uint32_t			dtx_flags = 0;
 	uint32_t			opc = opc_get(rpc->cr_opc);
-	struct obj_ec_split_req		*split_req = NULL;
 	struct dtx_memberships		*mbs = NULL;
 	struct daos_shard_tgt		*tgts = NULL;
 	struct dtx_id			*dti_cos = NULL;
@@ -2558,8 +2686,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(orw->orw_oid.id_pub, orw->orw_map_ver,
 			   orw->orw_pool_uuid, orw->orw_co_hdl,
-			   orw->orw_co_uuid, opc_get(rpc->cr_opc),
-			   orw->orw_flags, &ioc);
+			   orw->orw_co_uuid, rpc, orw->orw_flags, &ioc);
 	if (rc != 0) {
 		D_ASSERTF(rc < 0, "unexpected error# "DF_RC"\n", DP_RC(rc));
 		goto out;
@@ -2603,7 +2730,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		rc = dtx_begin(ioc.ioc_vos_coh, &orw->orw_dti, &epoch, 0, orw->orw_map_ver,
 			       &orw->orw_oid, NULL, 0, dtx_flags, NULL, &dth);
 		if (rc == 0) {
-			rc = obj_local_rw(rpc, &ioc, NULL, NULL, NULL, dth);
+			rc = obj_local_rw(rpc, &ioc, dth);
 			rc = dtx_end(dth, ioc.ioc_coc, rc);
 		}
 
@@ -2663,22 +2790,6 @@ again1:
 	}
 
 again2:
-	if (orw->orw_iod_array.oia_oiods != NULL && split_req == NULL) {
-		uint32_t start_tgt = 0;
-
-		start_tgt = obj_ec_grp_start(ioc.ioc_layout_ver, orw->orw_dkey_hash,
-					     obj_ec_tgt_nr(&ioc.ioc_oca));
-		rc = obj_ec_rw_req_split(orw->orw_oid, start_tgt,
-					 &orw->orw_iod_array, orw->orw_nr, orw->orw_start_shard,
-					 orw->orw_tgt_max, PO_COMP_ID_ALL, NULL, 0, &ioc.ioc_oca,
-					 tgt_cnt, tgts, &split_req, opm);
-		if (rc != 0) {
-			D_ERROR(DF_UOID": obj_ec_rw_req_split failed, rc %d.\n",
-				DP_UOID(orw->orw_oid), rc);
-			D_GOTO(out, rc);
-		}
-	}
-
 	/* For leader case, we need to find out the potential conflict
 	 * (or share the same non-committed object/dkey) DTX(s) in the
 	 * CoS (committable) cache, piggyback them via the dispdatched
@@ -2724,7 +2835,6 @@ again2:
 
 	exec_arg.rpc = rpc;
 	exec_arg.ioc = &ioc;
-	exec_arg.args = split_req;
 	exec_arg.flags = flags;
 	exec_arg.start = orw->orw_start_shard;
 
@@ -2784,7 +2894,6 @@ out:
 	}
 
 	obj_rw_reply(rpc, rc, epoch.oe_value, &ioc);
-	obj_ec_split_req_fini(split_req);
 	D_FREE(mbs);
 	D_FREE(dti_cos);
 	obj_ioc_end(&ioc, rc);
@@ -3092,7 +3201,7 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(oei->oei_oid.id_pub, oei->oei_map_ver,
 			   oei->oei_pool_uuid, oei->oei_co_hdl,
-			   oei->oei_co_uuid, opc, oei->oei_flags, &ioc);
+			   oei->oei_co_uuid, rpc, oei->oei_flags, &ioc);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -3279,8 +3388,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	D_ASSERT(opi != NULL);
 	rc = obj_ioc_begin(opi->opi_oid.id_pub, opi->opi_map_ver,
 			   opi->opi_pool_uuid, opi->opi_co_hdl,
-			   opi->opi_co_uuid, opc_get(rpc->cr_opc),
-			   opi->opi_flags, &ioc);
+			   opi->opi_co_uuid, rpc, opi->opi_flags, &ioc);
 	if (rc)
 		goto out;
 
@@ -3455,8 +3563,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	D_ASSERT(opi != NULL);
 	rc = obj_ioc_begin(opi->opi_oid.id_pub, opi->opi_map_ver,
 			   opi->opi_pool_uuid, opi->opi_co_hdl,
-			   opi->opi_co_uuid, opc_get(rpc->cr_opc),
-			   opi->opi_flags, &ioc);
+			   opi->opi_co_uuid, rpc, opi->opi_flags, &ioc);
 	if (rc)
 		goto out;
 
@@ -3657,8 +3764,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc, bool return_epoch)
 
 	rc = obj_ioc_begin(okqi->okqi_oid.id_pub, okqi->okqi_map_ver,
 			   okqi->okqi_pool_uuid, okqi->okqi_co_hdl,
-			   okqi->okqi_co_uuid, opc_get(rpc->cr_opc),
-			   okqi->okqi_flags, &ioc);
+			   okqi->okqi_co_uuid, rpc, okqi->okqi_flags, &ioc);
 	if (rc)
 		D_GOTO(failed, rc);
 
@@ -3754,7 +3860,7 @@ ds_obj_sync_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(osi->osi_oid.id_pub, osi->osi_map_ver,
 			   osi->osi_pool_uuid, osi->osi_co_hdl,
-			   osi->osi_co_uuid, opc_get(rpc->cr_opc), 0, &ioc);
+			   osi->osi_co_uuid, rpc, 0, &ioc);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -3875,6 +3981,7 @@ cleanup:
 /* Locally process the operations belong to one DTX.
  * Common logic, shared by both leader and non-leader.
  */
+#define LOCAL_STACK_NUM		2
 static int
 ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 		  struct daos_cpd_disp_ent *dcde,
@@ -3887,9 +3994,17 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 	daos_handle_t			 *iohs = NULL;
 	struct bio_desc			**biods = NULL;
 	struct obj_bulk_args		 *bulks = NULL;
-	struct dcs_iod_csums		 *csums;
-	daos_iod_t			 *iods;
-	uint64_t			 *offs = NULL;
+	daos_iod_t			local_iods[LOCAL_STACK_NUM] = { {0} };
+	struct dcs_iod_csums		local_csums[LOCAL_STACK_NUM] = { {0} };
+	struct dcs_csum_info		local_csum_info[LOCAL_STACK_NUM] = { 0 };
+	uint64_t			local_offs[LOCAL_STACK_NUM] = { 0 };
+	daos_iod_t			*local_p_iods[LOCAL_STACK_NUM] = { 0 };
+	struct dcs_iod_csums		*local_p_csums[LOCAL_STACK_NUM] = { 0 };
+	uint64_t			*local_p_offs[LOCAL_STACK_NUM] = { 0 };
+	daos_iod_t			**piods = NULL;
+	struct dcs_iod_csums		**pcsums = NULL;
+	uint64_t			**poffs = NULL;
+	struct dcs_csum_info		*pcsum_info = NULL;
 	int				  rma = 0;
 	int				  rma_idx = 0;
 	int				  rc = 0;
@@ -3934,6 +4049,25 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 	}
 
 	dcri += dcde->dcde_read_cnt;
+	if (dcde->dcde_write_cnt > LOCAL_STACK_NUM) {
+		D_ALLOC_ARRAY(piods, dcde->dcde_write_cnt);
+		D_ALLOC_ARRAY(pcsums, dcde->dcde_write_cnt);
+		D_ALLOC_ARRAY(poffs, dcde->dcde_write_cnt);
+		D_ALLOC_ARRAY(pcsum_info, dcde->dcde_write_cnt);
+		if (piods == NULL || pcsums == NULL || poffs == NULL || pcsum_info == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		piods = local_p_iods;
+		pcsums = local_p_csums;
+		poffs = local_p_offs;
+		pcsum_info = local_csum_info;
+		for (i = 0; i < dcde->dcde_write_cnt; i++) {
+			piods[i] = &local_iods[i];
+			pcsums[i] = &local_csums[i];
+			poffs[i] = &local_offs[i];
+		}
+	}
+
 	/* P2: vos_update_begin. */
 	for (i = 0; i < dcde->dcde_write_cnt; i++) {
 		dcsr = &dcsrs[dcri[i].dcri_req_idx];
@@ -3952,6 +4086,20 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 
 			D_GOTO(out, rc = -DER_INVAL);
 		}
+
+		/* There is no object associated with this ioc while
+		 * initializing, we have to do it at here.
+		 */
+		rc = obj_ioc_init_oca(ioc, dcsr->dcsr_oid.id_pub);
+		if (rc)
+			D_GOTO(out, rc);
+
+		rc = obj_get_iods_offs(dcsr->dcsr_oid, &dcu->dcu_iod_array,
+				       &ioc->ioc_oca, dcsr->dcsr_dkey_hash,
+				       ioc->ioc_layout_ver, &piods[i],
+				       &poffs[i], &pcsums[i], &pcsum_info[i], NULL);
+		if (rc != 0)
+			D_GOTO(out, rc);
 
 		rc = csum_verify_keys(ioc->ioc_coc->sc_csummer,
 				      &dcsr->dcsr_dkey, dcu->dcu_dkey_csum,
@@ -3976,33 +4124,16 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 		if (dcu->dcu_flags & ORF_EC) {
 			uint32_t tgt_off;
 
-			if (dcu->dcu_ec_split_req != NULL) {
-				iods = dcu->dcu_ec_split_req->osr_iods;
-				offs = dcu->dcu_ec_split_req->osr_offs;
-				csums = dcu->dcu_ec_split_req->osr_iod_csums;
-			} else {
-				iods = dcu->dcu_iod_array.oia_iods;
-				offs = dcu->dcu_iod_array.oia_offs;
-				csums = dcu->dcu_iod_array.oia_iod_csums;
-			}
-
-			/* There is no object associated with this ioc while
-			 * initializing, we have to do it at here.
-			 */
-			rc = obj_ioc_init_oca(ioc, dcsr->dcsr_oid.id_pub);
-			if (rc)
-				D_GOTO(out, rc);
-
 			tgt_off = obj_ec_shard_off_by_layout_ver(ioc->ioc_layout_ver,
 								 dcsr->dcsr_dkey_hash,
 								 &ioc->ioc_oca,
 								 dcsr->dcsr_oid.id_shard);
 			obj_singv_ec_rw_filter(dcsr->dcsr_oid, &ioc->ioc_oca, tgt_off,
-					       iods, offs, dcsh->dcsh_epoch.oe_value,
+					       piods[i], poffs[i], dcsh->dcsh_epoch.oe_value,
 					       dcu->dcu_flags, dcsr->dcsr_nr, true, false, NULL);
 		} else {
-			iods = dcu->dcu_iod_array.oia_iods;
-			csums = dcu->dcu_iod_array.oia_iod_csums;
+			piods[i] = dcu->dcu_iod_array.oia_iods;
+			pcsums[i] = dcu->dcu_iod_array.oia_iod_csums;
 		}
 
 		update_flags = dcsr->dcsr_api_flags;
@@ -4018,7 +4149,7 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 		rc = vos_update_begin(ioc->ioc_vos_coh,
 				dcsr->dcsr_oid, dcsh->dcsh_epoch.oe_value,
 				update_flags, &dcsr->dcsr_dkey,
-				dcsr->dcsr_nr, iods, csums,
+				dcsr->dcsr_nr, piods[i], pcsums[i],
 				ioc->ioc_coc->sc_props.dcp_dedup_size,
 				&iohs[i], dth);
 		if (rc != 0)
@@ -4043,14 +4174,9 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 					D_GOTO(out, rc = -DER_NOMEM);
 			}
 
-			if (dcu->dcu_ec_split_req != NULL)
-				offs = dcu->dcu_ec_split_req->osr_offs;
-			else
-				offs = dcu->dcu_iod_array.oia_offs;
-
 			rc = obj_bulk_transfer(rpc, CRT_BULK_GET,
 				dcu->dcu_flags & ORF_BULK_BIND, dcu->dcu_bulks,
-				offs, iohs[i], NULL, dcsr->dcsr_nr, &bulks[i], ioc->ioc_coh);
+				poffs[i], iohs[i], NULL, dcsr->dcsr_nr, &bulks[i], ioc->ioc_coh);
 			if (rc != 0) {
 				D_ERROR("Bulk transfer failed for obj "
 					DF_UOID", DTX "DF_DTI": "DF_RC"\n",
@@ -4108,14 +4234,6 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			continue;
 
 		dcu = &dcsr->dcsr_update;
-		if (dcu->dcu_ec_split_req != NULL) {
-			iods = dcu->dcu_ec_split_req->osr_iods;
-			csums = dcu->dcu_ec_split_req->osr_iod_csums;
-		} else {
-			iods = dcu->dcu_iod_array.oia_iods;
-			csums = dcu->dcu_iod_array.oia_iod_csums;
-		}
-
 		rc = vos_dedup_verify(iohs[i]);
 		if (rc != 0) {
 			D_ERROR("dedup_verify failed for obj "DF_UOID", DTX "DF_DTI": "DF_RC"\n",
@@ -4123,7 +4241,7 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			goto out;
 		}
 
-		rc = obj_verify_bio_csum(dcsr->dcsr_oid.id_pub, iods, csums, biods[i],
+		rc = obj_verify_bio_csum(dcsr->dcsr_oid.id_pub, piods[i], pcsums[i], biods[i],
 					 ioc->ioc_coc->sc_csummer, dcsr->dcsr_nr);
 		if (rc != 0) {
 			if (rc == -DER_CSUM)
@@ -4249,6 +4367,44 @@ out:
 	D_FREE(iohs);
 	D_FREE(biods);
 	D_FREE(bulks);
+
+	for (i = 0; i < dcde->dcde_write_cnt; i++) {
+		dcsr = &dcsrs[dcri[i].dcri_req_idx];
+		if (dcsr->dcsr_opc != DCSO_UPDATE)
+			continue;
+
+		dcu = &dcsr->dcsr_update;
+		if (piods!= NULL && piods[i] != NULL && piods[i] != &local_iods[i] &&
+		    piods[i] != dcu->dcu_iod_array.oia_iods)
+			D_FREE(piods[i]);
+
+		if (poffs != NULL && poffs[i] != NULL && poffs[i] != &local_offs[i] &&
+		    poffs[i] != dcu->dcu_iod_array.oia_offs)
+			D_FREE(poffs[i]);
+
+		if (pcsums != NULL && pcsums[i] != NULL && pcsums[i] != &local_csums[i] &&
+		    pcsums[i] != dcu->dcu_iod_array.oia_iod_csums) {
+			struct dcs_iod_csums	*csum = pcsums[i];
+			int j;
+
+			for (j = 0; j < dcu->dcu_iod_array.oia_oiod_nr &&
+			     dcu->dcu_iod_array.oia_iods[j].iod_type == DAOS_IOD_SINGLE; i++) {
+				if (csum[j].ic_data != NULL)
+					D_FREE(csum[j].ic_data);
+			}
+
+			D_FREE(csum);
+		}
+	}
+
+	if (piods != local_p_iods && piods != NULL)
+		D_FREE(piods);
+	if (poffs != local_p_offs && poffs != NULL)
+		D_FREE(poffs);
+	if (pcsums != local_p_csums && pcsums != NULL)
+		D_FREE(pcsums);
+	if (pcsum_info != local_csum_info && pcsum_info != NULL)
+		D_FREE(pcsum_info);
 
 	return unlikely(rc == -DER_ALREADY) ? 0 : rc;
 }
@@ -4410,43 +4566,21 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 			      int tgt_cnt, int req_cnt, struct obj_io_context *ioc,
 			      uint32_t *flags)
 {
-	struct dtx_daos_target	*ddt = &dcsh->dcsh_mbs->dm_tgts[0];
 	int			 rc = 0;
 	int			 i;
 
 	for (i = 0; i < req_cnt; i++) {
 		struct daos_cpd_sub_req	*dcsr;
-		struct daos_cpd_update	*dcu;
-		uint32_t		start_tgt;
 
 		dcsr = &dcsrs[i];
+
 		if (dcsr->dcsr_opc != DCSO_UPDATE)
 			continue;
 
 		rc = obj_ioc_init_oca(ioc, dcsr->dcsr_oid.id_pub);
 		if (rc)
 			break;
-
-		dcu = &dcsr->dcsr_update;
-		if (dcu->dcu_iod_array.oia_oiods == NULL)
-			continue;
-
-		start_tgt = obj_ec_grp_start(ioc->ioc_layout_ver, dcsr->dcsr_dkey_hash,
-					     obj_ec_tgt_nr(&ioc->ioc_oca));
-		rc = obj_ec_rw_req_split(dcsr->dcsr_oid, start_tgt,
-					 &dcu->dcu_iod_array, dcsr->dcsr_nr,
-					 dcu->dcu_start_shard, 0, ddt->ddt_id,
-					 dcu->dcu_ec_tgts, dcsr->dcsr_ec_tgt_nr, NULL,
-					 tgt_cnt, tgts, &dcu->dcu_ec_split_req, NULL);
-		if (rc != 0) {
-			D_ERROR("obj_ec_rw_req_split failed for obj "
-				DF_UOID", DTX "DF_DTI": "DF_RC"\n",
-				DP_UOID(dcsr->dcsr_oid),
-				DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
-			break;
-		}
 	}
-
 	return rc;
 }
 
@@ -4595,20 +4729,6 @@ out:
 		 rc != -DER_AGAIN, DLOG_ERR, DB_IO,
 		 "Handled DTX "DF_DTI" on leader, idx %u: "DF_RC"\n",
 		 DP_DTI(&dcsh->dcsh_xid), dca->dca_idx, DP_RC(rc));
-
-	if (tgt_cnt > 0) {
-		struct daos_cpd_sub_req	*dcsr;
-		int			 i;
-
-		for (i = 0; i < req_cnt; i++) {
-			dcsr = &dcsrs[i];
-			if (dcsr->dcsr_opc != DCSO_UPDATE)
-				continue;
-
-			obj_ec_split_req_fini(
-					dcsr->dcsr_update.dcu_ec_split_req);
-		}
-	}
 
 	if (rc == -DER_AGAIN) {
 		oci->oci_flags |= ORF_RESEND;
@@ -4828,8 +4948,7 @@ ds_obj_cpd_handler(crt_rpc_t *rpc)
 		DP_UUID(oci->oci_co_uuid), tx_count, oci->oci_flags);
 
 	rc = obj_ioc_begin_lite(oci->oci_map_ver, oci->oci_pool_uuid,
-				oci->oci_co_hdl, oci->oci_co_uuid,
-				opc_get(rpc->cr_opc), &ioc);
+				oci->oci_co_hdl, oci->oci_co_uuid, rpc, &ioc);
 	if (rc != 0)
 		goto reply;
 
@@ -4958,8 +5077,7 @@ ds_obj_key2anchor_handler(crt_rpc_t *rpc)
 
 	rc = obj_ioc_begin(oki->oki_oid.id_pub, oki->oki_map_ver,
 			   oki->oki_pool_uuid, oki->oki_co_hdl,
-			   oki->oki_co_uuid, opc_get(rpc->cr_opc),
-			   oki->oki_flags, &ioc);
+			   oki->oki_co_uuid, rpc, oki->oki_flags, &ioc);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -74,8 +74,6 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 		     dtx_sub_comp_cb_t comp_cb)
 {
 	struct ds_obj_exec_arg		*obj_exec_arg = data;
-	struct obj_ec_split_req		*split_req = obj_exec_arg->args;
-	struct obj_tgt_oiod		*tgt_oiod;
 	struct daos_shard_tgt		*shard_tgt;
 	crt_endpoint_t			 tgt_ep;
 	crt_rpc_t			*parent_req = obj_exec_arg->rpc;
@@ -83,19 +81,21 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	struct dtx_sub_status		*sub;
 	struct dtx_handle		*dth = &dlh->dlh_handle;
 	struct obj_remote_cb_arg	*remote_arg = NULL;
+	uint32_t			shard;
+	bool				sent_rpc = false;
 	struct obj_rw_in		*orw;
 	struct obj_rw_in		*orw_parent;
-	uint32_t			 tgt_idx;
 	int				 rc = 0;
 
 	D_ASSERT(idx < dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt);
 	sub = &dlh->dlh_subs[idx];
 	shard_tgt = &sub->dss_tgt;
+	shard = shard_tgt->st_shard;
 	if (DAOS_FAIL_CHECK(DAOS_OBJ_TGT_IDX_CHANGE)) {
 		/* to trigger retry on all other shards */
-		if (shard_tgt->st_shard != daos_fail_value_get()) {
+		if (shard != daos_fail_value_get()) {
 			D_DEBUG(DB_TRACE, "complete shard %d update as "
-				"-DER_TIMEDOUT.\n", shard_tgt->st_shard);
+				"-DER_TIMEDOUT.\n", shard);
 			D_GOTO(out, rc = -DER_TIMEDOUT);
 		}
 	}
@@ -124,21 +124,9 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	orw_parent = crt_req_get(parent_req);
 	orw = crt_req_get(req);
 	*orw = *orw_parent;
-	if (split_req != NULL) {
-		tgt_idx = shard_tgt->st_shard_id;
-		tgt_oiod = obj_ec_tgt_oiod_get(split_req->osr_tgt_oiods,
-					       dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt + 1,
-					       tgt_idx - obj_exec_arg->start);
-		D_ASSERT(tgt_oiod != NULL);
-		orw->orw_iod_array.oia_oiods = tgt_oiod->oto_oiods;
-		orw->orw_iod_array.oia_oiod_nr = orw->orw_iod_array.oia_iod_nr;
-		orw->orw_iod_array.oia_offs = tgt_oiod->oto_offs;
-	}
 	orw->orw_oid.id_shard = shard_tgt->st_shard_id;
 	uuid_copy(orw->orw_co_hdl, orw_parent->orw_co_hdl);
 	uuid_copy(orw->orw_co_uuid, orw_parent->orw_co_uuid);
-	orw->orw_shard_tgts.ca_count	= orw_parent->orw_shard_tgts.ca_count;
-	orw->orw_shard_tgts.ca_arrays	= orw_parent->orw_shard_tgts.ca_arrays;
 	orw->orw_flags |= ORF_BULK_BIND | obj_exec_arg->flags;
 	if (shard_tgt->st_flags & DTF_DELAY_FORWARD && dlh->dlh_drop_cond)
 		orw->orw_api_flags &= ~DAOS_COND_MASK;
@@ -152,10 +140,9 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 		D_ASSERT(sub->dss_comp == 1);
 		D_ERROR("crt_req_send failed, rc "DF_RC"\n", DP_RC(rc));
 	}
-	return rc;
-
+	sent_rpc = true;
 out:
-	if (rc) {
+	if (!sent_rpc) {
 		sub->dss_result = rc;
 		comp_cb(dlh, idx, rc);
 		if (remote_arg) {
@@ -369,37 +356,6 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 		 */
 		memcpy(&dcsr[cur], &dcsr_parent[idx], sizeof(dcsr[cur]));
 		dcri_child->dcri_req_idx = cur;
-
-		if (dcsr_parent[idx].dcsr_opc == DCSO_UPDATE) {
-			struct daos_cpd_update	*dcu_parent;
-			struct daos_cpd_update	*dcu;
-			struct obj_ec_split_req	*split;
-
-			dcu_parent = &dcsr_parent[idx].dcsr_update;
-			dcu = &dcsr[cur].dcsr_update;
-
-			/* For non-leader, does not need split EC sub-req. */
-			dcu->dcu_ec_tgts = NULL;
-			dcu->dcu_ec_split_req = NULL;
-			dcsr[cur].dcsr_ec_tgt_nr = 0;
-
-			split = dcu_parent->dcu_ec_split_req;
-			if (split != NULL) {
-				struct obj_tgt_oiod	*oiod;
-
-				oiod = obj_ec_tgt_oiod_get(split->osr_tgt_oiods,
-							   dcsr_parent[idx].dcsr_ec_tgt_nr,
-							   dcri_parent->dcri_shard_id -
-							   dcu_parent->dcu_start_shard);
-				D_ASSERT(oiod != NULL);
-
-				dcu->dcu_iod_array.oia_oiods = oiod->oto_oiods;
-				dcu->dcu_iod_array.oia_oiod_nr =
-					dcu_parent->dcu_iod_array.oia_iod_nr;
-				dcu->dcu_iod_array.oia_offs = oiod->oto_offs;
-			}
-		}
-
 		prev = idx;
 		cur++;
 	}

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -904,7 +904,10 @@ ec_singv_array_mixed_io(void **state)
 		d_iov_set(&iod[i].iod_name, akey[i], strlen(akey[i]));
 		iod[i].iod_nr		= 1;
 		if (i % 2 == 0) {
-			iod[i].iod_size		= size * (i + 1);
+			if (i == 0)
+				iod[i].iod_size = 5;
+			else
+				iod[i].iod_size	= size * (i + 1);
 			iod[i].iod_recxs	= NULL;
 			iod[i].iod_type		= DAOS_IOD_SINGLE;
 		} else {
@@ -929,10 +932,14 @@ ec_singv_array_mixed_io(void **state)
 			    NULL, NULL);
 	assert_rc_equal(rc, 0);
 	for (i = 0; i < NUM_AKEYS; i++) {
-		if (i % 2 == 0)
-			assert_int_equal(iod[i].iod_size, size * (i + 1));
-		else
+		if (i % 2 == 0) {
+			if (i == 0)
+				assert_int_equal(iod[i].iod_size, 5);
+			else
+				assert_int_equal(iod[i].iod_size, size * (i + 1));
+		} else {
 			assert_int_equal(iod[i].iod_size, 1);
+		}
 	}
 
 	for (i = 0; i < NUM_AKEYS; i++)


### PR DESCRIPTION
Remove obj_ec_rw_req_split from obj_rw_obj_handler(), and
only allocate the memory and copy for multiple IODs cases.

Signed-off-by: Di Wang <di.wang@intel.com>