### PR TITLE
DAOS-11876 chk: support to resume check for multiple pools

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -338,6 +338,7 @@ pipeline {
                                    password: GITHUB_USER_PSW,
                                    ignored_files: 'src/control/vendor/*:' +
                                                   '*.pb-c.[ch]:' +
+                                                  'src/chk/chk_internal.h:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:' +
                                                   /* groovylint-disable-next-line LineLength */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -338,7 +338,6 @@ pipeline {
                                    password: GITHUB_USER_PSW,
                                    ignored_files: 'src/control/vendor/*:' +
                                                   '*.pb-c.[ch]:' +
-                                                  'src/chk/chk_internal.h:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/dfs/uns/*:' +
                                                   'src/client/java/daos-java/src/main/java/io/daos/obj/attr/*:' +
                                                   /* groovylint-disable-next-line LineLength */

--- a/src/chk/chk.pb-c.c
+++ b/src/chk/chk.pb-c.c
@@ -410,7 +410,7 @@ static const ProtobufCEnumValue chk__check_flag__enum_values_by_number[8] =
   { "CF_RESET", "CHK__CHECK_FLAG__CF_RESET", 2 },
   { "CF_FAILOUT", "CHK__CHECK_FLAG__CF_FAILOUT", 4 },
   { "CF_AUTO", "CHK__CHECK_FLAG__CF_AUTO", 8 },
-  { "CF_DANGLING_POOL", "CHK__CHECK_FLAG__CF_DANGLING_POOL", 16 },
+  { "CF_ORPHAN_POOL", "CHK__CHECK_FLAG__CF_ORPHAN_POOL", 16 },
   { "CF_NO_FAILOUT", "CHK__CHECK_FLAG__CF_NO_FAILOUT", 32 },
   { "CF_NO_AUTO", "CHK__CHECK_FLAG__CF_NO_AUTO", 64 },
 };
@@ -420,12 +420,12 @@ static const ProtobufCIntRange chk__check_flag__value_ranges[] = {
 static const ProtobufCEnumValueIndex chk__check_flag__enum_values_by_name[8] =
 {
   { "CF_AUTO", 4 },
-  { "CF_DANGLING_POOL", 5 },
   { "CF_DRYRUN", 1 },
   { "CF_FAILOUT", 3 },
   { "CF_NONE", 0 },
   { "CF_NO_AUTO", 7 },
   { "CF_NO_FAILOUT", 6 },
+  { "CF_ORPHAN_POOL", 5 },
   { "CF_RESET", 2 },
 };
 const ProtobufCEnumDescriptor chk__check_flag__descriptor =

--- a/src/chk/chk.pb-c.h
+++ b/src/chk/chk.pb-c.h
@@ -224,10 +224,10 @@ typedef enum _Chk__CheckFlag {
    */
   CHK__CHECK_FLAG__CF_AUTO = 8,
   /*
-   * Handle dangling pool when start the check instance. If not specify the flag, dangling
-   * pool will not be handled (by default) unless all pools are checked from the scratch.
+   * Handle orphan pool when start the check instance. If not specify the flag, some orphan
+   * pool(s) may be not handled (by default) unless all pools are checked from the scratch.
    */
-  CHK__CHECK_FLAG__CF_DANGLING_POOL = 16,
+  CHK__CHECK_FLAG__CF_ORPHAN_POOL = 16,
   /*
    * Overwrite former set CF_FAILOUT flag, cannot be specified together with CF_FAILOUT.
    */

--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -118,21 +118,8 @@ chk_pool_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 {
 	struct chk_pool_rec	*cpr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	d_iov_t			*val_iov = args;
-	struct chk_pool_shard	*cps;
 
 	rec->rec_off = UMOFF_NULL;
-
-	while ((cps = d_list_pop_entry(&cpr->cpr_shard_list, struct chk_pool_shard,
-				       cps_link)) != NULL) {
-		if (cps->cps_free_cb != NULL)
-			cps->cps_free_cb(cps->cps_data);
-		else
-			D_FREE(cps->cps_data);
-		D_FREE(cps);
-	}
-
-	D_FREE(cpr->cpr_clues.pcs_array);
-
 	if (val_iov != 0)
 		d_iov_set(val_iov, cpr, sizeof(*cpr));
 	else

--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -17,6 +17,7 @@
 #include <daos_srv/pool.h>
 #include <daos_srv/vos.h>
 #include <daos_srv/iv.h>
+#include <daos_srv/daos_mgmt_srv.h>
 
 #include "chk.pb-c.h"
 #include "chk_internal.h"
@@ -351,68 +352,45 @@ chk_ranks_dump(uint32_t rank_nr, d_rank_t *ranks)
 }
 
 void
-chk_pools_dump(int pool_nr, uuid_t pools[])
+chk_pools_dump(d_list_t *head, int pool_nr, uuid_t pools[])
 {
-	char	 buf[256];
-	char	*ptr = buf;
-	int	 rc;
-	int	 i;
+	struct chk_pool_rec	*cpr;
+	int			 i = 0;
 
-	D_INFO("Pools List:\n");
-
-	while (pool_nr > 4) {
-		snprintf(buf, 255, DF_UUIDF" "DF_UUIDF" "DF_UUIDF" "DF_UUIDF, DP_UUID(pools[0]),
-			 DP_UUID(pools[1]), DP_UUID(pools[2]), DP_UUID(pools[3]));
-		D_INFO("%s\n", buf);
-		pool_nr -= 4;
-		pools += 4;
+	if (!d_list_empty(head)) {
+		D_INFO("Pools List:\n");
+		d_list_for_each_entry(cpr, head, cpr_link) {
+			D_INFO(DF_UUIDF"\n", DP_UUID(cpr->cpr_uuid));
+		}
+	} else if (pool_nr > 0) {
+		D_INFO("Pools List:\n");
+		do {
+			D_INFO(DF_UUIDF"\n", DP_UUID(pools[i++]));
+		} while (i < pool_nr);
+	} else {
+		D_INFO("Pools List: all\n");
 	}
-
-	if (pool_nr > 0) {
-		rc = snprintf(ptr, 255, DF_UUIDF, DP_UUID(pools[0]));
-		D_ASSERT(rc > 0);
-		ptr += rc;
-	}
-
-	for (i = 1; i < pool_nr; i++) {
-		rc = snprintf(ptr, 255, " "DF_UUIDF, DP_UUID(pools[i]));
-		D_ASSERT(rc > 0);
-		ptr += rc;
-	}
-
-	D_INFO("%s\n", buf);
 }
 
-int
-chk_pool_filter(uuid_t uuid, void *arg)
+void
+chk_pool_remove_nowait(struct chk_pool_rec *cpr, bool destroy)
 {
-	struct chk_pool_filter_args	*cpfa = arg;
-	d_iov_t				 kiov;
-	d_iov_t				 riov;
-	int				 i;
-	int				 rc;
-	bool				 found = false;
+	d_iov_t		kiov;
+	char		uuid_str[DAOS_UUID_STR_SIZE];
+	int		rc;
 
-	if (daos_handle_is_valid(cpfa->cpfa_pool_hdl)) {
-		d_iov_set(&riov, NULL, 0);
-		d_iov_set(&kiov, uuid, sizeof(uuid_t));
-		rc = dbtree_lookup(cpfa->cpfa_pool_hdl, &kiov, &riov);
-		if (rc == 0)
-			found = true;
-	} else {
-		if (cpfa->cpfa_pool_nr <= 0) {
-			found = true;
-		} else {
-			for (i = 0; i < cpfa->cpfa_pool_nr; i++) {
-				if (uuid_compare(uuid, cpfa->cpfa_pools[i]) == 0) {
-					found = true;
-					break;
-				}
-			}
-		}
+	cpr->cpr_skip = 1;
+	if (destroy) {
+		uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
+		rc = chk_bk_delete_pool(uuid_str);
+		if (rc != 0 && rc != -DER_NONEXIST)
+			D_WARN("Failed to destroy pool bookmark: "DF_RC"\n", DP_RC(rc));
 	}
 
-	return found ? 0 : 1;
+	d_iov_set(&kiov, cpr->cpr_uuid, sizeof(uuid_t));
+	rc = dbtree_delete(cpr->cpr_ins->ci_pool_hdl, BTR_PROBE_EQ, &kiov, NULL);
+	if (rc != 0 && rc != -DER_NONEXIST && rc != -DER_NO_HDL)
+		D_WARN("Failed to delete pool record: "DF_RC"\n", DP_RC(rc));
 }
 
 void
@@ -446,7 +424,6 @@ chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, int status, uint32_t ph
 		cbk = &cpr->cpr_bk;
 
 		chk_pool_wait(cpr);
-		chk_pool_shutdown(cpr);
 
 		if ((cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKING ||
 		     cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_PENDING) &&
@@ -457,6 +434,17 @@ chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, int status, uint32_t ph
 			cbk->cb_time.ct_stop_time = time(NULL);
 			uuid_unparse_lower(uuid, uuid_str);
 			rc = chk_bk_update_pool(cbk, uuid_str);
+		}
+
+		/*
+		 * NOTE: If the pool is successfully checked, then keep the PS for subsequent
+		 *	 operations. Otherwise the pool may contain some inconsistency. Under
+		 *	 such case, close the pool to avoid further damage.
+		 */
+		if (cpr->cpr_started &&
+		    cpr->cpr_bk.cb_pool_status != CHK__CHECK_POOL_STATUS__CPS_CHECKED) {
+			chk_pool_shutdown(cpr);
+			cpr->cpr_started = 0;
 		}
 
 		/* Drop the reference that is held when create in chk_pool_alloc(). */
@@ -482,19 +470,28 @@ chk_pools_cleanup_cb(struct sys_db *db, char *table, d_iov_t *key, void *args)
 	if (rc != 0)
 		goto out;
 
-	if (cbk.cb_gen >= ctpa->ctpa_gen)
-		D_GOTO(out, rc = 0);
+	if (ctpa->ctpa_ins->ci_start_flags & CSF_RESET_NONCOMP) {
+		if (cbk.cb_phase == CHK__CHECK_SCAN_PHASE__DSP_DONE)
+			goto out;
 
-	rc = chk_bk_delete_pool(uuid_str);
+		cbk.cb_gen = ctpa->ctpa_gen;
+		cbk.cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+		cbk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_UNCHECKED;
+		memset(&cbk.cb_statistics, 0, sizeof(cbk.cb_statistics));
+		memset(&cbk.cb_time, 0, sizeof(cbk.cb_time));
+		rc = chk_bk_update_pool(&cbk, uuid_str);
+	} else {
+		rc = chk_bk_delete_pool(uuid_str);
+	}
 
 out:
-	return rc;
+	return rc == -DER_NONEXIST ? 0 : rc;
 }
 
 int
 chk_pool_start_one(struct chk_instance *ins, uuid_t uuid, uint64_t gen)
 {
-	struct chk_bookmark	cbk;
+	struct chk_bookmark	cbk = { 0 };
 	char			uuid_str[DAOS_UUID_STR_SIZE];
 	int			rc;
 
@@ -504,34 +501,68 @@ chk_pool_start_one(struct chk_instance *ins, uuid_t uuid, uint64_t gen)
 		goto out;
 
 	if (cbk.cb_magic != CHK_BK_MAGIC_POOL) {
+		memset(&cbk, 0, sizeof(cbk));
 		cbk.cb_magic = CHK_BK_MAGIC_POOL;
 		cbk.cb_version = DAOS_CHK_VERSION;
-		cbk.cb_gen = gen;
 		cbk.cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
-	} else if (cbk.cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED) {
-		chk_ins_set_fail(ins, cbk.cb_phase);
 	}
 
-	/* Always refresh the start time. */
-	cbk.cb_time.ct_start_time = time(NULL);
-	/* QUEST: How to estimate the left time? */
-	cbk.cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk.cb_phase;
-	cbk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKING;
-	rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, uuid, dss_self_rank(),
-				&cbk, ins, NULL, NULL, NULL);
-	if (rc != 0)
-		goto out;
-
-	rc = chk_bk_update_pool(&cbk, uuid_str);
-	if (rc != 0)
-		chk_pool_del_shard(ins->ci_pool_hdl, uuid, dss_self_rank());
+	cbk.cb_gen = gen;
+	rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, uuid,
+				dss_self_rank(), &cbk, ins, NULL, NULL, NULL);
 
 out:
 	return rc;
 }
 
 int
-chk_pools_add_from_db(struct sys_db *db, char *table, d_iov_t *key, void *args)
+chk_pools_load_list(struct chk_instance *ins, uint64_t gen, uint32_t flags,
+		    int pool_nr, uuid_t pools[])
+{
+	struct chk_bookmark	cbk;
+	char			uuid_str[DAOS_UUID_STR_SIZE];
+	d_rank_t		myrank = dss_self_rank();
+	int			i;
+	int			rc = 0;
+
+	for (i = 0; i < pool_nr; i++) {
+		if (!ins->ci_is_leader) {
+			rc = ds_mgmt_pool_exist(pools[i]);
+			/* "rc == 0" means non-exist, skip it. */
+			if (rc == 0)
+				continue;
+			if (rc < 0)
+				break;
+		}
+
+		uuid_unparse_lower(pools[i], uuid_str);
+		rc = chk_bk_fetch_pool(&cbk, uuid_str);
+		if (rc != 0 && rc != -DER_NONEXIST)
+			break;
+
+		if (rc == -DER_NONEXIST || flags & CHK__CHECK_FLAG__CF_RESET) {
+			memset(&cbk, 0, sizeof(cbk));
+			cbk.cb_magic = CHK_BK_MAGIC_POOL;
+			cbk.cb_version = DAOS_CHK_VERSION;
+			cbk.cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
+		}
+
+		/*
+		 * NOTE: If the pool is in che check list, then load it even if its former
+		 *	 check has completed, otherwise, it may be handled as dangling one.
+		 */
+		cbk.cb_gen = gen;
+		rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, pools[i],
+					myrank, &cbk, ins, NULL, NULL, NULL);
+		if (rc != 0)
+			break;
+	}
+
+	return rc;
+}
+
+int
+chk_pools_load_from_db(struct sys_db *db, char *table, d_iov_t *key, void *args)
 {
 	struct chk_traverse_pools_args	*ctpa = args;
 	struct chk_instance		*ins = ctpa->ctpa_ins;
@@ -547,29 +578,114 @@ chk_pools_add_from_db(struct sys_db *db, char *table, d_iov_t *key, void *args)
 	if (rc != 0)
 		goto out;
 
-	if (cbk.cb_gen != ctpa->ctpa_gen)
-		D_GOTO(out, rc = 0);
-
-	if (cbk.cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED)
-		chk_ins_set_fail(ins, cbk.cb_phase);
+	if (cbk.cb_phase == CHK__CHECK_SCAN_PHASE__DSP_DONE)
+		goto out;
 
 	uuid_parse(uuid_str, uuid);
 
-	/* Always refresh the start time. */
-	cbk.cb_time.ct_start_time = time(NULL);
-	/* QUEST: How to estimate the left time? */
-	cbk.cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk.cb_phase;
-	cbk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKING;
+	if (!ins->ci_is_leader) {
+		rc = ds_mgmt_pool_exist(uuid);
+		/* "rc == 0" means non-exist, skip it. */
+		if (rc <= 0)
+			goto out;
+	}
+
 	rc = chk_pool_add_shard(ins->ci_pool_hdl, &ins->ci_pool_list, uuid,
 				dss_self_rank(), &cbk, ins, NULL, NULL, NULL);
-	if (rc != 0)
-		goto out;
-
-	rc = chk_bk_update_pool(&cbk, uuid_str);
-	if (rc != 0)
-		chk_pool_del_shard(ctpa->ctpa_ins->ci_pool_hdl, uuid, dss_self_rank());
 
 out:
+	return rc;
+}
+
+int
+chk_pools_update_bk(struct chk_instance *ins, uint32_t phase)
+{
+	struct chk_bookmark	*cbk;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
+	char			 uuid_str[DAOS_UUID_STR_SIZE];
+	int			 rc = 0;
+	int			 rc1;
+
+	/*
+	 * Hold reference on each before update to guarantee that the next 'tmp'
+	 * will not be unlinked from the list during current 'cpr' update.
+	 */
+	d_list_for_each_entry(cpr, &ins->ci_pool_list, cpr_link)
+		chk_pool_get(cpr);
+
+	d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link) {
+		cbk = &cpr->cpr_bk;
+		if (cbk->cb_phase < phase) {
+			cbk->cb_phase = phase;
+			uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
+			rc1 = chk_bk_update_pool(cbk, uuid_str);
+			if (rc1 != 0)
+				rc = rc1;
+		}
+		chk_pool_put(cpr);
+	}
+
+	return rc;
+}
+
+int
+chk_pool_handle_notify(struct chk_instance *ins, struct chk_iv *iv)
+{
+	struct chk_pool_rec	*cpr = NULL;
+	struct chk_bookmark	*cbk;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	char			 uuid_str[DAOS_UUID_STR_SIZE];
+	int			 rc = 0;
+	int			 rc1;
+
+	d_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, iv->ci_uuid, sizeof(uuid_t));
+	rc = dbtree_lookup(ins->ci_pool_hdl, &kiov, &riov);
+	if (rc != 0) {
+		if (rc == -DER_NONEXIST || rc == -DER_NO_HDL)
+			rc = -DER_NOTAPPLICABLE;
+
+		D_GOTO(out, rc);
+	}
+
+	cpr = (struct chk_pool_rec *)riov.iov_buf;
+	chk_pool_get(cpr);
+	cbk = &cpr->cpr_bk;
+
+	if (cpr->cpr_stop || unlikely(iv->ci_phase < cbk->cb_phase))
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (iv->ci_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKED)
+		cpr->cpr_done = 1;
+	else if (iv->ci_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED ||
+		 iv->ci_pool_status == CHK__CHECK_POOL_STATUS__CPS_IMPLICATED)
+		cpr->cpr_skip = 1;
+	else if (iv->ci_pool_status != CHK__CHECK_POOL_STATUS__CPS_CHECKING)
+		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
+
+	if (iv->ci_phase != cbk->cb_phase || iv->ci_pool_status != cbk->cb_pool_status) {
+		cbk->cb_phase = iv->ci_phase;
+		cbk->cb_pool_status = iv->ci_pool_status;
+		uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
+		rc = chk_bk_update_pool(cbk, uuid_str);
+	}
+
+	if (rc == 0 && !cpr->cpr_started &&
+	    cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKED) {
+		rc1 = ds_pool_start_with_svc(cpr->cpr_uuid);
+		if (rc1 == 0)
+			cpr->cpr_started = 1;
+		else
+			D_WARN("Cannot start the pool for "DF_UUIDF" after check: "DF_RC"\n",
+			       DP_UUID(cpr->cpr_uuid), DP_RC(rc1));
+	}
+
+out:
+	if (cpr != NULL)
+		chk_pool_put(cpr);
+
 	return rc;
 }
 
@@ -639,7 +755,6 @@ chk_pool_del_shard(daos_handle_t hdl, uuid_t uuid, d_rank_t rank)
 					D_ASSERT(cpr == riov.iov_buf);
 
 					chk_pool_wait(cpr);
-					chk_pool_shutdown(cpr);
 					chk_pool_put(cpr);
 				} else {
 					D_ASSERT(rc != -DER_NONEXIST);
@@ -737,32 +852,25 @@ chk_pending_destroy(struct chk_pending_rec *cpr)
 }
 
 int
-chk_prop_prepare(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		 struct chk_policy *policies, int pool_nr, uuid_t pools[],
-		 uint32_t flags, int phase, d_rank_t leader,
-		 struct chk_property *prop, d_rank_list_t **rlist)
+chk_prop_prepare(d_rank_t leader, uint32_t flags, int phase,
+		 uint32_t policy_nr, struct chk_policy *policies,
+		 d_rank_list_t *ranks, struct chk_property *prop)
 {
-	d_rank_list_t	*result = NULL;
-	uint32_t	 saved = prop->cp_rank_nr;
-	int		 rc = 0;
-	int		 i;
-
-	D_ASSERT(rlist != NULL);
-
-	if (rank_nr != 0) {
-		result = uint32_array_to_rank_list(ranks, rank_nr);
-		if (result == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		prop->cp_rank_nr = rank_nr;
-	} else if (*rlist == NULL) {
-		D_ERROR("Rank list cannot be NULL for check start\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
+	int	rc = 0;
+	int	i;
 
 	prop->cp_leader = leader;
-	prop->cp_flags = flags;
+	if (flags & CHK__CHECK_FLAG__CF_NO_FAILOUT)
+		prop->cp_flags &= ~CHK__CHECK_FLAG__CF_FAILOUT;
+	if (flags & CHK__CHECK_FLAG__CF_NO_AUTO)
+		prop->cp_flags &= ~CHK__CHECK_FLAG__CF_AUTO;
+	prop->cp_flags |= flags & ~(CHK__CHECK_FLAG__CF_RESET |
+				    CHK__CHECK_FLAG__CF_ORPHAN_POOL |
+				    CHK__CHECK_FLAG__CF_NO_FAILOUT |
+				    CHK__CHECK_FLAG__CF_NO_AUTO);
 	prop->cp_phase = phase;
+	if (ranks != NULL)
+		prop->cp_rank_nr = ranks->rl_nr;
 
 	/* Reuse former policies if "policy_nr == 0". */
 	if (policy_nr > 0) {
@@ -778,27 +886,7 @@ chk_prop_prepare(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
 		}
 	}
 
-	/* Reuse former pools if "pool_nr == 0". */
-	if (pool_nr >= CHK_POOLS_MAX || pool_nr < 0) {
-		prop->cp_pool_nr = -1;
-	} else if (pool_nr > 0) {
-		for (i = 0; i < pool_nr; i++)
-			uuid_copy(prop->cp_pools[i], pools[i]);
-		prop->cp_pool_nr = pool_nr;
-	}
-
-	if (prop->cp_pool_nr == 0)
-		prop->cp_pool_nr = -1;
-
-	rc = chk_prop_update(prop, result);
-	if (rc == 0) {
-		if (result != NULL)
-			*rlist = result;
-	} else {
-		/* Keep the prop->cp_rank_nr to always match the rank list. */
-		prop->cp_rank_nr = saved;
-		d_rank_list_free(result);
-	}
+	rc = chk_prop_update(prop, ranks);
 
 out:
 	return rc;

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -199,75 +199,26 @@ chk_engine_exit(struct chk_instance *ins, uint32_t ins_status, uint32_t pool_sta
 }
 
 static uint32_t
-chk_engine_find_slowest(struct chk_instance *ins)
+chk_engine_find_slowest(struct chk_instance *ins, bool *done)
 {
 	struct chk_pool_rec	*cpr;
 	uint32_t		 phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
 
+	if (done != NULL)
+		*done = true;
+
 	d_list_for_each_entry(cpr, &ins->ci_pool_list, cpr_link) {
-		if (cpr->cpr_skip)
+		if (cpr->cpr_skip || cpr->cpr_done)
 			continue;
+
+		if (done != NULL)
+			*done = false;
 
 		if (cpr->cpr_bk.cb_phase < phase)
 			phase = cpr->cpr_bk.cb_phase;
 	}
 
 	return phase;
-}
-
-static int
-chk_engine_setup_pools(struct chk_instance *ins)
-{
-	struct chk_property	*prop = &ins->ci_prop;
-	struct chk_bookmark	*eng_bk = &ins->ci_bk;
-	struct chk_bookmark	*pool_bk;
-	struct chk_pool_rec	*cpr;
-	struct chk_pool_rec	*tmp;
-	uuid_t			 uuid;
-	char			 uuid_str[DAOS_UUID_STR_SIZE];
-	int			 rc = 0;
-	int			 rc1;
-
-	d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link) {
-		if (cpr->cpr_started || cpr->cpr_stop)
-			continue;
-
-		pool_bk = &cpr->cpr_bk;
-		if (pool_bk->cb_phase < eng_bk->cb_phase) {
-			pool_bk->cb_phase = eng_bk->cb_phase;
-			/* QUEST: How to estimate the left time? */
-			pool_bk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE -
-							pool_bk->cb_phase;
-			uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
-			rc1 = chk_bk_update_pool(pool_bk, uuid_str);
-			if (rc1 != 0)
-				D_WARN("Failed to update pool bookmark (1) for %s: "DF_RC"\n",
-				       uuid_str, DP_RC(rc1));
-		}
-
-		uuid_copy(uuid, cpr->cpr_uuid);
-		rc = ds_pool_start(uuid);
-		if (rc != 0) {
-			chk_ins_set_fail(ins, pool_bk->cb_phase);
-			chk_pool_stop_one(ins, uuid, CHK__CHECK_POOL_STATUS__CPS_FAILED,
-					  CHK_INVAL_PHASE, NULL);
-			D_ERROR(DF_ENGINE " on rank %u failed (%s) to start pool "
-				DF_UUIDF": "DF_RC"\n", DP_ENGINE(ins), dss_self_rank(),
-				prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT ? "out" : "cnt",
-				DP_UUID(uuid), DP_RC(rc));
-
-			if (prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT)
-				goto out;
-			rc = 0;
-		} else {
-			cpr->cpr_started = 1;
-			D_INFO(DF_ENGINE" on rank %u start pool "DF_UUIDF" at phase %u\n",
-			       DP_ENGINE(ins), dss_self_rank(), DP_UUID(uuid), pool_bk->cb_phase);
-		}
-	}
-
-out:
-	return rc;
 }
 
 static inline void
@@ -910,8 +861,7 @@ chk_engine_cont_list_reduce_internal(struct chk_cont_list_aggregator *aggregator
 }
 
 static int
-chk_engine_cont_list_remote_cb(void *args, uint32_t rank, uint32_t phase,
-			       int result, void *data, uint32_t nr)
+chk_engine_cont_list_remote_cb(void *args, uint32_t rank, int result, void *data, uint32_t nr)
 {
 	int	rc;
 
@@ -1609,15 +1559,10 @@ chk_engine_sched(void *args)
 	uint32_t		 pool_status;
 	d_rank_t		 myrank = dss_self_rank();
 	int			 rc = 0;
+	bool			 done = false;
 
 	D_INFO(DF_ENGINE" scheduler on rank %u entry at phase %u\n",
 	       DP_ENGINE(ins), myrank, cbk->cb_phase);
-
-	if (cbk->cb_phase > CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
-		rc = chk_engine_setup_pools(ins);
-		if (rc != 0)
-			goto out;
-	}
 
 	while (1) {
 		/* Someone wants to stop the check. */
@@ -1626,8 +1571,8 @@ chk_engine_sched(void *args)
 
 		dss_sleep(300);
 
-		phase = chk_engine_find_slowest(ins);
-		if (phase == CHK__CHECK_SCAN_PHASE__DSP_DONE) {
+		phase = chk_engine_find_slowest(ins, &done);
+		if (done) {
 			D_INFO(DF_ENGINE" on rank %u has done\n", DP_ENGINE(ins), myrank);
 			D_GOTO(out, rc = 1);
 		}
@@ -1684,166 +1629,233 @@ out:
 }
 
 static int
-chk_engine_start_prepare(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *ranks,
-			 uint32_t policy_nr, struct chk_policy *policies,
-			 int pool_nr, uuid_t pools[], uint64_t gen, int phase,
-			 uint32_t flags, d_rank_t leader, d_rank_list_t **rlist)
+chk_engine_start_prep(struct chk_instance *ins, uint32_t rank_nr, d_rank_t *ranks,
+		      uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
+		      uuid_t pools[], uint64_t gen, int phase, uint32_t api_flags,
+		      d_rank_t leader, uint32_t flags)
 {
-	struct chk_bookmark	*cbk = &ins->ci_bk;
-	struct chk_property	*prop = &ins->ci_prop;
-	bool			 reset = (flags & CHK__CHECK_FLAG__CF_RESET) ? true : false;
-	int			 rc = 0;
-	int			 i;
-	int			 j;
+	struct chk_traverse_pools_args	 ctpa = { 0 };
+	struct chk_bookmark		*cbk = &ins->ci_bk;
+	struct chk_property		*prop = &ins->ci_prop;
+	d_rank_list_t			*rank_list = NULL;
+	int				 rc = 0;
 
-	/*
-	 * XXX: Currently we cannot distinguish whether it is caused by resent start request
-	 *	or not. That can be resolved via introducing new RPC sequence in the future.
-	 */
-	if (ins->ci_sched_running)
-		D_GOTO(out, rc = -DER_ALREADY);
+	/* Check leader has already verified related parameters, trust them. */
 
-	/* Corrupted bookmark or new created one. */
-	if (cbk->cb_magic != CHK_BK_MAGIC_ENGINE) {
-		if (!reset)
-			D_GOTO(out, rc = -DER_NOT_RESUME);
-
-		if (!chk_is_on_leader(gen, leader, true))
-			memset(prop, 0, sizeof(*prop));
-
-		memset(cbk, 0, sizeof(*cbk));
-		cbk->cb_magic = CHK_BK_MAGIC_ENGINE;
-		cbk->cb_version = DAOS_CHK_VERSION;
-		flags |= CHK__CHECK_FLAG__CF_RESET;
-		goto init;
-	}
-
-	if (cbk->cb_gen > gen)
-		D_GOTO(out, rc = -DER_EP_OLD);
-
-	/*
-	 * XXX: Leader wants to resume the check but with different generation, then this
-	 *	engine must be new joined one for current check instance. Under such case
-	 *	we have to restart the scan from scratch.
-	 */
-	if (cbk->cb_gen != gen && !reset)
-		D_GOTO(out, rc = -DER_NOT_RESUME);
-
-	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING)
-		D_GOTO(out, rc = -DER_ALREADY);
-
-	if (reset)
-		goto init;
-
-	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_COMPLETED)
-		D_GOTO(out, rc = 1);
-
-	/* For dryrun mode, restart from the beginning since we did not record former repairing. */
-	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
-		if (!reset)
-			D_GOTO(out, rc = -DER_NOT_RESUME);
-
-		goto init;
-	}
-
-	/*
-	 * XXX: If current rank list does not matches the former list, the we need to
-	 *	reset the check from scratch. Currently, we do not strictly check that.
-	 *	It is control plane's duty to generate valid rank list.
-	 */
-
-	/* Add new rank(s), need to reset. */
-	if (rank_nr > prop->cp_rank_nr) {
-		if (!reset)
-			D_GOTO(out, rc = -DER_NOT_RESUME);
-
-		goto init;
-	}
-
-	if (prop->cp_pool_nr < 0)
-		goto init;
-
-	/* Want to check new pool(s), need to reset. */
-	if (pool_nr < 0) {
-		if (!reset)
-			D_GOTO(out, rc = -DER_NOT_RESUME);
-
-		goto init;
-	}
-
-	for (i = 0; i < pool_nr; i++) {
-		for (j = 0; j < prop->cp_pool_nr; j++) {
-			if (uuid_compare(pools[i], prop->cp_pools[j]) == 0)
-				break;
-		}
-
-		/* Want to check new pool(s), need to reset. */
-		if (j == prop->cp_pool_nr) {
-			if (!reset)
-				D_GOTO(out, rc = -DER_NOT_RESUME);
-
-			goto init;
-		}
-	}
-
-init:
-	if (reset) {
-		ins->ci_slowest_fail_phase = CHK_INVAL_PHASE;
-		cbk->cb_gen = gen;
-		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
-		memset(&cbk->cb_statistics, 0, sizeof(cbk->cb_statistics));
-	}
+	ins->ci_start_flags = flags;
 
 	if (chk_is_on_leader(gen, leader, true)) {
-		/* The check leader has already verified the rank list. */
-		if (rank_nr != 0)
-			*rlist = uint32_array_to_rank_list(ranks, rank_nr);
-		else
-			rc = chk_prop_fetch(prop, rlist);
+		d_rank_list_free(ins->ci_ranks);
+		ins->ci_ranks = NULL;
+		rc = chk_prop_fetch(prop, &ins->ci_ranks);
+		if (rc != 0)
+			goto out;
 	} else {
-		rc = chk_prop_prepare(rank_nr, ranks, policy_nr, policies, pool_nr,
-				      pools, flags, phase, leader, prop, rlist);
+		rank_list = uint32_array_to_rank_list(ranks, rank_nr);
+		if (rank_list == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		d_rank_list_sort(rank_list);
 	}
 
+	if (ins->ci_start_flags & CSF_RESET_ALL)
+		goto reset;
+
+	/* For dryrun mode, restart from the scratch since we did not record former repairing. */
+	if (ins->ci_start_flags & CSF_RESET_NONCOMP) {
+		ctpa.ctpa_ins = ins;
+		ctpa.ctpa_gen = gen;
+		rc = chk_traverse_pools(chk_pools_cleanup_cb, &ctpa);
+		if (rc != 0)
+			goto out;
+	}
+
+	if (pool_nr > 0) {
+		rc = chk_pools_load_list(ins, gen, api_flags, pool_nr, pools);
+		if (rc != 0)
+			goto out;
+	} else {
+		ctpa.ctpa_ins = ins;
+		rc = chk_traverse_pools(chk_pools_load_from_db, &ctpa);
+		if (rc != 0)
+			goto out;
+	}
+
+	if (d_list_empty(&ins->ci_pool_list) && !(flags & CHK__CHECK_FLAG__CF_ORPHAN_POOL))
+		D_GOTO(out, rc = 1);
+
+	goto init;
+
+reset:
+	ctpa.ctpa_ins = ins;
+	ctpa.ctpa_gen = gen;
+	rc = chk_traverse_pools(chk_pools_cleanup_cb, &ctpa);
+	if (rc != 0)
+		goto out;
+
+	rc = ds_mgmt_tgt_pool_iterate(chk_pools_add_from_dir, &ctpa);
+	if (rc != 0)
+		goto out;
+
+	rc = ds_mgmt_newborn_pool_iterate(chk_pools_add_from_dir, &ctpa);
+	if (rc != 0)
+		goto out;
+
+	rc = ds_mgmt_zombie_pool_iterate(chk_pools_add_from_dir, &ctpa);
+	if (rc != 0)
+		goto out;
+
+	memset(cbk, 0, sizeof(*cbk));
+	cbk->cb_magic = CHK_BK_MAGIC_ENGINE;
+	cbk->cb_version = DAOS_CHK_VERSION;
+
+init:
+	if (!chk_is_on_leader(gen, leader, true)) {
+		rc = chk_prop_prepare(leader, api_flags | prop->cp_flags, phase,
+				      policy_nr, policies, rank_list, prop);
+		if (rc != 0)
+			goto out;
+
+		if (rank_list != NULL) {
+			d_rank_list_free(ins->ci_ranks);
+			ins->ci_ranks = rank_list;
+			rank_list = NULL;
+		}
+	}
+
+	cbk->cb_gen = gen;
+	if (api_flags & CHK__CHECK_FLAG__CF_RESET && !(ins->ci_start_flags & CSF_RESET_ALL)) {
+		memset(&cbk->cb_statistics, 0, sizeof(cbk->cb_statistics));
+		memset(&cbk->cb_time, 0, sizeof(cbk->cb_time));
+	}
+
+	ins->ci_slowest_fail_phase = CHK_INVAL_PHASE;
+
 out:
+	d_rank_list_free(rank_list);
+	if (rc < 0) {
+		/* Reset ci_ranks if hit failure, then we can reload when use it next time. */
+		d_rank_list_free(ins->ci_ranks);
+		ins->ci_ranks = NULL;
+	}
+
+	return rc;
+}
+
+static int
+chk_engine_start_post(struct chk_instance *ins)
+{
+	struct chk_pool_rec	*cpr;
+	struct chk_bookmark	*ins_cbk = &ins->ci_bk;
+	struct chk_bookmark	*pool_cbk;
+	char			 uuid_str[DAOS_UUID_STR_SIZE];
+	uint32_t		 phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
+	int			 rc = 0;
+
+	d_list_for_each_entry(cpr, &ins->ci_pool_list, cpr_link) {
+		pool_cbk = &cpr->cpr_bk;
+
+		if (pool_cbk->cb_phase == CHK__CHECK_SCAN_PHASE__DSP_DONE)
+			continue;
+
+		if (phase > pool_cbk->cb_phase)
+			phase = pool_cbk->cb_phase;
+
+		pool_cbk->cb_gen = ins_cbk->cb_gen;
+		pool_cbk->cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKING;
+		/* Always refresh the start time. */
+		pool_cbk->cb_time.ct_start_time = time(NULL);
+		/* QUEST: How to estimate the left time? */
+		pool_cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE -
+						 pool_cbk->cb_phase;
+
+		uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
+		rc = chk_bk_update_pool(pool_cbk, uuid_str);
+		if (rc != 0)
+			break;
+	}
+
+	if (rc == 0) {
+		/*
+		 * The phase may be CHK__CHECK_SCAN_PHASE__DSP_DONE, it is fine.
+		 *
+		 * The phase in engine bookmark may be larger then the phase in
+		 * some pools that may be new added into current check instance.
+		 * So we allow the phase to backward.
+		 */
+		ins_cbk->cb_phase = phase;
+		ins_cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
+		/* Always refresh the start time. */
+		ins_cbk->cb_time.ct_start_time = time(NULL);
+		/* QUEST: How to estimate the left time? */
+		ins_cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE -
+						ins_cbk->cb_phase;
+		rc = chk_bk_update_engine(ins_cbk);
+		if (rc == 0) {
+			d_list_for_each_entry(cpr, &ins->ci_pool_list, cpr_link) {
+				/* Shutdown former instance left opened pool. */
+				chk_pool_shutdown(cpr);
+			}
+		}
+	}
+
+	return rc;
+}
+
+static int
+chk_engine_pool_filter(uuid_t uuid, void *arg, int *phase)
+{
+	struct chk_instance	*ins = arg;
+	struct chk_pool_rec	*cpr;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
+	int			 rc;
+
+	D_ASSERT(ins != NULL);
+
+	d_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, uuid, sizeof(uuid_t));
+
+	rc = dbtree_lookup(ins->ci_pool_hdl, &kiov, &riov);
+	if (rc == 0) {
+		cpr = (struct chk_pool_rec *)riov.iov_buf;
+		*phase = cpr->cpr_bk.cb_phase;
+		D_ASSERT(*phase >= 0);
+	} else if (rc == -DER_NONEXIST && ins->ci_start_flags & CSF_ORPHAN_POOL) {
+		*phase = CHK_INVAL_PHASE;
+		rc = 0;
+	}
+
 	return rc;
 }
 
 int
-chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
-		 uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
-		 uuid_t pools[], uint32_t flags, int exp_phase, d_rank_t leader,
-		 uint32_t *cur_phase, struct ds_pool_clues *clues)
+chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
+		 struct chk_policy *policies, int pool_nr, uuid_t pools[], uint32_t api_flags,
+		 int phase, d_rank_t leader, uint32_t flags, struct ds_pool_clues *clues)
 {
 	struct chk_instance		*ins = chk_engine;
 	struct chk_bookmark		*cbk = &ins->ci_bk;
-	struct chk_property		*prop = &ins->ci_prop;
-	d_rank_list_t			*rank_list = NULL;
 	struct chk_pool_rec		*cpr;
 	struct chk_pool_rec		*tmp;
-	struct chk_traverse_pools_args	 ctpa = { 0 };
-	struct chk_pool_filter_args	 cpfa = { 0 };
 	struct umem_attr		 uma = { 0 };
 	uuid_t				 dummy_pool;
 	d_rank_t			 myrank = dss_self_rank();
 	int				 rc;
-	int				 i;
+	int				 rc1;
 
-	if (ins->ci_starting)
-		D_GOTO(out_log, rc = -DER_INPROGRESS);
-
-	if (ins->ci_stopping)
-		D_GOTO(out_log, rc = -DER_BUSY);
-
-	ins->ci_starting = 1;
-
-	rc = chk_engine_start_prepare(ins, rank_nr, ranks, policy_nr, policies,
-				      pool_nr, pools, gen, exp_phase, flags, leader, &rank_list);
+	rc = chk_ins_can_start(ins);
 	if (rc != 0)
 		goto out_log;
 
-	D_ASSERT(rank_list != NULL);
+	ins->ci_starting = 1;
+	ins->ci_started = 0;
+	ins->ci_start_flags = 0;
+
+	D_ASSERT(daos_handle_is_inval(ins->ci_pool_hdl));
 	D_ASSERT(d_list_empty(&ins->ci_pool_list));
+
+	D_ASSERT(daos_handle_is_inval(ins->ci_pending_hdl));
 	D_ASSERT(d_list_empty(&ins->ci_pending_list));
 
 	if (ins->ci_sched != ABT_THREAD_NULL)
@@ -1851,21 +1863,40 @@ chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 
 	chk_iv_ns_cleanup(&ins->ci_iv_ns);
 
+	if (ins->ci_iv_group != NULL) {
+		crt_group_secondary_destroy(ins->ci_iv_group);
+		ins->ci_iv_group = NULL;
+	}
+
+	uma.uma_id = UMEM_CLASS_VMEM;
+
+	rc = dbtree_create_inplace(DBTREE_CLASS_CHK_POOL, 0, CHK_BTREE_ORDER, &uma,
+				   &ins->ci_pool_btr, &ins->ci_pool_hdl);
+	if (rc != 0)
+		goto out_tree;
+
+	rc = dbtree_create_inplace(DBTREE_CLASS_CHK_PA, 0, CHK_BTREE_ORDER, &uma,
+				   &ins->ci_pending_btr, &ins->ci_pending_hdl);
+	if (rc != 0)
+		goto out_tree;
+
+	rc = chk_engine_start_prep(ins, rank_nr, ranks, policy_nr, policies,
+				   pool_nr, pools, gen, phase, api_flags, leader, flags);
+	if (rc != 0)
+		goto out_tree;
+
 	if (chk_is_on_leader(gen, leader, true)) {
 		ins->ci_iv_ns = chk_leader_get_iv_ns();
 		if (unlikely(ins->ci_iv_ns == NULL))
-			goto out_log;
+			goto out_tree;
 	} else {
-		if (ins->ci_iv_group != NULL) {
-			crt_group_secondary_destroy(ins->ci_iv_group);
-			ins->ci_iv_group = NULL;
-		}
-
-		rc = crt_group_secondary_create(CHK_DUMMY_POOL, NULL, rank_list, &ins->ci_iv_group);
+		rc = crt_group_secondary_create(CHK_DUMMY_POOL, NULL, ins->ci_ranks,
+						&ins->ci_iv_group);
 		if (rc != 0)
-			goto out_log;
+			goto out_tree;
 
 		uuid_parse(CHK_DUMMY_POOL, dummy_pool);
+
 		rc = ds_iv_ns_create(dss_get_module_info()->dmi_ctx, dummy_pool, ins->ci_iv_group,
 				     &ins->ci_iv_id, &ins->ci_iv_ns);
 		if (rc != 0)
@@ -1874,85 +1905,13 @@ chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 		ds_iv_ns_update(ins->ci_iv_ns, leader);
 	}
 
-	uma.uma_id = UMEM_CLASS_VMEM;
-
-	rc = dbtree_create_inplace(DBTREE_CLASS_CHK_POOL, 0, CHK_BTREE_ORDER, &uma,
-				   &ins->ci_pool_btr, &ins->ci_pool_hdl);
+	rc = ds_pool_clues_init(chk_engine_pool_filter, ins, clues);
 	if (rc != 0)
 		goto out_iv;
 
-	rc = dbtree_create_inplace(DBTREE_CLASS_CHK_PA, 0, CHK_BTREE_ORDER, &uma,
-				   &ins->ci_pending_btr, &ins->ci_pending_hdl);
+	rc = chk_engine_start_post(ins);
 	if (rc != 0)
-		goto out_tree;
-
-	if (prop->cp_pool_nr <= 0)
-		ins->ci_all_pools = 1;
-	else
-		ins->ci_all_pools = 0;
-
-	if (flags & CHK__CHECK_FLAG__CF_RESET) {
-		ctpa.ctpa_gen = cbk->cb_gen;
-		rc = chk_traverse_pools(chk_pools_cleanup_cb, &ctpa);
-		if (rc != 0)
-			goto out_tree;
-
-		ctpa.ctpa_gen = cbk->cb_gen;
-		ctpa.ctpa_ins = ins;
-
-		rc = ds_mgmt_tgt_pool_iterate(chk_pools_add_from_dir, &ctpa);
-		if (rc != 0)
-			goto out_pool;
-
-		rc = ds_mgmt_newborn_pool_iterate(chk_pools_add_from_dir, &ctpa);
-		if (rc != 0)
-			goto out_pool;
-
-		rc = ds_mgmt_zombie_pool_iterate(chk_pools_add_from_dir, &ctpa);
-		if (rc != 0)
-			goto out_pool;
-
-		*cur_phase = CHK__CHECK_SCAN_PHASE__CSP_PREPARE;
-	} else {
-		if (ins->ci_all_pools) {
-			ctpa.ctpa_gen = cbk->cb_gen;
-			ctpa.ctpa_ins = ins;
-			rc = chk_traverse_pools(chk_pools_add_from_db, &ctpa);
-			if (rc != 0)
-				goto out_pool;
-		} else {
-			for (i = 0; i < pool_nr; i++) {
-				rc = ds_mgmt_pool_exist(pools[i]);
-				if (rc < 0)
-					goto out_pool;
-
-				if (rc > 0) {
-					rc = chk_pool_start_one(ins, pools[i], cbk->cb_gen);
-					if (rc != 0)
-						goto out_pool;
-				}
-			}
-		}
-
-		*cur_phase = chk_engine_find_slowest(ins);
-	}
-
-	cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
-	cbk->cb_phase = *cur_phase;
-	/* Always refresh the start time. */
-	cbk->cb_time.ct_start_time = time(NULL);
-	/* XXX: How to estimate the left time? */
-	cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
-	rc = chk_bk_update_engine(cbk);
-	if (rc != 0)
-		goto out_pool;
-
-	if (cbk->cb_phase <= CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS) {
-		cpfa.cpfa_pool_hdl = ins->ci_pool_hdl;
-		rc = ds_pool_clues_init(chk_pool_filter, &cpfa, clues);
-		if (rc != 0)
-			goto out_bk;
-	}
+		goto out_stop;
 
 	ins->ci_sched_running = 1;
 
@@ -1960,24 +1919,23 @@ chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 			    &ins->ci_sched);
 	if (rc != 0) {
 		ins->ci_sched_running = 0;
-		goto out_bk;
+		goto out_stop;
 	}
 
 	goto out_log;
 
-out_bk:
-	if (rc != -DER_ALREADY && cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
-		cbk->cb_time.ct_stop_time = time(NULL);
-		cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
-		chk_bk_update_engine(cbk);
-	}
-out_pool:
+out_stop:
 	d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link)
 		chk_pool_stop_one(ins, cpr->cpr_uuid, CHK__CHECK_POOL_STATUS__CPS_IMPLICATED,
 				  CHK_INVAL_PHASE, NULL);
-out_tree:
-	chk_destroy_pending_tree(ins);
-	chk_destroy_pool_tree(ins);
+	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING) {
+		cbk->cb_time.ct_stop_time = time(NULL);
+		cbk->cb_ins_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+		rc1 = chk_bk_update_engine(cbk);
+		if (rc1 != 0)
+			D_WARN(DF_ENGINE" failed to update engine bookmark: "DF_RC"\n",
+			       DP_ENGINE(ins), DP_RC(rc1));
+	}
 out_iv:
 	chk_iv_ns_cleanup(&ins->ci_iv_ns);
 out_group:
@@ -1985,29 +1943,23 @@ out_group:
 		crt_group_secondary_destroy(ins->ci_iv_group);
 		ins->ci_iv_group = NULL;
 	}
+out_tree:
+	chk_destroy_pending_tree(ins);
+	chk_destroy_pool_tree(ins);
 out_log:
-	ins->ci_starting = 0;
+	if (rc >= 0) {
+		D_INFO(DF_ENGINE" started on rank %u with flags %x, phase %d, leader %u\n",
+		       DP_ENGINE(ins), myrank, flags, phase, leader);
 
-	if (rc == 0) {
-		D_INFO(DF_ENGINE" started on rank %u with %u ranks, %d pools, "
-		       "flags %x, phase %d, leader %u\n",
-		       DP_ENGINE(ins), myrank, rank_nr, pool_nr, flags, exp_phase, leader);
-
-		chk_ranks_dump(rank_list->rl_nr, rank_list->rl_ranks);
-
-		if (pool_nr > 0)
-			chk_pools_dump(pool_nr, pools);
-		else if (prop->cp_pool_nr > 0)
-			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
-	} else if (rc > 0) {
-		*cur_phase = CHK__CHECK_SCAN_PHASE__DSP_DONE;
+		chk_ranks_dump(ins->ci_ranks->rl_nr, ins->ci_ranks->rl_ranks);
+		chk_pools_dump(&ins->ci_pool_list, pool_nr, pools);
 	} else if (rc != -DER_ALREADY) {
 		D_ERROR(DF_ENGINE" failed to start on rank %u with %u ranks, %d pools, flags %x, "
 			"phase %d, leader %u, gen "DF_X64": "DF_RC"\n", DP_ENGINE(ins), myrank,
-			rank_nr, pool_nr, flags, exp_phase, leader, gen, DP_RC(rc));
+			rank_nr, pool_nr, flags, phase, leader, gen, DP_RC(rc));
 	}
 
-	d_rank_list_free(rank_list);
+	ins->ci_starting = 0;
 
 	return rc;
 }
@@ -2016,7 +1968,6 @@ int
 chk_engine_stop(uint64_t gen, int pool_nr, uuid_t pools[])
 {
 	struct chk_instance	*ins = chk_engine;
-	struct chk_property	*prop = &ins->ci_prop;
 	struct chk_bookmark	*cbk = &ins->ci_bk;
 	struct chk_pool_rec	*cpr;
 	struct chk_pool_rec	*tmp;
@@ -2032,10 +1983,10 @@ chk_engine_stop(uint64_t gen, int pool_nr, uuid_t pools[])
 	if (ins->ci_stopping)
 		D_GOTO(out, rc = -DER_INPROGRESS);
 
-	ins->ci_stopping = 1;
-
 	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
 		D_GOTO(out, rc = -DER_ALREADY);
+
+	ins->ci_stopping = 1;
 
 	if (pool_nr == 0) {
 		d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link) {
@@ -2064,18 +2015,15 @@ out:
 
 	if (rc >= 0) {
 		D_INFO(DF_ENGINE" stopped on rank %u with %d pools: rc %d\n", DP_ENGINE(ins),
-		       dss_self_rank(), pool_nr > 0 ? pool_nr : prop->cp_pool_nr, rc);
+		       dss_self_rank(), pool_nr, rc);
 
-		if (pool_nr > 0)
-			chk_pools_dump(pool_nr, pools);
-		else if (prop->cp_pool_nr > 0)
-			chk_pools_dump(prop->cp_pool_nr, prop->cp_pools);
+		chk_pools_dump(NULL, pool_nr, pools);
 	} else if (rc == -DER_ALREADY) {
 		rc = 1;
 	} else if (rc < 0) {
 		D_ERROR(DF_ENGINE" failed to stop on rank %u with %d pools, "
 			"gen "DF_X64": "DF_RC"\n", DP_ENGINE(ins), dss_self_rank(),
-			pool_nr > 0 ? pool_nr : prop->cp_pool_nr, gen, DP_RC(rc));
+			pool_nr, gen, DP_RC(rc));
 	}
 
 	return rc;
@@ -2280,8 +2228,9 @@ chk_engine_mark_rank_dead(uint64_t gen, d_rank_t rank, uint32_t version)
 	 *	 sometime later as the DAOS check going.
 	 */
 
-	rc = crt_group_secondary_modify(ins->ci_iv_group, rank_list, rank_list,
-					CRT_GROUP_MOD_OP_REPLACE, version);
+	if (ins->ci_iv_group != NULL)
+		rc = crt_group_secondary_modify(ins->ci_iv_group, rank_list, rank_list,
+						CRT_GROUP_MOD_OP_REPLACE, version);
 
 out:
 	d_rank_list_free(rank_list);
@@ -2748,10 +2697,6 @@ chk_engine_notify(struct chk_iv *iv)
 {
 	struct chk_instance	*ins = chk_engine;
 	struct chk_bookmark	*cbk = &ins->ci_bk;
-	struct chk_pool_rec	*cpr;
-	d_iov_t			 riov;
-	d_iov_t			 kiov;
-	char			 uuid_str[DAOS_UUID_STR_SIZE];
 	int			 rc = 0;
 
 	if (cbk->cb_gen != iv->ci_gen)
@@ -2761,45 +2706,7 @@ chk_engine_notify(struct chk_iv *iv)
 		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
 
 	if (!uuid_is_null(iv->ci_uuid)) {
-		switch (iv->ci_pool_status) {
-		case CHK__CHECK_POOL_STATUS__CPS_CHECKED:
-			if (iv->ci_phase != CHK__CHECK_SCAN_PHASE__DSP_DONE)
-				D_GOTO(out, rc = -DER_INVAL);
-
-			chk_pool_stop_one(ins, iv->ci_uuid, CHK__CHECK_POOL_STATUS__CPS_CHECKED,
-					  CHK__CHECK_SCAN_PHASE__DSP_DONE, &rc);
-			break;
-		case CHK__CHECK_POOL_STATUS__CPS_FAILED:
-		case CHK__CHECK_POOL_STATUS__CPS_IMPLICATED:
-			chk_pool_stop_one(ins, iv->ci_uuid, CHK__CHECK_POOL_STATUS__CPS_IMPLICATED,
-					  iv->ci_phase, &rc);
-			break;
-		case CHK__CHECK_POOL_STATUS__CPS_CHECKING:
-			d_iov_set(&riov, NULL, 0);
-			d_iov_set(&kiov, iv->ci_uuid, sizeof(uuid_t));
-			rc = dbtree_lookup(ins->ci_pool_hdl, &kiov, &riov);
-			if (rc != 0) {
-				if (rc == -DER_NONEXIST || rc == -DER_NO_HDL)
-					rc = -DER_NOTAPPLICABLE;
-				goto out;
-			}
-
-			cpr = (struct chk_pool_rec *)riov.iov_buf;
-			cbk = &cpr->cpr_bk;
-
-			if (cpr->cpr_stop || unlikely(iv->ci_phase < cbk->cb_phase))
-				D_GOTO(out, rc = -DER_NOTAPPLICABLE);
-
-			if (iv->ci_phase == cbk->cb_phase)
-				D_GOTO(out, rc = 0);
-
-			cbk->cb_phase = iv->ci_phase;
-			uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
-			rc = chk_bk_update_pool(cbk, uuid_str);
-			break;
-		default:
-			D_GOTO(out, rc = -DER_NOTAPPLICABLE);
-		}
+		rc = chk_pool_handle_notify(ins, iv);
 		goto out;
 	}
 
@@ -2816,6 +2723,9 @@ chk_engine_notify(struct chk_iv *iv)
 			D_GOTO(out, rc = 0);
 
 		cbk->cb_phase = iv->ci_phase;
+		rc = chk_bk_update_engine(cbk);
+		if (rc == 0)
+			rc = chk_pools_update_bk(ins, iv->ci_phase);
 		break;
 	case CHK__CHECK_INST_STATUS__CIS_FAILED:
 	case CHK__CHECK_INST_STATUS__CIS_IMPLICATED:
@@ -2981,7 +2891,7 @@ chk_engine_rejoin(void)
 	if (rc != 0)
 		goto out;
 
-	phase = chk_engine_find_slowest(ins);
+	phase = chk_engine_find_slowest(ins, NULL);
 	if (phase != cbk->cb_phase)
 		need_iv = true;
 

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -79,7 +79,7 @@ struct chk_pool_mbs {
 	((uint32_t)		(csi_flags)		CRT_VAR)		\
 	((int32_t)		(csi_phase)		CRT_VAR)		\
 	((d_rank_t)		(csi_leader_rank)	CRT_VAR)		\
-	((uint32_t)		(csi_padding)		CRT_VAR)		\
+	((uint32_t)		(csi_api_flags)		CRT_VAR)		\
 	((d_rank_t)		(csi_ranks)		CRT_ARRAY)		\
 	((struct chk_policy)	(csi_policies)		CRT_ARRAY)		\
 	((uuid_t)		(csi_uuids)		CRT_ARRAY)
@@ -87,8 +87,8 @@ struct chk_pool_mbs {
 #define DAOS_OSEQ_CHK_START							\
 	((int32_t)		(cso_status)		CRT_VAR)		\
 	((d_rank_t)		(cso_rank)		CRT_VAR)		\
-	((uint32_t)		(cso_phase)		CRT_VAR)		\
 	((int32_t)		(cso_child_status)	CRT_VAR)		\
+	((uint32_t)		(cso_padding)		CRT_VAR)		\
 	((struct ds_pool_clue)	(cso_clues)		CRT_ARRAY)
 
 CRT_RPC_DECLARE(chk_start, DAOS_ISEQ_CHK_START, DAOS_OSEQ_CHK_START);
@@ -287,16 +287,23 @@ CRT_RPC_DECLARE(chk_rejoin, DAOS_ISEQ_CHK_REJOIN, DAOS_OSEQ_CHK_REJOIN);
  *	to avoid hole is the struct chk_property.
  */
 #define CHK_POLICY_MAX		(CHK__CHECK_INCONSIST_CLASS__CIC_UNKNOWN + 1)
-#define CHK_POOLS_MAX		(1 << 6)
 
-typedef int (*chk_co_rpc_cb_t)(void *args, uint32_t rank, uint32_t phase, int result,
-			       void *data, uint32_t nr);
+typedef int (*chk_co_rpc_cb_t)(void *args, uint32_t rank, int result, void *data, uint32_t nr);
 
 typedef void (*chk_pool_free_data_t)(void *data);
 
+enum chk_start_flags {
+	/* Reset all check bookmarks, for leader, engines and all pools. */
+	CSF_RESET_ALL		= 1,
+	/* Reset the pool which check is not completed. */
+	CSF_RESET_NONCOMP	= 2,
+	/* Handle orphan pools. */
+	CSF_ORPHAN_POOL	= 4,
+};
+
 enum chk_act_flags {
 	/* The action is applicable to the same kind of inconssitency. */
-	CAF_FOR_ALL	= 1,
+	CAF_FOR_ALL		= 1,
 };
 
 enum chk_mbs_flags {
@@ -336,20 +343,98 @@ struct chk_bookmark {
 	struct chk_time			cb_time;
 };
 
-/* On each engine (including the leader), there is a key "chk/property" under its local sys_db. */
+/*
+ * On each engine (including the leader), there is a key "chk/property" under its local sys_db.
+ * That is shared by all the pools for current check instance.
+ *
+ * DAOS check property is persistent. Unless you specify new property to overwrite the old one
+ * when check start, otherwise, it will reuse former property for current check instance.
+ *
+ *
+ * About the leader:
+ *
+ * The leader bookmark and global pools' traces are only stored on current check leader. So if
+ * we switch to new check leader for current check instance, we will lose those former traces.
+ * Then we will have to rescan the whole system from scratch when switch to new check leader.
+ *
+ *
+ * About some flags:
+ *
+ * - CHK__CHECK_FLAG__CF_RESET
+ *
+ *   If 'reset' flag is specified together with pool list when check start, then it only makes
+ *   the check against the specified pools to rescan from the beginning.
+ *
+ *   If 'reset' flag is specified without pool list when check start, then all pools in system
+ *   will be affected with rescanning from scratch.
+ *
+ *   The 'reset' flag is not stored in the check property persistently. It is per instance, and
+ *   only affects current check start. When you restart DAOS check next time without explicitly
+ *   specify 'reset' flag, you will reuse former check property and resume the scan from former
+ *   pause/stop phase.
+ *
+ *   The 'reset' flag does not affect check property. If want to change check property, need to
+ *   overwrite related property explicitly when check start.
+ *
+ *   NOTE: If a pool has been 'checked' (as CHK__CHECK_SCAN_PHASE__DSP_DONE) in former instance,
+ *	   then current check instance will skip it directly unless explicitly set 'reset' flag
+ *	   or reset is triggered for other reason, such as check ranks changes.
+ *
+ * - CHK__CHECK_FLAG__CF_DRYRUN
+ *
+ *   To simplify the logic, dryrun mode is per system, not per pool. Means that if dryrun flag is
+ *   specified when check start, then all non-completed pools' check will be dryrun mode in spite
+ *   of whether a pool is in current instance check list or not.
+ *
+ *   Under dryrun mode, we do not really repair the found inconsistency, then we will lose former
+ *   stable base if we want to resume DAOS check from former pause/stop point. So if former check
+ *   instance ran under dryrun mode, then current check start will be handled as 'reset' for all
+ *   pools in spite of current instance is dryrun mode or not.
+ *
+ *   NOTE: Consider above behavior, although the 'dryrun' flag is stored persistently, it is per
+ *	   instance, and only affects current check instance.
+ *
+ * - CHK__CHECK_FLAG__CF_ORPHAN_POOL
+ *
+ *   Handle orphan pool requires all check engines to report their known pools (shards), then
+ *   compare the list with the MS known ones. But for most of time, the check instance may only
+ *   drive the check against some specified pool(s). So we offer two ways to trigger the handle
+ *   of orphan pools:
+ *
+ *   1. Anytime when the check is (re)start from the scratch for all pools, in spite of whether
+ *      it is for 'reset' flag without pool list or other reason, such as check ranks changes.
+ *
+ *   2. Explicitly specify 'orphan' flag when check start, in spite of it is for all pools or
+ *      just against the specified pool list.
+ *
+ *   NOTE: Similar as 'reset' flag, the 'orphan' flag is also not stored persistently, instead,
+ *	   it only affects current check instance.
+ *
+ *
+ * About the policies:
+ *
+ * The repair policies are shared among all pools. For some specified inconsistency, its repair
+ * policy may be changed during the check scan via CHECK_ACT dRPC downcall with 'for_all' flag.
+ *
+ * When check start, if do not specify policies, the former policies will be reused. Currently,
+ * we do not support to set policy just for special inconsistency class, means that either all
+ * are specified (to overwrite) or none. That can be improved in the future.
+ *
+ *
+ * About the ranks:
+ *
+ * The changes for the ranks that take part in the check means the potential pools' membership
+ * changes. It will affect former non-completed pools' check. Currently, to simplify the logic,
+ * if current check ranks do not match former ones, then current check start will be handled as
+ * 'reset' for all pools.
+ */
 struct chk_property {
 	d_rank_t			cp_leader;
 	Chk__CheckFlag			cp_flags;
 	Chk__CheckInconsistAction	cp_policies[CHK_POLICY_MAX];
 	/*
-	 * How many pools will be handled by the check instance. -1 means to handle all pools.
-	 * If the specified pools count exceeds CHK_POOLS_MAX, then all pools will be handled.
-	 */
-	int32_t				cp_pool_nr;
-	uuid_t				cp_pools[CHK_POOLS_MAX];
-	/*
-	 * XXX: Preserve for supporting to continue the check until the specified phase in the
-	 *	future. -1 means to check all phases.
+	 * NOTE: Preserve for supporting to continue the check until the specified phase in the
+	 *	 future. -1 means to check all phases.
 	 */
 	int32_t				cp_phase;
 	/* How many ranks (ever or should) take part in the check instance. */
@@ -399,13 +484,13 @@ struct chk_instance {
 	/* Generator for report event, pending repair actions, and so on. Only for leader. */
 	uint64_t		 ci_seq;
 
-	uint32_t		 ci_all_pools:1, /* Check all pools or not. */
-				 ci_is_leader:1,
+	uint32_t		 ci_is_leader:1,
 				 ci_sched_running:1,
 				 ci_starting:1,
 				 ci_stopping:1,
 				 ci_started:1,
 				 ci_implicated:1;
+	uint32_t		 ci_start_flags;
 };
 
 struct chk_iv {
@@ -439,6 +524,7 @@ struct chk_pool_rec {
 				 cpr_stop:1,
 				 cpr_done:1,
 				 cpr_skip:1,
+				 cpr_for_orphan:1,
 				 cpr_destroyed:1,
 				 cpr_healthy:1,
 				 cpr_delay_label:1,
@@ -493,12 +579,6 @@ struct chk_report_unit {
 	uint32_t		 cru_result;
 };
 
-struct chk_pool_filter_args {
-	daos_handle_t		 cpfa_pool_hdl;
-	int32_t			 cpfa_pool_nr;
-	uuid_t			*cpfa_pools;
-};
-
 struct chk_traverse_pools_args {
 	uint64_t		 ctpa_gen;
 	struct chk_instance	*ctpa_ins;
@@ -524,9 +604,9 @@ extern btr_ops_t		chk_cont_ops;
 
 void chk_ranks_dump(uint32_t rank_nr, d_rank_t *ranks);
 
-void chk_pools_dump(int pool_nr, uuid_t pools[]);
+void chk_pools_dump(d_list_t *head, int pool_nr, uuid_t pools[]);
 
-int chk_pool_filter(uuid_t uuid, void *arg);
+void  chk_pool_remove_nowait(struct chk_pool_rec *cpr, bool destroy);
 
 void chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, int status, uint32_t phase, int *ret);
 
@@ -534,7 +614,14 @@ int chk_pools_cleanup_cb(struct sys_db *db, char *table, d_iov_t *key, void *arg
 
 int chk_pool_start_one(struct chk_instance *ins, uuid_t uuid, uint64_t gen);
 
-int chk_pools_add_from_db(struct sys_db *db, char *table, d_iov_t *key, void *args);
+int chk_pools_load_list(struct chk_instance *ins, uint64_t gen, uint32_t flags,
+			int pool_nr, uuid_t pools[]);
+
+int chk_pools_load_from_db(struct sys_db *db, char *table, d_iov_t *key, void *args);
+
+int chk_pools_update_bk(struct chk_instance *ins, uint32_t phase);
+
+int chk_pool_handle_notify(struct chk_instance *ins, struct chk_iv *iv);
 
 int chk_pool_add_shard(daos_handle_t hdl, d_list_t *head, uuid_t uuid, d_rank_t rank,
 		       struct chk_bookmark *bk, struct chk_instance *ins,
@@ -549,10 +636,9 @@ int chk_pending_del(struct chk_instance *ins, uint64_t seq, struct chk_pending_r
 
 void chk_pending_destroy(struct chk_pending_rec *cpr);
 
-int chk_prop_prepare(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
-		     struct chk_policy *policies, int pool_nr, uuid_t pools[],
-		     uint32_t flags, int phase, d_rank_t leader,
-		     struct chk_property *prop, d_rank_list_t **rlist);
+int chk_prop_prepare(d_rank_t leader, uint32_t flags, int phase,
+		     uint32_t policy_nr, struct chk_policy *policies,
+		     d_rank_list_t *ranks, struct chk_property *prop);
 
 int chk_ins_init(struct chk_instance **p_ins);
 
@@ -562,8 +648,8 @@ void chk_ins_fini(struct chk_instance **p_ins);
 
 int chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 		     uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
-		     uuid_t pools[], uint32_t flags, int exp_phase, d_rank_t leader,
-		     uint32_t *cur_phase, struct ds_pool_clues *clues);
+		     uuid_t pools[], uint32_t api_flags, int phase, d_rank_t leader,
+		     uint32_t flags, struct ds_pool_clues *clues);
 
 int chk_engine_stop(uint64_t gen, int pool_nr, uuid_t pools[]);
 
@@ -624,7 +710,7 @@ void chk_leader_fini(void);
 
 int chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_rank_t *ranks,
 		     uint32_t policy_nr, struct chk_policy *policies, int pool_nr,
-		     uuid_t pools[], uint32_t flags, int phase, d_rank_t leader,
+		     uuid_t pools[], uint32_t api_flags, int phase, d_rank_t leader, uint32_t flags,
 		     chk_co_rpc_cb_t start_cb, void *args);
 
 int chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pools[],
@@ -874,12 +960,9 @@ chk_pool_shutdown(struct chk_pool_rec *cpr)
 
 	D_ASSERT(cpr->cpr_refs > 0);
 
-	if (cpr->cpr_started) {
-		d_iov_set(&psid, cpr->cpr_uuid, sizeof(uuid_t));
-		ds_rsvc_stop(DS_RSVC_CLASS_POOL, &psid, RDB_NIL_TERM, false);
-		ds_pool_stop(cpr->cpr_uuid);
-		cpr->cpr_started = 0;
-	}
+	d_iov_set(&psid, cpr->cpr_uuid, sizeof(uuid_t));
+	ds_rsvc_stop(DS_RSVC_CLASS_POOL, &psid, RDB_NIL_TERM, false);
+	ds_pool_stop(cpr->cpr_uuid);
 }
 
 static inline void
@@ -970,6 +1053,32 @@ chk_stop_sched(struct chk_instance *ins)
 	} else {
 		ABT_mutex_unlock(ins->ci_abt_mutex);
 	}
+}
+
+static inline int
+chk_ins_can_start(struct chk_instance *ins)
+{
+	struct chk_bookmark	*cbk = &ins->ci_bk;
+
+	if (ins->ci_starting)
+		return -DER_INPROGRESS;
+
+	if (ins->ci_stopping)
+		return -DER_BUSY;
+
+	if (ins->ci_sched_running)
+		return -DER_ALREADY;
+
+	/*
+	 * If ci_sched_running is zero but check instance is still running,
+	 * then someone is trying to stop it.
+	 */
+	if (((ins->ci_is_leader && cbk->cb_magic == CHK_BK_MAGIC_LEADER) ||
+	     (!ins->ci_is_leader && cbk->cb_magic == CHK_BK_MAGIC_ENGINE)) &&
+	    cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING)
+		return -DER_BUSY;
+
+	return 0;
 }
 
 #endif /* __CHK_INTERNAL_H__ */

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -827,12 +827,14 @@ chk_pool_wait(struct chk_pool_rec *cpr)
 {
 	D_ASSERT(cpr->cpr_refs > 0);
 
-	if (cpr->cpr_thread != ABT_THREAD_NULL) {
-		ABT_mutex_lock(cpr->cpr_mutex);
+	ABT_mutex_lock(cpr->cpr_mutex);
+	if (cpr->cpr_thread != ABT_THREAD_NULL && !cpr->cpr_stop) {
 		cpr->cpr_stop = 1;
 		ABT_cond_broadcast(cpr->cpr_cond);
 		ABT_mutex_unlock(cpr->cpr_mutex);
 		ABT_thread_free(&cpr->cpr_thread);
+	} else {
+		ABT_mutex_unlock(cpr->cpr_mutex);
 	}
 }
 

--- a/src/chk/chk_iv.c
+++ b/src/chk/chk_iv.c
@@ -100,24 +100,26 @@ chk_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			rc = -DER_IVCB_FORWARD;
 		} else {
 			/*
-			 * If it is message to engine, then it must be triggered by leader.
+			 * If it is message to engine, then it may be triggered by check leader,
+			 * but it also may be from the pool service leader to other pool shards.
 			 * Return zero that will trigger IV_SYNC to other check engines.
 			 */
-			D_ASSERT(chk_is_on_leader(src_iv->ci_gen, -1, false));
+			if (!src_iv->ci_from_psl)
+				D_ASSERT(chk_is_on_leader(src_iv->ci_gen, -1, false));
 
 			rc = 0;
 		}
 	} else if (src_iv->ci_to_leader) {
 		*dst_iv = *src_iv;
-		rc = chk_leader_notify(dst_iv->ci_gen, dst_iv->ci_rank, dst_iv->ci_phase,
-				       dst_iv->ci_status);
+		rc = chk_leader_notify(dst_iv);
 	} else {
 		/*
 		 * We got an IV SYNC (refresh) RPC from some engine. But because the engine
 		 * always set CRT_IV_SHORTCUT_TO_ROOT for sync, then this should not happen.
 		 */
-		D_ERROR("Got invalid IV SYNC with gen "DF_X64", rank %u, phase %u, status %d\n",
-			src_iv->ci_gen, src_iv->ci_rank, src_iv->ci_phase, src_iv->ci_status);
+		D_ERROR("Got invalid IV SYNC with gen "DF_X64", rank %u, phase %u, status %d/%d\n",
+			src_iv->ci_gen, src_iv->ci_rank, src_iv->ci_phase, src_iv->ci_ins_status,
+			src_iv->ci_pool_status);
 		rc = -DER_IO;
 	}
 
@@ -131,12 +133,18 @@ chk_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 {
 	struct chk_iv	*dst_iv = entry->iv_value.sg_iovs[0].iov_buf;
 	struct chk_iv	*src_iv = src->sg_iovs[0].iov_buf;
+	int		 rc = 0;
 
-	D_ASSERT(src_iv->ci_to_leader == 0);
+	/*
+	 * Do not need local refresh from the pool service leader.
+	 * But we need local refresh from the check leader on the same rank.
+	 */
+	if (src_iv->ci_rank != dss_self_rank()) {
+		*dst_iv = *src_iv;
+		rc = chk_engine_notify(dst_iv);
+	}
 
-	*dst_iv = *src_iv;
-	return chk_engine_notify(dst_iv->ci_gen, dst_iv->ci_uuid, dst_iv->ci_rank, dst_iv->ci_phase,
-				 dst_iv->ci_status, dst_iv->ci_remove_pool ? true : false);
+	return rc;
 }
 
 static int
@@ -168,10 +176,10 @@ chk_iv_update(void *ns, struct chk_iv *iv, uint32_t shortcut, uint32_t sync_mode
 
 	if (chk_is_on_leader(iv->ci_gen, -1, false) && iv->ci_to_leader) {
 		/*
-		 * XXX: It is the check engine sends IV message to the check leader on
-		 *	the same rank. Then directly notify the check leader without RPC.
+		 * It is the check engine sends IV message to the check leader on
+		 * the same rank. Then directly notify the check leader without RPC.
 		 */
-		rc = chk_leader_notify(iv->ci_gen, iv->ci_rank, iv->ci_phase, iv->ci_status);
+		rc = chk_leader_notify(iv);
 	} else {
 		iov.iov_buf = iv;
 		iov.iov_len = sizeof(*iv);

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -299,11 +299,11 @@ chk_leader_exit(struct chk_instance *ins, uint32_t status, bool bcast)
 	    status == CHK__CHECK_INST_STATUS__CIS_IMPLICATED) {
 		iv.ci_gen = cbk->cb_gen;
 		iv.ci_phase = cbk->cb_phase;
-		iv.ci_status = status;
+		iv.ci_ins_status = status;
 
-		/* Asynchronously notify the engines that the check leader exit. */
+		/* Synchronously notify the engines that the check leader exit. */
 		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
-				   CRT_IV_SYNC_LAZY, true);
+				   CRT_IV_SYNC_EAGER, true);
 		if (rc != 0)
 			D_ERROR(DF_LEADER" failed to notify the engines its exit, status %u: "
 				DF_RC"\n", DP_LEADER(ins), status, DP_RC(rc));
@@ -336,7 +336,8 @@ chk_leader_find_slowest(struct chk_instance *ins)
 }
 
 static void
-chk_leader_post_repair(struct chk_instance *ins, uuid_t uuid, int *result, bool update, bool notify)
+chk_leader_post_repair(struct chk_instance *ins, struct chk_pool_rec *cpr,
+		       int *result, bool update, bool notify)
 {
 	struct chk_bookmark	*cbk = &ins->ci_bk;
 	struct chk_iv		 iv = { 0 };
@@ -349,13 +350,15 @@ chk_leader_post_repair(struct chk_instance *ins, uuid_t uuid, int *result, bool 
 	if (*result == 0 || !(ins->ci_prop.cp_flags & CHK__CHECK_FLAG__CF_FAILOUT)) {
 		if (notify) {
 			iv.ci_gen = cbk->cb_gen;
-			uuid_copy(iv.ci_uuid, uuid);
+			uuid_copy(iv.ci_uuid, cpr->cpr_uuid);
 			iv.ci_phase = cbk->cb_phase;
+			/* TBD for pool status in next patch. */
 			if (*result != 0)
-				iv.ci_status = CHK__CHECK_INST_STATUS__CIS_FAILED;
+				iv.ci_pool_status = CHK__CHECK_POOL_STATUS__CPS_FAILED;
+			else if (cpr->cpr_destroyed)
+				iv.ci_pool_status = CHK__CHECK_POOL_STATUS__CPS_CHECKED;
 			else
-				iv.ci_status = CHK__CHECK_INST_STATUS__CIS_IMPLICATED;
-			iv.ci_remove_pool = 1;
+				iv.ci_pool_status = CHK__CHECK_POOL_STATUS__CPS_IMPLICATED;
 
 			/* Synchronously notify the engines that check on the pool got failure. */
 			rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
@@ -363,7 +366,7 @@ chk_leader_post_repair(struct chk_instance *ins, uuid_t uuid, int *result, bool 
 			if (rc != 0)
 				D_ERROR(DF_LEADER" failed to notify the engines that "
 					"the pool "DF_UUIDF" got failure: "DF_RC"\n",
-					DP_LEADER(ins), DP_UUID(uuid), DP_RC(rc));
+					DP_LEADER(ins), DP_UUID(cpr->cpr_uuid), DP_RC(rc));
 		}
 
 		if (update)
@@ -448,7 +451,7 @@ chk_leader_destroy_pool(struct chk_pool_rec *cpr, uint64_t seq, bool dereg)
 	 */
 	if (dereg) {
 		rc = ds_chk_deregpool_upcall(seq, cpr->cpr_uuid);
-		if (rc != 0)
+		if (rc != 0 && rc != -DER_NONEXIST)
 			goto out;
 	}
 
@@ -457,6 +460,10 @@ chk_leader_destroy_pool(struct chk_pool_rec *cpr, uint64_t seq, bool dereg)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	rc = ds_mgmt_tgt_pool_destroy(cpr->cpr_uuid, ranks);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+	if (rc == 0)
+		cpr->cpr_destroyed = 1;
 	d_rank_list_free(ranks);
 
 out:
@@ -540,7 +547,7 @@ out:
 		 * parse the pool clues, then have to skip it. Notify the check engines.
 		 */
 		cpr->cpr_skip = 1;
-		chk_leader_post_repair(ins, cpr->cpr_uuid, &rc, false, true);
+		chk_leader_post_repair(ins, cpr, &rc, false, true);
 	}
 
 	return rc;
@@ -722,7 +729,7 @@ report:
 	goto report;
 
 out:
-	chk_leader_post_repair(ins, uuid, &result, true, false);
+	chk_leader_post_repair(ins, NULL, &result, true, false);
 
 	return result;
 }
@@ -936,7 +943,7 @@ out:
 	 * to fix related inconsistency), then notify check engines to remove related
 	 * pool record and bookmark.
 	 */
-	chk_leader_post_repair(ins, cpr->cpr_uuid, &result, true, cpr->cpr_skip ? true : false);
+	chk_leader_post_repair(ins, cpr, &result, true, cpr->cpr_skip ? true : false);
 
 	return result;
 }
@@ -1242,7 +1249,7 @@ out:
 	 * to fix related inconsistency), then notify check engines to remove related
 	 * pool record and bookmark.
 	 */
-	chk_leader_post_repair(ins, cpr->cpr_uuid, &result, true, cpr->cpr_skip ? true : false);
+	chk_leader_post_repair(ins, cpr, &result, true, cpr->cpr_skip ? true : false);
 
 	return result;
 }
@@ -1327,10 +1334,10 @@ out:
 		cpr->cpr_skip = 1;
 		if (!cpr->cpr_healthy)
 			cbk->cb_statistics.cs_failed++;
-		chk_leader_post_repair(ins, cpr->cpr_uuid, &rc, !cpr->cpr_healthy, true);
+		chk_leader_post_repair(ins, cpr, &rc, !cpr->cpr_healthy, true);
 	} else if (!cpr->cpr_healthy) {
 		cbk->cb_statistics.cs_repaired++;
-		chk_leader_post_repair(ins, cpr->cpr_uuid, &rc, true, false);
+		chk_leader_post_repair(ins, cpr, &rc, true, false);
 	}
 
 	return rc;
@@ -1547,8 +1554,7 @@ out:
 	 * If decide to delay pool label update on PS until CHK__CHECK_SCAN_PHASE__CSP_POOL_CLEANUP,
 	 * then it is unnecessary to update the leader bookmark.
 	 */
-	chk_leader_post_repair(ins, cpr->cpr_uuid, &result,
-			       cpr->cpr_delay_label ? false : true, false);
+	chk_leader_post_repair(ins, cpr, &result, cpr->cpr_delay_label ? false : true, false);
 
 	return result;
 }
@@ -1558,10 +1564,12 @@ chk_leader_handle_pools_list(struct chk_sched_args *csa)
 {
 	struct chk_pool_filter_args	 cpfa = { 0 };
 	struct chk_property		*prop = &csa->csa_ins->ci_prop;
+	struct chk_bookmark		*cbk = &csa->csa_ins->ci_bk;
 	struct ds_pool_clue		*clue = NULL;
 	struct chk_list_pool		*clp = NULL;
 	struct chk_pool_rec		*cpr;
 	struct chk_pool_rec		*tmp;
+	static d_rank_list_t		*ranks;
 	d_iov_t				 riov;
 	d_iov_t				 kiov;
 	int				 clp_nr;
@@ -1621,19 +1629,48 @@ chk_leader_handle_pools_list(struct chk_sched_args *csa)
 	}
 
 	d_list_for_each_entry_safe(cpr, tmp, &csa->csa_list, cpr_link) {
-		if (cpr->cpr_exist_on_ms || cpr->cpr_skip)
-			continue;
-
-		rc = chk_leader_handle_pool_clues(cpr);
-		if (rc != 0)
-			goto out;
-
 		if (cpr->cpr_skip)
 			continue;
 
+		ranks = chk_leader_cpr2ranklist(cpr, false);
+		if (ranks == NULL) {
+			cpr->cpr_skip = 1;
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		if (cpr->cpr_exist_on_ms) {
+			rc = chk_pool_start_remote(ranks, cbk->cb_gen, cpr->cpr_uuid,
+						   CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST);
+			if (rc != 0) {
+				cpr->cpr_skip = 1;
+				if (rc == -DER_SHUTDOWN || rc == -DER_NONEXIST ||
+				    !(prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT))
+					rc = 0;
+			}
+			goto next;
+		}
+
+		rc = chk_leader_handle_pool_clues(cpr);
+		if (rc != 0 || cpr->cpr_skip)
+			goto next;
+
 		rc = chk_leader_orphan_pool(cpr);
+		if (rc != 0 || cpr->cpr_skip)
+			goto next;
+
+		rc = chk_pool_start_remote(ranks, cbk->cb_gen, cpr->cpr_uuid,
+					   CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST);
+		if (rc != 0) {
+			cpr->cpr_skip = 1;
+			if (rc == -DER_SHUTDOWN || rc == -DER_NONEXIST ||
+			    !(prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT))
+				rc = 0;
+		}
+
+next:
+		d_rank_list_free(ranks);
 		if (rc != 0)
-			goto out;
+			break;
 	}
 
 out:
@@ -1647,29 +1684,12 @@ out:
 }
 
 static int
-chk_leader_handle_pools_svc(struct chk_sched_args *csa)
-{
-	struct chk_pool_rec	*cpr;
-	struct chk_pool_rec	*tmp;
-	int			 rc = 0;
-
-	d_list_for_each_entry_safe(cpr, tmp, &csa->csa_list, cpr_link) {
-		if (!cpr->cpr_skip) {
-			rc = chk_leader_start_pool_svc(cpr);
-			if (rc != 0)
-				break;
-		}
-	}
-
-	return rc;
-}
-
-static int
-chk_leader_pool_mbs_one(struct chk_instance *ins, struct chk_pool_rec *cpr)
+chk_leader_pool_mbs_one(struct chk_pool_rec *cpr)
 {
 	struct rsvc_client	 client = { 0 };
 	crt_endpoint_t		 ep = { 0 };
 	struct rsvc_hint	 hint = { 0 };
+	struct chk_instance	*ins = cpr->cpr_ins;
 	struct chk_bookmark	*cbk = &ins->ci_bk;
 	d_rank_list_t		*ps_ranks = NULL;
 	struct chk_pool_shard	*cps;
@@ -1677,6 +1697,7 @@ chk_leader_pool_mbs_one(struct chk_instance *ins, struct chk_pool_rec *cpr)
 	int			 rc = 0;
 	int			 rc1;
 	int			 i = 0;
+	bool			 notify = true;
 
 	D_ASSERT(cpr->cpr_mbs == NULL);
 
@@ -1690,6 +1711,11 @@ chk_leader_pool_mbs_one(struct chk_instance *ins, struct chk_pool_rec *cpr)
 
 		cpr->cpr_mbs[i].cpm_rank = cps->cps_rank;
 		cpr->cpr_mbs[i].cpm_tgt_nr = clue->pc_tgt_nr;
+		/*
+		 * NOTE: Do not allocate space for cpm_tgt_status, instead, we can directly
+		 *	 use clue->pc_tgt_status, that will be freed when free the pool rec
+		 *	 via chk_pool_put()->cps_free_cb().
+		 */
 		cpr->cpr_mbs[i].cpm_tgt_status = clue->pc_tgt_status;
 		i++;
 	}
@@ -1709,7 +1735,8 @@ again:
 	if (rc != 0)
 		goto out_client;
 
-	rc = chk_pool_mbs_remote(ep.ep_rank, cbk->cb_gen, cpr->cpr_uuid, cpr->cpr_label,
+	rc = chk_pool_mbs_remote(ep.ep_rank, CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS, cbk->cb_gen,
+				 cpr->cpr_uuid, cpr->cpr_label,
 				 cpr->cpr_delay_label ? CMF_REPAIR_LABEL : 0,
 				 cpr->cpr_shard_nr, cpr->cpr_mbs, &hint);
 
@@ -1717,6 +1744,10 @@ again:
 	if (rc1 == RSVC_CLIENT_RECHOOSE ||
 	    (rc1 == RSVC_CLIENT_PROCEED && daos_rpc_retryable_rc(rc))) {
 		dss_sleep(RECHOOSE_SLEEP_MS);
+		if (cpr->cpr_stop || !ins->ci_sched_running) {
+			notify = false;
+			D_GOTO(out_client, rc = 0);
+		}
 		goto again;
 	}
 
@@ -1724,16 +1755,19 @@ out_client:
 	rsvc_client_fini(&client);
 
 out_post:
-	if (rc != 0)
+	if (rc != 0) {
 		cpr->cpr_skip = 1;
+		if (rc == -DER_SHUTDOWN || rc == -DER_NONEXIST)
+			rc = 0;
 
-	chk_leader_post_repair(ins, cpr->cpr_uuid, &rc, false, true);
+		chk_leader_post_repair(ins, cpr, &rc, false, notify);
+	}
 
 	return rc;
 }
 
 static int
-chk_leader_pool_mbs(struct chk_sched_args *csa)
+chk_leader_handle_pools_svc(struct chk_sched_args *csa)
 {
 	struct chk_pool_rec	*cpr;
 	struct chk_pool_rec	*tmp;
@@ -1741,7 +1775,9 @@ chk_leader_pool_mbs(struct chk_sched_args *csa)
 
 	d_list_for_each_entry_safe(cpr, tmp, &csa->csa_list, cpr_link) {
 		if (!cpr->cpr_skip) {
-			rc = chk_leader_pool_mbs_one(csa->csa_ins, cpr);
+			rc = chk_leader_start_pool_svc(cpr);
+			if (rc == 0 && !cpr->cpr_skip)
+				rc = chk_leader_pool_mbs_one(cpr);
 			if (rc != 0)
 				break;
 		}
@@ -1777,11 +1813,10 @@ chk_leader_sched(void *args)
 	struct chk_bookmark	*cbk = &ins->ci_bk;
 	uint32_t		 phase;
 	uint32_t		 status;
-	struct chk_iv		 iv = { 0 };
 	int			 rc = 0;
 	bool			 bcast = false;
 
-	D_INFO(DF_LEADER" start at the phase %u\n", DP_LEADER(ins), cbk->cb_phase);
+	D_INFO(DF_LEADER" scheduler enter at phase %u\n", DP_LEADER(ins), cbk->cb_phase);
 
 	ABT_mutex_lock(ins->ci_abt_mutex);
 
@@ -1825,34 +1860,16 @@ handle:
 		if (rc != 0)
 			D_GOTO(out, bcast = true);
 
-		rc = chk_leader_need_stop(ins);
-		if (rc >= 0)
-			goto out;
-
-		iv.ci_gen = cbk->cb_gen;
-		iv.ci_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST;
-		iv.ci_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
-
-		/* Synchronously notify the engines to move ahead. */
-		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
-				   CRT_IV_SYNC_EAGER, true);
-
-		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-			 DF_LEADER" notify the engines to move phase to %u: "DF_RC"\n",
-			 DP_LEADER(ins), CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST, DP_RC(rc));
-
-		if (rc != 0)
-			/* Have to failout since cannot drive the check to go ahead. */
-			D_GOTO(out, bcast = false);
-
 		/*
-		 * XXX: Update the bookmark after successfully notify the check engines.
-		 *	Do not change the order, otherwise if the check instance restart
-		 *	before the phase CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST, then next
-		 *	time leader will not IV for CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST.
+		 * NOTE: Update the bookmark after successfully notify the check engines.
+		 *	 Do not change the order, otherwise if the check instance restart
+		 *	 before the phase CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST, then next
+		 *	 time leader will not IV for CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST.
 		 */
 		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST;
-		chk_bk_update_leader(cbk);
+		rc = chk_bk_update_leader(cbk);
+		if (rc != 0)
+			D_GOTO(out, bcast = true);
 	}
 
 	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST) {
@@ -1864,42 +1881,14 @@ handle:
 		if (rc != 0)
 			D_GOTO(out, bcast = true);
 
-		rc = chk_leader_need_stop(ins);
-		if (rc >= 0)
-			goto out;
-
-		iv.ci_gen = cbk->cb_gen;
-		iv.ci_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS;
-		iv.ci_status = CHK__CHECK_INST_STATUS__CIS_RUNNING;
-
-		/* Synchronously notify the engines to move ahead. */
-		rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
-				   CRT_IV_SYNC_EAGER, true);
-
-		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-			 DF_LEADER" notify the engines to move phase to %u: "DF_RC"\n",
-			 DP_LEADER(ins), CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS, DP_RC(rc));
-
-		if (rc != 0)
-			/* Have to failout since cannot drive the check to go ahead. */
-			D_GOTO(out, bcast = false);
-
 		/*
-		 * XXX: Update the bookmark after successfully notify the check engines.
-		 *	Do not change the order, otherwise if the check instance restart
-		 *	before the phase CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST, then next
-		 *	time leader will not IV for CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS.
+		 * NOTE: Update the bookmark after successfully notify the check engines.
+		 *	 Do not change the order, otherwise if the check instance restart
+		 *	 before the phase CHK__CHECK_SCAN_PHASE__CSP_POOL_LIST, then next
+		 *	 time leader will not IV for CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS.
 		 */
 		cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS;
-		chk_bk_update_leader(cbk);
-	}
-
-	if (cbk->cb_phase == CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS) {
-		rc = chk_leader_need_stop(ins);
-		if (rc >= 0)
-			goto out;
-
-		rc = chk_leader_pool_mbs(csa);
+		rc = chk_bk_update_leader(cbk);
 		if (rc != 0)
 			D_GOTO(out, bcast = true);
 	}
@@ -1918,19 +1907,30 @@ handle:
 		 */
 
 		phase = chk_leader_find_slowest(ins);
-		if (phase != cbk->cb_phase) {
+		if (phase == CHK__CHECK_SCAN_PHASE__DSP_DONE) {
+			D_INFO(DF_LEADER" has done\n", DP_LEADER(ins));
+			D_GOTO(out, rc = 1);
+		}
+
+		if (phase > cbk->cb_phase) {
+			D_INFO(DF_LEADER" moves from phase %u to phase %u\n",
+			       DP_LEADER(ins), cbk->cb_phase, phase);
+
 			cbk->cb_phase = phase;
-			/* XXX: How to estimate the left time? */
+			/* QUEST: How to estimate the left time? */
 			cbk->cb_time.ct_left_time = CHK__CHECK_SCAN_PHASE__DSP_DONE - cbk->cb_phase;
-			chk_bk_update_leader(cbk);
-			if (phase == CHK__CHECK_SCAN_PHASE__DSP_DONE)
-				D_GOTO(out, rc = 1);
+			rc = chk_bk_update_leader(cbk);
+			if (rc != 0)
+				D_GOTO(out, bcast = true);
 		}
 	}
 
 out:
 	if (rc > 0) {
-		/* If some engine(s) failed during the start, then mark the instance as 'failed'. */
+		/*
+		 * If some engine(s) failed during the start, then mark the instance as 'failed'.
+		 * It means that there is at least one failure during the DAOS check at somewhere.
+		 */
 		if (ins->ci_slowest_fail_phase != CHK_INVAL_PHASE)
 			status = CHK__CHECK_INST_STATUS__CIS_FAILED;
 		else
@@ -1950,8 +1950,8 @@ out:
 	chk_leader_exit(ins, status, bcast);
 	chk_csa_put(csa);
 
-	D_INFO(DF_LEADER" exit at the phase %u: "DF_RC"\n",
-	       DP_LEADER(ins), cbk->cb_phase, DP_RC(rc));
+	D_INFO(DF_LEADER" scheduler exit at phase %u with status %u: "DF_RC"\n",
+	       DP_LEADER(ins), cbk->cb_phase, status, DP_RC(rc));
 
 	ins->ci_sched_running = 0;
 }
@@ -2801,7 +2801,7 @@ out:
 }
 
 int
-chk_leader_notify(uint64_t gen, d_rank_t rank, uint32_t phase, uint32_t status)
+chk_leader_notify(struct chk_iv *iv)
 {
 	struct chk_instance	*ins = chk_leader;
 	struct chk_property	*prop = &ins->ci_prop;
@@ -2816,13 +2816,18 @@ chk_leader_notify(uint64_t gen, d_rank_t rank, uint32_t phase, uint32_t status)
 	if (cbk->cb_magic != CHK_BK_MAGIC_LEADER)
 		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
 
-	if (cbk->cb_gen != gen)
+	if (cbk->cb_gen != iv->ci_gen)
 		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
 
 	if (cbk->cb_ins_status != CHK__CHECK_INST_STATUS__CIS_RUNNING)
 		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
 
-	switch (status) {
+	if (!uuid_is_null(iv->ci_uuid)) {
+		/* TBD in next patch. */
+		D_GOTO(out, rc = 0);
+	}
+
+	switch (iv->ci_ins_status) {
 	case CHK__CHECK_INST_STATUS__CIS_INIT:
 	case CHK__CHECK_INST_STATUS__CIS_STOPPED:
 	case CHK__CHECK_INST_STATUS__CIS_PAUSED:
@@ -2830,36 +2835,34 @@ chk_leader_notify(uint64_t gen, d_rank_t rank, uint32_t phase, uint32_t status)
 		/* Directly ignore above. */
 		break;
 	case CHK__CHECK_INST_STATUS__CIS_RUNNING:
-		if (unlikely(phase < cbk->cb_phase))
-			D_GOTO(out, rc = -DER_INVAL);
+		if (unlikely(iv->ci_phase < cbk->cb_phase))
+			D_GOTO(out, rc = -DER_NOTAPPLICABLE);
 
-		if (phase == cbk->cb_phase)
+		if (iv->ci_phase == cbk->cb_phase)
 			D_GOTO(out, rc = 0);
 
-		rbund.crb_rank = rank;
-		rbund.crb_phase = phase;
+		rbund.crb_rank = iv->ci_rank;
+		rbund.crb_phase = iv->ci_phase;
 		rbund.crb_ins = ins;
 
 		d_iov_set(&riov, &rbund, sizeof(rbund));
-		d_iov_set(&kiov, &rank, sizeof(rank));
+		d_iov_set(&kiov, &iv->ci_rank, sizeof(iv->ci_rank));
 		rc = dbtree_update(ins->ci_rank_hdl, &kiov, &riov);
 		break;
 	case CHK__CHECK_INST_STATUS__CIS_COMPLETED:
 		/*
-		 * XXX: Currently, we do not support to partial check till the specified phase.
-		 *	Then the completed phase will be either container cleanup or all done.
+		 * NOTE: Currently, we do not support to partial check till the specified phase.
+		 *	 Then the completed phase will be either container cleanup or all done.
 		 */
-		if (unlikely(phase != CHK__CHECK_SCAN_PHASE__CSP_CONT_CLEANUP &&
-			     phase != CHK__CHECK_SCAN_PHASE__DSP_DONE))
+		if (unlikely(iv->ci_phase != CHK__CHECK_SCAN_PHASE__CSP_CONT_CLEANUP &&
+			     iv->ci_phase != CHK__CHECK_SCAN_PHASE__DSP_DONE))
 			D_GOTO(out, rc = -DER_INVAL);
 
-		rc = chk_rank_del(ins, rank);
+		rc = chk_rank_del(ins, iv->ci_rank);
 		break;
 	case CHK__CHECK_INST_STATUS__CIS_FAILED:
-		if (ins->ci_slowest_fail_phase > phase)
-			ins->ci_slowest_fail_phase = phase;
-
-		rc = chk_rank_del(ins, rank);
+		chk_ins_set_fail(ins, iv->ci_phase);
+		rc = chk_rank_del(ins, iv->ci_rank);
 		if (rc != 0 || !(prop->cp_flags & CHK__CHECK_FLAG__CF_FAILOUT))
 			D_GOTO(out, rc = (rc == -DER_NONEXIST ? 0 : rc));
 
@@ -2873,8 +2876,10 @@ chk_leader_notify(uint64_t gen, d_rank_t rank, uint32_t phase, uint32_t status)
 
 out:
 	D_CDEBUG(rc != 0 && rc != -DER_NOTAPPLICABLE, DLOG_ERR, DLOG_INFO,
-		 DF_LEADER" handle notification from rank %u, phase %u, status %u: "
-		 DF_RC"\n", DP_LEADER(ins), rank, phase, status, DP_RC(rc));
+		 DF_LEADER" handle notification from rank %u, for pool "
+		 DF_UUIDF", phase %u, ins_status %u, pool_status %u, gen "DF_X64": "DF_RC"\n",
+		 DP_LEADER(ins), iv->ci_rank, DP_UUID(iv->ci_uuid), iv->ci_phase,
+		 iv->ci_ins_status, iv->ci_pool_status, iv->ci_gen, DP_RC(rc));
 
 	return (rc == 0 || rc == -DER_NOTAPPLICABLE) ? 0 : rc;
 }

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -161,14 +161,30 @@ ds_chk_cont_list_hdlr(crt_rpc_t *rpc)
 }
 
 static void
+ds_chk_pool_start_hdlr(crt_rpc_t *rpc)
+{
+	struct chk_pool_start_in	*cpsi = crt_req_get(rpc);
+	struct chk_pool_start_out	*cpso = crt_reply_get(rpc);
+	int				 rc;
+
+	rc = chk_engine_pool_start(cpsi->cpsi_gen, cpsi->cpsi_pool, cpsi->cpsi_phase);
+
+	cpso->cpso_status = rc;
+	cpso->cpso_rank = dss_self_rank();
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("Failed to reply check pool start: "DF_RC"\n", DP_RC(rc));
+}
+
+static void
 ds_chk_pool_mbs_hdlr(crt_rpc_t *rpc)
 {
 	struct chk_pool_mbs_in	*cpmi = crt_req_get(rpc);
 	struct chk_pool_mbs_out	*cpmo = crt_reply_get(rpc);
 	int			 rc;
 
-	rc = chk_engine_pool_mbs(cpmi->cpmi_gen, cpmi->cpmi_pool, cpmi->cpmi_label,
-				 cpmi->cpmi_flags, cpmi->cpmi_targets.ca_count,
+	rc = chk_engine_pool_mbs(cpmi->cpmi_gen, cpmi->cpmi_pool, cpmi->cpmi_phase,
+				 cpmi->cpmi_label, cpmi->cpmi_flags, cpmi->cpmi_targets.ca_count,
 				 cpmi->cpmi_targets.ca_arrays, &cpmo->cpmo_hint);
 
 	cpmo->cpmo_status = rc;

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -20,17 +20,15 @@ ds_chk_start_hdlr(crt_rpc_t *rpc)
 	struct chk_start_in	*csi = crt_req_get(rpc);
 	struct chk_start_out	*cso = crt_reply_get(rpc);
 	struct ds_pool_clues	 clues = { 0 };
-	uint32_t		 phase = 0;
 	int			 rc;
 
 	rc = chk_engine_start(csi->csi_gen, csi->csi_ranks.ca_count, csi->csi_ranks.ca_arrays,
 			      csi->csi_policies.ca_count, csi->csi_policies.ca_arrays,
-			      csi->csi_uuids.ca_count, csi->csi_uuids.ca_arrays,
-			      csi->csi_flags, csi->csi_phase, csi->csi_leader_rank, &phase, &clues);
+			      csi->csi_uuids.ca_count, csi->csi_uuids.ca_arrays, csi->csi_api_flags,
+			      csi->csi_phase, csi->csi_leader_rank, csi->csi_flags, &clues);
 
 	cso->cso_status = rc;
 	cso->cso_rank = dss_self_rank();
-	cso->cso_phase = phase;
 	cso->cso_clues.ca_count = clues.pcs_len;
 	cso->cso_clues.ca_arrays = clues.pcs_array;
 	rc = crt_reply_send(rpc);

--- a/src/chk/chk_upcall.c
+++ b/src/chk/chk_upcall.c
@@ -208,6 +208,7 @@ out:
 	D_FREE(report.dkey);
 	D_FREE(report.akey);
 	D_FREE(report.timestamp);
+	D_FREE(report.act_details);
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
 		 "Check leader upcall for instance "DF_X64" for seq "DF_X64": "DF_RC"\n",

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -4542,12 +4542,10 @@ ds_cont_existence_check(struct cont_svc *svc, uuid_t uuid, daos_prop_t **prop)
 		D_GOTO(out_cont, rc = (rc == -DER_NONEXIST ? 0 : rc));
 
 	if (strncmp(DAOS_PROP_NO_CO_LABEL, tmp->dpp_entries[0].dpe_str,
-		    DAOS_PROP_LABEL_MAX_LEN) == 0) {
+		    DAOS_PROP_LABEL_MAX_LEN) == 0)
 		daos_prop_free(tmp);
-		goto out_cont;
-	}
-
-	*prop = tmp;
+	else
+		*prop = tmp;
 
 out_cont:
 	cont_put(cont);
@@ -4585,10 +4583,8 @@ ds_cont_destroy_orphan(struct cont_svc *svc, uuid_t uuid)
 		D_GOTO(out, rc = -DER_BUSY);
 
 	rc = cont_destroy_bcast(dss_get_module_info()->dmi_ctx, svc, uuid);
-	if (rc != 0)
-		goto out;
-
-	cont_ec_agg_delete(svc, uuid);
+	if (rc == 0)
+		cont_ec_agg_delete(svc, uuid);
 
 out:
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,

--- a/src/engine/drpc_ras.c
+++ b/src/engine/drpc_ras.c
@@ -384,7 +384,9 @@ ds_chk_listpool_upcall(struct chk_list_pool **clp)
 	if (reqb == NULL)
 		D_GOTO(out_req, rc = -DER_NOMEM);
 
-	srv__check_list_pool_req__pack(&req, reqb);
+	rc = srv__check_list_pool_req__pack(&req, reqb);
+	if (rc < 0)
+		goto out_req;
 
 	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_CHK_LIST_POOL, reqb, size, 0, &dresp);
 	if (rc != 0)
@@ -470,7 +472,10 @@ ds_chk_regpool_upcall(uint64_t seq, uuid_t uuid, char *label, d_rank_list_t *svc
 	if (reqb == NULL)
 		D_GOTO(out_req, rc = -DER_NOMEM);
 
-	srv__check_reg_pool_req__pack(&req, reqb);
+	rc = srv__check_reg_pool_req__pack(&req, reqb);
+	if (rc < 0)
+		goto out_req;
+
 	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_CHK_REG_POOL, reqb, size, 0, &dresp);
 	if (rc != 0)
 		goto out_req;
@@ -517,7 +522,10 @@ ds_chk_deregpool_upcall(uint64_t seq, uuid_t uuid)
 	if (reqb == NULL)
 		D_GOTO(out_req, rc = -DER_NOMEM);
 
-	srv__check_dereg_pool_req__pack(&req, reqb);
+	rc = srv__check_dereg_pool_req__pack(&req, reqb);
+	if (rc < 0)
+		goto out_req;
+
 	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_CHK_DEREG_POOL, reqb, size, 0, &dresp);
 	if (rc != 0)
 		goto out_req;
@@ -563,7 +571,10 @@ ds_chk_report_upcall(void *rpt)
 	if (reqb == NULL)
 		D_GOTO(out_req, rc = -DER_NOMEM);
 
-	srv__check_report_req__pack(&req, reqb);
+	rc = srv__check_report_req__pack(&req, reqb);
+	if (rc < 0)
+		goto out_req;
+
 	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_CHK_REPORT, reqb, size, 0, &dresp);
 	if (rc != 0)
 		goto out_req;

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -176,6 +176,7 @@ int ds_pool_tgt_add_in(uuid_t pool_uuid, struct pool_target_id_list *list);
 int ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 			   unsigned int map_version);
 
+int ds_pool_start_with_svc(uuid_t uuid);
 int ds_pool_start(uuid_t uuid);
 void ds_pool_stop(uuid_t uuid);
 int ds_pool_extend(uuid_t pool_uuid, int ntargets, const d_rank_list_t *rank_list, int ndomains,
@@ -362,7 +363,11 @@ struct ds_pool_clue {
 	int				 pc_rc;
 	uint32_t			 pc_label_len;
 	uint32_t			 pc_tgt_nr;
-	uint32_t			 pc_padding;
+	/*
+	 * DAOS check phase for current pool shard. Different pool shards may claim different
+	 * check phase because some shards may has ever missed the RPC for check phase update.
+	 */
+	uint32_t			 pc_phase;
 	struct ds_pool_svc_clue		*pc_svc_clue;
 	char				*pc_label;
 	uint32_t			*pc_tgt_status;
@@ -382,7 +387,7 @@ struct ds_pool_clues {
  * If this callback returns 0, the pool with \a uuid will be glanced at;
  * otherwise, the pool with \a uuid will be skipped.
  */
-typedef int (*ds_pool_clues_init_filter_t)(uuid_t uuid, void *arg);
+typedef int (*ds_pool_clues_init_filter_t)(uuid_t uuid, void *arg, int *phase);
 
 int ds_pool_clues_init(ds_pool_clues_init_filter_t filter, void *filter_arg,
 		       struct ds_pool_clues *clues_out);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1983,6 +1983,12 @@ pool_start_all(void *arg)
 			DP_RC(rc));
 }
 
+int
+ds_pool_start_with_svc(uuid_t uuid)
+{
+	return start_one(uuid, NULL);
+}
+
 /* Note that this function is currently called from the main xstream. */
 int
 ds_pool_start_all(void)

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -71,12 +71,11 @@ pool_glance(uuid_t uuid, char *path, struct ds_pool_clue *clue_out)
 		if (strncmp(DAOS_PROP_NO_PO_LABEL, value.iov_buf, DAOS_PROP_LABEL_MAX_LEN) == 0) {
 			clue_out->pc_label_len = 0;
 		} else {
-			D_ALLOC(clue_out->pc_label, value.iov_len + 1);
+			D_STRNDUP(clue_out->pc_label, value.iov_buf, value.iov_len);
 			if (clue_out->pc_label == NULL)
 				D_GOTO(out_root, rc = -DER_NOMEM);
 
 			clue_out->pc_label_len = value.iov_len;
-			memcpy(clue_out->pc_label, value.iov_buf, value.iov_len);
 		}
 	} else if (rc == -DER_NONEXIST) {
 		clue_out->pc_label_len = 0;

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -254,9 +254,14 @@ glance_at_one(uuid_t uuid, void *varg)
 {
 	struct glance_arg      *arg = varg;
 	struct ds_pool_clues   *clues = &arg->ga_clues;
+	int			phase = 0;
+	int			rc;
 
-	if (arg->ga_filter != NULL && arg->ga_filter(uuid, arg->ga_filter_arg) != 0)
-		goto out;
+	if (arg->ga_filter != NULL) {
+		rc = arg->ga_filter(uuid, arg->ga_filter_arg, &phase);
+		if (rc != 0)
+			goto out;
+	}
 
 	if (clues->pcs_cap < clues->pcs_len + 1) {
 		int			new_cap = clues->pcs_cap;
@@ -277,6 +282,7 @@ glance_at_one(uuid_t uuid, void *varg)
 	}
 
 	ds_pool_clue_init(uuid, arg->ga_dir, &clues->pcs_array[clues->pcs_len]);
+	clues->pcs_array[clues->pcs_len].pc_phase = phase;
 	clues->pcs_len++;
 
 out:

--- a/src/proto/chk/chk.proto
+++ b/src/proto/chk/chk.proto
@@ -134,9 +134,9 @@ enum CheckFlag {
 	// If the admin does not want to interact with engine during check scan, then CIA_INTERACT
 	// will be converted to CIA_IGNORE. That will overwrite the CheckInconsistPolicy.
 	CF_AUTO		= 8;
-	// Handle dangling pool when start the check instance. If not specify the flag, dangling
-	// pool will not be handled (by default) unless all pools are checked from the scratch.
-	CF_DANGLING_POOL = 16;
+	// Handle orphan pool when start the check instance. If not specify the flag, some orphan
+	// pool(s) may be not handled (by default) unless all pools are checked from the scratch.
+	CF_ORPHAN_POOL = 16;
 	// Overwrite former set CF_FAILOUT flag, cannot be specified together with CF_FAILOUT.
 	CF_NO_FAILOUT	= 32;
 	// Overwrite former set CF_AUTO flag, cannot be specified together with CF_AUTO.


### PR DESCRIPTION
Multiple pools with different scan phases can be resumed together via single check instance. It also support to stop some in-checking pools during check and make others to continue the check. The stopped pools can be resumed from each own paused phases sometime later together or independently via multiple times, or with some new pools.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
