### PR TITLE
DAOS-11040 common: add lmdb backend kv for SMD

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,8 @@ Build-Depends: debhelper (>= 10),
                libipmctl-dev,
                libraft-dev (= 0.9.1-1401.gc18bcb8),
                python3-tabulate,
-               liblz4-dev
+               liblz4-dev,
+               liblmdb-dev
 Standards-Version: 4.1.2
 Homepage: https://docs.daos.io/
 Vcs-Git: https://github.com/daos-stack/daos.git

--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -246,6 +246,8 @@ def define_common(reqs):
 
     reqs.define('yaml', headers=['yaml.h'], package='libyaml-devel')
 
+    reqs.define('lmdb', headers=['lmdb.h'], package='lmdb-devel-devel')
+
     reqs.define('event', libs=['event'], package='libevent-devel')
 
     reqs.define('crypto', libs=['crypto'], headers=['openssl/md5.h'],

--- a/src/bio/bio_wal.c
+++ b/src/bio/bio_wal.c
@@ -904,10 +904,6 @@ bio_wal_commit(struct bio_meta_context *mc, struct umem_wal_tx *tx, struct bio_d
 	struct bio_dma_stats	*stats;
 	int			 iov_nr, rc;
 
-	/* FIXME: Skip WAL commit for sysdb for this moment */
-	if (mc->mc_is_sysdb)
-		return 0;
-
 	/* Bypass WAL commit, used for performance evaluation only */
 	if (daos_io_bypass & IOBP_WAL_COMMIT) {
 		bio_yield(NULL);
@@ -1542,10 +1538,6 @@ bio_wal_replay(struct bio_meta_context *mc,
 	unsigned int		 nr_replayed = 0, tight_loop, dbuf_len = 0;
 	uint64_t		 tx_id;
 	int			 rc;
-
-	/* FIXME: Skip WAL replay for sysdb for this moment */
-	if (mc->mc_is_sysdb)
-		return 0;
 
 	D_ALLOC(buf, max_blks * blk_bytes);
 	if (buf == NULL)

--- a/src/bio/bio_wal.h
+++ b/src/bio/bio_wal.h
@@ -104,7 +104,6 @@ struct bio_meta_context {
 	struct wal_super_info	 mc_wal_info;	/* WAL blob super information */
 	struct hash_ft		*mc_csum_algo;
 	void			*mc_csum_ctx;
-	unsigned int		 mc_is_sysdb:1;
 };
 
 struct meta_fmt_info {

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -199,7 +199,8 @@ set_faulty_criteria(void)
 
 int
 bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
-	      unsigned int hugepage_size, unsigned int tgt_nr, bool bypass_health_collect)
+	      unsigned int hugepage_size, unsigned int tgt_nr, struct sys_db *db,
+	      bool bypass_health_collect)
 {
 	char		*env;
 	int		 rc, fd;
@@ -290,6 +291,12 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 	D_INFO("Set per-xstream DMA buffer upper bound to %u %uMB chunks\n",
 	       bio_chk_cnt_max, size_mb);
 
+	rc = smd_init(db);
+	if (rc != 0) {
+		D_ERROR("Initialize SMD store failed. "DF_RC"\n", DP_RC(rc));
+		goto free_cond;
+	}
+
 	spdk_bs_opts_init(&nvme_glb.bd_bs_opts, sizeof(nvme_glb.bd_bs_opts));
 	nvme_glb.bd_bs_opts.cluster_sz = DAOS_BS_CLUSTER_SZ;
 	nvme_glb.bd_bs_opts.num_md_pages = DAOS_BS_MD_PAGES;
@@ -310,13 +317,15 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 	rc = bio_spdk_env_init();
 	if (rc) {
 		nvme_glb.bd_nvme_conf = NULL;
-		goto free_cond;
+		goto fini_smd;
 	}
 	bio_spdk_inited = true;
 	set_faulty_criteria();
 
 	return 0;
 
+fini_smd:
+	smd_fini();
 free_cond:
 	ABT_cond_free(&nvme_glb.bd_barrier);
 free_mutex:
@@ -1181,24 +1190,6 @@ alloc_xs_blobstore(void)
 	return bxb;
 }
 
-static inline struct bio_bdev *
-find_sys_bdev(unsigned int role)
-{
-	struct bio_bdev	*d_bdev;
-
-	D_ASSERT(!d_list_empty(&nvme_glb.bd_bdevs));
-	/*
-	 * Temporarily use the first meta/WAL device, needs be improved when we support
-	 * meta/WAL device hotplug.
-	 */
-	d_list_for_each_entry(d_bdev, &nvme_glb.bd_bdevs, bb_link) {
-		if (is_role_match(d_bdev->bb_roles, role))
-			return d_bdev;
-	}
-
-	return NULL;
-}
-
 static int
 assign_roles(struct bio_bdev *d_bdev, unsigned int tgt_id)
 {
@@ -1242,16 +1233,6 @@ assign_xs_bdev(struct bio_xs_context *ctxt, int tgt_id, enum smd_dev_type st,
 	int			 rc;
 
 	*dev_state = SMD_DEV_NORMAL;
-	if (tgt_id == BIO_SYS_TGT_ID || tgt_id == BIO_STANDALONE_TGT_ID) {
-		d_bdev = find_sys_bdev(dev_type2role(st));
-		if (d_bdev == NULL) {
-			D_ERROR("Failed to find sys bdev\n");
-			return NULL;
-		}
-		/* Assume the sys device in NORMAL state for this moment */
-		return d_bdev;
-	}
-
 	rc = smd_dev_get_by_tgt(tgt_id, st, &dev_info);
 	if (rc == -DER_NONEXIST) {
 		d_bdev = choose_device(tgt_id, st);

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1209,6 +1209,28 @@ assign_roles(struct bio_bdev *d_bdev, unsigned int tgt_id)
 			goto error;
 		}
 		assigned = true;
+		/*
+		 * Now a device will be assigned to SYS_TGT_ID for RDB
+		 * (the mapping will be recorded in target table), but we should not
+		 * treat the SYS_TGT mapping equally with other VOS targets mappings.
+		 *
+		 * Let's take an example, if there is a config having 4 meta SSDs and 3 targets,
+		 * how should we assign SSDs?
+		 *
+		 * 1. Assign 3 SSDs to 3 VOS targets and sys target (sys target share SSD with
+		 * one of VOS target), leave one SSD unused, or;
+		 * 2. Assign 1 SSD to sys target, assign the other 3 SSDs to VOS targets
+		 *
+		 * We use the 1st policy to assign SSDs and @bb_tgt_cnt won't be increased for
+		 * sys tgt id.
+		 *
+		 */
+		if (tgt_id != BIO_SYS_TGT_ID)
+			d_bdev->bb_tgt_cnt++;
+
+		D_DEBUG(DB_MGMT, "Successfully mapped dev "DF_UUID"/%d/%u to tgt %d role %u\n",
+			DP_UUID(d_bdev->bb_uuid), d_bdev->bb_tgt_cnt, d_bdev->bb_roles,
+			tgt_id, dev_type2role(st));
 
 		if (!bio_nvme_configured(SMD_DEV_TYPE_META))
 			break;
@@ -1246,26 +1268,6 @@ assign_xs_bdev(struct bio_xs_context *ctxt, int tgt_id, enum smd_dev_type st,
 			D_ERROR("Failed to assign roles. "DF_RC"\n", DP_RC(rc));
 			return NULL;
 		}
-		/*
-		 * Now a device will be assigned to SYS_TGT_ID for RDB
-		 * (the mapping will be recorded in target table), but we should not
-		 * treat the SYS_TGT mapping equally with other VOS targets mappings.
-		 *
-		 * Let's take an example, if there is a config having 4 meta SSDs and 3 targets,
-		 * how should we assign SSDs?
-		 *
-		 * 1. Assign 3 SSDs to 3 VOS targets and sys target (sys target share SSD with
-		 * one of VOS target), leave one SSD unused, or;
-		 * 2. Assign 1 SSD to sys target, assign the other 3 SSDs to VOS targets
-		 *
-		 * We use the 1st policy to assign SSDs and @bb_tgt_cnt won't be increased for
-		 * sys tgt id.
-		 *
-		 */
-		if (tgt_id != BIO_SYS_TGT_ID)
-			d_bdev->bb_tgt_cnt++;
-		D_DEBUG(DB_MGMT, "Successfully mapped dev "DF_UUID"/%d to tgt %d\n",
-			DP_UUID(d_bdev->bb_uuid), d_bdev->bb_tgt_cnt, tgt_id);
 
 		return d_bdev;
 	} else if (rc) {

--- a/src/bio/smd/smd_internal.h
+++ b/src/bio/smd/smd_internal.h
@@ -19,7 +19,6 @@
 #include <daos/sys_db.h>
 #include <daos/mem.h>
 #include <daos_srv/smd.h>
-#include <daos_srv/daos_engine.h>	/* Revise the potential layering issue later */
 
 #define TABLE_DEV	"device"
 

--- a/src/bio/smd/smd_internal.h
+++ b/src/bio/smd/smd_internal.h
@@ -16,6 +16,7 @@
 #include <abt.h>
 #include <daos_types.h>
 #include <daos/btree.h>
+#include <daos/sys_db.h>
 #include <daos/mem.h>
 #include <daos_srv/smd.h>
 #include <daos_srv/daos_engine.h>	/* Revise the potential layering issue later */

--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -18,6 +18,7 @@ def build_daos_common(denv, client, prereqs):
     stack_mmap_files = []
     ad_mem_files = []
     dav_src = []
+    sys_lmdb_files = []
 
     common_libs = ['isal', 'isal_crypto', 'cart', 'gurt', 'lz4', 'protobuf-c', 'uuid', 'pthread']
     if client:
@@ -30,12 +31,13 @@ def build_daos_common(denv, client, prereqs):
                    'dav/ravl_interval.c', 'dav/recycler.c', 'dav/stats.c', 'dav/tx.c', 'dav/ulog.c',
                    'dav/util.c', 'dav/wal_tx.c']
         ad_mem_files = ['ad_mem.c', 'ad_tx.c']
-        common_libs.extend(['pmemobj'])
+        sys_lmdb_files = ['sys_lmdb.c']
+        common_libs.extend(['pmemobj', 'lmdb', 'abt'])
         benv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
         benv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
         benv.Append(OBJPREFIX="v_")
         libname = 'daos_common_pmem'
-        prereqs.require(benv, 'pmdk')
+        prereqs.require(benv, 'pmdk', 'argobots')
 
     if benv["STACK_MMAP"] == 1:
         common_libs.extend(['abt'])
@@ -44,7 +46,7 @@ def build_daos_common(denv, client, prereqs):
         benv.Append(CCFLAGS=['-DULT_MMAP_STACK'])
 
     common = benv.d_library(libname, COMMON_FILES + dav_src + ad_mem_files +
-                            stack_mmap_files, LIBS=common_libs)
+                            stack_mmap_files + sys_lmdb_files, LIBS=common_libs)
     benv.Install('$PREFIX/lib64/', common)
     return common
 

--- a/src/common/sys_lmdb.c
+++ b/src/common/sys_lmdb.c
@@ -1,0 +1,517 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#define D_LOGFAC	DD_FAC(common)
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <abt.h>
+#include <lmdb.h>
+#include <daos/sys_db.h>
+#include <daos/common.h>
+#include <daos_types.h>
+
+#define	SYS_DB_NAME		"sys_db"
+
+#define SYS_DB_MD		"metadata"
+#define SYS_DB_MD_VER		"version"
+
+#define SYS_DB_VERSION_1	1
+#define SYS_DB_VERSION		SYS_DB_VERSION_1
+
+/** private information of LMDB based system DB */
+struct lmm_sys_db {
+	/** exported part of VOS system DB */
+	struct sys_db		 db_pub;
+	/* LMDB environment handle */
+	MDB_env			*db_env;
+	MDB_txn			*db_txn;
+	/* Address where the new MDB_dbi handle will be stored */
+	MDB_dbi			 db_dbi;
+	char			*db_file;
+	char			*db_path;
+	/* DB should be destroyed on exit */
+	bool			 db_destroy_db;
+	ABT_mutex		 db_lock;
+};
+
+static struct lmm_sys_db	lmm_db;
+
+static int
+lmm_db_upsert(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val);
+
+static int
+lmm_db_fetch(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val);
+
+static int
+lmm_db_tx_begin(struct sys_db *db);
+
+static int
+lmm_db_tx_end(struct sys_db *db, int rc);
+
+static struct lmm_sys_db *
+db2lmm(struct sys_db *db)
+{
+	return container_of(db, struct lmm_sys_db, db_pub);
+}
+
+static void
+lmm_db_unlink(struct sys_db *db)
+{
+	struct lmm_sys_db *ldb = db2lmm(db);
+
+	unlink(ldb->db_file); /* ignore error code */
+}
+
+static int
+mdb_error2daos_error(int rc)
+{
+	if (rc > 0)
+		rc = -rc;
+
+	switch (rc) {
+	case 0:
+		return 0;
+	case MDB_VERSION_MISMATCH:
+		return -DER_MISMATCH;
+	case MDB_INVALID:
+		return -DER_INVAL;
+	case MDB_PANIC:
+	case MDB_MAP_RESIZED:
+		return -DER_SHUTDOWN;
+	case MDB_READERS_FULL:
+		return -DER_AGAIN;
+	case MDB_NOTFOUND:
+		return -DER_NONEXIST;
+	case MDB_KEYEXIST:
+		return -DER_EXIST;
+	default:
+		return daos_errno2der(-rc);
+	}
+
+}
+
+/* open or create system DB stored in external storage */
+static int
+lmm_db_open_create(struct sys_db *db, bool try_create)
+{
+	struct lmm_sys_db *ldb = db2lmm(db);
+	d_iov_t		   key;
+	d_iov_t		   val;
+	uint32_t	   ver;
+	int		   rc = 0;
+
+	if (try_create) {
+		rc = mkdir(ldb->db_path, 0777);
+		if (rc < 0 && errno != EEXIST) {
+			rc = daos_errno2der(errno);
+			return rc;
+		}
+	} else if (access(ldb->db_file, F_OK) != 0) {
+		D_DEBUG(DB_IO, "%s doesn't exist, bypassing lmdb open\n",
+			ldb->db_file);
+		rc = -DER_NONEXIST;
+		return rc;
+	} else if (access(ldb->db_file, R_OK | W_OK) != 0) {
+		rc = -DER_NO_PERM;
+		D_CRIT("No access to existing db file %s\n", ldb->db_file);
+		return rc;
+	}
+
+	D_DEBUG(DB_IO, "Opening %s, try_create=%d\n", ldb->db_file, try_create);
+	rc = mdb_env_create(&ldb->db_env);
+	if (rc) {
+		rc = mdb_error2daos_error(rc);
+		D_CRIT("Failed to create env handle for sysdb: "DF_RC"\n", DP_RC(rc));
+		goto out;
+	}
+
+	rc = mdb_env_open(ldb->db_env, ldb->db_file, MDB_NOSUBDIR, 0664);
+	if (rc) {
+		rc = mdb_error2daos_error(rc);
+		D_CRIT("Failed to open env handle for sysdb: "DF_RC"\n", DP_RC(rc));
+		goto out;
+	}
+
+	rc = mdb_txn_begin(ldb->db_env, NULL, 0, &ldb->db_txn);
+	if (rc) {
+		rc = mdb_error2daos_error(rc);
+		D_CRIT("Failed to begin tx for sysdb: "DF_RC"\n", DP_RC(rc));
+		goto out;
+	}
+
+	rc = mdb_dbi_open(ldb->db_txn, NULL, 0, &ldb->db_dbi);
+	if (rc) {
+		rc = mdb_error2daos_error(rc);
+		D_CRIT("Failed to open sysdb: "DF_RC"\n", DP_RC(rc));
+		goto txn_abort;
+	}
+
+
+	d_iov_set(&key, SYS_DB_MD_VER, strlen(SYS_DB_MD_VER));
+	d_iov_set(&val, &ver, sizeof(ver));
+	if (try_create) {
+		ver = SYS_DB_VERSION;
+		rc = lmm_db_upsert(db, SYS_DB_MD, &key, &val);
+		if (rc) {
+			D_CRIT("Failed to set version for sysdb: "DF_RC"\n",
+			       DP_RC(rc));
+			goto txn_abort;
+		}
+		rc = mdb_txn_commit(ldb->db_txn);
+		if (rc)
+			D_CRIT("Failed to commit version for sysdb: "DF_RC"\n",
+			       DP_RC(rc));
+		goto out;
+	} else {
+		/* make lock assertion happen */
+		ABT_mutex_lock(db2lmm(db)->db_lock);
+		rc = lmm_db_fetch(db, SYS_DB_MD, &key, &val);
+		ABT_mutex_unlock(db2lmm(db)->db_lock);
+		if (rc) {
+			D_CRIT("Failed to read sysdb version: "DF_RC"\n",
+			       DP_RC(rc));
+			rc = -DER_INVAL;
+		}
+
+		if (ver < SYS_DB_VERSION_1 || ver > SYS_DB_VERSION)
+			rc = -DER_DF_INCOMPT;
+	}
+txn_abort:
+	mdb_txn_abort(ldb->db_txn);
+out:
+	ldb->db_txn = NULL;
+	return rc;
+}
+
+#define MAX_SMD_TABLE_LEN	32
+static int
+lmm_db_generate_key(char *table, d_iov_t *key, MDB_val *db_key)
+{
+	char	*new_key;
+	int	 table_len;
+
+	table_len = strnlen(table, MAX_SMD_TABLE_LEN);
+	db_key->mv_size = key->iov_len + table_len;
+	D_ALLOC(new_key, db_key->mv_size);
+	if (new_key == NULL)
+		return -DER_NOMEM;
+
+	memcpy(new_key, table, table_len);
+	memcpy(new_key + table_len, (char *)key->iov_buf, key->iov_len);
+	db_key->mv_data = new_key;
+
+	return 0;
+}
+
+static int
+lmm_db_unpack_key(char *table, d_iov_t *key, MDB_val *db_key)
+{
+	int	 table_len = strnlen(table, MAX_SMD_TABLE_LEN);
+	char	*buf;
+	int	 len;
+
+	if (db_key->mv_size < table_len)
+		return -DER_INVAL;
+
+	len = db_key->mv_size - table_len;
+	D_ALLOC(buf, len);
+	if (buf == NULL)
+		return -DER_NOMEM;
+
+	memcpy(buf, db_key->mv_data + table_len, len);
+	d_iov_set(key, buf, len);
+
+	return 0;
+}
+
+static int
+lmm_db_fetch(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val)
+{
+	MDB_val			 db_key, db_data;
+	struct lmm_sys_db	*ldb = db2lmm(db);
+	int			 rc;
+	bool			 end_tx = false;
+
+	D_ASSERT(ABT_mutex_trylock(db2lmm(db)->db_lock) == ABT_ERR_MUTEX_LOCKED);
+	if (ldb->db_txn == NULL) {
+		rc = mdb_txn_begin(ldb->db_env, NULL, MDB_RDONLY, &ldb->db_txn);
+		if (rc)
+			return mdb_error2daos_error(rc);
+		end_tx = true;
+	}
+
+	rc = lmm_db_generate_key(table, key, &db_key);
+	if (rc)
+		goto out;
+
+	rc = mdb_get(ldb->db_txn, ldb->db_dbi, &db_key, &db_data);
+	D_FREE(db_key.mv_data);
+	if (rc) {
+		rc = mdb_error2daos_error(rc);
+		goto out;
+	}
+
+	if (db_data.mv_size != val->iov_len) {
+		D_ERROR("mismatch value for table: %s, expected: %lu, got: %lu\n",
+			table, val->iov_len, db_data.mv_size);
+		rc = -DER_MISMATCH;
+		goto out;
+	}
+	memcpy(val->iov_buf, db_data.mv_data, db_data.mv_size);
+
+out:
+	if (end_tx) {
+		mdb_txn_abort(ldb->db_txn);
+		ldb->db_txn = NULL;
+	}
+	return rc;
+}
+
+static int
+lmm_db_upsert(struct sys_db *db, char *table, d_iov_t *key, d_iov_t *val)
+{
+	MDB_val			 db_key, db_data;
+	struct lmm_sys_db	*ldb = db2lmm(db);
+	int			 rc;
+	bool			 end_tx = false;
+
+	if (ldb->db_txn == NULL) {
+		rc = lmm_db_tx_begin(db);
+		if (rc)
+			return rc;
+		end_tx = true;
+	}
+
+	rc = lmm_db_generate_key(table, key, &db_key);
+	if (rc)
+		goto out;
+
+	db_data.mv_size = val->iov_len;
+	db_data.mv_data = val->iov_buf;
+
+	rc = mdb_put(ldb->db_txn, ldb->db_dbi, &db_key, &db_data, 0);
+	D_FREE(db_key.mv_data);
+
+out:
+	rc = mdb_error2daos_error(rc);
+	if (end_tx)
+		lmm_db_tx_end(db, rc);
+	return rc;
+}
+
+static int
+lmm_db_delete(struct sys_db *db, char *table, d_iov_t *key)
+{
+	MDB_val			 db_key;
+	struct lmm_sys_db	*ldb = db2lmm(db);
+	int			 rc;
+	bool			 end_tx = false;
+
+	if (ldb->db_txn == NULL) {
+		rc = lmm_db_tx_begin(db);
+		if (rc)
+			return rc;
+		end_tx = true;
+	}
+
+	rc = lmm_db_generate_key(table, key, &db_key);
+	if (rc)
+		goto out;
+
+	rc = mdb_del(ldb->db_txn, ldb->db_dbi, &db_key, NULL);
+	D_FREE(db_key.mv_data);
+
+out:
+	rc = mdb_error2daos_error(rc);
+	if (end_tx)
+		lmm_db_tx_end(db, rc);
+	return rc;
+}
+
+static int
+lmm_db_traverse(struct sys_db *db, char *table, sys_db_trav_cb_t cb, void *args)
+{
+	struct lmm_sys_db	*ldb = db2lmm(db);
+	MDB_cursor		*cursor;
+	MDB_val			 db_key, db_data;
+	int			 rc;
+	d_iov_t			 key;
+	int			 table_len = strnlen(table, MAX_SMD_TABLE_LEN);
+
+	D_ASSERT(ldb->db_txn == NULL);
+	rc = mdb_txn_begin(ldb->db_env, NULL, MDB_RDONLY, &ldb->db_txn);
+	if (rc)
+		return mdb_error2daos_error(rc);
+
+	rc = mdb_cursor_open(ldb->db_txn, ldb->db_dbi, &cursor);
+	if (rc)
+		goto tx_end;
+
+	while ((rc = mdb_cursor_get(cursor, &db_key, &db_data, MDB_NEXT)) == 0) {
+		if (strncmp(db_key.mv_data, table, table_len) != 0)
+			continue;
+
+		rc = lmm_db_unpack_key(table, &key, &db_key);
+		if (rc)
+			break;
+
+		d_iov_set(&key, db_key.mv_data, db_key.mv_size);
+		rc = cb(db, table, &key, args);
+		D_FREE(key.iov_buf);
+		if (rc)
+			break;
+	}
+	/* reach end */
+	if (rc == MDB_NOTFOUND)
+		rc = 0;
+
+	mdb_cursor_close(cursor);
+tx_end:
+	mdb_txn_abort(ldb->db_txn);
+	ldb->db_txn = NULL;
+	return mdb_error2daos_error(rc);
+}
+
+static int
+lmm_db_tx_begin(struct sys_db *db)
+{
+	struct lmm_sys_db	*ldb = db2lmm(db);
+	int			 rc;
+
+	D_ASSERT(ldb->db_txn == NULL);
+	rc = mdb_txn_begin(ldb->db_env, NULL, 0, &ldb->db_txn);
+
+	return mdb_error2daos_error(rc);
+}
+
+static int
+lmm_db_tx_end(struct sys_db *db, int rc)
+{
+	struct lmm_sys_db	*ldb = db2lmm(db);
+	MDB_txn			*txn = ldb->db_txn;
+
+	D_ASSERT(txn != NULL);
+	ldb->db_txn = NULL;
+
+	if (rc) {
+		mdb_txn_abort(txn);
+		return rc;
+	}
+
+	rc = mdb_txn_commit(txn);
+
+	return mdb_error2daos_error(rc);
+}
+
+static void
+lmm_db_lock(struct sys_db *db)
+{
+	ABT_mutex_lock(db2lmm(db)->db_lock);
+}
+
+static void
+lmm_db_unlock(struct sys_db *db)
+{
+	ABT_mutex_unlock(db2lmm(db)->db_lock);
+}
+
+/** Finalize system DB of VOS */
+void
+lmm_db_fini(void)
+{
+	if (lmm_db.db_lock)
+		ABT_mutex_free(&lmm_db.db_lock);
+	if (lmm_db.db_file) {
+		if (lmm_db.db_env)
+			mdb_env_close(lmm_db.db_env);
+		if (lmm_db.db_destroy_db)
+			lmm_db_unlink(&lmm_db.db_pub);
+		mdb_dbi_close(lmm_db.db_env, lmm_db.db_dbi);
+		free(lmm_db.db_file);
+	}
+
+	free(lmm_db.db_path);
+	memset(&lmm_db, 0, sizeof(lmm_db));
+}
+
+int
+lmm_db_init_ex(const char *db_path, const char *db_name, bool force_create, bool destroy_db_on_fini)
+{
+	int	create;
+	int	rc;
+
+	D_ASSERT(db_path != NULL);
+
+	memset(&lmm_db, 0, sizeof(lmm_db));
+	lmm_db.db_destroy_db = destroy_db_on_fini;
+
+	rc = ABT_mutex_create(&lmm_db.db_lock);
+	if (rc != ABT_SUCCESS)
+		return -DER_NOMEM;
+
+	rc = asprintf(&lmm_db.db_path, "%s", db_path);
+	if (rc < 0) {
+		D_ERROR("Generate sysdb path failed. %d\n", rc);
+		return -DER_NOMEM;
+	}
+
+	if (!db_name)
+		db_name = SYS_DB_NAME;
+
+	rc = asprintf(&lmm_db.db_file, "%s/%s", lmm_db.db_path, db_name);
+	if (rc < 0) {
+		D_ERROR("Generate sysdb filename failed. %d\n", rc);
+		rc = -DER_NOMEM;
+		goto failed;
+	}
+
+	strncpy(lmm_db.db_pub.sd_name, db_name, SYS_DB_NAME_SZ - 1);
+	lmm_db.db_pub.sd_fetch	  = lmm_db_fetch;
+	lmm_db.db_pub.sd_upsert	  = lmm_db_upsert;
+	lmm_db.db_pub.sd_delete	  = lmm_db_delete;
+	lmm_db.db_pub.sd_traverse = lmm_db_traverse;
+	lmm_db.db_pub.sd_tx_begin = lmm_db_tx_begin;
+	lmm_db.db_pub.sd_tx_end	  = lmm_db_tx_end;
+	lmm_db.db_pub.sd_lock	  = lmm_db_lock;
+	lmm_db.db_pub.sd_unlock	  = lmm_db_unlock;
+
+	if (force_create)
+		lmm_db_unlink(&lmm_db.db_pub);
+
+	for (create = 0; create <= 1; create++) {
+		rc = lmm_db_open_create(&lmm_db.db_pub, !!create);
+		if (rc == 0) {
+			D_DEBUG(DB_IO, "successfully open system DB\n");
+			break;
+		}
+		if (create || rc != -DER_NONEXIST) {
+			D_ERROR("Failed to open/create(%d) sys DB: "DF_RC"\n",
+				create, DP_RC(rc));
+			goto failed;
+		}
+		D_DEBUG(DB_DF, "Try to create system DB\n");
+	}
+	return 0;
+
+failed:
+	lmm_db_fini();
+	return rc;
+}
+
+/** Initialize system DB of VOS */
+int
+lmm_db_init(const char *db_path)
+{
+	return lmm_db_init_ex(db_path, NULL, false, false);
+}
+
+
+/** Export system DB of VOS */
+struct sys_db *
+lmm_db_get(void)
+{
+	return &lmm_db.db_pub;
+}

--- a/src/common/sys_lmdb.c
+++ b/src/common/sys_lmdb.c
@@ -193,7 +193,10 @@ lmm_db_generate_key(char *table, d_iov_t *key, MDB_val *db_key)
 	char	*new_key;
 	int	 table_len;
 
-	table_len = strnlen(table, MAX_SMD_TABLE_LEN);
+	table_len = strnlen(table, MAX_SMD_TABLE_LEN + 1);
+	if (table_len > MAX_SMD_TABLE_LEN)
+		return -DER_INVAL;
+
 	db_key->mv_size = key->iov_len + table_len;
 	D_ALLOC(new_key, db_key->mv_size);
 	if (new_key == NULL)
@@ -209,9 +212,12 @@ lmm_db_generate_key(char *table, d_iov_t *key, MDB_val *db_key)
 static int
 lmm_db_unpack_key(char *table, d_iov_t *key, MDB_val *db_key)
 {
-	int	 table_len = strnlen(table, MAX_SMD_TABLE_LEN);
+	int	 table_len = strnlen(table, MAX_SMD_TABLE_LEN + 1);
 	char	*buf;
 	int	 len;
+
+	if (table_len > MAX_SMD_TABLE_LEN)
+		return -DER_INVAL;
 
 	if (db_key->mv_size < table_len)
 		return -DER_INVAL;
@@ -358,7 +364,6 @@ lmm_db_traverse(struct sys_db *db, char *table, sys_db_trav_cb_t cb, void *args)
 		if (rc)
 			break;
 
-		d_iov_set(&key, db_key.mv_data, db_key.mv_size);
 		rc = cb(db, table, &key, args);
 		D_FREE(key.iov_buf);
 		if (rc)

--- a/src/include/daos/sys_db.h
+++ b/src/include/daos/sys_db.h
@@ -1,0 +1,53 @@
+/**
+ * (C) Copyright 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * This file is part of daos. It implements some miscellaneous policy functions
+ */
+#ifndef __SYS_DB_H__
+#define __SYS_DB_H__
+
+#include <daos_types.h>
+
+struct sys_db;
+typedef int (*sys_db_trav_cb_t)(struct sys_db *db, char *table, d_iov_t *key,
+				void *args);
+
+#define SYS_DB_NAME_SZ		32
+
+/** system database is a simple local KV store */
+struct sys_db {
+	char	 sd_name[SYS_DB_NAME_SZ];
+	/** look up the provided key in \a table and return its value */
+	int	(*sd_fetch)(struct sys_db *db, char *table,
+			    d_iov_t *key, d_iov_t *val);
+	/** update or insert a KV pair to \a table */
+	int	(*sd_upsert)(struct sys_db *db, char *table,
+			     d_iov_t *key, d_iov_t *val);
+	/** reserved */
+	int	(*sd_insert)(struct sys_db *db, char *table,
+			     d_iov_t *key, d_iov_t *val);
+	/** reserved */
+	int	(*sd_update)(struct sys_db *db, char *table,
+			     d_iov_t *key, d_iov_t *val);
+	/** delete provided key and its value from the \a table */
+	int	(*sd_delete)(struct sys_db *db, char *table, d_iov_t *key);
+	/** traverse all keys in the \a table */
+	int	(*sd_traverse)(struct sys_db *db, char *table,
+			       sys_db_trav_cb_t cb, void *args);
+	int	(*sd_tx_begin)(struct sys_db *db);
+	int	(*sd_tx_end)(struct sys_db *db, int rc);
+	void	(*sd_lock)(struct sys_db *db);
+	void	(*sd_unlock)(struct sys_db *db);
+};
+
+/* for lmdb backend apis */
+int lmm_db_init(const char *db_path);
+int lmm_db_init_ex(const char *db_path, const char *db_name,
+		   bool force_create, bool destroy_db_on_fini);
+void lmm_db_fini(void);
+struct sys_db *lmm_db_get(void);
+
+#endif /* __SYS_DB_H__ */

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -418,12 +418,14 @@ void bio_register_bulk_ops(int (*bulk_create)(void *ctxt, d_sg_list_t *sgl,
  * \param[IN] mem_size		SPDK memory alloc size when using primary mode
  * \param[IN] hugepage_size	Configured hugepage size on system
  * \paran[IN] tgt_nr		Number of targets
+ * \param[IN] db		persistent database to store SMD data
  * \param[IN] bypass		Set to bypass health data collection
  *
  * \return		Zero on success, negative value on error
  */
 int bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
-		  unsigned int hugepage_size, unsigned int tgt_nr, bool bypass);
+		  unsigned int hugepage_size, unsigned int tgt_nr,
+		  struct sys_db *db, bool bypass);
 
 /**
  * Global NVMe finilization.
@@ -901,8 +903,7 @@ int bio_copy(struct bio_io_context *ioctxt, struct umem_instance *umem,
 	     struct bio_csum_desc *csum_desc);
 
 enum bio_mc_flags {
-	BIO_MC_FL_SYSDB		= (1UL << 0),	/* for sysdb */
-	BIO_MC_FL_RDB		= (1UL << 1),	/* for RDB */
+	BIO_MC_FL_RDB		= (1UL << 0),	/* for RDB */
 };
 
 /*

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -805,38 +805,6 @@ int ds_get_pool_svc_ranks(uuid_t pool_uuid, d_rank_list_t **svc_ranks);
 int ds_pool_find_bylabel(d_const_string_t label, uuid_t pool_uuid,
 			 d_rank_list_t **svc_ranks);
 
-struct sys_db;
-typedef int (*sys_db_trav_cb_t)(struct sys_db *db, char *table, d_iov_t *key,
-				void *args);
-
-#define SYS_DB_NAME_SZ		32
-
-/** system database is a simple local KV store */
-struct sys_db {
-	char	 sd_name[SYS_DB_NAME_SZ];
-	/** look up the provided key in \a table and return its value */
-	int	(*sd_fetch)(struct sys_db *db, char *table,
-			    d_iov_t *key, d_iov_t *val);
-	/** update or insert a KV pair to \a table */
-	int	(*sd_upsert)(struct sys_db *db, char *table,
-			     d_iov_t *key, d_iov_t *val);
-	/** reserved */
-	int	(*sd_insert)(struct sys_db *db, char *table,
-			     d_iov_t *key, d_iov_t *val);
-	/** reserved */
-	int	(*sd_update)(struct sys_db *db, char *table,
-			     d_iov_t *key, d_iov_t *val);
-	/** delete provided key and its value from the \a table */
-	int	(*sd_delete)(struct sys_db *db, char *table, d_iov_t *key);
-	/** traverse all keys in the \a table */
-	int	(*sd_traverse)(struct sys_db *db, char *table,
-			       sys_db_trav_cb_t cb, void *args);
-	int	(*sd_tx_begin)(struct sys_db *db);
-	int	(*sd_tx_end)(struct sys_db *db, int rc);
-	void	(*sd_lock)(struct sys_db *db);
-	void	(*sd_unlock)(struct sys_db *db);
-};
-
 /** Flags for dss_drpc_call */
 enum dss_drpc_call_flag {
 	/** Do not wait for a response. Implies DSS_DRPC_NO_SCHED. */

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -92,10 +92,8 @@ enum vos_pool_open_flags {
 	VOS_POF_SKIP_UUID_CHECK = (1 << 2),
 	/** Caller does VEA flush periodically */
 	VOS_POF_EXTERNAL_FLUSH	= (1 << 3),
-	/** VOS DB pool*/
-	VOS_POF_SYSDB	= (1 << 4),
 	/** RDB pool */
-	VOS_POF_RDB	= (1 << 5),
+	VOS_POF_RDB	= (1 << 4),
 };
 
 enum vos_oi_attr {

--- a/src/vos/sys_db.c
+++ b/src/vos/sys_db.c
@@ -12,6 +12,7 @@
 
 #include <sys/stat.h>
 #include <daos_srv/vos.h>
+#include <daos/sys_db.h>
 #include "vos_internal.h"
 
 /* Reserved system pool and container UUIDs
@@ -123,13 +124,13 @@ db_open_create(struct sys_db *db, bool try_create)
 	D_DEBUG(DB_IO, "Opening %s, try_create=%d\n", vdb->db_file, try_create);
 	if (try_create) {
 		rc = vos_pool_create(vdb->db_file, vdb->db_pool, SYS_DB_SIZE, 0,
-				     VOS_POF_SYSDB, &vdb->db_poh);
+				     0, &vdb->db_poh);
 		if (rc) {
 			D_CRIT("sys pool create error: "DF_RC"\n", DP_RC(rc));
 			goto failed;
 		}
 	} else {
-		rc = vos_pool_open(vdb->db_file, vdb->db_pool, VOS_POF_SYSDB, &vdb->db_poh);
+		rc = vos_pool_open(vdb->db_file, vdb->db_pool, 0, &vdb->db_poh);
 		if (rc) {
 			/**
 			 * The access checks above should ensure the file
@@ -425,7 +426,7 @@ vos_db_fini(void)
 		if (vos_db.db_destroy_db) {
 			int rc;
 
-			rc = vos_pool_destroy_ex(vos_db.db_file, vos_db.db_pool, VOS_POF_SYSDB);
+			rc = vos_pool_destroy_ex(vos_db.db_file, vos_db.db_pool, 0);
 			if (rc != 0)
 				D_ERROR(DF_UUID": failed to destroy %s: %d\n",
 					DP_UUID(vos_db.db_pool), vos_db.db_file, rc);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -198,8 +198,6 @@ struct vos_pool {
 	int			vp_excl:1;
 	/** this pool is for rdb */
 	bool			vp_rdb;
-	/** this pool is for sysdb */
-	bool			vp_sysdb;
 	/** caller specifies pool is small (for sys space reservation) */
 	bool			vp_small;
 	/** UUID of vos pool */

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -139,8 +139,6 @@ vos2mc_flags(unsigned int vos_flags)
 {
 	enum bio_mc_flags mc_flags = 0;
 
-	if (vos_flags & VOS_POF_SYSDB)
-		mc_flags |= BIO_MC_FL_SYSDB;
 	if (vos_flags & VOS_POF_RDB)
 		mc_flags |= BIO_MC_FL_RDB;
 
@@ -367,7 +365,7 @@ pool_hop_free(struct d_ulink *hlink)
 		bio_ioctxt_close(pool->vp_dummy_ioctxt);
 
 	if (pool->vp_dying)
-		vos_delete_blob(pool->vp_id, pool->vp_sysdb ? VOS_POF_SYSDB : 0);
+		vos_delete_blob(pool->vp_id, 0);
 
 	D_FREE(pool);
 }
@@ -947,7 +945,6 @@ pool_open(void *ph, struct vos_pool_df *pool_df, unsigned int flags, void *metri
 	pool->vp_opened = 1;
 	pool->vp_excl = !!(flags & VOS_POF_EXCL);
 	pool->vp_small = !!(flags & VOS_POF_SMALL);
-	pool->vp_sysdb = !!(flags & VOS_POF_SYSDB);
 	pool->vp_rdb = !!(flags & VOS_POF_RDB);
 	if (pool_df->pd_version >= VOS_POOL_DF_2_2)
 		pool->vp_feats |= VOS_POOL_FEAT_2_2;

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -74,6 +74,7 @@ BuildRequires: daos-raft-devel = 0.9.1-2.402.gbae8a56%{?dist}
 BuildRequires: openssl-devel
 BuildRequires: libevent-devel
 BuildRequires: libyaml-devel
+BuildRequires: lmdb-devel
 BuildRequires: libcmocka-devel
 BuildRequires: valgrind-devel
 BuildRequires: systemd

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -150,12 +150,15 @@ if [ -d "/mnt/daos" ]; then
         dd if=/dev/zero of="${AIO_DEV}" bs=1G count=10
         sed -i "s+\"name\": \"AIO_1\"+\"name\": \"AIO_7\"+g" ${NVME_CONF}
 
+	LMM_DB_PATH=$(mktemp -d /tmp/lmm_db_XXXXX)
         export DAOS_MD_ON_SSD=1
+	export DAOS_LMM_DB_PATH=$LMM_DB_PATH
         run_test "sudo -E ${SL_PREFIX}/bin/vos_tests" -a
-        unset DAOS_MD_ON_SSD
+        unset DAOS_MD_ON_SSD DAOS_LMM_DB_PATH
 
         rm -f "${AIO_DEV}"
         rm -f "${NVME_CONF}"
+	rm -f "${LMM_DB_PATH}"
 
         run_test src/vos/tests/evt_stress.py
         run_test src/vos/tests/evt_stress.py --algo dist_even

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -44,6 +44,7 @@ dnf --nodocs install \
     libunwind-devel \
     libuuid-devel \
     libyaml-devel \
+    lmdb-devel \
     Lmod \
     lz4-devel \
     make \

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -43,6 +43,7 @@ dnf --nodocs install \
     libtool-ltdl-devel \
     libunwind-devel \
     libuuid-devel \
+    lmdb-devel \
     libyaml-devel \
     lz4-devel \
     make \

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -43,6 +43,7 @@ dnf --nodocs install \
     libunwind-devel \
     libuuid-devel \
     libyaml-devel \
+    lmdb-devel \
     lua-lmod \
     make \
     maven \

--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -41,6 +41,7 @@ apt-get install \
     libtool-bin \
     libunwind-dev \
     libyaml-dev \
+    liblmdb-dev \
     locales \
     maven \
     numactl \


### PR DESCRIPTION
LMDB is added as new backend kv store for sys DB, this new backend sys DB will be used to store SMD for MD-ON-SSD case.

For PMDK case, SMD will still be stored in PMEM for backward compatibility purpose.

Required-githooks: true
Signed-off-by: Wang Shilong <shilong.wang@intel.com>
