### PR TITLE
DAOS-9601 chk: container cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,7 +341,6 @@ pipeline {
                         checkPatch user: GITHUB_USER_USR,
                                    password: GITHUB_USER_PSW,
                                    ignored_files: 'src/control/vendor/*:' +
-                                                  'src/chk/chk_internal.h:' +
                                                   '*.pb-c.[ch]:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:' +

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -4205,3 +4205,85 @@ out_put:
 	cont_svc_put_leader(svc);
 	return rc;
 }
+
+/*
+ * Check whether the specified container exists in the container service or not.
+ * If yes, return the container label via the @prop.
+ */
+int
+ds_cont_existence_check(struct cont_svc *svc, uuid_t uuid, daos_prop_t **prop)
+{
+	struct cont	*cont = NULL;
+	daos_prop_t	*tmp = NULL;
+	struct rdb_tx	 tx;
+	int		 rc;
+
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0)
+		goto out;
+
+	ABT_rwlock_rdlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, uuid, &cont);
+	if (rc != 0)
+		goto out_tx;
+
+	rc = cont_prop_read(&tx, cont, DAOS_CO_QUERY_PROP_LABEL, &tmp, true);
+	if (rc != 0)
+		D_GOTO(out_cont, rc = (rc == -DER_NONEXIST ? 0 : rc));
+
+	if (strncmp(DAOS_PROP_NO_CO_LABEL, tmp->dpp_entries[0].dpe_str,
+		    DAOS_PROP_LABEL_MAX_LEN) == 0) {
+		daos_prop_free(tmp);
+		goto out_cont;
+	}
+
+	*prop = tmp;
+
+out_cont:
+	cont_put(cont);
+out_tx:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+out:
+	return rc;
+}
+
+/*
+ * Destroy the orphan container that is not registered
+ * to the container service (then without open handle).
+ */
+int
+ds_cont_destroy_orphan(struct cont_svc *svc, uuid_t uuid)
+{
+	struct rdb_tx	tx;
+	d_iov_t		key;
+	d_iov_t		tmp;
+	int		rc;
+
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0)
+		goto out;
+
+	ABT_rwlock_rdlock(svc->cs_lock);
+	d_iov_set(&key, uuid, sizeof(uuid_t));
+	d_iov_set(&tmp, NULL, 0);
+	rc = rdb_tx_lookup(&tx, &svc->cs_conts, &key, &tmp);
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+	if (rc == 0)
+		/* Forbid to destroy non-orphan container. */
+		D_GOTO(out, rc = -DER_BUSY);
+
+	rc = cont_destroy_bcast(dss_get_module_info()->dmi_ctx, svc, uuid);
+	if (rc != 0)
+		goto out;
+
+	cont_ec_agg_delete(svc, uuid);
+
+out:
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 DF_CONT" destroy orphan container: "DF_RC"\n",
+		 DP_CONT(svc->cs_pool->sp_uuid, uuid), DP_RC(rc));
+
+	return rc;
+}

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -58,7 +58,7 @@ static struct daos_prop_co_roots dummy_roots;
 struct daos_prop_entry cont_prop_entries_default_v0[CONT_PROP_NUM_V0] = {
 	{
 		.dpe_type	= DAOS_PROP_CO_LABEL,
-		.dpe_str	= "container_label_not_set",
+		.dpe_str	= DAOS_PROP_NO_CO_LABEL,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
 		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,
@@ -124,7 +124,7 @@ struct daos_prop_entry cont_prop_entries_default_v0[CONT_PROP_NUM_V0] = {
 struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 	{
 		.dpe_type	= DAOS_PROP_CO_LABEL,
-		.dpe_str	= "container_label_not_set",
+		.dpe_str	= DAOS_PROP_NO_CO_LABEL,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
 		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -564,6 +564,9 @@ daos_label_is_valid(const char *label)
 /* For the case of no label is set for the pool. */
 #define DAOS_PROP_NO_PO_LABEL		"pool_label_not_set"
 
+/* For the case of no label is set for the container. */
+#define DAOS_PROP_NO_CO_LABEL		"container_label_not_set"
+
 /** daos properties, for pool or container */
 typedef struct {
 	/** number of entries */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -257,4 +257,8 @@ int ds_cont_ec_eph_delete(struct ds_pool *pool, uuid_t cont_uuid, int tgt_idx);
 
 void ds_cont_ec_timestamp_update(struct ds_cont_child *cont);
 
+int ds_cont_existence_check(struct cont_svc *svc, uuid_t uuid, daos_prop_t **prop);
+
+int ds_cont_destroy_orphan(struct cont_svc *svc, uuid_t uuid);
+
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -272,6 +272,7 @@ int ds_pool_svc_flush_map(struct ds_pool_svc *ds_svc, struct pool_map *map);
 int ds_pool_svc_update_label(struct ds_pool_svc *ds_svc, const char *label);
 int ds_pool_svc_evict_all(struct ds_pool_svc *ds_svc);
 struct ds_pool *ds_pool_svc2pool(struct ds_pool_svc *ds_svc);
+struct cont_svc *ds_pool_ps2cs(struct ds_pool_svc *ds_svc);
 void ds_pool_disable_exclude(void);
 void ds_pool_enable_exclude(void);
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7191,3 +7191,9 @@ ds_pool_svc2pool(struct ds_pool_svc *ds_svc)
 {
 	return pool_ds2svc(ds_svc)->ps_pool;
 }
+
+struct cont_svc *
+ds_pool_ps2cs(struct ds_pool_svc *ds_svc)
+{
+	return pool_ds2svc(ds_svc)->ps_cont_svc;
+}

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -68,7 +68,7 @@ pool_glance(uuid_t uuid, char *path, struct ds_pool_clue *clue_out)
 			D_GOTO(out_root, rc = -DER_IO);
 		}
 
-		if (memcmp(DAOS_PROP_NO_PO_LABEL, value.iov_buf, value.iov_len) == 0) {
+		if (strncmp(DAOS_PROP_NO_PO_LABEL, value.iov_buf, DAOS_PROP_LABEL_MAX_LEN) == 0) {
 			clue_out->pc_label_len = 0;
 		} else {
 			D_ALLOC(clue_out->pc_label, value.iov_len + 1);


### PR DESCRIPTION
Destroy the orphan containers that have storage allocated on
the engine but do not exist in container service by default.

Signed-off-by: Fan Yong <fan.yong@intel.com>