### PR TITLE
DAOS-8648 tests: Re-enable skipped tests

### DIFF
--- a/src/tests/ftest/nvme/pool_extend.py
+++ b/src/tests/ftest/nvme/pool_extend.py
@@ -1,13 +1,11 @@
-#!/usr/bin/python3
 """
-  (C) Copyright 2020-2021 Intel Corporation.
+  (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import time
 import threading
 
-from apricot import skipForTicket
 from osa_utils import OSAUtils
 from write_host_file import write_host_file
 from dmg_utils import check_system_query_status
@@ -119,7 +117,6 @@ class NvmePoolExtend(OSAUtils):
             output = self.daos_command.container_check(**kwargs)
             self.log.info(output)
 
-    @skipForTicket("DAOS-7195, DAOS-7955")
     def test_nvme_pool_extend(self):
         """Test ID: DAOS-2086
         Test Description: NVME Pool Extend
@@ -127,6 +124,6 @@ class NvmePoolExtend(OSAUtils):
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
         :avocado: tags=nvme,checksum,nvme_osa
-        :avocado: tags=nvme_pool_extend
+        :avocado: tags=test_nvme_pool_extend
         """
         self.run_nvme_pool_extend(3)

--- a/src/tests/ftest/osa/offline_extend.py
+++ b/src/tests/ftest/osa/offline_extend.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -133,8 +132,8 @@ class OSAOfflineExtend(OSAUtils):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,large
-        :avocado: tags=osa,checksum,osa_extend
-        :avocado: tags=offline_extend,offline_extend_with_csum
+        :avocado: tags=osa,checksum,osa_extend,offline_extend
+        :avocado: tags=test_osa_offline_extend
         """
         self.log.info("Offline Extend Testing : With Checksum")
         self.run_offline_extend_test(1, True)
@@ -146,8 +145,8 @@ class OSAOfflineExtend(OSAUtils):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=osa,osa_extend
-        :avocado: tags=offline_extend,offline_extend_without_csum
+        :avocado: tags=osa,osa_extend,offline_extend
+        :avocado: tags=test_osa_offline_extend_without_checksum
         """
         self.test_with_checksum = self.params.get("test_with_checksum",
                                                   '/run/checksum/*')
@@ -161,8 +160,8 @@ class OSAOfflineExtend(OSAUtils):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=osa,osa_extend
-        :avocado: tags=offline_extend,offline_extend_multiple_pools
+        :avocado: tags=osa,osa_extend,offline_extend
+        :avocado: tags=test_osa_offline_extend_multiple_pools
         """
         self.log.info("Offline Extend Testing: Multiple Pools")
         self.run_offline_extend_test(5, data=True)
@@ -175,15 +174,14 @@ class OSAOfflineExtend(OSAUtils):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,large
-        :avocado: tags=osa,osa_extend
-        :avocado: tags=offline_extend,offline_extend_oclass
+        :avocado: tags=osa,osa_extend,offline_extend
+        :avocado: tags=test_osa_offline_extend_oclass
         """
         self.log.info("Offline Extend Testing: oclass")
         self.test_oclass = self.params.get("oclass", '/run/test_obj_class/*')
         self.run_offline_extend_test(4, data=True,
                                      oclass=self.test_oclass)
 
-    @skipForTicket("DAOS-7195")
     def test_osa_offline_extend_during_aggregation(self):
         """Test ID: DAOS-6294
         Test Description: Extend rank while aggregation
@@ -191,8 +189,8 @@ class OSAOfflineExtend(OSAUtils):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=osa,checksum,osa_extend
-        :avocado: tags=offline_extend,offline_extend_during_aggregation
+        :avocado: tags=osa,checksum,osa_extend,offline_extend
+        :avocado: tags=test_osa_offline_extend_during_aggregation
         """
         self.test_during_aggregation = self.params.get("test_with_aggregation",
                                                        '/run/aggregation/*')
@@ -207,8 +205,8 @@ class OSAOfflineExtend(OSAUtils):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,large
-        :avocado: tags=osa,osa_extend
-        :avocado: tags=offline_extend,offline_extend_after_snapshot
+        :avocado: tags=osa,osa_extend,offline_extend
+        :avocado: tags=otest_osa_offline_extend_after_snapshot
         """
         self.test_with_snapshot = self.params.get("test_with_snapshot",
                                                   '/run/snapshot/*')

--- a/src/tests/ftest/osa/offline_parallel_test.py
+++ b/src/tests/ftest/osa/offline_parallel_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -8,13 +7,13 @@ import time
 import random
 import threading
 import copy
+import queue
+
 from osa_utils import OSAUtils
 from daos_utils import DaosCommand
 from dmg_utils import check_system_query_status
 from exception_utils import CommandFailure
 from test_utils_pool import add_pool
-from apricot import skipForTicket
-import queue
 
 
 class OSAOfflineParallelTest(OSAUtils):
@@ -212,9 +211,9 @@ class OSAOfflineParallelTest(OSAUtils):
         Test Description: Runs multiple OSA commands in parallel.
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=offline_parallel,offline_parallel_basic_test
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,offline_parallel
+        :avocado: tags=test_osa_offline_parallel_test
         """
         self.log.info("Offline Parallel Test: Basic Test")
         self.run_offline_parallel_test(1, data=True)
@@ -227,9 +226,9 @@ class OSAOfflineParallelTest(OSAUtils):
         without enabling checksum.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa
-        :avocado: tags=offline_parallel,offline_parallel_without_csum
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,offline_parallel
+        :avocado: tags=test_osa_offline_parallel_test_without_csum
         """
         self.test_with_checksum = self.params.get("test_with_checksum",
                                                   '/run/checksum/*')
@@ -244,9 +243,9 @@ class OSAOfflineParallelTest(OSAUtils):
         with a rank rebooted using system stop/start.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa
-        :avocado: tags=offline_parallel,offline_parallel_srv_rank_boot
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,offline_parallel
+        :avocado: tags=test_osa_offline_parallel_test_rank_boot
         """
         self.test_with_checksum = self.params.get("test_with_checksum",
                                                   '/run/checksum/*')
@@ -255,7 +254,6 @@ class OSAOfflineParallelTest(OSAUtils):
         self.log.info("Offline Parallel Test: Restart a rank")
         self.run_offline_parallel_test(1, data=True)
 
-    @skipForTicket("DAOS-7195,DAOS-7247")
     def test_osa_offline_parallel_test_with_aggregation(self):
         """
         JIRA ID: DAOS-7161
@@ -264,9 +262,9 @@ class OSAOfflineParallelTest(OSAUtils):
         with aggregation turned on.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa
-        :avocado: tags=offline_parallel,offline_parallel_with_aggregation
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,offline_parallel
+        :avocado: tags=test_osa_offline_parallel_test_with_aggregation
         """
         self.test_during_aggregation = self.params.get("test_with_aggregation",
                                                        '/run/aggregation/*')
@@ -281,9 +279,9 @@ class OSAOfflineParallelTest(OSAUtils):
         with different object class.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa
-        :avocado: tags=offline_parallel,offline_parallel_oclass
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,offline_parallel
+        :avocado: tags=test_osa_offline_parallel_test_oclass
         """
         self.log.info("Offline Parallel Test : OClass")
         # Presently, the script is limited and supports only one extra

--- a/src/tests/ftest/osa/online_extend.py
+++ b/src/tests/ftest/osa/online_extend.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -12,7 +11,6 @@ from write_host_file import write_host_file
 from daos_racer_utils import DaosRacerCommand
 from dmg_utils import check_system_query_status
 from osa_utils import OSAUtils
-from apricot import skipForTicket
 from daos_utils import DaosCommand
 
 
@@ -151,71 +149,66 @@ class OSAOnlineExtend(OSAUtils):
             output = self.daos_command.container_check(**kwargs)
             self.log.info(output)
 
-    @skipForTicket("DAOS-7195,DAOS-7955")
     def test_osa_online_extend(self):
         """Test ID: DAOS-4751
         Test Description: Validate Online extend with checksum
         enabled.
 
         :avocado: tags=all,pr,daily_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=osa_extend,online_extend,online_extend_with_csum
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,osa_extend,online_extend
+        :avocado: tags=test_osa_online_extend
         """
         self.log.info("Online Extend : With Checksum")
         self.run_online_extend_test(1)
 
-    @skipForTicket("DAOS-7195,DAOS-7955")
     def test_osa_online_extend_without_checksum(self):
         """Test ID: DAOS-6645
         Test Description: Validate Online extend without checksum enabled.
 
         :avocado: tags=all,pr,daily_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=osa_extend,online_extend,online_extend_without_csum
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,osa_extend
+        :avocado: tags=test_osa_online_extend_without_checksum
         """
         self.log.info("Online Extend : Without Checksum")
         self.test_with_checksum = self.params.get("test_with_checksum",
                                                   '/run/checksum/*')
         self.run_online_extend_test(1)
 
-    @skipForTicket("DAOS-7195,DAOS-7955")
     def test_osa_online_extend_oclass(self):
         """Test ID: DAOS-6645
         Test Description: Validate Online extend with different
         object class.
 
         :avocado: tags=all,pr,daily_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=osa_extend,online_extend,online_extend_oclass
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,osa_extend
+        :avocado: tags=test_osa_online_extend_oclass
         """
         self.log.info("Online Extend : Oclass")
         self.run_online_extend_test(1, oclass=self.test_oclass[0])
 
-    @skipForTicket("DAOS-7195,DAOS-7955")
     def test_osa_online_extend_mdtest(self):
         """Test ID: DAOS-6645
         Test Description: Validate Online extend with mdtest application.
 
         :avocado: tags=all,pr,daily_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=osa_extend,online_extend,online_extend_mdtest
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,osa_extend
+        :avocado: tags=test_osa_online_extend_mdtest
         """
         self.log.info("Online Extend : Mdtest")
         self.run_online_extend_test(1, app_name="mdtest")
 
-    @skipForTicket("DAOS-7195,DAOS-7955")
     def test_osa_online_extend_with_aggregation(self):
         """Test ID: DAOS-6645
         Test Description: Validate Online extend with aggregation on.
 
         :avocado: tags=all,pr,daily_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=osa_extend,online_extend,online_extend_with_aggregation
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,osa_extend
+        :avocado: tags=test_osa_online_extend_with_aggregation
         """
         self.log.info("Online Extend : Aggregation")
         self.test_during_aggregation = self.params.get("test_with_aggregation",

--- a/src/tests/ftest/osa/online_reintegration.py
+++ b/src/tests/ftest/osa/online_reintegration.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2020-2022 Intel Corporation.
 
@@ -168,21 +167,20 @@ class OSAOnlineReintegration(OSAUtils):
         Test Description: Validate Online Reintegration
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=online_reintegration,online_reintegration_basic
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,online_reintegration
+        :avocado: tags=test_osa_online_reintegration
         """
         self.log.info("Online Reintegration : Basic test")
         self.run_online_reintegration_test(1)
 
-    @skipForTicket("DAOS-7195")
     def test_osa_online_reintegration_server_stop(self):
         """Test ID: DAOS-5920.
         Test Description: Validate Online Reintegration with server stop
         :avocado: tags=all,daily_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=online_reintegration,online_reintegration_srv_stop
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,online_reintegration
+        :avocado: tags=test_osa_online_reintegration_server_stop
         """
         self.log.info("Online Reintegration : System stop/start")
         self.run_online_reintegration_test(1, server_boot=True)
@@ -195,9 +193,9 @@ class OSAOnlineReintegration(OSAUtils):
         without checksum
 
         :avocado: tags=all,daily_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=online_reintegration,online_reintegration_without_csum
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,online_reintegration
+        :avocado: tags=test_osa_online_reintegration_without_csum
         """
         self.log.info("Online Reintegration : No Checksum")
         self.test_with_checksum = self.params.get("test_with_checksum",
@@ -211,9 +209,9 @@ class OSAOnlineReintegration(OSAUtils):
         is happening in parallel
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=online_reintegration,online_reintegration_aggregation
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,online_reintegration
+        :avocado: tags=test_osa_online_reintegration_with_aggregation
         """
         self.test_during_aggregation = self.params.get("test_with_aggregation",
                                                        '/run/aggregation/*')
@@ -227,9 +225,9 @@ class OSAOnlineReintegration(OSAUtils):
         object class
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
-        :avocado: tags=osa,checksum
-        :avocado: tags=online_reintegration,online_reintegration_oclass
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,checksum,online_reintegration
+        :avocado: tags=test_osa_online_reintegration_oclass
         """
         self.log.info("Online Reintegration : Object Class")
         for oclass in self.test_oclass:


### PR DESCRIPTION
Removing skipForTicket decorator for tests being skipped by a resolved ticket.

Quick-functional: true
Test-tag: test_nvme_pool_extend test_osa_offline_extend_during_aggregation test_osa_offline_parallel_test_with_aggregation osa,checksum,osa_extend test_osa_online_reintegration_server_stop

Required-githooks: true

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>