### PR TITLE
DAOS-12491 dtx: sync commit for punch obj with multiple RDGs

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -5654,7 +5654,7 @@ dc_obj_update(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 		}
 
 		obj_auxi->tx_convert = 0;
-		return dc_tx_convert(obj, DAOS_OBJ_RPC_UPDATE, task);
+		return dc_tx_convert(obj, DAOS_OBJ_RPC_UPDATE, task, false);
 	}
 
 	obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, args->dkey);
@@ -6563,7 +6563,7 @@ dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
 		 * internal transaction to handle that to guarantee the
 		 * atomicity of punch object.
 		 */
-		return dc_tx_convert(obj, opc, task);
+		return dc_tx_convert(obj, opc, task, true);
 
 	rc = obj_task_init(task, opc, map_ver, api_args->th, &obj_auxi, obj);
 	if (rc != 0) {
@@ -6573,7 +6573,7 @@ dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
 
 	if (obj_auxi->tx_convert) {
 		obj_auxi->tx_convert = 0;
-		return dc_tx_convert(obj, opc, task);
+		return dc_tx_convert(obj, opc, task, false);
 	}
 
 	if (opc == DAOS_OBJ_RPC_PUNCH) {

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -864,7 +864,7 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 	     tse_task_t *task);
 
 int
-dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task);
+dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task, bool sync);
 
 int
 iov_alloc_for_csum_info(d_iov_t *iov, struct dcs_csum_info *csum_info);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2375,9 +2375,6 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	epoch.oe_first = orw->orw_epoch_first;
 	epoch.oe_flags = orf_to_dtx_epoch_flags(orw->orw_flags);
 
-	if (orw->orw_flags & ORF_DTX_SYNC)
-		dtx_flags |= DTX_SYNC;
-
 	rc = dtx_begin(ioc.ioc_vos_coh, &orw->orw_dti, &epoch, 1,
 		       orw->orw_map_ver, &orw->orw_oid,
 		       orw->orw_dti_cos.ca_arrays,
@@ -3320,9 +3317,6 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	epoch.oe_value = opi->opi_epoch;
 	epoch.oe_first = epoch.oe_value; /* unused for TGT_PUNCH */
 	epoch.oe_flags = orf_to_dtx_epoch_flags(opi->opi_flags);
-
-	if (opi->opi_flags & ORF_DTX_SYNC)
-		dtx_flags |= DTX_SYNC;
 
 	/* Start the local transaction */
 	rc = dtx_begin(ioc.ioc_vos_coh, &opi->opi_dti, &epoch, 1,
@@ -4330,9 +4324,6 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 		D_GOTO(out, rc = rc1);
 	}
 
-	if (oci->oci_flags & ORF_DTX_SYNC)
-		dtx_flags |= DTX_SYNC;
-
 	rc = dtx_begin(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &dcsh->dcsh_epoch,
 		       dcde->dcde_write_cnt, oci->oci_map_ver,
 		       &dcsh->dcsh_leader_oid, NULL, 0, dtx_flags,
@@ -4570,6 +4561,8 @@ again:
 		dtx_flags |= DTX_PREPARED;
 	else
 		dtx_flags &= ~DTX_PREPARED;
+	if (oci->oci_flags & ORF_DTX_SYNC)
+		dtx_flags |= DTX_SYNC;
 
 	rc = dtx_leader_begin(dca->dca_ioc->ioc_vos_coh, &dcsh->dcsh_xid,
 			      &dcsh->dcsh_epoch, dcde->dcde_write_cnt,


### PR DESCRIPTION
If punch an object with multiple redundancy groups, then it will be handled via internal distributed transaction. We will synchronously commit such DTX that is helpful for re-creating the same object for some repeated tests.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
