### PR TITLE
DAOS-11648 doc: fabric_iface_port is not optional

### DIFF
--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -318,7 +318,7 @@
 #
 #  # Specify the fabric network interface and interface port that will
 #  # be used by this engine. The fabric_iface_port must be different
-#  # for each engine on a DAOS server. 
+#  # for each engine on a DAOS server.
 #
 #  fabric_iface: ib0
 #  fabric_iface_port: 20000

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -316,11 +316,9 @@
 #
 #  bypass_health_chk: true
 #
-#  # Use specific network interface.
-#  # Specify the fabric network interface that will be used by this engine.
-#  # Optionally specify the fabric network interface port that will be used
-#  # by this engine but please only if you have a specific need, this will
-#  # normally be chosen automatically.
+#  # Specify the fabric network interface and interface port that will
+#  # be used by this engine. The fabric_iface_port must be different
+#  # for each engine on a DAOS server. 
 #
 #  fabric_iface: ib0
 #  fabric_iface_port: 20000


### PR DESCRIPTION
remove comment in daos_server.yml stating that fabric_iface_port is optional (which is not the case).

Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>