### PR TITLE
DAOS-12036 bio: Fix LED state error in list smd devs on non-VMD

### DIFF
--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -697,7 +697,7 @@ led_device_action(void *ctx, struct spdk_pci_device *pci_device)
 
 	if (strcmp(spdk_pci_device_get_type(pci_device), "vmd") != 0) {
 		D_ERROR("Found unexpected non-VMD device type\n");
-		opts->status = -DER_NOTAPPLICABLE;
+		opts->status = -DER_NOSYS;
 		return;
 	}
 


### PR DESCRIPTION
When VMD is not enabled, retrieving LED state for a SSD fails. This
failure should be captured and logged but not cause fatal errors when
listing SMD device details.

Test-tag: daily_regression pr

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [x] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [x] Githooks were used. If not, request that user install them and check copyright dates.
* [x] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [x] All builds have passed.  Check non-required builds for any new compiler warnings.
* [x] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [x] If applicable, the PR has addressed any potential version compatibility issues.
* [x] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [x] Extra checks if forced landing is requested
  * [x] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [x] No new NLT or valgrind warnings.  Check the classic view.
  * [x] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
