### PR TITLE
DAOS-12580 test: Fix vos md-on-ssd unit tests

### DIFF
--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -148,7 +148,7 @@ if [ -d "/mnt/daos" ]; then
 
         rm -f "${AIO_DEV}"
         dd if=/dev/zero of="${AIO_DEV}" bs=1G count=20
-        sed -i "s+\"name\": \"AIO_1\"+\"name\": \"AIO_1_1_7\"+g" ${NVME_CONF}
+        sed -i "s+\"name\": \"AIO_1\"+\"name\": \"AIO_7\"+g" ${NVME_CONF}
 
         run_test "sudo -E ${SL_PREFIX}/bin/vos_tests" -a
 


### PR DESCRIPTION
Fix the standalone vos_tests failure related to reading JSON config
file. nvme_glb.bd_nvme_conf is freed stack memory in bio_xsctxt_alloc()
when spdk_subsystem_init_from_json_config(nvme_glb.bd_nvme_conf, ...)
is called (as memory confined in scope to bio_nvme_init). Allocate by
copying string and free explicitly on bio_nvme_fini.

Required-githooks: true

Co-authored-by: Dmitry Ivanov <dmitry.ivanov2@hpe.com>
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
