### PR TITLE
DAOS-11766 test: Fix harness/advanced.py bandit check

### DIFF
--- a/src/tests/ftest/harness/advanced.py
+++ b/src/tests/ftest/harness/advanced.py
@@ -157,7 +157,7 @@ class HarnessAdvancedTest(TestWithServers):
         :avocado: tags=harness,harness_advanced_test,launch_failures
         :avocado: tags=test_launch_failures
         """
-        host = NodeSet(choice(self.server_managers[0].hosts))
+        host = NodeSet(choice(self.server_managers[0].hosts))   # nosec
         self.log.info("Creating launch.py failure trigger files on %s", host)
         failure_trigger = "00_trigger-launch-failure_00"
         failure_trigger_dir = os.path.join(self.base_test_dir, failure_trigger)


### PR DESCRIPTION
Disable the bandit check for random.choice() usage in the harness/advance.py test_launch_failures test.

Quick-build: true
Skip-unit-tests: true
Skip-func-hw-test: true
Test-tag: test_launch_failures

Required-githooks: true

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>