### PR TITLE
DAOS-11679 dtx: misc patch for dtx related issues - b22

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -200,7 +200,13 @@ dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	    DTX_CLEANUP_THD_AGE_LO)
 		return 1;
 
-	D_ALLOC(dsp, sizeof(*dsp) + ent->ie_dtx_mbs_dsize);
+	D_ASSERT(ent->ie_dtx_mbs_dsize > 0);
+
+	if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE)
+		D_ALLOC_PTR(dsp);
+	else
+		D_ALLOC(dsp, sizeof(*dsp) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize);
+
 	if (dsp == NULL)
 		return -DER_NOMEM;
 
@@ -208,13 +214,21 @@ dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	dsp->dsp_oid = ent->ie_dtx_oid;
 	dsp->dsp_epoch = ent->ie_epoch;
 
-	mbs = &dsp->dsp_mbs;
-	mbs->dm_tgt_cnt = ent->ie_dtx_tgt_cnt;
-	mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
-	mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
-	mbs->dm_flags = ent->ie_dtx_mbs_flags;
-	mbs->dm_dte_flags = ent->ie_dtx_flags;
-	memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
+	if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE) {
+		dsp->dsp_inline_mbs = 0;
+		dsp->dsp_mbs = NULL;
+	} else {
+		mbs = (struct dtx_memberships *)(dsp + 1);
+		mbs->dm_tgt_cnt = ent->ie_dtx_tgt_cnt;
+		mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
+		mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
+		mbs->dm_flags = ent->ie_dtx_mbs_flags;
+		mbs->dm_dte_flags = ent->ie_dtx_flags;
+		memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
+
+		dsp->dsp_inline_mbs = 1;
+		dsp->dsp_mbs = mbs;
+	}
 
 	d_list_add_tail(&dsp->dsp_link, &dcsca->dcsca_list);
 	dcsca->dcsca_count++;
@@ -269,7 +283,7 @@ dtx_cleanup_stale(void *arg)
 	while ((dsp = d_list_pop_entry(&dcsca.dcsca_list,
 				       struct dtx_share_peer,
 				       dsp_link)) != NULL)
-		D_FREE(dsp);
+		dtx_dsp_free(dsp);
 
 	dbca->dbca_cleanup_done = 1;
 
@@ -682,22 +696,22 @@ dtx_shares_fini(struct dtx_handle *dth)
 	while ((dsp = d_list_pop_entry(&dth->dth_share_cmt_list,
 				       struct dtx_share_peer,
 				       dsp_link)) != NULL)
-		D_FREE(dsp);
+		dtx_dsp_free(dsp);
 
 	while ((dsp = d_list_pop_entry(&dth->dth_share_abt_list,
 				       struct dtx_share_peer,
 				       dsp_link)) != NULL)
-		D_FREE(dsp);
+		dtx_dsp_free(dsp);
 
 	while ((dsp = d_list_pop_entry(&dth->dth_share_act_list,
 				       struct dtx_share_peer,
 				       dsp_link)) != NULL)
-		D_FREE(dsp);
+		dtx_dsp_free(dsp);
 
 	while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
 				       struct dtx_share_peer,
 				       dsp_link)) != NULL)
-		D_FREE(dsp);
+		dtx_dsp_free(dsp);
 
 	dth->dth_share_tbd_count = 0;
 }

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -110,7 +110,7 @@ extern uint32_t dtx_agg_thd_cnt_lo;
 #define DTX_AGG_AGE_PRESERVE	3
 
 /* The threshold for yield CPU when handle DTX RPC. */
-#define DTX_RPC_YIELD_THD	64
+#define DTX_RPC_YIELD_THD	32
 
 /* The time threshold for triggering DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshold, it will trigger DTX
@@ -131,6 +131,13 @@ extern uint32_t dtx_agg_thd_age_lo;
 #define DTX_RPC_HELPER_THD_MAX	(~0U)
 #define DTX_RPC_HELPER_THD_MIN	18
 #define DTX_RPC_HELPER_THD_DEF	(DTX_THRESHOLD_COUNT + 1)
+
+/*
+ * If the size of dtx_memberships exceeds DTX_INLINE_MBS_SIZE, then load it (DTX mbs)
+ * dynamically when use it to avoid holding a lot of DRAM resource for long time that
+ * may happen on some very large system.
+ */
+#define DTX_INLINE_MBS_SIZE		512
 
 extern uint32_t dtx_rpc_helper_thd;
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -22,6 +22,7 @@ struct dtx_resync_entry {
 	d_list_t		dre_link;
 	daos_epoch_t		dre_epoch;
 	daos_unit_oid_t		dre_oid;
+	uint32_t		dre_inline_mbs:1;
 	uint64_t		dre_dkey_hash;
 	struct dtx_entry	dre_dte;
 };
@@ -46,8 +47,11 @@ dtx_dre_release(struct dtx_resync_head *drh, struct dtx_resync_entry *dre)
 {
 	drh->drh_count--;
 	d_list_del(&dre->dre_link);
-	if (--(dre->dre_dte.dte_refs) == 0)
+	if (--(dre->dre_dte.dte_refs) == 0) {
+		if (dre->dre_inline_mbs == 0)
+			D_FREE(dre->dre_dte.dte_mbs);
 		D_FREE(dre);
+	}
 }
 
 static int
@@ -121,6 +125,8 @@ next:
 
 			dre = d_list_entry(dtes[i], struct dtx_resync_entry,
 					   dre_dte);
+			if (dre->dre_inline_mbs == 0)
+				D_FREE(dre->dre_dte.dte_mbs);
 			D_FREE(dre);
 		}
 	} else {
@@ -403,6 +409,19 @@ dtx_status_handle(struct dtx_resync_args *dra)
 			continue;
 		}
 
+		if (dre->dre_dte.dte_mbs == NULL) {
+			rc = vos_dtx_load_mbs(cont->sc_hdl, &dre->dre_xid, &dre->dre_dte.dte_mbs);
+			if (rc != 0) {
+				if (rc != -DER_NONEXIST)
+					D_WARN("Failed to load mbs, do not know the leader for DTX "
+					       DF_DTI" (ver = %u/%u/%u): rc = %d, skip it.\n",
+					       DP_DTI(&dre->dre_xid), dra->resync_version,
+					       dra->discard_version, dre->dre_dte.dte_ver, rc);
+				dtx_dre_release(drh, dre);
+				continue;
+			}
+		}
+
 		mbs = dre->dre_dte.dte_mbs;
 		D_ASSERT(mbs->dm_tgt_cnt > 0);
 
@@ -481,7 +500,6 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	struct dtx_resync_entry		*dre;
 	struct dtx_entry		*dte;
 	struct dtx_memberships		*mbs;
-	size_t				 size;
 
 	/* We commit the DTXs periodically, there will be not too many DTXs
 	 * to be checked when resync. So we can load all those uncommitted
@@ -528,8 +546,11 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 
 	D_ASSERT(ent->ie_dtx_mbs_dsize > 0);
 
-	size = sizeof(*dre) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize;
-	D_ALLOC(dre, size);
+	if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE)
+		D_ALLOC_PTR(dre);
+	else
+		D_ALLOC(dre, sizeof(*dre) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize);
+
 	if (dre == NULL)
 		return -DER_NOMEM;
 
@@ -537,16 +558,23 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	dre->dre_dkey_hash = ent->ie_dkey_hash;
 
 	dte = &dre->dre_dte;
-	mbs = (struct dtx_memberships *)(dte + 1);
 
-	mbs->dm_tgt_cnt = ent->ie_dtx_tgt_cnt;
-	mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
-	mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
-	mbs->dm_flags = ent->ie_dtx_mbs_flags;
-	mbs->dm_dte_flags = ent->ie_dtx_flags;
-	memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
+	if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE) {
+		dre->dre_inline_mbs = 0;
+		dte->dte_mbs = NULL;
+	} else {
+		mbs = (struct dtx_memberships *)(dte + 1);
 
-	dte->dte_mbs = mbs;
+		mbs->dm_tgt_cnt = ent->ie_dtx_tgt_cnt;
+		mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
+		mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
+		mbs->dm_flags = ent->ie_dtx_mbs_flags;
+		mbs->dm_dte_flags = ent->ie_dtx_flags;
+		memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
+
+		dre->dre_inline_mbs = 1;
+		dte->dte_mbs = mbs;
+	}
 
 out:
 	dre->dre_epoch = ent->ie_epoch;

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -17,12 +17,13 @@
 #define DTX_REFRESH_MAX 4
 
 struct dtx_share_peer {
-	d_list_t		dsp_link;
-	struct dtx_id		dsp_xid;
-	daos_unit_oid_t		dsp_oid;
-	daos_epoch_t		dsp_epoch;
-	uint64_t		dsp_dkey_hash;
-	struct dtx_memberships	dsp_mbs;
+	d_list_t		 dsp_link;
+	struct dtx_id		 dsp_xid;
+	daos_unit_oid_t		 dsp_oid;
+	daos_epoch_t		 dsp_epoch;
+	uint64_t		 dsp_dkey_hash;
+	uint32_t		 dsp_inline_mbs:1;
+	struct dtx_memberships	*dsp_mbs;
 };
 
 /**
@@ -275,6 +276,15 @@ int dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont);
  */
 int dtx_handle_resend(daos_handle_t coh, struct dtx_id *dti,
 		      daos_epoch_t *epoch, uint32_t *pm_ver);
+
+static inline void
+dtx_dsp_free(struct dtx_share_peer *dsp)
+{
+	if (dsp->dsp_inline_mbs == 0)
+		D_FREE(dsp->dsp_mbs);
+
+	D_FREE(dsp);
+}
 
 static inline uint64_t
 dtx_hlc_age2sec(uint64_t hlc)

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -100,6 +100,18 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 	      bool for_refresh);
 
 /**
+ * Load participants information for the given DTX.
+ *
+ * \param coh		[IN]	Container open handle.
+ * \param dti		[IN]	Pointer to the DTX identifier.
+ * \param mbs		[OUT]	Pointer to the DTX participants information.
+ *
+ * \return		Zero on success, negative value if error.
+ */
+int
+vos_dtx_load_mbs(daos_handle_t coh, struct dtx_id *dti, struct dtx_memberships **mbs);
+
+/**
  * Commit the specified DTXs.
  *
  * \param coh	[IN]	Container open handle.

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -309,6 +309,9 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 {
 	struct daos_cpd_disp_ent	*dcde = NULL;
 	struct daos_cpd_sub_req		*dcsr = NULL;
+	struct daos_cpd_req_idx		*dcri_child;
+	struct daos_cpd_req_idx		*dcri_parent;
+	uint32_t			 idx;
 	int				 count;
 	int				 prev = -1;
 	int				 cur = 0;
@@ -334,10 +337,6 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 	dcde->dcde_write_cnt = dcde_parent->dcde_write_cnt;
 
 	for (i = 0; i < count; i++) {
-		struct daos_cpd_req_idx		*dcri_child;
-		struct daos_cpd_req_idx		*dcri_parent;
-		int				 idx;
-
 		dcri_child = &dcde->dcde_reqs[i];
 		dcri_parent = &dcde_parent->dcde_reqs[i];
 		idx = dcri_parent->dcri_req_idx;
@@ -345,24 +344,26 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 
 		dcri_child->dcri_shard_off = dcri_parent->dcri_shard_off;
 		dcri_child->dcri_shard_id = dcri_parent->dcri_shard_id;
-		dcri_child->dcri_req_idx = cur;
 		dcri_child->dcri_padding = dcri_parent->dcri_padding;
 
 		if (idx == prev &&
 		    (dcsr_parent[idx].dcsr_opc != DCSO_UPDATE ||
-		     dcsr_parent[idx].dcsr_update.dcu_ec_split_req == NULL))
-			continue;
+		     dcsr_parent[idx].dcsr_update.dcu_ec_split_req == NULL)) {
+			D_ASSERT(cur >= 1);
 
-		prev = idx;
+			dcri_child->dcri_req_idx = cur - 1;
+			continue;
+		}
 
 		/*
 		 * Only copy the top level data structure for daos_cpd_sub_req. Some DRAM
 		 * area pointed via the pointer inside daos_cpd_sub_req are shared between
 		 * 'dcsr' and 'dcsr_parent'. Because we hold the parent RPC's reference,
-		 * then related DRAM area will not be freeduntil the callback for forwarded
+		 * then related DRAM area will not be freed until the callback for forwarded
 		 * RPC is handled.
 		 */
 		memcpy(&dcsr[cur], &dcsr_parent[idx], sizeof(dcsr[cur]));
+		dcri_child->dcri_req_idx = cur;
 
 		if (dcsr_parent[idx].dcsr_opc == DCSO_UPDATE) {
 			struct daos_cpd_update	*dcu_parent;
@@ -394,6 +395,7 @@ ds_obj_cpd_clone_reqs(struct daos_shard_tgt *tgt, struct daos_cpd_disp_ent *dcde
 			}
 		}
 
+		prev = idx;
 		cur++;
 	}
 
@@ -490,6 +492,7 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 	oci->oci_disp_tgts.ca_arrays = NULL;
 	oci->oci_disp_tgts.ca_count = 0;
 
+	/* It is safe to share the head with parent since we are holding reference on parent RPC. */
 	dcsh = ds_obj_cpd_get_dcsh(dca->dca_rpc, dca->dca_idx);
 	head_dcs->dcs_type = DCST_HEAD;
 	head_dcs->dcs_nr = 1;
@@ -525,6 +528,8 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 		remote_arg->cpd_reqs = dcsr;
 		remote_arg->cpd_desc = dcde;
 	} else {
+		remote_arg->cpd_reqs = NULL;
+		remote_arg->cpd_desc = NULL;
 		dcsr = dcsr_parent;
 		dcde = dcde_parent;
 		rc = total;

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -105,22 +105,22 @@ vts_dtx_end(struct dtx_handle *dth)
 		while ((dsp = d_list_pop_entry(&dth->dth_share_cmt_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 
 		while ((dsp = d_list_pop_entry(&dth->dth_share_abt_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 
 		while ((dsp = d_list_pop_entry(&dth->dth_share_act_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 
 		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 
 		dth->dth_share_tbd_count = 0;
 	}

--- a/src/vos/vos_tls.h
+++ b/src/vos/vos_tls.h
@@ -115,7 +115,7 @@ vos_dth_set(struct dtx_handle *dth)
 		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
 					       struct dtx_share_peer,
 					       dsp_link)) != NULL)
-			D_FREE(dsp);
+			dtx_dsp_free(dsp);
 		dth->dth_share_tbd_count = 0;
 	}
 


### PR DESCRIPTION
master-commit: 839d77ead4471eb3a759573453a8ad23fcca1c1c

The patch fixes the following DTX related issues:

1. Use the address of tree handle for dtx_rpc_post. If we directly use the value of tree handle as dtx_rpc_post()'s input parameter, then it may be DAOS_HDL_INVAL before DTX helper ULT being scheduled. That will cause memory leak.

2. Abort remote DTX entry before local one. The DTX abort maybe triggered by dtx_leader_end for RPC timeout on some remote DTX participant(s). Under such case, client side RPC sponsor may also hit the RPC timeout and resends related RPC to the leader. To avoid DTX abort and resend RPC forwarding being executed in parallel, we will abort local DTX after remote done, before that the logic of handling resent RPC on server will find the local pinned DTX entry then notify related client to resend RPC sometime later.

3. More frequent CPU yield during DTX RPCs dispatch. It is possible that the DTX may contains a lot of participants. When we commit or abort such DTX, the leader needs to send RPCs to all related participant. That will take a lot of CPU cycles. Under such case, related DTX operation ULT will yield to avoid blocking others for too long time. The patch reduces the yield interval from per 64-RPCs to per 32-RPCs.

4. Dynamically load DTX participants information (dtx_memberships). For the transaction with very large participants information, handle related DTX (such as for DTX resync, for cleanup stale DTX entries) may take some time, expecially under the case of system very busy. If we pre-load all related MBS information in DRAM before really handle them, it will hold a lot of DRAM resource for long time. That may cause server OOM. The patch adjusts DTX MBS load policy as loading large MBS when use it instead of pre-loading.

5. Fix some reassemble issue for CPD RPC. The reassemble logic on leader has some defect that may cause access DRAM out of boundary. The patch also fixes it.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
