### PR TITLE
DAOS-11945 test: Increase pool/create_capacity.py timeout

### DIFF
--- a/src/tests/ftest/pool/create_capacity.yaml
+++ b/src/tests/ftest/pool/create_capacity.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 7
   test_clients: 1
 timeouts:
-  test_create_pool_quantity: 1100
+  test_create_pool_quantity: 1200
 server_config:
   name: daos_server
   engines_per_host: 1


### PR DESCRIPTION
Increasing the pool/create_capacity.py test timeout by 100 seconds to allow for enough time to tear down the test if the pool creation takes longer than norrmal.

Skip-unit-tests: true
Test-tag: create_performance
Test-repeat: 5

Required-githooks: true

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
