### PR TITLE
DAOS-12108 cart: Fix segfault over secondary provider

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1852,18 +1852,10 @@ crt_group_config_path_set(const char *path)
 int
 crt_nr_secondary_remote_tags_set(int idx, int num_tags)
 {
-	struct crt_prov_gdata *prov_data;
-
 	D_DEBUG(DB_ALL, "secondary_idx=%d num_tags=%d\n", idx, num_tags);
 
 	if (idx != 0) {
 		D_ERROR("Only idx=0 is currently supported\n");
-		return -DER_NONEXIST;
-	}
-
-	if ((crt_gdata.cg_prov_gdata_secondary == NULL) ||
-	    (idx >= crt_gdata.cg_num_secondary_provs)) {
-		D_ERROR("Secondary providers not initialized\n");
 		return -DER_NONEXIST;
 	}
 
@@ -1872,8 +1864,7 @@ crt_nr_secondary_remote_tags_set(int idx, int num_tags)
 		return -DER_INVAL;
 	}
 
-	prov_data = &crt_gdata.cg_prov_gdata_secondary[idx];
-	prov_data->cpg_num_remote_tags = num_tags;
+	crt_gdata.cg_num_remote_tags = num_tags;
 
 	return DER_SUCCESS;
 }

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -199,6 +199,10 @@ static int data_init(int server, crt_init_options_t *opt)
 	crt_gdata.cg_inited = 0;
 	crt_gdata.cg_primary_prov = CRT_PROV_OFI_SOCKETS;
 
+	/* By default set number of secondary remote tags to 1 */
+	crt_gdata.cg_num_remote_tags = 1;
+	crt_gdata.cg_last_remote_tag = 0;
+
 	d_srand(d_timeus_secdiff(0) + getpid());
 	start_rpcid = ((uint64_t)d_rand()) << 32;
 

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -115,6 +115,12 @@ struct crt_gdata {
 
 	ATOMIC uint64_t		cg_rpcid; /* rpc id */
 
+	/** Last remote tag sent */
+	uint32_t		cg_last_remote_tag;
+
+	/** Number of remote tags */
+	uint32_t		cg_num_remote_tags;
+
 	/* protects crt_gdata */
 	pthread_rwlock_t	cg_rwlock;
 


### PR DESCRIPTION
- daos tool crashed when running over a secondary provider 
- This issue was caused by wrong structure being used on the client end.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficent testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
