### PR TITLE
DAOS-11396 control: Enable hugepage support for tmpfs

### DIFF
--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -248,6 +248,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 				storage.NewTierConfig().
 					WithScmMountPoint("/mnt/daos/1").
 					WithStorageClass("ram").
+					WithScmDisableHugepages().
 					WithScmRamdiskSize(16),
 				storage.NewTierConfig().
 					WithStorageClass("nvme").

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -120,8 +120,9 @@ func (p *Provider) MountScm() error {
 	switch cfg.Class {
 	case ClassRam:
 		req.Ramdisk = &RamdiskParams{
-			Size:     cfg.Scm.RamdiskSize,
-			NUMANode: cfg.Scm.NumaNodeIndex,
+			Size:             cfg.Scm.RamdiskSize,
+			NUMANode:         cfg.Scm.NumaNodeIndex,
+			DisableHugepages: cfg.Scm.DisableHugepages,
 		}
 	case ClassDcpm:
 		if len(cfg.Scm.DeviceList) != 1 {
@@ -154,8 +155,9 @@ func createScmFormatRequest(class Class, scmCfg ScmConfig, force bool) (*ScmForm
 	switch class {
 	case ClassRam:
 		req.Ramdisk = &RamdiskParams{
-			Size:     scmCfg.RamdiskSize,
-			NUMANode: scmCfg.NumaNodeIndex,
+			Size:             scmCfg.RamdiskSize,
+			NUMANode:         scmCfg.NumaNodeIndex,
+			DisableHugepages: scmCfg.DisableHugepages,
 		}
 	case ClassDcpm:
 		if len(scmCfg.DeviceList) != 1 {

--- a/src/control/server/storage/scm.go
+++ b/src/control/server/storage/scm.go
@@ -303,8 +303,9 @@ type (
 	// RamdiskParams defines the sub-parameters of a Format or Mount operation that
 	// will use tmpfs-based ramdisk
 	RamdiskParams struct {
-		Size     uint
-		NUMANode uint
+		Size             uint
+		NUMANode         uint
+		DisableHugepages bool
 	}
 
 	// ScmFormatRequest defines the parameters for a Format operation or query.

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -611,6 +611,9 @@ func (p *Provider) MountRamdisk(target string, params *storage.RamdiskParams) (*
 	if params.Size > 0 {
 		opts = append(opts, fmt.Sprintf("size=%dg", params.Size))
 	}
+	if !params.DisableHugepages {
+		opts = append(opts, "huge=always")
+	}
 
 	return p.mount(ramFsType, target, ramFsType, defaultMountFlags, strings.Join(opts, ","))
 }

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -353,6 +353,11 @@
 #    # The size of ram is specified by scm_size in GB units.
 #    scm_size: 16
 #
+#    # When class is set to ram, tmpfs will be mounted with hugepage
+#    # support, if the kernel supports it. If this is not desirable,
+#    # the behavior may be disabled here.
+#    scm_hugepages_disabled: true
+#
 #  -
 #    # Backend block device type. Force a SPDK driver to be used by this engine
 #    # instance.


### PR DESCRIPTION
Unless scm_hugepages_disabled is true in the engine storage configuration,
the per-engine tmpfs will be mounted with the huge=always option.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
