### PR TITLE
DAOS-12043 control: Add unit tests for smd manage with dual-engine

### DIFF
--- a/src/control/server/ctl_smd_rpc_test.go
+++ b/src/control/server/ctl_smd_rpc_test.go
@@ -1078,6 +1078,46 @@ func TestServer_CtlSvc_SmdManage(t *testing.T) {
 				},
 			},
 		},
+		"led-manage; dual-engine": {
+			req: &ctlpb.SmdManageReq{
+				Op: &ctlpb.SmdManageReq_Led{
+					Led: &ctlpb.LedManageReq{
+						// Matches ID returned in initial list query.
+						Ids: test.MockUUID(1),
+					},
+				},
+			},
+			drpcResps: map[int][]*mockDrpcResponse{
+				0: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{pbNormDev},
+						},
+					},
+					{
+						Message: &ctlpb.DevManageResp{
+							Device: pbIdentifyDev,
+						},
+					},
+				},
+				1: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{},
+						},
+					},
+				},
+			},
+			expResp: &ctlpb.SmdManageResp{
+				Ranks: []*ctlpb.SmdManageResp_RankResp{
+					{
+						Results: []*ctlpb.SmdManageResp_Result{
+							{Device: pbIdentifyDev},
+						},
+					},
+				},
+			},
+		},
 		"led-manage; mixed id types in request": {
 			req: &ctlpb.SmdManageReq{
 				Op: &ctlpb.SmdManageReq_Led{
@@ -1199,6 +1239,46 @@ func TestServer_CtlSvc_SmdManage(t *testing.T) {
 				},
 			},
 		},
+		"set-faulty; dual-engine": {
+			req: &ctlpb.SmdManageReq{
+				Op: &ctlpb.SmdManageReq_Faulty{
+					Faulty: &ctlpb.SetFaultyReq{
+						Uuid: test.MockUUID(1),
+					},
+				},
+			},
+			drpcResps: map[int][]*mockDrpcResponse{
+				0: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{},
+						},
+					},
+				},
+				1: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{pbNormDev},
+						},
+					},
+					{
+						Message: &ctlpb.DevManageResp{
+							Device: pbFaultyDev,
+						},
+					},
+				},
+			},
+			expResp: &ctlpb.SmdManageResp{
+				Ranks: []*ctlpb.SmdManageResp_RankResp{
+					{
+						Rank: 1,
+						Results: []*ctlpb.SmdManageResp_Result{
+							{Device: pbFaultyDev},
+						},
+					},
+				},
+			},
+		},
 		"dev-replace; uuid not found": {
 			req: &ctlpb.SmdManageReq{
 				Op: &ctlpb.SmdManageReq_Replace{
@@ -1237,6 +1317,46 @@ func TestServer_CtlSvc_SmdManage(t *testing.T) {
 					{
 						Message: &ctlpb.DevManageResp{
 							Device: pbReplacedDev,
+						},
+					},
+				},
+			},
+			expResp: &ctlpb.SmdManageResp{
+				Ranks: []*ctlpb.SmdManageResp_RankResp{
+					{
+						Results: []*ctlpb.SmdManageResp_Result{
+							{Device: pbReplacedDev},
+						},
+					},
+				},
+			},
+		},
+		"dev-replace; dual-engine": {
+			req: &ctlpb.SmdManageReq{
+				Op: &ctlpb.SmdManageReq_Replace{
+					Replace: &ctlpb.DevReplaceReq{
+						OldDevUuid: test.MockUUID(1),
+						NewDevUuid: test.MockUUID(2),
+					},
+				},
+			},
+			drpcResps: map[int][]*mockDrpcResponse{
+				0: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{pbNormDev},
+						},
+					},
+					{
+						Message: &ctlpb.DevManageResp{
+							Device: pbReplacedDev,
+						},
+					},
+				},
+				1: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{},
 						},
 					},
 				},


### PR DESCRIPTION
Add unit test coverage for SMD manage set-faulty and replace cases with
a dual engine configuration to prevent any regressions.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
