### PR TITLE
DAOS-12270 chk: Adjust check query output based on status

### DIFF
--- a/src/control/lib/control/check.go
+++ b/src/control/lib/control/check.go
@@ -662,8 +662,8 @@ func SystemCheckRepair(ctx context.Context, rpcClient UnaryInvoker, req *SystemC
 		return errors.Errorf("nil %T", req)
 	}
 
+	req.CheckActReq.Sys = req.getSystem(rpcClient)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
-		req.CheckActReq.Sys = req.getSystem(rpcClient)
 		return mgmtpb.NewMgmtSvcClient(conn).SystemCheckRepair(ctx, &req.CheckActReq)
 	})
 


### PR DESCRIPTION
If the checker is running, show the number of pools being checked.
If the checker has completed, show the number of unique pools
found in the results.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
