### PR TITLE
DAOS-10939 container: hard_rebuild test with rebuild fixes from master

### DIFF
--- a/src/tests/ftest/ior/hard_rebuild.yaml
+++ b/src/tests/ftest/ior/hard_rebuild.yaml
@@ -2,10 +2,10 @@ hosts:
   servers: !mux
     6_server:
       test_servers: server-[1-3]
-    8_server:
-      test_servers: server-[1-4]
-    12_server:
-      test_servers: server-[1-6]
+    #8_server:
+    #  test_servers: server-[1-4]
+    #12_server:
+    #  test_servers: server-[1-6]
   test_clients: 2
 timeout: 1000
 setup:

--- a/src/tests/ftest/pool/create_all_hw.yaml
+++ b/src/tests/ftest/pool/create_all_hw.yaml
@@ -12,12 +12,12 @@ server_config:
   servers:
     0:
       targets_count: !mux
-        1_target:
-          targets: 1
-        2_targets:
-          targets: 2
-        3_targets:
-          targets: 3
+        #1_target:
+        #  targets: 1
+        #2_targets:
+        #  targets: 2
+        #3_targets:
+        #  targets: 3
         4_targets:
           targets: 4
       bdev_class: nvme


### PR DESCRIPTION
And have to artificially add test tag pool_create_all_one_hw due to some python2/python3 issue preventing tag matching from working with the ec_ior_hard_online_rebuild test tag...

No added debug logging, just looking to see the impact of the rebuild fixes from master.

Quick-Functional: true

Skip-test-centos-rpms: true
Skip-func-test-vm: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag: ec_ior_hard_online_rebuild pool_create_all_one_hw Test-repeat: 20

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>