### PR TITLE
DAOS-11417 rebuild: do not use stable epoch for reclaim

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5100,6 +5100,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	bool				updated;
 	int				rc;
 	char				*env;
+	daos_epoch_t			rebuild_eph = crt_hlc_get();
 	uint64_t			delay = 2;
 
 	rc = pool_svc_update_map_internal(svc, opc, exclude_rank, &target_list,
@@ -5152,7 +5153,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	D_DEBUG(DB_MD, "map ver %u/%u\n", map_version ? *map_version : -1,
 		tgt_map_ver);
 	if (tgt_map_ver != 0) {
-		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver, 0, 0,
+		rc = ds_rebuild_schedule(svc->ps_pool, tgt_map_ver, 0, rebuild_eph,
 					 &target_list, op, delay);
 		if (rc != 0) {
 			D_ERROR("rebuild fails rc: "DF_RC"\n", DP_RC(rc));
@@ -5260,6 +5261,7 @@ pool_extend_internal(uuid_t pool_uuid, struct rsvc_hint *hint, uint32_t nnodes,
 	struct pool_svc		*svc;
 	struct rdb_tx		tx;
 	bool			updated = false;
+	daos_epoch_t		extend_eph = crt_hlc_get();
 	struct pool_target_id_list tgts = { 0 };
 	int rc;
 
@@ -5291,7 +5293,7 @@ pool_extend_internal(uuid_t pool_uuid, struct rsvc_hint *hint, uint32_t nnodes,
 	}
 
 	/* Schedule an extension rebuild for those targets */
-	rc = ds_rebuild_schedule(svc->ps_pool, *map_version_p, 0, 0, &tgts,
+	rc = ds_rebuild_schedule(svc->ps_pool, *map_version_p, 0, extend_eph, &tgts,
 				 RB_OP_EXTEND, 2);
 	if (rc != 0) {
 		D_ERROR("failed to schedule extend rc: "DF_RC"\n", DP_RC(rc));

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -77,6 +77,9 @@ struct rebuild_tgt_pool_tracker {
 	uint64_t		rt_reported_size;
 	/* global stable epoch to use for rebuilding the data */
 	uint64_t		rt_stable_epoch;
+
+	/* Only used by reclaim job to discard those half-rebuild data */
+	uint64_t		rt_reclaim_epoch;
 	/* local rebuild epoch mainly to constrain the VOS aggregation
 	 * to make sure aggregation will not cross the epoch
 	 */
@@ -134,8 +137,15 @@ struct rebuild_global_pool_tracker {
 
 	uint64_t	rgt_time_start;
 
-	/* stable epoch of the rebuild */
+	/* Stable epoch of the rebuild, the minimum epoch from
+	 * all rebuilding targets
+	 */
 	uint64_t	rgt_stable_epoch;
+
+	/* reclaim epoch of the rebuild, which is used to discard
+	 * the half-rebuild data if rebuild fails
+	 */
+	uint64_t	rgt_reclaim_epoch;
 
 	ABT_mutex	rgt_lock;
 	/* The current rebuild is done on the leader */
@@ -203,7 +213,11 @@ struct rebuild_task {
 	uuid_t				dst_pool_uuid;
 	struct pool_target_id_list	dst_tgts;
 	daos_rebuild_opc_t		dst_rebuild_op;
-	daos_epoch_t			dst_stable_eph;
+
+	/* Epoch to use for reclaim job for discarding the data
+	 * of half-rebuild/reintegrated job.
+	 */
+	daos_epoch_t			dst_reclaim_eph;
 	uint64_t			dst_schedule_time;
 	uint32_t			dst_map_ver;
 	uint32_t			dst_rebuild_gen;

--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -23,7 +23,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_REBUILD_VERSION 3
+#define DAOS_REBUILD_VERSION 4
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
@@ -46,6 +46,7 @@ extern struct crt_proto_format rebuild_proto_fmt;
 #define DAOS_ISEQ_REBUILD_SCAN	/* input fields */		 \
 	((uuid_t)		(rsi_pool_uuid)		CRT_VAR) \
 	((uint64_t)		(rsi_leader_term)	CRT_VAR) \
+	((uint64_t)		(rsi_reclaim_epoch)	CRT_VAR) \
 	((int32_t)		(rsi_rebuild_op)	CRT_VAR) \
 	((uint32_t)		(rsi_tgts_num)		CRT_VAR) \
 	((uint32_t)		(rsi_ns_id)		CRT_VAR) \

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -630,7 +630,8 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 				" which is not reachable on rank %u tgt %u",
 				DP_UOID(oid), myrank, mytarget);
 
-			discard_epr.epr_hi = rpt->rt_stable_epoch;
+			D_ASSERT(rpt->rt_reclaim_epoch != 0);
+			discard_epr.epr_hi = rpt->rt_reclaim_epoch;
 			discard_epr.epr_lo = 0;
 			/*
 			 * It's possible this object might still be being

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -565,7 +565,7 @@ rebuild_leader_status_notify(struct rebuild_global_pool_tracker *rgt, struct ds_
 			DP_UUID(rgt->rgt_pool_uuid), DP_RC(rc));
 }
 
-#define RBLD_SBUF_LEN	256
+#define RBLD_SBUF_LEN	356
 
 enum {
 	RB_BCAST_NONE,
@@ -661,12 +661,13 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 		snprintf(sbuf, RBLD_SBUF_LEN,
 			 "%s [%s] (pool "DF_UUID" leader %u term "DF_U64" dtx gl %u ver=%u,"
 			 "gen %u toberb_obj=" DF_U64", rb_obj="DF_U64", rec="DF_U64", size="DF_U64
-			 " done %d status %d/%d epoch "DF_U64" duration=%d secs)\n",
+			 " done %d status %d/%d  stable "DF_X64" reclaim "DF_X64
+			 " duration=%d secs)\n",
 			 RB_OP_STR(op), str, DP_UUID(pool->sp_uuid), myrank,
 			 rgt->rgt_leader_term, rgt->rgt_dtx_resync_version, rgt->rgt_rebuild_ver,
 			 rgt->rgt_rebuild_gen, rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr,
 			 rs->rs_size, rs->rs_state, rs->rs_errno, rs->rs_fail_rank,
-			 rgt->rgt_stable_epoch, rs->rs_seconds);
+			 rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch, rs->rs_seconds);
 
 		D_INFO("%s", sbuf);
 		if (rs->rs_state == DRS_COMPLETED || rebuild_gst.rg_abort ||
@@ -708,7 +709,7 @@ rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 
 static int
 rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t rebuild_gen,
-				   uint64_t leader_term, daos_epoch_t stable_eph,
+				   uint64_t leader_term, daos_epoch_t reclaim_eph,
 				   struct rebuild_global_pool_tracker **p_rgt)
 {
 	struct rebuild_global_pool_tracker *rgt;
@@ -748,7 +749,7 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t 
 	rgt->rgt_leader_term = leader_term;
 	rgt->rgt_rebuild_gen = rebuild_gen;
 	rgt->rgt_time_start = d_timeus_secdiff(0);
-	rgt->rgt_stable_epoch = stable_eph;
+	rgt->rgt_reclaim_epoch = reclaim_eph;
 	d_list_add(&rgt->rgt_list, &rebuild_gst.rg_global_tracker_list);
 	*p_rgt = rgt;
 	rgt->rgt_refcount = 1;
@@ -796,7 +797,7 @@ rebuild_global_pool_tracker_lookup(const uuid_t pool_uuid, unsigned int ver, uns
 static int
 rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 		uint32_t rebuild_gen, uint64_t leader_term,
-		daos_epoch_t stable_eph,
+		daos_epoch_t reclaim_eph,
 		struct pool_target_id_list *tgts,
 		daos_rebuild_opc_t rebuild_op,
 		struct rebuild_global_pool_tracker **rgt)
@@ -809,7 +810,7 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 
 	/* Update pool iv ns for the pool */
 	rc = rebuild_global_pool_tracker_create(pool, rebuild_ver, rebuild_gen, leader_term,
-						stable_eph, rgt);
+						reclaim_eph, rgt);
 	if (rc) {
 		D_ERROR("rebuild_global_pool_tracker create failed: rc %d\n",
 			rc);
@@ -947,6 +948,10 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 	rsi->rsi_leader_term = rgt->rgt_leader_term;
 	rsi->rsi_rebuild_ver = rgt->rgt_rebuild_ver;
 	rsi->rsi_rebuild_gen = rgt->rgt_rebuild_gen;
+	if (rebuild_op == RB_OP_RECLAIM)
+		D_ASSERT(rgt->rgt_reclaim_epoch != 0);
+
+	rsi->rsi_reclaim_epoch = rgt->rgt_reclaim_epoch;
 	rsi->rsi_tgts_num = tgts_failed->pti_number;
 	rsi->rsi_rebuild_op = rebuild_op;
 	crt_group_rank(pool->sp_group,  &rsi->rsi_master_rank);
@@ -957,20 +962,10 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 		rc = rso->rso_status;
 
 	rgt->rgt_init_scan = 1;
-	if (rgt->rgt_stable_epoch == 0) {
-		rgt->rgt_stable_epoch = rso->rso_stable_epoch;
-	} else {
-		/* If initial rebuild/reintegration failed, the retry will keep
-		 * the same stable epoch to make sure reclaim only delete the data
-		 * before stable epoch, but keep the inflight data.
-		 */
-		D_ASSERTF(rgt->rgt_stable_epoch <= rso->rso_stable_epoch,
-			  "stable epoch "DF_X64" > collect epoch "DF_X64"\n",
-			  rgt->rgt_stable_epoch, rso->rso_stable_epoch);
-	}
-	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID": "DF_RC" got stable epoch "
-		DF_U64"\n", DP_UUID(rsi->rsi_pool_uuid), DP_RC(rc),
-		rgt->rgt_stable_epoch);
+	rgt->rgt_stable_epoch = rso->rso_stable_epoch;
+	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID": "DF_RC" got stable/reclaim epoch "
+		DF_X64"/"DF_X64"\n", DP_UUID(rsi->rsi_pool_uuid), DP_RC(rc),
+		rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch);
 	crt_req_decref(rpc);
 out:
 	if (excluded)
@@ -1190,7 +1185,7 @@ rebuild_leader_start(struct ds_pool *pool, struct rebuild_task *task,
 	}
 
 	rc = rebuild_prepare(pool, task->dst_map_ver, task->dst_rebuild_gen,
-			     leader_term, task->dst_stable_eph, &task->dst_tgts,
+			     leader_term, task->dst_reclaim_eph, &task->dst_tgts,
 			     task->dst_rebuild_op, p_rgt);
 	if (rc) {
 		D_ERROR("rebuild prepare failed: "DF_RC"\n", DP_RC(rc));
@@ -1216,7 +1211,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 
 	if (rgt == NULL) {
 		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-					 0, &task->dst_tgts, task->dst_rebuild_op, 5);
+					 task->dst_reclaim_eph, &task->dst_tgts,
+					 task->dst_rebuild_op, 5);
 		return rc;
 	}
 
@@ -1225,20 +1221,20 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
 		if (task->dst_rebuild_op == RB_OP_RECLAIM) {
 			rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-						 rgt->rgt_stable_epoch, &task->dst_tgts,
+						 rgt->rgt_reclaim_epoch, &task->dst_tgts,
 						 RB_OP_RECLAIM, 5);
 			return rc;
 		}
 
 		/* Schedule reclaim to clean up current op */
 		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-					 rgt->rgt_stable_epoch, &task->dst_tgts, RB_OP_RECLAIM, 5);
+					 rgt->rgt_reclaim_epoch, &task->dst_tgts, RB_OP_RECLAIM, 5);
 		if (rc)
 			return rc;
 
 		/* Then retry */
 		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-					 rgt->rgt_stable_epoch, &task->dst_tgts,
+					 rgt->rgt_reclaim_epoch, &task->dst_tgts,
 					 task->dst_rebuild_op, 5);
 		return rc;
 	}
@@ -1247,7 +1243,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 	if (task->dst_rebuild_op == RB_OP_REINT || task->dst_rebuild_op == RB_OP_EXTEND) {
 		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
 		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-					 rgt->rgt_stable_epoch, &task->dst_tgts, RB_OP_RECLAIM, 5);
+					 rgt->rgt_reclaim_epoch, &task->dst_tgts, RB_OP_RECLAIM, 5);
 		if (rc != 0)
 			D_ERROR("reschedule reclaim, "DF_UUID" failed: "DF_RC"\n",
 				DP_UUID(task->dst_pool_uuid), DP_RC(rc));
@@ -1650,7 +1646,7 @@ rebuild_print_list_update(const uuid_t uuid, const uint32_t map_ver,
  */
 int
 ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen,
-		    daos_epoch_t stable_eph, struct pool_target_id_list *tgts,
+		    daos_epoch_t reclaim_eph, struct pool_target_id_list *tgts,
 		    daos_rebuild_opc_t rebuild_op, uint64_t delay_sec)
 {
 	struct rebuild_task	*new_task;
@@ -1685,7 +1681,7 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen
 	new_task->dst_map_ver = map_ver;
 	new_task->dst_rebuild_gen = rebuild_gen;
 	new_task->dst_rebuild_op = rebuild_op;
-	new_task->dst_stable_eph = stable_eph;
+	new_task->dst_reclaim_eph = reclaim_eph;
 	uuid_copy(new_task->dst_pool_uuid, pool->sp_uuid);
 	D_INIT_LIST_HEAD(&new_task->dst_list);
 
@@ -1748,6 +1744,7 @@ static int
 regenerate_task_internal(struct ds_pool *pool, struct pool_target *tgts,
 			 unsigned int tgts_cnt, daos_rebuild_opc_t rebuild_op)
 {
+	daos_epoch_t	eph = crt_hlc_get();
 	unsigned int	i;
 	int		rc;
 
@@ -1762,10 +1759,10 @@ regenerate_task_internal(struct ds_pool *pool, struct pool_target *tgts,
 
 		if (rebuild_op == RB_OP_FAIL || rebuild_op == RB_OP_DRAIN)
 			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_fseq, 0,
-						 0, &id_list, rebuild_op, 0);
+						 eph, &id_list, rebuild_op, 0);
 		else
 			rc = ds_rebuild_schedule(pool, tgt->ta_comp.co_in_ver, 0,
-						 0, &id_list, rebuild_op, 0);
+						 eph, &id_list, rebuild_op, 0);
 
 		if (rc) {
 			D_ERROR(DF_UUID" schedule op %d ver %d failed: "
@@ -2123,7 +2120,7 @@ rebuild_prepare_one(void *data)
 static int
 rpt_create(struct ds_pool *pool, uint32_t master_rank, uint32_t pm_ver,
 	   uint64_t leader_term, uint32_t rebuild_gen, uint32_t tgts_num,
-	   struct rebuild_tgt_pool_tracker **p_rpt)
+	   uint64_t reclaim_epoch, struct rebuild_tgt_pool_tracker **p_rpt)
 {
 	struct rebuild_tgt_pool_tracker	*rpt;
 	d_rank_t	rank;
@@ -2155,6 +2152,7 @@ rpt_create(struct ds_pool *pool, uint32_t master_rank, uint32_t pm_ver,
 	rpt->rt_leader_term = leader_term;
 	rpt->rt_rebuild_gen = rebuild_gen;
 	rpt->rt_tgts_num = tgts_num;
+	rpt->rt_reclaim_epoch = reclaim_epoch;
 	crt_group_rank(pool->sp_group, &rank);
 	rpt->rt_rank = rank;
 	rpt->rt_leader_rank = master_rank;
@@ -2216,7 +2214,7 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	/* Create rpt for the target */
 	rc = rpt_create(pool, rsi->rsi_master_rank, rsi->rsi_rebuild_ver,
 			rsi->rsi_leader_term, rsi->rsi_rebuild_gen,
-			rsi->rsi_tgts_num, &rpt);
+			rsi->rsi_tgts_num, rsi->rsi_reclaim_epoch, &rpt);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -439,7 +439,7 @@ class ExecutableCommand(CommandWithParameters):
             env (EnvironmentVariables): a dictionary of environment variable
                 names and values to export prior to running the command
         """
-        self.env = env.copy()
+        self.env = EnvironmentVariables(env.copy())
 
 
 class CommandWithSubCommand(ExecutableCommand):


### PR DESCRIPTION
Instead of using stable epoch as the reclaim epoch, let's
use the epoch when the pool map is being changed, so if
the rebuild job fail, reclaim will not discard the in-flight
data.

Test-tag: pr rebuild
Signed-off-by: Di Wang <di.wang@intel.com>
Conflicts:
	src/rebuild/srv.c