### PR TITLE
DAOS-12372 mgmt: fix dev query assertion with MD-ON-SSD enabled

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -273,6 +273,24 @@ bio_bs_hold(struct bio_blobstore *bbs)
 out:
 	ABT_mutex_unlock(bbs->bb_mutex);
 	return rc;
+}
+
+struct bio_xs_blobstore *
+bio_xs_blobstore_by_devid(struct bio_xs_context *xs_ctxt, uuid_t dev_uuid)
+{
+	enum smd_dev_type	 st;
+	struct bio_xs_blobstore *bxb = NULL;
+
+	for (st = SMD_DEV_TYPE_DATA; st < SMD_DEV_TYPE_MAX; st++) {
+		bxb = xs_ctxt->bxc_xs_blobstores[st];
+		if (!bxb)
+			continue;
+
+		if (uuid_compare(bxb->bxb_blobstore->bb_dev->bb_uuid, dev_uuid) == 0)
+			return bxb;
+	}
+
+	return NULL;
 }
 
 /**

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -632,6 +632,8 @@ int bio_blob_open(struct bio_io_context *ctxt, bool async, enum bio_mc_flags fla
 		  enum smd_dev_type st, spdk_blob_id open_blobid);
 struct bio_xs_blobstore *
 bio_xs_context2xs_blobstore(struct bio_xs_context *xs_ctxt, enum smd_dev_type st);
+struct bio_xs_blobstore *
+bio_xs_blobstore_by_devid(struct bio_xs_context *xs_ctxt, uuid_t dev_uuid);
 
 /* bio_recovery.c */
 int bio_bs_state_transit(struct bio_blobstore *bbs);

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -24,7 +24,7 @@
 struct dev_state_msg_arg {
 	struct bio_xs_context		*xs;
 	struct nvme_stats		 devstate;
-	enum smd_dev_type		 dev_type;
+	uuid_t				 dev_uuid;
 	ABT_eventual			 eventual;
 };
 
@@ -68,8 +68,8 @@ bio_get_dev_state_internal(void *msg_arg)
 	struct bio_xs_blobstore		 *bxb;
 
 	D_ASSERT(dsm != NULL);
-	bxb = bio_xs_context2xs_blobstore(dsm->xs, dsm->dev_type);
-
+	bxb = bio_xs_blobstore_by_devid(dsm->xs, dsm->dev_uuid);
+	D_ASSERT(bxb != NULL);
 	dsm->devstate = bxb->bxb_blobstore->bb_dev_health.bdh_health_state;
 	collect_bs_usage(bxb->bxb_blobstore->bb_bs, &dsm->devstate);
 	ABT_eventual_set(dsm->eventual, NULL, 0);
@@ -84,7 +84,8 @@ bio_dev_set_faulty_internal(void *msg_arg)
 
 	D_ASSERT(dsm != NULL);
 
-	bxb = bio_xs_context2xs_blobstore(dsm->xs, dsm->dev_type);
+	bxb = bio_xs_blobstore_by_devid(dsm->xs, dsm->dev_uuid);
+	D_ASSERT(bxb != NULL);
 	rc = bio_bs_state_set(bxb->bxb_blobstore, BIO_BS_STATE_FAULTY);
 	if (rc)
 		D_ERROR("BIO FAULTY state set failed, rc=%d\n", rc);
@@ -123,21 +124,22 @@ bio_log_data_csum_err(struct bio_xs_context *bxc)
 
 /* Call internal method to get BIO device state from the device owner xstream */
 int
-bio_get_dev_state(struct nvme_stats *state, enum smd_dev_type st,
+bio_get_dev_state(struct nvme_stats *state, uuid_t dev_uuid,
 		  struct bio_xs_context *xs)
 {
 	struct dev_state_msg_arg	 dsm = { 0 };
 	int				 rc;
 	struct bio_xs_blobstore		*bxb;
 
+	bxb = bio_xs_blobstore_by_devid(xs, dev_uuid);
+	if (!bxb)
+		return -DER_ENOENT;
+
 	rc = ABT_eventual_create(0, &dsm.eventual);
 	if (rc != ABT_SUCCESS)
 		return dss_abterr2der(rc);
 
 	dsm.xs = xs;
-	dsm.dev_type = st;
-
-	bxb = bio_xs_context2xs_blobstore(xs, st);
 	spdk_thread_send_msg(owner_thread(bxb->bxb_blobstore),
 			     bio_get_dev_state_internal, &dsm);
 	rc = ABT_eventual_wait(dsm.eventual, NULL);
@@ -157,12 +159,13 @@ bio_get_dev_state(struct nvme_stats *state, enum smd_dev_type st,
  * Copy out the internal BIO blobstore device state.
  */
 void
-bio_get_bs_state(int *bs_state, enum smd_dev_type st, struct bio_xs_context *xs)
+bio_get_bs_state(int *bs_state, uuid_t dev_uuid, struct bio_xs_context *xs)
 {
-	struct bio_xs_blobstore		*bxb;
+	struct bio_xs_blobstore *bxb;
 
-	bxb = bio_xs_context2xs_blobstore(xs, st);
-	*bs_state = bxb->bxb_blobstore->bb_state;
+	bxb = bio_xs_blobstore_by_devid(xs, dev_uuid);
+	if (bxb)
+		*bs_state = bxb->bxb_blobstore->bb_state;
 
 	return;
 }
@@ -172,21 +175,23 @@ bio_get_bs_state(int *bs_state, enum smd_dev_type st, struct bio_xs_context *xs)
  * state transition. Called from the device owner xstream.
  */
 int
-bio_dev_set_faulty(struct bio_xs_context *xs, enum smd_dev_type st)
+bio_dev_set_faulty(struct bio_xs_context *xs, uuid_t dev_uuid)
 {
 	struct dev_state_msg_arg	dsm = { 0 };
 	int				rc;
 	int				*dsm_rc;
 	struct bio_xs_blobstore		*bxb;
 
+	bxb = bio_xs_blobstore_by_devid(xs, dev_uuid);
+	if (!bxb)
+		return -DER_ENOENT;
+
 	rc = ABT_eventual_create(sizeof(*dsm_rc), &dsm.eventual);
 	if (rc != ABT_SUCCESS)
 		return dss_abterr2der(rc);
 
 	dsm.xs = xs;
-	dsm.dev_type = st;
-
-	bxb = bio_xs_context2xs_blobstore(xs, st);
+	uuid_copy(dsm.dev_uuid, dev_uuid);
 	spdk_thread_send_msg(owner_thread(bxb->bxb_blobstore),
 			     bio_dev_set_faulty_internal, &dsm);
 	rc = ABT_eventual_wait(dsm.eventual, (void **)&dsm_rc);

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -329,7 +329,8 @@ sched_ult2xs(int xs_type, int tgt_id)
 {
 	uint32_t	xs_id;
 
-	D_ASSERT(tgt_id >= 0 && tgt_id < dss_tgt_nr);
+	if (xs_type == DSS_XS_VOS || xs_type == DSS_XS_OFFLOAD || xs_type == DSS_XS_IOFW)
+		D_ASSERT(tgt_id >= 0 && tgt_id < dss_tgt_nr);
 	switch (xs_type) {
 	case DSS_XS_SELF:
 		return DSS_XS_SELF;

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -719,12 +719,12 @@ bio_yield(struct umem_instance *umm)
  * Used for querying the BIO health information from the control plane command.
  *
  * \param dev_state	[OUT]	BIO device health state
- * \param xs		[IN]	xstream context
+ * \param dev_uuid	[IN]	uuid of device
  * \param st		[IN]	smd dev type
  *
  * \return			Zero on success, negative value on error
  */
-int bio_get_dev_state(struct nvme_stats *dev_state, enum smd_dev_type st,
+int bio_get_dev_state(struct nvme_stats *dev_state, uuid_t dev_uuid,
 		      struct bio_xs_context *xs);
 
 /*
@@ -732,11 +732,11 @@ int bio_get_dev_state(struct nvme_stats *dev_state, enum smd_dev_type st,
  * Used for daos_test validation in the daos_mgmt_get_bs_state() C API.
  *
  * \param dev_state	[OUT]	BIO blobstore state
- * \param st		[IN]	smd dev type
+ * \param dev_id	[IN]	UUID of device
  * \param xs		[IN]	xstream context
  *
  */
-void bio_get_bs_state(int *blobstore_state, enum smd_dev_type st, struct bio_xs_context *xs);
+void bio_get_bs_state(int *blobstore_state, uuid_t dev_uuid, struct bio_xs_context *xs);
 
 
 /*
@@ -744,11 +744,11 @@ void bio_get_bs_state(int *blobstore_state, enum smd_dev_type st, struct bio_xs_
  * state transition.
  *
  * \param xs		[IN]	xstream context
- * \param st		[IN]	smd dev type
+ * \param dev_id	[IN]	uuid of device
  *
  * \return			Zero on success, negative value on error
  */
-int bio_dev_set_faulty(struct bio_xs_context *xs, enum smd_dev_type st);
+int bio_dev_set_faulty(struct bio_xs_context *xs, uuid_t dev_id);
 
 /* Function to increment data CSUM media error. */
 void bio_log_data_csum_err(struct bio_xs_context *xs);

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -112,7 +112,6 @@ int ds_mgmt_cont_set_owner(uuid_t pool_uuid, d_rank_list_t *svc_ranks,
 struct mgmt_bio_health {
 	struct nvme_stats		mb_dev_state;
 	uuid_t				mb_devid;
-	enum smd_dev_type		mb_dev_type;
 };
 
 int ds_mgmt_bio_health_query(struct mgmt_bio_health *mbh, uuid_t uuid, char *tgt_id);


### PR DESCRIPTION
Two fixes:
1. dev query ult should be run on the owner xstream, introduce a new api to return dev's owner xs target id.

2. SYS XS might be owner of device, fix to pass correct XS type when creating ults.

Required-githooks: true
Signed-off-by: Wang Shilong <shilong.wang@intel.com>