### PR TITLE
DAOS-11486 test: Coverity CID 449352, fix NULL dereference...

### DIFF
--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -1278,7 +1278,7 @@ int verify_state_in_log(char *host, char *log_file, char *state)
 		snprintf(command, sizeof(command),
 			 "ssh %s cat %s | grep \"%s\"", host, pch, state);
 		fp = popen(command, "r");
-		while ((read = getline(&line, &len, fp)) != -1) {
+		while (fp && (read = getline(&line, &len, fp)) != -1) {
 			if (strstr(line, state) != NULL) {
 				print_message("Found state %s in Log file %s\n",
 					      state, pch);


### PR DESCRIPTION
in daos_test -n (NVMe recovery) verify_state_in_log() function,
when fp = popen() returns NULL. Avoid pclose(fp==NULL) in the
while loop (however impossible it may seem that getline(..., fp==NULL)
would return anything other than -1.

Skip-unit-tests: true
Test-tag: daos_core_test_nvme

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>