### PR TITLE
DAOS-9582 control: Add common.CheckDupeProcess()

### DIFF
--- a/src/control/common/proc_utils.go
+++ b/src/control/common/proc_utils.go
@@ -7,39 +7,43 @@
 package common
 
 import (
-	"io/ioutil"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 )
 
+func subStr(in string, max int) string {
+	if len(in) > max {
+		return in[:max]
+	}
+	return in
+}
+
 func getProcPids(procDir, procName string) (pids []int, _ error) {
-	allProcs, err := filepath.Glob(procDir + "/*/status")
+	allProcs, err := filepath.Glob(filepath.Join(procDir, "*", "stat"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read process list")
 	}
+
+	maxProcName := 15 // TASK_COMM_LEN-1 in linux/sched.h
+	var pid int
+	var name string
 	for _, proc := range allProcs {
-		data, err := ioutil.ReadFile(proc)
+		data, err := os.ReadFile(proc)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to read process command line")
+			return nil, errors.Wrap(err, "failed to read process file")
 		}
-		lines := strings.Split(string(data), "\n")
-		if len(lines) == 0 {
-			return nil, errors.Errorf("invalid process status file: %s", proc)
+		stat := string(data)
+		if _, err := fmt.Sscanf(stat, "%d %s", &pid, &name); err != nil {
+			return nil, errors.Wrapf(err, "failed to parse process stat file %q", stat)
 		}
-		namePair := strings.SplitN(lines[0], ":", 2)
-		if len(namePair) < 2 {
-			return nil, errors.Errorf("invalid process status file: %s", proc)
-		}
-		if strings.TrimSpace(namePair[1]) != procName {
+		if len(name) < 2 {
 			continue
 		}
-
-		pid, err := strconv.Atoi(filepath.Base(filepath.Dir(proc)))
-		if err != nil {
+		if subStr(name[1:len(name)-1], maxProcName) != subStr(procName, maxProcName) {
 			continue
 		}
 		pids = append(pids, pid)

--- a/src/control/common/proc_utils.go
+++ b/src/control/common/proc_utils.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/pkg/errors"
 )
@@ -105,5 +106,11 @@ func checkDupeProcess(pid int, procDir string) error {
 // CheckDupeProcess checks to see if another process with the same name as
 // ours is running.
 func CheckDupeProcess() error {
-	return checkDupeProcess(os.Getpid(), "/proc")
+	// Prefer the pgrp over the pid if it's set. This will
+	// allow us to avoid misidentifying threads as separate processes.
+	pid := syscall.Getpgrp()
+	if pid == 0 {
+		pid = os.Getpid()
+	}
+	return checkDupeProcess(pid, "/proc")
 }

--- a/src/control/common/proc_utils.go
+++ b/src/control/common/proc_utils.go
@@ -7,60 +7,35 @@
 package common
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/pkg/errors"
 )
 
-func subStr(in string, max int) string {
-	if len(in) > max {
-		return in[:max]
-	}
-	return in
-}
-
 func getProcPids(procDir, procName string) (pids []int, _ error) {
-	allProcs, err := filepath.Glob(filepath.Join(procDir, "*", "stat"))
+	allProcs, err := filepath.Glob(filepath.Join(procDir, "*", "cmdline"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read process list")
 	}
 
-	maxProcName := 15 // TASK_COMM_LEN-1 in linux/sched.h
-	var pid, ppid, pgrp int
 	for _, proc := range allProcs {
 		data, err := os.ReadFile(proc)
 		if err != nil {
 			continue
 		}
 		if len(data) == 0 {
-			return nil, errors.New("empty process file")
-		}
-		line := string(data)
-
-		lIdx := strings.Index(line, "(")
-		rIdx := strings.Index(line, ")")
-		if lIdx == -1 || rIdx == -1 {
 			continue
 		}
-		if subStr(line[lIdx+1:rIdx], maxProcName) != subStr(procName, maxProcName) {
+		comps := strings.Split(string(data), "\x00")
+		if !(filepath.Base(comps[0]) == procName) {
 			continue
 		}
 
-		if n, err := fmt.Sscanf(line, "%d", &pid); err != nil || n == 0 {
-			return nil, errors.Wrapf(err, "failed to parse pid from process stat file %q", line)
-		}
-		if n, err := fmt.Sscanf(line[rIdx+3:], "%d %d", &ppid, &pgrp); err != nil || n == 0 {
-			return nil, errors.Wrapf(err, "failed to parse pgrp from process stat file %q", line[rIdx+3:])
-		}
-		if pgrp != 0 {
-			// use the process group as the pid to avoid misidentifying
-			// threads as separate processes
-			pids = append(pids, pgrp)
+		pid, err := strconv.Atoi(filepath.Base(filepath.Dir(proc)))
+		if err != nil {
 			continue
 		}
 		pids = append(pids, pid)
@@ -106,11 +81,5 @@ func checkDupeProcess(pid int, procDir string) error {
 // CheckDupeProcess checks to see if another process with the same name as
 // ours is running.
 func CheckDupeProcess() error {
-	// Prefer the pgrp over the pid if it's set. This will
-	// allow us to avoid misidentifying threads as separate processes.
-	pid := syscall.Getpgrp()
-	if pid == 0 {
-		pid = os.Getpid()
-	}
-	return checkDupeProcess(pid, "/proc")
+	return checkDupeProcess(os.Getpid(), "/proc")
 }

--- a/src/control/common/proc_utils.go
+++ b/src/control/common/proc_utils.go
@@ -1,0 +1,89 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package common
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func getProcPids(procDir, procName string) (pids []int, _ error) {
+	allProcs, err := filepath.Glob(procDir + "/*/status")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read process list")
+	}
+	for _, proc := range allProcs {
+		data, err := ioutil.ReadFile(proc)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read process command line")
+		}
+		lines := strings.Split(string(data), "\n")
+		if len(lines) == 0 {
+			return nil, errors.Errorf("invalid process status file: %s", proc)
+		}
+		namePair := strings.SplitN(lines[0], ":", 2)
+		if len(namePair) < 2 {
+			return nil, errors.Errorf("invalid process status file: %s", proc)
+		}
+		if strings.TrimSpace(namePair[1]) != procName {
+			continue
+		}
+
+		pid, err := strconv.Atoi(filepath.Base(filepath.Dir(proc)))
+		if err != nil {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+
+	return
+}
+
+// GetProcPids returns a list of pids for the given process name.
+func GetProcPids(procName string) (pids []int, _ error) {
+	return getProcPids("/proc", procName)
+}
+
+func getProcName(pid int, procDir string) (string, error) {
+	exe, err := os.Readlink(procDir + "/" + strconv.Itoa(pid) + "/exe")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read executable path")
+	}
+	return filepath.Base(exe), nil
+}
+
+func checkDupeProcess(pid int, procDir string) error {
+	name, err := getProcName(pid, procDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to get process name")
+	}
+	pids, err := getProcPids(procDir, name)
+	if err != nil {
+		return errors.Wrap(err, "failed to read process list")
+	}
+
+	for _, otherPid := range pids {
+		if otherPid == pid {
+			continue
+		}
+
+		return errors.Errorf("another %s process is already running (pid: %d)", name, otherPid)
+	}
+
+	return nil
+}
+
+// CheckDupeProcess checks to see if another process with the same name as
+// ours is running.
+func CheckDupeProcess() error {
+	return checkDupeProcess(os.Getpid(), "/proc")
+}

--- a/src/control/common/proc_utils_test.go
+++ b/src/control/common/proc_utils_test.go
@@ -1,0 +1,124 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package common
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+)
+
+func addProcEntry(t *testing.T, root string, pid int, name string) {
+	if err := os.MkdirAll(root+"/"+strconv.Itoa(pid), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(root+"/"+strconv.Itoa(pid)+"/status", []byte("Name: "+name), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(name, root+"/"+strconv.Itoa(pid)+"/exe"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func makeProcTree(t *testing.T, numEntries int) string {
+	t.Helper()
+
+	procRoot := t.TempDir()
+	for i := 0; i < numEntries; i++ {
+		addProcEntry(t, procRoot, i, fmt.Sprintf("test-%d", i))
+	}
+
+	return procRoot
+}
+
+func Test_Common_checkDupeProcess(t *testing.T) {
+	procRoot := makeProcTree(t, 5)
+	addProcEntry(t, procRoot, 5, "test-1")
+
+	for name, tc := range map[string]struct {
+		procPid int
+		wantErr bool
+	}{
+		"duplicate process": {
+			procPid: 5,
+			wantErr: true,
+		},
+		"non-duplicate process": {
+			procPid: 2,
+			wantErr: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := checkDupeProcess(tc.procPid, procRoot); (err != nil) != tc.wantErr {
+				t.Errorf("checkDupeProcess() = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func Test_Common_getProcPids(t *testing.T) {
+	procRoot := makeProcTree(t, 5)
+	addProcEntry(t, procRoot, 5, "test-1")
+
+	for name, tc := range map[string]struct {
+		procName string
+		expPids  []int
+		expErr   error
+		setup    func(*testing.T)
+		cleanup  func(*testing.T)
+	}{
+		"dupe process name": {
+			procName: "test-1",
+			expPids:  []int{1, 5},
+			expErr:   nil,
+		},
+		"unique process name": {
+			procName: "test-2",
+			expPids:  []int{2},
+			expErr:   nil,
+		},
+		"bad status file": {
+			procName: "bad-status",
+			expErr:   errors.New("status file"),
+			setup: func(t *testing.T) {
+				addProcEntry(t, procRoot, 6, "bad-status")
+				if err := os.Truncate(procRoot+"/6/status", 0); err != nil {
+					t.Fatal(err)
+				}
+			},
+			cleanup: func(t *testing.T) {
+				os.RemoveAll(procRoot + "/6")
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+			if tc.cleanup != nil {
+				defer tc.cleanup(t)
+			}
+
+			gotPids, gotErr := getProcPids(procRoot, tc.procName)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(gotPids, tc.expPids); diff != "" {
+				t.Fatalf("getProcPids() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -500,6 +500,10 @@ func waitFabricReady(ctx context.Context, log logging.Logger, cfg *config.Server
 
 // Start is the entry point for a daos_server instance.
 func Start(log logging.Logger, cfg *config.Server) error {
+	if err := common.CheckDupeProcess(); err != nil {
+		return err
+	}
+
 	// Create the root context here. All contexts should inherit from this one so
 	// that they can be shut down from one place.
 	ctx, shutdown := context.WithCancel(context.Background())


### PR DESCRIPTION
Extracted from the cat_recovery feature branch and
cleaned up for inclusion in master. Allows a process
to check for other processes with the same name in
order to prevent starting more than one.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
