### PR TITLE
DAOS-11924 dtx: handle race among DTX commit and DTX refresh

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2225,7 +2225,7 @@ vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dti, uint32_t flags)
 	if (rc == -DER_NONEXIST) {
 		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
 		if (rc == 0) {
-			D_ERROR("Not allow to set flag on committed/aborted DTX entry "DF_DTI"\n",
+			D_ERROR("Not allow to set flag on committed (1) DTX entry "DF_DTI"\n",
 				DP_DTI(dti));
 			D_GOTO(out, rc = -DER_NO_PERM);
 		}
@@ -2238,7 +2238,7 @@ vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dti, uint32_t flags)
 	if (dae->dae_committable || dae->dae_committed || dae->dae_aborted) {
 		D_ERROR("Not allow to set flag on the %s DTX entry "DF_DTI"\n",
 			dae->dae_committable ? "committable" :
-			dae->dae_committed ? "committed" : "aborted", DP_DTI(dti));
+			dae->dae_committed ? "committed (2)" : "aborted", DP_DTI(dti));
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 


### PR DESCRIPTION
master-commit: ca354e7bfbe3994f4a14d19d0a16435ac4225cf7

There is race among DTX commit, DTX aggregation and DTX refresh: DTX refresh is triggered before some DTX entry committed on the non-leader. But such DTX entry has already been committed on the leader and removed by DTX aggregation locally very soon. Then the DTX refresh for such DTX entry will get -DER_TX_UNCERTAIN from the leader. That will cause non-leader to mark such DTX as DTE_ORPHAN via vos_dtx_set_flags(). But just during the DTX refresh, the DTX is committed on current non-leader (after some long time of delay), then the vos_dtx_set_flags() will get failure.

Under such race case, the DTX refresh needs to handle related DTX as committed one instead of report failure.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
