### PR TITLE
DAOS-11919 control: Add concurrent pool ops protection (#10668)

### DIFF
--- a/src/control/common/test/mocks.go
+++ b/src/control/common/test/mocks.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"net"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 var hostAddrs = make(map[int32]*net.TCPAddr)
@@ -35,6 +37,13 @@ func MockUUID(varIdx ...int32) string {
 	idx := GetIndex(varIdx...)
 
 	return fmt.Sprintf("%08d-%04d-%04d-%04d-%012d", idx, idx, idx, idx, idx)
+}
+
+// MockPoolUUID returns mock pool UUID values for use in tests.
+func MockPoolUUID(varIdx ...int32) uuid.UUID {
+	idx := GetIndex(varIdx...)
+
+	return uuid.MustParse(fmt.Sprintf("%08d-%04d-%04d-%04d-%012d", idx, idx, idx, idx, idx))
 }
 
 // MockHostAddr returns mock tcp addresses for use in tests.

--- a/src/control/common/test/utils.go
+++ b/src/control/common/test/utils.go
@@ -189,6 +189,9 @@ func ShowBufferOnFailure(t *testing.T, buf fmt.Stringer) {
 	if t.Failed() {
 		fmt.Printf("captured log output:\n%s", buf.String())
 	}
+	if r, ok := buf.(interface{ Reset() }); ok {
+		r.Reset()
+	}
 }
 
 // DefaultCmpOpts gets default go-cmp comparison options for tests.

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -92,6 +92,7 @@ const (
 const (
 	SystemUnknown Code = iota + 400
 	SystemBadFaultDomainDepth
+	SystemPoolLocked
 )
 
 // client fault codes

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -209,7 +209,7 @@ func (r *poolRequest) canRetry(reqErr error, try uint) bool {
 		}
 	case *fault.Fault:
 		switch e.Code {
-		case code.ServerDataPlaneNotStarted:
+		case code.ServerDataPlaneNotStarted, code.SystemPoolLocked:
 			return true
 		default:
 			return false

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -242,8 +242,8 @@ func SystemQuery(ctx context.Context, rpcClient UnaryInvoker, req *SystemQueryRe
 		}
 		return nil
 	}
-	rpcClient.Debugf("DAOS system query request: %+v", req)
 
+	rpcClient.Debugf("DAOS system query request: %s", mgmtpb.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err

--- a/src/control/server/mgmt_cont_test.go
+++ b/src/control/server/mgmt_cont_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	mockUUID = "00000000-0000-0000-0000-000000000000"
+	mockUUID = "11111111-1111-1111-1111-111111111111"
 )
 
 func makeBadBytes(count int) (badBytes []byte) {

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -18,6 +18,8 @@ import (
 
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -44,6 +46,20 @@ type poolServiceReq interface {
 	SetUUID(uuid.UUID)
 	GetSvcRanks() []uint32
 	SetSvcRanks(rl []uint32)
+}
+
+func (svc *mgmtSvc) makeLockedPoolServiceCall(ctx context.Context, method drpc.Method, req poolServiceReq) (*drpc.Response, error) {
+	ps, err := svc.getPoolService(req.GetId())
+	if err != nil {
+		return nil, err
+	}
+	lock, err := svc.sysdb.TakePoolLock(ctx, ps.PoolUUID)
+	if err != nil {
+		return nil, err
+	}
+	defer lock.Release()
+
+	return svc.makePoolServiceCall(lock.InContext(ctx), method, req)
 }
 
 func (svc *mgmtSvc) makePoolServiceCall(ctx context.Context, method drpc.Method, req poolServiceReq) (*drpc.Response, error) {
@@ -90,12 +106,12 @@ func (svc *mgmtSvc) resolvePoolID(id string) (uuid.UUID, error) {
 
 // getPoolService returns the pool service entry for the given UUID.
 func (svc *mgmtSvc) getPoolService(id string) (*system.PoolService, error) {
-	uuid, err := svc.resolvePoolID(id)
+	poolUUID, err := svc.resolvePoolID(id)
 	if err != nil {
 		return nil, err
 	}
 
-	ps, err := svc.sysdb.FindPoolServiceByUUID(uuid)
+	ps, err := svc.sysdb.FindPoolServiceByUUID(poolUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -229,20 +245,27 @@ func (svc *mgmtSvc) calculateCreateStorage(req *mgmtpb.PoolCreateReq) error {
 // Validate minimum SCM/NVMe pool size per VOS target, pool size request params
 // are per-engine so need to be larger than (minimum_target_allocation *
 // target_count).
-func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (resp *mgmtpb.PoolCreateResp, err error) {
+func (svc *mgmtSvc) PoolCreate(parent context.Context, req *mgmtpb.PoolCreateReq) (resp *mgmtpb.PoolCreateResp, err error) {
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
 
 	svc.log.Debugf("MgmtSvc.PoolCreate dispatch, req:%s\n", mgmtpb.Debug(req))
 
-	uuid, err := uuid.Parse(req.GetUuid())
+	poolUUID, err := uuid.Parse(req.GetUuid())
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse pool UUID %q", req.GetUuid())
 	}
 
+	lock, err := svc.sysdb.TakePoolLock(parent, poolUUID)
+	if err != nil {
+		return nil, err
+	}
+	defer lock.Release()
+	ctx := lock.InContext(parent)
+
 	resp = new(mgmtpb.PoolCreateResp)
-	ps, err := svc.sysdb.FindPoolServiceByUUID(uuid)
+	ps, err := svc.sysdb.FindPoolServiceByUUID(poolUUID)
 	if ps != nil {
 		svc.log.Debugf("found pool %s state=%s", ps.PoolUUID, ps.State)
 		resp.Status = int32(drpc.DaosAlready)
@@ -362,9 +385,9 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		return nil, err
 	}
 
-	ps = system.NewPoolService(uuid, req.Tierbytes, system.RanksFromUint32(req.GetRanks()))
+	ps = system.NewPoolService(poolUUID, req.Tierbytes, system.RanksFromUint32(req.GetRanks()))
 	ps.PoolLabel = poolLabel
-	if err := svc.sysdb.AddPoolService(ps); err != nil {
+	if err := svc.sysdb.AddPoolService(ctx, ps); err != nil {
 		return nil, err
 	}
 
@@ -409,7 +432,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 	dresp, err := svc.harness.CallDrpc(ctx, drpc.MethodPoolCreate, req)
 	if err != nil {
 		svc.log.Errorf("pool create dRPC call failed: %s", err)
-		if err := svc.sysdb.RemovePoolService(ps.PoolUUID); err != nil {
+		if err := svc.sysdb.RemovePoolService(ctx, ps.PoolUUID); err != nil {
 			return nil, err
 		}
 
@@ -429,7 +452,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 	}
 
 	if resp.GetStatus() != 0 {
-		if err := svc.sysdb.RemovePoolService(ps.PoolUUID); err != nil {
+		if err := svc.sysdb.RemovePoolService(ctx, ps.PoolUUID); err != nil {
 			return nil, err
 		}
 
@@ -438,7 +461,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 
 	ps.Replicas = system.RanksFromUint32(resp.GetSvcReps())
 	ps.State = system.PoolServiceStateReady
-	if err := svc.sysdb.UpdatePoolService(ps); err != nil {
+	if err := svc.sysdb.UpdatePoolService(ctx, ps); err != nil {
 		return nil, err
 	}
 
@@ -450,7 +473,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 // checkPools iterates over the list of pools in the system to check
 // for any that are in an unexpected state. Pools not in the Ready
 // state will be cleaned up and removed from the system.
-func (svc *mgmtSvc) checkPools(ctx context.Context, psList ...*system.PoolService) error {
+func (svc *mgmtSvc) checkPools(parent context.Context, psList ...*system.PoolService) error {
 	if err := svc.sysdb.CheckLeader(); err != nil {
 		return err
 	}
@@ -469,6 +492,17 @@ func (svc *mgmtSvc) checkPools(ctx context.Context, psList ...*system.PoolServic
 			continue
 		}
 
+		lock, err := svc.sysdb.TakePoolLock(parent, ps.PoolUUID)
+		if err != nil {
+			if fault.IsFaultCode(err, code.SystemPoolLocked) {
+				svc.log.Noticef("skipping cleanup on pool %s: %s", ps.PoolUUID, err)
+				continue
+			}
+			return err
+		}
+		defer lock.Release()
+		ctx := lock.InContext(parent)
+
 		svc.log.Errorf("pool %s is in unexpected state %s", ps.PoolUUID, ps.State)
 
 		// Change the pool state to Destroying in order to trigger
@@ -477,7 +511,7 @@ func (svc *mgmtSvc) checkPools(ctx context.Context, psList ...*system.PoolServic
 		// will be removed from the system.
 		if ps.State != system.PoolServiceStateDestroying {
 			ps.State = system.PoolServiceStateDestroying
-			if err := svc.sysdb.UpdatePoolService(ps); err != nil {
+			if err := svc.sysdb.UpdatePoolService(ctx, ps); err != nil {
 				return errors.Wrapf(err, "failed to update pool %s", ps.PoolUUID)
 			}
 		}
@@ -489,8 +523,9 @@ func (svc *mgmtSvc) checkPools(ctx context.Context, psList ...*system.PoolServic
 			Id:    ps.PoolUUID.String(),
 		}
 
-		_, err := svc.PoolDestroy(ctx, dr)
-		if err != nil {
+		if _, err := svc.PoolDestroy(ctx, dr); err != nil {
+			// Best effort cleanup. If the pool destroy fails here,
+			// another leadership step-up should get it eventually.
 			svc.log.Errorf("error while destroying pool %s: %s", ps.PoolUUID, err)
 		}
 	}
@@ -499,7 +534,7 @@ func (svc *mgmtSvc) checkPools(ctx context.Context, psList ...*system.PoolServic
 }
 
 // PoolDestroy implements the method defined for the Management Service.
-func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq) (*mgmtpb.PoolDestroyResp, error) {
+func (svc *mgmtSvc) PoolDestroy(parent context.Context, req *mgmtpb.PoolDestroyReq) (*mgmtpb.PoolDestroyResp, error) {
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
@@ -509,6 +544,13 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 	if err != nil {
 		return nil, err
 	}
+
+	lock, err := svc.sysdb.TakePoolLock(parent, poolUUID)
+	if err != nil {
+		return nil, err
+	}
+	defer lock.Release()
+	ctx := lock.InContext(parent)
 
 	ps, err := svc.sysdb.FindPoolServiceByUUID(poolUUID)
 	if err != nil {
@@ -541,7 +583,7 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 		// and persist the update(s).
 		if req.Force || (ds != drpc.DaosBusy && ds != drpc.DaosNoService) {
 			ps.State = system.PoolServiceStateDestroying
-			if err := svc.sysdb.UpdatePoolService(ps); err != nil {
+			if err := svc.sysdb.UpdatePoolService(ctx, ps); err != nil {
 				return nil, errors.Wrapf(err, "failed to update pool %s", poolUUID)
 			}
 		}
@@ -584,7 +626,7 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 
 	ds := drpc.DaosStatus(resp.Status)
 	if ds == drpc.DaosSuccess {
-		if err := svc.sysdb.RemovePoolService(poolUUID); err != nil {
+		if err := svc.sysdb.RemovePoolService(ctx, poolUUID); err != nil {
 			// In rare cases, there may be a race between pool cleanup handlers.
 			// As we know the service entry existed when we started this handler,
 			// if the attempt to remove it now fails because it doesn't exist,
@@ -607,7 +649,7 @@ func (svc *mgmtSvc) PoolEvict(ctx context.Context, req *mgmtpb.PoolEvictReq) (*m
 	}
 	svc.log.Debugf("MgmtSvc.PoolEvict dispatch, req:%+v\n", req)
 
-	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolEvict, req)
+	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolEvict, req)
 	if err != nil {
 		return nil, err
 	}
@@ -629,7 +671,7 @@ func (svc *mgmtSvc) PoolExclude(ctx context.Context, req *mgmtpb.PoolExcludeReq)
 	}
 	svc.log.Debugf("MgmtSvc.PoolExclude dispatch, req:%+v\n", req)
 
-	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolExclude, req)
+	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolExclude, req)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +693,7 @@ func (svc *mgmtSvc) PoolDrain(ctx context.Context, req *mgmtpb.PoolDrainReq) (*m
 	}
 	svc.log.Debugf("MgmtSvc.PoolDrain dispatch, req:%+v\n", req)
 
-	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolDrain, req)
+	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolDrain, req)
 	if err != nil {
 		return nil, err
 	}
@@ -691,7 +733,7 @@ func (svc *mgmtSvc) PoolExtend(ctx context.Context, req *mgmtpb.PoolExtendReq) (
 
 	svc.log.Debugf("MgmtSvc.PoolExtend forwarding modified req:%+v\n", req)
 
-	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolExtend, req)
+	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolExtend, req)
 	if err != nil {
 		return nil, err
 	}
@@ -713,7 +755,7 @@ func (svc *mgmtSvc) PoolReintegrate(ctx context.Context, req *mgmtpb.PoolReinteg
 	}
 	svc.log.Debugf("MgmtSvc.PoolReintegrate dispatch, req:%+v\n", req)
 
-	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolReintegrate, req)
+	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolReintegrate, req)
 	if err != nil {
 		return nil, err
 	}
@@ -757,7 +799,7 @@ func (svc *mgmtSvc) PoolUpgrade(ctx context.Context, req *mgmtpb.PoolUpgradeReq)
 	}
 	svc.log.Debugf("MgmtSvc.PoolUpgrade dispatch, req:%+v\n", req)
 
-	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolUpgrade, req)
+	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolUpgrade, req)
 	if err != nil {
 		return nil, err
 	}
@@ -825,20 +867,27 @@ func (svc *mgmtSvc) updatePoolLabel(ctx context.Context, sys string, uuid uuid.U
 	// Persist the label update in the MS DB if the
 	// dRPC call succeeded.
 	ps.PoolLabel = label
-	return svc.sysdb.UpdatePoolService(ps)
+	return svc.sysdb.UpdatePoolService(ctx, ps)
 }
 
 // PoolSetProp forwards a request to the I/O Engine to set pool properties.
-func (svc *mgmtSvc) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq) (*mgmtpb.PoolSetPropResp, error) {
+func (svc *mgmtSvc) PoolSetProp(parent context.Context, req *mgmtpb.PoolSetPropReq) (*mgmtpb.PoolSetPropResp, error) {
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
 	svc.log.Debugf("MgmtSvc.PoolSetProp dispatch, req:%+v", req)
 
-	uuid, err := svc.resolvePoolID(req.GetId())
+	poolUUID, err := svc.resolvePoolID(req.GetId())
 	if err != nil {
 		return nil, err
 	}
+
+	lock, err := svc.sysdb.TakePoolLock(parent, poolUUID)
+	if err != nil {
+		return nil, err
+	}
+	defer lock.Release()
+	ctx := lock.InContext(parent)
 
 	if len(req.GetProperties()) == 0 {
 		return nil, errors.New("PoolSetProp() request with 0 properties")
@@ -850,7 +899,7 @@ func (svc *mgmtSvc) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq)
 		// and also to update the pool service entry. Handle it first and separately
 		// so that if it fails, none of the other props are changed.
 		if prop.GetNumber() == drpc.PoolPropertyLabel {
-			if err := svc.updatePoolLabel(ctx, req.GetSys(), uuid, prop); err != nil {
+			if err := svc.updatePoolLabel(ctx, req.GetSys(), poolUUID, prop); err != nil {
 				return nil, err
 			}
 			continue
@@ -943,7 +992,7 @@ func (svc *mgmtSvc) PoolOverwriteACL(ctx context.Context, req *mgmtpb.ModifyACLR
 	}
 	svc.log.Debugf("MgmtSvc.PoolOverwriteACL dispatch, req:%+v\n", req)
 
-	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolOverwriteACL, req)
+	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolOverwriteACL, req)
 	if err != nil {
 		return nil, err
 	}
@@ -966,7 +1015,7 @@ func (svc *mgmtSvc) PoolUpdateACL(ctx context.Context, req *mgmtpb.ModifyACLReq)
 	}
 	svc.log.Debugf("MgmtSvc.PoolUpdateACL dispatch, req:%+v\n", req)
 
-	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolUpdateACL, req)
+	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolUpdateACL, req)
 	if err != nil {
 		return nil, err
 	}
@@ -989,7 +1038,7 @@ func (svc *mgmtSvc) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq)
 	}
 	svc.log.Debugf("MgmtSvc.PoolDeleteACL dispatch, req:%+v\n", req)
 
-	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolDeleteACL, req)
+	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolDeleteACL, req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -32,6 +32,21 @@ import (
 	"github.com/daos-stack/daos/src/control/system"
 )
 
+func getPoolLockCtx(t *testing.T, parent context.Context, sysdb *system.Database, poolUUID uuid.UUID) (*system.PoolLock, context.Context) {
+	t.Helper()
+
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	lock, err := sysdb.TakePoolLock(parent, poolUUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return lock, lock.InContext(parent)
+}
+
 func addTestPoolService(t *testing.T, sysdb *system.Database, ps *system.PoolService) {
 	t.Helper()
 
@@ -52,7 +67,9 @@ func addTestPoolService(t *testing.T, sysdb *system.Database, ps *system.PoolSer
 		i++
 	}
 
-	if err := sysdb.AddPoolService(ps); err != nil {
+	lock, ctx := getPoolLockCtx(t, nil, sysdb, ps.PoolUUID)
+	defer lock.Release()
+	if err := sysdb.AddPoolService(ctx, ps); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -110,20 +127,21 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 			defer test.ShowBufferOnFailure(t, buf)
 
 			svc := newTestMgmtSvc(t, log)
-			if err := svc.sysdb.AddPoolService(&system.PoolService{
-				PoolUUID: uuid.MustParse(test.MockUUID(0)),
+			poolUUID := test.MockPoolUUID(1)
+			lock, ctx := getPoolLockCtx(t, nil, svc.sysdb, poolUUID)
+			defer lock.Release()
+
+			if err := svc.sysdb.AddPoolService(ctx, &system.PoolService{
+				PoolUUID: poolUUID,
 				State:    tc.state,
 				Storage:  &system.PoolServiceStorage{},
 			}); err != nil {
 				t.Fatal(err)
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			req := &mgmtpb.PoolCreateReq{
 				Sys:        build.DefaultSystemName,
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Totalbytes: engine.ScmMinBytesPerTarget,
 				Properties: testPoolLabelProp(),
 			}
@@ -289,7 +307,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			mgmtSvc:     missingSB,
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -299,7 +317,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			mgmtSvc:     notAP,
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -308,7 +326,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"dRPC send fails": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -317,7 +335,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"zero target count": {
 			targetCount: 0,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -326,7 +344,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"garbage resp": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -341,7 +359,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"successful creation": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Properties: testPoolLabelProp(),
 			},
@@ -353,7 +371,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"successful creation minimum size": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{engine.ScmMinBytesPerTarget * 8, engine.NvmeMinBytesPerTarget * 8},
 				Properties: testPoolLabelProp(),
 			},
@@ -365,7 +383,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"successful creation auto size": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Totalbytes: 100 * humanize.GiByte,
 				Properties: testPoolLabelProp(),
 			},
@@ -377,7 +395,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"failed creation invalid ranks": {
 			targetCount: 1,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Ranks:      []uint32{40, 11},
 				Properties: testPoolLabelProp(),
@@ -387,7 +405,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"failed creation invalid number of ranks": {
 			targetCount: 1,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+				Uuid:       test.MockUUID(1),
 				Tierbytes:  []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 				Numranks:   3,
 				Properties: testPoolLabelProp(),
@@ -397,8 +415,8 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"svc replicas > max": {
 			targetCount: 1,
 			memberCount: MaxPoolServiceReps + 2,
-			req: &mgmt.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+			req: &mgmtpb.PoolCreateReq{
+				Uuid:       test.MockUUID(1),
 				Totalbytes: 100 * humanize.GByte,
 				Tierratio:  []float64{0.06, 0.94},
 				Numsvcreps: MaxPoolServiceReps + 2,
@@ -409,8 +427,8 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"svc replicas > numRanks": {
 			targetCount: 1,
 			memberCount: MaxPoolServiceReps - 2,
-			req: &mgmt.PoolCreateReq{
-				Uuid:       test.MockUUID(0),
+			req: &mgmtpb.PoolCreateReq{
+				Uuid:       test.MockUUID(1),
 				Totalbytes: 100 * humanize.GByte,
 				Tierratio:  []float64{0.06, 0.94},
 				Numsvcreps: MaxPoolServiceReps - 1,
@@ -421,7 +439,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		"no label": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
-				Uuid:      test.MockUUID(0),
+				Uuid:      test.MockUUID(1),
 				Tierbytes: []uint64{100 * humanize.GiByte, 10 * humanize.TByte},
 			},
 			expErr: FaultPoolNoLabel,
@@ -832,7 +850,10 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			if poolSvc == nil {
 				poolSvc = testPoolService
 			}
-			if err := tc.mgmtSvc.sysdb.AddPoolService(poolSvc); err != nil {
+			lock, ctx := getPoolLockCtx(t, nil, tc.mgmtSvc.sysdb, poolSvc.PoolUUID)
+			defer lock.Release()
+
+			if err := tc.mgmtSvc.sysdb.AddPoolService(ctx, poolSvc); err != nil {
 				t.Fatal(err)
 			}
 
@@ -847,7 +868,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 				tc.req.Sys = build.DefaultSystemName
 			}
 
-			gotResp, gotErr := tc.mgmtSvc.PoolDestroy(context.TODO(), tc.req)
+			gotResp, gotErr := tc.mgmtSvc.PoolDestroy(ctx, tc.req)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -1223,13 +1244,13 @@ func TestListPools_Success(t *testing.T) {
 
 	testPools := []*system.PoolService{
 		{
-			PoolUUID:  uuid.MustParse(test.MockUUID(0)),
+			PoolUUID:  test.MockPoolUUID(1),
 			PoolLabel: "0",
 			State:     system.PoolServiceStateReady,
 			Replicas:  []system.Rank{0, 1, 2},
 		},
 		{
-			PoolUUID:  uuid.MustParse(test.MockUUID(1)),
+			PoolUUID:  test.MockPoolUUID(2),
 			PoolLabel: "1",
 			State:     system.PoolServiceStateReady,
 			Replicas:  []system.Rank{0, 1, 2},
@@ -1239,9 +1260,11 @@ func TestListPools_Success(t *testing.T) {
 
 	svc := newTestMgmtSvc(t, log)
 	for _, ps := range testPools {
-		if err := svc.sysdb.AddPoolService(ps); err != nil {
+		lock, ctx := getPoolLockCtx(t, nil, svc.sysdb, ps.PoolUUID)
+		if err := svc.sysdb.AddPoolService(ctx, ps); err != nil {
 			t.Fatal(err)
 		}
+		lock.Release()
 		expectedResp.Pools = append(expectedResp.Pools, &mgmtpb.ListPoolsResp_Pool{
 			Uuid:    ps.PoolUUID.String(),
 			Label:   ps.PoolLabel,

--- a/src/control/system/database_test.go
+++ b/src/control/system/database_test.go
@@ -679,15 +679,21 @@ func TestSystem_Database_OnEvent(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer test.ShowBufferOnFailure(t, buf)
 
-			db := MockDatabase(t, log)
-			for _, ps := range tc.poolSvcs {
-				if err := db.AddPoolService(ps); err != nil {
-					t.Fatal(err)
-				}
-			}
-
 			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 			defer cancel()
+
+			db := MockDatabase(t, log)
+			for _, ps := range tc.poolSvcs {
+				lock, err := db.TakePoolLock(ctx, ps.PoolUUID)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := db.AddPoolService(lock.InContext(ctx), ps); err != nil {
+					t.Fatal(err)
+				}
+				lock.Release()
+			}
 
 			ps := events.NewPubSub(ctx, log)
 			defer ps.Close()
@@ -759,11 +765,18 @@ func TestSystemDatabase_PoolServiceList(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer test.ShowBufferOnFailure(t, buf)
 
+			ctx := context.Background()
 			db := MockDatabase(t, log)
 			for _, ps := range tc.poolSvcs {
-				if err := db.AddPoolService(ps); err != nil {
+				lock, err := db.TakePoolLock(ctx, ps.PoolUUID)
+				if err != nil {
 					t.Fatal(err)
 				}
+
+				if err := db.AddPoolService(lock.InContext(ctx), ps); err != nil {
+					t.Fatal(err)
+				}
+				lock.Release()
 			}
 
 			poolSvcs, err := db.PoolServiceList(tc.all)
@@ -929,6 +942,79 @@ func Test_Database_ResignLeadership(t *testing.T) {
 			}
 
 			test.AssertEqual(t, tc.expLeader, db.IsLeader(), "unexpected leader state")
+		})
+	}
+}
+
+func TestDatabase_TakePoolLock(t *testing.T) {
+	mockUUID := uuid.MustParse(test.MockUUID(1))
+	parentLock := makeLock(1, 1, 1)
+	wrongIdLock := makeLock(1, 2, 1)
+	wrongPoolLock := makeLock(1, 1, 2)
+
+	for name, tc := range map[string]struct {
+		ctx          context.Context
+		poolUUID     uuid.UUID
+		existingLock *PoolLock
+		expErr       error
+		expNewLock   bool
+	}{
+		"nil context": {
+			poolUUID: mockUUID,
+			expErr:   errors.New("nil context"),
+		},
+		"empty pool UUID": {
+			ctx:    context.Background(),
+			expErr: errors.New("nil pool UUID"),
+		},
+		"already-released parent lock": {
+			ctx:      parentLock.InContext(context.Background()),
+			poolUUID: mockUUID,
+			expErr:   errors.New("lock not found"),
+		},
+		"parent lock wrong id": {
+			ctx:          parentLock.InContext(context.Background()),
+			existingLock: wrongIdLock,
+			poolUUID:     mockUUID,
+			expErr:       errors.New("is locked"),
+		},
+		"parent lock for wrong pool": {
+			ctx:          wrongPoolLock.InContext(context.Background()),
+			existingLock: wrongPoolLock,
+			poolUUID:     mockUUID,
+			expErr:       errors.New("different pool"),
+		},
+		"successful new lock": {
+			ctx:        context.Background(),
+			poolUUID:   mockUUID,
+			expNewLock: true,
+		},
+		"successful parent lock": {
+			ctx:          parentLock.InContext(context.Background()),
+			existingLock: parentLock,
+			poolUUID:     mockUUID,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			db := MockDatabase(t, log)
+			if tc.existingLock != nil {
+				db.poolLocks.locks = make(map[uuid.UUID]*PoolLock)
+				db.poolLocks.locks[tc.existingLock.poolUUID] = tc.existingLock
+			}
+			gotLock, gotErr := db.TakePoolLock(tc.ctx, tc.poolUUID)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if tc.expNewLock && (gotLock == nil || gotLock == parentLock) {
+				t.Fatal("expected new lock")
+			} else if !tc.expNewLock && gotLock != parentLock {
+				t.Fatal("expected parent lock")
+			}
 		})
 	}
 }

--- a/src/control/system/faults.go
+++ b/src/control/system/faults.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,7 +8,11 @@ package system
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
@@ -20,6 +24,13 @@ func FaultBadFaultDomainDepth(domain *FaultDomain, expDepth int) *fault.Fault {
 	return systemFault(code.SystemBadFaultDomainDepth,
 		fmt.Sprintf("cannot join system with fault domain %q, need layers = %d", domain.String(), expDepth),
 		"reconfigure the fault domain with a depth consistent with other system members, and restart the server")
+}
+
+// FaultPoolLocked generates a fault indicating that the pool is locked.
+func FaultPoolLocked(poolUUID, lockID uuid.UUID, lockTime time.Time) *fault.Fault {
+	return systemFault(code.SystemPoolLocked,
+		fmt.Sprintf("pool %s is locked (id: %s, time: %s)", poolUUID, lockID, common.FormatTime(lockTime)),
+		"retry the pool operation")
 }
 
 func systemFault(code code.Code, desc, res string) *fault.Fault {

--- a/src/control/system/pool_lock.go
+++ b/src/control/system/pool_lock.go
@@ -1,0 +1,212 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package system
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+type (
+	// PoolLock represents a lock on a pool.
+	// These locks are reference counted to make
+	// them reentrant. Note that the lock release
+	// closure will only ever be called once, no
+	// matter how many times Release() is called.
+	PoolLock struct {
+		id       uuid.UUID
+		poolUUID uuid.UUID
+		takenAt  time.Time
+		refCount int32
+		relOnce  sync.Once
+		release  func()
+	}
+
+	// poolLockMap is a map of pool UUIDs to pool locks.
+	// With this implementation, there may only be one
+	// lock on a pool at a time in order to avoid concurrent
+	// operations by multiple gRPC handlers on the same pool.
+	// NB: This structure is not backed by raft, and is
+	// intended to be local to the current MS leader.
+	poolLockMap struct {
+		sync.RWMutex
+		locks map[uuid.UUID]*PoolLock
+		log   logging.DebugLogger
+	}
+
+	ctxKey string
+)
+
+const (
+	poolLockKey ctxKey = "poolLock"
+)
+
+var (
+	errNoCtxLock = errors.New("no pool lock in context")
+)
+
+// getCtxLock returns the pool lock from the supplied context, if
+// one is present.
+func getCtxLock(ctx context.Context) (*PoolLock, error) {
+	if ctx == nil {
+		return nil, errors.New("nil context in getCtxLock()")
+	}
+
+	lock, ok := ctx.Value(poolLockKey).(*PoolLock)
+	if !ok {
+		return nil, errNoCtxLock
+	}
+
+	return lock, nil
+}
+
+// AddContextLock adds a pool lock to the supplied context.
+func AddContextLock(parent context.Context, lock *PoolLock) (context.Context, error) {
+	if parent == nil {
+		return nil, errors.New("nil context in AddContextLock()")
+	}
+	if lock == nil {
+		return nil, errors.New("nil lock in AddContextLock()")
+	}
+
+	cl, err := getCtxLock(parent)
+	if err != nil {
+		if err != errNoCtxLock {
+			return nil, err
+		}
+		// If the parent context doesn't already have a lock,
+		// add the supplied lock to a new child context.
+		return context.WithValue(parent, poolLockKey, lock), nil
+	}
+
+	// Otherwise, if the parent context already has a lock,
+	// verify that it is the same as the supplied lock and
+	// return an error if not.
+	if cl.id != lock.id {
+		return nil, errors.Errorf("parent context contains another lock for pool %s", cl.poolUUID)
+	}
+
+	// If the parent context already has the supplied lock,
+	// just return the parent context.
+	return parent, nil
+}
+
+// InContext returns a new child context with the lock added
+// as a value. NB: It is the caller's responsibility to ensure
+// that the parent context is valid and does not already contain
+// a different pool lock. For a more robust implementation, see
+// the AddContextLock() function.
+func (pl *PoolLock) InContext(parent context.Context) context.Context {
+	ctx, err := AddContextLock(parent, pl)
+	if err != nil {
+		panic(err)
+	}
+	return ctx
+}
+
+func (pl *PoolLock) addRef() {
+	atomic.AddInt32(&pl.refCount, 1)
+}
+
+func (pl *PoolLock) decRef() {
+	atomic.AddInt32(&pl.refCount, -1)
+}
+
+func (pl *PoolLock) getRef() int32 {
+	return atomic.LoadInt32(&pl.refCount)
+}
+
+// Release releases the lock on the pool when the reference
+// count reaches zero.
+func (pl *PoolLock) Release() {
+	pl.decRef()
+	if pl.getRef() > 0 {
+		return
+	}
+	pl.relOnce.Do(pl.release)
+}
+
+// take returns a new pool lock for the supplied pool UUID
+// if the pool is not already locked, otherwise it returns
+// an error.
+func (plm *poolLockMap) take(poolUUID uuid.UUID) (*PoolLock, error) {
+	if poolUUID == uuid.Nil {
+		return nil, errors.New("nil pool UUID")
+	}
+
+	plm.Lock()
+	defer plm.Unlock()
+
+	if plm.locks == nil {
+		plm.locks = make(map[uuid.UUID]*PoolLock)
+	}
+
+	if lock, exists := plm.locks[poolUUID]; exists {
+		return nil, FaultPoolLocked(poolUUID, lock.id, lock.takenAt)
+	}
+
+	lock := &PoolLock{
+		id:       uuid.New(),
+		poolUUID: poolUUID,
+		takenAt:  time.Now(),
+		release:  func() { plm.release(poolUUID) },
+	}
+	lock.addRef()
+	plm.locks[poolUUID] = lock
+
+	plm.log.Debugf("%s: lock taken (id: %s)", dbgUuidStr(poolUUID), dbgUuidStr(lock.id))
+	return lock, nil
+}
+
+// release releases the lock on the pool with the supplied UUID.
+func (plm *poolLockMap) release(poolUUID uuid.UUID) {
+	plm.Lock()
+	defer plm.Unlock()
+
+	plm.log.Debugf("%s: lock released", dbgUuidStr(poolUUID))
+	delete(plm.locks, poolUUID)
+}
+
+// checkLockCtx is a helper to extract the pool lock from the
+// supplied context before sending it to checkLock().
+func (plm *poolLockMap) checkLockCtx(ctx context.Context) error {
+	lock, err := getCtxLock(ctx)
+	if err != nil {
+		return err
+	}
+
+	return plm.checkLock(lock)
+}
+
+// checkLock checks that the supplied lock is still valid.
+func (plm *poolLockMap) checkLock(lock *PoolLock) error {
+	if lock == nil {
+		return errors.New("nil pool lock in checkLock()")
+	}
+	plm.RLock()
+	defer plm.RUnlock()
+
+	// Verify that the supplied lock matches the stored lock. This
+	// is a belt-and-suspenders check because in theory the logic
+	// in take() should prevent this from ever happening.
+	if pl, exists := plm.locks[lock.poolUUID]; exists {
+		if lock.id != pl.id {
+			return FaultPoolLocked(lock.poolUUID, pl.id, pl.takenAt)
+		}
+	} else {
+		return errors.Errorf("pool %s: lock not found", lock.poolUUID)
+	}
+
+	return nil
+}

--- a/src/control/system/pool_lock_test.go
+++ b/src/control/system/pool_lock_test.go
@@ -1,0 +1,298 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package system
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+var (
+	lockCmpOpts = []cmp.Option{
+		cmp.AllowUnexported(PoolLock{}),
+		cmpopts.IgnoreUnexported(sync.Once{}),
+	}
+)
+
+func makeLock(refCt, id, pool int32) *PoolLock {
+	return &PoolLock{
+		id:       uuid.MustParse(test.MockUUID(id)),
+		poolUUID: uuid.MustParse(test.MockUUID(pool)),
+		takenAt:  time.Now(),
+		refCount: refCt,
+	}
+}
+
+func TestRaft_getLockCtx(t *testing.T) {
+	lock := makeLock(0, 1, 2)
+
+	for name, tc := range map[string]struct {
+		ctx    context.Context
+		expErr error
+	}{
+		"nil context": {
+			ctx:    nil,
+			expErr: errors.New("nil context"),
+		},
+		"no lock in context": {
+			ctx:    context.Background(),
+			expErr: errNoCtxLock,
+		},
+		"lock in context": {
+			ctx: lock.InContext(context.Background()),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotLock, gotErr := getCtxLock(tc.ctx)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(lock, gotLock, lockCmpOpts...); diff != "" {
+				t.Fatalf("unexpected lock (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRaft_PoolLock_Release(t *testing.T) {
+	var released int32
+
+	lock := makeLock(3, 1, 2)
+	lock.release = func() { atomic.AddInt32(&released, 1) }
+	lock.addRef()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 12; i++ {
+		wg.Add(1)
+		// run in goroutines to trigger the race detector
+		// on any unsafe shenanigans.
+		go func() {
+			lock.Release()
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	test.AssertEqual(t, atomic.LoadInt32(&released), int32(1), "unexpected release count")
+}
+
+func TestRaft_PoolLock_InContext(t *testing.T) {
+	lock1 := makeLock(0, 1, 2)
+	lock2 := makeLock(0, 3, 4)
+
+	for name, tc := range map[string]struct {
+		parent      context.Context
+		expLock     *PoolLock
+		shouldPanic bool
+	}{
+		"nil parent": {
+			parent:      nil,
+			shouldPanic: true,
+		},
+		"parent contains different lock": {
+			parent:      lock2.InContext(context.Background()),
+			shouldPanic: true,
+		},
+		"parent contains same lock": {
+			parent:  lock1.InContext(context.Background()),
+			expLock: lock1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tc.shouldPanic {
+						t.Fatalf("unexpected panic: %v", r)
+					}
+				}
+			}()
+
+			ctx := lock1.InContext(tc.parent)
+			if tc.shouldPanic {
+				t.Fatal("expected panic")
+			}
+
+			gotLock, err := getCtxLock(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expLock, gotLock, lockCmpOpts...); diff != "" {
+				t.Fatalf("unexpected lock (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRaft_AddContextLock(t *testing.T) {
+	lock1 := makeLock(0, 1, 2)
+	lock2 := makeLock(0, 3, 4)
+
+	for name, tc := range map[string]struct {
+		parent    context.Context
+		lock      *PoolLock
+		expLock   *PoolLock
+		expNewCtx bool
+		expErr    error
+	}{
+		"nil parent": {
+			parent: nil,
+			lock:   lock1,
+			expErr: errors.New("nil context"),
+		},
+		"nil lock": {
+			parent: context.Background(),
+			expErr: errors.New("nil lock"),
+		},
+		"parent contains different lock": {
+			parent: lock2.InContext(context.Background()),
+			lock:   lock1,
+			expErr: errors.New("contains another lock"),
+		},
+		"parent contains same lock": {
+			parent:  lock1.InContext(context.Background()),
+			lock:    lock1,
+			expLock: lock1,
+		},
+		"new child context with lock": {
+			parent:    context.Background(),
+			lock:      lock1,
+			expLock:   lock1,
+			expNewCtx: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, gotErr := AddContextLock(tc.parent, tc.lock)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			gotLock, err := getCtxLock(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expLock, gotLock, lockCmpOpts...); diff != "" {
+				t.Fatalf("unexpected lock (-want, +got):\n%s", diff)
+			}
+
+			if tc.expNewCtx && ctx == tc.parent {
+				t.Fatal("expected new context")
+			} else if !tc.expNewCtx && ctx != tc.parent {
+				t.Fatal("expected same context")
+			}
+		})
+	}
+}
+
+func TestRaft_poolLockMap_take(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	uuid0 := uuid.MustParse(test.MockUUID(1))
+	uuid1 := uuid.MustParse(test.MockUUID(2))
+	lock0 := &PoolLock{id: uuid1, poolUUID: uuid0}
+
+	for name, tc := range map[string]struct {
+		plm        *poolLockMap
+		poolToLock uuid.UUID
+		expErr     error
+		expLock    *PoolLock
+	}{
+		"already locked": {
+			plm: func() *poolLockMap {
+				plm := &poolLockMap{log: log}
+				plm.take(uuid0)
+				return plm
+			}(),
+			poolToLock: uuid0,
+			expErr:     errors.New("locked"),
+		},
+		"lock taken successfully": {
+			poolToLock: uuid0,
+			expLock:    lock0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.plm == nil {
+				tc.plm = &poolLockMap{log: log}
+			}
+			defer test.ShowBufferOnFailure(t, buf)
+
+			gotLock, err := tc.plm.take(tc.poolToLock)
+			test.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			test.AssertEqual(t, tc.expLock.poolUUID, gotLock.poolUUID, "unexpected lock")
+		})
+	}
+}
+
+func TestRaft_poolLockMap_checkLock(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	uuid0 := uuid.MustParse(test.MockUUID(1))
+	uuid1 := uuid.MustParse(test.MockUUID(2))
+	lock0 := &PoolLock{id: uuid1, poolUUID: uuid0}
+	lock1 := &PoolLock{id: uuid0, poolUUID: uuid0}
+
+	for name, tc := range map[string]struct {
+		plm       *poolLockMap
+		checkLock *PoolLock
+		expErr    error
+	}{
+		"nil lock": {
+			expErr: errors.New("nil pool lock"),
+		},
+		"locked, same id": {
+			plm: func() *poolLockMap {
+				plm := &poolLockMap{log: log}
+				plm.take(uuid0)
+				plm.locks[uuid0].id = lock0.id
+				return plm
+			}(),
+			checkLock: lock0,
+		},
+		"locked, different id": {
+			plm: func() *poolLockMap {
+				plm := &poolLockMap{log: log}
+				plm.take(uuid0)
+				plm.locks[uuid0].id = lock1.id
+				return plm
+			}(),
+			checkLock: lock0,
+			expErr:    errors.New("locked"),
+		},
+		"not locked": {
+			checkLock: lock0,
+			expErr:    errors.New("not found"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.plm == nil {
+				tc.plm = &poolLockMap{log: log}
+			}
+			defer test.ShowBufferOnFailure(t, buf)
+
+			checkErr := tc.plm.checkLock(tc.checkLock)
+			test.CmpErr(t, tc.expErr, checkErr)
+		})
+	}
+}

--- a/src/control/system/raft.go
+++ b/src/control/system/raft.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -109,7 +110,15 @@ func (db *Database) ResignLeadership(cause error) error {
 // outstanding log entries.
 func (db *Database) Barrier() error {
 	return db.raft.withReadLock(func(svc raftService) error {
-		return svc.Barrier(0).Error()
+		err := svc.Barrier(0).Error()
+		if IsRaftLeadershipError(err) {
+			db.log.Errorf("lost leadership during Barrier(): %s", err)
+			return &ErrNotLeader{
+				LeaderHint: db.leaderHint(),
+				Replicas:   db.cfg.stringReplicas(db.replicaAddr.get()),
+			}
+		}
+		return err
 	})
 }
 
@@ -303,7 +312,7 @@ func (db *Database) submitMemberUpdate(op raftOp, m *memberUpdate) error {
 	if err != nil {
 		return err
 	}
-	db.log.Debugf("member %d:%x updated @ %s", m.Member.Rank, m.Member.Incarnation, m.Member.LastUpdate)
+	db.log.Debugf("member %d:%x updated @ %s", m.Member.Rank, m.Member.Incarnation, common.FormatTime(m.Member.LastUpdate))
 	return db.submitRaftUpdate(data)
 }
 
@@ -315,7 +324,7 @@ func (db *Database) submitPoolUpdate(op raftOp, ps *PoolService) error {
 	if err != nil {
 		return err
 	}
-	db.log.Debugf("pool %s updated @ %s", ps.PoolUUID, ps.LastUpdate)
+	db.log.Debugf("pool %s (%s) updated @ %s", dbgUuidStr(ps.PoolUUID), ps.State, common.FormatTime(ps.LastUpdate))
 	return db.submitRaftUpdate(data)
 }
 


### PR DESCRIPTION
In certain circumstances, a PoolCreate and PoolDestroy may
race, leading to unexpected behavior. This commit adds a
new locking mechanism at the pool database level to prevent
concurrent write operations by more than one parent gRPC
handler.

Additionally, we now call raft.Barrier() as part of the
leadership check in order to ensure that the leader has caught
up with any outstanding logs before proceeding on to any logic
that depends on having leadership.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
