### PR TITLE
DAOS-12039 test: Fix NVMe recovery tests

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -637,21 +637,6 @@ is_bbs_faulty(struct bio_blobstore *bbs)
 {
 	struct nvme_stats	*dev_stats = &bbs->bb_dev_health.bdh_health_state;
 
-	if (!glb_criteria.fc_enabled)
-		return false;
-
-	if (dev_stats->bio_read_errs + dev_stats->bio_write_errs > glb_criteria.fc_max_io_errs) {
-		D_ERROR("NVMe I/O errors %u/%u reached limit %u\n", dev_stats->bio_read_errs,
-			dev_stats->bio_write_errs, glb_criteria.fc_max_io_errs);
-		return true;
-	}
-
-	if (dev_stats->checksum_errs > glb_criteria.fc_max_csum_errs) {
-		D_ERROR("NVME csum errors %u reached limit %u\n", dev_stats->checksum_errs,
-			glb_criteria.fc_max_csum_errs);
-		return true;
-	}
-
 	/*
 	 * Used for DAOS NVMe Recovery Tests. Will trigger bs faulty reaction
 	 * only if the specified target is assigned to the device.
@@ -665,6 +650,21 @@ is_bbs_faulty(struct bio_blobstore *bbs)
 			if (bbs->bb_xs_ctxts[i]->bxc_tgt_id == tgtidx)
 				return true;
 		}
+	}
+
+	if (!glb_criteria.fc_enabled)
+		return false;
+
+	if (dev_stats->bio_read_errs + dev_stats->bio_write_errs > glb_criteria.fc_max_io_errs) {
+		D_ERROR("NVMe I/O errors %u/%u reached limit %u\n", dev_stats->bio_read_errs,
+			dev_stats->bio_write_errs, glb_criteria.fc_max_io_errs);
+		return true;
+	}
+
+	if (dev_stats->checksum_errs > glb_criteria.fc_max_csum_errs) {
+		D_ERROR("NVME csum errors %u reached limit %u\n", dev_stats->checksum_errs,
+			glb_criteria.fc_max_csum_errs);
+		return true;
 	}
 
 	return false;

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -675,9 +675,9 @@ nvme_test_simulate_IO_error(void **state)
 
 	/*
 	 * Read the data which will induce the READ Error and expected to fail
-	 * with DER_IO Error.
+	 * with DER_NVME_IO Error.
 	 */
-	arg->expect_result = -DER_IO;
+	arg->expect_result = -DER_NVME_IO;
 	lookup_single_with_rxnr(dkey, akey, /*idx*/0, fbuf,
 				OW_IOD_SIZE, size, DAOS_TX_NONE, &req);
 
@@ -689,7 +689,7 @@ nvme_test_simulate_IO_error(void **state)
 
 	/*
 	 * Insert the 4K record again which will induce WRITE Error and
-	 * expected to fail with DER_IO Error.
+	 * expected to fail with DER_NVME_IO Error.
 	 */
 	rx_nr = size / OW_IOD_SIZE;
 	insert_single_with_rxnr(dkey, akey, /*idx*/0, ow_buf, OW_IOD_SIZE,

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -689,9 +689,10 @@ nvme_test_simulate_IO_error(void **state)
 
 	/*
 	 * Insert the 4K record again which will induce WRITE Error and
-	 * expected to fail with DER_NVME_IO Error.
+	 * expected to fail with DER_IO Error.
 	 */
 	rx_nr = size / OW_IOD_SIZE;
+	arg->expect_result = -DER_IO;
 	insert_single_with_rxnr(dkey, akey, /*idx*/0, ow_buf, OW_IOD_SIZE,
 				rx_nr, DAOS_TX_NONE, &req);
 


### PR DESCRIPTION
NVMe recovery tests are currently timing out because automatic fault
detection is assumed to be active in the tests but is disabled by
default in the engine.

Fix by moving test specific faulty check to the beginning of
bio_monitor.c:is_bbs_faulty() so true is returned when fail loc has
been set (from daos_nvme_recovery.c) regardless of whether auto
detection is enabled or not.

Test-tag: daos_core_test_nvme
Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
