### PR TITLE
DAOS-623 build: Fix build for older versions of scons.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -361,7 +361,8 @@ def scons():  # pylint: disable=too-many-locals,too-many-branches
         print('Exiting because --build-deps=only was set')
         Exit(0)
 
-    env = deps_env.Clone(tools=['extra', 'go_builder', 'daos_builder', 'compiler_setup'])
+    env = deps_env.Clone(tools=['extra', 'textfile', 'go_builder', 'daos_builder',
+                                'compiler_setup'])
 
     conf_dir = ARGUMENTS.get('CONF_DIR', '$PREFIX/etc')
 


### PR DESCRIPTION
The removal of the tesfile builder caused problems on older
scons versions so re-add it.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
