### PR TITLE
DAOS-11453 test: Detect silent daos_test failures (#10084)

### DIFF
--- a/src/tests/ftest/daos_test/dfuse.py
+++ b/src/tests/ftest/daos_test/dfuse.py
@@ -99,7 +99,7 @@ class DaosCoreTestDfuse(DfuseTestBase):
             daos_test_env['DD_SUBSYS'] = 'all'
             daos_test_env['D_LOG_MASK'] = 'INFO,IL=DEBUG'
 
-        command = [self.daos_test, '--test-dir', mount_dir, '--io', '--stream']
+        command = [self.daos_test, '--test-dir', mount_dir, '--io']
         if cache_mode != 'writeback':
             command.append('--metadata')
 

--- a/src/tests/ftest/daos_test/dfuse.py
+++ b/src/tests/ftest/daos_test/dfuse.py
@@ -6,8 +6,12 @@
 
 import os
 from collections import OrderedDict
-import general_utils
+
+from cmocka_utils import CmockaUtils
 from dfuse_test_base import DfuseTestBase
+from general_utils import create_directory, get_log_file
+from job_manager_utils import get_job_manager
+
 
 class DaosCoreTestDfuse(DfuseTestBase):
     # pylint: disable=too-many-ancestors
@@ -27,7 +31,7 @@ class DaosCoreTestDfuse(DfuseTestBase):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
         :avocado: tags=dfuse,dfuse_test
-        :avocado: tags=dfuse_unit
+        :avocado: tags=dfuse_unit,test_daos_dfuse_unit
         """
         self.daos_test = os.path.join(self.bin, 'dfuse_test')
 
@@ -43,6 +47,8 @@ class DaosCoreTestDfuse(DfuseTestBase):
 
         # How long to cache things for, if caching is enabled.
         cache_time = '5m'
+
+        use_dfuse = True
 
         if cache_mode == 'writeback':
             cont_attrs['dfuse-data-cache'] = 'on'
@@ -64,41 +70,43 @@ class DaosCoreTestDfuse(DfuseTestBase):
             cont_attrs['dfuse-attr-time'] = '0'
             cont_attrs['dfuse-dentry-time'] = '0'
             cont_attrs['dfuse-ndentry-time'] = '0'
+        elif cache_mode == 'native':
+            use_dfuse = False
         else:
             self.fail('Invalid cache_mode: {}'.format(cache_mode))
 
-        for key, value in cont_attrs.items():
-            daos_cmd.container_set_attr(pool=self.pool.uuid, cont=self.container.uuid,
-                                        attr=key, val=value)
+        if use_dfuse:
+            for key, value in cont_attrs.items():
+                daos_cmd.container_set_attr(pool=self.pool.uuid, cont=self.container.uuid,
+                                            attr=key, val=value)
 
-        self.start_dfuse(self.hostlist_clients, self.pool, self.container)
+            self.start_dfuse(self.hostlist_clients, self.pool, self.container)
 
-        mount_dir = self.dfuse.mount_dir.value
-
-        intercept = self.params.get('use_intercept', '/run/intercept/*', default=False)
-
-        cmd = [self.daos_test, '--test-dir', mount_dir, '--io']
-
-        if cache_mode != 'writeback':
-            cmd.append('--metadata')
-        if intercept:
-            remote_env = OrderedDict()
-
-            remote_env['LD_PRELOAD'] = os.path.join(self.prefix, 'lib64', 'libioil.so')
-            remote_env['D_LOG_FILE'] = '/var/tmp/daos_testing/daos-il.log'
-            remote_env['DD_MASK'] = 'all'
-            remote_env['DD_SUBSYS'] = 'all'
-            remote_env['D_LOG_MASK'] = 'INFO,IL=DEBUG'
-
-            envs = ['export {}={}'.format(env, value) for env, value in remote_env.items()]
-
-            preload_cmd = ';'.join(envs)
-
-            command = '{};{}'.format(preload_cmd, ' '.join(cmd))
+            mount_dir = self.dfuse.mount_dir.value
         else:
-            command = ' '.join(cmd)
-        ret_code = general_utils.pcmd(self.hostlist_clients, command, timeout=60)
-        if 0 in ret_code:
-            return
-        self.log.info(ret_code)
-        self.fail('Error running {}'.format(cmd))
+            # Bypass, simply create a remote directory and use that.
+            mount_dir = '/tmp/dfuse-test'
+            create_directory(self.hostlist_clients, mount_dir)
+
+        cmocka_utils = CmockaUtils(self.hostlist_clients, "dfuse", self.outputdir, self.test_dir)
+
+        daos_test_env = cmocka_utils.get_cmocka_env()
+        intercept = self.params.get('use_intercept', '/run/intercept/*', default=False)
+        if intercept:
+            daos_test_env['LD_PRELOAD'] = os.path.join(self.prefix, 'lib64', 'libioil.so')
+            daos_test_env['D_LOG_FILE'] = get_log_file('daos-il.log')
+            daos_test_env['DD_MASK'] = 'all'
+            daos_test_env['DD_SUBSYS'] = 'all'
+            daos_test_env['D_LOG_MASK'] = 'INFO,IL=DEBUG'
+
+        command = [self.daos_test, '--test-dir', mount_dir, '--io', '--stream']
+        if cache_mode != 'writeback':
+            command.append('--metadata')
+
+        job = get_job_manager(self, "Clush", cmocka_utils.get_cmocka_command(" ".join(command)))
+        job.assign_hosts(cmocka_utils.hosts)
+        job.assign_environment(daos_test_env)
+
+        cmocka_utils.run_cmocka_test(self, job)
+        if not job.result.passed:
+            self.fail(f'Error running {job.command} on {job.hosts}')

--- a/src/tests/ftest/scripts/post_process_xml.sh
+++ b/src/tests/ftest/scripts/post_process_xml.sh
@@ -61,15 +61,17 @@ for file in "${FILES[@]}"; do
                 grep -Po "name=\"\K.*(?=\" time=)" | uniq); then
                 echo "Failed to process XML $file. Cannot determine SUITE."
             else
-		for suite_name in ${SUITE}; do
+                for suite_name in ${SUITE}; do
                     sed -i \
                     "s/case name/case classname=\"${COMP}.${suite_name}\" name/" "$file"
                 done
-	    fi
+            fi
         else
             sed -i "s/case classname=\"/case classname=\"${COMP}./" "$file"
         fi
-        sed -i "/<\/testsuites>/,/<testsuites>/ d" "$file"
-        echo "</testsuites>" >> "$file"
+        if grep "<testsuites>" "$file" >/dev/null; then
+            sed -i "/<\/testsuites>/,/<testsuites>/ d" "$file"
+            echo "</testsuites>" >> "$file"
+        fi
     fi
 done

--- a/src/tests/ftest/util/cmocka_utils.py
+++ b/src/tests/ftest/util/cmocka_utils.py
@@ -134,9 +134,7 @@ class CmockaUtils():
         # List any remote cmocka files
         test.log.debug("Remote %s directories:", self.cmocka_dir)
         ls_command = "ls -alR {0}".format(self.cmocka_dir)
-        clush_ls_command = "{0} {1}".format(
-            get_clush_command(self.hosts, "-B -S"), ls_command)
-        run_remote(self.hosts, clush_ls_command)
+        run_remote(self.hosts, ls_command)
 
         # Copy any remote cmocka files back to this host
         command = "{0} --rcopy {1} --dest {1}".format(

--- a/src/tests/ftest/util/cmocka_utils.py
+++ b/src/tests/ftest/util/cmocka_utils.py
@@ -1,0 +1,193 @@
+"""
+  (C) Copyright 2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+import os
+
+from agent_utils import include_local_host
+from command_utils import ExecutableCommand
+from command_utils_base import EnvironmentVariables
+from exception_utils import CommandFailure
+from general_utils import get_clush_command, run_command, run_remote
+from results_utils import TestName, TestResult, Results, Job, create_xml
+
+
+class CmockaUtils():
+    """Utilities for running test that generate cmocka xml results."""
+
+    def __init__(self, hosts, test_name, outputdir, test_dir):
+        """Initialize a CmockaUtils object.
+
+        Args:
+            hosts (str): hosts on which to run the cmocka tests
+            test_name (str): simple name for the test
+            outputdir (str): final location for cmocka xml files on this host
+            test_dir (str): directory common to all hosts for storing remote cmocka xml files
+        """
+        self.hosts = hosts
+        self.test_name = test_name
+        self.outputdir = outputdir
+        self._using_local_host = False
+
+        # Use the local host if no hosts have been specified.
+        if not self.hosts:
+            self.hosts = include_local_host(self.hosts)
+            self._using_local_host = True
+
+        self.cmocka_dir = self._get_cmocka_dir(test_dir)
+
+    def _get_cmocka_dir(self, test_dir):
+        """Get the directory in which to write cmocka xml results.
+
+        For tests running locally use a directory that will place the cmocka results directly in
+        the avocado job-results/*/test-results/*/data/ directory (self.outputdir).
+
+        For tests running remotely use a 'cmocka' subdirectory in the DAOS_TEST_LOG_DIR directory as
+        this directory should exist on all hosts.  After the command runs these remote files will
+        need to be copied back to this host and placed in the self.outputdir directory in order for
+        them to be included as part of the Jenkins test results - see _collect_cmocka_results().
+
+        Args:
+            test_dir (str): directory common to all hosts
+
+        Returns:
+            str: the cmocka directory to use with the CMOCKA_XML_FILE env
+
+        """
+        cmocka_dir = self.outputdir
+        if not self._using_local_host:
+            cmocka_dir = os.path.join(test_dir, "cmocka")
+            command = " ".join(["mkdir", "-p", cmocka_dir])
+            run_remote(include_local_host(self.hosts), command)
+        return cmocka_dir
+
+    def get_cmocka_env(self):
+        """Get the environment variables to use when running the daos_test command.
+
+        Returns:
+            EnvironmentVariables: the environment variables for the daos_test command
+
+        """
+        return EnvironmentVariables({
+            "CMOCKA_XML_FILE": os.path.join(self.cmocka_dir, "%g_cmocka_results.xml"),
+            "CMOCKA_MESSAGE_OUTPUT": "xml",
+        })
+
+    def get_cmocka_command(self, command):
+        """Get an ExecutableCommand representing the provided command string.
+
+        Adds detection of any bad keywords in the command output that, if found, will result in a
+        command failure.
+
+        Args:
+            command (str): the command string to use to create the ExecutableCommand
+
+        Returns:
+            ExecutableCommand: the object setup to run the command
+
+        """
+        keywords = ["Process received signal", "stack smashing detected", "End of error message"]
+        return ExecutableCommand(namespace=None, command=command, check_results=keywords)
+
+    def run_cmocka_test(self, test, command):
+        """Run the cmocka test command.
+
+        After the command completes, copy any remote cmocka results that may exist back to this host
+        and generate a cmocka result if one is missing or the command failed before generating one.
+
+        Args:
+            test (Test): the avocado test class
+            command (ExecutableCommand): the command to run
+        """
+        job_command = command.job if hasattr(command, "job") else command
+        error_message = None
+        error_exception = None
+        try:
+            command.run()
+
+        except CommandFailure as error:
+            error_message = "Error detected running {}".format(job_command)
+            error_exception = error
+            test.log.exception(error_message)
+            test.fail(error_message)
+
+        finally:
+            self._collect_cmocka_results(test)
+            if not self._check_cmocka_files():
+                if error_message is None:
+                    error_message = "Missing cmocka results for {} in {}".format(
+                        job_command, self.cmocka_dir)
+                self._generate_cmocka_files(test, error_message, error_exception)
+
+    def _collect_cmocka_results(self, test):
+        """Collect any remote cmocka files.
+
+        Args:
+            test (Test): the avocado test class
+        """
+        if self._using_local_host:
+            # No remote hosts where used to run the daos_test command, so nothing to do
+            return
+
+        # List any remote cmocka files
+        test.log.debug("Remote %s directories:", self.cmocka_dir)
+        ls_command = "ls -alR {0}".format(self.cmocka_dir)
+        clush_ls_command = "{0} {1}".format(
+            get_clush_command(self.hosts, "-B -S"), ls_command)
+        run_remote(self.hosts, clush_ls_command)
+
+        # Copy any remote cmocka files back to this host
+        command = "{0} --rcopy {1} --dest {1}".format(
+            get_clush_command(self.hosts), self.cmocka_dir)
+        try:
+            run_command(command)
+
+        finally:
+            test.log.debug("Local %s directory after clush:", self.cmocka_dir)
+            run_command(ls_command)
+            # Move local files to the avocado test variant data directory
+            for cmocka_node_dir in os.listdir(self.cmocka_dir):
+                cmocka_node_path = os.path.join(self.cmocka_dir, cmocka_node_dir)
+                if os.path.isdir(cmocka_node_path):
+                    for cmocka_file in os.listdir(cmocka_node_path):
+                        if "_cmocka_results." in cmocka_file:
+                            cmocka_file_path = os.path.join(cmocka_node_path, cmocka_file)
+                            command = "mv {0} {1}".format(cmocka_file_path, self.outputdir)
+                            run_command(command)
+
+    def _check_cmocka_files(self):
+        """Determine if cmocka files exist in the expected location.
+
+        Returns:
+            bool: True if cmocka files exist in the expected location; False otherwise
+        """
+        for item in os.listdir(self.outputdir):
+            if "cmocka_results.xml" in item:
+                return True
+        return False
+
+    def _generate_cmocka_files(self, test, error_message, error_exception):
+        """Generate a cmocka xml file.
+
+        Args:
+            log_file (str): the avocado test log
+            test_variant (str): the avocado test name which includes the variant information
+            error_message (str): a description of the test failure
+            error_exception (Exception): the exception raised when the failure occurred
+        """
+        # Create a failed test result
+        test_name = TestName(test.name.name, test.name.str_uid, test.name.str_variant)
+        test_result = TestResult(self.test_name, test_name, test.logfile, test.logdir)
+        test_result.status = TestResult.ERROR
+        test_result.fail_class = "Missing file" if error_exception is None else "Failed command"
+        test_result.fail_reason = error_message
+        test_result.traceback = error_exception
+        test_result.time_elapsed = 0
+
+        cmocka_xml = os.path.join(self.outputdir, "{}_cmocka_results.xml".format(self.test_name))
+        job = Job(self.test_name, xml_output=cmocka_xml)
+        result = Results(test.logfile)
+        result.tests.append(test_result)
+        create_xml(job, result)

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -174,6 +174,7 @@ class ExecutableCommand(CommandWithParameters):
         status = True
         if self.result and self.check_results_list:
             regex = r"({})".format("|".join(self.check_results_list))
+            self.log.debug("Checking the command output for any bad keywords: %s", regex)
             for output in (self.result.stdout_text, self.result.stderr_text):
                 match = re.findall(regex, output)
                 if match:

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -1,20 +1,15 @@
-#!/usr/bin/python
 """
   (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import os
-
 from avocado import fail_on
-from avocado.utils import process
+
 from apricot import TestWithServers
-from general_utils import get_log_file, get_clush_command, run_command, log_task
-from command_utils_base import EnvironmentVariables
-from command_utils import ExecutableCommand
+from general_utils import get_log_file
+from cmocka_utils import CmockaUtils
 from exception_utils import CommandFailure
-from agent_utils import include_local_host
 from job_manager_utils import get_job_manager
 from test_utils_pool import POOL_TIMEOUT_INCREMENT
 
@@ -41,12 +36,6 @@ class DaosCoreBase(TestWithServers):
         self.update_log_file_names(self.subtest_name)
 
         super().setUp()
-
-        # if no client specified update self.hostlist_clients to local host
-        # and create a new self.hostfile_clients.
-        if not self.hostlist_clients:
-            self.hostlist_clients = include_local_host(self.hostlist_clients)
-            self.using_local_host = True
 
     def get_test_param(self, name, default=None):
         """Get the test-specific test yaml parameter value.
@@ -127,37 +116,22 @@ class DaosCoreBase(TestWithServers):
                 get_log_file("daosCA/certs"), self.hostlist_clients)
             dmg.copy_configuration(self.hostlist_clients)
 
-        # For tests running locally place the cmocka results directly into the avocado
-        # job-results/*/test-results/*/data/ directory (self.outputdir).  For remotely
-        # running tests, place the cmocka results in a 'cmocka' subdirectory in the
-        # DAOS_TEST_LOG_DIR directory.  These files will then need to be copied back to
-        # this host after the test runs.
-        cmocka_dir = self.outputdir
-        if not self.using_local_host:
-            cmocka_dir = os.path.join(self.test_dir, "cmocka")
-            log_task(
-                include_local_host(self.hostlist_clients), " ".join(["mkdir", "-p", cmocka_dir]))
-
-        # Set up the daos test command and environment settings
-        cmd = " ".join([self.daos_test, "-n", dmg_config_file, "".join(["-", subtest]), str(args)])
-        env = EnvironmentVariables({
-            "D_LOG_FILE": get_log_file(self.client_log),
-            "D_LOG_MASK": "DEBUG",
-            "DD_MASK": "mgmt,io,md,epc,rebuild,test",
-            "COVFILE": "/tmp/test.cov",
-            "CMOCKA_XML_FILE": os.path.join(cmocka_dir, "%g_cmocka_results.xml"),
-            "CMOCKA_MESSAGE_OUTPUT": "xml",
-            "POOL_SCM_SIZE": str(scm_size),
-            "POOL_NVME_SIZE": str(nvme_size),
-        })
-
-        # Assign the test to run
-        job_cmd = ExecutableCommand(namespace=None, command=cmd)
-        job = get_job_manager(self, "Orterun", job_cmd, mpi_type="openmpi")
-        job.assign_hosts(self.hostlist_clients, self.workdir, None)
+        # Set up the daos test command
+        cmocka_utils = CmockaUtils(
+            self.hostlist_clients, self.subtest_name, self.outputdir, self.test_dir)
+        daos_test_env = cmocka_utils.get_cmocka_env()
+        daos_test_env["D_LOG_FILE"] = get_log_file(self.client_log)
+        daos_test_env["D_LOG_MASK"] = "DEBUG"
+        daos_test_env["DD_MASK"] = "mgmt,io,md,epc,rebuild,test"
+        daos_test_env["COVFILE"] = "/tmp/test.cov"
+        daos_test_env["POOL_SCM_SIZE"] = str(scm_size)
+        daos_test_env["POOL_NVME_SIZE"] = str(nvme_size)
+        daos_test_cmd = cmocka_utils.get_cmocka_command(
+            " ".join([self.daos_test, "-n", dmg_config_file, "".join(["-", subtest]), str(args)]))
+        job = get_job_manager(self, "Orterun", daos_test_cmd, mpi_type="openmpi")
+        job.assign_hosts(cmocka_utils.hosts, self.workdir, None)
         job.assign_processes(num_clients)
-        job.assign_environment(env)
-        job_str = str(job)
+        job.assign_environment(daos_test_env)
 
         # Update the expected status for each ranks that will be stopped by this
         # test to avoid a false failure during tearDown().
@@ -173,67 +147,4 @@ class DaosCoreBase(TestWithServers):
                     manager.update_expected_states(
                         rank, ["Stopped", "Excluded"])
 
-        try:
-            process.run(job_str)
-        except process.CmdError as result:
-            if result.result.exit_status != 0:
-                # fake a JUnit failure output
-                self.create_results_xml(
-                    self.subtest_name, result, "Failed to run {0}.".format(self.daos_test))
-                self.fail(
-                    "{0} failed with return code={1}.\n".format(
-                        job_str, result.result.exit_status))
-        finally:
-            if not self.using_local_host:
-                # List any remote cmocka files
-                self.log.debug("Remote %s directories:", cmocka_dir)
-                ls_command = "ls -alR {0}".format(cmocka_dir)
-                clush_ls_command = "{0} {1}".format(
-                    get_clush_command(self.hostlist_clients, "-B -S"), ls_command)
-                log_task(self.hostlist_clients, clush_ls_command)
-
-                # Copy any remote cmocka files back to this host
-                command = "{0} --rcopy {1} --dest {1}".format(
-                    get_clush_command(self.hostlist_clients), cmocka_dir)
-                try:
-                    run_command(command)
-
-                finally:
-                    self.log.debug("Local %s directory after clush:", cmocka_dir)
-                    run_command(ls_command)
-                    # Move local files to the avocado test variant data directory
-                    for cmocka_node_dir in os.listdir(cmocka_dir):
-                        cmocka_node_path = os.path.join(cmocka_dir, cmocka_node_dir)
-                        if os.path.isdir(cmocka_node_path):
-                            for cmocka_file in os.listdir(cmocka_node_path):
-                                cmocka_file_path = os.path.join(cmocka_node_path, cmocka_file)
-                                if "_cmocka_results." in cmocka_file:
-                                    command = "mv {0} {1}".format(cmocka_file_path, self.outputdir)
-                                    run_command(command)
-
-    def create_results_xml(self, testname, result, error_message="Test failed to start up"):
-        """Create a JUnit result.xml file for the failed command.
-
-        Args:
-            testname (str): name of the test
-            result (CmdResult): result of the failed command.
-        """
-        filename = "".join([testname, "_results.xml"])
-        filename = os.path.join(self.outputdir, filename)
-        try:
-            with open(filename, "w") as results_xml:
-                results_xml.write('''<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="{0}" errors="1" failures="0" skipped="0" tests="1" time="0.0">
-  <testcase name="ALL" time="0.0" >
-    <error message="{3}"/>
-    <system-out>
-<![CDATA[{1}]]>
-    </system-out>
-    <system-err>
-<![CDATA[{2}]]>
-    </system-err>
-  </testcase>
-</testsuite>'''.format(
-    testname, result.result.stdout_text, result.result.stderr_text, error_message))
-        except IOError as error:
-            self.log.error("Error creating %s: %s", filename, error)
+        cmocka_utils.run_cmocka_test(self, job)

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -135,6 +135,146 @@ class SimpleProfiler():
         return max_time, min_time, avg_time
 
 
+class RemoteCommandResult():
+    """Stores the command result from a Task object."""
+
+    class ResultData():
+        # pylint: disable=too-few-public-methods
+        """Command result data for the set of hosts."""
+
+        def __init__(self, command, returncode, hosts, stdout, timeout):
+            """Initialize a ResultData object.
+
+            Args:
+                command (str): the executed command
+                returncode (int): the return code of the executed command
+                hosts (NodeSet): the host(s) on which the executed command yielded this result
+                stdout (list): the result of the executed command split by newlines
+                timeout (bool): indicator for a command timeout
+            """
+            self.command = command
+            self.returncode = returncode
+            self.hosts = hosts
+            self.stdout = stdout
+            self.timeout = timeout
+
+    def __init__(self, command, task):
+        """Create a RemoteCommandResult object.
+
+        Args:
+            command (str): command executed
+            task (Task): object containing the results from an executed clush command
+        """
+        self.output = []
+        self._process_task(task, command)
+
+    @property
+    def homogeneous(self):
+        """Did all the hosts produce the same output.
+
+        Returns:
+            bool: if all the hosts produced the same output
+
+        """
+        return len(self.output) == 1
+
+    @property
+    def passed(self):
+        """Did the command pass on all the hosts.
+
+        Returns:
+            bool: if the command was successful on each host
+
+        """
+        all_zero = all(data.returncode == 0 for data in self.output)
+        return all_zero and not self.timeout
+
+    @property
+    def timeout(self):
+        """Did the command timeout on any hosts.
+
+        Returns:
+            bool: True if the command timed out on at least one set of hosts; False otherwise
+
+        """
+        return any(data.timeout for data in self.output)
+
+    def _process_task(self, task, command):
+        """Populate the output list and determine the passed result for the specified task.
+
+        Args:
+            task (Task): a ClusterShell.Task.Task object for the executed command
+            command (str): the executed command
+        """
+        # Get a dictionary of host list values for each unique return code key
+        results = dict(task.iter_retcodes())
+
+        # Get a list of any hosts that timed out
+        timed_out = [str(hosts) for hosts in task.iter_keys_timeout()]
+
+        # Populate the a list of unique output for each NodeSet
+        for code in sorted(results):
+            output_data = list(task.iter_buffers(results[code]))
+            if not output_data:
+                output_data = [["<NONE>", results[code]]]
+            for output, output_hosts in output_data:
+                # In run_remote(), task.run() is executed with the stderr=False default.
+                # As a result task.iter_buffers() will return combined stdout and stderr.
+                stdout = []
+                for line in output.splitlines():
+                    if isinstance(line, bytes):
+                        stdout.append(line.decode("utf-8"))
+                    else:
+                        stdout.append(line)
+                self.output.append(
+                    self.ResultData(command, code, NodeSet.fromlist(output_hosts), stdout, False))
+        if timed_out:
+            self.output.append(
+                self.ResultData(command, 124, NodeSet.fromlist(timed_out), None, True))
+
+    def log_output(self):
+        """Log the command result."""
+        log = getLogger()
+        for data in self.output:
+            if data.timeout:
+                log.debug("  %s (rc=%s): timed out", str(data.hosts), data.returncode)
+            elif len(data.stdout) == 1:
+                log.debug("  %s (rc=%s): %s", str(data.hosts), data.returncode, data.stdout[0])
+            else:
+                log.debug("  %s (rc=%s):", str(data.hosts), data.returncode)
+                for line in data.stdout:
+                    log.debug("    %s", line)
+
+
+def run_remote(hosts, command, verbose=True, timeout=120, task_debug=False):
+    """Run the command on the remote hosts.
+
+    Args:
+        hosts (NodeSet): hosts on which to run the command
+        command (str): command from which to obtain the output
+        verbose (bool, optional): log the command output. Defaults to True.
+        timeout (int, optional): number of seconds to wait for the command to complete.
+            Defaults to 120 seconds.
+        task_debug (bool, optional): whether to enable debug for the task object. Defaults to False.
+
+    Returns:
+        RemoteCommandResult: a grouping of the command results from the same hosts with the same
+            return status
+
+    """
+    task = task_self()
+    if task_debug:
+        task.set_info('debug', True)
+    # Enable forwarding of the ssh authentication agent connection
+    task.set_info("ssh_options", "-oForwardAgent=yes")
+    getLogger().debug("Running on %s with a %s second timeout: %s", hosts, timeout, command)
+    task.run(command=command, nodes=hosts, timeout=timeout)
+    results = RemoteCommandResult(command, task)
+    if verbose:
+        results.log_output()
+    return results
+
+
 def human_to_bytes(size):
     """Convert a human readable size value to respective byte value.
 
@@ -1116,7 +1256,7 @@ def get_job_manager_class(name, job=None, subprocess=False, mpi="openmpi"):
     manager_class = get_module_class(name, "job_manager_utils")
     if name in ["Mpirun", "Orterun"]:
         manager = manager_class(job, subprocess=subprocess, mpi_type=mpi)
-    elif name == "Systemctl":
+    elif name in ["Systemctl", "Clush"]:
         manager = manager_class(job)
     else:
         manager = manager_class(job, subprocess=subprocess)

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -16,7 +16,7 @@ from command_utils import ExecutableCommand, SystemctlCommand
 from command_utils_base import FormattedParameter, EnvironmentVariables
 from exception_utils import CommandFailure, MPILoadError
 from env_modules import load_mpi
-from general_utils import pcmd, stop_processes, run_pcmd, get_job_manager_class
+from general_utils import pcmd, stop_processes, run_pcmd, get_job_manager_class, run_remote
 from write_host_file import write_host_file
 
 
@@ -63,7 +63,7 @@ def get_job_manager(test, class_name=None, job=None, subprocess=None, mpi_type=N
         job_manager = get_job_manager_class(class_name, job, subprocess, mpi_type)
         job_manager.get_params(test)
         job_manager.timeout = timeout
-        if mpi_type == "openmpi":
+        if mpi_type == "openmpi" and hasattr(job_manager, "tmpdir_base"):
             job_manager.tmpdir_base.update(test.test_dir, "tmpdir_base")
         if isinstance(test.job_manager, list):
             test.job_manager.append(job_manager)
@@ -1116,3 +1116,98 @@ class Systemctl(JobManager):
             if hosts is None:
                 hosts = self._hosts
             self.display_log_data(self.get_log_data(hosts, timestamp))
+
+
+class Clush(JobManager):
+    # pylint: disable=too-many-public-methods
+    """A class for the clush job manager command."""
+
+    def __init__(self, job):
+        """Create a Clush object.
+
+        Args:
+            job (ExecutableCommand): command object to manage.
+        """
+        super().__init__("/run/clush/*", "clush", job)
+        self.verbose = True
+        self.timeout = 60
+
+    def __str__(self):
+        """Return the command with all of its defined parameters as a string.
+
+        Returns:
+            str: the command with all the defined parameters
+
+        """
+        commands = [super().__str__(), "-w {}".format(self.hosts), str(self.job)]
+        return " ".join(commands)
+
+    def assign_hosts(self, hosts, path=None, slots=None):
+        """Assign the hosts to use with the command (--hostfile).
+
+        Args:
+            hosts (NodeSet): hosts to specify in the hostfile
+            path (str, optional): not used. Defaults to None.
+            slots (int, optional): not used. Defaults to None.
+        """
+        self._hosts = hosts.copy()
+
+    def assign_environment(self, env_vars, append=False):
+        """Assign or add environment variables to the command.
+
+        Args:
+            env_vars (EnvironmentVariables): the environment variables to use
+                assign or add to the command
+            append (bool): whether to assign (False) or append (True) the
+                specified environment variables
+        """
+        if append:
+            self.env.update(env_vars)
+        else:
+            self.set_environment(env_vars)
+
+    def run(self):
+        """Run the command.
+
+        Raises:
+            CommandFailure: if there is an error running the command
+
+        """
+        command = " ".join([self.env.to_export_str(), str(self.job)]).strip()
+        self.result = run_remote(self._hosts, command, self.verbose, self.timeout)
+
+        if self.result.timeout:
+            raise CommandFailure(
+                "Timeout detected running '{}' on {}".format(str(self.job), self.hosts))
+
+        if self.exit_status_exception and not self.check_results():
+            # Command failed if its output contains bad keywords
+            raise CommandFailure(
+                "Bad words detected in '{}' output on {}".format(str(self.job), self.hosts))
+
+        return self.result
+
+    def check_results(self):
+        """Check the command result for any bad keywords.
+
+        Returns:
+            bool: True if either there were no items from self.check_result_list to verify or if
+                none of the items were found in the command output; False if a item was found in
+                the command output.
+
+        """
+        status = True
+        if self.result and self.check_results_list:
+            regex = r"({})".format("|".join(self.check_results_list))
+            self.log.debug("Checking the command output for any bad keywords: %s", regex)
+            for data in self.result.output:
+                match = re.findall(regex, "\n".join(data.stdout))
+                if match:
+                    self.log.info(
+                        "The following error messages have been detected in the '%s' output on %s:",
+                        str(self.job), str(data.hosts))
+                    for item in match:
+                        self.log.info("  %s", item)
+                    status = False
+                    break
+        return status

--- a/src/tests/ftest/util/results_utils.py
+++ b/src/tests/ftest/util/results_utils.py
@@ -1,0 +1,340 @@
+"""
+  (C) Copyright 2022 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+import time
+
+
+class TestName():
+    # pylint: disable=too-few-public-methods
+    """Provides the necessary test name data to generate a xml/html results file."""
+
+    def __init__(self, name, uid, variant):
+        """Initialize a TestName object.
+
+        Args:
+            name (str): the test name
+            uid (str): the test uid
+            variant (str): the test variant
+        """
+        self.name = name
+        self.uid = uid
+        self.variant = variant
+
+    def __str__(self):
+        """Get the test name as a string.
+
+        Returns:
+            str: the test name including the uid, name, and variant
+
+        """
+        return "{}-{}{}".format(self.uid, self.name, self.variant)
+
+
+class TestResult():
+    """Provides the necessary test result data to generate a xml/html results file."""
+
+    PASS = "PASS"
+    WARN = "WARN"
+    SKIP = "SKIP"
+    FAIL = "FAIL"
+    ERROR = "ERROR"
+    CANCEL = "CANCEL"
+    INTERRUPT = "INTERRUPT"
+
+    def __init__(self, class_name, name, log_file, log_dir):
+        """Initialize a TestResult object.
+
+        Args:
+            class_name (str): the test class name, e.g. FTEST_<name>
+            name (TestName): the test uid, name, and variant
+            uid (str): the test uid
+            variant (str): the test variant
+            log_file (str): the log file for a single test
+            log_dir (str): the log file directory for a single test
+        """
+        self.class_name = class_name
+        self.name = name
+        self.logfile = log_file
+        self.logdir = log_dir
+        self._time_split = 0
+        self.time_start = -1
+        self.time_end = -1
+        self.time_elapsed = -1
+        self.status = None
+        self.fail_class = None
+        self.fail_reason = None
+        self.traceback = None
+
+    def __getitem__(self, name, default=None):
+        """Get the value of the attribute name.
+
+        Args:
+            name (str): name of the class attribute to get
+            default (object, optional): value to return if name is not defined. Defaults to None.
+
+        Returns:
+            object: the attribute value or default if not defined
+
+        """
+        return self.get(name, default)
+
+    def __contains__(self, item):
+        """Determine if the attribute exists in this class, e.g. 'item' in self.
+
+        This is used when creating the html test result.
+
+        Args:
+            item (str): attribute name
+
+        Returns:
+            bool: True if the attribute name has a value in this object; False otherwise
+
+        """
+        try:
+            getattr(self, item)
+        except (AttributeError, TypeError):
+            return False
+        return True
+
+    def get(self, name, default=None):
+        """Get the value of the attribute name.
+
+        Args:
+            name (str): name of the class attribute to get
+            default (object, optional): value to return if name is not defined. Defaults to None.
+
+        Returns:
+            object: the attribute value or default if not defined
+
+        """
+        try:
+            return getattr(self, name, default)
+        except TypeError:
+            return default
+
+    def start(self):
+        """Mark the start of the test."""
+        self._time_split = time.time()
+        if self.time_start == -1:
+            # Set the start time and initialize the elapsed time if this is the first start call
+            self.time_start = self._time_split
+            self.time_elapsed = 0
+
+    def end(self):
+        """Mark the end of the test."""
+        self.time_end = time.time()
+        # Increase the elapsed time by the delta between the last start call and this end call
+        self.time_elapsed += self.time_end - self._time_split
+
+
+class Results():
+    # pylint: disable=too-few-public-methods
+    """Provides the necessary result data to generate a xml/html results file."""
+
+    def __init__(self, log_file):
+        """Initialize a Results object.
+
+        Args:
+            log_file (str): the log file location for all of the tests
+        """
+        self.logfile = log_file
+        self.tests = []
+
+    @property
+    def tests_total(self):
+        """Get the total number of tests.
+
+        Returns:
+            int: total number of tests
+        """
+        return len(self.tests)
+
+    @property
+    def tests_total_time(self):
+        """Get the total test time.
+
+        Returns:
+            int: total duration of all the tests
+        """
+        return sum(test.time_elapsed for test in self.tests)
+
+    @property
+    def passed(self):
+        """Get the total number of passed tests.
+
+        Returns:
+            int: total number of passed tests
+        """
+        test_status = [str(test.status) for test in self.tests]
+        return test_status.count(TestResult.PASS)
+
+    @property
+    def warned(self):
+        """Get the total number of warned tests.
+
+        Returns:
+            int: total number of warned tests
+        """
+        test_status = [str(test.status) for test in self.tests]
+        return test_status.count(TestResult.WARN)
+
+    @property
+    def errors(self):
+        """Get the total number of tests with errors.
+
+        Returns:
+            int: total number of tests with errors
+
+        """
+        test_status = [str(test.status) for test in self.tests]
+        return test_status.count(TestResult.ERROR)
+
+    @property
+    def interrupted(self):
+        """Get the total number of interrupted tests.
+
+        Returns:
+            int: total number of interrupted tests
+
+        """
+        test_status = [str(test.status) for test in self.tests]
+        return test_status.count(TestResult.INTERRUPT)
+
+    @property
+    def failed(self):
+        """Get the total number of failed tests.
+
+        Returns:
+            int: total number of failed tests
+
+        """
+        test_status = [str(test.status) for test in self.tests]
+        return test_status.count(TestResult.FAIL)
+
+    @property
+    def skipped(self):
+        """Get the total number of skipped tests.
+
+        Returns:
+            int: total number of skipped tests
+
+        """
+        test_status = [str(test.status) for test in self.tests]
+        return test_status.count(TestResult.SKIP)
+
+    @property
+    def cancelled(self):
+        """Get the total number of cancelled tests.
+
+        Returns:
+            int: total number of cancelled tests
+
+        """
+        test_status = [str(test.status) for test in self.tests]
+        return test_status.count(TestResult.CANCEL)
+
+    @property
+    def completed(self):
+        """Get the total number of completed tests.
+
+        Returns:
+            int: total number of tests that were not skipped or cancelled
+
+        """
+        return self.tests_total - self.skipped - self.cancelled
+
+    @property
+    def succeeded(self):
+        """Get the total number of tests that succeeded.
+
+        Returns:
+            int: total number of tests that passed or warned
+
+        """
+        return self.passed + self.warned
+
+    @property
+    def rate(self):
+        """Get the pass rate for the tests.
+
+        Returns:
+            float: pass rate of all the tests
+
+        """
+        if not self.completed:
+            return 0.0
+        return 100 * (float(self.succeeded) / float(self.completed))
+
+
+class Job():
+    # pylint: disable=too-few-public-methods
+    """Provides the necessary job data to generate a xml/html results file."""
+
+    def __init__(self, name, xml_enabled=None, xml_output=None, html_enabled=None,
+                 html_output=None, log_dir=None, max_chars=100000):
+        """Initialize a DaosTestJob object.
+
+        Args:
+            name (str): name of the daos_test subtest
+            xml_enabled (str, optional): if set to 'on' results will be written to
+                {logdir}/results.xml. Defaults to None.
+            xml_output (str, optional): optional full path of an xml file to generate.  Used for
+                writing xml files with different names and/or file locations. Defaults to None.
+            html_enabled (str, optional): if set to 'on' results will be written to
+                {logdir}/results.html. Defaults to None.
+            html_output (_type_, optional): optional full path of an html file to generate.  Used
+                for writing html files with different names and/or file locations. Defaults to None.
+            log_dir (str, optional): directory in which to write the results.[xml|html] if
+                [xml|html]_enabled is set to 'on'. Defaults to None.
+            max_chars (int, optional): maximum number of characters of each test log to include in
+                with any test errors. Defaults to 100000.
+        """
+        self.config = {
+            "job.run.result.xunit.enabled": xml_enabled,
+            "job.run.result.xunit.output": xml_output,
+            "job.run.result.xunit.max_test_log_chars": max_chars,
+            "job.run.result.xunit.job_name": name,
+            "job.run.result.html.enabled": html_enabled,
+            "job.run.result.html.open_browser": False,
+            "job.run.result.html.output": html_output,
+            "stdout_claimed_by": None,
+        }
+        self.logdir = log_dir
+
+        # If set to either 'RUNNING', 'ERROR', or 'FAIL' an html result will not be generated
+        self.status = "COMPLETE"
+
+
+def create_xml(job, results):
+    """Create a xml file for the specified test results.
+
+    Location and filename of the xml file is controlled by the job argument.
+
+    Args:
+        job (Job): information about the job producing the results
+        results (Results): the test results to include in the xml file
+    """
+    # When SRE-439 is fixed we should be able to move these imports to the top of the file
+    # pylint: disable=import-outside-toplevel
+    from avocado.plugins.xunit import XUnitResult
+    result_xml = XUnitResult()
+    result_xml.render(results, job)
+
+
+def create_html(job, results):
+    """Create a html file for the specified test results.
+
+    Location and filename of the html file is controlled by the job argument.
+
+    Args:
+        job (Job): information about the job producing the results
+        results (Results): the test results to include in the html file
+    """
+    # When SRE-439 is fixed we should be able to move these imports to the top of the file
+    # pylint: disable=import-outside-toplevel
+    from avocado_result_html import HTMLResult
+    result_html = HTMLResult()
+    result_html.render(results, job)


### PR DESCRIPTION
Adding detecting 'Process received signal' error message in daos_test command output to avoid missing the detection of these errors.

Quick-Functional: true
Test-tag: daos_test dfs_test dfuse_test test_always_passes Allow-unstable-test: true
Skip-func-test-leap15: false

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>