### PR TITLE
DAOS-3916 test: Fix some Go unit test issues

### DIFF
--- a/src/control/lib/daos/hlc.go
+++ b/src/control/lib/daos/hlc.go
@@ -19,6 +19,12 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 )
 
+const (
+	// ZeroHLCDate is the date of the zero HLC, as
+	// defined by CRT_HLC_START_SEC in src/cart/crt_hlc.c
+	ZeroHLCDate = "2021-01-01 00:00:00 +0000 UTC"
+)
+
 type (
 	// HLC is a high-resolution clock.
 	HLC uint64

--- a/src/control/lib/daos/hlc_test.go
+++ b/src/control/lib/daos/hlc_test.go
@@ -17,6 +17,10 @@ import (
 
 func TestDaos_HLC(t *testing.T) {
 	now := time.Now().Truncate(0)
+	zeroTime, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", daos.ZeroHLCDate)
+	if err != nil {
+		panic(err)
+	}
 
 	for name, tc := range map[string]struct {
 		in      int64
@@ -24,7 +28,7 @@ func TestDaos_HLC(t *testing.T) {
 	}{
 		"zero": {
 			in:      0,
-			expDate: "2021-01-01 00:00:00 +0000 UTC", // HLC epoch is 2021-01-01
+			expDate: zeroTime.Local().String(),
 		},
 		"now": {
 			in:      now.UnixNano(),

--- a/utils/sl/setup_local.sh
+++ b/utils/sl/setup_local.sh
@@ -150,3 +150,4 @@ if [ $? -eq 0 ]; then
 fi
 export PATH
 export SL_PREFIX
+export SL_SRC_DIR


### PR DESCRIPTION
There are a few tests that were failing when run on
non-CI distributions or with non-UTC timezones. Also
exports SL_SRC_DIR in setup_local.sh to allow run_go_tests.sh
to work correctly in developer environments.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
