### PR TITLE
DAOS-10821 chk: handle dangling pool even if all check engine done

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -415,7 +415,7 @@ chk_pool_filter(uuid_t uuid, void *arg)
 		}
 	}
 
-	return found ? 1 : 0;
+	return found ? 0 : 1;
 }
 
 int

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -1727,6 +1727,25 @@ chk_leader_pool_mbs(struct chk_sched_args *csa)
 	return rc;
 }
 
+/*
+ * Whether need to stop current check instance or not.
+ *
+ * \return	1:	the check is completed.
+ * \return	0:	someone wants to stop the check.
+ * \return	-1:	continue the check.
+ */
+static inline int
+chk_leader_need_stop(struct chk_instance *ins)
+{
+	if (d_list_empty(&ins->ci_rank_list))
+		return 1;
+
+	if (!ins->ci_sched_running)
+		return 0;
+
+	return -1;
+}
+
 static void
 chk_leader_sched(void *args)
 {
@@ -1749,11 +1768,6 @@ again:
 		D_GOTO(out, rc = 0);
 	}
 
-	if (d_list_empty(&ins->ci_rank_list)) {
-		ABT_mutex_unlock(ins->ci_abt_mutex);
-		D_GOTO(out, rc = 1);
-	}
-
 	if (ins->ci_started) {
 		ABT_mutex_unlock(ins->ci_abt_mutex);
 		goto handle;
@@ -1764,6 +1778,19 @@ again:
 	goto again;
 
 handle:
+	/*
+	 * For very race case, there may be no pools on check engines, so check engines
+	 * may complete check scan very quickly before leader sched here. But there are
+	 * still potential dangling pool entries on MS. Let's check it before complete.
+	 */
+	if (unlikely(d_list_empty(&ins->ci_rank_list))) {
+		rc = chk_leader_handle_pools_list(csa);
+		if (rc == 0)
+			rc = 1;
+
+		D_GOTO(out, bcast = false);
+	}
+
 	phase = chk_leader_find_slowest(ins);
 	if (phase != cbk->cb_phase) {
 		cbk->cb_phase = phase;
@@ -1774,6 +1801,10 @@ handle:
 		rc = chk_leader_handle_pools_list(csa);
 		if (rc != 0)
 			D_GOTO(out, bcast = true);
+
+		rc = chk_leader_need_stop(ins);
+		if (rc >= 0)
+			goto out;
 
 		iv.ci_gen = cbk->cb_gen;
 		iv.ci_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST;
@@ -1802,9 +1833,17 @@ handle:
 	}
 
 	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
+		rc = chk_leader_need_stop(ins);
+		if (rc >= 0)
+			goto out;
+
 		rc = chk_leader_handle_pools_svc(csa);
 		if (rc != 0)
 			D_GOTO(out, bcast = true);
+
+		rc = chk_leader_need_stop(ins);
+		if (rc >= 0)
+			goto out;
 
 		iv.ci_gen = cbk->cb_gen;
 		iv.ci_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS;
@@ -1833,20 +1872,21 @@ handle:
 	}
 
 	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS) {
+		rc = chk_leader_need_stop(ins);
+		if (rc >= 0)
+			goto out;
+
 		rc = chk_leader_pool_mbs(csa);
 		if (rc != 0)
 			D_GOTO(out, bcast = true);
 	}
 
-	while (ins->ci_sched_running) {
+	while (1) {
+		rc = chk_leader_need_stop(ins);
+		if (rc >= 0)
+			goto out;
+
 		dss_sleep(300);
-
-		/* Someone wants to stop the check. */
-		if (!ins->ci_sched_running)
-			D_GOTO(out, rc = 0);
-
-		if (d_list_empty(&ins->ci_rank_list))
-			D_GOTO(out, rc = 1);
 
 		/*
 		 * TBD: The leader may need to detect engines' status/phase actively, otherwise


### PR DESCRIPTION
Some check engines may complete the check very soon because of no pools exist on them. But there may be dangling pools exist on MS. So the check leader still needs to handle the potential dangling pool even if all check engines have completed the check.

Signed-off-by: Fan Yong <fan.yong@intel.com>