### PR TITLE
DAOS-11951 test: Use 5 access points for pool/svc.py

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -201,6 +203,13 @@ func (r *poolRequest) canRetry(reqErr error, try uint) bool {
 		case daos.TimedOut, daos.GroupVersionMismatch,
 			daos.TryAgain, daos.OutOfGroup, daos.Unreachable,
 			daos.Excluded:
+			return true
+		default:
+			return false
+		}
+	case *fault.Fault:
+		switch e.Code {
+		case code.ServerDataPlaneNotStarted:
 			return true
 		default:
 			return false

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -20,6 +20,8 @@ import (
 
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -82,6 +84,17 @@ func TestControl_PoolDestroy(t *testing.T) {
 			mic: &MockInvokerConfig{
 				UnaryResponseSet: []*UnaryResponse{
 					MockMSResponse("host1", daos.TryAgain, nil),
+					MockMSResponse("host1", nil, &mgmtpb.PoolDestroyResp{}),
+				},
+			},
+		},
+		"DataPlaneNotStarted error is retried": {
+			req: &PoolDestroyReq{
+				ID: test.MockUUID(),
+			},
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", &fault.Fault{Code: code.ServerDataPlaneNotStarted}, nil),
 					MockMSResponse("host1", nil, &mgmtpb.PoolDestroyResp{}),
 				},
 			},
@@ -392,6 +405,16 @@ func TestControl_PoolCreate(t *testing.T) {
 			mic: &MockInvokerConfig{
 				UnaryResponseSet: []*UnaryResponse{
 					MockMSResponse("host1", daos.TryAgain, nil),
+					MockMSResponse("host1", nil, &mgmtpb.PoolCreateResp{}),
+				},
+			},
+			expResp: &PoolCreateResp{},
+		},
+		"create DataPlaneNotStarted error is retried": {
+			req: &PoolCreateReq{TotalBytes: 10},
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", &fault.Fault{Code: code.ServerDataPlaneNotStarted}, nil),
 					MockMSResponse("host1", nil, &mgmtpb.PoolCreateResp{}),
 				},
 			},

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -404,7 +404,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		}
 
 		switch errors.Cause(err) {
-		case errInstanceNotReady, FaultDataPlaneNotStarted:
+		case errInstanceNotReady:
 			// If the pool create failed because there was no available instance
 			// to service the request, signal to the client that it should try again.
 			resp.Status = int32(daos.TryAgain)

--- a/src/tests/ftest/pool/svc.py
+++ b/src/tests/ftest/pool/svc.py
@@ -59,7 +59,7 @@ class PoolSvc(TestWithServers):
         return current_leader
 
     def test_pool_svc(self):
-        """Test svc arg during pool create.
+        """Test svc argument during pool create.
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm

--- a/src/tests/ftest/pool/svc.py
+++ b/src/tests/ftest/pool/svc.py
@@ -114,31 +114,31 @@ class PoolSvc(TestWithServers):
                 len(set(self.pool.svc_ranks)),
                 "Duplicate values in returned rank list")
 
-            # Query the pool to get the leader
-            pool_leader = self.check_leader()
-            non_leader_ranks = list(self.pool.svc_ranks)
-            non_leader_ranks.remove(pool_leader)
+            if svc_params[1] > 2:
+                # Query the pool to get the leader
+                pool_leader = self.check_leader()
+                non_leader_ranks = list(self.pool.svc_ranks)
+                non_leader_ranks.remove(pool_leader)
 
-            # Stop the pool leader
-            self.log.info("Stopping the pool leader: %s", pool_leader)
-            try:
-                self.server_managers[-1].stop_ranks(
-                    [pool_leader], self.test_log)
-            except TestFail as error:
-                self.log.info(error)
-                self.fail(
-                    "Error stopping pool leader - "
-                    "DaosServerManager.stop_ranks([{}])".format(
-                        pool_leader))
+                # Stop the pool leader
+                self.log.info("Stopping the pool leader: %s", pool_leader)
+                try:
+                    self.server_managers[-1].stop_ranks(
+                        [pool_leader], self.test_log)
+                except TestFail as error:
+                    self.log.info(error)
+                    self.fail(
+                        "Error stopping pool leader - "
+                        "DaosServerManager.stop_ranks([{}])".format(
+                            pool_leader))
 
-            self.pool.wait_for_rebuild(to_start=True, interval=1)
-            self.pool.wait_for_rebuild(to_start=False, interval=1)
+                self.pool.wait_for_rebuild(to_start=True, interval=1)
+                self.pool.wait_for_rebuild(to_start=False, interval=1)
 
-            # Verify the pool leader has changed
-            pool_leader = self.check_leader(pool_leader, True)
-            non_leader_ranks.remove(pool_leader)
+                # Verify the pool leader has changed
+                pool_leader = self.check_leader(pool_leader, True)
+                non_leader_ranks.remove(pool_leader)
 
-            if svc_params[1] == 5:
                 # Stop a pool non-leader
                 non_leader = non_leader_ranks[-1]
                 self.log.info(

--- a/src/tests/ftest/pool/svc.yaml
+++ b/src/tests/ftest/pool/svc.yaml
@@ -1,5 +1,6 @@
 hosts:
   test_servers: 5
+  access_points_qty: 5
 server_config:
   name: daos_server
   engines_per_host: 1

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -737,10 +737,9 @@ class TestWithServers(TestWithoutServers):
         # Access points to use by default when starting servers and agents
         #  - for 1 or 2 servers use 1 access point
         #  - for 3 or more servers use 3 access points
-        access_points_qty = 1 if len(self.hostlist_servers) < 3 else 3
-        default_access_points = self.hostlist_servers[:access_points_qty]
-        self.access_points = NodeSet(
-            self.params.get("access_points", "/run/setup/*", default_access_points))
+        access_points_qty = self.params.get(
+            "access_points_qty", "/run/hosts/*", 1 if len(self.hostlist_servers) < 3 else 3)
+        self.access_points = NodeSet(self.hostlist_servers[:access_points_qty])
         self.access_points_suffix = self.params.get(
             "access_points_suffix", "/run/setup/*", self.access_points_suffix)
         if self.access_points_suffix:


### PR DESCRIPTION
The number of ranks we can stop depends on the number of MS replicas, or access points. For this 5-server test, we need 5 access points to be able to stop 2 ranks.

Currently, the test uses 3 access points when there are 3 or more servers. Update test.py so that we can specify the number of access points from test yaml.

Revert the change in PR10496 regarding the PS
replicas as that's irrelevant.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_pool_svc
Required-githooks: true

Signed-off-by: Makito Kano <makito.kano@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
