### PR TITLE
DAOS-10431 build: add gcc and leap/rocky build on ARM64

### DIFF
--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -302,15 +302,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [ubuntu, rocky, leap.15]
+        distro: [ubuntu, alma.8, leap.15]
         compiler: [clang]
         include:
           - distro: ubuntu
             base: ubuntu
             with: ubuntu:22.04
-          - distro: rocky
+          - distro: alma.8
             base: el.8
-            with: rockylinux/rockylinux:8
+            with: almalinux:8
           - distro: leap.15
             base: leap.15
             with: opensuse/leap:15.4

--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -302,12 +302,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [ubuntu]
+        distro: [ubuntu, rocky, leap.15]
         compiler: [clang]
         include:
           - distro: ubuntu
             base: ubuntu
             with: ubuntu:22.04
+          - distro: rocky
+            base: el.8
+            with: rockylinux/rockylinux:8
+          - distro: leap.15
+            base: leap.15
+            with: opensuse/leap:15.4
     env:
       DEPS_JOBS: 10
       BASE_DISTRO: ${{ matrix.with }}
@@ -351,24 +357,24 @@ jobs:
                             --build-arg DAOS_JAVA_BUILD=no
                             --build-arg DAOS_BUILD_TYPE=dev
                             --build-arg COMPILER=clang
-      #- name: Build in docker with gcc
-      #  run: docker build . --file utils/docker/Dockerfile.${{ matrix.base }}
-      #                      --build-arg DEPS_JOBS
-      #                      --build-arg BASE_DISTRO
-      #                      --build-arg DAOS_JAVA_BUILD=no
-      #                      --build-arg COMPILER=gcc
-      #- name: Build debug in docker with gcc
-      #  run: docker build . --file utils/docker/Dockerfile.${{ matrix.base }}
-      #                      --build-arg DEPS_JOBS
-      #                      --build-arg BASE_DISTRO
-      #                      --build-arg DAOS_JAVA_BUILD=no
-      #                      --build-arg DAOS_BUILD_TYPE=debug
-      #                      --build-arg COMPILER=gcc
-      #- name: Build devel in docker with gcc
-      #  run: docker build . --file utils/docker/Dockerfile.${{ matrix.base }}
-      #                      --build-arg DEPS_JOBS
-      #                      --build-arg BASE_DISTRO
-      #                      --build-arg DAOS_JAVA_BUILD=no
-      #                      --build-arg DAOS_BUILD_TYPE=dev
-      #                      --build-arg COMPILER=gcc
-      #                      --tag build-image
+      - name: Build in docker with gcc
+        run: docker build . --file utils/docker/Dockerfile.${{ matrix.base }}
+                            --build-arg DEPS_JOBS
+                            --build-arg BASE_DISTRO
+                            --build-arg DAOS_JAVA_BUILD=no
+                            --build-arg COMPILER=gcc
+      - name: Build debug in docker with gcc
+        run: docker build . --file utils/docker/Dockerfile.${{ matrix.base }}
+                            --build-arg DEPS_JOBS
+                            --build-arg BASE_DISTRO
+                            --build-arg DAOS_JAVA_BUILD=no
+                            --build-arg DAOS_BUILD_TYPE=debug
+                            --build-arg COMPILER=gcc
+      - name: Build devel in docker with gcc
+        run: docker build . --file utils/docker/Dockerfile.${{ matrix.base }}
+                            --build-arg DEPS_JOBS
+                            --build-arg BASE_DISTRO
+                            --build-arg DAOS_JAVA_BUILD=no
+                            --build-arg DAOS_BUILD_TYPE=dev
+                            --build-arg COMPILER=gcc
+                            --tag build-image


### PR DESCRIPTION
gcc build on ARM64 was disable due to a compiler issue
that has been worked around since then.
Add ARM build on leap and rocky.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>