### PR TITLE
DAOS-11159 test: Increase timeout to 35 minutes. (#10309)

### DIFF
--- a/src/tests/ftest/erasurecode/rank_failure.yaml
+++ b/src/tests/ftest/erasurecode/rank_failure.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 6
   test_clients: 1
-timeout: 1500
+timeout: 2100
 setup:
   start_agents_once: False
   start_servers_once: False


### PR DESCRIPTION
Test-tag: ec_io_conf_run
Test-repeat: 3

Summary: Increase the timeout for ec_io_conf_run from 1500 to 2100 seconds.

Signed-off-by: rpadma2 <ravindran.padmanabhan@intel.com>