### PR TITLE
DAOS-11551 tools: Update daos cmd output for clone/copy (#11189)

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -786,10 +786,26 @@ func (cmd *containerCloneCmd) Execute(_ []string) error {
 	rc := C.cont_clone_hdlr(ap)
 
 	if err := daosError(rc); err != nil {
-		return errors.Wrapf(err,
-			"failed to clone container %s",
-			cmd.Source)
+		return errors.Wrapf(err, "failed to clone container %s", cmd.Source)
 	}
+
+	if cmd.shouldEmitJSON {
+		return cmd.outputJSON(struct {
+			SourcePool string `json:"src_pool"`
+			SourceCont string `json:"src_cont"`
+			DestPool   string `json:"dst_pool"`
+			DestCont   string `json:"dst_cont"`
+		}{
+			C.GoString(&ap.dm_args.src_pool[0]),
+			C.GoString(&ap.dm_args.src_cont[0]),
+			C.GoString(&ap.dm_args.dst_pool[0]),
+			C.GoString(&ap.dm_args.dst_cont[0]),
+		}, nil)
+	}
+
+	// Compat with old-style output
+	cmd.log.Infof("Successfully created container %s", C.GoString(&ap.dm_args.dst_cont[0]))
+	cmd.log.Infof("Successfully copied to destination container %s", C.GoString(&ap.dm_args.dst_cont[0]))
 
 	return nil
 }

--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -62,10 +62,45 @@ func (cmd *fsCopyCmd) Execute(_ []string) error {
 	ap.fs_op = C.FS_COPY
 	rc := C.fs_copy_hdlr(ap)
 	if err := daosError(rc); err != nil {
-		return errors.Wrapf(err,
-			"failed to copy %s -> %s",
-			cmd.Source, cmd.Dest)
+		return errors.Wrapf(err, "failed to copy %s -> %s", cmd.Source, cmd.Dest)
 	}
+
+	if cmd.shouldEmitJSON {
+		type CopyStats struct {
+			NumDirs  uint64 `json:"num_dirs"`
+			NumFiles uint64 `json:"num_files"`
+			NumLinks uint64 `json:"num_links"`
+		}
+
+		return cmd.outputJSON(struct {
+			SourcePool string    `json:"src_pool"`
+			SourceCont string    `json:"src_cont"`
+			DestPool   string    `json:"dst_pool"`
+			DestCont   string    `json:"dst_cont"`
+			CopyStats  CopyStats `json:"copy_stats"`
+		}{
+			C.GoString(&ap.dm_args.src_pool[0]),
+			C.GoString(&ap.dm_args.src_cont[0]),
+			C.GoString(&ap.dm_args.dst_pool[0]),
+			C.GoString(&ap.dm_args.dst_cont[0]),
+			CopyStats{
+				uint64(ap.fs_copy_stats.num_dirs),
+				uint64(ap.fs_copy_stats.num_files),
+				uint64(ap.fs_copy_stats.num_links),
+			},
+		}, nil)
+	}
+
+	fsType := "DAOS"
+	if ap.fs_copy_posix {
+		fsType = "POSIX"
+	}
+	// Compat with old-style output
+	cmd.log.Infof("Successfully created container %s", C.GoString(&ap.dm_args.dst_cont[0]))
+	cmd.log.Infof("Successfully copied to %s: %s", fsType, cmd.Dest)
+	cmd.log.Infof("    Directories: %d", ap.fs_copy_stats.num_dirs)
+	cmd.log.Infof("    Files:       %d", ap.fs_copy_stats.num_files)
+	cmd.log.Infof("    Links:       %d", ap.fs_copy_stats.num_links)
 
 	return nil
 }

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -189,6 +189,12 @@ func freeCmdArgs(ap *C.struct_cmd_args_s) {
 
 	if ap.props != nil {
 		C.daos_prop_free(ap.props)
+	}
+	if ap.dm_args != nil {
+		C.free_daos_alloc(unsafe.Pointer(ap.dm_args))
+	}
+	if ap.fs_copy_stats != nil {
+		C.free_daos_alloc(unsafe.Pointer(ap.fs_copy_stats))
 	}
 
 	C.free(unsafe.Pointer(ap))

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -48,30 +48,6 @@ struct file_dfs {
 	daos_off_t offset;
 	dfs_obj_t *obj;
 	dfs_sys_t *dfs_sys;
-};
-
-struct dm_args {
-	char		*src;
-	char		*dst;
-	char		src_pool[DAOS_PROP_LABEL_MAX_LEN + 1];
-	char		src_cont[DAOS_PROP_LABEL_MAX_LEN + 1];
-	char		dst_pool[DAOS_PROP_LABEL_MAX_LEN + 1];
-	char		dst_cont[DAOS_PROP_LABEL_MAX_LEN + 1];
-	daos_handle_t	src_poh;
-	daos_handle_t	src_coh;
-	daos_handle_t	dst_poh;
-	daos_handle_t	dst_coh;
-	uint32_t	cont_prop_oid;
-	uint32_t	cont_prop_layout;
-	uint64_t	cont_layout;
-	uint64_t	cont_oid;
-
-};
-
-struct fs_copy_stats {
-	uint64_t		num_dirs;
-	uint64_t		num_files;
-	uint64_t		num_links;
 };
 
 /* Report an error with a system error number using a standard output format */
@@ -2000,7 +1976,6 @@ dm_connect(struct cmd_args_s *ap,
 				DH_PERROR_DER(ap, rc, "failed to open container");
 				D_GOTO(err, rc);
 			}
-			fprintf(ap->outstream, "Successfully created container %s\n", ca->dst_cont);
 		}
 		if (is_posix_copy) {
 			rc = dfs_sys_mount(ca->dst_poh, ca->dst_coh, O_RDWR, DFS_SYS_NO_LOCK,
@@ -2226,11 +2201,21 @@ fs_copy_hdlr(struct cmd_args_s *ap)
 	daos_cont_info_t	dst_cont_info = {0};
 	struct file_dfs		src_file_dfs = {0};
 	struct file_dfs		dst_file_dfs = {0};
-	struct dm_args		ca = {0};
+	struct dm_args		*ca = NULL;
 	bool			is_posix_copy = true;
-	struct fs_copy_stats	num = {0};
+	struct fs_copy_stats	*num = NULL;
 
-	set_dm_args_default(&ca);
+	D_ALLOC(ca, sizeof(struct dm_args));
+	if (ca == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+	ap->dm_args = ca;
+
+	D_ALLOC(num, sizeof(struct fs_copy_stats));
+	if (num == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+	ap->fs_copy_stats = num;
+
+	set_dm_args_default(ca);
 	file_set_defaults_dfs(&src_file_dfs);
 	file_set_defaults_dfs(&dst_file_dfs);
 
@@ -2246,7 +2231,7 @@ fs_copy_hdlr(struct cmd_args_s *ap)
 		DH_PERROR_DER(ap, rc, "Unable to allocate memory for source path");
 		D_GOTO(out, rc);
 	}
-	rc = dm_parse_path(&src_file_dfs, src_str, src_str_len, &ca.src_pool, &ca.src_cont);
+	rc = dm_parse_path(&src_file_dfs, src_str, src_str_len, &ca->src_pool, &ca->src_cont);
 	if (rc != 0) {
 		DH_PERROR_DER(ap, rc, "failed to parse source path");
 		D_GOTO(out, rc);
@@ -2264,34 +2249,28 @@ fs_copy_hdlr(struct cmd_args_s *ap)
 		DH_PERROR_DER(ap, rc, "Unable to allocate memory for destination path");
 		D_GOTO(out, rc);
 	}
-	rc = dm_parse_path(&dst_file_dfs, dst_str, dst_str_len, &ca.dst_pool, &ca.dst_cont);
+	rc = dm_parse_path(&dst_file_dfs, dst_str, dst_str_len, &ca->dst_pool, &ca->dst_cont);
 	if (rc != 0) {
 		DH_PERROR_DER(ap, rc, "failed to parse destination path");
 		D_GOTO(out, rc);
 	}
 
-	rc = dm_connect(ap, is_posix_copy, &src_file_dfs, &dst_file_dfs, &ca,
+	rc = dm_connect(ap, is_posix_copy, &src_file_dfs, &dst_file_dfs, ca,
 			ap->sysname, ap->dst, &src_cont_info, &dst_cont_info);
 	if (rc != 0) {
 		DH_PERROR_DER(ap, rc, "fs copy failed to connect");
 		D_GOTO(out, rc);
 	}
 
-	rc = fs_copy(ap, &src_file_dfs, &dst_file_dfs, src_str, dst_str, &num);
+	rc = fs_copy(ap, &src_file_dfs, &dst_file_dfs, src_str, dst_str, num);
 	if (rc != 0)
 		D_GOTO(out_disconnect, rc);
 
-	if (dst_file_dfs.type == DAOS) {
-		fprintf(ap->outstream, "Successfully copied to DAOS: %s\n", dst_str);
-	} else if (dst_file_dfs.type == POSIX) {
-		fprintf(ap->outstream, "Successfully copied to POSIX: %s\n", dst_str);
-	}
-	fprintf(ap->outstream, "    Directories: %lu\n", num.num_dirs);
-	fprintf(ap->outstream, "    Files:       %lu\n", num.num_files);
-	fprintf(ap->outstream, "    Links:       %lu\n", num.num_links);
+	if (dst_file_dfs.type == POSIX)
+		ap->fs_copy_posix = true;
 out_disconnect:
 	/* umount dfs, close conts, and disconnect pools */
-	rc2 = dm_disconnect(ap, is_posix_copy, &ca, &src_file_dfs, &dst_file_dfs);
+	rc2 = dm_disconnect(ap, is_posix_copy, ca, &src_file_dfs, &dst_file_dfs);
 	if (rc2 != 0)
 		DH_PERROR_DER(ap, rc2, "failed to disconnect");
 out:
@@ -2660,7 +2639,7 @@ cont_clone_hdlr(struct cmd_args_s *ap)
 	uint32_t		oids_nr;
 	daos_handle_t		toh;
 	daos_epoch_t		epoch;
-	struct			dm_args ca = {0};
+	struct			dm_args *ca = NULL;
 	bool			is_posix_copy = false;
 	daos_handle_t		oh;
 	daos_handle_t		dst_oh;
@@ -2672,7 +2651,12 @@ cont_clone_hdlr(struct cmd_args_s *ap)
 	size_t			dst_str_len = 0;
 	daos_epoch_range_t	epr;
 
-	set_dm_args_default(&ca);
+	D_ALLOC(ca, sizeof(struct dm_args));
+	if (ca == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+	ap->dm_args = ca;
+
+	set_dm_args_default(ca);
 	file_set_defaults_dfs(&src_cp_type);
 	file_set_defaults_dfs(&dst_cp_type);
 
@@ -2683,7 +2667,7 @@ cont_clone_hdlr(struct cmd_args_s *ap)
 		DH_PERROR_DER(ap, rc, "Unable to allocate memory for source path");
 		D_GOTO(out, rc);
 	}
-	rc = dm_parse_path(&src_cp_type, src_str, src_str_len, &ca.src_pool, &ca.src_cont);
+	rc = dm_parse_path(&src_cp_type, src_str, src_str_len, &ca->src_pool, &ca->src_cont);
 	if (rc != 0) {
 		DH_PERROR_DER(ap, rc, "Failed to parse source path");
 		D_GOTO(out, rc);
@@ -2696,16 +2680,16 @@ cont_clone_hdlr(struct cmd_args_s *ap)
 		DH_PERROR_DER(ap, rc, "Unable to allocate memory for destination path");
 		D_GOTO(out, rc);
 	}
-	rc = dm_parse_path(&dst_cp_type, dst_str, dst_str_len, &ca.dst_pool, &ca.dst_cont);
+	rc = dm_parse_path(&dst_cp_type, dst_str, dst_str_len, &ca->dst_pool, &ca->dst_cont);
 	if (rc != 0) {
 		DH_PERROR_DER(ap, rc, "Failed to parse destination path");
 		D_GOTO(out, rc);
 	}
 
-	if (strlen(ca.dst_cont) != 0) {
+	if (strlen(ca->dst_cont) != 0) {
 		/* make sure destination container does not already exist for object level copies
 		 */
-		rc = daos_pool_connect(ca.dst_pool, ap->sysname, DAOS_PC_RW, &ca.dst_poh,
+		rc = daos_pool_connect(ca->dst_pool, ap->sysname, DAOS_PC_RW, &ca->dst_poh,
 				       NULL, NULL);
 		if (rc != 0) {
 			DH_PERROR_DER(ap, rc, "Failed to connect to destination pool");
@@ -2714,7 +2698,7 @@ cont_clone_hdlr(struct cmd_args_s *ap)
 		/* make sure this destination container doesn't exist already,
 		 * if it does, exit
 		 */
-		rc = daos_cont_open(ca.dst_poh, ca.dst_cont, DAOS_COO_RW, &ca.dst_coh,
+		rc = daos_cont_open(ca->dst_poh, ca->dst_cont, DAOS_COO_RW, &ca->dst_coh,
 				    &dst_cont_info, NULL);
 		if (rc == 0) {
 			fprintf(ap->errstream,
@@ -2723,34 +2707,34 @@ cont_clone_hdlr(struct cmd_args_s *ap)
 				"provide an existing pool or new UNS path of the "
 				"form:\n\t--dst </$pool> | <path/to/uns>\n");
 			/* disconnect from only destination and exit */
-			rc = daos_cont_close(ca.dst_coh, NULL);
+			rc = daos_cont_close(ca->dst_coh, NULL);
 			if (rc != 0) {
 				DH_PERROR_DER(ap, rc, "Failed to close destination container");
 				D_GOTO(out, rc);
 			}
-			rc = daos_pool_disconnect(ca.dst_poh, NULL);
+			rc = daos_pool_disconnect(ca->dst_poh, NULL);
 			if (rc != 0) {
 				DH_PERROR_DER(ap, rc2,
 					      "failed to disconnect from destination pool %s",
-					      ca.dst_pool);
+					      ca->dst_pool);
 				D_GOTO(out, rc);
 			}
 			D_GOTO(out, rc = 1);
 		}
 	}
 
-	rc = dm_connect(ap, is_posix_copy, &dst_cp_type, &src_cp_type, &ca, ap->sysname,
+	rc = dm_connect(ap, is_posix_copy, &dst_cp_type, &src_cp_type, ca, ap->sysname,
 			ap->dst, &src_cont_info, &dst_cont_info);
 	if (rc != 0) {
 		D_GOTO(out_disconnect, rc);
 	}
-	rc = daos_cont_create_snap_opt(ca.src_coh, &epoch, NULL,
+	rc = daos_cont_create_snap_opt(ca->src_coh, &epoch, NULL,
 				       DAOS_SNAP_OPT_CR | DAOS_SNAP_OPT_OIT, NULL);
 	if (rc) {
 		DH_PERROR_DER(ap, rc, "Failed to create snapshot");
 		D_GOTO(out_disconnect, rc);
 	}
-	rc = daos_oit_open(ca.src_coh, epoch, &toh, NULL);
+	rc = daos_oit_open(ca->src_coh, epoch, &toh, NULL);
 	if (rc != 0) {
 		DH_PERROR_DER(ap, rc, "Failed to open object iterator");
 		D_GOTO(out_snap, rc);
@@ -2766,12 +2750,12 @@ cont_clone_hdlr(struct cmd_args_s *ap)
 
 		/* list object ID's */
 		for (i = 0; i < oids_nr; i++) {
-			rc = daos_obj_open(ca.src_coh, oids[i], 0, &oh, NULL);
+			rc = daos_obj_open(ca->src_coh, oids[i], 0, &oh, NULL);
 			if (rc != 0) {
 				DH_PERROR_DER(ap, rc, "Failed to open source object");
 				D_GOTO(out_oit, rc);
 			}
-			rc = daos_obj_open(ca.dst_coh, oids[i], 0, &dst_oh, NULL);
+			rc = daos_obj_open(ca->dst_coh, oids[i], 0, &dst_oh, NULL);
 			if (rc != 0) {
 				DH_PERROR_DER(ap, rc, "Failed to open destination object");
 				D_GOTO(err_dst, rc);
@@ -2813,25 +2797,23 @@ out_oit:
 out_snap:
 	epr.epr_lo = epoch;
 	epr.epr_hi = epoch;
-	rc2 = daos_cont_destroy_snap(ca.src_coh, epr, NULL);
+	rc2 = daos_cont_destroy_snap(ca->src_coh, epr, NULL);
 	if (rc2 != 0) {
 		DH_PERROR_DER(ap, rc2, "Failed to destroy snapshot");
 	}
 out_disconnect:
 	/* close src and dst pools, conts */
-	rc2 = dm_disconnect(ap, is_posix_copy, &ca, &src_cp_type, &dst_cp_type);
+	rc2 = dm_disconnect(ap, is_posix_copy, ca, &src_cp_type, &dst_cp_type);
 	if (rc2 != 0) {
 		DH_PERROR_DER(ap, rc2, "Failed to disconnect");
 	}
 out:
-	if (rc == 0) {
-		fprintf(ap->outstream, "Successfully copied to destination container %s\n",
-			ca.dst_cont);
-	}
 	D_FREE(src_str);
 	D_FREE(dst_str);
-	D_FREE(ca.src);
-	D_FREE(ca.dst);
+	if (ca != NULL) {
+		D_FREE(ca->src);
+		D_FREE(ca->dst);
+	}
 	return rc;
 }
 

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -66,6 +66,30 @@ enum sh_op {
 	SH_VOS
 };
 
+struct fs_copy_stats {
+	uint64_t		num_dirs;
+	uint64_t		num_files;
+	uint64_t		num_links;
+};
+
+struct dm_args {
+	char		*src;
+	char		*dst;
+	char		src_pool[DAOS_PROP_LABEL_MAX_LEN + 1];
+	char		src_cont[DAOS_PROP_LABEL_MAX_LEN + 1];
+	char		dst_pool[DAOS_PROP_LABEL_MAX_LEN + 1];
+	char		dst_cont[DAOS_PROP_LABEL_MAX_LEN + 1];
+	daos_handle_t	src_poh;
+	daos_handle_t	src_coh;
+	daos_handle_t	dst_poh;
+	daos_handle_t	dst_coh;
+	uint32_t	cont_prop_oid;
+	uint32_t	cont_prop_layout;
+	uint64_t	cont_layout;
+	uint64_t	cont_oid;
+
+};
+
 /* cmd_args_s: consolidated result of parsing command-line arguments
  * for pool, cont, obj commands, much of which is common.
  */
@@ -105,6 +129,11 @@ struct cmd_args_s {
 	daos_epoch_t		epcrange_end;
 	daos_obj_id_t		oid;
 	daos_prop_t		*props;		/* --properties cont create */
+
+	/* Container datamover related */
+	struct dm_args		*dm_args;	/* datamover arguments */
+	struct fs_copy_stats	*fs_copy_stats;	/* fs copy stats */
+	bool			 fs_copy_posix; /* fs copy to POSIX */
 
 	FILE			*outstream;	/* normal output stream */
 	FILE			*errstream;	/* errors stream */

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -2711,14 +2711,16 @@ class posix_tests():
                src_dir.name,
                '--dst',
                'daos://{}/{}'.format(self.pool.uuid, self.container)]
-        rc = run_daos_cmd(self.conf, cmd)
+        rc = run_daos_cmd(self.conf, cmd, use_json=True)
         print(rc)
-        lineresult = rc.stdout.decode('utf-8').splitlines()
-        assert len(lineresult) == 4
-        assert lineresult[1] == '    Directories: 1'
-        assert lineresult[2] == '    Files:       1'
-        assert lineresult[3] == '    Links:       1'
-        assert rc.returncode == 0
+
+        data = rc.json
+        assert data['status'] == 0, rc
+        assert data['error'] is None, rc
+        assert data['response'] is not None, rc
+        assert data['response']['copy_stats']['num_dirs'] == 1
+        assert data['response']['copy_stats']['num_files'] == 1
+        assert data['response']['copy_stats']['num_links'] == 1
 
     def test_cont_clone(self):
         """Verify that cloning a container works
@@ -2741,9 +2743,13 @@ class posix_tests():
                src_dir.name,
                '--dst',
                'daos://{}/{}'.format(self.pool.uuid, self.container)]
-        rc = run_daos_cmd(self.conf, cmd)
+        rc = run_daos_cmd(self.conf, cmd, use_json=True)
         print(rc)
-        assert rc.returncode == 0
+
+        data = rc.json
+        assert data['status'] == 0, rc
+        assert data['error'] is None, rc
+        assert data['response'] is not None, rc
 
         # Now create a container uuid and do an object based copy.
         # The daos command will create the target container on demand.
@@ -2753,12 +2759,15 @@ class posix_tests():
                'daos://{}/{}'.format(self.pool.uuid, self.container),
                '--dst',
                'daos://{}/'.format(self.pool.uuid)]
-        rc = run_daos_cmd(self.conf, cmd)
+        rc = run_daos_cmd(self.conf, cmd, use_json=True)
         print(rc)
-        assert rc.returncode == 0
-        lineresult = rc.stdout.decode('utf-8').splitlines()
-        assert len(lineresult) == 2
-        destroy_container(self.conf, self.pool.id(), lineresult[1][-36:])
+
+        data = rc.json
+        assert data['status'] == 0, rc
+        assert data['error'] is None, rc
+        assert data['response'] is not None, rc
+
+        destroy_container(self.conf, self.pool.id(), data['response']['dst_cont'])
 
 class nlt_stdout_wrapper():
     """Class for capturing stdout from threads"""


### PR DESCRIPTION
Improve output options to ensure reliable output of container
clone and fs copy information (for both standard and JSON output).

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
