### PR TITLE
DAOS-11538 chk: engine rejoin check instance after restart

### DIFF
--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -249,11 +249,12 @@ CRT_RPC_DECLARE(chk_report, DAOS_ISEQ_CHK_REPORT, DAOS_OSEQ_CHK_REPORT);
 #define DAOS_ISEQ_CHK_REJOIN							\
 	((uint64_t)		(cri_gen)		CRT_VAR)		\
 	((d_rank_t)		(cri_rank)		CRT_VAR)		\
-	((d_rank_t)		(cri_phase)		CRT_VAR)
+	((d_rank_t)		(cri_padding)		CRT_VAR)
 
 #define DAOS_OSEQ_CHK_REJOIN							\
 	((int32_t)		(cro_status)		CRT_VAR)		\
-	((uint32_t)		(cro_padding)		CRT_VAR)
+	((uint32_t)		(cro_padding)		CRT_VAR)		\
+	((uuid_t)		(cro_pools)		CRT_ARRAY)
 
 CRT_RPC_DECLARE(chk_rejoin, DAOS_ISEQ_CHK_REJOIN, DAOS_OSEQ_CHK_REJOIN);
 
@@ -699,7 +700,7 @@ int chk_leader_report(struct chk_report_unit *cru, uint64_t *seq, int *decision)
 
 int chk_leader_notify(struct chk_iv *iv);
 
-int chk_leader_rejoin(uint64_t gen, d_rank_t rank, uint32_t phase);
+int chk_leader_rejoin(uint64_t gen, d_rank_t rank, int *pool_nr, uuid_t **pools);
 
 void chk_leader_pause(void);
 
@@ -739,7 +740,8 @@ int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act,
 		      uint32_t option_nr, uint32_t *options, uint32_t detail_nr,
 		      d_sg_list_t *details, uint64_t *seq);
 
-int chk_rejoin_remote(d_rank_t leader, uint64_t gen, d_rank_t rank, uint32_t phase);
+int chk_rejoin_remote(d_rank_t leader, uint64_t gen, d_rank_t rank,
+		      uint32_t *pool_nr, uuid_t **pools);
 
 /* chk_updcall.c */
 

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -229,14 +229,23 @@ ds_chk_rejoin_hdlr(crt_rpc_t *rpc)
 {
 	struct chk_rejoin_in	*cri = crt_req_get(rpc);
 	struct chk_rejoin_out	*cro = crt_reply_get(rpc);
+	uuid_t			*pools = NULL;
+	int			 pool_nr = 0;
 	int			 rc;
 
-	rc = chk_leader_rejoin(cri->cri_gen, cri->cri_rank, cri->cri_phase);
+	rc = chk_leader_rejoin(cri->cri_gen, cri->cri_rank, &pool_nr, &pools);
 
 	cro->cro_status = rc;
+	if (rc == 0) {
+		cro->cro_pools.ca_count = pool_nr;
+		cro->cro_pools.ca_arrays = pools;
+	}
+
 	rc = crt_reply_send(rpc);
 	if (rc != 0)
 		D_ERROR("Failed to reply check rejoin: "DF_RC"\n", DP_RC(rc));
+
+	D_FREE(pools);
 }
 
 static int


### PR DESCRIPTION
Some DAOS check instance may run for very long time. Before completion, at some time point, some check engine may hit corruption, then restart very quickly. If the engine downtime is very short, then there maybe no DAOS check failure for such engine down. Under such case, we need allow such check engine to rejoin former check instance after the restart. It will be better than making related pool(s) to be rechecked.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
