### PR TITLE
DAOS-11882 pydaos: AsyncWorker1() should use passed DaosEvent() (#10530)

### DIFF
--- a/src/client/pydaos/raw/daos_cref.py
+++ b/src/client/pydaos/raw/daos_cref.py
@@ -276,8 +276,7 @@ def AsyncWorker1(func_ref, param_list, context, cb_func=None, obj=None):
     c_wait = ctypes.c_int(0)
     c_timeout = ctypes.c_ulonglong(-1)
     c_num = ctypes.c_uint(1)
-    anotherEvent = DaosEvent()
-    c_event_ptr = ctypes.pointer(anotherEvent)
+    c_event_ptr = ctypes.pointer(the_event)
 
     # start polling, wait forever
     rc = efunc(qhandle, c_wait, c_timeout, c_num, ctypes.byref(c_event_ptr))


### PR DESCRIPTION
pydaos AsyncWorker1() method uses an extraneous/unnecessary DaosEvent() instance than the one already created/passed by callers.

This patch enables usage of original/caller's DaosEvent() instance, like in AsyncWorker2().

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
