### PR TITLE
DAOS-12119 control: Handle -DER_NONEXIST on retried PoolDestroy

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -305,7 +305,17 @@ func PoolDestroy(ctx context.Context, rpcClient UnaryInvoker, req *PoolDestroyRe
 		return err
 	}
 
-	return errors.Wrap(ur.getMSError(), "pool destroy failed")
+	if err := ur.getMSError(); err != nil {
+		// If the error is due to a retried destroy failing to find
+		// the pool, then we can assume that the pool was destroyed
+		// via a server-side cleanup and we can intercept it. Everything
+		// else is still an error.
+		if !(ur.retryCount > 0 && errors.Cause(err) == daos.Nonexistent) {
+			return errors.Wrap(err, "pool destroy failed")
+		}
+	}
+
+	return nil
 }
 
 // PoolUpgradeReq contains the parameters for a pool upgrade request.

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -88,6 +88,28 @@ func TestControl_PoolDestroy(t *testing.T) {
 				},
 			},
 		},
+		"-DER_NONEXIST on first try is not retried": {
+			req: &PoolDestroyReq{
+				ID: test.MockUUID(),
+			},
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", daos.Nonexistent, nil),
+				},
+			},
+			expErr: daos.Nonexistent,
+		},
+		"-DER_NONEXIST on retry is treated as success": {
+			req: &PoolDestroyReq{
+				ID: test.MockUUID(),
+			},
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", daos.TimedOut, nil),
+					MockMSResponse("host1", daos.Nonexistent, nil),
+				},
+			},
+		},
 		"DataPlaneNotStarted error is retried": {
 			req: &PoolDestroyReq{
 				ID: test.MockUUID(),

--- a/src/control/lib/control/response.go
+++ b/src/control/lib/control/response.go
@@ -157,9 +157,10 @@ func (hem HostErrorsMap) Keys() []string {
 // UnaryResponse contains a slice of *HostResponse items returned
 // from synchronous unary RPC invokers.
 type UnaryResponse struct {
-	Responses []*HostResponse
-	fromMS    bool
-	log       debugLogger
+	Responses  []*HostResponse
+	fromMS     bool
+	retryCount uint
+	log        debugLogger
 }
 
 func (ur *UnaryResponse) debugf(format string, args ...interface{}) {

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -412,7 +412,7 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 			return nil, wrapReqTimeout(req, err)
 		}
 
-		ur := &UnaryResponse{log: log, fromMS: true}
+		ur := &UnaryResponse{log: log, fromMS: true, retryCount: try}
 		err = gatherResponses(tryCtx, respChan, ur)
 		if isHardFailure(err, reqCtx) {
 			return nil, wrapReqTimeout(req, err)


### PR DESCRIPTION
In the event that a PoolDestroy RPC is retried and the pool is
destroyed while the client is waiting to retry, the server will
return a -DER_NONEXIST in response to the final retry. As this
is not really an error, just catch it and signal success.

Test-repeat-vm: 10

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
