### PR TITLE
DAOS-11423 object: Set EC cell alignment to 32 bytes

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -87,8 +87,8 @@ daos_ec_cs_valid(uint32_t cell_sz)
 	if (cell_sz < DAOS_EC_CELL_MIN || cell_sz > DAOS_EC_CELL_MAX)
 		return false;
 
-	/* should be multiplier of the min size */
-	if (cell_sz % DAOS_EC_CELL_MIN != 0)
+	/* should be multiplier of the min size, EC/ISAL lib require 32 byte alignment */
+	if (cell_sz % 32 != 0)
 		return false;
 
 	return true;


### PR DESCRIPTION
Set EC cell alignment to be 32 bytes, instead of 4096 bytes, so to avoid the data to be splitted by setting proper EC cell size like IOR hard.

Signed-off-by: Di Wang <di.wang@intel.com>