### PR TITLE
DAOS-10663 dfs: add new DFS readdirplus API

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -3447,8 +3447,8 @@ dfs_lookup(dfs_t *dfs, const char *path, int flags, dfs_obj_t **_obj,
 }
 
 int
-dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
-	    struct dirent *dirs)
+readdir_int(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
+	    struct dirent *dirs, struct stat *stbufs)
 {
 	daos_key_desc_t	*kds;
 	char		*enum_buf;
@@ -3500,6 +3500,18 @@ dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
 				       kds[i].kd_key_len + 1, "%s", ptr);
 			D_ASSERT(len >= kds[i].kd_key_len);
 			ptr += kds[i].kd_key_len;
+
+			/** stat the entry if requested */
+			if (stbufs) {
+				rc = entry_stat(dfs, DAOS_TX_NONE, obj->oh, dirs[key_nr].d_name,
+						kds[i].kd_key_len, NULL, true, &stbufs[key_nr],
+						NULL);
+				if (rc) {
+					D_ERROR("Failed to stat entry %s: %d (%s)\n",
+						dirs[key_nr].d_name, rc, strerror(rc));
+					D_GOTO(out, rc);
+				}
+			}
 			key_nr++;
 		}
 		number = *nr - key_nr;
@@ -3512,6 +3524,20 @@ out:
 	D_FREE(enum_buf);
 	D_FREE(kds);
 	return rc;
+}
+
+int
+dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
+	    struct dirent *dirs)
+{
+	return readdir_int(dfs, obj, anchor, nr, dirs, NULL);
+}
+
+int
+dfs_readdirplus(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
+		struct dirent *dirs, struct stat *stbufs)
+{
+	return readdir_int(dfs, obj, anchor, nr, dirs, stbufs);
 }
 
 int

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -602,8 +602,32 @@ dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len);
  * \return		0 on success, errno code on failure.
  */
 int
-dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor,
-	    uint32_t *nr, struct dirent *dirs);
+dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr, struct dirent *dirs);
+
+/**
+ * directory readdir + stat.
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ * \param[in]	obj	Opened directory object.
+ * \param[in,out]
+ *		anchor	Hash anchor for the next call, it should be set to
+ *			zeroes for the first call, it should not be changed
+ *			by caller between calls.
+ * \param[in,out]
+ *		nr	[in]: number of dirents allocated in \a dirs.
+ *			[out]: number of returned dirents.
+ * \param[in,out]
+ *		dirs	[in] preallocated array of dirents.
+ *			[out]: dirents returned with d_name filled only.
+ * \param[in,out]
+ *		stbufs	[in] preallocated array of struct stat.
+ *			[out]: stat of every entry in \a dirs.
+ *
+ * \return		0 on success, errno code on failure.
+ */
+int
+dfs_readdirplus(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
+		struct dirent *dirs, struct stat *stbufs);
 
 /**
  * User callback defined for dfs_readdir_size.


### PR DESCRIPTION
Same as readdir but also does a stat on the entry for convenience.

Required-githooks: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>