### PR TITLE
DAOS-12209 control: Don't clean up Creating pools on MS step-up (#11157)

### DIFF
--- a/src/control/server/mgmt_drpc.go
+++ b/src/control/server/mgmt_drpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2022 Intel Corporation.
+// (C) Copyright 2018-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -106,7 +106,7 @@ func (mod *srvModule) handleGetPoolServiceRanks(reqb []byte) ([]byte, error) {
 	resp := new(srvpb.GetPoolSvcResp)
 
 	ps, err := mod.sysdb.FindPoolServiceByUUID(uuid)
-	if err != nil {
+	if err != nil || ps.State != system.PoolServiceStateReady {
 		resp.Status = int32(drpc.DaosNonexistant)
 		mod.log.Debugf("GetPoolSvcResp: %+v", resp)
 		return proto.Marshal(resp)
@@ -130,7 +130,7 @@ func (mod *srvModule) handlePoolFindByLabel(reqb []byte) ([]byte, error) {
 	resp := new(srvpb.PoolFindByLabelResp)
 
 	ps, err := mod.sysdb.FindPoolServiceByLabel(req.GetLabel())
-	if err != nil {
+	if err != nil || ps.State != system.PoolServiceStateReady {
 		resp.Status = int32(drpc.DaosNonexistant)
 		mod.log.Debugf("PoolFindByLabelResp: %+v", resp)
 		return proto.Marshal(resp)

--- a/src/control/server/mgmt_drpc_test.go
+++ b/src/control/server/mgmt_drpc_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -7,16 +7,20 @@
 package server
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
+	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/system"
 )
 
 func getTestNotifyReadyReqBytes(t *testing.T, sockPath string, idx uint32) []byte {
@@ -347,4 +351,190 @@ func TestSrvModule_HandleClusterEvent_Invalid(t *testing.T) {
 	}
 
 	test.CmpErr(t, expectedErr, err)
+}
+
+func getTestBytes(t *testing.T, msg proto.Message) []byte {
+	t.Helper()
+
+	testBytes, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return testBytes
+}
+
+func TestSrvModule_handleGetPoolServiceRanks(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	for name, tc := range map[string]struct {
+		reqBytes []byte
+		testPool *system.PoolService
+		expResp  []byte
+		expErr   error
+	}{
+		"bad request bytes": {
+			reqBytes: []byte("bad bytes"),
+			expErr:   drpc.UnmarshalingPayloadFailure(),
+		},
+		"bad pool uuid in request": {
+			reqBytes: getTestBytes(t, &srvpb.GetPoolSvcReq{
+				Uuid: "bad-uuid",
+			}),
+			expErr: errors.New("invalid pool uuid"),
+		},
+		"not found": {
+			reqBytes: getTestBytes(t, &srvpb.GetPoolSvcReq{
+				Uuid: test.MockUUID(),
+			}),
+			expResp: getTestBytes(t, &srvpb.GetPoolSvcResp{
+				Status: int32(drpc.DaosNonexistant),
+			}),
+		},
+		"found, but not Ready": {
+			reqBytes: getTestBytes(t, &srvpb.GetPoolSvcReq{
+				Uuid: test.MockUUID(),
+			}),
+			testPool: &system.PoolService{
+				PoolUUID:  test.MockPoolUUID(),
+				PoolLabel: "testlabel",
+				State:     system.PoolServiceStateCreating,
+				Replicas:  []system.Rank{0, 1, 2},
+			},
+			expResp: getTestBytes(t, &srvpb.GetPoolSvcResp{
+				Status: int32(drpc.DaosNonexistant),
+			}),
+		},
+		"success": {
+			reqBytes: getTestBytes(t, &srvpb.GetPoolSvcReq{
+				Uuid: test.MockUUID(),
+			}),
+			testPool: &system.PoolService{
+				PoolUUID:  test.MockPoolUUID(),
+				PoolLabel: "testlabel",
+				State:     system.PoolServiceStateReady,
+				Replicas:  []system.Rank{0, 1, 2},
+			},
+			expResp: getTestBytes(t, &srvpb.GetPoolSvcResp{
+				Svcreps: []uint32{0, 1, 2},
+			}),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			db := system.MockDatabase(t, log)
+			mod := &srvModule{
+				log:   log,
+				sysdb: db,
+			}
+			if tc.testPool != nil {
+				lock, err := db.TakePoolLock(ctx, tc.testPool.PoolUUID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer lock.Release()
+				if err := db.AddPoolService(lock.InContext(ctx), tc.testPool); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			resp, err := mod.handleGetPoolServiceRanks(tc.reqBytes)
+			test.CmpErr(t, tc.expErr, err)
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expResp, resp); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestSrvModule_handlePoolFindByLabel(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	for name, tc := range map[string]struct {
+		reqBytes []byte
+		testPool *system.PoolService
+		expResp  []byte
+		expErr   error
+	}{
+		"bad request bytes": {
+			reqBytes: []byte("bad bytes"),
+			expErr:   drpc.UnmarshalingPayloadFailure(),
+		},
+		"not found": {
+			reqBytes: getTestBytes(t, &srvpb.PoolFindByLabelReq{
+				Label: "testlabel",
+			}),
+			expResp: getTestBytes(t, &srvpb.PoolFindByLabelResp{
+				Status: int32(drpc.DaosNonexistant),
+			}),
+		},
+		"found, but not Ready": {
+			reqBytes: getTestBytes(t, &srvpb.PoolFindByLabelReq{
+				Label: "testlabel",
+			}),
+			testPool: &system.PoolService{
+				PoolUUID:  test.MockPoolUUID(),
+				PoolLabel: "testlabel",
+				State:     system.PoolServiceStateCreating,
+				Replicas:  []system.Rank{0, 1, 2},
+			},
+			expResp: getTestBytes(t, &srvpb.PoolFindByLabelResp{
+				Status: int32(drpc.DaosNonexistant),
+			}),
+		},
+		"success": {
+			reqBytes: getTestBytes(t, &srvpb.PoolFindByLabelReq{
+				Label: "testlabel",
+			}),
+			testPool: &system.PoolService{
+				PoolUUID:  test.MockPoolUUID(),
+				PoolLabel: "testlabel",
+				State:     system.PoolServiceStateReady,
+				Replicas:  []system.Rank{0, 1, 2},
+			},
+			expResp: getTestBytes(t, &srvpb.PoolFindByLabelResp{
+				Uuid:    test.MockPoolUUID().String(),
+				Svcreps: []uint32{0, 1, 2},
+			}),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			db := system.MockDatabase(t, log)
+			mod := &srvModule{
+				log:   log,
+				sysdb: db,
+			}
+			if tc.testPool != nil {
+				lock, err := db.TakePoolLock(ctx, tc.testPool.PoolUUID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer lock.Release()
+				if err := db.AddPoolService(lock.InContext(ctx), tc.testPool); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			resp, err := mod.handlePoolFindByLabel(tc.reqBytes)
+			test.CmpErr(t, tc.expErr, err)
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expResp, resp); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
 }

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -271,7 +271,7 @@ func (svc *mgmtSvc) PoolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 		resp.Status = int32(drpc.DaosAlready)
 		if ps.State != system.PoolServiceStateReady {
 			resp.Status = int32(drpc.DaosTryAgain)
-			return resp, svc.checkPools(ctx, ps)
+			return resp, svc.checkPools(ctx, false, ps)
 		}
 		return resp, nil
 	}
@@ -473,7 +473,7 @@ func (svc *mgmtSvc) PoolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 // checkPools iterates over the list of pools in the system to check
 // for any that are in an unexpected state. Pools not in the Ready
 // state will be cleaned up and removed from the system.
-func (svc *mgmtSvc) checkPools(parent context.Context, psList ...*system.PoolService) error {
+func (svc *mgmtSvc) checkPools(parent context.Context, ignCreating bool, psList ...*system.PoolService) error {
 	if err := svc.sysdb.CheckLeader(); err != nil {
 		return err
 	}
@@ -491,11 +491,15 @@ func (svc *mgmtSvc) checkPools(parent context.Context, psList ...*system.PoolSer
 		if ps.State == system.PoolServiceStateReady {
 			continue
 		}
+		if ignCreating && ps.State == system.PoolServiceStateCreating {
+			svc.log.Noticef("pool %s in %s state but cleanup skipped due to ignore", ps.PoolUUID, ps.State)
+			continue
+		}
 
 		lock, err := svc.sysdb.TakePoolLock(parent, ps.PoolUUID)
 		if err != nil {
 			if fault.IsFaultCode(err, code.SystemPoolLocked) {
-				svc.log.Noticef("skipping cleanup on pool %s: %s", ps.PoolUUID, err)
+				svc.log.Noticef("pool %s not cleaned up due to err: %s", ps.PoolUUID, err)
 				continue
 			}
 			return err
@@ -512,7 +516,7 @@ func (svc *mgmtSvc) checkPools(parent context.Context, psList ...*system.PoolSer
 		if ps.State != system.PoolServiceStateDestroying {
 			ps.State = system.PoolServiceStateDestroying
 			if err := svc.sysdb.UpdatePoolService(ctx, ps); err != nil {
-				return errors.Wrapf(err, "failed to update pool %s", ps.PoolUUID)
+				return errors.Wrapf(err, "pool %s not updated", ps.PoolUUID)
 			}
 		}
 
@@ -526,7 +530,7 @@ func (svc *mgmtSvc) checkPools(parent context.Context, psList ...*system.PoolSer
 		if _, err := svc.PoolDestroy(ctx, dr); err != nil {
 			// Best effort cleanup. If the pool destroy fails here,
 			// another leadership step-up should get it eventually.
-			svc.log.Errorf("error while destroying pool %s: %s", ps.PoolUUID, err)
+			svc.log.Errorf("pool %s not destroyed: %s", ps.PoolUUID, err)
 		}
 	}
 

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2022 Intel Corporation.
+// (C) Copyright 2018-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -412,7 +412,7 @@ func (srv *server) registerEvents() {
 			return nil
 		},
 		func(ctx context.Context) error {
-			return srv.mgmtSvc.checkPools(ctx)
+			return srv.mgmtSvc.checkPools(ctx, true)
 		},
 	)
 	srv.sysdb.OnLeadershipLost(func() error {


### PR DESCRIPTION
When a MS leader steps up, it checks the list of pools for any
not found in a Ready state. With this change, a pool in the
Creating state will be ignored rather than destroyed, on the
theory that the create may be completing on the previous leader.

Update the pool svc RAS event handler to automatically set
a Creating pool to Ready, on the theory that the pool create
has most likely completed, given that it is sending us a
svc ranks update event.

Finally, modify dc_mgmt_pool_find() to retry on -DER_NONEXIST
errors which can result from stale MS replica reads.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
