### PR TITLE
DAOS-11667 object: fix auto object class selection for RP hints for arrays

### DIFF
--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -716,7 +716,7 @@ dc_set_oclass(uint64_t rf_factor, int domain_nr, int target_nr,
 		}
 		break;
 	case DAOS_PROP_CO_REDUN_RF1:
-		if (rdd == DAOS_OCH_RDD_EC || daos_is_array_type(otype)) {
+		if (rdd == DAOS_OCH_RDD_EC || (rdd == 0 && daos_is_array_type(otype))) {
 			if (domain_nr >= 18) {
 				*ord = OR_RS_16P1;
 				grp_size = 17;
@@ -736,7 +736,7 @@ dc_set_oclass(uint64_t rf_factor, int domain_nr, int target_nr,
 		}
 		break;
 	case DAOS_PROP_CO_REDUN_RF2:
-		if (rdd == DAOS_OCH_RDD_EC || daos_is_array_type(otype)) {
+		if (rdd == DAOS_OCH_RDD_EC || (rdd == 0 && daos_is_array_type(otype))) {
 			if (domain_nr >= 20) {
 				*ord = OR_RS_16P2;
 				grp_size = 18;

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4364,6 +4364,12 @@ oclass_auto_setting(void **state)
 			  DAOS_RES_REPL, 2, OC_RP_2GX);
 	assert_rc_equal(rc, 0);
 
+	/** Array object with RP hint should use OC_RP_GX */
+	print_message("Array oid with DAOS_OCH_RDD_RP hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_RP, feat_array,
+			  DAOS_RES_REPL, 2, OC_RP_2GX);
+	assert_rc_equal(rc, 0);
+
 	/** object with EC hint should use OC_EC_NP1G1 */
 	print_message("oid with DAOS_OCH_RDD_EC hint:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_EC, 0,
@@ -4426,6 +4432,12 @@ oclass_auto_setting(void **state)
 	print_message("BYTE ARRAY oid class:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_byte_array,
 			  DAOS_RES_EC, 2, ecidx);
+	assert_rc_equal(rc, 0);
+
+	/** Array object with RP hint should use OC_RP_GX */
+	print_message("Byte Array with DAOS_OCH_RDD_RP hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_RP, feat_byte_array,
+			  DAOS_RES_REPL, 2, OC_RP_2GX);
 	assert_rc_equal(rc, 0);
 
 	print_message("KV oid with DAOS_OCH_RDD_EC hint:\t");
@@ -4491,6 +4503,12 @@ oclass_auto_setting(void **state)
 	print_message("BYTE ARRAY oid class:\t");
 	rc = check_oclass(coh, attr.pa_domain_nr, 0, feat_byte_array,
 			  DAOS_RES_EC, 3, ecidx);
+	assert_rc_equal(rc, 0);
+
+	/** Array object with RP hint should use OC_RP_GX */
+	print_message("Byte Array with DAOS_OCH_RDD_RP hint:\t");
+	rc = check_oclass(coh, attr.pa_domain_nr, DAOS_OCH_RDD_RP, feat_byte_array,
+			  DAOS_RES_REPL, 3, OC_RP_3GX);
 	assert_rc_equal(rc, 0);
 
 	print_message("KV oid with DAOS_OCH_RDD_EC hint:\t");


### PR DESCRIPTION
If the container RF > 0 and user specified RP hint for arrays, that hint is currently ignored, and the oclass selected is EC. This PR fixes the issue to respect the user specified hint in this case.

Required-githooks: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>