### PR TITLE
DAOS-12268 build: improvements related to compile/link flags

### DIFF
--- a/site_scons/site_tools/compiler_setup.py
+++ b/site_scons/site_tools/compiler_setup.py
@@ -55,6 +55,9 @@ def _base_setup(env):
     env.Append(CCFLAGS=['-g', '-Wextra', '-Wshadow', '-Wall', '-fpic'])
 
     env.AppendIfSupported(CCFLAGS=DESIRED_FLAGS)
+    env.AppendIfSupported(LINKFLAGS=["-fstack-protector-strong"])
+    if '-fstack-protector-strong' in env["CCFLAGS"]:
+        env.AppendENVPath("CGO_LDFLAGS", "-fstack-protector-strong", sep=" ")
 
     if '-Wmismatched-dealloc' in env['CCFLAGS']:
         env.AppendUnique(CPPDEFINES={'HAVE_DEALLOC': '1'})

--- a/src/gurt/tests/SConscript
+++ b/src/gurt/tests/SConscript
@@ -23,13 +23,11 @@ def scons():
     tests = []
 
     for test in TEST_SRC:
-        flags = []
         testobj = test_env.Object(test)
         testname = os.path.splitext(test)[0]
         testprog = test_env.d_test_program(target=testname,
                                            source=testobj + gurt_targets,
-                                           LIBS=test_env["LIBS"] + ['yaml'],
-                                           LINKFLAGS=flags)
+                                           LIBS=test_env["LIBS"] + ['yaml'])
         tests.append(testprog)
 
     Default(tests)

--- a/src/tests/ftest/cart/utest/SConscript
+++ b/src/tests/ftest/cart/utest/SConscript
@@ -26,9 +26,7 @@ def scons():
     test_env.AppendUnique(RPATH_FULL=LIBPATH)
 
     for test in TEST_SRC:
-        flags = []
-        testprog = test_env.d_test_program(source=[test, cart_targets, swim_targets, gurt_targets],
-                                           LINKFLAGS=flags)
+        testprog = test_env.d_test_program(source=[test, cart_targets, swim_targets, gurt_targets])
         Default(testprog)
 
 


### PR DESCRIPTION
Test-tag: pr DaosBuild

- Set LINKFLAGS to the same as CCFLAGS.
- Set -fstack-protector-strong in CGO_LDFLAGS if set in CCFLAGS.
- Update some places to not override LINKFLAGS to be empty.
- Fix a build warning in vos_cmd.c

Required-githooks: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
