### PR TITLE
DAOS-12025 control: Add os.ErrDeadlineExceeded to retryable errors

### DIFF
--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -87,6 +87,7 @@ func outputJSON(out io.Writer, in interface{}, cmdErr error) error {
 		} else {
 			status = int(daos.MiscError)
 		}
+		in = nil // response should be null if err isn't
 	}
 
 	data, err := json.MarshalIndent(struct {

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -9,6 +9,7 @@ package control
 import (
 	"context"
 	"math/rand"
+	"os"
 	"sync"
 	"time"
 
@@ -222,14 +223,16 @@ func setDeadlineIfUnset(parent context.Context, req UnaryRequest) (context.Conte
 	return context.WithDeadline(parent, rd)
 }
 
-// isTimeout returns true if the error is a context timeout error.
+// isTimeout returns true if the error is a context/connection timeout error.
 func isTimeout(err error) bool {
 	if err == nil {
 		return false
 	}
 
 	cause := errors.Cause(err)
-	return cause == context.DeadlineExceeded || status.Code(cause) == codes.DeadlineExceeded
+	return cause == context.DeadlineExceeded ||
+		cause == os.ErrDeadlineExceeded ||
+		status.Code(cause) == codes.DeadlineExceeded
 }
 
 // wrapReqTimeout checks the error for a timeout and returns a


### PR DESCRIPTION
This error can occur in certain circumstances and should be
retryable. Also fixes the JSON output handler to ensure that
the response field is null if there was an error.
