### PR TITLE
DAOS-11438 control: Call raft.Barrier() after leadership step-up (#10053)

### DIFF
--- a/src/control/system/database.go
+++ b/src/control/system/database.go
@@ -43,6 +43,7 @@ type (
 		Leader() raft.ServerAddress
 		LeaderCh() <-chan bool
 		LeadershipTransfer() raft.Future
+		Barrier(time.Duration) raft.Future
 		Shutdown() raft.Future
 		State() raft.RaftState
 	}
@@ -465,6 +466,14 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 			}
 
 			db.log.Debugf("node %s gained MS leader state", db.replicaAddr)
+			barrierStart := time.Now()
+			if err := db.Barrier(); err != nil {
+				db.log.Errorf("raft Barrier() failed: %s", err)
+				_ = db.ResignLeadership(err)
+				break
+			}
+			db.log.Debugf("raft Barrier() complete after %s", time.Since(barrierStart))
+
 			var gainedCtx context.Context
 			gainedCtx, cancelGainedCtx = context.WithCancel(parent)
 			for _, fn := range db.onLeadershipGained {
@@ -475,7 +484,6 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 					break
 				}
 			}
-
 		}
 	}
 }

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -147,6 +147,10 @@ func (mrs *mockRaftService) State() raft.RaftState {
 	return mrs.cfg.State
 }
 
+func (mrs *mockRaftService) Barrier(time.Duration) raft.Future {
+	return &mockRaftFuture{}
+}
+
 func newMockRaftService(cfg *mockRaftServiceConfig, fsm raft.FSM) *mockRaftService {
 	if cfg == nil {
 		cfg = &mockRaftServiceConfig{

--- a/src/control/system/raft.go
+++ b/src/control/system/raft.go
@@ -102,6 +102,14 @@ func (db *Database) ResignLeadership(cause error) error {
 	return cause
 }
 
+// Barrier blocks until the raft implementation has persisted all
+// outstanding log entries.
+func (db *Database) Barrier() error {
+	return db.raft.withReadLock(func(svc raftService) error {
+		return svc.Barrier(0).Error()
+	})
+}
+
 // ShutdownRaft signals that the raft implementation should shut down
 // and release any resources it is holding. Blocks until the shutdown
 // is complete.


### PR DESCRIPTION
In rare cases, there could be a race between replaying logs
and system queries that results in erroneous pool cleanup
attempts on leader step-up.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
