### PR TITLE
DAOS-12383 common: Persist DAV heap statistics

### DIFF
--- a/src/bio/bio_wal.c
+++ b/src/bio/bio_wal.c
@@ -663,7 +663,7 @@ fill_trans_blks(struct bio_meta_context *mc, struct bio_sglist *bsgl, struct ume
 static inline uint64_t
 off2lba(struct wal_super_info *si, unsigned int blk_off)
 {
-	return (blk_off + WAL_HDR_BLKS) * si->si_header.wh_blk_bytes;
+	return (uint64_t)(blk_off + WAL_HDR_BLKS) * si->si_header.wh_blk_bytes;
 }
 
 struct wal_tx_desc {

--- a/src/common/dav/dav_iface.c
+++ b/src/common/dav/dav_iface.c
@@ -311,10 +311,6 @@ dav_obj_close(dav_obj_t *hdl)
 	heap_cleanup(hdl->do_heap);
 	D_FREE(hdl->do_heap);
 
-	lw_tx_begin(hdl);
-	stats_persist(hdl, hdl->do_stats);
-	lw_tx_end(hdl, NULL);
-
 	stats_delete(hdl, hdl->do_stats);
 
 	munmap(hdl->do_base, hdl->do_size);

--- a/src/common/dav/dav_iface.c
+++ b/src/common/dav/dav_iface.c
@@ -277,8 +277,7 @@ dav_obj_open(const char *path, int flags, struct umem_store *store)
 	}
 	size = (size_t)statbuf.st_size;
 
-	if (store->stor_priv != NULL &&
-	    (strcmp(basename(path), "sys_db") != 0)) {
+	if (store->stor_priv != NULL) {
 		if (ftruncate(fd, 0) == -1) {
 			close(fd);
 			return NULL;
@@ -313,8 +312,10 @@ dav_obj_close(dav_obj_t *hdl)
 	D_FREE(hdl->do_heap);
 
 	lw_tx_begin(hdl);
-	stats_delete(hdl, hdl->do_stats);
+	stats_persist(hdl, hdl->do_stats);
 	lw_tx_end(hdl, NULL);
+
+	stats_delete(hdl, hdl->do_stats);
 
 	munmap(hdl->do_base, hdl->do_size);
 	close(hdl->do_fd);

--- a/src/common/dav/stats.c
+++ b/src/common/dav/stats.c
@@ -44,10 +44,23 @@ error_transient_alloc:
 void
 stats_delete(dav_obj_t *pop, struct stats *s)
 {
-	mo_wal_persist(&pop->p_ops, s->persistent,
-	sizeof(struct stats_persistent));
 	D_FREE(s->transient);
 	D_FREE(s);
+}
+
+/*
+ * stats_persist -- save the persistent statistics to wal
+ */
+void
+stats_persist(dav_obj_t *pop, struct stats *s)
+{
+	if (s->transient->heap_prev_pval !=
+	    s->persistent->heap_curr_allocated) {
+		mo_wal_persist(&pop->p_ops, s->persistent,
+		    sizeof(struct stats_persistent));
+		s->transient->heap_prev_pval =
+		    s->persistent->heap_curr_allocated;
+	}
 }
 
 int

--- a/src/common/dav/stats.c
+++ b/src/common/dav/stats.c
@@ -57,7 +57,7 @@ stats_persist(dav_obj_t *pop, struct stats *s)
 	if (s->transient->heap_prev_pval !=
 	    s->persistent->heap_curr_allocated) {
 		mo_wal_persist(&pop->p_ops, s->persistent,
-		    sizeof(struct stats_persistent));
+			       sizeof(struct stats_persistent));
 		s->transient->heap_prev_pval =
 		    s->persistent->heap_curr_allocated;
 	}

--- a/src/common/dav/stats.h
+++ b/src/common/dav/stats.h
@@ -11,6 +11,7 @@
 struct stats_transient {
 	uint64_t heap_run_allocated;
 	uint64_t heap_run_active;
+	uint64_t heap_prev_pval; /* previous persisted value of curr allocated */
 };
 
 struct stats_persistent {
@@ -55,5 +56,6 @@ struct dav_obj;
 
 struct stats *stats_new(struct dav_obj *pop);
 void stats_delete(struct dav_obj *pop, struct stats *stats);
+void stats_persist(struct dav_obj *pop, struct stats *s);
 
 #endif /* __DAOS_COMMON_STATS_H */

--- a/src/common/dav/tx.c
+++ b/src/common/dav/tx.c
@@ -474,6 +474,9 @@ lw_tx_end(dav_obj_t *pop, void *data)
 	struct umem_wal_tx	*utx;
 	int			 rc;
 
+	/* Persist the frequently updated persistent globals */
+	stats_persist(pop, pop->do_stats);
+
 	utx = pop->do_utx;
 	D_ASSERT(utx != NULL);
 	pop->do_utx = NULL;


### PR DESCRIPTION
- counter related to currently allocated memory is now persisted at the end of every transaction.
- Removed check for sysdb in umem_pobj_open()
- Fixed integer overflow in off2lba() wich was inturn causing failures while rehydrating large vos files.

Required-githooks: true

Signed-off-by: sherintg <sherin-t.george@hpe.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
