### PR TITLE
DAOS-11425 bio: reject read/write hole

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -1481,6 +1481,13 @@ bio_rwv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl_in,
 	struct bio_desc		*biod;
 	int			 i, rc;
 
+	for (i = 0; i < bsgl_in->bs_nr; i++) {
+		if (bio_addr_is_hole(&bsgl_in->bs_iovs[i].bi_addr)) {
+			D_ERROR("Read/write a hole isn't allowed\n");
+			return -DER_INVAL;
+		}
+	}
+
 	/* allocate blob I/O descriptor */
 	biod = bio_iod_alloc(ioctxt, 1 /* single bsgl */,
 			update ? BIO_IOD_TYPE_UPDATE : BIO_IOD_TYPE_FETCH);

--- a/src/vos/vos_pool_scrub.c
+++ b/src/vos/vos_pool_scrub.c
@@ -451,6 +451,10 @@ sc_verify_obj_value(struct scrub_ctx *ctx, struct bio_iov *biov, daos_handle_t i
 	struct vos_obj_iter	*oiter;
 	int			 rc;
 
+	/* Don't verify a hole */
+	if (bio_addr_is_hole(&biov->bi_addr))
+		return 0;
+
 	/*
 	 * Know that there will always only be 1 recx because verifying a
 	 * single extent at a time so use first recx in iod for data_len


### PR DESCRIPTION
Improve bio_read/write(), bio_readv/writev() to reject read/write
from/to a hole, fix scrubber to skip verify on a hole.

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>