### PR TITLE
DAOS-12104 control: Allow an optional second layer in domain path

### DIFF
--- a/src/common/fault_domain.c
+++ b/src/common/fault_domain.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2021 Intel Corporation.
+ * (C) Copyright 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -182,4 +182,17 @@ d_fd_get_exp_num_domains(uint32_t compressed_len, uint32_t exp_num_ranks,
 
 	*result = domain_len / FD_TREE_TUPLE_LEN;
 	return 0;
+}
+
+bool
+d_fd_node_is_group(struct d_fd_node *node)
+{
+	if (node == NULL)
+		return false;
+
+	if (node->fdn_type == D_FD_NODE_TYPE_DOMAIN &&
+	    node->fdn_val.dom->fd_level == D_FD_GROUP_DOMAIN_LEVEL)
+		return true;
+
+	return false;
 }

--- a/src/common/fault_domain.h
+++ b/src/common/fault_domain.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2021 Intel Corporation.
+ * (C) Copyright 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -8,6 +8,15 @@
 #define __DAOS_COMMON_FAULT_DOMAIN__
 
 #include <daos/common.h>
+
+/**
+ * The group domain level indicates which level (if any) represents the "group"
+ * domains.
+ *
+ * TODO DAOS-6353: Remove this when we have an arbitrary number of levels. At that
+ * point the concept of "groups" goes away.
+ */
+#define D_FD_GROUP_DOMAIN_LEVEL	2
 
 /**
  * Possible types of fault domain tree node.
@@ -124,5 +133,19 @@ d_fd_tree_reset(struct d_fd_tree *tree);
 int
 d_fd_get_exp_num_domains(uint32_t compressed_len, uint32_t exp_num_ranks,
 			 uint32_t *result);
+
+/**
+ * Determine whether the domain tree node is a group component.
+ *
+ * TODO DAOS-6353: Remove this when we have an arbitrary number of levels. At that
+ * point the concept of "groups" goes away.
+ *
+ * @param[in]	node	Node of a fault domain tree
+ *
+ * @return	true	if the node is at the right level to be a group component
+ *		false	otherwise
+ */
+bool
+d_fd_node_is_group(struct d_fd_node *node);
 
 #endif /* __DAOS_COMMON_FAULT_DOMAIN__ */

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1476,6 +1476,7 @@ add_domain_tree_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 	uint32_t		num_dom_comps;
 	uint32_t		num_grp_comps;
 	uint32_t		num_rank_comps;
+	uint32_t		num_comps;
 	uint8_t			new_status;
 	uint8_t			dom_type;
 	struct d_fd_tree	tree = {0};
@@ -1518,8 +1519,14 @@ add_domain_tree_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 		switch (node.fdn_type) {
 		case D_FD_NODE_TYPE_DOMAIN:
 			/* TODO DAOS-6353: Use the layer number as type */
-			dom_type = d_fd_node_is_group(&node) ? PO_COMP_TP_GRP : PO_COMP_TP_NODE;
-			fill_domain_comp(map, dom_type, &node, num_dom_comps, map_version,
+			if (d_fd_node_is_group(&node)) {
+				dom_type = PO_COMP_TP_GRP;
+				num_comps = num_grp_comps;
+			} else {
+				dom_type = PO_COMP_TP_NODE;
+				num_comps = num_dom_comps;
+			}
+			fill_domain_comp(map, dom_type, &node, num_comps, map_version,
 					 new_status, &map_comp);
 			if (map != NULL) {
 				struct pool_domain	*current;

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1437,11 +1437,10 @@ pool_map_merge(struct pool_map *map, uint32_t version,
 }
 
 static void
-fill_domain_comp(struct pool_map *map, struct d_fd_node *domain, int idx, int map_version,
-		 uint8_t new_status, struct pool_component *map_comp)
+fill_domain_comp(struct pool_map *map, uint8_t type, struct d_fd_node *domain, int idx,
+		 int map_version, uint8_t new_status, struct pool_component *map_comp)
 {
-	/* TODO DAOS-6353: Use the layer number as type */
-	map_comp->co_type = PO_COMP_TP_NODE;
+	map_comp->co_type = type;
 	map_comp->co_status = new_status;
 	map_comp->co_index = idx;
 	map_comp->co_id = domain->fdn_val.dom->fd_id;
@@ -1475,8 +1474,10 @@ add_domain_tree_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 {
 	int			rc;
 	uint32_t		num_dom_comps;
+	uint32_t		num_grp_comps;
 	uint32_t		num_rank_comps;
 	uint8_t			new_status;
+	uint8_t			dom_type;
 	struct d_fd_tree	tree = {0};
 	struct d_fd_node	node = {0};
 	bool			updated = false;
@@ -1486,11 +1487,14 @@ add_domain_tree_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 		new_status = PO_COMP_ST_NEW;
 		num_dom_comps = pool_map_find_domain(map, PO_COMP_TP_NODE,
 						     PO_COMP_ID_ALL, NULL);
+		num_grp_comps = pool_map_find_domain(map, PO_COMP_TP_GRP,
+						     PO_COMP_ID_ALL, NULL);
 		num_rank_comps = pool_map_find_domain(map, PO_COMP_TP_RANK,
 						      PO_COMP_ID_ALL, NULL);
 	} else {
 		new_status = PO_COMP_ST_UPIN;
 		num_dom_comps = 0;
+		num_grp_comps = 0;
 		num_rank_comps = 0;
 	}
 
@@ -1513,24 +1517,30 @@ add_domain_tree_to_pool_buf(struct pool_map *map, struct pool_buf *map_buf,
 
 		switch (node.fdn_type) {
 		case D_FD_NODE_TYPE_DOMAIN:
-			fill_domain_comp(map, &node, num_dom_comps, map_version, new_status,
-					 &map_comp);
+			/* TODO DAOS-6353: Use the layer number as type */
+			dom_type = d_fd_node_is_group(&node) ? PO_COMP_TP_GRP : PO_COMP_TP_NODE;
+			fill_domain_comp(map, dom_type, &node, num_dom_comps, map_version,
+					 new_status, &map_comp);
 			if (map != NULL) {
 				struct pool_domain	*current;
 				int			already_in_map;
 
 				already_in_map = pool_map_find_domain(map,
-								      PO_COMP_TP_NODE,
-									map_comp.co_id,
-									&current);
+								      dom_type,
+								      map_comp.co_id,
+								      &current);
 				if (already_in_map > 0) {
 					D_DEBUG(DB_TRACE, "domain %d already in map\n",
 						map_comp.co_id);
 					map_comp.co_status = current->do_comp.co_status;
 					map_comp.co_index = current->do_comp.co_index;
+				} else if (dom_type == PO_COMP_TP_GRP) {
+					num_grp_comps++;
 				} else {
 					num_dom_comps++;
 				}
+			} else if (dom_type == PO_COMP_TP_GRP) {
+				num_grp_comps++;
 			} else {
 				num_dom_comps++;
 			}
@@ -1591,7 +1601,6 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_versio
 	uint32_t		num_comps;
 	uint8_t			new_status;
 	int			i, rc;
-	unsigned		num_pd = 0;
 	uint32_t		num_domain_comps = 0;
 	d_rank_list_t		*ordered_ranks;
 
@@ -1606,21 +1615,6 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_versio
 	D_ASSERT(num_domain_comps > 0);
 	num_domain_comps--; /* remove the root domain - allocated separately */
 
-	if (map == NULL) {
-		/* Temporary hack to pass in the performance domain info before control plane
-		 * support available.
-		 */
-		d_getenv_int("DAOS_PD_NUM", &num_pd);
-		if (num_pd < 2)
-			num_pd = 0;
-		if (num_pd > num_domain_comps) {
-			D_ERROR("invalid num_perf_dom %d > num_fault_dom %d\n",
-				num_pd, num_domain_comps);
-			return -DER_INVAL;
-		}
-		num_domain_comps += num_pd;
-	}
-
 	ordered_ranks = d_rank_list_alloc(nnodes);
 	if (ordered_ranks == NULL)
 		return -DER_NOMEM;
@@ -1628,35 +1622,6 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_versio
 	map_buf = pool_buf_alloc(num_domain_comps + nnodes + ntargets);
 	if (map_buf == NULL)
 		D_GOTO(out_ranks, rc = -DER_NOMEM);
-
-	/* firstly add performance domain */
-	if (num_pd > 0) {
-		uint32_t	num_fdom, fdom_per_pd;
-
-		num_fdom = num_domain_comps - num_pd;
-		fdom_per_pd = num_fdom / num_pd;
-		for (i = 0; i < num_pd; i++) {
-			map_comp.co_type = PO_COMP_TP_GRP;
-			map_comp.co_status = PO_COMP_ST_UPIN;
-			map_comp.co_padding = 0;
-			map_comp.co_id = i;
-			map_comp.co_rank = i;
-			map_comp.co_ver = map_version;
-			map_comp.co_in_ver = map_version;
-			map_comp.co_fseq = 1;
-			map_comp.co_flags = PO_COMPF_NONE;
-			map_comp.co_nr = fdom_per_pd;
-			if ((num_fdom % num_pd) != 0 && i < (num_fdom % num_pd))
-				map_comp.co_nr++;
-
-			rc = pool_buf_attach(map_buf, &map_comp, 1 /* comp_nr */);
-			if (rc != 0) {
-				D_ERROR("failed to attach to pool buf, "DF_RC"\n",
-					DP_RC(rc));
-				D_GOTO(out_map_buf, rc);
-			}
-		}
-	}
 
 	rc = add_domain_tree_to_pool_buf(map, map_buf, map_version, dss_tgt_nr, ndomains,
 					 domains, ordered_ranks);

--- a/src/common/tests/fault_domain_tests.c
+++ b/src/common/tests/fault_domain_tests.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2021 Intel Corporation.
+ * (C) Copyright 2021-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -255,6 +255,39 @@ test_fd_get_exp_num_domains(void **state)
 	assert_int_equal(result, 3);
 }
 
+static void
+test_fd_node_is_group(void **state)
+{
+	struct d_fd_node	dom_node = {0};
+	struct d_fd_node	rank_node = {0};
+	struct d_fault_domain	dom = {0};
+
+	/* setup domain node */
+	dom_node.fdn_type = D_FD_NODE_TYPE_DOMAIN;
+	dom_node.fdn_val.dom = &dom;
+
+	/* setup rank node */
+	rank_node.fdn_type = D_FD_NODE_TYPE_RANK;
+
+	/* null input */
+	assert_false(d_fd_node_is_group(NULL));
+
+	/* rank node */
+	assert_false(d_fd_node_is_group(&rank_node));
+
+	/* group level */
+	dom.fd_level = D_FD_GROUP_DOMAIN_LEVEL;
+	assert_true(d_fd_node_is_group(&dom_node));
+
+	/* level higher than group */
+	dom.fd_level = D_FD_GROUP_DOMAIN_LEVEL + 1;
+	assert_false(d_fd_node_is_group(&dom_node));
+
+	/* level lower than group */
+	dom.fd_level = D_FD_GROUP_DOMAIN_LEVEL - 1;
+	assert_false(d_fd_node_is_group(&dom_node));
+}
+
 int
 main(void)
 {
@@ -268,6 +301,7 @@ main(void)
 		cmocka_unit_test(test_fd_tree_next_len_bigger_than_tree),
 		cmocka_unit_test(test_fd_tree_reset),
 		cmocka_unit_test(test_fd_get_exp_num_domains),
+		cmocka_unit_test(test_fd_node_is_group),
 	};
 
 	return cmocka_run_group_tests_name("common_fault_domain",

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -87,7 +87,7 @@ var (
 	)
 	FaultConfigTooManyLayersInFaultDomain = serverConfigFault(
 		code.ServerConfigFaultDomainTooManyLayers,
-		"only a single fault domain layer below the root is supported",
+		"the fault domain path may have a maximum of 2 levels below the root",
 		"update either the fault domain ('fault_path' parameter) or callback script ('fault_cb' parameter) and restart the control server",
 	)
 	FaultConfigHugepagesDisabled = serverConfigFault(

--- a/src/control/server/faultdomain.go
+++ b/src/control/server/faultdomain.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -58,7 +58,7 @@ func newFaultDomainFromConfig(domainStr string) (*system.FaultDomain, error) {
 		return nil, config.FaultConfigFaultDomainInvalid
 	}
 	// TODO DAOS-6353: remove when multiple layers supported
-	if fd.NumLevels() != 1 {
+	if fd.NumLevels() > 2 {
 		return nil, config.FaultConfigTooManyLayersInFaultDomain
 	}
 	return fd, nil

--- a/src/control/server/faultdomain_test.go
+++ b/src/control/server/faultdomain_test.go
@@ -91,11 +91,17 @@ func TestServer_getFaultDomain(t *testing.T) {
 		"nil cfg": {
 			expErr: config.FaultBadConfig,
 		},
-		"cfg fault path": {
+		"single-layer fault path": {
 			cfg: &config.Server{
 				FaultPath: validFaultDomain,
 			},
 			expResult: validFaultDomain,
+		},
+		"two-layer fault path": {
+			cfg: &config.Server{
+				FaultPath: "/grp1/host0",
+			},
+			expResult: "/grp1/host0",
 		},
 		"cfg fault path is not valid": {
 			cfg: &config.Server{
@@ -109,9 +115,9 @@ func TestServer_getFaultDomain(t *testing.T) {
 			},
 			expErr: config.FaultConfigFaultDomainInvalid,
 		},
-		"too many layers": { // TODO DAOS-6353: change when multiple layers supported
+		"too many layers": { // TODO DAOS-6353: change when arbitrary layers supported
 			cfg: &config.Server{
-				FaultPath: "/rack1/host0",
+				FaultPath: "/rack1/grp1/host0",
 			},
 			expErr: config.FaultConfigTooManyLayersInFaultDomain,
 		},
@@ -229,7 +235,7 @@ func TestServer_getFaultDomainFromCallback(t *testing.T) {
 	createFaultCBScriptFile(t, invalidScriptPath, 0755, "some junk")
 
 	multiLayerScriptPath := filepath.Join(tmpDir, "multilayer.sh")
-	createFaultCBScriptFile(t, multiLayerScriptPath, 0755, "/one/two")
+	createFaultCBScriptFile(t, multiLayerScriptPath, 0755, "/one/two/three")
 
 	rootScriptPath := filepath.Join(tmpDir, "rootdomain.sh")
 	createFaultCBScriptFile(t, rootScriptPath, 0755, "/")


### PR DESCRIPTION
- Add support for a second layer in fault_path in config yaml.
- Update pool map parsing to understand the second layer, if it exists, as PO_COMP_TP_GRP.
- Remove previous hacks to add group components.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
