### PR TITLE
DAOS-12241 test: Moving io/large_file_count.py back to large cluster

### DIFF
--- a/src/tests/ftest/io/large_file_count.py
+++ b/src/tests/ftest/io/large_file_count.py
@@ -24,7 +24,7 @@ class LargeFileCount(FileCountTestBase):
             Run MDTEST to create 1M files with DFS and POSIX
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=hw,large
         :avocado: tags=io,daosio,dfuse
         :avocado: tags=LargeFileCount,test_largefilecount
         """

--- a/src/tests/ftest/io/large_file_count.yaml
+++ b/src/tests/ftest/io/large_file_count.yaml
@@ -1,6 +1,6 @@
 hosts:
-  test_servers: 3
-  test_clients: 1
+  test_servers: 5
+  test_clients: 3
 timeout: 5000
 server_config:
   name: daos_server


### PR DESCRIPTION
io/large_file_count.py is consistently failing since moved to medium cluster. Reason being, test timeouts while running mdtest as the workload is handled by a single client now compared to 3 client nodes previously. Reducing the workload to accommodate the test on medium cluster will defeat the purpose of the test. Hence, moving back to large cluster.

Quick-Functional: true
Test-repeat: 10
Test-tag: test_largefilecount

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>