### PR TITLE
Revert "DAOS-12130 test: Cross check core file collection with failed test"

### DIFF
--- a/src/tests/ftest/harness/advanced.py
+++ b/src/tests/ftest/harness/advanced.py
@@ -11,7 +11,7 @@ from apricot import TestWithServers
 from ClusterShell.NodeSet import NodeSet
 
 from general_utils import get_avocado_config_value
-from run_utils import run_remote, run_local, RunException
+from run_utils import run_remote
 from test_utils_pool import POOL_TIMEOUT_INCREMENT
 from user_utils import get_chown_command
 
@@ -42,22 +42,6 @@ class HarnessAdvancedTest(TestWithServers):
         :avocado: tags=harness,core_files
         :avocado: tags=HarnessAdvancedTest,test_core_files
         """
-        # create a core.gdb file
-        self.log.debug("Create a core.gdb.harness.advanced file in core_pattern dir.")
-        try:
-            results = run_local(self.log, "cat /proc/sys/kernel/core_pattern", check=True)
-        except RunException:
-            self.fail("Unable to find local core file pattern")
-        core_path = os.path.split(results.stdout.splitlines()[-1])[0]
-        core_file = "{}/core.gdb.harness.advanced".format(core_path)
-
-        self.log.debug("Creating %s", core_file)
-        try:
-            with open(core_file, "w", encoding="utf-8") as local_core_file:
-                local_core_file.write("THIS IS JUST A TEST\n")
-        except IOError as error:
-            self.fail("Error writing {}: {}".format(local_core_file, str(error)))
-
         # Choose a server find the pid of its daos_engine process
         host = NodeSet(choice(self.server_managers[0].hosts))   # nosec
         ranks = self.server_managers[0].get_host_ranks(host)

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -28,7 +28,7 @@ from ClusterShell.NodeSet import NodeSet
 # When SRE-439 is fixed we should be able to include these import statements here
 # from util.distro_utils import detect
 # pylint: disable=import-error,no-name-in-module
-from process_core_files import CoreFileProcessing, CoreFileException
+from process_core_files import CoreFileProcessing
 
 # Update the path to support utils files that import other utils files
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "util"))
@@ -36,7 +36,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "util")
 from host_utils import get_node_set, get_local_host, HostInfo, HostException  # noqa: E402
 from logger_utils import get_console_handler, get_file_handler                # noqa: E402
 from results_utils import create_html, create_xml, Job, Results, TestResult   # noqa: E402
-from run_utils import run_local, run_remote, find_command, RunException       # noqa: E402
+from run_utils import run_local, run_remote, RunException                     # noqa: E402
 from slurm_utils import show_partition, create_partition, delete_partition    # noqa: E402
 from user_utils import get_chown_command, groupadd, useradd, userdel, get_group_id, \
     get_user_groups  # noqa: E402
@@ -223,6 +223,28 @@ def find_pci_address(value):
     return re.findall(pattern, str(value))
 
 
+def find_command(source, pattern, depth, other=None):
+    """Get the find command.
+
+    Args:
+        source (str): where the files are currently located
+        pattern (str): pattern used to limit which files are processed
+        depth (int): max depth for find command
+        other (object, optional): other commands, as a list or str, to include at the end of the
+            base find command. Defaults to None.
+
+    Returns:
+        str: the find command
+
+    """
+    command = ["find", source, "-maxdepth", str(depth), "-type", "f", "-name", f"'{pattern}'"]
+    if isinstance(other, list):
+        command.extend(other)
+    elif isinstance(other, str):
+        command.append(other)
+    return " ".join(command)
+
+
 class AvocadoInfo():
     """Information about this version of avocado."""
 
@@ -339,7 +361,7 @@ class AvocadoInfo():
         except ModuleNotFoundError:
             # Once lightweight runs are using python3-avocado, this can be removed
             try:
-                result = run_local(logger, "avocado -v", check=True)
+                result = run_local(logger, ["avocado", "-v"], check=True)
             except RunException as error:
                 message = "Error obtaining avocado version after failed avocado.core.version import"
                 raise LaunchException(message) from error
@@ -389,7 +411,7 @@ class AvocadoInfo():
 
         except ModuleNotFoundError:
             # Once lightweight runs are using python3-avocado, this can be removed
-            result = run_local(logger, "avocado config", check=True)
+            result = run_local(logger, ["avocado", "config"], check=True)
             try:
                 return re.findall(rf"{section}\.{key}\s+(.*)", result.stdout)[0]
             except IndexError:
@@ -1690,7 +1712,7 @@ class Launch():
 
         # Find all the test files that contain tests matching the tags
         logger.info("Detecting tests matching tags: %s", " ".join(command))
-        output = run_local(logger, " ".join(command), check=True)
+        output = run_local(logger, command, check=True)
         unique_test_files = set(re.findall(self.avocado.get_list_regex(), output.stdout))
         for index, test_file in enumerate(unique_test_files):
             self.tests.append(TestInfo(test_file, index + 1))
@@ -1706,7 +1728,7 @@ class Launch():
         """
         logger.debug("Checking for fault injection enablement via 'fault_status':")
         try:
-            run_local(logger, "fault_status", check=True)
+            run_local(logger, ["fault_status"], check=True)
             logger.debug("  Fault injection is enabled")
             return True
         except RunException:
@@ -1739,7 +1761,7 @@ class Launch():
             if args.extra_yaml:
                 command.extend(args.extra_yaml)
             command.extend(["--summary", "3"])
-            run_local(logger, " ".join(command), check=False)
+            run_local(logger, command, check=False)
 
             # Collect the host information from the updated test yaml
             test.set_yaml_info(args.include_localhost)
@@ -2105,7 +2127,7 @@ class Launch():
             # Optionally display a diff of the yaml file
             if args.verbose > 0:
                 command = ["diff", "-y", orig_yaml_file, yaml_file]
-                run_local(logger, " ".join(command), check=False)
+                run_local(logger, command, check=False)
 
         # Return the untouched or modified yaml file
         return yaml_file
@@ -2319,7 +2341,7 @@ class Launch():
         logger.debug("-" * 80)
         logger.debug("Current disk space usage of %s", path)
         try:
-            run_local(logger, " ".join(["df", "-h", path]), check=False)
+            run_local(logger, ["df", "-h", path], check=False)
         except RunException:
             pass
 
@@ -2462,8 +2484,8 @@ class Launch():
             os.path.join("..", "..", "..", "..", "lib64", "daos", "certgen"))
         command = os.path.join(certgen_dir, "gen_certificates.sh")
         try:
-            run_local(logger, " ".join(["/usr/bin/rm", "-rf", certs_dir]))
-            run_local(logger, " ".join([command, daos_test_log_dir]))
+            run_local(logger, ["/usr/bin/rm", "-rf", certs_dir])
+            run_local(logger, [command, daos_test_log_dir])
         except RunException:
             message = "Error generating certificates"
             self._fail_test(self.result.tests[-1], "Prepare", message, sys.exc_info())
@@ -2492,8 +2514,7 @@ class Launch():
         start_time = int(time.time())
 
         try:
-            return_code = run_local(
-                logger, " ".join(command), capture_output=False, check=False).returncode
+            return_code = run_local(logger, command, capture_output=False, check=False).returncode
             if return_code == 0:
                 logger.debug("All avocado test variants passed")
             elif return_code == 2:
@@ -2533,10 +2554,9 @@ class Launch():
             if crash_files:
                 latest_crash_dir = os.path.join(avocado_logs_dir, "latest", "crashes")
                 try:
-                    run_local(logger, " ".join(["mkdir", "-p", latest_crash_dir]), check=True)
+                    run_local(logger, ["mkdir", "-p", latest_crash_dir], check=True)
                     for crash_file in crash_files:
-                        run_local(
-                            logger, " ".join(["mv", crash_file, latest_crash_dir]), check=True)
+                        run_local(logger, ["mv", crash_file, latest_crash_dir], check=True)
                 except RunException:
                     message = "Error collecting crash files"
                     self._fail_test(self.result.tests[-1], "Execute", message, sys.exc_info())
@@ -3082,7 +3102,7 @@ class Launch():
         command = ["clush", "-w", str(hosts), "-v", "--rcopy", tmp_copy_dir, "--dest", rcopy_dest]
         return_code = 0
         try:
-            run_local(logger, " ".join(command), check=True, timeout=timeout)
+            run_local(logger, command, check=True, timeout=timeout)
 
         except RunException:
             message = f"Error copying remote files to {destination}"
@@ -3106,27 +3126,21 @@ class Launch():
             test_job_results (str): the location of the core files
 
         Returns:
-            int: status code: 2048 = Core file exist; 256 = failure; 0 = success
+            int: status code: 0 = success, 256 = failure
 
         """
         core_file_processing = CoreFileProcessing(logger)
         try:
-            corefiles_processed = core_file_processing.process_core_files(test_job_results, True)
-
-        except CoreFileException:
-            message = "Errors detected processing test core files"
-            self._fail_test(self.result.tests[-1], "Process", message, sys.exc_info())
-            return 256
+            error_count = core_file_processing.process_core_files(test_job_results, True)
+            if error_count:
+                message = f"Errors detected processing test core files: {error_count}"
+                self._fail_test(self.result.tests[-1], "Process", message)
+                return 256
 
         except Exception:       # pylint: disable=broad-except
             message = "Unhandled error processing test core files"
             self._fail_test(self.result.tests[-1], "Process", message, sys.exc_info())
             return 256
-
-        if corefiles_processed > 0:
-            message = "One or more core files detected after test execution"
-            self._fail_test(self.result.tests[-1], "Process", message, None)
-            return 2048
 
         return 0
 
@@ -3248,7 +3262,6 @@ class Launch():
             256: "ERROR: Failed to process core files after one or more tests!",
             512: "ERROR: Failed to stop daos_server.service after one or more tests!",
             1024: "ERROR: Failed to rename logs and results after one or more tests!",
-            2048: "ERROR: Core stack trace files detected!",
         }
         for bit_code, error_message in bit_error_map.items():
             if status & bit_code == bit_code:

--- a/src/tests/ftest/process_core_files.py
+++ b/src/tests/ftest/process_core_files.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2022 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -12,16 +12,12 @@ import sys
 
 # pylint: disable=import-error,no-name-in-module
 from util.logger_utils import get_console_handler
-from util.run_utils import run_local, find_command, RunException
+from util.run_utils import run_local, RunException
 
 # Set up a logger for the console messages
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logger.addHandler(get_console_handler("%(message)s", logging.DEBUG))
-
-
-class CoreFileException(Exception):
-    """Base exception for this module."""
 
 
 class CoreFileProcessing():
@@ -51,16 +47,12 @@ class CoreFileProcessing():
                 process
             delete (bool): delete the core files.
 
-        Raises:
-            CoreFileException: if there is an error processing core files.
-
         Returns:
-            int: num of core files processed
+            int: number of errors encountered
 
         """
         errors = 0
         create_stacktrace = True
-        corefiles_processed = 0
         self.log.debug("-" * 80)
         self.log.info("Processing core files in %s", os.path.join(directory, "stacktraces*"))
         if self.is_el7():
@@ -99,28 +91,20 @@ class CoreFileProcessing():
                     if os.path.splitext(core_name)[-1] == ".bz2":
                         # Decompress the file
                         command = ["lbzip2", "-d", "-v", os.path.join(core_dir, core_name)]
-                        run_local(self.log, " ".join(command))
+                        run_local(self.log, command)
                         core_name = os.path.splitext(core_name)[0]
                     self._create_stacktrace(core_dir, core_name)
-                    corefiles_processed += 1
-                    self.log.debug(
-                        "Successfully processed core file %s", os.path.join(core_dir, core_name))
                 except Exception as error:      # pylint: disable=broad-except
                     self.log.error(error)
                     self.log.debug("Stacktrace", exc_info=True)
-                    self.log.error(
-                        "Failed to process core file %s", os.path.join(core_dir, core_name))
                     errors += 1
                 finally:
                     if delete:
                         core_file = os.path.join(core_dir, core_name)
                         self.log.debug("Removing %s", core_file)
                         os.remove(core_file)
-        # remove any core file generated post core processing on the local node
-        errors += self.delete_gdb_core_files()
-        if errors:
-            raise CoreFileException("Errors detected processing core files")
-        return corefiles_processed
+
+        return errors
 
     def _create_stacktrace(self, core_dir, core_name):
         """Create a stacktrace from the specified core file.
@@ -138,7 +122,7 @@ class CoreFileProcessing():
         stack_trace_file = os.path.join(core_dir, f"{core_name}.stacktrace")
 
         self.log.debug("Generating a stacktrace from the %s core file from %s", core_full, host)
-        run_local(self.log, " ".join(['ls', '-l', core_full]))
+        run_local(self.log, ['ls', '-l', core_full])
 
         try:
             command = [
@@ -154,7 +138,7 @@ class CoreFileProcessing():
             raise RunException(f"Error obtaining the exe name from {core_name}") from error
 
         try:
-            output = run_local(self.log, " ".join(command), check=False, verbose=False)
+            output = run_local(self.log, command, check=False, verbose=False)
             with open(stack_trace_file, "w", encoding="utf-8") as stack_trace:
                 stack_trace.writelines(output.stdout)
 
@@ -179,7 +163,7 @@ class CoreFileProcessing():
         """
         self.log.debug("Extracting the executable name from %s", core_file)
         command = ["gdb", "-c", core_file, "-ex", "info proc exe", "-ex", "quit"]
-        result = run_local(self.log, " ".join(command), verbose=False)
+        result = run_local(self.log, command, verbose=False)
         last_line = result.stdout.splitlines()[-1]
         self.log.debug("  last line:       %s", last_line)
         cmd = last_line[7:-1]
@@ -244,8 +228,7 @@ class CoreFileProcessing():
                 else:
                     raise RunException(f"Unsupported distro: {self.distro_info}")
                 cmds.append(["sudo", "dnf", "-y", "install"] + dnf_args)
-            output = run_local(
-                self.log, " ".join(["rpm", "-q", "--qf", "%{evr}", "daos"]), check=False)
+            output = run_local(self.log, ["rpm", "-q", "--qf", "%{evr}", "daos"], check=False)
             rpm_version = output.stdout
             cmds.append(
                 ["sudo", "dnf", "debuginfo-install", "-y"] + dnf_args
@@ -279,7 +262,7 @@ class CoreFileProcessing():
         retry = False
         for cmd in cmds:
             try:
-                run_local(self.log, " ".join(cmd), check=True)
+                run_local(self.log, cmd, check=True)
             except RunException:
                 # got an error, so abort this list of commands and re-run
                 # it with a dnf clean, makecache first
@@ -294,7 +277,7 @@ class CoreFileProcessing():
             cmds.insert(1, cmd_prefix + ["makecache"])
             for cmd in cmds:
                 try:
-                    run_local(self.log, " ".join(cmd))
+                    run_local(self.log, cmd)
                 except RunException:
                     break
 
@@ -337,8 +320,7 @@ class CoreFileProcessing():
         try:
             # Eventually use python libraries for this rather than exec()ing out to rpm
             output = run_local(
-                self.log,
-                " ".join(["rpm", "-q", "--qf", "%{name} %{version} %{release} %{epoch}", pkg]),
+                self.log, ["rpm", "-q", "--qf", "%{name} %{version} %{release} %{epoch}", pkg],
                 check=False)
             name, version, release, epoch = output.stdout.split()
 
@@ -358,32 +340,6 @@ class CoreFileProcessing():
 
         return package_info
 
-    def delete_gdb_core_files(self):
-        """Delete any post processing core files on local host.
-
-        Returns:
-            int: number of errors
-
-        """
-        self.log.debug("Checking core files generated by core file processing")
-        try:
-            results = run_local(self.log, "cat /proc/sys/kernel/core_pattern", check=True)
-        except RunException:
-            self.log.error("Unable to find local core file pattern")
-            self.log.debug("Stacktrace", exc_info=True)
-            return 1
-        core_path = os.path.split(results.stdout.splitlines()[-1])[0]
-
-        self.log.debug("Deleting core.gdb.*.* core files located in %s", core_path)
-        other = ["-printf '%M %n %-12u %-12g %12k %t %p\n' -delete"]
-        try:
-            run_local(
-                self.log, find_command(core_path, "core.gdb.*.*", 1, other), check=True)
-        except RunException:
-            self.log.debug("core.gdb.*.* files could not be removed")
-            return 1
-        return 0
-
 
 def main():
     """Generate a stacktrace for each core file in the provided directory."""
@@ -402,11 +358,10 @@ def main():
 
     core_file_processing = CoreFileProcessing(logger)
     try:
-        core_file_processing.process_core_files(args.directory, args.delete)
-
-    except CoreFileException as error:
-        logger.error(str(error))
-        sys.exit(1)
+        error_count = core_file_processing.process_core_files(args.directory, args.delete)
+        if error_count:
+            logger.error("Errors detected processing test core files: %s", error_count)
+            sys.exit(1)
 
     except Exception:       # pylint: disable=broad-except
         logger.error("Unhandled error processing test core files",)

--- a/src/tests/ftest/util/cmocka_utils.py
+++ b/src/tests/ftest/util/cmocka_utils.py
@@ -142,11 +142,11 @@ class CmockaUtils():
         command = get_clush_command_list(self.hosts)
         command.extend(["--rcopy", self.cmocka_dir, "--dest", self.cmocka_dir])
         try:
-            run_local(test.log, " ".join(command))
+            run_local(test.log, command)
 
         finally:
             test.log.debug("Local %s directory after clush:", self.cmocka_dir)
-            run_local(test.log, " ".join(ls_command))
+            run_local(test.log, ls_command)
             # Move local files to the avocado test variant data directory
             for cmocka_node_dir in os.listdir(self.cmocka_dir):
                 cmocka_node_path = os.path.join(self.cmocka_dir, cmocka_node_dir)
@@ -155,7 +155,7 @@ class CmockaUtils():
                         if "_cmocka_results." in cmocka_file:
                             cmocka_file_path = os.path.join(cmocka_node_path, cmocka_file)
                             command = ["mv", cmocka_file_path, self.outputdir]
-                            run_local(test.log, " ".join(command))
+                            run_local(test.log, command)
 
     def _check_cmocka_files(self):
         """Determine if cmocka files exist in the expected location.

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -5,7 +5,7 @@
 """
 from socket import gethostname
 import subprocess   # nosec
-import shlex
+
 from ClusterShell.NodeSet import NodeSet
 from ClusterShell.Task import task_self
 
@@ -225,7 +225,7 @@ def run_local(log, command, capture_output=True, timeout=None, check=False, verb
 
     Args:
         log (logger): logger for the messages produced by this method
-        command (str): command from which to obtain the output
+        command (list): command from which to obtain the output
         capture_output(bool, optional): whether or not to include the command output in the
             subprocess.CompletedProcess.stdout returned by this method. Defaults to True.
         timeout (int, optional): number of seconds to wait for the command to complete.
@@ -250,42 +250,43 @@ def run_local(log, command, capture_output=True, timeout=None, check=False, verb
 
     """
     local_host = gethostname().split(".")[0]
+    command_str = " ".join(command)
     kwargs = {"encoding": "utf-8", "shell": False, "check": check, "timeout": timeout}
     if capture_output:
         kwargs["stdout"] = subprocess.PIPE
         kwargs["stderr"] = subprocess.STDOUT
     if timeout and verbose:
-        log.debug("Running on %s with a %s timeout: %s", local_host, timeout, command)
+        log.debug("Running on %s with a %s timeout: %s", local_host, timeout, command_str)
     elif verbose:
-        log.debug("Running on %s: %s", local_host, command)
+        log.debug("Running on %s: %s", local_host, command_str)
 
     try:
         # pylint: disable=subprocess-run-check
-        result = subprocess.run(shlex.split(command), **kwargs)     # nosec
+        result = subprocess.run(command, **kwargs)     # nosec
 
     except subprocess.TimeoutExpired as error:
         # Raised if command times out
         log.debug(str(error))
         log.debug("  output: %s", error.output)
         log.debug("  stderr: %s", error.stderr)
-        raise RunException(f"Command '{command}' exceed {timeout}s timeout") from error
+        raise RunException(f"Command '{command_str}' exceed {timeout}s timeout") from error
 
     except subprocess.CalledProcessError as error:
         # Raised if command yields a non-zero return status with check=True
         log.debug(str(error))
         log.debug("  output: %s", error.output)
         log.debug("  stderr: %s", error.stderr)
-        raise RunException(f"Command '{command}' returned non-zero status") from error
+        raise RunException(f"Command '{command_str}' returned non-zero status") from error
 
     except KeyboardInterrupt as error:
         # User Ctrl-C
-        message = f"Command '{command}' interrupted by user"
+        message = f"Command '{command_str}' interrupted by user"
         log.debug(message)
         raise RunException(message) from error
 
     except Exception as error:
         # Catch all
-        message = f"Command '{command}' encountered unknown error"
+        message = f"Command '{command_str}' encountered unknown error"
         log.debug(message)
         log.debug(str(error))
         raise RunException(message) from error
@@ -346,25 +347,3 @@ def command_as_user(command, user):
         return command
     switch_command = " ".join(get_switch_user(user))
     return f"{switch_command} {command}"
-
-
-def find_command(source, pattern, depth, other=None):
-    """Get the find command.
-
-    Args:
-        source (str): where the files are currently located
-        pattern (str): pattern used to limit which files are processed
-        depth (int): max depth for find command
-        other (object, optional): other commands, as a list or str, to include at the end of the
-            base find command. Defaults to None.
-
-    Returns:
-        str: the find command
-
-    """
-    command = ["find", source, "-maxdepth", str(depth), "-type", "f", "-name", f"'{pattern}'"]
-    if isinstance(other, list):
-        command.extend(other)
-    elif isinstance(other, str):
-        command.append(other)
-    return " ".join(command)

--- a/src/tests/ftest/util/slurm_utils.py
+++ b/src/tests/ftest/util/slurm_utils.py
@@ -313,7 +313,7 @@ def check_slurm_job(log, handle):
     state = "UNKNOWN"
     command = ["scontrol", "show", "job", handle]
     try:
-        result = run_local(log, " ".join(command), verbose=False, check=True)
+        result = run_local(log, command, verbose=False, check=True)
         match = re.search(r"JobState=([a-zA-Z]+)", result.stdout)
         if match is not None:
             state = match.group(1)


### PR DESCRIPTION
This commit broke the core file handling in gdb as the commands are no longer correctly
escaped properly.  run_local() should remain taking an array rather that a single string
so that spaces are correctly propagated to gdb on the command line.

Reverts daos-stack/daos#10944