### PR TITLE
DAOS-9582 control: Fix raft test fixture generation

### DIFF
--- a/src/control/system/raft/raft.go
+++ b/src/control/system/raft/raft.go
@@ -196,6 +196,12 @@ func ConfigureComponents(log logging.Logger, dbCfg *DatabaseConfig) (*RaftCompon
 	// volume, so set this value to strike a balance between
 	// creating snapshots too frequently and not often enough.
 	raftCfg.SnapshotThreshold = 32
+	if dbCfg.RaftSnapshotThreshold > 0 {
+		raftCfg.SnapshotThreshold = dbCfg.RaftSnapshotThreshold
+	}
+	if dbCfg.RaftSnapshotInterval > 0 {
+		raftCfg.SnapshotInterval = dbCfg.RaftSnapshotInterval
+	}
 	raftCfg.HeartbeatTimeout = 2000 * time.Millisecond
 	raftCfg.ElectionTimeout = 2000 * time.Millisecond
 	raftCfg.LeaderLeaseTimeout = 1000 * time.Millisecond


### PR DESCRIPTION
The change allowing custom configuration of some raft parameters
was somehow lost from the original PR.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
