### PR TITLE
DAOS-12124 control: Fix pool create error after format

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -1289,6 +1289,11 @@ func processNVMeSpaceStats(log logging.Logger, filterRank filterRankFn, nvmeCont
 
 // Return the maximal SCM and NVMe size of a pool which could be created with all the storage nodes.
 func GetMaxPoolSize(ctx context.Context, log logging.Logger, rpcClient UnaryInvoker, ranks ranklist.RankList) (uint64, uint64, error) {
+	// Check if DAOS system is ready. If it's not, we should fail the Pool create.
+	if _, err := SystemQuery(ctx, rpcClient, &SystemQueryReq{FailOnUnavailable: true}); err != nil {
+		return 0, 0, err
+	}
+
 	resp, err := StorageScan(ctx, rpcClient, &StorageScanReq{Usage: true})
 	if err != nil {
 		return 0, 0, err

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -1634,10 +1634,11 @@ func TestControl_ListPools(t *testing.T) {
 func TestControl_GetMaxPoolSize(t *testing.T) {
 	devStateFaulty := storage.NvmeStateFaulty
 	type ExpectedOutput struct {
-		ScmBytes  uint64
-		NvmeBytes uint64
-		Error     error
-		Debug     string
+		ScmBytes   uint64
+		NvmeBytes  uint64
+		Error      error
+		QueryError error
+		Debug      string
 	}
 
 	for name, tc := range map[string]struct {
@@ -2042,6 +2043,13 @@ func TestControl_GetMaxPoolSize(t *testing.T) {
 				Error: errors.New("host storage response"),
 			},
 		},
+		"query fails (system not ready)": {
+			HostsConfigArray: []MockHostStorageConfig{},
+			ExpectedOutput: ExpectedOutput{
+				QueryError: system.ErrRaftUnavail,
+				Error:      system.ErrRaftUnavail,
+			},
+		},
 		"No SCM storage": {
 			HostsConfigArray: []MockHostStorageConfig{
 				{
@@ -2265,8 +2273,19 @@ func TestControl_GetMaxPoolSize(t *testing.T) {
 			defer test.ShowBufferOnFailure(t, buf)
 
 			mockInvokerConfig := &MockInvokerConfig{
-				UnaryResponse: &UnaryResponse{
-					Responses: []*HostResponse{},
+				UnaryResponseSet: []*UnaryResponse{
+					{
+						Responses: []*HostResponse{
+							{
+								Addr:    "foo",
+								Message: &mgmtpb.SystemQueryResp{},
+								Error:   tc.ExpectedOutput.QueryError,
+							},
+						},
+					},
+					{
+						Responses: []*HostResponse{},
+					},
 				},
 			}
 			for _, hostStorageConfig := range tc.HostsConfigArray {
@@ -2282,7 +2301,8 @@ func TestControl_GetMaxPoolSize(t *testing.T) {
 						Message: storageScanResp,
 					}
 				}
-				mockInvokerConfig.UnaryResponse.Responses = append(mockInvokerConfig.UnaryResponse.Responses, hostResponse)
+				scanResp := mockInvokerConfig.UnaryResponseSet[1]
+				scanResp.Responses = append(scanResp.Responses, hostResponse)
 			}
 			mockInvoker := NewMockInvoker(log, mockInvokerConfig)
 


### PR DESCRIPTION
When the --size=% flag is used, the pool create command
performs a storage scan in order to determine the actual
available storage across the ranks. In cases where the
system has not started yet (i.e. pool create is run
immediately after storage format completes), the user may
receive a confusing error message. This patch changes the
flow to perform a system query before storage scan so that
the user receives a normal error if the MS hasn't started
yet.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
