### PR TITLE
DAOS-623 test: remove duplicate ior pool space functions

### DIFF
--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -72,23 +72,6 @@ class IorTestBase(DfuseTestBase):
 
         return self.container
 
-    def display_pool_space(self, pool=None):
-        """Display the current pool space.
-
-        If the TestPool object has a DmgCommand object assigned, also display
-        the free pool space per target.
-
-        Args:
-            pool (TestPool, optional): The pool for which to display space.
-                    Default is self.pool.
-        """
-        if not pool:
-            pool = self.pool
-
-        pool.display_pool_daos_space()
-        if pool.dmg:
-            pool.set_query_data()
-
     def run_ior_with_pool(self, intercept=None, display_space=True, test_file_suffix="",
                           test_file="daos:/testFile", create_pool=True,
                           create_cont=True, stop_dfuse=True, plugin_path=None,
@@ -255,7 +238,7 @@ class IorTestBase(DfuseTestBase):
 
         try:
             if display_space:
-                self.display_pool_space(pool)
+                pool.display_space()
             out = manager.run()
 
             if self.subprocess:
@@ -281,7 +264,7 @@ class IorTestBase(DfuseTestBase):
             self.fail("IOR Failed")
         finally:
             if not self.subprocess and display_space:
-                self.display_pool_space(pool)
+                pool.display_space()
 
         return None
 
@@ -302,7 +285,7 @@ class IorTestBase(DfuseTestBase):
             self.log.error("IOR stop Failed: %s", str(error))
             self.fail("Failed to stop in-progress IOR command")
         finally:
-            self.display_pool_space()
+            self.pool.display_space()
 
         return None
 

--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -410,20 +410,6 @@ class Ior:
         """
         return self.manager.job
 
-    @staticmethod
-    def display_pool_space(pool):
-        """Display the current pool space.
-
-        If the TestPool object has a DmgCommand object assigned, also display
-        the free pool space per target.
-
-        Args:
-            pool (TestPool): The pool for which to display space.
-        """
-        pool.display_pool_daos_space()
-        if pool.dmg:
-            pool.set_query_data()
-
     def run(self, group, pool, container, processes, ppn=None, intercept=None, plugin_path=None,
             dfuse=None, display_space=True, fail_on_warning=False):
         # pylint: disable=too-many-arguments
@@ -485,7 +471,7 @@ class Ior:
 
         try:
             if display_space:
-                self.display_pool_space(pool)
+                pool.display_space()
             result = self.manager.run()
 
         except CommandFailure as error:
@@ -493,7 +479,7 @@ class Ior:
 
         finally:
             if not self.manager.run_as_subprocess and display_space:
-                self.display_pool_space(pool)
+                pool.display_space()
 
         if error_message:
             raise CommandFailure(error_message)
@@ -519,6 +505,6 @@ class Ior:
                 error_message = "IOR Failed: {}".format(error)
             finally:
                 if pool:
-                    self.display_pool_space(pool)
+                    pool.display_space()
             if error_message:
                 raise CommandFailure(error_message)

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """
   (C) Copyright 2018-2022 Intel Corporation.
 
@@ -9,11 +8,12 @@ from time import sleep, time
 import ctypes
 import json
 
-from test_utils_base import TestDaosApiBase, LabelGenerator
 from avocado import fail_on, TestFail
+from pydaos.raw import (DaosApiError, DaosPool, c_uuid_to_str, daos_cref)
+
+from test_utils_base import TestDaosApiBase, LabelGenerator
 from command_utils import BasicParameter
 from exception_utils import CommandFailure
-from pydaos.raw import (DaosApiError, DaosPool, c_uuid_to_str, daos_cref)
 from general_utils import check_pool_files, DaosTestError
 from server_utils_base import ServerFailed, AutosizeCancel
 from dmg_utils import DmgCommand, DmgJsonCommandFailure
@@ -874,6 +874,20 @@ class TestPool(TestDaosApiBase):
         elif dev == "nvme":
             free_space = daos_space["s_free"][1]
         return free_space
+
+    def display_space(self):
+        """Display the current pool space.
+
+        If the TestPool object has a DmgCommand object assigned, also display
+        the free pool space per target.
+
+        """
+        if self.dmg:
+            # Display all query data
+            self.set_query_data()
+        else:
+            # Display just the space
+            self.display_pool_daos_space()
 
     def display_pool_daos_space(self, msg=None):
         """Display the pool info daos space attributes.


### PR DESCRIPTION
Test-tag: ior,pr ior,daily_regression
Skip-unit-tests: true
Skip-fault-injection-test: true

- Move IorTestBase.display_pool_space to TestPool.display_space
- Don't call both display_pool_daos_space and set_query_data since set_query_data already displays the space in a more readable format. display_pool_daos_space should be phased-out anyway.

Required-githooks: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
