### PR TITLE
Revert DAOS-9881 engine: disable transparent hugepages (#9544)

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -18,7 +18,6 @@
 #include <getopt.h>
 #include <errno.h>
 #include <execinfo.h>
-#include <sys/prctl.h>
 
 #include <daos/btree_class.h>
 #include <daos/common.h>
@@ -1157,17 +1156,6 @@ main(int argc, char **argv)
 	sigset_t	set;
 	int		sig;
 	int		rc;
-
-	/**
-	 * Disable transparent huge pages (THP) early before any allocations
-	 * see https://github.com/pmodels/argobots/issues/369 for more
-	 * information
-	 */
-	rc = prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
-	if (rc < 0) {
-		perror("failed to disable transparent hugepages");
-		exit(EXIT_FAILURE);
-	}
 
 	/** parse command line arguments */
 	rc = parse(argc, argv);


### PR DESCRIPTION
This reverts commit c6c7d0c3c27cf06ab870ed098644617cd2c917f0.
