### PR TITLE
DAOS-11205 test: support access_points_suffix (#9986)

### DIFF
--- a/src/tests/ftest/harness/config.py
+++ b/src/tests/ftest/harness/config.py
@@ -1,0 +1,70 @@
+"""
+(C) Copyright 2021-2022 Intel Corporation.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import yaml
+
+from apricot import TestWithServers
+
+from general_utils import nodeset_append_suffix
+from dmg_utils import DmgCommand
+
+
+class HarnessConfigTest(TestWithServers):
+    """Harness config test cases.
+
+    :avocado: recursive
+    """
+
+    def test_harness_config_access_points(self):
+        """Verify the TestWithServers.access_points handling.
+
+        :avocado: tags=all
+        :avocado: tags=vm
+        :avocado: tags=harness
+        :avocado: tags=test_harness_config_access_points
+        """
+        self.log.info('Verify access_points_suffix set from yaml')
+        access_points_suffix = self.params.get("access_points_suffix", "/run/setup/*")
+        self.assertEqual(self.access_points_suffix, access_points_suffix)
+
+        self.log.info('Verify access_points_suffix is appended exactly once')
+        access_points = nodeset_append_suffix(self.access_points, access_points_suffix)
+        self.assertEqual(sorted(self.access_points), sorted(access_points))
+        access_points = nodeset_append_suffix(access_points, access_points_suffix)
+        self.assertEqual(sorted(self.access_points), sorted(access_points))
+
+        self.log.info('Verify self.get_dmg_command().hostlist_suffix and hostlist')
+        dmg = self.get_dmg_command()
+        self.assertEqual(dmg.hostlist_suffix, self.access_points_suffix)
+        expected_hostlist = sorted(nodeset_append_suffix(dmg.hostlist, self.access_points_suffix))
+        self.assertEqual(sorted(dmg.hostlist), expected_hostlist)
+
+        self.log.info('Verify self.get_dmg_command().yaml.get_yaml_data()["hostlist"]')
+        self.assertEqual(sorted(dmg.yaml.get_yaml_data()['hostlist']), expected_hostlist)
+
+        self.log.info('Verify DmgCommand().hostlist_suffix and hostlist')
+        dmg2 = DmgCommand(self.bin, hostlist_suffix=access_points_suffix)
+        dmg2.hostlist = dmg.hostlist
+        self.assertEqual(dmg2.hostlist_suffix, self.access_points_suffix)
+        self.assertEqual(sorted(dmg2.hostlist), expected_hostlist)
+
+        self.log.info('Verify server_manager...get_yaml_data...access_points"]')
+        yaml_data = self.server_managers[0].manager.job.yaml.get_yaml_data()
+        self.assertEqual(sorted(yaml_data['access_points']), sorted(self.access_points))
+
+        self.log.info('Verify daos_server.yaml access_points')
+        with open(self.server_managers[0].manager.job.temporary_file, 'r') as yaml_file:
+            daos_server_yaml = yaml.safe_load(yaml_file.read())
+        self.assertEqual(sorted(daos_server_yaml['access_points']), sorted(self.access_points))
+
+        self.log.info('Verify daos_control.yaml hostlist')
+        with open(self.get_dmg_command().temporary_file, 'r') as yaml_file:
+            daos_agent_yaml = yaml.safe_load(yaml_file.read())
+        self.assertEqual(sorted(daos_agent_yaml['hostlist']), expected_hostlist)
+
+        self.log.info('Verify daos_agent.yaml access_points')
+        with open(self.agent_managers[0].manager.job.temporary_file, 'r') as yaml_file:
+            daos_agent_yaml = yaml.safe_load(yaml_file.read())
+        self.assertEqual(sorted(daos_agent_yaml['access_points']), sorted(self.access_points))

--- a/src/tests/ftest/harness/config.yaml
+++ b/src/tests/ftest/harness/config.yaml
@@ -1,0 +1,8 @@
+hosts:
+  test_servers: 2
+  test_clients: 1
+timeout: 60
+setup:
+  access_points_suffix: .wolf.hpdd.intel.com
+server_config:
+  name: daos_server

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -16,6 +15,7 @@ from avocado import fail_on, skip, TestFail
 from avocado import Test as avocadoTest
 from avocado.core import exceptions
 from ClusterShell.NodeSet import NodeSet
+from pydaos.raw import DaosContext, DaosLog, DaosApiError
 
 from agent_utils import DaosAgentManager, include_local_host
 from cart_ctl_utils import CartCtl
@@ -28,9 +28,8 @@ from fault_config_utils import FaultInjection
 from general_utils import \
     get_partition_hosts, stop_processes, get_default_config_file, pcmd, get_file_listing, \
     DaosTestError, run_command, get_avocado_config_value, set_avocado_config_value, \
-    dump_engines_stacks
+    dump_engines_stacks, nodeset_append_suffix
 from logger_utils import TestLogger
-from pydaos.raw import DaosContext, DaosLog, DaosApiError
 from server_utils import DaosServerManager
 from test_utils_container import TestContainer
 from test_utils_pool import LabelGenerator, add_pool, POOL_NAMESPACE
@@ -705,6 +704,9 @@ class TestWithServers(TestWithoutServers):
         self.dumped_engines_stacks = False
         self.label_generator = LabelGenerator()
 
+        # Suffix to append to each access point name
+        self.access_points_suffix = None
+
     def setUp(self):
         """Set up each test case."""
         super().setUp()
@@ -763,6 +765,11 @@ class TestWithServers(TestWithoutServers):
         default_access_points = self.hostlist_servers[:access_points_qty]
         self.access_points = NodeSet(
             self.params.get("access_points", "/run/setup/*", default_access_points))
+        self.access_points_suffix = self.params.get(
+            "access_points_suffix", "/run/setup/*", self.access_points_suffix)
+        if self.access_points_suffix:
+            self.access_points = nodeset_append_suffix(
+                self.access_points, self.access_points_suffix)
 
         # Display host information
         self.log.info("-" * 100)
@@ -1159,7 +1166,7 @@ class TestWithServers(TestWithoutServers):
             DaosServerManager(
                 group, self.bin, svr_cert_dir, svr_config_file, dmg_cert_dir,
                 dmg_config_file, svr_config_temp, dmg_config_temp,
-                self.server_manager_class)
+                self.server_manager_class, access_points_suffix=self.access_points_suffix)
         )
 
     def configure_manager(self, name, manager, hosts, slots, access_points=None):
@@ -1692,7 +1699,7 @@ class TestWithServers(TestWithoutServers):
 
         dmg_cmd = get_dmg_command(
             self.server_group, dmg_cert_dir, self.bin, dmg_config_file,
-            dmg_config_temp)
+            dmg_config_temp, self.access_points_suffix)
         dmg_cmd.hostlist = self.access_points
         return dmg_cmd
 

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2018-2022 Intel Corporation.
 
@@ -19,7 +18,7 @@ class DmgJsonCommandFailure(CommandFailure):
     """Exception raised when a dmg --json command fails."""
 
 
-def get_dmg_command(group, cert_dir, bin_dir, config_file, config_temp=None):
+def get_dmg_command(group, cert_dir, bin_dir, config_file, config_temp=None, hostlist_suffix=None):
     """Get a dmg command object.
 
     Args:
@@ -31,6 +30,8 @@ def get_dmg_command(group, cert_dir, bin_dir, config_file, config_temp=None):
             configuration file locally and then copy it to all the hosts using
             the config_file specification. Defaults to None, which creates and
             utilizes the file specified by config_file.
+        hostlist_suffix (str, optional): Suffix to append to each host name.
+            Defaults to None.
 
     Returns:
         DmgCommand: the dmg command object
@@ -38,7 +39,7 @@ def get_dmg_command(group, cert_dir, bin_dir, config_file, config_temp=None):
     """
     transport_config = DmgTransportCredentials(cert_dir)
     config = DmgYamlParameters(config_file, group, transport_config)
-    command = DmgCommand(bin_dir, config)
+    command = DmgCommand(bin_dir, config, hostlist_suffix)
     if config_temp:
         # Setup the DaosServerCommand to write the config file data to the
         # temporary file and then copy the file to all the hosts using the

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -8,15 +7,15 @@ from socket import gethostname
 
 from ClusterShell.NodeSet import NodeSet
 
-from command_utils_base import \
-    FormattedParameter, CommandWithParameters
+from command_utils_base import FormattedParameter, CommandWithParameters
 from command_utils import CommandWithSubCommand, YamlCommand
+from general_utils import nodeset_append_suffix
 
 
 class DmgCommandBase(YamlCommand):
     """Defines a base object representing a dmg command."""
 
-    def __init__(self, path, yaml_cfg=None):
+    def __init__(self, path, yaml_cfg=None, hostlist_suffix=None):
         """Create a dmg Command object.
 
         Args:
@@ -24,6 +23,7 @@ class DmgCommandBase(YamlCommand):
             yaml_cfg (DmgYamlParameters, optional): dmg config file
                 settings. Defaults to None, in which case settings
                 must be supplied as command-line parameters.
+            hostlist_suffix (str, optional): Suffix to append to each host name. Defaults to None.
         """
         super().__init__("/run/dmg/*", "dmg", path, yaml_cfg)
 
@@ -34,6 +34,8 @@ class DmgCommandBase(YamlCommand):
         default_yaml_file = None
         if self.yaml is not None and hasattr(self.yaml, "filename"):
             default_yaml_file = self.yaml.filename
+
+        self.hostlist_suffix = hostlist_suffix
 
         self._hostlist = FormattedParameter("-l {}")
         self.hostfile = FormattedParameter("-f {}")
@@ -61,6 +63,9 @@ class DmgCommandBase(YamlCommand):
         Args:
             hostlist (string list): list of host addresses
         """
+        if self.hostlist_suffix:
+            hostlist = nodeset_append_suffix(hostlist, self.hostlist_suffix)
+
         if self.yaml:
             if isinstance(hostlist, NodeSet):
                 hostlist = list(hostlist)

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2018-2022 Intel Corporation.
 
@@ -529,7 +528,7 @@ def colate_results(command, results):
     res += "Results:\n"
     for result in results:
         res += "  %s: exit_status=%s, interrupted=%s:" % (
-               result["hosts"], result["exit_status"], result["interrupted"])
+            result["hosts"], result["exit_status"], result["interrupted"])
         for line in result["stdout"]:
             res += "    %s\n" % line
 
@@ -1525,3 +1524,19 @@ def set_avocado_config_value(section, key, value):
         settings.update_option(".".join([section, key]), value)
     else:
         settings.config.set(section, key, str(value))
+
+
+def nodeset_append_suffix(nodeset, suffix):
+    """Append a suffix to each element of a NodeSet/list.
+
+    Only appends if the element does not already end with the suffix.
+
+    Args:
+        nodeset (NodeSet/list): the NodeSet or list
+        suffix: the suffix to append
+
+    Returns:
+        NodeSet: a new NodeSet with the suffix
+    """
+    return NodeSet.fromlist(
+        map(lambda host: host if host.endswith(suffix) else host + suffix, nodeset))

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -1,9 +1,10 @@
-#!/usr/bin/python
 """
   (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+# pylint: disable=too-many-lines
+
 from getpass import getuser
 import math
 import os
@@ -13,6 +14,7 @@ import yaml
 import random
 
 from avocado import fail_on
+from ClusterShell.NodeSet import NodeSet
 
 from command_utils_base import CommonConfig, BasicParameter
 from exception_utils import CommandFailure
@@ -24,7 +26,6 @@ from dmg_utils import get_dmg_command
 from server_utils_base import \
     ServerFailed, DaosServerCommand, DaosServerInformation, AutosizeCancel
 from server_utils_params import DaosServerTransportCredentials, DaosServerYamlParameters
-from ClusterShell.NodeSet import NodeSet
 
 
 def get_server_command(group, cert_dir, bin_dir, config_file, config_temp=None):
@@ -73,7 +74,8 @@ class DaosServerManager(SubprocessManager):
     def __init__(self, group, bin_dir,
                  svr_cert_dir, svr_config_file, dmg_cert_dir, dmg_config_file,
                  svr_config_temp=None, dmg_config_temp=None, manager="Orterun",
-                 namespace="/run/server_manager/*"):
+                 namespace="/run/server_manager/*", access_points_suffix=None):
+        # pylint: disable=too-many-arguments
         """Initialize a DaosServerManager object.
 
         Args:
@@ -93,6 +95,8 @@ class DaosServerManager(SubprocessManager):
                 manage the YamlCommand defined through the "job" attribute.
                 Defaults to "Orterun".
             namespace (str): yaml namespace (path to parameters)
+            access_points_suffix (str, optional): Suffix to append to each access point name.
+                Defaults to None.
         """
         self.group = group
         server_command = get_server_command(
@@ -102,7 +106,8 @@ class DaosServerManager(SubprocessManager):
 
         # Dmg command to access this group of servers which will be configured
         # to access the daos_servers when they are started
-        self.dmg = get_dmg_command(group, dmg_cert_dir, bin_dir, dmg_config_file, dmg_config_temp)
+        self.dmg = get_dmg_command(
+            group, dmg_cert_dir, bin_dir, dmg_config_file, dmg_config_temp, access_points_suffix)
 
         # Set the correct certificate file ownership
         if manager == "Systemctl":
@@ -870,8 +875,8 @@ class DaosServerManager(SubprocessManager):
         self.log.info("Resetting engine_params")
         self.manager.job.yaml.engine_params = []
         engines = generated_yaml["engines"]
-        for i, engine in enumerate(engines):
-            self.log.info("engine %d", i)
+        for idx, engine in enumerate(engines):
+            self.log.info("engine %d", idx)
             for storage_tier in engine["storage"]:
                 if storage_tier["class"] != "dcpm":
                     continue
@@ -880,15 +885,14 @@ class DaosServerManager(SubprocessManager):
                 self.log.info("class = %s", storage_tier["class"])
                 self.log.info("scm_list = %s", storage_tier["scm_list"])
 
-                per_engine_yaml_parameters = DaosServerYamlParameters.PerEngineYamlParameters(i)
+                per_engine_yaml_parameters = DaosServerYamlParameters.PerEngineYamlParameters(idx)
                 per_engine_yaml_parameters.scm_mount.update(storage_tier["scm_mount"])
                 per_engine_yaml_parameters.scm_class.update(storage_tier["class"])
                 per_engine_yaml_parameters.scm_size.update(None)
                 per_engine_yaml_parameters.scm_list.update(storage_tier["scm_list"])
                 per_engine_yaml_parameters.reset_yaml_data_updated()
 
-                self.manager.job.yaml.engine_params.append(
-                    per_engine_yaml_parameters)
+                self.manager.job.yaml.engine_params.append(per_engine_yaml_parameters)
 
     def get_host_ranks(self, hosts):
         """Get the list of ranks for the specified hosts.


### PR DESCRIPTION
Test-tag: pr,-hw test_harness_config_access_points

- Support specifying access_points_suffix in test config, which will be appended to each hostname.
- Add ftest/harness/config to test this usage

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>