### PR TITLE
DAOS-11241 object: forward IO req by using multiple ULTs

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -30,6 +30,9 @@
 /** number of target (XS set) per engine */
 extern unsigned int	 dss_tgt_nr;
 
+/** Number of offload XS */
+extern unsigned int	 dss_tgt_offload_xs_nr;
+
 /** Storage path (hack) */
 extern const char	*dss_storage_path;
 

--- a/src/tests/dts.c
+++ b/src/tests/dts.c
@@ -102,11 +102,20 @@ engine_cont_init(struct credit_context *tsc)
 	int		rc = 0;
 
 	if (tsc->tsc_mpi_rank == 0) {
-		char str[37];
+		daos_prop_t	*redun_lvl_prop = NULL;
+		char		 str[37];
 
 		if (tsc_create_cont(tsc)) {
-			rc = daos_cont_create(tsc->tsc_poh, &tsc->tsc_cont_uuid,
-					      NULL, NULL);
+			redun_lvl_prop = daos_prop_alloc(1);
+			if (redun_lvl_prop == NULL) {
+				D_ERROR("failed to allocate prop\n");
+				return -DER_NOMEM;
+			}
+			redun_lvl_prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+			redun_lvl_prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RANK;
+			rc = daos_cont_create(tsc->tsc_poh, &tsc->tsc_cont_uuid, redun_lvl_prop,
+					      NULL);
+			daos_prop_free(redun_lvl_prop);
 			if (rc != 0)
 				goto bcast;
 		}


### PR DESCRIPTION
Refine IO forwarding to be able to use multiple ULTs (at most 4).
Refine daos_perf to create container on RANK domain.

Required-githooks: true
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>