### PR TITLE
DAOS-12524 control: Return created pool on retry

### DIFF
--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -268,11 +268,20 @@ func (svc *mgmtSvc) PoolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 	ps, err := svc.sysdb.FindPoolServiceByUUID(poolUUID)
 	if ps != nil {
 		svc.log.Debugf("found pool %s state=%s", ps.PoolUUID, ps.State)
-		resp.Status = int32(drpc.DaosAlready)
 		if ps.State != system.PoolServiceStateReady {
 			resp.Status = int32(drpc.DaosTryAgain)
 			return resp, svc.checkPools(ctx, false, ps)
 		}
+
+		// If the pool is already created and is Ready, just return the existing pool info.
+		// This can happen in the case of a retried PoolCreate after a leadership
+		// shuffle that results in the pool being successfully created by the previous
+		// gRPC handler which returned an error to the client after being unable to
+		// persist the state update.
+		resp.SvcReps = system.RanksToUint32(ps.Replicas)
+		resp.TgtRanks = system.RanksToUint32(ps.Storage.CreationRanks())
+		resp.TierBytes = ps.Storage.PerRankTierStorage
+
 		return resp, nil
 	}
 	if !system.IsPoolNotFound(err) {

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -102,6 +102,7 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 	for name, tc := range map[string]struct {
 		state   system.PoolServiceState
 		expResp *mgmtpb.PoolCreateResp
+		expErr  error
 	}{
 		"creating": {
 			state: system.PoolServiceStateCreating,
@@ -112,7 +113,9 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 		"ready": {
 			state: system.PoolServiceStateReady,
 			expResp: &mgmtpb.PoolCreateResp{
-				Status: int32(drpc.DaosAlready),
+				SvcReps:   []uint32{1},
+				TgtRanks:  []uint32{1},
+				TierBytes: []uint64{1, 2},
 			},
 		},
 		"destroying": {
@@ -127,6 +130,9 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 			defer test.ShowBufferOnFailure(t, buf)
 
 			svc := newTestMgmtSvc(t, log)
+			if _, err := svc.membership.Add(system.MockMember(t, 1, system.MemberStateJoined)); err != nil {
+				t.Fatal(err)
+			}
 			poolUUID := test.MockPoolUUID(1)
 			lock, ctx := getPoolLockCtx(t, nil, svc.sysdb, poolUUID)
 			defer lock.Release()
@@ -134,7 +140,11 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 			if err := svc.sysdb.AddPoolService(ctx, &system.PoolService{
 				PoolUUID: poolUUID,
 				State:    tc.state,
-				Storage:  &system.PoolServiceStorage{},
+				Storage: &system.PoolServiceStorage{
+					CreationRankStr:    "1",
+					PerRankTierStorage: []uint64{1, 2},
+				},
+				Replicas: []system.Rank{1},
 			}); err != nil {
 				t.Fatal(err)
 			}
@@ -146,9 +156,10 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 				Properties: testPoolLabelProp(),
 			}
 
-			gotResp, err := svc.PoolCreate(ctx, req)
-			if err != nil {
-				t.Fatal(err)
+			gotResp, gotErr := svc.PoolCreate(ctx, req)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
 			}
 			if diff := cmp.Diff(tc.expResp, gotResp, test.DefaultCmpOpts()...); diff != "" {
 				t.Fatalf("unexpected response (-want, +got)\n%s\n", diff)


### PR DESCRIPTION
Since #11157 landed, there is a possibility that a retried
pool create may encounter a pool that was automatically
promoted to the Ready state. Instead of returning -DER_ALREADY
(which is unhandled and unhelpful) to the dmg side, just
populate the pool create response as if the retried create handler
was responsible for doing it.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
