### PR TITLE
DAOS-12155 cart:  Fix iv test cleanup stage

### DIFF
--- a/src/tests/ftest/cart/iv/iv_one_node.py
+++ b/src/tests/ftest/cart/iv/iv_one_node.py
@@ -486,7 +486,7 @@ class CartIvOneNodeTest(CartTest):
 
         # Shutdown Servers
 
-        num_servers = self.get_srv_cnt("test_servers")
+        num_servers = 1
 
         srv_ppn = self.params.get("test_servers_ppn", '/run/tests/*/')
 

--- a/src/tests/ftest/cart/iv/iv_two_node.py
+++ b/src/tests/ftest/cart/iv/iv_two_node.py
@@ -239,7 +239,7 @@ class CartIvTwoNodeTest(CartTest):
             self.print("TEST FAILED: {}".format(exception))
 
         # Shutdown Servers
-        num_servers = self.get_srv_cnt("test_servers")
+        num_servers = 2
 
         srv_ppn = self.params.get("test_servers_ppn", '/run/tests/*/')
 


### PR DESCRIPTION
Wrong number of servers were calculated during the cleanup stage of the test. This resulted in non-existent ranks being pinged for the shutdown leading to asserts and core files being generated.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
