### PR TITLE
DAOS-10339 test: Fix inconsitant size test (#10355)

### DIFF
--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -176,7 +176,7 @@ class ListVerboseTest(IorTestBase):
             # Verify scm_size using the threshold rather than the exact match.
             rank_count = len(pool.target_list.value)
             if scm_size[index] is None:
-                created = pool.scm_size.value * rank_count
+                created = pool.scm_per_rank * rank_count
             else:
                 created = scm_size[index]
             self.verify_scm_size(

--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -61,12 +61,18 @@ class ListVerboseTest(IorTestBase):
             "targets") * rank_count
         # self.log.debug("## targets_total = {}".format(targets_total))
 
+        p_query = self.get_dmg_command().pool_query(pool.identifier)
+        pool_layout_ver = p_query["response"]["pool_layout_ver"]
+        upgrade_layout_ver = p_query["response"]["upgrade_layout_ver"]
+
         return {
             "uuid": pool.uuid.lower(),
             "label": pool.label.value,
             "svc_reps": pool.svc_ranks,
             "targets_total": targets_total,
             "targets_disabled": targets_disabled,
+            "upgrade_layout_ver": upgrade_layout_ver,
+            "pool_layout_ver": pool_layout_ver,
             "query_error_msg": "",
             "query_status_msg": "",
             "state": "Ready",


### PR DESCRIPTION
The SCM size of a pool created given could eventually be greater than the one provided to dmg.  Thus, the size given to the dmg is not reliable and should not be used for consistancy checks.

Quick-functional: true
Test-tag: list_verbose

Signed-off-by: Cedric Koch-Hofer <cedric.koch-hofer@intel.com>