### PR TITLE
DAOS-10339 test: Fix inconsitant size test

### DIFF
--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -177,7 +177,7 @@ class ListVerboseTest(IorTestBase):
             # Verify scm_size using the threshold rather than the exact match.
             rank_count = len(pool.target_list.value)
             if scm_size[index] is None:
-                created = pool.scm_size.value * rank_count
+                created = pool.scm_per_rank * rank_count
             else:
                 created = scm_size[index]
             self.verify_scm_size(


### PR DESCRIPTION
# Description

The SCM size of a pool created could eventually be greater than the one provided to dmg.  Thus, the size given to the dmg is not reliable and should not be used for consistancy checks.

Quick-Functional: true
Test-tag: list_verbose_basic
Test-repeat: 20
Required-githooks: true

Signed-off-by: Cedric Koch-Hofer <cedric.koch-hofer@intel.com>