### PR TITLE
DAOS-623 vea: fix spelling in vea test (#10605, #10607)

### DIFF
--- a/src/vea/tests/vea_stress.c
+++ b/src/vea/tests/vea_stress.c
@@ -51,7 +51,7 @@ struct vs_perf_cntr {
 };
 
 enum {
-	VS_OP_RESERV	= 0,
+	VS_OP_RESERVE	= 0,
 	VS_OP_PUBLISH,
 	VS_OP_FREE,
 	VS_OP_MERGE,
@@ -319,7 +319,7 @@ vs_update(struct vea_stress_pool *vs_pool)
 			fprintf(stderr, "failed to reserve %u blks for io\n", blk_cnt);
 			goto error;
 		}
-		vs_counter_inc(&vs_pool->vsp_cntr[VS_OP_RESERV], cur_ts);
+		vs_counter_inc(&vs_pool->vsp_cntr[VS_OP_RESERVE], cur_ts);
 
 		/*
 		 * Reserved list will be freed on publish, duplicate it to track the
@@ -468,7 +468,7 @@ vs_coalesce(struct vea_stress_pool *vs_pool)
 		fprintf(stderr, "failed to reserve %u blks for aggregation\n", merge_blks);
 		return rc;
 	}
-	vs_counter_inc(&vs_pool->vsp_cntr[VS_OP_RESERV], cur_ts);
+	vs_counter_inc(&vs_pool->vsp_cntr[VS_OP_RESERVE], cur_ts);
 
 	rsrvd = d_list_entry(r_list.prev, struct vea_resrvd_ext, vre_link);
 	D_ASSERT(rsrvd->vre_blk_cnt == merge_blks);
@@ -915,8 +915,8 @@ static inline char *
 vs_op2str(unsigned int op)
 {
 	switch (op) {
-	case VS_OP_RESERV:
-		return "reserv";
+	case VS_OP_RESERVE:
+		return "reserve";
 	case VS_OP_PUBLISH:
 		return "tx_publish";
 	case VS_OP_FREE:


### PR DESCRIPTION
Fix spelling in vea_stress.c
Change spelling of enumerations as well.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
