### PR TITLE
DAOS-12223 control: Allow VMD backing device addresses in NVMe prepare

### DIFF
--- a/src/control/server/storage/bdev/backend_test.go
+++ b/src/control/server/storage/bdev/backend_test.go
@@ -28,12 +28,6 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
-const (
-	vmdAddr         = "0000:5d:05.5"
-	vmdBackingAddr1 = "5d0505:01:00.0"
-	vmdBackingAddr2 = "5d0505:03:00.0"
-)
-
 func addrListFromStrings(addrs ...string) *hardware.PCIAddressSet {
 	return hardware.MustNewPCIAddressSet(addrs...)
 }

--- a/src/control/server/storage/bdev/backend_vmd_test.go
+++ b/src/control/server/storage/bdev/backend_vmd_test.go
@@ -20,13 +20,13 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
-func TestBackend_substituteVMDAddresses(t *testing.T) {
-	const (
-		vmdAddr         = "0000:05:05.5"
-		vmdBackingAddr1 = "050505:01:00.0"
-		vmdBackingAddr2 = "050505:03:00.0"
-	)
+const (
+	vmdAddr         = "0000:05:05.5"
+	vmdBackingAddr1 = "050505:01:00.0"
+	vmdBackingAddr2 = "050505:03:00.0"
+)
 
+func TestBackend_substituteVMDAddresses(t *testing.T) {
 	for name, tc := range map[string]struct {
 		inAddrs     *hardware.PCIAddressSet
 		bdevCache   *storage.BdevScanResponse
@@ -189,9 +189,43 @@ func TestBackend_vmdFilterAddresses(t *testing.T) {
 			inVmdAddrs:   mockAddrList(3, 2, 1),
 			expAllowList: mockAddrList(2),
 		},
+		"vmd backing devices allowed": {
+			inReq: &storage.BdevPrepareRequest{
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIAllowList: hardware.MustNewPCIAddressSet(
+					vmdBackingAddr1, vmdBackingAddr2).String(),
+			},
+			inVmdAddrs:   hardware.MustNewPCIAddressSet(vmdAddr, test.MockPCIAddr(1)),
+			expAllowList: hardware.MustNewPCIAddressSet(vmdAddr),
+		},
+		"vmd backing devices blocked": {
+			inReq: &storage.BdevPrepareRequest{
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIBlockList: hardware.MustNewPCIAddressSet(
+					vmdBackingAddr1, vmdBackingAddr2).String(),
+			},
+			inVmdAddrs:   hardware.MustNewPCIAddressSet(vmdAddr, test.MockPCIAddr(1)),
+			expAllowList: hardware.MustNewPCIAddressSet(test.MockPCIAddr(1)),
+		},
+		"vmd backing devices allowed and blocked": {
+			inReq: &storage.BdevPrepareRequest{
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIAllowList: hardware.MustNewPCIAddressSet(
+					vmdBackingAddr1, vmdBackingAddr2, test.MockPCIAddr(1)).String(),
+				PCIBlockList: hardware.MustNewPCIAddressSet(vmdBackingAddr2).String(),
+			},
+			inVmdAddrs:   hardware.MustNewPCIAddressSet(vmdAddr, test.MockPCIAddr(1)),
+			expAllowList: hardware.MustNewPCIAddressSet(test.MockPCIAddr(1)),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			allowList, blockList, gotErr := vmdFilterAddresses(tc.inReq, tc.inVmdAddrs)
+			log, buf := logging.NewTestLogger(name)
+			defer test.ShowBufferOnFailure(t, buf)
+
+			allowList, blockList, gotErr := vmdFilterAddresses(log, tc.inReq, tc.inVmdAddrs)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if gotErr != nil {
 				return
@@ -338,6 +372,44 @@ func TestBackend_updatePrepareRequest(t *testing.T) {
 				PCIAllowList: strings.Join([]string{
 					test.MockPCIAddr(1), test.MockPCIAddr(2),
 				}, " "),
+			},
+		},
+		"vmd enabled; vmds detected; backing devices in allow list": {
+			inReq: &storage.BdevPrepareRequest{
+				EnableVMD:     true,
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIAllowList: hardware.MustNewPCIAddressSet(
+					vmdBackingAddr1, vmdBackingAddr2).String(),
+			},
+			detectVMD: func() (*hardware.PCIAddressSet, error) {
+				return hardware.MustNewPCIAddressSet(vmdAddr, test.MockPCIAddr(1)),
+					nil
+			},
+			expOutReq: &storage.BdevPrepareRequest{
+				EnableVMD:     true,
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIAllowList:  hardware.MustNewPCIAddressSet(vmdAddr).String(),
+			},
+		},
+		"vmd enabled; vmds detected; backing devices in block list": {
+			inReq: &storage.BdevPrepareRequest{
+				EnableVMD:     true,
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIBlockList: hardware.MustNewPCIAddressSet(
+					vmdBackingAddr1, vmdBackingAddr2).String(),
+			},
+			detectVMD: func() (*hardware.PCIAddressSet, error) {
+				return hardware.MustNewPCIAddressSet(vmdAddr, test.MockPCIAddr(1)),
+					nil
+			},
+			expOutReq: &storage.BdevPrepareRequest{
+				EnableVMD:     true,
+				HugePageCount: testNrHugePages,
+				TargetUser:    username,
+				PCIAllowList:  test.MockPCIAddr(1),
 			},
 		},
 	} {


### PR DESCRIPTION
The prepare step during server start-up should prepare the entire VMD
domain of any VMD backing device to be used by an engine. This should
happen if the backing device PCI address is included in server config 
file bdev_lists or provided explicitly in a daos_server nvme prepare
cmdline option. Without this change server start-up will fail if VMD
backing device addresses are included in the server config file. To
implement, the allow list parameter passed when calling into NVMe/SPDK
prepare should be processed to replace backing device addresses with the
endpoint addresses

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
