### PR TITLE
DAOS-11685 dtx: handle DTX abort by race

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1142,9 +1142,13 @@ dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
 	if (rc == 0) {
 		D_ASSERT(dth->dth_share_tbd_count == 0);
 
-		vos_dtx_cleanup(dth);
-		dtx_handle_reinit(dth);
-		rc = -DER_AGAIN;
+		if (dth->dth_aborted) {
+			rc = -DER_CANCELED;
+		} else {
+			vos_dtx_cleanup(dth, false);
+			dtx_handle_reinit(dth);
+			rc = -DER_AGAIN;
+		}
 	}
 
 	return rc;

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -195,9 +195,10 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint);
  * Cleanup local DTX when local modification failed.
  *
  * \param dth	[IN]	The DTX handle.
+ * \param unpin	[IN]	unpin the DTX entry or not.
  */
 void
-vos_dtx_cleanup(struct dtx_handle *dth);
+vos_dtx_cleanup(struct dtx_handle *dth, bool unpin);
 
 /**
  * Reset DTX related cached information in VOS.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1608,6 +1608,10 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 post:
 	rc = bio_iod_post(biod, rc);
 out:
+	/* The DTX has been aborted during long time bulk data transfer. */
+	if (unlikely(dth->dth_aborted))
+		rc = -DER_CANCELED;
+
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.
 	 */
@@ -4030,6 +4034,10 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			goto out;
 		}
 	}
+
+	/* The DTX has been aborted during long time bulk data transfer. */
+	if (unlikely(dth->dth_aborted))
+		D_GOTO(out, rc = -DER_CANCELED);
 
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.


### PR DESCRIPTION
master-commit: 4ae0e5e6301e4bec820f457fd5e82fc85a7a45c9

It is possible that some DTX on non-leader is blocked by long time bulk data transfer or DTX refresh, as to related RPC from DTX leader to non-leader for current operation get timeout, and then the DTX may be aborted by the DTX leader before current DTX complete on the non-leader locally. Under such case, the non-leader should break the operation for current DTX.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
