### PR TITLE
DAOS-12290 control: Bdev class file should have 0600 perms (#11238)

### DIFF
--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -429,17 +429,7 @@ func (sb *spdkBackend) formatAioFile(req *storage.BdevFormatRequest) (*storage.B
 	}
 
 	for _, path := range req.Properties.DeviceList.Devices() {
-		devResp := new(storage.BdevDeviceFormatResponse)
-		resp.DeviceResponses[path] = devResp
-		if err := createEmptyFile(sb.log, path, req.Properties.DeviceFileSize); err != nil {
-			devResp.Error = FaultFormatError(path, err)
-			continue
-		}
-		if err := os.Chown(path, req.OwnerUID, req.OwnerGID); err != nil {
-			devResp.Error = FaultFormatError(path, errors.Wrapf(err,
-				"failed to set ownership of %q to %d.%d", path,
-				req.OwnerUID, req.OwnerGID))
-		}
+		resp.DeviceResponses[path] = createAioFile(sb.log, path, req)
 	}
 
 	return resp, nil

--- a/src/control/server/storage/bdev/backend_class.go
+++ b/src/control/server/storage/bdev/backend_class.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	// device block size hardcoded to 4096
-	aioBlockSize = humanize.KiByte * 4
+	aioBlockSize       = humanize.KiByte * 4 // device block size hardcoded to 4096 bytes
+	defaultAioFileMode = 0600                // AIO file permissions set to owner +rw
 )
 
 func createEmptyFile(log logging.Logger, path string, size uint64) error {
@@ -60,6 +60,34 @@ func createEmptyFile(log logging.Logger, path string, size uint64) error {
 	}
 
 	return nil
+}
+
+func createAioFile(log logging.Logger, path string, req *storage.BdevFormatRequest) (devResp *storage.BdevDeviceFormatResponse) {
+	devResp = new(storage.BdevDeviceFormatResponse)
+	defer func() {
+		if devResp.Error != nil {
+			os.Remove(path)
+		}
+	}()
+
+	if err := createEmptyFile(log, path, req.Properties.DeviceFileSize); err != nil {
+		devResp.Error = FaultFormatError(path, err)
+		return
+	}
+	if err := os.Chown(path, req.OwnerUID, req.OwnerGID); err != nil {
+		devResp.Error = FaultFormatError(path, errors.Wrapf(err,
+			"failed to set ownership of %q to %d.%d", path,
+			req.OwnerUID, req.OwnerGID))
+		return
+	}
+	if err := os.Chmod(path, defaultAioFileMode); err != nil {
+		devResp.Error = FaultFormatError(path, errors.Wrapf(err,
+			"failed to set file mode of %q to %s", path,
+			os.FileMode(defaultAioFileMode)))
+		return
+	}
+
+	return
 }
 
 func writeConfigFile(log logging.Logger, buf *bytes.Buffer, req *storage.BdevWriteConfigRequest) error {


### PR DESCRIPTION
Create AIO files for NVMe/SPDK emulation with 0600 perms. Remove the
created file if either the permissions or ownership change fails and
add unit test coverage

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
