### PR TITLE
DAOS_11605 common: register arena type for large allocation

### DIFF
--- a/src/common/ad_mem.h
+++ b/src/common/ad_mem.h
@@ -266,12 +266,6 @@ struct ad_blob_df {
 	uint32_t		bd_magic;
 	/** version number */
 	uint32_t		bd_version;
-	/** alignment */
-	int32_t			bd_unused;
-	/** number of registered arena types */
-	int32_t			bd_asp_nr;
-	/** specifications of registered arena types */
-	struct ad_arena_spec	bd_asp[ARENA_SPEC_MAX];
 	/** loading incarnation */
 	uint64_t		bd_incarnation;
 	/** it is DRAM reference of blob */
@@ -282,6 +276,10 @@ struct ad_blob_df {
 	uint64_t		bd_size;
 	/** size of each arena, default size is 16MB */
 	uint64_t		bd_arena_size;
+	/** specifications of registered arena types */
+	struct ad_arena_spec	bd_asp[ARENA_SPEC_MAX];
+	/** reserve some bytes for future usage */
+	uint64_t		bd_reserved[4];
 	/** allocated bits */
 	uint64_t		bd_bmap[0];
 };

--- a/src/include/daos_srv/ad_mem.h
+++ b/src/include/daos_srv/ad_mem.h
@@ -123,6 +123,18 @@ struct ad_group_spec {
 	uint32_t		gs_count;
 };
 
+/** reserved arena types */
+enum {
+	ARENA_TYPE_DEF		= 0,
+	ARENA_TYPE_LARGE	= 1,
+	/**
+	 * type={0, 1, 2, 3} are for internal usage, customized arena should between
+	 * ARENA_TYPE_BASE and ARENA_TYPE_MAX.
+	 */
+	ARENA_TYPE_BASE		= 4,
+	ARENA_TYPE_MAX		= 31,
+};
+
 int ad_arena_register(struct ad_blob_handle bh, unsigned int arena_type,
 		      struct ad_group_spec *specs, unsigned int specs_nr);
 daos_off_t ad_reserve(struct ad_blob_handle bh, int type, daos_size_t size, uint32_t *arena_id,


### PR DESCRIPTION
DAOS engine may allocate large chunk for DTX, ad_mem should support it as well. umem layer should use AD_ARENA_LARGE flag to reserve space if size > 4K.

- Fix a bug in bits number calculation for reserving group
- Removed registered arena specification counter
- Add unit test for large allocation
- Decrease the mimimum unit count per group to 2 (2MB is huge page size)
- Add more error messages

Signed-off-by: Liang Zhen <liang.zhen@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
