### PR TITLE
DAOS-12250 control: Log gRPC req before processing

### DIFF
--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -364,7 +364,7 @@ func (srv *server) addEngines(ctx context.Context) error {
 
 // setupGrpc creates a new grpc server and registers services.
 func (srv *server) setupGrpc() error {
-	srvOpts, err := getGrpcOpts(srv.log, srv.cfg.TransportConfig)
+	srvOpts, err := getGrpcOpts(srv.log, srv.cfg.TransportConfig, srv.sysdb.IsLeader)
 	if err != nil {
 		return err
 	}

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -709,9 +709,9 @@ func registerLeaderSubscriptions(srv *server) {
 }
 
 // getGrpcOpts generates a set of gRPC options for the server based on the supplied configuration.
-func getGrpcOpts(log logging.Logger, cfgTransport *security.TransportConfig) ([]grpc.ServerOption, error) {
+func getGrpcOpts(log logging.Logger, cfgTransport *security.TransportConfig, ldrChk func() bool) ([]grpc.ServerOption, error) {
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
-		unaryLoggingInterceptor(log), // must be first in order to properly log errors
+		unaryLoggingInterceptor(log, ldrChk), // must be first in order to properly log errors
 		unaryErrorInterceptor,
 		unaryStatusInterceptor,
 		unaryVersionInterceptor,


### PR DESCRIPTION
The previous commit placed the request log behind a
conditional check in order to try to cut down on noisy
logging for requests that often result in a sentinel error
(e.g. ErrNotLeader). That approach does result in cleaner
logs, but has the downside of making requests more difficult
to trace, as the beginning of the request handling is not
logged first.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
