### PR TITLE
DAOS-11970 cart: Fix limit checks on contexts

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -193,8 +193,7 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 	cur_ctx_num = crt_provider_get_cur_ctx_num(provider);
 	max_ctx_num = crt_provider_get_max_ctx_num(provider);
 
-	if (sep_mode &&
-	    cur_ctx_num >= max_ctx_num) {
+	if (cur_ctx_num >= max_ctx_num) {
 		D_WARN("Number of active contexts (%d) reached limit (%d).\n",
 			cur_ctx_num, max_ctx_num);
 		D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -178,7 +178,6 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 	struct crt_context	*ctx = NULL;
 	int			rc = 0;
 	size_t			uri_len = CRT_ADDR_STR_MAX_LEN;
-	bool			sep_mode;
 	int			cur_ctx_num;
 	int			max_ctx_num;
 	d_list_t		*ctx_list;
@@ -189,7 +188,6 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 	}
 
 	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
-	sep_mode = crt_provider_is_sep(provider);
 	cur_ctx_num = crt_provider_get_cur_ctx_num(provider);
 	max_ctx_num = crt_provider_get_max_ctx_num(provider);
 

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -323,7 +323,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 	int		plugin_idx;
 	int		prov;
 	bool		set_sep = false;
-	int		max_num_ctx = 256;
+	int		max_num_ctx = CRT_SRV_CONTEXT_NUM;
 	uint32_t	ctx_num;
 	bool		share_addr;
 	int		rc = 0;
@@ -432,19 +432,21 @@ do_init:
 		prov = crt_gdata.cg_init_prov;
 
 		if (opt && opt->cio_sep_override) {
-			if (opt->cio_use_sep)
+			if (opt->cio_use_sep) {
 				set_sep = true;
-			max_num_ctx = opt->cio_ctx_max_num;
+				max_num_ctx = opt->cio_ctx_max_num;
+			}
 		} else {
 			share_addr = false;
 			ctx_num = 0;
 
 			d_getenv_bool("CRT_CTX_SHARE_ADDR", &share_addr);
-			if (share_addr)
-				set_sep = true;
-
 			d_getenv_int("CRT_CTX_NUM", &ctx_num);
-			max_num_ctx = ctx_num;
+
+			if (share_addr) {
+				set_sep = true;
+				max_num_ctx = ctx_num;
+			}
 		}
 
 		uint32_t max_expect_size = 0;


### PR DESCRIPTION
- The check for not overflowing 256 contexts was only set for SEP mode, causing crash if client tried to allocate more.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
