### PR TITLE
DAOS-11171 test: add dfuse mtime unit tests (#9778)

### DIFF
--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -81,7 +81,7 @@ dfuse_fuse_init(void *arg, struct fuse_conn_info *conn)
 	conn->want |= FUSE_CAP_READDIRPLUS;
 	conn->want |= FUSE_CAP_READDIRPLUS_AUTO;
 
-	conn->time_gran = 1000000000;
+	conn->time_gran = 1;
 
 	if (fs_handle->dpi_info->di_wb_cache)
 		conn->want |= FUSE_CAP_WRITEBACK_CACHE;

--- a/src/tests/ftest/daos_test/dfuse.py
+++ b/src/tests/ftest/daos_test/dfuse.py
@@ -77,7 +77,11 @@ class DaosCoreTestDfuse(DfuseTestBase):
 
         intercept = self.params.get('use_intercept', '/run/intercept/*', default=False)
 
-        cmd = [self.daos_test, '--test-dir', mount_dir]
+        cmd = [self.daos_test, '--test-dir', mount_dir, '--io']
+
+        # Metadata tests don't work with caching enabled, see DAOS-11204
+        if intercept or cache_mode in ('nocache', 'native'):
+            cmd.append('--metadata')
 
         if intercept:
             remote_env = OrderedDict()

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -25,12 +25,28 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/statfs.h>
+
+#include "daos.h"
+
+/**
+ * Tests can be run by specifying the appropriate argument for a test or
+ * all will be run if no test is specified.
+ */
+#define TESTS "im"
+static const char *all_tests = TESTS;
 
 static void
 print_usage()
 {
-	printf("DFuse tests\n");
-	printf("dfuse_test --test-dir <path to test>\n");
+	print_message("\n\nDFuse tests\n=============================\n");
+	print_message("dfuse_test -M|--test-dir <path to test>\n");
+	print_message("Tests: Use one of these arg(s) for specific test\n");
+	print_message("dfuse_test -a|--all\n");
+	print_message("dfuse_test -i|--io\n");
+	print_message("dfuse_test -m|--metadata\n");
+	print_message("Default <dfuse_test> runs all tests\n=============\n");
+	print_message("\n=============================\n");
 }
 
 char *test_dir;
@@ -142,20 +158,181 @@ do_openat(void **state)
 	assert_return_code(rc, errno);
 }
 
+static bool
+timespec_gt(struct timespec t1, struct timespec t2)
+{
+	if (t1.tv_sec == t2.tv_sec)
+		return t1.tv_nsec > t2.tv_nsec;
+	else
+		return t1.tv_sec > t2.tv_sec;
+}
+
+#define FUSE_SUPER_MAGIC  0x65735546
+
+void
+do_mtime(void **state)
+{
+	struct stat     stbuf;
+	struct timespec prev_ts;
+	struct timespec now;
+	struct timespec times[2];
+	int             fd;
+	int             rc;
+	char            input_buf[] = "hello";
+	struct statfs   fs;
+	int             root        = open(test_dir, O_PATH | O_DIRECTORY);
+
+	assert_return_code(root, errno);
+
+	/* Open a file and sanity check the mtime */
+	fd = openat(root, "my_file", O_RDWR | O_CREAT | O_EXCL, S_IWUSR | S_IRUSR);
+	assert_return_code(fd, errno);
+
+	rc = fstatfs(root, &fs);
+	assert_return_code(fd, errno);
+
+	rc = clock_gettime(CLOCK_REALTIME, &now);
+	assert_return_code(fd, errno);
+	rc = fstat(fd, &stbuf);
+	assert_return_code(rc, errno);
+	prev_ts.tv_sec  = stbuf.st_mtim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
+	if (fs.f_type == FUSE_SUPER_MAGIC) {
+		assert_true(timespec_gt(now, stbuf.st_mtim));
+	} else {
+		printf("Not comparing mtime\n");
+		printf("%ld %ld\n", now.tv_sec, now.tv_nsec);
+		printf("%ld %ld\n", stbuf.st_mtim.tv_sec, stbuf.st_mtim.tv_nsec);
+	}
+
+	/* Write to the file and verify mtime is newer */
+	rc = write(fd, input_buf, sizeof(input_buf));
+	assert_return_code(rc, errno);
+	rc = fstat(fd, &stbuf);
+	assert_return_code(rc, errno);
+
+	if (fs.f_type == FUSE_SUPER_MAGIC) {
+		assert_true(timespec_gt(stbuf.st_mtim, prev_ts));
+	} else {
+		printf("Not comparing mtime\n");
+		printf("%ld %ld\n", stbuf.st_mtim.tv_sec, stbuf.st_mtim.tv_nsec);
+		printf("%ld %ld\n", prev_ts.tv_sec, prev_ts.tv_nsec);
+	}
+	prev_ts.tv_sec  = stbuf.st_mtim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
+
+	/* Truncate the file and verify mtime is newer */
+	rc = ftruncate(fd, 0);
+	assert_return_code(rc, errno);
+	rc = fstat(fd, &stbuf);
+	assert_return_code(rc, errno);
+	if (fs.f_type == FUSE_SUPER_MAGIC) {
+		assert_true(timespec_gt(stbuf.st_mtim, prev_ts));
+	} else {
+		printf("Not comparing mtime\n");
+		printf("%ld %ld\n", stbuf.st_mtim.tv_sec, stbuf.st_mtim.tv_nsec);
+		printf("%ld %ld\n", prev_ts.tv_sec, prev_ts.tv_nsec);
+	}
+	prev_ts.tv_sec  = stbuf.st_mtim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
+
+	/* Set and verify mtime set in the past */
+	times[0]         = now;
+	times[1].tv_sec  = now.tv_sec - 10;
+	times[1].tv_nsec = 20;
+	rc               = futimens(fd, times);
+	assert_return_code(fd, errno);
+	rc = fstat(fd, &stbuf);
+	assert_return_code(rc, errno);
+	assert_int_equal(stbuf.st_mtim.tv_sec, times[1].tv_sec);
+	assert_int_equal(stbuf.st_mtim.tv_nsec, times[1].tv_nsec);
+	prev_ts.tv_sec  = stbuf.st_mtim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
+
+	/* Repeat the write test again */
+	rc = write(fd, input_buf, sizeof(input_buf));
+	assert_return_code(rc, errno);
+	rc = fstat(fd, &stbuf);
+	assert_return_code(rc, errno);
+	assert_true(timespec_gt(stbuf.st_mtim, prev_ts));
+
+	rc = close(fd);
+	assert_return_code(rc, errno);
+
+	rc = unlinkat(root, "my_file", 0);
+	assert_return_code(rc, errno);
+
+	rc = close(root);
+	assert_return_code(rc, errno);
+}
+
+static int
+run_specified_tests(const char *tests, int *sub_tests, int sub_tests_size)
+{
+	int nr_failed = 0;
+
+	if (strlen(tests) == 0)
+		tests = all_tests;
+
+	while (*tests != '\0') {
+		switch (*tests) {
+		case 'i':
+			printf("\n\n=================");
+			printf("dfuse IO tests");
+			printf("=====================");
+			const struct CMUnitTest io_tests[] = {
+			    cmocka_unit_test(do_openat),
+			};
+			nr_failed = cmocka_run_group_tests(io_tests, NULL, NULL);
+			break;
+		case 'm':
+			printf("\n\n=================");
+			printf("dfuse metadata tests");
+			printf("=====================");
+			const struct CMUnitTest metadata_tests[] = {
+			    cmocka_unit_test(do_mtime),
+			};
+			nr_failed = cmocka_run_group_tests(metadata_tests, NULL, NULL);
+			break;
+
+		default:
+			assert_true(0);
+		}
+
+		tests++;
+	}
+
+	return nr_failed;
+}
+
 int
 main(int argc, char **argv)
 {
-	int                     index = 0;
-	int                     opt;
-	struct option           long_options[] = {{"test-dir", required_argument, NULL, 'M'},
-						  {NULL, 0, NULL, 0} };
+	char                 tests[64];
+	int                  ntests          = 0;
+	int                  nr_failed       = 0;
+	int                  nr_total_failed = 0;
+	int                  opt = 0, index = 0;
 
-	const struct CMUnitTest tests[]        = {
-		   cmocka_unit_test(do_openat),
+	static struct option long_options[] = {
+		{"test-dir", required_argument, NULL, 'M'},
+		{"all", no_argument, NULL, 'a'},
+		{"io", no_argument, NULL, 'i'},
+		{"metadata", no_argument, NULL, 'm'},
+		{NULL, 0, NULL, 0}
 	};
 
-	while ((opt = getopt_long(argc, argv, "M:", long_options, &index)) != -1) {
+	memset(tests, 0, sizeof(tests));
+
+	while ((opt = getopt_long(argc, argv, "a:M:im", long_options, &index)) != -1) {
+		if (strchr(all_tests, opt) != NULL) {
+			tests[ntests] = opt;
+			ntests++;
+			continue;
+		}
 		switch (opt) {
+		case 'a':
+			break;
 		case 'M':
 			test_dir = optarg;
 			break;
@@ -167,9 +344,17 @@ main(int argc, char **argv)
 	}
 
 	if (test_dir == NULL) {
-		printf("--test-dir option required\n");
+		printf("-M|--test-dir option required\n");
 		return 1;
 	}
 
-	return cmocka_run_group_tests(tests, NULL, NULL);
+	nr_failed = run_specified_tests(tests, NULL, 0);
+
+	print_message("\n============ Summary %s\n", __FILE__);
+	if (nr_total_failed == 0)
+		print_message("OK - NO TEST FAILURES\n");
+	else
+		print_message("ERROR, %i TEST(S) FAILED\n", nr_total_failed);
+
+	return nr_failed;
 }


### PR DESCRIPTION
Test-tag: pr dfuse,daily_regression dfuse_unit

- Change dfuse time granularity to 1 (nanosecond)
- overhaul dfuse_test.c
- Add dfuse unit mtime unit tests
- Adjust dfuse_test to run with or without metadata tests
- Add metadata tests to ftest/daos_test/dfuse.py

Co-authored-by: Ashley Pittman <ashley.m.pittman@intel.com>
Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>