### PR TITLE
DAOS-12040 test: Error message has changed

### DIFF
--- a/src/tests/ftest/fault_injection/pool.py
+++ b/src/tests/ftest/fault_injection/pool.py
@@ -29,7 +29,7 @@ class PoolServicesFaultInjection(TestWithServers):
         self.object_class = self.params.get("object_class", "/run/*")
         self.number_servers = len(self.hostlist_servers) - 1
 
-    def look_missed_request(self, cmd_stderr, msg=b"MS request error"):
+    def look_missed_request(self, cmd_stderr, msg=b"err:"):
         """ Read dmg_stderr for the msg string
         If found, the instance attribute self.failed_request is
         increased by 1.

--- a/src/tests/ftest/fault_injection/pool.py
+++ b/src/tests/ftest/fault_injection/pool.py
@@ -29,7 +29,7 @@ class PoolServicesFaultInjection(TestWithServers):
         self.object_class = self.params.get("object_class", "/run/*")
         self.number_servers = len(self.hostlist_servers) - 1
 
-    def look_missed_request(self, cmd_stderr, msg=b"err:"):
+    def look_missed_request(self, cmd_stderr, msg=b"err: DER_TIMEDOUT"):
         """ Read dmg_stderr for the msg string
         If found, the instance attribute self.failed_request is
         increased by 1.


### PR DESCRIPTION
The rpc error message that is reported when a fault is injected during the pool fault injection test has changed and the test is no longer detecting the failure.  The test needs to be updated to detect the correct error message.

Test-tag: test_pool_services pr

Required-githooks: true

Signed-off-by: Maureen Jean <maureen.jean@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
