### PR TITLE
DAOS-12257 rdb: preallocate rdb-pool vos file

### DIFF
--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -9,8 +9,10 @@
 
 #define D_LOGFAC	DD_FAC(rdb)
 
-#include <daos_srv/rdb.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
+#include <daos_srv/rdb.h>
 #include <daos_srv/daos_mgmt_srv.h>
 #include <daos_srv/daos_engine.h>
 #include <daos_srv/vos.h>
@@ -20,6 +22,55 @@
 static int rdb_open_internal(daos_handle_t pool, daos_handle_t mc, const uuid_t uuid,
 			     uint64_t caller_term, struct rdb_cbs *cbs, void *arg,
 			     struct rdb **dbp);
+
+static int
+rdb_vos_preallocate(const char *path, const uuid_t uuid, daos_size_t size)
+{
+	int			 fd = -1;
+	int			 rc = 0;
+
+	D_DEBUG(DB_MGMT, DF_UUID": creating rdb vos file %s\n", DP_UUID(uuid), path);
+
+	fd = open(path, O_CREAT|O_RDWR, 0600);
+	if (fd < 0) {
+		rc = daos_errno2der(errno);
+		D_ERROR(DF_UUID": failed to create rdb vos file %s: "DF_RC"\n",
+			DP_UUID(uuid), path, DP_RC(rc));
+		return rc;
+	}
+
+	/** Align to 4K or locking the region based on the size will fail */
+	size = D_ALIGNUP(size, 1ULL << 12);
+	/**
+	 * Pre-allocate blocks for vos files in order to provide
+	 * consistent performance and avoid entering into the backend
+	 * filesystem allocator through page faults.
+	 * Use fallocate(2) instead of posix_fallocate(3) since the
+	 * latter is bogus with tmpfs.
+	 */
+	rc = fallocate(fd, 0, 0, size);
+	if (rc) {
+		rc = daos_errno2der(errno);
+		D_ERROR(DF_UUID": failed to allocate vos file %s with size: "DF_U64": "DF_RC"\n",
+			DP_UUID(uuid), path, size, DP_RC(rc));
+		goto out;
+	}
+
+	rc = fsync(fd);
+	(void)close(fd);
+	fd = -1;
+	if (rc) {
+		rc = daos_errno2der(errno);
+		D_ERROR(DF_UUID": failed to sync rdb vos pool %s: "
+			DF_RC"\n", DP_UUID(uuid), path, DP_RC(rc));
+	}
+
+out:
+	if (fd != -1)
+		close(fd);
+
+	return rc;
+}
 
 /**
  * Create an RDB replica at \a path with \a uuid, \a size, and \a replicas, and
@@ -49,15 +100,22 @@ rdb_create(const char *path, const uuid_t uuid, uint64_t caller_term, size_t siz
 	D_DEBUG(DB_MD, DF_UUID": creating db %s with %u replicas: caller_term="DF_X64"\n",
 		DP_UUID(uuid), path, replicas == NULL ? 0 : replicas->rl_nr, caller_term);
 
+	rc = rdb_vos_preallocate(path, uuid, size);
+	if (rc != 0)
+		goto out;
+
+	D_DEBUG(DB_MD, DF_UUID": preallocated rdb vos file %s\n", DP_UUID(uuid), path);
 	/*
 	 * Create and open a VOS pool. RDB pools specify VOS_POF_SMALL for
 	 * basic system memory reservation and VOS_POF_EXCL for concurrent
-	 * access protection.
+	 * access protection. A zero scm_sz accommodates the preallocated file.
 	 */
-	rc = vos_pool_create(path, (unsigned char *)uuid, size, 0 /* nvme_sz */,
+	rc = vos_pool_create(path, (unsigned char *)uuid, 0 /* scm_sz */, 0 /* nvme_sz */,
 			     VOS_POF_SMALL | VOS_POF_EXCL, &pool);
 	if (rc != 0)
 		goto out;
+	D_DEBUG(DB_MD, DF_UUID": created rdb vos file %s\n", DP_UUID(uuid), path);
+
 	ABT_thread_yield();
 
 	/* Create and open the metadata container. */
@@ -67,6 +125,7 @@ rdb_create(const char *path, const uuid_t uuid, uint64_t caller_term, size_t siz
 	rc = vos_cont_open(pool, (unsigned char *)uuid, &mc);
 	if (rc != 0)
 		goto out_pool_hdl;
+	D_DEBUG(DB_MD, DF_UUID": created/opened rdb metadata container\n", DP_UUID(uuid));
 
 	/* Initialize the layout version. */
 	d_iov_set(&value, &version, sizeof(version));
@@ -79,6 +138,7 @@ rdb_create(const char *path, const uuid_t uuid, uint64_t caller_term, size_t siz
 	rc = rdb_raft_init(pool, mc, replicas);
 	if (rc != 0)
 		goto out_mc_hdl;
+	D_DEBUG(DB_MD, DF_UUID": initialized raft\n", DP_UUID(uuid));
 
 	/*
 	 * Mark this replica as fully initialized by storing its UUID.
@@ -106,6 +166,7 @@ out_pool_hdl:
 		if (rc_tmp != 0)
 			D_ERROR(DF_UUID": failed to destroy %s: %d\n",
 				DP_UUID(uuid), path, rc_tmp);
+		D_DEBUG(DB_MD, DF_UUID": cleaned up failed rdb create\n", DP_UUID(uuid));
 	}
 out:
 	return rc;


### PR DESCRIPTION
Before this change, the SCM portion of pool storage target allocation is done in two steps: fallocate() and vos_pool_create/pmemobj_create(), whereas the rdb-pool allocation is done with just pmemobj_create(). In some scenarios (including in specific Linux distro versions), using a small amount of tmpfs results in enospc when allocating rdb-pool. Internally, pmemobj_create() calls posix_fallocate(). The vos target preallocation code prefers fallocate() to avoid issues with tmpfs and posix_fallocate().

With this change, in an attempt to achieve more predicatable allocation behavior, rdb-pool is similarly preallocated with fallocate().

In a separate change, the daos functional tests will need to increase the daos_server scm_size configuration so that there is a little more headroom to perform pool target and rdb-pool allocations, as well as perfom any cleanups needed (e.g., destroy partially created pools as a result of timeout errors).

Test-tag: pr daily_regression vm,full_regression

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
