### PR TITLE
DAOS-11975 test: replace dfuse_utils pcmd with run_remote (#10696)

### DIFF
--- a/src/tests/ftest/dfuse/caching_check.py
+++ b/src/tests/ftest/dfuse/caching_check.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2019-2021 Intel Corporation.
+  (C) Copyright 2019-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand, IorMetrics
-from general_utils import pcmd, percent_change
+from general_utils import percent_change
 
 
 class CachingCheck(IorTestBase):
@@ -19,7 +19,7 @@ class CachingCheck(IorTestBase):
     :avocado: recursive
     """
 
-    def test_caching_check(self):
+    def test_dfuse_caching_check(self):
         """Jira ID: DAOS-4874.
 
         Test Description:
@@ -35,9 +35,9 @@ class CachingCheck(IorTestBase):
             higher than with caching disabled.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,medium
         :avocado: tags=daosio,dfuse
-        :avocado: tags=dfusecachingcheck
+        :avocado: tags=test_dfuse_caching_check
         """
         # get params
         flags = self.params.get("iorflags", '/run/ior/*')
@@ -63,8 +63,7 @@ class CachingCheck(IorTestBase):
         max_mib = int(IorMetrics.Max_MiB)
 
         # unmount dfuse and mount again with caching enabled
-        pcmd(self.hostlist_clients,
-             self.dfuse.get_umount_command(), expect_rc=None)
+        self.dfuse.unmount(tries=1)
         self.dfuse.disable_caching.update(False)
         self.dfuse.run()
         # run ior to obtain first read performance after mount

--- a/src/tests/ftest/dfuse/root_container.py
+++ b/src/tests/ftest/dfuse/root_container.py
@@ -5,11 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from dfuse_test_base import DfuseTestBase
-from exception_utils import CommandFailure
-from daos_utils import DaosCommand
-from test_utils_container import TestContainer
-from general_utils import pcmd
-from ClusterShell.NodeSet import NodeSet
+from run_utils import run_remote
 
 
 class RootContainerTest(DfuseTestBase):
@@ -24,14 +20,10 @@ class RootContainerTest(DfuseTestBase):
         super().__init__(*args, **kwargs)
         self.pool = []
         self.container = []
-        self.tmp_file_count = self.params.get(
-            "tmp_file_count", '/run/container/*')
-        self.cont_count = self.params.get(
-            "cont_count", '/run/container/*')
-        self.tmp_file_size = self.params.get(
-            "tmp_file_size", '/run/container/*')
-        self.tmp_file_name = self.params.get(
-            "tmp_file_name", '/run/container/*')
+        self.tmp_file_count = self.params.get("tmp_file_count", '/run/container/*')
+        self.cont_count = self.params.get("cont_count", '/run/container/*')
+        self.tmp_file_size = self.params.get("tmp_file_size", '/run/container/*')
+        self.tmp_file_name = self.params.get("tmp_file_name", '/run/container/*')
         # device where the pools and containers are created
         self.device = "scm"
 
@@ -51,35 +43,28 @@ class RootContainerTest(DfuseTestBase):
         self.pool.append(self.get_pool(connect=False))
         return self.pool[-1]
 
-    def _create_cont(self, pool, path=None):
+    def _create_cont(self, pool, **params):
         """Add a new TestContainer object to the list of containers.
 
         Args:
             pool (TestPool): pool object
-            path (str): Unified namespace path for container
+            params (dict, optional): name/value of container attributes to update
 
         Returns:
             TestContainer: the newly added container
 
         """
-        # Get container params
-        container = TestContainer(pool, daos_command=DaosCommand(self.bin))
-        container.get_params(self)
-        if path is not None:
-            container.path.update(path)
-
-        # create container
-        container.create()
+        container = self.get_container(pool, **params)
         self.container.append(container)
         return container
 
-    def test_rootcontainer(self):
+    def test_dfuse_root_container(self):
         """Jira ID: DAOS-3782.
 
         Test Description:
             Purpose of this test is to try and create a container and
             mount it over dfuse and use it as a root container and create
-            subcontainers underneath it and insert several files and see
+            sub containers underneath it and insert several files and see
             if they can be accessed using ls and cd. Verify the pool size
             reflects the space occupied by container. Try to remove the
             files and containers and see the space is reclaimed.
@@ -106,7 +91,7 @@ class RootContainerTest(DfuseTestBase):
         self.insert_files_and_verify("")
         # Insert files into sub container
         self.insert_files_and_verify("cont0")
-        # Create 100 subcontainer and verify the temp files
+        # Create 100 sub containers and verify the temp files
         self.verify_create_delete_containers(pool, 100)
         self.verify_multi_pool_containers()
 
@@ -202,26 +187,9 @@ class RootContainerTest(DfuseTestBase):
         Args:
             cmd (str): Command to run
 
-        Returns:
-            dict: a dictionary of return codes keys and accompanying NodeSet
-                values indicating which hosts yielded the return code.
-
         """
-        try:
-            # execute bash cmds
-            ret = pcmd(
-                self.dfuse_hosts, cmd, verbose=True, timeout=30)
-            if 0 not in ret:
-                error_hosts = NodeSet(
-                    ",".join(
-                        [str(node_set) for code, node_set in
-                         list(ret.items()) if code != 0]))
-                raise CommandFailure(
-                    "Error running '{}' on the following "
-                    "hosts: {}".format(cmd, error_hosts))
-
-        # report error if any command fails
-        except CommandFailure as error:
-            self.log.error("DfuseSparseFile Test Failed: %s", str(error))
+        result = run_remote(self.log, self.dfuse_hosts, cmd, timeout=30)
+        if not result.passed:
+            self.log.error(
+                "Error running '%s' on the following hosts: %s", cmd, result.failed_hosts)
             self.fail("Test was expected to pass but it failed.\n")
-        return ret

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -10,7 +10,8 @@ from ClusterShell.NodeSet import NodeSet
 from command_utils_base import FormattedParameter
 from exception_utils import CommandFailure
 from command_utils import ExecutableCommand
-from general_utils import check_file_exists, pcmd, get_log_file
+from general_utils import check_file_exists, get_log_file
+from run_utils import run_remote
 
 
 class DfuseCommand(ExecutableCommand):
@@ -21,8 +22,8 @@ class DfuseCommand(ExecutableCommand):
         super().__init__(namespace, command)
 
         # dfuse options
-        self.puuid = FormattedParameter("--pool {}")
-        self.cuuid = FormattedParameter("--container {}")
+        self.pool = FormattedParameter("--pool {}")
+        self.cont = FormattedParameter("--container {}")
         self.mount_dir = FormattedParameter("--mountpoint {}")
         self.sys_name = FormattedParameter("--sys-name {}")
         self.thread_count = FormattedParameter("--thread-count {}")
@@ -32,33 +33,6 @@ class DfuseCommand(ExecutableCommand):
         self.enable_wb_cache = FormattedParameter("--enable-wb-cache", False)
         self.disable_caching = FormattedParameter("--disable-caching", False)
         self.disable_wb_cache = FormattedParameter("--disable-wb-cache", False)
-
-    def set_dfuse_params(self, pool, display=True):
-        """Set the dfuse params for the DAOS group, pool, and container uuid.
-
-        Args:
-            pool (TestPool): DAOS test pool object
-            display (bool, optional): print updated params. Defaults to True.
-        """
-        self.set_dfuse_pool_params(pool, display)
-
-    def set_dfuse_pool_params(self, pool, display=True):
-        """Set Dfuse params based on Daos Pool.
-
-        Args:
-            pool (TestPool): DAOS test pool object
-            display (bool, optional): print updated params. Defaults to True.
-        """
-        self.puuid.update(pool.uuid, "puuid" if display else None)
-
-    def set_dfuse_cont_param(self, cont, display=True):
-        """Set dfuse cont param from Container object.
-
-        Args:
-            cont (TestContainer): Daos test container object
-            display (bool, optional): print updated params. Defaults to True.
-        """
-        self.cuuid.update(cont, "cuuid" if display else None)
 
     def set_dfuse_exports(self, log_file):
         """Set exports to issue before the dfuse command.
@@ -78,29 +52,35 @@ class Dfuse(DfuseCommand):
 
         Args:
             hosts (NodeSet): hosts on which to run dfuse
+            tmp (str): tmp directory path
+
         """
         super().__init__("/run/dfuse/*", "dfuse")
 
         # set params
         self.hosts = hosts.copy()
         self.tmp = tmp
-        self.running_hosts = NodeSet()
+
+        # hosts where dfuse is currently running
+        self._running_hosts = NodeSet()
+
+        # which fusermount command to use for unmount
+        self._fusermount_cmd = ""
 
     def __del__(self):
         """Destruct the object."""
-        if self.running_hosts:
+        if self._running_hosts:
             self.log.error('Dfuse object deleted without shutting down')
 
-    def check_mount_state(self, nodes=None):
+    def check_mount_state(self, hosts):
         """Check the dfuse mount point mounted state on the hosts.
 
         Args:
-            nodes (NodeSet, optional): hosts on which to check if dfuse is
-                mounted. Defaults to None, which will use all of the hosts.
+            hosts (NodeSet): hosts on which to check if dfuse is mounted.
 
         Returns:
-            dict: a dictionary of NodeSets of hosts with the dfuse mount point
-                either "mounted" or "unmounted"
+            dict: a dictionary of NodeSets of hosts with the dfuse mount point.
+                Either "mounted", "unmounted", or "nodirectory"
 
         """
         state = {
@@ -108,38 +88,30 @@ class Dfuse(DfuseCommand):
             "unmounted": NodeSet(),
             "nodirectory": NodeSet()
         }
-        if not nodes:
-            nodes = self.hosts.copy()
-        check_mounted = NodeSet()
 
-        # Detect which hosts have mount point directories defined
-        command = "test -d {0} -a ! -L {0}".format(self.mount_dir.value)
-        retcodes = pcmd(nodes, command, expect_rc=None)
-        for retcode, hosts in list(retcodes.items()):
-            if retcode == 0:
-                check_mounted.add(hosts)
-            else:
-                command = "grep 'dfuse {}' /proc/mounts" .format(self.mount_dir.value)
-                retcodes = pcmd(hosts, command, expect_rc=None)
-                for ret_code, host_names in list(retcodes.items()):
-                    if ret_code == 0:
-                        check_mounted.add(host_names)
-                    else:
-                        state["nodirectory"].add(host_names)
+        # Detect which hosts have mount point directories created
+        command = f"test -d {self.mount_dir.value} -a ! -L {self.mount_dir.value}"
+        test_result = run_remote(self.log, hosts, command)
+        check_mounted = test_result.passed_hosts
+        if not test_result.passed:
+            command = f"grep 'dfuse {self.mount_dir.value}' /proc/mounts"
+            grep_result = run_remote(self.log, test_result.failed_hosts, command)
+            check_mounted.add(grep_result.passed_hosts)
+            state["nodirectory"].add(grep_result.failed_hosts)
 
         if check_mounted:
             # Detect which hosts with mount point directories have it mounted as a fuseblk device
-            command = "stat -c %T -f {0} | grep -v fuseblk".format(self.mount_dir.value)
-            retcodes = pcmd(check_mounted, command, expect_rc=None)
-            for retcode, hosts in list(retcodes.items()):
-                if retcode == 1:
-                    state["mounted"].add(hosts)
+            command = f"stat -c %T -f {self.mount_dir.value}"
+            stat_result = run_remote(self.log, check_mounted, command)
+            for data in stat_result.output:
+                if data.returncode == 0 and 'fuseblk' in '\n'.join(data.stdout):
+                    state["mounted"].add(data.hosts)
                 else:
-                    state["unmounted"].add(hosts)
+                    state["unmounted"].add(data.hosts)
 
         return state
 
-    def get_umount_command(self, force=False):
+    def _get_umount_command(self, force=False):
         """Get the command to umount the dfuse mount point.
 
         Args:
@@ -150,14 +122,12 @@ class Dfuse(DfuseCommand):
             str: the dfuse umount command
 
         """
-        umount = "-uz" if force else "-u"
-        command = [
-            "if [ -x '$(command -v fusermount)' ]",
-            "then fusermount {0} {1}".format(umount, self.mount_dir.value),
-            "else fusermount3 {0} {1}".format(umount, self.mount_dir.value),
-            "fi"
-        ]
-        return ";".join(command)
+        return ' '.join(filter(None, [
+            self._fusermount_cmd,
+            '-u',
+            '-z' if force else None,
+            self.mount_dir.value
+        ]))
 
     def create_mount_point(self):
         """Create dfuse directory.
@@ -168,26 +138,19 @@ class Dfuse(DfuseCommand):
         """
         # Raise exception if mount point not specified
         if self.mount_dir.value is None:
-            raise CommandFailure("Mount point not specified, "
-                                 "check test yaml file")
+            raise CommandFailure("Mount point not specified. Check test yaml file")
 
         # Create the mount point on any host without dfuse already mounted
-        state = self.check_mount_state()
+        state = self.check_mount_state(self.hosts)
         if state["nodirectory"]:
-            command = "mkdir -p {}".format(self.mount_dir.value)
-            ret_code = pcmd(state["nodirectory"], command, timeout=30)
-            if len(ret_code) > 1 or 0 not in ret_code:
-                failed_nodes = [
-                    str(node_set) for code, node_set in list(ret_code.items())
-                    if code != 0
-                ]
-                error_hosts = NodeSet(",".join(failed_nodes))
+            command = f"mkdir -p {self.mount_dir.value}"
+            result = run_remote(self.log, state["nodirectory"], command, timeout=30)
+            if not result.passed:
                 raise CommandFailure(
-                    "Error creating the {} dfuse mount point on the "
-                    "following hosts: {}".format(
-                        self.mount_dir.value, error_hosts))
+                    f"Error creating the {self.mount_dir.value} dfuse mount point "
+                    f"on the following hosts: {result.failed_hosts}")
 
-    def remove_mount_point(self, fail=True):
+    def remove_mount_point(self):
         """Remove dfuse directory.
 
         Try once with a simple rmdir which should succeed, if this does not then
@@ -199,59 +162,48 @@ class Dfuse(DfuseCommand):
         """
         # raise exception if mount point not specified
         if self.mount_dir.value is None:
-            raise CommandFailure("Mount point not specified, "
-                                 "check test yaml file")
+            raise CommandFailure("Mount point not specified. Check test yaml file")
 
         dir_exists, clean_nodes = check_file_exists(
             self.hosts, self.mount_dir.value, directory=True)
-        if dir_exists:
-            target_nodes = self.hosts.copy()
-            if clean_nodes:
-                target_nodes.remove(clean_nodes)
 
+        if not dir_exists:
             self.log.info(
-                "Removing the %s dfuse mount point on %s",
-                self.mount_dir.value, target_nodes)
+                "No %s dfuse mount point directory found on %s", self.mount_dir.value, self.hosts)
+            return
 
-            cmd = "rmdir {}".format(self.mount_dir.value)
-            ret_code = pcmd(target_nodes, cmd, timeout=30)
-            if len(ret_code) == 1 and 0 in ret_code:
-                return
+        target_nodes = self.hosts - clean_nodes
 
-            failed_nodes = NodeSet(",".join(
-                [str(node_set) for code, node_set in list(ret_code.items())
-                 if code != 0]))
+        self.log.info(
+            "Removing the %s dfuse mount point on %s", self.mount_dir.value, target_nodes)
 
-            cmd = "rm -rf {}".format(self.mount_dir.value)
-            ret_code = pcmd(failed_nodes, cmd, timeout=30)
-            if len(ret_code) > 1 or 0 not in ret_code:
-                error_hosts = NodeSet(
-                    ",".join(
-                        [str(node_set) for code, node_set in list(
-                            ret_code.items()) if code != 0]))
-                if fail:
-                    raise CommandFailure(
-                        "Error removing the {} dfuse mount point with rm on "
-                        "the following hosts: {}".format(self.mount_dir.value,
-                                                         error_hosts))
-            if fail:
-                raise CommandFailure(
-                    "Error removing the {} dfuse mount point with rmdir on the "
-                    "following hosts: {}".format(self.mount_dir.value,
-                                                 failed_nodes))
-        else:
-            self.log.info(
-                "No %s dfuse mount point directory found on %s",
-                self.mount_dir.value, self.hosts)
+        # Try removing with rmdir
+        command = f"rmdir {self.mount_dir.value}"
+        rmdir_result = run_remote(self.log, target_nodes, command, timeout=30)
+        if rmdir_result.passed:
+            return
+
+        # Try removing with rm -rf
+        command = f"rm -rf {self.mount_dir.value}"
+        rm_result = run_remote(self.log, rmdir_result.failed_hosts, command, timeout=30)
+        if not rm_result.passed:
+            raise CommandFailure(
+                f"Error removing the {self.mount_dir.value} dfuse mount point with rm on "
+                f"the following hosts: {rm_result.failed_hosts}")
+
+        # rm -rf worked but rmdir failed
+        raise CommandFailure(
+            f"Error removing the {self.mount_dir.value} dfuse mount point with rmdir on the "
+            f"following hosts: {rmdir_result.failed_hosts}")
 
     def run(self, check=True, bind_cores=None):
         # pylint: disable=arguments-differ
         """Run the dfuse command.
 
         Args:
-            check (bool): Check if dfuse mounted properly after
-                mount is executed.
+            check (bool): Check if dfuse mounted properly after mount is executed.
             bind_cores (str): List of CPU cores to pass to taskset
+
         Raises:
             CommandFailure: In case dfuse run command fails
 
@@ -260,8 +212,7 @@ class Dfuse(DfuseCommand):
 
         # A log file must be defined to ensure logs are captured
         if "D_LOG_FILE" not in self.env:
-            raise CommandFailure(
-                "Dfuse missing environment variables for D_LOG_FILE")
+            raise CommandFailure("Dfuse missing environment variables for D_LOG_FILE")
 
         if 'D_LOG_MASK' not in self.env:
             self.env['D_LOG_MASK'] = 'INFO'
@@ -272,41 +223,39 @@ class Dfuse(DfuseCommand):
         # create dfuse dir if does not exist
         self.create_mount_point()
 
+        if not self._fusermount_cmd:
+            self.log.info('Check which fusermount command to use')
+            for fusermount in ('fusermount3', 'fusermount'):
+                if run_remote(self.log, self.hosts, f'{fusermount} --version').passed:
+                    self._fusermount_cmd = fusermount
+                    break
+            if not self._fusermount_cmd:
+                raise CommandFailure(f'Failed to get fusermount command on: {self.hosts}')
+
         # run dfuse command
         cmd = self.env.to_export_str()
         if bind_cores:
             cmd += 'taskset -c {} '.format(bind_cores)
         cmd += str(self)
-        self.log.info("Command is '%s'", cmd)
-        ret_code = pcmd(self.hosts, cmd, timeout=30)
 
-        if 0 in ret_code:
-            self.running_hosts.add(ret_code[0])
-            del ret_code[0]
-
-        if ret_code:
-            error_hosts = NodeSet(
-                ",".join(
-                    [str(node_set) for code, node_set in list(ret_code.items())
-                     if code != 0]))
+        result = run_remote(self.log, self.hosts, cmd, timeout=30)
+        self._running_hosts.add(result.passed_hosts)
+        if not result.passed:
             raise CommandFailure(
-                "Error starting dfuse on the following hosts: {}".format(
-                    error_hosts))
+                f"Error starting dfuse on the following hosts: {result.failed_hosts}")
 
         if check:
             # Dfuse will block in the command for the mount to complete, even
             # if run in background mode so it should be possible to start using
             # it immediately after the command returns.
-            if not self.check_running(fail_on_error=False):
-                self.log.info('Waiting two seconds for dfuse to start')
-                time.sleep(2)
-                if not self.check_running(fail_on_error=False):
-                    self.log.info('Waiting five seconds for dfuse to start')
-                    time.sleep(5)
-                    self.check_running()
+            num_retries = 3
+            for retry in range(1, num_retries + 1):
+                if not self.check_running(fail_on_error=(retry == num_retries)):
+                    self.log.info('Waiting two seconds for dfuse to start')
+                    time.sleep(2)
 
     def check_running(self, fail_on_error=True):
-        """Check dfuse is running.
+        """Check if dfuse is running.
 
         Run a command to verify dfuse is running on hosts where it is supposed
         to be.  Use grep -v and rc=1 here so that if it isn't, then we can
@@ -324,16 +273,47 @@ class Dfuse(DfuseCommand):
             bool: whether or not dfuse is running
 
         """
-        status = True
-        state = self.check_mount_state(self.running_hosts)
+        state = self.check_mount_state(self._running_hosts)
         if state["unmounted"] or state["nodirectory"]:
             self.log.error(
                 "Error: dfuse not running on %s",
                 str(state["unmounted"].union(state["nodirectory"])))
-            status = False
             if fail_on_error:
                 raise CommandFailure("dfuse not running")
-        return status
+            return False
+        return True
+
+    def _update_running_hosts(self):
+        """Updating the hosts where dfuse is still running."""
+        if not self._running_hosts:
+            return
+        mount_state = self.check_mount_state(self._running_hosts)
+        self._running_hosts = mount_state['mounted'].copy()
+
+    def unmount(self, tries=2):
+        """Unmount dfuse.
+
+        Args:
+            tries (int, optional): number of times to try unmount. Defaults to 2
+
+        """
+        self._update_running_hosts()
+
+        for current_try in range(tries):
+            if not self._running_hosts:
+                return
+
+            # Forcibly kill dfuse after the first unmount fails
+            if current_try > 0:
+                kill_command = "pkill dfuse --signal KILL"
+                _ = run_remote(self.log, self._running_hosts, kill_command, timeout=30)
+
+            # Try to unmount dfuse on each host, ignoring errors for now
+            _ = run_remote(
+                self.log, self._running_hosts, self._get_umount_command(force=(current_try > 0)))
+            time.sleep(2)
+
+            self._update_running_hosts()
 
     def stop(self):
         """Stop dfuse.
@@ -349,60 +329,33 @@ class Dfuse(DfuseCommand):
             CommandFailure: In case dfuse stop fails
 
         """
-        # Include all hosts when stopping to ensure all mount points in any
-        # state are properly removed
-        self.running_hosts.add(self.hosts)
+        self.log.info("Stopping dfuse at %s on %s", self.mount_dir.value, self.hosts)
 
-        self.log.info(
-            "Stopping dfuse at %s on %s",
-            self.mount_dir.value, self.running_hosts)
-
-        if self.mount_dir.value and self.running_hosts:
-            error_list = []
-
-            # Loop until all fuseblk mounted devices are unmounted
-            counter = 0
-            while self.running_hosts and counter < 3:
-                # Attempt to kill dfuse on after first unmount fails
-                if self.running_hosts and counter > 1:
-                    kill_command = "pkill dfuse --signal KILL"
-                    pcmd(self.running_hosts, kill_command, timeout=30)
-
-                # Attempt to unmount any fuseblk mounted devices after detection
-                if self.running_hosts and counter > 0:
-                    pcmd(
-                        self.running_hosts,
-                        self.get_umount_command(counter > 1), expect_rc=None)
-                    time.sleep(2)
-
-                # Detect which hosts have fuseblk mounted devices and remove any
-                # hosts which no longer have the dfuse mount point mounted
-                state = self.check_mount_state(self.running_hosts)
-                for host in state["unmounted"].union(state["nodirectory"]):
-                    self.running_hosts.remove(host)
-
-                # Increment the loop counter
-                counter += 1
-
-            if self.running_hosts:
-                error_list.append(
-                    "Error stopping dfuse on {}".format(self.running_hosts))
-
-            # Remove mount points
-            try:
-                self.remove_mount_point()
-            except CommandFailure as error:
-                error_list.append(str(error))
-
-            # Report any errors
-            if error_list:
-                raise CommandFailure("\n".join(error_list))
-
-        elif self.mount_dir.value is None:
+        if self.mount_dir.value is None:
             self.log.info("No dfuse mount directory defined - nothing to stop")
+            return
 
-        else:
+        if not self.hosts:
             self.log.info("No hosts running dfuse - nothing to stop")
+            return
+
+        # Try to unmount on all hosts to account for mount points in any state
+        self._running_hosts.add(self.hosts)
+        self.unmount()
+
+        error_list = []
+        if self._running_hosts:
+            error_list.append(f"Error stopping dfuse on {self._running_hosts}")
+
+        # Remove mount points
+        try:
+            self.remove_mount_point()
+        except CommandFailure as error:
+            error_list.append(str(error))
+
+        # Report any errors
+        if error_list:
+            raise CommandFailure("\n".join(error_list))
 
 
 def get_dfuse(test, hosts):
@@ -431,11 +384,10 @@ def start_dfuse(test, dfuse, pool=None, container=None, **params):
         params (Object, optional): Dfuse command arguments to update
 
     """
-    # Update dfuse params
     if pool:
-        dfuse.set_dfuse_params(pool)
+        params['pool'] = pool.identifier
     if container:
-        dfuse.set_dfuse_cont_param(container)
+        params['cont'] = container.uuid
     if params:
         dfuse.update_params(**params)
     dfuse.set_dfuse_exports(test.client_log)

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -79,6 +79,26 @@ class RemoteCommandResult():
         return any(data.timeout for data in self.output)
 
     @property
+    def passed_hosts(self):
+        """Get all passed hosts.
+
+        Returns:
+            NodeSet: all nodes where the command passed
+
+        """
+        return NodeSet.fromlist(data.hosts for data in self.output if data.returncode == 0)
+
+    @property
+    def failed_hosts(self):
+        """Get all failed hosts.
+
+        Returns:
+            NodeSet: all nodes where the command failed
+
+        """
+        return NodeSet.fromlist(data.hosts for data in self.output if data.returncode != 0)
+
+    @property
     def all_stdout(self):
         """Get all of the stdout from the issued command from each host.
 

--- a/src/tests/ftest/util/soak_utils.py
+++ b/src/tests/ftest/util/soak_utils.py
@@ -743,9 +743,7 @@ def start_dfuse(self, pool, container, name=None, job_spec=None):
     unique = get_random_string(5, self.used)
     self.used.append(unique)
     mount_dir = dfuse.mount_dir.value + unique
-    dfuse.mount_dir.update(mount_dir)
-    dfuse.set_dfuse_params(pool)
-    dfuse.set_dfuse_cont_param(container)
+    dfuse.update_params(mount_dir=mount_dir, pool=pool.identifier, cont=container.uuid)
     dfuse_log = os.path.join(
         self.soaktest_dir,
         self.test_name + "_" + name + "_`hostname -s`_"


### PR DESCRIPTION
Test-tag: dfuse,-manual,-dm_posix_meta_entry soak_smoke Skip-func-test-leap15: false
Skip-unit-tests: true
Skip-fault-injection-test: true

- dfuse_utils
  - replace all pcmd() with run_remote().
  - cleanup setting pool and cont params
- run_utils
  - add RemoteCommandResult.passed_hosts
  - add RemoteCommandResult.failed_hosts

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
