### PR TITLE
DAOS-12053 control: Try stopping excluded ranks

### DIFF
--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -792,6 +792,19 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, req *mgmtpb.SystemStopReq) (
 	return resp, nil
 }
 
+// tryStoppingRank attempts to stop a rank without any interest in the result.
+func (svc *mgmtSvc) tryStoppingRank(ctx context.Context, rank ranklist.Rank) {
+	req := mgmtpb.SystemStopReq{
+		Sys:   svc.sysdb.SystemName(),
+		Prep:  false,
+		Kill:  true,
+		Force: true,
+		Ranks: rank.String(),
+	}
+	resp, err := svc.SystemStop(ctx, &req)
+	svc.log.Debugf("Attempted to stop rank %s: %v: %+v", rank, err, resp)
+}
+
 func newSystemStartFailedEvent(errs string) *events.RASEvent {
 	return events.NewGenericEvent(events.RASSystemStartFailed, events.RASSeverityError,
 		fmt.Sprintf("System startup failed, %s", errs), "")

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -602,6 +602,7 @@ func registerLeaderSubscriptions(srv *server) {
 					return
 				}
 				srv.mgmtSvc.reqGroupUpdate(ctx, false)
+				srv.mgmtSvc.tryStoppingRank(ctx, ranklist.Rank(evt.Rank))
 			}
 		}))
 


### PR DESCRIPTION
Features: control
Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
