### PR TITLE
DAOS-12259 test: reduce dfuse caching perf threshold

### DIFF
--- a/src/tests/ftest/dfuse/caching_check.py
+++ b/src/tests/ftest/dfuse/caching_check.py
@@ -9,11 +9,10 @@ from ior_utils import IorCommand, IorMetrics
 from general_utils import percent_change
 
 
-class CachingCheck(IorTestBase):
+class DfuseCachingCheck(IorTestBase):
     # pylint: disable=too-many-ancestors
-    """Test class Description: Check dfuse read performance with and
-       without caching on a single server and single client setting with
-       basic parameters.
+    """Test class Description: Check dfuse read performance with and without caching
+       on a single server and single client setting with basic parameters.
 
     :avocado: recursive
     """
@@ -22,7 +21,7 @@ class CachingCheck(IorTestBase):
         """Jira ID: DAOS-4874.
 
         Test Description:
-            Purpose of this test is to check if dfuse caching is working.
+            Verify dfuse caching is working.
         Use case:
             Write using ior over dfuse with caching disabled.
             Perform ior read twice to get base read performance.
@@ -36,20 +35,20 @@ class CachingCheck(IorTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium
         :avocado: tags=daosio,dfuse
-        :avocado: tags=test_dfuse_caching_check
+        :avocado: tags=DfuseCachingCheck,test_dfuse_caching_check
         """
         # get params
         flags = self.params.get("iorflags", '/run/ior/*')
         read_x = self.params.get("read_x", "/run/ior/*", 1)
 
         # update flag
-        self.ior_cmd.flags.update(flags[0])
+        self.ior_cmd.update_params(flags=flags[0])
 
         # run ior to write to the dfuse mount point
         self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
 
         # update ior flag to read
-        self.ior_cmd.flags.update(flags[1])
+        self.ior_cmd.update_params(flags=flags[1])
         # run ior to read and store the read performance
         base_read_arr = []
         out = self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
@@ -63,7 +62,7 @@ class CachingCheck(IorTestBase):
 
         # unmount dfuse and mount again with caching enabled
         self.dfuse.unmount(tries=1)
-        self.dfuse.disable_caching.update(False)
+        self.dfuse.update_params(disable_caching=False)
         self.dfuse.run()
         # run ior to obtain first read performance after mount
         out = self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
@@ -79,4 +78,5 @@ class CachingCheck(IorTestBase):
             self.log.info('assert actual_change > min_change: %f > %f', actual_change, read_x)
         for base_read in base_read_arr:
             actual_change = percent_change(base_read[0][max_mib], with_caching[0][max_mib])
-            self.assertTrue(actual_change > read_x)
+            if actual_change < read_x:
+                self.fail('Expected a speedup of {} but got {}'.format(read_x, actual_change))

--- a/src/tests/ftest/dfuse/caching_check.yaml
+++ b/src/tests/ftest/dfuse/caching_check.yaml
@@ -17,28 +17,24 @@ server_config:
           class: nvme
           bdev_list: ["aaaa:aa:aa.a", "bbbb:bb:bb.b"]
 pool:
-  scm_size: 20%
-  nvme_size: 40%
+  size: 50%
   control_method: dmg
 container:
   type: POSIX
   control_method: daos
 ior:
   client_processes:
-    np_16:
-      np: 16
+    ppn: 32
   test_file: testFile
-  repetitions: 1
   api: POSIX
   dfs_destroy: false
-  transfer_size: '1M'
-  block_size: '64M'
+  transfer_size: 1M
+  block_size: 1G
   dfs_oclass: "EC_2P1G1"
-  read_x: 4.5  # 450%
+  read_x: 3  # 300%
   iorflags:
-    - "-v -w -k"
-    - "-v -r -k"
+    - "-v -w -k -G 3"
+    - "-v -r -k -G 3"
 dfuse:
-  mount_dir: "/tmp/daos_dfuse/"
   disable_caching: true
   disable_wb_caching: true


### PR DESCRIPTION
Test-tag: test_dfuse_caching_check
Skip-unit-tests: true
Skip-fault-injection-test: true

- Reduce threshold from 450% to 300%
- Misc cleanup

Required-githooks: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
