### PR TITLE
DAOS-12068  Support dkey/akey length less than 8 bytes in Java synchronous object API

### DIFF
--- a/src/client/java/daos-java/src/main/java/io/daos/Constants.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/Constants.java
@@ -19,6 +19,8 @@ public final class Constants {
 
   public static final String KEY_CHARSET = "UTF-8";
 
+  public static final int DKEY_MIN_LENGTH = 8;
+
   public static final int KEY_LIST_BATCH_SIZE_DEFAULT = 128;
 
   public static final int ENCODED_LENGTH_KEY = 2;

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosEventQueue.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosEventQueue.java
@@ -558,7 +558,7 @@ public class DaosEventQueue {
     void reuse();
 
     /**
-     * it's should be called before attachment being consumed by user.
+     * it should be called before attachment being consumed by user.
      */
     void ready();
 

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosIOException.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosIOException.java
@@ -138,6 +138,7 @@ public class DaosIOException extends IOException {
     sb.append(" error code: ");
     if (errorCode == Integer.MIN_VALUE) {
       sb.append("unknown.");
+      needSuperMsg = true;
     } else {
       sb.append(errorCode);
       if (errorCode < Constants.CUSTOM_ERROR_BASE) {

--- a/src/client/java/daos-java/src/main/java/io/daos/DaosUtils.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/DaosUtils.java
@@ -9,6 +9,7 @@ package io.daos;
 import io.daos.dfs.StatAttributes;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -178,5 +179,15 @@ public final class DaosUtils {
   public static byte[] keyToBytes8(String key, int lenLimit) {
     byte[] bytes = keyToBytes(key, lenLimit);
     return padZero8(bytes);
+  }
+
+  public static String keyBytes8ToStr(byte[] keyBytes) {
+    int i = 0;
+    for (; i < keyBytes.length && keyBytes[i] == (byte)0; i++) {}
+    try {
+      return new String(keyBytes, i, keyBytes.length - i, Constants.KEY_CHARSET);
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalArgumentException("cannot decode bytes in " + Constants.KEY_CHARSET);
+    }
   }
 }

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjClient.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObjClient.java
@@ -318,7 +318,7 @@ public class DaosObjClient extends ShareableClient implements ForceCloseable {
       throws DaosIOException;
 
   /**
-   * update object with one entry. Dkey and Akey are described in {@link IODescUpdAsync}.
+   * update object asynchronously with one entry. Dkey and Akey are described in {@link IODescUpdAsync}.
    *
    * @param objectPtr
    * @param descMemAddress
@@ -329,8 +329,21 @@ public class DaosObjClient extends ShareableClient implements ForceCloseable {
    * @param dataMemAddress
    * @throws DaosIOException
    */
-  native void updateObjNoDecode(long objectPtr, long descMemAddress, long eqWrapHdl, short eventId,
+  native void updateObjAsyncNoDecode(long objectPtr, long descMemAddress, long eqWrapHdl, short eventId,
                              long offset, int dataLen, long dataMemAddress) throws DaosIOException;
+
+  /**
+   * update object synchronously with one entry. Dkey and Akey are described in {@link IODescUpdSync}.
+   *
+   * @param objectPtr
+   * @param descMemAddress
+   * @param offset
+   * @param dataLen
+   * @param dataMemAddress
+   * @throws DaosIOException
+   */
+  native void updateObjSyncNoDecode(long objectPtr, long descMemAddress, long offset, int dataLen,
+                                    long dataMemAddress) throws DaosIOException;
 
   /**
    * list dkeys of given object.

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObject.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/DaosObject.java
@@ -423,11 +423,33 @@ public class DaosObject {
       log.debug(oid + " update object with description " + desc);
     }
     try {
-      client.updateObjNoDecode(objectPtr, desc.descMemoryAddress(), desc.getEqHandle(), desc.getEventId(),
+      client.updateObjAsyncNoDecode(objectPtr, desc.descMemoryAddress(), desc.getEqHandle(), desc.getEventId(),
           desc.getDestOffset(), desc.readableBytes(), desc.dataMemoryAddress());
     } catch (DaosIOException e) {
       throw new DaosObjectException(oid, "failed to update object with description " + desc,
           e);
+    }
+  }
+
+  /**
+   * update with {@link IODescUpdSync}.
+   *
+   * @param desc
+   * @throws DaosObjectException
+   */
+  public void updateAsync(IODescUpdSync desc)
+          throws DaosObjectException {
+    checkOpen();
+
+    if (log.isDebugEnabled()) {
+      log.debug(oid + " update object with description " + desc);
+    }
+    try {
+      client.updateObjSyncNoDecode(objectPtr, desc.descMemoryAddress(),
+              desc.getDestOffset(), desc.readableBytes(), desc.dataMemoryAddress());
+    } catch (DaosIOException e) {
+      throw new DaosObjectException(oid, "failed to update object with description " + desc,
+              e);
     }
   }
 

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescSync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescSync.java
@@ -145,7 +145,7 @@ public class IODataDescSync extends IODataDescBase {
     super(dkey, updateOrFetch);
     this.maxKeyLen = -1;
     this.dkey = dkey;
-    this.dkeyBytes = DaosUtils.keyToBytes(dkey);
+    this.dkeyBytes = DaosUtils.keyToBytes8(dkey);
     if (iodType == IodType.NONE) {
       throw new IllegalArgumentException("need valid IodType, either " + IodType.ARRAY + " or " +
         IodType.SINGLE);
@@ -269,7 +269,7 @@ public class IODataDescSync extends IODataDescBase {
     if (dkey.equals(this.dkey)) { // in case of same dkey
       return;
     }
-    byte[] dkeyBytes = DaosUtils.keyToBytes(dkey);
+    byte[] dkeyBytes = DaosUtils.keyToBytes8(dkey);
     this.dkey = dkey;
     this.dkeyBytes = dkeyBytes;
   }
@@ -553,7 +553,7 @@ public class IODataDescSync extends IODataDescBase {
       }
       this.key = key;
       int limit = maxKeyLen > 0 ? maxKeyLen : Short.MAX_VALUE;
-      this.keyBytes = DaosUtils.keyToBytes(key, limit);
+      this.keyBytes = DaosUtils.keyToBytes8(key, limit);
       this.offset = offset;
       this.dataSize = dataSize;
       if (offset%recordSize != 0) {
@@ -719,7 +719,7 @@ public class IODataDescSync extends IODataDescBase {
       }
       if (!akey.equals(this.key)) {
         this.key = akey;
-        this.keyBytes = DaosUtils.keyToBytes(akey, maxKeyLen);
+        this.keyBytes = DaosUtils.keyToBytes8(akey, maxKeyLen);
       }
       this.offset = offset;
       if (updateOrFetch) {

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescSync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODataDescSync.java
@@ -73,7 +73,7 @@ public class IODataDescSync extends IODataDescBase {
    * and buffer length.
    *
    * @param maxKeyLen
-   * max length of dkey and akey
+   * max length of dkey and akey, should be no less than 8
    * @param nbrOfEntries
    * number of entries/akeys
    * @param entryBufLen
@@ -89,8 +89,9 @@ public class IODataDescSync extends IODataDescBase {
   protected IODataDescSync(int maxKeyLen, int nbrOfEntries, int entryBufLen,
                            IodType iodType, int recordSize, boolean updateOrFetch) {
     super(null, updateOrFetch);
-    if (maxKeyLen <= 0) {
-      throw new IllegalArgumentException("dkey length should be positive. " + maxKeyLen);
+    if (maxKeyLen < Constants.DKEY_MIN_LENGTH) {
+      throw new IllegalArgumentException("dkey length should be no less than " + Constants.DKEY_MIN_LENGTH +
+          ". " + maxKeyLen);
     }
     if (maxKeyLen > Short.MAX_VALUE) {
       throw new IllegalArgumentException("dkey and akey length in should not exceed "
@@ -553,7 +554,7 @@ public class IODataDescSync extends IODataDescBase {
       }
       this.key = key;
       int limit = maxKeyLen > 0 ? maxKeyLen : Short.MAX_VALUE;
-      this.keyBytes = DaosUtils.keyToBytes8(key, limit);
+      this.keyBytes = DaosUtils.keyToBytes(key, limit);
       this.offset = offset;
       this.dataSize = dataSize;
       if (offset%recordSize != 0) {
@@ -719,7 +720,7 @@ public class IODataDescSync extends IODataDescBase {
       }
       if (!akey.equals(this.key)) {
         this.key = akey;
-        this.keyBytes = DaosUtils.keyToBytes8(akey, maxKeyLen);
+        this.keyBytes = DaosUtils.keyToBytes(akey, maxKeyLen);
       }
       this.offset = offset;
       if (updateOrFetch) {

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdAsync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdAsync.java
@@ -20,19 +20,11 @@ import java.io.UnsupportedEncodingException;
 /**
  * IO Description for asynchronously update only one entry, dkey/akey.
  */
-public class IODescUpdAsync implements DaosEventQueue.Attachment {
+public class IODescUpdAsync extends IODescUpdBase implements DaosEventQueue.Attachment {
 
   private final short maxKeyLen;
 
   private final long nativeHdl;
-
-  private ByteBuf descBuffer;
-
-  private long offset;
-
-  private ByteBuf dataBuffer;
-
-  private int requestLen;
 
   private DaosEventQueue.Event event;
 
@@ -41,8 +33,6 @@ public class IODescUpdAsync implements DaosEventQueue.Attachment {
   private boolean discarded;
 
   private int retCode = Integer.MAX_VALUE;
-
-  public static final int RET_CODE_SUCCEEDED = Constants.RET_CODE_SUCCEEDED;
 
   private static final Logger log = LoggerFactory.getLogger(IODescUpdAsync.class);
 
@@ -55,21 +45,9 @@ public class IODescUpdAsync implements DaosEventQueue.Attachment {
    * @param dataBuffer
    */
   public IODescUpdAsync(String dkey, String akey, long offset, ByteBuf dataBuffer) {
+    super(dkey, akey, offset, dataBuffer, true);
     this.maxKeyLen = 0;
     this.nativeHdl = 0L;
-    this.offset = offset;
-    this.dataBuffer = dataBuffer;
-    byte[] dkeyBytes = DaosUtils.keyToBytes8(dkey);
-    byte[] akeyBytes = DaosUtils.keyToBytes(akey);
-    // 8 for null native handle, 4 = 2 + 2 for lens,
-    requestLen = 8 + dkeyBytes.length + akeyBytes.length + 4;
-    // 4 for return code
-    descBuffer = BufferAllocator.objBufWithNativeOrder(requestLen + 4);
-    descBuffer.writeLong(0L);
-    descBuffer.writeShort(dkeyBytes.length);
-    descBuffer.writeBytes(dkeyBytes);
-    descBuffer.writeShort(akeyBytes.length);
-    descBuffer.writeBytes(akeyBytes);
   }
 
   /**
@@ -78,6 +56,7 @@ public class IODescUpdAsync implements DaosEventQueue.Attachment {
    * @param maxKeyLen
    */
   public IODescUpdAsync(int maxKeyLen) {
+    super();
     if (maxKeyLen <= 0 || maxKeyLen > Short.MAX_VALUE) {
       throw new IllegalArgumentException("max key length should be bigger than 0 and less than " + Short.MAX_VALUE
           + ", value is " + maxKeyLen);
@@ -143,14 +122,6 @@ public class IODescUpdAsync implements DaosEventQueue.Attachment {
 
   public boolean isSucceeded() {
     return retCode == RET_CODE_SUCCEEDED;
-  }
-
-  public ByteBuf getDescBuffer() {
-    return descBuffer;
-  }
-
-  public ByteBuf getDataBuffer() {
-    return dataBuffer;
   }
 
   public DaosEventQueue.Event getEvent() {
@@ -237,22 +208,6 @@ public class IODescUpdAsync implements DaosEventQueue.Attachment {
       throw new IllegalStateException("event is not set");
     }
     return event.getId();
-  }
-
-  public long getDestOffset() {
-    return offset;
-  }
-
-  public int readableBytes() {
-    return dataBuffer.readableBytes();
-  }
-
-  public long dataMemoryAddress() {
-    return dataBuffer.memoryAddress();
-  }
-
-  public long descMemoryAddress() {
-    return descBuffer.memoryAddress();
   }
 
   private String readKey(ByteBuf buf, int len) {

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdAsync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdAsync.java
@@ -176,7 +176,7 @@ public class IODescUpdAsync extends IODescUpdBase implements DaosEventQueue.Atta
   @Override
   public void release() {
     if (descBuffer != null) {
-      if (isReusable() & nativeHdl > 0) {
+      if (isReusable() & nativeHdl > 0) { // non reusable native desc released in callback function
         DaosObjClient.releaseDescUpdAsync(nativeHdl);
       }
       descBuffer.release();

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdBase.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdBase.java
@@ -1,0 +1,82 @@
+/*
+ * (C) Copyright 2018-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+package io.daos.obj;
+
+import io.daos.BufferAllocator;
+import io.daos.Constants;
+import io.daos.DaosUtils;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * IO Description for update only one entry, dkey/akey.
+ */
+public class IODescUpdBase {
+
+    protected ByteBuf descBuffer;
+
+    protected long offset;
+
+    protected ByteBuf dataBuffer;
+
+    protected int requestLen;
+
+    public static final int RET_CODE_SUCCEEDED = Constants.RET_CODE_SUCCEEDED;
+
+    protected IODescUpdBase(String dkey, String akey, long offset, ByteBuf dataBuffer, boolean async) {
+        this.offset = offset;
+        this.dataBuffer = dataBuffer;
+        byte[] dkeyBytes = DaosUtils.keyToBytes8(dkey);
+        byte[] akeyBytes = DaosUtils.keyToBytes(akey);
+        int handleLen = 0;
+        int retLen = 0;
+        if (async) {
+            // 8 for null native handle
+            // 4 for return code
+            handleLen = 8;
+            retLen = 4;
+        }
+        // 4 = 2 + 2 for lens,
+        requestLen = handleLen + dkeyBytes.length + akeyBytes.length + 4;
+        descBuffer = BufferAllocator.objBufWithNativeOrder(requestLen + retLen);
+        if (async) {
+            descBuffer.writeLong(0L);
+        }
+        descBuffer.writeShort(dkeyBytes.length);
+        descBuffer.writeBytes(dkeyBytes);
+        descBuffer.writeShort(akeyBytes.length);
+        descBuffer.writeBytes(akeyBytes);
+    }
+
+    /**
+     * for reusable async update
+     */
+    protected IODescUpdBase() {}
+
+    public ByteBuf getDataBuffer() {
+        return dataBuffer;
+    }
+
+    public ByteBuf getDescBuffer() {
+        return descBuffer;
+    }
+
+    public long getDestOffset() {
+        return offset;
+    }
+
+    public int readableBytes() {
+        return dataBuffer.readableBytes();
+    }
+
+    public long dataMemoryAddress() {
+        return dataBuffer.memoryAddress();
+    }
+
+    public long descMemoryAddress() {
+        return descBuffer.memoryAddress();
+    }
+}

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdSync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdSync.java
@@ -6,6 +6,7 @@
 
 package io.daos.obj;
 
+import io.daos.DaosIOException;
 import io.netty.buffer.ByteBuf;
 
 /**
@@ -15,5 +16,16 @@ public class IODescUpdSync extends IODescUpdBase {
 
     public IODescUpdSync(String dkey, String akey, long offset, ByteBuf dataBuffer) {
         super(dkey, akey, offset, dataBuffer, false);
+    }
+
+    public void release() {
+        if (descBuffer != null) {
+            descBuffer.release();
+            descBuffer = null;
+        }
+        if (dataBuffer != null) {
+            dataBuffer.release();
+            dataBuffer = null;
+        }
     }
 }

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdSync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdSync.java
@@ -1,0 +1,19 @@
+/*
+ * (C) Copyright 2018-2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+
+package io.daos.obj;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * IO Description for synchronously update only one entry, dkey/akey.
+ */
+public class IODescUpdSync extends IODescUpdBase {
+
+    public IODescUpdSync(String dkey, String akey, long offset, ByteBuf dataBuffer) {
+        super(dkey, akey, offset, dataBuffer, false);
+    }
+}

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdSync.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IODescUpdSync.java
@@ -18,6 +18,9 @@ public class IODescUpdSync extends IODescUpdBase {
         super(dkey, akey, offset, dataBuffer, false);
     }
 
+    /**
+     * native desc released in native code
+     */
     public void release() {
         if (descBuffer != null) {
             descBuffer.release();

--- a/src/client/java/daos-java/src/main/java/io/daos/obj/IOKeyDesc.java
+++ b/src/client/java/daos-java/src/main/java/io/daos/obj/IOKeyDesc.java
@@ -69,7 +69,7 @@ public class IOKeyDesc {
   protected IOKeyDesc(String dkey, int nbrOfKeys, int akeyLen, int batchSize) throws IOException {
     this.dkey = dkey;
     if (dkey != null) {
-      dkeyBytes = DaosUtils.keyToBytes(dkey);
+      dkeyBytes = DaosUtils.keyToBytes8(dkey);
     }
     if (nbrOfKeys < 1) {
       throw new IllegalArgumentException("nbrOfKeys should be at least 1, " + nbrOfKeys);
@@ -299,7 +299,7 @@ public class IOKeyDesc {
         keyLen = descBuffer.readLong();
         byte bytes[] = new byte[(int)keyLen];
         keyBuffer.readBytes(bytes);
-        resultKeys.add(new String(bytes, Constants.KEY_CHARSET));
+        resultKeys.add(DaosUtils.keyBytes8ToStr(bytes));
         descBuffer.readerIndex(descBuffer.readerIndex() + 4); // uint32_t kd_val_type(4)
 //        csumLen = descBuffer.readShort();
         idx += keyLen;

--- a/src/client/java/daos-java/src/main/native/include/daos_jni_common.h
+++ b/src/client/java/daos-java/src/main/native/include/daos_jni_common.h
@@ -90,14 +90,6 @@ typedef struct {
 } data_desc_upd_async_t;
 
 typedef struct {
-    daos_key_t dkey;
-    daos_iod_t *iods;
-    d_sg_list_t *sgls;
-    daos_recx_t *recxs;
-    d_iov_t *iovs;
-} data_desc_upd_sync_t;
-
-typedef struct {
     int nbrOfDescs;
     data_desc_simple_t **descs;
 } data_desc_simple_grp_t;

--- a/src/client/java/daos-java/src/main/native/include/daos_jni_common.h
+++ b/src/client/java/daos-java/src/main/native/include/daos_jni_common.h
@@ -76,14 +76,26 @@ typedef struct {
 
 typedef struct {
     daos_key_t dkey;
-    uint16_t maxKeyLen;
-    data_event_t *event;
     daos_iod_t *iods;
     d_sg_list_t *sgls;
     daos_recx_t *recxs;
     d_iov_t *iovs;
+} data_desc_upd_sync_t;
+
+typedef struct {
+    data_desc_upd_sync_t basicDesc;
+    data_event_t *event;
     uint64_t ret_buf_address;
+    uint16_t maxKeyLen;
 } data_desc_upd_async_t;
+
+typedef struct {
+    daos_key_t dkey;
+    daos_iod_t *iods;
+    d_sg_list_t *sgls;
+    daos_recx_t *recxs;
+    d_iov_t *iovs;
+} data_desc_upd_sync_t;
 
 typedef struct {
     int nbrOfDescs;

--- a/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
@@ -1163,8 +1163,8 @@ Java_io_daos_obj_DaosObjClient_updateObjAsyncNoDecode(JNIEnv *env,
 	desc->event->status = EVENT_IN_USE;
 	desc->event->event.ev_error = 0;
 	rc = daos_obj_update(oh, DAOS_TX_NONE, 0L, &basicDesc->dkey,
-			1, basicDesc->iods,
-			basicDesc->sgls, &desc->event->event);
+			     1, basicDesc->iods,
+			     basicDesc->sgls, &desc->event->event);
 	if (rc) {
 		throw_const_obj(env,
 				"Failed to update DAOS object",
@@ -1192,7 +1192,7 @@ Java_io_daos_obj_DaosObjClient_updateObjSyncNoDecode(JNIEnv *env,
 	int rc;
 	char *msg = "memory allocation failed";
 	data_desc_upd_sync_t *desc = (data_desc_upd_sync_t *)malloc(
-                                         sizeof(data_desc_upd_sync_t));
+					sizeof(data_desc_upd_sync_t));
 
 	if (desc == NULL) {
 		throw_const_obj(env,

--- a/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
@@ -823,16 +823,16 @@ allocate_desc_update_async(char *descBuf, data_desc_upd_async_t *desc,
 		memcpy(&value16, desc_buffer, 2);
 	}
 	desc_buffer += 2;
-	d_iov_set(&desc->basicDesc->dkey, desc_buffer, value16);
+	d_iov_set(&desc->basicDesc.dkey, desc_buffer, value16);
 	desc_buffer += (desc->maxKeyLen == 0 ? value16 : desc->maxKeyLen);
 	/* entries */
 	rc = allocate_basic_desc_for_update(&desc->basicDesc);
-    if (rc) {
-        return rc;
-    }
+	if (rc) {
+		return rc;
+	}
 	/* iod */
 	/* akey */
-	iod = &desc->basicDesc->iods[0];
+	iod = &desc->basicDesc.iods[0];
 	if (!reuse) {
 		memcpy(&value16, desc_buffer, 2);
 	}
@@ -853,6 +853,8 @@ allocate_desc_update_sync(char *descBuf, data_desc_upd_sync_t *desc)
 {
 	char *desc_buffer = descBuf;
 	uint16_t value16 = 0;
+	daos_iod_t *iod;
+	int rc;
 
 	/* set dkey address */
 	memcpy(&value16, desc_buffer, 2);
@@ -861,9 +863,9 @@ allocate_desc_update_sync(char *descBuf, data_desc_upd_sync_t *desc)
 	desc_buffer += value16;
 	/* entries */
 	rc = allocate_basic_desc_for_update(desc);
-    if (rc) {
-        return rc;
-    }
+	if (rc) {
+		return rc;
+	}
 	/* iod */
 	/* akey */
 	iod = &desc->iods[0];

--- a/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_obj_DaosObjClient.c
@@ -1180,9 +1180,9 @@ fail:
 
 JNIEXPORT void JNICALL
 Java_io_daos_obj_DaosObjClient_updateObjSyncNoDecode(JNIEnv *env,
-		jobject clientObj, jlong objPtr,
-		jlong descBufAddress, jlong offset,
-		jint len, jlong dataBufAddress)
+					jobject clientObj, jlong objPtr,
+					jlong descBufAddress, jlong offset,
+					jint len, jlong dataBufAddress)
 {
 	daos_handle_t oh;
 	char *desc_buf = (char *)descBufAddress;

--- a/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIT.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIT.java
@@ -1580,8 +1580,6 @@ public class DaosObjectIT {
     } catch (Exception e) {
       throw e;
     } finally {
-      System.out.println(1);
-      System.out.println(2);
       if (object.isOpen()) {
         object.punch();
       }

--- a/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIT.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/obj/DaosObjectIT.java
@@ -908,7 +908,7 @@ public class DaosObjectIT {
       try {
         List<String> keys1 = dkey == null ? object.listDkeys(keyDesc) : object.listAkeys(keyDesc);
         Assert.assertEquals(0, keys1.size());
-        Assert.assertEquals(6, keyDesc.getSuggestedKeyLen());
+        Assert.assertEquals(dkey == null ? 9 : 6, keyDesc.getSuggestedKeyLen());
         ByteBuf anchorBuffer = keyDesc.getAnchorBuffer();
         anchorBuffer.readerIndex(0);
         Assert.assertEquals(Constants.KEY_LIST_CODE_KEY2BIG, anchorBuffer.readByte());
@@ -1350,9 +1350,9 @@ public class DaosObjectIT {
     int akeyLen = 4;
     int reduces = 3;
     int maps = 3;
-    IODataDescSync desc = object.createReusableDesc(5, 1, bufLen,
+    IODataDescSync desc = object.createReusableDesc(8, 1, bufLen,
         IODataDescSync.IodType.ARRAY, 1, true);
-    IODataDescSync fetchDesc = object.createReusableDesc(5, 2, bufLen,
+    IODataDescSync fetchDesc = object.createReusableDesc(8, 2, bufLen,
         IODataDescSync.IodType.ARRAY, 1, false);
 //    IOSimpleDataDesc fetchDescSim = object.createSimpleDataDesc(4,  2, bufLen,
 //        null);
@@ -1677,6 +1677,43 @@ public class DaosObjectIT {
       verify(object, dkey2, akey2, offset, data, dq);
     } finally {
       desc.release();
+      object.close();
+    }
+  }
+
+  @Test
+  public void testIODescUpdSync() throws Exception {
+    DaosObjectId id = new DaosObjectId(random.nextInt(), lowSeq.incrementAndGet());
+    id.encode(client.getContPtr());
+    DaosObject object = client.getObject(id);
+    int bufLen = 100;
+    byte[] data = generateDataArray(bufLen);
+    DaosEventQueue dq = DaosEventQueue.getInstance(128);
+    String dkey = "dkey1";
+    String akey = "akey1";
+    ByteBuf buf = BufferAllocator.objBufWithNativeOrder(bufLen);
+    buf.writeBytes(data);
+    IODescUpdSync desc = new IODescUpdSync(dkey, akey, 0L, buf);
+    IOSimpleDDAsync fetchDesc = object.createAsyncDataDescForFetch(dkey, dq.getEqWrapperHdl());
+    try {
+      object.open();
+      object.punch();
+      object.updateSync(desc);
+      List<DaosEventQueue.Attachment> compList = new LinkedList<>();
+      // verify written bytes
+      fetchDesc.setEvent(dq.acquireEvent());
+      fetchDesc.addEntryForFetch(akey, 0L, bufLen);
+      object.fetchAsync(fetchDesc);
+      dq.waitForCompletion(5000, IOSimpleDDAsync.class, compList);
+      Assert.assertTrue(compList.size() == 1);
+      Assert.assertTrue(((IOSimpleDDAsync)compList.get(0)).isSucceeded());
+      Assert.assertEquals(bufLen, fetchDesc.getEntry(0).getActualSize());
+      byte[] fetchedData = new byte[bufLen];
+      fetchDesc.getEntry(0).getFetchedData().readBytes(fetchedData);
+      Assert.assertTrue(Arrays.equals(data, fetchedData));
+    } finally {
+      desc.release();
+      fetchDesc.release();
       object.close();
     }
   }

--- a/src/client/java/daos-java/src/test/java/io/daos/obj/IODataDescSyncTest.java
+++ b/src/client/java/daos-java/src/test/java/io/daos/obj/IODataDescSyncTest.java
@@ -2,11 +2,13 @@ package io.daos.obj;
 
 import io.daos.BufferAllocator;
 import io.daos.Constants;
+import io.daos.DaosUtils;
 import io.netty.buffer.ByteBuf;
 import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class IODataDescSyncTest {
@@ -269,16 +271,18 @@ public class IODataDescSyncTest {
     // record size
     Assert.assertEquals(10, descBuffer.readInt());
     // dkey
-    Assert.assertEquals(4, descBuffer.readShort());
-    byte keyBytes[] = new byte[4];
+    Assert.assertEquals(8, descBuffer.readShort());
+    byte keyBytes[] = new byte[8];
     descBuffer.readBytes(keyBytes);
-    Assert.assertTrue(Arrays.equals("dkey".getBytes(Constants.KEY_CHARSET), keyBytes));
-    descBuffer.readerIndex(descBuffer.readerIndex() + 10 - 4);
+    Assert.assertTrue(Arrays.equals(DaosUtils.keyToBytes8("dkey"), keyBytes));
+    // max key len - key length = 10 - 8
+    descBuffer.readerIndex(descBuffer.readerIndex() + 10 - 8);
     // entries
+    keyBytes = new byte[4];
     for (int i = 0; i < 2; i++) {
       Assert.assertEquals(4, descBuffer.readShort());
       descBuffer.readBytes(keyBytes);
-      Assert.assertTrue(Arrays.equals(("key" + i).getBytes(Constants.KEY_CHARSET), keyBytes));
+      Assert.assertTrue(Arrays.equals(("key" + i).getBytes(StandardCharsets.UTF_8), keyBytes));
       descBuffer.readerIndex(descBuffer.readerIndex() + 10 - 4);
       if (type == IODataDescSync.IodType.ARRAY) {
         Assert.assertEquals(0, descBuffer.readLong());
@@ -297,7 +301,7 @@ public class IODataDescSyncTest {
       desc = new IODataDescSync("dkey", IODataDescSync.IodType.SINGLE, 10, false);
       IODataDescSync.Entry entry = desc.addEntryForFetch("akey", 0, 10);
       desc.encode();
-      Assert.assertEquals(33, desc.getDescBuffer().writerIndex());
+      Assert.assertEquals(37, desc.getDescBuffer().writerIndex());
       ByteBuf descBuf = desc.getDescBuffer();
       descBuf.writeInt(8);
       descBuf.writeInt(8);
@@ -317,21 +321,22 @@ public class IODataDescSyncTest {
       IODataDescSync.Entry entry = desc.addEntryForFetch("akey", 0, 30);
       desc.encode();
       ByteBuf descBuf = desc.getDescBuffer();
-      Assert.assertEquals(45, descBuf.writerIndex());
+      Assert.assertEquals(49, descBuf.writerIndex());
       // not reusable
       descBuf.readerIndex(0);
       Assert.assertEquals(-1L, descBuf.readLong());
       // check iod type and record size
       Assert.assertEquals(IODataDescSync.IodType.ARRAY.getValue(), descBuf.readByte());
       Assert.assertEquals(10, descBuf.readInt());
-      // check dkey
-      Assert.assertEquals(4, descBuf.readShort());
-      byte keyBytes[] = new byte[4];
+      // check dkey and akey
+      Assert.assertEquals(8, descBuf.readShort());
+      byte keyBytes[] = new byte[8];
       descBuf.readBytes(keyBytes);
-      Assert.assertTrue(Arrays.equals("dkey".getBytes(Constants.KEY_CHARSET), keyBytes));
+      Assert.assertTrue(Arrays.equals(DaosUtils.keyToBytes8("dkey"), keyBytes));
+      keyBytes = new byte[4];
       Assert.assertEquals(4, descBuf.readShort());
       descBuf.readBytes(keyBytes);
-      Assert.assertTrue(Arrays.equals("akey".getBytes(Constants.KEY_CHARSET), keyBytes));
+      Assert.assertTrue(Arrays.equals("akey".getBytes(StandardCharsets.UTF_8), keyBytes));
       Assert.assertEquals(0, descBuf.readLong());
       Assert.assertEquals(3, descBuf.readInt());
       // parse


### PR DESCRIPTION
1. pad zero when dkey length is less than 8
2. fix some UT and IT
3. add new IO Desc to write only one akey entry for remote shuffle

Signed-off-by: Jifu Zhang <jiafu.zhang@intel.com>