### PR TITLE
DAOS-12266 cart: Fix swim_dump_updates segfaults (#11048)

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -380,6 +380,7 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 
 			/* Simulate ALIVE answer */
 			D_FREE(rpc_out->upds.ca_arrays);
+			rpc_out->upds.ca_count = 0;
 			rc = swim_updates_prepare(ctx, to_id, to_id,
 						  &rpc_out->upds.ca_arrays,
 						  &rpc_out->upds.ca_count);


### PR DESCRIPTION
Michael MacDonald noticed segfault

    swim_dump_updates (nupds=5, upds=0x0, to_id=2, from_id=3, self_id=2)
      at src/cart/swim/swim.c:105
    swim_updates_parse (ctx=ctx@entry=0x7fb0c0240290,
      from_id=from_id@entry=3, id=3, upds=0x0, nupds=5) at
      src/cart/swim/swim.c:1079
    crt_swim_cli_cb (cb_info=<optimized out>) at src/cart/crt_swim.c:566
    ...

with log messages

    src/cart/swim/swim.c:116 swim_dump_updates() 2 <= 1: {2 A
      983719075285041154} {1 A 983719042620850176} {4 S
      983718416466575360} {0 A 983719070998986752}
    src/cart/swim/swim.c:151 swim_updates_prepare() 2: not bootstrapped
      yet with 3
    src/engine/init.c:1106 print_backtrace() *** Process 24533 received
      signal 11 ***

From "nupds=5, upds=0x0" and the second log message we can infer that the "retry_rc == -DER_NONEXIST" path of crt_swim_cli_cb freed the original array, set the array pointer to NULL, but didn't set the array length to zero. So when the swim_updates_prepare call returned an error (because the peer had already been removed from the local group), the array pointer and the array length were left as NULL and 5, causing the segfault down the subsequent swim_updates_parse call.

This patch adds the missing array length reset.

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
