### PR TITLE
DAOS-12366 control: Limit reference sharing when updating bdev stats

### DIFF
--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -171,22 +171,6 @@ func (cs *ControlService) getScmUsage(ssr *storage.ScmScanResponse) (*storage.Sc
 	return &storage.ScmScanResponse{Namespaces: nss}, nil
 }
 
-// mapCtrlrs maps each controller to it's PCI address.
-func mapCtrlrs(ctrlrs storage.NvmeControllers) (map[string]*storage.NvmeController, error) {
-	ctrlrMap := make(map[string]*storage.NvmeController)
-
-	for _, ctrlr := range ctrlrs {
-		if _, exists := ctrlrMap[ctrlr.PciAddr]; exists {
-			return nil, errors.Errorf("duplicate entries for controller %s",
-				ctrlr.PciAddr)
-		}
-
-		ctrlrMap[ctrlr.PciAddr] = ctrlr
-	}
-
-	return ctrlrMap, nil
-}
-
 // scanAssignedBdevs retrieves up-to-date NVMe controller info including
 // health statistics and stored server meta-data. If I/O Engines are running
 // then query is issued over dRPC as go-spdk bindings cannot be used to access
@@ -194,7 +178,7 @@ func mapCtrlrs(ctrlrs storage.NvmeControllers) (map[string]*storage.NvmeControll
 // assigned to I/O Engines.
 func (cs *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) (*storage.BdevScanResponse, error) {
 	instances := cs.harness.Instances()
-	ctrlrs := storage.NvmeControllers{}
+	ctrlrs := new(storage.NvmeControllers)
 
 	for _, ei := range instances {
 		if !ei.GetStorage().HasBlockDevices() {
@@ -206,32 +190,35 @@ func (cs *ControlService) scanAssignedBdevs(ctx context.Context, statsReq bool) 
 			return nil, err
 		}
 
-		// If the engine is not running or we aren't interested in temporal
-		// statistics for the bdev devices then continue to next.
-		if !ei.IsReady() || !statsReq {
-			for _, tsr := range tsrs {
-				ctrlrs = ctrlrs.Update(tsr.Result.Controllers...)
+		// Build slice of controllers in all tiers.
+		tierCtrlrs := make([]storage.NvmeController, 0)
+		for _, tsr := range tsrs {
+			for _, c := range tsr.Result.Controllers {
+				tierCtrlrs = append(tierCtrlrs, *c)
 			}
+		}
+
+		// If the engine is not running or we aren't interested in temporal
+		// statistics for the bdev devices then continue to next engine.
+		if !ei.IsReady() || !statsReq {
+			ctrlrs.Update(tierCtrlrs...)
 			continue
 		}
+
+		cs.log.Debugf("updating stats for %d bdev(s) on instance %d", len(tierCtrlrs),
+			ei.Index())
 
 		// If engine is running and has claimed the assigned devices for
 		// each tier, iterate over scan results for each tier and send query
 		// over drpc to update controller details with current health stats
 		// and smd info.
-		for _, tsr := range tsrs {
-			ctrlrMap, err := mapCtrlrs(tsr.Result.Controllers)
-			if err != nil {
-				return nil, errors.Wrap(err, "create controller map")
-			}
-
-			if err := ei.updateInUseBdevs(ctx, ctrlrMap); err != nil {
-				return nil, err
-			}
-
-			ctrlrs = ctrlrs.Update(tsr.Result.Controllers...)
+		updatedCtrlrs, err := ei.updateInUseBdevs(ctx, tierCtrlrs)
+		if err != nil {
+			return nil, errors.Wrapf(err, "instance %d: update online bdevs", ei.Index())
 		}
+
+		ctrlrs.Update(updatedCtrlrs...)
 	}
 
-	return &storage.BdevScanResponse{Controllers: ctrlrs}, nil
+	return &storage.BdevScanResponse{Controllers: *ctrlrs}, nil
 }

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -343,11 +343,8 @@ func TestServer_CtlSvc_StorageScan_PreEngineStart(t *testing.T) {
 			}
 			sCfg := config.DefaultServer().WithEngines(engineCfgs...)
 
-			cs := mockControlService(t, log, sCfg, tc.bmbc, tc.smbc, nil)
-			for _, ei := range cs.harness.instances {
-				// tests are for pre-engine-start scenario
-				ei.(*EngineInstance).ready.SetFalse()
-			}
+			// tests are for pre-engine-start scenario so pass notStarted: true
+			cs := mockControlService(t, log, sCfg, tc.bmbc, tc.smbc, nil, true)
 
 			if tc.req == nil {
 				tc.req = &ctlpb.StorageScanReq{

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -36,7 +36,7 @@ type Engine interface {
 	newCret(string, error) *ctlpb.NvmeControllerResult
 	tryDrpc(context.Context, drpc.Method) *system.MemberResult
 	requestStart(context.Context)
-	updateInUseBdevs(context.Context, map[string]*storage.NvmeController) error
+	updateInUseBdevs(context.Context, []storage.NvmeController) ([]storage.NvmeController, error)
 	isAwaitingFormat() bool
 
 	// These methods should probably be replaced by callbacks.

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -218,33 +218,28 @@ func (ei *EngineInstance) getSmdDetails(smd *ctlpb.SmdDevice) (*storage.SmdDevic
 	return smdDev, nil
 }
 
-func updateCtrlrHealth(pbStats *ctlpb.BioHealthResp, ctrlr *storage.NvmeController) error {
-	ctrlr.HealthStats = new(storage.NvmeHealth)
-	if err := convert.Types(pbStats, ctrlr.HealthStats); err != nil {
-		return errors.Wrap(err, "convert health stats")
-	}
-
-	return nil
-}
-
 // updateInUseBdevs updates-in-place the input list of controllers with new NVMe health stats and
 // SMD metadata info.
 //
 // Query each SmdDevice on each I/O Engine instance for health stats and update existing controller
 // data in ctrlrMap using PCI address key.
-func (ei *EngineInstance) updateInUseBdevs(ctx context.Context, ctrlrMap map[string]*storage.NvmeController) (err error) {
-	defer func() {
-		err = errors.Wrapf(err, "instance %d", ei.Index())
-	}()
+func (ei *EngineInstance) updateInUseBdevs(ctx context.Context, ctrlrs []storage.NvmeController) ([]storage.NvmeController, error) {
+	ctrlrMap := make(map[string]*storage.NvmeController)
+	for idx, ctrlr := range ctrlrs {
+		if _, exists := ctrlrMap[ctrlr.PciAddr]; exists {
+			return nil, errors.Errorf("duplicate entries for controller %s",
+				ctrlr.PciAddr)
+		}
 
-	// Clear SMD info for controllers in ctrlrMap, populate smd info from scratch.
-	for _, ctrlr := range ctrlrMap {
-		ctrlr.SmdDevices = []*storage.SmdDevice{}
+		// Clear SMD info for controllers to remove stale stats.
+		ctrlrs[idx].SmdDevices = []*storage.SmdDevice{}
+		// Update controllers in input slice through map by reference.
+		ctrlrMap[ctrlr.PciAddr] = &ctrlrs[idx]
 	}
 
 	smdDevs, err := ei.ListSmdDevices(ctx, new(ctlpb.SmdDevReq))
 	if err != nil {
-		return errors.Wrapf(err, "list smd devices")
+		return nil, errors.Wrapf(err, "list smd devices")
 	}
 	ei.log.Debugf("engine %d: smdDevs %+v", ei.Index(), smdDevs)
 
@@ -261,7 +256,7 @@ func (ei *EngineInstance) updateInUseBdevs(ctx context.Context, ctrlrMap map[str
 
 		smdDev, err := ei.getSmdDetails(smd)
 		if err != nil {
-			return errors.Wrapf(err, "%s: collect smd info", msg)
+			return nil, errors.Wrapf(err, "%s: collect smd info", msg)
 		}
 
 		pbStats, err := ei.GetBioHealth(ctx, &ctlpb.BioHealthReq{DevUuid: smdDev.UUID})
@@ -293,15 +288,14 @@ func (ei *EngineInstance) updateInUseBdevs(ctx context.Context, ctrlrMap map[str
 		if hasUpdatedHealth[ctrlr.PciAddr] {
 			continue
 		}
-
-		if err := updateCtrlrHealth(pbStats, ctrlr); err != nil {
-			ei.log.Errorf("%s: update ctrlr health: %s", err.Error())
+		ctrlr.HealthStats = new(storage.NvmeHealth)
+		if err := convert.Types(pbStats, ctrlr.HealthStats); err != nil {
+			ei.log.Errorf("%s: update ctrlr health: %s", msg, err.Error())
 			continue
 		}
-		hasUpdatedHealth[ctrlr.PciAddr] = true
-
 		ei.log.Debugf("%s: ctrlr health updated", msg)
+		hasUpdatedHealth[ctrlr.PciAddr] = true
 	}
 
-	return nil
+	return ctrlrs, nil
 }

--- a/src/control/server/instance_test.go
+++ b/src/control/server/instance_test.go
@@ -278,8 +278,8 @@ func (mi *MockInstance) tryDrpc(_ context.Context, _ drpc.Method) *system.Member
 
 func (mi *MockInstance) requestStart(_ context.Context) {}
 
-func (mi *MockInstance) updateInUseBdevs(_ context.Context, _ map[string]*storage.NvmeController) error {
-	return nil
+func (mi *MockInstance) updateInUseBdevs(_ context.Context, _ []storage.NvmeController) ([]storage.NvmeController, error) {
+	return []storage.NvmeController{}, nil
 }
 
 func (mi *MockInstance) isAwaitingFormat() bool {

--- a/src/control/server/storage/bdev_test.go
+++ b/src/control/server/storage/bdev_test.go
@@ -128,6 +128,24 @@ func Test_Convert_SmdDevice(t *testing.T) {
 	}
 }
 
+func Test_NvmeController_Update(t *testing.T) {
+	mockCtrlrs := MockNvmeControllers(5)
+
+	// Verify in-place update.
+	test.AssertEqual(t, mockCtrlrs[1].SmdDevices[0].UUID, test.MockUUID(1), "unexpected uuid")
+	c1 := MockNvmeController(1)
+	c1.SmdDevices[0].UUID = test.MockUUID(10)
+	mockCtrlrs.Update(*c1)
+	test.AssertEqual(t, len(mockCtrlrs), 5, "expected 5")
+	test.AssertEqual(t, mockCtrlrs[1].SmdDevices[0].UUID, test.MockUUID(10), "unexpected uuid")
+
+	// Verify multiple new controllers are added.
+	c2 := MockNvmeController(6)
+	c3 := MockNvmeController(9)
+	mockCtrlrs.Update(*c2, *c3)
+	test.AssertEqual(t, len(mockCtrlrs), 7, "expected 7")
+}
+
 func Test_filterBdevScanResponse(t *testing.T) {
 	const (
 		vmdAddr1         = "0000:5d:05.5"


### PR DESCRIPTION
The data race was made possible because of sharing object references
too liberally. Close the gap by reducing the scope of reference
sharing when updating in-use bdev stats.

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
