### PR TITLE
DAOS-12260 vos: Fix bug where uncommitted update can be removed

### DIFF
--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -2742,6 +2742,68 @@ uncommitted_parent(void **state)
 }
 
 static void
+test_uncommitted_key(void **state)
+{
+	struct io_test_args *arg = *state;
+	int                  rc  = 0;
+	daos_epoch_range_t   epr;
+	daos_key_t           dkey;
+	daos_key_t           akey;
+	daos_iod_t           iod;
+	d_sg_list_t          sgl;
+	char                 buf[32];
+	daos_epoch_t         epoch = start_epoch;
+	daos_handle_t        coh;
+	char                *first = "Hello";
+	char                 dkey_buf[UPDATE_DKEY_SIZE];
+	char                 akey_buf[UPDATE_AKEY_SIZE];
+	daos_unit_oid_t      oid;
+	struct dtx_id        xid;
+
+	test_args_reset(arg, VPOOL_SIZE);
+	coh = arg->ctx.tc_co_hdl;
+
+	memset(&iod, 0, sizeof(iod));
+
+	rc = d_sgl_init(&sgl, 1);
+	assert_rc_equal(rc, 0);
+
+	/* Set up dkey and akey */
+	oid = gen_oid(arg->otype);
+	vts_key_gen(&dkey_buf[0], arg->dkey_size, true, arg);
+	set_iov(&dkey, &dkey_buf[0], is_daos_obj_type_set(arg->otype, DAOS_OT_DKEY_UINT64));
+	vts_key_gen(&akey_buf[0], arg->akey_size, true, arg);
+	set_iov(&akey, &akey_buf[0], is_daos_obj_type_set(arg->otype, DAOS_OT_AKEY_UINT64));
+
+	/** Update the dkey */
+	execute_op(coh, oid, epoch, &dkey, &akey, &sgl, first, 5, true, TX_OP_UPDATE1);
+	epoch += 10;
+	/** Punch the dkey */
+	execute_op(coh, oid, epoch, &dkey, NULL, NULL, NULL, 0, true, TX_OP_PUNCH_DKEY);
+	epoch += 10;
+	/** Update the dkey but don't commit */
+	xid = execute_op(coh, oid, epoch, &dkey, &akey, &sgl, first, 5, false, TX_OP_UPDATE1);
+	epoch += 10;
+
+	epr.epr_hi = epoch;
+	epr.epr_lo = 0;
+	rc         = vos_aggregate(coh, &epr, NULL, NULL, 0);
+	assert_rc_equal(rc, 0);
+
+	/** Commit the update */
+	rc = vos_dtx_commit(coh, &xid, 1, NULL);
+	assert_rc_equal(rc, 1);
+
+	memset(buf, 'x', sizeof(buf));
+	epoch += 10;
+	execute_op(coh, oid, epoch, &dkey, &akey, &sgl, buf, 5, true, TX_OP_FETCH1);
+	assert_memory_equal(buf, "Hello", 5);
+
+	d_sgl_fini(&sgl, false);
+	start_epoch = epoch + 1;
+}
+
+static void
 test_multiple_key_conditionals_common(void **state, bool with_dtx)
 {
 	struct io_test_args	*arg = *state;
@@ -2969,17 +3031,15 @@ test_multiple_key_conditionals_tx(void **state)
 }
 
 static const struct CMUnitTest punch_model_tests_pmdk[] = {
-	{ "VOS860: Conditionals test", cond_test, NULL, NULL },
-	{ "VOS861: Multiple oid cond test", multiple_oid_cond_test, NULL,
-		NULL },
-	{ "VOS862: Punch while other akey is inprogress",
-		test_inprogress_parent_punch, NULL, NULL },
-	{ "VOS863: Multikey conditionals",
-		test_multiple_key_conditionals, NULL, NULL },
-	{ "VOS864: Multikey conditionals with tx",
-		test_multiple_key_conditionals_tx, NULL, NULL },
-	{ "VOS865: Many transactions", many_tx, NULL, NULL },
-	{ "VOS866: Uncommitted parent punch", uncommitted_parent, NULL, NULL },
+    {"VOS860: Conditionals test", cond_test, NULL, NULL},
+    {"VOS861: Multiple oid cond test", multiple_oid_cond_test, NULL, NULL},
+    {"VOS862: Punch while other akey is inprogress", test_inprogress_parent_punch, NULL, NULL},
+    {"VOS863: Multikey conditionals", test_multiple_key_conditionals, NULL, NULL},
+    {"VOS864: Multikey conditionals with tx", test_multiple_key_conditionals_tx, NULL, NULL},
+    {"VOS865: Many transactions", many_tx, NULL, NULL},
+    {"VOS866: Uncommitted parent punch", uncommitted_parent, NULL, NULL},
+    {"VOS867: Aggregate committed key punch with subsequent in-flight update", test_uncommitted_key,
+     NULL, NULL},
 };
 
 static const struct CMUnitTest punch_model_tests_all[] = {

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -586,7 +586,7 @@ vos_ilog_is_punched(daos_handle_t coh, struct ilog_df *ilog, const daos_epoch_ra
 	rc = vos_ilog_fetch_internal(umm, coh, DAOS_INTENT_PURGE, ilog, epr, 0, &punch_rec, NULL,
 				     info);
 
-	if (rc != 0 || !info->ii_full_scan || info->ii_create != 0)
+	if (rc != 0 || !info->ii_full_scan || info->ii_create != 0 || info->ii_uncommitted != 0)
 		return false;
 
 	return true;


### PR DESCRIPTION
If a key is punched and there is a subsequent, not-yet-committed update, aggregation will remove the key.  Fix the check so that it also checks for uncommitted entries to avoid this.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
