### PR TITLE
DAOS-12258 test: fix run_dm_activities_with_ior testfile

### DIFF
--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -1,5 +1,5 @@
 """
-(C) Copyright 2018-2022 Intel Corporation.
+(C) Copyright 2018-2023 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -1076,11 +1076,12 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                 dst_path=format_path(pool, cont3))
             read_back_cont = cont3
             read_back_pool = pool
+        test_file = os.path.basename(self.ior_cmd.test_file.value)
         if tool in ['FS_COPY', 'DCP']:
             # the result is that a NEW directory is created in the destination
-            daos_path = os.path.join(os.sep, os.path.basename(posix_path), 'testfile')
+            daos_path = os.path.join(os.sep, os.path.basename(posix_path), test_file)
         elif tool in ['CONT_CLONE', 'DSERIAL']:
-            daos_path = os.path.join(os.sep, 'testfile')
+            daos_path = os.path.join(os.sep, test_file)
         else:
             self.fail("Invalid tool: {}".format(tool))
         # update ior params, read back and verify data from cont3


### PR DESCRIPTION
Test-tag: test_basic_checkout_dm test_io_sys_admin
Skip-unit-tests: true
Skip-fault-injection-test: true

- Use ior_cmd.test_file instead of hardcoded 'testfile'

Required-githooks: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
