### PR TITLE
DAOS-9799 chk: Allow checker policies to be set all-interactive

### DIFF
--- a/src/control/lib/ui/bool_flags.go
+++ b/src/control/lib/ui/bool_flags.go
@@ -1,0 +1,35 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package ui
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// EnabledFlag allows a flag to be optionally set to a boolean value.
+type EnabledFlag struct {
+	Set     bool
+	Enabled bool
+}
+
+// UnmarshalFlag implements the flags.Unmarshaler interface.
+func (f *EnabledFlag) UnmarshalFlag(fv string) error {
+	f.Set = true
+
+	switch strings.ToLower(fv) {
+	case "true", "1", "yes", "on":
+		f.Enabled = true
+	case "false", "0", "no", "off":
+		f.Enabled = false
+	default:
+		return errors.Errorf("invalid boolean value %q", fv)
+	}
+
+	return nil
+}

--- a/src/control/lib/ui/bool_flags_test.go
+++ b/src/control/lib/ui/bool_flags_test.go
@@ -1,0 +1,40 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+)
+
+func TestUI_EnabledFlag(t *testing.T) {
+	trueVals := []string{"true", "1", "yes", "on"}
+	falseVals := []string{"false", "0", "no", "off"}
+
+	for _, val := range trueVals {
+		testFlag := EnabledFlag{}
+		t.Run(val, func(t *testing.T) {
+			test.CmpErr(t, nil, testFlag.UnmarshalFlag(val))
+		})
+		test.AssertTrue(t, testFlag.Set, "not set")
+		test.AssertTrue(t, testFlag.Enabled, "not enabled")
+	}
+	for _, val := range falseVals {
+		testFlag := EnabledFlag{}
+		t.Run(val, func(t *testing.T) {
+			test.CmpErr(t, nil, testFlag.UnmarshalFlag(val))
+		})
+		test.AssertTrue(t, testFlag.Set, "not set")
+		test.AssertFalse(t, testFlag.Enabled, "enabled")
+	}
+
+	testFlag := EnabledFlag{}
+	if err := testFlag.UnmarshalFlag("invalid"); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
Provides two new set-policy flags:
  * dmg check set-policy --all-interactive
  * dmg check set-policy --reset-defaults

These flags can be used instead of setting each policy's action
individually.

Additionally, adds UI support for the new checker flags added
in a previous commit.
  * dmg check start --auto=[on|off] --failout=[on|off]

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
