### PR TITLE
DAOS-12216 gurt: increase share memory for telemetry

### DIFF
--- a/src/include/gurt/telemetry_common.h
+++ b/src/include/gurt/telemetry_common.h
@@ -15,7 +15,7 @@
 #define D_TM_TIME_BUFF_LEN		26
 
 #define D_TM_SHARED_MEMORY_KEY		0x10242048
-#define D_TM_SHARED_MEMORY_SIZE		(1024 * 1024)
+#define D_TM_SHARED_MEMORY_SIZE		(1024 * 1024 * 2)
 
 /**
  * The following definitions are suggested strings for units that may be used


### PR DESCRIPTION
Creating pool failed if target number exceeds 22, increase shared memory from 1MiB to 2MiB.

Required-githooks: true

Signed-off-by: Wang Shilong <shilong.wang@intel.com>
