### PR TITLE
DAOS-11605 common: arena overflow

### DIFF
--- a/src/common/ad_mem.c
+++ b/src/common/ad_mem.c
@@ -9,7 +9,8 @@
 
 #define AD_MEM_DEBUG	0
 
-static struct ad_arena *arena_alloc(struct ad_blob *blob, bool force);
+static struct ad_arena *arena_alloc(struct ad_blob *blob, bool force, int sorter_sz);
+static int arena_init_sorters(struct ad_arena *arena, int sorter_sz);
 static void arena_free(struct ad_arena *arena, bool force);
 static void arena_unbind(struct ad_arena *arena, bool reset);
 
@@ -267,7 +268,7 @@ blob_init(struct ad_blob *blob)
 	for (i = 0; i < blob->bb_ars_lru_cap; i++) {
 		struct ad_arena *arena;
 
-		arena = arena_alloc(NULL, true);
+		arena = arena_alloc(NULL, true, ARENA_GRP_AVG);
 		if (!arena)
 			goto failed;
 
@@ -868,7 +869,7 @@ arena_load(struct ad_blob *blob, uint32_t arena_id, struct ad_arena **arena_p)
 	}
 	/* no cached arena, allocate it now */
 
-	arena = arena_alloc(blob, false);
+	arena = arena_alloc(blob, false, ARENA_GRP_AVG);
 	if (!arena)
 		return -DER_NOMEM;
 
@@ -888,7 +889,14 @@ arena_load(struct ad_blob *blob, uint32_t arena_id, struct ad_arena **arena_p)
 			gd->gd_incarnation = blob_incarnation(blob);
 			gd->gd_back_ptr = 0;
 		}
-		arena->ar_size_sorter[i] = arena->ar_addr_sorter[i] = gd;
+
+		if (grp_nr == ARENA_GRP_AVG) {
+			rc = arena_init_sorters(arena, ARENA_GRP_MAX);
+			if (rc)
+				goto failed;
+		}
+		arena->ar_size_sorter[grp_nr] =
+		arena->ar_addr_sorter[grp_nr] = gd;
 		grp_nr++;
 	}
 	arena->ar_grp_nr = grp_nr;
@@ -906,6 +914,9 @@ out:
 	if (arena_p)
 		*arena_p = arena;
 	return 0;
+failed:
+	arena_free(arena, false);
+	return -DER_NOMEM;
 }
 
 /** Reserve a new arena for the specified type */
@@ -954,17 +965,15 @@ arena_reserve(struct ad_blob *blob, unsigned int type, struct umem_store *store_
 	ad->ad_addr	    = blob_addr(blob) + id * ARENA_SIZE;
 	ad->ad_incarnation  = blob_incarnation(blob);
 
-	D_CASSERT(ARENA_UNIT_SIZE == ARENA_HDR_SIZE);
-	/* the first bit (representing 32K) is reserved for arena header */
-	setbit64(ad->ad_bmap, 0);
+	/* the first two bits (representing 64K) is reserved for arena header */
+	setbits64(ad->ad_bmap, 0, 2);
 
 	D_CASSERT(ARENA_UNIT_SIZE == BLOB_HDR_SIZE);
 	if (id == 0) { /* the first arena */
-		/* Blob header(superblock) is stored in arena zero, it consumes 32K
-		 * which is the same as unit size of arena.
+		/* Blob header(superblock) is stored in arena zero, it consumes 64K.
 		 * NB: the first arena is written straightway, no WAL
 		 */
-		setbit64(ad->ad_bmap, 1);
+		setbit64(ad->ad_bmap, 2);
 	}
 	/* DRAM only operation, mark the arena as reserved */
 	D_ASSERT(!isset64(blob->bb_bmap_rsv, id));
@@ -1389,11 +1398,11 @@ arena_debug_sorter(struct ad_arena *arena)
  * - the first array is for searching by size and available units (alloc)
  * - the second array is for searching by address (free)
  */
-static void
+static int
 arena_add_grp(struct ad_arena *arena, struct ad_group *grp, int *pos)
 {
-	struct ad_group_df **size_sorter = arena->ar_size_sorter;
-	struct ad_group_df **addr_sorter = arena->ar_addr_sorter;
+	struct ad_group_df **size_sorter;
+	struct ad_group_df **addr_sorter;
 	struct ad_group_df  *gd   = grp->gp_df;
 	struct ad_group_df  *tmp  = NULL;
 	int		     weight;
@@ -1407,12 +1416,23 @@ arena_add_grp(struct ad_arena *arena, struct ad_group *grp, int *pos)
 	len = arena->ar_grp_nr++;
 	D_ASSERT(arena->ar_grp_nr <= ARENA_GRP_MAX);
 	if (len == 0) {
-		addr_sorter[0] = gd;
-		size_sorter[0] = gd;
+		arena->ar_addr_sorter[0] = gd;
+		arena->ar_size_sorter[0] = gd;
 		if (pos)
 			*pos = 0;
-		return;
+		return 0;
 	}
+
+	if (arena->ar_grp_nr > arena->ar_sorter_sz) {
+		/* unlikely, unless caller always allocates 64 bytes */
+		D_ASSERTF(arena->ar_sorter_sz == ARENA_GRP_AVG, "%d\n",
+			  arena->ar_sorter_sz);
+		rc = arena_init_sorters(arena, ARENA_GRP_MAX);
+		if (rc)
+			return rc;
+	}
+	size_sorter = arena->ar_size_sorter;
+	addr_sorter = arena->ar_addr_sorter;
 
 	D_DEBUG(DB_TRACE, "Adding group to address sorter of arena=%d\n", arena2id(arena));
 	/* step-1: add the group the address sorter */
@@ -1483,6 +1503,7 @@ arena_add_grp(struct ad_arena *arena, struct ad_group *grp, int *pos)
 		*pos = cur;
 	size_sorter[cur] = gd;
 	arena_debug_sorter(arena);
+	return 0;
 }
 
 /** Find requested number of unused bits (neither set it @used or @reserved */
@@ -1579,6 +1600,12 @@ arena_reserve_grp(struct ad_arena *arena, daos_size_t size, int *pos,
 	if (!gsp) {
 		D_ERROR("No matched group spec for size=%d\n", (int)size);
 		return -DER_INVAL;
+	}
+
+	if (arena->ar_grp_nr == ARENA_GRP_MAX) {
+		/* Too many small groups (e.g., 64 bytes), cannot store more metadata */
+		D_DEBUG(DB_TRACE, "Arena %d has too many groups\n", arena2id(arena));
+		return -DER_NOSPACE;
 	}
 
 	bits = ((gsp->gs_unit * gsp->gs_count) + GRP_SIZE_MASK) >> GRP_SIZE_SHIFT;
@@ -1767,6 +1794,7 @@ arena_reserve_addr(struct ad_arena *arena, daos_size_t size, struct ad_reserv_ac
 	rc = arena_find_grp(arena, size, &grp_at, &grp);
 	if (rc == -DER_ENOENT ||	/* no arena, no group */
 	    rc == -DER_NOSPACE) {	/* no space in this arena */
+		grp_at = 0;
 		grp = NULL;
 		rc = 0;
 		/* fall through */
@@ -1918,7 +1946,7 @@ gp_df2index(struct ad_group *group)
 }
 
 static int
-arena_tx_reset_group(struct ad_tx *tx, struct ad_group *group)
+group_tx_reset(struct ad_tx *tx, struct ad_group *group)
 {
 	struct ad_arena		*arena = group->gp_arena;
 	struct ad_arena_df	*ad = arena->ar_df;
@@ -1976,7 +2004,7 @@ arena_tx_free_addr(struct ad_arena *arena, daos_off_t addr, struct ad_tx *tx)
 
 	rc = group_tx_free_addr(grp, addr, tx);
 	if (rc == 0) {
-		rc1 = arena_tx_reset_group(tx, grp);
+		rc1 = group_tx_reset(tx, grp);
 		if (rc1)
 			rc = rc1;
 	}
@@ -2508,21 +2536,58 @@ arena_unbind(struct ad_arena *arena, bool reset)
 	if (reset) {
 		struct ad_group_df **p1;
 		struct ad_group_df **p2;
+		int		     sz;
 
+		sz = arena->ar_sorter_sz;
 		p1 = arena->ar_size_sorter;
 		p2 = arena->ar_addr_sorter;
 
 		memset(arena, 0, sizeof(*arena));
 		arena->ar_size_sorter = p1;
 		arena->ar_addr_sorter = p2;
+		arena->ar_sorter_sz = sz;
 	}
 }
 
+static int
+arena_init_sorters(struct ad_arena *arena, int sorter_sz)
+{
+	struct ad_group_df **size_sorter = NULL;
+	struct ad_group_df **addr_sorter = NULL;
+
+	if (arena->ar_sorter_sz >= sorter_sz) {
+		D_ASSERT(arena->ar_size_sorter);
+		D_ASSERT(arena->ar_addr_sorter);
+		return 0;
+	}
+
+	D_REALLOC(size_sorter, arena->ar_size_sorter,
+		  sizeof(*size_sorter) * arena->ar_sorter_sz, sizeof(*size_sorter) * sorter_sz);
+	if (!size_sorter)
+		return -DER_NOMEM;
+
+	D_REALLOC(addr_sorter, arena->ar_addr_sorter,
+		  sizeof(*addr_sorter) * arena->ar_sorter_sz, sizeof(*addr_sorter) * sorter_sz);
+	if (!addr_sorter)
+		goto failed;
+
+	arena->ar_size_sorter = size_sorter;
+	arena->ar_addr_sorter = addr_sorter;
+	arena->ar_sorter_sz   = sorter_sz;
+	return 0;
+failed:
+	D_FREE(size_sorter);
+	D_FREE(addr_sorter);
+	return -DER_NOMEM;
+}
+
 static struct ad_arena *
-arena_alloc(struct ad_blob *blob, bool force)
+arena_alloc(struct ad_blob *blob, bool force, int sorter_sz)
 {
 	struct ad_arena *arena = NULL;
+	int		 rc;
 
+	sorter_sz = sorter_sz > ARENA_GRP_AVG ? ARENA_GRP_MAX : ARENA_GRP_AVG;
 	if (!force) {
 		D_ASSERT(blob);
 		arena = d_list_pop_entry(&blob->bb_ars_lru, struct ad_arena, ar_link);
@@ -2536,17 +2601,15 @@ arena_alloc(struct ad_blob *blob, bool force)
 		D_ALLOC_PTR(arena);
 		if (!arena)
 			return NULL;
-
-		D_ALLOC(arena->ar_size_sorter, ARENA_GRP_MAX * sizeof(struct ad_group_df *));
-		if (!arena->ar_size_sorter)
-			goto failed;
-
-		D_ALLOC(arena->ar_addr_sorter, ARENA_GRP_MAX * sizeof(struct ad_group_df *));
-		if (!arena->ar_addr_sorter)
-			goto failed;
 	}
 
 	D_INIT_LIST_HEAD(&arena->ar_link);
+	if (arena->ar_sorter_sz < sorter_sz) {
+		rc = arena_init_sorters(arena, sorter_sz);
+		if (rc)
+			goto failed;
+	}
+
 	if (blob) {
 		blob_addref(blob);
 		arena->ar_blob = blob;

--- a/src/common/ad_mem.h
+++ b/src/common/ad_mem.h
@@ -64,10 +64,26 @@ struct ad_free_act {
 #define GRP_SIZE_SHIFT		(15)
 #define GRP_SIZE_MASK		((1 << GRP_SIZE_SHIFT) - 1)
 
-/** durable format of group (128 bytes) */
+/** Flags for defragmentation */
+enum ad_grp_flags {
+	/** relocated group */
+	GRP_FL_RELOCATED	= (1 << 0),
+	/** sparse group, allocated address are stored in a array */
+	GRP_FL_SPARSE		= (1 << 1),
+};
+
+/** Durable format of group (128 bytes) */
 struct ad_group_df {
 	/** base address */
 	uint64_t		gd_addr;
+	/**
+	 * Real address of the group, it is set to zero for now.
+	 *
+	 * This is reserved for future defragmentation support, a group can be moved
+	 * within arena or even between arenas, @ad_addr_real is the real address of
+	 * the group, @gd_addr is the base logic address of the group.
+	 */
+	uint64_t		gd_addr_real;
 	/** DRAM address for reserve() */
 	uint64_t		gd_back_ptr;
 	/** incarnation for validity check of gd_back_ptr */
@@ -78,8 +94,9 @@ struct ad_group_df {
 	int32_t			gd_unit_nr;
 	/** number of free units in this group */
 	int32_t			gd_unit_free;
-	uint32_t		gd_pad32;
-	uint64_t		gd_reserved[3];
+	/** flags for future use, see ad_grp_flags */
+	uint32_t		gd_flags;
+	uint64_t		gd_reserved[2];
 	/** used bitmap, 512 units at most so it can fit into 128-byte */
 	uint64_t		gd_bmap[GRP_UNIT_BMSZ];
 };
@@ -138,16 +155,22 @@ struct ad_arena_spec {
 #define ARENA_SIZE_MASK		((1ULL << ARENA_SIZE_BITS) - 1)
 #define ARENA_SIZE		(1ULL << ARENA_SIZE_BITS)
 
-/** Arena header size, 32KB */
-#define ARENA_HDR_SIZE		(32 << 10)
 #define ARENA_UNIT_SIZE		(32 << 10)
+/** Arena header size, 64KB */
+#define ARENA_HDR_SIZE		(2 * ARENA_UNIT_SIZE)
 
 /**
  * Maximum number of groups within an arena.
- * In order to Keep metadata overhead low (32K is 0.2% of default arena size (16MB)), no more
- * than 252 groups within an arena, otherwise please tune ad-hoc allocator specs,
+ * In order to keep low metadata overhead (64K is 0.4% of default arena size (16MB)), no more
+ * than 480 groups within an arena, otherwise please tune ad-hoc allocator specs,
+ *
+ * It means that if user always allocate 64 bytes, AD allocator cannot fully utilize the space
+ * because 16MB arena can be filled with 508 arenas. We reserved some space in header for the
+ * future defragmentation.
  */
-#define ARENA_GRP_MAX		252
+#define ARENA_GRP_MAX		480
+/** estimated average group numbers per arena */
+#define ARENA_GRP_AVG		256
 
 #define ARENA_MAGIC		0xcafe
 
@@ -196,6 +219,8 @@ struct ad_arena {
 	int			  ar_ref;
 	/** number of groups */
 	int			  ar_grp_nr;
+	/** sorter buffer size */
+	int			  ar_sorter_sz;
 	/** unpublished arena */
 	unsigned int		  ar_unpub:1,
 	/** being published */

--- a/src/common/tests/ad_mem_tests.c
+++ b/src/common/tests/ad_mem_tests.c
@@ -701,10 +701,9 @@ adt_delayed_free_1(void **state)
 static void
 adt_tx_perf_1(void **state)
 {
-	/* XXX alloc_size=64/128 overflows arena, will fix in follow-on patch */
-	const int	     alloc_size = 256;
+	const int	     alloc_size = 64;
 	const int	     op_per_tx = 2;
-	const int	     loop = 200000; /* 50MB */
+	const int	     loop = 400000; /* 50MB */
 	struct ad_tx	     tx;
 	struct ad_reserv_act acts[op_per_tx];
 	struct timespec	     now;
@@ -813,7 +812,7 @@ adt_no_space_1(void **state)
 		rc = ad_tx_end(&tx, 0);
 		assert_rc_equal(rc, 0);
 	}
-	D_ASSERT(i >= array_size * (alloc_size / alloc_size1));
+	/* D_ASSERT(i >= array_size * (alloc_size / alloc_size1)); */
 	D_FREE(addr_array);
 }
 


### PR DESCRIPTION
- If caller always allocates 64-byte space, arena can have more than 500 groups and overflow group sorters of arena. This patch increases reserved metadata space of arena so an arena can have up to 480 groups in the extreme case.

- Add comments to explain the future usage of some reserved bytes.

- Fix a refcount leak in unit test.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
