### PR TITLE
DAOS-11498 mgmt: Fix PS replica leaks (#10162)

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -167,10 +167,10 @@ int ds_pool_target_update_state(uuid_t pool_uuid, d_rank_list_t *ranks,
 				struct pool_target_addr_list *target_list,
 				pool_comp_state_t state);
 
-int ds_pool_svc_create(const uuid_t pool_uuid, int ntargets, const char *group,
-		       const d_rank_list_t *target_addrs, int ndomains, const uint32_t *domains,
-		       daos_prop_t *prop, d_rank_list_t *svc_addrs);
-int ds_pool_svc_destroy(const uuid_t pool_uuid, d_rank_list_t *svc_ranks);
+int ds_pool_svc_dist_create(const uuid_t pool_uuid, int ntargets, const char *group,
+			    const d_rank_list_t *target_addrs, int ndomains,
+			    const uint32_t *domains, daos_prop_t *prop, d_rank_list_t *svc_addrs);
+int ds_pool_svc_stop(uuid_t pool_uuid);
 
 int ds_pool_svc_get_prop(uuid_t pool_uuid, d_rank_list_t *ranks,
 			 daos_prop_t *prop);

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -142,8 +142,7 @@ int ds_mgmt_tgt_map_update_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 void ds_mgmt_tgt_mark_hdlr(crt_rpc_t *rpc);
 
 /** srv_util.c */
-int ds_mgmt_group_update(crt_group_mod_op_t op, struct server_entry *servers,
-			 int nservers, uint32_t version);
+int ds_mgmt_group_update(struct server_entry *servers, int nservers, uint32_t version);
 void ds_mgmt_kill_rank(bool force);
 
 #endif /* __SRV_MGMT_INTERNAL_H__ */

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -157,8 +157,8 @@ ds_mgmt_pool_svc_create(uuid_t pool_uuid, int ntargets, const char *group, d_ran
 	D_DEBUG(DB_MGMT, DF_UUID": all tgts created, setting up pool "
 		"svc\n", DP_UUID(pool_uuid));
 
-	return ds_pool_svc_create(pool_uuid, ranks->rl_nr, group, ranks, domains_nr, domains, prop,
-				  svc_list);
+	return ds_pool_svc_dist_create(pool_uuid, ranks->rl_nr, group, ranks, domains_nr, domains,
+				       prop, svc_list);
 }
 
 int
@@ -230,6 +230,12 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 	if (rc) {
 		D_ERROR("create pool "DF_UUID" svc failed: rc "DF_RC"\n",
 			DP_UUID(pool_uuid), DP_RC(rc));
+		/*
+		 * The ds_mgmt_pool_svc_create call doesn't clean up any
+		 * successful PS replica creations upon errors; we clean up
+		 * those here together with other pool resources to save one
+		 * round of RPCs.
+		 */
 		goto out_svcp;
 	}
 
@@ -258,7 +264,6 @@ ds_mgmt_destroy_pool(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 {
 	int		 rc;
 	d_rank_list_t	*ranks = NULL;
-	d_rank_list_t	*filtered_svc = NULL;
 
 	D_DEBUG(DB_MGMT, "Destroying pool "DF_UUID"\n", DP_UUID(pool_uuid));
 
@@ -275,38 +280,15 @@ ds_mgmt_destroy_pool(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 		goto out;
 	}
 
-	/* Destroy pool service. Send corpc only to svc_ranks found in ranks.
-	 * Control plane may not have been updated yet if any of svc_ranks
-	 * were recently excluded from the pool.
-	 */
-	rc = d_rank_list_dup(&filtered_svc, svc_ranks);
-	if (rc)
-		D_GOTO(free_ranks, rc = -DER_NOMEM);
-	d_rank_list_filter(ranks, filtered_svc, false /* exclude */);
-	if (!d_rank_list_identical(filtered_svc, svc_ranks)) {
-		D_DEBUG(DB_MGMT, DF_UUID": %u svc_ranks, but only %u found "
-			"in pool map\n", DP_UUID(pool_uuid),
-			svc_ranks->rl_nr, filtered_svc->rl_nr);
-	}
-
-	rc = ds_pool_svc_destroy(pool_uuid, filtered_svc);
-	if (rc != 0) {
-		D_ERROR("Failed to destroy pool service " DF_UUID ", "
-			DF_RC "\n", DP_UUID(pool_uuid), DP_RC(rc));
-		goto free_filtered;
-	}
-
 	rc = ds_mgmt_tgt_pool_destroy(pool_uuid, ranks);
 	if (rc != 0) {
 		D_ERROR("Destroying pool "DF_UUID" failed, " DF_RC ".\n",
 			DP_UUID(pool_uuid), DP_RC(rc));
-		goto free_filtered;
+		goto free_ranks;
 	}
 
 	D_DEBUG(DB_MGMT, "Destroying pool " DF_UUID " succeeded.\n",
 		DP_UUID(pool_uuid));
-free_filtered:
-	d_rank_list_free(filtered_svc);
 free_ranks:
 	d_rank_list_free(ranks);
 out:

--- a/src/mgmt/srv_system.c
+++ b/src/mgmt/srv_system.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -179,15 +179,9 @@ ds_mgmt_group_update_handler(struct mgmt_grp_up_in *in)
 	if (rc != 0 && rc != -DER_NOTLEADER)
 		goto out;
 
-	D_DEBUG(DB_MGMT, "setting %d servers in map version %u\n",
-		in->gui_n_servers, in->gui_map_version);
-	rc = ds_mgmt_group_update(CRT_GROUP_MOD_OP_REPLACE, in->gui_servers,
-				  in->gui_n_servers, in->gui_map_version);
+	rc = ds_mgmt_group_update(in->gui_servers, in->gui_n_servers, in->gui_map_version);
 	if (rc != 0)
 		goto out_svc;
-
-	D_DEBUG(DB_MGMT, "set %d servers in map version %u\n",
-		in->gui_n_servers, in->gui_map_version);
 
 	map_servers = dup_server_list(in->gui_servers, in->gui_n_servers);
 	if (map_servers == NULL) {

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -975,6 +975,18 @@ ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *td_req)
 	D_DEBUG(DB_MGMT, DF_UUID": ready to destroy targets\n",
 		DP_UUID(td_in->td_pool_uuid));
 
+	/*
+	 * If there is a local PS replica, its RDB file will be deleted later
+	 * together with the other pool files by the tgt_destroy call below; if
+	 * there is no local PS replica, rc will be zero.
+	 */
+	rc = ds_pool_svc_stop(td_in->td_pool_uuid);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to stop pool service replica (if any): "DF_RC"\n",
+			DP_UUID(td_in->td_pool_uuid), DP_RC(rc));
+		goto out;
+	}
+
 	ds_pool_stop(td_in->td_pool_uuid);
 
 	/** generate path to the target directory */
@@ -1100,23 +1112,9 @@ int
 ds_mgmt_tgt_map_update_pre_forward(crt_rpc_t *rpc, void *arg)
 {
 	struct mgmt_tgt_map_update_in  *in = crt_req_get(rpc);
-	uint32_t			version;
-	int				rc;
 
-	rc = crt_group_version(NULL /* grp */, &version);
-	D_ASSERTF(rc == 0, "%d\n", rc);
-	D_DEBUG(DB_MGMT, "in=%u current=%u\n", in->tm_map_version, version);
-	if (in->tm_map_version <= version)
-		return 0;
-
-	rc = ds_mgmt_group_update(CRT_GROUP_MOD_OP_REPLACE,
-				  in->tm_servers.ca_arrays,
-				  in->tm_servers.ca_count, in->tm_map_version);
-	if (rc != 0)
-		return rc;
-
-	D_INFO("updated group: %u -> %u\n", version, in->tm_map_version);
-	return 0;
+	return ds_mgmt_group_update(in->tm_servers.ca_arrays, in->tm_servers.ca_count,
+				    in->tm_map_version);
 }
 
 void

--- a/src/pool/README.md
+++ b/src/pool/README.md
@@ -24,7 +24,7 @@ The top-level KVS stores the pool map, security attributes such as the UID, GID 
 
 #### Pool / Pool Service Creation
 
-Pool creation is driven entirely by the Management Service since it requires special privileges for steps related to allocation of storage and querying of fault domains. After formatting all the targets, the management module passes the control to the pool module by calling the`ds_pool_svc_create`, which initializes service replication on the selected subset of nodes for the combined Pool and Container Service. The Pool module now sends a `POOL_CREATE` request to the service leader which creates the service database; the list of targets and their fault domains are then converted into the initial version of the pool map and stored in the pool service, along with other initial pool metadata.
+Pool creation is driven entirely by the Management Service since it requires special privileges for steps related to allocation of storage and querying of fault domains. After formatting all the targets, the management module passes the control to the pool module by calling the`ds_pool_svc_dist_create`, which initializes service replication on the selected subset of nodes for the combined Pool and Container Service. The Pool module now sends a `POOL_CREATE` request to the service leader which creates the service database; the list of targets and their fault domains are then converted into the initial version of the pool map and stored in the pool service, along with other initial pool metadata.
 
 <a id="9.3.2"></a>
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -639,6 +639,11 @@ pool_rsvc_client_complete_rpc(struct rsvc_client *client, const crt_endpoint_t *
  * Create a (combined) pool(/container) service. This method shall be called on
  * a single storage node in the pool.
  *
+ * Note that if the return value is nonzero, the caller is responsible for
+ * stopping and destroying any PS replicas that may have been created. This
+ * behavior is tailored for ds_mgmt_create_pool, who will clean up all pool
+ * resources upon errors.
+ *
  * \param[in]		pool_uuid	pool UUID
  * \param[in]		ntargets	number of targets in the pool
  * \param[in]		group		crt group ID (unused now)
@@ -651,9 +656,9 @@ pool_rsvc_client_complete_rpc(struct rsvc_client *client, const crt_endpoint_t *
  *					list of pool service replica ranks
  */
 int
-ds_pool_svc_create(const uuid_t pool_uuid, int ntargets, const char *group,
-		   const d_rank_list_t *target_addrs, int ndomains, const uint32_t *domains,
-		   daos_prop_t *prop, d_rank_list_t *svc_addrs)
+ds_pool_svc_dist_create(const uuid_t pool_uuid, int ntargets, const char *group,
+			const d_rank_list_t *target_addrs, int ndomains, const uint32_t *domains,
+			daos_prop_t *prop, d_rank_list_t *svc_addrs)
 {
 	d_rank_list_t	       *ranks;
 	d_iov_t			psid;
@@ -682,7 +687,7 @@ ds_pool_svc_create(const uuid_t pool_uuid, int ntargets, const char *group,
 
 	rc = rsvc_client_init(&client, ranks);
 	if (rc != 0)
-		D_GOTO(out_creation, rc);
+		D_GOTO(out_ranks, rc);
 
 	rc = d_backoff_seq_init(&backoff_seq, 0 /* nzeros */, 16 /* factor */,
 				8 /* next (ms) */, 1 << 10 /* max (ms) */);
@@ -740,28 +745,30 @@ out_rpc:
 out_backoff_seq:
 	d_backoff_seq_fini(&backoff_seq);
 	rsvc_client_fini(&client);
-out_creation:
-	if (rc != 0)
-		ds_rsvc_dist_stop(DS_RSVC_CLASS_POOL, &psid, ranks,
-				  NULL, true /* destroy */);
+	/*
+	 * Intentionally skip cleaning up the PS replicas. See the function
+	 * documentation above.
+	 */
 out_ranks:
 	d_rank_list_free(ranks);
 out:
 	return rc;
 }
 
+/** Stop any local PS replica for \a pool_uuid. */
 int
-ds_pool_svc_destroy(const uuid_t pool_uuid, d_rank_list_t *svc_ranks)
+ds_pool_svc_stop(uuid_t pool_uuid)
 {
-	d_iov_t		psid;
-	int		rc;
+	d_iov_t	id;
+	int	rc;
 
-	d_iov_set(&psid, (void *)pool_uuid, sizeof(uuid_t));
-	rc = ds_rsvc_dist_stop(DS_RSVC_CLASS_POOL, &psid, svc_ranks,
-			       NULL /* excluded */, true /* destroy */);
-	if (rc != 0)
-		D_ERROR(DF_UUID": failed to destroy pool service: "DF_RC"\n",
-			DP_UUID(pool_uuid), DP_RC(rc));
+	d_iov_set(&id, pool_uuid, sizeof(uuid_t));
+
+	rc = ds_rsvc_stop(DS_RSVC_CLASS_POOL, &id, false /* destroy */);
+	if (rc == -DER_ALREADY) {
+		D_DEBUG(DB_MD, DF_UUID": ds_rsvc_stop: "DF_RC"\n", DP_UUID(pool_uuid), DP_RC(rc));
+		rc = 0;
+	}
 
 	return rc;
 }


### PR DESCRIPTION
For each pool, the PS ranks stored on the MS may not cover all PS replicas, in and out of the latest PS membership. The PS may have not been able to send the latest PS ranks to the MS. Or, it may have been unable to destroy some PS replicas after removing them from the membership. The ds_mgmt_destroy_pool function currently only destroys the PS replicas in the latest membership known to the MS, leaking any other PS replicas.

This patch removes the step that only destroys the known PS replicas, combines it with the target destroy CoRPC, and attempts to stop any PS replicas on all PS engines. Note that the RDB files shall be deleted along with other pool files. And, ds_pool_svc_create is renamed to ds_pool_svc_dist_create to avoid confusion.

We then have a few interesting directions to explore?

  - Try releasing local pool handles and associated data structures (e.g., container handles) when destroy targets for a force-destroy operation.

  - Allow force-destroy to blindly, repeatedly attempt to destroy a pool, because it no longer needs to know what the PS ranks are and may go straightly to the target destroy CoRPC without contacting the PS, who may have already become unavailable due to previous destroy attempts.

Additionally, this patch fixes an unrelated assertion failure in ds_mgmt_group_update that has happened during its CI testing:

  mgmt EMRG src/mgmt/srv_util.c:33 ds_mgmt_group_update() Assertion
  'version_current < version' failed: 10 < 9

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true