### PR TITLE
DAOS-11565 dfs: fix dfs sys tests to ignore atime setting

### DIFF
--- a/src/include/daos_fs_sys.h
+++ b/src/include/daos_fs_sys.h
@@ -227,8 +227,7 @@ dfs_sys_setattr(dfs_sys_t *dfs_sys, const char *path, struct stat *stbuf,
 		int flags, int sflags);
 
 /**
- * Set atime and mtime of a path. This currently does not set
- * nanosecond precision.
+ * Set atime and mtime of a path. atime as of 2.2 is ignored.
  *
  * \param[in]	dfs_sys Pointer to the mounted file system.
  * \param[in]	path	Link path of object.

--- a/src/tests/suite/dfs_sys_unit_test.c
+++ b/src/tests/suite/dfs_sys_unit_test.c
@@ -459,7 +459,6 @@ setattr_hlpr(const char *path, bool no_follow)
 	/** Check new times are set */
 	rc = dfs_sys_stat(dfs_sys_mt, path, sflags, &stbuf);
 	assert_int_equal(rc, 0);
-	assert_int_equal(stbuf.st_atim.tv_sec, times[0].tv_sec);
 	assert_int_equal(stbuf.st_mtim.tv_sec, times[1].tv_sec);
 
 	/** Increment times again */
@@ -477,7 +476,6 @@ setattr_hlpr(const char *path, bool no_follow)
 	/** Check new times are set */
 	rc = dfs_sys_stat(dfs_sys_mt, path, sflags, &stbuf);
 	assert_int_equal(rc, 0);
-	assert_int_equal(stbuf.st_atim.tv_sec, times[0].tv_sec);
 	assert_int_equal(stbuf.st_mtim.tv_sec, times[1].tv_sec);
 }
 


### PR DESCRIPTION
atime in DFS is not longer maintaines as of 2.2 and thus the dfs sys tests need to be adjusted.

Quick-Functional: true
Test-tag: test_daos_dfs_sys
Required-githooks: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>