### PR TITLE
DAOS-11493 rebuild: check tgts before print

### DIFF
--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1697,7 +1697,8 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver, uint32_t rebuild_gen
 			D_GOTO(free, rc);
 	}
 
-	rebuild_print_list_update(pool->sp_uuid, map_ver, rebuild_op, tgts);
+	if (tgts != NULL)
+		rebuild_print_list_update(pool->sp_uuid, map_ver, rebuild_op, tgts);
 
 	/* Insert the task into the queue by order to make sure the rebuild
 	 * task with smaller version are being executed first.


### PR DESCRIPTION
Check tgts NULL before print.

Signed-off-by: Di Wang <di.wang@intel.com>