### PR TITLE
DAOS-11815 ci: Add "agent" as commit msg component

### DIFF
--- a/ci/jira_query.py
+++ b/ci/jira_query.py
@@ -24,7 +24,7 @@ import jira
 # Expected components from the commit message, and directory in src/, src/client or utils/ is also
 # valid.  We've never checked/enforced these before so there have been a lot of values used in the
 # past.
-VALID_COMPONENTS = ('build', 'ci', 'doc', 'gha', 'il', 'mercury', 'test', 'md')
+VALID_COMPONENTS = ('build', 'ci', 'doc', 'gha', 'il', 'mercury', 'test', 'md', 'agent')
 
 # Expected ticket prefix.
 VALID_TICKET_PREFIX = ('DAOS', 'CORCI', 'SRE')


### PR DESCRIPTION
"agent" is a valid component string. It is used for changes to the control plane that are client-side only.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>