### PR TITLE
DAOS-11048 bio: monitor WAL and Meta SSDs

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -610,7 +610,7 @@ int bulk_reclaim_chunk(struct bio_dma_buffer *bdb,
 /* bio_monitor.c */
 int bio_init_health_monitoring(struct bio_blobstore *bb, char *bdev_name);
 void bio_fini_health_monitoring(struct bio_blobstore *bb);
-void bio_bs_monitor(struct bio_xs_context *xs_ctxt, uint64_t now);
+void bio_bs_monitor(struct bio_xs_context *xs_ctxt, enum smd_dev_type st, uint64_t now);
 void bio_media_error(void *msg_arg);
 void bio_export_health_stats(struct bio_blobstore *bb, char *bdev_name);
 void bio_export_vendor_health_stats(struct bio_blobstore *bb, char *bdev_name);

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -202,12 +202,13 @@ bio_dev_set_faulty(struct bio_xs_context *xs, enum smd_dev_type st)
 }
 
 static inline struct bio_dev_health *
-xs_ctxt2dev_health(struct bio_xs_context *ctxt)
+cb_arg2dev_health(void *cb_arg)
 {
-	D_ASSERT(ctxt != NULL);
+
+	struct bio_xs_blobstore **bxb_ptr = (struct bio_xs_blobstore **)cb_arg;
 	struct bio_xs_blobstore *bxb;
 
-	bxb = bio_xs_context2xs_blobstore(ctxt, SMD_DEV_TYPE_DATA);
+	bxb = *bxb_ptr;
 	/* bio_xsctxt_free() is underway */
 	if (bxb == NULL)
 		return NULL;
@@ -219,8 +220,7 @@ static void
 get_spdk_err_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 				 void *cb_arg)
 {
-	struct bio_xs_context	*ctxt = cb_arg;
-	struct bio_dev_health	*dev_health = xs_ctxt2dev_health(ctxt);
+	struct bio_dev_health	*dev_health = cb_arg2dev_health(cb_arg);
 	int			 sc, sct;
 	uint32_t		 cdw0;
 
@@ -245,8 +245,7 @@ static void
 get_spdk_identify_ctrlr_completion(struct spdk_bdev_io *bdev_io, bool success,
 				   void *cb_arg)
 {
-	struct bio_xs_context		*ctxt = cb_arg;
-	struct bio_dev_health		*dev_health = xs_ctxt2dev_health(ctxt);
+	struct bio_dev_health		*dev_health = cb_arg2dev_health(cb_arg);
 	struct spdk_nvme_ctrlr_data	*cdata;
 	struct spdk_bdev		*bdev;
 	struct spdk_nvme_cmd		 cmd;
@@ -532,8 +531,7 @@ static void
 get_spdk_intel_smart_log_completion(struct spdk_bdev_io *bdev_io, bool success,
 				    void *cb_arg)
 {
-	struct bio_xs_context	*ctxt = cb_arg;
-	struct bio_dev_health	*dev_health = xs_ctxt2dev_health(ctxt);
+	struct bio_dev_health	*dev_health = cb_arg2dev_health(cb_arg);
 	struct spdk_bdev	*bdev;
 	struct spdk_nvme_cmd	 cmd;
 	uint32_t		 cp_sz;
@@ -590,10 +588,9 @@ out:
 
 static void
 get_spdk_health_info_completion(struct spdk_bdev_io *bdev_io, bool success,
-			     void *cb_arg)
+				void *cb_arg)
 {
-	struct bio_xs_context	*ctxt = cb_arg;
-	struct bio_dev_health	*dev_health = xs_ctxt2dev_health(ctxt);
+	struct bio_dev_health	*dev_health = cb_arg2dev_health(cb_arg);
 	struct spdk_bdev	*bdev;
 	struct spdk_nvme_cmd	 cmd;
 	uint32_t		 page_sz;
@@ -715,9 +712,9 @@ auto_faulty_detect(struct bio_blobstore *bbs)
 
 /* Collect the raw device health state through SPDK admin APIs */
 static void
-collect_raw_health_data(struct bio_xs_context *ctxt)
+collect_raw_health_data(void *cb_arg)
 {
-	struct bio_dev_health	*dev_health = xs_ctxt2dev_health(ctxt);
+	struct bio_dev_health	*dev_health = cb_arg2dev_health(cb_arg);
 	struct spdk_bdev	*bdev;
 	struct spdk_nvme_cmd	 cmd;
 	uint32_t		 numd, numdl, numdu;
@@ -771,25 +768,25 @@ collect_raw_health_data(struct bio_xs_context *ctxt)
 					   dev_health->bdh_health_buf,
 					   page_sz,
 					   get_spdk_health_info_completion,
-					   ctxt);
+					   cb_arg);
 	if (rc) {
 		D_ERROR("NVMe admin passthru (health log), rc:%d\n", rc);
 		dev_health->bdh_inflights--;
 	}
-
 }
 
 void
-bio_bs_monitor(struct bio_xs_context *xs_ctxt, uint64_t now)
+bio_bs_monitor(struct bio_xs_context *xs_ctxt, enum smd_dev_type st, uint64_t now)
 {
 	struct bio_dev_health	*dev_health;
 	int			 rc;
 	uint64_t		 monitor_period;
-	struct bio_xs_blobstore	*bxb = xs_ctxt->bxc_xs_blobstores[SMD_DEV_TYPE_DATA];
+	struct bio_xs_blobstore	*bxb = xs_ctxt->bxc_xs_blobstores[st];
 	struct bio_blobstore	*bbs;
 
-	if (bxb == NULL || bxb->bxb_blobstore == NULL)
-		return;
+
+	D_ASSERT(bxb != NULL);
+	D_ASSERT(bxb->bxb_blobstore != NULL);
 
 	bbs = bxb->bxb_blobstore;
 	dev_health = &bbs->bb_dev_health;
@@ -804,15 +801,17 @@ bio_bs_monitor(struct bio_xs_context *xs_ctxt, uint64_t now)
 		return;
 	dev_health->bdh_stat_age = now;
 
-	auto_faulty_detect(bbs);
-
-	rc = bio_bs_state_transit(bbs);
-	if (rc)
-		D_ERROR("State transition on target %d failed. %d\n",
-			bbs->bb_owner_xs->bxc_tgt_id, rc);
+	/* only support Data SSD auto fauty detection and state transit. */
+	if (st == SMD_DEV_TYPE_DATA) {
+		auto_faulty_detect(bbs);
+		rc = bio_bs_state_transit(bbs);
+		if (rc)
+			D_ERROR("State transition on target %d failed. %d\n",
+				bbs->bb_owner_xs->bxc_tgt_id, rc);
+	}
 
 	if (!bypass_health_collect())
-		collect_raw_health_data(xs_ctxt);
+		collect_raw_health_data((void *)&xs_ctxt->bxc_xs_blobstores[st]);
 }
 
 /* Free all device health monitoring info */

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1838,9 +1838,7 @@ bio_nvme_poll(struct bio_xs_context *ctxt)
 		bxb = ctxt->bxc_xs_blobstores[st];
 		if (bxb && bxb->bxb_blobstore &&
 		    is_bbs_owner(ctxt, bxb->bxb_blobstore))
-			bio_bs_monitor(ctxt, now);
-		/* Only support DATA for now */
-		break;
+			bio_bs_monitor(ctxt, st, now);
 	}
 
 	if (is_init_xstream(ctxt)) {


### PR DESCRIPTION
Currently only data SSDs monitoring is supported, this patch tries
enable health collection for WAL and Meta SSDs as well.

Auto fault detection and state transit for WAL/Meta SSDs are not
supported yet.

Required-githooks: true
Signed-off-by: Wang Shilong <shilong.wang@intel.com>

