### PR TITLE
DAOS-10431 test: run NLT on ARM64 runners

### DIFF
--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -377,7 +377,6 @@ jobs:
                             --build-arg DAOS_JAVA_BUILD=no
                             --build-arg DAOS_BUILD_TYPE=dev
                             --build-arg COMPILER=gcc
-                            --tag build-image
       - name: Run NLT
         if: matrix.distro != 'alma.9'
         run: docker run --mount type=tmpfs,destination=/mnt/daos_0,tmpfs-mode=1777 --user root:root

--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -378,3 +378,8 @@ jobs:
                             --build-arg DAOS_BUILD_TYPE=dev
                             --build-arg COMPILER=gcc
                             --tag build-image
+      - name: Run NLT
+        if: matrix.distro != 'alma.9'
+        run: docker run --mount type=tmpfs,destination=/mnt/daos_0,tmpfs-mode=1777 --user root:root
+                 build-image ./daos/utils/node_local_test.py --no-root
+                 --memcheck no --test cont_copy


### PR DESCRIPTION
So far, we have only been building on ARM64. This patch
runs node-local test (NLT) on the ARM64 self-hosted runners
kindly provided by the community.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>