### PR TITLE
DAOS-10339 pool: Fix pool creation drpc response

### DIFF
--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -61,12 +61,18 @@ class ListVerboseTest(IorTestBase):
             "targets") * rank_count
         # self.log.debug("## targets_total = {}".format(targets_total))
 
+        p_query = self.get_dmg_command().pool_query(pool.identifier)
+        pool_layout_ver = p_query["response"]["pool_layout_ver"]
+        upgrade_layout_ver = p_query["response"]["upgrade_layout_ver"]
+
         return {
             "uuid": pool.uuid.lower(),
             "label": pool.label.value,
             "svc_reps": pool.svc_ranks,
             "targets_total": targets_total,
             "targets_disabled": targets_disabled,
+            "upgrade_layout_ver": upgrade_layout_ver,
+            "pool_layout_ver": pool_layout_ver,
             "query_error_msg": "",
             "query_status_msg": "",
             "state": "Ready",


### PR DESCRIPTION
Add missing pool's fields "upgrade_layout_ver" and "pool_layout_ver". These new fields where introduced with the commit 2ff935a57a.  More details could be found at
https://github.com/daos-stack/daos/pull/8864/commits

Quick-Functional: true
Test-tag: list_verbose
Test-repeat: 20
Required-githooks: true

Signed-off-by: Cedric Koch-Hofer <cedric.koch-hofer@intel.com>