### PR TITLE
SRE-564 ci: Don't stop on UT failure on timed...

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -654,7 +654,7 @@ pipeline {
                       expression { !skipStage() }
                     }
                     agent {
-                        label params.CI_UNIT_VM1_LABEL
+                        label cachedCommitPragma(pragma: 'VM1-label', def_val: params.CI_UNIT_VM1_LABEL)
                     }
                     steps {
                         unitTest timeout_time: 60,
@@ -710,7 +710,7 @@ pipeline {
                       expression { !skipStage() }
                     }
                     agent {
-                        label params.CI_UNIT_VM1_LABEL
+                        label cachedCommitPragma(pragma: 'VM1-label', def_val: params.CI_UNIT_VM1_LABEL)
                     }
                     steps {
                         unitTest timeout_time: 60,
@@ -737,7 +737,7 @@ pipeline {
                       expression { !skipStage() }
                     }
                     agent {
-                        label params.CI_UNIT_VM1_LABEL
+                        label cachedCommitPragma(pragma: 'VM1-label', def_val: params.CI_UNIT_VM1_LABEL)
                     }
                     steps {
                         unitTest timeout_time: 60,
@@ -849,7 +849,7 @@ pipeline {
                         expression { !skipStage() }
                     }
                     agent {
-                        label params.CI_UNIT_VM1_LABEL
+                        label cachedCommitPragma(pragma: 'VM1-label', def_val: params.CI_UNIT_VM1_LABEL)
                     }
                     steps {
                         scanRpms inst_repos: daosRepos(),
@@ -868,7 +868,7 @@ pipeline {
                         expression { !skipStage() }
                     }
                     agent {
-                        label params.CI_UNIT_VM1_LABEL
+                        label cachedCommitPragma(pragma: 'VM1-label', def_val: params.CI_UNIT_VM1_LABEL)
                     }
                     steps {
                         scanRpms inst_repos: daosRepos(),

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -143,7 +143,7 @@ function get_test_runner()
 		test_runner="gotestsum --format short "
 		test_runner+="--junitfile-testcase-classname relative "
 		test_runner+="--junitfile-testsuite-name relative "
-		if [ -n "${IS_CI:-}" ]; then
+		if ${IS_CI:-false}; then
 			test_runner+="--no-color "
 		fi
 		test_runner+="--junitfile $GO_TEST_XML --"

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -248,7 +248,9 @@ if [ -d "/mnt/daos" ]; then
         for ((i = 0; i < ${#failures[@]}; i++)); do
             echo "    ${failures[$i]}"
         done
-        exit 1
+        if ! ${IS_CI:-false}; then
+            exit 1
+        fi
     fi
 else
     echo "/mnt/daos isn't present for unit tests"


### PR DESCRIPTION
Runs.

Has the effect of restoring the `Allow-unstable-test: true` commit pragma for UT also.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
