### PR TITLE
DAOS-10821 chk: handle dangling pool even if all check engine done

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -415,7 +415,7 @@ chk_pool_filter(uuid_t uuid, void *arg)
 		}
 	}
 
-	return found ? 1 : 0;
+	return found ? 0 : 1;
 }
 
 int


### PR DESCRIPTION
Some check engines may complete the check very soon because of no pools exist on them. But there may be dangling pools exist on MS. So the check leader still needs to handle the potential dangling pool even if all check engines have completed the check.

Signed-off-by: Fan Yong <fan.yong@intel.com>