### PR TITLE
DAOS-11609 test: increase rebuild/cascading_failures timeout (#10307)

### DIFF
--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 6
   test_clients: 1
-timeout: 360
+timeout: 420
 server_config:
   name: daos_server
   servers:


### PR DESCRIPTION
Increase timeout from 360s to 420s

Test-tag: test_simultaneous_failures test_sequential_failures test_cascading_failures Test-repeat: 3
Skip-func-test-leap15: false
Skip-unit-tests: true
Skip-fault-injection-test: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>