### PR TITLE
DAOS-11431 test: Fix daos object subcommand

### DIFF
--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -465,7 +465,7 @@ class DaosCommandBase(CommandWithSubCommand):
             else:
                 self.sub_command_class = None
 
-        class CommonObjectSubCommand(CommandWithParameters):
+        class CommonObjectSubCommand(CommandWithPositionalParameters):
             """Defines an object for the common daos object sub-command."""
 
             def __init__(self, sub_command):


### PR DESCRIPTION
In the switch to supporting positional parameters, the
subcommand parent class wasn't updated, and therefore
the parameters were not being supplied correctly.

Features: daos_object_query

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
