### PR TITLE
DAOS-11465 dfs: fix dfs_open for directories without O_EXCL

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -967,7 +967,6 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 	daos_handle_t		th = DAOS_TX_NONE;
 	bool			oexcl = flags & O_EXCL;
 	bool			ocreat = flags & O_CREAT;
-	struct timespec		now;
 	int			rc;
 
 	/*
@@ -984,6 +983,8 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 
 restart:
 	if (ocreat) {
+		struct timespec		now;
+
 		/*
 		 * If O_CREATE | O_EXCL, we just use conditional check to fail
 		 * when inserting the file. Otherwise we need the fetch to make
@@ -1039,6 +1040,7 @@ restart:
 		entry->atime = entry->mtime = entry->ctime = now.tv_sec;
 		entry->atime_nano = entry->mtime_nano = entry->ctime_nano = now.tv_nsec;
 		entry->chunk_size = chunk_size;
+
 		rc = insert_entry(dfs->layout_v, parent->oh, th, file->name, len,
 				  (!dfs->use_dtx || oexcl) ? DAOS_COND_DKEY_INSERT : 0, entry);
 		if (rc == EEXIST && !oexcl) {
@@ -1058,7 +1060,7 @@ restart:
 	rc = fetch_entry(dfs->layout_v, parent->oh, th, file->name, len, false, &exists,
 			 entry, 0, NULL, NULL, NULL);
 	if (rc) {
-		D_ERROR("fetch_entry %s failed %d.\n", file->name, rc);
+		D_DEBUG(DB_TRACE, "fetch_entry %s failed %d.\n", file->name, rc);
 		D_GOTO(out, rc);
 	}
 
@@ -1163,15 +1165,47 @@ open_dir(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 {
 	bool			exists;
 	int			daos_mode;
+	daos_handle_t		th = DAOS_TX_NONE;
+	bool			oexcl = flags & O_EXCL;
+	bool			ocreat = flags & O_CREAT;
 	daos_handle_t		parent_oh;
 	int			rc;
 
 	parent_oh = parent ? parent->oh : dfs->super_oh;
 
-	if (flags & O_CREAT) {
+	/*
+	 * we only need a DTX in the case of O_CREAT without O_EXCL since we don't use a conditional
+	 * insert.
+	 */
+	if (ocreat && !oexcl && dfs->use_dtx) {
+		rc = daos_tx_open(dfs->coh, &th, 0, NULL);
+		if (rc) {
+			D_ERROR("daos_tx_open() failed "DF_RC"\n", DP_RC(rc));
+			D_GOTO(out, rc = daos_der2errno(rc));
+		}
+	}
+
+restart:
+	if (ocreat) {
 		struct timespec		now;
 
 		D_ASSERT(parent);
+
+		/*
+		 * If O_CREATE | O_EXCL, we just use conditional check to fail when inserting the
+		 * file. Otherwise we need the fetch to make sure there is no existing entry that is
+		 * not a dir, or it's just a dir open if the dir entry exists.
+		 */
+		if (!oexcl) {
+			rc = fetch_entry(dfs->layout_v, parent->oh, th, dir->name, len, false,
+					 &exists, entry, 0, NULL, NULL, NULL);
+			if (rc)
+				D_GOTO(out, rc);
+
+			/** Just open the dir */
+			if (exists)
+				goto dopen;
+		}
 
 		/** this generates the OID and opens the object */
 		rc = create_dir(dfs, parent, cid, dir);
@@ -1192,51 +1226,69 @@ open_dir(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 		entry->oclass = parent->d.oclass;
 
 		/** since it's a single conditional op, we don't need a DTX */
-		rc = insert_entry(dfs->layout_v, parent->oh, DAOS_TX_NONE, dir->name, len,
-				  DAOS_COND_DKEY_INSERT, entry);
-		if (rc != 0) {
+		rc = insert_entry(dfs->layout_v, parent->oh, th, dir->name, len,
+				  (!dfs->use_dtx || oexcl) ? DAOS_COND_DKEY_INSERT : 0, entry);
+		if (rc == EEXIST && !oexcl) {
+			/** just try refetching entry to open the file */
 			daos_obj_close(dir->oh, NULL);
-			if (rc != EPERM)
-				D_ERROR("Inserting dir entry %s failed (%d)\n",	dir->name, rc);
-			return rc;
+		} else if (rc) {
+			daos_obj_close(dir->oh, NULL);
+			D_DEBUG(DB_TRACE, "Insert dir entry %s failed (%d)\n", dir->name, rc);
+			D_GOTO(out, rc);
+		} else {
+			/** Success, commit */
+			dir->d.chunk_size = entry->chunk_size;
+			dir->d.oclass = entry->oclass;
+			D_GOTO(commit, rc);
 		}
-
-		dir->d.chunk_size = entry->chunk_size;
-		dir->d.oclass = entry->oclass;
-		return rc;
 	}
+
+	/* Check if parent has the dirname entry */
+	rc = fetch_entry(dfs->layout_v, parent_oh, th, dir->name, len, false, &exists, entry, 0,
+			 NULL, NULL, NULL);
+	if (rc) {
+		D_DEBUG(DB_TRACE, "fetch_entry %s failed %d.\n", dir->name, rc);
+		D_GOTO(out, rc);
+	}
+
+	if (!exists)
+		D_GOTO(out, rc = ENOENT);
+
+dopen:
+	/* Check that the opened object is the type that's expected. */
+	if (!S_ISDIR(entry->mode))
+		return ENOTDIR;
 
 	daos_mode = get_daos_obj_mode(flags);
 	if (daos_mode == -1)
 		return EINVAL;
 
-	/* Check if parent has the dirname entry */
-	rc = fetch_entry(dfs->layout_v, parent_oh, DAOS_TX_NONE, dir->name, len, false,
-			 &exists, entry, 0, NULL, NULL, NULL);
-	if (rc)
-		return rc;
-
-	if (!exists)
-		return ENOENT;
-
-	/* Check that the opened object is the type that's expected, this could
-	 * happen for example if dfs_open() is called with S_IFDIR but without
-	 * O_CREATE and a entry of a different type exists already.
-	 */
-	if (!S_ISDIR(entry->mode))
-		return ENOTDIR;
-
 	rc = daos_obj_open(dfs->coh, entry->oid, daos_mode, &dir->oh, NULL);
 	if (rc) {
 		D_ERROR("daos_obj_open() Failed, "DF_RC"\n", DP_RC(rc));
-		return daos_der2errno(rc);
+		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 	dir->mode = entry->mode;
 	oid_cp(&dir->oid, entry->oid);
 	dir->d.chunk_size = entry->chunk_size;
 	dir->d.oclass = entry->oclass;
 
-	return 0;
+commit:
+	if (daos_handle_is_valid(th) && dfs->use_dtx) {
+		rc = daos_tx_commit(th, NULL);
+		if (rc) {
+			if (rc != -DER_TX_RESTART)
+				D_ERROR("daos_tx_commit() failed (%d)\n", rc);
+			D_GOTO(out, rc = daos_der2errno(rc));
+		}
+	}
+
+out:
+	rc = check_tx(th, rc);
+	if (rc == ERESTART)
+		goto restart;
+
+	return rc;
 }
 
 static int

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1210,7 +1210,7 @@ restart:
 		/** this generates the OID and opens the object */
 		rc = create_dir(dfs, parent, cid, dir);
 		if (rc)
-			return rc;
+			D_GOTO(out, rc);
 
 		entry->oid = dir->oid;
 		entry->mode = dir->mode;
@@ -1218,7 +1218,7 @@ restart:
 		if (rc) {
 			rc = errno;
 			daos_obj_close(dir->oh, NULL);
-			return rc;
+			D_GOTO(out, rc);
 		}
 		entry->atime = entry->mtime = entry->ctime = now.tv_sec;
 		entry->atime_nano = entry->mtime_nano = entry->ctime_nano = now.tv_nsec;
@@ -1257,11 +1257,11 @@ restart:
 dopen:
 	/* Check that the opened object is the type that's expected. */
 	if (!S_ISDIR(entry->mode))
-		return ENOTDIR;
+		D_GOTO(out, rc = ENOTDIR);
 
 	daos_mode = get_daos_obj_mode(flags);
 	if (daos_mode == -1)
-		return EINVAL;
+		D_GOTO(out, rc = EINVAL);
 
 	rc = daos_obj_open(dfs->coh, entry->oid, daos_mode, &dir->oh, NULL);
 	if (rc) {

--- a/src/tests/suite/dfs_par_test.c
+++ b/src/tests/suite/dfs_par_test.c
@@ -52,6 +52,7 @@ test_cond_helper(test_arg_t *arg, int rf)
 	dfs_t		*dfs;
 	daos_handle_t	coh;
 	dfs_obj_t	*file;
+	dfs_obj_t	*dir;
 	char		*filename = "cond_testfile";
 	char		*dirname = "cond_testdir";
 	int		rc, op_rc;
@@ -102,7 +103,7 @@ test_cond_helper(test_arg_t *arg, int rf)
 	par_barrier(PAR_COMM_WORLD);
 
 	if (arg->myrank == 0)
-		print_message("All ranks create the same directory\n");
+		print_message("All ranks create the same directory with mkdir\n");
 	par_barrier(PAR_COMM_WORLD);
 	op_rc = dfs_mkdir(dfs, NULL, dirname, S_IWUSR | S_IRUSR, 0);
 	rc = check_one_success(op_rc, EEXIST);
@@ -113,6 +114,30 @@ test_cond_helper(test_arg_t *arg, int rf)
 
 	if (arg->myrank == 0)
 		print_message("All ranks remove the same directory\n");
+	par_barrier(PAR_COMM_WORLD);
+	op_rc = dfs_remove(dfs, NULL, dirname, true, NULL);
+	rc = check_one_success(op_rc, ENOENT);
+	if (rc)
+		print_error("Failed concurrent rmdir\n");
+	assert_int_equal(rc, 0);
+	par_barrier(PAR_COMM_WORLD);
+
+
+	if (arg->myrank == 0)
+		print_message("All ranks create the same dir with O_EXCL\n");
+	par_barrier(PAR_COMM_WORLD);
+	op_rc = dfs_open(dfs, NULL, dirname, S_IFDIR | S_IWUSR | S_IRUSR,
+			 O_RDWR | O_CREAT | O_EXCL, 0, 0, NULL, &dir);
+	rc = check_one_success(op_rc, EEXIST);
+	assert_int_equal(rc, 0);
+	if (op_rc == 0) {
+		rc = dfs_release(dir);
+		assert_int_equal(rc, 0);
+	}
+	par_barrier(PAR_COMM_WORLD);
+
+	if (arg->myrank == 0)
+		print_message("All ranks remove the same dir\n");
 	par_barrier(PAR_COMM_WORLD);
 	op_rc = dfs_remove(dfs, NULL, dirname, true, NULL);
 	rc = check_one_success(op_rc, ENOENT);
@@ -690,14 +715,17 @@ dfs_test_cont_atomic(void **state)
 }
 
 static void
-file_atomicity_test_helper(test_arg_t *arg, int rf)
+atomicity_test_helper(test_arg_t *arg, int rf)
 {
 	uuid_t		cuuid;
 	dfs_t		*dfs;
 	daos_handle_t	coh;
 	dfs_obj_t	*file;
+	dfs_obj_t	*dir;
 	char		*filename = "testfile";
-	daos_obj_id_t	oid1, oid2;
+	char		*dirname = "testdir";
+	daos_obj_id_t	foid1, foid2;
+	daos_obj_id_t	doid1, doid2;
 	uint64_t	*oids_hi = NULL, *oids_lo = NULL;
 	int		i;
 	int		rc;
@@ -729,7 +757,16 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 	assert_int_equal(rc, 0);
 	par_barrier(PAR_COMM_WORLD);
 
-	rc = dfs_obj2id(file, &oid1);
+	/** all should succeed with the same dir oid */
+	rc = dfs_open(dfs, NULL, dirname, S_IFDIR | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT, 0, 0,
+		      NULL, &dir);
+	assert_int_equal(rc, 0);
+	par_barrier(PAR_COMM_WORLD);
+
+	rc = dfs_obj2id(file, &foid1);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_obj2id(dir, &doid1);
 	assert_int_equal(rc, 0);
 
 	if (arg->myrank == 0) {
@@ -739,33 +776,51 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 		assert_non_null(oids_lo);
 	}
 
-	par_gather(PAR_COMM_WORLD, &oid1.hi, oids_hi, 1, PAR_UINT64, 0);
-	par_gather(PAR_COMM_WORLD, &oid1.lo, oids_lo, 1, PAR_UINT64, 0);
+	par_gather(PAR_COMM_WORLD, &foid1.hi, oids_hi, 1, PAR_UINT64, 0);
+	par_gather(PAR_COMM_WORLD, &foid1.lo, oids_lo, 1, PAR_UINT64, 0);
 
 	if (arg->myrank == 0) {
 		for (i = 0; i < arg->rank_size; i++) {
-			if (oid1.hi != oids_hi[i])
+			if (foid1.hi != oids_hi[i])
 				print_error("OID mismatch between ranks opening the same file");
-			assert_int_equal(oid1.hi, oids_hi[i]);
-			if (oid1.lo != oids_lo[i])
+			assert_int_equal(foid1.hi, oids_hi[i]);
+			if (foid1.lo != oids_lo[i])
 				print_error("OID mismatch between ranks opening the same file");
-			assert_int_equal(oid1.lo, oids_lo[i]);
+			assert_int_equal(foid1.lo, oids_lo[i]);
+		}
+	}
+
+	par_gather(PAR_COMM_WORLD, &doid1.hi, oids_hi, 1, PAR_UINT64, 0);
+	par_gather(PAR_COMM_WORLD, &doid1.lo, oids_lo, 1, PAR_UINT64, 0);
+
+	if (arg->myrank == 0) {
+		for (i = 0; i < arg->rank_size; i++) {
+			if (doid1.hi != oids_hi[i])
+				print_error("OID mismatch between ranks opening the same file");
+			assert_int_equal(doid1.hi, oids_hi[i]);
+			if (doid1.lo != oids_lo[i])
+				print_error("OID mismatch between ranks opening the same file");
+			assert_int_equal(doid1.lo, oids_lo[i]);
 		}
 	}
 
 	rc = dfs_release(file);
 	assert_int_equal(rc, 0);
+	rc = dfs_release(dir);
+	assert_int_equal(rc, 0);
 
 	par_barrier(PAR_COMM_WORLD);
 	if (arg->myrank == 0) {
-		print_message("remove the file\n");
+		print_message("remove the file and dir\n");
 		rc = dfs_remove(dfs, NULL, filename, true, NULL);
+		assert_int_equal(rc, 0);
+		rc = dfs_remove(dfs, NULL, dirname, true, NULL);
 		assert_int_equal(rc, 0);
 	}
 	par_barrier(PAR_COMM_WORLD);
 
 	if (arg->myrank == 0)
-		print_message("reopen the file with OCREAT from all ranks\n");
+		print_message("reopen the file and dir with OCREAT from all ranks\n");
 	par_barrier(PAR_COMM_WORLD);
 
 	/** all should succeed with the same file oid */
@@ -773,30 +828,57 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 		      NULL, &file);
 	assert_int_equal(rc, 0);
 	par_barrier(PAR_COMM_WORLD);
+	rc = dfs_open(dfs, NULL, dirname, S_IFREG | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT, 0, 0,
+		      NULL, &dir);
+	assert_int_equal(rc, 0);
+	par_barrier(PAR_COMM_WORLD);
 
-	rc = dfs_obj2id(file, &oid2);
+	rc = dfs_obj2id(file, &foid2);
+	assert_int_equal(rc, 0);
+	rc = dfs_obj2id(dir, &doid2);
 	assert_int_equal(rc, 0);
 
-	if (oid2.hi == oid1.hi && oid2.lo == oid1.lo) {
+	if (foid2.hi == foid1.hi && foid2.lo == foid1.lo) {
 		print_error("%d: dfs_open returned an existing OID!\n", arg->myrank);
-		assert_false(oid2.hi == oid1.hi && oid2.lo == oid1.lo);
+		assert_false(foid2.hi == foid1.hi && foid2.lo == foid1.lo);
 	}
 
-	par_gather(PAR_COMM_WORLD, &oid2.hi, oids_hi, 1, PAR_UINT64, 0);
-	par_gather(PAR_COMM_WORLD, &oid2.lo, oids_lo, 1, PAR_UINT64, 0);
+	if (doid2.hi == doid1.hi && doid2.lo == doid1.lo) {
+		print_error("%d: dfs_open returned an existing OID!\n", arg->myrank);
+		assert_false(doid2.hi == doid1.hi && doid2.lo == doid1.lo);
+	}
+
+	par_gather(PAR_COMM_WORLD, &foid2.hi, oids_hi, 1, PAR_UINT64, 0);
+	par_gather(PAR_COMM_WORLD, &foid2.lo, oids_lo, 1, PAR_UINT64, 0);
 
 	if (arg->myrank == 0) {
 		for (i = 0; i < arg->rank_size; i++) {
-			if (oid2.hi != oids_hi[i])
+			if (foid2.hi != oids_hi[i])
 				print_error("OID mismatch between ranks opening the same file");
-			assert_int_equal(oid2.hi, oids_hi[i]);
-			if (oid2.lo != oids_lo[i])
+			assert_int_equal(foid2.hi, oids_hi[i]);
+			if (foid2.lo != oids_lo[i])
 				print_error("OID mismatch between ranks opening the same file");
-			assert_int_equal(oid2.lo, oids_lo[i]);
+			assert_int_equal(foid2.lo, oids_lo[i]);
+		}
+	}
+
+	par_gather(PAR_COMM_WORLD, &doid2.hi, oids_hi, 1, PAR_UINT64, 0);
+	par_gather(PAR_COMM_WORLD, &doid2.lo, oids_lo, 1, PAR_UINT64, 0);
+
+	if (arg->myrank == 0) {
+		for (i = 0; i < arg->rank_size; i++) {
+			if (doid2.hi != oids_hi[i])
+				print_error("OID mismatch between ranks opening the same file");
+			assert_int_equal(doid2.hi, oids_hi[i]);
+			if (doid2.lo != oids_lo[i])
+				print_error("OID mismatch between ranks opening the same file");
+			assert_int_equal(doid2.lo, oids_lo[i]);
 		}
 	}
 
 	rc = dfs_release(file);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(dir);
 	assert_int_equal(rc, 0);
 	if (arg->myrank == 0) {
 		D_FREE(oids_hi);
@@ -805,8 +887,10 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 
 	par_barrier(PAR_COMM_WORLD);
 	if (arg->myrank == 0) {
-		print_message("remove the file\n");
+		print_message("remove the file and dir\n");
 		rc = dfs_remove(dfs, NULL, filename, true, NULL);
+		assert_int_equal(rc, 0);
+		rc = dfs_remove(dfs, NULL, dirname, true, NULL);
 		assert_int_equal(rc, 0);
 	}
 	par_barrier(PAR_COMM_WORLD);
@@ -830,25 +914,25 @@ file_atomicity_test_helper(test_arg_t *arg, int rf)
 }
 
 static void
-dfs_test_file_create_atomicity(void **state)
+dfs_test_create_atomicity(void **state)
 {
 	test_arg_t	*arg = *state;
 
 	if (arg->myrank == 0) {
-		print_message("All ranks create the same file without O_EXCL\n");
+		print_message("All ranks create the same file & dir without O_EXCL\n");
 		print_message("Testing with RF 0 ...\n");
 	}
-	file_atomicity_test_helper(arg, DAOS_PROP_CO_REDUN_RF0);
+	atomicity_test_helper(arg, DAOS_PROP_CO_REDUN_RF0);
 
 	if (test_runable(arg, 2)) {
 		if (arg->myrank == 0)
 			print_message("Testing with RF 1 ...\n");
-		file_atomicity_test_helper(arg, DAOS_PROP_CO_REDUN_RF1);
+		atomicity_test_helper(arg, DAOS_PROP_CO_REDUN_RF1);
 	}
 	if (test_runable(arg, 3)) {
 		if (arg->myrank == 0)
 			print_message("Testing with RF 2 ...\n");
-		file_atomicity_test_helper(arg, DAOS_PROP_CO_REDUN_RF2);
+		atomicity_test_helper(arg, DAOS_PROP_CO_REDUN_RF2);
 	}
 }
 
@@ -863,8 +947,8 @@ static const struct CMUnitTest dfs_par_tests[] = {
 	  dfs_test_hole_mgmt, async_disable, test_case_teardown},
 	{ "DFS_PAR_TEST5: DFS Container create atomicity",
 	  dfs_test_cont_atomic, async_disable, test_case_teardown},
-	{ "DFS_PAR_TEST6: DFS File create (without O_EXCL) atomicity",
-	  dfs_test_file_create_atomicity, async_disable, test_case_teardown},
+	{ "DFS_PAR_TEST6: DFS File and Dir create (without O_EXCL) atomicity",
+	  dfs_test_create_atomicity, async_disable, test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
dfs_open with O_CREAT for directories always assume O_EXCL. While posix
does not provide a way to support that, we can easily support that in DFS
to have many processes/threads succeed when creating the same directory
with O_CREAT with only 1 creator and the rest just opening.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>