### PR TITLE
DAOS-11552 control: Support 2.0/2.2 agent interop

### DIFF
--- a/src/control/build/interop_test.go
+++ b/src/control/build/interop_test.go
@@ -88,6 +88,34 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 			b:      testComponent(t, "", "1.2.0"),
 			expErr: errors.New("incompatible components"),
 		},
+		"2.4 server compatible with 2.2 agent": {
+			a: testComponent(t, "server", "2.4.0"),
+			b: testComponent(t, "agent", "2.2.0"),
+		},
+		"2.4 agent compatible with 2.2 server": {
+			a: testComponent(t, "server", "2.2.0"),
+			b: testComponent(t, "agent", "2.4.0"),
+		},
+		"2.6 server not compatible with 2.2 agent": {
+			a:      testComponent(t, "server", "2.6.0"),
+			b:      testComponent(t, "agent", "2.2.0"),
+			expErr: errors.New("incompatible components"),
+		},
+		"2.6 agent not compatible with 2.2 server": {
+			a:      testComponent(t, "server", "2.2.0"),
+			b:      testComponent(t, "agent", "2.6.0"),
+			expErr: errors.New("incompatible components"),
+		},
+		"3.4 server not compatible with 2.2 agent": {
+			a:      testComponent(t, "server", "3.4.0"),
+			b:      testComponent(t, "agent", "2.2.0"),
+			expErr: errors.New("incompatible components"),
+		},
+		"unversioned agent (assume 2.0.x) compatible with 2.2.x server": {
+			a:          testComponent(t, "server", "2.1.100"),
+			b:          testComponent(t, "agent", "0.0.0"),
+			customRule: build.Server22xAgent20x,
+		},
 		// --- Unit testing ---
 		"nil a": {
 			a:      nil,
@@ -106,7 +134,7 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 		},
 		"general: server/agent minor delta too large": {
 			a:      testComponent(t, "server", "1.0.0"),
-			b:      testComponent(t, "agent", "1.1.0"),
+			b:      testComponent(t, "agent", "1.3.0"),
 			expErr: errors.New("incompatible components"),
 		},
 		"custom: specific version not backwards compatible": {
@@ -141,7 +169,7 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var gotErr error
 			if tc.customRule != nil {
-				gotErr = build.CheckCompatibility(tc.a, tc.b, *tc.customRule)
+				gotErr = build.CheckCompatibility(tc.a, tc.b, tc.customRule)
 			} else {
 				gotErr = build.CheckCompatibility(tc.a, tc.b)
 			}

--- a/src/control/build/version.go
+++ b/src/control/build/version.go
@@ -101,6 +101,12 @@ func (v Version) GreaterThan(other Version) bool {
 	return v.Patch > other.Patch
 }
 
+// GreaterThanOrEquals tests if the version is greater than or
+// equal to the other.
+func (v Version) GreaterThanOrEquals(other Version) bool {
+	return v.GreaterThan(other) || v.Equals(other)
+}
+
 // LessThan tests if the version is less than the other.
 func (v Version) LessThan(other Version) bool {
 	if v.Major < other.Major {
@@ -112,6 +118,12 @@ func (v Version) LessThan(other Version) bool {
 	}
 
 	return v.Patch < other.Patch
+}
+
+// LessThanOrEquals tests if the version is less than or
+// equal to the other.
+func (v Version) LessThanOrEquals(other Version) bool {
+	return v.LessThan(other) || v.Equals(other)
 }
 
 // PatchCompatible tests if the major and minor versions

--- a/src/control/cmd/daos_agent/attachinfo.go
+++ b/src/control/cmd/daos_agent/attachinfo.go
@@ -1,8 +1,9 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
+
 package main
 
 import (
@@ -40,6 +41,7 @@ func (cmd *dumpAttachInfoCmd) Execute(_ []string) error {
 		AllRanks: true,
 	}
 	req.SetSystem(cmd.cfg.SystemName)
+	req.SetAgentRequest()
 	resp, err := control.GetAttachInfo(ctx, cmd.ctlInvoker, req)
 	if err != nil {
 		return errors.Wrap(err, "GetAttachInfo failed")

--- a/src/control/cmd/daos_agent/mgmt_rpc.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc.go
@@ -193,6 +193,7 @@ func (mod *mgmtModule) getAttachInfoRemote(ctx context.Context, numaNode int, sy
 	// cache can serve future "pbReq.AllRanks == true" requests.
 	req := new(control.GetAttachInfoReq)
 	req.SetSystem(sys)
+	req.SetAgentRequest()
 	req.AllRanks = true
 	resp, err := control.GetAttachInfo(ctx, mod.ctlInvoker, req)
 	if err != nil {

--- a/src/control/cmd/daos_agent/mgmt_rpc_test.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc_test.go
@@ -116,6 +116,12 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 		},
 		"incompatible fault": {
 			rpcResps: []*control.HostResponse{
+				// First one will be retried.
+				{
+					Error: &fault.Fault{
+						Code: code.ServerWrongSystem,
+					},
+				},
 				{
 					Error: &fault.Fault{
 						Code: code.ServerWrongSystem,

--- a/src/control/cmd/daos_agent/procmon.go
+++ b/src/control/cmd/daos_agent/procmon.go
@@ -247,6 +247,7 @@ func (p *procMon) cleanupLeakedHandles(ctx context.Context, info *procInfo) {
 		handles := info.handles[poolUUID].ToSlice()
 		req := &control.PoolEvictReq{ID: poolUUID, Handles: handles}
 		req.SetSystem(p.systemName)
+		req.SetAgentRequest()
 
 		err := control.PoolEvict(ctx, p.ctlInvoker, req)
 		if err != nil {

--- a/src/control/server/interceptors.go
+++ b/src/control/server/interceptors.go
@@ -145,7 +145,7 @@ func checkVersion(ctx context.Context, self *build.VersionedComponent, req inter
 	}
 
 	other, err := build.NewVersionedComponent(buildComponent, otherVersion)
-	if err != nil || other.Version.IsZero() {
+	if err != nil {
 		other = &build.VersionedComponent{
 			Component: "unknown",
 			Version:   build.MustNewVersion(otherVersion),
@@ -153,7 +153,11 @@ func checkVersion(ctx context.Context, self *build.VersionedComponent, req inter
 		return FaultIncompatibleComponents(self, other)
 	}
 
-	if err := build.CheckCompatibility(self, other); err != nil {
+	// Set per-release compatibility rules here.
+	releaseCompatRules := []*build.InteropRule{
+		build.Server22xAgent20x,
+	}
+	if err := build.CheckCompatibility(self, other, releaseCompatRules...); err != nil {
 		return FaultIncompatibleComponents(self, other)
 	}
 

--- a/src/control/server/interceptors_test.go
+++ b/src/control/server/interceptors_test.go
@@ -122,7 +122,7 @@ func TestServer_checkVersion(t *testing.T) {
 		"secure pre-2.0.0 component with version somehow is still incompatible": {
 			selfVersion:  "2.2.0",
 			otherVersion: "1.0.0",
-			ctx:          newTestAuthCtx(context.TODO(), "agent"),
+			ctx:          newTestAuthCtx(context.TODO(), "admin"),
 			expErr:       errors.New("not compatible"),
 		},
 		"unknown secure component rejected": {


### PR DESCRIPTION
A 2.2 agent must be able to communicate with a 2.0 server,
and a 2.0 agent must be able to communicate with a 2.2
server. Also adds a compatibility rule for future releases
to allow server/agent interopability within 2 minor versions.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
