### PR TITLE
DAOS-11269 test:  Update pipeline-lib to enable soak-branch (#9911)

### DIFF
--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -188,10 +188,8 @@ set_local_repo() {
     local version
     version="$(lsb_release -sr)"
     version=${version%%.*}
-    if [ "$repo_server" = "artifactory" ] &&
-       [ -z "$(rpm_test_version)" ] &&
-       [[ ${CHANGE_TARGET:-$BRANCH_NAME} != weekly-testing* ]] &&
-       [[ ${CHANGE_TARGET:-$BRANCH_NAME} != provider-testing* ]]; then
+    if [ "$repo_server" = "artifactory" ] && [ -z "$(rpm_test_version)" ] &&
+       [[ ! ${CHANGE_TARGET:-$BRANCH_NAME} =~ ^[-0-9A-Za-z]+-testing ]]; then
         # Disable the daos repo so that the Jenkins job repo or a PR-repos*: repo is
         # used for daos packages
         dnf -y config-manager \

--- a/ftest.sh
+++ b/ftest.sh
@@ -53,7 +53,7 @@ NFS_SERVER=${NFS_SERVER:-${HOSTNAME%%.*}}
 trap 'echo "encountered an unchecked return code, exiting with error"' ERR
 
 IFS=" " read -r -a nodes <<< "${2//,/ }"
-TEST_NODES=$(IFS=","; echo "${nodes[*]:1:8}")
+TEST_NODES=$(IFS=","; echo "${nodes[*]:1}")
 
 # Optional arguments for launch.py
 LAUNCH_OPT_ARGS="${3:-}"

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -32,6 +32,7 @@ ET.Element = Element
 ET.SubElement = SubElement
 ET.tostring = tostring
 
+DEFAULT_DAOS_APP_DIR = "/scratch"
 DEFAULT_DAOS_TEST_LOG_DIR = "/var/tmp/daos_testing"
 YAML_KEYS = OrderedDict(
     [
@@ -202,6 +203,8 @@ def set_test_environment(args):
         os.environ["D_LOG_FILE"] = os.path.join(
             os.environ["DAOS_TEST_LOG_DIR"], "daos.log")
         os.environ["D_LOG_FILE_APPEND_PID"] = "1"
+        if "DAOS_APP_DIR" not in os.environ:
+            os.environ["DAOS_APP_DIR"] = DEFAULT_DAOS_APP_DIR
 
         # Assign the default value for transport configuration insecure mode
         os.environ["DAOS_INSECURE_MODE"] = str(args.insecure_mode)

--- a/src/tests/ftest/soak/faults.py
+++ b/src/tests/ftest/soak/faults.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 """
-(C) Copyright 2018-2021 Intel Corporation.
+(C) Copyright 2018-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from test_base import SoakTestBase
+from soak_test_base import SoakTestBase
 
 
 class SoakFaultInject(SoakTestBase):
@@ -24,9 +24,10 @@ class SoakFaultInject(SoakTestBase):
         This test will run for the time specified by test_timeout in
         the soak_faults config file.
 
-        :avocado: tags=hw,large
-        :avocado: tags=soak
-        :avocado: tags=soak_faults
+        :avocado: tags=manual
+        :avocado: tags=hw,24
+        :avocado: tags=soak,soak_harassers
+        :avocado: tags=test_soak_faults
         """
         test_param = "/run/soak_faults/"
         self.run_soak(test_param)

--- a/src/tests/ftest/soak/harassers.py
+++ b/src/tests/ftest/soak/harassers.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 """
-(C) Copyright 2018-2021 Intel Corporation.
+(C) Copyright 2018-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from test_base import SoakTestBase
+from soak_test_base import SoakTestBase
 
 
 class SoakHarassers(SoakTestBase):
@@ -24,9 +24,10 @@ class SoakHarassers(SoakTestBase):
         This test will run for the time specififed in
         /run/test_timeout.
 
-        :avocado: tags=hw,large
-        :avocado: tags=soak
-        :avocado: tags=soak_harassers
+        :avocado: tags=manual
+        :avocado: tags=hw,24
+        :avocado: tags=soak,soak_harassers
+        :avocado: tags=test_soak_harassers
         """
         test_param = "/run/soak_harassers/"
         self.run_soak(test_param)

--- a/src/tests/ftest/soak/smoke.py
+++ b/src/tests/ftest/soak/smoke.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 """
-(C) Copyright 2018-2021 Intel Corporation.
+(C) Copyright 2018-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from test_base import SoakTestBase
+from soak_test_base import SoakTestBase
 
 
 class SoakSmoke(SoakTestBase):
@@ -24,9 +24,10 @@ class SoakSmoke(SoakTestBase):
         various jobs defined in the soak yaml.  It will run for no more than
         20 min
 
-        :avocado: tags=hw,large
-        :avocado: tags=soak
-        :avocado: tags=soak_smoke
+        :avocado: tags=manual
+        :avocado: tags=hw,large,24
+        :avocado: tags=soak,soak_smoke
+        :avocado: tags=test_soak_smoke
         """
         test_param = "/run/smoke/"
         self.run_soak(test_param)

--- a/src/tests/ftest/soak/smoke.yaml
+++ b/src/tests/ftest/soak/smoke.yaml
@@ -97,8 +97,8 @@ smoke:
         - fio_smoke
         - daos_racer
         - mdtest_smoke
-        #- vpic_smoke
-        #- lammps_smoke
+        - vpic_smoke
+        - lammps_smoke
         - macsio_smoke
     # num of bytes to write to reserved container
     resv_bytes: 500
@@ -177,10 +177,9 @@ vpic_smoke:
         - 1
     taskspernode:
         - 1
-    cmdline: "/home/mjean/vpic-install/bin/harris.Linux"
+    cmdline: "${DAOS_APP_DIR}/soak/apps/vpic-install/bin/harris.Linux"
     posix: True
     workdir: "/tmp/daos_dfuse/vpic/"
-    module: "mpi/latest"
     dfuse:
         mount_dir: "/tmp/daos_dfuse/vpic/"
     oclass:
@@ -191,7 +190,7 @@ lammps_smoke:
         - 1
     taskspernode:
         - 1
-    cmdline: "/home/mjean/lammps/src/lmp_mpi -i /home/mjean/lammps/bench/in.lj.smoke"
+    cmdline: "${DAOS_APP_DIR}/soak/apps/lammps/src/lmp_mpi -i ${DAOS_APP_DIR}/soak/apps/lammps/bench/in.lj.smoke"
     posix: True
     workdir: "/tmp/daos_dfuse/lammps/"
     dfuse:

--- a/src/tests/ftest/soak/stress_2h.py
+++ b/src/tests/ftest/soak/stress_2h.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 """
-(C) Copyright 2018-2021 Intel Corporation.
+(C) Copyright 2018-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from test_base import SoakTestBase
+from soak_test_base import SoakTestBase
 
 
 class SoakStress(SoakTestBase):
@@ -24,9 +24,10 @@ class SoakStress(SoakTestBase):
         various jobs defined in the soak yaml
         This test will run soak_stress for 2 hours.
 
+        :avocado: tags=manual
         :avocado: tags=hw,large
         :avocado: tags=soak
-        :avocado: tags=soak_stress_2h
+        :avocado: tags=soak_stress_2h,test_soak_stress
         """
         test_param = "/run/soak_stress/"
         self.run_soak(test_param)

--- a/src/tests/ftest/soak/stress_2h.yaml
+++ b/src/tests/ftest/soak/stress_2h.yaml
@@ -5,7 +5,7 @@ hosts:
     # server_partition: daos_server
     client_partition: normal
     client_reservation: daos-test
-mpi_module: mpich/gnu-sockets
+mpi_module: mpich/gnu-tcp
 # This timeout must be longer than the test_timeout param (+15minutes)
 # 2 hour test
 timeout: 2H15M
@@ -141,11 +141,10 @@ mdtest_stress:
 vpic_stress:
     job_timeout: 20
     nodesperjob:
-        - 4
+        - 1
     taskspernode:
         - 16
     cmdline: "/var/hit/daos/builds/vpic-install/bin/harris.Linux"
-    module: mpi/latest
     posix: true
     workdir: "/tmp/daos_dfuse/vpic/"
     dfuse:

--- a/src/tests/ftest/soak/stress_48h.py
+++ b/src/tests/ftest/soak/stress_48h.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 """
-(C) Copyright 2018-2021 Intel Corporation.
+(C) Copyright 2018-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from test_base import SoakTestBase
+from soak_test_base import SoakTestBase
 
 
 class SoakStress(SoakTestBase):
@@ -15,16 +15,17 @@ class SoakStress(SoakTestBase):
     :avocado: recursive
     """
 
-    def test_soak_stress(self):
+    def test_soak_stress_48h(self):
         """Run soak test for 48hours on performance cluster.
 
         Test Description: This will create a slurm batch jobs that run
         various jobs defined in the soak yaml
         This test will run soak_stress for 48 hours.
 
-        :avocado: tags=hw,large
-        :avocado: tags=soak
-        :avocado: tags=soak_stress_48h
+        :avocado: tags=manual
+        :avocado: tags=hw,24
+        :avocado: tags=soak,soak_stress
+        :avocado: tags=soak_stress_48h,test_soak_stress_48h
         """
         test_param = "/run/soak_stress/"
         self.run_soak(test_param)

--- a/src/tests/ftest/soak/stress_48h.yaml
+++ b/src/tests/ftest/soak/stress_48h.yaml
@@ -1,6 +1,6 @@
 hosts:
 # servers if no server partition is defined
-    test_servers: 10
+    test_servers: 8
 # servers if a server partition is defined
     # server_partition: daos_server
     client_partition: daos_client
@@ -95,7 +95,7 @@ soak_stress:
     test_timeout: 48
     joblist:
         - fio_stress
-        - daos_racer
+        #- daos_racer
         - ior_stress
         - mdtest_stress
         - vpic_stress
@@ -183,11 +183,10 @@ vpic_stress:
 # Requires opeapi
     job_timeout: 20
     nodesperjob:
-        - 8
+        - 1
     taskspernode:
         - 32
-    cmdline: "/home/mjean/vpic-install/bin/harris.Linux"
-    module: mpi/latest
+    cmdline: "${DAOS_APP_DIR}/soak/apps/vpic-install/bin/harris.Linux"
     posix: True
     workdir: "/tmp/daos_dfuse/vpic/"
     dfuse:
@@ -200,7 +199,7 @@ lammps_stress:
         - 8
     taskspernode:
         - 32
-    cmdline: "/home/mjean/lammps/src/lmp_mpi -i /home/mjean/lammps/bench/in.lj"
+    cmdline: "${DAOS_APP_DIR}/soak/apps/lammps/src/lmp_mpi -i ${DAOS_APP_DIR}/soak/apps/lammps/bench/in.lj"
     posix: True
     workdir: "/tmp/daos_dfuse/lammps/"
     dfuse:

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -679,6 +679,8 @@ class TestWithServers(TestWithoutServers):
         self.agent_manager_class = "Systemctl"
         self.setup_start_servers = True
         self.setup_start_agents = True
+        self.slurm_exclude_servers = False
+        self.slurm_exclude_nodes = NodeSet()
         self.hostlist_servers = NodeSet()
         self.hostlist_clients = NodeSet()
         self.hostfile_clients = None
@@ -728,6 +730,10 @@ class TestWithServers(TestWithoutServers):
         self.setup_start_agents = self.params.get(
             "start_agents", "/run/setup/*", self.setup_start_agents)
 
+        # Support removing any servers from the client list
+        self.slurm_exclude_servers = self.params.get(
+            "slurm_exclude_servers", "/run/setup/*", self.slurm_exclude_servers)
+
         # The server config name should be obtained from each ServerManager
         # object, but some tests still use this TestWithServers attribute.
         self.server_group = self.params.get(
@@ -741,6 +747,16 @@ class TestWithServers(TestWithoutServers):
             "test_servers", "server_partition", "server_reservation", "/run/hosts/*")
         self.hostlist_clients = self.get_hosts_from_yaml(
             "test_clients", "client_partition", "client_reservation", "/run/hosts/*")
+
+        # Optionally remove any servers that may have ended up in the client list.  This can occur
+        # with tests using slurm partitions as they are setup with all hosts.
+        if self.slurm_exclude_servers:
+            self.log.debug(
+                "Excluding any %s servers from the current client list: %s",
+                self.hostlist_servers, self.hostlist_clients)
+            new_client_list = self.hostlist_clients.difference(self.hostlist_servers)
+            self.slurm_exclude_nodes = self.hostlist_clients.difference(new_client_list)
+            self.hostlist_clients = new_client_list
 
         # # Find a configuration that meets the test requirements
         # self.config = Configuration(

--- a/src/tests/ftest/util/soak_utils.py
+++ b/src/tests/ftest/util/soak_utils.py
@@ -1223,6 +1223,7 @@ def create_app_cmdline(self, job_spec, pool, ppn, nodesperjob):
         self.log.info(
             "<<{} command line not specified in yaml; job will not be run>>".format(job_spec))
         return commands
+
     oclass_list = self.params.get("oclass", app_params)
     for oclass in oclass_list:
         add_containers(self, pool, oclass)
@@ -1298,7 +1299,7 @@ def build_job_script(self, commands, job, nodesperjob):
         error = os.path.join(str(output) + "ERROR_")
         sbatch = {
             "time": str(job_timeout) + ":00",
-            "exclude": self.exclude_slurm_nodes,
+            "exclude": str(self.slurm_exclude_nodes),
             "error": str(error),
             "export": "ALL",
             "exclusive": None


### PR DESCRIPTION
Allow-unstable-test: true
Skip-unit-tests: true
Test-tag: pr soak_smoke

Updated test code to run soak via a Jenkins build in CI Updates include:
- Allow ftest/main to include up to 24 nodes
- Update post provisioning to easily add *-testing branch
- Create DAOS_APP_DIR env within the testing framework
- Changed vpic default mpi to mpich
- Fixed an issue in soak cleanup where it was removing the shared tmp dir

Signed-off-by: Maureen Jean <maureen.jean@intel.com>