### PR TITLE
DAOS-12181 ds3: Don't use stack allocated variables

### DIFF
--- a/src/client/ds3/ds3_internal.h
+++ b/src/client/ds3/ds3_internal.h
@@ -58,8 +58,6 @@ struct ds3_bucket {
 struct ds3_obj {
 	/** DFS object handle */
 	dfs_obj_t *dfs_obj;
-	d_sg_list_t	ds3_sgl;
-	d_iov_t		ds3_iov;
 };
 
 /** DAOS S3 Upload Part handle */

--- a/src/client/ds3/ds3_internal.h
+++ b/src/client/ds3/ds3_internal.h
@@ -58,6 +58,8 @@ struct ds3_bucket {
 struct ds3_obj {
 	/** DFS object handle */
 	dfs_obj_t *dfs_obj;
+	d_sg_list_t	ds3_sgl;
+	d_iov_t		ds3_iov;
 };
 
 /** DAOS S3 Upload Part handle */

--- a/src/client/ds3/object.c
+++ b/src/client/ds3/object.c
@@ -6,6 +6,11 @@
 
 #include "ds3_internal.h"
 
+typedef struct ds3_obj_args {
+	d_iov_t	iov;
+	d_sg_list_t sg;
+} ds3_obj_args_t;
+
 /* helper */
 static bool
 ends_with(const char *str, const char *suffix)
@@ -199,6 +204,32 @@ ds3_obj_set_info(struct ds3_object_info *info, ds3_bucket_t *ds3b, ds3_obj_t *ds
 			     info->encoded_length, 0);
 }
 
+static int
+ds3_obj_read_int_cb(void *args, daos_event_t *ev, int ret)
+{
+	D_FREE(args);
+	return 0;
+}
+
+static int
+ds3_obj_read_int(void *buf, daos_off_t off, daos_size_t *size, ds3_bucket_t *ds3b, ds3_obj_t *ds3o,
+	     daos_event_t *ev)
+{
+	ds3_obj_args_t	*args;
+
+	D_ALLOC_PTR(args);
+	if (args == NULL)
+		return -DER_NOMEM;
+
+	d_iov_set(&args->iov, buf, *size);
+	args->sg.sg_nr     = 1;
+	args->sg.sg_iovs   = &args->iov;
+	args->sg.sg_nr_out = 1;
+
+	daos_event_register_comp_cb(ev, ds3_obj_read_int_cb, args);
+	return -dfs_read(ds3b->dfs, ds3o->dfs_obj, &args->sg, off, size, ev);
+}
+
 int
 ds3_obj_read(void *buf, daos_off_t off, daos_size_t *size, ds3_bucket_t *ds3b, ds3_obj_t *ds3o,
 	     daos_event_t *ev)
@@ -206,11 +237,18 @@ ds3_obj_read(void *buf, daos_off_t off, daos_size_t *size, ds3_bucket_t *ds3b, d
 	if (ds3b == NULL || buf == NULL || ds3o == NULL)
 		return -EINVAL;
 
-	d_iov_set(&ds3o->ds3_iov, buf, *size);
-	ds3o->ds3_sgl.sg_nr     = 1;
-	ds3o->ds3_sgl.sg_iovs   = &ds3o->ds3_iov;
-	ds3o->ds3_sgl.sg_nr_out = 1;
-	return -dfs_read(ds3b->dfs, ds3o->dfs_obj, &ds3o->ds3_sgl, off, size, ev);
+	if (ev == NULL) {
+		d_iov_t     iov;
+		d_sg_list_t rsgl;
+
+		d_iov_set(&iov, buf, *size);
+		rsgl.sg_nr     = 1;
+		rsgl.sg_iovs   = &iov;
+		rsgl.sg_nr_out = 1;
+		return -dfs_read(ds3b->dfs, ds3o->dfs_obj, &rsgl, off, size, ev);
+	}
+
+	return ds3_obj_read_int(buf, off, size, ds3b, ds3o, ev);
 }
 
 int

--- a/src/client/ds3/object.c
+++ b/src/client/ds3/object.c
@@ -203,17 +203,14 @@ int
 ds3_obj_read(void *buf, daos_off_t off, daos_size_t *size, ds3_bucket_t *ds3b, ds3_obj_t *ds3o,
 	     daos_event_t *ev)
 {
-	d_iov_t     iov;
-	d_sg_list_t rsgl;
-
 	if (ds3b == NULL || buf == NULL || ds3o == NULL)
 		return -EINVAL;
 
-	d_iov_set(&iov, buf, *size);
-	rsgl.sg_nr     = 1;
-	rsgl.sg_iovs   = &iov;
-	rsgl.sg_nr_out = 1;
-	return -dfs_read(ds3b->dfs, ds3o->dfs_obj, &rsgl, off, size, ev);
+	d_iov_set(&ds3o->ds3_iov, buf, *size);
+	ds3o->ds3_sgl.sg_nr     = 1;
+	ds3o->ds3_sgl.sg_iovs   = &ds3o->ds3_iov;
+	ds3o->ds3_sgl.sg_nr_out = 1;
+	return -dfs_read(ds3b->dfs, ds3o->dfs_obj, &ds3o->ds3_sgl, off, size, ev);
 }
 
 int

--- a/src/include/daos_s3.h
+++ b/src/include/daos_s3.h
@@ -172,7 +172,7 @@ ds3_disconnect(ds3_t *ds3, daos_event_t *ev);
  *
  * \param[in]	name		Name of the S3 user to look up.
  * \param[in]	info		User info.
- * \param[in]	olf_info	(Optional) Old user info.
+ * \param[in]	old_info	(Optional) Old user info.
  * \param[in]	ds3		Pointer to the DAOS S3 pool handle to use.
  * \param[in]	ev		Completion event, it is optional and can be NULL.
  *				Function will run in blocking mode if \a ev is NULL.


### PR DESCRIPTION
The function ds3_obj_read() allocates IOV and SGL variables on the stack for the underlying call to dfs_read(). This pattern works for synchronous calls, but it causes a segmentation violation for asynchronous read operations (i.e., when the event structure passed to dfs_read is not NULL).

Fix this by adding an SG list and IOV structures to the ds3_obj and using those variables in the call to dfs_read().

Signed-off-by: Chuck Tuffli <chuck.tuffli@hpe.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
