### PR TITLE
DAOS-12147 build: Include server build on el9.

### DIFF
--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -294,7 +294,6 @@ jobs:
                             --build-arg DAOS_BUILD_TYPE=dev
                             --build-arg COMPILER=gcc
       - name: Run NLT
-        if: matrix.distro != 'alma.9'
         run: docker run --mount type=tmpfs,destination=/mnt/daos_0,tmpfs-mode=1777 --user root:root
                  build-image ./daos/utils/node_local_test.py --no-root
                  --memcheck no --test cont_copy
@@ -381,7 +380,6 @@ jobs:
                             --build-arg DAOS_BUILD_TYPE=dev
                             --build-arg COMPILER=gcc
       - name: Run NLT
-        if: matrix.distro != 'alma.9'
         run: docker run --mount type=tmpfs,destination=/mnt/daos_0,tmpfs-mode=1777 --user root:root
                  build-image ./daos/utils/node_local_test.py --no-root
                  --memcheck no --test cont_copy

--- a/utils/docker/Dockerfile.el.9
+++ b/utils/docker/Dockerfile.el.9
@@ -190,13 +190,13 @@ WORKDIR /home/daos/daos/src/client/java
 ARG DAOS_JAVA_BUILD=$DAOS_BUILD
 
 # Disable Java build for now since it fails
-RUN [ "$DAOS_JAVA_BUILD" != "yes" ] || {                                                      \
-        mkdir /home/daos/.m2 &&                                                               \
-        cp /home/daos/daos/utils/ci/maven-settings.xml.in /home/daos/.m2/settings.xml &&      \
-        mvn clean install -T 1C                                                               \
-            -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn                                                   \
-            -DskipITs -Dgpg.skip -Ddaos.install.path=/opt/daos;                               \
-    }
+#RUN [ "$DAOS_JAVA_BUILD" != "yes" ] || {                                                      \
+#        mkdir /home/daos/.m2 &&                                                               \
+#        cp /home/daos/daos/utils/ci/maven-settings.xml.in /home/daos/.m2/settings.xml &&      \
+#        mvn clean install -T 1C                                                               \
+#            -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn                                                   \
+#            -DskipITs -Dgpg.skip -Ddaos.install.path=/opt/daos;                               \
+#    }
 WORKDIR /home/daos
 
 ARG DAOS_KEEP_SRC=no

--- a/utils/docker/Dockerfile.el.9
+++ b/utils/docker/Dockerfile.el.9
@@ -172,11 +172,9 @@ ARG DAOS_BUILD_TYPE=$DAOS_TARGET_TYPE
 ARG DAOS_BUILD=$DAOS_DEPS_BUILD
 
 # Build DAOS
-# Build client only for now since some deps couldn't be satisfied yet see
-# install-el9.sh
 RUN [ "$DAOS_BUILD" != "yes" ] || {                                        \
         scons --jobs $JOBS install PREFIX=/opt/daos COMPILER=$COMPILER     \
-              BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE client && \
+              BUILD_TYPE=$DAOS_BUILD_TYPE TARGET_TYPE=$DAOS_TARGET_TYPE && \
         ([ "$DAOS_KEEP_BUILD" != "no" ] || /bin/rm -rf build) &&           \
         go clean -cache &&                                                 \
         cp -r utils/config/examples /opt/daos;                             \
@@ -192,13 +190,13 @@ WORKDIR /home/daos/daos/src/client/java
 ARG DAOS_JAVA_BUILD=$DAOS_BUILD
 
 # Disable Java build for now since it fails
-#RUN [ "$DAOS_JAVA_BUILD" != "yes" ] || {                                                      \
-#        mkdir /home/daos/.m2 &&                                                               \
-#        cp /home/daos/daos/utils/ci/maven-settings.xml.in /home/daos/.m2/settings.xml &&      \
-#        mvn clean install -T 1C                                                               \
-#            -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn                                                   \
-#            -DskipITs -Dgpg.skip -Ddaos.install.path=/opt/daos;                               \
-#    }
+RUN [ "$DAOS_JAVA_BUILD" != "yes" ] || {                                                      \
+        mkdir /home/daos/.m2 &&                                                               \
+        cp /home/daos/daos/utils/ci/maven-settings.xml.in /home/daos/.m2/settings.xml &&      \
+        mvn clean install -T 1C                                                               \
+            -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn                                                   \
+            -DskipITs -Dgpg.skip -Ddaos.install.path=/opt/daos;                               \
+    }
 WORKDIR /home/daos
 
 ARG DAOS_KEEP_SRC=no

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -10,8 +10,6 @@
 
 set -e
 
-#arch=$(uname -i)
-
 dnf --nodocs install \
     boost-python3-devel \
     bzip2 \
@@ -33,11 +31,13 @@ dnf --nodocs install \
     graphviz \
     help2man \
     hwloc-devel \
+    ipmctl \
     java-1.8.0-openjdk \
     json-c-devel \
     libaio-devel \
     libcmocka-devel \
     libevent-devel \
+    libipmctl-devel \
     libiscsi-devel \
     libtool \
     libtool-ltdl-devel \
@@ -60,16 +60,3 @@ dnf --nodocs install \
     valgrind-devel \
     which \
     yasm
-
-# No packages for the one below have been
-# identified yet. Limit build to client only for now
-#    ipmctl \
-#    libipmctl-devel \
-#    Lmod \
-#
-# ipmctl is only available on x86_64
-#if [ "$arch" = x86_64 ]; then
-#    dnf --nodocs install \
-#        ipmctl \
-#        libipmctl-devel
-#fi


### PR DESCRIPTION
Update package list on el9 and enable server build.  Initially
el9 didn't include enough packages to allow the server to build
however they have now all been ported upstream so update the
package list and enable the build.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
