### PR TITLE
DAOS-10752 control: Fix flaky PoolCreate unit test

### DIFF
--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -608,7 +608,13 @@ func TestServer_MgmtSvc_PoolCreateDownRanks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if diff := cmp.Diff(wantReq, gotReq, test.DefaultCmpOpts()...); diff != "" {
+	cmpOpts := append(test.DefaultCmpOpts(),
+		// Ensure stable ordering of properties to avoid intermittent failures.
+		protocmp.SortRepeated(func(a, b *mgmtpb.PoolProperty) bool {
+			return a.Number < b.Number
+		}),
+	)
+	if diff := cmp.Diff(wantReq, gotReq, cmpOpts...); diff != "" {
 		t.Fatalf("unexpected pool create req (-want, +got):\n%s\n", diff)
 	}
 }


### PR DESCRIPTION
Add a sorter cmp option to ensure stable comparisons
between actual/expected PoolProperties.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
