### PR TITLE
DAOS-12059 gurt: fix potential double free

### DIFF
--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -875,8 +875,10 @@ d_hash_table_create(uint32_t feats, uint32_t bits, void *priv,
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	rc = d_hash_table_create_inplace(feats, bits, priv, hops, htable);
-	if (rc)
+	if (rc) {
 		D_FREE(htable);
+		htable = NULL;
+	}
 out:
 	*htable_pp = htable;
 	return rc;
@@ -1161,6 +1163,7 @@ d_hhash_create(uint32_t feats, uint32_t bits, struct d_hhash **hhash_pp)
 					 &hhash->ch_htable);
 	if (rc) {
 		D_FREE(hhash);
+		hhash = NULL;
 		D_GOTO(out, rc);
 	}
 


### PR DESCRIPTION
in d_hhash_create()/d_hash_table_create(), if
d_hash_table_create_inplace() failed, @htable will be freed, but its pointer will be still returned.

This is not safe, and might cause double free if caller cleanup to free memory by checking if pointer is NULL or not.

Required-githooks: true

Signed-off-by: Wang Shilong <shilong.wang@intel.com>