### PR TITLE
DAOS-12584 build: fix d_test_program() method's prototype

### DIFF
--- a/src/common/tests/SConscript
+++ b/src/common/tests/SConscript
@@ -25,7 +25,7 @@ def scons():
     if tenv["STACK_MMAP"] == 1:
         new_env = tenv.Clone()
         new_env.Append(CCFLAGS=['-DULT_MMAP_STACK'])
-        new_env.d_test_program(new_env, 'abt_perf', 'abt_perf.c',
+        new_env.d_test_program('abt_perf', 'abt_perf.c',
                                LIBS=['daos_common_pmem', 'gurt', 'abt'])
     else:
         tenv.d_test_program('abt_perf', 'abt_perf.c',


### PR DESCRIPTION
Since commit 6711cc9cb15d73447972c0f000c8a0f30bb962db the Env is not passed as the first parameter of
d_test_program() method since it is its "self" now. But this behavioral change had mistakenly not been propagated to the "STACK_MMAP==1" conditional branch.

Required-githooks: true

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
