### PR TITLE
DAOS-12214 test: basic IO test for WAL

### DIFF
--- a/src/bio/bio_wal.c
+++ b/src/bio/bio_wal.c
@@ -1312,10 +1312,9 @@ entry_move_next(struct wal_trans_blk *entry_blk, struct wal_blks_desc *bd)
 {
 	unsigned int	entry_sz = sizeof(struct wal_trans_entry);
 
+	entry_blk->tb_off += entry_sz;
 	if ((entry_blk->tb_off + entry_sz) > entry_blk->tb_blk_sz)
 		next_wal_blk(entry_blk);
-	else
-		entry_blk->tb_off += entry_sz;
 
 	if (entry_blk->tb_idx < bd->bd_payload_idx)
 		D_ASSERT((entry_blk->tb_off + entry_sz) <= entry_blk->tb_blk_sz);

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -29,7 +29,7 @@ cleanup(void)
 	gc_wait();
 }
 
-static void
+void
 update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 	     uint64_t flags, char *dkey, char *akey, daos_iod_type_t type,
 	     daos_size_t iod_size, daos_recx_t *recx, char *buf)
@@ -84,7 +84,7 @@ update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 	arg->ta_flags &= ~TF_ZERO_COPY;
 }
 
-static void
+void
 fetch_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 	    uint64_t flags, char *dkey, char *akey, daos_iod_type_t type,
 	    daos_size_t iod_size, daos_recx_t *recx, char *buf)

--- a/src/vos/tests/vts_io.h
+++ b/src/vos/tests/vts_io.h
@@ -125,5 +125,15 @@ hash_key(d_iov_t *key, int flag)
 	return d_hash_string_u32((char *)key->iov_buf, key->iov_len);
 }
 
+/* vts_aggregate.c */
+void
+update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
+	     uint64_t flags, char *dkey, char *akey, daos_iod_type_t type,
+	     daos_size_t iod_size, daos_recx_t *recx, char *buf);
+void
+fetch_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
+	    uint64_t flags, char *dkey, char *akey, daos_iod_type_t type,
+	    daos_size_t iod_size, daos_recx_t *recx, char *buf);
+
 #endif
 


### PR DESCRIPTION
- Added basic IO test for WAL, it verifies pool space SCM & NVMe usage and updated values after replay.
- Expand basic pool test for WAL as basic pool/cont test.
- Fix entry_move_next() to move the offset correctly.

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
