### PR TITLE
DAOS-12074 rebuild: add generation to migrate tls

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -762,21 +762,21 @@ struct ds_migrate_status {
 };
 
 int
-ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver,
+ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, uint32_t generation,
 			struct ds_migrate_status *dms);
 int
 ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_uuid,
-		       uuid_t cont_hdl_uuid, int tgt_id, uint32_t version,
+		       uuid_t cont_hdl_uuid, int tgt_id, uint32_t version, unsigned int generation,
 		       uint64_t max_eph, daos_unit_oid_t *oids, daos_epoch_t *ephs,
 		       daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
 		       uint32_t new_gl_ver, unsigned int migrate_opc);
 int
 ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
-		  uint32_t version, uint64_t max_eph, uint32_t opc, daos_unit_oid_t *oids,
-		  daos_epoch_t *epochs, daos_epoch_t *punched_epochs, unsigned int *shards,
-		  uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);
+		  uint32_t version, uint32_t generation, uint64_t max_eph, uint32_t opc,
+		  daos_unit_oid_t *oids, daos_epoch_t *epochs, daos_epoch_t *punched_epochs,
+		  unsigned int *shards, uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);
 void
-ds_migrate_stop(struct ds_pool *pool, uint32_t ver);
+ds_migrate_stop(struct ds_pool *pool, uint32_t ver, unsigned int generation);
 
 int
 obj_layout_diff(struct pl_map *map, daos_unit_oid_t oid, uint32_t new_ver, uint32_t old_ver,

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -371,7 +371,8 @@ CRT_RPC_DECLARE(obj_sync, DAOS_ISEQ_OBJ_SYNC, DAOS_OSEQ_OBJ_SYNC)
 	((uint64_t)		(om_punched_ephs)	CRT_ARRAY)	\
 	((uint32_t)		(om_shards)		CRT_ARRAY)	\
 	((uint32_t)		(om_new_layout_ver)	CRT_VAR)	\
-	((uint32_t)		(om_opc)		CRT_VAR)
+	((uint32_t)		(om_opc)		CRT_VAR)	\
+	((uint32_t)		(om_generation)		CRT_VAR)
 
 #define DAOS_OSEQ_OBJ_MIGRATE	/* output fields */		 \
 	((int32_t)		(om_status)		CRT_VAR)

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -31,6 +31,7 @@ struct migrate_pool_tls {
 	uuid_t			mpt_pool_uuid;
 	struct ds_pool_child	*mpt_pool;
 	unsigned int		mpt_version;
+	unsigned int		mpt_generation;
 
 	/* Link to the migrate_pool_tls list */
 	d_list_t		mpt_list;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -84,6 +84,7 @@ struct migrate_one {
 	uint32_t		 mo_pool_tls_version;
 	uint32_t		 mo_iods_num_from_parity;
 	uint32_t		 mo_layout_version;
+	uint32_t		 mo_generation;
 	d_list_t		 mo_list;
 	d_iov_t			 mo_csum_iov;
 };
@@ -121,6 +122,7 @@ struct iter_obj_arg {
 	uint64_t		*snaps;
 	uint32_t		snap_cnt;
 	uint32_t		version;
+	uint32_t		generation;
 };
 
 static int
@@ -372,7 +374,7 @@ migrate_pool_tls_put(struct migrate_pool_tls *tls)
 }
 
 struct migrate_pool_tls *
-migrate_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver)
+migrate_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver, uint32_t gen)
 {
 	struct obj_tls	*tls = obj_tls_get();
 	struct migrate_pool_tls *pool_tls;
@@ -382,8 +384,8 @@ migrate_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver)
 	/* Only 1 thread will access the list, no need lock */
 	d_list_for_each_entry(pool_tls, &tls->ot_pool_list, mpt_list) {
 		if (uuid_compare(pool_tls->mpt_pool_uuid, pool_uuid) == 0 &&
-		    (ver == (unsigned int)(-1) ||
-		     ver == pool_tls->mpt_version)) {
+		    (ver == (unsigned int)(-1) || ver == pool_tls->mpt_version) &&
+		    (gen == (unsigned int)(-1) || gen == pool_tls->mpt_generation)) {
 			migrate_pool_tls_get(pool_tls);
 			found = pool_tls;
 			break;
@@ -399,7 +401,8 @@ struct migrate_pool_tls_create_arg {
 	uuid_t  co_hdl_uuid;
 	d_rank_list_t *svc_list;
 	uint64_t max_eph;
-	int	version;
+	unsigned int version;
+	unsigned int generation;
 	uint32_t opc;
 	uint32_t new_layout_ver;
 };
@@ -412,7 +415,7 @@ migrate_pool_tls_create_one(void *data)
 	struct migrate_pool_tls		   *pool_tls;
 	int rc;
 
-	pool_tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
+	pool_tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (pool_tls != NULL) {
 		/* Some one else already created, because collective function
 		 * might yield xstream.
@@ -441,6 +444,7 @@ migrate_pool_tls_create_one(void *data)
 	uuid_copy(pool_tls->mpt_poh_uuid, arg->pool_hdl_uuid);
 	uuid_copy(pool_tls->mpt_coh_uuid, arg->co_hdl_uuid);
 	pool_tls->mpt_version = arg->version;
+	pool_tls->mpt_generation = arg->generation;
 	pool_tls->mpt_rec_count = 0;
 	pool_tls->mpt_obj_count = 0;
 	pool_tls->mpt_size = 0;
@@ -474,9 +478,9 @@ out:
 }
 
 static struct migrate_pool_tls*
-migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
-			       uuid_t pool_hdl_uuid, uuid_t co_hdl_uuid,
-			       uint64_t max_eph, uint32_t new_layout_ver, uint32_t opc)
+migrate_pool_tls_lookup_create(struct ds_pool *pool, unsigned int version, unsigned int generation,
+			       uuid_t pool_hdl_uuid, uuid_t co_hdl_uuid, uint64_t max_eph,
+			       uint32_t new_layout_ver, uint32_t opc)
 {
 	struct migrate_pool_tls *tls = NULL;
 	struct migrate_pool_tls_create_arg arg = { 0 };
@@ -485,7 +489,7 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
 	int			rc = 0;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
-	tls = migrate_pool_tls_lookup(pool->sp_uuid, version);
+	tls = migrate_pool_tls_lookup(pool->sp_uuid, version, generation);
 	if (tls) {
 		if (tls->mpt_init_tls) {
 			ABT_mutex_lock(tls->mpt_init_mutex);
@@ -495,6 +499,7 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
 		return tls;
 	}
 
+	D_ASSERT(generation != (unsigned int)(-1));
 	uuid_copy(arg.pool_uuid, pool->sp_uuid);
 	uuid_copy(arg.pool_hdl_uuid, pool_hdl_uuid);
 	uuid_copy(arg.co_hdl_uuid, co_hdl_uuid);
@@ -502,12 +507,13 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, int version,
 	arg.opc = opc;
 	arg.max_eph = max_eph;
 	arg.new_layout_ver = new_layout_ver;
+	arg.generation = generation;
 	/* dss_task_collective does not do collective on xstream 0 */
 	rc = migrate_pool_tls_create_one(&arg);
 	if (rc)
 		D_GOTO(out, rc);
 
-	tls = migrate_pool_tls_lookup(pool->sp_uuid, version);
+	tls = migrate_pool_tls_lookup(pool->sp_uuid, version, generation);
 	D_ASSERT(tls != NULL);
 	if (opc == RB_OP_REINT)
 		pool->sp_reintegrating++;
@@ -618,7 +624,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 	int			rc = 0;
 
 	tls = migrate_pool_tls_lookup(mrone->mo_pool_uuid,
-				      mrone->mo_pool_tls_version);
+				      mrone->mo_pool_tls_version, mrone->mo_generation);
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(mrone->mo_pool_uuid));
@@ -1655,7 +1661,7 @@ migrate_one_ult(void *arg)
 		dss_sleep(daos_fail_value_get() * 1000000);
 
 	tls = migrate_pool_tls_lookup(mrone->mo_pool_uuid,
-				      mrone->mo_pool_tls_version);
+				      mrone->mo_pool_tls_version, mrone->mo_generation);
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(mrone->mo_pool_uuid));
@@ -2123,7 +2129,7 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 	D_DEBUG(DB_REBUILD, "migrate dkey "DF_KEY" iod nr %d\n", DP_KEY(dkey),
 		iod_eph_total);
 
-	tls = migrate_pool_tls_lookup(iter_arg->pool_uuid, iter_arg->version);
+	tls = migrate_pool_tls_lookup(iter_arg->pool_uuid, iter_arg->version, iter_arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(iter_arg->pool_uuid));
@@ -2184,6 +2190,7 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 	mrone->mo_iod_alloc_num = iod_eph_total;
 	mrone->mo_min_epoch = DAOS_EPOCH_MAX;
 	mrone->mo_version = version;
+	mrone->mo_generation = tls->mpt_generation;
 	mrone->mo_dkey_hash = io->ui_dkey_hash;
 	mrone->mo_layout_version = obj->cob_layout_version;
 	/* only do the copy below when each with inline recx data */
@@ -2283,7 +2290,8 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	if (rc < 0)
 		return rc;
 
-	tls = migrate_pool_tls_lookup(arg->arg->pool_uuid, arg->arg->version);
+	tls = migrate_pool_tls_lookup(arg->arg->pool_uuid, arg->arg->version,
+				      arg->arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(arg->arg->pool_uuid));
@@ -2403,7 +2411,7 @@ migrate_obj_punch_one(void *data)
 	struct ds_cont_child	*cont;
 	int			rc;
 
-	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
+	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(arg->pool_uuid));
@@ -2445,7 +2453,7 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 	struct migrate_one	*tmp;
 	int			rc = 0;
 
-	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
+	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(arg->pool_uuid));
@@ -2734,7 +2742,8 @@ out:
 
 struct migrate_stop_arg {
 	uuid_t	pool_uuid;
-	uint32_t version;
+	unsigned int version;
+	unsigned int generation;
 };
 
 static int
@@ -2744,7 +2753,7 @@ migrate_fini_one_ult(void *data)
 	struct migrate_pool_tls *tls;
 	int			 rc;
 
-	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
+	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (tls == NULL)
 		return 0;
 
@@ -2772,13 +2781,13 @@ migrate_fini_one_ult(void *data)
 
 /* stop the migration */
 void
-ds_migrate_stop(struct ds_pool *pool, unsigned int version)
+ds_migrate_stop(struct ds_pool *pool, unsigned int version, unsigned int generation)
 {
 	struct migrate_pool_tls *tls;
 	struct migrate_stop_arg arg;
 	int			 rc;
 
-	tls = migrate_pool_tls_lookup(pool->sp_uuid, version);
+	tls = migrate_pool_tls_lookup(pool->sp_uuid, version, generation);
 	if (tls == NULL) {
 		D_INFO(DF_UUID" migrate stopped\n", DP_UUID(pool->sp_uuid));
 		return;
@@ -2786,6 +2795,7 @@ ds_migrate_stop(struct ds_pool *pool, unsigned int version)
 
 	uuid_copy(arg.pool_uuid, pool->sp_uuid);
 	arg.version = version;
+	arg.generation = generation;
 	rc = dss_thread_collective(migrate_fini_one_ult, &arg, 0);
 	if (rc)
 		D_ERROR(DF_UUID" migrate stop: %d\n", DP_UUID(pool->sp_uuid), rc);
@@ -2837,7 +2847,7 @@ migrate_obj_ult(void *data)
 	int			 i;
 	int			 rc = 0;
 
-	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
+	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(arg->pool_uuid));
@@ -2909,9 +2919,9 @@ free:
 		tls->mpt_status = rc;
 
 	D_DEBUG(DB_REBUILD, ""DF_UUID"/%u stop migrate obj "DF_UOID
-		" for shard %u executed "DF_U64" : " DF_RC"\n",
+		" for shard %u executed "DF_U64"/"DF_U64" : " DF_RC"\n",
 		DP_UUID(tls->mpt_pool_uuid), tls->mpt_version,
-		DP_UOID(arg->oid), arg->shard, tls->mpt_obj_executed_ult,
+		DP_UOID(arg->oid), arg->shard, tls->mpt_obj_executed_ult, tls->mpt_obj_count,
 		DP_RC(rc));
 free_notls:
 	D_FREE(arg->snaps);
@@ -2954,6 +2964,7 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 	uuid_copy(obj_arg->pool_uuid, cont_arg->pool_tls->mpt_pool_uuid);
 	uuid_copy(obj_arg->cont_uuid, cont_arg->cont_uuid);
 	obj_arg->version = cont_arg->pool_tls->mpt_version;
+	obj_arg->generation = cont_arg->pool_tls->mpt_generation;
 	if (cont_arg->snaps) {
 		D_ALLOC(obj_arg->snaps,
 			sizeof(*cont_arg->snaps) * cont_arg->snap_cnt);
@@ -3310,17 +3321,18 @@ migrate_try_obj_insert(struct migrate_pool_tls *tls, uuid_t co_uuid,
 
 int
 ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
-		  uint32_t version, uint64_t max_eph, uint32_t opc, daos_unit_oid_t *oids,
-		  daos_epoch_t *epochs, daos_epoch_t *punched_epochs, unsigned int *shards,
-		  uint32_t count, unsigned int tgt_idx, uint32_t new_layout_ver)
+		  uint32_t version, unsigned int generation, uint64_t max_eph, uint32_t opc,
+		  daos_unit_oid_t *oids, daos_epoch_t *epochs, daos_epoch_t *punched_epochs,
+		  unsigned int *shards, uint32_t count, unsigned int tgt_idx,
+		  uint32_t new_layout_ver)
 {
 	struct migrate_pool_tls	*tls;
 	int			i;
 	int			rc;
 
 	/* Check if the pool tls exists */
-	tls = migrate_pool_tls_lookup_create(pool, version, po_hdl, co_hdl, max_eph, new_layout_ver,
-					     opc);
+	tls = migrate_pool_tls_lookup_create(pool, version, generation, po_hdl, co_hdl, max_eph,
+					     new_layout_ver, opc);
 	if (tls == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 	if (tls->mpt_fini)
@@ -3431,11 +3443,10 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 		D_GOTO(out, rc);
 	}
 
-	rc = ds_migrate_object(pool, po_hdl_uuid, co_hdl_uuid, co_uuid,
-			       migrate_in->om_version, migrate_in->om_max_eph,
-			       migrate_in->om_opc, oids, ephs, punched_ephs,
-			       shards, oids_count, migrate_in->om_tgt_idx,
-			       migrate_in->om_new_layout_ver);
+	rc = ds_migrate_object(pool, po_hdl_uuid, co_hdl_uuid, co_uuid, migrate_in->om_version,
+			       migrate_in->om_generation, migrate_in->om_max_eph,
+			       migrate_in->om_opc, oids, ephs, punched_ephs, shards, oids_count,
+			       migrate_in->om_tgt_idx, migrate_in->om_new_layout_ver);
 out:
 	if (pool)
 		ds_pool_put(pool);
@@ -3454,6 +3465,7 @@ struct migrate_query_arg {
 	uint32_t generated_ult;
 	uint32_t executed_ult;
 	uint32_t version;
+	uint32_t generation;
 };
 
 static int
@@ -3462,7 +3474,7 @@ migrate_check_one(void *data)
 	struct migrate_query_arg	*arg = data;
 	struct migrate_pool_tls		*tls;
 
-	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
+	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (tls == NULL)
 		return 0;
 
@@ -3488,19 +3500,20 @@ migrate_check_one(void *data)
 }
 
 int
-ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver,
+ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation,
 			struct ds_migrate_status *dms)
 {
 	struct migrate_query_arg	arg = { 0 };
 	struct migrate_pool_tls		*tls;
 	int				rc;
 
-	tls = migrate_pool_tls_lookup(pool_uuid, ver);
+	tls = migrate_pool_tls_lookup(pool_uuid, ver, generation);
 	if (tls == NULL)
 		return 0;
 
 	uuid_copy(arg.pool_uuid, pool_uuid);
 	arg.version = ver;
+	arg.generation = generation;
 	rc = ABT_mutex_create(&arg.status_lock);
 	if (rc != ABT_SUCCESS)
 		D_GOTO(out, rc);
@@ -3549,6 +3562,10 @@ out:
  * param cont_uuid [in]		container uuid.
  * param cont_hdl_uuid [in]	container handle uuid.
  * param tgt_id [in]		target id where the data to be migrated.
+ * param version [in]		rebuild version.
+ * param generation [in]	rebuild generation.
+ * param max_eph [in]		maxim epoch of the migration.
+ * param max_eph [in]		maxim epoch of the migration.
  * param max_eph [in]		maxim epoch of the migration.
  * param oids [in]		array of the objects to be migrated.
  * param ephs [in]		epoch of the objects.
@@ -3563,12 +3580,11 @@ out:
  * return			0 if it succeeds, otherwise errno.
  */
 int
-ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid,
-		       uuid_t cont_hdl_uuid, uuid_t cont_uuid, int tgt_id,
-		       uint32_t version, uint64_t max_eph, daos_unit_oid_t *oids,
-		       daos_epoch_t *ephs, daos_epoch_t *punched_ephs,
-		       unsigned int *shards, int cnt, uint32_t new_layout_ver,
-		       uint32_t migrate_opc)
+ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_hdl_uuid,
+		       uuid_t cont_uuid, int tgt_id, uint32_t version, unsigned int generation,
+		       uint64_t max_eph, daos_unit_oid_t *oids, daos_epoch_t *ephs,
+		       daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
+		       uint32_t new_layout_ver, uint32_t migrate_opc)
 {
 	struct obj_migrate_in	*migrate_in = NULL;
 	struct obj_migrate_out	*migrate_out = NULL;
@@ -3617,6 +3633,7 @@ ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid,
 	uuid_copy(migrate_in->om_cont_uuid, cont_uuid);
 	uuid_copy(migrate_in->om_coh_uuid, cont_hdl_uuid);
 	migrate_in->om_version = version;
+	migrate_in->om_generation = generation;
 	migrate_in->om_max_eph = max_eph,
 	migrate_in->om_tgt_idx = index;
 	migrate_in->om_new_layout_ver = new_layout_ver;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -888,7 +888,7 @@ ds_pool_stop(uuid_t uuid)
 	pool_fetch_hdls_ult_abort(pool);
 
 	ds_rebuild_abort(pool->sp_uuid, -1, -1, -1);
-	ds_migrate_stop(pool, -1);
+	ds_migrate_stop(pool, -1, -1);
 	ds_pool_put(pool); /* held by ds_pool_start */
 	ds_pool_put(pool);
 	D_INFO(DF_UUID": pool service is aborted\n", DP_UUID(uuid));

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -114,10 +114,9 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 		rc = ds_object_migrate_send(rpt->rt_pool, rpt->rt_poh_uuid,
 					    rpt->rt_coh_uuid, arg->cont_uuid,
 					    arg->tgt_id, rpt->rt_rebuild_ver,
-					    rpt->rt_stable_epoch, arg->oids,
-					    arg->ephs, arg->punched_ephs, arg->shards,
-					    arg->count, rpt->rt_new_layout_ver,
-					    rpt->rt_rebuild_op);
+					    rpt->rt_rebuild_gen, rpt->rt_stable_epoch,
+					    arg->oids, arg->ephs, arg->punched_ephs, arg->shards,
+					    arg->count, rpt->rt_new_layout_ver, rpt->rt_rebuild_op);
 		/* If it does not need retry */
 		if (rc == 0 || (rc != -DER_TIMEDOUT && rc != -DER_GRPVER &&
 		    rc != -DER_AGAIN && !daos_crt_network_error(rc)))
@@ -574,9 +573,9 @@ rebuild_obj_ult(void *data)
 	struct rebuild_tgt_pool_tracker	*rpt = arg->rpt;
 
 	ds_migrate_object(rpt->rt_pool, rpt->rt_poh_uuid, rpt->rt_coh_uuid, arg->co_uuid,
-			  rpt->rt_rebuild_ver, rpt->rt_stable_epoch, rpt->rt_rebuild_op,
-			  &arg->oid, &arg->epoch, &arg->punched_epoch, &arg->shard, 1,
-			  arg->tgt_index, rpt->rt_new_layout_ver);
+			  rpt->rt_rebuild_ver, rpt->rt_rebuild_gen, rpt->rt_stable_epoch,
+			  rpt->rt_rebuild_op, &arg->oid, &arg->epoch, &arg->punched_epoch,
+			  &arg->shard, 1, arg->tgt_index, rpt->rt_new_layout_ver);
 	rpt_put(rpt);
 	D_FREE(arg);
 }

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -428,7 +428,7 @@ rebuild_tgt_query(struct rebuild_tgt_pool_tracker *rpt,
 
 	if (rpt->rt_rebuild_op != RB_OP_RECLAIM && rpt->rt_rebuild_op != RB_OP_FAIL_RECLAIM) {
 		rc = ds_migrate_query_status(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
-					     &dms);
+					     rpt->rt_rebuild_gen, &dms);
 		if (rc)
 			D_GOTO(out, rc);
 	}
@@ -2020,7 +2020,7 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 
 	/* destroy the migrate_tls of 0-xstream */
 	if (rpt->rt_rebuild_op != RB_OP_RECLAIM && rpt->rt_rebuild_op != RB_OP_FAIL_RECLAIM)
-		ds_migrate_stop(rpt->rt_pool, rpt->rt_rebuild_ver);
+		ds_migrate_stop(rpt->rt_pool, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
 	d_list_del_init(&rpt->rt_list);
 	rpt_put(rpt);
 	/* No one should access rpt after rebuild_fini_one.

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1222,11 +1222,12 @@ rebuild_wait_reset_fail_cb(void *data)
 {
 	test_arg_t	*arg = data;
 
-	print_message("wait 120 seconds for rebuild/reclaim/retry....");
-	sleep(120);
+	print_message("wait 300 seconds for rebuild/reclaim/retry....");
+	sleep(60);
 
 	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
 	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_VALUE, 0, 0, NULL);
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_NUM, 0, 0, NULL);
 
 	return 0;
 }
@@ -1235,26 +1236,25 @@ static void
 rebuild_many_objects_with_failure(void **state)
 {
 	test_arg_t	*arg = *state;
-	daos_obj_id_t	oid;
-	int		tgt = DEFAULT_FAIL_TGT;
+	daos_obj_id_t	*oids;
+	int		rc;
 	int		i;
 
-	if (!test_runable(arg, 4))
+	if (!test_runable(arg, 6))
 		return;
 
-	for (i = 0; i < 15000; i++) {
-		char buffer[16];
+	D_ALLOC_ARRAY(oids, 8000);
+	for (i = 0; i < 8000; i++) {
+		char buffer[256];
 		daos_recx_t recx;
 		struct ioreq req;
 
-		oid = daos_test_oid_gen(arg->coh, DAOS_OC_R2S_SPEC_RANK, 0, 0, arg->myrank);
-		oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-		oid = dts_oid_set_tgt(oid, DEFAULT_FAIL_TGT);
-		ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-		memset(buffer, 'a', 16);
+		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_3G1, 0, 0, arg->myrank);
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+		memset(buffer, 'a', 256);
 		recx.rx_idx = 0;
-		recx.rx_nr = 16;
-		insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, buffer, 16, &req);
+		recx.rx_nr = 256;
+		insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, buffer, 256, &req);
 
 		ioreq_fini(&req);
 	}
@@ -1262,15 +1262,20 @@ rebuild_many_objects_with_failure(void **state)
 	if (arg->myrank == 0) {
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				      DAOS_REBUILD_OBJ_FAIL | DAOS_FAIL_ALWAYS, 0, NULL);
-		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_VALUE, 100,
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_VALUE, 50,
 				      0, NULL);
 	}
 
 	arg->rebuild_cb = rebuild_wait_reset_fail_cb;
 
-	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
+	rebuild_single_pool_target(arg, 3, -1, false);
 
-	reintegrate_with_inflight_io(arg, &oid, ranks_to_kill[0], tgt);
+	for (i = 0; i < 8000; i++) {
+		rc = daos_obj_verify(arg->coh, oids[i], DAOS_EPOCH_MAX);
+		if (rc != 0)
+			assert_rc_equal(rc, -DER_NOSYS);
+	}
+	D_FREE(oids);
 }
 
 /** create a new pool/container for each test */


### PR DESCRIPTION
Add rebuild generation to migrate tls to avoid the tls being wrongly picked by rebuild retry job, which can cause some objects being skipped during
rebuild/migration.

Required-githooks: true

Signed-off-by: Di Wang <di.wang@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
