### PR TITLE
DAOS-11706 control: Move system.Rank* to lib/ranklist

### DIFF
--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -21,8 +21,8 @@ import (
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/lib/ui"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 /*
@@ -264,11 +264,11 @@ func (cmd *poolQueryCmd) Execute(_ []string) error {
 	if cmd.ShowEnabledRanks && cmd.ShowDisabledRanks {
 		return errors.New("show-enabled and show-disabled can't be used at the same time.")
 	}
-	var ranklistPtr **C.d_rank_list_t = nil
-	var ranklist *C.d_rank_list_t = nil
+	var rlPtr **C.d_rank_list_t = nil
+	var rl *C.d_rank_list_t = nil
 
 	if cmd.ShowEnabledRanks || cmd.ShowDisabledRanks {
-		ranklistPtr = &ranklist
+		rlPtr = &rl
 	}
 
 	cleanup, err := cmd.resolveAndConnect(C.DAOS_PC_RO, nil)
@@ -284,8 +284,8 @@ func (cmd *poolQueryCmd) Execute(_ []string) error {
 		pinfo.pi_bits &= C.uint64_t(^(uint64(C.DPI_ENGINES_ENABLED)))
 	}
 
-	rc := C.daos_pool_query(cmd.cPoolHandle, ranklistPtr, &pinfo, nil, nil)
-	defer C.d_rank_list_free(ranklist)
+	rc := C.daos_pool_query(cmd.cPoolHandle, rlPtr, &pinfo, nil, nil)
+	defer C.d_rank_list_free(rl)
 	if err := daosError(rc); err != nil {
 		return errors.Wrapf(err,
 			"failed to query pool %s", cmd.poolUUID)
@@ -296,12 +296,12 @@ func (cmd *poolQueryCmd) Execute(_ []string) error {
 		return err
 	}
 
-	if ranklistPtr != nil {
+	if rlPtr != nil {
 		if cmd.ShowEnabledRanks {
-			pqr.EnabledRanks = system.MustCreateRankSet(generateRankSet(ranklist))
+			pqr.EnabledRanks = ranklist.MustCreateRankSet(generateRankSet(rl))
 		}
 		if cmd.ShowDisabledRanks {
-			pqr.DisabledRanks = system.MustCreateRankSet(generateRankSet(ranklist))
+			pqr.DisabledRanks = ranklist.MustCreateRankSet(generateRankSet(rl))
 		}
 	}
 

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -20,9 +20,9 @@ import (
 	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/lib/ui"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // PoolCmd is the struct representing the top-level pool subcommand.
@@ -133,7 +133,7 @@ func (cmd *PoolCreateCmd) Execute(args []string) error {
 			context.Background(),
 			cmd.Logger,
 			cmd.ctlInvoker,
-			system.RankList(req.Ranks))
+			ranklist.RankList(req.Ranks))
 		if err != nil {
 			return err
 		}
@@ -393,7 +393,7 @@ func (cmd *PoolExcludeCmd) Execute(args []string) error {
 		return errors.WithMessage(err, "parsing target list")
 	}
 
-	req := &control.PoolExcludeReq{ID: cmd.PoolID().String(), Rank: system.Rank(cmd.Rank), Targetidx: idxlist}
+	req := &control.PoolExcludeReq{ID: cmd.PoolID().String(), Rank: ranklist.Rank(cmd.Rank), Targetidx: idxlist}
 
 	err := control.PoolExclude(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
@@ -422,7 +422,7 @@ func (cmd *PoolDrainCmd) Execute(args []string) error {
 		return err
 	}
 
-	req := &control.PoolDrainReq{ID: cmd.PoolID().String(), Rank: system.Rank(cmd.Rank), Targetidx: idxlist}
+	req := &control.PoolDrainReq{ID: cmd.PoolID().String(), Rank: ranklist.Rank(cmd.Rank), Targetidx: idxlist}
 
 	err := control.PoolDrain(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
@@ -475,7 +475,7 @@ func (cmd *PoolReintegrateCmd) Execute(args []string) error {
 		return err
 	}
 
-	req := &control.PoolReintegrateReq{ID: cmd.PoolID().String(), Rank: system.Rank(cmd.Rank), Targetidx: idxlist}
+	req := &control.PoolReintegrateReq{ID: cmd.PoolID().String(), Rank: ranklist.Rank(cmd.Rank), Targetidx: idxlist}
 
 	err := control.PoolReintegrate(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {
@@ -543,7 +543,7 @@ func (cmd *PoolQueryTargetsCmd) Execute(args []string) error {
 
 	req := &control.PoolQueryTargetReq{
 		ID:      cmd.PoolID().String(),
-		Rank:    system.Rank(cmd.Rank),
+		Rank:    ranklist.Rank(cmd.Rank),
 		Targets: tgtsList,
 	}
 

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -124,7 +125,7 @@ func TestPoolCommands(t *testing.T) {
 					TierRatio:  []float64{0.06, 0.94},
 					User:       eUsr.Username + "@",
 					UserGroup:  eGrp.Name + "@",
-					Ranks:      []system.Rank{},
+					Ranks:      []ranklist.Rank{},
 					Properties: []*control.PoolProperty{
 						propWithVal("label", "foo"),
 					},
@@ -141,7 +142,7 @@ func TestPoolCommands(t *testing.T) {
 					TierRatio:  []float64{0.06, 0.94},
 					User:       eUsr.Username + "@",
 					UserGroup:  eGrp.Name + "@",
-					Ranks:      []system.Rank{},
+					Ranks:      []ranklist.Rank{},
 					Properties: []*control.PoolProperty{
 						propWithVal("label", "foo"),
 					},
@@ -158,7 +159,7 @@ func TestPoolCommands(t *testing.T) {
 					TierRatio:  []float64{0.06, 0.94},
 					User:       eUsr.Username + "@",
 					UserGroup:  eGrp.Name + "@",
-					Ranks:      []system.Rank{},
+					Ranks:      []ranklist.Rank{},
 					Properties: []*control.PoolProperty{
 						propWithVal("label", "foo"),
 					},
@@ -223,7 +224,7 @@ func TestPoolCommands(t *testing.T) {
 					TierRatio:  []float64{0.1, 0.9},
 					User:       eUsr.Username + "@",
 					UserGroup:  eGrp.Name + "@",
-					Ranks:      []system.Rank{},
+					Ranks:      []ranklist.Rank{},
 				}),
 			}, " "),
 			nil,
@@ -242,7 +243,7 @@ func TestPoolCommands(t *testing.T) {
 					NumSvcReps: 3,
 					User:       eUsr.Username + "@",
 					UserGroup:  eGrp.Name + "@",
-					Ranks:      []system.Rank{},
+					Ranks:      []ranklist.Rank{},
 					TierBytes:  []uint64{uint64(testSize), 0},
 				}),
 			}, " "),
@@ -255,7 +256,7 @@ func TestPoolCommands(t *testing.T) {
 				printRequest(t, &control.PoolCreateReq{
 					User:       eUsr.Username + "@",
 					UserGroup:  eGrp.Name + "@",
-					Ranks:      []system.Rank{1, 2},
+					Ranks:      []ranklist.Rank{1, 2},
 					TotalBytes: uint64(testSize),
 					TierRatio:  []float64{0.06, 0.94},
 				}),
@@ -272,7 +273,7 @@ func TestPoolCommands(t *testing.T) {
 					NumRanks:   8,
 					User:       eUsr.Username + "@",
 					UserGroup:  eGrp.Name + "@",
-					Ranks:      []system.Rank{},
+					Ranks:      []ranklist.Rank{},
 				}),
 			}, " "),
 			nil,
@@ -285,7 +286,7 @@ func TestPoolCommands(t *testing.T) {
 					NumSvcReps: 3,
 					User:       "foo@home",
 					UserGroup:  "bar@home",
-					Ranks:      []system.Rank{},
+					Ranks:      []ranklist.Rank{},
 					TierBytes:  []uint64{uint64(testSize), 0},
 				}),
 			}, " "),
@@ -299,7 +300,7 @@ func TestPoolCommands(t *testing.T) {
 					NumSvcReps: 3,
 					User:       "foo@",
 					UserGroup:  eGrp.Name + "@",
-					Ranks:      []system.Rank{},
+					Ranks:      []ranklist.Rank{},
 					TierBytes:  []uint64{uint64(testSize), 0},
 				}),
 			}, " "),
@@ -313,7 +314,7 @@ func TestPoolCommands(t *testing.T) {
 					NumSvcReps: 3,
 					User:       eUsr.Username + "@",
 					UserGroup:  "foo@",
-					Ranks:      []system.Rank{},
+					Ranks:      []ranklist.Rank{},
 					TierBytes:  []uint64{uint64(testSize), 0},
 				}),
 			}, " "),
@@ -342,7 +343,7 @@ func TestPoolCommands(t *testing.T) {
 					},
 					User:      eUsr.Username + "@",
 					UserGroup: eGrp.Name + "@",
-					Ranks:     []system.Rank{},
+					Ranks:     []ranklist.Rank{},
 					TierBytes: []uint64{uint64(testSize), 0},
 				}),
 			}, " "),
@@ -433,7 +434,7 @@ func TestPoolCommands(t *testing.T) {
 			strings.Join([]string{
 				printRequest(t, &control.PoolExtendReq{
 					ID:    "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
-					Ranks: []system.Rank{1},
+					Ranks: []ranklist.Rank{1},
 				}),
 			}, " "),
 			nil,
@@ -444,7 +445,7 @@ func TestPoolCommands(t *testing.T) {
 			strings.Join([]string{
 				printRequest(t, &control.PoolExtendReq{
 					ID:    "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
-					Ranks: []system.Rank{1, 2, 3},
+					Ranks: []ranklist.Rank{1, 2, 3},
 				}),
 			}, " "),
 			nil,
@@ -1457,12 +1458,12 @@ func TestDmg_PoolCreateAllCmd(t *testing.T) {
 					"Invalid size of TotalBytes attribute: disabled with manual allocation")
 				if tc.TgtRanks != "" {
 					test.AssertEqual(t,
-						system.RankList(poolCreateRequest.Ranks).String(),
+						ranklist.RankList(poolCreateRequest.Ranks).String(),
 						tc.ExpectedOutput.PoolConfig.Ranks,
 						"Invalid list of Ranks")
 				} else {
 					test.AssertEqual(t,
-						system.RankList(poolCreateRequest.Ranks).String(),
+						ranklist.RankList(poolCreateRequest.Ranks).String(),
 						"",
 						"Invalid list of Ranks")
 				}

--- a/src/control/cmd/dmg/pretty/pool.go
+++ b/src/control/cmd/dmg/pretty/pool.go
@@ -14,8 +14,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/lib/txtfmt"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 func getTierNameText(tierIdx int) string {
@@ -247,7 +247,7 @@ func poolListCreateRowVerbose(pool *control.Pool) txtfmt.TableRow {
 
 	svcReps := "N/A"
 	if len(pool.ServiceReplicas) != 0 {
-		rl := system.RanksToUint32(pool.ServiceReplicas)
+		rl := ranklist.RanksToUint32(pool.ServiceReplicas)
 		svcReps = formatRanks(rl)
 	}
 

--- a/src/control/cmd/dmg/pretty/pool_test.go
+++ b/src/control/cmd/dmg/pretty/pool_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
@@ -87,7 +88,7 @@ Rebuild busy, 42 objs, 21 recs
 					Version:          100,
 					PoolLayoutVer:    1,
 					UpgradeLayoutVer: 2,
-					EnabledRanks:     system.MustCreateRankSet("[0,1,2]"),
+					EnabledRanks:     ranklist.MustCreateRankSet("[0,1,2]"),
 					Rebuild: &control.PoolRebuildStatus{
 						State:   control.PoolRebuildStateBusy,
 						Objects: 42,
@@ -131,7 +132,7 @@ Rebuild busy, 42 objs, 21 recs
 					Version:          100,
 					PoolLayoutVer:    1,
 					UpgradeLayoutVer: 2,
-					DisabledRanks:    system.MustCreateRankSet("[0,1,3]"),
+					DisabledRanks:    ranklist.MustCreateRankSet("[0,1,3]"),
 					Rebuild: &control.PoolRebuildStatus{
 						State:   control.PoolRebuildStateBusy,
 						Objects: 42,
@@ -175,7 +176,7 @@ Rebuild busy, 42 objs, 21 recs
 					Version:          100,
 					PoolLayoutVer:    1,
 					UpgradeLayoutVer: 2,
-					DisabledRanks:    system.MustCreateRankSet("[0,1,3]"),
+					DisabledRanks:    ranklist.MustCreateRankSet("[0,1,3]"),
 					Rebuild: &control.PoolRebuildStatus{
 						State:   42,
 						Objects: 42,
@@ -982,7 +983,7 @@ no pools in system
 				Pools: []*control.Pool{
 					{
 						UUID:            test.MockUUID(1),
-						ServiceReplicas: []system.Rank{0, 1, 2},
+						ServiceReplicas: []ranklist.Rank{0, 1, 2},
 						State:           system.PoolServiceStateReady.String(),
 					},
 				},
@@ -998,7 +999,7 @@ Pool     Size State Used Imbalance Disabled
 			resp: &control.ListPoolsResp{
 				Pools: []*control.Pool{
 					{
-						ServiceReplicas: []system.Rank{0, 1, 2},
+						ServiceReplicas: []ranklist.Rank{0, 1, 2},
 						Usage:           exampleUsage,
 					},
 				},
@@ -1010,7 +1011,7 @@ Pool     Size State Used Imbalance Disabled
 				Pools: []*control.Pool{
 					{
 						UUID:             test.MockUUID(1),
-						ServiceReplicas:  []system.Rank{0, 1, 2},
+						ServiceReplicas:  []ranklist.Rank{0, 1, 2},
 						Usage:            exampleUsage,
 						TargetsTotal:     16,
 						TargetsDisabled:  0,
@@ -1020,7 +1021,7 @@ Pool     Size State Used Imbalance Disabled
 					{
 						UUID:             test.MockUUID(2),
 						Label:            "one",
-						ServiceReplicas:  []system.Rank{3, 4, 5},
+						ServiceReplicas:  []ranklist.Rank{3, 4, 5},
 						Usage:            exampleUsage[1:],
 						TargetsTotal:     64,
 						TargetsDisabled:  8,
@@ -1036,7 +1037,7 @@ Pool     Size State Used Imbalance Disabled
 				Pools: []*control.Pool{
 					{
 						UUID:             test.MockUUID(1),
-						ServiceReplicas:  []system.Rank{0, 1, 2},
+						ServiceReplicas:  []ranklist.Rank{0, 1, 2},
 						Usage:            exampleUsage,
 						TargetsTotal:     16,
 						TargetsDisabled:  0,
@@ -1047,7 +1048,7 @@ Pool     Size State Used Imbalance Disabled
 					{
 						Label:            "two",
 						UUID:             test.MockUUID(2),
-						ServiceReplicas:  []system.Rank{3, 4, 5},
+						ServiceReplicas:  []ranklist.Rank{3, 4, 5},
 						Usage:            exampleUsage,
 						TargetsTotal:     64,
 						TargetsDisabled:  8,
@@ -1071,7 +1072,7 @@ two      6.0 TB Ready 83%  12%       8/64     1->2
 					{
 						Label:            "one",
 						UUID:             test.MockUUID(1),
-						ServiceReplicas:  []system.Rank{0, 1, 2},
+						ServiceReplicas:  []ranklist.Rank{0, 1, 2},
 						Usage:            exampleUsage,
 						TargetsTotal:     16,
 						TargetsDisabled:  0,
@@ -1082,7 +1083,7 @@ two      6.0 TB Ready 83%  12%       8/64     1->2
 					{
 						Label:           "two",
 						UUID:            test.MockUUID(2),
-						ServiceReplicas: []system.Rank{3, 4, 5},
+						ServiceReplicas: []ranklist.Rank{3, 4, 5},
 						Usage: []*control.PoolTierUsage{
 							exampleUsage[0],
 							{TierName: "NVME"},
@@ -1109,7 +1110,7 @@ two  100 GB Ready 80%  12%       8/64     None
 					{
 						Label:            "one",
 						UUID:             test.MockUUID(1),
-						ServiceReplicas:  []system.Rank{0, 1, 2},
+						ServiceReplicas:  []ranklist.Rank{0, 1, 2},
 						Usage:            exampleUsage,
 						TargetsTotal:     16,
 						TargetsDisabled:  0,
@@ -1120,7 +1121,7 @@ two  100 GB Ready 80%  12%       8/64     None
 					{
 						Label:           "two",
 						UUID:            test.MockUUID(2),
-						ServiceReplicas: []system.Rank{3, 4, 5},
+						ServiceReplicas: []ranklist.Rank{3, 4, 5},
 						QueryErrorMsg:   "stats unavailable",
 					},
 				},
@@ -1140,7 +1141,7 @@ one  6.0 TB Ready 83%  12%       0/16     1->2
 					{
 						Label:            "one",
 						UUID:             test.MockUUID(1),
-						ServiceReplicas:  []system.Rank{0, 1, 2},
+						ServiceReplicas:  []ranklist.Rank{0, 1, 2},
 						Usage:            exampleUsage,
 						TargetsTotal:     16,
 						TargetsDisabled:  0,
@@ -1150,13 +1151,13 @@ one  6.0 TB Ready 83%  12%       0/16     1->2
 					},
 					{
 						UUID:            test.MockUUID(2),
-						ServiceReplicas: []system.Rank{3, 4, 5},
+						ServiceReplicas: []ranklist.Rank{3, 4, 5},
 						QueryErrorMsg:   "stats unavailable",
 					},
 					{
 						Label:           "three",
 						UUID:            test.MockUUID(3),
-						ServiceReplicas: []system.Rank{3, 4, 5},
+						ServiceReplicas: []ranklist.Rank{3, 4, 5},
 						QueryStatusMsg:  "DER_UNINIT",
 					},
 				},
@@ -1206,7 +1207,7 @@ Label UUID                                 State SvcReps SCM Size SCM Used SCM I
 					{
 						Label:            "one",
 						UUID:             test.MockUUID(1),
-						ServiceReplicas:  []system.Rank{0, 1, 2},
+						ServiceReplicas:  []ranklist.Rank{0, 1, 2},
 						Usage:            exampleUsage,
 						TargetsTotal:     16,
 						TargetsDisabled:  0,
@@ -1217,7 +1218,7 @@ Label UUID                                 State SvcReps SCM Size SCM Used SCM I
 					{
 						Label:            "two",
 						UUID:             test.MockUUID(2),
-						ServiceReplicas:  []system.Rank{3, 4, 5},
+						ServiceReplicas:  []ranklist.Rank{3, 4, 5},
 						Usage:            exampleUsage,
 						TargetsTotal:     64,
 						TargetsDisabled:  8,

--- a/src/control/cmd/dmg/pretty/ranks.go
+++ b/src/control/cmd/dmg/pretty/ranks.go
@@ -1,16 +1,16 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
 package pretty
 
-import "github.com/daos-stack/daos/src/control/system"
+import "github.com/daos-stack/daos/src/control/lib/ranklist"
 
 // formatRanks takes a slice of uint32 ranks and returns a string
 // representation of the set created from the slice.
 func formatRanks(ranks []uint32) string {
-	rs := system.RankSetFromRanks(system.RanksFromUint32(ranks))
+	rs := ranklist.RankSetFromRanks(ranklist.RanksFromUint32(ranks))
 	return rs.RangedString()
 }

--- a/src/control/cmd/dmg/pretty/system.go
+++ b/src/control/cmd/dmg/pretty/system.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/lib/txtfmt"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -58,7 +59,7 @@ func printAbsentHosts(out io.Writer, absentHosts *hostlist.HostSet) {
 	}
 }
 
-func printAbsentRanks(out io.Writer, absentRanks *system.RankSet) {
+func printAbsentRanks(out io.Writer, absentRanks *ranklist.RankSet) {
 	if absentRanks.Count() > 0 {
 		fmt.Fprintf(out, "Unknown %s: %s\n",
 			english.Plural(absentRanks.Count(), "rank", "ranks"),
@@ -66,7 +67,7 @@ func printAbsentRanks(out io.Writer, absentRanks *system.RankSet) {
 	}
 }
 
-func printSystemQuery(out io.Writer, members system.Members, absentRanks *system.RankSet) error {
+func printSystemQuery(out io.Writer, members system.Members, absentRanks *ranklist.RankSet) error {
 	groups := make(system.RankGroups)
 	if err := groups.FromMembers(members); err != nil {
 		return err
@@ -135,7 +136,7 @@ func PrintSystemQueryResponse(out, outErr io.Writer, resp *control.SystemQueryRe
 	return nil
 }
 
-func printSystemResultTable(out io.Writer, results system.MemberResults, absentRanks *system.RankSet) error {
+func printSystemResultTable(out io.Writer, results system.MemberResults, absentRanks *ranklist.RankSet) error {
 	groups := make(system.RankGroups)
 	if err := groups.FromMemberResults(results, rowFieldSep); err != nil {
 		return err
@@ -152,7 +153,7 @@ func printSystemResultTable(out io.Writer, results system.MemberResults, absentR
 	return nil
 }
 
-func printSystemResults(out, outErr io.Writer, results system.MemberResults, absentHosts *hostlist.HostSet, absentRanks *system.RankSet) error {
+func printSystemResults(out, outErr io.Writer, results system.MemberResults, absentHosts *hostlist.HostSet, absentRanks *ranklist.RankSet) error {
 	if len(results) == 0 {
 		fmt.Fprintln(out, "No results returned")
 		printAbsentHosts(outErr, absentHosts)

--- a/src/control/cmd/dmg/pretty/system_test.go
+++ b/src/control/cmd/dmg/pretty/system_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 	. "github.com/daos-stack/daos/src/control/system"
 )
 

--- a/src/control/cmd/dmg/storage_query.go
+++ b/src/control/cmd/dmg/storage_query.go
@@ -13,19 +13,19 @@ import (
 
 	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 type rankCmd struct {
 	Rank *uint32 `short:"r" long:"rank" description:"Constrain operation to the specified server rank"`
 }
 
-func (r *rankCmd) GetRank() system.Rank {
+func (r *rankCmd) GetRank() ranklist.Rank {
 	if r.Rank == nil {
-		return system.NilRank
+		return ranklist.NilRank
 	}
-	return system.Rank(*r.Rank)
+	return ranklist.Rank(*r.Rank)
 }
 
 type smdQueryCmd struct {
@@ -78,7 +78,7 @@ func (cmd *devHealthQueryCmd) Execute(_ []string) error {
 	req := &control.SmdQueryReq{
 		OmitPools:        true,
 		IncludeBioHealth: true,
-		Rank:             system.NilRank,
+		Rank:             ranklist.NilRank,
 		UUID:             cmd.UUID,
 	}
 	return cmd.makeRequest(ctx, req)
@@ -95,7 +95,7 @@ func (cmd *tgtHealthQueryCmd) Execute(_ []string) error {
 	req := &control.SmdQueryReq{
 		OmitPools:        true,
 		IncludeBioHealth: true,
-		Rank:             system.Rank(cmd.Rank),
+		Rank:             ranklist.Rank(cmd.Rank),
 		Target:           strconv.Itoa(int(cmd.TgtId)),
 	}
 	return cmd.makeRequest(ctx, req)

--- a/src/control/cmd/dmg/storage_query_test.go
+++ b/src/control/cmd/dmg/storage_query_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 func TestStorageQueryCommands(t *testing.T) {
@@ -23,7 +23,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata target health query",
 			"storage query target-health -r 0 -t 1",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:             system.Rank(0),
+				Rank:             ranklist.Rank(0),
 				OmitPools:        true,
 				IncludeBioHealth: true,
 				Target:           "1",
@@ -40,7 +40,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata device health query",
 			"storage query device-health --uuid 842c739b-86b5-462f-a7ba-b4a91b674f3d",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:             system.NilRank,
+				Rank:             ranklist.NilRank,
 				OmitPools:        true,
 				IncludeBioHealth: true,
 				UUID:             "842c739b-86b5-462f-a7ba-b4a91b674f3d",
@@ -57,7 +57,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata query pools",
 			"storage query list-pools",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:        system.NilRank,
+				Rank:        ranklist.NilRank,
 				OmitDevices: true,
 			}),
 			nil,
@@ -66,7 +66,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata query pools (by rank)",
 			"storage query list-pools --rank 42",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:        system.Rank(42),
+				Rank:        ranklist.Rank(42),
 				OmitDevices: true,
 			}),
 			nil,
@@ -75,7 +75,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata query pools (by uuid)",
 			"storage query list-pools --uuid 842c739b-86b5-462f-a7ba-b4a91b674f3d",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:        system.NilRank,
+				Rank:        ranklist.NilRank,
 				OmitDevices: true,
 				UUID:        "842c739b-86b5-462f-a7ba-b4a91b674f3d",
 			}),
@@ -85,7 +85,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata query devices",
 			"storage query list-devices",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:      system.NilRank,
+				Rank:      ranklist.NilRank,
 				OmitPools: true,
 			}),
 			nil,
@@ -94,7 +94,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata query devices (include health)",
 			"storage query list-devices --health",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:             system.NilRank,
+				Rank:             ranklist.NilRank,
 				OmitPools:        true,
 				IncludeBioHealth: true,
 			}),
@@ -104,7 +104,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata query devices (show only evicted)",
 			"storage query list-devices --show-evicted",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:      system.NilRank,
+				Rank:      ranklist.NilRank,
 				OmitPools: true,
 				StateMask: storage.NvmeStateFaulty,
 			}),
@@ -114,7 +114,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata query devices (show only evicted short)",
 			"storage query list-devices -e",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:      system.NilRank,
+				Rank:      ranklist.NilRank,
 				OmitPools: true,
 				StateMask: storage.NvmeStateFaulty,
 			}),
@@ -124,7 +124,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata query devices (by rank)",
 			"storage query list-devices --rank 42",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:      system.Rank(42),
+				Rank:      ranklist.Rank(42),
 				OmitPools: true,
 			}),
 			nil,
@@ -133,7 +133,7 @@ func TestStorageQueryCommands(t *testing.T) {
 			"per-server metadata query devices (by uuid)",
 			"storage query list-devices --uuid 842c739b-86b5-462f-a7ba-b4a91b674f3d",
 			printRequest(t, &control.SmdQueryReq{
-				Rank:      system.NilRank,
+				Rank:      ranklist.NilRank,
 				UUID:      "842c739b-86b5-462f-a7ba-b4a91b674f3d",
 				OmitPools: true,
 			}),

--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -18,9 +18,9 @@ import (
 	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/lib/txtfmt"
 	"github.com/daos-stack/daos/src/control/lib/ui"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // SystemCmd is the struct representing the top-level system subcommand.
@@ -227,7 +227,7 @@ func (cmd *baseExcludeCmd) execute(clear bool) error {
 		return cmd.outputJSON(resp, resp.Errors())
 	}
 
-	updated := system.NewRankSet()
+	updated := ranklist.NewRankSet()
 	for _, result := range resp.Results {
 		updated.Add(result.Rank)
 	}

--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -19,14 +19,15 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
 func TestDmg_SystemCommands(t *testing.T) {
-	withRanks := func(req control.UnaryRequest, ranks ...system.Rank) control.UnaryRequest {
-		if rs, ok := req.(interface{ SetRanks(*system.RankSet) }); ok {
-			rs.SetRanks(system.RankSetFromRanks(ranks))
+	withRanks := func(req control.UnaryRequest, ranks ...ranklist.Rank) control.UnaryRequest {
+		if rs, ok := req.(interface{ SetRanks(*ranklist.RankSet) }); ok {
+			rs.SetRanks(ranklist.RankSetFromRanks(ranks))
 		}
 
 		return req

--- a/src/control/common/proto/mgmt/addons.go
+++ b/src/control/common/proto/mgmt/addons.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/daos-stack/daos/src/control/system"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
 func (p *PoolProperty) UnmarshalJSON(b []byte) error {
@@ -223,12 +223,12 @@ func Debug(msg proto.Message) string {
 	var bld strings.Builder
 	switch m := msg.(type) {
 	case *SystemQueryResp:
-		stateRanks := make(map[string]*system.RankSet)
+		stateRanks := make(map[string]*ranklist.RankSet)
 		for _, m := range m.Members {
 			if _, found := stateRanks[m.State]; !found {
-				stateRanks[m.State] = &system.RankSet{}
+				stateRanks[m.State] = &ranklist.RankSet{}
 			}
-			stateRanks[m.State].Add(system.Rank(m.Rank))
+			stateRanks[m.State].Add(ranklist.Rank(m.Rank))
 		}
 		fmt.Fprintf(&bld, "%T ", m)
 		for state, set := range stateRanks {
@@ -239,9 +239,9 @@ func Debug(msg proto.Message) string {
 		if len(m.Properties) > 0 {
 			fmt.Fprintf(&bld, "p:%+v ", m.Properties)
 		}
-		ranks := &system.RankSet{}
+		ranks := &ranklist.RankSet{}
 		for _, r := range m.Ranks {
-			ranks.Add(system.Rank(r))
+			ranks.Add(ranklist.Rank(r))
 		}
 		fmt.Fprintf(&bld, "ranks: %s ", ranks.String())
 		fmt.Fprint(&bld, "tiers: ")
@@ -253,14 +253,14 @@ func Debug(msg proto.Message) string {
 		}
 	case *PoolCreateResp:
 		fmt.Fprintf(&bld, "%T ", m)
-		ranks := &system.RankSet{}
+		ranks := &ranklist.RankSet{}
 		for _, r := range m.SvcReps {
-			ranks.Add(system.Rank(r))
+			ranks.Add(ranklist.Rank(r))
 		}
 		fmt.Fprintf(&bld, "svc_ranks: %s ", ranks.String())
-		ranks = &system.RankSet{}
+		ranks = &ranklist.RankSet{}
 		for _, r := range m.TgtRanks {
-			ranks.Add(system.Rank(r))
+			ranks.Add(ranklist.Rank(r))
 		}
 		fmt.Fprintf(&bld, "tgt_ranks: %s ", ranks.String())
 		fmt.Fprint(&bld, "tiers: ")

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -25,8 +25,8 @@ import (
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // MockMessage implements the proto.Message
@@ -580,12 +580,12 @@ type (
 
 	MockScmConfig struct {
 		MockStorageConfig
-		Rank system.Rank
+		Rank ranklist.Rank
 	}
 
 	MockNvmeConfig struct {
 		MockStorageConfig
-		Rank system.Rank
+		Rank ranklist.Rank
 	}
 
 	MockHostStorageConfig struct {

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -21,6 +21,7 @@ import (
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/system"
@@ -28,7 +29,7 @@ import (
 
 func rankSetCmpOpt() []cmp.Option {
 	return []cmp.Option{
-		cmp.Transformer("RankSet", func(in *system.RankSet) *[]system.Rank {
+		cmp.Transformer("RankSet", func(in *ranklist.RankSet) *[]ranklist.Rank {
 			if in == nil {
 				return nil
 			}
@@ -492,8 +493,8 @@ func TestControl_PoolQueryResp_MarshallJSON(t *testing.T) {
 					DisabledTargets:  4,
 					Version:          5,
 					Leader:           6,
-					EnabledRanks:     system.MustCreateRankSet("[0-3,5]"),
-					DisabledRanks:    &system.RankSet{},
+					EnabledRanks:     ranklist.MustCreateRankSet("[0-3,5]"),
+					DisabledRanks:    &ranklist.RankSet{},
 					PoolLayoutVer:    7,
 					UpgradeLayoutVer: 8,
 				},
@@ -549,8 +550,8 @@ func TestControl_PoolQueryResp_UnmarshallJSON(t *testing.T) {
 					DisabledTargets:  4,
 					Version:          5,
 					Leader:           6,
-					EnabledRanks:     system.MustCreateRankSet("[0-3,5]"),
-					DisabledRanks:    &system.RankSet{},
+					EnabledRanks:     ranklist.MustCreateRankSet("[0-3,5]"),
+					DisabledRanks:    &ranklist.RankSet{},
 					PoolLayoutVer:    7,
 					UpgradeLayoutVer: 8,
 				},
@@ -737,7 +738,7 @@ func TestControl_PoolQuery(t *testing.T) {
 							MediaType: StorageMediaTypeNvme,
 						},
 					},
-					EnabledRanks: system.MustCreateRankSet("[0-3,5]"),
+					EnabledRanks: ranklist.MustCreateRankSet("[0-3,5]"),
 				},
 			},
 		},
@@ -809,7 +810,7 @@ func TestControl_PoolQuery(t *testing.T) {
 							MediaType: StorageMediaTypeNvme,
 						},
 					},
-					DisabledRanks: &system.RankSet{},
+					DisabledRanks: &ranklist.RankSet{},
 				},
 			},
 		},
@@ -1351,7 +1352,7 @@ func TestControl_ListPools(t *testing.T) {
 				Pools: []*Pool{
 					{
 						UUID:            test.MockUUID(1),
-						ServiceReplicas: []system.Rank{1, 3, 5, 8},
+						ServiceReplicas: []ranklist.Rank{1, 3, 5, 8},
 						TargetsTotal:    42,
 						TargetsDisabled: 17,
 						Usage:           expUsage,
@@ -1402,7 +1403,7 @@ func TestControl_ListPools(t *testing.T) {
 				Pools: []*Pool{
 					{
 						UUID:            test.MockUUID(1),
-						ServiceReplicas: []system.Rank{1, 3, 5, 8},
+						ServiceReplicas: []ranklist.Rank{1, 3, 5, 8},
 						TargetsTotal:    42,
 						TargetsDisabled: 17,
 						Usage:           expUsage,
@@ -1410,7 +1411,7 @@ func TestControl_ListPools(t *testing.T) {
 					},
 					{
 						UUID:            test.MockUUID(2),
-						ServiceReplicas: []system.Rank{1, 2, 3},
+						ServiceReplicas: []ranklist.Rank{1, 2, 3},
 						TargetsTotal:    42,
 						TargetsDisabled: 17,
 						Usage:           expUsage,
@@ -1444,13 +1445,13 @@ func TestControl_ListPools(t *testing.T) {
 				Pools: []*Pool{
 					{
 						UUID:            test.MockUUID(1),
-						ServiceReplicas: []system.Rank{1, 3, 5, 8},
+						ServiceReplicas: []ranklist.Rank{1, 3, 5, 8},
 						QueryErrorMsg:   "remote failed",
 						State:           system.PoolServiceStateReady.String(),
 					},
 					{
 						UUID:            test.MockUUID(2),
-						ServiceReplicas: []system.Rank{1, 2, 3},
+						ServiceReplicas: []ranklist.Rank{1, 2, 3},
 						TargetsTotal:    42,
 						TargetsDisabled: 17,
 						Usage:           expUsage,
@@ -1486,13 +1487,13 @@ func TestControl_ListPools(t *testing.T) {
 				Pools: []*Pool{
 					{
 						UUID:            test.MockUUID(1),
-						ServiceReplicas: []system.Rank{1, 3, 5, 8},
+						ServiceReplicas: []ranklist.Rank{1, 3, 5, 8},
 						QueryStatusMsg:  "DER_UNINIT(-1015): Device or resource not initialized",
 						State:           system.PoolServiceStateReady.String(),
 					},
 					{
 						UUID:            test.MockUUID(2),
-						ServiceReplicas: []system.Rank{1, 2, 3},
+						ServiceReplicas: []ranklist.Rank{1, 2, 3},
 						TargetsTotal:    42,
 						TargetsDisabled: 17,
 						Usage:           expUsage,
@@ -1526,7 +1527,7 @@ func TestControl_ListPools(t *testing.T) {
 				Pools: []*Pool{
 					{
 						UUID:            test.MockUUID(1),
-						ServiceReplicas: []system.Rank{1, 3, 5, 8},
+						ServiceReplicas: []ranklist.Rank{1, 3, 5, 8},
 						TargetsTotal:    42,
 						TargetsDisabled: 17,
 						Usage:           expUsage,
@@ -1534,7 +1535,7 @@ func TestControl_ListPools(t *testing.T) {
 					},
 					{
 						UUID:            test.MockUUID(2),
-						ServiceReplicas: []system.Rank{1, 2, 3},
+						ServiceReplicas: []ranklist.Rank{1, 2, 3},
 						State:           system.PoolServiceStateDestroying.String(),
 					},
 				},
@@ -1580,7 +1581,7 @@ func TestControl_GetMaxPoolSize(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		HostsConfigArray []MockHostStorageConfig
-		TgtRanks         []system.Rank
+		TgtRanks         []ranklist.Rank
 		ExpectedOutput   ExpectedOutput
 	}{
 		"single server": {
@@ -1805,7 +1806,7 @@ func TestControl_GetMaxPoolSize(t *testing.T) {
 					},
 				},
 			},
-			TgtRanks: []system.Rank{0, 1, 2, 4},
+			TgtRanks: []ranklist.Rank{0, 1, 2, 4},
 			ExpectedOutput: ExpectedOutput{
 				ScmBytes:  uint64(50) * uint64(humanize.GByte),
 				NvmeBytes: uint64(700) * uint64(humanize.GByte),
@@ -1933,7 +1934,7 @@ func TestControl_GetMaxPoolSize(t *testing.T) {
 					},
 				},
 			},
-			TgtRanks: []system.Rank{0, 1, 2, 4},
+			TgtRanks: []ranklist.Rank{0, 1, 2, 4},
 			ExpectedOutput: ExpectedOutput{
 				ScmBytes:  uint64(50) * uint64(humanize.GByte),
 				NvmeBytes: uint64(0),
@@ -2192,7 +2193,7 @@ func TestControl_GetMaxPoolSize(t *testing.T) {
 					},
 				},
 			},
-			TgtRanks: []system.Rank{1},
+			TgtRanks: []ranklist.Rank{1},
 			ExpectedOutput: ExpectedOutput{
 				Error: errors.New("No SCM storage space available"),
 			},

--- a/src/control/lib/control/server_meta.go
+++ b/src/control/lib/control/server_meta.go
@@ -15,17 +15,17 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 type (
 	// SmdPool contains the per-server components of a DAOS pool.
 	SmdPool struct {
-		UUID      string      `json:"uuid"`
-		TargetIDs []int32     `hash:"set" json:"tgt_ids"`
-		Blobs     []uint64    `hash:"set" json:"blobs"`
-		Rank      system.Rank `hash:"set" json:"rank"`
+		UUID      string        `json:"uuid"`
+		TargetIDs []int32       `hash:"set" json:"tgt_ids"`
+		Blobs     []uint64      `hash:"set" json:"blobs"`
+		Rank      ranklist.Rank `hash:"set" json:"rank"`
 	}
 
 	// SmdPoolMap provides a map from pool UUIDs to per-rank pool info.
@@ -46,7 +46,7 @@ type (
 		IncludeBioHealth bool                 `json:"include_bio_health"`
 		SetFaulty        bool                 `json:"set_faulty"`
 		UUID             string               `json:"uuid"` // UUID of pool or device for single result
-		Rank             system.Rank          `json:"rank"`
+		Rank             ranklist.Rank        `json:"rank"`
 		Target           string               `json:"target"`
 		ReplaceUUID      string               `json:"replace_uuid"` // UUID of new device to replace storage
 		NoReint          bool                 `json:"no_reint"`     // for device replacement
@@ -62,7 +62,7 @@ type (
 	}
 )
 
-func (si *SmdInfo) addRankPools(rank system.Rank, pools []*SmdPool) {
+func (si *SmdInfo) addRankPools(rank ranklist.Rank, pools []*SmdPool) {
 	for _, pool := range pools {
 		if _, found := si.Pools[pool.UUID]; !found {
 			si.Pools[pool.UUID] = make([]*SmdPool, 0, 1)
@@ -84,7 +84,7 @@ func (sqr *SmdQueryResp) addHostResponse(hr *HostResponse) (err error) {
 		},
 	}
 	for _, rResp := range pbResp.GetRanks() {
-		rank := system.Rank(rResp.Rank)
+		rank := ranklist.Rank(rResp.Rank)
 
 		rDevices := make([]*storage.SmdDevice, len(rResp.GetDevices()))
 		if err = convert.Types(rResp.GetDevices(), &rDevices); err != nil {

--- a/src/control/lib/control/server_meta_test.go
+++ b/src/control/lib/control/server_meta_test.go
@@ -15,9 +15,9 @@ import (
 
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 type mockSmdQueryResp struct {
@@ -142,13 +142,13 @@ func TestControl_SmdQuery(t *testing.T) {
 							test.MockUUID(0): {
 								{
 									UUID:      test.MockUUID(0),
-									Rank:      system.Rank(0),
+									Rank:      ranklist.Rank(0),
 									TargetIDs: []int32{0, 1},
 									Blobs:     []uint64{42, 43},
 								},
 								{
 									UUID:      test.MockUUID(0),
-									Rank:      system.Rank(1),
+									Rank:      ranklist.Rank(1),
 									TargetIDs: []int32{0, 1},
 									Blobs:     []uint64{42, 43},
 								},
@@ -200,13 +200,13 @@ func TestControl_SmdQuery(t *testing.T) {
 						Devices: []*storage.SmdDevice{
 							{
 								UUID:      test.MockUUID(0),
-								Rank:      system.Rank(0),
+								Rank:      ranklist.Rank(0),
 								TargetIDs: []int32{0},
 								NvmeState: stateNormal,
 							},
 							{
 								UUID:      test.MockUUID(1),
-								Rank:      system.Rank(1),
+								Rank:      ranklist.Rank(1),
 								TargetIDs: []int32{0},
 								NvmeState: stateFaulty,
 							},
@@ -248,7 +248,7 @@ func TestControl_SmdQuery(t *testing.T) {
 						Devices: []*storage.SmdDevice{
 							{
 								UUID:      test.MockUUID(0),
-								Rank:      system.Rank(0),
+								Rank:      ranklist.Rank(0),
 								TargetIDs: []int32{0},
 								NvmeState: storage.NvmeStateUnknown,
 							},
@@ -304,7 +304,7 @@ func TestControl_SmdQuery(t *testing.T) {
 						Devices: []*storage.SmdDevice{
 							{
 								UUID:      test.MockUUID(0),
-								Rank:      system.Rank(0),
+								Rank:      ranklist.Rank(0),
 								TargetIDs: []int32{0},
 								Health: &storage.NvmeHealth{
 									Temperature:     2,

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -26,6 +26,7 @@ import (
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
@@ -45,11 +46,11 @@ var (
 )
 
 type sysRequest struct {
-	Ranks system.RankSet
+	Ranks ranklist.RankSet
 	Hosts hostlist.HostSet
 }
 
-func (req *sysRequest) SetRanks(ranks *system.RankSet) {
+func (req *sysRequest) SetRanks(ranks *ranklist.RankSet) {
 	req.Ranks.Replace(ranks)
 }
 
@@ -58,7 +59,7 @@ func (req *sysRequest) SetHosts(hosts *hostlist.HostSet) {
 }
 
 type sysResponse struct {
-	AbsentRanks system.RankSet   `json:"-"`
+	AbsentRanks ranklist.RankSet `json:"-"`
 	AbsentHosts hostlist.HostSet `json:"-"`
 }
 
@@ -67,7 +68,7 @@ func (resp *sysResponse) getAbsentHostsRanks(inHosts, inRanks string) error {
 	if err != nil {
 		return err
 	}
-	ars, err := system.CreateRankSet(inRanks)
+	ars, err := ranklist.CreateRankSet(inRanks)
 	if err != nil {
 		return err
 	}
@@ -101,7 +102,7 @@ type SystemJoinReq struct {
 	retryableRequest
 	ControlAddr *net.TCPAddr
 	UUID        string
-	Rank        system.Rank
+	Rank        ranklist.Rank
 	URI         string
 	NumContexts uint32              `json:"Nctxs"`
 	FaultDomain *system.FaultDomain `json:"SrvFaultDomain"`
@@ -127,7 +128,7 @@ func (req *SystemJoinReq) MarshalJSON() ([]byte, error) {
 
 // SystemJoinResp contains the request response.
 type SystemJoinResp struct {
-	Rank      system.Rank
+	Rank      ranklist.Rank
 	State     system.MemberState
 	LocalJoin bool
 }
@@ -524,7 +525,7 @@ func checkSystemErase(ctx context.Context, rpcClient UnaryInvoker) error {
 		return nil
 	}
 
-	aliveRanks, err := system.CreateRankSet("")
+	aliveRanks, err := ranklist.CreateRankSet("")
 	if err != nil {
 		return err
 	}

--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -20,6 +20,7 @@ import (
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -446,21 +447,21 @@ func TestControl_getResetRankErrors(t *testing.T) {
 		},
 		"successful result": {
 			results: system.MemberResults{
-				{Addr: "10.0.0.1:10001", Rank: system.Rank(0)},
+				{Addr: "10.0.0.1:10001", Rank: ranklist.Rank(0)},
 			},
 			expRankErrs: make(map[string][]string),
 			expHosts:    []string{"10.0.0.1:10001"},
 		},
 		"successful result missing address": {
 			results: system.MemberResults{
-				{Addr: "", Rank: system.Rank(0)},
+				{Addr: "", Rank: ranklist.Rank(0)},
 			},
 			expErrMsg: "host address missing for rank 0 result",
 		},
 		"failed result": {
 			results: system.MemberResults{
 				{
-					Addr: "10.0.0.1:10001", Rank: system.Rank(0),
+					Addr: "10.0.0.1:10001", Rank: ranklist.Rank(0),
 					Errored: true, Msg: "didn't start",
 				},
 			},
@@ -470,7 +471,7 @@ func TestControl_getResetRankErrors(t *testing.T) {
 		"failed result missing error message": {
 			results: system.MemberResults{
 				{
-					Addr: "10.0.0.1:10001", Rank: system.Rank(0),
+					Addr: "10.0.0.1:10001", Rank: ranklist.Rank(0),
 					Errored: true, Msg: "",
 				},
 			},
@@ -481,29 +482,29 @@ func TestControl_getResetRankErrors(t *testing.T) {
 		},
 		"mixed results": {
 			results: system.MemberResults{
-				{Addr: "10.0.0.1:10001", Rank: system.Rank(0)},
-				{Addr: "10.0.0.1:10001", Rank: system.Rank(1)},
+				{Addr: "10.0.0.1:10001", Rank: ranklist.Rank(0)},
+				{Addr: "10.0.0.1:10001", Rank: ranklist.Rank(1)},
 				{
-					Addr: "10.0.0.2:10001", Rank: system.Rank(2),
+					Addr: "10.0.0.2:10001", Rank: ranklist.Rank(2),
 					Errored: true, Msg: "didn't start",
 				},
 				{
-					Addr: "10.0.0.2:10001", Rank: system.Rank(3),
+					Addr: "10.0.0.2:10001", Rank: ranklist.Rank(3),
 					Errored: true, Msg: "didn't start",
 				},
 				{
-					Addr: "10.0.0.3:10001", Rank: system.Rank(4),
+					Addr: "10.0.0.3:10001", Rank: ranklist.Rank(4),
 					Errored: true, Msg: "something bad",
 				},
 				{
-					Addr: "10.0.0.3:10001", Rank: system.Rank(5),
+					Addr: "10.0.0.3:10001", Rank: ranklist.Rank(5),
 					Errored: true, Msg: "didn't start",
 				},
 				{
-					Addr: "10.0.0.4:10001", Rank: system.Rank(6),
+					Addr: "10.0.0.4:10001", Rank: ranklist.Rank(6),
 					Errored: true, Msg: "something bad",
 				},
-				{Addr: "10.0.0.4:10001", Rank: system.Rank(7)},
+				{Addr: "10.0.0.4:10001", Rank: ranklist.Rank(7)},
 			},
 			expRankErrs: map[string][]string{
 				"didn't start": {
@@ -534,7 +535,7 @@ func TestControl_SystemQuery(t *testing.T) {
 	testRespHS := new(SystemQueryResp)
 	testRespHS.AbsentHosts.Replace(testHS)
 
-	testRS := system.MustCreateRankSet("1-23")
+	testRS := ranklist.MustCreateRankSet("1-23")
 	testReqRS := new(SystemQueryReq)
 	testReqRS.Ranks.Replace(testRS)
 	testRespRS := new(SystemQueryResp)
@@ -694,7 +695,7 @@ func TestControl_SystemQueryRespErrors(t *testing.T) {
 			resp := new(SystemQueryResp)
 			ahs := hostlist.MustCreateSet(tc.absentHosts)
 			resp.AbsentHosts.Replace(ahs)
-			ars := system.MustCreateRankSet(tc.absentRanks)
+			ars := ranklist.MustCreateRankSet(tc.absentRanks)
 			resp.AbsentRanks.Replace(ars)
 
 			test.CmpErr(t, tc.expErr, resp.Errors())
@@ -709,7 +710,7 @@ func TestControl_SystemStart(t *testing.T) {
 	testRespHS := new(SystemStartResp)
 	testRespHS.AbsentHosts.Replace(testHS)
 
-	testRS := system.MustCreateRankSet("1-23")
+	testRS := ranklist.MustCreateRankSet("1-23")
 	testReqRS := new(SystemStartReq)
 	testReqRS.Ranks.Replace(testRS)
 	testRespRS := new(SystemStartResp)
@@ -864,7 +865,7 @@ func TestControl_SystemStartRespErrors(t *testing.T) {
 			resp := new(SystemStartResp)
 			ahs := hostlist.MustCreateSet(tc.absentHosts)
 			resp.AbsentHosts.Replace(ahs)
-			ars := system.MustCreateRankSet(tc.absentRanks)
+			ars := ranklist.MustCreateRankSet(tc.absentRanks)
 			resp.AbsentRanks.Replace(ars)
 			resp.Results = tc.results
 
@@ -880,7 +881,7 @@ func TestControl_SystemStop(t *testing.T) {
 	testRespHS := new(SystemStopResp)
 	testRespHS.AbsentHosts.Replace(testHS)
 
-	testRS := system.MustCreateRankSet("1-23")
+	testRS := ranklist.MustCreateRankSet("1-23")
 	testReqRS := new(SystemStopReq)
 	testReqRS.Ranks.Replace(testRS)
 	testRespRS := new(SystemStopResp)
@@ -1035,7 +1036,7 @@ func TestControl_SystemStopRespErrors(t *testing.T) {
 			resp := new(SystemStopResp)
 			ahs := hostlist.MustCreateSet(tc.absentHosts)
 			resp.AbsentHosts.Replace(ahs)
-			ars := system.MustCreateRankSet(tc.absentRanks)
+			ars := ranklist.MustCreateRankSet(tc.absentRanks)
 			resp.AbsentRanks.Replace(ars)
 			resp.Results = tc.results
 

--- a/src/control/lib/hardware/pretty.go
+++ b/src/control/lib/hardware/pretty.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/lib/txtfmt"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // PrintTopology prints the topology to the given writer.
@@ -24,9 +24,9 @@ func PrintTopology(t *Topology, output io.Writer) error {
 	}
 
 	for _, numaNode := range t.NUMANodes.AsSlice() {
-		coreSet := &system.RankSet{}
+		coreSet := &ranklist.RankSet{}
 		for _, core := range numaNode.Cores {
-			coreSet.Add(system.Rank(core.ID))
+			coreSet.Add(ranklist.Rank(core.ID))
 		}
 
 		fmt.Fprintf(ew, "NUMA Node %d\n", numaNode.ID)

--- a/src/control/lib/ranklist/rank.go
+++ b/src/control/lib/ranklist/rank.go
@@ -4,12 +4,11 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-package system
+package ranklist
 
 import (
 	"math"
 	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -17,9 +16,6 @@ import (
 type (
 	// Rank is used to uniquely identify a server within a cluster.
 	Rank uint32
-
-	// RankList provides convenience methods for working with Rank slices.
-	RankList []Rank
 )
 
 const (
@@ -108,14 +104,6 @@ func (r *Rank) RemoveFromList(ranks []Rank) []Rank {
 	}
 
 	return rankList
-}
-
-func (rl RankList) String() string {
-	rs := make([]string, len(rl))
-	for i, r := range rl {
-		rs[i] = r.String()
-	}
-	return strings.Join(rs, ",")
 }
 
 // RanksToUint32 is a convenience method to convert this

--- a/src/control/lib/ranklist/rank_test.go
+++ b/src/control/lib/ranklist/rank_test.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-package system
+package ranklist
 
 import (
 	"fmt"

--- a/src/control/lib/ranklist/ranklist.go
+++ b/src/control/lib/ranklist/ranklist.go
@@ -4,13 +4,10 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-package system
+package ranklist
 
 import (
-	"bytes"
-	"fmt"
 	"math/bits"
-	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -38,6 +35,17 @@ func fixBrackets(stringRanks string, remove bool) string {
 	}
 
 	return stringRanks
+}
+
+// RankList provides convenience methods for working with Rank slices.
+type RankList []Rank
+
+func (rl RankList) String() string {
+	rs := make([]string, len(rl))
+	for i, r := range rl {
+		rs[i] = r.String()
+	}
+	return strings.Join(rs, ",")
 }
 
 // RankSet implements a set of unique ranks in a condensed format.
@@ -182,133 +190,4 @@ func ParseRanks(stringRanks string) ([]Rank, error) {
 	}
 
 	return rs.Ranks(), nil
-}
-
-// RankGroups maps a set of ranks to string value (group).
-type RankGroups map[string]*RankSet
-
-// Keys returns sorted group names.
-//
-// Sort first by number of ranks in grouping then by alphabetical order of
-// group name.
-func (rgs RankGroups) Keys() []string {
-	keys := make([]string, 0, len(rgs))
-
-	for key := range rgs {
-		keys = append(keys, key)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		ci := rgs[keys[i]].Count()
-		cj := rgs[keys[j]].Count()
-		if ci == cj {
-			return keys[i] < keys[j]
-		}
-
-		return ci > cj
-	})
-
-	return keys
-}
-
-func (rgs RankGroups) String() string {
-	var buf bytes.Buffer
-
-	padding := 0
-	keys := rgs.Keys()
-	for _, key := range keys {
-		valStr := rgs[key].String()
-		if len(valStr) > padding {
-			padding = len(valStr)
-		}
-	}
-
-	for _, key := range rgs.Keys() {
-		fmt.Fprintf(&buf, "%*s: %s\n", padding, rgs[key], key)
-	}
-
-	return buf.String()
-}
-
-// FromMembers initializes groupings of ranks that are at a particular state
-// from a slice of system members.
-func (rgs RankGroups) FromMembers(members Members) error {
-	if rgs == nil || len(rgs) > 0 {
-		return errors.New("expecting non-nil empty rank groups")
-	}
-
-	ranksInState := make(map[MemberState]*bytes.Buffer)
-	ranksSeen := make(map[Rank]struct{})
-
-	for _, m := range members {
-		if _, exists := ranksSeen[m.Rank]; exists {
-			return &ErrMemberExists{Rank: &m.Rank}
-		}
-		ranksSeen[m.Rank] = struct{}{}
-
-		if _, exists := ranksInState[m.State]; !exists {
-			ranksInState[m.State] = new(bytes.Buffer)
-		}
-		fmt.Fprintf(ranksInState[m.State], "%d,", m.Rank)
-	}
-
-	for state, ranksStrBuf := range ranksInState {
-		rankSet, err := CreateRankSet(
-			strings.TrimSuffix(ranksStrBuf.String(), ","))
-		if err != nil {
-			return errors.WithMessage(err,
-				"generating groups of ranks at state")
-		}
-		rgs[state.String()] = rankSet
-	}
-
-	return nil
-}
-
-// FromMemberResults initializes groupings of ranks that had a particular result
-// from a requested action, populated from a slice of system member results.
-//
-// Supplied rowFieldsep parameter is used to separate row field elements in
-// the string that is used as the key for the rank groups.
-func (rgs RankGroups) FromMemberResults(results MemberResults, rowFieldSep string) error {
-	if rgs == nil || len(rgs) > 0 {
-		return errors.New("expecting non-nil empty rank groups")
-	}
-
-	ranksWithResult := make(map[string]*bytes.Buffer)
-	ranksSeen := make(map[Rank]struct{})
-
-	for _, r := range results {
-		if _, exists := ranksSeen[r.Rank]; exists {
-			return errors.Wrap(&ErrMemberExists{Rank: &r.Rank},
-				"duplicate result for rank")
-		}
-		ranksSeen[r.Rank] = struct{}{}
-
-		msg := "OK"
-		if r.Errored {
-			msg = r.Msg
-		}
-		if r.Action == "" {
-			return errors.Errorf(
-				"action field empty for rank %d result", r.Rank)
-		}
-
-		resStr := fmt.Sprintf("%s%s%s", r.Action, rowFieldSep, msg)
-		if _, exists := ranksWithResult[resStr]; !exists {
-			ranksWithResult[resStr] = new(bytes.Buffer)
-		}
-		fmt.Fprintf(ranksWithResult[resStr], "%d,", r.Rank)
-	}
-
-	for strResult, ranksStrBuf := range ranksWithResult {
-		rankSet, err := CreateRankSet(
-			strings.TrimSuffix(ranksStrBuf.String(), ","))
-		if err != nil {
-			return errors.WithMessage(err,
-				"generating groups of ranks with same result")
-		}
-		rgs[strResult] = rankSet
-	}
-
-	return nil
 }

--- a/src/control/lib/ranklist/ranklist_test.go
+++ b/src/control/lib/ranklist/ranklist_test.go
@@ -1,0 +1,98 @@
+//
+// (C) Copyright 2020-2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package ranklist
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+)
+
+func TestRankList_RankSet(t *testing.T) {
+	for name, tc := range map[string]struct {
+		ranks    string
+		addRanks []Rank
+		expOut   string
+		expCount int
+		expRanks []Rank
+		expErr   error
+	}{
+		"empty start list": {
+			ranks:    "",
+			expOut:   "",
+			expCount: 0,
+			expRanks: []Rank{},
+		},
+		"invalid with hostnames": {
+			ranks:  "node2-1,node1-2.suffix1,node1-[45,47].suffix2,node3,node1-3",
+			expErr: errors.New("unexpected alphabetic character(s)"),
+		},
+		"simple ranged rank list": {
+			ranks:    "0-10",
+			expOut:   "0-10",
+			expCount: 11,
+			expRanks: []Rank{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		"deranged rank list": {
+			ranks:    "1,2,3,5,6,8,10,10,1",
+			expOut:   "1-3,5-6,8,10",
+			expCount: 7,
+			expRanks: []Rank{1, 2, 3, 5, 6, 8, 10},
+		},
+		"ranged rank list": {
+			ranks:    "2,3,10-19,0-9",
+			addRanks: []Rank{30, 32},
+			expOut:   "0-19,30,32",
+			expCount: 22,
+			expRanks: []Rank{
+				0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+				10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+				30, 32,
+			},
+		},
+		"adding to empty list": {
+			ranks:    "",
+			addRanks: []Rank{30, 32},
+			expOut:   "30,32",
+			expCount: 2,
+			expRanks: []Rank{30, 32},
+		},
+		"invalid list with spaces": {
+			ranks:  "1, 5",
+			expErr: errors.New("unexpected whitespace character(s)"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rs, gotErr := CreateRankSet(tc.ranks)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+			for _, r := range tc.addRanks {
+				rs.Add(r)
+			}
+
+			if diff := cmp.Diff(tc.expOut, rs.String()); diff != "" {
+				t.Fatalf("unexpected value (-want, +got):\n%s\n", diff)
+			}
+
+			gotCount := rs.Count()
+			if gotCount != tc.expCount {
+				t.Fatalf("\nexpected count to be %d; got %d", tc.expCount, gotCount)
+			}
+
+			ranks := rs.Ranks()
+			if diff := cmp.Diff(tc.expRanks, ranks); diff != "" {
+				t.Fatalf("unexpected ranks (-want, +got):\n%s\n", diff)
+			}
+
+		})
+	}
+}

--- a/src/control/lib/ui/list_flags.go
+++ b/src/control/lib/ui/list_flags.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
-	"github.com/daos-stack/daos/src/control/system"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
 var (
@@ -21,7 +21,7 @@ var (
 // RankSetFlag is a go-flags compatible flag type for
 // handling inputs that can be converted to a system.RankSet.
 type RankSetFlag struct {
-	system.RankSet
+	ranklist.RankSet
 }
 
 // Empty returns true if the flag was not set.
@@ -32,7 +32,7 @@ func (f RankSetFlag) Empty() bool {
 // UnmarshalFlag implements the go-flags.Unmarshaler
 // interface.
 func (f *RankSetFlag) UnmarshalFlag(fv string) error {
-	rs, err := system.CreateRankSet(fv)
+	rs, err := ranklist.CreateRankSet(fv)
 	if err != nil {
 		return err
 	}

--- a/src/control/lib/ui/list_flags_test.go
+++ b/src/control/lib/ui/list_flags_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/lib/ui"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 func TestUI_RankSetFlag(t *testing.T) {
@@ -44,7 +44,7 @@ func TestUI_RankSetFlag(t *testing.T) {
 			arg: "1-128",
 			expFlag: func() *ui.RankSetFlag {
 				flag := &ui.RankSetFlag{}
-				flag.Replace(system.MustCreateRankSet("1-128"))
+				flag.Replace(ranklist.MustCreateRankSet("1-128"))
 				return flag
 			}(),
 			expString: "1-128",
@@ -64,7 +64,7 @@ func TestUI_RankSetFlag(t *testing.T) {
 			cmpOpts := []cmp.Option{
 				cmpopts.IgnoreUnexported(
 					ui.RankSetFlag{},
-					system.RankSet{},
+					ranklist.RankSet{},
 				),
 			}
 			if diff := cmp.Diff(tc.expFlag, &f, cmpOpts...); diff != "" {

--- a/src/control/server/ctl_firmware_test.go
+++ b/src/control/server/ctl_firmware_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 func getPBNvmeQueryResults(t *testing.T, devs storage.NvmeControllers) []*ctlpb.NvmeFirmwareQueryResp {
@@ -811,7 +811,7 @@ func TestCtlSvc_FirmwareUpdate(t *testing.T) {
 				if !tc.noRankEngines {
 					instance._superblock = &Superblock{}
 					instance._superblock.ValidRank = true
-					instance._superblock.Rank = system.NewRankPtr(uint32(i))
+					instance._superblock.Rank = ranklist.NewRankPtr(uint32(i))
 				}
 				if err := cs.harness.AddInstance(instance); err != nil {
 					t.Fatal(err)

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
@@ -292,7 +293,7 @@ func (svc *ControlService) ResetFormatRanks(ctx context.Context, req *ctlpb.Rank
 		return nil, err
 	}
 
-	savedRanks := make(map[uint32]system.Rank) // instance idx to system rank
+	savedRanks := make(map[uint32]ranklist.Rank) // instance idx to system rank
 	for _, srv := range instances {
 		rank, err := srv.GetRank()
 		if err != nil {

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/events"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
@@ -199,8 +200,8 @@ func TestServer_CtlSvc_PrepShutdownRanks(t *testing.T) {
 				srv.runner = engine.NewTestRunner(trc, engine.MockConfig())
 				srv.setIndex(uint32(i))
 
-				srv._superblock.Rank = new(system.Rank)
-				*srv._superblock.Rank = system.Rank(i + 1)
+				srv._superblock.Rank = new(ranklist.Rank)
+				*srv._superblock.Rank = ranklist.Rank(i + 1)
 
 				cfg := new(mockDrpcClientConfig)
 				if tc.drpcRet != nil {
@@ -371,11 +372,11 @@ func TestServer_CtlSvc_StopRanks(t *testing.T) {
 				ei.runner = engine.NewTestRunner(trc, engine.MockConfig())
 				ei.setIndex(uint32(i))
 
-				ei._superblock.Rank = new(system.Rank)
-				*ei._superblock.Rank = system.Rank(i + 1)
+				ei._superblock.Rank = new(ranklist.Rank)
+				*ei._superblock.Rank = ranklist.Rank(i + 1)
 
 				ei.OnInstanceExit(
-					func(_ context.Context, _ uint32, _ system.Rank, _ error, _ int) error {
+					func(_ context.Context, _ uint32, _ ranklist.Rank, _ error, _ int) error {
 						svc.events.Publish(mockEvtEngineDied(t))
 						return nil
 					})
@@ -566,8 +567,8 @@ func TestServer_CtlSvc_PingRanks(t *testing.T) {
 				srv.runner = engine.NewTestRunner(trc, engine.MockConfig())
 				srv.setIndex(uint32(i))
 
-				srv._superblock.Rank = new(system.Rank)
-				*srv._superblock.Rank = system.Rank(i + 1)
+				srv._superblock.Rank = new(ranklist.Rank)
+				*srv._superblock.Rank = ranklist.Rank(i + 1)
 
 				cfg := new(mockDrpcClientConfig)
 				if tc.drpcRet != nil {
@@ -723,8 +724,8 @@ func TestServer_CtlSvc_ResetFormatRanks(t *testing.T) {
 					UUID:    test.MockUUID(),
 					System:  "test",
 				}
-				superblock.Rank = new(system.Rank)
-				*superblock.Rank = system.Rank(i + 1)
+				superblock.Rank = new(ranklist.Rank)
+				*superblock.Rank = ranklist.Rank(i + 1)
 				ei.setSuperblock(superblock)
 				if err := ei.WriteSuperblock(); err != nil {
 					t.Fatal(err)
@@ -842,8 +843,8 @@ func TestServer_CtlSvc_StartRanks(t *testing.T) {
 				srv.runner = engine.NewTestRunner(trc, engine.MockConfig())
 				srv.setIndex(uint32(i))
 
-				srv._superblock.Rank = new(system.Rank)
-				*srv._superblock.Rank = system.Rank(i + 1)
+				srv._superblock.Rank = new(ranklist.Rank)
+				*srv._superblock.Rank = ranklist.Rank(i + 1)
 
 				// mimic srv.run, set "ready" on startLoop rx
 				go func(s *EngineInstance, startFails bool) {
@@ -967,8 +968,8 @@ func TestServer_CtlSvc_SetEngineLogMasks(t *testing.T) {
 				srv.setIndex(uint32(i))
 
 				if !tc.missingRank {
-					srv._superblock.Rank = new(system.Rank)
-					*srv._superblock.Rank = system.Rank(i + 1)
+					srv._superblock.Rank = new(ranklist.Rank)
+					*srv._superblock.Rank = ranklist.Rank(i + 1)
 				}
 
 				cfg := new(mockDrpcClientConfig)

--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -18,13 +18,13 @@ import (
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
-func queryRank(reqRank uint32, engineRank system.Rank) bool {
-	rr := system.Rank(reqRank)
-	if rr.Equals(system.NilRank) {
+func queryRank(reqRank uint32, engineRank ranklist.Rank) bool {
+	rr := ranklist.Rank(reqRank)
+	if rr.Equals(ranklist.NilRank) {
 		return true
 	}
 	return rr.Equals(engineRank)
@@ -185,8 +185,8 @@ func (svc *ControlService) querySmdPools(ctx context.Context, req *ctlpb.SmdQuer
 	return nil
 }
 
-func (svc *ControlService) smdQueryDevice(ctx context.Context, req *ctlpb.SmdQueryReq) (system.Rank, *ctlpb.SmdQueryResp_Device, error) {
-	rank := system.NilRank
+func (svc *ControlService) smdQueryDevice(ctx context.Context, req *ctlpb.SmdQueryReq) (ranklist.Rank, *ctlpb.SmdQueryResp_Device, error) {
+	rank := ranklist.NilRank
 	if req.Uuid == "" {
 		return rank, nil, errors.New("empty UUID in device query")
 	}
@@ -203,7 +203,7 @@ func (svc *ControlService) smdQueryDevice(ctx context.Context, req *ctlpb.SmdQue
 		case 1:
 			svc.log.Debugf("smdQueryDevice(): uuid %q, rank %d, states %q", req.Uuid,
 				rr.Rank, rr.Devices[0].DevState)
-			rank = system.Rank(rr.Rank)
+			rank = ranklist.Rank(rr.Rank)
 
 			return rank, rr.Devices[0], nil
 		default:
@@ -215,7 +215,7 @@ func (svc *ControlService) smdQueryDevice(ctx context.Context, req *ctlpb.SmdQue
 }
 
 func (svc *ControlService) smdSetFaulty(ctx context.Context, req *ctlpb.SmdQueryReq) (*ctlpb.SmdQueryResp, error) {
-	req.Rank = uint32(system.NilRank)
+	req.Rank = uint32(ranklist.NilRank)
 	rank, device, err := svc.smdQueryDevice(ctx, req)
 	if err != nil {
 		return nil, err
@@ -266,7 +266,7 @@ func (svc *ControlService) smdSetFaulty(ctx context.Context, req *ctlpb.SmdQuery
 }
 
 func (svc *ControlService) smdReplace(ctx context.Context, req *ctlpb.SmdQueryReq) (*ctlpb.SmdQueryResp, error) {
-	req.Rank = uint32(system.NilRank)
+	req.Rank = uint32(ranklist.NilRank)
 	rank, device, err := svc.smdQueryDevice(ctx, req)
 	if err != nil {
 		return nil, err
@@ -319,7 +319,7 @@ func (svc *ControlService) smdReplace(ctx context.Context, req *ctlpb.SmdQueryRe
 }
 
 func (svc *ControlService) smdIdentify(ctx context.Context, req *ctlpb.SmdQueryReq) (*ctlpb.SmdQueryResp, error) {
-	req.Rank = uint32(system.NilRank)
+	req.Rank = uint32(ranklist.NilRank)
 	rank, device, err := svc.smdQueryDevice(ctx, req)
 	if err != nil {
 		return nil, err
@@ -397,7 +397,7 @@ func (svc *ControlService) SmdQuery(ctx context.Context, req *ctlpb.SmdQueryReq)
 	if req.Uuid != "" && (!req.OmitDevices && !req.OmitPools) {
 		return nil, errors.New("UUID is ambiguous when querying both pools and devices")
 	}
-	if req.Target != "" && req.Rank == uint32(system.NilRank) {
+	if req.Target != "" && req.Rank == uint32(ranklist.NilRank) {
 		return nil, errors.New("Target is invalid without Rank")
 	}
 

--- a/src/control/server/ctl_smd_rpc_test.go
+++ b/src/control/server/ctl_smd_rpc_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 func TestServer_CtlSvc_SmdQuery(t *testing.T) {
@@ -151,7 +151,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"list-pools": {
 			req: &ctlpb.SmdQueryReq{
 				OmitDevices: true,
-				Rank:        uint32(system.NilRank),
+				Rank:        uint32(ranklist.NilRank),
 			},
 			drpcResps: map[int][]*mockDrpcResponse{
 				0: {
@@ -223,7 +223,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"list-pools; filter by uuid": {
 			req: &ctlpb.SmdQueryReq{
 				OmitDevices: true,
-				Rank:        uint32(system.NilRank),
+				Rank:        uint32(ranklist.NilRank),
 				Uuid:        test.MockUUID(1),
 			},
 			drpcResps: map[int][]*mockDrpcResponse{
@@ -267,7 +267,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"list-pools; DAOS Failure": {
 			req: &ctlpb.SmdQueryReq{
 				OmitDevices: true,
-				Rank:        uint32(system.NilRank),
+				Rank:        uint32(ranklist.NilRank),
 			},
 			drpcResps: map[int][]*mockDrpcResponse{
 				0: {
@@ -283,7 +283,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"list-devices": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools: true,
-				Rank:      uint32(system.NilRank),
+				Rank:      uint32(ranklist.NilRank),
 			},
 			drpcResps: map[int][]*mockDrpcResponse{
 				0: {
@@ -369,7 +369,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"list-devices; missing state": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools: true,
-				Rank:      uint32(system.NilRank),
+				Rank:      uint32(ranklist.NilRank),
 			},
 			drpcResps: map[int][]*mockDrpcResponse{
 				0: {
@@ -404,7 +404,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"list-devices; show only faulty": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools: true,
-				Rank:      uint32(system.NilRank),
+				Rank:      uint32(ranklist.NilRank),
 				StateMask: storage.NvmeStateFaulty.Uint32(),
 			},
 			drpcResps: map[int][]*mockDrpcResponse{
@@ -516,7 +516,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"list-devices; filter by uuid": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools: true,
-				Rank:      uint32(system.NilRank),
+				Rank:      uint32(ranklist.NilRank),
 				Uuid:      test.MockUUID(1),
 			},
 			drpcResps: map[int][]*mockDrpcResponse{
@@ -563,7 +563,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"list-devices; DAOS Failure": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools: true,
-				Rank:      uint32(system.NilRank),
+				Rank:      uint32(ranklist.NilRank),
 			},
 			drpcResps: map[int][]*mockDrpcResponse{
 				0: {
@@ -579,7 +579,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"device-health": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools:        true,
-				Rank:             uint32(system.NilRank),
+				Rank:             uint32(ranklist.NilRank),
 				Uuid:             test.MockUUID(1),
 				IncludeBioHealth: true,
 			},
@@ -636,7 +636,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"device-health (NEW SMD); skip health collection": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools:        true,
-				Rank:             uint32(system.NilRank),
+				Rank:             uint32(ranklist.NilRank),
 				Uuid:             test.MockUUID(1),
 				IncludeBioHealth: true,
 			},
@@ -690,7 +690,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"device-health; DAOS Failure": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools:        true,
-				Rank:             uint32(system.NilRank),
+				Rank:             uint32(ranklist.NilRank),
 				Uuid:             test.MockUUID(1),
 				IncludeBioHealth: true,
 			},
@@ -812,7 +812,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		"target-health; missing rank": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools:        true,
-				Rank:             uint32(system.NilRank),
+				Rank:             uint32(ranklist.NilRank),
 				Target:           "0",
 				IncludeBioHealth: true,
 			},
@@ -820,7 +820,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 		},
 		"ambiguous UUID": {
 			req: &ctlpb.SmdQueryReq{
-				Rank: uint32(system.NilRank),
+				Rank: uint32(ranklist.NilRank),
 				Uuid: test.MockUUID(),
 			},
 			expErr: errors.New("ambiguous"),

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -30,13 +30,13 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 const (
@@ -1185,7 +1185,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 					t.Fatal("drpc response mocks unpopulated")
 				}
 				ne.setDrpcClient(newMockDrpcClient(dcc))
-				ne._superblock.Rank = system.NewRankPtr(uint32(idx + 1))
+				ne._superblock.Rank = ranklist.NewRankPtr(uint32(idx + 1))
 
 				cs.harness.instances[idx] = ne
 			}

--- a/src/control/server/ctl_svc_test.go
+++ b/src/control/server/ctl_svc_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 
 	"github.com/daos-stack/daos/src/control/events"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // mockControlService takes cfgs for tuneable scm and sys provider behavior but
@@ -59,7 +59,7 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *config.Server, bm
 			bdev.NewMockProvider(log, bmbc))
 		ei := NewEngineInstance(log, sp, nil, runner)
 		ei.setSuperblock(&Superblock{
-			Rank: system.NewRankPtr(ec.Rank.Uint32()),
+			Rank: ranklist.NewRankPtr(ec.Rank.Uint32()),
 		})
 		ei.ready.SetTrue()
 		if err := cs.harness.AddInstance(ei); err != nil {

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 const maxHelperStreamCount = 2
@@ -137,7 +137,7 @@ func mergeEnvVars(curVars []string, newVars []string) (merged []string) {
 
 // Config encapsulates an I/O Engine's configuration.
 type Config struct {
-	Rank              *system.Rank   `yaml:"rank,omitempty"`
+	Rank              *ranklist.Rank `yaml:"rank,omitempty"`
 	Modules           string         `yaml:"modules,omitempty" cmdLongFlag:"--modules" cmdShortFlag:"-m"`
 	TargetCount       int            `yaml:"targets,omitempty" cmdLongFlag:"--targets,nonzero" cmdShortFlag:"-t,nonzero"`
 	HelperStreamCount int            `yaml:"nr_xs_helpers" cmdLongFlag:"--xshelpernr" cmdShortFlag:"-x"`
@@ -271,7 +271,7 @@ func (c *Config) WithEnvPassThrough(allowList ...string) *Config {
 
 // WithRank sets the instance rank.
 func (c *Config) WithRank(r uint32) *Config {
-	c.Rank = system.NewRankPtr(r)
+	c.Rank = ranklist.NewRankPtr(r)
 	return c
 }
 

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -16,8 +16,8 @@ import (
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/engine"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 var (
@@ -66,7 +66,7 @@ func FaultPoolInvalidServiceReps(maxSvcReps uint32) *fault.Fault {
 	)
 }
 
-func FaultInstancesNotStopped(action string, rank system.Rank) *fault.Fault {
+func FaultInstancesNotStopped(action string, rank ranklist.Rank) *fault.Fault {
 	return serverFault(
 		code.ServerInstancesNotStopped,
 		fmt.Sprintf("%s not supported when rank %d is running", action, rank),
@@ -96,7 +96,7 @@ func FaultPoolScmTooSmall(minTotal, minSCM uint64) *fault.Fault {
 	)
 }
 
-func FaultPoolInvalidRanks(invalid []system.Rank) *fault.Fault {
+func FaultPoolInvalidRanks(invalid []ranklist.Rank) *fault.Fault {
 	rs := make([]string, len(invalid))
 	for i, r := range invalid {
 		rs[i] = r.String()

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -19,6 +19,7 @@ import (
 	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/atm"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -53,7 +54,7 @@ type Engine interface {
 
 	// This is a more reasonable surface that will be easier to maintain and test.
 	CallDrpc(context.Context, drpc.Method, proto.Message) (*drpc.Response, error)
-	GetRank() (system.Rank, error)
+	GetRank() (ranklist.Rank, error)
 	GetTargetCount() int
 	Index() uint32
 	IsStarted() bool
@@ -61,7 +62,7 @@ type Engine interface {
 	LocalState() system.MemberState
 	RemoveSuperblock() error
 	Run(context.Context, bool)
-	SetupRank(context.Context, system.Rank) error
+	SetupRank(context.Context, ranklist.Rank) error
 	Stop(os.Signal) error
 	OnInstanceExit(...onInstanceExitFn)
 	OnReady(...onReadyFn)
@@ -110,7 +111,7 @@ func (h *EngineHarness) FilterInstancesByRankSet(ranks string) ([]Engine, error)
 	h.RLock()
 	defer h.RUnlock()
 
-	rankList, err := system.ParseRanks(ranks)
+	rankList, err := ranklist.ParseRanks(ranks)
 	if err != nil {
 		return nil, err
 	}
@@ -265,11 +266,11 @@ func (h *EngineHarness) Start(ctx context.Context, db dbLeader, cfg *config.Serv
 
 // readyRanks returns rank assignment of configured harness instances that are
 // in a ready state. Rank assignments can be nil.
-func (h *EngineHarness) readyRanks() []system.Rank {
+func (h *EngineHarness) readyRanks() []ranklist.Rank {
 	h.RLock()
 	defer h.RUnlock()
 
-	ranks := make([]system.Rank, 0)
+	ranks := make([]ranklist.Rank, 0)
 	for idx, ei := range h.instances {
 		if ei.IsReady() {
 			rank, err := ei.GetRank()

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/atm"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/config"
@@ -56,7 +57,7 @@ func TestServer_Harness_Start(t *testing.T) {
 		expStartCount    uint32                   // number of instance.runner.Start() calls
 		expDrpcCalls     map[uint32][]drpc.Method // method ids called for each instance.Index()
 		expGrpcCalls     map[uint32][]string      // string repr of call for each instance.Index()
-		expRanks         map[uint32]system.Rank   // ranks to have been set during Start()
+		expRanks         map[uint32]ranklist.Rank // ranks to have been set during Start()
 		expMembers       system.Members           // members to have been registered during Start()
 		expIoErrs        map[uint32]error         // errors expected from instances
 	}{
@@ -85,12 +86,12 @@ func TestServer_Harness_Start(t *testing.T) {
 				},
 			},
 			expGrpcCalls: map[uint32][]string{
-				0: {fmt.Sprintf("Join %d", system.NilRank)},
-				1: {fmt.Sprintf("Join %d", system.NilRank)},
+				0: {fmt.Sprintf("Join %d", ranklist.NilRank)},
+				1: {fmt.Sprintf("Join %d", ranklist.NilRank)},
 			},
-			expRanks: map[uint32]system.Rank{
-				0: system.Rank(0),
-				1: system.Rank(1),
+			expRanks: map[uint32]ranklist.Rank{
+				0: ranklist.Rank(0),
+				1: ranklist.Rank(1),
 			},
 		},
 		"startup/shutdown with preset ranks": {
@@ -118,9 +119,9 @@ func TestServer_Harness_Start(t *testing.T) {
 				0: {"Join 1"}, // rank == instance.Index() + 1
 				1: {"Join 2"},
 			},
-			expRanks: map[uint32]system.Rank{
-				0: system.Rank(1),
-				1: system.Rank(2),
+			expRanks: map[uint32]ranklist.Rank{
+				0: ranklist.Rank(1),
+				1: ranklist.Rank(2),
 			},
 		},
 		"fails to start": {
@@ -142,9 +143,9 @@ func TestServer_Harness_Start(t *testing.T) {
 				},
 			},
 			expStartCount: maxEngines,
-			expRanks: map[uint32]system.Rank{
-				0: system.NilRank,
-				1: system.NilRank,
+			expRanks: map[uint32]ranklist.Rank{
+				0: ranklist.NilRank,
+				1: ranklist.NilRank,
 			},
 			expIoErrs: map[uint32]error{
 				0: errors.New("oops"),
@@ -178,12 +179,12 @@ func TestServer_Harness_Start(t *testing.T) {
 				},
 			},
 			expGrpcCalls: map[uint32][]string{
-				0: {fmt.Sprintf("Join %d", system.NilRank)},
-				1: {fmt.Sprintf("Join %d", system.NilRank)},
+				0: {fmt.Sprintf("Join %d", ranklist.NilRank)},
+				1: {fmt.Sprintf("Join %d", ranklist.NilRank)},
 			},
-			expRanks: map[uint32]system.Rank{
-				0: system.Rank(0),
-				1: system.Rank(1),
+			expRanks: map[uint32]ranklist.Rank{
+				0: ranklist.Rank(0),
+				1: ranklist.Rank(1),
 			},
 			expIoErrs: map[uint32]error{
 				0: errors.New("oops"),
@@ -249,7 +250,7 @@ func TestServer_Harness_Start(t *testing.T) {
 					defer joinMu.Unlock()
 					joinRequests[idx] = []string{fmt.Sprintf("Join %d", req.Rank)}
 					return &control.SystemJoinResp{
-						Rank: system.Rank(idx),
+						Rank: ranklist.Rank(idx),
 					}, nil
 				}
 
@@ -262,13 +263,13 @@ func TestServer_Harness_Start(t *testing.T) {
 				if UUID, exists := tc.instanceUuids[i]; exists {
 					uuid = UUID
 				}
-				var rank *system.Rank
+				var rank *ranklist.Rank
 				var isValid bool
 				if tc.rankInSuperblock {
-					rank = system.NewRankPtr(uint32(i + 1))
+					rank = ranklist.NewRankPtr(uint32(i + 1))
 					isValid = true
 				} else if isAP { // bootstrap will assume rank 0
-					rank = new(system.Rank)
+					rank = new(ranklist.Rank)
 				}
 				ei.setSuperblock(&Superblock{
 					UUID: uuid, Rank: rank, ValidRank: isValid,

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -20,6 +20,7 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/atm"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/system"
@@ -30,7 +31,7 @@ type (
 	onAwaitFormatFn  func(context.Context, uint32, string) error
 	onStorageReadyFn func(context.Context) error
 	onReadyFn        func(context.Context) error
-	onInstanceExitFn func(context.Context, uint32, system.Rank, error, int) error
+	onInstanceExitFn func(context.Context, uint32, ranklist.Rank, error, int) error
 )
 
 // EngineInstance encapsulates control-plane specific configuration
@@ -177,13 +178,13 @@ func (ei *EngineInstance) removeSocket() error {
 	return nil
 }
 
-func (ei *EngineInstance) determineRank(ctx context.Context, ready *srvpb.NotifyReadyReq) (system.Rank, bool, error) {
+func (ei *EngineInstance) determineRank(ctx context.Context, ready *srvpb.NotifyReadyReq) (ranklist.Rank, bool, error) {
 	superblock := ei.getSuperblock()
 	if superblock == nil {
-		return system.NilRank, false, errors.New("nil superblock while determining rank")
+		return ranklist.NilRank, false, errors.New("nil superblock while determining rank")
 	}
 
-	r := system.NilRank
+	r := ranklist.NilRank
 	if superblock.Rank != nil {
 		r = *superblock.Rank
 	}
@@ -199,25 +200,25 @@ func (ei *EngineInstance) determineRank(ctx context.Context, ready *srvpb.Notify
 	})
 	if err != nil {
 		ei.log.Errorf("join failed: %s", err)
-		return system.NilRank, false, err
+		return ranklist.NilRank, false, err
 	}
 	switch resp.State {
 	case system.MemberStateAdminExcluded, system.MemberStateExcluded:
-		return system.NilRank, resp.LocalJoin, errors.Errorf("rank %d excluded", resp.Rank)
+		return ranklist.NilRank, resp.LocalJoin, errors.Errorf("rank %d excluded", resp.Rank)
 	}
-	r = system.Rank(resp.Rank)
+	r = ranklist.Rank(resp.Rank)
 
 	// TODO: Check to see if ready.Uri != superblock.URI, which might
 	// need to trigger some kind of update?
 
 	if !superblock.ValidRank {
-		superblock.Rank = new(system.Rank)
+		superblock.Rank = new(ranklist.Rank)
 		*superblock.Rank = r
 		superblock.ValidRank = true
 		superblock.URI = ready.GetUri()
 		ei.setSuperblock(superblock)
 		if err := ei.WriteSuperblock(); err != nil {
-			return system.NilRank, resp.LocalJoin, err
+			return ranklist.NilRank, resp.LocalJoin, err
 		}
 	}
 
@@ -272,7 +273,7 @@ func (ei *EngineInstance) handleReady(ctx context.Context, ready *srvpb.NotifyRe
 	return ei.SetupRank(ctx, r)
 }
 
-func (ei *EngineInstance) SetupRank(ctx context.Context, rank system.Rank) error {
+func (ei *EngineInstance) SetupRank(ctx context.Context, rank ranklist.Rank) error {
 	if err := ei.callSetRank(ctx, rank); err != nil {
 		return errors.Wrap(err, "SetRank failed")
 	}
@@ -285,7 +286,7 @@ func (ei *EngineInstance) SetupRank(ctx context.Context, rank system.Rank) error
 	return nil
 }
 
-func (ei *EngineInstance) callSetRank(ctx context.Context, rank system.Rank) error {
+func (ei *EngineInstance) callSetRank(ctx context.Context, rank ranklist.Rank) error {
 	dresp, err := ei.CallDrpc(ctx, drpc.MethodSetRank, &mgmtpb.SetRankReq{Rank: rank.Uint32()})
 	if err != nil {
 		return err
@@ -303,7 +304,7 @@ func (ei *EngineInstance) callSetRank(ctx context.Context, rank system.Rank) err
 }
 
 // GetRank returns a valid instance rank or error.
-func (ei *EngineInstance) GetRank() (system.Rank, error) {
+func (ei *EngineInstance) GetRank() (ranklist.Rank, error) {
 	var err error
 	sb := ei.getSuperblock()
 
@@ -315,7 +316,7 @@ func (ei *EngineInstance) GetRank() (system.Rank, error) {
 	}
 
 	if err != nil {
-		return system.NilRank, err
+		return ranklist.NilRank, err
 	}
 
 	return *sb.Rank, nil

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -22,6 +22,7 @@ import (
 	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -90,7 +91,7 @@ func (ei *EngineInstance) CallDrpc(ctx context.Context, method drpc.Method, body
 //
 // MemberResult is populated with rank, state and error dependent on processing
 // dRPC response. Target state param is populated on success, Errored otherwise.
-func drespToMemberResult(rank system.Rank, dresp *drpc.Response, err error, tState system.MemberState) *system.MemberResult {
+func drespToMemberResult(rank ranklist.Rank, dresp *drpc.Response, err error, tState system.MemberState) *system.MemberResult {
 	if err != nil {
 		return system.NewMemberResult(rank,
 			errors.WithMessagef(err, "rank %s dRPC failed", &rank),

--- a/src/control/server/instance_drpc_test.go
+++ b/src/control/server/instance_drpc_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	. "github.com/daos-stack/daos/src/control/system"
 )

--- a/src/control/server/instance_exec.go
+++ b/src/control/server/instance_exec.go
@@ -17,8 +17,8 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
 	"github.com/daos-stack/daos/src/control/events"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/engine"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // EngineRunner defines an interface for starting and stopping the
@@ -111,7 +111,7 @@ func (ei *EngineInstance) finishStartup(ctx context.Context, ready *srvpb.Notify
 // createPublishInstanceExitFunc returns onInstanceExitFn which will publish an exit
 // event using the provided publish function.
 func createPublishInstanceExitFunc(publish func(*events.RASEvent), hostname string) onInstanceExitFn {
-	return func(_ context.Context, engineIdx uint32, rank system.Rank, exitErr error, exPid int) error {
+	return func(_ context.Context, engineIdx uint32, rank ranklist.Rank, exitErr error, exPid int) error {
 		if exitErr == nil {
 			return errors.New("expected non-nil exit error")
 		}
@@ -120,7 +120,7 @@ func createPublishInstanceExitFunc(publish func(*events.RASEvent), hostname stri
 			common.ExitStatus(exitErr.Error()), exPid)
 
 		// set forwardable if there is a rank for the MS to operate on
-		publish(evt.WithForwardable(!rank.Equals(system.NilRank)))
+		publish(evt.WithForwardable(!rank.Equals(ranklist.NilRank)))
 
 		return nil
 	}
@@ -139,7 +139,7 @@ func (ei *EngineInstance) handleExit(ctx context.Context, exitPid int, exitErr e
 	if exitPid != 0 {
 		details = append(details, fmt.Sprintf("pid %d", exitPid))
 	}
-	if !rank.Equals(system.NilRank) {
+	if !rank.Equals(ranklist.NilRank) {
 		details = append(details, fmt.Sprintf("rank %d", rank))
 	}
 	strDetails := strings.Join(details, ", ")

--- a/src/control/server/instance_exec_test.go
+++ b/src/control/server/instance_exec_test.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/events"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/engine"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // TestIOEngineInstance_exit establishes that event is published on exit.
@@ -73,7 +73,7 @@ func TestIOEngineInstance_exit(t *testing.T) {
 
 			if tc.rankInSuperblock {
 				engine.setSuperblock(&Superblock{
-					Rank: system.NewRankPtr(0), ValidRank: true,
+					Rank: ranklist.NewRankPtr(0), ValidRank: true,
 				})
 			}
 			if tc.expExPid == 0 {

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/events"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // GetStorage retrieve the storage provider for an engine instance.
@@ -53,7 +53,7 @@ func (ei *EngineInstance) NotifyStorageReady() {
 func createPublishFormatRequiredFunc(publish func(*events.RASEvent), hostname string) onAwaitFormatFn {
 	return func(_ context.Context, engineIdx uint32, formatType string) error {
 		evt := events.NewEngineFormatRequiredEvent(hostname, engineIdx, formatType).
-			WithRank(uint32(system.NilRank))
+			WithRank(uint32(ranklist.NilRank))
 		publish(evt)
 
 		return nil

--- a/src/control/server/instance_storage_test.go
+++ b/src/control/server/instance_storage_test.go
@@ -14,15 +14,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/events"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
-	"github.com/daos-stack/daos/src/control/system"
-	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 )
 
 func TestIOEngineInstance_MountScmDevice(t *testing.T) {
@@ -348,7 +349,7 @@ func TestIOEngineInstance_awaitStorageReady(t *testing.T) {
 
 			if tc.hasSB {
 				engine.setSuperblock(&Superblock{
-					Rank: system.NewRankPtr(0), ValidRank: true,
+					Rank: ranklist.NewRankPtr(0), ValidRank: true,
 				})
 			}
 

--- a/src/control/server/instance_superblock.go
+++ b/src/control/server/instance_superblock.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/system"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
 const (
@@ -30,7 +30,7 @@ type Superblock struct {
 	Version         uint8
 	UUID            string
 	System          string
-	Rank            *system.Rank
+	Rank            *ranklist.Rank
 	URI             string
 	ValidRank       bool
 	HostFaultDomain string
@@ -155,7 +155,7 @@ func (ei *EngineInstance) createSuperblock(recreate bool) error {
 	}
 
 	if cfg.Rank != nil {
-		superblock.Rank = new(system.Rank)
+		superblock.Rank = new(ranklist.Rank)
 		if cfg.Rank != nil {
 			*superblock.Rank = *cfg.Rank
 		}

--- a/src/control/server/instance_test.go
+++ b/src/control/server/instance_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/atm"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -182,7 +183,7 @@ type (
 	MockInstanceConfig struct {
 		CallDrpcResp        *drpc.Response
 		CallDrpcErr         error
-		GetRankResp         system.Rank
+		GetRankResp         ranklist.Rank
 		GetRankErr          error
 		TargetCount         int
 		Index               uint32
@@ -219,7 +220,7 @@ func (mi *MockInstance) CallDrpc(_ context.Context, _ drpc.Method, _ proto.Messa
 	return mi.cfg.CallDrpcResp, mi.cfg.CallDrpcErr
 }
 
-func (mi *MockInstance) GetRank() (system.Rank, error) {
+func (mi *MockInstance) GetRank() (ranklist.Rank, error) {
 	return mi.cfg.GetRankResp, mi.cfg.GetRankErr
 }
 
@@ -249,7 +250,7 @@ func (mi *MockInstance) RemoveSuperblock() error {
 
 func (mi *MockInstance) Run(_ context.Context, _ bool) {}
 
-func (mi *MockInstance) SetupRank(_ context.Context, _ system.Rank) error {
+func (mi *MockInstance) SetupRank(_ context.Context, _ ranklist.Rank) error {
 	return mi.cfg.SetupRankErr
 }
 

--- a/src/control/server/mgmt_cont_test.go
+++ b/src/control/server/mgmt_cont_test.go
@@ -18,6 +18,7 @@ import (
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/events"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 	"github.com/daos-stack/daos/src/control/system/raft"
@@ -39,10 +40,10 @@ func testPoolService() *system.PoolService {
 	return &system.PoolService{
 		PoolLabel: "test-pool",
 		PoolUUID:  uuid.MustParse(mockUUID),
-		Replicas:  []system.Rank{0, 1, 2},
+		Replicas:  []ranklist.Rank{0, 1, 2},
 		State:     system.PoolServiceStateReady,
 		Storage: &system.PoolServiceStorage{
-			CreationRankStr: system.MustCreateRankSet("0-2").String(),
+			CreationRankStr: ranklist.MustCreateRankSet("0-2").String(),
 		},
 	}
 }

--- a/src/control/server/mgmt_drpc.go
+++ b/src/control/server/mgmt_drpc.go
@@ -18,6 +18,7 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -113,7 +114,7 @@ func (mod *srvModule) handleGetPoolServiceRanks(reqb []byte) ([]byte, error) {
 		return proto.Marshal(resp)
 	}
 
-	resp.Svcreps = system.RanksToUint32(ps.Replicas)
+	resp.Svcreps = ranklist.RanksToUint32(ps.Replicas)
 
 	mod.log.Debugf("GetPoolSvcResp: %+v", resp)
 
@@ -137,7 +138,7 @@ func (mod *srvModule) handlePoolFindByLabel(reqb []byte) ([]byte, error) {
 		return proto.Marshal(resp)
 	}
 
-	resp.Svcreps = system.RanksToUint32(ps.Replicas)
+	resp.Svcreps = ranklist.RanksToUint32(ps.Replicas)
 	resp.Uuid = ps.PoolUUID.String()
 	mod.log.Debugf("GetPoolSvcResp: %+v", resp)
 

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -19,6 +19,7 @@ import (
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -107,7 +108,7 @@ func (svc *mgmtSvc) getPoolService(id string) (*system.PoolService, error) {
 // getPoolServiceRanks returns a slice of ranks designated as the
 // pool service hosts.
 func (svc *mgmtSvc) getPoolServiceRanks(ps *system.PoolService) ([]uint32, error) {
-	readyRanks := make([]system.Rank, 0, len(ps.Replicas))
+	readyRanks := make([]ranklist.Rank, 0, len(ps.Replicas))
 	for _, r := range ps.Replicas {
 		m, err := svc.sysdb.FindMemberByRank(r)
 		if err != nil {
@@ -123,7 +124,7 @@ func (svc *mgmtSvc) getPoolServiceRanks(ps *system.PoolService) ([]uint32, error
 		return nil, errors.Errorf("unable to find any available service ranks for pool %s", ps.PoolUUID)
 	}
 
-	return system.RanksToUint32(readyRanks), nil
+	return ranklist.RanksToUint32(readyRanks), nil
 }
 
 func minRankScm(tgtCount uint64) uint64 {
@@ -284,15 +285,15 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		// If the request supplies a specific rank list, use it. Note that
 		// the rank list may include downed ranks, in which case the create
 		// will fail with an error.
-		reqRanks := system.RanksFromUint32(req.GetRanks())
+		reqRanks := ranklist.RanksFromUint32(req.GetRanks())
 		// Create a RankSet to sort/dedupe the ranks.
-		reqRanks = system.RankSetFromRanks(reqRanks).Ranks()
+		reqRanks = ranklist.RankSetFromRanks(reqRanks).Ranks()
 
-		if invalid := system.CheckRankMembership(allRanks, reqRanks); len(invalid) > 0 {
+		if invalid := ranklist.CheckRankMembership(allRanks, reqRanks); len(invalid) > 0 {
 			return nil, FaultPoolInvalidRanks(invalid)
 		}
 
-		req.Ranks = system.RanksToUint32(reqRanks)
+		req.Ranks = ranklist.RanksToUint32(reqRanks)
 	} else {
 		// Otherwise, create the pool across the requested number of
 		// available ranks in the system (if the request does not
@@ -346,7 +347,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		return nil, err
 	}
 
-	ps = system.NewPoolService(uuid, req.Tierbytes, system.RanksFromUint32(req.GetRanks()))
+	ps = system.NewPoolService(uuid, req.Tierbytes, ranklist.RanksFromUint32(req.GetRanks()))
 	ps.PoolLabel = poolLabel
 	if err := svc.sysdb.AddPoolService(ps); err != nil {
 		return nil, err
@@ -420,7 +421,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		return resp, nil
 	}
 
-	ps.Replicas = system.RanksFromUint32(resp.GetSvcReps())
+	ps.Replicas = ranklist.RanksFromUint32(resp.GetSvcReps())
 	ps.State = system.PoolServiceStateReady
 	if err := svc.sysdb.UpdatePoolService(ps); err != nil {
 		return nil, err
@@ -545,7 +546,7 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 		return nil, err
 	}
 	req.SetUUID(poolUUID)
-	req.SvcRanks = system.RanksToUint32(ps.Replicas)
+	req.SvcRanks = ranklist.RanksToUint32(ps.Replicas)
 
 	resp := &mgmtpb.PoolDestroyResp{}
 
@@ -554,7 +555,7 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 		// If we already tried to destroy the pool but it failed for some
 		// reason, try again, but instead use the full set of storage ranks
 		// in case the MS has lost track of the actual svc ranks.
-		req.SvcRanks = system.RanksToUint32(ps.Storage.CreationRanks())
+		req.SvcRanks = ranklist.RanksToUint32(ps.Storage.CreationRanks())
 		inCleanupMode = true
 	} else {
 		// If recursive flag is unset, refuse to destroy pool if resident containers exist.
@@ -1083,7 +1084,7 @@ func (svc *mgmtSvc) ListPools(ctx context.Context, req *mgmtpb.ListPoolsReq) (*m
 		resp.Pools = append(resp.Pools, &mgmtpb.ListPoolsResp_Pool{
 			Uuid:    ps.PoolUUID.String(),
 			Label:   ps.PoolLabel,
-			SvcReps: system.RanksToUint32(ps.Replicas),
+			SvcReps: ranklist.RanksToUint32(ps.Replicas),
 			State:   ps.State.String(),
 		})
 	}

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -66,7 +67,7 @@ func addTestPools(t *testing.T, sysdb *raft.Database, poolUUIDs ...string) {
 			PoolUUID:  uuid.MustParse(uuidStr),
 			PoolLabel: fmt.Sprintf("%d", i),
 			State:     system.PoolServiceStateReady,
-			Replicas:  []system.Rank{0},
+			Replicas:  []ranklist.Rank{0},
 		})
 	}
 }
@@ -383,7 +384,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 				Ranks:      []uint32{40, 11},
 				Properties: testPoolLabelProp(),
 			},
-			expErr: FaultPoolInvalidRanks([]system.Rank{11, 40}),
+			expErr: FaultPoolInvalidRanks([]ranklist.Rank{11, 40}),
 		},
 		"svc replicas > max": {
 			targetCount: 1,
@@ -578,10 +579,10 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 	testPoolService := &system.PoolService{
 		PoolLabel: "test-pool",
 		PoolUUID:  uuid.MustParse(mockUUID),
-		Replicas:  []system.Rank{0, 1, 2},
+		Replicas:  []ranklist.Rank{0, 1, 2},
 		State:     system.PoolServiceStateReady,
 		Storage: &system.PoolServiceStorage{
-			CreationRankStr: system.MustCreateRankSet("0-7").String(),
+			CreationRankStr: ranklist.MustCreateRankSet("0-7").String(),
 		},
 	}
 	svcWithState := func(in *system.PoolService, state system.PoolServiceState) (out *system.PoolService) {
@@ -986,7 +987,7 @@ func TestServer_MgmtSvc_PoolExtend(t *testing.T) {
 	testPoolService := &system.PoolService{
 		PoolUUID: uuid.MustParse(mockUUID),
 		State:    system.PoolServiceStateReady,
-		Replicas: []system.Rank{0},
+		Replicas: []ranklist.Rank{0},
 		Storage: &system.PoolServiceStorage{
 			CreationRankStr:    "0",
 			CurrentRankStr:     "0",
@@ -1090,7 +1091,7 @@ func TestServer_MgmtSvc_PoolDrain(t *testing.T) {
 	testPoolService := &system.PoolService{
 		PoolUUID: uuid.MustParse(mockUUID),
 		State:    system.PoolServiceStateReady,
-		Replicas: []system.Rank{0},
+		Replicas: []ranklist.Rank{0},
 	}
 
 	for name, tc := range map[string]struct {
@@ -1187,7 +1188,7 @@ func TestServer_MgmtSvc_PoolEvict(t *testing.T) {
 	testPoolService := &system.PoolService{
 		PoolUUID: uuid.MustParse(mockUUID),
 		State:    system.PoolServiceStateReady,
-		Replicas: []system.Rank{0},
+		Replicas: []ranklist.Rank{0},
 	}
 
 	for name, tc := range map[string]struct {
@@ -1304,13 +1305,13 @@ func TestListPools_Success(t *testing.T) {
 			PoolUUID:  uuid.MustParse(test.MockUUID(0)),
 			PoolLabel: "0",
 			State:     system.PoolServiceStateReady,
-			Replicas:  []system.Rank{0, 1, 2},
+			Replicas:  []ranklist.Rank{0, 1, 2},
 		},
 		{
 			PoolUUID:  uuid.MustParse(test.MockUUID(1)),
 			PoolLabel: "1",
 			State:     system.PoolServiceStateReady,
-			Replicas:  []system.Rank{0, 1, 2},
+			Replicas:  []ranklist.Rank{0, 1, 2},
 		},
 	}
 	expectedResp := new(mgmtpb.ListPoolsResp)
@@ -2019,7 +2020,7 @@ func TestServer_MgmtSvc_PoolUpgrade(t *testing.T) {
 	testPoolService := &system.PoolService{
 		PoolUUID: uuid.MustParse(mockUUID),
 		State:    system.PoolServiceStateReady,
-		Replicas: []system.Rank{0},
+		Replicas: []ranklist.Rank{0},
 	}
 
 	for name, tc := range map[string]struct {

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -33,6 +33,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -77,7 +78,7 @@ func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfo
 		}
 	}
 	resp.ClientNetHint = svc.clientNetworkHint
-	resp.MsRanks = system.RanksToUint32(groupMap.MSRanks)
+	resp.MsRanks = ranklist.RanksToUint32(groupMap.MSRanks)
 
 	// For resp.RankUris may be large, we make a resp copy with a limited
 	// number of rank URIs, to avoid flooding the debug log.
@@ -269,7 +270,7 @@ func (svc *mgmtSvc) join(ctx context.Context, req *batchJoinRequest) *batchJoinR
 	}
 
 	joinResponse, err := svc.membership.Join(&system.JoinRequest{
-		Rank:           system.Rank(req.Rank),
+		Rank:           ranklist.Rank(req.Rank),
 		UUID:           uuid,
 		ControlAddr:    req.peerAddr,
 		FabricURI:      req.GetUri(),
@@ -356,7 +357,7 @@ func (svc *mgmtSvc) doGroupUpdate(ctx context.Context, forced bool) error {
 	req := &mgmtpb.GroupUpdateReq{
 		MapVersion: gm.Version,
 	}
-	rankSet := &system.RankSet{}
+	rankSet := &ranklist.RankSet{}
 	for rank, entry := range gm.RankEntries {
 		req.Engines = append(req.Engines, &mgmtpb.GroupUpdateReq_Engine{
 			Rank:        rank.Uint32(),
@@ -458,7 +459,7 @@ type (
 
 	fanoutRequest struct {
 		Method     systemRanksFunc
-		Ranks      *system.RankSet
+		Ranks      *ranklist.RankSet
 		Force      bool
 		FullSystem bool
 	}
@@ -466,13 +467,13 @@ type (
 	fanoutResponse struct {
 		Results     system.MemberResults
 		AbsentHosts *hostlist.HostSet
-		AbsentRanks *system.RankSet
+		AbsentRanks *ranklist.RankSet
 	}
 )
 
 // resolveRanks derives ranks to be used for fanout by comparing host and rank
 // sets with the contents of the membership.
-func (svc *mgmtSvc) resolveRanks(hosts, ranks string) (hitRS, missRS *system.RankSet, missHS *hostlist.HostSet, err error) {
+func (svc *mgmtSvc) resolveRanks(hosts, ranks string) (hitRS, missRS *ranklist.RankSet, missHS *hostlist.HostSet, err error) {
 	hasHosts := hosts != ""
 	hasRanks := ranks != ""
 
@@ -504,14 +505,14 @@ func (svc *mgmtSvc) resolveRanks(hosts, ranks string) (hitRS, missRS *system.Ran
 		missHS = new(hostlist.HostSet)
 	}
 	if missRS == nil {
-		missRS = new(system.RankSet)
+		missRS = new(ranklist.RankSet)
 	}
 
 	return
 }
 
 // synthesise "Stopped" rank results for any harness host errors
-func addUnresponsiveResults(log logging.Logger, hostRanks map[string][]system.Rank, rr *control.RanksResp, resp *fanoutResponse) {
+func addUnresponsiveResults(log logging.Logger, hostRanks map[string][]ranklist.Rank, rr *control.RanksResp, resp *fanoutResponse) {
 	for _, hes := range rr.HostErrors {
 		for _, addr := range strings.Split(hes.HostSet.DerangedString(), ",") {
 			for _, rank := range hostRanks[addr] {
@@ -564,7 +565,7 @@ func removeDuplicateResults(log logging.Logger, resp *fanoutResponse) {
 // Pass true as last parameter to update member states on request failure.
 //
 // Fan-out is invoked by control API *Ranks functions.
-func (svc *mgmtSvc) rpcFanout(ctx context.Context, req *fanoutRequest, resp *fanoutResponse, updateOnFail bool) (*fanoutResponse, *system.RankSet, error) {
+func (svc *mgmtSvc) rpcFanout(ctx context.Context, req *fanoutRequest, resp *fanoutResponse, updateOnFail bool) (*fanoutResponse, *ranklist.RankSet, error) {
 	if req == nil || req.Method == nil {
 		return nil, nil, errors.New("nil fanout request or method")
 	}
@@ -584,8 +585,8 @@ func (svc *mgmtSvc) rpcFanout(ctx context.Context, req *fanoutRequest, resp *fan
 		return filepath.Base(runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name())
 	}
 
-	waiting := system.RankSetFromRanks(req.Ranks.Ranks())
-	finished := system.MustCreateRankSet("")
+	waiting := ranklist.RankSetFromRanks(req.Ranks.Ranks())
+	finished := ranklist.MustCreateRankSet("")
 	ranksReq.SetReportCb(func(hr *control.HostResponse) {
 		rs, ok := hr.Message.(interface{ GetResults() []*sharedpb.RankResult })
 		if !ok {
@@ -594,8 +595,8 @@ func (svc *mgmtSvc) rpcFanout(ctx context.Context, req *fanoutRequest, resp *fan
 		}
 
 		for _, rr := range rs.GetResults() {
-			waiting.Delete(system.Rank(rr.Rank))
-			finished.Add(system.Rank(rr.Rank))
+			waiting.Delete(ranklist.Rank(rr.Rank))
+			finished.Add(ranklist.Rank(rr.Rank))
 		}
 
 		svc.log.Infof("%s: finished: %s; waiting: %s", funcName(req.Method), finished, waiting)
@@ -733,7 +734,7 @@ func (svc *mgmtSvc) getFanout(req systemReq) (*fanoutRequest, *fanoutResponse, e
 	return &fanoutRequest{
 			Ranks:      hitRanks,
 			Force:      force,
-			FullSystem: len(system.CheckRankMembership(hitRanks.Ranks(), allRanks)) == 0,
+			FullSystem: len(ranklist.CheckRankMembership(hitRanks.Ranks(), allRanks)) == 0,
 		}, &fanoutResponse{
 			AbsentRanks: missRanks,
 			AbsentHosts: missHosts,

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/system"
@@ -462,7 +463,7 @@ func mockMember(t *testing.T, r, a int32, s string) *system.Member {
 	}
 	uri := fmt.Sprintf("tcp://%s", addr)
 
-	m := system.MockMemberFullSpec(t, system.Rank(r), test.MockUUID(r), uri, addr, state)
+	m := system.MockMemberFullSpec(t, ranklist.Rank(r), test.MockUUID(r), uri, addr, state)
 	m.FabricContexts = uint32(r)
 	m.FaultDomain = fd
 	m.Incarnation = uint64(r)
@@ -531,7 +532,7 @@ func mgmtSystemTestSetup(t *testing.T, l logging.Logger, mbs system.Members, r .
 
 	svc := newTestMgmtSvcMulti(t, l, maxEngines, false)
 	svc.harness.started.SetTrue()
-	svc.harness.instances[0].(*EngineInstance)._superblock.Rank = system.NewRankPtr(0)
+	svc.harness.instances[0].(*EngineInstance)._superblock.Rank = ranklist.NewRankPtr(0)
 	svc.sysdb = raft.MockDatabase(t, l)
 	svc.membership = system.MockMembership(t, l, svc.sysdb, mockResolver)
 	for _, m := range mbs {
@@ -648,7 +649,7 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 			},
 			expFanReq: &fanoutRequest{
 				Method:     control.StartRanks,
-				Ranks:      system.MustCreateRankSet("0-7"),
+				Ranks:      ranklist.MustCreateRankSet("0-7"),
 				FullSystem: true,
 			},
 			// results from ranks on failing hosts generated
@@ -748,7 +749,7 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 			},
 			expFanReq: &fanoutRequest{
 				Method: control.StartRanks,
-				Ranks:  system.MustCreateRankSet("0-3,6-7"),
+				Ranks:  ranklist.MustCreateRankSet("0-3,6-7"),
 			},
 			// results from ranks on failing hosts generated
 			// results from host responses amalgamated
@@ -839,7 +840,7 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 			},
 			expFanReq: &fanoutRequest{
 				Method: control.StartRanks,
-				Ranks:  system.MustCreateRankSet("0-5"),
+				Ranks:  ranklist.MustCreateRankSet("0-5"),
 			},
 			// results from ranks on failing hosts generated
 			// results from host responses amalgamated
@@ -931,7 +932,7 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 			},
 			expFanReq: &fanoutRequest{
 				Method: control.StopRanks,
-				Ranks:  system.MustCreateRankSet("0-3"),
+				Ranks:  ranklist.MustCreateRankSet("0-3"),
 			},
 			// Verifies de-duplication of rank results.
 			expResults: system.MemberResults{
@@ -1915,7 +1916,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 		},
 		"rejoining host; NilRank": {
 			req: &mgmtpb.JoinReq{
-				Rank:        uint32(system.NilRank),
+				Rank:        uint32(ranklist.NilRank),
 				Uuid:        curMember.UUID.String(),
 				Incarnation: curMember.Incarnation + 1,
 			},
@@ -1937,7 +1938,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 		},
 		"new host (non local)": {
 			req: &mgmtpb.JoinReq{
-				Rank:        uint32(system.NilRank),
+				Rank:        uint32(ranklist.NilRank),
 				Incarnation: newMember.Incarnation,
 			},
 			expGuReq: &mgmtpb.GroupUpdateReq{
@@ -1962,7 +1963,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 			req: &mgmtpb.JoinReq{
 				Addr:        common.LocalhostCtrlAddr().String(),
 				Uri:         "tcp://" + common.LocalhostCtrlAddr().String(),
-				Rank:        uint32(system.NilRank),
+				Rank:        uint32(ranklist.NilRank),
 				Incarnation: newMember.Incarnation,
 			},
 			expGuReq: &mgmtpb.GroupUpdateReq{
@@ -1991,7 +1992,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 			// Make a copy to avoid test side-effects.
 			curCopy := &system.Member{}
 			*curCopy = *curMember
-			curCopy.Rank = system.NilRank // ensure that db.data.NextRank is incremented
+			curCopy.Rank = ranklist.NilRank // ensure that db.data.NextRank is incremented
 
 			svc := mgmtSystemTestSetup(t, log, system.Members{curCopy}, nil)
 

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
 	"github.com/daos-stack/daos/src/control/security"
@@ -495,7 +496,7 @@ func configureFirstEngine(ctx context.Context, engine *EngineInstance, sysdb *ra
 		if sb := engine.getSuperblock(); !sb.ValidRank {
 			engine.log.Debug("marking bootstrap instance as rank 0")
 			req.Rank = 0
-			sb.Rank = system.NewRankPtr(0)
+			sb.Rank = ranklist.NewRankPtr(0)
 		}
 
 		return join(ctx, req)
@@ -550,7 +551,7 @@ func registerLeaderSubscriptions(srv *server) {
 				srv.log.Debugf("%s marked rank %d:%x dead @ %s", evt.Hostname, evt.Rank, evt.Incarnation, ts)
 				// Mark the rank as unavailable for membership in
 				// new pools, etc. Do group update on success.
-				if err := srv.membership.MarkRankDead(system.Rank(evt.Rank), evt.Incarnation); err != nil {
+				if err := srv.membership.MarkRankDead(ranklist.Rank(evt.Rank), evt.Incarnation); err != nil {
 					srv.log.Errorf("failed to mark rank %d:%x dead: %s", evt.Rank, evt.Incarnation, err)
 					if system.IsNotLeader(err) {
 						// If we've lost leadership while processing the event,

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -20,9 +20,9 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 /*
@@ -179,15 +179,15 @@ type NvmeNamespace struct {
 // SmdDevice contains DAOS storage device information, including
 // health details if requested.
 type SmdDevice struct {
-	UUID        string       `json:"uuid"`
-	TargetIDs   []int32      `hash:"set" json:"tgt_ids"`
-	NvmeState   NvmeDevState `json:"-"`
-	Rank        system.Rank  `json:"rank"`
-	TotalBytes  uint64       `json:"total_bytes"`
-	AvailBytes  uint64       `json:"avail_bytes"`
-	ClusterSize uint64       `json:"cluster_size"`
-	Health      *NvmeHealth  `json:"health"`
-	TrAddr      string       `json:"tr_addr"`
+	UUID        string        `json:"uuid"`
+	TargetIDs   []int32       `hash:"set" json:"tgt_ids"`
+	NvmeState   NvmeDevState  `json:"-"`
+	Rank        ranklist.Rank `json:"rank"`
+	TotalBytes  uint64        `json:"total_bytes"`
+	AvailBytes  uint64        `json:"avail_bytes"`
+	ClusterSize uint64        `json:"cluster_size"`
+	Health      *NvmeHealth   `json:"health"`
+	TrAddr      string        `json:"tr_addr"`
 }
 
 // MarshalJSON marshals SmdDevice to JSON.

--- a/src/control/server/storage/mocks.go
+++ b/src/control/server/storage/mocks.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // NvmeDevState constant definitions to represent mock bitset flag combinations.
@@ -207,7 +207,7 @@ func MockScmMountPoint(varIdx ...int32) *ScmMountPoint {
 		DeviceList: []string{fmt.Sprintf("pmem%d", idx)},
 		TotalBytes: uint64(humanize.TByte) * uint64(idx+1),
 		AvailBytes: uint64(humanize.TByte/4) * uint64(idx+1), // 75% used
-		Rank:       system.Rank(uint32(idx)),
+		Rank:       ranklist.Rank(uint32(idx)),
 	}
 }
 

--- a/src/control/server/storage/scm.go
+++ b/src/control/server/storage/scm.go
@@ -15,9 +15,9 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 // ScmState represents the probed state of PMem modules on the system.
@@ -90,13 +90,13 @@ type (
 
 	// ScmMountPoint represents location PMem filesystem is mounted.
 	ScmMountPoint struct {
-		Class      Class       `json:"class"`
-		DeviceList []string    `json:"device_list"`
-		Info       string      `json:"info"`
-		Path       string      `json:"path"`
-		Rank       system.Rank `json:"rank"`
-		TotalBytes uint64      `json:"total_bytes"`
-		AvailBytes uint64      `json:"avail_bytes"`
+		Class      Class         `json:"class"`
+		DeviceList []string      `json:"device_list"`
+		Info       string        `json:"info"`
+		Path       string        `json:"path"`
+		Rank       ranklist.Rank `json:"rank"`
+		TotalBytes uint64        `json:"total_bytes"`
+		AvailBytes uint64        `json:"avail_bytes"`
 	}
 
 	// ScmMountPoints is a type alias for []ScmMountPoint that implements fmt.Stringer.

--- a/src/control/server/telemetry.go
+++ b/src/control/server/telemetry.go
@@ -16,9 +16,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/lib/telemetry/promexp"
 	"github.com/daos-stack/daos/src/control/logging"
-	"github.com/daos-stack/daos/src/control/system"
 )
 
 func regPromEngineSources(ctx context.Context, log logging.Logger, engines []Engine) error {
@@ -33,7 +33,7 @@ func regPromEngineSources(ctx context.Context, log logging.Logger, engines []Eng
 	}
 	prometheus.MustRegister(c)
 
-	addFn := func(idx uint32, rank system.Rank) func(context.Context) error {
+	addFn := func(idx uint32, rank ranklist.Rank) func(context.Context) error {
 		return func(context.Context) error {
 			log.Debugf("Setting up metrics collection for engine %d", idx)
 			es, cleanup, err := promexp.NewEngineSource(ctx, idx, rank.Uint32())
@@ -45,8 +45,8 @@ func regPromEngineSources(ctx context.Context, log logging.Logger, engines []Eng
 		}
 	}
 
-	delFn := func(idx uint32) func(context.Context, uint32, system.Rank, error, int) error {
-		return func(_ context.Context, _ uint32, rank system.Rank, _ error, _ int) error {
+	delFn := func(idx uint32) func(context.Context, uint32, ranklist.Rank, error, int) error {
+		return func(_ context.Context, _ uint32, rank ranklist.Rank, _ error, _ int) error {
 			log.Debugf("Tearing down metrics collection for engine %d (rank %s)", idx, rank.String())
 			c.RemoveSource(idx)
 			return nil

--- a/src/control/server/util_test.go
+++ b/src/control/server/util_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/events"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -175,7 +176,7 @@ func newTestEngine(log logging.Logger, isAP bool, provider *storage.Provider, en
 
 	srv := NewEngineInstance(log, provider, nil, r)
 	srv.setSuperblock(&Superblock{
-		Rank: system.NewRankPtr(0),
+		Rank: ranklist.NewRankPtr(0),
 	})
 	srv.ready.SetTrue()
 	srv.OnReady()
@@ -219,7 +220,7 @@ func newTestMgmtSvcMulti(t *testing.T, log logging.Logger, count int, isAP bool)
 
 	for i := 0; i < count; i++ {
 		srv := newTestEngine(log, i == 0 && isAP, provider)
-		srv._superblock.Rank = system.NewRankPtr(uint32(i))
+		srv._superblock.Rank = ranklist.NewRankPtr(uint32(i))
 
 		if err := harness.AddInstance(srv); err != nil {
 			t.Fatal(err)

--- a/src/control/system/errors.go
+++ b/src/control/system/errors.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
 var (
@@ -96,7 +97,7 @@ func IsNotLeader(err error) bool {
 // ErrMemberExists indicates the failure of an operation that
 // expected the given member to not exist.
 type ErrMemberExists struct {
-	Rank *Rank
+	Rank *ranklist.Rank
 	UUID *uuid.UUID
 }
 
@@ -111,7 +112,7 @@ func (err *ErrMemberExists) Error() string {
 	}
 }
 
-func ErrRankExists(r Rank) *ErrMemberExists {
+func ErrRankExists(r ranklist.Rank) *ErrMemberExists {
 	return &ErrMemberExists{Rank: &r}
 }
 
@@ -134,8 +135,8 @@ type ErrJoinFailure struct {
 	isExcluded  bool
 	newUUID     *uuid.UUID
 	curUUID     *uuid.UUID
-	newRank     *Rank
-	curRank     *Rank
+	newRank     *ranklist.Rank
+	curRank     *ranklist.Rank
 }
 
 func (err *ErrJoinFailure) Error() string {
@@ -151,7 +152,7 @@ func (err *ErrJoinFailure) Error() string {
 	}
 }
 
-func ErrRankChanged(new, cur Rank, uuid uuid.UUID) *ErrJoinFailure {
+func ErrRankChanged(new, cur ranklist.Rank, uuid uuid.UUID) *ErrJoinFailure {
 	return &ErrJoinFailure{
 		rankChanged: true,
 		curUUID:     &uuid,
@@ -160,7 +161,7 @@ func ErrRankChanged(new, cur Rank, uuid uuid.UUID) *ErrJoinFailure {
 	}
 }
 
-func ErrUuidChanged(new, cur uuid.UUID, rank Rank) *ErrJoinFailure {
+func ErrUuidChanged(new, cur uuid.UUID, rank ranklist.Rank) *ErrJoinFailure {
 	return &ErrJoinFailure{
 		uuidChanged: true,
 		newUUID:     &new,
@@ -169,7 +170,7 @@ func ErrUuidChanged(new, cur uuid.UUID, rank Rank) *ErrJoinFailure {
 	}
 }
 
-func ErrAdminExcluded(uuid uuid.UUID, rank Rank) *ErrJoinFailure {
+func ErrAdminExcluded(uuid uuid.UUID, rank ranklist.Rank) *ErrJoinFailure {
 	return &ErrJoinFailure{
 		isExcluded: true,
 		curUUID:    &uuid,
@@ -187,7 +188,7 @@ func IsJoinFailure(err error) bool {
 // ErrMemberNotFound indicates a failure to find a member with the
 // given search criterion.
 type ErrMemberNotFound struct {
-	byRank *Rank
+	byRank *ranklist.Rank
 	byUUID *uuid.UUID
 	byAddr *net.TCPAddr
 }
@@ -212,7 +213,7 @@ func IsMemberNotFound(err error) bool {
 	return ok
 }
 
-func ErrMemberRankNotFound(r Rank) *ErrMemberNotFound {
+func ErrMemberRankNotFound(r ranklist.Rank) *ErrMemberNotFound {
 	return &ErrMemberNotFound{byRank: &r}
 }
 
@@ -227,7 +228,7 @@ func ErrMemberAddrNotFound(a *net.TCPAddr) *ErrMemberNotFound {
 // ErrPoolNotFound indicates a failure to find a pool service with the
 // given search criterion.
 type ErrPoolNotFound struct {
-	byRank  *Rank
+	byRank  *ranklist.Rank
 	byUUID  *uuid.UUID
 	byLabel *string
 }
@@ -252,7 +253,7 @@ func IsPoolNotFound(err error) bool {
 	return ok
 }
 
-func ErrPoolRankNotFound(r Rank) *ErrPoolNotFound {
+func ErrPoolRankNotFound(r ranklist.Rank) *ErrPoolNotFound {
 	return &ErrPoolNotFound{byRank: &r}
 }
 

--- a/src/control/system/member.go
+++ b/src/control/system/member.go
@@ -16,6 +16,8 @@ import (
 	"github.com/dustin/go-humanize/english"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
 // MemberState represents the activity state of DAOS system members.
@@ -159,16 +161,16 @@ func (ms MemberState) isTransitionIllegal(to MemberState) bool {
 // Member refers to a data-plane instance that is a member of this DAOS
 // system running on host with the control-plane listening at "Addr".
 type Member struct {
-	Rank           Rank         `json:"rank"`
-	Incarnation    uint64       `json:"incarnation"`
-	UUID           uuid.UUID    `json:"uuid"`
-	Addr           *net.TCPAddr `json:"addr"`
-	FabricURI      string       `json:"fabric_uri"`
-	FabricContexts uint32       `json:"fabric_contexts"`
-	State          MemberState  `json:"-"`
-	Info           string       `json:"info"`
-	FaultDomain    *FaultDomain `json:"fault_domain"`
-	LastUpdate     time.Time    `json:"last_update"`
+	Rank           ranklist.Rank `json:"rank"`
+	Incarnation    uint64        `json:"incarnation"`
+	UUID           uuid.UUID     `json:"uuid"`
+	Addr           *net.TCPAddr  `json:"addr"`
+	FabricURI      string        `json:"fabric_uri"`
+	FabricContexts uint32        `json:"fabric_contexts"`
+	State          MemberState   `json:"-"`
+	Info           string        `json:"info"`
+	FaultDomain    *FaultDomain  `json:"fault_domain"`
+	LastUpdate     time.Time     `json:"last_update"`
 }
 
 // MarshalJSON marshals system.Member to JSON.
@@ -254,7 +256,7 @@ type Members []*Member
 // MemberResult refers to the result of an action on a Member.
 type MemberResult struct {
 	Addr    string
-	Rank    Rank
+	Rank    ranklist.Rank
 	Action  string
 	Errored bool
 	Msg     string
@@ -314,7 +316,7 @@ func (mr *MemberResult) Equals(other *MemberResult) bool {
 // NewMemberResult returns a reference to a new member result struct.
 //
 // Host address and action fields are not always used so not populated here.
-func NewMemberResult(rank Rank, err error, state MemberState, action ...string) *MemberResult {
+func NewMemberResult(rank ranklist.Rank, err error, state MemberState, action ...string) *MemberResult {
 	result := MemberResult{Rank: rank, State: state}
 	if err != nil {
 		result.Errored = true
@@ -332,7 +334,7 @@ type MemberResults []*MemberResult
 
 // Errors returns an error indicating if and which ranks failed.
 func (mrs MemberResults) Errors() error {
-	rs, err := CreateRankSet("")
+	rs, err := ranklist.CreateRankSet("")
 	if err != nil {
 		return err
 	}

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -21,6 +21,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	. "github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/events"
+	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	. "github.com/daos-stack/daos/src/control/system"
 	"github.com/daos-stack/daos/src/control/system/raft"

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/daos-stack/daos/src/control/common/test"
+	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 

--- a/src/control/system/pool.go
+++ b/src/control/system/pool.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
+
+	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
 const (

--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -23,6 +23,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/atm"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -66,7 +67,7 @@ type (
 		log logging.Logger
 
 		Version       uint64
-		NextRank      system.Rank
+		NextRank      ranklist.Rank
 		MapVersion    uint32
 		Members       *MemberDatabase
 		Pools         *PoolDatabase
@@ -108,8 +109,8 @@ type (
 	// GroupMap represents a version of the system membership map.
 	GroupMap struct {
 		Version     uint32
-		RankEntries map[system.Rank]RankEntry
-		MSRanks     []system.Rank
+		RankEntries map[ranklist.Rank]RankEntry
+		MSRanks     []ranklist.Rank
 	}
 
 	// RankEntry comprises the information about a rank in GroupMap.
@@ -527,7 +528,7 @@ func (db *Database) IncMapVer() error {
 func newGroupMap(version uint32) *GroupMap {
 	return &GroupMap{
 		Version:     version,
-		RankEntries: make(map[system.Rank]RankEntry),
+		RankEntries: make(map[ranklist.Rank]RankEntry),
 	}
 }
 
@@ -550,7 +551,7 @@ func (db *Database) GroupMap() (*GroupMap, error) {
 		}
 		// Quick sanity-check: Don't include members that somehow have
 		// a nil rank or fabric URI, either.
-		if srv.Rank.Equals(system.NilRank) || srv.FabricURI == "" {
+		if srv.Rank.Equals(ranklist.NilRank) || srv.FabricURI == "" {
 			db.log.Errorf("member has invalid rank (%d) or URI (%s)", srv.Rank, srv.FabricURI)
 			continue
 		}
@@ -631,14 +632,14 @@ func (db *Database) filterMembers(desiredStates ...system.MemberState) (result [
 }
 
 // MemberRanks returns a slice of all the ranks in the membership.
-func (db *Database) MemberRanks(desiredStates ...system.MemberState) ([]system.Rank, error) {
+func (db *Database) MemberRanks(desiredStates ...system.MemberState) ([]ranklist.Rank, error) {
 	if err := db.CheckReplica(); err != nil {
 		return nil, err
 	}
 	db.data.RLock()
 	defer db.data.RUnlock()
 
-	ranks := make([]system.Rank, 0, len(db.data.Members.Ranks))
+	ranks := make([]ranklist.Rank, 0, len(db.data.Members.Ranks))
 	for _, m := range db.filterMembers(desiredStates...) {
 		ranks = append(ranks, m.Rank)
 	}
@@ -745,7 +746,7 @@ func (db *Database) AddMember(newMember *system.Member) error {
 	}
 
 	mu := &memberUpdate{Member: newMember}
-	if newMember.Rank.Equals(system.NilRank) {
+	if newMember.Rank.Equals(ranklist.NilRank) {
 		newMember.Rank = db.data.NextRank
 		mu.NextRank = true
 	}
@@ -775,7 +776,7 @@ func (db *Database) UpdateMember(m *system.Member) error {
 
 // FindMemberByRank searches the member database by rank. If no
 // member is found, an error is returned.
-func (db *Database) FindMemberByRank(rank system.Rank) (*system.Member, error) {
+func (db *Database) FindMemberByRank(rank ranklist.Rank) (*system.Member, error) {
 	if err := db.CheckReplica(); err != nil {
 		return nil, err
 	}
@@ -996,7 +997,7 @@ func (db *Database) handlePoolRepsUpdate(evt *events.RASEvent) {
 	db.log.Debugf("update pool %s (state=%s) svc ranks %v->%v",
 		ps.PoolUUID, ps.State, ps.Replicas, ei.SvcReplicas)
 
-	ps.Replicas = system.RanksFromUint32(ei.SvcReplicas)
+	ps.Replicas = ranklist.RanksFromUint32(ei.SvcReplicas)
 
 	if err := db.UpdatePoolService(ps); err != nil {
 		db.log.Errorf("failed to apply pool service update: %s", err)

--- a/src/control/system/raft/database_members.go
+++ b/src/control/system/raft/database_members.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -13,12 +13,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
 type (
 	// MemberRankMap provides a map of Rank->*system.Member.
-	MemberRankMap map[system.Rank]*system.Member
+	MemberRankMap map[ranklist.Rank]*system.Member
 	// MemberUuidMap provides a map of UUID->*system.Member.
 	MemberUuidMap map[uuid.UUID]*system.Member
 	// MemberAddrMap provides a map of string->[]*system.Member.
@@ -39,7 +40,7 @@ type (
 // The member's UUID is used to represent the member in order to
 // avoid duplicating member details in the serialized format.
 func (mrm MemberRankMap) MarshalJSON() ([]byte, error) {
-	jm := make(map[system.Rank]uuid.UUID)
+	jm := make(map[ranklist.Rank]uuid.UUID)
 	for rank, member := range mrm {
 		jm[rank] = member.UUID
 	}
@@ -97,11 +98,11 @@ func (mdb *MemberDatabase) UnmarshalJSON(data []byte) error {
 
 	type fromJSON MemberDatabase
 	from := &struct {
-		Ranks map[system.Rank]uuid.UUID
+		Ranks map[ranklist.Rank]uuid.UUID
 		Addrs map[string][]uuid.UUID
 		*fromJSON
 	}{
-		Ranks:    make(map[system.Rank]uuid.UUID),
+		Ranks:    make(map[ranklist.Rank]uuid.UUID),
 		Addrs:    make(map[string][]uuid.UUID),
 		fromJSON: (*fromJSON)(mdb),
 	}

--- a/src/control/system/raft/database_pools.go
+++ b/src/control/system/raft/database_pools.go
@@ -12,12 +12,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
 type (
 	// PoolRankMap provides a map of Rank->[]*PoolService.
-	PoolRankMap map[system.Rank][]*system.PoolService
+	PoolRankMap map[ranklist.Rank][]*system.PoolService
 	// PoolUuidMap provides a map of UUID->*PoolService.
 	PoolUuidMap map[uuid.UUID]*system.PoolService
 	// PoolLabelMap provides a map of Label->*PoolService.
@@ -36,7 +37,7 @@ type (
 // The pool's UUID is used to represent the pool service in order to
 // avoid duplicating pool service details in the serialized format.
 func (prm PoolRankMap) MarshalJSON() ([]byte, error) {
-	jm := make(map[system.Rank][]uuid.UUID)
+	jm := make(map[ranklist.Rank][]uuid.UUID)
 	for rank, svcList := range prm {
 		if _, exists := jm[rank]; !exists {
 			jm[rank] = []uuid.UUID{}
@@ -70,11 +71,11 @@ func (pdb *PoolDatabase) UnmarshalJSON(data []byte) error {
 
 	type fromJSON PoolDatabase
 	from := &struct {
-		Ranks  map[system.Rank][]uuid.UUID
+		Ranks  map[ranklist.Rank][]uuid.UUID
 		Labels map[string]uuid.UUID
 		*fromJSON
 	}{
-		Ranks:    make(map[system.Rank][]uuid.UUID),
+		Ranks:    make(map[ranklist.Rank][]uuid.UUID),
 		Labels:   make(map[string]uuid.UUID),
 		fromJSON: (*fromJSON)(pdb),
 	}

--- a/src/control/system/raft/database_test.go
+++ b/src/control/system/raft/database_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/events"
+	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	. "github.com/daos-stack/daos/src/control/system"
 )

--- a/src/control/system/raft/raft_recovery.go
+++ b/src/control/system/raft/raft_recovery.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -301,7 +302,7 @@ type SnapshotDetails struct {
 	MapVersion    uint
 	SchemaVersion uint
 	NextRank      uint
-	MemberRanks   *system.RankSet
+	MemberRanks   *ranklist.RankSet
 	Pools         []string
 }
 
@@ -334,7 +335,7 @@ func (sd *SnapshotDetails) DecodeSnapshot(data []byte) error {
 		return err
 	}
 
-	sd.MemberRanks = system.NewRankSet()
+	sd.MemberRanks = ranklist.NewRankSet()
 	for _, m := range from.Members.Uuids {
 		sd.MemberRanks.Add(m.Rank)
 	}

--- a/src/control/system/raft/raft_recovery_test.go
+++ b/src/control/system/raft/raft_recovery_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/test"
+	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 	. "github.com/daos-stack/daos/src/control/system"
 )

--- a/src/control/system/rankgroups.go
+++ b/src/control/system/rankgroups.go
@@ -1,0 +1,147 @@
+//
+// (C) Copyright 2020-2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package system
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
+)
+
+// RankGroups maps a set of ranks to string value (group).
+type RankGroups map[string]*ranklist.RankSet
+
+// Keys returns sorted group names.
+//
+// Sort first by number of ranks in grouping then by alphabetical order of
+// group name.
+func (rgs RankGroups) Keys() []string {
+	keys := make([]string, 0, len(rgs))
+
+	for key := range rgs {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		ci := rgs[keys[i]].Count()
+		cj := rgs[keys[j]].Count()
+		if ci == cj {
+			return keys[i] < keys[j]
+		}
+
+		return ci > cj
+	})
+
+	return keys
+}
+
+func (rgs RankGroups) String() string {
+	var buf bytes.Buffer
+
+	padding := 0
+	keys := rgs.Keys()
+	for _, key := range keys {
+		valStr := rgs[key].String()
+		if len(valStr) > padding {
+			padding = len(valStr)
+		}
+	}
+
+	for _, key := range rgs.Keys() {
+		fmt.Fprintf(&buf, "%*s: %s\n", padding, rgs[key], key)
+	}
+
+	return buf.String()
+}
+
+// FromMembers initializes groupings of ranks that are at a particular state
+// from a slice of system members.
+func (rgs RankGroups) FromMembers(members Members) error {
+	if rgs == nil || len(rgs) > 0 {
+		return errors.New("expecting non-nil empty rank groups")
+	}
+
+	ranksInState := make(map[MemberState]*bytes.Buffer)
+	ranksSeen := make(map[ranklist.Rank]struct{})
+
+	for _, m := range members {
+		if _, exists := ranksSeen[m.Rank]; exists {
+			return &ErrMemberExists{Rank: &m.Rank}
+		}
+		ranksSeen[m.Rank] = struct{}{}
+
+		if _, exists := ranksInState[m.State]; !exists {
+			ranksInState[m.State] = new(bytes.Buffer)
+		}
+		fmt.Fprintf(ranksInState[m.State], "%d,", m.Rank)
+	}
+
+	for state, ranksStrBuf := range ranksInState {
+		rankSet, err := ranklist.CreateRankSet(
+			strings.TrimSuffix(ranksStrBuf.String(), ","))
+		if err != nil {
+			return errors.WithMessage(err,
+				"generating groups of ranks at state")
+		}
+		rgs[state.String()] = rankSet
+	}
+
+	return nil
+}
+
+// FromMemberResults initializes groupings of ranks that had a particular result
+// from a requested action, populated from a slice of system member results.
+//
+// Supplied rowFieldsep parameter is used to separate row field elements in
+// the string that is used as the key for the rank groups.
+func (rgs RankGroups) FromMemberResults(results MemberResults, rowFieldSep string) error {
+	if rgs == nil || len(rgs) > 0 {
+		return errors.New("expecting non-nil empty rank groups")
+	}
+
+	ranksWithResult := make(map[string]*bytes.Buffer)
+	ranksSeen := make(map[ranklist.Rank]struct{})
+
+	for _, r := range results {
+		if _, exists := ranksSeen[r.Rank]; exists {
+			return errors.Wrap(&ErrMemberExists{Rank: &r.Rank},
+				"duplicate result for rank")
+		}
+		ranksSeen[r.Rank] = struct{}{}
+
+		msg := "OK"
+		if r.Errored {
+			msg = r.Msg
+		}
+		if r.Action == "" {
+			return errors.Errorf(
+				"action field empty for rank %d result", r.Rank)
+		}
+
+		resStr := fmt.Sprintf("%s%s%s", r.Action, rowFieldSep, msg)
+		if _, exists := ranksWithResult[resStr]; !exists {
+			ranksWithResult[resStr] = new(bytes.Buffer)
+		}
+		fmt.Fprintf(ranksWithResult[resStr], "%d,", r.Rank)
+	}
+
+	for strResult, ranksStrBuf := range ranksWithResult {
+		rankSet, err := ranklist.CreateRankSet(
+			strings.TrimSuffix(ranksStrBuf.String(), ","))
+		if err != nil {
+			return errors.WithMessage(err,
+				"generating groups of ranks with same result")
+		}
+		rgs[strResult] = rankSet
+	}
+
+	return nil
+}

--- a/src/control/system/rankgroups_test.go
+++ b/src/control/system/rankgroups_test.go
@@ -13,89 +13,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
-
-func TestSystem_RankSet(t *testing.T) {
-	for name, tc := range map[string]struct {
-		ranks    string
-		addRanks []Rank
-		expOut   string
-		expCount int
-		expRanks []Rank
-		expErr   error
-	}{
-		"empty start list": {
-			ranks:    "",
-			expOut:   "",
-			expCount: 0,
-			expRanks: []Rank{},
-		},
-		"invalid with hostnames": {
-			ranks:  "node2-1,node1-2.suffix1,node1-[45,47].suffix2,node3,node1-3",
-			expErr: errors.New("unexpected alphabetic character(s)"),
-		},
-		"simple ranged rank list": {
-			ranks:    "0-10",
-			expOut:   "0-10",
-			expCount: 11,
-			expRanks: []Rank{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		},
-		"deranged rank list": {
-			ranks:    "1,2,3,5,6,8,10,10,1",
-			expOut:   "1-3,5-6,8,10",
-			expCount: 7,
-			expRanks: []Rank{1, 2, 3, 5, 6, 8, 10},
-		},
-		"ranged rank list": {
-			ranks:    "2,3,10-19,0-9",
-			addRanks: []Rank{30, 32},
-			expOut:   "0-19,30,32",
-			expCount: 22,
-			expRanks: []Rank{
-				0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-				10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-				30, 32,
-			},
-		},
-		"adding to empty list": {
-			ranks:    "",
-			addRanks: []Rank{30, 32},
-			expOut:   "30,32",
-			expCount: 2,
-			expRanks: []Rank{30, 32},
-		},
-		"invalid list with spaces": {
-			ranks:  "1, 5",
-			expErr: errors.New("unexpected whitespace character(s)"),
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			rs, gotErr := CreateRankSet(tc.ranks)
-			test.CmpErr(t, tc.expErr, gotErr)
-			if tc.expErr != nil {
-				return
-			}
-			for _, r := range tc.addRanks {
-				rs.Add(r)
-			}
-
-			if diff := cmp.Diff(tc.expOut, rs.String()); diff != "" {
-				t.Fatalf("unexpected value (-want, +got):\n%s\n", diff)
-			}
-
-			gotCount := rs.Count()
-			if gotCount != tc.expCount {
-				t.Fatalf("\nexpected count to be %d; got %d", tc.expCount, gotCount)
-			}
-
-			ranks := rs.Ranks()
-			if diff := cmp.Diff(tc.expRanks, ranks); diff != "" {
-				t.Fatalf("unexpected ranks (-want, +got):\n%s\n", diff)
-			}
-
-		})
-	}
-}
 
 func TestSystem_RankGroupsFromMembers(t *testing.T) {
 	for name, tc := range map[string]struct {
@@ -110,7 +29,7 @@ func TestSystem_RankGroupsFromMembers(t *testing.T) {
 		},
 		"existing groups": {
 			rankGroups: RankGroups{
-				"foo": MustCreateRankSet("0-4"),
+				"foo": ranklist.MustCreateRankSet("0-4"),
 			},
 			expErr: errors.New("expecting non-nil empty"),
 		},
@@ -132,7 +51,7 @@ func TestSystem_RankGroupsFromMembers(t *testing.T) {
 				MockMember(t, 4, MemberStateExcluded),
 				MockMember(t, 1, MemberStateJoined),
 			},
-			expErr: &ErrMemberExists{Rank: NewRankPtr(4)},
+			expErr: &ErrMemberExists{Rank: ranklist.NewRankPtr(4)},
 		},
 		"multiple groups": {
 			rankGroups: make(RankGroups),
@@ -183,7 +102,7 @@ func TestSystem_RankGroupsFromMemberResults(t *testing.T) {
 		},
 		"existing groups": {
 			rankGroups: RankGroups{
-				"foo": MustCreateRankSet("0-4"),
+				"foo": ranklist.MustCreateRankSet("0-4"),
 			},
 			expErr: errors.New("expecting non-nil empty"),
 		},
@@ -210,7 +129,7 @@ func TestSystem_RankGroupsFromMemberResults(t *testing.T) {
 				MockMemberResult(4, "ping", nil, MemberStateExcluded),
 				MockMemberResult(4, "ping", nil, MemberStateExcluded),
 			},
-			expErr: &ErrMemberExists{Rank: NewRankPtr(4)},
+			expErr: &ErrMemberExists{Rank: ranklist.NewRankPtr(4)},
 		},
 		"successful results": {
 			rankGroups: make(RankGroups),


### PR DESCRIPTION
The system package imposes a lot of extra dependencies on
parts of the code that just want to work with ranks or
ranklists. Having ranks in the system package also makes
import cycles more likely without extra work to avoid them.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
