### PR TITLE
DAOS-11146 client: reduce lock contention on hash lock (#8704)

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -164,8 +164,11 @@ daos_init(void)
 		}
 	}
 
-	/** set up handle hash-table */
-	rc = daos_hhash_init();
+	/**
+	 * Set up handle hash-table, use RW lock instead of spinlock
+	 * improves multiple threads performance significantly.
+	 */
+	rc = daos_hhash_init_feats(D_HASH_FT_RWLOCK);
 	if (rc != 0)
 		D_GOTO(out_debug, rc);
 

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -545,7 +545,7 @@ static pthread_mutex_t	daos_ht_lock = PTHREAD_MUTEX_INITIALIZER;
 static unsigned int	daos_ht_ref;
 
 int
-daos_hhash_init(void)
+daos_hhash_init_feats(uint32_t feats)
 {
 	int rc;
 
@@ -555,8 +555,8 @@ daos_hhash_init(void)
 		D_GOTO(unlock, rc = 0);
 	}
 
-	rc = d_hhash_create(D_HASH_FT_GLOCK | D_HASH_FT_LRU, D_HHASH_BITS,
-			    &daos_ht.dht_hhash);
+	/* D_HASH_FT_NO_KEYINIT_LOCK for optimized link_insert perf */
+	rc = d_hhash_create(feats | D_HASH_FT_NO_KEYINIT_LOCK, D_HHASH_BITS, &daos_ht.dht_hhash);
 	if (rc == 0) {
 		D_ASSERT(daos_ht.dht_hhash != NULL);
 		daos_ht_ref = 1;

--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -519,14 +519,16 @@ d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *link,
 			 void *arg)
 {
 	struct d_hash_bucket	*bucket;
-	uint32_t	 idx;
-	uint32_t	 nr = 1U << htable->ht_bits;
-	bool		 need_lock = !(htable->ht_feats & D_HASH_FT_NOLOCK);
+	uint32_t		 idx;
+	uint32_t		 nr = 1U << htable->ht_bits;
+	bool			 need_lock = !(htable->ht_feats & D_HASH_FT_NOLOCK);
+	bool			 need_keyinit_lock;
 
 	if (htable->ht_ops->hop_key_init == NULL)
 		return -DER_INVAL;
 
-	if (need_lock) {
+	need_keyinit_lock = !(htable->ht_feats & D_HASH_FT_NO_KEYINIT_LOCK);
+	if (need_lock && need_keyinit_lock) {
 		/* Lock all buckets because of unknown key yet */
 		for (idx = 0; idx < nr; idx++) {
 			ch_bucket_lock(htable, idx, false);
@@ -537,16 +539,23 @@ d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *link,
 
 	/* has no key, hash table should have provided key generator */
 	ch_key_init(htable, link, arg);
-
 	idx = ch_rec_hash(htable, link);
 	bucket = &htable->ht_buckets[idx];
+
+	if (need_lock && !need_keyinit_lock)
+		ch_bucket_lock(htable, idx, false);
+
 	ch_rec_insert_addref(htable, bucket, link);
 
 	if (need_lock) {
-		for (idx = 0; idx < nr; idx++) {
+		if (!need_keyinit_lock) {
 			ch_bucket_unlock(htable, idx, false);
-			if (htable->ht_feats & D_HASH_FT_GLOCK)
-				break;
+		} else {
+			for (idx = 0; idx < nr; idx++) {
+				ch_bucket_unlock(htable, idx, false);
+				if (htable->ht_feats & D_HASH_FT_GLOCK)
+					break;
+			}
 		}
 	}
 	return 0;
@@ -1006,7 +1015,7 @@ d_hash_table_debug(struct d_hash_table *htable)
  ******************************************************************************/
 
 struct d_hhash {
-	uint64_t		ch_cookie;
+	ATOMIC uint64_t		ch_cookie;
 	struct d_hash_table	ch_htable;
 	/* server-side uses D_HTYPE_PTR handle */
 	bool			ch_ptrtype;
@@ -1022,23 +1031,26 @@ link2rlink(d_list_t *link)
 static void
 rl_op_addref(struct d_rlink *rlink)
 {
-	rlink->rl_ref++;
+	atomic_fetch_add_relaxed(&rlink->rl_ref, 1);
 }
 
 static bool
 rl_op_decref(struct d_rlink *rlink)
 {
-	D_ASSERT(rlink->rl_ref > 0);
-	rlink->rl_ref--;
-	return rlink->rl_ref == 0;
+	uint32_t oldref;
+
+	oldref = atomic_fetch_sub_relaxed(&rlink->rl_ref, 1);
+	D_ASSERT(oldref > 0);
+
+	return oldref == 1;
 }
 
 static void
 rl_op_init(struct d_rlink *rlink)
 {
 	D_INIT_LIST_HEAD(&rlink->rl_link);
-	rlink->rl_initialized	= 1;
-	rlink->rl_ref		= 1; /* for caller */
+	rlink->rl_initialized = 1;
+	atomic_store_relaxed(&rlink->rl_ref, 1); /* for caller */
 }
 
 static bool
@@ -1049,8 +1061,10 @@ rl_op_empty(struct d_rlink *rlink)
 	if (!rlink->rl_initialized)
 		return true;
 
-	is_unlinked = d_hash_rec_unlinked(&rlink->rl_link);
-	D_ASSERT(rlink->rl_ref != 0 || is_unlinked);
+	is_unlinked = (atomic_load_relaxed(&rlink->rl_ref) == 0);
+	if (is_unlinked)
+		D_ASSERT(d_hash_rec_unlinked(&rlink->rl_link));
+
 	return is_unlinked;
 }
 
@@ -1068,10 +1082,11 @@ hh_op_key_init(struct d_hash_table *htable, d_list_t *link, void *arg)
 	struct d_hhash	*hhash;
 	struct d_hlink	*hlink = link2hlink(link);
 	int		 type  = *(int *)arg;
+	uint64_t	 cookie;
 
 	hhash = container_of(htable, struct d_hhash, ch_htable);
-	hlink->hl_key = ((hhash->ch_cookie++) << D_HTYPE_BITS)
-			| (type & D_HTYPE_MASK);
+	cookie = atomic_fetch_add_relaxed(&hhash->ch_cookie, 1);
+	hlink->hl_key = (cookie << D_HTYPE_BITS) | (type & D_HTYPE_MASK);
 }
 
 static uint32_t
@@ -1149,7 +1164,7 @@ d_hhash_create(uint32_t feats, uint32_t bits, struct d_hhash **hhash_pp)
 		D_GOTO(out, rc);
 	}
 
-	hhash->ch_cookie  = 1ULL;
+	atomic_store_relaxed(&hhash->ch_cookie, 1);
 	hhash->ch_ptrtype = false;
 out:
 	*hhash_pp = hhash;
@@ -1200,8 +1215,6 @@ d_uhash_link_empty(struct d_ulink *ulink)
 void
 d_hhash_link_insert(struct d_hhash *hhash, struct d_hlink *hlink, int type)
 {
-	bool need_lock = !(hhash->ch_htable.ht_feats & D_HASH_FT_NOLOCK);
-
 	D_ASSERT(hlink->hl_link.rl_initialized);
 
 	/* check if handle type fits in allocated bits */
@@ -1210,34 +1223,15 @@ d_hhash_link_insert(struct d_hhash *hhash, struct d_hlink *hlink, int type)
 		  type, D_HTYPE_BITS);
 
 	if (d_hhash_is_ptrtype(hhash)) {
-		uint64_t ptr_key = (uintptr_t)hlink;
-		uint32_t nr = 1U << hhash->ch_htable.ht_bits;
-		uint32_t idx = 0;
+		uint64_t		 ptr_key = (uintptr_t)hlink;
 
 		D_ASSERTF(type == D_HTYPE_PTR, "direct/ptr-based htable can "
 			  "only contain D_HTYPE_PTR type entries");
 		D_ASSERTF(d_hhash_key_isptr(ptr_key), "hlink ptr %p is invalid "
 			  "D_HTYPE_PTR type", hlink);
 
-		if (need_lock) {
-			/* Lock all buckets to emulate proper hlink lock */
-			for (idx = 0; idx < nr; idx++) {
-				ch_bucket_lock(&hhash->ch_htable, idx, false);
-				if (hhash->ch_htable.ht_feats & D_HASH_FT_GLOCK)
-					break;
-			}
-		}
-
-		ch_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 		hlink->hl_key = ptr_key;
-
-		if (need_lock) {
-			for (idx = 0; idx < nr; idx++) {
-				ch_bucket_unlock(&hhash->ch_htable, idx, false);
-				if (hhash->ch_htable.ht_feats & D_HASH_FT_GLOCK)
-					break;
-			}
-		}
+		ch_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 	} else {
 		D_ASSERTF(type != D_HTYPE_PTR, "PTR type key being inserted "
 			  "in a non ptr-based htable.\n");
@@ -1514,7 +1508,7 @@ d_uhash_link_insert(struct d_hash_table *htable, struct d_uuid *key,
 bool
 d_uhash_link_last_ref(struct d_ulink *ulink)
 {
-	return ulink->ul_link.rl_ref == 1;
+	return atomic_load_relaxed(&ulink->ul_link.rl_ref) == 1;
 }
 
 void

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -839,7 +839,12 @@ struct daos_hhash_table {
 extern struct daos_hhash_table daos_ht;
 
 /* daos handle hash table helpers */
-int daos_hhash_init(void);
+int daos_hhash_init_feats(uint32_t feats);
+static inline int
+daos_hhash_init(void)
+{
+	return daos_hhash_init_feats(D_HASH_FT_GLOCK | D_HASH_FT_LRU);
+}
 int daos_hhash_fini(void);
 struct d_hlink *daos_hhash_link_lookup(uint64_t key);
 void daos_hhash_link_insert(struct d_hlink *hlink, int type);

--- a/src/include/gurt/atomic.h
+++ b/src/include/gurt/atomic.h
@@ -11,12 +11,17 @@
 
 #if HAVE_STDATOMIC
 
+#ifndef __cplusplus
 #include <stdatomic.h>
 
 #ifdef __INTEL_COMPILER
 #define ATOMIC volatile
 #else
 #define ATOMIC _Atomic
+#endif
+
+#else
+#define ATOMIC
 #endif
 
 /* stdatomic interface for compare_and_exchange doesn't quite align */

--- a/src/include/gurt/hash.h
+++ b/src/include/gurt/hash.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -19,6 +19,7 @@
 
 #include <gurt/list.h>
 #include <gurt/types.h>
+#include <gurt/atomic.h>
 
 /**
  * Hash table keeps and prints extra debugging information
@@ -196,13 +197,19 @@ enum d_hash_feats {
 	 * The found in bucket item is moved on top of the list.
 	 * So, next search for it will be much faster.
 	 */
-	D_HASH_FT_LRU		= (1 << 4),
+	D_HASH_FT_LRU			= (1 << 4),
+
+	/**
+	 * Need not take lock for ch_key_init.
+	 * Only valid when without D_HASH_FT_NOLOCK feat bit set.
+	 */
+	D_HASH_FT_NO_KEYINIT_LOCK	= (1 << 5),
 
 	/**
 	 * Use Global Table Lock instead of per bucket locking.
 	 * TODO: should be removed when all will use per bucket locking.
 	 */
-	D_HASH_FT_GLOCK		= (1 << 15),
+	D_HASH_FT_GLOCK			= (1 << 15),
 };
 
 union d_hash_lock {
@@ -539,7 +546,7 @@ struct d_hlink_ops {
 
 struct d_rlink {
 	d_list_t		rl_link;
-	uint32_t		rl_ref;
+	ATOMIC uint32_t		rl_ref;
 	uint32_t		rl_initialized:1;
 };
 

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4753,6 +4753,39 @@ io_tx_convert(void **state)
 	ioreq_fini(&req);
 }
 
+static void
+obj_open_perf(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	daos_handle_t	*oh;
+	uint64_t	start_usec, end_usec;
+	float		opens_per_sec;
+	int		i, nr, rc;
+
+	nr = 10000;
+	D_ALLOC_ARRAY(oh, nr);
+	assert_non_null(oh);
+
+	start_usec = daos_getutime();
+	for (i = 0; i < nr; i++) {
+		oid = daos_test_oid_gen(arg->coh, dts_obj_class, 0, 0, arg->myrank);
+		rc = daos_obj_open(arg->coh, oid, 0, &oh[i], NULL);
+		assert_rc_equal(rc, 0);
+	}
+	end_usec = daos_getutime();
+	opens_per_sec = (nr * 1000.0 * 1000) / (end_usec - start_usec);
+
+	print_message("opens per second %.2f (total #obj_opens %d)\n", opens_per_sec, nr);
+
+	for (i = 0; i < nr; i++) {
+		rc = daos_obj_close(oh[i], NULL);
+		assert_rc_equal(rc, 0);
+	}
+
+	D_FREE(oh);
+}
+
 static const struct CMUnitTest io_tests[] = {
 	{ "IO1: simple update/fetch/verify",
 	  io_simple, async_disable, test_case_teardown},
@@ -4848,6 +4881,7 @@ static const struct CMUnitTest io_tests[] = {
 	  enum_recxs_with_aggregation, async_disable, test_case_teardown},
 	{ "IO46: tx convert",
 	  io_tx_convert, async_disable, test_case_teardown},
+	{ "IO47: obj_open perf", obj_open_perf, async_disable, test_case_teardown},
 };
 
 int


### PR DESCRIPTION
1. switch one global lock to per bucket lock.
    to reduce lock contention for multiple threads.

2.  add following adjustment to make apply read/write lock possible:

     2.1 use atomic counter to implement rl_op_addref()/rl_op_decref()
     because getref/putref switch to read lock.
     2.2: remove LRU feats so we don't need hold write lock for read.

3. Refine d_hhash_link_insert() - for PTR type handle hash table, need not take
any extra lock for non-PTR type, refine d_hash_rec_insert_anonym()
add feat bit D_HASH_FT_NO_KEYINIT_LOCK set that for d_hhash
to avoid take all buckets' lock Addd a simple test fo obj_open perf,
by testing on boro obj_open per second increased from 427.36 OPs/S to 313038.03 OPs/S.
(./daos_test -i -u 46, only one engine and client is enough) (From Xuezhao)

Single client fio 4k random write testing(4 daos servers):

                  before                                after
64thread  28.1k iops                          171k iops

Signed-off-by: Wang Shilong <shilong.wang@intel.com>