### PR TITLE
DAOS-11552 control: Interop rule processing fixes

### DIFF
--- a/src/control/build/interop_test.go
+++ b/src/control/build/interop_test.go
@@ -94,7 +94,7 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 		},
 		"2.4 agent compatible with 2.2 server": {
 			a: testComponent(t, "server", "2.2.0"),
-			b: testComponent(t, "agent", "2.4.0"),
+			b: testComponent(t, "agent", "2.3.100"),
 		},
 		"2.6 server not compatible with 2.2 agent": {
 			a:      testComponent(t, "server", "2.6.0"),
@@ -112,9 +112,8 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 			expErr: errors.New("incompatible components"),
 		},
 		"unversioned agent (assume 2.0.x) compatible with 2.2.x server": {
-			a:          testComponent(t, "server", "2.1.100"),
-			b:          testComponent(t, "agent", "0.0.0"),
-			customRule: build.Server22xAgent20x,
+			a: testComponent(t, "server", "2.1.100"),
+			b: testComponent(t, "agent", "0.0.0"),
 		},
 		// --- Unit testing ---
 		"nil a": {

--- a/src/control/build/version.go
+++ b/src/control/build/version.go
@@ -92,10 +92,14 @@ func (v Version) Equals(other Version) bool {
 func (v Version) GreaterThan(other Version) bool {
 	if v.Major > other.Major {
 		return true
+	} else if v.Major < other.Major {
+		return false
 	}
 
 	if v.Minor > other.Minor {
 		return true
+	} else if v.Minor < other.Minor {
+		return false
 	}
 
 	return v.Patch > other.Patch
@@ -111,10 +115,14 @@ func (v Version) GreaterThanOrEquals(other Version) bool {
 func (v Version) LessThan(other Version) bool {
 	if v.Major < other.Major {
 		return true
+	} else if v.Major > other.Major {
+		return false
 	}
 
 	if v.Minor < other.Minor {
 		return true
+	} else if v.Minor > other.Minor {
+		return false
 	}
 
 	return v.Patch < other.Patch

--- a/src/control/build/version_test.go
+++ b/src/control/build/version_test.go
@@ -97,6 +97,11 @@ func TestBuild_Version_GreaterThan(t *testing.T) {
 			b:           "1.2.3",
 			greaterThan: false,
 		},
+		"x.y.a < x.y.b": {
+			a:           "2.1.100",
+			b:           "2.6.0",
+			greaterThan: false,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			a := build.MustNewVersion(tc.a)
@@ -128,6 +133,11 @@ func TestBuild_Version_LessThan(t *testing.T) {
 		"a == b": {
 			a:        "1.2.3",
 			b:        "1.2.3",
+			lessThan: false,
+		},
+		"x.y.a > x.y.b": {
+			a:        "2.6.0",
+			b:        "2.1.100",
 			lessThan: false,
 		},
 	} {

--- a/src/control/server/interceptors.go
+++ b/src/control/server/interceptors.go
@@ -153,11 +153,7 @@ func checkVersion(ctx context.Context, self *build.VersionedComponent, req inter
 		return FaultIncompatibleComponents(self, other)
 	}
 
-	// Set per-release compatibility rules here.
-	releaseCompatRules := []*build.InteropRule{
-		build.Server22xAgent20x,
-	}
-	if err := build.CheckCompatibility(self, other, releaseCompatRules...); err != nil {
+	if err := build.CheckCompatibility(self, other); err != nil {
 		return FaultIncompatibleComponents(self, other)
 	}
 


### PR DESCRIPTION
Fixes an oversight in the comparison logic that could lead
to a larger version being seen as less than. Also adds
support for finer-grained rule matching logic.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
