### PR TITLE
DAOS-11391 control,bio: Add explicit SSD role assignment to server config

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -89,7 +89,7 @@ const (
 	BdevDuplicatesInDeviceList
 	BdevNoDevicesMatchFilter
 	BdevAccelEngineUnknown
-	BdevAccelOptionUnknown
+	BdevConfigOptFlagUnknown
 	BdevConfigTypeMismatch
 	BdevNonRootVFIODisable
 	BdevNoIOMMU

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -93,6 +93,8 @@ const (
 	BdevConfigTypeMismatch
 	BdevNonRootVFIODisable
 	BdevNoIOMMU
+	BdevConfigMultiTiersWithDCPM
+	BdevConfigBadNrRoles
 )
 
 // DAOS system fault codes

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -871,7 +871,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
 							WithStorageClass(storage.ClassNvme.String()).
-							WithBdevDeviceList(test.MockPCIAddr(1)),
+							WithBdevDeviceList(test.MockPCIAddr(1)).
+							WithBdevDeviceRoles(storage.BdevRoleData),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
@@ -903,7 +904,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
 							WithStorageClass(storage.ClassNvme.String()).
-							WithBdevDeviceList(test.MockPCIAddrs(0, 1, 2)...),
+							WithBdevDeviceList(test.MockPCIAddrs(0, 1, 2)...).
+							WithBdevDeviceRoles(storage.BdevRoleData),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
@@ -922,7 +924,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos1"),
 						storage.NewTierConfig().
 							WithStorageClass(storage.ClassNvme.String()).
-							WithBdevDeviceList(test.MockPCIAddrs(4, 5, 6)...),
+							WithBdevDeviceList(test.MockPCIAddrs(4, 5, 6)...).
+							WithBdevDeviceRoles(storage.BdevRoleData),
 					).
 					WithStorageNumaNodeIndex(1).
 					WithStorageConfigOutputPath("/mnt/daos1/daos_nvme.conf").
@@ -953,7 +956,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
 							WithStorageClass(storage.ClassNvme.String()).
-							WithBdevDeviceList(test.MockPCIAddr(1)),
+							WithBdevDeviceList(test.MockPCIAddr(1)).
+							WithBdevDeviceRoles(storage.BdevRoleData),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
@@ -986,7 +990,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
 							WithStorageClass(storage.ClassNvme.String()).
-							WithBdevDeviceList(test.MockPCIAddrs(0, 1, 2)...),
+							WithBdevDeviceList(test.MockPCIAddrs(0, 1, 2)...).
+							WithBdevDeviceRoles(storage.BdevRoleData),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
@@ -1006,7 +1011,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos1"),
 						storage.NewTierConfig().
 							WithStorageClass(storage.ClassNvme.String()).
-							WithBdevDeviceList(test.MockPCIAddrs(4, 5, 6)...),
+							WithBdevDeviceList(test.MockPCIAddrs(4, 5, 6)...).
+							WithBdevDeviceRoles(storage.BdevRoleData),
 					).
 					WithStorageConfigOutputPath("/mnt/daos1/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
@@ -1040,7 +1046,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos0"),
 						storage.NewTierConfig().
 							WithStorageClass(storage.ClassNvme.String()).
-							WithBdevDeviceList("0000:5d:05.5"),
+							WithBdevDeviceList("0000:5d:05.5").
+							WithBdevDeviceRoles(storage.BdevRoleData),
 					).
 					WithStorageConfigOutputPath("/mnt/daos0/daos_nvme.conf").
 					WithStorageVosEnv("NVME").
@@ -1060,7 +1067,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 							WithScmMountPoint("/mnt/daos1"),
 						storage.NewTierConfig().
 							WithStorageClass(storage.ClassNvme.String()).
-							WithBdevDeviceList("0000:d7:07.1"),
+							WithBdevDeviceList("0000:d7:07.1").
+							WithBdevDeviceRoles(storage.BdevRoleData),
 					).
 					WithStorageConfigOutputPath("/mnt/daos1/daos_nvme.conf").
 					WithStorageVosEnv("NVME").

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -36,6 +36,8 @@ const (
 	verbsExample     = "../../../../utils/config/examples/daos_server_verbs.yml"
 	defaultConfig    = "../../../../utils/config/daos_server.yml"
 	legacyConfig     = "../../../../utils/config/examples/daos_server_unittests.yml"
+
+	allBdevRoles = storage.BdevRoleWAL | storage.BdevRoleIndex | storage.BdevRoleData
 )
 
 var (
@@ -252,7 +254,8 @@ func TestServerConfig_Constructed(t *testing.T) {
 				storage.NewTierConfig().
 					WithStorageClass("nvme").
 					WithBdevDeviceList("0000:81:00.0", "0000:82:00.0").
-					WithBdevBusidRange("0x80-0x8f"),
+					WithBdevBusidRange("0x80-0x8f").
+					WithBdevDeviceRoles(allBdevRoles),
 			).
 			WithFabricInterface("ib0").
 			WithFabricInterfacePort(20000).
@@ -639,7 +642,8 @@ func TestServerConfig_Validation(t *testing.T) {
 							WithScmMountPoint("/foo"),
 						storage.NewTierConfig().
 							WithStorageClass("nvme").
-							WithBdevDeviceList("0000:81:00.0"),
+							WithBdevDeviceList("0000:81:00.0").
+							WithBdevDeviceRoles(allBdevRoles),
 					).
 					WithStorageConfigOutputPath("/foo/daos_nvme.conf").
 					WithStorageVosEnv("NVME"),

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -36,8 +36,6 @@ const (
 	verbsExample     = "../../../../utils/config/examples/daos_server_verbs.yml"
 	defaultConfig    = "../../../../utils/config/daos_server.yml"
 	legacyConfig     = "../../../../utils/config/examples/daos_server_unittests.yml"
-
-	allBdevRoles = storage.BdevRoleWAL | storage.BdevRoleIndex | storage.BdevRoleData
 )
 
 var (
@@ -255,7 +253,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 					WithStorageClass("nvme").
 					WithBdevDeviceList("0000:81:00.0", "0000:82:00.0").
 					WithBdevBusidRange("0x80-0x8f").
-					WithBdevDeviceRoles(allBdevRoles),
+					WithBdevDeviceRoles(storage.BdevRoleAll),
 			).
 			WithFabricInterface("ib0").
 			WithFabricInterfacePort(20000).
@@ -643,7 +641,7 @@ func TestServerConfig_Validation(t *testing.T) {
 						storage.NewTierConfig().
 							WithStorageClass("nvme").
 							WithBdevDeviceList("0000:81:00.0").
-							WithBdevDeviceRoles(allBdevRoles),
+							WithBdevDeviceRoles(storage.BdevRoleAll),
 					).
 					WithStorageConfigOutputPath("/foo/daos_nvme.conf").
 					WithStorageVosEnv("NVME"),

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -63,6 +63,7 @@ const (
 	BdevRoleData  = C.NVME_ROLE_DATA
 	BdevRoleIndex = C.NVME_ROLE_INDEX
 	BdevRoleWAL   = C.NVME_ROLE_WAL
+	BdevRoleAll   = BdevRoleData | BdevRoleIndex | BdevRoleWAL
 )
 
 // NvmeDevState represents the health state of NVMe device as reported by DAOS engine BIO module.

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -58,6 +58,13 @@ const (
 	AccelOptCRCFlag  = C.NVME_ACCEL_FLAG_CRC
 )
 
+// Role assignments for NVMe SSDs related to type of storage (enables Metadata-on-SSD capability).
+const (
+	BdevRoleData  = C.NVME_ROLE_DATA
+	BdevRoleIndex = C.NVME_ROLE_INDEX
+	BdevRoleWAL   = C.NVME_ROLE_WAL
+)
+
 // NvmeDevState represents the health state of NVMe device as reported by DAOS engine BIO module.
 type NvmeDevState uint32
 
@@ -407,6 +414,7 @@ type (
 		DeviceList     *BdevDeviceList
 		DeviceFileSize uint64 // size in bytes for NVMe device emulation
 		Tier           int
+		DeviceRoles    BdevDeviceRoles // NVMe SSD role assignments
 	}
 
 	// BdevFormatRequest defines the parameters for a Format operation.

--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
-const allBdevRoles = storage.BdevRoleWAL | storage.BdevRoleIndex | storage.BdevRoleData
-
 // TestBackend_createEmptyFile verifies empty files are created as expected.
 func TestBackend_createEmptyFile(t *testing.T) {
 	tests := map[string]struct {
@@ -163,7 +161,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1, 2)...),
 					DeviceRoles: storage.BdevDeviceRoles{
-						OptionBits: storage.OptionBits(allBdevRoles),
+						OptionBits: storage.OptionBits(storage.BdevRoleAll),
 					},
 				},
 			},

--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
+const allBdevRoles = storage.BdevRoleWAL | storage.BdevRoleIndex | storage.BdevRoleData
+
 // TestBackend_createEmptyFile verifies empty files are created as expected.
 func TestBackend_createEmptyFile(t *testing.T) {
 	tests := map[string]struct {
@@ -143,7 +145,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84",
+            "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -160,6 +162,9 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1, 2)...),
+					DeviceRoles: storage.BdevDeviceRoles{
+						OptionBits: storage.OptionBits(allBdevRoles),
+					},
 				},
 			},
 			expOut: `
@@ -198,7 +203,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84",
+            "name": "Nvme_hostfoo_0_84_7",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -206,7 +211,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_1_84",
+            "name": "Nvme_hostfoo_1_84_7",
             "traddr": "0000:02:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -263,7 +268,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84",
+            "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -271,7 +276,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_1_84",
+            "name": "Nvme_hostfoo_1_84_0",
             "traddr": "0000:02:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -345,7 +350,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84",
+            "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -353,7 +358,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_1_84",
+            "name": "Nvme_hostfoo_1_84_0",
             "traddr": "0000:02:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -418,7 +423,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84",
+            "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -426,7 +431,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_1_84",
+            "name": "Nvme_hostfoo_1_84_0",
             "traddr": "0000:02:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -493,7 +498,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84",
+            "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -550,7 +555,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84",
+            "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
@@ -615,7 +620,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
         {
           "params": {
             "trtype": "PCIe",
-            "name": "Nvme_hostfoo_0_84",
+            "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"

--- a/src/control/server/storage/bdev/backend_json.go
+++ b/src/control/server/storage/bdev/backend_json.go
@@ -217,7 +217,9 @@ func getSpdkConfigMethods(req *storage.BdevWriteConfigRequest) (sscs []*SpdkSubs
 		}
 
 		for index, dev := range tier.DeviceList.Devices() {
-			name := fmt.Sprintf("%s_%d_%d", req.Hostname, index, tier.Tier)
+			// Encode bdev tier info in RPC name field.
+			name := fmt.Sprintf("%s_%d_%d_%s", req.Hostname, index, tier.Tier,
+				tier.DeviceRoles.String())
 			sscs = append(sscs, f(name, dev))
 		}
 	}

--- a/src/control/server/storage/bdev/backend_json_test.go
+++ b/src/control/server/storage/bdev/backend_json_test.go
@@ -93,14 +93,14 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 		"multiple controllers": {
 			class:       storage.ClassNvme,
 			devList:     []string{test.MockPCIAddr(1), test.MockPCIAddr(2)},
-			devRoles:    allBdevRoles,
+			devRoles:    storage.BdevRoleAll,
 			expBdevCfgs: multiCtrlrConfs(),
 		},
 		"multiple controllers; vmd enabled": {
 			class:       storage.ClassNvme,
 			enableVmd:   true,
 			devList:     []string{test.MockPCIAddr(1), test.MockPCIAddr(2)},
-			devRoles:    allBdevRoles,
+			devRoles:    storage.BdevRoleAll,
 			expBdevCfgs: multiCtrlrConfs(),
 			expExtraSubsystems: []*SpdkSubsystem{
 				{
@@ -117,7 +117,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 		"multiple controllers; hotplug enabled; bus-id range specified": {
 			class:         storage.ClassNvme,
 			devList:       []string{test.MockPCIAddr(1), test.MockPCIAddr(2)},
-			devRoles:      allBdevRoles,
+			devRoles:      storage.BdevRoleAll,
 			enableHotplug: true,
 			busidRange:    "0x8a-0x8f",
 			expBdevCfgs:   hotplugConfs,
@@ -185,7 +185,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 		"multiple controllers; acceleration set to spdk; move and crc opts specified": {
 			class:        storage.ClassNvme,
 			devList:      []string{test.MockPCIAddr(1), test.MockPCIAddr(2)},
-			devRoles:     allBdevRoles,
+			devRoles:     storage.BdevRoleAll,
 			accelEngine:  storage.AccelEngineSPDK,
 			accelOptMask: storage.AccelOptCRCFlag | storage.AccelOptMoveFlag,
 			expBdevCfgs:  multiCtrlrConfs(),

--- a/src/control/server/storage/bdev/backend_json_test.go
+++ b/src/control/server/storage/bdev/backend_json_test.go
@@ -29,6 +29,17 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 	mockMntpt := "/mock/mnt/daos"
 	tierID := 84
 	host, _ := os.Hostname()
+	disabledRoleBits := 0
+	enabledRoleBits := 7
+	namePostfix := func(i, r int) string {
+		return fmt.Sprintf("%s_%d_%d_%d", host, i, tierID, r)
+	}
+	nvmeName := func(i int) string {
+		return fmt.Sprintf("Nvme_%s", namePostfix(i, enabledRoleBits))
+	}
+	aioName := func(i int) string {
+		return fmt.Sprintf("AIO_%s", namePostfix(i, disabledRoleBits))
+	}
 
 	multiCtrlrConfs := func() []*SpdkSubsystemConfig {
 		return append(defaultSpdkConfig().Subsystems[0].Configs,
@@ -37,7 +48,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 					Method: storage.ConfBdevNvmeAttachController,
 					Params: NvmeAttachControllerParams{
 						TransportType:    "PCIe",
-						DeviceName:       fmt.Sprintf("Nvme_%s_0_%d", host, tierID),
+						DeviceName:       nvmeName(0),
 						TransportAddress: test.MockPCIAddr(1),
 					},
 				},
@@ -45,7 +56,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 					Method: storage.ConfBdevNvmeAttachController,
 					Params: NvmeAttachControllerParams{
 						TransportType:    "PCIe",
-						DeviceName:       fmt.Sprintf("Nvme_%s_1_%d", host, tierID),
+						DeviceName:       nvmeName(1),
 						TransportAddress: test.MockPCIAddr(2),
 					},
 				},
@@ -61,6 +72,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 		class              storage.Class
 		fileSizeGB         int
 		devList            []string
+		devRoles           int
 		enableVmd          bool
 		enableHotplug      bool
 		busidRange         string
@@ -81,12 +93,14 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 		"multiple controllers": {
 			class:       storage.ClassNvme,
 			devList:     []string{test.MockPCIAddr(1), test.MockPCIAddr(2)},
+			devRoles:    allBdevRoles,
 			expBdevCfgs: multiCtrlrConfs(),
 		},
 		"multiple controllers; vmd enabled": {
 			class:       storage.ClassNvme,
 			enableVmd:   true,
 			devList:     []string{test.MockPCIAddr(1), test.MockPCIAddr(2)},
+			devRoles:    allBdevRoles,
 			expBdevCfgs: multiCtrlrConfs(),
 			expExtraSubsystems: []*SpdkSubsystem{
 				{
@@ -103,6 +117,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 		"multiple controllers; hotplug enabled; bus-id range specified": {
 			class:         storage.ClassNvme,
 			devList:       []string{test.MockPCIAddr(1), test.MockPCIAddr(2)},
+			devRoles:      allBdevRoles,
 			enableHotplug: true,
 			busidRange:    "0x8a-0x8f",
 			expBdevCfgs:   hotplugConfs,
@@ -130,7 +145,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 						Method: storage.ConfBdevAioCreate,
 						Params: AioCreateParams{
 							BlockSize:  humanize.KiByte * 4,
-							DeviceName: fmt.Sprintf("AIO_%s_0_%d", host, tierID),
+							DeviceName: aioName(0),
 							Filename:   "/path/to/myfile",
 						},
 					},
@@ -138,7 +153,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 						Method: storage.ConfBdevAioCreate,
 						Params: AioCreateParams{
 							BlockSize:  humanize.KiByte * 4,
-							DeviceName: fmt.Sprintf("AIO_%s_1_%d", host, tierID),
+							DeviceName: aioName(1),
 							Filename:   "/path/to/myotherfile",
 						},
 					},
@@ -153,14 +168,14 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 					{
 						Method: storage.ConfBdevAioCreate,
 						Params: AioCreateParams{
-							DeviceName: fmt.Sprintf("AIO_%s_0_%d", host, tierID),
+							DeviceName: aioName(0),
 							Filename:   "/dev/sdb",
 						},
 					},
 					{
 						Method: storage.ConfBdevAioCreate,
 						Params: AioCreateParams{
-							DeviceName: fmt.Sprintf("AIO_%s_1_%d", host, tierID),
+							DeviceName: aioName(1),
 							Filename:   "/dev/sdc",
 						},
 					},
@@ -170,6 +185,7 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 		"multiple controllers; acceleration set to spdk; move and crc opts specified": {
 			class:        storage.ClassNvme,
 			devList:      []string{test.MockPCIAddr(1), test.MockPCIAddr(2)},
+			devRoles:     allBdevRoles,
 			accelEngine:  storage.AccelEngineSPDK,
 			accelOptMask: storage.AccelOptCRCFlag | storage.AccelOptMoveFlag,
 			expBdevCfgs:  multiCtrlrConfs(),
@@ -197,6 +213,9 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 					DeviceList: storage.MustNewBdevDeviceList(tc.devList...),
 					FileSize:   tc.fileSizeGB,
 					BusidRange: storage.MustNewBdevBusRange(tc.busidRange),
+					DeviceRoles: storage.BdevDeviceRoles{
+						storage.OptionBits(tc.devRoles),
+					},
 				},
 			}
 			if tc.class != "" {
@@ -212,8 +231,8 @@ func TestBackend_newSpdkConfig(t *testing.T) {
 				WithFabricInterfacePort(42).
 				WithStorage(
 					storage.NewTierConfig().
-						WithStorageClass("dcpm").
-						WithScmDeviceList("foo").
+						WithStorageClass("ram").
+						WithScmRamdiskSize(16).
 						WithScmMountPoint(mockMntpt),
 					cfg,
 				).

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -91,11 +91,12 @@ func FaultBdevAccelEngineUnknown(input string, options ...string) *fault.Fault {
 			options))
 }
 
-// FaultBdevAccelOptUnknown creates a Fault when an unrecognized acceleration option is detected.
-func FaultBdevAccelOptionUnknown(input string, options ...string) *fault.Fault {
+// FaultBdevConfigOptFlagUnknown creates a Fault when an unrecognized option flag (string) is detected
+// in the engine storage section of the config file.
+func FaultBdevConfigOptFlagUnknown(input string, options ...string) *fault.Fault {
 	return storageFault(
-		code.BdevAccelOptionUnknown,
-		fmt.Sprintf("unknown acceleration option %q", input),
+		code.BdevConfigOptFlagUnknown,
+		fmt.Sprintf("unknown option flag given: %q", input),
 		fmt.Sprintf("supported options are %v, update server config file and restart daos_server",
 			options))
 }

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -101,6 +101,22 @@ func FaultBdevConfigOptFlagUnknown(input string, options ...string) *fault.Fault
 			options))
 }
 
+// FaultBdevConfigMultiTiersWithDCPM creates a Fault when multiple bdev tiers are specified with DCPM
+// SCM class, which is unsupported.
+var FaultBdevConfigMultiTiersWithDCPM = storageFault(
+	code.BdevConfigMultiTiersWithDCPM,
+	"Multiple bdev tiers in config with scm class set to dcpm",
+	"Only a single bdev tier is supported if scm tier is of class dcpm, reduce the number of bdev tiers in config")
+
+// FaultBdevConfigBadNrRoles creates a Fault when an unexpected number of roles have been assigned
+// to bdev tiers.
+func FaultBdevConfigBadNrRoles(tierType string, gotNr, wantNr int) *fault.Fault {
+	return storageFault(
+		code.BdevConfigBadNrRoles,
+		fmt.Sprintf("found %d %s tiers, wanted %d", gotNr, tierType, wantNr),
+		"Adjust the bdev tier role assignments in config to fulfil the requirement")
+}
+
 var FaultBdevNonRootVFIODisable = storageFault(
 	code.BdevNonRootVFIODisable,
 	"VFIO can not be disabled if running as non-root user",

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -258,11 +258,11 @@ func (p *Provider) HasBlockDevices() bool {
 // BdevTierPropertiesFromConfig returns BdevTierProperties struct from given TierConfig.
 func BdevTierPropertiesFromConfig(cfg *TierConfig) BdevTierProperties {
 	return BdevTierProperties{
-		Class:      cfg.Class,
-		DeviceList: cfg.Bdev.DeviceList,
-		// cfg size in nr GiBytes
+		Class:          cfg.Class,
+		DeviceList:     cfg.Bdev.DeviceList,
 		DeviceFileSize: uint64(humanize.GiByte * cfg.Bdev.FileSize),
 		Tier:           cfg.Tier,
+		DeviceRoles:    cfg.Bdev.DeviceRoles,
 	}
 }
 

--- a/src/include/daos_srv/control.h
+++ b/src/include/daos_srv/control.h
@@ -62,6 +62,11 @@ dpdk_cli_override_opts;
 #define NVME_ACCEL_FLAG_MOVE	(1 << 0)
 #define NVME_ACCEL_FLAG_CRC	(1 << 1)
 
+/** Device role flags */
+#define NVME_ROLE_DATA		(1 << 0)
+#define NVME_ROLE_INDEX		(1 << 1)
+#define NVME_ROLE_WAL		(1 << 2)
+
 static inline char *
 nvme_state2str(int state)
 {

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -384,6 +384,19 @@
 #    bdev_busid_range: 0x80-0x8f
 #    #bdev_busid_range: 128-143
 #
+#    # Optional explicit nvme-class bdev tier role assignments, will define the roles and
+#    # responsibilities of this bdev tier. Note that roles will not be assigned if DCPM
+#    # class tier is defined. Roles will be derived implicitly based on configured bdev
+#    # tiers if not explicitly specified here.
+#    # Options are:
+#    # - "data" SSDs will be used to store actual data
+#    # - "index" SSDs will be used to store the VOS index
+#    # - "wal" SSDs will be used to store the write-ahead-log
+#    bdev_roles:
+#    - data
+#    - index
+#    - wal
+#
 #
 #  # Specify accelerator engine setting (experimental).
 #
@@ -552,6 +565,16 @@
 #    # will not be processed by this engine. Empty or unset range signifies allow all.
 #    #bdev_busid_range: 0xd0-0xdf
 #    #bdev_busid_range: 208-223
+#
+#    # Optional explicit nvme-class bdev tier role assignments, will define the roles and
+#    # responsibilities of this bdev tier. Note that roles will not be assigned if DCPM
+#    # class tier is defined. Roles will be derived implicitly based on configured bdev
+#    # tiers if not explicitly specified here.
+#    # Options are:
+#    # - "data" SSDs will be used to store actual data
+#    # - "index" SSDs will be used to store the VOS index
+#    # - "wal" SSDs will be used to store the write-ahead-log
+#    bdev_roles: []
 #
 #
 #  # Specify accelerator engine setting (experimental).


### PR DESCRIPTION
Allow NVMe SSD roles for MD-on-SSD to be explicitly set per-bdev-tier in
the server config file. The settings are data, index and wal. Settings
are communicated to the engine in the SPDK JSON config and exposed in
the bdev name once the SPDK subsystems have been initialized in the
engine's BIO module.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>