### PR TITLE
DAOS-11467 build: Update DAOS to use UCX 1.13

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -11,7 +11,8 @@ OFI = v1.15.1
 MERCURY = v2.2.0
 PSM2 = PSM2_11.2.78
 PROTOBUFC = v1.3.3
-UCX=v1.12.1
+UCX=v1.13.0
 
 [patch_versions]
 spdk=https://github.com/spdk/spdk/commit/b0aba3fcd5aceceea530a702922153bc75664978.diff
+mercury=https://raw.githubusercontent.com/daos-stack/mercury/master/na_ucx_local_addr.patch

--- a/utils/build.config
+++ b/utils/build.config
@@ -15,4 +15,4 @@ UCX=v1.13.0
 
 [patch_versions]
 spdk=https://github.com/spdk/spdk/commit/b0aba3fcd5aceceea530a702922153bc75664978.diff
-mercury=https://raw.githubusercontent.com/daos-stack/mercury/master/na_ucx_local_addr.patch
+mercury=https://raw.githubusercontent.com/daos-stack/mercury/9070d5c89600278c1c7ebfd9b17f0275cca13fcc/na_ucx_local_addr.patch


### PR DESCRIPTION
Signed-off-by: Joseph Moore <joseph.moore@intel.com>