### PR TITLE
DAOS-11491 object: echo_rw only supports one iod

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -789,10 +789,11 @@ obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
 		bulk_op = CRT_BULK_GET;
 	}
 
+	/* Only support 1 iod now */
 	bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 	rc = obj_bulk_transfer(rpc, bulk_op, bulk_bind,
 			       orw->orw_bulks.ca_arrays, off,
-			       DAOS_HDL_INVAL, &p_sgl, orw->orw_nr, NULL, NULL);
+			       DAOS_HDL_INVAL, &p_sgl, 1, NULL, NULL);
 out:
 	orwo->orw_ret = rc;
 	orwo->orw_map_version = orw->orw_map_ver;


### PR DESCRIPTION
Addresses CID: 21837

echo_rw can only support one iod and one sgl

Signed-off-by: Liang Zhen <liang.zhen@intel.com>