### PR TITLE
SRE-416 test: Fix Launchable xunit1 de-mangle

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
                description: 'Distribution to use for CI Hardware Tests')
         string(name: 'CI_CENTOS7_TARGET',
                defaultValue: '',
-               description: 'Image to used for Centos 7 CI tests.  I.e. el7, el7.9, etc.')
+               description: 'Image to used for CentOS 7 CI tests.  I.e. el7, el7.9, etc.')
         string(name: 'CI_EL8_TARGET',
                defaultValue: '',
                description: 'Image to used for EL 8 CI tests.  I.e. el8, el8.3, etc.')
@@ -793,7 +793,7 @@ pipeline {
                         expression { !skipStage() }
                     }
                     agent {
-                        label params.CI_FUNCTIONAL_VM9_LABEL
+                        label params.FUNCTIONAL_VM_LABEL
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),
@@ -813,7 +813,7 @@ pipeline {
                         expression { !skipStage() }
                     }
                     agent {
-                        label params.CI_FUNCTIONAL_VM9_LABEL
+                        label params.FUNCTIONAL_VM_LABEL
                     }
                     steps {
                         functionalTest inst_repos: daosRepos(),

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2957,7 +2957,7 @@ class Launch():
             xml_file = xml_file[0:-11] + "xunit1_results.xml"
             logger.debug("Updating the xml data for the Launchable %s file", xml_file)
             xml_data = org_xml_data
-            org_name = r'(name=")\d+-\.\/.+.(test_[^;]+);[^"]+(")'
+            org_name = r'(name=")\d+-\.\/.+\.(test_[^;]+);[^"]+(")'
             new_name = rf'\1\2\3 file="{test.test_file}"'
             xml_data = re.sub(org_name, new_name, xml_data)
             try:


### PR DESCRIPTION
An unescaped . in an RE makes a huge difference if was supposed to be
escaped.

Also fix missed CI_FUNCTIONAL_VM9_LABEL -> FUNCTIONAL_VM_LABEL from
c27811bbed.