### PR TITLE
DAOS-11986 control: Don't break out of leadership monitoring loop

### DIFF
--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -495,7 +495,7 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 					cancelGainedCtx()
 				}
 				runOnLeadershipLost()
-				break
+				continue // restart the monitoring loop
 			}
 
 			db.log.Debugf("node %s gained MS leader state", db.replicaAddr)
@@ -505,7 +505,7 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 				if err = db.ResignLeadership(err); err != nil {
 					db.log.Errorf("raft ResignLeadership() failed: %s", err)
 				}
-				break
+				continue // restart the monitoring loop
 			}
 			db.log.Debugf("raft Barrier() complete after %s", time.Since(barrierStart))
 
@@ -518,7 +518,7 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 					if err = db.ResignLeadership(err); err != nil {
 						db.log.Errorf("raft ResignLeadership() failed: %s", err)
 					}
-					break
+					break // break out of the inner loop; restart the monitoring loop
 				}
 			}
 		}


### PR DESCRIPTION
The loop should just be restarted in order to act on future
leadership changes.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
