### PR TITLE
DAOS-11523 Doc: Fix the broken link in README.

### DIFF
--- a/src/control/cmd/daos/README.md
+++ b/src/control/cmd/daos/README.md
@@ -1,6 +1,6 @@
 # DAOS CLI
 
-The source files in this directory are used to build the command-line interface for DAOS ($PREFIX/bin/daos). This utility is intended to be used by both admin and unprivileged users. It leverages the <a href="../../client/api/README.md">libdaos client library</a> in order to communicate with DAOS Data Plane servers via the storage fabric.
+The source files in this directory are used to build the command-line interface for DAOS ($PREFIX/bin/daos). This utility is intended to be used by both admin and unprivileged users. It leverages the <a href="../../../client/api/README.md">libdaos client library</a> in order to communicate with DAOS Data Plane servers via the storage fabric.
 
 ## Implementation Details
 

--- a/src/control/cmd/daos/README.md
+++ b/src/control/cmd/daos/README.md
@@ -23,8 +23,6 @@ The backend code is entirely written in C and for the moment is organized in the
   * daos_dfs_hdlr.c
   * daos_hdlr.c
 
-Note that the daos.c file contains frontend code for the C-only implementation, and its contents are not available to be utilized from Go.
-
 Longer-term, it would probably make sense to move the source files for `daos_cmd_hdlrs` under src/control/cmd/daos so that they live alongside the frontend code and can be compiled directly into the new daos binary in order to remove the need for the shared library. We could also consider implementing more of the backend logic in Go, but this may not necessarily make sense in many cases (e.g. data mover).
 
 ## Adding New Features

--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -52,7 +52,7 @@ directory.
 
 ### Control Service
 
-The gRPC server registers the [control service](/src/proto/ctl/control.proto)
+The gRPC server registers the [control service](/src/proto/ctl/ctl.proto)
 to handle requests from the management tool.
 
 Control service requests are operations that will be performed on one or more


### PR DESCRIPTION
File name was changed from control.proto --> ctl.proto, so
fixing the README file.

Signed-off-by: Samir Raval <samir.raval@intel.com>

Doc-only: true