### PR TITLE
DAOS-11697 test: bad_evict.py test baduuid case, manipulation of UUID can be a no-op and cause negative test failure

### DIFF
--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -63,7 +63,10 @@ class BadEvictTest(TestWithServers):
             saveduuid = (ctypes.c_ubyte * 16)(0)
             for index, _ in enumerate(saveduuid):
                 saveduuid[index] = self.pool.pool.uuid[index]
-            self.pool.pool.uuid[4] = 244
+            if self.pool.pool.uuid[4] != 244:
+                self.pool.pool.uuid[4] = 244
+            else:
+                self.pool.pool.uuid[4] == 255
 
         self.pool.uuid = self.pool.pool.get_uuid_str()
 


### PR DESCRIPTION
Description: Check pool uuid 4th byte before update an invalid ID.
Test-repeat: 10
Test-tag: bad_evict
Required-githooks: true

Signed-off-by: Ding Ho ding-hwa.ho@intel.com
