### PR TITLE
DAOS-11811 control: Tighten up permissions of dRPC socket files (#10470)

### DIFF
--- a/src/common/drpc.c
+++ b/src/common/drpc.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <linux/un.h>
 #include <errno.h>
 #include <string.h>
@@ -183,6 +184,16 @@ new_unixcomm_socket(int flags, struct unixcomm **newcommp)
 	}
 
 	comm->flags = flags;
+
+	/** Socket file to be readable and writable by user only */
+	if (fchmod(comm->fd, S_IRUSR|S_IWUSR) != 0) {
+		int rc = errno;
+
+		D_ERROR("Failed to set access permissions on socket fd %d, errno=%d(%s)\n",
+			comm->fd, rc, strerror(rc));
+		unixcomm_close(comm);
+		return daos_errno2der(rc);
+	}
 
 	*newcommp = comm;
 

--- a/src/common/drpc.c
+++ b/src/common/drpc.c
@@ -186,7 +186,7 @@ new_unixcomm_socket(int flags, struct unixcomm **newcommp)
 	comm->flags = flags;
 
 	/** Socket file to be readable and writable by user only */
-	if (fchmod(comm->fd, S_IRUSR|S_IWUSR) != 0) {
+	if (fchmod(comm->fd, S_IRUSR | S_IWUSR) != 0) {
 		int rc = errno;
 
 		D_ERROR("Failed to set access permissions on socket fd %d, errno=%d(%s)\n",

--- a/src/common/tests/common-mock-ld-opts
+++ b/src/common/tests/common-mock-ld-opts
@@ -1,6 +1,7 @@
 --wrap=socket
 --wrap=connect
 --wrap=bind
+--wrap=fchmod
 --wrap=fcntl
 --wrap=listen
 --wrap=accept

--- a/src/common/tests/test_mocks.c
+++ b/src/common/tests/test_mocks.c
@@ -3,8 +3,11 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
+
 #include <daos/test_mocks.h>
 #include <daos/test_utils.h>
+
+#include <sys/stat.h>
 
 /**
  * Generic mocks for external functions
@@ -34,6 +37,29 @@ __wrap_socket(int family, int type, int protocol)
 		return -1;
 	}
 	return socket_return;
+}
+
+void
+mock_fchmod_setup(void)
+{
+	fchmod_return = 0; /* 0 is success */
+	fchmod_fd = 0;
+	fchmod_mode = 0;
+}
+
+int fchmod_return; /* value to be returned by fchmod() */
+int fchmod_fd; /* saved input */
+mode_t fchmod_mode; /* saved input */
+int
+__wrap_fchmod(int fd, mode_t mode)
+{
+	fchmod_fd = fd;
+	fchmod_mode = mode;
+	if (fchmod_return != 0) {
+		errno = -fchmod_return;
+		return -1;
+	}
+	return 0;
 }
 
 void

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -54,7 +54,8 @@ func (cmd *startCmd) Execute(_ []string) error {
 	sockPath := filepath.Join(cmd.cfg.RuntimeDir, agentSockName)
 	cmd.log.Debugf("Full socket path is now: %s", sockPath)
 
-	drpcServer, err := drpc.NewDomainSocketServer(cmd.log, sockPath)
+	// Agent socket file to be readable and writable by all.
+	drpcServer, err := drpc.NewDomainSocketServer(cmd.log, sockPath, 0666)
 	if err != nil {
 		cmd.log.Errorf("Unable to create socket server: %v", err)
 		return err

--- a/src/control/cmd/drpc_test/main.go
+++ b/src/control/cmd/drpc_test/main.go
@@ -54,7 +54,7 @@ func runDrpcServer(log logging.Logger) error {
 	ctx, shutdown := context.WithCancel(context.Background())
 	defer shutdown()
 
-	drpcServer, err := drpc.NewDomainSocketServer(log, *unixSocket)
+	drpcServer, err := drpc.NewDomainSocketServer(log, *unixSocket, 0666)
 	if err != nil {
 		return errors.Wrap(err, "creating socket server")
 	}

--- a/src/control/drpc/README.md
+++ b/src/control/drpc/README.md
@@ -49,9 +49,9 @@ Individual dRPC modules must be registered with the server in order to handle in
 
 #### Basic Server Workflow
 
-1. Create the new DomainSocketServer with the server's Unix Domain Socket:
+1. Create the new DomainSocketServer with the server's Unix Domain Socket (file permissions 0600):
     ```
-    drpcServer, err := drpc.NewDomainSocketServer("/var/run/my_socket.sock")
+    drpcServer, err := drpc.NewDomainSocketServer(log, "/var/run/my_socket.sock", 0600)
     ```
 2. Register the dRPC modules that the server needs to handle:
     ```

--- a/src/control/drpc/drpc_server.go
+++ b/src/control/drpc/drpc_server.go
@@ -31,6 +31,7 @@ const MaxMsgSize = 1 << 17
 type DomainSocketServer struct {
 	log           logging.Logger
 	sockFile      string
+	sockFileMode  os.FileMode
 	listener      net.Listener
 	service       *ModuleService
 	sessions      map[net.Conn]*Session
@@ -98,9 +99,9 @@ func (d *DomainSocketServer) Start(ctx context.Context) error {
 	}
 	d.listener = lis
 
-	// TODO: Should we set more granular permissions? The only writer should
-	// be the I/O Engine and we should know which user is running it.
-	if err := os.Chmod(d.sockFile, 0777); err != nil {
+	// The only writer should be the I/O Engines which should be running as the same user as
+	// daos_server process.
+	if err := os.Chmod(d.sockFile, d.sockFileMode); err != nil {
 		return errors.Wrapf(err, "Unable to set permissions on %s", d.sockFile)
 	}
 
@@ -116,17 +117,21 @@ func (d *DomainSocketServer) RegisterRPCModule(mod Module) {
 
 // NewDomainSocketServer returns a new unstarted instance of a
 // DomainSocketServer for the specified unix domain socket path.
-func NewDomainSocketServer(log logging.Logger, sock string) (*DomainSocketServer, error) {
+func NewDomainSocketServer(log logging.Logger, sock string, sockMode os.FileMode) (*DomainSocketServer, error) {
 	if sock == "" {
 		return nil, errors.New("Missing Argument: sockFile")
+	}
+	if sockMode == 0 {
+		return nil, errors.New("Missing Argument: sockFileMode")
 	}
 	service := NewModuleService(log)
 	sessions := make(map[net.Conn]*Session)
 	return &DomainSocketServer{
-		log:      log,
-		sockFile: sock,
-		service:  service,
-		sessions: sessions}, nil
+		log:          log,
+		sockFile:     sock,
+		sockFileMode: sockMode,
+		service:      service,
+		sessions:     sessions}, nil
 }
 
 // Session represents an individual client connection to the Domain Socket Server.

--- a/src/control/drpc/drpc_server_test.go
+++ b/src/control/drpc/drpc_server_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
+var testFileMode os.FileMode = 0600
+
 func TestNewSession(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
@@ -107,7 +109,17 @@ func TestNewDomainSocketServer_NoSockFile(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
-	dss, err := NewDomainSocketServer(log, "")
+	dss, err := NewDomainSocketServer(log, "", testFileMode)
+
+	test.CmpErr(t, errors.New("Missing Argument"), err)
+	test.AssertTrue(t, dss == nil, "expected no server created")
+}
+
+func TestNewDomainSocketServer_NoSockFileMode(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	dss, err := NewDomainSocketServer(log, "test.sock", 0)
 
 	test.CmpErr(t, errors.New("Missing Argument"), err)
 	test.AssertTrue(t, dss == nil, "expected no server created")
@@ -119,7 +131,7 @@ func TestNewDomainSocketServer(t *testing.T) {
 
 	expectedSock := "test.sock"
 
-	dss, err := NewDomainSocketServer(log, expectedSock)
+	dss, err := NewDomainSocketServer(log, expectedSock, testFileMode)
 
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -149,7 +161,7 @@ func TestServer_Start_CantUnlinkSocket(t *testing.T) {
 		_ = os.Chmod(tmpDir, 0700)
 	}()
 
-	dss, _ := NewDomainSocketServer(log, path)
+	dss, _ := NewDomainSocketServer(log, path, testFileMode)
 
 	err := dss.Start(context.Background())
 
@@ -173,7 +185,7 @@ func TestServer_Start_CantListen(t *testing.T) {
 		_ = os.Chmod(tmpDir, 0700)
 	}()
 
-	dss, _ := NewDomainSocketServer(log, path)
+	dss, _ := NewDomainSocketServer(log, path, testFileMode)
 
 	err := dss.Start(context.Background())
 
@@ -185,7 +197,7 @@ func TestServer_RegisterModule(t *testing.T) {
 	defer test.ShowBufferOnFailure(t, buf)
 
 	mod := newTestModule(1234)
-	dss, _ := NewDomainSocketServer(log, "dontcare.sock")
+	dss, _ := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
 
 	dss.RegisterRPCModule(mod)
 
@@ -206,7 +218,7 @@ func TestServer_Listen_AcceptError(t *testing.T) {
 
 	lis := newMockListener()
 	lis.acceptErr = errors.New("mock accept error")
-	dss, _ := NewDomainSocketServer(log, "dontcare.sock")
+	dss, _ := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
 	dss.listener = lis
 
 	dss.Listen(context.Background()) // should return instantly
@@ -220,7 +232,7 @@ func TestServer_Listen_AcceptConnection(t *testing.T) {
 
 	lis := newMockListener()
 	lis.setNumConnsToAccept(3)
-	dss, _ := NewDomainSocketServer(log, "dontcare.sock")
+	dss, _ := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
 	dss.listener = lis
 
 	dss.Listen(context.Background()) // will return when error is sent
@@ -235,7 +247,7 @@ func TestServer_ListenSession_Error(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
-	dss, _ := NewDomainSocketServer(log, "dontcare.sock")
+	dss, _ := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
 	conn := newMockConn()
 	conn.ReadOutputError = errors.New("mock read error")
 	session := NewSession(conn, dss.service)
@@ -257,7 +269,7 @@ func TestServer_Shutdown(t *testing.T) {
 
 	ctx, shutdown := context.WithCancel(context.Background())
 
-	dss, _ := NewDomainSocketServer(log, "dontcare.sock")
+	dss, _ := NewDomainSocketServer(log, "dontcare.sock", testFileMode)
 	lis := newCtxMockListener(ctx)
 	dss.listener = lis
 
@@ -283,7 +295,7 @@ func TestServer_IntegrationNoMethod(t *testing.T) {
 	defer tmpCleanup()
 	path := filepath.Join(tmpDir, "test.sock")
 
-	dss, err := NewDomainSocketServer(log, path)
+	dss, err := NewDomainSocketServer(log, path, testFileMode)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -115,7 +115,10 @@ func drpcServerSetup(ctx context.Context, req *drpcServerSetupReq) error {
 	}
 
 	sockPath := getDrpcServerSocketPath(req.sockDir)
-	drpcServer, err := drpc.NewDomainSocketServer(req.log, sockPath)
+
+	// Server socket file to be readable and writable by user. daos_server should receive
+	// messages from daos_engine and both processes will be run by the same user.
+	drpcServer, err := drpc.NewDomainSocketServer(req.log, sockPath, 0600)
 	if err != nil {
 		return errors.Wrap(err, "unable to create socket server")
 	}

--- a/src/engine/tests/drpc_client_tests.c
+++ b/src/engine/tests/drpc_client_tests.c
@@ -106,6 +106,7 @@ static int
 drpc_client_test_setup(void **state)
 {
 	mock_socket_setup();
+	mock_fchmod_setup();
 	mock_connect_setup();
 	mock_sendmsg_setup();
 	mock_recvmsg_setup();
@@ -131,6 +132,27 @@ drpc_client_test_teardown(void **state)
 /*
  * Unit tests
  */
+static void
+test_drpc_call_sockfile_chmod_fails(void **state)
+{
+	Drpc__Response	*resp;
+	int		 rc;
+
+	assert_rc_equal(drpc_init(), 0);
+
+	fchmod_return = -EACCES;
+
+	rc = dss_drpc_call(DRPC_MODULE_SRV, DRPC_METHOD_SRV_NOTIFY_READY,
+			   NULL /* req */, 0 /* req_size */, 0 /* flags */,
+			   &resp);
+	assert_rc_equal(rc, -DER_NO_PERM);
+
+	/* make sure socket was closed */
+	assert_int_equal(close_call_count, 1);
+
+	drpc_fini();
+}
+
 static void
 test_drpc_call_connect_fails(void **state)
 {
@@ -490,6 +512,7 @@ int
 main(void)
 {
 	const struct CMUnitTest tests[] = {
+		UTEST(test_drpc_call_sockfile_chmod_fails),
 		UTEST(test_drpc_call_connect_fails),
 		UTEST(test_drpc_call_sendmsg_fails),
 		UTEST(test_drpc_verify_notify_ready),

--- a/src/include/daos/test_mocks.h
+++ b/src/include/daos/test_mocks.h
@@ -14,6 +14,7 @@
 
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/un.h>
 #include <fcntl.h>
 #include <poll.h>
@@ -26,6 +27,11 @@ extern int socket_return; /* value to be returned by socket() */
 extern int socket_family; /* saved input */
 extern int socket_type; /* saved input */
 extern int socket_protocol; /* saved input */
+
+void mock_fchmod_setup(void);
+extern int fchmod_return; /* value to be returned by fchmod() */
+extern int fchmod_fd; /* saved input */
+extern mode_t fchmod_mode; /* saved input */
 
 void mock_connect_setup(void);
 extern int connect_return; /* value to be returned by connect() */


### PR DESCRIPTION
/var/daos/daos_server/daos_server.sock has permissions 777, should be 600
/var/daos/daos_server/daos_engine_^pid^.sock has permission 755, should be 600
/var/daos/daos_agent/daos_agent.sock has permissions 777, should be 666

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
