### PR TITLE
DAOS-11884 cart: Add new API to set a number of remote endpoints 

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1849,6 +1849,14 @@ crt_group_config_path_set(const char *path)
 	return 0;
 }
 
+int
+crt_group_num_remote_tags_set(crt_group_t *group, int *tags, int num_entries)
+{
+	struct crt_grp_priv	*grp_priv = NULL;
+
+	grp_priv = crt_grp_pub2priv(grp);
+}
+
 /**
  * Save attach info to file with the name
  * "<singleton_attach_path>/grpid.attach_info_tmp".

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1854,7 +1854,7 @@ crt_nr_secondary_remote_tags_set(int idx, int num_tags)
 {
 	struct crt_prov_gdata *prov_data;
 
-	D_DEBUG(DB_ALL, "secondary_idx=%d num_tags=%d\n", num_tags, idx);
+	D_DEBUG(DB_ALL, "secondary_idx=%d num_tags=%d\n", idx, num_tags);
 
 	if (idx != 0) {
 		D_ERROR("Only idx=0 is currently supported\n");

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1850,11 +1850,32 @@ crt_group_config_path_set(const char *path)
 }
 
 int
-crt_group_num_remote_tags_set(crt_group_t *group, int *tags, int num_entries)
+crt_nr_secondary_remote_tags_set(int idx, int num_tags)
 {
-	struct crt_grp_priv	*grp_priv = NULL;
+	struct crt_prov_gdata *prov_data;
 
-	grp_priv = crt_grp_pub2priv(grp);
+	D_DEBUG(DB_ALL, "secondary_idx=%d num_tags=%d\n", num_tags, idx);
+
+	if (idx != 0) {
+		D_ERROR("Only idx=0 is currently supported\n");
+		return -DER_NONEXIST;
+	}
+
+	if ((crt_gdata.cg_prov_gdata_secondary == NULL) ||
+	    (idx >= crt_gdata.cg_num_secondary_provs)) {
+		D_ERROR("Secondary providers not initialized\n");
+		return -DER_NONEXIST;
+	}
+
+	if (num_tags <= 0) {
+		D_ERROR("Invalid number of tags: %d\n", num_tags);
+		return -DER_INVAL;
+	}
+
+	prov_data = &crt_gdata.cg_prov_gdata_secondary[idx];
+	prov_data->cpg_num_remote_tags = num_tags;
+
+	return DER_SUCCESS;
 }
 
 /**

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -53,11 +53,18 @@ struct crt_prov_gdata {
 	uint32_t		cpg_max_exp_size;
 	uint32_t		cpg_max_unexp_size;
 
+	/** Number of remote tags */
+	uint32_t		cpg_num_remote_tags;
+	uint32_t		cpg_last_remote_tag;
+
 	/** Set of flags */
 	unsigned int		cpg_sep_mode		: 1,
 				cpg_primary		: 1,
 				cpg_contig_ports	: 1,
 				cpg_inited		: 1;
+
+	/** Mutext to protect fields above */
+	pthread_mutex_t		cpg_mutex;
 };
 
 #define MAX_NUM_SECONDARY_PROVS 2

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -2165,7 +2165,7 @@ int crt_group_info_set(d_iov_t *grp_info);
  * to endpoint0 for secondary provider communications.
  *
  * \param[in] idx               Secondary provider index. Currently only 0 is supported.
- * \param[in] num_tags          Numer of remote tags to set.
+ * \param[in] num_tags          Number of remote tags to set.
  *
  * \return                      DER_SUCCESS on success, negative value
  *                              on failure.

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -2155,6 +2155,29 @@ int crt_group_info_get(crt_group_t *group, d_iov_t *grp_info);
 int crt_group_info_set(d_iov_t *grp_info);
 
 /**
+ * Sets the number of the remote tags for the specified group.
+ *
+ * Tags are specified as an array, one for each provider, starting
+ * with a primary provider followed by zero or more secondary provider
+ * values.
+ *
+ * Each tag corresponds to a remote context or an endpoint.
+ * By default, CaRT assumes 1 remote tag for each newly created group/provider.
+ *
+ * When a number of tags is set to more than 1 for any secondary provider then
+ * CaRT will round-robin across all secondary provider tags instead of defaulting
+ * to endpoint0 for secondary provider communications.
+ *
+ * \param[in] group             Group identifier
+ * \param[in] tags              Array, each entry specifying a number of tags
+ * \param[in] num_entries       Number of entries in the array
+ *
+ * \return                      DER_SUCCESS on success, negative value
+ *                              on failure.
+ */
+int crt_group_num_remote_tags_set(crt_group_t *group, int *tags, int num_entries);
+
+/**
  * Retrieve list of ranks that belong to the specified group.
  *
  * \param[in] group             Group identifier

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -2155,27 +2155,22 @@ int crt_group_info_get(crt_group_t *group, d_iov_t *grp_info);
 int crt_group_info_set(d_iov_t *grp_info);
 
 /**
- * Sets the number of the remote tags for the specified group.
- *
- * Tags are specified as an array, one for each provider, starting
- * with a primary provider followed by zero or more secondary provider
- * values.
+ * Sets the number of the remote tags for the secondary provider.
  *
  * Each tag corresponds to a remote context or an endpoint.
- * By default, CaRT assumes 1 remote tag for each newly created group/provider.
+ * By default, CaRT assumes 1 remote tag for each secondary provider.
  *
  * When a number of tags is set to more than 1 for any secondary provider then
  * CaRT will round-robin across all secondary provider tags instead of defaulting
  * to endpoint0 for secondary provider communications.
  *
- * \param[in] group             Group identifier
- * \param[in] tags              Array, each entry specifying a number of tags
- * \param[in] num_entries       Number of entries in the array
+ * \param[in] idx               Secondary provider index. Currently only 0 is supported.
+ * \param[in] num_tags          Numer of remote tags to set.
  *
  * \return                      DER_SUCCESS on success, negative value
  *                              on failure.
  */
-int crt_group_num_remote_tags_set(crt_group_t *group, int *tags, int num_entries);
+int crt_nr_secondary_remote_tags_set(int idx, int num_tags);
 
 /**
  * Retrieve list of ranks that belong to the specified group.

--- a/src/tests/ftest/cart/dual_provider_server.c
+++ b/src/tests/ftest/cart/dual_provider_server.c
@@ -190,13 +190,13 @@ int main(int argc, char **argv)
 	}
 
 	if (num_primary_ctx > NUM_PRIMARY_CTX_MAX) {
-		printf("Error: Exceeded max alllowed %d for primary ctx\n",
+		printf("Error: Exceeded max allowed %d for primary ctx\n",
 		       NUM_PRIMARY_CTX_MAX);
 		return -1;
 	}
 
 	if (num_secondary_ctx > NUM_SECONDARY_CTX_MAX) {
-		printf("Error: Exceeded max alllowed %d for secondary ctx\n",
+		printf("Error: Exceeded max allowed %d for secondary ctx\n",
 		       NUM_SECONDARY_CTX_MAX);
 		return -1;
 	}


### PR DESCRIPTION
Add new API to set number of remote tags for a secondary provider
Round-robin across all secondary tags when sending RPC from a secondary cluster

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>