### PR TITLE
DAOS-11476 test: Fix coverity unchecked return in jobtest

### DIFF
--- a/src/tests/jobtest.c
+++ b/src/tests/jobtest.c
@@ -57,14 +57,20 @@ void cleanup_handles(char **pool_ids, int num_pools,
 				if (rc) {
 					uuid_t		cont;
 					uuid_t		hdl;
-					char		cont_str[DAOS_UUID_STR_SIZE];
-					char		hdl_str[DAOS_UUID_STR_SIZE];
 
-					dc_cont_hdl2uuid(cont_handles[i][j], &hdl, &cont);
-					uuid_unparse_lower(cont, cont_str);
-					uuid_unparse_lower(hdl, hdl_str);
-					printf("disconnect handle %s from container %s "
-						"failed: %d\n", hdl_str, cont_str, rc);
+					if (dc_cont_hdl2uuid(cont_handles[i][j], &hdl, &cont)) {
+						printf("disconnect container handle (pool %d, "
+						       "hdl %d) failed: %d\n", i, j, rc);
+					} else {
+						char		cont_str[DAOS_UUID_STR_SIZE];
+						char		hdl_str[DAOS_UUID_STR_SIZE];
+
+						uuid_unparse_lower(cont, cont_str);
+						uuid_unparse_lower(hdl, hdl_str);
+						printf("disconnect handle %s from container %s "
+						       "(pool %d, hdl %d) failed: %d\n", hdl_str,
+						       cont_str, i, j, rc);
+					}
 				}
 			}
 
@@ -78,9 +84,12 @@ void cleanup_handles(char **pool_ids, int num_pools,
 				if (pool) {
 					uuid_unparse_lower(pool->dp_pool, pool_str);
 					uuid_unparse_lower(pool->dp_pool, hdl_str);
-					printf("disconnect handle %s from pool %s "
-						"failed\n", hdl_str, pool_str);
+					printf("disconnect handle %s from pool %s (pool n%d, "
+					       "hdl %d) failed: %d\n", hdl_str, pool_str, i, j, rc);
 					dc_pool_put(pool);
+				} else {
+					printf("disconnect pool handle (pool %d, hdl %d) "
+					       "failed: %d\n", i, j, rc);
 				}
 			}
 		}


### PR DESCRIPTION
Before this change the jobtest invocation of dc_cont_hdl2uuid() did
not check for a failure, leading to Coverity CID 22078. With this
change, the return code is checked and the test output is adjusted.

Performing build only in CI (skipping testing) since jobtest is only
invoked manually at this time. It was tested manually with this change.

Skip-test: true

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>