### PR TITLE
DAOS-11894 vos: Avoid segfault due to default evtree sort policy

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2131,6 +2131,7 @@ done:
 	return rc == 0 ? alt_rc : rc;
 }
 
+#define EVT_DIST_DEPTH_LIMIT 6
 static inline void
 evt_check_sort_policy(struct evt_context *tcx)
 {
@@ -2138,11 +2139,12 @@ evt_check_sort_policy(struct evt_context *tcx)
 	 *  segfault when the depth is larger than EVT_TRACE_MAX.  Rather than let it get too
 	 *  deep, let's detect cases where it starts getting deep and switch policies.
 	 */
-	if (unlikely(tcx->tc_depth > 5 &&
+	if (unlikely(tcx->tc_depth > EVT_DIST_DEPTH_LIMIT &&
 		     (tcx->tc_feats & EVT_FEATS_SUPPORTED) == EVT_FEAT_SORT_DIST)) {
 		tcx->tc_feats ^= EVT_FEAT_SORT_DIST | EVT_FEAT_SORT_DIST_EVEN;
 		tcx->tc_ops = evt_policies[2];
-		D_DEBUG(DB_IO, "evtree depth is greater than 10, switching sort policy\n");
+		D_DEBUG(DB_IO, "evtree depth is greater than %d, switching sort policy\n",
+			EVT_DIST_DEPTH_LIMIT);
 	}
 }
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -3378,7 +3378,7 @@ evt_sdist_split(struct evt_context *tcx, bool leaf, struct evt_node *nd_src,
 	bool			 cond;
 	int64_t			 dist;
 
-	if (tcx->tc_depth > 6)
+	if (unlikely(tcx->tc_depth > 6))
 		return evt_even_split(tcx, leaf, nd_src, nd_dst);
 
 	evt_mbr_read(&mbr, nd_src);

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2134,9 +2134,9 @@ done:
 static inline void
 evt_check_sort_policy(struct evt_context *tcx)
 {
-	/** EVT_FEAT_SORT_DIST can get inbalanced and, under certain conditions, can cause a
+	/** EVT_FEAT_SORT_DIST can get imbalanced and, under certain conditions, can cause a
 	 *  segfault when the depth is larger than EVT_TRACE_MAX.  Rather than let it get too
-	 *  deep, let's detect cases where it starts getting deep and swith policies.
+	 *  deep, let's detect cases where it starts getting deep and switch policies.
 	 */
 	if (unlikely(tcx->tc_depth > 5 &&
 		     (tcx->tc_feats & EVT_FEATS_SUPPORTED) == EVT_FEAT_SORT_DIST)) {

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -93,7 +93,7 @@ enum {
 	RT_OVERLAP_PARTIAL	= (1 << 6),
 };
 
-static struct evt_policy_ops evt_ssof_pol_ops;
+static struct evt_policy_ops  evt_soff_pol_ops;
 static struct evt_policy_ops evt_sdist_pol_ops;
 static struct evt_policy_ops evt_sdist_even_pol_ops;
 /**
@@ -101,10 +101,10 @@ static struct evt_policy_ops evt_sdist_even_pol_ops;
  * - Sorted by Start Offset(SSOF): it is the only policy for now.
  */
 static struct evt_policy_ops *evt_policies[] = {
-	&evt_ssof_pol_ops,
-	&evt_sdist_pol_ops,
-	&evt_sdist_even_pol_ops,
-	NULL,
+    &evt_soff_pol_ops,
+    &evt_sdist_pol_ops,
+    &evt_sdist_even_pol_ops,
+    NULL,
 };
 
 static void
@@ -2131,6 +2131,21 @@ done:
 	return rc == 0 ? alt_rc : rc;
 }
 
+static inline void
+evt_check_sort_policy(struct evt_context *tcx)
+{
+	/** EVT_FEAT_SORT_DIST can get inbalanced and, under certain conditions, can cause a
+	 *  segfault when the depth is larger than EVT_TRACE_MAX.  Rather than let it get too
+	 *  deep, let's detect cases where it starts getting deep and swith policies.
+	 */
+	if (unlikely(tcx->tc_depth > 5 &&
+		     (tcx->tc_feats & EVT_FEATS_SUPPORTED) == EVT_FEAT_SORT_DIST)) {
+		tcx->tc_feats ^= EVT_FEAT_SORT_DIST | EVT_FEAT_SORT_DIST_EVEN;
+		tcx->tc_ops = evt_policies[2];
+		D_DEBUG(DB_IO, "evtree depth is greater than 10, switching sort policy\n");
+	}
+}
+
 /**
  * Insert a versioned extent (rectangle) and its data offset into the tree.
  *
@@ -2152,6 +2167,8 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 	tcx = evt_hdl2tcx(toh);
 	if (tcx == NULL)
 		return -DER_NO_HDL;
+
+	evt_check_sort_policy(tcx);
 
 	if (tcx->tc_inob && entry->ei_inob && tcx->tc_inob != entry->ei_inob) {
 		D_ERROR("Variable record size not supported in evtree:"
@@ -3305,32 +3322,30 @@ move:
 
 /** Rectangle comparison for sorting */
 static int
-evt_ssof_cmp_rect(struct evt_context *tcx, const struct evt_node *nd,
-		  const struct evt_rect *rt1, const struct evt_rect *rt2)
+evt_soff_cmp_rect(struct evt_context *tcx, const struct evt_node *nd, const struct evt_rect *rt1,
+		  const struct evt_rect *rt2)
 {
 	return evt_rect_cmp(rt1, rt2);
 }
 
 static int
-evt_ssof_insert(struct evt_context *tcx, struct evt_node *nd,
-		umem_off_t in_off, const struct evt_entry_in *ent,
-		bool *changed, uint8_t **csum_bufp)
+evt_soff_insert(struct evt_context *tcx, struct evt_node *nd, umem_off_t in_off,
+		const struct evt_entry_in *ent, bool *changed, uint8_t **csum_bufp)
 {
-	return evt_common_insert(tcx, nd, in_off, ent, changed,
-				 evt_ssof_cmp_rect, csum_bufp);
+	return evt_common_insert(tcx, nd, in_off, ent, changed, evt_soff_cmp_rect, csum_bufp);
 }
 
 static int
-evt_ssof_adjust(struct evt_context *tcx, struct evt_node *nd, int at)
+evt_soff_adjust(struct evt_context *tcx, struct evt_node *nd, int at)
 {
-	return evt_common_adjust(tcx, nd, at, evt_ssof_cmp_rect);
+	return evt_common_adjust(tcx, nd, at, evt_soff_cmp_rect);
 }
 
-static struct evt_policy_ops evt_ssof_pol_ops = {
-	.po_insert		= evt_ssof_insert,
-	.po_adjust		= evt_ssof_adjust,
-	.po_split		= evt_even_split,
-	.po_rect_weight		= evt_common_rect_weight,
+static struct evt_policy_ops evt_soff_pol_ops = {
+    .po_insert      = evt_soff_insert,
+    .po_adjust      = evt_soff_adjust,
+    .po_split       = evt_even_split,
+    .po_rect_weight = evt_common_rect_weight,
 };
 
 /**
@@ -3364,7 +3379,7 @@ evt_sdist_cmp_rect(struct evt_context *tcx, const struct evt_node *nd,
 	if (dist1 > dist2)
 		return 1;
 
-	/* All else being equal, revert to ssof */
+	/* All else being equal, revert to soff */
 	return evt_rect_cmp(rt1, rt2);
 }
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2131,7 +2131,7 @@ done:
 	return rc == 0 ? alt_rc : rc;
 }
 
-#define EVT_DIST_DEPTH_LIMIT 6
+#define EVT_DIST_DEPTH_LIMIT 10
 static inline void
 evt_check_sort_policy(struct evt_context *tcx)
 {

--- a/src/vos/tests/evt_stress.py
+++ b/src/vos/tests/evt_stress.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Run evt_ctl with a specific pattern that causes a segfault with the default sort algorithm"""
+import os
+from os.path import join
+import json
+import argparse
+
+
+class EVTStress():
+    """Helper class for running the test"""
+    def __init__(self):
+        parser = argparse.ArgumentParser(description='Run evt_ctl with pattern from DAOS-11894')
+        parser.add_argument('--algo', default='dist', choices=['dist', 'dist_even', 'soff'])
+        self.args = parser.parse_args()
+
+        file_self = os.path.dirname(os.path.abspath(__file__))
+        json_file = None
+        while True:
+            new_file = join(file_self, '.build_vars.json')
+            if os.path.exists(new_file):
+                json_file = new_file
+                break
+            file_self = os.path.dirname(file_self)
+            if file_self == '/':
+                raise Exception('build file not found')
+        with open(json_file, 'r', encoding='utf-8') as ofh:
+            self._bc = json.load(ofh)
+
+    def __getitem__(self, key):
+        return self._bc[key]
+
+    def run_cmd(self):
+        """Run the configured command"""
+        algo = ""
+        if self.args.algo != "dist":
+            algo = f"-s {self.args.algo}"
+        test_name = f"\"evtree stress {self.args.algo}\""
+
+        cmd = f"{self['PREFIX']}/bin/evt_ctl --start-test {test_name} {algo} -C o:23"
+        for start in range(1, 707):
+            end = 1024
+            cmd += f" -a {start}-{end}@{start}"
+        cmd += " -b -2 -D"
+
+        os.system(cmd)
+
+
+def run():
+    """Run the stress test"""
+
+    conf = EVTStress()
+
+    conf.run_cmd()
+
+
+if __name__ == "__main__":
+    run()

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -117,6 +117,11 @@ if [ -d "/mnt/daos" ]; then
 
         rm -f "${AIO_DEV}"
         rm -f "${NVME_CONF}"
+
+        run_test src/vos/tests/evt_stress.py
+        run_test src/vos/tests/evt_stress.py --algo dist_even
+        run_test src/vos/tests/evt_stress.py --algo soff
+
     else
         if [ "$RUN_TEST_VALGRIND" = "memcheck" ]; then
             [ -z "$VALGRIND_SUPP" ] &&


### PR DESCRIPTION
Modify default sort to use even split if the tree is too deep.  Otherwise, some I/O patterns can cause a segfault
due to the depth exceeding the EVT_TRACE_MAX

Rename ssof to soff for consistency

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
