### PR TITLE
DAOS-12425 control: Bring-up engines without server config file

### DIFF
--- a/src/control/cmd/daos_server/start.go
+++ b/src/control/cmd/daos_server/start.go
@@ -7,12 +7,15 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
+	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server"
 	"github.com/daos-stack/daos/src/control/server/config"
@@ -153,16 +156,67 @@ func (cmd *startCmd) configureLogging() error {
 	return applyLogConfig()
 }
 
+func (cmd *startCmd) fetchLocalConfig(ctx context.Context) (*config.Server, error) {
+	// TODO: Receive access points, provider and use-tmpfs-scm on commandline.
+	//       This can be done by embedding cmdutil.ConfGenerateCmd into startCmd.
+	cmd.Info("generating config to start server with")
+
+	hf, err := getLocalFabric(ctx, cmd.Logger, "") // Fetch all providers.
+	if err != nil {
+		return nil, err
+	}
+	cmd.Debugf("fetched host fabric info on localhost: %+v", hf)
+
+	hs, err := getLocalStorage(ctx, cmd.Logger, false) // Include NVMe-prep.
+	if err != nil {
+		return nil, err
+	}
+	cmd.Debugf("fetched host storage info on localhost: %+v", hs)
+
+	req := control.ConfGenerateReq{
+		Log: cmd.Logger,
+		// TODO: hardcode defaults for the moment until taken from commandline
+		NetClass:     hardware.Infiniband,
+		AccessPoints: []string{"localhost"},
+		// NetProvider:  cmd.NetProvider,
+		// AccessPoints: accessPoints,
+	}
+	if len(hs.ScmNamespaces) == 0 {
+		req.UseTmpfsSCM = true
+	}
+
+	cmd.Debugf("control API ConfGenerate called with req: %+v", req)
+
+	resp, err := control.ConfGenerate(req, control.DefaultEngineCfg, hf, hs)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd.Debugf("control API ConfGenerate resp: %+v", resp)
+	return &resp.Server, nil
+}
+
 func (cmd *startCmd) Execute(args []string) error {
 	if cmd.start == nil {
 		cmd.start = server.Start
 	}
 
+	if cmd.AutoFormat {
+		// TODO: pass context from here into start
+		ctx := context.TODO()
+		cfg, err := cmd.fetchLocalConfig(ctx)
+		if err != nil {
+			return errors.WithMessage(err, "starting with auto config")
+		}
+		cfg.AutoFormat = true
+		// TODO: hardcoded for the moment ???
+		cfg.TransportConfig.AllowInsecure = true
+		cmd.config = cfg
+	}
+
 	if err := cmd.configureLogging(); err != nil {
 		return err
 	}
-
-	cmd.config.AutoFormat = cmd.AutoFormat
 
 	return cmd.start(cmd.Logger, cmd.config)
 }

--- a/src/control/cmd/daos_server/start.go
+++ b/src/control/cmd/daos_server/start.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -27,13 +27,14 @@ type startCmd struct {
 	Port                uint16  `short:"p" long:"port" description:"Port for the gRPC management interfect to listen on"`
 	MountPath           string  `short:"s" long:"storage" description:"Storage path"`
 	Modules             *string `short:"m" long:"modules" description:"List of server modules to load"`
-	Targets             uint16  `short:"t" long:"targets" description:"number of targets to use (default use all cores)"`
-	NrXsHelpers         *uint16 `short:"x" long:"xshelpernr" description:"number of helper XS per VOS target"`
-	FirstCore           uint16  `short:"f" long:"firstcore" default:"0" description:"index of first core for service thread"`
+	Targets             uint16  `short:"t" long:"targets" description:"Number of targets to use (default use all cores)"`
+	NrXsHelpers         *uint16 `short:"x" long:"xshelpernr" description:"Number of helper XS per VOS target"`
+	FirstCore           uint16  `short:"f" long:"firstcore" default:"0" description:"Index of first core for service thread"`
 	Group               string  `short:"g" long:"group" description:"Server group name"`
 	SocketDir           string  `short:"d" long:"socket_dir" description:"Location for all daos_server & daos_engine sockets"`
-	Insecure            bool    `short:"i" long:"insecure" description:"allow for insecure connections"`
-	RecreateSuperblocks bool    `long:"recreate-superblocks" description:"recreate missing superblocks rather than failing"`
+	Insecure            bool    `short:"i" long:"insecure" description:"Allow for insecure connections"`
+	RecreateSuperblocks bool    `long:"recreate-superblocks" description:"Recreate missing superblocks rather than failing"`
+	Auto                bool    `long:"auto" description:"Automatically generate server config used to start service"`
 }
 
 func (cmd *startCmd) setCLIOverrides() error {
@@ -160,6 +161,8 @@ func (cmd *startCmd) Execute(args []string) error {
 	if err := cmd.configureLogging(); err != nil {
 		return err
 	}
+
+	cmd.config.AutoFormat = cmd.Auto
 
 	return cmd.start(cmd.Logger, cmd.config)
 }

--- a/src/control/cmd/daos_server/start.go
+++ b/src/control/cmd/daos_server/start.go
@@ -34,7 +34,7 @@ type startCmd struct {
 	SocketDir           string  `short:"d" long:"socket_dir" description:"Location for all daos_server & daos_engine sockets"`
 	Insecure            bool    `short:"i" long:"insecure" description:"Allow for insecure connections"`
 	RecreateSuperblocks bool    `long:"recreate-superblocks" description:"Recreate missing superblocks rather than failing"`
-	Auto                bool    `long:"auto" description:"Automatically generate server config used to start service"`
+	AutoFormat          bool    `long:"auto-format" description:"Automatically format storage on server start to bring-up engines without requiring dmg storage format command"`
 }
 
 func (cmd *startCmd) setCLIOverrides() error {
@@ -162,7 +162,7 @@ func (cmd *startCmd) Execute(args []string) error {
 		return err
 	}
 
-	cmd.config.AutoFormat = cmd.Auto
+	cmd.config.AutoFormat = cmd.AutoFormat
 
 	return cmd.start(cmd.Logger, cmd.config)
 }

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -78,6 +78,9 @@ type Server struct {
 
 	// Legacy config file parameters stored in a separate struct.
 	Legacy ServerLegacy `yaml:",inline"`
+
+	// Behavior flags
+	AutoFormat bool `yaml:"-"`
 }
 
 // WithCoreDumpFilter sets the core dump filter written to /proc/self/coredump_filter.

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -467,6 +467,14 @@ func (srv *server) start(ctx context.Context) error {
 	}()
 
 	srv.mgmtSvc.startAsyncLoops(ctx)
+
+	if srv.cfg.AutoFormat {
+		srv.log.Notice("--auto flag set on server start so formatting storage now")
+		if _, err := srv.ctlSvc.StorageFormat(ctx, &ctlpb.StorageFormatReq{}); err != nil {
+			return errors.WithMessage(err, "attempting to auto format")
+		}
+	}
+
 	return errors.Wrapf(srv.harness.Start(ctx, srv.sysdb, srv.cfg),
 		"%s harness exited", build.ControlPlaneName)
 }


### PR DESCRIPTION
Start engines automatically on server start without a user-supplied
server config file (essentially a zero config option).. Internally the
config generate control API is used to bootstrap the server and
engines based on local environment.

TODO:
Access-point addresses should be passed in as a commandline parameter
in addition to optional parameters such as provider and use-tmpfs-scm.

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
