### PR TITLE
DAOS-12257 pool: create logging with log_mask: INFO and DEBUG

### DIFF
--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -101,13 +101,12 @@ ds_mgmt_tgt_pool_create_ranks(uuid_t pool_uuid, char *tgt_dev, d_rank_list_t *ra
 	tc_out = crt_reply_get(tc_req);
 	rc = tc_out->tc_rc;
 	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to update pool map on targets: rc="
-			DF_RC"\n",
+		D_ERROR(DF_UUID": failed to create targets: rc="DF_RC"\n",
 			DP_UUID(tc_in->tc_pool_uuid), DP_RC(rc));
 		D_GOTO(decref, rc);
 	}
 
-	D_DEBUG(DB_MGMT, DF_UUID" create %zu tgts pool\n",
+	D_DEBUG(DB_MGMT, DF_UUID" created pool tgts on %zu ranks\n",
 		DP_UUID(pool_uuid), tc_out->tc_ranks.ca_count);
 
 decref:
@@ -120,6 +119,9 @@ decref:
 		if (rc_cleanup)
 			D_ERROR(DF_UUID": failed to clean up failed pool: "
 				DF_RC"\n", DP_UUID(pool_uuid), DP_RC(rc));
+		else
+			D_DEBUG(DB_MGMT, DF_UUID": cleaned up failed create targets\n",
+				DP_UUID(pool_uuid));
 	}
 
 	return rc;
@@ -194,6 +196,8 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 		D_GOTO(out, rc);
 	}
 
+	D_INFO(DF_UUID": creating targets on ranks succeeded\n", DP_UUID(pool_uuid));
+
 	rc = ds_mgmt_pool_svc_create(pool_uuid, targets->rl_nr, group, targets, prop, svcp,
 				     domains_nr, domains);
 	if (rc) {
@@ -209,6 +213,11 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 		if (rc_cleanup)
 			D_ERROR(DF_UUID": failed to clean up failed pool: "DF_RC"\n",
 				DP_UUID(pool_uuid), DP_RC(rc_cleanup));
+		else
+			D_DEBUG(DB_MGMT, DF_UUID": cleaned up failed create targets\n",
+				DP_UUID(pool_uuid));
+	} else {
+		D_INFO(DF_UUID": creating svc succeeded\n", DP_UUID(pool_uuid));
 	}
 
 out:

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -635,6 +635,8 @@ tgt_create_preallocate(void *arg)
 		 * failed
 		 */
 		rc = dir_fsync(tca->tca_path);
+		D_DEBUG(DB_MGMT, "reuse existing tca_path: %s, dir_fsync rc: "DF_RC"\n",
+			tca->tca_path, DP_RC(rc));
 	} else if (errno == ENOENT) { /** target doesn't exist, create one */
 		/** create the pool directory under NEWBORNS */
 		rc = path_gen(tca->tca_ptrec->dptr_uuid, newborns_path, NULL,
@@ -755,24 +757,23 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 		/* Try to join with thread - either canceled or normal exit. */
 		rc = pthread_tryjoin_np(thread, &res);
 		if (rc == 0) {
-			if (canceled_thread) {
-				D_DEBUG(DB_MGMT,
-					DF_UUID": tgt_create thread canceled\n",
-					DP_UUID(tc_in->tc_pool_uuid));
-				rc = -DER_CANCELED;
-			} else {
-				D_DEBUG(DB_MGMT,
-					DF_UUID": tgt_create thread finished\n",
-					DP_UUID(tc_in->tc_pool_uuid));
-				rc = tca.tca_rc;
-			}
+			rc = canceled_thread ? -DER_CANCELED : tca.tca_rc;
 			break;
 		}
 		ABT_thread_yield();
 	}
 	/* check the result of tgt_create_preallocate() */
-	if (rc)
+	if (rc == -DER_CANCELED) {
+		D_DEBUG(DB_MGMT, DF_UUID": tgt preallocate thread canceled\n",
+			DP_UUID(tc_in->tc_pool_uuid));
 		goto out;
+	} else if (rc) {
+		D_ERROR(DF_UUID": tgt preallocate thread failed, "DF_RC"\n",
+			DP_UUID(tc_in->tc_pool_uuid), DP_RC(rc));
+		goto out;
+	} else {
+		D_INFO(DF_UUID": tgt preallocate thread succeeded\n", DP_UUID(tc_in->tc_pool_uuid));
+	}
 
 	if (tca.tca_newborn != NULL) {
 		struct vos_pool_arg vpa = {0};
@@ -783,8 +784,11 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 		vpa.vpa_scm_size = 0;
 		vpa.vpa_nvme_size = tc_in->tc_nvme_size / dss_tgt_nr;
 		rc = dss_thread_collective(tgt_vos_create_one, &vpa, 0);
-		if (rc)
+		if (rc) {
+			D_ERROR(DF_UUID": thread collective tgt_vos_create_one failed, "DF_RC"\n",
+				DP_UUID(tc_in->tc_pool_uuid), DP_RC(rc));
 			goto out;
+		}
 
 		/** ready for prime time, move away from NEWBORNS dir */
 		rc = rename(tca.tca_newborn, tca.tca_path);
@@ -814,6 +818,8 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 		D_ERROR(DF_UUID": failed to start pool: "DF_RC"\n",
 			DP_UUID(tc_in->tc_pool_uuid), DP_RC(rc));
 		D_GOTO(out, rc);
+	} else {
+		D_INFO(DF_UUID": started pool\n", DP_UUID(tc_in->tc_pool_uuid));
 	}
 out:
 	if (rc && tca.tca_newborn != NULL) {
@@ -823,6 +829,8 @@ out:
 		 */
 		(void)tgt_destroy(tca.tca_ptrec->dptr_uuid,
 				  tca.tca_newborn);
+		D_DEBUG(DB_MGMT, DF_UUID": cleaned up failed create targets\n",
+			DP_UUID(tc_in->tc_pool_uuid));
 	}
 	D_FREE(tca.tca_newborn);
 	D_FREE(tca.tca_path);


### PR DESCRIPTION
With this change, add some INFO level log messages in the engine
pool create code execution flow, so coarse-grained progress
on stuck pool creates can be more easily seen. Additionally,
add more D_DEBUG statements so progress is more explicitly
visible when engines are configured with the more verbose
log_mask: DEBUG setting.

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
