### PR TITLE
DAOS-11197 test: Increase timeout for dfs.yaml parallel test

### DIFF
--- a/src/tests/ftest/daos_test/dfs.yaml
+++ b/src/tests/ftest/daos_test/dfs.yaml
@@ -6,7 +6,7 @@ hosts:
 timeout: 4000
 timeouts:
   test_daos_dfs_unit: 2000
-  test_daos_dfs_parallel: 2060
+  test_daos_dfs_parallel: 2150
   test_daos_dfs_sys: 90
 pool:
   scm_size: 8G


### PR DESCRIPTION
Description:
Increase timeout for dfs.py parallel test and update script/main.sh to correct cmocka.xml path with Test-repeat.

Skip-unit-tests: true
Test-tag: daos_core_test_dfs
Test-repeat: 3
Required-githooks: true

Signed-off-by: Ding Ho ding-hwa.ho@intel.com