### PR TITLE
DAOS-11679 dtx: dispatch large transaction via multiple steps

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -56,9 +56,19 @@ struct dtx_batched_cont_args {
 					 dbca_agg_done:1;
 };
 
-struct dtx_cleanup_stale_cb_args {
-	d_list_t		dcsca_list;
-	int			dcsca_count;
+struct dtx_partial_cmt_item {
+	d_list_t		dpci_link;
+	uint32_t		dpci_inline_mbs:1;
+	struct dtx_entry	dpci_dte;
+};
+
+struct dtx_cleanup_cb_args {
+	/* The list for stale DTX entries. */
+	d_list_t		dcca_st_list;
+	/* The list for partial committed DTX entries. */
+	d_list_t		dcca_pc_list;
+	int			dcca_st_count;
+	int			dcca_pc_count;
 };
 
 static inline void
@@ -166,11 +176,13 @@ dtx_stat(struct ds_cont_child *cont, struct dtx_stat *stat)
 }
 
 static int
-dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
+dtx_cleanup_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 {
-	struct dtx_cleanup_stale_cb_args	*dcsca = args;
-	struct dtx_memberships			*mbs;
-	struct dtx_share_peer			*dsp;
+	struct dtx_cleanup_cb_args	*dcca = args;
+	struct dtx_share_peer		*dsp = NULL;
+	struct dtx_partial_cmt_item	*dpci = NULL;
+	struct dtx_memberships		*mbs;
+	struct dtx_entry		*dte;
 
 	/* We commit the DTXs periodically, there will be very limited DTXs
 	 * to be checked when cleanup. So we can load all those uncommitted
@@ -180,10 +192,6 @@ dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	 */
 
 	D_ASSERT(!(ent->ie_dtx_flags & DTE_INVALID));
-
-	/* Skip the DTX entry which leader resides on current target and may be still alive. */
-	if (ent->ie_dtx_flags & DTE_LEADER)
-		return 0;
 
 	/* Skip corrupted entry that will be handled via other special tool. */
 	if (ent->ie_dtx_flags & DTE_CORRUPTED)
@@ -204,88 +212,155 @@ dtx_cleanup_stale_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 
 	D_ASSERT(ent->ie_dtx_mbs_dsize > 0);
 
-	if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE)
-		D_ALLOC_PTR(dsp);
-	else
-		D_ALLOC(dsp, sizeof(*dsp) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize);
+	/*
+	 * NOTE: Usually, the partial committed DTX entries will be handled by batched commit ULT
+	 *	 (if related container is not closed) or DTX resync (after the container re-open).
+	 *	 So here, the left ones are for rare failure cases in these process, they will be
+	 *	 re-committed via dtx_cleanup logic.
+	 */
+	if (unlikely(ent->ie_dtx_flags & DTE_PARTIAL_COMMITTED)) {
+		if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE)
+			D_ALLOC_PTR(dpci);
+		else
+			D_ALLOC(dpci, sizeof(*dpci) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize);
+		if (dpci == NULL)
+			return -DER_NOMEM;
 
-	if (dsp == NULL)
-		return -DER_NOMEM;
+		dte = &dpci->dpci_dte;
+		dte->dte_xid = ent->ie_dtx_xid;
+		dte->dte_ver = ent->ie_dtx_ver;
+		dte->dte_refs = 1;
 
-	dsp->dsp_xid = ent->ie_dtx_xid;
-	dsp->dsp_oid = ent->ie_dtx_oid;
-	dsp->dsp_epoch = ent->ie_epoch;
+		if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE)
+			goto add;
 
-	if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE) {
-		dsp->dsp_inline_mbs = 0;
-		dsp->dsp_mbs = NULL;
+		mbs = (struct dtx_memberships *)(dte + 1);
+		dpci->dpci_inline_mbs = 1;
+		dte->dte_mbs = mbs;
 	} else {
-		mbs = (struct dtx_memberships *)(dsp + 1);
-		mbs->dm_tgt_cnt = ent->ie_dtx_tgt_cnt;
-		mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
-		mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
-		mbs->dm_flags = ent->ie_dtx_mbs_flags;
-		mbs->dm_dte_flags = ent->ie_dtx_flags;
-		memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
+		/* Skip the DTX which leader resides on current target and may be still alive. */
+		if (ent->ie_dtx_flags & DTE_LEADER)
+			return 0;
 
+		if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE)
+			D_ALLOC_PTR(dsp);
+		else
+			D_ALLOC(dsp, sizeof(*dsp) + sizeof(*mbs) + ent->ie_dtx_mbs_dsize);
+		if (dsp == NULL)
+			return -DER_NOMEM;
+
+		dsp->dsp_xid = ent->ie_dtx_xid;
+		dsp->dsp_oid = ent->ie_dtx_oid;
+		dsp->dsp_epoch = ent->ie_epoch;
+
+		if (ent->ie_dtx_mbs_dsize > DTX_INLINE_MBS_SIZE)
+			goto add;
+
+		mbs = (struct dtx_memberships *)(dsp + 1);
 		dsp->dsp_inline_mbs = 1;
 		dsp->dsp_mbs = mbs;
 	}
 
-	d_list_add_tail(&dsp->dsp_link, &dcsca->dcsca_list);
-	dcsca->dcsca_count++;
+	mbs->dm_tgt_cnt = ent->ie_dtx_tgt_cnt;
+	mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
+	mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
+	mbs->dm_flags = ent->ie_dtx_mbs_flags;
+	mbs->dm_dte_flags = ent->ie_dtx_flags;
+	memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
+
+add:
+	if (ent->ie_dtx_flags & DTE_PARTIAL_COMMITTED) {
+		d_list_add_tail(&dpci->dpci_link, &dcca->dcca_pc_list);
+		dcca->dcca_pc_count++;
+	} else {
+		d_list_add_tail(&dsp->dsp_link, &dcca->dcca_st_list);
+		dcca->dcca_st_count++;
+	}
 
 	return 0;
 }
 
-static void
-dtx_cleanup_stale(void *arg)
+static inline void
+dtx_dpci_free(struct dtx_partial_cmt_item *dpci)
 {
-	struct dtx_batched_cont_args		*dbca = arg;
-	struct ds_cont_child			*cont = dbca->dbca_cont;
-	struct dtx_share_peer			*dsp;
-	struct dtx_cleanup_stale_cb_args	 dcsca;
-	int					 count;
-	int					 rc;
+	if (dpci->dpci_inline_mbs == 0)
+		D_FREE(dpci->dpci_dte.dte_mbs);
+
+	D_FREE(dpci);
+}
+
+static void
+dtx_cleanup(void *arg)
+{
+	struct dtx_batched_cont_args	*dbca = arg;
+	struct ds_cont_child		*cont = dbca->dbca_cont;
+	struct dtx_share_peer		*dsp;
+	struct dtx_partial_cmt_item	*dpci;
+	struct dtx_entry		*dte;
+	struct dtx_cleanup_cb_args	 dcca;
+	int				 count;
+	int				 rc;
 
 	if (dbca->dbca_cleanup_req == NULL)
 		goto out;
 
-	D_INIT_LIST_HEAD(&dcsca.dcsca_list);
-	dcsca.dcsca_count = 0;
+	D_INIT_LIST_HEAD(&dcca.dcca_st_list);
+	D_INIT_LIST_HEAD(&dcca.dcca_pc_list);
+	dcca.dcca_st_count = 0;
+	dcca.dcca_pc_count = 0;
 	rc = ds_cont_iter(cont->sc_pool->spc_hdl, cont->sc_uuid,
-			  dtx_cleanup_stale_iter_cb, &dcsca, VOS_ITER_DTX, 0);
+			  dtx_cleanup_iter_cb, &dcca, VOS_ITER_DTX, 0);
 	if (rc < 0)
-		D_WARN("Failed to scan stale DTX entry for "
+		D_WARN("Failed to scan DTX entry for cleanup "
 		       DF_UUID": "DF_RC"\n", DP_UUID(cont->sc_uuid), DP_RC(rc));
 
 	/* dbca->dbca_reg_gen != cont->sc_dtx_batched_gen means someone reopen the container. */
-	while (!dss_ult_exiting(dbca->dbca_cleanup_req) &&
-	       !d_list_empty(&dcsca.dcsca_list) && dbca->dbca_reg_gen == cont->sc_dtx_batched_gen) {
-		if (dcsca.dcsca_count > DTX_REFRESH_MAX) {
+	while (!dss_ult_exiting(dbca->dbca_cleanup_req) && !d_list_empty(&dcca.dcca_st_list) &&
+	       dbca->dbca_reg_gen == cont->sc_dtx_batched_gen) {
+		if (dcca.dcca_st_count > DTX_REFRESH_MAX) {
 			count = DTX_REFRESH_MAX;
-			dcsca.dcsca_count -= DTX_REFRESH_MAX;
+			dcca.dcca_st_count -= DTX_REFRESH_MAX;
 		} else {
-			D_ASSERT(dcsca.dcsca_count > 0);
+			D_ASSERT(dcca.dcca_st_count > 0);
 
-			count = dcsca.dcsca_count;
-			dcsca.dcsca_count = 0;
+			count = dcca.dcca_st_count;
+			dcca.dcca_st_count = 0;
 		}
 
 		/* Use false as the "failout" parameter that should guarantee
 		 * that all the DTX entries in the check list will be handled
 		 * even if some former ones hit failure.
 		 */
-		rc = dtx_refresh_internal(cont, &count, &dcsca.dcsca_list,
+		rc = dtx_refresh_internal(cont, &count, &dcca.dcca_st_list,
 					  NULL, NULL, NULL, false);
 		D_ASSERTF(count == 0, "%d entries are not handled: "DF_RC"\n",
 			  count, DP_RC(rc));
 	}
 
-	while ((dsp = d_list_pop_entry(&dcsca.dcsca_list,
-				       struct dtx_share_peer,
+	/* dbca->dbca_reg_gen != cont->sc_dtx_batched_gen means someone reopen the container. */
+	while (!dss_ult_exiting(dbca->dbca_cleanup_req) && !d_list_empty(&dcca.dcca_pc_list) &&
+	       dbca->dbca_reg_gen == cont->sc_dtx_batched_gen) {
+		dpci = d_list_pop_entry(&dcca.dcca_pc_list, struct dtx_partial_cmt_item, dpci_link);
+		dcca.dcca_pc_count--;
+
+		dte = &dpci->dpci_dte;
+		if (dte->dte_mbs == NULL)
+			rc = vos_dtx_load_mbs(cont->sc_hdl, &dte->dte_xid, &dte->dte_mbs);
+		if (dte->dte_mbs != NULL)
+			rc = dtx_commit(cont, &dte, NULL, 1);
+
+		D_DEBUG(DB_IO, "Cleanup partial committed DTX "DF_DTI", left %d: %d\n",
+			DP_DTI(&dte->dte_xid), dcca.dcca_pc_count, rc);
+		dtx_dpci_free(dpci);
+	}
+
+	while ((dsp = d_list_pop_entry(&dcca.dcca_st_list, struct dtx_share_peer,
 				       dsp_link)) != NULL)
 		dtx_dsp_free(dsp);
+
+	while ((dpci = d_list_pop_entry(&dcca.dcca_pc_list, struct dtx_partial_cmt_item,
+					dpci_link)) != NULL)
+		dtx_dpci_free(dpci);
 
 	dbca->dbca_cleanup_done = 1;
 
@@ -515,7 +590,7 @@ dtx_batched_commit_one(void *arg)
 			break;
 		}
 
-		rc = dtx_commit(cont, dtes, dcks, cnt, 0);
+		rc = dtx_commit(cont, dtes, dcks, cnt);
 		dtx_free_committable(dtes, dcks, cnt);
 		if (rc != 0) {
 			D_WARN("Fail to batched commit %d entries for "DF_UUID": "DF_RC"\n",
@@ -630,8 +705,7 @@ dtx_batched_commit(void *arg)
 
 			D_ASSERT(dbca->dbca_cont);
 			sched_req_attr_init(&attr, SCHED_REQ_GC, &dbca->dbca_cont->sc_pool_uuid);
-			dbca->dbca_cleanup_req = sched_create_ult(&attr, dtx_cleanup_stale,
-								  dbca, 0);
+			dbca->dbca_cleanup_req = sched_create_ult(&attr, dtx_cleanup, dbca, 0);
 			if (dbca->dbca_cleanup_req == NULL) {
 				D_WARN("Fail to start DTX ULT (3) for "DF_UUID"\n",
 				       DP_UUID(cont->sc_uuid));
@@ -1269,14 +1343,29 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 
 sync:
 	if (dth->dth_sync) {
+		/*
+		 * TBD: We need to reserve some space to guarantee that the local commit can be
+		 *	done successfully. That is not only for sync commit, but also for async
+		 *	batched commit.
+		 */
+		vos_dtx_mark_committable(dth);
 		dte = &dth->dth_dte;
-		rc = dtx_commit(cont, &dte, NULL, 1, dth->dth_epoch);
+		rc = dtx_commit(cont, &dte, NULL, 1);
 		if (rc != 0)
-			D_ERROR(DF_UUID": Fail to sync commit DTX "DF_DTI
-				": "DF_RC"\n", DP_UUID(cont->sc_uuid),
-				DP_DTI(&dth->dth_xid), DP_RC(rc));
+			D_WARN(DF_UUID": Fail to sync commit DTX "DF_DTI": "DF_RC"\n",
+			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), DP_RC(rc));
 
-		D_GOTO(out, result = rc);
+		/*
+		 * NOTE: The semantics of 'sync' commit does not guarantee that all
+		 *	 participants of the DTX can commit it on each local target
+		 *	 successfully, instead, we try to commit the DTX immediately
+		 *	 after all participants claiming 'prepared'. But even if we
+		 *	 failed to commit it, we will not rollback the commit since
+		 *	 the DTX has been marked as 'committable' and may has been
+		 *	 accessed by others. The subsequent dtx_cleanup logic will
+		 *	 handle (re-commit) current failed commit.
+		 */
+		D_GOTO(out, result = 0);
 	}
 
 abort:
@@ -1458,26 +1547,27 @@ dtx_flush_on_close(struct dss_module_info *dmi, struct dtx_batched_cont_args *db
 
 		cnt = dtx_fetch_committable(cont, DTX_THRESHOLD_COUNT,
 					    NULL, DAOS_EPOCH_MAX, &dtes, &dcks);
-		if (cnt <= 0) {
-			rc = cnt;
-			break;
-		}
+		if (cnt <= 0)
+			D_GOTO(out, rc = cnt);
 
 		total += cnt;
 		/* When flush_on_deregister, nobody will add more DTX
 		 * into the CoS cache. So if accumulated commit count
 		 * is more than the total committable ones, then some
 		 * DTX entries cannot be removed from the CoS cache.
+		 * Under such case, have to break the dtx_flush.
 		 */
-		D_ASSERTF(total <= stat.dtx_committable_count,
-			  "Some DTX in CoS may cannot be removed: %lu/%lu\n",
-			  (unsigned long)total,
-			  (unsigned long)stat.dtx_committable_count);
+		if (unlikely(total > stat.dtx_committable_count)) {
+			D_WARN("Some DTX in CoS cannot be committed: %lu/%lu\n",
+			       (unsigned long)total, (unsigned long)stat.dtx_committable_count);
+			D_GOTO(out, rc = -DER_MISC);
+		}
 
-		rc = dtx_commit(cont, dtes, dcks, cnt, 0);
+		rc = dtx_commit(cont, dtes, dcks, cnt);
 		dtx_free_committable(dtes, dcks, cnt);
 	}
 
+out:
 	if (rc < 0)
 		D_ERROR(DF_UUID": Fail to flush CoS cache: rc = %d\n",
 			DP_UUID(cont->sc_uuid), rc);
@@ -2090,7 +2180,7 @@ dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 			break;
 		}
 
-		rc = dtx_commit(cont, dtes, dcks, cnt, 0);
+		rc = dtx_commit(cont, dtes, dcks, cnt);
 		dtx_free_committable(dtes, dcks, cnt);
 		if (rc < 0) {
 			D_ERROR("Fail to commit dtx: "DF_RC"\n", DP_RC(rc));

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1875,30 +1875,43 @@ dtx_handle_resend(daos_handle_t coh,  struct dtx_id *dti,
 	}
 }
 
+/*
+ * If a large transaction has sub-requests to dispatch to a lot of DTX participants,
+ * then we may have to split the dispatch process to multiple steps; otherwise, the
+ * dispatch process may trigger too many in-flight or in-queued RPCs that will hold
+ * too much resource as to server maybe out of memory.
+ */
+#define DTX_EXEC_STEP_LENGTH	DTX_THRESHOLD_COUNT
+
+struct dtx_ult_arg {
+	dtx_sub_func_t			 func;
+	void				*func_arg;
+	struct dtx_leader_handle	*dlh;
+};
+
 static void
 dtx_comp_cb(void **arg)
 {
-	struct dtx_leader_handle	*dlh;
-	uint32_t			 sub_cnt;
+	struct dtx_leader_handle	*dlh = arg[0];
+	struct dtx_sub_status		*sub;
 	uint32_t			 i;
+	uint32_t			 j;
 
-	dlh = arg[0];
+	if (dlh->dlh_agg_cb != NULL) {
+		dlh->dlh_result = dlh->dlh_agg_cb(dlh, dlh->dlh_allow_failure);
+	} else {
+		for (i = dlh->dlh_forward_idx, j = 0; j < dlh->dlh_forward_cnt; i++, j++) {
+			sub = &dlh->dlh_subs[i];
 
-	if (dlh->dlh_agg_cb) {
-		dlh->dlh_result = dlh->dlh_agg_cb(dlh, dlh->dlh_agg_cb_arg);
-		return;
-	}
+			if (sub->dss_tgt.st_rank == DAOS_TGT_IGNORE || sub->dss_comp == 0 ||
+			    sub->dss_result == 0 || sub->dss_result == -DER_ALREADY ||
+			    sub->dss_result == dlh->dlh_allow_failure)
+				continue;
 
-	sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
-	for (i = 0; i < sub_cnt; i++) {
-		struct dtx_sub_status	*sub = &dlh->dlh_subs[i];
-
-		if (sub->dss_result == 0)
-			continue;
-
-		/* Ignore DER_INPROGRESS if there are other failures */
-		if (dlh->dlh_result == 0 || dlh->dlh_result == -DER_INPROGRESS)
-			dlh->dlh_result = sub->dss_result;
+			/* Ignore DER_INPROGRESS if there is other failure. */
+			if (dlh->dlh_result == 0 || dlh->dlh_result == -DER_INPROGRESS)
+				dlh->dlh_result = sub->dss_result;
+		}
 	}
 }
 
@@ -1906,51 +1919,63 @@ static void
 dtx_sub_comp_cb(struct dtx_leader_handle *dlh, int idx, int rc)
 {
 	struct dtx_sub_status	*sub = &dlh->dlh_subs[idx];
-	ABT_future		future = dlh->dlh_future;
+	struct daos_shard_tgt	*tgt = &sub->dss_tgt;
 
-	D_ASSERTF(sub->dss_comp == 0, "Repeat sub completion for idx %d: %d\n", idx, rc);
-	sub->dss_comp = 1;
+	if ((dlh->dlh_normal_sub_done == 0 && !(tgt->st_flags & DTF_DELAY_FORWARD)) ||
+	    (dlh->dlh_normal_sub_done == 1 && tgt->st_flags & DTF_DELAY_FORWARD)) {
+		D_ASSERTF(sub->dss_comp == 0,
+			  "Repeat sub completion for idx %d (%d:%d), flags %x: %d\n",
+			  idx, tgt->st_rank, tgt->st_tgt_idx, tgt->st_flags, rc);
+		sub->dss_comp = 1;
+		sub->dss_result = rc;
 
-	sub->dss_result = rc;
-	rc = ABT_future_set(future, dlh);
-	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed %d.\n", rc);
+		D_DEBUG(DB_TRACE, "execute from idx %d (%d:%d), flags %x: rc %d\n",
+			idx, tgt->st_rank, tgt->st_tgt_idx, tgt->st_flags, rc);
+	}
 
-	D_DEBUG(DB_TRACE, "execute from rank %d tag %d, rc %d.\n",
-		sub->dss_tgt.st_rank, sub->dss_tgt.st_tgt_idx,
-		sub->dss_result);
+	rc = ABT_future_set(dlh->dlh_future, dlh);
+	D_ASSERTF(rc == ABT_SUCCESS,
+		  "ABT_future_set failed for idx %d (%d:%d), flags %x: %d\n",
+		  idx, tgt->st_rank, tgt->st_tgt_idx, tgt->st_flags, rc);
 }
 
-struct dtx_ult_arg {
-	dtx_sub_func_t			func;
-	void				*func_arg;
-	struct dtx_leader_handle	*dlh;
-};
-
 static void
-dtx_leader_exec_ops_normal_ult(void *arg)
+dtx_leader_exec_ops_ult(void *arg)
 {
 	struct dtx_ult_arg		*ult_arg = arg;
 	struct dtx_leader_handle	*dlh = ult_arg->dlh;
 	struct dtx_sub_status		*sub;
-	ABT_future			 future = dlh->dlh_future;
-	uint32_t			 sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
-	uint32_t			 i, j;
+	struct daos_shard_tgt		*tgt;
+	uint32_t			 i;
+	uint32_t			 j;
+	uint32_t			 k;
 	int				 rc = 0;
 
-	D_ASSERT(future != ABT_FUTURE_NULL);
-	for (i = 0, j = 0; i < sub_cnt; i++, j++) {
+	for (i = dlh->dlh_forward_idx, j = 0, k = 0; j < dlh->dlh_forward_cnt; i++, j++) {
 		sub = &dlh->dlh_subs[i];
-		sub->dss_result = 0;
-		sub->dss_comp = 0;
+		tgt = &sub->dss_tgt;
 
-		if (unlikely(sub->dss_tgt.st_flags & DTF_DELAY_FORWARD))
+		if (dlh->dlh_normal_sub_done == 0) {
+			sub->dss_result = 0;
+			sub->dss_comp = 0;
+
+			if (unlikely(tgt->st_flags & DTF_DELAY_FORWARD)) {
+				dtx_sub_comp_cb(dlh, i, 0);
+				continue;
+			}
+		} else {
+			if (!(tgt->st_flags & DTF_DELAY_FORWARD))
+				continue;
+
+			sub->dss_result = 0;
+			sub->dss_comp = 0;
+		}
+
+		if (tgt->st_rank == DAOS_TGT_IGNORE ||
+		    (i == daos_fail_value_get() && DAOS_FAIL_CHECK(DAOS_DTX_SKIP_PREPARE))) {
+			if (dlh->dlh_normal_sub_done == 0 || tgt->st_flags & DTF_DELAY_FORWARD)
+				dtx_sub_comp_cb(dlh, i, 0);
 			continue;
-
-		if (sub->dss_tgt.st_rank == DAOS_TGT_IGNORE ||
-		    (i == daos_fail_value_get() &&
-		     DAOS_FAIL_CHECK(DAOS_DTX_SKIP_PREPARE))) {
-			dtx_sub_comp_cb(dlh, i, 0);
-			goto next;
 		}
 
 		rc = ult_arg->func(dlh, ult_arg->func_arg, i, dtx_sub_comp_cb);
@@ -1960,88 +1985,29 @@ dtx_leader_exec_ops_normal_ult(void *arg)
 			break;
 		}
 
-next:
 		/* Yield to avoid holding CPU for too long time. */
-		if (j >= DTX_RPC_YIELD_THD) {
+		if ((++k) % DTX_RPC_YIELD_THD == 0)
 			ABT_thread_yield();
-			j = 0;
-		}
 	}
 
 	if (rc != 0) {
-		for (i++, j++; i < sub_cnt; i++, j++) {
+		for (i++, j++; j < dlh->dlh_forward_cnt; i++, j++) {
 			sub = &dlh->dlh_subs[i];
-			if (unlikely(sub->dss_tgt.st_flags & DTF_DELAY_FORWARD))
-				continue;
+			tgt = &sub->dss_tgt;
 
-			dtx_sub_comp_cb(dlh, i, 0);
-			if (j >= DTX_RPC_YIELD_THD) {
-				ABT_thread_yield();
-				j = 0;
+			if (dlh->dlh_normal_sub_done == 0 || tgt->st_flags & DTF_DELAY_FORWARD) {
+				sub->dss_result = 0;
+				sub->dss_comp = 0;
+				dtx_sub_comp_cb(dlh, i, 0);
 			}
 		}
 	}
 
 	/* To indicate that the IO forward ULT itself has done. */
-	rc = ABT_future_set(future, dlh);
-	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed (3) %d.\n", rc);
-
-	D_FREE(ult_arg);
-}
-
-static void
-dtx_leader_exec_ops_delay_ult(void *arg)
-{
-	struct dtx_ult_arg		*ult_arg = arg;
-	struct dtx_leader_handle	*dlh = ult_arg->dlh;
-	struct dtx_sub_status		*sub;
-	ABT_future			 future = dlh->dlh_future;
-	uint32_t			 sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
-	uint32_t			 i, j;
-	int				 rc = 0;
-
-	D_ASSERT(future != ABT_FUTURE_NULL);
-	for (i = 0, j = 0; i < sub_cnt; i++, j++) {
-		sub = &dlh->dlh_subs[i];
-		if (!(sub->dss_tgt.st_flags & DTF_DELAY_FORWARD))
-			continue;
-
-		sub->dss_result = 0;
-		sub->dss_comp = 0;
-
-		rc = ult_arg->func(dlh, ult_arg->func_arg, i, dtx_sub_comp_cb);
-		if (rc != 0) {
-			if (sub->dss_comp == 0)
-				dtx_sub_comp_cb(dlh, i, rc);
-			break;
-		}
-
-		/* Yield to avoid holding CPU for too long time. */
-		if (j >= DTX_RPC_YIELD_THD) {
-			ABT_thread_yield();
-			j = 0;
-		}
-	}
-
-	if (rc != 0) {
-		for (i++, j++; i < sub_cnt; i++, j++) {
-			sub = &dlh->dlh_subs[i];
-			if (!(sub->dss_tgt.st_flags & DTF_DELAY_FORWARD))
-				continue;
-
-			dtx_sub_comp_cb(dlh, i, 0);
-			if (j >= DTX_RPC_YIELD_THD) {
-				ABT_thread_yield();
-				j = 0;
-			}
-		}
-	}
-
-	/* To indicate that the IO forward ULT itself has done. */
-	rc = ABT_future_set(future, dlh);
-	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed (4) %d.\n", rc);
-
-	D_FREE(ult_arg);
+	rc = ABT_future_set(dlh->dlh_future, dlh);
+	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed [%u, %u), for delay %s: %d\n",
+		  dlh->dlh_forward_idx, dlh->dlh_forward_idx + dlh->dlh_forward_cnt,
+		  dlh->dlh_normal_sub_done == 1 ? "yes" : "no", rc);
 }
 
 /**
@@ -2049,112 +2015,140 @@ dtx_leader_exec_ops_delay_ult(void *arg)
  */
 int
 dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
-		    dtx_agg_cb_t agg_cb, void *agg_cb_arg, void *func_arg)
+		    dtx_agg_cb_t agg_cb, int allow_failure, void *func_arg)
 {
-	struct dtx_ult_arg	*ult_arg;
-	int			 rc;
-	int			 rc1 = 0;
+	struct dtx_ult_arg	ult_arg;
+	int			sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
+	int			rc = 0;
+	int			local_rc = 0;
+	int			remote_rc = 0;
+
+	ult_arg.func = func;
+	ult_arg.func_arg = func_arg;
+	ult_arg.dlh = dlh;
 
 	dlh->dlh_result = 0;
+	dlh->dlh_allow_failure = allow_failure;
 	dlh->dlh_normal_sub_done = 0;
+	dlh->dlh_forward_idx = 0;
+
+	if (sub_cnt > DTX_EXEC_STEP_LENGTH) {
+		dlh->dlh_forward_cnt = DTX_EXEC_STEP_LENGTH;
+		dlh->dlh_agg_cb = NULL;
+	} else {
+		dlh->dlh_forward_cnt = sub_cnt;
+		if (likely(dlh->dlh_delay_sub_cnt == 0))
+			dlh->dlh_agg_cb = agg_cb;
+		else
+			dlh->dlh_agg_cb = NULL;
+	}
 
 	if (dlh->dlh_normal_sub_cnt == 0)
 		goto exec;
 
-	D_ALLOC_PTR(ult_arg);
-	if (ult_arg == NULL)
-		return -DER_NOMEM;
-
-	ult_arg->func = func;
-	ult_arg->func_arg = func_arg;
-	ult_arg->dlh = dlh;
-
-	if (dlh->dlh_delay_sub_cnt > 0) {
-		dlh->dlh_agg_cb = NULL;
-		dlh->dlh_agg_cb_arg = NULL;
-	} else {
-		dlh->dlh_agg_cb = agg_cb;
-		dlh->dlh_agg_cb_arg = agg_cb_arg;
-	}
-
+again:
 	D_ASSERT(dlh->dlh_future == ABT_FUTURE_NULL);
 
 	/*
-	 * Create the future with sub_cnt + 1, the additional one is used by the IO forward
-	 * ULT itself to prevent the DTX handle being freed before the IO forward ULT exit.
+	 * Create the future with dlh->dlh_forward_cnt + 1, the additional one is used by the IO
+	 * forward ULT itself to prevent the DTX handle being freed before the IO forward ULT exit.
 	 */
-	rc = ABT_future_create(dlh->dlh_normal_sub_cnt + 1, dtx_comp_cb, &dlh->dlh_future);
+	rc = ABT_future_create(dlh->dlh_forward_cnt + 1, dtx_comp_cb, &dlh->dlh_future);
 	if (rc != ABT_SUCCESS) {
-		D_ERROR("ABT_future_create failed (1): "DF_RC"\n", DP_RC(rc));
-		D_FREE(ult_arg);
-		return dss_abterr2der(rc);
+		D_ERROR("ABT_future_create failed [%u, %u] (1): "DF_RC"\n",
+			dlh->dlh_forward_idx, dlh->dlh_forward_cnt, DP_RC(rc));
+		D_GOTO(out, rc = dss_abterr2der(rc));
 	}
 
 	/*
-	 * XXX: Ideally, we probably should create ULT for each shard, but for performance
-	 *	reasons, let's only create one for all remote targets for now.
+	 * NOTE: Ideally, we probably should create ULT for each shard, but for performance
+	 *	 reasons, let's only create one for all remote targets for now.
 	 */
-	rc = dss_ult_create(dtx_leader_exec_ops_normal_ult, ult_arg, DSS_XS_IOFW,
+	rc = dss_ult_create(dtx_leader_exec_ops_ult, &ult_arg, DSS_XS_IOFW,
 			    dss_get_module_info()->dmi_tgt_id, DSS_DEEP_STACK_SZ, NULL);
 	if (rc != 0) {
-		D_ERROR("ult create failed (2): "DF_RC"\n", DP_RC(rc));
-		D_FREE(ult_arg);
+		D_ERROR("ult create failed [%u, %u] (2): "DF_RC"\n",
+			dlh->dlh_forward_idx, dlh->dlh_forward_cnt, DP_RC(rc));
 		ABT_future_free(&dlh->dlh_future);
-		return rc;
+		goto out;
 	}
 
 exec:
-	/* Then execute the local operation */
-	rc = func(dlh, func_arg, -1, NULL);
+	/* Execute the local operation only for once. */
+	if (dlh->dlh_forward_idx == 0)
+		local_rc = func(dlh, func_arg, -1, NULL);
 
 	/* Even the local request failure, we still need to wait for remote sub request. */
-	if (dlh->dlh_normal_sub_cnt > 0) {
-		rc1 = dtx_leader_wait(dlh);
-		if (unlikely(rc1 == -DER_ALREADY))
-			rc1 = 0;
+	if (dlh->dlh_normal_sub_cnt > 0)
+		remote_rc = dtx_leader_wait(dlh);
+
+	if (local_rc != 0 && local_rc != allow_failure)
+		D_GOTO(out, rc = local_rc);
+
+	if (remote_rc != 0 && remote_rc != allow_failure)
+		D_GOTO(out, rc = remote_rc);
+
+	sub_cnt -= dlh->dlh_forward_cnt;
+	if (sub_cnt > 0) {
+		dlh->dlh_forward_idx += dlh->dlh_forward_cnt;
+		if (sub_cnt <= DTX_EXEC_STEP_LENGTH) {
+			dlh->dlh_forward_cnt = sub_cnt;
+			if (likely(dlh->dlh_delay_sub_cnt == 0))
+				dlh->dlh_agg_cb = agg_cb;
+		}
+
+		D_DEBUG(DB_IO, "More dispatch sub-requests for "DF_DTI", normal %u, "
+			"delay %u, idx %u, cnt %d, allow_failure %d\n",
+			DP_DTI(&dlh->dlh_handle.dth_xid), dlh->dlh_normal_sub_cnt,
+			dlh->dlh_delay_sub_cnt, dlh->dlh_forward_idx,
+			dlh->dlh_forward_cnt, allow_failure);
+
+		goto again;
 	}
-
-	if (rc != 0)
-		return rc;
-
-	if (rc1 != 0 || likely(dlh->dlh_delay_sub_cnt == 0))
-		return rc1;
-
-	/* For delay forward sub requests. */
 
 	dlh->dlh_normal_sub_done = 1;
 
-	D_ALLOC_PTR(ult_arg);
-	if (ult_arg == NULL)
-		return -DER_NOMEM;
-
-	ult_arg->func = func;
-	ult_arg->func_arg = func_arg;
-	ult_arg->dlh = dlh;
-	dlh->dlh_agg_cb = agg_cb;
-	dlh->dlh_agg_cb_arg = agg_cb_arg;
+	if (likely(dlh->dlh_delay_sub_cnt == 0))
+		goto out;
 
 	D_ASSERT(dlh->dlh_future == ABT_FUTURE_NULL);
 
+	/*
+	 * Delay forward is rare case, the count of targets with delay forward
+	 * will be very limited. So le's handle them via another one cycle dispatch.
+	 */
 	rc = ABT_future_create(dlh->dlh_delay_sub_cnt + 1, dtx_comp_cb, &dlh->dlh_future);
 	if (rc != ABT_SUCCESS) {
 		D_ERROR("ABT_future_create failed (3): "DF_RC"\n", DP_RC(rc));
-		D_FREE(ult_arg);
-		return dss_abterr2der(rc);
+		D_GOTO(out, rc = dss_abterr2der(rc));
 	}
 
-	rc = dss_ult_create(dtx_leader_exec_ops_delay_ult, ult_arg, DSS_XS_IOFW,
+	dlh->dlh_agg_cb = agg_cb;
+	dlh->dlh_forward_idx = 0;
+	/* The ones without DELAY flag will be skipped when scan the targets array. */
+	dlh->dlh_forward_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
+
+	rc = dss_ult_create(dtx_leader_exec_ops_ult, &ult_arg, DSS_XS_IOFW,
 			    dss_get_module_info()->dmi_tgt_id, DSS_DEEP_STACK_SZ, NULL);
 	if (rc != 0) {
 		D_ERROR("ult create failed (4): "DF_RC"\n", DP_RC(rc));
-		D_FREE(ult_arg);
 		ABT_future_free(&dlh->dlh_future);
-		return rc;
+		goto out;
 	}
 
-	rc = dtx_leader_wait(dlh);
-	if (unlikely(rc == -DER_ALREADY))
-		rc = 0;
+	remote_rc = dtx_leader_wait(dlh);
+	if (remote_rc != 0 && remote_rc != allow_failure)
+		rc = remote_rc;
+
+	D_DEBUG(DB_IO, "Delay dispatched sub-requests for "DF_DTI", normal %u, delay %u, cnt %d, "
+		"allow_failure %d, local_rc %d, remote_rc %d\n", DP_DTI(&dlh->dlh_handle.dth_xid),
+		dlh->dlh_normal_sub_cnt, dlh->dlh_delay_sub_cnt, dlh->dlh_forward_cnt,
+		allow_failure, local_rc, remote_rc);
+
+out:
+	if (rc == 0 && local_rc == allow_failure &&
+	    (dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt == 0 || remote_rc == allow_failure))
+		rc = allow_failure;
 
 	return rc;
 }

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -22,7 +22,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_DTX_VERSION	2
+#define DAOS_DTX_VERSION	3
 
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
@@ -45,7 +45,8 @@ enum dtx_operation {
 	((uuid_t)		(di_po_uuid)		CRT_VAR)	\
 	((uuid_t)		(di_co_uuid)		CRT_VAR)	\
 	((uint64_t)		(di_epoch)		CRT_VAR)	\
-	((struct dtx_id)	(di_dtx_array)		CRT_ARRAY)
+	((struct dtx_id)	(di_dtx_array)		CRT_ARRAY)	\
+	((uint32_t)		(di_flags)		CRT_ARRAY)
 
 /* DTX RPC output fields */
 #define DAOS_OSEQ_DTX							\
@@ -61,12 +62,12 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  * If the oldest active DTX exceeds such threshold, it will trigger
  * DTX cleanup locally.
  */
-#define DTX_CLEANUP_THD_AGE_UP	60
+#define DTX_CLEANUP_THD_AGE_UP	90
 
 /* If DTX cleanup for stale entries is triggered, then the DTXs with
  * older ages than this threshold will be cleanup.
  */
-#define DTX_CLEANUP_THD_AGE_LO	45
+#define DTX_CLEANUP_THD_AGE_LO	75
 
 /* The count threshold (per pool) for triggering DTX aggregation. */
 #define DTX_AGG_THD_CNT_MAX	(1 << 24)
@@ -213,7 +214,7 @@ uint64_t dtx_cos_oldest(struct ds_cont_child *cont);
 
 /* dtx_rpc.c */
 int dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
-	       struct dtx_cos_key *dcks, int count, daos_epoch_t epoch);
+	       struct dtx_cos_key *dcks, int count);
 int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
 	      daos_epoch_t epoch);
 
@@ -232,6 +233,10 @@ enum dtx_status_handle_result {
 	DSHR_IGNORE		= 3,
 	DSHR_ABORT_FAILED	= 4,
 	DSHR_CORRUPT		= 5,
+};
+
+enum dtx_rpc_flags {
+	DRF_INITIAL_LEADER	= (1 << 0),
 };
 
 #endif /* __DTX_INTERNAL_H__ */

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -115,7 +115,7 @@ next:
 	}
 
 	if (j > 0) {
-		rc = dtx_commit(cont, dtes, dcks, j, 0);
+		rc = dtx_commit(cont, dtes, dcks, j);
 		if (rc < 0)
 			D_ERROR("Failed to commit the DTXs: rc = "DF_RC"\n",
 				DP_RC(rc));
@@ -424,6 +424,9 @@ dtx_status_handle(struct dtx_resync_args *dra)
 
 		mbs = dre->dre_dte.dte_mbs;
 		D_ASSERT(mbs->dm_tgt_cnt > 0);
+
+		if (mbs->dm_dte_flags & DTE_PARTIAL_COMMITTED)
+			goto commit;
 
 		rc = dtx_is_leader(pool, dra, dre);
 		if (rc <= 0) {

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -83,6 +83,7 @@ struct dtx_req_rec {
 	int				 drr_result; /* The RPC result */
 	uint32_t			 drr_comp:1;
 	struct dtx_id			*drr_dti; /* The DTX array */
+	uint32_t			*drr_flags;
 	struct dtx_share_peer		**drr_cb_args; /* Used by dtx_req_cb. */
 };
 
@@ -163,13 +164,10 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 				dtx_dsp_free(dsp);
 			break;
 		case DTX_ST_COMMITTABLE:
-			/* Committable, will be committed soon. */
-			if (dra->dra_cmt_list != NULL)
-				d_list_add_tail(&dsp->dsp_link,
-						dra->dra_cmt_list);
-			else
-				dtx_dsp_free(dsp);
-			break;
+			/*
+			 * Committable, will be committed soon.
+			 * Fall through.
+			 */
 		case DTX_ST_COMMITTED:
 			/* Has been committed on leader, we may miss related
 			 * commit request, so let's commit it locally.
@@ -192,7 +190,8 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			 * been aborted or committed (then removed by DTX aggregation). Then mark it
 			 * as 'orphan' that will be handled via some special DAOS tools in future.
 			 */
-			rc1 = vos_dtx_set_flags(dra->dra_cont->sc_hdl, &dsp->dsp_xid, DTE_ORPHAN);
+			rc1 = vos_dtx_set_flags(dra->dra_cont->sc_hdl, &dsp->dsp_xid, 1,
+						DTE_ORPHAN);
 			if (rc1 == -DER_NONEXIST || rc1 == -DER_NO_PERM) {
 				dtx_dsp_free(dsp);
 				break;
@@ -257,6 +256,13 @@ dtx_req_send(struct dtx_req_rec *drr, daos_epoch_t epoch)
 		din->di_epoch = epoch;
 		din->di_dtx_array.ca_count = drr->drr_count;
 		din->di_dtx_array.ca_arrays = drr->drr_dti;
+		if (drr->drr_flags != NULL) {
+			din->di_flags.ca_count = drr->drr_count;
+			din->di_flags.ca_arrays = drr->drr_flags;
+		} else {
+			din->di_flags.ca_count = 0;
+			din->di_flags.ca_arrays = NULL;
+		}
 
 		if (dra->dra_opc == DTX_REFRESH && DAOS_FAIL_CHECK(DAOS_DTX_RESYNC_DELAY)) {
 			rc = crt_req_set_timeout(req, 3);
@@ -467,6 +473,7 @@ dtx_cf_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 	d_list_del(&drr->drr_link);
 	D_FREE(drr->drr_cb_args);
 	D_FREE(drr->drr_dti);
+	D_FREE(drr->drr_flags);
 	D_FREE(drr);
 
 	return 0;
@@ -746,8 +753,10 @@ dtx_rpc_post(d_list_t *head, daos_handle_t *tree_hdl, struct dtx_req_args *dra,
 	}
 
 	while ((drr = d_list_pop_entry(head, struct dtx_req_rec, drr_link)) != NULL) {
-		if (free_dti)
+		if (free_dti) {
 			D_FREE(drr->drr_dti);
+			D_FREE(drr->drr_flags);
+		}
 		D_FREE(drr);
 	}
 
@@ -770,7 +779,7 @@ dtx_rpc_post(d_list_t *head, daos_handle_t *tree_hdl, struct dtx_req_args *dra,
  */
 int
 dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
-	   struct dtx_cos_key *dcks, int count, daos_epoch_t epoch)
+	   struct dtx_cos_key *dcks, int count)
 {
 	d_list_t		 head;
 	struct btr_root		 tree_root = { 0 };
@@ -784,83 +793,89 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	int			 committed = 0;
 	int			 rc;
 	int			 rc1 = 0;
-	int			 rc2 = 0;
 	int			 i;
 
 	if (count > 1) {
 		D_ALLOC_ARRAY(dtis, count);
 		if (dtis == NULL)
-			D_GOTO(log, rc = -DER_NOMEM);
+			D_GOTO(out, rc = -DER_NOMEM);
 	} else {
 		dtis = &dti;
 	}
 
 	rc = dtx_rpc_prep(cont, &head, &tree_root, &tree_hdl, &dra, &helper, dtis,
 			  dtes, 0, count, DTX_COMMIT, &committed);
-	if (rc < 0)
-		goto out;
 
-	if (dcks != NULL) {
-		if (count > 1) {
-			D_ALLOC_ARRAY(rm_cos, count);
-			if (rm_cos == NULL)
-				D_GOTO(out, rc = -DER_NOMEM);
-		} else {
-			rm_cos = &cos;
-		}
-	}
+	/*
+	 * NOTE: Before committing the DTX on remote participants, we cannot remove the active
+	 *	 DTX locally; otherwise, the local committed DTX entry may be removed via DTX
+	 *	 aggregation before remote participants commit done. Under such case, if some
+	 *	 remote DTX participant triggere DTX_REFRESH for such DTX during the interval,
+	 *	 then it will get -DER_TX_UNCERTAIN, that may cause related application to be
+	 *	 failed. So here, we let remote participants to commit firstly, if failed, we
+	 *	 will ask the leader to retry the commit until all participants got committed.
+	 *
+	 * Some RPC may has been sent, so need to wait even if dtx_rpc_prep hit failure.
+	 */
+	rc = dtx_rpc_post(&head, &tree_hdl, &dra, &helper, rc);
+	if (rc > 0 || rc == -DER_NONEXIST || rc == -DER_EXCLUDED)
+		rc = 0;
 
-	rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count, rm_cos);
-	if (rc1 >= 0 && rm_cos != NULL) {
-		for (i = 0; i < count; i++) {
-			if (rm_cos[i]) {
-				D_ASSERT(!daos_oid_is_null(dcks[i].oid.id_pub));
-				dtx_del_cos(cont, &dtis[i], &dcks[i].oid, dcks[i].dkey_hash);
+	if (rc != 0) {
+		/*
+		 * Some DTX entries may have been committed on some participants. Then mark all
+		 * the DTX entries (in the dtis) as "PARTIAL_COMMITTED" and re-commit them later.
+		 * It is harmless to re-commit the DTX that has ever been committed.
+		 */
+		if (committed > 0)
+			rc1 = vos_dtx_set_flags(cont->sc_hdl, dtis, count, DTE_PARTIAL_COMMITTED);
+	} else {
+		if (dcks != NULL) {
+			if (count > 1) {
+				D_ALLOC_ARRAY(rm_cos, count);
+				if (rm_cos == NULL)
+					D_GOTO(out, rc1 = -DER_NOMEM);
+			} else {
+				rm_cos = &cos;
 			}
 		}
-	}
 
-	/* -DER_NONEXIST may be caused by race or repeated commit, ignore it. */
-	if (rc1 > 0) {
-		committed += rc1;
-		rc1 = 0;
-	} else if (rc1 == -DER_NONEXIST) {
-		rc1 = 0;
+		rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count, rm_cos);
+		if (rc1 > 0) {
+			committed += rc1;
+			rc1 = 0;
+		} else if (rc1 == -DER_NONEXIST) {
+			/* -DER_NONEXIST may be caused by race or repeated commit, ignore it. */
+			rc1 = 0;
+		}
+
+		if (rc1 == 0 && rm_cos != NULL) {
+			for (i = 0; i < count; i++) {
+				if (rm_cos[i]) {
+					D_ASSERT(!daos_oid_is_null(dcks[i].oid.id_pub));
+					dtx_del_cos(cont, &dtis[i], &dcks[i].oid,
+						    dcks[i].dkey_hash);
+				}
+			}
+		}
+
+		if (rm_cos != &cos)
+			D_FREE(rm_cos);
 	}
 
 out:
-	rc2 = dtx_rpc_post(&head, &tree_hdl, &dra, &helper, rc);
-	if (rc2 > 0 || rc2 == -DER_NONEXIST || rc2 == -DER_EXCLUDED)
-		rc2 = 0;
-
 	if (dtis != &dti)
 		D_FREE(dtis);
 
-	if (rm_cos != &cos)
-		D_FREE(rm_cos);
-
-log:
-	if (rc != 0 || rc1 != 0 || rc2 != 0) {
-		D_ERROR("Some failure during commit DTX entries "DF_DTI", epoch "
-			DF_X64", count %d: rc %d %d %d, %s committed\n",
-			DP_DTI(&dtes[0]->dte_xid), epoch, count, rc, rc1, rc2,
-			committed > 0 ? "partial" : "nothing");
-
-		if (epoch != 0) {
-			if (committed == 0) {
-				D_ASSERT(count == 1);
-
-				dtx_abort(cont, dtes[0], epoch);
-			} else {
-				rc = rc1 = rc2 = 0;
-			}
-		}
-	} else {
+	if (rc != 0 || rc1 != 0)
+		D_ERROR("Failed to commit DTX entries "DF_DTI", count %d, %s committed: %d %d\n",
+			DP_DTI(&dtes[0]->dte_xid), count, committed > 0 ? "partial" : "nothing",
+			rc, rc1);
+	else
 		D_DEBUG(DB_IO, "Commit DTXs " DF_DTI", count %d\n",
 			DP_DTI(&dtes[0]->dte_xid), count);
-	}
 
-	return rc != 0 ? rc : (rc1 != 0 ? rc1 : rc2);
+	return rc != 0 ? rc : rc1;
 }
 
 
@@ -895,7 +910,7 @@ dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	if (epoch != 0)
 		rc1 = vos_dtx_abort(cont->sc_hdl, &dte->dte_xid, epoch);
 	else
-		rc1 = vos_dtx_set_flags(cont->sc_hdl, &dte->dte_xid, DTE_CORRUPTED);
+		rc1 = vos_dtx_set_flags(cont->sc_hdl, &dte->dte_xid, 1, DTE_CORRUPTED);
 	if (rc1 > 0 || rc1 == -DER_NONEXIST)
 		rc1 = 0;
 
@@ -947,6 +962,7 @@ dtx_refresh_internal(struct ds_cont_child *cont, int *check_count,
 	d_list_t		 head;
 	d_list_t		 self;
 	d_rank_t		 myrank;
+	uint32_t		 flags;
 	int			 len = 0;
 	int			 rc = 0;
 	int			 count;
@@ -1020,10 +1036,17 @@ again:
 			goto again;
 		}
 
+		if (dsp->dsp_mbs->dm_flags & DMF_CONTAIN_LEADER &&
+		    dsp->dsp_mbs->dm_tgts[0].ddt_id == target->ta_comp.co_id)
+			flags = DRF_INITIAL_LEADER;
+		else
+			flags = 0;
+
 		d_list_for_each_entry(drr, &head, drr_link) {
 			if (drr->drr_rank == target->ta_comp.co_rank &&
 			    drr->drr_tag == target->ta_comp.co_index) {
 				drr->drr_dti[drr->drr_count] = dsp->dsp_xid;
+				drr->drr_flags[drr->drr_count] = flags;
 				drr->drr_cb_args[drr->drr_count++] = dsp;
 				goto next;
 			}
@@ -1039,9 +1062,17 @@ again:
 			D_GOTO(out, rc = -DER_NOMEM);
 		}
 
+		D_ALLOC_ARRAY(drr->drr_flags, *check_count);
+		if (drr->drr_flags == NULL) {
+			D_FREE(drr->drr_dti);
+			D_FREE(drr);
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+
 		D_ALLOC_ARRAY(drr->drr_cb_args, *check_count);
 		if (drr->drr_cb_args == NULL) {
 			D_FREE(drr->drr_dti);
+			D_FREE(drr->drr_flags);
 			D_FREE(drr);
 			D_GOTO(out, rc = -DER_NOMEM);
 		}
@@ -1050,6 +1081,7 @@ again:
 		drr->drr_tag = target->ta_comp.co_index;
 		drr->drr_count = 1;
 		drr->drr_dti[0] = dsp->dsp_xid;
+		drr->drr_flags[0] = flags;
 		drr->drr_cb_args[0] = dsp;
 		d_list_add_tail(&drr->drr_link, &head);
 		len++;
@@ -1093,7 +1125,7 @@ next:
 
 			dck.oid = dsp->dsp_oid;
 			dck.dkey_hash = dsp->dsp_dkey_hash;
-			rc = dtx_commit(cont, &pdte, &dck, 1, 0);
+			rc = dtx_commit(cont, &pdte, &dck, 1);
 			if (rc < 0 && rc != -DER_NONEXIST && cmt_list != NULL)
 				d_list_add_tail(&dsp->dsp_link, cmt_list);
 			else
@@ -1134,6 +1166,7 @@ out:
 				       drr_link)) != NULL) {
 		D_FREE(drr->drr_cb_args);
 		D_FREE(drr->drr_dti);
+		D_FREE(drr->drr_flags);
 		D_FREE(drr);
 	}
 

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -212,6 +212,13 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 			else
 				dtx_dsp_free(dsp);
 			break;
+		case -DER_INPROGRESS:
+			rc1 = vos_dtx_check(dra->dra_cont->sc_hdl, &dsp->dsp_xid,
+					    NULL, NULL, NULL, NULL, false);
+			dtx_dsp_free(dsp);
+			if (rc1 != DTX_ST_COMMITTED && rc1 != DTX_ST_ABORTED && rc != -DER_NONEXIST)
+				D_GOTO(out, rc = *ret);
+			break;
 		default:
 			dtx_dsp_free(dsp);
 			D_GOTO(out, rc = *ret);

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -141,6 +141,7 @@ dtx_handler(crt_rpc_t *rpc)
 	uint32_t		 vers[DTX_REFRESH_MAX] = { 0 };
 	uint32_t		 opc = opc_get(rpc->cr_opc);
 	uint32_t		 committed = 0;
+	uint32_t		*flags;
 	int			*ptr;
 	int			 count = DTX_YIELD_CYCLE;
 	int			 i = 0;
@@ -199,18 +200,19 @@ dtx_handler(crt_rpc_t *rpc)
 		if (DAOS_FAIL_CHECK(DAOS_DTX_MISS_ABORT))
 			break;
 
-		/* Currently, only support to abort single DTX. */
-		if (din->di_dtx_array.ca_count != 1)
-			D_GOTO(out, rc = -DER_PROTO);
+		if (din->di_epoch != 0) {
+			/* Currently, only support to abort single DTX. */
+			if (din->di_dtx_array.ca_count != 1)
+				D_GOTO(out, rc = -DER_PROTO);
 
-		if (din->di_epoch != 0)
 			rc = vos_dtx_abort(cont->sc_hdl,
 					   (struct dtx_id *)din->di_dtx_array.ca_arrays,
 					   din->di_epoch);
-		else
+		} else {
 			rc = vos_dtx_set_flags(cont->sc_hdl,
 					       (struct dtx_id *)din->di_dtx_array.ca_arrays,
-					       DTE_CORRUPTED);
+					       din->di_dtx_array.ca_count, DTE_CORRUPTED);
+		}
 		break;
 	case DTX_CHECK:
 		/* Currently, only support to check single DTX state. */
@@ -257,12 +259,14 @@ dtx_handler(crt_rpc_t *rpc)
 			D_GOTO(out, rc = 0);
 		}
 
+		flags = din->di_flags.ca_arrays;
+
 		for (i = 0, rc1 = 0; i < count; i++) {
 			ptr = (int *)dout->do_sub_rets.ca_arrays + i;
 			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
 			*ptr = vos_dtx_check(cont->sc_hdl, dtis, NULL, &vers[i], &mbs[i], &dcks[i],
 					     true);
-			if (*ptr == -DER_NONEXIST) {
+			if (*ptr == -DER_NONEXIST && !(flags[i] & DRF_INITIAL_LEADER)) {
 				struct dtx_stat		stat = { 0 };
 
 				/* dtx_id::dti_hlc is client side time stamp. If it is
@@ -339,7 +343,7 @@ out:
 		/* Commit the DTX after replied the original refresh request to
 		 * avoid further query the same DTX.
 		 */
-		rc = dtx_commit(cont, pdte, dcks, j, 0);
+		rc = dtx_commit(cont, pdte, dcks, j);
 		if (rc < 0)
 			D_WARN("Failed to commit DTX "DF_DTI", count %d: "
 			       DF_RC"\n", DP_DTI(&dtes[0].dte_xid), j,
@@ -370,7 +374,7 @@ dtx_init(void)
 		dtx_agg_thd_cnt_up = DTX_AGG_THD_CNT_DEF;
 	}
 
-	dtx_agg_thd_cnt_lo = dtx_agg_thd_cnt_up * 6 / 7;
+	dtx_agg_thd_cnt_lo = dtx_agg_thd_cnt_up * 19 / 20;
 	D_INFO("Set DTX aggregation count threshold as %u (entries)\n", dtx_agg_thd_cnt_up);
 
 	dtx_agg_thd_age_up = DTX_AGG_THD_AGE_DEF;
@@ -382,7 +386,7 @@ dtx_init(void)
 		dtx_agg_thd_age_up = DTX_AGG_THD_AGE_DEF;
 	}
 
-	dtx_agg_thd_age_lo = dtx_agg_thd_age_up - 30;
+	dtx_agg_thd_age_lo = dtx_agg_thd_age_up * 19 / 20;
 	D_INFO("Set DTX aggregation time threshold as %u (seconds)\n", dtx_agg_thd_age_up);
 
 	dtx_rpc_helper_thd = DTX_RPC_HELPER_THD_DEF;

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -42,23 +42,24 @@ enum dtx_grp_flags {
 };
 
 enum dtx_mbs_flags {
-	/* The targets modified via the DTX belong to replicated object
-	 * within single redundancy group.
+	/* The targets being modified via the DTX belong to a replicated
+	 * object within single redundancy group.
 	 */
 	DMF_SRDG_REP			= (1 << 0),
-	/* The MBS contains the leader information, used for distributed
-	 * transaction. For stand-alone modification, leader information
-	 * is not stored inside MBS as optimization.
+	/* The MBS contains the DTX leader information, usually used for
+	 * distributed transaction. In old release (before 2.4), for some
+	 * stand-alone modification, leader information may be not stored
+	 * inside MBS as optimization.
 	 */
 	DMF_CONTAIN_LEADER		= (1 << 1),
-	/* The dtx_memberships::dm_tgts is sorted against target ID. */
+	/* The dtx_memberships::dm_tgts is sorted against target ID. Obsolete. */
 	DMF_SORTED_TGT_ID		= (1 << 2),
 	/* The dtx_memberships::dm_tgts is sorted against shard index.
 	 * For most of cases, shard index matches the shard ID. But during
 	 * shard migration, there may be some temporary shards in related
 	 * object layout. Under such case, related shard ID is not unique
 	 * in the object layout, but the shard index is unique. So we use
-	 * shard index to sort the dtx_memberships::dm_tgts.
+	 * shard index to sort the dtx_memberships::dm_tgts. Obsolete.
 	 */
 	DMF_SORTED_SAD_IDX		= (1 << 3),
 };
@@ -72,8 +73,7 @@ struct dtx_daos_target {
 	union {
 		/* For distributed transaction, see dtx_target_flags. */
 		uint32_t		ddt_flags;
-		/* For standalong modification. */
-		uint32_t		ddt_shard;
+		uint32_t		ddt_padding;
 	};
 };
 

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -145,7 +145,8 @@ struct dtx_sub_status {
 };
 
 struct dtx_leader_handle;
-typedef int (*dtx_agg_cb_t)(struct dtx_leader_handle *dlh, void *arg);
+typedef int (*dtx_agg_cb_t)(struct dtx_leader_handle *dlh, int allow_failure);
+
 /* Transaction handle on the leader node to manage the transaction */
 struct dtx_leader_handle {
 	/* The dtx handle on the leader node */
@@ -160,16 +161,20 @@ struct dtx_leader_handle {
 	/* The future to wait for sub requests to finish. */
 	ABT_future			dlh_future;
 
+	dtx_agg_cb_t			dlh_agg_cb;
+	int32_t				dlh_allow_failure;
 	/* Normal sub requests have been processed. */
 	uint32_t			dlh_normal_sub_done:1;
 	/* How many normal sub request. */
 	uint32_t			dlh_normal_sub_cnt;
 	/* How many delay forward sub request. */
 	uint32_t			dlh_delay_sub_cnt;
+	/* The index of the first target that forward sub-request to. */
+	uint32_t			dlh_forward_idx;
+	/* The count of the targets that forward sub-request to. */
+	uint32_t			dlh_forward_cnt;
 	/* Sub transaction handle to manage the dtx leader */
 	struct dtx_sub_status		*dlh_subs;
-	dtx_agg_cb_t			dlh_agg_cb;
-	void				*dlh_agg_cb_arg;
 };
 
 struct dtx_stat {
@@ -239,7 +244,7 @@ dtx_list_cos(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 	     uint64_t dkey_hash, int max, struct dtx_id **dtis);
 int
 dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
-		    dtx_agg_cb_t agg_cb, void *agg_cb_arg, void *func_arg);
+		    dtx_agg_cb_t agg_cb, int allow_failure, void *func_arg);
 
 int dtx_cont_open(struct ds_cont_child *cont);
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -141,13 +141,14 @@ vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch);
  * Set flags on the active DTXs.
  *
  * \param coh	[IN]	Container open handle.
- * \param dti	[IN]	The DTX identifiers to be handled.
+ * \param dtis	[IN]	The array for DTX identifiers to be set.
+ * \param count [IN]	The count of DTXs to be set.
  * \param flags [IN]	The flags for the DTXs.
  *
  * \return		Zero on success, negative value if error.
  */
 int
-vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dti, uint32_t flags);
+vos_dtx_set_flags(daos_handle_t coh, struct dtx_id dtis[], int count, uint32_t flags);
 
 /**
  * Aggregate the committed DTXs.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -60,6 +60,10 @@ enum dtx_entry_flags {
 	DTE_CORRUPTED		= (1 << 3),
 	/* The DTX entry on leader does not exist, then not sure the status. */
 	DTE_ORPHAN		= (1 << 4),
+	/* Related DTX may be only committed on some participants, but not
+	 * on all yet, need to be re-committed.
+	 */
+	DTE_PARTIAL_COMMITTED	= (1 << 5),
 };
 
 struct dtx_entry {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1209,7 +1209,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 		D_ASSERT(tgt == req_tgts->ort_shard_tgts + shard_cnt);
 
 out:
-	D_CDEBUG(rc == 0 || rc == -DER_NEED_TX || rc == -DER_TGT_RETRY, DB_IO,
+	D_CDEBUG(rc == 0 || rc == -DER_NEED_TX || rc == -DER_TGT_RETRY, DB_TRACE,
 		 DLOG_ERR, DF_OID", forward:" DF_RC"\n", DP_OID(obj->cob_md.omd_id), DP_RC(rc));
 	return rc;
 }

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1598,6 +1598,25 @@ dc_obj_layout_refresh(daos_handle_t oh)
 	return rc;
 }
 
+static inline uint32_t
+dc_obj_retry_delay(struct obj_auxi_args *obj_auxi, int err)
+{
+	uint32_t	delay = 0;
+
+	/* Randomly delay 5 - 36 us if it is not the first retry for -DER_INPROGRESS case. */
+	if (err == -DER_INPROGRESS) {
+		obj_auxi->inprogress_cnt++;
+		if (obj_auxi->inprogress_cnt > 1) {
+			delay = (d_rand() & ((1 << 5) - 1)) + 5;
+			D_DEBUG(DB_IO, "Try to re-sched task %p for %d/%d times with %u us delay\n",
+				obj_auxi->obj_task, (int)obj_auxi->inprogress_cnt,
+				(int)obj_auxi->retry_cnt, delay);
+		}
+	}
+
+	return delay;
+}
+
 static int
 obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 	     struct obj_auxi_args *obj_auxi, bool pmap_stale,
@@ -1624,13 +1643,12 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 			}
 		}
 
-		rc = dc_task_resched(task);
-		if (rc != 0) {
-			D_ERROR("Failed to re-init task (%p)\n", task);
-			D_GOTO(err, rc);
-		}
-		*io_task_reinited = true;
 		obj_auxi->retry_cnt++;
+		rc = tse_task_reinit_with_delay(task, dc_obj_retry_delay(obj_auxi, result));
+		if (rc != 0)
+			D_GOTO(err, rc);
+
+		*io_task_reinited = true;
 	}
 
 	if (pool_task != NULL)
@@ -4389,7 +4407,6 @@ obj_comp_cb(tse_task_t *task, void *data)
 		pm_stale = true;
 	}
 
-	obj_auxi->to_leader = 0;
 	if (obj_retry_error(task->dt_result)) {
 		/* If the RPC sponsor specify shard/group, then means it wants
 		 * to fetch data from the specified target. If such shard isn't
@@ -4625,8 +4642,6 @@ obj_task_init_common(tse_task_t *task, int opc, uint32_t map_ver,
 {
 	struct obj_auxi_args	*obj_auxi;
 
-	D_DEBUG(DB_IO, "client task init "DF_OID" 0x%x\n",
-		DP_OID(obj->cob_md.omd_id), opc);
 	obj_auxi = tse_task_stack_push(task, sizeof(*obj_auxi));
 	if (obj_is_modification_opc(opc))
 		obj_auxi->spec_group = 0;
@@ -4641,6 +4656,9 @@ obj_task_init_common(tse_task_t *task, int opc, uint32_t map_ver,
 	shard_task_list_init(obj_auxi);
 	obj_auxi->is_ec_obj = obj_is_ec(obj);
 	*auxi = obj_auxi;
+
+	D_DEBUG(DB_IO, "client task %p init "DF_OID" opc 0x%x, try %d\n",
+		task, DP_OID(obj->cob_md.omd_id), opc, (int)obj_auxi->retry_cnt);
 }
 
 /**
@@ -5331,9 +5349,11 @@ dc_obj_fetch_task(tse_task_t *task)
 	    DAOS_FAIL_CHECK(DAOS_OBJ_SPECIAL_SHARD))
 		args->extra_flags |= DIOF_TO_SPEC_SHARD;
 
-	obj_auxi->spec_shard = (args->extra_flags & DIOF_TO_SPEC_SHARD) != 0;
-	obj_auxi->spec_group = (args->extra_flags & DIOF_TO_SPEC_GROUP) != 0;
-	obj_auxi->to_leader = (args->extra_flags & DIOF_TO_LEADER) != 0;
+	if (!obj_auxi->io_retry) {
+		obj_auxi->spec_shard = (args->extra_flags & DIOF_TO_SPEC_SHARD) != 0;
+		obj_auxi->spec_group = (args->extra_flags & DIOF_TO_SPEC_GROUP) != 0;
+		obj_auxi->to_leader = (args->extra_flags & DIOF_TO_LEADER) != 0;
+	}
 
 	obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, args->dkey);
 	obj_auxi->iod_nr = args->nr;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -395,7 +395,8 @@ struct obj_auxi_args {
 	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 flags;
 	uint32_t			 specified_shard;
-	uint32_t			 retry_cnt;
+	uint16_t			 retry_cnt;
+	uint16_t			 inprogress_cnt;
 	struct obj_req_tgts		 req_tgts;
 	d_sg_list_t			*sgls_dup;
 	crt_bulk_t			*bulks;

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1564,7 +1564,7 @@ out:
 static void
 dc_tx_dump(struct dc_tx *tx)
 {
-	D_DEBUG(DB_TRACE,
+	D_DEBUG(DB_IO,
 		"Dump TX %p:\n"
 		"ID: "DF_DTI"\n"
 		"epoch: "DF_U64"\n"
@@ -1837,7 +1837,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	mbs = dcsh->dcsh_mbs;
-	mbs->dm_flags = DMF_CONTAIN_LEADER | DMF_SORTED_TGT_ID;
+	mbs->dm_flags = DMF_CONTAIN_LEADER;
 
 	/* For the case of modification(s) within single RDG,
 	 * elect leader as standalone modification case does.

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -834,7 +834,8 @@ dc_tx_get_epoch(tse_task_t *task, daos_handle_t th, struct dtx_epoch *epoch)
 		 * The TX epoch hasn't been chosen yet, and nobody is choosing
 		 * it. So this task will be the "epoch task".
 		 */
-		D_DEBUG(DB_IO, DF_X64"/%p: choosing epoch\n", th.cookie, task);
+		D_DEBUG(DB_IO, DF_X64"/%p: choosing epoch value="DF_U64" first="DF_U64"\n",
+			th.cookie, task, tx->tx_epoch.oe_value, tx->tx_epoch.oe_first);
 		tse_task_addref(task);
 		tx->tx_epoch_task = task;
 		rc = tse_task_register_comp_cb(task, complete_epoch_task, &th,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2729,7 +2729,7 @@ again2:
 	exec_arg.start = orw->orw_start_shard;
 
 	/* Execute the operation on all targets */
-	rc = dtx_leader_exec_ops(dlh, obj_tgt_update, NULL, NULL, &exec_arg);
+	rc = dtx_leader_exec_ops(dlh, obj_tgt_update, NULL, 0, &exec_arg);
 
 	/* Stop the distributed transaction */
 	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
@@ -3355,50 +3355,44 @@ out:
 }
 
 static int
-obj_punch_agg_cb(struct dtx_leader_handle *dlh, void *agg_arg)
+obj_punch_agg_cb(struct dtx_leader_handle *dlh, int allow_failure)
 {
-	uint64_t	*flag = agg_arg;
-	uint32_t	sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
-	int		succeeds = 0;
-	int		allow_failure = 0;
-	int		allow_failure_cnt = 0;
-	int		result = 0;
-	int		i;
+	struct dtx_sub_status	*sub;
+	uint32_t		 sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
+	int			 allow_failure_cnt = 0;
+	int			 succeeds = 0;
+	int			 result = 0;
+	int			 i;
 
-	D_ASSERT(flag != NULL);
-	if (*flag & DAOS_COND_PUNCH)
-		allow_failure = -DER_NONEXIST;
+	/*
+	 * For conditional punch, let's ignore DER_NONEXIST if some shard succeed,
+	 * since the object may not exist on some shards due to EC partial update.
+	 */
+	if (allow_failure != 0)
+		D_ASSERTF(allow_failure == -DER_NONEXIST,
+			  "Unexpected allow failure %d\n", allow_failure);
 
 	for (i = 0; i < sub_cnt; i++) {
-		struct dtx_sub_status	*sub = &dlh->dlh_subs[i];
+		sub = &dlh->dlh_subs[i];
+		if (sub->dss_tgt.st_rank != DAOS_TGT_IGNORE) {
+			D_ASSERT(sub->dss_comp == 1);
 
-		if (sub->dss_result == 0) {
-			succeeds++;
-		} else if (sub->dss_result == allow_failure) {
-			allow_failure_cnt++;
-		} else {
-			/* Ignore INPROGRESS if there other failures */
-			if (result == -DER_INPROGRESS || result == 0)
+			if (sub->dss_result == 0)
+				succeeds++;
+			else if (sub->dss_result == allow_failure)
+				allow_failure_cnt++;
+			else if (result == -DER_INPROGRESS || result == 0)
+				/* Ignore INPROGRESS if there is other failure. */
 				result = sub->dss_result;
 		}
 	}
 
-	D_DEBUG(DB_IO, DF_DTI" %d/%d shards flags "DF_X64" result %d\n",
-		DP_DTI(&dlh->dlh_handle.dth_xid), allow_failure_cnt,
-		succeeds, *flag, result);
+	D_DEBUG(DB_IO, DF_DTI" sub_requests %d/%d, allow_failure %d, result %d\n",
+		DP_DTI(&dlh->dlh_handle.dth_xid),
+		allow_failure_cnt, succeeds, allow_failure, result);
 
-	if (*flag & DAOS_COND_PUNCH) {
-		/* For punch, let's ignore DER_NONEXIST if there are shards
-		 * succeed, since the object may not exist on some shards
-		 * due to EC partial update.
-		 */
-		if (result == 0 && succeeds == 0) {
-			D_ASSERT(sub_cnt == allow_failure_cnt);
-			return -DER_NONEXIST;
-		}
-
-		return result;
-	}
+	if (allow_failure != 0 && allow_failure_cnt > 0 && result == 0 && succeeds == 0)
+		result = allow_failure;
 
 	return result;
 }
@@ -3591,7 +3585,8 @@ again2:
 
 	/* Execute the operation on all shards */
 	rc = dtx_leader_exec_ops(dlh, obj_tgt_punch, obj_punch_agg_cb,
-				 &opi->opi_api_flags, &exec_arg);
+				 (opi->opi_api_flags & DAOS_COND_PUNCH) ? -DER_NONEXIST : 0,
+				 &exec_arg);
 
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
@@ -4592,7 +4587,7 @@ again:
 	exec_arg.flags = flags;
 
 	/* Execute the operation on all targets */
-	rc = dtx_leader_exec_ops(dlh, obj_obj_dtx_leader, NULL, NULL, &exec_arg);
+	rc = dtx_leader_exec_ops(dlh, obj_obj_dtx_leader, NULL, 0, &exec_arg);
 
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(dlh, dca->dca_ioc->ioc_coh, rc);

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -140,6 +140,8 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	orw->orw_shard_tgts.ca_count	= orw_parent->orw_shard_tgts.ca_count;
 	orw->orw_shard_tgts.ca_arrays	= orw_parent->orw_shard_tgts.ca_arrays;
 	orw->orw_flags |= ORF_BULK_BIND | obj_exec_arg->flags;
+	if (shard_tgt->st_flags & DTF_DELAY_FORWARD)
+		orw->orw_api_flags &= ~DAOS_COND_MASK;
 	orw->orw_dti_cos.ca_count	= dth->dth_dti_cos_count;
 	orw->orw_dti_cos.ca_arrays	= dth->dth_dti_cos;
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -883,6 +883,8 @@ vos_dtx_flags2name(uint32_t flags)
 		return "corrupted";
 	case DTE_ORPHAN:
 		return "orphan";
+	case DTE_PARTIAL_COMMITTED:
+		return "partial_committed";
 	default:
 		return "unknown";
 	}
@@ -1139,7 +1141,7 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		return ALB_AVAILABLE_CLEAN;
 	}
 
-	if (dae->dae_committable || dae->dae_committed)
+	if (dae->dae_committable || dae->dae_committed || DAE_FLAGS(dae) & DTE_PARTIAL_COMMITTED)
 		return ALB_AVAILABLE_CLEAN;
 
 	if (dae->dae_aborted)
@@ -1811,10 +1813,9 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			return DTX_ST_COMMITTED;
 		}
 
-		if (dae->dae_committable) {
+		if (dae->dae_committable || DAE_FLAGS(dae) & DTE_PARTIAL_COMMITTED) {
 			if (mbs != NULL)
-				*mbs = vos_dtx_pack_mbs(vos_cont2umm(cont),
-							dae);
+				*mbs = vos_dtx_pack_mbs(vos_cont2umm(cont), dae);
 
 			if (epoch != NULL)
 				*epoch = DAE_EPOCH(dae);
@@ -1825,10 +1826,8 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 		if (dae->dae_aborted)
 			return -DER_NONEXIST;
 
-		if (mbs != NULL)
-			dae->dae_maybe_shared = 1;
-
 		if (for_refresh) {
+			dae->dae_maybe_shared = 1;
 			/*
 			 * If DTX_REFRESH happened on current DTX entry but it was not marked
 			 * as leader, then there must be leader switch and the DTX resync has
@@ -2107,7 +2106,7 @@ vos_dtx_post_handle(struct vos_container *cont,
 				daes[i]->dae_committed = 1;
 				dtx_act_ent_cleanup(cont, daes[i], NULL, false);
 			}
-			DAE_FLAGS(daes[i]) &= ~(DTE_CORRUPTED | DTE_ORPHAN);
+			DAE_FLAGS(daes[i]) &= ~(DTE_CORRUPTED | DTE_ORPHAN | DTE_PARTIAL_COMMITTED);
 		}
 	}
 }
@@ -2229,10 +2228,9 @@ out:
 	return rc;
 }
 
-int
-vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dti, uint32_t flags)
+static int
+vos_dtx_set_flags_one(struct vos_container *cont, struct dtx_id *dti, uint32_t flags)
 {
-	struct vos_container		*cont;
 	struct umem_instance		*umm;
 	struct vos_dtx_act_ent		*dae;
 	struct vos_dtx_act_ent_df	*dae_df;
@@ -2240,24 +2238,14 @@ vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dti, uint32_t flags)
 	d_iov_t				 kiov;
 	int				 rc;
 
-	cont = vos_hdl2cont(coh);
-	D_ASSERT(cont != NULL);
-
-	/* Only allow set single flags. */
-	if (flags != DTE_CORRUPTED && flags != DTE_ORPHAN) {
-		D_ERROR("Try to set unrecognized flags %x on DTX "
-			DF_DTI"\n", flags, DP_DTI(dti));
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
 	d_iov_set(&kiov, dti, sizeof(*dti));
 	d_iov_set(&riov, NULL, 0);
 	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 	if (rc == -DER_NONEXIST) {
 		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
 		if (rc == 0) {
-			D_ERROR("Not allow to set flag on committed (1) DTX entry "DF_DTI"\n",
-				DP_DTI(dti));
+			D_ERROR("Not allow to set flag %s on committed (1) DTX entry "DF_DTI"\n",
+				vos_dtx_flags2name(flags), DP_DTI(dti));
 			D_GOTO(out, rc = -DER_NO_PERM);
 		}
 	}
@@ -2266,9 +2254,12 @@ vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dti, uint32_t flags)
 		goto out;
 
 	dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+	if (DAE_FLAGS(dae) & flags)
+		goto out;
+
 	if (dae->dae_committable || dae->dae_committed || dae->dae_aborted) {
-		D_ERROR("Not allow to set flag on the %s DTX entry "DF_DTI"\n",
-			dae->dae_committable ? "committable" :
+		D_ERROR("Not allow to set flag %s on the %s DTX entry "DF_DTI"\n",
+			vos_dtx_flags2name(flags), dae->dae_committable ? "committable" :
 			dae->dae_committed ? "committed (2)" : "aborted", DP_DTI(dti));
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
@@ -2277,23 +2268,58 @@ vos_dtx_set_flags(daos_handle_t coh, struct dtx_id *dti, uint32_t flags)
 	dae_df = umem_off2ptr(umm, dae->dae_df_off);
 	D_ASSERT(dae_df != NULL);
 
-	rc = umem_tx_begin(umm, NULL);
-	if (rc != 0)
-		goto out;
-
 	rc = umem_tx_add_ptr(umm, &dae_df->dae_flags, sizeof(dae_df->dae_flags));
-	if (rc == 0)
+	if (rc == 0) {
 		dae_df->dae_flags |= flags;
-
-	rc = umem_tx_end(umm, rc);
-	if (rc == 0)
 		DAE_FLAGS(dae) |= flags;
+	}
 
 out:
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_WARN,
 		 "Mark the DTX entry "DF_DTI" as %s: "DF_RC"\n",
 		 DP_DTI(dti), vos_dtx_flags2name(flags), DP_RC(rc));
 
+	if ((rc == -DER_NO_PERM || rc == -DER_NONEXIST) && flags == DTE_PARTIAL_COMMITTED)
+		rc = 0;
+
+	return rc;
+}
+
+int
+vos_dtx_set_flags(daos_handle_t coh, struct dtx_id dtis[], int count, uint32_t flags)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 rc = 0;
+	int			 i;
+
+	if (unlikely(count == 0))
+		goto out;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	/* Only allow set single flags. */
+	if (flags != DTE_CORRUPTED && flags != DTE_ORPHAN && flags != DTE_PARTIAL_COMMITTED) {
+		D_ERROR("Try to set unrecognized flags %x on DTX "DF_DTI", count %u\n",
+			flags, DP_DTI(&dtis[0]), count);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	umm = vos_cont2umm(cont);
+	rc = umem_tx_begin(umm, NULL);
+	if (rc != 0)
+		goto out;
+
+	for (i = 0; i < count; i++) {
+		rc = vos_dtx_set_flags_one(cont, &dtis[i], flags);
+		if (rc != 0)
+			break;
+	}
+
+	rc = umem_tx_end(umm, rc);
+
+out:
 	return rc;
 }
 


### PR DESCRIPTION
If a large transaction has sub-requests to dispatch to a lot of DTX participants, then we may have to split the dispatch process to multiple steps; otherwise, the dispatch process may trigger too many in-flight or in-queued RPCs that will hold too much resource as to server maybe out of memory.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
