### PR TITLE
DAOS-11241 object: fix a task err handling bug

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2976,10 +2976,11 @@ out_task:
 		D_ASSERTF(!obj_retry_error(rc), "unexpected ret "DF_RC"\n",
 			DP_RC(rc));
 
+		/* abort/complete sub-tasks will complete obj_task */
 		tse_task_list_traverse(task_list, shard_task_abort, &rc);
+	} else {
+		tse_task_complete(obj_task, rc);
 	}
-
-	tse_task_complete(obj_task, rc);
 
 	return rc;
 }
@@ -6512,11 +6513,11 @@ out_task:
 	if (head != NULL && !d_list_empty(head)) {
 		D_ASSERTF(!obj_retry_error(rc), "unexpected ret "DF_RC"\n",
 			DP_RC(rc));
-
+		/* abort/complete sub-tasks will complete api_task */
 		tse_task_list_traverse(head, shard_task_abort, &rc);
+	} else {
+		tse_task_complete(api_task, rc);
 	}
-
-	tse_task_complete(api_task, rc);
 
 	return rc;
 }


### PR DESCRIPTION
Need not complete parent task again if aborted all its dep-tasks.

Required-githooks: true
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>