### PR TITLE
DAOS-11443 test: fix set_environment() (#10060)

### DIFF
--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -439,7 +439,7 @@ class ExecutableCommand(CommandWithParameters):
             env (EnvironmentVariables): a dictionary of environment variable
                 names and values to export prior to running the command
         """
-        self.env = env.copy()
+        self.env = EnvironmentVariables(env.copy())
 
 
 class CommandWithSubCommand(ExecutableCommand):


### PR DESCRIPTION
Test-tag: pr,hw,large ec_io_conf_run unaligned_io iorebuild
Skip-unit-tests: true
Skip-fault-injection-test: true

Convert passed env to EnvironmentVariables in case it's a dict.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>