### PR TITLE
DAOS-11432 test: Fix cmocka post processing with Test-repeat (#10041)

### DIFF
--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -266,7 +266,7 @@ TEST_DIRS=("daos_test" "checksum")
 for test_dir in "${TEST_DIRS[@]}"; do
     COMP="FTEST_${test_dir}"
     if [[ "${LAUNCH_OPT_ARGS}" == *"--repeat="* ]]; then
-        FILES=("${logs_prefix}/ftest/avocado/job-results/${test_dir}"/*/test-results/*/*/data/*.xml)
+        FILES=("${logs_prefix}/ftest/avocado/job-results/${test_dir}"/*/*/test-results/*/data/*.xml)
     else
         FILES=("${logs_prefix}/ftest/avocado/job-results/${test_dir}"/*/test-results/*/data/*.xml)
     fi


### PR DESCRIPTION
Fix the search path for cmocka files when test-results directory path
includes a Test-repeat number.

Quick-functional: true
Test-tag: daos_core_test dfs_test
Test-repeat-hw-large: 10

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>