### PR TITLE
DAOS-11505 vos: Update durable format version on pool upgrade (#10174)

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -291,13 +291,15 @@ int
 vos_pool_open(const char *path, uuid_t uuid, unsigned int flags,
 	      daos_handle_t *poh);
 
-/** Enable any version specific features on the pool
+/** Upgrade the vos pool version
  *
- * \param poh	[IN]	Container open handle
- * \param feats	[IN]	Features to enable
+ * \param poh		[IN]	Container open handle
+ * \param version	[IN]	pool version
+ *
+ * \return	0 on success, error otherwise
  */
-void
-vos_pool_features_set(daos_handle_t poh, uint64_t feats);
+int
+vos_pool_upgrade(daos_handle_t poh, uint32_t version);
 
 /**
  * Extended vos_pool_open() with an additional 'metrics' parameter to VOS telemetry.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -17,6 +17,8 @@
 
 #define VOS_SUB_OP_MAX	((uint16_t)-2)
 
+#define VOS_POOL_DF_2_2 24
+
 struct dtx_rsrvd_uint {
 	void			*dru_scm;
 	d_list_t		dru_nvme;
@@ -259,7 +261,7 @@ enum {
 
 enum {
 	/** Aggregation optimization is enabled for this pool */
-	VOS_POOL_FEAT_AGG_OPT	= (1 << 0),
+	VOS_POOL_FEAT_AGG_OPT = (1ULL << 0),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1467,9 +1467,6 @@ migrate_get_cont_child(struct migrate_pool_tls *tls, uuid_t cont_uuid,
 		}
 	}
 
-	if (tls->mpt_global_version >= 1)
-		vos_pool_features_set(cont_child->sc_pool->spc_hdl, VOS_POOL_FEAT_AGG_OPT);
-
 	*cont_p = cont_child;
 	return rc;
 }

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1471,8 +1471,7 @@ update_vos_prop_on_targets(void *in)
 	struct ds_pool			*pool = (struct ds_pool *)in;
 	struct ds_pool_child		*child = NULL;
 	struct policy_desc_t		policy_desc = {0};
-	int				ret = 0;
-	uint64_t			features = 0;
+	int                              ret         = 0;
 
 	child = ds_pool_child_lookup(pool->sp_uuid);
 	if (child == NULL)
@@ -1481,9 +1480,11 @@ update_vos_prop_on_targets(void *in)
 	policy_desc = pool->sp_policy_desc;
 	ret = vos_pool_ctl(child->spc_hdl, VOS_PO_CTL_SET_POLICY, &policy_desc);
 
-	if (pool->sp_global_version >= 1)
-		features = VOS_POOL_FEAT_AGG_OPT;
-	vos_pool_features_set(child->spc_hdl, features);
+	if (ret == 0 && pool->sp_global_version >= 1) {
+		/** If necessary, upgrade the vos pool format */
+		ret = vos_pool_upgrade(child->spc_hdl, VOS_POOL_DF_2_2);
+	}
+
 	ds_pool_child_put(child);
 
 	return ret;

--- a/src/rdb/raft_tests/raft_tests.py
+++ b/src/rdb/raft_tests/raft_tests.py
@@ -18,7 +18,7 @@ import json
 #pylint: disable=C0325
 
 TEST_NOT_RUN = -1
-DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'raft')
+DIR = os.path.join(os.path.dirname(os.path.relpath(os.path.dirname(__file__))), 'raft')
 
 def number_of_failures():
     """
@@ -31,15 +31,16 @@ def number_of_failures():
     json_file = ".build_vars.json"
     path = os.path.join("build", DIR, "src")
     if os.path.exists(json_file):
-        ofh = open(json_file, "r")
-        conf = json.load(ofh)
-        ofh.close()
+        with open(json_file, "r") as ofh:
+            conf = json.load(ofh)
+        print(f"DIR={DIR}")
         path = os.path.join(conf["BUILD_DIR"], DIR, "src")
+    print(f"path={path}")
     if not os.path.exists(path):
         try:
             res = subprocess.check_output(['/usr/bin/make', '-C', DIR, 'tests'])
-        except Exception as e:
-            print("Building Raft Tests failed due to\n{}".format(e))
+        except subprocess.CalledProcessError as error:
+            print(f"Building Raft Tests failed due to{error}\n")
             return TEST_NOT_RUN
     else:
         os.chdir(path)
@@ -47,7 +48,7 @@ def number_of_failures():
 
     for line in res.split('\n'):
         if line.startswith("not ok"):
-            line = "FAIL: {}".format(line)
+            line = f"FAIL: {line}"
             failures += 1
         elif line.startswith("ok"):
             successes += 1
@@ -68,7 +69,7 @@ def main():
     elif failures == TEST_NOT_RUN:
         print("Raft Tests did not run")
     else:
-        print("Raft Tests had {} failures".format(failures))
+        print(f"Raft Tests had {failures} failures")
     sys.exit(failures)
 
 

--- a/src/rdb/raft_tests/raft_tests.py
+++ b/src/rdb/raft_tests/raft_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Copyright 2018-2022 Intel Corporation
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -33,9 +33,7 @@ def number_of_failures():
     if os.path.exists(json_file):
         with open(json_file, "r") as ofh:
             conf = json.load(ofh)
-        print(f"DIR={DIR}")
         path = os.path.join(conf["BUILD_DIR"], DIR, "src")
-    print(f"path={path}")
     if not os.path.exists(path):
         try:
             res = subprocess.check_output(['/usr/bin/make', '-C', DIR, 'tests'])

--- a/src/tests/vos_engine.c
+++ b/src/tests/vos_engine.c
@@ -76,8 +76,6 @@ engine_cont_init(struct credit_context *tsc)
 	if (rc)
 		return rc;
 
-	vos_pool_features_set(tsc->tsc_poh, VOS_POOL_FEAT_AGG_OPT);
-
 	tsc->tsc_coh = coh;
 	return rc;
 }

--- a/src/vos/tests/vts_common.c
+++ b/src/vos/tests/vts_common.c
@@ -128,7 +128,6 @@ vts_ctx_init(struct vos_test_ctx *tcx, size_t psize)
 		goto failed;
 	}
 
-	vos_pool_features_set(tcx->tc_po_hdl, VOS_POOL_FEAT_AGG_OPT);
 	tcx->tc_step = TCX_READY;
 	return 0;
 
@@ -311,7 +310,6 @@ cont_init(struct credit_context *tsc)
 	if (rc)
 		goto out;
 
-	vos_pool_features_set(tsc->tsc_poh, VOS_POOL_FEAT_AGG_OPT);
 	tsc->tsc_coh = coh;
  out:
 	return rc;

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -96,7 +96,7 @@ enum vos_gc_type {
  *  This enables the user to continue using the pool with the older version unless
  *  they have explicitly upgraded it.
  */
-#define POOL_DF_AGG_OPT				24
+#define POOL_DF_AGG_OPT                         VOS_POOL_DF_2_2
 /** Current durable format version */
 #define POOL_DF_VERSION				POOL_DF_AGG_OPT
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -881,15 +881,45 @@ vos_pool_open(const char *path, uuid_t uuid, unsigned int flags, daos_handle_t *
 	return vos_pool_open_metrics(path, uuid, flags, NULL, poh);
 }
 
-void
-vos_pool_features_set(daos_handle_t poh, uint64_t feats)
+int
+vos_pool_upgrade(daos_handle_t poh, uint32_t version)
 {
-	struct vos_pool	*pool;
+	struct vos_pool    *pool;
+	struct vos_pool_df *pool_df;
+	int                 rc = 0;
 
 	pool = vos_hdl2pool(poh);
 	D_ASSERT(pool != NULL);
 
-	pool->vp_feats |= feats;
+	pool_df = pool->vp_pool_df;
+
+	if (version == pool_df->pd_version)
+		return 0;
+
+	D_ASSERTF(version > pool_df->pd_version && version <= POOL_DF_VERSION,
+		  "Invalid pool upgrade version %d, current version is %d\n", version,
+		  pool_df->pd_version);
+
+	rc = umem_tx_begin(&pool->vp_umm, NULL);
+	if (rc != 0)
+		return rc;
+
+	rc = umem_tx_add_ptr(&pool->vp_umm, &pool_df->pd_version, sizeof(pool_df->pd_version));
+	if (rc != 0)
+		goto end;
+
+	pool_df->pd_version = version;
+
+end:
+	rc = umem_tx_end(&pool->vp_umm, rc);
+
+	if (rc != 0)
+		return rc;
+
+	if (version >= POOL_DF_AGG_OPT)
+		pool->vp_feats |= VOS_POOL_FEAT_AGG_OPT;
+
+	return 0;
 }
 
 /**

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -21,6 +21,10 @@ failed=0
 failures=()
 log_num=0
 
+if [ -z "$DAOS_BASE" ]; then
+    DAOS_BASE="."
+fi
+
 run_test()
 {
     local in="$*"


### PR DESCRIPTION
Rather than setting feats, we should update the format version
so that we don't need to continually set features on every pool
open operation.

Also addresses CID105928

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>