### PR TITLE
DAOS-11913 dfs: coverity fixes CID 452244 & 452245

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -478,10 +478,10 @@ dfs_suggest_oclass(dfs_t *dfs, const char *hint, daos_oclass_id_t *cid)
 	if (rc)
 		D_GOTO(out, rc);
 
-	*cid = daos_obj_get_oclass(dfs->coh, type, obj_hint, 0);
-	if (*cid < 0) {
-		D_ERROR("Failed to generate object class from hints %s\n", hint);
-		return EINVAL;
+	rc = daos_obj_get_oclass(dfs->coh, type, obj_hint, 0, cid);
+	if (rc) {
+		D_ERROR("daos_obj_get_oclass() failed "DF_RC"\n", DP_RC(rc));
+		return daos_der2errno(rc);
 	}
 out:
 	D_FREE(local);
@@ -1789,8 +1789,10 @@ dfs_cont_create(daos_handle_t poh, uuid_t *cuuid, dfs_attr_t *attr,
 		else
 			dattr.da_chunk_size = DFS_DEFAULT_CHUNK_SIZE;
 
-		if (attr->da_hints[0] != 0)
+		if (attr->da_hints[0] != 0) {
 			strncpy(dattr.da_hints, attr->da_hints, DAOS_CONT_HINT_MAX_LEN);
+			dattr.da_hints[DAOS_CONT_HINT_MAX_LEN - 1] = '\0';
+		}
 	} else {
 		dattr.da_oclass_id = 0;
 		dattr.da_dir_oclass_id = 0;
@@ -2951,12 +2953,17 @@ dfs_obj_get_info(dfs_t *dfs, dfs_obj_t *obj, dfs_obj_info_t *info)
 
 	switch (obj->mode & S_IFMT) {
 	case S_IFDIR:
-		if (obj->d.oclass)
+		if (obj->d.oclass) {
 			info->doi_oclass_id = obj->d.oclass;
-		else if (dfs->attr.da_oclass_id)
+		} else if (dfs->attr.da_oclass_id) {
 			info->doi_oclass_id = dfs->attr.da_oclass_id;
-		else
-			info->doi_oclass_id = daos_obj_get_oclass(dfs->coh, 0, 0, 0);
+		} else {
+			rc = daos_obj_get_oclass(dfs->coh, 0, 0, 0, &info->doi_oclass_id);
+			if (rc) {
+				D_ERROR("daos_obj_get_oclass() failed "DF_RC"\n", DP_RC(rc));
+				return daos_der2errno(rc);
+			}
+		}
 
 		if (obj->d.chunk_size)
 			info->doi_chunk_size = obj->d.chunk_size;

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -674,8 +674,10 @@ create_cont(daos_handle_t poh, struct duns_attr_t *attrp, bool create_with_label
 		dfs_attr.da_dir_oclass_id = attrp->da_dir_oclass_id;
 		dfs_attr.da_chunk_size = attrp->da_chunk_size;
 		dfs_attr.da_props = attrp->da_props;
-		if (attrp->da_hints[0] != 0)
+		if (attrp->da_hints[0] != 0) {
 			strncpy(dfs_attr.da_hints, attrp->da_hints, DAOS_CONT_HINT_MAX_LEN);
+			dfs_attr.da_hints[DAOS_CONT_HINT_MAX_LEN - 1] = '\0';
+		}
 		if (create_with_label)
 			rc = dfs_cont_create_with_label(poh, attrp->da_cont, &dfs_attr,
 							&attrp->da_cuuid, NULL, NULL);

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -237,8 +237,8 @@ unsigned int daos_oclass_grp_nr(struct daos_oclass_attr *oc_attr,
 int daos_oclass_fit_max(daos_oclass_id_t oc_id, int domain_nr, int target_nr,
 			enum daos_obj_redun *ord, uint32_t *nr);
 bool daos_oclass_is_valid(daos_oclass_id_t oc_id);
-daos_oclass_id_t daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type,
-				   daos_oclass_hints_t hints, uint32_t args);
+int daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type, daos_oclass_hints_t hints,
+			uint32_t args, daos_oclass_id_t *cid);
 #define daos_oclass_grp_off_by_shard(oca, shard)				\
 	(rounddown(shard, daos_oclass_grp_size(oca)))
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -6822,7 +6822,7 @@ daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type, daos_oclass_hints
 	attr.pa_domain = props.dcp_redun_lvl;
 	rc = pl_map_query(pool->dp_pool, &attr);
 	if (rc) {
-		D_ERROR("dc_cont_hdl2redunfac failed, "DF_RC"\n", DP_RC(rc));
+		D_ERROR("pl_map_query failed, "DF_RC"\n", DP_RC(rc));
 		return rc;
 	}
 	dc_pool_put(pool);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -6797,9 +6797,9 @@ daos_obj_generate_oid_by_rf(daos_handle_t poh, uint64_t rf_factor,
 	return rc;
 }
 
-daos_oclass_id_t
-daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type,
-		    daos_oclass_hints_t hints, uint32_t args)
+int
+daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type, daos_oclass_hints_t hints,
+		    uint32_t args, daos_oclass_id_t *cid)
 {
 	daos_handle_t		poh;
 	struct dc_pool		*pool;
@@ -6821,7 +6821,10 @@ daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type,
 	props = dc_cont_hdl2props(coh);
 	attr.pa_domain = props.dcp_redun_lvl;
 	rc = pl_map_query(pool->dp_pool, &attr);
-	D_ASSERT(rc == 0);
+	if (rc) {
+		D_ERROR("dc_cont_hdl2redunfac failed, "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
 	dc_pool_put(pool);
 
 	rc = dc_cont_hdl2redunfac(coh, &rf);
@@ -6831,7 +6834,8 @@ daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type,
 	}
 	rc = dc_set_oclass(rf, attr.pa_domain_nr, attr.pa_target_nr, type, hints, &ord, &nr_grp);
 	if (rc)
-		return 0;
+		return rc;
 
-	return (ord << OC_REDUN_SHIFT) | nr_grp;
+	*cid = (ord << OC_REDUN_SHIFT) | nr_grp;
+	return 0;
 }


### PR DESCRIPTION
- also include fix for DAOS-11914

Required-githooks: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
