### PR TITLE
DAOS-11035 dtx: fix some DXT related issues (#10056)

### DIFF
--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -131,7 +131,8 @@ dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t next /
 		dae = rec_iov.iov_buf;
 	}
 
-	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted) {
+	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+	       dae->dae_dth != NULL) {
 		if (oiter->oit_linear) {
 			if (dae->dae_link.next ==
 			    &oiter->oit_cont->vc_dtx_act_list) {
@@ -202,7 +203,8 @@ dtx_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 				 sizeof(struct vos_dtx_act_ent));
 			dae = rec_iov.iov_buf;
 		}
-	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted);
+	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+		 dae->dae_dth != NULL);
 
 out:
 	return rc;
@@ -241,6 +243,7 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	D_ASSERT(!dae->dae_committable);
 	D_ASSERT(!dae->dae_committed);
 	D_ASSERT(!dae->dae_aborted);
+	D_ASSERT(dae->dae_dth == NULL);
 
 	it_entry->ie_epoch = DAE_EPOCH(dae);
 	it_entry->ie_dtx_xid = DAE_XID(dae);


### PR DESCRIPTION
It includes the following fixes:

1. Skip new non-committed DTX when check visibility for rebuild

Up layer rebuild logic guarantees that the rebuild scan will not be
triggered until DTX resync has been done on all related targets. So
here, if rebuild logic hits non-committed DTX entry, it must be for
new IO that version is not older than rebuild, then it is invisible
to rebuild. Related new IO corresponding to such non-committed DTX
has already been sent to the in-rebuilding target.

2. Skip new DTX during DTX resync

Even if current target was the DTX leader, but if the version of
the DTX is older than DTX resync version, we still need to resync
it. Because its sponsor may be dead (if not dead, then skip it).

Signed-off-by: Fan Yong <fan.yong@intel.com>