### PR TITLE
Add UCX debug output

### DIFF
--- a/src/control/lib/hardware/ucx/disabled_bindings.go
+++ b/src/control/lib/hardware/ucx/disabled_bindings.go
@@ -11,6 +11,7 @@ package ucx
 import (
 	"github.com/daos-stack/daos/src/control/lib/dlopen"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 var errNotSupported = hardware.ErrUnsupportedFabric("ucx")
@@ -28,11 +29,11 @@ type uctComponent struct {
 	name string
 }
 
-func getUCTComponents(uctHdl *dlopen.LibHandle) ([]*uctComponent, func() error, error) {
+func getUCTComponents(_ logging.Logger, _ *dlopen.LibHandle) ([]*uctComponent, func() error, error) {
 	return nil, nil, errNotSupported
 }
 
-func getMDResourceNames(uctHdl *dlopen.LibHandle, component *uctComponent) ([]string, error) {
+func getMDResourceNames(_ logging.Logger, _ *dlopen.LibHandle, _ *uctComponent) ([]string, error) {
 	return nil, errNotSupported
 }
 
@@ -63,6 +64,6 @@ func (d *transportDev) isNetwork() bool {
 	return false
 }
 
-func getMDTransportDevices(uctHdl *dlopen.LibHandle, md *uctMD) ([]*transportDev, error) {
+func getMDTransportDevices(_ logging.Logger, uctHdl *dlopen.LibHandle, md *uctMD) ([]*transportDev, error) {
 	return nil, errNotSupported
 }

--- a/src/control/lib/hardware/ucx/ucx_interfaces_test.go
+++ b/src/control/lib/hardware/ucx/ucx_interfaces_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2022-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -14,9 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-
-	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/logging"
 )
@@ -45,4 +42,6 @@ func TestUCX_Provider_GetFabricInterfaces_Integrated(t *testing.T) {
 	}
 
 	fmt.Printf("FabricInterfaceSet:\n%s\n", result)
+
+	fmt.Printf("captured log output:\n%s", buf.String())
 }


### PR DESCRIPTION
This patch adds some diagnostic output to UCX logic in the control plane. This is *not* intended to be landed.
