### PR TITLE
DAOS-11529 rebuild:remove rt_done_cond

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1521,6 +1521,9 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 		D_GOTO(obj_close, rc);
 	}
 
+	if (DAOS_FAIL_CHECK(DAOS_REBUILD_UPDATE_FAIL))
+		D_GOTO(obj_close, rc = -DER_INVAL);
+
 	if (mrone->mo_iods[0].iod_type == DAOS_IOD_SINGLE)
 		rc = migrate_fetch_update_single(mrone, oh, cont);
 	else if (obj_shard_is_ec_parity(mrone->mo_oid, mrone->mo_dkey_hash,
@@ -2654,8 +2657,10 @@ ds_migrate_stop(struct ds_pool *pool, unsigned int version)
 	int			 rc;
 
 	tls = migrate_pool_tls_lookup(pool->sp_uuid, version);
-	if (tls == NULL)
+	if (tls == NULL) {
+		D_INFO(DF_UUID" migrate stopped\n", DP_UUID(pool->sp_uuid));
 		return;
+	}
 
 	uuid_copy(arg.pool_uuid, pool->sp_uuid);
 	arg.version = version;

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -65,10 +65,7 @@ struct rebuild_tgt_pool_tracker {
 	 * can be go ahead to finish the rebuild.
 	 */
 	ABT_cond		rt_fini_cond;
-	/* Notify others the rebuild of this pool has been
-	 * done on this target.
-	 */
-	ABT_cond		rt_done_cond;
+
 	/* # to-be-rebuilt objs */
 	uint64_t		rt_reported_toberb_objs;
 	/* reported # rebuilt objs */

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -212,6 +212,7 @@ rpt_lookup(uuid_t pool_uuid, unsigned int ver, unsigned int gen)
 	/* Only stream 0 will access the list */
 	d_list_for_each_entry(rpt, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
 		if (uuid_compare(rpt->rt_pool_uuid, pool_uuid) == 0 &&
+		    rpt->rt_finishing == 0 &&
 		    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
 		    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen)) {
 			rpt_get(rpt);
@@ -1000,9 +1001,6 @@ rpt_destroy(struct rebuild_tgt_pool_tracker *rpt)
 	if (rpt->rt_fini_cond)
 		ABT_cond_free(&rpt->rt_fini_cond);
 
-	if (rpt->rt_done_cond)
-		ABT_cond_free(&rpt->rt_done_cond);
-
 	D_FREE(rpt);
 }
 
@@ -1513,27 +1511,6 @@ rebuild_ults(void *arg)
 	ABT_mutex_unlock(rebuild_gst.rg_lock);
 }
 
-static void
-rpt_abort(struct rebuild_tgt_pool_tracker *rpt)
-{
-	/* If it can find rpt, it means rebuild has not finished yet
-	 * on this target, so the rpt has to been hold by someone
-	 * else, so it is safe to use rpt after rpt_put().
-	 *
-	 * And we have to do rpt_put(), otherwise it will hold
-	 * rebuild_tgt_fini().
-	 */
-	D_ASSERT(rpt->rt_refcount > 1);
-
-	rpt->rt_abort = 1;
-	/* Since the rpt will be destroyed after signal rt_done_cond,
-	 * so we have to use another lock here.
-	 */
-	ABT_mutex_lock(rebuild_gst.rg_lock);
-	ABT_cond_wait(rpt->rt_done_cond, rebuild_gst.rg_lock);
-	ABT_mutex_unlock(rebuild_gst.rg_lock);
-}
-
 void
 ds_rebuild_abort(uuid_t pool_uuid, unsigned int ver, unsigned int gen, uint64_t term)
 {
@@ -1543,13 +1520,26 @@ ds_rebuild_abort(uuid_t pool_uuid, unsigned int ver, unsigned int gen, uint64_t 
 	rebuild_leader_stop(pool_uuid, ver, gen, term);
 
 	/* Only stream 0 will access the list */
-	d_list_for_each_entry_safe(rpt, tmp, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
-		if (uuid_compare(rpt->rt_pool_uuid, pool_uuid) == 0 &&
-		    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
-		    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen) &&
-		    (term == (uint64_t)(-1) || rpt->rt_leader_term == term))
-			rpt_abort(rpt);
+	while(1) {
+		bool aborted = true;
+
+		d_list_for_each_entry_safe(rpt, tmp, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
+			if (uuid_compare(rpt->rt_pool_uuid, pool_uuid) == 0 &&
+			    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
+			    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen) &&
+			    (term == (uint64_t)(-1) || rpt->rt_leader_term == term)) {
+				rpt->rt_abort = 1;
+				aborted = false;
+			}
+		}
+
+		if (aborted)
+			break;
+
+		dss_sleep(1000);
+		D_INFO(DF_UUID" wait for rebuild abort.\n", DP_UUID(pool_uuid));
 	}
+	D_INFO(DF_UUID" rebuild aborted\n", DP_UUID(pool_uuid));
 }
 
 static void
@@ -1562,9 +1552,7 @@ rgt_leader_stop(struct rebuild_global_pool_tracker *rgt)
 
 	/* Remove it from the rgt list to avoid stopping rgt duplicately */
 	d_list_del(&rgt->rgt_list);
-	/* Since the rpt will be destroyed after signal rt_done_cond,
-	 * so we have to use another lock here.
-	 */
+
 	ABT_mutex_lock(rgt->rgt_lock);
 	ABT_cond_wait(rgt->rgt_done_cond, rgt->rgt_lock);
 	ABT_mutex_unlock(rgt->rgt_lock);
@@ -1891,8 +1879,8 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	struct rebuild_pool_tls	*pool_tls;
 	int			 rc;
 
-	D_DEBUG(DB_REBUILD, "Finalize rebuild for "DF_UUID", map_ver=%u\n",
-		DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver);
+	D_INFO("finishing rebuild for "DF_UUID", map_ver=%u refcount %u\n",
+	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver, rpt->rt_refcount);
 
 	if (rpt->rt_rebuild_op == RB_OP_REINT) {
 		D_ASSERT(rpt->rt_pool->sp_reintegrating > 0);
@@ -1900,7 +1888,6 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	}
 	ABT_mutex_lock(rpt->rt_lock);
 	D_ASSERT(rpt->rt_refcount > 0);
-	d_list_del_init(&rpt->rt_list);
 	rpt->rt_finishing = 1;
 	/* Wait until all ult/tasks finish and release the rpt.
 	 * NB: Because rebuild_tgt_fini will be only called in
@@ -1925,15 +1912,14 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 
 	/* destroy the migrate_tls of 0-xstream */
 	ds_migrate_stop(rpt->rt_pool, rpt->rt_rebuild_ver);
+	d_list_del_init(&rpt->rt_list);
 	rpt_put(rpt);
 	/* No one should access rpt after rebuild_fini_one.
 	 */
 	D_ASSERT(rpt->rt_refcount == 0);
 
-	/* Notify anyone who is waiting for the rebuild to finish */
-	ABT_mutex_lock(rebuild_gst.rg_lock);
-	ABT_cond_signal(rpt->rt_done_cond);
-	ABT_mutex_unlock(rebuild_gst.rg_lock);
+	D_INFO("Finalized rebuild for "DF_UUID", map_ver=%u.\n",
+	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver);
 
 	rpt_destroy(rpt);
 
@@ -2071,11 +2057,11 @@ rebuild_tgt_status_check_ult(void *arg)
 
 		D_INFO("ver %d obj "DF_U64" rec "DF_U64" size "
 			DF_U64" scan done %d pull done %d scan gl done %d"
-			" gl done %d status %d\n",
+			" gl done %d abort %u status %d\n",
 			rpt->rt_rebuild_ver, iv.riv_obj_count,
 			iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done,
 			iv.riv_pull_done, rpt->rt_global_scan_done,
-			rpt->rt_global_done, iv.riv_status);
+			rpt->rt_global_done, rpt->rt_abort, iv.riv_status);
 
 		if (rpt->rt_global_done || rpt->rt_abort)
 			break;
@@ -2149,10 +2135,6 @@ rpt_create(struct ds_pool *pool, uint32_t master_rank, uint32_t pm_ver,
 		D_GOTO(free, rc = dss_abterr2der(rc));
 
 	rc = ABT_cond_create(&rpt->rt_fini_cond);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(free, rc = dss_abterr2der(rc));
-
-	rc = ABT_cond_create(&rpt->rt_done_cond);
 	if (rc != ABT_SUCCESS)
 		D_GOTO(free, rc = dss_abterr2der(rc));
 

--- a/src/tests/ftest/daos_test/rebuild.py
+++ b/src/tests/ftest/daos_test/rebuild.py
@@ -269,3 +269,19 @@ class DaosCoreTestRebuild(DaosCoreBase):
         :avocado: tags=daos_test,daos_core_test_rebuild,test_rebuild_29
         """
         self.run_subtest()
+
+    def test_rebuild_30(self):
+        """Jira ID: DAOS-2770
+
+        Test Description:
+            Run daos_test -r -s5 -u subtests=30
+
+        Use cases:
+            Core tests for daos_test rebuild
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=unittest
+        :avocado: tags=daos_test,daos_core_test_rebuild,test_rebuild_30
+        """
+        self.run_subtest()

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -73,6 +73,7 @@ daos_tests:
     test_rebuild_27: DAOS_Rebuild_27
     test_rebuild_28: DAOS_Rebuild_28
     test_rebuild_29: DAOS_Rebuild_29
+    test_rebuild_30: DAOS_Rebuild_30
   daos_test:
     test_rebuild_0to10: r
     test_rebuild_12to15: r
@@ -90,6 +91,7 @@ daos_tests:
     test_rebuild_27: r
     test_rebuild_28: r
     test_rebuild_29: r
+    test_rebuild_30: r
   args:
     test_rebuild_0to10: -s3 -u subtests="0-10"
     test_rebuild_12to15: -s3 -u subtests="12-15"
@@ -107,6 +109,7 @@ daos_tests:
     test_rebuild_27: -s6 -u subtests="27"
     test_rebuild_28: -s3 -u subtests="28"
     test_rebuild_29: -s5 -u subtests="29"
+    test_rebuild_30: -s5 -u subtests="30"
   stopped_ranks:
     test_rebuild_26: ["random"]
     test_rebuild_27: ["random"]

--- a/src/tests/ftest/erasurecode/multiple_failure.py
+++ b/src/tests/ftest/erasurecode/multiple_failure.py
@@ -1,11 +1,10 @@
-#!/usr/bin/python
 '''
   (C) Copyright 2021-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeIor
-from apricot import skipForTicket
+
 
 class EcodOnlineMultFail(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -20,7 +19,6 @@ class EcodOnlineMultFail(ErasureCodeIor):
         super().__init__(*args, **kwargs)
         self.set_online_rebuild = True
 
-    @skipForTicket("DAOS-9051")
     def run_ior_cascade_failure(self):
         """Common function to Write and Read IOR"""
         # Write IOR data set with different EC object. kill rank, targets or mix of both while IOR
@@ -35,7 +33,6 @@ class EcodOnlineMultFail(ErasureCodeIor):
         # intact and no data corruption observed.
         self.ior_read_dataset(parity=2)
 
-    @skipForTicket("DAOS-9051")
     def test_ec_multiple_rank_failure(self):
         """Jira ID: DAOS-7344.
 
@@ -45,9 +42,9 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_multiple_rank_failure
+        :avocado: tags=test_ec_multiple_rank_failure
         """
         # Kill Two server ranks
         self.rank_to_kill = [self.server_count - 1, self.server_count - 3]
@@ -62,9 +59,9 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_multiple_target_on_same_rank_failure
+        :avocado: tags=test_ec_multiple_targets_on_same_rank
         """
         # Kill Two targets 2,4 from same rank 2
         self.pool_exclude[2] = "2,4"
@@ -79,16 +76,15 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_multiple_rank_on_diff_target_failure
+        :avocado: tags=test_ec_multiple_targets_on_diff_ranks
         """
         # Kill Two targets from different ranks
         self.pool_exclude[2] = "2"
         self.pool_exclude[3] = "3"
         self.run_ior_cascade_failure()
 
-    @skipForTicket("DAOS-9051")
     def test_ec_single_target_rank_failure(self):
         """Jira ID: DAOS-7344.
 
@@ -98,9 +94,9 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_single_target_rank_failure
+        :avocado: tags=test_ec_single_target_rank_failure
         """
         # Kill One server rank
         self.rank_to_kill = [self.server_count - 1]

--- a/src/tests/ftest/erasurecode/online_rebuild.py
+++ b/src/tests/ftest/erasurecode/online_rebuild.py
@@ -1,11 +1,10 @@
-#!/usr/bin/python
 '''
   (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeIor
-from apricot import skipForTicket
+
 
 class EcodOnlineRebuild(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -20,7 +19,6 @@ class EcodOnlineRebuild(ErasureCodeIor):
         super().__init__(*args, **kwargs)
         self.set_online_rebuild = True
 
-    @skipForTicket("DAOS-9051")
     def test_ec_online_rebuild(self):
         """Jira ID: DAOS-5894.
 
@@ -31,9 +29,9 @@ class EcodOnlineRebuild(ErasureCodeIor):
                   verify all IOR write finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild
-        :avocado: tags=ec_online_rebuild_array
+        :avocado: tags=test_ec_online_rebuild_array
         """
         # Kill last server rank
         self.rank_to_kill = [self.server_count - 1]

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -370,6 +370,8 @@ rebuild_destroy_pool_cb(void *data)
 
 	rebuild_pool_disconnect_internal(data);
 
+	print_message("sleep 20 seconds to make rebuild ready\n");
+	sleep(20);
 	if (arg->myrank == 0) {
 		/* Disable fail_loc and start rebuild */
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -384,8 +386,7 @@ rebuild_destroy_pool_cb(void *data)
 	}
 
 	arg->pool.destroyed = true;
-	print_message("pool destroyed "DF_UUIDF"\n",
-		      DP_UUID(arg->pool.pool_uuid));
+	print_message("pool destroyed "DF_UUIDF"\n", DP_UUID(arg->pool.pool_uuid));
 
 	par_barrier(PAR_COMM_WORLD);
 
@@ -1342,6 +1343,13 @@ rebuild_kill_PS_leader_during_rebuild(void **state)
 	reintegrate_single_pool_rank(arg, leader, true);
 }
 
+static void
+rebuild_pool_destroy_during_rebuild_failure(void **state)
+{
+	return rebuild_destroy_pool_internal(state, DAOS_REBUILD_UPDATE_FAIL |
+						    DAOS_FAIL_ALWAYS);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: drop rebuild scan reply",
@@ -1417,6 +1425,9 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_sub_teardown},
 	{"REBUILD29: rebuild kill PS leader during rebuild",
 	 rebuild_kill_PS_leader_during_rebuild, rebuild_sub_setup,
+	 rebuild_sub_teardown},
+	{"REBUILD30: destroy pool during rebuild failure and retry",
+	  rebuild_pool_destroy_during_rebuild_failure, rebuild_sub_setup,
 	 rebuild_sub_teardown},
 };
 


### PR DESCRIPTION
Remove done_cond from rpt, which is used to notify rebuild_abort() when the current rebuild finish. But rpt might be destroyed once notify others, which can cause unexpected scenarios, so let's not use done_cond, instead it checks the rebuild list until the current rpt is removed from the running list.

Add the test to verify it.

Add a few extra DINFO message for rebuild abort.

Required-githooks: true

Signed-off-by: Di Wang <di.wang@intel.com>