### PR TITLE
Revert "DAOS-11260 dfuse: Apply timeouts to dfuse data cache."

### DIFF
--- a/docs/user/filesystem.md
+++ b/docs/user/filesystem.md
@@ -310,26 +310,24 @@ to be set to 0 or off, except dentry-dir-time which defaults to dentry-time
 | dfuse-dentry-time       | How long directory entries are cached                                  |
 | dfuse-dentry-dir-time   | How long dentries are cached, if the entry is itself a directory       |
 | dfuse-ndentry-time      | How long negative dentries are cached                                  |
-| dfuse-data-cache        | Data caching enabled, duration or ("on"/"true"/"off"/"false")          |
+| dfuse-data-cache        | Data caching enabled for this file ("on"/"true"/"off"/"false")         |
 | dfuse-direct-io-disable | Force use of page cache for this container ("on"/"true"/"off"/"false") |
 
 For metadata caching attributes specify the duration that the cache should be
 valid for, specified in seconds or with a 's', 'm', 'h' or 'd' suffix for seconds,
 minutes, hours or days.
 
-dfuse-data-cache can be set to a time value or "on", "true", "off" or "false" if set, other values
-will log an error, and result in the cache being off.  The O\_DIRECT flag for open files will be
-honoured with this option enabled, files which do not set O\_DIRECT will be cached.  Data caching
-is controlled by dfuse passing a flag to the kernel on open, if data-cache is enabled then it will
-be allowed for files if that file is already open, and timeout value will be the duration between
-a previous close call which reduced the open count to zero and the next subsequent call to open.
+dfuse-data-cache should be set to "on", "true", "off" or "false" if set, other values will
+log an error, and result in the cache being off.  The O\_DIRECT flag for open
+files will be honoured with this option enabled, files which do not set
+O\_DIRECT will be cached.
 
 dfuse-direct-io-disable will enable data caching, similar to dfuse-data-cache,
 however if this is enabled then the O\_DIRECT flag will be ignored, and all
 files will use the page cache.  This default value for this is disabled.
 
 With no options specified attr and dentry timeouts will be 1 second, dentry-dir
-and ndentry timeouts will be 5 seconds, and data caching will be set to 10 minutes.
+and ndentry timeouts will be 5 seconds, and data caching will be enabled.
 
 Readdir caching is available when supported by libfuse; however, on many distributions the system
 libfuse is not able to support this feature. Libfuse version 3.5.0 or newer is required at both

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -97,12 +97,6 @@ struct dfuse_obj_hdl {
 	/** True if caching is enabled for this file. */
 	bool                             doh_caching;
 
-	/* True of the kernel may have been told to keep the cache for this open.  This is used
-	 * for knowing if we need to reset the cache timer on close so it's OK to be conservative
-	 * here and this flag may be set on create even if the kernel flag isn't provided.
-	 */
-	bool                             doh_keep_cache;
-
 	/* True if the file handle is writeable - used for cache invalidation */
 	bool                             doh_writeable;
 
@@ -207,35 +201,35 @@ struct dfuse_pool {
  */
 struct dfuse_cont {
 	/** Fuse handlers to use for this container */
-	struct dfuse_inode_ops *dfs_ops;
+	struct dfuse_inode_ops	*dfs_ops;
 
 	/** Pointer to parent pool, where a reference is held */
-	struct dfuse_pool      *dfs_dfp;
+	struct dfuse_pool	*dfs_dfp;
 
 	/** dfs mount handle */
-	dfs_t                  *dfs_ns;
+	dfs_t			*dfs_ns;
 
 	/** UUID of the container */
-	uuid_t                  dfs_cont;
+	uuid_t			dfs_cont;
 
 	/** Container handle */
-	daos_handle_t           dfs_coh;
+	daos_handle_t		dfs_coh;
 
 	/** Hash table entry entry in dfp_cont_table */
-	d_list_t                dfs_entry;
+	d_list_t		dfs_entry;
 	/** Hash table reference count */
-	ATOMIC uint             dfs_ref;
+	ATOMIC uint		dfs_ref;
 
 	/** Inode number of the root of this container */
-	ino_t                   dfs_ino;
+	ino_t			dfs_ino;
 
 	/** Caching information */
-	double                  dfc_attr_timeout;
-	double                  dfc_dentry_timeout;
-	double                  dfc_dentry_dir_timeout;
-	double                  dfc_ndentry_timeout;
-	double                  dfc_data_timeout;
-	bool                    dfc_direct_io_disable;
+	double			dfc_attr_timeout;
+	double			dfc_dentry_timeout;
+	double			dfc_dentry_dir_timeout;
+	double			dfc_ndentry_timeout;
+	bool			dfc_data_caching;
+	bool			dfc_direct_io_disable;
 };
 
 void
@@ -569,9 +563,6 @@ struct dfuse_inode_entry {
 	d_list_t                 ie_htl;
 
 	/* Time of last kernel cache update.
-	 * For directories this is the time of the most recent closedir for a handle which may
-	 * have populated the cache.
-	 * For files this is when the file was last closed after been written to.
 	 */
 	struct timespec          ie_cache_last_update;
 

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -585,20 +585,16 @@ dfuse_cont_get_cache(struct dfuse_cont *dfc)
 
 		if (i == ATTR_DATA_CACHE_INDEX) {
 			if (dfuse_char_enabled(buff_addrs[i], sizes[i])) {
-				dfc->dfc_data_timeout = -1;
+				dfc->dfc_data_caching = true;
 				DFUSE_TRA_INFO(dfc, "setting '%s' is enabled", cont_attr_names[i]);
 			} else if (dfuse_char_disabled(buff_addrs[i], sizes[i])) {
 				have_cache_off        = true;
-				dfc->dfc_data_timeout = 0;
+				dfc->dfc_data_caching = false;
 				DFUSE_TRA_INFO(dfc, "setting '%s' is disabled", cont_attr_names[i]);
-			} else if (dfuse_parse_time(buff_addrs[i], sizes[i], &value) == 0) {
-				DFUSE_TRA_INFO(dfc, "setting '%s' is %u seconds",
-					       cont_attr_names[i], value);
-				dfc->dfc_data_timeout = value;
 			} else {
 				DFUSE_TRA_WARNING(dfc, "Failed to parse '%s' for '%s'",
 						  buff_addrs[i], cont_attr_names[i]);
-				dfc->dfc_data_timeout = 0;
+				dfc->dfc_data_caching = false;
 			}
 			continue;
 		}
@@ -647,7 +643,7 @@ dfuse_cont_get_cache(struct dfuse_cont *dfc)
 		if (have_cache_off)
 			DFUSE_TRA_WARNING(dfc, "Caching enabled because of %s",
 					  cont_attr_names[ATTR_DIRECT_IO_DISABLE_INDEX]);
-		dfc->dfc_data_timeout = -1;
+		dfc->dfc_data_caching = true;
 	}
 
 	if (have_dentry && !have_dentry_dir)
@@ -678,7 +674,7 @@ dfuse_set_default_cont_cache_values(struct dfuse_cont *dfc)
 	dfc->dfc_dentry_timeout     = 1;
 	dfc->dfc_dentry_dir_timeout = 5;
 	dfc->dfc_ndentry_timeout    = 1;
-	dfc->dfc_data_timeout       = 60 * 10;
+	dfc->dfc_data_caching       = true;
 	dfc->dfc_direct_io_disable  = false;
 }
 

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -129,8 +129,8 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	/* Upgrade fd permissions from O_WRONLY to O_RDWR if wb caching is
 	 * enabled so the kernel can do read-modify-write
 	 */
-	if (parent->ie_dfs->dfc_data_timeout != 0 && fs_handle->dpi_info->di_wb_cache &&
-	    (fi->flags & O_ACCMODE) == O_WRONLY) {
+	if (parent->ie_dfs->dfc_data_caching && fs_handle->dpi_info->di_wb_cache &&
+		(fi->flags & O_ACCMODE) == O_WRONLY) {
 		DFUSE_TRA_DEBUG(parent, "Upgrading fd to O_RDRW");
 		fi->flags &= ~O_ACCMODE;
 		fi->flags |= O_RDWR;
@@ -176,14 +176,9 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	oh->doh_writeable = true;
 
-	if (dfs->dfc_data_timeout != 0) {
+	if (dfs->dfc_data_caching) {
 		if (fi->flags & O_DIRECT)
 			fi_out.direct_io = 1;
-
-		/* keep_cache cannot be set here as ie is new and create might be being called
-		 * to open an existing file so the check needs to happen in reply_create()
-		 * after the hash table lookup.
-		 */
 	} else {
 		fi_out.direct_io = 1;
 	}
@@ -191,10 +186,8 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	if (dfs->dfc_direct_io_disable)
 		fi_out.direct_io = 0;
 
-	if (!fi_out.direct_io) {
+	if (!fi_out.direct_io)
 		oh->doh_caching = true;
-		oh->doh_keep_cache = true;
-	}
 
 	fi_out.fh = (uint64_t)oh;
 

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -124,20 +124,10 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		entry.attr_timeout = ie->ie_dfs->dfc_attr_timeout;
 	}
 
-	if (fi_out) {
-		/* Now set the value of keep_cache, this is for creat where we need to do the hash
-		 * table lookup before setting this value.
-		 */
-		if (atomic_load_relaxed(&ie->ie_open_count) > 1) {
-			fi_out->keep_cache = 1;
-		} else if (dfuse_cache_get_valid(ie, ie->ie_dfs->dfc_data_timeout, NULL)) {
-			fi_out->keep_cache = 1;
-		}
-
+	if (fi_out)
 		DFUSE_REPLY_CREATE(ie, req, entry, fi_out);
-	} else {
+	else
 		DFUSE_REPLY_ENTRY(ie, req, entry);
-	}
 
 	if (wipe_parent == 0)
 		return;

--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -35,7 +35,7 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	/* Upgrade fd permissions from O_WRONLY to O_RDWR if wb caching is
 	 * enabled so the kernel can do read-modify-write
 	 */
-	if (ie->ie_dfs->dfc_data_timeout != 0 && fs_handle->dpi_info->di_wb_cache &&
+	if (ie->ie_dfs->dfc_data_caching && fs_handle->dpi_info->di_wb_cache &&
 	    (fi->flags & O_ACCMODE) == O_WRONLY) {
 		DFUSE_TRA_DEBUG(ie, "Upgrading fd to O_RDRW");
 		fi->flags &= ~O_ACCMODE;
@@ -50,18 +50,11 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	if ((fi->flags & O_ACCMODE) != O_RDONLY)
 		oh->doh_writeable = true;
 
-	if (ie->ie_dfs->dfc_data_timeout != 0) {
+	if (ie->ie_dfs->dfc_data_caching) {
 		if (fi->flags & O_DIRECT)
 			fi_out.direct_io = 1;
 
-		if (atomic_load_relaxed(&ie->ie_open_count) > 0) {
-			fi_out.keep_cache = 1;
-		} else if (dfuse_cache_get_valid(ie, ie->ie_dfs->dfc_data_timeout, NULL)) {
-			fi_out.keep_cache = 1;
-		}
-
-		if (fi_out.keep_cache)
-			oh->doh_keep_cache = true;
+		fi_out.keep_cache = 1;
 	} else {
 		fi_out.direct_io = 1;
 	}
@@ -108,18 +101,13 @@ dfuse_cb_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	 * but the inode only tracks number of open handles with non-zero ioctl counts
 	 */
 
-	DFUSE_TRA_DEBUG(oh, "Closing %d %d", oh->doh_caching, oh->doh_keep_cache);
-
 	if (atomic_load_relaxed(&oh->doh_write_count) != 0) {
-		dfuse_cache_set_time(oh->doh_ie);
 		atomic_fetch_sub_relaxed(&oh->doh_ie->ie_open_write_count, 1);
 	}
 
 	if (atomic_load_relaxed(&oh->doh_il_calls) != 0) {
 		atomic_fetch_sub_relaxed(&oh->doh_ie->ie_il_count, 1);
 	}
-	if (oh->doh_caching && !oh->doh_keep_cache)
-		dfuse_cache_set_time(oh->doh_ie);
 	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_open_count, 1);
 
 	rc = dfs_release(oh->doh_obj);

--- a/src/client/dfuse/ops/setattr.c
+++ b/src/client/dfuse/ops/setattr.c
@@ -85,15 +85,16 @@ dfuse_cb_setattr(fuse_req_t req, struct dfuse_inode_entry *ie, struct stat *attr
 	}
 
 	if (to_set & FUSE_SET_ATTR_SIZE) {
-		DFUSE_TRA_DEBUG(ie, "size %#lx", attr->st_size);
+		DFUSE_TRA_DEBUG(ie, "size %#lx",
+				attr->st_size);
 		to_set &= ~FUSE_SET_ATTR_SIZE;
 		dfs_flags |= DFS_SET_ATTR_SIZE;
-		if (ie->ie_dfs->dfc_data_timeout != 0 && ie->ie_stat.st_size == 0 &&
-		    attr->st_size > 0) {
+		if (ie->ie_dfs->dfc_data_caching &&
+		    ie->ie_stat.st_size == 0 && attr->st_size > 0) {
 			DFUSE_TRA_DEBUG(ie, "truncating 0-size file");
-			ie->ie_truncated    = true;
-			ie->ie_start_off    = 0;
-			ie->ie_end_off      = 0;
+			ie->ie_truncated = true;
+			ie->ie_start_off = 0;
+			ie->ie_end_off = 0;
 			ie->ie_stat.st_size = attr->st_size;
 		} else {
 			ie->ie_truncated = false;

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -122,12 +122,12 @@ class DaosBuild(DfuseTestBase):
         self.load_dfuse(self.hostlist_clients, dfuse_namespace)
 
         if cache_mode == 'writeback':
-            cont_attrs['dfuse-data-cache'] = '5m'
+            cont_attrs['dfuse-data-cache'] = 'on'
             cont_attrs['dfuse-attr-time'] = cache_time
             cont_attrs['dfuse-dentry-time'] = cache_time
             cont_attrs['dfuse-ndentry-time'] = cache_time
         elif cache_mode == 'writethrough':
-            cont_attrs['dfuse-data-cache'] = '5m'
+            cont_attrs['dfuse-data-cache'] = 'on'
             cont_attrs['dfuse-attr-time'] = cache_time
             cont_attrs['dfuse-dentry-time'] = cache_time
             cont_attrs['dfuse-ndentry-time'] = cache_time


### PR DESCRIPTION
Reverts daos-stack/daos#9897

Test-tag: dfuse