### PR TITLE
DAOS-12145: chk: misc fixes for chk related issues - VI

### DIFF
--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -2397,7 +2397,7 @@ chk_engine_query_pool(uuid_t uuid, void *args)
 	coll_ops.co_func = chk_engine_query_one;
 	coll_args.ca_func_args = shard;
 
-	rc = dss_task_collective_reduce(&coll_ops, &coll_args, 0);
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0);
 
 out:
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_DBG,

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -2070,12 +2070,6 @@ again:
 handle:
 	if (!d_list_empty(&ins->ci_rank_list) || ins->ci_start_flags & CSF_ORPHAN_POOL) {
 		rc = chk_leader_handle_pools_list(ins);
-		if (ins->ci_for_orphan) {
-			cbk->cb_phase = CHK__CHECK_SCAN_PHASE__CSP_DONE;
-			if (rc == 0)
-				rc = 1;
-		}
-
 		if (rc != 0)
 			D_GOTO(out, bcast = true);
 	}
@@ -2085,7 +2079,7 @@ handle:
 
 		rc = chk_leader_need_stop(ins);
 		if (rc >= 0)
-			D_GOTO(out, bcast = false);
+			D_GOTO(out, bcast = (rc > 0 ? true : false));
 
 		/*
 		 * TBD: The leader may need to detect engines' status/phase actively, otherwise


### PR DESCRIPTION
It contains the following fixes:

1. Keep leader scheduler until handled dangling pools

Otherwise, if there are only dangling pools, then leader scheduler may exist too early as to the pool tree (that is attached to check instance) is destroyed before dangling pool ULTs accessing it.

2. Use dss_thread_collective_reduce when query pool on check engine

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
