### PR TITLE
DAOS-12063 object: reset kds and recxs for each shard

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5580,8 +5580,11 @@ shard_anchors_check_alloc_bufs(struct obj_auxi_args *obj_auxi,
 			continue;
 		}
 
-		if (sub_anchor->ssa_kds != NULL)
-			continue;
+		if (sub_anchor->ssa_kds != NULL) {
+			if (sub_anchors->sa_nr == nr)
+				continue;
+			D_FREE(sub_anchor->ssa_kds);
+		}
 
 		D_ALLOC_ARRAY(sub_anchor->ssa_kds, nr);
 		if (sub_anchor->ssa_kds == NULL)
@@ -5598,8 +5601,11 @@ shard_anchors_check_alloc_bufs(struct obj_auxi_args *obj_auxi,
 			req_tgts->ort_shard_tgts[i].st_rank = DAOS_TGT_IGNORE;
 		}
 
-		if (sub_anchor->ssa_recxs != NULL)
-			continue;
+		if (sub_anchor->ssa_recxs != NULL) {
+			if (sub_anchors->sa_nr == nr)
+				continue;
+			D_FREE(sub_anchor->ssa_recxs);
+		}
 
 		D_ALLOC_ARRAY(sub_anchor->ssa_recxs, nr);
 		if (sub_anchor->ssa_recxs == NULL)

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1848,7 +1848,7 @@ dfs_test_async_io(void **state)
 }
 
 static void
-dfs_test_readdir(void **state)
+dfs_test_readdir_internal(void **state, daos_oclass_id_t obj_class)
 {
 	dfs_obj_t		*dir;
 	dfs_obj_t		*obj;
@@ -1860,11 +1860,13 @@ dfs_test_readdir(void **state)
 	struct stat		stbufs[10];
 	int			num_files = 0;
 	int			num_dirs = 0;
+	char			dir_name[24];
 	int			i;
 	int			rc;
 
-	rc = dfs_open(dfs_mt, NULL, "dir", S_IFDIR | S_IWUSR | S_IRUSR,
-		      O_RDWR | O_CREAT, OC_SX, 0, NULL, &dir);
+	sprintf(dir_name, "dir_%d", obj_class);
+	rc = dfs_open(dfs_mt, NULL, dir_name, S_IFDIR | S_IWUSR | S_IRUSR,
+		      O_RDWR | O_CREAT, obj_class, 0, NULL, &dir);
 	assert_int_equal(rc, 0);
 
 	/** create 100 files and dirs */
@@ -1904,6 +1906,16 @@ dfs_test_readdir(void **state)
 
 	rc = dfs_release(dir);
 	assert_int_equal(rc, 0);
+}
+
+static void
+dfs_test_readdir(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	dfs_test_readdir_internal(state, OC_SX);
+	if (test_runable(arg, 4))
+		dfs_test_readdir_internal(state, OC_EC_2P2GX);
 }
 
 static int


### PR DESCRIPTION
During EC object enumeration, kds and recxs over each sub anchor may need reallocate, if the number is changed.

set rd_lvl to rank, in the case the test runs with more ranks and fewer nodes.

Required-githooks: true

Signed-off-by: Di Wang <di.wang@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
