### PR TITLE
DAOS-10038 doc: Add concurrent pool creation warning

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -106,10 +106,10 @@ The capacity of the pool can be specified in three different ways:
 
 !!! warning
     Concurrent creation of pools using **size percentage** could lead to
-    `ENOSPACE` errors.  Indeed, this operations is not atomic and the overall
-    available size retrieved in a first step could be different from the one
-    available when the second step will be performed (i.e. the creation of the
-    pool).
+    `ENOSPACE` errors.  Indeed, these operations are not atomic and the overall
+    available size retrieved in the first step could be different from the size
+    actually available when the second step will be performed (i.e. allocation
+    of space for the pool).
 
 Examples:
 

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -104,6 +104,13 @@ The capacity of the pool can be specified in three different ways:
     So in the first example above, specifying `--scm-size=256GB`
     would fail as 256 GB is smaller than the minimum 256 GiB.
 
+!!! warning
+    Concurrent creation of pools using **size percentage** could lead to
+    `ENOSPACE` errors.  Indeed, this operations is not atomic and the overall
+    available size retrieved in a first step could be different from the one
+    available when the second step will be performed (i.e. the creation of the
+    pool).
+
 Examples:
 
 To create a pool labeled `tank`:


### PR DESCRIPTION
# Description

Add documentation indicating that dmg is not supporting concurent creation of pools with size given as a percentage of the overall available storage size.

# Actions

## Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

## Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
