### PR TITLE
DAOS-11986 control: Don't break out of leadership monitoring loop (#10937)

### DIFF
--- a/src/control/system/database.go
+++ b/src/control/system/database.go
@@ -471,7 +471,7 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 					cancelGainedCtx()
 				}
 				runOnLeadershipLost()
-				break
+				continue // restart the monitoring loop
 			}
 
 			db.log.Debugf("node %s gained MS leader state", db.replicaAddr)
@@ -481,7 +481,7 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 				if err = db.ResignLeadership(err); err != nil {
 					db.log.Errorf("raft ResignLeadership() failed: %s", err)
 				}
-				break
+				continue // restart the monitoring loop
 			}
 			db.log.Debugf("raft Barrier() complete after %s", time.Since(barrierStart))
 
@@ -494,7 +494,7 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 					if err = db.ResignLeadership(err); err != nil {
 						db.log.Errorf("raft ResignLeadership() failed: %s", err)
 					}
-					break
+					break // break out of the inner loop; restart the monitoring loop
 				}
 			}
 		}


### PR DESCRIPTION
The loop should just be restarted in order to act on future
leadership changes.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>