### PR TITLE
DAOS-3916 container: query metadata open, close/modify times

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -43,10 +43,9 @@ def get_version(env):
 
 
 API_VERSION_MAJOR = "2"
-API_VERSION_MINOR = "3"
+API_VERSION_MINOR = "4"
 API_VERSION_FIX = "0"
-API_VERSION = "{}.{}.{}".format(API_VERSION_MAJOR, API_VERSION_MINOR,
-                                API_VERSION_FIX)
+API_VERSION = f'{API_VERSION_MAJOR}.{API_VERSION_MINOR}.{API_VERSION_FIX}'
 
 
 def update_rpm_version(version, tag):

--- a/ci/jira_query.py
+++ b/ci/jira_query.py
@@ -24,7 +24,7 @@ import jira
 # Expected components from the commit message, and directory in src/, src/client or utils/ is also
 # valid.  We've never checked/enforced these before so there have been a lot of values used in the
 # past.
-VALID_COMPONENTS = ('build', 'ci', 'doc', 'gha', 'il', 'mercury', 'test')
+VALID_COMPONENTS = ('build', 'ci', 'doc', 'gha', 'il', 'mercury', 'test', 'md')
 
 # Expected ticket prefix.
 VALID_TICKET_PREFIX = ('DAOS', 'CORCI', 'SRE')

--- a/src/container/rpc.c
+++ b/src/container/rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -70,10 +70,18 @@ CRT_RPC_DEFINE(cont_destroy, DAOS_ISEQ_CONT_DESTROY, DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DEFINE(cont_destroy_bylabel, DAOS_ISEQ_CONT_DESTROY_BYLABEL,
 	       DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DEFINE(cont_open, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN)
+CRT_RPC_DEFINE(cont_open_v7, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN_V7)
+CRT_RPC_DEFINE(cont_open_v6, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN_V6)
 CRT_RPC_DEFINE(cont_open_bylabel, DAOS_ISEQ_CONT_OPEN_BYLABEL,
 	       DAOS_OSEQ_CONT_OPEN_BYLABEL)
+CRT_RPC_DEFINE(cont_open_bylabel_v7, DAOS_ISEQ_CONT_OPEN_BYLABEL,
+	       DAOS_OSEQ_CONT_OPEN_BYLABEL_V7)
+CRT_RPC_DEFINE(cont_open_bylabel_v6, DAOS_ISEQ_CONT_OPEN_BYLABEL,
+	       DAOS_OSEQ_CONT_OPEN_BYLABEL_V6)
 CRT_RPC_DEFINE(cont_close, DAOS_ISEQ_CONT_CLOSE, DAOS_OSEQ_CONT_CLOSE)
 CRT_RPC_DEFINE(cont_query, DAOS_ISEQ_CONT_QUERY, DAOS_OSEQ_CONT_QUERY)
+CRT_RPC_DEFINE(cont_query_v7, DAOS_ISEQ_CONT_QUERY, DAOS_OSEQ_CONT_QUERY_V7)
+CRT_RPC_DEFINE(cont_query_v6, DAOS_ISEQ_CONT_QUERY, DAOS_OSEQ_CONT_QUERY_V6)
 CRT_RPC_DEFINE(cont_oid_alloc, DAOS_ISEQ_CONT_OID_ALLOC,
 		DAOS_OSEQ_CONT_OID_ALLOC)
 CRT_RPC_DEFINE(cont_attr_list, DAOS_ISEQ_CONT_ATTR_LIST,
@@ -111,17 +119,30 @@ CRT_RPC_DEFINE(cont_acl_delete, DAOS_ISEQ_CONT_ACL_DELETE,
 	.prf_co_ops  = NULL,	\
 }
 
-static struct crt_proto_rpc_format cont_proto_rpc_fmt[] = {
-	CONT_PROTO_CLI_RPC_LIST,
+static struct crt_proto_rpc_format cont_proto_rpc_fmt_v7[] = {
+	CONT_PROTO_CLI_RPC_LIST(7, ds_cont_op_handler_v7),
+	CONT_PROTO_SRV_RPC_LIST,
+};
+
+static struct crt_proto_rpc_format cont_proto_rpc_fmt_v6[] = {
+	CONT_PROTO_CLI_RPC_LIST(6, ds_cont_op_handler_v6),
 	CONT_PROTO_SRV_RPC_LIST,
 };
 
 #undef X
 
-struct crt_proto_format cont_proto_fmt = {
+struct crt_proto_format cont_proto_fmt_v7 = {
 	.cpf_name  = "cont",
-	.cpf_ver   = DAOS_CONT_VERSION,
-	.cpf_count = ARRAY_SIZE(cont_proto_rpc_fmt),
-	.cpf_prf   = cont_proto_rpc_fmt,
+	.cpf_ver   = 7,
+	.cpf_count = ARRAY_SIZE(cont_proto_rpc_fmt_v7),
+	.cpf_prf   = cont_proto_rpc_fmt_v7,
+	.cpf_base  = DAOS_RPC_OPCODE(0, DAOS_CONT_MODULE, 0)
+};
+
+struct crt_proto_format cont_proto_fmt_v6 = {
+	.cpf_name  = "cont",
+	.cpf_ver   = 6,
+	.cpf_count = ARRAY_SIZE(cont_proto_rpc_fmt_v6),
+	.cpf_prf   = cont_proto_rpc_fmt_v6,
 	.cpf_base  = DAOS_RPC_OPCODE(0, DAOS_CONT_MODULE, 0)
 };

--- a/src/container/srv.c
+++ b/src/container/srv.c
@@ -83,8 +83,13 @@ static struct crt_corpc_ops ds_cont_tgt_snapshot_notify_co_ops = {
 	.dr_corpc_ops = e,	\
 }
 
-static struct daos_rpc_handler cont_handlers[] = {
-	CONT_PROTO_CLI_RPC_LIST,
+static struct daos_rpc_handler cont_handlers_v7[] = {
+	CONT_PROTO_CLI_RPC_LIST(7, ds_cont_op_handler_v7),
+	CONT_PROTO_SRV_RPC_LIST,
+};
+
+static struct daos_rpc_handler cont_handlers_v6[] = {
+	CONT_PROTO_CLI_RPC_LIST(6, ds_cont_op_handler_v6),
 	CONT_PROTO_SRV_RPC_LIST,
 };
 
@@ -148,12 +153,12 @@ struct dss_module cont_module =  {
 	.sm_name	= "cont",
 	.sm_mod_id	= DAOS_CONT_MODULE,
 	.sm_ver		= DAOS_CONT_VERSION,
-	.sm_proto_count	= 1,
+	.sm_proto_count	= 2,
 	.sm_init	= init,
 	.sm_fini	= fini,
-	.sm_proto_fmt	= &cont_proto_fmt,
-	.sm_cli_count	= CONT_PROTO_CLI_COUNT,
-	.sm_handlers	= cont_handlers,
+	.sm_proto_fmt	= {&cont_proto_fmt_v6, &cont_proto_fmt_v7},
+	.sm_cli_count	= {CONT_PROTO_CLI_COUNT, CONT_PROTO_CLI_COUNT},
+	.sm_handlers	= {cont_handlers_v6, cont_handlers_v7},
 	.sm_key		= &cont_module_key,
 	.sm_metrics	= &cont_metrics,
 };

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -28,6 +28,8 @@
 #include "gurt/telemetry_common.h"
 #include "gurt/telemetry_producer.h"
 
+#define DAOS_POOL_GLOBAL_VERSION_WITH_CONT_MDTIMES 2
+
 static int
 cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 	       daos_prop_t **prop_out, bool ignore_not_set);
@@ -299,6 +301,79 @@ ds_cont_init_metadata(struct rdb_tx *tx, const rdb_path_t *kvs,
 	}
 
 	return rc;
+}
+
+
+/* Get or update container open and metadata modify times, if the co_md_times key exists in rdb */
+static int
+get_metadata_times(struct rdb_tx *tx, struct cont *cont, struct co_md_times *mdtimes)
+{
+	struct co_md_times	cur_mdtimes = {.otime = 0, .mtime = 0};
+	d_iov_t			value;
+	int			rc;
+
+	d_iov_set(&value, &cur_mdtimes, sizeof(cur_mdtimes));
+	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_co_md_times, &value);
+	if (rc == -DER_NONEXIST)
+		goto out;	/* pool/container has old layout without metadata times */
+	else if (rc != 0) {
+		D_ERROR(DF_CONT": rdb_tx_lookup co_md_times failed, "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+		goto err;
+	}
+
+	D_DEBUG(DB_MD, DF_CONT": metadata times: open="DF_X64", modify="DF_X64"\n",
+		DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), cur_mdtimes.otime,
+		cur_mdtimes.mtime);
+
+out:
+	*mdtimes = cur_mdtimes;
+	return 0;
+err:
+	return rc;
+}
+
+static int
+update_metadata_times(struct rdb_tx *tx, struct cont *cont, bool update_otime, bool update_mtime)
+{
+	struct co_md_times	cur_mdtimes;
+	struct co_md_times	upd_mdtimes;
+	uint64_t		cur_hlc;
+	d_iov_t			value;
+	int			rc;
+
+	if (!update_otime && !update_mtime)
+		return 0;
+
+	/* Lookup most recent metadata times (may need to keep the mtime in the update below) */
+	d_iov_set(&value, &cur_mdtimes, sizeof(cur_mdtimes));
+	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_co_md_times, &value);
+	if (rc == -DER_NONEXIST)
+		return 0;	/* pool/container has old layout without metadata times */
+	else if (rc != 0) {
+		D_ERROR(DF_CONT": rdb_tx_lookup co_md_times failed, "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+		return rc;
+	}
+
+	cur_hlc = crt_hlc_get();
+	upd_mdtimes.otime = update_otime ? cur_hlc : cur_mdtimes.otime;
+	upd_mdtimes.mtime = update_mtime ? cur_hlc : cur_mdtimes.mtime;
+
+	d_iov_set(&value, &upd_mdtimes, sizeof(upd_mdtimes));
+	rc = rdb_tx_update(tx, &cont->c_prop, &ds_cont_prop_co_md_times, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to update metadata times, "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+		return rc;
+	}
+
+	D_DEBUG(DB_MD, DF_CONT": metadata times: open(%s)="DF_X64", modify(%s)="DF_X64"\n",
+		DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid),
+		update_otime ? "updated" : "unchanged", upd_mdtimes.otime,
+		update_mtime ? "updated" : "unchanged", upd_mdtimes.mtime);
+
+	return 0;
 }
 
 /* check if container exists by UUID and (if applicable) non-default label */
@@ -806,7 +881,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	 * opened.
 	 */
 
-	/* Create the container attribute KVS under the container KVS. */
+	/* Create the container property KVS under the container KVS. */
 	d_iov_set(&key, in->cci_op.ci_uuid, sizeof(uuid_t));
 	attr.dsa_class = RDB_KVS_GENERIC;
 	attr.dsa_order = 16;
@@ -819,7 +894,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		D_GOTO(out, rc);
 	}
 
-	/* Create a path to the container attribute KVS. */
+	/* Create a path to the container property KVS. */
 	rc = rdb_path_clone(&svc->cs_conts, &kvs);
 	if (rc != 0)
 		D_GOTO(out, rc);
@@ -837,7 +912,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		D_GOTO(out_kvs, rc);
 	}
 
-	/** Create the ALLOCED_OID property. */
+	/* Create the ALLOCED_OID property. */
 	d_iov_set(&value, &alloced_oid, sizeof(alloced_oid));
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_alloced_oid, &value);
 	if (rc != 0) {
@@ -845,6 +920,25 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			DP_CONT(pool_hdl->sph_pool->sp_uuid,
 				in->cci_op.ci_uuid), DP_RC(rc));
 		D_GOTO(out_kvs, rc);
+	}
+
+	/* Set initial container open and metadata modify times. */
+	if (pool_hdl->sph_global_ver >= DAOS_POOL_GLOBAL_VERSION_WITH_CONT_MDTIMES) {
+		struct co_md_times	mdtimes;
+
+		mdtimes.otime = 0;
+		mdtimes.mtime = crt_hlc_get();
+		d_iov_set(&value, &mdtimes, sizeof(mdtimes));
+		rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_co_md_times, &value);
+		if (rc != 0) {
+			D_ERROR(DF_CONT": create co_md_times failed: "DF_RC"\n",
+				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid),
+				DP_RC(rc));
+			D_GOTO(out_kvs, rc);
+		}
+		D_DEBUG(DB_MD, DF_CONT": set metadata times: open="DF_X64", modify="DF_X64"\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), mdtimes.otime,
+			mdtimes.mtime);
 	}
 
 	/* write container properties to rdb. */
@@ -1546,8 +1640,7 @@ cont_svc_ec_agg_leader_stop(struct cont_svc *svc)
 }
 
 int
-cont_lookup(struct rdb_tx *tx, const struct cont_svc *svc, const uuid_t uuid,
-	    struct cont **cont)
+cont_lookup(struct rdb_tx *tx, const struct cont_svc *svc, const uuid_t uuid, struct cont **cont)
 {
 	struct cont    *p;
 	d_iov_t		key;
@@ -1694,7 +1787,7 @@ cont_status_set_unclean(daos_prop_t *prop)
 
 static int
 cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-	  crt_rpc_t *rpc)
+	  crt_rpc_t *rpc, int cont_proto_ver)
 {
 	struct cont_open_in    *in = crt_req_get(rpc);
 	struct cont_open_out   *out = crt_reply_get(rpc);
@@ -1705,7 +1798,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	char			zero = 0;
 	int			rc;
 	struct ownership	owner;
-	struct daos_acl		*acl;
+	struct daos_acl	       *acl;
 	bool			is_healthy;
 	bool			cont_hdl_opened = false;
 	uint32_t		stat_pm_ver = 0;
@@ -1788,6 +1881,30 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 				cont->c_uuid), DP_RC(rc));
 		daos_prop_free(prop);
 		goto out;
+	}
+
+	/* lookup metadata times (NB: before updating open time in caller cont_op_with_svc() */
+	if (cont_proto_ver >= CONT_PROTO_VER_WITH_MDTIMES) {
+		struct co_md_times	mdtimes;
+
+		/* NB client/engine may have recent (protocol) versions, however the pool may not
+		 * have been upgraded to new layout yet. mdtimes will be zeros in that case.
+		 */
+		rc = get_metadata_times(tx, cont, &mdtimes);
+		if (rc != 0)
+			goto out;
+
+		if (opc_get(rpc->cr_opc) == CONT_OPEN) {
+			struct cont_open_v7_out *out_v7 = crt_reply_get(rpc);
+
+			out_v7->coo_md_otime = mdtimes.otime;
+			out_v7->coo_md_mtime = mdtimes.mtime;
+		} else {	/* CONT_OPEN_BYLABEL */
+			struct cont_open_bylabel_v7_out *out_v7 = crt_reply_get(rpc);
+
+			out_v7->coo_md_otime = mdtimes.otime;
+			out_v7->coo_md_mtime = mdtimes.mtime;
+		}
 	}
 
 	/* query the container properties from RDB and update to IV */
@@ -2008,13 +2125,14 @@ out:
 
 static int
 cont_close(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-	   crt_rpc_t *rpc)
+	   crt_rpc_t *rpc, bool *update_mtime)
 {
 	struct cont_close_in	       *in = crt_req_get(rpc);
-	d_iov_t			key;
-	d_iov_t			value;
+	d_iov_t				key;
+	d_iov_t				value;
 	struct container_hdl		chdl;
 	struct cont_tgt_close_rec	rec;
+	bool				update_mtime_needed = false;
 	int				rc;
 
 	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p hdl=" DF_UUID "\n",
@@ -2049,7 +2167,12 @@ cont_close(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 
 	rc = cont_close_one_hdl(tx, cont->c_svc, rpc->cr_ctx, rec.tcr_hdl);
 
+	/* On success update modify time (except if open specified read-only metadata stats) */
+	if (rc == 0 && !(chdl.ch_flags & DAOS_COO_RO_MDSTATS))
+		update_mtime_needed = true;
+
 out:
+	*update_mtime = update_mtime_needed;
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), rpc, DP_RC(rc));
 	return rc;
@@ -2547,7 +2670,7 @@ cont_status_check(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont,
 
 static int
 cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
-	   struct container_hdl *hdl, crt_rpc_t *rpc)
+	   struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver)
 {
 	struct cont_query_in   *in  = crt_req_get(rpc);
 	struct cont_query_out  *out = crt_reply_get(rpc);
@@ -2587,6 +2710,23 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		out->cqo_lsnapshot = *(uint64_t *)key_out.iov_buf;
 		D_DEBUG(DB_MD, DF_CONT": got lsnapshot="DF_X64"\n",
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), out->cqo_lsnapshot);
+	}
+
+	/* lookup metadata times */
+	D_DEBUG(DB_MD, DF_CONT": cont_proto_ver=%d\n",
+		DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), cont_proto_ver);
+	if (cont_proto_ver >= CONT_PROTO_VER_WITH_MDTIMES) {
+		struct cont_query_v7_out       *out_v7 = crt_reply_get(rpc);
+		struct co_md_times		mdtimes;
+
+		/* NB client/engine may have recent (protocol) versions, however the pool may not
+		 * have been upgraded to new layout yet. mdtimes will be zeros in that case.
+		 */
+		rc = get_metadata_times(tx, cont, &mdtimes);
+		if (rc != 0)
+			goto out;
+		out_v7->cqo_md_otime = mdtimes.otime;
+		out_v7->cqo_md_mtime = mdtimes.mtime;
 	}
 
 	/* need RF to process co_status */
@@ -3511,8 +3651,10 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	int				 rc;
 	bool				 upgraded = false;
 	uint32_t			 global_ver = 0;
+	uint32_t			 from_global_ver;
 	daos_prop_t			*prop = NULL;
 	struct daos_prop_entry		*entry;
+	struct co_md_times		 mdtimes;
 	(void)val;
 
 	if (key->iov_len != sizeof(uuid_t)) {
@@ -3547,11 +3689,24 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		goto out;
 	}
 
+	/* TODO? make sure global_ver == (DAOS_POOL_GLOBAL_VERSION - 1)? */
+
 	/* Read all props for prop IV update */
 	rc = cont_prop_read(ap->tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop, false);
 	if (rc)
 		goto out;
 
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_GLOBAL_VERSION);
+	D_ASSERT(entry != NULL);
+	if (global_ver == 0) {
+		D_ASSERT(daos_prop_is_set(entry) == false);
+		entry->dpe_flags &= ~DAOS_PROP_ENTRY_NOT_SET;
+	}
+	entry->dpe_val = DAOS_POOL_GLOBAL_VERSION;
+	D_DEBUG(DB_MD, "pool/cont: "DF_CONTF" upgrading layout %d->%d\n",
+		DP_CONT(ap->pool_uuid, cont_uuid), global_ver, DAOS_POOL_GLOBAL_VERSION);
+
+	from_global_ver = global_ver;
 	global_ver = DAOS_POOL_GLOBAL_VERSION;
 	rc = rdb_tx_update(ap->tx, &cont->c_prop,
 			   &ds_cont_prop_cont_global_version, &value);
@@ -3561,11 +3716,6 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		goto out;
 	}
 	upgraded = true;
-	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_GLOBAL_VERSION);
-	D_ASSERT(entry != NULL);
-	D_ASSERT(daos_prop_is_set(entry) == false);
-	entry->dpe_flags &= ~DAOS_PROP_ENTRY_NOT_SET;
-	entry->dpe_val = global_ver;
 
 	d_iov_set(&value, &pda, sizeof(pda));
 	rc = rdb_tx_lookup(ap->tx, &cont->c_prop,
@@ -3609,6 +3759,32 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		entry->dpe_flags &= ~DAOS_PROP_ENTRY_NOT_SET;
 		entry->dpe_val = pda;
 	}
+
+	/* Initialize or update container open / metadata modify times.
+	 * Update even when the container already has co_md_times key in properties KVS.
+	 */
+	d_iov_set(&value, &mdtimes, sizeof(mdtimes));
+	rc = rdb_tx_lookup(ap->tx, &cont->c_prop,
+			   &ds_cont_prop_co_md_times, &value);
+	if (rc && rc != -DER_NONEXIST)
+		goto out;
+	if ((rc == -DER_NONEXIST) &&
+	    (from_global_ver >= DAOS_POOL_GLOBAL_VERSION_WITH_CONT_MDTIMES)) {
+		D_ERROR(DF_CONT": version %u container metadata is missing key co_md_times!\n",
+			DP_CONT(ap->pool_uuid, cont_uuid), from_global_ver);
+		goto out;
+	}
+	mdtimes.otime = 0;
+	mdtimes.mtime = crt_hlc_get();
+	rc = rdb_tx_update(ap->tx, &cont->c_prop, &ds_cont_prop_co_md_times, &value);
+	if (rc) {
+		D_ERROR("failed to upgrade container co_md_times/cont: "DF_CONTF"\n",
+			DP_CONT(ap->pool_uuid, cont_uuid));
+		goto out;
+	}
+	upgraded = true;
+	D_DEBUG(DB_MD, DF_CONT": set metadata times: open="DF_X64", modify="DF_X64"\n",
+		DP_CONT(ap->pool_uuid, cont_uuid), mdtimes.otime, mdtimes.mtime);
 
 out:
 	if (rc == 0) {
@@ -3691,15 +3867,17 @@ out_svc:
 }
 
 static int
-cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
-		 struct cont *cont, struct container_hdl *hdl, crt_rpc_t *rpc)
+cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
+		 struct container_hdl *hdl, crt_rpc_t *rpc, int cont_proto_ver, bool *update_mtime)
 {
 	struct cont_pool_metrics *metrics;
 	int			  rc;
 
+	*update_mtime = false;
+
 	switch (opc_get(rpc->cr_opc)) {
 	case CONT_QUERY:
-		rc = cont_query(tx, pool_hdl, cont, hdl, rpc);
+		rc = cont_query(tx, pool_hdl, cont, hdl, rpc, cont_proto_ver);
 		if (likely(rc == 0)) {
 			metrics = pool_hdl->sph_pool->sp_metrics[DAOS_CONT_MODULE];
 			d_tm_inc_counter(metrics->query_total, 1);
@@ -3710,22 +3888,30 @@ cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	case CONT_ATTR_GET:
 		return cont_attr_get(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_ATTR_SET:
+		*update_mtime = true;
 		return cont_attr_set(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_ATTR_DEL:
+		*update_mtime = true;
 		return cont_attr_del(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_EPOCH_AGGREGATE:
+		*update_mtime = true;
 		return ds_cont_epoch_aggregate(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_LIST:
 		return ds_cont_snap_list(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_CREATE:
+		*update_mtime = true;
 		return ds_cont_snap_create(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_DESTROY:
+		*update_mtime = true;
 		return ds_cont_snap_destroy(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_PROP_SET:
+		*update_mtime = true;
 		return ds_cont_prop_set(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_ACL_UPDATE:
+		*update_mtime = true;
 		return ds_cont_acl_update(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_ACL_DELETE:
+		*update_mtime = true;
 		return ds_cont_acl_delete(tx, pool_hdl, cont, hdl, rpc);
 	default:
 		D_ASSERT(0);
@@ -3740,13 +3926,14 @@ cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
  */
 static int
 cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
-		  struct cont *cont, crt_rpc_t *rpc)
+		  struct cont *cont, crt_rpc_t *rpc, bool *update_mtime, int cont_proto_ver)
 {
 	struct cont_op_in		*in = crt_req_get(rpc);
 	d_iov_t				 key;
 	d_iov_t				 value;
 	struct container_hdl		 hdl;
 	struct cont_pool_metrics	*metrics;
+	bool				 update_mtime_needed = false;
 	int				 rc;
 
 	metrics = pool_hdl->sph_pool->sp_metrics[DAOS_CONT_MODULE];
@@ -3754,12 +3941,12 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	switch (opc_get(rpc->cr_opc)) {
 	case CONT_OPEN:
 	case CONT_OPEN_BYLABEL:
-		rc = cont_open(tx, pool_hdl, cont, rpc);
+		rc = cont_open(tx, pool_hdl, cont, rpc, cont_proto_ver);
 		if (likely(rc == 0))
 			d_tm_inc_counter(metrics->open_total, 1);
 		break;
 	case CONT_CLOSE:
-		rc = cont_close(tx, pool_hdl, cont, rpc);
+		rc = cont_close(tx, pool_hdl, cont, rpc, &update_mtime_needed);
 		if (likely(rc == 0))
 			d_tm_inc_counter(metrics->close_total, 1);
 		break;
@@ -3789,11 +3976,17 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 						cont->c_uuid),
 					DP_UUID(in->ci_hdl), rc);
 			}
-			D_GOTO(out, rc);
+			goto out;
 		}
-		rc = cont_op_with_hdl(tx, pool_hdl, cont, &hdl, rpc);
+		rc = cont_op_with_hdl(tx, pool_hdl, cont, &hdl, rpc, cont_proto_ver,
+				      &update_mtime_needed);
+		if (rc != 0)
+			goto out;
 	}
 out:
+	if (rc == 0)
+		*update_mtime = update_mtime_needed;
+
 	return rc;
 }
 
@@ -3803,9 +3996,10 @@ out:
  */
 static int
 cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
-		 crt_rpc_t *rpc)
+		 crt_rpc_t *rpc, int cont_proto_ver)
 {
 	struct cont_op_in		*in = crt_req_get(rpc);
+	struct cont_open_in		*o_in = NULL;
 	struct cont_open_bylabel_in	*olbl_in = NULL;
 	struct cont_open_bylabel_out	*olbl_out = NULL;
 	struct cont_destroy_bylabel_in	*dlbl_in = NULL;
@@ -3813,6 +4007,9 @@ cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
 	crt_opcode_t			 opc = opc_get(rpc->cr_opc);
 	struct cont			*cont = NULL;
 	struct cont_pool_metrics	*metrics;
+	const uint64_t			 FLAG_RO_MDSTATS = (DAOS_COO_RO | DAOS_COO_RO_MDSTATS);
+	bool				 update_otime = false;
+	bool				 update_mtime = false;
 	int				 rc;
 
 	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
@@ -3828,6 +4025,8 @@ cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
 
 	switch (opc) {
 	case CONT_CREATE:
+		D_DEBUG(DB_MD, DF_CONT": opc=%d (CONT_CREATE)\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), opc);
 		rc = cont_create(&tx, pool_hdl, svc, rpc);
 		if (likely(rc == 0)) {
 			metrics = pool_hdl->sph_pool->sp_metrics[DAOS_CONT_MODULE];
@@ -3835,34 +4034,53 @@ cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
 		}
 		break;
 	case CONT_OPEN_BYLABEL:
+		D_DEBUG(DB_MD, DF_CONT": opc=%d (CONT_OPEN_BYLABEL)\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), opc);
 		olbl_in = crt_req_get(rpc);
 		olbl_out = crt_reply_get(rpc);
 		rc = cont_lookup_bylabel(&tx, svc, olbl_in->coli_label, &cont);
 		if (rc != 0)
-			D_GOTO(out_lock, rc);
+			goto out_lock;
 		/* NB: call common cont_op_with_cont() same as CONT_OPEN case */
-		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc);
+		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc, &update_mtime, cont_proto_ver);
 		uuid_copy(olbl_out->colo_uuid, cont->c_uuid);
-		cont_put(cont);
+		update_otime = ((olbl_in->coi_flags & FLAG_RO_MDSTATS) == FLAG_RO_MDSTATS) ?
+				false : true;
 		break;
 	case CONT_DESTROY_BYLABEL:
+		D_DEBUG(DB_MD, DF_CONT": opc=%d (CONT_DESTROY_BYLABEL)\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), opc);
 		dlbl_in = crt_req_get(rpc);
 		rc = cont_lookup_bylabel(&tx, svc, dlbl_in->cdli_label, &cont);
 		if (rc != 0)
-			D_GOTO(out_lock, rc);
+			goto out_lock;
 		/* NB: call common cont_op_with_cont() same as CONT_DESTROY */
-		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc);
-		cont_put(cont);
+		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc, &update_mtime, cont_proto_ver);
 		break;
+	case CONT_OPEN:
+		D_DEBUG(DB_MD, DF_CONT": opc=%d (CONT_OPEN)\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), opc);
+		o_in = crt_req_get(rpc);
+		update_otime = ((o_in->coi_flags & FLAG_RO_MDSTATS) == FLAG_RO_MDSTATS) ?
+				false : true;
+		/* pass through */
 	default:
+		D_DEBUG(DB_MD, DF_CONT": opc=%d\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), opc);
 		rc = cont_lookup(&tx, svc, in->ci_uuid, &cont);
 		if (rc != 0)
-			D_GOTO(out_lock, rc);
-		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc);
-		cont_put(cont);
+			goto out_lock;
+		rc = cont_op_with_cont(&tx, pool_hdl, cont, rpc, &update_mtime, cont_proto_ver);
 	}
 	if (rc != 0)
-		D_GOTO(out_lock, rc);
+		goto out_contref;
+
+	/* Update container open and metadata modified times as applicable
+	 * NB: this is a NOOP if the pool has not been upgraded to the layout containing mdtimes.
+	 */
+	rc = update_metadata_times(&tx, cont, update_otime, update_mtime);
+	if (rc != 0)
+		goto out_contref;
 
 	rc = rdb_tx_commit(&tx);
 	if (rc != 0)
@@ -3871,6 +4089,9 @@ cont_op_with_svc(struct ds_pool_hdl *pool_hdl, struct cont_svc *svc,
 			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid),
 			rpc, opc, DP_UUID(in->ci_hdl), DP_RC(rc));
 
+out_contref:
+	if (cont)
+		cont_put(cont);
 out_lock:
 	ABT_rwlock_unlock(svc->cs_lock);
 	rdb_tx_end(&tx);
@@ -3879,12 +4100,15 @@ out:
 	if (rc == 0 && (opc == CONT_SNAP_CREATE || opc == CONT_SNAP_DESTROY))
 		ds_cont_update_snap_iv(svc, in->ci_uuid);
 
+	D_DEBUG(DB_MD, DF_CONT": opc=%d returning, "DF_RC"\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), opc, DP_RC(rc));
+
 	return rc;
 }
 
 /* Look up the pool handle and the matching container service. */
-void
-ds_cont_op_handler(crt_rpc_t *rpc)
+static void
+ds_cont_op_handler(crt_rpc_t *rpc, int cont_proto_ver)
 {
 	struct cont_op_in		*in = crt_req_get(rpc);
 	struct cont_op_out		*out = crt_reply_get(rpc);
@@ -3915,7 +4139,7 @@ ds_cont_op_handler(crt_rpc_t *rpc)
 		D_GOTO(out_pool_hdl, rc);
 	}
 
-	rc = cont_op_with_svc(pool_hdl, svc, rpc);
+	rc = cont_op_with_svc(pool_hdl, svc, rpc, cont_proto_ver);
 
 	ds_rsvc_set_hint(svc->cs_rsvc, &out->co_hint);
 	cont_svc_put_leader(svc);
@@ -3941,7 +4165,7 @@ out_pool_hdl:
 out:
 	/* cleanup the properties for cont_query */
 	if (opc == CONT_QUERY) {
-		struct cont_query_out  *cqo = crt_reply_get(rpc);
+		struct cont_query_out *cqo = crt_reply_get(rpc);
 
 		prop = cqo->cqo_prop;
 	} else if ((opc == CONT_OPEN) || (opc == CONT_OPEN_BYLABEL)) {
@@ -3952,6 +4176,18 @@ out:
 	out->co_rc = rc;
 	crt_reply_send(rpc);
 	daos_prop_free(prop);
+}
+
+void
+ds_cont_op_handler_v7(crt_rpc_t *rpc)
+{
+	return ds_cont_op_handler(rpc, 7);
+}
+
+void
+ds_cont_op_handler_v6(crt_rpc_t *rpc)
+{
+	return ds_cont_op_handler(rpc, 6);
 }
 
 int
@@ -4100,7 +4336,7 @@ ds_cont_set_prop_handler(crt_rpc_t *rpc)
 
 	/* Client RPCs go through the regular flow with pool/cont handles */
 	if (daos_rpc_from_client(rpc)) {
-		ds_cont_op_handler(rpc);
+		ds_cont_op_handler(rpc, 7);
 		return;
 	}
 

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -178,7 +178,8 @@ struct cont_iv_key {
 };
 
 /* srv_container.c */
-void ds_cont_op_handler(crt_rpc_t *rpc);
+void ds_cont_op_handler_v7(crt_rpc_t *rpc);
+void ds_cont_op_handler_v6(crt_rpc_t *rpc);
 void ds_cont_set_prop_handler(crt_rpc_t *rpc);
 int ds_cont_bcast_create(crt_context_t ctx, struct cont_svc *svc,
 			 crt_opcode_t opcode, crt_rpc_t **rpc);

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -50,6 +50,7 @@ RDB_STRING_KEY(ds_cont_prop_, ec_pda);
 RDB_STRING_KEY(ds_cont_prop_, rp_pda);
 RDB_STRING_KEY(ds_cont_prop_, cont_global_version);
 RDB_STRING_KEY(ds_cont_prop_, scrubber_disabled);
+RDB_STRING_KEY(ds_cont_prop_, co_md_times);
 
 /* dummy value for container roots, avoid malloc on demand */
 static struct daos_prop_co_roots dummy_roots;

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -79,6 +79,11 @@ extern d_iov_t ds_cont_prop_cont_handles;	/* container handle KVS */
  *   usage shall be described above in this comment following existing
  *   examples. If the value is another KVS, its type shall be the KVS name.
  */
+struct co_md_times {
+	uint64_t	otime;	/* container open time */
+	uint64_t	mtime;	/* container metadata modify time */
+};
+
 extern d_iov_t ds_cont_prop_ghce;		/* uint64_t */
 extern d_iov_t ds_cont_prop_alloced_oid;	/* uint64_t */
 extern d_iov_t ds_cont_prop_label;		/* string */
@@ -108,6 +113,8 @@ extern d_iov_t ds_cont_prop_ec_pda;		/* uint64_t */
 extern d_iov_t ds_cont_prop_rp_pda;		/* uint64_t */
 extern d_iov_t ds_cont_prop_cont_global_version;/* uint32_t */
 extern d_iov_t ds_cont_prop_scrubber_disabled;	/* uint64_t */
+extern d_iov_t ds_cont_prop_co_md_times;	/* co_md_times */
+
 /* Please read the IMPORTANT notes above before adding new keys. */
 
 /*

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -79,6 +79,9 @@ func (cmd *containerBaseCmd) contUUIDPtr() *C.uchar {
 
 func (cmd *containerBaseCmd) openContainer(openFlags C.uint) error {
 	openFlags |= C.DAOS_COO_FORCE
+	if (openFlags & C.DAOS_COO_RO) != 0 {
+		openFlags |= C.DAOS_COO_RO_MDSTATS
+	}
 
 	var rc C.int
 	switch {
@@ -720,6 +723,8 @@ func printContainerInfo(out io.Writer, ci *containerInfo, verbose bool) error {
 			{"Number of snapshots": fmt.Sprintf("%d", *ci.NumSnapshots)},
 			{"Latest Persistent Snapshot": fmt.Sprintf("%#x", *ci.LatestSnapshot)},
 			{"Container redundancy factor": fmt.Sprintf("%d", *ci.RedundancyFactor)},
+			{"Latest open time": fmt.Sprintf("%#x", *ci.OpenTime)},
+			{"Latest close/modify time": fmt.Sprintf("%#x", *ci.CloseModifyTime)},
 		}...)
 
 		if ci.ObjectClass != "" {
@@ -741,6 +746,8 @@ type containerInfo struct {
 	LatestSnapshot   *uint64    `json:"latest_snapshot"`
 	RedundancyFactor *uint32    `json:"redundancy_factor"`
 	NumSnapshots     *uint32    `json:"num_snapshots"`
+	OpenTime         *uint64    `json:"open_time"`
+	CloseModifyTime  *uint64    `json:"close_modify_time"`
 	Type             string     `json:"container_type"`
 	ObjectClass      string     `json:"object_class,omitempty"`
 	ChunkSize        uint64     `json:"chunk_size,omitempty"`
@@ -765,7 +772,8 @@ func newContainerInfo(poolUUID, contUUID *uuid.UUID) *containerInfo {
 	ci.LatestSnapshot = (*uint64)(&ci.dci.ci_lsnapshot)
 	ci.RedundancyFactor = (*uint32)(&ci.dci.ci_redun_fac)
 	ci.NumSnapshots = (*uint32)(&ci.dci.ci_nsnapshots)
-
+	ci.OpenTime = (*uint64)(&ci.dci.ci_md_otime)
+	ci.CloseModifyTime = (*uint64)(&ci.dci.ci_md_mtime)
 	return ci
 }
 

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -39,8 +39,11 @@ extern "C" {
  */
 #define DAOS_COO_FORCE		(1U << 3)
 
+/** Skips container metadata time updates on DAOS_COO_RO open, and subsequent close */
+#define DAOS_COO_RO_MDSTATS	(1U << 4)
+
 /** Number of bits in the container open mode flag, DAOS_COO_ bits */
-#define DAOS_COO_NBITS	(4)
+#define DAOS_COO_NBITS	(5)
 
 /** Mask for all of the bits in the container open mode flag, DAOS_COO_ bits */
 #define DAOS_COO_MASK	((1U << DAOS_COO_NBITS) - 1)
@@ -55,10 +58,10 @@ typedef struct {
 	uint32_t		ci_redun_fac;
 	/** Number of snapshots */
 	uint32_t		ci_nsnapshots;
-	/** Redundancy level */
-	uint32_t		ci_redun_lvl;
-	/** Container information pad (not used) */
-	uint32_t		ci_pad[3];
+	/** Latest open time (hybrid logical clock) */
+	uint64_t		ci_md_otime;
+	/** Latest close/modify time (hybrid logical clock) */
+	uint64_t		ci_md_mtime;
 	/* TODO: add more members, e.g., size, # objects, uid, gid... */
 } daos_cont_info_t;
 
@@ -228,8 +231,7 @@ daos_cont_close(daos_handle_t coh, daos_event_t *ev);
  * when the operation completes.
  *
  * \param[in]	poh	Pool connection handle.
- * \param[in]	cont	Label or UUID string to idenfity the container to
- *			destroy
+ * \param[in]	cont	Label or UUID string to identify the container to destroy.
  * \param[in]	force	Container destroy will return failure if the container
  *			is still busy (outstanding open handles). This parameter
  *			will force the destroy to proceed even if there is an

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -77,8 +77,8 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
                     "total": self.params.get("total", path="/run/exp_vals/nvme/*")
                 }
             ],
-            "pool_layout_ver": 1,
-            "upgrade_layout_ver": 1,
+            "pool_layout_ver": 2,
+            "upgrade_layout_ver": 2,
             "rebuild": {
                 "status": self.params.get("rebuild_status", path="/run/exp_vals/rebuild/*"),
                 "state": self.params.get("state", path="/run/exp_vals/rebuild/*"),

--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -58,11 +58,11 @@ class ListVerboseTest(IorTestBase):
             "svc_reps": pool.svc_ranks,
             "targets_total": targets_total,
             "targets_disabled": targets_disabled,
-            "pool_layout_ver": 1,
+            "pool_layout_ver": 2,
             "query_error_msg": "",
             "query_status_msg": "",
             "state": "Ready",
-            "upgrade_layout_ver": 1,
+            "upgrade_layout_ver": 2,
             "usage": [
                 {
                     "tier_name": "SCM",


### PR DESCRIPTION
With this change, daos_cont_open() and daos_cont_query() return the
most recent open and close/modify times in the daos_cont_info_t
output argument. The new information is returned as hybrid logical
clock (HLC) values. Container operations that only read the metadata
state will not update these times, while other operations will update
the modify time. This is envisioned as a basic mechanism for a user
to identify containers not used recently (from a metadata standpoint,
not an IO standpoint).

A future patch is envisioned to provide a pool list containers
interface with some filtering criteria, to find containers that
may fit some user-determined criteria for migration or removal.

Main changes summary
- container properties KVS includes new key/val for metadata times
  (using same DAOS_POOL_GLOBAL_VERSION=2 for master/release 2.4 dev).
- pool/container upgrade code changed to initialize metadata times.
- libdaos API minor version incremented (v2.3.0 -> v2.4.0)
- daos_cont_info_t.ci_pad, .ci_redun_lvl repurposed to make space
  for the new time fields while keeping the same structure size.
  (ci_redun_lvl is otherwise available through container properties).
- daos_test container test added (co_mdtimes).
- daos_test container tests modified to check redundancy level via
  property value rather than daos_cont_info_t field.
- daos utility output (both JSON and human-readable when run with -v)
  contains the new metadata time information.
  (future change will make HLC data human-readable date/time strings).
- CaRT protocol for CONT_OPEN, CONT_OPEN_BYLABEL, and CONT_QUERY
  existing version (6) maintained, and new version (7) added that
  returns metadata open and close/modify times.
- engine code register and handle protocol v6 or v7 RPCs.
- client code registers and uses uses only the new/v7 protocol.
  (Possible future change: client query engine then register v6 or v7).

Other changes:
- fix for container upgrade is implemented, since the original code
  only supported global version 0->1 upgrade. See DAOS-11386.
- change dmg and pool functional tests to expect pool layout v2
  following recent DAOS_POOL_GLOBAL_VERSION update. DAOS-11282.
- satisfy pylint suggestion for f-string in SConstruct, API_VERSION.
- satisfy jira_query.py failure, add 'md' as a valid component
  in PR/commit titles.

Quick-Functional: true
Skip-func-test-vm: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: true
Test-tag: test_pool_query_basic

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>