### PR TITLE
DAOS-12145 chk: misc fixes for chk related issues - IV

### DIFF
--- a/src/chk/chk.pb-c.c
+++ b/src/chk/chk.pb-c.c
@@ -558,8 +558,8 @@ static const ProtobufCEnumValue chk__check_scan_phase__enum_values_by_number[11]
   { "CSP_DTX_RESYNC", "CHK__CHECK_SCAN_PHASE__CSP_DTX_RESYNC", 6 },
   { "CSP_OBJ_SCRUB", "CHK__CHECK_SCAN_PHASE__CSP_OBJ_SCRUB", 7 },
   { "CSP_REBUILD", "CHK__CHECK_SCAN_PHASE__CSP_REBUILD", 8 },
-  { "OSP_AGGREGATION", "CHK__CHECK_SCAN_PHASE__OSP_AGGREGATION", 9 },
-  { "DSP_DONE", "CHK__CHECK_SCAN_PHASE__DSP_DONE", 10 },
+  { "CSP_AGGREGATION", "CHK__CHECK_SCAN_PHASE__CSP_AGGREGATION", 9 },
+  { "CSP_DONE", "CHK__CHECK_SCAN_PHASE__CSP_DONE", 10 },
 };
 static const ProtobufCIntRange chk__check_scan_phase__value_ranges[] = {
 {0, 0},{0, 11}
@@ -575,8 +575,8 @@ static const ProtobufCEnumValueIndex chk__check_scan_phase__enum_values_by_name[
   { "CSP_POOL_MBS", 2 },
   { "CSP_PREPARE", 0 },
   { "CSP_REBUILD", 8 },
-  { "DSP_DONE", 10 },
-  { "OSP_AGGREGATION", 9 },
+  { "CSP_DONE", 10 },
+  { "CSP_AGGREGATION", 9 },
 };
 const ProtobufCEnumDescriptor chk__check_scan_phase__descriptor =
 {

--- a/src/chk/chk.pb-c.h
+++ b/src/chk/chk.pb-c.h
@@ -353,11 +353,11 @@ typedef enum _Chk__CheckScanPhase {
   /*
    * EC aggregation & VOS aggregation.
    */
-  CHK__CHECK_SCAN_PHASE__OSP_AGGREGATION = 9,
+  CHK__CHECK_SCAN_PHASE__CSP_AGGREGATION = 9,
   /*
    * All done.
    */
-  CHK__CHECK_SCAN_PHASE__DSP_DONE = 10
+  CHK__CHECK_SCAN_PHASE__CSP_DONE = 10
     PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(CHK__CHECK_SCAN_PHASE)
 } Chk__CheckScanPhase;
 

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -619,7 +619,7 @@ out:
 
 int
 chk_pool_mbs_remote(d_rank_t rank, uint32_t phase, uint64_t gen, uuid_t uuid, char *label,
-		    uint32_t flags, uint32_t mbs_nr, struct chk_pool_mbs *mbs_array,
+		    uint64_t seq, uint32_t flags, uint32_t mbs_nr, struct chk_pool_mbs *mbs_array,
 		    struct rsvc_hint *hint)
 {
 	crt_rpc_t		*req;
@@ -637,6 +637,7 @@ chk_pool_mbs_remote(d_rank_t rank, uint32_t phase, uint64_t gen, uuid_t uuid, ch
 	cpmi->cpmi_flags = flags;
 	cpmi->cpmi_phase = phase;
 	cpmi->cpmi_label = label;
+	cpmi->cpmi_label_seq = seq;
 	cpmi->cpmi_targets.ca_count = mbs_nr;
 	cpmi->cpmi_targets.ca_arrays = mbs_array;
 
@@ -653,9 +654,9 @@ out:
 		crt_req_decref(req);
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "Sent pool ("DF_UUIDF") members and label %s to rank %u with phase %d gen "
-		 DF_X64": "DF_RC"\n",
-		 DP_UUID(uuid), label != NULL ? label : "(null)", rank, phase, gen, DP_RC(rc));
+		 "Sent pool ("DF_UUIDF") members and label %s ("
+		 DF_X64") to rank %u with phase %d gen "DF_X64": "DF_RC"\n",
+		 DP_UUID(uuid), label != NULL ? label : "(null)", seq, rank, phase, gen, DP_RC(rc));
 
 	return rc;
 }

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -188,8 +188,9 @@ ds_chk_pool_mbs_hdlr(crt_rpc_t *rpc)
 	int			 rc;
 
 	rc = chk_engine_pool_mbs(cpmi->cpmi_gen, cpmi->cpmi_pool, cpmi->cpmi_phase,
-				 cpmi->cpmi_label, cpmi->cpmi_flags, cpmi->cpmi_targets.ca_count,
-				 cpmi->cpmi_targets.ca_arrays, &cpmo->cpmo_hint);
+				 cpmi->cpmi_label, cpmi->cpmi_label_seq, cpmi->cpmi_flags,
+				 cpmi->cpmi_targets.ca_count, cpmi->cpmi_targets.ca_arrays,
+				 &cpmo->cpmo_hint);
 
 	cpmo->cpmo_status = rc;
 	rc = crt_reply_send(rpc);

--- a/src/control/common/proto/chk/chk.pb.go
+++ b/src/control/common/proto/chk/chk.pb.go
@@ -491,8 +491,8 @@ const (
 	CheckScanPhase_CSP_DTX_RESYNC   CheckScanPhase = 6  // DTX resync and cleanup.
 	CheckScanPhase_CSP_OBJ_SCRUB    CheckScanPhase = 7  // RP/EC shards consistency verification with checksum scrub if have.
 	CheckScanPhase_CSP_REBUILD      CheckScanPhase = 8  // Object rebuild.
-	CheckScanPhase_OSP_AGGREGATION  CheckScanPhase = 9  // EC aggregation & VOS aggregation.
-	CheckScanPhase_DSP_DONE         CheckScanPhase = 10 // All done.
+	CheckScanPhase_CSP_AGGREGATION  CheckScanPhase = 9  // EC aggregation & VOS aggregation.
+	CheckScanPhase_CSP_DONE         CheckScanPhase = 10 // All done.
 )
 
 // Enum value maps for CheckScanPhase.
@@ -507,8 +507,8 @@ var (
 		6:  "CSP_DTX_RESYNC",
 		7:  "CSP_OBJ_SCRUB",
 		8:  "CSP_REBUILD",
-		9:  "OSP_AGGREGATION",
-		10: "DSP_DONE",
+		9:  "CSP_AGGREGATION",
+		10: "CSP_DONE",
 	}
 	CheckScanPhase_value = map[string]int32{
 		"CSP_PREPARE":      0,
@@ -520,8 +520,8 @@ var (
 		"CSP_DTX_RESYNC":   6,
 		"CSP_OBJ_SCRUB":    7,
 		"CSP_REBUILD":      8,
-		"OSP_AGGREGATION":  9,
-		"DSP_DONE":         10,
+		"CSP_AGGREGATION":  9,
+		"CSP_DONE":         10,
 	}
 )
 

--- a/src/control/common/proto/mgmt/check.pb.go
+++ b/src/control/common/proto/mgmt/check.pb.go
@@ -638,7 +638,7 @@ type CheckQueryTarget struct {
 	Target uint32              `protobuf:"varint,2,opt,name=target,proto3" json:"target,omitempty"`                          // Target index in the rank.
 	Status chk.CheckInstStatus `protobuf:"varint,3,opt,name=status,proto3,enum=chk.CheckInstStatus" json:"status,omitempty"` // Check instance status on this target - see CheckInstStatus.
 	// Inconsistency statistics during the phases range
-	// [CSP_DTX_RESYNC, OSP_AGGREGATION] for the pool shard on the target.
+	// [CSP_DTX_RESYNC, CSP_AGGREGATION] for the pool shard on the target.
 	Inconsistency *CheckQueryInconsist `protobuf:"bytes,4,opt,name=inconsistency,proto3" json:"inconsistency,omitempty"`
 	// Time information for the pool shard on the target if applicable.
 	Time *CheckQueryTime `protobuf:"bytes,5,opt,name=time,proto3" json:"time,omitempty"`

--- a/src/control/lib/control/check.go
+++ b/src/control/lib/control/check.go
@@ -383,8 +383,8 @@ const (
 	SystemCheckScanPhaseDtxResync        = SystemCheckScanPhase(chkpb.CheckScanPhase_CSP_DTX_RESYNC)
 	SystemCheckScanPhaseObjectScrub      = SystemCheckScanPhase(chkpb.CheckScanPhase_CSP_OBJ_SCRUB)
 	SystemCheckScanPhaseObjectRebuild    = SystemCheckScanPhase(chkpb.CheckScanPhase_CSP_REBUILD)
-	SystemCheckScanPhaseAggregation      = SystemCheckScanPhase(chkpb.CheckScanPhase_OSP_AGGREGATION)
-	SystemCheckScanPhaseDone             = SystemCheckScanPhase(chkpb.CheckScanPhase_DSP_DONE)
+	SystemCheckScanPhaseAggregation      = SystemCheckScanPhase(chkpb.CheckScanPhase_CSP_AGGREGATION)
+	SystemCheckScanPhaseDone             = SystemCheckScanPhase(chkpb.CheckScanPhase_CSP_DONE)
 )
 
 type SystemCheckRepairChoice struct {

--- a/src/control/system/checker/finding.go
+++ b/src/control/system/checker/finding.go
@@ -137,7 +137,7 @@ func descAction(class chkpb.CheckInconsistClass, action chkpb.CheckInconsistActi
 		case contObj:
 			switch class {
 			case chkpb.CheckInconsistClass_CIC_CONT_BAD_LABEL:
-				return fmt.Sprintf("Update the PS label to use the container property value for %s", detMap[1])
+				return fmt.Sprintf("Update the CS label to use the container property value for %s", detMap[1])
 			}
 		}
 		return fmt.Sprintf("Trust the %s result", ro)

--- a/src/control/system/checker/finding_test.go
+++ b/src/control/system/checker/finding_test.go
@@ -244,7 +244,7 @@ func TestChecker_AnnotateFinding(t *testing.T) {
 					Timestamp: "Mon Dec  5 19:25:49 2022",
 					Msg:       "Check engine detects inconsistent container label: new-label (CS) vs six-cont (property).",
 					ActMsgs: []string{
-						"Update the PS label to use the container property value for 00c841c8-4e01-4001-bd58-7de5ad602926",
+						"Update the CS label to use the container property value for 00c841c8-4e01-4001-bd58-7de5ad602926",
 					},
 				}),
 		},

--- a/src/mgmt/check.pb-c.h
+++ b/src/mgmt/check.pb-c.h
@@ -282,7 +282,7 @@ struct  _Mgmt__CheckQueryTarget
   Chk__CheckInstStatus status;
   /*
    * Inconsistency statistics during the phases range
-   * [CSP_DTX_RESYNC, OSP_AGGREGATION] for the pool shard on the target.
+   * [CSP_DTX_RESYNC, CSP_AGGREGATION] for the pool shard on the target.
    */
   Mgmt__CheckQueryInconsist *inconsistency;
   /*

--- a/src/proto/chk/chk.proto
+++ b/src/proto/chk/chk.proto
@@ -186,9 +186,9 @@ enum CheckScanPhase {
 	CSP_DTX_RESYNC = 6; // DTX resync and cleanup.
 	CSP_OBJ_SCRUB = 7; // RP/EC shards consistency verification with checksum scrub if have.
 	CSP_REBUILD = 8; // Object rebuild.
-	OSP_AGGREGATION = 9; // EC aggregation & VOS aggregation.
+	CSP_AGGREGATION = 9; // EC aggregation & VOS aggregation.
 
-	DSP_DONE = 10; // All done.
+	CSP_DONE = 10; // All done.
 }
 
 // DAOS check engine reports the found inconsistency and repair result to control plane.

--- a/src/proto/mgmt/check.proto
+++ b/src/proto/mgmt/check.proto
@@ -101,7 +101,7 @@ message CheckQueryTarget {
 	uint32 target = 2; // Target index in the rank.
 	chk.CheckInstStatus status = 3; // Check instance status on this target - see CheckInstStatus.
 	// Inconsistency statistics during the phases range
-	// [CSP_DTX_RESYNC, OSP_AGGREGATION] for the pool shard on the target.
+	// [CSP_DTX_RESYNC, CSP_AGGREGATION] for the pool shard on the target.
 	CheckQueryInconsist inconsistency = 4;
 	// Time information for the pool shard on the target if applicable.
 	CheckQueryTime time = 5;

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -127,7 +127,7 @@ struct vos_pool_df {
 	/**
 	 * Offset to area for DAOS check related information (chk_pool_info) for this pool.
 	 * The chk_pool_info::cpi_statistics contains the inconsistency statistics during
-	 * the phases range [CSP_DTX_RESYNC, OSP_AGGREGATION] for the pool shard on the target.
+	 * the phases range [CSP_DTX_RESYNC, CSP_AGGREGATION] for the pool shard on the target.
 	 */
 	umem_off_t				pd_chk;
 	/** Unique PoolID for each VOS pool assigned on creation */


### PR DESCRIPTION
It contains the following fixes:

1. Use the same sequence for delay repair inconsistent pool label

When the user choose to trust MS to repair inconsistent pool label,
then the real repair will not be done on the check leader, instead,
it will be postponed until the pool service started and related PS
leader will repair the pool label. After that related check engine
will report the repair result. It should reuse the same sequence#
to allow control plane to locate the original interaction report.

2. Typo fix for CheckScanPhase

Rename OSP_AGGREGATION to CSP_AGGREGATION.
Rename DSP_DONE to CSP_DONE.

3. Fix confused query output with scan phase DONE but RUNNING status.

4. Repair multiple dangling pools via dedicated ULTs concurrently.

Then check and repair for different pools will be totally independent,
even if some one is blocked by interaction, it will not affect others.

5. Fix pending request leak

Link pending request into chk_rank_rec::crr_pending_list on leader.
Then when the rank record is removed, related pending requests can
be cleanup properly.

6. More suitable message for inconsistent container label interaction.

7. Set pool status as 'PENDING' when interact with admin.

8. Return dangling pool info for check query.

9. Fix bug when handle check repair with "for_all" option.

The pending records tree on some check engines may be empty or has been
destroy under the case of check repair with "for_all" option, handle it
properly.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
