### PR TITLE
DAOS-11534 build: add -fpic -pie in linkflag for program

### DIFF
--- a/site_scons/daos_build.py
+++ b/site_scons/daos_build.py
@@ -154,6 +154,7 @@ def library(env, *args, **kwargs):
 def program(env, *args, **kwargs):
     """build Program with relative RPATH"""
     denv = env.Clone()
+    denv.AppendUnique(LINKFLAGS=['-fpic','-pie'])
     denv.Replace(RPATH=[])
     add_rpaths(denv, kwargs.get('install_off', '..'), False, True)
     prog = denv.Program(*args, **kwargs)

--- a/site_scons/daos_build.py
+++ b/site_scons/daos_build.py
@@ -154,7 +154,7 @@ def library(env, *args, **kwargs):
 def program(env, *args, **kwargs):
     """build Program with relative RPATH"""
     denv = env.Clone()
-    denv.AppendUnique(LINKFLAGS=['-fpic', '-pie'])
+    denv.AppendUnique(LINKFLAGS=['-pie'])
     denv.Replace(RPATH=[])
     add_rpaths(denv, kwargs.get('install_off', '..'), False, True)
     prog = denv.Program(*args, **kwargs)
@@ -167,6 +167,7 @@ def program(env, *args, **kwargs):
 def test(env, *args, **kwargs):
     """build Program with fixed RPATH"""
     denv = env.Clone()
+    denv.AppendUnique(LINKFLAGS=['-pie'])
     denv.Replace(RPATH=[])
     add_rpaths(denv, kwargs.get("install_off", None), False, True)
     testbuild = denv.Program(*args, **kwargs)

--- a/site_scons/daos_build.py
+++ b/site_scons/daos_build.py
@@ -154,7 +154,7 @@ def library(env, *args, **kwargs):
 def program(env, *args, **kwargs):
     """build Program with relative RPATH"""
     denv = env.Clone()
-    denv.AppendUnique(LINKFLAGS=['-fpic','-pie'])
+    denv.AppendUnique(LINKFLAGS=['-fpic', '-pie'])
     denv.Replace(RPATH=[])
     add_rpaths(denv, kwargs.get('install_off', '..'), False, True)
     prog = denv.Program(*args, **kwargs)

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -118,9 +118,13 @@ def install_go_bin(denv, gosrc, libs, name, install_name):
     # Propagate useful GO environment variables from the caller
     if 'GOCACHE' in os.environ:
         denv['ENV']['GOCACHE'] = os.environ['GOCACHE']
+    if not is_release_build(denv):
+        flag_pie = ' '
+    else:
+        flag_pie = '-buildmode=pie '
     target = daos_build.run_command(denv, build_bin, src, libs,
                                     f'cd {gosrc}; {GO_BIN} build -mod vendor {go_ldflags()} '
-                                    + f'-buildmode=pie '
+                                    + flag_pie
                                     + f'{get_build_flags(denv)} '
                                     + f'{get_build_tags(denv)} '
                                     + f'-o {build_bin} {install_src}')

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -65,6 +65,8 @@ def get_build_flags(benv):
     if not is_release_build(benv):
         # enable race detector for non-release builds
         flags += "-race"
+    else:
+        flags += '-buildmode=pie'
     return flags
 
 
@@ -118,13 +120,8 @@ def install_go_bin(denv, gosrc, libs, name, install_name):
     # Propagate useful GO environment variables from the caller
     if 'GOCACHE' in os.environ:
         denv['ENV']['GOCACHE'] = os.environ['GOCACHE']
-    if not is_release_build(denv):
-        flag_pie = ' '
-    else:
-        flag_pie = '-buildmode=pie '
     target = daos_build.run_command(denv, build_bin, src, libs,
                                     f'cd {gosrc}; {GO_BIN} build -mod vendor {go_ldflags()} '
-                                    + flag_pie
                                     + f'{get_build_flags(denv)} '
                                     + f'{get_build_tags(denv)} '
                                     + f'-o {build_bin} {install_src}')

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -120,6 +120,7 @@ def install_go_bin(denv, gosrc, libs, name, install_name):
         denv['ENV']['GOCACHE'] = os.environ['GOCACHE']
     target = daos_build.run_command(denv, build_bin, src, libs,
                                     f'cd {gosrc}; {GO_BIN} build -mod vendor {go_ldflags()} '
+                                    + f'-buildmode=pie '
                                     + f'{get_build_flags(denv)} '
                                     + f'{get_build_tags(denv)} '
                                     + f'-o {build_bin} {install_src}')


### PR DESCRIPTION
Per SDL requirement, "-pie" is added for linking C executable files. "-buildmode=pie" is added for linking Go executable files.

Required-githooks: true

Signed-off-by: Lei Huang <lei.huang@intel.com>