### PR TITLE
DAOS-10884 control: not mix dmg pool create --tier-ratio and --size=percentage

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -117,7 +117,13 @@ func (cmd *PoolCreateCmd) Execute(args []string) error {
 	switch {
 	case allFlagPattern.MatchString(cmd.Size):
 		if cmd.NumRanks > 0 {
-			return errIncompatFlags("size", "num-ranks")
+			return errIncompatFlags("size", "nranks")
+		}
+
+		// If the user use a tier-ratio equal to the default value, the error will not be
+		// raised.
+		if cmd.TierRatio != `6,94` {
+			return errIncompatFlags("size", "tier-ratio")
 		}
 
 		storageRatioString := allFlagPattern.FindStringSubmatch(cmd.Size)[1]
@@ -161,7 +167,7 @@ func (cmd *PoolCreateCmd) Execute(args []string) error {
 		}
 
 		if cmd.NumRanks > 0 && !cmd.RankList.Empty() {
-			return errIncompatFlags("num-ranks", "ranks")
+			return errIncompatFlags("nranks", "ranks")
 		}
 		req.NumRanks = cmd.NumRanks
 

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -189,7 +189,13 @@ func TestPoolCommands(t *testing.T) {
 			"Create pool with incompatible arguments (size nranks)",
 			"pool create --size 100% --nranks 16",
 			"",
-			errors.New("--size may not be mixed with --num-ranks"),
+			errors.New("--size may not be mixed with --nranks"),
+		},
+		{
+			"Create pool with incompatible arguments (size tier-ratio)",
+			"pool create --size 100% --tier-ratio 16",
+			"",
+			errors.New("--size may not be mixed with --tier-ratio"),
 		},
 		{
 			"Create pool with invalid arguments (too small ratio)",
@@ -1432,6 +1438,7 @@ func TestDmg_PoolCreateAllCmd(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
+			poolCreateCmd.TierRatio = `6,94`
 
 			err := poolCreateCmd.Execute(nil)
 

--- a/src/tests/ftest/erasurecode/mdtest_smoke.yaml
+++ b/src/tests/ftest/erasurecode/mdtest_smoke.yaml
@@ -39,7 +39,6 @@ server_config:
 pool:
   control_method: dmg
   size: 53%
-  tier_ratio: 50
 container:
   type: POSIX
   control_method: daos


### PR DESCRIPTION
# Description

The proposed patch return an error when the --tier-ratio option is used to create a pool with a ratio of the available storage.

# Limitations

With this patch, if the user gives the default value '6,94' to the --tier-ratio option, then the error will not be raised, and the given tier-ratio will be silently ignored as if the --tier-ratio option was not given.  From my investigation, it will not be so easy to deal with this limitation as the goflag package only define the value of the options and not if they were used.

# Actions

## Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

## Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
