### PR TITLE
utils: add missing packages for CentOS 7

### DIFF
--- a/utils/scripts/install-centos7.sh
+++ b/utils/scripts/install-centos7.sh
@@ -43,6 +43,7 @@ dnf --nodocs install \
     lz4-devel \
     make \
     maven \
+    meson \
     ndctl \
     numactl \
     numactl-devel \
@@ -51,6 +52,7 @@ dnf --nodocs install \
     patch \
     patchelf \
     pciutils \
+    python-pyelftools \
     python3-devel \
     python3-pip \
     sg3_utils \


### PR DESCRIPTION
Add missing packages for CentOS 7: meson and python-pyelftools.

Signed-off-by: Lukasz Dorau <lukasz.dorau@intel.com>