### PR TITLE
DAOS-10524 pool: add rebuild version to pool query

### DIFF
--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -128,7 +128,8 @@ bool pl_obj_layout_contains(struct pool_map *map, struct pl_obj_layout *layout,
 			    uint32_t shard);
 
 int pl_obj_place(struct pl_map *map, struct daos_obj_md *md, unsigned int mode,
-		 struct daos_obj_shard_md *shard_md, struct pl_obj_layout **layout_pp);
+		 uint32_t rebuild_ver, struct daos_obj_shard_md *shard_md,
+		 struct pl_obj_layout **layout_pp);
 
 int pl_obj_find_rebuild(struct pl_map *map,
 			struct daos_obj_md *md,

--- a/src/include/daos/pool.h
+++ b/src/include/daos/pool.h
@@ -83,6 +83,7 @@ struct dc_pool {
 	pthread_rwlock_t	dp_map_lock;
 	struct pool_map	       *dp_map;
 	tse_task_t	       *dp_map_task;
+	uint32_t		dp_rebuild_version;
 	/* highest known pool map version */
 	uint32_t		dp_map_version_known;
 	uint32_t		dp_disconnecting:1,

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -64,6 +64,7 @@ struct ds_pool {
 	uuid_t			sp_srv_pool_hdl;
 	uint32_t		sp_stopping:1,
 				sp_fetch_hdls:1,
+				sp_disable_rebuild:1,
 				sp_need_discard:1;
 	int			sp_reintegrating;
 	/** path to ephemeral metrics */

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -41,6 +41,7 @@ int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 			daos_rebuild_opc_t rebuild_op, uint64_t delay_sec);
 int ds_rebuild_query(uuid_t pool_uuid,
 		     struct daos_rebuild_status *status);
+void ds_rebuild_running_query(uuid_t pool_uuid, uint32_t *rebuild_ver);
 int ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop);
 void ds_rebuild_leader_stop_all(void);
 void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -213,6 +213,7 @@ obj_layout_create(struct dc_object *obj, unsigned int mode, bool refresh)
 	struct dc_pool		*pool;
 	struct pl_map		*map;
 	uint32_t		old;
+	uint32_t		rebuild_ver;
 	int			i;
 	int			rc;
 
@@ -229,10 +230,11 @@ obj_layout_create(struct dc_object *obj, unsigned int mode, bool refresh)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
+	rebuild_ver = pool->dp_rebuild_version;
 	obj->cob_md.omd_ver = dc_pool_get_version(pool);
 	obj->cob_md.omd_fdom_lvl = dc_obj_get_redun_lvl(obj);
 	dc_pool_put(pool);
-	rc = pl_obj_place(map, &obj->cob_md, mode, NULL, &layout);
+	rc = pl_obj_place(map, &obj->cob_md, mode, rebuild_ver, NULL, &layout);
 	pl_map_decref(map);
 	if (rc != 0) {
 		D_DEBUG(DB_PL, DF_OID" Failed to generate object layout fdom_lvl %d\n",
@@ -1014,6 +1016,9 @@ obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
 		shard_tgt->st_flags |= DTF_DELAY_FORWARD;
 	if (obj_shard->do_reintegrating)
 		obj_auxi->reintegrating = 1;
+	if (obj_shard->do_rebuilding)
+		obj_auxi->rebuilding = 1;
+
 	rc = obj_shard2tgtid(obj, shard, map_ver, &shard_tgt->st_tgt_id);
 close:
 	obj_shard_close(obj_shard);
@@ -4559,6 +4564,7 @@ obj_task_init_common(tse_task_t *task, int opc, uint32_t map_ver,
 	obj_auxi->obj = obj;
 	obj_auxi->dkey_hash = 0;
 	obj_auxi->reintegrating = 0;
+	obj_auxi->rebuilding = 0;
 	shard_task_list_init(obj_auxi);
 	obj_auxi->is_ec_obj = obj_is_ec(obj);
 	*auxi = obj_auxi;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1273,6 +1273,8 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_flags = auxi->flags | flags;
 	if (auxi->obj_auxi->reintegrating)
 		orw->orw_flags |= ORF_REINTEGRATING_IO;
+	if (auxi->obj_auxi->rebuilding)
+		orw->orw_flags |= ORF_REBUILDING_IO;
 	orw->orw_tgt_idx = auxi->ec_tgt_idx;
 	if (args->reasb_req && args->reasb_req->orr_oca)
 		orw->orw_tgt_max = obj_ec_tgt_nr(args->reasb_req->orr_oca) - 1;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -375,7 +375,8 @@ struct obj_auxi_args {
 					 cond_modify:1,
 					 /* conf_fetch split to multiple sub-tasks */
 					 cond_fetch_split:1,
-					 reintegrating:1;
+					 reintegrating:1,
+					 rebuilding:1;
 	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 flags;
 	uint32_t			 specified_shard;

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -180,8 +180,10 @@ enum obj_rpc_flags {
 	ORF_CONTAIN_LEADER	= (1 << 20),
 	/*Ascending Order - 0, descending order - 1*/
 	ORF_DESCENDING_ORDER	= (1 << 21),
-	/* send to reintegrating target */
+	/* The IO include reintegrating target */
 	ORF_REINTEGRATING_IO	= (1 << 22),
+	/* The IO include rebuilding target */
+	ORF_REBUILDING_IO	= (1 << 23),
 };
 
 /* common for update/fetch */

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2306,7 +2306,7 @@ ec_agg_object(daos_handle_t ih, vos_iter_entry_t *entry, struct ec_agg_param *ag
 	md.omd_id = entry->ie_oid.id_pub;
 	md.omd_ver = agg_param->ap_pool_info.api_pool->sp_map_version;
 	md.omd_fdom_lvl = props.dcp_redun_lvl;
-	rc = pl_obj_place(map, &md, DAOS_OO_RO, NULL, &agg_entry->ae_obj_layout);
+	rc = pl_obj_place(map, &md, DAOS_OO_RO, -1, NULL, &agg_entry->ae_obj_layout);
 
 out:
 	return rc;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2022,6 +2022,39 @@ obj_ioc_init_oca(struct obj_io_context *ioc, daos_obj_id_t oid)
 	return 0;
 }
 
+static int
+obj_inflight_io_check(struct ds_cont_child *child, uint32_t opc, uint32_t flags)
+{
+	if (!obj_is_modification_opc(opc))
+		return 0;
+
+	/* If the incoming I/O is during integration, then it needs to wait the
+	 * vos discard to finish, which otherwise might discard these new inflight
+	 * I/O update.
+	 */
+	if ((flags & ORF_REINTEGRATING_IO) &&
+	    (child->sc_pool->spc_pool->sp_need_discard &&
+	     child->sc_pool->spc_discard_done == 0)) {
+		D_ERROR("reintegrating "DF_UUID" retry.\n", DP_UUID(child->sc_pool->spc_uuid));
+		return -DER_UPDATE_AGAIN;
+	}
+
+	/* All I/O during rebuilding, needs to wait for the rebuild fence to
+	 * be generated (see rebuild_prepare_one()), which will create a boundary
+	 * for rebuild, so the data after boundary(epoch) should not be rebuilt,
+	 * which otherwise might be written duplicately, which might cause
+	 * the failure in VOS.
+	 */
+	if ((flags & ORF_REBUILDING_IO) &&
+	    (!child->sc_pool->spc_pool->sp_disable_rebuild &&
+	      child->sc_pool->spc_rebuild_fence == 0)) {
+		D_ERROR("rebuilding "DF_UUID" retry.\n", DP_UUID(child->sc_pool->spc_uuid));
+		return -DER_UPDATE_AGAIN;
+	}
+
+	return 0;
+}
+
 /* Various check before access VOS */
 static int
 obj_ioc_begin(daos_obj_id_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
@@ -2035,12 +2068,9 @@ obj_ioc_begin(daos_obj_id_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 	if (rc != 0)
 		return rc;
 
-	if (obj_is_modification_opc(opc) && (flags & ORF_REINTEGRATING_IO) &&
-	    ioc->ioc_coc->sc_pool->spc_pool->sp_need_discard &&
-	    ioc->ioc_coc->sc_pool->spc_discard_done == 0) {
-		D_ERROR("reintegrating "DF_UUID" retry.\n", DP_UUID(pool_uuid));
-		D_GOTO(failed, rc = -DER_UPDATE_AGAIN);
-	}
+	rc = obj_inflight_io_check(ioc->ioc_coc, opc, flags);
+	if (rc != 0)
+		goto failed;
 
 	rc = obj_capa_check(ioc->ioc_coh, obj_is_modification_opc(opc),
 			    obj_is_ec_agg_opc(opc) ||
@@ -4627,12 +4657,9 @@ ds_obj_cpd_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		goto reply;
 
-	if ((oci->oci_flags & ORF_REINTEGRATING_IO) &&
-	    ioc.ioc_coc->sc_pool->spc_pool->sp_need_discard &&
-	    ioc.ioc_coc->sc_pool->spc_rebuild_fence == 0) {
-		D_ERROR("reintegrating "DF_UUID" retry.\n", DP_UUID(oci->oci_pool_uuid));
-		D_GOTO(reply, rc = -DER_UPDATE_AGAIN);
-	}
+	rc = obj_inflight_io_check(ioc.ioc_coc, opc_get(rpc->cr_opc), oci->oci_flags);
+	if (rc != 0)
+		goto reply;
 
 	if (!leader) {
 		if (tx_count != 1 || oci->oci_sub_reqs.ca_count != 1 ||

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2070,8 +2070,7 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 		       DP_UUID(iter_arg->pool_uuid));
 		D_GOTO(put, rc = 0);
 	}
-	if (iod_eph_total == 0 || tls->mpt_version <= version ||
-	    tls->mpt_fini) {
+	if (iod_eph_total == 0 || tls->mpt_fini) {
 		D_DEBUG(DB_REBUILD, "No need eph_total %d version %u"
 			" migrate ver %u fini %d\n", iod_eph_total, version,
 			tls->mpt_version, tls->mpt_fini);

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -1060,6 +1060,7 @@ jump_map_query(struct pl_map *map, struct pl_map_attr *attr)
  * \param[in]   md              The object metadata which contains data about
  *                              the object being placed such as the object ID.
  * \param[in]   mode		mode of daos_obj_open(DAOS_OO_RO, DAOS_OO_RW etc).
+ * \param[in]	rebuild_ver	rebuild version of the current pool.
  * \param[in]   shard_md        Shard metadata.
  * \param[out]  layout_pp       The layout generated for the object. Contains
  *                              references to the targets in the pool map where
@@ -1071,7 +1072,8 @@ jump_map_query(struct pl_map *map, struct pl_map_attr *attr)
  */
 static int
 jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
-		   unsigned int mode, struct daos_obj_shard_md *shard_md,
+		   unsigned int mode, uint32_t rebuild_version,
+		   struct daos_obj_shard_md *shard_md,
 		   struct pl_obj_layout **layout_pp)
 {
 	struct pl_jump_map	*jmap;
@@ -1133,7 +1135,7 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
 		if (is_extending)
 			allow_status |= PO_COMP_ST_UP;
 
-		rc = obj_layout_alloc_and_get(jmap, &jmop, md, allow_status, -1,
+		rc = obj_layout_alloc_and_get(jmap, &jmop, md, allow_status, rebuild_version,
 					      &extend_layout, NULL, NULL);
 		if (rc)
 			D_GOTO(out, rc);

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -116,14 +116,14 @@ void pl_map_print(struct pl_map *map)
  * is not NULL.
  */
 int
-pl_obj_place(struct pl_map *map, struct daos_obj_md *md,
-	     unsigned int mode, struct daos_obj_shard_md *shard_md,
+pl_obj_place(struct pl_map *map, struct daos_obj_md *md, unsigned int mode,
+	     uint32_t rebuild_ver, struct daos_obj_shard_md *shard_md,
 	     struct pl_obj_layout **layout_pp)
 {
 	D_ASSERT(map->pl_ops != NULL);
 	D_ASSERT(map->pl_ops->o_obj_place != NULL);
 
-	return map->pl_ops->o_obj_place(map, md, mode, shard_md, layout_pp);
+	return map->pl_ops->o_obj_place(map, md, mode, rebuild_ver, shard_md, layout_pp);
 }
 
 /**

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -35,7 +35,7 @@ struct pl_map_ops {
 	/** see \a pl_map_obj_select and \a pl_map_obj_rebalance */
 	int (*o_obj_place)(struct pl_map *map,
 			   struct daos_obj_md *md,
-			   unsigned int	mode,
+			   unsigned int	mode, uint32_t rebuild_ver,
 			   struct daos_obj_shard_md *shard_md,
 			   struct pl_obj_layout **layout_pp);
 	/** see \a pl_map_obj_rebuild */

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1103,7 +1103,8 @@ out:
 
 static int
 ring_obj_place(struct pl_map *map, struct daos_obj_md *md,
-	       unsigned int mode, struct daos_obj_shard_md *shard_md,
+	       unsigned int mode, uint32_t rebuild_ver,
+	       struct daos_obj_shard_md *shard_md,
 	       struct pl_obj_layout **layout_pp)
 {
 	struct ring_obj_placement  rop;

--- a/src/placement/tests/pl_bench.c
+++ b/src/placement/tests/pl_bench.c
@@ -222,7 +222,7 @@ benchmark_placement(int argc, char **argv, uint32_t num_domains,
 
 	/* Warm up the cache and check that it works correctly */
 	for (i = 0; i < BENCHMARK_COUNT; i++)
-		pl_obj_place(pl_map, &obj_table[i], 0, NULL, &layout_table[i]);
+		pl_obj_place(pl_map, &obj_table[i], 0, -1, NULL, &layout_table[i]);
 	check_unique_layout(num_domains, nodes_per_domain, vos_per_target,
 			    layout_table, BENCHMARK_COUNT, 0);
 
@@ -230,7 +230,7 @@ benchmark_placement(int argc, char **argv, uint32_t num_domains,
 		D_PRINT("Starting vtune loop!\n");
 		while (1)
 			for (i = 0; i < BENCHMARK_COUNT; i++)
-				pl_obj_place(pl_map, &obj_table[i], 0, NULL,
+				pl_obj_place(pl_map, &obj_table[i], 0, -1, NULL,
 					     &layout_table[i]);
 	}
 
@@ -243,7 +243,7 @@ benchmark_placement(int argc, char **argv, uint32_t num_domains,
 
 		benchmark_start(bench_hdl);
 		for (i = 0; i < BENCHMARK_COUNT; i++)
-			pl_obj_place(pl_map, &obj_table[i], 0, NULL,
+			pl_obj_place(pl_map, &obj_table[i], 0, -1, NULL,
 				     &layout_table[i]);
 		benchmark_stop(bench_hdl);
 
@@ -322,7 +322,7 @@ compute_data_movement(uint32_t domains, uint32_t nodes_per_domain,
 
 	/* Calculate new placement using this configuration */
 	for (obj_idx = 0; obj_idx < test_entries; obj_idx++)
-		pl_obj_place(iter_pl_map, &obj_table[obj_idx], 0,
+		pl_obj_place(iter_pl_map, &obj_table[obj_idx], 0, -1,
 			     NULL, &iter_layout[obj_idx]);
 
 	/* Compute the number of objects that moved */
@@ -514,7 +514,7 @@ benchmark_add_data_movement(int argc, char **argv, uint32_t num_domains,
 
 		/* Initial placement */
 		for (obj_idx = 0; obj_idx < test_entries; obj_idx++)
-			pl_obj_place(initial_pl_map, &obj_table[obj_idx], 0, NULL,
+			pl_obj_place(initial_pl_map, &obj_table[obj_idx], 0, -1, NULL,
 				     &initial_layout[obj_idx]);
 
 		for (added = 0; added <= domains_to_add; added++) {

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -51,7 +51,7 @@ plt_obj_place(daos_obj_id_t oid, struct pl_obj_layout **layout,
 	D_ASSERT(pl_map != NULL);
 	md.omd_ver = pool_map_get_version(pl_map->pl_poolmap);
 
-	rc = pl_obj_place(pl_map, &md, 0, NULL, layout);
+	rc = pl_obj_place(pl_map, &md, 0, -1, NULL, layout);
 
 	if (print_layout_flag) {
 		if (*layout != NULL)

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -439,13 +439,14 @@ err:
  */
 static int
 process_query_reply(struct dc_pool *pool, struct pool_buf *map_buf,
-		    uint32_t map_version, uint32_t leader_rank,
+		    uint32_t map_version, uint32_t rebuild_ver, uint32_t leader_rank,
 		    struct daos_pool_space *ps, struct daos_rebuild_status *rs,
 		    d_rank_list_t **ranks, daos_pool_info_t *info,
 		    daos_prop_t *prop_req, daos_prop_t *prop_reply,
 		    bool connect)
 {
 	struct pool_map	       *map;
+	unsigned int		up_tgt_cnt = 0;
 	int			rc;
 
 	D_DEBUG(DB_MD, DF_UUID": info=%p (pi_bits="DF_X64"), ranks=%p\n",
@@ -458,7 +459,18 @@ process_query_reply(struct dc_pool *pool, struct pool_buf *map_buf,
 	}
 
 	D_RWLOCK_WRLOCK(&pool->dp_map_lock);
+	pool_map_find_up_tgts(map, NULL, &up_tgt_cnt);
+	if (up_tgt_cnt > 0 && rebuild_ver == 0) {
+		/* There are UP targets, but no rebuild/reintegration now, let's retry
+		 * until rebuild or reintegration start, so we know the upper version
+		 * to create the object layout.
+		 */
+		D_DEBUG(DB_MD, DF_UUID": UP targets %u, but no rebuild job yet.\n",
+			DP_UUID(pool->dp_pool), up_tgt_cnt);
+		D_GOTO(out_unlock, rc = -DER_AGAIN);
+	}
 
+	pool->dp_rebuild_version = rebuild_ver;
 	rc = dc_pool_map_update(pool, map, connect);
 	if (rc)
 		goto out_unlock;
@@ -592,10 +604,17 @@ pool_connect_cp(tse_task_t *task, void *data)
 	}
 
 	rc = process_query_reply(pool, map_buf, pco->pco_op.po_map_version,
-				 pco->pco_op.po_hint.sh_rank,
+				 pco->pco_rebuild_ver, pco->pco_op.po_hint.sh_rank,
 				 &pco->pco_space, &pco->pco_rebuild_st,
 				 NULL /* tgts */, info, NULL, NULL, true);
 	if (rc != 0) {
+		if (rc == -DER_AGAIN) {
+			rc = tse_task_reinit(task);
+			if (rc == 0)
+				put_pool = false;
+			D_GOTO(out, rc);
+		}
+
 		/* TODO: What do we do about the remote connection state? */
 		D_ERROR("failed to create local pool map: "DF_RC"\n",
 			DP_RC(rc));
@@ -1456,14 +1475,18 @@ pool_query_cb(tse_task_t *task, void *data)
 {
 	struct pool_query_arg	       *arg = (struct pool_query_arg *)data;
 	struct pool_buf		       *map_buf = arg->dqa_map_buf;
-	struct pool_query_v4_in	       *in = crt_req_get(arg->rpc);
-	struct pool_query_v4_out       *out = crt_reply_get(arg->rpc);
+	struct pool_query_v5_in	       *in = crt_req_get(arg->rpc);
+	struct pool_query_v5_out       *out_v5 = crt_reply_get(arg->rpc);
 	d_rank_list_t		       *ranks = NULL;
 	d_rank_list_t		      **ranks_arg;
+	uint32_t			rebuild_ver = -1;
 	int				rc = task->dt_result;
 
+	/* NB: out_v4 and out_v5 share the same fields of v4, so it can use
+	 * v5 to refer v4 here.
+	 */
 	rc = pool_rsvc_client_complete_rpc(arg->dqa_pool, &arg->rpc->cr_ep, rc,
-					   &out->pqo_op, task);
+					   &out_v5->pqo_op, task);
 	if (rc < 0)
 		D_GOTO(out, rc);
 	else if (rc == RSVC_CLIENT_RECHOOSE)
@@ -1477,17 +1500,17 @@ pool_query_cb(tse_task_t *task, void *data)
 		D_GOTO(out, rc);
 	}
 
-	rc = out->pqo_op.po_rc;
+	rc = out_v5->pqo_op.po_rc;
 	if (rc == -DER_TRUNC) {
 		struct dc_pool *pool = arg->dqa_pool;
 
 		D_WARN("pool map buffer size (%ld) < required (%u)\n",
-			pool_buf_size(map_buf->pb_nr), out->pqo_map_buf_size);
+		       pool_buf_size(map_buf->pb_nr), out_v5->pqo_map_buf_size);
 
 		/* retry with map buffer size required by server */
 		D_INFO("retry with map buffer size required by server (%ul)\n",
-		       out->pqo_map_buf_size);
-		pool->dp_map_sz = out->pqo_map_buf_size;
+		       out_v5->pqo_map_buf_size);
+		pool->dp_map_sz = out_v5->pqo_map_buf_size;
 		rc = tse_task_reinit(task);
 		D_GOTO(out, rc);
 	} else if (rc != 0) {
@@ -1496,18 +1519,26 @@ pool_query_cb(tse_task_t *task, void *data)
 	}
 
 	ranks_arg = arg->dqa_ranks ? arg->dqa_ranks : &ranks;
+	if (dc_pool_proto_version >= 5)
+		rebuild_ver = out_v5->pqo_rebuild_ver;
+
 	rc = process_query_reply(arg->dqa_pool, map_buf,
-				 out->pqo_op.po_map_version,
-				 out->pqo_op.po_hint.sh_rank,
-				 &out->pqo_space, &out->pqo_rebuild_st,
+				 out_v5->pqo_op.po_map_version,
+				 rebuild_ver, out_v5->pqo_op.po_hint.sh_rank,
+				 &out_v5->pqo_space, &out_v5->pqo_rebuild_st,
 				 ranks_arg, arg->dqa_info,
-				 arg->dqa_prop, out->pqo_prop, false);
-	if (rc == 0) {
-		D_DEBUG(DB_MD, DF_UUID": got ranklist with %u ranks\n",
-			DP_UUID(arg->dqa_pool->dp_pool), (*ranks_arg)->rl_nr);
-		if (ranks_arg == &ranks)
-			d_rank_list_free(ranks);
+				 arg->dqa_prop, out_v5->pqo_prop, false);
+	if (rc != 0) {
+		if (rc == -DER_AGAIN) {
+			rc = tse_task_reinit(task);
+			D_GOTO(out, rc);
+		}
+		D_GOTO(out, rc);
 	}
+	D_DEBUG(DB_MD, DF_UUID": got ranklist with %u ranks\n",
+		DP_UUID(arg->dqa_pool->dp_pool), (*ranks_arg)->rl_nr);
+	if (ranks_arg == &ranks)
+		d_rank_list_free(ranks);
 
 out:
 	crt_req_decref(arg->rpc);
@@ -1766,6 +1797,7 @@ map_refresh_cb(tse_task_t *task, void *varg)
 	unsigned int			version_cached;
 	struct pool_map		       *map;
 	bool				reinit = false;
+	unsigned int			up_tgt_cnt = 0;
 	int				rc = task->dt_result;
 
 	/*
@@ -1856,6 +1888,20 @@ map_refresh_cb(tse_task_t *task, void *varg)
 		goto out;
 	}
 
+	pool_map_find_up_tgts(map, NULL, &up_tgt_cnt);
+	if (up_tgt_cnt > 0 && out->tmo_rebuild_ver == 0) {
+		/* There are UP targets, but no rebuild/reintegration now, let's retry
+		 * until rebuild or reintegration start, so we know the upper version
+		 * to create the object layout.
+		 */
+		D_DEBUG(DB_MD, DF_UUID": UP targets %u, but no rebuild job yet.\n",
+			DP_UUID(pool->dp_pool), up_tgt_cnt);
+		D_FREE(map);
+		reinit = true;
+		goto out;
+	}
+
+	pool->dp_rebuild_version = out->tmo_rebuild_ver;
 	rc = dc_pool_map_update(pool, map, false /* connect */);
 	pool_map_decref(map);
 

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -192,7 +192,8 @@ CRT_RPC_DECLARE(pool_create, DAOS_ISEQ_POOL_CREATE, DAOS_OSEQ_POOL_CREATE)
 	((struct daos_pool_space) (pco_space)		CRT_RAW) \
 	((struct daos_rebuild_status) (pco_rebuild_st)	CRT_RAW) \
 	/* only set on -DER_TRUNC */				 \
-	((uint32_t)		(pco_map_buf_size)	CRT_VAR)
+	((uint32_t)		(pco_map_buf_size)	CRT_VAR) \
+	((uint32_t)		(pco_rebuild_ver)	CRT_VAR)
 
 CRT_RPC_DECLARE(pool_connect_v4, DAOS_ISEQ_POOL_CONNECT_V4, DAOS_OSEQ_POOL_CONNECT)
 
@@ -226,7 +227,7 @@ CRT_RPC_DECLARE(pool_disconnect, DAOS_ISEQ_POOL_DISCONNECT,
 	((struct daos_pool_space) (pqo_space)		CRT_RAW) \
 	((struct daos_rebuild_status) (pqo_rebuild_st)	CRT_RAW) \
 	/* only set on -DER_TRUNC */				 \
-	((uint32_t)		(pqo_map_buf_size)	CRT_VAR)
+	((uint32_t)		(pqo_map_buf_size)	CRT_VAR) \
 
 CRT_RPC_DECLARE(pool_query_v4, DAOS_ISEQ_POOL_QUERY, DAOS_OSEQ_POOL_QUERY_V4)
 
@@ -238,7 +239,8 @@ CRT_RPC_DECLARE(pool_query_v4, DAOS_ISEQ_POOL_QUERY, DAOS_OSEQ_POOL_QUERY_V4)
 	/* only set on -DER_TRUNC */				 \
 	((uint32_t)		(pqo_map_buf_size)	CRT_VAR) \
 	((uint32_t)		(pqo_pool_layout_ver)	CRT_VAR) \
-	((uint32_t)	       (pqo_upgrade_layout_ver)	CRT_VAR)
+	((uint32_t)	       (pqo_upgrade_layout_ver)	CRT_VAR) \
+	((uint32_t)		(pqo_rebuild_ver)	CRT_VAR)
 
 CRT_RPC_DECLARE(pool_query_v5, DAOS_ISEQ_POOL_QUERY, DAOS_OSEQ_POOL_QUERY_V5)
 
@@ -470,7 +472,8 @@ CRT_RPC_DECLARE(pool_upgrade, DAOS_ISEQ_POOL_UPGRADE, DAOS_OSEQ_POOL_UPGRADE)
 #define DAOS_OSEQ_POOL_TGT_QUERY_MAP	/* output fields */	 \
 	((struct pool_op_out)	(tmo_op)		CRT_VAR) \
 	/* only set on -DER_TRUNC */				 \
-	((uint32_t)		(tmo_map_buf_size)	CRT_VAR)
+	((uint32_t)		(tmo_map_buf_size)	CRT_VAR) \
+	((uint32_t)		(tmo_rebuild_ver)	CRT_VAR)
 
 CRT_RPC_DECLARE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP,
 		DAOS_OSEQ_POOL_TGT_QUERY_MAP)

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -859,6 +859,8 @@ ds_pool_iv_refresh_hdl(struct ds_pool *pool, struct pool_iv_hdl *pih)
 				 pih->pih_cont_hdl) == 0)
 			return 0;
 		ds_cont_tgt_close(pool->sp_srv_cont_hdl);
+		uuid_clear(pool->sp_srv_cont_hdl);
+		uuid_clear(pool->sp_srv_pool_hdl);
 	}
 
 	rc = ds_cont_tgt_open(pool->sp_uuid, pih->pih_cont_hdl, NULL, 0,
@@ -889,6 +891,7 @@ pool_iv_ent_invalid(struct ds_iv_entry *entry, struct ds_iv_key *key)
 			ds_cont_tgt_close(iv_entry->piv_hdl.pih_cont_hdl);
 			uuid_clear(pool->sp_srv_cont_hdl);
 			uuid_clear(pool->sp_srv_pool_hdl);
+			uuid_clear(iv_entry->piv_hdl.pih_cont_hdl);
 			ds_pool_put(pool);
 			return 0;
 		}

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1591,6 +1591,11 @@ ds_pool_tgt_prop_update(struct ds_pool *pool, struct pool_iv_prop *iv_prop)
 	pool->sp_ec_pda = iv_prop->pip_ec_pda;
 	pool->sp_rp_pda = iv_prop->pip_rp_pda;
 
+	if (iv_prop->pip_self_heal & DAOS_SELF_HEAL_AUTO_REBUILD)
+		pool->sp_disable_rebuild = 0;
+	else
+		pool->sp_disable_rebuild = 1;
+
 	if (!daos_policy_try_parse(iv_prop->pip_policy_str,
 				   &pool->sp_policy_desc)) {
 		D_ERROR("Failed to parse policy string: %s\n",
@@ -1680,6 +1685,7 @@ ds_pool_tgt_query_map_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		goto out_version;
 
+	ds_rebuild_running_query(in->tmi_op.pi_uuid, &out->tmo_rebuild_ver);
 	rc = ds_pool_transfer_map_buf(buf, version, rpc, in->tmi_map_bulk,
 				      &out->tmo_map_buf_size);
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -613,7 +613,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 		 * still includes the current rank. If not, the object can be
 		 * deleted/reclaimed because it is no longer reachable
 		 */
-		rc = pl_obj_place(map, &md, DAOS_OO_RO, NULL, &layout);
+		rc = pl_obj_place(map, &md, DAOS_OO_RO, rpt->rt_rebuild_ver, NULL, &layout);
 		if (rc != 0)
 			D_GOTO(out, rc);
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -464,6 +464,19 @@ out:
 	return rc;
 }
 
+void
+ds_rebuild_running_query(uuid_t pool_uuid, uint32_t *upper_ver)
+{
+	struct rebuild_tgt_pool_tracker	*rpt;
+
+	*upper_ver = 0;
+	rpt = rpt_lookup(pool_uuid, -1, -1);
+	if (rpt != NULL) {
+		*upper_ver = rpt->rt_rebuild_ver;
+		rpt_put(rpt);
+	}
+}
+
 /* TODO: Add something about what the current operation is for output status */
 int
 ds_rebuild_query(uuid_t pool_uuid, struct daos_rebuild_status *status)


### PR DESCRIPTION
Add rebuild version to pool map query reply, which will be used to generate the object layout. So any targets whose in_version (when target is added to the map) is newer than the rebuild version will be regarded as unavaible targets, otherwise inflight I/O data may be lost during reintegration.

Inflight I/O also needs to wait rebuild fence is generated, so the inflight I/O epoch will have newer epoch than the rebuild stable epoch, which is even older than rebuild fence, so rebuild will use rebuild fence epoch to check if the data needs to be rebuilt.

Do not need change it during leader switch to avoid unnecessary IV communication, i.e. do not need invalidate this IV entry during svc step down, and the new PS leader will still pick up the same handle anyway.

Signed-off-by: Di Wang <di.wang@intel.com>