### PR TITLE
DAOS-11919 control: Add concurrent pool ops protection

### DIFF
--- a/src/control/common/test/mocks.go
+++ b/src/control/common/test/mocks.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"net"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 var hostAddrs = make(map[int32]*net.TCPAddr)
@@ -35,6 +37,13 @@ func MockUUID(varIdx ...int32) string {
 	idx := GetIndex(varIdx...)
 
 	return fmt.Sprintf("%08d-%04d-%04d-%04d-%012d", idx, idx, idx, idx, idx)
+}
+
+// MockPoolUUID returns mock pool UUID values for use in tests.
+func MockPoolUUID(varIdx ...int32) uuid.UUID {
+	idx := GetIndex(varIdx...)
+
+	return uuid.MustParse(fmt.Sprintf("%08d-%04d-%04d-%04d-%012d", idx, idx, idx, idx, idx))
 }
 
 // MockHostAddr returns mock tcp addresses for use in tests.

--- a/src/control/common/test/utils.go
+++ b/src/control/common/test/utils.go
@@ -191,6 +191,9 @@ func ShowBufferOnFailure(t *testing.T, buf fmt.Stringer) {
 	if t.Failed() {
 		fmt.Printf("captured log output:\n%s", buf.String())
 	}
+	if r, ok := buf.(interface{ Reset() }); ok {
+		r.Reset()
+	}
 }
 
 // DefaultCmpOpts gets default go-cmp comparison options for tests.

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -100,6 +100,7 @@ const (
 const (
 	SystemUnknown Code = iota + 400
 	SystemBadFaultDomainDepth
+	SystemPoolLocked
 )
 
 // client fault codes

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -209,7 +209,7 @@ func (r *poolRequest) canRetry(reqErr error, try uint) bool {
 		}
 	case *fault.Fault:
 		switch e.Code {
-		case code.ServerDataPlaneNotStarted:
+		case code.ServerDataPlaneNotStarted, code.SystemPoolLocked:
 			return true
 		default:
 			return false

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -243,8 +243,8 @@ func SystemQuery(ctx context.Context, rpcClient UnaryInvoker, req *SystemQueryRe
 		}
 		return nil
 	}
-	rpcClient.Debugf("DAOS system query request: %+v", req)
 
+	rpcClient.Debugf("DAOS system query request: %s", mgmtpb.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err

--- a/src/control/server/mgmt_cont_test.go
+++ b/src/control/server/mgmt_cont_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	mockUUID = "00000000-0000-0000-0000-000000000000"
+	mockUUID = "11111111-1111-1111-1111-111111111111"
 )
 
 func makeBadBytes(count int) (badBytes []byte) {

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -35,6 +35,8 @@ import (
 )
 
 func getPoolLockCtx(t *testing.T, parent context.Context, sysdb *raft.Database, poolUUID uuid.UUID) (*raft.PoolLock, context.Context) {
+	t.Helper()
+
 	if parent == nil {
 		parent = context.Background()
 	}
@@ -127,7 +129,7 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 			defer test.ShowBufferOnFailure(t, buf)
 
 			svc := newTestMgmtSvc(t, log)
-			poolUUID := uuid.MustParse(test.MockUUID(0))
+			poolUUID := test.MockPoolUUID(1)
 			lock, ctx := getPoolLockCtx(t, nil, svc.sysdb, poolUUID)
 			defer lock.Release()
 
@@ -141,7 +143,7 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 
 			req := &mgmtpb.PoolCreateReq{
 				Sys:        build.DefaultSystemName,
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Totalbytes: engine.ScmMinBytesPerTarget,
 				Properties: testPoolLabelProp(),
 			}
@@ -307,7 +309,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			mgmtSvc:     missingSB,
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -317,7 +319,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			mgmtSvc:     notAP,
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -326,7 +328,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"dRPC send fails": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -335,7 +337,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"zero target count": {
 			targetCount: 0,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -344,7 +346,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"garbage resp": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -359,7 +361,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"successful creation": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -371,7 +373,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"successful creation minimum size": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{engine.ScmMinBytesPerTarget * 8, engine.NvmeMinBytesPerTarget * 8},
 				Properties: testPoolLabelProp(),
 			},
@@ -383,7 +385,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"successful creation auto size": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Totalbytes: 100 * humanize.GiByte,
 				Properties: testPoolLabelProp(),
 			},
@@ -395,7 +397,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"failed creation invalid ranks": {
 			targetCount: 1,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Ranks:      []uint32{40, 11},
 				Properties: testPoolLabelProp(),
@@ -405,7 +407,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"failed creation invalid number of ranks": {
 			targetCount: 1,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Numranks:   3,
 				Properties: testPoolLabelProp(),
@@ -416,7 +418,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			targetCount: 1,
 			memberCount: MaxPoolServiceReps + 2,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Totalbytes: 100 * humanize.GByte,
 				Tierratio:  []float64{0.06, 0.94},
 				Numsvcreps: MaxPoolServiceReps + 2,
@@ -428,7 +430,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			targetCount: 1,
 			memberCount: MaxPoolServiceReps - 2,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Totalbytes: 100 * humanize.GByte,
 				Tierratio:  []float64{0.06, 0.94},
 				Numsvcreps: MaxPoolServiceReps - 1,
@@ -439,7 +441,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"no label": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:      test.MockUUID(0),
+				Uuid:      test.MockUUID(1),
 				Tierbytes: []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 			},
 			expErr: FaultPoolNoLabel,
@@ -1305,13 +1307,13 @@ func TestListPools_Success(t *testing.T) {
 
 	testPools := []*system.PoolService{
 		{
-			PoolUUID:  uuid.MustParse(test.MockUUID(0)),
+			PoolUUID:  test.MockPoolUUID(1),
 			PoolLabel: "0",
 			State:     system.PoolServiceStateReady,
 			Replicas:  []ranklist.Rank{0, 1, 2},
 		},
 		{
-			PoolUUID:  uuid.MustParse(test.MockUUID(1)),
+			PoolUUID:  test.MockPoolUUID(2),
 			PoolLabel: "1",
 			State:     system.PoolServiceStateReady,
 			Replicas:  []ranklist.Rank{0, 1, 2},

--- a/src/control/system/faults.go
+++ b/src/control/system/faults.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,7 +8,11 @@ package system
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
@@ -20,6 +24,13 @@ func FaultBadFaultDomainDepth(domain *FaultDomain, expDepth int) *fault.Fault {
 	return systemFault(code.SystemBadFaultDomainDepth,
 		fmt.Sprintf("cannot join system with fault domain %q, need layers = %d", domain.String(), expDepth),
 		"reconfigure the fault domain with a depth consistent with other system members, and restart the server")
+}
+
+// FaultPoolLocked generates a fault indicating that the pool is locked.
+func FaultPoolLocked(poolUUID, lockID uuid.UUID, lockTime time.Time) *fault.Fault {
+	return systemFault(code.SystemPoolLocked,
+		fmt.Sprintf("pool %s is locked (id: %s, time: %s)", poolUUID, lockID, common.FormatTime(lockTime)),
+		"retry the pool operation")
 }
 
 func systemFault(code code.Code, desc, res string) *fault.Fault {

--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -92,8 +92,9 @@ type (
 		onRaftShutdown     []onRaftShutdownFn
 		shutdownCb         context.CancelFunc
 		shutdownErrCh      chan error
+		poolLocks          poolLockMap
 
-		data *dbData
+		data *dbData // raft-backed system data
 	}
 
 	// DatabaseConfig defines the configuration for the system database.
@@ -260,6 +261,8 @@ func NewDatabase(log logging.Logger, cfg *DatabaseConfig) (*Database, error) {
 			SchemaVersion: CurrentSchemaVersion,
 		},
 	}
+	// NB: We may remove this once the locking stuff is solid.
+	db.poolLocks.log = log
 
 	return db, nil
 }
@@ -354,7 +357,7 @@ func (db *Database) CheckLeader() error {
 		return err
 	}
 
-	return db.raft.withReadLock(func(svc raftService) error {
+	if err := db.raft.withReadLock(func(svc raftService) error {
 		if svc.State() != raft.Leader {
 			return &system.ErrNotLeader{
 				LeaderHint: db.leaderHint(),
@@ -362,7 +365,13 @@ func (db *Database) CheckLeader() error {
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Block any leadership-dependent logic until the leader
+	// has applied any outstanding logs.
+	return db.Barrier()
 }
 
 // leaderHint returns a string representation of the current raft
@@ -898,13 +907,40 @@ func (db *Database) FindPoolServiceByLabel(label string) (*system.PoolService, e
 	return nil, system.ErrPoolLabelNotFound(label)
 }
 
+func (db *Database) TakePoolLock(ctx context.Context, uuid uuid.UUID) (*PoolLock, error) {
+	if err := db.CheckLeader(); err != nil {
+		return nil, err
+	}
+	db.Lock()
+	defer db.Unlock()
+
+	lock, err := getCtxLock(ctx)
+	if err != nil && err != errNoCtxLock {
+		return nil, err
+	} else if lock != nil {
+		if err := db.poolLocks.checkLock(lock); err != nil {
+			return nil, err
+		}
+		if lock.poolUUID == uuid {
+			lock.addRef()
+			return lock, nil
+		}
+	}
+
+	return db.poolLocks.take(uuid)
+}
+
 // AddPoolService creates an entry for a new pool service in the pool database.
-func (db *Database) AddPoolService(ps *system.PoolService) error {
+func (db *Database) AddPoolService(ctx context.Context, ps *system.PoolService) error {
 	if err := db.CheckLeader(); err != nil {
 		return err
 	}
 	db.Lock()
 	defer db.Unlock()
+
+	if err := db.poolLocks.checkLockCtx(ctx); err != nil {
+		return err
+	}
 
 	if p, err := db.FindPoolServiceByUUID(ps.PoolUUID); err == nil {
 		return errors.Errorf("pool %s already exists", p.PoolUUID)
@@ -918,16 +954,20 @@ func (db *Database) AddPoolService(ps *system.PoolService) error {
 }
 
 // RemovePoolService removes a pool database entry.
-func (db *Database) RemovePoolService(uuid uuid.UUID) error {
+func (db *Database) RemovePoolService(ctx context.Context, poolUUID uuid.UUID) error {
 	if err := db.CheckLeader(); err != nil {
 		return err
 	}
 	db.Lock()
 	defer db.Unlock()
 
-	ps, err := db.FindPoolServiceByUUID(uuid)
+	if err := db.poolLocks.checkLockCtx(ctx); err != nil {
+		return err
+	}
+
+	ps, err := db.FindPoolServiceByUUID(poolUUID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to retrieve pool %s", uuid)
+		return errors.Wrapf(err, "failed to retrieve pool %s", poolUUID)
 	}
 
 	if err := db.submitPoolUpdate(raftOpRemovePoolService, ps); err != nil {
@@ -938,12 +978,16 @@ func (db *Database) RemovePoolService(uuid uuid.UUID) error {
 }
 
 // UpdatePoolService updates an existing pool database entry.
-func (db *Database) UpdatePoolService(ps *system.PoolService) error {
+func (db *Database) UpdatePoolService(ctx context.Context, ps *system.PoolService) error {
 	if err := db.CheckLeader(); err != nil {
 		return err
 	}
 	db.Lock()
 	defer db.Unlock()
+
+	if err := db.poolLocks.checkLockCtx(ctx); err != nil {
+		return err
+	}
 
 	p, err := db.FindPoolServiceByUUID(ps.PoolUUID)
 	if err != nil {
@@ -979,27 +1023,41 @@ func (db *Database) handlePoolRepsUpdate(evt *events.RASEvent) {
 		db.log.Error("no extended info in PoolSvcReplicasUpdate event received")
 		return
 	}
-	db.log.Debugf("processing RAS event %q for pool %s with info %+v on host %q",
-		evt.Msg, evt.PoolUUID, ei, evt.Hostname)
 
-	uuid, err := uuid.Parse(evt.PoolUUID)
+	poolUUID, err := uuid.Parse(evt.PoolUUID)
 	if err != nil {
 		db.log.Errorf("failed to parse pool UUID %q: %s", evt.PoolUUID, err)
 		return
 	}
 
-	ps, err := db.FindPoolServiceByUUID(uuid)
+	ps, err := db.FindPoolServiceByUUID(poolUUID)
 	if err != nil {
 		db.log.Errorf("failed to find pool with UUID %q: %s", evt.PoolUUID, err)
 		return
 	}
 
+	// If the pool service is not in the Ready state, ignore the update.
+	if ps.State != system.PoolServiceStateReady {
+		return
+	}
+
+	db.log.Debugf("processing RAS event %q for pool %s with info %+v on host %q",
+		evt.Msg, dbgUuidStr(poolUUID), ei, evt.Hostname)
+
+	ctx := context.Background()
+	lock, err := db.TakePoolLock(ctx, poolUUID)
+	if err != nil {
+		db.log.Errorf("failed to take lock for pool svc update: %s", err)
+		return
+	}
+	defer lock.Release()
+
 	db.log.Debugf("update pool %s (state=%s) svc ranks %v->%v",
-		ps.PoolUUID, ps.State, ps.Replicas, ei.SvcReplicas)
+		dbgUuidStr(ps.PoolUUID), ps.State, ps.Replicas, ei.SvcReplicas)
 
 	ps.Replicas = ranklist.RanksFromUint32(ei.SvcReplicas)
 
-	if err := db.UpdatePoolService(ps); err != nil {
+	if err := db.UpdatePoolService(lock.InContext(ctx), ps); err != nil {
 		db.log.Errorf("failed to apply pool service update: %s", err)
 	}
 }
@@ -1058,4 +1116,8 @@ func (db *Database) GetSystemAttrs(keys []string, filterFn func(string) bool) (m
 		return nil, system.ErrSystemAttrNotFound(k)
 	}
 	return out, nil
+}
+
+func dbgUuidStr(u uuid.UUID) string {
+	return u.String()[0:8]
 }

--- a/src/control/system/raft/pool_lock.go
+++ b/src/control/system/raft/pool_lock.go
@@ -1,0 +1,192 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package raft
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/system"
+)
+
+type (
+	// PoolLock represents a lock on a pool.
+	// These locks are reference counted to make
+	// them reentrant. Note that the lock release
+	// closure will only ever be called once, no
+	// matter how many times Release() is called.
+	PoolLock struct {
+		id       uuid.UUID
+		poolUUID uuid.UUID
+		takenAt  time.Time
+		refCount int32
+		relOnce  sync.Once
+		release  func()
+	}
+
+	// poolLockMap is a map of pool UUIDs to pool locks.
+	// With this implementation, there may only be one
+	// lock on a pool at a time in order to avoid concurrent
+	// operations by multiple gRPC handlers on the same pool.
+	// NB: This structure is not backed by raft, and is
+	// intended to be local to the current MS leader.
+	poolLockMap struct {
+		sync.RWMutex
+		locks map[uuid.UUID]*PoolLock
+		log   logging.DebugLogger
+	}
+
+	ctxKey string
+)
+
+const (
+	poolLockKey ctxKey = "poolLock"
+)
+
+var (
+	errNoCtxLock = errors.New("no pool lock in context")
+)
+
+// getCtxLock returns the pool lock from the supplied context, if
+// one is present.
+func getCtxLock(ctx context.Context) (*PoolLock, error) {
+	if ctx == nil {
+		return nil, errors.New("nil context in getCtxLock()")
+	}
+
+	lock, ok := ctx.Value(poolLockKey).(*PoolLock)
+	if !ok {
+		return nil, errNoCtxLock
+	}
+
+	return lock, nil
+}
+
+// AddContextLock adds a pool lock to the supplied context.
+func AddContextLock(parent context.Context, lock *PoolLock) (context.Context, error) {
+	if parent == nil {
+		return nil, errors.New("nil context in AddContextLock()")
+	}
+	if lock == nil {
+		return nil, errors.New("nil lock in AddContextLock()")
+	}
+
+	cl, err := getCtxLock(parent)
+	if err != nil && err != errNoCtxLock {
+		return nil, err
+	} else if cl != nil {
+		if cl.id != lock.id {
+			return nil, errors.Errorf("context already contains lock for pool %s", cl.poolUUID)
+		}
+	}
+
+	return context.WithValue(parent, poolLockKey, lock), nil
+}
+
+// InContext returns a new child context with the lock added
+// as a value. NB: It is the caller's responsibility to ensure
+// that the parent context is valid and does not already contain
+// a different pool lock. For a more robust implementation, see
+// the AddContextLock() function.
+func (pl *PoolLock) InContext(parent context.Context) context.Context {
+	ctx, err := AddContextLock(parent, pl)
+	if err != nil {
+		panic(err)
+	}
+	return ctx
+}
+
+func (pl *PoolLock) addRef() {
+	atomic.AddInt32(&pl.refCount, 1)
+}
+
+func (pl *PoolLock) decRef() {
+	atomic.AddInt32(&pl.refCount, -1)
+}
+
+// Release releases the lock on the pool when the reference
+// count reaches zero.
+func (pl *PoolLock) Release() {
+	pl.decRef()
+	if atomic.LoadInt32(&pl.refCount) > 0 {
+		return
+	}
+	pl.relOnce.Do(pl.release)
+}
+
+// take returns a new pool lock for the supplied pool UUID
+// if the pool is not already locked, otherwise it returns
+// an error.
+func (plm *poolLockMap) take(poolUUID uuid.UUID) (*PoolLock, error) {
+	plm.Lock()
+	defer plm.Unlock()
+
+	if plm.locks == nil {
+		plm.locks = make(map[uuid.UUID]*PoolLock)
+	}
+
+	if lock, exists := plm.locks[poolUUID]; exists {
+		return nil, system.FaultPoolLocked(poolUUID, lock.id, lock.takenAt)
+	}
+
+	lock := &PoolLock{
+		id:       uuid.New(),
+		poolUUID: poolUUID,
+		takenAt:  time.Now(),
+		release:  func() { plm.release(poolUUID) },
+	}
+	lock.addRef()
+	plm.locks[poolUUID] = lock
+
+	plm.log.Debugf("%s: lock taken (id: %s)", dbgUuidStr(poolUUID), dbgUuidStr(lock.id))
+	return lock, nil
+}
+
+// release releases the lock on the pool with the supplied UUID.
+func (plm *poolLockMap) release(poolUUID uuid.UUID) {
+	plm.Lock()
+	defer plm.Unlock()
+
+	plm.log.Debugf("%s: lock released", dbgUuidStr(poolUUID))
+	delete(plm.locks, poolUUID)
+}
+
+// checkLockCtx is a helper to extract the pool lock from the
+// supplied context before sending it to checkLock().
+func (plm *poolLockMap) checkLockCtx(ctx context.Context) error {
+	lock, err := getCtxLock(ctx)
+	if err != nil {
+		return err
+	}
+
+	return plm.checkLock(lock)
+}
+
+// checkLock checks that the supplied lock is still valid.
+func (plm *poolLockMap) checkLock(lock *PoolLock) error {
+	if lock == nil {
+		return errors.New("nil pool lock in checkLock()")
+	}
+	plm.RLock()
+	defer plm.RUnlock()
+
+	if pl, exists := plm.locks[lock.poolUUID]; exists {
+		if lock.id != pl.id {
+			return system.FaultPoolLocked(lock.poolUUID, pl.id, pl.takenAt)
+		}
+	} else {
+		return errors.Errorf("pool %s: lock not found", lock.poolUUID)
+	}
+
+	return nil
+}

--- a/src/control/system/raft/pool_lock_test.go
+++ b/src/control/system/raft/pool_lock_test.go
@@ -1,0 +1,285 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package raft
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+var (
+	lockCmpOpts = []cmp.Option{
+		cmp.AllowUnexported(PoolLock{}),
+		cmpopts.IgnoreUnexported(sync.Once{}),
+	}
+)
+
+func makeLock(refCt, id, pool int32) *PoolLock {
+	return &PoolLock{
+		id:       uuid.MustParse(test.MockUUID(id)),
+		poolUUID: uuid.MustParse(test.MockUUID(pool)),
+		takenAt:  time.Now(),
+		refCount: refCt,
+	}
+}
+
+func TestRaft_getLockCtx(t *testing.T) {
+	lock := makeLock(0, 1, 2)
+
+	for name, tc := range map[string]struct {
+		ctx    context.Context
+		expErr error
+	}{
+		"nil context": {
+			ctx:    nil,
+			expErr: errors.New("nil context"),
+		},
+		"no lock in context": {
+			ctx:    context.Background(),
+			expErr: errNoCtxLock,
+		},
+		"lock in context": {
+			ctx: lock.InContext(context.Background()),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotLock, gotErr := getCtxLock(tc.ctx)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(lock, gotLock, lockCmpOpts...); diff != "" {
+				t.Fatalf("unexpected lock (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRaft_PoolLock_Release(t *testing.T) {
+	var released int32
+
+	lock := makeLock(3, 1, 2)
+	lock.release = func() { atomic.AddInt32(&released, 1) }
+	lock.addRef()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 12; i++ {
+		wg.Add(1)
+		// run in goroutines to trigger the race detector
+		// on any unsafe shenanigans.
+		go func() {
+			lock.Release()
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	test.AssertEqual(t, atomic.LoadInt32(&released), int32(1), "unexpected release count")
+}
+
+func TestRaft_PoolLock_InContext(t *testing.T) {
+	lock1 := makeLock(0, 1, 2)
+	lock2 := makeLock(0, 3, 4)
+
+	for name, tc := range map[string]struct {
+		parent      context.Context
+		expLock     *PoolLock
+		shouldPanic bool
+	}{
+		"nil parent": {
+			parent:      nil,
+			shouldPanic: true,
+		},
+		"parent contains different lock": {
+			parent:      lock2.InContext(context.Background()),
+			shouldPanic: true,
+		},
+		"parent contains same lock": {
+			parent:  lock1.InContext(context.Background()),
+			expLock: lock1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tc.shouldPanic {
+						t.Fatalf("unexpected panic: %v", r)
+					}
+				}
+			}()
+
+			ctx := lock1.InContext(tc.parent)
+			if tc.shouldPanic {
+				t.Fatal("expected panic")
+			}
+
+			gotLock, err := getCtxLock(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expLock, gotLock, lockCmpOpts...); diff != "" {
+				t.Fatalf("unexpected lock (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRaft_AddContextLock(t *testing.T) {
+	lock1 := makeLock(0, 1, 2)
+	lock2 := makeLock(0, 3, 4)
+
+	for name, tc := range map[string]struct {
+		parent  context.Context
+		lock    *PoolLock
+		expLock *PoolLock
+		expErr  error
+	}{
+		"nil parent": {
+			parent: nil,
+			lock:   lock1,
+			expErr: errors.New("nil context"),
+		},
+		"nil lock": {
+			parent: context.Background(),
+			expErr: errors.New("nil lock"),
+		},
+		"parent contains different lock": {
+			parent: lock2.InContext(context.Background()),
+			lock:   lock1,
+			expErr: errors.New("already contains lock"),
+		},
+		"parent contains same lock": {
+			parent:  lock1.InContext(context.Background()),
+			lock:    lock1,
+			expLock: lock1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, gotErr := AddContextLock(tc.parent, tc.lock)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			gotLock, err := getCtxLock(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expLock, gotLock, lockCmpOpts...); diff != "" {
+				t.Fatalf("unexpected lock (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRaft_poolLockMap_take(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	uuid0 := uuid.MustParse(test.MockUUID(0))
+	uuid1 := uuid.MustParse(test.MockUUID(1))
+	lock0 := &PoolLock{id: uuid1, poolUUID: uuid0}
+
+	for name, tc := range map[string]struct {
+		plm        *poolLockMap
+		poolToLock uuid.UUID
+		expErr     error
+		expLock    *PoolLock
+	}{
+		"already locked": {
+			plm: func() *poolLockMap {
+				plm := &poolLockMap{log: log}
+				plm.take(uuid0)
+				return plm
+			}(),
+			poolToLock: uuid0,
+			expErr:     errors.New("locked"),
+		},
+		"lock taken successfully": {
+			poolToLock: uuid0,
+			expLock:    lock0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.plm == nil {
+				tc.plm = &poolLockMap{log: log}
+			}
+			defer test.ShowBufferOnFailure(t, buf)
+
+			gotLock, err := tc.plm.take(tc.poolToLock)
+			test.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			test.AssertEqual(t, tc.expLock.poolUUID, gotLock.poolUUID, "unexpected lock")
+		})
+	}
+}
+
+func TestRaft_poolLockMap_checkLock(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	uuid0 := uuid.MustParse(test.MockUUID(0))
+	uuid1 := uuid.MustParse(test.MockUUID(1))
+	lock0 := &PoolLock{id: uuid1, poolUUID: uuid0}
+	lock1 := &PoolLock{id: uuid0, poolUUID: uuid0}
+
+	for name, tc := range map[string]struct {
+		plm       *poolLockMap
+		checkLock *PoolLock
+		expErr    error
+	}{
+		"nil lock": {
+			expErr: errors.New("nil pool lock"),
+		},
+		"locked, same id": {
+			plm: func() *poolLockMap {
+				plm := &poolLockMap{log: log}
+				plm.take(uuid0)
+				plm.locks[uuid0].id = lock0.id
+				return plm
+			}(),
+			checkLock: lock0,
+		},
+		"locked, different id": {
+			plm: func() *poolLockMap {
+				plm := &poolLockMap{log: log}
+				plm.take(uuid0)
+				plm.locks[uuid0].id = lock1.id
+				return plm
+			}(),
+			checkLock: lock0,
+			expErr:    errors.New("locked"),
+		},
+		"not locked": {
+			checkLock: lock0,
+			expErr:    errors.New("not found"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.plm == nil {
+				tc.plm = &poolLockMap{log: log}
+			}
+			defer test.ShowBufferOnFailure(t, buf)
+
+			checkErr := tc.plm.checkLock(tc.checkLock)
+			test.CmpErr(t, tc.expErr, checkErr)
+		})
+	}
+}

--- a/src/control/system/raft/raft.go
+++ b/src/control/system/raft/raft.go
@@ -21,6 +21,7 @@ import (
 	"go.etcd.io/bbolt"
 	"google.golang.org/grpc"
 
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -116,7 +117,15 @@ func (db *Database) ResignLeadership(cause error) error {
 // outstanding log entries.
 func (db *Database) Barrier() error {
 	return db.raft.withReadLock(func(svc raftService) error {
-		return svc.Barrier(0).Error()
+		err := svc.Barrier(0).Error()
+		if IsRaftLeadershipError(err) {
+			db.log.Errorf("lost leadership during Barrier(): %s", err)
+			return &system.ErrNotLeader{
+				LeaderHint: db.leaderHint(),
+				Replicas:   db.cfg.stringReplicas(db.replicaAddr),
+			}
+		}
+		return err
 	})
 }
 
@@ -411,7 +420,7 @@ func (db *Database) submitMemberUpdate(op raftOp, m *memberUpdate) error {
 	if err != nil {
 		return err
 	}
-	db.log.Debugf("member %d:%x updated @ %s", m.Member.Rank, m.Member.Incarnation, m.Member.LastUpdate)
+	db.log.Debugf("member %d:%x updated @ %s", m.Member.Rank, m.Member.Incarnation, common.FormatTime(m.Member.LastUpdate))
 	return db.submitRaftUpdate(data)
 }
 
@@ -423,7 +432,7 @@ func (db *Database) submitPoolUpdate(op raftOp, ps *system.PoolService) error {
 	if err != nil {
 		return err
 	}
-	db.log.Debugf("pool %s updated @ %s", ps.PoolUUID, ps.LastUpdate)
+	db.log.Debugf("pool %s (%s) updated @ %s", dbgUuidStr(ps.PoolUUID), ps.State, common.FormatTime(ps.LastUpdate))
 	return db.submitRaftUpdate(data)
 }
 

--- a/src/control/system/raft/raft_recovery.go
+++ b/src/control/system/raft/raft_recovery.go
@@ -267,6 +267,9 @@ func GetLogEntries(log logging.Logger, cfg *DatabaseConfig, maxEntries ...uint64
 					close(entries)
 					return
 				}
+			} else {
+				details.Time = details.Log.AppendedAt
+				details.Operation = details.Log.Type.String()
 			}
 
 			entries <- details

--- a/src/control/system/raft/raft_recovery_test.go
+++ b/src/control/system/raft/raft_recovery_test.go
@@ -133,9 +133,15 @@ func Test_Raft_RegenerateFixtures(t *testing.T) {
 			},
 		}
 
-		if err := db.AddPoolService(ps); err != nil {
+		lock, err := db.TakePoolLock(ctx, ps.PoolUUID)
+		if err != nil {
 			t.Fatal(err)
 		}
+
+		if err := db.AddPoolService(lock.InContext(ctx), ps); err != nil {
+			t.Fatal(err)
+		}
+		lock.Release()
 	}
 	t.Log("waiting for snapshot")
 	waitForSnapshots(ctx, t, log, dbCfg, 2)


### PR DESCRIPTION
In certain circumstances, a PoolCreate and PoolDestroy may
race, leading to unexpected behavior. This commit adds a
new locking mechanism at the pool database level to prevent
concurrent write operations by more than one parent gRPC
handler.

Additionally, we now call raft.Barrier() as part of the
leadership check in order to ensure that the leader has caught
up with any outstanding logs before proceeding on to any logic
that depends on having leadership.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
