### PR TITLE
DAOS-11724 test: pool/svc.py - Update the number of ranks to stop

### DIFF
--- a/src/tests/ftest/pool/svc.py
+++ b/src/tests/ftest/pool/svc.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 '''
   (C) Copyright 2018-2022 Intel Corporation.
 
@@ -87,8 +86,7 @@ class PoolSvc(TestWithServers):
         # Verify the result - If the svc_params[1] == 0 the dmg pool create is
         # expected to fail
         if svc_params[1] == 0 and pool_create_error:
-            self.log.info(
-                "Pool creation with svcn=%s failed as expected", svc_params[0])
+            self.log.info("Pool creation with svcn=%s failed as expected", svc_params[0])
         elif pool_create_error:
             self.fail(
                 "Pool creation with svcn={} failed when it was expected to "
@@ -116,7 +114,13 @@ class PoolSvc(TestWithServers):
                 len(set(self.pool.svc_ranks)),
                 "Duplicate values in returned rank list")
 
-            if svc_params[1] > 2:
+            # The number of ranks we can stop depends on the expected number of PS
+            # replicas (svc_params[1]) as below:
+            # svc_params[1] - Ranks we can stop
+            # 1 - 0
+            # 3 - 1
+            # 5 - 2
+            if svc_params[1] >= 3:
                 # Query the pool to get the leader
                 pool_leader = self.check_leader()
                 non_leader_ranks = list(self.pool.svc_ranks)
@@ -141,23 +145,23 @@ class PoolSvc(TestWithServers):
                 pool_leader = self.check_leader(pool_leader, True)
                 non_leader_ranks.remove(pool_leader)
 
-                # Stop a pool non-leader
-                non_leader = non_leader_ranks[-1]
-                self.log.info(
-                    "Stopping a pool non-leader (%s): %s",
-                    non_leader_ranks, non_leader)
-                try:
-                    self.server_managers[-1].stop_ranks(
-                        [non_leader], self.test_log)
-                except TestFail as error:
-                    self.log.info(error)
-                    self.fail(
-                        "Error stopping a pool non-leader - "
-                        "DaosServerManager.stop_ranks([{}])".format(non_leader))
+                if svc_params[1] == 5:
+                    # Stop a pool non-leader
+                    non_leader = non_leader_ranks[-1]
+                    self.log.info(
+                        "Stopping a pool non-leader (%s): %s",
+                        non_leader_ranks, non_leader)
+                    try:
+                        self.server_managers[-1].stop_ranks([non_leader], self.test_log)
+                    except TestFail as error:
+                        self.log.info(error)
+                        self.fail(
+                            "Error stopping a pool non-leader - "
+                            "DaosServerManager.stop_ranks([{}])".format(non_leader))
 
-                self.pool.wait_for_rebuild(to_start=True, interval=1)
-                self.pool.wait_for_rebuild(to_start=False, interval=1)
-                # Verify the pool leader has not changed
-                self.check_leader(pool_leader, False)
+                    self.pool.wait_for_rebuild(to_start=True, interval=1)
+                    self.pool.wait_for_rebuild(to_start=False, interval=1)
+                    # Verify the pool leader has not changed
+                    self.check_leader(pool_leader, False)
 
         self.log.info("Test passed!")


### PR DESCRIPTION
In pool/svc.py, we stop 0, 1, or 2 ranks based on the expected number
of PS replicas. However, there's a limit for the number of ranks we can
stop, which are:

Number of PS replicas - Number of ranks we can stop
1 - 0
3 - 1
5 - 2

We were stopping 2 ranks when the number of PS replicas was 3. Update
the test so that we only stop 1 rank; and stop 2 ranks only when the
number of PS replicas is 5.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_pool_svc
Required-githooks: true
Signed-off-by: Makito Kano <makito.kano@intel.com>