### PR TITLE
DAOS-11925 test: Error running /usr/lib/daos/TESTING/ftest/cart/cart_logtest.py

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2726,7 +2726,8 @@ class Launch():
         logger.debug("Running %s on %s files on %s", cart_logtest, source_files, hosts)
         other = ["-print0", "|", "xargs", "-0", "-r0", "-n1", "-I", "%", "sh", "-c",
                  f"'{cart_logtest} % > %.cart_logtest 2>&1'"]
-        result = run_remote(logger, hosts, find_command(source, pattern, depth, other), timeout=1200)
+        result = run_remote(
+            logger, hosts, find_command(source, pattern, depth, other), timeout=1200)
         if not result.passed:
             message = f"Error running {cart_logtest} on the {source_files} files"
             self._fail_test(self.result.tests[-1], "Process", message)

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2727,7 +2727,7 @@ class Launch():
         other = ["-print0", "|", "xargs", "-0", "-r0", "-n1", "-I", "%", "sh", "-c",
                  f"'{cart_logtest} % > %.cart_logtest 2>&1'"]
         result = run_remote(
-            logger, hosts, find_command(source, pattern, depth, other), timeout=1200)
+            logger, hosts, find_command(source, pattern, depth, other), timeout=2500)
         if not result.passed:
             message = f"Error running {cart_logtest} on the {source_files} files"
             self._fail_test(self.result.tests[-1], "Process", message)

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2726,7 +2726,7 @@ class Launch():
         logger.debug("Running %s on %s files on %s", cart_logtest, source_files, hosts)
         other = ["-print0", "|", "xargs", "-0", "-r0", "-n1", "-I", "%", "sh", "-c",
                  f"'{cart_logtest} % > %.cart_logtest 2>&1'"]
-        result = run_remote(logger, hosts, find_command(source, pattern, depth, other), timeout=900)
+        result = run_remote(logger, hosts, find_command(source, pattern, depth, other), timeout=1200)
         if not result.passed:
             message = f"Error running {cart_logtest} on the {source_files} files"
             self._fail_test(self.result.tests[-1], "Process", message)

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2364,7 +2364,7 @@ class Launch():
                 "pattern": "*log*",
                 "hosts": test.host_info.all_hosts,
                 "depth": 1,
-                "timeout": 900,
+                "timeout": 1200,
             }
             remote_files["cart log files"] = {
                 "source": daos_test_log_dir,
@@ -2372,7 +2372,7 @@ class Launch():
                 "pattern": "*log*",
                 "hosts": test.host_info.all_hosts,
                 "depth": 2,
-                "timeout": 900,
+                "timeout": 1200,
             }
             remote_files["ULTs stacks dump files"] = {
                 "source": os.path.join(os.sep, "tmp"),
@@ -2380,7 +2380,7 @@ class Launch():
                 "pattern": "daos_dump*.txt*",
                 "hosts": test.host_info.servers.hosts,
                 "depth": 1,
-                "timeout": 900,
+                "timeout": 1200,
             }
             remote_files["valgrind log files"] = {
                 "source": os.environ.get("DAOS_TEST_SHARED_DIR", DEFAULT_DAOS_TEST_SHARED_DIR),
@@ -2388,7 +2388,7 @@ class Launch():
                 "pattern": "valgrind*",
                 "hosts": test.host_info.servers.hosts,
                 "depth": 1,
-                "timeout": 900,
+                "timeout": 1200,
             }
             for index, hosts in enumerate(core_files):
                 remote_files[f"core files {index + 1}/{len(core_files)}"] = {

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2364,7 +2364,7 @@ class Launch():
                 "pattern": "*log*",
                 "hosts": test.host_info.all_hosts,
                 "depth": 1,
-                "timeout": 1200,
+                "timeout": 900,
             }
             remote_files["cart log files"] = {
                 "source": daos_test_log_dir,
@@ -2372,7 +2372,7 @@ class Launch():
                 "pattern": "*log*",
                 "hosts": test.host_info.all_hosts,
                 "depth": 2,
-                "timeout": 1200,
+                "timeout": 900,
             }
             remote_files["ULTs stacks dump files"] = {
                 "source": os.path.join(os.sep, "tmp"),
@@ -2380,7 +2380,7 @@ class Launch():
                 "pattern": "daos_dump*.txt*",
                 "hosts": test.host_info.servers.hosts,
                 "depth": 1,
-                "timeout": 1200,
+                "timeout": 900,
             }
             remote_files["valgrind log files"] = {
                 "source": os.environ.get("DAOS_TEST_SHARED_DIR", DEFAULT_DAOS_TEST_SHARED_DIR),
@@ -2388,7 +2388,7 @@ class Launch():
                 "pattern": "valgrind*",
                 "hosts": test.host_info.servers.hosts,
                 "depth": 1,
-                "timeout": 1200,
+                "timeout": 900,
             }
             for index, hosts in enumerate(core_files):
                 remote_files[f"core files {index + 1}/{len(core_files)}"] = {
@@ -2727,7 +2727,7 @@ class Launch():
         other = ["-print0", "|", "xargs", "-0", "-r0", "-n1", "-I", "%", "sh", "-c",
                  f"'{cart_logtest} % > %.cart_logtest 2>&1'"]
         result = run_remote(
-            logger, hosts, find_command(source, pattern, depth, other), timeout=2500)
+            logger, hosts, find_command(source, pattern, depth, other), timeout=1800)
         if not result.passed:
             message = f"Error running {cart_logtest} on the {source_files} files"
             self._fail_test(self.result.tests[-1], "Process", message)


### PR DESCRIPTION
Update launch.py logger timeout to 1200 seconds (still failed timeout)

Allow-unstable-test: true
Test-tag: offline_drain
Required-githooks: true
Signed-off-by: Ding Ho ding-hwa.ho@intel.com

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
