### PR TITLE
DAOS-11132 rebuild: Incorrect deletion of local objects

### DIFF
--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -242,7 +242,8 @@ pl_obj_layout_contains(struct pool_map *map, struct pl_obj_layout *layout,
 		rc = pool_map_find_target(map, layout->ol_shards[i].po_target,
 					  &target);
 		if (rc != 0 && target->ta_comp.co_rank == rank &&
-		    target->ta_comp.co_index == target_index && i == id_shard)
+		    target->ta_comp.co_index == target_index &&
+		    layout->ol_shards[i].po_shard == id_shard)
 			return true; /* Found a target and rank matches */
 	}
 


### PR DESCRIPTION
The cluster has an UP state target, and the object's layout may have an extending target. Calling the pl_obj_layout_contains interface in the reclaim process essentially means that the variable i in this interface is no longer equivalent to po_shard in the layout.

Required-githooks: true

Signed-off-by: wangzhaorong <wangzhaorong@cestc.cn>