### PR TITLE
DAOS-11585: SMD changes to support additional tables to map meta/wal …

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -336,7 +336,7 @@ bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt, enum smd_dev_type s
 	/**
 	 * Query per-server metadata to get blobID for this pool:target
 	 */
-	rc = smd_pool_get_blob(uuid, xs_ctxt->bxc_tgt_id, SMD_DEV_TYPE_DATA, &blob_id);
+	rc = smd_pool_get_blob(uuid, xs_ctxt->bxc_tgt_id, st, &blob_id);
 	if (rc != 0) {
 		D_WARN("Blob for xs:%p, pool:"DF_UUID" doesn't exist\n",
 		       xs_ctxt, DP_UUID(uuid));
@@ -386,7 +386,7 @@ bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt, enum smd_dev_type s
 		D_DEBUG(DB_MGMT, "Successfully deleted blobID "DF_U64" for "
 			"pool:"DF_UUID" xs:%p\n", blob_id, DP_UUID(uuid),
 			xs_ctxt);
-		rc = smd_pool_del_tgt(uuid, xs_ctxt->bxc_tgt_id, SMD_DEV_TYPE_DATA);
+		rc = smd_pool_del_tgt(uuid, xs_ctxt->bxc_tgt_id, st);
 		if (rc)
 			D_ERROR("Failed to unassign blob:"DF_U64" from pool: "
 				""DF_UUID":%d. %d\n", blob_id, DP_UUID(uuid),

--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -572,7 +572,7 @@ __bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt,
 	}
 
 	ctxt->bic_xs_blobstore = bxb;
-	rc = bio_blob_open(ctxt, false, flags & BIO_MC_FL_SYSDB, open_blobid);
+	rc = bio_blob_open(ctxt, false, flags & BIO_MC_FL_SYSDB, st, open_blobid);
 	if (rc) {
 		D_FREE(ctxt);
 	} else {
@@ -702,7 +702,8 @@ get_super_cb(void *arg1, spdk_blob_id blobid, int bserrno)
 }
 
 int
-bio_blob_open(struct bio_io_context *ctxt, bool async, bool is_sys, spdk_blob_id open_blobid)
+bio_blob_open(struct bio_io_context *ctxt, bool async, bool is_sys, enum smd_dev_type st,
+		spdk_blob_id open_blobid)
 {
 	struct bio_xs_context		*xs_ctxt = ctxt->bic_xs_ctxt;
 	spdk_blob_id			 blob_id;
@@ -736,7 +737,7 @@ bio_blob_open(struct bio_io_context *ctxt, bool async, bool is_sys, spdk_blob_id
 		 */
 		if (!is_sys || !bio_is_meta_on_ssd_configured()) {
 			rc = smd_pool_get_blob(ctxt->bic_pool_id, xs_ctxt->bxc_tgt_id,
-					       SMD_DEV_TYPE_DATA, &blob_id);
+					       st, &blob_id);
 			if (rc != 0) {
 				D_ERROR("Failed to find blobID for xs:%p, pool:"DF_UUID", tgt:%d\n",
 					xs_ctxt, DP_UUID(ctxt->bic_pool_id), xs_ctxt->bxc_tgt_id);

--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -703,7 +703,7 @@ get_super_cb(void *arg1, spdk_blob_id blobid, int bserrno)
 
 int
 bio_blob_open(struct bio_io_context *ctxt, bool async, bool is_sys, enum smd_dev_type st,
-		spdk_blob_id open_blobid)
+	      spdk_blob_id open_blobid)
 {
 	struct bio_xs_context		*xs_ctxt = ctxt->bic_xs_ctxt;
 	spdk_blob_id			 blob_id;

--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -336,7 +336,7 @@ bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt, enum smd_dev_type s
 	/**
 	 * Query per-server metadata to get blobID for this pool:target
 	 */
-	rc = smd_pool_get_blob(uuid, xs_ctxt->bxc_tgt_id, &blob_id);
+	rc = smd_pool_get_blob(uuid, xs_ctxt->bxc_tgt_id, SMD_DEV_TYPE_DATA, &blob_id);
 	if (rc != 0) {
 		D_WARN("Blob for xs:%p, pool:"DF_UUID" doesn't exist\n",
 		       xs_ctxt, DP_UUID(uuid));
@@ -386,7 +386,7 @@ bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt, enum smd_dev_type s
 		D_DEBUG(DB_MGMT, "Successfully deleted blobID "DF_U64" for "
 			"pool:"DF_UUID" xs:%p\n", blob_id, DP_UUID(uuid),
 			xs_ctxt);
-		rc = smd_pool_del_tgt(uuid, xs_ctxt->bxc_tgt_id);
+		rc = smd_pool_del_tgt(uuid, xs_ctxt->bxc_tgt_id, SMD_DEV_TYPE_DATA);
 		if (rc)
 			D_ERROR("Failed to unassign blob:"DF_U64" from pool: "
 				""DF_UUID":%d. %d\n", blob_id, DP_UUID(uuid),
@@ -469,7 +469,7 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz,
 		 * Query per-server metadata to make sure the blob for this pool:target
 		 * hasn't been created yet.
 		 */
-		rc = smd_pool_get_blob(uuid, xs_ctxt->bxc_tgt_id, &blob_id1);
+		rc = smd_pool_get_blob(uuid, xs_ctxt->bxc_tgt_id, st, &blob_id1);
 		if (rc == 0) {
 			D_ERROR("Duplicated blob for xs:%p pool:"DF_UUID"\n",
 				xs_ctxt, DP_UUID(uuid));
@@ -507,7 +507,7 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz,
 
 		if (!(flags & BIO_MC_FL_SYSDB) || !bio_is_meta_on_ssd_configured()) {
 			rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id,
-					      blob_sz);
+					      st, blob_sz);
 		} else if (st == SMD_DEV_TYPE_META) {
 			ba->bca_inflights = 1;
 			spdk_bs_set_super(bbs->bb_bs, ba->bca_id,
@@ -736,7 +736,7 @@ bio_blob_open(struct bio_io_context *ctxt, bool async, bool is_sys, spdk_blob_id
 		 */
 		if (!is_sys || !bio_is_meta_on_ssd_configured()) {
 			rc = smd_pool_get_blob(ctxt->bic_pool_id, xs_ctxt->bxc_tgt_id,
-					       &blob_id);
+					       SMD_DEV_TYPE_DATA, &blob_id);
 			if (rc != 0) {
 				D_ERROR("Failed to find blobID for xs:%p, pool:"DF_UUID", tgt:%d\n",
 					xs_ctxt, DP_UUID(ctxt->bic_pool_id), xs_ctxt->bxc_tgt_id);
@@ -1214,7 +1214,7 @@ bio_write_blob_hdr(struct bio_io_context *ioctxt, struct bio_blob_hdr *bio_bh)
 	bio_bh->bbh_magic = BIO_BLOB_HDR_MAGIC;
 	bio_bh->bbh_vos_id = (uint32_t)ioctxt->bic_xs_ctxt->bxc_tgt_id;
 	/* Query per-server metadata to get blobID for this pool:target */
-	rc = smd_pool_get_blob(bio_bh->bbh_pool, bio_bh->bbh_vos_id, &blob_id);
+	rc = smd_pool_get_blob(bio_bh->bbh_pool, bio_bh->bbh_vos_id, SMD_DEV_TYPE_DATA, &blob_id);
 	if (rc) {
 		D_ERROR("Failed to find blobID for xs:%p, pool:"DF_UUID"\n",
 			ioctxt->bic_xs_ctxt, DP_UUID(bio_bh->bbh_pool));
@@ -1224,7 +1224,7 @@ bio_write_blob_hdr(struct bio_io_context *ioctxt, struct bio_blob_hdr *bio_bh)
 	bio_bh->bbh_blob_id = blob_id;
 
 	/* Query per-server metadata to get device id for xs */
-	rc = smd_dev_get_by_tgt(bio_bh->bbh_vos_id, &dev_info);
+	rc = smd_dev_get_by_tgt(bio_bh->bbh_vos_id, SMD_DEV_TYPE_DATA, &dev_info);
 	if (rc) {
 		D_ERROR("Not able to find device id/blobstore for tgt %d\n",
 			bio_bh->bbh_vos_id);

--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -226,13 +226,13 @@ create_old_blobs(struct bio_xs_context *xs_ctxt, struct smd_dev_info *old_info,
 	d_list_for_each_entry(pool_info, pool_list, spi_link) {
 		bool	found_tgt = false;
 
-		for (i = 0; i < pool_info->spi_tgt_cnt; i++) {
+		for (i = 0; i < pool_info->spi_tgt_cnt[SMD_DEV_TYPE_DATA]; i++) {
 			/* Skip the targets not assigned to old device */
-			if (!is_tgt_on_dev(old_info, pool_info->spi_tgts[i]))
+			if (!is_tgt_on_dev(old_info, pool_info->spi_tgts[SMD_DEV_TYPE_DATA][i]))
 				continue;
 
 			found_tgt = true;
-			rc = create_one_blob(bs, pool_info->spi_blob_sz,
+			rc = create_one_blob(bs, pool_info->spi_blob_sz[SMD_DEV_TYPE_DATA],
 					     &blob_id);
 			if (rc)
 				goto out;
@@ -249,7 +249,7 @@ create_old_blobs(struct bio_xs_context *xs_ctxt, struct smd_dev_info *old_info,
 			d_list_add_tail(&created->bi_link, blob_list);
 
 			/* Replace the blob id in pool info */
-			pool_info->spi_blobs[i] = blob_id;
+			pool_info->spi_blobs[SMD_DEV_TYPE_DATA][i] = blob_id;
 		}
 
 		/*

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -607,7 +607,8 @@ void bio_set_vendor_id(struct bio_blobstore *bb, char *bdev_name);
 
 /* bio_context.c */
 int bio_blob_close(struct bio_io_context *ctxt, bool async);
-int bio_blob_open(struct bio_io_context *ctxt, bool async, bool is_sys, spdk_blob_id open_blobid);
+int bio_blob_open(struct bio_io_context *ctxt, bool async, bool is_sys,
+		enum smd_dev_type st, spdk_blob_id open_blobid);
 struct bio_xs_blobstore *
 bio_xs_context2xs_blobstore(struct bio_xs_context *xs_ctxt, enum smd_dev_type st);
 

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -608,7 +608,7 @@ void bio_set_vendor_id(struct bio_blobstore *bb, char *bdev_name);
 /* bio_context.c */
 int bio_blob_close(struct bio_io_context *ctxt, bool async);
 int bio_blob_open(struct bio_io_context *ctxt, bool async, bool is_sys,
-		enum smd_dev_type st, spdk_blob_id open_blobid);
+		  enum smd_dev_type st, spdk_blob_id open_blobid);
 struct bio_xs_blobstore *
 bio_xs_context2xs_blobstore(struct bio_xs_context *xs_ctxt, enum smd_dev_type st);
 

--- a/src/bio/bio_recovery.c
+++ b/src/bio/bio_recovery.c
@@ -257,7 +257,7 @@ setup_blobstore(struct bio_xs_context *xs_ctxt, enum smd_dev_type st,
 			continue;
 
 		/* fix sysdb */
-		bio_blob_open(ioc, true, false, SPDK_BLOBID_INVALID);
+		bio_blob_open(ioc, true, false, st, SPDK_BLOBID_INVALID);
 	}
 
 	if (*closed_blobs)

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1125,7 +1125,7 @@ assign_device(int tgt_id, enum smd_dev_type st)
 	}
 
 	/* Update mapping for this target in NVMe device table */
-	rc = smd_dev_add_tgt(chosen_bdev->bb_uuid, tgt_id, SMD_DEV_TYPE_DATA);
+	rc = smd_dev_add_tgt(chosen_bdev->bb_uuid, tgt_id, st);
 	if (rc) {
 		D_ERROR("Failed to map dev "DF_UUID" to tgt %d. "DF_RC"\n",
 			DP_UUID(chosen_bdev->bb_uuid), tgt_id, DP_RC(rc));

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1125,7 +1125,7 @@ assign_device(int tgt_id, enum smd_dev_type st)
 	}
 
 	/* Update mapping for this target in NVMe device table */
-	rc = smd_dev_add_tgt(chosen_bdev->bb_uuid, tgt_id);
+	rc = smd_dev_add_tgt(chosen_bdev->bb_uuid, tgt_id, SMD_DEV_TYPE_DATA);
 	if (rc) {
 		D_ERROR("Failed to map dev "DF_UUID" to tgt %d. "DF_RC"\n",
 			DP_UUID(chosen_bdev->bb_uuid), tgt_id, DP_RC(rc));
@@ -1189,7 +1189,7 @@ find_xs_bio_dev(struct bio_xs_context *ctxt, int tgt_id, enum smd_dev_type st,
 	 */
 	if (tgt_id != BIO_SYS_TGT_ID && tgt_id != BIO_STANDALONE_TGT_ID) {
 retry:
-		rc = smd_dev_get_by_tgt(tgt_id, &dev_info);
+		rc = smd_dev_get_by_tgt(tgt_id, st, &dev_info);
 		if (rc == -DER_NONEXIST && !assigned) {
 			rc = assign_device(tgt_id, st);
 			if (rc)

--- a/src/bio/smd/smd_device.c
+++ b/src/bio/smd/smd_device.c
@@ -364,7 +364,7 @@ smd_dev_replace(uuid_t old_id, uuid_t new_id, d_list_t *pool_list)
 			if (rc == 0) {
 				uuid_copy(id.uuid, new_id);
 				rc = smd_db_upsert((char *)TABLE_TGTS[st], &tgt_id, sizeof(tgt_id),
-					   &id, sizeof(id));
+						   &id, sizeof(id));
 				if (rc) {
 					D_ERROR("Update target %d failed. "DF_RC"\n",
 						tgt_id, DP_RC(rc));

--- a/src/bio/smd/smd_device.c
+++ b/src/bio/smd/smd_device.c
@@ -27,7 +27,7 @@ smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type smd_type)
 	smd_db_lock();
 
 	/* Check if the target is already bound to a device */
-	rc = smd_db_fetch((char *)TABLE_TGTS[smd_type], &tgt_id, sizeof(tgt_id),
+	rc = smd_db_fetch(TABLE_TGTS[smd_type], &tgt_id, sizeof(tgt_id),
 			  &id_org, sizeof(id_org));
 	if (rc == 0) {
 		D_ERROR("Target %d is already bound to dev "DF_UUID"\n",
@@ -73,7 +73,7 @@ smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type smd_type)
 		goto out_tx;
 	}
 
-	rc = smd_db_upsert((char *)TABLE_TGTS[smd_type], &tgt_id, sizeof(tgt_id), &id, sizeof(id));
+	rc = smd_db_upsert(TABLE_TGTS[smd_type], &tgt_id, sizeof(tgt_id), &id, sizeof(id));
 	if (rc) {
 		D_ERROR("Update target %d failed: "DF_RC"\n",
 			tgt_id, DP_RC(rc));
@@ -206,7 +206,7 @@ smd_dev_get_by_tgt(uint32_t tgt_id, enum smd_dev_type smd_type, struct smd_dev_i
 	int		rc;
 
 	smd_db_lock();
-	rc = smd_db_fetch((char *)TABLE_TGTS[smd_type], &tgt_id, sizeof(tgt_id), &id, sizeof(id));
+	rc = smd_db_fetch(TABLE_TGTS[smd_type], &tgt_id, sizeof(tgt_id), &id, sizeof(id));
 	if (rc) {
 		D_CDEBUG(rc != -DER_NONEXIST, DLOG_ERR, DB_MGMT,
 			 "Fetch target %d failed. "DF_RC"\n", tgt_id,
@@ -363,7 +363,7 @@ smd_dev_replace(uuid_t old_id, uuid_t new_id, d_list_t *pool_list)
 			}
 			if (rc == 0) {
 				uuid_copy(id.uuid, new_id);
-				rc = smd_db_upsert((char *)TABLE_TGTS[st], &tgt_id, sizeof(tgt_id),
+				rc = smd_db_upsert(TABLE_TGTS[st], &tgt_id, sizeof(tgt_id),
 						   &id, sizeof(id));
 				if (rc) {
 					D_ERROR("Update target %d failed. "DF_RC"\n",

--- a/src/bio/smd/smd_device.c
+++ b/src/bio/smd/smd_device.c
@@ -16,7 +16,7 @@ struct smd_device {
 };
 
 int
-smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type smd_type)
+smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type st)
 {
 	struct smd_device	dev;
 	struct d_uuid		id_org;
@@ -27,7 +27,7 @@ smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type smd_type)
 	smd_db_lock();
 
 	/* Check if the target is already bound to a device */
-	rc = smd_db_fetch(TABLE_TGTS[smd_type], &tgt_id, sizeof(tgt_id),
+	rc = smd_db_fetch(TABLE_TGTS[st], &tgt_id, sizeof(tgt_id),
 			  &id_org, sizeof(id_org));
 	if (rc == 0) {
 		D_ERROR("Target %d is already bound to dev "DF_UUID"\n",
@@ -73,7 +73,7 @@ smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type smd_type)
 		goto out_tx;
 	}
 
-	rc = smd_db_upsert(TABLE_TGTS[smd_type], &tgt_id, sizeof(tgt_id), &id, sizeof(id));
+	rc = smd_db_upsert(TABLE_TGTS[st], &tgt_id, sizeof(tgt_id), &id, sizeof(id));
 	if (rc) {
 		D_ERROR("Update target %d failed: "DF_RC"\n",
 			tgt_id, DP_RC(rc));
@@ -87,7 +87,7 @@ out:
 }
 
 int
-smd_dev_del_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type smd_type)
+smd_dev_del_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type st)
 {
 	return -DER_NOSYS;
 }
@@ -200,13 +200,13 @@ smd_dev_get_by_id(uuid_t dev_id, struct smd_dev_info **dev_info)
 }
 
 int
-smd_dev_get_by_tgt(uint32_t tgt_id, enum smd_dev_type smd_type, struct smd_dev_info **dev_info)
+smd_dev_get_by_tgt(uint32_t tgt_id, enum smd_dev_type st, struct smd_dev_info **dev_info)
 {
 	struct d_uuid	id;
 	int		rc;
 
 	smd_db_lock();
-	rc = smd_db_fetch(TABLE_TGTS[smd_type], &tgt_id, sizeof(tgt_id), &id, sizeof(id));
+	rc = smd_db_fetch(TABLE_TGTS[st], &tgt_id, sizeof(tgt_id), &id, sizeof(id));
 	if (rc) {
 		D_CDEBUG(rc != -DER_NONEXIST, DLOG_ERR, DB_MGMT,
 			 "Fetch target %d failed. "DF_RC"\n", tgt_id,
@@ -349,28 +349,13 @@ smd_dev_replace(uuid_t old_id, uuid_t new_id, d_list_t *pool_list)
 	/* Replace old device ID with new device ID in target table */
 	for (i = 0; i < dev.sd_tgt_cnt; i++) {
 		uint32_t tgt_id = dev.sd_tgts[i];
-		enum smd_dev_type st;
 
-		for (st = SMD_DEV_TYPE_DATA; st < SMD_DEV_TYPE_MAX; st++) {
-			/* Old device bound to that target? */
-			uuid_copy(id.uuid, old_id);
-			rc = smd_db_fetch(TABLE_TGTS[st], &tgt_id, sizeof(tgt_id), &id, sizeof(id));
-			if (rc && !(rc == -DER_NONEXIST && st > SMD_DEV_TYPE_DATA)) {
-				D_CDEBUG(rc != -DER_NONEXIST, DLOG_ERR, DB_MGMT,
-					 "Fetch target %d failed. "DF_RC"\n", tgt_id,
-					 DP_RC(rc));
-				goto tx_end;
-			}
-			if (rc == 0) {
-				uuid_copy(id.uuid, new_id);
-				rc = smd_db_upsert(TABLE_TGTS[st], &tgt_id, sizeof(tgt_id),
-						   &id, sizeof(id));
-				if (rc) {
-					D_ERROR("Update target %d failed. "DF_RC"\n",
-						tgt_id, DP_RC(rc));
-					goto tx_end;
-				}
-			}
+		rc = smd_db_upsert(TABLE_TGTS[SMD_DEV_TYPE_DATA], &tgt_id, sizeof(tgt_id),
+				   &id, sizeof(id));
+		if (rc) {
+			D_ERROR("Update target %d failed. "DF_RC"\n",
+				tgt_id, DP_RC(rc));
+			goto tx_end;
 		}
 	}
 
@@ -379,8 +364,7 @@ smd_dev_replace(uuid_t old_id, uuid_t new_id, d_list_t *pool_list)
 
 	/* Replace old blob IDs with new blob IDs in pool map */
 	d_list_for_each_entry(pool_info, pool_list, spi_link) {
-		rc = smd_pool_replace_blobs_locked(pool_info, dev.sd_tgt_cnt,
-						   &dev.sd_tgts[0]);
+		rc = smd_pool_replace_blobs_locked(pool_info, dev.sd_tgt_cnt, &dev.sd_tgts[0]);
 		if (rc) {
 			D_ERROR("Update pool "DF_UUID" failed. "DF_RC"\n",
 				DP_UUID(pool_info->spi_id), DP_RC(rc));

--- a/src/bio/smd/smd_internal.h
+++ b/src/bio/smd/smd_internal.h
@@ -20,8 +20,10 @@
 #include <daos_srv/smd.h>
 
 #define TABLE_DEV	"device"
-#define TABLE_TGT	"target"
-#define TABLE_POOL	"pool"
+
+extern char *TABLE_TGTS[SMD_DEV_TYPE_MAX];
+
+extern char *TABLE_POOLS[SMD_DEV_TYPE_MAX];
 
 #define SMD_MAX_TGT_CNT		64
 

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -337,7 +337,7 @@ smd_pool_replace_blobs_locked(struct smd_pool_info *info, int tgt_cnt,
 	uuid_copy(id.uuid, info->spi_id);
 	for (st = SMD_DEV_TYPE_DATA; st < SMD_DEV_TYPE_MAX; st++) {
 		rc = smd_db_fetch(TABLE_POOLS[st], &id, sizeof(id),
-				&pools[st], sizeof(pools[st]));
+				  &pools[st], sizeof(pools[st]));
 		if (rc && !(rc == -DER_NONEXIST && st > SMD_DEV_TYPE_DATA)) {
 			D_ERROR("Fetch pool "DF_UUID" failed. %d\n",
 				DP_UUID(&id.uuid), rc);
@@ -372,7 +372,7 @@ smd_pool_replace_blobs_locked(struct smd_pool_info *info, int tgt_cnt,
 	for (st = SMD_DEV_TYPE_DATA; st < SMD_DEV_TYPE_MAX; st++) {
 		if (pools[st].sp_tgt_cnt) {
 			rc = smd_db_upsert(TABLE_POOLS[st], &id, sizeof(id),
-					&pools[st], sizeof(pools[st]));
+					   &pools[st], sizeof(pools[st]));
 			if (rc) {
 				D_ERROR("Replace blobs for pool "DF_UUID" failed. "DF_RC"\n",
 					DP_UUID(&id.uuid), DP_RC(rc));

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -325,7 +325,7 @@ smd_pool_list(d_list_t *pool_list, int *pools)
 /* smd_lock() and smd_tx_begin() are called by caller */
 int
 smd_pool_replace_blobs_locked(struct smd_pool_info *info, int tgt_cnt,
-				uint32_t *tgts)
+			      uint32_t *tgts)
 {
 	struct smd_pool		pool;
 	struct d_uuid		id;

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -376,6 +376,7 @@ smd_pool_replace_blobs_locked(struct smd_pool_info *info, int tgt_cnt,
 			if (rc) {
 				D_ERROR("Replace blobs for pool "DF_UUID" failed. "DF_RC"\n",
 					DP_UUID(&id.uuid), DP_RC(rc));
+				return rc;
 			}
 		}
 	}

--- a/src/bio/smd/tests/smd_ut.c
+++ b/src/bio/smd/tests/smd_ut.c
@@ -301,9 +301,8 @@ ut_device(void **state)
 		rc = smd_dev_get_by_tgt(i, st, &dev_info);
 		assert_rc_equal(rc, 0);
 		verify_dev(dev_info, dev_id2, 2);
+		smd_dev_free_info(dev_info);
 	}
-
-	smd_dev_free_info(dev_info);
 
 	D_INIT_LIST_HEAD(&dev_list);
 	rc = smd_dev_list(&dev_list, &dev_cnt);

--- a/src/bio/smd/tests/smd_ut.c
+++ b/src/bio/smd/tests/smd_ut.c
@@ -241,8 +241,9 @@ verify_dev(struct smd_dev_info *dev_info, uuid_t id, int dev_idx)
 			assert_int_equal(dev_info->sdi_tgts[i], i);
 	} else {
 		assert_int_equal(dev_info->sdi_state, SMD_DEV_FAULTY);
-		assert_int_equal(dev_info->sdi_tgt_cnt, 1);
-		assert_int_equal(dev_info->sdi_tgts[0], 3);
+		assert_int_equal(dev_info->sdi_tgt_cnt, 3);
+		for (i = 3; i < 6; i++)
+			assert_int_equal(dev_info->sdi_tgts[i - 3], i);
 	}
 }
 
@@ -252,13 +253,14 @@ ut_device(void **state)
 	struct smd_dev_info	*dev_info, *tmp;
 	d_list_t		 dev_list;
 	uuid_t			 id3;
+	enum smd_dev_type	 st;
 	int			 i, dev_cnt = 0, rc;
 
 	uuid_generate(dev_id1);
 	uuid_generate(dev_id2);
 	uuid_generate(id3);
 
-	/* Assigned dev1 to target 0, 1, 2, dev2 to target 3 */
+	/* Assigned dev1 to target 0, 1, 2, dev2 to target 3. 4. 5 */
 	rc = smd_dev_add_tgt(dev_id1, 0, SMD_DEV_TYPE_DATA);
 	assert_rc_equal(rc, 0);
 
@@ -273,8 +275,11 @@ ut_device(void **state)
 	rc = smd_dev_add_tgt(dev_id2, 1, SMD_DEV_TYPE_DATA);
 	assert_rc_equal(rc, -DER_EXIST);
 
-	rc = smd_dev_add_tgt(dev_id2, 3, SMD_DEV_TYPE_DATA);
-	assert_rc_equal(rc, 0);
+	for (i = 3; i < 6; i++) {
+		st = (i < 4) ? SMD_DEV_TYPE_DATA : SMD_DEV_TYPE_DATA + i - 3;
+		rc = smd_dev_add_tgt(dev_id2, i, st);
+		assert_rc_equal(rc, 0);
+	}
 
 	rc = smd_dev_set_state(dev_id2, SMD_DEV_FAULTY);
 	assert_rc_equal(rc, 0);
@@ -291,9 +296,12 @@ ut_device(void **state)
 	rc = smd_dev_get_by_tgt(4, SMD_DEV_TYPE_DATA, &dev_info);
 	assert_rc_equal(rc, -DER_NONEXIST);
 
-	rc = smd_dev_get_by_tgt(3, SMD_DEV_TYPE_DATA, &dev_info);
-	assert_rc_equal(rc, 0);
-	verify_dev(dev_info, dev_id2, 2);
+	for (i = 3; i < 6; i++) {
+		st = (i < 4) ? SMD_DEV_TYPE_DATA : SMD_DEV_TYPE_DATA + i - 3;
+		rc = smd_dev_get_by_tgt(i, st, &dev_info);
+		assert_rc_equal(rc, 0);
+		verify_dev(dev_info, dev_id2, 2);
+	}
 
 	smd_dev_free_info(dev_info);
 
@@ -318,14 +326,19 @@ ut_device(void **state)
 static void
 verify_pool(struct smd_pool_info *pool_info, uuid_t id, int shift)
 {
-	int	i;
+	enum smd_dev_type	st;
+	int			i, j;
 
 	assert_int_equal(uuid_compare(pool_info->spi_id, id), 0);
 	assert_int_equal(pool_info->spi_tgt_cnt[SMD_DEV_TYPE_DATA], 4);
+	assert_int_equal(pool_info->spi_tgt_cnt[SMD_DEV_TYPE_META], 1);
+	assert_int_equal(pool_info->spi_tgt_cnt[SMD_DEV_TYPE_WAL], 1);
 
-	for (i = 0; i < 4; i++) {
-		assert_int_equal(pool_info->spi_tgts[SMD_DEV_TYPE_DATA][i], i);
-		assert_int_equal(pool_info->spi_blobs[SMD_DEV_TYPE_DATA][i], i << shift);
+	for (i = 0; i < 6; i++) {
+		st = (i < 4) ? SMD_DEV_TYPE_DATA : SMD_DEV_TYPE_DATA + i - 3;
+		j = (i < 4) ? i : 0;
+		assert_int_equal(pool_info->spi_tgts[st][j], i);
+		assert_int_equal(pool_info->spi_blobs[st][j], i << shift);
 	}
 }
 
@@ -336,17 +349,19 @@ ut_pool(void **state)
 	uuid_t			 id1, id2, id3;
 	uint64_t		 blob_id;
 	d_list_t		 pool_list;
+	enum smd_dev_type	 st;
 	int			 i, pool_cnt = 0, rc;
 
 	uuid_generate(id1);
 	uuid_generate(id2);
 	uuid_generate(id3);
 
-	for (i = 0; i < 4; i++) {
-		rc = smd_pool_add_tgt(id1, i, i << 10, SMD_DEV_TYPE_DATA, 100);
+	for (i = 0; i < 6; i++) {
+		st = (i < 4) ? SMD_DEV_TYPE_DATA : SMD_DEV_TYPE_DATA + i - 3;
+		rc = smd_pool_add_tgt(id1, i, i << 10, st, 100);
 		assert_rc_equal(rc, 0);
 
-		rc = smd_pool_add_tgt(id2, i, i << 20, SMD_DEV_TYPE_DATA, 200);
+		rc = smd_pool_add_tgt(id2, i, i << 20, st, 200);
 		assert_rc_equal(rc, 0);
 	}
 
@@ -354,6 +369,18 @@ ut_pool(void **state)
 	assert_rc_equal(rc, -DER_EXIST);
 
 	rc = smd_pool_add_tgt(id1, 4, 4 << 10, SMD_DEV_TYPE_DATA, 200);
+	assert_rc_equal(rc, -DER_INVAL);
+
+	rc = smd_pool_add_tgt(id1, 4, 5000, SMD_DEV_TYPE_META, 100);
+	assert_rc_equal(rc, -DER_EXIST);
+
+	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_META, 200);
+	assert_rc_equal(rc, -DER_INVAL);
+
+	rc = smd_pool_add_tgt(id1, 5, 5000, SMD_DEV_TYPE_WAL, 100);
+	assert_rc_equal(rc, -DER_EXIST);
+
+	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_WAL, 200);
 	assert_rc_equal(rc, -DER_INVAL);
 
 	rc = smd_pool_get_info(id1, &pool_info);
@@ -365,18 +392,21 @@ ut_pool(void **state)
 	rc = smd_pool_get_info(id3, &pool_info);
 	assert_rc_equal(rc, -DER_NONEXIST);
 
-	for (i = 0; i < 4; i++) {
-		rc = smd_pool_get_blob(id1, i, SMD_DEV_TYPE_DATA, &blob_id);
+	for (i = 0; i < 6; i++) {
+		st = (i < 4) ? SMD_DEV_TYPE_DATA : SMD_DEV_TYPE_DATA + i - 3;
+		rc = smd_pool_get_blob(id1, i, st, &blob_id);
 		assert_rc_equal(rc, 0);
 		assert_int_equal(blob_id, i << 10);
 
-		rc = smd_pool_get_blob(id2, i, SMD_DEV_TYPE_DATA, &blob_id);
+		rc = smd_pool_get_blob(id2, i, st, &blob_id);
 		assert_rc_equal(rc, 0);
 		assert_int_equal(blob_id, i << 20);
 	}
 
-	rc = smd_pool_get_blob(id1, 5, SMD_DEV_TYPE_DATA, &blob_id);
-	assert_rc_equal(rc, -DER_NONEXIST);
+	for (st = SMD_DEV_TYPE_DATA; st < SMD_DEV_TYPE_MAX; st++) {
+		rc = smd_pool_get_blob(id1, 6, st, &blob_id);
+		assert_rc_equal(rc, -DER_NONEXIST);
+	}
 
 	D_INIT_LIST_HEAD(&pool_list);
 	rc = smd_pool_list(&pool_list, &pool_cnt);
@@ -395,14 +425,17 @@ ut_pool(void **state)
 		smd_pool_free_info(pool_info);
 	}
 
-	rc = smd_pool_del_tgt(id1, 5, SMD_DEV_TYPE_DATA);
-	assert_rc_equal(rc, -DER_NONEXIST);
+	for (st = SMD_DEV_TYPE_DATA; st < SMD_DEV_TYPE_MAX; st++) {
+		rc = smd_pool_del_tgt(id1, 6, st);
+		assert_rc_equal(rc, -DER_NONEXIST);
+	}
 
-	for (i = 0; i < 4; i++) {
-		rc = smd_pool_del_tgt(id1, i, SMD_DEV_TYPE_DATA);
+	for (i = 0; i < 6; i++) {
+		st = (i < 4) ? SMD_DEV_TYPE_DATA : SMD_DEV_TYPE_DATA + i - 3;
+		rc = smd_pool_del_tgt(id1, i, st);
 		assert_rc_equal(rc, 0);
 
-		rc = smd_pool_del_tgt(id2, i, SMD_DEV_TYPE_DATA);
+		rc = smd_pool_del_tgt(id2, i, st);
 		assert_rc_equal(rc, 0);
 	}
 

--- a/src/bio/smd/tests/smd_ut.c
+++ b/src/bio/smd/tests/smd_ut.c
@@ -19,7 +19,7 @@
 #include <daos/tests_lib.h>
 
 #define SMD_STORAGE_PATH	"/mnt/daos"
-#define DB_LIST_NR		(SMD_DEV_TYPE_MAX*2+1)
+#define DB_LIST_NR		(SMD_DEV_TYPE_MAX * 2 + 1)
 
 struct ut_db {
 	struct sys_db	ud_db;
@@ -46,9 +46,9 @@ db_name2list(struct sys_db *db, char *name)
 		return &ud->ud_lists[0];
 	for (st = SMD_DEV_TYPE_DATA; st < SMD_DEV_TYPE_MAX; st++) {
 		if (!strcmp(name, TABLE_TGTS[st]))
-			return &ud->ud_lists[st+1];
+			return &ud->ud_lists[st + 1];
 		if (!strcmp(name, TABLE_POOLS[st]))
-			return &ud->ud_lists[st+SMD_DEV_TYPE_MAX+1];
+			return &ud->ud_lists[st + SMD_DEV_TYPE_MAX + 1];
 	}
 	D_ASSERT(0);
 	return NULL;

--- a/src/include/daos_srv/smd.h
+++ b/src/include/daos_srv/smd.h
@@ -187,7 +187,7 @@ int smd_pool_get_info(uuid_t pool_id, struct smd_pool_info **pool_info);
  * \return			Zero on success, negative value on error
  */
 int smd_pool_get_blob(uuid_t pool_id, uint32_t tgt_id,
-		enum smd_dev_type smd_type, uint64_t *blob_id);
+		      enum smd_dev_type smd_type, uint64_t *blob_id);
 
 /**
  * Get pool info, caller is responsible to free list items

--- a/src/include/daos_srv/smd.h
+++ b/src/include/daos_srv/smd.h
@@ -40,10 +40,10 @@ struct smd_dev_info {
 struct smd_pool_info {
 	d_list_t	 spi_link;
 	uuid_t		 spi_id;
-	uint64_t	 spi_blob_sz;
-	uint32_t	 spi_tgt_cnt;
-	int		*spi_tgts;
-	uint64_t	*spi_blobs;
+	uint64_t	 spi_blob_sz[SMD_DEV_TYPE_MAX];
+	uint32_t	 spi_tgt_cnt[SMD_DEV_TYPE_MAX];
+	int		*spi_tgts[SMD_DEV_TYPE_MAX];
+	uint64_t	*spi_blobs[SMD_DEV_TYPE_MAX];
 };
 
 /**
@@ -63,22 +63,24 @@ void smd_fini(void);
 /**
  * Assign a NVMe device to a target (VOS xstream)
  *
- * \param [IN]	dev_id	NVMe device ID
- * \param [IN]	tgt_id	Target ID
+ * \param [IN]	dev_id		NVMe device ID
+ * \param [IN]	tgt_id		Target ID
+ * \param [IN]	smd_type	SMD type
  *
- * \return		Zero on success, negative value on error
+ * \return			Zero on success, negative value on error
  */
-int smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id);
+int smd_dev_add_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type smd_type);
 
 /**
  * Unassign a NVMe device from a target (VOS xstream)
  *
- * \param [IN]	dev_id	NVMe device ID
- * \param [IN]	tgt_id	Target ID
+ * \param [IN]	dev_id		NVMe device ID
+ * \param [IN]	tgt_id		Target ID
+ * \param [IN]	smd_type	SMD type
  *
- * \return		Zero on success, negative value on error
+ * \return			Zero on success, negative value on error
  */
-int smd_dev_del_tgt(uuid_t dev_id, uint32_t tgt_id);
+int smd_dev_del_tgt(uuid_t dev_id, uint32_t tgt_id, enum smd_dev_type smd_type);
 
 /**
  * Set a NVMe device state
@@ -104,11 +106,12 @@ int smd_dev_get_by_id(uuid_t dev_id, struct smd_dev_info **dev_info);
  * Get NVMe device info by target ID, caller is responsible to free @dev_info
  *
  * \param [IN]	tgt_id		Target ID
+ * \param [IN]	smd_type	SMD type
  * \param [OUT]	dev_info	Device info
  *
  * \return			Zero on success, negative value on error
  */
-int smd_dev_get_by_tgt(uint32_t tgt_id, struct smd_dev_info **dev_info);
+int smd_dev_get_by_tgt(uint32_t tgt_id, enum smd_dev_type smd_type, struct smd_dev_info **dev_info);
 
 /**
  * List all NVMe devices, caller is responsible to free list items
@@ -145,22 +148,24 @@ int smd_dev_replace(uuid_t old_id, uuid_t new_id, d_list_t *pool_list);
  * \param [IN]	pool_id		Pool UUID
  * \param [IN]	tgt_id		Target ID
  * \param [IN]	blob_id		Blob ID
+ * \param [IN]	smd_type	SMD type
  * \param [IN]	blob_sz		Blob size
  *
  * \return			Zero on success, negative value on error
  */
 int smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		     uint64_t blob_sz);
+		     enum smd_dev_type smd_type, uint64_t blob_sz);
 
 /**
  * Unassign a VOS pool target
  *
  * \param [IN]	pool_id		Pool UUID
  * \param [IN]	tgt_id		Target ID
+ * \param [IN]	smd_type	SMD type
  *
  * \return			Zero on success, negative value on error
  */
-int smd_pool_del_tgt(uuid_t pool_id, uint32_t tgt_id);
+int smd_pool_del_tgt(uuid_t pool_id, uint32_t tgt_id, enum smd_dev_type smd_type);
 
 /**
  * Get pool info, caller is responsible to free @pool_info
@@ -181,7 +186,8 @@ int smd_pool_get_info(uuid_t pool_id, struct smd_pool_info **pool_info);
  *
  * \return			Zero on success, negative value on error
  */
-int smd_pool_get_blob(uuid_t pool_id, uint32_t tgt_id, uint64_t *blob_id);
+int smd_pool_get_blob(uuid_t pool_id, uint32_t tgt_id,
+		enum smd_dev_type smd_type, uint64_t *blob_id);
 
 /**
  * Get pool info, caller is responsible to free list items
@@ -205,10 +211,14 @@ char *smd_dev_stat2str(enum smd_dev_state state);
 static inline void
 smd_pool_free_info(struct smd_pool_info *pool_info)
 {
-	if (pool_info->spi_blobs != NULL)
-		D_FREE(pool_info->spi_blobs);
-	if (pool_info->spi_tgts != NULL)
-		D_FREE(pool_info->spi_tgts);
+	enum smd_dev_type	st;
+
+	for (st = SMD_DEV_TYPE_DATA; st < SMD_DEV_TYPE_MAX; st++) {
+		if (pool_info->spi_blobs[st] != NULL)
+			D_FREE(pool_info->spi_blobs[st]);
+		if (pool_info->spi_tgts[st] != NULL)
+			D_FREE(pool_info->spi_tgts[st]);
+	}
 	D_FREE(pool_info);
 }
 

--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -186,7 +186,7 @@ ds_mgmt_bio_health_query(struct mgmt_bio_health *mbh, uuid_t dev_uuid,
 		tgt_id = dev_info->sdi_tgts[0];
 	} else {
 		tgt_id = atoi(tgt);
-		rc = smd_dev_get_by_tgt(tgt_id, &dev_info);
+		rc = smd_dev_get_by_tgt(tgt_id, SMD_DEV_TYPE_DATA, &dev_info);
 		if (rc != 0) {
 			D_ERROR("Tgt_id:%d not found\n", tgt_id);
 			return rc;
@@ -415,25 +415,25 @@ ds_mgmt_smd_list_pools(Ctl__SmdPoolResp *resp)
 		}
 		uuid_unparse_lower(pool_info->spi_id, resp->pools[i]->uuid);
 
-		resp->pools[i]->n_tgt_ids = pool_info->spi_tgt_cnt;
+		resp->pools[i]->n_tgt_ids = pool_info->spi_tgt_cnt[SMD_DEV_TYPE_DATA];
 		D_ALLOC(resp->pools[i]->tgt_ids,
-			sizeof(int) * pool_info->spi_tgt_cnt);
+			sizeof(int) * pool_info->spi_tgt_cnt[SMD_DEV_TYPE_DATA]);
 		if (resp->pools[i]->tgt_ids == NULL) {
 			rc = -DER_NOMEM;
 			break;
 		}
-		for (j = 0; j < pool_info->spi_tgt_cnt; j++)
-			resp->pools[i]->tgt_ids[j] = pool_info->spi_tgts[j];
+		for (j = 0; j < pool_info->spi_tgt_cnt[SMD_DEV_TYPE_DATA]; j++)
+			resp->pools[i]->tgt_ids[j] = pool_info->spi_tgts[SMD_DEV_TYPE_DATA][j];
 
-		resp->pools[i]->n_blobs = pool_info->spi_tgt_cnt;
+		resp->pools[i]->n_blobs = pool_info->spi_tgt_cnt[SMD_DEV_TYPE_DATA];
 		D_ALLOC(resp->pools[i]->blobs,
-			sizeof(uint64_t) * pool_info->spi_tgt_cnt);
+			sizeof(uint64_t) * pool_info->spi_tgt_cnt[SMD_DEV_TYPE_DATA]);
 		if (resp->pools[i]->blobs == NULL) {
 			rc = -DER_NOMEM;
 			break;
 		}
-		for (j = 0; j < pool_info->spi_tgt_cnt; j++)
-			resp->pools[i]->blobs[j] = pool_info->spi_blobs[j];
+		for (j = 0; j < pool_info->spi_tgt_cnt[SMD_DEV_TYPE_DATA]; j++)
+			resp->pools[i]->blobs[j] = pool_info->spi_blobs[SMD_DEV_TYPE_DATA][j];
 
 
 		d_list_del(&pool_info->spi_link);


### PR DESCRIPTION
…device and target information

Required-githooks: true

Signed-off-by: ylivis <yann.livis@hpe.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
