### PR TITLE
DAOS-11266 test: Fix ftest divergence from master

### DIFF
--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -134,7 +134,7 @@ class FormattedParameter(BasicParameter):
     """A class for test parameters whose values are read from a yaml file."""
 
     def __init__(self, str_format, default=None, yaml_key=None):
-        """Create a FormattedParameter object.
+        """Create a FormattedParameter  object.
 
         Normal use includes assigning this object to an attribute name that
         matches the test yaml file key used to assign its value.  If the
@@ -196,7 +196,7 @@ class LogParameter(FormattedParameter):
     """A class for a test log file parameter which is read from a yaml file."""
 
     def __init__(self, directory, str_format, default=None):
-        """Create a LogParameter object.
+        """Create a LogParameter  object.
 
         Args:
             directory (str): fixed location for the log file name specified by
@@ -301,9 +301,6 @@ class ObjectWithParameters():
     def get_attribute_names(self, attr_type=None):
         """Get a sorted list of the names of the attr_type attributes.
 
-        The list has the ordered positional parameters first, then
-        non-positional parameters.
-
         Args:
             attr_type(object, optional): A single object type or tuple of
                 object types used to filter class attributes by their type.
@@ -313,16 +310,9 @@ class ObjectWithParameters():
             list: a list of class attribute names used to define parameters
 
         """
-        positional = {}
-        non_positional = []
-        for name in sorted(list(self.__dict__)):
-            attr = getattr(self, name)
-            if attr_type is None or isinstance(attr, attr_type):
-                if hasattr(attr, "position"):
-                    positional[attr] = name
-                else:
-                    non_positional.append(name)
-        return [positional[key] for key in sorted(positional)] + non_positional
+        return [
+            name for name in sorted(self.__dict__.keys())
+            if attr_type is None or isinstance(getattr(self, name), attr_type)]
 
     def get_param_names(self):
         """Get a sorted list of the names of the BasicParameter attributes.
@@ -752,7 +742,7 @@ class PositionalParameter(FormattedParameter):
     """
 
     def __init__(self, position, default=None, str_format="{}", yaml_key=None):
-        """Create a PositionalParameter object.
+        """Create a PositionalParameter  object.
 
         Args:
             position (int): argument position/order
@@ -785,8 +775,41 @@ class PositionalParameter(FormattedParameter):
     def __hash__(self):
         """Returns self.position as the hash of the class.
 
-        This is used in ObjectWithParameters.get_attribute_names() where we use this
-        object as the key for a dictionary.
+        This is used in CommandWithPositionalParameters.get_attribute_names()
+        where we use this object as the key for a dictionary.
 
         """
         return self.position
+
+
+class CommandWithPositionalParameters(CommandWithParameters):
+    """Command that uses positional parameters.
+
+    Used to support positional parameters for dmg, daos, and ddb.
+    """
+
+    def get_attribute_names(self, attr_type=None):
+        """Get a sorted list of the names of the attr_type attributes.
+
+        The list has the ordered positional parameters first, then
+        non-positional parameters.
+
+        Args:
+            attr_type(object, optional): A single object type or tuple of
+                object types used to filter class attributes by their type.
+                Defaults to None.
+
+        Returns:
+            list: a list of class attribute names used to define parameters
+
+        """
+        positional = {}
+        non_positional = []
+        for name in sorted(list(self.__dict__)):
+            attr = getattr(self, name)
+            if isinstance(attr, attr_type):
+                if hasattr(attr, "position"):
+                    positional[attr] = name
+                else:
+                    non_positional.append(name)
+        return [positional[key] for key in sorted(positional)] + non_positional

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from command_utils_base import FormattedParameter, CommandWithParameters,\
-    PositionalParameter
+    CommandWithPositionalParameters, PositionalParameter
 from command_utils import CommandWithSubCommand
 
 
@@ -64,7 +64,7 @@ class DaosCommandBase(CommandWithSubCommand):
             else:
                 self.sub_command_class = None
 
-        class CommonPoolSubCommand(CommandWithParameters):
+        class CommonPoolSubCommand(CommandWithPositionalParameters):
             """Defines an object for the common daos pool sub-command.
 
             Use PositionalParameter for positional parameter subcommands. The
@@ -200,7 +200,7 @@ class DaosCommandBase(CommandWithSubCommand):
             else:
                 self.sub_command_class = None
 
-        class CommonContainerSubCommand(CommandWithParameters):
+        class CommonContainerSubCommand(CommandWithPositionalParameters):
             """Defines an object for the common daos container sub-command."""
 
             def __init__(self, sub_command):
@@ -347,7 +347,7 @@ class DaosCommandBase(CommandWithSubCommand):
                 super().__init__("get-prop")
                 self.prop = FormattedParameter("--properties={}")
 
-        class ListSubCommand(CommandWithParameters):
+        class ListSubCommand(CommandWithPositionalParameters):
             """Defines an object for the daos container list command."""
 
             def __init__(self):

--- a/src/tests/ftest/util/ddb_utils.py
+++ b/src/tests/ftest/util/ddb_utils.py
@@ -5,11 +5,11 @@
 """
 import os
 
-from command_utils_base import PositionalParameter, CommandWithParameters
+from command_utils_base import PositionalParameter, CommandWithPositionalParameters
 from general_utils import run_pcmd
 
 
-class DdbCommandBase(CommandWithParameters):
+class DdbCommandBase(CommandWithPositionalParameters):
     """Defines the basic structures of ddb command."""
 
     def __init__(self, server_host, path, verbose=True, timeout=None, sudo=True):


### PR DESCRIPTION
The master and feature/cat_recovery branches had differing
approaches to adding support for positional parameters to
test commands.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
