### PR TITLE
DAOS-11437 test: Support multiple IP addresses per node for test_netw…

### DIFF
--- a/src/tests/ftest/deployment/network_failure.yaml
+++ b/src/tests/ftest/deployment/network_failure.yaml
@@ -39,7 +39,7 @@ pool_size_ratio_80:
   size: 80%
   control_method: dmg
 pool_size_value:
-  size: 50G
+  size: 100G
   control_method: dmg
 
 container_wo_rf:


### PR DESCRIPTION
…… (#10087)

The network failure isolation test was written with the assumption of one IP address per node. However, in Aurora, there are two IP addresses per node. Update
create_ip_to_host() to handle multiple IP addresses.

Also increase pool size for the test.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: target_failure_wo_rf network_failure_isolation
Required-githooks: true
Test-repeat: 5
Signed-off-by: Makito Kano <makito.kano@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
