### PR TITLE
DAOS-11380 rebuild: do not set rebuild status for reclaim job

### DIFF
--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -26,6 +26,7 @@ typedef enum {
 	RB_OP_REINT,
 	RB_OP_EXTEND,
 	RB_OP_RECLAIM,
+	RB_OP_FAIL_RECLAIM,
 } daos_rebuild_opc_t;
 
 #define RB_OP_STR(rb_op) ((rb_op) == RB_OP_FAIL ? "Rebuild" : \
@@ -33,6 +34,7 @@ typedef enum {
 			  (rb_op) == RB_OP_REINT ? "Reintegrate" : \
 			  (rb_op) == RB_OP_EXTEND ? "Extend" : \
 			  (rb_op) == RB_OP_RECLAIM ? "Reclaim" : \
+			  (rb_op) == RB_OP_FAIL_RECLAIM ? "Reclaim fail" : \
 			  "Unknown")
 
 int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -603,7 +603,8 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 				DP_UOID(oid), DP_RC(rc));
 			D_GOTO(out, rc);
 		}
-	} else if (rpt->rt_rebuild_op == RB_OP_RECLAIM) {
+	} else if (rpt->rt_rebuild_op == RB_OP_RECLAIM ||
+		   rpt->rt_rebuild_op == RB_OP_FAIL_RECLAIM) {
 		struct pl_obj_layout *layout = NULL;
 		bool still_needed;
 		uint32_t mytarget = dss_get_module_info()->dmi_tgt_id;
@@ -673,7 +674,8 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 			 rpt->rt_rebuild_op == RB_OP_DRAIN ||
 			 rpt->rt_rebuild_op == RB_OP_REINT ||
 			 rpt->rt_rebuild_op == RB_OP_EXTEND ||
-			 rpt->rt_rebuild_op == RB_OP_RECLAIM);
+			 rpt->rt_rebuild_op == RB_OP_RECLAIM ||
+			 rpt->rt_rebuild_op == RB_OP_FAIL_RECLAIM);
 	}
 	if (rebuild_nr <= 0) /* No need rebuild */
 		D_GOTO(out, rc = rebuild_nr);
@@ -851,7 +853,7 @@ rebuild_scanner(void *data)
 		D_GOTO(out, rc);
 	}
 
-	if (rpt->rt_rebuild_op != RB_OP_RECLAIM) {
+	if (rpt->rt_rebuild_op != RB_OP_RECLAIM && rpt->rt_rebuild_op != RB_OP_FAIL_RECLAIM) {
 		rpt_get(rpt);
 		rc = dss_ult_create(rebuild_objects_send_ult, rpt, DSS_XS_SELF,
 				    0, 0, &ult_send);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -819,7 +819,7 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 		return rc;
 	}
 
-	if (rebuild_op == RB_OP_RECLAIM)
+	if (rebuild_op == RB_OP_RECLAIM || rebuild_op == RB_OP_FAIL_RECLAIM)
 		return 0;
 
 	D_ASSERT(rebuild_op == RB_OP_FAIL ||
@@ -892,7 +892,7 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 	 */
 	D_DEBUG(DB_REBUILD, "rebuild op %d\n", rebuild_op);
 	if (rebuild_op == RB_OP_REINT || rebuild_op == RB_OP_EXTEND ||
-	    rebuild_op == RB_OP_RECLAIM) {
+	    rebuild_op == RB_OP_RECLAIM || rebuild_op == RB_OP_FAIL_RECLAIM) {
 		d_rank_list_t	up_ranks = { 0 };
 		int		i;
 		int		nr = 0;
@@ -950,7 +950,7 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 	rsi->rsi_leader_term = rgt->rgt_leader_term;
 	rsi->rsi_rebuild_ver = rgt->rgt_rebuild_ver;
 	rsi->rsi_rebuild_gen = rgt->rgt_rebuild_gen;
-	if (rebuild_op == RB_OP_RECLAIM)
+	if (rebuild_op == RB_OP_RECLAIM || rebuild_op == RB_OP_FAIL_RECLAIM)
 		D_ASSERT(rgt->rgt_reclaim_epoch != 0);
 
 	rsi->rsi_reclaim_epoch = rgt->rgt_reclaim_epoch;
@@ -1120,7 +1120,8 @@ rebuild_try_merge_tgts(struct ds_pool *pool, uint32_t map_ver,
 			continue;
 
 		/* Do not merge reclaim rebuild job */
-		if (task->dst_rebuild_op == RB_OP_RECLAIM)
+		if (task->dst_rebuild_op == RB_OP_RECLAIM ||
+		    task->dst_rebuild_op == RB_OP_FAIL_RECLAIM)
 			continue;
 
 		/* Since the queue is sorted by map version, so we only need compare
@@ -1225,10 +1226,11 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 	if (!is_rebuild_global_done(rgt) || rgt->rgt_status.rs_errno != 0) {
 		/* If current job failed */
 		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
-		if (task->dst_rebuild_op == RB_OP_RECLAIM) {
+		if (task->dst_rebuild_op == RB_OP_RECLAIM ||
+		    task->dst_rebuild_op == RB_OP_FAIL_RECLAIM) {
 			rc = ds_rebuild_schedule(pool, task->dst_map_ver,
 						 rgt->rgt_stable_epoch, &task->dst_tgts,
-						 RB_OP_RECLAIM, 5);
+						 task->dst_rebuild_op, 5);
 			return rc;
 		}
 
@@ -1236,7 +1238,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		if (rgt->rgt_init_scan) {
 			rc = ds_rebuild_schedule(pool, task->dst_map_ver,
 						 rgt->rgt_stable_epoch, &task->dst_tgts,
-						 RB_OP_RECLAIM, 5);
+						 RB_OP_FAIL_RECLAIM, 5);
 			if (rc)
 				D_ERROR(DF_UUID "schedule reclaim fail: "DF_RC"\n",
 					DP_UUID(task->dst_pool_uuid), DP_RC(rc));
@@ -1256,14 +1258,15 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 				DP_UUID(task->dst_pool_uuid), DP_RC(rc));
 	}
 
-
-	/* Update the rebuild complete status for pool query */
-	rc1 = rebuild_status_completed_update(task->dst_pool_uuid, &rgt->rgt_status);
-	if (rc1 != 0) {
-		D_ERROR("rebuild_status_completed_update, "DF_UUID" failed: "DF_RC"\n",
-			DP_UUID(task->dst_pool_uuid), DP_RC(rc1));
-		if (rc == 0)
-			rc = rc1;
+	if (task->dst_rebuild_op != RB_OP_FAIL_RECLAIM) {
+		/* Update the rebuild complete status for pool query */
+		rc1 = rebuild_status_completed_update(task->dst_pool_uuid, &rgt->rgt_status);
+		if (rc1 != 0) {
+			D_ERROR("rebuild_status_completed_update, "DF_UUID" failed: "DF_RC"\n",
+				DP_UUID(task->dst_pool_uuid), DP_RC(rc1));
+			if (rc == 0)
+				rc = rc1;
+		}
 	}
 
 	return rc;
@@ -1709,6 +1712,7 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 		 * before any other tasks with same version.
 		 */
 		if (new_task->dst_rebuild_op != RB_OP_RECLAIM &&
+		    new_task->dst_rebuild_op != RB_OP_FAIL_RECLAIM &&
 		    new_task->dst_map_ver == task->dst_map_ver)
 			continue;
 


### PR DESCRIPTION
Do not set rebuild status for reclaim job to avoid messing up the real rebuild status.

Required-githooks: true
Test-tags: pr no_cap
Signed-off-by: Di Wang <di.wang@intel.com>