### PR TITLE
DAOS-11964 container: update agg boundary eph

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1551,9 +1551,14 @@ cont_refresh_vos_agg_eph_one(void *data)
 	if (rc)
 		return rc;
 
-	D_DEBUG(DB_MD, DF_CONT": update aggregation max eph "DF_U64"\n",
-		DP_CONT(arg->pool_uuid, arg->cont_uuid), arg->min_eph);
-	cont_child->sc_ec_agg_eph_boundry = arg->min_eph;
+	D_DEBUG(DB_MD, DF_CONT": %s agg boundary eph "DF_X64"->"DF_X64"\n",
+		DP_CONT(arg->pool_uuid, arg->cont_uuid),
+		cont_child->sc_ec_agg_eph_boundary < arg->min_eph ? "update" : "ignore",
+		cont_child->sc_ec_agg_eph_boundary, arg->min_eph);
+
+	if (cont_child->sc_ec_agg_eph_boundary < arg->min_eph)
+		cont_child->sc_ec_agg_eph_boundary = arg->min_eph;
+
 	ds_cont_child_put(cont_child);
 	return rc;
 }

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -279,7 +279,7 @@ adjust_upper_bound(struct ds_cont_child *cont, bool vos_agg, uint64_t *upper_bou
 		return;
 
 	/* Cap VOS aggregation upper bound to EC aggregation HAE */
-	*upper_bound = min(*upper_bound, cont->sc_ec_agg_eph_boundry);
+	*upper_bound = min(*upper_bound, cont->sc_ec_agg_eph_boundary);
 }
 
 #define MAX_SNAPSHOT_LOCAL	16

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -103,7 +103,7 @@ struct ds_cont_child {
 	 * not cross this limit. For simplification purpose, all objects
 	 * VOS aggregation will use this boundary. We will optimize it later.
 	 */
-	uint64_t		sc_ec_agg_eph_boundry;
+	uint64_t		sc_ec_agg_eph_boundary;
 	/* The current EC aggregate epoch for this xstream */
 	uint64_t		sc_ec_agg_eph;
 	/* Used by cont_ec_eph_query_ult to query the minimum EC agg epoch from all

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1242,15 +1242,15 @@ obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_rw_out *orwo,
 	if (DAOS_FAIL_CHECK(DAOS_FAIL_AGG_BOUNDRY_MOVED))
 		return true;
 
-	/* agg_eph_boundry advanced, possibly cause epoch of EC data recovery
+	/* agg_eph_boundary advanced, possibly cause epoch of EC data recovery
 	 * cannot get corresponding parity/data exts, need to retry the degraded
 	 * fetch from beginning. For ORF_EC_RECOV_SNAP case, need not retry as
-	 * that flag was only set when (snapshot_epoch < sc_ec_agg_eph_boundry).
+	 * that flag was only set when (snapshot_epoch < sc_ec_agg_eph_boundary).
 	 */
 	if ((orw->orw_flags & ORF_EC_RECOV_SNAP) == 0 &&
 	    (orw->orw_flags & ORF_FOR_MIGRATION) == 0 &&
-	    orw->orw_epoch < ioc->ioc_coc->sc_ec_agg_eph_boundry) {
-		orwo->orw_epoch = ioc->ioc_coc->sc_ec_agg_eph_boundry;
+	    orw->orw_epoch < ioc->ioc_coc->sc_ec_agg_eph_boundary) {
+		orwo->orw_epoch = ioc->ioc_coc->sc_ec_agg_eph_boundary;
 		return true;
 	}
 
@@ -1387,7 +1387,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			D_DEBUG(DB_IO, DF_UOID" "DF_X64"<"DF_X64
 				" ec_recov needs redo, "DF_RC".\n",
 				DP_UOID(orw->orw_oid), orw->orw_epoch,
-				ioc->ioc_coc->sc_ec_agg_eph_boundry,
+				ioc->ioc_coc->sc_ec_agg_eph_boundary,
 				DP_RC(rc));
 			goto out;
 		}
@@ -1455,7 +1455,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			parity_list = vos_ioh2recx_list(ioh);
 			if (parity_list != NULL) {
 				daos_recx_ep_list_set(parity_list, iods_nr,
-						      ioc->ioc_coc->sc_ec_agg_eph_boundry, 0);
+						      ioc->ioc_coc->sc_ec_agg_eph_boundary, 0);
 				daos_recx_ep_list_merge(parity_list, iods_nr);
 				orwo->orw_rels.ca_arrays = parity_list;
 				orwo->orw_rels.ca_count = iods_nr;
@@ -1502,7 +1502,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			 * Or, will recovery from max{parity_epoch, vos_epoch_
 			 * boundary}.
 			 */
-			vos_agg_epoch = ioc->ioc_coc->sc_ec_agg_eph_boundry;
+			vos_agg_epoch = ioc->ioc_coc->sc_ec_agg_eph_boundary;
 			if (ioc->ioc_fetch_snap &&
 			    orw->orw_epoch < vos_agg_epoch) {
 				recov_epoch = orw->orw_epoch;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1676,8 +1676,8 @@ migrate_one_ult(void *arg)
 	while (tls->mpt_inflight_size + data_size >=
 	       tls->mpt_inflight_max_size && tls->mpt_inflight_max_size != 0
 	       && !tls->mpt_fini) {
-		D_INFO("mrone %p wait "DF_U64"/"DF_U64"\n", mrone, tls->mpt_inflight_size,
-			tls->mpt_inflight_max_size);
+		D_DEBUG(DB_REBUILD, "mrone %p wait "DF_U64"/"DF_U64"\n", mrone,
+			tls->mpt_inflight_size, tls->mpt_inflight_max_size);
 		ABT_mutex_lock(tls->mpt_inflight_mutex);
 		ABT_cond_wait(tls->mpt_inflight_cond, tls->mpt_inflight_mutex);
 		ABT_mutex_unlock(tls->mpt_inflight_mutex);


### PR DESCRIPTION
Only update the agg boundary if incoming boundary epoch is larger than the current boundary epoch, since boundary epoch distribute might be out of order.

Required-githooks: true

Signed-off-by: Di Wang <di.wang@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
