### PR TITLE
DAOS-12155 cart:  Fix iv test cleanup stage (#10932)

### DIFF
--- a/src/tests/ftest/cart/iv/iv_one_node.py
+++ b/src/tests/ftest/cart/iv/iv_one_node.py
@@ -491,7 +491,7 @@ class CartIvOneNodeTest(CartTest):
 
         ########## Shutdown Servers ##########
 
-        num_servers = self.get_srv_cnt("test_servers")
+        num_servers = 1
 
         srv_ppn = self.params.get("test_servers_ppn", '/run/tests/*/')
 

--- a/src/tests/ftest/cart/iv/iv_two_node.py
+++ b/src/tests/ftest/cart/iv/iv_two_node.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-  (C) Copyright 2018-2021 Intel Corporation.
+  (C) Copyright 2018-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -242,8 +242,8 @@ class CartIvTwoNodeTest(CartTest):
             failed = True
             self.print("TEST FAILED: {}".format(exception))
 
-        ########## Shutdown Servers ##########
-        num_servers = self.get_srv_cnt("test_servers")
+        # Shutdown Servers
+        num_servers = 2
 
         srv_ppn = self.params.get("test_servers_ppn", '/run/tests/*/')
 

--- a/src/tests/ftest/cart/util/cart_utils.py
+++ b/src/tests/ftest/cart/util/cart_utils.py
@@ -301,18 +301,6 @@ class CartTest(TestWithoutServers):
 
         return env
 
-    def get_srv_cnt(self, host):
-        """Get server count for 'host' test yaml parameter.
-
-        Args:
-            host (str): test yaml parameter name
-
-        Returns:
-            int: length of the 'host' test yaml parameter
-
-        """
-        return len(self.params.get("{}".format(host), "/run/hosts/*/", []))
-
     @staticmethod
     def get_yaml_list_elem(param, index):
         """Get n-th element from YAML param.


### PR DESCRIPTION
* Wrong number of servers were calculated during the cleanup stage of the test. This resulted in non-existent ranks being pinged for the shutdown leading to asserts and core files being generated.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
