### PR TITLE
DAOS-11511 control: Make ResignLeadership() a noop on some errors

### DIFF
--- a/src/control/system/database.go
+++ b/src/control/system/database.go
@@ -469,7 +469,9 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 			barrierStart := time.Now()
 			if err := db.Barrier(); err != nil {
 				db.log.Errorf("raft Barrier() failed: %s", err)
-				_ = db.ResignLeadership(err)
+				if err = db.ResignLeadership(err); err != nil {
+					db.log.Errorf("raft ResignLeadership() failed: %s", err)
+				}
 				break
 			}
 			db.log.Debugf("raft Barrier() complete after %s", time.Since(barrierStart))
@@ -480,7 +482,9 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 				if err := fn(gainedCtx); err != nil {
 					db.log.Errorf("failure in onLeadershipGained callback: %s", err)
 					cancelGainedCtx()
-					_ = db.ResignLeadership(err)
+					if err = db.ResignLeadership(err); err != nil {
+						db.log.Errorf("raft ResignLeadership() failed: %s", err)
+					}
 					break
 				}
 			}

--- a/src/control/system/database_test.go
+++ b/src/control/system/database_test.go
@@ -881,3 +881,54 @@ func TestSystem_Database_GroupMap(t *testing.T) {
 		})
 	}
 }
+
+func Test_Database_ResignLeadership(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cause     error
+		expErr    error
+		expLeader bool
+	}{
+		"nil cause": {
+			expLeader: false,
+		},
+		// For these next errors, we just want to verify that the
+		// method exits early, preventing the state from being toggled.
+		"cause: raft.ErrNotLeader": {
+			cause:     raft.ErrNotLeader,
+			expLeader: true,
+		},
+		"cause: raft.ErrLeadershipLost": {
+			cause:     raft.ErrLeadershipLost,
+			expLeader: true,
+		},
+		"cause: raft.ErrLeadershipTransferInProgress": {
+			cause:     raft.ErrLeadershipTransferInProgress,
+			expLeader: true,
+		},
+		// Also check to see what happens if we get a raft error during
+		// leadership transfer.
+		"leadership transfer fails": {
+			expErr:    errors.New("leadership transfer failed"),
+			expLeader: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			db := MockDatabase(t, log)
+			db.raft.setSvc(newMockRaftService(&mockRaftServiceConfig{
+				LeadershipTransferErr: tc.expErr,
+				State:                 raft.Leader,
+			}, (*fsm)(db)))
+
+			resignErr := db.ResignLeadership(tc.cause)
+			test.CmpErr(t, tc.expErr, resignErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			test.AssertEqual(t, tc.expLeader, db.IsLeader(), "unexpected leader state")
+		})
+	}
+}

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -94,9 +94,10 @@ type (
 		response interface{}
 	}
 	mockRaftServiceConfig struct {
-		LeaderCh      <-chan bool
-		ServerAddress raft.ServerAddress
-		State         raft.RaftState
+		LeaderCh              <-chan bool
+		ServerAddress         raft.ServerAddress
+		State                 raft.RaftState
+		LeadershipTransferErr error
 	}
 	mockRaftService struct {
 		cfg mockRaftServiceConfig
@@ -135,7 +136,10 @@ func (mrs *mockRaftService) LeaderCh() <-chan bool {
 }
 
 func (mrs *mockRaftService) LeadershipTransfer() raft.Future {
-	return &mockRaftFuture{}
+	if mrs.cfg.LeadershipTransferErr == nil {
+		mrs.cfg.State = raft.Follower
+	}
+	return &mockRaftFuture{err: mrs.cfg.LeadershipTransferErr}
 }
 
 func (mrs *mockRaftService) Shutdown() raft.Future {


### PR DESCRIPTION
In some cases, a raft operation will fail due to a leadership loss
or other transition, and in these cases it is not safe to call
ResignLeadership(). Instead, just make these calls noops as
leadership is already lost.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
