### PR TITLE
DAOS-11927 test: fix deprecated json output rf property

### DIFF
--- a/src/tests/ftest/nvme/pool_exclude.py
+++ b/src/tests/ftest/nvme/pool_exclude.py
@@ -69,7 +69,7 @@ class NvmePoolExclude(OSAUtils):
             self.add_container(self.pool)
             self.cont_list.append(self.container)
             rf = ''.join(self.container.properties.value.split(":"))
-            rf_num = int(re.search(r"rf([0-9]+)", rf).group(1))
+            rf_num = int(re.search(r"rd_fac([0-9]+)", rf).group(1))
             for test in range(0, rf_num):
                 threads = []
                 threads.append(threading.Thread(target=self.run_ior_thread,

--- a/src/tests/ftest/nvme/pool_exclude.yaml
+++ b/src/tests/ftest/nvme/pool_exclude.yaml
@@ -20,13 +20,13 @@ server_config:
       log_file: daos_server0.log
       log_mask: ERR
       storage:
-      0:
-        class: dcpm
-        scm_list: ["/dev/pmem0"]
-        scm_mount: /mnt/daos0
-      1:
-        class: nvme
-        bdev_list: ["aaaa:aa:aa.a"]
+        0:
+          class: dcpm
+          scm_list: ["/dev/pmem0"]
+          scm_mount: /mnt/daos0
+        1:
+          class: nvme
+          bdev_list: ["aaaa:aa:aa.a"]
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -35,13 +35,13 @@ server_config:
       log_file: daos_server1.log
       log_mask: ERR
       storage:
-      0:
-        class: dcpm
-        scm_list: ["/dev/pmem1"]
-        scm_mount: /mnt/daos1
-      1:
-        class: nvme
-        bdev_list: ["bbbb:bb:bb.b"]
+        0:
+          class: dcpm
+          scm_list: ["/dev/pmem1"]
+          scm_mount: /mnt/daos1
+        1:
+          class: nvme
+          bdev_list: ["bbbb:bb:bb.b"]
 pool:
   scm_size: 50000000000
   nvme_size: 300000000000

--- a/src/tests/ftest/pool/rf.py
+++ b/src/tests/ftest/pool/rf.py
@@ -10,7 +10,7 @@ from ior_test_base import IorTestBase
 class PoolRedunFacProperty(IorTestBase):
     # pylint: disable=too-many-ancestors
     # pylint: disable=too-few-public-methods
-    """run tests with different pool Redun factor.
+    """run tests with different pool redundancy factor.
 
     Test Class Description: To validate pool rf works properly
 
@@ -23,9 +23,9 @@ class PoolRedunFacProperty(IorTestBase):
         Args:
             expected_value (int): expected container rf value
         """
-        cont_props = self.container.get_prop(properties=["rf"])
+        cont_props = self.container.get_prop(properties=["rd_fac"])
         rf_str = cont_props["response"][0]["value"]
-        rf_value = int(rf_str.replace("rf", ""))
+        rf_value = int(rf_str.replace("rd_fac", ""))
         self.assertEqual(expected_value, rf_value)
 
     def test_rf_pool_property(self):
@@ -54,7 +54,7 @@ class PoolRedunFacProperty(IorTestBase):
         # Verify pool rf.
         pool_prop_expected = int(self.pool.properties.value.split(":")[1])
         self.assertEqual(pool_prop_expected,
-                         self.pool.get_property("rf"))
+                         self.pool.get_property("rd_fac"))
 
         for cont_rf in cont_rfs:
             # Initial container


### PR DESCRIPTION
# Description

The pool and container rf property is depdrecated in favor of the name rd_fac property.
This PR also fix a regression, on the indentation of the nvme/pool_exclude.yaml configuration file, introduced with DAOS-11624.
Finally, this PR fix some minor codespell

The two targeted ftest have been run sucessfully 20 times with the CI https://build.hpdd.intel.com/blue/organizations/jenkins/daos-stack%2Fdaos/detail/PR-10625/6/tests/

# Actions

## Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

## Gatekeeper:

* [x] You are the appropriate gatekeeper to be landing the patch.
* [x] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [x] Githooks were used. If not, request that user install them and check copyright dates.
* [x] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [x] All builds have passed.  Check non-required builds for any new compiler warnings.
* [x] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [x] If applicable, the PR has addressed any potential version compatibility issues.
* [x] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [x] Extra checks if forced landing is requested
  * [x] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [x] No new NLT or valgrind warnings.  Check the classic view.
  * [x] Quick-build or Quick-functional is not used.
* [x] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
