### PR TITLE
DAOS-11405 vos: Simplify vos slab allocation

### DIFF
--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -282,8 +282,7 @@ typedef struct {
 					       void *data);
 } umem_ops_t;
 
-
-#define UMM_SLABS_CNT	7
+#define UMM_SLABS_CNT 13
 
 /** attributes to initialize an unified memory class */
 struct umem_attr {

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1411,8 +1411,7 @@ evt_node_alloc(struct evt_context *tcx, unsigned int flags,
 	umem_off_t		 nd_off;
 	bool			 leaf = (flags & EVT_NODE_LEAF);
 
-	nd_off = vos_slab_alloc(evt_umm(tcx), evt_node_size(tcx, leaf),
-			leaf ? VOS_SLAB_EVT_NODE : VOS_SLAB_EVT_NODE_SM);
+	nd_off = vos_slab_alloc(evt_umm(tcx), evt_node_size(tcx, leaf));
 	if (UMOFF_IS_NULL(nd_off))
 		return -DER_NOSPACE;
 
@@ -3152,8 +3151,7 @@ evt_common_insert(struct evt_context *tcx, struct evt_node *nd,
 						"for checksum", csum_buf_size);
 			desc_off = umem_zalloc(evt_umm(tcx), desc_size);
 		} else {
-			desc_off = vos_slab_alloc(evt_umm(tcx), desc_size,
-							VOS_SLAB_EVT_DESC);
+			desc_off = vos_slab_alloc(evt_umm(tcx), desc_size);
 		}
 		if (UMOFF_IS_NULL(desc_off))
 			return -DER_NOSPACE;

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -166,7 +166,7 @@ struct ilog_entry {
 	int32_t		ie_idx;
 };
 
-#define ILOG_PRIV_SIZE 408
+#define ILOG_PRIV_SIZE 600
 /* Information about ilog entries */
 struct ilog_info {
 	/** Status of ilog entry */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1289,31 +1289,52 @@ vos_iterate_key(struct vos_object *obj, daos_handle_t toh, vos_iter_type_t type,
 /** Start epoch of vos */
 extern daos_epoch_t	vos_start_epoch;
 
-/* Slab allocation */
-enum {
-	VOS_SLAB_OBJ_NODE	= 0,
-	VOS_SLAB_KEY_NODE	= 1,
-	VOS_SLAB_SV_NODE	= 2,
-	VOS_SLAB_EVT_NODE	= 3,
-	VOS_SLAB_EVT_DESC	= 4,
-	VOS_SLAB_OBJ_DF		= 5,
-	VOS_SLAB_EVT_NODE_SM	= 6,
-	VOS_SLAB_MAX		= 7
+/** Define common slabs.  We can refine this for 2.4 pools but that is for next patch */
+static const int        slab_map[] = {
+    0,                  /* 32 bytes */
+    1,                  /* 64 bytes */
+    2,                  /* 96 bytes */
+    3,                  /* 128 bytes */
+    4,                  /* 160 bytes */
+    5,                  /* 192 bytes */
+    6,                  /* 224 bytes */
+    -1,                 /* 256 bytes */
+    7,                  /* 288 bytes */
+    -1, -1, 8,          /* 384 bytes */
+    9,                  /* 416 bytes */
+    -1, -1, -1, -1, 10, /* 576 bytes */
+    -1, -1, 11,         /* 672 bytes */
+    -1, -1, 12,         /* 768 bytes */
 };
-D_CASSERT(VOS_SLAB_MAX <= UMM_SLABS_CNT);
 
 static inline umem_off_t
-vos_slab_alloc(struct umem_instance *umm, int size, int slab_id)
+vos_slab_alloc(struct umem_instance *umm, int size)
 {
-	/* evtree unit tests may skip slab register in vos_pool_open() */
-	D_ASSERTF(!umem_slab_registered(umm, slab_id) ||
-		  size == umem_slab_usize(umm, slab_id),
-		  "registered: %d, id: %d, size: %d != %zu\n",
-		  umem_slab_registered(umm, slab_id),
-		  slab_id, size, umem_slab_usize(umm, slab_id));
+	int aligned_size = D_ALIGNUP(size, 32);
+	int slab_idx;
+	int slab;
 
-	return umem_alloc_verb(umm, umem_slab_flags(umm, slab_id) |
-					POBJ_FLAG_ZERO, size);
+	slab_idx = (aligned_size >> 5) - 1;
+	if (slab_idx >= ARRAY_SIZE(slab_map))
+		goto no_slab_alloc;
+
+	if (slab_map[slab_idx] == -1) {
+		D_DEBUG(DB_MGMT, "No slab %d for allocation of size %d, idx=%d\n", aligned_size,
+			size, slab_idx);
+		goto no_slab_alloc;
+	}
+
+	slab = slab_map[slab_idx];
+
+	/* evtree unit tests may skip slab register in vos_pool_open() */
+	D_ASSERTF(!umem_slab_registered(umm, slab) || aligned_size == umem_slab_usize(umm, slab),
+		  "registered: %d, id: %d, size: %d != %zu\n", umem_slab_registered(umm, slab),
+		  slab, aligned_size, umem_slab_usize(umm, slab));
+
+	return umem_alloc_verb(umm, umem_slab_flags(umm, slab) | POBJ_FLAG_ZERO, aligned_size);
+
+no_slab_alloc:
+	return umem_zalloc(umm, size);
 }
 
 /* vos_space.c */

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -78,8 +78,7 @@ oi_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	int			 rc;
 
 	/* Allocate a PMEM value of type vos_obj_df */
-	obj_off = vos_slab_alloc(&tins->ti_umm, sizeof(struct vos_obj_df),
-				 VOS_SLAB_OBJ_DF);
+	obj_off = vos_slab_alloc(&tins->ti_umm, sizeof(struct vos_obj_df));
 	if (UMOFF_IS_NULL(obj_off))
 		return -DER_NOSPACE;
 
@@ -165,7 +164,7 @@ oi_rec_update(struct btr_instance *tins, struct btr_record *rec,
 static umem_off_t
 oi_node_alloc(struct btr_instance *tins, int size)
 {
-	return vos_slab_alloc(&tins->ti_umm, size, VOS_SLAB_OBJ_NODE);
+	return vos_slab_alloc(&tins->ti_umm, size);
 }
 
 static btr_ops_t oi_btr_ops = {

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -519,93 +519,27 @@ exit:
 }
 
 static int
-set_slab_prop(int id, struct pobj_alloc_class_desc *slab)
-{
-	struct daos_tree_overhead	ovhd = { 0 };
-	int				tclass, *size, rc;
-
-	if (id == VOS_SLAB_OBJ_DF) {
-		slab->unit_size = sizeof(struct vos_obj_df);
-		goto done;
-	}
-
-	size = &ovhd.to_leaf_overhead.no_size;
-
-	switch (id) {
-	case VOS_SLAB_OBJ_NODE:
-		tclass = VOS_TC_OBJECT;
-		break;
-	case VOS_SLAB_KEY_NODE:
-		tclass = VOS_TC_DKEY;
-		break;
-	case VOS_SLAB_SV_NODE:
-		tclass = VOS_TC_SV;
-		break;
-	case VOS_SLAB_EVT_NODE:
-		tclass = VOS_TC_ARRAY;
-		break;
-	case VOS_SLAB_EVT_NODE_SM:
-		tclass = VOS_TC_ARRAY;
-		size = &ovhd.to_int_node_size;
-		break;
-	case VOS_SLAB_EVT_DESC:
-		tclass = VOS_TC_ARRAY;
-		size = &ovhd.to_record_msize;
-		break;
-	default:
-		D_ERROR("Invalid slab ID: %d\n", id);
-		return -DER_INVAL;
-	}
-
-	rc = vos_tree_get_overhead(0, tclass, 0, &ovhd);
-	if (rc)
-		return rc;
-
-	slab->unit_size = *size;
-done:
-	D_ASSERT(slab->unit_size > 0);
-	D_DEBUG(DB_MGMT, "Slab ID:%d, Size:%lu\n", id, slab->unit_size);
-
-	slab->alignment = 0;
-	slab->units_per_block = 1000;
-	slab->header_type = POBJ_HEADER_NONE;
-
-	return 0;
-}
-
-static int
 vos_register_slabs(struct umem_attr *uma)
 {
-	struct pobj_alloc_class_desc	*slab;
-	int				 i, rc, j;
-	bool				 skip_set;
+	struct pobj_alloc_class_desc *slab;
+	int                           i, rc;
+	int                           defined;
+	int                           used = 0;
+
+	for (i = 0; i < ARRAY_SIZE(slab_map); i++) {
+		if (slab_map[i] != -1)
+			used |= (1 << i);
+	}
 
 	D_ASSERT(uma->uma_pool != NULL);
-	for (i = 0; i < VOS_SLAB_MAX; i++) {
+	for (i = 0; i < UMM_SLABS_CNT; i++) {
+		D_ASSERT(used != 0);
+		defined               = __builtin_ctz(used);
 		slab = &uma->uma_slabs[i];
-
-		D_ASSERT(slab->class_id == 0);
-		rc = set_slab_prop(i, slab);
-		if (rc) {
-			D_ERROR("Failed to get unit size %d. rc:%d\n", i, rc);
-			return rc;
-		}
-
-		skip_set = false;
-		for (j = 0; j < i; j++) {
-			if (uma->uma_slabs[j].unit_size == slab->unit_size) {
-				/** PMDK will fail to register a new slab of the same size
-				 *  so reuse the class id
-				 */
-				slab->class_id = uma->uma_slabs[j].class_id;
-				skip_set = true;
-				D_ASSERT(slab->class_id != 0);
-				break;
-			}
-		}
-
-		if (skip_set)
-			continue;
+		slab->alignment       = 0;
+		slab->unit_size       = (defined + 1) * 32;
+		slab->units_per_block = 1000;
+		slab->header_type     = POBJ_HEADER_NONE;
 
 		rc = pmemobj_ctl_set(uma->uma_pool, "heap.alloc_class.new.desc",
 				     slab);
@@ -616,7 +550,11 @@ vos_register_slabs(struct umem_attr *uma)
 			return rc;
 		}
 		D_ASSERT(slab->class_id != 0);
+		D_DEBUG(DB_MGMT, "slab registered with size %zu\n", slab->unit_size);
+
+		used &= ~(1 << defined);
 	}
+	D_ASSERT(used == 0);
 
 	return 0;
 }

--- a/src/vos/vos_space.c
+++ b/src/vos/vos_space.c
@@ -183,8 +183,8 @@ estimate_space_key(struct umem_instance *umm, daos_key_t *key)
 
 	/* Key record */
 	size = vos_krec_size(&rbund);
-	/* Assume one more key tree node created */
-	size += umem_slab_usize(umm, VOS_SLAB_KEY_NODE);
+	/* Add ample space assuming one tree node is added.  We could refine this later */
+	size += 1024;
 
 	return size;
 }
@@ -208,9 +208,9 @@ estimate_space(struct vos_pool *pool, daos_key_t *dkey, unsigned int iod_nr,
 	int			 i, j;
 
 	/* Object record */
-	scm = umem_slab_usize(umm, VOS_SLAB_OBJ_DF);
+	scm = D_ALIGNUP(sizeof(struct vos_obj_df), 32);
 	/* Assume one more object tree node created */
-	scm += umem_slab_usize(umm, VOS_SLAB_OBJ_NODE);
+	scm += 1024;
 
 	/* Dkey */
 	scm += estimate_space_key(umm, dkey);
@@ -237,7 +237,7 @@ estimate_space(struct vos_pool *pool, daos_key_t *dkey, unsigned int iod_nr,
 					nvme += vos_byte2blkcnt(iod->iod_size);
 			}
 			/* Assume one more SV tree node created */
-			scm += umem_slab_usize(umm, VOS_SLAB_SV_NODE);
+			scm += 256;
 			continue;
 		}
 
@@ -256,11 +256,11 @@ estimate_space(struct vos_pool *pool, daos_key_t *dkey, unsigned int iod_nr,
 			else if (size != 0)
 				nvme += vos_byte2blkcnt(size);
 			/* EVT desc */
-			scm += umem_slab_usize(umm, VOS_SLAB_EVT_DESC);
+			scm += 256;
 			/* Checksum */
 			scm += recx_csum_len(recx, recx_csum, iod->iod_size);
 			/* Assume one more evtree node created */
-			scm += umem_slab_usize(umm, VOS_SLAB_EVT_NODE);
+			scm += 1024;
 		}
 	}
 

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -332,10 +332,7 @@ ktr_rec_update(struct btr_instance *tins, struct btr_record *rec,
 static umem_off_t
 ktr_node_alloc(struct btr_instance *tins, int size)
 {
-	/* Dynamic root could have smaller size */
-	if (size == umem_slab_usize(&tins->ti_umm, VOS_SLAB_KEY_NODE))
-		return vos_slab_alloc(&tins->ti_umm, size, VOS_SLAB_KEY_NODE);
-	return umem_zalloc(&tins->ti_umm, size);
+	return vos_slab_alloc(&tins->ti_umm, size);
 }
 
 static btr_ops_t key_btr_ops = {
@@ -692,10 +689,7 @@ svt_check_availability(struct btr_instance *tins, struct btr_record *rec,
 static umem_off_t
 svt_node_alloc(struct btr_instance *tins, int size)
 {
-	/* Dynamic root could have smaller size */
-	if (size == umem_slab_usize(&tins->ti_umm, VOS_SLAB_SV_NODE))
-		return vos_slab_alloc(&tins->ti_umm, size, VOS_SLAB_SV_NODE);
-	return umem_zalloc(&tins->ti_umm, size);
+	return vos_slab_alloc(&tins->ti_umm, size);
 }
 
 static btr_ops_t singv_btr_ops = {


### PR DESCRIPTION
This is a precursor to subsequent changes I will make in my evtree dynamic root patch.  Rather than defining exact slab values, we define common known ones and use the size, aligned to 32 bytes to calculate the slab id.  This allows us to use the slab allocator for integer key nodes as well since they didn't previously fit the hard coded size definition.

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
