### PR TITLE
DAOS-11035 dtx: continue to fix DXT related issues

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1364,8 +1364,7 @@ ds_dtx_resync(void *arg)
 	int				 rc;
 
 	rc = dtx_resync(ddra->pool->spc_hdl, ddra->pool->spc_uuid,
-			ddra->co_uuid, ddra->pool->spc_map_version,
-			false, true);
+			ddra->co_uuid, ddra->pool->spc_map_version, false);
 	if (rc != 0)
 		D_WARN("Fail to resync some DTX(s) for the pool/cont "
 		       DF_UUID"/"DF_UUID" that may affect subsequent "

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -778,6 +778,7 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_verified = 0;
 	dth->dth_aborted = 0;
 	dth->dth_already = 0;
+	dth->dth_need_validation = 0;
 
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_cnt;
@@ -1028,6 +1029,8 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 			     (flags & DTX_FOR_MIGRATION) ? true : false, false,
 			     (flags & DTX_RESEND) ? true : false,
 			     (flags & DTX_PREPARED) ? true : false, dth);
+	if (rc == 0 && sub_modification_cnt > 0)
+		rc = vos_dtx_attach(dth, false, (flags & DTX_PREPARED) ? true : false);
 
 	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, leader "
 		DF_UOID", dti_cos_cnt %d, flags %x: "DF_RC"\n",
@@ -1100,7 +1103,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 	if (daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
 
-	if (dth->dth_pinned || dth->dth_prepared) {
+	if (dth->dth_need_validation) {
 		/* During waiting for bulk data transfer or other non-leaders, the DTX
 		 * status may be changes by others (such as DTX resync or DTX refresh)
 		 * by race. Let's check it.
@@ -1346,6 +1349,8 @@ dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 			     (flags & DTX_FOR_MIGRATION) ? true : false,
 			     (flags & DTX_IGNORE_UNCOMMITTED) ? true : false,
 			     (flags & DTX_RESEND) ? true : false, false, dth);
+	if (rc == 0 && sub_modification_cnt > 0)
+		rc = vos_dtx_attach(dth, false, false);
 
 	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, "
 		"dti_cos_cnt %d, flags %x: "DF_RC"\n",

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -39,7 +39,6 @@ struct dtx_resync_args {
 	daos_epoch_t		 epoch;
 	uint32_t		 resync_version;
 	uint32_t		 discard_version;
-	uint32_t		 resync_all:1;
 };
 
 static inline void
@@ -560,8 +559,7 @@ out:
 }
 
 int
-dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
-	   bool block, bool resync_all)
+dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, bool block)
 {
 	struct ds_cont_child		*cont = NULL;
 	struct ds_pool			*pool;
@@ -631,10 +629,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	dra.cont = cont;
 	dra.resync_version = ver;
 	dra.epoch = crt_hlc_get();
-	if (resync_all)
-		dra.resync_all = 1;
-	else
-		dra.resync_all = 0;
 	D_INIT_LIST_HEAD(&dra.tables.drh_list);
 	dra.tables.drh_count = 0;
 
@@ -704,8 +698,7 @@ container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	uuid_copy(scan_arg->co_uuid, entry->ie_couuid);
-	rc = dtx_resync(iter_param->ip_hdl, arg->pool_uuid, entry->ie_couuid,
-			arg->version, true, false);
+	rc = dtx_resync(iter_param->ip_hdl, arg->pool_uuid, entry->ie_couuid, arg->version, true);
 	if (rc)
 		D_ERROR(DF_UUID" dtx resync failed: rc %d\n",
 			DP_UUID(arg->pool_uuid), rc);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -820,7 +820,7 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 
 out:
 	rc2 = dtx_rpc_post(&head, tree_hdl, &dra, &helper, rc);
-	if (rc2 > 0 || rc2 == -DER_NONEXIST)
+	if (rc2 > 0 || rc2 == -DER_NONEXIST || rc2 == -DER_EXCLUDED)
 		rc2 = 0;
 
 	if (dtis != &dti)

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -87,6 +87,8 @@ struct dtx_handle {
 					 dth_aborted:1,
 					 /* The modification is done by others. */
 					 dth_already:1,
+					 /* Need validation on leader before commit/committable. */
+					 dth_need_validation:1,
 					 /* Ignore other uncommitted DTXs. */
 					 dth_ignore_uncommitted:1;
 
@@ -310,8 +312,7 @@ struct dtx_scan_args {
 	uint32_t	version;
 };
 
-int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
-	       uint32_t ver, bool block, bool resync_all);
+int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, bool block);
 void dtx_resync_ult(void *arg);
 
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -42,9 +42,10 @@ vos_dtx_rsrvd_fini(struct dtx_handle *dth);
  *
  * \param dth		[IN]	The dtx handle
  * \param persistent	[IN]	Save the DTX entry in persistent storage if set.
+ * \param exist		[IN]	Related DTX entry exists or not.
  */
 int
-vos_dtx_attach(struct dtx_handle *dth, bool persistent);
+vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist);
 
 /**
  * Detach the DTX entry from the DTX handle.

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -69,6 +69,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_verified = 0;
 	dth->dth_aborted = 0;
 	dth->dth_already = 0;
+	dth->dth_need_validation = 0;
 
 	dth->dth_dti_cos_count = 0;
 	dth->dth_dti_cos = NULL;

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1404,7 +1404,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		return 0;
 	}
 
-	if (dth->dth_pinned && !dth->dth_verified) {
+	if (dth->dth_need_validation && !dth->dth_verified) {
 		rc = vos_dtx_validation(dth);
 		switch (rc) {
 		case DTX_ST_INITED:
@@ -1795,7 +1795,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 		if (mbs != NULL)
 			dae->dae_maybe_shared = 1;
 
-		if (dae->dae_dbd == NULL)
+		if (dae->dae_dbd == NULL || dae->dae_dth != NULL)
 			return -DER_INPROGRESS;
 
 		if (epoch != NULL) {
@@ -2760,27 +2760,47 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 }
 
 int
-vos_dtx_attach(struct dtx_handle *dth, bool persistent)
+vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist)
 {
 	struct vos_container	*cont;
 	struct umem_instance	*umm = NULL;
 	struct vos_dtx_blob_df	*dbd = NULL;
 	struct vos_dtx_cmt_ent	*dce = NULL;
+	struct vos_dtx_act_ent	*dae;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	bool			 began = false;
 	int			 rc = 0;
 
 	if (!dtx_is_valid_handle(dth))
 		return 0;
 
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
 	if (dth->dth_ent != NULL) {
 		if (!persistent || dth->dth_active)
 			return 0;
 	} else {
 		D_ASSERT(dth->dth_pinned == 0);
-	}
 
-	cont = vos_hdl2cont(dth->dth_coh);
-	D_ASSERT(cont != NULL);
+		if (exist) {
+			d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
+			d_iov_set(&riov, NULL, 0);
+			rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+			if (rc != 0)
+				goto out;
+
+			dae = riov.iov_buf;
+			if (dae->dae_dth == NULL)
+				dae->dae_dth = dth;
+			else
+				D_ASSERT(dae->dae_dth == dth);
+
+			dth->dth_ent = dae;
+			dth->dth_need_validation = dae->dae_need_validation;
+		}
+	}
 
 	if (persistent) {
 		struct vos_cont_df	*cont_df;
@@ -2806,16 +2826,16 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent)
 	if (dth->dth_ent == NULL) {
 		rc = vos_dtx_alloc(dbd, dth);
 	} else if (dbd != NULL) {
-		struct vos_dtx_act_ent	*dae = dth->dth_ent;
-
 		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
+		dae = dth->dth_ent;
 		dae->dae_df_off = cont->vc_cont_df->cd_dtx_active_tail +
 			offsetof(struct vos_dtx_blob_df, dbd_active_data) +
 			sizeof(struct vos_dtx_act_ent_df) * dbd->dbd_index;
 		dae->dae_dbd = dbd;
 	}
 
+out:
 	if (rc == 0) {
 		if (persistent) {
 			dth->dth_active = 1;
@@ -2823,10 +2843,7 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent)
 		} else {
 			dth->dth_pinned = 1;
 		}
-	}
-
-out:
-	if (rc != 0) {
+	} else {
 		if (dth->dth_ent != NULL) {
 			dth->dth_pinned = 0;
 			vos_dtx_cleanup_internal(dth);
@@ -2839,8 +2856,7 @@ out:
 	if (began) {
 		rc = umem_tx_end(umm, rc);
 		if (dce != NULL) {
-			struct vos_dtx_act_ent	*dae = dth->dth_ent;
-
+			dae = dth->dth_ent;
 			vos_dtx_post_handle(cont, &dae, &dce, 1,
 					    false, rc != 0 ? true : false);
 			dth->dth_ent = NULL;

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -246,6 +246,15 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	D_ASSERT(!dae->dae_aborted);
 	D_ASSERT(dae->dae_dth == NULL);
 
+	/*
+	 * The DTX entry is returned via the iteration. The upper layer caller, for DTX resync
+	 * or DTX cleanup, may abort it sometime later. Before being aborted, it may re-attach
+	 * to some DTX handle for handling resent request. Then there is race between them. So
+	 * before become committable or being committed by RPC handler, needs to check whether
+	 * it has been aborted or not.
+	 */
+	dae->dae_need_validation = 1;
+
 	it_entry->ie_epoch = DAE_EPOCH(dae);
 	it_entry->ie_dtx_xid = DAE_XID(dae);
 	it_entry->ie_dtx_oid = DAE_OID(dae);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -326,6 +326,8 @@ struct vos_dtx_act_ent {
 					 dae_committed:1,
 					 dae_aborted:1,
 					 dae_maybe_shared:1,
+					 /* Need validation on leader before commit/committable. */
+					 dae_need_validation:1,
 					 dae_prepared:1;
 };
 


### PR DESCRIPTION
It includes the following fixes:

1. Pin DTX entry in DRAM when DTX start

Originally, we pin the DTX entry in DRAM conditionally before ULT
yield. But it is relative complex to forecast whether the ULT may
yield or not. This patch much simplifies related logic and avoids
missing some corner cases.

2. Validate DTX entry before being committable or committed

If the DTX entry is returned via DTX iteration. The upper layer caller,
for DTX resync or DTX cleanup, may abort it sometime later. Before being
aborted, it may re-attach to some DTX handle for handling resent request.
Then there is race between them. So before being committable or committed
by RPC handler, needs to check whether it has been aborted or not.

3. Unify DTX resync for pool map refresh and container open

That will simplify DTX resync logic, drop confused parameter "resync_all",
and avoid missing to handle some DTX entry that is required for both cases
by race.

Signed-off-by: Fan Yong <fan.yong@intel.com>