### PR TITLE
DAOS-9040 iv:  create separate ULT for async IV sync (#7463)

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2193,11 +2193,6 @@ handle_ivsync_response(const struct crt_cb_info *cb_info)
 		D_ASSERT(iv_sync->isc_ivns_internal == NULL);
 	}
 
-	if (iv_sync->isc_sync_type.ivs_comp_cb)
-		iv_sync->isc_sync_type.ivs_comp_cb(
-			iv_sync->isc_sync_type.ivs_comp_cb_arg,
-			cb_info->cci_rc);
-
 	if (iv_sync->isc_ivns_internal) {
 		iv_ops = crt_iv_ops_get(iv_sync->isc_ivns_internal,
 					iv_sync->isc_class_id);
@@ -2593,11 +2588,6 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 			rc = iv_ops->ivo_on_put(iv_info->uci_ivns_internal,
 						tmp_iv_value,
 						iv_info->uci_user_priv);
-			if (iv_info->uci_sync_type.ivs_comp_cb)
-				iv_info->uci_sync_type.ivs_comp_cb(iv_info->
-								   uci_sync_type.
-								   ivs_comp_cb_arg,
-								   rc);
 		}
 	}
 
@@ -3322,7 +3312,6 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 		if (sync_type.ivs_flags & CRT_IV_SYNC_BIDIRECTIONAL) {
 			rc = update_comp_cb(ivns_internal, class_id, iv_key,
 					    NULL, iv_value, rc, cb_arg);
-			D_ASSERT(sync_type.ivs_comp_cb == NULL);
 		} else {
 			/* issue sync. will call completion callback */
 			rc = crt_ivsync_rpc_issue(ivns_internal, class_id,
@@ -3364,7 +3353,6 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 		}
 
 		/* comp_cb is only for sync update for now */
-		D_ASSERT(sync_type.ivs_comp_cb == NULL);
 		D_ALLOC_PTR(cb_info);
 		if (cb_info == NULL)
 			D_GOTO(put, rc = -DER_NOMEM);
@@ -3406,9 +3394,6 @@ crt_iv_update_internal(crt_iv_namespace_t ivns, uint32_t class_id,
 put:
 	iv_ops->ivo_on_put(ivns, NULL, priv);
 exit:
-	if (rc != 0 && sync_type.ivs_comp_cb)
-		sync_type.ivs_comp_cb(sync_type.ivs_comp_cb_arg, rc);
-
 	if (ivns_internal)
 		IVNS_DECREF(ivns_internal);
 	return rc;
@@ -3436,8 +3421,6 @@ crt_iv_update(crt_iv_namespace_t ivns, uint32_t class_id,
 		update_comp_cb(ivns, class_id, iv_key, NULL, iv_value,
 			       rc, cb_arg);
 
-		if (sync_type.ivs_comp_cb)
-			sync_type.ivs_comp_cb(sync_type.ivs_comp_cb_arg, rc);
 		D_GOTO(exit, rc);
 	}
 

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -960,11 +960,8 @@ iv_op_internal(struct ds_iv_ns *ns, struct ds_iv_key *key_iv,
 	int			rc;
 
 	rc = ABT_future_create(1, NULL, &future);
-	if (rc) {
-		if (sync != NULL && sync->ivs_comp_cb)
-			sync->ivs_comp_cb(sync->ivs_comp_cb_arg, rc);
+	if (rc)
 		return rc;
-	}
 
 	key_iv->rank = ns->iv_master_rank;
 	class = iv_class_lookup(key_iv->class_id);
@@ -1015,7 +1012,7 @@ out:
 	return rc;
 }
 
-struct sync_comp_cb_arg {
+struct iv_op_ult_arg {
 	d_sg_list_t	iv_value;
 	struct ds_iv_key iv_key;
 	struct ds_iv_ns	*ns;
@@ -1026,88 +1023,15 @@ struct sync_comp_cb_arg {
 };
 
 static int
-iv_op(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
-      crt_iv_sync_t *sync, unsigned int shortcut, bool retry, int opc);
-
-static int
-sync_comp_cb(void *arg, int rc)
+_iv_op(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
+       crt_iv_sync_t *sync, unsigned int shortcut, bool retry, int opc)
 {
-	struct sync_comp_cb_arg *cb_arg = arg;
-
-	if (cb_arg == NULL)
-		return rc;
-
-	/* Let's retry asynchronous IV only for GRPVER for the moment */
-	if (cb_arg->retry && rc == -DER_GRPVER && !cb_arg->ns->iv_stop) {
-		int rc1;
-
-		/* If the IV ns leader has been changed, then it will retry
-		 * in the mean time, it will rely on others to update the
-		 * ns for it.
-		 */
-		D_WARN("retry for class %d opc %d rc "DF_RC"\n",
-			cb_arg->iv_key.class_id, IV_UPDATE, DP_RC(rc));
-		rc1 = iv_op(cb_arg->ns, &cb_arg->iv_key, &cb_arg->iv_value,
-			    &cb_arg->iv_sync, cb_arg->shortcut, cb_arg->retry,
-			    cb_arg->opc);
-		if (rc1) {
-			D_ERROR("ds iv update retry failed: %d\n", rc1);
-			rc = rc1;
-		}
-	}
-
-	ds_iv_ns_put(cb_arg->ns);
-	d_sgl_fini(&cb_arg->iv_value, true);
-	D_FREE(cb_arg);
-	return rc;
-}
-
-static int
-iv_op(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
-      crt_iv_sync_t *sync, unsigned int shortcut, bool retry, int opc)
-{
-	struct ds_iv_key *_key = key;
-	d_sg_list_t	 *_value = value;
 	int rc;
 
 	if (ns->iv_stop)
 		return -DER_SHUTDOWN;
 retry:
-	if (sync && sync->ivs_mode == CRT_IV_SYNC_LAZY) {
-		struct sync_comp_cb_arg *arg = NULL;
-
-		/* Register asynchronous sync(lazy mode) callback */
-		D_ALLOC_PTR(arg);
-		if (arg == NULL)
-			return -DER_NOMEM;
-
-		/* Asynchronous mode, let's realloc the value and key, since
-		 * the input parameters will be invalid after the call.
-		 */
-		if (value) {
-			rc = daos_sgl_alloc_copy_data(&arg->iv_value, value);
-			if (rc) {
-				D_FREE(arg);
-				return -DER_NOMEM;
-			}
-		}
-
-		memcpy(&arg->iv_key, key, sizeof(*key));
-		arg->shortcut = shortcut;
-		arg->iv_sync = *sync;
-		arg->retry = retry;
-		ds_iv_ns_get(ns);
-		arg->ns = ns;
-		arg->opc = opc;
-
-		sync->ivs_comp_cb = sync_comp_cb;
-		sync->ivs_comp_cb_arg = arg;
-		if (value)
-			_value = &arg->iv_value;
-		_key = &arg->iv_key;
-	}
-
-	rc = iv_op_internal(ns, _key, _value, sync, shortcut, opc);
+	rc = iv_op_internal(ns, key, value, sync, shortcut, opc);
 	if (retry && !ns->iv_stop &&
 	    (daos_rpc_retryable_rc(rc) || rc == -DER_NOTLEADER)) {
 		if (rc == -DER_NOTLEADER && key->rank != (d_rank_t)(-1) &&
@@ -1128,12 +1052,82 @@ retry:
 		 */
 		D_WARN("retry upon %d for class %d opc %d\n", rc,
 		       key->class_id, opc);
-		/* Yield to avoid hijack the cycle if IV RPC is not sent */
-		ABT_thread_yield();
+		/* sleep 1sec and retry */
+		dss_sleep(1000);
 		goto retry;
 	}
 
 	return rc;
+}
+
+static void
+iv_op_ult(void *arg)
+{
+	struct iv_op_ult_arg *ult_arg = arg;
+
+	D_ASSERT(ult_arg->iv_sync.ivs_mode == CRT_IV_SYNC_LAZY);
+	/* Since it will put LAZY sync in a separate and asynchronous ULT, so
+	 * let's use EAGER mode in CRT to make it simipler.
+	 */
+	ult_arg->iv_sync.ivs_mode = CRT_IV_SYNC_EAGER;
+	_iv_op(ult_arg->ns, &ult_arg->iv_key,
+	       ult_arg->iv_value.sg_nr == 0 ? NULL : &ult_arg->iv_value,
+	       &ult_arg->iv_sync, ult_arg->shortcut, ult_arg->retry, ult_arg->opc);
+	ds_iv_ns_put(ult_arg->ns);
+	d_sgl_fini(&ult_arg->iv_value, true);
+	D_FREE(ult_arg);
+}
+
+static int
+iv_op_async(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
+	    crt_iv_sync_t *sync, unsigned int shortcut, bool retry, int opc)
+{
+	struct iv_op_ult_arg	*ult_arg;
+	int			rc;
+
+	D_ALLOC_PTR(ult_arg);
+	if (ult_arg == NULL)
+		return -DER_NOMEM;
+
+	/* Asynchronous mode, let's realloc the value and key, since
+	 * the input parameters will be invalid after the call.
+	 */
+	if (value) {
+		rc = daos_sgl_alloc_copy_data(&ult_arg->iv_value, value);
+		if (rc) {
+			D_FREE(ult_arg);
+			return -DER_NOMEM;
+		}
+	}
+
+	memcpy(&ult_arg->iv_key, key, sizeof(*key));
+	ult_arg->shortcut = shortcut;
+	ult_arg->iv_sync = *sync;
+	ult_arg->retry = retry;
+	ds_iv_ns_get(ns);
+	ult_arg->ns = ns;
+	ult_arg->opc = opc;
+	rc = dss_ult_create(iv_op_ult, ult_arg, DSS_XS_SYS, 0, 0, NULL);
+	if (rc != 0) {
+		ds_iv_ns_put(ult_arg->ns);
+		d_sgl_fini(&ult_arg->iv_value, true);
+		D_FREE(ult_arg);
+	}
+
+	return rc;
+}
+
+static int
+iv_op(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
+      crt_iv_sync_t *sync, unsigned int shortcut, bool retry, int opc)
+{
+	if (ns->iv_stop)
+		return -DER_SHUTDOWN;
+
+	if (sync && sync->ivs_mode == CRT_IV_SYNC_LAZY)
+		return iv_op_async(ns, key, value, sync, shortcut, retry, opc);
+
+	return _iv_op(ns, key, value, sync, shortcut, retry, opc);
 }
 
 /**

--- a/src/include/cart/iv.h
+++ b/src/include/cart/iv.h
@@ -601,12 +601,6 @@ typedef int (*crt_iv_sync_done_cb_t)(void *cb_arg, int rc);
 typedef struct {
 	crt_iv_sync_mode_t	ivs_mode;
 	crt_iv_sync_event_t	ivs_event;
-	/** This callback will be called once the current IV sync is done
-	 * for the local node.
-	 **/
-	crt_iv_sync_done_cb_t	ivs_comp_cb;
-	/* argument for ivs_comp_cb */
-	void			*ivs_comp_cb_arg;
 	/* OR-ed combination of 0 or more crt_iv_sync_flag_t flags */
 	uint32_t		ivs_flags;
 } crt_iv_sync_t;

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1250,14 +1250,14 @@ done:
 		    || task->dst_rebuild_op == RB_OP_DRAIN) {
 			rc = ds_pool_tgt_exclude_out(pool->sp_uuid,
 						     &task->dst_tgts);
-			D_DEBUG(DB_REBUILD, "mark failed target %d of "DF_UUID
+			D_INFO("mark failed target %d of "DF_UUID
 				" as DOWNOUT: "DF_RC"\n",
 				task->dst_tgts.pti_ids[0].pti_id,
 				DP_UUID(task->dst_pool_uuid), DP_RC(rc));
 		} else if (task->dst_rebuild_op == RB_OP_REINT ||
 			   task->dst_rebuild_op == RB_OP_EXTEND) {
 			rc = ds_pool_tgt_add_in(pool->sp_uuid, &task->dst_tgts);
-			D_DEBUG(DB_REBUILD, "mark added target %d of "DF_UUID
+			D_INFO("mark added target %d of "DF_UUID
 				" UPIN: "DF_RC"\n",
 				task->dst_tgts.pti_ids[0].pti_id,
 				DP_UUID(task->dst_pool_uuid), DP_RC(rc));


### PR DESCRIPTION
Create separate ULT for async IV sync to avoid
complicate IV complete callback.

Throttle IV retry in iv_op().
Change a few REBUILD log to INFO.

Signed-off-by: Di Wang <di.wang@intel.com>