### PR TITLE
DAOS-11907 dfs: check passed in object classes if they satisfy the RF

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -237,6 +237,9 @@ int daos_oclass_fit_max(daos_oclass_id_t oc_id, int domain_nr, int target_nr,
 bool daos_oclass_is_valid(daos_oclass_id_t oc_id);
 int daos_obj_get_oclass(daos_handle_t coh, enum daos_otype_t type, daos_oclass_hints_t hints,
 			uint32_t args, daos_oclass_id_t *cid);
+int
+daos_oclass_cid2allowedfailures(daos_oclass_id_t oc_id, uint32_t *tf);
+
 #define daos_oclass_grp_off_by_shard(oca, shard)				\
 	(rounddown(shard, daos_oclass_grp_size(oca)))
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1320,7 +1320,7 @@ dc_obj_redun_check(struct dc_object *obj, daos_handle_t coh)
 	D_ASSERT(cont_tf >= 0);
 	if (obj_tf < cont_tf) {
 		rc = -DER_INVAL;
-		D_ERROR(DF_OID" obj:cont tolerate faiures %d:%d, "DF_RC"\n",
+		D_ERROR(DF_OID" obj:cont tolerate failures %d:%d, "DF_RC"\n",
 			DP_OID(obj->cob_md.omd_id), obj_tf, cont_tf,
 			DP_RC(rc));
 		return rc;

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -20,6 +20,18 @@ static struct daos_obj_class  *oclass_ident2cl(daos_oclass_id_t oc_id,
 					       uint32_t *nr_grps);
 static struct daos_obj_class  *oclass_resil2cl(struct daos_oclass_attr *ca);
 
+int
+daos_oclass_cid2allowedfailures(daos_oclass_id_t oc_id, uint32_t *tf)
+{
+	struct daos_obj_class *oc;
+
+	oc = oclass_ident2cl(oc_id, NULL);
+	if (oc == NULL)
+		return -DER_INVAL;
+	*tf = oc->oc_resil_degree;
+	return 0;
+}
+
 /**
  * Find the object class attributes for the provided @oid.
  */


### PR DESCRIPTION
when creating a container, the file object class is not checked since we only create the root directory and SB object. Add a check to see if the file oclass is passed, it satisfies the RF.

Test-tag: pr oc_selection

Required-githooks: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
