### PR TITLE
DAOS-11422 dfs: add support for mtime and ctime on directory objects

### DIFF
--- a/src/client/api/object.c
+++ b/src/client/api/object.c
@@ -138,6 +138,20 @@ daos_obj_query_key(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 }
 
 int
+daos_obj_query_max_epoch(daos_handle_t oh, daos_handle_t th, daos_epoch_t *epoch, daos_event_t *ev)
+{
+	tse_task_t	*task;
+	int		rc;
+
+	*epoch = 0;
+	rc = dc_obj_query_max_epoch_task_create(oh, th, epoch, ev, NULL, &task);
+	if (rc)
+		return rc;
+
+	return dc_task_schedule(task, true);
+}
+
+int
 daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 	       daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
 	       d_sg_list_t *sgls, daos_iom_t *maps, daos_event_t *ev)

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -949,12 +949,87 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 
 	switch (entry.mode & S_IFMT) {
 	case S_IFDIR:
+	{
+		daos_handle_t	dir_oh;
+		daos_epoch_t	ep;
+
 		size = sizeof(entry);
-		stbuf->st_mtim.tv_sec = entry.mtime;
-		stbuf->st_mtim.tv_nsec = entry.mtime_nano;
-		stbuf->st_ctim.tv_sec = entry.ctime;
-		stbuf->st_ctim.tv_nsec = entry.ctime_nano;
+
+		/** check if dir is empty */
+		rc = daos_obj_open(dfs->coh, entry.oid, DAOS_OO_RO, &dir_oh, NULL);
+		if (rc) {
+			D_ERROR("daos_obj_open() Failed, "DF_RC"\n", DP_RC(rc));
+			return daos_der2errno(rc);
+		}
+
+		rc = daos_obj_query_max_epoch(dir_oh, th, &ep, NULL);
+		if (rc) {
+			daos_obj_close(oh, NULL);
+			return daos_der2errno(rc);
+		}
+
+		rc = daos_obj_close(dir_oh, NULL);
+		if (rc)
+			return daos_der2errno(rc);
+
+		/** object was updated since creation */
+		if (ep) {
+			struct timespec obj_mtime, entry_mtime;
+
+			rc = crt_hlc2timespec(ep, &obj_mtime);
+			if (rc) {
+				D_ERROR("crt_hlc2timespec() failed "DF_RC"\n", DP_RC(rc));
+				return daos_der2errno(rc);
+			}
+
+			if (obj_hlc)
+				*obj_hlc = ep;
+
+			rc = crt_hlc2timespec(entry.obj_hlc, &entry_mtime);
+			if (rc) {
+				D_ERROR("crt_hlc2timespec() failed "DF_RC"\n", DP_RC(rc));
+				return daos_der2errno(rc);
+			}
+
+			/** ctime should be the greater of the entry and object hlc */
+			stbuf->st_ctim.tv_sec = entry.ctime;
+			stbuf->st_ctim.tv_nsec = entry.ctime_nano;
+			if (tspec_gt(obj_mtime, stbuf->st_ctim)) {
+				stbuf->st_ctim.tv_sec = obj_mtime.tv_sec;
+				stbuf->st_ctim.tv_nsec = obj_mtime.tv_nsec;
+			}
+
+			/*
+			 * mtime is not like ctime since user can update it manually. So returning
+			 * the larger mtime like ctime would not work since the user can manually
+			 * set the mtime to the past.
+			 */
+			if (obj_mtime.tv_sec == entry_mtime.tv_sec &&
+			    obj_mtime.tv_nsec == entry_mtime.tv_nsec) {
+				/*
+				 * internal mtime entry set through a user set mtime and is up to
+				 * date with the object epoch time, which means that the user set
+				 * mtime in the inode entry is the correct value to return.
+				 */
+				stbuf->st_mtim.tv_sec = entry.mtime;
+				stbuf->st_mtim.tv_nsec = entry.mtime_nano;
+			} else {
+				/*
+				 * the user has not updated the mtime explicitly or the object
+				 * itself was modified after an explicit mtime update.
+				 */
+				stbuf->st_mtim.tv_sec = obj_mtime.tv_sec;
+				stbuf->st_mtim.tv_nsec = obj_mtime.tv_nsec;
+			}
+		} else {
+			/** the dir has not been touched, so the entry times are accurate */
+			stbuf->st_ctim.tv_sec = entry.ctime;
+			stbuf->st_ctim.tv_nsec = entry.ctime_nano;
+			stbuf->st_mtim.tv_sec = entry.mtime;
+			stbuf->st_mtim.tv_nsec = entry.mtime_nano;
+		}
 		break;
+	}
 	case S_IFREG:
 	{
 		daos_array_stbuf_t	array_stbuf = {0};
@@ -1023,7 +1098,8 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 				stbuf->st_ctim.tv_nsec = obj_mtime.tv_nsec;
 			}
 
-			/** mtime is not like ctime since user can update it manually. So returning
+			/*
+			 * mtime is not like ctime since user can update it manually. So returning
 			 * the larger mtime like ctime would not work since the user can manually
 			 * set the mtime to the past.
 			 */
@@ -2886,8 +2962,7 @@ dfs_set_prefix(dfs_t *dfs, const char *prefix)
 		return 0;
 	}
 
-	if (prefix[0] != '/' ||
-	    strnlen(prefix, DFS_MAX_PATH) > DFS_MAX_PATH - 1)
+	if (prefix[0] != '/' || strnlen(prefix, DFS_MAX_PATH) > DFS_MAX_PATH - 1)
 		return EINVAL;
 
 	D_STRNDUP(dfs->prefix, prefix, DFS_MAX_PATH - 1);

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -200,6 +200,9 @@ dc_obj_query_key_task_create(daos_handle_t oh, daos_handle_t th,
 			     daos_recx_t *recx, daos_event_t *ev,
 			     tse_sched_t *tse, tse_task_t **task);
 int
+dc_obj_query_max_epoch_task_create(daos_handle_t oh, daos_handle_t th, daos_epoch_t *epoch,
+				   daos_event_t *ev, tse_sched_t *tse, tse_task_t **task);
+int
 dc_obj_sync_task_create(daos_handle_t oh, daos_epoch_t epoch,
 			daos_epoch_t **epochs_p, int *nr, daos_event_t *ev,
 			tse_sched_t *tse, tse_task_t **task);

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -1020,6 +1020,26 @@ daos_obj_query_key(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 		   daos_event_t *ev);
 
 /**
+ * Retrieve the max epoch where the object has been updated.
+ *
+ * \param[in]	oh	Object open handle.
+ * \param[in]	th	Optional transaction handle to query at.
+ *			Use DAOS_TX_NONE for an independent transaction.
+ * \param[out]	epoch	max epoch at which an update to the object happened.
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			Function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_NO_HDL	Invalid object open handle
+ *			-DER_INVAL	Invalid parameter
+ *			-DER_UNREACH	Network is unreachable
+ */
+int
+daos_obj_query_max_epoch(daos_handle_t oh, daos_handle_t th, daos_epoch_t *epoch, daos_event_t *ev);
+
+/**
  * Verify object data consistency against the specified epoch.
  *
  * \param[in]	coh	Container open handle.

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2131,6 +2131,10 @@ static int
 check_query_flags(daos_obj_id_t oid, uint32_t flags, daos_key_t *dkey,
 		  daos_key_t *akey, daos_recx_t *recx)
 {
+	/** just query max epoch */
+	if (flags == 0)
+		return 0;
+
 	if (!(flags & (DAOS_GET_DKEY | DAOS_GET_AKEY | DAOS_GET_RECX))) {
 		D_ERROR("Key type or recx not specified in flags.\n");
 		return -DER_INVAL;
@@ -6401,7 +6405,8 @@ dc_obj_query_key(tse_task_t *api_task)
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 
-	D_ASSERTF(api_args->dkey != NULL, "dkey should not be NULL\n");
+	if (api_args->flags)
+		D_ASSERTF(api_args->dkey != NULL, "dkey should not be NULL\n");
 	obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, api_args->dkey);
 	if (api_args->flags & DAOS_GET_DKEY) {
 		grp_idx = 0;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -2154,6 +2154,9 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 
 	D_RWLOCK_WRLOCK(&cb_args->obj->cob_lock);
 
+	if (flags == 0)
+		goto set_max_epoch;
+
 	bool check = true;
 	bool changed = false;
 	bool first = (cb_args->dkey->iov_len == 0);
@@ -2263,8 +2266,7 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 	if ((int)tgt_ep.ep_rank < 0)
 		D_GOTO(out, rc = (int)tgt_ep.ep_rank);
 
-	D_DEBUG(DB_IO, "OBJ_QUERY_KEY_RPC, rank=%d tag=%d.\n",
-		tgt_ep.ep_rank, tgt_ep.ep_tag);
+	D_DEBUG(DB_IO, "OBJ_QUERY_KEY_RPC, rank=%d tag=%d.\n", tgt_ep.ep_rank, tgt_ep.ep_tag);
 
 	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, DAOS_OBJ_RPC_QUERY_KEY, &req);
 	if (rc != 0)

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -149,6 +149,30 @@ dc_obj_query_key_task_create(daos_handle_t oh, daos_handle_t th,
 	args->akey	= akey;
 	args->recx	= recx;
 	args->max_epoch = NULL;
+
+	return 0;
+}
+
+int
+dc_obj_query_max_epoch_task_create(daos_handle_t oh, daos_handle_t th, daos_epoch_t *epoch,
+				   daos_event_t *ev, tse_sched_t *tse, tse_task_t **task)
+{
+	daos_obj_query_key_t	*args;
+	int			 rc;
+
+	DAOS_API_ARG_ASSERT(*args, OBJ_QUERY_KEY);
+	rc = dc_task_create(dc_obj_query_key, tse, ev, task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(*task);
+	args->oh	= oh;
+	args->th	= th;
+	args->flags	= 0;
+	args->dkey	= NULL;
+	args->akey	= NULL;
+	args->recx	= NULL;
+	args->max_epoch = epoch;
 
 	return 0;
 }

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1218,49 +1218,28 @@ dfs_test_mt_connect(void **state)
 }
 
 static void
-dfs_test_chown(void **state)
+run_chown_tests(dfs_obj_t *obj, char *name, int mode)
 {
-	test_arg_t	*arg = *state;
-	dfs_obj_t	*obj, *sym;
-	char		*filename = "chown_test";
-	char		*symname = "sym_chown_test";
+	dfs_obj_t	*sym;
+	char		*s = "sym_chown_test";
 	struct stat	stbuf;
-	struct stat	stbuf2;
 	uid_t		orig_uid;
 	gid_t		orig_gid;
-	int		rc;
-	char		*filename_file1 = "open_stat1";
-	char		*filename_file2 = "open_stat2";
-	mode_t		create_mode = S_IWUSR | S_IRUSR;
-	int		create_flags = O_RDWR | O_CREAT | O_EXCL;
 	struct timespec	prev_ts;
+	int		rc;
 
-	if (arg->myrank != 0)
-		return;
-
-	rc = dfs_lookup(dfs_mt, "/", O_RDWR, &obj, NULL, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
-	assert_int_equal(stbuf.st_uid, geteuid());
-	assert_int_equal(stbuf.st_gid, getegid());
-	rc = dfs_release(obj);
-	assert_int_equal(rc, 0);
-
-	rc = dfs_open(dfs_mt, NULL, filename, S_IFREG | S_IWUSR | S_IRUSR | S_IXUSR,
-		      O_RDWR | O_CREAT | O_EXCL, 0, 0, NULL, &obj);
-	assert_int_equal(rc, 0);
-
-	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
-	assert_int_equal(rc, 0);
-	prev_ts.tv_sec = stbuf.st_mtim.tv_sec;
-	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
+	prev_ts.tv_sec = stbuf.st_ctim.tv_sec;
+	prev_ts.tv_nsec = stbuf.st_ctim.tv_nsec;
 
 	orig_uid = stbuf.st_uid;
 	orig_gid = stbuf.st_gid;
 
 	/** should succeed but not change anything */
-	rc = dfs_chown(dfs_mt, NULL, filename, -1, -1, 0);
+	rc = dfs_chown(dfs_mt, NULL, name, -1, -1, 0);
 	assert_int_equal(rc, 0);
-	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, orig_uid);
 	assert_int_equal(stbuf.st_gid, orig_gid);
@@ -1269,9 +1248,9 @@ dfs_test_chown(void **state)
 	assert_int_equal(prev_ts.tv_nsec, stbuf.st_ctim.tv_nsec);
 
 	/** set uid to 0 */
-	rc = dfs_chown(dfs_mt, NULL, filename, 0, -1, 0);
+	rc = dfs_chown(dfs_mt, NULL, name, 0, -1, 0);
 	assert_int_equal(rc, 0);
-	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 0);
 	assert_int_equal(stbuf.st_gid, orig_gid);
@@ -1280,9 +1259,9 @@ dfs_test_chown(void **state)
 	prev_ts.tv_nsec = stbuf.st_ctim.tv_nsec;
 
 	/** set gid to 0 */
-	rc = dfs_chown(dfs_mt, NULL, filename, -1, 0, 0);
+	rc = dfs_chown(dfs_mt, NULL, name, -1, 0, 0);
 	assert_int_equal(rc, 0);
-	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 0);
 	assert_int_equal(stbuf.st_gid, 0);
@@ -1298,7 +1277,7 @@ dfs_test_chown(void **state)
 	assert_int_equal(rc, 0);
 	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 	memset(&stbuf, 0, sizeof(stbuf));
-	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 3);
 	assert_int_equal(stbuf.st_gid, 4);
@@ -1307,9 +1286,9 @@ dfs_test_chown(void **state)
 	prev_ts.tv_nsec = stbuf.st_ctim.tv_nsec;
 
 	/** set uid to 1, gid to 2 */
-	rc = dfs_chown(dfs_mt, NULL, filename, 1, 2, 0);
+	rc = dfs_chown(dfs_mt, NULL, name, 1, 2, 0);
 	assert_int_equal(rc, 0);
-	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 1);
 	assert_int_equal(stbuf.st_gid, 2);
@@ -1317,43 +1296,92 @@ dfs_test_chown(void **state)
 	prev_ts.tv_sec = stbuf.st_ctim.tv_sec;
 	prev_ts.tv_nsec = stbuf.st_ctim.tv_nsec;
 
-	/** create a symlink to that file */
-	rc = dfs_open(dfs_mt, NULL, symname, S_IFLNK | S_IWUSR | S_IRUSR,
-		      O_RDWR | O_CREAT | O_EXCL, 0, 0, filename, &sym);
+	/** create a symlink to that file/dir */
+	rc = dfs_open(dfs_mt, NULL, s, S_IFLNK | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT | O_EXCL, 0, 0,
+		      name, &sym);
 	assert_int_equal(rc, 0);
 
-	/** chown of file through symlink */
-	rc = dfs_chown(dfs_mt, NULL, symname, 3, 4, 0);
+	/** chown of file/dir through symlink */
+	rc = dfs_chown(dfs_mt, NULL, s, 3, 4, 0);
 	assert_int_equal(rc, 0);
-	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 3);
 	assert_int_equal(stbuf.st_gid, 4);
 
 	/** chown of symlink itself */
-	rc = dfs_chown(dfs_mt, NULL, symname, 5, 6, O_NOFOLLOW);
+	rc = dfs_chown(dfs_mt, NULL, s, 5, 6, O_NOFOLLOW);
 	assert_int_equal(rc, 0);
-	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 3);
 	assert_int_equal(stbuf.st_gid, 4);
-	rc = dfs_stat(dfs_mt, NULL, symname, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, s, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_uid, 5);
 	assert_int_equal(stbuf.st_gid, 6);
 
-	rc = dfs_release(obj);
-	assert_int_equal(rc, 0);
 	rc = dfs_release(sym);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_mt, NULL, s, 0, NULL);
+	assert_int_equal(rc, 0);
+}
+
+static void
+dfs_test_chown(void **state)
+{
+	test_arg_t	*arg = *state;
+	dfs_obj_t	*file, *dir;
+	char		*f = "chown_test_f";
+	char		*d = "chown_test_d";
+	struct stat	stbuf;
+	struct stat	stbuf2;
+	char		*filename_file1 = "open_stat1";
+	char		*filename_file2 = "open_stat2";
+	mode_t		create_mode = S_IWUSR | S_IRUSR;
+	int		create_flags = O_RDWR | O_CREAT | O_EXCL;
+	int		rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	rc = dfs_lookup(dfs_mt, "/", O_RDWR, &dir, NULL, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(stbuf.st_uid, geteuid());
+	assert_int_equal(stbuf.st_gid, getegid());
+	rc = dfs_release(dir);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_open(dfs_mt, NULL, f, S_IFREG | S_IWUSR | S_IRUSR | S_IXUSR, create_flags,
+		      0, 0, NULL, &file);
+	assert_int_equal(rc, 0);
+	rc = dfs_open(dfs_mt, NULL, d, S_IFDIR | S_IWUSR | S_IRUSR | S_IXUSR, create_flags,
+		      0, 0, NULL, &dir);
+	assert_int_equal(rc, 0);
+
+	print_message("Running chown tests on file object...\n");
+	run_chown_tests(file, f, S_IFREG);
+	print_message("done\n");
+	print_message("Running chown tests on dir object...\n");
+	run_chown_tests(dir, d, S_IFDIR);
+	print_message("done\n");
+
+	rc = dfs_release(file);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_mt, NULL, f, 0, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(dir);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_mt, NULL, d, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	/* Test the open_stat call with passing in uid/gid */
 	/** Create /file1 */
 	rc = dfs_open_stat(dfs_mt, NULL, filename_file1, create_mode | S_IFREG,
-			   create_flags, 0, 0, NULL, &obj, NULL);
+			   create_flags, 0, 0, NULL, &file, NULL);
 	assert_int_equal(rc, 0);
 
-	rc = dfs_release(obj);
+	rc = dfs_release(file);
 	assert_int_equal(rc, 0);
 
 	/** verify ownership */
@@ -1366,13 +1394,13 @@ dfs_test_chown(void **state)
 	stbuf2.st_uid = 14;
 	stbuf2.st_gid = 15;
 	rc = dfs_open_stat(dfs_mt, NULL, filename_file2, create_mode | S_IFREG,
-			   create_flags, 0, 0, NULL, &obj, &stbuf2);
+			   create_flags, 0, 0, NULL, &file, &stbuf2);
 	assert_int_equal(rc, 0);
 
 	assert_int_equal(stbuf2.st_uid, 14);
 	assert_int_equal(stbuf2.st_gid, 15);
 
-	rc = dfs_release(obj);
+	rc = dfs_release(file);
 	assert_int_equal(rc, 0);
 
 	/** verify ownership */
@@ -1383,11 +1411,8 @@ dfs_test_chown(void **state)
 }
 
 static void
-dfs_test_mtime(void **state)
+run_time_tests(dfs_obj_t *obj, char *name, int mode)
 {
-	test_arg_t		*arg = *state;
-	dfs_obj_t		*file;
-	char			*f = "test_mtime";
 	d_sg_list_t		sgl;
 	d_iov_t			iov;
 	char			buf[64];
@@ -1396,16 +1421,8 @@ dfs_test_mtime(void **state)
 	daos_size_t		size;
 	int			rc;
 
-	if (arg->myrank != 0)
-		return;
-
-	rc = dfs_open(dfs_mt, NULL, f, S_IFREG | S_IWUSR | S_IRUSR | S_IXUSR,
-		      O_RDWR | O_CREAT | O_EXCL, 0, 0, NULL, &file);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
-
-	rc = dfs_stat(dfs_mt, NULL, f, &stbuf);
-	assert_int_equal(rc, 0);
-	assert_int_equal(stbuf.st_size, 0);
 	prev_ts.tv_sec = stbuf.st_mtim.tv_sec;
 	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 
@@ -1413,69 +1430,83 @@ dfs_test_mtime(void **state)
 	first_ts.tv_sec = prev_ts.tv_sec;
 	first_ts.tv_nsec = prev_ts.tv_nsec;
 
-	d_iov_set(&iov, buf, 64);
-	sgl.sg_nr = 1;
-	sgl.sg_nr_out = 1;
-	sgl.sg_iovs = &iov;
-	dts_buf_render(buf, 64);
-	rc = dfs_write(dfs_mt, file, &sgl, 0, NULL);
-	assert_int_equal(rc, 0);
+	if (S_ISREG(mode)) {
+		d_iov_set(&iov, buf, 64);
+		sgl.sg_nr = 1;
+		sgl.sg_nr_out = 1;
+		sgl.sg_iovs = &iov;
+		dts_buf_render(buf, 64);
+		rc = dfs_write(dfs_mt, obj, &sgl, 0, NULL);
+		assert_int_equal(rc, 0);
+	} else {
+		rc = dfs_mkdir(dfs_mt, obj, "d1", S_IFDIR, OC_S1);
+		assert_int_equal(rc, 0);
+	}
 
 	memset(&stbuf, 0, sizeof(stbuf));
-	rc = dfs_stat(dfs_mt, NULL, f, &stbuf);
+	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
 	assert_int_equal(rc, 0);
-	assert_int_equal(stbuf.st_size, 64);
+	if (S_ISREG(mode))
+		assert_int_equal(stbuf.st_size, 64);
 	assert_true(check_ts(prev_ts, stbuf.st_mtim));
 	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 	prev_ts.tv_sec = stbuf.st_mtim.tv_sec;
 	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 
-	rc = dfs_read(dfs_mt, file, &sgl, 0, &size, NULL);
-	assert_int_equal(rc, 0);
+	if (S_ISREG(mode)) {
+		rc = dfs_read(dfs_mt, obj, &sgl, 0, &size, NULL);
+		assert_int_equal(rc, 0);
 
-	memset(&stbuf, 0, sizeof(stbuf));
-	rc = dfs_stat(dfs_mt, NULL, f, &stbuf);
-	assert_int_equal(rc, 0);
-	assert_int_equal(stbuf.st_size, 64);
-	assert_int_equal(prev_ts.tv_sec, stbuf.st_mtim.tv_sec);
-	assert_int_equal(prev_ts.tv_nsec, stbuf.st_mtim.tv_nsec);
+		memset(&stbuf, 0, sizeof(stbuf));
+		rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
+		assert_int_equal(rc, 0);
+		assert_int_equal(stbuf.st_size, 64);
+		assert_int_equal(prev_ts.tv_sec, stbuf.st_mtim.tv_sec);
+		assert_int_equal(prev_ts.tv_nsec, stbuf.st_mtim.tv_nsec);
+	}
 
-	/** reset the mtime on the file to the first timestamp */
+	/** reset the mtime on the file/dir to the first timestamp */
 	memset(&stbuf, 0, sizeof(stbuf));
 	stbuf.st_mtim.tv_sec = first_ts.tv_sec;
 	stbuf.st_mtim.tv_nsec = first_ts.tv_nsec;
-	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_MTIME);
+	rc = dfs_osetattr(dfs_mt, obj, &stbuf, DFS_SET_ATTR_MTIME);
 	assert_int_equal(rc, 0);
 	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 
 	/** verify mtime is now the same as the one we just set */
 	memset(&stbuf, 0, sizeof(stbuf));
-	rc = dfs_ostat(dfs_mt, file, &stbuf);
+	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(first_ts.tv_sec, stbuf.st_mtim.tv_sec);
 	assert_int_equal(first_ts.tv_nsec, stbuf.st_mtim.tv_nsec);
 	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 
-	/** truncate the file */
-	rc = dfs_punch(dfs_mt, file, 0, DFS_MAX_FSIZE);
-	assert_int_equal(rc, 0);
+	/** truncate the file or remove an entry from the dir */
+	if (S_ISREG(mode)) {
+		rc = dfs_punch(dfs_mt, obj, 0, DFS_MAX_FSIZE);
+		assert_int_equal(rc, 0);
+	} else {
+		rc = dfs_remove(dfs_mt, obj, "d1", true, NULL);
+		assert_int_equal(rc, 0);
+	}
 	memset(&stbuf, 0, sizeof(stbuf));
-	rc = dfs_ostat(dfs_mt, file, &stbuf);
+	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
-	assert_int_equal(stbuf.st_size, 0);
 	assert_true(check_ts(prev_ts, stbuf.st_mtim));
 	assert_true(check_ts(prev_ts, stbuf.st_ctim));
 	prev_ts.tv_sec = stbuf.st_mtim.tv_sec;
 	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 
 	/** set size on file with dfs_osetattr and stat at same time */
-	memset(&stbuf, 0, sizeof(stbuf));
-	stbuf.st_size = 1024;
-	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_SIZE);
-	assert_int_equal(rc, 0);
-	assert_int_equal(stbuf.st_size, 1024);
-	/** check the mtime was updated with the setattr */
-	assert_true(check_ts(prev_ts, stbuf.st_mtim));
+	if (S_ISREG(mode)) {
+		memset(&stbuf, 0, sizeof(stbuf));
+		stbuf.st_size = 1024;
+		rc = dfs_osetattr(dfs_mt, obj, &stbuf, DFS_SET_ATTR_SIZE);
+		assert_int_equal(rc, 0);
+		assert_int_equal(stbuf.st_size, 1024);
+		/** check the mtime was updated with the setattr */
+		assert_true(check_ts(prev_ts, stbuf.st_mtim));
+	}
 
 	struct tm	tm = {0};
 	time_t		ts;
@@ -1490,11 +1521,11 @@ dfs_test_mtime(void **state)
 	memset(&stbuf, 0, sizeof(stbuf));
 	stbuf.st_mtim.tv_sec = ts;
 	stbuf.st_mtim.tv_nsec = 0;
-	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_MTIME);
+	rc = dfs_osetattr(dfs_mt, obj, &stbuf, DFS_SET_ATTR_MTIME);
 	assert_int_equal(rc, 0);
 	/** verify */
 	memset(&stbuf, 0, sizeof(stbuf));
-	rc = dfs_ostat(dfs_mt, file, &stbuf);
+	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(ts, stbuf.st_mtim.tv_sec);
 	timeptr = localtime(&stbuf.st_mtim.tv_sec);
@@ -1510,11 +1541,11 @@ dfs_test_mtime(void **state)
 	memset(&stbuf, 0, sizeof(stbuf));
 	stbuf.st_mtim.tv_sec = ts;
 	stbuf.st_mtim.tv_nsec = 0;
-	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_MTIME);
+	rc = dfs_osetattr(dfs_mt, obj, &stbuf, DFS_SET_ATTR_MTIME);
 	assert_int_equal(rc, 0);
 	/* verify */
 	memset(&stbuf, 0, sizeof(stbuf));
-	rc = dfs_ostat(dfs_mt, file, &stbuf);
+	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(ts, stbuf.st_mtim.tv_sec);
 	timeptr = localtime(&stbuf.st_mtim.tv_sec);
@@ -1530,21 +1561,53 @@ dfs_test_mtime(void **state)
 	memset(&stbuf, 0, sizeof(stbuf));
 	stbuf.st_mtim.tv_sec = ts;
 	stbuf.st_mtim.tv_nsec = 0;
-	rc = dfs_osetattr(dfs_mt, file, &stbuf, DFS_SET_ATTR_MTIME);
+	rc = dfs_osetattr(dfs_mt, obj, &stbuf, DFS_SET_ATTR_MTIME);
 	assert_int_equal(rc, 0);
 	/* verify */
 	memset(&stbuf, 0, sizeof(stbuf));
-	rc = dfs_ostat(dfs_mt, file, &stbuf);
+	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(ts, stbuf.st_mtim.tv_sec);
 	timeptr = localtime(&stbuf.st_mtim.tv_sec);
 	strftime(time_str, sizeof(time_str), "%Y-%m-%d", timeptr);
 	print_message("mtime = %s\n", time_str);
 	assert_true(strncmp("2999", time_str, 4) == 0);
+}
+
+static void
+dfs_test_mtime(void **state)
+{
+	test_arg_t		*arg = *state;
+	dfs_obj_t		*file, *dir;
+	char			*f = "test_mtime_f";
+	char			*d = "test_mtime_d";
+	int			rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	rc = dfs_open(dfs_mt, NULL, f, S_IFREG | S_IWUSR | S_IRUSR | S_IXUSR,
+		      O_RDWR | O_CREAT | O_EXCL, 0, 0, NULL, &file);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_open(dfs_mt, NULL, d, S_IFDIR | S_IWUSR | S_IRUSR | S_IXUSR,
+		      O_RDWR | O_CREAT | O_EXCL, 0, 0, NULL, &dir);
+	assert_int_equal(rc, 0);
+
+	print_message("Running mtime/ctime tests on file object...\n");
+	run_time_tests(file, f, S_IFREG);
+	print_message("done\n");
+	print_message("Running mtime/ctime tests on dir object...\n");
+	run_time_tests(dir, d, S_IFDIR);
+	print_message("done\n");
 
 	rc = dfs_release(file);
 	assert_int_equal(rc, 0);
 	rc = dfs_remove(dfs_mt, NULL, f, 0, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(dir);
+	assert_int_equal(rc, 0);
+	rc = dfs_remove(dfs_mt, NULL, d, 0, NULL);
 	assert_int_equal(rc, 0);
 }
 


### PR DESCRIPTION
- add a new API to allow querying the max update epoch from an object without needing to query the keys.
- use the new API to return correct mtime and ctime for directory objects in DFS.

Required-githooks: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
