### PR TITLE
DAOS-12239 control: Check for ErrNotLeader in ResignLeadership

### DIFF
--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -349,6 +349,15 @@ func (db *Database) CheckReplica() error {
 	return db.raft.withReadLock(func(_ raftService) error { return nil })
 }
 
+// errNotSysLeader returns an error indicating that the node is not
+// the current system leader.
+func errNotSysLeader(svc raftService, db *Database) error {
+	return &system.ErrNotLeader{
+		LeaderHint: string(svc.Leader()),
+		Replicas:   db.cfg.stringReplicas(db.replicaAddr),
+	}
+}
+
 // CheckLeader returns an error if the node is not a replica
 // or is not the current system leader. The error can be inspected
 // for hints about where to find the current leader.
@@ -359,10 +368,7 @@ func (db *Database) CheckLeader() error {
 
 	if err := db.raft.withReadLock(func(svc raftService) error {
 		if svc.State() != raft.Leader {
-			return &system.ErrNotLeader{
-				LeaderHint: db.leaderHint(),
-				Replicas:   db.cfg.stringReplicas(db.replicaAddr),
-			}
+			return errNotSysLeader(svc, db)
 		}
 		return nil
 	}); err != nil {

--- a/src/control/system/raft/database_test.go
+++ b/src/control/system/raft/database_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -32,6 +32,7 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/system"
 	. "github.com/daos-stack/daos/src/control/system"
 )
 
@@ -996,6 +997,10 @@ func Test_Database_ResignLeadership(t *testing.T) {
 		},
 		"cause: raft.ErrLeadershipTransferInProgress": {
 			cause:     raft.ErrLeadershipTransferInProgress,
+			expLeader: true,
+		},
+		"cause: system.ErrNotLeader": {
+			cause:     &system.ErrNotLeader{},
 			expLeader: true,
 		},
 		// Also check to see what happens if we get a raft error during

--- a/src/control/system/raft/mocks.go
+++ b/src/control/system/raft/mocks.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/control/system/raft/raft.go
+++ b/src/control/system/raft/raft.go
@@ -100,7 +100,7 @@ func IsRaftLeadershipError(err error) bool {
 // leadership state. No-op if there is only one replica configured
 // or the cause is a raft leadership error.
 func (db *Database) ResignLeadership(cause error) error {
-	if IsRaftLeadershipError(cause) {
+	if system.IsNotLeader(cause) || IsRaftLeadershipError(cause) {
 		// no-op
 		return nil
 	}
@@ -110,6 +110,13 @@ func (db *Database) ResignLeadership(cause error) error {
 	}
 	db.log.Errorf("resigning leadership (%s)", cause)
 	return db.raft.withReadLock(func(svc raftService) error {
+		// One more belt-and-suspenders check to make sure we're
+		// actually the leader before we try to transfer leadership.
+		// This is important because trying to transfer leadership
+		// if we're not the leader will result in a blocked channel, i.e. hang.
+		if svc.State() != raft.Leader {
+			return nil
+		}
 		return svc.LeadershipTransfer().Error()
 	})
 }
@@ -130,10 +137,7 @@ func (db *Database) Barrier() error {
 		}
 		if IsRaftLeadershipError(err) {
 			db.log.Errorf("lost leadership during Barrier(): %s", err)
-			return &system.ErrNotLeader{
-				LeaderHint: db.leaderHint(),
-				Replicas:   db.cfg.stringReplicas(db.replicaAddr),
-			}
+			return errNotSysLeader(svc, db)
 		}
 		return err
 	})
@@ -466,10 +470,7 @@ func (db *Database) submitRaftUpdate(data []byte) error {
 		// signal some callers to retry the operation on the
 		// new leader.
 		if IsRaftLeadershipError(err) {
-			return &system.ErrNotLeader{
-				LeaderHint: db.leaderHint(),
-				Replicas:   db.cfg.stringReplicas(db.replicaAddr),
-			}
+			return errNotSysLeader(svc, db)
 		}
 
 		return err


### PR DESCRIPTION
The call to raft.Barrier() was modified to return ErrNotLeader
on leadership loss in order to convey this information back to
dmg, but ResignLeadership() was not updated to include a check
for this error in order to avoid calling raft.LeadershipTransfer()
on a non-leader (which can cause a hang due to blocked channel read).

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
