### PR TITLE
DAOS-11552 control: Interop rule processing fixes

### DIFF
--- a/src/control/build/interop_test.go
+++ b/src/control/build/interop_test.go
@@ -94,7 +94,7 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 		},
 		"2.4 agent compatible with 2.2 server": {
 			a: testComponent(t, "server", "2.2.0"),
-			b: testComponent(t, "agent", "2.4.0"),
+			b: testComponent(t, "agent", "2.3.100"),
 		},
 		"2.6 server not compatible with 2.2 agent": {
 			a:      testComponent(t, "server", "2.6.0"),
@@ -159,6 +159,37 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 					return self.Version.Equals(v1_1_1) && other.Version.Equals(v2_0_0)
 				},
 			},
+		},
+		"custom matcher: narrowly-scoped rule (non-match)": {
+			a: testComponent(t, "server", "2.0.0"),
+			b: testComponent(t, "agent", "2.0.0"),
+			customRule: &build.InteropRule{
+				Self:        build.ComponentServer,
+				Other:       build.ComponentAgent,
+				Description: "server/agent 2.0.0/2.0.1 interop rule",
+				Match: func(self, other *build.VersionedComponent) bool {
+					v1_1_1 := build.MustNewVersion("2.0.0")
+					v2_0_1 := build.MustNewVersion("2.0.1")
+					return self.Version.Equals(v1_1_1) && other.Version.Equals(v2_0_1)
+				},
+				Check: func(self, other *build.VersionedComponent) bool { return false },
+			},
+		},
+		"custom matcher: narrowly-scoped rule (match)": {
+			a: testComponent(t, "server", "2.0.0"),
+			b: testComponent(t, "agent", "2.0.1"),
+			customRule: &build.InteropRule{
+				Self:        build.ComponentServer,
+				Other:       build.ComponentAgent,
+				Description: "server/agent 2.0.0/2.0.1 interop rule",
+				Match: func(self, other *build.VersionedComponent) bool {
+					v1_1_1 := build.MustNewVersion("2.0.0")
+					v2_0_1 := build.MustNewVersion("2.0.1")
+					return self.Version.Equals(v1_1_1) && other.Version.Equals(v2_0_1)
+				},
+				Check: func(self, other *build.VersionedComponent) bool { return false },
+			},
+			expErr: errors.New("2.0.0/2.0.1 interop rule"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/build/interop_test.go
+++ b/src/control/build/interop_test.go
@@ -166,13 +166,9 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 			customRule: &build.InteropRule{
 				Self:        build.ComponentServer,
 				Other:       build.ComponentAgent,
-				Description: "server/agent 2.0.0/2.0.1 interop rule",
-				Match: func(self, other *build.VersionedComponent) bool {
-					v1_1_1 := build.MustNewVersion("2.0.0")
-					v2_0_1 := build.MustNewVersion("2.0.1")
-					return self.Version.Equals(v1_1_1) && other.Version.Equals(v2_0_1)
-				},
-				Check: func(self, other *build.VersionedComponent) bool { return false },
+				Description: "custom matcher",
+				Match:       func(self, other *build.VersionedComponent) bool { return false },
+				Check:       func(self, other *build.VersionedComponent) bool { return false },
 			},
 		},
 		"custom matcher: narrowly-scoped rule (match)": {
@@ -181,15 +177,11 @@ func TestBuild_CheckCompatibility(t *testing.T) {
 			customRule: &build.InteropRule{
 				Self:        build.ComponentServer,
 				Other:       build.ComponentAgent,
-				Description: "server/agent 2.0.0/2.0.1 interop rule",
-				Match: func(self, other *build.VersionedComponent) bool {
-					v1_1_1 := build.MustNewVersion("2.0.0")
-					v2_0_1 := build.MustNewVersion("2.0.1")
-					return self.Version.Equals(v1_1_1) && other.Version.Equals(v2_0_1)
-				},
-				Check: func(self, other *build.VersionedComponent) bool { return false },
+				Description: "custom matcher",
+				Match:       func(self, other *build.VersionedComponent) bool { return true },
+				Check:       func(self, other *build.VersionedComponent) bool { return false },
 			},
-			expErr: errors.New("2.0.0/2.0.1 interop rule"),
+			expErr: errors.New("custom matcher"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/build/version.go
+++ b/src/control/build/version.go
@@ -98,7 +98,7 @@ func (v Version) GreaterThan(other Version) bool {
 
 	if v.Minor > other.Minor {
 		return true
-	} else if v.Minor < other.Major {
+	} else if v.Minor < other.Minor {
 		return false
 	}
 

--- a/src/control/build/version.go
+++ b/src/control/build/version.go
@@ -92,10 +92,14 @@ func (v Version) Equals(other Version) bool {
 func (v Version) GreaterThan(other Version) bool {
 	if v.Major > other.Major {
 		return true
+	} else if v.Major < other.Major {
+		return false
 	}
 
 	if v.Minor > other.Minor {
 		return true
+	} else if v.Minor < other.Major {
+		return false
 	}
 
 	return v.Patch > other.Patch
@@ -111,10 +115,14 @@ func (v Version) GreaterThanOrEquals(other Version) bool {
 func (v Version) LessThan(other Version) bool {
 	if v.Major < other.Major {
 		return true
+	} else if v.Major > other.Major {
+		return false
 	}
 
 	if v.Minor < other.Minor {
 		return true
+	} else if v.Minor > other.Minor {
+		return false
 	}
 
 	return v.Patch < other.Patch

--- a/src/control/build/version_test.go
+++ b/src/control/build/version_test.go
@@ -97,6 +97,11 @@ func TestBuild_Version_GreaterThan(t *testing.T) {
 			b:           "1.2.3",
 			greaterThan: false,
 		},
+		"x.y.a < x.y.b": {
+			a:           "2.1.100",
+			b:           "2.6.0",
+			greaterThan: false,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			a := build.MustNewVersion(tc.a)
@@ -128,6 +133,11 @@ func TestBuild_Version_LessThan(t *testing.T) {
 		"a == b": {
 			a:        "1.2.3",
 			b:        "1.2.3",
+			lessThan: false,
+		},
+		"x.y.a > x.y.b": {
+			a:        "2.6.0",
+			b:        "2.1.100",
 			lessThan: false,
 		},
 	} {


### PR DESCRIPTION
Fixes an oversight in the comparison logic that could lead
to a larger version being seen as less than. Also adds
support for finer-grained rule matching logic.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
