### PR TITLE
DAOS-11422 vos: Extend vos_obj_query_key to allow only max_write query

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1063,15 +1063,18 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
  * a recx is found or no more dkeys exist in which case -DER_NONEXIST is
  * returned.
  *
+ * The maximum write epoch for the object can be returned at the same time
+ * as the min or max query. Alternatively, this API can be used to only query
+ * the maximum write for an object if no flags are given.
+ *
  * \param[in]	coh		Container open handle.
  * \param[in]	oid		Object id
  * \param[in]	flags		mask with the following options:
  *				DAOS_GET_DKEY, DAOS_GET_AKEY, DAOS_GET_RECX,
  *				DAOS_GET_MAX, DAOS_GET_MIN
- *				User has to indicate whether to query the MAX or MIN, in
- *				addition to what needs to be queried. Providing
- *				(MAX | MIN) in any combination will return an error.
- *				i.e. user can only query MAX or MIN in one call.
+ *				If the user isn't querying max_write, they must specify either
+ *				DAOS_GET_MAX or DAOS_GET_MIN, exclusively. Anything else is
+ *				an error.
  * \param[in,out]
  *		dkey		[in]: allocated integer dkey. User can provide the dkey
  *				if not querying the max or min dkey.
@@ -1083,7 +1086,7 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
  * \param[out]	recx		max or min offset in dkey/akey, and the size of the
  *				extent at the offset. If there are no visible array
  *				records, the size in the recx returned will be 0.
- * \param[out]	max_write	Optional: Returns max write epoch for object
+ * \param[out]	max_write	Optional: Returns max write epoch for object.
  * \param[in]	cell_size cell size for EC object, used to calculated the replicated
  *                      space address on parity shard.
  * \param[in]	stripe_size stripe size for EC object, used to calculated the replicated

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -743,6 +743,19 @@ punch_model_test(void **state)
 	assert_int_equal(rex.rx_idx, 0);
 	assert_int_equal(rex.rx_nr, strlen(latest));
 	assert_int_equal(max_write, 11);
+
+	/** Just query max_write */
+	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, 0, 11, NULL, NULL, NULL, &max_write, 0, 0,
+			       NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(max_write, 11);
+
+	/** Invalid arguments tests */
+	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_MAX, 11, NULL, NULL, NULL,
+			       &max_write, 0, 0, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
+	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, 0, 11, NULL, NULL, NULL, NULL, 0, 0, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
 }
 
 static void

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -573,6 +573,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	struct vos_object	*obj = NULL;
 	struct open_query	*query;
 	daos_epoch_t		 bound;
+	bool                     max_write_only = false;
 	daos_epoch_range_t	 dkey_epr;
 	struct vos_punch_record	 dkey_punch;
 	enum daos_otype_t	 obj_type;
@@ -596,8 +597,12 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	}
 
 	if (!(flags & VOS_GET_MAX) && !(flags & VOS_GET_MIN)) {
+		if (max_write != NULL) {
+			max_write_only = true;
+			goto query_write;
+		}
 		D_ERROR("No query type.  Please select either VOS_GET_MAX"
-			" or VOS_GET_MIN\n");
+			" or VOS_GET_MIN or pass non-NULL max_write\n");
 		return -DER_INVAL;
 	}
 
@@ -606,6 +611,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 			" VOS_GET_DKEY, VOS_GET_AKEY, or VOS_GET_RECX\n");
 		return -DER_INVAL;
 	}
+query_write:
 
 	D_ALLOC_PTR(query);
 	if (query == NULL)
@@ -613,35 +619,39 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 
 	query->qt_ts_set = NULL;
 
-	if (flags & VOS_GET_DKEY) {
-		if (dkey == NULL) {
-			D_ERROR("dkey can't be NULL with VOS_GET_DKEY\n");
-			D_GOTO(free_query, rc = -DER_INVAL);
-		}
-		daos_anchor_set_zero(&query->qt_dkey_anchor);
-
+	if (!max_write_only) {
 		cflags = VOS_TS_READ_OBJ;
-	}
+	} else {
+		if (flags & VOS_GET_DKEY) {
+			if (dkey == NULL) {
+				D_ERROR("dkey can't be NULL with VOS_GET_DKEY\n");
+				D_GOTO(free_query, rc = -DER_INVAL);
+			}
+			daos_anchor_set_zero(&query->qt_dkey_anchor);
 
-	if (flags & VOS_GET_AKEY) {
-		if (akey == NULL) {
-			D_ERROR("akey can't be NULL with VOS_GET_AKEY\n");
-			D_GOTO(free_query, rc = -DER_INVAL);
+			cflags = VOS_TS_READ_OBJ;
 		}
 
-		if (cflags == 0)
-			cflags = VOS_TS_READ_DKEY;
-	}
+		if (flags & VOS_GET_AKEY) {
+			if (akey == NULL) {
+				D_ERROR("akey can't be NULL with VOS_GET_AKEY\n");
+				D_GOTO(free_query, rc = -DER_INVAL);
+			}
 
-	if (flags & VOS_GET_RECX) {
-		if (recx == NULL) {
-			D_ERROR("recx can't be NULL with VOS_GET_RECX\n");
-			D_GOTO(free_query, rc = -DER_INVAL);
+			if (cflags == 0)
+				cflags = VOS_TS_READ_DKEY;
 		}
 
-		nr_akeys = 1;
-		if (cflags == 0)
-			cflags = VOS_TS_READ_AKEY;
+		if (flags & VOS_GET_RECX) {
+			if (recx == NULL) {
+				D_ERROR("recx can't be NULL with VOS_GET_RECX\n");
+				D_GOTO(free_query, rc = -DER_INVAL);
+			}
+
+			nr_akeys = 1;
+			if (cflags == 0)
+				cflags = VOS_TS_READ_AKEY;
+		}
 	}
 
 	vos_dth_set(dth);
@@ -670,6 +680,9 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		rc = -DER_TX_RESTART;
 		goto out;
 	}
+
+	if (max_write_only)
+		goto out;
 
 	D_ASSERT(obj != NULL);
 	/* only integer keys supported */

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -619,7 +619,7 @@ query_write:
 
 	query->qt_ts_set = NULL;
 
-	if (!max_write_only) {
+	if (max_write_only) {
 		cflags = VOS_TS_READ_OBJ;
 	} else {
 		if (flags & VOS_GET_DKEY) {


### PR DESCRIPTION
This is a bit overloaded but simple enough. There are cases where we
want to query the max_write of an object but don't want to query the
key(s).   Allow a call to the existing API to just query the max_write.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>