### PR TITLE
Jvolivie/test produce junit

### DIFF
--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -71,6 +71,7 @@ ut_format(void **state)
 	rc = vea_format(&args->vua_umm, &args->vua_txd, args->vua_md, blk_sz,
 			hdr_blks, capacity, NULL, NULL, true);
 	assert_rc_equal(rc, 0);
+	assert_rc_equal(rc, 1);
 }
 
 static void

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -25,6 +25,37 @@ if [ -z "$DAOS_BASE" ]; then
     DAOS_BASE="."
 fi
 
+produce_output()
+{
+    echo "$2"
+
+    cname="UTEST_all.run_test_${RUN_TEST_VALGRIND:-native}"
+    name="run_test"
+    fname="${DAOS_BASE}/test_results/test_run_test.sh.${RUN_TEST_VALGRIND:-native}.xml"
+
+    if [ "$1" -eq 0 ]; then
+       teststr="    <testcase classname=\"$cname\" name=\"$name\" />"
+    else
+       teststr="    <testcase classname=\"$cname\" name=\"$name\">
+      <failure type=\"format\">
+        <![CDATA[$2
+          ]]>
+      </failure>
+    </testcase>"
+    fi
+
+    cat > "${fname}" << EOF
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+  <testsuite tests="1" failures="$1" errors="0" skipped="0" >
+EOF
+echo "${teststr}" >> "${fname}"
+cat >> "${fname}" << EOF
+  </testsuite>
+</testsuites>
+EOF
+}
+
 run_test()
 {
     local in="$*"
@@ -245,12 +276,15 @@ if [ -d "/mnt/daos" ]; then
     # Reporting
     if [ "$failed" -eq 0 ]; then
         # spit out the magic string that the post build script looks for
-        echo "SUCCESS! NO TEST FAILURES"
+        produce_output 0 "SUCCESS! NO TEST FAILURES"
     else
-        echo "FAILURE: $failed tests failed (listed below)"
+        fail_msg="FAILURE: $failed tests failed (listed below)
+"
         for ((i = 0; i < ${#failures[@]}; i++)); do
-            echo "    ${failures[$i]}"
+            fail_msg=$"$fail_msg    ${failures[$i]}
+"
         done
+        produce_output 1 "$fail_msg"
         if ! ${IS_CI:-false}; then
             exit 1
         fi


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
