### PR TITLE
DAOS-11961 control: Add config awareness for daos_server nvme scan cmd

### DIFF
--- a/src/control/cmd/daos_server/storage_nvme_test.go
+++ b/src/control/cmd/daos_server/storage_nvme_test.go
@@ -469,7 +469,7 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 			} else {
 				if len(mbb.ResetCalls) != 1 {
 					t.Fatalf("unexpected number of reset calls, want 1 got %d",
-						len(mbb.PrepareCalls))
+						len(mbb.ResetCalls))
 				}
 				// If empty TargetUser in cmd, expect current user in call.
 				if tc.resetCmd.TargetUser == "" {
@@ -478,6 +478,191 @@ func TestDaosServer_resetNVMe(t *testing.T) {
 				if diff := cmp.Diff(*tc.expResetCall, mbb.ResetCalls[0]); diff != "" {
 					t.Fatalf("unexpected reset calls (-want, +got):\n%s\n", diff)
 				}
+			}
+			mbb.RUnlock()
+		})
+	}
+}
+
+func TestDaosServer_getVMDState(t *testing.T) {
+	fa := false
+	tr := true
+
+	for name, tc := range map[string]struct {
+		cfg           *config.Server
+		ignoreCfg     bool
+		cmdDisableVMD bool
+		expOut        bool
+	}{
+		"nil cmd cfg": {
+			expOut: true,
+		},
+		"vmd state not specified in cfg": {
+			cfg:    &config.Server{},
+			expOut: true,
+		},
+		"vmd not disabled in cfg": {
+			cfg: &config.Server{
+				DisableVMD: &fa,
+			},
+			expOut: true,
+		},
+		"vmd disabled in cfg": {
+			cfg: &config.Server{
+				DisableVMD: &tr,
+			},
+		},
+		"vmd disabled in cfg; cfg ignored": {
+			cfg: &config.Server{
+				DisableVMD: &tr,
+			},
+			ignoreCfg: true,
+			expOut:    true,
+		},
+		"vmd disabled on commandline": {
+			cfg:           &config.Server{},
+			cmdDisableVMD: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer test.ShowBufferOnFailure(t, buf)
+
+			scanCmd := &scanNVMeCmd{}
+			scanCmd.LogCmd = cmdutil.LogCmd{
+				Logger: log,
+			}
+			scanCmd.config = tc.cfg
+			scanCmd.IgnoreConfig = tc.ignoreCfg
+			scanCmd.DisableVMD = tc.cmdDisableVMD
+
+			test.AssertEqual(t, tc.expOut, scanCmd.getVMDState(), "unexpected VMD state")
+		})
+	}
+}
+
+func TestDaosServer_scanNVMe(t *testing.T) {
+	cmpopt := cmp.Comparer(func(x, y *storage.BdevDeviceList) bool {
+		if x == nil && y == nil {
+			return true
+		}
+		return x.Equals(y)
+	})
+
+	for name, tc := range map[string]struct {
+		scanCmd     *scanNVMeCmd
+		cfg         *config.Server
+		ignoreCfg   bool
+		bmbc        *bdev.MockBackendConfig
+		expErr      error
+		expScanCall *storage.BdevScanRequest
+	}{
+		"normal scan": {
+			bmbc: &bdev.MockBackendConfig{
+				ScanRes: &storage.BdevScanResponse{
+					Controllers: storage.NvmeControllers{
+						storage.MockNvmeController(1),
+					},
+				},
+			},
+			expScanCall: &storage.BdevScanRequest{},
+		},
+		"failed scan": {
+			bmbc: &bdev.MockBackendConfig{
+				ScanErr: errors.New("fail"),
+			},
+			expErr: errors.New("fail"),
+		},
+		"devices filtered by config": {
+			bmbc: &bdev.MockBackendConfig{
+				ScanRes: &storage.BdevScanResponse{
+					Controllers: storage.NvmeControllers{
+						storage.MockNvmeController(1),
+						storage.MockNvmeController(2),
+						storage.MockNvmeController(3),
+					},
+				},
+			},
+			cfg: (&config.Server{}).WithEngines(
+				(&engine.Config{}).WithStorage(storage.NewTierConfig().
+					WithStorageClass(storage.ClassNvme.String()).
+					WithBdevDeviceList(test.MockPCIAddr(1))),
+				(&engine.Config{}).WithStorage(storage.NewTierConfig().
+					WithStorageClass(storage.ClassNvme.String()).
+					WithBdevDeviceList(test.MockPCIAddr(3))),
+			),
+			expScanCall: &storage.BdevScanRequest{
+				DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddr(1),
+					test.MockPCIAddr(3)),
+			},
+		},
+		"no devices specified in config": {
+			bmbc: &bdev.MockBackendConfig{
+				ScanRes: &storage.BdevScanResponse{
+					Controllers: storage.NvmeControllers{
+						storage.MockNvmeController(1),
+						storage.MockNvmeController(2),
+						storage.MockNvmeController(3),
+					},
+				},
+			},
+			cfg: (&config.Server{}).WithEngines(
+				(&engine.Config{}).WithStorage(),
+			),
+			expScanCall: &storage.BdevScanRequest{},
+		},
+		"cfg ignore flag set; device filtering skipped": {
+			bmbc: &bdev.MockBackendConfig{
+				ScanRes: &storage.BdevScanResponse{
+					Controllers: storage.NvmeControllers{
+						storage.MockNvmeController(1),
+						storage.MockNvmeController(2),
+						storage.MockNvmeController(3),
+					},
+				},
+			},
+			ignoreCfg: true,
+			cfg: (&config.Server{}).WithEngines(
+				(&engine.Config{}).WithStorage(storage.NewTierConfig().
+					WithStorageClass(storage.ClassNvme.String()).
+					WithBdevDeviceList(test.MockPCIAddr(1))),
+				(&engine.Config{}).WithStorage(storage.NewTierConfig().
+					WithStorageClass(storage.ClassNvme.String()).
+					WithBdevDeviceList(test.MockPCIAddr(3))),
+			),
+			expScanCall: &storage.BdevScanRequest{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer test.ShowBufferOnFailure(t, buf)
+
+			mbb := bdev.NewMockBackend(tc.bmbc)
+			mbp := bdev.NewProvider(log, mbb)
+			msp := scm.NewMockProvider(log, nil, nil)
+			scs := server.NewMockStorageControlService(log, nil, nil, msp, mbp)
+
+			if tc.scanCmd == nil {
+				tc.scanCmd = &scanNVMeCmd{}
+			}
+			tc.scanCmd.LogCmd = cmdutil.LogCmd{
+				Logger: log,
+			}
+			tc.scanCmd.config = tc.cfg
+			tc.scanCmd.IgnoreConfig = tc.ignoreCfg
+
+			gotErr := tc.scanCmd.scanNVMe(scs.NvmeScan)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			mbb.RLock()
+			if len(mbb.ScanCalls) != 1 {
+				t.Fatalf("unexpected number of scan calls, want 1 got %d", len(mbb.ScanCalls))
+			}
+			if diff := cmp.Diff(tc.expScanCall, &mbb.ScanCalls[0], cmpopt); diff != "" {
+				t.Fatalf("unexpected scan calls (-want, +got):\n%s\n", diff)
 			}
 			mbb.RUnlock()
 		})

--- a/src/control/server/storage/bdev/mocks.go
+++ b/src/control/server/storage/bdev/mocks.go
@@ -17,12 +17,13 @@ type (
 	MockBackendConfig struct {
 		VMDEnabled   bool // VMD is disabled by default
 		ResetErr     error
-		PrepareResp  *storage.BdevPrepareResponse
+		PrepareRes   *storage.BdevPrepareResponse
 		PrepareErr   error
 		ScanRes      *storage.BdevScanResponse
 		ScanErr      error
 		FormatRes    *storage.BdevFormatResponse
 		FormatErr    error
+		WriteConfRes *storage.BdevWriteConfigResponse
 		WriteConfErr error
 		UpdateErr    error
 	}
@@ -33,6 +34,7 @@ type (
 		PrepareCalls   []storage.BdevPrepareRequest
 		ResetCalls     []storage.BdevPrepareRequest
 		WriteConfCalls []storage.BdevWriteConfigRequest
+		ScanCalls      []storage.BdevScanRequest
 	}
 )
 
@@ -51,19 +53,29 @@ func DefaultMockBackend() *MockBackend {
 }
 
 func (mb *MockBackend) Scan(req storage.BdevScanRequest) (*storage.BdevScanResponse, error) {
-	if mb.cfg.ScanRes == nil {
-		mb.cfg.ScanRes = &storage.BdevScanResponse{}
-	}
+	mb.Lock()
+	mb.ScanCalls = append(mb.ScanCalls, req)
+	mb.Unlock()
 
-	return mb.cfg.ScanRes, mb.cfg.ScanErr
+	switch {
+	case mb.cfg.ScanErr != nil:
+		return nil, mb.cfg.ScanErr
+	case mb.cfg.ScanRes == nil:
+		return &storage.BdevScanResponse{}, nil
+	default:
+		return mb.cfg.ScanRes, nil
+	}
 }
 
 func (mb *MockBackend) Format(req storage.BdevFormatRequest) (*storage.BdevFormatResponse, error) {
-	if mb.cfg.FormatRes == nil {
-		mb.cfg.FormatRes = &storage.BdevFormatResponse{}
+	switch {
+	case mb.cfg.FormatErr != nil:
+		return nil, mb.cfg.FormatErr
+	case mb.cfg.FormatRes == nil:
+		return &storage.BdevFormatResponse{}, nil
+	default:
+		return mb.cfg.FormatRes, nil
 	}
-
-	return mb.cfg.FormatRes, mb.cfg.FormatErr
 }
 
 func (mb *MockBackend) Prepare(req storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error) {
@@ -74,10 +86,10 @@ func (mb *MockBackend) Prepare(req storage.BdevPrepareRequest) (*storage.BdevPre
 	switch {
 	case mb.cfg.PrepareErr != nil:
 		return nil, mb.cfg.PrepareErr
-	case mb.cfg.PrepareResp == nil:
+	case mb.cfg.PrepareRes == nil:
 		return &storage.BdevPrepareResponse{}, nil
 	default:
-		return mb.cfg.PrepareResp, nil
+		return mb.cfg.PrepareRes, nil
 	}
 }
 
@@ -102,7 +114,14 @@ func (mb *MockBackend) WriteConfig(req storage.BdevWriteConfigRequest) (*storage
 	mb.WriteConfCalls = append(mb.WriteConfCalls, req)
 	mb.Unlock()
 
-	return &storage.BdevWriteConfigResponse{}, mb.cfg.WriteConfErr
+	switch {
+	case mb.cfg.WriteConfErr != nil:
+		return nil, mb.cfg.WriteConfErr
+	case mb.cfg.WriteConfRes == nil:
+		return &storage.BdevWriteConfigResponse{}, nil
+	default:
+		return mb.cfg.WriteConfRes, nil
+	}
 }
 
 func NewMockProvider(log logging.Logger, mbc *MockBackendConfig) *Provider {


### PR DESCRIPTION
To improve consistency, nvme scan command should only report bdevs
specified in provided configuration file (if none specified then report all).

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
