### PR TITLE
DAOS-11462 doc: fix typo (#10608)

### DIFF
--- a/docs/admin/hardware.md
+++ b/docs/admin/hardware.md
@@ -37,7 +37,7 @@ The DAOS data plane relies on [OFI libfabric](https://ofiwg.github.io/libfabric/
 and supports OFI providers for Ethernet/tcp and InfiniBand/verbs.
 Starting with a Technology Preview in DAOS 2.2, [UCX](https://www.openucx.org/)
 is also supported as an alternative network stack for DAOS.
-Refer to [UCX Fabric Support (DAOS 2.2 Technology Preview)](./uxd.md)
+Refer to [UCX Fabric Support (DAOS 2.2 Technology Preview)](./ucx.md)
 for details on setting up DAOS with UCX support.
 
 DAOS supports multiple network interfaces on the servers


### PR DESCRIPTION
fix ucx link typo

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>
