### PR TITLE
DAOS-11643 tests: fix parameters passing to API

### DIFF
--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1575,7 +1575,7 @@ class DaosContainer():
                 params = [self.poh, ctypes.byref(self.uuid), None, event]
             else:
                 params = [self.poh, ctypes.byref(self.uuid), ctypes.byref(self.cont_prop),
-                          None, event]
+                          event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
                                             params,


### PR DESCRIPTION
Commit c5c4b26989 (DAOS-3927/PR-1617) had introduced a regression (one parameter in excess to be passed to daos_cont_create() api, when properties specified) which has only been unveilled when commit 44c7676212 (DAOS-11375/PR-10203) has landed due to causing redundancy factor property to be passed by default !!...

This patch removes the extra/erroneous parameter.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it
      should be force landed and forced-landing tag is set.
* [x] Commit messages follows the guidelines outlined
      [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [x] The PR has 2 reviews by people familiar with the code.
* [x] Any appropriate watchers have had a chance to review the PR.
* [x] Review comments are sufficiently resolved, particularly by prior reviewers that requested
      changes.
* [ ] Githooks were used. If not, there is a sufficient reason to move forward.  Check copyrights
      if githooks were not used.
* [x] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future
      PRs.
* [x] All builds have passed.  Check non-required builds to ensure they don't indicate any problem
      such as a compiler warning on extraneous platforms.
* [x] No new NLT or valgrind warnings.  Check the classic view. This step should only matter if
      the build requires force landing.
* [x] Ensure sufficent testing is done.   Check feature pragmas and test tags. Check that tests
      skipped for the ticket are run and now pass with the changes.
* [x] Quick-build or Quick-functional is not used.
* [x] Pay attention to PRs that may affect compatibility between versions and ensure it has been
      addressed.
* [x] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If
      it is a release branch, does it have merge approval in the JIRA ticket.
* [x] Check the commit message when landing. Check the standard
      [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit
      it to create a single commit. If necessary, ask submitter for a new summary.
