### PR TITLE
DAOS-11437 test: Support multiple IP addresses per node for test_netw…

### DIFF
--- a/src/tests/ftest/deployment/network_failure.yaml
+++ b/src/tests/ftest/deployment/network_failure.yaml
@@ -39,7 +39,7 @@ pool_size_ratio_80:
   size: 80%
   control_method: dmg
 pool_size_value:
-  size: 50G
+  size: 100G
   control_method: dmg
 
 container_wo_rf:


### PR DESCRIPTION
…… (#10087)

The network failure isolation test was written with the assumption of
one IP address per node. However, in Aurora, there are two IP
addresses per node. Update `create_ip_to_host()` to handle multiple
IP addresses.

Also increase pool size for the test.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: target_failure_wo_rf network_failure_isolation
Required-githooks: true
Test-repeat: 5
Signed-off-by: Makito Kano <makito.kano@intel.com>