### PR TITLE
DAOS-9355 doc: fix doc URLs in src tree

### DIFF
--- a/src/control/README.md
+++ b/src/control/README.md
@@ -44,4 +44,4 @@ Please refer to package-specific README's.
 
 ## User Documentation
 
-- [online documentation](https://daos-stack.github.io/)
+- [online documentation](https://docs.daos.io/latest/)

--- a/src/control/cmd/daos_admin/README.md
+++ b/src/control/cmd/daos_admin/README.md
@@ -2,7 +2,7 @@
 
 This page is intended to provide developer-focused documentation for the
 `daos_admin` helper. For installation instructions, please see the
-[DAOS Admin Guide](https://docs.daos.io/latest/admin/predeployment_check/#elevated-privileges).
+[DAOS Admin Guide](https://docs.daos.io/latest/admin/predeployment_check/#privileged-helper).
 
 ## Overview
 

--- a/src/control/cmd/daos_admin/README.md
+++ b/src/control/cmd/daos_admin/README.md
@@ -2,7 +2,7 @@
 
 This page is intended to provide developer-focused documentation for the
 `daos_admin` helper. For installation instructions, please see the
-[DAOS Admin Guide](https://daos-stack.github.io/admin/predeployment_check/#elevated-privileges).
+[DAOS Admin Guide](https://docs.daos.io/latest/admin/predeployment_check/#elevated-privileges).
 
 ## Overview
 

--- a/src/control/cmd/daos_server/README.md
+++ b/src/control/cmd/daos_server/README.md
@@ -18,7 +18,7 @@ The DAOS Server provides capability to provision and manage network devices and
 non-volatile storage including the allocation of resources to engine instances.
 
 See
-[admin guide](https://daos-stack.github.io/admin/deployment/#hardware-provisioning)
+[admin guide](https://docs.daos.io/latest/admin/deployment/#hardware-provisioning)
 for details on hardware provisioning.
 
 ## Configuration
@@ -157,7 +157,7 @@ Preparing SCM involves configuring DCPM modules in AppDirect memory regions
 resultant nvdimm namespaces are defined by a device identifier (e.g.
 /dev/pmem0).
 
-See the [admin guide](https://daos-stack.github.io/admin/deployment/#hardware-provisioning) for usage.
+See the [admin guide](https://docs.daos.io/latest/admin/deployment/#hardware-provisioning) for usage.
 
 ### Storage Scan
 
@@ -168,7 +168,7 @@ Device details for any discovered PMem (Intel(R) Optane(TM) persistent memory)
 modules on the storage server will be returned when running the `storage scan`
 subcommand.
 
-See the [admin guide](https://daos-stack.github.io/admin/deployment/#hardware-provisioning) for usage.
+See the [admin guide](https://docs.daos.io/latest/admin/deployment/#hardware-provisioning) for usage.
 
 ### Network Scan
 

--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -203,10 +203,10 @@ A view of DAOS' software component architecture:
 ## Running
 
 For instructions on building and running DAOS see the
-[admin guide](https://daos-stack.github.io/admin/installation/).
+[admin guide](https://docs.daos.io/latest/admin/hardware/).
 
 ## Configuration
 
 For instructions on configuring the DAOS server see the
-[admin guide](https://daos-stack.github.io/admin/deployment/#server-configuration-file).
+[admin guide](https://docs.daos.io/latest/admin/deployment/#server-configuration-file).
 

--- a/src/tests/simple_obj.c
+++ b/src/tests/simple_obj.c
@@ -7,8 +7,8 @@
 /*
  * This provides a simple example for how to access different DAOS objects.
  *
- * For more information on the DAOS object model, please visit this
- * page: https://daos-stack.github.io/overview/storage/#daos-object
+ * For more information on the DAOS object model, please visit this page:
+ * https://docs.daos.io/latest/overview/storage/#daos-object
  */
 
 #include <stdlib.h>


### PR DESCRIPTION
change daos-stack.github.io to docs.daos.io/latest

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>