### PR TITLE
DAOS-11035 dtx: fix some DXT related issues

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -407,9 +407,6 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		mbs = dre->dre_dte.dte_mbs;
 		D_ASSERT(mbs->dm_tgt_cnt > 0);
 
-		if (mbs->dm_dte_flags & DTE_LEADER)
-			goto commit;
-
 		rc = dtx_is_leader(pool, dra, dre);
 		if (rc <= 0) {
 			if (rc < 0)
@@ -521,22 +518,13 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	if (ent->ie_dtx_tgt_cnt == 0)
 		return 0;
 
-	if (ent->ie_dtx_flags & DTE_LEADER) {
-		/* Pool map refresh, non-discard case, I am still the leader, do nothing. */
-		if (!dra->resync_all)
-			return 0;
-
-		/*
-		 * Open container, old committable DTX entries are not in the CoS cache.
-		 * Then handle the DTX entries with old epoch (dtx_epoch < resync_epoch).
-		 */
-		if (ent->ie_epoch > dra->epoch)
-			return 0;
-	} else {
-		/* Leader switch only can happen for old DTX entries (dtx_ver < resync_ver). */
-		if (ent->ie_dtx_ver >= dra->resync_version)
-			return 0;
-	}
+	/*
+	 * Current DTX resync may be shared by pool map refresh and container open. If it is
+	 * sponsored by pool map refresh, then it is possible that resync version is smaller
+	 * than some DTX entries that also need to be resynced. So here, we only trust epoch.
+	 */
+	if (ent->ie_epoch > dra->epoch)
+		return 0;
 
 	D_ASSERT(ent->ie_dtx_mbs_dsize > 0);
 

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -132,7 +132,8 @@ dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t next /
 		dae = rec_iov.iov_buf;
 	}
 
-	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted) {
+	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+	       dae->dae_dth != NULL) {
 		if (oiter->oit_linear) {
 			if (dae->dae_link.next ==
 			    &oiter->oit_cont->vc_dtx_act_list) {
@@ -203,7 +204,8 @@ dtx_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 				 sizeof(struct vos_dtx_act_ent));
 			dae = rec_iov.iov_buf;
 		}
-	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted);
+	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+		 dae->dae_dth != NULL);
 
 out:
 	return rc;
@@ -242,6 +244,7 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	D_ASSERT(!dae->dae_committable);
 	D_ASSERT(!dae->dae_committed);
 	D_ASSERT(!dae->dae_aborted);
+	D_ASSERT(dae->dae_dth == NULL);
 
 	it_entry->ie_epoch = DAE_EPOCH(dae);
 	it_entry->ie_dtx_xid = DAE_XID(dae);


### PR DESCRIPTION
It includes the following fixes:

1. Skip new non-committed DTX when check visibility for rebuild

Up layer rebuild logic guarantees that the rebuild scan will not be
triggered until DTX resync has been done on all related targets. So
here, if rebuild logic hits non-committed DTX entry, it must be for
new IO that version is not older than rebuild, then it is invisible
to rebuild. Related new IO corresponding to such non-committed DTX
has already been sent to the in-rebuilding target.

2. Skip new DTX during DTX resync

Even if current target was the DTX leader, but if the version of
the DTX is older than DTX resync version, we still need to resync
it. Because its sponsor may be dead (if not dead, then skip it).

Signed-off-by: Fan Yong <fan.yong@intel.com>