### PR TITLE
DAOS-12250 control: Improve debug logging

### DIFF
--- a/src/control/common/proto/logging.go
+++ b/src/control/common/proto/logging.go
@@ -1,0 +1,165 @@
+//
+// (C) Copyright 2022 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package proto
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	grpcpb "github.com/Jille/raft-grpc-transport/proto"
+	"github.com/daos-stack/daos/src/control/common"
+	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
+	"github.com/daos-stack/daos/src/control/events"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
+)
+
+// ShouldDebug returns true if the protobuf message should be logged.
+func ShouldDebug(msg proto.Message) bool {
+	switch msg.(type) {
+	case *grpcpb.AppendEntriesRequest, *grpcpb.AppendEntriesResponse,
+		*grpcpb.RequestVoteRequest, *grpcpb.RequestVoteResponse,
+		*grpcpb.TimeoutNowRequest, *grpcpb.TimeoutNowResponse,
+		*grpcpb.InstallSnapshotRequest, *grpcpb.InstallSnapshotResponse,
+		*ctlpb.StorageScanResp, *ctlpb.NetworkScanResp,
+		*ctlpb.StorageFormatResp, *ctlpb.PrepareScmResp:
+		return false
+	default:
+		return true
+	}
+}
+
+// Debug returns a string representation of the protobuf message.
+// Certain messages have hand-crafted representations for optimal
+// log density and relevance. The default representation should
+// be sufficient for most messages.
+//
+// NB: This is fairly expensive and should only be invoked when debug
+// logging is enabled.
+func Debug(msg proto.Message) string {
+	if common.InterfaceIsNil(msg) {
+		return fmt.Sprintf("nil %T", msg)
+	}
+
+	var bld strings.Builder
+	switch m := msg.(type) {
+	case *mgmtpb.SystemQueryResp:
+		stateRanks := make(map[string]*ranklist.RankSet)
+		for _, m := range m.Members {
+			if _, found := stateRanks[m.State]; !found {
+				stateRanks[m.State] = &ranklist.RankSet{}
+			}
+			stateRanks[m.State].Add(ranklist.Rank(m.Rank))
+		}
+		fmt.Fprintf(&bld, "%T@%d ", m, m.DataVersion)
+		for state, set := range stateRanks {
+			fmt.Fprintf(&bld, "%s:%s ", state, set.String())
+		}
+	case *mgmtpb.PoolCreateReq:
+		fmt.Fprintf(&bld, "%T uuid:%s u:%s g:%s ", m, m.Uuid, m.User, m.Usergroup)
+		if len(m.Properties) > 0 {
+			fmt.Fprintf(&bld, "p:%+v ", m.Properties)
+		}
+		ranks := &ranklist.RankSet{}
+		for _, r := range m.Ranks {
+			ranks.Add(ranklist.Rank(r))
+		}
+		fmt.Fprintf(&bld, "ranks:%s ", ranks.String())
+		fmt.Fprint(&bld, "tiers:")
+		for i, b := range m.Tierbytes {
+			fmt.Fprintf(&bld, "%d: %d ", i, b)
+			if len(m.Tierratio) > i+1 {
+				fmt.Fprintf(&bld, "(%.02f%%) ", m.Tierratio[i])
+			}
+		}
+	case *mgmtpb.PoolCreateResp:
+		fmt.Fprintf(&bld, "%T ", m)
+		ranks := &ranklist.RankSet{}
+		for _, r := range m.SvcReps {
+			ranks.Add(ranklist.Rank(r))
+		}
+		fmt.Fprintf(&bld, "svc_ranks:%s ", ranks.String())
+		ranks = &ranklist.RankSet{}
+		for _, r := range m.TgtRanks {
+			ranks.Add(ranklist.Rank(r))
+		}
+		fmt.Fprintf(&bld, "tgt_ranks:%s ", ranks.String())
+		fmt.Fprint(&bld, "tiers:")
+		for i, b := range m.TierBytes {
+			fmt.Fprintf(&bld, "%d:%d ", i, b)
+		}
+	case *mgmtpb.ListPoolsResp:
+		fmt.Fprintf(&bld, "%T%d %d pools:", m, m.DataVersion, len(m.Pools))
+		for _, p := range m.Pools {
+			fmt.Fprintf(&bld, " %s:%s", p.Label, p.State)
+		}
+	case *mgmtpb.JoinResp:
+		fmt.Fprintf(&bld, "%T rank:%d (state:%s, local:%t)", m, m.Rank, m.State, m.LocalJoin)
+	case *mgmtpb.GetAttachInfoResp:
+		msRanks := ranklist.RankSetFromRanks(ranklist.RanksFromUint32(m.MsRanks))
+		uriRanks := ranklist.NewRankSet()
+		for _, ru := range m.RankUris {
+			uriRanks.Add(ranklist.Rank(ru.Rank))
+		}
+		fmt.Fprintf(&bld, "%T@%d ms:%s ranks:%s client:%+v", m, m.DataVersion, msRanks.String(), uriRanks.String(), m.ClientNetHint)
+	case *mgmtpb.LeaderQueryResp:
+		fmt.Fprintf(&bld, "%T leader:%s reps:%s", m, m.CurrentLeader, strings.Join(m.Replicas, ","))
+	case *sharedpb.ClusterEventReq:
+		fmt.Fprintf(&bld, "%T seq:%d", m, m.Sequence)
+		if m.Event == nil {
+			break
+		}
+		fmt.Fprintf(&bld, " evt: ts:%s ", m.Event.Timestamp)
+		switch m.Event.Id {
+		case events.RASSwimRankDead.Uint32():
+			fmt.Fprintf(&bld, "host %s@%d: rank %d is dead", m.Event.Hostname, m.Event.Incarnation, m.Event.Rank)
+		case events.RASPoolRepsUpdate.Uint32():
+			fmt.Fprintf(&bld, "pool %s: svc reps upd", m.Event.PoolUuid)
+			if m.Event.ExtendedInfo == nil {
+				break
+			}
+			if psi, ok := m.Event.ExtendedInfo.(*sharedpb.RASEvent_PoolSvcInfo); ok {
+				svcRanks := ranklist.RankSetFromRanks(ranklist.RanksFromUint32(psi.PoolSvcInfo.SvcReps))
+				fmt.Fprintf(&bld, ": %s", svcRanks.String())
+			}
+		default:
+			fmt.Fprintf(&bld, "(%+v)", m.Event)
+		}
+	case *ctlpb.RanksResp, *mgmtpb.SystemStartResp, *mgmtpb.SystemStopResp, *mgmtpb.SystemExcludeResp, *mgmtpb.SystemEraseResp:
+		fmt.Fprintf(&bld, "%T", m)
+		if rg, ok := m.(interface{ GetResults() []*sharedpb.RankResult }); ok {
+			resMap := make(map[string]*ranklist.RankSet)
+			for _, res := range rg.GetResults() {
+				if resMap[res.State] == nil {
+					resMap[res.State] = ranklist.NewRankSet()
+				}
+				resMap[res.State].Add(ranklist.Rank(res.Rank))
+			}
+			for state, ranks := range resMap {
+				fmt.Fprintf(&bld, " %s:%s", state, ranks.String())
+			}
+		}
+	default:
+		fmt.Fprintf(&bld, "%T", m)
+		if vm, ok := m.(interface{ GetDataVersion() uint64 }); ok {
+			fmt.Fprintf(&bld, "@%d", vm.GetDataVersion())
+		}
+		if sr, ok := m.(interface{ GetStatus() int32 }); ok {
+			fmt.Fprintf(&bld, " status:%s", daos.Status(sr.GetStatus()))
+		}
+		dbg := fmt.Sprintf("%+v", m)
+		if len(dbg) > 0 {
+			fmt.Fprintf(&bld, " (%s)", dbg)
+		}
+	}
+
+	return bld.String()
+}

--- a/src/control/common/proto/mgmt/addons.go
+++ b/src/control/common/proto/mgmt/addons.go
@@ -8,14 +8,8 @@ package mgmt
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
 
 	"github.com/google/uuid"
-	"google.golang.org/protobuf/proto"
-
-	"github.com/daos-stack/daos/src/control/lib/daos"
-	"github.com/daos-stack/daos/src/control/lib/ranklist"
 )
 
 func (p *PoolProperty) UnmarshalJSON(b []byte) error {
@@ -218,71 +212,4 @@ func (r *ListContReq) SetSvcRanks(rl []uint32) {
 // SetUUID sets the request's ID to a UUID.
 func (r *ListContReq) SetUUID(id uuid.UUID) {
 	r.Id = id.String()
-}
-
-func Debug(msg proto.Message) string {
-	var bld strings.Builder
-	switch m := msg.(type) {
-	case *SystemQueryResp:
-		stateRanks := make(map[string]*ranklist.RankSet)
-		for _, m := range m.Members {
-			if _, found := stateRanks[m.State]; !found {
-				stateRanks[m.State] = &ranklist.RankSet{}
-			}
-			stateRanks[m.State].Add(ranklist.Rank(m.Rank))
-		}
-		fmt.Fprintf(&bld, "%T@%d ", m, m.DataVersion)
-		for state, set := range stateRanks {
-			fmt.Fprintf(&bld, "%s:%s ", state, set.String())
-		}
-	case *PoolCreateReq:
-		fmt.Fprintf(&bld, "%T uuid:%s u:%s g:%s ", m, m.Uuid, m.User, m.Usergroup)
-		if len(m.Properties) > 0 {
-			fmt.Fprintf(&bld, "p:%+v ", m.Properties)
-		}
-		ranks := &ranklist.RankSet{}
-		for _, r := range m.Ranks {
-			ranks.Add(ranklist.Rank(r))
-		}
-		fmt.Fprintf(&bld, "ranks:%s ", ranks.String())
-		fmt.Fprint(&bld, "tiers:")
-		for i, b := range m.Tierbytes {
-			fmt.Fprintf(&bld, "%d: %d ", i, b)
-			if len(m.Tierratio) > i+1 {
-				fmt.Fprintf(&bld, "(%.02f%%) ", m.Tierratio[i])
-			}
-		}
-	case *PoolCreateResp:
-		fmt.Fprintf(&bld, "%T ", m)
-		ranks := &ranklist.RankSet{}
-		for _, r := range m.SvcReps {
-			ranks.Add(ranklist.Rank(r))
-		}
-		fmt.Fprintf(&bld, "svc_ranks:%s ", ranks.String())
-		ranks = &ranklist.RankSet{}
-		for _, r := range m.TgtRanks {
-			ranks.Add(ranklist.Rank(r))
-		}
-		fmt.Fprintf(&bld, "tgt_ranks:%s ", ranks.String())
-		fmt.Fprint(&bld, "tiers:")
-		for i, b := range m.TierBytes {
-			fmt.Fprintf(&bld, "%d:%d ", i, b)
-		}
-	case *JoinResp:
-		fmt.Fprintf(&bld, "%T rank:%d (state:%s, local:%t)", m, m.Rank, m.State, m.LocalJoin)
-	default:
-		fmt.Fprintf(&bld, "%T", m)
-		if vm, ok := m.(interface{ GetDataVersion() uint64 }); ok {
-			fmt.Fprintf(&bld, "@%d", vm.GetDataVersion())
-		}
-		if sr, ok := m.(interface{ GetStatus() int32 }); ok {
-			fmt.Fprintf(&bld, " status:%s", daos.Status(sr.GetStatus()))
-		}
-		dbg := fmt.Sprintf("%+v", m)
-		if len(dbg) > 0 {
-			fmt.Fprintf(&bld, " (%s)", dbg)
-		}
-	}
-
-	return bld.String()
 }

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
+	pbUtil "github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/fault"
@@ -262,7 +263,7 @@ func PoolCreate(ctx context.Context, rpcClient UnaryInvoker, req *PoolCreateReq)
 		return mgmtpb.NewMgmtSvcClient(conn).PoolCreate(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Create DAOS pool request: %+v\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Create DAOS pool request: %+v\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -299,7 +300,7 @@ func PoolDestroy(ctx context.Context, rpcClient UnaryInvoker, req *PoolDestroyRe
 		return mgmtpb.NewMgmtSvcClient(conn).PoolDestroy(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Destroy DAOS pool request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Destroy DAOS pool request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -334,7 +335,7 @@ func PoolUpgrade(ctx context.Context, rpcClient UnaryInvoker, req *PoolUpgradeRe
 		return mgmtpb.NewMgmtSvcClient(conn).PoolUpgrade(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Upgrade DAOS pool request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Upgrade DAOS pool request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -361,7 +362,7 @@ func PoolEvict(ctx context.Context, rpcClient UnaryInvoker, req *PoolEvictReq) e
 		return mgmtpb.NewMgmtSvcClient(conn).PoolEvict(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Evict DAOS pool request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Evict DAOS pool request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -590,7 +591,7 @@ func PoolQuery(ctx context.Context, rpcClient UnaryInvoker, req *PoolQueryReq) (
 		return mgmtpb.NewMgmtSvcClient(conn).PoolQuery(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Query DAOS pool request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Query DAOS pool request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -613,7 +614,7 @@ func PoolQueryTargets(ctx context.Context, rpcClient UnaryInvoker, req *PoolQuer
 		return mgmtpb.NewMgmtSvcClient(conn).PoolQueryTarget(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Query DAOS pool targets request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Query DAOS pool targets request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -759,7 +760,7 @@ func PoolSetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolSetPropRe
 		return mgmtpb.NewMgmtSvcClient(conn).PoolSetProp(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS pool set-prop request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS pool set-prop request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -808,7 +809,7 @@ func PoolGetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetPropRe
 		return mgmtpb.NewMgmtSvcClient(conn).PoolGetProp(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("pool get-prop request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("pool get-prop request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -908,7 +909,7 @@ func PoolDrain(ctx context.Context, rpcClient UnaryInvoker, req *PoolDrainReq) e
 		return mgmtpb.NewMgmtSvcClient(conn).PoolDrain(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Drain DAOS pool target request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Drain DAOS pool target request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -947,7 +948,7 @@ func PoolExtend(ctx context.Context, rpcClient UnaryInvoker, req *PoolExtendReq)
 		return mgmtpb.NewMgmtSvcClient(conn).PoolExtend(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Extend DAOS pool request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Extend DAOS pool request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -981,7 +982,7 @@ func PoolReintegrate(ctx context.Context, rpcClient UnaryInvoker, req *PoolReint
 		return mgmtpb.NewMgmtSvcClient(conn).PoolReintegrate(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Reintegrate DAOS pool target request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Reintegrate DAOS pool target request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -1141,7 +1142,7 @@ func ListPools(ctx context.Context, rpcClient UnaryInvoker, req *ListPoolsReq) (
 		return mgmtpb.NewMgmtSvcClient(conn).ListPools(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system list-pools request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system list-pools request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err

--- a/src/control/lib/control/pool_acl.go
+++ b/src/control/lib/control/pool_acl.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
+	pbUtil "github.com/daos-stack/daos/src/control/common/proto"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
@@ -38,7 +39,7 @@ func PoolGetACL(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetACLReq)
 		return mgmtpb.NewMgmtSvcClient(conn).PoolGetACL(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Get DAOS pool ACL request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Get DAOS pool ACL request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -80,7 +81,7 @@ func PoolOverwriteACL(ctx context.Context, rpcClient UnaryInvoker, req *PoolOver
 		return mgmtpb.NewMgmtSvcClient(conn).PoolOverwriteACL(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Overwrite DAOS pool ACL request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Overwrite DAOS pool ACL request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -123,7 +124,7 @@ func PoolUpdateACL(ctx context.Context, rpcClient UnaryInvoker, req *PoolUpdateA
 		return mgmtpb.NewMgmtSvcClient(conn).PoolUpdateACL(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Update DAOS pool ACL request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Update DAOS pool ACL request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -165,7 +166,7 @@ func PoolDeleteACL(ctx context.Context, rpcClient UnaryInvoker, req *PoolDeleteA
 		return mgmtpb.NewMgmtSvcClient(conn).PoolDeleteACL(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("Delete DAOS pool ACL request: %s\n", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("Delete DAOS pool ACL request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err

--- a/src/control/lib/control/response.go
+++ b/src/control/lib/control/response.go
@@ -15,9 +15,9 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
+	pbUtil "github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
-	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
 )
 
@@ -251,7 +251,7 @@ func (ur *UnaryResponse) getMSResponse() (proto.Message, error) {
 		return nil, err
 	}
 
-	ur.debugf("%s: %s", msr.Addr, mgmtpb.Debug(msr.Message))
+	ur.debugf("%s: %s", msr.Addr, pbUtil.Debug(msr.Message))
 	return msr.Message, nil
 }
 

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/daos-stack/daos/src/control/build"
+	pbUtil "github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
@@ -244,7 +245,7 @@ func SystemQuery(ctx context.Context, rpcClient UnaryInvoker, req *SystemQueryRe
 		return nil
 	}
 
-	rpcClient.Debugf("DAOS system query request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system query request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -330,7 +331,7 @@ func SystemStart(ctx context.Context, rpcClient UnaryInvoker, req *SystemStartRe
 		return mgmtpb.NewMgmtSvcClient(conn).SystemStart(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system start request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system start request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -402,7 +403,7 @@ func SystemStop(ctx context.Context, rpcClient UnaryInvoker, req *SystemStopReq)
 		return mgmtpb.NewMgmtSvcClient(conn).SystemStop(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system stop request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system stop request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -476,7 +477,7 @@ func SystemExclude(ctx context.Context, rpcClient UnaryInvoker, req *SystemExclu
 		return mgmtpb.NewMgmtSvcClient(conn).SystemExclude(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system exclude request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system exclude request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -563,7 +564,7 @@ func SystemErase(ctx context.Context, rpcClient UnaryInvoker, req *SystemEraseRe
 		return system.ErrRaftUnavail
 	}
 
-	rpcClient.Debugf("DAOS system-erase request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system-erase request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -622,7 +623,7 @@ func LeaderQuery(ctx context.Context, rpcClient UnaryInvoker, req *LeaderQueryRe
 		return mgmtpb.NewMgmtSvcClient(conn).LeaderQuery(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system leader-query request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system leader-query request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -725,7 +726,7 @@ func PrepShutdownRanks(ctx context.Context, rpcClient UnaryInvoker, req *RanksRe
 		return ctlpb.NewCtlSvcClient(conn).PrepShutdownRanks(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system prep shutdown-ranks request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system prep shutdown-ranks request: %s", pbUtil.Debug(pbReq))
 	return invokeRPCFanout(ctx, rpcClient, req)
 }
 
@@ -746,7 +747,7 @@ func StopRanks(ctx context.Context, rpcClient UnaryInvoker, req *RanksReq) (*Ran
 		return ctlpb.NewCtlSvcClient(conn).StopRanks(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system stop-ranks request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system stop-ranks request: %s", pbUtil.Debug(pbReq))
 	return invokeRPCFanout(ctx, rpcClient, req)
 }
 
@@ -767,7 +768,7 @@ func ResetFormatRanks(ctx context.Context, rpcClient UnaryInvoker, req *RanksReq
 		return ctlpb.NewCtlSvcClient(conn).ResetFormatRanks(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system reset-format-ranks request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system reset-format-ranks request: %s", pbUtil.Debug(pbReq))
 	return invokeRPCFanout(ctx, rpcClient, req)
 }
 
@@ -788,7 +789,7 @@ func StartRanks(ctx context.Context, rpcClient UnaryInvoker, req *RanksReq) (*Ra
 		return ctlpb.NewCtlSvcClient(conn).StartRanks(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system start-ranks request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system start-ranks request: %s", pbUtil.Debug(pbReq))
 	return invokeRPCFanout(ctx, rpcClient, req)
 }
 
@@ -809,7 +810,7 @@ func PingRanks(ctx context.Context, rpcClient UnaryInvoker, req *RanksReq) (*Ran
 		return ctlpb.NewCtlSvcClient(conn).PingRanks(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system ping-ranks request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system ping-ranks request: %s", pbUtil.Debug(pbReq))
 	return invokeRPCFanout(ctx, rpcClient, req)
 }
 
@@ -869,7 +870,7 @@ func SystemCleanup(ctx context.Context, rpcClient UnaryInvoker, req *SystemClean
 		return mgmtpb.NewMgmtSvcClient(conn).SystemCleanup(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS system cleanup request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS system cleanup request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -904,7 +905,7 @@ func SystemSetAttr(ctx context.Context, rpcClient UnaryInvoker, req *SystemSetAt
 		return mgmtpb.NewMgmtSvcClient(conn).SystemSetAttr(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS SystemSetAttr request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS SystemSetAttr request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -942,7 +943,7 @@ func SystemGetAttr(ctx context.Context, rpcClient UnaryInvoker, req *SystemGetAt
 		return mgmtpb.NewMgmtSvcClient(conn).SystemGetAttr(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS SystemGetAttr request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS SystemGetAttr request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err
@@ -980,7 +981,7 @@ func SystemSetProp(ctx context.Context, rpcClient UnaryInvoker, req *SystemSetPr
 		return mgmtpb.NewMgmtSvcClient(conn).SystemSetProp(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS SystemSetProp request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS SystemSetProp request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err
@@ -1020,7 +1021,7 @@ func SystemGetProp(ctx context.Context, rpcClient UnaryInvoker, req *SystemGetPr
 		return mgmtpb.NewMgmtSvcClient(conn).SystemGetProp(ctx, pbReq)
 	})
 
-	rpcClient.Debugf("DAOS SystemGetProp request: %s", mgmtpb.Debug(pbReq))
+	rpcClient.Debugf("DAOS SystemGetProp request: %s", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return nil, err

--- a/src/control/logging/logger.go
+++ b/src/control/logging/logger.go
@@ -15,6 +15,7 @@ import (
 type (
 	// Logger defines a standard logging interface
 	Logger interface {
+		EnabledFor(level LogLevel) bool
 		DebugLogger
 		Debug(msg string)
 		InfoLogger
@@ -84,6 +85,12 @@ func (ll *LeveledLogger) SetLevel(newLevel LogLevel) {
 // Level returns the logger's current LogLevel.
 func (ll *LeveledLogger) Level() LogLevel {
 	return ll.level.Get()
+}
+
+// EnabledFor returns true if the logger is enabled for the
+// specified LogLevel.
+func (ll *LeveledLogger) EnabledFor(level LogLevel) bool {
+	return ll.level.Get() >= level
 }
 
 // ClearLevel clears all loggers for the specified level.

--- a/src/control/server/ctl_firmware.go
+++ b/src/control/server/ctl_firmware.go
@@ -23,8 +23,6 @@ import (
 // caller's request parameters. It can fetch firmware information for NVMe, SCM,
 // or both.
 func (svc *ControlService) FirmwareQuery(parent context.Context, pbReq *ctlpb.FirmwareQueryReq) (*ctlpb.FirmwareQueryResp, error) {
-	svc.log.Debug("received FirmwareQuery RPC")
-
 	pbResp := new(ctlpb.FirmwareQueryResp)
 
 	if pbReq.QueryScm {
@@ -43,7 +41,6 @@ func (svc *ControlService) FirmwareQuery(parent context.Context, pbReq *ctlpb.Fi
 		pbResp.NvmeResults = nvmeResults
 	}
 
-	svc.log.Debug("responding to FirmwareQuery RPC")
 	return pbResp, nil
 }
 
@@ -104,8 +101,6 @@ func (svc *ControlService) queryNVMeFirmware(pbReq *ctlpb.FirmwareQueryReq) ([]*
 //
 // It updates the firmware on the storage devices of the specified type.
 func (svc *ControlService) FirmwareUpdate(parent context.Context, pbReq *ctlpb.FirmwareUpdateReq) (*ctlpb.FirmwareUpdateResp, error) {
-	svc.log.Debug("received FirmwareUpdate RPC")
-
 	instances := svc.harness.Instances()
 	for _, srv := range instances {
 		if srv.IsStarted() {
@@ -132,7 +127,6 @@ func (svc *ControlService) FirmwareUpdate(parent context.Context, pbReq *ctlpb.F
 		return nil, err
 	}
 
-	svc.log.Debug("responding to FirmwareUpdate RPC")
 	return pbResp, nil
 }
 

--- a/src/control/server/ctl_network_rpc.go
+++ b/src/control/server/ctl_network_rpc.go
@@ -18,8 +18,6 @@ import (
 
 // NetworkScan retrieves details of network interfaces on remote hosts.
 func (c *ControlService) NetworkScan(ctx context.Context, req *ctlpb.NetworkScanReq) (*ctlpb.NetworkScanResp, error) {
-	c.log.Debugf("NetworkScanDevices() Received request: %s", req.GetProvider())
-
 	provider := c.srvCfg.Fabric.Provider
 	switch {
 	case strings.EqualFold(req.GetProvider(), "all"):
@@ -46,9 +44,6 @@ func (c *ControlService) NetworkScan(ctx context.Context, req *ctlpb.NetworkScan
 
 	resp.Numacount = int32(topo.NumNUMANodes())
 	resp.Corespernuma = int32(topo.NumCoresPerNUMA())
-
-	c.log.Debugf("NetworkScanResp: %d NUMA nodes with %d cores each",
-		resp.GetNumacount(), resp.GetCorespernuma())
 
 	return resp, nil
 }

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -166,7 +166,6 @@ func (svc *ControlService) StopRanks(ctx context.Context, req *ctlpb.RanksReq) (
 	if len(req.GetRanks()) == 0 {
 		return nil, errors.New("no ranks specified in request")
 	}
-	svc.log.Debugf("CtlSvc.StopRanks dispatch, req:%+v\n", req)
 
 	signal := syscall.SIGINT
 	if req.Force {
@@ -205,8 +204,6 @@ func (svc *ControlService) StopRanks(ctx context.Context, req *ctlpb.RanksReq) (
 	if err := convert.Types(results, &resp.Results); err != nil {
 		return nil, err
 	}
-
-	svc.log.Debugf("CtlSvc.StopRanks dispatch, resp:%+v\n", resp)
 
 	return resp, nil
 }
@@ -253,8 +250,6 @@ func (svc *ControlService) PingRanks(ctx context.Context, req *ctlpb.RanksReq) (
 		return nil, errors.New("no ranks specified in request")
 	}
 
-	svc.log.Debugf("CtlSvc.PingRanks dispatch, req:%+v\n", req)
-
 	results, err := svc.queryLocalRanks(ctx, req)
 	if err != nil {
 		return nil, err
@@ -264,8 +259,6 @@ func (svc *ControlService) PingRanks(ctx context.Context, req *ctlpb.RanksReq) (
 	if err := convert.Types(results, &resp.Results); err != nil {
 		return nil, err
 	}
-
-	svc.log.Debugf("CtlSvc.PingRanks dispatch, resp:%+v\n", resp)
 
 	return resp, nil
 }
@@ -286,7 +279,6 @@ func (svc *ControlService) ResetFormatRanks(ctx context.Context, req *ctlpb.Rank
 	if len(req.GetRanks()) == 0 {
 		return nil, errors.New("no ranks specified in request")
 	}
-	svc.log.Debugf("CtlSvc.ResetFormatRanks dispatch, req:%+v\n", req)
 
 	instances, err := svc.harness.FilterInstancesByRankSet(req.GetRanks())
 	if err != nil {
@@ -332,8 +324,6 @@ func (svc *ControlService) ResetFormatRanks(ctx context.Context, req *ctlpb.Rank
 		return nil, err
 	}
 
-	svc.log.Debugf("CtlSvc.ResetFormatRanks dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -350,7 +340,6 @@ func (svc *ControlService) StartRanks(ctx context.Context, req *ctlpb.RanksReq) 
 	if len(req.GetRanks()) == 0 {
 		return nil, errors.New("no ranks specified in request")
 	}
-	svc.log.Debugf("CtlSvc.StartRanks dispatch, req:%+v\n", req)
 
 	instances, err := svc.harness.FilterInstancesByRankSet(req.GetRanks())
 	if err != nil {
@@ -380,8 +369,6 @@ func (svc *ControlService) StartRanks(ctx context.Context, req *ctlpb.RanksReq) 
 		return nil, err
 	}
 
-	svc.log.Debugf("CtlSvc.StartRanks dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -390,8 +377,6 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 	if req == nil {
 		return nil, errors.New("nil request")
 	}
-
-	svc.log.Debugf("CtlSvc.SetEngineLogMasks dispatch, req:%+v\n", req)
 
 	var errs []string
 
@@ -433,8 +418,6 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 	}
 
 	resp := new(ctlpb.SetLogMasksResp)
-
-	svc.log.Debugf("CtlSvc.SetEngineLogMasks dispatch, resp:%+v\n", resp)
 
 	return resp, nil
 }

--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -191,8 +191,6 @@ func (svc *ControlService) querySmdPools(ctx context.Context, req *ctlpb.SmdQuer
 //
 // Query SMD info for pools or devices.
 func (svc *ControlService) SmdQuery(ctx context.Context, req *ctlpb.SmdQueryReq) (*ctlpb.SmdQueryResp, error) {
-	svc.log.Debugf("CtlSvc.SmdQuery dispatch, req:%+v\n", *req)
-
 	if !svc.harness.isStarted() {
 		return nil, FaultHarnessNotStarted
 	}
@@ -219,7 +217,6 @@ func (svc *ControlService) SmdQuery(ctx context.Context, req *ctlpb.SmdQueryReq)
 		}
 	}
 
-	svc.log.Debugf("CtlSvc.SmdQuery dispatch, resp:%+v\n", *resp)
 	return resp, nil
 }
 
@@ -469,6 +466,5 @@ func (svc *ControlService) SmdManage(ctx context.Context, req *ctlpb.SmdManageRe
 
 	resp := &ctlpb.SmdManageResp{Ranks: rankResps}
 
-	svc.log.Debugf("CtlSvc.SmdManage dispatch, resp:%+v\n", *resp)
 	return resp, nil
 }

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -292,8 +292,6 @@ func (c *ControlService) adjustScmSize(resp *ctlpb.ScanScmResp) {
 
 // StorageScan discovers non-volatile storage hardware on node.
 func (c *ControlService) StorageScan(ctx context.Context, req *ctlpb.StorageScanReq) (*ctlpb.StorageScanResp, error) {
-	c.log.Debugf("received StorageScan RPC %v", req)
-
 	if req == nil {
 		return nil, errors.New("nil request")
 	}
@@ -325,8 +323,6 @@ func (c *ControlService) StorageScan(ctx context.Context, req *ctlpb.StorageScan
 		return nil, err
 	}
 
-	c.log.Debug("responding to StorageScan RPC")
-
 	return resp, nil
 }
 
@@ -344,8 +340,6 @@ func (c *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageFo
 	resp.Mrets = make([]*ctlpb.ScmMountResult, 0, len(instances))
 	resp.Crets = make([]*ctlpb.NvmeControllerResult, 0, len(instances))
 	scmChan := make(chan *ctlpb.ScmMountResult, len(instances))
-
-	c.log.Debugf("received StorageFormat RPC %v", req)
 
 	// TODO: enable per-instance formatting
 	formatting := 0
@@ -415,8 +409,6 @@ func (c *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageFo
 
 // StorageNvmeRebind rebinds SSD from kernel and binds to user-space to allow DAOS to use it.
 func (c *ControlService) StorageNvmeRebind(ctx context.Context, req *ctlpb.NvmeRebindReq) (*ctlpb.NvmeRebindResp, error) {
-	c.log.Debugf("received StorageNvmeRebind RPC %v", req)
-
 	if req == nil {
 		return nil, errors.New("nil request")
 	}
@@ -447,8 +439,6 @@ func (c *ControlService) StorageNvmeRebind(ctx context.Context, req *ctlpb.NvmeR
 		return resp, nil // report prepare call result in response
 	}
 
-	c.log.Debug("responding to StorageNvmeRebind RPC")
-
 	return resp, nil
 }
 
@@ -456,8 +446,6 @@ func (c *ControlService) StorageNvmeRebind(ctx context.Context, req *ctlpb.NvmeR
 //
 // If StorageTierIndex is set to -1 in request, add the device to the first configured bdev tier.
 func (c *ControlService) StorageNvmeAddDevice(ctx context.Context, req *ctlpb.NvmeAddDeviceReq) (resp *ctlpb.NvmeAddDeviceResp, err error) {
-	c.log.Debugf("received StorageNvmeAddDevice RPC %v", req)
-
 	if req == nil {
 		return nil, errors.New("nil request")
 	}
@@ -508,8 +496,6 @@ func (c *ControlService) StorageNvmeAddDevice(ctx context.Context, req *ctlpb.Nv
 			Status: ctlpb.ResponseStatus_CTL_ERR_NVME,
 		}
 	}
-
-	c.log.Debug("responding to StorageNvmeAddDevice RPC")
 
 	return resp, nil
 }

--- a/src/control/server/interceptors.go
+++ b/src/control/server/interceptors.go
@@ -9,6 +9,7 @@ package server
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -17,11 +18,14 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
+	"github.com/daos-stack/daos/src/control/system"
 )
 
 func componentFromContext(ctx context.Context) (comp *security.Component, err error) {
@@ -204,4 +208,53 @@ func unaryStatusInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 	}
 
 	return res, err
+}
+
+// isSentinelErr indicates whether or not the error is a sentinel
+// error used to convey a specific state to the client.
+func isSentinelErr(err error) bool {
+	return system.IsNotReady(err) || system.IsNotReplica(err) || system.IsNotLeader(err)
+}
+
+// unaryLoggingInterceptor generates a grpc.UnaryServerInterceptor that
+// will log an error if the RPC handler returned an error. If debugging is
+// enabled, it will also log the request and response messages.
+//
+// NB: This interceptor should be the last in the chain, i.e. first in the
+// list of interceptors passed to grpc.NewServer.
+func unaryLoggingInterceptor(log logging.Logger) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		startTime := time.Now()
+		res, err := handler(ctx, req)
+		elapsed := time.Since(startTime)
+		logErr := err
+		if logErr != nil {
+			// Unwrap the message if it's a gRPC status error.
+			if st, ok := status.FromError(err); ok {
+				logErr = proto.UnwrapError(st)
+			}
+		}
+
+		// If the error is nil or is not a sentinel error, log the request.
+		// We don't want to log sentinel errors because they're spammy and
+		// don't provide any useful debug information.
+		if logErr == nil || !isSentinelErr(logErr) {
+			if m, ok := req.(protoreflect.ProtoMessage); ok && log.EnabledFor(logging.LogLevelDebug) && proto.ShouldDebug(m) {
+				log.Debugf("gRPC request: %s", proto.Debug(m))
+			}
+		}
+
+		// Log the unwrapped error if it's not a sentinel error.
+		if logErr != nil {
+			if !isSentinelErr(logErr) {
+				log.Errorf("gRPC handler for %T failed: %s (elapsed: %s)", req, logErr, elapsed)
+			}
+			return res, err
+		}
+
+		if m, ok := res.(protoreflect.ProtoMessage); ok && log.EnabledFor(logging.LogLevelDebug) && proto.ShouldDebug(m) {
+			log.Debugf("gRPC response for %T: %s (elapsed: %s)", req, proto.Debug(m), elapsed)
+		}
+		return res, err
+	}
 }

--- a/src/control/server/mgmt_cont.go
+++ b/src/control/server/mgmt_cont.go
@@ -21,7 +21,6 @@ func (svc *mgmtSvc) ListContainers(ctx context.Context, req *mgmtpb.ListContReq)
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.ListContainers dispatch, req:%+v\n", *req)
 
 	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodListContainers, req)
 	if err != nil {
@@ -33,8 +32,6 @@ func (svc *mgmtSvc) ListContainers(ctx context.Context, req *mgmtpb.ListContReq)
 		return nil, errors.Wrap(err, "unmarshal ListContainers response")
 	}
 
-	svc.log.Debugf("MgmtSvc.ListContainers dispatch, resp:%+v\n", *resp)
-
 	return resp, nil
 }
 
@@ -43,7 +40,6 @@ func (svc *mgmtSvc) ContSetOwner(ctx context.Context, req *mgmtpb.ContSetOwnerRe
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.ContSetOwner dispatch, req:%+v\n", *req)
 
 	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodContSetOwner, req)
 	if err != nil {
@@ -54,8 +50,6 @@ func (svc *mgmtSvc) ContSetOwner(ctx context.Context, req *mgmtpb.ContSetOwnerRe
 	if err = proto.Unmarshal(dresp.Body, resp); err != nil {
 		return nil, errors.Wrap(err, "unmarshal ContSetOwner response")
 	}
-
-	svc.log.Debugf("MgmtSvc.ContSetOwner dispatch, resp:%+v\n", *resp)
 
 	return resp, nil
 }

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -248,8 +248,6 @@ func (svc *mgmtSvc) PoolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 		return nil, err
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolCreate dispatch, req:%s\n", mgmtpb.Debug(req))
-
 	poolUUID, err := uuid.Parse(req.GetUuid())
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse pool UUID %q", req.GetUuid())
@@ -413,12 +411,11 @@ func (svc *mgmtSvc) PoolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 		}
 
 		if cuErr == nil {
-			svc.log.Errorf("removed pool service entry for %s in cleanup", req.Uuid)
+			svc.log.Debugf("removed pool service entry for %s in cleanup", req.Uuid)
 			return
 		}
 	}()
 
-	svc.log.Debugf("MgmtSvc.PoolCreate forwarding modified req:%s\n", mgmtpb.Debug(req))
 	dresp, err := svc.harness.CallDrpc(ctx, drpc.MethodPoolCreate, req)
 	if err != nil {
 		svc.log.Errorf("pool create dRPC call failed: %s", err)
@@ -454,8 +451,6 @@ func (svc *mgmtSvc) PoolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 	if err := svc.sysdb.UpdatePoolService(ctx, ps); err != nil {
 		return nil, err
 	}
-
-	svc.log.Debugf("MgmtSvc.PoolCreate dispatch resp:%s\n", mgmtpb.Debug(resp))
 
 	return resp, nil
 }
@@ -538,8 +533,6 @@ func (svc *mgmtSvc) poolHasContainers(ctx context.Context, req *mgmtpb.PoolDestr
 		return false, err
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolDestroy drpc.MethodListContainers, resp:%+v\n", lcResp)
-
 	dStatus := daos.Status(lcResp.GetStatus())
 	if dStatus != daos.Success {
 		return false, dStatus // daos.Status implements error
@@ -574,7 +567,6 @@ func (svc *mgmtSvc) PoolDestroy(parent context.Context, req *mgmtpb.PoolDestroyR
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolDestroy dispatch, req:%+v\n", req)
 
 	poolUUID, err := svc.resolvePoolID(req.Id)
 	if err != nil {
@@ -666,8 +658,6 @@ func (svc *mgmtSvc) PoolDestroy(parent context.Context, req *mgmtpb.PoolDestroyR
 		return nil, errors.Wrap(err, "unmarshal PoolDestroy response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolDestroy dispatch, resp:%+v\n", resp)
-
 	ds := daos.Status(resp.Status)
 	if ds == daos.Success {
 		if err := svc.sysdb.RemovePoolService(ctx, poolUUID); err != nil {
@@ -691,7 +681,6 @@ func (svc *mgmtSvc) PoolEvict(ctx context.Context, req *mgmtpb.PoolEvictReq) (*m
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolEvict dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolEvict, req)
 	if err != nil {
@@ -703,8 +692,6 @@ func (svc *mgmtSvc) PoolEvict(ctx context.Context, req *mgmtpb.PoolEvictReq) (*m
 		return nil, errors.Wrap(err, "unmarshal PoolEvict response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolEvict dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -713,7 +700,6 @@ func (svc *mgmtSvc) PoolExclude(ctx context.Context, req *mgmtpb.PoolExcludeReq)
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolExclude dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolExclude, req)
 	if err != nil {
@@ -725,8 +711,6 @@ func (svc *mgmtSvc) PoolExclude(ctx context.Context, req *mgmtpb.PoolExcludeReq)
 		return nil, errors.Wrap(err, "unmarshal PoolExclude response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolExclude dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -735,7 +719,6 @@ func (svc *mgmtSvc) PoolDrain(ctx context.Context, req *mgmtpb.PoolDrainReq) (*m
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolDrain dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolDrain, req)
 	if err != nil {
@@ -747,8 +730,6 @@ func (svc *mgmtSvc) PoolDrain(ctx context.Context, req *mgmtpb.PoolDrainReq) (*m
 		return nil, errors.Wrap(err, "unmarshal PoolDrain response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolDrain dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -757,8 +738,6 @@ func (svc *mgmtSvc) PoolExtend(ctx context.Context, req *mgmtpb.PoolExtendReq) (
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-
-	svc.log.Debugf("MgmtSvc.PoolExtend dispatch, req:%+v\n", req)
 
 	// the IO engine needs the domain tree for placement purposes
 	fdTree, err := svc.membership.CompressedFaultDomainTree(req.Ranks...)
@@ -787,8 +766,6 @@ func (svc *mgmtSvc) PoolExtend(ctx context.Context, req *mgmtpb.PoolExtendReq) (
 		return nil, errors.Wrap(err, "unmarshal PoolExtend response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolExtend dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -797,7 +774,6 @@ func (svc *mgmtSvc) PoolReintegrate(ctx context.Context, req *mgmtpb.PoolReinteg
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolReintegrate dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolReintegrate, req)
 	if err != nil {
@@ -809,8 +785,6 @@ func (svc *mgmtSvc) PoolReintegrate(ctx context.Context, req *mgmtpb.PoolReinteg
 		return nil, errors.Wrap(err, "unmarshal PoolReintegrate response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolReintegrate dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -819,7 +793,6 @@ func (svc *mgmtSvc) PoolQuery(ctx context.Context, req *mgmtpb.PoolQueryReq) (*m
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolQuery dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolQuery, req)
 	if err != nil {
@@ -831,8 +804,6 @@ func (svc *mgmtSvc) PoolQuery(ctx context.Context, req *mgmtpb.PoolQueryReq) (*m
 		return nil, errors.Wrap(err, "unmarshal PoolQuery response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolQuery dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -841,7 +812,6 @@ func (svc *mgmtSvc) PoolQueryTarget(ctx context.Context, req *mgmtpb.PoolQueryTa
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolQueryTarget dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolQueryTarget, req)
 	if err != nil {
@@ -853,8 +823,6 @@ func (svc *mgmtSvc) PoolQueryTarget(ctx context.Context, req *mgmtpb.PoolQueryTa
 		return nil, errors.Wrap(err, "unmarshal PoolQueryTarget response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolQueryTarget dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -863,7 +831,6 @@ func (svc *mgmtSvc) PoolUpgrade(ctx context.Context, req *mgmtpb.PoolUpgradeReq)
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolUpgrade dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolUpgrade, req)
 	if err != nil {
@@ -874,8 +841,6 @@ func (svc *mgmtSvc) PoolUpgrade(ctx context.Context, req *mgmtpb.PoolUpgradeReq)
 	if err = proto.Unmarshal(dresp.Body, resp); err != nil {
 		return nil, errors.Wrap(err, "unmarshal PoolUpgrade response")
 	}
-
-	svc.log.Debugf("MgmtSvc.PoolUpgrade dispatch, resp:%+v\n", resp)
 
 	return resp, nil
 }
@@ -941,7 +906,6 @@ func (svc *mgmtSvc) PoolSetProp(parent context.Context, req *mgmtpb.PoolSetPropR
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolSetProp dispatch, req:%+v", req)
 
 	poolUUID, err := svc.resolvePoolID(req.GetId())
 	if err != nil {
@@ -991,8 +955,6 @@ func (svc *mgmtSvc) PoolSetProp(parent context.Context, req *mgmtpb.PoolSetPropR
 		return nil, errors.Wrap(err, "unmarshal PoolSetProp response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolSetProp dispatch, resp:%+v", resp)
-
 	return resp, nil
 }
 
@@ -1001,7 +963,6 @@ func (svc *mgmtSvc) PoolGetProp(ctx context.Context, req *mgmtpb.PoolGetPropReq)
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolGetProp dispatch, req:%+v", req)
 
 	// The request must contain a list of expected properties. We don't want
 	// to just let the engine return all properties because not all properties
@@ -1020,8 +981,6 @@ func (svc *mgmtSvc) PoolGetProp(ctx context.Context, req *mgmtpb.PoolGetPropReq)
 		return nil, errors.Wrap(err, "unmarshal PoolGetProp response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolGetProp dispatch, resp: %+v", resp)
-
 	if resp.GetStatus() != 0 {
 		return resp, nil
 	}
@@ -1034,7 +993,6 @@ func (svc *mgmtSvc) PoolGetACL(ctx context.Context, req *mgmtpb.GetACLReq) (*mgm
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolGetACL dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolGetACL, req)
 	if err != nil {
@@ -1046,8 +1004,6 @@ func (svc *mgmtSvc) PoolGetACL(ctx context.Context, req *mgmtpb.GetACLReq) (*mgm
 		return nil, errors.Wrap(err, "unmarshal PoolGetACL response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolGetACL dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -1056,7 +1012,6 @@ func (svc *mgmtSvc) PoolOverwriteACL(ctx context.Context, req *mgmtpb.ModifyACLR
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolOverwriteACL dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolOverwriteACL, req)
 	if err != nil {
@@ -1068,8 +1023,6 @@ func (svc *mgmtSvc) PoolOverwriteACL(ctx context.Context, req *mgmtpb.ModifyACLR
 		return nil, errors.Wrap(err, "unmarshal PoolOverwriteACL response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolOverwriteACL dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -1079,7 +1032,6 @@ func (svc *mgmtSvc) PoolUpdateACL(ctx context.Context, req *mgmtpb.ModifyACLReq)
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolUpdateACL dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolUpdateACL, req)
 	if err != nil {
@@ -1091,8 +1043,6 @@ func (svc *mgmtSvc) PoolUpdateACL(ctx context.Context, req *mgmtpb.ModifyACLReq)
 		return nil, errors.Wrap(err, "unmarshal PoolUpdateACL response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolUpdateACL dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -1102,7 +1052,6 @@ func (svc *mgmtSvc) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq)
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.PoolDeleteACL dispatch, req:%+v\n", req)
 
 	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolDeleteACL, req)
 	if err != nil {
@@ -1114,8 +1063,6 @@ func (svc *mgmtSvc) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq)
 		return nil, errors.Wrap(err, "unmarshal PoolDeleteACL response")
 	}
 
-	svc.log.Debugf("MgmtSvc.PoolDeleteACL dispatch, resp:%+v\n", resp)
-
 	return resp, nil
 }
 
@@ -1124,7 +1071,6 @@ func (svc *mgmtSvc) ListPools(ctx context.Context, req *mgmtpb.ListPoolsReq) (*m
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.ListPools dispatch, req:%+v\n", req)
 
 	psList, err := svc.sysdb.PoolServiceList(true)
 	if err != nil {
@@ -1146,8 +1092,6 @@ func (svc *mgmtSvc) ListPools(ctx context.Context, req *mgmtpb.ListPoolsReq) (*m
 		return nil, err
 	}
 	resp.DataVersion = v
-
-	svc.log.Debugf("MgmtSvc.ListPools dispatch, resp:%+v\n", resp)
 
 	return resp, nil
 }

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -51,7 +51,6 @@ func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfo
 	if svc.clientNetworkHint == nil {
 		return nil, errors.New("clientNetworkHint is missing")
 	}
-	svc.log.Debugf("MgmtSvc.GetAttachInfo dispatch, req:%+v\n", *req)
 
 	groupMap, err := svc.sysdb.GroupMap()
 	if err != nil {
@@ -86,19 +85,6 @@ func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfo
 	}
 	resp.DataVersion = v
 
-	// For resp.RankUris may be large, we make a resp copy with a limited
-	// number of rank URIs, to avoid flooding the debug log.
-	svc.log.Debugf("MgmtSvc.GetAttachInfo dispatch, resp:%+v len(RankUris):%d\n",
-		*func(r *mgmtpb.GetAttachInfoResp) *mgmtpb.GetAttachInfoResp {
-			max := 1
-			if len(r.RankUris) <= max {
-				return r
-			}
-			s := *r
-			s.RankUris = s.RankUris[0:max]
-			return &s
-		}(resp), len(resp.RankUris))
-
 	return resp, nil
 }
 
@@ -107,7 +93,6 @@ func (svc *mgmtSvc) LeaderQuery(ctx context.Context, req *mgmtpb.LeaderQueryReq)
 	if err := svc.checkSystemRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.LeaderQuery dispatch, req:%+v\n", req)
 
 	leaderAddr, replicas, err := svc.sysdb.LeaderQuery()
 	if err != nil {
@@ -119,7 +104,6 @@ func (svc *mgmtSvc) LeaderQuery(ctx context.Context, req *mgmtpb.LeaderQueryReq)
 		Replicas:      replicas,
 	}
 
-	svc.log.Debugf("MgmtSvc.LeaderQuery dispatch, resp:%+v\n", resp)
 	return resp, nil
 }
 
@@ -418,14 +402,6 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (resp *mgmtpb
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("MgmtSvc.Join dispatch, req:%s", mgmtpb.Debug(req))
-	defer func() {
-		if err != nil {
-			svc.log.Errorf("MgmtSvc.Join failed: %s", err)
-			return
-		}
-		svc.log.Debugf("MgmtSvc.Join succeeded, resp:%s", mgmtpb.Debug(resp))
-	}()
 
 	replyAddr, err := getPeerListenAddr(ctx, req.GetAddr())
 	if err != nil {
@@ -651,7 +627,6 @@ func (svc *mgmtSvc) SystemQuery(ctx context.Context, req *mgmtpb.SystemQueryReq)
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("Received SystemQuery RPC: %+v", req)
 
 	hitRanks, missRanks, missHosts, err := svc.resolveRanks(req.Hosts, req.Ranks)
 	if err != nil {
@@ -682,8 +657,6 @@ func (svc *mgmtSvc) SystemQuery(ctx context.Context, req *mgmtpb.SystemQueryReq)
 		return nil, err
 	}
 	resp.DataVersion = v
-
-	svc.log.Debugf("Responding to SystemQuery RPC: %s", mgmtpb.Debug(resp))
 
 	return resp, nil
 }
@@ -799,7 +772,6 @@ func (svc *mgmtSvc) SystemStop(ctx context.Context, req *mgmtpb.SystemStopReq) (
 	if err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("Responding to SystemStop RPC: %+v", resp)
 
 	return resp, nil
 }
@@ -860,7 +832,6 @@ func (svc *mgmtSvc) SystemStart(ctx context.Context, req *mgmtpb.SystemStartReq)
 	if err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("Responding to SystemStart RPC: %+v", resp)
 
 	return resp, nil
 }
@@ -870,7 +841,6 @@ func (svc *mgmtSvc) SystemExclude(ctx context.Context, req *mgmtpb.SystemExclude
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("Received SystemExclude RPC: %s", mgmtpb.Debug(req))
 
 	if req.Hosts == "" && req.Ranks == "" {
 		return nil, errors.New("no hosts or ranks specified")
@@ -910,7 +880,6 @@ func (svc *mgmtSvc) SystemExclude(ctx context.Context, req *mgmtpb.SystemExclude
 			Addr:   m.Addr.String(),
 		})
 	}
-	svc.log.Debugf("Responding to SystemExclude RPC: %+v", resp)
 
 	return resp, nil
 }
@@ -1047,7 +1016,6 @@ func (svc *mgmtSvc) SystemCleanup(ctx context.Context, req *mgmtpb.SystemCleanup
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("Received SystemCleanup RPC: %+v", req)
 
 	if req.Machine == "" {
 		return nil, errors.New("SystemCleanup requires a machine name.")
@@ -1095,8 +1063,6 @@ func (svc *mgmtSvc) SystemCleanup(ctx context.Context, req *mgmtpb.SystemCleanup
 		})
 	}
 
-	svc.log.Debugf("Responding to SystemCleanup RPC: %+v", resp)
-
 	return resp, nil
 }
 
@@ -1105,10 +1071,6 @@ func (svc *mgmtSvc) SystemSetAttr(ctx context.Context, req *mgmtpb.SystemSetAttr
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("Received SystemSetAttr RPC: %+v", req)
-	defer func() {
-		svc.log.Debugf("Responding to SystemSetAttr RPC: (%v)", err)
-	}()
 
 	if err := system.SetAttributes(svc.sysdb, req.GetAttributes()); err != nil {
 		return nil, err
@@ -1122,10 +1084,6 @@ func (svc *mgmtSvc) SystemGetAttr(ctx context.Context, req *mgmtpb.SystemGetAttr
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("Received SystemGetAttr RPC: %+v", req)
-	defer func() {
-		svc.log.Debugf("Responding to SystemGetAttr RPC: %+v (%v)", resp, err)
-	}()
 
 	props, err := system.GetAttributes(svc.sysdb, req.GetKeys())
 	if err != nil {
@@ -1141,10 +1099,6 @@ func (svc *mgmtSvc) SystemSetProp(ctx context.Context, req *mgmtpb.SystemSetProp
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("Received SystemSetProp RPC: %+v", req)
-	defer func() {
-		svc.log.Debugf("Responding to SystemSetProp RPC: (%v)", err)
-	}()
 
 	if err := system.SetUserProperties(svc.sysdb, svc.systemProps, req.GetProperties()); err != nil {
 		return nil, err
@@ -1158,10 +1112,6 @@ func (svc *mgmtSvc) SystemGetProp(ctx context.Context, req *mgmtpb.SystemGetProp
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err
 	}
-	svc.log.Debugf("Received SystemGetProp RPC: %+v", req)
-	defer func() {
-		svc.log.Debugf("Responding to SystemGetProp RPC: %+v (%v)", resp, err)
-	}()
 
 	props, err := system.GetUserProperties(svc.sysdb, svc.systemProps, req.GetKeys())
 	if err != nil {

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -381,7 +381,7 @@ func (srv *server) addEngines(ctx context.Context) error {
 
 // setupGrpc creates a new grpc server and registers services.
 func (srv *server) setupGrpc() error {
-	srvOpts, err := getGrpcOpts(srv.cfg.TransportConfig)
+	srvOpts, err := getGrpcOpts(srv.log, srv.cfg.TransportConfig)
 	if err != nil {
 		return err
 	}

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -612,8 +612,9 @@ func registerLeaderSubscriptions(srv *server) {
 }
 
 // getGrpcOpts generates a set of gRPC options for the server based on the supplied configuration.
-func getGrpcOpts(cfgTransport *security.TransportConfig) ([]grpc.ServerOption, error) {
+func getGrpcOpts(log logging.Logger, cfgTransport *security.TransportConfig) ([]grpc.ServerOption, error) {
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
+		unaryLoggingInterceptor(log), // must be first in order to properly log errors
 		unaryErrorInterceptor,
 		unaryStatusInterceptor,
 		unaryVersionInterceptor,

--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -478,6 +478,8 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 	}
 
 	for {
+		db.log.Debug("(re-)starting leadership monitoring loop")
+
 		select {
 		case <-parent.Done():
 			if cancelGainedCtx != nil {
@@ -499,7 +501,6 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 			}
 
 			db.log.Debugf("node %s gained MS leader state", db.replicaAddr)
-			barrierStart := time.Now()
 			if err := db.Barrier(); err != nil {
 				db.log.Errorf("raft Barrier() failed: %s", err)
 				if err = db.ResignLeadership(err); err != nil {
@@ -507,7 +508,6 @@ func (db *Database) monitorLeadershipState(parent context.Context) {
 				}
 				continue // restart the monitoring loop
 			}
-			db.log.Debugf("raft Barrier() complete after %s", time.Since(barrierStart))
 
 			var gainedCtx context.Context
 			gainedCtx, cancelGainedCtx = context.WithCancel(parent)


### PR DESCRIPTION
Remove boilerplate from gRPC handlers by logging
request and result automatically via an interceptor.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
