### PR TITLE
DAOS-10162 control:Support auto reint target by swimming

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -2399,7 +2399,7 @@ pmap_comp_failed(struct pool_component *comp)
 {
 	return (comp->co_status == PO_COMP_ST_DOWN) ||
 	       (comp->co_status == PO_COMP_ST_DOWNOUT &&
-		comp->co_flags == PO_COMPF_DOWN2OUT);
+		comp->co_flags & PO_COMPF_DOWN2OUT);
 }
 
 static bool

--- a/src/control/lib/daos/pool_cont_prop.go
+++ b/src/control/lib/daos/pool_cont_prop.go
@@ -134,6 +134,8 @@ const (
 	PoolSelfHealingAutoExclude = C.DAOS_SELF_HEAL_AUTO_EXCLUDE
 	// PoolSelfHealingAutoRebuild sets the self-healing strategy to auto-rebuild.
 	PoolSelfHealingAutoRebuild = C.DAOS_SELF_HEAL_AUTO_REBUILD
+	// PoolSelfHealingAutoReint sets the self-healing strategy to auto-reint.
+	PoolSelfHealingAutoReint = C.DAOS_SELF_HEAL_AUTO_REINT
 )
 
 const (

--- a/src/control/lib/daos/pool_property.go
+++ b/src/control/lib/daos/pool_property.go
@@ -56,6 +56,8 @@ func PoolProperties() PoolPropertyMap {
 						return "exclude"
 					case n&PoolSelfHealingAutoRebuild > 0:
 						return "rebuild"
+					case n&PoolSelfHealingAutoReint > 0:
+						return "reint"
 					default:
 						return "unknown"
 					}
@@ -64,6 +66,7 @@ func PoolProperties() PoolPropertyMap {
 			values: map[string]uint64{
 				"exclude": PoolSelfHealingAutoExclude,
 				"rebuild": PoolSelfHealingAutoRebuild,
+				"reint":   PoolSelfHealingAutoReint,
 			},
 		},
 		"space_rb": {

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -62,6 +62,7 @@ enum pool_component_flags {
 	 * PO_COMP_ST_DOWN (rather than from PO_COMP_ST_DRAIN).
 	 */
 	PO_COMPF_DOWN2OUT	= 1,
+	PO_COMPF_COMMAND	= 1 << 1,
 };
 
 #define co_in_ver	co_out_ver

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -201,6 +201,7 @@ enum {
 /** self healing strategy bits */
 #define DAOS_SELF_HEAL_AUTO_EXCLUDE	(1U << 0)
 #define DAOS_SELF_HEAL_AUTO_REBUILD	(1U << 1)
+#define DAOS_SELF_HEAL_AUTO_REINT	(1U << 2)
 
 /**
  * DAOS container property types

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -506,7 +506,7 @@ jtc_set_status_on_target(struct jm_test_ctx *ctx, const int status,
 	tgts.pti_number = 1;
 
 	int rc = ds_pool_map_tgts_update(ctx->po_map, &tgts, status,
-					 false, &ctx->ver, ctx->enable_print_debug_msgs);
+					 false, &ctx->ver, ctx->enable_print_debug_msgs, false);
 
 	/* Make sure pool map changed */
 	assert_success(rc);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1099,18 +1099,21 @@ discard_events(d_list_t *queue)
 	}
 }
 
-static int pool_svc_exclude_rank(struct pool_svc *svc, d_rank_t rank);
+static int pool_svc_change_rank(struct pool_svc *svc, d_rank_t rank, crt_opcode_t opc);
 
 static void
 handle_event(struct pool_svc *svc, struct pool_svc_event *event)
 {
 	daos_prop_t		prop = {0};
 	struct daos_prop_entry *entry;
+	struct pool_domain	*dom = NULL;
 	int			rc;
+	uint8_t			co_status;
 
-	/* Only used for exclude the rank for the moment */
+	/* used for exclude or reint the rank*/
 	if ((event->psv_src != CRT_EVS_GRPMOD && event->psv_src != CRT_EVS_SWIM) ||
-	    event->psv_type != CRT_EVT_DEAD || pool_disable_exclude) {
+	    (event->psv_type != CRT_EVT_ALIVE && event->psv_type != CRT_EVT_DEAD) ||
+	    (event->psv_type == CRT_EVT_DEAD && pool_disable_exclude)) {
 		D_DEBUG(DB_MD, "ignore event: "DF_PS_EVENT" exclude=%d\n", DP_PS_EVENT(event),
 			pool_disable_exclude);
 		goto out;
@@ -1128,19 +1131,57 @@ handle_event(struct pool_svc *svc, struct pool_svc_event *event)
 
 	entry = daos_prop_entry_get(&prop, DAOS_PROP_PO_SELF_HEAL);
 	D_ASSERT(entry != NULL);
-	if (!(entry->dpe_val & DAOS_SELF_HEAL_AUTO_EXCLUDE)) {
-		D_DEBUG(DB_MD, DF_UUID": self healing is disabled\n", DP_UUID(svc->ps_uuid));
+
+	ABT_rwlock_rdlock(svc->ps_pool->sp_lock);
+	dom = pool_map_find_node_by_rank(svc->ps_pool->sp_map, event->psv_rank);
+	if (dom == NULL) {
+		D_ERROR("rank %u not in map \n", event->psv_rank);
+		ABT_rwlock_unlock(svc->ps_pool->sp_lock);
 		goto out_prop;
 	}
+	co_status = dom->do_comp.co_status;
+	ABT_rwlock_unlock(svc->ps_pool->sp_lock);
 
-	rc = pool_svc_exclude_rank(svc, event->psv_rank);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to exclude rank %u: "DF_RC"\n", DP_UUID(svc->ps_uuid),
-			event->psv_rank, DP_RC(rc));
-		goto out_prop;
+	switch (event->psv_type) {
+	case CRT_EVT_ALIVE:
+		if (!(entry->dpe_val & DAOS_SELF_HEAL_AUTO_REINT)) {
+			D_DEBUG(DB_MD, DF_UUID": self healing is disabled\n", DP_UUID(svc->ps_uuid));
+			goto out_prop;
+		}
+		if (co_status != PO_COMP_ST_DOWN && co_status != PO_COMP_ST_DOWNOUT) {
+			D_DEBUG(DB_MD, "rank %u status is ok,don't need up!\n",event->psv_rank);
+			goto out_prop;
+		}
+		rc = pool_svc_change_rank(svc, event->psv_rank, POOL_REINT);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to reint rank %u: "DF_RC"\n", DP_UUID(svc->ps_uuid),
+			    event->psv_rank, DP_RC(rc));
+			goto out_prop;
+		}
+		D_DEBUG(DB_MD, DF_UUID": reint rank %u\n", DP_UUID(svc->ps_uuid), event->psv_rank);
+		break;
+	case CRT_EVT_DEAD:
+		if (!(entry->dpe_val & DAOS_SELF_HEAL_AUTO_EXCLUDE)) {
+			D_DEBUG(DB_MD, DF_UUID": self healing is disabled\n", DP_UUID(svc->ps_uuid));
+			goto out_prop;
+		}
+		if (co_status == PO_COMP_ST_DOWN || co_status == PO_COMP_ST_DOWNOUT) {
+			D_DEBUG(DB_MD, "rank %u status is already down,don't need mark down again!\n", event->psv_rank);
+			goto out_prop;
+		}
+
+		rc = pool_svc_change_rank(svc, event->psv_rank, POOL_EXCLUDE);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to exclude rank %u: "DF_RC"\n", DP_UUID(svc->ps_uuid),
+			  event->psv_rank, DP_RC(rc));
+			goto out_prop;
+		}
+		D_DEBUG(DB_MD, DF_UUID": excluded rank %u\n", DP_UUID(svc->ps_uuid), event->psv_rank);
+		break;
+	default:
+		D_ASSERTF(0, "bad psv_type %d\n", event->psv_type);
+		break;
 	}
-
-	D_DEBUG(DB_MD, DF_UUID": excluded rank %u\n", DP_UUID(svc->ps_uuid), event->psv_rank);
 out_prop:
 	daos_prop_fini(&prop);
 out:
@@ -5635,10 +5676,10 @@ pool_svc_cancel_and_wait_reconf(struct pool_svc *svc)
 	reconf_cancel_and_wait(&svc->ps_reconf);
 }
 
-static int pool_find_all_targets_by_addr(struct pool_map *map,
+static int pool_find_all_targets_by_addr_without_flag(struct pool_map *map,
 					 struct pool_target_addr_list *list,
 					 struct pool_target_id_list *tgt_list,
-					 struct pool_target_addr_list *inval);
+					 struct pool_target_addr_list *inval, uint32_t flags);
 
 /*
  * Perform an update to the pool map of \a svc.
@@ -5672,7 +5713,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 			     struct pool_target_addr_list *tgt_addrs,
 			     struct rsvc_hint *hint, bool *p_updated,
 			     uint32_t *map_version_p, uint32_t *tgt_map_ver,
-			     struct pool_target_addr_list *inval_tgt_addrs)
+			     struct pool_target_addr_list *inval_tgt_addrs, bool is_command)
 {
 	struct rdb_tx		tx;
 	struct pool_map	       *map;
@@ -5728,8 +5769,12 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 			D_ASSERT(tgts->pti_ids == NULL);
 			D_ASSERT(tgt_addrs != NULL);
 			D_ASSERT(inval_tgt_addrs != NULL);
-			rc = pool_find_all_targets_by_addr(map, tgt_addrs, tgts,
-							   inval_tgt_addrs);
+			if (!is_command && opc == POOL_REINT)
+				rc = pool_find_all_targets_by_addr_without_flag(map, tgt_addrs, tgts,
+							   inval_tgt_addrs, PO_COMPF_COMMAND);
+			else
+				rc = pool_find_all_targets_by_addr_without_flag(map, tgt_addrs, tgts,
+							   inval_tgt_addrs, PO_COMPF_NONE);
 			if (rc != 0)
 				goto out_map;
 			if (inval_tgt_addrs->pta_number > 0) {
@@ -5752,7 +5797,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 	 */
 	map_version_before = pool_map_get_version(map);
 	rc = ds_pool_map_tgts_update(map, tgts, opc, exclude_rank, tgt_map_ver,
-				     true);
+				     true, is_command);
 	if (rc != 0)
 		D_GOTO(out_map, rc);
 	map_version = pool_map_get_version(map);
@@ -5814,10 +5859,10 @@ out:
 }
 
 static int
-pool_find_all_targets_by_addr(struct pool_map *map,
+pool_find_all_targets_by_addr_without_flag(struct pool_map *map,
 			      struct pool_target_addr_list *list,
 			      struct pool_target_id_list *tgt_list,
-			      struct pool_target_addr_list *inval_list_out)
+			      struct pool_target_addr_list *inval_list_out, uint32_t flags)
 {
 	int	i;
 	int	rc = 0;
@@ -5849,6 +5894,11 @@ pool_find_all_targets_by_addr(struct pool_map *map,
 		for (j = 0; j < tgt_nr; j++) {
 			struct pool_target_id tid;
 
+			if (flags != PO_COMPF_NONE && tgt[j].ta_comp.co_flags & flags) {
+				D_DEBUG(DB_MD, " rank %u target %u has flag COMMAND\n",
+					list->pta_addrs[i].pta_rank, list->pta_addrs[i].pta_target);
+				continue;
+			}
 			tid.pti_id = tgt[j].ta_comp.co_id;
 			ret = pool_target_id_list_append(tgt_list, &tid);
 			if (ret) {
@@ -5881,7 +5931,7 @@ pool_update_map_internal(uuid_t pool_uuid, unsigned int opc, bool exclude_rank,
 			 struct pool_target_addr_list *tgt_addrs,
 			 struct rsvc_hint *hint, bool *p_updated,
 			 uint32_t *map_version_p, uint32_t *tgt_map_ver,
-			 struct pool_target_addr_list *inval_tgt_addrs)
+			 struct pool_target_addr_list *inval_tgt_addrs, bool is_command)
 {
 	struct pool_svc	       *svc;
 	int			rc;
@@ -5893,7 +5943,7 @@ pool_update_map_internal(uuid_t pool_uuid, unsigned int opc, bool exclude_rank,
 	rc = pool_svc_update_map_internal(svc, opc, exclude_rank, NULL, 0,
 					  NULL, tgts, tgt_addrs, hint, p_updated,
 					  map_version_p, tgt_map_ver,
-					  inval_tgt_addrs);
+					  inval_tgt_addrs, is_command);
 
 	pool_svc_put_leader(svc);
 	return rc;
@@ -5904,21 +5954,21 @@ ds_pool_tgt_exclude_out(uuid_t pool_uuid, struct pool_target_id_list *list)
 {
 	return pool_update_map_internal(pool_uuid, POOL_EXCLUDE_OUT, false,
 					list, NULL, NULL, NULL, NULL, NULL,
-					NULL);
+					NULL, false);
 }
 
 int
 ds_pool_tgt_exclude(uuid_t pool_uuid, struct pool_target_id_list *list)
 {
 	return pool_update_map_internal(pool_uuid, POOL_EXCLUDE, false, list,
-					NULL, NULL, NULL, NULL, NULL, NULL);
+					NULL, NULL, NULL, NULL, NULL, NULL, false);
 }
 
 int
 ds_pool_tgt_add_in(uuid_t pool_uuid, struct pool_target_id_list *list)
 {
 	return pool_update_map_internal(pool_uuid, POOL_ADD_IN, false, list,
-					NULL, NULL, NULL, NULL, NULL, NULL);
+					NULL, NULL, NULL, NULL, NULL, NULL, false);
 }
 
 /*
@@ -5931,7 +5981,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 		    d_rank_list_t *extend_rank_list, uint32_t *extend_domains,
 		    uint32_t extend_domains_nr, struct pool_target_addr_list *list,
 		    struct pool_target_addr_list *inval_list_out,
-		    uint32_t *map_version, struct rsvc_hint *hint)
+		    uint32_t *map_version, struct rsvc_hint *hint, bool is_command)
 {
 	daos_rebuild_opc_t		op;
 	struct pool_target_id_list	target_list = { 0 };
@@ -5947,7 +5997,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	rc = pool_svc_update_map_internal(svc, opc, exclude_rank, extend_rank_list,
 					  extend_domains_nr, extend_domains,
 					  &target_list, list, hint, &updated,
-					  map_version, &tgt_map_ver, inval_list_out);
+					  map_version, &tgt_map_ver, inval_list_out, is_command);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -6037,7 +6087,7 @@ ds_pool_extend_handler(crt_rpc_t *rpc)
 				 false /* exclude_rank */,
 				 &rank_list, domains, ndomains,
 				 NULL, NULL, &out->peo_op.po_map_version,
-				 &out->peo_op.po_hint);
+				 &out->peo_op.po_hint, true);
 
 	pool_svc_put_leader(svc);
 out:
@@ -6140,7 +6190,7 @@ ds_pool_update_handler(crt_rpc_t *rpc)
 	rc = pool_svc_update_map(svc, opc_get(rpc->cr_opc),
 				 false /* exclude_rank */, NULL, NULL, 0, &list,
 				 &inval_list_out, &out->pto_op.po_map_version,
-				 &out->pto_op.po_hint);
+				 &out->pto_op.po_hint, true /* from command */);
 	if (rc != 0)
 		goto out_svc;
 
@@ -6158,25 +6208,38 @@ out:
 }
 
 static int
-pool_svc_exclude_rank(struct pool_svc *svc, d_rank_t rank)
+pool_svc_change_rank(struct pool_svc *svc, d_rank_t rank, crt_opcode_t opc)
 {
 	struct pool_target_addr_list	list;
 	struct pool_target_addr_list	inval_list_out = { 0 };
 	struct pool_target_addr		tgt_rank;
 	uint32_t			map_version = 0;
-	int				rc;
+	int				rc = 0;
+	bool				exclude_rank = false;
 
+	D_ASSERTF(opc == POOL_REINT || opc == POOL_EXCLUDE, " opc = %u\n", opc);
 	tgt_rank.pta_rank = rank;
 	tgt_rank.pta_target = -1;
 	list.pta_number = 1;
 	list.pta_addrs = &tgt_rank;
 
-	rc = pool_svc_update_map(svc, POOL_EXCLUDE, true /* exclude_rank */,
-				 NULL, NULL, 0, &list, &inval_list_out, &map_version,
-				 NULL /* hint */);
+	switch (opc) {
+	case POOL_REINT:
+		exclude_rank = false;
+		break;
+	case POOL_EXCLUDE:
+		exclude_rank = true;
+		break;
+	default:
+		break;
+	}
 
-	D_DEBUG(DB_MD, "Exclude pool "DF_UUID"/%u rank %u: rc %d\n",
-		DP_UUID(svc->ps_uuid), map_version, rank, rc);
+	rc = pool_svc_update_map(svc, opc, exclude_rank /* exclude_rank */,
+				 NULL, NULL, 0, &list, &inval_list_out, &map_version,
+				 NULL /* hint */, false);
+
+	D_DEBUG(DB_MD, "opc=%d pool "DF_UUID"/%u rank %u: rc %d\n",
+		opc, DP_UUID(svc->ps_uuid), map_version, rank, rc);
 
 	pool_target_addr_list_free(&inval_list_out);
 

--- a/src/pool/srv_pool_map.c
+++ b/src/pool/srv_pool_map.c
@@ -18,7 +18,7 @@
 static int
 update_one_tgt(struct pool_map *map, struct pool_target *target,
 	       struct pool_domain *dom, int opc, uint32_t *version,
-	       bool print_changes)
+	       bool print_changes, bool is_command)
 {
 	int rc;
 
@@ -46,6 +46,11 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 				DP_TARGET(target), map);
 			target->ta_comp.co_status = PO_COMP_ST_DOWN;
 			target->ta_comp.co_fseq = ++(*version);
+			if (is_command) {
+				target->ta_comp.co_flags |= PO_COMPF_COMMAND;
+				D_DEBUG(DB_MD, DF_TARGET" add flag %d\n",
+				DP_TARGET(target), target->ta_comp.co_flags);
+			}
 			if (print_changes)
 				D_PRINT(DF_TARGET " is down.\n",
 					DP_TARGET(target));
@@ -87,6 +92,8 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 				DP_TARGET(target), map);
 			target->ta_comp.co_status = PO_COMP_ST_DRAIN;
 			target->ta_comp.co_fseq = ++(*version);
+			if (is_command)
+				target->ta_comp.co_flags |= PO_COMPF_COMMAND;
 			if (print_changes)
 				D_PRINT(DF_TARGET " is draining.\n",
 					DP_TARGET(target));
@@ -116,10 +123,20 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 				DP_TARGET(target));
 			return -DER_BUSY;
 		case PO_COMP_ST_DOWNOUT:
+			if (!is_command && target->ta_comp.co_flags & PO_COMPF_COMMAND) {
+				D_DEBUG(DB_MD, DF_TARGET" must be reinted by admin command\n",
+					DP_TARGET(target));
+				return -DER_NO_PERM;
+			}
 			D_DEBUG(DB_MD, "change "DF_TARGET" to UP %p\n",
 				DP_TARGET(target), map);
 			target->ta_comp.co_status = PO_COMP_ST_UP;
 			target->ta_comp.co_in_ver = ++(*version);
+			if (is_command) {
+				target->ta_comp.co_flags &= ~PO_COMPF_COMMAND;
+				D_DEBUG(DB_MD, DF_TARGET" after clear PO_COMP_COMMAND flag, co_flags is %d\n",
+					DP_TARGET(target), target->ta_comp.co_flags);
+			}
 			if (print_changes)
 				D_PRINT(DF_TARGET " start reintegration.\n",
 					DP_TARGET(target));
@@ -133,7 +150,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 				D_DEBUG(DB_MD, "change rank %u to UP ver %u\n",
 					dom->do_comp.co_rank, dom->do_comp.co_in_ver);
 			}
-			dom->do_comp.co_flags = 0;
+			dom->do_comp.co_flags &= ~PO_COMPF_DOWN2OUT;
 			break;
 		}
 		break;
@@ -216,8 +233,11 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 		case PO_COMP_ST_DRAIN:
 			D_DEBUG(DB_MD, "change "DF_TARGET" to DOWNOUT %p\n",
 				DP_TARGET(target), map);
-			if (target->ta_comp.co_status == PO_COMP_ST_DOWN)
-				target->ta_comp.co_flags = PO_COMPF_DOWN2OUT;
+			if (target->ta_comp.co_status == PO_COMP_ST_DOWN) {
+				target->ta_comp.co_flags |= PO_COMPF_DOWN2OUT;
+				D_DEBUG(DB_MD, DF_TARGET" flag is  %d\n",
+				DP_TARGET(target), target->ta_comp.co_flags);
+			}
 			target->ta_comp.co_status = PO_COMP_ST_DOWNOUT;
 			target->ta_comp.co_out_ver = ++(*version);
 			if (print_changes)
@@ -238,12 +258,15 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 
 /*
  * Update "tgts" in "map". A new map version is generated only if actual
- * changes have been made.
+ * changes have been made. There are two ways to change the tgts state:
+ * user command and swim failure detection. is_command is used to identify
+ * whether it is a user command to change the status. swim cannot change 
+ * the status that user command requires
  */
 int
 ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 			int opc, bool exclude_rank, uint32_t *tgt_map_ver,
-			bool print_changes)
+			bool print_changes, bool is_command)
 {
 	uint32_t	version;
 	int		i;
@@ -277,7 +300,7 @@ ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 		}
 
 		rc = update_one_tgt(map, target, dom, opc, &version,
-				    print_changes);
+				    print_changes, is_command);
 		if (rc != 0)
 			return rc;
 
@@ -303,7 +326,7 @@ ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 					target->ta_comp.co_fseq;
 			} else if (opc == POOL_EXCLUDE_OUT) {
 				dom->do_comp.co_status = PO_COMP_ST_DOWNOUT;
-				dom->do_comp.co_flags = PO_COMPF_DOWN2OUT;
+				dom->do_comp.co_flags |= PO_COMPF_DOWN2OUT;
 				dom->do_comp.co_out_ver =
 					target->ta_comp.co_out_ver;
 			} else

--- a/src/pool/srv_pool_map.h
+++ b/src/pool/srv_pool_map.h
@@ -10,5 +10,5 @@
 int
 ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 			int opc, bool evict_rank, uint32_t *tgt_map_ver,
-			bool print_changes);
+			bool print_changes, bool is_command);
 #endif /* DAOS_SRV_POOL_MAP_H */


### PR DESCRIPTION
Admin should be able to set a DAOS pool property and disable auto-rebuild, 
in this case, even if an auto-evicted target is marked as DOWN to declare death, 
rebuild should not be immediately scheduled for this target because admin might 
fix the problem in minutes, simultaneously, the storage system should continue to
server I/O requests in degraded mode instead of waiting. 

Signed-off-by: wangzhaorong <wangzhaorong@cestc.cn>