### PR TITLE
DAOS-11859 control: Add MD-on-SSD bdev tiering to config generate cmds

### DIFF
--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -139,15 +139,20 @@ func TestAuto_confGen(t *testing.T) {
 		Addr:    "host1",
 		Message: control.MockServerScanResp(t, "withSpaceUsage"),
 	}
-	exmplEngineCfgs := []*engine.Config{
-		control.MockEngineCfg(t, 0, 2, 4, 6, 8).WithHelperStreamCount(4),
-		control.MockEngineCfg(t, 1, 1, 3, 5, 7).WithHelperStreamCount(4),
-	}
+	e0 := control.MockEngineCfg(0, 2, 4, 6, 8).WithHelperStreamCount(4)
+	e0.Storage.Tiers[1].WithBdevDeviceRoles(storage.BdevRoleData)
+	e1 := control.MockEngineCfg(1, 1, 3, 5, 7).WithHelperStreamCount(4)
+	e1.Storage.Tiers[1].WithBdevDeviceRoles(storage.BdevRoleData)
+	exmplEngineCfgs := []*engine.Config{e0, e1}
 	mockRamdiskSize := 5 // RoundDownGiB(16*0.75/2)
 	tmpfsEngineCfgs := []*engine.Config{
-		control.MockEngineCfgTmpfs(t, 0, mockRamdiskSize, 2, 4, 6, 8).
+		control.MockEngineCfgTmpfs(0, mockRamdiskSize,
+			control.MockBdevTierWithRole(0, storage.BdevRoleWAL, 2),
+			control.MockBdevTierWithRole(0, storage.BdevRoleMeta|storage.BdevRoleData, 4, 6, 8)).
 			WithHelperStreamCount(4),
-		control.MockEngineCfgTmpfs(t, 1, mockRamdiskSize, 1, 3, 5, 7).
+		control.MockEngineCfgTmpfs(1, mockRamdiskSize,
+			control.MockBdevTierWithRole(1, storage.BdevRoleWAL, 1),
+			control.MockBdevTierWithRole(1, storage.BdevRoleMeta|storage.BdevRoleData, 3, 5, 7)).
 			WithHelperStreamCount(4),
 	}
 
@@ -188,7 +193,7 @@ func TestAuto_confGen(t *testing.T) {
 				{netHostResp},
 				{storHostResp},
 			},
-			expCfg: control.MockServerCfg(t, "ofi+psm2", exmplEngineCfgs).
+			expCfg: control.MockServerCfg("ofi+psm2", exmplEngineCfgs).
 				WithNrHugePages(16384).
 				WithAccessPoints("localhost:10001").
 				WithControlLogFile("/tmp/daos_server.log"),
@@ -199,7 +204,7 @@ func TestAuto_confGen(t *testing.T) {
 				{netHostResp},
 				{storHostResp},
 			},
-			expCfg: control.MockServerCfg(t, "ofi+psm2", exmplEngineCfgs).
+			expCfg: control.MockServerCfg("ofi+psm2", exmplEngineCfgs).
 				WithNrHugePages(16384).
 				WithAccessPoints("moon-111:10001", "mars-115:10001", "jupiter-119:10001").
 				WithControlLogFile("/tmp/daos_server.log"),
@@ -238,7 +243,7 @@ func TestAuto_confGen(t *testing.T) {
 				{netHostResp},
 				{storHostResp},
 			},
-			expCfg: control.MockServerCfg(t, "ofi+psm2", tmpfsEngineCfgs).
+			expCfg: control.MockServerCfg("ofi+psm2", tmpfsEngineCfgs).
 				WithNrHugePages(16384).
 				WithControlLogFile("/tmp/daos_server.log"),
 		},

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -323,11 +323,11 @@ func (tcs TierConfigs) validateBdevTierRoles() error {
 //
 // Role assignments will be decided based on the following rule set:
 //   - For 1 bdev tier, all roles will be assigned to that tier.
-//   - For 2 bdev tiers, WAL and Meta roles will be assigned to the first bdev tier and Data to
+//   - For 2 bdev tiers, WAL role will be assigned to the first bdev tier and Meta and Data to
 //     the second bdev tier.
 //   - For 3 or more bdev tiers, WAL role will be assigned to the first bdev tier, Meta to the
 //     second bdev tier and Data to all remaining bdev tiers.
-//   - If the scm tier is of class dcpm, the first bdev tier should have the Data role only.
+//   - If the scm tier is of class dcpm, the first (and only) bdev tier should have the Data role.
 //   - If emulated NVMe is present in bdev tiers, implicit role assignment is skipped.
 func (tcs TierConfigs) assignBdevTierRoles() error {
 	scs := tcs.ScmConfigs()
@@ -373,8 +373,8 @@ func (tcs TierConfigs) assignBdevTierRoles() error {
 	case 1:
 		tcs[1].WithBdevDeviceRoles(BdevRoleAll)
 	case 2:
-		tcs[1].WithBdevDeviceRoles(BdevRoleWAL | BdevRoleMeta)
-		tcs[2].WithBdevDeviceRoles(BdevRoleData)
+		tcs[1].WithBdevDeviceRoles(BdevRoleWAL)
+		tcs[2].WithBdevDeviceRoles(BdevRoleMeta | BdevRoleData)
 	default:
 		tcs[1].WithBdevDeviceRoles(BdevRoleWAL)
 		tcs[2].WithBdevDeviceRoles(BdevRoleMeta)

--- a/src/control/server/storage/config_test.go
+++ b/src/control/server/storage/config_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -374,12 +374,12 @@ storage:
 					WithTier(1).
 					WithStorageClass("nvme").
 					WithBdevDeviceList("0000:80:00.0").
-					WithBdevDeviceRoles(BdevRoleMeta | BdevRoleWAL),
+					WithBdevDeviceRoles(BdevRoleWAL),
 				NewTierConfig().
 					WithTier(2).
 					WithStorageClass("nvme").
 					WithBdevDeviceList("0000:81:00.0", "0000:82:00.0").
-					WithBdevDeviceRoles(BdevRoleData),
+					WithBdevDeviceRoles(BdevRoleMeta | BdevRoleData),
 			},
 		},
 		"unspecified roles; implicit role assignment; three bdev tiers": {


### PR DESCRIPTION
Add support for MD-on-SSD in config generate. When
automatically generating a config with dmg or daos_server tools
if --use-tmpfs-scm is set then populate bdev tiers appropriately.

NVMe SSDs on same NUMA as engine to be split into bdev tiers:
-  1 SSD: tiers 1
-  2-5 SSDs: tiers 1:N-1
-  6+ SSDs: tiers 2:N-2

Configs generated will not have explicit roles assigned to each bdev
tiers, instead roles will be assigned implicitly based on the bdev
tiers during control-plane validation on daos_server service start.

Implicit role assignments are decided based on the following rules:                                          
- For 1 bdev tier, all roles will be assigned to that tier.                                        
- For 2 bdev tiers, WAL role will be assigned to the first bdev tier
  and Meta and Data to the second bdev tier.                                                                            
- For 3 or more bdev tiers, WAL role will be assigned to the first
  bdev tier, Meta to the second bdev tier and Data to all remaining
  bdev tiers.                                           
- If the scm tier is of class dcpm, the first (and only) bdev tier
  should have the Data role.      
- If emulated NVMe is present in bdev tiers, implicit role assignment
  is skipped.                  

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
