### PR TITLE
DAOS-623 ci: Remove the releasever removal (#10413)

### DIFF
--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -98,11 +98,6 @@ chmod 600 "${jenkins_ssh}"/{authorized_keys,id_rsa*,config}
 chown -R jenkins.jenkins /localhome/jenkins/
 echo "jenkins ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/jenkins
 
-# remove any defined releasever
-# any deviation from the default releasever for a distro should be
-# handled on a per-test-run, or even per-dnf command basis
-rm -f  /etc/yum/vars/releasever
-
 # defined in ci/functional/post_provision_config_nodes_<distro>.sh
 # and catted to the remote node along with this script
 if ! post_provision_config_nodes; then


### PR DESCRIPTION
Test images are provisioned based on the desired version of O/S for the stage.  /etc/yum/vars/releasever is what keeps an O/S at the version requested by the stage and prevents it from being upgraded beyond the requested version.  So don't remove that file.