### PR TITLE
DAOS-11470 dfs: add proper ctime support

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -782,6 +782,8 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 		size = sizeof(entry);
 		stbuf->st_mtim.tv_sec = entry.mtime;
 		stbuf->st_mtim.tv_nsec = entry.mtime_nano;
+		stbuf->st_ctim.tv_sec = entry.ctime;
+		stbuf->st_ctim.tv_nsec = entry.ctime_nano;
 		break;
 	case S_IFREG:
 	{
@@ -843,6 +845,18 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 				return daos_der2errno(rc);
 			}
 
+			/** ctime should be the greater of the entry and object hlc */
+			stbuf->st_ctim.tv_sec = entry.ctime;
+			stbuf->st_ctim.tv_nsec = entry.ctime_nano;
+			if (tspec_gt(obj_mtime, stbuf->st_ctim)) {
+				stbuf->st_ctim.tv_sec = obj_mtime.tv_sec;
+				stbuf->st_ctim.tv_nsec = obj_mtime.tv_nsec;
+			}
+
+			/** mtime is not like ctime since user can update it manually. So returning
+			 * the larger mtime like ctime would not work since the user can manually
+			 * set the mtime to the past.
+			 */
 			if (obj_mtime.tv_sec == entry_mtime.tv_sec &&
 			    obj_mtime.tv_nsec == entry_mtime.tv_nsec) {
 				/*
@@ -861,13 +875,16 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 				stbuf->st_mtim.tv_nsec = obj_mtime.tv_nsec;
 			}
 		} else {
+			/** the file has not been touched, so the entry times are accurate */
+			stbuf->st_ctim.tv_sec = entry.ctime;
+			stbuf->st_ctim.tv_nsec = entry.ctime_nano;
 			stbuf->st_mtim.tv_sec = entry.mtime;
 			stbuf->st_mtim.tv_nsec = entry.mtime_nano;
 		}
 
 		/*
-		 * TODO - this is not accurate since it does not account for
-		 * sparse files or file metadata or xattributes.
+		 * TODO - this is not accurate since it does not account for sparse files or file
+		 * metadata or xattributes.
 		 */
 		stbuf->st_blocks = (size + (1 << 9) - 1) >> 9;
 		break;
@@ -877,6 +894,8 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 		D_FREE(entry.value);
 		stbuf->st_mtim.tv_sec = entry.mtime;
 		stbuf->st_mtim.tv_nsec = entry.mtime_nano;
+		stbuf->st_ctim.tv_sec = entry.ctime;
+		stbuf->st_ctim.tv_nsec = entry.ctime_nano;
 		break;
 	default:
 		D_ERROR("Invalid entry type (not a dir, file, symlink).\n");
@@ -888,8 +907,6 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 	stbuf->st_mode = entry.mode;
 	stbuf->st_uid = entry.uid;
 	stbuf->st_gid = entry.gid;
-	stbuf->st_ctim.tv_sec = entry.ctime;
-	stbuf->st_ctim.tv_nsec = entry.ctime_nano;
 	if (dfs->layout_v > 2) {
 		if (tspec_gt(stbuf->st_ctim, stbuf->st_mtim)) {
 			stbuf->st_atim.tv_sec = entry.ctime;
@@ -4592,14 +4609,15 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 	bool			exists;
 	struct dfs_entry	entry = {0};
 	d_sg_list_t		sgl;
-	d_iov_t			sg_iov;
+	d_iov_t			sg_iovs[3];
 	daos_iod_t		iod;
-	daos_recx_t		recx;
+	daos_recx_t		recxs[3];
 	daos_key_t		dkey;
 	size_t			len;
 	dfs_obj_t		*sym;
 	mode_t			orig_mode;
 	const char		*entry_name;
+	struct timespec		now;
 	int			rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -4652,8 +4670,7 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 			return rc;
 		}
 
-		rc = daos_obj_open(dfs->coh, sym->parent_oid, DAOS_OO_RW,
-				   &oh, NULL);
+		rc = daos_obj_open(dfs->coh, sym->parent_oid, DAOS_OO_RW, &oh, NULL);
 		D_FREE(entry.value);
 		if (rc) {
 			dfs_release(sym);
@@ -4679,21 +4696,30 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 	/** set dkey as the entry name */
 	d_iov_set(&dkey, (void *)entry_name, len);
 	d_iov_set(&iod.iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
-	iod.iod_nr	= 1;
-	recx.rx_idx	= MODE_IDX;
-	recx.rx_nr	= sizeof(mode_t);
-	iod.iod_recxs	= &recx;
+	iod.iod_recxs	= recxs;
 	iod.iod_type	= DAOS_IOD_ARRAY;
 	iod.iod_size	= 1;
+	iod.iod_nr	= 3;
+	recxs[0].rx_idx	= MODE_IDX;
+	recxs[0].rx_nr	= sizeof(mode_t);
+	recxs[1].rx_idx	= CTIME_IDX;
+	recxs[1].rx_nr	= sizeof(uint64_t);
+	recxs[2].rx_idx	= CTIME_NSEC_IDX;
+	recxs[2].rx_nr	= sizeof(uint64_t);
+
+	rc = clock_gettime(CLOCK_REALTIME, &now);
+	if (rc)
+		D_GOTO(out, rc = errno);
 
 	/** set sgl for update */
-	d_iov_set(&sg_iov, &mode, sizeof(mode_t));
-	sgl.sg_nr	= 1;
+	sgl.sg_nr	= 3;
 	sgl.sg_nr_out	= 0;
-	sgl.sg_iovs	= &sg_iov;
+	sgl.sg_iovs	= &sg_iovs[0];
+	d_iov_set(&sg_iovs[0], &mode, sizeof(mode_t));
+	d_iov_set(&sg_iovs[1], &now.tv_sec, sizeof(uint64_t));
+	d_iov_set(&sg_iovs[2], &now.tv_nsec, sizeof(uint64_t));
 
-	rc = daos_obj_update(oh, th, DAOS_COND_DKEY_UPDATE, &dkey, 1, &iod,
-			     &sgl, NULL);
+	rc = daos_obj_update(oh, th, DAOS_COND_DKEY_UPDATE, &dkey, 1, &iod, &sgl, NULL);
 	if (rc) {
 		D_ERROR("Failed to update mode, "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc = daos_der2errno(rc));
@@ -4716,13 +4742,14 @@ dfs_chown(dfs_t *dfs, dfs_obj_t *parent, const char *name, uid_t uid, gid_t gid,
 	struct dfs_entry	entry = {0};
 	daos_key_t		dkey;
 	d_sg_list_t		sgl;
-	d_iov_t			sg_iovs[2];
+	d_iov_t			sg_iovs[4];
 	daos_iod_t		iod;
-	daos_recx_t		recx[2];
+	daos_recx_t		recxs[4];
 	size_t			len;
 	dfs_obj_t		*sym;
 	const char		*entry_name;
 	int			i;
+	struct timespec		now;
 	int			rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -4790,18 +4817,32 @@ dfs_chown(dfs_t *dfs, dfs_obj_t *parent, const char *name, uid_t uid, gid_t gid,
 		entry_name = name;
 	}
 
+	rc = clock_gettime(CLOCK_REALTIME, &now);
+	if (rc)
+		D_GOTO(out, rc = errno);
+
 	i = 0;
+	recxs[i].rx_idx	= CTIME_IDX;
+	recxs[i].rx_nr	= sizeof(uint64_t);
+	d_iov_set(&sg_iovs[i], &now.tv_sec, sizeof(uint64_t));
+	i++;
+
+	recxs[i].rx_idx	= CTIME_NSEC_IDX;
+	recxs[i].rx_nr	= sizeof(uint64_t);
+	d_iov_set(&sg_iovs[i], &now.tv_nsec, sizeof(uint64_t));
+	i++;
+
 	/** not enforcing any restriction on chown more than write access to the container */
 	if (uid != -1) {
 		d_iov_set(&sg_iovs[i], &uid, sizeof(uid_t));
-		recx[i].rx_idx	= UID_IDX;
-		recx[i].rx_nr	= sizeof(uid_t);
+		recxs[i].rx_idx	= UID_IDX;
+		recxs[i].rx_nr	= sizeof(uid_t);
 		i++;
 	}
 	if (gid != -1) {
 		d_iov_set(&sg_iovs[i], &gid, sizeof(gid_t));
-		recx[i].rx_idx	= GID_IDX;
-		recx[i].rx_nr	= sizeof(gid_t);
+		recxs[i].rx_idx	= GID_IDX;
+		recxs[i].rx_nr	= sizeof(gid_t);
 		i++;
 	}
 
@@ -4809,7 +4850,7 @@ dfs_chown(dfs_t *dfs, dfs_obj_t *parent, const char *name, uid_t uid, gid_t gid,
 	d_iov_set(&dkey, (void *)entry_name, len);
 	d_iov_set(&iod.iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
 	iod.iod_nr	= i;
-	iod.iod_recxs	= recx;
+	iod.iod_recxs	= recxs;
 	iod.iod_type	= DAOS_IOD_ARRAY;
 	iod.iod_size	= 1;
 
@@ -4839,11 +4880,12 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	daos_key_t		dkey;
 	daos_handle_t		oh;
 	d_sg_list_t		sgl;
-	d_iov_t			sg_iovs[8];
+	d_iov_t			sg_iovs[10];
 	daos_iod_t		iod;
-	daos_recx_t		recx[8];
+	daos_recx_t		recxs[10];
 	bool			set_size = false;
 	bool			set_mtime = false;
+	bool			set_ctime = false;
 	int			i = 0;
 	size_t			len;
 	int			rc;
@@ -4891,15 +4933,39 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	/** set dkey as the entry name */
 	d_iov_set(&dkey, (void *)obj->name, len);
 	d_iov_set(&iod.iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
-	iod.iod_recxs	= recx;
+	iod.iod_recxs	= recxs;
 	iod.iod_type	= DAOS_IOD_ARRAY;
 	iod.iod_size	= 1;
 
+	/** need to update ctime */
+	if (flags & DFS_SET_ATTR_MODE || flags & DFS_SET_ATTR_MTIME ||
+	    flags & DFS_SET_ATTR_UID || flags & DFS_SET_ATTR_GID) {
+		struct timespec	now;
+
+		rc = clock_gettime(CLOCK_REALTIME, &now);
+		if (rc)
+			D_GOTO(out_obj, rc = errno);
+		rstat.st_ctim.tv_sec = now.tv_sec;
+		rstat.st_ctim.tv_nsec = now.tv_nsec;
+		set_ctime = true;
+
+		d_iov_set(&sg_iovs[i], &rstat.st_ctim.tv_sec, sizeof(uint64_t));
+		recxs[i].rx_idx = CTIME_IDX;
+		recxs[i].rx_nr = sizeof(uint64_t);
+		i++;
+
+		d_iov_set(&sg_iovs[i], &rstat.st_ctim.tv_nsec, sizeof(uint64_t));
+		recxs[i].rx_idx = CTIME_NSEC_IDX;
+		recxs[i].rx_nr = sizeof(uint64_t);
+		i++;
+	}
+
 	if (flags & DFS_SET_ATTR_MODE) {
 		d_iov_set(&sg_iovs[i], &stbuf->st_mode, sizeof(mode_t));
-		recx[i].rx_idx = MODE_IDX;
-		recx[i].rx_nr = sizeof(mode_t);
+		recxs[i].rx_idx = MODE_IDX;
+		recxs[i].rx_nr = sizeof(mode_t);
 		i++;
+
 		flags &= ~DFS_SET_ATTR_MODE;
 		rstat.st_mode = stbuf->st_mode;
 	}
@@ -4909,18 +4975,18 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	}
 	if (flags & DFS_SET_ATTR_MTIME) {
 		d_iov_set(&sg_iovs[i], &stbuf->st_mtim.tv_sec, sizeof(uint64_t));
-		recx[i].rx_idx = MTIME_IDX;
-		recx[i].rx_nr = sizeof(uint64_t);
+		recxs[i].rx_idx = MTIME_IDX;
+		recxs[i].rx_nr = sizeof(uint64_t);
 		i++;
 
 		d_iov_set(&sg_iovs[i], &stbuf->st_mtim.tv_nsec, sizeof(uint64_t));
-		recx[i].rx_idx = MTIME_NSEC_IDX;
-		recx[i].rx_nr = sizeof(uint64_t);
+		recxs[i].rx_idx = MTIME_NSEC_IDX;
+		recxs[i].rx_nr = sizeof(uint64_t);
 		i++;
 
 		d_iov_set(&sg_iovs[i], &obj_hlc, sizeof(uint64_t));
-		recx[i].rx_idx = HLC_IDX;
-		recx[i].rx_nr = sizeof(uint64_t);
+		recxs[i].rx_idx = HLC_IDX;
+		recxs[i].rx_nr = sizeof(uint64_t);
 		i++;
 
 		set_mtime = true;
@@ -4930,26 +4996,22 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	}
 	if (flags & DFS_SET_ATTR_UID) {
 		d_iov_set(&sg_iovs[i], &stbuf->st_uid, sizeof(uid_t));
-		recx[i].rx_idx = UID_IDX;
-		recx[i].rx_nr = sizeof(uid_t);
+		recxs[i].rx_idx = UID_IDX;
+		recxs[i].rx_nr = sizeof(uid_t);
 		i++;
 		flags &= ~DFS_SET_ATTR_UID;
-		rstat.st_mtim.tv_sec = stbuf->st_mtim.tv_sec;
-		rstat.st_mtim.tv_nsec = stbuf->st_mtim.tv_nsec;
 	}
 	if (flags & DFS_SET_ATTR_GID) {
 		d_iov_set(&sg_iovs[i], &stbuf->st_gid, sizeof(gid_t));
-		recx[i].rx_idx = GID_IDX;
-		recx[i].rx_nr = sizeof(gid_t);
+		recxs[i].rx_idx = GID_IDX;
+		recxs[i].rx_nr = sizeof(gid_t);
 		i++;
 		flags &= ~DFS_SET_ATTR_GID;
-		rstat.st_mtim.tv_sec = stbuf->st_mtim.tv_sec;
-		rstat.st_mtim.tv_nsec = stbuf->st_mtim.tv_nsec;
 	}
 	if (flags & DFS_SET_ATTR_SIZE) {
-		/* It shouldn't be possible to set the size of something which
-		 * isn't a file but check here anyway, as entries which aren't
-		 * files won't have array objects so check and return error here
+		/* It shouldn't be possible to set the size of something which isn't a file but
+		 * check here anyway, as entries which aren't files won't have array objects so
+		 * check and return error here
 		 */
 		if (!S_ISREG(obj->mode)) {
 			D_ERROR("Cannot set_size on a non file object\n");
@@ -4972,8 +5034,8 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		rstat.st_blocks = (stbuf->st_size + (1 << 9) - 1) >> 9;
 		rstat.st_size = stbuf->st_size;
 
-		/* mtime needs to be updated too only if mtime was not explicitly set */
-		if (!set_mtime) {
+		/* mtime and ctime need to be updated too only if not set earlier */
+		if (!set_mtime || !set_ctime) {
 			daos_array_stbuf_t	array_stbuf = {0};
 
 			/** TODO - need an array API to just stat the max epoch without size */
@@ -4981,10 +5043,20 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 			if (rc)
 				D_GOTO(out_obj, rc = daos_der2errno(rc));
 
-			rc = crt_hlc2timespec(array_stbuf.st_max_epoch, &rstat.st_mtim);
-			if (rc) {
-				D_ERROR("crt_hlc2timespec() failed "DF_RC"\n", DP_RC(rc));
-				D_GOTO(out_obj, rc = daos_der2errno(rc));
+			if (!set_mtime) {
+				rc = crt_hlc2timespec(array_stbuf.st_max_epoch, &rstat.st_mtim);
+				if (rc) {
+					D_ERROR("crt_hlc2timespec() failed "DF_RC"\n", DP_RC(rc));
+					D_GOTO(out_obj, rc = daos_der2errno(rc));
+				}
+			}
+
+			if (!set_ctime) {
+				rc = crt_hlc2timespec(array_stbuf.st_max_epoch, &rstat.st_ctim);
+				if (rc) {
+					D_ERROR("crt_hlc2timespec() failed "DF_RC"\n", DP_RC(rc));
+					D_GOTO(out_obj, rc = daos_der2errno(rc));
+				}
 			}
 		}
 	}
@@ -5577,12 +5649,14 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 {
 	char		*xname = NULL;
 	daos_handle_t	th = DAOS_TX_NONE;
-	d_sg_list_t	sgl;
-	d_iov_t		sg_iov;
-	daos_iod_t	iod;
+	d_sg_list_t	sgls[2];
+	d_iov_t		sg_iovs[3];
+	daos_iod_t	iods[2];
+	daos_recx_t	recxs[2];
 	daos_key_t	dkey;
 	daos_handle_t	oh;
 	uint64_t	cond = 0;
+	struct timespec	now;
 	int		rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -5611,11 +5685,35 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 	/** set dkey as the entry name */
 	d_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
 
-	/** set akey as the xattr name */
-	d_iov_set(&iod.iod_name, xname, strlen(xname));
-	iod.iod_nr	= 1;
-	iod.iod_recxs	= NULL;
-	iod.iod_type	= DAOS_IOD_SINGLE;
+	/** add xattr iod & sgl */
+	d_iov_set(&iods[0].iod_name, xname, strlen(xname));
+	iods[0].iod_nr	= 1;
+	iods[0].iod_recxs	= NULL;
+	iods[0].iod_type	= DAOS_IOD_SINGLE;
+	iods[0].iod_size	= size;
+	d_iov_set(&sg_iovs[0], (void *)value, size);
+	sgls[0].sg_nr		= 1;
+	sgls[0].sg_nr_out	= 0;
+	sgls[0].sg_iovs		= &sg_iovs[0];
+
+	/** add ctime iod & sgl */
+	d_iov_set(&iods[1].iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
+	iods[1].iod_recxs	= recxs;
+	iods[1].iod_type	= DAOS_IOD_ARRAY;
+	iods[1].iod_size	= 1;
+	iods[1].iod_nr		= 2;
+	recxs[0].rx_idx		= CTIME_IDX;
+	recxs[0].rx_nr		= sizeof(uint64_t);
+	recxs[1].rx_idx		= CTIME_NSEC_IDX;
+	recxs[1].rx_nr		= sizeof(uint64_t);
+	rc = clock_gettime(CLOCK_REALTIME, &now);
+	if (rc)
+		D_GOTO(out, rc = errno);
+	sgls[1].sg_nr		= 2;
+	sgls[1].sg_nr_out	= 0;
+	sgls[1].sg_iovs		= &sg_iovs[1];
+	d_iov_set(&sg_iovs[1], &now.tv_sec, sizeof(uint64_t));
+	d_iov_set(&sg_iovs[2], &now.tv_nsec, sizeof(uint64_t));
 
 	/** if not default flag, check for xattr existence */
 	if (flags != 0) {
@@ -5624,19 +5722,30 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 		if (flags == XATTR_REPLACE)
 			cond |= DAOS_COND_AKEY_UPDATE;
 	}
-
-	/** set sgl for update */
-	d_iov_set(&sg_iov, (void *)value, size);
-	sgl.sg_nr	= 1;
-	sgl.sg_nr_out	= 0;
-	sgl.sg_iovs	= &sg_iov;
-
 	cond |= DAOS_COND_DKEY_UPDATE;
-	iod.iod_size	= size;
-	rc = daos_obj_update(oh, th, cond, &dkey, 1, &iod, &sgl, NULL);
-	if (rc) {
-		D_ERROR("Failed to add extended attribute %s\n", name);
-		D_GOTO(out, rc = daos_der2errno(rc));
+
+	/** update ctime in a separate update if DAOS_COND_AKEY_INSERT is used for the xattr */
+	if (cond & DAOS_COND_AKEY_INSERT) {
+		/** insert the xattr */
+		rc = daos_obj_update(oh, th, cond, &dkey, 1, &iods[0], &sgls[0], NULL);
+		if (rc) {
+			D_ERROR("Failed to insert extended attribute %s\n", name);
+			D_GOTO(out, rc = daos_der2errno(rc));
+		}
+		/** update the ctime */
+		rc = daos_obj_update(oh, th, DAOS_COND_DKEY_UPDATE, &dkey, 1, &iods[1], &sgls[1],
+				     NULL);
+		if (rc) {
+			D_ERROR("Failed to update ctime %s\n", name);
+			D_GOTO(out, rc = daos_der2errno(rc));
+		}
+	} else {
+		/** replace the xattr and update the ctime */
+		rc = daos_obj_update(oh, th, cond, &dkey, 2, iods, sgls, NULL);
+		if (rc) {
+			D_ERROR("Failed to insert extended attribute %s\n", name);
+			D_GOTO(out, rc = daos_der2errno(rc));
+		}
 	}
 
 out:
@@ -5728,6 +5837,11 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name)
 	daos_key_t	dkey, akey;
 	daos_handle_t	oh;
 	uint64_t	cond = 0;
+	d_sg_list_t	sgl;
+	d_iov_t		sg_iovs[2];
+	daos_iod_t	iod;
+	daos_recx_t	recxs[2];
+	struct timespec	now;
 	int		rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -5760,6 +5874,31 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name)
 	if (rc) {
 		D_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR,
 			 "Failed to punch extended attribute '%s'\n", name);
+		D_GOTO(out, rc = daos_der2errno(rc));
+	}
+
+	/** update ctime */
+	d_iov_set(&iod.iod_name, INODE_AKEY_NAME, sizeof(INODE_AKEY_NAME) - 1);
+	iod.iod_recxs	= recxs;
+	iod.iod_type	= DAOS_IOD_ARRAY;
+	iod.iod_size	= 1;
+	iod.iod_nr	= 2;
+	recxs[0].rx_idx	= CTIME_IDX;
+	recxs[0].rx_nr	= sizeof(uint64_t);
+	recxs[1].rx_idx	= CTIME_NSEC_IDX;
+	recxs[1].rx_nr	= sizeof(uint64_t);
+	rc = clock_gettime(CLOCK_REALTIME, &now);
+	if (rc)
+		D_GOTO(out, rc = errno);
+	sgl.sg_nr	= 2;
+	sgl.sg_nr_out	= 0;
+	sgl.sg_iovs	= &sg_iovs[0];
+	d_iov_set(&sg_iovs[0], &now.tv_sec, sizeof(uint64_t));
+	d_iov_set(&sg_iovs[1], &now.tv_nsec, sizeof(uint64_t));
+
+	rc = daos_obj_update(oh, th, DAOS_COND_DKEY_UPDATE, &dkey, 1, &iod, &sgl, NULL);
+	if (rc) {
+		D_ERROR("Failed to update mode, "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -14,6 +14,15 @@ static uuid_t		co_uuid;
 static daos_handle_t	co_hdl;
 static dfs_t		*dfs_mt;
 
+static bool
+check_ts(struct timespec l, struct timespec r)
+{
+	if (l.tv_sec == r.tv_sec)
+		return l.tv_nsec < r.tv_nsec;
+	else
+		return l.tv_sec < r.tv_sec;
+}
+
 static void
 dfs_test_mount(void **state)
 {
@@ -1000,6 +1009,7 @@ dfs_test_rename(void **state)
 	d_iov_t			iov;
 	char			buf[64];
 	struct stat		stbuf;
+	struct timespec		prev_ts;
 	int			rc;
 
 	if (arg->myrank != 0)
@@ -1027,6 +1037,8 @@ dfs_test_rename(void **state)
 
 	rc = dfs_stat(dfs_mt, NULL, f1, &stbuf);
 	assert_int_equal(rc, 0);
+	prev_ts.tv_sec = stbuf.st_ctim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_ctim.tv_nsec;
 	rc = dfs_stat(dfs_mt, NULL, f2, &stbuf);
 	assert_int_equal(rc, 0);
 
@@ -1037,6 +1049,8 @@ dfs_test_rename(void **state)
 
 	rc = dfs_stat(dfs_mt, NULL, f1, &stbuf);
 	assert_int_equal(rc, 0);
+	/** check ctime updated */
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 	rc = dfs_stat(dfs_mt, NULL, f2, &stbuf);
 	assert_int_equal(rc, 0);
 
@@ -1217,6 +1231,7 @@ dfs_test_chown(void **state)
 	char		*filename_file2 = "open_stat2";
 	mode_t		create_mode = S_IWUSR | S_IRUSR;
 	int		create_flags = O_RDWR | O_CREAT | O_EXCL;
+	struct timespec	prev_ts;
 
 	if (arg->myrank != 0)
 		return;
@@ -1234,6 +1249,8 @@ dfs_test_chown(void **state)
 
 	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
 	assert_int_equal(rc, 0);
+	prev_ts.tv_sec = stbuf.st_mtim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 
 	orig_uid = stbuf.st_uid;
 	orig_gid = stbuf.st_gid;
@@ -1245,6 +1262,9 @@ dfs_test_chown(void **state)
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, orig_uid);
 	assert_int_equal(stbuf.st_gid, orig_gid);
+	/** check ctime unchanged */
+	assert_int_equal(prev_ts.tv_sec, stbuf.st_ctim.tv_sec);
+	assert_int_equal(prev_ts.tv_nsec, stbuf.st_ctim.tv_nsec);
 
 	/** set uid to 0 */
 	rc = dfs_chown(dfs_mt, NULL, filename, 0, -1, 0);
@@ -1253,6 +1273,9 @@ dfs_test_chown(void **state)
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 0);
 	assert_int_equal(stbuf.st_gid, orig_gid);
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
+	prev_ts.tv_sec = stbuf.st_ctim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_ctim.tv_nsec;
 
 	/** set gid to 0 */
 	rc = dfs_chown(dfs_mt, NULL, filename, -1, 0, 0);
@@ -1261,17 +1284,25 @@ dfs_test_chown(void **state)
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 0);
 	assert_int_equal(stbuf.st_gid, 0);
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
+	prev_ts.tv_sec = stbuf.st_ctim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_ctim.tv_nsec;
 
 	/** set uid to 3, gid to 4 - using dfs_osetattr */
+	memset(&stbuf, 0, sizeof(stbuf));
 	stbuf.st_uid = 3;
 	stbuf.st_gid = 4;
 	rc = dfs_osetattr(dfs_mt, obj, &stbuf, DFS_SET_ATTR_UID | DFS_SET_ATTR_GID);
 	assert_int_equal(rc, 0);
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 	memset(&stbuf, 0, sizeof(stbuf));
 	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 3);
 	assert_int_equal(stbuf.st_gid, 4);
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
+	prev_ts.tv_sec = stbuf.st_ctim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_ctim.tv_nsec;
 
 	/** set uid to 1, gid to 2 */
 	rc = dfs_chown(dfs_mt, NULL, filename, 1, 2, 0);
@@ -1280,6 +1311,9 @@ dfs_test_chown(void **state)
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 1);
 	assert_int_equal(stbuf.st_gid, 2);
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
+	prev_ts.tv_sec = stbuf.st_ctim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_ctim.tv_nsec;
 
 	/** create a symlink to that file */
 	rc = dfs_open(dfs_mt, NULL, symname, S_IFLNK | S_IWUSR | S_IRUSR,
@@ -1346,15 +1380,6 @@ dfs_test_chown(void **state)
 	assert_int_equal(stbuf.st_gid, stbuf2.st_gid);
 }
 
-static bool
-check_ts(struct timespec l, struct timespec r)
-{
-	if (l.tv_sec == r.tv_sec)
-		return l.tv_nsec < r.tv_nsec;
-	else
-		return l.tv_sec < r.tv_sec;
-}
-
 static void
 dfs_test_mtime(void **state)
 {
@@ -1399,6 +1424,7 @@ dfs_test_mtime(void **state)
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_size, 64);
 	assert_true(check_ts(prev_ts, stbuf.st_mtim));
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 	prev_ts.tv_sec = stbuf.st_mtim.tv_sec;
 	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 
@@ -1418,6 +1444,7 @@ dfs_test_mtime(void **state)
 	stbuf.st_mtim.tv_nsec = first_ts.tv_nsec;
 	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_MTIME);
 	assert_int_equal(rc, 0);
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 
 	/** verify mtime is now the same as the one we just set */
 	memset(&stbuf, 0, sizeof(stbuf));
@@ -1425,6 +1452,7 @@ dfs_test_mtime(void **state)
 	assert_int_equal(rc, 0);
 	assert_int_equal(first_ts.tv_sec, stbuf.st_mtim.tv_sec);
 	assert_int_equal(first_ts.tv_nsec, stbuf.st_mtim.tv_nsec);
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 
 	/** truncate the file */
 	rc = dfs_punch(dfs_mt, file, 0, DFS_MAX_FSIZE);
@@ -1434,6 +1462,7 @@ dfs_test_mtime(void **state)
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_size, 0);
 	assert_true(check_ts(prev_ts, stbuf.st_mtim));
+	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 	prev_ts.tv_sec = stbuf.st_mtim.tv_sec;
 	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 


### PR DESCRIPTION
DFS inode stores ctime, but it’s not properly updated when doing any
metadata updates. This adds proper ctime support when object metadata
is updated.

Required-githooks: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>