### PR TITLE
DAOS-11633 doc: fix hrefs to DAOS 2.0 docs

### DIFF
--- a/docs/testing/ior.md
+++ b/docs/testing/ior.md
@@ -6,7 +6,7 @@ IOR processes on the client nodes. For this purpose, any MPI implementation
 can be used. IOR also has an MPI-IO backend, and in order to use this
 MPI-IO backend with DAOS, an MPI stack that includes the DAOS ROMIO backend
 has to be used to build and run IOR.
-Refer to [MPI-IO Support](https://docs.daos.io/v2.0/user/mpi-io/) for details.
+Refer to [MPI-IO Support](../user/mpi-io/) for details.
 
 In addition to the default POSIX API, IOR also natively supports the
 DFS backend that directly uses DAOS File System (DFS) I/O calls instead
@@ -18,7 +18,7 @@ The `mdtest` tool to benchmark metadata performance is included in the
 same repository as the IOR tool.
 Like `IOR`, it is also an MPI-parallel application.
 
-The [Performance Tuning](https://docs.daos.io/v2.0/admin/performance_tuning/#benchmarking-daos)
+The [Performance Tuning](../admin/performance_tuning/#benchmarking-daos)
 section of the Administration Guide contains further information on IOR and mdtest.
 
 ## Build ior and mdtest
@@ -39,7 +39,7 @@ $ make install
 This example uses the default IOR `API=POSIX`, and requires that the DAOS POSIX container
 is dfuse-mounted at `/tmp/daos_dfuse` on all client nodes. The per-task performance over a dfuse
 mount is limited. To obtain better performance, the POSIX API can be used in conjunction with the
-[IOIL](https://docs.daos.io/v2.0/user/filesystem/#interception-library) interception library.
+[IOIL](../user/filesystem/#interception-library) interception library.
 For best performance IOR can be run with `API=DFS`, passing in the DAOS pool and container
 information (`ior -a DFS --dfs.pool=$DAOS_POOL --daos.cont=$DAOS_CONT ...`).
 


### PR DESCRIPTION
fix hrefs to DAOS 2.0 docs

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>
