### PR TITLE
DAOS-12011 test: setup fuse3.conf

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -821,7 +821,8 @@ class Launch():
             logger.debug(message)
         test_result.status = TestResult.PASS
 
-    def _fail_test(self, test_result, fail_class, fail_reason, exc_info=None):
+    @staticmethod
+    def _fail_test(test_result, fail_class, fail_reason, exc_info=None):
         """Set the test result as failed.
 
         Args:
@@ -1013,6 +1014,12 @@ class Launch():
             return self.get_exit_status(1, message, "Setup", sys.exc_info())
         if args.modify:
             return self.get_exit_status(0, "Modifying test yaml files complete")
+
+        try:
+            self.setup_fuse_config(args.test_servers | args.test_clients)
+        except LaunchException as error:
+            # Warn but don't fail
+            logger.warning(error)
 
         # Get the core file pattern information
         core_files = self._get_core_file_pattern(
@@ -1739,6 +1746,30 @@ class Launch():
             logger.debug(
                 msg_format, test.name.order, test.test_file, test.yaml_file, test.hosts.servers,
                 test.hosts.clients)
+
+    @staticmethod
+    def setup_fuse_config(hosts):
+        """Set up the system fuse config file.
+
+        Args:
+            hosts (NodeSet): hosts to setup
+
+        Raises:
+            LaunchException: if setup fails
+
+        """
+        logger.info("Setting up fuse config")
+        fuse_configs = ("/etc/fuse.conf", "/etc/fuse3.conf")
+        command = ";".join([
+            "if [ -e {0} ]",
+            "then ls -l {0}",
+            "(grep -q '^user_allow_other$' {0} || echo user_allow_other | sudo tee -a {0})",
+            "cat {0}",
+            "fi"
+        ])
+        for config in fuse_configs:
+            if not run_remote(logger, hosts, command.format(config)).passed:
+                raise LaunchException(f"Failed to setup {config}")
 
     @staticmethod
     def _replace_yaml_file(yaml_file, args, yaml_dir):

--- a/src/tests/ftest/scripts/setup_nodes.sh
+++ b/src/tests/ftest/scripts/setup_nodes.sh
@@ -73,14 +73,6 @@ if [ -f /usr/lib/daos/TESTING/ftest/test.cov ]; then
     chmod 777 /tmp/test.cov
 fi
 
-echo Setting up fuse.conf
-ls -l /etc/fuse.conf || true
-if [ -e /etc/fuse.conf ]
-then
-        echo user_allow_other | sudo tee -a /etc/fuse.conf
-        cat /etc/fuse.conf
-fi
-
 # make sure to set up for daos_agent. The test harness will take care of
 # creating the /var/run/daos_{agent,server} directories when needed.
 sudo bash -c "set -ex


### PR DESCRIPTION
Setup both fuse.conf and fuse3.conf to account for OS differences.

Test-tag: test_dfuse_mu_mount pr,vm
Skip-func-test-leap15: false
Skip-unit-tests: true
Skip-fault-injection-test: true

Required-githooks: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [x] You are the appropriate gatekeeper to be landing the patch.
* [x] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [x] Githooks were used. If not, request that user install them and check copyright dates.
* [x] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [x] All builds have passed.  Check non-required builds for any new compiler warnings.
* [x] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [x] If applicable, the PR has addressed any potential version compatibility issues.
* [x] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [x] Extra checks if forced landing is requested
  * [x] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [x] No new NLT or valgrind warnings.  Check the classic view.
  * [x] Quick-build or Quick-functional is not used.
* [x] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
