### PR TITLE
DAOS-10856 test: verify dfuse multi-user chown

### DIFF
--- a/src/tests/ftest/dfuse/mu_perms.py
+++ b/src/tests/ftest/dfuse/mu_perms.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2022 Intel Corporation.
+  (C) Copyright 2022-2023 Intel Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
@@ -9,6 +9,8 @@ from ClusterShell.NodeSet import NodeSet
 
 from dfuse_test_base import DfuseTestBase
 from dfuse_utils import VerifyPermsCommand
+from user_utils import get_chown_command
+from run_utils import run_remote, command_as_user
 
 
 class DfuseMUPerms(DfuseTestBase):
@@ -16,14 +18,21 @@ class DfuseMUPerms(DfuseTestBase):
 
     def test_dfuse_mu_perms(self):
         """Jira ID: DAOS-10854.
+                    DAOS-10856.
 
         Test Description:
-            Verify dfuse multi-user permissions.
+            Verify dfuse multi-user rwx permissions.
+            Verify dfuse multi-user chown and chmod.
         Use cases:
             Create a pool.
             Create a container.
             Mount dfuse in multi-user mode.
-            Verify all rwx permissions for the owner and other users.
+            Verify all rwx permissions for dfuse owner : group user : other user.
+            Create a sub-directory and give the group user ownership.
+            Verify real rwx permissions for owner : dfuse user : other user.
+            Create a sub-directory and give the other user ownership.
+            Verify real rwx permissions for other user : None : dfuse user.
+
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dfuse,dfuse_mu,verify_perms
@@ -35,6 +44,13 @@ class DfuseMUPerms(DfuseTestBase):
         # Setup the verify command
         verify_perms_cmd = VerifyPermsCommand(client)
         verify_perms_cmd.get_params(self)
+
+        # Save original users
+        original_users = {
+            'owner': verify_perms_cmd.owner.value,
+            'group_user': verify_perms_cmd.group_user.value,
+            'other_user': verify_perms_cmd.other_user.value
+        }
 
         # Use the owner to mount dfuse
         dfuse_user = verify_perms_cmd.owner.value
@@ -60,3 +76,65 @@ class DfuseMUPerms(DfuseTestBase):
             verify_perms_cmd.update_params(path=path, create_type=_type, verify_mode=_mode)
             verify_perms_cmd.run()
             self.log.info('Passed %s %s permissions on %s', _mode, _type, path)
+
+        # Create a sub-directory owned by the group user and verify permissions
+        verify_perms_cmd.update_params(
+            owner=original_users['group_user'],
+            group_user=original_users['owner'],
+            other_user=original_users['other_user'])
+        sub_dir = os.path.join(self.dfuse.mount_dir.value, 'dir1')
+        self._create_dir_and_chown(
+            client, sub_dir, create_as=dfuse_user, owner=verify_perms_cmd.owner.value)
+
+        # Verify real permissions
+        for _type in ('file', 'dir'):
+            path = os.path.join(sub_dir, 'test_' + _type)
+            self.log.info('Verifying real %s permissions on %s', _type, path)
+            verify_perms_cmd.update_params(path=path, create_type=_type, verify_mode='real')
+            verify_perms_cmd.run()
+            self.log.info('Passed real %s permissions on %s', _type, path)
+
+        # Create a sub-directory owned by the other user and verify permissions
+        verify_perms_cmd.update_params(
+            owner=original_users['other_user'],
+            group_user=None,
+            other_user=original_users['owner'])
+        sub_dir = os.path.join(self.dfuse.mount_dir.value, 'dir2')
+        self._create_dir_and_chown(
+            client, sub_dir, create_as=dfuse_user,
+            owner=verify_perms_cmd.owner.value, group='root')
+
+        # Verify real permissions
+        for _type in ('file', 'dir'):
+            path = os.path.join(sub_dir, 'test_' + _type)
+            self.log.info('Verifying real %s permissions on %s', _type, path)
+            verify_perms_cmd.update_params(path=path, create_type=_type, verify_mode='real')
+            verify_perms_cmd.run()
+            self.log.info('Passed real %s permissions on %s', _type, path)
+
+    def _create_dir_and_chown(self, client, path, create_as, owner, group=None):
+        '''Create a directory and give some user and group ownership.
+
+        Args:
+            client (NodeSet): client to create directory on
+            path (str): path to create
+            create_as (str): user to run mkdir as
+            owner (str): user to give ownership to
+            group (str): group to give ownership to
+
+        '''
+        self.log.info('Creating directory: %s', path)
+        command = command_as_user('mkdir ' + path, create_as)
+        if not run_remote(self.log, client, command).passed:
+            self.fail('Failed to create directory: {}'.format(path))
+
+        if group:
+            self.log.info('Giving ownership to %s:%s', owner, group)
+        else:
+            self.log.info('Giving ownership to %s', owner)
+        command = command_as_user(get_chown_command(user=owner, group=group, file=path), 'root')
+        if not run_remote(self.log, client, command).passed:
+            self.fail('Failed to give ownership to {}'.format(owner))
+        command = command_as_user('stat {}'.format(path), owner)
+        if not run_remote(self.log, client, command).passed:
+            self.fail('Failed to stat {}'.format(path))

--- a/src/tests/ftest/dfuse/mu_perms.yaml
+++ b/src/tests/ftest/dfuse/mu_perms.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 1
   test_clients: 1
-timeout: 300
+timeout: 420
 server_config:
   name: daos_server
   engines_per_host: 1


### PR DESCRIPTION

Expand mu_perms.py to chown a directory as a different user and verify permissions.

Test-tag: test_dfuse_mu_perms
Skip-unit-tests: true
Skip-fault-injection-test: true

Required-githooks: true

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
