### PR TITLE
DAOS-9602 chk: verify container label

### DIFF
--- a/src/chk/chk_upcall.c
+++ b/src/chk/chk_upcall.c
@@ -158,7 +158,7 @@ chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int re
 		report.objid = NULL;
 	}
 
-	if (dkey != NULL && !daos_key_is_null(*dkey)) {
+	if (!daos_iov_empty(dkey)) {
 		D_ASPRINTF(report.dkey, DF_KEY, DP_KEY(dkey));
 		if (report.dkey == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
@@ -166,7 +166,7 @@ chk_report_upcall(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, int re
 		report.dkey = NULL;
 	}
 
-	if (akey != NULL && !daos_key_is_null(*akey)) {
+	if (!daos_iov_empty(akey)) {
 		D_ASPRINTF(report.akey, DF_KEY, DP_KEY(akey));
 		if (report.akey == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -4537,3 +4537,120 @@ out:
 
 	return rc;
 }
+
+int
+ds_cont_iterate_labels(struct cont_svc *svc, rdb_iterate_cb_t cb, void *arg)
+{
+	struct rdb_tx	tx;
+	int		rc;
+
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc == 0) {
+		ABT_rwlock_rdlock(svc->cs_lock);
+		rc = rdb_tx_iterate(&tx, &svc->cs_uuids, false /* !backward */, cb, arg);
+		ABT_rwlock_unlock(svc->cs_lock);
+		rdb_tx_end(&tx);
+	}
+
+	return rc;
+}
+
+int
+ds_cont_set_label(struct cont_svc *svc, uuid_t uuid, daos_prop_t *prop_in, bool for_svc)
+{
+	struct ds_pool		*pool = svc->cs_pool;
+	daos_prop_t		*prop_old = NULL;
+	daos_prop_t		*prop_iv = NULL;
+	struct cont		*cont = NULL;
+	struct daos_prop_entry	*entry;
+	struct rdb_tx		 tx;
+	d_iov_t			 key;
+	d_iov_t			 val;
+	uuid_t			 tmp;
+	int			 rc = 0;
+
+	D_ASSERT(prop_in != NULL);
+
+	if (!daos_prop_valid(prop_in, false, true))
+		D_GOTO(out, rc = -DER_INVAL);
+
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0)
+		goto out;
+
+	ABT_rwlock_wrlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, uuid, &cont);
+	if (rc != 0)
+		goto out_tx;
+
+	if (!for_svc) {
+		/* Read all props for prop IV update */
+		rc = cont_prop_read(&tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop_old, true);
+		if (rc != 0)
+			D_GOTO(out_cont, rc);
+
+		D_ASSERT(prop_old != NULL);
+
+		entry = daos_prop_entry_get(prop_old, DAOS_PROP_CO_LABEL);
+		D_ASSERT(entry != NULL);
+
+		/* If specified label matches existing label, do nothing. */
+		if (strncmp(entry->dpe_str, prop_in->dpp_entries[0].dpe_str,
+			    DAOS_PROP_LABEL_MAX_LEN) == 0)
+			D_GOTO(out_cont, rc = 0);
+
+		prop_iv = daos_prop_merge(prop_old, prop_in);
+		if (prop_iv == NULL)
+			D_GOTO(out_cont, rc = -DER_NOMEM);
+
+		rc = cont_prop_write(&tx, &cont->c_prop, prop_in, false);
+		if (rc != 0)
+			D_GOTO(out_cont, rc);
+
+		/* Update prop IV with merged prop */
+		rc = cont_iv_prop_update(pool->sp_iv_ns, uuid, prop_iv);
+		if (rc != 0) {
+			D_ERROR(DF_UUIDF" failed to update prop IV for cont: "DF_RC"\n",
+				DP_UUID(uuid), DP_RC(rc));
+			goto out_cont;
+		}
+	} else {
+		d_iov_set(&key, prop_in->dpp_entries[0].dpe_str,
+			  strnlen(prop_in->dpp_entries[0].dpe_str, DAOS_PROP_MAX_LABEL_BUF_LEN));
+		d_iov_set(&val, tmp, sizeof(uuid_t));
+		rc = rdb_tx_lookup(&tx, &cont->c_svc->cs_uuids, &key, &val);
+		if (rc == 0) {
+			/* If specified label matches existing label in svc, do nothing. */
+			if (uuid_compare(uuid, tmp) == 0)
+				D_GOTO(out_cont, rc = 0);
+
+			D_ERROR("Forbid non-unique label (%s) for different containers: "
+				DF_UUIDF"/"DF_UUIDF"\n", prop_in->dpp_entries[0].dpe_str,
+				DP_UUID(uuid), DP_UUID(tmp));
+			D_GOTO(out_cont, rc = -DER_EXIST);
+		} else if (rc == -DER_NONEXIST) {
+			d_iov_set(&val, uuid, sizeof(uuid_t));
+			rc = rdb_tx_update(&tx, &cont->c_svc->cs_uuids, &key, &val);
+			if (rc != 0) {
+				D_ERROR(DF_UUIDF" failed to set container label %s: "DF_RC"\n",
+					DP_UUID(uuid), prop_in->dpp_entries[0].dpe_str, DP_RC(rc));
+				goto out_cont;
+			}
+		} else {
+			D_ERROR(DF_UUIDF" failed to lookup container label %s in svc: "DF_RC"\n",
+				DP_UUID(uuid), prop_in->dpp_entries[0].dpe_str, DP_RC(rc));
+			goto out_cont;
+		}
+	}
+
+out_cont:
+	cont_put(cont);
+out_tx:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+out:
+	daos_prop_free(prop_iv);
+	daos_prop_free(prop_old);
+
+	return rc;
+}

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -443,6 +443,13 @@ int daos_sgl_processor(d_sg_list_t *sgl, bool check_buf,
 		       daos_sgl_process_cb process_cb, void *cb_args);
 
 char *daos_str_trimwhite(char *str);
+
+static inline bool
+daos_iov_empty(d_iov_t *iov)
+{
+	return iov == NULL || iov->iov_buf == NULL || iov->iov_len == 0;
+}
+
 int daos_iov_copy(d_iov_t *dst, d_iov_t *src);
 int daos_iov_alloc(d_iov_t *iov, daos_size_t size, bool set_full);
 void daos_iov_free(d_iov_t *iov);

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -261,4 +261,8 @@ int ds_cont_existence_check(struct cont_svc *svc, uuid_t uuid, daos_prop_t **pro
 
 int ds_cont_destroy_orphan(struct cont_svc *svc, uuid_t uuid);
 
+int ds_cont_iterate_labels(struct cont_svc *svc, rdb_iterate_cb_t cb, void *arg);
+
+int ds_cont_set_label(struct cont_svc *svc, uuid_t uuid, daos_prop_t *prop_in, bool for_svc);
+
 #endif /* ___DAOS_SRV_CONTAINER_H_ */


### PR DESCRIPTION
If the container label in the container service (cont_svc::cs_uuids)
exists but does not match the label in the container property, then
trust the container service and reset the one in container property.

Otherwise, if the container label in the container service does not
exists, but the one in the container property is there, then trust
the label in the container property and add it to container service.

Signed-off-by: Fan Yong <fan.yong@intel.com>