### PR TITLE
DAOS-9585 chk: reset check DB only when (re-)start from beginning

### DIFF
--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -2294,6 +2294,10 @@ out_log:
 			chk_pools_dump(pool_nr, pools);
 		else if (prop->cp_pool_nr > 0)
 			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+
+		/* Notify the control plane that the check (re-)starts from the beginning. */
+		if (flags & CHK__CHECK_FLAG__CF_RESET)
+			rc = 1;
 	} else if (rc != -DER_ALREADY) {
 		D_ERROR("Leader failed to start check on %u ranks for %d pools with "
 			"flags %x, phase %d, leader %u, gen "DF_X64": "DF_RC"\n",

--- a/src/control/server/mgmt_check.go
+++ b/src/control/server/mgmt_check.go
@@ -200,10 +200,6 @@ func (svc *mgmtSvc) SystemCheckStart(ctx context.Context, req *mgmtpb.CheckStart
 	}()
 	svc.log.Debugf("Received SystemCheckStart RPC: %+v", req)
 
-	if err := svc.sysdb.ResetCheckerData(); err != nil {
-		return nil, errors.Wrap(err, "failed to reset checker finding database")
-	}
-
 	dResp, err := svc.makePoolCheckerCall(ctx, drpc.MethodCheckerStart, req)
 	if err != nil {
 		return nil, err
@@ -212,6 +208,12 @@ func (svc *mgmtSvc) SystemCheckStart(ctx context.Context, req *mgmtpb.CheckStart
 	resp = new(mgmtpb.CheckStartResp)
 	if err = proto.Unmarshal(dResp.Body, resp); err != nil {
 		return nil, errors.Wrap(err, "unmarshal CheckStart response")
+	}
+
+	if resp.Status > 0 {
+		if err := svc.sysdb.ResetCheckerData(); err != nil {
+			return nil, errors.Wrap(err, "failed to reset checker finding database")
+		}
 	}
 
 	return resp, nil

--- a/src/control/server/mgmt_check.go
+++ b/src/control/server/mgmt_check.go
@@ -211,9 +211,11 @@ func (svc *mgmtSvc) SystemCheckStart(ctx context.Context, req *mgmtpb.CheckStart
 	}
 
 	if resp.Status > 0 {
+		svc.log.Debug("resetting checker findings DB")
 		if err := svc.sysdb.ResetCheckerData(); err != nil {
 			return nil, errors.Wrap(err, "failed to reset checker finding database")
 		}
+		resp.Status = 0 // reset status to indicate success
 	}
 
 	return resp, nil

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -2620,7 +2620,7 @@ ds_mgmt_drpc_check_start(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 
 	rc = ds_mgmt_check_start(req->n_ranks, req->ranks, req->n_policies, req->policies,
 				 req->n_uuids, req->uuids, req->flags, -1 /* phase */);
-	if (rc != 0)
+	if (rc < 0)
 		D_ERROR("Failed to start check: "DF_RC"\n", DP_RC(rc));
 
 	resp.status = rc;


### PR DESCRIPTION
If DAOS check is resumed from former checkpoint, then the control plane shoud not reset the check DB, otherwise the former reported events will be lost.

Signed-off-by: Fan Yong <fan.yong@intel.com>