### PR TITLE
DAOS-8714 cart: Fix hdf5 test under tcp.

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -242,9 +242,12 @@ read_map_buf(struct rdb_tx *tx, const rdb_path_t *kvs, struct pool_buf **buf,
 		return rc;
 	size = pool_buf_size(b->pb_nr);
 	D_ALLOC(*buf, size);
+	D_EMIT("alloc-ed buf: %d\n", buf ? 1 : 0);
 	if (*buf == NULL)
 		return -DER_NOMEM;
+	D_EMIT("memcpy buf, \n");
 	memcpy(*buf, b, size);
+	D_EMIT("memcpy-ed buf, \n");
 	return 0;
 }
 
@@ -3566,7 +3569,9 @@ ds_pool_query_handler(crt_rpc_t *rpc, int version)
 	if (rc != 0)
 		D_GOTO(out_svc, rc);
 
+	D_EMIT("Getting ps_lock\n");
 	ABT_rwlock_rdlock(svc->ps_lock);
+	D_EMIT("Got ps_lock\n");
 
 	/* Verify the pool handle for client calls.
 	 * Note: since rebuild will not connect the pool, so we only verify
@@ -3705,28 +3710,35 @@ ds_pool_query_handler(crt_rpc_t *rpc, int version)
 		}
 	}
 
+	D_EMIT("Reading map buf\n");
 	rc = read_map_buf(&tx, &svc->ps_root, &map_buf, &map_version);
+	D_EMIT("Read map buf, rc: %d\n", rc);
 	if (rc != 0)
 		D_ERROR(DF_UUID": failed to read pool map: "DF_RC"\n",
 			DP_UUID(svc->ps_uuid), DP_RC(rc));
 
 out_lock:
+	D_EMIT("Unlocking ABT_rwlock\n");
 	ABT_rwlock_unlock(svc->ps_lock);
 	rdb_tx_end(&tx);
 	if (rc != 0)
 		goto out_svc;
 
+	D_EMIT("transfer map buf\n");
 	rc = ds_pool_transfer_map_buf(map_buf, map_version, rpc,
 				      in->pqi_map_bulk, &out->pqo_map_buf_size);
+	D_EMIT("free map buf\n");
 	D_FREE(map_buf);
 	if (rc != 0)
 		goto out_svc;
 
+	D_EMIT("sp_metrics\n");
 	metrics = svc->ps_pool->sp_metrics[DAOS_POOL_MODULE];
 
 	/* See comment above, rebuild doesn't connect the pool */
 	if ((in->pqi_query_bits & DAOS_PO_QUERY_SPACE) &&
 	    !is_pool_from_srv(in->pqi_op.pi_uuid, in->pqi_op.pi_hdl)) {
+		D_DEBUG(DB_MD, "pool_space_query_bcast\n");
 		rc = pool_space_query_bcast(rpc->cr_ctx, svc, in->pqi_op.pi_hdl,
 					    &out->pqo_space);
 		if (unlikely(rc))
@@ -3734,6 +3746,7 @@ out_lock:
 
 		d_tm_inc_counter(metrics->query_space_total, 1);
 	}
+	D_EMIT("d_tm_inc_counter\n");
 	d_tm_inc_counter(metrics->query_total, 1);
 
 out_svc:

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -163,7 +163,9 @@ ds_pool_transfer_map_buf(struct pool_buf *map_buf, uint32_t map_version,
 	map_sgl.sg_nr_out = 0;
 	map_sgl.sg_iovs = &map_iov;
 
+	D_EMIT("Creating bulk.");
 	rc = crt_bulk_create(rpc->cr_ctx, &map_sgl, CRT_BULK_RO, &bulk);
+	D_EMIT("Created bulk.");
 	if (rc != 0)
 		goto out;
 


### PR DESCRIPTION
Skip-build-leap15-icc: true
Skip-build-el8-gcc: true
Skip-func-test-vm: true
Skip-unit-tests: true
Skip-func-hw-test-large: true
Test-tag: pr daily_regression
Test-provider: ofi+tcp

Signed-off-by: Joseph Moore <joseph.moore@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
