### PR TITLE
DAOS-11679 dtx: misc patch for dtx related issues

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -110,7 +110,7 @@ extern uint32_t dtx_agg_thd_cnt_lo;
 #define DTX_AGG_AGE_PRESERVE	3
 
 /* The threshold for yield CPU when handle DTX RPC. */
-#define DTX_RPC_YIELD_THD	64
+#define DTX_RPC_YIELD_THD	32
 
 /* The time threshold for triggering DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshold, it will trigger DTX
@@ -144,6 +144,13 @@ extern uint32_t dtx_batched_ult_max;
 /* The threshold for using helper ULT when handle DTX RPC. */
 #define DTX_RPC_HELPER_THD_MIN	18
 #define DTX_RPC_HELPER_THD_DEF	(DTX_THRESHOLD_COUNT + 1)
+
+/*
+ * If the size of dtx_memberships exceeds DTX_INLINE_MBS_SIZE, then load it (DTX mbs)
+ * dynamically when use it to avoid holding a lot of DRAM resource for long time that
+ * may happen on some very large system.
+ */
+#define DTX_INLINE_MBS_SIZE		512
 
 extern uint32_t dtx_rpc_helper_thd;
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -22,6 +22,7 @@ struct dtx_resync_entry {
 	d_list_t		dre_link;
 	daos_epoch_t		dre_epoch;
 	daos_unit_oid_t		dre_oid;
+	uint32_t		dre_inline_mbs:1;
 	uint64_t		dre_dkey_hash;
 	struct dtx_entry	dre_dte;
 };
@@ -46,8 +47,11 @@ dtx_dre_release(struct dtx_resync_head *drh, struct dtx_resync_entry *dre)
 {
 	drh->drh_count--;
 	d_list_del(&dre->dre_link);
-	if (--(dre->dre_dte.dte_refs) == 0)
+	if (--(dre->dre_dte.dte_refs) == 0) {
+		if (dre->dre_inline_mbs == 0)
+			D_FREE(dre->dre_dte.dte_mbs);
 		D_FREE(dre);
+	}
 }
 
 static int
@@ -121,6 +125,8 @@ next:
 
 			dre = d_list_entry(dtes[i], struct dtx_resync_entry,
 					   dre_dte);
+			if (dre->dre_inline_mbs == 0)
+				D_FREE(dre->dre_dte.dte_mbs);
 			D_FREE(dre);
 		}
 	} else {
@@ -403,6 +409,19 @@ dtx_status_handle(struct dtx_resync_args *dra)
 			continue;
 		}
 
+		if (dre->dre_dte.dte_mbs == NULL) {
+			rc = vos_dtx_load_mbs(cont->sc_hdl, &dre->dre_xid, &dre->dre_dte.dte_mbs);
+			if (rc != 0) {
+				if (rc != -DER_NONEXIST)
+					D_WARN("Failed to load mbs, do not know the leader for DTX "
+					       DF_DTI" (ver = %u/%u/%u): rc = %d, skip it.\n",
+					       DP_DTI(&dre->dre_xid), dra->resync_version,
+					       dra->discard_version, dre->dre_dte.dte_ver, rc);
+				dtx_dre_release(drh, dre);
+				continue;
+			}
+		}
+
 		mbs = dre->dre_dte.dte_mbs;
 		D_ASSERT(mbs->dm_tgt_cnt > 0);
 
@@ -481,7 +500,6 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	struct dtx_resync_entry		*dre;
 	struct dtx_entry		*dte;
 	struct dtx_memberships		*mbs;
-	size_t				 size;
 
 	/* We commit the DTXs periodically, there will be not too many DTXs
 	 * to be checked when resync. So we can load all those uncommitted
@@ -527,8 +545,11 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 
 	D_ASSERT(ent->ie_dtx_mbs_dsize > 0);
 
-	size = sizeof(*dre) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize;
-	D_ALLOC(dre, size);
+	if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE)
+		D_ALLOC_PTR(dre);
+	else
+		D_ALLOC(dre, sizeof(*dre) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize);
+
 	if (dre == NULL)
 		return -DER_NOMEM;
 
@@ -536,16 +557,23 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	dre->dre_dkey_hash = ent->ie_dkey_hash;
 
 	dte = &dre->dre_dte;
-	mbs = (struct dtx_memberships *)(dte + 1);
 
-	mbs->dm_tgt_cnt = ent->ie_dtx_tgt_cnt;
-	mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
-	mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
-	mbs->dm_flags = ent->ie_dtx_mbs_flags;
-	mbs->dm_dte_flags = ent->ie_dtx_flags;
-	memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
+	if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE) {
+		dre->dre_inline_mbs = 0;
+		dte->dte_mbs = NULL;
+	} else {
+		mbs = (struct dtx_memberships *)(dte + 1);
 
-	dte->dte_mbs = mbs;
+		mbs->dm_tgt_cnt = ent->ie_dtx_tgt_cnt;
+		mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
+		mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
+		mbs->dm_flags = ent->ie_dtx_mbs_flags;
+		mbs->dm_dte_flags = ent->ie_dtx_flags;
+		memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
+
+		dre->dre_inline_mbs = 1;
+		dte->dte_mbs = mbs;
+	}
 
 out:
 	dre->dre_epoch = ent->ie_epoch;

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -17,12 +17,13 @@
 #define DTX_REFRESH_MAX 4
 
 struct dtx_share_peer {
-	d_list_t		dsp_link;
-	struct dtx_id		dsp_xid;
-	daos_unit_oid_t		dsp_oid;
-	daos_epoch_t		dsp_epoch;
-	uint64_t		dsp_dkey_hash;
-	struct dtx_memberships	dsp_mbs;
+	d_list_t		 dsp_link;
+	struct dtx_id		 dsp_xid;
+	daos_unit_oid_t		 dsp_oid;
+	daos_epoch_t		 dsp_epoch;
+	uint64_t		 dsp_dkey_hash;
+	uint32_t		 dsp_inline_mbs:1;
+	struct dtx_memberships	*dsp_mbs;
 };
 
 /**
@@ -275,6 +276,15 @@ int dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont);
  */
 int dtx_handle_resend(daos_handle_t coh, struct dtx_id *dti,
 		      daos_epoch_t *epoch, uint32_t *pm_ver);
+
+static inline void
+dtx_dsp_free(struct dtx_share_peer *dsp)
+{
+	if (dsp->dsp_inline_mbs == 0)
+		D_FREE(dsp->dsp_mbs);
+
+	D_FREE(dsp);
+}
 
 static inline uint64_t
 dtx_hlc_age2sec(uint64_t hlc)

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -100,6 +100,18 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 	      bool for_refresh);
 
 /**
+ * Load participants information for the given DTX.
+ *
+ * \param coh		[IN]	Container open handle.
+ * \param dti		[IN]	Pointer to the DTX identifier.
+ * \param mbs		[OUT]	Pointer to the DTX participants information.
+ *
+ * \return		Zero on success, negative value if error.
+ */
+int
+vos_dtx_load_mbs(daos_handle_t coh, struct dtx_id *dti, struct dtx_memberships **mbs);
+
+/**
  * Commit the specified DTXs.
  *
  * \param coh	[IN]	Container open handle.

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1179,6 +1179,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 	int			 grp_start;
 	int			 rc = 0;
 	int			 idx;
+	uint32_t		 shard_idx;
 	uint8_t			 tgt_flags = 0;
 	int			 i;
 
@@ -1218,13 +1219,14 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 		start_tgt = obj_get_grp_size(obj) - 1;
 	}
 	/* Descending order to guarantee that EC parity is handled firstly. */
-	for (i = 0, idx = start_tgt; i < obj_get_grp_size(obj);
-	     i++, idx = ((idx + obj_get_grp_size(obj) - 1) % obj_get_grp_size(obj))) {
+	for (i = 0, idx = start_tgt, shard_idx = idx + grp_start; i < obj_get_grp_size(obj);
+	     i++, idx = ((idx + obj_get_grp_size(obj) - 1) % obj_get_grp_size(obj)),
+	     shard_idx = idx + grp_start) {
 		if (reasb_req != NULL && reasb_req->tgt_bitmap != NIL_BITMAP &&
 		    isclr(reasb_req->tgt_bitmap, idx))
 			continue;
 
-		rc = obj_shard_open(obj, idx + grp_start, tx->tx_pm_ver, &shard);
+		rc = obj_shard_open(obj, shard_idx, tx->tx_pm_ver, &shard);
 		if (rc == -DER_NONEXIST) {
 			rc = 0;
 			if (daos_oclass_is_ec(oca) && !all) {
@@ -1252,9 +1254,9 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 
 		if (shard->do_reintegrating)
 			tx->tx_reintegrating = 1;
-		/* XXX: It is possible that more than one shards locate on the
-		 *	same DAOS target under OSA mode, then the "idx" may be
-		 *	not equal to "shard->do_shard".
+		/*
+		 * NOTE: It is possible that more than one shards locate on the same DAOS target
+		 *	 under OSA mode, then the shard_idx may be not equal to "shard->do_shard".
 		 */
 
 		D_ASSERTF(shard->do_target_id < dtrg_nr,
@@ -1264,7 +1266,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 		dtrg = &dtrgs[shard->do_target_id];
 
 		dtrg->dtrg_flags |= tgt_flags;
-		if (unlikely(shard->do_shard != idx))
+		if (unlikely(shard->do_shard != shard_idx))
 			dtrg->dtrg_flags |= DTF_REASSEMBLE_REQ;
 
 		if (dtrg->dtrg_req_idx == NULL) {
@@ -1308,7 +1310,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 
 		dcri = &dtrg->dtrg_req_idx[dtrg->dtrg_read_cnt +
 					   dtrg->dtrg_write_cnt];
-		dcri->dcri_shard_off = idx;
+		dcri->dcri_shard_off = shard_idx;
 		dcri->dcri_shard_id = shard->do_shard;
 		dcri->dcri_req_idx = req_idx;
 		dcri->dcri_padding = 0;

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -309,6 +309,9 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 {
 	struct daos_cpd_disp_ent	*dcde = NULL;
 	struct daos_cpd_sub_req		*dcsr = NULL;
+	struct daos_cpd_req_idx		*dcri_child;
+	struct daos_cpd_req_idx		*dcri_parent;
+	uint32_t			 idx;
 	int				 count;
 	int				 prev = -1;
 	int				 cur = 0;
@@ -334,10 +337,6 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 	dcde->dcde_write_cnt = dcde_parent->dcde_write_cnt;
 
 	for (i = 0; i < count; i++) {
-		struct daos_cpd_req_idx		*dcri_child;
-		struct daos_cpd_req_idx		*dcri_parent;
-		int				 idx;
-
 		dcri_child = &dcde->dcde_reqs[i];
 		dcri_parent = &dcde_parent->dcde_reqs[i];
 		idx = dcri_parent->dcri_req_idx;
@@ -345,24 +344,26 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 
 		dcri_child->dcri_shard_off = dcri_parent->dcri_shard_off;
 		dcri_child->dcri_shard_id = dcri_parent->dcri_shard_id;
-		dcri_child->dcri_req_idx = cur;
 		dcri_child->dcri_padding = dcri_parent->dcri_padding;
 
 		if (idx == prev &&
 		    (dcsr_parent[idx].dcsr_opc != DCSO_UPDATE ||
-		     dcsr_parent[idx].dcsr_update.dcu_ec_split_req == NULL))
-			continue;
+		     dcsr_parent[idx].dcsr_update.dcu_ec_split_req == NULL)) {
+			D_ASSERT(cur >= 1);
 
-		prev = idx;
+			dcri_child->dcri_req_idx = cur - 1;
+			continue;
+		}
 
 		/*
 		 * Only copy the top level data structure for daos_cpd_sub_req. Some DRAM
 		 * area pointed via the pointer inside daos_cpd_sub_req are shared between
 		 * 'dcsr' and 'dcsr_parent'. Because we hold the parent RPC's reference,
-		 * then related DRAM area will not be freeduntil the callback for forwarded
+		 * then related DRAM area will not be freed until the callback for forwarded
 		 * RPC is handled.
 		 */
 		memcpy(&dcsr[cur], &dcsr_parent[idx], sizeof(dcsr[cur]));
+		dcri_child->dcri_req_idx = cur;
 
 		if (dcsr_parent[idx].dcsr_opc == DCSO_UPDATE) {
 			struct daos_cpd_update	*dcu_parent;
@@ -394,6 +395,7 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 			}
 		}
 
+		prev = idx;
 		cur++;
 	}
 
@@ -490,6 +492,7 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 	oci->oci_disp_tgts.ca_arrays = NULL;
 	oci->oci_disp_tgts.ca_count = 0;
 
+	/* It is safe to share the head with parent since we are holding reference on parent RPC. */
 	dcsh = ds_obj_cpd_get_dcsh(dca->dca_rpc, dca->dca_idx);
 	head_dcs->dcs_type = DCST_HEAD;
 	head_dcs->dcs_nr = 1;
@@ -514,6 +517,8 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 		remote_arg->cpd_reqs = dcsr;
 		remote_arg->cpd_desc = dcde;
 	} else {
+		remote_arg->cpd_reqs = NULL;
+		remote_arg->cpd_desc = NULL;
 		dcsr = dcsr_parent;
 		dcde = dcde_parent;
 		rc = total;

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -105,22 +105,22 @@ vts_dtx_end(struct dtx_handle *dth)
 		while ((dsp = d_list_pop_entry(&dth->dth_share_cmt_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 
 		while ((dsp = d_list_pop_entry(&dth->dth_share_abt_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 
 		while ((dsp = d_list_pop_entry(&dth->dth_share_act_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 
 		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 
 		dth->dth_share_tbd_count = 0;
 	}

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -135,7 +135,7 @@ dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 		dth->dth_share_tbd_count = 0;
 		goto out;
 	}
@@ -151,7 +151,7 @@ dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 	if (dth->dth_share_tbd_count >= DTX_REFRESH_MAX)
 		goto out;
 
-	D_ALLOC(dsp, sizeof(*dsp) + DAE_MBS_DSIZE(dae));
+	D_ALLOC(dsp, sizeof(*dsp) + sizeof(*mbs) + DAE_MBS_DSIZE(dae));
 	if (dsp == NULL) {
 		D_ERROR("Hit uncommitted DTX "DF_DTI" at %d: lid=%d, "
 			"but fail to alloc DRAM.\n",
@@ -164,7 +164,7 @@ dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 	dsp->dsp_epoch = DAE_EPOCH(dae);
 	dsp->dsp_dkey_hash = DAE_DKEY_HASH(dae);
 
-	mbs = &dsp->dsp_mbs;
+	mbs = (struct dtx_memberships *)(dsp + 1);
 	mbs->dm_tgt_cnt = DAE_TGT_CNT(dae);
 	mbs->dm_grp_cnt = DAE_GRP_CNT(dae);
 	mbs->dm_data_size = DAE_MBS_DSIZE(dae);
@@ -179,6 +179,9 @@ dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 		memcpy(mbs->dm_data, umem_off2ptr(umm, DAE_MBS_OFF(dae)),
 		       DAE_MBS_DSIZE(dae));
 	}
+
+	dsp->dsp_inline_mbs = 1;
+	dsp->dsp_mbs = mbs;
 
 	d_list_add_tail(&dsp->dsp_link, &dth->dth_share_tbd_list);
 	dth->dth_share_tbd_count++;
@@ -1846,6 +1849,35 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 
 	if (rc == -DER_NONEXIST && !cont->vc_cmt_dtx_indexed)
 		rc = -DER_INPROGRESS;
+
+	return rc;
+}
+
+int
+vos_dtx_load_mbs(daos_handle_t coh, struct dtx_id *dti, struct dtx_memberships **mbs)
+{
+	struct vos_container	*cont;
+	struct dtx_memberships	*tmp;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	d_iov_set(&kiov, dti, sizeof(*dti));
+	d_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc == 0) {
+		tmp = vos_dtx_pack_mbs(vos_cont2umm(cont), riov.iov_buf);
+		if (tmp == NULL)
+			rc = -DER_NOMEM;
+		else
+			*mbs = tmp;
+	}
+
+	if (rc != 0)
+		D_ERROR("Failed to load mbs for "DF_DTI": "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
 
 	return rc;
 }

--- a/src/vos/vos_tls.h
+++ b/src/vos/vos_tls.h
@@ -115,7 +115,7 @@ vos_dth_set(struct dtx_handle *dth)
 		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 		dth->dth_share_tbd_count = 0;
 	}
 


### PR DESCRIPTION
The patch fixes the following DTX related issues:

1. Use the address of tree handle for dtx_rpc_post.
   If we directly use the value of tree handle as dtx_rpc_post()'s
   input parameter, then it may be DAOS_HDL_INVAL before DTX helper
   ULT being scheduled. That will cause memory leak.

2. Abort remote DTX entry before local one.
   The DTX abort maybe triggered by dtx_leader_end for RPC timeout
   on some remote DTX participant(s). Under such case, client side
   RPC sponsor may also hit the RPC timeout and resends related RPC
   to the leader. To avoid DTX abort and resend RPC forwarding being
   executed in parallel, we will abort local DTX after remote done,
   before that the logic of handling resent RPC on server will find
   the local pinned DTX entry then notify related client to resend
   RPC sometime later.

3. More frequent CPU yield during DTX RPCs dispatch.
   It is possible that the DTX may contains a lot of participants.
   When we commit or abort such DTX, the leader needs to send RPCs
   to all related participant. That will take a lot of CPU cycles.
   Under such case, related DTX operation ULT will yield to avoid
   blocking others for too long time. The patch reduces the yield
   interval from per 64-RPCs to per 32-RPCs.

4. Dynamically load DTX participants information (dtx_memberships).
   For the transaction with very large participants information,
   handle related DTX (such as for DTX resync, for cleanup stale
   DTX entries) may take some time, expecially under the case of
   system very busy. If we pre-load all related MBS information
   in DRAM before really handle them, it will hold a lot of DRAM
   resource for long time. That may cause server OOM. The patch
   adjusts DTX MBS load policy as loading large MBS when use it
   instead of pre-loading.

5. Use absolute shard index to reassemble CPD RPC.
   The absolute shard index was changed accidentally to local index
   within single redundancy group when handle EC parity rotation.
   That will cause unexpected CPD RPC reassemble on leader. On the
   other hand, the reassemble logic on leader has some defect that
   may cause access DRAM out of boundary. The patch also fixes it.

Signed-off-by: Fan Yong <fan.yong@intel.com>