### PR TITLE
DAOS-11762 test: Match log threshold with log rollover size

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -64,9 +64,6 @@ if [[ "${LAUNCH_OPT_ARGS}" == "auto:-3DNAND" ]]; then
     LAUNCH_OPT_ARGS="--nvme=${LAUNCH_OPT_ARGS}"
 fi
 
-# Log size threshold
-LOGS_THRESHOLD="1G"
-
 # For nodes that are only rebooted between CI nodes left over mounts
 # need to be cleaned up.
 pre_clean () {
@@ -151,7 +148,6 @@ if ! ssh -A $SSH_KEY_ARGS ${REMOTE_ACCT:-jenkins}@"${nodes[0]}" \
      TEST_TAG_ARG=\"$TEST_TAG_ARG\"
      TEST_NODES=\"$TEST_NODES\"
      LAUNCH_OPT_ARGS=\"$LAUNCH_OPT_ARGS\"
-     LOGS_THRESHOLD=\"$LOGS_THRESHOLD\"
      WITH_VALGRIND=\"$WITH_VALGRIND\"
      STAGE_NAME=\"$STAGE_NAME\"
      $(sed -e '1,/^$/d' "$SCRIPT_LOC"/main.sh)"; then

--- a/src/tests/ftest/scripts/main.sh
+++ b/src/tests/ftest/scripts/main.sh
@@ -231,8 +231,7 @@ if [ "${STAGE_NAME}" == "Functional Hardware 24" ]; then
     launch_node_args="-ts ${server_nodes} -tc ${client_nodes}"
 fi
 # shellcheck disable=SC2086,SC2090
-if ! ./launch.py --mode ci -th "${LOGS_THRESHOLD}" \
-                 ${launch_node_args} ${LAUNCH_OPT_ARGS} ${TEST_TAG_ARR[*]}; then
+if ! ./launch.py --mode ci ${launch_node_args} ${LAUNCH_OPT_ARGS} ${TEST_TAG_ARR[*]}; then
     rc=${PIPESTATUS[0]}
 else
     rc=0


### PR DESCRIPTION
Increasing the test logs threshold size check to match the log rollover size: 1GB -> 2GB.  Increasing the timeout for the cart_logtest command and removing any empty log files prior to running the cart_logtest command. Also resolving DAOS-11812, where non-contiguous node sets where not processed correctly when updating test yaml files.

Quick-build: true
Skip-unit-tests: true
Test-tag: daosracer dfs_test ec_online_rebuild_fio ec_offline_rebuild_fio der_enospace Test-repeat: 3

Required-githooks: true

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>