### PR TITLE
DAOS-11664 agent: Add config option to ignore interfaces (#10445)

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -26,16 +26,17 @@ const (
 
 // Config defines the agent configuration.
 type Config struct {
-	SystemName       string                    `yaml:"name"`
-	AccessPoints     []string                  `yaml:"access_points"`
-	ControlPort      int                       `yaml:"port"`
-	RuntimeDir       string                    `yaml:"runtime_dir"`
-	LogFile          string                    `yaml:"log_file"`
-	LogLevel         common.ControlLogLevel    `yaml:"control_log_mask,omitempty"`
-	TransportConfig  *security.TransportConfig `yaml:"transport_config"`
-	DisableCache     bool                      `yaml:"disable_caching,omitempty"`
-	DisableAutoEvict bool                      `yaml:"disable_auto_evict,omitempty"`
-	FabricInterfaces []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
+	SystemName          string                    `yaml:"name"`
+	AccessPoints        []string                  `yaml:"access_points"`
+	ControlPort         int                       `yaml:"port"`
+	RuntimeDir          string                    `yaml:"runtime_dir"`
+	LogFile             string                    `yaml:"log_file"`
+	LogLevel            common.ControlLogLevel    `yaml:"control_log_mask,omitempty"`
+	TransportConfig     *security.TransportConfig `yaml:"transport_config"`
+	DisableCache        bool                      `yaml:"disable_caching,omitempty"`
+	DisableAutoEvict    bool                      `yaml:"disable_auto_evict,omitempty"`
+	ExcludeFabricIfaces common.StringSet          `yaml:"exclude_fabric_ifaces,omitempty"`
+	FabricInterfaces    []*NUMAFabricConfig       `yaml:"fabric_ifaces,omitempty"`
 }
 
 // NUMAFabricConfig defines a list of fabric interfaces that belong to a NUMA

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -46,6 +46,7 @@ disable_caching: true
 disable_auto_evict: true
 transport_config:
   allow_insecure: true
+exclude_fabric_ifaces: ["ib3"]
 fabric_ifaces:
 -
   numa_node: 0
@@ -132,6 +133,7 @@ transport_config:
 					AllowInsecure:     true,
 					CertificateConfig: DefaultConfig().TransportConfig.CertificateConfig,
 				},
+				ExcludeFabricIfaces: common.NewStringSet("ib3"),
 				FabricInterfaces: []*NUMAFabricConfig{
 					{
 						NUMANode: 0,

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -105,8 +105,16 @@ type localFabricCache struct {
 	log         logging.Logger
 	enabled     atm.Bool
 	initialized atm.Bool
+	cfg         *Config
+
 	// cached fabric interfaces organized by NUMA affinity
 	localNUMAFabric *NUMAFabric
+}
+
+// WithConfig adds a config file for the cache to use.
+func (c *localFabricCache) WithConfig(cfg *Config) *localFabricCache {
+	c.cfg = cfg
+	return c
 }
 
 // IsEnabled reports whether the cache is enabled.
@@ -157,7 +165,11 @@ func (c *localFabricCache) setCache(nf *NUMAFabric) {
 		return
 	}
 
-	c.localNUMAFabric = nf
+	if c.cfg == nil {
+		c.localNUMAFabric = nf
+	} else {
+		c.localNUMAFabric = nf.WithIgnoredDevices(c.cfg.ExcludeFabricIfaces)
+	}
 
 	c.initialized.SetTrue()
 	c.log.Debugf("cached:\n%+v", c.localNUMAFabric.numaMap)

--- a/src/control/cmd/daos_agent/infocache_test.go
+++ b/src/control/cmd/daos_agent/infocache_test.go
@@ -298,6 +298,17 @@ func TestAgent_localFabricCache_CacheScan(t *testing.T) {
 				},
 			},
 		},
+		"ignores passed down": {
+			lfc: newLocalFabricCache(nil, true).WithConfig(&Config{
+				ExcludeFabricIfaces: common.NewStringSet("test1"),
+			}),
+			input:     hardware.NewFabricInterfaceSet(),
+			expCached: true,
+			expResult: &NUMAFabric{
+				numaMap:      map[int][]*FabricInterface{},
+				ignoreIfaces: common.NewStringSet("test1"),
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -319,6 +330,9 @@ func TestAgent_localFabricCache_CacheScan(t *testing.T) {
 				if diff := cmp.Diff(tc.expResult.numaMap, tc.lfc.localNUMAFabric.numaMap, cmp.AllowUnexported(FabricInterface{})); diff != "" {
 					t.Fatalf("-want, +got:\n%s", diff)
 				}
+				if diff := cmp.Diff(tc.expResult.ignoreIfaces, tc.lfc.localNUMAFabric.ignoreIfaces); diff != "" {
+					t.Fatalf("-want, +got:\n%s", diff)
+				}
 			} else if len(tc.lfc.localNUMAFabric.numaMap) > 0 {
 				t.Fatalf("expected nothing cached, found: %+v", tc.lfc.localNUMAFabric.numaMap)
 			}
@@ -328,9 +342,10 @@ func TestAgent_localFabricCache_CacheScan(t *testing.T) {
 
 func TestAgent_localFabricCache_Cache(t *testing.T) {
 	for name, tc := range map[string]struct {
-		lfc       *localFabricCache
-		input     *NUMAFabric
-		expCached bool
+		lfc        *localFabricCache
+		input      *NUMAFabric
+		expCached  bool
+		expIgnored common.StringSet
 	}{
 		"nil": {},
 		"nil NUMAFabric": {
@@ -367,6 +382,23 @@ func TestAgent_localFabricCache_Cache(t *testing.T) {
 			},
 			expCached: true,
 		},
+		"ignores passed down": {
+			lfc: newLocalFabricCache(nil, true).WithConfig(&Config{
+				ExcludeFabricIfaces: common.NewStringSet("test1"),
+			}),
+			input: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						{
+							Name:        "test1",
+							NetDevClass: hardware.Infiniband,
+						},
+					},
+				},
+			},
+			expCached:  true,
+			expIgnored: common.NewStringSet("test1"),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -374,6 +406,9 @@ func TestAgent_localFabricCache_Cache(t *testing.T) {
 
 			if tc.lfc != nil {
 				tc.lfc.log = log
+			}
+			if tc.input != nil {
+				tc.input.log = log
 			}
 
 			tc.lfc.Cache(context.TODO(), tc.input)
@@ -390,6 +425,9 @@ func TestAgent_localFabricCache_Cache(t *testing.T) {
 
 			if tc.expCached {
 				if diff := cmp.Diff(tc.input.numaMap, tc.lfc.localNUMAFabric.numaMap, cmp.AllowUnexported(FabricInterface{})); diff != "" {
+					t.Fatalf("-want, +got:\n%s", diff)
+				}
+				if diff := cmp.Diff(tc.expIgnored, tc.lfc.localNUMAFabric.ignoreIfaces); diff != "" {
 					t.Fatalf("-want, +got:\n%s", diff)
 				}
 			} else if len(tc.lfc.localNUMAFabric.numaMap) > 0 {

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -79,7 +79,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 	procmon := NewProcMon(cmd.log, cmd.ctlInvoker, cmd.cfg.SystemName)
 	procmon.startMonitoring(ctx)
 
-	fabricCache := newLocalFabricCache(cmd.log, ficEnabled)
+	fabricCache := newLocalFabricCache(cmd.log, ficEnabled).WithConfig(cmd.cfg)
 	if len(cmd.cfg.FabricInterfaces) > 0 {
 		// Cache is required to use user-defined fabric interfaces
 		fabricCache.enabled.SetTrue()

--- a/src/control/common/collection_utils.go
+++ b/src/control/common/collection_utils.go
@@ -67,6 +67,22 @@ func (s StringSet) String() string {
 	return strings.Join(s.ToSlice(), ", ")
 }
 
+// UnmarshalYAML converts from the YAML string slice to a StringSet.
+func (s *StringSet) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var strSlice []string
+	if err := unmarshal(&strSlice); err != nil {
+		return err
+	}
+
+	*s = NewStringSet(strSlice...)
+	return nil
+}
+
+// MarshalYAML converts from the StringSet to a slice that can be marshaled into YAML.
+func (s StringSet) MarshalYAML() (interface{}, error) {
+	return s.ToSlice(), nil
+}
+
 // NewStringSet creates a StringSet and initializes it with zero or more strings.
 func NewStringSet(values ...string) StringSet {
 	set := make(StringSet)

--- a/src/control/common/collection_utils_test.go
+++ b/src/control/common/collection_utils_test.go
@@ -225,6 +225,66 @@ func TestCommon_StringSet_String(t *testing.T) {
 	}
 }
 
+func TestCommon_StringSet_UnmarshalYAML(t *testing.T) {
+	for name, tc := range map[string]struct {
+		yamlStrs  []string
+		yamlErr   error
+		expResult StringSet
+		expErr    error
+	}{
+		"yaml error": {
+			yamlErr: errors.New("yaml error"),
+			expErr:  errors.New("yaml error"),
+		},
+		"empty": {
+			expResult: NewStringSet(),
+		},
+		"success": {
+			yamlStrs:  []string{"one", "two"},
+			expResult: NewStringSet("one", "two"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var set StringSet
+			err := set.UnmarshalYAML(func(result interface{}) error {
+				if slice, ok := result.(*[]string); ok {
+					*slice = tc.yamlStrs
+				} else {
+					t.Fatalf("%+v wasn't a string slice", result)
+				}
+				return tc.yamlErr
+			})
+
+			CmpErr(t, tc.expErr, err)
+			AssertEqual(t, tc.expResult, set, "")
+		})
+	}
+}
+
+func TestCommon_StringSet_MarshalYAML(t *testing.T) {
+	for name, tc := range map[string]struct {
+		set       StringSet
+		expResult []string
+		expErr    error
+	}{
+		"empty": {
+			set:       NewStringSet(),
+			expResult: []string{},
+		},
+		"success": {
+			set:       NewStringSet("one", "two"),
+			expResult: []string{"one", "two"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result, err := tc.set.MarshalYAML()
+
+			AssertEqual(t, tc.expResult, result, "")
+			CmpErr(t, tc.expErr, err)
+		})
+	}
+}
+
 func TestCommon_ParseNumberListUint32(t *testing.T) {
 	for name, tc := range map[string]struct {
 		input     string

--- a/src/tests/ftest/harness/config.py
+++ b/src/tests/ftest/harness/config.py
@@ -17,13 +17,17 @@ class HarnessConfigTest(TestWithServers):
     :avocado: recursive
     """
 
-    def test_harness_config_access_points(self):
-        """Verify the TestWithServers.access_points handling.
+    def test_harness_config(self):
+        """Verify the config handling.
+
+        Verfies the following:
+            TestWithServers.access_points
+            DaosAgentYamlParameters.exclude_fabric_ifaces
 
         :avocado: tags=all
         :avocado: tags=vm
         :avocado: tags=harness
-        :avocado: tags=test_harness_config_access_points
+        :avocado: tags=harness_config,test_harness_config
         """
         self.log.info('Verify access_points_suffix set from yaml')
         access_points_suffix = self.params.get("access_points_suffix", "/run/setup/*")
@@ -68,3 +72,10 @@ class HarnessConfigTest(TestWithServers):
         with open(self.agent_managers[0].manager.job.temporary_file, 'r') as yaml_file:
             daos_agent_yaml = yaml.safe_load(yaml_file.read())
         self.assertEqual(sorted(daos_agent_yaml['access_points']), sorted(self.access_points))
+
+        self.log.info('Verify daos_agent.yaml exclude_fabric_ifaces')
+        expected = self.params.get('exclude_fabric_ifaces', '/run/agent_config/*')
+        self.assertNotIn(expected, (None, []), 'exclude_fabric_ifaces not set in yaml')
+        with open(self.agent_managers[0].manager.job.temporary_file, 'r') as yaml_file:
+            daos_agent_yaml = yaml.safe_load(yaml_file.read())
+        self.assertEqual(daos_agent_yaml['exclude_fabric_ifaces'], expected)

--- a/src/tests/ftest/harness/config.py
+++ b/src/tests/ftest/harness/config.py
@@ -20,7 +20,7 @@ class HarnessConfigTest(TestWithServers):
     def test_harness_config(self):
         """Verify the config handling.
 
-        Verfies the following:
+        Verifies the following:
             TestWithServers.access_points
             DaosAgentYamlParameters.exclude_fabric_ifaces
 

--- a/src/tests/ftest/harness/config.yaml
+++ b/src/tests/ftest/harness/config.yaml
@@ -6,3 +6,5 @@ setup:
   access_points_suffix: .wolf.hpdd.intel.com
 server_config:
   name: daos_server
+agent_config:
+  exclude_fabric_ifaces: ["fake_iface1", "fake_iface2"]

--- a/src/tests/ftest/util/agent_utils_params.py
+++ b/src/tests/ftest/util/agent_utils_params.py
@@ -50,9 +50,12 @@ class DaosAgentYamlParameters(YamlParameters):
         #       Full path and name of the DAOS agent logfile.
         #   - control_log_mask: <str>, one of: error, info, debug
         #       Specifies the log level for agent logs.
+        #   - exclude_fabric_ifaces: <list>, Ignore a subset of fabric interfaces when selecting
+        #       an interface for client applications.
         self.runtime_dir = BasicParameter(None, "/var/run/daos_agent")
         self.log_file = LogParameter(log_dir, None, "daos_agent.log")
         self.control_log_mask = BasicParameter(None, "debug")
+        self.exclude_fabric_ifaces = BasicParameter(None)
 
     def update_log_file(self, name):
         """Update the log file name for the daos agent.

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -74,6 +74,11 @@
 ## default: false
 #disable_caching: true
 
+## Ignore a subset of fabric interfaces when selecting an interface for client
+## applications.
+#
+#exclude_fabric_ifaces: ["lo", "eth1"]
+
 # Manually define the fabric interfaces and domains to be used by the agent,
 # organized by NUMA node.
 # If not defined, the agent will automatically detect all fabric interfaces and


### PR DESCRIPTION
Note that this backport PR includes both the initial implementation and a functional test added by @daltonbohning.

The cherry-pick of #10445 wasn't clean due to differences between master and release/2.2.
