### PR TITLE
DAOS-12128 test: fix telemetry expected values

### DIFF
--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -33,7 +33,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
         """Return the expected metrics value output.
 
         This function returns a hash map of pairs defining min and max values of each tested
-        telemetry metrics.  The hash map of pairs returned depends of the tested object class, and
+        telemetry metrics.  The hash map of pairs returned depends on the tested object class, and
         the values are weighted according to the number of timeout rpc and resent update rpc.
 
         Note:

--- a/src/tests/ftest/telemetry/telemetry_pool_metrics.py
+++ b/src/tests/ftest/telemetry/telemetry_pool_metrics.py
@@ -29,19 +29,32 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
 
         self.dfs_oclass = self.params.get("oclass", '/run/container/*', self.dfs_oclass)
 
-    def get_expected_value_range(self, resent_ops):
-        """Return the expected metrics value output
+    def get_expected_value_range(self, timeout_ops, resent_ops):
+        """Return the expected metrics value output.
 
-            This function returns a hash map of pairs defining min and max values of each tested
-            telemetry metrics.  The hash map of pairs returned depends of the tested object class,
-            and the values are weighted according to the number of resent update rpc.
+        This function returns a hash map of pairs defining min and max values of each tested
+        telemetry metrics.  The hash map of pairs returned depends of the tested object class, and
+        the values are weighted according to the number of timeout rpc and resent update rpc.
+
+        Note:
+            There is not yet a telemetry counter defining the number of failing fetch operations.
+            However, the number of timeout_ops should be at least equal to the number of fetch which
+            have failed and thus have been redo one or more times.
+
+        Args:
+            timeout_ops (int): Total number of timed out RPC requests.
+            resent_ops (int): Total number of timed out RPC requests.
+
+        Returns:
+            dict: Dictionary of the expected metrics value output.
         """
+
         ops_number = int(self.ior_cmd.block_size.value / self.ior_cmd.transfer_size.value)
         pool_ops_minmax = {
             "SX": {
                 "engine_pool_ops_fetch": (
                     ops_number + 7,
-                    ops_number + 8
+                    ops_number + timeout_ops + 8
                 ),
                 "engine_pool_ops_update": (
                     ops_number + 1,
@@ -49,7 +62,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
                 ),
                 "engine_pool_xferred_fetch": (
                     ops_number * self.ior_cmd.transfer_size.value,
-                    (ops_number + 1) * self.ior_cmd.transfer_size.value
+                    (ops_number + timeout_ops + 1) * self.ior_cmd.transfer_size.value
                 ),
                 "engine_pool_xferred_update": (
                     ops_number * self.ior_cmd.transfer_size.value,
@@ -59,7 +72,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
             "RP_3GX": {
                 "engine_pool_ops_fetch": (
                     ops_number + 7,
-                    ops_number + 8
+                    ops_number + timeout_ops + 8
                 ),
                 "engine_pool_ops_update": (
                     ops_number + 1,
@@ -67,7 +80,7 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
                 ),
                 "engine_pool_xferred_fetch": (
                     ops_number * self.ior_cmd.transfer_size.value,
-                    (ops_number + 1) * self.ior_cmd.transfer_size.value
+                    (ops_number + timeout_ops + 1) * self.ior_cmd.transfer_size.value
                 ),
                 "engine_pool_xferred_update": (
                     3 * ops_number * self.ior_cmd.transfer_size.value,
@@ -77,23 +90,25 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
         }
         return pool_ops_minmax[self.dfs_oclass]
 
-    def get_metric_value(self, name, metrics_data):
-        """Aggregate the metric value of the DAOS targets"""
-        metric_value = 0
-        metric_data = metrics_data[0]
-        for host in metric_data[name]:
-            for rank in metric_data[name][host]:
-                for target in metric_data[name][host][rank]:
-                    value_init = metric_data[name][host][rank][target]
-                    value_end = metrics_data[1][name][host][rank][target]
-                    self.assertLessEqual(
-                        value_init, value_end,
-                        "Inconsistent metric values: metric_name={}, host={}, rank={}, target={},"
-                        " value_init={}, value_end={}"
-                        .format(name, host, rank, target, value_init, value_end))
-                    metric_value += value_end - value_init
+    def get_metrics(self, names):
+        """Obtain the specified metrics information.
 
-        return metric_value
+        Args:
+            name (list): List of metric names to query.
+
+        Returns:
+            dict: a dictionary of metric keys linked to their aggregated values.
+        """
+        metrics = {}
+        for name in names:
+            metrics[name] = 0
+
+        for data in self.telemetry.get_metrics(",".join(names)).values():
+            for name, value in data.items():
+                for metric in value["metrics"]:
+                    metrics[name] += metric["value"]
+
+        return metrics
 
     def test_telemetry_pool_metrics(self):
         """JIRA ID: DAOS-8357
@@ -132,10 +147,10 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
             "engine_pool_ops_update",
             "engine_pool_xferred_fetch",
             "engine_pool_xferred_update",
+            "engine_net_req_timeout",
             "engine_pool_resent"
         ]
-        metrics_data = []
-        metrics_data.append(self.telemetry.get_pool_metrics(metric_names))
+        metrics_init = self.get_metrics(metric_names)
 
         # Run ior command.
         try:
@@ -148,16 +163,21 @@ class TelemetryPoolMetrics(IorTestBase, TestWithTelemetry):
             self.log.info("#ior command failed!")
 
         # collect second set of pool metric data after read/write
-        metrics_data.append(self.telemetry.get_pool_metrics(metric_names))
+        metrics_end = self.get_metrics(metric_names)
 
-        metric_values = {}
+        metrics = {}
         for name in metric_names:
-            metric_values[name] = self.get_metric_value(name, metrics_data)
+            metrics[name] = metrics_end[name] - metrics_init[name]
+            self.log.debug(
+                "Successfully retrieve metric: %s=%d (init=%d, end=%d)",
+                name, metrics[name], metrics_init[name], metrics_end[name])
 
         # perform verification check
-        expected_values = self.get_expected_value_range(metric_values["engine_pool_resent"])
+        timeout_ops = metrics["engine_net_req_timeout"]
+        resent_ops = metrics["engine_pool_resent"]
+        expected_values = self.get_expected_value_range(timeout_ops, resent_ops)
         for name in expected_values:
-            val = metric_values[name]
+            val = metrics[name]
             min_val, max_val = expected_values[name]
             self.assertTrue(
                 min_val <= val <= max_val,


### PR DESCRIPTION
# Description

There is not yet a dedicated metric (as the `engine_pool_resent` one for update operations) allowing to count the number of fetch operations which have failed.
To alleviate this issue, the `engine_net_req_timeout` is used to weight the expected number of fetch operations.

# Validation

Sadly, It was not possible to properly check if this workaround is 100% effective.
Indeed, it was not possible to reproduce fetch operations error: this PR was submitted multiple times to the CI (with different number of repetitions) without being able to have failed fetch operations (and thus have been re-received).
However, it was possible to check that when update operations were failing (i.e.  `engine_pool_resent` > 0), the `engine_net_req_timeout` was most of the time > 0.
Thus, the `engine_net_req_timeout` should be at least greater or equal to the number of fetch operations which have failed (and thus have been re-received).

The Test-tag was used to run the telemetry tests.

# Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

# Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
