### PR TITLE
DAOS-11623 test: Fix cmocka_utils Leap 15 timeout

### DIFF
--- a/src/tests/ftest/util/cmocka_utils.py
+++ b/src/tests/ftest/util/cmocka_utils.py
@@ -134,9 +134,7 @@ class CmockaUtils():
         # List any remote cmocka files
         test.log.debug("Remote %s directories:", self.cmocka_dir)
         ls_command = "ls -alR {0}".format(self.cmocka_dir)
-        clush_ls_command = "{0} {1}".format(
-            get_clush_command(self.hosts, "-B -S"), ls_command)
-        run_remote(self.hosts, clush_ls_command)
+        run_remote(self.hosts, ls_command)
 
         # Copy any remote cmocka files back to this host
         command = "{0} --rcopy {1} --dest {1}".format(


### PR DESCRIPTION
When collecting the cmocka xml files from the remote hosts the cmocka_utils code was unintentionally issuing a doulbe clush command. This resulted in the daos_test/dfuse.py timing out when run on Leap 15.

Quick-functional: true
Skip-func-test-leap15: false
Test-tag: test_daos_dfuse_unit

Required-githooks: true

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>