### PR TITLE
DAOS-11423 container: do not update oid IV for failure

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2520,7 +2520,7 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 	/* For bi-directional updates, transfer data back to child */
 	if (iv_info->uci_sync_type.ivs_flags & CRT_IV_SYNC_BIDIRECTIONAL) {
 		transfer_back_to_child(&input->ivu_key, iv_info, true,
-				       cb_info->cci_rc);
+				       cb_info->cci_rc ?: output->rc);
 		D_GOTO(exit, 0);
 	}
 

--- a/src/container/oid_iv.c
+++ b/src/container/oid_iv.c
@@ -107,7 +107,8 @@ oid_iv_ent_refresh(struct ds_iv_entry *iv_entry, struct ds_iv_key *key,
 
 	/** Set the number of oids to what was asked for. */
 	oids->num_oids = num_oids;
-	D_DEBUG(DB_MD, "%u: ON REFRESH %zu/%zu\n", dss_self_rank(), oids->oid, oids->num_oids);
+	D_DEBUG(DB_MD, "%u: ON REFRESH %zu/%zu avail %zu/%zu\n", dss_self_rank(),
+		oids->oid, oids->num_oids, avail->oid, avail->num_oids);
 
 out:
 	ABT_mutex_unlock(entry->lock);
@@ -328,7 +329,7 @@ oid_iv_reserve(void *ns, uuid_t po_uuid, uuid_t co_uuid, uint64_t num_oids, d_sg
 	oids->num_oids = num_oids;
 
 	rc = ds_iv_update(ns, &key, value, 0, CRT_IV_SYNC_NONE,
-			  CRT_IV_SYNC_BIDIRECTIONAL, false /* retry */);
+			  CRT_IV_SYNC_BIDIRECTIONAL, true /* retry */);
 	if (rc)
 		D_ERROR("iv update failed "DF_RC"\n", DP_RC(rc));
 


### PR DESCRIPTION
Pass in error code to make sure OID IV cache is not updated during failure case.

And Retry OID allocation for retry error.

Signed-off-by: Di Wang <di.wang@intel.com>