### PR TITLE
DAOS-11596 utils: Fix version check in libdpar.so

### DIFF
--- a/src/include/daos/dpar.h
+++ b/src/include/daos/dpar.h
@@ -22,20 +22,9 @@ extern "C" {
 
 #define PAR_COMM_WORLD	0
 
-static inline bool
-par_version_compatible(uint32_t version)
-{
-	uint32_t major = version >> DPAR_VERSION_SHIFT;
-	uint32_t minor = version & DPAR_VERSION_MASK;
-
-	if (major != DPAR_MAJOR) /* Total incompatibility */
-		return false;
-
-	if (minor > DPAR_MINOR) /* An API used by the caller doesn't exist in this library */
-		return false;
-
-	return true;
-}
+/** Return true if the opened library is compatible with the client */
+bool
+par_version_compatible(uint32_t version);
 
 enum par_type {
 	PAR_INT		= 0,

--- a/src/include/daos/dpar.h
+++ b/src/include/daos/dpar.h
@@ -31,7 +31,7 @@ par_version_compatible(uint32_t version)
 	if (major != DPAR_MAJOR) /* Total incompatibility */
 		return false;
 
-	if (minor < DPAR_MINOR) /* An API we use doesn't exist in other library */
+	if (minor > DPAR_MINOR) /* An API used by the caller doesn't exist in this library */
 		return false;
 
 	return true;

--- a/src/include/daos/dpar.h
+++ b/src/include/daos/dpar.h
@@ -22,9 +22,11 @@ extern "C" {
 
 #define PAR_COMM_WORLD	0
 
-/** Return true if the opened library is compatible with the client */
+/** Return true if the opened library is compatible with the client.  Not
+ *  defined in stub library.
+ */
 bool
-par_version_compatible(uint32_t version);
+par_version_compatible(uint32_t version, uint32_t *libmajor, uint32_t *libminor);
 
 enum par_type {
 	PAR_INT		= 0,
@@ -39,10 +41,6 @@ enum par_op {
 	PAR_MIN		= 1,
 	PAR_SUM		= 2,
 };
-
-/** Retrieve the version */
-uint32_t
-par_getversion(void);
 
 /** Initialize the library */
 int

--- a/src/include/daos/dpar.h
+++ b/src/include/daos/dpar.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-#define DPAR_MAJOR 1
+#define DPAR_MAJOR 2
 #define DPAR_MINOR 0
 
 #define DPAR_VERSION_SHIFT	16

--- a/src/utils/wrap/mpi/dpar_mpi.c
+++ b/src/utils/wrap/mpi/dpar_mpi.c
@@ -1,3 +1,8 @@
+/**
+ * (C) Copyright 2021-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
 #include <stdio.h>
 #include <mpi.h>
 #include <daos/dpar.h>
@@ -347,4 +352,24 @@ par_comm_free(uint32_t pcom)
 	free_pcom(pcom);
 
 	return 0;
+}
+
+bool
+par_version_compatible(uint32_t version)
+{
+	uint32_t major = version >> DPAR_VERSION_SHIFT;
+	uint32_t minor = version & DPAR_VERSION_MASK;
+
+	/** Major version difference means this library is incompatible with the caller */
+	if (major != DPAR_MAJOR)
+		return false;
+
+	/** For minor version, it is only incompatible if the caller minor version is greater
+	 *  than the minor version of the library.  This means that new APIs are expected
+	 *  but are not defined.
+	 */
+	if (minor > DPAR_MINOR)
+		return false;
+
+	return true;
 }

--- a/src/utils/wrap/mpi/dpar_mpi.c
+++ b/src/utils/wrap/mpi/dpar_mpi.c
@@ -31,12 +31,6 @@ pcom2comm(uint32_t pcom, MPI_Comm *comm)
 	return 0;
 }
 
-uint32_t
-par_getversion(void)
-{
-	return DPAR_VERSION;
-}
-
 int
 par_init(int *argc, char ***argv)
 {
@@ -355,10 +349,15 @@ par_comm_free(uint32_t pcom)
 }
 
 bool
-par_version_compatible(uint32_t version)
+par_version_compatible(uint32_t version, uint32_t *libmajor, uint32_t *libminor)
 {
 	uint32_t major = version >> DPAR_VERSION_SHIFT;
 	uint32_t minor = version & DPAR_VERSION_MASK;
+
+	if (libmajor != NULL)
+		*libmajor = DPAR_MAJOR;
+	if (libminor != NULL)
+		*libminor = DPAR_MINOR;
 
 	/** Major version difference means this library is incompatible with the caller */
 	if (major != DPAR_MAJOR)

--- a/src/utils/wrap/mpi/dpar_stub.c
+++ b/src/utils/wrap/mpi/dpar_stub.c
@@ -1,3 +1,8 @@
+/**
+ * (C) Copyright 2021-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
 #include <stdio.h>
 #include <errno.h>
 #include <stdbool.h>

--- a/src/utils/wrap/mpi/dpar_stub.c
+++ b/src/utils/wrap/mpi/dpar_stub.c
@@ -13,7 +13,7 @@
 #include <daos/dpar.h>
 
 struct par_stubs {
-	uint32_t	(*ps_getversion)(void);
+	bool (*ps_version_compatible)(uint32_t version, uint32_t *libmajor, uint32_t *libminor);
 	int		(*ps_init)(int *argc, char ***argv);
 	int		(*ps_fini)(void);
 	int		(*ps_barrier)(uint32_t);
@@ -36,19 +36,18 @@ struct par_stubs {
 static struct par_stubs	 stubs;
 static void		*stubs_handle;
 
-#define FOREACH_PAR_SYMBOL(ACTION, arg)	\
-	ACTION(getversion, arg)	\
-	ACTION(init, arg)		\
-	ACTION(fini, arg)		\
-	ACTION(barrier, arg)		\
-	ACTION(rank, arg)		\
-	ACTION(size, arg)		\
-	ACTION(reduce, arg)		\
-	ACTION(gather, arg)		\
-	ACTION(allreduce, arg)		\
-	ACTION(allgather, arg)		\
-	ACTION(bcast, arg)		\
-	ACTION(comm_split, arg)		\
+#define FOREACH_PAR_SYMBOL(ACTION, arg)                                                            \
+	ACTION(init, arg)                                                                          \
+	ACTION(fini, arg)                                                                          \
+	ACTION(barrier, arg)                                                                       \
+	ACTION(rank, arg)                                                                          \
+	ACTION(size, arg)                                                                          \
+	ACTION(reduce, arg)                                                                        \
+	ACTION(gather, arg)                                                                        \
+	ACTION(allreduce, arg)                                                                     \
+	ACTION(allgather, arg)                                                                     \
+	ACTION(bcast, arg)                                                                         \
+	ACTION(comm_split, arg)                                                                    \
 	ACTION(comm_free, arg)
 
 #define LOAD_SYM(name, fail)							\
@@ -67,7 +66,8 @@ static void
 init_routine(void)
 {
 	bool		fail = false;
-	uint32_t	version;
+	uint32_t        major = 0;
+	uint32_t        minor = 0;
 
 	stubs_handle = dlopen("libdpar_mpi.so", RTLD_NOW);
 
@@ -76,26 +76,28 @@ init_routine(void)
 		return;
 	}
 
-	FOREACH_PAR_SYMBOL(LOAD_SYM, fail);
+	LOAD_SYM(version_compatible, fail);
+	if (!fail) {
+		if (stubs.ps_version_compatible(DPAR_VERSION, &major, &minor)) {
+			printf("Using compatible version\n");
+		} else {
+			printf("libdpar_mpi.so version %d.%d is not compatible with stub version "
+			       "%d.%d\n",
+			       major, minor, DPAR_MAJOR, DPAR_MINOR);
+			fail = true;
+		}
+	}
 
 	if (!fail) {
-		version = stubs.ps_getversion();
-		if (par_version_compatible(version)) {
-			printf("Using compatible version\n");
-			return;
-		}
-
-		printf("libdpar_mpi.so version %d.%d is not compatible with stub version %d.%d\n",
-		       version >> DPAR_VERSION_SHIFT, version & DPAR_VERSION_MASK,
-		       DPAR_MAJOR, DPAR_MINOR);
-		printf("Continuing with serial library\n");
-		fail = true;
+		/** Load the other symbols now */
+		FOREACH_PAR_SYMBOL(LOAD_SYM, fail);
 	}
 
 	if (fail) {
 		/* Ideally, we would do some check here to ensure we are not running under MPI
 		 * but I don't know of a reliable way, MPI vendor independent way to do that.
 		 */
+		printf("Using serial library\n");
 		memset(&stubs, 0, sizeof(stubs));
 	}
 }
@@ -122,12 +124,6 @@ static void
 unload_stubs(void)
 {
 	memset(&stubs, 0, sizeof(stubs));
-}
-
-uint32_t
-par_getversion(void)
-{
-	return DPAR_VERSION;
 }
 
 int


### PR DESCRIPTION
It's only incompatible if the user is trying to use a library that doesn't have an API they need, not the other way around.

Addresses CID: 105934

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>