### PR TITLE
DAOS-12471 chk: do not check non-specified pool

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -357,8 +357,12 @@ chk_pools_dump(d_list_t *head, int pool_nr, uuid_t pools[])
 
 	if (head != NULL && !d_list_empty(head)) {
 		D_INFO("Pools List:\n");
-		d_list_for_each_entry(cpr, head, cpr_link)
-			D_INFO(DF_UUIDF"\n", DP_UUID(cpr->cpr_uuid));
+		d_list_for_each_entry(cpr, head, cpr_link) {
+			if (cpr->cpr_for_orphan)
+				D_INFO(DF_UUIDF" (for orphan/dangling)\n", DP_UUID(cpr->cpr_uuid));
+			else
+				D_INFO(DF_UUIDF"\n", DP_UUID(cpr->cpr_uuid));
+		}
 	} else if (pool_nr > 0) {
 		D_INFO("Pools List:\n");
 		do {

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -1954,17 +1954,23 @@ reset:
 	if (rc != 0)
 		goto out;
 
-	rc = ds_mgmt_tgt_pool_iterate(chk_pools_add_from_dir, &ctpa);
-	if (rc != 0)
-		goto out;
+	if (pool_nr > 0) {
+		rc = chk_pools_load_list(ins, gen, api_flags, pool_nr, pools);
+		if (rc != 0)
+			goto out;
+	} else {
+		rc = ds_mgmt_tgt_pool_iterate(chk_pools_add_from_dir, &ctpa);
+		if (rc != 0)
+			goto out;
 
-	rc = ds_mgmt_newborn_pool_iterate(chk_pools_add_from_dir, &ctpa);
-	if (rc != 0)
-		goto out;
+		rc = ds_mgmt_newborn_pool_iterate(chk_pools_add_from_dir, &ctpa);
+		if (rc != 0)
+			goto out;
 
-	rc = ds_mgmt_zombie_pool_iterate(chk_pools_add_from_dir, &ctpa);
-	if (rc != 0)
-		goto out;
+		rc = ds_mgmt_zombie_pool_iterate(chk_pools_add_from_dir, &ctpa);
+		if (rc != 0)
+			goto out;
+	}
 
 	memset(cbk, 0, sizeof(*cbk));
 	cbk->cb_magic = CHK_BK_MAGIC_ENGINE;

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -2339,7 +2339,10 @@ reset:
 	if (rc != 0)
 		goto out;
 
-	ins->ci_start_flags |= CSF_RESET_ALL | CSF_ORPHAN_POOL;
+	ins->ci_start_flags |= CSF_RESET_ALL;
+	if (pool_nr <= 0)
+		ins->ci_start_flags |= CSF_ORPHAN_POOL;
+
 	memset(cbk, 0, sizeof(*cbk));
 	cbk->cb_magic = CHK_BK_MAGIC_LEADER;
 	cbk->cb_version = DAOS_CHK_VERSION;


### PR DESCRIPTION
If the user/admin ony wants to check some specified pool(s), then DAOS engine logic needs to filter out those pools that are not in the check list.

If the user/admin does not specify the pools list when start check, then by default, the DAOS engine will do:

1. Resume former paused pools if have, or
2. (re)check all pools from the beginning.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
