### PR TITLE
DAOS-11533 tests: Move io_conf files out of /usr/bin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.3.100-22) unstable; urgency=medium
+  [ Jeff Olivier ]
+  * Move io_conf files from bin to TESTING
+
+ -- Jeff Olivier <jeffrey.v.olivier@intel.com>  Thu, 9 Sep 2022 10:26:00 -0400
+
 daos (2.3.100-21) unstable; urgency=medium
   [ Jeff Olivier ]
   * Update PMDK to 1.12.1~rc1 to fix DAOS-11151

--- a/debian/daos-client-tests.install
+++ b/debian/daos-client-tests.install
@@ -9,7 +9,6 @@ usr/bin/dfuse_test
 usr/bin/job_tests
 usr/bin/eq_tests
 usr/bin/security_test
-usr/bin/io_conf
 usr/bin/fault_status
 usr/lib64/libdaos_tests.so
 etc/daos/fault-inject-cart.yaml

--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -126,11 +126,11 @@ def scons():
     denv.Install('$PREFIX/bin/', daostest)
     denv.Install('$PREFIX/bin/', dfstest)
     denv.Install('$PREFIX/bin/', daosdebug)
-    denv.Install('$PREFIX/bin/io_conf', 'io_conf/daos_io_conf_1')
-    denv.Install('$PREFIX/bin/io_conf', 'io_conf/daos_io_conf_2')
-    denv.Install('$PREFIX/bin/io_conf', 'io_conf/daos_io_conf_3')
-    denv.Install('$PREFIX/bin/io_conf', 'io_conf/daos_io_conf_4')
-    denv.Install('$PREFIX/bin/io_conf', 'io_conf/daos_io_conf_5')
+    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_1')
+    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_2')
+    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_3')
+    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_4')
+    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_5')
     SConscript('io_conf/SConscript', exports='denv')
 
 

--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -126,11 +126,11 @@ def scons():
     denv.Install('$PREFIX/bin/', daostest)
     denv.Install('$PREFIX/bin/', dfstest)
     denv.Install('$PREFIX/bin/', daosdebug)
-    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_1')
-    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_2')
-    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_3')
-    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_4')
-    denv.Install('$PREFIX/TESTING/io_conf', 'io_conf/daos_io_conf_5')
+    denv.Install('$PREFIX/lib/daos/TESTING/io_conf', 'io_conf/daos_io_conf_1')
+    denv.Install('$PREFIX/lib/daos/TESTING/io_conf', 'io_conf/daos_io_conf_2')
+    denv.Install('$PREFIX/lib/daos/TESTING/io_conf', 'io_conf/daos_io_conf_3')
+    denv.Install('$PREFIX/lib/daos/TESTING/io_conf', 'io_conf/daos_io_conf_4')
+    denv.Install('$PREFIX/lib/daos/TESTING/io_conf', 'io_conf/daos_io_conf_5')
     SConscript('io_conf/SConscript', exports='denv')
 
 

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -1552,7 +1552,8 @@ epoch_io_predefined(void **state)
 		print_message("will run predefined io_conf %s ...\n",
 			      predefined_io_confs[i]);
 
-		rc = snprintf(tmp, PATH_APPEND, "/../TESTING/io_conf/%s", predefined_io_confs[i]);
+		rc = snprintf(tmp, PATH_APPEND, "/../lib/daos/TESTING/io_conf/%s",
+			      predefined_io_confs[i]);
 		tmp[PATH_APPEND - 1] = 0;
 
 		rc = io_conf_run(arg, path);

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.3.100
-Release:       21%{?relval}%{?dist}
+Release:       22%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -493,7 +493,6 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{daoshome}/TESTING
 %{_bindir}/hello_drpc
 %{_libdir}/libdaos_tests.so
-%{_bindir}/io_conf
 %{_bindir}/common_test
 %{_bindir}/acl_dump_test
 %{_bindir}/agent_tests
@@ -561,6 +560,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Thu Sep 9 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.3.100-22
+- Move io_conf files from bin to TESTING 
+
 * Tue Aug 16 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.3.100-21
 - Update PMDK to 1.12.1~rc1 to fix DAOS-11151
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -561,7 +561,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 
 %changelog
 * Thu Sep 9 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.3.100-22
-- Move io_conf files from bin to TESTING 
+- Move io_conf files from bin to TESTING
 
 * Tue Aug 16 2022 Jeff Olivier <jeffrey.v.olivier@intel.com> 2.3.100-21
 - Update PMDK to 1.12.1~rc1 to fix DAOS-11151


### PR DESCRIPTION
Also fix up daos_test -x to find them.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>