### PR TITLE
DAOS-623 build: Improve Go builder for scons

### DIFF
--- a/site_scons/site_tools/go_builder.py
+++ b/site_scons/site_tools/go_builder.py
@@ -33,9 +33,11 @@ def _scan_go_file(node, _env, _path):
                     includes.append(File(os.path.join(src_dir, header)))
                 else:
                     includes.append(f'../../../include/{header}')
-        elif line.strip().startswith(GOINC_PREFIX):
-            deps_dir = line[len(GOINC_PREFIX) + 1:-1]
-            includes.extend(Glob(f'src/{deps_dir}/*.go'))
+        else:
+            goinc_idx = line.find(GOINC_PREFIX)
+            if goinc_idx > -1:
+                deps_dir = line[goinc_idx:][len(GOINC_PREFIX):-1]
+                includes.extend(Glob(f'src/{deps_dir}/*.go'))
 
     return includes
 


### PR DESCRIPTION
The include scanning code needs to take into account
import aliases, so it can't just check that a line
starts with the import string.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
