### PR TITLE
DAOS-11160 test: Fixing Misspelling of 'Sending' (#9993)

### DIFF
--- a/src/tests/ftest/cart/no_pmix_corpc_errors.c
+++ b/src/tests/ftest/cart/no_pmix_corpc_errors.c
@@ -444,7 +444,7 @@ int main(int argc, char **argv)
 	}
 
 	/* Send shutdown RPC to all nodes except for self */
-	DBG_PRINT("Senidng shutdown to all nodes\n");
+	DBG_PRINT("Sending shutdown to all nodes\n");
 
 	/* Note rank at i=0 corresponds to 'self' */
 	for (i = 0; i < s_list->rl_nr; i++) {

--- a/src/tests/ftest/cart/no_pmix_group_test.c
+++ b/src/tests/ftest/cart/no_pmix_group_test.c
@@ -605,7 +605,7 @@ int main(int argc, char **argv)
 	DBG_PRINT("CORRPC to secondary group finished\n");
 
 	/* Send shutdown RPC to all nodes except for self */
-	DBG_PRINT("Senidng shutdown to all nodes\n");
+	DBG_PRINT("Sending shutdown to all nodes\n");
 
 	/* Note rank at i=1 corresponds to 'self' */
 	for (i = 0; i < rank_list->rl_nr; i++) {

--- a/src/tests/ftest/cart/no_pmix_group_version.c
+++ b/src/tests/ftest/cart/no_pmix_group_version.c
@@ -459,7 +459,7 @@ int main(int argc, char **argv)
 	verify_corpc(crt_ctx[1], grp, -DER_GRPVER);
 
 	/* Send shutdown RPC to all nodes except for self */
-	DBG_PRINT("Senidng shutdown to all nodes\n");
+	DBG_PRINT("Sending shutdown to all nodes\n");
 
 	/* Note rank at i=0 corresponds to 'self' */
 	for (i = 0; i < s_list->rl_nr; i++) {


### PR DESCRIPTION
Fix misspellings in test code, as describe in DAOS-11160.
./src/tests/ftest/cart/no_pmix_corpc_errors.c:  DBG_PRINT("Senidng shutdown to all nodes\n");
./src/tests/ftest/cart/no_pmix_group_test.c:    DBG_PRINT("Senidng shutdown to all nodes\n");
./src/tests/ftest/cart/no_pmix_group_version.c: DBG_PRINT("Senidng shutdown to all nodes\n");

Need to merge to DAOS-2.0.

Signed-off-by: Kurniawan Alfizah <kurniawan.alfizah@intel.com>