### PR TITLE
DAOS-12309 test: Introduce param to toggle log mast for pool create/destroy

### DIFF
--- a/src/tests/ftest/container/boundary.py
+++ b/src/tests/ftest/container/boundary.py
@@ -94,7 +94,11 @@ class BoundaryTest(TestWithServers):
         for _ in range(num_pools):
             pool_manager.add()
         self.log.info('Creating %d pools', num_pools)
+        # Explicitly elevate log mask to DEBUG for multiple pool create scenario and
+        # restore it after.
+        self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
         result = pool_manager.run()
+        self.dmg.server_set_logmasks(raise_exception=False)
         num_failed = len(list(filter(lambda r: not r.passed, result)))
         if num_failed > 0:
             self.fail('{} pool create threads failed'.format(num_failed))

--- a/src/tests/ftest/container/boundary.py
+++ b/src/tests/ftest/container/boundary.py
@@ -41,6 +41,7 @@ class BoundaryTest(TestWithServers):
         self.io_run_time = self.params.get("run_time", '/run/container/execute_io/*')
         self.io_rank = self.params.get("rank", '/run/container/execute_io/*')
         self.io_obj_classs = self.params.get("obj_classs", '/run/container/execute_io/*')
+        self.dmg = self.get_dmg_command()
 
     def create_pool(self):
         """Get a test pool object and append to list.

--- a/src/tests/ftest/container/boundary.yaml
+++ b/src/tests/ftest/container/boundary.yaml
@@ -16,6 +16,7 @@ pool:
   scm_size: 200M
   control_method: dmg
   label: pool
+  set_logmasks: False
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/pool/create_capacity.py
+++ b/src/tests/ftest/pool/create_capacity.py
@@ -37,7 +37,11 @@ class PoolCreateTests(PoolTestBase):
         # available capacity, e.g. 0.6% for 100 pools.
         quantity = self.params.get("quantity", "/run/pool/*", 1)
         self.add_pool_qty(quantity, create=False)
+        # for multiple pool creation cases, enabling and disabling
+        # logmask setting to DEBUG explicitly to save run time..
+        self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
         self.check_pool_creation(30)
+        self.dmg.server_set_logmasks(raise_exception=False)
 
         # Verify DAOS can be restarted in less than 2 minutes
         try:

--- a/src/tests/ftest/pool/create_capacity.yaml
+++ b/src/tests/ftest/pool/create_capacity.yaml
@@ -15,11 +15,11 @@ server_config:
       fabric_iface: ib0
       fabric_iface_port: 31317
       log_file: daos_server0.log
-      log_mask: DEBUG
+      log_mask: WARN
       targets: 4
       env_vars:
         - DD_MASK=group_metadata_only
-        - D_LOG_FLUSH=DEBUG
+        - D_LOG_FLUSH=WARN
       storage:
         0:
           class: dcpm

--- a/src/tests/ftest/pool/create_capacity.yaml
+++ b/src/tests/ftest/pool/create_capacity.yaml
@@ -15,11 +15,11 @@ server_config:
       fabric_iface: ib0
       fabric_iface_port: 31317
       log_file: daos_server0.log
-      log_mask: WARN
+      log_mask: DEBUG
       targets: 4
       env_vars:
         - DD_MASK=group_metadata_only
-        - D_LOG_FLUSH=WARN
+        - D_LOG_FLUSH=DEBUG
       storage:
         0:
           class: dcpm
@@ -53,3 +53,4 @@ pool:
   scm_size: 60%
   nvme_size: 60%
   quantity: 200
+  set_logmasks: False

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1487,8 +1487,9 @@ class TestWithServers(TestWithoutServers):
                 labels = []
 
             # Destroy each pool found
-            # Elevate log_mask to DEBUG, then restore after pool destroy
-            manager.dmg.server_set_logmasks("DEBUG", raise_exception=False)
+            if len(labels) > 0:
+                self.log.info("Elevating engines log_mask before destroying found pools")
+                manager.dmg.server_set_logmasks("DEBUG", raise_exception=False)
 
             for label in labels:
                 try:
@@ -1497,7 +1498,9 @@ class TestWithServers(TestWithoutServers):
                 except CommandFailure as error:
                     error_list.append("Error destroying pool: {}".format(error))
 
-            manager.dmg.server_set_logmasks(raise_exception=False)
+            if len(labels) > 0:
+                self.log.info("Restoring engines log_mask after destroying found pools")
+                manager.dmg.server_set_logmasks(raise_exception=False)
 
         return error_list
 

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -340,13 +340,13 @@ class TestPool(TestDaosApiBase):
         # Create a pool with the dmg command and store its CmdResult
         # Elevate engine log_mask to DEBUG before, then restore after pool create
         self._log_method("dmg.pool_create", kwargs)
-        if self.set_logmasks:
+        if self.set_logmasks is True:
             self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
         try:
             data = self.dmg.pool_create(**kwargs)
             create_res = self.dmg.result
         finally:
-            if self.set_logmasks:
+            if self.set_logmasks is True:
                 self.dmg.server_set_logmasks(raise_exception=False)
 
         # make sure dmg exit status is that of the pool create, not the set-logmasks
@@ -445,7 +445,7 @@ class TestPool(TestDaosApiBase):
 
                 # Destroy the pool with the dmg command.
                 # Elevate log_mask to DEBUG, then restore after pool destroy
-                if self.set_logmasks:
+                if self.set_logmasks is True:
                     self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
                     self.dmg.pool_destroy(pool=self.identifier, force=force, recursive=recursive)
                     self.dmg.server_set_logmasks(raise_exception=False)

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -147,8 +147,7 @@ class TestPool(TestDaosApiBase):
         self.quantity = BasicParameter(None, 1)
         self.min_targets = BasicParameter(None, 1)
 
-        # Parameter to control setting and unsetting of log mask
-        # for pool create/destroy
+        # Parameter to control log mask enable/disable for pool create/destroy
         self.set_logmasks = BasicParameter(None, True)
 
         self.pool = None

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -147,6 +147,10 @@ class TestPool(TestDaosApiBase):
         self.quantity = BasicParameter(None, 1)
         self.min_targets = BasicParameter(None, 1)
 
+        # Parameter to control setting and unsetting of log mask
+        # for pool create/destroy
+        self.set_logmasks = BasicParameter(None, True)
+
         self.pool = None
         self.info = None
         self.svc_ranks = None
@@ -336,12 +340,14 @@ class TestPool(TestDaosApiBase):
         # Create a pool with the dmg command and store its CmdResult
         # Elevate engine log_mask to DEBUG before, then restore after pool create
         self._log_method("dmg.pool_create", kwargs)
-        self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
+        if self.set_logmasks:
+            self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
         try:
             data = self.dmg.pool_create(**kwargs)
             create_res = self.dmg.result
         finally:
-            self.dmg.server_set_logmasks(raise_exception=False)
+            if self.set_logmasks:
+                self.dmg.server_set_logmasks(raise_exception=False)
 
         # make sure dmg exit status is that of the pool create, not the set-logmasks
         if data is not None and create_res is not None:
@@ -439,9 +445,12 @@ class TestPool(TestDaosApiBase):
 
                 # Destroy the pool with the dmg command.
                 # Elevate log_mask to DEBUG, then restore after pool destroy
-                self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
-                self.dmg.pool_destroy(pool=self.identifier, force=force, recursive=recursive)
-                self.dmg.server_set_logmasks(raise_exception=False)
+                if self.set_logmasks:
+                    self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
+                    self.dmg.pool_destroy(pool=self.identifier, force=force, recursive=recursive)
+                    self.dmg.server_set_logmasks(raise_exception=False)
+                else:
+                    self.dmg.pool_destroy(pool=self.identifier, force=force, recursive=recursive)
 
                 status = True
 


### PR DESCRIPTION
Adding a TestPool param to enable/disable elevating log
mask to DEBUG during pool create/destroy. Currently, this is
done by default for every pool create and destroy dmg call
hence adding significant test run time, causing tests to
timeout in multiple pool scenarios.

Quick-Functional: true
Test-repeat: 10
Test-tag: pool_create_tests test_container_boundary

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>