### PR TITLE
DAOS-12440 tools: Add positional support for label on cont create

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -206,11 +206,14 @@ type containerCreateCmd struct {
 	ChunkSize   ChunkSizeFlag        `long:"chunk-size" short:"z" description:"container chunk size"`
 	ObjectClass ObjClassFlag         `long:"oclass" short:"o" description:"default object class"`
 	Properties  CreatePropertiesFlag `long:"properties" description:"container properties"`
-	Label       string               `long:"label" short:"l" description:"container label"`
+	Label       string               `long:"label" short:"l" description:"container label (deprecated: use positional arg)"`
 	Mode        ConsModeFlag         `long:"mode" short:"M" description:"DFS consistency mode"`
 	ACLFile     string               `long:"acl-file" short:"A" description:"input file containing ACL"`
 	User        string               `long:"user" short:"u" description:"user who will own the container (username@[domain])"`
 	Group       string               `long:"group" short:"g" description:"group who will own the container (group@[domain])"`
+	Args        struct {
+		Label string `positional-arg-name:"<label>"`
+	} `positional-args:"yes"`
 }
 
 func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
@@ -219,6 +222,28 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 		return err
 	}
 	defer deallocCmdArgs()
+
+	if cmd.Label != "" {
+		if cmd.Args.Label != "" {
+			return errors.New("can't use both --label and positional argument")
+		}
+		cmd.Args.Label = cmd.Label
+	}
+	if cmd.Args.Label != "" {
+		for key := range cmd.Properties.ParsedProps {
+			if key == "label" {
+				return errors.New("can't supply label arg and --properties label:")
+			}
+		}
+		if err := cmd.Properties.AddPropVal("label", cmd.Args.Label); err != nil {
+			return err
+		}
+		cmd.contLabel = cmd.Args.Label
+	}
+
+	if cmd.Properties.props != nil {
+		ap.props = cmd.Properties.props
+	}
 
 	if cmd.PoolID().Empty() {
 		if cmd.Path == "" {
@@ -258,22 +283,6 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 	if cmd.ACLFile != "" {
 		ap.aclfile = C.CString(cmd.ACLFile)
 		defer freeString(ap.aclfile)
-	}
-
-	if cmd.Label != "" {
-		for key := range cmd.Properties.ParsedProps {
-			if key == "label" {
-				return errors.New("can't use both --label and --properties label:")
-			}
-		}
-		if err := cmd.Properties.AddPropVal("label", cmd.Label); err != nil {
-			return err
-		}
-		cmd.contLabel = cmd.Label
-	}
-
-	if cmd.Properties.props != nil {
-		ap.props = cmd.Properties.props
 	}
 
 	ap._type = cmd.Type.Type
@@ -337,7 +346,7 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 		ci.PoolUUID = &cmd.poolUUID
 		ci.Type = cmd.Type.String()
 		ci.ContainerUUID = &cmd.contUUID
-		ci.ContainerLabel = cmd.Label
+		ci.ContainerLabel = cmd.Args.Label
 	}
 
 	if cmd.jsonOutputEnabled() {


### PR DESCRIPTION
This should have landed for 2.2.0, but better late than never.
Retains the existing --label flag but indicates deprecation in
2.4+.

Features: container

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
