### PR TITLE
DAOS-11602 vos: fix some DTX visibility issues

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1133,9 +1133,6 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		return ALB_AVAILABLE_DIRTY;
 
 	if (!found) {
-		/** If we move to not marking entries explicitly, this
-		 *  state will mean it is committed
-		 */
 		D_DEBUG(DB_TRACE,
 			"Entry %d "DF_U64" not in lru array, it must be"
 			" committed\n", entry, epoch);
@@ -1245,18 +1242,26 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		return ALB_UNAVAILABLE;
 
 	if (intent == DAOS_INTENT_DEFAULT) {
-		if (!(DAE_FLAGS(dae) & DTE_LEADER) ||
-		    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER))
-			/* Non-leader or rebuild case, return -DER_INPROGRESS,
-			 * then the caller will retry the RPC (with leader).
-			 */
-			return dtx_inprogress(dae, dth, false, true, 1);
+		if (DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER))
+			return dtx_inprogress(dae, dth, false, true, 6);
 
-		/* For transactional read, has to wait the non-committed
+		/*
+		 * For transactional read, has to wait the non-committed
 		 * modification to guarantee the transaction semantics.
 		 */
 		if (dtx_is_valid_handle(dth))
 			return dtx_inprogress(dae, dth, false, true, 2);
+
+		/* Ignore non-prepared DTX in spite of on leader or not. */
+		if (dae->dae_dbd == NULL || dae->dae_dth != NULL)
+			return ALB_UNAVAILABLE;
+
+		if (!(DAE_FLAGS(dae) & DTE_LEADER))
+			/*
+			 * Read on non-leader, return -DER_INPROGRESS, then the caller
+			 * will refresh the DTX or retry related RPC with the leader.
+			 */
+			return dtx_inprogress(dae, dth, false, true, 1);
 
 		/* For stand-alone read on leader, ignore non-committed DTX. */
 		return ALB_UNAVAILABLE;
@@ -1798,7 +1803,21 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 		if (mbs != NULL)
 			dae->dae_maybe_shared = 1;
 
-		if (dae->dae_dbd == NULL || dae->dae_dth != NULL)
+		if (for_refresh) {
+			/*
+			 * If DTX_REFRESH happened on current DTX entry but it was not marked
+			 * as leader, then there must be leader switch and the DTX resync has
+			 * not completed yet. Under such case, returning "-DER_INPROGRESS" to
+			 * make related DTX_REFRESH sponsor (client) to retry sometime later.
+			 */
+			if (!(DAE_FLAGS(dae) & DTE_LEADER))
+				return -DER_INPROGRESS;
+
+			return dae->dae_prepared ? DTX_ST_PREPARED : DTX_ST_INITED;
+		}
+
+		/* Not committable yet, related RPC handler ULT is still running. */
+		if (dae->dae_dth != NULL)
 			return -DER_INPROGRESS;
 
 		if (epoch != NULL) {
@@ -1809,20 +1828,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 				return -DER_MISMATCH;
 		}
 
-		if (dae->dae_prepared) {
-			/*
-			 * If DTX_REFRESH happened on current DTX entry but it was not marked
-			 * as leader, then there must be leader switch and the DTX resync has
-			 * not completed yet. Under such case, returning "-DER_INPROGRESS" to
-			 * make related DTX_REFRESH sponsor (client) to retry sometime later.
-			 */
-			if (for_refresh && !(DAE_FLAGS(dae) & DTE_LEADER))
-				return -DER_INPROGRESS;
-
-			return DTX_ST_PREPARED;
-		}
-
-		return DTX_ST_INITED;
+		return dae->dae_prepared ? DTX_ST_PREPARED : DTX_ST_INITED;
 	}
 
 	if (rc == -DER_NONEXIST) {


### PR DESCRIPTION
master-commit: eedb765cd3748df0db98f7f8dbfcdc0ec6b18cfc

Mainly include the followings:

1. If the DTX entry is not committable, then do NOT return -DER_INPROGRESS when DTX refresh on it.

2. For stand-alone read, ignore non-prepared DTX in spite of it is on the leader or not.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
