### PR TITLE
DAOS-11601 object: refine daos_recx_ep_list_set

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1519,7 +1519,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		if (get_parity_list) {
 			parity_list = vos_ioh2recx_list(ioh);
 			if (parity_list != NULL) {
-				daos_recx_ep_list_set(parity_list, orw->orw_nr, 0, 0);
+				daos_recx_ep_list_set(parity_list, orw->orw_nr,
+						      ioc->ioc_coc->sc_ec_agg_eph_boundry, 0);
 				daos_recx_ep_list_merge(parity_list, orw->orw_nr);
 				orwo->orw_rels.ca_arrays = parity_list;
 				orwo->orw_rels.ca_count = orw->orw_nr;


### PR DESCRIPTION
Refine daos_recx_ep_list_set() to release the requirement of parity epoch mismatch check for client side,
because the client-side retry for parity epoch mismatch is for the case of EC aggregation unstable case that
parity ext updated to different parity shards asynchronously. This patch set the parity epoch as max of
parity ext and EC aggregation epoch boundary, which means once the EC aggregation done we can release
the requirement of parity ext epoch mismatch check for client-side retry.

Required-githooks: true

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>