### PR TITLE
DAOS-11764 build: Enable debuginfo sub-packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -252,7 +252,7 @@ pipeline {
                     env.COMMIT_MESSAGE.split('\n').each { line ->
                         String key, value
                         try {
-                            (key, value) = line.split(':')
+                            (key, value) = line.split(':', 2)
                             if (key.contains(' ')) {
                                 return
                             }

--- a/src/tests/ftest/harness/advanced.py
+++ b/src/tests/ftest/harness/advanced.py
@@ -162,18 +162,18 @@ class HarnessAdvancedTest(TestWithServers):
         failure_trigger = "00_trigger-launch-failure_00"
         failure_trigger_dir = os.path.join(self.base_test_dir, failure_trigger)
         failure_trigger_files = [
-            os.path.join(self.base_test_dir, f"{failure_trigger}_local.yaml"),
-            os.path.join(os.sep, "etc", "daos", f"daos_{failure_trigger}.yml"),
-            os.path.join(self.base_test_dir, f"{failure_trigger}.log"),
-            os.path.join(failure_trigger_dir, f"{failure_trigger}.log"),
-            os.path.join(os.sep, "tmp", f"daos_dump_{failure_trigger}.txt"),
-            os.path.join(self.tmp, f"valgrind_{failure_trigger}"),
+            os.path.join(self.base_test_dir, "{}_local.yaml".format(failure_trigger)),
+            os.path.join(os.sep, "etc", "daos", "daos_{}.yml".format(failure_trigger)),
+            os.path.join(self.base_test_dir, "{}.log".format(failure_trigger)),
+            os.path.join(failure_trigger_dir, "{}.log".format(failure_trigger)),
+            os.path.join(os.sep, "tmp", "daos_dump_{}.txt".format(failure_trigger)),
+            os.path.join(self.tmp, "valgrind_{}".format(failure_trigger)),
         ]
 
         self.log.debug("Creating %s", failure_trigger_dir)
         commands = [
-            f"sudo -n mkdir -p {failure_trigger_dir}",
-            f"sudo -n {get_chown_command(options='-R', file=failure_trigger_dir)}",
+            "sudo -n mkdir -p {}".format(failure_trigger_dir),
+            "sudo -n {}".format(get_chown_command(options='-R', file=failure_trigger_dir)),
         ]
 
         local_trigger_file = failure_trigger_files.pop(0)
@@ -182,23 +182,23 @@ class HarnessAdvancedTest(TestWithServers):
             with open(local_trigger_file, "w", encoding="utf-8") as local_trigger:
                 local_trigger.write("THIS IS JUST A TEST\n")
         except IOError as error:
-            self.fail(f"Error writing {local_trigger_file}: {str(error)}")
+            self.fail("Error writing {}: {}".format(local_trigger_file, str(error)))
 
         for command in commands:
             if not run_remote(self.log, host, command, timeout=20).passed:
-                self.fail(f"Error creating directory {failure_trigger_dir}")
+                self.fail("Error creating directory {}".format(failure_trigger_dir))
 
         for failure_trigger_file in failure_trigger_files:
             self.log.debug("Creating %s", failure_trigger_file)
             sudo = "" if failure_trigger_file.startswith(self.tmp) else "sudo -n "
             commands = [
-                f"{sudo}touch {failure_trigger_file}",
-                f"{sudo}{get_chown_command(options='-R', file=failure_trigger_file)}",
-                f"echo 'THIS IS JUST A TEST' > {failure_trigger_file}",
+                "{}touch {}".format(sudo, failure_trigger_file),
+                "{}{}".format(sudo, get_chown_command(options='-R', file=failure_trigger_file)),
+                "echo 'THIS IS JUST A TEST' > {}".format(failure_trigger_file),
             ]
             for command in commands:
                 if not run_remote(self.log, host, command, timeout=20).passed:
-                    self.fail(f"Error creating file {failure_trigger_file}")
+                    self.fail("Error creating file {}".format(failure_trigger_file))
 
     def test_launch_failures_hw(self):
         """Test to verify launch.py post processing error reporting.

--- a/src/tests/ftest/harness/basic.py
+++ b/src/tests/ftest/harness/basic.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 """
   (C) Copyright 2022 Intel Corporation.
 
@@ -112,25 +111,26 @@ class HarnessBasicTest(TestWithoutServers):
         cmocka_utils.run_cmocka_test(self, command)
 
         # Verify a generated cmocka xml file exists
-        expected = os.path.join(self.outputdir, f"{name}_cmocka_results.xml")
+        expected = os.path.join(self.outputdir, "{}_cmocka_results.xml".format(name))
         self.log.info("Verifying the existence of the generated cmocka file: %s", expected)
         if not os.path.isfile(expected):
-            self.fail(f"No {expected} file found")
+            self.fail("No {} file found".format(expected))
 
         # Verify the generated cmocka xml file contains the expected error
         self.log.info("Verifying contents of the generated cmocka file: %s", expected)
         with open(expected, "r", encoding="utf-8") as file_handle:
             actual_contents = file_handle.readlines()
-        error_message = f"Missing cmocka results for hostname in {self.outputdir}"
+        error_message = "Missing cmocka results for hostname in {}".format(self.outputdir)
         expected_lines = [
-            f"<testsuite errors=\"1\" failures=\"0\" name=\"{name}\" skipped=\"0\" tests=\"1\"",
-            f"<testcase classname=\"{name}\" name=\"{self.name}\"",
-            f"<error message=\"{error_message}\" type=\"Missing file\">"
+            "<testsuite errors=\"1\" failures=\"0\" name=\"{}\" skipped=\"0\" tests=\"1\"".format(
+                name),
+            "<testcase classname=\"{}\" name=\"{}\"".format(name, self.name),
+            "<error message=\"{}\" type=\"Missing file\">".format(error_message)
         ]
         for index, actual_line in enumerate(actual_contents[1:4]):
             self.log.debug("  expecting: %s", expected_lines[index])
             self.log.debug("  in actual: %s", actual_line[:-1].strip())
             if expected_lines[index] not in actual_line:
-                self.fail(f"Badly formed {expected} file")
+                self.fail("Badly formed {} file".format(expected))
 
         self.log.info("Test passed")

--- a/src/tests/ftest/process_core_files.py
+++ b/src/tests/ftest/process_core_files.py
@@ -200,9 +200,11 @@ class CoreFileProcessing():
         cmds = []
 
         # -debuginfo packages that don't get installed with debuginfo-install
-        for pkg in ['systemd', 'ndctl', 'mercury', 'hdf5', 'argobots', 'libfabric',
-                    'hdf5-vol-daos', 'hdf5-vol-daos-mpich', 'hdf5-vol-daos-mpich-tests',
-                    'hdf5-vol-daos-openmpi', 'hdf5-vol-daos-openmpi-tests', 'ior']:
+        for pkg in ['systemd', 'ndctl', 'mercury', 'hdf5',
+                    'libabt0' if "suse" in self.distro_info.name.lower() else "argobots",
+                    'libfabric', 'hdf5-vol-daos', 'hdf5-vol-daos-mpich',
+                    'hdf5-vol-daos-mpich-tests', 'hdf5-vol-daos-openmpi',
+                    'hdf5-vol-daos-openmpi-tests', 'ior']:
             debug_pkg = self.resolve_debuginfo(pkg)
             if debug_pkg and debug_pkg not in install_pkgs:
                 install_pkgs.append(debug_pkg)
@@ -317,7 +319,7 @@ class CoreFileProcessing():
         """
         package_info = None
         try:
-            # Eventually use python libraries for this rather than exec()ing out
+            # Eventually use python libraries for this rather than exec()ing out to rpm
             output = run_local(
                 self.log, ["rpm", "-q", "--qf", "%{name} %{version} %{release} %{epoch}", pkg],
                 check=False)

--- a/utils/githooks/pre-commit.d/20-flake.sh
+++ b/utils/githooks/pre-commit.d/20-flake.sh
@@ -36,14 +36,14 @@ else
         if command -v gh > /dev/null 2>&1
         then
                 # If there is no PR created yet then do not check anything.
-                if ! TARGET=$(gh pr view "$BRANCH" --json baseRefName -t "{{.baseRefName}}")
+                if ! TARGET=origin/$(gh pr view "$BRANCH" --json baseRefName -t "{{.baseRefName}}")
                 then
                        TARGET=HEAD
                 fi
         else
                 # With no 'gh' command installed then check against master.
                 echo "Install gh command to auto-detect target branch, assuming master."
-                TARGET=master
+                TARGET=origin/master
         fi
 
         if [ $TARGET = "HEAD" ]

--- a/utils/githooks/pre-commit.d/40-pylint.sh
+++ b/utils/githooks/pre-commit.d/40-pylint.sh
@@ -16,14 +16,14 @@ fi
 if command -v gh > /dev/null 2>&1
 then
         # If there is no PR created yet then do not check anything.
-        if ! TARGET=$(gh pr view "$BRANCH" --json baseRefName -t "{{.baseRefName}}")
+        if ! TARGET=origin/$(gh pr view "$BRANCH" --json baseRefName -t "{{.baseRefName}}")
         then
                 TARGET=HEAD
         fi
 else
         # With no 'gh' command installed then check against master.
         echo "Install gh command to auto-detect target branch, assuming master."
-        TARGET=master
+        TARGET=origin/master
 fi
 
 if [ $TARGET = "HEAD" ]

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.3.101
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -283,7 +283,7 @@ This is the package that bridges the difference between the MOFED openmpi
 
 %if (0%{?suse_version} > 0)
 %global __debug_package 1
-%global _debuginfo_subpackages 0
+%global _debuginfo_subpackages 1
 %debug_package
 %endif
 
@@ -528,9 +528,11 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Tue Oct 18 2022 Brian J. Murrell <brian.murrell@intel.com> 2.1.101-3
+- Set flag to build per-subpackage debuginfo packages for Leap 15
+
 * Thu Oct 6 2022 Michael MacDonald <mjmac.macdonald@intel.com> 2.3.101-2
 - Rename daos_admin -> daos_server_helper
-
 
 * Tue Sep 20 2022 Johann Lombardi <johann.lombardi@intel.com> 2.3.101-1
 - Bump version to 2.3.101


### PR DESCRIPTION
On Leap 15.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
