### PR TITLE
DAOS-11642 container: 2.2 client -> 2.0 engine: use pool RF 0

### DIFF
--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -105,7 +105,7 @@ enum daos_pool_props {
 #define DAOS_PROP_PO_EC_CELL_SZ_MAX	(1UL << 30)
 
 #define DAOS_PROP_PO_REDUN_FAC_MAX	4
-#define DAOS_RPOP_PO_REDUN_FAC_DEFAULT	0
+#define DAOS_PROP_PO_REDUN_FAC_DEFAULT	0
 
 static inline bool
 daos_rf_is_valid(unsigned long long rf)

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -3095,6 +3095,10 @@ int dc_pool_get_redunc(daos_handle_t poh)
 	if (pool == NULL)
 		return -DER_NO_HDL;
 
+	/* RF property supported by engines with protocol >= 5 ; default for older versions. */
+	if (dc_pool_proto_version <= 4)
+		return DAOS_PROP_PO_REDUN_FAC_DEFAULT;
+
 	D_RWLOCK_RDLOCK(&pool->dp_map_lock);
 	if (pool->dp_rf_valid) {
 		rf = pool->dp_rf;

--- a/src/pool/srv_layout.c
+++ b/src/pool/srv_layout.c
@@ -72,7 +72,7 @@ struct daos_prop_entry pool_prop_entries_default[DAOS_PROP_PO_NUM] = {
 		.dpe_val	= DAOS_EC_CELL_DEF,
 	}, {
 		.dpe_type	= DAOS_PROP_PO_REDUN_FAC,
-		.dpe_val	= DAOS_RPOP_PO_REDUN_FAC_DEFAULT,
+		.dpe_val	= DAOS_PROP_PO_REDUN_FAC_DEFAULT,
 	}, {
 		.dpe_type	= DAOS_PROP_PO_EC_PDA,
 		.dpe_val	= DAOS_PROP_PO_EC_PDA_DEFAULT,

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1905,7 +1905,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 		 */
 		if (rc == -DER_NONEXIST && global_ver < 1) {
 			rc = 0;
-			val = DAOS_RPOP_PO_REDUN_FAC_DEFAULT;
+			val = DAOS_PROP_PO_REDUN_FAC_DEFAULT;
 		} else if (rc != 0) {
 			return rc;
 		}
@@ -4012,7 +4012,7 @@ static int pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
 	if (rc && rc != -DER_NONEXIST) {
 		D_GOTO(out_free, rc);
 	} else if (rc == -DER_NONEXIST) {
-		val = DAOS_RPOP_PO_REDUN_FAC_DEFAULT;
+		val = DAOS_PROP_PO_REDUN_FAC_DEFAULT;
 		rc = rdb_tx_update(tx, &svc->ps_root, &ds_pool_prop_redun_fac, &value);
 		if (rc) {
 			D_ERROR(DF_UUID": failed to upgrade redundancy factor of pool, "


### PR DESCRIPTION
Without this change, libdaos2.2, "daos cont create" (type POSIX) interacting with a 2.0 engine results in an underlying pool query (property DAOS_PROP_PO_REDUN_FAC). The 2.0 engine is unaware of this property and does not return it. The libdaos client code when copying RPC reply properties fails with -DER_PROTO due to the missing entry.

With this change, the libdaos 2.2 client code inspects the dc_pool_proto_version gotten from an earlier cart protocol query, and in this interop scenario uses a default RF value (0) rather than query the 2.0 engine/pool.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>