### PR TITLE
DAOS-11796 control: Consistently resolve MS replica addresses

### DIFF
--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -166,7 +166,7 @@ func (srv *server) logDuration(msg string, start time.Time) {
 
 // createServices builds scaffolding for rpc and event services.
 func (srv *server) createServices(ctx context.Context) error {
-	dbReplicas, err := cfgGetReplicas(srv.cfg, net.ResolveTCPAddr)
+	dbReplicas, err := cfgGetReplicas(srv.cfg, net.LookupIP)
 	if err != nil {
 		return errors.Wrap(err, "retrieve replicas from config")
 	}
@@ -250,7 +250,7 @@ func (srv *server) initNetwork() error {
 	ctlAddr, err := getControlAddr(ctlAddrParams{
 		port:           srv.cfg.ControlPort,
 		replicaAddrSrc: srv.sysdb,
-		resolveAddr:    net.ResolveTCPAddr,
+		lookupHost:     net.LookupIP,
 	})
 	if err != nil {
 		return err

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -7,11 +7,13 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,8 +37,45 @@ import (
 // netListenerFn is a type alias for the net.Listener function signature.
 type netListenFn func(string, string) (net.Listener, error)
 
-// resolveTCPFn is a type alias for the net.ResolveTCPAddr function signature.
-type resolveTCPFn func(string, string) (*net.TCPAddr, error)
+// ipLookupFn defines the function signature for a helper that can
+// be used to resolve a host address to a list of IP addresses.
+type ipLookupFn func(string) ([]net.IP, error)
+
+// resolveFirstAddr is a helper function to resolve a hostname to a TCP address.
+// If the hostname resolves to multiple addresses, the first one is returned.
+func resolveFirstAddr(addr string, lookup ipLookupFn) (*net.TCPAddr, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to split %q", addr)
+	}
+	iPort, err := strconv.Atoi(port)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to convert %q to int", port)
+	}
+	addrs, err := lookup(host)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to resolve %q", host)
+	}
+
+	if len(addrs) == 0 {
+		return nil, errors.Errorf("no addresses found for %q", host)
+	}
+
+	isIPv4 := func(ip net.IP) bool {
+		return ip.To4() != nil
+	}
+	// Ensure stable ordering of addresses.
+	sort.Slice(addrs, func(i, j int) bool {
+		if !isIPv4(addrs[i]) && isIPv4(addrs[j]) {
+			return false
+		} else if isIPv4(addrs[i]) && !isIPv4(addrs[j]) {
+			return true
+		}
+		return bytes.Compare(addrs[i], addrs[j]) < 0
+	})
+
+	return &net.TCPAddr{IP: addrs[0], Port: iPort}, nil
+}
 
 const scanMinHugePageCount = 128
 
@@ -58,10 +97,10 @@ func getBdevCfgsFromSrvCfg(cfg *config.Server) storage.TierConfigs {
 	return bdevCfgs
 }
 
-func cfgGetReplicas(cfg *config.Server, resolve resolveTCPFn) ([]*net.TCPAddr, error) {
+func cfgGetReplicas(cfg *config.Server, lookup ipLookupFn) ([]*net.TCPAddr, error) {
 	var dbReplicas []*net.TCPAddr
 	for _, ap := range cfg.AccessPoints {
-		apAddr, err := resolve("tcp", ap)
+		apAddr, err := resolveFirstAddr(ap, lookup)
 		if err != nil {
 			return nil, config.FaultConfigBadAccessPoints
 		}
@@ -106,7 +145,7 @@ type replicaAddrGetter interface {
 type ctlAddrParams struct {
 	port           int
 	replicaAddrSrc replicaAddrGetter
-	resolveAddr    resolveTCPFn
+	lookupHost     ipLookupFn
 }
 
 func getControlAddr(params ctlAddrParams) (*net.TCPAddr, error) {
@@ -116,7 +155,7 @@ func getControlAddr(params ctlAddrParams) (*net.TCPAddr, error) {
 		ipStr = repAddr.IP.String()
 	}
 
-	ctlAddr, err := params.resolveAddr("tcp", fmt.Sprintf("[%s]:%d", ipStr, params.port))
+	ctlAddr, err := resolveFirstAddr(fmt.Sprintf("[%s]:%d", ipStr, params.port), params.lookupHost)
 	if err != nil {
 		return nil, errors.Wrap(err, "resolving control address")
 	}

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -819,6 +819,86 @@ func (m *mockReplicaAddrSrc) ReplicaAddr() (*net.TCPAddr, error) {
 	return m.replicaAddrResult, m.replicaAddrErr
 }
 
+func TestServerUtils_resolveFirstAddr(t *testing.T) {
+	for name, tc := range map[string]struct {
+		host    string
+		lookup  ipLookupFn
+		expAddr *net.TCPAddr
+		expErr  error
+	}{
+		"host without port": {
+			host:   "localhost",
+			expErr: errors.New("missing port"),
+		},
+		"invalid port": {
+			host:   "localhost:daos",
+			expErr: errors.New("strconv.Atoi"),
+		},
+		"lookup failure": {
+			host:   "localhost:42",
+			lookup: func(string) ([]net.IP, error) { return nil, errors.New("lookup") },
+			expErr: errors.New("lookup"),
+		},
+		"no addresses": {
+			host:   "localhost:42",
+			lookup: func(string) ([]net.IP, error) { return nil, nil },
+			expErr: errors.New("no addresses"),
+		},
+		"localhost resolves to ipv6 & ipv4; prefer ipv4": {
+			host: "localhost:10001",
+			lookup: func(host string) ([]net.IP, error) {
+				return []net.IP{
+					net.ParseIP("::1"),
+					net.ParseIP("127.0.0.1"),
+				}, nil
+			},
+			expAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 10001},
+		},
+		"localhost resolves to ipv4 & ipv6; prefer ipv4": {
+			host: "localhost:10001",
+			lookup: func(host string) ([]net.IP, error) {
+				return []net.IP{
+					net.ParseIP("127.0.0.1"),
+					net.ParseIP("::1"),
+				}, nil
+			},
+			expAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 10001},
+		},
+		"host resolves to 2 ipv4; prefer lower": {
+			host: "host:10001",
+			lookup: func(host string) ([]net.IP, error) {
+				return []net.IP{
+					net.ParseIP("127.0.0.2"),
+					net.ParseIP("127.0.0.1"),
+				}, nil
+			},
+			expAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 10001},
+		},
+		"host resolves to 2 ipv6; prefer lower": {
+			host: "host:10001",
+			lookup: func(host string) ([]net.IP, error) {
+				return []net.IP{
+					net.ParseIP("::2"),
+					net.ParseIP("::1"),
+				}, nil
+			},
+			expAddr: &net.TCPAddr{IP: net.ParseIP("::1"), Port: 10001},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotAddr, gotErr := resolveFirstAddr(tc.host, tc.lookup)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if !common.CmpTCPAddr(tc.expAddr, gotAddr) {
+				t.Fatalf("unexpected address: want %s, got %s", tc.expAddr, gotAddr)
+			}
+		})
+	}
+}
+
 func TestServerUtils_getControlAddr(t *testing.T) {
 	testTCPAddr := &net.TCPAddr{
 		IP:   net.ParseIP("127.0.0.1"),
@@ -836,10 +916,9 @@ func TestServerUtils_getControlAddr(t *testing.T) {
 				replicaAddrSrc: &mockReplicaAddrSrc{
 					replicaAddrErr: errors.New("not a replica"),
 				},
-				resolveAddr: func(net, addr string) (*net.TCPAddr, error) {
-					test.AssertEqual(t, "tcp", net, "")
-					test.AssertEqual(t, "[0.0.0.0]:1234", addr, "")
-					return testTCPAddr, nil
+				lookupHost: func(addr string) ([]net.IP, error) {
+					test.AssertEqual(t, "0.0.0.0", addr, "")
+					return []net.IP{testTCPAddr.IP}, nil
 				},
 			},
 			expAddr: testTCPAddr,
@@ -850,17 +929,31 @@ func TestServerUtils_getControlAddr(t *testing.T) {
 				replicaAddrSrc: &mockReplicaAddrSrc{
 					replicaAddrResult: testTCPAddr,
 				},
-				resolveAddr: func(net, addr string) (*net.TCPAddr, error) {
-					test.AssertEqual(t, "tcp", net, "")
-					test.AssertEqual(t, "[127.0.0.1]:1234", addr, "")
-					return testTCPAddr, nil
+				lookupHost: func(addr string) ([]net.IP, error) {
+					test.AssertEqual(t, "127.0.0.1", addr, "")
+					return []net.IP{testTCPAddr.IP}, nil
+				},
+			},
+			expAddr: testTCPAddr,
+		},
+		"hostname with multiple IPs resolves to single replica address": {
+			params: ctlAddrParams{
+				port: testTCPAddr.Port,
+				replicaAddrSrc: &mockReplicaAddrSrc{
+					replicaAddrResult: testTCPAddr,
+				},
+				lookupHost: func(addr string) ([]net.IP, error) {
+					return []net.IP{
+						{testTCPAddr.IP[0], testTCPAddr.IP[1], testTCPAddr.IP[2], testTCPAddr.IP[3] + 1},
+						testTCPAddr.IP,
+					}, nil
 				},
 			},
 			expAddr: testTCPAddr,
 		},
 		"resolve fails": {
 			params: ctlAddrParams{
-				resolveAddr: func(_, _ string) (*net.TCPAddr, error) {
+				lookupHost: func(addr string) ([]net.IP, error) {
 					return nil, errors.New("mock resolve")
 				},
 			},
@@ -868,9 +961,9 @@ func TestServerUtils_getControlAddr(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if tc.params.resolveAddr == nil {
-				tc.params.resolveAddr = func(_, _ string) (*net.TCPAddr, error) {
-					return testTCPAddr, nil
+			if tc.params.lookupHost == nil {
+				tc.params.lookupHost = func(_ string) ([]net.IP, error) {
+					return []net.IP{testTCPAddr.IP}, nil
 				}
 			}
 


### PR DESCRIPTION
In environments where access_points hostnames can resolve
to multiple IP addresses in a nondeterministic manner, we
can run into problems due to MS peers not recognizing each
other. This patch works around the problem by pinning each
replica to the lowest IP address in the set of addresses
associated with each replica's hostname.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
