### PR TITLE
DAOS-11363 test: Apply threshold for SCM free space check in test (#9…

### DIFF
--- a/src/tests/ftest/container/multiple_delete.py
+++ b/src/tests/ftest/container/multiple_delete.py
@@ -3,7 +3,11 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import time
+
 from ior_test_base import IorTestBase
+
+SCM_THRESHOLD = 400000
 
 
 class MultipleContainerDelete(IorTestBase):
@@ -29,7 +33,8 @@ class MultipleContainerDelete(IorTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=container,multi_container_delete
+        :avocado: tags=container
+        :avocado: tags=multi_container_delete,test_multiple_container_delete
         """
         self.add_pool(connect=False)
 
@@ -37,8 +42,8 @@ class MultipleContainerDelete(IorTestBase):
 
         initial_scm_fs, initial_ssd_fs = self.get_pool_space()
 
-        for i in range(50):
-            self.log.info("Create-Write-Destroy Iteration %d", i)
+        for loop in range(50):
+            self.log.info("Create-Write-Destroy Iteration %d", loop)
             self.create_cont()
             self.ior_cmd.set_daos_params(
                 self.server_group, self.pool, self.container.uuid)
@@ -47,7 +52,7 @@ class MultipleContainerDelete(IorTestBase):
             self.run_ior_with_pool(create_cont=False)
             self.container.destroy()
             scm_fs, ssd_fs = self.get_pool_space()
-            out.append("iter = {}, scm = {}, ssd = {}".format(i + 1, scm_fs, ssd_fs))
+            out.append("iter = {}, scm = {}, ssd = {}".format(loop + 1, scm_fs, ssd_fs))
 
         self.log.info("Initial Free Space")
         self.log.info("SCM = %d, NVMe = %d", initial_scm_fs, initial_ssd_fs)
@@ -60,10 +65,32 @@ class MultipleContainerDelete(IorTestBase):
         self.log.info("Verifying NVMe space is recovered")
         self.check_pool_free_space(self.pool, expected_nvme=initial_ssd_fs)
 
+        # Verify SCM space recovery. About 198KB of the SCM free space isn't recovered
+        # even after waiting for 180 sec, so apply the threshold. Considered not a bug.
+        # DAOS-8643
         self.log.info("Verifying SCM space is recovered")
-        self.log.info("%d (Final) == %d (Initial)", final_scm_fs, initial_scm_fs)
-        # Uncomment the below verification once DAOS-8643 is fixed
-        # self.assertTrue(final_scm_fs == initial_scm_fs)
+        scm_recovered = False
+        # Based on the experiments, the recovery occurs in every 8 iterations. However,
+        # since 50 is not divisible by 8, some data would remain in the disk right after
+        # the 50th iteration. If we wait for several seconds, that remaining data will be
+        # deleted (and we have 198KB left as mentioned above).
+        for _ in range(5):
+            final_scm_fs, _ = self.get_pool_space()
+            scm_diff = initial_scm_fs - final_scm_fs
+            if scm_diff <= SCM_THRESHOLD:
+                msg = ("SCM space was recovered. Initial = {}; Final = {}; "
+                       "Threshold = {}; (Unit is in byte)").format(
+                           initial_scm_fs, final_scm_fs, SCM_THRESHOLD)
+                self.log.info(msg)
+                scm_recovered = True
+                break
+            time.sleep(10)
+
+        if not scm_recovered:
+            msg = ("SCM space wasn't recovered! Initial = {}, Final = {}, "
+                   "Threshold = {}; (Unit is in byte.)".format(
+                       initial_scm_fs, final_scm_fs, SCM_THRESHOLD))
+            self.fail(msg)
 
     def get_pool_space(self):
         """Get scm and ssd pool free space

--- a/src/tests/ftest/container/multiple_delete.yaml
+++ b/src/tests/ftest/container/multiple_delete.yaml
@@ -15,7 +15,7 @@ server_config:
 
 pool:
     name: daos_server
-    size: 10%
+    size: 50%
     control_method: dmg
 
 container:


### PR DESCRIPTION
…974)

After 50 iterations of container create, IOR run, and container destroy, SCM free space isn’t fully recovered (about 20MB left). If we wait for several seconds, most of them would be recovered and the remaining data would be about ~198KB, which is considered not a bug.

Apply threshold of 400KB to the SCM free space check.

Increase pool size to avoid out of space during IOR.

Test-tag: multi_container_delete
Skip-unit-tests: true
Skip-fault-injection-test: true
Test-repeat: 5
Required-githooks: true
Signed-off-by: Makito Kano <makito.kano@intel.com>