### PR TITLE
DAOS-12317 test: Update rebuild_disabled_single test timeout.

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -7,7 +7,7 @@ hosts:
     10_server:
       test_servers: server-[1-5]
   test_clients: 1
-timeout: 400
+timeout: 500
 setup:
   # Test variants use different server counts, so ensure servers are stopped after each run
   start_agents_once: False
@@ -39,7 +39,6 @@ server_config:
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
 pool:
-    mode: 146
     name: daos_server
     scm_size: 25%
     nvme_size: 93%

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -7,7 +7,7 @@ hosts:
     10_server:
       test_servers: server-[1-5]
   test_clients: 1
-timeout: 500
+timeout: 550
 setup:
   # Test variants use different server counts, so ensure servers are stopped after each run
   start_agents_once: False


### PR DESCRIPTION
Test-tag: ec_disabled_rebuild_single
Test-repeat: 6

Summary:
- Increase the test timeout from 400 to 550 seconds.
- Remove the pool mode to match master branch.

Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
