### PR TITLE
DAOS-12119 control: Handle correct error on retried PoolDestroy

### DIFF
--- a/src/control/common/proto/error_test.go
+++ b/src/control/common/proto/error_test.go
@@ -78,6 +78,7 @@ func TestProto_AnnotateError(t *testing.T) {
 		LeaderHint: "foo.bar.baz",
 		Replicas:   []string{"a", "b", "c"},
 	}
+	testPoolNotFound := system.ErrPoolLabelNotFound("foo")
 
 	for name, tc := range map[string]struct {
 		err      error
@@ -109,6 +110,10 @@ func TestProto_AnnotateError(t *testing.T) {
 		"wrap/unwrap ErrNotLeader": {
 			err:    testNotLeader,
 			expErr: testNotLeader,
+		},
+		"wrap/unwrap ErrPoolNotFound": {
+			err:    testPoolNotFound,
+			expErr: testPoolNotFound,
 		},
 		"non-fault err": {
 			err:    errors.New("not a fault"),

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -310,7 +310,7 @@ func PoolDestroy(ctx context.Context, rpcClient UnaryInvoker, req *PoolDestroyRe
 		// the pool, then we can assume that the pool was destroyed
 		// via a server-side cleanup and we can intercept it. Everything
 		// else is still an error.
-		if !(ur.retryCount > 0 && errors.Cause(err) == daos.Nonexistent) {
+		if !(ur.retryCount > 0 && system.IsPoolNotFound(err)) {
 			return errors.Wrap(err, "pool destroy failed")
 		}
 	}

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -88,25 +88,25 @@ func TestControl_PoolDestroy(t *testing.T) {
 				},
 			},
 		},
-		"-DER_NONEXIST on first try is not retried": {
+		"ErrPoolNotFound on first try is not retried": {
 			req: &PoolDestroyReq{
 				ID: test.MockUUID(),
 			},
 			mic: &MockInvokerConfig{
 				UnaryResponseSet: []*UnaryResponse{
-					MockMSResponse("host1", daos.Nonexistent, nil),
+					MockMSResponse("host1", system.ErrPoolUUIDNotFound(test.MockPoolUUID()), nil),
 				},
 			},
-			expErr: daos.Nonexistent,
+			expErr: system.ErrPoolUUIDNotFound(test.MockPoolUUID()),
 		},
-		"-DER_NONEXIST on retry is treated as success": {
+		"ErrPoolNotFound on retry is treated as success": {
 			req: &PoolDestroyReq{
 				ID: test.MockUUID(),
 			},
 			mic: &MockInvokerConfig{
 				UnaryResponseSet: []*UnaryResponse{
 					MockMSResponse("host1", daos.TimedOut, nil),
-					MockMSResponse("host1", daos.Nonexistent, nil),
+					MockMSResponse("host1", system.ErrPoolUUIDNotFound(test.MockPoolUUID()), nil),
 				},
 			},
 		},

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -99,7 +99,7 @@ func (svc *mgmtSvc) resolvePoolID(id string) (uuid.UUID, error) {
 		}
 	}
 
-	return uuid.Nil, errors.Errorf("unable to find pool with label %q", id)
+	return uuid.Nil, system.ErrPoolLabelNotFound(id)
 }
 
 // getPoolService returns the pool service entry for the given UUID.

--- a/src/control/system/errors.go
+++ b/src/control/system/errors.go
@@ -7,6 +7,7 @@
 package system
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -231,6 +232,37 @@ type ErrPoolNotFound struct {
 	byRank  *ranklist.Rank
 	byUUID  *uuid.UUID
 	byLabel *string
+}
+
+func (err *ErrPoolNotFound) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Rank  *ranklist.Rank
+		UUID  *uuid.UUID
+		Label *string
+	}{
+		Rank:  err.byRank,
+		UUID:  err.byUUID,
+		Label: err.byLabel,
+	})
+}
+
+func (err *ErrPoolNotFound) UnmarshalJSON(data []byte) error {
+	if err == nil {
+		return nil
+	}
+
+	var tmp struct {
+		Rank  *ranklist.Rank
+		UUID  *uuid.UUID
+		Label *string
+	}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	err.byRank = tmp.Rank
+	err.byUUID = tmp.UUID
+	err.byLabel = tmp.Label
+	return nil
 }
 
 func (err *ErrPoolNotFound) Error() string {


### PR DESCRIPTION
The previous commit checked for the wrong error in determining
whether or not a PoolDestroy failure is fatal.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
