### PR TITLE
DAOS-12454 test: fix leap generation of results.xml,html (#11330)

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -712,7 +712,7 @@ class Launch():
         self.mode = mode
 
         self.avocado = AvocadoInfo()
-        self.class_name = f"FTEST_launch.launch-{self.name.lower()}"
+        self.class_name = f"FTEST_launch.launch-{self.name.lower().replace('.', '-')}"
         self.logdir = None
         self.logfile = None
         self.tests = []
@@ -843,19 +843,29 @@ class Launch():
         self._write_details_json()
 
         if self.job and self.result:
-            # Generate a results.xml for the this run
+            # Generate a results.xml for this run
+            results_xml_path = os.path.join(self.logdir, "results.xml")
             try:
+                logger.debug("Creating results.xml: %s", results_xml_path)
                 create_xml(self.job, self.result)
             except ModuleNotFoundError as error:
                 # When SRE-439 is fixed this should be an error
                 logger.warning("Unable to create results.xml file: %s", str(error))
+            else:
+                if not os.path.exists(results_xml_path):
+                    logger.error("results.xml does not exist: %s", results_xml_path)
 
-            # Generate a results.html for the this run
+            # Generate a results.html for this run
+            results_html_path = os.path.join(self.logdir, "results.html")
             try:
+                logger.debug("Creating results.html: %s", results_html_path)
                 create_html(self.job, self.result)
             except ModuleNotFoundError as error:
                 # When SRE-439 is fixed this should be an error
                 logger.warning("Unable to create results.html file: %s", str(error))
+            else:
+                if not os.path.exists(results_html_path):
+                    logger.error("results.html does not exist: %s", results_html_path)
 
         # Set the return code for the program based upon the mode and the provided status
         #   - always return 0 in CI mode since errors will be reported via the results.xml file

--- a/src/tests/ftest/util/results_utils.py
+++ b/src/tests/ftest/util/results_utils.py
@@ -1,10 +1,11 @@
 """
-  (C) Copyright 2022 Intel Corporation.
+  (C) Copyright 2022-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
 import time
+from argparse import Namespace
 
 
 class TestName():
@@ -291,6 +292,7 @@ class Job():
             max_chars (int, optional): maximum number of characters of each test log to include in
                 with any test errors. Defaults to 100000.
         """
+        # For newer avocado versions
         self.config = {
             "job.run.result.xunit.enabled": xml_enabled,
             "job.run.result.xunit.output": xml_output,
@@ -302,7 +304,17 @@ class Job():
             "stdout_claimed_by": None,
         }
         self.logdir = log_dir
-        self.args = None
+
+        # For older avocado versions
+        self.args = Namespace(
+            xunit_job_result=('on' if xml_enabled else 'off'),
+            xunit_output=xml_output,
+            xunit_max_test_log_chars=max_chars,
+            xunit_job_name=name,
+            html_job_result=('on' if html_enabled else 'off'),
+            html_output=html_output,
+            open_browser=False,
+            stdout_claimed_by=None)
 
         # If set to either 'RUNNING', 'ERROR', or 'FAIL' an html result will not be generated
         self.status = "COMPLETE"


### PR DESCRIPTION
Test-tag: pr
Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-test-leap15: false

Combination of #11330 and #11391
- Support older versions of avocado xml and html result generation
- Add logging to launch.py to print an error if the expected xml or html is not generated

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
