### PR TITLE
DAOS-11538 proto: replace dangling pool option with orphan pool

### DIFF
--- a/src/chk/chk.pb-c.c
+++ b/src/chk/chk.pb-c.c
@@ -410,7 +410,7 @@ static const ProtobufCEnumValue chk__check_flag__enum_values_by_number[8] =
   { "CF_RESET", "CHK__CHECK_FLAG__CF_RESET", 2 },
   { "CF_FAILOUT", "CHK__CHECK_FLAG__CF_FAILOUT", 4 },
   { "CF_AUTO", "CHK__CHECK_FLAG__CF_AUTO", 8 },
-  { "CF_DANGLING_POOL", "CHK__CHECK_FLAG__CF_DANGLING_POOL", 16 },
+  { "CF_ORPHAN_POOL", "CHK__CHECK_FLAG__CF_ORPHAN_POOL", 16 },
   { "CF_NO_FAILOUT", "CHK__CHECK_FLAG__CF_NO_FAILOUT", 32 },
   { "CF_NO_AUTO", "CHK__CHECK_FLAG__CF_NO_AUTO", 64 },
 };
@@ -420,12 +420,12 @@ static const ProtobufCIntRange chk__check_flag__value_ranges[] = {
 static const ProtobufCEnumValueIndex chk__check_flag__enum_values_by_name[8] =
 {
   { "CF_AUTO", 4 },
-  { "CF_DANGLING_POOL", 5 },
   { "CF_DRYRUN", 1 },
   { "CF_FAILOUT", 3 },
   { "CF_NONE", 0 },
   { "CF_NO_AUTO", 7 },
   { "CF_NO_FAILOUT", 6 },
+  { "CF_ORPHAN_POOL", 5 },
   { "CF_RESET", 2 },
 };
 const ProtobufCEnumDescriptor chk__check_flag__descriptor =

--- a/src/chk/chk.pb-c.h
+++ b/src/chk/chk.pb-c.h
@@ -224,10 +224,10 @@ typedef enum _Chk__CheckFlag {
    */
   CHK__CHECK_FLAG__CF_AUTO = 8,
   /*
-   * Handle dangling pool when start the check instance. If not specify the flag, dangling
-   * pool will not be handled (by default) unless all pools are checked from the scratch.
+   * Handle orphan pool when start the check instance. If not specify the flag, some orphan
+   * pool(s) may be not handled (by default) unless all pools are checked from the scratch.
    */
-  CHK__CHECK_FLAG__CF_DANGLING_POOL = 16,
+  CHK__CHECK_FLAG__CF_ORPHAN_POOL = 16,
   /*
    * Overwrite former set CF_FAILOUT flag, cannot be specified together with CF_FAILOUT.
    */

--- a/src/proto/chk/chk.proto
+++ b/src/proto/chk/chk.proto
@@ -134,9 +134,9 @@ enum CheckFlag {
 	// If the admin does not want to interact with engine during check scan, then CIA_INTERACT
 	// will be converted to CIA_IGNORE. That will overwrite the CheckInconsistPolicy.
 	CF_AUTO		= 8;
-	// Handle dangling pool when start the check instance. If not specify the flag, dangling
-	// pool will not be handled (by default) unless all pools are checked from the scratch.
-	CF_DANGLING_POOL = 16;
+	// Handle orphan pool when start the check instance. If not specify the flag, some orphan
+	// pool(s) may be not handled (by default) unless all pools are checked from the scratch.
+	CF_ORPHAN_POOL = 16;
 	// Overwrite former set CF_FAILOUT flag, cannot be specified together with CF_FAILOUT.
 	CF_NO_FAILOUT	= 32;
 	// Overwrite former set CF_AUTO flag, cannot be specified together with CF_AUTO.


### PR DESCRIPTION
From control plane's perspective, it always can know the pool UUID from MS database if it exists on MS. So if the user wants to check whether some pool is dangling pool or not, he/she can specify such UUID via DAOS check start option. But for orphan pool, since there is no record in MS database, the user cannot know its UUID as then cannot be aware of its existence. So unless all pools are checked from the scratch or the user records the pool UUID via other way, otherwise, he/she has no chance to detect some orphan pools.

So we need the start option "-o | --orphan" for such purpose. It is more meaningful than the option "-d | --dangling".

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
