### PR TITLE
DAOS-11232 vos: Remove unecessary and incorrect assertion (#10236)

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1510,7 +1510,6 @@ insert_segments(daos_handle_t ih, struct agg_merge_window *mw,
 
 		D_ASSERTF(rect.rc_ex.ex_lo <= rect.rc_ex.ex_hi, "phy_ent "DF_RECT" off="DF_X64"\n",
 			  DP_RECT(&phy_ent->pe_rect), phy_ent->pe_off);
-		D_ASSERT(phy_ent->pe_remove || rect.rc_ex.ex_lo <= mw->mw_ext.ex_hi);
 
 		/*
 		 * The physical entry spans window end, but is fully covered


### PR DESCRIPTION
The assertion in question is incorrect.  A set of valid inputs can be chosen to make it fail.  I'm in process of creating a regression test and checking in my utility that I wrote while debugging this but it's taking too long so let's fix the issue only first.

The valid sequence that fails looks like this

write 3 bytes at index 0 at time 1
write 4 bytes at index 2 at time 2
remove 3 bytes at index 2 at time 2
write 4 bytes at index 5 at time 3
remove 3 bytes at index 5 at time 3

The issue is by the time we know we need to flush the merge window, the physical record that causes the assertion (4 bytes at 5) is already enqueued. Here is the sequence we see at aggregation time

3 visible records at 0 at time 1
removal record at time 2 (3 bytes at 2)
3 covered records at 2 at time 2
removal record at time 3 (3 bytes at 5)
3 covered records at 5 at time 3 => physical record is enqueued
1 visible record at 5 at time 2 (visible because the later write was removed)

The last record, being disjoint from the merge window triggers a flush which asserts because the physical record is also disjoint with the merge window.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>