### PR TITLE
DAOS-12306 object: fix a bug of server reject IO incorrectly

### DIFF
--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -137,7 +137,7 @@ daos_shard_in_fail_value(uint16_t shard)
 
 	D_ASSERT(shard != 0xffff);
 	for (i = 0; i < 4; i++) {
-		if ((shard + 1) == (fail_val & (mask << (i * 16))))
+		if ((shard + 1) == ((fail_val & (mask << (i * 16))) >> (i * 16)))
 			return true;
 	}
 	return false;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -554,7 +554,9 @@ obj_ec_leader_select(struct dc_object *obj, int grp_idx, bool cond_modify, uint3
 		shard = grp_start + tgt_idx;
 		pl_shard = obj_get_shard(obj, shard);
 		if (pl_shard->po_target == -1 || pl_shard->po_shard == -1 ||
-		    pl_shard->po_rebuilding) {
+		    pl_shard->po_rebuilding ||
+		    (DAOS_FAIL_CHECK(DAOS_FAIL_SHARD_OPEN) &&
+		     daos_shard_in_fail_value(grp_size - 1 - i))) {
 			/* Then try former one */
 			continue;
 		}

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -1809,6 +1809,124 @@ ec_rec_parity_list(void **state)
 	ioreq_fini(&req);
 }
 
+static void
+ec_update_2akeys(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	 oid;
+	daos_handle_t	 oh;
+	d_iov_t		 dkey;
+	d_iov_t		 non_exist_dkey;
+	d_sg_list_t	 sgl[2];
+	d_iov_t		 sg_iov[2];
+	daos_iod_t	 iod[2];
+	daos_recx_t	 recx[2];
+	char		*buf[2];
+	char		*buf_cmp[2];
+	char		*akey[2];
+	const char	*akey_fmt = "akey21_%d";
+	int		 i, rc;
+	daos_size_t	 size;
+	uint16_t	 fail_shards[2];
+	uint64_t	 fail_val;
+
+	FAULT_INJECTION_REQUIRED();
+
+	if (!test_runable(arg, 6))
+		return;
+
+	/** open object */
+	oid = daos_test_oid_gen(arg->coh, ec_obj_class, 0, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, oid, DAOS_OO_RW, &oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	/** init dkey */
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&non_exist_dkey, "non_dkey", strlen("non_dkey"));
+
+	for (i = 0; i < 2; i++) {
+		D_ALLOC(akey[i], strlen(akey_fmt) + 1);
+		sprintf(akey[i], akey_fmt, i);
+
+		if (i == 0)
+			size = ec_cell_size * 4;
+		else
+			size = 8192;
+		D_ALLOC(buf[i], size);
+		assert_non_null(buf[i]);
+		D_ALLOC(buf_cmp[i], size);
+		assert_non_null(buf_cmp[i]);
+
+		dts_buf_render(buf[i], size);
+		memcpy(buf_cmp[i], buf[i], size);
+
+		/** init scatter/gather */
+		d_iov_set(&sg_iov[i], buf[i], size);
+		sgl[i].sg_nr		= 1;
+		sgl[i].sg_nr_out	= 0;
+		sgl[i].sg_iovs		= &sg_iov[i];
+
+		/** init I/O descriptor */
+		d_iov_set(&iod[i].iod_name, akey[i], strlen(akey[i]));
+		iod[i].iod_nr		= 1;
+		iod[i].iod_size		= 1;
+		iod[i].iod_recxs	= &recx[i];
+		iod[i].iod_type		= DAOS_IOD_ARRAY;
+		if (i == 0) {
+			recx[i].rx_idx		= 0;
+			recx[i].rx_nr		= size;
+		} else {
+			recx[i].rx_idx		= ec_cell_size;
+			recx[i].rx_nr		= size;
+		}
+	}
+
+	/* test the case that update 2 akeys in one IO, one akey is full-stripe update,
+	 * another is partial update, fail two parity shards, then will select data shard 0
+	 * as leader and 2nd akey update is empty on the leader.
+	 */
+	fail_shards[0] = 4;
+	fail_shards[1] = 5;
+	fail_val = daos_shard_fail_value(fail_shards, 2);
+	daos_fail_value_set(fail_val);
+	daos_fail_loc_set(DAOS_FAIL_SHARD_OPEN | DAOS_FAIL_ALWAYS);
+
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 2, iod, sgl, NULL);
+	assert_rc_equal(rc, 0);
+
+	for (i = 0; i < 2; i++)
+		iod[i].iod_size	= DAOS_REC_ANY;
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 2, iod, NULL, NULL, NULL);
+	assert_rc_equal(rc, 0);
+	for (i = 0; i < 2; i++)
+		assert_int_equal(iod[i].iod_size, 1);
+
+	for (i = 0; i < 2; i++) {
+		if (i == 0)
+			size = ec_cell_size * 4;
+		else
+			size = 8192;
+		memset(buf[i], 0, size);
+		d_iov_set(&sg_iov[i], buf[i], size);
+	}
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 2, iod, sgl, NULL, NULL);
+	assert_rc_equal(rc, 0);
+	assert_memory_equal(buf[0], buf_cmp[0], ec_cell_size * 4);
+	assert_memory_equal(buf[1], buf_cmp[1], 8192);
+
+	rc = daos_obj_close(oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	daos_fail_value_set(0);
+	daos_fail_loc_set(0);
+
+	for (i = 0; i < 2; i++) {
+		D_FREE(akey[i]);
+		D_FREE(buf[i]);
+		D_FREE(buf_cmp[i]);
+	}
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest ec_tests[] = {
 	{"EC0: ec dkey list and punch test",
@@ -1852,6 +1970,8 @@ static const struct CMUnitTest ec_tests[] = {
 	{"EC19: ec few partial stripe update", ec_few_partial_stripe_aggregation, async_disable,
 	 test_case_teardown},
 	{"EC20: ec recx list from parity", ec_rec_parity_list, async_disable, test_case_teardown},
+	{"EC21: ec update two akeys and parity shards failed", ec_update_2akeys, async_disable,
+	 test_case_teardown},
 };
 
 int

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -704,8 +704,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 		int iov_nr = iods[i].iod_nr;
 		struct bio_sglist *bsgl;
 
-		if ((iods[i].iod_type == DAOS_IOD_SINGLE && iov_nr != 1) ||
-		    (iov_nr == 0 && iods[i].iod_recxs != NULL)) {
+		if ((iods[i].iod_type == DAOS_IOD_SINGLE && iov_nr != 1)) {
 			D_ERROR("Invalid iod_nr=%d, iod_type %d.\n",
 				iov_nr, iods[i].iod_type);
 			rc = -DER_IO_INVAL;
@@ -1738,7 +1737,6 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 
 	if (is_array) {
 		if (iod->iod_nr == 0 || iod->iod_recxs == NULL) {
-			D_ASSERT(iod->iod_nr == 0 && iod->iod_recxs == NULL);
 			D_DEBUG(DB_TRACE, "akey "DF_KEY" update array bypassed - NULL iod_recxs.\n",
 				DP_KEY(&iod->iod_name));
 			return rc;


### PR DESCRIPTION
For EC multiple akeys update, it possibly with IO request that "(iov_nr == 0 && iods[i].iod_recxs != NULL)" for array type, server should not reject IO for that case.
Fix a bug in daos_shard_in_fail_value().
Add a test case to reproduce it.

Required-githooks: true

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
