### PR TITLE
DAOS-10376 test: datamover: use -E -X -G 27 (#8737)

### DIFF
--- a/src/tests/ftest/datamover/large_dir.py
+++ b/src/tests/ftest/datamover/large_dir.py
@@ -1,17 +1,17 @@
-#!/usr/bin/python
 '''
   (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from data_mover_test_base import DataMoverTestBase
 import os
+
+from data_mover_test_base import DataMoverTestBase
+from duns_utils import format_path
 
 # pylint: disable=too-many-ancestors
 class DmvrLargeDir(DataMoverTestBase):
     """Test class Description: Add datamover test to copy a large directory
-                               amongst daos containers and external file
-                               system.
+                               amongst DAOS containers and external file system.
 
     :avocado: recursive
     """
@@ -19,10 +19,9 @@ class DmvrLargeDir(DataMoverTestBase):
     def run_dm_large_dir(self, tool):
         """
         Test Description:
-            Copy a very large directory between daos POSIX containers and
-            an external POSIX file system.
+            Copy a large directory between DAOS POSIX containers and external POSIX file system.
         Use Cases:
-            Create a pool
+            Create a pool.
             Create POSIX type cont1.
             Run mdtest -a DFS on cont1.
             Create POSIX type cont2.
@@ -30,8 +29,7 @@ class DmvrLargeDir(DataMoverTestBase):
             Copy data from cont2 to external POSIX file system.
             Create POSIX type cont4.
             Copy data from external POSIX file system to cont4.
-            Run mdtest -a DFS with read verify on copied directory to verify
-            data in cont3.
+            Run mdtest -a DFS with read verify on copied directory to verify data in cont3.
         """
         # Set the tool to use
         self.set_tool(tool)
@@ -52,9 +50,7 @@ class DmvrLargeDir(DataMoverTestBase):
 
         # run mdtest to create data in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
-        self.run_mdtest_with_params(
-            "DAOS", "/", pool, cont1,
-            flags=mdtest_flags[0])
+        self.run_mdtest_with_params("DAOS", "/", pool, cont1, flags=mdtest_flags[0])
 
         # create cont2
         cont2 = self.create_cont(pool)
@@ -62,16 +58,16 @@ class DmvrLargeDir(DataMoverTestBase):
         # copy from daos cont1 to cont2
         self.run_datamover(
             self.test_id + " (cont1 to cont2)",
-            "DAOS", "/", pool, cont1,
-            "DAOS", "/", pool, cont2)
+            src_path=format_path(pool, cont1),
+            dst_path=format_path(pool, cont2))
 
         posix_path = self.new_posix_test_path()
 
         # copy from daos cont2 to posix file system
         self.run_datamover(
             self.test_id + " (cont2 to posix)",
-            "DAOS", "/", pool, cont2,
-            "POSIX", posix_path)
+            src_path=format_path(pool, cont2),
+            dst_path=posix_path)
 
         # create cont3
         cont3 = self.create_cont(pool)
@@ -79,8 +75,8 @@ class DmvrLargeDir(DataMoverTestBase):
         # copy from posix file system to daos cont3
         self.run_datamover(
             self.test_id + " (posix to cont3)",
-            "POSIX", posix_path, None, None,
-            "DAOS", "/", pool, cont3)
+            src_path=posix_path,
+            dst_path=format_path(pool, cont3))
 
         # the result is that a NEW directory is created in the destination
         daos_path = "/" + os.path.basename(posix_path) + self.mdtest_cmd.test_dir.value
@@ -97,8 +93,8 @@ class DmvrLargeDir(DataMoverTestBase):
             Copy a very large directory between daos POSIX containers and
             an external POSIX file system using dcp.
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,medium
         :avocado: tags=datamover,mfu,mfu_dcp,dfs,mdtest
-        :avocado: tags=dm_large_dir,dm_large_dir_dcp
+        :avocado: tags=dm_large_dir,dm_large_dir_dcp,test_dm_large_dir_dcp
         """
         self.run_dm_large_dir("DCP")

--- a/src/tests/ftest/datamover/large_dir.yaml
+++ b/src/tests/ftest/datamover/large_dir.yaml
@@ -34,7 +34,6 @@ pool:
   mode: 146
   name: daos_server
   size: 95%
-  svcn: 1
   control_method: dmg
 container:
   type: POSIX
@@ -50,8 +49,8 @@ mdtest:
   dfs_dir_oclass: RP_3GX
   num_of_files_dirs: 500 # total 16K files and 16K dirs for dcp
   mdtest_flags:
-    - "-C"
-    - "-E"
+    - "-C -G 27"
+    - "-E -X -G 27"
   depth: 4
   branching_factor: 4
   bytes: 4096

--- a/src/tests/ftest/datamover/obj_large_posix.py
+++ b/src/tests/ftest/datamover/obj_large_posix.py
@@ -1,17 +1,16 @@
-#!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from data_mover_test_base import DataMoverTestBase
+from duns_utils import format_path
 
 
 # pylint: disable=too-many-ancestors
 class DmvrObjLargePosix(DataMoverTestBase):
     """Test class Description:
-       Verify cloning a large POSIX container at the object level (non-DFS)
-       using dcp.
+       Verify cloning a large POSIX container at the object level (non-DFS).
 
     :avocado: recursive
     """
@@ -43,22 +42,18 @@ class DmvrObjLargePosix(DataMoverTestBase):
 
         # Create a large directory in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
-        self.run_mdtest_with_params(
-            "DAOS", "/", pool1, cont1,
-            flags=mdtest_flags[0])
+        self.run_mdtest_with_params("DAOS", "/", pool1, cont1, flags=mdtest_flags[0])
 
         # Clone cont1 to cont2
         result = self.run_datamover(
             self.test_id + " (cont1 to cont2)",
-            "DAOS", None, pool1, cont1,
-            "DAOS", None, pool1, None)
+            src_path=format_path(pool1, cont1),
+            dst_path=format_path(pool1))
         cont2_uuid = self.parse_create_cont_uuid(result.stdout_text)
 
         # Update mdtest params, read back and verify data from cont2
         self.mdtest_cmd.read_bytes.update(file_size)
-        self.run_mdtest_with_params(
-            "DAOS", "/", pool1, cont2_uuid,
-            flags=mdtest_flags[1])
+        self.run_mdtest_with_params("DAOS", "/", pool1, cont2_uuid, flags=mdtest_flags[1])
 
     def test_dm_obj_large_posix_dcp(self):
         """Jira ID: DAOS-6892
@@ -67,7 +62,7 @@ class DmvrObjLargePosix(DataMoverTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
         :avocado: tags=datamover,mfu,mfu_dcp,mdtest
-        :avocado: tags=dm_obj_large_posix,dm_obj_large_posix_dcp
+        :avocado: tags=dm_obj_large_posix,test_dm_obj_large_posix_dcp
         """
         self.run_dm_obj_large_posix("DCP")
 
@@ -79,6 +74,6 @@ class DmvrObjLargePosix(DataMoverTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
         :avocado: tags=datamover,daos_cont_clone,mdtest
-        :avocado: tags=dm_obj_large_posix,dm_obj_large_posix_cont_clone
+        :avocado: tags=dm_obj_large_posix,test_dm_obj_large_posix_cont_clone
         """
         self.run_dm_obj_large_posix("CONT_CLONE")

--- a/src/tests/ftest/datamover/obj_large_posix.yaml
+++ b/src/tests/ftest/datamover/obj_large_posix.yaml
@@ -15,9 +15,7 @@ server_config:
 pool:
   mode: 146
   name: daos_server
-  scm_size: 1G
-  nvme_size: 10G
-  svcn: 1
+  size: 50G
   control_method: dmg
 container:
   type: POSIX
@@ -27,17 +25,16 @@ mdtest:
     np: 30
   api: DFS
   test_dir: "/"
-  iteration: 1
-  dfs_destroy: False
+  dfs_destroy: false
   manager: "MPICH"
   num_of_files_dirs: 1667  # total 50K files and 50K dirs
   mdtest_flags:
-    - "-C"
-    - "-E -X"
+    - "-C -G 27"
+    - "-E -X -G 27"
   depth: 2
   branching_factor: 2
   bytes: 4096
 dcp:
   client_processes:
-    np: 16
+    np: 30
   daos_api: DAOS

--- a/src/tests/ftest/datamover/serial_large_posix.py
+++ b/src/tests/ftest/datamover/serial_large_posix.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
 '''
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from data_mover_test_base import DataMoverTestBase
+from duns_utils import format_path
 
 
 # pylint: disable=too-many-ancestors
@@ -47,9 +47,7 @@ class DmvrSerialLargePosix(DataMoverTestBase):
 
         # Create a large directory in cont1
         self.mdtest_cmd.write_bytes.update(file_size)
-        self.run_mdtest_with_params(
-            "DAOS", "/", pool1, cont1,
-            flags=mdtest_flags[0])
+        self.run_mdtest_with_params("DAOS", "/", pool1, cont1, flags=mdtest_flags[0])
 
         # Create pool2
         pool2 = self.create_pool()
@@ -62,17 +60,15 @@ class DmvrSerialLargePosix(DataMoverTestBase):
         # Serialize/Deserialize cont1 to a new cont2 in pool2
         result = self.run_datamover(
             self.test_id + " (cont1->HDF5->cont2)",
-            "DAOS_UUID", None, pool1, cont1,
-            "DAOS_UUID", None, pool2, None)
+            src_path=format_path(pool1, cont1),
+            dst_pool=pool2)
 
         # Get the destination cont2 uuid
         cont2_uuid = self.parse_create_cont_uuid(result.stdout_text)
 
         # Update mdtest params, read back and verify data from cont2
         self.mdtest_cmd.read_bytes.update(file_size)
-        self.run_mdtest_with_params(
-            "DAOS", "/", pool2, cont2_uuid,
-            flags=mdtest_flags[1])
+        self.run_mdtest_with_params("DAOS", "/", pool2, cont2_uuid, flags=mdtest_flags[1])
 
     def test_dm_serial_large_posix_dserialize(self):
         """

--- a/src/tests/ftest/datamover/serial_large_posix.yaml
+++ b/src/tests/ftest/datamover/serial_large_posix.yaml
@@ -13,9 +13,7 @@ server_config:
 pool:
   mode: 146
   name: daos_server
-  scm_size: 1G
-  nvme_size: 10G
-  svcn: 1
+  size: 50G
   control_method: dmg
 container:
   type: POSIX
@@ -25,13 +23,12 @@ mdtest:
     np: 30
   api: DFS
   test_dir: "/"
-  iteration: 1
-  dfs_destroy: False
+  dfs_destroy: false
   manager: "MPICH"
   num_of_files_dirs: 1667  # total 50K files and 50K dirs
   mdtest_flags:
-    - "-C"
-    - "-E -X"
+    - "-C -G 27"
+    - "-E -X -G 27"
   depth: 2
   branching_factor: 2
   bytes: 4096


### PR DESCRIPTION
Test-tag: dm_large_dir dm_obj_large_posix dm_serial_large_posix
Skip-unit-tests: true
Skip-fault-injection-test: true

- when using mdtest to create and read-verify in separate phases, -G is
   needed to make sure the buffers are the same
- when using -E to read, use -X to verify
- misc cleanup

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>