### PR TITLE
DAOS-11664 test: support agent exclude_fabric_ifaces

### DIFF
--- a/src/tests/ftest/harness/config.py
+++ b/src/tests/ftest/harness/config.py
@@ -17,13 +17,17 @@ class HarnessConfigTest(TestWithServers):
     :avocado: recursive
     """
 
-    def test_harness_config_access_points(self):
-        """Verify the TestWithServers.access_points handling.
+    def test_harness_config(self):
+        """Verify the config handling.
+
+        Verfies the following:
+            TestWithServers.access_points
+            DaosAgentYamlParameters.exclude_fabric_ifaces
 
         :avocado: tags=all
         :avocado: tags=vm
         :avocado: tags=harness
-        :avocado: tags=test_harness_config_access_points
+        :avocado: tags=harness_config,test_harness_config
         """
         self.log.info('Verify access_points_suffix set from yaml')
         access_points_suffix = self.params.get("access_points_suffix", "/run/setup/*")
@@ -68,3 +72,10 @@ class HarnessConfigTest(TestWithServers):
         with open(self.agent_managers[0].manager.job.temporary_file, 'r') as yaml_file:
             daos_agent_yaml = yaml.safe_load(yaml_file.read())
         self.assertEqual(sorted(daos_agent_yaml['access_points']), sorted(self.access_points))
+
+        self.log.info('Verify daos_agent.yaml exclude_fabric_ifaces')
+        expected = self.params.get('exclude_fabric_ifaces', '/run/agent_config/*')
+        self.assertNotIn(expected, (None, []), 'exclude_fabric_ifaces not set in yaml')
+        with open(self.agent_managers[0].manager.job.temporary_file, 'r') as yaml_file:
+            daos_agent_yaml = yaml.safe_load(yaml_file.read())
+        self.assertEqual(daos_agent_yaml['exclude_fabric_ifaces'], expected)

--- a/src/tests/ftest/harness/config.yaml
+++ b/src/tests/ftest/harness/config.yaml
@@ -6,3 +6,5 @@ setup:
   access_points_suffix: .wolf.hpdd.intel.com
 server_config:
   name: daos_server
+agent_config:
+  exclude_fabric_ifaces: ["fake_iface1", "fake_iface2"]

--- a/src/tests/ftest/util/agent_utils_params.py
+++ b/src/tests/ftest/util/agent_utils_params.py
@@ -50,9 +50,12 @@ class DaosAgentYamlParameters(YamlParameters):
         #       Full path and name of the DAOS agent logfile.
         #   - control_log_mask: <str>, one of: error, info, debug
         #       Specifies the log level for agent logs.
+        #   - exclude_fabric_ifaces: <list>, Ignore a subset of fabric interfaces when selecting
+        #       an interface for client applications.
         self.runtime_dir = BasicParameter(None, "/var/run/daos_agent")
         self.log_file = LogParameter(log_dir, None, "daos_agent.log")
         self.control_log_mask = BasicParameter(None, "debug")
+        self.exclude_fabric_ifaces = BasicParameter(None)
 
     def update_log_file(self, name):
         """Update the log file name for the daos agent.


### PR DESCRIPTION
Test-tag: harness_config
Skip-unit-tests: true
Skip-fault-injection-test: true

Add exclude_fabric_ifaces to agent params.
Add test case to verify value from config.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>