### PR TITLE
DAOS-623 build: Improve the preprocessing steps (#9390)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,14 +1,18 @@
 # clang-format script for daos that most closely matches our coding style.
 # Tested on EL 8, and uses version 12 so check for that in
 # site_scons/site_tools/extra/extra.py
----
+# Versions up to 14.0.4 had a bug where generated code could be wrongly indented
+# so this should only be used for formatting code with 14.0.5 or above.  Versions prior to that
+# will have whitespace errors.
+# https://github.com/llvm/llvm-project/issues/55407
 BasedOnStyle: LLVM
 IndentWidth: 8
 UseTab: ForContinuationAndIndentation
 BreakBeforeBraces: Linux
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
-ForEachMacros: ['d_list_for_each_entry', 'd_list_for_each_entry_safe',
+ForEachMacros: ['d_list_for_each_entry',
+                'd_list_for_each_entry_safe',
                 'evt_ent_array_for_each']
 PointerAlignment: Right
 AlignConsecutiveAssignments: true
@@ -20,7 +24,7 @@ AlwaysBreakAfterReturnType: All
 IndentGotoLabels: false
 AlignConsecutiveDeclarations: AcrossEmptyLinesAndComments
 AlignConsecutiveMacros: AcrossEmptyLinesAndComments
-AlignConsecutiveAssignments: AcrossEmptyLinesAndComments
+AlignConsecutiveAssignments: Consecutive
 AlignConsecutiveBitFields: AcrossEmptyLinesAndComments
 SpaceBeforeParens: ControlStatementsExceptForEachMacros
 KeepEmptyLinesAtTheStartOfBlocks: false

--- a/.clang-format
+++ b/.clang-format
@@ -15,8 +15,6 @@ ForEachMacros: ['d_list_for_each_entry',
                 'd_list_for_each_entry_safe',
                 'evt_ent_array_for_each']
 PointerAlignment: Right
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true
 AlignTrailingComments: true
 ColumnLimit: 100
 SortIncludes: false
@@ -29,4 +27,3 @@ AlignConsecutiveBitFields: AcrossEmptyLinesAndComments
 SpaceBeforeParens: ControlStatementsExceptForEachMacros
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 1
-...

--- a/.flake8
+++ b/.flake8
@@ -12,3 +12,4 @@ exclude =
     build,
     install
 max-line-length: 100
+ignore=W503

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""Code to handle clang-format when used in the build.
+
+This is used by scons to reformat automatically generated header files to be readable, but also
+outside of scons by the clang-format commit hook to check the version.
+"""
+
 # Copyright 2018-2022 Intel Corporation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,11 +25,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 """SCons extra features"""
-from __future__ import print_function
-
 import subprocess #nosec
 import re
 import os
+import sys
 
 from SCons.Builder import Builder
 from SCons.Script import WhereIs
@@ -33,7 +38,8 @@ from SCons.Script import WhereIs
 MIN_FORMAT_VERSION = 12
 
 def _supports_custom_format(clang_exe):
-    """Get the version of clang-format"""
+    """Checks if the version of clang-foramt is new enough to parse the settings used by
+    the config file"""
 
     try:
         rawbytes = subprocess.check_output([clang_exe, "-version"])
@@ -46,7 +52,31 @@ def _supports_custom_format(clang_exe):
     if match and int(match.group(1)) >= MIN_FORMAT_VERSION:
         return True
 
-    print('Custom .clang-format wants version {}+. Using Mozilla style.'.format(MIN_FORMAT_VERSION))
+    print(f'Custom .clang-format wants version {MIN_FORMAT_VERSION}+. Using Mozilla style.')
+    return False
+
+
+def _supports_correct_style(clang_exe):
+    """Checks if the version of clang-format is 14.0.5 or newer which is required to correctly
+    reformat code for landing"""
+
+    try:
+        rawbytes = subprocess.check_output([clang_exe, "-version"])
+        output = rawbytes.decode('utf-8')
+    except subprocess.CalledProcessError:
+        return False
+
+    match = re.search(r'version ([\d+\.]+) ', output)
+    if match:
+        parts = match.group(1).split('.')
+        if int(parts[0]) < 14:
+            return False
+        if int(parts[1]) > 0:
+            return True
+        if int(parts[2]) < 5:
+            return False
+        return True
+
     return False
 
 def _find_indent():
@@ -58,51 +88,73 @@ def _find_indent():
         style = "file"
     else:
         style = "Mozilla"
-    return "%s --style=%s" % (indent, style)
+    return f'{indent} --style={style}'
 
-def _pp_gen(source, target, env, indent):
-    """generate commands for preprocessor builder"""
-    action = []
-    nenv = env.Clone()
-    cccom = nenv.subst("$CCCOM").replace(" -o ", " ")
-    for src, tgt in zip(source, target):
-        if indent:
-            action.append("%s -E -P %s | %s > %s" % (cccom, src, indent, tgt))
-        else:
-            action.append("%s -E -P %s > %s" % (cccom, src, tgt))
-    return action
 
 def _preprocess_emitter(source, target, env):
     """generate target list for preprocessor builder"""
     target = []
     for src in source:
+        dirname = os.path.dirname(src.abspath)
         basename = os.path.basename(src.abspath)
-        (base, _ext) = os.path.splitext(basename)
+        (base, ext) = os.path.splitext(basename)
         prefix = ""
         for var in ["OBJPREFIX", "OBJSUFFIX", "SHOBJPREFIX", "SHOBJSUFFIX"]:
-            mod = env.subst("$%s" % var)
+            mod = env.subst(f'${var}')
             if var == "OBJSUFFIX" and mod == ".o":
                 continue
             if var == "SHOBJSUFFIX" and mod == ".os":
                 continue
             if mod != "":
                 prefix = prefix + "_" + mod
-        target.append(prefix + base + "_pp.c")
+        newtarget = os.path.join(dirname, f'{prefix}{base}_pp{ext}')
+        target.append(newtarget)
     return target, source
+
+
+def _ch_emitter(source, target, **_kw):
+    """generate target list for check header builder"""
+    target = []
+    for src in source:
+        (base, _ext) = os.path.splitext(src.abspath)
+        target.append(f"{base}_check_header$OBJSUFFIX")
+    return target, source
+
+
+def main():
+    """Check for a supported version of clang-format"""
+    supported = _supports_correct_style(WhereIs('clang-format'))
+    if not supported:
+        print('Install clang-format version 14.0.5 or newer to reformat code')
+        sys.exit(1)
+    sys.exit(0)
 
 def generate(env):
     """Setup the our custom tools"""
 
     indent = _find_indent()
-
-    generator = lambda source, target, env, for_signature: _pp_gen(source, target, env, indent)
+    def _pp_gen(source, target, env, for_signature):
+        """generate commands for preprocessor builder"""
+        action = []
+        cccom = env.subst("$CCCOM").replace(" -o ", " ")
+        for src, tgt in zip(source, target):
+            if indent:
+                action.append(f'{cccom} -E -P {src} | {indent} > {tgt}')
+            else:
+                action.append(f'{cccom} -E -P {src} > {tgt}')
+        return action
 
     # Only handle C for now
-    preprocess = Builder(generator=generator, suffix="_pp.c",
-                         emitter=_preprocess_emitter, src_suffix=".c")
+    preprocess = Builder(generator=_pp_gen, emitter=_preprocess_emitter)
+    if not env["BUILDERS"].get("Preprocess", False):
+        env.Append(BUILDERS={"Preprocess": preprocess})
 
     env.Append(BUILDERS={"Preprocess":preprocess})
 
 def exists(_env):
     """assert existence of tool"""
     return True
+
+
+if __name__ == '__main__':
+    main()

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -133,6 +133,7 @@ def generate(env):
     """Setup the our custom tools"""
 
     indent = _find_indent()
+
     # pylint: disable-next=unused-argument
     def _pp_gen(source, target, env, for_signature):
         """generate commands for preprocessor builder"""

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -133,6 +133,7 @@ def generate(env):
     """Setup the our custom tools"""
 
     indent = _find_indent()
+    # pylint: disable-next=unused-argument
     def _pp_gen(source, target, env, for_signature):
         """generate commands for preprocessor builder"""
         action = []

--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -4,9 +4,8 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 """Build CaRT components"""
-
 import os
-import sys
+from datetime import date
 import daos_build
 # pylint: disable=no-name-in-module
 # pylint: disable=import-error
@@ -22,36 +21,37 @@ SRC = ['crt_bulk.c', 'crt_context.c', 'crt_corpc.c',
        'crt_swim.c', 'crt_tree.c', 'crt_tree_flat.c', 'crt_tree_kary.c',
        'crt_tree_knomial.c', 'crt_hlc.c', 'crt_hlct.c']
 
-# pylint: disable=unused-argument
-def macro_expand(target, source, env):
-    """Function for PostAction"""
+
+def parse_pp(env, pp_targets):
+    """Use command builder to process each preprocessed file"""
+    results = []
     scope = r"'/struct [^ ]*_\(in\|out\) {/,/};/p'"
     sed_e = r"-e 's/\s\s*/ /g' -e 's/};struct /};\nstruct /g'"
+    for tgt in pp_targets:
+        fname = f"{tgt.abspath}_grep"
+        cmd = f"sed -n {scope} $SOURCE | tr -d '\\n' | sed {sed_e} > $TARGET"
+        results.extend(env.Command(fname, tgt, cmd))
+    return results
+
+
+def copy_header(**kw):
+    """Copy the target file to source directory"""
+    Execute(Copy(Dir("src/cart").srcnode().abspath, kw['target'][0].abspath))
+
+
+def consolidate_pp(env, parsed_targets):
+    """Consolidate parsed headers"""
     sed_d = r"-e 's/\([{;]\) /\1\t/g' -e 's/\([{;]\)/\1\n/g'"
     grepv = r"'struct sockaddr_in {'"
-    tgts = ""
-    for tgt in target:
-        tgts += "%s_grep " % tgt.abspath
-        os.system("sed -n %s %s | tr -d '\\n' | sed %s > %s_grep"
-                  % (scope, tgt.abspath, sed_e, tgt.abspath))
-    h_name = "src/cart/_structures_from_macros_.h"
-    h_file = os.path.join(Dir('#').abspath, h_name)
-    with open(h_file, "w") as outfile:
-        outfile.write("/* Automatically generated with structures\n"
-                      " * expanded from CRT_RPC_DECLARE() macros\n *\n")
-        with open("LICENSE", "r") as infile:
-            for line in infile.readlines():
-                if line == "\n":
-                    outfile.write(" *\n")
-                else:
-                    outfile.write(" * " + line)
-            infile.close()
-        outfile.write(" */\n\n")
-        outfile.close()
-    if tgts != "":
-        os.system("cat %s | grep -v %s | sort -u | sed %s >> %s"
-                  % (tgts, grepv, sed_d, h_file))
-# pylint: enable=unused-argument
+    year = date.today().year
+    sd = {'@YEAR@': year}
+    preamble = env.Substfile('macro_prefix.h_in', SUBST_DICT=sd)
+    parsed_sources = [x.abspath for x in parsed_targets]
+    cmd = (f"cat {preamble[0].abspath} > $TARGET; cat {' '.join(parsed_sources)}"
+           + f" | grep -v {grepv} | sort -u | sed {sed_d} >> $TARGET")
+    header = env.Command('_structures_from_macros.h', preamble + parsed_targets, cmd)
+    env.AddPostAction(header, SCons.Action.Action(copy_header, None))
+    return header
 
 def scons():
     """Scons function"""
@@ -89,11 +89,15 @@ def scons():
     compiler = env.get('COMPILER').lower()
     if compiler != 'covc':
         pp_env = denv.Clone()
+        pp_files = []
+        for src in SRC:
+            # Some day, the preprocess builder should be fixed so it can do multiple commands
+            # in parallel but until then, just submit them one at a time
+            pp_files.extend(pp_env.Preprocess(src))
+        parsed_files = parse_pp(pp_env, pp_files)
+        header = consolidate_pp(pp_env, parsed_files)
 
-        pp_files = pp_env.Preprocess(SRC)
-        pp_env.AddPostAction(pp_files, SCons.Action.Action(macro_expand, None))
-
-        denv.Requires(cart_targets, pp_files)
+        Depends(cart_targets, header)
 
     cart_lib = daos_build.library(denv, 'libcart', [cart_targets, swim_targets],
                                   SHLIBVERSION=CART_VERSION)

--- a/src/cart/macro_prefix.h_in
+++ b/src/cart/macro_prefix.h_in
@@ -1,0 +1,7 @@
+/* Automatically generated with structures expanded from CRT_RPC_DECLARE() macros
+ *
+ * (C) Copyright 2016-@YEAR@ Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -363,7 +363,7 @@ class LogTest():
                     server_shutdown = True
                 if line.level <= cart_logparse.LOG_LEVELS['WARN']:
                     show = True
-                    if self.hide_fi_calls:
+                    if self.hide_fi_calls and line.fac != 'external':
                         if line.is_fi_site():
                             show = False
                         elif line.is_fi_alloc_fail():

--- a/utils/githooks/pre-commit.d/40-clang-format
+++ b/utils/githooks/pre-commit.d/40-clang-format
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -ue
+
+if [ -e .git/MERGE_HEAD ]
+then
+    echo Merge commit
+    exit 0
+fi
+
+if ! command -v git-clang-format > /dev/null 2>&1
+then
+    echo "No git-clang-format checking"
+    exit 0
+fi
+if ! command -v clang-format > /dev/null 2>&1
+then
+    echo "No clang-format checking"
+    exit 0
+fi
+
+# Check version of clang-format, and print a helpful message if it's too old.  If the right version
+# is not found then exit.
+./site_scons/site_tools/extra/extra.py || exit 0
+
+git-clang-format --staged src

--- a/utils/sl/fake_scons/SCons/Script/__init__.py
+++ b/utils/sl/fake_scons/SCons/Script/__init__.py
@@ -303,11 +303,13 @@ class Configure():
     def Finish(self):
         """Fake finish"""
 
+
 class Literal():
     """Fake Literal"""
 
     def __init__(self, *_args, **_kw):
         """constructor"""
+
 
 class Dir():
     """Fake Dir"""
@@ -319,76 +321,101 @@ class Dir():
         """Fake srcnode"""
         return self
 
+
 class File():
     """Fake File"""
 
+
 def VariantDir(*_args, **_kw):
     """Fake VariantDir"""
+
 
 def AddOption(*_args, **_kw):
     """Fake AddOption"""
     return True
 
+
 def GetOption(*_args, **_kw):
     """Fake GetOption"""
     return []
 
+
 def SetOption(*_args, **_kw):
     """Fake SetOption"""
     return True
+
 
 class Help():
     """Fake Help"""
     def __init__(self, *_args, **_kw):
         """constructor"""
 
+
 def Glob(*_args):
     """Fake Glob"""
     return []
+
 
 def Split(*_args):
     """Fake Split"""
     return []
 
+
 def Exit(status):
     """Fake Exit"""
     sys.exit(status)
 
+
 def Import(*_args):
     """Fake Import"""
+
 
 def Export(*_args):
     """Fake Export"""
 
+
 def Default(*_args):
     """Fake Default"""
+
 
 def Delete(*_args, **_kw):
     """Fake Delete"""
     return ["fake"]
 
+
 def AlwaysBuild(*_args):
     """Fake AlwaysBuild"""
+
 
 def Copy(*_args, **_kw):
     """Fake Copy"""
     return ["fake"]
 
+
 def Command(*_args, **_kw):
     """Fake Command"""
     return ["fake"]
+
+
+def Execute(*_args, **_kw):
+    """Fake Execute"""
+    return ["fake"]
+
 
 def Builder(*_args, **_kw):
     """Fake Builder"""
     return ["fake"]
 
+
 def WhereIs(path):
     """Fake WhereIs"""
     return ''
 
+
 def Platform():
     """Fake Platform"""
     return ''
+
 
 def Depends(*_args, **_kw):
     """Fake Depends"""
@@ -405,6 +432,7 @@ __all__ = ['DefaultEnvironment',
            'Configure',
            'GetOption',
            'SetOption',
+           'Execute',
            'Depends',
            'Platform',
            'Literal',


### PR DESCRIPTION
A couple of things were causing the preprocessing step in cart
to generate _structures_from_macros.h to be slow

1. The Preprocessor builder currently doesn't support building
   multiple items in parallel so it's better to call it one file
   at a time.
2. Use Command builders for intermediate steps so they don't need
   to be repeated
3. Pick to allow W503

Also cherry-picks this patch because it also modified extra.py so it made the other cherry-pick simpler:
DAOS-623 build: Update clang-format settings. (#9007)

Change Alignment to be closer to our established code.
Change spaces to tabs to avoid a clang bug.
Enable clang-format githook if clang-format 14.0.5 or greater is detected

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>