### PR TITLE
DAOS-9585 chk: Set checker action in reports

### DIFF
--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -628,6 +628,7 @@ chk_leader_dangling_pool(struct chk_instance *ins, uuid_t uuid)
 			else
 				cbk->cb_statistics.cs_repaired++;
 		}
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 		break;
 	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
 		/* Report the inconsistency without repair. */
@@ -777,6 +778,7 @@ chk_leader_orphan_pool(struct chk_pool_rec *cpr)
 				cpr->cpr_exist_on_ms = 1;
 			}
 		}
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 		break;
 	case CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD:
 		/* Fall through. */
@@ -796,6 +798,7 @@ chk_leader_orphan_pool(struct chk_pool_rec *cpr)
 		 * whether it is destroyed successfully or not.
 		 */
 		cpr->cpr_skip = 1;
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS;
 		break;
 	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
 		/* Report the inconsistency without repair. */
@@ -987,6 +990,7 @@ chk_leader_no_quorum_pool(struct chk_pool_rec *cpr)
 			 * whether it is destroyed successfully or not.
 			 */
 			cpr->cpr_skip = 1;
+			act = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 			break;
 		case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
 			/* Report the inconsistency without repair. */
@@ -1049,6 +1053,7 @@ chk_leader_no_quorum_pool(struct chk_pool_rec *cpr)
 			 * XXX: For result == 0 case, it still cannot be regarded as repaired.
 			 *	We need to start the PS under DICTATE mode in subsequent step.
 			 */
+			act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 			break;
 		case CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD:
 			seq = ++(ins->ci_seq);
@@ -1364,6 +1369,7 @@ chk_leader_handle_pool_label(struct chk_pool_rec *cpr, struct ds_pool_clue *clue
 
 		/* Delay pool label update on PS until CHK__CHECK_SCAN_PHASE__CSP_POOL_CLEANUP. */
 		cpr->cpr_delay_label = 1;
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS;
 		goto out;
 	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS:
 
@@ -1380,6 +1386,7 @@ try_ps:
 			else
 				cbk->cb_statistics.cs_repaired++;
 		}
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 		break;
 	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
 		cbk->cb_statistics.cs_total++;

--- a/src/control/server/mgmt_drpc_checker.go
+++ b/src/control/server/mgmt_drpc_checker.go
@@ -161,6 +161,7 @@ func (mod *srvModule) handleCheckerReport(_ context.Context, reqb []byte) (out [
 	}()
 
 	finding := checker.AnnotateFinding(checker.NewFinding(req.Report))
+	mod.log.Debugf("annotated finding: %+v", finding)
 	if err := mod.checkerDB.AddCheckerFinding(finding); err != nil {
 		mod.log.Errorf("failed to add checker finding %+v: %s", finding, err)
 		resp.Status = int32(daos.MiscError)

--- a/src/control/system/checker/finding_test.go
+++ b/src/control/system/checker/finding_test.go
@@ -58,6 +58,44 @@ func TestChecker_AnnotateFinding(t *testing.T) {
 					},
 				}),
 		},
+		"action report: orphaned pool restored to MS": {
+			rpt: &chkpb.CheckReport{
+				Class:    chkpb.CheckInconsistClass_CIC_POOL_NONEXIST_ON_MS,
+				Action:   chkpb.CheckInconsistAction_CIA_TRUST_PS,
+				PoolUuid: test.MockUUID(),
+				Msg:      "Check leader detects orphan pool",
+				ActMsgs:  []string{"Trust the information recorded in PS DB."},
+			},
+			expFinding: checker.NewFinding(
+				&chkpb.CheckReport{
+					Class:    chkpb.CheckInconsistClass_CIC_POOL_NONEXIST_ON_MS,
+					Action:   chkpb.CheckInconsistAction_CIA_TRUST_PS,
+					PoolUuid: test.MockUUID(),
+					Msg:      fmt.Sprintf("Scanned pool service %s missing from MS", test.MockUUID()),
+					ActMsgs: []string{
+						fmt.Sprintf("Recreate the MS entry for %s", test.MockUUID()),
+					},
+				}),
+		},
+		"action report: dangling pool removed from MS": {
+			rpt: &chkpb.CheckReport{
+				Class:    chkpb.CheckInconsistClass_CIC_POOL_NONEXIST_ON_ENGINE,
+				Action:   chkpb.CheckInconsistAction_CIA_TRUST_PS,
+				PoolUuid: test.MockUUID(),
+				Msg:      "Check leader detects dangling pool",
+				ActMsgs:  []string{"Trust the information recorded in PS DB."},
+			},
+			expFinding: checker.NewFinding(
+				&chkpb.CheckReport{
+					Class:    chkpb.CheckInconsistClass_CIC_POOL_NONEXIST_ON_ENGINE,
+					Action:   chkpb.CheckInconsistAction_CIA_TRUST_PS,
+					PoolUuid: test.MockUUID(),
+					Msg:      fmt.Sprintf("MS pool service %s missing on engines", test.MockUUID()),
+					ActMsgs: []string{
+						fmt.Sprintf("Remove the MS entry for %s", test.MockUUID()),
+					},
+				}),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			f := checker.NewFinding(tc.rpt)


### PR DESCRIPTION
When the checker takes the default action, 
it should set the action in the report so that 
the admin can learn what happened.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
