### PR TITLE
SRE-549 test: Install MOFED ... (#10628)

### DIFF
--- a/ci/provisioning/post_provision_config_common.sh
+++ b/ci/provisioning/post_provision_config_common.sh
@@ -56,3 +56,6 @@ case "$id" in
         EXCLUDE_UPGRADE+=,fuse,fuse-libs,fuse-devel
         ;;
 esac
+
+# shellcheck disable=SC2034
+MLNX_VER_NUM=5.6-2.0.9.0

--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -256,6 +256,27 @@ post_provision_config_nodes() {
                      slurm-example-configs slurmctld slurm-slurmmd
     fi
 
+    lsb_release -a
+
+    # start with everything fully up-to-date
+    # all subsequent package installs beyond this will install the newest packages
+    # but we need some hacks for images with MOFED already installed
+    cmd=(retry_dnf 600)
+    if grep MOFED_VERSION /etc/do-release; then
+        cmd+=(--setopt=best=0 upgrade --exclude "$EXCLUDE_UPGRADE")
+    else
+        cmd+=(upgrade)
+    fi
+    if ! "${cmd[@]}"; then
+        dump_repos
+        return 1
+    fi
+
+    if lspci | grep "ConnectX-6" && ! grep MOFED_VERSION /etc/do-release; then
+        # Remove OPA and install MOFED
+        install_mofed
+    fi
+
     if [ -n "$INST_REPOS" ]; then
         local repo
         for repo in $INST_REPOS; do
@@ -301,15 +322,6 @@ post_provision_config_nodes() {
     fi
 
     distro_custom
-
-    lsb_release -a
-
-    # now make sure everything is fully up-to-date
-    # shellcheck disable=SC2154
-    if ! retry_dnf 600 --setopt=best=0 upgrade --exclude "$EXCLUDE_UPGRADE"; then
-        dump_repos
-        return 1
-    fi
 
     lsb_release -a
 

--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -321,6 +321,34 @@ post_provision_config_nodes() {
         fi
     fi
 
+    if lspci | grep "ConnectX-6" && ! grep MOFED_VERSION /etc/do-release; then
+        # Need this module file
+        version="$(rpm -q --qf "%{version}" openmpi)"
+        mkdir -p /etc/modulefiles/mpi/
+        cat << EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
+#%Module 1.0
+#
+#  OpenMPI module for use with 'environment-modules' package:
+#
+conflict		mpi
+prepend-path 		PATH 		/usr/mpi/gcc/openmpi-$version/bin
+prepend-path 		LD_LIBRARY_PATH /usr/mpi/gcc/openmpi-$version/lib64
+prepend-path 		PKG_CONFIG_PATH	/usr/mpi/gcc/openmpi-$version/lib64/pkgconfig
+prepend-path		MANPATH		/usr/mpi/gcc/openmpi-$version/share/man
+setenv 			MPI_BIN		/usr/mpi/gcc/openmpi-$version/bin
+setenv			MPI_SYSCONFIG	/usr/mpi/gcc/openmpi-$version/etc
+setenv			MPI_FORTRAN_MOD_DIR	/usr/mpi/gcc/openmpi-$version/lib64
+setenv			MPI_INCLUDE	/usr/mpi/gcc/openmpi-$version/include
+setenv	 		MPI_LIB		/usr/mpi/gcc/openmpi-$version/lib64
+setenv			MPI_MAN			/usr/mpi/gcc/openmpi-$version/share/man
+setenv			MPI_COMPILER	openmpi-x86_64
+setenv			MPI_SUFFIX	_openmpi
+setenv	 		MPI_HOME	/usr/mpi/gcc/openmpi-$version
+EOF
+
+        printf 'MOFED_VERSION=%s\n' "$MLNX_VER_NUM" >> /etc/do-release
+    fi 
+
     distro_custom
 
     lsb_release -a

--- a/ci/provisioning/post_provision_config_nodes.sh
+++ b/ci/provisioning/post_provision_config_nodes.sh
@@ -31,8 +31,8 @@ add_repo() {
         local repo_url="${REPOSITORY_URL}${add_repo}"
         local repo_name
         repo_name=$(url_to_repo "$repo_url")
-        if ! dnf repolist | grep "$repo_name"; then
-            dnf config-manager --add-repo="${repo_url}" >&2
+        if ! dnf -y repolist | grep "$repo_name"; then
+            dnf -y config-manager --add-repo="${repo_url}" >&2
             if ! $gpg_check; then
                 disable_gpg_check "$add_repo" >&2
             fi
@@ -57,8 +57,8 @@ disable_gpg_check() {
 
     repo="$(url_to_repo "$url")"
     # bug in EL7 DNF: this needs to be enabled before it can be disabled
-    dnf config-manager --save --setopt="$repo".gpgcheck=1
-    dnf config-manager --save --setopt="$repo".gpgcheck=0
+    dnf -y config-manager --save --setopt="$repo".gpgcheck=1
+    dnf -y config-manager --save --setopt="$repo".gpgcheck=0
     # but even that seems to be not enough, so just brute-force it
     if [ -d /etc/yum.repos.d ] &&
        ! grep gpgcheck /etc/yum.repos.d/"$repo".repo; then

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+#
+#  (C) Copyright 2021-2023 Intel Corporation.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 bootstrap_dnf() {
     systemctl enable postfix.service
@@ -18,88 +22,88 @@ distro_custom() {
     # for Launchable's pip install
     dnf -y install python3-setuptools.noarch
 
-    # New Rocky images don't have debuginfo baked into them
-    if ! dnf --enablerepo=\*-debuginfo repolist 2>/dev/null | grep -e -debuginfo; then
-        if [ "$(lsb_release -s -i)" = "Rocky" ]; then
-            # Need to remove the upstream [debuginfo] repos
-            # But need to have the files present so that re-installation is blocked
-            for file in /etc/yum.repos.d/{Rocky-Debuginfo,epel{,{,-testing}-modular}}.repo; do
-                true > $file
-            done
+}
 
-            # add local debuginfo repos
-            if [ -f /etc/yum.repos.d/daos_ci-rocky8-artifactory.repo ]; then
-                echo >> /etc/yum.repos.d/daos_ci-rocky8-artifactory.repo
-            fi
-
-            cat <<EOF >> /etc/yum.repos.d/daos_ci-rocky8-artifactory.repo
-[daos_ci-rocky8-base-artifactory-debuginfo]
-name=daos_ci-rocky8-base-artifactory-debuginfo
-baseurl=${ARTIFACTORY_URL}artifactory/rocky-\$releasever-proxy/BaseOS/\$arch/debug/tree/
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
-
-[daos_ci-rocky8-appstream-artifactory-debuginfo]
-name=daos_ci-rocky8-appstream-artifactory-debuginfo
-baseurl=${ARTIFACTORY_URL}artifactory/rocky-\$releasever-proxy/AppStream/\$arch/debug/tree/
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
-
-[daos_ci-rocky8-powertools-artifactory-debuginfo]
-name=daos_ci-rocky8-powertools-artifactory-debuginfo
-baseurl=${ARTIFACTORY_URL}artifactory/rocky-\$releasever-proxy/PowerTools/\$arch/debug/tree/
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
-
-[daos_ci-rocky8-extras-artifactory-debuginfo]
-name=daos_ci-rocky8-extras-artifactory-debuginfo
-baseurl=${ARTIFACTORY_URL}artifactory/rocky-\$releasever-proxy/extras/\$arch/debug/tree/
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
-EOF
-        else
-            if [ -f /etc/yum.repos.d/daos_ci-centos8.repo ]; then
-                echo >> /etc/yum.repos.d/daos_ci-centos8.repo
-            fi
-
-            cat <<EOF >> /etc/yum.repos.d/daos_ci-centos8.repo
-[daos_ci-centos8-artifactory-debuginfo]
-name=daos_ci-centos8-artifactory-debuginfo
-baseurl=${ARTIFACTORY_URL}artifactory/centos-debuginfo-proxy/\$releasever/\$basearch/
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-EOF
-        fi
+install_mofed() {
+    if [ -z "$MLNX_VER_NUM" ]; then
+        echo "MLNX_VER_NUM is not set"
+        env
+        exit 1
     fi
 
-    # Mellanox OFED hack
-    if ls -d /usr/mpi/gcc/openmpi-*; then
-        version="$(rpm -q --qf "%{version}" openmpi)"
-        mkdir -p /etc/modulefiles/mpi/
-        cat <<EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
-#%Module 1.0
-#
-#  OpenMPI module for use with 'environment-modules' package:
-#
-conflict		mpi
-prepend-path 		PATH 		/usr/mpi/gcc/openmpi-${version}/bin
-prepend-path 		LD_LIBRARY_PATH /usr/mpi/gcc/openmpi-${version}/lib64
-prepend-path 		PKG_CONFIG_PATH	/usr/mpi/gcc/openmpi-${version}/lib64/pkgconfig
-prepend-path		MANPATH		/usr/mpi/gcc/openmpi-${version}/share/man
-setenv 			MPI_BIN		/usr/mpi/gcc/openmpi-${version}/bin
-setenv			MPI_SYSCONFIG	/usr/mpi/gcc/openmpi-${version}/etc
-setenv			MPI_FORTRAN_MOD_DIR	/usr/mpi/gcc/openmpi-${version}/lib64
-setenv			MPI_INCLUDE	/usr/mpi/gcc/openmpi-${version}/include
-setenv	 		MPI_LIB		/usr/mpi/gcc/openmpi-${version}/lib64
-setenv			MPI_MAN			/usr/mpi/gcc/openmpi-${version}/share/man
-setenv			MPI_COMPILER	openmpi-x86_64
-setenv			MPI_SUFFIX	_openmpi
-setenv	 		MPI_HOME	/usr/mpi/gcc/openmpi-${version}
-EOF
+    # Remove omnipath software
+    # shellcheck disable=SC2046
+    time dnf -y remove $(rpm -q opa-address-resolution \
+                                opa-basic-tools \
+                                opa-fastfabric \
+                                opa-libopamgt \
+                                compat-openmpi16 \
+                                compat-openmpi16-devel \
+                                openmpi \
+                                openmpi-devel \
+                                ompi \
+                                ompi-debuginfo \
+                                ompi-devel | grep -v 'is not installed')
+
+
+    stream=false
+    gversion="$(lsb_release -sr)"
+    if [ "$gversion" == "8" ]; then
+        gversion="8.6"
+        stream=true
+     elif [[ $gversion = *.*.* ]]; then
+        gversion="${gversion%.*}"
     fi
+
+    # Add a repo to install MOFED RPMS
+    repo_url=https://artifactory.dc.hpdd.intel.com/artifactory/mlnx_ofed/"$MLNX_VER_NUM-rhel$gversion"-x86_64/
+    dnf -y config-manager --add-repo="$repo_url"
+    curl -L -O "$repo_url"RPM-GPG-KEY-Mellanox
+    dnf -y config-manager --save --setopt="$(url_to_repo "$repo_url")".gpgcheck=1
+    rpm --import RPM-GPG-KEY-Mellanox
+    rm -f RPM-GPG-KEY-Mellanox
+    dnf repolist || true
+
+    time dnf -y install mlnx-ofed-basic
+
+    # now, upgrade firmware
+    time dnf -y install mlnx-fw-updater
+
+    # Make sure that tools are present.
+    #ls /usr/bin/ib_* /usr/bin/ibv_*
+
+    dnf list --showduplicates perftest
+    if [ "$gversion" == "8.5" ]; then
+        dnf remove -y perftest || true
+    fi
+    if $stream; then
+        dnf list --showduplicates ucx-knem
+        dnf remove -y ucx-knem || true
+    fi
+
+    # Need this module file
+    version="$(rpm -q --qf "%{version}" openmpi)"
+    mkdir -p /etc/modulefiles/mpi/
+    cat << EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
+    #%Module 1.0
+    #
+    #  OpenMPI module for use with 'environment-modules' package:
+    #
+    conflict		mpi
+    prepend-path 		PATH 		/usr/mpi/gcc/openmpi-$version/bin
+    prepend-path 		LD_LIBRARY_PATH /usr/mpi/gcc/openmpi-$version/lib64
+    prepend-path 		PKG_CONFIG_PATH	/usr/mpi/gcc/openmpi-$version/lib64/pkgconfig
+    prepend-path		MANPATH		/usr/mpi/gcc/openmpi-$version/share/man
+    setenv 			MPI_BIN		/usr/mpi/gcc/openmpi-$version/bin
+    setenv			MPI_SYSCONFIG	/usr/mpi/gcc/openmpi-$version/etc
+    setenv			MPI_FORTRAN_MOD_DIR	/usr/mpi/gcc/openmpi-$version/lib64
+    setenv			MPI_INCLUDE	/usr/mpi/gcc/openmpi-$version/include
+    setenv	 		MPI_LIB		/usr/mpi/gcc/openmpi-$version/lib64
+    setenv			MPI_MAN			/usr/mpi/gcc/openmpi-$version/share/man
+    setenv			MPI_COMPILER	openmpi-x86_64
+    setenv			MPI_SUFFIX	_openmpi
+    setenv	 		MPI_HOME	/usr/mpi/gcc/openmpi-$version
+EOF
+
+    printf 'MOFED_VERSION=%s\n' "$MLNX_VER_NUM" >> /etc/do-release
 }

--- a/ci/provisioning/post_provision_config_nodes_EL_8.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_8.sh
@@ -64,7 +64,7 @@ install_mofed() {
     rm -f RPM-GPG-KEY-Mellanox
     dnf repolist || true
 
-    time dnf -y install mlnx-ofed-basic
+    time dnf -y install mlnx-ofed-basic ucx-cma ucx-ib ucx-knem ucx-rdmacm ucx-xpmem
 
     # now, upgrade firmware
     time dnf -y install mlnx-fw-updater
@@ -81,29 +81,4 @@ install_mofed() {
         dnf remove -y ucx-knem || true
     fi
 
-    # Need this module file
-    version="$(rpm -q --qf "%{version}" openmpi)"
-    mkdir -p /etc/modulefiles/mpi/
-    cat << EOF > /etc/modulefiles/mpi/mlnx_openmpi-x86_64
-    #%Module 1.0
-    #
-    #  OpenMPI module for use with 'environment-modules' package:
-    #
-    conflict		mpi
-    prepend-path 		PATH 		/usr/mpi/gcc/openmpi-$version/bin
-    prepend-path 		LD_LIBRARY_PATH /usr/mpi/gcc/openmpi-$version/lib64
-    prepend-path 		PKG_CONFIG_PATH	/usr/mpi/gcc/openmpi-$version/lib64/pkgconfig
-    prepend-path		MANPATH		/usr/mpi/gcc/openmpi-$version/share/man
-    setenv 			MPI_BIN		/usr/mpi/gcc/openmpi-$version/bin
-    setenv			MPI_SYSCONFIG	/usr/mpi/gcc/openmpi-$version/etc
-    setenv			MPI_FORTRAN_MOD_DIR	/usr/mpi/gcc/openmpi-$version/lib64
-    setenv			MPI_INCLUDE	/usr/mpi/gcc/openmpi-$version/include
-    setenv	 		MPI_LIB		/usr/mpi/gcc/openmpi-$version/lib64
-    setenv			MPI_MAN			/usr/mpi/gcc/openmpi-$version/share/man
-    setenv			MPI_COMPILER	openmpi-x86_64
-    setenv			MPI_SUFFIX	_openmpi
-    setenv	 		MPI_HOME	/usr/mpi/gcc/openmpi-$version
-EOF
-
-    printf 'MOFED_VERSION=%s\n' "$MLNX_VER_NUM" >> /etc/do-release
 }


### PR DESCRIPTION
during node provisioning, so that the network stack and/or version can
be chosen per test run.

SRE-549 test: Install MOFED ucx-* packages (#10756)
    
Install ucx-{cma,ib,knem,rdmacm,xpmem} from the MOFED repo.

Move the modulefile module creation from being EL8 specific to being
done in post_provision_config_nodes() on all distros.

Fixes: DAOS-12361