### PR TITLE
DAOS-11605 common: free blob on destroy

### DIFF
--- a/src/common/ad_mem.h
+++ b/src/common/ad_mem.h
@@ -156,7 +156,7 @@ struct ad_arena_df {
 	uint64_t		ad_addr;
 	/** for future use */
 	uint64_t		ad_reserved[2];
-	/** 128 bytes (1024 bits) for each, each bit represents 32K(minimum group size) */
+	/** 64 bytes (512 bits) for each, each bit represents 32K(minimum group size) */
 	uint64_t		ad_bmap[ARENA_GRP_BMSZ];
 	/** it is DRAM reference of arena (the DRAM arena is created on demand) */
 	uint64_t		ad_back_ptr;
@@ -275,8 +275,8 @@ struct ad_blob {
 	int			 bb_ref;
 	/** is dummy blob, for unit test */
 	bool			 bb_dummy;
-	/** opened blob */
-	bool			 bb_opened;
+	/** open refcount */
+	int			 bb_opened;
 	/** number of pages */
 	unsigned int		 bb_pgs_nr;
 	/**

--- a/src/common/tests/ad_mem_tests.c
+++ b/src/common/tests/ad_mem_tests.c
@@ -698,7 +698,8 @@ adt_delayed_free_1(void **state)
 static void
 adt_tx_perf_1(void **state)
 {
-	const int	     alloc_size = 64;
+	/* XXX alloc_size=64/128 overflows arena, will fix in follow-on patch */
+	const int	     alloc_size = 256;
 	const int	     op_per_tx = 2;
 	const int	     loop = 400000; /* 50MB */
 	struct ad_tx	     tx;
@@ -840,7 +841,7 @@ adt_teardown(void **state)
 	int	rc;
 
 	printf("close ad_blob\n");
-	rc = ad_blob_close(adt_bh);
+	rc = ad_blob_destroy(adt_bh);
 	assert_rc_equal(rc, 0);
 	return 0;
 }


### PR DESCRIPTION
- A blob is pinned in memory because arenas in LRU keeps refcount on it, so there is no way to actually free it on close/destroy. With this patch, all groups & arenas in LRU can release refcounts on close, so close & destroy are able to free memory.

- Blob incarnation was overwritten on open(), it is fixed by this patch.

- Change allocation size of the performance test from 64 to 256 bytes, because arena will overflow when the size is 64 (too many groups), this requires a seprate fix in follow-on patch.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
