### PR TITLE
DAOS-12561 control: Allow floats in pool create tier ratios

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -49,59 +50,64 @@ type tierRatioFlag struct {
 	ratios []float64
 }
 
-func (tr *tierRatioFlag) IsSet() bool {
-	return len(tr.ratios) > 0
+func (trf *tierRatioFlag) IsSet() bool {
+	return len(trf.ratios) > 0
 }
 
-func (tr tierRatioFlag) Ratios() []float64 {
-	if tr.IsSet() {
-		return tr.ratios
+func (trf tierRatioFlag) Ratios() []float64 {
+	if trf.IsSet() {
+		return trf.ratios
 	}
 
 	// Default to 6% SCM:94% NVMe
 	return []float64{0.06, 0.94}
 }
 
-func (tr tierRatioFlag) String() string {
+func (trf tierRatioFlag) String() string {
 	var ratioStrs []string
-	for _, ratio := range tr.Ratios() {
+	for _, ratio := range trf.Ratios() {
 		ratioStrs = append(ratioStrs, fmt.Sprintf("%.2f", ratio))
 	}
 	return strings.Join(ratioStrs, ",")
 }
 
-func (tr *tierRatioFlag) UnmarshalFlag(fv string) error {
+func (trf *tierRatioFlag) UnmarshalFlag(fv string) error {
 	if fv == "" {
 		return errors.New("no tier ratio specified")
 	}
 
-	var ratios []uint64
+	roundFloatTo := func(f float64, places int) float64 {
+		if f <= 0 && f >= 100 {
+			return f
+		}
+		shift := math.Pow(10, float64(places))
+		return math.Round(f*shift) / shift
+	}
+
 	for _, trStr := range strings.Split(fv, ",") {
-		trUint, err := strconv.ParseUint(strings.TrimSpace(trStr), 10, 64)
+		tr, err := strconv.ParseFloat(strings.TrimSpace(trStr), 64)
 		if err != nil {
 			return errors.Wrapf(err, "invalid tier ratio %s", trStr)
 		}
-		ratios = append(ratios, trUint)
+		trf.ratios = append(trf.ratios, roundFloatTo(tr, 2)/100)
 	}
 
 	// Handle single tier ratio as a special case and fill
 	// second tier with remainder (-t 6 will assign 6% of total
 	// storage to tier0 and 94% to tier1).
-	if len(ratios) == 1 && ratios[0] < 100 {
-		ratios = append(ratios, 100-ratios[0])
+	if len(trf.ratios) == 1 && trf.ratios[0] < 1 {
+		trf.ratios = append(trf.ratios, 1-trf.ratios[0])
 	}
 
-	tr.ratios = make([]float64, len(ratios))
-	var totalRatios uint64
-	for tierIdx, ratio := range ratios {
-		if ratio > 100 {
+	var totalRatios float64
+	for _, ratio := range trf.ratios {
+		if ratio > 1 {
 			return errors.New("Storage tier ratio must be a value between 0-100")
 		}
 		totalRatios += ratio
-		tr.ratios[tierIdx] = float64(ratio) / 100
 	}
-	if totalRatios != 100 {
-		return errors.New("Storage tier ratios must add up to 100")
+	if math.Abs(totalRatios-1) > 0.01 {
+		return errors.Errorf("Storage tier ratios must add up to 100 (got %f)", totalRatios*100)
 	}
 
 	return nil

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -211,6 +211,40 @@ func TestPoolCommands(t *testing.T) {
 			nil,
 		},
 		{
+			"Create pool with fine-grained tier-ratios (auto)",
+			fmt.Sprintf("pool create label --size %s --tier-ratio 3.23,96.77", testSizeStr),
+			strings.Join([]string{
+				printRequest(t, &control.PoolCreateReq{
+					TotalBytes: uint64(testSize),
+					TierRatio:  []float64{0.0323, 0.9677},
+					User:       eUsr.Username + "@",
+					UserGroup:  eGrp.Name + "@",
+					Ranks:      []ranklist.Rank{},
+					Properties: []*daos.PoolProperty{
+						propWithVal("label", "label"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Create pool with really fine-grained tier-ratios (auto; rounded)",
+			fmt.Sprintf("pool create label --size %s --tier-ratio 23.725738953,76.274261047", testSizeStr),
+			strings.Join([]string{
+				printRequest(t, &control.PoolCreateReq{
+					TotalBytes: uint64(testSize),
+					TierRatio:  []float64{0.2373, 0.7626999999999999},
+					User:       eUsr.Username + "@",
+					UserGroup:  eGrp.Name + "@",
+					Ranks:      []ranklist.Rank{},
+					Properties: []*daos.PoolProperty{
+						propWithVal("label", "label"),
+					},
+				}),
+			}, " "),
+			nil,
+		},
+		{
 			"Create pool with incompatible arguments (manual)",
 			fmt.Sprintf("pool create label --scm-size %s --nranks 42", testSizeStr),
 			"",


### PR DESCRIPTION
Instead of restricting the inputs to whole integers, allow
float-based inputs for more precision and control over
storage tier allocation.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
