### PR TITLE
DAOS-11442 test: add option for --bind-to (#10061)

### DIFF
--- a/src/tests/ftest/cart/util/cart_utils.py
+++ b/src/tests/ftest/cart/util/cart_utils.py
@@ -427,6 +427,7 @@ class CartTest(TestWithoutServers):
             tst_cmd += " " + tst_arg
 
         job = Orterun(tst_cmd)
+        job.get_params(self)
         job.mca.update(mca_flags)
         job.hostfile.update(hostfile)
         job.pprnode.update(tst_ppn)

--- a/src/tests/ftest/performance/ior_easy.yaml
+++ b/src/tests/ftest/performance/ior_easy.yaml
@@ -102,3 +102,5 @@ dfuse:
 performance:
   env:
     - D_LOG_MASK=ERR
+mpirun:
+  bind_to: socket

--- a/src/tests/ftest/performance/ior_hard.yaml
+++ b/src/tests/ftest/performance/ior_hard.yaml
@@ -81,3 +81,5 @@ dfuse:
 performance:
   env:
     - D_LOG_MASK=ERR
+mpirun:
+  bind_to: socket

--- a/src/tests/ftest/performance/mdtest_easy.yaml
+++ b/src/tests/ftest/performance/mdtest_easy.yaml
@@ -75,3 +75,5 @@ mdtest_dfs_ec_16p2g1:
 performance:
   env:
     - D_LOG_MASK=ERR
+mpirun:
+  bind_to: socket

--- a/src/tests/ftest/performance/mdtest_hard.yaml
+++ b/src/tests/ftest/performance/mdtest_hard.yaml
@@ -66,3 +66,5 @@ mdtest_dfs_ec_16p2g1:
 performance:
   env:
     - D_LOG_MASK=ERR
+mpirun:
+  bind_to: socket

--- a/src/tests/ftest/soak/utils.py
+++ b/src/tests/ftest/soak/utils.py
@@ -355,7 +355,7 @@ def run_metrics_check(self, logging=True, prefix=None):
 
 
 def get_harassers(harasser):
-    """Create a valid harasserlist from the yaml job harassers.
+    """Create a valid harasser list from the yaml job harassers.
 
     Args:
         harassers (list): harasser jobs from yaml.
@@ -729,7 +729,7 @@ def start_dfuse(self, pool, container, name=None, job_spec=None):
         pool (obj):             TestPool obj
 
     Returns dfuse(obj):         Dfuse obj
-            cmd(list):          list of dfuse commands to add to jobscript
+            cmd(list):          list of dfuse commands to add to job script
     """
     # Get Dfuse params
     dfuse = Dfuse(self.hostlist_clients, self.tmp)
@@ -752,7 +752,7 @@ def start_dfuse(self, pool, container, name=None, job_spec=None):
     dfuse_start_cmds = [
         "clush -S -w $SLURM_JOB_NODELIST \"mkdir -p {}\"".format(dfuse.mount_dir.value),
         "clush -S -w $SLURM_JOB_NODELIST \"cd {};{};{};{}\"".format(
-            dfuse.mount_dir.value, dfuse_env, module_load, dfuse.__str__()),
+            dfuse.mount_dir.value, dfuse_env, module_load, str(dfuse)),
         "sleep 10",
         "clush -S -w $SLURM_JOB_NODELIST \"df -h {}\"".format(dfuse.mount_dir.value),
     ]
@@ -898,6 +898,7 @@ def create_ior_cmdline(self, job_spec, pool, ppn, nodesperjob):
                         ior_cmd.test_file.update(
                             os.path.join(dfuse.mount_dir.value, "testfile"))
                     mpirun_cmd = Mpirun(ior_cmd, mpi_type=self.mpi_module)
+                    mpirun_cmd.get_params(self)
                     # add envs if api is HDF5-VOL
                     if api == "HDF5-VOL":
                         vol = True
@@ -964,6 +965,7 @@ def create_macsio_cmdline(self, job_spec, pool, ppn, nodesperjob):
             env = macsio.get_environment("mpirun", log_file=daos_log)
             sbatch_cmds = ["module purge", "module load {}".format(self.mpi_module)]
             mpirun_cmd = Mpirun(macsio, mpi_type=self.mpi_module)
+            mpirun_cmd.get_params(self)
             mpirun_cmd.assign_processes(nodesperjob * ppn)
             if api in ["HDF5-VOL"]:
                 # include dfuse cmdlines
@@ -1067,6 +1069,7 @@ def create_mdtest_cmdline(self, job_spec, pool, ppn, nodesperjob):
                             mdtest_cmd.test_dir.update(
                                 dfuse.mount_dir.value)
                         mpirun_cmd = Mpirun(mdtest_cmd, mpi_type=self.mpi_module)
+                        mpirun_cmd.get_params(self)
                         mpirun_cmd.assign_processes(nodesperjob * ppn)
                         mpirun_cmd.assign_environment(env, True)
                         mpirun_cmd.ppn.update(ppn)
@@ -1111,7 +1114,7 @@ def create_racer_cmdline(self, job_spec):
     daos_racer.set_environment(env)
     log_name = job_spec
     cmds = []
-    cmds.append(str(daos_racer.__str__()))
+    cmds.append(str(daos_racer))
     cmds.append("status=$?")
     # add exit code
     commands.append([cmds, log_name])
@@ -1122,7 +1125,7 @@ def create_racer_cmdline(self, job_spec):
 
 
 def create_fio_cmdline(self, job_spec, pool):
-    """Create the FOI commandline for job script.
+    """Create the FOI command line for job script.
 
     Args:
 
@@ -1182,8 +1185,8 @@ def create_fio_cmdline(self, job_spec, pool):
                         "global", "directory",
                         dfuse.mount_dir.value,
                         "fio --name=global --directory")
-                    # add fio cmline
-                    cmds.append(str(fio_cmd.__str__()))
+                    # add fio cmdline
+                    cmds.append(str(fio_cmd))
                     cmds.append("status=$?")
                     # If posix, add the srun dfuse stop cmds
                     if fio_cmd.api.value == "POSIX":
@@ -1235,6 +1238,7 @@ def create_app_cmdline(self, job_spec, pool, ppn, nodesperjob):
         if mpi_module != self.mpi_module:
             sbatch_cmds.append("module load {}".format(mpi_module))
         mpirun_cmd = Mpirun(app_cmd, False, mpi_module)
+        mpirun_cmd.get_params(self)
         if "mpich" in mpi_module:
             # Pass pool and container information to the commands
             env = EnvironmentVariables()
@@ -1257,6 +1261,7 @@ def create_app_cmdline(self, job_spec, pool, ppn, nodesperjob):
             self.log.info("%s", cmd)
         if mpi_module != self.mpi_module:
             mpirun_cmd = Mpirun(app_cmd, False, self.mpi_module)
+            mpirun_cmd.get_params(self)
     return commands
 
 
@@ -1265,7 +1270,7 @@ def build_job_script(self, commands, job, nodesperjob):
 
     Args:
         self (obj): soak obj
-        commands(list): commandlines and cmd specific log_name
+        commands(list): command lines and cmd specific log_name
         job(str): the job name that will be defined in the slurm script
 
     Returns:

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -61,6 +61,7 @@ def get_job_manager(test, class_name=None, job=None, subprocess=None, mpi_type=N
     # Setup a job manager command for running the test command
     if class_name is not None:
         job_manager = get_job_manager_class(class_name, job, subprocess, mpi_type)
+        job_manager.get_params(test)
         job_manager.timeout = timeout
         if mpi_type == "openmpi":
             job_manager.tmpdir_base.update(test.test_dir, "tmpdir_base")
@@ -298,6 +299,7 @@ class Orterun(JobManager):
         self.ompi_server = FormattedParameter("--ompi-server {}", None)
         self.working_dir = FormattedParameter("-wdir {}", None)
         self.tmpdir_base = FormattedParameter("--mca orte_tmpdir_base {}", None)
+        self.bind_to = FormattedParameter("--bind-to {}", None)
         self.mpi_type = mpi_type
 
     def assign_hosts(self, hosts, path=None, slots=None):
@@ -382,7 +384,7 @@ class Mpirun(JobManager):
             raise MPILoadError(mpi_type)
 
         path = os.path.dirname(find_executable("mpirun"))
-        super().__init__("/run/mpirun", "mpirun", job, path, subprocess)
+        super().__init__("/run/mpirun/*", "mpirun", job, path, subprocess)
 
         mca_default = None
         if mpi_type == "openmpi":
@@ -406,6 +408,7 @@ class Mpirun(JobManager):
         self.mca = FormattedParameter("--mca {}", mca_default)
         self.working_dir = FormattedParameter("-wdir {}", None)
         self.tmpdir_base = FormattedParameter("--mca orte_tmpdir_base {}", None)
+        self.bind_to = FormattedParameter("--bind-to {}", None)
         self.mpi_type = mpi_type
 
     def assign_hosts(self, hosts, path=None, slots=None):
@@ -483,7 +486,7 @@ class Srun(JobManager):
             subprocess (bool, optional): whether the command is run as a
                 subprocess. Defaults to False.
         """
-        super().__init__("/run/srun", "srun", job, path, subprocess)
+        super().__init__("/run/srun/*", "srun", job, path, subprocess)
 
         self.label = FormattedParameter("--label", True)
         self.mpi = FormattedParameter("--mpi={}", "pmi2")


### PR DESCRIPTION
Test-tag: performance_ior_easy_dfs_sx performance_ior_hard_dfs_sx performance_mdtest_easy_dfs_s1 performance_mdtest_hard_dfs_s1 corpc,five_node soak_smoke pr,-hw pr,hw,large
Skip-unit-tests: true
Skip-fault-injection-test: true

- Fix Mpirun and Srun namespace
- Add --bind-to {} to Mpirun and Orterun
  - Update instantiations to call get_params()
- Adjust performance tests to use --bind-to socket

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>