### PR TITLE
DAOS-11473 control: Fix VMD domain parsing (#10145)

### DIFF
--- a/src/control/lib/hardware/pci.go
+++ b/src/control/lib/hardware/pci.go
@@ -23,8 +23,6 @@ import (
 const (
 	// bdevPciAddrSep defines the separator used between PCI addresses in string sets.
 	bdevPciAddrSep = " "
-	// vmdDomainLen defines the expected length of a VMD backing devices address domain.
-	vmdDomainLen = 6
 	// PCIAddrBusBitSize defines the number of bits used to represent bus in address.
 	PCIAddrBusBitSize = 8
 )
@@ -33,10 +31,8 @@ var ErrNotVMDBackingAddress = errors.New("not a vmd backing device address")
 
 // parseVMDAddress returns the domain string interpreted as the VMD address.
 func parseVMDAddress(addr string) (*PCIAddress, error) {
-	if len(addr) != vmdDomainLen {
-		return nil, errors.Errorf("unexpected length of vmd domain: %q", addr)
-	}
-
+	// Left-pad domain string as necessary make it a valid PCI address.
+	addr = fmt.Sprintf("%06s", addr)
 	return NewPCIAddress(fmt.Sprintf("0000:%s:%s.%s", addr[:2], addr[2:4], addr[4:]))
 }
 

--- a/src/control/lib/hardware/pci_test.go
+++ b/src/control/lib/hardware/pci_test.go
@@ -67,10 +67,6 @@ func TestHardware_NewPCIAddress(t *testing.T) {
 			addrStr: "0000:gg:00.0",
 			expErr:  errors.New("parsing \"gg\""),
 		},
-		"invalid vmd": {
-			addrStr: "1ffff:01:00.0",
-			expErr:  errors.New("unexpected length of vmd"),
-		},
 		"vmd address": {
 			addrStr: "0000:5d:05.5",
 		},
@@ -82,6 +78,14 @@ func TestHardware_NewPCIAddress(t *testing.T) {
 				Function: 0xff,
 			},
 		},
+		"short vmd backing device address": {
+			addrStr: "50505:05:00.0",
+			expVMD: &PCIAddress{
+				Bus:      0x05,
+				Device:   0x05,
+				Function: 0x05,
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			addr, err := NewPCIAddress(tc.addrStr)
@@ -90,9 +94,6 @@ func TestHardware_NewPCIAddress(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(tc.addrStr, addr.String()); diff != "" {
-				t.Fatalf("unexpected string (-want, +got):\n%s\n", diff)
-			}
 			if diff := cmp.Diff(tc.expVMD, addr.VMDAddr); diff != "" {
 				t.Fatalf("unexpected VMD address (-want, +got):\n%s\n", diff)
 			}
@@ -299,9 +300,9 @@ func TestHardware_PCIAddressSet_BackingToVMDAddresses(t *testing.T) {
 			inAddrs:     []string{"5d0505:01:00.0", "5d0505:03:00.0"},
 			expOutAddrs: []string{"0000:5d:05.5"},
 		},
-		"invalid vmd domain in address": {
-			inAddrs: []string{"5d055:01:00.0"},
-			expErr:  errors.New("unexpected length of vmd domain"),
+		"short vmd domain in address": {
+			inAddrs:     []string{"5d055:01:00.0"},
+			expOutAddrs: []string{"0000:05:d0.55"},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
The parsing code imposed an arbitrary constraint on the
length of the VMD address. Instead, just left-pad with
zeroes as necessary to ensure it can be parsed into a
PCI address.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>