### PR TITLE
DAOS-11490 erasure code: Fix Coverity issue with integer overflow.

### DIFF
--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -452,10 +452,11 @@ agg_overlap(uint64_t estart, uint64_t elen, unsigned int cell_idx,
 
 static unsigned int
 agg_count_cells(uint8_t *fcbit_map, uint8_t *tbit_map, uint64_t estart,
-		uint64_t elen, unsigned int k, unsigned int len,
+		uint64_t elen, unsigned int k, uint64_t len,
 		uint64_t stripenum, unsigned int *full_cell_cnt)
 {
-	unsigned int i, cell_cnt = 0;
+	uint64_t	i;
+	unsigned int	cell_cnt = 0;
 
 	for (i = 0; i < k; i++) {
 		if (i * len >= estart &&  estart + elen >= (i + 1) * len) {


### PR DESCRIPTION
#10180

Signed-off-by: Joseph Moore <joseph.moore@intel.com>