### PR TITLE
DAOS-12214 tests: VOS unit tests for WAL

### DIFF
--- a/src/bio/bio_wal.c
+++ b/src/bio/bio_wal.c
@@ -1495,6 +1495,10 @@ bio_wal_replay(struct bio_meta_context *mc, int (*replay_cb)(struct umem_action 
 	uint64_t		 tx_id;
 	int			 rc;
 
+	/* FIXME: Skip WAL replay for sysdb for this moment */
+	if (mc->mc_is_sysdb)
+		return 0;
+
 	D_ALLOC(buf, max_blks * blk_bytes);
 	if (buf == NULL)
 		return -DER_NOMEM;

--- a/src/vos/tests/SConscript
+++ b/src/vos/tests/SConscript
@@ -18,7 +18,7 @@ def scons():
     vos_test_src = ['vos_tests.c', 'vts_io.c', 'vts_pool.c', 'vts_container.c',
                     denv.Object("vts_common.c"), 'vts_aggregate.c', 'vts_dtx.c',
                     'vts_gc.c', 'vts_checksum.c', 'vts_ilog.c', 'vts_array.c',
-                    'vts_pm.c', 'vts_ts.c', 'vts_mvcc.c', 'vos_cmd.c',
+                    'vts_pm.c', 'vts_ts.c', 'vts_mvcc.c', 'vos_cmd.c', 'vts_wal.c',
                     '../../object/srv_csum.c', '../../object/srv_io_map.c']
     vos_tests = denv.d_program('vos_tests', vos_test_src, LIBS=libraries)
     denv.AppendUnique(CPPPATH=[Dir('../../common/tests').srcnode()])

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -42,6 +42,7 @@ print_usage()
 	print_message("vos_tests -A|--all <size>\n");
 	print_message("vos_tests -m|--punch_model\n");
 	print_message("vos_tests -C|--mvcc\n");
+	print_message("vos_tests -w|--wal\n");
 	print_message("vos_tests -r|--run_vos_cmd <command>\n");
 	print_message("-S|--storage <storage path>\n");
 	print_message("vos_tests -h|--help\n");
@@ -89,6 +90,7 @@ run_all_tests(int keys, bool nest_iterators)
 		failed += run_dtx_tests(cfg_desc_io);
 		failed += run_ilog_tests(cfg_desc_io);
 		failed += run_csum_extent_tests(cfg_desc_io);
+		failed += run_wal_tests(cfg_desc_io);
 
 		it = "standalone";
 	} else {
@@ -114,7 +116,7 @@ main(int argc, char **argv)
 	int	keys;
 	bool	nest_iterators = false;
 	const char          *vos_command    = NULL;
-	const char          *short_options  = "apcdglzni:mXA:S:hf:e:tCr:";
+	const char          *short_options  = "apcdglzni:mXA:S:hf:e:tCwr:";
 	static struct option long_options[] = {
 	    {"all", required_argument, 0, 'A'},
 	    {"pool", no_argument, 0, 'p'},
@@ -129,6 +131,7 @@ main(int argc, char **argv)
 	    {"ilog", no_argument, 0, 'l'},
 	    {"epoch_cache", no_argument, 0, 't'},
 	    {"mvcc", no_argument, 0, 'C'},
+	    {"wal", no_argument, 0, 'w'},
 	    {"csum", no_argument, 0, 'z'},
 	    {"run_vos_cmd", required_argument, 0, 'r'},
 	    {"help", no_argument, 0, 'h'},
@@ -277,6 +280,10 @@ main(int argc, char **argv)
 			break;
 		case 'C':
 			nr_failed += run_mvcc_tests("");
+			test_run = true;
+			break;
+		case 'w':
+			nr_failed += run_wal_tests("");
 			test_run = true;
 			break;
 		case 'S':

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -130,6 +130,7 @@ int run_ts_tests(const char *cfg);
 int run_ilog_tests(const char *cfg);
 int run_csum_extent_tests(const char *cfg);
 int run_mvcc_tests(const char *cfg);
+int run_wal_tests(const char *cfg);
 int
 run_vos_command(const char *arg0, const char *cmd);
 

--- a/src/vos/tests/vts_wal.c
+++ b/src/vos/tests/vts_wal.c
@@ -1,0 +1,223 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * This file is part of vos/tests/
+ *
+ * vos/tests/vts_wal.c
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <vos_internal.h>
+#include "vts_io.h"
+
+struct wal_test_args {
+	char	*wta_clone;
+	void	*wta_buf;
+	int	 wta_buf_sz;
+};
+
+static int
+teardown_wal_test(void **state)
+{
+	struct wal_test_args	*arg = *state;
+
+	if (arg == NULL) {
+		print_message("state not set, likely due to group-setup issue\n");
+		return 0;
+	}
+
+	unlink(arg->wta_clone);
+	D_FREE(arg->wta_clone);
+	D_FREE(arg->wta_buf);
+	D_FREE(arg);
+	return 0;
+}
+
+static int
+setup_wal_test(void **state)
+{
+	struct wal_test_args	*arg = NULL;
+	char			*pool_name;
+	int			 rc;
+
+	D_ALLOC(arg, sizeof(struct wal_test_args));
+	if (arg == NULL)
+		return -1;
+
+	arg->wta_buf_sz = (32UL << 20);	/* 32MB */
+	D_ALLOC(arg->wta_buf, arg->wta_buf_sz);
+	if (arg->wta_buf == NULL)
+		goto error;
+
+	D_ASPRINTF(arg->wta_clone, "%s/pool_clone", vos_path);
+	if (arg->wta_clone == NULL)
+		goto error;
+
+	rc = vts_pool_fallocate(&pool_name);
+	if (rc)
+		goto error;
+
+	rc = rename(pool_name, arg->wta_clone);
+	if (rc) {
+		unlink(pool_name);
+		free(pool_name);
+		goto error;
+	}
+	free(pool_name);
+
+	*state = arg;
+	return 0;
+error:
+	D_FREE(arg->wta_clone);
+	D_FREE(arg->wta_buf);
+	D_FREE(arg);
+	return -1;
+}
+
+static int
+copy_pool_file(struct wal_test_args *arg, const char *src_pool, const char *dst_pool)
+{
+	struct stat	lstat;
+	uint64_t	copy_sz, left;
+	int		src_fd, dst_fd, rc;
+
+	rc = stat(src_pool, &lstat);
+	if (rc != 0) {
+		D_ERROR("Stat source pool:%s failed. %s\n", src_pool, strerror(errno));
+		return -1;
+	}
+
+	src_fd = open(src_pool, O_RDONLY);
+	if (src_fd < 0) {
+		D_ERROR("Open source pool:%s failed. %s\n", src_pool, strerror(errno));
+		return -1;
+	}
+
+	dst_fd = open(dst_pool, O_WRONLY);
+	if (dst_fd < 0) {
+		D_ERROR("Open dest pool:%s failed. %s\n", dst_pool, strerror(errno));
+		close(src_fd);
+		return -1;
+	}
+
+	left = lstat.st_size;
+	while (left > 0) {
+		ssize_t	read_sz;
+
+		copy_sz = min(left, arg->wta_buf_sz);
+
+		read_sz = read(src_fd, arg->wta_buf, copy_sz);
+		if (read_sz < copy_sz) {
+			D_ERROR("Failed to read "DF_U64" bytes from source pool:%s. %s\n",
+				copy_sz, src_pool, strerror(errno));
+			rc = -1;
+			break;
+		}
+
+		read_sz = write(dst_fd, arg->wta_buf, copy_sz);
+		if (read_sz < copy_sz) {
+			D_ERROR("Failed to write "DF_U64" bytes to dest pool:%s. %s\n",
+				copy_sz, dst_pool, strerror(errno));
+			rc = -1;
+			break;
+		}
+		left -= copy_sz;
+	}
+
+	close(src_fd);
+	close(dst_fd);
+	return rc;
+}
+
+static inline int
+save_pool(struct wal_test_args *arg, const char *pool_name)
+{
+	return copy_pool_file(arg, pool_name, arg->wta_clone);
+}
+
+static inline int
+restore_pool(struct wal_test_args *arg, const char *pool_name)
+{
+	return copy_pool_file(arg, arg->wta_clone, pool_name);
+}
+
+static inline void
+skip_wal_test(void)
+{
+	unsigned int	val = 0;
+
+	d_getenv_int("DAOS_MD_ON_SSD", &val);
+	if (val == 0) {
+		print_message("MD_ON_SSD isn't enabled, skip test\n");
+		skip();
+	}
+	/* FIXME Enable WAL test when meta load & WAL replay is integrated in umem */
+	print_message("WAL replay isn't integrated in umem, skip test\n");
+	skip();
+}
+
+/* Create pool, clear content in tmpfs, open pool by meta blob loading & WAL replay */
+static void
+wal_tst_01(void **state)
+{
+	struct wal_test_args	*arg = *state;
+	char			*pool_name;
+	uuid_t			 pool_id;
+	daos_handle_t		 poh;
+	int			 rc;
+
+	skip_wal_test();
+
+	uuid_generate(pool_id);
+
+	/* Create VOS pool file */
+	rc = vts_pool_fallocate(&pool_name);
+	assert_int_equal(rc, 0);
+
+	/* Save the empty pool file */
+	rc = save_pool(arg, pool_name);
+	assert_int_equal(rc, 0);
+
+	/* Create pool: Create meta & WAL blobs, write meta & WAL header */
+	rc = vos_pool_create(pool_name, pool_id, 0, 0, 0, NULL);
+	assert_int_equal(rc, 0);
+
+	/* Restore pool content from the empty clone */
+	rc = restore_pool(arg, pool_name);
+	assert_int_equal(rc, 0);
+
+	/* Open pool: Open meta & WAL blobs, load meta & WAL header, replay WAL */
+	rc = vos_pool_open(pool_name, pool_id, 0, &poh);
+	assert_int_equal(rc, 0);
+
+	/* Close pool: Flush meta & WAL header, close meta & WAL blobs */
+	rc = vos_pool_close(poh);
+	assert_int_equal(rc, 0);
+
+	/* Destroy pool: Destroy meta & WAL blobs */
+	rc = vos_pool_destroy(pool_name, pool_id);
+	assert_int_equal(rc, 0);
+
+	free(pool_name);
+}
+
+static const struct CMUnitTest wal_tests[] = {
+	{ "WAL01: Basic pool operations",
+	  wal_tst_01, NULL, NULL },
+};
+
+int
+run_wal_tests(const char *cfg)
+{
+	char	test_name[DTS_CFG_MAX];
+
+	dts_create_config(test_name, "WAL Tests %s", cfg);
+	return cmocka_run_group_tests_name(test_name, wal_tests, setup_wal_test,
+					   teardown_wal_test);
+}


### PR DESCRIPTION
Added VOS unit tests to test meta blob loading, WAL replay and checkpoint. This PR only added test infrastructure and single basic pool test as an example, more tests will be added when WAL replay and checkpoint is implemented.

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
