### PR TITLE
DAOS-11896 dtx: drop committed DTX for non-conditional solo modification

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -745,8 +745,8 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 		uint16_t sub_modification_cnt, uint32_t pm_ver,
 		daos_unit_oid_t *leader_oid, struct dtx_id *dti_cos,
 		int dti_cos_cnt, struct dtx_memberships *mbs, bool leader,
-		bool solo, bool sync, bool dist, bool migration,
-		bool ignore_uncommitted, bool resent, bool prepared, struct dtx_handle *dth)
+		bool solo, bool sync, bool dist, bool migration, bool ignore_uncommitted,
+		bool resent, bool prepared, bool drop_cmt, struct dtx_handle *dth)
 {
 	if (sub_modification_cnt > DTX_SUB_MOD_MAX) {
 		D_ERROR("Too many modifications in a single transaction:"
@@ -769,6 +769,7 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_cos_done = 0;
 	dth->dth_resent = resent ? 1 : 0;
 	dth->dth_solo = solo ? 1 : 0;
+	dth->dth_drop_cmt = drop_cmt ? 1 : 0;
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;
 	dth->dth_touched_leader_oid = 0;
@@ -1030,7 +1031,8 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 			     (flags & DTX_DIST) ? true : false,
 			     (flags & DTX_FOR_MIGRATION) ? true : false, false,
 			     (flags & DTX_RESEND) ? true : false,
-			     (flags & DTX_PREPARED) ? true : false, dth);
+			     (flags & DTX_PREPARED) ? true : false,
+			     (flags & DTX_DROP_CMT) ? true : false, dth);
 	if (rc == 0 && sub_modification_cnt > 0)
 		rc = vos_dtx_attach(dth, false, (flags & DTX_PREPARED) ? true : false);
 
@@ -1350,7 +1352,7 @@ dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 			     (flags & DTX_DIST) ? true : false,
 			     (flags & DTX_FOR_MIGRATION) ? true : false,
 			     (flags & DTX_IGNORE_UNCOMMITTED) ? true : false,
-			     (flags & DTX_RESEND) ? true : false, false, dth);
+			     (flags & DTX_RESEND) ? true : false, false, false, dth);
 	if (rc == 0 && sub_modification_cnt > 0)
 		rc = vos_dtx_attach(dth, false, false);
 

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -65,6 +65,8 @@ struct dtx_handle {
 					 dth_resent:1, /* For resent case. */
 					 /* Only one participator in the DTX. */
 					 dth_solo:1,
+					 /* Do not keep committed entry. */
+					 dth_drop_cmt:1,
 					 /* Modified shared items: object/key */
 					 dth_modify_shared:1,
 					 /* The DTX entry is in active table. */
@@ -202,6 +204,8 @@ enum dtx_flags {
 	DTX_FORCE_REFRESH	= (1 << 6),
 	/** Transaction has been prepared locally. */
 	DTX_PREPARED		= (1 << 7),
+	/** Do not keep committed entry. */
+	DTX_DROP_CMT		= (1 << 8),
 };
 
 int

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2621,8 +2621,12 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	version = orw->orw_map_ver;
 
-	if (tgt_cnt == 0)
+	if (tgt_cnt == 0) {
+		if (!(orw->orw_api_flags & DAOS_COND_MASK))
+			dtx_flags |= DTX_DROP_CMT;
 		dtx_flags |= DTX_SOLO;
+	}
+
 	if (orw->orw_flags & ORF_DTX_SYNC)
 		dtx_flags |= DTX_SYNC;
 
@@ -3497,8 +3501,11 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 			D_GOTO(out, rc);
 	}
 
-	if (tgt_cnt == 0)
+	if (tgt_cnt == 0) {
+		if (!(opi->opi_api_flags & DAOS_COND_MASK))
+			dtx_flags |= DTX_DROP_CMT;
 		dtx_flags |= DTX_SOLO;
+	}
 	if (opi->opi_flags & ORF_DTX_SYNC)
 		dtx_flags |= DTX_SYNC;
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -60,6 +60,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
 	dth->dth_solo = 0;
+	dth->dth_drop_cmt = 0;
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;
 	dth->dth_dist = 0;


### PR DESCRIPTION
When modify single replicated object, if it is not conditional, then it is unnecessary to keep related committed DTX entry, because:

1. We do not have DTX resync for such DTX.
2. We do not have DTX refresh for such DTX.
3. For relative rare case, the client may resend related modification RPC, then it is harmless to re-execute related modifiation since it does not break related semantics. The redundant (old) modification will be clean via VOS aggregation some time later.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
