### PR TITLE
DAOS-10138 rdb: Re-enable RPC timeouts

### DIFF
--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -370,10 +370,9 @@ rdb_send_raft_rpc(crt_rpc_t *rpc, struct rdb *db)
 	timeout /= 1000; /* ms to s */
 	if (timeout < timeout_min)
 		timeout = timeout_min;
-#if 0
 	rc = crt_req_set_timeout(rpc, timeout);
 	D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
-#endif
+
 	rrpc->drc_sent = ABT_get_wtime();
 
 	rc = crt_req_send(rpc, rdb_raft_rpc_cb, rrpc);


### PR DESCRIPTION
Custom RPC timeouts have been in use by swim and other modules for a while. Re-enable them for RDB RPCs to avoid accumulating RPCs locally when peers are unavailable.

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true