### PR TITLE
DAOS-11423 engine: choose helper randomly

### DIFF
--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -371,10 +371,9 @@ sched_ult2xs(int xs_type, int tgt_id)
 		 * ask neighbor to do IO forwarding seems is helpful to make
 		 * them concurrent, right?
 		 */
-		if (dss_tgt_offload_xs_nr >= dss_tgt_nr)
-			xs_id = dss_sys_xs_nr + dss_tgt_nr + tgt_id;
-		else if (dss_tgt_offload_xs_nr > 0)
-			xs_id = dss_sys_xs_nr + dss_tgt_nr + tgt_id % dss_tgt_offload_xs_nr;
+		if (dss_tgt_offload_xs_nr > 0)
+			xs_id = dss_sys_xs_nr + dss_tgt_nr +
+				rand() % min(dss_tgt_nr, dss_tgt_offload_xs_nr);
 		else
 			xs_id = (DSS_MAIN_XS_ID(tgt_id) + 1) % dss_tgt_nr;
 		break;


### PR DESCRIPTION
IO request should choose helper xstream randomly from all helpers.

Signed-off-by: Di Wang <di.wang@intel.com>