### PR TITLE
DAOS-11949 tests: Do not kill all replicas

### DIFF
--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1095,12 +1095,12 @@ rebuild_multiple_failures(void **state)
 
 	arg->rebuild_post_cb_arg = cb_arg_oids;
 
-	rebuild_pools_ranks(&arg, 1, ranks_to_kill, MAX_KILLS, true);
+	rebuild_pools_ranks(&arg, 1, ranks_to_kill, 2, true);
 
 	arg->rebuild_cb = NULL;
 	arg->rebuild_post_cb = NULL;
 
-	reintegrate_pools_ranks(&arg, 1, ranks_to_kill, MAX_KILLS, true);
+	reintegrate_pools_ranks(&arg, 1, ranks_to_kill, 2, true);
 }
 
 static void


### PR DESCRIPTION
Do not kill all replicas of the object, otherwise
it may cause EIO for inflight I/O for the moment.

Test-tag: daos_core_test_rebuild
Required-githooks: true

Signed-off-by: Di Wang <di.wang@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
