### PR TITLE
DAOS-11880 engine: Scale size of metrics shmem region

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -624,13 +624,19 @@ server_id_cb(uint32_t *tid, uint64_t *uid)
 	}
 }
 
+static uint64_t
+metrics_region_size(int num_tgts)
+{
+	const uint64_t	est_std_metrics = 1024; /* high estimate to allow for pool links */
+	const uint64_t	est_tgt_metrics = 128; /* high estimate */
+
+	return (est_std_metrics + est_tgt_metrics * num_tgts) * D_TM_METRIC_SIZE;
+}
+
 static int
 server_init(int argc, char *argv[])
 {
 	uint64_t		bound;
-	uint64_t		metrics_size;
-	const uint64_t		est_std_metrics = 1024; /* high estimate to allow for pool links */
-	const uint64_t		est_tgt_metrics = 128; /* high estimate */
 	unsigned int		ctx_nr;
 	int			rc;
 	struct engine_metrics	*metrics;
@@ -653,8 +659,7 @@ server_init(int argc, char *argv[])
 	if (rc != 0)
 		D_GOTO(exit_debug_init, rc);
 
-	metrics_size = (est_std_metrics + est_tgt_metrics * dss_tgt_nr) * D_TM_METRIC_SIZE;
-	rc = d_tm_init(dss_instance_idx, metrics_size, D_TM_SERVER_PROCESS);
+	rc = d_tm_init(dss_instance_idx, metrics_region_size(dss_tgt_nr), D_TM_SERVER_PROCESS);
 	if (rc != 0)
 		goto exit_debug_init;
 

--- a/src/include/gurt/telemetry_common.h
+++ b/src/include/gurt/telemetry_common.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -223,6 +223,14 @@ struct d_tm_nodeList_t {
 	struct d_tm_node_t	*dtnl_node;
 	struct d_tm_nodeList_t	*dtnl_next;
 };
+
+/*
+ * Estimate of a metric size. This leans toward a large estimate, but is not the absolute maximum
+ * possible size.
+ */
+#define D_TM_METRIC_SIZE (sizeof(struct d_tm_node_t) + sizeof(struct d_tm_metric_t) + \
+			  D_TM_MAX_DESC_LEN + D_TM_MAX_NAME_LEN + D_TM_MAX_UNIT_LEN + \
+			  sizeof(struct d_tm_stats_t))
 
 /** Context for a telemetry instance */
 struct d_tm_context;


### PR DESCRIPTION
Previously the metrics shared memory region was created with a static size. However many metrics are now created on a per-target basis. The size needs to scale with the number of targets.

The estimates of the number of standard metrics and number of target metrics are higher than the actual number, to allow some buffer space for future additions.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
