### PR TITLE
DAOS-5921 md: TEST-ONLY DO NOT LAND

### DIFF
--- a/src/include/daos_srv/rdb.h
+++ b/src/include/daos_srv/rdb.h
@@ -248,6 +248,8 @@ int rdb_tx_destroy_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
 		       const d_iov_t *key);
 int rdb_tx_update(struct rdb_tx *tx, const rdb_path_t *kvs,
 		  const d_iov_t *key, const d_iov_t *value);
+int rdb_tx_update_critical(struct rdb_tx *tx, const rdb_path_t *kvs,
+			   const d_iov_t *key, const d_iov_t *value);
 int rdb_tx_delete(struct rdb_tx *tx, const rdb_path_t *kvs,
 		  const d_iov_t *key);
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -6197,8 +6197,7 @@ ds_pool_evict_handler(crt_rpc_t *rpc)
 		d_iov_t		value;
 
 		d_iov_set(&value, &connectable, sizeof(connectable));
-		rc = rdb_tx_update(&tx, &svc->ps_root,
-				   &ds_pool_prop_connectable, &value);
+		rc = rdb_tx_update_critical(&tx, &svc->ps_root, &ds_pool_prop_connectable, &value);
 		if (rc != 0)
 			D_GOTO(out_free, rc);
 

--- a/src/rdb/rdb_tx.c
+++ b/src/rdb/rdb_tx.c
@@ -308,12 +308,11 @@ rdb_tx_op_decode(const void *buf, size_t len, struct rdb_tx_op *op)
 
 /* Append an update operation to tx->dt_entry. */
 static int
-rdb_tx_append(struct rdb_tx *tx, struct rdb_tx_op *op)
+rdb_tx_append(struct rdb_tx *tx, struct rdb_tx_op *op, bool is_critical)
 {
 	struct rdb_tx_hdr	hdr;
 	size_t			op_len;
 	size_t			len;
-	bool			opc_is_critical;
 	const size_t		RDB_TX_CRITICAL_OPS_LIMIT = 8;
 	int			rc;
 
@@ -369,16 +368,13 @@ rdb_tx_append(struct rdb_tx *tx, struct rdb_tx_op *op)
 
 	/* TX is critical if it is reasonably-sized, and any op is critical */
 	tx->dt_num_ops++;
-	opc_is_critical = ((op->dto_opc == RDB_TX_DESTROY_ROOT) ||
-			   (op->dto_opc == RDB_TX_DESTROY) ||
-			   (op->dto_opc == RDB_TX_DELETE));
 	if (tx->dt_entry_len == 0) {
-		hdr.critical = opc_is_critical ? 1 : 0;
+		hdr.critical = is_critical ? 1 : 0;
 		tx->dt_entry_len += rdb_tx_hdr_encode(&hdr, tx->dt_entry);
 	} else if (tx->dt_num_ops > RDB_TX_CRITICAL_OPS_LIMIT) {
 		hdr.critical = 0;
 		rdb_tx_hdr_encode(&hdr, tx->dt_entry);
-	} else if (opc_is_critical) {
+	} else if (is_critical) {
 		hdr.critical = 1;
 		rdb_tx_hdr_encode(&hdr, tx->dt_entry);
 	}
@@ -466,7 +462,7 @@ rdb_tx_create_root(struct rdb_tx *tx, const struct rdb_kvs_attr *attr)
 		.dto_attr	= (struct rdb_kvs_attr *)attr
 	};
 
-	return rdb_tx_append(tx, &op);
+	return rdb_tx_append(tx, &op, false /* is_critical */);
 }
 
 /**
@@ -487,7 +483,7 @@ rdb_tx_destroy_root(struct rdb_tx *tx)
 		.dto_attr	= NULL
 	};
 
-	return rdb_tx_append(tx, &op);
+	return rdb_tx_append(tx, &op, true /* is_critical */);
 }
 
 /**
@@ -512,7 +508,7 @@ rdb_tx_create_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
 		.dto_attr	= (struct rdb_kvs_attr *)attr
 	};
 
-	return rdb_tx_append(tx, &op);
+	return rdb_tx_append(tx, &op, false /* is_critical */);
 }
 
 /**
@@ -537,7 +533,7 @@ rdb_tx_destroy_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
 		.dto_attr	= NULL
 	};
 
-	return rdb_tx_append(tx, &op);
+	return rdb_tx_append(tx, &op, true /* is_critical */);
 }
 
 /**
@@ -562,7 +558,33 @@ rdb_tx_update(struct rdb_tx *tx, const rdb_path_t *kvs, const d_iov_t *key,
 		.dto_attr	= NULL
 	};
 
-	return rdb_tx_append(tx, &op);
+	return rdb_tx_append(tx, &op, false /* is_critical */);
+}
+
+/**
+ * Update the value of \a key in \a kvs to \a value.
+ * Mark the TX as critical (to not fail the TX due to SCM free space checks).
+ *
+ * \param[in]	tx	transaction
+ * \param[in]	kvs	path to KVS
+ * \param[in]	key	key in KVS
+ * \param[in]	value	new value
+ *
+ * \retval -DER_NOTLEADER	not current leader
+ */
+int
+rdb_tx_update_critical(struct rdb_tx *tx, const rdb_path_t *kvs, const d_iov_t *key,
+		       const d_iov_t *value)
+{
+	struct rdb_tx_op op = {
+		.dto_opc	= RDB_TX_UPDATE,
+		.dto_kvs	= *kvs,
+		.dto_key	= *key,
+		.dto_value	= *value,
+		.dto_attr	= NULL
+	};
+
+	return rdb_tx_append(tx, &op, true /* is_critical */);
 }
 
 /**
@@ -585,7 +607,7 @@ rdb_tx_delete(struct rdb_tx *tx, const rdb_path_t *kvs, const d_iov_t *key)
 		.dto_attr	= NULL
 	};
 
-	return rdb_tx_append(tx, &op);
+	return rdb_tx_append(tx, &op, true /* is_critical */);
 }
 
 static inline int

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -280,6 +280,10 @@ class ObjectMetadata(TestWithServers):
             "Phase 3: passed (created %d / %d containers)", len(self.container), loop)
         self.log.info("Test passed")
 
+        # instruct tearDown to skip containers destroy
+        # (we want to invoke pool destroy with a full metadata rdb)
+        self.skip_destroy_containers = True
+
     def test_metadata_addremove(self):
         """JIRA ID: DAOS-1512.
 

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -669,6 +669,9 @@ class TestWithServers(TestWithoutServers):
         # Suffix to append to each access point name
         self.access_points_suffix = None
 
+        # Option to skip destroying containers during tearDown (default: destroy containers)
+        self.skip_destroy_containers = False
+
     def setUp(self):
         """Set up each test case."""
         super().setUp()
@@ -1426,7 +1429,7 @@ class TestWithServers(TestWithoutServers):
 
         """
         error_list = []
-        if containers:
+        if containers and not self.skip_destroy_containers:
             if not isinstance(containers, (list, tuple)):
                 containers = [containers]
             self.test_log.info("Destroying containers")
@@ -1452,6 +1455,8 @@ class TestWithServers(TestWithoutServers):
                         self.test_log.info("  {}".format(error))
                         error_list.append(
                             "Error destroying container: {}".format(error))
+        elif self.skip_destroy_containers:
+            self.test_log.info("SKIP Destroying containers as requested by test")
         return error_list
 
     def destroy_pools(self, pools):

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -421,6 +421,7 @@ class TestPool(TestDaosApiBase):
         status = False
         if self.pool:
             if disconnect:
+                self.log.info("Disconnecting from pool %s", self.identifier)
                 self.disconnect()
             if self.pool.attached:
                 self.log.info("Destroying pool %s", self.identifier)


### PR DESCRIPTION
bypass space checks in pool evict rdb tx update

Before this change if pool rdb metadata is exhausted, and if the pool has no open connections, a pool destroy operation fails with -DER_NOSPACE. This is because the evict handles step only performs an RDB tx update on the "connectable" metadata property. Updates are not marked as a critical operation (so far, only RDB tx delete and destroy operations have that special designation).

With this change, certain RDB TX updates (currently only this one) can be declared "critical" by invoking the new function rdb_tx_update_critical() rather than rdb_tx_update(). This results in bypassing the SCM free space checks when committing the TX, and ultimately results in successful operation.

Also with this change the functional test infrastructure allows a test to customize, when destroying a pool, if its containers will be destroyed first. The test_metadata_fillup test is changed to keep its containers (whose creates have filled the pool metadata). So the test in tearDown exercises pool destroy under metadata full conditions.

Features: pool

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>