### PR TITLE
 DAOS-11674 doc: document default EC cell size change in DAOS 2.2 (#10583) 

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -373,7 +373,7 @@ When setting this property, specifying the percentage symbol is optional:
 This property defines the default erasure code cell size inherited to DAOS
 containers. The EC cell size can be between 1kiB and 1GiB,
 although it should typically be set to a value between 32kiB and 1MiB.
-The default in DAOS 2.0 was 1MiB. The default in DAOS 2.2 is 64 kiB.
+The default in DAOS 2.0 was 1MiB. The default in DAOS 2.2 is 64kiB.
 When setting this property, the cell size can be specified in Bytes
 (as a number with no suffix), with a base-10 suffix like `k` or `MB`,
 or with a base-2 suffix like `ki` or `MiB`.

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -293,7 +293,7 @@ $ dmg pool get-prop tank
 Pool 8a05bf3a-a088-4a77-bb9f-df989fce7cc8 properties:
 Name                            Value
 ----                            -----
-EC cell size (ec_cell_sz)       1.0 MiB
+EC cell size (ec_cell_sz)       64 kiB
 Pool label (label)              tank
 Reclaim strategy (reclaim)      lazy
 Self-healing policy (self_heal) exclude
@@ -318,7 +318,7 @@ $ dmg pool get-prop tank2
 Pool 1f265216-5877-4302-ad29-aa0f90df3f86 properties:
 Name                            Value
 ----                            -----
-EC cell size (ec_cell_sz)       1.0 MiB
+EC cell size (ec_cell_sz)       64 kiB
 Pool label (label)              tank2
 Reclaim strategy (reclaim)      disabled
 Self-healing policy (self_heal) exclude
@@ -373,7 +373,7 @@ When setting this property, specifying the percentage symbol is optional:
 This property defines the default erasure code cell size inherited to DAOS
 containers. The EC cell size can be between 1kiB and 1GiB,
 although it should typically be set to a value between 32kiB and 1MiB.
-The default is 1MiB.
+The default in DAOS 2.0 was 1MiB. The default in DAOS 2.2 is 64 kiB.
 When setting this property, the cell size can be specified in Bytes
 (as a number with no suffix), with a base-10 suffix like `k` or `MB`,
 or with a base-2 suffix like `ki` or `MiB`.
@@ -384,6 +384,9 @@ This property defines the number of faulty replicas the pool service shall try
 to tolerate. Valid values are between 0 to 4, inclusive, with 2 being the
 default. If specified during a pool create operation, this property overrides
 any `--nsvc` options. This property cannot yet be changed afterward.
+
+See [Erasure Code](../user/container/#erasure-code) for details on
+erasure coding at the container level.
 
 ## Access Control Lists
 

--- a/docs/user/container.md
+++ b/docs/user/container.md
@@ -260,7 +260,7 @@ The table below summarizes the available container properties.
 | rf\_lvl                 | Yes             | Redundancy Level which is the level in the fault domain hierarchy to use for object placement|
 | health                  | No              | Current state of the container|
 | alloc\_oid              | No              | Maximum allocated object ID by container allocator|
-| ec\_cell                | Yes             | Erasure code cell size for erasure-coded objects|
+| ec\_cell\_sz            | Yes             | Erasure code cell size for erasure-coded objects|
 | cksum                   | Yes             | Checksum off, or algorithm to use (adler32, crc[16,32,64] or sha[1,256,512])|
 | cksum\_size             | Yes             | Checksum Size determining the maximum extent size that a checksum can cover|
 | srv\_cksum              | Yes             | Whether to verify checksum on the server before writing data (default: off)|
@@ -455,23 +455,50 @@ Server Checksumming   on
 
 ### Erasure Code
 
-DAOS erasure code implementation uses a fixed cell size that applies to all
-objects in the container. The cell size in DAOS is the size of each data and
-parity fragments (also called sometimes chunks). The cell size can be set at
-container creation time via the property:
+The DAOS erasure code implementation uses a fixed cell size that applies to all
+objects in the container.
+The cell size in DAOS is the size of a single data and parity fragment.
+By default, a container's `ec_cell_sz` property is inherited from the pool's
+default `ec_cell_sz`, which was 1MiB in DAOS 2.0 and has been reduced to
+64kiB in DAOS 2.2.  The container cell size can also be set at
+container creation time via the `--property` option:
 
 ```bash
-$ daos cont create tank --label mycont5 --type POSIX --properties rd_fac:1,cell_size:65536
+$ daos cont create tank --label mycont5 --type POSIX --properties rd_fac:1,cell_size:131072
   Container UUID : 90185799-0e22-4a0b-be9d-1a20900a35ee
   Container Label: mycont5
   Container Type : unknown
 Successfully created container 90185799-0e22-4a0b-be9d-1a20900a35ee
 ```
 
-This will force a cell size of 64KiB for all erasure-coded objects created in
-this container. If no cell size is specified, it will be inherited from the
-pool. The default cell size on the pool is set to 1MiB if not modified by the
-administrator at pool creation time.
+This will set an EC cell size of 128 KiB for all erasure-coded objects created in
+this container.
+
+DFS (POSIX) containers use a default `chunk_size` of 1MiB.
+This is the largest I/O request size that a DFS client will send to a storage target
+in a single request. The `chunk_size` can be displayed with the `daos cont query` command.
+When using Erasure Coding as the data protection mechanism, performance is best when
+the _stripe width_ of an EC stripe is either identical to the container's `chunk size`
+or an integer multiple of the _stripe width_ is equal to the container's `chunk_size`.
+For example:
+
+* With a DFS container chunk size of 1MiB, an `ec_cell_sz` of 128kiB is a perfect setting
+  for EC\_8P1GX and EC\_8P2GX: Eight EC cells of 128kiB exactly match the 1MiB chunk size.
+  It is also good for smaller erasure coding stripe widths like EC\_4P1GX and
+  EC\_4P2GX: Four EC cells of 128kiB are 512kiB, half of the 1MiB chunk size.
+  So a single DFS container chunk will fill two _full stripes_.
+
+* With a DFS container chunk size of 1MiB, an `ec_cell_sz` of 128kiB is **not** a good
+  fit for EC\_16P2GX and other more widely striped EC types: Sixteen EC cells of
+  128kiB are 2MiB, twice as big as the DFS container's chunk size.
+  This means that even the largest DFS client write operation results in a
+  _read-modify-write_ penalty, because it only fills **half** of an EC stripe.
+
+* With a DFS container chunk size of 1MiB, an `ec_cell_sz` of 64kiB is a perfect setting
+  for EC\_16P1GX and EC\_16P2GX: Sixteen EC cells of 64kiB exactly match the 1MiB chunk size.
+  Smaller EC stripe widths like EC\_8P2GX and EC\_4P1GX also work with this EC cell size,
+  which is the reason why 4kiB is the new DAOS 2.2 default for the `ec_cell_sz`.
+
 
 ### Checksum Background Scrubbing
 A pool ULT can be configured to scan the VOS trees to discover silent data

--- a/docs/user/container.md
+++ b/docs/user/container.md
@@ -148,7 +148,7 @@ Checksum Chunk Size   32 KiB
 Compression           off
 Deduplication         off
 Dedupe Threshold      4.0 KiB
-EC Cell Size          1.0 MiB
+EC Cell Size          64 kiB
 Encryption            off
 Group                 jlombard@
 Label                 mycont
@@ -190,7 +190,7 @@ Checksum Chunk Size   32 KiB
 Compression           off
 Deduplication         hash
 Dedupe Threshold      4.0 KiB
-EC Cell Size          1.0 MiB
+EC Cell Size          64kiB
 Encryption            off
 Group                 jlombard@
 Label                 mycont2
@@ -229,7 +229,7 @@ Checksum Chunk Size   32 KiB
 Compression           off
 Deduplication         hash
 Dedupe Threshold      4.0 KiB
-EC Cell Size          1.0 MiB
+EC Cell Size          64 kiB
 Encryption            off
 Group                 jlombard@
 Label                 mycont3
@@ -497,7 +497,7 @@ For example:
 * With a DFS container chunk size of 1MiB, an `ec_cell_sz` of 64kiB is a perfect setting
   for EC\_16P1GX and EC\_16P2GX: Sixteen EC cells of 64kiB exactly match the 1MiB chunk size.
   Smaller EC stripe widths like EC\_8P2GX and EC\_4P1GX also work with this EC cell size,
-  which is the reason why 4kiB is the new DAOS 2.2 default for the `ec_cell_sz`.
+  which is the reason why 64kiB is the new DAOS 2.2 default for the `ec_cell_sz`.
 
 
 ### Checksum Background Scrubbing


### PR DESCRIPTION
document that ec_cell_sz changed from 1MiB to 64kiB in DAOS 2.2
provide better guidance how to select the optimal EC cell size

Doc-only: true
Signed-off-by: Michael Hennecke <michael.hennecke@intel.com>