### PR TITLE
DAOS-11696 doc: clarify wording of pool map version exchange

### DIFF
--- a/docs/overview/fault.md
+++ b/docs/overview/fault.md
@@ -58,8 +58,8 @@ action).
 All storage targets are promptly notified of pool map changes by the pool
 service. This is not the case for client nodes, which are lazily informed
 of pool map invalidation each time they communicate with any engines. To do so,
-clients pack in every RPC their current pool map version. Servers reply not
-only with the current pool map version. Consequently, when a DAOS client
+clients include their last known pool map version with every RPC and servers reply
+with the current pool map version. Consequently, when a DAOS client
 experiences RPC timeout, it regularly communicates with the other DAOS
 target to guarantee that its pool map is always current. Clients will then
 eventually be informed of the target exclusion and enter into degraded mode.

--- a/docs/overview/use_cases.md
+++ b/docs/overview/use_cases.md
@@ -86,8 +86,9 @@ blocking barriers and then a more loosely coupled execution.
 <b>Blocking Barrier</b>
 
 When the simulation job starts, one task opens the checkpoint container
-and fetches the current global HCE. It thens obtains an epoch hold and
-shares the data (the container handle, the current LHE and global HCE)
+and fetches the current global HCE (highest committed epoch).
+It thens obtains an epoch hold and shares the data (the container handle,
+the current LHE (lowest held epoch) and global HCE)
 with peer tasks. Each task checks for the latest computation state saved
 to the checkpoint container by reading with an epoch equal to the global
 HCE and resumes computation from where it was last checkpointed.

--- a/docs/overview/use_cases.md
+++ b/docs/overview/use_cases.md
@@ -87,7 +87,7 @@ blocking barriers and then a more loosely coupled execution.
 
 When the simulation job starts, one task opens the checkpoint container
 and fetches the current global HCE (highest committed epoch).
-It thens obtains an epoch hold and shares the data (the container handle,
+It then obtains an epoch hold and shares the data (the container handle,
 the current LHE (lowest held epoch) and global HCE)
 with peer tasks. Each task checks for the latest computation state saved
 to the checkpoint container by reading with an epoch equal to the global

--- a/src/client/kv/README.md
+++ b/src/client/kv/README.md
@@ -4,7 +4,7 @@ The KV API simplifies the DAOS Object API and exposes a simple API to manipulate
 a Key-Value object with simple put/get/remove/list operations. The API exposes
 only a single Key (no multi-level keys) and a value associated with that key
 which is overwritten entirely anytime the key is updated. So internally the
-mapping of a the HL KV object looks like:
+mapping of the Multi-level KV object looks like:
 
 ~~~~~~
 Key -> DKey

--- a/src/control/cmd/daos_server/README.md
+++ b/src/control/cmd/daos_server/README.md
@@ -115,7 +115,7 @@ and the DAOS Server occur over the management network, via the gRPC protocol.
 Management requests can be made to operate over resources local to specific
 storage nodes or to operate over the distributed DAOS system.
 When issuing `dmg` commands that operate over the DAOS system, requests are
-directed to the management service leader which is capable of handling them.
+directed to the management service (MS) leader which is capable of handling them.
 The control API is responsible for working out which `daos_server` instance
 is the MS leader and issuing the request, `dmg` uses the control API.
 The `dmg` tool requires the hostlist of all hosts in the DAOS system to be

--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -39,7 +39,7 @@ enum daos_obj_redun {
 	OR_RP_128,
 
 	/**
-	 * N+K reed solomon erasude-coded object (OC_EC_NPK).
+	 * N+K reed solomon erasure-coded object (OC_EC_NPK).
 	 * - the first number is data cells number within a redundancy group
 	 * - the number after P is parity cells number within a redundancy group
 	 * C_S1

--- a/src/object/README.md
+++ b/src/object/README.md
@@ -33,7 +33,7 @@ the current supported object types. The default one is DAOS\_OT\_MULTI\_HASHED
 that does not impose any type of the akey or dkey and can store either a
 single value or array value under an akey. Lexical and integer (i.e. UINT64)
 keys are supported. The KV object type provides a simplified data model
-bypassing the akey and allowing only single single, while array object stores
+bypassing the akey and allowing only single value, while array object stores
 array chunks under integer dkeys.
 
 ## Object Class


### PR DESCRIPTION
DAOS-11696 doc: clarify wording of pool map version exchange

Clients detect pool map changes by passing their version to servers with
every RPC.

Required-githooks: true
Signed-off-by: Ted Anderson <nonzero@google.com>