### PR TITLE
DAOS-12228 docs: Remove info about VMD backing addresses in cfg

### DIFF
--- a/docs/admin/vmd.md
+++ b/docs/admin/vmd.md
@@ -136,7 +136,7 @@ e20005:07:00.0 SSDPF2KX038T9L 2CV1L028    1         3.8 TB
 
 The recommended setup to use VMD devices within the DAOS server configuration file
 is to list the PCIe IDs of the _VMD controllers_ in the storage engines' `bdev_list`.
-This ensures that all NVMe disks that are members of a VMD domain are always 
+This ensures that all NVMe disks that are members of a VMD domain are always
 managed together, and assigned to the same DAOS storage engine.
 The `daos_server.yml` file for the above example would have one VMD domain per engine:
 
@@ -163,48 +163,3 @@ storage: # engine 1
     bdev_list:
     - "0000:e2:00.5"
 ```
-
-As an alternative, the server configuration file could list the PCIe IDs of the 
-_individual NVMe backing devices_:
-
-```yaml
- storage: # engine 0
-  -
-    class: dcpm
-    scm_mount: /var/daos/pmem0
-    scm_list:
-    - /dev/pmem0
-  -
-    class: nvme
-    bdev_list:
-    - "640005:81:00.0"
-    - "640005:83:00.0"
-    - "640005:85:00.0"
-    - "640005:87:00.0"
-
- storage: # engine 1
-  -
-    class: dcpm
-    scm_mount: /var/daos/pmem1
-    scm_list:
-    - /dev/pmem1
-  -
-    class: nvme
-    bdev_list:
-    - "e20005:01:00.0"
-    - "e20005:03:00.0"
-    - "e20005:05:00.0"
-    - "e20005:07:00.0"
-```
-
-While this configuration _should_ work, this code path has not been fully validated with DAOS 2.2.
-It should also be noted that listing less than all four NVMe disks can lead to unexpected
-behavior. For example, the `dmg storage format` command in DAOS 2.2 will still format
-all four NVMe disks that are part of the VMD domain, even if only one NVMe disk is listed
-in the `bdev_list`.
-
-!!! note TODO - validate if fixes for this issue have landed for 2.4.
-
-!!! warning It is **not** supported in DAOS 2.2 to assign NVMe disks of a single VMD domain to different
-            DAOS engines. All NVMe disks of a VMD domain must be assigned to the same storage engine.
-


### PR DESCRIPTION
Specifying individual VMD backing device addresses is not supported so
remove the suggestions in the admin guide. It it is not possible to
share devices from the same VMD domain between engine processes.

Doc-change: true
Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
