### PR TITLE
DAOS-12357 test: Ignore cfg when using daos_server storage cmds

### DIFF
--- a/src/tests/ftest/control/config_generate_run.yaml
+++ b/src/tests/ftest/control/config_generate_run.yaml
@@ -8,7 +8,7 @@ server_config:
       storage:
         0:
           class: ram
-          scm_mount: /mnt/daos
+          scm_mount: /mnt/daos0
           scm_size: 16
 pool:
   control_method: dmg

--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -357,7 +357,8 @@ class DaosServerCommand(YamlCommand):
                 #                       groups.
                 #   --disable-vfio      Force SPDK to use the UIO driver for NVMe device access
                 self.helper_log_file = FormattedParameter("--helper-log-file={}")
-                self.ignore_config = FormattedParameter("--ignore-config", False)
+                # default operation should not filter on config file contents
+                self.ignore_config = FormattedParameter("--ignore-config", True)
                 self.pci_block_list = FormattedParameter("--pci-block-list={}")
                 self.hugepages = FormattedParameter("--hugepages={}")
                 self.target_user = FormattedParameter("--target-user={}")
@@ -380,7 +381,8 @@ class DaosServerCommand(YamlCommand):
                 #                      groups.
                 #   --disable-vfio     Force SPDK to use the UIO driver for NVMe device access
                 self.helper_log_file = FormattedParameter("--helper-log-file={}")
-                self.ignore_config = FormattedParameter("--ignore-config", False)
+                # default operation should not filter on config file contents
+                self.ignore_config = FormattedParameter("--ignore-config", True)
                 self.pci_block_list = FormattedParameter("--pci-block-list={}")
                 self.target_user = FormattedParameter("--target-user={}")
                 self.disable_vfio = FormattedParameter("--disable-vfio", False)
@@ -398,7 +400,8 @@ class DaosServerCommand(YamlCommand):
                 #   --ignore-config     Ignore parameters set in config file when running command
                 #   --disable-vmd       Disable VMD-aware scan.
                 self.helper_log_file = FormattedParameter("--helper-log-file={}")
-                self.ignore_config = FormattedParameter("--ignore-config", False)
+                # default operation should not filter on config file contents
+                self.ignore_config = FormattedParameter("--ignore-config", True)
                 self.disable_vmd = FormattedParameter("--disable-vmd", False)
 
     class ScmSubCommand(CommandWithSubCommand):
@@ -439,7 +442,8 @@ class DaosServerCommand(YamlCommand):
                 #   --scm-ns-per-socket= Number of PMem namespaces to create per socket (default:1)
                 #   --force              Perform SCM operations without waiting for confirmation
                 self.helper_log_file = FormattedParameter("--helper-log-file={}")
-                self.ignore_config = FormattedParameter("--ignore-config", False)
+                # default operation should not filter on config file contents
+                self.ignore_config = FormattedParameter("--ignore-config", True)
                 self.socket = FormattedParameter("--socket={}")
                 self.scm_ns_per_socket = FormattedParameter("--scm-ns-per-socket={}")
                 self.force = FormattedParameter("--force", False)
@@ -459,7 +463,8 @@ class DaosServerCommand(YamlCommand):
                 #                        region operations will be performed across all sockets.
                 #   --force              Perform SCM operations without waiting for confirmation
                 self.helper_log_file = FormattedParameter("--helper-log-file={}")
-                self.ignore_config = FormattedParameter("--ignore-config", False)
+                # default operation should not filter on config file contents
+                self.ignore_config = FormattedParameter("--ignore-config", True)
                 self.socket = FormattedParameter("--socket={}")
                 self.force = FormattedParameter("--force", False)
 


### PR DESCRIPTION
Test script wrappers for daos_server scm and nvme commands should set
--ignore-config option by default to preserve behavior seen with
deprecated daos_server storage commands.

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
