### PR TITLE
DAOS-12324 pool: Reset pse_stop in fini_events (#11132)

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1061,6 +1061,7 @@ init_events(struct pool_svc *svc)
 
 	D_ASSERT(d_list_empty(&events->pse_queue));
 	D_ASSERT(events->pse_handler == ABT_THREAD_NULL);
+	D_ASSERT(events->pse_stop == false);
 
 	rc = crt_register_event_cb(ds_pool_crt_event_cb, svc);
 	if (rc != 0) {
@@ -1116,6 +1117,7 @@ fini_events(struct pool_svc *svc)
 	D_ASSERTF(rc == 0, DF_RC"\n", DP_RC(rc));
 	ABT_thread_free(&events->pse_handler);
 	events->pse_handler = ABT_THREAD_NULL;
+	events->pse_stop = false;
 }
 
 static void


### PR DESCRIPTION
When a PS leader steps down, it doesn't reset pse_stop to false. If the same PS replica becomes a new PS leader, events_handler will stop immediately after starting, as shown by these log messages:

    12/11-06:50:14.89 [...] rdb_raft_step_down() e572b42d[1]: no longer leader of term 1
    [...]
    12/11-06:50:14.89 [...] events_handler() e572b42d: stopping
    [...]
    12/11-06:50:30.15 [...] rdb_raft_step_up() e572b42d[1]: became leader of term 3
    [...]
    12/11-06:50:30.16 [...] events_handler() e572b42d: starting
    12/11-06:50:30.16 [...] events_handler() e572b42d: stopping

This patch resets pse_stop in fini_events and asserts that pse_stop must be false in init_events.

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
