### PR TITLE
DAOS-8938 tools: Fix --path handling for daos cont commands

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -386,54 +386,107 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 type existingContainerCmd struct {
 	containerBaseCmd
 
-	Path string `long:"path" short:"d" description:"unified namespace path"`
+	Path string `long:"path" short:"p" description:"unified namespace path"`
 	Args struct {
 		Container ContainerID `positional-arg-name:"container name or UUID" description:"required if --path is not used"`
 	} `positional-args:"yes"`
 }
 
-func (cmd *existingContainerCmd) ContainerID() ContainerID {
-	return cmd.Args.Container
+func (cmd *existingContainerCmd) ContainerID() ui.LabelOrUUIDFlag {
+	return cmd.Args.Container.LabelOrUUIDFlag
+}
+
+// parseContPathArgs is a gross hack to support the --path flag with positional
+// arguments. It's necessary because the positional arguments are parsed at the
+// same time as the flags, so we can't tell if the user is trying to use a path
+// with positional arguments (e.g. --path=/tmp/dfuse set-attr foo:bar) until after
+// the flags have been parsed. If --path was used, any consumed positional arguments
+// are appended in reverse order to the end of the args slice so that the command
+// handler (which must be aware of this convention) may parse them again. Otherwise,
+// the positional arguments are parsed as normal pool/container IDs.
+func (cmd *existingContainerCmd) parseContPathArgs(args []string) ([]string, error) {
+	if contArg := cmd.Args.Container.String(); contArg != "" {
+		if cmd.Path != "" {
+			args = append(args, contArg)
+			cmd.Args.Container.Clear()
+		} else {
+			if err := cmd.Args.Container.LabelOrUUIDFlag.UnmarshalFlag(contArg); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if poolArg := cmd.poolBaseCmd.Args.Pool.String(); poolArg != "" {
+		if cmd.Path != "" {
+			args = append(args, poolArg)
+			cmd.poolBaseCmd.Args.Pool.Clear()
+		} else {
+			if err := cmd.poolBaseCmd.Args.Pool.LabelOrUUIDFlag.UnmarshalFlag(poolArg); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return args, nil
+}
+
+func (cmd *existingContainerCmd) resolveContainerPath(ap *C.struct_cmd_args_s) (err error) {
+	if cmd.Path == "" {
+		return errors.New("path cannot be empty")
+	}
+	if ap == nil {
+		return errors.New("ap cannot be nil")
+	}
+
+	if err := resolveDunsPath(cmd.Path, ap); err != nil {
+		return err
+	}
+
+	cmd.poolBaseCmd.Args.Pool.UUID, err = uuidFromC(ap.p_uuid)
+	if err != nil {
+		return
+	}
+	cmd.poolBaseCmd.poolUUID = cmd.poolBaseCmd.Args.Pool.UUID
+	cmd.poolBaseCmd.Args.Pool.Label = C.GoString(&ap.pool_str[0])
+	if cmd.poolBaseCmd.Args.Pool.Label != "" {
+		cmd.poolBaseCmd.poolLabel = C.CString(cmd.poolBaseCmd.Args.Pool.Label)
+	}
+
+	cmd.Args.Container.UUID, err = uuidFromC(ap.c_uuid)
+	if err != nil {
+		return
+	}
+	cmd.contUUID = cmd.Args.Container.UUID
+	cmd.Args.Container.Label = C.GoString(&ap.cont_str[0])
+	if cmd.Args.Container.Label != "" {
+		cmd.contLabel = cmd.Args.Container.Label
+	}
+	cmd.Debugf("resolved %s into pool %s and container %s", cmd.Path, cmd.poolBaseCmd.Args.Pool, cmd.Args.Container)
+
+	return
 }
 
 func (cmd *existingContainerCmd) resolveContainer(ap *C.struct_cmd_args_s) (err error) {
-	switch {
-	case cmd.Path != "" && !(cmd.PoolID().Empty() && cmd.ContainerID().Empty()):
-		return errors.New("can't specify --path with pool ID or container ID")
-	case cmd.Path == "" && (cmd.PoolID().Empty() || cmd.ContainerID().Empty()):
-		return errors.New("pool and container ID must be specified if --path not used")
+	if cmd.Path != "" {
+		return cmd.resolveContainerPath(ap)
 	}
 
-	if cmd.Path != "" {
-		if ap == nil {
-			return errors.New("ap cannot be nil with --path")
+	switch {
+	case cmd.ContainerID().HasLabel():
+		cmd.contLabel = cmd.ContainerID().Label
+		if ap != nil {
+			cLabel := C.CString(cmd.ContainerID().Label)
+			defer freeString(cLabel)
+			C.strncpy(&ap.cont_str[0], cLabel, C.DAOS_PROP_LABEL_MAX_LEN)
 		}
-		if err = resolveDunsPath(cmd.Path, ap); err != nil {
-			return
+	case cmd.ContainerID().HasUUID():
+		cmd.contUUID = cmd.ContainerID().UUID
+		if ap != nil {
+			cUUIDstr := C.CString(cmd.contUUID.String())
+			defer freeString(cUUIDstr)
+			C.strncpy(&ap.cont_str[0], cUUIDstr, C.DAOS_PROP_LABEL_MAX_LEN)
 		}
-
-		cmd.poolBaseCmd.Args.Pool.Label = C.GoString(&ap.pool_str[0])
-		cmd.contLabel = C.GoString(&ap.cont_str[0])
-		cmd.contUUID = cmd.Args.Container.UUID
-	} else {
-		switch {
-		case cmd.ContainerID().HasLabel():
-			cmd.contLabel = cmd.ContainerID().Label
-			if ap != nil {
-				cLabel := C.CString(cmd.ContainerID().Label)
-				defer freeString(cLabel)
-				C.strncpy(&ap.cont_str[0], cLabel, C.DAOS_PROP_LABEL_MAX_LEN)
-			}
-		case cmd.ContainerID().HasUUID():
-			cmd.contUUID = cmd.ContainerID().UUID
-			if ap != nil {
-				cUUIDstr := C.CString(cmd.contUUID.String())
-				defer freeString(cUUIDstr)
-				C.strncpy(&ap.cont_str[0], cUUIDstr, C.DAOS_PROP_LABEL_MAX_LEN)
-			}
-		default:
-			return errors.New("no container label or UUID supplied")
-		}
+	default:
+		return errors.New("no container label or UUID supplied")
 	}
 
 	cmd.Debugf("pool ID: %s, container ID: %s", cmd.PoolID(), cmd.ContainerID())
@@ -1024,18 +1077,22 @@ func (cmd *containerDelAttrCmd) Execute(args []string) error {
 type containerGetAttrCmd struct {
 	existingContainerCmd
 
-	FlagAttr string `long:"attr" short:"a" description:"attribute name (deprecated; use positional argument)"`
+	FlagAttr string `long:"attr" short:"a" description:"single attribute name (deprecated; use positional argument)"`
 	Args     struct {
-		Attr string `positional-arg-name:"<attribute name>"`
+		Attrs ui.GetPropertiesFlag `positional-arg-name:"key[,key...]"`
 	} `positional-args:"yes"`
 }
 
 func (cmd *containerGetAttrCmd) Execute(args []string) error {
 	if cmd.FlagAttr != "" {
-		cmd.Args.Attr = cmd.FlagAttr
-	}
-	if cmd.Args.Attr == "" {
-		return errors.New("attribute name is required")
+		if len(cmd.Args.Attrs.ParsedProps) > 0 {
+			return errors.New("cannot specify both --attr and positional arguments")
+		}
+		cmd.Args.Attrs.ParsedProps.Add(cmd.FlagAttr)
+	} else if len(args) > 0 {
+		if err := cmd.Args.Attrs.UnmarshalFlag(args[len(args)-1]); err != nil {
+			return err
+		}
 	}
 
 	ap, deallocCmdArgs, err := allocCmdArgs(cmd.Logger)
@@ -1050,20 +1107,28 @@ func (cmd *containerGetAttrCmd) Execute(args []string) error {
 	}
 	defer cleanup()
 
-	attr, err := cmd.getAttr(cmd.Args.Attr)
+	var attrs attrList
+	if len(cmd.Args.Attrs.ParsedProps) == 0 {
+		attrs, err = listDaosAttributes(cmd.cContHandle, contAttr, true)
+	} else {
+		cmd.Debugf("getting attributes: %s", cmd.Args.Attrs.ParsedProps)
+		attrs, err = getDaosAttributes(cmd.cContHandle, contAttr, cmd.Args.Attrs.ParsedProps.ToSlice())
+	}
 	if err != nil {
-		return errors.Wrapf(err,
-			"failed to get attribute %q from container %s",
-			cmd.Args.Attr, cmd.ContainerID())
+		return errors.Wrapf(err, "failed to get attributes from container %s", cmd.ContainerID())
 	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(attr, nil)
+		// Maintain compatibility with older behavior.
+		if len(cmd.Args.Attrs.ParsedProps) == 1 && len(attrs) == 1 {
+			return cmd.outputJSON(attrs[0], nil)
+		}
+		return cmd.outputJSON(attrs, nil)
 	}
 
 	var bld strings.Builder
 	title := fmt.Sprintf("Attributes for container %s:", cmd.ContainerID())
-	printAttributes(&bld, title, attr)
+	printAttributes(&bld, title, attrs...)
 
 	cmd.Info(bld.String())
 
@@ -1076,24 +1141,28 @@ type containerSetAttrCmd struct {
 	FlagAttr  string `long:"attr" short:"a" description:"attribute name (deprecated; use positional argument)"`
 	FlagValue string `long:"value" short:"v" description:"attribute value (deprecated; use positional argument)"`
 	Args      struct {
-		Attr  string `positional-arg-name:"<attribute name>"`
-		Value string `positional-arg-name:"<attribute value>"`
+		Attrs ui.SetPropertiesFlag `positional-arg-name:"key:val[,key:val...]"`
 	} `positional-args:"yes"`
 }
 
 func (cmd *containerSetAttrCmd) Execute(args []string) error {
-	if cmd.FlagAttr != "" {
-		cmd.Args.Attr = cmd.FlagAttr
-	}
-	if cmd.FlagValue != "" {
-		cmd.Args.Value = cmd.FlagValue
+	if cmd.FlagAttr != "" || cmd.FlagValue != "" {
+		if cmd.FlagAttr == "" || cmd.FlagValue == "" {
+			return errors.New("both --attr and --value are required if either are used")
+		}
+		if len(cmd.Args.Attrs.ParsedProps) > 0 {
+			return errors.New("cannot specify both --attr and positional arguments")
+		}
+		cmd.Args.Attrs.ParsedProps = make(map[string]string)
+		cmd.Args.Attrs.ParsedProps[cmd.FlagAttr] = cmd.FlagValue
+	} else if len(args) > 0 {
+		if err := cmd.Args.Attrs.UnmarshalFlag(args[len(args)-1]); err != nil {
+			return err
+		}
 	}
 
-	if cmd.Args.Attr == "" {
-		return errors.New("attribute name is required")
-	}
-	if cmd.Args.Value == "" {
-		return errors.New("attribute value is required")
+	if len(cmd.Args.Attrs.ParsedProps) == 0 {
+		return errors.New("attribute name and value are required")
 	}
 
 	ap, deallocCmdArgs, err := allocCmdArgs(cmd.Logger)
@@ -1108,13 +1177,16 @@ func (cmd *containerSetAttrCmd) Execute(args []string) error {
 	}
 	defer cleanup()
 
-	if err := setDaosAttribute(cmd.cContHandle, contAttr, &attribute{
-		Name:  cmd.Args.Attr,
-		Value: []byte(cmd.Args.Value),
-	}); err != nil {
-		return errors.Wrapf(err,
-			"failed to set attribute %q on container %s",
-			cmd.Args.Attr, cmd.ContainerID())
+	attrs := make(attrList, 0, len(cmd.Args.Attrs.ParsedProps))
+	for key, val := range cmd.Args.Attrs.ParsedProps {
+		attrs = append(attrs, &attribute{
+			Name:  key,
+			Value: []byte(val),
+		})
+	}
+
+	if err := setDaosAttributes(cmd.cContHandle, contAttr, attrs); err != nil {
+		return errors.Wrapf(err, "failed to set attributes on container %s", cmd.ContainerID())
 	}
 
 	return nil
@@ -1123,10 +1195,31 @@ func (cmd *containerSetAttrCmd) Execute(args []string) error {
 type containerGetPropCmd struct {
 	existingContainerCmd
 
-	Properties GetPropertiesFlag `long:"properties" description:"container properties to get" default:"all"`
+	PropsFlag GetPropertiesFlag `long:"properties" description:"container properties to get (deprecated: use positional argument)"`
+	Args      struct {
+		Props GetPropertiesFlag `positional-arg-name:"key[,key...]"`
+	} `positional-args:"yes"`
 }
 
 func (cmd *containerGetPropCmd) Execute(args []string) error {
+	if len(args) > 0 {
+		if err := cmd.Args.Props.UnmarshalFlag(args[len(args)-1]); err != nil {
+			return err
+		}
+	}
+	if len(cmd.PropsFlag.names) > 0 {
+		if len(cmd.Args.Props.names) > 0 {
+			return errors.New("cannot specify both --properties and positional arguments")
+		}
+		cmd.Args.Props = cmd.PropsFlag
+	}
+	if len(cmd.Args.Props.names) == 0 {
+		// Ensure that things are set up correctly for the default case.
+		if err := cmd.Args.Props.UnmarshalFlag(""); err != nil {
+			return err
+		}
+	}
+
 	ap, deallocCmdArgs, err := allocCmdArgs(cmd.Logger)
 	if err != nil {
 		return err
@@ -1139,7 +1232,7 @@ func (cmd *containerGetPropCmd) Execute(args []string) error {
 	}
 	defer cleanup()
 
-	props, freeProps, err := getContainerProperties(cmd.cContHandle, cmd.Properties.names...)
+	props, freeProps, err := getContainerProperties(cmd.cContHandle, cmd.Args.Props.names...)
 	defer freeProps()
 	if err != nil {
 		return errors.Wrapf(err,
@@ -1147,7 +1240,7 @@ func (cmd *containerGetPropCmd) Execute(args []string) error {
 			cmd.ContainerID())
 	}
 
-	if len(cmd.Properties.names) == len(propHdlrs) {
+	if len(cmd.Args.Props.names) == len(propHdlrs) {
 		aclProps, cleanupAcl, err := getContAcl(cmd.cContHandle)
 		if err != nil && err != daos.NoPermission {
 			return errors.Wrapf(err,
@@ -1181,17 +1274,35 @@ func (cmd *containerGetPropCmd) Execute(args []string) error {
 type containerSetPropCmd struct {
 	existingContainerCmd
 
-	Properties SetPropertiesFlag `long:"properties" required:"1" description:"container properties to set"`
+	PropsFlag SetPropertiesFlag `long:"properties" description:"container properties to set (deprecated: use positional argument)"`
+	Args      struct {
+		Props SetPropertiesFlag `positional-arg-name:"key:val[,key:val...]"`
+	} `positional-args:"yes"`
 }
 
 func (cmd *containerSetPropCmd) Execute(args []string) error {
+	if len(args) > 0 {
+		if err := cmd.Args.Props.UnmarshalFlag(args[len(args)-1]); err != nil {
+			return err
+		}
+	}
+	if len(cmd.PropsFlag.ParsedProps) > 0 {
+		if len(cmd.Args.Props.ParsedProps) > 0 {
+			return errors.New("cannot specify both --properties and positional arguments")
+		}
+		cmd.Args.Props = cmd.PropsFlag
+	}
+	if len(cmd.Args.Props.ParsedProps) == 0 {
+		return errors.New("property name and value are required")
+	}
+
 	ap, deallocCmdArgs, err := allocCmdArgs(cmd.Logger)
 	if err != nil {
 		return err
 	}
 	defer deallocCmdArgs()
 
-	ap.props = cmd.Properties.props
+	ap.props = cmd.Args.Props.props
 
 	cleanup, err := cmd.resolveAndConnect(C.DAOS_COO_RW, ap)
 	if err != nil {
@@ -1244,7 +1355,7 @@ func parsePoolFlag() *poolFlagCmd {
 }
 
 type ContainerID struct {
-	ui.LabelOrUUIDFlag
+	argOrID
 }
 
 // Implement the completion handler to provide a list of container IDs
@@ -1290,8 +1401,8 @@ type containerLinkCmd struct {
 	} `positional-args:"yes"`
 }
 
-func (cmd *containerLinkCmd) ContainerID() ContainerID {
-	return cmd.Args.Container
+func (cmd *containerLinkCmd) ContainerID() ui.LabelOrUUIDFlag {
+	return cmd.Args.Container.LabelOrUUIDFlag
 }
 
 func (cmd *containerLinkCmd) Execute(_ []string) (err error) {

--- a/src/control/cmd/daos/container_test.go
+++ b/src/control/cmd/daos/container_test.go
@@ -1,0 +1,191 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+func TestDaos_existingContainerCmd_parseContPathArgs(t *testing.T) {
+	for name, tc := range map[string]struct {
+		inArgs   []string
+		contPath string
+		poolArg  string
+		contArg  string
+		expArgs  []string
+		expErr   error
+	}{
+		"no args": {},
+		"pool UUID only": {
+			poolArg: test.MockUUID(1),
+		},
+		"pool label only": {
+			poolArg: "pool1",
+		},
+		"cont UUID only": {
+			contArg: test.MockUUID(2),
+		},
+		"cont label only": {
+			contArg: "cont1",
+		},
+		"pool UUID + cont UUID": {
+			poolArg: test.MockUUID(1),
+			contArg: test.MockUUID(2),
+		},
+		"pool label + cont label": {
+			poolArg: "pool1",
+			contArg: "cont1",
+		},
+		"bad pool label + good cont label": {
+			poolArg: "pool1$bad",
+			contArg: "cont1",
+			expErr:  errors.New("invalid label"),
+		},
+		"good pool label + bad cont label": {
+			poolArg: "pool1",
+			contArg: "cont1#bad",
+			expErr:  errors.New("invalid label"),
+		},
+		"path + 1 arg": {
+			contPath: "/path/to/cont",
+			poolArg:  "foo:bar,baz:qux",
+			expArgs:  []string{"foo:bar,baz:qux"},
+		},
+		"path + 2 args": {
+			contPath: "/path/to/cont",
+			poolArg:  "foo:bar,baz:qux",
+			contArg:  "quux:quuz",
+			expArgs:  []string{"quux:quuz", "foo:bar,baz:qux"},
+		},
+		"inArgs + path + 1 arg": {
+			contPath: "/path/to/cont",
+			inArgs:   []string{"foo:bar,baz:qux"},
+			poolArg:  "cow:dog,quack:blam",
+			expArgs:  []string{"foo:bar,baz:qux", "cow:dog,quack:blam"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cmd := &existingContainerCmd{
+				Path: tc.contPath,
+			}
+			if poolUUID, err := uuid.Parse(tc.poolArg); err == nil {
+				cmd.poolBaseCmd.Args.Pool.UUID = poolUUID
+			} else if err := cmd.poolBaseCmd.Args.Pool.SetLabel(tc.poolArg); err != nil {
+				cmd.poolBaseCmd.Args.Pool.unparsedArg = tc.poolArg
+			}
+			if contUUID, err := uuid.Parse(tc.contArg); err == nil {
+				cmd.Args.Container.UUID = contUUID
+			} else if err := cmd.Args.Container.SetLabel(tc.contArg); err != nil {
+				cmd.Args.Container.unparsedArg = tc.contArg
+			}
+
+			got, err := cmd.parseContPathArgs(tc.inArgs)
+			test.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+			if diff := cmp.Diff(tc.expArgs, got); diff != "" {
+				t.Fatalf("unexpected args (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestDaos_existingContainerCmd_resolveContainer(t *testing.T) {
+	for name, tc := range map[string]struct {
+		contPath string
+		contType string
+		poolID   string
+		contID   string
+		expErr   error
+	}{
+		"no path, no pool, no cont": {
+			expErr: errors.New("no container label or UUID"),
+		},
+		"bad DUNS path (POSIX)": {
+			contType: "POSIX",
+			contPath: "bad-path",
+			expErr:   errors.New("DER_NONEXIST"),
+		},
+		"valid DUNS path (POSIX)": {
+			contType: "POSIX",
+			contPath: "valid-path",
+			poolID:   test.MockUUID(1),
+			contID:   test.MockUUID(2),
+		},
+		"pool UUID + cont UUID": {
+			poolID: test.MockUUID(1),
+			contID: test.MockUUID(2),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			cmd := &existingContainerCmd{
+				Path: tc.contPath,
+			}
+			cmd.SetLog(log)
+
+			if tc.contPath != "" && tc.contPath != "bad-path" {
+				path := filepath.Join(t.TempDir(), tc.contPath)
+				if tc.contType == "POSIX" {
+					if err := os.MkdirAll(path, 0755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				poolUUID, err := uuid.Parse(tc.poolID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				contUUID, err := uuid.Parse(tc.contID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := _writeDunsPath(path, tc.contType, poolUUID, contUUID); err != nil {
+					t.Fatal(err)
+				}
+				cmd.Path = path
+			} else {
+				if tc.poolID != "" {
+					gotErr := cmd.poolBaseCmd.Args.Pool.UnmarshalFlag(tc.poolID)
+					test.CmpErr(t, tc.expErr, gotErr)
+					if tc.expErr != nil {
+						return
+					}
+				}
+				if tc.contID != "" {
+					gotErr := cmd.Args.Container.UnmarshalFlag(tc.contID)
+					test.CmpErr(t, tc.expErr, gotErr)
+					if tc.expErr != nil {
+						return
+					}
+				}
+			}
+
+			ap, deallocCmdArgs, err := allocCmdArgs(cmd.Logger)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer deallocCmdArgs()
+
+			gotErr := cmd.resolveContainer(ap)
+			test.CmpErr(t, tc.expErr, gotErr)
+			test.AssertEqual(t, tc.poolID, cmd.poolBaseCmd.Args.Pool.String(), "PoolID")
+			test.AssertEqual(t, tc.contID, cmd.Args.Container.String(), "ContainerID")
+		})
+	}
+}

--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -118,6 +118,10 @@ func setupFSAttrCmd(cmd *fsAttrCmd) (*C.struct_cmd_args_s, func(), error) {
 		return nil, nil, err
 	}
 
+	if cmd.DfsPath == "" && cmd.Path == "" {
+		deallocCmdArgs()
+		return nil, nil, errors.New("If not using --path, --dfs-path must be specified along with pool/container IDs")
+	}
 	if cmd.DfsPath != "" {
 		if cmd.Path != "" {
 			deallocCmdArgs()

--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -187,6 +187,18 @@ or query/manage an object inside a container.`
 			}
 		}
 
+		// fixup args for commands that can use --path and
+		// positional arguments
+		if contPathCmd, ok := cmd.(interface {
+			parseContPathArgs([]string) ([]string, error)
+		}); ok {
+			var err error
+			args, err = contPathCmd.parseContPathArgs(args)
+			if err != nil {
+				return err
+			}
+		}
+
 		if err := cmd.Execute(args); err != nil {
 			return err
 		}

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -750,7 +750,7 @@ func propInvalidValue(e *C.struct_daos_prop_entry, name string) string {
 
 func propError(fs string, args ...interface{}) *flags.Error {
 	return &flags.Error{
-		Message: fmt.Sprintf("--properties: "+fs, args...),
+		Message: fmt.Sprintf("properties: "+fs, args...),
 	}
 }
 
@@ -1028,7 +1028,7 @@ func (f *GetPropertiesFlag) UnmarshalFlag(fv string) error {
 	// Accept a list of property names to fetch, if specified,
 	// otherwise just fetch all known properties.
 	f.names = strings.Split(fv, ",")
-	if len(f.names) == 0 || f.names[0] == "all" {
+	if fv == "" || len(f.names) == 0 || f.names[0] == "all" {
 		f.names = propHdlrs.keys()
 	}
 
@@ -1038,8 +1038,8 @@ func (f *GetPropertiesFlag) UnmarshalFlag(fv string) error {
 			return propError("name must not be empty")
 		}
 		if len(key) > maxNameLen {
-			return propError("name too long (%d > %d)",
-				len(name), maxNameLen)
+			return propError("%q: name too long (%d > %d)",
+				key, len(key), maxNameLen)
 		}
 		if newKey, found := contDeprProps[key]; found {
 			key = newKey
@@ -1140,7 +1140,7 @@ func printProperties(out io.Writer, header string, props ...*property) {
 	table := []txtfmt.TableRow{}
 	for _, prop := range props {
 		row := txtfmt.TableRow{}
-		row[nameTitle] = prop.Description
+		row[nameTitle] = fmt.Sprintf("%s (%s)", prop.Description, prop.Name)
 		if prop.String() != "" {
 			row[valueTitle] = prop.String()
 			if len(titles) == 1 {

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -280,3 +280,20 @@ func resolveDunsPath(path string, ap *C.struct_cmd_args_s) error {
 
 	return nil
 }
+
+// _writeDunsPath is a test helper for creating a DUNS EA on a path.
+func _writeDunsPath(path, ct string, poolUUID uuid.UUID, contUUID uuid.UUID) error {
+	attrStr := fmt.Sprintf(C.DUNS_XATTR_FMT, ct, poolUUID.String(), contUUID.String())
+
+	cPath := C.CString(path)
+	defer freeString(cPath)
+	cAttrStr := C.CString(attrStr)
+	defer freeString(cAttrStr)
+	cAttrName := C.CString(C.DUNS_XATTR_NAME)
+	defer freeString(cAttrName)
+	if err := dfsError(C.lsetxattr(cPath, cAttrName, unsafe.Pointer(cAttrStr), C.size_t(len(attrStr)+1), 0)); err != nil {
+		return errors.Wrapf(err, "failed to set xattr on %s", path)
+	}
+
+	return nil
+}

--- a/src/control/cmd/daos/util.h
+++ b/src/control/cmd/daos/util.h
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/xattr.h>
 #include <fcntl.h>
 #include <daos.h>
 #include <daos/common.h>

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -584,7 +584,7 @@ func TestPoolCommands(t *testing.T) {
 			"Set pool property missing value",
 			"pool set-prop 031bcaf8-f0f5-42ef-b3c5-ee048676dceb label:",
 			"",
-			errors.New("must not be empty"),
+			errors.New("invalid property"),
 		},
 		{
 			"Set pool property bad value",

--- a/src/control/lib/daos/constants.go
+++ b/src/control/lib/daos/constants.go
@@ -6,9 +6,17 @@
 
 package daos
 
+/*
+#include <daos_types.h>
+*/
+import "C"
+
 import "time"
 
 const (
 	// DefaultCartTimeout defines the default timeout for cart operations.
 	DefaultCartTimeout = 60 * time.Second // Should use CRT_DEFAULT_TIMEOUT_S but it's not exported
+
+	// MaxAttributeNameLength defines the maximum length of an attribute name.
+	MaxAttributeNameLength = C.DAOS_ATTR_NAME_MAX
 )

--- a/src/control/lib/ui/id_flags.go
+++ b/src/control/lib/ui/id_flags.go
@@ -25,6 +25,12 @@ type LabelOrUUIDFlag struct {
 	Label string    `json:"label"`
 }
 
+// Clear resets the flag to its zero value.
+func (f *LabelOrUUIDFlag) Clear() {
+	f.Label = ""
+	f.UUID = uuid.Nil
+}
+
 // Empty returns true if neither UUID or Label were set.
 func (f LabelOrUUIDFlag) Empty() bool {
 	return !f.HasLabel() && !f.HasUUID()

--- a/src/control/lib/ui/prop_flags_test.go
+++ b/src/control/lib/ui/prop_flags_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -27,7 +27,7 @@ func TestUI_SetPropertiesFlag_UnmarshalFlag(t *testing.T) {
 		expErr   error
 	}{
 		"empty": {
-			expErr: errors.New("invalid property"),
+			expErr: errors.New("empty property"),
 		},
 		"invalid property": {
 			settable: []string{"a", "b"},
@@ -35,20 +35,16 @@ func TestUI_SetPropertiesFlag_UnmarshalFlag(t *testing.T) {
 			expErr:   errors.New("not a settable property"),
 		},
 		"empty key": {
-			fv:     ":value",
+			fv:     " :value",
 			expErr: errors.New("must not be empty"),
 		},
 		"empty value": {
-			fv:     "key:",
+			fv:     "key: ",
 			expErr: errors.New("must not be empty"),
 		},
 		"key too long": {
 			fv:     strings.Repeat("x", ui.MaxPropKeyLen+1) + ":value",
 			expErr: errors.New("key too long"),
-		},
-		"value too long": {
-			fv:     "key:" + strings.Repeat("x", ui.MaxPropValLen+1),
-			expErr: errors.New("value too long"),
 		},
 		"valid properties": {
 			settable: []string{"a", "b"},
@@ -64,6 +60,30 @@ func TestUI_SetPropertiesFlag_UnmarshalFlag(t *testing.T) {
 			deprKeys: map[string]string{"e": "a"},
 			fv:       "e:b,b:d",
 			expProps: map[string]string{"a": "b", "b": "d"},
+		},
+		"avocado unescaped chars": {
+			fv:       `attr4:~@#$%^*-=_+[]{}/?.,~@#$%^*-=_+[]{}/?.:attr11`,
+			expProps: map[string]string{"attr4": `~@#$%^*-=_+[]{}/?.`, `~@#$%^*-=_+[]{}/?.`: "attr11"},
+		},
+		"avocado escaped chars": {
+			fv:       `attr5:&()\\;!<>\,\:,&()\\;!<>\,\::attr12`,
+			expProps: map[string]string{"attr5": `&()\\;!<>\,\:`, `&()\\;!<>\,\:`: "attr12"},
+		},
+		", in quotes": {
+			fv:       `a:"b,c",b:'d,e',c:"'f,g'",d:'"h,i"',"e,f":g`,
+			expProps: map[string]string{"a": `"b,c"`, "b": `'d,e'`, "c": `"'f,g'"`, "d": `'"h,i"'`, `"e,f"`: "g"},
+		},
+		": in quotes": {
+			fv:       `a:"b:c",b:'d:e',c:"'f:g'",d:'"h:i"',"e,f":g`,
+			expProps: map[string]string{"a": `"b:c"`, "b": `'d:e'`, "c": `"'f:g'"`, "d": `'"h:i"'`, `"e,f"`: "g"},
+		},
+		": escaped": {
+			fv:       `a:b\:c,b\\\:c:d`,
+			expProps: map[string]string{"a": `b\:c`, `b\\\:c`: "d"},
+		},
+		", escaped": {
+			fv:       `a:b\,c,b\\\,c:d`,
+			expProps: map[string]string{"a": `b\,c`, `b\\\,c`: "d"},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -84,6 +104,21 @@ func TestUI_SetPropertiesFlag_UnmarshalFlag(t *testing.T) {
 	}
 
 }
+
+/* NB: Doesn't work with go < 1.18
+func FuzzUI_SetPropertiesFlag_UnmarshalFlag(f *testing.F) {
+	f.Fuzz(func(t *testing.T, fv string) {
+		f := ui.SetPropertiesFlag{}
+
+		// Simple fuzzing; just make sure it doesn't panic on
+		// bad inputs.
+		gotErr := f.UnmarshalFlag(fv)
+		if gotErr != nil {
+			t.Log(gotErr)
+		}
+	})
+}
+*/
 
 func TestUI_SetPropertiesFlag_Complete(t *testing.T) {
 	comps := ui.CompletionMap{
@@ -210,9 +245,21 @@ func TestUI_GetPropertiesFlag_UnmarshalFlag(t *testing.T) {
 			fv:     strings.Repeat("x", ui.MaxPropKeyLen+1),
 			expErr: errors.New("key too long"),
 		},
-		"key contains property separator": {
+		"key is just a space": {
+			fv:     " ",
+			expErr: errors.New("must not be empty"),
+		},
+		"key contains unescaped property separator": {
 			fv:     "a:b",
 			expErr: errors.New("cannot contain"),
+		},
+		"key contains escaped property separator": {
+			fv:      `a\:b`,
+			expKeys: []string{`a\:b`},
+		},
+		"quoted properties with commas": {
+			fv:      `"a,b",c`,
+			expKeys: []string{`"a,b"`, `c`},
 		},
 		"valid properties": {
 			gettable: []string{"a", "b"},

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -163,6 +163,7 @@ DAOS_BASE=${DAOS_BASE:-${SL_SRC_DIR}}
 export PATH=$SL_PREFIX/bin:$PATH
 GO_TEST_XML="$DAOS_BASE/test_results/run_go_tests.xml"
 GO_TEST_RUNNER=$(get_test_runner)
+GO_TEST_EXTRA_ARGS=${*:-""}
 
 controldir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
 
@@ -182,7 +183,7 @@ set +e
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
 CGO_LDFLAGS="$CGO_LDFLAGS" \
 CGO_CFLAGS="$CGO_CFLAGS" \
-	$GO_TEST_RUNNER
+	$GO_TEST_RUNNER "$GO_TEST_EXTRA_ARGS"
 testrc=$?
 popd >/dev/null
 

--- a/src/tests/ftest/container/query_attribute.py
+++ b/src/tests/ftest/container/query_attribute.py
@@ -7,6 +7,31 @@ import base64
 from apricot import TestWithServers
 
 
+# Test container set-attr, get-attr, and list-attrs with different
+# types of characters.
+test_strings = [
+    "abcd",
+    "1234",
+    "abc123",
+    "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij",
+    # Characters that don't require backslash. The backslashes in here
+    # are required for the code to work, but not by daos.
+    "~@#$%^*-=_+[]\{\}/?.",  # noqa: W605
+    # Characters that require backslash.
+    "\`\&\(\)\\\;\!\<\>\\\\\\,\\\\\\:",  # noqa: W605
+    # Characters that include space.
+    "\"aa bb\""]
+# We added backslashes for the code to work, but get-attr output
+# does not contain them, so prepare the expected output that does not
+# include backslashes.
+escape_to_not = {}
+escape_to_not[test_strings[-3]] = '~@#$%^*-=_+[]{}/?.'
+# We still need a backslash before the double quote for the code to
+# work.
+escape_to_not[test_strings[-2]] = "`&()\;!<>\,\:"  # noqa: W605
+escape_to_not[test_strings[-1]] = "aa bb"
+
+
 class ContainerQueryAttributeTest(TestWithServers):
     # pylint: disable=anomalous-backslash-in-string
     """Test class for daos container query and attribute tests.
@@ -47,6 +72,7 @@ class ContainerQueryAttributeTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container
+        :avocado: tags=daos_cmd
         :avocado: tags=cont_query_attr,test_container_query_attr
         """
         # Create a pool and a container.
@@ -67,29 +93,6 @@ class ContainerQueryAttributeTest(TestWithServers):
         self.assertEqual(actual_pool_uuid, self.pool.uuid.lower())
         self.assertEqual(actual_cont_uuid, self.container.uuid.lower())
 
-        # Test container set-attr, get-attr, and list-attrs with different
-        # types of characters.
-        test_strings = [
-            "abcd",
-            "1234",
-            "abc123",
-            "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij",
-            # Characters that don't require backslash. The backslashes in here
-            # are required for the code to work, but not by daos.
-            "~@#$%^*-=_+[]\{\}:/?,.",  # noqa: W605
-            # Characters that require backslash.
-            "\`\&\(\)\\\;\\'\\\"\!\<\>",  # noqa: W605
-            # Characters that include space.
-            "\"aa bb\""]
-        # We added backslashes for the code to work, but get-attr output
-        # does not contain them, so prepare the expected output that does not
-        # include backslashes.
-        escape_to_not = {}
-        escape_to_not[test_strings[-3]] = "~@#$%^*-=_+[]{}:/?,."
-        # We still need a backslash before the double quote for the code to
-        # work.
-        escape_to_not[test_strings[-2]] = "`&()\;'\"!<>"  # noqa: W605
-        escape_to_not[test_strings[-1]] = "aa bb"
         # Prepare attr-value pairs. Use the test_strings in value for the first
         # 7 and in attr for the next 7.
         attr_values = []
@@ -147,6 +150,91 @@ class ContainerQueryAttributeTest(TestWithServers):
         self.log.debug(str(actual_attrs))
         self.assertEqual(actual_attrs, expected_attrs)
 
+    def test_container_query_attrs(self):
+        """JIRA ID: DAOS-4640
+
+        Test Description:
+            Test daos container query and attribute commands as described
+            above.
+
+        Use Cases:
+            Test container query, set-attr, get-attr with bulk inputs.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=container
+        :avocado: tags=daos_cmd
+        :avocado: tags=cont_query_attr,test_container_query_attrs
+        """
+        # Create a pool and a container.
+        self.add_pool()
+        self.add_container(pool=self.pool)
+
+        self.daos_cmd = self.get_daos_command()
+
+        # Call daos container query, obtain pool and container UUID, and
+        # compare against those used when creating the pool and the container.
+        kwargs = {
+            "pool": self.pool.uuid,
+            "cont": self.container.uuid
+        }
+        data = self.daos_cmd.container_query(**kwargs)['response']
+        actual_pool_uuid = data['pool_uuid']
+        actual_cont_uuid = data['container_uuid']
+        self.assertEqual(actual_pool_uuid, self.pool.uuid.lower())
+        self.assertEqual(actual_cont_uuid, self.container.uuid.lower())
+
+        # Prepare attr-value pairs. Use the test_strings in value for the first
+        # 7 and in attr for the next 7.
+        attr_values = {}
+        attr_idx = 0
+        for idx in range(2):
+            for test_string in test_strings:
+                if idx == 0:
+                    attr_values["attr" + str(attr_idx)] = test_string
+                else:
+                    attr_values[test_string] = "attr" + str(attr_idx)
+                attr_idx += 1
+
+        # Set and verify get-attr.
+        errors = []
+
+        # bulk-set all attributes
+        self.daos_cmd.container_set_attrs(
+            pool=actual_pool_uuid, cont=actual_cont_uuid,
+            attrs=attr_values)
+
+        attrs = []
+        for attr in attr_values:
+            attrs.append(attr)
+
+        # bulk-get all attributes
+        kwargs["attrs"] = attrs
+        data = self.daos_cmd.container_get_attrs(**kwargs)['response']
+
+        for attr_resp in data:
+            key = attr_resp["name"]
+            for k, v in escape_to_not.items():
+                if v == key:
+                    key = k
+                    break
+
+            actual_val = base64.b64decode(attr_resp["value"]).decode()
+            if attr_values[key] in escape_to_not:
+                # Special character string.
+                if actual_val != escape_to_not[attr_values[key]]:
+                    errors.append(
+                        "Unexpected output for get_attr: {} != {}\n".format(
+                            actual_val, escape_to_not[attr_values[key]]))
+            else:
+                # Standard character string.
+                if actual_val != attr_values[key]:
+                    errors.append(
+                        "Unexpected output for get_attr: {} != {}\n".format(
+                            actual_val, attr_values[key]))
+
+        self.assertEqual(len(errors), 0, "; ".join(errors))
+
     def test_list_attrs_long(self):
         """JIRA ID: DAOS-4640
 
@@ -159,6 +247,7 @@ class ContainerQueryAttributeTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container
+        :avocado: tags=daos_cmd
         :avocado: tags=cont_list_attrs,test_list_attrs_long
         """
         # Create a pool and a container.

--- a/src/tests/ftest/control/daos_snapshot.py
+++ b/src/tests/ftest/control/daos_snapshot.py
@@ -98,6 +98,7 @@ class DaosSnapshotTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=control,snap,snapshot
         :avocado: tags=daos_snapshot,test_create_list_delete
         """
@@ -131,6 +132,7 @@ class DaosSnapshotTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=container,snap,snapshot
         :avocado: tags=daos_snapshot_range,test_epcrange
         """

--- a/src/tests/ftest/control/dmg_pool_evict.py
+++ b/src/tests/ftest/control/dmg_pool_evict.py
@@ -32,6 +32,7 @@ class DmgPoolEvictTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=control
         :avocado: tags=dmg_pool_evict,test_dmg_pool_evict
         """

--- a/src/tests/ftest/control/dmg_telemetry_io_latency.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_latency.py
@@ -163,6 +163,7 @@ class TestWithTelemetryIOLatency(IorTestBase, TestWithTelemetry):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium,ib2
+        :avocado: tags=daos_cmd
         :avocado: tags=telemetry
         :avocado: tags=test_io_latency_telemetry,test_io_latency_telmetry_metrics
         """
@@ -335,6 +336,7 @@ class TestWithTelemetryIOLatency(IorTestBase, TestWithTelemetry):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium,ib2
+        :avocado: tags=daos_cmd
         :avocado: tags=telemetry,control
         :avocado: tags=test_ior_dtx_telemetry,test_ior_dtx_telemetry_metrics
         """

--- a/src/tests/ftest/control/version.py
+++ b/src/tests/ftest/control/version.py
@@ -23,6 +23,7 @@ class DAOSVersion(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=control
+        :avocado: tags=daos_cmd
         :avocado: tags=version_number,test_version
         """
         errors = []

--- a/src/tests/ftest/daos_test/dfuse.py
+++ b/src/tests/ftest/daos_test/dfuse.py
@@ -30,6 +30,7 @@ class DaosCoreTestDfuse(DfuseTestBase):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=dfuse,dfuse_test
         :avocado: tags=dfuse_unit,test_daos_dfuse_unit
         """
@@ -76,9 +77,8 @@ class DaosCoreTestDfuse(DfuseTestBase):
             self.fail('Invalid cache_mode: {}'.format(cache_mode))
 
         if use_dfuse:
-            for key, value in cont_attrs.items():
-                daos_cmd.container_set_attr(pool=self.pool.uuid, cont=self.container.uuid,
-                                            attr=key, val=value)
+            daos_cmd.container_set_attrs(pool=self.pool.uuid, cont=self.container.uuid,
+                                         attrs=cont_attrs)
 
             self.start_dfuse(self.hostlist_clients, self.pool, self.container)
 

--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -301,6 +301,7 @@ class DmvrDstCreate(DataMoverTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=datamover,daos_fs_copy,dfs,ior
         :avocado: tags=dm_dst_create,dm_dst_create_fs_copy_posix_dfs
         :avocado: tags=test_dm_dst_create_fs_copy_posix_dfs

--- a/src/tests/ftest/datamover/obj_small.py
+++ b/src/tests/ftest/datamover/obj_small.py
@@ -127,6 +127,7 @@ class DmvrObjSmallTest(DataMoverTestBase):
             DAOS-6858: Verify cloning a small container.
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=datamover,daos_cont_clone
         :avocado: tags=dm_obj_small,dm_obj_small_cont_clone,test_dm_obj_small_cont_clone
         """

--- a/src/tests/ftest/datamover/posix_preserve_props.py
+++ b/src/tests/ftest/datamover/posix_preserve_props.py
@@ -237,6 +237,7 @@ class DmvrPreserveProps(DataMoverTestBase):
 
         :avocado: tags=all,pr
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=datamover,daos_fs_copy,dfs,ior,hdf5
         :avocado: tags=dm_preserve_props,dm_preserve_props_fs_copy_posix_dfs
         :avocado: tags=test_dm_preserve_props_fs_copy_posix_dfs

--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -176,6 +176,7 @@ class DmvrPosixSubsets(DataMoverTestBase):
             DAOS-6752: daos fs copy improvements
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=datamover,daos_fs_copy,dfuse,dfs,ior
         :avocado: tags=dm_posix_subsets,dm_posix_subsets_fs_copy
         :avocado: tags=test_dm_posix_subsets_fs_copy

--- a/src/tests/ftest/datamover/posix_types.py
+++ b/src/tests/ftest/datamover/posix_types.py
@@ -220,6 +220,7 @@ class DmvrPosixTypesTest(DataMoverTestBase):
             DAOS-6233: add tests for daos filesystem copy
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=datamover,daos_fs_copy,dfuse,dfs,ior
         :avocado: tags=dm_posix_types,dm_posix_types_fs_copy,test_dm_posix_types_fs_copy
         """

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -29,6 +29,7 @@ class DaosBuild(DfuseTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,medium
         :avocado: tags=daosio,dfuse
+        :avocado: tags=daos_cmd
         :avocado: tags=DaosBuild,test_dfuse_daos_build_wb
         """
         self.run_build_test("writeback")
@@ -172,9 +173,8 @@ class DaosBuild(DfuseTestBase):
         else:
             self.fail('Invalid cache_mode: {}'.format(cache_mode))
 
-        for key, value in cont_attrs.items():
-            daos_cmd.container_set_attr(pool=self.pool.uuid, cont=self.container.uuid,
-                                        attr=key, val=value)
+        daos_cmd.container_set_attrs(pool=self.pool.uuid, cont=self.container.uuid,
+                                     attrs=cont_attrs)
 
         self.start_dfuse(self.hostlist_clients, self.pool, self.container)
 

--- a/src/tests/ftest/dfuse/mu_mount.py
+++ b/src/tests/ftest/dfuse/mu_mount.py
@@ -31,6 +31,7 @@ class DfuseMUMount(DfuseTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dfuse,dfuse_mu
+        :avocado: tags=daos_cmd
         :avocado: tags=DfuseMUMount,test_dfuse_mu_mount
         """
         # Create a pool and container for dfuse

--- a/src/tests/ftest/dfuse/mu_perms.py
+++ b/src/tests/ftest/dfuse/mu_perms.py
@@ -36,6 +36,7 @@ class DfuseMUPerms(DfuseTestBase):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dfuse,dfuse_mu,verify_perms
+        :avocado: tags=daos_cmd
         :avocado: tags=DfuseMUPerms,test_dfuse_mu_perms
         """
         # Use a single client for file/dir operations

--- a/src/tests/ftest/erasurecode/cell_size_property.py
+++ b/src/tests/ftest/erasurecode/cell_size_property.py
@@ -50,6 +50,7 @@ class EcodCellSizeProperty(IorTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large,ib2
+        :avocado: tags=daos_cmd
         :avocado: tags=ec,ec_ior
         :avocado: tags=ec_cell_property,test_ec_pool_property
         """

--- a/src/tests/ftest/nvme/pool_exclude.py
+++ b/src/tests/ftest/nvme/pool_exclude.py
@@ -121,6 +121,7 @@ class NvmePoolExclude(OSAUtils):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
+        :avocado: tags=daos_cmd
         :avocado: tags=nvme,checksum,nvme_osa
         :avocado: tags=NvmePoolExclude,test_nvme_pool_excluded
         """

--- a/src/tests/ftest/nvme/pool_extend.py
+++ b/src/tests/ftest/nvme/pool_extend.py
@@ -139,6 +139,7 @@ class NvmePoolExtend(OSAUtils):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
+        :avocado: tags=daos_cmd
         :avocado: tags=nvme,checksum,nvme_osa,rebuild
         :avocado: tags=NvmePoolExtend,test_nvme_pool_extend
         """

--- a/src/tests/ftest/pool/autotest.py
+++ b/src/tests/ftest/pool/autotest.py
@@ -19,6 +19,7 @@ class PoolAutotestTest(TestWithServers):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,medium,ib2
+        :avocado: tags=daos_cmd
         :avocado: tags=pool
         :avocado: tags=autotest,pool_autotest,quick,test_pool_autotest
         """

--- a/src/tests/ftest/pool/query_attribute.py
+++ b/src/tests/ftest/pool/query_attribute.py
@@ -39,6 +39,7 @@ class QueryAttributeTest(TestWithServers):
 
         :avocado: tags=all,full_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=pool,pool_query
         :avocado: tags=pool_query_attr,test_query_attr
         """

--- a/src/tests/ftest/rebuild/basic.py
+++ b/src/tests/ftest/rebuild/basic.py
@@ -120,6 +120,7 @@ class RbldBasic(TestWithServers):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=rebuild,pool,rebuild_tests
         :avocado: tags=RbldBasic,test_simple_rebuild
         """

--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -43,6 +43,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=security,container_acl
         :avocado: tags=cont_delete_acl_inputs,test_acl_delete_invalid_inputs
         """
@@ -72,6 +73,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container delete command successfully
             removes principal in ACL.
 
+        :avocado: tags=daos_cmd
         :avocado: tags=all,daily_regression,security,container_acl
         :avocado: tags=cont_delete_acl,test_delete_valid_acl
         """
@@ -93,6 +95,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container delete command doesn't
             remove principal in ACL without permission.
 
+        :avocado: tags=daos_cmd
         :avocado: tags=all,daily_regression,security,container_acl
         :avocado: tags=cont_delete_acl_noperms,test_no_user_permissions
         """

--- a/src/tests/ftest/security/cont_get_acl.py
+++ b/src/tests/ftest/security/cont_get_acl.py
@@ -39,6 +39,7 @@ class GetContainerACLTest(ContSecurityTestBase):
 
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=security,container_acl
         :avocado: tags=cont_get_acl_inputs,test_get_acl_valid
         """
@@ -85,6 +86,7 @@ class GetContainerACLTest(ContSecurityTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=security,container_acl
         :avocado: tags=cont_get_acl_noperms,test_no_user_permissions
         """

--- a/src/tests/ftest/security/cont_overwrite_acl.py
+++ b/src/tests/ftest/security/cont_overwrite_acl.py
@@ -43,6 +43,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=security,container_acl
         :avocado: tags=cont_overwrite_acl_inputs,test_acl_overwrite_invalid_inputs
         """
@@ -81,6 +82,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=security,container_acl
         :avocado: tags=cont_overwrite_acl_file,test_overwrite_invalid_acl_file
         """
@@ -117,6 +119,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container overwrite command performs as
             expected with valid ACL file provided.
 
+        :avocado: tags=daos_cmd
         :avocado: tags=all,daily_regression,security,container_acl
         :avocado: tags=cont_overwrite_acl_file,test_overwrite_valid_acl_file
         """
@@ -144,6 +147,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container overwrite command fails with
             no permission -1001 when user doesn't have the right permissions.
 
+        :avocado: tags=daos_cmd
         :avocado: tags=all,daily_regression,security,container_acl
         :avocado: tags=cont_overwrite_acl_noperms,test_no_user_permissions
         """

--- a/src/tests/ftest/security/cont_update_acl.py
+++ b/src/tests/ftest/security/cont_update_acl.py
@@ -40,6 +40,7 @@ class UpdateContainerACLTest(ContSecurityTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=security,container_acl
         :avocado: tags=cont_update_acl_inputs,test_acl_update_invalid_inputs
         """
@@ -88,6 +89,7 @@ class UpdateContainerACLTest(ContSecurityTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=security,container_acl
         :avocado: tags=cont_update_invalid_acl,test_update_invalid_acl
         """
@@ -127,6 +129,7 @@ class UpdateContainerACLTest(ContSecurityTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=security,container_acl
         :avocado: tags=cont_update_acl,test_update_acl_file
         """
@@ -180,6 +183,7 @@ class UpdateContainerACLTest(ContSecurityTestBase):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
+        :avocado: tags=daos_cmd
         :avocado: tags=security,container_acl
         :avocado: tags=cont_update_acl_noperms,test_no_user_permissions
         """

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -280,7 +280,7 @@ class DaosCommand(DaosCommandBase):
             ("container", "list"), pool=pool, sys_name=sys_name)
 
     def pool_set_attr(self, pool, attr, value, sys_name=None):
-        """Set pool attribute.
+        """Set single pool attribute.
 
         Args:
             pool (str): Pool UUID.
@@ -297,7 +297,28 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("pool", "set-attr"), pool=pool, attr=attr, value=value,
+            ("pool", "set-attr"), pool=pool, attr=':'.join([attr, value]),
+            sys_name=sys_name)
+
+    def pool_set_attrs(self, pool, attrs, sys_name=None):
+        """Set multiple pool attributes.
+
+        Args:
+            pool (str): Pool UUID.
+            attrs (map): Attribute name/value map.
+            sys_name (str): DAOS system name. Defaults to None.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the daos pool set-attr command fails.
+
+        """
+        attr_list = [':'.join([key, value]) for key, value in attrs.items()]
+        return self._get_result(
+            ("pool", "set-attr"), pool=pool, attr=','.join(attr_list),
             sys_name=sys_name)
 
     def pool_get_attr(self, pool, attr, sys_name=None):
@@ -358,7 +379,7 @@ class DaosCommand(DaosCommandBase):
             ("container", "query"), pool=pool, cont=cont, sys_name=sys_name)
 
     def container_set_prop(self, pool, cont, prop, value):
-        """Call daos container set-prop.
+        """Call daos container set-prop for a single property.
 
         Args:
             pool (str): Pool UUID.
@@ -378,6 +399,28 @@ class DaosCommand(DaosCommandBase):
         return self._get_result(
             ("container", "set-prop"),
             pool=pool, cont=cont, prop=prop_value)
+
+    def container_set_props(self, pool, cont, props, sys_name=None):
+        """Set multiple container properties.
+
+        Args:
+            pool (str): Pool UUID.
+            cont (str): Container UUID.
+            props (map): Property name/value pairs.
+            sys_name (str): DAOS system name. Defaults to None.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the daos pool set-attr command fails.
+
+        """
+        attr_list = [":".join([k, v]) for k, v in props.items()]
+        return self._get_result(
+            ("container", "set-prop"), pool=pool, cont=cont,
+            attr=','.join(attr_list), sys_name=sys_name)
 
     def container_get_prop(self, pool, cont, properties=None):
         """Call daos container get-prop.
@@ -543,7 +586,7 @@ class DaosCommand(DaosCommandBase):
 
     def container_set_attr(
             self, pool, cont, attr, val, sys_name=None):
-        """Call daos container set-attr.
+        """Call daos container set-attr for a single attribute.
 
         Args:
             pool (str): Pool UUID.
@@ -563,10 +606,32 @@ class DaosCommand(DaosCommandBase):
         """
         return self._get_result(
             ("container", "set-attr"), pool=pool, cont=cont,
-            sys_name=sys_name, attr=attr, value=val)
+            sys_name=sys_name, attr=':'.join([attr, val]))
+
+    def container_set_attrs(self, pool, cont, attrs, sys_name=None):
+        """Set multiple container attributes.
+
+        Args:
+            pool (str): Pool UUID.
+            cont (str): Container UUID.
+            attrs (map): Attribute key/val pairs.
+            sys_name (str): DAOS system name. Defaults to None.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the daos pool set-attr command fails.
+
+        """
+        attr_list = [':'.join([key, val]) for key, val in attrs.items()]
+        return self._get_result(
+            ("container", "set-attr"), pool=pool, cont=cont,
+            attr=','.join(attr_list), sys_name=sys_name)
 
     def container_get_attr(self, pool, cont, attr, sys_name=None):
-        """Call daos container get-attr.
+        """Call daos container get-attr for a single attribute.
 
         Args:
             pool (str): Pool UUID.
@@ -584,6 +649,27 @@ class DaosCommand(DaosCommandBase):
         """
         return self._get_json_result(
             ("container", "get-attr"), pool=pool, cont=cont, attr=attr, sys_name=sys_name)
+
+    def container_get_attrs(self, pool, cont, attrs, sys_name=None):
+        """Call daos container get-attr for multiple attributes.
+
+        Args:
+            pool (str): Pool UUID.
+            cont (str): Container UUID.
+            attrs (list): Attribute names.
+            sys_name (str, optional): DAOS system name context for servers.
+                Defaults to None.
+
+        Returns:
+            dict: the daos json command output converted to a python dictionary
+
+        Raises:
+            CommandFailure: if the daos get-attr command fails.
+
+        """
+        return self._get_json_result(
+            ("container", "get-attr"), pool=pool, cont=cont,
+            attr=','.join(attrs), sys_name=sys_name)
 
     def container_list_attrs(self, pool, cont, sys_name=None, verbose=False):
         """Call daos container list-attrs.

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -68,9 +68,8 @@ class DaosCommandBase(CommandWithSubCommand):
 
             Use BasicParameter for positional parameter subcommands. The
             value passed in defines the position. "pool" comes first, so it gets
-            1. Other subcommands get 2 or later. For example set-attr's attr and
-            value gets 2 and 3 because the order is "daos pool set-attr <attr>
-            <value>".
+            1. Other subcommands get 2 or later. For example set-attr's attr:value
+            gets 2 because the order is "daos pool set-attr <attr>:<value>".
             """
 
             def __init__(self, sub_command):
@@ -130,7 +129,6 @@ class DaosCommandBase(CommandWithSubCommand):
                 """Create a daos pool set-attr command object."""
                 super().__init__("set-attr")
                 self.attr = BasicParameter(None, position=2)
-                self.value = BasicParameter(None, position=3)
                 self.sys_name = FormattedParameter("--sys-name={}")
 
         class AutotestSubCommand(CommonPoolSubCommand):
@@ -360,7 +358,7 @@ class DaosCommandBase(CommandWithSubCommand):
             def __init__(self):
                 """Create a daos container get-prop command object."""
                 super().__init__("get-prop")
-                self.prop = FormattedParameter("--properties={}")
+                self.prop = BasicParameter(None, position=3)
 
         class ListSubCommand(CommandWithParameters):
             """Defines an object for the daos container list command."""
@@ -425,7 +423,6 @@ class DaosCommandBase(CommandWithSubCommand):
                 """Create a daos container set-attr command object."""
                 super().__init__("set-attr")
                 self.attr = BasicParameter(None, position=3)
-                self.value = BasicParameter(None, position=4)
 
         class SetOwnerSubCommand(CommonContainerSubCommand):
             """Defines an object for the daos container set-owner command."""
@@ -442,7 +439,7 @@ class DaosCommandBase(CommandWithSubCommand):
             def __init__(self):
                 """Create a daos container set-prop command object."""
                 super().__init__("set-prop")
-                self.prop = FormattedParameter("--properties={}")
+                self.prop = BasicParameter(None, position=3)
 
         class StatSubCommand(CommonContainerSubCommand):
             """Defines an object for the daos container stat command."""

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1733,29 +1733,29 @@ class PosixTests():
         run_daos_cmd(self.conf,
                      ['container', 'set-attr',
                       self.pool.id(), container,
-                      '--attr', 'dfuse-attr-time', '--value', '2'],
+                      'dfuse-attr-time:2'],
                      show_stdout=True)
 
         run_daos_cmd(self.conf,
                      ['container', 'set-attr',
                       self.pool.id(), container,
-                      '--attr', 'dfuse-dentry-time', '--value', '100s'],
+                      'dfuse-dentry-time:100s'],
                      show_stdout=True)
 
         run_daos_cmd(self.conf,
                      ['container', 'set-attr',
                       self.pool.id(), container,
-                      '--attr', 'dfuse-dentry-time-dir', '--value', '100s'],
+                      'dfuse-dentry-time-dir:100s'],
                      show_stdout=True)
 
         run_daos_cmd(self.conf,
                      ['container', 'set-attr',
                       self.pool.id(), container,
-                      '--attr', 'dfuse-ndentry-time', '--value', '100s'],
+                      'dfuse-ndentry-time:100s'],
                      show_stdout=True)
 
         run_daos_cmd(self.conf,
-                     ['container', 'list-attrs',
+                     ['container', 'get-attrs',
                       self.pool.id(), container],
                      show_stdout=True)
 
@@ -2785,7 +2785,7 @@ class PosixTests():
         run_daos_cmd(self.conf,
                      ['container', 'set-attr',
                       self.pool.id(), self.container,
-                      '--attr', 'dfuse-direct-io-disable', '--value', 'on'],
+                      'dfuse-direct-io-disable:on'],
                      show_stdout=True)
         dfuse = DFuse(self.server,
                       self.conf,
@@ -3623,7 +3623,7 @@ def run_in_fg(server, conf, args):
 
         for key, value in cont_attrs.items():
             run_daos_cmd(conf, ['container', 'set-attr', pool.label, container,
-                                '--attr', key, '--value', str(value)],
+                                f'{key}:{value}'],
                          show_stdout=True)
 
     dfuse = DFuse(server,
@@ -4482,12 +4482,12 @@ def test_fi_list_attr(server, conf, wf):
     run_daos_cmd(conf,
                  ['container', 'set-attr',
                   pool, container,
-                  '--attr', 'my-test-attr-1', '--value', 'some-value'])
+                  'my-test-attr-1:some-value'])
 
     run_daos_cmd(conf,
                  ['container', 'set-attr',
                   pool, container,
-                  '--attr', 'my-test-attr-2', '--value', 'some-other-value'])
+                  'my-test-attr-2:some-other-value'])
 
     cmd = [join(conf['PREFIX'], 'bin', 'daos'),
            'container',
@@ -4535,7 +4535,7 @@ def test_fi_get_attr(server, conf, wf):
     run_daos_cmd(conf,
                  ['container', 'set-attr',
                   pool, container,
-                  '--attr', attr_name, '--value', 'value'])
+                  f'{attr_name}:value'])
 
     cmd = [join(conf['PREFIX'], 'bin', 'daos'),
            'container',


### PR DESCRIPTION
As --path support was bolted on during the transition from
--pool/--cont flags to positional arguments, some regressions
crept in. This commit refactors things to centralize logic
and responsibility for consistent application of the argument
handling rules.

Also adds positional arg support for the (get|set)-(attrs|props)
subcommands for consistency with the dmg command surface.

Features: container
Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
