### PR TITLE
DAOS-12087 test: Removing HW Small stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,6 +68,11 @@ pipeline {
                defaultValue: 'pr daily_regression',
                description: 'Test-tag to use for the Functional Hardware Small/Medium/Large stages of this run (i.e. ' +
                             'pr, daily_regression, full_regression, etc.)')
+        string(name: 'TestRepeat',
+               defaultValue: '',
+               description: 'Test-repeat to use for this run.  Specifies the number of times to ' +
+                            'repeat each functional test. CAUTION: only use in combination with ' +
+                            'a reduced number of tests specified with the TestTag parameter.')
         string(name: 'TestProvider',
                defaultValue: 'ofi+tcp',
                description: 'Provider to use for the Functional Hardware Small/Medium/Large stages of this run (i.e. ' +
@@ -75,24 +80,40 @@ pipeline {
         string(name: 'BaseBranch',
                defaultValue: base_branch,
                description: 'The base branch to run weekly-testing against (i.e. master, or a PR\'s branch)')
-        booleanParam(name: 'CI_small_TEST',
-                     defaultValue: true,
-                     description: 'Run the CI Functional Hardware Small test stage')
+        string(name: 'CI_RPM_TEST_VERSION',
+               defaultValue: '',
+               description: 'Package version to use instead of building. example: 1.3.103-1, 1.2-2')
+        string(name: 'CI_PR_REPOS',
+               defaultValue: '',
+               description: 'Additional repository used for locating packages for the build and ' +
+                            'test nodes, in the project@PR-number[:build] format.')
+        string(name: 'CI_HARDWARE_DISTRO',
+               defaultValue: '',
+               description: 'Distribution to use for CI Hardware Tests')
+        string(name: 'CI_EL8_TARGET',
+               defaultValue: '',
+               description: 'Image to used for EL 8 CI tests.  I.e. el8, el8.3, etc.')
+        string(name: 'CI_LEAP15_TARGET',
+               defaultValue: '',
+               description: 'Image to use for OpenSUSE Leap CI tests.  I.e. leap15, leap15.2, etc.')
+        string(name: 'CI_UBUNTU20.04_TARGET',
+               defaultValue: '',
+               description: 'Image to used for Ubuntu 20 CI tests.  I.e. ubuntu20.04, etc.')
         booleanParam(name: 'CI_medium_TEST',
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Medium test stage')
         booleanParam(name: 'CI_large_TEST',
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Large test stage')
-        string(name: 'CI_NVME_3_LABEL',
-               defaultValue: 'ci_nvme3',
-               description: 'Label to use for 3 node Functional Hardware Small stage')
         string(name: 'CI_NVME_5_LABEL',
                defaultValue: 'ci_nvme5',
                description: 'Label to use for 5 node Functional Hardware Medium stage')
         string(name: 'CI_NVME_9_LABEL',
                defaultValue: 'ci_nvme9',
                description: 'Label to use for 9 node Functional Hardware Large stage')
+        string(name: 'CI_BUILD_DESCRIPTION',
+               defaultValue: '',
+               description: 'A description of the build')
     }
 
     stages {
@@ -132,31 +153,6 @@ pipeline {
                 expression { !skipStage() }
             }
             parallel {
-                stage('Functional Hardware Small') {
-                    when {
-                        beforeAgent true
-                        expression { !skipStage() }
-                    }
-                    agent {
-                        // 2 node cluster with 1 IB/node + 1 test control node
-                        label params.CI_NVME_3_LABEL
-                    }
-                    steps {
-                        // Need to get back onto base_branch for ci/
-                        checkoutScm url: 'https://github.com/daos-stack/daos.git',
-                                    branch: base_branch,
-                                    withSubmodules: true
-                        functionalTest inst_repos: daosRepos(),
-                                       inst_rpms: functionalPackages(1, next_version,
-                                                                     '{client,server}-tests-openmpi'),
-                                       test_function: 'runTestFunctionalV2'
-                    }
-                    post {
-                        always {
-                            functionalTestPostV2()
-                        }
-                    }
-                } // stage('Functional_Hardware_Small')
                 stage('Functional Hardware Medium') {
                     when {
                         beforeAgent true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,15 +90,6 @@ pipeline {
         string(name: 'CI_HARDWARE_DISTRO',
                defaultValue: '',
                description: 'Distribution to use for CI Hardware Tests')
-        string(name: 'CI_EL8_TARGET',
-               defaultValue: '',
-               description: 'Image to used for EL 8 CI tests.  I.e. el8, el8.3, etc.')
-        string(name: 'CI_LEAP15_TARGET',
-               defaultValue: '',
-               description: 'Image to use for OpenSUSE Leap CI tests.  I.e. leap15, leap15.2, etc.')
-        string(name: 'CI_UBUNTU20.04_TARGET',
-               defaultValue: '',
-               description: 'Image to used for Ubuntu 20 CI tests.  I.e. ubuntu20.04, etc.')
         booleanParam(name: 'CI_medium_TEST',
                      defaultValue: true,
                      description: 'Run the CI Functional Hardware Medium test stage')


### PR DESCRIPTION
In conjunction with moving all functional tests tagged to run on the Functional Hardware Small stage to now run on the Functional Hardware Medium or Large stages, this PR removed the now unused Functional Hardware Small stage.

Test-tag: always_passes

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
