### PR TITLE
DAOS-11658 object: several fixes for EC migration

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2520,7 +2520,7 @@ handle_ivupdate_response(const struct crt_cb_info *cb_info)
 	/* For bi-directional updates, transfer data back to child */
 	if (iv_info->uci_sync_type.ivs_flags & CRT_IV_SYNC_BIDIRECTIONAL) {
 		transfer_back_to_child(&input->ivu_key, iv_info, true,
-				       cb_info->cci_rc);
+				       cb_info->cci_rc ?: output->rc);
 		D_GOTO(exit, 0);
 	}
 

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -431,9 +431,9 @@ cont_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
 
 	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
 
+again:
 	d_iov_set(&key_iov, &civ_key->cont_uuid, sizeof(civ_key->cont_uuid));
 	d_iov_set(&val_iov, NULL, 0);
-again:
 	rc = dbtree_lookup(root_hdl, &key_iov, &val_iov);
 	if (rc < 0) {
 		if (rc == -DER_NONEXIST && is_master(entry)) {
@@ -453,8 +453,29 @@ again:
 				D_ERROR("create cont prop iv entry failed "
 					""DF_RC"\n", DP_RC(rc));
 			} else if (class_id == IV_CONT_CAPA) {
-				/* Can not find the handle on leader */
-				rc = -DER_NONEXIST;
+				struct container_hdl	chdl;
+				int			rc1;
+
+				/* If PS leader switches, it may not in IV cache,
+				 * let's lookup RDB then.
+				 **/
+				rc1 = ds_cont_hdl_rdb_lookup(entry->ns->iv_pool_uuid,
+							     civ_key->cont_uuid, &chdl);
+				if (rc1 == 0) {
+					struct cont_iv_entry	iv_entry = { 0 };
+
+					/* Only happens on xstream 0 */
+					D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+					iv_entry.iv_capa.flags = chdl.ch_flags;
+					iv_entry.iv_capa.sec_capas = chdl.ch_sec_capas;
+					uuid_copy(iv_entry.cont_uuid, chdl.ch_cont);
+					d_iov_set(&val_iov, &iv_entry, sizeof(iv_entry));
+					rc = dbtree_update(root_hdl, &key_iov, &val_iov);
+					if (rc == 0)
+						goto again;
+				} else {
+					rc = -DER_NONEXIST;
+				}
 			}
 		}
 		D_DEBUG(DB_MGMT, "lookup cont: rc "DF_RC"\n", DP_RC(rc));

--- a/src/container/oid_iv.c
+++ b/src/container/oid_iv.c
@@ -108,6 +108,8 @@ oid_iv_ent_refresh(struct ds_iv_entry *iv_entry, struct ds_iv_key *key,
 	/** Set the number of oids to what was asked for. */
 	oids->num_oids = num_oids;
 
+	D_DEBUG(DB_MD, "%u: ON REFRESH %zu/%zu avail %zu/%zu\n", dss_self_rank(),
+		oids->oid, oids->num_oids, avail->oid, avail->num_oids);
 out:
 	ABT_mutex_unlock(entry->lock);
 	return ref_rc;
@@ -328,7 +330,7 @@ oid_iv_reserve(void *ns, uuid_t po_uuid, uuid_t co_uuid, uint64_t num_oids, d_sg
 	oids->num_oids = num_oids;
 
 	rc = ds_iv_update(ns, &key, value, 0, CRT_IV_SYNC_NONE,
-			  CRT_IV_SYNC_BIDIRECTIONAL, false /* retry */);
+			  CRT_IV_SYNC_BIDIRECTIONAL, true /* retry */);
 	if (rc)
 		D_ERROR("iv update failed "DF_RC"\n", DP_RC(rc));
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -4178,3 +4178,41 @@ out_put:
 	cont_svc_put_leader(svc);
 	return rc;
 }
+
+int
+ds_cont_hdl_rdb_lookup(uuid_t pool_uuid, uuid_t cont_hdl_uuid, struct container_hdl *chdl)
+{
+	d_iov_t		key;
+	d_iov_t		value;
+	struct rdb_tx	tx;
+	struct cont_svc *svc;
+	int		rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": find leader: %d\n",
+			DP_CONT(pool_uuid, cont_hdl_uuid), rc);
+		return rc;
+	}
+
+	/* check if it is server container hdl */
+	if (uuid_compare(cont_hdl_uuid, svc->cs_pool->sp_srv_cont_hdl) == 0)
+		D_GOTO(put, rc);
+
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0)
+		D_GOTO(put, rc);
+
+	ABT_rwlock_rdlock(svc->cs_lock);
+	/* See if this container handle already exists. */
+	d_iov_set(&key, cont_hdl_uuid, sizeof(uuid_t));
+	d_iov_set(&value, chdl, sizeof(*chdl));
+	rc = rdb_tx_lookup(&tx, &svc->cs_hdls, &key, &value);
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+
+put:
+	D_DEBUG(DB_MD, DF_CONT "lookup rc %d.\n", DP_CONT(pool_uuid, cont_hdl_uuid), rc);
+	cont_svc_put_leader(svc);
+	return rc;
+}

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -286,4 +286,6 @@ int ds_cont_metrics_count(void);
 int cont_child_gather_oids(struct ds_cont_child *cont, uuid_t coh_uuid,
 			   daos_epoch_t epoch);
 
+int ds_cont_hdl_rdb_lookup(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
+			   struct container_hdl *chdl);
 #endif /* __CONTAINER_SRV_INTERNAL_H__ */

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -281,6 +281,9 @@ extern "C" {
 	/** The TX ID may be reused. */					\
 	ACTION(DER_TX_ID_REUSED,	(DER_ERR_DAOS_BASE + 40),	\
 	       TX ID may be reused)					\
+	/** Re-update again */						\
+	ACTION(DER_UPDATE_AGAIN,	(DER_ERR_DAOS_BASE + 41),	\
+	       update again)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -820,6 +820,7 @@ struct dss_enum_unpack_io {
 	/* punched epochs for dkey */
 	daos_epoch_t		ui_dkey_punch_eph;
 	d_sg_list_t		*ui_sgls;	/**< optional */
+	uint64_t		ui_dkey_hash;
 	uint32_t		ui_version;
 	uint32_t		ui_type;
 };

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3630,8 +3630,8 @@ obj_shard_list_obj_cb(struct shard_auxi_args *shard_auxi,
 		kds[i] = shard_arg->la_kds[i];
 	iter_arg->merge_nr += shard_arg->la_nr;
 
-	D_DEBUG(DB_TRACE, "merge_nr %d/"DF_U64"\n", iter_arg->merge_nr,
-		obj_arg->sgl->sg_iovs[0].iov_len);
+	D_DEBUG(DB_TRACE, "shard %u shard nr %u merge_nr %d/"DF_U64"\n", shard_auxi->shard,
+		shard_arg->la_nr, iter_arg->merge_nr, obj_arg->sgl->sg_iovs[0].iov_len);
 	return rc;
 }
 
@@ -3890,6 +3890,7 @@ obj_shard_comp_cb(tse_task_t *task, struct shard_auxi_args *shard_auxi,
 						shard_auxi->shard, obj_arg->kds[0].kd_key_len,
 						shard_arg->la_kds[0].kd_key_len);
 					obj_arg->kds[0] = shard_arg->la_kds[0];
+					iter_arg->merge_nr++;
 				}
 			}
 
@@ -6838,4 +6839,61 @@ daos_obj_get_oclass(daos_handle_t coh, daos_ofeat_t ofeats,
 		return 0;
 
 	return (ord << OC_REDUN_SHIFT) | nr_grp;
+}
+
+static inline bool
+obj_shard_is_invalid(struct dc_object *obj, uint32_t shard_idx, uint32_t opc)
+{
+	bool invalid_shard;
+
+	D_RWLOCK_RDLOCK(&obj->cob_lock);
+	if (obj_is_modification_opc(opc))
+		invalid_shard = obj->cob_shards->do_shards[shard_idx].do_target_id == -1 ||
+				obj->cob_shards->do_shards[shard_idx].do_shard == -1;
+	else
+		invalid_shard = obj->cob_shards->do_shards[shard_idx].do_rebuilding ||
+				obj->cob_shards->do_shards[shard_idx].do_target_id == -1 ||
+				obj->cob_shards->do_shards[shard_idx].do_shard == -1;
+	D_RWLOCK_UNLOCK(&obj->cob_lock);
+
+	return invalid_shard || (DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_OPEN) &&
+				 daos_shard_in_fail_value(shard_idx));
+}
+
+/**
+ * Check if there are any EC parity shards still alive under the oh/dkey_hash.
+ * 1: alive,  0: no alive  < 0: failure.
+ */
+int
+obj_ec_parity_alive(daos_handle_t oh, uint64_t dkey_hash, uint32_t *shard)
+{
+	struct daos_oclass_attr *oca;
+	struct dc_object	*obj;
+	int			grp_idx;
+	int			i;
+	int			rc = 0;
+
+	obj = obj_hdl2ptr(oh);
+	if (obj == NULL)
+		return -DER_NO_HDL;
+
+	grp_idx = obj_dkey2grpidx(obj, dkey_hash, obj->cob_version);
+	if (grp_idx < 0)
+		D_GOTO(out_put, rc = grp_idx);
+
+	oca = obj_get_oca(obj);
+	for (i = 0; i < obj_ec_parity_tgt_nr(oca); i++) {
+		*shard = grp_idx * obj_get_grp_size(obj) + obj_ec_data_tgt_nr(oca) + i;
+		D_DEBUG(DB_TRACE, "shard %u %d/%d/%d\n", *shard,
+			obj->cob_shards->do_shards[*shard].do_rebuilding,
+			obj->cob_shards->do_shards[*shard].do_target_id,
+			obj->cob_shards->do_shards[*shard].do_shard);
+		if (!obj_shard_is_invalid(obj, *shard, DAOS_OBJ_RPC_FETCH) &&
+		    !obj->cob_shards->do_shards[*shard].do_reintegrating)
+			D_GOTO(out_put, rc = 1);
+	}
+
+out_put:
+	obj_decref(obj);
+	return rc;
 }

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -13,6 +13,7 @@
 #include <daos_srv/daos_engine.h>
 #include <daos_srv/vos.h>
 #include <daos/object.h>
+#include "obj_internal.h"
 
 static d_iov_t *
 io_csums_iov(struct dss_enum_unpack_io *io)
@@ -1239,6 +1240,7 @@ enum_unpack_key(daos_key_desc_t *kds, char *key_data,
 			daos_iov_free(&io->ui_dkey);
 			rc = daos_iov_copy(&io->ui_dkey, &key);
 		}
+		io->ui_dkey_hash = obj_dkey2hash(io->ui_oid.id_pub, &key);
 		D_DEBUG(DB_IO, "process dkey "DF_KEY": rc "DF_RC"\n",
 			DP_KEY(&key), DP_RC(rc));
 		return rc;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -585,6 +585,8 @@ obj_singv_ec_rw_filter(daos_unit_oid_t oid, struct daos_oclass_attr *oca,
 		       uint32_t flags, uint32_t start_shard,
 		       uint32_t nr, bool for_update, bool deg_fetch,
 		       struct daos_recx_ep_list **recov_lists_ptr);
+int
+obj_ec_parity_alive(daos_handle_t oh, uint64_t dkey_hash, uint32_t *shard);
 
 static inline struct pl_obj_shard*
 obj_get_shard(void *data, int idx)
@@ -602,7 +604,7 @@ obj_retry_error(int err)
 	       err == -DER_EXCLUDED || err == -DER_CSUM ||
 	       err == -DER_TX_BUSY || err == -DER_TX_UNCERTAIN ||
 	       err == -DER_NEED_TX || err == -DER_NOTLEADER ||
-	       daos_crt_network_error(err);
+	       err == -DER_UPDATE_AGAIN || daos_crt_network_error(err);
 }
 
 static inline daos_handle_t

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -962,7 +962,7 @@ dc_tx_commit_cb(tse_task_t *task, void *data)
 	}
 
 	/* Need to restart the TX with newer epoch. */
-	if (rc == -DER_TX_RESTART || rc == -DER_STALE) {
+	if (rc == -DER_TX_RESTART || rc == -DER_STALE || rc == -DER_UPDATE_AGAIN) {
 		tx->tx_set_resend = 1;
 		tx->tx_status = TX_FAILED;
 

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -65,10 +65,7 @@ struct rebuild_tgt_pool_tracker {
 	 * can be go ahead to finish the rebuild.
 	 */
 	ABT_cond		rt_fini_cond;
-	/* Notify others the rebuild of this pool has been
-	 * done on this target.
-	 */
-	ABT_cond		rt_done_cond;
+
 	/* # to-be-rebuilt objs */
 	uint64_t		rt_reported_toberb_objs;
 	/* reported # rebuilt objs */

--- a/src/tests/ftest/daos_test/rebuild.py
+++ b/src/tests/ftest/daos_test/rebuild.py
@@ -269,3 +269,19 @@ class DaosCoreTestRebuild(DaosCoreBase):
         :avocado: tags=daos_test,daos_core_test_rebuild,test_rebuild_29
         """
         self.run_subtest()
+
+    def test_rebuild_30(self):
+        """Jira ID: DAOS-2770
+
+        Test Description:
+            Run daos_test -r -s5 -u subtests=30
+
+        Use cases:
+            Core tests for daos_test rebuild
+
+        :avocado: tags=all,pr,daily_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=unittest
+        :avocado: tags=daos_test,daos_core_test_rebuild,test_rebuild_30
+        """
+        self.run_subtest()

--- a/src/tests/ftest/daos_test/rebuild.yaml
+++ b/src/tests/ftest/daos_test/rebuild.yaml
@@ -73,6 +73,7 @@ daos_tests:
     test_rebuild_27: DAOS_Rebuild_27
     test_rebuild_28: DAOS_Rebuild_28
     test_rebuild_29: DAOS_Rebuild_29
+    test_rebuild_30: DAOS_Rebuild_30
   daos_test:
     test_rebuild_0to10: r
     test_rebuild_12to15: r
@@ -90,6 +91,7 @@ daos_tests:
     test_rebuild_27: r
     test_rebuild_28: r
     test_rebuild_29: r
+    test_rebuild_30: r
   args:
     test_rebuild_0to10: -s3 -u subtests="0-10"
     test_rebuild_12to15: -s3 -u subtests="12-15"
@@ -107,6 +109,7 @@ daos_tests:
     test_rebuild_27: -s6 -u subtests="27"
     test_rebuild_28: -s3 -u subtests="28"
     test_rebuild_29: -s5 -u subtests="29"
+    test_rebuild_30: -s5 -u subtests="30"
   stopped_ranks:
     test_rebuild_22: [7]
     test_rebuild_23: [7]

--- a/src/tests/ftest/erasurecode/multiple_failure.py
+++ b/src/tests/ftest/erasurecode/multiple_failure.py
@@ -1,11 +1,10 @@
-#!/usr/bin/python
 '''
   (C) Copyright 2021-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeIor
-from apricot import skipForTicket
+
 
 class EcodOnlineMultFail(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -20,7 +19,6 @@ class EcodOnlineMultFail(ErasureCodeIor):
         super().__init__(*args, **kwargs)
         self.set_online_rebuild = True
 
-    @skipForTicket("DAOS-9051")
     def run_ior_cascade_failure(self):
         """Common function to Write and Read IOR"""
         # Write IOR data set with different EC object. kill rank, targets or mix of both while IOR
@@ -35,7 +33,6 @@ class EcodOnlineMultFail(ErasureCodeIor):
         # intact and no data corruption observed.
         self.ior_read_dataset(parity=2)
 
-    @skipForTicket("DAOS-9051")
     def test_ec_multiple_rank_failure(self):
         """Jira ID: DAOS-7344.
 
@@ -45,9 +42,9 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_multiple_rank_failure
+        :avocado: tags=test_ec_multiple_rank_failure
         """
         # Kill Two server ranks
         self.rank_to_kill = [self.server_count - 1, self.server_count - 3]
@@ -62,9 +59,9 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_multiple_target_on_same_rank_failure
+        :avocado: tags=test_ec_multiple_targets_on_same_rank
         """
         # Kill Two targets 2,4 from same rank 2
         self.pool_exclude[2] = "2,4"
@@ -79,16 +76,15 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_multiple_rank_on_diff_target_failure
+        :avocado: tags=test_ec_multiple_targets_on_diff_ranks
         """
         # Kill Two targets from different ranks
         self.pool_exclude[2] = "2"
         self.pool_exclude[3] = "3"
         self.run_ior_cascade_failure()
 
-    @skipForTicket("DAOS-9051")
     def test_ec_single_target_rank_failure(self):
         """Jira ID: DAOS-7344.
 
@@ -98,9 +94,9 @@ class EcodOnlineMultFail(ErasureCodeIor):
                   finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_online_rebuild,rebuild,ec_fault,ec_multiple_failure
-        :avocado: tags=ec_single_target_rank_failure
+        :avocado: tags=test_ec_single_target_rank_failure
         """
         # Kill One server rank
         self.rank_to_kill = [self.server_count - 1]

--- a/src/tests/ftest/erasurecode/online_rebuild.py
+++ b/src/tests/ftest/erasurecode/online_rebuild.py
@@ -1,11 +1,10 @@
-#!/usr/bin/python
 '''
   (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from ec_utils import ErasureCodeIor
-from apricot import skipForTicket
+
 
 class EcodOnlineRebuild(ErasureCodeIor):
     # pylint: disable=too-many-ancestors
@@ -20,7 +19,6 @@ class EcodOnlineRebuild(ErasureCodeIor):
         super().__init__(*args, **kwargs)
         self.set_online_rebuild = True
 
-    @skipForTicket("DAOS-9051")
     def test_ec_online_rebuild(self):
         """Jira ID: DAOS-5894.
 
@@ -31,9 +29,9 @@ class EcodOnlineRebuild(ErasureCodeIor):
                   verify all IOR write finish.Read and verify data.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,large,ib2
+        :avocado: tags=hw,large
         :avocado: tags=ec,ec_array,ec_online_rebuild,rebuild
-        :avocado: tags=ec_online_rebuild_array
+        :avocado: tags=test_ec_online_rebuild_array
         """
         # Kill last server rank
         self.rank_to_kill = [self.server_count - 1]

--- a/src/tests/ftest/rebuild/container_rf.yaml
+++ b/src/tests/ftest/rebuild/container_rf.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 6
   test_clients: 1
-timeout: 360
+timeout: 480
 server_config:
   name: daos_server
   servers:

--- a/src/tests/ftest/rebuild/delete_objects.yaml
+++ b/src/tests/ftest/rebuild/delete_objects.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 6
   test_clients: 1
-timeout: 300
+timeout: 450
 server_config:
   name: daos_server
   servers:

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 5
   test_clients: 1
-timeout: 240
+timeout: 360
 server_config:
   name: daos_server
   servers:

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -371,6 +371,8 @@ rebuild_destroy_pool_cb(void *data)
 
 	rebuild_pool_disconnect_internal(data);
 
+	print_message("sleep 20 seconds to make rebuild ready\n");
+	sleep(20);
 	if (arg->myrank == 0) {
 		/* Disable fail_loc and start rebuild */
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
@@ -385,8 +387,7 @@ rebuild_destroy_pool_cb(void *data)
 	}
 
 	arg->pool.destroyed = true;
-	print_message("pool destroyed "DF_UUIDF"\n",
-		      DP_UUID(arg->pool.pool_uuid));
+	print_message("pool destroyed "DF_UUIDF"\n", DP_UUID(arg->pool.pool_uuid));
 
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -1330,6 +1331,13 @@ rebuild_kill_PS_leader_during_rebuild(void **state)
 	rebuild_single_pool_rank(arg, leader, true);
 }
 
+static void
+rebuild_pool_destroy_during_rebuild_failure(void **state)
+{
+	return rebuild_destroy_pool_internal(state, DAOS_REBUILD_UPDATE_FAIL |
+						    DAOS_FAIL_ALWAYS);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: drop rebuild scan reply",
@@ -1405,6 +1413,9 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_sub_teardown},
 	{"REBUILD29: rebuild kill PS leader during rebuild",
 	 rebuild_kill_PS_leader_during_rebuild, rebuild_sub_setup,
+	 rebuild_sub_teardown},
+	{"REBUILD30: destroy pool during rebuild failure and retry",
+	  rebuild_pool_destroy_during_rebuild_failure, rebuild_sub_setup,
 	 rebuild_sub_teardown},
 };
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -965,12 +965,13 @@ io_obj_cache_test(void **state)
 	rc = vos_obj_discard_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &obj1);
 	assert_rc_equal(rc, 0);
 	/** Should be prevented because object olready held for discard */
-	expect_assert_failure(vos_obj_discard_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0],
-						   &obj2));
+	rc = vos_obj_discard_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &obj2);
+	assert_rc_equal(rc, -DER_UPDATE_AGAIN);
 	/** Should prevent simultaneous hold for create as well */
-	expect_assert_failure(vos_obj_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &epr, 0,
+	rc = vos_obj_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &epr, 0,
 					   VOS_OBJ_CREATE | VOS_OBJ_VISIBLE, DAOS_INTENT_DEFAULT,
-					   &obj2, 0));
+					   &obj2, 0);
+	assert_rc_equal(rc, -DER_UPDATE_AGAIN);
 
 	/** Need to be able to hold for read though or iteration won't work */
 	rc = vos_obj_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &epr, 0,

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -404,8 +404,9 @@ check_object:
 	if (obj->obj_discard && (create || (flags & VOS_OBJ_DISCARD) != 0)) {
 		/** Cleanup before assert so unit test that triggers doesn't corrupt the state */
 		vos_obj_release(occ, obj, false);
-		D_ASSERTF(0, "Simultaneous object hold and discard detected\n");
-		goto failed;
+		/* Update request will retry with this error */
+		rc = -DER_UPDATE_AGAIN;
+		goto failed_2;
 	}
 
 	if ((flags & VOS_OBJ_DISCARD) || intent == DAOS_INTENT_KILL || intent == DAOS_INTENT_PUNCH)


### PR DESCRIPTION
These fixes are ported from master for EC migration

1. add ec_parity shard check during migration, so only fetch from shards if it still exists.

2. skip empty IOD.

3. Remove discard vs write assertion in vos_obj_hold, instead it will return -DER_UPDATE_AGAIN to make client retry, since it may see inflight update during rebuild reclaim.

4. Use stable epoch to discard the rebuild failure job.

5. Let's skip the empty IOD during migration to avoid creating too much ULT.

6. DAOS-11423 object: skip the first return la kds (#10267)

7. DAOS-10524 rebuild: skip reclaim job during merge

8. DAOS-11423 container: do not update oid IV for failure

9. DAOS-10423 container: check container hdl in rdb (#10241)

Required-githooks: true
Test-tag: pr rebuild ec_ior_hard_online_rebuild pool_create_all_one_hw
Signed-off-by: Di Wang <di.wang@intel.com>