### PR TITLE
DAOS-10138 pool: Allow rank 0 to PS replica

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -173,10 +173,10 @@ int ds_pool_target_update_state(uuid_t pool_uuid, d_rank_list_t *ranks,
 				struct pool_target_addr_list *target_list,
 				pool_comp_state_t state);
 
-int ds_pool_svc_create(const uuid_t pool_uuid, int ntargets, const char *group,
-		       const d_rank_list_t *target_addrs, int ndomains, const uint32_t *domains,
-		       daos_prop_t *prop, d_rank_list_t **svc_addrs);
-int ds_pool_svc_destroy(const uuid_t pool_uuid, d_rank_list_t *svc_ranks);
+int ds_pool_svc_dist_create(const uuid_t pool_uuid, int ntargets, const char *group,
+			    const d_rank_list_t *target_addrs, int ndomains,
+			    const uint32_t *domains, daos_prop_t *prop, d_rank_list_t **svc_addrs);
+int ds_pool_svc_stop(uuid_t pool_uuid);
 int ds_pool_svc_rf_to_nreplicas(int svc_rf);
 int ds_pool_svc_rf_from_nreplicas(int nreplicas);
 

--- a/src/include/daos_srv/rdb.h
+++ b/src/include/daos_srv/rdb.h
@@ -116,10 +116,11 @@ struct rdb_storage;
 struct rdb_cbs;
 
 /** Database storage methods */
-int rdb_create(const char *path, const uuid_t uuid, size_t size, const d_rank_list_t *replicas,
-	       struct rdb_cbs *cbs, void *arg, struct rdb_storage **storagep);
-int rdb_open(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
-	     struct rdb_storage **storagep);
+int rdb_create(const char *path, const uuid_t uuid, uint64_t caller_term, size_t size,
+	       const d_rank_list_t *replicas, struct rdb_cbs *cbs, void *arg,
+	       struct rdb_storage **storagep);
+int rdb_open(const char *path, const uuid_t uuid, uint64_t caller_term, struct rdb_cbs *cbs,
+	     void *arg, struct rdb_storage **storagep);
 void rdb_close(struct rdb_storage *storage);
 int rdb_destroy(const char *path, const uuid_t uuid);
 
@@ -165,6 +166,7 @@ int rdb_get_leader(struct rdb *db, uint64_t *term, d_rank_t *rank);
 int rdb_get_ranks(struct rdb *db, d_rank_list_t **ranksp);
 int rdb_add_replicas(struct rdb *db, d_rank_list_t *replicas);
 int rdb_remove_replicas(struct rdb *db, d_rank_list_t *replicas);
+int rdb_ping(struct rdb *db, uint64_t caller_term);
 
 /**
  * Path (opaque)

--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -93,6 +93,8 @@ enum ds_rsvc_state {
 	DS_RSVC_DOWN		/**< down */
 };
 
+char *ds_rsvc_state_str(enum ds_rsvc_state state);
+
 /** Replicated service */
 struct ds_rsvc {
 	d_list_t		s_entry;	/* in rsvc_hash */
@@ -120,27 +122,26 @@ int ds_rsvc_start_nodb(enum ds_rsvc_class_id class, d_iov_t *id,
 		       uuid_t db_uuid);
 int ds_rsvc_stop_nodb(enum ds_rsvc_class_id class, d_iov_t *id);
 
-int ds_rsvc_start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid,
+int ds_rsvc_start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, uint64_t caller_term,
 		  bool create, size_t size, d_rank_list_t *replicas, void *arg);
-int ds_rsvc_stop(enum ds_rsvc_class_id class, d_iov_t *id, bool destroy);
+int ds_rsvc_stop(enum ds_rsvc_class_id class, d_iov_t *id, uint64_t caller_term, bool destroy);
 int ds_rsvc_stop_all(enum ds_rsvc_class_id class);
 int ds_rsvc_stop_leader(enum ds_rsvc_class_id class, d_iov_t *id,
 			struct rsvc_hint *hint);
-int ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
-		       const uuid_t dbid, const d_rank_list_t *ranks,
-		       bool create, bool bootstrap, size_t size);
-int ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
-		      const d_rank_list_t *ranks, d_rank_list_t *excluded,
-		      bool destroy);
+int ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id, const uuid_t dbid,
+		       const d_rank_list_t *ranks, uint64_t caller_term, bool create,
+		       bool bootstrap, size_t size);
+int ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id, const d_rank_list_t *ranks,
+		      d_rank_list_t *excluded, uint64_t caller_term, bool destroy);
+enum ds_rsvc_state ds_rsvc_get_state(struct ds_rsvc *svc);
+void ds_rsvc_set_state(struct ds_rsvc *svc, enum ds_rsvc_state state);
 int ds_rsvc_add_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks,
 			   size_t size);
 int ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
 			 d_rank_list_t *ranks, size_t size,
 			 struct rsvc_hint *hint);
-int ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks,
-			      bool stop);
-int ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
-			    d_rank_list_t *ranks, bool stop,
+int ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks);
+int ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, d_iov_t *id, d_rank_list_t *ranks,
 			    struct rsvc_hint *hint);
 int ds_rsvc_lookup(enum ds_rsvc_class_id class, d_iov_t *id,
 		   struct ds_rsvc **svc);

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -142,8 +142,7 @@ int ds_mgmt_tgt_map_update_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 void ds_mgmt_tgt_mark_hdlr(crt_rpc_t *rpc);
 
 /** srv_util.c */
-int ds_mgmt_group_update(crt_group_mod_op_t op, struct server_entry *servers,
-			 int nservers, uint32_t version);
+int ds_mgmt_group_update(struct server_entry *servers, int nservers, uint32_t version);
 void ds_mgmt_kill_rank(bool force);
 
 #endif /* __SRV_MGMT_INTERNAL_H__ */

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -157,8 +157,8 @@ ds_mgmt_pool_svc_create(uuid_t pool_uuid, int ntargets, const char *group, d_ran
 	D_DEBUG(DB_MGMT, DF_UUID": all tgts created, setting up pool "
 		"svc\n", DP_UUID(pool_uuid));
 
-	return ds_pool_svc_create(pool_uuid, ranks->rl_nr, group, ranks, domains_nr, domains, prop,
-				  svc_list);
+	return ds_pool_svc_dist_create(pool_uuid, ranks->rl_nr, group, ranks, domains_nr, domains,
+				       prop, svc_list);
 }
 
 int
@@ -242,7 +242,6 @@ ds_mgmt_destroy_pool(uuid_t pool_uuid, d_rank_list_t *svc_ranks)
 {
 	int		 rc;
 	d_rank_list_t	*ranks = NULL;
-	d_rank_list_t	*filtered_svc = NULL;
 
 	D_DEBUG(DB_MGMT, "Destroying pool "DF_UUID"\n", DP_UUID(pool_uuid));
 
@@ -259,38 +258,15 @@ ds_mgmt_destroy_pool(uuid_t pool_uuid, d_rank_list_t *svc_ranks)
 		goto out;
 	}
 
-	/* Destroy pool service. Send corpc only to svc_ranks found in ranks.
-	 * Control plane may not have been updated yet if any of svc_ranks
-	 * were recently excluded from the pool.
-	 */
-	rc = d_rank_list_dup(&filtered_svc, svc_ranks);
-	if (rc)
-		D_GOTO(free_ranks, rc = -DER_NOMEM);
-	d_rank_list_filter(ranks, filtered_svc, false /* exclude */);
-	if (!d_rank_list_identical(filtered_svc, svc_ranks)) {
-		D_DEBUG(DB_MGMT, DF_UUID": %u svc_ranks, but only %u found "
-			"in pool map\n", DP_UUID(pool_uuid),
-			svc_ranks->rl_nr, filtered_svc->rl_nr);
-	}
-
-	rc = ds_pool_svc_destroy(pool_uuid, filtered_svc);
-	if (rc != 0) {
-		D_ERROR("Failed to destroy pool service " DF_UUID ", "
-			DF_RC "\n", DP_UUID(pool_uuid), DP_RC(rc));
-		goto free_filtered;
-	}
-
 	rc = ds_mgmt_tgt_pool_destroy(pool_uuid, ranks);
 	if (rc != 0) {
 		D_ERROR("Destroying pool "DF_UUID" failed, " DF_RC ".\n",
 			DP_UUID(pool_uuid), DP_RC(rc));
-		goto free_filtered;
+		goto free_ranks;
 	}
 
 	D_DEBUG(DB_MGMT, "Destroying pool " DF_UUID " succeeded.\n",
 		DP_UUID(pool_uuid));
-free_filtered:
-	d_rank_list_free(filtered_svc);
 free_ranks:
 	d_rank_list_free(ranks);
 out:

--- a/src/mgmt/srv_system.c
+++ b/src/mgmt/srv_system.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -179,15 +179,9 @@ ds_mgmt_group_update_handler(struct mgmt_grp_up_in *in)
 	if (rc != 0 && rc != -DER_NOTLEADER)
 		goto out;
 
-	D_DEBUG(DB_MGMT, "setting %d servers in map version %u\n",
-		in->gui_n_servers, in->gui_map_version);
-	rc = ds_mgmt_group_update(CRT_GROUP_MOD_OP_REPLACE, in->gui_servers,
-				  in->gui_n_servers, in->gui_map_version);
+	rc = ds_mgmt_group_update(in->gui_servers, in->gui_n_servers, in->gui_map_version);
 	if (rc != 0)
 		goto out_svc;
-
-	D_DEBUG(DB_MGMT, "set %d servers in map version %u\n",
-		in->gui_n_servers, in->gui_map_version);
 
 	map_servers = dup_server_list(in->gui_servers, in->gui_n_servers);
 	if (map_servers == NULL) {

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -977,6 +977,13 @@ ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *td_req)
 	D_DEBUG(DB_MGMT, DF_UUID": ready to destroy targets\n",
 		DP_UUID(td_in->td_pool_uuid));
 
+	rc = ds_pool_svc_stop(td_in->td_pool_uuid);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to stop pool service replica: "DF_RC"\n",
+			DP_UUID(td_in->td_pool_uuid), DP_RC(rc));
+		goto out;
+	}
+
 	ds_pool_stop(td_in->td_pool_uuid);
 
 	/** generate path to the target directory */
@@ -1102,23 +1109,9 @@ int
 ds_mgmt_tgt_map_update_pre_forward(crt_rpc_t *rpc, void *arg)
 {
 	struct mgmt_tgt_map_update_in  *in = crt_req_get(rpc);
-	uint32_t			version;
-	int				rc;
 
-	rc = crt_group_version(NULL /* grp */, &version);
-	D_ASSERTF(rc == 0, "%d\n", rc);
-	D_DEBUG(DB_MGMT, "in=%u current=%u\n", in->tm_map_version, version);
-	if (in->tm_map_version <= version)
-		return 0;
-
-	rc = ds_mgmt_group_update(CRT_GROUP_MOD_OP_REPLACE,
-				  in->tm_servers.ca_arrays,
-				  in->tm_servers.ca_count, in->tm_map_version);
-	if (rc != 0)
-		return rc;
-
-	D_INFO("updated group: %u -> %u\n", version, in->tm_map_version);
-	return 0;
+	return ds_mgmt_group_update(in->tm_servers.ca_arrays, in->tm_servers.ca_count,
+				    in->tm_map_version);
 }
 
 void

--- a/src/pool/README.md
+++ b/src/pool/README.md
@@ -24,7 +24,7 @@ The top-level KVS stores the pool map, security attributes such as the UID, GID 
 
 #### Pool / Pool Service Creation
 
-Pool creation is driven entirely by the Management Service since it requires special privileges for steps related to allocation of storage and querying of fault domains. After formatting all the targets, the management module passes the control to the pool module by calling the`ds_pool_svc_create`, which initializes service replication on the selected subset of nodes for the combined Pool and Container Service. The Pool module now sends a `POOL_CREATE` request to the service leader which creates the service database; the list of targets and their fault domains are then converted into the initial version of the pool map and stored in the pool service, along with other initial pool metadata.
+Pool creation is driven entirely by the Management Service since it requires special privileges for steps related to allocation of storage and querying of fault domains. After formatting all the targets, the management module passes the control to the pool module by calling the`ds_pool_svc_dist_create`, which initializes service replication on the selected subset of nodes for the combined Pool and Container Service. The Pool module now sends a `POOL_CREATE` request to the service leader which creates the service database; the list of targets and their fault domains are then converted into the initial version of the pool map and stored in the pool service, along with other initial pool metadata.
 
 <a id="9.3.2"></a>
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -684,7 +684,6 @@ select_svc_ranks(int svc_rf, const d_rank_list_t *target_addrs, int ndomains,
 		 const uint32_t *domains, d_rank_list_t **ranksp)
 {
 	int			nreplicas = ds_pool_svc_rf_to_nreplicas(svc_rf);
-	int			i_rank_zero = -1;
 	int			selectable;
 	d_rank_list_t		*rnd_tgts;
 	d_rank_list_t		*ranks;
@@ -704,15 +703,6 @@ select_svc_ranks(int svc_rf, const d_rank_list_t *target_addrs, int ndomains,
 
 	/* Determine the number of selectable targets. */
 	selectable = rnd_tgts->rl_nr;
-	if (daos_rank_list_find((d_rank_list_t *)rnd_tgts, 0 /* rank */,
-				&i_rank_zero)) {
-		/*
-		 * Unless it is the only target available, we don't select rank
-		 * 0 for now to avoid losing orterun stdout.
-		 */
-		if (selectable > 1)
-			selectable -= 1 /* rank 0 */;
-	}
 
 	if (nreplicas > selectable)
 		nreplicas = selectable;
@@ -725,9 +715,6 @@ select_svc_ranks(int svc_rf, const d_rank_list_t *target_addrs, int ndomains,
 	for (i = 0; i < rnd_tgts->rl_nr; i++) {
 		if (j == ranks->rl_nr)
 			break;
-		if (i == i_rank_zero && selectable > 1)
-			/* This is rank 0 and it's not the only rank. */
-			continue;
 		D_DEBUG(DB_MD, "ranks[%d]: %u\n", j, rnd_tgts->rl_ranks[i]);
 		ranks->rl_ranks[j] = rnd_tgts->rl_ranks[i];
 		j++;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -61,6 +61,75 @@ struct pool_svc_events {
 	bool			pse_stop;
 };
 
+/* Pool service reconfiguration state */
+struct pool_svc_reconf {
+	int		psc_svc_rf;
+	bool		psc_force_notify;	/* for pool_svc_step_up_cb */
+	ABT_mutex	psc_mutex;		/* only for psc_cv */
+	ABT_cond	psc_cv;
+	bool		psc_in_progress;
+	bool		psc_canceled;
+};
+
+static int
+reconf_init(struct pool_svc_reconf *reconf)
+{
+	int rc;
+
+	rc = ABT_mutex_create(&reconf->psc_mutex);
+	if (rc != ABT_SUCCESS) {
+		return dss_abterr2der(rc);
+	}
+
+	rc = ABT_cond_create(&reconf->psc_cv);
+	if (rc != ABT_SUCCESS) {
+		ABT_mutex_free(&reconf->psc_mutex);
+		return dss_abterr2der(rc);
+	}
+
+	reconf->psc_svc_rf = -1;
+	reconf->psc_force_notify = false;
+	reconf->psc_in_progress = false;
+	reconf->psc_canceled = false;
+	return 0;
+}
+
+static void
+reconf_fini(struct pool_svc_reconf *reconf)
+{
+	ABT_cond_free(&reconf->psc_cv);
+	ABT_mutex_free(&reconf->psc_mutex);
+}
+
+static void
+reconf_begin(struct pool_svc_reconf *reconf)
+{
+	reconf->psc_in_progress = true;
+	reconf->psc_canceled = false;
+}
+
+static void
+reconf_end(struct pool_svc_reconf *reconf)
+{
+	reconf->psc_in_progress = false;
+	reconf->psc_canceled = false;
+}
+
+static void
+reconf_cancel_and_wait(struct pool_svc_reconf *reconf)
+{
+	/*
+	 * The CV requires a mutex. We don't otherwise need it for ULTs within
+	 * the same xstream.
+	 */
+	ABT_mutex_lock(reconf->psc_mutex);
+	if (reconf->psc_in_progress)
+		reconf->psc_canceled = true;
+	while (reconf->psc_in_progress)
+		ABT_cond_wait(reconf->psc_cv, reconf->psc_mutex);
+	ABT_mutex_unlock(reconf->psc_mutex);
+}
+
 /* Pool service */
 struct pool_svc {
 	struct ds_rsvc		ps_rsvc;
@@ -73,6 +142,7 @@ struct pool_svc {
 	struct ds_pool	       *ps_pool;
 	struct pool_svc_events	ps_events;
 	uint32_t		ps_global_version;
+	struct pool_svc_reconf	ps_reconf;
 };
 
 /* Pool service failed to start */
@@ -742,8 +812,8 @@ ds_pool_svc_dist_create(const uuid_t pool_uuid, int ntargets, const char *group,
 		D_GOTO(out, rc);
 
 	d_iov_set(&psid, (void *)pool_uuid, sizeof(uuid_t));
-	rc = ds_rsvc_dist_start(DS_RSVC_CLASS_POOL, &psid, pool_uuid, ranks, true /* create */,
-				true /* bootstrap */, ds_rsvc_get_md_cap());
+	rc = ds_rsvc_dist_start(DS_RSVC_CLASS_POOL, &psid, pool_uuid, ranks, RDB_NIL_TERM,
+				true /* create */, true /* bootstrap */, ds_rsvc_get_md_cap());
 	if (rc != 0)
 		D_GOTO(out_ranks, rc);
 
@@ -809,8 +879,8 @@ out_backoff_seq:
 	rsvc_client_fini(&client);
 out_creation:
 	if (rc != 0)
-		ds_rsvc_dist_stop(DS_RSVC_CLASS_POOL, &psid, ranks,
-				  NULL, true /* destroy */);
+		ds_rsvc_dist_stop(DS_RSVC_CLASS_POOL, &psid, ranks, NULL, RDB_NIL_TERM,
+				  true /* destroy */);
 out_ranks:
 	d_rank_list_free(ranks);
 out:
@@ -826,7 +896,7 @@ ds_pool_svc_stop(uuid_t pool_uuid)
 
 	d_iov_set(&id, pool_uuid, sizeof(uuid_t));
 
-	rc = ds_rsvc_stop(DS_RSVC_CLASS_POOL, &id, false /* destroy */);
+	rc = ds_rsvc_stop(DS_RSVC_CLASS_POOL, &id, RDB_NIL_TERM, false /* destroy */);
 	if (rc == -DER_ALREADY) {
 		D_DEBUG(DB_MD, DF_UUID": pool service replica already stopped\n",
 			DP_UUID(pool_uuid));
@@ -932,14 +1002,20 @@ pool_svc_alloc_cb(d_iov_t *id, struct ds_rsvc **rsvc)
 		goto err_events_mutex;
 	}
 
+	rc = reconf_init(&svc->ps_reconf);
+	if (rc != 0)
+		goto err_events_cv;
+
 	rc = ds_cont_svc_init(&svc->ps_cont_svc, svc->ps_uuid, 0 /* id */,
 			      &svc->ps_rsvc);
 	if (rc != 0)
-		goto err_events_cv;
+		goto err_reconf;
 
 	*rsvc = &svc->ps_rsvc;
 	return 0;
 
+err_reconf:
+	reconf_fini(&svc->ps_reconf);
 err_events_cv:
 	ABT_cond_free(&svc->ps_events.pse_cv);
 err_events_mutex:
@@ -1104,6 +1180,12 @@ events_handler(void *arg)
 	D_DEBUG(DB_MD, DF_UUID": stopping\n", DP_UUID(svc->ps_uuid));
 }
 
+static bool
+events_pending(struct pool_svc *svc)
+{
+	return !d_list_empty(&svc->ps_events.pse_queue);
+}
+
 static void
 ds_pool_crt_event_cb(d_rank_t rank, uint64_t incarnation, enum crt_event_source src,
 		     enum crt_event_type type, void *arg)
@@ -1190,6 +1272,7 @@ pool_svc_free_cb(struct ds_rsvc *rsvc)
 	struct pool_svc *svc = pool_svc_obj(rsvc);
 
 	ds_cont_svc_fini(&svc->ps_cont_svc);
+	reconf_fini(&svc->ps_reconf);
 	ABT_cond_free(&svc->ps_events.pse_cv);
 	ABT_mutex_free(&svc->ps_events.pse_mutex);
 	rdb_path_fini(&svc->ps_user);
@@ -1257,10 +1340,11 @@ static int
 read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf,
 			uint32_t *map_version, daos_prop_t **prop)
 {
-	struct rdb_tx	tx;
-	d_iov_t		value;
-	bool		version_exists = false;
-	int		rc;
+	struct rdb_tx		tx;
+	d_iov_t			value;
+	bool			version_exists = false;
+	struct daos_prop_entry *svc_rf_entry;
+	int			rc;
 
 	rc = rdb_tx_begin(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term, &tx);
 	if (rc != 0)
@@ -1329,9 +1413,18 @@ check_map:
 		D_DEBUG(DB_MD, DF_UUID": assuming 2.0\n", DP_UUID(svc->ps_uuid));
 
 	rc = pool_prop_read(&tx, svc, DAOS_PO_QUERY_PROP_ALL, prop);
-	if (rc != 0)
+	if (rc != 0) {
 		D_ERROR(DF_UUID": cannot get properties: "DF_RC"\n", DP_UUID(svc->ps_uuid),
 			DP_RC(rc));
+		goto out_lock;
+	}
+
+	svc_rf_entry = daos_prop_entry_get(*prop, DAOS_PROP_PO_SVC_REDUN_FAC);
+	D_ASSERT(svc_rf_entry != NULL);
+	if (daos_prop_is_set(svc_rf_entry))
+		svc->ps_reconf.psc_svc_rf = svc_rf_entry->dpe_val;
+	else
+		svc->ps_reconf.psc_svc_rf = -1;
 
 out_lock:
 	ABT_rwlock_unlock(svc->ps_lock);
@@ -1421,6 +1514,8 @@ pool_svc_check_node_status(struct pool_svc *svc)
 	return rc;
 }
 
+static void pool_svc_schedule_reconf(struct pool_svc *svc);
+
 static int
 pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 {
@@ -1473,6 +1568,13 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc != 0)
 		goto out;
 	events_initialized = true;
+
+	/*
+	 * Just in case the previous leader didn't finish the last series of
+	 * reconfigurations or the last MS notification.
+	 */
+	svc->ps_reconf.psc_force_notify = true;
+	pool_svc_schedule_reconf(svc);
 
 	rc = ds_pool_iv_prop_update(svc->ps_pool, prop);
 	if (rc) {
@@ -1532,6 +1634,8 @@ out:
 	return rc;
 }
 
+static void pool_svc_cancel_and_wait_reconf(struct pool_svc *svc);
+
 static void
 pool_svc_step_down_cb(struct ds_rsvc *rsvc)
 {
@@ -1542,6 +1646,7 @@ pool_svc_step_down_cb(struct ds_rsvc *rsvc)
 	ds_pool_iv_srv_hdl_invalidate(svc->ps_pool);
 
 	fini_events(svc);
+	pool_svc_cancel_and_wait_reconf(svc);
 	ds_cont_svc_step_down(svc->ps_cont_svc);
 	fini_svc_pool(svc);
 
@@ -1777,7 +1882,7 @@ start_one(uuid_t uuid, void *varg)
 	}
 
 	d_iov_set(&id, uuid, sizeof(uuid_t));
-	ds_rsvc_start(DS_RSVC_CLASS_POOL, &id, uuid, false /* create */, 0 /* size */,
+	ds_rsvc_start(DS_RSVC_CLASS_POOL, &id, uuid, RDB_NIL_TERM, false /* create */, 0 /* size */,
 		      NULL /* replicas */, NULL /* arg */);
 	return 0;
 }
@@ -2200,6 +2305,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 		if (rc == -DER_NONEXIST && global_ver < 2) {
 			rc = 0;
 			val = DAOS_PROP_PO_SVC_REDUN_FAC_DEFAULT;
+			prop->dpp_entries[idx].dpe_flags |= DAOS_PROP_ENTRY_NOT_SET;
 		} else if (rc != 0) {
 			return rc;
 		}
@@ -2315,7 +2421,7 @@ out_tx:
 	if (rc != 0)
 		D_GOTO(out_mutex, rc);
 
-	if (svc->ps_rsvc.s_state == DS_RSVC_UP_EMPTY) {
+	if (ds_rsvc_get_state(&svc->ps_rsvc) == DS_RSVC_UP_EMPTY) {
 		/*
 		 * The DB is no longer empty. Since the previous
 		 * pool_svc_step_up_cb() call didn't finish stepping up due to
@@ -2331,8 +2437,7 @@ out_tx:
 			rdb_resign(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term);
 			D_GOTO(out_mutex, rc);
 		}
-		svc->ps_rsvc.s_state = DS_RSVC_UP;
-		ABT_cond_broadcast(svc->ps_rsvc.s_state_cv);
+		ds_rsvc_set_state(&svc->ps_rsvc, DS_RSVC_UP);
 	}
 
 out_mutex:
@@ -5029,22 +5134,36 @@ out:
 }
 
 static void
-pool_svc_reconfigure_replicas(struct pool_svc *svc, int svc_rf, struct pool_map *map)
+pool_svc_reconf_ult(void *arg)
 {
-	d_rank_list_t	*current;
-	d_rank_list_t	*to_add;
-	d_rank_list_t	*to_remove;
-	d_rank_list_t	*new;
-	int              rc;
+	struct pool_svc		*svc = arg;
+	struct pool_svc_reconf	*reconf = &svc->ps_reconf;
+	d_rank_list_t		*current;
+	d_rank_list_t		*to_add;
+	d_rank_list_t		*to_remove;
+	d_rank_list_t		*new;
+	int			 rc;
+
+	D_DEBUG(DB_MD, DF_UUID": begin\n", DP_UUID(svc->ps_uuid));
+
+	/* When there are pending events, the pool map may be unstable. */
+	while (events_pending(svc)) {
+		dss_sleep(3000 /* ms */);
+		if (reconf->psc_canceled)
+			goto out;
+	}
 
 	rc = rdb_get_ranks(svc->ps_rsvc.s_db, &current);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to get pool service replica ranks: "DF_RC"\n",
 			DP_UUID(svc->ps_uuid), DP_RC(rc));
-		return;
+		goto out;
 	}
 
-	rc = ds_pool_plan_svc_reconfs(svc_rf, map, current, dss_self_rank(), &to_add, &to_remove);
+	ABT_rwlock_rdlock(svc->ps_pool->sp_lock);
+	rc = ds_pool_plan_svc_reconfs(reconf->psc_svc_rf, svc->ps_pool->sp_map, current,
+				      dss_self_rank(), &to_add, &to_remove);
+	ABT_rwlock_unlock(svc->ps_pool->sp_lock);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": cannot plan pool service reconfigurations: "DF_RC"\n",
 			DP_UUID(svc->ps_uuid), DP_RC(rc));
@@ -5052,7 +5171,8 @@ pool_svc_reconfigure_replicas(struct pool_svc *svc, int svc_rf, struct pool_map 
 	}
 
 	D_DEBUG(DB_MD, DF_UUID": svc_rf=%d current=%u to_add=%u to_remove=%u\n",
-		DP_UUID(svc->ps_uuid), svc_rf, current->rl_nr, to_add->rl_nr, to_remove->rl_nr);
+		DP_UUID(svc->ps_uuid), reconf->psc_svc_rf, current->rl_nr, to_add->rl_nr,
+		to_remove->rl_nr);
 
 	/*
 	 * Ignore the return values from the "add" and "remove" calls here. If
@@ -5064,66 +5184,116 @@ pool_svc_reconfigure_replicas(struct pool_svc *svc, int svc_rf, struct pool_map 
 	 */
 	if (to_add->rl_nr > 0)
 		ds_rsvc_add_replicas_s(&svc->ps_rsvc, to_add, ds_rsvc_get_md_cap());
+	if (reconf->psc_canceled)
+		goto out_to_add_remove;
 	if (to_add->rl_nr > to_remove->rl_nr)
 		to_remove->rl_nr = 0;
 	else
 		to_remove->rl_nr -= to_add->rl_nr;
-	if (to_remove->rl_nr > 0)
-		ds_rsvc_remove_replicas_s(&svc->ps_rsvc, to_remove, false /* stop */);
+	if (to_remove->rl_nr > 0) {
+		d_rank_list_t *tmp;
+
+		/*
+		 * Since the ds_rsvc_dist_stop part is likely to hit RPC
+		 * timeouts, after removing the replicas from the membership,
+		 * we notify the MS first, and then come back to
+		 * ds_rsvc_dist_stop.
+		 */
+		rc = d_rank_list_dup(&tmp, to_remove);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to duplicate to_remove: "DF_RC"\n",
+				DP_UUID(svc->ps_uuid), DP_RC(rc));
+			goto out_to_add_remove;
+		}
+		rc = rdb_remove_replicas(svc->ps_rsvc.s_db, tmp);
+		/* Delete from to_remove ranks that are not removed. */
+		d_rank_list_filter(tmp, to_remove, true /* exclude */);
+		d_rank_list_free(tmp);
+	}
 
 	if (rdb_get_ranks(svc->ps_rsvc.s_db, &new) == 0) {
 		d_rank_list_sort(current);
 		d_rank_list_sort(new);
 
-		if (!d_rank_list_identical(new, current)) {
+		if (reconf->psc_force_notify || !d_rank_list_identical(new, current)) {
 			/*
 			 * Send RAS event to control-plane over dRPC to indicate
 			 * change in pool service replicas.
 			 */
 			rc = ds_notify_pool_svc_update(&svc->ps_uuid, new);
-			if (rc != 0)
+			if (rc == 0)
+				reconf->psc_force_notify = false;
+			else
 				D_ERROR(DF_UUID": replica update notify failure: "DF_RC"\n",
 					DP_UUID(svc->ps_uuid), DP_RC(rc));
 		}
 
 		d_rank_list_free(new);
 	}
+	if (reconf->psc_canceled)
+		goto out_to_add_remove;
 
+	/* Ignore the return value of this ds_rsvc_dist_stop call. */
+	if (to_remove->rl_nr > 0)
+		ds_rsvc_dist_stop(svc->ps_rsvc.s_class, &svc->ps_rsvc.s_id, to_remove,
+				  NULL /* excluded */, svc->ps_rsvc.s_term, true /* destroy */);
+
+out_to_add_remove:
 	d_rank_list_free(to_remove);
 	d_rank_list_free(to_add);
 out_cur:
 	d_rank_list_free(current);
+out:
+	reconf_end(reconf);
+	ABT_cond_broadcast(reconf->psc_cv);
+	D_DEBUG(DB_MD, DF_UUID": end\n", DP_UUID(svc->ps_uuid));
 }
 
-static int
-get_svc_rf(struct rdb_tx *tx, struct pool_svc *svc)
+static void
+pool_svc_schedule_reconf(struct pool_svc *svc)
 {
-	uint32_t		global_version;
-	d_iov_t			value;
-	daos_prop_t	       *svc_rf_prop = NULL;
-	struct daos_prop_entry *svc_rf_entry;
+	struct pool_svc_reconf *reconf = &svc->ps_reconf;
+	enum ds_rsvc_state	state;
 	int			rc;
 
-	d_iov_set(&value, &global_version, sizeof(global_version));
-	rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_global_version, &value);
-	if (rc == -DER_NONEXIST)
-		global_version = 0;
-	else if (rc != 0)
-		return rc;
-	if (global_version < 2)
-		return -DER_NONEXIST;
+	D_DEBUG(DB_MD, DF_UUID": begin\n", DP_UUID(svc->ps_uuid));
 
-	rc = pool_prop_read(tx, svc, DAOS_PO_QUERY_PROP_SVC_REDUN_FAC, &svc_rf_prop);
-	if (rc != 0) {
-		daos_prop_free(svc_rf_prop);
-		return rc;
+	/*
+	 * Avoid scheduling new reconfigurations when the PS is stepping down
+	 * and has already called pool_svc_cancel_and_wait_reconf.
+	 */
+	state = ds_rsvc_get_state(&svc->ps_rsvc);
+	if (state == DS_RSVC_DRAINING) {
+		D_DEBUG(DB_MD, DF_UUID": end: service %s\n", DP_UUID(svc->ps_uuid),
+			ds_rsvc_state_str(state));
+		return;
 	}
-	svc_rf_entry = daos_prop_entry_get(svc_rf_prop, DAOS_PROP_PO_SVC_REDUN_FAC);
-	D_ASSERT(svc_rf_entry != NULL && daos_prop_is_set(svc_rf_entry));
-	rc = svc_rf_entry->dpe_val;
-	daos_prop_free(svc_rf_prop);
 
-	return rc;
+	reconf_cancel_and_wait(reconf);
+
+	/* Ended by pool_svc_reconf_ult. */
+	reconf_begin(reconf);
+
+	/*
+	 * An extra svc leader reference is not required, because
+	 * pool_svc_step_down_cb waits for this ULT to terminate.
+	 *
+	 * ULT tracking is achieved through svc->ps_reconf, not a ULT handle.
+	 */
+	rc = dss_ult_create(pool_svc_reconf_ult, svc, DSS_XS_SELF, 0, 0, NULL /* ult */);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to create reconfiguration ULT: "DF_RC"\n",
+			DP_UUID(svc->ps_uuid), DP_RC(rc));
+		reconf_end(reconf);
+	}
+
+	D_DEBUG(DB_MD, DF_UUID": end: "DF_RC"\n", DP_UUID(svc->ps_uuid), DP_RC(rc));
+}
+
+static void
+pool_svc_cancel_and_wait_reconf(struct pool_svc *svc)
+{
+	reconf_cancel_and_wait(&svc->ps_reconf);
 }
 
 static int pool_find_all_targets_by_addr(struct pool_map *map,
@@ -5162,7 +5332,6 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 			     struct pool_target_addr_list *inval_tgt_addrs)
 {
 	struct rdb_tx		tx;
-	uint64_t		svc_rf;
 	struct pool_map	       *map;
 	uint32_t		map_version_before;
 	uint32_t		map_version;
@@ -5178,14 +5347,6 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 	if (rc != 0)
 		goto out;
 	ABT_rwlock_wrlock(svc->ps_lock);
-
-	rc = get_svc_rf(&tx, svc);
-	if (rc == -DER_NONEXIST)
-		svc_rf = -1;
-	else if (rc >= 0)
-		svc_rf = rc;
-	else
-		goto out_lock;
 
 	/* Create a temporary pool map based on the last committed version. */
 	rc = read_map(&tx, &svc->ps_root, &map);
@@ -5266,7 +5427,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 
 	ds_rsvc_request_map_dist(&svc->ps_rsvc);
 
-	pool_svc_reconfigure_replicas(svc, svc_rf, map);
+	pool_svc_schedule_reconf(svc);
 
 out_map_buf:
 	pool_buf_free(map_buf);
@@ -5488,7 +5649,6 @@ pool_extend_map(struct rdb_tx *tx, struct pool_svc *svc, uint32_t nnodes,
 		uint32_t *domains, bool *updated_p,
 		uint32_t *map_version_p, struct rsvc_hint *hint)
 {
-	uint64_t		svc_rf;
 	struct pool_buf		*map_buf = NULL;
 	struct pool_map		*map = NULL;
 	uint32_t		map_version;
@@ -5497,14 +5657,6 @@ pool_extend_map(struct rdb_tx *tx, struct pool_svc *svc, uint32_t nnodes,
 	int			rc;
 
 	ntargets = nnodes * dss_tgt_nr;
-
-	rc = get_svc_rf(tx, svc);
-	if (rc == -DER_NONEXIST)
-		svc_rf = -1;
-	else if (rc >= 0)
-		svc_rf = rc;
-	else
-		return rc;
 
 	/* Create a temporary pool map based on the last committed version. */
 	rc = read_map(tx, &svc->ps_root, &map);
@@ -5554,7 +5706,7 @@ pool_extend_map(struct rdb_tx *tx, struct pool_svc *svc, uint32_t nnodes,
 
 	ds_rsvc_request_map_dist(&svc->ps_rsvc);
 
-	pool_svc_reconfigure_replicas(svc, svc_rf, map);
+	pool_svc_schedule_reconf(svc);
 
 out_map:
 	if (map_version_p != NULL) {
@@ -6680,8 +6832,7 @@ ds_pool_replicas_update_handler(crt_rpc_t *rpc)
 		break;
 
 	case POOL_REPLICAS_REMOVE:
-		rc = ds_rsvc_remove_replicas(DS_RSVC_CLASS_POOL, &id, ranks,
-					     true /* stop */, &out->pmo_hint);
+		rc = ds_rsvc_remove_replicas(DS_RSVC_CLASS_POOL, &id, ranks, &out->pmo_hint);
 		break;
 
 	default:

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -18,7 +18,8 @@
 #include "rdb_layout.h"
 
 static int rdb_open_internal(daos_handle_t pool, daos_handle_t mc, const uuid_t uuid,
-			     struct rdb_cbs *cbs, void *arg, struct rdb **dbp);
+			     uint64_t caller_term, struct rdb_cbs *cbs, void *arg,
+			     struct rdb **dbp);
 
 /**
  * Create an RDB replica at \a path with \a uuid, \a size, and \a replicas, and
@@ -26,6 +27,7 @@ static int rdb_open_internal(daos_handle_t pool, daos_handle_t mc, const uuid_t 
  *
  * \param[in]	path		replica path
  * \param[in]	uuid		database UUID
+ * \param[in]	caller_term	caller term if not RDB_NIL_TERM (see rdb_open)
  * \param[in]	size		replica size in bytes
  * \param[in]	replicas	list of replica ranks
  * \param[in]	cbs		callbacks (not copied)
@@ -33,8 +35,9 @@ static int rdb_open_internal(daos_handle_t pool, daos_handle_t mc, const uuid_t 
  * \param[out]	storagep	database storage
  */
 int
-rdb_create(const char *path, const uuid_t uuid, size_t size, const d_rank_list_t *replicas,
-	   struct rdb_cbs *cbs, void *arg, struct rdb_storage **storagep)
+rdb_create(const char *path, const uuid_t uuid, uint64_t caller_term, size_t size,
+	   const d_rank_list_t *replicas, struct rdb_cbs *cbs, void *arg,
+	   struct rdb_storage **storagep)
 {
 	daos_handle_t	pool;
 	daos_handle_t	mc;
@@ -43,8 +46,8 @@ rdb_create(const char *path, const uuid_t uuid, size_t size, const d_rank_list_t
 	struct rdb     *db;
 	int		rc;
 
-	D_DEBUG(DB_MD, DF_UUID": creating db %s with %u replicas\n",
-		DP_UUID(uuid), path, replicas == NULL ? 0 : replicas->rl_nr);
+	D_DEBUG(DB_MD, DF_UUID": creating db %s with %u replicas: caller_term="DF_X64"\n",
+		DP_UUID(uuid), path, replicas == NULL ? 0 : replicas->rl_nr, caller_term);
 
 	/*
 	 * Create and open a VOS pool. RDB pools specify VOS_POF_SMALL for
@@ -86,7 +89,7 @@ rdb_create(const char *path, const uuid_t uuid, size_t size, const d_rank_list_t
 	if (rc != 0)
 		goto out_mc_hdl;
 
-	rc = rdb_open_internal(pool, mc, uuid, cbs, arg, &db);
+	rc = rdb_open_internal(pool, mc, uuid, caller_term, cbs, arg, &db);
 	if (rc != 0)
 		goto out_mc_hdl;
 
@@ -224,8 +227,8 @@ rdb_lookup(const uuid_t uuid)
  * the caller shall not close in this case.
  */
 static int
-rdb_open_internal(daos_handle_t pool, daos_handle_t mc, const uuid_t uuid, struct rdb_cbs *cbs,
-		  void *arg, struct rdb **dbp)
+rdb_open_internal(daos_handle_t pool, daos_handle_t mc, const uuid_t uuid, uint64_t caller_term,
+		  struct rdb_cbs *cbs, void *arg, struct rdb **dbp)
 {
 	struct rdb	       *db;
 	int			rc;
@@ -309,7 +312,7 @@ rdb_open_internal(daos_handle_t pool, daos_handle_t mc, const uuid_t uuid, struc
 		SCM_TOTAL(&vps), SCM_FREE(&vps), SCM_SYS(&vps),
 		rdb_extra_sys[DAOS_MEDIA_SCM]);
 
-	rc = rdb_raft_open(db);
+	rc = rdb_raft_open(db, caller_term);
 	if (rc != 0)
 		goto err_kvss;
 
@@ -333,14 +336,22 @@ err:
 /**
  * Open an RDB replica at \a path.
  *
+ * If \a caller_term is not RDB_NIL_TERM, it shall be the term of the leader
+ * (of the same RDB) who is calling this function (usually via an RPC). This is
+ * used to perform the Raft term check/update so that an older leader doesn't
+ * interrupt with a newer leader.
+ *
  * \param[in]	path		replica path
  * \param[in]	uuid		database UUID
+ * \param[in]	caller_term	caller term if not RDB_NIL_TERM
  * \param[in]	cbs		callbacks (not copied)
  * \param[in]	arg		argument for cbs
  * \param[out]	storagep	database storage
+ *
+ * \retval	-DER_STALE	\a caller_term < the current term
  */
 int
-rdb_open(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
+rdb_open(const char *path, const uuid_t uuid, uint64_t caller_term, struct rdb_cbs *cbs, void *arg,
 	 struct rdb_storage **storagep)
 {
 	daos_handle_t	pool;
@@ -351,7 +362,8 @@ rdb_open(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 	struct rdb     *db;
 	int		rc;
 
-	D_DEBUG(DB_MD, DF_UUID": opening db %s\n", DP_UUID(uuid), path);
+	D_DEBUG(DB_MD, DF_UUID": opening db %s: caller_term="DF_X64"\n", DP_UUID(uuid), path,
+		caller_term);
 
 	/*
 	 * RDB pools specify VOS_POF_SMALL for basic system memory reservation
@@ -422,7 +434,7 @@ rdb_open(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 		goto err_mc;
 	}
 
-	rc = rdb_open_internal(pool, mc, uuid, cbs, arg, &db);
+	rc = rdb_open_internal(pool, mc, uuid, caller_term, cbs, arg, &db);
 	if (rc != 0)
 		goto err_mc;
 
@@ -650,6 +662,22 @@ int
 rdb_campaign(struct rdb *db)
 {
 	return rdb_raft_campaign(db);
+}
+
+/**
+ * Simulate a ping (i.e., an empty AE) from the leader of \a caller_term to \a
+ * db. This essentially checks if \a caller_term is stale, and if not, update
+ * the current term. See also rdb_open.
+ *
+ * \param[in]	db		database
+ * \param[in]	caller_term	caller term
+ *
+ * \retval -DER_STALE	\a caller_term < the current term
+ */
+int
+rdb_ping(struct rdb *db, uint64_t caller_term)
+{
+	return rdb_raft_ping(db, caller_term);
 }
 
 /**

--- a/src/rdb/rdb_internal.h
+++ b/src/rdb/rdb_internal.h
@@ -150,14 +150,14 @@ struct rdb_raft_node {
 	struct rdb_raft_is	dn_is;
 };
 
-int rdb_raft_init(daos_handle_t pool, daos_handle_t mc,
-		  const d_rank_list_t *replicas);
-int rdb_raft_open(struct rdb *db);
+int rdb_raft_init(daos_handle_t pool, daos_handle_t mc, const d_rank_list_t *replicas);
+int rdb_raft_open(struct rdb *db, uint64_t caller_term);
 int rdb_raft_start(struct rdb *db);
 void rdb_raft_stop(struct rdb *db);
 void rdb_raft_close(struct rdb *db);
 void rdb_raft_resign(struct rdb *db, uint64_t term);
 int rdb_raft_campaign(struct rdb *db);
+int rdb_raft_ping(struct rdb *db, uint64_t caller_term);
 int rdb_raft_verify_leadership(struct rdb *db);
 int rdb_raft_add_replica(struct rdb *db, d_rank_t rank);
 int rdb_raft_remove_replica(struct rdb *db, d_rank_t rank);

--- a/src/rdb/tests/README
+++ b/src/rdb/tests/README
@@ -3,10 +3,11 @@ Manual execution instructions:
 From the command line the tests are run with:
 
 ==== server: start on S server ranks:
+# specify all regular modules plus rdbt
 orterun -np <S> --hostfile <file_containing_server_hostnames> --map-by-node
  --enable-recovery -x LD_LIBRARY_PATH daos_server
  -o <builddir>/utils/config/examples/daos_server_unittests.yml
- start -d ./ -t 1 -m vos,rdb,rsvc,mgmt,rdbt
+ start -d ./ -t 1 -m vos,rdb,rsvc,security,mgmt,dtx,pool,cont,obj,rebuild,rdbt
 
 ==== agent:
 daos_agent --config-path=<builddir>/utils/config/daos_agent.yml
@@ -23,7 +24,7 @@ rdbt init --group=daos_server --uuid <uuid> --replicas=<N>
 
 # wait a short number of seconds for RDB initialization, then:
 # create KV stores in the initialized RDB on N replicas
-rdbt create --group=daos_server -replicas=<N> --nranks=<S>
+rdbt create --group=daos_server --replicas=<N> --nranks=<S>
 
 # run multi-replica tests
 rdbt test-multi --group=daos_server --replicas=<N> --nranks=<S>

--- a/src/rdb/tests/rdb_test.c
+++ b/src/rdb/tests/rdb_test.c
@@ -34,8 +34,6 @@ rdbt_svc_obj(struct ds_rsvc *rsvc)
 	return container_of(rsvc, struct rdbt_svc, rt_rsvc);
 }
 
-#define ID_OK(id) ioveq((id), &test_svc_id)
-
 #define MUST(call)							\
 do {									\
 	int _rc = call;							\
@@ -62,8 +60,7 @@ ioveq(const d_iov_t *iov1, const d_iov_t *iov2)
 static int
 test_svc_name_cb(d_iov_t *id, char **name)
 {
-	ID_OK(id);
-	D_STRNDUP(*name, test_svc_name, strlen(test_svc_name));
+	D_STRNDUP(*name, id->iov_buf, id->iov_len - 1);
 	D_ASSERT(*name != NULL);
 	return 0;
 }
@@ -73,8 +70,7 @@ test_svc_locate_cb(d_iov_t *id, char **path)
 {
 	int	rc;
 
-	ID_OK(id);
-	rc = asprintf(path, "%s/rdbt-%s", dss_storage_path, test_svc_name);
+	rc = asprintf(path, "%s/rdbt-%s", dss_storage_path, (char *)id->iov_buf);
 	D_ASSERTF(rc > 0, "%d\n", rc);
 	D_ASSERT(*path != NULL);
 	return 0;
@@ -85,10 +81,14 @@ test_svc_alloc_cb(d_iov_t *id, struct ds_rsvc **svcp)
 {
 	struct rdbt_svc	       *svc;
 
-	ID_OK(id);
 	D_ALLOC_PTR(svc);
 	D_ASSERT(svc != NULL);
-	svc->rt_rsvc.s_id = test_svc_id;
+
+	D_ALLOC(svc->rt_rsvc.s_id.iov_buf, id->iov_len);
+	D_ASSERT(svc->rt_rsvc.s_id.iov_buf != NULL);
+	memcpy(svc->rt_rsvc.s_id.iov_buf, id->iov_buf, id->iov_len);
+	svc->rt_rsvc.s_id.iov_buf_len = id->iov_len;
+	svc->rt_rsvc.s_id.iov_len = id->iov_len;
 
 	MUST(rdb_path_init(&svc->rt_root_kvs_path));
 	MUST(rdb_path_push(&svc->rt_root_kvs_path, &rdb_path_root_key));
@@ -108,6 +108,7 @@ test_svc_free_cb(struct ds_rsvc *rsvc)
 	svc = rdbt_svc_obj(rsvc);
 	rdb_path_fini(&svc->rt_kvs1_path);
 	rdb_path_fini(&svc->rt_root_kvs_path);
+	D_FREE(svc->rt_rsvc.s_id.iov_buf);
 	D_FREE(svc);
 }
 
@@ -259,6 +260,39 @@ rdbt_test_path(void)
 
 	D_WARN("fini rdb path\n");
 	rdb_path_fini(&path);
+}
+
+static void
+rdbt_test_rsvc(void)
+{
+	char	       *svc_name = "tmp";
+	d_iov_t		svc_id;
+	uuid_t		uuid;
+	int		rc;
+
+	d_iov_set(&svc_id, svc_name, strlen(svc_name) + 1);
+	uuid_generate(uuid);
+
+	/*
+	 * A leader of an older term can't destroy a replica created by a
+	 * leader with a newer term.
+	 */
+	MUST(ds_rsvc_start(DS_RSVC_CLASS_TEST, &svc_id, uuid, 2 /* term */, true /* create */,
+			   DB_CAP, NULL /* replicas */, NULL /* arg */));
+	rc = ds_rsvc_stop(DS_RSVC_CLASS_TEST, &svc_id, 1 /* term */, true /* destroy */);
+	D_ASSERTF(rc == -DER_STALE, DF_RC"\n", DP_RC(rc));
+
+	/*
+	 * A leader of an older term can't destroy a replica touched by a
+	 * leader with a newer term.
+	 */
+	rc = ds_rsvc_start(DS_RSVC_CLASS_TEST, &svc_id, uuid, 3 /* term */, true /* create */,
+			   DB_CAP, NULL /* replicas */, NULL /* arg */);
+	D_ASSERTF(rc == -DER_ALREADY, DF_RC"\n", DP_RC(rc));
+	rc = ds_rsvc_stop(DS_RSVC_CLASS_TEST, &svc_id, 2 /* term */, true /* destroy */);
+	D_ASSERTF(rc == -DER_STALE, DF_RC"\n", DP_RC(rc));
+
+	MUST(ds_rsvc_stop(DS_RSVC_CLASS_TEST, &svc_id, 3 /* term */, true /* destroy */));
 }
 
 struct iterate_cb_arg {
@@ -606,9 +640,8 @@ rdbt_init_handler(crt_rpc_t *rpc)
 	for (ri = 0; ri < ranks->rl_nr; ri++)
 		D_WARN("ranks[%u]=%u\n", ri, ranks->rl_ranks[ri]);
 
-	MUST(ds_rsvc_dist_start(DS_RSVC_CLASS_TEST, &test_svc_id, in->tii_uuid,
-				ranks, true /* create */, true /* bootstrap */,
-				DB_CAP));
+	MUST(ds_rsvc_dist_start(DS_RSVC_CLASS_TEST, &test_svc_id, in->tii_uuid, ranks, RDB_NIL_TERM,
+				true /* create */, true /* bootstrap */, DB_CAP));
 	crt_reply_send(rpc);
 }
 
@@ -629,8 +662,7 @@ rdbt_fini_handler(crt_rpc_t *rpc)
 	for (ri = 0; ri < ranks->rl_nr; ri++)
 		D_WARN("ranks[%u]=%u\n", ri, ranks->rl_ranks[ri]);
 
-	MUST(ds_rsvc_dist_stop(DS_RSVC_CLASS_TEST, &test_svc_id, ranks, NULL,
-			       true));
+	MUST(ds_rsvc_dist_stop(DS_RSVC_CLASS_TEST, &test_svc_id, ranks, NULL, RDB_NIL_TERM, true));
 	crt_reply_send(rpc);
 }
 
@@ -698,6 +730,7 @@ rdbt_test_handler(crt_rpc_t *rpc)
 	       rdbt_membership_opname(in->tti_memb_op));
 	rdbt_test_util();
 	rdbt_test_path();
+	rdbt_test_rsvc();
 	rc = rdbt_test_tx(in->tti_update, in->tti_memb_op, in->tti_key,
 			  in->tti_val, &out->tto_val, &out->tto_hint);
 	out->tto_rc = rc;
@@ -760,8 +793,7 @@ rdbt_replicas_remove_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		goto out;
 
-	rc = ds_rsvc_remove_replicas(DS_RSVC_CLASS_TEST, &test_svc_id, ranks,
-				     true /* stop */, &out->rtmo_hint);
+	rc = ds_rsvc_remove_replicas(DS_RSVC_CLASS_TEST, &test_svc_id, ranks, &out->rtmo_hint);
 	out->rtmo_failed = ranks;
 
 out:

--- a/src/rsvc/rpc.h
+++ b/src/rsvc/rpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -23,7 +23,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_RSVC_VERSION 2
+#define DAOS_RSVC_VERSION 3
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
@@ -54,6 +54,7 @@ extern struct crt_proto_format rsvc_proto_fmt;
 	((uint32_t)		(sai_class)		CRT_VAR) \
 	((uint32_t)		(sai_flags)		CRT_VAR) \
 	((uint64_t)		(sai_size)		CRT_VAR) \
+	((uint64_t)		(sai_term)		CRT_VAR) \
 	((d_rank_list_t)	(sai_ranks)		CRT_PTR)
 
 #define DAOS_OSEQ_RSVC_START /* output fields (rc: err count) */ \
@@ -66,7 +67,8 @@ CRT_RPC_DECLARE(rsvc_start, DAOS_ISEQ_RSVC_START, DAOS_OSEQ_RSVC_START)
 #define DAOS_ISEQ_RSVC_STOP /* input fields */			 \
 	((d_iov_t)		(soi_svc_id)		CRT_VAR) \
 	((uint32_t)		(soi_class)		CRT_VAR) \
-	((uint32_t)		(soi_flags)		CRT_VAR)
+	((uint32_t)		(soi_flags)		CRT_VAR) \
+	((uint64_t)		(soi_term)		CRT_VAR)
 
 #define DAOS_OSEQ_RSVC_STOP /* output fields */			 \
 	((int32_t)		(soo_rc)		CRT_VAR)

--- a/src/tests/ftest/pool/svc.yaml
+++ b/src/tests/ftest/pool/svc.yaml
@@ -15,9 +15,9 @@ pool:
   pool_query_timeout: 30
 svc_params_mux: !mux
   svc_params_none:
-    svc_params: [None, 4]
+    svc_params: [None, 5]
   svc_params_0:
-    svc_params: [0, 4]
+    svc_params: [0, 5]
   svc_params_1:
     svc_params: [1, 1]
   svc_params_2:
@@ -27,6 +27,6 @@ svc_params_mux: !mux
   svc_params_4:
     svc_params: [4, 3]
   svc_params_5:
-    svc_params: [5, 4]
+    svc_params: [5, 5]
   svc_params_6:
     svc_params: [6, 0]


### PR DESCRIPTION
Since the tests have adopted 3-replica MSs, we can try removing the
historical no-rank-0 rule when selecting the initial PS ranks.

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true