### PR TITLE
DAOS-12049 test: Fix speed check for virtio network interface

### DIFF
--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -78,6 +78,19 @@ class RemoteCommandResult():
         """
         return any(data.timeout for data in self.output)
 
+    @property
+    def all_stdout(self):
+        """Get all of the stdout from the issued command from each host.
+
+        Returns:
+            dict: the stdout (the values) from each set of hosts (the keys, as a str of the NodeSet)
+
+        """
+        stdout = {}
+        for data in self.output:
+            stdout[str(data.hosts)] = '\n'.join(data.stdout)
+        return stdout
+
     def _process_task(self, task, command):
         """Populate the output list and determine the passed result for the specified task.
 

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -78,19 +78,6 @@ class RemoteCommandResult():
         """
         return any(data.timeout for data in self.output)
 
-    @property
-    def all_stdout(self):
-        """Get all of the stdout from the issued command from each host.
-
-        Returns:
-            dict: the stdout (the values) from each set of hosts (the keys, as a str of the NodeSet)
-
-        """
-        stdout = {}
-        for data in self.output:
-            stdout[str(data.hosts)] = '\n'.join(data.stdout)
-        return stdout
-
     def _process_task(self, task, command):
         """Populate the output list and determine the passed result for the specified task.
 


### PR DESCRIPTION
Now that the interface speed check performed by launch.py is performed via a clushed cat command the error handling for a virtio network interface needs to be updated to handle the error coming from the cat command.  Also fixed the error handling for detecting the core file pattern.

Skip-func-test-el7: false
Skip-func-test-leap15: false
Test-tag: always_passes

Required-githooks: true

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
