### PR TITLE
DAOS-10524 rebuild: skip reclaim job during merge

### DIFF
--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1120,6 +1120,13 @@ rebuild_try_merge_tgts(struct ds_pool *pool, uint32_t map_ver,
 			/* This task isn't for this pool - don't consider it */
 			continue;
 
+		/* Do not merge reclaim rebuild job */
+		if (task->dst_rebuild_op == RB_OP_RECLAIM)
+			continue;
+
+		/* Since the queue is sorted by map version, so we only need compare
+		 * the first non-reclaim job.
+		 */
 		if (task->dst_rebuild_op != rebuild_op)
 			/* Found a different operation. If we had found a task
 			 * to merge to before this, clear it, as that is no


### PR DESCRIPTION
Skip the reclaim job in the rebuild queue, otherwise it might mess up the rebuild job order in the queue.

Signed-off-by: Di Wang <di.wang@intel.com>