### PR TITLE
DAOS-11755 control: Allow daos_server to show version/help without helper

### DIFF
--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -71,6 +71,8 @@ func (icc *iommuCheckerCmd) IsIOMMUEnabled() (bool, error) {
 	return icc.isIOMMUEnabled()
 }
 
+type execTestFn func() error
+
 type mainOpts struct {
 	AllowProxy bool `long:"allow-proxy" description:"Allow proxy configuration via environment"`
 	// Minimal set of top-level options
@@ -90,13 +92,15 @@ type mainOpts struct {
 	Version       versionCmd             `command:"version" description:"Print daos_server version"`
 	MgmtSvc       msCmdRoot              `command:"ms" description:"Perform tasks related to management service replicas"`
 	DumpTopo      hwprov.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
+
+	// Allow a set of tests to be run before executing commands.
+	preExecTests []execTestFn
 }
 
 type versionCmd struct{}
 
 func (cmd *versionCmd) Execute(_ []string) error {
 	fmt.Printf("%s v%s\n", build.ControlPlaneName, build.DaosVersion)
-	os.Exit(0)
 	return nil
 }
 
@@ -116,6 +120,19 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 		if len(cmdArgs) > 0 {
 			// don't support positional arguments, extra cmdArgs are unexpected
 			return errors.Errorf("unexpected commandline arguments: %v", cmdArgs)
+		}
+
+		switch cmd.(type) {
+		case *versionCmd:
+			// No pre-exec tests or setup needed for these commands; just
+			// execute them directly.
+			return cmd.Execute(nil)
+		default:
+			for _, test := range opts.preExecTests {
+				if err := test(); err != nil {
+					return err
+				}
+			}
 		}
 
 		if !opts.AllowProxy {
@@ -182,11 +199,13 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 
 func main() {
 	log := logging.NewCommandLineLogger()
-	var opts mainOpts
-
-	// Check this right away to avoid lots of annoying failures later.
-	if err := pbin.CheckHelper(log, pbin.DaosAdminName); err != nil {
-		exitWithError(log, err)
+	opts := mainOpts{
+		preExecTests: []execTestFn{
+			// Check that the privileged helper is installed and working.
+			func() error {
+				return pbin.CheckHelper(log, pbin.DaosAdminName)
+			},
+		},
 	}
 
 	if err := parseOpts(os.Args[1:], &opts, log); err != nil {


### PR DESCRIPTION
Move the privileged helper check to a pre-exec list that is run in
the command processor. Allows certain commands (e.g. version) to
bypass installation sanity checks with minimal code and unit
test changes.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
