### PR TITLE
DAOS-10488 test: Add dfuse unit test code and call it from ftest. (#7286)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-daos (2.3.100-7) unstable; urgency=medium
+daos (2.1.104-5) unstable; urgency=medium
   [ Ashley Pittman ]
   * Add dfuse unit-test binary to call from ftest.
 
- -- Ashley Pittman <ashley.m.pittman@intel.com>  Fri, 6 May 2022 09:03:00 -0100
+ -- Ashley Pittman <ashley.m.pittman@intel.com>  Thu,25 Aug 2022 09:03:00 -0100
 
 daos (2.1.104-4) unstable; urgency=medium
   [ Jeff Olivier ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ daos (2.1.104-5) unstable; urgency=medium
   [ Ashley Pittman ]
   * Add dfuse unit-test binary to call from ftest.
 
- -- Ashley Pittman <ashley.m.pittman@intel.com>  Thu,25 Aug 2022 09:03:00 -0100
+ -- Ashley Pittman <ashley.m.pittman@intel.com>  Thu, 25 Aug 2022 09:03:00 -0100
 
 daos (2.1.104-4) unstable; urgency=medium
   [ Jeff Olivier ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.3.100-7) unstable; urgency=medium
+  [ Ashley Pittman ]
+  * Add dfuse unit-test binary to call from ftest.
+
+ -- Ashley Pittman <ashley.m.pittman@intel.com>  Fri, 6 May 2022 09:03:00 -0100
+
 daos (2.1.104-4) unstable; urgency=medium
   [ Jeff Olivier ]
   * Update PMDK to 1.12.1~rc1 to fix DAOS-11151

--- a/debian/daos-client-tests.install
+++ b/debian/daos-client-tests.install
@@ -6,6 +6,7 @@ usr/bin/common_test
 usr/bin/daos_debug_set_params
 usr/bin/drpc_engine_test
 usr/bin/drpc_test
+usr/bin/dfuse_test
 usr/bin/job_tests
 usr/bin/eq_tests
 usr/bin/security_test

--- a/src/tests/ftest/daos_test/dfuse.py
+++ b/src/tests/ftest/daos_test/dfuse.py
@@ -1,0 +1,102 @@
+"""
+  (C) Copyright 2021-2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+import os
+from collections import OrderedDict
+import general_utils
+from dfuse_test_base import DfuseTestBase
+
+class DaosCoreTestDfuse(DfuseTestBase):
+    # pylint: disable=too-many-ancestors
+    """Runs DAOS DFuse tests.
+
+    :avocado: recursive
+    """
+
+    def test_daos_dfuse_unit(self):
+        """
+
+        Test Description: Run dfuse_test to check correctness.
+
+        Use cases:
+            DAOS DFuse unit tests
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=dfuse,dfuse_test
+        :avocado: tags=dfuse_unit
+        """
+        self.daos_test = os.path.join(self.bin, 'dfuse_test')
+
+        # Create a pool, container and start dfuse.
+        self.add_pool(connect=False)
+        self.add_container(self.pool)
+
+        daos_cmd = self.get_daos_command()
+
+        cont_attrs = OrderedDict()
+
+        cache_mode = self.params.get('name', '/run/dfuse/*')
+
+        # How long to cache things for, if caching is enabled.
+        cache_time = '5m'
+
+        if cache_mode == 'writeback':
+            cont_attrs['dfuse-data-cache'] = 'on'
+            cont_attrs['dfuse-attr-time'] = cache_time
+            cont_attrs['dfuse-dentry-time'] = cache_time
+            cont_attrs['dfuse-ndentry-time'] = cache_time
+        elif cache_mode == 'writethrough':
+            cont_attrs['dfuse-data-cache'] = 'on'
+            cont_attrs['dfuse-attr-time'] = cache_time
+            cont_attrs['dfuse-dentry-time'] = cache_time
+            cont_attrs['dfuse-ndentry-time'] = cache_time
+        elif cache_mode == 'metadata':
+            cont_attrs['dfuse-data-cache'] = 'off'
+            cont_attrs['dfuse-attr-time'] = cache_time
+            cont_attrs['dfuse-dentry-time'] = cache_time
+            cont_attrs['dfuse-ndentry-time'] = cache_time
+        elif cache_mode == 'nocache':
+            cont_attrs['dfuse-data-cache'] = 'off'
+            cont_attrs['dfuse-attr-time'] = '0'
+            cont_attrs['dfuse-dentry-time'] = '0'
+            cont_attrs['dfuse-ndentry-time'] = '0'
+        else:
+            self.fail('Invalid cache_mode: {}'.format(cache_mode))
+
+        for key, value in cont_attrs.items():
+            daos_cmd.container_set_attr(pool=self.pool.uuid, cont=self.container.uuid,
+                                        attr=key, val=value)
+
+        self.start_dfuse(self.hostlist_clients, self.pool, self.container)
+
+        mount_dir = self.dfuse.mount_dir.value
+
+        intercept = self.params.get('use_intercept', '/run/intercept/*', default=False)
+
+        cmd = [self.daos_test, '--test-dir', mount_dir]
+
+        if intercept:
+            remote_env = OrderedDict()
+
+            remote_env['LD_PRELOAD'] = os.path.join(self.prefix, 'lib64', 'libioil.so')
+            remote_env['D_LOG_FILE'] = '/var/tmp/daos_testing/daos-il.log'
+            remote_env['DD_MASK'] = 'all'
+            remote_env['DD_SUBSYS'] = 'all'
+            remote_env['D_LOG_MASK'] = 'INFO,IL=DEBUG'
+
+            envs = ['export {}={}'.format(env, value) for env, value in remote_env.items()]
+
+            preload_cmd = ';'.join(envs)
+
+            command = '{};{}'.format(preload_cmd, ' '.join(cmd))
+        else:
+            command = ' '.join(cmd)
+        ret_code = general_utils.pcmd(self.hostlist_clients, command, timeout=60)
+        if 0 in ret_code:
+            return
+        self.log.info(ret_code)
+        self.fail('Error running {}'.format(cmd))

--- a/src/tests/ftest/daos_test/dfuse.yaml
+++ b/src/tests/ftest/daos_test/dfuse.yaml
@@ -1,0 +1,38 @@
+hosts:
+  test_servers:
+    - server-A
+  test_clients:
+    - client-B
+timeout: 60
+pool:
+  scm_size: 1G
+  control_method: dmg
+server_config:
+  name: daos_server
+container:
+  type: POSIX
+  control_method: daos
+dfuse: !mux
+  writeback:
+    # File metadata is incorrect after write with writeback caching and IL.
+    !filter-only : "/run/intercept/off"  # yamllint disable-line rule:colons
+    mount_dir: "/tmp/daos_dfuse/"
+    name: "writeback"
+  writethrough:
+    mount_dir: "/tmp/daos_dfuse/"
+    disable_wb_cache: true
+    name: "writethrough"
+  metadata:
+    mount_dir: "/tmp/daos_dfuse/"
+    disable_wb_cache: true
+    name: "metadata"
+  nocache:
+    mount_dir: "/tmp/daos_dfuse/"
+    disable_wb_cache: true
+    disable_caching: true
+    name: "nocache"
+intercept: !mux
+  off:
+    use_intercept: false
+  on:
+    use_intercept: true

--- a/src/tests/ftest/daos_test/dfuse.yaml
+++ b/src/tests/ftest/daos_test/dfuse.yaml
@@ -1,8 +1,6 @@
 hosts:
-  test_servers:
-    - server-A
-  test_clients:
-    - client-B
+  test_servers: 1
+  test_clients: 1
 timeout: 60
 pool:
   scm_size: 1G

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1428,7 +1428,8 @@ def run_tests(test_files, tag_filter, args):
 
 
 def get_yaml_data(yaml_file):
-    """Get the contents of a yaml file as a dictionary.
+    """Get the contents of a yaml file as a dictionary, removing any mux tags and ignoring any
+    other tags present.
 
     Removes any mux tags and ignores any other tags present.
 
@@ -1460,8 +1461,7 @@ def get_yaml_data(yaml_file):
     if os.path.isfile(yaml_file):
         with open(yaml_file, "r") as open_file:
             try:
-                file_data = open_file.read()
-                yaml_data = yaml.safe_load(file_data.replace("!mux", ""))
+                yaml_data = yaml.load(open_file.read(), Loader=DaosLoader)
             except yaml.YAMLError as error:
                 log("Error reading {}: {}".format(yaml_file, error))
                 sys.exit(1)

--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -1,15 +1,8 @@
 """Build test suite"""
 import sys
-
 import subprocess
-#hack to handle old subprocess version
-try:
-    from subprocess import DEVNULL
-except ImportError:
-    import os
-    DEVNULL = open(os.devnull, "wb")
-
 import daos_build
+import compiler_setup
 
 test_cmocka_skip = """
 #include <stdarg.h>
@@ -45,8 +38,8 @@ def CheckCmockaSkip(context):
         return rc
     prog = context.lastTarget
     pname = prog.get_abspath()
-    rc = subprocess.call(pname, env={"CMOCKA_TEST_ABORT": "1"}, stdout=DEVNULL,
-                         stderr=DEVNULL)
+    rc = subprocess.call(pname, env={"CMOCKA_TEST_ABORT": "1"},
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     #in case of abort rc is -6 instead of 134 (128+6) with shell ...
     if rc == -6:
         sys.stdout.write(" (Bug reproduced) ")
@@ -77,10 +70,15 @@ def configure_cmocka(nenv):
 #
 def scons():
     """Execute build"""
-    Import('denv')
+    Import('denv', 'base_env')
 
     libraries = ['daos', 'dfs', 'daos_tests', 'gurt', 'cart']
     libraries += ['uuid', 'cmocka', 'pthread', 'isal']
+
+    dfuse_env = base_env.Clone()
+    compiler_setup.base_setup(dfuse_env)
+    dfusetest = daos_build.program(dfuse_env, File("dfuse_test.c"), LIBS='cmocka')
+    denv.Install('$PREFIX/bin/', dfusetest)
 
     denv.AppendUnique(CPPPATH=["#/src/client/dfs"])
     denv.AppendUnique(CPPPATH=[Dir('../../mgmt').srcnode()])

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -1,0 +1,175 @@
+/**
+ * (C) Copyright 2021-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * Unit testing for dfuse and Interception library.  This code does not interact with dfuse
+ * directly, however makes filesystem calls into libc and checks the results are as expected.
+ *
+ * It is also called with the Interception Library to verify that I/O calls have the expected
+ * behavior in this case as well.
+ *
+ * It uses cmocka, but not to mock any functions, only for the reporting and assert macros.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <stdio.h>
+#include <getopt.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+static void
+print_usage()
+{
+	printf("DFuse tests\n");
+	printf("dfuse_test --test-dir <path to test>\n");
+}
+
+char *test_dir;
+
+#ifndef O_PATH
+#define O_PATH 0
+#endif
+
+void
+do_openat(void **state)
+{
+	struct stat stbuf0;
+	struct stat stbuf;
+	int         fd;
+	int         rc;
+	char        output_buf[10];
+	char        input_buf[] = "hello";
+	off_t       offset;
+	int         root = open(test_dir, O_PATH | O_DIRECTORY);
+
+	assert_return_code(root, errno);
+
+	fd = openat(root, "my_file", O_RDWR | O_CREAT | O_EXCL, S_IWUSR | S_IRUSR);
+	assert_return_code(fd, errno);
+
+	/* This will write six bytes, including a \0 terminator */
+	rc = write(fd, input_buf, sizeof(input_buf));
+	assert_return_code(rc, errno);
+
+	/* First fstat.  IL will forward this to the kernel so it can save ino for future calls */
+	rc = fstat(fd, &stbuf0);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf0.st_size, sizeof(input_buf));
+
+	/* Second fstat.  IL will bypass the kernel for this one */
+	rc = fstat(fd, &stbuf);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf.st_size, sizeof(input_buf));
+	assert_int_equal(stbuf0.st_dev, stbuf.st_dev);
+	assert_int_equal(stbuf0.st_ino, stbuf.st_ino);
+
+	/* This will write six bytes, including a \0 terminator */
+	rc = write(fd, input_buf, sizeof(input_buf));
+	assert_return_code(rc, errno);
+
+	/* fstat to check the file size is updated */
+	rc = fstat(fd, &stbuf0);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf0.st_size, sizeof(input_buf) * 2);
+
+	/* stat through kernel to ensure it has observed write */
+	rc = fstatat(root, "my_file", &stbuf, AT_SYMLINK_NOFOLLOW);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf.st_size, stbuf0.st_size);
+
+	offset = lseek(fd, -8, SEEK_CUR);
+	assert_return_code(offset, errno);
+	assert_int_equal(offset, sizeof(input_buf) - 2);
+
+	rc = read(fd, &output_buf, 2);
+	assert_return_code(rc, errno);
+	assert_int_equal(rc, 2);
+	assert_memory_equal(&input_buf[offset], &output_buf, rc);
+
+	rc = fstat(fd, &stbuf);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf.st_size, 12);
+
+	rc = ftruncate(fd, offset);
+	assert_return_code(rc, errno);
+
+	rc = fstatat(root, "my_file", &stbuf, AT_SYMLINK_NOFOLLOW);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf.st_size, offset);
+
+	rc = fstat(fd, &stbuf);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf.st_size, offset);
+
+	/* stat/fstatat */
+	rc = read(fd, &output_buf, 2);
+	assert_return_code(rc, errno);
+	assert_int_equal(rc, 0);
+
+	offset = lseek(fd, -4, SEEK_CUR);
+	assert_return_code(offset, errno);
+	assert_int_equal(offset, 2);
+
+	rc = read(fd, &output_buf, 10);
+	assert_return_code(rc, errno);
+	assert_int_equal(rc, 2);
+	assert_memory_equal(&input_buf[offset], &output_buf, rc);
+
+	rc = fstat(fd, &stbuf);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf.st_size, 4);
+
+	rc = fstatat(root, "my_file", &stbuf0, AT_SYMLINK_NOFOLLOW);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf.st_size, stbuf0.st_size);
+
+	rc = close(fd);
+	assert_return_code(rc, errno);
+
+	rc = unlinkat(root, "my_file", 0);
+	assert_return_code(rc, errno);
+
+	rc = close(root);
+	assert_return_code(rc, errno);
+}
+
+int
+main(int argc, char **argv)
+{
+	int                     index = 0;
+	int                     opt;
+	struct option           long_options[] = {{"test-dir", required_argument, NULL, 'M'},
+						  {NULL, 0, NULL, 0} };
+
+	const struct CMUnitTest tests[]        = {
+		   cmocka_unit_test(do_openat),
+	};
+
+	while ((opt = getopt_long(argc, argv, "M:", long_options, &index)) != -1) {
+		switch (opt) {
+		case 'M':
+			test_dir = optarg;
+			break;
+		default:
+			printf("Unknown Option\n");
+			print_usage();
+			return 1;
+		}
+	}
+
+	if (test_dir == NULL) {
+		printf("--test-dir option required\n");
+		return 1;
+	}
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -571,7 +571,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
-* Thur Aug 25 2022 Ashley Pittman <ashley.m.pittman@intel.com> 2.1.104-5
+* Thu Aug 25 2022 Ashley Pittman <ashley.m.pittman@intel.com> 2.1.104-5
 - Add dfuse unit-test binary to call from ftest.
 
 * Tue Aug 16 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.1.104-4

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.1.104
-Release:       4%{?relval}%{?dist}
+Release:       5%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -510,6 +510,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_bindir}/daos_debug_set_params
 %{_bindir}/drpc_engine_test
 %{_bindir}/drpc_test
+%{_bindir}/dfuse_test
 %{_bindir}/eq_tests
 %{_bindir}/job_tests
 %{_bindir}/security_test
@@ -570,6 +571,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Thur Aug 25 2022 Ashley Pittman <ashley.m.pittman@intel.com> 2.1.104-5
+- Add dfuse unit-test binary to call from ftest.
+
 * Tue Aug 16 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.1.104-4
 - Update PMDK to 1.12.1~rc1 to fix DAOS-11151
 


### PR DESCRIPTION

Combined cherry-pick
DAOS-10488 test: Add dfuse unit test code and call it from ftest. (#7286)


DAOS-10029 test: Use python3 for list_tests. (#8911) 

Now the builders have python3 installed use it for list tests.
This means that launch.py and the tests themselves can use
python3 features and the codebase should not depend on python2
any longer.

Fix some linting errors in launch.py

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>