### PR TITLE
DAOS-9511 csum: Initial VOS scan counts corrupted values

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2022 Intel Corporation.
+ * (C) Copyright 2015-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1230,6 +1230,7 @@ struct cont_scrub {
 	void			*scs_cont_src;
 	daos_handle_t		 scs_cont_hdl;
 	uuid_t			 scs_cont_uuid;
+	bool			 scs_props_fetched;
 };
 
 /*
@@ -1322,7 +1323,9 @@ struct scrub_ctx {
 	void			*sc_sched_arg;
 
 	enum scrub_status	 sc_status;
-	bool			 sc_did_yield;
+	uint8_t			 sc_did_yield:1,
+				 sc_cont_loaded :1, /* Have all the containers been loaded */
+				 sc_first_pass_done:1; /* Is this the first pass of the scrubber */
 };
 
 /*

--- a/src/pool/srv_pool_scrub_ult.c
+++ b/src/pool/srv_pool_scrub_ult.c
@@ -82,6 +82,7 @@ cont_lookup_cb(uuid_t pool_uuid, uuid_t cont_uuid, void *arg,
 	cont->scs_cont_hdl = cont_child->sc_hdl;
 	uuid_copy(cont->scs_cont_uuid, cont_uuid);
 	cont->scs_cont_src = cont_child;
+	cont->scs_props_fetched = cont_child->sc_props_fetched;
 
 	ABT_mutex_lock(cont_child->sc_mutex);
 	cont_child->sc_scrubbing = 1;
@@ -328,7 +329,7 @@ scrubbing_ult(void *arg)
 
 	sc_add_pool_metrics(&ctx);
 	while (!dss_ult_exiting(child->spc_scrubbing_req)) {
-		uint32_t sleep_time = 5000;
+		uint32_t sleep_time = 1000;
 
 		rc = vos_scrub_pool(&ctx);
 		if (rc == -DER_SHUTDOWN) {

--- a/src/vos/tests/pool_scrubbing_tests.c
+++ b/src/vos/tests/pool_scrubbing_tests.c
@@ -422,22 +422,19 @@ sts_ctx_update(struct sts_context *ctx, int oid_lo, int iod_type,
 		((char *)sgl.sg_iovs[0].iov_buf)[idx_to_corrupt] += 2;
 
 		/* confirm corruption */
-		rc = daos_csummer_verify_iod(ctx->tsc_csummer, &iod, &sgl,
-					     iod_csum, NULL, 0, NULL);
+		rc = daos_csummer_verify_iod(ctx->tsc_csummer, &iod, &sgl, iod_csum, NULL, 0, NULL);
 		assert_csum_error(rc);
 	}
 
 	iov_alloc_str(&dkey, dkey_str);
-	rc = vos_obj_update(ctx->tsc_coh, oid, epoch, 0, 0, &dkey, 1, &iod,
-			    iod_csum, &sgl);
+	rc = vos_obj_update(ctx->tsc_coh, oid, epoch, 0, 0, &dkey, 1, &iod, iod_csum, &sgl);
 	assert_success(rc);
 
 	/**
 	 * make sure can fetch right after update. Even if data was corrupted,
 	 * it should still fetch fine
 	 */
-	rc = sts_ctx_fetch(ctx, oid_lo, iod_type,
-			   dkey_str, akey_str, epoch);
+	rc = sts_ctx_fetch(ctx, oid_lo, iod_type, dkey_str, akey_str, epoch);
 	assert_success(rc);
 
 	daos_csummer_free_ic(ctx->tsc_csummer, &iod_csum);
@@ -499,6 +496,7 @@ sts_ctx_setup_scrub_ctx(struct sts_context *ctx)
 	ctx->tsc_scrub_ctx.sc_drain_pool_tgt_fn = fake_target_drain;
 	ctx->tsc_scrub_ctx.sc_pool = &ctx->tsc_pool;
 	ctx->tsc_scrub_ctx.sc_dmi = &ctx->tsc_dmi;
+	ctx->tsc_scrub_ctx.sc_cont.scs_props_fetched = true;
 }
 
 static void
@@ -508,8 +506,7 @@ sts_ctx_do_scrub(struct sts_context *ctx)
 
 	clear_ctx(&ctx->tsc_scrub_ctx);
 
-	assert_rc_equal(ctx->tsc_expected_rc,
-			vos_scrub_pool(&ctx->tsc_scrub_ctx));
+	assert_rc_equal(ctx->tsc_expected_rc, vos_scrub_pool(&ctx->tsc_scrub_ctx));
 }
 
 /**

--- a/src/vos/vos_pool_scrub.c
+++ b/src/vos/vos_pool_scrub.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2020-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -302,6 +302,12 @@ sc_is_nvme(struct scrub_ctx *ctx)
 	return bio_iov2media(ctx->sc_cur_biov) == DAOS_MEDIA_NVME;
 }
 
+static bool
+sc_is_first_pass(struct scrub_ctx *ctx)
+{
+	return !ctx->sc_first_pass_done;
+}
+
 static int
 sc_handle_corruption(struct scrub_ctx *ctx)
 {
@@ -480,6 +486,11 @@ sc_verify_obj_value(struct scrub_ctx *ctx, struct bio_iov *biov, daos_handle_t i
 
 	if (BIO_ADDR_IS_CORRUPTED(&biov->bi_addr)) {
 		/* Already know this is corrupt so just return */
+		if (sc_is_first_pass(ctx))
+			/* Because metrics aren't persisted across engine resets,
+			 * need to count the number of corrupted records found previously
+			 */
+			d_tm_inc_counter(ctx->sc_metrics.scm_corruption_total, 1);
 		D_GOTO(out, rc = DER_SUCCESS);
 	} else if (rc != 0) {
 		D_WARN("Unable to fetch data for scrubber: "DF_RC"\n", DP_RC(rc));
@@ -745,8 +756,7 @@ cont_iter_scrub_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		rc = sc_cont_setup(ctx, entry);
 		if (rc != 0) {
 			/* log error for container, but then keep going */
-			D_ERROR("Unable to setup the container. "DF_RC"\n",
-				DP_RC(rc));
+			D_ERROR("Unable to setup the container. "DF_RC"\n", DP_RC(rc));
 			return 0;
 		}
 
@@ -792,6 +802,72 @@ sc_pool_stop(struct scrub_ctx *ctx)
 	ctx->sc_status = SCRUB_STATUS_NOT_RUNNING;
 }
 
+/* structure for the cont_iter_is_loaded_cb args */
+struct cont_are_loaded_args {
+	struct scrub_ctx	*args_ctx;
+	bool			 args_found_unloaded_container;
+};
+
+/** vos_iter_cb_t */
+static int
+cont_iter_is_loaded_cb(daos_handle_t ih, vos_iter_entry_t *entry,
+		       vos_iter_type_t type, vos_iter_param_t *param,
+		       void *cb_arg, unsigned int *acts)
+{
+	struct cont_are_loaded_args	*args = cb_arg;
+	struct scrub_ctx		*ctx  = args->args_ctx;
+	int				 rc = 0;
+
+	D_ASSERT(type == VOS_ITER_COUUID);
+
+	rc = sc_cont_setup(ctx, entry);
+	if (rc != 0)
+		return rc;
+	if (sc_cont_is_stopping(ctx))
+		return 0;
+
+	/*
+	 * Is loaded when the properties have been fetched. That way the csummer has been
+	 * initialized if csums are enabled
+	 */
+	if (!args->args_found_unloaded_container)
+		args->args_found_unloaded_container = !args->args_ctx->sc_cont.scs_props_fetched;
+
+	sc_cont_teardown(ctx);
+	return 0;
+}
+
+/*
+ * When the scrubber starts, make sure all containers are loaded. Using the "props_fetched" field
+ * from the ds_cont_child which indicates that the csummer has been initialized if checksums are
+ * enabled.
+ */
+static int
+sc_ensure_containers_are_loaded(struct scrub_ctx *ctx)
+{
+	vos_iter_param_t	param = {0};
+	struct cont_are_loaded_args args = {0};
+	int			rc = 0;
+
+	if (ctx->sc_cont_loaded)
+		return 0;
+
+	args.args_ctx = ctx;
+	param.ip_hdl = ctx->sc_vos_pool_hdl;
+	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	do {
+		struct vos_iter_anchors	anchors = {0};
+
+		args.args_found_unloaded_container = false;
+		rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchors, NULL,
+				 cont_iter_is_loaded_cb, &args, NULL);
+		sc_sleep(ctx, 500);
+	} while (args.args_found_unloaded_container || rc != 0);
+	ctx->sc_cont_loaded = true;
+
+	return rc;
+}
+
 int
 vos_scrub_pool(struct scrub_ctx *ctx)
 {
@@ -808,6 +884,12 @@ vos_scrub_pool(struct scrub_ctx *ctx)
 	if (!sc_should_start(ctx))
 		return 0;
 
+	rc = sc_ensure_containers_are_loaded(ctx);
+	if (rc != 0) {
+		D_ERROR("Error ensuring containers are loaded: "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+
 	sc_pool_start(ctx);
 
 	param.ip_hdl = ctx->sc_vos_pool_hdl;
@@ -818,6 +900,9 @@ vos_scrub_pool(struct scrub_ctx *ctx)
 	sc_pool_stop(ctx);
 	if (rc == SCRUB_POOL_OFF)
 		return 0;
+
+	if (sc_is_first_pass(ctx))
+		ctx->sc_first_pass_done = true;
 
 	return rc;
 }


### PR DESCRIPTION
Because telemetry metrics aren't persisted across system reboots, the first time the scrubber runs, it should increment the corrupted counter for any already marked corrupted values.

When the scrubber first starts, the containers' csummer might not have initialized yet, so a check was added to make sure all containers' csummers are loaded if csums are enabled. Really it looks at if the sc_cont_child's properties have been fetched. If so then the csummer should have been initialized.

Reduced the forced sleep_time between vos_scrub_pool calls because 1 second is the minimum frequency.

Required-githooks: true

Features: scrubbing checksum

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
