### PR TITLE
DAOS-11530 test: fix dfuse_unit return code

### DIFF
--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -432,7 +432,7 @@ run_specified_tests(const char *tests, int *sub_tests, int sub_tests_size)
 			    cmocka_unit_test(do_openat),
 			    cmocka_unit_test(do_ioctl),
 			};
-			nr_failed = cmocka_run_group_tests(io_tests, NULL, NULL);
+			nr_failed += cmocka_run_group_tests(io_tests, NULL, NULL);
 			break;
 		case 's':
 			printf("\n\n=================");
@@ -441,7 +441,7 @@ run_specified_tests(const char *tests, int *sub_tests, int sub_tests_size)
 			const struct CMUnitTest stream_tests[] = {
 			    cmocka_unit_test(do_stream),
 			};
-			nr_failed = cmocka_run_group_tests(stream_tests, NULL, NULL);
+			nr_failed += cmocka_run_group_tests(stream_tests, NULL, NULL);
 			break;
 
 		case 'm':
@@ -451,7 +451,7 @@ run_specified_tests(const char *tests, int *sub_tests, int sub_tests_size)
 			const struct CMUnitTest metadata_tests[] = {
 			    cmocka_unit_test(do_mtime),
 			};
-			nr_failed = cmocka_run_group_tests(metadata_tests, NULL, NULL);
+			nr_failed += cmocka_run_group_tests(metadata_tests, NULL, NULL);
 			break;
 
 		default:
@@ -469,8 +469,7 @@ main(int argc, char **argv)
 {
 	char                 tests[64];
 	int                  ntests          = 0;
-	int                  nr_failed       = 0;
-	int                  nr_total_failed = 0;
+	int                  nr_failed = 0;
 	int                  opt = 0, index = 0;
 
 	static struct option long_options[] = {{"test-dir", required_argument, NULL, 'M'},
@@ -509,10 +508,10 @@ main(int argc, char **argv)
 	nr_failed = run_specified_tests(tests, NULL, 0);
 
 	print_message("\n============ Summary %s\n", __FILE__);
-	if (nr_total_failed == 0)
+	if (nr_failed == 0)
 		print_message("OK - NO TEST FAILURES\n");
 	else
-		print_message("ERROR, %i TEST(S) FAILED\n", nr_total_failed);
+		print_message("ERROR, %i TEST(S) FAILED\n", nr_failed);
 
 	return nr_failed;
 }


### PR DESCRIPTION
Test-tag: dfuse_unit

Fix return code handling in dfuse_unit

Required-githooks: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>