### PR TITLE
DAOS-623 common: Fix for/while loop in common/policy. (#10391)

### DIFF
--- a/src/common/policy.c
+++ b/src/common/policy.c
@@ -87,7 +87,7 @@ daos_policy_try_parse(const char *policy_str, struct policy_desc_t *out_pd)
 	int		param_idx = POLICY_BAD_PARAM;
 	int		tok_len = 0;
 	bool		ret_val = false;
-	int		i, j;
+	int              i;
 	size_t		len;
 	char		*str, *orig_str;
 	unsigned int	policy_idx = DAOS_MEDIA_POLICY_MAX;
@@ -107,10 +107,8 @@ daos_policy_try_parse(const char *policy_str, struct policy_desc_t *out_pd)
 		/* tokenize left and right items of "name=value" */
 		str2 = tok;
 
-		for (j = 0; ; j++, str2 = NULL) {
-			tok = strtok_r(str2, delim2, &saveptr2);
-			if (tok == NULL)
-				break;
+		while ((tok = strtok_r(str2, delim2, &saveptr2)) != NULL) {
+			str2 = NULL;
 
 			tok_len = strlen(tok);
 

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -2246,7 +2246,6 @@ test_enumerate_object(void **state)
 	struct dcs_csum_info	*csum_info = NULL;
 	void			*end_byte;
 	daos_key_desc_t		*kds = NULL;
-	uint32_t		 csum_count = 0;
 	uint32_t		 nr;
 	int			 rc;
 	char			 dkey[32];
@@ -2364,7 +2363,6 @@ test_enumerate_object(void **state)
 		tmp_csum_iov.iov_buf += ci_size(*csum_info);
 		tmp_csum_iov.iov_buf_len -= ci_size(*csum_info);
 		tmp_csum_iov.iov_len -= ci_size(*csum_info);
-		csum_count++;
 	}
 
 

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -667,8 +667,8 @@ co_acl(void **state)
 	daos_prop_t		*prop_in;
 	daos_pool_info_t	 info = {0};
 	int			 rc;
-	const char		*exp_owner = "fictionaluser@";
-	const char		*exp_owner_grp = "admins@";
+	const char		exp_owner[] = "fictionaluser@";
+	const char		exp_owner_grp[] = "admins@";
 	struct daos_acl		*exp_acl;
 	struct daos_acl		*update_acl;
 	struct daos_ace		*ace;
@@ -706,11 +706,9 @@ co_acl(void **state)
 	prop_in = daos_prop_alloc(3);
 	assert_non_null(prop_in);
 	prop_in->dpp_entries[0].dpe_type = DAOS_PROP_CO_OWNER;
-	D_STRNDUP(prop_in->dpp_entries[0].dpe_str, exp_owner,
-		  DAOS_ACL_MAX_PRINCIPAL_BUF_LEN);
+	D_STRNDUP_S(prop_in->dpp_entries[0].dpe_str, exp_owner);
 	prop_in->dpp_entries[1].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
-	D_STRNDUP(prop_in->dpp_entries[1].dpe_str, exp_owner_grp,
-		  DAOS_ACL_MAX_PRINCIPAL_BUF_LEN);
+	D_STRNDUP_S(prop_in->dpp_entries[1].dpe_str, exp_owner_grp);
 	prop_in->dpp_entries[2].dpe_type = DAOS_PROP_CO_ACL;
 	prop_in->dpp_entries[2].dpe_val_ptr = daos_acl_dup(exp_acl);
 
@@ -845,8 +843,8 @@ co_set_prop(void **state)
 	daos_prop_t		*prop_out = NULL;
 	struct daos_prop_entry	*entry;
 	int			 rc;
-	const char		*exp_label = "NEW_FANCY_LABEL";
-	const char		*exp_owner = "wonderfuluser@wonderfuldomain";
+	const char		 exp_label[] = "NEW_FANCY_LABEL";
+	const char		 exp_owner[] = "wonderfuluser@wonderfuldomain";
 
 	print_message("create container with default props and modify them.\n");
 	rc = test_setup((void **)&arg, SETUP_POOL_CONNECT, arg0->multi_rank,
@@ -865,11 +863,9 @@ co_set_prop(void **state)
 	prop_in = daos_prop_alloc(2);
 	assert_non_null(prop_in);
 	prop_in->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
-	D_STRNDUP(prop_in->dpp_entries[0].dpe_str, exp_label,
-		  DAOS_PROP_LABEL_MAX_LEN);
+	D_STRNDUP_S(prop_in->dpp_entries[0].dpe_str, exp_label);
 	prop_in->dpp_entries[1].dpe_type = DAOS_PROP_CO_OWNER;
-	D_STRNDUP(prop_in->dpp_entries[1].dpe_str, exp_owner,
-		  DAOS_ACL_MAX_PRINCIPAL_LEN);
+	D_STRNDUP_S(prop_in->dpp_entries[1].dpe_str, exp_owner);
 
 	print_message("Setting the container props\n");
 	rc = daos_cont_set_prop(arg->coh, prop_in, NULL);

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -493,7 +493,7 @@ pool_properties(void **state)
 {
 	test_arg_t		*arg0 = *state;
 	test_arg_t		*arg = NULL;
-	char			*label = "test_pool_properties";
+	char			 label[] = "test_pool_properties";
 #if 0 /* DAOS-5456 space_rb props not supported with dmg pool create */
 	uint64_t		 space_rb = 36;
 #endif
@@ -515,9 +515,9 @@ pool_properties(void **state)
 	prop = daos_prop_alloc(1);
 	/* label - set arg->pool_label to use daos_pool_connect() */
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_PO_LABEL;
-	D_STRNDUP(prop->dpp_entries[0].dpe_str, label, DAOS_PROP_LABEL_MAX_LEN);
+	D_STRNDUP_S(prop->dpp_entries[0].dpe_str, label);
 	assert_ptr_not_equal(prop->dpp_entries[0].dpe_str, NULL);
-	D_STRNDUP(arg->pool_label, label, DAOS_PROP_LABEL_MAX_LEN);
+	D_STRNDUP_S(arg->pool_label, label);
 	assert_ptr_not_equal(arg->pool_label, NULL);
 
 #if 0 /* DAOS-5456 space_rb props not supported with dmg pool create */

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -6,7 +6,7 @@
 #
 
 # Pull base image
-FROM opensuse/leap:15.3
+FROM opensuse/leap:15.4
 LABEL maintainer="daos@daos.groups.io"
 
 # Intermittent cache-bust.  Used to reduce load on the actual CACHEBUST later.


### PR DESCRIPTION
* This code was a while loop written using a for loop so correct code and avoid compile error.
* Fix rocky build and update leap distro.

Also cherry-pick's part of #8127 to fix static strndup calls

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>