### PR TITLE
DAOS-11873 test: datamover dcp test with root->new dir

### DIFF
--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -57,34 +57,27 @@ class DmvrPosixSubsets(DataMoverTestBase):
         # create dfuse containers to test copying to dfuse subdirectories
         dfuse_cont1 = self.get_container(pool1)
         dfuse_cont2 = self.get_container(pool1)
-        dfuse_cont1_dir = join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont1.uuid)
-        # destination directory should be created by program
-        dfuse_cont2_dir = self.new_posix_test_path(
-            create=False,
-            parent=join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont2.uuid))
+        dfuse_src_dir = join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont1.uuid)
         # Create a special container to hold UNS entries
         uns_cont = self.get_container(pool1)
 
-        # Create a testing container
-        container1_path = join(self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
+        # Create two test containers
+        container1_path = join(
+            self.dfuse.mount_dir.value, pool1.uuid, uns_cont.uuid, 'uns1')
         container1 = self.get_container(pool1, path=container1_path)
+        container2 = self.get_container(pool1)
 
         # Create some source directories in the container
         sub_dir = self.new_daos_test_path(False)
         sub_sub_dir = self.new_daos_test_path(True, container1, sub_dir)
 
         # Create initial test files
+        self.write_location("DAOS_UUID", '/', pool1, container1)
         self.write_location("DAOS_UUID", sub_dir, pool1, container1)
         self.write_location("DAOS_UUID", sub_sub_dir, pool1, container1)
-        self.write_location("POSIX", dfuse_cont1_dir)
+        self.write_location("POSIX", dfuse_src_dir)
 
         copy_list = []
-
-        if self.tool == "FS_COPY":
-            copy_list.append(
-                ["dfuse copy (dfuse cont1 dir to dfuse cont2 dir that doesn't exist)",
-                    ["POSIX", dfuse_cont1_dir, None, None],
-                    ["POSIX", dfuse_cont2_dir, None, None]])
 
         # For each copy, use a new destination directory.
         # This ensures that the source directory is copied
@@ -126,6 +119,20 @@ class DmvrPosixSubsets(DataMoverTestBase):
                 "copy_subsets (uns sub_sub_dir to uuid sub_sub_dir)",
                 ["DAOS_UNS", sub_sub_dir, pool1, container1],
                 ["DAOS_UUID", sub_sub_dir2, pool1, container1]])
+
+            sub_dir3 = self.new_daos_test_path(False)
+            copy_list.append([
+                "copy_subsets (uuid root to new uuid sub_dir)",
+                ["DAOS_UUID", '/', pool1, container1],
+                ["DAOS_UUID", sub_dir3, pool1, container2]])
+
+            dfuse_dst_dir = self.new_posix_test_path(
+                create=False,
+                parent=join(self.dfuse.mount_dir.value, pool1.uuid, dfuse_cont2.uuid))
+            copy_list.append([
+                "copy_subsets (dfuse root to new dfuse dir)",
+                ["POSIX", dfuse_src_dir, None, None],
+                ["POSIX", dfuse_dst_dir, None, None]])
 
         # Run and verify each copy.
         # Each src or dst is a list of params:

--- a/src/tests/ftest/datamover/posix_subsets.yaml
+++ b/src/tests/ftest/datamover/posix_subsets.yaml
@@ -34,4 +34,4 @@ dcp:
   client_processes:
     np: 1
 dfuse:
-  mount_dir: "/tmp/daos_dfuse"
+  disable_caching: true


### PR DESCRIPTION
Test-tag: dm_posix_subsets
Skip-unit-tests: true
Skip-fault-injection-test: true

- Enable root -> new dir variant with dcp

Required-githooks: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
