### PR TITLE
DAOS-11433 dfs: fix mtime set to not rely on DAOS HLC (#10048)

### DIFF
--- a/src/client/dfs/README.md
+++ b/src/client/dfs/README.md
@@ -78,11 +78,12 @@ Directory Object
       RECX (byte array starting at idx 0):
         mode_t: permission bit mask + type of entry
         oid: object id of entry
-        atime: access time
-        mtime: modify time
-        ctime: change time
+        mtime: modify time (seconds)
+        ctime: change time (seconds)
         chunk_size: chunk_size of file (0 if default or not a file)
         object class: default object class of objects under this dir
+        mtime: modify time (nano-seconds)
+        ctime: change time (nano-seconds)
         uid: user identifier
         gid: group identifier
         size: symlink size (0 for files/dirs)
@@ -192,3 +193,11 @@ namespace.
 
 setuid(), setgid() programs, supplementary groups, ACLs are not supported in the
 DFS namespace.
+
+## Time settings
+
+DFS stores the mtime (modify) and ctime (change) in the inode information of an object. the mtime is
+actively maintained for just file objects (changing a file contents updates the mtime value that
+would be returned on stat). At this time, mtime for directory objects and ctime for all objects are
+not actively maintained. atime (access) is not stored in DFS and stat returns the max value between
+mtime and ctime for atime.

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -57,21 +57,28 @@
 #define DFS_OBJ_GLOB_MAGIC	0xdf500b90
 
 /** Number of A-keys for attributes in any object entry */
-#define INODE_AKEYS	11
+#define INODE_AKEYS	12
 #define INODE_AKEY_NAME	"DFS_INODE"
 #define SLINK_AKEY_NAME	"DFS_SLINK"
 #define MODE_IDX	0
 #define OID_IDX		(sizeof(mode_t))
-#define ATIME_IDX	(OID_IDX + sizeof(daos_obj_id_t))
-#define MTIME_IDX	(ATIME_IDX + sizeof(uint64_t))
+#define MTIME_IDX	(OID_IDX + sizeof(daos_obj_id_t))
 #define CTIME_IDX	(MTIME_IDX + sizeof(uint64_t))
 #define CSIZE_IDX	(CTIME_IDX + sizeof(uint64_t))
 #define OCLASS_IDX	(CSIZE_IDX + sizeof(daos_size_t))
-#define UID_IDX		(OCLASS_IDX + sizeof(daos_oclass_id_t))
+#define MTIME_NSEC_IDX	(OCLASS_IDX + sizeof(daos_oclass_id_t))
+#define CTIME_NSEC_IDX	(MTIME_NSEC_IDX + sizeof(uint64_t))
+#define UID_IDX		(CTIME_NSEC_IDX + sizeof(uint64_t))
 #define GID_IDX		(UID_IDX + sizeof(uid_t))
 #define SIZE_IDX	(GID_IDX + sizeof(gid_t))
 #define HLC_IDX		(SIZE_IDX + sizeof(daos_size_t))
 #define END_IDX		(HLC_IDX + sizeof(uint64_t))
+
+/*
+ * END IDX for layout V2 (2.0) is at the current offset where we store the mtime nsec, but also need
+ * to account for the atime which is not stored anymore, but was stored (as a time_t) in layout V2.
+ */
+#define END_L2_IDX	(MTIME_NSEC_IDX + sizeof(time_t))
 
 /** Parameters for dkey enumeration */
 #define ENUM_DESC_NR	10
@@ -173,14 +180,20 @@ struct dfs_entry {
 	daos_size_t		value_len;
 	/** Object ID if not a symbolic link */
 	daos_obj_id_t		oid;
-	/* Time of last access */
+	/* Time of last access (sec) */
 	uint64_t		atime;
-	/* Time of last modification */
+	/* Time of last access (nsec) */
+	uint64_t		atime_nano;
+	/* Time of last modification (sec) */
 	uint64_t		mtime;
+	/* Time of last modification (nsec) */
+	uint64_t		mtime_nano;
 	/* for regular file, the time of last modification of the object */
 	uint64_t		obj_hlc;
-	/* Time of last status change */
+	/* Time of last status change (sec) */
 	uint64_t		ctime;
+	/* Time of last status change (nsec) */
+	uint64_t		ctime_nano;
 	/** chunk size of file or default for all files in a dir */
 	daos_size_t		chunk_size;
 	/** oclass of file or all files in a dir */
@@ -245,6 +258,15 @@ print_stat(struct stat *stbuf)
 	D_DEBUG(DB_TRACE, "Change time %s\n", buf);
 }
 #endif
+
+static inline bool
+tspec_gt(struct timespec l, struct timespec r)
+{
+	if (l.tv_sec == r.tv_sec)
+		return l.tv_nsec > r.tv_nsec;
+	else
+		return l.tv_sec > r.tv_sec;
+}
 
 static inline int
 get_daos_obj_mode(int flags)
@@ -435,20 +457,23 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 	i = 0;
 	d_iov_set(&sg_iovs[i++], &entry->mode, sizeof(mode_t));
 	d_iov_set(&sg_iovs[i++], &entry->oid, sizeof(daos_obj_id_t));
-	d_iov_set(&sg_iovs[i++], &entry->atime, sizeof(uint64_t));
+	/** atime is stored only in 2.0 containers */
+	if (ver <= 2)
+		d_iov_set(&sg_iovs[i++], &entry->atime, sizeof(uint64_t));
 	d_iov_set(&sg_iovs[i++], &entry->mtime, sizeof(uint64_t));
 	d_iov_set(&sg_iovs[i++], &entry->ctime, sizeof(uint64_t));
 	d_iov_set(&sg_iovs[i++], &entry->chunk_size, sizeof(daos_size_t));
 	d_iov_set(&sg_iovs[i++], &entry->oclass, sizeof(daos_oclass_id_t));
-	d_iov_set(&sg_iovs[i++], &entry->uid, sizeof(uid_t));
-	d_iov_set(&sg_iovs[i++], &entry->gid, sizeof(gid_t));
-	d_iov_set(&sg_iovs[i++], &entry->value_len, sizeof(daos_size_t));
-	d_iov_set(&sg_iovs[i++], &entry->obj_hlc, sizeof(uint64_t));
 
-	/* if we are reading from a layout ver 2 or older, we only have up to oclass IDX */
 	if (ver <= 2) {
-		recx.rx_nr = UID_IDX;
-		i = i - 4;
+		recx.rx_nr = END_L2_IDX;
+	} else {
+		d_iov_set(&sg_iovs[i++], &entry->mtime_nano, sizeof(uint64_t));
+		d_iov_set(&sg_iovs[i++], &entry->ctime_nano, sizeof(uint64_t));
+		d_iov_set(&sg_iovs[i++], &entry->uid, sizeof(uid_t));
+		d_iov_set(&sg_iovs[i++], &entry->gid, sizeof(gid_t));
+		d_iov_set(&sg_iovs[i++], &entry->value_len, sizeof(daos_size_t));
+		d_iov_set(&sg_iovs[i++], &entry->obj_hlc, sizeof(uint64_t));
 	}
 
 	sgl->sg_nr	= i;
@@ -487,10 +512,10 @@ fetch_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const char
 
 		/*
 		 * If we are reading from a layout ver 2 or older container, symlink value starts at
-		 * the current uid_idx; otherwise symlink is in a separate akey.
+		 * the current END_L2_IDX; otherwise symlink is in a separate akey.
 		 */
 		if (ver <= 2) {
-			recx.rx_idx = UID_IDX;
+			recx.rx_idx = END_L2_IDX;
 			recx.rx_nr = val_len;
 		} else {
 			d_iov_set(&iod->iod_name, SLINK_AKEY_NAME, sizeof(SLINK_AKEY_NAME) - 1);
@@ -617,7 +642,9 @@ insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const cha
 	i = 0;
 	d_iov_set(&sg_iovs[i++], &entry->mode, sizeof(mode_t));
 	d_iov_set(&sg_iovs[i++], &entry->oid, sizeof(daos_obj_id_t));
-	d_iov_set(&sg_iovs[i++], &entry->atime, sizeof(uint64_t));
+	/** atime is stored only in 2.0 containers */
+	if (ver <= 2)
+		d_iov_set(&sg_iovs[i++], &entry->atime, sizeof(uint64_t));
 	d_iov_set(&sg_iovs[i++], &entry->mtime, sizeof(uint64_t));
 	d_iov_set(&sg_iovs[i++], &entry->ctime, sizeof(uint64_t));
 	d_iov_set(&sg_iovs[i++], &entry->chunk_size, sizeof(daos_size_t));
@@ -626,14 +653,10 @@ insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const cha
 	nr_iods = 1;
 	/*
 	 * if we are writing to a layout ver 2 or older container, don't add the uid, gid, internal
-	 * mtime and put symlink value in the same akey.
+	 * mtime, nsec granularity for times, and put symlink value in the same akey.
 	 */
 	if (ver <= 2) {
-		/*
-		 * length of the array in that version is at the first new entry added in the new
-		 * format, which is the uid.
-		 */
-		recx.rx_nr = UID_IDX;
+		recx.rx_nr = END_L2_IDX;
 
 		/** Add symlink value to the array */
 		if (S_ISLNK(entry->mode)) {
@@ -641,6 +664,8 @@ insert_entry(dfs_layout_ver_t ver, daos_handle_t oh, daos_handle_t th, const cha
 			recx.rx_nr += entry->value_len;
 		}
 	} else {
+		d_iov_set(&sg_iovs[i++], &entry->mtime_nano, sizeof(uint64_t));
+		d_iov_set(&sg_iovs[i++], &entry->ctime_nano, sizeof(uint64_t));
 		d_iov_set(&sg_iovs[i++], &entry->uid, sizeof(uid_t));
 		d_iov_set(&sg_iovs[i++], &entry->gid, sizeof(gid_t));
 		/** Add file size / symlink length. for now, file size cached in the entry is 0. */
@@ -751,9 +776,8 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 	switch (entry.mode & S_IFMT) {
 	case S_IFDIR:
 		size = sizeof(entry);
-		rc = crt_hlc2timespec(entry.mtime, &stbuf->st_mtim);
-		if (rc)
-			return daos_der2errno(rc);
+		stbuf->st_mtim.tv_sec = entry.mtime;
+		stbuf->st_mtim.tv_nsec = entry.mtime_nano;
 		break;
 	case S_IFREG:
 	{
@@ -812,9 +836,8 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 				 * date with the object epoch time, which means that the user set
 				 * mtime in the inode entry is the correct value to return.
 				 */
-				rc = crt_hlc2timespec(entry.mtime, &stbuf->st_mtim);
-				if (rc)
-					return daos_der2errno(rc);
+				stbuf->st_mtim.tv_sec = entry.mtime;
+				stbuf->st_mtim.tv_nsec = entry.mtime_nano;
 			} else {
 				/*
 				 * the user has not updated the mtime explicitly or the object
@@ -824,9 +847,8 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 				stbuf->st_mtim.tv_nsec = obj_mtime.tv_nsec;
 			}
 		} else {
-			rc = crt_hlc2timespec(entry.mtime, &stbuf->st_mtim);
-			if (rc)
-				return daos_der2errno(rc);
+			stbuf->st_mtim.tv_sec = entry.mtime;
+			stbuf->st_mtim.tv_nsec = entry.mtime_nano;
 		}
 
 		/*
@@ -840,9 +862,8 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 	case S_IFLNK:
 		size = entry.value_len;
 		D_FREE(entry.value);
-		rc = crt_hlc2timespec(entry.mtime, &stbuf->st_mtim);
-		if (rc)
-			return daos_der2errno(rc);
+		stbuf->st_mtim.tv_sec = entry.mtime;
+		stbuf->st_mtim.tv_nsec = entry.mtime_nano;
 		break;
 	default:
 		D_ERROR("Invalid entry type (not a dir, file, symlink).\n");
@@ -854,9 +875,20 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 	stbuf->st_mode = entry.mode;
 	stbuf->st_uid = entry.uid;
 	stbuf->st_gid = entry.gid;
-	stbuf->st_atim.tv_sec = entry.atime;
 	stbuf->st_ctim.tv_sec = entry.ctime;
-
+	stbuf->st_ctim.tv_nsec = entry.ctime_nano;
+	if (dfs->layout_v > 2) {
+		if (tspec_gt(stbuf->st_ctim, stbuf->st_mtim)) {
+			stbuf->st_atim.tv_sec = entry.ctime;
+			stbuf->st_atim.tv_nsec = entry.ctime_nano;
+		} else {
+			stbuf->st_atim.tv_sec = entry.mtime;
+			stbuf->st_atim.tv_nsec = entry.mtime_nano;
+		}
+	} else {
+		stbuf->st_atim.tv_sec = entry.atime;
+		stbuf->st_atim.tv_nsec = 0;
+	}
 	return 0;
 }
 
@@ -932,7 +964,6 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 	bool			oexcl = flags & O_EXCL;
 	bool			ocreat = flags & O_CREAT;
 	struct timespec		now;
-	uint64_t		hlc;
 	int			rc;
 
 	/*
@@ -1001,14 +1032,11 @@ restart:
 		rc = clock_gettime(CLOCK_REALTIME, &now);
 		if (rc)
 			D_GOTO(out, rc = errno);
-		rc = crt_timespec2hlc(now, &hlc);
-		if (rc)
-			D_GOTO(out, rc = daos_der2errno(rc));
-		entry->atime = entry->mtime = entry->ctime = hlc;
+		entry->atime = entry->mtime = entry->ctime = now.tv_sec;
+		entry->atime_nano = entry->mtime_nano = entry->ctime_nano = now.tv_nsec;
 		entry->chunk_size = chunk_size;
 		entry->uid = geteuid();
 		entry->gid = getegid();
-
 		rc = insert_entry(dfs->layout_v, parent->oh, th, file->name, len,
 				  (!dfs->use_dtx || oexcl) ? DAOS_COND_DKEY_INSERT : 0, entry);
 		if (rc == EEXIST && !oexcl) {
@@ -1140,7 +1168,6 @@ open_dir(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 
 	if (flags & O_CREAT) {
 		struct timespec		now;
-		uint64_t		hlc;
 
 		D_ASSERT(parent);
 
@@ -1157,12 +1184,8 @@ open_dir(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 			daos_obj_close(dir->oh, NULL);
 			return rc;
 		}
-		rc = crt_timespec2hlc(now, &hlc);
-		if (rc) {
-			daos_obj_close(dir->oh, NULL);
-			return daos_der2errno(rc);
-		}
-		entry->atime = entry->mtime = entry->ctime = hlc;
+		entry->atime = entry->mtime = entry->ctime = now.tv_sec;
+		entry->atime_nano = entry->mtime_nano = entry->ctime_nano = now.tv_nsec;
 		entry->chunk_size = parent->d.chunk_size;
 		entry->oclass = parent->d.oclass;
 		entry->uid = geteuid();
@@ -1226,7 +1249,6 @@ open_symlink(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 
 	if (flags & O_CREAT) {
 		struct timespec	now;
-		uint64_t	hlc;
 
 		if (value == NULL)
 			return EINVAL;
@@ -1261,10 +1283,8 @@ open_symlink(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 		rc = clock_gettime(CLOCK_REALTIME, &now);
 		if (rc)
 			return errno;
-		rc = crt_timespec2hlc(now, &hlc);
-		if (rc)
-			return daos_der2errno(rc);
-		entry->atime = entry->mtime = entry->ctime = hlc;
+		entry->atime = entry->mtime = entry->ctime = now.tv_sec;
+		entry->atime_nano = entry->mtime_nano = entry->ctime_nano = now.tv_nsec;
 		D_STRNDUP(sym->value, value, value_len + 1);
 		if (sym->value == NULL)
 			return ENOMEM;
@@ -1463,7 +1483,6 @@ dfs_cont_create(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr,
 	int			rc;
 	struct daos_prop_entry  *dpe;
 	struct timespec		now;
-	uint64_t		hlc;
 
 	if (cuuid == NULL)
 		return EINVAL;
@@ -1575,10 +1594,8 @@ dfs_cont_create(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr,
 	rc = clock_gettime(CLOCK_REALTIME, &now);
 	if (rc)
 		D_GOTO(err_super, rc = errno);
-	rc = crt_timespec2hlc(now, &hlc);
-	if (rc)
-		D_GOTO(err_super, rc = daos_der2errno(rc));
-	entry.atime = entry.mtime = entry.ctime = hlc;
+	entry.atime = entry.mtime = entry.ctime = now.tv_sec;
+	entry.atime_nano = entry.mtime_nano = entry.ctime_nano = now.tv_nsec;
 	entry.chunk_size = dattr.da_chunk_size;
 	entry.oclass = dattr.da_oclass_id;
 	entry.uid = geteuid();
@@ -1983,15 +2000,22 @@ dfs_mount(daos_handle_t poh, daos_handle_t coh, int flags, dfs_t **_dfs)
 	dfs->root_stbuf.st_mode = dfs->root.mode;
 	dfs->root_stbuf.st_uid = root_dir.uid;
 	dfs->root_stbuf.st_gid = root_dir.gid;
-	rc = crt_hlc2timespec(root_dir.atime, &dfs->root_stbuf.st_atim);
-	if (rc)
-		D_GOTO(err_super, rc = daos_der2errno(rc));
-	rc = crt_hlc2timespec(root_dir.mtime, &dfs->root_stbuf.st_mtim);
-	if (rc)
-		D_GOTO(err_super, rc = daos_der2errno(rc));
-	rc = crt_hlc2timespec(root_dir.ctime, &dfs->root_stbuf.st_ctim);
-	if (rc)
-		D_GOTO(err_super, rc = daos_der2errno(rc));
+	dfs->root_stbuf.st_mtim.tv_sec = root_dir.mtime;
+	dfs->root_stbuf.st_mtim.tv_nsec = root_dir.mtime_nano;
+	dfs->root_stbuf.st_ctim.tv_sec = root_dir.ctime;
+	dfs->root_stbuf.st_ctim.tv_nsec = root_dir.ctime_nano;
+	if (dfs->layout_v > 2) {
+		if (tspec_gt(dfs->root_stbuf.st_ctim, dfs->root_stbuf.st_mtim)) {
+			dfs->root_stbuf.st_atim.tv_sec = root_dir.ctime;
+			dfs->root_stbuf.st_atim.tv_nsec = root_dir.ctime_nano;
+		} else {
+			dfs->root_stbuf.st_atim.tv_sec = root_dir.mtime;
+			dfs->root_stbuf.st_atim.tv_nsec = root_dir.mtime_nano;
+		}
+	} else {
+		dfs->root_stbuf.st_atim.tv_sec = root_dir.atime;
+		dfs->root_stbuf.st_atim.tv_nsec = root_dir.atime_nano;
+	}
 
 	/** if RW, allocate an OID for the namespace */
 	if (amode == O_RDWR) {
@@ -2710,7 +2734,6 @@ dfs_mkdir(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
 	struct dfs_entry	entry = {0};
 	size_t			len;
 	struct timespec		now;
-	uint64_t		hlc;
 	int			rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -2738,10 +2761,8 @@ dfs_mkdir(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
 	rc = clock_gettime(CLOCK_REALTIME, &now);
 	if (rc)
 		return errno;
-	rc = crt_timespec2hlc(now, &hlc);
-	if (rc)
-		return daos_der2errno(rc);
-	entry.atime = entry.mtime = entry.ctime = hlc;
+	entry.atime = entry.mtime = entry.ctime = now.tv_sec;
+	entry.atime_nano = entry.mtime_nano = entry.ctime_nano = now.tv_nsec;
 	entry.chunk_size = parent->d.chunk_size;
 	entry.oclass = parent->d.oclass;
 	entry.uid = geteuid();
@@ -3201,13 +3222,22 @@ lookup_rel_path_loop:
 			stbuf->st_mode = obj->mode;
 			stbuf->st_uid = entry.uid;
 			stbuf->st_gid = entry.gid;
-			/** assertion is fine here as we know the sink buffer is valid */
-			rc = crt_hlc2timespec(entry.atime, &stbuf->st_atim);
-			D_ASSERT(rc == 0);
-			rc = crt_hlc2timespec(entry.mtime, &stbuf->st_mtim);
-			D_ASSERT(rc == 0);
-			rc = crt_hlc2timespec(entry.ctime, &stbuf->st_ctim);
-			D_ASSERT(rc == 0);
+			stbuf->st_mtim.tv_sec = entry.mtime;
+			stbuf->st_mtim.tv_nsec = entry.mtime_nano;
+			stbuf->st_ctim.tv_sec = entry.ctime;
+			stbuf->st_ctim.tv_nsec = entry.ctime_nano;
+			if (dfs->layout_v > 2) {
+				if (tspec_gt(stbuf->st_ctim, stbuf->st_mtim)) {
+					stbuf->st_atim.tv_sec = entry.ctime;
+					stbuf->st_atim.tv_nsec = entry.ctime_nano;
+				} else {
+					stbuf->st_atim.tv_sec = entry.mtime;
+					stbuf->st_atim.tv_nsec = entry.mtime_nano;
+				}
+			} else {
+				stbuf->st_atim.tv_sec = entry.atime;
+				stbuf->st_atim.tv_nsec = 0;
+			}
 		}
 	}
 
@@ -3537,13 +3567,22 @@ dfs_lookup_rel_int(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags,
 		stbuf->st_mode = obj->mode;
 		stbuf->st_uid = entry.uid;
 		stbuf->st_gid = entry.gid;
-		/** assertion is fine here as we know the sink buffer is valid */
-		rc = crt_hlc2timespec(entry.atime, &stbuf->st_atim);
-		D_ASSERT(rc == 0);
-		rc = crt_hlc2timespec(entry.mtime, &stbuf->st_mtim);
-		D_ASSERT(rc == 0);
-		rc = crt_hlc2timespec(entry.ctime, &stbuf->st_ctim);
-		D_ASSERT(rc == 0);
+		stbuf->st_mtim.tv_sec = entry.mtime;
+		stbuf->st_mtim.tv_nsec = entry.mtime_nano;
+		stbuf->st_ctim.tv_sec = entry.ctime;
+		stbuf->st_ctim.tv_nsec = entry.ctime_nano;
+		if (dfs->layout_v > 2) {
+			if (tspec_gt(stbuf->st_ctim, stbuf->st_mtim)) {
+				stbuf->st_atim.tv_sec = entry.ctime;
+				stbuf->st_atim.tv_nsec = entry.ctime_nano;
+			} else {
+				stbuf->st_atim.tv_sec = entry.mtime;
+				stbuf->st_atim.tv_nsec = entry.mtime_nano;
+			}
+		} else {
+			stbuf->st_atim.tv_sec = entry.atime;
+			stbuf->st_atim.tv_nsec = 0;
+		}
 	}
 
 out:
@@ -3660,13 +3699,22 @@ out:
 			stbuf->st_mode = entry.mode;
 			stbuf->st_uid = entry.uid;
 			stbuf->st_gid = entry.gid;
-			/** assertion is fine here as we know the sink buffer is valid */
-			rc = crt_hlc2timespec(entry.atime, &stbuf->st_atim);
-			D_ASSERT(rc == 0);
-			rc = crt_hlc2timespec(entry.mtime, &stbuf->st_mtim);
-			D_ASSERT(rc == 0);
-			rc = crt_hlc2timespec(entry.ctime, &stbuf->st_ctim);
-			D_ASSERT(rc == 0);
+			stbuf->st_mtim.tv_sec = entry.mtime;
+			stbuf->st_mtim.tv_nsec = entry.mtime_nano;
+			stbuf->st_ctim.tv_sec = entry.ctime;
+			stbuf->st_ctim.tv_nsec = entry.ctime_nano;
+			if (dfs->layout_v > 2) {
+				if (tspec_gt(stbuf->st_ctim, stbuf->st_mtim)) {
+					stbuf->st_atim.tv_sec = entry.ctime;
+					stbuf->st_atim.tv_nsec = entry.ctime_nano;
+				} else {
+					stbuf->st_atim.tv_sec = entry.mtime;
+					stbuf->st_atim.tv_nsec = entry.mtime_nano;
+				}
+			} else {
+				stbuf->st_atim.tv_sec = entry.atime;
+				stbuf->st_atim.tv_nsec = 0;
+			}
 		}
 		*_obj = obj;
 	} else {
@@ -4623,14 +4671,14 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	daos_key_t		dkey;
 	daos_handle_t		oh;
 	d_sg_list_t		sgl;
-	d_iov_t			sg_iovs[5];
+	d_iov_t			sg_iovs[8];
 	daos_iod_t		iod;
-	daos_recx_t		recx[5];
+	daos_recx_t		recx[8];
 	bool			set_size = false;
 	int			i = 0;
 	size_t			len;
 	int			rc;
-	uint64_t		obj_hlc = 0, atime_hlc = 0, mtime_hlc = 0;
+	uint64_t		obj_hlc = 0;
 	struct stat		rstat = {};
 
 	if (dfs == NULL || !dfs->mounted)
@@ -4683,22 +4731,17 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		rstat.st_mode = stbuf->st_mode;
 	}
 	if (flags & DFS_SET_ATTR_ATIME) {
-		rc = crt_timespec2hlc(stbuf->st_atim, &atime_hlc);
-		if (rc)
-			D_GOTO(out_obj, rc);
-		d_iov_set(&sg_iovs[i], &atime_hlc, sizeof(uint64_t));
-		recx[i].rx_idx = ATIME_IDX;
-		recx[i].rx_nr = sizeof(uint64_t);
-		i++;
 		flags &= ~DFS_SET_ATTR_ATIME;
-		rstat.st_atim = stbuf->st_atim;
+		D_WARN("ATIME is no longer stored in DFS and setting it is ignored.\n");
 	}
 	if (flags & DFS_SET_ATTR_MTIME) {
-		rc = crt_timespec2hlc(stbuf->st_mtim, &mtime_hlc);
-		if (rc)
-			D_GOTO(out_obj, rc);
-		d_iov_set(&sg_iovs[i], &mtime_hlc, sizeof(uint64_t));
+		d_iov_set(&sg_iovs[i], &stbuf->st_mtim.tv_sec, sizeof(uint64_t));
 		recx[i].rx_idx = MTIME_IDX;
+		recx[i].rx_nr = sizeof(uint64_t);
+		i++;
+
+		d_iov_set(&sg_iovs[i], &stbuf->st_mtim.tv_nsec, sizeof(uint64_t));
+		recx[i].rx_idx = MTIME_NSEC_IDX;
 		recx[i].rx_nr = sizeof(uint64_t);
 		i++;
 
@@ -4708,7 +4751,8 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		i++;
 
 		flags &= ~DFS_SET_ATTR_MTIME;
-		rstat.st_mtim = stbuf->st_mtim;
+		rstat.st_mtim.tv_sec = stbuf->st_mtim.tv_sec;
+		rstat.st_mtim.tv_nsec = stbuf->st_mtim.tv_nsec;
 	}
 	if (flags & DFS_SET_ATTR_UID) {
 		d_iov_set(&sg_iovs[i], &stbuf->st_uid, sizeof(uid_t));
@@ -4716,7 +4760,8 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		recx[i].rx_nr = sizeof(uid_t);
 		i++;
 		flags &= ~DFS_SET_ATTR_UID;
-		rstat.st_mtim = stbuf->st_mtim;
+		rstat.st_mtim.tv_sec = stbuf->st_mtim.tv_sec;
+		rstat.st_mtim.tv_nsec = stbuf->st_mtim.tv_nsec;
 	}
 	if (flags & DFS_SET_ATTR_GID) {
 		d_iov_set(&sg_iovs[i], &stbuf->st_gid, sizeof(gid_t));
@@ -4724,15 +4769,18 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		recx[i].rx_nr = sizeof(gid_t);
 		i++;
 		flags &= ~DFS_SET_ATTR_GID;
-		rstat.st_mtim = stbuf->st_mtim;
+		rstat.st_mtim.tv_sec = stbuf->st_mtim.tv_sec;
+		rstat.st_mtim.tv_nsec = stbuf->st_mtim.tv_nsec;
 	}
 	if (flags & DFS_SET_ATTR_SIZE) {
 		/* It shouldn't be possible to set the size of something which
 		 * isn't a file but check here anyway, as entries which aren't
 		 * files won't have array objects so check and return error here
 		 */
-		if (!S_ISREG(obj->mode))
+		if (!S_ISREG(obj->mode)) {
+			D_ERROR("Cannot set_size on a non file object\n");
 			D_GOTO(out_obj, rc = EIO);
+		}
 
 		set_size = true;
 		flags &= ~DFS_SET_ATTR_SIZE;
@@ -5123,15 +5171,12 @@ restart:
 	}
 
 	struct timespec		now;
-	uint64_t		hlc;
 
 	rc = clock_gettime(CLOCK_REALTIME, &now);
 	if (rc)
 		D_GOTO(out, rc = errno);
-	rc = crt_timespec2hlc(now, &hlc);
-	if (rc)
-		D_GOTO(out, rc = daos_der2errno(rc));
-	entry.atime = entry.mtime = entry.ctime = hlc;
+	entry.atime = entry.mtime = entry.ctime = now.tv_sec;
+	entry.atime_nano = entry.mtime_nano = entry.ctime_nano = now.tv_nsec;
 
 	/** insert old entry in new parent object */
 	rc = insert_entry(dfs->layout_v, new_parent->oh, th, new_name, new_len,
@@ -5269,16 +5314,13 @@ restart:
 	}
 
 	struct timespec		now;
-	uint64_t		hlc;
 
 	rc = clock_gettime(CLOCK_REALTIME, &now);
 	if (rc)
 		D_GOTO(out, rc = errno);
-	rc = crt_timespec2hlc(now, &hlc);
-	if (rc)
-		D_GOTO(out, rc = daos_der2errno(rc));
+	entry1.atime = entry1.mtime = entry1.ctime = now.tv_sec;
+	entry1.atime_nano = entry1.mtime_nano = entry1.ctime_nano = now.tv_nsec;
 
-	entry1.atime = entry1.mtime = entry1.ctime = hlc;
 	/** insert entry1 in parent2 object */
 	rc = insert_entry(dfs->layout_v, parent2->oh, th, name1, len1,
 			  dfs->use_dtx ? 0 : DAOS_COND_DKEY_INSERT, &entry1);
@@ -5287,7 +5329,9 @@ restart:
 		D_GOTO(out, rc);
 	}
 
-	entry2.atime = entry2.mtime = entry2.ctime = hlc;
+	entry2.atime = entry2.mtime = entry2.ctime = now.tv_sec;
+	entry2.atime_nano = entry2.mtime_nano = entry2.ctime_nano = now.tv_nsec;
+
 	/** insert entry2 in parent1 object */
 	rc = insert_entry(dfs->layout_v, parent1->oh, th, name2, len2,
 			  dfs->use_dtx ? 0 : DAOS_COND_DKEY_INSERT, &entry2);

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1049,7 +1049,7 @@ dfuse_fs_start(struct dfuse_projection_info *fs_handle, struct dfuse_cont *dfs)
 	struct dfuse_inode_entry	*ie = NULL;
 	int				rc;
 
-	args.argc = 4;
+	args.argc = 5;
 
 	/* These allocations are freed later by libfuse so do not use the
 	 * standard allocation macros
@@ -1073,6 +1073,10 @@ dfuse_fs_start(struct dfuse_projection_info *fs_handle, struct dfuse_cont *dfs)
 
 	args.argv[3] = strdup("-odefault_permissions");
 	if (!args.argv[3])
+		D_GOTO(err, rc = -DER_NOMEM);
+
+	args.argv[4] = strdup("-onoatime");
+	if (!args.argv[4])
 		D_GOTO(err, rc = -DER_NOMEM);
 
 	/* Create the root inode and insert into table */

--- a/src/client/dfuse/ops/setattr.c
+++ b/src/client/dfuse/ops/setattr.c
@@ -61,7 +61,6 @@ dfuse_cb_setattr(fuse_req_t req, struct dfuse_inode_entry *ie,
 		DFUSE_TRA_DEBUG(ie, "atime %#lx",
 				attr->st_atime);
 		to_set &= ~(FUSE_SET_ATTR_ATIME | FUSE_SET_ATTR_ATIME_NOW);
-		dfs_flags |= DFS_SET_ATTR_ATIME;
 	}
 
 	if (to_set & FUSE_SET_ATTR_MTIME) {

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1376,6 +1376,71 @@ dfs_test_mtime(void **state)
 	assert_int_equal(stbuf.st_size, 0);
 	assert_true(check_ts(prev_ts, stbuf.st_mtim));
 
+	struct tm	tm = {0};
+	time_t		ts;
+	char		*p;
+	struct tm       *timeptr;
+	char		time_str[64];
+
+	/** set the mtime to 2020 */
+	p = strptime("2020-12-31", "%Y-%m-%d", &tm);
+	assert_non_null(p);
+	ts = mktime(&tm);
+	memset(&stbuf, 0, sizeof(stbuf));
+	stbuf.st_mtim.tv_sec = ts;
+	stbuf.st_mtim.tv_nsec = 0;
+	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_MTIME);
+	assert_int_equal(rc, 0);
+	/** verify */
+	memset(&stbuf, 0, sizeof(stbuf));
+	rc = dfs_ostat(dfs_mt, file, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(ts, stbuf.st_mtim.tv_sec);
+	timeptr = localtime(&stbuf.st_mtim.tv_sec);
+	strftime(time_str, sizeof(time_str), "%Y-%m-%d", timeptr);
+	print_message("mtime = %s\n", time_str);
+	assert_true(strncmp("2020", time_str, 4) == 0);
+
+	/** set the mtime to 1900 */
+	memset(&tm, 0, sizeof(struct tm));
+	p = strptime("1900-12-31", "%Y-%m-%d", &tm);
+	assert_non_null(p);
+	ts = mktime(&tm);
+	memset(&stbuf, 0, sizeof(stbuf));
+	stbuf.st_mtim.tv_sec = ts;
+	stbuf.st_mtim.tv_nsec = 0;
+	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_MTIME);
+	assert_int_equal(rc, 0);
+	/* verify */
+	memset(&stbuf, 0, sizeof(stbuf));
+	rc = dfs_ostat(dfs_mt, file, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(ts, stbuf.st_mtim.tv_sec);
+	timeptr = localtime(&stbuf.st_mtim.tv_sec);
+	strftime(time_str, sizeof(time_str), "%Y-%m-%d", timeptr);
+	print_message("mtime = %s\n", time_str);
+	assert_true(strncmp("1900", time_str, 4) == 0);
+
+	/** set the mtime to 2999 */
+	memset(&tm, 0, sizeof(struct tm));
+	p = strptime("2999-12-31", "%Y-%m-%d", &tm);
+	assert_non_null(p);
+	ts = mktime(&tm);
+	memset(&stbuf, 0, sizeof(stbuf));
+	stbuf.st_mtim.tv_sec = ts;
+	stbuf.st_mtim.tv_nsec = 0;
+	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_MTIME);
+	assert_int_equal(rc, 0);
+	/* verify */
+	memset(&stbuf, 0, sizeof(stbuf));
+	rc = dfs_ostat(dfs_mt, file, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(ts, stbuf.st_mtim.tv_sec);
+	timeptr = localtime(&stbuf.st_mtim.tv_sec);
+	strftime(time_str, sizeof(time_str), "%Y-%m-%d", timeptr);
+	print_message("mtime = %s\n", time_str);
+	assert_true(strncmp("2999", time_str, 4) == 0);
+
 	rc = dfs_release(file);
 	assert_int_equal(rc, 0);
 	rc = dfs_remove(dfs_mt, NULL, f, 0, NULL);


### PR DESCRIPTION
DAOS HLC starts on 2021, which means a user would not be able to set
mtime on files before that. Fix the mtime setting in DFS to use timespec
(which changes the layout to add the nano sec granularity) instead of the
HLC to support older dates.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>