### PR TITLE
DAOS-11146 client: improve multiple threads performance

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -495,12 +495,6 @@ dc_cont_hdl_link(struct dc_cont *dc)
 }
 
 void
-dc_cont_hdl_unlink(struct dc_cont *dc)
-{
-	daos_hhash_link_delete(&dc->dc_hlink);
-}
-
-void
 dc_cont_free(struct dc_cont *dc)
 {
 	D_ASSERT(daos_hhash_link_empty(&dc->dc_hlink));

--- a/src/container/cli_internal.h
+++ b/src/container/cli_internal.h
@@ -34,16 +34,39 @@ struct dc_cont {
 				dc_slave:1; /* generated via g2l */
 };
 
+/* Per thread handle cache */
+#define DC_CONT_CACHE_NR		4
+static __thread struct dc_cont *dc_cont_local[DC_CONT_CACHE_NR];
+static __thread uint64_t	dc_cont_cookie[DC_CONT_CACHE_NR];
+
 static inline struct dc_cont *
 dc_hdl2cont(daos_handle_t coh)
 {
 	struct d_hlink *hlink;
+	struct dc_cont *dc_cont;
+	int i;
+	int insert_i = 0;
+
+	for (i = 0; i < DC_CONT_CACHE_NR; i++) {
+		if (dc_cont_cookie[i] && coh.cookie == dc_cont_cookie[i]) {
+			daos_hhash_link_getref(&dc_cont_local[i]->dc_hlink);
+
+			return dc_cont_local[i];
+		}
+		if (dc_cont_cookie[i] == 0)
+			insert_i = i;
+	}
 
 	hlink = daos_hhash_link_lookup(coh.cookie);
 	if (hlink == NULL)
 		return NULL;
 
-	return container_of(hlink, struct dc_cont, dc_hlink);
+	dc_cont = container_of(hlink, struct dc_cont, dc_hlink);
+	/* if there is no free slot, we replace first one to cache now*/
+	dc_cont_local[insert_i] = dc_cont;
+	dc_cont_cookie[insert_i] = coh.cookie;
+
+	return dc_cont;
 }
 
 static inline void
@@ -53,8 +76,22 @@ dc_cont2hdl(struct dc_cont *dc, daos_handle_t *hdl)
 	daos_hhash_link_key(&dc->dc_hlink, &hdl->cookie);
 }
 
+void
+dc_cont_hdl_unlink(struct dc_cont *dc)
+{
+	int i;
+
+	daos_hhash_link_delete(&dc->dc_hlink);
+	for (i = 0; i < DC_CONT_CACHE_NR; i++) {
+		if (dc == dc_cont_local[i]) {
+			dc_cont_local[i] = NULL;
+			dc_cont_cookie[i] = 0;
+		}
+
+	}
+}
+
 void dc_cont_hdl_link(struct dc_cont *dc);
-void dc_cont_hdl_unlink(struct dc_cont *dc);
 
 struct dc_cont *dc_cont_alloc(const uuid_t uuid);
 void dc_cont_free(struct dc_cont *);

--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -1310,7 +1310,15 @@ d_hhash_link_getref(struct d_hhash *hhash, struct d_hlink *hlink)
 void
 d_hhash_link_putref(struct d_hhash *hhash, struct d_hlink *hlink)
 {
-	ch_rec_decref(&hhash->ch_htable, &hlink->hl_link.rl_link);
+	/**
+	 * handle hash table should not use D_HASH_FT_EPHEMERAL,
+	 * just in case someone add it.
+	 */
+	if (hhash->ch_htable.ht_feats & D_HASH_FT_EPHEMERAL)
+		d_hash_rec_decref(&hhash->ch_htable, &hlink->hl_link.rl_link);
+	else
+		if (ch_rec_decref(&hhash->ch_htable, &hlink->hl_link.rl_link))
+			ch_rec_free(&hhash->ch_htable, &hlink->hl_link.rl_link);
 }
 
 bool

--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -1304,13 +1304,13 @@ d_hhash_link_delete(struct d_hhash *hhash, struct d_hlink *hlink)
 void
 d_hhash_link_getref(struct d_hhash *hhash, struct d_hlink *hlink)
 {
-	d_hash_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
+	ch_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 }
 
 void
 d_hhash_link_putref(struct d_hhash *hhash, struct d_hlink *hlink)
 {
-	d_hash_rec_decref(&hhash->ch_htable, &hlink->hl_link.rl_link);
+	ch_rec_decref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 }
 
 bool


### PR DESCRIPTION
Two main improvements:

1. hop_rec_{addref,decref} has used ATOMIC for handle hash table
operation, there is no need to hold lock for ref operation, 32 thread
4k randwrite iops improved from 119k to 199k iops.

2. Introduce per thread pool/cont handle cache, this will avoid
read lock for most of cases(as there are scalability of pthread read lock).
performance improved from 199k to 720k iops.

Signed-off-by: Wang Shilong <shilong.wang@intel.com>