### PR TITLE
DAOS-11446 object: do not need degraded fetch for specific shard fetch

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1153,7 +1153,7 @@ shard_open:
 				shard_tgt->st_rank = DAOS_TGT_IGNORE;
 				rc = 0;
 			} else {
-				if (obj_auxi->opc == DAOS_OBJ_RPC_FETCH)
+				if (obj_auxi->opc == DAOS_OBJ_RPC_FETCH && !obj_auxi->spec_shard)
 					ec_degrade = true;
 				else
 					shard_tgt->st_rank = DAOS_TGT_IGNORE;


### PR DESCRIPTION
Do not need degraded fetch for specific shard fetch.

Signed-off-by: Di Wang <di.wang@intel.com>