### PR TITLE
DAOS-12309 debug: strace dmg and archive output

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-  (C) Copyright 2018-2022 Intel Corporation.
+  (C) Copyright 2018-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -2624,6 +2624,14 @@ class Launch():
                 "source": daos_test_log_dir,
                 "destination": os.path.join(self.job_results_dir, "latest", "daos_logs"),
                 "pattern": "*log*",
+                "hosts": test.host_info.all_hosts,
+                "depth": 1,
+                "timeout": 900,
+            }
+            remote_files["dmg strace files"] = {
+                "source": daos_test_log_dir,
+                "destination": os.path.join(self.job_results_dir, "latest", "daos_dmg_strace"),
+                "pattern": "dmg.*.strace",
                 "hosts": test.host_info.all_hosts,
                 "depth": 1,
                 "timeout": 900,

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2629,7 +2629,7 @@ class Launch():
                 "timeout": 900,
             }
             remote_files["dmg strace files"] = {
-                "source": daos_test_log_dir,
+                "source": os.path.join(os.sep, "tmp"),
                 "destination": os.path.join(self.job_results_dir, "latest", "daos_dmg_strace"),
                 "pattern": "dmg.*.strace",
                 "hosts": test.host_info.all_hosts,

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -187,7 +187,7 @@ class ExecutableCommand(CommandWithParameters):
         first = command.split()[0]
         second = command.split()[1]
         third = command.split()[2]
-        if first is 'dmg' and second is 'pool' and third is 'create':
+        if first == 'dmg' and second == 'pool' and third == 'create':
             command = ' '.join(['strace', '-f -tt -T -o ', 'dmg.{}.strace'.format(time.time()), command])
 
         if raise_exception is None:

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2018-2022 Intel Corporation.
+  (C) Copyright 2018-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -182,6 +182,14 @@ class ExecutableCommand(CommandWithParameters):
         # Clear any previous run results
         self.result = None
         command = str(self)
+
+        # add strace if a "dmg pool create" command
+        first = command.split()[0]
+        second = command.split()[1]
+        third = command.split()[2]
+        if first is 'dmg' and second is 'pool' and third is 'create':
+            command = ' '.join(['strace', '-f -tt -T -o ', 'dmg.{}.strace'.format(time.time()), command])
+
         if raise_exception is None:
             raise_exception = self.exit_status_exception
 

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -185,13 +185,8 @@ class ExecutableCommand(CommandWithParameters):
 
         # add strace if a "dmg pool create" command
         # commands are of form '/usr/bin/dmg -o /etc/daos/daos_control.yml -d -j pool create ...'
-        first = command.split()[0]
-        self.log.debug("first: %s", first)
-        sixth = command.split()[5]
-        self.log.debug("sixth: %s", sixth)
-        seventh = command.split()[6]
-        self.log.debug("seventh: %s", seventh)
-        if 'dmg' in first and sixth == 'pool' and seventh == 'create':
+        words = command.split()
+        if len(words) > 6 and 'dmg' in words[0]  and words[5] == 'pool' and words[6] == 'create':
             command = ' '.join(['strace', '-f -tt -T -o ', 'dmg.{}.strace'.format(time.time()), command])
 
         if raise_exception is None:

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -184,13 +184,14 @@ class ExecutableCommand(CommandWithParameters):
         command = str(self)
 
         # add strace if a "dmg pool create" command
+        # commands are of form '/usr/bin/dmg -o /etc/daos/daos_control.yml -d -j pool create ...'
         first = command.split()[0]
         self.log.debug("first: %s", first)
-        second = command.split()[1]
-        self.log.debug("second: %s", second)
-        third = command.split()[2]
-        self.log.debug("third: %s", third)
-        if first == 'dmg' and second == 'pool' and third == 'create':
+        sixth = command.split()[5]
+        self.log.debug("sixth: %s", sixth)
+        seventh = command.split()[6]
+        self.log.debug("seventh: %s", seventh)
+        if 'dmg' in first and sixth == 'pool' and seventh == 'create':
             command = ' '.join(['strace', '-f -tt -T -o ', 'dmg.{}.strace'.format(time.time()), command])
 
         if raise_exception is None:

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -187,7 +187,7 @@ class ExecutableCommand(CommandWithParameters):
         # commands are of form '/usr/bin/dmg -o /etc/daos/daos_control.yml -d -j pool create ...'
         words = command.split()
         if len(words) > 6 and 'dmg' in words[0]  and words[5] == 'pool' and words[6] == 'create':
-            command = ' '.join(['strace', '-f -tt -T -o ', 'dmg.{}.strace'.format(time.time()), command])
+            command = ' '.join(['strace', '-f -tt -T -o ', '/tmp/dmg.{}.strace'.format(time.time()), command])
 
         if raise_exception is None:
             raise_exception = self.exit_status_exception

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -185,8 +185,11 @@ class ExecutableCommand(CommandWithParameters):
 
         # add strace if a "dmg pool create" command
         first = command.split()[0]
+        self.log.debug("first: %s", first)
         second = command.split()[1]
+        self.log.debug("second: %s", second)
         third = command.split()[2]
+        self.log.debug("third: %s", third)
         if first == 'dmg' and second == 'pool' and third == 'create':
             command = ' '.join(['strace', '-f -tt -T -o ', 'dmg.{}.strace'.format(time.time()), command])
 


### PR DESCRIPTION
strace all "dmg pool create" commands and archive their strace outputs as CI artifacts, for further examination in order to find some reason to explain why a single pool creation can unexpectedly take about 10s and more ...

Test-tag: test_create_pool_quantity
Required-githooks: true

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
