### PR TITLE
DAOS-11613 cart: Fix a race condition in context creation

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -188,14 +188,16 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
+	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
 	sep_mode = crt_provider_is_sep(provider);
 	cur_ctx_num = crt_provider_get_cur_ctx_num(provider);
 	max_ctx_num = crt_provider_get_max_ctx_num(provider);
 
 	if (sep_mode &&
 	    cur_ctx_num >= max_ctx_num) {
-		D_ERROR("Number of active contexts (%d) reached limit (%d).\n",
+		D_WARN("Number of active contexts (%d) reached limit (%d).\n",
 			cur_ctx_num, max_ctx_num);
+		D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 		D_GOTO(out, rc = -DER_AGAIN);
 	}
 
@@ -210,7 +212,6 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 		D_GOTO(out, rc);
 	}
 
-	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
 
 	rc = crt_hg_ctx_init(&ctx->cc_hg_ctx, provider, cur_ctx_num);
 

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -876,7 +876,7 @@ crt_grp_lc_addr_insert(struct crt_grp_priv *passed_grp_priv,
 	}
 
 	ctx_idx = crt_ctx->cc_idx;
-	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
+	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
 
 	rlink = d_hash_rec_find(&grp_priv->gp_lookup_cache[ctx_idx],
 				(void *)&rank, sizeof(rank));
@@ -2519,7 +2519,7 @@ crt_rank_self_set(d_rank_t rank)
 		D_GOTO(out, rc);
 	}
 
-	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
+	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
 
 	ctx_list = crt_provider_get_ctx_list(crt_gdata.cg_init_prov);
 


### PR DESCRIPTION
- Context creation could race with itself causing two different contexts to be created with the same internal id. This then leads to a cascade of problems as wrong handles are then being used.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>