### PR TITLE
DAOS-12417 security: Add ui.ACLPrincipalFlag type (#11258)

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -209,8 +209,8 @@ type containerCreateCmd struct {
 	Label       string               `long:"label" short:"l" description:"container label (deprecated: use positional arg)"`
 	Mode        ConsModeFlag         `long:"mode" short:"M" description:"DFS consistency mode"`
 	ACLFile     string               `long:"acl-file" short:"A" description:"input file containing ACL"`
-	User        string               `long:"user" short:"u" description:"user who will own the container (username@[domain])"`
-	Group       string               `long:"group" short:"g" description:"group who will own the container (group@[domain])"`
+	User        ui.ACLPrincipalFlag  `long:"user" short:"u" description:"user who will own the container (username@[domain])"`
+	Group       ui.ACLPrincipalFlag  `long:"group" short:"g" description:"group who will own the container (group@[domain])"`
 	Args        struct {
 		Label string `positional-arg-name:"<label>"`
 	} `positional-args:"yes"`
@@ -273,11 +273,11 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 	ap.c_op = C.CONT_CREATE
 
 	if cmd.User != "" {
-		ap.user = C.CString(cmd.User)
+		ap.user = C.CString(cmd.User.String())
 		defer freeString(ap.user)
 	}
 	if cmd.Group != "" {
-		ap.group = C.CString(cmd.Group)
+		ap.group = C.CString(cmd.Group.String())
 		defer freeString(ap.group)
 	}
 	if cmd.ACLFile != "" {

--- a/src/control/cmd/dmg/cont.go
+++ b/src/control/cmd/dmg/cont.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/ui"
 )
 
 // ContCmd is the struct representing the top-level container subcommand.
@@ -25,10 +26,10 @@ type ContSetOwnerCmd struct {
 	logCmd
 	ctlInvokerCmd
 	jsonOutputCmd
-	GroupName string `short:"g" long:"group" description:"New owner-group for the container, format name@domain"`
-	UserName  string `short:"u" long:"user" description:"New owner-user for the container, format name@domain"`
-	ContUUID  string `short:"c" long:"cont" required:"1" description:"UUID of the DAOS container"`
-	PoolUUID  string `short:"p" long:"pool" required:"1" description:"UUID of the DAOS pool for the container"`
+	GroupName ui.ACLPrincipalFlag `short:"g" long:"group" description:"New owner-group for the container, format name@domain"`
+	UserName  ui.ACLPrincipalFlag `short:"u" long:"user" description:"New owner-user for the container, format name@domain"`
+	ContUUID  string              `short:"c" long:"cont" required:"1" description:"UUID of the DAOS container"`
+	PoolUUID  string              `short:"p" long:"pool" required:"1" description:"UUID of the DAOS pool for the container"`
 }
 
 // Execute runs the container set-owner command
@@ -43,8 +44,8 @@ func (c *ContSetOwnerCmd) Execute(args []string) error {
 	req := &control.ContSetOwnerReq{
 		ContUUID: c.ContUUID,
 		PoolUUID: c.PoolUUID,
-		User:     c.UserName,
-		Group:    c.GroupName,
+		User:     c.UserName.String(),
+		Group:    c.GroupName.String(),
 	}
 
 	ctx := context.Background()

--- a/src/control/cmd/dmg/cont_test.go
+++ b/src/control/cmd/dmg/cont_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/control"
 )
@@ -69,6 +70,18 @@ func TestContSetOwnerCommand(t *testing.T) {
 				}),
 			}, " "),
 			nil,
+		},
+		{
+			"Bad owner principal",
+			fmt.Sprintf("cont set-owner --pool=%s --cont=%s --user=%s --group=%s",
+				testPoolUUID, testContUUID, "bad@@", testGroup),
+			"", errors.New("invalid ACL principal"),
+		},
+		{
+			"Bad group principal",
+			fmt.Sprintf("cont set-owner --pool=%s --cont=%s --user=%s --group=%s",
+				testPoolUUID, testContUUID, testUser, "bad@@"),
+			"", errors.New("invalid ACL principal"),
 		},
 	})
 }

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -51,18 +51,18 @@ type PoolCreateCmd struct {
 	cfgCmd
 	ctlInvokerCmd
 	jsonOutputCmd
-	GroupName     string           `short:"g" long:"group" description:"DAOS pool to be owned by given group, format name@domain"`
-	UserName      string           `short:"u" long:"user" description:"DAOS pool to be owned by given user, format name@domain"`
-	PoolLabelFlag string           `short:"p" long:"label" description:"Unique label for pool (deprecated, use positional argument)"`
-	Properties    PoolSetPropsFlag `short:"P" long:"properties" description:"Pool properties to be set"`
-	ACLFile       string           `short:"a" long:"acl-file" description:"Access Control List file path for DAOS pool"`
-	Size          string           `short:"z" long:"size" description:"Total size of DAOS pool or its percentage ratio (auto)"`
-	TierRatio     string           `short:"t" long:"tier-ratio" default:"6,94" description:"Percentage of storage tiers for pool storage (auto)"`
-	NumRanks      uint32           `short:"k" long:"nranks" description:"Number of ranks to use (auto)"`
-	NumSvcReps    uint32           `short:"v" long:"nsvc" description:"Number of pool service replicas"`
-	ScmSize       string           `short:"s" long:"scm-size" description:"Per-engine SCM allocation for DAOS pool (manual)"`
-	NVMeSize      string           `short:"n" long:"nvme-size" description:"Per-engine NVMe allocation for DAOS pool (manual)"`
-	RankList      string           `short:"r" long:"ranks" description:"Storage engine unique identifiers (ranks) for DAOS pool"`
+	GroupName     ui.ACLPrincipalFlag `short:"g" long:"group" description:"DAOS pool to be owned by given group, format name@domain"`
+	UserName      ui.ACLPrincipalFlag `short:"u" long:"user" description:"DAOS pool to be owned by given user, format name@domain"`
+	PoolLabelFlag string              `short:"p" long:"label" description:"Unique label for pool (deprecated, use positional argument)"`
+	Properties    PoolSetPropsFlag    `short:"P" long:"properties" description:"Pool properties to be set"`
+	ACLFile       string              `short:"a" long:"acl-file" description:"Access Control List file path for DAOS pool"`
+	Size          string              `short:"z" long:"size" description:"Total size of DAOS pool or its percentage ratio (auto)"`
+	TierRatio     string              `short:"t" long:"tier-ratio" default:"6,94" description:"Percentage of storage tiers for pool storage (auto)"`
+	NumRanks      uint32              `short:"k" long:"nranks" description:"Number of ranks to use (auto)"`
+	NumSvcReps    uint32              `short:"v" long:"nsvc" description:"Number of pool service replicas"`
+	ScmSize       string              `short:"s" long:"scm-size" description:"Per-engine SCM allocation for DAOS pool (manual)"`
+	NVMeSize      string              `short:"n" long:"nvme-size" description:"Per-engine NVMe allocation for DAOS pool (manual)"`
+	RankList      string              `short:"r" long:"ranks" description:"Storage engine unique identifiers (ranks) for DAOS pool"`
 
 	Args struct {
 		PoolLabel string `positional-arg-name:"<pool label>"`
@@ -98,8 +98,8 @@ func (cmd *PoolCreateCmd) Execute(args []string) error {
 
 	var err error
 	req := &control.PoolCreateReq{
-		User:       cmd.UserName,
-		UserGroup:  cmd.GroupName,
+		User:       cmd.UserName.String(),
+		UserGroup:  cmd.GroupName.String(),
 		NumSvcReps: cmd.NumSvcReps,
 		Properties: cmd.Properties.ToSet,
 	}

--- a/src/control/drpc/acl.go
+++ b/src/control/drpc/acl.go
@@ -1,0 +1,28 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package drpc
+
+import "unsafe"
+
+/*
+#include <stdlib.h>
+
+#include <daos_security.h>
+*/
+import "C"
+
+const (
+	// ACLPrincipalMaxLen is the maximum length of a principal string.
+	ACLPrincipalMaxLen = C.DAOS_ACL_MAX_PRINCIPAL_LEN
+)
+
+// ACLPrincipalIsValid returns true if the principal is valid.
+func ACLPrincipalIsValid(principal string) bool {
+	cPrincipal := C.CString(principal)
+	defer C.free(unsafe.Pointer(cPrincipal))
+	return bool(C.daos_acl_principal_is_valid(cPrincipal))
+}

--- a/src/control/lib/ui/acl.go
+++ b/src/control/lib/ui/acl.go
@@ -1,0 +1,38 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package ui
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/drpc"
+)
+
+// ACLPrincipalFlag is a flag that represents a DAOS ACL principal.
+type ACLPrincipalFlag string
+
+func (p ACLPrincipalFlag) String() string {
+	return string(p)
+}
+
+// UnmarshalFlag implements the go-flags.Unmarshaler interface.
+func (p *ACLPrincipalFlag) UnmarshalFlag(fv string) error {
+	pv := fv // Copy to avoid modifying the original string.
+	// If necessary, try adding a trailing '@' to the string
+	// in order to convert a bare user/group name to a principal.
+	if !strings.ContainsRune(pv, '@') {
+		pv += "@"
+	}
+	if !drpc.ACLPrincipalIsValid(pv) {
+		return errors.Errorf("invalid ACL principal %q", fv)
+	}
+
+	*p = ACLPrincipalFlag(pv)
+	return nil
+}

--- a/src/control/lib/ui/acl_test.go
+++ b/src/control/lib/ui/acl_test.go
@@ -1,0 +1,47 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package ui_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/lib/ui"
+)
+
+func TestUI_ACLPrincipalFlag(t *testing.T) {
+	var p ui.ACLPrincipalFlag
+	tooLong := strings.Repeat("a", drpc.ACLPrincipalMaxLen+1)
+
+	for _, tc := range []struct {
+		in     string
+		out    string
+		expErr error
+	}{
+		{"user", "user@", nil},
+		{"user@", "user@", nil},
+		{"user@domain", "user@domain", nil},
+		{"user@domain@", "", errors.New("invalid ACL principal \"user@domain@\"")},
+		{"@user", "", errors.New("invalid ACL principal \"@user\"")},
+		{"@", "", errors.New("invalid ACL principal \"@\"")},
+		{tooLong, "", errors.New("invalid ACL principal \"" + tooLong + "\"")},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			gotErr := p.UnmarshalFlag(tc.in)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+			if p.String() != tc.out {
+				t.Fatalf("got %q, want %q", p, tc.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Centralizes input handling for user/group principals, and
improves user-friendliness by automatically converting bare
names to principals as necessary.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
