### PR TITLE
DAOS-11540 tests: only free line upon exit in verify_state_in_log()

### DIFF
--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -1266,12 +1266,15 @@ int verify_state_in_log(char *host, char *log_file, char *state)
 
 		if (fp != NULL)
 			pclose(fp);
-		free(line);
 	}
 
+	if (line)
+		free(line);
 	D_FREE(tmp);
 	return -DER_INVAL;
 out:
+	if (line)
+		free(line);
 	D_FREE(tmp);
 	return 0;
 }


### PR DESCRIPTION
Prior to this patch line pointer was freed upon each loop where it could be re-used by getline(), so this was a potential use-after-free situation, but also a double-free one !! Since getline() can use an already allocated buffer and also manage to re-allocate it if needed, only free line pointer upon exit/return cases.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>