### PR TITLE
DAOS-12239 control: Check for ErrNotLeader in ResignLeadership (#11163)

### DIFF
--- a/src/control/system/database_test.go
+++ b/src/control/system/database_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -916,6 +916,10 @@ func Test_Database_ResignLeadership(t *testing.T) {
 		},
 		"cause: raft.ErrLeadershipTransferInProgress": {
 			cause:     raft.ErrLeadershipTransferInProgress,
+			expLeader: true,
+		},
+		"cause: system.ErrNotLeader": {
+			cause:     &ErrNotLeader{},
 			expLeader: true,
 		},
 		// Also check to see what happens if we get a raft error during


### PR DESCRIPTION
The call to raft.Barrier() was modified to return ErrNotLeader
on leadership lost in order to convey this information back to
dmg, but ResignLeadership() was not updated to include a check
for this error in order to avoid calling raft.LeadershipTransfer()
on a non-leader (which can cause a hang due to blocked channel read).

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
