### PR TITLE
DAOS-12041 object: dc_set_oclass should consider small domain_nr

### DIFF
--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -229,13 +229,17 @@ daos_oclass_fit_max(daos_oclass_id_t oc_id, int domain_nr, int target_nr,
 	struct daos_oclass_attr	 ca;
 	int grp_size;
 	uint32_t nr_grps;
+	int rc;
 
 	D_ASSERT(target_nr > 0);
 	D_ASSERT(domain_nr > 0);
 
 	oc = oclass_ident2cl(oc_id, &nr_grps);
-	if (!oc)
-		return -DER_INVAL;
+	if (!oc) {
+		rc = -DER_INVAL;
+		D_ERROR("oclass_ident2cl(oc_id %d), failed "DF_RC"\n", oc_id, DP_RC(rc));
+		return rc;
+	}
 
 	memcpy(&ca, &oc->oc_attr, sizeof(ca));
 	ca.ca_grp_nr = nr_grps;
@@ -738,6 +742,7 @@ dc_set_oclass(uint64_t rf_factor, int domain_nr, int target_nr,
 	uint16_t rdd;
 	uint32_t grp_size;
 	uint32_t grp_nr;
+	int      rc;
 
 	rdd = hints & DAOS_OCH_RDD_MASK;
 	shd = hints & DAOS_OCH_SHD_MASK;
@@ -746,7 +751,7 @@ dc_set_oclass(uint64_t rf_factor, int domain_nr, int target_nr,
 	switch (rf_factor) {
 	default:
 	case DAOS_PROP_CO_REDUN_RF0:
-		if (rdd == DAOS_OCH_RDD_RP) {
+		if (rdd == DAOS_OCH_RDD_RP && domain_nr >= 2) {
 			*ord =  OR_RP_2;
 			grp_size = 2;
 		} else if (rdd == DAOS_OCH_RDD_EC) {
@@ -769,7 +774,8 @@ dc_set_oclass(uint64_t rf_factor, int domain_nr, int target_nr,
 		}
 		break;
 	case DAOS_PROP_CO_REDUN_RF1:
-		if (rdd == DAOS_OCH_RDD_EC || daos_is_array_type(otype)) {
+		if ((rdd == DAOS_OCH_RDD_EC || daos_is_array_type(otype)) &&
+		    domain_nr >= 3) {
 			if (domain_nr >= 18) {
 				*ord = OR_RS_16P1;
 				grp_size = 17;
@@ -789,7 +795,8 @@ dc_set_oclass(uint64_t rf_factor, int domain_nr, int target_nr,
 		}
 		break;
 	case DAOS_PROP_CO_REDUN_RF2:
-		if (rdd == DAOS_OCH_RDD_EC || daos_is_array_type(otype)) {
+		if ((rdd == DAOS_OCH_RDD_EC || daos_is_array_type(otype)) &&
+		    domain_nr >= 4) {
 			if (domain_nr >= 20) {
 				*ord = OR_RS_16P2;
 				grp_size = 18;
@@ -822,7 +829,9 @@ dc_set_oclass(uint64_t rf_factor, int domain_nr, int target_nr,
 
 	if (unlikely(grp_size > domain_nr)) {
 		/** cannot meet redundancy requirement */
-		return -DER_INVAL;
+		rc = -DER_INVAL;
+		D_ERROR("grp_size %d > domain_nr %d, "DF_RC"\n", grp_size, domain_nr, DP_RC(rc));
+		return rc;
 	}
 
 	/** adjust the group size based on the sharding hint */


### PR DESCRIPTION
dc_set_oclass set the obj class possibly cause grp size exceed domain_nr, this patch is to fix it.

Required-githooks: true
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
