### PR TITLE
DAOS-12319 test: invoke ior with clush not orterun

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -1,12 +1,11 @@
 """
-  (C) Copyright 2019-2022 Intel Corporation.
+  (C) Copyright 2019-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import shutil
-from tempfile import mkdtemp
 import traceback
 import uuid
+import time
 
 from avocado.core.exceptions import TestFail
 
@@ -17,13 +16,12 @@ from job_manager_utils import get_job_manager
 from thread_manager import ThreadManager
 
 
-def run_ior_loop(manager, uuids, tmpdir_base):
+def run_ior_loop(manager, uuids):
     """IOR run for each UUID provided.
 
     Args:
         manager (str): mpi job manager command
         uuids (list): list of container UUIDs
-        tmpdir_base (str): base directory for the mpi orte_tmpdir_base mca parameter
 
     Returns:
         list: a list of CmdResults from each ior command run
@@ -34,9 +32,7 @@ def run_ior_loop(manager, uuids, tmpdir_base):
     for index, cont_uuid in enumerate(uuids):
         manager.job.dfs_cont.update(cont_uuid, "ior.cont_uuid")
 
-        # Create a unique temporary directory for the the manager command
-        tmp_dir = mkdtemp(dir=tmpdir_base)
-        manager.tmpdir_base.update(tmp_dir, "tmpdir_base")
+        t_start = time.time()
 
         try:
             results.append(manager.run())
@@ -46,8 +42,9 @@ def run_ior_loop(manager, uuids, tmpdir_base):
                 "IOR {} Loop {}/{} failed for container {}: {}".format(
                     ior_mode, index, len(uuids), cont_uuid, error))
         finally:
-            # Remove the unique temporary directory and its contents to avoid conflicts
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+            t_end = time.time()
+            ior_cmd_time = t_end - t_start
+            results.append("ior_cmd_time = {}".format(ior_cmd_time))
 
     if errors:
         raise CommandFailure(
@@ -209,7 +206,7 @@ class ObjectMetadata(TestWithServers):
         #
         # Phase 2: if Phase 1 passed:
         #          clean up all containers created (prove "critical" destroy
-        #          in rdb (and vos) works without cascading nospace errors
+        #          in rdb (and vos) works without cascading no space errors
         #
         # Phase 3: if Phase 2 passed:
         #          Sustained container create loop, eventually encountering
@@ -233,12 +230,12 @@ class ObjectMetadata(TestWithServers):
             self.fail("Phase 2: fail (unexpected container destroy error)")
         self.log.info("Phase 2: passed")
 
-        # Phase 3 sustained container creates even after nospace error
-        # Due to rdb log compaction after initial nospace errors, some brief
+        # Phase 3 sustained container creates even after no space error
+        # Due to rdb log compaction after initial no space errors, some brief
         # periods of available space will occur, allowing a few container
         # creates to succeed in the interim.
         self.log.info(
-            "Phase 3: sustained container creates: to nospace and beyond")
+            "Phase 3: sustained container creates: to no space and beyond")
         self.container = []
         sequential_fail_counter = 0
         sequential_fail_max = 1000
@@ -262,13 +259,13 @@ class ObjectMetadata(TestWithServers):
 
                 if status and in_failure:
                     self.log.info(
-                        "Phase 3: container: %d - nospace -> available "
+                        "Phase 3: container: %d - no space -> available "
                         "transition, sequential no space failures: %d",
                         loop, sequential_fail_counter)
                     in_failure = False
                 elif not status and not in_failure:
                     self.log.info(
-                        "Phase 3: container: %d - available -> nospace "
+                        "Phase 3: container: %d - available -> no space "
                         "transition, sequential no space failures: %d",
                         loop, sequential_fail_counter)
                     in_failure = True
@@ -390,7 +387,7 @@ class ObjectMetadata(TestWithServers):
 
                 # Define the job manager for the IOR command
                 self.ior_managers.append(
-                    get_job_manager(self, "Orterun", ior_cmd, mpi_type="openmpi"))
+                    get_job_manager(self, "Clush", ior_cmd))
                 env = ior_cmd.get_default_env(str(self.ior_managers[-1]))
                 self.ior_managers[-1].assign_hosts(self.hostlist_clients, self.workdir, None)
                 self.ior_managers[-1].assign_processes(processes)
@@ -399,8 +396,7 @@ class ObjectMetadata(TestWithServers):
 
                 # Add a thread for these IOR arguments
                 thread_manager.add(
-                    manager=self.ior_managers[-1], uuids=list_of_uuid_lists[index],
-                    tmpdir_base=self.test_dir)
+                    manager=self.ior_managers[-1], uuids=list_of_uuid_lists[index])
                 self.log.info(
                     "Created %s thread %s with container uuids %s", operation,
                     index, list_of_uuid_lists[index])
@@ -408,6 +404,7 @@ class ObjectMetadata(TestWithServers):
             # Launch the IOR threads
             self.log.info("Launching %d IOR %s threads", thread_manager.qty, operation)
             failed_thread_count = thread_manager.check_run()
+            self.log.info("Done %d IOR %s threads", thread_manager.qty, operation)
             if failed_thread_count > 0:
                 msg = "{} FAILED IOR {} Thread(s)".format(failed_thread_count, operation)
                 self.d_log.error(msg)


### PR DESCRIPTION
To address slowdowns in orterun arbitrary command launching on release/2.2 branch tests, replace the use of orterun with clush, to launch ior commands in test_metadata_server_restart.

Skip-test-centos-rpms: true
Skip-test-centos-7-rpms: true
Skip-test-el-8.5-rpms: true

Quick-Functional: true
Test-tag: test_metadata_server_restart test_basic_config

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
