### PR TITLE
DAOS-11554 control: Don't log missing lib as error (#10327)

### DIFF
--- a/src/control/lib/hardware/hwprov/defaults.go
+++ b/src/control/lib/hardware/hwprov/defaults.go
@@ -89,10 +89,7 @@ func Init(log logging.Logger) (func(), error) {
 			numLoaded++
 			cleanupFns = append(cleanupFns, cleanupLib)
 		} else {
-			log.Debugf("failed to load library: %s", err)
-			if !hardware.IsUnsupportedFabric(err) {
-				log.Error(err.Error())
-			}
+			log.Debug(err.Error())
 		}
 	}
 

--- a/src/control/lib/hardware/libfabric/bindings.go
+++ b/src/control/lib/hardware/libfabric/bindings.go
@@ -95,7 +95,7 @@ import (
 func Load() (func(), error) {
 	hdl, err := openLib()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "loading libfabric")
 	}
 	return func() {
 		hdl.Close()

--- a/src/control/lib/hardware/ucx/bindings.go
+++ b/src/control/lib/hardware/ucx/bindings.go
@@ -203,7 +203,7 @@ import (
 func Load() (func(), error) {
 	ucsHdl, err := openUCS()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "loading libucs")
 	}
 	defer ucsHdl.Close()
 
@@ -213,7 +213,7 @@ func Load() (func(), error) {
 
 	hdl, err := openUCT()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "loading libuct")
 	}
 	return func() {
 		hdl.Close()


### PR DESCRIPTION
The use case where libfabric is present but UCX libs aren't installed is normal.

- Log missing dynamically loaded libs at debug level only.
- Improve error messages so it's easier to tell which library failed to load.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>