### PR TITLE
DAOS-11448 vos: Modify pool version handling (#10271)

### DIFF
--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -18,6 +18,7 @@
 #define VOS_SUB_OP_MAX	((uint16_t)-2)
 
 #define VOS_POOL_DF_2_2 24
+#define VOS_POOL_DF_2_4 25
 
 struct dtx_rsrvd_uint {
 	void			*dru_scm;
@@ -272,6 +273,8 @@ enum {
 enum {
 	/** Aggregation optimization is enabled for this pool */
 	VOS_POOL_FEAT_AGG_OPT = (1ULL << 0),
+	/** Pool check is supported for this pool */
+	VOS_POOL_FEAT_CHK = (1ULL << 1),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1565,9 +1565,12 @@ update_vos_prop_on_targets(void *in)
 	policy_desc = pool->sp_policy_desc;
 	ret = vos_pool_ctl(child->spc_hdl, VOS_PO_CTL_SET_POLICY, &policy_desc);
 
-	if (ret == 0 && pool->sp_global_version >= 1) {
+	if (ret == 0) {
 		/** If necessary, upgrade the vos pool format */
-		ret = vos_pool_upgrade(child->spc_hdl, VOS_POOL_DF_2_2);
+		if (pool->sp_global_version >= 2)
+			ret = vos_pool_upgrade(child->spc_hdl, VOS_POOL_DF_2_4);
+		else if (pool->sp_global_version == 1)
+			ret = vos_pool_upgrade(child->spc_hdl, VOS_POOL_DF_2_2);
 	}
 
 	ds_pool_child_put(child);

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -89,16 +89,24 @@ enum vos_gc_type {
 
 /** Lowest supported durable format version */
 #define POOL_DF_VER_1				23
-/** Minimum pool version for built-in aggregation optimization. Otherwise,
- *  the optimization can only be enabled by a pool upgrade which sets the global
- *  version but doesn't update the durable format.  If both the durable format
- *  and global version remain as currently set, the optimization is disabled.
- *  This enables the user to continue using the pool with the older version unless
- *  they have explicitly upgraded it.
+
+/** Individual version specific featuers are assigned to a release specific durable
+ * format version number.  This allows us to add multiple features in a release cycle
+ * while keeping checks related to the feature rather than the more ambiguous version
+ * number.   Each new feature should be assigned to the latest VOS durable format.
+ * Each feature is only enabled if the pool durable format is at least equal to that
+ * feature's assigned durable format.  Otherwise, the feature must not be used.
  */
+/** 2.2 features */
+/** Aggregation optimization to avoid scanning subtrees where aggregation is not possible */
 #define POOL_DF_AGG_OPT                         VOS_POOL_DF_2_2
+
+/** 2.4 features */
+/** Feature for checking pool consistency related to catastrophic recovery */
+#define POOL_DF_POOL_CHK                        VOS_POOL_DF_2_4
+
 /** Current durable format version */
-#define POOL_DF_VERSION				POOL_DF_AGG_OPT
+#define POOL_DF_VERSION                         VOS_POOL_DF_2_4
 
 /**
  * Durable format for VOS pool

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -771,6 +771,8 @@ pool_open(PMEMobjpool *ph, struct vos_pool_df *pool_df, unsigned int flags, void
 	pool->vp_small = !!(flags & VOS_POF_SMALL);
 	if (pool_df->pd_version >= POOL_DF_AGG_OPT)
 		pool->vp_feats |= VOS_POOL_FEAT_AGG_OPT;
+	if (pool_df->pd_version >= POOL_DF_POOL_CHK)
+		pool->vp_feats |= VOS_POOL_FEAT_CHK;
 
 	vos_space_sys_init(pool);
 	/* Ensure GC is triggered after server restart */
@@ -922,6 +924,8 @@ end:
 
 	if (version >= POOL_DF_AGG_OPT)
 		pool->vp_feats |= VOS_POOL_FEAT_AGG_OPT;
+	if (version >= POOL_DF_POOL_CHK)
+		pool->vp_feats |= VOS_POOL_FEAT_CHK;
 
 	return 0;
 }


### PR DESCRIPTION
Partial cherry-pick from feature/cat_recovery because it's needed for other feature branches

Version 24 must work as aggregation optimization for backward compatibility so create a new version for the checker

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>