### PR TITLE
SRE-549 test: Install MOFED ucx-* packages

### DIFF
--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -321,6 +321,34 @@ post_provision_config_nodes() {
         fi
     fi
 
+    if lspci | grep "ConnectX-6" && ! grep MOFED_VERSION /etc/do-release; then
+        # Need this module file
+        version="$(rpm -q --qf "%{version}" openmpi)"
+        mkdir -p /etc/modulefiles/mpi/
+        cat << EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
+#%Module 1.0
+#
+#  OpenMPI module for use with 'environment-modules' package:
+#
+conflict		mpi
+prepend-path 		PATH 		/usr/mpi/gcc/openmpi-$version/bin
+prepend-path 		LD_LIBRARY_PATH /usr/mpi/gcc/openmpi-$version/lib64
+prepend-path 		PKG_CONFIG_PATH	/usr/mpi/gcc/openmpi-$version/lib64/pkgconfig
+prepend-path		MANPATH		/usr/mpi/gcc/openmpi-$version/share/man
+setenv 			MPI_BIN		/usr/mpi/gcc/openmpi-$version/bin
+setenv			MPI_SYSCONFIG	/usr/mpi/gcc/openmpi-$version/etc
+setenv			MPI_FORTRAN_MOD_DIR	/usr/mpi/gcc/openmpi-$version/lib64
+setenv			MPI_INCLUDE	/usr/mpi/gcc/openmpi-$version/include
+setenv	 		MPI_LIB		/usr/mpi/gcc/openmpi-$version/lib64
+setenv			MPI_MAN			/usr/mpi/gcc/openmpi-$version/share/man
+setenv			MPI_COMPILER	openmpi-x86_64
+setenv			MPI_SUFFIX	_openmpi
+setenv	 		MPI_HOME	/usr/mpi/gcc/openmpi-$version
+EOF
+
+        printf 'MOFED_VERSION=%s\n' "$MLNX_VER_NUM" >> /etc/do-release
+    fi 
+
     distro_custom
 
     lsb_release -a

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -64,7 +64,7 @@ install_mofed() {
     rm -f RPM-GPG-KEY-Mellanox
     dnf repolist || true
 
-    time dnf -y install mlnx-ofed-basic
+    time dnf -y install mlnx-ofed-basic ucx-cma ucx-ib ucx-knem ucx-rdmacm ucx-xpmem
 
     # now, upgrade firmware
     time dnf -y install mlnx-fw-updater
@@ -81,29 +81,4 @@ install_mofed() {
         dnf remove -y ucx-knem || true
     fi
 
-    # Need this module file
-    version="$(rpm -q --qf "%{version}" openmpi)"
-    mkdir -p /etc/modulefiles/mpi/
-    cat << EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
-    #%Module 1.0
-    #
-    #  OpenMPI module for use with 'environment-modules' package:
-    #
-    conflict		mpi
-    prepend-path 		PATH 		/usr/mpi/gcc/openmpi-$version/bin
-    prepend-path 		LD_LIBRARY_PATH /usr/mpi/gcc/openmpi-$version/lib64
-    prepend-path 		PKG_CONFIG_PATH	/usr/mpi/gcc/openmpi-$version/lib64/pkgconfig
-    prepend-path		MANPATH		/usr/mpi/gcc/openmpi-$version/share/man
-    setenv 			MPI_BIN		/usr/mpi/gcc/openmpi-$version/bin
-    setenv			MPI_SYSCONFIG	/usr/mpi/gcc/openmpi-$version/etc
-    setenv			MPI_FORTRAN_MOD_DIR	/usr/mpi/gcc/openmpi-$version/lib64
-    setenv			MPI_INCLUDE	/usr/mpi/gcc/openmpi-$version/include
-    setenv	 		MPI_LIB		/usr/mpi/gcc/openmpi-$version/lib64
-    setenv			MPI_MAN			/usr/mpi/gcc/openmpi-$version/share/man
-    setenv			MPI_COMPILER	openmpi-x86_64
-    setenv			MPI_SUFFIX	_openmpi
-    setenv	 		MPI_HOME	/usr/mpi/gcc/openmpi-$version
-EOF
-
-    printf 'MOFED_VERSION=%s\n' "$MLNX_VER_NUM" >> /etc/do-release
 }


### PR DESCRIPTION
Install ucx-{cma,ib,knem,rdmacm,xpmem} from the MOFED repo.

Move the modulefile module creation from being EL8 specific to being
done in post_provision_config_nodes() on all distros.
