### PR TITLE
DAOS-11231 cart: debug patch for RPC reference

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -877,6 +877,9 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 			  grp_priv->gp_pub.cg_grpid,
 			  tgt_ep->ep_rank,
 			  rpc_priv->crp_tgt_uri);
+
+		D_ASSERT(rpc_priv->crp_completed == 0);
+
 		crt_context_req_untrack(rpc_priv);
 		crt_rpc_complete(rpc_priv, -DER_UNREACH);
 		break;

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -23,7 +23,7 @@
 #define CRT_HG_ONEWAY_RPCID	(0xDA036869)
 
 /** MAX number of HG handles in pool */
-#define CRT_HG_POOL_MAX_NUM	(512)
+#define CRT_HG_POOL_MAX_NUM	(32)
 /** number of prepost HG handles when enable pool */
 #define CRT_HG_POOL_PREPOST_NUM	(16)
 


### PR DESCRIPTION
Assert when try to complete the timeout RPC for more than once. Only for test.

Signed-off-by: Fan Yong <fan.yong@intel.com>