### PR TITLE
DAOS-11522 common: Address overflow in bit shift operation

### DIFF
--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -122,7 +122,7 @@ daos_shard_fail_value(uint16_t *shards, int nr)
 
 	for (i = 0; i < nr; i++) {
 		D_ASSERT(shards[i] != 0xffff);
-		fail_val |= ((shards[i] + 1) << (16 * i));
+		fail_val |= ((uint64_t)(shards[i] + 1) << (16 * i));
 	}
 
 	return fail_val;


### PR DESCRIPTION
A 16 bit field is being shifted by more then 16 bits causing an
overflow.  Cast it first.

Coverity issues #105945, 105930

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>