### PR TITLE
DAOS-12012 cart: Segfault in OFI-RXM when using SPDK DAOS bdev module

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -195,7 +195,6 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 	if (ctx_idx < 0 || ctx_idx >= max_ctx_num) {
 		D_WARN("Provider: %d; Context limit (%d) reached\n",
 		       provider, max_ctx_num);
-		crt_provider_put_ctx_idx(provider, ctx_idx);
 		D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 		D_GOTO(out, rc = -DER_AGAIN);
 	}

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -540,19 +540,33 @@ crt_provider_get_max_ctx_num(int provider)
 }
 
 void
-crt_provider_inc_cur_ctx_num(int provider)
+crt_provider_put_ctx_idx(int provider, int idx)
 {
 	struct crt_prov_gdata *prov_data = crt_get_prov_gdata(provider);
 
-	prov_data->cpg_ctx_num++;
+	if (prov_data->cpg_used_idx[idx] == false) {
+		D_WARN("Put context on free idx=%d:%d\n", provider, idx);
+	} else {
+		prov_data->cpg_used_idx[idx] = false;
+		prov_data->cpg_ctx_num--;
+	}
 }
 
-void
-crt_provider_dec_cur_ctx_num(int provider)
+int
+crt_provider_get_ctx_idx(bool primary, int provider)
 {
-	struct crt_prov_gdata *prov_data = crt_get_prov_gdata(provider);
+	struct crt_prov_gdata	*prov_data = crt_get_prov_gdata(provider);
+	int			i;
 
-	prov_data->cpg_ctx_num--;
+	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
+		if (prov_data->cpg_used_idx[i] == false) {
+			prov_data->cpg_used_idx[i] = true;
+			prov_data->cpg_ctx_num++;
+			return i;
+		}
+	}
+
+	return -1;
 }
 
 d_list_t

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -553,7 +553,7 @@ crt_provider_put_ctx_idx(int provider, int idx)
 }
 
 int
-crt_provider_get_ctx_idx(bool primary, int provider)
+crt_provider_get_ctx_idx(int provider)
 {
 	struct crt_prov_gdata	*prov_data = crt_get_prov_gdata(provider);
 	int			i;

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -155,12 +155,13 @@ bool crt_provider_is_port_based(int provider);
 bool crt_provider_is_sep(int provider);
 void crt_provider_set_sep(int provider, bool enable);
 int crt_provider_get_cur_ctx_num(int provider);
-void crt_provider_inc_cur_ctx_num(int provider);
-void crt_provider_dec_cur_ctx_num(int provider);
 char *crt_provider_name_get(int provider);
 
 int crt_provider_get_max_ctx_num(int provider);
 d_list_t *crt_provider_get_ctx_list(int provider);
+
+int crt_provider_get_ctx_idx(int provider);
+void crt_provider_put_ctx_idx(int provider, int idx);
 
 static inline int
 crt_hgret_2_der(int hg_ret)

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -90,6 +90,8 @@ prov_data_init(struct crt_prov_gdata *prov_data, int provider,
 	       bool sep_mode, int max_ctx_num,
 	       uint32_t max_exp_size, uint32_t max_unexp_size)
 {
+	int i;
+
 	prov_data->cpg_inited = true;
 	prov_data->cpg_provider = provider;
 	prov_data->cpg_ctx_num = 0;
@@ -98,6 +100,9 @@ prov_data_init(struct crt_prov_gdata *prov_data, int provider,
 	prov_data->cpg_ctx_max_num = max_ctx_num;
 	prov_data->cpg_max_exp_size = max_exp_size;
 	prov_data->cpg_max_unexp_size = max_unexp_size;
+
+	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++)
+		prov_data->cpg_used_idx[i] = false;
 
 	D_DEBUG(DB_ALL, "Provider (%d), sep_mode (%d), sizes (%d/%d)\n",
 		provider, sep_mode, max_exp_size, max_unexp_size);

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -13,6 +13,11 @@
 
 #define CRT_CONTEXT_NULL         (NULL)
 
+#ifndef CRT_SRV_CONTEXT_NUM
+#define CRT_SRV_CONTEXT_NUM (64)	/* Maximum number of contexts */
+#endif
+
+
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 
@@ -48,6 +53,9 @@ struct crt_prov_gdata {
 	int			cpg_ctx_num;
 	/** maximum number of contexts user wants to create */
 	uint32_t		cpg_ctx_max_num;
+
+	/** free-list of indices */
+	bool			cpg_used_idx[CRT_SRV_CONTEXT_NUM];
 
 	/** Hints to mercury/ofi for max expected/unexp sizes */
 	uint32_t		cpg_max_exp_size;
@@ -128,10 +136,6 @@ struct crt_event_cb_priv {
 	crt_event_cb		 cecp_func;
 	void			*cecp_args;
 };
-
-#ifndef CRT_SRV_CONTEXT_NUM
-#define CRT_SRV_CONTEXT_NUM (64)	/* Maximum number of contexts */
-#endif
 
 #ifndef CRT_PROGRESS_NUM
 #define CRT_CALLBACKS_NUM		(4)	/* start number of CBs */

--- a/src/tests/ftest/cart/no_pmix_multi_ctx.c
+++ b/src/tests/ftest/cart/no_pmix_multi_ctx.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -27,6 +27,7 @@
 
 #define NUM_CTX 8
 #define NUM_RANKS 99
+#define NUM_CREATE_DESTROY 10
 
 static pthread_barrier_t	barrier1;
 static pthread_barrier_t	barrier2;
@@ -38,6 +39,16 @@ my_crtu_progress_fn(void *data)
 	crt_context_t	*p_ctx = (crt_context_t *)data;
 	void		*ret;
 	int		rc;
+	int		i;
+
+	/* Create and destroy context multiple times to test DAOS-12012 */
+	for (i = 0; i < NUM_CREATE_DESTROY; i++) {
+		rc = crt_context_create(p_ctx);
+		D_ASSERTF(rc == 0, "crt_context_create() failed; rc=%d\n", rc);
+
+		rc = crt_context_destroy(*p_ctx, false);
+		D_ASSERTF(rc == 0, "crt_context_destroy() failed; rc=%d\n", rc);
+	}
 
 	rc = crt_context_create(p_ctx);
 	D_ASSERTF(rc == 0, "crt_context_create() failed; rc=%d\n", rc);
@@ -48,7 +59,6 @@ my_crtu_progress_fn(void *data)
 	/* Only the first thread will do the sanity check */
 	if (p_ctx == &crt_ctx[0]) {
 		bool		ctx_id_present[NUM_CTX];
-		int		i;
 		int		idx;
 		char		*my_uri;
 		crt_group_t	*grp;


### PR DESCRIPTION
The crash happened due to bdev module using crt_context_create() and crt_context_destroy() in parallel from different threads, causing internal mess-up of context indices and associated tables.

- Introduce array of free indices for context ids and helper functions to get/put the index.
- Use free index instead of 'context number' as a context id.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
