### PR TITLE
DAOS-12119 control: Handle ErrPoolNotFound on retried PoolDestroy (#10873)

### DIFF
--- a/src/control/common/proto/error_test.go
+++ b/src/control/common/proto/error_test.go
@@ -78,6 +78,7 @@ func TestProto_AnnotateError(t *testing.T) {
 		LeaderHint: "foo.bar.baz",
 		Replicas:   []string{"a", "b", "c"},
 	}
+	testPoolNotFound := system.ErrPoolLabelNotFound("foo")
 
 	for name, tc := range map[string]struct {
 		err      error
@@ -109,6 +110,10 @@ func TestProto_AnnotateError(t *testing.T) {
 		"wrap/unwrap ErrNotLeader": {
 			err:    testNotLeader,
 			expErr: testNotLeader,
+		},
+		"wrap/unwrap ErrPoolNotFound": {
+			err:    testPoolNotFound,
+			expErr: testPoolNotFound,
 		},
 		"non-fault err": {
 			err:    errors.New("not a fault"),

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -303,7 +303,17 @@ func PoolDestroy(ctx context.Context, rpcClient UnaryInvoker, req *PoolDestroyRe
 		return err
 	}
 
-	return errors.Wrap(ur.getMSError(), "pool destroy failed")
+	if err := ur.getMSError(); err != nil {
+		// If the error is due to a retried destroy failing to find
+		// the pool, then we can assume that the pool was destroyed
+		// via a server-side cleanup and we can intercept it. Everything
+		// else is still an error.
+		if !(ur.retryCount > 0 && system.IsPoolNotFound(err)) {
+			return errors.Wrap(err, "pool destroy failed")
+		}
+	}
+
+	return nil
 }
 
 // PoolUpgradeReq contains the parameters for a pool upgrade request.

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -87,6 +87,28 @@ func TestControl_PoolDestroy(t *testing.T) {
 				},
 			},
 		},
+		"ErrPoolNotFound on first try is not retried": {
+			req: &PoolDestroyReq{
+				ID: test.MockUUID(),
+			},
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", system.ErrPoolUUIDNotFound(test.MockPoolUUID()), nil),
+				},
+			},
+			expErr: system.ErrPoolUUIDNotFound(test.MockPoolUUID()),
+		},
+		"ErrPoolNotFound on retry is treated as success": {
+			req: &PoolDestroyReq{
+				ID: test.MockUUID(),
+			},
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", drpc.DaosTimedOut, nil),
+					MockMSResponse("host1", system.ErrPoolUUIDNotFound(test.MockPoolUUID()), nil),
+				},
+			},
+		},
 		"DataPlaneNotStarted error is retried": {
 			req: &PoolDestroyReq{
 				ID: test.MockUUID(),

--- a/src/control/lib/control/response.go
+++ b/src/control/lib/control/response.go
@@ -157,9 +157,10 @@ func (hem HostErrorsMap) Keys() []string {
 // UnaryResponse contains a slice of *HostResponse items returned
 // from synchronous unary RPC invokers.
 type UnaryResponse struct {
-	Responses []*HostResponse
-	fromMS    bool
-	log       debugLogger
+	Responses  []*HostResponse
+	fromMS     bool
+	retryCount uint
+	log        debugLogger
 }
 
 func (ur *UnaryResponse) debugf(format string, args ...interface{}) {

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -411,7 +411,7 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 			return nil, wrapReqTimeout(req, err)
 		}
 
-		ur := &UnaryResponse{log: log, fromMS: true}
+		ur := &UnaryResponse{log: log, fromMS: true, retryCount: try}
 		err = gatherResponses(tryCtx, respChan, ur)
 		if isHardFailure(err, reqCtx) {
 			return nil, wrapReqTimeout(req, err)

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -101,7 +101,7 @@ func (svc *mgmtSvc) resolvePoolID(id string) (uuid.UUID, error) {
 		}
 	}
 
-	return uuid.Nil, errors.Errorf("unable to find pool with label %q", id)
+	return uuid.Nil, system.ErrPoolLabelNotFound(id)
 }
 
 // getPoolService returns the pool service entry for the given UUID.
@@ -275,7 +275,7 @@ func (svc *mgmtSvc) PoolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 		}
 		return resp, nil
 	}
-	if _, ok := err.(*system.ErrPoolNotFound); !ok {
+	if !system.IsPoolNotFound(err) {
 		return nil, err
 	}
 

--- a/src/control/system/database.go
+++ b/src/control/system/database.go
@@ -864,7 +864,7 @@ func (db *Database) FindPoolServiceByUUID(uuid uuid.UUID) (*PoolService, error) 
 		return copyPoolService(p), nil
 	}
 
-	return nil, &ErrPoolNotFound{byUUID: &uuid}
+	return nil, ErrPoolUUIDNotFound(uuid)
 }
 
 // FindPoolServiceByLabel searches the pool database by Label. If no
@@ -880,7 +880,7 @@ func (db *Database) FindPoolServiceByLabel(label string) (*PoolService, error) {
 		return copyPoolService(p), nil
 	}
 
-	return nil, &ErrPoolNotFound{byLabel: &label}
+	return nil, ErrPoolLabelNotFound(label)
 }
 
 // TakePoolLock attempts to take a lock on the pool with the given UUID,


### PR DESCRIPTION
In the event that a PoolDestroy RPC is retried and the pool is
destroyed while the client is waiting to retry, the server will
return an ErrPoolNotFound error in response to the final retry. As
this is not really an error, just catch it and signal success.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
