### PR TITLE
DAOS-11532 test: Increase unit test timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -733,7 +733,7 @@ pipeline {
                         label params.CI_UNIT_VM1_LABEL
                     }
                     steps {
-                        unitTest timeout_time: 45,
+                        unitTest timeout_time: 60,
                                  ignore_failure: true,
                                  inst_repos: prRepos(),
                                  inst_rpms: unitPackages()


### PR DESCRIPTION
Increasing the Unit Test with memcheck stage timeout from 45 to 60
minutes.

Skip-func-test: true

Required-githooks: true

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>