### PR TITLE
DAOS-11274 cart: Fix swim paranoia

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -418,7 +418,7 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 			SWIM_RPC_TYPE_STR[rpc_type], rpc_in->upds.ca_count,
 			self_id, to_id, from_id, DP_RC(rc));
 	} else {
-		rc = swim_updates_parse(ctx, from_id, rpc_in->upds.ca_arrays,
+		rc = swim_updates_parse(ctx, from_id, from_id, rpc_in->upds.ca_arrays,
 					rpc_in->upds.ca_count);
 		if (rc == -DER_SHUTDOWN) {
 			if (grp_priv->gp_size > 1)
@@ -559,8 +559,9 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 		}
 	}
 
-	rc = swim_updates_parse(ctx, to_id, rpc_out->upds.ca_arrays,
-				rpc_out->upds.ca_count);
+	rc = swim_updates_parse(ctx, to_id,
+				rpc_type == SWIM_RPC_IREQ && !reply_rc ? from_id : to_id,
+				rpc_out->upds.ca_arrays, rpc_out->upds.ca_count);
 	if (rc == -DER_SHUTDOWN) {
 		if (grp_priv->gp_size > 1)
 			D_ERROR("SWIM shutdown\n");
@@ -1318,7 +1319,6 @@ int crt_swim_rank_add(struct crt_grp_priv *grp_priv, d_rank_t rank)
 {
 	struct crt_swim_membs	*csm = &grp_priv->gp_membs_swim;
 	struct crt_swim_target	*cst = NULL;
-	swim_id_t		 id = SWIM_ID_INVALID;
 	swim_id_t		 self_id;
 	d_rank_t		 self = grp_priv->gp_self;
 	bool			 self_in_list = false;
@@ -1366,10 +1366,9 @@ int crt_swim_rank_add(struct crt_grp_priv *grp_priv, d_rank_t rank)
 			if (cst == NULL)
 				D_GOTO(out_unlock, rc = -DER_NOMEM);
 		}
-		id = (swim_id_t)rank;
-		cst->cst_id = id;
+		cst->cst_id = rank;
 		cst->cst_state.sms_incarnation = 0;
-		cst->cst_state.sms_status = SWIM_MEMBER_INACTIVE;
+		cst->cst_state.sms_status = SWIM_MEMBER_ALIVE;
 		rc = crt_swim_membs_add(csm, cst);
 		if (rc != 0)
 			D_GOTO(out_unlock, rc);
@@ -1389,9 +1388,6 @@ out_check_self:
 out_unlock:
 	crt_swim_csm_unlock(csm);
 	D_FREE(cst);
-
-	if (id != SWIM_ID_INVALID)
-		(void)swim_member_new_remote(csm->csm_ctx, id);
 
 	if (rc && rc != -DER_ALREADY) {
 		if (rank_in_list)

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -326,6 +326,7 @@ update:
 		}
 	}
 
+	SWIM_INFO("member %lu %lu is ALIVE\n", id, nr);
 	id_state.sms_incarnation = nr;
 	id_state.sms_status = SWIM_MEMBER_ALIVE;
 	rc = swim_updates_notify(ctx, from, id, &id_state, count);
@@ -372,7 +373,7 @@ update:
 		}
 	}
 
-	SWIM_ERROR("member %lu is DEAD\n", id);
+	SWIM_ERROR("member %lu %lu is DEAD\n", id, nr);
 	id_state.sms_incarnation = nr;
 	id_state.sms_status = SWIM_MEMBER_DEAD;
 	rc = swim_updates_notify(ctx, from, id, &id_state, 0);
@@ -426,6 +427,7 @@ search:
 	TAILQ_INSERT_TAIL(&ctx->sc_suspects, item, si_link);
 
 update:
+	SWIM_INFO("member %lu %lu is SUSPECT\n", id, nr);
 	id_state.sms_incarnation = nr;
 	id_state.sms_status = SWIM_MEMBER_SUSPECT;
 	rc = swim_updates_notify(ctx, from, id, &id_state, 0);
@@ -653,33 +655,6 @@ out:
 	return rc;
 }
 
-int
-swim_member_new_remote(struct swim_context *ctx, swim_id_t id)
-{
-	struct swim_item	*item;
-	int			 rc = 0;
-
-	D_ALLOC_PTR(item);
-	if (item == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	swim_ctx_lock(ctx);
-	if (swim_state_get(ctx) == SCS_BEGIN) {
-		item->si_from = id;
-		item->si_id   = id;
-		TAILQ_INSERT_TAIL(&ctx->sc_subgroup, item, si_link);
-	} else {
-		rc = -DER_BUSY;
-	}
-	swim_ctx_unlock(ctx);
-
-	if (rc)
-		D_FREE(item);
-out:
-	SWIM_INFO("%lu: new remote %lu "DF_RC"\n", swim_self_get(ctx), id, DP_RC(rc));
-	return rc;
-}
-
 void *
 swim_data(struct swim_context *ctx)
 {
@@ -830,7 +805,7 @@ swim_net_glitch_update(struct swim_context *ctx, swim_id_t id, uint64_t delay)
 	}
 
 	if (id == self_id || id == ctx->sc_target) {
-		if (swim_state_get(ctx) == SCS_PINGED)
+		if (swim_state_get(ctx) == SCS_PINGED || swim_state_get(ctx) == SCS_IPINGED)
 			ctx->sc_deadline += delay;
 	}
 
@@ -840,6 +815,17 @@ swim_net_glitch_update(struct swim_context *ctx, swim_id_t id, uint64_t delay)
 		SWIM_ERROR("%lu: A network glitch of %lu with %lu ms delay"
 			   " is detected.\n", self_id, id, delay);
 	return rc;
+}
+
+static uint64_t
+swim_ping_delay(uint64_t state_delay)
+{
+	uint64_t	delay = state_delay * 2;
+	uint64_t	ping_timeout = swim_ping_timeout_get();
+
+	if (delay < ping_timeout || delay > 3 * ping_timeout)
+		delay = ping_timeout;
+	return delay;
 }
 
 int
@@ -910,32 +896,23 @@ swim_progress(struct swim_context *ctx, int64_t timeout_us)
 		switch (ctx_state) {
 		case SCS_BEGIN:
 			if (now > ctx->sc_next_tick_time) {
-				if (TAILQ_EMPTY(&ctx->sc_subgroup)) {
-					uint64_t delay = target_state.sms_delay * 2;
-					uint64_t ping_timeout = swim_ping_timeout_get();
+				uint64_t delay = swim_ping_delay(target_state.sms_delay);
 
-					if (delay < ping_timeout ||
-					    delay > 3 * ping_timeout)
-						delay = ping_timeout;
+				target_id = ctx->sc_target;
+				sendto_id = ctx->sc_target;
+				send_updates = true;
+				SWIM_INFO("%lu: dping %lu => {%lu %c %lu} "
+					  "delay: %u ms, timeout: %lu ms\n",
+					  ctx->sc_self, ctx->sc_self, sendto_id,
+					  SWIM_STATUS_CHARS[target_state.sms_status],
+					  target_state.sms_incarnation,
+					  target_state.sms_delay, delay);
 
-					target_id = ctx->sc_target;
-					sendto_id = ctx->sc_target;
-					send_updates = true;
-					SWIM_INFO("%lu: dping %lu => {%lu %c %lu} "
-						  "delay: %u ms, timeout: %lu ms\n",
-						  ctx->sc_self, ctx->sc_self, sendto_id,
-						  SWIM_STATUS_CHARS[target_state.sms_status],
-						  target_state.sms_incarnation,
-						  target_state.sms_delay, delay);
-
-					ctx->sc_next_tick_time = now + swim_period_get();
-					ctx->sc_deadline = now + delay;
-					if (ctx->sc_deadline < ctx->sc_next_event)
-						ctx->sc_next_event = ctx->sc_deadline;
-					ctx_state = SCS_PINGED;
-				} else {
-					ctx_state = SCS_TIMEDOUT;
-				}
+				ctx->sc_next_tick_time = now + swim_period_get();
+				ctx->sc_deadline = now + delay;
+				if (ctx->sc_deadline < ctx->sc_next_event)
+					ctx->sc_next_event = ctx->sc_deadline;
+				ctx_state = SCS_PINGED;
 			} else {
 				if (ctx->sc_next_tick_time < ctx->sc_next_event)
 					ctx->sc_next_event = ctx->sc_next_tick_time;
@@ -950,10 +927,6 @@ swim_progress(struct swim_context *ctx, int64_t timeout_us)
 			if (now > ctx->sc_deadline) {
 				/* no response from direct ping */
 				if (target_state.sms_status != SWIM_MEMBER_INACTIVE) {
-					/* suspect this member */
-					swim_member_suspect(ctx, ctx->sc_self,
-							    ctx->sc_target,
-							    target_state.sms_incarnation);
 					ctx_state = SCS_TIMEDOUT;
 				} else {
 					/* just goto next member,
@@ -985,7 +958,9 @@ swim_progress(struct swim_context *ctx, int64_t timeout_us)
 			}
 
 			if (item != NULL) {
-				struct swim_member_state state;
+				struct swim_member_state	state;
+				uint64_t			delay;
+				uint64_t			deadline;
 
 				target_id = item->si_from;
 				sendto_id = item->si_id;
@@ -999,39 +974,62 @@ swim_progress(struct swim_context *ctx, int64_t timeout_us)
 					goto done_item;
 				}
 
+				delay = swim_ping_delay(target_state.sms_delay);
+
 				if (target_id != sendto_id) {
 					/* Send indirect ping request to ALIVE member only */
 					if (state.sms_status != SWIM_MEMBER_ALIVE)
 						goto done_item;
 
+					delay *= 2;
 					SWIM_INFO("%lu: ireq  %lu => {%lu %c %lu} "
-						  "delay: %u ms\n",
+						  "delay: %u ms, timeout: %lu ms\n",
 						  ctx->sc_self, sendto_id, target_id,
 						  SWIM_STATUS_CHARS[target_state.sms_status],
 								    target_state.sms_incarnation,
-								    target_state.sms_delay);
+								    target_state.sms_delay, delay);
 				} else {
 					/* Send ping only if this member is not respond yet */
 					if (state.sms_status != SWIM_MEMBER_INACTIVE)
 						goto done_item;
 
 					SWIM_INFO("%lu: dping  %lu => {%lu %c %lu} "
-						  "delay: %u ms\n",
+						  "delay: %u ms, timeout: %lu ms\n",
 						  ctx->sc_self, ctx->sc_self, sendto_id,
 						  SWIM_STATUS_CHARS[state.sms_status],
 								    state.sms_incarnation,
-								    state.sms_delay);
+								    state.sms_delay, delay);
 				}
 
 				send_updates = true;
-done_item:
-				if (TAILQ_EMPTY(&ctx->sc_subgroup)) {
-					/* So, just goto next member. */
-					ctx_state = SCS_SELECT;
-				}
-				break;
+
+				deadline = now + delay;
+				if (deadline > ctx->sc_deadline)
+					ctx->sc_deadline = deadline;
+				if (ctx->sc_deadline < ctx->sc_next_event)
+					ctx->sc_next_event = ctx->sc_deadline;
 			}
-			/* fall through to select a next target */
+
+done_item:
+			if (TAILQ_EMPTY(&ctx->sc_subgroup))
+				ctx_state = SCS_IPINGED;
+			break;
+		case SCS_IPINGED:
+			ctx->sc_deadline += net_glitch_delay;
+			if (now > ctx->sc_deadline) {
+				/* no response from indirect pings */
+				if (target_state.sms_status != SWIM_MEMBER_INACTIVE) {
+					/* suspect this member */
+					swim_member_suspect(ctx, ctx->sc_self, ctx->sc_target,
+							    target_state.sms_incarnation);
+				}
+				ctx->sc_next_event = now;
+				ctx_state = SCS_SELECT;
+			} else {
+				if (ctx->sc_next_tick_time < ctx->sc_next_event)
+					ctx->sc_next_event = ctx->sc_next_tick_time;
+			}
+			break;
 		case SCS_SELECT:
 			ctx->sc_target = ctx->sc_ops->get_dping_target(ctx);
 			if (ctx->sc_target == SWIM_ID_INVALID) {
@@ -1068,13 +1066,13 @@ out_err:
 }
 
 int
-swim_updates_parse(struct swim_context *ctx, swim_id_t from_id,
+swim_updates_parse(struct swim_context *ctx, swim_id_t from_id, swim_id_t id,
 		   struct swim_member_update *upds, size_t nupds)
 {
 	enum swim_context_state ctx_state;
 	struct swim_member_state self_state;
 	swim_id_t self_id = swim_self_get(ctx);
-	swim_id_t id;
+	swim_id_t upd_id;
 	size_t i;
 	int rc = 0;
 
@@ -1086,12 +1084,15 @@ swim_updates_parse(struct swim_context *ctx, swim_id_t from_id,
 	swim_ctx_lock(ctx);
 	ctx_state = swim_state_get(ctx);
 
-	if (from_id == ctx->sc_target &&
-	    (ctx_state == SCS_BEGIN || ctx_state == SCS_PINGED))
+	if ((from_id == ctx->sc_target || id == ctx->sc_target) &&
+	    (ctx_state == SCS_BEGIN || ctx_state == SCS_PINGED || ctx_state == SCS_IPINGED)) {
 		ctx_state = SCS_SELECT;
+		SWIM_INFO("target %lu %s okay\n", ctx->sc_target,
+			  from_id == id ? "dping" : "iping");
+	}
 
 	for (i = 0; i < nupds; i++) {
-		id = upds[i].smu_id;
+		upd_id = upds[i].smu_id;
 
 		switch (upds[i].smu_state.sms_status) {
 		case SWIM_MEMBER_INACTIVE:
@@ -1101,15 +1102,14 @@ swim_updates_parse(struct swim_context *ctx, swim_id_t from_id,
 			 */
 			break;
 		case SWIM_MEMBER_ALIVE:
-			if (id == self_id)
+			if (upd_id == self_id)
 				break; /* ignore alive updates for self */
 
-			swim_member_alive(ctx, from_id, id,
-					  upds[i].smu_state.sms_incarnation);
+			swim_member_alive(ctx, from_id, upd_id, upds[i].smu_state.sms_incarnation);
 			break;
 		case SWIM_MEMBER_SUSPECT:
 		case SWIM_MEMBER_DEAD:
-			if (id == self_id) {
+			if (upd_id == self_id) {
 				/* increment our incarnation number if we are
 				 * suspected/confirmed in the current
 				 * incarnation
@@ -1151,11 +1151,11 @@ swim_updates_parse(struct swim_context *ctx, swim_id_t from_id,
 			}
 
 			if (upds[i].smu_state.sms_status == SWIM_MEMBER_SUSPECT)
-				swim_member_suspect(ctx, from_id, id,
-					     upds[i].smu_state.sms_incarnation);
+				swim_member_suspect(ctx, from_id, upd_id,
+						    upds[i].smu_state.sms_incarnation);
 			else
-				swim_member_dead(ctx, from_id, id,
-					     upds[i].smu_state.sms_incarnation);
+				swim_member_dead(ctx, from_id, upd_id,
+						 upds[i].smu_state.sms_incarnation);
 			break;
 		}
 	}

--- a/src/cart/swim/swim_internal.h
+++ b/src/cart/swim/swim_internal.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016 UChicago Argonne, LLC
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -67,6 +67,10 @@ enum swim_context_state {
 				 */
 	SCS_TIMEDOUT,		/**< the state when no dping response was
 				 * received and we should select iping targets.
+				 */
+	SCS_IPINGED,		/**< the state after ipings were sent and we
+				 * are waiting for responses or the end of the
+				 * current period.
 				 */
 	SCS_SELECT,		/**< the state to select next target */
 };

--- a/src/include/cart/swim.h
+++ b/src/include/cart/swim.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016 UChicago Argonne, LLC
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -189,13 +189,14 @@ void swim_self_set(struct swim_context *ctx, swim_id_t self_id);
  * Parse a SWIM message from other group member.
  *
  * @param[in]  ctx	SWIM context pointer from swim_init()
- * @param[in]  from	IDs of selected target for message
+ * @param[in]  from	IDs where message is from
+ * @param[in]  id	IDs of selected target for message
  * @param[in]  upds	SWIM updates from other group member
  * @param[in]  nupds	the count of SWIM updates
  * @returns		0 on success, negative error ID otherwise
  */
-int swim_updates_parse(struct swim_context *ctx, swim_id_t from,
-			struct swim_member_update *upds, size_t nupds);
+int swim_updates_parse(struct swim_context *ctx, swim_id_t from, swim_id_t id,
+		       struct swim_member_update *upds, size_t nupds);
 
 /**
  * Prepare a SWIM message for other group member.
@@ -265,15 +266,6 @@ int swim_progress(struct swim_context *ctx, int64_t timeout);
  */
 int swim_net_glitch_update(struct swim_context *ctx, swim_id_t id,
 			   uint64_t delay);
-
-/**
- * Notify SWIM about new remote member.
- *
- * @param[in]  ctx	SWIM context pointer from swim_init()
- * @param[in]  id	IDs of new member in inactive state
- * @returns		0 on success, negative error ID otherwise
- */
-int swim_member_new_remote(struct swim_context *ctx, swim_id_t id);
 
 /** @} */
 

--- a/src/tests/ftest/cart/test_swim.c
+++ b/src/tests/ftest/cart/test_swim.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -265,9 +265,9 @@ static void *network_thread(void *arg)
 			} else if (failed_member != item->np_from &&
 				   failed_member != item->np_to) {
 				/* emulate RPC receive by target */
-				rc = swim_updates_parse(g.swim_ctx[item->np_to],
-						   item->np_from, item->np_upds,
-						   item->np_nupds);
+				rc = swim_updates_parse(g.swim_ctx[item->np_to], item->np_from,
+							item->np_from, item->np_upds,
+							item->np_nupds);
 				if (rc) {
 					fprintf(stderr, "swim_parse_message() "
 						" error %d\n", rc);

--- a/src/tests/ftest/cart/test_swim_emu.c
+++ b/src/tests/ftest/cart/test_swim_emu.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -341,7 +341,7 @@ static void deliver_pkt(struct network_pkt *item)
 		swim_net_glitch_update(ctx, from_id, snd_delay - max_delay);
 
 	/* emulate RPC receive by target */
-	rc = swim_updates_parse(ctx, from_id, item->np_upds, item->np_nupds);
+	rc = swim_updates_parse(ctx, from_id, from_id, item->np_upds, item->np_nupds);
 	if (rc == -DER_SHUTDOWN)
 		swim_self_set(ctx, SWIM_ID_INVALID);
 	else if (rc)

--- a/src/tests/ftest/cart/test_swim_net.c
+++ b/src/tests/ftest/cart/test_swim_net.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -100,7 +100,7 @@ static void swim_srv_cb(crt_rpc_t *rpc_req)
 	dbg("receive RPC %u <== %lu", global_srv.my_rank, rpc_cli_input->src);
 	if (global_srv.my_rank != FAILED_MEMBER &&
 	    rpc_cli_input->src != FAILED_MEMBER) {
-		rc = swim_updates_parse(global_srv.swim_ctx, rpc_cli_input->src,
+		rc = swim_updates_parse(global_srv.swim_ctx, rpc_cli_input->src, rpc_cli_input->src,
 					rpc_cli_input->upds.ca_arrays,
 					rpc_cli_input->upds.ca_count);
 		D_ASSERTF(rc == 0, "swim_parse_rpc() failed rc=%d", rc);


### PR DESCRIPTION
Currently, swim starts to suspect a member as soon as a direct ping to
this member times out:

    19:10:29.77 swim_progress() 24: dping 24 => {62 A 829446131208945664}
      delay: 0 ms, timeout: 1900 ms
    ...
    19:10:31.68 swim_member_suspect() alloc(calloc) 'item':48 at
      0x7f4e9431fab0.
    19:10:31.68 swim_progress() 24: ireq  79 => {62 S 829446131208945664}
      delay: 1900 ms
    19:10:31.68 swim_progress() 24: ireq  37 => {62 S 829446131208945664}
      delay: 1900 ms

In this example, member 24 pinged member 62 directly. When that timed
out after 1.9 s, it immediately set the local state of member 62 to
SUSPECT, and sent indirect pings to member 79 and 37. The "S" on member
24, 79, and 37 might propogate to other members, while member 62 was
clarifying the suspicion by incrementing its incarnation. This behavior
is a bit too aggressive compared to the original design of the SWIM
protocol, that is, a member only generates a suspicion on another if all
indirect pings fail. We change swim to the original design:

  - Add a new swim state machine state, SCS_IPINGED, for awaiting
    indirect ping deadlines.

  - Add a parameter to swim_updates_parse for processing successful
    indirect ping replies, following how the function processes direct
    ping replies, that is, move the swim state machine out of
    SCS_PINGED or SCS_IPINGED.

  - Remove the reuse of ctx->sc_subgroup for pinging INACTIVE members.
    See https://github.com/daos-stack/daos/commit/67cc65a29a715b4c48d6f5425597d724a4cece5e. This changes makes
    modifying swim_progress easier. In this author's opinion, we no
    longer need to add new members as INACTIVE, since Dmitry has
    already converted swim to use two-way RPCs. And this author has
    tested

      * a member joins but don't get the self rank for 30 s,
      * a member joins but don't get the initial group membership for 30
	s, and
      * a member joins but crashes immediately.

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true