### PR TITLE
DAOS-12415 test: Allow for tests which may produce core files.

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -197,13 +197,13 @@ class DaosBuild(DfuseTestBase):
 
         preload_cmd = ';'.join(envs)
 
+        # Run the deps build in parallel for speed/coverage however the daos build itself does
+        # not yet work under the interception library so run this part in serial.
         build_jobs = 6 * 5
         intercept_jobs = build_jobs
         if intercept:
             intercept_jobs = 1
 
-        # Run the deps build in parallel for speed/coverage however the daos build itself does
-        # not yet work, so run this part in serial.  The VMs have 6 cores each.
         cmds = ['python3 -m venv {}/venv'.format(mount_dir),
                 'git clone https://github.com/daos-stack/daos.git {}'.format(build_dir),
                 'git -C {} submodule init'.format(build_dir),
@@ -243,9 +243,14 @@ class DaosBuild(DfuseTestBase):
 
             if cmd_ret['interrupted']:
                 self.log.info('Command timed out')
+                general_utils.run_pcmd(self.hostlist_clients, 'ps auwx', timeout=30)
                 fail_type = 'Timeout building'
 
             self.log.error('BuildDaos Test Failed')
+
+            if cmd.startswith('scons'):
+                general_utils.run_pcmd(self.hostlist_clients, 'cat {}/config.log'.format(build_dir),
+                                       timeout=30)
             if intercept:
                 self.fail('{} over dfuse with il in mode {}.\n'.format(fail_type, cache_mode))
             else:

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2656,12 +2656,6 @@ class Launch():
             self._fail_test(self.result.tests[-1], "Process", message, sys.exc_info())
             return 256
 
-        # One of the dfuse tests intermittently creates core files which is known so make a
-        # special case for that test.
-        if str(test) == './dfuse/daos_build.py' and './conftest' in core_file_processing.exe_names:
-            logger.info('conftest core file exists from daos_build test, ignoring')
-            corefiles_processed = len(core_file_processing.exe_names) - 1
-
         if corefiles_processed > 0 and str(test) not in TEST_EXPECT_CORE_FILES:
             message = "One or more core files detected after test execution"
             self._fail_test(self.result.tests[-1], "Process", message, None)

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2656,11 +2656,11 @@ class Launch():
             self._fail_test(self.result.tests[-1], "Process", message, sys.exc_info())
             return 256
 
-        # One of the dfuse tests intermittently creates a core file which is known so make a
+        # One of the dfuse tests intermittently creates core files which is known so make a
         # special case for that test.
         if str(test) == './dfuse/daos_build.py' and './conftest' in core_file_processing.exe_names:
             logger.info('conftest core file exists from daos_build test, ignoring')
-            corefiles_processed = corefiles_processed - 1
+            corefiles_processed = len(core_file_processing.exe_names) - 1
 
         if corefiles_processed > 0 and str(test) not in TEST_EXPECT_CORE_FILES:
             message = "One or more core files detected after test execution"

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2656,6 +2656,12 @@ class Launch():
             self._fail_test(self.result.tests[-1], "Process", message, sys.exc_info())
             return 256
 
+        # One of the dfuse tests intermittently creates a core file which is known so make a
+        # special case for that test.
+        if str(test) == './dfuse/daos_build.py' and './conftest' in core_file_processing.exe_names:
+            logger.info('conftest core file exists from daos_build test, ignoring')
+            corefiles_processed = corefiles_processed - 1
+
         if corefiles_processed > 0 and str(test) not in TEST_EXPECT_CORE_FILES:
             message = "One or more core files detected after test execution"
             self._fail_test(self.result.tests[-1], "Process", message, None)

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2643,7 +2643,8 @@ class Launch():
         """
         core_file_processing = CoreFileProcessing(logger)
         try:
-            corefiles_processed = core_file_processing.process_core_files(test_job_results, True)
+            corefiles_processed = core_file_processing.process_core_files(test_job_results, True,
+                                                                          test=str(test))
 
         except CoreFileException:
             message = "Errors detected processing test core files"

--- a/src/tests/ftest/process_core_files.py
+++ b/src/tests/ftest/process_core_files.py
@@ -39,6 +39,7 @@ class CoreFileProcessing():
         from util.distro_utils import detect
 
         self.log = log
+        self.exe_names = set()
         self.distro_info = detect()
 
     def process_core_files(self, directory, delete):
@@ -182,15 +183,16 @@ class CoreFileProcessing():
         result = run_local(self.log, " ".join(command), verbose=False)
         last_line = result.stdout.splitlines()[-1]
         self.log.debug("  last line:       %s", last_line)
-        cmd = last_line[7:-1]
+        cmd = last_line[7:]
         self.log.debug("  last_line[7:-1]: %s", cmd)
         # assume there are no arguments on cmd
         find_char = "'"
         if cmd.find(" ") > -1:
             # there are arguments on cmd
             find_char = " "
-        exe_name = cmd[0:cmd.find(find_char)]
+        exe_name = cmd[:cmd.find(find_char)]
         self.log.debug("  executable name: %s", exe_name)
+        self.exe_names.add(exe_name)
         return exe_name
 
     def install_debuginfo_packages(self):

--- a/src/tests/ftest/process_core_files.py
+++ b/src/tests/ftest/process_core_files.py
@@ -19,6 +19,10 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logger.addHandler(get_console_handler("%(message)s", logging.DEBUG))
 
+# One of the dfuse tests intermittently creates core files which is known so make a special case
+# for that test.
+CORE_FILES_IGNORE = {'/dfuse/daos_build.py': ('./conftest')}
+
 
 class CoreFileException(Exception):
     """Base exception for this module."""
@@ -39,10 +43,9 @@ class CoreFileProcessing():
         from util.distro_utils import detect
 
         self.log = log
-        self.exe_names = set()
         self.distro_info = detect()
 
-    def process_core_files(self, directory, delete):
+    def process_core_files(self, directory, delete, test=None):
         """Process any core files found in the 'stacktrace*' sub-directories of the specified path.
 
         Generate a stacktrace for each detected core file and then remove the core file.
@@ -51,6 +54,7 @@ class CoreFileProcessing():
             directory (str): location of the stacktrace* directories containing the core files to
                 process
             delete (bool): delete the core files.
+            test (str, optional): The name of the test
 
         Raises:
             CoreFileException: if there is an error processing core files.
@@ -102,8 +106,12 @@ class CoreFileProcessing():
                         command = ["lbzip2", "-d", "-v", os.path.join(core_dir, core_name)]
                         run_local(self.log, " ".join(command))
                         core_name = os.path.splitext(core_name)[0]
-                    self._create_stacktrace(core_dir, core_name)
-                    corefiles_processed += 1
+                    exe_name = self._get_exe_name(os.path.join(core_dir, core_name))
+                    self._create_stacktrace(core_dir, core_name, exe_name)
+                    if test in CORE_FILES_IGNORE and exe_name in CORE_FILES_IGNORE[test]:
+                        self.log.info('core file name configured for ignore, skipping')
+                    else:
+                        corefiles_processed += 1
                     self.log.debug(
                         "Successfully processed core file %s", os.path.join(core_dir, core_name))
                 except Exception as error:      # pylint: disable=broad-except
@@ -123,12 +131,13 @@ class CoreFileProcessing():
             raise CoreFileException("Errors detected processing core files")
         return corefiles_processed
 
-    def _create_stacktrace(self, core_dir, core_name):
+    def _create_stacktrace(self, core_dir, core_name, exe_name):
         """Create a stacktrace from the specified core file.
 
         Args:
             core_dir (str): location of the core file
             core_name (str): name of the core file
+            exe_name (str): name of the executable
 
         Raises:
             RunException: if there is an error creating a stacktrace
@@ -148,7 +157,7 @@ class CoreFileProcessing():
                 "-ex", "'thread apply all bt full'",
                 "-ex", "detach",
                 "-ex", "quit",
-                self._get_exe_name(core_full), core_name
+                exe_name, core_name
             ]
 
         except RunException as error:
@@ -192,7 +201,6 @@ class CoreFileProcessing():
             find_char = " "
         exe_name = cmd[:cmd.find(find_char)]
         self.log.debug("  executable name: %s", exe_name)
-        self.exe_names.add(exe_name)
         return exe_name
 
     def install_debuginfo_packages(self):

--- a/src/tests/ftest/process_core_files.py
+++ b/src/tests/ftest/process_core_files.py
@@ -21,7 +21,7 @@ logger.addHandler(get_console_handler("%(message)s", logging.DEBUG))
 
 # One of the dfuse tests intermittently creates core files which is known so make a special case
 # for that test.
-CORE_FILES_IGNORE = {'/dfuse/daos_build.py': ('./conftest')}
+CORE_FILES_IGNORE = {'./dfuse/daos_build.py': ('./conftest')}
 
 
 class CoreFileException(Exception):


### PR DESCRIPTION
Add logic to not fail the DaosBuild test if it creates a forefile,
it sometimes creates a corefile from conftest which is expected
and should not cause a test failure.
Fix a bug where the program that generated the core file was read
incorrectly.
Add some debugging where the DaosBuild test fails.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
