### PR TITLE
DAOS-7612 test: Re-enable the offline extend oclass test

### DIFF
--- a/src/tests/ftest/osa/offline_extend.py
+++ b/src/tests/ftest/osa/offline_extend.py
@@ -167,7 +167,6 @@ class OSAOfflineExtend(OSAUtils):
         self.log.info("Offline Extend Testing: Multiple Pools")
         self.run_offline_extend_test(5, data=True)
 
-    @skipForTicket("DAOS-7493")
     def test_osa_offline_extend_oclass(self):
         """Test ID: DAOS-6924
         Test Description: Validate Offline extend without


### PR DESCRIPTION
Re-enabling the offline extend oclass test because DAOS-7493 is not reproducible.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>
