### PR TITLE
DAOS-12364 gurt: Delete old metrics shmem region on startup

### DIFF
--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -189,8 +189,7 @@ attach_shmem(key_t key, size_t size, int flags, struct d_tm_shmem_hdr **shmem)
 
 	shmid = shmget(key, size, flags);
 	if (shmid < 0) {
-		D_ERROR("can't get shmid for key 0x%x, %s\n", key,
-			strerror(errno));
+		D_INFO("can't get shmid for key 0x%x, %s\n", key, strerror(errno));
 		return -DER_NO_SHMEM;
 	}
 
@@ -207,9 +206,16 @@ attach_shmem(key_t key, size_t size, int flags, struct d_tm_shmem_hdr **shmem)
 static int
 new_shmem(key_t key, size_t size, struct d_tm_shmem_hdr **shmem)
 {
+	int rc;
+
 	D_INFO("creating new shared memory segment, key=0x%x, size=%lu\n",
 	       key, size);
-	return attach_shmem(key, size, IPC_CREAT | 0660, shmem);
+	rc = attach_shmem(key, size, IPC_CREAT | 0660, shmem);
+	if (rc < 0)
+		D_ERROR("failed to create shared memory segment, key=0x%x: "DF_RC"\n", key,
+			DP_RC(rc));
+
+	return rc;
 }
 
 static int
@@ -704,6 +710,42 @@ create_shmem(const char *root_path, key_t key, size_t size_bytes,
 	return 0;
 }
 
+int
+destroy_shmem_with_key(key_t key)
+{
+	struct d_tm_shmem_hdr		*header;
+	struct shmem_region_list	*entry;
+	d_list_t			*cur;
+	d_list_t			*head;
+	int				rc;
+	int				shmid;
+
+	rc = open_shmem(key, &header);
+	if (rc == -DER_NO_SHMEM) /* if it doesn't exist, nothing to do */
+		return 0;
+	if (rc < 0) {
+		D_ERROR("Unable to open shmem region 0x%x for cleanup. An admin must clean up "
+			"manually using ipcrm.\n", key);
+		return rc;
+	}
+	shmid = rc;
+
+	header->sh_deleted = 1;
+	head = &header->sh_subregions;
+	for (cur = conv_ptr(header, head->next); cur != head; cur = conv_ptr(header, cur->next)) {
+		entry = d_list_entry(cur, __typeof__(*entry), rl_link);
+		rc = destroy_shmem_with_key(entry->rl_key);
+		if (rc != 0)
+			D_ERROR("Unable to destroy shmem region 0x%x: "DF_RC"\n", entry->rl_key,
+				DP_RC(rc));
+	}
+
+	D_INFO("destroying shmem with key: 0x%x\n", key);
+	destroy_shmem(shmid);
+	close_shmem(header);
+	return 0;
+}
+
 /**
  * Initialize an instance of the telemetry and metrics API for the producer
  * process.
@@ -754,6 +796,9 @@ d_tm_init(int id, uint64_t mem_size, int flags)
 	tm_shmem.id = id;
 	snprintf(tmp, sizeof(tmp), "ID: %d", id);
 	key = d_tm_get_srv_key(id);
+	rc = destroy_shmem_with_key(key);
+	if (rc != 0)
+		goto failure;
 	rc = create_shmem(tmp, key, mem_size, &shmid, &new_shmem);
 	if (rc != 0)
 		goto failure;

--- a/src/gurt/tests/test_gurt_telem_producer.c
+++ b/src/gurt/tests/test_gurt_telem_producer.c
@@ -1277,7 +1277,7 @@ test_shared_memory_cleanup(void **state)
 	/* Detach */
 	d_tm_fini();
 
-	/* can still get retained region*/
+	/* can still get retained region */
 	ctx = d_tm_open(simulated_srv_idx);
 	assert_non_null(ctx);
 	d_tm_close(&ctx);
@@ -1287,6 +1287,48 @@ test_shared_memory_cleanup(void **state)
 	shmid = shmget(key, 0, 0);
 	assert_false(shmid < 0);
 	assert_false(shmctl(shmid, IPC_RMID, NULL) < 0);
+}
+
+static void
+test_cleanup_on_init(void **state)
+{
+	int			idx = TEST_IDX + 1;
+	struct d_tm_context	*ctx;
+	struct d_tm_node_t	*node;
+	key_t			sub_key;
+	int			rc;
+
+	/* Close the default stuff */
+	d_tm_fini();
+
+	/* Retain the old shmem region so we can delete/recreate */
+	rc = d_tm_init(idx, 1024, D_TM_RETAIN_SHMEM);
+	assert_rc_equal(rc, 0);
+
+	/* add sub-region */
+	ctx = d_tm_open(idx);
+	assert_non_null(ctx);
+
+	rc = d_tm_add_ephemeral_dir(&node, 256, "/test1");
+	assert_rc_equal(rc, 0);
+	sub_key = node->dtn_shmem_key;
+
+	d_tm_close(&ctx);
+	d_tm_fini();
+
+	/* Verify the regions survived the fini */
+	rc = shmget(d_tm_get_srv_key(idx), 0, 0);
+	assert_false(rc < 0);
+	rc = shmget(sub_key, 0, 0);
+	assert_false(rc < 0);
+
+	/* Recreate fresh */
+	rc = d_tm_init(idx, 2048, 0);
+	assert_rc_equal(rc, 0);
+
+	/* Verify the sub-region was destroyed in recreate */
+	rc = shmget(sub_key, 0, 0);
+	assert_true(rc < 0);
 }
 
 static int
@@ -1327,6 +1369,7 @@ main(int argc, char **argv)
 		cmocka_unit_test(test_print_metrics),
 		/* Run last since nothing can be written afterward */
 		cmocka_unit_test(test_shared_memory_cleanup),
+		cmocka_unit_test(test_cleanup_on_init),
 	};
 
 	d_register_alt_assert(mock_assert);


### PR DESCRIPTION
If the user increases the number of targets in the server config, the size of the old shmem region may not be large enough for per-target metrics. Instead of reattaching to the old region, we now delete it if it exists before creating the new one.

Features: telemetry

Required-githooks: true

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
