### PR TITLE
DAOS-11478 pool: Coverity CID 105939: check rank list copy

### DIFF
--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -158,6 +158,8 @@ pool_iv_prop_l2g(daos_prop_t *prop, struct pool_iv_prop *iv_prop)
 		case DAOS_PROP_PO_SVC_LIST:
 			svc_list = prop_entry->dpe_val_ptr;
 			if (svc_list) {
+				int rc;
+
 				D_ASSERT(svc_list->rl_nr <
 					 PROP_SVC_LIST_MAX_TMP);
 				iv_prop->pip_svc_list.rl_nr = svc_list->rl_nr;
@@ -165,8 +167,8 @@ pool_iv_prop_l2g(daos_prop_t *prop, struct pool_iv_prop *iv_prop)
 						(void *)(iv_prop->pip_iv_buf +
 						roundup(offset, 8));
 				iv_prop->pip_svc_list_offset = offset;
-				d_rank_list_copy(&iv_prop->pip_svc_list,
-						 svc_list);
+				rc = d_rank_list_copy(&iv_prop->pip_svc_list, svc_list);
+				D_ASSERT(rc == 0);
 				offset += roundup(
 					svc_list->rl_nr * sizeof(d_rank_t), 8);
 			}


### PR DESCRIPTION
Proactive cherry-pick of same change in progress for master branch.

The pool_iv_prop_l2g() function returns void, but for property
entry DAOS_PROP_PO_SVC_LIST, it calls d_rank_list_copy(). The calling
conditions are such that d_rank_list_copy() argument checking will
not return -DER_INVAL, and the execution will only perform memcpy
and return 0.

With this change get the return value and assert it is zero (success).

Features: pool

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>