### PR TITLE
DAOS-? engine: Add env variable DAOS_USE_SWIM

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -721,9 +721,14 @@ server_init(int argc, char *argv[])
 		goto exit_init_state;
 	D_INFO("Modules successfully set up\n");
 
-	rc = crt_register_event_cb(dss_crt_event_cb, NULL);
-	if (rc)
-		D_GOTO(exit_init_state, rc);
+	bool use_swim = true;
+	d_getenv_bool("DAOS_USE_SWIM", &use_swim);
+	D_INFO("%s SWIM", use_swim ? "using" : "not using");
+	if (use_swim) {
+		rc = crt_register_event_cb(dss_crt_event_cb, NULL);
+		if (rc)
+			D_GOTO(exit_init_state, rc);
+	}
 
 	rc = crt_register_hlc_error_cb(dss_crt_hlc_error_cb, NULL);
 	if (rc)

--- a/src/pool/srv.c
+++ b/src/pool/srv.c
@@ -25,6 +25,10 @@ init(void)
 {
 	int rc;
 
+	bool use_swim = true;
+	d_getenv_bool("DAOS_USE_SWIM", &use_swim);
+	pool_disable_exclude = !use_swim;
+
 	rc = ds_pool_cache_init();
 	if (rc != 0)
 		D_GOTO(err, rc);

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -116,6 +116,7 @@ struct pool_map_refresh_ult_arg {
 /*
  * srv_pool.c
  */
+extern bool pool_disable_exclude;
 void ds_pool_rsvc_class_register(void);
 void ds_pool_rsvc_class_unregister(void);
 int ds_pool_start_all(void);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -87,7 +87,7 @@ static pthread_rwlock_t		psfl_rwlock = PTHREAD_RWLOCK_INITIALIZER;
 /* tracking failed pool service */
 D_LIST_HEAD(pool_svc_failed_list);
 
-static bool pool_disable_exclude = false;
+bool pool_disable_exclude;
 static int pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc,
 			  uint64_t bits, daos_prop_t **prop_out);
 static int pool_space_query_bcast(crt_context_t ctx, struct pool_svc *svc,


### PR DESCRIPTION
To disable SWIM info usage in daos, set the DAOS_USE_SWIM environment variable to "0" for all engines.

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true