### PR TITLE
DAOS-12222 pool: more INFO logs; test: DEBUG in create/destroy

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2176,8 +2176,11 @@ cont_close_hdls(struct cont_svc *svc, struct cont_tgt_close_rec *recs,
 		nrecs, DP_UUID(recs[0].tcr_hdl), recs[0].tcr_hce);
 
 	rc = cont_close_recs(ctx, svc, recs, nrecs);
-	if (rc != 0)
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to close %d recs: "DF_RC"\n",
+			DP_CONT(svc->cs_pool_uuid, NULL), nrecs, DP_RC(rc));
 		D_GOTO(out, rc);
+	}
 
 	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
 	if (rc != 0)
@@ -2185,8 +2188,12 @@ cont_close_hdls(struct cont_svc *svc, struct cont_tgt_close_rec *recs,
 
 	for (i = 0; i < nrecs; i++) {
 		rc = cont_close_one_hdl(&tx, svc, ctx, recs[i].tcr_hdl);
-		if (rc != 0)
+		if (rc != 0) {
+			D_ERROR(DF_CONT": failed to close handle: "DF_UUID", "DF_RC"\n",
+				DP_CONT(svc->cs_pool_uuid, NULL), DP_UUID(recs[i].tcr_hdl),
+				DP_RC(rc));
 			goto out_tx;
+		}
 
 		/*
 		 * Yield frequently, in order to cope with the slow
@@ -2212,8 +2219,8 @@ cont_close_hdls(struct cont_svc *svc, struct cont_tgt_close_rec *recs,
 out_tx:
 	rdb_tx_end(&tx);
 out:
-	D_DEBUG(DB_MD, DF_CONT": leaving: %d\n",
-		DP_CONT(svc->cs_pool_uuid, NULL), rc);
+	if (rc == 0)
+		D_INFO(DF_CONT": closed %d recs\n", DP_CONT(svc->cs_pool_uuid, NULL), nrecs);
 	return rc;
 }
 

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -111,7 +111,6 @@ extern d_iov_t ds_cont_prop_scrubber_disabled;	/* uint64_t */
 extern d_iov_t ds_cont_prop_co_md_times;	/* co_md_times */
 extern d_iov_t ds_cont_prop_cont_obj_version;	/* uint32_t */
 extern d_iov_t ds_cont_prop_nhandles;		/* uint32_t */
-
 /* Please read the IMPORTANT notes above before adding new keys. */
 
 struct co_md_times {

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -238,8 +238,7 @@ ds_mgmt_destroy_pool(uuid_t pool_uuid, d_rank_list_t *ranks)
 		goto out;
 	}
 
-	D_DEBUG(DB_MGMT, "Destroying pool " DF_UUID " succeeded.\n",
-		DP_UUID(pool_uuid));
+	D_INFO(DF_UUID": destroy succeeded.\n", DP_UUID(pool_uuid));
 out:
 	return rc;
 }
@@ -293,8 +292,7 @@ ds_mgmt_evict_pool(uuid_t pool_uuid, d_rank_list_t *svc_ranks, uuid_t *handles, 
 		goto out;
 	}
 
-	D_DEBUG(DB_MGMT, "evicting pool connections "DF_UUID" succeed.\n",
-		DP_UUID(pool_uuid));
+	D_INFO(DF_UUID": evict connections succeeded\n", DP_UUID(pool_uuid));
 out:
 	return rc;
 }

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2980,8 +2980,8 @@ pool_disconnect_hdls(struct rdb_tx *tx, struct pool_svc *svc, uuid_t *hdl_uuids,
 		D_GOTO(out, rc);
 
 out:
-	D_DEBUG(DB_MD, DF_UUID": leaving: "DF_RC"\n", DP_UUID(svc->ps_uuid),
-		DP_RC(rc));
+	if (rc == 0)
+		D_INFO(DF_UUID": success\n", DP_UUID(svc->ps_uuid));
 	return rc;
 }
 
@@ -6384,10 +6384,9 @@ ds_pool_evict_handler(crt_rpc_t *rpc)
 					&n_hdl_uuids, in->pvi_machine);
 	}
 
-	D_DEBUG(DB_MD, "number of handles found was: %d\n", n_hdl_uuids);
-
 	if (rc != 0)
 		D_GOTO(out_lock, rc);
+	D_DEBUG(DB_MD, "number of handles found was: %d\n", n_hdl_uuids);
 
 	if (n_hdl_uuids > 0) {
 		/* If pool destroy but not forcibly, error: the pool is busy */

--- a/src/tests/ftest/pool/label.py
+++ b/src/tests/ftest/pool/label.py
@@ -35,7 +35,9 @@ class Label(TestWithServers):
 
         try:
             if use_dmg:
+                pool.dmg.server_set_logmasks("DEBUG", raise_exception=False)
                 pool.dmg.pool_destroy(pool=pool.label.value, force=1)
+                pool.dmg.server_set_logmasks(raise_exception=False)
             else:
                 pool.destroy()
             if failure_expected:

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1480,12 +1480,17 @@ class TestWithServers(TestWithoutServers):
                 labels = []
 
             # Destroy each pool found
+            # Elevate log_mask to DEBUG, then restore after pool destroy
+            manager.dmg.server_set_logmasks("DEBUG", raise_exception=False)
+
             for label in labels:
                 try:
                     manager.dmg.pool_destroy(pool=label, force=True)
 
                 except CommandFailure as error:
                     error_list.append("Error destroying pool: {}".format(error))
+
+            manager.dmg.server_set_logmasks(raise_exception=False)
 
         return error_list
 

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -609,8 +609,6 @@ class CommandWithSubCommand(ExecutableCommand):
             kwargs (dict): Parameters for the command.
         """
 
-        self.log.info("CommandWithSubCommand._get_json_result: kwargs=%s", kwargs)
-
         if self.json is None:
             raise CommandFailure(
                 f"The {self.command} command doesn't have json option defined!")

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -124,8 +124,13 @@ class ExecutableCommand(CommandWithParameters):
         """
         return " ".join([self.env.to_export_str(), str(self)]).strip()
 
-    def run(self):
+    def run(self, raise_exception=None):
         """Run the command.
+
+        Args:
+            raise_exception (bool, optional): whether or not to raise an exception if the command
+                fails. This overrides the self.exit_status_exception
+                setting if defined. Defaults to None.
 
         Raises:
             CommandFailure: if there is an error running the command
@@ -134,10 +139,15 @@ class ExecutableCommand(CommandWithParameters):
         if self.run_as_subprocess:
             self._run_subprocess()
             return None
-        return self._run_process()
+        return self._run_process(raise_exception)
 
-    def _run_process(self):
+    def _run_process(self, raise_exception=None):
         """Run the command as a foreground process.
+
+        Args:
+            raise_exception (bool, optional): whether or not to raise an exception if the command
+                fails. This overrides the self.exit_status_exception
+                setting if defined. Defaults to None.
 
         Raises:
             CommandFailure: if there is an error running the command
@@ -149,17 +159,21 @@ class ExecutableCommand(CommandWithParameters):
         # Clear any previous run results
         self.result = None
         command = str(self)
+        if raise_exception is None:
+            raise_exception = self.exit_status_exception
+
         try:
             # Block until the command is complete or times out
+
             self.result = run_command(
-                command, self.timeout, self.verbose, self.exit_status_exception,
+                command, self.timeout, self.verbose, raise_exception,
                 self.output_check, env=self.env)
 
         except DaosTestError as error:
             # Command failed or possibly timed out
             raise CommandFailure(str(error))    # pylint: disable=raise-missing-from
 
-        if self.exit_status_exception and not self.check_results():
+        if raise_exception and not self.check_results():
             # Command failed if its output contains bad keywords
             raise CommandFailure(
                 "<{}> command failed: Error messages detected in output".format(
@@ -512,13 +526,18 @@ class CommandWithSubCommand(ExecutableCommand):
         self.sub_command.value = value
         self.get_sub_command_class()
 
-    def run(self):
+    def run(self, raise_exception=None):
         """Run the command and assign the 'result' attribute.
+
+        Args:
+            raise_exception (bool, optional): whether or not to raise an exception if the command
+                fails. This overrides the self.exit_status_exception
+                setting if defined. Defaults to None.
 
         Raises:
             CommandFailure: if there is an error running the command and the
                 CommandWithSubCommand.exit_status_exception attribute is set to
-                True.
+                True (and not overridden by the raise_exception argument).
 
         Returns:
             CmdResult: a CmdResult object containing the results of the command
@@ -527,14 +546,14 @@ class CommandWithSubCommand(ExecutableCommand):
         """
         try:
             # This assigns self.result
-            super().run()
+            super().run(raise_exception)
         except CommandFailure as error:
             raise CommandFailure(
                 "<{}> command failed: {}".format(
                     self.command, error)) from error
         return self.result
 
-    def _get_result(self, sub_command_list=None, **kwargs):
+    def _get_result(self, sub_command_list=None, raise_exception=None, **kwargs):
         """Get the result from running the command with the defined arguments.
 
         The optional sub_command_list and kwargs are used to define the command
@@ -548,11 +567,14 @@ class CommandWithSubCommand(ExecutableCommand):
             sub_command_list (list, optional): a list of sub commands used to
                 define the command to execute. Defaults to None, which will run
                 the command as it is currently defined.
+            raise_exception (bool, optional): whether or not to raise an exception if the command
+                fails. This overrides the self.exit_status_exception
+                setting if defined. Defaults to None.
 
         Raises:
             CommandFailure: if there is an error running the command and the
                 CommandWithSubCommand.exit_status_exception attribute is set to
-                True.
+                True (and is not overridden by the raise_exception argument).
 
         Returns:
             CmdResult: a CmdResult object containing the results of the command
@@ -571,17 +593,24 @@ class CommandWithSubCommand(ExecutableCommand):
             getattr(this_command, name).value = value
 
         # Issue the command and store the command result
-        return self.run()
+        return self.run(raise_exception)
 
-    def _get_json_result(self, sub_command_list=None, json_err=False, **kwargs):
+    def _get_json_result(self, sub_command_list=None, json_err=False,
+                         raise_exception=None, **kwargs):
         """Wrap the base _get_result method to force JSON output.
 
         Args:
             sub_command_list (list): List of subcommands.
             json_err (bool, optional): If True, return JSON
                 even if the command fails.
+            raise_exception (bool, optional): whether or not to raise an exception if the command
+                fails. This overrides the self.exit_status_exception
+                setting if defined. Defaults to None.
             kwargs (dict): Parameters for the command.
         """
+
+        self.log.info("CommandWithSubCommand._get_json_result: kwargs=%s", kwargs)
+
         if self.json is None:
             raise CommandFailure(
                 f"The {self.command} command doesn't have json option defined!")
@@ -592,8 +621,9 @@ class CommandWithSubCommand(ExecutableCommand):
         if json_err:
             prev_exit_exception = self.exit_status_exception
             self.exit_status_exception = False
+
         try:
-            self._get_result(sub_command_list, **kwargs)
+            self._get_result(sub_command_list, raise_exception=raise_exception, **kwargs)
         finally:
             self.json.update(prev_json_val)
             self.output_check = prev_output_check
@@ -832,11 +862,16 @@ class YamlCommand(SubProcessCommand):
 
         return value
 
-    def run(self):
+    def run(self, raise_exception=None):
         """Run the command and assign the 'result' attribute.
 
         Ensure the yaml file is updated with the current attributes before
         executing the command.
+
+        Args:
+            raise_exception (bool, optional): whether or not to raise an exception if the command
+                fails. This overrides the self.exit_status_exception
+                setting if defined. Defaults to None.
 
         Raises:
             CommandFailure: if there is an error running the command and the
@@ -850,7 +885,7 @@ class YamlCommand(SubProcessCommand):
         """
         if self.yaml:
             self.create_yaml_file()
-        return super().run()
+        return super().run(raise_exception)
 
     def copy_certificates(self, source, hosts):
         """Copy certificates files from the source to the destination hosts.

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -483,9 +483,14 @@ class DmgCommand(DmgCommandBase):
         # }
         return self._get_json_result(("storage", "query", "usage"))
 
-    def server_set_logmasks(self):
+    def server_set_logmasks(self, masks=None, raise_exception=None):
         """Set engine log-masks at runtime.
 
+        Args:
+            masks (str, optional): log masks to set. Defaults to None.
+            raise_exception (bool, optional): whether or not to raise an exception if the command
+                fails. This overrides the self.exit_status_exception
+                setting if defined. Defaults to None.
         Raises:
             CommandFailure: if the dmg server set logmasks command fails.
 
@@ -501,7 +506,13 @@ class DmgCommand(DmgCommandBase):
         #   "error": null,
         #   "status": 0
         # }
-        return self._get_json_result(("server", "set-logmasks"))
+
+        kwargs = {
+            "masks": masks,
+        }
+
+        return self._get_json_result(("server", "set-logmasks"),
+                                     raise_exception=raise_exception, **kwargs)
 
     def pool_create(self, scm_size, uid=None, gid=None, nvme_size=None,
                     target_list=None, svcn=None, acl_file=None, size=None,
@@ -584,6 +595,7 @@ class DmgCommand(DmgCommandBase):
         if output["response"] is None:
             return data
 
+        data["status"] = output["status"]
         data["uuid"] = output["response"]["uuid"]
         data["svc"] = ",".join([str(svc) for svc in output["response"]["svc_reps"]])
         data["ranks"] = ",".join([str(r) for r in output["response"]["tgt_ranks"]])

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -481,6 +481,9 @@ class DmgCommandBase(YamlCommand):
             def __init__(self):
                 """Create a dmg server set-logmasks command object."""
                 super().__init__("/run/dmg/server/set-logmasks/*", "set-logmasks")
+                # Set log masks for a set of facilities to a given level.
+                # Syntax is identical to the 'D_LOG_MASK' environment variable.
+                self.masks = FormattedParameter("{}", None)
 
     class StorageSubCommand(CommandWithSubCommand):
         """Defines an object for the dmg storage sub command."""

--- a/src/tests/ftest/util/fio_utils.py
+++ b/src/tests/ftest/util/fio_utils.py
@@ -154,8 +154,13 @@ class FioCommand(ExecutableCommand):
                 command.append(str(self._jobs[name]))
         return " ".join(command)
 
-    def _run_process(self):
+    def _run_process(self, raise_exception=None):
         """Run the command as a foreground process.
+
+        Args:
+            raise_exception (bool, optional): whether or not to raise an exception if the command
+                fails. This overrides the self.exit_status_exception
+                setting if defined. Defaults to None.
 
         Raises:
             CommandFailure: if there is an error running the command
@@ -163,12 +168,12 @@ class FioCommand(ExecutableCommand):
         """
         if not self._hosts:
             # Run fio locally
-            self.log.debug("Running: %s", self.__str__())
-            super()._run_process()
+            self.log.debug("Running: %s", str(self))
+            super()._run_process(raise_exception)
         else:
             # Run fio remotely
-            self.log.debug("Running: %s", self.__str__())
-            ret_codes = pcmd(self._hosts, self.__str__())
+            self.log.debug("Running: %s", str(self))
+            ret_codes = pcmd(self._hosts, str(self))
 
             # Report any failures
             if len(ret_codes) > 1 or 0 not in ret_codes:

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -342,6 +342,10 @@ class TestPool(TestDaosApiBase):
         finally:
             self.dmg.server_set_logmasks(raise_exception=False)
 
+        # make sure dmg exit status is that of the pool create, not the set-logmasks
+        if data:
+            self.dmg.result.exit_status = data["status"]
+
         if data and data["status"] == 0:
             # Convert the string of service replicas from the dmg command
             # output into an ctype array for the DaosPool object using the

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -16,7 +16,7 @@ from exception_utils import CommandFailure
 from pydaos.raw import (DaosApiError, DaosPool, c_uuid_to_str, daos_cref)
 from general_utils import check_pool_files, DaosTestError
 from server_utils_base import ServerFailed, AutosizeCancel
-from dmg_utils import DmgCommand
+from dmg_utils import DmgCommand, DmgJsonCommandFailure
 
 POOL_NAMESPACE = "/run/pool/*"
 POOL_TIMEOUT_INCREMENT = 200
@@ -287,6 +287,7 @@ class TestPool(TestDaosApiBase):
 
     @fail_on(CommandFailure)
     @fail_on(DaosApiError)
+    @fail_on(DmgJsonCommandFailure)
     def create(self):
         """Create a pool with dmg.
 
@@ -333,10 +334,15 @@ class TestPool(TestDaosApiBase):
                 kwargs[key] = value
 
         # Create a pool with the dmg command and store its CmdResult
+        # Elevate engine log_mask to DEBUG before, then restore after pool create
         self._log_method("dmg.pool_create", kwargs)
-        data = self.dmg.pool_create(**kwargs)
+        self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
+        try:
+            data = self.dmg.pool_create(**kwargs)
+        finally:
+            self.dmg.server_set_logmasks(raise_exception=False)
 
-        if self.dmg.result.exit_status == 0:
+        if data and data["status"] == 0:
             # Convert the string of service replicas from the dmg command
             # output into an ctype array for the DaosPool object using the
             # same technique used in DaosPool.create().
@@ -427,7 +433,11 @@ class TestPool(TestDaosApiBase):
                 self.log.info("Destroying pool %s", self.identifier)
 
                 # Destroy the pool with the dmg command.
+                # Elevate log_mask to DEBUG, then restore after pool destroy
+                self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
                 self.dmg.pool_destroy(pool=self.identifier, force=force, recursive=recursive)
+                self.dmg.server_set_logmasks(raise_exception=False)
+
                 status = True
 
             self.pool = None

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -339,12 +339,13 @@ class TestPool(TestDaosApiBase):
         self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
         try:
             data = self.dmg.pool_create(**kwargs)
+            create_res = self.dmg.result
         finally:
             self.dmg.server_set_logmasks(raise_exception=False)
 
         # make sure dmg exit status is that of the pool create, not the set-logmasks
-        if data:
-            self.dmg.result.exit_status = data["status"]
+        if data is not None and create_res is not None:
+            self.dmg.result = create_res
 
         if data and data["status"] == 0:
             # Convert the string of service replicas from the dmg command


### PR DESCRIPTION
Change pool destroy code so some essential log entries are
D_INFO (rather than D_DEBUG). This is done so when pool destroy fails
(or hangs), a course-grained understanding of progress is visible
before running a reproducer with log_mask: DEBUG. Additionally,
some D_ERROR entries are added so slightly more information is
reported about the location of a failed destroy.

Also with this change, the functional test code uses the
dmg server set-logmasks command to elevate the engine log_mask
to "DEBUG" immediately preceding any pool create or pool destroy.
Correspondingly, immediately following, it executes
dmg server set-logmasks (no argument) to restore the original
log_mask. This is done to lessen the need for test reproducer
runs when a test failed in pool create/destroy (fairly common)
but whose engine configuration is log_mask: INFO (also common).
Additional raise_exception boolean argument is provided in various
methods to override the exit_status_exception class attribute for
specific command invocations such as set-logmasks that will
fail if, for example, an engine has been stopped (commonly done
by tests).

Test-tag: pr daily_regression

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
