### PR TITLE
DAOS-11664 agent: Add config option to ignore interfaces

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -26,16 +26,17 @@ const (
 
 // Config defines the agent configuration.
 type Config struct {
-	SystemName       string                    `yaml:"name"`
-	AccessPoints     []string                  `yaml:"access_points"`
-	ControlPort      int                       `yaml:"port"`
-	RuntimeDir       string                    `yaml:"runtime_dir"`
-	LogFile          string                    `yaml:"log_file"`
-	LogLevel         common.ControlLogLevel    `yaml:"control_log_mask,omitempty"`
-	TransportConfig  *security.TransportConfig `yaml:"transport_config"`
-	DisableCache     bool                      `yaml:"disable_caching,omitempty"`
-	DisableAutoEvict bool                      `yaml:"disable_auto_evict,omitempty"`
-	FabricInterfaces []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
+	SystemName          string                    `yaml:"name"`
+	AccessPoints        []string                  `yaml:"access_points"`
+	ControlPort         int                       `yaml:"port"`
+	RuntimeDir          string                    `yaml:"runtime_dir"`
+	LogFile             string                    `yaml:"log_file"`
+	LogLevel            common.ControlLogLevel    `yaml:"control_log_mask,omitempty"`
+	TransportConfig     *security.TransportConfig `yaml:"transport_config"`
+	DisableCache        bool                      `yaml:"disable_caching,omitempty"`
+	DisableAutoEvict    bool                      `yaml:"disable_auto_evict,omitempty"`
+	ExcludeFabricIfaces []string                  `yaml:"exclude_fabric_ifaces,omitempty"`
+	FabricInterfaces    []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
 }
 
 // NUMAFabricConfig defines a list of fabric interfaces that belong to a NUMA

--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	TransportConfig     *security.TransportConfig `yaml:"transport_config"`
 	DisableCache        bool                      `yaml:"disable_caching,omitempty"`
 	DisableAutoEvict    bool                      `yaml:"disable_auto_evict,omitempty"`
-	ExcludeFabricIfaces []string                  `yaml:"exclude_fabric_ifaces,omitempty"`
+	ExcludeFabricIfaces common.StringSet          `yaml:"exclude_fabric_ifaces,omitempty"`
 	FabricInterfaces    []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
 }
 

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -133,7 +133,7 @@ transport_config:
 					AllowInsecure:     true,
 					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,
 				},
-				ExcludeFabricIfaces: []string{"ib3"},
+				ExcludeFabricIfaces: common.NewStringSet("ib3"),
 				FabricInterfaces: []*NUMAFabricConfig{
 					{
 						NUMANode: 0,

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -46,6 +46,7 @@ disable_caching: true
 disable_auto_evict: true
 transport_config:
   allow_insecure: true
+exclude_fabric_ifaces: ["ib3"]
 fabric_ifaces:
 -
   numa_node: 0
@@ -132,6 +133,7 @@ transport_config:
 					AllowInsecure:     true,
 					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,
 				},
+				ExcludeFabricIfaces: []string{"ib3"},
 				FabricInterfaces: []*NUMAFabricConfig{
 					{
 						NUMANode: 0,

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -83,7 +83,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 	procmon := NewProcMon(cmd.Logger, cmd.ctlInvoker, cmd.cfg.SystemName)
 	procmon.startMonitoring(ctx)
 
-	fabricCache := newLocalFabricCache(cmd.Logger, ficEnabled)
+	fabricCache := newLocalFabricCache(cmd.Logger, ficEnabled).WithIgnoredDevices(cmd.cfg.ExcludeFabricIfaces...)
 	if len(cmd.cfg.FabricInterfaces) > 0 {
 		// Cache is required to use user-defined fabric interfaces
 		fabricCache.enabled.SetTrue()

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -83,7 +83,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 	procmon := NewProcMon(cmd.Logger, cmd.ctlInvoker, cmd.cfg.SystemName)
 	procmon.startMonitoring(ctx)
 
-	fabricCache := newLocalFabricCache(cmd.Logger, ficEnabled).WithIgnoredDevices(cmd.cfg.ExcludeFabricIfaces...)
+	fabricCache := newLocalFabricCache(cmd.Logger, ficEnabled).WithConfig(cmd.cfg)
 	if len(cmd.cfg.FabricInterfaces) > 0 {
 		// Cache is required to use user-defined fabric interfaces
 		fabricCache.enabled.SetTrue()

--- a/src/control/common/collection_utils.go
+++ b/src/control/common/collection_utils.go
@@ -67,6 +67,22 @@ func (s StringSet) String() string {
 	return strings.Join(s.ToSlice(), ", ")
 }
 
+// UnmarshalYAML converts from the YAML string slice to a StringSet.
+func (s *StringSet) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var strSlice []string
+	if err := unmarshal(&strSlice); err != nil {
+		return err
+	}
+
+	*s = NewStringSet(strSlice...)
+	return nil
+}
+
+// MarshalYAML converts from the StringSet to a slice that can be marshaled into YAML.
+func (s StringSet) MarshalYAML() (interface{}, error) {
+	return s.ToSlice(), nil
+}
+
 // NewStringSet creates a StringSet and initializes it with zero or more strings.
 func NewStringSet(values ...string) StringSet {
 	set := make(StringSet)

--- a/src/control/common/collection_utils_test.go
+++ b/src/control/common/collection_utils_test.go
@@ -225,6 +225,66 @@ func TestCommon_StringSet_String(t *testing.T) {
 	}
 }
 
+func TestCommon_StringSet_UnmarshalYAML(t *testing.T) {
+	for name, tc := range map[string]struct {
+		yamlStrs  []string
+		yamlErr   error
+		expResult StringSet
+		expErr    error
+	}{
+		"yaml error": {
+			yamlErr: errors.New("yaml error"),
+			expErr:  errors.New("yaml error"),
+		},
+		"empty": {
+			expResult: NewStringSet(),
+		},
+		"success": {
+			yamlStrs:  []string{"one", "two"},
+			expResult: NewStringSet("one", "two"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var set StringSet
+			err := set.UnmarshalYAML(func(result interface{}) error {
+				if slice, ok := result.(*[]string); ok {
+					*slice = tc.yamlStrs
+				} else {
+					t.Fatalf("%+v wasn't a string slice", result)
+				}
+				return tc.yamlErr
+			})
+
+			CmpErr(t, tc.expErr, err)
+			AssertEqual(t, tc.expResult, set, "")
+		})
+	}
+}
+
+func TestCommon_StringSet_MarshalYAML(t *testing.T) {
+	for name, tc := range map[string]struct {
+		set       StringSet
+		expResult []string
+		expErr    error
+	}{
+		"empty": {
+			set:       NewStringSet(),
+			expResult: []string{},
+		},
+		"success": {
+			set:       NewStringSet("one", "two"),
+			expResult: []string{"one", "two"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := tc.set.MarshalYAML()
+
+			AssertEqual(t, tc.expResult, result, "")
+			CmpErr(t, tc.expErr, err)
+		})
+	}
+}
+
 func TestCommon_ParseNumberListUint32(t *testing.T) {
 	for name, tc := range map[string]struct {
 		input     string

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -74,6 +74,11 @@
 ## default: false
 #disable_caching: true
 
+## Ignore a subset of fabric interfaces when selecting an interface for client
+## applications.
+#
+#exclude_fabric_ifaces: ["lo", "eth1"]
+
 # Manually define the fabric interfaces and domains to be used by the agent,
 # organized by NUMA node.
 # If not defined, the agent will automatically detect all fabric interfaces and


### PR DESCRIPTION
In some environments clients may be connected to multiple networks that support the server's fabric provider, but some of them should not or cannot be used for DAOS. This new config option allows unwanted fabric interfaces to be excluded by name, rather than defining a full fabric_ifaces configuration. Excluded interfaces will not be suggested to clients.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>