### PR TITLE
DAOS-11146 object: cache dc_pool and dc_cont

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -496,12 +496,6 @@ static struct d_hlink_ops cont_h_ops = {
 };
 
 void
-dc_cont_put(struct dc_cont *dc)
-{
-	daos_hhash_link_putref(&dc->dc_hlink);
-}
-
-void
 dc_cont_hdl_link(struct dc_cont *dc)
 {
 	daos_hhash_link_insert(&dc->dc_hlink, DAOS_HTYPE_CO);

--- a/src/container/cli_internal.h
+++ b/src/container/cli_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -9,49 +9,6 @@
 
 #ifndef __CONTAINER_CLIENT_INTERNAL_H__
 #define __CONTAINER_CLIENT_INTERNAL_H__
-
-/* Client container handle */
-struct dc_cont {
-	/** link chain in the global handle hash table */
-	struct d_hlink		dc_hlink;
-	/* list to pool */
-	d_list_t		dc_po_list;
-	/* object list for this container */
-	d_list_t		dc_obj_list;
-	/* lock for list of dc_obj_list */
-	pthread_rwlock_t	dc_obj_list_lock;
-	/* uuid for this container */
-	uuid_t			dc_uuid;
-	uuid_t			dc_cont_hdl;
-	uint64_t		dc_capas;
-	/* pool handler of the container */
-	daos_handle_t		dc_pool_hdl;
-	struct daos_csummer    *dc_csummer;
-	struct cont_props	dc_props;
-	/* minimal pmap version */
-	uint32_t		dc_min_ver;
-	uint32_t		dc_closing:1,
-				dc_slave:1; /* generated via g2l */
-};
-
-static inline struct dc_cont *
-dc_hdl2cont(daos_handle_t coh)
-{
-	struct d_hlink *hlink;
-
-	hlink = daos_hhash_link_lookup(coh.cookie);
-	if (hlink == NULL)
-		return NULL;
-
-	return container_of(hlink, struct dc_cont, dc_hlink);
-}
-
-static inline void
-dc_cont2hdl(struct dc_cont *dc, daos_handle_t *hdl)
-{
-	daos_hhash_link_getref(&dc->dc_hlink);
-	daos_hhash_link_key(&dc->dc_hlink, &hdl->cookie);
-}
 
 void dc_cont_hdl_link(struct dc_cont *dc);
 void dc_cont_hdl_unlink(struct dc_cont *dc);

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -14,7 +14,63 @@
 #include <daos/pool_map.h>
 #include <daos/tse.h>
 #include <daos_types.h>
+#include <daos/cont_props.h>
 #include "checksum.h"
+
+/* Client container handle */
+struct dc_cont {
+	/** link chain in the global handle hash table */
+	struct d_hlink		dc_hlink;
+	/* list to pool */
+	d_list_t		dc_po_list;
+	/* object list for this container */
+	d_list_t		dc_obj_list;
+	/* lock for list of dc_obj_list */
+	pthread_rwlock_t	dc_obj_list_lock;
+	/* uuid for this container */
+	uuid_t			dc_uuid;
+	uuid_t			dc_cont_hdl;
+	uint64_t		dc_capas;
+	/* pool handler of the container */
+	daos_handle_t           dc_pool_hdl;
+	struct daos_csummer    *dc_csummer;
+	struct cont_props	dc_props;
+	/* minimal pmap version */
+	uint32_t		dc_min_ver;
+	uint32_t		dc_closing:1,
+				dc_slave:1; /* generated via g2l */
+};
+
+static inline struct dc_cont *
+dc_hdl2cont(daos_handle_t coh)
+{
+	struct d_hlink *hlink;
+
+	hlink = daos_hhash_link_lookup(coh.cookie);
+	if (hlink == NULL)
+		return NULL;
+
+	return container_of(hlink, struct dc_cont, dc_hlink);
+}
+
+static inline void
+dc_cont_put(struct dc_cont *dc)
+{
+	daos_hhash_link_putref(&dc->dc_hlink);
+}
+
+static inline void
+dc_cont2hdl_noref(struct dc_cont *dc, daos_handle_t *hdl)
+{
+	daos_hhash_link_key(&dc->dc_hlink, &hdl->cookie);
+}
+
+static inline void
+dc_cont2hdl(struct dc_cont *dc, daos_handle_t *hdl)
+{
+	daos_hhash_link_getref(&dc->dc_hlink);
+	daos_hhash_link_key(&dc->dc_hlink, &hdl->cookie);
+}
 
 int dc_cont_init(void);
 void dc_cont_fini(void);

--- a/src/include/daos/pool.h
+++ b/src/include/daos/pool.h
@@ -108,6 +108,19 @@ dc_pool_get_version(struct dc_pool *pool)
 	return ver;
 }
 
+static inline void
+dc_pool2hdl(struct dc_pool *pool, daos_handle_t *hdl)
+{
+	daos_hhash_link_getref(&pool->dp_hlink);
+	daos_hhash_link_key(&pool->dp_hlink, &hdl->cookie);
+}
+
+static inline void
+dc_pool2hdl_noref(struct dc_pool *pool, daos_handle_t *hdl)
+{
+	daos_hhash_link_key(&pool->dp_hlink, &hdl->cookie);
+}
+
 struct dc_pool *dc_hdl2pool(daos_handle_t hdl);
 void dc_pool_get(struct dc_pool *pool);
 void dc_pool_put(struct dc_pool *pool);
@@ -128,6 +141,9 @@ int dc_pool_reint(tse_task_t *task);
 int dc_pool_drain(tse_task_t *task);
 int dc_pool_stop_svc(tse_task_t *task);
 int dc_pool_list_cont(tse_task_t *task);
+int dc_pool_tgt_idx2ptr(struct dc_pool *pool, uint32_t tgt_idx,
+			struct pool_target **tgt);
+
 int dc_pool_get_redunc(daos_handle_t poh);
 
 int dc_pool_map_version_get(daos_handle_t ph, unsigned int *map_ver);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -120,6 +120,8 @@ obj_free(struct d_hlink *hlink)
 
 	obj = container_of(hlink, struct dc_object, cob_hlink);
 	D_ASSERT(daos_hhash_link_empty(&obj->cob_hlink));
+	dc_pool_put(obj->cob_pool);
+	dc_cont_put(obj->cob_co);
 	obj_layout_free(obj);
 	D_FREE(obj->cob_time_fetch_leader);
 	D_SPIN_DESTROY(&obj->cob_spin);
@@ -186,7 +188,7 @@ dc_obj_get_redun_lvl(struct dc_object *obj)
 {
 	struct cont_props	props;
 
-	props = dc_cont_hdl2props(obj->cob_coh);
+	props = obj->cob_co->dc_props;
 
 	return props.dcp_redun_lvl;
 }
@@ -201,7 +203,7 @@ dc_obj_hdl2cont_hdl(daos_handle_t oh)
 	if (obj == NULL)
 		return DAOS_HDL_INVAL;
 
-	hdl = obj->cob_coh;
+	daos_hhash_link_key(&obj->cob_co->dc_hlink, &hdl.cookie);
 	obj_decref(obj);
 	return hdl;
 }
@@ -217,23 +219,18 @@ obj_layout_create(struct dc_object *obj, unsigned int mode, bool refresh)
 	int			i;
 	int			rc;
 
-	pool = dc_hdl2pool(dc_cont_hdl2pool_hdl(obj->cob_coh));
-	if (pool == NULL) {
-		D_WARN("Cannot find valid pool\n");
-		D_GOTO(out, rc = -DER_NO_HDL);
-	}
+	pool = obj->cob_pool;
+	D_ASSERT(pool != NULL);
 
 	map = pl_map_find(pool->dp_pool, obj->cob_md.omd_id);
 	if (map == NULL) {
 		D_DEBUG(DB_PL, "Cannot find valid placement map\n");
-		dc_pool_put(pool);
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
 	rebuild_ver = pool->dp_rebuild_version;
 	obj->cob_md.omd_ver = dc_pool_get_version(pool);
 	obj->cob_md.omd_fdom_lvl = dc_obj_get_redun_lvl(obj);
-	dc_pool_put(pool);
 	rc = pl_obj_place(map, &obj->cob_md, mode, rebuild_ver, NULL, &layout);
 	pl_map_decref(map);
 	if (rc != 0) {
@@ -375,7 +372,7 @@ obj_init_oca(struct dc_object *obj)
 	obj->cob_oca.ca_grp_nr = nr_grps;
 	if (daos_oclass_is_ec(oca)) {
 		/* Inherit cell size from container property */
-		props = dc_cont_hdl2props(obj->cob_coh);
+		props = obj->cob_co->dc_props;
 		obj->cob_oca.u.ec.e_len = props.dcp_ec_cell_sz;
 	}
 
@@ -700,22 +697,6 @@ obj_grp_leader_get(struct dc_object *obj, int grp_idx, uint64_t dkey_hash,
 	return obj_replica_leader_select(obj, grp_idx, map_ver);
 }
 
-static int
-obj_ptr2poh(struct dc_object *obj, daos_handle_t *ph)
-{
-	daos_handle_t   coh;
-
-	coh = obj->cob_coh;
-	if (daos_handle_is_inval(coh))
-		return -DER_NO_HDL;
-
-	*ph = dc_cont_hdl2pool_hdl(coh);
-	if (daos_handle_is_inval(*ph))
-		return -DER_NO_HDL;
-
-	return 0;
-}
-
 /* If the client has been asked to fetch (list/query) from leader replica,
  * then means that related data is associated with some prepared DTX that
  * may be committable on the leader replica. According to our current DTX
@@ -737,19 +718,12 @@ int
 obj_dkey2grpidx(struct dc_object *obj, uint64_t hash, unsigned int map_ver)
 {
 	struct dc_pool	*pool;
-	daos_handle_t	ph;
 	int		grp_size;
 	unsigned int	pool_map_ver;
 	uint64_t	grp_idx;
-	int		rc;
 
-	rc = obj_ptr2poh(obj, &ph);
-	if (rc < 0)
-		return rc;
-
-	pool = dc_hdl2pool(ph);
-	if (pool == NULL)
-		return -DER_NO_HDL;
+	pool = obj->cob_pool;
+	D_ASSERT(pool != NULL);
 
 	D_RWLOCK_RDLOCK(&pool->dp_map_lock);
 	pool_map_ver = pool_map_get_version(pool->dp_map);
@@ -763,10 +737,8 @@ obj_dkey2grpidx(struct dc_object *obj, uint64_t hash, unsigned int map_ver)
 		D_RWLOCK_UNLOCK(&obj->cob_lock);
 		D_DEBUG(DB_IO, "cob_ersion %u map_ver %u pool_map_ver %u\n",
 			obj->cob_version, map_ver, pool_map_ver);
-		dc_pool_put(pool);
 		return -DER_STALE;
 	}
-	dc_pool_put(pool);
 
 	D_ASSERT(obj->cob_shards_nr >= grp_size);
 
@@ -1263,7 +1235,6 @@ obj_pool_query_cb(tse_task_t *task, void *data)
 	}
 
 	obj_decref(arg->oqa_obj);
-	dc_pool_put(arg->oqa_pool);
 	return 0;
 }
 
@@ -1272,24 +1243,18 @@ obj_pool_query_task(tse_sched_t *sched, struct dc_object *obj,
 		    unsigned int map_ver, tse_task_t **taskp)
 {
 	tse_task_t		       *task;
-	daos_handle_t			ph;
 	struct dc_pool		       *pool;
 	struct obj_pool_query_arg	arg;
 	int				rc = 0;
+	daos_handle_t			ph;
 
-	rc = obj_ptr2poh(obj, &ph);
+	pool = obj->cob_pool;
+	D_ASSERT(pool != NULL);
+
+	dc_pool2hdl_noref(pool, &ph);
+	rc = dc_pool_create_map_refresh_task(ph, map_ver, sched, &task);
 	if (rc != 0)
 		return rc;
-
-	pool = dc_hdl2pool(ph);
-	if (pool == NULL)
-		return -DER_NO_HDL;
-
-	rc = dc_pool_create_map_refresh_task(ph, map_ver, sched, &task);
-	if (rc != 0) {
-		dc_pool_put(pool);
-		return rc;
-	}
 
 	arg.oqa_pool = pool;
 	pool = NULL;
@@ -1300,7 +1265,6 @@ obj_pool_query_task(tse_sched_t *sched, struct dc_object *obj,
 				       sizeof(arg));
 	if (rc != 0) {
 		obj_decref(arg.oqa_obj);
-		dc_pool_put(arg.oqa_pool);
 		dc_pool_abandon_map_refresh_task(task);
 		return rc;
 	}
@@ -1342,13 +1306,7 @@ dc_obj_redun_check(struct dc_object *obj, daos_handle_t coh)
 	int			 cont_tf;	/* cont #tolerate failures */
 	int			 rc;
 
-	rc = dc_cont_hdl2redunfac(coh, &cont_rf);
-	if (rc) {
-		D_ERROR(DF_OID" dc_cont_hdl2redunfac failed, "DF_RC"\n",
-			DP_OID(obj->cob_md.omd_id), DP_RC(rc));
-		return rc;
-	}
-
+	cont_rf = obj->cob_co->dc_props.dcp_redun_fac;
 	if (obj_is_ec(obj)) {
 		obj_tf = obj_ec_parity_tgt_nr(oca);
 	} else {
@@ -1386,12 +1344,19 @@ dc_obj_open(tse_task_t *task)
 	if (obj == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	obj->cob_coh  = args->coh;
+	obj->cob_co = dc_hdl2cont(args->coh);
+	if (obj->cob_co == NULL)
+		D_GOTO(fail, rc = -DER_NO_HDL);
+
+	obj->cob_pool = dc_hdl2pool(obj->cob_co->dc_pool_hdl);
+	if (obj->cob_pool == NULL)
+		D_GOTO(fail_put_cont, rc = -DER_NO_HDL);
+
 	obj->cob_mode = args->mode;
 
 	rc = D_SPIN_INIT(&obj->cob_spin, PTHREAD_PROCESS_PRIVATE);
 	if (rc != 0)
-		D_GOTO(fail, rc);
+		D_GOTO(fail_put_pool, rc);
 
 	rc = D_RWLOCK_INIT(&obj->cob_lock, NULL);
 	if (rc != 0)
@@ -1432,6 +1397,10 @@ fail_rwlock_created:
 	D_RWLOCK_DESTROY(&obj->cob_lock);
 fail_spin_created:
 	D_SPIN_DESTROY(&obj->cob_spin);
+fail_put_pool:
+	dc_pool_put(obj->cob_pool);
+fail_put_cont:
+	dc_cont_put(obj->cob_co);
 fail:
 	D_FREE(obj);
 	tse_task_complete(task, rc);
@@ -1564,7 +1533,7 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 			if (obj_shard->do_target_id == -1)
 				continue;
 
-			rc = dc_cont_tgt_idx2ptr(obj->cob_coh,
+			rc = dc_pool_tgt_idx2ptr(obj->cob_pool,
 						 obj_shard->do_target_id, &tgt);
 			if (rc != 0)
 				D_GOTO(out, rc);
@@ -1764,7 +1733,7 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 	tse_sched_t			*sched = tse_task2sched(task);
 	struct obj_ec_recov_task	*recov_task;
 	tse_task_t			*sub_task = NULL;
-	daos_handle_t			 coh = obj->cob_coh;
+	daos_handle_t			 coh;
 	daos_handle_t			 th = DAOS_HDL_INVAL;
 	d_list_t			 task_list;
 	uint32_t			 extra_flags, i;
@@ -1790,6 +1759,7 @@ obj_ec_recov_cb(tse_task_t *task, struct dc_object *obj,
 		 */
 		if (recov_task->ert_epoch == DAOS_EPOCH_MAX)
 			recov_task->ert_epoch = crt_hlc_get();
+		dc_cont2hdl_noref(obj->cob_co, &coh);
 		rc = dc_tx_local_open(coh, recov_task->ert_epoch, 0, &th);
 		if (rc) {
 			D_ERROR("task %p "DF_OID" dc_tx_local_open failed "
@@ -2990,7 +2960,7 @@ shard_task_list_init(struct obj_auxi_args *auxi)
 static void
 obj_rw_csum_destroy(const struct dc_object *obj, struct obj_auxi_args *obj_auxi)
 {
-	struct daos_csummer	*csummer = dc_cont_hdl2csummer(obj->cob_coh);
+	struct daos_csummer	*csummer = obj->cob_co->dc_csummer;
 
 	if (!daos_csummer_initialized(csummer))
 		return;
@@ -4690,9 +4660,9 @@ static int
 obj_csum_update(struct dc_object *obj, daos_obj_update_t *args,
 		struct obj_auxi_args *obj_auxi)
 {
-	struct daos_csummer	*csummer = dc_cont_hdl2csummer(obj->cob_coh);
+	struct daos_csummer	*csummer = obj->cob_co->dc_csummer;
 	struct daos_csummer	*csummer_copy = NULL;
-	struct cont_props	 cont_props = dc_cont_hdl2props(obj->cob_coh);
+	struct cont_props	 cont_props = obj->cob_co->dc_props;
 	struct dcs_csum_info	*dkey_csum = NULL;
 	struct dcs_iod_csums	*iod_csums = NULL;
 	int			 rc;
@@ -4761,7 +4731,7 @@ static int
 obj_csum_fetch(const struct dc_object *obj, daos_obj_fetch_t *args,
 	       struct obj_auxi_args *obj_auxi)
 {
-	struct daos_csummer	*csummer = dc_cont_hdl2csummer(obj->cob_coh);
+	struct daos_csummer	*csummer = obj->cob_co->dc_csummer;
 	struct daos_csummer	*csummer_copy;
 	struct dcs_csum_info	*dkey_csum = NULL;
 	struct dcs_iod_csums	*iod_csums = NULL;
@@ -6088,16 +6058,11 @@ shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 		 struct obj_auxi_args *obj_auxi, uint32_t grp_idx)
 {
 	struct shard_punch_args	*shard_arg;
-	daos_handle_t		 coh;
 	uuid_t			 coh_uuid;
 	uuid_t			 cont_uuid;
 	int			 rc;
 
-	coh = obj->cob_coh;
-	if (daos_handle_is_inval(coh))
-		return -DER_NO_HDL;
-
-	rc = dc_cont_hdl2uuid(coh, &coh_uuid, &cont_uuid);
+	rc = dc_cont2uuid(obj->cob_co, &coh_uuid, &cont_uuid);
 	if (rc != 0)
 		return rc;
 
@@ -6355,7 +6320,6 @@ dc_obj_query_key(tse_task_t *api_task)
 	struct obj_auxi_args	*obj_auxi;
 	struct dc_object	*obj;
 	d_list_t		*head = NULL;
-	daos_handle_t		coh;
 	uuid_t			coh_uuid;
 	uuid_t			cont_uuid;
 	int			grp_idx;
@@ -6393,11 +6357,7 @@ dc_obj_query_key(tse_task_t *api_task)
 	obj_auxi->spec_shard = 0;
 	obj_auxi->spec_group = 0;
 
-	coh = dc_obj_hdl2cont_hdl(api_args->oh);
-	if (daos_handle_is_inval(coh))
-		D_GOTO(out_task, rc = -DER_NO_HDL);
-
-	rc = dc_cont_hdl2uuid(coh, &coh_uuid, &cont_uuid);
+	rc = dc_cont2uuid(obj->cob_co, &coh_uuid, &cont_uuid);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 
@@ -6703,6 +6663,7 @@ daos_obj_generate_oid(daos_handle_t coh, daos_obj_id_t *oid,
 	uint32_t		nr_grp;
 	struct cont_props	props;
 	int			rc;
+	struct dc_cont		*dc;
 
 	if (!daos_otype_t_is_valid(type))
 		return -DER_INVAL;
@@ -6712,10 +6673,17 @@ daos_obj_generate_oid(daos_handle_t coh, daos_obj_id_t *oid,
 	if (daos_handle_is_inval(poh))
 		return -DER_NO_HDL;
 
-	pool = dc_hdl2pool(poh);
-	D_ASSERT(pool);
+	dc = dc_hdl2cont(coh);
+	if (dc == NULL)
+		return -DER_NO_HDL;
 
-	props = dc_cont_hdl2props(coh);
+	pool = dc_hdl2pool(poh);
+	if (pool == NULL) {
+		dc_cont_put(dc);
+		return -DER_NO_HDL;
+	}
+
+	props = dc->dc_props;
 	attr.pa_domain = props.dcp_redun_lvl;
 	rc = pl_map_query(pool->dp_pool, &attr);
 	D_ASSERT(rc == 0);
@@ -6727,16 +6695,13 @@ daos_obj_generate_oid(daos_handle_t coh, daos_obj_id_t *oid,
 	if (cid == OC_UNKNOWN) {
 		uint32_t rf;
 
-		rc = dc_cont_hdl2redunfac(coh, &rf);
-		if (rc) {
-			D_ERROR("dc_cont_hdl2redunfac failed, "DF_RC"\n", DP_RC(rc));
-			return rc;
-		}
+		rf = dc->dc_props.dcp_redun_fac;
 		rc = dc_set_oclass(rf, attr.pa_domain_nr, attr.pa_target_nr, type, hints, &ord,
 				   &nr_grp);
 	} else {
 		rc = daos_oclass_fit_max(cid, attr.pa_domain_nr, attr.pa_target_nr, &ord, &nr_grp);
 	}
+	dc_cont_put(dc);
 
 	if (rc)
 		return rc;
@@ -6809,29 +6774,32 @@ daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type, daos_oclass_hints
 	enum daos_obj_redun	ord;
 	struct cont_props	props;
 	uint32_t		nr_grp;
+	struct dc_cont		*dc;
 
 	/** select the oclass */
 	poh = dc_cont_hdl2pool_hdl(coh);
 	if (daos_handle_is_inval(poh))
 		return -DER_NO_HDL;
 
+	dc = dc_hdl2cont(coh);
+	if (dc == NULL)
+		return -DER_NO_HDL;
 	pool = dc_hdl2pool(poh);
-	D_ASSERT(pool);
+	if (pool == NULL) {
+		dc_cont_put(dc);
+		return -DER_NO_HDL;
+	}
 
-	props = dc_cont_hdl2props(coh);
+	props = dc->dc_props;
 	attr.pa_domain = props.dcp_redun_lvl;
 	rc = pl_map_query(pool->dp_pool, &attr);
 	if (rc) {
 		D_ERROR("pl_map_query failed, "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
+	rf = dc->dc_props.dcp_redun_fac;
+	dc_cont_put(dc);
 	dc_pool_put(pool);
-
-	rc = dc_cont_hdl2redunfac(coh, &rf);
-	if (rc) {
-		D_ERROR("dc_cont_hdl2redunfac failed, "DF_RC"\n", DP_RC(rc));
-		return rc;
-	}
 	rc = dc_set_oclass(rf, attr.pa_domain_nr, attr.pa_target_nr, type, hints, &ord, &nr_grp);
 	if (rc)
 		return rc;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -70,7 +70,7 @@ dc_obj_shard_open(struct dc_object *obj, daos_unit_oid_t oid,
 	D_ASSERT(obj != NULL && shard != NULL);
 	D_ASSERT(shard->do_obj == NULL);
 
-	rc = dc_cont_tgt_idx2ptr(obj->cob_coh, shard->do_target_id,
+	rc = dc_pool_tgt_idx2ptr(obj->cob_pool, shard->do_target_id,
 				 &map_tgt);
 	if (rc)
 		return rc;
@@ -79,7 +79,7 @@ dc_obj_shard_open(struct dc_object *obj, daos_unit_oid_t oid,
 	shard->do_target_rank = map_tgt->ta_comp.co_rank;
 	shard->do_target_idx = map_tgt->ta_comp.co_index;
 	shard->do_obj = obj;
-	shard->do_co_hdl = obj->cob_coh;
+	shard->do_co = obj->cob_co;
 	obj_shard_addref(shard); /* release this until obj_layout_free */
 
 	D_SPIN_LOCK(&obj->cob_spin);
@@ -99,7 +99,7 @@ struct rw_cb_args {
 	crt_rpc_t		*rpc;
 	daos_handle_t		*hdlp;
 	d_sg_list_t		*rwaa_sgls;
-	daos_handle_t		coh;
+	struct dc_cont		*co;
 	unsigned int		*map_ver;
 	daos_iom_t		*maps;
 	crt_endpoint_t		tgt_ep;
@@ -260,7 +260,7 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	int			 i;
 	int			 rc = 0;
 
-	csummer = dc_cont_hdl2csummer(rw_args->coh);
+	csummer = rw_args->co->dc_csummer;
 	if (!daos_csummer_initialized(csummer) || csummer->dcs_skip_data_verify)
 		return 0;
 
@@ -1163,7 +1163,6 @@ out:
 	if (rc == -DER_CSUM && opc == DAOS_OBJ_RPC_FETCH)
 		dc_shard_csum_report(task, &rw_args->tgt_ep, rw_args->rpc);
 	crt_req_decref(rw_args->rpc);
-	dc_pool_put((struct dc_pool *)rw_args->hdlp);
 
 	if (ret == 0 || obj_retry_error(rc))
 		ret = rc;
@@ -1173,13 +1172,7 @@ out:
 static struct dc_pool *
 obj_shard_ptr2pool(struct dc_obj_shard *shard)
 {
-	daos_handle_t poh;
-
-	poh = dc_cont_hdl2pool_hdl(shard->do_co_hdl);
-	if (daos_handle_is_inval(poh))
-		return NULL;
-
-	return dc_hdl2pool(poh);
+	return shard->do_obj->cob_pool;
 }
 
 int
@@ -1227,7 +1220,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	if (auxi->epoch.oe_flags & DTX_EPOCH_UNCERTAIN)
 		flags |= ORF_EPOCH_UNCERTAIN;
 
-	rc = dc_cont_hdl2uuid(shard->do_co_hdl, &cont_hdl_uuid, &cont_uuid);
+	rc = dc_cont2uuid(shard->do_co, &cont_hdl_uuid, &cont_uuid);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1240,14 +1233,14 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	tgt_ep.ep_rank = shard->do_target_rank;
 	rw_args.tgt_ep = tgt_ep;
 	if ((int)tgt_ep.ep_rank < 0)
-		D_GOTO(out_pool, rc = (int)tgt_ep.ep_rank);
+		D_GOTO(out, rc = (int)tgt_ep.ep_rank);
 
 	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, opc, &req);
 	D_DEBUG(DB_TRACE, "rpc %p opc:%d "DF_UOID" "DF_KEY" rank:%d tag:%d eph "
 		DF_U64"\n", req, opc, DP_UOID(shard->do_id), DP_KEY(dkey),
 		tgt_ep.ep_rank, tgt_ep.ep_tag, auxi->epoch.oe_value);
 	if (rc != 0)
-		D_GOTO(out_pool, rc);
+		D_GOTO(out, rc);
 
 	if (DAOS_FAIL_CHECK(DAOS_SHARD_OBJ_FAIL))
 		D_GOTO(out_req, rc = -DER_INVAL);
@@ -1346,7 +1339,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	rw_args.rpc = req;
 	rw_args.hdlp = (daos_handle_t *)pool;
 	rw_args.map_ver = &auxi->map_ver;
-	rw_args.coh = shard->do_co_hdl;
+	rw_args.co = shard->do_co;
 	rw_args.shard_args = args;
 	/* remember the sgl to copyout the data inline for fetch */
 	rw_args.rwaa_sgls = (opc == DAOS_OBJ_RPC_FETCH) ? sgls : NULL;
@@ -1400,8 +1393,6 @@ out_args:
 	crt_req_decref(req);
 out_req:
 	crt_req_decref(req);
-out_pool:
-	dc_pool_put(pool);
 out:
 	tse_task_complete(task, rc);
 	return rc;
@@ -1503,15 +1494,12 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	opi->opi_dti_cos.ca_arrays = NULL;
 
 	rc = daos_rpc_send(req, task);
-	dc_pool_put(pool);
 	return rc;
 
 out_req:
 	crt_req_decref(req);
 	crt_req_decref(req);
 out:
-	if (pool != NULL)
-		dc_pool_put(pool);
 	tse_task_complete(task, rc);
 	return rc;
 }
@@ -1685,7 +1673,7 @@ csum_enum_verify(const struct obj_enum_args *enum_args,
 	    sgl.sg_nr_out == 0)
 		return 0; /** no keys to verify */
 
-	csummer = dc_cont_hdl2csummer(enum_args->eaa_obj->do_co_hdl);
+	csummer = enum_args->eaa_obj->do_co->dc_csummer;
 	if (!daos_csummer_initialized(csummer) || csummer->dcs_skip_key_verify)
 		return 0; /** csums not enabled */
 
@@ -1851,7 +1839,6 @@ out:
 	if (oei->oei_kds_bulk != NULL)
 		crt_bulk_free(oei->oei_kds_bulk);
 	crt_req_decref(enum_args->rpc);
-	dc_pool_put((struct dc_pool *)enum_args->hdlp);
 
 	if (ret == 0 || obj_retry_error(rc))
 		ret = rc;
@@ -1886,7 +1873,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 	if (pool == NULL)
 		D_GOTO(out_put, rc = -DER_NO_HDL);
 
-	rc = dc_cont_hdl2uuid(obj_shard->do_co_hdl, &cont_hdl_uuid, &cont_uuid);
+	rc = dc_cont2uuid(obj_shard->do_co, &cont_hdl_uuid, &cont_uuid);
 	if (rc != 0)
 		D_GOTO(out_put, rc);
 
@@ -1894,14 +1881,14 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 	tgt_ep.ep_tag = obj_shard->do_target_idx;
 	tgt_ep.ep_rank = obj_shard->do_target_rank;
 	if ((int)tgt_ep.ep_rank < 0)
-		D_GOTO(out_pool, rc = (int)tgt_ep.ep_rank);
+		D_GOTO(out_put, rc = (int)tgt_ep.ep_rank);
 
 	D_DEBUG(DB_IO, "opc %d "DF_UOID" rank %d tag %d\n",
 		opc, DP_UOID(obj_shard->do_id), tgt_ep.ep_rank, tgt_ep.ep_tag);
 
 	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, opc, &req);
 	if (rc != 0)
-		D_GOTO(out_pool, rc);
+		D_GOTO(out_put, rc);
 
 	oei = crt_req_get(req);
 	D_ASSERT(oei != NULL);
@@ -2011,8 +1998,6 @@ out_eaa:
 		crt_bulk_free(oei->oei_bulk);
 out_req:
 	crt_req_decref(req);
-out_pool:
-	dc_pool_put(pool);
 out_put:
 	obj_shard_decref(obj_shard);
 	tse_task_complete(task, rc);
@@ -2310,15 +2295,12 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 	daos_dti_copy(&okqi->okqi_dti, dti);
 
 	rc = daos_rpc_send(req, task);
-	dc_pool_put(pool);
 	return rc;
 
 out_req:
 	crt_req_decref(req);
 	crt_req_decref(req);
 out:
-	if (pool)
-		dc_pool_put(pool);
 	tse_task_complete(task, rc);
 	return rc;
 }
@@ -2394,7 +2376,7 @@ dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	if (pool == NULL)
 		D_GOTO(out, rc = -DER_NO_HDL);
 
-	rc = dc_cont_hdl2uuid(shard->do_co_hdl, &cont_hdl_uuid, &cont_uuid);
+	rc = dc_cont2uuid(shard->do_co, &cont_hdl_uuid, &cont_uuid);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -2431,18 +2413,13 @@ dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	osi->osi_epoch		= args->sa_auxi.epoch.oe_value;
 	osi->osi_map_ver	= args->sa_auxi.map_ver;
 
-	rc = daos_rpc_send(req, task);
-	dc_pool_put(pool);
-	return rc;
+	return daos_rpc_send(req, task);
 
 out_req:
 	crt_req_decref(req);
 	crt_req_decref(req);
 
 out:
-	if (pool != NULL)
-		dc_pool_put(pool);
-
 	tse_task_complete(task, rc);
 	return rc;
 }

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -21,6 +21,7 @@
 #include <daos/btree_class.h>
 #include <daos/object.h>
 #include <daos/cont_props.h>
+#include <daos/container.h>
 
 #include "obj_rpc.h"
 #include "obj_ec.h"
@@ -48,8 +49,8 @@ struct dc_obj_shard {
 	uint32_t		do_target_rank;
 	/** object id */
 	daos_unit_oid_t		do_id;
-	/** container handler of the object */
-	daos_handle_t		do_co_hdl;
+	/** container ptr */
+	struct dc_cont		*do_co;
 	struct pl_obj_shard	do_pl_shard;
 	/** point back to object */
 	struct dc_object	*do_obj;
@@ -82,8 +83,10 @@ struct dc_object {
 	struct daos_obj_md	 cob_md;
 	/** object class attribute */
 	struct daos_oclass_attr	 cob_oca;
-	/** container open handle */
-	daos_handle_t		 cob_coh;
+	/** container ptr */
+	struct dc_cont		*cob_co;
+	/** pool ptr */
+	struct dc_pool		*cob_pool;
 	/** cob_spin protects obj_shards' do_ref */
 	pthread_spinlock_t	 cob_spin;
 
@@ -491,6 +494,19 @@ struct dc_obj_verify_args {
 	uint32_t			 current_shard;
 	struct dc_obj_verify_cursor	 cursor;
 };
+
+static inline int
+dc_cont2uuid(struct dc_cont *dc_cont, uuid_t *hdl_uuid, uuid_t *uuid)
+{
+	if (!dc_cont)
+		return -DER_NO_HDL;
+
+	if (hdl_uuid != NULL)
+		uuid_copy(*hdl_uuid, dc_cont->dc_cont_hdl);
+	if (uuid != NULL)
+		uuid_copy(*uuid, dc_cont->dc_uuid);
+	return 0;
+}
 
 int dc_set_oclass(uint32_t rf, int domain_nr, int target_nr, enum daos_otype_t otype,
 		  daos_oclass_hints_t hints, enum daos_obj_redun *ord, uint32_t *nr);

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -371,8 +371,7 @@ out:
 	if (tx) {
 		if (tx->tx_pool)
 			dc_pool_put(tx->tx_pool);
-		if (tx->tx_req_cache)
-			D_FREE(tx->tx_req_cache);
+		D_FREE(tx->tx_req_cache);
 		D_FREE(tx);
 	}
 

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -914,8 +914,10 @@ dc_obj_verify_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 {
 	daos_handle_t	th;
 	int		rc;
+	daos_handle_t	coh;
 
-	rc = dc_tx_local_open(obj->cob_coh, epoch, 0, &th);
+	dc_cont2hdl_noref(obj->cob_co, &coh);
+	rc = dc_tx_local_open(coh, epoch, 0, &th);
 	if (rc != 0) {
 		D_ERROR("dc_tx_local-open failed: "DF_RC"\n", DP_RC(rc));
 		return rc;

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -3170,3 +3170,31 @@ int dc_pool_get_redunc(daos_handle_t poh)
 
 	return rf;
 }
+
+/**
+ * Get pool_target by dc pool and target index.
+ *
+ * \param pool [IN]	dc pool
+ * \param tgt_idx [IN]	target index.
+ * \param tgt [OUT]	pool target pointer.
+ *
+ * \return		0 if get the pool_target.
+ * \return		errno if it does not get the pool_target.
+ */
+int
+dc_pool_tgt_idx2ptr(struct dc_pool *pool, uint32_t tgt_idx,
+		    struct pool_target **tgt)
+{
+	int		 n;
+
+	/* Get map_tgt so that we can have the rank of the target. */
+	D_ASSERT(pool != NULL);
+	D_RWLOCK_RDLOCK(&pool->dp_map_lock);
+	n = pool_map_find_target(pool->dp_map, tgt_idx, tgt);
+	D_RWLOCK_UNLOCK(&pool->dp_map_lock);
+	if (n != 1) {
+		D_ERROR("failed to find target %u\n", tgt_idx);
+		return -DER_INVAL;
+	}
+	return 0;
+}

--- a/src/pool/cli_internal.h
+++ b/src/pool/cli_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -9,13 +9,6 @@
 
 #ifndef __POOL_CLIENT_INTERNAL_H__
 #define __POOL_CLIENT_INTERNAL_H__
-
-static inline void
-dc_pool2hdl(struct dc_pool *pool, daos_handle_t *hdl)
-{
-	daos_hhash_link_getref(&pool->dp_hlink);
-	daos_hhash_link_key(&pool->dp_hlink, &hdl->cookie);
-}
 
 void dc_pool_hdl_link(struct dc_pool *pool);
 void dc_pool_hdl_unlink(struct dc_pool *pool);


### PR DESCRIPTION
Whenever we want to access pool and container pointer in daos client stack,
looking a per-proccess handle hash table by daos handle is required.
Performance could not scale well for multiple threads because of pthread read lock scability.

To avoid above issue, It is possible to store container and pool pointers in dc_object directly,
extra reference will be held for pool/cont if object is opened. during IO, accessing these
pointers are safe, even pool/cont are closed, server will return errors.

Benchmarking showed fio 4k random write(32 threads) improved from 381k iops to
1500k iops on Rocky8.

Required-githooks: true

Signed-off-by: Wang Shilong <shilong.wang@intel.com>