### PR TITLE
DAOS-11517 test: deployment/network_failure.py - Create pool across 4…

### DIFF
--- a/src/tests/ftest/deployment/network_failure.py
+++ b/src/tests/ftest/deployment/network_failure.py
@@ -5,6 +5,7 @@
 """
 import os
 import time
+from collections import defaultdict
 from ClusterShell.NodeSet import NodeSet
 
 from ior_test_base import IorTestBase
@@ -120,6 +121,47 @@ class NetworkFailureTest(IorTestBase):
                 ip_to_host[ip_address] = NodeSet(str(result["hosts"]))
 
         return ip_to_host
+
+    def create_host_to_ranks(self, ip_to_host, system_query_members):
+        """Create a dictionary of hostname to ranks.
+
+        Args:
+            ip_to_host (dict): create_ip_to_host output.
+            system_query_members (dict): Contents of dmg system query accessed with
+                ["response"]["members"].
+
+        Returns:
+            dict: Hostname to ranks mapping. Hostname (key) is string. Ranks (value) is
+                list of int.
+
+        """
+        host_to_ranks = defaultdict(list)
+        for member in system_query_members:
+            ip_addr = member["addr"].split(":")[0]
+            host = str(ip_to_host[ip_addr])
+            rank = member["rank"]
+            host_to_ranks[host].append(rank)
+
+        return host_to_ranks
+
+    def wait_for_ranks_to_join(self):
+        """Wait for all ranks to join.
+
+        Returns:
+            bool: False if any of the rank's state is in the failed state (unknown,
+                excluded, errored, unresponsive) after waiting for 2 min. True otherwise.
+
+        """
+        time.sleep(60)
+
+        for _ in range(12):
+            time.sleep(10)
+            if check_system_query_status(self.get_dmg_command().system_query()):
+                self.log.info("All ranks are joined after updating the interface.")
+                return True
+            self.log.info("One or more servers crashed. Check system query again.")
+
+        return False
 
     def verify_network_failure(self, ior_namespace, container_namespace):
         """Verify network failure can be recovered with some user interventions with
@@ -291,11 +333,11 @@ class NetworkFailureTest(IorTestBase):
         Verify that network failure in a node where pool isn't created doesn't affect the
         connection.
 
-        1. Determine the two ranks to create the pool and an interface to take down.
-        2. Create a pool across two ranks on the same node.
+        1. Determine the four ranks to create the pool and an interface to take down.
+        2. Create a pool across the four ranks on the two nodes.
         3. Create a container without redundancy factor.
         4. Take down the interface where the pool isn't created. This will simulate the
-        case where there’s a network failure, but doesn’t affect the user because their
+        case where there’s a network failure, but does not affect the user because their
         pool isn’t created on the failed node (assuming that everything else such as
         client node, engine, etc. are still working).
         5. Run IOR with oclass SX.
@@ -310,44 +352,35 @@ class NetworkFailureTest(IorTestBase):
         :avocado: tags=deployment,network_failure
         :avocado: tags=network_failure_isolation
         """
-        # 1. Determine the two ranks to create the pool and an interface to take down.
-        # We'll create a pool on rank 0 and the other rank that's on the same node. Find
-        # hostname of rank 0.
-        rank_0_ip = None
+        # 1. Determine the four ranks to create the pool and an interface to take down.
+        # We'll create a pool on two ranks in hostlist_servers[0] and two ranks in
+        # hostlist_servers[1].
+        # There's no way to determine the mapping of hostname to ranks, but there's IP
+        # address to rank mapping and IP address to hostname mapping, so we'll combine
+        # them.
+        # Call dmg system query, which contains IP address - Rank mapping.
         output = self.get_dmg_command().system_query()
         members = output["response"]["members"]
-        for member in members:
-            if member["rank"] == 0:
-                rank_0_ip = member["addr"].split(":")[0]
-                break
-        self.log.info("rank 0 IP = %s", rank_0_ip)
 
-        # Find the other rank that's on the same node as in rank 0. Call it rank_r.
-        rank_r = None
-        for member in members:
-            if member["addr"].split(":")[0] == rank_0_ip and member["rank"] != 0:
-                rank_r = member["rank"]
-                break
-        self.log.info("rank_r = %s", rank_r)
-
-        # Find the hostname that's different from rank_0_ip. We'll take down the
-        # interface on it.
-        # dmg system query output gives IP address, but run_pcmd doesn't work with IP in
-        # CI. In addition, in Aurora, it's easier to determine where to run the ip link
-        # command if we know the hostname, so create the IP - hostname mapping.
+        # Create IP address - Hostname mapping by calling "hostname -i" on every server
+        # node.
         ip_to_host = self.create_ip_to_host()
-        for member in members:
-            ip_addr = member["addr"].split(":")[0]
-            if ip_to_host[rank_0_ip] != ip_to_host[ip_addr]:
-                self.network_down_host = ip_to_host[ip_addr]
-                break
+        # Using dmg system query output and ip_to_host, create Hostname - Ranks mapping.
+        host_to_ranks = self.create_host_to_ranks(
+            ip_to_host=ip_to_host, system_query_members=members)
+        # Create a pool on the two ranks on two of the server nodes.
+        target_list = []
+        target_list.extend(host_to_ranks[self.hostlist_servers[0]])
+        target_list.extend(host_to_ranks[self.hostlist_servers[1]])
+        self.log.info("Ranks to create pool = %s", target_list)
+
+        # We'll take down network on the last server node where the pool isn't created.
+        self.network_down_host = NodeSet(self.hostlist_servers[2])
         self.log.info("network_down_host = %s", self.network_down_host)
 
-        # 2. Create a pool across two ranks on the same node; 0 and rank_r. We have to
-        # provide the size because we're using --ranks.
-        self.add_pool(namespace="/run/pool_size_value/*", create=False)
-        self.pool.target_list.update([0, rank_r])
-        self.pool.create()
+        # 2. Create a pool across the four ranks on the two nodes. Use --nsvc=3. We have
+        # to provide the size because we're using --ranks.
+        self.add_pool(namespace="/run/pool_size_value/*", target_list=target_list)
 
         # 3. Create a container without redundancy factor.
         self.container = []
@@ -356,8 +389,7 @@ class NetworkFailureTest(IorTestBase):
 
         # 4. Take down the interface where the pool isn't created.
         errors = []
-        self.interface = self.params.get(
-            "fabric_iface", "/run/server_config/servers/0/*")
+        self.interface = self.params.get("fabric_iface", "/run/server_config/servers/0/*")
 
         # wolf
         if self.test_env == "ci":
@@ -369,6 +401,12 @@ class NetworkFailureTest(IorTestBase):
             command = "sudo ip link set {} {}".format(self.interface, "down")
             self.log.debug("## Call %s on %s", command, self.network_down_host)
             time.sleep(20)
+
+        # Some ranks may be excluded after bringing down the network interface, so wait
+        # until they are up (joined).
+        if not self.wait_for_ranks_to_join():
+            self.fail(
+                "One or more servers crashed after bringing down the network interface!")
 
         # 5. Run IOR with oclass SX.
         ior_results = {}
@@ -411,16 +449,7 @@ class NetworkFailureTest(IorTestBase):
 
         # Some ranks may be excluded after bringing up the network interface, so wait
         # until they are up (joined).
-        server_crashed = True
-        for _ in range(6):
-            time.sleep(10)
-            if check_system_query_status(self.get_dmg_command().system_query()):
-                self.log.info("All ranks are joined after bringing up the interface.")
-                server_crashed = False
-                break
-            self.log.info("One or more servers crashed. Check system query again.")
-
-        if server_crashed:
+        if not self.wait_for_ranks_to_join():
             msg = "One or more servers crashed after bringing up the network interface!"
             errors.append(msg)
 

--- a/src/tests/ftest/deployment/network_failure.yaml
+++ b/src/tests/ftest/deployment/network_failure.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 3
   test_clients: 1
 
-timeout: 300
+timeout: 420
 daos_server:
   pattern_timeout: 60
 
@@ -41,6 +41,7 @@ pool_size_ratio_80:
 pool_size_value:
   size: 100G
   control_method: dmg
+  svcn: 3
 
 container_wo_rf:
   type: POSIX


### PR DESCRIPTION
…… (#10195)

For the network isolation test, we used to create a pool across two ranks in one node. However, this may cause an issue with pool service replica when the network interface is taken down.

Pool service leader can be located in any node regardless of the pool’s location, so if we happen to take down the interface on the node where the leader is located, the pool service will not be accessible and will not be recovered. Then the subsequent operations may fail.

To resolve this issue, create a pool across four ranks in two nodes with --nsvc=3, 3 service replicas. Then we should be able to recover even when the leader is
affected.

Also added the dmg system query check after bringing down/up the network interface. When we update the
interface, some ranks may get excluded after a while. i.e., they don't get excluded right after the update. Thus, wait for 1 min, then repeatedly call dmg system query to check the status.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-repeat: 6
Test-tag: target_failure_with_rp network_failure_isolation
Required-githooks: true
Signed-off-by: Makito Kano <makito.kano@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
