### PR TITLE
DAOS-12402 control: daos_server config generate VMD NVMe scan fix

### DIFF
--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -110,6 +110,11 @@ given set of hosts either through the `dmg` or `daos_server` tools.
 To generate a configuration file for a single storage server, run the `daos_server config generate`
 command locally. In this case, the `daos_server` service should not be running on the local host.
 
+`daos_server nvme prepare` should be run prior to `daos_server config generate` if the intent is to
+use NVMe and likewise `daos_server scm prepare` should be run prior to `daos_server config generate`
+if the intent is to use PMem for SCM. This will allow the relevant storage to be available for
+detection when attempting to generate the configuration files.
+
 ```bash
 $ daos_server config generate --help
 Usage:

--- a/src/control/cmd/daos_server/auto.go
+++ b/src/control/cmd/daos_server/auto.go
@@ -63,7 +63,8 @@ func getLocalFabric(ctx context.Context, log logging.Logger) (*control.HostFabri
 type getStorageFn func(context.Context, logging.Logger) (*control.HostStorage, error)
 
 func getLocalStorage(ctx context.Context, log logging.Logger) (*control.HostStorage, error) {
-	svc := server.NewStorageControlService(log, config.DefaultServer().Engines)
+	svc := server.NewStorageControlService(log, config.DefaultServer().Engines).
+		WithVMDEnabled() // use vmd if present
 
 	nvmeResp, err := svc.NvmeScan(storage.BdevScanRequest{})
 	if err != nil {


### PR DESCRIPTION
Update docs to indicate the need for storage prepare commands before
running local config generate. Fix scanning NVMe when VMD is enabled
by setting the EnableVMD flag in the storage control service during
local command variant execution. VMD should always be used if
available in the case of config generate as there is no input config
in which the user could intentionally disable a VMD prerequisite.

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
