### PR TITLE
DAOS-11447 rebuild: ignore exist ERROR for object insert

### DIFF
--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -136,17 +136,19 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		rebuild_global_status_update(rgt, src_iv);
 		if (rgt->rgt_status.rs_errno == 0) {
 			rgt->rgt_status.rs_errno = src_iv->riv_status;
-			if (src_iv->riv_status != 0)
+			if (src_iv->riv_status != 0) {
 				rgt->rgt_status.rs_fail_rank = src_iv->riv_rank;
+				rgt->rgt_abort = 1;
+			}
 		}
-		D_DEBUG(DB_TRACE, "update rebuild "DF_UUID" ver %d gen %u"
-			"toberb_obj/rb_obj/rec/global state/status/rank "
-			DF_U64"/"DF_U64"/"DF_U64"/%d/%d/%d\n",
+		D_DEBUG(DB_REBUILD, "update rebuild "DF_UUID" ver %d gen %u"
+			" toberb_obj/rb_obj/rec/global state/status/rank/abort "
+			DF_U64"/"DF_U64"/"DF_U64"/%d/%d/%d/%d\n",
 			DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver,
 			rgt->rgt_rebuild_gen, rgt->rgt_status.rs_toberb_obj_nr,
 			rgt->rgt_status.rs_obj_nr, rgt->rgt_status.rs_rec_nr,
 			rgt->rgt_status.rs_state, rgt->rgt_status.rs_errno,
-			src_iv->riv_rank);
+			src_iv->riv_rank, rgt->rgt_abort);
 	}
 	rgt_put(rgt);
 out:

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -366,11 +366,14 @@ rebuild_object_insert(struct rebuild_tgt_pool_tracker *rpt,
 		 * reclaim is not being scheduled in the previous failure reintegration,
 		 * so let's ignore duplicate shards(DER_EXIST) in this case.
 		 */
-		if (rpt->rt_rebuild_op == RB_OP_REINT || rpt->rt_rebuild_op == RB_OP_EXTEND) {
+		if (rpt->rt_rebuild_op == RB_OP_REINT || rpt->rt_rebuild_op == RB_OP_EXTEND)
 			D_DEBUG(DB_REBUILD, DF_UUID" found duplicate "DF_UOID" %d\n",
 				DP_UUID(co_uuid), DP_UOID(oid), tgt_id);
-			rc = 0;
-		}
+		else
+			/* Since it is harmless, let's skip duplicate obj for other cases. */
+			D_WARN(DF_UUID" found duplicate "DF_UOID" %d\n",
+			       DP_UUID(co_uuid), DP_UOID(oid), tgt_id);
+		rc = 0;
 	}
 	D_DEBUG(DB_REBUILD, "insert "DF_UOID"/"DF_UUID" tgt %u "DF_U64"/"DF_U64": "DF_RC"\n",
 		DP_UOID(oid), DP_UUID(co_uuid), tgt_id, epoch, punched_epoch, DP_RC(rc));


### PR DESCRIPTION
Ignore the EXIST error for scan object insertion for now,
since it is harmless for rebuild process.

Once there are errors, let's abort the rebuild immediately
and retry.

Test-tags: pr rebuild
Signed-off-by: Di Wang <di.wang@intel.com>