### PR TITLE
DAOS-10616 ddb: Add device info to SMD Sync

### DIFF
--- a/src/ddb/ddb_cmd_options.h
+++ b/src/ddb/ddb_cmd_options.h
@@ -77,6 +77,11 @@ struct clear_cmt_dtx_options {
 	char *path;
 };
 
+struct smd_sync_options {
+	char *nvme_conf;
+	char *db_path;
+};
+
 struct update_vea_options {
 	char *offset;
 	char *blk_cnt;
@@ -105,6 +110,7 @@ struct ddb_cmd_info {
 		struct rm_ilog_options dci_rm_ilog;
 		struct dump_dtx_options dci_dump_dtx;
 		struct clear_cmt_dtx_options dci_clear_cmt_dtx;
+		struct smd_sync_options dci_smd_sync;
 		struct update_vea_options dci_update_vea;
 		struct dtx_commit_options dci_dtx_commit;
 		struct dtx_abort_options dci_dtx_abort;
@@ -128,7 +134,7 @@ int ddb_run_commit_ilog(struct ddb_ctx *ctx, struct commit_ilog_options *opt);
 int ddb_run_rm_ilog(struct ddb_ctx *ctx, struct rm_ilog_options *opt);
 int ddb_run_dump_dtx(struct ddb_ctx *ctx, struct dump_dtx_options *opt);
 int ddb_run_clear_cmt_dtx(struct ddb_ctx *ctx, struct clear_cmt_dtx_options *opt);
-int ddb_run_smd_sync(struct ddb_ctx *ctx);
+int ddb_run_smd_sync(struct ddb_ctx *ctx, struct smd_sync_options *opt);
 int ddb_run_dump_vea(struct ddb_ctx *ctx);
 int ddb_run_update_vea(struct ddb_ctx *ctx, struct update_vea_options *opt);
 int ddb_run_dtx_commit(struct ddb_ctx *ctx, struct dtx_commit_options *opt);

--- a/src/ddb/ddb_main.c
+++ b/src/ddb/ddb_main.c
@@ -124,7 +124,7 @@ run_cmd(struct ddb_ctx *ctx, const char *cmd_str, bool write_mode)
 		rc = ddb_run_clear_cmt_dtx(ctx, &info.dci_cmd_option.dci_clear_cmt_dtx);
 		break;
 	case DDB_CMD_SMD_SYNC:
-		rc = ddb_run_smd_sync(ctx);
+		rc = ddb_run_smd_sync(ctx, &info.dci_cmd_option.dci_smd_sync);
 		break;
 	case DDB_CMD_DUMP_VEA:
 		rc = ddb_run_dump_vea(ctx);

--- a/src/ddb/ddb_spdk.c
+++ b/src/ddb/ddb_spdk.c
@@ -11,28 +11,88 @@
 #include <spdk/event.h>
 #include <spdk/blob_bdev.h>
 #include <spdk/blob.h>
-#include <spdk/log.h>
 #include <spdk/string.h>
 #include <uuid/uuid.h>
 
 #include "ddb_common.h"
 #include "ddb_spdk.h"
 
+#define TRACE(...) D_DEBUG(DB_TRACE, __VA_ARGS__)
+
+/*
+ * According to https://spdk.io/doc/concurrency.html, the best way to manage concurrency is to
+ * use a state machine.
+ */
+
+/* States of the machine */
+enum DDB_SPDK_ST {
+	DDB_SPDK_ST_BDEV,
+	DDB_SPDK_ST_BS_OPEN_ASYNC,
+	DDB_SPDK_ST_BLOB_ITER_ASYNC,
+	DDB_SPDK_ST_BLOB_READ_ASYNC,
+	DDB_SPDK_ST_BLOB_CLOSE_ASYNC,
+	DDB_SPDK_ST_SEND_INFO,
+	DDB_SPDK_ST_BS_CLOSE_ASYNC,
+	DDB_SPDK_ST_DONE,
+};
+
+/* Just for debugging purposes */
+static const char *
+state_str(enum DDB_SPDK_ST s)
+{
+	switch (s) {
+	case DDB_SPDK_ST_BDEV:
+		return "DDB_SPDK_ST_BDEV";
+	case DDB_SPDK_ST_BS_OPEN_ASYNC:
+		return "DDB_SPDK_ST_BS_OPEN_ASYNC";
+	case DDB_SPDK_ST_BLOB_ITER_ASYNC:
+		return "DDB_SPDK_ST_BLOB_ITER_ASYNC";
+	case DDB_SPDK_ST_BLOB_READ_ASYNC:
+		return "DDB_SPDK_ST_BLOB_READ_ASYNC";
+	case DDB_SPDK_ST_SEND_INFO:
+		return "DDB_SPDK_ST_SEND_INFO";
+	case DDB_SPDK_ST_BLOB_CLOSE_ASYNC:
+		return "DDB_SPDK_ST_BLOB_CLOSE_ASYNC";
+	case DDB_SPDK_ST_BS_CLOSE_ASYNC:
+		return "DDB_SPDK_ST_BS_CLOSE_ASYNC";
+	case DDB_SPDK_ST_DONE:
+		return "DDB_SPDK_ST_DONE";
+	default:
+		return "UNKNOWN";
+	}
+}
+
+static void
+print_transition(enum DDB_SPDK_ST a, enum DDB_SPDK_ST b, int rc)
+{
+	if (a != b)
+		TRACE("%s -> %s, rc: "DF_RC"\n", state_str(a), state_str(b), DP_RC(rc));
+}
+
 #define BDEV_NAME_MAX 128
 struct ddb_spdk_context {
-	char			 bdev_name[BDEV_NAME_MAX];
+	/* Used for passing info back to the caller */
+	struct ddbs_sync_info	 dsc_dsi;
+	ddbs_sync_cb		 dsc_cb_func;
+	void			*dsc_cb_arg;
+
+	/* For managing the interaction with spdk */
+	struct spdk_bdev	*dsc_bdev;
+	struct spdk_bs_dev	*dsc_bs_dev;
 	struct spdk_blob_store	*dsc_bs;
 	struct spdk_blob	*dsc_blob;
-	spdk_blob_id		 dsc_blobid;
 	struct spdk_io_channel	*dsc_channel;
 	uint8_t			*dsc_read_buf;
 	uint64_t		 dsc_io_unit_size;
-	ddbs_sync_cb		 dsc_cb_func;
-	void			*dsc_cb_arg;
+
+	/* For managing the state machine */
+	enum DDB_SPDK_ST	 dsc_state;
+	bool			 dsc_async_state_done;
+	bool			 dsc_running;
+
+	/* Capture any error along the way */
 	int			 dsc_rc;
 };
-
-static void iter_cb(void *cb_arg, struct spdk_blob *blb, int bs_errno);
 
 static int
 dsc_init(struct ddb_spdk_context **ctx)
@@ -50,147 +110,210 @@ dsc_init(struct ddb_spdk_context **ctx)
 static void
 dsc_fini(struct ddb_spdk_context *ctx)
 {
-	spdk_free(ctx->dsc_read_buf);
 	free(ctx);
 }
 
-static void
-unload_complete(void *cb_arg, int bs_errno)
-{
-	struct ddb_spdk_context *ctx = cb_arg;
+/* Setup what's needed to do a blob read */
+static int
+dsc_read_setup(struct ddb_spdk_context *ctx) {
+	D_ASSERT(ctx->dsc_bs != NULL);
+	ctx->dsc_channel = spdk_bs_alloc_io_channel(ctx->dsc_bs);
+	if (ctx->dsc_channel == NULL)
+		return -DER_NOMEM;
 
-	if (!SUCCESS(bs_errno)) {
-		ctx->dsc_rc = daos_errno2der(-bs_errno);
-		D_ERROR("Error: "DF_RC"\n", DP_RC(ctx->dsc_rc));
-	}
-
-	spdk_app_stop(ctx->dsc_rc);
-}
-
-static void
-bs_unload(struct ddb_spdk_context *ctx, char *msg, int rc)
-{
-	if (!SUCCESS(rc)) {
-		D_ERROR("%s: "DF_RC"\n", msg, DP_RC(rc));
-		ctx->dsc_rc = rc;
-	}
-	if (ctx->dsc_bs) {
-		if (ctx->dsc_channel)
-			spdk_bs_free_io_channel(ctx->dsc_channel);
-		spdk_bs_unload(ctx->dsc_bs, unload_complete, ctx);
-	} else {
-		spdk_app_stop(rc);
-	}
-}
-
-static void
-bs_unload_spdk_error(struct ddb_spdk_context *ctx, char *msg, int bs_errno)
-{
-	bs_unload(ctx, msg, daos_errno2der(-bs_errno));
-}
-
-static void
-close_blob_cb(void *cb_arg, int bs_errno)
-{
-	struct ddb_spdk_context *ctx = cb_arg;
-
-	if (bs_errno) {
-		bs_unload_spdk_error(ctx, "Error in close completion", bs_errno);
-		return;
-	}
-
-	/* blob closed so move on to the next */
-	spdk_bs_iter_next(ctx->dsc_bs, ctx->dsc_blob, iter_cb, ctx);
-}
-
-static void
-read_complete_cb(void *cb_arg, int bs_errno)
-{
-	struct ddb_spdk_context	*ctx = cb_arg;
-	struct bio_blob_hdr	*hdr;
-	int			 rc;
-
-	if (bs_errno) {
-		spdk_blob_close(ctx->dsc_blob, close_blob_cb, ctx);
-		bs_unload_spdk_error(ctx, "Error in read completion", bs_errno);
-		return;
-	}
-
-	hdr = (struct bio_blob_hdr *)ctx->dsc_read_buf;
-
-	if (hdr->bbh_magic == BIO_BLOB_HDR_MAGIC) {
-		rc = ctx->dsc_cb_func(hdr, ctx->dsc_cb_arg);
-		if (!SUCCESS(rc))
-			ctx->dsc_rc = rc; /* Record the error, but don't fail */
-	} else {
-		D_ERROR("BIO Header for blob ID %lu is invalid. Not using to sync.\n",
-			ctx->dsc_blobid);
-		ctx->dsc_rc = -DER_INVAL;
-	}
-
-	spdk_blob_close(ctx->dsc_blob, close_blob_cb, ctx);
-}
-
-static void
-blob_open_complete_cb(void *cb_arg, struct spdk_blob *blob, int bs_errno)
-{
-	struct ddb_spdk_context *ctx = cb_arg;
-
-	if (bs_errno) {
-		bs_unload_spdk_error(ctx, "Error in open completion", bs_errno);
-		return;
-	}
-
-	ctx->dsc_blob = blob;
-
-	/* Read the first block ... that's where the bio header is */
-	spdk_blob_io_read(ctx->dsc_blob, ctx->dsc_channel, ctx->dsc_read_buf, 0, 1,
-			  read_complete_cb, ctx);
-}
-
-static void
-iter_cb(void *cb_arg, struct spdk_blob *blb, int bs_errno)
-{
-	struct ddb_spdk_context *ctx = cb_arg;
-
-	if (!SUCCESS(bs_errno)) {
-		if (bs_errno == -ENOENT)
-			/* No more ... so unload */
-			bs_unload(ctx, "", 0);
-		else
-			bs_unload_spdk_error(ctx, "Error in blob iter callback", bs_errno);
-		return;
-	}
-
-	ctx->dsc_blobid = spdk_blob_get_id(blb);
-	spdk_bs_open_blob(ctx->dsc_bs, ctx->dsc_blobid, blob_open_complete_cb, ctx);
-}
-
-static void
-bs_init_complete_cb(void *cb_arg, struct spdk_blob_store *bs, int bs_errno)
-{
-	struct ddb_spdk_context *ctx = cb_arg;
-
-	if (!SUCCESS(bs_errno)) {
-		bs_unload_spdk_error(ctx, "Error initializing the blobstore", bs_errno);
-		return;
-	}
-
-	ctx->dsc_bs = bs;
 	ctx->dsc_io_unit_size = spdk_bs_get_io_unit_size(ctx->dsc_bs);
 	ctx->dsc_read_buf = spdk_malloc(ctx->dsc_io_unit_size, 0x1000, NULL,
 					SPDK_ENV_LCORE_ID_ANY, SPDK_MALLOC_DMA);
-	if (ctx->dsc_read_buf == NULL) {
-		bs_unload(ctx, "Error in memory allocation", -DER_NOMEM);
+	if (ctx->dsc_read_buf == NULL)
+		return -DER_NOMEM;
+
+	return 0;
+}
+
+static void
+dsc_read_teardown(struct ddb_spdk_context *ctx)
+{
+	if (ctx->dsc_channel) {
+		spdk_bs_free_io_channel(ctx->dsc_channel);
+		ctx->dsc_channel = NULL;
+	}
+	if (ctx->dsc_read_buf) {
+		spdk_free(ctx->dsc_read_buf);
+		ctx->dsc_read_buf = NULL;
+	}
+	ctx->dsc_io_unit_size = 0;
+}
+
+static void
+dsc_record_error(struct ddb_spdk_context *ctx, int bs_errno)
+{
+	/* only keep error if there is one and rc isn't already an error code */
+	if (bs_errno != 0 && ctx->dsc_rc == 0) {
+		ctx->dsc_rc = daos_errno2der(-bs_errno);
+		TRACE("Recording error: "DF_RC"\n", DP_RC(ctx->dsc_rc));
+	}
+}
+
+/*
+ * The next section of functions are callback/async pairs. SPDK relies heavily on callback
+ * functions. The "async" function executes an SPDK function which takes a callback. In general,
+ * the callback function should come right before the function that executes the SPDK function. The
+ * callback function will record any error. Due to the async nature, the state machine might exit
+ * before the callbacks are executed by SPDK, therefore the callbacks may restart the state
+ * machine at the appropriate state if needed. The 'before'/'after' tracing in the async methods
+ * with the 'callback' trace is helpful in seeing how the async works which was critical in
+ * developing and debugging the state machine as well as viewing the behavior of SPDK.
+ */
+
+/* Allow the callback functions to restart the state machine */
+static void dsc_continue_state_machine_after_async(struct ddb_spdk_context *ctx);
+
+static void
+blob_close_cb(void *cb_arg, int bs_errno)
+{
+	struct ddb_spdk_context *ctx = cb_arg;
+
+	TRACE("blob close callback\n");
+
+	dsc_record_error(ctx, bs_errno);
+	dsc_continue_state_machine_after_async(ctx);
+}
+
+static void
+dsc_blob_close_async(struct ddb_spdk_context *ctx)
+{
+	TRACE("blob close (before)\n");
+	spdk_blob_close(ctx->dsc_blob, blob_close_cb, ctx);
+	TRACE("blob close (after)\n");
+}
+
+static void
+bs_open_complete_cb(void *cb_arg, struct spdk_blob_store *bs, int bs_errno)
+{
+	struct ddb_spdk_context *ctx = cb_arg;
+
+	TRACE("bs open callback\n");
+	if (!SUCCESS(bs_errno)) {
+		dsc_record_error(ctx, bs_errno);
 		return;
+	}
+	ctx->dsc_bs = bs;
+
+	/* now setup for reading */
+	ctx->dsc_rc = dsc_read_setup(ctx);
+	dsc_continue_state_machine_after_async(ctx);
+}
+
+static void
+dsc_bs_open_async(struct ddb_spdk_context *ctx)
+{
+	TRACE("bs open (before)\n");
+	spdk_bs_load(ctx->dsc_bs_dev, NULL, bs_open_complete_cb, ctx);
+	TRACE("bs open (close)\n");
+}
+
+static void
+bs_close_cb(void *cb_arg, int bs_errno)
+{
+	struct ddb_spdk_context *ctx = cb_arg;
+
+	TRACE("bs close callback\n");
+	dsc_record_error(ctx, bs_errno);
+	ctx->dsc_bs = NULL;
+
+	dsc_continue_state_machine_after_async(ctx);
+}
+
+static void
+dsc_bs_close_async(struct ddb_spdk_context *ctx) {
+	dsc_read_teardown(ctx);
+
+	if (ctx->dsc_bs) {
+		TRACE("close bs (before)\n");
+		spdk_bs_unload(ctx->dsc_bs, bs_close_cb, ctx);
+		TRACE("close bs (after)\n");
+	} else {
+		TRACE("bs already closed??\n");
+	}
+}
+
+static void
+dsc_blob_iter_cb(void *cb_arg, struct spdk_blob *blb, int bs_errno)
+{
+	struct ddb_spdk_context *ctx = cb_arg;
+
+	TRACE("blob iter callback\n");
+
+	if (bs_errno != 0) {
+		/*
+		 * No more blobs to process. This will indicate to
+		 * the state machine to close the blobstore.
+		 */
+		ctx->dsc_blob = NULL;
+		if (bs_errno != -ENOENT) {
+			dsc_record_error(ctx, bs_errno);
+			TRACE("error\n");
+		} else {
+			TRACE("No more blobs\n");
+		}
+	} else {
+		TRACE("setting blob\n");
+		ctx->dsc_blob = blb;
+	}
+	dsc_continue_state_machine_after_async(ctx);
+}
+
+static void
+dsc_blob_iter_async(struct ddb_spdk_context *ctx)
+{
+	D_ASSERT(ctx->dsc_bs != NULL);
+
+	if (ctx->dsc_blob == NULL) {
+		TRACE("first blob (before)\n");
+		spdk_bs_iter_first(ctx->dsc_bs, dsc_blob_iter_cb, ctx);
+		TRACE("first blob (after)\n");
+	} else {
+		TRACE("next blob (before)\n");
+		spdk_bs_iter_next(ctx->dsc_bs, ctx->dsc_blob, dsc_blob_iter_cb, ctx);
+		TRACE("next blob (after)\n");
+	}
+}
+
+static void
+blob_read_hdr_cb(void *cb_arg, int bs_errno)
+{
+	struct ddb_spdk_context *ctx = cb_arg;
+
+	TRACE("read blob callback\n");
+
+	dsc_record_error(ctx, bs_errno);
+	if (bs_errno == 0) {
+		struct bio_blob_hdr *hdr;
+
+		D_ASSERT(ctx->dsc_read_buf != NULL);
+		hdr = (struct bio_blob_hdr *) ctx->dsc_read_buf;
+		/* verify the header */
+		if (hdr->bbh_magic == BIO_BLOB_HDR_MAGIC) {
+			ctx->dsc_dsi.dsi_hdr = hdr;
+		} else {
+			D_PRINT("BIO_BLOB_HDR_MAGIC is not correct for blob id '%lu'. "
+				"Got '%x' but expected '%x'\n",
+				spdk_blob_get_id(ctx->dsc_blob), hdr->bbh_magic,
+				BIO_BLOB_HDR_MAGIC);
+			ctx->dsc_rc = -DER_UNKNOWN;
+		}
 	}
 
-	ctx->dsc_channel = spdk_bs_alloc_io_channel(ctx->dsc_bs);
-	if (ctx->dsc_channel == NULL) {
-		bs_unload(ctx, "Error in allocating channel", -DER_NOMEM);
-		return;
-	}
-	spdk_bs_iter_first(bs, iter_cb, ctx);
+	dsc_continue_state_machine_after_async(ctx);
+}
+
+static void
+dsc_blob_read_hdr_async(struct ddb_spdk_context *ctx)
+{
+	TRACE("reading blob (before)\n");
+	spdk_blob_io_read(ctx->dsc_blob, ctx->dsc_channel, ctx->dsc_read_buf, 0, 1,
+			  blob_read_hdr_cb, ctx);
+	TRACE("reading blob (after)\n");
 }
 
 static void
@@ -200,29 +323,214 @@ base_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev, void 
 }
 
 static void
-dsc_start_cb(void *arg)
+dsc_bdev(struct ddb_spdk_context *ctx)
 {
-	struct ddb_spdk_context *ctx = arg;
-	struct spdk_bs_dev	*bs_dev = NULL;
-	struct spdk_bdev	*bdev;
-	int			 rc;
+	char	bdev_name[BDEV_NAME_MAX];
+	int	err;
+	int	rc = 0;
 
-	for (bdev = spdk_bdev_first(); bdev != NULL; bdev = spdk_bdev_next(bdev)) {
-		strncpy(ctx->bdev_name, spdk_bdev_get_name(bdev), sizeof(ctx->bdev_name) - 1);
-		ctx->bdev_name[sizeof(ctx->bdev_name) - 1] = '\0';
-		rc = spdk_bdev_create_bs_dev_ext(ctx->bdev_name, base_bdev_event_cb, NULL, &bs_dev);
-		if (rc != 0) {
-			D_ERROR("Could not create blob bdev: %s\n", spdk_strerror(-rc));
-			spdk_app_stop(daos_errno2der(-rc));
-			return;
-		}
+	if (ctx->dsc_bdev == NULL)
+		ctx->dsc_bdev = spdk_bdev_first();
+	else
+		ctx->dsc_bdev = spdk_bdev_next(ctx->dsc_bdev);
+
+	if (ctx->dsc_bdev == NULL)
+		return;
+
+	strncpy(bdev_name, spdk_bdev_get_name(ctx->dsc_bdev), sizeof(bdev_name) - 1);
+	bdev_name[sizeof(bdev_name) - 1] = '\0';
+
+	TRACE("Creating bs dev for device name: %s\n", bdev_name);
+	err = spdk_bdev_create_bs_dev_ext(bdev_name, base_bdev_event_cb, NULL, &ctx->dsc_bs_dev);
+	if (err != 0) {
+		rc = daos_errno2der(-err);
+		D_ERROR("Could not create blob bdev: %s\n", spdk_strerror(-err));
 	}
-
-	spdk_bs_load(bs_dev, NULL, bs_init_complete_cb, ctx);
+	ctx->dsc_rc = rc;
 }
 
+static void
+dsc_get_dev_id(struct ddb_spdk_context *ctx)
+{
+	struct spdk_bs_type bstype = spdk_bs_get_bstype(ctx->dsc_bs);
+
+	memcpy(ctx->dsc_dsi.dsi_dev_id, bstype.bstype, sizeof(ctx->dsc_dsi.dsi_dev_id));
+	TRACE("Got device id: "DF_UUID"\n", DP_UUID(ctx->dsc_dsi.dsi_dev_id));
+}
+
+static void
+dsc_send_info(struct ddb_spdk_context *ctx)
+{
+	dsc_get_dev_id(ctx);
+
+	TRACE("sending info to callback\n");
+	ctx->dsc_cb_func(&ctx->dsc_dsi, ctx->dsc_cb_arg);
+}
+
+static void
+dsc_if_error_handle_state_change(struct ddb_spdk_context *ctx)
+{
+	enum DDB_SPDK_ST prev_state = ctx->dsc_state;
+
+	if (ctx->dsc_rc == 0)
+		return;
+	switch (ctx->dsc_state) {
+	case DDB_SPDK_ST_BDEV:
+		ctx->dsc_state = DDB_SPDK_ST_DONE;
+		break;
+	case DDB_SPDK_ST_BS_OPEN_ASYNC:
+	case DDB_SPDK_ST_BLOB_ITER_ASYNC:
+		ctx->dsc_state = DDB_SPDK_ST_BS_CLOSE_ASYNC;
+		break;
+	case DDB_SPDK_ST_BLOB_READ_ASYNC:
+		ctx->dsc_state = DDB_SPDK_ST_BLOB_CLOSE_ASYNC;
+		break;
+	case DDB_SPDK_ST_SEND_INFO:
+	case DDB_SPDK_ST_BLOB_CLOSE_ASYNC:
+	case DDB_SPDK_ST_BS_CLOSE_ASYNC:
+	case DDB_SPDK_ST_DONE:
+		break;
+	}
+	if (prev_state != ctx->dsc_state)
+		/* Forced a transition so reset async state */
+		ctx->dsc_async_state_done = false;
+
+	TRACE("Error State ("DF_RC"): Transitioning from %s --> %s\n",
+	      DP_RC(ctx->dsc_rc), state_str(prev_state), state_str(ctx->dsc_state));
+}
+
+/* Macros to help define the function for each state and what the next state should be */
+#define ST_TSN(ctx, fn, next_state) \
+	do { \
+		fn; \
+		ctx->dsc_state = next_state; \
+	} while (0)
+#define ST_TSN_COND(ctx, fn, cond, true_state, false_state) \
+	do { \
+		fn; \
+		if ((cond)) \
+			ctx->dsc_state = true_state; \
+		else \
+			ctx->dsc_state = false_state; \
+	} while (0)
+#define ST_TSN_ASYNC(ctx, fn, next_state) \
+	do { \
+		if (ctx->dsc_async_state_done) { \
+			ctx->dsc_async_state_done = false; \
+			ctx->dsc_state = next_state; \
+		} else { \
+		fn; \
+		} \
+	} while (0)
+#define ST_TSN_COND_ASYNC(ctx, fn, cond, true_state, false_state) \
+	do { \
+		if (ctx->dsc_async_state_done) { \
+			ctx->dsc_async_state_done = false; \
+			if ((cond)) \
+				ctx->dsc_state = true_state; \
+			else \
+				ctx->dsc_state = false_state; \
+		} else { \
+			fn; \
+		} \
+	} while (0)
+
+static void
+dsc_run_state_machine(struct ddb_spdk_context *ctx)
+{
+	enum DDB_SPDK_ST prev_state;
+
+	ctx->dsc_running = true;
+
+	TRACE("\nState Machine starting with state: %s\n", state_str(ctx->dsc_state));
+
+	do {
+		dsc_if_error_handle_state_change(ctx);
+		prev_state = ctx->dsc_state;
+		switch (ctx->dsc_state) {
+		case DDB_SPDK_ST_BDEV:
+			ST_TSN_COND(ctx, dsc_bdev(ctx),
+				    /*
+				     * if bdev == NULL then no more devices, everything should
+				     * already be closed so just finish
+				     */
+				    ctx->dsc_bdev != NULL, DDB_SPDK_ST_BS_OPEN_ASYNC,
+				    DDB_SPDK_ST_DONE);
+			break;
+		case DDB_SPDK_ST_BS_OPEN_ASYNC:
+			ST_TSN_ASYNC(ctx, dsc_bs_open_async(ctx), DDB_SPDK_ST_BLOB_ITER_ASYNC);
+			break;
+		case DDB_SPDK_ST_BLOB_ITER_ASYNC:
+			ST_TSN_COND_ASYNC(ctx, dsc_blob_iter_async(ctx),
+					  /* if blob == NULL then there are no more blobs */
+					  ctx->dsc_blob == NULL, DDB_SPDK_ST_BS_CLOSE_ASYNC,
+					  DDB_SPDK_ST_BLOB_READ_ASYNC);
+			break;
+		case DDB_SPDK_ST_BLOB_READ_ASYNC:
+			ST_TSN_ASYNC(ctx, dsc_blob_read_hdr_async(ctx), DDB_SPDK_ST_SEND_INFO);
+			break;
+		case DDB_SPDK_ST_SEND_INFO:
+			ST_TSN(ctx, dsc_send_info(ctx), DDB_SPDK_ST_BLOB_CLOSE_ASYNC);
+			break;
+		case DDB_SPDK_ST_BLOB_CLOSE_ASYNC:
+			/* After closing, start the iteration loop over */
+			ST_TSN_ASYNC(ctx, dsc_blob_close_async(ctx), DDB_SPDK_ST_BLOB_ITER_ASYNC);
+			break;
+		case DDB_SPDK_ST_BS_CLOSE_ASYNC:
+			ST_TSN_ASYNC(ctx, dsc_bs_close_async(ctx), DDB_SPDK_ST_BDEV);
+			break;
+		case DDB_SPDK_ST_DONE:
+			spdk_app_stop(ctx->dsc_rc);
+			break;
+		}
+		print_transition(prev_state, ctx->dsc_state, ctx->dsc_rc);
+	/*
+	 * If the state hasn't changed then leave the state machine. Should
+	 * get called again by a asynchronous callback if not done. Note: if dsc_async_state_done is
+	 * true then the state changed by a callback because the machine always leaves
+	 * dsc_async_state_done to false.
+	 */
+	} while ((prev_state != ctx->dsc_state) || ctx->dsc_async_state_done);
+	TRACE("Leaving state machine on state: %s\n\n", state_str(ctx->dsc_state));
+	ctx->dsc_running = false;
+}
+
+static void
+dsc_continue_state_machine_after_async(struct ddb_spdk_context *ctx)
+{
+	/*
+	 * Sometimes the callbacks are run after the state machine leaves and sometimes right after
+	 * the "parent" function is called. Callbacks should re-enter the state machine if it's
+	 * not already running. Set a callback done flag so the machine knows  if it was already
+	 * called.
+	 */
+	ctx->dsc_async_state_done = true;
+	if (!ctx->dsc_running) {
+		TRACE("Restarting state machine at state: %s\n", state_str(ctx->dsc_state));
+		dsc_run_state_machine(ctx);
+	}
+}
+
+static void
+app_start_cb(void *arg)
+{
+	struct ddb_spdk_context *ctx = arg;
+
+	/* start by getting the first bdev */
+	ctx->dsc_state = DDB_SPDK_ST_BDEV;
+	dsc_run_state_machine(ctx);
+}
+
+/*
+ * This is used by the smd sync command for ddb. Most of the SMD table info can be rebuilt by using
+ * information saved in the SPDK blobs used for each target.
+ *
+ * Using the state machine above, will start an spdk_app that will iterate over the blobs, read
+ * the blob header (a daos construct, see struct bio_blob_hdr), gather other information needed
+ * from the blob or blobstore and pass to the callback function provided
+ */
 int
-ddbs_for_each_bio_blob_hdr(char *nvme_json, ddbs_sync_cb cb, void *cb_arg)
+ddbs_for_each_bio_blob_hdr(const char *nvme_json, ddbs_sync_cb cb, void *cb_arg)
 {
 	struct spdk_app_opts	opts = {0};
 	struct ddb_spdk_context *ctx = NULL;
@@ -237,12 +545,10 @@ ddbs_for_each_bio_blob_hdr(char *nvme_json, ddbs_sync_cb cb, void *cb_arg)
 	ctx->dsc_cb_arg = cb_arg;
 
 	spdk_app_opts_init(&opts, sizeof(opts));
-
-	opts.print_level = SPDK_LOG_ERROR;
+	opts.print_level = SPDK_LOG_DISABLED;
 	opts.name = "ddb_spdk";
 	opts.json_config_file = nvme_json;
-
-	rc = spdk_app_start(&opts, dsc_start_cb, ctx);
+	rc = spdk_app_start(&opts, app_start_cb, ctx);
 	if (!SUCCESS(rc))
 		D_ERROR("Failed: "DF_RC"\n", DP_RC(rc));
 

--- a/src/ddb/ddb_spdk.c
+++ b/src/ddb/ddb_spdk.c
@@ -355,6 +355,8 @@ dsc_get_dev_id(struct ddb_spdk_context *ctx)
 	struct spdk_bs_type bstype = spdk_bs_get_bstype(ctx->dsc_bs);
 
 	memcpy(ctx->dsc_dsi.dsi_dev_id, bstype.bstype, sizeof(ctx->dsc_dsi.dsi_dev_id));
+	ctx->dsc_dsi.dsi_cluster_size = spdk_bs_get_cluster_size(ctx->dsc_bs);
+	ctx->dsc_dsi.dsi_cluster_nr = spdk_blob_get_num_clusters(ctx->dsc_blob);
 	TRACE("Got device id: "DF_UUID"\n", DP_UUID(ctx->dsc_dsi.dsi_dev_id));
 }
 
@@ -470,7 +472,7 @@ dsc_run_state_machine(struct ddb_spdk_context *ctx)
 			ST_TSN_ASYNC(ctx, dsc_blob_read_hdr_async(ctx), DDB_SPDK_ST_SEND_INFO);
 			break;
 		case DDB_SPDK_ST_SEND_INFO:
-			ST_TSN(ctx, dsc_send_info(ctx), DDB_SPDK_ST_BLOB_CLOSE_ASYNC);
+			ST_TSN(ctx, dsc_send_info(ctx), DDB_SPDK_ST_BLOB_ITER_ASYNC);
 			break;
 		case DDB_SPDK_ST_BLOB_CLOSE_ASYNC:
 			/* After closing, start the iteration loop over */

--- a/src/ddb/ddb_spdk.h
+++ b/src/ddb/ddb_spdk.h
@@ -9,8 +9,13 @@
 
 #include <daos_srv/bio.h>
 
-typedef int (*ddbs_sync_cb)(struct bio_blob_hdr *hdr, void *cb_arg);
+struct ddbs_sync_info {
+	struct bio_blob_hdr	*dsi_hdr;
+	uuid_t			 dsi_dev_id;
+};
 
-int ddbs_for_each_bio_blob_hdr(char *nvme_json, ddbs_sync_cb cb, void *cb_arg);
+typedef void (*ddbs_sync_cb)(struct ddbs_sync_info *dsi, void *cb_arg);
+
+int ddbs_for_each_bio_blob_hdr(const char *nvme_json, ddbs_sync_cb cb, void *cb_arg);
 
 #endif /* DAOS_DDB_SPDK_H */

--- a/src/ddb/ddb_spdk.h
+++ b/src/ddb/ddb_spdk.h
@@ -12,6 +12,8 @@
 struct ddbs_sync_info {
 	struct bio_blob_hdr	*dsi_hdr;
 	uuid_t			 dsi_dev_id;
+	uint64_t		 dsi_cluster_size;
+	uint64_t		 dsi_cluster_nr;
 };
 
 typedef void (*ddbs_sync_cb)(struct ddbs_sync_info *dsi, void *cb_arg);

--- a/src/ddb/ddb_vos.h
+++ b/src/ddb/ddb_vos.h
@@ -171,8 +171,9 @@ int dv_dtx_abort_active_entry(daos_handle_t coh, struct dtx_id *dti);
 
 /* Sync the smd table with information saved in blobs */
 typedef int (*dv_smd_sync_complete)(void *cb_args, uuid_t pool_id, uint32_t vos_id,
-				    uint64_t blob_id, daos_size_t blob_size);
-int dv_sync_smd(dv_smd_sync_complete complete_cb, void *cb_args);
+				    uint64_t blob_id, daos_size_t blob_size, uuid_t dev_id);
+int dv_sync_smd(const char *nvme_conf, const char *db_path, dv_smd_sync_complete complete_cb,
+		void *cb_args);
 
 typedef int (*dv_vea_extent_handler)(void *cb_arg, struct vea_free_extent *free_extent);
 int dv_enumerate_vea(daos_handle_t poh, dv_vea_extent_handler cb, void *cb_arg);

--- a/src/ddb/tests/ddb_cmd_options_tests.c
+++ b/src/ddb/tests/ddb_cmd_options_tests.c
@@ -231,6 +231,22 @@ clear_cmt_dtx_options_parsing(void **state)
 }
 
 static void
+smd_sync_options_parsing(void **state)
+{
+	struct ddb_cmd_info	 info = {0};
+	struct smd_sync_options	*options = &info.dci_cmd_option.dci_smd_sync;
+
+	/* test invalid arguments and options */
+	test_run_inval_cmd("smd_sync", "nvme_conf", "db_path", "extra"); /* too many argument */
+	test_run_inval_cmd("smd_sync", "-z"); /* invalid option */
+
+	/* test all arguments */
+	test_run_cmd(&info, "smd_sync", "nvme_conf", "db_path");
+	assert_non_null(options->nvme_conf);
+	assert_non_null(options->db_path);
+}
+
+static void
 update_vea_options_parsing(void **state)
 {
 	struct ddb_cmd_info	 info = {0};
@@ -298,6 +314,7 @@ ddb_cmd_options_tests_run()
 		TEST(rm_ilog_options_parsing),
 		TEST(dump_dtx_options_parsing),
 		TEST(clear_cmt_dtx_options_parsing),
+		TEST(smd_sync_options_parsing),
 		TEST(update_vea_options_parsing),
 		TEST(dtx_commit_options_parsing),
 		TEST(dtx_abort_options_parsing),


### PR DESCRIPTION
- Added command arguments to smd_sync so can include path to system 
  path (/mnt/daos), and nvme config json path (/mnt/daos/daos_nvme.conf)
- Restructured ddb_spdk to use a  state machine to manage callback 
  complexity.
- Added device to target info for SMD sync.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>

Skip-func-test: true