### PR TITLE
DAOS-10854 test: replace dfuse_utils pcmd with run_remote

### DIFF
--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -10,7 +10,8 @@ from ClusterShell.NodeSet import NodeSet
 from command_utils_base import FormattedParameter
 from exception_utils import CommandFailure
 from command_utils import ExecutableCommand
-from general_utils import check_file_exists, pcmd
+from general_utils import check_file_exists
+from run_utils import run_remote
 
 
 class DfuseCommand(ExecutableCommand):
@@ -119,32 +120,26 @@ class Dfuse(DfuseCommand):
         }
         if not nodes:
             nodes = self.hosts.copy()
-        check_mounted = NodeSet()
 
         # Detect which hosts have mount point directories defined
-        command = "test -d {0} -a ! -L {0}".format(self.mount_dir.value)
-        retcodes = pcmd(nodes, command, expect_rc=None)
-        for retcode, hosts in list(retcodes.items()):
-            if retcode == 0:
-                check_mounted.add(hosts)
-            else:
-                command = "grep 'dfuse {}' /proc/mounts" .format(self.mount_dir.value)
-                retcodes = pcmd(hosts, command, expect_rc=None)
-                for ret_code, host_names in list(retcodes.items()):
-                    if ret_code == 0:
-                        check_mounted.add(host_names)
-                    else:
-                        state["nodirectory"].add(host_names)
+        command = f"test -d {self.mount_dir.value} -a ! -L {self.mount_dir.value}"
+        test_result = run_remote(self.log, nodes, command)
+        check_mounted = test_result.passed_hosts
+        if not test_result.passed:
+            command = f"grep 'dfuse {self.mount_dir.value}' /proc/mounts"
+            grep_result = run_remote(self.log, test_result.failed_hosts, command)
+            check_mounted.add(grep_result.passed_hosts)
+            state["nodirectory"].add(grep_result.failed_hosts)
 
         if check_mounted:
             # Detect which hosts with mount point directories have it mounted as a fuseblk device
-            command = "stat -c %T -f {0} | grep -v fuseblk".format(self.mount_dir.value)
-            retcodes = pcmd(check_mounted, command, expect_rc=None)
-            for retcode, hosts in list(retcodes.items()):
-                if retcode == 1:
-                    state["mounted"].add(hosts)
+            command = f"stat -c %T -f {self.mount_dir.value} | grep -v fuseblk"
+            stat_result = run_remote(self.log, check_mounted, command)
+            for data in stat_result.output:
+                if data.returncode == 1:
+                    state["mounted"].add(data.hosts)
                 else:
-                    state["unmounted"].add(hosts)
+                    state["unmounted"].add(data.hosts)
 
         return state
 
@@ -177,24 +172,17 @@ class Dfuse(DfuseCommand):
         """
         # Raise exception if mount point not specified
         if self.mount_dir.value is None:
-            raise CommandFailure("Mount point not specified, "
-                                 "check test yaml file")
+            raise CommandFailure("Mount point not specified. Check test yaml file")
 
         # Create the mount point on any host without dfuse already mounted
         state = self.check_mount_state()
         if state["nodirectory"]:
-            command = "mkdir -p {}".format(self.mount_dir.value)
-            ret_code = pcmd(state["nodirectory"], command, timeout=30)
-            if len(ret_code) > 1 or 0 not in ret_code:
-                failed_nodes = [
-                    str(node_set) for code, node_set in list(ret_code.items())
-                    if code != 0
-                ]
-                error_hosts = NodeSet(",".join(failed_nodes))
+            command = f"mkdir -p {self.mount_dir.value}"
+            result = run_remote(self.log, state["nodirectory"], command, timeout=30)
+            if not result.passed:
                 raise CommandFailure(
-                    "Error creating the {} dfuse mount point on the "
-                    "following hosts: {}".format(
-                        self.mount_dir.value, error_hosts))
+                    f"Error creating the {self.mount_dir.value} dfuse mount point "
+                    f"on the following hosts: {result.failed_hosts}")
 
     def remove_mount_point(self, fail=True):
         """Remove dfuse directory.
@@ -208,59 +196,45 @@ class Dfuse(DfuseCommand):
         """
         # raise exception if mount point not specified
         if self.mount_dir.value is None:
-            raise CommandFailure("Mount point not specified, "
-                                 "check test yaml file")
+            raise CommandFailure("Mount point not specified. Check test yaml file")
 
         dir_exists, clean_nodes = check_file_exists(
             self.hosts, self.mount_dir.value, directory=True)
-        if dir_exists:
-            target_nodes = self.hosts.copy()
-            if clean_nodes:
-                target_nodes.remove(clean_nodes)
 
+        if not dir_exists:
             self.log.info(
-                "Removing the %s dfuse mount point on %s",
-                self.mount_dir.value, target_nodes)
+                "No %s dfuse mount point directory found on %s", self.mount_dir.value, self.hosts)
+            return
 
-            cmd = "rmdir {}".format(self.mount_dir.value)
-            ret_code = pcmd(target_nodes, cmd, timeout=30)
-            if len(ret_code) == 1 and 0 in ret_code:
-                return
+        target_nodes = self.hosts - clean_nodes
 
-            failed_nodes = NodeSet(",".join(
-                [str(node_set) for code, node_set in list(ret_code.items())
-                 if code != 0]))
+        self.log.info(
+            "Removing the %s dfuse mount point on %s", self.mount_dir.value, target_nodes)
 
-            cmd = "rm -rf {}".format(self.mount_dir.value)
-            ret_code = pcmd(failed_nodes, cmd, timeout=30)
-            if len(ret_code) > 1 or 0 not in ret_code:
-                error_hosts = NodeSet(
-                    ",".join(
-                        [str(node_set) for code, node_set in list(
-                            ret_code.items()) if code != 0]))
-                if fail:
-                    raise CommandFailure(
-                        "Error removing the {} dfuse mount point with rm on "
-                        "the following hosts: {}".format(self.mount_dir.value,
-                                                         error_hosts))
-            if fail:
-                raise CommandFailure(
-                    "Error removing the {} dfuse mount point with rmdir on the "
-                    "following hosts: {}".format(self.mount_dir.value,
-                                                 failed_nodes))
-        else:
-            self.log.info(
-                "No %s dfuse mount point directory found on %s",
-                self.mount_dir.value, self.hosts)
+        command = f"rmdir {self.mount_dir.value}"
+        rmdir_result = run_remote(self.log, target_nodes, command, timeout=30)
+        if rmdir_result.passed:
+            return
+
+        command = f"rm -rf {self.mount_dir.value}"
+        rm_result = run_remote(self.log, rmdir_result.failed_hosts, command, timeout=30)
+        if fail and not rm_result.passed:
+            raise CommandFailure(
+                f"Error removing the {self.mount_dir.value} dfuse mount point with rm on "
+                f"the following hosts: {rm_result.failed_hosts}")
+        if fail:
+            raise CommandFailure(
+                f"Error removing the {self.mount_dir.value} dfuse mount point with rmdir on the "
+                f"following hosts: {rmdir_result.failed_hosts}")
 
     def run(self, check=True, bind_cores=None):
         # pylint: disable=arguments-differ
         """Run the dfuse command.
 
         Args:
-            check (bool): Check if dfuse mounted properly after
-                mount is executed.
+            check (bool): Check if dfuse mounted properly after mount is executed.
             bind_cores (str): List of CPU cores to pass to taskset
+
         Raises:
             CommandFailure: In case dfuse run command fails
 
@@ -269,8 +243,7 @@ class Dfuse(DfuseCommand):
 
         # A log file must be defined to ensure logs are captured
         if "D_LOG_FILE" not in self.env:
-            raise CommandFailure(
-                "Dfuse missing environment variables for D_LOG_FILE")
+            raise CommandFailure("Dfuse missing environment variables for D_LOG_FILE")
 
         if 'D_LOG_MASK' not in self.env:
             self.env['D_LOG_MASK'] = 'INFO'
@@ -286,36 +259,25 @@ class Dfuse(DfuseCommand):
         if bind_cores:
             cmd += 'taskset -c {} '.format(bind_cores)
         cmd += str(self)
-        self.log.info("Command is '%s'", cmd)
-        ret_code = pcmd(self.hosts, cmd, timeout=30)
 
-        if 0 in ret_code:
-            self.running_hosts.add(ret_code[0])
-            del ret_code[0]
-
-        if ret_code:
-            error_hosts = NodeSet(
-                ",".join(
-                    [str(node_set) for code, node_set in list(ret_code.items())
-                     if code != 0]))
+        result = run_remote(self.log, self.hosts, cmd, timeout=30)
+        self.running_hosts.add(result.passed_hosts)
+        if not result.passed:
             raise CommandFailure(
-                "Error starting dfuse on the following hosts: {}".format(
-                    error_hosts))
+                f"Error starting dfuse on the following hosts: {result.failed_hosts}")
 
         if check:
             # Dfuse will block in the command for the mount to complete, even
             # if run in background mode so it should be possible to start using
             # it immediately after the command returns.
-            if not self.check_running(fail_on_error=False):
-                self.log.info('Waiting two seconds for dfuse to start')
-                time.sleep(2)
-                if not self.check_running(fail_on_error=False):
-                    self.log.info('Waiting five seconds for dfuse to start')
-                    time.sleep(5)
-                    self.check_running()
+            num_retries = 3
+            for retry in range(1, num_retries + 1):
+                if not self.check_running(fail_on_error=(retry == num_retries)):
+                    self.log.info('Waiting two seconds for dfuse to start')
+                    time.sleep(2)
 
     def check_running(self, fail_on_error=True):
-        """Check dfuse is running.
+        """Check if dfuse is running.
 
         Run a command to verify dfuse is running on hosts where it is supposed
         to be.  Use grep -v and rc=1 here so that if it isn't, then we can
@@ -363,55 +325,51 @@ class Dfuse(DfuseCommand):
         self.running_hosts.add(self.hosts)
 
         self.log.info(
-            "Stopping dfuse at %s on %s",
-            self.mount_dir.value, self.running_hosts)
+            "Stopping dfuse at %s on %s", self.mount_dir.value, self.running_hosts)
 
-        if self.mount_dir.value and self.running_hosts:
-            error_list = []
-
-            # Loop until all fuseblk mounted devices are unmounted
-            counter = 0
-            while self.running_hosts and counter < 3:
-                # Attempt to kill dfuse on after first unmount fails
-                if self.running_hosts and counter > 1:
-                    kill_command = "pkill dfuse --signal KILL"
-                    pcmd(self.running_hosts, kill_command, timeout=30)
-
-                # Attempt to unmount any fuseblk mounted devices after detection
-                if self.running_hosts and counter > 0:
-                    pcmd(
-                        self.running_hosts,
-                        self.get_umount_command(counter > 1), expect_rc=None)
-                    time.sleep(2)
-
-                # Detect which hosts have fuseblk mounted devices and remove any
-                # hosts which no longer have the dfuse mount point mounted
-                state = self.check_mount_state(self.running_hosts)
-                for host in state["unmounted"].union(state["nodirectory"]):
-                    self.running_hosts.remove(host)
-
-                # Increment the loop counter
-                counter += 1
-
-            if self.running_hosts:
-                error_list.append(
-                    "Error stopping dfuse on {}".format(self.running_hosts))
-
-            # Remove mount points
-            try:
-                self.remove_mount_point()
-            except CommandFailure as error:
-                error_list.append(error)
-
-            # Report any errors
-            if error_list:
-                raise CommandFailure("\n".join(error_list))
-
-        elif self.mount_dir.value is None:
+        if self.mount_dir.value is None:
             self.log.info("No dfuse mount directory defined - nothing to stop")
+            return
 
-        else:
+        if not self.running_hosts:
             self.log.info("No hosts running dfuse - nothing to stop")
+            return
+
+        error_list = []
+
+        # Loop until all fuseblk mounted devices are unmounted
+        counter = 0
+        while self.running_hosts and counter < 3:
+            # Attempt to kill dfuse on after first unmount fails
+            if self.running_hosts and counter > 1:
+                kill_command = "pkill dfuse --signal KILL"
+                _ = run_remote(self.log, self.running_hosts, kill_command, timeout=30)
+
+            # Attempt to unmount any fuseblk mounted devices after detection
+            if self.running_hosts and counter > 0:
+                _ = run_remote(self.log, self.running_hosts, self.get_umount_command(counter > 1))
+                time.sleep(2)
+
+            # Detect which hosts have fuseblk mounted devices and remove any
+            # hosts which no longer have the dfuse mount point mounted
+            state = self.check_mount_state(self.running_hosts)
+            self.running_hosts.remove(state["unmounted"].union(state["nodirectory"]))
+
+            # Increment the loop counter
+            counter += 1
+
+        if self.running_hosts:
+            error_list.append(f"Error stopping dfuse on {self.running_hosts}")
+
+        # Remove mount points
+        try:
+            self.remove_mount_point()
+        except CommandFailure as error:
+            error_list.append(error)
+
+        # Report any errors
+        if error_list:
+            raise CommandFailure("\n".join(error_list))
 
 
 def get_dfuse(test, hosts, namespace=None):

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -78,6 +78,26 @@ class RemoteCommandResult():
         """
         return any(data.timeout for data in self.output)
 
+    @property
+    def passed_hosts(self):
+        """Get all passed hosts.
+
+        Returns:
+            NodeSet: all nodes where the command passed
+
+        """
+        return NodeSet.fromlist(data.hosts for data in self.output if data.returncode == 0)
+
+    @property
+    def failed_hosts(self):
+        """Get all failed hosts.
+
+        Returns:
+            NodeSet: all nodes where the command failed
+
+        """
+        return NodeSet.fromlist(data.hosts for data in self.output if data.returncode != 0)
+
     def _process_task(self, task, command):
         """Populate the output list and determine the passed result for the specified task.
 


### PR DESCRIPTION
Test-tag: dfuse,-manual
Skip-unit-tests: true
Skip-fault-injection-test: true

- dfuse_utils
  - replace all pcmd() with run_remote().
- run_utils
  - add RemoteCommandResult.passed_hosts
  - add RemoteCommandResult.failed_hosts

Required-githooks: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
