### PR TITLE
DAOS-11477 pool: Coverity CIDs 105913/105918 always free prop

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4081,9 +4081,13 @@ static int pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
 		if (rc)
 			D_GOTO(out_free, rc);
 		rc = pool_prop_read(tx, svc, DAOS_PO_QUERY_PROP_ALL, &prop);
-		if (rc)
+		if (rc) {
+			/* Prop might be allocated and returned even if rc != 0 */
+			daos_prop_free(prop);
 			D_GOTO(out_free, rc);
+		}
 		rc = ds_pool_iv_prop_update(svc->ps_pool, prop);
+		daos_prop_free(prop);
 	}
 
 out_free:
@@ -4154,12 +4158,13 @@ static int ds_pool_mark_upgrade_completed(uuid_t pool_uuid,
 
 	rc1 = pool_prop_read(&tx, svc, DAOS_PO_QUERY_PROP_ALL, &prop);
 	if (rc1)
-		D_GOTO(out_tx, rc1);
-	rc1 = ds_pool_iv_prop_update(svc->ps_pool, prop);
-	daos_prop_free(prop);
-	if (rc1)
-		D_GOTO(out_tx, rc1);
+		/* Prop might be allocated and returned even if rc != 0 */
+		D_GOTO(out_prop, rc1);
 
+	rc1 = ds_pool_iv_prop_update(svc->ps_pool, prop);
+
+out_prop:
+	daos_prop_free(prop);
 out_tx:
 	ABT_rwlock_unlock(svc->ps_lock);
 	rdb_tx_end(&tx);


### PR DESCRIPTION
Proactive cherry-pick of same change in progress for master branch.

In pool_upgrade_props() and ds_pool_mark_upgrade_completed() it is
possible that the pool_prop_read() call allocates memory for the
daos_prop_t * output argument (even when rc != 0 is returned).
Before this change, prop was not freed, and with this change
it is freed even when pool_prop_read() fails.

Features: pool

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>