### PR TITLE
DAOS-12309 test: coarse log_mask update for pool create/destroy

### DIFF
--- a/src/tests/ftest/pool/create_capacity.py
+++ b/src/tests/ftest/pool/create_capacity.py
@@ -1,5 +1,5 @@
 """
-(C) Copyright 2021-2022 Intel Corporation.
+(C) Copyright 2021-2023 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -33,10 +33,14 @@ class PoolCreateTests(PoolTestBase):
         :avocado: tags=pool
         :avocado: tags=PoolCreateTests,test_create_pool_quantity
         """
+        self.log.info('Elevating engines log_mask to DEBUG in the engines before pool creates')
+        self.get_dmg_command().server_set_logmasks("DEBUG", raise_exception=False)
+
         # Create some number of pools each using a equal amount of 60% of the
         # available capacity, e.g. 0.6% for 100 pools.
         quantity = self.params.get("quantity", "/run/pool/*", 1)
-        self.add_pool_qty(quantity, create=False)
+        self.add_pool_qty(quantity, create=False, set_masks_oncreate=False,
+                          set_masks_ondestroy=False)
         self.check_pool_creation(30)
 
         # Verify DAOS can be restarted in less than 2 minutes
@@ -74,3 +78,5 @@ class PoolCreateTests(PoolTestBase):
         self.assertEqual(
             len(self.pool), len(detected_pools),
             "Additional pools detected after rebooting the servers")
+        self.log.info("Elevating engines log_mask to DEBUG in the engines before tearDown")
+        self.get_dmg_command().server_set_logmasks("DEBUG", raise_exception=False)


### PR DESCRIPTION
Before this change, every functional test pool create/destroy was preceded by dmg server set-logmasks DEBUG, and followed by another set-logmasks command to restore log_mask to original configuration. Some tests (pool/create_capacity.py, container/boundary.py) create many pools (e.g., 100s) - and sometimes in parallel. This dynamic log_mask adjustment on a per-pool basis is unnecessary and can disturb test timing as well.

With this change, parameters are added to the functional test classes and methods used for creating and destroying pools, to control whether log_mask will be dynamically adjusted for the given pool being created. By default, per-pool dynamic log_mask adjustment is done. The two boundary/stress tests noted are updated to use this parameter to avoid per-pool dynamic log_mask adjustment when creating/destroying pools.

Quick-Functional: true
Test-tag test_create_pool_quantity test_container_boundary Test-repeat: 4

Required-githooks: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
