### PR TITLE
DAOS-8722 dfuse: Improve dfuse readdir code.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -74,7 +74,7 @@ struct dfuse_readdir_entry {
 struct dfuse_obj_hdl {
 	/** pointer to dfs_t */
 	dfs_t                           *doh_dfs;
-	/** the DFS object handle */
+	/** the DFS object handle.  Not created for directories. */
 	dfs_obj_t                       *doh_obj;
 	/** the inode entry for the file */
 	struct dfuse_inode_entry        *doh_ie;

--- a/src/client/dfuse/ops/opendir.c
+++ b/src/client/dfuse/ops/opendir.c
@@ -22,11 +22,6 @@ dfuse_cb_opendir(fuse_req_t req, struct dfuse_inode_entry *ie, struct fuse_file_
 
 	dfuse_open_handle_init(oh, ie);
 
-	/** duplicate the file handle for the fuse handle */
-	rc = dfs_dup(ie->ie_dfs->dfs_ns, ie->ie_obj, fi->flags, &oh->doh_obj);
-	if (rc)
-		D_GOTO(err, rc);
-
 	fi_out.fh = (uint64_t)oh;
 
 #if HAVE_CACHE_READDIR
@@ -54,7 +49,6 @@ void
 dfuse_cb_releasedir(fuse_req_t req, struct dfuse_inode_entry *ino, struct fuse_file_info *fi)
 {
 	struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
-	int                   rc;
 
 	/* Perform the opposite of what the ioctl call does, always change the open handle count
 	 * but the inode only tracks number of open handles with non-zero ioctl counts
@@ -73,11 +67,7 @@ dfuse_cb_releasedir(fuse_req_t req, struct dfuse_inode_entry *ino, struct fuse_f
 		dfuse_cache_set_time(oh->doh_ie);
 	}
 
-	rc = dfs_release(oh->doh_obj);
-	if (rc == 0)
-		DFUSE_REPLY_ZERO(oh, req);
-	else
-		DFUSE_REPLY_ERR_RAW(oh, req, rc);
+	DFUSE_REPLY_ZERO(oh, req);
 	D_FREE(oh->doh_dre);
 	D_FREE(oh);
 };

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -10,7 +10,7 @@
 #include "daos_uns.h"
 
 /* Maximum number of dentries to read at one time. */
-#define READDIR_MAX_COUNT 1024
+#define READDIR_MAX_COUNT  1024
 
 /* Initial number of dentries to read when doing readdirplus */
 #define READDIR_PLUS_COUNT 26
@@ -18,32 +18,30 @@
 #define READDIR_BASE_COUNT 128
 
 /* Marker offset used to signify end-of-directory */
-#define READDIR_EOD (1LL << 63)
+#define READDIR_EOD        (1LL << 63)
 
 /* Offset of the first file, allow two entries for . and .. */
-#define OFFSET_BASE 2
+#define OFFSET_BASE        2
 
 struct iterate_data {
-	off_t			id_base_offset;
-	int			id_index;
-	struct dfuse_obj_hdl	 *id_oh;
+	off_t                 id_base_offset;
+	int                   id_index;
+	struct dfuse_obj_hdl *id_oh;
 };
 
 static int
 filler_cb(dfs_t *dfs, dfs_obj_t *dir, const char name[], void *arg)
 {
-	struct iterate_data		*idata = arg;
-	struct dfuse_readdir_entry	*dre;
+	struct iterate_data        *idata = arg;
+	struct dfuse_readdir_entry *dre;
 
 	dre = &idata->id_oh->doh_dre[idata->id_index];
 
-	DFUSE_TRA_DEBUG(idata->id_oh, "Adding at index %d offset %ld '%s'",
-			idata->id_index,
-			idata->id_base_offset + idata->id_index,
-			name);
+	DFUSE_TRA_DEBUG(idata->id_oh, "Adding at index %d offset %ld '%s'", idata->id_index,
+			idata->id_base_offset + idata->id_index, name);
 
 	strncpy(dre->dre_name, name, NAME_MAX);
-	dre->dre_offset = idata->id_base_offset + idata->id_index;
+	dre->dre_offset      = idata->id_base_offset + idata->id_index;
 	dre->dre_next_offset = idata->id_base_offset + idata->id_index + 1;
 	idata->id_index++;
 
@@ -51,27 +49,26 @@ filler_cb(dfs_t *dfs, dfs_obj_t *dir, const char name[], void *arg)
 }
 
 static int
-fetch_dir_entries(struct dfuse_obj_hdl *oh, off_t offset, int to_fetch,
-		  bool *eod)
+fetch_dir_entries(struct dfuse_obj_hdl *oh, off_t offset, int to_fetch, bool *eod)
 {
-	struct iterate_data	idata = {};
-	uint32_t		count = to_fetch;
-	int			rc;
+	struct iterate_data idata = {};
+	uint32_t            count = to_fetch;
+	int                 rc;
 
 	idata.id_base_offset = offset;
-	idata.id_oh = oh;
+	idata.id_oh          = oh;
 
 	DFUSE_TRA_DEBUG(oh, "Fetching new entries at offset %ld", offset);
 
-	rc = dfs_iterate(oh->doh_dfs, oh->doh_obj, &oh->doh_anchor, &count,
+	rc = dfs_iterate(oh->doh_dfs, oh->doh_ie->ie_obj, &oh->doh_anchor, &count,
 			 (NAME_MAX + 1) * count, filler_cb, &idata);
 
 	oh->doh_anchor_index += count;
-	oh->doh_dre_index = 0;
+	oh->doh_dre_index      = 0;
 	oh->doh_dre_last_index = count;
 
-	DFUSE_TRA_DEBUG(oh, "Added %d entries, anchor_index %d rc %d",
-			count, oh->doh_anchor_index, rc);
+	DFUSE_TRA_DEBUG(oh, "Added %d entries, anchor_index %d rc %d", count, oh->doh_anchor_index,
+			rc);
 
 	if (count) {
 		if (daos_anchor_is_eof(&oh->doh_anchor))
@@ -84,18 +81,13 @@ fetch_dir_entries(struct dfuse_obj_hdl *oh, off_t offset, int to_fetch,
 }
 
 static int
-create_entry(struct dfuse_projection_info *fs_handle,
-	     struct dfuse_inode_entry *parent,
-	     struct fuse_entry_param *entry,
-	     dfs_obj_t *obj,
-	     char *name,
-	     char *attr,
-	     daos_size_t attr_len,
-	     d_list_t **rlinkp)
+create_entry(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *parent,
+	     struct fuse_entry_param *entry, dfs_obj_t *obj, char *name, char *attr,
+	     daos_size_t attr_len, d_list_t **rlinkp)
 {
-	struct dfuse_inode_entry	*ie;
-	d_list_t			 *rlink;
-	int				 rc = 0;
+	struct dfuse_inode_entry *ie;
+	d_list_t                 *rlink;
+	int                       rc = 0;
 
 	D_ALLOC_PTR(ie);
 	if (!ie) {
@@ -105,7 +97,7 @@ create_entry(struct dfuse_projection_info *fs_handle,
 
 	DFUSE_TRA_UP(ie, parent, "inode");
 
-	ie->ie_obj = obj;
+	ie->ie_obj  = obj;
 	ie->ie_stat = entry->attr;
 
 	dfs_obj2id(ie->ie_obj, &ie->ie_oid);
@@ -119,34 +111,30 @@ create_entry(struct dfuse_projection_info *fs_handle,
 	}
 
 	ie->ie_parent = parent->ie_stat.st_ino;
-	ie->ie_dfs = parent->ie_dfs;
+	ie->ie_dfs    = parent->ie_dfs;
 
 	if (S_ISDIR(ie->ie_stat.st_mode) && attr_len) {
 		rc = check_for_uns_ep(fs_handle, ie, attr, attr_len);
 		if (rc != 0) {
-			DFUSE_TRA_WARNING(ie, "check_for_uns_ep() returned %d,"
-					" ignoring", rc);
+			DFUSE_TRA_WARNING(ie, "check_for_uns_ep() returned %d, ignoring", rc);
 			rc = 0;
 		}
 		entry->attr.st_mode = ie->ie_stat.st_mode;
-		entry->attr.st_ino = ie->ie_stat.st_ino;
-		ie->ie_root = (ie->ie_stat.st_ino == ie->ie_dfs->dfs_ino);
+		entry->attr.st_ino  = ie->ie_stat.st_ino;
+		ie->ie_root         = (ie->ie_stat.st_ino == ie->ie_dfs->dfs_ino);
 	}
 
 	entry->generation = 1;
-	entry->ino = entry->attr.st_ino;
+	entry->ino        = entry->attr.st_ino;
 
 	strncpy(ie->ie_name, name, NAME_MAX);
 	ie->ie_name[NAME_MAX] = '\0';
 	atomic_store_relaxed(&ie->ie_ref, 1);
 
-	DFUSE_TRA_DEBUG(ie, "Inserting inode %#lx mode 0%o",
-			entry->ino, ie->ie_stat.st_mode);
+	DFUSE_TRA_DEBUG(ie, "Inserting inode %#lx mode 0%o", entry->ino, ie->ie_stat.st_mode);
 
-	rlink = d_hash_rec_find_insert(&fs_handle->dpi_iet,
-				       &ie->ie_stat.st_ino,
-				       sizeof(ie->ie_stat.st_ino),
-				       &ie->ie_htl);
+	rlink = d_hash_rec_find_insert(&fs_handle->dpi_iet, &ie->ie_stat.st_ino,
+				       sizeof(ie->ie_stat.st_ino), &ie->ie_htl);
 
 	if (rlink != &ie->ie_htl) {
 		struct dfuse_inode_entry *inode;
@@ -160,9 +148,8 @@ create_entry(struct dfuse_projection_info *fs_handle,
 
 		/* Update the existing object with the new name/parent */
 
-		DFUSE_TRA_DEBUG(inode,
-				"Maybe updating parent inode %#lx dfs_ino %#lx",
-				entry->ino, ie->ie_dfs->dfs_ino);
+		DFUSE_TRA_DEBUG(inode, "Maybe updating parent inode %#lx dfs_ino %#lx", entry->ino,
+				ie->ie_dfs->dfs_ino);
 
 		/** update the chunk size and oclass of inode entry */
 		dfs_obj_copy_attr(inode->ie_obj, ie->ie_obj);
@@ -170,12 +157,9 @@ create_entry(struct dfuse_projection_info *fs_handle,
 		if (ie->ie_stat.st_ino == ie->ie_dfs->dfs_ino) {
 			DFUSE_TRA_DEBUG(inode, "Not updating parent");
 		} else {
-			rc = dfs_update_parent(inode->ie_obj, ie->ie_obj,
-					       ie->ie_name);
+			rc = dfs_update_parent(inode->ie_obj, ie->ie_obj, ie->ie_name);
 			if (rc != 0)
-				DFUSE_TRA_ERROR(inode,
-						"dfs_update_parent() failed %d",
-						rc);
+				DFUSE_TRA_ERROR(inode, "dfs_update_parent() failed %d", rc);
 		}
 		inode->ie_parent = ie->ie_parent;
 		strncpy(inode->ie_name, ie->ie_name, NAME_MAX + 1);
@@ -197,17 +181,16 @@ dfuse_readdir_reset(struct dfuse_obj_hdl *oh)
 {
 	memset(&oh->doh_anchor, 0, sizeof(oh->doh_anchor));
 	memset(oh->doh_dre, 0, sizeof(*oh->doh_dre) * READDIR_MAX_COUNT);
-	oh->doh_dre_index = 0;
+	oh->doh_dre_index      = 0;
 	oh->doh_dre_last_index = 0;
-	oh->doh_anchor_index = 0;
+	oh->doh_anchor_index   = 0;
 }
 
-#define FADP   fuse_add_direntry_plus
-#define FAD    fuse_add_direntry
+#define FADP fuse_add_direntry_plus
+#define FAD  fuse_add_direntry
 
 void
-dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh,
-		 size_t size, off_t offset, bool plus)
+dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh, size_t size, off_t offset, bool plus)
 {
 	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
 	char                         *reply_buff;
@@ -243,15 +226,13 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh,
 		dfuse_readdir_reset(oh);
 	}
 
-	DFUSE_TRA_DEBUG(oh, "plus %d offset %ld idx %d idx_offset %ld",
-			plus, offset, oh->doh_dre_index,
-			oh->doh_dre[oh->doh_dre_index].dre_offset);
+	DFUSE_TRA_DEBUG(oh, "plus %d offset %ld idx %d idx_offset %ld", plus, offset,
+			oh->doh_dre_index, oh->doh_dre[oh->doh_dre_index].dre_offset);
 
 	/* If there is an offset, and either there is no current offset, or it's
 	 * different then seek
 	 */
-	if (offset &&
-	    oh->doh_dre[oh->doh_dre_index].dre_offset != offset &&
+	if (offset && oh->doh_dre[oh->doh_dre_index].dre_offset != offset &&
 	    oh->doh_anchor_index + OFFSET_BASE != offset) {
 		uint32_t num;
 
@@ -263,18 +244,15 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh,
 		 * many entries. This is the telldir/seekdir use case.
 		 */
 
-		DFUSE_TRA_DEBUG(oh,
-				"Seeking from offset %ld(%d) to %ld (index %d)",
+		DFUSE_TRA_DEBUG(oh, "Seeking from offset %ld(%d) to %ld (index %d)",
 				oh->doh_dre[oh->doh_dre_index].dre_offset, oh->doh_anchor_index,
-				offset,	oh->doh_dre_index);
+				offset, oh->doh_dre_index);
 
 		dfuse_readdir_reset(oh);
 		num = (uint32_t)offset - OFFSET_BASE;
 		while (num) {
-			rc = dfs_iterate(oh->doh_dfs, oh->doh_obj,
-					 &oh->doh_anchor, &num,
-					 (NAME_MAX + 1) * num,
-					 NULL, NULL);
+			rc = dfs_iterate(oh->doh_dfs, oh->doh_ie->ie_obj, &oh->doh_anchor, &num,
+					 (NAME_MAX + 1) * num, NULL, NULL);
 			if (rc)
 				D_GOTO(out_reset, rc);
 
@@ -297,15 +275,14 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh,
 		large_fetch = false;
 
 	do {
-		int i;
+		int  i;
 		bool fetched = false;
 
 		if (oh->doh_dre_last_index == 0) {
 			uint32_t to_fetch;
-			bool eod = false;
+			bool     eod = false;
 
-			D_ASSERT(offset !=
-				oh->doh_dre[oh->doh_dre_index].dre_offset);
+			D_ASSERT(offset != oh->doh_dre[oh->doh_dre_index].dre_offset);
 
 			if (large_fetch)
 				to_fetch = READDIR_MAX_COUNT;
@@ -329,83 +306,65 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh,
 		DFUSE_TRA_DEBUG(oh, "processing offset %ld", offset);
 
 		/* Populate dir */
-		for (i = oh->doh_dre_index; i < oh->doh_dre_last_index ; i++) {
-			struct dfuse_readdir_entry	*dre = &oh->doh_dre[i];
-			struct stat			stbuf = {0};
-			daos_obj_id_t			oid;
-			dfs_obj_t			*obj;
-			size_t				written;
-			char				out[DUNS_MAX_XATTR_LEN];
-			char				*outp = &out[0];
-			daos_size_t			attr_len;
+		for (i = oh->doh_dre_index; i < oh->doh_dre_last_index; i++) {
+			struct dfuse_readdir_entry *dre   = &oh->doh_dre[i];
+			struct stat                 stbuf = {0};
+			daos_obj_id_t               oid;
+			dfs_obj_t                  *obj;
+			size_t                      written;
+			char                        out[DUNS_MAX_XATTR_LEN];
+			char                       *outp = &out[0];
+			daos_size_t                 attr_len;
 
 			attr_len = DUNS_MAX_XATTR_LEN;
 			D_ASSERT(dre->dre_offset != 0);
 
 			oh->doh_dre_index += 1;
 
-			DFUSE_TRA_DEBUG(oh, "Checking offset %ld next %ld '%s'",
-					dre->dre_offset,
-					dre->dre_next_offset,
-					dre->dre_name);
+			DFUSE_TRA_DEBUG(oh, "Checking offset %ld next %ld '%s'", dre->dre_offset,
+					dre->dre_next_offset, dre->dre_name);
 
 			if (plus)
-				rc = dfs_lookupx(oh->doh_dfs, oh->doh_obj,
-						 dre->dre_name,
-						 O_RDWR | O_NOFOLLOW, &obj,
-						 &stbuf.st_mode, &stbuf,
-						 1, &duns_xattr_name,
-						 (void **)&outp, &attr_len);
+				rc = dfs_lookupx(oh->doh_dfs, oh->doh_ie->ie_obj, dre->dre_name,
+						 O_RDWR | O_NOFOLLOW, &obj, &stbuf.st_mode, &stbuf,
+						 1, &duns_xattr_name, (void **)&outp, &attr_len);
 			else
-				rc = dfs_lookup_rel(oh->doh_dfs, oh->doh_obj,
-						    dre->dre_name,
-						    O_RDWR | O_NOFOLLOW,
-						    &obj, &stbuf.st_mode, NULL);
+				rc =
+				    dfs_lookup_rel(oh->doh_dfs, oh->doh_ie->ie_obj, dre->dre_name,
+						   O_RDWR | O_NOFOLLOW, &obj, &stbuf.st_mode, NULL);
 			if (rc == ENOENT) {
 				DFUSE_TRA_DEBUG(oh, "File does not exist");
 				continue;
 			} else if (rc != 0) {
-				DFUSE_TRA_DEBUG(oh, "Problem finding file %d",
-						rc);
+				DFUSE_TRA_DEBUG(oh, "Problem finding file %d", rc);
 				D_GOTO(reply, rc);
 			}
 
 			dfs_obj2id(obj, &oid);
 
-			dfuse_compute_inode(oh->doh_ie->ie_dfs,
-					    &oid, &stbuf.st_ino);
+			dfuse_compute_inode(oh->doh_ie->ie_dfs, &oid, &stbuf.st_ino);
 
 			if (plus) {
-				struct fuse_entry_param	entry = {0};
-				d_list_t *rlink;
+				struct fuse_entry_param entry = {0};
+				d_list_t               *rlink;
 
 				entry.attr = stbuf;
 
-				rc = create_entry(fs_handle,
-						  oh->doh_ie,
-						  &entry,
-						  obj,
-						  dre->dre_name,
-						  out,
-						  attr_len,
-						  &rlink);
+				rc = create_entry(fs_handle, oh->doh_ie, &entry, obj, dre->dre_name,
+						  out, attr_len, &rlink);
 				if (rc != 0)
 					D_GOTO(reply, rc);
 
-				written = FADP(req, &reply_buff[buff_offset],
-					       size - buff_offset,
-					       dre->dre_name, &entry,
-					       dre->dre_next_offset);
+				written = FADP(req, &reply_buff[buff_offset], size - buff_offset,
+					       dre->dre_name, &entry, dre->dre_next_offset);
 				if (written > size - buff_offset)
-					d_hash_rec_decref(&fs_handle->dpi_iet,
-							  rlink);
+					d_hash_rec_decref(&fs_handle->dpi_iet, rlink);
 
 			} else {
 				dfs_release(obj);
 
-				written = FAD(req, &reply_buff[buff_offset],
-					      size - buff_offset, dre->dre_name,
-					      &stbuf, dre->dre_next_offset);
+				written = FAD(req, &reply_buff[buff_offset], size - buff_offset,
+					      dre->dre_name, &stbuf, dre->dre_next_offset);
 			}
 			if (written > size - buff_offset) {
 				DFUSE_TRA_DEBUG(oh, "Buffer is full");
@@ -428,7 +387,7 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh,
 			}
 		}
 		if (oh->doh_dre_index == oh->doh_dre_last_index) {
-			oh->doh_dre_index = 0;
+			oh->doh_dre_index      = 0;
 			oh->doh_dre_last_index = 0;
 		}
 		if (fetched && !large_fetch)

--- a/utils/cq/daos_pylint.py
+++ b/utils/cq/daos_pylint.py
@@ -586,12 +586,16 @@ def main():
                 continue
             if line.startswith('@@ '):
                 parts = line.split(' ')
-                try:
-                    (post_start, post_len) = parts[2][1:].split(',')
-                except ValueError:
-                    print(f'Unable to split parts[2] ("{parts[2]}") from line "{line.rstrip()}" '
-                          'on line number {lineno}')
-                    raise
+                if parts[2] == '+1':
+                    post_start = 1
+                    post_len = 1
+                else:
+                    try:
+                        (post_start, post_len) = parts[2][1:].split(',')
+                    except ValueError:
+                        print(f'Unable to split parts[2] ("{parts[2]}") from line'
+                              ' "{line.rstrip()}" on line number {lineno}')
+                        raise
                 regions.add_region(int(post_start), int(post_len))
                 continue
         if file and regions:

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1779,41 +1779,38 @@ class posix_tests():
     @needs_dfuse
     def test_readdir_25(self):
         """Test reading a directory with 25 entries"""
-        self.readdir_test(25, test_all=True)
+        self.readdir_test(25)
 
-    # Works, but is very slow so needs to be run without debugging.
-    #@needs_dfuse
-    #def test_readdir_300(self):
-    #    self.readdir_test(300, test_all=False)
+    def test_readdir_300(self):
+        """Test reading a directory with 25 entries"""
+        self.readdir_test(300, test_all=True)
 
     def readdir_test(self, count, test_all=False):
         """Run a rudimentary readdir test"""
 
         wide_dir = tempfile.mkdtemp(dir=self.dfuse.dir)
-        if count == 0:
-            files = os.listdir(wide_dir)
-            assert len(files) == 0
-            return
         start = time.time()
         for idx in range(count):
-            with open(join(wide_dir, str(idx)), 'w'):
+            with open(join(wide_dir, f'file_{idx}'), 'w'):
                 pass
             if test_all:
                 files = os.listdir(wide_dir)
                 assert len(files) == idx + 1
         duration = time.time() - start
-        rate = count / duration
-        print('Created {} files in {:.1f} seconds rate {:.1f}'.format(count,
-                                                                      duration,
-                                                                      rate))
+        print(f'Created {count} files in {duration:.1f} seconds rate {count / duration:.1f}')
         print('Listing dir contents')
         start = time.time()
         files = os.listdir(wide_dir)
         duration = time.time() - start
-        rate = count / duration
-        print('Listed {} files in {:.1f} seconds rate {:.1f}'.format(count,
-                                                                     duration,
-                                                                     rate))
+        print(f'Listed {count} files in {duration:.1f} seconds rate {count / duration:.1f}')
+        print(files)
+        print(len(files))
+        assert len(files) == count
+        print('Listing dir contents again')
+        start = time.time()
+        files = os.listdir(wide_dir)
+        duration = time.time() - start
+        print(f'Listed {count} files in {duration:.1f} seconds rate {count / duration:.1f}')
         print(files)
         print(len(files))
         assert len(files) == count


### PR DESCRIPTION
Extend readdir testing.
Do not duplicate inode handle for open directories.

Test-tag: dfuse

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
