### PR TITLE
DAOS-11728 object: refine sgl iov_len handling in EC data recovery

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -322,7 +322,7 @@ daos_sgl_get_bytes(d_sg_list_t *sgl, bool check_buf, struct daos_sgl_idx *idx,
 	daos_size_t len;
 
 	if (p_buf_len != NULL)
-	*p_buf_len = 0;
+		*p_buf_len = 0;
 
 	if (idx->iov_idx >= sgl->sg_nr)
 		return true; /** no data in sgl to get bytes from */
@@ -330,7 +330,9 @@ daos_sgl_get_bytes(d_sg_list_t *sgl, bool check_buf, struct daos_sgl_idx *idx,
 	len = check_buf ? sgl->sg_iovs[idx->iov_idx].iov_buf_len :
 		sgl->sg_iovs[idx->iov_idx].iov_len;
 
-	D_ASSERT(idx->iov_offset < len);
+	D_ASSERT(idx->iov_offset <= len);
+	if (len == 0)
+		goto next_iov;
 	/** Point to current idx */
 	if (p_buf != NULL)
 		*p_buf = sgl->sg_iovs[idx->iov_idx].iov_buf + idx->iov_offset;
@@ -345,6 +347,7 @@ daos_sgl_get_bytes(d_sg_list_t *sgl, bool check_buf, struct daos_sgl_idx *idx,
 	idx->iov_offset += buf_len;
 
 	/** If end of iov was reached, go to next iov */
+next_iov:
 	if (idx->iov_offset == len) {
 		idx->iov_idx++;
 		idx->iov_offset = 0;

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -330,9 +330,7 @@ daos_sgl_get_bytes(d_sg_list_t *sgl, bool check_buf, struct daos_sgl_idx *idx,
 	len = check_buf ? sgl->sg_iovs[idx->iov_idx].iov_buf_len :
 		sgl->sg_iovs[idx->iov_idx].iov_len;
 
-	D_ASSERT(idx->iov_offset <= len);
-	if (len == 0)
-		goto next_iov;
+	D_ASSERT(idx->iov_offset < len);
 	/** Point to current idx */
 	if (p_buf != NULL)
 		*p_buf = sgl->sg_iovs[idx->iov_idx].iov_buf + idx->iov_offset;
@@ -347,7 +345,6 @@ daos_sgl_get_bytes(d_sg_list_t *sgl, bool check_buf, struct daos_sgl_idx *idx,
 	idx->iov_offset += buf_len;
 
 	/** If end of iov was reached, go to next iov */
-next_iov:
 	if (idx->iov_offset == len) {
 		idx->iov_idx++;
 		idx->iov_offset = 0;

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2633,7 +2633,7 @@ obj_ec_sgl_copy(d_sg_list_t *sgl, uint64_t off, void *buf, uint64_t size)
 
 	/* to skip the sgl to offset - off */
 	if (off != 0) {
-		rc = daos_sgl_processor(sgl, false, &sgl_idx, off, NULL, NULL);
+		rc = daos_sgl_processor(sgl, true, &sgl_idx, off, NULL, NULL);
 		D_ASSERT(rc == 0);
 	}
 
@@ -2641,7 +2641,7 @@ obj_ec_sgl_copy(d_sg_list_t *sgl, uint64_t off, void *buf, uint64_t size)
 	arg.size = size;
 	arg.copied = 0;
 	/* to copy data from [buf, buf + size) to sgl */
-	rc = daos_sgl_processor(sgl, false, &sgl_idx, size, oes_copy, &arg);
+	rc = daos_sgl_processor(sgl, true, &sgl_idx, size, oes_copy, &arg);
 	D_ASSERT(rc == 0);
 }
 


### PR DESCRIPTION
Fix a bug of after obj_ec_recov_data() did not set sgl's iov_len. 
Added a test case to verify it.

Required-githooks: true

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>