### PR TITLE
DAOS-10739 Test daos_build against the new vm cluster

### DIFF
--- a/site_scons/daos_build.py
+++ b/site_scons/daos_build.py
@@ -150,6 +150,7 @@ def _configure_mpi_pkg(env, libs):
         print("**********************************")
         raise e
 
+
     # assume mpi is needed in the fallback case
     libs.append('mpi')
     return env.subst("$MPI_PKG")

--- a/site_scons/daos_build.py
+++ b/site_scons/daos_build.py
@@ -150,7 +150,6 @@ def _configure_mpi_pkg(env, libs):
         print("**********************************")
         raise e
 
-
     # assume mpi is needed in the fallback case
     libs.append('mpi')
     return env.subst("$MPI_PKG")

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -3,6 +3,7 @@
   (C) Copyright 2020-2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
+
 """
 
 import os


### PR DESCRIPTION
Previously, ./dfuse/daos_build.py:DaosBuild.test_daos_build test failed with a timeout Test it against a new vm cluster

Test-tag: pr test_daos_build
EL8-VM9-label: new_vm9
Leap15-VM9-label: new_vm9
Skip-func-hw-test: true
Doc-only: false
Signed-off-by: Ray Dennis <ray.dennis@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
