### PR TITLE
DAOS-11901 test: Cleanup and coverity fixes for multi-send

### DIFF
--- a/src/tests/ftest/cart/test_multisend_client.c
+++ b/src/tests/ftest/cart/test_multisend_client.c
@@ -156,7 +156,8 @@ test_run()
 				sgl.sg_iovs[0].iov_len = chunk_size;
 				sgl.sg_iovs[0].iov_buf_len = chunk_size;
 
-				rc = crt_bulk_create(ctx, &sgl, CRT_BULK_RW, &bulk_hdl[chunk_index]);
+				rc = crt_bulk_create(ctx, &sgl, CRT_BULK_RW,
+						     &bulk_hdl[chunk_index]);
 				D_ASSERTF(rc == 0, "crt_bulk_create() failed; rc: %d\n", rc);
 
 				input->bulk_hdl = bulk_hdl[chunk_index];
@@ -189,7 +190,8 @@ test_run()
 		     (tv_end.tv_usec - tv_start.tv_usec);
 
 	if (test.tg_force_rank == -1 ) {
-		DBG_PRINT("%s mode (%s) : Transfer of %d chunks size %dkb each took %ld usec (%d repeats)\n",
+		DBG_PRINT("%s mode (%s) : Transfer of %d chunks size %dkb each took "
+			  "%ld usec (%d repeats)\n",
 			  test.tg_test_mode == TEST_MODE_SYNC ? "Synchronous" : "Asynchronous",
 			  test.tg_do_put == true ? "PUT" : "GET",
 			  num_chunks, test.tg_chunk_size_kb, time_delta/num_iterations,

--- a/src/tests/ftest/cart/test_multisend_client.c
+++ b/src/tests/ftest/cart/test_multisend_client.c
@@ -29,7 +29,9 @@ rpc_cb_common(const struct crt_cb_info *info)
 	sem_post(&test.tg_token_to_proceed);
 }
 
-static int handler_ping(crt_rpc_t *rpc)
+/* stub */
+static int
+handler_ping(crt_rpc_t *rpc)
 {
 	return 0;
 }
@@ -63,6 +65,10 @@ test_run()
 
 	DBG_PRINT("Client starting with %d contexts\n", test.tg_num_ctx);
 
+	if (test.tg_force_rank != -1)
+		DBG_PRINT("Forcing simple RPC to the fixed target %d:0\n",
+			  test.tg_force_rank);
+
 	rc = crtu_cli_start_basic(test.tg_local_group_name,
 				  test.tg_remote_group_name,
 				  &grp, &rank_list, &test.tg_crt_ctx[0],
@@ -71,8 +77,9 @@ test_run()
 				  test.tg_use_daos_agent_env);
 	D_ASSERTF(rc == 0, "crtu_cli_start_basic()\n");
 
-	if (test.tg_num_ctx < 1 || test.tg_num_ctx > MAX_NUM_CTX) {
-		DBG_PRINT("Wrong number of ctx specified\n");
+	if (test.tg_num_ctx < 1 || test.tg_num_ctx > MAX_NUM_CLIENT_CTX) {
+		DBG_PRINT("Wrong number of ctx specified. Can't exceed %d\n",
+			  MAX_NUM_CLIENT_CTX);
 		return ;
 	}
 
@@ -123,7 +130,11 @@ test_run()
 			ctx = test.tg_crt_ctx[ctx_idx];
 			ctx_idx = (ctx_idx + 1) % test.tg_num_ctx;
 
-			rank = chunk_index % test.tg_remote_group_size;
+
+			if (test.tg_force_rank == -1)
+				rank = chunk_index % test.tg_remote_group_size;
+			else
+				rank = test.tg_force_rank;
 
 			/* Pick a new server based on a test mode selected */
 			server_ep.ep_grp = grp;
@@ -134,30 +145,39 @@ test_run()
 			D_ASSERTF(rc == 0 && rpc_req != NULL, "crt_req_create() failed,"
 				  " rc: %d rpc_req: %p\n", rc, rpc_req);
 
-			rc = d_sgl_init(&sgl, 1);
-			D_ASSERTF(rc == 0, "d_sgl_init() failed; rc: %d\n", rc);
-
-			sgl.sg_iovs[0].iov_buf = dma_buff + (chunk_size * chunk_index);
-			sgl.sg_iovs[0].iov_len = chunk_size;
-			sgl.sg_iovs[0].iov_buf_len = chunk_size;
-
-			rc = crt_bulk_create(ctx, &sgl, CRT_BULK_RW, &bulk_hdl[chunk_index]);
-			D_ASSERTF(rc == 0, "crt_bulk_create() failed; rc: %d\n", rc);
-
 			input = crt_req_get(rpc_req);
-			input->bulk_hdl = bulk_hdl[chunk_index];
-			input->chunk_size = chunk_size;
-			input->chunk_index = chunk_index;
-			input->do_put = test.tg_do_put;
+
+			/* TODO: for now rdma is disabled when forcing all rpcs to the same rank */
+			if (test.tg_force_rank == -1) {
+				rc = d_sgl_init(&sgl, 1);
+				D_ASSERTF(rc == 0, "d_sgl_init() failed; rc: %d\n", rc);
+
+				sgl.sg_iovs[0].iov_buf = dma_buff + (chunk_size * chunk_index);
+				sgl.sg_iovs[0].iov_len = chunk_size;
+				sgl.sg_iovs[0].iov_buf_len = chunk_size;
+
+				rc = crt_bulk_create(ctx, &sgl, CRT_BULK_RW, &bulk_hdl[chunk_index]);
+				D_ASSERTF(rc == 0, "crt_bulk_create() failed; rc: %d\n", rc);
+
+				input->bulk_hdl = bulk_hdl[chunk_index];
+				input->chunk_size = chunk_size;
+				input->chunk_index = chunk_index;
+				input->do_put = test.tg_do_put;
+			} else {
+				input->chunk_size = 0;
+				input->bulk_hdl = CRT_BULK_NULL;
+				input->chunk_index = 0;
+				input->do_put = false;
+			}
 
 			rc = crt_req_send(rpc_req, rpc_cb_common, &bulk_hdl[chunk_index]);
 			D_ASSERTF(rc == 0, "crt_req_send() failed. rc: %d\n", rc);
 
-			if (test.tg_test_mode == 1)
+			if (test.tg_test_mode == TEST_MODE_SYNC)
 				crtu_sem_timedwait(&test.tg_token_to_proceed, 61, __LINE__);
 		}
 
-		if (test.tg_test_mode == 2) {
+		if (test.tg_test_mode == TEST_MODE_ASYNC) {
 			for (chunk_index = 0; chunk_index < num_chunks; chunk_index++) {
 				crtu_sem_timedwait(&test.tg_token_to_proceed, 61, __LINE__);
 			}
@@ -168,13 +188,19 @@ test_run()
 	time_delta = (tv_end.tv_sec - tv_start.tv_sec) * 1000000 +
 		     (tv_end.tv_usec - tv_start.tv_usec);
 
-	DBG_PRINT("%s mode (%s) : Transfer of %d chunks size %d kb each took %ld usec\n",
-		  test.tg_test_mode == 1 ? "Synchronous" : "Asynchronous",
-		  test.tg_do_put == true ? "PUT" : "GET",
-		  num_chunks, test.tg_chunk_size_kb, time_delta/num_iterations);
+	if (test.tg_force_rank == -1 ) {
+		DBG_PRINT("%s mode (%s) : Transfer of %d chunks size %dkb each took %ld usec (%d repeats)\n",
+			  test.tg_test_mode == TEST_MODE_SYNC ? "Synchronous" : "Asynchronous",
+			  test.tg_do_put == true ? "PUT" : "GET",
+			  num_chunks, test.tg_chunk_size_kb, time_delta/num_iterations,
+			  num_iterations);
+	} else {
+		DBG_PRINT("%s mode, RPCs forced to target %d:0 ; delta %ld usec (%d repeats)\n",
+			  test.tg_test_mode == TEST_MODE_SYNC ? "Synchronous" : "Asynchronous",
+			  test.tg_force_rank, time_delta/num_iterations, num_iterations);
+	}
 
 	/* SHUTDOWN servers */
-
 	if (test.tg_do_shutdown) {
 		for (i = 0; i < test.tg_remote_group_size; i++) {
 
@@ -213,6 +239,8 @@ test_run()
 
 	rc = sem_destroy(&test.tg_token_to_proceed);
 	D_ASSERTF(rc == 0, "sem_destroy() failed.\n");
+
+	D_FREE(dma_buff);
 
 	rc = crt_finalize();
 	D_ASSERTF(rc == 0, "crt_finalize() failed. rc: %d\n", rc);

--- a/src/tests/ftest/cart/test_multisend_common.h
+++ b/src/tests/ftest/cart/test_multisend_common.h
@@ -24,6 +24,8 @@
 #define MY_VER  0
 
 #define NUM_SERVER_CTX 8
+#define MAX_NUM_CLIENT_CTX 32
+
 
 #define RPC_DECLARE(name)					\
 	CRT_RPC_DECLARE(name, CRT_ISEQ_##name, CRT_OSEQ_##name)	\
@@ -77,7 +79,10 @@ struct crt_proto_format my_proto_fmt = {
 	.cpf_base = MY_BASE,
 };
 
-#define MAX_NUM_CTX 16
+enum test_sync_mode_t {
+	TEST_MODE_SYNC  = 1,
+	TEST_MODE_ASYNC = 2,
+};
 
 struct test_global_t {
 	crt_group_t		*tg_local_group;
@@ -88,8 +93,8 @@ struct test_global_t {
 	uint32_t		 tg_is_service:1,
 				 tg_should_attach:1;
 	uint32_t		 tg_my_rank;
-	crt_context_t		 tg_crt_ctx[MAX_NUM_CTX];
-	pthread_t		 tg_tid[MAX_NUM_CTX];
+	crt_context_t		 tg_crt_ctx[MAX_NUM_CLIENT_CTX];
+	pthread_t		 tg_tid[MAX_NUM_CLIENT_CTX];
 	int			 tg_thread_id;
 	sem_t			 tg_token_to_proceed;
 	bool			 tg_use_cfg;
@@ -102,6 +107,7 @@ struct test_global_t {
 	int			 tg_num_ctx;
 	int			 tg_num_iterations;
 	int			 tg_chunk_size_kb;
+	int			 tg_force_rank;
 };
 
 struct test_global_t test = {0};
@@ -120,13 +126,14 @@ handler_shutdown(crt_rpc_t *rpc)
 static void
 show_usage(void)
 {
-	printf("Usage: ./test_multisend_client [-acaspqmex]\n");
+	printf("Usage: ./test_multisend_client [-acfspqmex]\n");
 	printf("Options:\n");
 	printf("-a [--attach-to <group_name>] : server group to attach to\n");
 	printf("-s [--cfg-path <path>]: path to attach info file\n");
 	printf("-c <kb>: Chunk size in kb\n");
 	printf("-e <num>: Number of client contexts to use\n");
 	printf("-n <num>: Number of iterations\n");
+	printf("-f <rank>: Force all rpcs to go to the specified rank\n");
 	printf("-x: When set performs DMA_PUT to client instead of DMA_GET\n");
 	printf("-m: Mode. 1 - Synchronous, 2 - Asynchronous\n");
 	printf("-q: Shut servers down at the end of the run\n");
@@ -149,32 +156,33 @@ test_parse_args(int argc, char **argv)
 	test.tg_use_daos_agent_env = false;
 	test.tg_num_ctx = 1;
 	test.tg_do_put = false;
+	test.tg_force_rank = -1;
 
 	while (1) {
-		rc = getopt_long(argc, argv, "g:c:n:a:s:p:m:e:xq", long_options,
+		rc = getopt_long(argc, argv, "g:c:n:a:s:p:m:e:f:xq", long_options,
 				 &option_index);
 		if (rc == -1)
 			break;
+
 		switch (rc) {
 		case 0:
 			if (long_options[option_index].flag != 0)
 				break;
-		case 'e':
-			test.tg_num_ctx = atoi(optarg);
-			break;
-		case 'c':
-			test.tg_chunk_size_kb = atoi(optarg);
-			break;
 		case 'a':
 			test.tg_remote_group_name = optarg;
 			test.tg_should_attach = 1;
 			break;
+		case 'c':
+			test.tg_chunk_size_kb = atoi(optarg);
+			break;
+		case 'e':
+			test.tg_num_ctx = atoi(optarg);
+			break;
+		case 'f':
+			test.tg_force_rank = atoi(optarg);
+			break;
 		case 'g':
 			test.tg_local_group_name =  optarg;
-			break;
-		case 's':
-			test.tg_save_cfg = true;
-			test.tg_cfg_path = optarg;
 			break;
 		case 'm':
 			test.tg_test_mode = atoi(optarg);
@@ -182,11 +190,15 @@ test_parse_args(int argc, char **argv)
 		case 'n':
 			test.tg_num_iterations = atoi(optarg);
 			break;
-		case 'x':
-			test.tg_do_put = true;
-			break;
 		case 'q':
 			test.tg_do_shutdown = true;
+			break;
+		case 's':
+			test.tg_save_cfg = true;
+			test.tg_cfg_path = optarg;
+			break;
+		case 'x':
+			test.tg_do_put = true;
 			break;
 		case '?':
 		default:


### PR DESCRIPTION
Cleanup and coverity fixes for a multi-send client/server.
Added an option to force RPCs to be forced to a fixed target.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
