### PR TITLE
DAOS-7821 build: Update gofmt githook to skip if no .go files changed

### DIFF
--- a/utils/githooks/pre-commit.d/40-gofmt.sh
+++ b/utils/githooks/pre-commit.d/40-gofmt.sh
@@ -26,16 +26,26 @@ else
         TARGET=origin/master
 fi
 
-output=
+go_files=
 if [ $TARGET = "HEAD" ]
 then
         echo "Checking against HEAD"
-        output=$(git diff HEAD^ --name-only | grep -e '.go$' | xargs gofmt -d)
+	go_files=$(git diff HEAD^ --name-only | grep -e '.go$' || exit 0)
 else
         echo "Checking against branch ${TARGET}"
-        output=$(git diff $TARGET... --name-only | grep -e '.go$' | xargs gofmt -d)
+        go_files=$(git diff $TARGET... --name-only | grep -e '.go$' || exit 0)
 fi
 
+if [ -z "$go_files" ]; then
+	exit 0
+fi
+
+if ! which gofmt >/dev/null 2>&1; then
+	echo "ERROR: Changed .go files found but gofmt is not in your PATH"
+	exit 1
+fi
+
+output=$(echo "$go_files" | xargs gofmt -d)
 if [ -n "$output" ]; then
         echo "ERROR: Your code hasn't been run through gofmt!"
         echo "Please configure your editor to run gofmt on save."


### PR DESCRIPTION
Avoid running the hook if the commit didn't change any .go files.
If the commit did change .go files, and gofmt is not in the $PATH
for some reason, the hook will fail.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
