### PR TITLE
DAOS-11658 rebuild: few fixes about EC parity rotation rebuild.

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -472,7 +472,7 @@ obj_grp_valid_shard_get(struct dc_object *obj, int grp_idx,
 	D_ASSERT(grp_size >= obj_get_replicas(obj));
 	grp_start = grp_idx * grp_size;
 	idx = grp_start + d_rand() % grp_size;
-	for (i = 0; i < grp_size; i++, idx++) {
+	for (i = 0; i < obj_get_replicas(obj); i++, idx++) {
 		uint32_t tgt_id;
 		int index;
 
@@ -1720,7 +1720,7 @@ obj_shard_is_invalid(struct dc_object *obj, uint32_t shard_idx, uint32_t opc)
  * 1: alive,  0: no alive  < 0: failure.
  */
 int
-obj_ec_parity_alive(daos_handle_t oh, uint64_t dkey_hash)
+obj_ec_parity_alive(daos_handle_t oh, uint64_t dkey_hash, uint32_t *shard)
 {
 	struct daos_oclass_attr *oca;
 	struct dc_object	*obj;
@@ -1743,14 +1743,15 @@ obj_ec_parity_alive(daos_handle_t oh, uint64_t dkey_hash)
 	oca = obj_get_oca(obj);
 	p_shard = obj_ec_parity_start(obj_ec_dkey_hash_get(obj, dkey_hash), oca);
 	for (i = 0; i < obj_ec_parity_tgt_nr(oca); i++, p_shard++) {
-		uint32_t shard;
-
-		shard = p_shard % obj_get_grp_size(obj) + grp_idx * obj_get_grp_size(obj);
-		D_DEBUG(DB_TRACE, "shard %u %d/%d/%d\n", shard,
-			obj->cob_shards->do_shards[shard].do_rebuilding,
-			obj->cob_shards->do_shards[shard].do_target_id,
-			obj->cob_shards->do_shards[shard].do_shard);
-		if (!obj_shard_is_invalid(obj, shard, DAOS_OBJ_RPC_FETCH))
+		*shard = p_shard % obj_get_grp_size(obj) + grp_idx * obj_get_grp_size(obj);
+		D_DEBUG(DB_TRACE, "shard %u %d/%d/%d/%d/%d\n", *shard,
+			obj->cob_shards->do_shards[*shard].do_rebuilding,
+			obj->cob_shards->do_shards[*shard].do_reintegrating,
+			obj->cob_shards->do_shards[*shard].do_target_id,
+			obj->cob_shards->do_shards[*shard].do_shard,
+			obj->cob_shards->do_shards[*shard].do_shard_idx);
+		if (!obj_shard_is_invalid(obj, *shard, DAOS_OBJ_RPC_FETCH) &&
+		    !obj->cob_shards->do_shards[*shard].do_reintegrating)
 			D_GOTO(out_put, rc = 1);
 	}
 
@@ -5912,7 +5913,7 @@ obj_list_shards_get(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 	    daos_anchor_get_flags(args->dkey_anchor) & DIOF_TO_SPEC_GROUP) {
 		*shard = dc_obj_anchor2shard(args->dkey_anchor);
 		obj_auxi->spec_group = 1;
-		grp_idx = *shard / obj_get_grp_size(obj);
+		grp_idx = *shard / obj_get_replicas(obj);
 	} else {
 		if (args->dkey != NULL) {
 			grp_idx = obj_dkey2grpidx(obj, obj_auxi->dkey_hash, map_ver);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -575,7 +575,7 @@ obj_ec_encode_buf(daos_obj_id_t oid, struct daos_oclass_attr *oca,
 		  unsigned char *p_bufs[]);
 
 int
-obj_ec_parity_alive(daos_handle_t oh, uint64_t dkey_hash);
+obj_ec_parity_alive(daos_handle_t oh, uint64_t dkey_hash, uint32_t *shard);
 
 static inline struct pl_obj_shard*
 obj_get_shard(void *data, int idx)

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1521,6 +1521,9 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 		D_GOTO(obj_close, rc);
 	}
 
+	if (DAOS_FAIL_CHECK(DAOS_REBUILD_UPDATE_FAIL))
+		D_GOTO(obj_close, rc = -DER_INVAL);
+
 	if (mrone->mo_iods[0].iod_type == DAOS_IOD_SINGLE)
 		rc = migrate_fetch_update_single(mrone, oh, cont);
 	else if (obj_shard_is_ec_parity(mrone->mo_oid, mrone->mo_dkey_hash,
@@ -2187,7 +2190,10 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	uint32_t		shard = arg->arg->shard;
 	struct migrate_one	*mo;
 	bool			merged = false;
+	bool			create_migrate_one = false;
 	int			rc = 0;
+	struct migrate_pool_tls *tls;
+	uint32_t		parity_shard;
 	int			i;
 
 	if (!daos_oclass_is_ec(&arg->oc_attr))
@@ -2197,29 +2203,41 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	 * If parity shard alive for this dkey, then ignore the data shard enumeration
 	 * from data shard.
 	 */
-	rc = obj_ec_parity_alive(arg->oh, io->ui_dkey_hash);
+	rc = obj_ec_parity_alive(arg->oh, io->ui_dkey_hash, &parity_shard);
 	if (rc < 0)
 		return rc;
+
+	tls = migrate_pool_tls_lookup(arg->arg->pool_uuid, arg->arg->version);
+	if (tls == NULL || tls->mpt_fini) {
+		D_WARN("some one abort the rebuild "DF_UUID"\n",
+		       DP_UUID(arg->arg->pool_uuid));
+		return 0;
+	}
 
 	if (!arg->ec_rotate_parity)
 		io->ui_dkey_hash = 0;
 
-	if (rc == 1 &&
-	    is_ec_data_shard(io->ui_oid.id_shard, io->ui_dkey_hash, &arg->oc_attr)) {
-		D_DEBUG(DB_REBUILD, DF_UOID" ignore data shard "DF_KEY"/%u/"DF_U64".\n",
+	if ((rc == 1 &&
+	     (is_ec_data_shard(io->ui_oid.id_shard, io->ui_dkey_hash, &arg->oc_attr) ||
+	      (arg->ec_rotate_parity && io->ui_oid.id_shard != parity_shard))) ||
+	    (tls->mpt_opc == RB_OP_FAIL && io->ui_oid.id_shard == shard)) {
+		D_DEBUG(DB_REBUILD, DF_UOID" ignore shard "DF_KEY"/%u/"DF_U64".\n",
 			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
 			obj_ec_shard_off(io->ui_dkey_hash, &arg->oc_attr, 0));
-		return 0;
+		D_GOTO(put, rc = 0);
 	}
 	rc = 0;
 
 	/* Convert EC object offset to DAOS offset. */
-	for (i = 0; i <= io->ui_iods_top; i++) {
+	for (i = 0; i <= io->ui_iods_top && io->ui_dkey_punch_eph == 0 &&
+	     io->ui_obj_punch_eph == 0; i++) {
 		daos_iod_t	*iod = &io->ui_iods[i];
 		daos_epoch_t	**ephs = &io->ui_recx_ephs[i];
 
-		if (iod->iod_type == DAOS_IOD_SINGLE)
+		if (iod->iod_type == DAOS_IOD_SINGLE || io->ui_akey_punch_ephs[i] != 0) {
+			create_migrate_one = true;
 			continue;
+		}
 
 		D_DEBUG(DB_REBUILD, DF_UOID" unpack for shard %u start EC "DF_U64"/"DF_X64"\n",
 			DP_UOID(io->ui_oid), shard,
@@ -2227,7 +2245,7 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 
 		/**
 		 * Since we do not need split the rebuild into parity rebuild
-		 * (by mo_iods_from_parity) and partial updatei(by mo_iods),
+		 * (by mo_iods_from_parity) and partial update(by mo_iods),
 		 * so it does not need keep the PARITY BIT in recx, see rw_iod_pack().
 		 */
 		rc = obj_recx_ec2_daos(&arg->oc_attr, io->ui_dkey_hash, io->ui_oid.id_shard,
@@ -2235,7 +2253,7 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 		if (rc != 0) {
 			D_ERROR(DF_UOID" ec 2 daos %u failed: "DF_RC"\n",
 				DP_UOID(io->ui_oid), shard, DP_RC(rc));
-			return rc;
+			D_GOTO(put, rc);
 		}
 
 		/* Filter the DAOS recxs to the rebuild data shard */
@@ -2249,12 +2267,18 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 			if (rc) {
 				D_ERROR(DF_UOID" daos to shard %u failed: "DF_RC"\n",
 					DP_UOID(io->ui_oid), shard, DP_RC(rc));
-				return rc;
+				D_GOTO(put, rc);
 			}
-			/* No data needs to be migrate. */
-			if (iod->iod_nr == 0)
-				continue;
 		}
+
+		if (iod->iod_nr > 0)
+			create_migrate_one = true;
+	}
+
+	if (!create_migrate_one) {
+		D_DEBUG(DB_REBUILD, DF_UOID"/"DF_KEY" does not need rebuild.\n",
+			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey));
+		D_GOTO(put, rc = 0);
 	}
 
 	/* Check if some IODs from this unpack can be merged to the exist mrone, mostly for EC
@@ -2268,7 +2292,7 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 		    daos_key_match(&mo->mo_dkey, &io->ui_dkey)) {
 			rc = migrate_try_merge_recx(mo, io);
 			if (rc < 0)
-				return rc;
+				D_GOTO(put, rc);
 
 			if (rc == 0)
 				merged = true; /* merged all recxs already */
@@ -2281,7 +2305,8 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 
 	if (!merged)
 		rc = migrate_one_create(arg, io);
-
+put:
+	migrate_pool_tls_put(tls);
 	return rc;
 }
 
@@ -2395,6 +2420,7 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	daos_handle_t		 poh = DAOS_HDL_INVAL;
 	daos_handle_t		 coh = DAOS_HDL_INVAL;
 	daos_handle_t		 oh  = DAOS_HDL_INVAL;
+	uint32_t		 minimum_nr;
 	uint32_t		 num;
 	int			 rc1;
 	int			 rc = 0;
@@ -2423,7 +2449,10 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 		D_GOTO(out_pool, rc);
 	}
 
-	rc = dsc_obj_open(coh, arg->oid.id_pub, DAOS_OO_RO, &oh);
+	/* Only open with RW flag, reintegrating flag will be set, which is needed
+	 * during unpack_cb to check if parity shard alive.
+	 */
+	rc = dsc_obj_open(coh, arg->oid.id_pub, DAOS_OO_RW, &oh);
 	if (rc) {
 		D_ERROR("dsc_obj_open failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out_cont, rc);
@@ -2452,7 +2481,13 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 
 	if (daos_oclass_is_ec(&unpack_arg.oc_attr)) {
 		p_csum = NULL;
+		/* EC rotate needs to fetch from all shards */
+		if (unpack_arg.ec_rotate_parity)
+			minimum_nr = obj_ec_tgt_nr(&unpack_arg.oc_attr);
+		else
+			minimum_nr = 2;
 	} else {
+		minimum_nr = 2;
 		p_csum = &csum;
 		d_iov_set(&csum, stack_csum_buf, CSUM_BUF_SIZE);
 	}
@@ -2560,7 +2595,7 @@ retry:
 		}
 
 		/* Each object enumeration RPC will at least one OID */
-		if (num < 2) {
+		if (num <= minimum_nr) {
 			D_DEBUG(DB_REBUILD, "enumeration buffer %u empty"
 				DF_UOID"\n", num, DP_UOID(arg->oid));
 			break;
@@ -2654,8 +2689,10 @@ ds_migrate_stop(struct ds_pool *pool, unsigned int version)
 	int			 rc;
 
 	tls = migrate_pool_tls_lookup(pool->sp_uuid, version);
-	if (tls == NULL)
+	if (tls == NULL) {
+		D_INFO(DF_UUID" migrate stopped\n", DP_UUID(pool->sp_uuid));
 		return;
+	}
 
 	uuid_copy(arg.pool_uuid, pool->sp_uuid);
 	arg.version = version;

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -65,10 +65,7 @@ struct rebuild_tgt_pool_tracker {
 	 * can be go ahead to finish the rebuild.
 	 */
 	ABT_cond		rt_fini_cond;
-	/* Notify others the rebuild of this pool has been
-	 * done on this target.
-	 */
-	ABT_cond		rt_done_cond;
+
 	/* # to-be-rebuilt objs */
 	uint64_t		rt_reported_toberb_objs;
 	/* reported # rebuilt objs */

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -212,6 +212,7 @@ rpt_lookup(uuid_t pool_uuid, unsigned int ver, unsigned int gen)
 	/* Only stream 0 will access the list */
 	d_list_for_each_entry(rpt, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
 		if (uuid_compare(rpt->rt_pool_uuid, pool_uuid) == 0 &&
+		    rpt->rt_finishing == 0 &&
 		    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
 		    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen)) {
 			rpt_get(rpt);
@@ -1000,9 +1001,6 @@ rpt_destroy(struct rebuild_tgt_pool_tracker *rpt)
 	if (rpt->rt_fini_cond)
 		ABT_cond_free(&rpt->rt_fini_cond);
 
-	if (rpt->rt_done_cond)
-		ABT_cond_free(&rpt->rt_done_cond);
-
 	D_FREE(rpt);
 }
 
@@ -1229,23 +1227,24 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
 		if (task->dst_rebuild_op == RB_OP_RECLAIM) {
 			rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-						 rgt->rgt_reclaim_epoch, &task->dst_tgts,
+						 rgt->rgt_stable_epoch, &task->dst_tgts,
 						 RB_OP_RECLAIM, 5);
 			return rc;
 		}
 
-		/* Schedule reclaim to clean up current op. Let's keep go ahead to retry even if
-		 * reclaim the current rebuilding fails.
-		 */
-		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-					 rgt->rgt_reclaim_epoch, &task->dst_tgts, RB_OP_RECLAIM, 5);
-		if (rc)
-			D_ERROR(DF_UUID "schedule reclaim fail: "DF_RC"\n",
-				DP_UUID(task->dst_pool_uuid), DP_RC(rc));
-
+		/* Schedule reclaim to clean up current op, if scan/migrate already start */
+		if (rgt->rgt_init_scan) {
+			rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
+						 rgt->rgt_stable_epoch, &task->dst_tgts,
+						 RB_OP_RECLAIM, 5);
+			if (rc)
+				D_ERROR(DF_UUID "schedule reclaim fail: "DF_RC"\n",
+					DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+			/* Let's keep go ahead to retry anyway. */
+		}
 		/* Then retry */
 		rc = ds_rebuild_schedule(pool, task->dst_map_ver, ++task->dst_rebuild_gen,
-					 rgt->rgt_reclaim_epoch, &task->dst_tgts,
+					 rgt->rgt_stable_epoch, &task->dst_tgts,
 					 task->dst_rebuild_op, 5);
 	} else if (task->dst_rebuild_op == RB_OP_REINT || task->dst_rebuild_op == RB_OP_EXTEND) {
 		/* Otherwise schedule reclaim for reintegrate/extend/upgrade. */
@@ -1513,27 +1512,6 @@ rebuild_ults(void *arg)
 	ABT_mutex_unlock(rebuild_gst.rg_lock);
 }
 
-static void
-rpt_abort(struct rebuild_tgt_pool_tracker *rpt)
-{
-	/* If it can find rpt, it means rebuild has not finished yet
-	 * on this target, so the rpt has to been hold by someone
-	 * else, so it is safe to use rpt after rpt_put().
-	 *
-	 * And we have to do rpt_put(), otherwise it will hold
-	 * rebuild_tgt_fini().
-	 */
-	D_ASSERT(rpt->rt_refcount > 1);
-
-	rpt->rt_abort = 1;
-	/* Since the rpt will be destroyed after signal rt_done_cond,
-	 * so we have to use another lock here.
-	 */
-	ABT_mutex_lock(rebuild_gst.rg_lock);
-	ABT_cond_wait(rpt->rt_done_cond, rebuild_gst.rg_lock);
-	ABT_mutex_unlock(rebuild_gst.rg_lock);
-}
-
 void
 ds_rebuild_abort(uuid_t pool_uuid, unsigned int ver, unsigned int gen, uint64_t term)
 {
@@ -1543,13 +1521,26 @@ ds_rebuild_abort(uuid_t pool_uuid, unsigned int ver, unsigned int gen, uint64_t 
 	rebuild_leader_stop(pool_uuid, ver, gen, term);
 
 	/* Only stream 0 will access the list */
-	d_list_for_each_entry_safe(rpt, tmp, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
-		if (uuid_compare(rpt->rt_pool_uuid, pool_uuid) == 0 &&
-		    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
-		    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen) &&
-		    (term == (uint64_t)(-1) || rpt->rt_leader_term == term))
-			rpt_abort(rpt);
+	while(1) {
+		bool aborted = true;
+
+		d_list_for_each_entry_safe(rpt, tmp, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
+			if (uuid_compare(rpt->rt_pool_uuid, pool_uuid) == 0 &&
+			    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
+			    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen) &&
+			    (term == (uint64_t)(-1) || rpt->rt_leader_term == term)) {
+				rpt->rt_abort = 1;
+				aborted = false;
+			}
+		}
+
+		if (aborted)
+			break;
+
+		dss_sleep(1000);
+		D_INFO(DF_UUID" wait for rebuild abort.\n", DP_UUID(pool_uuid));
 	}
+	D_INFO(DF_UUID" rebuild aborted\n", DP_UUID(pool_uuid));
 }
 
 static void
@@ -1562,9 +1553,7 @@ rgt_leader_stop(struct rebuild_global_pool_tracker *rgt)
 
 	/* Remove it from the rgt list to avoid stopping rgt duplicately */
 	d_list_del(&rgt->rgt_list);
-	/* Since the rpt will be destroyed after signal rt_done_cond,
-	 * so we have to use another lock here.
-	 */
+
 	ABT_mutex_lock(rgt->rgt_lock);
 	ABT_cond_wait(rgt->rgt_done_cond, rgt->rgt_lock);
 	ABT_mutex_unlock(rgt->rgt_lock);
@@ -1891,8 +1880,8 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	struct rebuild_pool_tls	*pool_tls;
 	int			 rc;
 
-	D_DEBUG(DB_REBUILD, "Finalize rebuild for "DF_UUID", map_ver=%u\n",
-		DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver);
+	D_INFO("finishing rebuild for "DF_UUID", map_ver=%u refcount %u\n",
+	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver, rpt->rt_refcount);
 
 	if (rpt->rt_rebuild_op == RB_OP_REINT) {
 		D_ASSERT(rpt->rt_pool->sp_reintegrating > 0);
@@ -1900,7 +1889,6 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	}
 	ABT_mutex_lock(rpt->rt_lock);
 	D_ASSERT(rpt->rt_refcount > 0);
-	d_list_del_init(&rpt->rt_list);
 	rpt->rt_finishing = 1;
 	/* Wait until all ult/tasks finish and release the rpt.
 	 * NB: Because rebuild_tgt_fini will be only called in
@@ -1925,15 +1913,14 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 
 	/* destroy the migrate_tls of 0-xstream */
 	ds_migrate_stop(rpt->rt_pool, rpt->rt_rebuild_ver);
+	d_list_del_init(&rpt->rt_list);
 	rpt_put(rpt);
 	/* No one should access rpt after rebuild_fini_one.
 	 */
 	D_ASSERT(rpt->rt_refcount == 0);
 
-	/* Notify anyone who is waiting for the rebuild to finish */
-	ABT_mutex_lock(rebuild_gst.rg_lock);
-	ABT_cond_signal(rpt->rt_done_cond);
-	ABT_mutex_unlock(rebuild_gst.rg_lock);
+	D_INFO("Finalized rebuild for "DF_UUID", map_ver=%u.\n",
+	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver);
 
 	rpt_destroy(rpt);
 
@@ -2071,11 +2058,11 @@ rebuild_tgt_status_check_ult(void *arg)
 
 		D_INFO("ver %d obj "DF_U64" rec "DF_U64" size "
 			DF_U64" scan done %d pull done %d scan gl done %d"
-			" gl done %d status %d\n",
+			" gl done %d abort %u status %d\n",
 			rpt->rt_rebuild_ver, iv.riv_obj_count,
 			iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done,
 			iv.riv_pull_done, rpt->rt_global_scan_done,
-			rpt->rt_global_done, iv.riv_status);
+			rpt->rt_global_done, rpt->rt_abort, iv.riv_status);
 
 		if (rpt->rt_global_done || rpt->rt_abort)
 			break;
@@ -2149,10 +2136,6 @@ rpt_create(struct ds_pool *pool, uint32_t master_rank, uint32_t pm_ver,
 		D_GOTO(free, rc = dss_abterr2der(rc));
 
 	rc = ABT_cond_create(&rpt->rt_fini_cond);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(free, rc = dss_abterr2der(rc));
-
-	rc = ABT_cond_create(&rpt->rt_done_cond);
 	if (rc != ABT_SUCCESS)
 		D_GOTO(free, rc = dss_abterr2der(rc));
 

--- a/src/tests/ftest/daos_test/rebuild.py
+++ b/src/tests/ftest/daos_test/rebuild.py
@@ -269,3 +269,19 @@ class DaosCoreTestRebuild(DaosCoreBase):
         :avocado: tags=daos_test,daos_core_test_rebuild,test_rebuild_29
         """
         self.run_subtest()
+
+    def test_rebuild_30(self):
+        """Jira ID: DAOS-2770
+
+        Test Description:
+            Run daos_test -r -s5 -u subtests=30
+
+        Use cases:
+            Core tests for daos_test rebuild
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=unittest
+        :avocado: tags=daos_test,daos_core_test_rebuild,test_rebuild_30
+        """
+        self.run_subtest()

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -73,6 +73,7 @@ daos_tests:
     test_rebuild_27: DAOS_Rebuild_27
     test_rebuild_28: DAOS_Rebuild_28
     test_rebuild_29: DAOS_Rebuild_29
+    test_rebuild_30: DAOS_Rebuild_30
   daos_test:
     test_rebuild_0to10: r
     test_rebuild_12to15: r
@@ -90,6 +91,7 @@ daos_tests:
     test_rebuild_27: r
     test_rebuild_28: r
     test_rebuild_29: r
+    test_rebuild_30: r
   args:
     test_rebuild_0to10: -s3 -u subtests="0-10"
     test_rebuild_12to15: -s3 -u subtests="12-15"
@@ -107,6 +109,7 @@ daos_tests:
     test_rebuild_27: -s6 -u subtests="27"
     test_rebuild_28: -s3 -u subtests="28"
     test_rebuild_29: -s5 -u subtests="29"
+    test_rebuild_30: -s5 -u subtests="30"
   stopped_ranks:
     test_rebuild_26: ["random"]
     test_rebuild_27: ["random"]

--- a/src/tests/ftest/erasurecode/multiple_failure.py
+++ b/src/tests/ftest/erasurecode/multiple_failure.py
@@ -1,11 +1,10 @@
-#!/usr/bin/python
 '''
   (C) Copyright 2021-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeIor
-from apricot import skipForTicket
+
 
 class EcodOnlineMultFail(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -20,7 +19,6 @@ class EcodOnlineMultFail(ErasureCodeIor):
         super().__init__(*args, **kwargs)
         self.set_online_rebuild = True
 
-    @skipForTicket("DAOS-9051")
     def run_ior_cascade_failure(self):
         """Common function to Write and Read IOR"""
         # Write IOR data set with different EC object. kill rank, targets or mix of both while IOR
@@ -35,7 +33,6 @@ class EcodOnlineMultFail(ErasureCodeIor):
         # intact and no data corruption observed.
         self.ior_read_dataset(parity=2)
 
-    @skipForTicket("DAOS-9051")
     def test_ec_multiple_rank_failure(self):
         """Jira ID: DAOS-7344.
 
@@ -45,9 +42,9 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_multiple_rank_failure
+        :avocado: tags=test_ec_multiple_rank_failure
         """
         # Kill Two server ranks
         self.rank_to_kill = [self.server_count - 1, self.server_count - 3]
@@ -62,9 +59,9 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_multiple_target_on_same_rank_failure
+        :avocado: tags=test_ec_multiple_targets_on_same_rank
         """
         # Kill Two targets 2,4 from same rank 2
         self.pool_exclude[2] = "2,4"
@@ -79,16 +76,15 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_multiple_rank_on_diff_target_failure
+        :avocado: tags=test_ec_multiple_targets_on_diff_ranks
         """
         # Kill Two targets from different ranks
         self.pool_exclude[2] = "2"
         self.pool_exclude[3] = "3"
         self.run_ior_cascade_failure()
 
-    @skipForTicket("DAOS-9051")
     def test_ec_single_target_rank_failure(self):
         """Jira ID: DAOS-7344.
 
@@ -98,9 +94,9 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_single_target_rank_failure
+        :avocado: tags=test_ec_single_target_rank_failure
         """
         # Kill One server rank
         self.rank_to_kill = [self.server_count - 1]

--- a/src/tests/ftest/erasurecode/online_rebuild.py
+++ b/src/tests/ftest/erasurecode/online_rebuild.py
@@ -1,11 +1,10 @@
-#!/usr/bin/python
 '''
   (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeIor
-from apricot import skipForTicket
+
 
 class EcodOnlineRebuild(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -20,7 +19,6 @@ class EcodOnlineRebuild(ErasureCodeIor):
         super().__init__(*args, **kwargs)
         self.set_online_rebuild = True
 
-    @skipForTicket("DAOS-9051")
     def test_ec_online_rebuild(self):
         """Jira ID: DAOS-5894.
 
@@ -31,9 +29,9 @@ class EcodOnlineRebuild(ErasureCodeIor):
                   verify all IOR write finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild
-        :avocado: tags=ec_online_rebuild_array
+        :avocado: tags=test_ec_online_rebuild_array
         """
         # Kill last server rank
         self.rank_to_kill = [self.server_count - 1]

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -370,6 +370,8 @@ rebuild_destroy_pool_cb(void *data)
 
 	rebuild_pool_disconnect_internal(data);
 
+	print_message("sleep 20 seconds to make rebuild ready\n");
+	sleep(20);
 	if (arg->myrank == 0) {
 		/* Disable fail_loc and start rebuild */
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -384,8 +386,7 @@ rebuild_destroy_pool_cb(void *data)
 	}
 
 	arg->pool.destroyed = true;
-	print_message("pool destroyed "DF_UUIDF"\n",
-		      DP_UUID(arg->pool.pool_uuid));
+	print_message("pool destroyed "DF_UUIDF"\n", DP_UUID(arg->pool.pool_uuid));
 
 	par_barrier(PAR_COMM_WORLD);
 
@@ -1342,6 +1343,13 @@ rebuild_kill_PS_leader_during_rebuild(void **state)
 	reintegrate_single_pool_rank(arg, leader, true);
 }
 
+static void
+rebuild_pool_destroy_during_rebuild_failure(void **state)
+{
+	return rebuild_destroy_pool_internal(state, DAOS_REBUILD_UPDATE_FAIL |
+						    DAOS_FAIL_ALWAYS);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: drop rebuild scan reply",
@@ -1417,6 +1425,9 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_sub_teardown},
 	{"REBUILD29: rebuild kill PS leader during rebuild",
 	 rebuild_kill_PS_leader_during_rebuild, rebuild_sub_setup,
+	 rebuild_sub_teardown},
+	{"REBUILD30: destroy pool during rebuild failure and retry",
+	  rebuild_pool_destroy_during_rebuild_failure, rebuild_sub_setup,
 	 rebuild_sub_teardown},
 };
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -968,12 +968,13 @@ io_obj_cache_test(void **state)
 	rc = vos_obj_discard_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &obj1);
 	assert_rc_equal(rc, 0);
 	/** Should be prevented because object olready held for discard */
-	expect_assert_failure(vos_obj_discard_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0],
-						   &obj2));
+	rc = vos_obj_discard_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &obj2);
+	assert_rc_equal(rc, -DER_UPDATE_AGAIN);
 	/** Should prevent simultaneous hold for create as well */
-	expect_assert_failure(vos_obj_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &epr, 0,
+	rc = vos_obj_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &epr, 0,
 					   VOS_OBJ_CREATE | VOS_OBJ_VISIBLE, DAOS_INTENT_DEFAULT,
-					   &obj2, 0));
+					   &obj2, 0);
+	assert_rc_equal(rc, -DER_UPDATE_AGAIN);
 
 	/** Need to be able to hold for read though or iteration won't work */
 	rc = vos_obj_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &epr, 0,

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -404,8 +404,9 @@ check_object:
 	if (obj->obj_discard && (create || (flags & VOS_OBJ_DISCARD) != 0)) {
 		/** Cleanup before assert so unit test that triggers doesn't corrupt the state */
 		vos_obj_release(occ, obj, false);
-		D_ASSERTF(0, "Simultaneous object hold and discard detected\n");
-		goto failed;
+		/* Update request will retry with this error */
+		rc = -DER_UPDATE_AGAIN;
+		goto failed_2;
 	}
 
 	if ((flags & VOS_OBJ_DISCARD) || intent == DAOS_INTENT_KILL || intent == DAOS_INTENT_PUNCH)


### PR DESCRIPTION
Remove assertion is vos_obj_hold(), instead of assertion for
inflight update request during discarding, let's return DER_UPDATE_BUSY,
which make client retry update.

Set minimum number for EC rotate object enumeration to avoid endless
enumeration during cascading failure case.

Use stable epoch to discard those rebuild failure objects. And
reclaim epoch will only be used for reintegration cleanup.

skip the empty IOD during migration to avoid creating
too much ULT.

Open object with RW mode during migrating, so reintegrating
flags can be set.

Fix grp size in valid shard get for OSA.

Remove done_cond from rpt, which is used to notify
rebuild_abort() when the current rebuild finish. But
rpt might be destroyed once notify others, which can
cause unexpected scenarios, so let's not use done_cond,
instead it checks the rebuild list until the current
rpt is removed from the running list.

Add the test to verify it.

Add a few extra DINFO message for rebuild abort.

Removed ib2 tag.

Removing skipForTicket decorator for tests being skipped by a resolved
ticket.

Required-githooks: true
Features: rebuild daos_core_test_rebuild
Test-tag: pr rebuild ec_ior_hard_online_rebuild pool_create_all_one_hw multiple_failure create_max_pool_scm_only ec_multiple_failure test_ec_online_rebuild_array
Signed-off-by: Di Wang <di.wang@intel.com>
Signed-off-by: Phil Henderson <phillip.henderson@intel.com>