### PR TITLE
DAOS-12058 common: Integrating BMEM with WAL

### DIFF
--- a/src/common/dav/dav.h
+++ b/src/common/dav/dav.h
@@ -46,6 +46,11 @@
 					DAV_XADD_ASSUME_INITIALIZED |\
 					DAV_XADD_NO_ABORT)
 
+/*
+ * WAL Redo hints.
+ */
+#define DAV_XADD_WAL_CPTR		(((uint64_t)1) << 5)
+
 #define DAV_XLOCK_NO_ABORT	DAV_FLAG_TX_NO_ABORT
 #define DAV_XLOCK_VALID_FLAGS	(DAV_XLOCK_NO_ABORT)
 
@@ -220,7 +225,7 @@ void dav_tx_commit(void);
  *
  * This function must *not* be called during TX_STAGE_WORK.
  */
-int dav_tx_end(void);
+int dav_tx_end(void *data);
 
 /*
  * Returns the current stage of the transaction.

--- a/src/common/dav/dav_internal.h
+++ b/src/common/dav/dav_internal.h
@@ -47,9 +47,6 @@ struct dav_phdr {
 			sizeof(struct stats_persistent)];
 };
 
-/*REVISIT*/
-struct bio_meta_instance;
-
 /* DAV object handle */
 typedef struct dav_obj {
 	char				*do_path;
@@ -64,7 +61,7 @@ typedef struct dav_obj {
 	int				 do_fd;
 	int				 nested_tx;
 	struct umem_wal_tx		*do_utx;
-	struct umem_store		 do_store;
+	struct umem_store		*do_store;
 
 	struct dav_clogs		 clogs __attribute__ ((__aligned__(CACHELINE_SIZE)));
 } dav_obj_t;
@@ -83,6 +80,6 @@ struct umem_wal_tx *wtx2utx(struct dav_tx *wtx)
 }
 
 int lw_tx_begin(dav_obj_t *pop);
-int lw_tx_end(dav_obj_t *pop);
+int lw_tx_end(dav_obj_t *pop, void *data);
 
 #endif /* __DAOS_COMMON_DAV_INTERNAL_H */

--- a/src/common/dav/memblock.c
+++ b/src/common/dav/memblock.c
@@ -1451,7 +1451,7 @@ memblock_run_init(struct palloc_heap *heap,
 
 	mo_wal_flush(&heap->p_ops, run,
 		sizeof(struct chunk_run_header) +
-		bitmap_size);
+		bitmap_size, 0);
 
 	struct chunk_header run_data_hdr;
 

--- a/src/common/dav/mo_wal.h
+++ b/src/common/dav/mo_wal.h
@@ -51,9 +51,9 @@ mo_wal_persist(const struct mo_ops *p_ops, void *d, size_t s)
 }
 
 static force_inline void
-mo_wal_flush(const struct mo_ops *p_ops, void *d, size_t s)
+mo_wal_flush(const struct mo_ops *p_ops, void *d, size_t s, int flags)
 {
-	dav_wal_tx_snap(p_ops->base, d, s, d, 0);
+	dav_wal_tx_snap(p_ops->base, d, s, d, flags);
 }
 
 static force_inline void
@@ -68,7 +68,7 @@ mo_wal_memcpy(const struct mo_ops *p_ops, void *dest,
 {
 	SUPPRESS_UNUSED(p_ops);
 	memcpy(dest, src, len);
-	mo_wal_flush(p_ops, dest, len);
+	mo_wal_flush(p_ops, dest, len, 0);
 	return dest;
 }
 
@@ -78,7 +78,7 @@ mo_wal_memmove(const struct mo_ops *p_ops, void *dest,
 {
 	SUPPRESS_UNUSED(p_ops);
 	memmove(dest, src, len);
-	mo_wal_flush(p_ops, dest, len);
+	mo_wal_flush(p_ops, dest, len, 0);
 	return dest;
 }
 

--- a/src/common/dav/wal_tx.h
+++ b/src/common/dav/wal_tx.h
@@ -20,7 +20,6 @@ struct wal_action {
 
 struct dav_tx {
 	struct dav_obj		*wt_dav_hdl;
-	uint64_t		 wt_id;
 	d_list_t		 wt_redo;
 	uint32_t		 wt_redo_cnt;
 	uint32_t		 wt_redo_payload_len;
@@ -29,12 +28,12 @@ struct dav_tx {
 D_CASSERT(sizeof(struct dav_tx) <= UTX_PRIV_SIZE,
 	  "Size of struct dav_tx is too big!");
 
-#define dav_action_get_next(it) d_list_entry(&it.next, struct wal_action, wa_link)
+#define dav_action_get_next(it) d_list_entry(it.next, struct wal_action, wa_link)
 
 struct umem_wal_tx *dav_umem_wtx_new(struct dav_obj *dav_hdl);
 void dav_umem_wtx_cleanup(struct umem_wal_tx *utx);
 int dav_wal_tx_reserve(struct dav_obj *hdl);
-int dav_wal_tx_commit(struct dav_obj *hdl, struct umem_wal_tx *utx);
+int dav_wal_tx_commit(struct dav_obj *hdl, struct umem_wal_tx *utx, void *data);
 int dav_wal_tx_snap(void *hdl, void *addr, daos_size_t size, void *src, uint32_t flags);
 int dav_wal_tx_assign(void *hdl, void *addr, uint64_t val);
 int dav_wal_tx_clr_bits(void *hdl, void *addr, uint32_t pos, uint16_t num_bits);

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -135,15 +135,13 @@ umempobj_create(const char *path, const char *layout_name, int flags,
 		umm_pool->up_priv = pop;
 		return umm_pool;
 	case DAOS_MD_BMEM:
-		dav_hdl = dav_obj_create(path, 0, poolsize, mode, store);
+		dav_hdl = dav_obj_create(path, 0, poolsize, mode, &umm_pool->up_store);
 		if (!dav_hdl) {
 			D_ERROR("Failed to create pool %s, size="DF_U64": errno = %d\n",
 				path, poolsize, errno);
 			D_FREE(umm_pool);
 			return NULL;
 		}
-		if (store != NULL)
-			umm_pool->up_store = *store;
 		umm_pool->up_priv = dav_hdl;
 
 		/* TODO: Do checkpoint here to write back allocator heap */
@@ -221,7 +219,7 @@ umempobj_open(const char *path, const char *layout_name, int flags, struct umem_
 		/* TODO Load all meta pages from SSD */
 		/* TODO Replay WAL */
 
-		dav_hdl = dav_obj_open(path, 0, store);
+		dav_hdl = dav_obj_open(path, 0, &umm_pool->up_store);
 		if (!dav_hdl) {
 			D_ERROR("Error in opening the pool %s: errno =%d\n",
 				path, errno);
@@ -984,7 +982,7 @@ bmem_tx_abort(struct umem_instance *umm, int err)
 	if (dav_tx_stage() != DAV_TX_STAGE_ONABORT)
 		dav_tx_abort(err);
 
-	err = dav_tx_end();
+	err = dav_tx_end(NULL);
 	return err ? umem_tx_errno(err) : 0;
 }
 
@@ -1007,7 +1005,7 @@ bmem_tx_begin(struct umem_instance *umm, struct umem_tx_stage_data *txd)
 		 * dav_tx_end() needs be called to re-initialize the
 		 * tx state when dav_tx_begin() failed.
 		 */
-		rc = dav_tx_end();
+		rc = dav_tx_end(NULL);
 		return rc ? umem_tx_errno(rc) : 0;
 	}
 	return 0;
@@ -1019,7 +1017,7 @@ bmem_tx_commit(struct umem_instance *umm, void *data)
 	int rc;
 
 	dav_tx_commit();
-	rc = dav_tx_end();
+	rc = dav_tx_end(data);
 
 	return rc ? umem_tx_errno(rc) : 0;
 }

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -115,6 +115,10 @@ if [ -d "/mnt/daos" ]; then
         export VOS_BDEV_CLASS="AIO"
         run_test "sudo -E ${SL_PREFIX}/bin/vos_tests" -a
 
+        rm -f "${AIO_DEV}"
+        dd if=/dev/zero of="${AIO_DEV}" bs=1G count=10
+        sed -i "s+\"name\": \"AIO_1\"+\"name\": \"AIO_7\"+g" ${NVME_CONF}
+
         export DAOS_MD_ON_SSD=1
         run_test "sudo -E ${SL_PREFIX}/bin/vos_tests" -a
         unset DAOS_MD_ON_SSD


### PR DESCRIPTION
The changes include:
- umem_store integration with BMEM.
- dav_tx_end() now accepts data_iod and passes it to wal_commit.
- redo log entry associated with dav_reserve() will not use ACT_COPY_PTR.

Signed-off-by: sherintg <sherin-t.george@hpe.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
