### PR TITLE
DAOS-11538 chk: misc fixes for chk related issues - part II

### DIFF
--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -256,6 +256,7 @@ chk_engine_pm_orphan(struct chk_pool_rec *cpr, d_rank_t rank, int index)
 		 */
 	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS:
 	case CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 		if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
 			cbk->cb_statistics.cs_repaired++;
 		} else {
@@ -272,7 +273,6 @@ chk_engine_pm_orphan(struct chk_pool_rec *cpr, d_rank_t rank, int index)
 			else
 				cbk->cb_statistics.cs_repaired++;
 		}
-		act = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 		break;
 	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
 		/* Report the inconsistency without repair. */
@@ -291,6 +291,8 @@ chk_engine_pm_orphan(struct chk_pool_rec *cpr, d_rank_t rank, int index)
 			act = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
 			cbk->cb_statistics.cs_ignored++;
 		} else {
+			act = CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT;
+
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
 			option_nr = 2;
@@ -462,6 +464,8 @@ chk_engine_pm_dangling(struct chk_pool_rec *cpr, struct pool_map *map, struct po
 			cbk->cb_statistics.cs_ignored++;
 			cpr->cpr_skip = 1;
 		} else {
+			act = CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT;
+
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
 			option_nr = 2;
@@ -946,6 +950,7 @@ chk_engine_cont_orphan(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr, struc
 		 */
 	case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS:
 	case CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD:
+		act = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 		if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
 			cbk->cb_statistics.cs_repaired++;
 		} else {
@@ -955,7 +960,6 @@ chk_engine_cont_orphan(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr, struc
 			else
 				cbk->cb_statistics.cs_repaired++;
 		}
-		act = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 		break;
 	case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
 		/* Report the inconsistency without repair. */
@@ -974,6 +978,8 @@ chk_engine_cont_orphan(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr, struc
 			act = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
 			cbk->cb_statistics.cs_ignored++;
 		} else {
+			act = CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT;
+
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_DISCARD;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
 			option_nr = 2;
@@ -1126,6 +1132,7 @@ chk_engine_cont_set_label(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr,
 			 * Fall through.
 			 */
 		case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS:
+			act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 			if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
 				cbk->cb_statistics.cs_repaired++;
 			} else {
@@ -1139,7 +1146,6 @@ chk_engine_cont_set_label(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr,
 				else
 					cbk->cb_statistics.cs_repaired++;
 			}
-			act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 			break;
 		case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
 			/* Report the inconsistency without repair. */
@@ -1159,6 +1165,8 @@ chk_engine_cont_set_label(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr,
 				cbk->cb_statistics.cs_ignored++;
 				break;
 			}
+
+			act = CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT;
 
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
@@ -1190,6 +1198,7 @@ chk_engine_cont_set_label(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr,
 			 * Fall through.
 			 */
 		case CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET:
+			act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET;
 			if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN) {
 				cbk->cb_statistics.cs_repaired++;
 			} else {
@@ -1200,7 +1209,6 @@ chk_engine_cont_set_label(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr,
 				else
 					cbk->cb_statistics.cs_repaired++;
 			}
-			act = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET;
 			break;
 		case CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE:
 			/* Report the inconsistency without repair. */
@@ -1220,6 +1228,8 @@ chk_engine_cont_set_label(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr,
 				cbk->cb_statistics.cs_ignored++;
 				break;
 			}
+
+			act = CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT;
 
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -275,7 +275,7 @@ chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_ran
 	csi->csi_flags = flags;
 	csi->csi_phase = phase;
 	csi->csi_leader_rank = leader;
-	csi->csi_api_flags = flags;
+	csi->csi_api_flags = api_flags;
 	csi->csi_ranks.ca_count = rank_nr;
 	csi->csi_ranks.ca_arrays = ranks;
 	csi->csi_policies.ca_count = policy_nr;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -667,8 +667,8 @@ vos_obj_del_key(daos_handle_t coh, daos_unit_oid_t oid, daos_key_t *dkey,
 	daos_handle_t		 toh;
 	int			 rc;
 
-	rc = vos_obj_hold(occ, cont, oid, &epr, 0, VOS_OBJ_VISIBLE,
-			  DAOS_INTENT_PUNCH, &obj, NULL);
+	rc = vos_obj_hold(occ, cont, oid, &epr, 0, VOS_OBJ_VISIBLE | VOS_OBJ_KILL_DKEY,
+			  DAOS_INTENT_KILL, &obj, NULL);
 	if (rc == -DER_NONEXIST)
 		return 0;
 

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -60,6 +60,8 @@ enum {
 	VOS_OBJ_CREATE		= (1 << 1),
 	/** Hold for object specific discard */
 	VOS_OBJ_DISCARD		= (1 << 2),
+	/** Hold the object for delete dkey */
+	VOS_OBJ_KILL_DKEY	= (1 << 3),
 };
 
 /**

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -347,7 +347,7 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 	if (obj->obj_zombie)
 		D_GOTO(failed, rc = -DER_AGAIN);
 
-	if (intent == DAOS_INTENT_KILL) {
+	if (intent == DAOS_INTENT_KILL && !(flags & VOS_OBJ_KILL_DKEY)) {
 		if (obj != &obj_local) {
 			if (vos_obj_refcount(obj) > 2)
 				D_GOTO(failed, rc = -DER_BUSY);


### PR DESCRIPTION
It contains the following:

1. Introduce new flags VOS_OBJ_KILL_DKEY for vos_obj_del_key() to
   avoid failing inside vos_obj_hold().

2. Check start RPC transfers wrong flags to check engine, that may
   causes the check engine on non-leader to run under dryrun mode.
   Fix it.

3. Set repair action more accurately.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
