### PR TITLE
DAOS-11755 control: Allow daos_server to show version/help without helper (#10528)

### DIFF
--- a/src/control/cmd/daos_server/command_test.go
+++ b/src/control/cmd/daos_server/command_test.go
@@ -1,0 +1,70 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+func TestBadCommand(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	var opts mainOpts
+	err := parseOpts([]string{"foo"}, &opts, log)
+	testExpectedError(t, fmt.Errorf("Unknown command `foo'"), err)
+}
+
+func TestNoCommand(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	var opts mainOpts
+	err := parseOpts([]string{}, &opts, log)
+	testExpectedError(t, fmt.Errorf("Please specify one command"), err)
+}
+
+func TestPreExecCheckBypass(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cmdLine string
+		expErr  error
+	}{
+		"help": {
+			cmdLine: "--help",
+			expErr:  &flags.Error{Type: flags.ErrHelp},
+		},
+		"version": {
+			cmdLine: "version",
+		},
+		"start (should fail)": {
+			cmdLine: "start",
+			expErr:  errors.New("ouch"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			opts := mainOpts{
+				preExecTests: []execTestFn{
+					func() error {
+						return errors.New("ouch")
+					},
+				},
+			}
+			err := parseOpts([]string{tc.cmdLine}, &opts, log)
+			test.CmpErr(t, tc.expErr, err)
+		})
+	}
+}


### PR DESCRIPTION
Move the privileged helper check to a pre-exec list that is run in
the command processor. Allows certain commands (e.g. version) to
bypass installation sanity checks with minimal code and unit
test changes.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
