### PR TITLE
DAOS-11183 control: Add helper log file option to daos_server legacy cmd

### DIFF
--- a/src/control/cmd/daos_server/storage_legacy.go
+++ b/src/control/cmd/daos_server/storage_legacy.go
@@ -30,6 +30,7 @@ type legacyStorageCmd struct {
 
 type legacyPrepCmd struct {
 	cmdutil.LogCmd
+	helperLogCmd
 	iommuCheckerCmd
 	scs *server.StorageControlService
 
@@ -129,6 +130,10 @@ func (cmd *legacyPrepCmd) prep(scs *server.StorageControlService) error {
 }
 
 func (cmd *legacyPrepCmd) Execute(args []string) error {
+	if err := cmd.setHelperLogFile(); err != nil {
+		return err
+	}
+
 	cmd.Info("storage prepare subcommand is deprecated, use nvme or scm subcommands instead")
 
 	// This is a little ugly, but allows for easier unit testing.


### PR DESCRIPTION
To make command syntax consistent, add option to output daos_admin
logging to file.

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>