### PR TITLE
DAOS-10423 container: check container hdl in rdb

### DIFF
--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -288,4 +288,6 @@ int ds_cont_metrics_count(void);
 int cont_child_gather_oids(struct ds_cont_child *cont, uuid_t coh_uuid,
 			   daos_epoch_t epoch);
 
+int ds_cont_hdl_rdb_lookup(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
+			   struct container_hdl *chdl);
 #endif /* __CONTAINER_SRV_INTERNAL_H__ */


### PR DESCRIPTION
During leader switch, the IV container hdl cache
might not be migrated to the new leader, so let's
check the container hdl in RDB if it does not exist in IV cache.

Signed-off-by: Di Wang <di.wang@intel.com>