### PR TITLE
DAOS-12259 test: reduce dfuse caching perf threshold (#11116)

### DIFF
--- a/src/tests/ftest/dfuse/caching_check.yaml
+++ b/src/tests/ftest/dfuse/caching_check.yaml
@@ -11,29 +11,24 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 pool:
-    mode: 146 # 146 is RW
-    name: daos_server
-    scm_size: 20%
-    nvme_size: 40%
-    control_method: dmg
+  size: 50%
+  control_method: dmg
 container:
-    type: POSIX
-    control_method: daos
+  type: POSIX
+  control_method: daos
 ior:
-    client_processes:
-        np_16:
-            np: 16
-    test_file: testFile
-    repetitions: 1
-    api: POSIX
-    dfs_destroy: False
-    transfer_size: '1M'
-    block_size: '64M'
-    dfs_oclass: "EC_2P1G1"
-    read_x: 5 # 500%
-    iorflags:
-      - "-v -w -k"
-      - "-v -r -k"
+  client_processes:
+    ppn: 32
+  test_file: testFile
+  api: POSIX
+  dfs_destroy: false
+  transfer_size: 1M
+  block_size: 1G
+  dfs_oclass: "EC_2P1G1"
+  read_x: 3  # 300%
+  iorflags:
+    - "-v -w -k -G 3"
+    - "-v -r -k -G 3"
 dfuse:
     mount_dir: "/tmp/daos_dfuse/"
     disable_caching: True


### PR DESCRIPTION
Test-tag: test_dfuse_caching_check
Skip-unit-tests: true
Skip-fault-injection-test: true

- Reduce threshold from 450% to 300%
- Misc cleanup

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
