### PR TITLE
bugfix: ring map placement test failed

### DIFF
--- a/src/placement/tests/ring_map_place_obj.c
+++ b/src/placement/tests/ring_map_place_obj.c
@@ -48,7 +48,7 @@ main(int argc, char **argv)
 
 	po_ver = 1;
 	rc = daos_debug_init(DAOS_LOG_DEFAULT);
-	if (rc != 0)
+	if (rc)
 		goto out;
 
 	rc = obj_class_init();


### PR DESCRIPTION
1. Ring map test will fail without obj_class_init;
2. assert_success(rc==0) will fail even daos_obj_set_oid_by_class succeeds.