### PR TITLE
DAOS-11395 CART: remove RPC post increment restriction

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -720,7 +720,6 @@ crt_hg_class_init(int provider, int idx, hg_class_t **ret_hg_class)
 	if (prov_data->cpg_max_unexp_size > 0)
 		init_info.na_init_info.max_unexpected_size = prov_data->cpg_max_unexp_size;
 
-	init_info.request_post_incr = 0;
 	hg_class = HG_Init_opt(info_string, crt_is_service(), &init_info);
 	if (hg_class == NULL) {
 		D_ERROR("Could not initialize HG class.\n");


### PR DESCRIPTION
The current setting was preventing extra RPC handles from being posted once the original batch is exhausted.