### PR TITLE
DAOS-11237 test: Collect checksum cmocka results (#9909)

### DIFF
--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -261,10 +261,16 @@ fi
 # daos_test uses cmocka framework which generates a set of xml of its own.
 # Post-processing the xml files here to put them in proper categories
 # for publishing in Jenkins
-dt_xml_path="${logs_prefix}/ftest/avocado/job-results/daos_test"
-FILES=("${dt_xml_path}"/*/test-results/*/data/*.xml)
-COMP="FTEST_daos_test"
+TEST_DIRS=("daos_test" "checksum")
 
-./scripts/post_process_xml.sh "${COMP}" "${FILES[@]}"
+for test_dir in "${TEST_DIRS[@]}"; do
+    COMP="FTEST_${test_dir}"
+    if [[ "${LAUNCH_OPT_ARGS}" == *"--repeat="* ]]; then
+        FILES=("${logs_prefix}/ftest/avocado/job-results/${test_dir}"/*/test-results/*/*/data/*.xml)
+    else
+        FILES=("${logs_prefix}/ftest/avocado/job-results/${test_dir}"/*/test-results/*/data/*.xml)
+    fi
+    ./scripts/post_process_xml.sh "${COMP}" "${FILES[@]}"
+done
 
 exit $rc


### PR DESCRIPTION
The checksum/csum_error_logging.py test generates a cmocka result that
needs to be processed by the post_process_xml.sh script.  Updating
main.sh to include running post_process_xml.sh against the
FTEST_checksum.

Also fixing an error in utils/cq/daos_pylint.py that was preventing git
commit from working.

Quick-Functional: true
Test-tag: daos_test basic_checksum_object csum_error_log

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>