### PR TITLE
DAOS-11231 client: fix memory corruption during query_key

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1901,7 +1901,6 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 	tse_task_t	 *pool_task = NULL;
 	int		  result = task->dt_result;
 	int		  rc;
-	bool		  keep_result = false;
 
 	if (pmap_stale) {
 		rc = obj_pool_query_task(sched, obj, 0, &pool_task);
@@ -1926,21 +1925,11 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 		}
 		*io_task_reinited = true;
 		obj_auxi->retry_cnt++;
-	} else if (obj_auxi->spec_shard || obj_auxi->spec_group) {
-		/* If the RPC sponsor specifies shard or group, we will NOT
-		 * reschedule the IO, but not prevent the pool map refresh.
-		 * Restore the original RPC (task) result, the RPC sponsor
-		 * will handle that by itself.
-		 */
-		keep_result = true;
 	}
 
 	if (pool_task != NULL)
 		/* ignore returned value, error is reported by comp_cb */
 		tse_task_schedule(pool_task, obj_auxi->io_retry);
-
-	if (keep_result)
-		task->dt_result = result;
 
 	D_DEBUG(DB_IO, "Retrying task=%p/%d for err=%d, io_retry=%d\n",
 		task, task->dt_result, result, obj_auxi->io_retry);
@@ -6241,6 +6230,7 @@ dc_obj_punch_akeys_task(tse_task_t *task)
 }
 
 struct shard_query_key_args {
+	/* shard_auxi_args must be the first for shard_task_sched(). */
 	struct shard_auxi_args	 kqa_auxi;
 	uuid_t			 kqa_coh_uuid;
 	uuid_t			 kqa_cont_uuid;
@@ -6271,13 +6261,13 @@ shard_query_key_task(tse_task_t *task)
 		if (rc < 0) {
 			tse_task_complete(task, rc);
 			return rc;
-		} else if (rc == DC_TX_GE_REINITED) {
-			return 0;
 		}
+
+		if (rc == DC_TX_GE_REINITED)
+			return 0;
 	}
 
-	rc = obj_shard_open(obj, args->kqa_auxi.shard, args->kqa_auxi.map_ver,
-			    &obj_shard);
+	rc = obj_shard_open(obj, args->kqa_auxi.shard, args->kqa_auxi.map_ver, &obj_shard);
 	if (rc != 0) {
 		/* skip a failed target */
 		if (rc == -DER_NONEXIST)
@@ -6287,16 +6277,13 @@ shard_query_key_task(tse_task_t *task)
 		return rc;
 	}
 
-	tse_task_stack_push_data(task, &args->kqa_dkey_hash,
-				 sizeof(args->kqa_dkey_hash));
 	api_args = args->kqa_api_args;
-	rc = dc_obj_shard_query_key(obj_shard, epoch, api_args->flags, obj,
+	rc = dc_obj_shard_query_key(obj_shard, epoch, api_args->flags,
+				    args->kqa_auxi.obj_auxi->map_ver_req, args->kqa_dkey_hash, obj,
 				    api_args->dkey, api_args->akey,
 				    api_args->recx, api_args->max_epoch, args->kqa_coh_uuid,
 				    args->kqa_cont_uuid, &args->kqa_dti,
-				    &args->kqa_auxi.obj_auxi->map_ver_reply,
-				    args->kqa_auxi.obj_auxi->map_ver_req,
-				    th, task);
+				    &args->kqa_auxi.obj_auxi->map_ver_reply, th, task);
 
 	obj_shard_close(obj_shard);
 	return rc;
@@ -6442,7 +6429,6 @@ dc_obj_query_key(tse_task_t *api_task)
 		 * the leader status might change.
 		 */
 		tse_task_list_traverse(head, shard_task_remove, NULL);
-		D_ASSERT(d_list_empty(head));
 		obj_auxi->args_initialized = 0;
 		obj_auxi->new_shard_tasks = 1;
 	}
@@ -6496,14 +6482,13 @@ non_leader:
 	}
 
 	obj_auxi->args_initialized = 1;
-
 	obj_shard_task_sched(obj_auxi, &epoch);
-	return rc;
+
+	return 0;
 
 out_task:
 	if (head != NULL && !d_list_empty(head)) {
-		D_ASSERTF(!obj_retry_error(rc), "unexpected ret "DF_RC"\n",
-			DP_RC(rc));
+		D_ASSERTF(!obj_retry_error(rc), "unexpected ret "DF_RC"\n", DP_RC(rc));
 		/* abort/complete sub-tasks will complete api_task */
 		tse_task_list_traverse(head, shard_task_abort, &rc);
 	} else {

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -2257,12 +2257,11 @@ out:
 }
 
 int
-dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch,
-		       uint32_t flags, struct dc_object *obj, daos_key_t *dkey,
-		       daos_key_t *akey, daos_recx_t *recx, daos_epoch_t *max_epoch,
-		       const uuid_t coh_uuid, const uuid_t cont_uuid,
-		       struct dtx_id *dti, unsigned int *map_ver,
-		       unsigned int req_map_ver, daos_handle_t th, tse_task_t *task)
+dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint32_t flags,
+		       uint32_t req_map_ver, uint64_t dkey_hash, struct dc_object *obj,
+		       daos_key_t *dkey, daos_key_t *akey, daos_recx_t *recx,
+		       daos_epoch_t *max_epoch, const uuid_t coh_uuid, const uuid_t cont_uuid,
+		       struct dtx_id *dti, uint32_t *map_ver, daos_handle_t th, tse_task_t *task)
 {
 	struct dc_pool			*pool = NULL;
 	struct obj_query_key_1_in	*okqi;
@@ -2270,10 +2269,7 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch,
 	struct obj_query_key_cb_args	 cb_args;
 	daos_unit_oid_t			 oid;
 	crt_endpoint_t			 tgt_ep;
-	uint64_t			 dkey_hash;
 	int				 rc;
-
-	tse_task_stack_pop_data(task, &dkey_hash, sizeof(dkey_hash));
 
 	pool = obj_shard_ptr2pool(shard);
 	if (pool == NULL)

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -535,12 +535,11 @@ int dc_obj_shard_list(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		      void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
 		      uint32_t fw_cnt, tse_task_t *task);
 
-int dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch,
-			   uint32_t flags, struct dc_object *obj,
-			   daos_key_t *dkey, daos_key_t *akey,
-			   daos_recx_t *recx, daos_epoch_t *max_epoch, const uuid_t coh_uuid,
-			   const uuid_t cont_uuid, struct dtx_id *dti,
-			   unsigned int *map_ver, unsigned int req_map_ver,
+int dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint32_t flags,
+			   uint32_t req_map_ver, uint64_t dkey_hash, struct dc_object *obj,
+			   daos_key_t *dkey, daos_key_t *akey, daos_recx_t *recx,
+			   daos_epoch_t *max_epoch, const uuid_t coh_uuid, const uuid_t cont_uuid,
+			   struct dtx_id *dti, uint32_t *map_ver,
 			   daos_handle_t th, tse_task_t *task);
 
 int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -148,6 +148,7 @@ dc_obj_query_key_task_create(daos_handle_t oh, daos_handle_t th,
 	args->dkey	= dkey;
 	args->akey	= akey;
 	args->recx	= recx;
+	args->max_epoch = NULL;
 
 	return 0;
 }


### PR DESCRIPTION
For dc_array_get_size/dc_array_stat, if some failure happened after registering cleanup (to free memory and drop reference) callback, then the cleanup logic may be triggered repeatedly by both task complete callback and current task sponsor.

Other fixes:

Drop tse_task_stack_{push,pop}_data for shard_query_key_task().

Remove redundant logic for obj_retry_cb().

Signed-off-by: Fan Yong <fan.yong@intel.com>