### PR TITLE
DAOS-12527 test: Add missing debug symbols for stacktraces

### DIFF
--- a/src/tests/ftest/process_core_files.py
+++ b/src/tests/ftest/process_core_files.py
@@ -109,7 +109,9 @@ class CoreFileProcessing():
                     exe_name = self._get_exe_name(os.path.join(core_dir, core_name))
                     self._create_stacktrace(core_dir, core_name, exe_name)
                     if test in CORE_FILES_IGNORE and exe_name in CORE_FILES_IGNORE[test]:
-                        self.log.info('core file name configured for ignore, skipping')
+                        self.log.debug(
+                            'Excluding the %s core file (%s) detected while running %s from '
+                            'the processed core count', core_name, exe_name, test)
                     else:
                         corefiles_processed += 1
                     self.log.debug(
@@ -260,7 +262,7 @@ class CoreFileProcessing():
             cmds.append(
                 ["sudo", "dnf", "debuginfo-install", "-y"] + dnf_args
                 + ["daos-client-" + rpm_version, "daos-server-" + rpm_version,
-                   "daos-tests-" + rpm_version])
+                   "daos-client-tests-" + rpm_version, "daos-server-tests-" + rpm_version])
         # else:
         #     # We're not using the yum API to install packages
         #     # See the comments below.


### PR DESCRIPTION
Resolve 'No symbol table info available.' errors in CI stacktrace generation by installing missing doas-*-tests debuginfo packages.

Skip-unit-tests: true
Skip-func-hw-test: true

Required-githooks: true

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
