### PR TITLE
DAOS-8722 dfuse: Add common init function for inodes and checking to readdir.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -204,7 +204,7 @@ struct dfuse_pool {
 	/** Hash table entry in dpi_pool_table */
 	d_list_t		dfp_entry;
 	/** Hash table reference count */
-	ATOMIC uint		dfp_ref;
+	ATOMIC uint32_t         dfp_ref;
 
 	/** Hash table of open containers in pool */
 	struct d_hash_table	dfp_cont_table;
@@ -546,8 +546,6 @@ struct fuse_lowlevel_ops dfuse_ops;
  * be a directory, file, symbolic link or anything else.
  */
 
-#define DFUSE_IE_MAGIC 0xf05ef05ef05e
-
 struct dfuse_inode_entry {
 	/** stat structure for this inode.
 	 * This will be valid, but out-of-date at any given moment in time,
@@ -576,8 +574,6 @@ struct dfuse_inode_entry {
 	 * a reference on the parent so the inode may not be valid.
 	 */
 	fuse_ino_t               ie_parent;
-
-	uint64_t                 ie_magic;
 
 	struct dfuse_cont       *ie_dfs;
 

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -92,6 +92,10 @@ struct dfuse_obj_hdl {
 	struct dfuse_readdir_hdl *doh_rd;
 
 	ATOMIC uint32_t           doh_il_calls;
+
+	/** Number of active readdir operations */
+	ATOMIC uint32_t           doh_readir_number;
+
 	ATOMIC uint64_t           doh_write_count;
 
 	/** True if caching is enabled for this file. */
@@ -542,6 +546,8 @@ struct fuse_lowlevel_ops dfuse_ops;
  * be a directory, file, symbolic link or anything else.
  */
 
+#define DFUSE_IE_MAGIC 0xf05ef05ef05e
+
 struct dfuse_inode_entry {
 	/** stat structure for this inode.
 	 * This will be valid, but out-of-date at any given moment in time,
@@ -571,6 +577,8 @@ struct dfuse_inode_entry {
 	 */
 	fuse_ino_t               ie_parent;
 
+	uint64_t                 ie_magic;
+
 	struct dfuse_cont       *ie_dfs;
 
 	/** Hash table of inodes
@@ -587,10 +595,8 @@ struct dfuse_inode_entry {
 	size_t                   ie_start_off;
 	size_t                   ie_end_off;
 
-	/** Reference counting for the inode.
-	 * Used by the hash table callbacks
-	 */
-	ATOMIC uint              ie_ref;
+	/** Reference counting for the inode Used by the hash table callbacks */
+	ATOMIC uint32_t          ie_ref;
 
 	/* Number of open file descriptors for this inode */
 	ATOMIC uint32_t          ie_open_count;
@@ -599,6 +605,9 @@ struct dfuse_inode_entry {
 
 	/* Number of file open file descriptors using IL */
 	ATOMIC uint32_t          ie_il_count;
+
+	/** Number of active readdir operations */
+	ATOMIC uint32_t          ie_readir_number;
 
 	/** file was truncated from 0 to a certain size */
 	bool                     ie_truncated;
@@ -653,6 +662,9 @@ dfuse_cache_get_valid(struct dfuse_inode_entry *ie, double max_age, double *time
 int
 check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 		 struct dfuse_inode_entry *ie, char *attr, daos_size_t len);
+
+void
+dfuse_ie_init(struct dfuse_inode_entry *ie);
 
 void
 dfuse_ie_close(struct dfuse_projection_info *, struct dfuse_inode_entry *);

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -239,7 +239,7 @@ struct dfuse_cont {
 	/** Hash table entry entry in dfp_cont_table */
 	d_list_t		dfs_entry;
 	/** Hash table reference count */
-	ATOMIC uint		dfs_ref;
+	ATOMIC uint32_t          dfs_ref;
 
 	/** Inode number of the root of this container */
 	ino_t			dfs_ino;

--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -83,6 +83,8 @@ dfuse_cont_lookup(fuse_req_t req, struct dfuse_inode_entry *parent, const char *
 
 	DFUSE_TRA_UP(ie, parent, "inode");
 
+	dfuse_ie_init(ie);
+
 	rc = dfs_lookup(dfc->dfs_ns, "/", O_RDWR, &ie->ie_obj, NULL,
 			&ie->ie_stat);
 	if (rc) {
@@ -93,7 +95,6 @@ dfuse_cont_lookup(fuse_req_t req, struct dfuse_inode_entry *parent, const char *
 	ie->ie_parent = parent->ie_stat.st_ino;
 	strncpy(ie->ie_name, name, NAME_MAX);
 
-	atomic_store_relaxed(&ie->ie_ref, 1);
 	ie->ie_dfs = dfc;
 
 	ie->ie_stat.st_ino = dfc->dfs_ino;

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1015,11 +1015,20 @@ dfuse_open_handle_init(struct dfuse_obj_hdl *oh, struct dfuse_inode_entry *ie)
 }
 
 void
+dfuse_ie_init(struct dfuse_inode_entry *ie)
+{
+	ie->ie_magic = DFUSE_IE_MAGIC;
+	atomic_init(&ie->ie_ref, 1);
+}
+
+void
 dfuse_ie_close(struct dfuse_projection_info *fs_handle,
 	       struct dfuse_inode_entry *ie)
 {
 	int	rc;
 	int	ref;
+
+	D_ASSERT(ie->ie_magic == DFUSE_IE_MAGIC);
 
 	ref = atomic_load_relaxed(&ie->ie_ref);
 	DFUSE_TRA_DEBUG(ie,
@@ -1183,7 +1192,7 @@ dfuse_fs_start(struct dfuse_projection_info *fs_handle, struct dfuse_cont *dfs)
 	ie->ie_dfs = dfs;
 	ie->ie_root = true;
 	ie->ie_parent = 1;
-	atomic_store_relaxed(&ie->ie_ref, 1);
+	dfuse_ie_init(ie);
 
 	if (dfs->dfs_ops == &dfuse_dfs_ops) {
 		rc = dfs_lookup(dfs->dfs_ns, "/", O_RDWR, &ie->ie_obj, NULL, &ie->ie_stat);

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -129,32 +129,27 @@ ih_rec_hash(struct d_hash_table *htable, d_list_t *rlink)
 static void
 ih_addref(struct d_hash_table *htable, d_list_t *rlink)
 {
-	struct dfuse_inode_entry	*ie;
-	uint				oldref;
+	struct dfuse_inode_entry *ie;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
-	oldref = atomic_fetch_add_relaxed(&ie->ie_ref, 1);
-	DFUSE_TRA_DEBUG(ie, "addref to %u", oldref + 1);
+	atomic_fetch_add_relaxed(&ie->ie_ref, 1);
 }
 
 static bool
 ih_decref(struct d_hash_table *htable, d_list_t *rlink)
 {
-	struct dfuse_inode_entry	*ie;
-	uint				oldref;
+	struct dfuse_inode_entry *ie;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
-	oldref = atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
-	DFUSE_TRA_DEBUG(ie, "decref to %u", oldref - 1);
-	return oldref == 1;
+	return (atomic_fetch_sub_relaxed(&ie->ie_ref, 1) == 1);
 }
 
 static int
 ih_ndecref(struct d_hash_table *htable, d_list_t *rlink, int count)
 {
 	struct dfuse_inode_entry	*ie;
-	uint				oldref = 0;
-	uint				newref = 0;
+	uint32_t                         oldref = 0;
+	uint32_t                         newref = 0;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
@@ -174,7 +169,6 @@ ih_ndecref(struct d_hash_table *htable, d_list_t *rlink, int count)
 		return -DER_INVAL;
 	}
 
-	DFUSE_TRA_DEBUG(ie, "decref of %u to %u", count, newref);
 	if (newref == 0)
 		return 1;
 	return 0;
@@ -331,7 +325,7 @@ static void
 ch_addref(struct d_hash_table *htable, d_list_t *link)
 {
 	struct dfuse_cont	*dfc;
-	uint			oldref;
+	uint32_t                 oldref;
 
 	dfc = container_of(link, struct dfuse_cont, dfs_entry);
 	oldref = atomic_fetch_add_relaxed(&dfc->dfs_ref, 1);
@@ -342,7 +336,7 @@ static bool
 ch_decref(struct d_hash_table *htable, d_list_t *link)
 {
 	struct dfuse_cont	*dfc;
-	uint			oldref;
+	uint32_t                 oldref;
 
 	dfc = container_of(link, struct dfuse_cont, dfs_entry);
 	oldref = atomic_fetch_sub_relaxed(&dfc->dfs_ref, 1);

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -92,22 +92,20 @@ dfuse_parse_time(char *buff, size_t len, unsigned int *_out)
 
 /* Shrink a 64 bit value into 32 bits to avoid hash collisions */
 static uint32_t
-ih_key_hash(struct d_hash_table *htable, const void *key,
-	    unsigned int ksize)
+ih_key_hash(struct d_hash_table *htable, const void *key, unsigned int ksize)
 {
 	const ino_t *_ino = key;
-	ino_t ino = *_ino;
-	uint32_t hash = ino ^ (ino >> 32);
+	ino_t        ino  = *_ino;
+	uint32_t     hash = ino ^ (ino >> 32);
 
 	return hash;
 }
 
 static bool
-ih_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
-	   const void *key, unsigned int ksize)
+ih_key_cmp(struct d_hash_table *htable, d_list_t *rlink, const void *key, unsigned int ksize)
 {
-	const struct dfuse_inode_entry	*ie;
-	const ino_t			*ino = key;
+	const struct dfuse_inode_entry *ie;
+	const ino_t                    *ino = key;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
@@ -117,13 +115,11 @@ ih_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 static uint32_t
 ih_rec_hash(struct d_hash_table *htable, d_list_t *rlink)
 {
-	const struct dfuse_inode_entry	*ie;
+	const struct dfuse_inode_entry *ie;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
-	return ih_key_hash(NULL,
-			   &ie->ie_stat.st_ino,
-			   sizeof(ie->ie_stat.st_ino));
+	return ih_key_hash(NULL, &ie->ie_stat.st_ino, sizeof(ie->ie_stat.st_ino));
 }
 
 static void
@@ -147,9 +143,9 @@ ih_decref(struct d_hash_table *htable, d_list_t *rlink)
 static int
 ih_ndecref(struct d_hash_table *htable, d_list_t *rlink, int count)
 {
-	struct dfuse_inode_entry	*ie;
-	uint32_t                         oldref = 0;
-	uint32_t                         newref = 0;
+	struct dfuse_inode_entry *ie;
+	uint32_t                  oldref = 0;
+	uint32_t                  newref = 0;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
@@ -164,8 +160,7 @@ ih_ndecref(struct d_hash_table *htable, d_list_t *rlink, int count)
 	} while (!atomic_compare_exchange(&ie->ie_ref, oldref, newref));
 
 	if (oldref < count) {
-		DFUSE_TRA_ERROR(ie, "unable to decref %u from %u",
-				count, oldref);
+		DFUSE_TRA_ERROR(ie, "unable to decref %u from %u", count, oldref);
 		return -DER_INVAL;
 	}
 
@@ -177,8 +172,8 @@ ih_ndecref(struct d_hash_table *htable, d_list_t *rlink, int count)
 static void
 ih_free(struct d_hash_table *htable, d_list_t *rlink)
 {
-	struct dfuse_projection_info	*fs_handle = htable->ht_priv;
-	struct dfuse_inode_entry	*ie;
+	struct dfuse_projection_info *fs_handle = htable->ht_priv;
+	struct dfuse_inode_entry     *ie;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
@@ -187,18 +182,17 @@ ih_free(struct d_hash_table *htable, d_list_t *rlink)
 }
 
 static d_hash_table_ops_t ie_hops = {
-	.hop_key_cmp		= ih_key_cmp,
-	.hop_key_hash		= ih_key_hash,
-	.hop_rec_hash		= ih_rec_hash,
-	.hop_rec_addref		= ih_addref,
-	.hop_rec_decref		= ih_decref,
-	.hop_rec_ndecref	= ih_ndecref,
-	.hop_rec_free		= ih_free,
+    .hop_key_cmp     = ih_key_cmp,
+    .hop_key_hash    = ih_key_hash,
+    .hop_rec_hash    = ih_rec_hash,
+    .hop_rec_addref  = ih_addref,
+    .hop_rec_decref  = ih_decref,
+    .hop_rec_ndecref = ih_ndecref,
+    .hop_rec_free    = ih_free,
 };
 
 static uint32_t
-ph_key_hash(struct d_hash_table *htable, const void *key,
-	    unsigned int ksize)
+ph_key_hash(struct d_hash_table *htable, const void *key, unsigned int ksize)
 {
 	return *((const uint32_t *)key);
 }
@@ -214,8 +208,7 @@ ph_rec_hash(struct d_hash_table *htable, d_list_t *link)
 }
 
 static bool
-ph_key_cmp(struct d_hash_table *htable, d_list_t *link,
-	   const void *key, unsigned int ksize)
+ph_key_cmp(struct d_hash_table *htable, d_list_t *link, const void *key, unsigned int ksize)
 {
 	struct dfuse_pool *dfp;
 
@@ -226,10 +219,10 @@ ph_key_cmp(struct d_hash_table *htable, d_list_t *link,
 static void
 ph_addref(struct d_hash_table *htable, d_list_t *link)
 {
-	struct dfuse_pool	 *dfp;
-	uint			 oldref;
+	struct dfuse_pool *dfp;
+	uint32_t           oldref;
 
-	dfp = container_of(link, struct dfuse_pool, dfp_entry);
+	dfp    = container_of(link, struct dfuse_pool, dfp_entry);
 	oldref = atomic_fetch_add_relaxed(&dfp->dfp_ref, 1);
 	DFUSE_TRA_DEBUG(dfp, "addref to %u", oldref + 1);
 }
@@ -237,10 +230,10 @@ ph_addref(struct d_hash_table *htable, d_list_t *link)
 static bool
 ph_decref(struct d_hash_table *htable, d_list_t *link)
 {
-	struct dfuse_pool	*dfp;
-	uint			oldref;
+	struct dfuse_pool *dfp;
+	uint32_t           oldref;
 
-	dfp = container_of(link, struct dfuse_pool, dfp_entry);
+	dfp    = container_of(link, struct dfuse_pool, dfp_entry);
 	oldref = atomic_fetch_sub_relaxed(&dfp->dfp_ref, 1);
 	DFUSE_TRA_DEBUG(dfp, "decref to %u", oldref - 1);
 	return oldref == 1;
@@ -266,15 +259,12 @@ _ph_free(struct dfuse_pool *dfp)
 				rc = -DER_SUCCESS;
 		}
 		if (rc != -DER_SUCCESS)
-			DFUSE_TRA_ERROR(dfp,
-					"daos_pool_disconnect() failed: "DF_RC,
-					DP_RC(rc));
+			DFUSE_TRA_ERROR(dfp, "daos_pool_disconnect() failed: " DF_RC, DP_RC(rc));
 	}
 
 	rc = d_hash_table_destroy_inplace(&dfp->dfp_cont_table, false);
 	if (rc != -DER_SUCCESS)
-		DFUSE_TRA_ERROR(dfp, "Failed to destroy pool hash table: "DF_RC,
-				DP_RC(rc));
+		DFUSE_TRA_ERROR(dfp, "Failed to destroy pool hash table: " DF_RC, DP_RC(rc));
 
 	D_FREE(dfp);
 }
@@ -286,17 +276,16 @@ ph_free(struct d_hash_table *htable, d_list_t *link)
 }
 
 static d_hash_table_ops_t pool_hops = {
-	.hop_key_cmp		= ph_key_cmp,
-	.hop_key_hash		= ph_key_hash,
-	.hop_rec_hash		= ph_rec_hash,
-	.hop_rec_addref		= ph_addref,
-	.hop_rec_decref		= ph_decref,
-	.hop_rec_free		= ph_free,
+    .hop_key_cmp    = ph_key_cmp,
+    .hop_key_hash   = ph_key_hash,
+    .hop_rec_hash   = ph_rec_hash,
+    .hop_rec_addref = ph_addref,
+    .hop_rec_decref = ph_decref,
+    .hop_rec_free   = ph_free,
 };
 
 static uint32_t
-ch_key_hash(struct d_hash_table *htable, const void *key,
-	    unsigned int ksize)
+ch_key_hash(struct d_hash_table *htable, const void *key, unsigned int ksize)
 {
 	return *((const uint32_t *)key);
 }
@@ -312,8 +301,7 @@ ch_rec_hash(struct d_hash_table *htable, d_list_t *link)
 }
 
 static bool
-ch_key_cmp(struct d_hash_table *htable, d_list_t *link,
-	   const void *key, unsigned int ksize)
+ch_key_cmp(struct d_hash_table *htable, d_list_t *link, const void *key, unsigned int ksize)
 {
 	struct dfuse_cont *dfc;
 
@@ -324,10 +312,10 @@ ch_key_cmp(struct d_hash_table *htable, d_list_t *link,
 static void
 ch_addref(struct d_hash_table *htable, d_list_t *link)
 {
-	struct dfuse_cont	*dfc;
-	uint32_t                 oldref;
+	struct dfuse_cont *dfc;
+	uint32_t           oldref;
 
-	dfc = container_of(link, struct dfuse_cont, dfs_entry);
+	dfc    = container_of(link, struct dfuse_cont, dfs_entry);
 	oldref = atomic_fetch_add_relaxed(&dfc->dfs_ref, 1);
 	DFUSE_TRA_DEBUG(dfc, "addref to %u", oldref + 1);
 }
@@ -335,10 +323,10 @@ ch_addref(struct d_hash_table *htable, d_list_t *link)
 static bool
 ch_decref(struct d_hash_table *htable, d_list_t *link)
 {
-	struct dfuse_cont	*dfc;
-	uint32_t                 oldref;
+	struct dfuse_cont *dfc;
+	uint32_t           oldref;
 
-	dfc = container_of(link, struct dfuse_cont, dfs_entry);
+	dfc    = container_of(link, struct dfuse_cont, dfs_entry);
 	oldref = atomic_fetch_sub_relaxed(&dfc->dfs_ref, 1);
 	DFUSE_TRA_DEBUG(dfc, "decref to %u", oldref - 1);
 	return oldref == 1;
@@ -358,7 +346,7 @@ _ch_free(struct dfuse_projection_info *fs_handle, struct dfuse_cont *dfc)
 		if (rc == -DER_NOMEM)
 			rc = daos_cont_close(dfc->dfs_coh, NULL);
 		if (rc != 0)
-			DFUSE_TRA_ERROR(dfc, "daos_cont_close() failed, "DF_RC, DP_RC(rc));
+			DFUSE_TRA_ERROR(dfc, "daos_cont_close() failed, " DF_RC, DP_RC(rc));
 	}
 
 	d_hash_rec_decref(&fs_handle->dpi_pool_table, &dfc->dfs_dfp->dfp_entry);
@@ -369,17 +357,16 @@ _ch_free(struct dfuse_projection_info *fs_handle, struct dfuse_cont *dfc)
 static void
 ch_free(struct d_hash_table *htable, d_list_t *link)
 {
-	_ch_free(htable->ht_priv,
-		 container_of(link, struct dfuse_cont, dfs_entry));
+	_ch_free(htable->ht_priv, container_of(link, struct dfuse_cont, dfs_entry));
 }
 
 d_hash_table_ops_t cont_hops = {
-	.hop_key_cmp		= ch_key_cmp,
-	.hop_key_hash		= ch_key_hash,
-	.hop_rec_hash		= ch_rec_hash,
-	.hop_rec_addref		= ch_addref,
-	.hop_rec_decref		= ch_decref,
-	.hop_rec_free		= ch_free,
+    .hop_key_cmp    = ch_key_cmp,
+    .hop_key_hash   = ch_key_hash,
+    .hop_rec_hash   = ch_rec_hash,
+    .hop_rec_addref = ch_addref,
+    .hop_rec_decref = ch_decref,
+    .hop_rec_free   = ch_free,
 };
 
 /* Connect to a pool.

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -391,7 +391,7 @@ dfuse_pool_connect(struct dfuse_projection_info *fs_handle, const char *label,
 	if (dfp == NULL)
 		D_GOTO(err, rc = ENOMEM);
 
-	atomic_store_relaxed(&dfp->dfp_ref, 1);
+	atomic_init(&dfp->dfp_ref, 1);
 
 	DFUSE_TRA_UP(dfp, fs_handle, "dfp");
 
@@ -780,7 +780,7 @@ dfuse_cont_open(struct dfuse_projection_info *fs_handle, struct dfuse_pool *dfp,
 
 	/* No existing container found, so setup dfs and connect to one */
 
-	atomic_store_relaxed(&dfc->dfs_ref, 1);
+	atomic_init(&dfc->dfs_ref, 1);
 
 	DFUSE_TRA_DEBUG(dfp, "New cont "DF_UUIDF" in pool "DF_UUIDF,
 			DP_UUID(cont), DP_UUID(dfp->dfp_pool));

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -405,6 +405,7 @@ static void
 df_ll_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, struct fuse_file_info *fi)
 {
 	struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
+	uint32_t              count;
 
 	if (oh == NULL) {
 		struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
@@ -413,7 +414,16 @@ df_ll_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, struct 
 		return;
 	}
 
+	count = atomic_fetch_add_relaxed(&oh->doh_readir_number, 1);
+	D_ASSERTF(count == 0, "Multiple readdir per handle");
+
+	count = atomic_fetch_add_relaxed(&oh->doh_ie->ie_readir_number, 1);
+	D_ASSERTF(count == 0, "Multiple readdir per inode");
+
 	dfuse_cb_readdir(req, oh, size, offset, false);
+
+	atomic_fetch_sub_relaxed(&oh->doh_readir_number, 1);
+	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_readir_number, 1);
 }
 
 static void
@@ -421,6 +431,7 @@ df_ll_readdirplus(fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset,
 		  struct fuse_file_info *fi)
 {
 	struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
+	uint32_t              count;
 
 	if (oh == NULL) {
 		struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
@@ -429,7 +440,15 @@ df_ll_readdirplus(fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset,
 		return;
 	}
 
+	count = atomic_fetch_add_relaxed(&oh->doh_readir_number, 1);
+	D_ASSERTF(count == 0, "Multiple readdir per handle");
+
+	count = atomic_fetch_add_relaxed(&oh->doh_ie->ie_readir_number, 1);
+	D_ASSERTF(count == 0, "Multiple readdir per inode");
+
 	dfuse_cb_readdir(req, oh, size, offset, true);
+	atomic_fetch_sub_relaxed(&oh->doh_readir_number, 1);
+	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_readir_number, 1);
 }
 
 void

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -405,7 +405,6 @@ static void
 df_ll_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, struct fuse_file_info *fi)
 {
 	struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
-	uint32_t              count;
 
 	if (oh == NULL) {
 		struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
@@ -414,16 +413,7 @@ df_ll_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset, struct 
 		return;
 	}
 
-	count = atomic_fetch_add_relaxed(&oh->doh_readir_number, 1);
-	D_ASSERTF(count == 0, "Multiple readdir per handle");
-
-	count = atomic_fetch_add_relaxed(&oh->doh_ie->ie_readir_number, 1);
-	D_ASSERTF(count == 0, "Multiple readdir per inode");
-
 	dfuse_cb_readdir(req, oh, size, offset, false);
-
-	atomic_fetch_sub_relaxed(&oh->doh_readir_number, 1);
-	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_readir_number, 1);
 }
 
 static void
@@ -431,7 +421,6 @@ df_ll_readdirplus(fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset,
 		  struct fuse_file_info *fi)
 {
 	struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
-	uint32_t              count;
 
 	if (oh == NULL) {
 		struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
@@ -440,15 +429,7 @@ df_ll_readdirplus(fuse_req_t req, fuse_ino_t ino, size_t size, off_t offset,
 		return;
 	}
 
-	count = atomic_fetch_add_relaxed(&oh->doh_readir_number, 1);
-	D_ASSERTF(count == 0, "Multiple readdir per handle");
-
-	count = atomic_fetch_add_relaxed(&oh->doh_ie->ie_readir_number, 1);
-	D_ASSERTF(count == 0, "Multiple readdir per inode");
-
 	dfuse_cb_readdir(req, oh, size, offset, true);
-	atomic_fetch_sub_relaxed(&oh->doh_readir_number, 1);
-	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_readir_number, 1);
 }
 
 void

--- a/src/client/dfuse/dfuse_pool.c
+++ b/src/client/dfuse/dfuse_pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -87,10 +87,11 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	DFUSE_TRA_UP(ie, parent, "inode");
 
+	dfuse_ie_init(ie);
+
 	ie->ie_parent = parent->ie_stat.st_ino;
 	strncpy(ie->ie_name, name, NAME_MAX);
 
-	atomic_store_relaxed(&ie->ie_ref, 1);
 	ie->ie_dfs = dfc;
 
 	prop = daos_prop_alloc(0);

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -156,6 +156,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	ie->ie_stat.st_uid = ctx->uid;
 	ie->ie_stat.st_gid = ctx->gid;
 
+	dfuse_ie_init(ie);
 	dfuse_open_handle_init(oh, ie);
 
 	if (!fs_handle->dpi_info->di_multi_user) {
@@ -198,7 +199,6 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	strncpy(ie->ie_name, name, NAME_MAX);
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_truncated = false;
-	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	LOG_FLAGS(ie, fi->flags);
 	LOG_MODES(ie, mode);

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -236,6 +236,8 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	DFUSE_TRA_UP(ie, parent, "inode");
 
+	dfuse_ie_init(ie);
+
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_dfs = parent->ie_dfs;
 
@@ -252,7 +254,6 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	DFUSE_TRA_DEBUG(ie, "Attr len is %zi", attr_len);
 
 	strncpy(ie->ie_name, name, NAME_MAX);
-	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	dfs_obj2id(ie->ie_obj, &ie->ie_oid);
 

--- a/src/client/dfuse/ops/mknod.c
+++ b/src/client/dfuse/ops/mknod.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2020-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -10,10 +10,10 @@
 void
 dfuse_cb_mknod(fuse_req_t req, struct dfuse_inode_entry *parent, const char *name, mode_t mode)
 {
-	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
-	const struct fuse_ctx		*ctx = fuse_req_ctx(req);
-	struct dfuse_inode_entry	*ie;
-	int				rc;
+	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
+	const struct fuse_ctx        *ctx       = fuse_req_ctx(req);
+	struct dfuse_inode_entry     *ie;
+	int                           rc;
 
 	DFUSE_TRA_DEBUG(parent, "Parent:%lu '%s'", parent->ie_stat.st_ino, name);
 
@@ -29,6 +29,8 @@ dfuse_cb_mknod(fuse_req_t req, struct dfuse_inode_entry *parent, const char *nam
 	if (rc != 0)
 		D_GOTO(err, rc);
 
+	dfuse_ie_init(ie);
+
 	ie->ie_stat.st_uid = ctx->uid;
 	ie->ie_stat.st_gid = ctx->gid;
 
@@ -38,10 +40,9 @@ dfuse_cb_mknod(fuse_req_t req, struct dfuse_inode_entry *parent, const char *nam
 		D_GOTO(err, rc);
 
 	strncpy(ie->ie_name, name, NAME_MAX);
-	ie->ie_parent = parent->ie_stat.st_ino;
-	ie->ie_dfs = parent->ie_dfs;
+	ie->ie_parent    = parent->ie_stat.st_ino;
+	ie->ie_dfs       = parent->ie_dfs;
 	ie->ie_truncated = false;
-	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	LOG_MODES(ie, mode);
 

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -115,6 +115,7 @@ create_entry(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *
 
 	DFUSE_TRA_UP(ie, parent, "inode");
 
+	dfuse_ie_init(ie);
 	ie->ie_obj  = obj;
 	ie->ie_stat = entry->attr;
 
@@ -147,7 +148,6 @@ create_entry(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *
 
 	strncpy(ie->ie_name, name, NAME_MAX);
 	ie->ie_name[NAME_MAX] = '\0';
-	atomic_store_relaxed(&ie->ie_ref, 1);
 
 	DFUSE_TRA_DEBUG(ie, "Inserting inode %#lx mode 0%o", entry->ino, ie->ie_stat.st_mode);
 

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -13,7 +13,7 @@ dfuse_cb_symlink(fuse_req_t req, const char *link, struct dfuse_inode_entry *par
 {
 	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
 	const struct fuse_ctx        *ctx       = fuse_req_ctx(req);
-	struct dfuse_inode_entry     *ie        = NULL;
+	struct dfuse_inode_entry     *ie;
 	int                           rc;
 
 	D_ALLOC_PTR(ie);

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -8,14 +8,13 @@
 #include "dfuse.h"
 
 void
-dfuse_cb_symlink(fuse_req_t req, const char *link,
-		 struct dfuse_inode_entry *parent,
+dfuse_cb_symlink(fuse_req_t req, const char *link, struct dfuse_inode_entry *parent,
 		 const char *name)
 {
-	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
-	const struct fuse_ctx		*ctx = fuse_req_ctx(req);
-	struct dfuse_inode_entry	*ie = NULL;
-	int rc;
+	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
+	const struct fuse_ctx        *ctx       = fuse_req_ctx(req);
+	struct dfuse_inode_entry     *ie        = NULL;
+	int                           rc;
 
 	D_ALLOC_PTR(ie);
 	if (!ie)
@@ -23,12 +22,13 @@ dfuse_cb_symlink(fuse_req_t req, const char *link,
 
 	DFUSE_TRA_UP(ie, parent, "inode");
 
+	dfuse_ie_init(ie);
+
 	ie->ie_stat.st_uid = ctx->uid;
 	ie->ie_stat.st_gid = ctx->gid;
 
-	rc = dfs_open_stat(parent->ie_dfs->dfs_ns, parent->ie_obj, name,
-			   S_IFLNK, O_CREAT | O_RDWR | O_EXCL,
-			   0, 0, link, &ie->ie_obj, &ie->ie_stat);
+	rc = dfs_open_stat(parent->ie_dfs->dfs_ns, parent->ie_obj, name, S_IFLNK,
+			   O_CREAT | O_RDWR | O_EXCL, 0, 0, link, &ie->ie_obj, &ie->ie_stat);
 	if (rc != 0)
 		D_GOTO(err, rc);
 
@@ -36,13 +36,11 @@ dfuse_cb_symlink(fuse_req_t req, const char *link,
 
 	strncpy(ie->ie_name, name, NAME_MAX);
 	ie->ie_parent = parent->ie_stat.st_ino;
-	ie->ie_dfs = parent->ie_dfs;
-	atomic_store_relaxed(&ie->ie_ref, 1);
+	ie->ie_dfs    = parent->ie_dfs;
 
 	dfs_obj2id(ie->ie_obj, &ie->ie_oid);
 
-	dfuse_compute_inode(ie->ie_dfs, &ie->ie_oid,
-			    &ie->ie_stat.st_ino);
+	dfuse_compute_inode(ie->ie_dfs, &ie->ie_oid, &ie->ie_stat.st_ino);
 
 	dfuse_reply_entry(fs_handle, ie, NULL, true, req);
 


### PR DESCRIPTION
Create a common inode init function to allow us to have a common code-path.
Add a magic value which we check for in close to ensure init has been called.

Use atomics to check for concurrent readdir operations, both on the handle
and on the inode.

Test-tag: dfuse
Required-githooks: true
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
