### PR TITLE
DAOS-8518 pool: Check input for default label values (#8056)

### DIFF
--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -61,7 +61,7 @@ static struct daos_prop_co_roots dummy_roots;
 struct daos_prop_entry cont_prop_entries_default_v0[CONT_PROP_NUM_V0] = {
 	{
 		.dpe_type	= DAOS_PROP_CO_LABEL,
-		.dpe_str	= DEFAULT_CONT_LABEL,
+		.dpe_str	= DAOS_PROP_CO_LABEL_DEFAULT,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
 		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,
@@ -127,7 +127,7 @@ struct daos_prop_entry cont_prop_entries_default_v0[CONT_PROP_NUM_V0] = {
 struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 	{
 		.dpe_type	= DAOS_PROP_CO_LABEL,
-		.dpe_str	= DEFAULT_CONT_LABEL,
+		.dpe_str	= DAOS_PROP_CO_LABEL_DEFAULT,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_LAYOUT_TYPE,
 		.dpe_val	= DAOS_PROP_CO_LAYOUT_UNKNOWN,

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -160,7 +160,6 @@ extern daos_prop_t cont_prop_default_v0;
 #define CONT_PROP_NUM_V0 20
 #define CONT_PROP_NUM	(DAOS_PROP_CO_MAX - DAOS_PROP_CO_MIN - 1)
 
-#define DEFAULT_CONT_LABEL "container_label_not_set"
 /**
  * Initialize the default container properties.
  *

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -499,6 +499,10 @@ struct daos_prop_entry {
 /** DAOS_PROP_LABEL_MAX_LEN including NULL terminator */
 #define DAOS_PROP_MAX_LABEL_BUF_LEN	(DAOS_PROP_LABEL_MAX_LEN + 1)
 
+/** default values for unset labels */
+#define DAOS_PROP_CO_LABEL_DEFAULT "container_label_not_set"
+#define DAOS_PROP_PO_LABEL_DEFAULT "pool_label_not_set"
+
 /**
  * Check if DAOS (pool or container property) label string is valid.
  * DAOS labels must consist only of alphanumeric characters, colon ':',

--- a/src/pool/srv_layout.c
+++ b/src/pool/srv_layout.c
@@ -48,7 +48,7 @@ RDB_STRING_KEY(ds_pool_prop_, obj_version);
 struct daos_prop_entry pool_prop_entries_default[DAOS_PROP_PO_NUM] = {
 	{
 		.dpe_type	= DAOS_PROP_PO_LABEL,
-		.dpe_str	= "pool_label_not_set",
+		.dpe_str	= DAOS_PROP_PO_LABEL_DEFAULT,
 	}, {
 		.dpe_type	= DAOS_PROP_PO_SPACE_RB,
 		.dpe_val	= 0,

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -805,10 +805,25 @@ ds_pool_svc_dist_create(const uuid_t pool_uuid, int ntargets, const char *group,
 	struct dss_module_info *info = dss_get_module_info();
 	crt_endpoint_t		ep;
 	crt_rpc_t	       *rpc;
+	struct daos_prop_entry *lbl_ent;
+	struct daos_prop_entry *def_lbl_ent;
 	struct pool_create_in  *in;
 	struct pool_create_out *out;
 	struct d_backoff_seq	backoff_seq;
 	int			rc;
+
+	/* Check for default label supplied via property. */
+	def_lbl_ent = daos_prop_entry_get(&pool_prop_default, DAOS_PROP_PO_LABEL);
+	D_ASSERT(def_lbl_ent != NULL);
+	lbl_ent = daos_prop_entry_get(prop, DAOS_PROP_PO_LABEL);
+	if (lbl_ent != NULL) {
+		if (strncmp(def_lbl_ent->dpe_str, lbl_ent->dpe_str,
+			    DAOS_PROP_LABEL_MAX_LEN) == 0) {
+			D_ERROR(DF_UUID": label is the same as default label\n",
+				DP_UUID(pool_uuid));
+			D_GOTO(out, rc = -DER_INVAL);
+		}
+	}
 
 	D_ASSERTF(ntargets == target_addrs->rl_nr, "ntargets=%d num=%u\n",
 		  ntargets, target_addrs->rl_nr);

--- a/src/tests/ftest/pool/label.py
+++ b/src/tests/ftest/pool/label.py
@@ -135,6 +135,7 @@ class Label(TestWithServers):
         """Test ID: DAOS-7942
 
         Test Description: Create pool with following invalid labels.
+        * The default string for an unset pool label property.
         * UUID format string: 23ab123e-5296-4f95-be14-641de40b4d5a
         * Long label - 128 random chars.
 
@@ -146,6 +147,7 @@ class Label(TestWithServers):
         self.pool = []
         errors = []
         label_outs = [
+            ("pool_label_not_set", "Invalid parameters"),
             ("23ab123e-5296-4f95-be14-641de40b4d5a", "invalid label"),
             (get_random_string(128), "invalid label")
         ]


### PR DESCRIPTION
If the supplied label matches one of the special values
indicating that the label was unset, reject it as invalid.

Features: pool container datamover

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
