### PR TITLE
DAOS-12279 control: Remove support for config-specified ranks

### DIFF
--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -240,7 +240,6 @@ func TestServerConfig_Constructed(t *testing.T) {
 		engine.MockConfig().
 			WithSystemName("daos_server").
 			WithSocketDir("./.daos/daos_server").
-			WithRank(0).
 			WithTargetCount(16).
 			WithHelperStreamCount(4).
 			WithServiceThreadCore(0).
@@ -271,7 +270,6 @@ func TestServerConfig_Constructed(t *testing.T) {
 		engine.MockConfig().
 			WithSystemName("daos_server").
 			WithSocketDir("./.daos/daos_server").
-			WithRank(1).
 			WithTargetCount(16).
 			WithHelperStreamCount(4).
 			WithServiceThreadCore(22).

--- a/src/control/server/ctl_smd_rpc_test.go
+++ b/src/control/server/ctl_smd_rpc_test.go
@@ -739,7 +739,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 
 			cfg := config.DefaultServer()
 			for i := 0; i < engineCount; i++ {
-				cfg.Engines = append(cfg.Engines, engine.MockConfig().WithTargetCount(1).WithRank(uint32(i)))
+				cfg.Engines = append(cfg.Engines, engine.MockConfig().WithTargetCount(1))
 			}
 			svc := mockControlService(t, log, cfg, nil, nil, nil)
 			svc.harness.started.SetTrue()
@@ -1383,7 +1383,7 @@ func TestServer_CtlSvc_SmdManage(t *testing.T) {
 
 			cfg := config.DefaultServer()
 			for i := 0; i < engineCount; i++ {
-				cfg.Engines = append(cfg.Engines, engine.MockConfig().WithTargetCount(1).WithRank(uint32(i)))
+				cfg.Engines = append(cfg.Engines, engine.MockConfig().WithTargetCount(1))
 			}
 			svc := mockControlService(t, log, cfg, nil, nil, nil)
 			svc.harness.started.SetTrue()

--- a/src/control/server/ctl_storage_test.go
+++ b/src/control/server/ctl_storage_test.go
@@ -206,8 +206,8 @@ func TestServer_CtlSvc_getScmUsage(t *testing.T) {
 			defer test.ShowBufferOnFailure(t, buf)
 
 			var engineCfgs []*engine.Config
-			for i, sc := range tc.storageCfgs {
-				engineCfgs = append(engineCfgs, engine.MockConfig().WithStorage(sc...).WithRank(uint32(i)))
+			for _, sc := range tc.storageCfgs {
+				engineCfgs = append(engineCfgs, engine.MockConfig().WithStorage(sc...))
 			}
 			sCfg := config.DefaultServer().WithEngines(engineCfgs...)
 			cs := mockControlService(t, log, sCfg, nil, nil, tc.smsc)

--- a/src/control/server/ctl_svc_test.go
+++ b/src/control/server/ctl_svc_test.go
@@ -52,7 +52,7 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *config.Server, bm
 		srvCfg: cfg,
 	}
 
-	for _, ec := range cfg.Engines {
+	for idx, ec := range cfg.Engines {
 		trc := new(engine.TestRunnerConfig)
 		trc.Running.SetTrue()
 		runner := engine.NewTestRunner(trc, ec)
@@ -62,7 +62,7 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *config.Server, bm
 			bdev.NewMockProvider(log, bmbc))
 		ei := NewEngineInstance(log, sp, nil, runner)
 		ei.setSuperblock(&Superblock{
-			Rank: ranklist.NewRankPtr(ec.Rank.Uint32()),
+			Rank: ranklist.NewRankPtr(uint32(idx)),
 		})
 		ei.ready.SetTrue()
 		if err := cs.harness.AddInstance(ei); err != nil {

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -138,7 +137,6 @@ func mergeEnvVars(curVars []string, newVars []string) (merged []string) {
 
 // Config encapsulates an I/O Engine's configuration.
 type Config struct {
-	Rank              *ranklist.Rank `yaml:"rank,omitempty"`
 	Modules           string         `yaml:"modules,omitempty" cmdLongFlag:"--modules" cmdShortFlag:"-m"`
 	TargetCount       int            `yaml:"targets,omitempty" cmdLongFlag:"--targets,nonzero" cmdShortFlag:"-t,nonzero"`
 	HelperStreamCount int            `yaml:"nr_xs_helpers" cmdLongFlag:"--xshelpernr" cmdShortFlag:"-x"`
@@ -312,12 +310,6 @@ func (c *Config) WithEnvVars(newVars ...string) *Config {
 // engine subprocess environment.
 func (c *Config) WithEnvPassThrough(allowList ...string) *Config {
 	c.EnvPassThrough = allowList
-	return c
-}
-
-// WithRank sets the instance rank.
-func (c *Config) WithRank(r uint32) *Config {
-	c.Rank = ranklist.NewRankPtr(r)
 	return c
 }
 

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -181,7 +181,6 @@ func TestConfig_Constructed(t *testing.T) {
 
 	// just set all values regardless of validity
 	constructed := MockConfig().
-		WithRank(37).
 		WithFabricProvider("foo+bar").
 		WithFabricInterface("qib42"). // qib42 recognized by mock validator
 		WithFabricInterfacePort(100).

--- a/src/control/server/engine/testdata/full.golden
+++ b/src/control/server/engine/testdata/full.golden
@@ -1,4 +1,3 @@
-rank: 37
 modules: foo,bar,baz
 targets: 12
 nr_xs_helpers: 1

--- a/src/control/server/instance_superblock.go
+++ b/src/control/server/instance_superblock.go
@@ -154,12 +154,6 @@ func (ei *EngineInstance) createSuperblock(recreate bool) error {
 		superblock.HostFaultDomain = ei.hostFaultDomain.String()
 	}
 
-	if cfg.Rank != nil {
-		superblock.Rank = new(ranklist.Rank)
-		if cfg.Rank != nil {
-			*superblock.Rank = *cfg.Rank
-		}
-	}
 	ei.setSuperblock(superblock)
 	ei.log.Debugf("index %d: creating %s: (rank: %s, uuid: %s)",
 		ei.Index(), ei.superblockPath(), superblock.Rank, superblock.UUID)

--- a/src/control/server/instance_superblock_test.go
+++ b/src/control/server/instance_superblock_test.go
@@ -29,12 +29,11 @@ func TestServer_Instance_createSuperblock(t *testing.T) {
 	defer cleanup()
 
 	h := NewEngineHarness(log)
-	for idx, mnt := range []string{"one", "two"} {
+	for _, mnt := range []string{"one", "two"} {
 		if err := os.MkdirAll(filepath.Join(testDir, mnt), 0777); err != nil {
 			t.Fatal(err)
 		}
 		cfg := engine.MockConfig().
-			WithRank(uint32(idx)).
 			WithSystemName(t.Name()).
 			WithStorage(
 				storage.NewTierConfig().
@@ -73,9 +72,6 @@ func TestServer_Instance_createSuperblock(t *testing.T) {
 
 	for idx, e := range h.Instances() {
 		i := e.(*EngineInstance)
-		if i._superblock.Rank.Uint32() != uint32(idx) {
-			t.Fatalf("instance %d has rank %s (not %d)", idx, i._superblock.Rank, idx)
-		}
 
 		test.AssertEqual(t, i.hostFaultDomain.String(), i._superblock.HostFaultDomain, fmt.Sprintf("instance %d", idx))
 

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -240,15 +240,6 @@
 #
 #engines:
 #-
-#  # Rank to be assigned as identifier for this engine.
-#  # Immutable after running "dmg storage format".
-#  #
-#  # Optional parameter; must be unique across all engines in the DAOS system.
-#  #
-#  # default: will be auto generated if not supplied.
-#
-#  rank: 0
-#
 #  # Number of I/O service threads (and network endpoints) per engine.
 #  # Immutable after running "dmg storage format".
 #  #
@@ -410,15 +401,6 @@
 #
 #
 #-
-#  # Rank to be assigned as identifier for this engine.
-#  # Immutable after running "dmg storage format".
-#  #
-#  # Optional parameter; must be unique across all engines in the DAOS system.
-#  #
-#  # default: will be auto generated if not supplied.
-#
-#  rank: 1
-#
 #  # Number of I/O service threads (and network endpoints) per engine.
 #  # Immutable after running "dmg storage format".
 #  #


### PR DESCRIPTION
The ranks assigned to engines will be determined by the DAOS
Management Service. The old rank parameter in the engine
configuration section was a legacy remnant of pre-Control Plane
days and is a source of confusion and errors for new users.

Features: control

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
