### PR TITLE
DAOS-11570 tests: do not check if line is NULL

### DIFF
--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -1273,8 +1273,7 @@ int verify_state_in_log(char *host, char *log_file, char *state)
 	D_FREE(tmp);
 	return -DER_INVAL;
 out:
-	if (line)
-		free(line);
+	free(line);
 	D_FREE(tmp);
 	return 0;
 }


### PR DESCRIPTION
Coverity has raised CID 449529 because it has found that testing if line is not NULL is useless here since this part of code can not be reached with line == NULL.
This regression has been introduced with PR-10245 to fix previous Coverity CID 449429.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>