### PR TITLE
DAOS-12145 chk: misc fixes for chk related issues - I

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -351,9 +351,8 @@ chk_pools_dump(d_list_t *head, int pool_nr, uuid_t pools[])
 
 	if (head != NULL && !d_list_empty(head)) {
 		D_INFO("Pools List:\n");
-		d_list_for_each_entry(cpr, head, cpr_link) {
+		d_list_for_each_entry(cpr, head, cpr_link)
 			D_INFO(DF_UUIDF"\n", DP_UUID(cpr->cpr_uuid));
-		}
 	} else if (pool_nr > 0) {
 		D_INFO("Pools List:\n");
 		do {

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -252,7 +252,7 @@ CRT_RPC_DECLARE(chk_report, DAOS_ISEQ_CHK_REPORT, DAOS_OSEQ_CHK_REPORT);
 #define DAOS_ISEQ_CHK_REJOIN							\
 	((uint64_t)		(cri_gen)		CRT_VAR)		\
 	((d_rank_t)		(cri_rank)		CRT_VAR)		\
-	((d_rank_t)		(cri_padding)		CRT_VAR)
+	((uint32_t)		(cri_padding)		CRT_VAR)
 
 #define DAOS_OSEQ_CHK_REJOIN							\
 	((int32_t)		(cro_status)		CRT_VAR)		\
@@ -669,7 +669,7 @@ int chk_engine_mark_rank_dead(uint64_t gen, d_rank_t rank, uint32_t version);
 
 int chk_engine_act(uint64_t gen, uint64_t seq, uint32_t cla, uint32_t act, uint32_t flags);
 
-int chk_engine_cont_list(uint64_t gen, uuid_t uuid, uuid_t **conts, uint32_t *count);
+int chk_engine_cont_list(uint64_t gen, uuid_t pool_uuid, uuid_t **conts, uint32_t *count);
 
 int chk_engine_pool_start(uint64_t gen, uuid_t uuid, uint32_t phase);
 
@@ -677,11 +677,9 @@ int chk_engine_pool_mbs(uint64_t gen, uuid_t uuid, uint32_t phase, const char *l
 			uint32_t flags, uint32_t mbs_nr, struct chk_pool_mbs *mbs_array,
 			struct rsvc_hint *hint);
 
-int chk_engine_report(struct chk_report_unit *cru, int *decision);
-
 int chk_engine_notify(struct chk_iv *iv);
 
-void chk_engine_rejoin(void);
+void chk_engine_rejoin(void *args);
 
 void chk_engine_pause(void);
 

--- a/src/chk/chk_iv.c
+++ b/src/chk/chk_iv.c
@@ -205,9 +205,9 @@ chk_iv_update(void *ns, struct chk_iv *iv, uint32_t shortcut, uint32_t sync_mode
 		rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0, retry);
 	}
 
-	if (rc != 0)
-		D_ERROR("CHK iv "DF_X64"/"DF_X64" update failed: "DF_RC"\n",
-			iv->ci_gen, iv->ci_seq, DP_RC(rc));
+	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+		 "CHK iv "DF_X64"/"DF_X64" on rank %u: "DF_RC"\n",
+		 iv->ci_gen, iv->ci_seq, iv->ci_rank, DP_RC(rc));
 
 	return rc;
 }

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -728,9 +728,8 @@ out:
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
 		 "Rank %u report DAOS check to leader %u, gen "DF_X64", class %u, action %u, "
-		 "result %d, "DF_UUIDF"/"DF_UUIDF", msg %s, got seq "DF_X64": "DF_RC"\n",
-		 rank, leader, gen, cla, act, result, DP_UUID(pool), DP_UUID(cont),
-		 msg, *seq, DP_RC(rc));
+		 "result %d, "DF_UUIDF"/"DF_UUIDF", seq "DF_X64": "DF_RC"\n", rank, leader,
+		 gen, cla, act, result, DP_UUID(pool), DP_UUID(cont), *seq, DP_RC(rc));
 
 	return rc;
 }

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -310,7 +310,8 @@ ds_chk_setup(void)
 	 * the check explicitly.
 	 */
 
-	chk_engine_rejoin();
+	rc = dss_ult_create(chk_engine_rejoin, NULL, DSS_XS_SYS, 0, 0, NULL);
+	D_ASSERT(rc == 0);
 
 	goto out_done;
 

--- a/src/chk/chk_upcall.c
+++ b/src/chk/chk_upcall.c
@@ -82,8 +82,10 @@ chk_sg_list2string_array(d_sg_list_t *sgls, uint32_t sgl_nr, char ***array)
 	/* QUEST: How to transfer all the data into d_sg_list_t array? Some may be not string. */
 
 	for (i = 0, k = 0; i < sgl_nr; i++) {
-		for (j = 0; j < sgls[i].sg_nr; j++)
-			buf[k++] = sgls[i].sg_iovs[j].iov_buf;
+		for (j = 0; j < sgls[i].sg_nr; j++, k++) {
+			buf[k] = sgls[i].sg_iovs[j].iov_buf;
+			buf[k][sgls[i].sg_iovs[j].iov_len] = '\0';
+		}
 	}
 
 out:

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -751,12 +751,16 @@ dtx_resync_one(void *data)
 	if (child == NULL)
 		D_GOTO(out, rc = -DER_NONEXIST);
 
+	if (unlikely(child->spc_no_storage))
+		D_GOTO(put, rc = 0);
+
 	cb_arg.arg = *arg;
 	param.ip_hdl = child->spc_hdl;
 	param.ip_flags = VOS_IT_FOR_MIGRATION;
 	rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchor,
 			 container_scan_cb, NULL, &cb_arg, NULL);
 
+put:
 	ds_pool_child_put(child);
 out:
 	D_DEBUG(DB_TRACE, DF_UUID" iterate pool done: rc %d\n",

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -75,7 +75,7 @@ typedef int (*chk_prop_cb_t)(void *buf, struct chk_policy *policies, int cnt, ui
 
 int chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr,
 		     struct chk_policy *policies, int pool_nr, uuid_t pools[],
-		     uint32_t flags, int phase);
+		     uint32_t api_flags, int phase);
 
 int chk_leader_stop(int pool_nr, uuid_t pools[]);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -148,7 +148,9 @@ struct ds_pool_child {
 	int		spc_ref;
 	ABT_eventual	spc_ref_eventual;
 
-	uint64_t	spc_discard_done:1;
+	uint64_t	spc_discard_done:1,
+			spc_no_storage:1; /* The pool shard has no storage. */
+
 	/**
 	 * Per-pool per-module metrics, see ${modname}_pool_metrics for the
 	 * actual structure. Initialized only for modules that specified a

--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -105,6 +105,7 @@ struct ds_rsvc {
 	char		       *s_db_path;
 	uuid_t			s_db_uuid;
 	int			s_ref;
+	uint32_t		s_gen;
 	ABT_mutex		s_mutex;	/* for the following members */
 	bool			s_stop;
 	uint64_t		s_term;		/**< leader term */
@@ -173,5 +174,6 @@ int ds_rsvc_list_attr(struct ds_rsvc *svc, struct rdb_tx *tx, rdb_path_t *path,
 size_t ds_rsvc_get_md_cap(void);
 
 void ds_rsvc_request_map_dist(struct ds_rsvc *svc);
+void ds_rsvc_wait_map_dist(struct ds_rsvc *svc);
 
 #endif /* DAOS_SRV_RSVC_H */

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -328,9 +328,9 @@ rebuild_scan_done(void *data)
 
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
 				      rpt->rt_rebuild_gen);
-	D_ASSERT(tls != NULL);
+	if (tls != NULL)
+		tls->rebuild_pool_scanning = 0;
 
-	tls->rebuild_pool_scanning = 0;
 	return 0;
 }
 
@@ -828,7 +828,8 @@ rebuild_scanner(void *data)
 
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
 				      rpt->rt_rebuild_gen);
-	D_ASSERT(tls != NULL);
+	if (tls == NULL)
+		return 0;
 
 	if (rebuild_status_match(rpt, PO_COMP_ST_DOWNOUT | PO_COMP_ST_DOWN |
 				      PO_COMP_ST_NEW) ||


### PR DESCRIPTION
It contains the following fixes:

1. Wait pool map refresh before next step check.

If the check engine refreshes the pool map, then it needs to wait
for a while until the pool map has been dispatched to all related
pool shards, that will avoid group versioning related trouble for
subsequent container based check.

2. Auto re-start check from the beginning if former check done.

That will avoid explicitly specifying '-r' option when start check
every time after the first check completed.

3. Allow to start pool service with lost some pool shards.

That is useful when the storage for some pool shards are broken
(such as related vos-x file under the pool directory is lost).

4. Use the same sequence# if report an inconsistency multiple times

For an inconsistency, its sequence# is assigned when it is reported
for the first time. If the first report is for ask for interaction,
then the next report after the repair should reuse the sequence# to
allow control plane to locate the original interaction report.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
