### PR TITLE
DAOS-12072 control: Check client cert dir on startup

### DIFF
--- a/src/control/lib/daos/status.go
+++ b/src/control/lib/daos/status.go
@@ -150,4 +150,6 @@ const (
 	ChecksumError Status = -C.DER_CSUM
 	// ControlIncompatible indicates that one or more control plane components are incompatible
 	ControlIncompatible Status = -C.DER_CONTROL_INCOMPAT
+	// NoCert indicates that one or more configured certificates could not be accessed.
+	NoCert Status = -C.DER_NO_CERT
 )

--- a/src/control/security/config.go
+++ b/src/control/security/config.go
@@ -12,6 +12,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/fs"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -123,6 +124,13 @@ func (tc *TransportConfig) PreLoadCertData() error {
 		// In order to reload data use ReloadCertDatA
 		return nil
 	}
+
+	if tc.ClientCertDir != "" {
+		if _, err := os.ReadDir(tc.ClientCertDir); err != nil {
+			return FaultUnreadableCertFile(tc.ClientCertDir)
+		}
+	}
+
 	certificate, certPool, err := loadCertWithCustomCA(tc.CARootPath, tc.CertificatePath, tc.PrivateKeyPath, tc.maxKeyPerms)
 	if err != nil {
 		return err

--- a/src/control/server/security_rpc.go
+++ b/src/control/server/security_rpc.go
@@ -52,12 +52,12 @@ func (m *SecurityModule) processValidateCredentials(body []byte) ([]byte, error)
 	if m.config.AllowInsecure {
 		key = nil
 	} else {
-		certName := fmt.Sprintf("%s.%s", cred.Origin, "crt")
+		certName := fmt.Sprintf("%s.crt", cred.Origin)
 		certPath := filepath.Join(m.config.ClientCertDir, certName)
 		cert, err := security.LoadCertificate(certPath)
 		if err != nil {
 			m.log.Errorf("loading certificate %s failed: %v", certPath, err)
-			return m.validateRespWithStatus(daos.BadPath)
+			return m.validateRespWithStatus(daos.NoCert)
 		}
 		key = cert.PublicKey
 	}

--- a/src/control/server/security_rpc_test.go
+++ b/src/control/server/security_rpc_test.go
@@ -317,7 +317,7 @@ func TestSrvSecurityModule_ValidateCred_Secure_LoadingCertFailed(t *testing.T) {
 	}
 
 	expectValidateResp(t, resp, &auth.ValidateCredResp{
-		Status: int32(daos.BadPath),
+		Status: int32(daos.NoCert),
 	})
 }
 

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -285,7 +285,9 @@ extern "C" {
 	ACTION(DER_UPDATE_AGAIN,	(DER_ERR_DAOS_BASE + 41),	\
 	       update again)						\
 	ACTION(DER_NVME_IO,		(DER_ERR_DAOS_BASE + 42),	\
-	       NVMe I/O error)
+	       NVMe I/O error)						\
+	ACTION(DER_NO_CERT,		(DER_ERR_DAOS_BASE + 43),	\
+	       Unable to access one or more certificates)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\


### PR DESCRIPTION
- Verify the client certificate directory is accessible during DAOS server startup.
- Provide a more descriptive error if the client certs can't be loaded at runtime.

Features: security control

Required-githooks: true

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
