### PR TITLE
DAOS-11522 control: Allow server/agent interop across minor versions

### DIFF
--- a/src/control/build/interop_test.go
+++ b/src/control/build/interop_test.go
@@ -88,6 +88,29 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 			b:      testComponent(t, "", "1.2.0"),
 			expErr: errors.New("incompatible components"),
 		},
+		"2.4 server compatible with 2.2 agent": {
+			a: testComponent(t, "server", "2.4.0"),
+			b: testComponent(t, "agent", "2.2.0"),
+		},
+		"2.4 agent compatible with 2.2 server": {
+			a: testComponent(t, "server", "2.2.0"),
+			b: testComponent(t, "agent", "2.4.0"),
+		},
+		"2.6 server not compatible with 2.2 agent": {
+			a:      testComponent(t, "server", "2.6.0"),
+			b:      testComponent(t, "agent", "2.2.0"),
+			expErr: errors.New("incompatible components"),
+		},
+		"2.6 agent not compatible with 2.2 server": {
+			a:      testComponent(t, "server", "2.2.0"),
+			b:      testComponent(t, "agent", "2.6.0"),
+			expErr: errors.New("incompatible components"),
+		},
+		"3.4 server not compatible with 2.2 agent": {
+			a:      testComponent(t, "server", "3.4.0"),
+			b:      testComponent(t, "agent", "2.2.0"),
+			expErr: errors.New("incompatible components"),
+		},
 		// --- Unit testing ---
 		"nil a": {
 			a:      nil,
@@ -106,7 +129,7 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 		},
 		"general: server/agent minor delta too large": {
 			a:      testComponent(t, "server", "1.0.0"),
-			b:      testComponent(t, "agent", "1.1.0"),
+			b:      testComponent(t, "agent", "1.3.0"),
 			expErr: errors.New("incompatible components"),
 		},
 		"custom: specific version not backwards compatible": {
@@ -141,7 +164,7 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var gotErr error
 			if tc.customRule != nil {
-				gotErr = build.CheckCompatibility(tc.a, tc.b, *tc.customRule)
+				gotErr = build.CheckCompatibility(tc.a, tc.b, tc.customRule)
 			} else {
 				gotErr = build.CheckCompatibility(tc.a, tc.b)
 			}

--- a/src/control/build/version.go
+++ b/src/control/build/version.go
@@ -101,6 +101,12 @@ func (v Version) GreaterThan(other Version) bool {
 	return v.Patch > other.Patch
 }
 
+// GreaterThanOrEquals tests if the version is greater than or
+// equal to the other.
+func (v Version) GreaterThanOrEquals(other Version) bool {
+	return v.GreaterThan(other) || v.Equals(other)
+}
+
 // LessThan tests if the version is less than the other.
 func (v Version) LessThan(other Version) bool {
 	if v.Major < other.Major {
@@ -112,6 +118,12 @@ func (v Version) LessThan(other Version) bool {
 	}
 
 	return v.Patch < other.Patch
+}
+
+// LessThanOrEquals tests if the version is less than or
+// equal to the other.
+func (v Version) LessThanOrEquals(other Version) bool {
+	return v.LessThan(other) || v.Equals(other)
 }
 
 // PatchCompatible tests if the major and minor versions

--- a/src/control/server/interceptors.go
+++ b/src/control/server/interceptors.go
@@ -145,7 +145,7 @@ func checkVersion(ctx context.Context, self *build.VersionedComponent, req inter
 	}
 
 	other, err := build.NewVersionedComponent(buildComponent, otherVersion)
-	if err != nil || other.Version.IsZero() {
+	if err != nil {
 		other = &build.VersionedComponent{
 			Component: "unknown",
 			Version:   build.MustNewVersion(otherVersion),

--- a/src/control/server/interceptors_test.go
+++ b/src/control/server/interceptors_test.go
@@ -122,7 +122,7 @@ func TestServer_checkVersion(t *testing.T) {
 		"secure pre-2.0.0 component with version somehow is still incompatible": {
 			selfVersion:  "2.2.0",
 			otherVersion: "1.0.0",
-			ctx:          newTestAuthCtx(context.TODO(), "agent"),
+			ctx:          newTestAuthCtx(context.TODO(), "admin"),
 			expErr:       errors.New("not compatible"),
 		},
 		"unknown secure component rejected": {


### PR DESCRIPTION
Allow servers and agents to communicate if they are within two
minor versions of each other (e.g. 2.2/2.4).

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
