### PR TITLE
DAOS-12247 object: Use correct grp size for enumeration

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -430,17 +430,18 @@ obj_get_grp_nr(struct dc_object *obj)
 	return obj->cob_grp_nr;
 }
 
-/* Get a valid shard from an object group */
+/* Get a valid shard from an replicate object group for readonly operation */
 static int
-obj_grp_valid_shard_get(struct dc_object *obj, int grp_idx,
-			unsigned int map_ver,
-			struct obj_auxi_tgt_list *failed_list)
+obj_replica_grp_fetch_valid_shard_get(struct dc_object *obj, int grp_idx,
+				      unsigned int map_ver,
+				      struct obj_auxi_tgt_list *failed_list)
 {
 	int grp_start;
 	int idx;
 	int grp_size;
 	int i = 0;
 
+	D_ASSERT(!obj_is_ec(obj));
 	grp_size = obj_get_grp_size(obj);
 	D_ASSERT(grp_size > 0);
 
@@ -476,6 +477,10 @@ obj_grp_valid_shard_get(struct dc_object *obj, int grp_idx,
 		index = (idx + i) % obj_get_replicas(obj) + grp_start;
 		/* let's skip the rebuild shard */
 		if (obj->cob_shards->do_shards[index].do_rebuilding)
+			continue;
+
+		/* skip the reintegrating shard as well */
+		if (obj->cob_shards->do_shards[index].do_reintegrating)
 			continue;
 
 		/* Skip the target which is already in the failed list, i.e.
@@ -521,8 +526,8 @@ obj_shard_find_replica(struct dc_object *obj, unsigned int target,
 		return -DER_NONEXIST;
 
 	grp_idx = idx / obj_get_replicas(obj);
-	return obj_grp_valid_shard_get(obj, grp_idx, obj->cob_version,
-				       tgt_list);
+	return obj_replica_grp_fetch_valid_shard_get(obj, grp_idx, obj->cob_version,
+						     tgt_list);
 }
 
 static int
@@ -544,7 +549,7 @@ obj_ec_leader_select(struct dc_object *obj, int grp_idx, bool cond_modify, uint3
 
 	oca = obj_get_oca(obj);
 	grp_size = obj_ec_tgt_nr(oca);
-	grp_start = grp_idx * grp_size;
+	grp_start = grp_idx * obj_get_grp_size(obj);
 
 	/* 1. Find one from parity, and start from the last parity. */
 	tgt_idx = obj_ec_shard_idx(obj, dkey_hash, grp_size - 1);
@@ -580,8 +585,10 @@ obj_ec_leader_select(struct dc_object *obj, int grp_idx, bool cond_modify, uint3
 		pl_shard = obj_get_shard(obj, shard);
 		if (pl_shard->po_target == -1 || pl_shard->po_shard == -1 ||
 		    pl_shard->po_rebuilding) {
-			D_ERROR(DF_OID" unhealthy targets exceed the max redundancy, e_p %d\n",
-				DP_OID(obj->cob_md.omd_id), obj_ec_parity_tgt_nr(oca));
+			D_ERROR(DF_OID" unhealthy targets exceed the max redundancy, e_p %d"
+				" shard %d %u/%u/%u\n", DP_OID(obj->cob_md.omd_id),
+				obj_ec_parity_tgt_nr(oca), shard, pl_shard->po_target,
+				pl_shard->po_shard, pl_shard->po_rebuilding);
 			D_GOTO(unlock, rc = -DER_IO);
 		}
 		break;
@@ -596,8 +603,8 @@ obj_ec_leader_select(struct dc_object *obj, int grp_idx, bool cond_modify, uint3
 
 unlock:
 	D_RWLOCK_UNLOCK(&obj->cob_lock);
-	D_DEBUG(DB_TRACE, DF_OID" choose shard %d as leader for group%d layout %u\n",
-		DP_OID(obj->cob_md.omd_id), shard, grp_idx, obj->cob_layout_version);
+	D_DEBUG(DB_TRACE, DF_OID" choose shard %d as leader for group%d layout %u: %d\n",
+		DP_OID(obj->cob_md.omd_id), shard, grp_idx, obj->cob_layout_version, rc);
 
 	return rc;
 }
@@ -955,8 +962,9 @@ obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
 
 	rc = obj_shard_open(obj, shard, map_ver, &obj_shard);
 	if (rc != 0) {
-		D_DEBUG(DB_IO, DF_OID" obj_shard_open %u, rc "DF_RC".\n",
-			DP_OID(obj->cob_md.omd_id), shard, DP_RC(rc));
+		D_CDEBUG(rc == -DER_STALE || rc == -DER_NONEXIST, DB_IO, DLOG_ERR,
+			 DF_OID" obj_shard_open %u opc %u, rc "DF_RC".\n",
+			 DP_OID(obj->cob_md.omd_id), obj_auxi->opc, shard, DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
@@ -1169,7 +1177,11 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 				if (rc != -DER_NONEXIST)
 					D_GOTO(out, rc);
 				rc = 0;
-				tgt_idx = (tgt_idx + 1) % obj_get_grp_size(obj);
+				if (obj_is_modification_opc(obj_auxi->opc))
+					tgt_idx = (tgt_idx + 1) % obj_get_grp_size(obj);
+				else
+					tgt_idx = (tgt_idx + 1) %
+						  daos_oclass_grp_size(&obj->cob_oca);
 				continue;
 			}
 
@@ -1195,7 +1207,10 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 					D_GOTO(out, rc = -DER_NEED_TX);
 				}
 			}
-			tgt_idx = (tgt_idx + 1) % obj_get_grp_size(obj);
+			if (obj_is_modification_opc(obj_auxi->opc))
+				tgt_idx = (tgt_idx + 1) % obj_get_grp_size(obj);
+			else
+				tgt_idx = (tgt_idx + 1) % daos_oclass_grp_size(&obj->cob_oca);
 			cur_grp_size--;
 			tgt++;
 		}
@@ -5121,7 +5136,7 @@ obj_ec_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned 
 		DP_OID(obj->cob_md.omd_id), grp_idx, tgt_idx, obj->cob_layout_version);
 	*shard = tgt_idx + grp_start;
 	for (i = 0; i < obj_ec_tgt_nr(oca); i++,
-	     tgt_idx = (tgt_idx + 1) % obj_get_grp_size(obj)) {
+	     tgt_idx = (tgt_idx + 1) % obj_ec_tgt_nr(oca)) {
 		struct obj_tgt_oiod	*toiod;
 		uint32_t		ec_deg_tgt;
 
@@ -5151,8 +5166,9 @@ obj_ec_fetch_shards_get(struct dc_object *obj, daos_obj_fetch_t *args, unsigned 
 			DP_OID(obj->cob_md.omd_id), grp_start + tgt_idx, grp_start + ec_deg_tgt);
 
 		/* Update the tgt map */
-		D_ASSERT(is_ec_parity_shard(obj_auxi->obj, obj_auxi->dkey_hash,
-					    grp_start + ec_deg_tgt));
+		/* Fetch will never from the extending shard */
+		D_ASSERT(ec_deg_tgt < obj_ec_tgt_nr(oca));
+		D_ASSERT(is_ec_parity_shard(obj_auxi->obj, obj_auxi->dkey_hash, ec_deg_tgt));
 		clrbit(tgt_bitmap, tgt_idx);
 		toiod = obj_ec_tgt_oiod_get(obj_auxi->reasb_req.tgt_oiods,
 					    obj_auxi->reasb_req.orr_tgt_nr, tgt_idx);
@@ -5200,7 +5216,8 @@ obj_replica_fetch_shards_get(struct dc_object *obj, struct obj_auxi_args *obj_au
 	else if (to_leader)
 		rc = obj_replica_leader_select(obj, grp_idx, map_ver);
 	else
-		rc = obj_grp_valid_shard_get(obj, grp_idx, map_ver, obj_auxi->failed_tgt_list);
+		rc = obj_replica_grp_fetch_valid_shard_get(obj, grp_idx, map_ver,
+							   obj_auxi->failed_tgt_list);
 
 	if (rc < 0)
 		return rc;
@@ -6092,7 +6109,7 @@ obj_ec_get_parity_or_alldata_shard(struct obj_auxi_args *obj_auxi, unsigned int 
 	for (i = 0; i < obj_ec_data_tgt_nr(oca); i++) {
 		int shard_idx;
 
-		shard_idx = grp_start + (first + i) % obj_get_grp_size(obj);
+		shard_idx = grp_start + (first + i) % obj_ec_tgt_nr(oca);
 		if (obj_shard_is_invalid(obj, shard_idx, DAOS_OBJ_RPC_ENUMERATE)) {
 			shard = -DER_DATA_LOSS;
 			D_ERROR("shard %d on "DF_OID" "DF_RC"\n", shard_idx,
@@ -6101,7 +6118,7 @@ obj_ec_get_parity_or_alldata_shard(struct obj_auxi_args *obj_auxi, unsigned int 
 		}
 
 		if (bitmaps != NULL)
-			setbit(*bitmaps, shard_idx % obj_get_grp_size(obj));
+			setbit(*bitmaps, shard_idx % obj_ec_tgt_nr(oca));
 	}
 
 	shard = first + grp_start;
@@ -6164,7 +6181,7 @@ obj_list_shards_get(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 		} else {
 			D_ASSERT(args->dkey_anchor != NULL);
 			grp_idx = dc_obj_anchor2shard(args->dkey_anchor) /
-				  obj_get_replicas(obj);
+				  obj_get_grp_size(obj);
 		}
 	}
 
@@ -6177,8 +6194,8 @@ obj_list_shards_get(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 		if (obj_auxi->to_leader) {
 			rc = obj_replica_leader_select(obj, grp_idx, map_ver);
 		} else {
-			rc = obj_grp_valid_shard_get(obj, grp_idx, map_ver,
-						     obj_auxi->failed_tgt_list);
+			rc = obj_replica_grp_fetch_valid_shard_get(obj, grp_idx, map_ver,
+								   obj_auxi->failed_tgt_list);
 			if (rc == -DER_NONEXIST) {
 				D_ERROR(DF_OID" can not find any shard %d\n",
 					DP_OID(obj->cob_md.omd_id), -DER_DATA_LOSS);
@@ -6396,8 +6413,8 @@ dc_obj_key2anchor(tse_task_t *task)
 		if (obj_auxi->to_leader) {
 			rc = obj_replica_leader_select(obj, grp_idx, map_ver);
 		} else {
-			rc = obj_grp_valid_shard_get(obj, grp_idx, map_ver,
-						     obj_auxi->failed_tgt_list);
+			rc = obj_replica_grp_fetch_valid_shard_get(obj, grp_idx, map_ver,
+								   obj_auxi->failed_tgt_list);
 			if (rc == -DER_NONEXIST) {
 				D_ERROR(DF_OID" can not find any shard %d\n",
 					DP_OID(obj->cob_md.omd_id), -DER_DATA_LOSS);

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -24,7 +24,7 @@ timeouts:
   test_daos_md_replication: 104
   test_daos_rebuild_simple: 1800
   test_daos_drain_simple: 500
-  test_daos_extend_simple: 500
+  test_daos_extend_simple: 1500
   test_daos_oid_allocator: 640
   test_daos_checksum: 500
   test_daos_rebuild_ec: 4800


### PR DESCRIPTION
Use real grp size to get grp idx by shard for enumeration/update,
in case the object is being extended.
    
Skip the reintegrating shard for read operation.
    
Add more tests for extending.
    
Required-githooks: true
    
Signed-off-by: Di Wang <di.wang@intel.com>
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
