### PR TITLE
DAOS-11685 dtx: handle DTX abort by race

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -713,8 +713,10 @@ dtx_shares_fini(struct dtx_handle *dth)
 int
 dtx_handle_reinit(struct dtx_handle *dth)
 {
-	D_ASSERT(dth->dth_ent == NULL);
-	D_ASSERT(dth->dth_pinned == 0);
+	if (dth->dth_modification_cnt > 0) {
+		D_ASSERT(dth->dth_ent != NULL);
+		D_ASSERT(dth->dth_pinned != 0);
+	}
 	D_ASSERT(dth->dth_already == 0);
 
 	dth->dth_modify_shared = 0;
@@ -1268,7 +1270,7 @@ abort:
 	 */
 	if (unpin || (result < 0 && result != -DER_AGAIN && !dth->dth_solo)) {
 		/* Drop partial modification for distributed transaction. */
-		vos_dtx_cleanup(dth);
+		vos_dtx_cleanup(dth, true);
 		dtx_abort(cont, &dth->dth_dte, dth->dth_epoch);
 		aborted = true;
 	}
@@ -1276,7 +1278,7 @@ abort:
 out:
 	if (!daos_is_zero_dti(&dth->dth_xid)) {
 		if (result < 0 && !aborted)
-			vos_dtx_cleanup(dth);
+			vos_dtx_cleanup(dth, true);
 
 		vos_dtx_rsrvd_fini(dth);
 		vos_dtx_detach(dth);
@@ -1400,7 +1402,7 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 		/* 1. Drop partial modification for distributed transaction.
 		 * 2. Remove the pinned DTX entry.
 		 */
-		vos_dtx_cleanup(dth);
+		vos_dtx_cleanup(dth, true);
 	}
 
 	D_DEBUG(DB_IO,

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1142,9 +1142,13 @@ dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
 	if (rc == 0) {
 		D_ASSERT(dth->dth_share_tbd_count == 0);
 
-		vos_dtx_cleanup(dth);
-		dtx_handle_reinit(dth);
-		rc = -DER_AGAIN;
+		if (dth->dth_aborted) {
+			rc = -DER_CANCELED;
+		} else {
+			vos_dtx_cleanup(dth, false);
+			dtx_handle_reinit(dth);
+			rc = -DER_AGAIN;
+		}
 	}
 
 	return rc;

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -195,9 +195,10 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint);
  * Cleanup local DTX when local modification failed.
  *
  * \param dth	[IN]	The DTX handle.
+ * \param unpin	[IN]	unpin the DTX entry or not.
  */
 void
-vos_dtx_cleanup(struct dtx_handle *dth);
+vos_dtx_cleanup(struct dtx_handle *dth, bool unpin);
 
 /**
  * Reset DTX related cached information in VOS.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1690,6 +1690,10 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 post:
 	rc = bio_iod_post(biod, rc);
 out:
+	/* The DTX has been aborted during long time bulk data transfer. */
+	if (unlikely(dth->dth_aborted))
+		rc = -DER_CANCELED;
+
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.
 	 */
@@ -4098,6 +4102,10 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			goto out;
 		}
 	}
+
+	/* The DTX has been aborted during long time bulk data transfer. */
+	if (unlikely(dth->dth_aborted))
+		D_GOTO(out, rc = -DER_CANCELED);
 
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2153,8 +2153,11 @@ vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 
 			dae->dae_dth = NULL;
 			dth->dth_aborted = 1;
-			dtx_act_ent_cleanup(cont, dae, dth, true);
 			dth->dth_ent = NULL;
+			/*
+			 * dtx_act_ent_cleanup() will be triggered via vos_dtx_post_handle()
+			 * when remove the DTX entry from active DTX table.
+			 */
 		}
 	}
 
@@ -2713,6 +2716,9 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 			}
 		} else {
 			dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+			if (dth->dth_ent != NULL)
+				D_ASSERT(dth->dth_ent == dae);
+
 			/* Cannot cleanup 'committed' DTX entry. */
 			if (dae->dae_committable || dae->dae_committed)
 				goto out;
@@ -2737,7 +2743,7 @@ out:
 }
 
 void
-vos_dtx_cleanup(struct dtx_handle *dth)
+vos_dtx_cleanup(struct dtx_handle *dth, bool unpin)
 {
 	struct vos_dtx_act_ent	*dae;
 	struct vos_container	*cont;
@@ -2757,7 +2763,9 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 			return;
 	}
 
-	dth->dth_pinned = 0;
+	if (unpin)
+		dth->dth_pinned = 0;
+
 	cont = vos_hdl2cont(dth->dth_coh);
 	/** This will abort the transaction and callback to
 	 *  vos_dtx_cleanup_internal


### PR DESCRIPTION
It is possible that some DTX on non-leader is blocked by long time bulk data transfer or DTX refresh, as to related RPC from DTX leader to non-leader for current operation get timeout, and then the DTX may be aborted by the DTX leader before current DTX complete on the non-leader locally. Under such case, the non-leader should break the operation for current DTX.

Signed-off-by: Fan Yong <fan.yong@intel.com>