### PR TITLE
DAOS-10844 object: check object existence before unpack

### DIFF
--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -807,12 +807,14 @@ dc_obj_verify_ec_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 				D_GOTO(out, rc);
 			}
 
-			rc = dc_obj_enum_unpack(oid, dova->kds, dova->num, &dova->list_sgl,
-						NULL, dc_obj_verify_ec_cb, dova);
-			if (rc) {
-				D_ERROR(DF_UOID" failed to verify ec object: "DF_RC"\n",
-					DP_UOID(oid), DP_RC(rc));
-				D_GOTO(out, rc);
+			if (!dova->non_exist && dova->num > 0) {
+				rc = dc_obj_enum_unpack(oid, dova->kds, dova->num, &dova->list_sgl,
+							NULL, dc_obj_verify_ec_cb, dova);
+				if (rc) {
+					D_ERROR(DF_UOID" failed to verify ec object: "DF_RC"\n",
+						DP_UOID(oid), DP_RC(rc));
+					D_GOTO(out, rc);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Check object existence after object list before enumeration unpack during EC object verification.

Required-githooks: true

Signed-off-by: Di Wang <di.wang@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
