### PR TITLE
DAOS-11538 chk: new flags to overwrite former start options

### DIFF
--- a/src/chk/chk.pb-c.c
+++ b/src/chk/chk.pb-c.c
@@ -403,7 +403,7 @@ const ProtobufCEnumDescriptor chk__check_inconsist_action__descriptor =
   chk__check_inconsist_action__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCEnumValue chk__check_flag__enum_values_by_number[6] =
+static const ProtobufCEnumValue chk__check_flag__enum_values_by_number[8] =
 {
   { "CF_NONE", "CHK__CHECK_FLAG__CF_NONE", 0 },
   { "CF_DRYRUN", "CHK__CHECK_FLAG__CF_DRYRUN", 1 },
@@ -411,17 +411,21 @@ static const ProtobufCEnumValue chk__check_flag__enum_values_by_number[6] =
   { "CF_FAILOUT", "CHK__CHECK_FLAG__CF_FAILOUT", 4 },
   { "CF_AUTO", "CHK__CHECK_FLAG__CF_AUTO", 8 },
   { "CF_DANGLING_POOL", "CHK__CHECK_FLAG__CF_DANGLING_POOL", 16 },
+  { "CF_NO_FAILOUT", "CHK__CHECK_FLAG__CF_NO_FAILOUT", 32 },
+  { "CF_NO_AUTO", "CHK__CHECK_FLAG__CF_NO_AUTO", 64 },
 };
 static const ProtobufCIntRange chk__check_flag__value_ranges[] = {
-{0, 0},{4, 3},{8, 4},{16, 5},{0, 6}
+{0, 0},{4, 3},{8, 4},{16, 5},{32, 6},{64, 7},{0, 8}
 };
-static const ProtobufCEnumValueIndex chk__check_flag__enum_values_by_name[6] =
+static const ProtobufCEnumValueIndex chk__check_flag__enum_values_by_name[8] =
 {
   { "CF_AUTO", 4 },
   { "CF_DANGLING_POOL", 5 },
   { "CF_DRYRUN", 1 },
   { "CF_FAILOUT", 3 },
   { "CF_NONE", 0 },
+  { "CF_NO_AUTO", 7 },
+  { "CF_NO_FAILOUT", 6 },
   { "CF_RESET", 2 },
 };
 const ProtobufCEnumDescriptor chk__check_flag__descriptor =
@@ -431,11 +435,11 @@ const ProtobufCEnumDescriptor chk__check_flag__descriptor =
   "CheckFlag",
   "Chk__CheckFlag",
   "chk",
-  6,
+  8,
   chk__check_flag__enum_values_by_number,
-  6,
+  8,
   chk__check_flag__enum_values_by_name,
-  4,
+  6,
   chk__check_flag__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };

--- a/src/chk/chk.pb-c.h
+++ b/src/chk/chk.pb-c.h
@@ -227,7 +227,15 @@ typedef enum _Chk__CheckFlag {
    * Handle dangling pool when start the check instance. If not specify the flag, dangling
    * pool will not be handled (by default) unless all pools are checked from the scratch.
    */
-  CHK__CHECK_FLAG__CF_DANGLING_POOL = 16
+  CHK__CHECK_FLAG__CF_DANGLING_POOL = 16,
+  /*
+   * Overwrite former set CF_FAILOUT flag, cannot be specified together with CF_FAILOUT.
+   */
+  CHK__CHECK_FLAG__CF_NO_FAILOUT = 32,
+  /*
+   * Overwrite former set CF_AUTO flag, cannot be specified together with CF_AUTO.
+   */
+  CHK__CHECK_FLAG__CF_NO_AUTO = 64
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(CHK__CHECK_FLAG)
 } Chk__CheckFlag;
 /*

--- a/src/proto/chk/chk.proto
+++ b/src/proto/chk/chk.proto
@@ -137,6 +137,10 @@ enum CheckFlag {
 	// Handle dangling pool when start the check instance. If not specify the flag, dangling
 	// pool will not be handled (by default) unless all pools are checked from the scratch.
 	CF_DANGLING_POOL = 16;
+	// Overwrite former set CF_FAILOUT flag, cannot be specified together with CF_FAILOUT.
+	CF_NO_FAILOUT	= 32;
+	// Overwrite former set CF_AUTO flag, cannot be specified together with CF_AUTO.
+	CF_NO_AUTO	= 64;
 
 	// More flags with 2^n.
 }


### PR DESCRIPTION
Introduce new flags for check start to overwrite former set flags when resume the check from former paused/stop phase without reset all the process.

CF_NO_FAILOUT:  Overwrite former set CF_FAILOUT flag.
CF_NO_AUTO:     Overwrite former set CF_AUTO flag.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
