### PR TITLE
DAOS-11511 control: Make ResignLeadership() a noop on some errors

### DIFF
--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -492,7 +492,9 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 			barrierStart := time.Now()
 			if err := db.Barrier(); err != nil {
 				db.log.Errorf("raft Barrier() failed: %s", err)
-				_ = db.ResignLeadership(err)
+				if err = db.ResignLeadership(err); err != nil {
+					db.log.Errorf("raft ResignLeadership() failed: %s", err)
+				}
 				break
 			}
 			db.log.Debugf("raft Barrier() complete after %s", time.Since(barrierStart))
@@ -503,7 +505,9 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 				if err := fn(gainedCtx); err != nil {
 					db.log.Errorf("failure in onLeadershipGained callback: %s", err)
 					cancelGainedCtx()
-					_ = db.ResignLeadership(err)
+					if err = db.ResignLeadership(err); err != nil {
+						db.log.Errorf("raft ResignLeadership() failed: %s", err)
+					}
 					break
 				}
 			}

--- a/src/control/system/raft/mocks.go
+++ b/src/control/system/raft/mocks.go
@@ -25,9 +25,10 @@ type (
 		response interface{}
 	}
 	mockRaftServiceConfig struct {
-		LeaderCh      <-chan bool
-		ServerAddress raft.ServerAddress
-		State         raft.RaftState
+		LeaderCh              <-chan bool
+		ServerAddress         raft.ServerAddress
+		State                 raft.RaftState
+		LeadershipTransferErr error
 	}
 	mockRaftService struct {
 		cfg mockRaftServiceConfig
@@ -66,7 +67,10 @@ func (mrs *mockRaftService) LeaderCh() <-chan bool {
 }
 
 func (mrs *mockRaftService) LeadershipTransfer() raft.Future {
-	return &mockRaftFuture{}
+	if mrs.cfg.LeadershipTransferErr == nil {
+		mrs.cfg.State = raft.Follower
+	}
+	return &mockRaftFuture{err: mrs.cfg.LeadershipTransferErr}
 }
 
 func (mrs *mockRaftService) Shutdown() raft.Future {

--- a/src/control/system/raft/raft.go
+++ b/src/control/system/raft/raft.go
@@ -95,18 +95,21 @@ func IsRaftLeadershipError(err error) bool {
 }
 
 // ResignLeadership causes this instance to give up its raft
-// leadership state. No-op if there is only one replica configured.
+// leadership state. No-op if there is only one replica configured
+// or the cause is a raft leadership error.
 func (db *Database) ResignLeadership(cause error) error {
+	if IsRaftLeadershipError(cause) {
+		// no-op
+		return nil
+	}
+
 	if cause == nil {
 		cause = errors.New("unknown error")
 	}
 	db.log.Errorf("resigning leadership (%s)", cause)
-	if err := db.raft.withReadLock(func(svc raftService) error {
+	return db.raft.withReadLock(func(svc raftService) error {
 		return svc.LeadershipTransfer().Error()
-	}); err != nil {
-		return errors.Wrap(err, cause.Error())
-	}
-	return cause
+	})
 }
 
 // Barrier blocks until the raft implementation has persisted all


### PR DESCRIPTION
In some cases, a raft operation will fail due to a leadership loss
or other transition, and in these cases it is not safe to call
ResignLeadership(). Instead, just make these calls noops as
leadership is already lost.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
