### PR TITLE
DAOS-11438 control: Call raft.Barrier() after leadership step-up

### DIFF
--- a/src/control/system/raft/mocks.go
+++ b/src/control/system/raft/mocks.go
@@ -78,6 +78,10 @@ func (mrs *mockRaftService) State() raft.RaftState {
 	return mrs.cfg.State
 }
 
+func (mrs *mockRaftService) Barrier(time.Duration) raft.Future {
+	return &mockRaftFuture{}
+}
+
 func newMockRaftService(cfg *mockRaftServiceConfig, fsm raft.FSM) *mockRaftService {
 	if cfg == nil {
 		cfg = &mockRaftServiceConfig{

--- a/src/control/system/raft/raft.go
+++ b/src/control/system/raft/raft.go
@@ -106,6 +106,14 @@ func (db *Database) ResignLeadership(cause error) error {
 	return cause
 }
 
+// Barrier blocks until the raft implementation has persisted all
+// outstanding log entries.
+func (db *Database) Barrier() error {
+	return db.raft.withReadLock(func(svc raftService) error {
+		return svc.Barrier(0).Error()
+	})
+}
+
 // ShutdownRaft signals that the raft implementation should shut down
 // and release any resources it is holding. Blocks until the shutdown
 // is complete.


### PR DESCRIPTION
In rare cases, there could be a race between replaying logs
and system queries that results in erroneous pool cleanup
attempts on leader step-up.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
