### PR TITLE
DAOS-623 bio: Workaround compilation failure

### DIFF
--- a/src/bio/bio_wal.c
+++ b/src/bio/bio_wal.c
@@ -1437,7 +1437,7 @@ load_wal:
 
 		if (tight_loop >= 20) {
 			tight_loop = 0;
-			bio_yield();
+			bio_yield(NULL);
 		}
 	}
 out:

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -720,7 +720,7 @@ static inline void
 bio_yield(struct umem_instance *umm)
 {
 #ifdef DAOS_PMEM_BUILD
-	D_ASSERT(umem_tx_none(umm));
+	D_ASSERT(umm == NULL || umem_tx_none(umm));
 #endif
 	ABT_thread_yield();
 }


### PR DESCRIPTION
I'm not sure we should be passing umm to bio_yield. Perhaps it's better handled with a macro for use in places we may be in a transaction.
Anyway, rather than pass a umm to the vio_replay routine, just pass and handle NULL parameter to bio_yield.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
