### PR TITLE
DAOS-10138 chk: Schedule PS reconf before DONE

### DIFF
--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -1617,7 +1617,7 @@ cont:
 	if (rc != 0)
 		goto out;
 
-	ds_pool_svc_reconf(svc);
+	ds_pool_svc_schedule_reconf(svc);
 
 out:
 	chk_engine_cont_list_fini(&aggregator);

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -1614,6 +1614,10 @@ cont:
 	}
 
 	rc = chk_engine_cont_cleanup(cpr, svc, &aggregator);
+	if (rc != 0)
+		goto out;
+
+	ds_pool_svc_reconf(svc);
 
 out:
 	chk_engine_cont_list_fini(&aggregator);

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -25,7 +25,7 @@
 #include <daos_srv/policy.h>
 #include <daos_srv/rdb.h>
 
-/*, Wrap of pool service (opaque) */
+/* Pool service (opaque) */
 struct ds_pool_svc;
 
 /*
@@ -277,6 +277,7 @@ int ds_pool_target_status_check(struct ds_pool *pool, uint32_t id,
 				uint8_t matched_status, struct pool_target **p_tgt);
 int ds_pool_svc_load_map(struct ds_pool_svc *ds_svc, struct pool_map **map);
 int ds_pool_svc_flush_map(struct ds_pool_svc *ds_svc, struct pool_map *map);
+void ds_pool_svc_reconf(struct ds_pool_svc *svc);
 int ds_pool_svc_update_label(struct ds_pool_svc *ds_svc, const char *label);
 int ds_pool_svc_evict_all(struct ds_pool_svc *ds_svc);
 struct ds_pool *ds_pool_svc2pool(struct ds_pool_svc *ds_svc);

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -277,7 +277,7 @@ int ds_pool_target_status_check(struct ds_pool *pool, uint32_t id,
 				uint8_t matched_status, struct pool_target **p_tgt);
 int ds_pool_svc_load_map(struct ds_pool_svc *ds_svc, struct pool_map **map);
 int ds_pool_svc_flush_map(struct ds_pool_svc *ds_svc, struct pool_map *map);
-void ds_pool_svc_reconf(struct ds_pool_svc *svc);
+void ds_pool_svc_schedule_reconf(struct ds_pool_svc *svc);
 int ds_pool_svc_update_label(struct ds_pool_svc *ds_svc, const char *label);
 int ds_pool_svc_evict_all(struct ds_pool_svc *ds_svc);
 struct ds_pool *ds_pool_svc2pool(struct ds_pool_svc *ds_svc);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5422,7 +5422,8 @@ pool_svc_schedule_reconf(struct pool_svc *svc, bool for_chk)
 	D_DEBUG(DB_MD, DF_UUID": begin\n", DP_UUID(svc->ps_uuid));
 
 	if (!for_chk && engine_in_check()) {
-		D_DEBUG(DB_MD, DF_UUID": end: skip in check mode\n", DP_UUID(svc->ps_uuid));
+		D_DEBUG(DB_MD, DF_UUID": end: skip automatic reconf in check mode\n",
+			DP_UUID(svc->ps_uuid));
 		return;
 	}
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -116,15 +116,6 @@ reconf_end(struct pool_svc_reconf *reconf)
 }
 
 static void
-reconf_wait(struct pool_svc_reconf *reconf)
-{
-	ABT_mutex_lock(reconf->psc_mutex);
-	while (reconf->psc_in_progress)
-		ABT_cond_wait(reconf->psc_cv, reconf->psc_mutex);
-	ABT_mutex_unlock(reconf->psc_mutex);
-}
-
-static void
 reconf_cancel_and_wait(struct pool_svc_reconf *reconf)
 {
 	/*
@@ -5474,16 +5465,15 @@ pool_svc_cancel_and_wait_reconf(struct pool_svc *svc)
 }
 
 /**
- * Perform PS reconfigurations (if necessary) synchronously. This is currently
- * for the chk module only.
+ * Schedule PS reconfigurations (if necessary). This is currently for the chk
+ * module only.
  */
 void
-ds_pool_svc_reconf(struct ds_pool_svc *svc)
+ds_pool_svc_schedule_reconf(struct ds_pool_svc *svc)
 {
 	struct pool_svc *s = pool_ds2svc(svc);
 
 	pool_svc_schedule_reconf(s, true /* for_chk */);
-	reconf_wait(&s->ps_reconf);
 }
 
 static int pool_find_all_targets_by_addr(struct pool_map *map,

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1006,7 +1006,7 @@ ds_rsvc_stop(enum ds_rsvc_class_id class, d_iov_t *id, uint64_t caller_term, boo
 		if (rc != -DER_NOTREPLICA && destroy) {
 			char *path;
 
-			rc = rsvc_class(class)->sc_locate(&svc->s_id, &path);
+			rc = rsvc_class(class)->sc_locate(id, &path);
 			if (rc != 0)
 				return rc;
 			rc = remove_path(path);


### PR DESCRIPTION
Prevent automatic PS reconfigurations in the CR "check" mode, in order
to avoid racing with the chk module's actions. Schedule PS
reconfigurations when the chk module is ready before moving a pool to
the DONE phase.

Fix a segfault due to the use of an invalid svc variable when destroying
a stopped rsvc replica:

    pool_svc_locate_cb (id=0x18, path=0x7fa947c6d2e0) at
      src/pool/srv_pool.c:953
    ds_rsvc_stop (class=DS_RSVC_CLASS_POOL, id=0x7fa96c5f0860,
      caller_term=18446744073709551615, destroy=<optimized out>) at
      src/rsvc/srv.c:1009
    ds_rsvc_stop_handler (rpc=0x7fa96c5f0660) at src/rsvc/srv.c:1437
    crt_handle_rpc (arg=0x7fa96c5f0660) at src/cart/crt_rpc.c:1654

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true