### PR TITLE
DAOS-11390 control: Refine filesystem detection

### DIFF
--- a/src/control/cmd/daos_server_helper/handler.go
+++ b/src/control/cmd/daos_server_helper/handler.go
@@ -91,7 +91,9 @@ func (h *metadataFormatHandler) Handle(log logging.Logger, req *pbin.Request) *p
 	case "MetadataNeedsFormat":
 		var result bool
 		result, err = h.mdProvider.NeedsFormat(mReq)
-		resp = pbin.NewResponseWithPayload(&result)
+		if err == nil {
+			resp = pbin.NewResponseWithPayload(&result)
+		}
 	}
 	if err != nil {
 		return pbin.NewResponseWithError(err)

--- a/src/control/provider/system/mocks.go
+++ b/src/control/provider/system/mocks.go
@@ -44,7 +44,7 @@ type (
 		SourceToTarget  map[string]string
 		GetfsIndex      int
 		GetfsUsageResps []GetfsUsageRetval
-		GetFsTypeStr    string
+		GetFsTypeRes    *FsType
 		GetFsTypeErr    []error
 		StatErrors      map[string]error
 		RealStat        bool
@@ -162,20 +162,20 @@ func (msp *MockSysProvider) GetfsUsage(_ string) (uint64, uint64, error) {
 	return resp.Total, resp.Avail, resp.Err
 }
 
-func (msp *MockSysProvider) GetFsType(path string) (string, error) {
+func (msp *MockSysProvider) GetFsType(path string) (*FsType, error) {
 	idx := msp.GetFsTypeCount
 	msp.GetFsTypeCount++
 	var err error
-	var str string
+	var result *FsType
 	if idx < len(msp.cfg.GetFsTypeErr) {
 		err = msp.cfg.GetFsTypeErr[idx]
 	}
 
 	if err == nil {
-		str = msp.cfg.GetFsTypeStr
+		result = msp.cfg.GetFsTypeRes
 	}
 
-	return str, err
+	return result, err
 }
 
 func (msp *MockSysProvider) Stat(path string) (os.FileInfo, error) {

--- a/src/control/server/storage/metadata/faults.go
+++ b/src/control/server/storage/metadata/faults.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
+	"github.com/daos-stack/daos/src/control/provider/system"
 )
 
 var (
@@ -23,11 +24,16 @@ var (
 
 // FaultBadFilesystem is an error that can occur if the control metadata path points at a
 // filesystem that cannot be used.
-func FaultBadFilesystem(fs string) *fault.Fault {
+func FaultBadFilesystem(fs *system.FsType) *fault.Fault {
+	noSUIDStr := ""
+	if fs.NoSUID {
+		noSUIDStr = " with nosuid set"
+	}
+
 	return metadataFault(
 		code.ControlMetadataBadFilesystem,
-		fmt.Sprintf("%q is not a usable filesystem for the control metadata storage directory", fs),
-		"Configure the control_metadata path to a directory that is not on a networked filesystem",
+		fmt.Sprintf("%q%s is not usable for the control metadata storage directory", fs.Name, noSUIDStr),
+		"Configure the control_metadata path to a directory that is not on a networked or nosuid filesystem",
 	)
 }
 

--- a/src/control/server/storage/mount/provider.go
+++ b/src/control/server/storage/mount/provider.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	defaultMountPointPerms = 0755
+	defaultMountPointPerms = 0750
 	defaultUnmountFlags    = 0
 )
 

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -162,7 +162,7 @@ func (p *Provider) MountControlMetadata() error {
 	return err
 }
 
-// ControlMetadataIsMounted determines whether the control metadata storage is a;ready mounted.
+// ControlMetadataIsMounted determines whether the control metadata storage is already mounted.
 func (p *Provider) ControlMetadataIsMounted() (bool, error) {
 	if p == nil {
 		return false, errors.New("nil provider")

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -374,7 +374,7 @@ func (p *Provider) formatDcpm(req storage.ScmFormatRequest) (*storage.ScmFormatR
 		// since we don't use xattr
 		"-I", "128",
 		// reduce the inode per bytes ratio
-		// one inode for 64M is more than enough
+		// one inode for 64MiB is more than enough
 		"-i", "67108864",
 	}
 	opts = append(opts, getDistroArgs()...)


### PR DESCRIPTION
- Detect common non-distributed Linux filesystems. NFS is still disallowed for control metadata. Other unrecognized filesystems log an error to allow for easier debugging in the event that the user encounters issues with distributed filesystems.
- Clean up minor issues and typos.

Features: control
Required-githooks: true

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
