### PR TITLE
DAOS-12336 control: Relax validation condition on SCM names

### DIFF
--- a/src/control/server/storage/scm/ipmctl.go
+++ b/src/control/server/storage/scm/ipmctl.go
@@ -239,7 +239,7 @@ func verifyPMem(log logging.Logger, resp *storage.ScmPrepareResponse, regions Re
 		}
 
 		if uint32(maj) != ns.NumaNode {
-			return errors.Errorf("expected namespace major version (%d) to equal numa node (%d)",
+			log.Noticef("expected namespace major version (%d) to equal numa node (%d)",
 				maj, ns.NumaNode)
 		}
 

--- a/src/control/server/storage/scm/ipmctl_test.go
+++ b/src/control/server/storage/scm/ipmctl_test.go
@@ -363,7 +363,20 @@ func TestIpmctl_prep(t *testing.T) {
 			runOut: []string{
 				verStr, mockXMLRegions(t, "sock-one"), "",
 			},
-			expErr: errors.New("namespace major version (0) to equal numa node (1)"),
+			expPrepResp: &storage.ScmPrepareResponse{
+				Socket: storage.ScmSocketState{
+					State: storage.ScmNoFreeCap,
+				},
+				Namespaces: storage.ScmNamespaces{
+					{
+						UUID:        "842fc847-28e0-4bb6-8dfc-d24afdba1528",
+						BlockDevice: "pmem0",
+						Name:        "namespace0.0",
+						NumaNode:    1,
+						Size:        3012 * humanize.GiByte,
+					},
+				},
+			},
 			expCalls: []string{
 				cmdShowIpmctlVersion, cmdShowRegions, cmdDeleteGoals,
 			},


### PR DESCRIPTION
During daos_server scm prepare, when the SCM namespace name does not
match the NUMA node index (e.g. namespace1.0 for NUMA-4 or
namespace0.0 for NUMA-1), log a NOTICE-level warning instead of
failing validation.

This will allow continued operation in environments without 1:1
NUMA-to-socket mappings or where ndctl generates namespace names that
don't match the numa_node.

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
