### PR TITLE
DAOS-11204 dfs: Resample file stat after changing size.

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -743,8 +743,8 @@ get_num_entries(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
 }
 
 static int
-entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
-	   size_t len, struct dfs_obj *obj, struct stat *stbuf, uint64_t *obj_hlc)
+entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, size_t len,
+	   struct dfs_obj *obj, bool get_size, struct stat *stbuf, uint64_t *obj_hlc)
 {
 	struct dfs_entry	entry = {0};
 	bool			exists;
@@ -782,6 +782,16 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 	case S_IFREG:
 	{
 		daos_array_stbuf_t	array_stbuf = {0};
+
+		stbuf->st_blksize = entry.chunk_size ? entry.chunk_size : dfs->attr.da_chunk_size;
+
+		/** don't stat the array and use the entry mtime */
+		if (!get_size) {
+			stbuf->st_mtim.tv_sec = entry.mtime;
+			stbuf->st_mtim.tv_nsec = entry.mtime_nano;
+			size = 0;
+			break;
+		}
 
 		if (obj) {
 			rc = daos_array_stat(obj->oh, th, &array_stbuf, NULL);
@@ -856,7 +866,6 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 		 * sparse files or file metadata or xattributes.
 		 */
 		stbuf->st_blocks = (size + (1 << 9) - 1) >> 9;
-		stbuf->st_blksize = entry.chunk_size ? entry.chunk_size : dfs->attr.da_chunk_size;
 		break;
 	}
 	case S_IFLNK:
@@ -4319,7 +4328,7 @@ dfs_stat(dfs_t *dfs, dfs_obj_t *parent, const char *name, struct stat *stbuf)
 		oh = parent->oh;
 	}
 
-	return entry_stat(dfs, DAOS_TX_NONE, oh, name, len, NULL, stbuf, NULL);
+	return entry_stat(dfs, DAOS_TX_NONE, oh, name, len, NULL, true, stbuf, NULL);
 }
 
 int
@@ -4338,7 +4347,8 @@ dfs_ostat(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf)
 	if (rc)
 		return daos_der2errno(rc);
 
-	rc = entry_stat(dfs, DAOS_TX_NONE, oh, obj->name, strlen(obj->name), obj, stbuf, NULL);
+	rc = entry_stat(dfs, DAOS_TX_NONE, oh, obj->name, strlen(obj->name), obj, true, stbuf,
+			NULL);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -4684,6 +4694,7 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	daos_iod_t		iod;
 	daos_recx_t		recx[8];
 	bool			set_size = false;
+	bool			set_mtime = false;
 	int			i = 0;
 	size_t			len;
 	int			rc;
@@ -4717,10 +4728,14 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 
 	len = strlen(obj->name);
 
-	/* Fetch the remote entry first so we can check the oid, then keep
-	 * a track locally of what has been updated
+	/*
+	 * Fetch the remote entry first so we can check the oid, then keep track locally of what has
+	 * been updated. If we are setting the file size, there is no need to query it.
 	 */
-	rc = entry_stat(dfs, th, oh, obj->name, len, obj, &rstat, &obj_hlc);
+	if (flags & DFS_SET_ATTR_SIZE)
+		rc = entry_stat(dfs, th, oh, obj->name, len, obj, false, &rstat, &obj_hlc);
+	else
+		rc = entry_stat(dfs, th, oh, obj->name, len, obj, true, &rstat, &obj_hlc);
 	if (rc)
 		D_GOTO(out_obj, rc);
 
@@ -4759,6 +4774,7 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		recx[i].rx_nr = sizeof(uint64_t);
 		i++;
 
+		set_mtime = true;
 		flags &= ~DFS_SET_ATTR_MTIME;
 		rstat.st_mtim.tv_sec = stbuf->st_mtim.tv_sec;
 		rstat.st_mtim.tv_nsec = stbuf->st_mtim.tv_nsec;
@@ -4802,7 +4818,26 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		rc = daos_array_set_size(obj->oh, th, stbuf->st_size, NULL);
 		if (rc)
 			D_GOTO(out_obj, rc = daos_der2errno(rc));
+
+		/** update the returned stat buf size with the new set size */
+		rstat.st_blocks = (stbuf->st_size + (1 << 9) - 1) >> 9;
 		rstat.st_size = stbuf->st_size;
+
+		/* mtime needs to be updated too only if mtime was not explicitly set */
+		if (!set_mtime) {
+			daos_array_stbuf_t	array_stbuf = {0};
+
+			/** TODO - need an array API to just stat the max epoch without size */
+			rc = daos_array_stat(obj->oh, th, &array_stbuf, NULL);
+			if (rc)
+				D_GOTO(out_obj, rc = daos_der2errno(rc));
+
+			rc = crt_hlc2timespec(array_stbuf.st_max_epoch, &rstat.st_mtim);
+			if (rc) {
+				D_ERROR("crt_hlc2timespec() failed "DF_RC"\n", DP_RC(rc));
+				D_GOTO(out_obj, rc = daos_der2errno(rc));
+			}
+		}
 	}
 
 	iod.iod_nr = i;

--- a/src/tests/ftest/container/multiple_delete.py
+++ b/src/tests/ftest/container/multiple_delete.py
@@ -47,7 +47,7 @@ class MultipleContainerDelete(IorTestBase):
             self.run_ior_with_pool(create_cont=False)
             self.container.destroy()
             scm_fs, ssd_fs = self.get_pool_space()
-            out.append("iter = {}, scm = {}, ssd = {}".format(i+1, scm_fs, ssd_fs))
+            out.append("iter = {}, scm = {}, ssd = {}".format(i + 1, scm_fs, ssd_fs))
 
         self.log.info("Initial Free Space")
         self.log.info("SCM = %d, NVMe = %d", initial_scm_fs, initial_ssd_fs)

--- a/src/tests/ftest/daos_test/dfuse.py
+++ b/src/tests/ftest/daos_test/dfuse.py
@@ -77,11 +77,7 @@ class DaosCoreTestDfuse(DfuseTestBase):
 
         intercept = self.params.get('use_intercept', '/run/intercept/*', default=False)
 
-        cmd = [self.daos_test, '--test-dir', mount_dir, '--io']
-
-        # Metadata tests don't work with caching enabled, see DAOS-11204
-        if intercept or cache_mode in ('nocache', 'native'):
-            cmd.append('--metadata')
+        cmd = [self.daos_test, '--test-dir', mount_dir, '--io', '--metadata']
 
         if intercept:
             remote_env = OrderedDict()

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1369,11 +1369,21 @@ dfs_test_mtime(void **state)
 	/** truncate the file */
 	rc = dfs_punch(dfs_mt, file, 0, DFS_MAX_FSIZE);
 	assert_int_equal(rc, 0);
-
 	memset(&stbuf, 0, sizeof(stbuf));
 	rc = dfs_ostat(dfs_mt, file, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_size, 0);
+	assert_true(check_ts(prev_ts, stbuf.st_mtim));
+	prev_ts.tv_sec = stbuf.st_mtim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
+
+	/** set size on file with dfs_osetattr and stat at same time */
+	memset(&stbuf, 0, sizeof(stbuf));
+	stbuf.st_size = 1024;
+	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_SIZE);
+	assert_int_equal(rc, 0);
+	assert_int_equal(stbuf.st_size, 1024);
+	/** check the mtime was updated with the setattr */
 	assert_true(check_ts(prev_ts, stbuf.st_mtim));
 
 	struct tm	tm = {0};


### PR DESCRIPTION
Test-tag: pr dfuse_unit
    
Improve dfs_setattr to re-sample mtime on file size changes.  Update tests
to enable test existing which checks for this.
    
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
Co-authored-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>