### PR TITLE
DAOS-10915 csum: Scrubbing Cleanup

### DIFF
--- a/ci/jira_query.py
+++ b/ci/jira_query.py
@@ -24,7 +24,8 @@ import jira
 # Expected components from the commit message, and directory in src/, src/client or utils/ is also
 # valid.  We've never checked/enforced these before so there have been a lot of values used in the
 # past.
-VALID_COMPONENTS = ('build', 'ci', 'doc', 'gha', 'il', 'mercury', 'test', 'md', 'agent')
+VALID_COMPONENTS = ('build', 'ci', 'doc', 'gha', 'il', 'mercury', 'test', 'md',
+		    'agent', 'csum')
 
 # Expected ticket prefix.
 VALID_TICKET_PREFIX = ('DAOS', 'CORCI', 'SRE')

--- a/src/include/daos_srv/srv_csum.h
+++ b/src/include/daos_srv/srv_csum.h
@@ -17,13 +17,13 @@
  * checksums for the bsgl as needed and appropriate. The result is the iod will
  * have checksums appropriate for the extents and data they represent
  *
- * @param iod[in]			I/O Descriptor that will receive the
+ * @param[in]		iod		I/O Descriptor that will receive the
  *					csums
- * @param csummer[in]			csummer object for calculating and csum
+ * @param[in]		csummer		csummer object for calculating and csum
  *					logic
- * @param bsgl[in]			bio scatter gather list with the data
- * @param biov_csums[in]			list csum info for each \bsgl
- * @param biov_csums_used[in/out]	track the number of csums used
+ * @param[in]		bsgl		bio scatter gather list with the data
+ * @param[in]		biov_csums	list csum info for each \bsgl
+ * @param[in/out]	biov_csums_used	track the number of csums used
  * @return
  */
 int
@@ -35,12 +35,12 @@ ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer, struct bio_sglist
  * Allocate the memory for and populate the IO Maps structure. This structure is used to identify
  * the parts of the iods' recxes for which there is data and which part are holes.
  *
- * @param biod[in]	contains the extents and info on holes
- * @param iods[in]	IO Descriptor
- * @param iods_nr[in]	Number of iods
- * @param flags[in]	if ORF_CREATE_MAP_DETAIL is set, then all mapped extents are requested,
+ * @param[in]	biod	contains the extents and info on holes
+ * @param[in]	iods	IO Descriptor
+ * @param[in]	iods_nr	Number of iods
+ * @param[in]	flags	if ORF_CREATE_MAP_DETAIL is set, then all mapped extents are requested,
  *			not just the low and high extents.
- * @param p_maps[out]	pointer to the resulting structures
+ * @param[out]	p_maps	pointer to the resulting structures
  *
  * @return		0 on success, else error
  */
@@ -53,7 +53,9 @@ ds_iom_free(daos_iom_t **p_maps, uint64_t map_nr);
 
 
 /* For the pool target to start and stop the scrubbing ult */
-int ds_start_scrubbing_ult(struct ds_pool_child *child);
-void ds_stop_scrubbing_ult(struct ds_pool_child *child);
+int
+ds_start_scrubbing_ult(struct ds_pool_child *child);
+void
+ds_stop_scrubbing_ult(struct ds_pool_child *child);
 
 #endif

--- a/src/pool/srv_pool_scrub_ult.c
+++ b/src/pool/srv_pool_scrub_ult.c
@@ -43,9 +43,10 @@
 static inline bool
 scrubbing_is_enabled()
 {
-	char *disabled = getenv("DAOS_CSUM_SCRUB_DISABLED");
+	bool result = false;
 
-	return disabled == NULL;
+	d_getenv_bool("DAOS_CSUM_SCRUB_DISABLED", &result);
+	return result;
 }
 
 static inline int
@@ -214,7 +215,7 @@ drain_pool_target(uuid_t pool_uuid, d_rank_t rank, uint32_t target)
 	struct pool_target_addr		 addr = {0};
 	int rc;
 
-	D_ERROR("Draining target. rank: %d, target: %d", rank, target);
+	D_ERROR("Draining target. rank: %d, target: %d\n", rank, target);
 
 	rc = ds_pool_get_ranks(pool_uuid, PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_NEW,
 			       &out_ranks);
@@ -356,14 +357,12 @@ ds_start_scrubbing_ult(struct ds_pool_child *child)
 
 	/** Don't even create the ULT if scrubbing is disabled. */
 	if (!scrubbing_is_enabled()) {
-		C_TRACE("Checksum scrubbing DISABLED. "
-			"xs_id: %d, tgt_id: %d, ctx_id: %d, ",
+		C_TRACE("Checksum scrubbing DISABLED. xs_id: %d, tgt_id: %d, ctx_id: %d\n",
 			dmi->dmi_xs_id, dmi->dmi_tgt_id, dmi->dmi_ctx_id);
 		return 0;
 	}
 
-	C_TRACE("Checksum scrubbing ENABLED. "
-		"xs_id: %d, tgt_id: %d, ctx_id: %d, ",
+	C_TRACE("Checksum scrubbing ENABLED. xs_id: %d, tgt_id: %d, ctx_id: %d\n",
 		dmi->dmi_xs_id, dmi->dmi_tgt_id, dmi->dmi_ctx_id);
 
 	/* There will be several levels iteration, such as pool, container, object, and lower,
@@ -373,7 +372,7 @@ ds_start_scrubbing_ult(struct ds_pool_child *child)
 	child->spc_scrubbing_req = sched_create_ult(&attr, scrubbing_ult, child,
 						    DSS_DEEP_STACK_SZ);
 	if (child->spc_scrubbing_req == NULL) {
-		D_ERROR(DF_UUID"[%d]: Failed to create Scrubbing ULT.n",
+		D_ERROR(DF_UUID"[%d]: Failed to create Scrubbing ULT.\n",
 			DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
 		return -DER_NOMEM;
 	}


### PR DESCRIPTION
When the csum scrubbing feature branch landed, there where some minor style and text items that needed to be resolved. This change resolves those.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
