### PR TITLE
DAOS-11972 cq: Change GitHub Actions distros matrix.

### DIFF
--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -74,10 +74,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [rocky9, fedora, leap.15]
+        distro: [rocky.9, fedora, leap.15]
         compiler: [clang, gcc]
         include:
-          - distro: rocky9
+          - distro: rocky.9
             base: el.9
             with: rockylinux/rockylinux:9
           - distro: fedora

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -74,10 +74,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [rocky.9, fedora, leap.15]
+        distro: [rocky, fedora, leap.15]
         compiler: [clang, gcc]
         include:
-          - distro: rocky.9
+          - distro: rocky
             base: el.9
             with: rockylinux/rockylinux:9
           - distro: fedora

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -74,12 +74,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [rocky, fedora, leap.15]
+        distro: [rocky9, fedora, leap.15]
         compiler: [clang, gcc]
         include:
-          - distro: rocky
-            base: el.8
-            with: rockylinux/rockylinux:8
+          - distro: rocky9
+            base: el.9
+            with: rockylinux/rockylinux:9
           - distro: fedora
             base: el.8
             with: fedora:36

--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -144,15 +144,15 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        distro: [ubuntu, rocky, fedora, leap.15]
+        distro: [ubuntu, rocky9, fedora, leap.15]
         compiler: [clang, gcc]
         include:
           - distro: ubuntu
             base: ubuntu
             with: ubuntu:22.04
-          - distro: rocky
-            base: el.8
-            with: rockylinux/rockylinux:8
+          - distro: rocky9
+            base: el.9
+            with: rockylinux/rockylinux:9
           - distro: fedora
             base: el.8
             with: fedora:36
@@ -221,7 +221,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [alma.8, alma.9]
+        distro: [alma.8, alma.9, rocky9]
         include:
           - distro: alma.8
             base: el.8
@@ -229,6 +229,9 @@ jobs:
           - distro: alma.9
             base: el.9
             with: almalinux:9
+          - distro: rocky8
+            base: el.8
+            with: rockylinux/rockylinux:8
     env:
       DEPS_JOBS: 10
       BASE_DISTRO: ${{ matrix.with }}

--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -35,14 +35,14 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        distro: [ubuntu, rocky.9, fedora, leap.15]
+        distro: [ubuntu, rocky, fedora, leap.15]
         include:
           - distro: ubuntu
             base: ubuntu
             with: ubuntu:22.04
-          - distro: rocky.9
-            base: el.8
-            with: rockylinux/rockylinux:8
+          - distro: rocky
+            base: el.9
+            with: rockylinux/rockylinux:9
           - distro: fedora
             base: el.8
             with: fedora:36
@@ -144,13 +144,13 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        distro: [ubuntu, rocky9, fedora, leap.15]
+        distro: [ubuntu, rocky, fedora, leap.15]
         compiler: [clang, gcc]
         include:
           - distro: ubuntu
             base: ubuntu
             with: ubuntu:22.04
-          - distro: rocky9
+          - distro: rocky
             base: el.9
             with: rockylinux/rockylinux:9
           - distro: fedora

--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -35,12 +35,12 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        distro: [ubuntu, rocky, fedora, leap.15]
+        distro: [ubuntu, rocky.9, fedora, leap.15]
         include:
           - distro: ubuntu
             base: ubuntu
             with: ubuntu:22.04
-          - distro: rocky
+          - distro: rocky.9
             base: el.8
             with: rockylinux/rockylinux:8
           - distro: fedora
@@ -221,7 +221,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [alma.8, alma.9, rocky9]
+        distro: [alma.8, alma.9, rocky.8]
         include:
           - distro: alma.8
             base: el.8
@@ -229,7 +229,7 @@ jobs:
           - distro: alma.9
             base: el.9
             with: almalinux:9
-          - distro: rocky8
+          - distro: rocky.8
             base: el.8
             with: rockylinux/rockylinux:8
     env:

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -674,10 +674,8 @@ create_cont(daos_handle_t poh, struct duns_attr_t *attrp, bool create_with_label
 		dfs_attr.da_dir_oclass_id = attrp->da_dir_oclass_id;
 		dfs_attr.da_chunk_size = attrp->da_chunk_size;
 		dfs_attr.da_props = attrp->da_props;
-		if (attrp->da_hints[0] != 0) {
-			strncpy(dfs_attr.da_hints, attrp->da_hints, DAOS_CONT_HINT_MAX_LEN);
-			dfs_attr.da_hints[DAOS_CONT_HINT_MAX_LEN - 1] = '\0';
-		}
+		if (attrp->da_hints[0] != 0)
+			memcpy(dfs_attr.da_hints, attrp->da_hints, DAOS_CONT_HINT_MAX_LEN);
 		if (create_with_label)
 			rc = dfs_cont_create_with_label(poh, attrp->da_cont, &dfs_attr,
 							&attrp->da_cuuid, NULL, NULL);


### PR DESCRIPTION
Move rocky8 to Landings only, and add rocky9 to PRs and landings.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
