### PR TITLE
DAOS-10797 pool: Fix fault domain to rank mapping

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1384,25 +1384,62 @@ pool_map_merge(struct pool_map *map, uint32_t version,
 	return rc;
 }
 
-static int
-add_domains_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
-			int map_version,
-			int ndomains, const uint32_t *domains)
+static void
+fill_domain_comp(struct pool_map *map, struct d_fd_node *domain, int idx, int map_version,
+		 uint8_t new_status, struct pool_component *map_comp)
 {
-	int			i = 0;
+	/* TODO DAOS-6353: Use the layer number as type */
+	map_comp->co_type = PO_COMP_TP_NODE;
+	map_comp->co_status = new_status;
+	map_comp->co_index = idx;
+	map_comp->co_id = domain->fdn_val.dom->fd_id;
+	map_comp->co_ver = map_version;
+	map_comp->co_in_ver = map_version;
+	map_comp->co_fseq = 1;
+	map_comp->co_flags = PO_COMPF_NONE;
+	map_comp->co_nr = domain->fdn_val.dom->fd_children_nr;
+}
+
+static void
+fill_rank_comp(uint32_t rank, int idx, int map_version, uint8_t new_status, uint32_t nr_tgts,
+	       struct pool_component *map_comp)
+{
+	map_comp->co_type = PO_COMP_TP_RANK;
+	map_comp->co_status = new_status;
+	map_comp->co_index = idx;
+	map_comp->co_id = rank;
+	map_comp->co_rank = rank;
+	map_comp->co_ver = map_version;
+	map_comp->co_in_ver = map_version;
+	map_comp->co_fseq = 1;
+	map_comp->co_flags = PO_COMPF_NONE;
+	map_comp->co_nr = nr_tgts;
+}
+
+static int
+add_domain_tree_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
+			    int map_version, uint32_t nr_tgts,
+			    int ndomains, const uint32_t *domains, d_rank_list_t *ordered_ranks)
+{
 	int			rc;
-	uint32_t		num_comps;
+	uint32_t		num_dom_comps;
+	uint32_t		num_rank_comps;
 	uint8_t			new_status;
 	struct d_fd_tree	tree = {0};
 	struct d_fd_node	node = {0};
+	bool			updated = false;
+	int			i = 0;
 
 	if (map != NULL) {
 		new_status = PO_COMP_ST_NEW;
-		num_comps = pool_map_find_domain(map, PO_COMP_TP_NODE,
-						 PO_COMP_ID_ALL, NULL);
+		num_dom_comps = pool_map_find_domain(map, PO_COMP_TP_NODE,
+						     PO_COMP_ID_ALL, NULL);
+		num_rank_comps = pool_map_find_domain(map, PO_COMP_TP_RANK,
+						      PO_COMP_ID_ALL, NULL);
 	} else {
 		new_status = PO_COMP_ST_UPIN;
-		num_comps = 0;
+		num_dom_comps = 0;
+		num_rank_comps = 0;
 	}
 
 	rc = d_fd_tree_init(&tree, domains, ndomains);
@@ -1412,7 +1449,7 @@ add_domains_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 	/* discard the root - it's being added to the pool buf elsewhere */
 	rc = d_fd_tree_next(&tree, &node);
 	while (rc == 0) {
-		struct pool_component map_comp;
+		struct pool_component map_comp = {0};
 
 		rc = d_fd_tree_next(&tree, &node);
 		if (rc != 0) {
@@ -1422,41 +1459,68 @@ add_domains_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 			break;
 		}
 
-		/* ranks are handled elsewhere for now */
-		if (node.fdn_type != D_FD_NODE_TYPE_DOMAIN)
+		switch (node.fdn_type) {
+		case D_FD_NODE_TYPE_DOMAIN:
+			fill_domain_comp(map, &node, num_dom_comps, map_version, new_status,
+					 &map_comp);
+			if (map != NULL) {
+				struct pool_domain	*current;
+				int			already_in_map;
+
+				already_in_map = pool_map_find_domain(map,
+									PO_COMP_TP_NODE,
+									map_comp.co_id,
+									&current);
+				if (already_in_map > 0) {
+					D_DEBUG(DB_TRACE, "domain %d already in map\n",
+						map_comp.co_id);
+					map_comp.co_status = current->do_comp.co_status;
+					map_comp.co_index = current->do_comp.co_index;
+				} else {
+					num_dom_comps++;
+				}
+			} else {
+				num_dom_comps++;
+			}
 			break;
+		case D_FD_NODE_TYPE_RANK:
+		{
+			uint32_t rank = node.fdn_val.rank;
 
-		/* TODO DAOS-6353: Use the layer number as type */
-		map_comp.co_type = PO_COMP_TP_NODE;
-		map_comp.co_status = new_status;
-		map_comp.co_index = i + num_comps;
-		map_comp.co_padding = 0;
-		map_comp.co_id = node.fdn_val.dom->fd_id;
-		map_comp.co_rank = 0;
-		map_comp.co_ver = map_version;
-		map_comp.co_in_ver = map_version;
-		map_comp.co_fseq = 1;
-		map_comp.co_flags = PO_COMPF_NONE;
-		map_comp.co_nr = node.fdn_val.dom->fd_children_nr;
+			if (map) {
+				struct pool_domain *found_dom;
 
-		if (map != NULL) {
-			struct pool_domain	*current;
-			int			already_in_map;
-
-			already_in_map = pool_map_find_domain(map,
-							      PO_COMP_TP_NODE,
-							      map_comp.co_id,
-							      &current);
-			if (already_in_map > 0)
-				map_comp.co_status = current->do_comp.co_status;
+				found_dom = pool_map_find_node_by_rank(map, rank);
+				if (found_dom) {
+					D_DEBUG(DB_TRACE, "rank %u already in map\n", rank);
+					continue;
+				}
+			}
+			updated = true;
+			fill_rank_comp(node.fdn_val.rank, num_rank_comps, map_version,
+				       new_status, nr_tgts, &map_comp);
+			ordered_ranks->rl_ranks[i++] = node.fdn_val.rank;
+			num_rank_comps++;
+			break;
+		}
+		default:
+			D_ERROR("bad fault domain tree, node type=%d\n", node.fdn_type);
+			return -DER_INVAL;
 		}
 
-		rc = pool_buf_attach(map_buf, &map_comp, 1 /* comp_nr */);
+		D_DEBUG(DB_TRACE, "adding component: type=0x%hhx, status=%hhu, idx=%d, id=%u, "
+			"ver=%d, in_ver=%d, fseq=%u, flags=0x%x, nr=%u\n",
+			map_comp.co_type, map_comp.co_status, map_comp.co_index, map_comp.co_id,
+			map_comp.co_ver, map_comp.co_in_ver, map_comp.co_fseq, map_comp.co_flags,
+			map_comp.co_nr);
+
+		rc = pool_buf_attach(map_buf, &map_comp, 1);
 		if (rc != 0)
-			D_ERROR("failed attaching domain ID %d to pool "
-				"buf\n", node.fdn_val.dom->fd_id);
-		i++;
+			D_ERROR("failed attaching component ID %u to pool buf\n", map_comp.co_id);
 	}
+
+	if (rc == 0 && !updated)
+		return -DER_ALREADY;
 
 	return rc;
 }
@@ -1468,83 +1532,46 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_versio
 {
 	struct pool_component	map_comp;
 	struct pool_buf		*map_buf;
-	struct pool_domain	*found_dom;
 	uint32_t		num_comps;
 	uint8_t			new_status;
-	bool			updated;
 	int			i, rc;
-	uint32_t		num_domain_comps;
-
-	updated = false;
+	uint32_t		num_domain_comps = 0;
+	d_rank_list_t		*ordered_ranks;
 
 	/*
 	 * Estimate number of domains for allocating the pool buffer
 	 */
 	rc = d_fd_get_exp_num_domains(ndomains, nnodes, &num_domain_comps);
 	if (rc != 0) {
-		D_ERROR("Invalid domain array, len=%u\n", ndomains);
+		D_ERROR("failed to calculate number of domains, "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
 	D_ASSERT(num_domain_comps > 0);
 	num_domain_comps--; /* remove the root domain - allocated separately */
 
+	ordered_ranks = d_rank_list_alloc(nnodes);
+	if (ordered_ranks == NULL)
+		return -DER_NOMEM;
+
 	map_buf = pool_buf_alloc(num_domain_comps + nnodes + ntargets);
 	if (map_buf == NULL)
-		D_GOTO(out_map_buf, rc = -DER_NOMEM);
+		D_GOTO(out_ranks, rc = -DER_NOMEM);
 
-	rc = add_domains_to_pool_buf(map, map_buf, map_version, ndomains,
-				     domains);
+	rc = add_domain_tree_to_pool_buf(map, map_buf, map_version, dss_tgt_nr, ndomains,
+					 domains, ordered_ranks);
 	if (rc != 0)
 		D_GOTO(out_map_buf, rc);
 
 	if (map != NULL) {
 		new_status = PO_COMP_ST_NEW;
-		num_comps = pool_map_find_domain(map, PO_COMP_TP_RANK,
-						 PO_COMP_ID_ALL, NULL);
+		num_comps = pool_map_find_target(map, PO_COMP_ID_ALL, NULL);
 	} else {
 		new_status = PO_COMP_ST_UPIN;
 		num_comps = 0;
 	}
 
-	/* fill nodes */
-	for (i = 0; i < nnodes; i++) {
-		if (map) {
-			found_dom = pool_map_find_node_by_rank(map, ranks->rl_ranks[i]);
-			if (found_dom)
-				continue;
-		}
-
-		updated = true;
-		map_comp.co_type = PO_COMP_TP_RANK;
-		map_comp.co_status = new_status;
-		map_comp.co_index = i + num_comps;
-		map_comp.co_padding = 0;
-		map_comp.co_id = ranks->rl_ranks[i];
-		map_comp.co_rank = ranks->rl_ranks[i];
-		map_comp.co_ver = map_version;
-		map_comp.co_in_ver = map_version;
-		map_comp.co_fseq = 1;
-		map_comp.co_flags = PO_COMPF_NONE;
-		map_comp.co_nr = dss_tgt_nr;
-
-		rc = pool_buf_attach(map_buf, &map_comp, 1 /* comp_nr */);
-		if (rc != 0) {
-			D_ERROR("failed to attach to pool buf, "DF_RC"\n",
-				DP_RC(rc));
-			D_GOTO(out_map_buf, rc);
-		}
-	}
-
-	if (!updated)
-		D_GOTO(out_map_buf, rc = -DER_ALREADY);
-
-	if (map != NULL)
-		num_comps = pool_map_find_target(map, PO_COMP_ID_ALL, NULL);
-	else
-		num_comps = 0;
-
 	/* fill targets */
-	for (i = 0; i < nnodes; i++) {
+	for (i = 0; i < ordered_ranks->rl_nr; i++) {
 		int j;
 
 		for (j = 0; j < dss_tgt_nr; j++) {
@@ -1553,12 +1580,18 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_versio
 			map_comp.co_index = j;
 			map_comp.co_padding = 0;
 			map_comp.co_id = (i * dss_tgt_nr + j) + num_comps;
-			map_comp.co_rank = ranks->rl_ranks[i];
+			map_comp.co_rank = ordered_ranks->rl_ranks[i];
 			map_comp.co_ver = map_version;
 			map_comp.co_in_ver = map_version;
 			map_comp.co_fseq = 1;
 			map_comp.co_flags = PO_COMPF_NONE;
 			map_comp.co_nr = 1;
+
+			D_DEBUG(DB_TRACE, "adding target: type=0x%hhx, status=%hhu, idx=%d, "
+				"rank=%d, ver=%d, in_ver=%d, fseq=%u, flags=0x%x, nr=%u\n",
+				map_comp.co_type, map_comp.co_status, map_comp.co_index,
+				map_comp.co_rank, map_comp.co_ver, map_comp.co_in_ver,
+				map_comp.co_fseq, map_comp.co_flags, map_comp.co_nr);
 
 			rc = pool_buf_attach(map_buf, &map_comp, 1);
 			if (rc != 0)
@@ -1567,10 +1600,13 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_versio
 	}
 
 	*map_buf_out = map_buf;
+	d_rank_list_free(ordered_ranks);
 	return 0;
 
 out_map_buf:
 	pool_buf_free(map_buf);
+out_ranks:
+	d_rank_list_free(ordered_ranks);
 	return rc;
 }
 

--- a/src/control/system/faultdomain_test.go
+++ b/src/control/system/faultdomain_test.go
@@ -698,7 +698,7 @@ func TestSystem_FaultDomain_MustCreateFaultDomainFromString(t *testing.T) {
 	}
 }
 
-func expFaultDomainID(offset uint32) uint32 {
+func ExpFaultDomainID(offset uint32) uint32 {
 	return FaultDomainRootID + offset
 }
 
@@ -718,7 +718,7 @@ func TestSystem_NewFaultDomainTree(t *testing.T) {
 		"no domains": {
 			expResult: &FaultDomainTree{
 				Domain:   MustCreateFaultDomain(),
-				ID:       expFaultDomainID(0),
+				ID:       ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{},
 			},
 		},
@@ -726,7 +726,7 @@ func TestSystem_NewFaultDomainTree(t *testing.T) {
 			domains: []*FaultDomain{nil},
 			expResult: &FaultDomainTree{
 				Domain:   MustCreateFaultDomain(),
-				ID:       expFaultDomainID(0),
+				ID:       ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{},
 			},
 		},
@@ -734,7 +734,7 @@ func TestSystem_NewFaultDomainTree(t *testing.T) {
 			domains: []*FaultDomain{MustCreateFaultDomain()},
 			expResult: &FaultDomainTree{
 				Domain:   MustCreateFaultDomain(),
-				ID:       expFaultDomainID(0),
+				ID:       ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{},
 			},
 		},
@@ -742,11 +742,11 @@ func TestSystem_NewFaultDomainTree(t *testing.T) {
 			domains: []*FaultDomain{fd1},
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
 					{
 						Domain:   fd1,
-						ID:       expFaultDomainID(1),
+						ID:       ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{},
 					},
 				},
@@ -760,15 +760,15 @@ func TestSystem_NewFaultDomainTree(t *testing.T) {
 				Children: []*FaultDomainTree{
 					{
 						Domain: fd1,
-						ID:     expFaultDomainID(1),
+						ID:     ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{
 							{
 								Domain: fd2,
-								ID:     expFaultDomainID(2),
+								ID:     ExpFaultDomainID(2),
 								Children: []*FaultDomainTree{
 									{
 										Domain:   fd3,
-										ID:       expFaultDomainID(3),
+										ID:       ExpFaultDomainID(3),
 										Children: []*FaultDomainTree{},
 									},
 								},
@@ -786,31 +786,31 @@ func TestSystem_NewFaultDomainTree(t *testing.T) {
 				Children: []*FaultDomainTree{
 					{
 						Domain: fd4,
-						ID:     expFaultDomainID(4),
+						ID:     ExpFaultDomainID(4),
 						Children: []*FaultDomainTree{
 							{
 								Domain:   fd5,
-								ID:       expFaultDomainID(5),
+								ID:       ExpFaultDomainID(5),
 								Children: []*FaultDomainTree{},
 							},
 							{
 								Domain:   fd6,
-								ID:       expFaultDomainID(6),
+								ID:       ExpFaultDomainID(6),
 								Children: []*FaultDomainTree{},
 							},
 						},
 					},
 					{
 						Domain: fd1,
-						ID:     expFaultDomainID(1),
+						ID:     ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{
 							{
 								Domain: fd2,
-								ID:     expFaultDomainID(2),
+								ID:     ExpFaultDomainID(2),
 								Children: []*FaultDomainTree{
 									{
 										Domain:   fd3,
-										ID:       expFaultDomainID(3),
+										ID:       ExpFaultDomainID(3),
 										Children: []*FaultDomainTree{},
 									},
 								},
@@ -1013,9 +1013,9 @@ func TestSystem_FaultDomainTree_AddDomain(t *testing.T) {
 			toAdd: single,
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
-					NewFaultDomainTree().WithNodeDomain(single).WithID(expFaultDomainID(1)),
+					NewFaultDomainTree().WithNodeDomain(single).WithID(ExpFaultDomainID(1)),
 				},
 			},
 		},
@@ -1024,15 +1024,15 @@ func TestSystem_FaultDomainTree_AddDomain(t *testing.T) {
 			toAdd: multi,
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
 					{
 						Domain: single,
-						ID:     expFaultDomainID(1),
+						ID:     ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{
 							{
 								Domain:   multi,
-								ID:       expFaultDomainID(2),
+								ID:       ExpFaultDomainID(2),
 								Children: []*FaultDomainTree{},
 							},
 						},
@@ -1045,26 +1045,26 @@ func TestSystem_FaultDomainTree_AddDomain(t *testing.T) {
 			toAdd: multi,
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
 					{
 						Domain: MustCreateFaultDomain("another"),
-						ID:     expFaultDomainID(1),
+						ID:     ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{
 							{
 								Domain:   MustCreateFaultDomain("another", "branch"),
-								ID:       expFaultDomainID(2),
+								ID:       ExpFaultDomainID(2),
 								Children: []*FaultDomainTree{},
 							},
 						},
 					},
 					{
 						Domain: single,
-						ID:     expFaultDomainID(3),
+						ID:     ExpFaultDomainID(3),
 						Children: []*FaultDomainTree{
 							{
 								Domain:   multi,
-								ID:       expFaultDomainID(4),
+								ID:       ExpFaultDomainID(4),
 								Children: []*FaultDomainTree{},
 							},
 						},
@@ -1077,20 +1077,20 @@ func TestSystem_FaultDomainTree_AddDomain(t *testing.T) {
 			toAdd: multi2,
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
 					{
 						Domain: single,
-						ID:     expFaultDomainID(1),
+						ID:     ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{
 							{
 								Domain:   multi,
-								ID:       expFaultDomainID(2),
+								ID:       ExpFaultDomainID(2),
 								Children: []*FaultDomainTree{},
 							},
 							{
 								Domain:   multi2,
-								ID:       expFaultDomainID(3),
+								ID:       ExpFaultDomainID(3),
 								Children: []*FaultDomainTree{},
 							},
 						},
@@ -1133,36 +1133,36 @@ func TestSystem_FaultDomainTree_Merge(t *testing.T) {
 	fullTree := func() *FaultDomainTree {
 		return &FaultDomainTree{
 			Domain: MustCreateFaultDomain(),
-			ID:     expFaultDomainID(0),
+			ID:     ExpFaultDomainID(0),
 			Children: []*FaultDomainTree{
 				{
 					Domain: rack0,
-					ID:     expFaultDomainID(1),
+					ID:     ExpFaultDomainID(1),
 					Children: []*FaultDomainTree{
 						{
 							Domain:   rack0node1,
-							ID:       expFaultDomainID(2),
+							ID:       ExpFaultDomainID(2),
 							Children: []*FaultDomainTree{},
 						},
 						{
 							Domain:   rack0node2,
-							ID:       expFaultDomainID(3),
+							ID:       ExpFaultDomainID(3),
 							Children: []*FaultDomainTree{},
 						},
 					},
 				},
 				{
 					Domain: rack1,
-					ID:     expFaultDomainID(4),
+					ID:     ExpFaultDomainID(4),
 					Children: []*FaultDomainTree{
 						{
 							Domain:   rack1node3,
-							ID:       expFaultDomainID(5),
+							ID:       ExpFaultDomainID(5),
 							Children: []*FaultDomainTree{},
 						},
 						{
 							Domain:   rack1node4,
-							ID:       expFaultDomainID(6),
+							ID:       ExpFaultDomainID(6),
 							Children: []*FaultDomainTree{},
 						},
 					},
@@ -1203,22 +1203,22 @@ func TestSystem_FaultDomainTree_Merge(t *testing.T) {
 			toMerge: NewFaultDomainTree(rack0node1),
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
 					{
 						Domain: rack0,
-						ID:     expFaultDomainID(2),
+						ID:     ExpFaultDomainID(2),
 						Children: []*FaultDomainTree{
 							{
 								Domain:   rack0node1,
-								ID:       expFaultDomainID(3),
+								ID:       ExpFaultDomainID(3),
 								Children: []*FaultDomainTree{},
 							},
 						},
 					},
 					{
 						Domain:   rack1,
-						ID:       expFaultDomainID(4),
+						ID:       ExpFaultDomainID(4),
 						Children: []*FaultDomainTree{},
 					},
 				},
@@ -1229,20 +1229,20 @@ func TestSystem_FaultDomainTree_Merge(t *testing.T) {
 			toMerge: NewFaultDomainTree(rack0node2),
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
 					{
 						Domain: rack0,
-						ID:     expFaultDomainID(1),
+						ID:     ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{
 							{
 								Domain:   rack0node1,
-								ID:       expFaultDomainID(2),
+								ID:       ExpFaultDomainID(2),
 								Children: []*FaultDomainTree{},
 							},
 							{
 								Domain:   rack0node2,
-								ID:       expFaultDomainID(3),
+								ID:       ExpFaultDomainID(3),
 								Children: []*FaultDomainTree{},
 							},
 						},
@@ -1737,19 +1737,19 @@ func TestSystem_FaultDomain_Subtree(t *testing.T) {
 			},
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
 					{
 						Domain: MustCreateFaultDomain("a"),
-						ID:     expFaultDomainID(1),
+						ID:     ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{
 							{
 								Domain: MustCreateFaultDomain("a", "e"),
-								ID:     expFaultDomainID(5), // preserve IDs from original tree
+								ID:     ExpFaultDomainID(5), // preserve IDs from original tree
 								Children: []*FaultDomainTree{
 									{
 										Domain:   MustCreateFaultDomain("a", "e", "f"),
-										ID:       expFaultDomainID(6),
+										ID:       ExpFaultDomainID(6),
 										Children: []*FaultDomainTree{},
 									},
 								},
@@ -1766,15 +1766,15 @@ func TestSystem_FaultDomain_Subtree(t *testing.T) {
 			},
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
 					{
 						Domain: MustCreateFaultDomain("a"),
-						ID:     expFaultDomainID(1),
+						ID:     ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{
 							{
 								Domain:   MustCreateFaultDomain("a", "e"),
-								ID:       expFaultDomainID(5), // preserve IDs from original tree
+								ID:       ExpFaultDomainID(5), // preserve IDs from original tree
 								Children: []*FaultDomainTree{},
 							},
 						},
@@ -1799,19 +1799,19 @@ func TestSystem_FaultDomain_Subtree(t *testing.T) {
 			},
 			expResult: &FaultDomainTree{
 				Domain: MustCreateFaultDomain(),
-				ID:     expFaultDomainID(0),
+				ID:     ExpFaultDomainID(0),
 				Children: []*FaultDomainTree{
 					{
 						Domain: MustCreateFaultDomain("a"),
-						ID:     expFaultDomainID(1),
+						ID:     ExpFaultDomainID(1),
 						Children: []*FaultDomainTree{
 							{
 								Domain: MustCreateFaultDomain("a", "e"),
-								ID:     expFaultDomainID(5), // preserve IDs from original tree
+								ID:     ExpFaultDomainID(5), // preserve IDs from original tree
 								Children: []*FaultDomainTree{
 									{
 										Domain:   MustCreateFaultDomain("a", "e", "f"),
-										ID:       expFaultDomainID(6),
+										ID:       ExpFaultDomainID(6),
 										Children: []*FaultDomainTree{},
 									},
 								},
@@ -1820,22 +1820,22 @@ func TestSystem_FaultDomain_Subtree(t *testing.T) {
 					},
 					{
 						Domain: MustCreateFaultDomain("g"),
-						ID:     expFaultDomainID(7),
+						ID:     ExpFaultDomainID(7),
 						Children: []*FaultDomainTree{
 							{
 								Domain: MustCreateFaultDomain("g", "h"),
-								ID:     expFaultDomainID(8),
+								ID:     ExpFaultDomainID(8),
 								Children: []*FaultDomainTree{
 									{
 										Domain:   MustCreateFaultDomain("g", "h", "i"),
-										ID:       expFaultDomainID(9),
+										ID:       ExpFaultDomainID(9),
 										Children: []*FaultDomainTree{},
 									},
 								},
 							},
 							{
 								Domain:   MustCreateFaultDomain("g", "j"),
-								ID:       expFaultDomainID(10),
+								ID:       ExpFaultDomainID(10),
 								Children: []*FaultDomainTree{},
 							},
 						},

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -613,18 +613,19 @@ func getFaultDomainSubtree(tree *FaultDomainTree, ranks ...uint32) (*FaultDomain
 	return tree.Subtree(rankDomains...)
 }
 
-const rankFaultDomainPrefix = "rank"
+// RankFaultDomainPrefix is the prefix for rank-level fault domains.
+const RankFaultDomainPrefix = "rank"
 
 // MemberFaultDomain generates a standardized fault domain for a Member,
 // based on its parent fault domain and rank.
 func MemberFaultDomain(m *Member) *FaultDomain {
-	rankDomain := fmt.Sprintf("%s%d", rankFaultDomainPrefix, uint32(m.Rank))
+	rankDomain := fmt.Sprintf("%s%d", RankFaultDomainPrefix, m.Rank.Uint32())
 	// we know the string we're adding is valid, so can't fail
 	return m.FaultDomain.MustCreateChild(rankDomain)
 }
 
 func getFaultDomainRank(fd *FaultDomain) (uint32, bool) {
-	fmtStr := rankFaultDomainPrefix + "%d"
+	fmtStr := RankFaultDomainPrefix + "%d"
 	var rank uint32
 	n, err := fmt.Sscanf(fd.BottomLevel(), fmtStr, &rank)
 	if err != nil || n != 1 {

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -8,6 +8,7 @@ package system_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/test"
 	. "github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -965,7 +967,14 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 	}
 }
 
-/*func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
+func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
+	testMemberWithFaultDomain := func(rank Rank, faultDomain *FaultDomain) *Member {
+		return &Member{
+			Rank:        rank,
+			FaultDomain: faultDomain,
+		}
+	}
+
 	rankDomain := func(parent string, rank uint32) *FaultDomain {
 		parentFd := MustCreateFaultDomainFromString(parent)
 		member := testMemberWithFaultDomain(Rank(rank), parentFd)
@@ -985,7 +994,7 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 			tree: NewFaultDomainTree(),
 			expResult: []uint32{
 				0,
-				expFaultDomainID(0),
+				ExpFaultDomainID(0),
 				0,
 			},
 		},
@@ -995,16 +1004,16 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 			),
 			expResult: []uint32{
 				3,
-				expFaultDomainID(0),
+				ExpFaultDomainID(0),
 				1,
 				2,
-				expFaultDomainID(1),
+				ExpFaultDomainID(1),
 				1,
 				1,
-				expFaultDomainID(2),
+				ExpFaultDomainID(2),
 				1,
 				0,
-				expFaultDomainID(3),
+				ExpFaultDomainID(3),
 				0,
 			},
 		},
@@ -1018,31 +1027,31 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 			),
 			expResult: []uint32{
 				2, // root
-				expFaultDomainID(0),
+				ExpFaultDomainID(0),
 				3,
 				1, // rack0
-				expFaultDomainID(1),
+				ExpFaultDomainID(1),
 				2,
 				1, // rack1
-				expFaultDomainID(4),
+				ExpFaultDomainID(4),
 				2,
 				1, // rack2
-				expFaultDomainID(7),
+				ExpFaultDomainID(7),
 				1,
 				0, // pdu0
-				expFaultDomainID(2),
+				ExpFaultDomainID(2),
 				0,
 				0, // pdu1
-				expFaultDomainID(3),
+				ExpFaultDomainID(3),
 				0,
 				0, // pdu2
-				expFaultDomainID(5),
+				ExpFaultDomainID(5),
 				0,
 				0, // pdu3
-				expFaultDomainID(6),
+				ExpFaultDomainID(6),
 				0,
 				0, // pdu4
-				expFaultDomainID(8),
+				ExpFaultDomainID(8),
 				0,
 			},
 		},
@@ -1052,16 +1061,16 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 			),
 			expResult: []uint32{
 				4,
-				expFaultDomainID(0),
+				ExpFaultDomainID(0),
 				1,
 				3,
-				expFaultDomainID(1),
+				ExpFaultDomainID(1),
 				1,
 				2,
-				expFaultDomainID(2),
+				ExpFaultDomainID(2),
 				1,
 				1,
-				expFaultDomainID(3),
+				ExpFaultDomainID(3),
 				1,
 				5,
 			},
@@ -1077,31 +1086,31 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 			),
 			expResult: []uint32{
 				3,
-				expFaultDomainID(0), // root
+				ExpFaultDomainID(0), // root
 				3,
 				2,
-				expFaultDomainID(1), // rack0
+				ExpFaultDomainID(1), // rack0
 				2,
 				2,
-				expFaultDomainID(6), // rack1
+				ExpFaultDomainID(6), // rack1
 				2,
 				2,
-				expFaultDomainID(12), // rack2
+				ExpFaultDomainID(12), // rack2
 				1,
 				1,
-				expFaultDomainID(2), // pdu0
+				ExpFaultDomainID(2), // pdu0
 				1,
 				1,
-				expFaultDomainID(4), // pdu1
+				ExpFaultDomainID(4), // pdu1
 				1,
 				1,
-				expFaultDomainID(7), // pdu2
+				ExpFaultDomainID(7), // pdu2
 				1,
 				1,
-				expFaultDomainID(9), // pdu3
+				ExpFaultDomainID(9), // pdu3
 				2,
 				1,
-				expFaultDomainID(13), // pdu4
+				ExpFaultDomainID(13), // pdu4
 				1,
 				// ranks
 				0,
@@ -1114,20 +1123,20 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 		},
 		"intermediate domain has name like rank": {
 			tree: NewFaultDomainTree(
-				rankDomain(fmt.Sprintf("/top/%s2/bottom", rankFaultDomainPrefix), 1),
+				rankDomain(fmt.Sprintf("/top/%s2/bottom", RankFaultDomainPrefix), 1),
 			),
 			expResult: []uint32{
 				4,
-				expFaultDomainID(0), // root
+				ExpFaultDomainID(0), // root
 				1,
 				3,
-				expFaultDomainID(1), // top
+				ExpFaultDomainID(1), // top
 				1,
 				2,
-				expFaultDomainID(2), // rank2
+				ExpFaultDomainID(2), // rank2
 				1,
 				1,
-				expFaultDomainID(3), // bottom
+				ExpFaultDomainID(3), // bottom
 				1,
 				1, // rank
 			},
@@ -1144,13 +1153,13 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 			inputRanks: []uint32{4},
 			expResult: []uint32{
 				3,
-				expFaultDomainID(0), // root
+				ExpFaultDomainID(0), // root
 				1,
 				2,
-				expFaultDomainID(6), // rack1
+				ExpFaultDomainID(6), // rack1
 				1,
 				1,
-				expFaultDomainID(9), // pdu3
+				ExpFaultDomainID(9), // pdu3
 				1,
 				// ranks
 				4,
@@ -1168,25 +1177,25 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 			inputRanks: []uint32{4, 0, 5, 3},
 			expResult: []uint32{
 				3,
-				expFaultDomainID(0), // root
+				ExpFaultDomainID(0), // root
 				3,
 				2,
-				expFaultDomainID(1), // rack0
+				ExpFaultDomainID(1), // rack0
 				1,
 				2,
-				expFaultDomainID(6), // rack1
+				ExpFaultDomainID(6), // rack1
 				1,
 				2,
-				expFaultDomainID(12), // rack2
+				ExpFaultDomainID(12), // rack2
 				1,
 				1,
-				expFaultDomainID(2), // pdu0
+				ExpFaultDomainID(2), // pdu0
 				1,
 				1,
-				expFaultDomainID(9), // pdu3
+				ExpFaultDomainID(9), // pdu3
 				2,
 				1,
-				expFaultDomainID(13), // pdu4
+				ExpFaultDomainID(13), // pdu4
 				1,
 				// ranks
 				0,
@@ -1212,8 +1221,7 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer test.ShowBufferOnFailure(t, buf)
 
-			db := MockDatabase(t, log)
-			db.data.Members.FaultDomains = tc.tree
+			db := raft.MockDatabaseWithFaultDomainTree(t, log, tc.tree)
 			membership := NewMembership(log, db)
 
 			result, err := membership.CompressedFaultDomainTree(tc.inputRanks...)
@@ -1226,4 +1234,3 @@ func TestSystem_Membership_MarkDead(t *testing.T) {
 		})
 	}
 }
-*/

--- a/src/control/system/raft/mocks.go
+++ b/src/control/system/raft/mocks.go
@@ -16,6 +16,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/system"
 )
 
 type (
@@ -134,6 +135,13 @@ func MockDatabaseWithCfg(t *testing.T, log logging.Logger, dbCfg *DatabaseConfig
 // operations in memory.
 func MockDatabase(t *testing.T, log logging.Logger) *Database {
 	return MockDatabaseWithAddr(t, log, common.LocalhostCtrlAddr())
+}
+
+// MockDatabaseWithFaultDomainTree creates a MockDatabase and sets the fault domain tree.
+func MockDatabaseWithFaultDomainTree(t *testing.T, log logging.Logger, tree *system.FaultDomainTree) *Database {
+	db := MockDatabase(t, log)
+	db.data.Members.FaultDomains = tree
+	return db
 }
 
 // TestDatabase returns a database that is backed by temporary storage


### PR DESCRIPTION
- Ranks weren't being correctly mapped to their parent fault domain.
- Re-enabled and fixed Go unit tests for generating the compressed fault domain tree, including ranks.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>