### PR TITLE
DAOS-11532 test: Increase unit test timeout (#10211)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -731,7 +731,7 @@ pipeline {
                         label params.CI_UNIT_VM1_LABEL
                     }
                     steps {
-                        unitTest timeout_time: 35,
+                        unitTest timeout_time: 60,
                                  ignore_failure: true,
                                  inst_repos: prRepos(),
                                  inst_rpms: unitPackages()


### PR DESCRIPTION
Increasing the Unit Test with memcheck stage timeout from 45 to 60
minutes.

Skip-func-test: true

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>