### PR TITLE
DAOS-12038 dfs: add file_oclass option for DFS container creation

### DIFF
--- a/src/client/dfs/README.md
+++ b/src/client/dfs/README.md
@@ -55,10 +55,13 @@ A-key: "DFS_CHUNK_SIZE"
 single-value (uint64_t): Default chunk size for files in this container
 
 A-key: "DFS_OBJ_CLASS"
-single-value (uint16_t): Default object class for files in this container
+single-value (uint16_t): Default object class for all objects in this container
 
 A-key: "DFS_DIR_OBJ_CLASS"
 single-value (uint16_t): Default object class for directories in this container
+
+A-key: "DFS_FILE_OBJ_CLASS"
+single-value (uint16_t): Default object class for files in this container
 
 A-key: "DFS_MODE"
 single-value (uint16_t): Consistency mode of this container (Relaxed vs Balanced)

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -727,6 +727,7 @@ create_cont(daos_handle_t poh, struct duns_attr_t *attrp, bool create_with_label
 		dfs_attr.da_id = 0;
 		dfs_attr.da_oclass_id = attrp->da_oclass_id;
 		dfs_attr.da_dir_oclass_id = attrp->da_dir_oclass_id;
+		dfs_attr.da_file_oclass_id = attrp->da_file_oclass_id;
 		dfs_attr.da_chunk_size = attrp->da_chunk_size;
 		dfs_attr.da_props = attrp->da_props;
 		if (attrp->da_hints[0] != 0)

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -63,7 +63,7 @@ typedef struct {
 	uint64_t		da_id;
 	/** Default Chunk size for all files in container */
 	daos_size_t		da_chunk_size;
-	/** Default Object Class for all files in the container */
+	/** Default Object Class for all objects in the container */
 	daos_oclass_id_t	da_oclass_id;
 	/** DAOS properties on the DFS container */
 	daos_prop_t		*da_props;
@@ -74,6 +74,8 @@ typedef struct {
 	uint32_t		da_mode;
 	/** Default Object Class for all directories in the container */
 	daos_oclass_id_t	da_dir_oclass_id;
+	/** Default Object Class for all files in the container */
+	daos_oclass_id_t	da_file_oclass_id;
 	/**
 	 * Comma separated hints for POSIX container creation of the format: "type:hint".
 	 * examples include: "file:single,dir:max", "directory:single,file:max", etc.

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -48,7 +48,7 @@ enum {
 struct duns_attr_t {
 	/** IN/OUT: Container layout (POSIX, HDF5, Python, etc.) */
 	daos_cont_layout_t	da_type;
-	/** IN: (Optional) For a POSIX container, set a default object class for all files. */
+	/** IN: (Optional) For a POSIX container, set a default object class for all objects. */
 	daos_oclass_id_t	da_oclass_id;
 	/** IN: (Optional) For a POSIX container, set a default chunk size for all files. */
 	daos_size_t		da_chunk_size;
@@ -116,6 +116,8 @@ struct duns_attr_t {
 	uuid_t			da_cuuid;
 	/** IN: (Optional) For a POSIX container, set a default object class for all directories. */
 	daos_oclass_id_t	da_dir_oclass_id;
+	/** IN: (Optional) For a POSIX container, set a default object class for all files. */
+	daos_oclass_id_t	da_file_oclass_id;
 	/** IN: (Optional) For a POSIX container, set hints for file and dir object classes. */
 	char			da_hints[DAOS_CONT_HINT_MAX_LEN];
 };

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -569,6 +569,7 @@ cont_create_hdlr(struct cmd_args_s *ap)
 		attr.da_id = 0;
 		attr.da_oclass_id = ap->oclass;
 		attr.da_dir_oclass_id = ap->dir_oclass;
+		attr.da_file_oclass_id = ap->file_oclass;
 		attr.da_chunk_size = ap->chunk_size;
 		attr.da_props = ap->props;
 		attr.da_mode = ap->mode;
@@ -615,6 +616,7 @@ cont_create_uns_hdlr(struct cmd_args_s *ap)
 	dattr.da_type = ap->type;
 	dattr.da_oclass_id = ap->oclass;
 	dattr.da_dir_oclass_id = ap->dir_oclass;
+	dattr.da_file_oclass_id = ap->file_oclass;
 	dattr.da_chunk_size = ap->chunk_size;
 	if (ap->hints)
 		strncpy(dattr.da_hints, ap->hints, DAOS_CONT_HINT_MAX_LEN - 1);

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -97,6 +97,7 @@ struct cmd_args_s {
 	daos_cont_layout_t	type;		/* --type cont type */
 	daos_oclass_id_t	oclass;		/* --oclass object class */
 	daos_oclass_id_t	dir_oclass;	/* --dir_oclass object class */
+	daos_oclass_id_t	file_oclass;	/* --file_oclass object class */
 	uint32_t		mode;		/* --posix consistency mode */
 	char			*hints;		/* --posix hints */
 	daos_size_t		chunk_size;	/* --chunk_size of cont objs */

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1437,6 +1437,7 @@ def create_cont(conf,
                 path=None,
                 oclass=None,
                 dir_oclass=None,
+                file_oclass=None,
                 hints=None,
                 valgrind=False,
                 log_check=True,
@@ -1463,6 +1464,9 @@ def create_cont(conf,
 
     if dir_oclass:
         cmd.extend(['--dir_oclass', dir_oclass])
+
+    if file_oclass:
+        cmd.extend(['--file_oclass', file_oclass])
 
     if hints:
         cmd.extend(['--hints', hints])
@@ -1694,7 +1698,7 @@ class PosixTests():
         """Test container object class options"""
 
         container = create_cont(self.conf, self.pool.id(), ctype="POSIX", label='oclass_test',
-                                oclass='S1', dir_oclass='S2')
+                                oclass='S1', dir_oclass='S2', file_oclass='S4')
         run_daos_cmd(self.conf,
                      ['container', 'query',
                       self.pool.id(), container],
@@ -1724,7 +1728,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(rc)
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, 'S1', '1048576')
+        assert check_dfs_tool_output(output, 'S4', '1048576')
 
         if dfuse.stop():
             self.fatal_errors = True


### PR DESCRIPTION
Change oclass to be the default for all objects, and add a new option for file_oclass (dir_oclass is already there).

Features: dfs
Required-githooks: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
