### PR TITLE
DAOS-11915 vos: Reregistration of btree doesn't fail

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -4183,8 +4183,12 @@ dbtree_class_register(unsigned int tree_class, uint64_t tree_feats,
 		return -DER_INVAL;
 
 	/* XXX should be multi-thread safe */
-	if (btr_class_registered[tree_class].tc_ops != NULL)
-		return -DER_EXIST;
+	if (btr_class_registered[tree_class].tc_ops != NULL) {
+		if (btr_class_registered[tree_class].tc_ops != ops ||
+		    btr_class_registered[tree_class].tc_feats != tree_feats)
+			return -DER_EXIST;
+		return 0;
+	}
 
 	/* These are mandatory functions */
 	D_ASSERT(ops != NULL);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1148,7 +1148,7 @@ events_handler(void *arg)
 	D_DEBUG(DB_MD, DF_UUID": starting\n", DP_UUID(svc->ps_uuid));
 
 	for (;;) {
-		struct pool_svc_event  *event;
+		struct pool_svc_event  *event = NULL;
 		bool			stop;
 
 		ABT_mutex_lock(events->pse_mutex);


### PR DESCRIPTION
It was discovered by the ddb tool that when vos_self_init/fini are called repeatedly, the container btree class is never really 'unregistered' so registering again causes it to fail with -DER_EXIST. This changes that behavior so that if registering and the class already exists, it will check if it's registering the same thing, then returns success. The registration process does not allocate memory or resources so there is no harm in multiple registrations.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
