### PR TITLE
DAOS-12277 test: Convert suite to use new-style dmg helpers

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -750,6 +750,123 @@ out:
 	return rc;
 }
 
+static int
+dmg_pool_target(const char *cmd, const char *dmg_config_file, const uuid_t uuid,
+		const char *grp, d_rank_t rank, int tgt_idx)
+{
+	char			uuid_str[DAOS_UUID_STR_SIZE];
+	int			argcount = 0;
+	char			**args = NULL;
+	struct json_object	*dmg_out = NULL;
+	int			rc = 0;
+
+	uuid_unparse_lower(uuid, uuid_str);
+	args = cmd_push_arg(args, &argcount, "%s ", uuid_str);
+	if (args == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (grp != NULL) {
+		args = cmd_push_arg(args, &argcount, "--sys=%s ", grp);
+		if (args == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	if (tgt_idx >= 0) {
+		args = cmd_push_arg(args, &argcount, "--target-idx=%d ", tgt_idx);
+		if (args == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	args = cmd_push_arg(args, &argcount, "--rank=%d ", rank);
+	if (args == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rc = daos_dmg_json_pipe(cmd, dmg_config_file,
+				args, argcount, &dmg_out);
+	if (rc != 0) {
+		D_ERROR("dmg failed");
+		goto out_json;
+	}
+
+out_json:
+	if (dmg_out != NULL)
+		json_object_put(dmg_out);
+	cmd_free_args(args, argcount);
+out:
+	return rc;
+}
+
+int
+dmg_pool_exclude(const char *dmg_config_file, const uuid_t uuid,
+		 const char *grp, d_rank_t rank, int tgt_idx)
+{
+	return dmg_pool_target("pool exclude", dmg_config_file, uuid, grp, rank, tgt_idx);
+}
+
+int
+dmg_pool_reintegrate(const char *dmg_config_file, const uuid_t uuid,
+		     const char *grp, d_rank_t rank, int tgt_idx)
+{
+	return dmg_pool_target("pool reintegrate", dmg_config_file, uuid, grp, rank, tgt_idx);
+}
+
+int
+dmg_pool_drain(const char *dmg_config_file, const uuid_t uuid,
+	       const char *grp, d_rank_t rank, int tgt_idx)
+{
+	return dmg_pool_target("pool drain", dmg_config_file, uuid, grp, rank, tgt_idx);
+}
+
+int
+dmg_pool_extend(const char *dmg_config_file, const uuid_t uuid,
+		const char *grp, d_rank_t *ranks, int rank_nr)
+{
+	char			uuid_str[DAOS_UUID_STR_SIZE];
+	d_rank_list_t		rank_list = { 0 };
+	char			*rank_str = NULL;
+	int			argcount = 0;
+	char			**args = NULL;
+	struct json_object	*dmg_out = NULL;
+	int			rc = 0;
+
+	uuid_unparse_lower(uuid, uuid_str);
+	args = cmd_push_arg(args, &argcount, "%s ", uuid_str);
+	if (args == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (grp != NULL) {
+		args = cmd_push_arg(args, &argcount, "--sys=%s ", grp);
+		if (args == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	rank_list.rl_ranks = ranks;
+	rank_list.rl_nr = rank_nr;
+
+	rank_str = d_rank_list_to_str(&rank_list);
+	if (rank_str == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+	args = cmd_push_arg(args, &argcount, "--ranks=%s ", rank_str);
+	if (args == NULL)
+		D_GOTO(out_rankstr, rc = -DER_NOMEM);
+
+	rc = daos_dmg_json_pipe("pool extend", dmg_config_file,
+				args, argcount, &dmg_out);
+	if (rc != 0) {
+		D_ERROR("dmg failed");
+		goto out_json;
+	}
+
+out_json:
+	if (dmg_out != NULL)
+		json_object_put(dmg_out);
+	cmd_free_args(args, argcount);
+out_rankstr:
+	D_FREE(rank_str);
+out:
+	return rc;
+}
+
 int
 dmg_pool_list(const char *dmg_config_file, const char *group,
 	      daos_size_t *npools, daos_mgmt_pool_info_t *pools)

--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -829,23 +829,24 @@ dmg_pool_extend(const char *dmg_config_file, const uuid_t uuid,
 	struct json_object	*dmg_out = NULL;
 	int			rc = 0;
 
-	uuid_unparse_lower(uuid, uuid_str);
-	args = cmd_push_arg(args, &argcount, "%s ", uuid_str);
-	if (args == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	if (grp != NULL) {
-		args = cmd_push_arg(args, &argcount, "--sys=%s ", grp);
-		if (args == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-	}
-
 	rank_list.rl_ranks = ranks;
 	rank_list.rl_nr = rank_nr;
 
 	rank_str = d_rank_list_to_str(&rank_list);
 	if (rank_str == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
+
+	uuid_unparse_lower(uuid, uuid_str);
+	args = cmd_push_arg(args, &argcount, "%s ", uuid_str);
+	if (args == NULL)
+		D_GOTO(out_rankstr, rc = -DER_NOMEM);
+
+	if (grp != NULL) {
+		args = cmd_push_arg(args, &argcount, "--sys=%s ", grp);
+		if (args == NULL)
+			D_GOTO(out_rankstr, rc = -DER_NOMEM);
+	}
+
 	args = cmd_push_arg(args, &argcount, "--ranks=%s ", rank_str);
 	if (args == NULL)
 		D_GOTO(out_rankstr, rc = -DER_NOMEM);

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -242,6 +242,58 @@ int dmg_pool_destroy(const char *dmg_config_file,
 		     const uuid_t uuid, const char *grp, int force);
 
 /**
+ * Exclude an entire rank or a target on that rank from a pool.
+ *
+ * \param dmg_config_file
+ *			[IN]	DMG config file
+ * \param uuid		[IN]	UUID of the pool for exclusion
+ * \param grp		[IN]	Process set name of the DAOS servers managing the pool
+ * \param rank		[IN]	Rank to exclude (all targets if no tgt_idx set)
+ * \param tgt_idx	[IN]	Target index to exclude (ignored if -1)
+ */
+int dmg_pool_exclude(const char *dmg_config_file, const uuid_t uuid,
+		     const char *grp, d_rank_t rank, int tgt_idx);
+
+/**
+ * Reintegrate an entire rank or a target on that rank to a pool.
+ *
+ * \param dmg_config_file
+ *			[IN]	DMG config file
+ * \param uuid		[IN]	UUID of the pool for reintegration
+ * \param grp		[IN]	Process set name of the DAOS servers managing the pool
+ * \param rank		[IN]	Rank to reintegrate (all targets if no tgt_idx set)
+ * \param tgt_idx	[IN]	Target index to reintegrate (ignored if -1)
+ */
+int dmg_pool_reintegrate(const char *dmg_config_file, const uuid_t uuid,
+			 const char *grp, d_rank_t rank, int tgt_idx);
+
+/**
+ * Drain an entire rank or a target on that rank from a pool.
+ *
+ * \param dmg_config_file
+ *			[IN]	DMG config file
+ * \param uuid		[IN]	UUID of the pool for reintegration
+ * \param grp		[IN]	Process set name of the DAOS servers managing the pool
+ * \param rank		[IN]	Rank to drain (all targets if no tgt_idx set)
+ * \param tgt_idx	[IN]	Target index to drain (ignored if -1)
+ */
+int dmg_pool_drain(const char *dmg_config_file, const uuid_t uuid,
+		   const char *grp, d_rank_t rank, int tgt_idx);
+
+/**
+ * Extend a pool by adding ranks.
+ *
+ * \param dmg_config_file
+ *			[IN]	DMG config file
+ * \param uuid		[IN]	UUID of the pool for reintegration
+ * \param grp		[IN]	Process set name of the DAOS servers managing the pool
+ * \param ranks		[IN]	Ranks to add to the pool
+ * \param ranks_nr	[IN]	Number of ranks to add to the pool
+ */
+int dmg_pool_extend(const char *dmg_config_file, const uuid_t uuid,
+		    const char *grp, d_rank_t *ranks, int ranks_nr);
+
+/**
  * Set property of the pool with \a pool_uuid.
  *
  * \param dmg_config_file	[IN] DMG config file.

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1835,9 +1835,9 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	rank_to_exclude = layout1->ol_shards[0]->os_shard_loc[0].sd_rank;
 	print_message("Excluding rank %d\n", rank_to_exclude);
 	disabled_nr = disabled_targets(arg, NULL /* affected_engines */);
-	daos_exclude_server(arg->pool.pool_uuid, arg->group,
-			    arg->dmg_config,
-			    layout1->ol_shards[0]->os_shard_loc[0].sd_rank);
+	rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+			      layout1->ol_shards[0]->os_shard_loc[0].sd_rank, -1);
+	assert_success(rc);
 	after_disabled_nr = disabled_targets(arg, &affected_engines);
 	assert_true(disabled_nr < after_disabled_nr);
 	assert_true(d_rank_list_find(affected_engines, rank_to_exclude, NULL));
@@ -1872,8 +1872,9 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	daos_fail_loc_reset();
 	daos_fail_num_set(0);
 
-	daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			  rank_to_exclude);
+	rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+				  rank_to_exclude, -1);
+	assert_success(rc);
 	after_disabled_nr = disabled_targets(arg, NULL);
 	assert_int_equal(disabled_nr, after_disabled_nr);
 	/** wait for rebuild */

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -2287,10 +2287,12 @@ co_rf_simple(void **state)
 		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_REBUILD_DELAY | DAOS_FAIL_ALWAYS,
 				      0, NULL);
-		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, 5);
-		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, 4);
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
+				      arg->group, 5, -1);
+		assert_success(rc);
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
+				      arg->group, 4, -1);
+		assert_success(rc);
 	}
 	par_barrier(PAR_COMM_WORLD);
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
@@ -2327,9 +2329,11 @@ co_rf_simple(void **state)
 			     NULL);
 	assert_rc_equal(rc, 0);
 
-	if (arg->myrank == 0)
-		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, 3);
+	if (arg->myrank == 0) {
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
+				      arg->group, 3, -1);
+		assert_success(rc);
+	}
 	par_barrier(PAR_COMM_WORLD);
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
 	assert_rc_equal(rc, 0);
@@ -2351,12 +2355,15 @@ co_rf_simple(void **state)
 	if (arg->myrank == 0) {
 		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
 		test_rebuild_wait(&arg, 1);
-		daos_reint_server(arg->pool.pool_uuid, arg->group,
-				  arg->dmg_config, 3);
-		daos_reint_server(arg->pool.pool_uuid, arg->group,
-				  arg->dmg_config, 4);
-		daos_reint_server(arg->pool.pool_uuid, arg->group,
-				  arg->dmg_config, 5);
+		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+					  3, -1);
+		assert_success(rc);
+		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+					  4, -1);
+		assert_success(rc);
+		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+					  5, -1);
+		assert_success(rc);
 		test_rebuild_wait(&arg, 1);
 	}
 	par_barrier(PAR_COMM_WORLD);
@@ -2711,8 +2718,12 @@ co_redun_lvl(void **state)
 	if (arg->myrank == 0) {
 		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_REBUILD_DELAY | DAOS_FAIL_ALWAYS, 0, NULL);
-		daos_exclude_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[0]);
-		daos_exclude_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[1]);
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+				      ranks[0], -1);
+		assert_success(rc);
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+				      ranks[1], -1);
+		assert_success(rc);
 	}
 	par_barrier(PAR_COMM_WORLD);
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
@@ -2759,8 +2770,12 @@ co_redun_lvl(void **state)
 	assert_rc_equal(rc, 0);
 
 	/* exclude one more rank on another NODE dom */
-	if (arg->myrank == 0)
-		daos_exclude_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[2]);
+	if (arg->myrank == 0) {
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
+				      arg->group, ranks[2], -1);
+		assert_success(rc);
+	}
+
 	par_barrier(PAR_COMM_WORLD);
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
 	assert_rc_equal(rc, 0);
@@ -2779,9 +2794,15 @@ co_redun_lvl(void **state)
 	if (arg->myrank == 0) {
 		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
 		test_rebuild_wait(&arg, 1);
-		daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[2]);
-		daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[1]);
-		daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config, ranks[0]);
+		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+					  ranks[2], -1);
+		assert_success(rc);
+		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+					  ranks[1], -1);
+		assert_success(rc);
+		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+					  ranks[0], -1);
+		assert_success(rc);
 		test_rebuild_wait(&arg, 1);
 	}
 	par_barrier(PAR_COMM_WORLD);

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -337,9 +337,12 @@ static int
 daos_test_cb_add(test_arg_t *arg, struct test_op_record *op,
 		 char **rbuf, daos_size_t *rbuf_size)
 {
+	int rc = 0;
+
 	print_message("add rank %u\n", op->ae_arg.ua_rank);
-	daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			  op->ae_arg.ua_rank);
+	rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+				  op->ae_arg.ua_rank, -1);
+	assert_success(rc);
 	test_rebuild_wait(&arg, 1);
 	return 0;
 }
@@ -348,17 +351,19 @@ static int
 daos_test_cb_exclude(test_arg_t *arg, struct test_op_record *op,
 		     char **rbuf, daos_size_t *rbuf_size)
 {
+	int	rc = 0;
+
 	if (op->ae_arg.ua_tgt == -1) {
 		print_message("exclude rank %u\n", op->ae_arg.ua_rank);
-		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config,
-				    op->ae_arg.ua_rank);
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+				      op->ae_arg.ua_rank, -1);
+		assert_success(rc);
 	} else {
 		print_message("exclude rank %u target %d\n",
 			       op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
-		daos_exclude_target(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config,
-				    op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+				      op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
+		assert_success(rc);
 	}
 
 	test_rebuild_wait(&arg, 1);

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3165,9 +3165,9 @@ tgt_idx_change_retry(void **state)
 
 		/** exclude target of the replica */
 		print_message("rank 0 excluding target rank %u ...\n", rank);
-		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, rank);
-		assert_int_equal(rc, 0);
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
+				      arg->group, rank, -1);
+		assert_success(rc);
 
 		/** progress the async IO (not must) */
 		insert_test(&req, 1000);
@@ -3223,8 +3223,9 @@ tgt_idx_change_retry(void **state)
 
 	if (arg->myrank == 0) {
 		print_message("rank 0 adding target rank %u ...\n", rank);
-		daos_reint_server(arg->pool.pool_uuid, arg->group,
-				  arg->dmg_config, rank);
+		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+					  rank, -1);
+		assert_success(rc);
 	}
 	par_barrier(PAR_COMM_WORLD);
 	ioreq_fini(&req);
@@ -3242,6 +3243,7 @@ fetch_replica_unavail(void **state)
 	uint32_t		 size = 64;
 	d_rank_t		 rank = 2;
 	char			*buf;
+	int			 rc = 0;
 
 	FAULT_INJECTION_REQUIRED();
 
@@ -3262,8 +3264,9 @@ fetch_replica_unavail(void **state)
 
 	if (arg->myrank == 0) {
 		/** exclude the target of this obj's replicas */
-		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, rank);
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
+				      arg->group, rank, -1);
+		assert_success(rc);
 	}
 	par_barrier(PAR_COMM_WORLD);
 
@@ -3280,12 +3283,12 @@ fetch_replica_unavail(void **state)
 		test_rebuild_wait(&arg, 1);
 
 		/* add back the excluded targets */
-		daos_reint_server(arg->pool.pool_uuid, arg->group,
-				  arg->dmg_config, rank);
+		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+					  rank, -1);
+		assert_success(rc);
 
 		/* wait until reintegration is done */
 		test_rebuild_wait(&arg, 1);
-
 	}
 	D_FREE(buf);
 	par_barrier(PAR_COMM_WORLD);

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3164,7 +3164,7 @@ tgt_idx_change_retry(void **state)
 		assert_rc_equal(rc, 0);
 
 		/** exclude target of the replica */
-		print_message("rank 0 excluding target rank %u ...\n", rank);
+		print_message("rank 0 excluding rank %u ...\n", rank);
 		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
 				      arg->group, rank, -1);
 		assert_success(rc);
@@ -3222,7 +3222,7 @@ tgt_idx_change_retry(void **state)
 	}
 
 	if (arg->myrank == 0) {
-		print_message("rank 0 adding target rank %u ...\n", rank);
+		print_message("rank 0 adding rank %u ...\n", rank);
 		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
 					  rank, -1);
 		assert_success(rc);

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -199,11 +199,11 @@ pool_exclude(void **state)
 	}
 	rank = info.pi_nnodes - 1;
 	print_message("rank 0 excluding rank %u... ", rank);
-	/* TODO: remove the loop, call daos_exclude_target passing in the rank just calculated? */
+	/* TODO: remove the loop, call dmg_pool_exclude passing in the rank just calculated? */
 	for (idx = 0; idx < arg->pool.svc->rl_nr; idx++) {
-		daos_exclude_target(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config,
-				    arg->pool.svc->rl_ranks[idx], tgt);
+		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+				      arg->pool.svc->rl_ranks[idx], tgt);
+		assert_success(rc);
 	}
 	WAIT_ON_ASYNC(arg, ev);
 	print_message("success\n");

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -923,10 +923,9 @@ rebuild_multiple_tgts(void **state)
 
 			if (rank != leader) {
 				exclude_ranks[fail_cnt] = rank;
-				daos_exclude_server(arg->pool.pool_uuid,
-						    arg->group,
-						    arg->dmg_config,
-						    rank);
+				rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
+						      arg->group, rank, -1);
+				assert_success(rc);
 				if (++fail_cnt >= 2)
 					break;
 			}
@@ -949,10 +948,11 @@ rebuild_multiple_tgts(void **state)
 
 	/* Add back the target if it is not being killed */
 	if (arg->myrank == 0) {
-		for (i = 0; i < 2; i++)
-			daos_reint_server(arg->pool.pool_uuid, arg->group,
-					  arg->dmg_config,
-					  exclude_ranks[i]);
+		for (i = 0; i < 2; i++) {
+			rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+						  exclude_ranks[i], -1);
+			assert_success(rc);
+		}
 	}
 	par_barrier(PAR_COMM_WORLD);
 }
@@ -1267,6 +1267,7 @@ rebuild_kill_rank_during_rebuild(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
+	int		rc = 0;
 
 	if (!test_runable(arg, 6))
 		return;
@@ -1289,8 +1290,9 @@ rebuild_kill_rank_during_rebuild(void **state)
 
 	arg->rebuild_cb = rebuild_destroy_pool_cb;
 
-	daos_exclude_target(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			    ranks_to_kill[0], -1);
+	rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+			      ranks_to_kill[0], -1);
+	assert_success(rc);
 
 	sleep(2);
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group,

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -33,6 +33,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 		    int tgt_idx, bool kill)
 {
 	int i;
+	int rc = 0;
 
 	if (kill) {
 		daos_kill_server(args[0], args[0]->pool.pool_uuid,
@@ -46,9 +47,9 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	}
 
 	for (i = 0; i < arg_cnt; i++) {
-		daos_exclude_target(args[i]->pool.pool_uuid,
-				    args[i]->group, args[i]->dmg_config,
-				    rank, tgt_idx);
+		rc = dmg_pool_exclude(args[i]->dmg_config, args[i]->pool.pool_uuid,
+				      args[i]->group, rank, tgt_idx);
+		assert_success(rc);
 	}
 }
 
@@ -57,6 +58,7 @@ rebuild_reint_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 		  int tgt_idx, bool restart)
 {
 	int i;
+	int rc = 0;
 
 	if (restart) {
 		daos_start_server(args[0], args[0]->pool.pool_uuid,
@@ -65,11 +67,11 @@ rebuild_reint_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 	}
 
 	for (i = 0; i < args_cnt; i++) {
-		if (!args[i]->pool.destroyed)
-			daos_reint_target(args[i]->pool.pool_uuid,
-					  args[i]->group,
-					  args[i]->dmg_config,
-					  rank, tgt_idx);
+		if (!args[i]->pool.destroyed) {
+			rc = dmg_pool_reintegrate(args[i]->dmg_config, args[i]->pool.pool_uuid,
+						  args[i]->group, rank, tgt_idx);
+			assert_success(rc);
+		}
 		sleep(2);
 	}
 }
@@ -79,13 +81,14 @@ rebuild_extend_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 		   int tgt_idx, daos_size_t nvme_size)
 {
 	int i;
+	int rc = 0;
 
 	for (i = 0; i < args_cnt; i++) {
-		if (!args[i]->pool.destroyed)
-			daos_extend_target(args[i]->pool.pool_uuid,
-					   args[i]->group,
-					   args[i]->dmg_config,
-					   rank, tgt_idx, nvme_size);
+		if (!args[i]->pool.destroyed) {
+			rc = dmg_pool_extend(args[i]->dmg_config, args[i]->pool.pool_uuid,
+					     args[i]->group, &rank, 1);
+			assert_success(rc);
+		}
 		sleep(2);
 	}
 }
@@ -95,13 +98,14 @@ rebuild_drain_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 		int tgt_idx)
 {
 	int i;
+	int rc = 0;
 
 	for (i = 0; i < args_cnt; i++) {
-		if (!args[i]->pool.destroyed)
-			daos_drain_target(args[i]->pool.pool_uuid,
-					args[i]->group,
-					args[i]->dmg_config,
-					rank, tgt_idx);
+		if (!args[i]->pool.destroyed) {
+			rc = dmg_pool_drain(args[i]->dmg_config, args[i]->pool.pool_uuid,
+					    args[i]->group, rank, tgt_idx);
+			assert_success(rc);
+		}
 		sleep(2);
 	}
 }
@@ -356,16 +360,19 @@ void
 rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank, int *failed_tgts,
 		      int nr)
 {
+	int rc = 0;
+
 	par_barrier(PAR_COMM_WORLD);
 	/* Add back the target if it is not being killed */
 	if (arg->myrank == 0 && !arg->pool.destroyed) {
 		int i;
 
-		for (i = 0; i < nr; i++)
-			daos_reint_target(arg->pool.pool_uuid, arg->group,
-					  arg->dmg_config,
-					  failed_rank,
-					  failed_tgts ? failed_tgts[i] : -1);
+		for (i = 0; i < nr; i++) {
+			rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid,
+						  arg->group, failed_rank,
+						  failed_tgts ? failed_tgts[i] : -1);
+			assert_success(rc);
+		}
 	}
 	par_barrier(PAR_COMM_WORLD);
 }

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -745,6 +745,7 @@ rebuild_sx_object_internal(void **state, daos_oclass_id_t oclass)
 	d_rank_t	rank = 2;
 	int		rank_nr = 1;
 	int		i;
+	int		rc = 0;
 
 	if (!test_runable(arg, 4))
 		return;
@@ -760,15 +761,17 @@ rebuild_sx_object_internal(void **state, daos_oclass_id_t oclass)
 
 	get_killing_rank_by_oid(arg, oid, 1, 0, &rank, &rank_nr);
 	/** exclude the target of this obj's replicas */
-	daos_exclude_server(arg->pool.pool_uuid, arg->group,
-			    arg->dmg_config, rank);
+	rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
+			      arg->group, rank, -1);
+	assert_success(rc);
 
 	/* wait until rebuild done */
 	test_rebuild_wait(&arg, 1);
 
 	/* add back the excluded targets */
-	daos_reint_server(arg->pool.pool_uuid, arg->group,
-			  arg->dmg_config, rank);
+	rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+				  rank, -1);
+	assert_success(rc);
 
 	/* wait until reintegration is done */
 	test_rebuild_wait(&arg, 1);
@@ -814,6 +817,7 @@ rebuild_large_object(void **state)
 	d_rank_t	rank = 2;
 	int		i;
 	int		j;
+	int		rc = 0;
 
 	if (!test_runable(arg, 4))
 		return;
@@ -830,15 +834,17 @@ rebuild_large_object(void **state)
 	}
 
 	/** exclude the target of this obj's replicas */
-	daos_exclude_server(arg->pool.pool_uuid, arg->group,
-			    arg->dmg_config, rank);
+	rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+			      rank, -1);
+	assert_success(rc);
 
 	/* wait until rebuild done */
 	test_rebuild_wait(&arg, 1);
 
 	/* add back the excluded targets */
-	daos_reint_server(arg->pool.pool_uuid, arg->group,
-			  arg->dmg_config, rank);
+	rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
+				  rank, -1);
+	assert_success(rc);
 
 	/* wait until reintegration is done */
 	test_rebuild_wait(&arg, 1);

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -394,24 +394,6 @@ int test_pool_get_info(test_arg_t *arg, daos_pool_info_t *pinfo, d_rank_list_t *
 int test_get_leader(test_arg_t *arg, d_rank_t *rank);
 bool test_rebuild_query(test_arg_t **args, int args_cnt);
 void test_rebuild_wait(test_arg_t **args, int args_cnt);
-void daos_exclude_target(const uuid_t pool_uuid, const char *grp,
-			 const char *dmg_config,
-			 d_rank_t rank, int tgt);
-void daos_reint_target(const uuid_t pool_uuid, const char *grp,
-		       const char *dmg_config,
-		       d_rank_t rank, int tgt);
-void daos_drain_target(const uuid_t pool_uuid, const char *grp,
-		       const char *dmg_config,
-		       d_rank_t rank, int tgt);
-void daos_extend_target(const uuid_t pool_uuid, const char *grp,
-			const char *dmg_config,
-			d_rank_t rank, int tgt, daos_size_t nvme_size);
-void daos_exclude_server(const uuid_t pool_uuid, const char *grp,
-			 const char *dmg_config,
-			 d_rank_t rank);
-void daos_reint_server(const uuid_t pool_uuid, const char *grp,
-		       const char *dmg_config,
-		       d_rank_t rank);
 int daos_pool_set_prop(const uuid_t pool_uuid, const char *name,
 		       const char *value);
 

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -875,34 +875,6 @@ run_daos_sub_tests(char *test_name, const struct CMUnitTest *tests,
 	return rc;
 }
 
-static void
-daos_dmg_pool_target(const char *sub_cmd, const uuid_t pool_uuid,
-		     const char *grp, const char *dmg_config,
-		     d_rank_t rank, int tgt_idx, daos_size_t scm_size)
-{
-	char		dmg_cmd[DTS_CFG_MAX];
-	int		rc;
-
-	/* build and invoke dmg cmd */
-	if (strncmp(sub_cmd, "extend", strlen("extend")) == 0)
-		dts_create_config(dmg_cmd, "dmg pool %s " DF_UUIDF
-				  " --ranks=%d", sub_cmd,
-				  DP_UUID(pool_uuid), rank);
-	else
-		dts_create_config(dmg_cmd, "dmg pool %s " DF_UUIDF
-				  " --rank=%d", sub_cmd, DP_UUID(pool_uuid),
-				  rank);
-
-	if (tgt_idx != -1)
-		dts_append_config(dmg_cmd, " --target-idx=%d", tgt_idx);
-	if (dmg_config != NULL)
-		dts_append_config(dmg_cmd, " -o %s", dmg_config);
-
-	rc = system(dmg_cmd);
-	print_message("%s rc %#x\n", dmg_cmd, rc);
-	assert_int_equal(rc, 0);
-}
-
 static int
 daos_dmg_pool_upgrade(const uuid_t pool_uuid, const char *dmg_config)
 {
@@ -930,55 +902,6 @@ daos_pool_set_prop(const uuid_t pool_uuid, const char *name,
 		   const char *value)
 {
 	return dmg_pool_set_prop(dmg_config_file, name, value, pool_uuid);
-}
-
-void
-daos_exclude_target(const uuid_t pool_uuid, const char *grp,
-		    const char *dmg_config,
-		    d_rank_t rank, int tgt_idx)
-{
-	daos_dmg_pool_target("exclude", pool_uuid, grp, dmg_config,
-			     rank, tgt_idx, 0);
-}
-
-void
-daos_reint_target(const uuid_t pool_uuid, const char *grp,
-		  const char *dmg_config, d_rank_t rank, int tgt_idx)
-{
-	daos_dmg_pool_target("reintegrate", pool_uuid, grp, dmg_config,
-			     rank, tgt_idx, 0);
-}
-
-void
-daos_extend_target(const uuid_t pool_uuid, const char *grp,
-		   const char *dmg_config, d_rank_t rank, int tgt_idx,
-		   daos_size_t nvme_size)
-{
-	daos_dmg_pool_target("extend", pool_uuid, grp, dmg_config,
-			     rank, tgt_idx, nvme_size);
-}
-
-void
-daos_drain_target(const uuid_t pool_uuid, const char *grp,
-		  const char *dmg_config, d_rank_t rank, int tgt_idx)
-{
-
-	daos_dmg_pool_target("drain", pool_uuid, grp, dmg_config,
-			     rank, tgt_idx, 0);
-}
-
-void
-daos_exclude_server(const uuid_t pool_uuid, const char *grp,
-		    const char *dmg_config, d_rank_t rank)
-{
-	daos_exclude_target(pool_uuid, grp, dmg_config, rank, -1);
-}
-
-void
-daos_reint_server(const uuid_t pool_uuid, const char *grp,
-		  const char *dmg_config, d_rank_t rank)
-{
-	daos_reint_target(pool_uuid, grp, dmg_config, rank, -1);
 }
 
 void


### PR DESCRIPTION
Use the new-style dmg helper to perform all pool operations.
Avoids malloc/RDMA problems as described in DAOS-10301.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
