### PR TITLE
DAOS-11885 bio: remove umem from bio_io_context

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -790,32 +790,9 @@ out_free:
 	return rc;
 }
 
-void
-bio_mc_init_umem(struct bio_meta_context *mc, struct umem_instance *umem)
+int bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt, uuid_t uuid)
 {
-	if (mc->mc_data != NULL)
-		mc->mc_data->bic_umem = umem;
-
-	if (mc->mc_meta != NULL)
-		mc->mc_meta->bic_umem = umem;
-
-	if (mc->mc_wal != NULL)
-		mc->mc_wal->bic_umem = umem;
-
-}
-
-int bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt,
-		    struct umem_instance *umem, uuid_t uuid)
-{
-	int rc;
-
-	rc = __bio_ioctxt_open(pctxt, xs_ctxt, uuid, 0, SMD_DEV_TYPE_DATA, SPDK_BLOBID_INVALID);
-	if (rc)
-		return rc;
-
-	(*pctxt)->bic_umem = umem;
-
-	return rc;
+	return __bio_ioctxt_open(pctxt, xs_ctxt, uuid, 0, SMD_DEV_TYPE_DATA, SPDK_BLOBID_INVALID);
 }
 
 int bio_mc_open(struct bio_xs_context *xs_ctxt, uuid_t pool_id,
@@ -1120,7 +1097,7 @@ blob_unmap_sgl(struct bio_io_context *ioctxt, d_sg_list_t *unmap_sgl, uint32_t b
 		i++;
 		unmap_cnt--;
 
-		drain_inflight_ios(xs_ctxt, bxb, ioctxt->bic_umem);
+		drain_inflight_ios(xs_ctxt, bxb);
 
 		ba->bca_inflights++;
 		bxb->bxb_blob_rw++;

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -386,7 +386,6 @@ struct bio_xs_context {
 /* Per VOS instance I/O context */
 struct bio_io_context {
 	d_list_t		 bic_link; /* link to bxb_io_ctxts */
-	struct umem_instance	*bic_umem;
 	struct spdk_blob	*bic_blob;
 	struct bio_xs_blobstore	*bic_xs_blobstore;
 	struct bio_xs_context	*bic_xs_ctxt;
@@ -431,6 +430,7 @@ struct bio_rsrvd_dma {
 
 /* I/O descriptor */
 struct bio_desc {
+	struct umem_instance	*bd_umem;
 	struct bio_io_context	*bd_ctxt;
 	/* DMA buffers reserved by this io descriptor */
 	struct bio_rsrvd_dma	 bd_rsrvd;
@@ -547,8 +547,7 @@ void setup_bio_bdev(void *arg);
 void destroy_bio_bdev(struct bio_bdev *d_bdev);
 void replace_bio_bdev(struct bio_bdev *old_dev, struct bio_bdev *new_dev);
 bool bypass_health_collect(void);
-void drain_inflight_ios(struct bio_xs_context *ctxt, struct bio_xs_blobstore *bbs,
-			struct umem_instance *umm);
+void drain_inflight_ios(struct bio_xs_context *ctxt, struct bio_xs_blobstore *bbs);
 
 /* bio_buffer.c */
 void dma_buffer_destroy(struct bio_dma_buffer *buf);

--- a/src/bio/bio_wal.c
+++ b/src/bio/bio_wal.c
@@ -781,7 +781,7 @@ bio_wal_commit(struct bio_meta_context *mc, struct umem_tx *tx, struct bio_desc 
 		return -DER_INVAL;
 	}
 
-	biod = bio_iod_alloc(mc->mc_wal, 1, BIO_IOD_TYPE_UPDATE);
+	biod = bio_iod_alloc(mc->mc_wal, NULL, 1, BIO_IOD_TYPE_UPDATE);
 	if (biod == NULL)
 		return -DER_NOMEM;
 

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -365,8 +365,7 @@ bio_need_nvme_poll(struct bio_xs_context *ctxt)
 }
 
 void
-drain_inflight_ios(struct bio_xs_context *ctxt, struct bio_xs_blobstore *bxb,
-		   struct umem_instance *umm)
+drain_inflight_ios(struct bio_xs_context *ctxt, struct bio_xs_blobstore *bxb)
 {
 
 	if (ctxt == NULL || bxb == NULL || bxb->bxb_blob_rw <= BIO_BS_POLL_WATERMARK)
@@ -376,7 +375,7 @@ drain_inflight_ios(struct bio_xs_context *ctxt, struct bio_xs_blobstore *bxb,
 		if (ctxt->bxc_self_polling)
 			spdk_thread_poll(ctxt->bxc_thread, 0, 0);
 		else
-			bio_yield(umm);
+			bio_yield(NULL);
 	} while (bxb->bxb_blob_rw >= BIO_BS_STOP_WATERMARK);
 }
 

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -494,14 +494,12 @@ int bio_nvme_poll(struct bio_xs_context *ctxt);
  *
  * \param[OUT] pctxt	I/O context to be returned
  * \param[IN] xs_ctxt	Per-xstream NVMe context
- * \param[IN] umem	umem instance
  * \param[IN] uuid	Pool UUID
  *
  * \returns		Zero on success, negative value on error
  */
 int bio_ioctxt_open(struct bio_io_context **pctxt,
-		    struct bio_xs_context *xs_ctxt,
-		    struct umem_instance *umem, uuid_t uuid);
+		    struct bio_xs_context *xs_ctxt, uuid_t uuid);
 
 enum bio_mc_flags {
 	BIO_MC_FL_SYSDB		= (1UL << 0),	/* for sysdb */
@@ -608,12 +606,13 @@ enum bio_iod_type {
  * Allocate & initialize an io descriptor
  *
  * \param ctxt       [IN]	I/O context
+ * \param umem       [IN]	umem instance
  * \param sgl_cnt    [IN]	SG list count
  * \param type       [IN]	IOD type
  *
  * \return			Opaque io descriptor or NULL on error
  */
-struct bio_desc *bio_iod_alloc(struct bio_io_context *ctxt,
+struct bio_desc *bio_iod_alloc(struct bio_io_context *ctxt, struct umem_instance *umem,
 			       unsigned int sgl_cnt, unsigned int type);
 /**
  * Free an io descriptor
@@ -846,14 +845,14 @@ void *bio_buf_addr(struct bio_desc *biod);
  * SGLs. bio_copy_post() must be called after a success bio_copy_prep() call.
  *
  * \param ioctxt	[IN]	BIO io context
+ * \param umem		[IN]	umem instance
  * \param bsgl_src	[IN]	Source BIO SGL
  * \param bsgl_dst	[IN]	Target BIO SGL
  *
  * \return			BIO copy descriptor on success, NULL on error
  */
-struct bio_copy_desc *bio_copy_prep(struct bio_io_context *ioctxt,
-				    struct bio_sglist *bsgl_src,
-				    struct bio_sglist *bsgl_dst);
+struct bio_copy_desc *bio_copy_prep(struct bio_io_context *ioctxt, struct umem_instance *umem,
+				    struct bio_sglist *bsgl_src, struct bio_sglist *bsgl_dst);
 
 struct bio_csum_desc {
 	uint8_t		*bmd_csum_buf;
@@ -901,6 +900,7 @@ struct bio_sglist *bio_copy_get_sgl(struct bio_copy_desc *copy_desc, bool src);
  * Copy data from source BIO SGL to target BIO SGL.
  *
  * \param ioctxt	[IN]	BIO io context
+ * \param umem		[IN]	umem instance
  * \param bsgl_src	[IN]	Source BIO SGL
  * \param bsgl_dst	[IN]	Target BIO SGL
  * \param copy_size	[IN]	Specified copy size, the size must be aligned
@@ -909,8 +909,8 @@ struct bio_sglist *bio_copy_get_sgl(struct bio_copy_desc *copy_desc, bool src);
  *
  * \return			0 on success, negative value on error
  */
-int bio_copy(struct bio_io_context *ioctxt, struct bio_sglist *bsgl_src,
-	     struct bio_sglist *bsgl_dst, unsigned int copy_size,
+int bio_copy(struct bio_io_context *ioctxt, struct umem_instance *umem,
+	     struct bio_sglist *bsgl_src, struct bio_sglist *bsgl_dst, unsigned int copy_size,
 	     struct bio_csum_desc *csum_desc);
 
 /*
@@ -966,12 +966,6 @@ int bio_mc_close(struct bio_meta_context *mc, enum bio_mc_flags flags);
 
 /* Function to return current data io context */
 struct bio_io_context *bio_mc2data(struct bio_meta_context *mc);
-
-/*
- * Init Metadata context umem instance
- */
-void
-bio_mc_init_umem(struct bio_meta_context *mc, struct umem_instance *umem);
 
 /* Function to check if metadata on ssd enabled or not */
 bool bio_is_meta_on_ssd_configured(void);

--- a/src/include/daos_srv/vea.h
+++ b/src/include/daos_srv/vea.h
@@ -124,7 +124,7 @@ struct vea_stat {
 struct vea_space_info;
 
 /* Callback to initialize block device header */
-typedef int (*vea_format_callback_t)(void *cb_data, struct umem_instance *umem);
+typedef int (*vea_format_callback_t)(void *cb_data);
 
 /**
  * Initialize the space tracking information on SCM and the header of the

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -98,7 +98,7 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 		 */
 		D_ASSERT(umem_tx_none(umem));
 
-		rc = cb(cb_data, umem);
+		rc = cb(cb_data);
 		if (rc != 0)
 			return rc;
 	}

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1104,6 +1104,7 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 	daos_off_t		 phy_lo = 0;
 	unsigned int		 i, seg_count, biov_idx = 0;
 	struct bio_copy_desc	*copy_desc;
+	struct umem_instance	*umem;
 	int			 rc;
 
 	D_ASSERT(obj != NULL);
@@ -1121,6 +1122,7 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 
 	bio_ctxt = bio_mc2data(obj->obj_cont->vc_pool->vp_meta_context);
 	D_ASSERT(bio_ctxt != NULL);
+	umem = &obj->obj_cont->vc_pool->vp_umm;
 
 	seg_count = lgc_seg->ls_idx_end - lgc_seg->ls_idx_start + 1;
 	rc = bio_sgl_init(&bsgl, seg_count);
@@ -1202,7 +1204,7 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 	D_ASSERT(!bio_addr_is_hole(&ent_in->ei_addr));
 	bio_iov_set(&bsgl_dst.bs_iovs[0], ent_in->ei_addr, seg_size);
 
-	copy_desc = bio_copy_prep(bio_ctxt, &bsgl, &bsgl_dst);
+	copy_desc = bio_copy_prep(bio_ctxt, umem, &bsgl, &bsgl_dst);
 	if (copy_desc == NULL) {
 		D_ERROR("Failed to Prepare source & target SGLs for copy.\n");
 		goto out;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1514,4 +1514,17 @@ vos_anchor_is_zero(daos_anchor_t *anchor)
 	return anchor == NULL || daos_anchor_is_zero(anchor);
 }
 
+static inline int
+vos_media_read(struct bio_io_context *ioc, struct umem_instance *umem,
+	       bio_addr_t addr, d_iov_t *iov_out)
+{
+	if (addr.ba_type == DAOS_MEDIA_NVME) {
+		D_ASSERT(ioc != NULL);
+		return bio_read(ioc, addr, iov_out);
+	}
+
+	D_ASSERT(umem != NULL);
+	memcpy(iov_out->iov_buf, umem_off2ptr(umem, addr.ba_off), iov_out->iov_len);
+	return 0;
+}
 #endif /* __VOS_INTERNAL_H__ */

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -683,7 +683,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	cont = vos_hdl2cont(coh);
 	bioc = bio_mc2data(cont->vc_pool->vp_meta_context);
 	D_ASSERT(bioc != NULL);
-	ioc->ic_biod = bio_iod_alloc(bioc, iod_nr,
+	ioc->ic_biod = bio_iod_alloc(bioc, vos_ioc2umm(ioc), iod_nr,
 			read_only ? BIO_IOD_TYPE_FETCH : BIO_IOD_TYPE_UPDATE);
 	if (ioc->ic_biod == NULL) {
 		rc = -DER_NOMEM;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1552,6 +1552,7 @@ recx_iter_copy(struct vos_obj_iter *oiter, vos_iter_entry_t *it_entry,
 	       d_iov_t *iov_out)
 {
 	struct bio_io_context	*bioc;
+	struct umem_instance	*umem;
 	struct bio_iov		*biov = &it_entry->ie_biov;
 
 	D_ASSERT(bio_iov2buf(biov) == NULL);
@@ -1565,13 +1566,14 @@ recx_iter_copy(struct vos_obj_iter *oiter, vos_iter_entry_t *it_entry,
 
 	/*
 	 * Set 'iov_len' beforehand, cause it will be used as copy
-	 * size in bio_read().
+	 * size in vos_media_read().
 	 */
 	iov_out->iov_len = bio_iov2len(biov);
 	bioc = bio_mc2data(oiter->it_obj->obj_cont->vc_pool->vp_meta_context);
 	D_ASSERT(bioc != NULL);
+	umem = &oiter->it_obj->obj_cont->vc_pool->vp_umm;
 
-	return bio_read(bioc, biov->bi_addr, iov_out);
+	return vos_media_read(bioc, umem, biov->bi_addr, iov_out);
 }
 
 static int

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -216,7 +216,7 @@ pool_lookup(struct d_uuid *ukey, struct vos_pool **pool)
 }
 
 static int
-vos_blob_format_cb(void *cb_data, struct umem_instance *umem)
+vos_blob_format_cb(void *cb_data)
 {
 	struct bio_blob_hdr	*blob_hdr = cb_data;
 	struct bio_xs_context	*xs_ctxt = vos_xsctxt_get();
@@ -224,7 +224,7 @@ vos_blob_format_cb(void *cb_data, struct umem_instance *umem)
 	int			 rc;
 
 	/* Create a bio_io_context to get the blob */
-	rc = bio_ioctxt_open(&ioctxt, xs_ctxt, umem, blob_hdr->bbh_pool);
+	rc = bio_ioctxt_open(&ioctxt, xs_ctxt, blob_hdr->bbh_pool);
 	if (rc) {
 		D_ERROR("Failed to create an I/O context for writing blob "
 			"header: "DF_RC"\n", DP_RC(rc));
@@ -715,7 +715,6 @@ pool_open(void *ph, struct vos_pool_df *pool_df, unsigned int flags, void *metri
 			goto failed;
 		}
 	}
-	bio_mc_init_umem(pool->vp_meta_context, &pool->vp_umm);
 
 	/* initialize a umem instance for later btree operations */
 	rc = umem_class_init(uma, &pool->vp_umm);

--- a/src/vos/vos_pool_scrub.c
+++ b/src/vos/vos_pool_scrub.c
@@ -447,6 +447,7 @@ sc_verify_obj_value(struct scrub_ctx *ctx, struct bio_iov *biov, daos_handle_t i
 	daos_iod_t		*iod = &ctx->sc_iod;
 	uint64_t		 data_len;
 	struct bio_io_context	*bio_ctx;
+	struct umem_instance	*umem;
 	struct vos_iterator	*iter;
 	struct vos_obj_iter	*oiter;
 	int			 rc;
@@ -472,9 +473,10 @@ sc_verify_obj_value(struct scrub_ctx *ctx, struct bio_iov *biov, daos_handle_t i
 	iter = vos_hdl2iter(ih);
 	oiter = vos_iter2oiter(iter);
 	bio_ctx = bio_mc2data(oiter->it_obj->obj_cont->vc_pool->vp_meta_context);
-	rc = bio_read(bio_ctx, biov->bi_addr, &data);
+	umem = &oiter->it_obj->obj_cont->vc_pool->vp_umm;
+	rc = vos_media_read(bio_ctx, umem, biov->bi_addr, &data);
 
-	/* if bio_read of NVME then it might have yielded */
+	/* if vos_media_read of NVME then it might have yielded */
 	if (bio_iov2media(biov) == DAOS_MEDIA_NVME)
 		ctx->sc_did_yield = true;
 


### PR DESCRIPTION
When md on SSD introduced, umem_instance will require bio_io_context for underlying meta SSD I/O, to get rid of this awkward circular referencing between umem_instance and bio_io_context, this patch moved the umem_instance (bic_umem) from bio_io_context into bio_desc.

This will make the umem_instance setup procedure more straightforward, prepare BIO meta/IO contexts first, then setup umem_instance.

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
