### PR TITLE
DAOS-11538 chk: some enhancement and cleanup

### DIFF
--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -647,11 +647,11 @@ int chk_bk_update_engine(struct chk_bookmark *cbk);
 
 int chk_bk_delete_engine(void);
 
-int chk_bk_fetch_pool(struct chk_bookmark *cbk, uuid_t uuid);
+int chk_bk_fetch_pool(struct chk_bookmark *cbk, char *uuid_str);
 
-int chk_bk_update_pool(struct chk_bookmark *cbk, uuid_t uuid);
+int chk_bk_update_pool(struct chk_bookmark *cbk, char *uuid_str);
 
-int chk_bk_delete_pool(uuid_t uuid);
+int chk_bk_delete_pool(char *uuid_str);
 
 int chk_prop_fetch(struct chk_property *cpp, d_rank_list_t **rank_list);
 

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -641,6 +641,12 @@ chk_leader_dangling_pool(struct chk_instance *ins, uuid_t uuid)
 		 * Fall through.
 		 */
 	case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
+		if (prop->cp_flags & CHK__CHECK_FLAG__CF_AUTO) {
+			/* Ignore the inconsistency if admin does not want interaction. */
+			cbk->cb_statistics.cs_ignored++;
+			break;
+		}
+
 		options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 		options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
 		option_nr = 2;
@@ -807,6 +813,12 @@ chk_leader_orphan_pool(struct chk_pool_rec *cpr)
 	case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
 
 interact:
+		if (prop->cp_flags & CHK__CHECK_FLAG__CF_AUTO) {
+			/* Ignore the inconsistency if admin does not want interaction. */
+			cbk->cb_statistics.cs_ignored++;
+			break;
+		}
+
 		options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_READD;
 		options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 		options[2] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
@@ -990,6 +1002,12 @@ chk_leader_no_quorum_pool(struct chk_pool_rec *cpr)
 			 * Fall through.
 			 */
 		case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
+			if (prop->cp_flags & CHK__CHECK_FLAG__CF_AUTO) {
+				/* Ignore the inconsistency if admin does not want interaction. */
+				cbk->cb_statistics.cs_ignored++;
+				break;
+			}
+
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
 			option_nr = 2;
@@ -1063,6 +1081,12 @@ chk_leader_no_quorum_pool(struct chk_pool_rec *cpr)
 			 * Fall through.
 			 */
 		case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
+			if (prop->cp_flags & CHK__CHECK_FLAG__CF_AUTO) {
+				/* Ignore the inconsistency if admin does not want interaction. */
+				cbk->cb_statistics.cs_ignored++;
+				break;
+			}
+
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 			options[2] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
@@ -1370,6 +1394,12 @@ try_ps:
 		 * Fall through.
 		 */
 	case CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT:
+		if (prop->cp_flags & CHK__CHECK_FLAG__CF_AUTO) {
+			/* Ignore the inconsistency if admin does not want interaction. */
+			cbk->cb_statistics.cs_ignored++;
+			break;
+		}
+
 		if (clp->clp_label == NULL) {
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS;

--- a/src/chk/chk_vos.c
+++ b/src/chk/chk_vos.c
@@ -159,46 +159,40 @@ chk_bk_delete_engine(void)
 }
 
 int
-chk_bk_fetch_pool(struct chk_bookmark *cbk, uuid_t uuid)
+chk_bk_fetch_pool(struct chk_bookmark *cbk, char *uuid_str)
 {
-	char	uuid_str[DAOS_UUID_STR_SIZE];
 	int	rc;
 
-	uuid_unparse_lower(uuid, uuid_str);
 	rc = chk_db_fetch(uuid_str, strlen(uuid_str), cbk, sizeof(*cbk));
 	if (rc != 0 && rc != -DER_NONEXIST)
-		D_ERROR("Failed to fetch pool "DF_UUIDF" bookmark on rank %u: "DF_RC"\n",
-			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
+		D_ERROR("Failed to fetch pool %s bookmark on rank %u: "DF_RC"\n",
+			uuid_str, dss_self_rank(), DP_RC(rc));
 
 	return rc;
 }
 
 int
-chk_bk_update_pool(struct chk_bookmark *cbk, uuid_t uuid)
+chk_bk_update_pool(struct chk_bookmark *cbk, char *uuid_str)
 {
-	char	uuid_str[DAOS_UUID_STR_SIZE];
 	int	rc;
 
-	uuid_unparse_lower(uuid, uuid_str);
 	rc = chk_db_update(uuid_str, strlen(uuid_str), cbk, sizeof(*cbk));
 	if (rc != 0)
-		D_ERROR("Failed to update pool "DF_UUIDF" bookmark on rank %u: "DF_RC"\n",
-			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
+		D_ERROR("Failed to update pool %s bookmark on rank %u: "DF_RC"\n",
+			uuid_str, dss_self_rank(), DP_RC(rc));
 
 	return rc;
 }
 
 int
-chk_bk_delete_pool(uuid_t uuid)
+chk_bk_delete_pool(char *uuid_str)
 {
-	char	uuid_str[DAOS_UUID_STR_SIZE];
 	int	rc;
 
-	uuid_unparse_lower(uuid, uuid_str);
 	rc = chk_db_delete(uuid_str, strlen(uuid_str));
 	if (rc != 0)
-		D_ERROR("Failed to delete pool "DF_UUIDF" bookmark on rank %u: "DF_RC"\n",
-			DP_UUID(uuid), dss_self_rank(), DP_RC(rc));
+		D_ERROR("Failed to delete pool %s bookmark on rank %u: "DF_RC"\n",
+			uuid_str, dss_self_rank(), DP_RC(rc));
 
 	return rc;
 }

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -498,8 +498,6 @@ void daos_iov_append(d_iov_t *iov, void *buf, uint64_t buf_len);
 	     ({ type __x = (x); type __y = (y); __x > __y ? __x : __y; })
 #endif
 
-#define DAOS_UUID_STR_SIZE 37	/* 36 + 1 for '\0' */
-
 /* byte swapper */
 #define D_SWAP16(x)	bswap_16(x)
 #define D_SWAP32(x)	bswap_32(x)

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -532,28 +532,8 @@ daos_label_is_valid(const char *label)
 	}
 
 	/** Check to see if it could be a valid UUID */
-	if (maybe_uuid && strnlen(label, 36) == 36) {
-		bool		is_uuid = true;
-		const char	*p;
-
-		/** Implement the check directly to avoid uuid_parse() overhead */
-		for (i = 0, p = label; i < 36; i++, p++) {
-			if (i == 8 || i == 13 || i == 18 || i == 23) {
-				if (*p != '-') {
-					is_uuid = false;
-					break;
-				}
-				continue;
-			}
-			if (!isxdigit(*p)) {
-				is_uuid = false;
-				break;
-			}
-		}
-
-		if (is_uuid)
-			return false;
-	}
+	if (maybe_uuid && daos_is_valid_uuid_string(label))
+		return false;
 
 	return true;
 }

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -18,6 +18,7 @@ extern "C" {
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
+#include <ctype.h>
 
 /** uuid_t */
 #include <uuid/uuid.h>
@@ -216,6 +217,30 @@ typedef struct {
 	/** most significant (high) bits of object ID */
 	uint64_t	hi;
 } daos_obj_id_t;
+
+#define DAOS_UUID_STR_SIZE 37	/* 36 + 1 for '\0' */
+
+static inline bool
+daos_is_valid_uuid_string(const char *uuid)
+{
+	const char	*p;
+	int		 len = DAOS_UUID_STR_SIZE - 1; /* Not include the ternimated '\0' */
+	int		 i;
+
+	if (strnlen(uuid, len) != len)
+		return false;
+
+	for (i = 0, p = uuid; i < len; i++, p++) {
+		if (i == 8 || i == 13 || i == 18 || i == 23) {
+			if (*p != '-')
+				return false;
+		} else if (!isxdigit(*p)) {
+			return false;
+		}
+	}
+
+	return true;
+}
 
 /** max pool/cont attr size */
 #define DAOS_ATTR_NAME_MAX 511

--- a/src/mgmt/srv_chk.c
+++ b/src/mgmt/srv_chk.c
@@ -8,19 +8,55 @@
  */
 #define D_LOGFAC	DD_FAC(mgmt)
 
+#include <uuid/uuid.h>
 #include <daos_srv/daos_chk.h>
 #include <daos_srv/daos_engine.h>
 
 #include "srv_internal.h"
 
+static int
+ds_mgmt_chk_parse_uuid(int pool_nr, char **pools, uuid_t **p_uuids)
+{
+	uuid_t	*uuids = NULL;
+	int	 rc = 0;
+	int	 i;
+
+	if (pool_nr != 0) {
+		D_ALLOC_ARRAY(uuids, pool_nr);
+		if (uuids == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		for (i = 0; i < pool_nr; i++) {
+			rc = uuid_parse(pools[i], uuids[i]);
+			if (rc != 0) {
+				D_ERROR("Failed to parse pool %s: "DF_RC"\n", pools[i], DP_RC(rc));
+				D_GOTO(out, rc);
+			}
+		}
+	}
+
+out:
+	if (rc != 0)
+		D_FREE(uuids);
+	else
+		*p_uuids = uuids;
+
+	return rc;
+}
+
 int
 ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		    Mgmt__CheckInconsistPolicy **policies, int32_t pool_nr, uuid_t pools[],
+		    Mgmt__CheckInconsistPolicy **policies, int32_t pool_nr, char **pools,
 		    uint32_t flags, int32_t phase)
 {
-	struct chk_policy *ply = NULL;
-	int		   rc = 0;
-	int		   i;
+	uuid_t			*uuids = NULL;
+	struct chk_policy	*ply = NULL;
+	int			 rc = 0;
+	int			 i;
+
+	rc = ds_mgmt_chk_parse_uuid(pool_nr, pools, &uuids);
+	if (rc != 0)
+		goto out;
 
 	if (policy_nr != 0) {
 		D_ALLOC_ARRAY(ply, policy_nr);
@@ -33,25 +69,44 @@ ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
 		}
 	}
 
-	rc = chk_leader_start(rank_nr, ranks, policy_nr, ply, pool_nr, pools, flags, phase);
+	rc = chk_leader_start(rank_nr, ranks, policy_nr, ply, pool_nr, uuids, flags, phase);
 
 out:
+	D_FREE(uuids);
 	D_FREE(ply);
 
 	return rc;
 }
 
 int
-ds_mgmt_check_stop(int32_t pool_nr, uuid_t pools[])
+ds_mgmt_check_stop(int32_t pool_nr, char **pools)
 {
-	return chk_leader_stop(pool_nr, pools);
+	uuid_t	*uuids = NULL;
+	int	 rc;
+
+	rc = ds_mgmt_chk_parse_uuid(pool_nr, pools, &uuids);
+	if (rc == 0) {
+		rc = chk_leader_stop(pool_nr, uuids);
+		D_FREE(uuids);
+	}
+
+	return rc;
 }
 
 int
-ds_mgmt_check_query(int32_t pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+ds_mgmt_check_query(int32_t pool_nr, char **pools, chk_query_head_cb_t head_cb,
 		    chk_query_pool_cb_t pool_cb, void *buf)
 {
-	return chk_leader_query(pool_nr, pools, head_cb, pool_cb, buf);
+	uuid_t	*uuids = NULL;
+	int	 rc;
+
+	rc = ds_mgmt_chk_parse_uuid(pool_nr, pools, &uuids);
+	if (rc == 0) {
+		rc = chk_leader_query(pool_nr, uuids, head_cb, pool_cb, buf);
+		D_FREE(uuids);
+	}
+
+	return rc;
 }
 
 int

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -2588,10 +2588,10 @@ out:
 }
 
 /*
- * XXX: It is the control plane to choose the check leader and rank list.
- *	There are some requirements for the rank list:
- *	1. There are no repeated ranks in the list.
- *	2. It is better to sort ranks in the list that will much speedup searching rank in the list.
+ * NOTE: It is the control plane to choose the check leader and generate the rank list.
+ *	 There are some requirements for the rank list:
+ *	 1. There are no repeated ranks in the list.
+ *	 2. Better to sort ranks in the list that will much speedup searching rank in the list.
  */
 void
 ds_mgmt_drpc_check_start(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
@@ -2599,11 +2599,9 @@ ds_mgmt_drpc_check_start(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	struct drpc_alloc	 alloc = PROTO_ALLOCATOR_INIT(alloc);
 	Mgmt__CheckStartReq	*req = NULL;
 	Mgmt__CheckStartResp	 resp = MGMT__CHECK_START_RESP__INIT;
-	uuid_t			*pools = NULL;
 	uint8_t			*body;
 	size_t			 len;
 	int			 rc = 0;
-	int			 i;
 
 	if (!ds_mgmt_check_enabled()) {
 		D_ERROR("Not in check mode\n");
@@ -2620,28 +2618,11 @@ ds_mgmt_drpc_check_start(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 
 	D_INFO("Received request to start check\n");
 
-	if (req->n_uuids != 0) {
-		D_ALLOC_ARRAY(pools, req->n_uuids);
-		if (pools == NULL)
-			D_GOTO(rep, rc = -DER_NOMEM);
-
-		for (i = 0; i < req->n_uuids; i++) {
-			rc = uuid_parse(req->uuids[i], pools[i]);
-			if (rc != 0) {
-				D_ERROR("Failed to parse uuid %s: %d\n", req->uuids[i], rc);
-				D_GOTO(rep, rc);
-			}
-		}
-	}
-
-	/* XXX: support to check to the specified phase in the future. */
-
-	rc = ds_mgmt_check_start(req->n_ranks, req->ranks, req->n_policies,
-				 req->policies, req->n_uuids, pools, req->flags, -1 /* phase */);
+	rc = ds_mgmt_check_start(req->n_ranks, req->ranks, req->n_policies, req->policies,
+				 req->n_uuids, req->uuids, req->flags, -1 /* phase */);
 	if (rc != 0)
 		D_ERROR("Failed to start check: "DF_RC"\n", DP_RC(rc));
 
-rep:
 	resp.status = rc;
 	len = mgmt__check_start_resp__get_packed_size(&resp);
 	D_ALLOC(body, len);
@@ -2654,7 +2635,6 @@ rep:
 		drpc_resp->body.data = body;
 	}
 
-	D_FREE(pools);
 	mgmt__check_start_req__free_unpacked(req, &alloc.alloc);
 }
 
@@ -2668,11 +2648,9 @@ ds_mgmt_drpc_check_stop(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	struct drpc_alloc	 alloc = PROTO_ALLOCATOR_INIT(alloc);
 	Mgmt__CheckStopReq	*req = NULL;
 	Mgmt__CheckStopResp	 resp = MGMT__CHECK_STOP_RESP__INIT;
-	uuid_t			*pools = NULL;
 	uint8_t			*body;
 	size_t			 len;
 	int			 rc = 0;
-	int			 i;
 
 	if (!ds_mgmt_check_enabled()) {
 		D_ERROR("Not in check mode\n");
@@ -2689,25 +2667,10 @@ ds_mgmt_drpc_check_stop(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 
 	D_INFO("Received request to stop check\n");
 
-	if (req->n_uuids != 0) {
-		D_ALLOC_ARRAY(pools, req->n_uuids);
-		if (pools == NULL)
-			D_GOTO(rep, rc = -DER_NOMEM);
-
-		for (i = 0; i < req->n_uuids; i++) {
-			rc = uuid_parse(req->uuids[i], pools[i]);
-			if (rc != 0) {
-				D_ERROR("Failed to parse uuid %s: %d\n", req->uuids[i], rc);
-				D_GOTO(rep, rc);
-			}
-		}
-	}
-
-	rc = ds_mgmt_check_stop(req->n_uuids, pools);
+	rc = ds_mgmt_check_stop(req->n_uuids, req->uuids);
 	if (rc != 0)
 		D_ERROR("Failed to stop check: "DF_RC"\n", DP_RC(rc));
 
-rep:
 	resp.status = rc;
 	len = mgmt__check_stop_resp__get_packed_size(&resp);
 	D_ALLOC(body, len);
@@ -2720,7 +2683,6 @@ rep:
 		drpc_resp->body.data = body;
 	}
 
-	D_FREE(pools);
 	mgmt__check_stop_req__free_unpacked(req, &alloc.alloc);
 }
 
@@ -2807,7 +2769,7 @@ ds_chk_query_head_cb(uint32_t ins_status, uint32_t ins_phase, struct chk_statist
 		     struct chk_time *time, size_t n_pools, void *buf)
 {
 	Mgmt__CheckQueryResp	*resp = buf;
-	int			  rc = 0;
+	int			 rc = 0;
 
 	resp->ins_status = ins_status;
 	resp->ins_phase = ins_phase;
@@ -2895,19 +2857,19 @@ out:
 }
 
 /*
- * XXX: One pool may have M pool shards on M daos engines. Each of them has each own status and
- *	summary in the qurey result. They have the same UUID and contiguous each other. Control
- *	plane can decide how to show them to the admin based on the qurey option.
+ * NOTE: One pool may have M pool shards on M daos engines. Each of them has each own status and
+ *	 summary in the qurey result. They have the same UUID and contiguous each other. Control
+ *	 plane can decide how to show them to the admin based on the qurey option.
  *
- *	Similarly, each pool shard may have N vos target on the engine. Then there will be M * N
- *	vos targets for the whole pool. Each of them has each own check summary in qurey result.
- *	It is the control plane's duty to re-organize related result before showing to the admin.
+ *	 Similarly, each pool shard may have N vos target on the engine. Then there will be M * N
+ *	 vos targets for the whole pool. Each of them has each own check summary in qurey result.
+ *	 It is the control plane's duty to re-organize related result before showing to the admin.
  *
- *	If some required pool is absence in the qurey result, then means that it does not exist.
+ *	 If some required pool is absence in the qurey result, then means that it does not exist.
  *
- *	On the other hand, it is the control plane's duty to guarantee that if the check leader
- *	is still available, the CHK_QUERY dRPC needs to be sent to the check leader. Otherwise,
- *	the query result may be not inaccurate.
+ *	 On the other hand, it is the control plane's duty to guarantee that if the check leader
+ *	 is still available, the CHK_QUERY dRPC needs to be sent to the check leader. Otherwise,
+ *	 the query result may be not inaccurate.
  */
 void
 ds_mgmt_drpc_check_query(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
@@ -2919,7 +2881,6 @@ ds_mgmt_drpc_check_query(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	uint8_t				*body;
 	size_t				 len;
 	int				 rc = 0;
-	int				 i;
 
 	if (!ds_mgmt_check_enabled()) {
 		D_ERROR("Not in check mode\n");
@@ -2936,26 +2897,11 @@ ds_mgmt_drpc_check_query(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 
 	D_INFO("Received request to query check\n");
 
-	if (req->n_uuids != 0) {
-		D_ALLOC_ARRAY(pools, req->n_uuids);
-		if (pools == NULL)
-			D_GOTO(rep, rc = -DER_NOMEM);
-
-		for (i = 0; i < req->n_uuids; i++) {
-			rc = uuid_parse(req->uuids[i], pools[i]);
-			if (rc != 0) {
-				D_ERROR("Failed to parse uuid %s: %d\n", req->uuids[i], rc);
-				D_GOTO(rep, rc);
-			}
-		}
-	}
-
-	rc = ds_mgmt_check_query(req->n_uuids, pools, ds_chk_query_head_cb,
+	rc = ds_mgmt_check_query(req->n_uuids, req->uuids, ds_chk_query_head_cb,
 				 ds_chk_query_pool_cb, &resp);
 	if (rc != 0)
 		D_ERROR("Failed to query check: "DF_RC"\n", DP_RC(rc));
 
-rep:
 	resp.req_status = rc;
 	len = mgmt__check_query_resp__get_packed_size(&resp);
 	D_ALLOC(body, len);
@@ -3020,9 +2966,6 @@ out:
 	return rc;
 }
 
-/*
- * CHK_PROP dRPC can be sent to any engine that participates in the check.
- */
 void
 ds_mgmt_drpc_check_prop(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 {
@@ -3068,9 +3011,6 @@ ds_mgmt_drpc_check_prop(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	mgmt__check_prop_req__free_unpacked(req, &alloc.alloc);
 }
 
-/*
- * CHK_ACT dRPC only can be sent to the check leader.
- */
 void
 ds_mgmt_drpc_check_act(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 {

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -110,10 +110,10 @@ int ds_mgmt_cont_set_owner(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 
 /** srv_chk.c */
 int ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-			Mgmt__CheckInconsistPolicy **policies, int pool_nr, uuid_t pools[],
+			Mgmt__CheckInconsistPolicy **policies, int pool_nr, char **pools,
 			uint32_t flags, int phase);
-int ds_mgmt_check_stop(int pool_nr, uuid_t pools[]);
-int ds_mgmt_check_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+int ds_mgmt_check_stop(int pool_nr, char **pools);
+int ds_mgmt_check_query(int pool_nr, char **pools, chk_query_head_cb_t head_cb,
 			chk_query_pool_cb_t pool_cb, void *buf);
 int ds_mgmt_check_prop(chk_prop_cb_t prop_cb, void *buf);
 int ds_mgmt_check_act(uint64_t seq, uint32_t act, bool for_all);

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -683,7 +683,7 @@ ds_mgmt_tgt_pool_shard_destroy(uuid_t pool_uuid, int shard_idx, d_rank_t rank)
 
 	tgt_ep.ep_grp = NULL;
 	tgt_ep.ep_rank = rank;
-	tgt_ep.ep_tag = daos_rpc_tag(DAOS_REQ_CHK, 0);
+	tgt_ep.ep_tag = daos_rpc_tag(DAOS_REQ_MGMT, 0);
 
 	opc = DAOS_RPC_OPCODE(MGMT_TGT_SHARD_DESTROY, DAOS_MGMT_MODULE,
 			      DAOS_MGMT_VERSION);

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -581,20 +581,20 @@ mock_ds_mgmt_pool_upgrade_setup(void)
 
 int
 ds_mgmt_check_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		    Mgmt__CheckInconsistPolicy **policies, int pool_nr, uuid_t pools[],
+		    Mgmt__CheckInconsistPolicy **policies, int pool_nr, char **pools,
 		    uint32_t flags, int phase)
 {
 	return 0;
 }
 
 int
-ds_mgmt_check_stop(int pool_nr, uuid_t pools[])
+ds_mgmt_check_stop(int pool_nr, char **pools)
 {
 	return 0;
 }
 
 int
-ds_mgmt_check_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
+ds_mgmt_check_query(int pool_nr, char **pools, chk_query_head_cb_t head_cb,
 		    chk_query_pool_cb_t pool_cb, void *buf)
 {
 	return 0;


### PR DESCRIPTION
Including the followings:

1. If the admin does not want to interact with DAOS check during the
   process, he/she can specify "CF_AUTO" flag when start DAOS check.
   then all interaction actions will be automatically handled as 'IGNORE'.

2. Unify the message buffer size for reporting inconsistency and ask
   for interaction with admin.

3. Standardize the usage for uuid_t and uuid string in DAOS check logic.

4. More comment for how to handle dead rank during DAOS check.

Signed-off-by: Fan Yong <fan.yong@intel.com>