### PR TITLE
DAOS-11390 control: Refactor mount logic

### DIFF
--- a/src/control/cmd/daos_server/storage_legacy_test.go
+++ b/src/control/cmd/daos_server/storage_legacy_test.go
@@ -163,7 +163,7 @@ func TestDaosServer_StoragePrepare_Legacy(t *testing.T) {
 			mbb := bdev.NewMockBackend(tc.bmbc)
 			mbp := bdev.NewProvider(log, mbb)
 			msb := scm.NewMockBackend(tc.smbc)
-			msp := scm.NewProvider(log, msb, nil)
+			msp := scm.NewProvider(log, msb, nil, nil)
 			scs := server.NewMockStorageControlService(log, nil, nil, msp, mbp)
 
 			if tc.legacyCmd == nil {

--- a/src/control/cmd/daos_server/storage_scm_test.go
+++ b/src/control/cmd/daos_server/storage_scm_test.go
@@ -235,7 +235,7 @@ func TestDaosServer_preparePMem(t *testing.T) {
 				PrepErr: tc.prepErr,
 			}
 			msb := scm.NewMockBackend(smbc)
-			msp := scm.NewProvider(log, msb, nil)
+			msp := scm.NewProvider(log, msb, nil, nil)
 			scs := server.NewMockStorageControlService(log, nil, nil, msp, mbp)
 
 			cmd := prepareSCMCmd{
@@ -420,7 +420,7 @@ func TestDaosServer_resetPMem(t *testing.T) {
 				PrepResetErr: tc.prepErr,
 			}
 			msb := scm.NewMockBackend(smbc)
-			msp := scm.NewProvider(log, msb, nil)
+			msp := scm.NewProvider(log, msb, nil, nil)
 			scs := server.NewMockStorageControlService(log, nil, nil, msp, mbp)
 
 			cmd := resetSCMCmd{

--- a/src/control/cmd/daos_server_helper/handler.go
+++ b/src/control/cmd/daos_server_helper/handler.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -49,7 +49,7 @@ func (h *scmMountUnmountHandler) Handle(log logging.Logger, req *pbin.Request) *
 
 	h.setupProvider(log)
 
-	var mRes *storage.ScmMountResponse
+	var mRes *storage.MountResponse
 	var err error
 	switch req.Method {
 	case "ScmMount":

--- a/src/control/cmd/daos_server_helper/handler_test.go
+++ b/src/control/cmd/daos_server_helper/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
@@ -57,8 +58,8 @@ func TestDaosAdmin_ScmMountUnmountHandler(t *testing.T) {
 	for name, tc := range map[string]struct {
 		req        *pbin.Request
 		smbc       *scm.MockBackendConfig
-		smsc       *scm.MockSysConfig
-		expPayload *storage.ScmMountResponse
+		smsc       *system.MockSysConfig
+		expPayload *storage.MountResponse
 		expErr     *fault.Fault
 	}{
 		"nil request": {
@@ -75,14 +76,14 @@ func TestDaosAdmin_ScmMountUnmountHandler(t *testing.T) {
 				Method:  "ScmMount",
 				Payload: mountReqPayload,
 			},
-			expPayload: &storage.ScmMountResponse{Target: testTarget, Mounted: true},
+			expPayload: &storage.MountResponse{Target: testTarget, Mounted: true},
 		},
 		"ScmMount failure": {
 			req: &pbin.Request{
 				Method:  "ScmMount",
 				Payload: mountReqPayload,
 			},
-			smsc: &scm.MockSysConfig{
+			smsc: &system.MockSysConfig{
 				MountErr: errors.New("test mount failed"),
 			},
 			expErr: pbin.PrivilegedHelperRequestFailed(fmt.Sprintf("mount tmpfs->%s failed: test mount failed", testTarget)),
@@ -98,14 +99,14 @@ func TestDaosAdmin_ScmMountUnmountHandler(t *testing.T) {
 				Method:  "ScmUnmount",
 				Payload: mountReqPayload,
 			},
-			expPayload: &storage.ScmMountResponse{Target: testTarget, Mounted: false},
+			expPayload: &storage.MountResponse{Target: testTarget, Mounted: false},
 		},
 		"ScmUnmount failure": {
 			req: &pbin.Request{
 				Method:  "ScmUnmount",
 				Payload: mountReqPayload,
 			},
-			smsc: &scm.MockSysConfig{
+			smsc: &system.MockSysConfig{
 				UnmountErr: errors.New("test unmount failed"),
 			},
 			expErr: pbin.PrivilegedHelperRequestFailed(fmt.Sprintf("failed to unmount %s: test unmount failed", testTarget)),
@@ -124,9 +125,9 @@ func TestDaosAdmin_ScmMountUnmountHandler(t *testing.T) {
 				t.Errorf("got wrong fault (-want, +got)\n%s\n", diff)
 			}
 			if tc.expPayload == nil {
-				tc.expPayload = &storage.ScmMountResponse{}
+				tc.expPayload = &storage.MountResponse{}
 			}
-			expectPayload(t, resp, &storage.ScmMountResponse{}, tc.expPayload)
+			expectPayload(t, resp, &storage.MountResponse{}, tc.expPayload)
 		})
 	}
 }
@@ -151,7 +152,7 @@ func TestDaosAdmin_ScmFormatCheckHandler(t *testing.T) {
 		Mountpoint: testTarget,
 		OwnerUID:   os.Getuid(),
 		OwnerGID:   os.Getgid(),
-		Dcpm: &storage.DcpmParams{
+		Dcpm: &storage.DeviceParams{
 			Device: "/foo/bar",
 		},
 	})
@@ -164,7 +165,7 @@ func TestDaosAdmin_ScmFormatCheckHandler(t *testing.T) {
 	for name, tc := range map[string]struct {
 		req        *pbin.Request
 		smbc       *scm.MockBackendConfig
-		smsc       *scm.MockSysConfig
+		smsc       *system.MockSysConfig
 		expPayload *storage.ScmFormatResponse
 		expErr     *fault.Fault
 	}{
@@ -193,7 +194,7 @@ func TestDaosAdmin_ScmFormatCheckHandler(t *testing.T) {
 				Method:  "ScmFormat",
 				Payload: scmFormatReqPayload,
 			},
-			smsc: &scm.MockSysConfig{
+			smsc: &system.MockSysConfig{
 				MountErr: errors.New("test mount failed"),
 			},
 			expErr: pbin.PrivilegedHelperRequestFailed(fmt.Sprintf("mount tmpfs->%s failed: test mount failed", testTarget)),
@@ -253,7 +254,7 @@ func TestDaosAdmin_ScmPrepHandler(t *testing.T) {
 	for name, tc := range map[string]struct {
 		req        *pbin.Request
 		smbc       *scm.MockBackendConfig
-		smsc       *scm.MockSysConfig
+		smsc       *system.MockSysConfig
 		expPayload *storage.ScmPrepareResponse
 		expErr     *fault.Fault
 	}{
@@ -352,7 +353,7 @@ func TestDaosAdmin_ScmScanHandler(t *testing.T) {
 	for name, tc := range map[string]struct {
 		req        *pbin.Request
 		smbc       *scm.MockBackendConfig
-		smsc       *scm.MockSysConfig
+		smsc       *system.MockSysConfig
 		expPayload *storage.ScmScanResponse
 		expErr     *fault.Fault
 	}{

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -59,6 +59,7 @@ const (
 	StorageFilesystemAlreadyMounted
 	StorageDeviceAlreadyMounted
 	StorageTargetAlreadyMounted
+	StoragePathAccessDenied
 )
 
 // SCM fault codes

--- a/src/control/provider/system/mocks.go
+++ b/src/control/provider/system/mocks.go
@@ -1,0 +1,166 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package system
+
+import (
+	"os"
+	"sync"
+
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+type (
+	// GetfsUsageRetval encapsulates return values from a GetfsUsage call.
+	GetfsUsageRetval struct {
+		Total, Avail uint64
+		Err          error
+	}
+
+	MountMap struct {
+		sync.RWMutex
+		mounted map[string]bool
+	}
+
+	// MockSysConfig alters mock SystemProvider behavior.
+	MockSysConfig struct {
+		IsMountedBool   bool
+		IsMountedErr    error
+		MountErr        error
+		UnmountErr      error
+		MkfsErr         error
+		ChmodErr        error
+		ChownErr        error
+		GetfsStr        string
+		GetfsErr        error
+		SourceToTarget  map[string]string
+		GetfsIndex      int
+		GetfsUsageResps []GetfsUsageRetval
+		StatErrors      map[string]error
+		RealStat        bool
+	}
+
+	// MockSysProvider gives a mock SystemProvider implementation.
+	MockSysProvider struct {
+		sync.RWMutex
+		log       logging.Logger
+		cfg       MockSysConfig
+		isMounted MountMap
+	}
+)
+
+func (mm *MountMap) Set(mount string, mounted bool) {
+	mm.Lock()
+	defer mm.Unlock()
+
+	mm.mounted[mount] = mounted
+}
+
+func (mm *MountMap) Get(mount string) (bool, bool) {
+	mm.RLock()
+	defer mm.RUnlock()
+
+	mounted, exists := mm.mounted[mount]
+	return mounted, exists
+}
+
+func (msp *MockSysProvider) IsMounted(target string) (bool, error) {
+	err := msp.cfg.IsMountedErr
+
+	msp.Lock()
+	defer msp.Unlock()
+
+	// lookup target of a given source device (target actually a source
+	// device in this case)
+	mount, exists := msp.cfg.SourceToTarget[target]
+	if exists {
+		target = mount
+	}
+
+	isMounted, exists := msp.isMounted.Get(target)
+	if !exists {
+		return msp.cfg.IsMountedBool, err
+	}
+	return isMounted, err
+}
+
+func (msp *MockSysProvider) Mount(_, target, _ string, _ uintptr, _ string) error {
+	if msp.cfg.MountErr == nil {
+		msp.Lock()
+		msp.isMounted.Set(target, true)
+		msp.Unlock()
+	}
+	return msp.cfg.MountErr
+}
+
+func (msp *MockSysProvider) Unmount(target string, _ int) error {
+	if msp.cfg.UnmountErr == nil {
+		msp.Lock()
+		msp.isMounted.Set(target, false)
+		msp.Unlock()
+	}
+	return msp.cfg.UnmountErr
+}
+
+func (msp *MockSysProvider) Mkfs(_, _ string, _ bool) error {
+	return msp.cfg.MkfsErr
+}
+
+func (msp *MockSysProvider) Chmod(string, os.FileMode) error {
+	return msp.cfg.ChmodErr
+}
+
+func (msp *MockSysProvider) Chown(string, int, int) error {
+	return msp.cfg.ChownErr
+}
+
+func (msp *MockSysProvider) Getfs(_ string) (string, error) {
+	return msp.cfg.GetfsStr, msp.cfg.GetfsErr
+}
+
+func (msp *MockSysProvider) GetfsUsage(_ string) (uint64, uint64, error) {
+	msp.cfg.GetfsIndex += 1
+	if len(msp.cfg.GetfsUsageResps) < msp.cfg.GetfsIndex {
+		return 0, 0, nil
+	}
+	resp := msp.cfg.GetfsUsageResps[msp.cfg.GetfsIndex-1]
+	return resp.Total, resp.Avail, resp.Err
+}
+
+func (msp *MockSysProvider) Stat(path string) (os.FileInfo, error) {
+	msp.RLock()
+	defer msp.RUnlock()
+
+	if msp.cfg.RealStat {
+		return os.Stat(path)
+	}
+
+	// default return value for missing key is nil so
+	// add entries to indicate path failure e.g. perms or not-exist
+	return nil, msp.cfg.StatErrors[path]
+}
+
+func NewMockSysProvider(log logging.Logger, cfg *MockSysConfig) *MockSysProvider {
+	if cfg == nil {
+		cfg = &MockSysConfig{}
+	}
+	if cfg.StatErrors == nil {
+		cfg.RealStat = true
+	}
+	msp := &MockSysProvider{
+		log: log,
+		cfg: *cfg,
+		isMounted: MountMap{
+			mounted: make(map[string]bool),
+		},
+	}
+	log.Debugf("creating MockSysProvider with cfg: %+v", msp.cfg)
+	return msp
+}
+
+func DefaultMockSysProvider(log logging.Logger) *MockSysProvider {
+	return NewMockSysProvider(log, nil)
+}

--- a/src/control/provider/system/system.go
+++ b/src/control/provider/system/system.go
@@ -1,10 +1,15 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
 package system
+
+import (
+	"fmt"
+	"os/exec"
+)
 
 type (
 	// IsMountedProvider is the interface that wraps the IsMounted method,
@@ -22,4 +27,19 @@ type (
 	UnmountProvider interface {
 		Unmount(target string, flags int) error
 	}
+
+	// RunCmdError documents the output of a command that has been run.
+	RunCmdError struct {
+		Wrapped error  // Error from the command run
+		Stdout  string // Standard output from the command
+	}
 )
+
+func (rce *RunCmdError) Error() string {
+	if ee, ok := rce.Wrapped.(*exec.ExitError); ok {
+		return fmt.Sprintf("%s: stdout: %s; stderr: %s", ee.ProcessState,
+			rce.Stdout, ee.Stderr)
+	}
+
+	return fmt.Sprintf("%s: stdout: %s", rce.Wrapped.Error(), rce.Stdout)
+}

--- a/src/control/provider/system/system_linux.go
+++ b/src/control/provider/system/system_linux.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -11,12 +11,22 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
+)
+
+const (
+	FsTypeNone    = "none"
+	FsTypeExt4    = "ext4"
+	FsTypeTmpfs   = "tmpfs"
+	FsTypeUnknown = "unknown"
+
+	parseFsUnformatted = "data"
 )
 
 // DefaultProvider returns the package-default provider implementation.
@@ -164,4 +174,158 @@ func (s LinuxProvider) GetfsUsage(target string) (uint64, uint64, error) {
 	frSize := uint64(stBuf.Frsize)
 
 	return frSize * stBuf.Blocks, frSize * stBuf.Bavail, nil
+}
+
+func (s LinuxProvider) checkDevice(device string) error {
+	st, err := s.Stat(device)
+	if err != nil {
+		return errors.Wrapf(err, "stat failed on %s", device)
+	}
+
+	if st.Mode()&os.ModeDevice == 0 {
+		return errors.Errorf("%s is not a device file", device)
+	}
+
+	return nil
+}
+
+func getDistroArgs() []string {
+	distro := GetDistribution()
+
+	// use stride option for SCM interleaved mode
+	// disable lazy initialization (hurts perf)
+	// discard is not needed/supported on SCM
+	opts := "stride=512,lazy_itable_init=0,lazy_journal_init=0,nodiscard"
+
+	// enable flex_bg to allow larger contiguous block allocation
+	// disable uninit_bg to initialize everything upfront
+	// disable resize to avoid GDT block allocations
+	// disable extra isize since we really have no use for this
+	feat := "flex_bg,^uninit_bg,^resize_inode,^extra_isize"
+
+	switch {
+	case distro.ID == "centos" && distro.Version.Major < 8:
+		// use strict minimum listed above here since that's
+		// the oldest distribution we support
+	default:
+		// packed_meta_blocks allows to group all data blocks together
+		opts += ",packed_meta_blocks=1"
+		// enable sparse_super2 since 2x superblock copies are enough
+		// disable csum since we have ECC already for SCM
+		// bigalloc is intentionally not used since some kernels don't support it
+		feat += ",sparse_super2,^metadata_csum"
+	}
+
+	return []string{
+		"-E", opts,
+		"-O", feat,
+		// each ext4 group is of size 32767 x 4KB = 128M
+		// pack 128 groups together to increase ability to use huge
+		// pages for a total virtual group size of 16G
+		"-G", "128",
+	}
+}
+
+// Mkfs attempts to create a filesystem of the supplied type, on the
+// supplied device.
+func (s LinuxProvider) Mkfs(fsType, device string, force bool) error {
+	cmdPath, err := exec.LookPath(fmt.Sprintf("mkfs.%s", fsType))
+	if err != nil {
+		return errors.Wrapf(err, "unable to find mkfs.%s", fsType)
+	}
+
+	if err := s.checkDevice(device); err != nil {
+		return err
+	}
+
+	// TODO: Think about a way to allow for some kind of progress
+	// callback so that the user has some visibility into long-running
+	// format operations (very large devices).
+	args := []string{
+		// use quiet mode
+		"-q",
+		// use direct i/o to avoid polluting page cache
+		"-D",
+		// use DAOS label
+		"-L", "daos",
+		// don't reserve blocks for super-user
+		"-m", "0",
+		// use largest possible block size
+		"-b", "4096",
+		// don't need large inode, 128B is enough
+		// since we don't use xattr
+		"-I", "128",
+		// reduce the inode per bytes ratio
+		// one inode for 64M is more than enough
+		"-i", "67108864",
+	}
+	args = append(args, getDistroArgs()...)
+	// string always comes last
+	args = append(args, []string{device}...)
+	if force {
+		args = append([]string{"-F"}, args...)
+	}
+	out, err := exec.Command(cmdPath, args...).Output()
+	if err != nil {
+		return &RunCmdError{
+			Wrapped: err,
+			Stdout:  string(out),
+		}
+	}
+
+	return nil
+}
+
+// Getfs probes the specified device in an attempt to determine the
+// formatted filesystem type, if any.
+func (s LinuxProvider) Getfs(device string) (string, error) {
+	cmdPath, err := exec.LookPath("file")
+	if err != nil {
+		return FsTypeNone, errors.Wrap(err, "unable to find file")
+	}
+
+	if err := s.checkDevice(device); err != nil {
+		return FsTypeNone, err
+	}
+
+	args := []string{"-s", device}
+	out, err := exec.Command(cmdPath, args...).Output()
+	if err != nil {
+		return FsTypeNone, &RunCmdError{
+			Wrapped: err,
+			Stdout:  string(out),
+		}
+	}
+
+	return parseFsType(string(out)), nil
+}
+
+// Stat probes the specified path and returns os level file info.
+func (s LinuxProvider) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+// Chmod changes the mode of the specified path.
+func (s LinuxProvider) Chmod(path string, mode os.FileMode) error {
+	return os.Chmod(path, mode)
+}
+
+// Chown changes the ownership of the specified path.
+func (s LinuxProvider) Chown(path string, uid, gid int) error {
+	return os.Chown(path, uid, gid)
+}
+
+func parseFsType(input string) string {
+	// /dev/pmem0: Linux rev 1.0 ext4 filesystem data, UUID=09619a0d-0c9e-46b4-add5-faf575dd293d
+	// /dev/pmem1: data
+	// /dev/pmem1: COM executable for DOS
+	fields := strings.Fields(input)
+	switch {
+	case len(fields) == 2 && fields[1] == parseFsUnformatted:
+		return FsTypeNone
+	case len(fields) >= 5:
+		return fields[4]
+	default:
+		return FsTypeUnknown
+	}
 }

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -511,7 +512,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 		csCtrlrs    *storage.NvmeControllers   // control service storage provider
 		eCtrlrs     []*storage.NvmeControllers // engine storage provider
 		smbc        *scm.MockBackendConfig
-		smsc        *scm.MockSysConfig
+		smsc        *system.MockSysConfig
 		storageCfgs []storage.TierConfigs
 		scanTwice   bool
 		junkResp    bool
@@ -782,8 +783,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				GetModulesRes:    storage.ScmModules{storage.MockScmModule(0)},
 				GetNamespacesRes: storage.ScmNamespaces{storage.MockScmNamespace(0)},
 			},
-			smsc: &scm.MockSysConfig{
-				GetfsUsageResps: []scm.GetfsUsageRetval{
+			smsc: &system.MockSysConfig{
+				GetfsUsageResps: []system.GetfsUsageRetval{
 					{
 						Total: mockPbScmMount0.TotalBytes,
 						Avail: mockPbScmMount0.AvailBytes,
@@ -835,8 +836,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				GetModulesRes:    storage.ScmModules{storage.MockScmModule(0)},
 				GetNamespacesRes: storage.ScmNamespaces{storage.MockScmNamespace(0)},
 			},
-			smsc: &scm.MockSysConfig{
-				GetfsUsageResps: []scm.GetfsUsageRetval{
+			smsc: &system.MockSysConfig{
+				GetfsUsageResps: []system.GetfsUsageRetval{
 					{
 						Total: mockPbScmMount0.TotalBytes,
 						Avail: mockPbScmMount0.AvailBytes,
@@ -875,8 +876,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				GetModulesRes:    storage.ScmModules{storage.MockScmModule(0)},
 				GetNamespacesRes: storage.ScmNamespaces{storage.MockScmNamespace(0)},
 			},
-			smsc: &scm.MockSysConfig{
-				GetfsUsageResps: []scm.GetfsUsageRetval{
+			smsc: &system.MockSysConfig{
+				GetfsUsageResps: []system.GetfsUsageRetval{
 					{
 						Total: mockPbScmMount0.TotalBytes,
 						Avail: mockPbScmMount0.AvailBytes,
@@ -932,8 +933,8 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 					storage.MockScmNamespace(1),
 				},
 			},
-			smsc: &scm.MockSysConfig{
-				GetfsUsageResps: []scm.GetfsUsageRetval{
+			smsc: &system.MockSysConfig{
+				GetfsUsageResps: []system.GetfsUsageRetval{
 					{
 						Total: mockPbScmMount0.TotalBytes,
 						Avail: mockPbScmMount0.AvailBytes,
@@ -1697,7 +1698,7 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 			if tc.scmMounted {
 				getFsRetStr = "ext4"
 			}
-			msc := &scm.MockSysConfig{
+			msc := &system.MockSysConfig{
 				IsMountedBool:  tc.scmMounted,
 				MountErr:       tc.mountRet,
 				UnmountErr:     tc.unmountRet,

--- a/src/control/server/ctl_storage_test.go
+++ b/src/control/server/ctl_storage_test.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
-	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
 func TestServer_CtlSvc_getScmUsage(t *testing.T) {
@@ -31,7 +31,7 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 	mockScmNs1wMount.Mount = storage.MockScmMountPoint(1)
 
 	for name, tc := range map[string]struct {
-		smsc        *scm.MockSysConfig
+		smsc        *system.MockSysConfig
 		inResp      *storage.ScmScanResponse
 		storageCfgs []storage.TierConfigs
 		nilRank     bool
@@ -87,8 +87,8 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			expErr: errors.New("no pmem namespace"),
 		},
 		"get usage fails": {
-			smsc: &scm.MockSysConfig{
-				GetfsUsageResps: []scm.GetfsUsageRetval{
+			smsc: &system.MockSysConfig{
+				GetfsUsageResps: []system.GetfsUsageRetval{
 					{Err: errors.New("unknown")},
 				},
 			},
@@ -108,8 +108,8 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			expErr: errors.New("unknown"),
 		},
 		"get rank fails": {
-			smsc: &scm.MockSysConfig{
-				GetfsUsageResps: []scm.GetfsUsageRetval{
+			smsc: &system.MockSysConfig{
+				GetfsUsageResps: []system.GetfsUsageRetval{
 					{
 						Total: mockScmNs0wMount.Mount.TotalBytes,
 						Avail: mockScmNs0wMount.Mount.AvailBytes,
@@ -133,8 +133,8 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			expErr:  errors.New("nil rank in superblock"),
 		},
 		"get usage": {
-			smsc: &scm.MockSysConfig{
-				GetfsUsageResps: []scm.GetfsUsageRetval{
+			smsc: &system.MockSysConfig{
+				GetfsUsageResps: []system.GetfsUsageRetval{
 					{
 						Total: mockScmNs0wMount.Mount.TotalBytes,
 						Avail: mockScmNs0wMount.Mount.AvailBytes,
@@ -161,8 +161,8 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			},
 		},
 		"get usage; multiple engines": {
-			smsc: &scm.MockSysConfig{
-				GetfsUsageResps: []scm.GetfsUsageRetval{
+			smsc: &system.MockSysConfig{
+				GetfsUsageResps: []system.GetfsUsageRetval{
 					{
 						Total: mockScmNs0wMount.Mount.TotalBytes,
 						Avail: mockScmNs0wMount.Mount.AvailBytes,

--- a/src/control/server/ctl_svc_test.go
+++ b/src/control/server/ctl_svc_test.go
@@ -13,16 +13,18 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/bdev"
+	"github.com/daos-stack/daos/src/control/server/storage/mount"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
 // mockControlService takes cfgs for tuneable scm and sys provider behavior but
 // default nvmeStorage behavior (cs.nvoe can be subsequently replaced in test).
-func mockControlService(t *testing.T, log logging.Logger, cfg *config.Server, bmbc *bdev.MockBackendConfig, smbc *scm.MockBackendConfig, smsc *scm.MockSysConfig) *ControlService {
+func mockControlService(t *testing.T, log logging.Logger, cfg *config.Server, bmbc *bdev.MockBackendConfig, smbc *scm.MockBackendConfig, smsc *system.MockSysConfig) *ControlService {
 	t.Helper()
 
 	if cfg == nil {
@@ -32,7 +34,8 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *config.Server, bm
 	}
 
 	// share sys provider between engines to be able to access to same mock config data
-	sp := scm.NewMockSysProvider(log, smsc)
+	sp := system.NewMockSysProvider(log, smsc)
+	mounter := mount.NewProvider(log, sp)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -40,7 +43,7 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *config.Server, bm
 	cs := &ControlService{
 		StorageControlService: *NewMockStorageControlService(log, cfg.Engines,
 			sp,
-			scm.NewProvider(log, scm.NewMockBackend(smbc), sp),
+			scm.NewProvider(log, scm.NewMockBackend(smbc), sp, mounter),
 			bdev.NewMockProvider(log, bmbc)),
 		harness: &EngineHarness{
 			log: log,
@@ -55,7 +58,7 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *config.Server, bm
 		runner := engine.NewTestRunner(trc, ec)
 
 		sp := storage.MockProvider(log, 0, &ec.Storage, sp,
-			scm.NewProvider(log, scm.NewMockBackend(smbc), sp),
+			scm.NewProvider(log, scm.NewMockBackend(smbc), sp, mounter),
 			bdev.NewMockProvider(log, bmbc))
 		ei := NewEngineInstance(log, sp, nil, runner)
 		ei.setSuperblock(&Superblock{
@@ -70,7 +73,7 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *config.Server, bm
 	return cs
 }
 
-func mockControlServiceNoSB(t *testing.T, log logging.Logger, cfg *config.Server, bmbc *bdev.MockBackendConfig, smbc *scm.MockBackendConfig, smsc *scm.MockSysConfig) *ControlService {
+func mockControlServiceNoSB(t *testing.T, log logging.Logger, cfg *config.Server, bmbc *bdev.MockBackendConfig, smbc *scm.MockBackendConfig, smsc *system.MockSysConfig) *ControlService {
 	cs := mockControlService(t, log, cfg, bmbc, smbc, smsc)
 
 	// don't set a superblock and init with a stopped test runner

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
+	sysprov "github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
@@ -234,12 +235,12 @@ func TestServer_Harness_Start(t *testing.T) {
 				}
 				runner := engine.NewTestRunner(tc.trc, engineCfg)
 
-				msc := scm.MockSysConfig{IsMountedBool: true}
-				sysp := scm.NewMockSysProvider(log, &msc)
+				msc := &sysprov.MockSysConfig{IsMountedBool: true}
+				sysp := sysprov.NewMockSysProvider(log, msc)
 				provider := storage.MockProvider(
 					log, 0, &engineCfg.Storage,
 					sysp,
-					scm.NewMockProvider(log, nil, &msc),
+					scm.NewMockProvider(log, nil, msc),
 					bdev.NewMockProvider(log, &bdev.MockBackendConfig{}),
 				)
 

--- a/src/control/server/instance_storage_test.go
+++ b/src/control/server/instance_storage_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
@@ -58,7 +59,7 @@ func TestIOEngineInstance_MountScmDevice(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		cfg    *storage.Config
-		msCfg  *scm.MockSysConfig
+		msCfg  *system.MockSysConfig
 		expErr error
 	}{
 		"empty config": {
@@ -66,14 +67,14 @@ func TestIOEngineInstance_MountScmDevice(t *testing.T) {
 		},
 		"IsMounted fails": {
 			cfg: ramCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				IsMountedErr: errors.New("failed to check mount"),
 			},
 			expErr: errors.New("failed to check mount"),
 		},
 		"already mounted": {
 			cfg: ramCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				IsMountedBool: true,
 			},
 		},
@@ -82,7 +83,7 @@ func TestIOEngineInstance_MountScmDevice(t *testing.T) {
 		},
 		"mount ramdisk fails": {
 			cfg: ramCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				MountErr: errors.New("mount failed"),
 			},
 			expErr: errors.New("mount failed"),
@@ -92,7 +93,7 @@ func TestIOEngineInstance_MountScmDevice(t *testing.T) {
 		},
 		"mount dcpm fails": {
 			cfg: dcpmCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				MountErr: errors.New("mount failed"),
 			},
 			expErr: errors.New("mount failed"),
@@ -121,7 +122,7 @@ func TestIOEngineInstance_MountScmDevice(t *testing.T) {
 
 			ec := engine.MockConfig().WithStorage(tc.cfg.Tiers...)
 			runner := engine.NewRunner(log, ec)
-			sys := scm.NewMockSysProvider(log, tc.msCfg)
+			sys := system.NewMockSysProvider(log, tc.msCfg)
 			scm := scm.NewMockProvider(log, nil, tc.msCfg)
 			provider := storage.MockProvider(log, 0, tc.cfg, sys, scm, nil)
 			instance := NewEngineInstance(log, provider, nil, runner)
@@ -154,7 +155,7 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 	for name, tc := range map[string]struct {
 		engineCfg      *engine.Config
 		mbCfg          *scm.MockBackendConfig
-		msCfg          *scm.MockSysConfig
+		msCfg          *system.MockSysConfig
 		expNeedsFormat bool
 		expErr         error
 	}{
@@ -163,14 +164,14 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 		},
 		"check ramdisk fails (IsMounted fails)": {
 			engineCfg: ramCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				IsMountedErr: errors.New("failed to check mount"),
 			},
 			expErr: errors.New("failed to check mount"),
 		},
 		"check ramdisk (mounted)": {
 			engineCfg: ramCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				IsMountedBool: true,
 			},
 			expNeedsFormat: false,
@@ -181,35 +182,35 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 		},
 		"check ramdisk (unmounted, mountpoint doesn't exist)": {
 			engineCfg: ramCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				IsMountedErr: os.ErrNotExist,
 			},
 			expNeedsFormat: true,
 		},
 		"check dcpm (mounted)": {
 			engineCfg: dcpmCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				IsMountedBool: true,
 			},
 			expNeedsFormat: false,
 		},
 		"check dcpm (unmounted, unformatted)": {
 			engineCfg: dcpmCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				GetfsStr: "none",
 			},
 			expNeedsFormat: true,
 		},
 		"check dcpm (unmounted, formatted)": {
 			engineCfg: dcpmCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				GetfsStr: "ext4",
 			},
 			expNeedsFormat: false,
 		},
 		"check dcpm (unmounted, formatted, mountpoint doesn't exist)": {
 			engineCfg: dcpmCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				IsMountedErr: os.ErrNotExist,
 				GetfsStr:     "ext4",
 			},
@@ -217,7 +218,7 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 		},
 		"check dcpm fails (IsMounted fails)": {
 			engineCfg: dcpmCfg,
-			msCfg: &scm.MockSysConfig{
+			msCfg: &system.MockSysConfig{
 				IsMountedErr: errors.New("failed to check mount"),
 			},
 			expErr: errors.New("failed to check mount"),
@@ -240,7 +241,7 @@ func TestEngineInstance_NeedsScmFormat(t *testing.T) {
 
 			runner := engine.NewRunner(log, tc.engineCfg)
 			mp := storage.NewProvider(log, 0, &tc.engineCfg.Storage,
-				scm.NewMockSysProvider(log, tc.msCfg),
+				system.NewMockSysProvider(log, tc.msCfg),
 				scm.NewMockProvider(log, tc.mbCfg, tc.msCfg),
 				nil)
 			instance := NewEngineInstance(log, mp, nil, runner)
@@ -337,10 +338,10 @@ func TestIOEngineInstance_awaitStorageReady(t *testing.T) {
 				fs = "ext4"
 			}
 
-			msc := scm.MockSysConfig{GetfsStr: fs}
+			msc := system.MockSysConfig{GetfsStr: fs}
 			mbc := scm.MockBackendConfig{}
 			mp := storage.NewProvider(log, 0, &dcpmCfg.Storage,
-				scm.NewMockSysProvider(log, &msc),
+				system.NewMockSysProvider(log, &msc),
 				scm.NewMockProvider(log, &mbc, &msc),
 				nil)
 			engine := NewEngineInstance(log, mp, nil, runner)

--- a/src/control/server/instance_superblock_test.go
+++ b/src/control/server/instance_superblock_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/logging"
+	sysprov "github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
@@ -42,11 +43,11 @@ func TestServer_Instance_createSuperblock(t *testing.T) {
 					WithScmMountPoint(mnt),
 			)
 		r := engine.NewRunner(log, cfg)
-		msc := &scm.MockSysConfig{
+		msc := &sysprov.MockSysConfig{
 			IsMountedBool: true,
 		}
 		mbc := &scm.MockBackendConfig{}
-		mp := storage.NewProvider(log, 0, &cfg.Storage, scm.NewMockSysProvider(log, msc), scm.NewMockProvider(log, mbc, msc), nil)
+		mp := storage.NewProvider(log, 0, &cfg.Storage, sysprov.NewMockSysProvider(log, msc), scm.NewMockProvider(log, mbc, msc), nil)
 		ei := NewEngineInstance(log, mp, nil, r).
 			WithHostFaultDomain(system.MustCreateFaultDomainFromString("/host1"))
 		ei.fsRoot = testDir

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/logging"
+	sysprov "github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -581,12 +582,12 @@ func TestServer_prepBdevStorage(t *testing.T) {
 
 			mbb := bdev.NewMockBackend(tc.bmbc)
 			mbp := bdev.NewProvider(log, mbb)
-			sp := scm.NewMockSysProvider(log, nil)
+			sp := sysprov.NewMockSysProvider(log, nil)
 
 			srv.ctlSvc = &ControlService{
 				StorageControlService: *NewMockStorageControlService(log, cfg.Engines,
 					sp,
-					scm.NewProvider(log, scm.NewMockBackend(nil), sp),
+					scm.NewProvider(log, scm.NewMockBackend(nil), sp, nil),
 					mbp),
 				srvCfg: cfg,
 			}
@@ -697,12 +698,12 @@ func TestServer_scanBdevStorage(t *testing.T) {
 
 			mbb := bdev.NewMockBackend(tc.bmbc)
 			mbp := bdev.NewProvider(log, mbb)
-			sp := scm.NewMockSysProvider(log, nil)
+			sp := sysprov.NewMockSysProvider(log, nil)
 
 			srv.ctlSvc = &ControlService{
 				StorageControlService: *NewMockStorageControlService(log, cfg.Engines,
 					sp,
-					scm.NewProvider(log, scm.NewMockBackend(nil), sp),
+					scm.NewProvider(log, scm.NewMockBackend(nil), sp, nil),
 					mbp),
 				srvCfg: cfg,
 			}

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -20,6 +20,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/lib/spdk"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -178,9 +179,9 @@ func logNUMAStats(log logging.Logger) {
 
 	out, err := exec.Command("numastat", "-m").Output()
 	if err != nil {
-		toLog = (&runCmdError{
-			wrapped: err,
-			stdout:  string(out),
+		toLog = (&system.RunCmdError{
+			Wrapped: err,
+			Stdout:  string(out),
 		}).Error()
 	} else {
 		toLog = string(out)

--- a/src/control/server/storage/bdev/runner.go
+++ b/src/control/server/storage/bdev/runner.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -32,20 +33,6 @@ const (
 )
 
 type runCmdFn func(logging.Logger, []string, string, ...string) (string, error)
-
-type runCmdError struct {
-	wrapped error
-	stdout  string
-}
-
-func (rce *runCmdError) Error() string {
-	if ee, ok := rce.wrapped.(*exec.ExitError); ok {
-		return fmt.Sprintf("%s: stdout: %s; stderr: %s", ee.ProcessState,
-			rce.stdout, ee.Stderr)
-	}
-
-	return fmt.Sprintf("%s: stdout: %s", rce.wrapped.Error(), rce.stdout)
-}
 
 func run(log logging.Logger, env []string, cmdStr string, args ...string) (string, error) {
 	if os.Geteuid() != 0 {
@@ -69,9 +56,9 @@ func run(log logging.Logger, env []string, cmdStr string, args ...string) (strin
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Errorf("run script %q failed, env: %v", cmdPath, env)
-		return "", &runCmdError{
-			wrapped: err,
-			stdout:  string(out),
+		return "", &system.RunCmdError{
+			Wrapped: err,
+			Stdout:  string(out),
 		}
 	}
 	log.Debugf("run script %q, env: %v, out:\n%s\n", cmdPath, env, out)

--- a/src/control/server/storage/device.go
+++ b/src/control/server/storage/device.go
@@ -1,0 +1,14 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package storage
+
+type (
+	// DeviceParams defines the sub-parameters of a Format operation that will use a storage device.
+	DeviceParams struct {
+		Device string
+	}
+)

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -110,6 +110,23 @@ var FaultBdevNoIOMMU = storageFault(
 	"IOMMU capability is required to access NVMe devices but no IOMMU capability detected",
 	"enable IOMMU per the DAOS Admin Guide")
 
+// FaultTargetAlreadyMounted represents an error where the target was already mounted.
+var FaultTargetAlreadyMounted = storageFault(
+	code.StorageTargetAlreadyMounted,
+	"request included already-mounted mount target (cannot double-mount)",
+	"unmount the target and retry the operation",
+)
+
+// FaultPathAccessDenied represents an error where a mount point or device path for
+// a storage target is inaccessible because of a permissions issue.
+func FaultPathAccessDenied(path string) *fault.Fault {
+	return storageFault(
+		code.StoragePathAccessDenied,
+		fmt.Sprintf("path %q has incompatible access permissions", path),
+		"verify the path is accessible by the user running daos_server and try again",
+	)
+}
+
 func storageFault(code code.Code, desc, res string) *fault.Fault {
 	return &fault.Fault{
 		Domain:      "storage",

--- a/src/control/server/storage/mocks.go
+++ b/src/control/server/storage/mocks.go
@@ -257,3 +257,79 @@ func MockGetTopology(context.Context) (*hardware.Topology, error) {
 		},
 	}, nil
 }
+
+type (
+	// MockMountProviderConfig is a configuration for a mock MountProvider.
+	MockMountProviderConfig struct {
+		MountErr           error
+		UnmountErr         error
+		IsMountedRes       bool
+		IsMountedErr       error
+		IsMountedCount     int
+		ClearMountpointErr error
+		MakeMountPathErr   error
+	}
+
+	// MockMountProvider is a mocked version of a MountProvider that can be used for testing.
+	MockMountProvider struct {
+		cfg *MockMountProviderConfig
+	}
+)
+
+// Mount is a mock implementation.
+func (m *MockMountProvider) Mount(req MountRequest) (*MountResponse, error) {
+	if m.cfg == nil || m.cfg.MountErr == nil {
+		return &MountResponse{
+			Target:  req.Target,
+			Mounted: true,
+		}, nil
+	}
+	return nil, m.cfg.MountErr
+}
+
+// Unmount is a mock implementation.
+func (m *MockMountProvider) Unmount(req MountRequest) (*MountResponse, error) {
+	if m.cfg == nil || m.cfg.UnmountErr == nil {
+		return &MountResponse{
+			Target:  req.Target,
+			Mounted: false,
+		}, nil
+	}
+	return nil, m.cfg.UnmountErr
+}
+
+// IsMounted is a mock implementation.
+func (m *MockMountProvider) IsMounted(_ string) (bool, error) {
+	if m.cfg == nil {
+		return true, nil
+	}
+	return m.cfg.IsMountedRes, m.cfg.IsMountedErr
+}
+
+// ClearMountpoint is a mock implementation.
+func (m *MockMountProvider) ClearMountpoint(_ string) error {
+	if m.cfg == nil {
+		return nil
+	}
+	return m.cfg.ClearMountpointErr
+}
+
+// MakeMountPath is a mock implementation.
+func (m *MockMountProvider) MakeMountPath(_ string, _, _ int) error {
+	if m.cfg == nil {
+		return nil
+	}
+	return m.cfg.MakeMountPathErr
+}
+
+// NewMockMountProvider creates a new MockProvider.
+func NewMockMountProvider(cfg *MockMountProviderConfig) *MockMountProvider {
+	return &MockMountProvider{
+		cfg: cfg,
+	}
+}
+
+// DefaultMockMountProvider creates a mock provider in which all requests succeed.
+func DefaultMockMountProvider() *MockMountProvider {
+	return NewMockMountProvider(nil)
+}

--- a/src/control/server/storage/mount.go
+++ b/src/control/server/storage/mount.go
@@ -1,0 +1,33 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package storage
+
+type (
+	// MountProvider defines an interface to be implemented by a mount/unmount provider.
+	MountProvider interface {
+		Mount(MountRequest) (*MountResponse, error)
+		Unmount(MountRequest) (*MountResponse, error)
+		IsMounted(string) (bool, error)
+		ClearMountpoint(string) error
+		MakeMountPath(path string, tgtUID, tgtGID int) error
+	}
+
+	// MountRequest represents a generic storage mount/unmount request.
+	MountRequest struct {
+		Source     string
+		Target     string
+		Filesystem string
+		Flags      uintptr
+		Options    string
+	}
+
+	// MountResponse indicates a successful mount or unmount operation on a generic device.
+	MountResponse struct {
+		Target  string
+		Mounted bool
+	}
+)

--- a/src/control/server/storage/mount/provider.go
+++ b/src/control/server/storage/mount/provider.go
@@ -1,0 +1,185 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package mount
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
+	"github.com/daos-stack/daos/src/control/server/storage"
+)
+
+const (
+	defaultMountPointPerms = 0700
+	defaultUnmountFlags    = 0
+)
+
+type (
+	// SystemProvider defines a set of methods to be implemented by a provider
+	// of system capabilities.
+	SystemProvider interface {
+		system.IsMountedProvider
+		system.MountProvider
+		system.UnmountProvider
+		Chmod(string, os.FileMode) error
+		Stat(string) (os.FileInfo, error)
+	}
+
+	// Provider provides methods to interact with a generic storage device.
+	Provider struct {
+		log logging.Logger
+		sys SystemProvider
+	}
+)
+
+// DefaultProvider returns an initialized *Provider suitable for use with production code.
+func DefaultProvider(log logging.Logger) *Provider {
+	return NewProvider(log, system.DefaultProvider())
+}
+
+// NewProvider returns an initialized *Provider.
+func NewProvider(log logging.Logger, sys SystemProvider) *Provider {
+	p := &Provider{
+		log: log,
+		sys: sys,
+	}
+	return p
+}
+
+// IsMounted checks whether the requested path is mounted.
+func (p *Provider) IsMounted(target string) (bool, error) {
+	if p == nil {
+		return false, errors.New("nil provider")
+	}
+
+	isMounted, err := p.sys.IsMounted(target)
+
+	if errors.Is(err, os.ErrPermission) {
+		return false, errors.Wrap(storage.FaultPathAccessDenied(target), "check if mounted")
+	}
+
+	return isMounted, err
+}
+
+// Mount mounts a given device with a set of arguments.
+func (p *Provider) Mount(req storage.MountRequest) (*storage.MountResponse, error) {
+	if p == nil {
+		return nil, errors.New("nil mount provider")
+	}
+	return p.mount(req.Source, req.Target, req.Filesystem, req.Flags, req.Options)
+}
+
+func (p *Provider) mount(src, target, fsType string, flags uintptr, opts string) (*storage.MountResponse, error) {
+	// make sure that we're not double-mounting over an existing mount
+	tgtMounted, err := p.IsMounted(target)
+	if err != nil {
+		return nil, err
+	}
+	if tgtMounted {
+		return nil, errors.Wrap(storage.FaultTargetAlreadyMounted, target)
+	}
+
+	p.log.Debugf("mount %s->%s (%s) (%s)", src, target, fsType, opts)
+	if err := p.sys.Mount(src, target, fsType, flags, opts); err != nil {
+		return nil, errors.Wrapf(err, "mount %s->%s failed", src, target)
+	}
+
+	// Adjust permissions on the mounted filesystem.
+	if err := p.sys.Chmod(target, defaultMountPointPerms); err != nil {
+		return nil, errors.Wrapf(err, "failed to set permissions on %s", target)
+	}
+
+	return &storage.MountResponse{
+		Target:  target,
+		Mounted: true,
+	}, nil
+}
+
+// Unmount unmounts a device from a mount point.
+func (p *Provider) Unmount(req storage.MountRequest) (*storage.MountResponse, error) {
+	if p == nil {
+		return nil, errors.New("nil mount provider")
+	}
+
+	if err := p.sys.Unmount(req.Target, int(req.Flags)); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmount %s", req.Target)
+	}
+
+	return &storage.MountResponse{
+		Target:  req.Target,
+		Mounted: false,
+	}, nil
+}
+
+// ClearMountpoint unmounts and removes a mountpoint.
+func (p *Provider) ClearMountpoint(mntpt string) error {
+	mounted, err := p.IsMounted(mntpt)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if mounted {
+		_, err := p.Unmount(storage.MountRequest{
+			Target: mntpt,
+			Flags:  defaultUnmountFlags,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := os.RemoveAll(mntpt); err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "failed to remove %s", mntpt)
+	}
+
+	return nil
+}
+
+// MakeMountPath will build the target path by creating any non-existent
+// subdirectories and setting ownership to target uid/gid to ensure that the
+// target user is able to access the created mount point if multiple layers
+// deep. If subdirectories in path already exist, their permissions will not be
+// modified.
+func (p *Provider) MakeMountPath(path string, tgtUID, tgtGID int) error {
+	if !filepath.IsAbs(path) {
+		return errors.Errorf("expecting absolute target path, got %q", path)
+	}
+	if _, err := p.sys.Stat(path); err == nil {
+		return nil // path already exists
+	}
+
+	sep := string(filepath.Separator)
+	dirs := strings.Split(path, sep)[1:] // omit empty element
+
+	for i := range dirs {
+		ps := sep + filepath.Join(dirs[:i+1]...)
+		_, err := p.sys.Stat(ps)
+		switch {
+		case os.IsNotExist(err):
+			// subdir missing, attempt to create and chown
+			if err := os.Mkdir(ps, defaultMountPointPerms); err != nil {
+				return errors.Wrapf(err, "failed to create directory %q", ps)
+			}
+			if err := os.Chown(ps, tgtUID, tgtGID); err != nil {
+				return errors.Wrapf(err, "failed to set ownership of %s to %d.%d",
+					ps, tgtUID, tgtGID)
+			}
+		case err != nil:
+			return errors.Wrapf(err, "unable to stat %q", ps)
+		}
+	}
+
+	return nil
+}

--- a/src/control/server/storage/mount/provider_test.go
+++ b/src/control/server/storage/mount/provider_test.go
@@ -1,0 +1,401 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package mount
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
+	"github.com/daos-stack/daos/src/control/server/storage"
+)
+
+func TestProvider_Mount(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nilProv bool
+		msc     *system.MockSysConfig
+		req     storage.MountRequest
+		expResp *storage.MountResponse
+		expErr  error
+	}{
+		"nil": {
+			nilProv: true,
+			expErr:  errors.New("nil"),
+		},
+		"IsMounted error": {
+			msc: &system.MockSysConfig{
+				IsMountedErr: errors.New("mock IsMounted"),
+			},
+			req: storage.MountRequest{
+				Source: "/dev/something",
+				Target: "/something",
+			},
+			expErr: errors.New("mock IsMounted"),
+		},
+		"already mounted": {
+			msc: &system.MockSysConfig{
+				IsMountedBool: true,
+			},
+			req: storage.MountRequest{
+				Source: "/dev/something",
+				Target: "/something",
+			},
+			expErr: storage.FaultTargetAlreadyMounted,
+		},
+		"mount failed": {
+			msc: &system.MockSysConfig{
+				MountErr: errors.New("mock mount"),
+			},
+			req: storage.MountRequest{
+				Source: "/dev/something",
+				Target: "/something",
+			},
+			expErr: errors.New("mock mount"),
+		},
+		"chmod failed": {
+			msc: &system.MockSysConfig{
+				ChmodErr: errors.New("mock chmod"),
+			},
+			req: storage.MountRequest{
+				Source: "/dev/something",
+				Target: "/something",
+			},
+			expErr: errors.New("mock chmod"),
+		},
+		"success": {
+			msc: &system.MockSysConfig{},
+			req: storage.MountRequest{
+				Source: "/dev/something",
+				Target: "/something",
+			},
+			expResp: &storage.MountResponse{
+				Target:  "/something",
+				Mounted: true,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			var p *Provider
+			if !tc.nilProv {
+				p = NewProvider(log, system.NewMockSysProvider(log, tc.msc))
+			}
+
+			resp, err := p.Mount(tc.req)
+
+			test.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResp, resp); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestProvider_Unmount(t *testing.T) {
+	for name, tc := range map[string]struct {
+		nilProv bool
+		msc     *system.MockSysConfig
+		req     storage.MountRequest
+		expResp *storage.MountResponse
+		expErr  error
+	}{
+		"nil": {
+			nilProv: true,
+			expErr:  errors.New("nil"),
+		},
+		"unmount failed": {
+			msc: &system.MockSysConfig{
+				UnmountErr: errors.New("mock unmount"),
+			},
+			req:    storage.MountRequest{Target: "/something"},
+			expErr: errors.New("mock unmount"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			var p *Provider
+			if !tc.nilProv {
+				p = NewProvider(log, system.NewMockSysProvider(log, tc.msc))
+			}
+
+			resp, err := p.Unmount(tc.req)
+
+			test.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResp, resp); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestProvider_IsMounted(t *testing.T) {
+	testTarget := "/fake"
+	for name, tc := range map[string]struct {
+		nilProv   bool
+		msc       *system.MockSysConfig
+		input     string
+		expResult bool
+		expErr    error
+	}{
+		"nil": {
+			nilProv: true,
+			expErr:  errors.New("nil"),
+		},
+		"permission error": {
+			msc: &system.MockSysConfig{
+				IsMountedErr: os.ErrPermission,
+			},
+			expErr: storage.FaultPathAccessDenied(testTarget),
+		},
+		"error": {
+			msc: &system.MockSysConfig{
+				IsMountedErr: errors.New("mock IsMounted"),
+			},
+			expErr: errors.New("mock IsMounted"),
+		},
+		"not mounted": {
+			msc: &system.MockSysConfig{},
+		},
+		"mounted": {
+			msc: &system.MockSysConfig{
+				IsMountedBool: true,
+			},
+			expResult: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			var p *Provider
+			if !tc.nilProv {
+				p = NewProvider(log, system.NewMockSysProvider(log, tc.msc))
+			}
+
+			result, err := p.IsMounted(testTarget)
+
+			test.CmpErr(t, tc.expErr, err)
+			test.AssertEqual(t, tc.expResult, result, "")
+		})
+	}
+}
+
+func TestProvider_ClearMountpoint(t *testing.T) {
+	testMountpoint := func(path string) string {
+		return filepath.Join(path, "mnt")
+	}
+
+	for name, tc := range map[string]struct {
+		nilProv bool
+		msc     *system.MockSysConfig
+		setup   func(t *testing.T, testDir string) func(*testing.T)
+		expErr  error
+	}{
+		"nil": {
+			nilProv: true,
+			expErr:  errors.New("nil"),
+		},
+		"IsMounted error": {
+			msc: &system.MockSysConfig{
+				IsMountedErr: errors.New("mock IsMounted"),
+			},
+			expErr: errors.New("mock IsMounted"),
+		},
+		"IsMounted nonexistent": {
+			msc: &system.MockSysConfig{
+				IsMountedErr: os.ErrNotExist,
+			},
+		},
+		"not mounted": {
+			msc: &system.MockSysConfig{},
+		},
+		"mountpoint dir does not exist": { // error is ignored
+			msc: &system.MockSysConfig{},
+			setup: func(t *testing.T, testDir string) func(*testing.T) {
+				return func(_ *testing.T) {}
+			},
+		},
+		"mountpoint dir bad permissions": { // error is ignored
+			msc: &system.MockSysConfig{},
+			setup: func(t *testing.T, testDir string) func(*testing.T) {
+				t.Helper()
+				if err := os.Mkdir(testMountpoint(testDir), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(testDir, 0600); err != nil {
+					t.Fatal(err)
+				}
+
+				return func(t *testing.T) {
+					t.Helper()
+
+					if err := os.Chmod(testDir, 0755); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			expErr: os.ErrPermission,
+		},
+		"unmount failed": {
+			msc: &system.MockSysConfig{
+				IsMountedBool: true,
+				UnmountErr:    errors.New("mock unmount"),
+			},
+			expErr: errors.New("mock unmount"),
+		},
+		"mounted success": {
+			msc: &system.MockSysConfig{
+				IsMountedBool: true,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			testDir, cleanupDir := test.CreateTestDir(t)
+			defer cleanupDir()
+
+			if tc.setup == nil {
+				tc.setup = func(t *testing.T, testDir string) func(*testing.T) {
+					t.Helper()
+
+					if err := os.Mkdir(testMountpoint(testDir), 0755); err != nil {
+						t.Fatal(err)
+					}
+
+					return func(_ *testing.T) {}
+				}
+			}
+			teardown := tc.setup(t, testDir)
+			defer teardown(t)
+
+			var p *Provider
+			if !tc.nilProv {
+				p = NewProvider(log, system.NewMockSysProvider(log, tc.msc))
+			}
+
+			err := p.ClearMountpoint(testMountpoint(testDir))
+
+			test.CmpErr(t, tc.expErr, err)
+		})
+	}
+}
+
+func TestProvider_MakeMountPath(t *testing.T) {
+	testDir, cleanupDir := test.CreateTestDir(t)
+	defer cleanupDir()
+
+	dir1 := "/fake"
+	dir2 := "/nested"
+	dir3 := "/mountpoint"
+	nestedMount := dir1 + dir2 + dir3
+
+	for name, tc := range map[string]struct {
+		mntpt     string
+		existPath string
+		statErrs  map[string]error
+		expCreate bool
+		expErr    error
+	}{
+		"existing nested": {
+			mntpt: nestedMount,
+		},
+		"existing nested; bad perms": {
+			mntpt: nestedMount,
+			statErrs: map[string]error{
+				nestedMount: os.ErrPermission,
+			},
+			expErr: os.ErrPermission,
+		},
+		"new nested": {
+			mntpt: nestedMount,
+			statErrs: map[string]error{
+				dir1:        os.ErrNotExist,
+				dir1 + dir2: os.ErrNotExist,
+				nestedMount: os.ErrNotExist,
+			},
+			expCreate: true,
+		},
+		"partial existing nested": {
+			mntpt:     nestedMount,
+			existPath: dir1,
+			statErrs: map[string]error{
+				dir1 + dir2: os.ErrNotExist,
+				nestedMount: os.ErrNotExist,
+			},
+			expCreate: true,
+		},
+		// similate situation where mount ancestor dir exists with
+		// incompatible permissions
+		"partial existing nested; bad perms": {
+			mntpt:     nestedMount,
+			existPath: dir1 + dir2,
+			statErrs: map[string]error{
+				dir1 + dir2: os.ErrPermission,
+				nestedMount: os.ErrNotExist,
+			},
+			expErr: os.ErrPermission,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			testCaseDir := filepath.Join(testDir, "tc")
+			if err := os.Mkdir(testCaseDir, defaultMountPointPerms); err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(testCaseDir)
+
+			if tc.existPath != "" {
+				// when simulating full or partial mountpoint
+				// path, create the existing directory structure
+				// in the test case temporary directory
+				ep := filepath.Join(testCaseDir, tc.existPath)
+				if err := os.MkdirAll(ep, defaultMountPointPerms); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			msc := &system.MockSysConfig{
+				StatErrors: make(map[string]error),
+			}
+			for mp, err := range tc.statErrs {
+				// mocked stat return errors updated for paths
+				// relative to the test case temporary directory
+				k := filepath.Join(testCaseDir, mp)
+				msc.StatErrors[k] = err
+			}
+			p := NewProvider(log, system.NewMockSysProvider(log, msc))
+
+			tMntpt := filepath.Join(testCaseDir, tc.mntpt)
+
+			gotErr := p.MakeMountPath(tMntpt, os.Getuid(), os.Getgid())
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil || tc.expCreate == false {
+				return
+			}
+
+			// verify that the expected directory structure has been
+			// created within the test case temporary directory
+			if _, err := os.Stat(tMntpt); err != nil {
+				t.Fatalf("Mount point not accessible: %s", err)
+			}
+		})
+	}
+}

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -161,7 +161,7 @@ func createScmFormatRequest(class Class, scmCfg ScmConfig, force bool) (*ScmForm
 		if len(scmCfg.DeviceList) != 1 {
 			return nil, ErrInvalidDcpmCount
 		}
-		req.Dcpm = &DcpmParams{
+		req.Dcpm = &DeviceParams{
 			Device: scmCfg.DeviceList[0],
 		}
 	default:

--- a/src/control/server/storage/scm.go
+++ b/src/control/server/storage/scm.go
@@ -258,8 +258,8 @@ const (
 type (
 	// ScmProvider defines an interface to be implemented by a PMem provider.
 	ScmProvider interface {
-		Mount(ScmMountRequest) (*ScmMountResponse, error)
-		Unmount(ScmMountRequest) (*ScmMountResponse, error)
+		Mount(ScmMountRequest) (*MountResponse, error)
+		Unmount(ScmMountRequest) (*MountResponse, error)
 		Format(ScmFormatRequest) (*ScmFormatResponse, error)
 		CheckFormat(ScmFormatRequest) (*ScmFormatResponse, error)
 		Scan(ScmScanRequest) (*ScmScanResponse, error)
@@ -295,11 +295,6 @@ type (
 		Namespaces ScmNamespaces
 	}
 
-	// DcpmParams defines the sub-parameters of a Format operation that will use PMem
-	DcpmParams struct {
-		Device string
-	}
-
 	// RamdiskParams defines the sub-parameters of a Format or Mount operation that
 	// will use tmpfs-based ramdisk
 	RamdiskParams struct {
@@ -315,7 +310,7 @@ type (
 		OwnerUID   int
 		OwnerGID   int
 		Ramdisk    *RamdiskParams
-		Dcpm       *DcpmParams
+		Dcpm       *DeviceParams
 	}
 
 	// ScmFormatResponse contains the results of a successful Format operation or query.
@@ -326,19 +321,13 @@ type (
 		Mountable  bool
 	}
 
-	// ScmMountRequest defines the parameters for a Mount operation.
+	// ScmMountRequest represents an SCM mount request.
 	ScmMountRequest struct {
 		pbin.ForwardableRequest
 		Class   Class
 		Device  string
 		Target  string
 		Ramdisk *RamdiskParams
-	}
-
-	// ScmMountResponse contains the results of a successful Mount operation.
-	ScmMountResponse struct {
-		Target  string
-		Mounted bool
 	}
 
 	// ScmFirmwareQueryRequest defines the parameters for a firmware query.
@@ -411,10 +400,10 @@ func NewScmAdminForwarder(log logging.Logger) *ScmAdminForwarder {
 }
 
 // Mount forwards an SCM mount request.
-func (f *ScmAdminForwarder) Mount(req ScmMountRequest) (*ScmMountResponse, error) {
+func (f *ScmAdminForwarder) Mount(req ScmMountRequest) (*MountResponse, error) {
 	req.Forwarded = true
 
-	res := new(ScmMountResponse)
+	res := new(MountResponse)
 	if err := f.SendReq("ScmMount", req, res); err != nil {
 		return nil, err
 	}
@@ -423,10 +412,10 @@ func (f *ScmAdminForwarder) Mount(req ScmMountRequest) (*ScmMountResponse, error
 }
 
 // Unmount forwards an SCM unmount request.
-func (f *ScmAdminForwarder) Unmount(req ScmMountRequest) (*ScmMountResponse, error) {
+func (f *ScmAdminForwarder) Unmount(req ScmMountRequest) (*MountResponse, error) {
 	req.Forwarded = true
 
-	res := new(ScmMountResponse)
+	res := new(MountResponse)
 	if err := f.SendReq("ScmUnmount", req, res); err != nil {
 		return nil, err
 	}

--- a/src/control/server/storage/scm/faults.go
+++ b/src/control/server/storage/scm/faults.go
@@ -71,14 +71,6 @@ var (
 		"unmount the device and retry the operation",
 	)
 
-	// FaultTargetAlreadyMounted represents an error where a format was requested
-	// on an SCM storage target that was already mounted on the system.
-	FaultTargetAlreadyMounted = scmFault(
-		code.StorageTargetAlreadyMounted,
-		"request included already-mounted mount target (cannot double-mount)",
-		"unmount the target and retry the operation",
-	)
-
 	// FaultMissingNdctl represents an error where the ndctl SCM management tool
 	// is not installed on the system.
 	FaultMissingNdctl = scmFault(
@@ -116,16 +108,6 @@ func FaultFormatMissingDevice(device string) *fault.Fault {
 		code.ScmFormatMissingDevice,
 		fmt.Sprintf("configured SCM device %s does not exist", device),
 		"check the configured value and/or perform the SCM preparation procedure",
-	)
-}
-
-// FaultPathAccessDenied represents an error where a mount point or device path for
-// a SCM storage target is inaccessible because of a permissions issue.
-func FaultPathAccessDenied(path string) *fault.Fault {
-	return scmFault(
-		code.ScmPathAccessDenied,
-		fmt.Sprintf("path %q has incompatible access permissions", path),
-		"verify the path is accessible by the user running daos_server and try again",
 	)
 }
 

--- a/src/control/server/storage/scm/ipmctl.go
+++ b/src/control/server/storage/scm/ipmctl.go
@@ -7,7 +7,6 @@
 package scm
 
 import (
-	"fmt"
 	"os/exec"
 	"sort"
 	"strconv"
@@ -19,6 +18,7 @@ import (
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/ipmctl"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -32,29 +32,16 @@ const (
 )
 
 type (
-	runCmdFn    func(string) (string, error)
-	lookPathFn  func(string) (string, error)
-	runCmdError struct {
-		wrapped error
-		stdout  string
-	}
+	runCmdFn   func(string) (string, error)
+	lookPathFn func(string) (string, error)
 )
-
-func (rce *runCmdError) Error() string {
-	if ee, ok := rce.wrapped.(*exec.ExitError); ok {
-		return fmt.Sprintf("%s: stdout: %s; stderr: %s", ee.ProcessState,
-			rce.stdout, ee.Stderr)
-	}
-
-	return fmt.Sprintf("%s: stdout: %s", rce.wrapped.Error(), rce.stdout)
-}
 
 func run(cmd string) (string, error) {
 	out, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {
-		return "", &runCmdError{
-			wrapped: err,
-			stdout:  string(out),
+		return "", &system.RunCmdError{
+			Wrapped: err,
+			Stdout:  string(out),
 		}
 	}
 

--- a/src/control/server/storage/scm/mocks.go
+++ b/src/control/server/storage/scm/mocks.go
@@ -7,14 +7,14 @@
 package scm
 
 import (
-	"os"
-	"strings"
 	"sync"
 
 	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/lib/ipmctl"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/storage"
+	"github.com/daos-stack/daos/src/control/server/storage/mount"
 )
 
 type (
@@ -115,158 +115,6 @@ func mockModule(dIn ...ipmctl.DeviceDiscovery) *storage.ScmModule {
 	}
 }
 
-type (
-	// GetfsUsageRetval encapsulates return values from a GetfsUsage call.
-	GetfsUsageRetval struct {
-		Total, Avail uint64
-		Err          error
-	}
-
-	mountMap struct {
-		sync.RWMutex
-		mounted map[string]bool
-	}
-
-	// MockSysConfig alters mock SystemProvider behavior.
-	MockSysConfig struct {
-		IsMountedBool   bool
-		IsMountedErr    error
-		MountErr        error
-		UnmountErr      error
-		MkfsErr         error
-		ChmodErr        error
-		GetfsStr        string
-		GetfsErr        error
-		SourceToTarget  map[string]string
-		getfsIndex      int
-		GetfsUsageResps []GetfsUsageRetval
-		statErrors      map[string]error
-		realStat        bool
-	}
-
-	// MockSysProvider gives a mock SystemProvider implementation.
-	MockSysProvider struct {
-		sync.RWMutex
-		log       logging.Logger
-		cfg       MockSysConfig
-		isMounted mountMap
-	}
-)
-
-func (mm *mountMap) Set(mount string, mounted bool) {
-	mm.Lock()
-	defer mm.Unlock()
-
-	mm.mounted[mount] = mounted
-}
-
-func (mm *mountMap) Get(mount string) (bool, bool) {
-	mm.RLock()
-	defer mm.RUnlock()
-
-	mounted, exists := mm.mounted[mount]
-	return mounted, exists
-}
-
-func (msp *MockSysProvider) IsMounted(target string) (bool, error) {
-	err := msp.cfg.IsMountedErr
-	// hack... don't fail the format tests which also want
-	// to make sure that the device isn't already formatted.
-	if os.IsNotExist(err) && strings.HasPrefix(target, "/dev") {
-		err = nil
-	}
-
-	msp.Lock()
-	defer msp.Unlock()
-
-	// lookup target of a given source device (target actually a source
-	// device in this case)
-	mount, exists := msp.cfg.SourceToTarget[target]
-	if exists {
-		target = mount
-	}
-
-	isMounted, exists := msp.isMounted.Get(target)
-	if !exists {
-		return msp.cfg.IsMountedBool, err
-	}
-	return isMounted, err
-}
-
-func (msp *MockSysProvider) Mount(_, target, _ string, _ uintptr, _ string) error {
-	if msp.cfg.MountErr == nil {
-		msp.Lock()
-		msp.isMounted.Set(target, true)
-		msp.Unlock()
-	}
-	return msp.cfg.MountErr
-}
-
-func (msp *MockSysProvider) Unmount(target string, _ int) error {
-	if msp.cfg.UnmountErr == nil {
-		msp.Lock()
-		msp.isMounted.Set(target, false)
-		msp.Unlock()
-	}
-	return msp.cfg.UnmountErr
-}
-
-func (msp *MockSysProvider) Mkfs(_, _ string, _ bool) error {
-	return msp.cfg.MkfsErr
-}
-
-func (msp *MockSysProvider) Chmod(string, os.FileMode) error {
-	return msp.cfg.ChmodErr
-}
-
-func (msp *MockSysProvider) Getfs(_ string) (string, error) {
-	return msp.cfg.GetfsStr, msp.cfg.GetfsErr
-}
-
-func (msp *MockSysProvider) GetfsUsage(_ string) (uint64, uint64, error) {
-	msp.cfg.getfsIndex += 1
-	if len(msp.cfg.GetfsUsageResps) < msp.cfg.getfsIndex {
-		return 0, 0, nil
-	}
-	resp := msp.cfg.GetfsUsageResps[msp.cfg.getfsIndex-1]
-	return resp.Total, resp.Avail, resp.Err
-}
-
-func (msp *MockSysProvider) Stat(path string) (os.FileInfo, error) {
-	msp.RLock()
-	defer msp.RUnlock()
-
-	if msp.cfg.realStat {
-		return os.Stat(path)
-	}
-
-	// default return value for missing key is nil so
-	// add entries to indicate path failure e.g. perms or not-exist
-	return nil, msp.cfg.statErrors[path]
-}
-
-func NewMockSysProvider(log logging.Logger, cfg *MockSysConfig) *MockSysProvider {
-	if cfg == nil {
-		cfg = &MockSysConfig{}
-	}
-	if cfg.statErrors == nil {
-		cfg.realStat = true
-	}
-	msp := &MockSysProvider{
-		log: log,
-		cfg: *cfg,
-		isMounted: mountMap{
-			mounted: make(map[string]bool),
-		},
-	}
-	log.Debugf("creating MockSysProvider with cfg: %+v", msp.cfg)
-	return msp
-}
-
-func DefaultMockSysProvider(log logging.Logger) *MockSysProvider {
-	return NewMockSysProvider(log, nil)
-}
-
 // MockBackendConfig specifies behavior for a mock SCM backend
 // implementation providing capability to access and configure
 // SCM modules and namespaces.
@@ -346,10 +194,14 @@ func DefaultMockBackend() *MockBackend {
 	return NewMockBackend(nil)
 }
 
-func NewMockProvider(log logging.Logger, mbc *MockBackendConfig, msc *MockSysConfig) *Provider {
-	return NewProvider(log, NewMockBackend(mbc), NewMockSysProvider(log, msc))
+func NewMockProvider(log logging.Logger, mbc *MockBackendConfig, msc *system.MockSysConfig) *Provider {
+	sysProv := system.NewMockSysProvider(log, msc)
+	mountProv := mount.NewProvider(log, sysProv)
+	return NewProvider(log, NewMockBackend(mbc), sysProv, mountProv)
 }
 
 func DefaultMockProvider(log logging.Logger) *Provider {
-	return NewProvider(log, DefaultMockBackend(), DefaultMockSysProvider(log))
+	sysProv := system.DefaultMockSysProvider(log)
+	mountProv := mount.NewProvider(log, sysProv)
+	return NewProvider(log, DefaultMockBackend(), sysProv, mountProv)
 }

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -9,8 +9,6 @@ package scm
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -19,27 +17,20 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/storage"
+	"github.com/daos-stack/daos/src/control/server/storage/mount"
 )
 
 var _ storage.ScmProvider = &Provider{}
 
 const (
-	defaultUnmountFlags = 0
-	defaultMountFlags   = unix.MS_NOATIME
+	defaultMountFlags = unix.MS_NOATIME
 
 	defaultMountPointPerms = 0700
 
-	parseFsUnformatted = "data"
-
-	fsTypeNone    = "none"
-	fsTypeExt4    = "ext4"
-	fsTypeTmpfs   = "tmpfs"
-	fsTypeUnknown = "unknown"
-
-	dcpmFsType    = fsTypeExt4
+	dcpmFsType    = system.FsTypeExt4
 	dcpmMountOpts = "dax,nodelalloc"
 
-	ramFsType = fsTypeTmpfs
+	ramFsType = system.FsTypeTmpfs
 )
 
 type (
@@ -56,17 +47,11 @@ type (
 	// SystemProvider defines a set of methods to be implemented by a provider
 	// of SCM-specific system capabilities.
 	SystemProvider interface {
-		system.IsMountedProvider
-		system.MountProvider
-		system.UnmountProvider
 		Mkfs(fsType, device string, force bool) error
 		Getfs(device string) (string, error)
 		Stat(string) (os.FileInfo, error)
 		Chmod(string, os.FileMode) error
-	}
-
-	defaultSystemProvider struct {
-		system.LinuxProvider
+		Chown(string, int, int) error
 	}
 
 	// Provider encapsulates configuration and logic for
@@ -75,6 +60,7 @@ type (
 		log     logging.Logger
 		backend Backend
 		sys     SystemProvider
+		mounter storage.MountProvider
 	}
 )
 
@@ -106,170 +92,18 @@ func validateFormatRequest(r storage.ScmFormatRequest) error {
 	return nil
 }
 
-func (dsp *defaultSystemProvider) checkDevice(device string) error {
-	st, err := dsp.Stat(device)
-	if err != nil {
-		return errors.Wrapf(err, "stat failed on %s", device)
-	}
-
-	if st.Mode()&os.ModeDevice == 0 {
-		return errors.Errorf("%s is not a device file", device)
-	}
-
-	return nil
-}
-
-func getDistroArgs() []string {
-	distro := system.GetDistribution()
-
-	// use stride option for SCM interleaved mode
-	// disable lazy initialization (hurts perf)
-	// discard is not needed/supported on SCM
-	opts := "stride=512,lazy_itable_init=0,lazy_journal_init=0,nodiscard"
-
-	// enable flex_bg to allow larger contiguous block allocation
-	// disable uninit_bg to initialize everything upfront
-	// disable resize to avoid GDT block allocations
-	// disable extra isize since we really have no use for this
-	feat := "flex_bg,^uninit_bg,^resize_inode,^extra_isize"
-
-	switch {
-	case distro.ID == "centos" && distro.Version.Major < 8:
-		// use strict minimum listed above here since that's
-		// the oldest distribution we support
-	default:
-		// packed_meta_blocks allows to group all data blocks together
-		opts += ",packed_meta_blocks=1"
-		// enable sparse_super2 since 2x superblock copies are enough
-		// disable csum since we have ECC already for SCM
-		// bigalloc is intentionally not used since some kernels don't support it
-		feat += ",sparse_super2,^metadata_csum"
-	}
-
-	return []string{
-		"-E", opts,
-		"-O", feat,
-		// each ext4 group is of size 32767 x 4KB = 128M
-		// pack 128 groups together to increase ability to use huge
-		// pages for a total virtual group size of 16G
-		"-G", "128",
-	}
-}
-
-// Mkfs attempts to create a filesystem of the supplied type, on the
-// supplied device.
-func (dsp *defaultSystemProvider) Mkfs(fsType, device string, force bool) error {
-	cmdPath, err := exec.LookPath(fmt.Sprintf("mkfs.%s", fsType))
-	if err != nil {
-		return errors.Wrapf(err, "unable to find mkfs.%s", fsType)
-	}
-
-	if err := dsp.checkDevice(device); err != nil {
-		return err
-	}
-
-	// TODO: Think about a way to allow for some kind of progress
-	// callback so that the user has some visibility into long-running
-	// format operations (very large devices).
-	args := []string{
-		// use quiet mode
-		"-q",
-		// use direct i/o to avoid polluting page cache
-		"-D",
-		// use DAOS label
-		"-L", "daos",
-		// don't reserve blocks for super-user
-		"-m", "0",
-		// use largest possible block size
-		"-b", "4096",
-		// don't need large inode, 128B is enough
-		// since we don't use xattr
-		"-I", "128",
-		// reduce the inode per bytes ratio
-		// one inode for 64M is more than enough
-		"-i", "67108864",
-	}
-	args = append(args, getDistroArgs()...)
-	// string always comes last
-	args = append(args, []string{device}...)
-	if force {
-		args = append([]string{"-F"}, args...)
-	}
-	out, err := exec.Command(cmdPath, args...).Output()
-	if err != nil {
-		return &runCmdError{
-			wrapped: err,
-			stdout:  string(out),
-		}
-	}
-
-	return nil
-}
-
-// Getfs probes the specified device in an attempt to determine the
-// formatted filesystem type, if any.
-func (dsp *defaultSystemProvider) Getfs(device string) (string, error) {
-	cmdPath, err := exec.LookPath("file")
-	if err != nil {
-		return fsTypeNone, errors.Wrap(err, "unable to find file")
-	}
-
-	if err := dsp.checkDevice(device); err != nil {
-		return fsTypeNone, err
-	}
-
-	args := []string{"-s", device}
-	out, err := exec.Command(cmdPath, args...).Output()
-	if err != nil {
-		return fsTypeNone, &runCmdError{
-			wrapped: err,
-			stdout:  string(out),
-		}
-	}
-
-	return parseFsType(string(out)), nil
-}
-
-// Stat probes the specified path and returns os level file info.
-func (dsp *defaultSystemProvider) Stat(path string) (os.FileInfo, error) {
-	return os.Stat(path)
-}
-
-// Chmod changes the mode of the specified path.
-func (dsp *defaultSystemProvider) Chmod(path string, mode os.FileMode) error {
-	return os.Chmod(path, mode)
-}
-
-func parseFsType(input string) string {
-	// /dev/pmem0: Linux rev 1.0 ext4 filesystem data, UUID=09619a0d-0c9e-46b4-add5-faf575dd293d
-	// /dev/pmem1: data
-	// /dev/pmem1: COM executable for DOS
-	fields := strings.Fields(input)
-	switch {
-	case len(fields) == 2 && fields[1] == parseFsUnformatted:
-		return fsTypeNone
-	case len(fields) >= 5:
-		return fields[4]
-	default:
-		return fsTypeUnknown
-	}
-}
-
 // DefaultProvider returns an initialized *Provider suitable for use with production code.
 func DefaultProvider(log logging.Logger) *Provider {
-	lp := system.DefaultProvider()
-	p := &defaultSystemProvider{
-		LinuxProvider: *lp,
-	}
-	return NewProvider(log, defaultCmdRunner(log), p)
+	return NewProvider(log, defaultCmdRunner(log), system.DefaultProvider(), mount.DefaultProvider(log))
 }
 
 // NewProvider returns an initialized *Provider.
-func NewProvider(log logging.Logger, backend Backend, sys SystemProvider) *Provider {
+func NewProvider(log logging.Logger, backend Backend, sys SystemProvider, mounter storage.MountProvider) *Provider {
 	p := &Provider{
 		log:     log,
 		backend: backend,
 		sys:     sys,
+		mounter: mounter,
 	}
 	return p
 }
@@ -348,7 +182,9 @@ func (p *Provider) prepare(req storage.ScmPrepareRequest, scan scanFn) (*storage
 				}
 				if isMounted {
 					p.log.Debugf("Unmounting %s", nsDev)
-					if err := p.sys.Unmount(nsDev, 0); err != nil {
+					if _, err := p.mounter.Unmount(storage.MountRequest{
+						Target: nsDev,
+					}); err != nil {
 						p.log.Errorf("Unmount error: %s", err)
 						return nil, err
 					}
@@ -409,11 +245,11 @@ func (p *Provider) CheckFormat(req storage.ScmFormatRequest) (*storage.ScmFormat
 	p.log.Debugf("device %s filesystem: %s", req.Dcpm.Device, fsType)
 
 	switch fsType {
-	case fsTypeExt4:
+	case system.FsTypeExt4:
 		res.Mountable = true
-	case fsTypeNone:
+	case system.FsTypeNone:
 		res.Formatted = false
-	case fsTypeUnknown:
+	case system.FsTypeUnknown:
 		// formatted but not mountable
 		p.log.Debugf("unexpected format of output from 'file -s %s'", req.Dcpm.Device)
 	default:
@@ -422,67 +258,6 @@ func (p *Provider) CheckFormat(req storage.ScmFormatRequest) (*storage.ScmFormat
 	}
 
 	return res, nil
-}
-
-func (p *Provider) clearMount(mntpt string) error {
-	mounted, err := p.IsMounted(mntpt)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	if mounted {
-		_, err := p.unmount(mntpt, defaultUnmountFlags)
-		if err != nil {
-			return err
-		}
-	}
-
-	if err := os.RemoveAll(mntpt); err != nil {
-		if !os.IsNotExist(err) {
-			return errors.Wrapf(err, "failed to remove %s", mntpt)
-		}
-	}
-
-	return nil
-}
-
-// makeMountPath will build the target path by creating any non-existent
-// subdirectories and setting ownership to target uid/gid to ensure that the
-// target user is able to access the created mount point if multiple layers
-// deep. If subdirectories in path already exist, their permissions will not be
-// modified.
-func (p *Provider) makeMountPath(path string, tgtUID, tgtGID int) error {
-	if !filepath.IsAbs(path) {
-		return errors.Errorf("expecting absolute target path, got %q", path)
-	}
-	if _, err := p.Stat(path); err == nil {
-		return nil // path already exists
-	}
-	// don't need to validate request UID/GID as they are populated inside
-	// this package during CreateFormatRequest()
-
-	sep := string(filepath.Separator)
-	dirs := strings.Split(path, sep)[1:] // omit empty element
-
-	for i := range dirs {
-		ps := sep + filepath.Join(dirs[:i+1]...)
-		_, err := p.Stat(ps)
-		switch {
-		case os.IsNotExist(err):
-			// subdir missing, attempt to create and chown
-			if err := os.Mkdir(ps, defaultMountPointPerms); err != nil {
-				return errors.Wrapf(err, "failed to create directory %q", ps)
-			}
-			if err := os.Chown(ps, tgtUID, tgtGID); err != nil {
-				return errors.Wrapf(err, "failed to set ownership of %s to %d.%d",
-					ps, tgtUID, tgtGID)
-			}
-		case err != nil:
-			return errors.Wrapf(err, "unable to stat %q", ps)
-		}
-	}
-
-	return nil
 }
 
 // Format attempts to fulfill the specified SCM format request.
@@ -497,11 +272,11 @@ func (p *Provider) Format(req storage.ScmFormatRequest) (*storage.ScmFormatRespo
 		}
 	}
 
-	if err := p.clearMount(req.Mountpoint); err != nil {
+	if err := p.mounter.ClearMountpoint(req.Mountpoint); err != nil {
 		return nil, errors.Wrap(err, "failed to clear existing mount")
 	}
 
-	if err := p.makeMountPath(req.Mountpoint, req.OwnerUID, req.OwnerGID); err != nil {
+	if err := p.mounter.MakeMountPath(req.Mountpoint, req.OwnerUID, req.OwnerGID); err != nil {
 		return nil, errors.Wrap(err, "failed to create mount path")
 	}
 
@@ -520,7 +295,7 @@ func (p *Provider) formatRamdisk(req storage.ScmFormatRequest) (*storage.ScmForm
 		return nil, FaultFormatMissingParam
 	}
 
-	res, err := p.MountRamdisk(req.Mountpoint, req.Ramdisk)
+	res, err := p.mountRamdisk(req.Mountpoint, req.Ramdisk)
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +304,7 @@ func (p *Provider) formatRamdisk(req storage.ScmFormatRequest) (*storage.ScmForm
 		return nil, errors.Errorf("%s was not mounted", req.Mountpoint)
 	}
 
-	if err := os.Chown(req.Mountpoint, req.OwnerUID, req.OwnerGID); err != nil {
+	if err := p.sys.Chown(req.Mountpoint, req.OwnerUID, req.OwnerGID); err != nil {
 		return nil, errors.Wrapf(err, "failed to set ownership of %s to %d.%d",
 			req.Mountpoint, req.OwnerUID, req.OwnerGID)
 	}
@@ -547,20 +322,12 @@ func (p *Provider) formatDcpm(req storage.ScmFormatRequest) (*storage.ScmFormatR
 		return nil, FaultFormatMissingParam
 	}
 
-	alreadyMounted, err := p.IsMounted(req.Dcpm.Device)
-	if err != nil {
-		return nil, err
-	}
-	if alreadyMounted {
-		return nil, errors.Wrap(FaultDeviceAlreadyMounted, req.Dcpm.Device)
-	}
-
 	p.log.Debugf("running mkfs.%s %s", dcpmFsType, req.Dcpm.Device)
 	if err := p.sys.Mkfs(dcpmFsType, req.Dcpm.Device, req.Force); err != nil {
 		return nil, errors.Wrapf(err, "failed to format %s", req.Dcpm.Device)
 	}
 
-	res, err := p.MountDcpm(req.Dcpm.Device, req.Mountpoint)
+	res, err := p.mountDcpm(req.Dcpm.Device, req.Mountpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +336,7 @@ func (p *Provider) formatDcpm(req storage.ScmFormatRequest) (*storage.ScmFormatR
 		return nil, errors.Errorf("%s was not mounted", req.Mountpoint)
 	}
 
-	if err := os.Chown(req.Mountpoint, req.OwnerUID, req.OwnerGID); err != nil {
+	if err := p.sys.Chown(req.Mountpoint, req.OwnerUID, req.OwnerGID); err != nil {
 		return nil, errors.Wrapf(err, "failed to set ownership of %s to %d.%d",
 			req.Mountpoint, req.OwnerUID, req.OwnerGID)
 	}
@@ -582,23 +349,20 @@ func (p *Provider) formatDcpm(req storage.ScmFormatRequest) (*storage.ScmFormatR
 	}, nil
 }
 
-// MountDcpm attempts to mount a DCPM device at the specified mountpoint.
-func (p *Provider) MountDcpm(device, target string) (*storage.ScmMountResponse, error) {
-	// make sure the source device is not already mounted somewhere else
-	devMounted, err := p.sys.IsMounted(device)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to check if %s is mounted", device)
-	}
-	if devMounted {
-		return nil, errors.Wrap(FaultDeviceAlreadyMounted, device)
-	}
-
-	return p.mount(device, target, dcpmFsType, defaultMountFlags, dcpmMountOpts)
+// mountDcpm attempts to mount a DCPM device at the specified mountpoint.
+func (p *Provider) mountDcpm(device, target string) (*storage.MountResponse, error) {
+	return p.mounter.Mount(storage.MountRequest{
+		Source:     device,
+		Target:     target,
+		Filesystem: dcpmFsType,
+		Flags:      defaultMountFlags,
+		Options:    dcpmMountOpts,
+	})
 }
 
-// MountRamdisk attempts to mount a tmpfs-based ramdisk of the specified size at
+// mountRamdisk attempts to mount a tmpfs-based ramdisk of the specified size at
 // the specified mountpoint.
-func (p *Provider) MountRamdisk(target string, params *storage.RamdiskParams) (*storage.ScmMountResponse, error) {
+func (p *Provider) mountRamdisk(target string, params *storage.RamdiskParams) (*storage.MountResponse, error) {
 	if params == nil {
 		return nil, FaultFormatMissingParam
 	}
@@ -612,61 +376,32 @@ func (p *Provider) MountRamdisk(target string, params *storage.RamdiskParams) (*
 		opts = append(opts, fmt.Sprintf("size=%dg", params.Size))
 	}
 
-	return p.mount(ramFsType, target, ramFsType, defaultMountFlags, strings.Join(opts, ","))
+	return p.mounter.Mount(storage.MountRequest{
+		Source:     ramFsType,
+		Target:     target,
+		Filesystem: ramFsType,
+		Flags:      defaultMountFlags,
+		Options:    strings.Join(opts, ","),
+	})
 }
 
 // Mount attempts to mount the target specified in the supplied request.
-func (p *Provider) Mount(req storage.ScmMountRequest) (*storage.ScmMountResponse, error) {
+func (p *Provider) Mount(req storage.ScmMountRequest) (*storage.MountResponse, error) {
 	switch req.Class {
 	case storage.ClassDcpm:
-		return p.MountDcpm(req.Device, req.Target)
+		return p.mountDcpm(req.Device, req.Target)
 	case storage.ClassRam:
-		return p.MountRamdisk(req.Target, req.Ramdisk)
+		return p.mountRamdisk(req.Target, req.Ramdisk)
 	default:
 		return nil, errors.New(storage.ScmMsgClassNotSupported)
 	}
 }
 
-func (p *Provider) mount(src, target, fsType string, flags uintptr, opts string) (*storage.ScmMountResponse, error) {
-	// make sure that we're not double-mounting over an existing mount
-	tgtMounted, err := p.IsMounted(target)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-	if tgtMounted {
-		return nil, errors.Wrap(FaultTargetAlreadyMounted, target)
-	}
-
-	p.log.Debugf("mount %s->%s (%s) (%s)", src, target, fsType, opts)
-	if err := p.sys.Mount(src, target, fsType, flags, opts); err != nil {
-		return nil, errors.Wrapf(err, "mount %s->%s failed", src, target)
-	}
-
-	// Adjust permissions on the mounted filesystem.
-	if err := p.sys.Chmod(target, defaultMountPointPerms); err != nil {
-		return nil, errors.Wrapf(err, "failed to set permissions on %s", target)
-	}
-
-	return &storage.ScmMountResponse{
-		Target:  target,
-		Mounted: true,
-	}, nil
-}
-
 // Unmount attempts to unmount the target specified in the supplied request.
-func (p *Provider) Unmount(req storage.ScmMountRequest) (*storage.ScmMountResponse, error) {
-	return p.unmount(req.Target, defaultUnmountFlags)
-}
-
-func (p *Provider) unmount(target string, flags int) (*storage.ScmMountResponse, error) {
-	if err := p.sys.Unmount(target, flags); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmount %s", target)
-	}
-
-	return &storage.ScmMountResponse{
-		Target:  target,
-		Mounted: false,
-	}, nil
+func (p *Provider) Unmount(req storage.ScmMountRequest) (*storage.MountResponse, error) {
+	return p.mounter.Unmount(storage.MountRequest{
+		Target: req.Target,
+	})
 }
 
 // Stat probes the specified path and returns os level file info.
@@ -677,11 +412,5 @@ func (p *Provider) Stat(path string) (os.FileInfo, error) {
 // IsMounted checks to see if the target device or directory is mounted and
 // returns flag to specify whether mounted or a relevant fault.
 func (p *Provider) IsMounted(target string) (bool, error) {
-	isMounted, err := p.sys.IsMounted(target)
-
-	if errors.Is(err, os.ErrPermission) {
-		return false, errors.Wrap(FaultPathAccessDenied(target), "check if mounted")
-	}
-
-	return isMounted, err
+	return p.mounter.IsMounted(target)
 }


### PR DESCRIPTION
- Move mount/unmount logic into its own provider.
- Move SystemProvider functionality into centralized location.

Features: control

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
