### PR TITLE
DAOS-11639 test: Do not install slurm on VM stage

### DIFF
--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -224,7 +224,6 @@ if ${SETUP_ONLY:-false}; then
 fi
 
 export DAOS_APP_DIR=${DAOS_APP_DIR:-$DAOS_TEST_SHARED_DIR}
-export STAGE_NAME
 
 # check if slurm needs to be configured for soak
 if [[ "${TEST_TAG_ARG}" =~ soak && "${STAGE_NAME}" =~ Hardware ]]; then


### PR DESCRIPTION
Enable slurm on hardware stages only

Test-tag: pr daily_regression soak_smoke
Skip-func-test-leap15: false

Required-githooks: true

Signed-off-by: Maureen Jean <maureen.jean@intel.com>