### PR TITLE
DAOS-12296 common: Fix Intel compiler warnings (#11095)

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -110,12 +110,12 @@ struct btr_context {
 	/** cached tree depth, avoid loading from slow memory */
 	uint16_t			 tc_depth;
 	/** credits for drain, see dbtree_drain */
-	int				 tc_creds:30;
+	uint32_t                         tc_creds    : 30;
 	/**
 	 * credits is turned on, \a tcx::tc_creds should be checked
 	 * while draining the tree
 	 */
-	int				 tc_creds_on:1;
+	uint32_t                         tc_creds_on : 1;
 	/**
 	 * returned value of the probe, it should be reset after upsert
 	 * or delete because the probe path could have been changed.

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -212,8 +212,8 @@ struct test_update_fetch_arg {
 	int			*ua_values;
 	int			ua_recx_num;
 	int			ua_single_value;
-	int			ua_array:1, /* false for single */
-				ua_verify:1;
+	uint32_t                 ua_array : 1, /* false for single */
+	    ua_verify                     : 1;
 	bool			snap;
 };
 

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -118,8 +118,7 @@ struct epoch_io_args {
 	/* cached dkey/akey used last time, so need not specify it every time */
 	char			*op_dkey;
 	char			*op_akey;
-	int			op_no_verify:1,
-				op_ec:1; /* true for EC, false for replica */
+	uint32_t                 op_no_verify : 1, op_ec : 1; /* true for EC, false for replica */
 };
 
 typedef struct {

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2017-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -66,9 +66,9 @@ struct evt_context {
 	/** cached tree depth (reduce PMEM access) */
 	uint16_t			 tc_depth;
 	/** number of credits for "drain" operation */
-	int				 tc_creds:30;
+	uint32_t                         tc_creds    : 30;
 	/** credits is enabled */
-	int				 tc_creds_on:1;
+	uint32_t                         tc_creds_on : 1;
 	/** cached number of bytes per entry */
 	uint32_t			 tc_inob;
 	/** cached tree feature bits (reduce PMEM access) */

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -73,8 +73,8 @@ struct agg_rmv_ent {
 	struct evt_rect		re_rect;
 	/** Real entries, if any, contained in a logical rectangle */
 	d_list_t		re_contained;
-	int			re_aggregate:1, /* Aggregate of one or more records */
-				re_child:1;	/* Contained in aggregate record */
+	uint32_t                re_aggregate : 1, /* Aggregate of one or more records */
+	    re_child                         : 1; /* Contained in aggregate record */
 	/** Refcount of physical records that reference this removal */
 	int			re_phy_count;
 };

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -191,8 +191,8 @@ struct vos_pool {
 	/** VOS uuid hash-link with refcnt */
 	struct d_ulink		vp_hlink;
 	/** number of openers */
-	int			vp_opened:30;
-	int			vp_dying:1;
+	uint32_t                 vp_opened : 30;
+	uint32_t                 vp_dying  : 1;
 	/** exclusive handle (see VOS_POF_EXCL) */
 	int			vp_excl:1;
 	/** caller specifies pool is small (for sys space reservation) */


### PR DESCRIPTION
Signed bit fields cause a compiler warning with new Intel compiler.  I suspect this may be a bug but there is also no reason a bit field should be signed.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
