### PR TITLE
DAOS-12610 vos: Add iterator API to validate current position

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1035,6 +1035,21 @@ int
 vos_iter_empty(daos_handle_t ih);
 
 /**
+ * When the callback executes code that may yield, in some cases, it needs to
+ * verify the value or key it is operating on still exists before continuing.
+ * This function will revalidate from the object layer down.   This is only
+ * supported in conjunction with recursive vos_iterate from VOS_ITER_OBJ.
+ *
+ * \param[in]	ih	The iterator handle
+ *
+ * \return		0 if iterator value is valid
+ *			VOS_ITER_* level that needs probe
+ *			<0 on error
+ */
+int
+vos_iter_validate(daos_handle_t ih);
+
+/**
  * Iterate VOS entries (i.e., containers, objects, dkeys, etc.) and call \a
  * cb(\a arg) for each entry.
  *
@@ -1325,10 +1340,9 @@ struct scrub_ctx {
 	sc_yield_fn_t		 sc_yield_fn;
 	void			*sc_sched_arg;
 
-	enum scrub_status	 sc_status;
-	uint8_t			 sc_did_yield:1,
-				 sc_cont_loaded :1, /* Have all the containers been loaded */
-				 sc_first_pass_done:1; /* Is this the first pass of the scrubber */
+	enum scrub_status        sc_status;
+	uint8_t                  sc_cont_loaded : 1, /* Have all the containers been loaded */
+	    sc_first_pass_done                  : 1; /* Is this the first pass of the scrubber */
 };
 
 /*

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -553,12 +553,9 @@ struct vos_iter_anchors {
 	/** Anchor for EV tree */
 	daos_anchor_t	ia_ev;
 	/** Triggers for re-probe */
-	unsigned int	ia_reprobe_co:1,
-			ia_reprobe_obj:1,
-			ia_reprobe_dkey:1,
-			ia_reprobe_akey:1,
-			ia_reprobe_sv:1,
-			ia_reprobe_ev:1;
+	unsigned int    ia_reprobe_co : 1, ia_reprobe_obj : 1, ia_reprobe_dkey : 1,
+	    ia_reprobe_akey : 1, ia_reprobe_sv : 1, ia_reprobe_ev : 1;
+	unsigned int ia_probe_level;
 };
 
 /* Ignores DTX as they are transient records */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -912,6 +912,8 @@ struct vos_iterator {
 	struct vos_ts_set	*it_ts_set;
 	vos_iter_filter_cb_t	 it_filter_cb;
 	void			*it_filter_arg;
+	uint64_t                 it_seq;
+	struct vos_iter_anchors *it_anchors;
 	daos_epoch_t		 it_bound;
 	vos_iter_type_t		 it_type;
 	enum vos_iter_state	 it_state;

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -619,6 +619,11 @@ advance_stage(vos_iter_type_t type, unsigned int acts, vos_iter_param_t *param,
 	if (acts & VOS_ITER_CB_EXIT)
 		D_GOTO(out, rc = ITER_EXIT);
 
+	if (anchors->ia_probe_level != 0) {
+		anchors->ia_probe_level = 0;
+		acts |= VOS_ITER_CB_YIELD;
+	}
+
 	set_reprobe(type, acts, anchors, param->ip_flags);
 	if (acts & VOS_ITER_CB_ABORT)
 		D_GOTO(out, rc = ITER_ABORT);
@@ -648,17 +653,33 @@ out:
 	return rc;
 }
 
+static inline void
+vos_iter_sched_sync(struct vos_iterator *iter)
+{
+	iter->it_seq = vos_sched_seq();
+}
+
+static inline bool
+vos_iter_sched_check(struct vos_iterator *iter)
+{
+	uint64_t seq = vos_sched_seq();
+	bool     ret = iter->it_seq != seq;
+
+	iter->it_seq = seq;
+	return ret;
+}
 
 static inline int
 vos_iter_cb(vos_iter_cb_t iter_cb, daos_handle_t ih, vos_iter_entry_t *iter_ent,
 	    vos_iter_type_t type, vos_iter_param_t *param, void *arg, unsigned int *acts)
 {
-	uint64_t	start_seq = vos_sched_seq();
+	struct vos_iterator *iter = vos_hdl2iter(ih);
 	int		rc;
 
+	vos_iter_sched_sync(iter);
 	D_ASSERT(iter_cb != NULL);
 	rc = iter_cb(ih, iter_ent, type, param, arg, acts);
-	if (start_seq != vos_sched_seq())
+	if (vos_iter_sched_check(iter))
 		*acts |= VOS_ITER_CB_YIELD;
 
 	return rc;
@@ -732,6 +753,8 @@ vos_iterate_internal(vos_iter_param_t *param, vos_iter_type_t type,
 	}
 
 	iter = vos_hdl2iter(ih);
+	/** Save pointer to anchors for vos_iter_validate */
+	iter->it_anchors          = anchors;
 	iter->it_show_uncommitted = 0;
 	if (show_uncommitted) {
 		iter->it_show_uncommitted = 1;
@@ -773,9 +796,13 @@ probe:
 
 		if (pre_cb && stage == VOS_ITER_STAGE_PRE) {
 			acts = 0;
+			anchors->ia_probe_level = 0;
 			rc = vos_iter_cb(pre_cb, ih, &iter_ent, type, param, arg, &acts);
 			if (rc != 0)
 				break;
+			if (anchors->ia_probe_level != 0 &&
+			    anchors->ia_probe_level != iter->it_type)
+				goto finish;
 
 			rc = advance_stage(type, acts, param, anchors, anchor, &stage,
 					   VOS_ITER_STAGE_RECURSE, &probe_flags);
@@ -818,6 +845,10 @@ probe:
 
 			reset_anchors(iter_ent.ie_child_type, anchors);
 
+			if (anchors->ia_probe_level != 0 &&
+			    anchors->ia_probe_level != iter->it_type)
+				goto finish;
+
 			rc = advance_stage(type, 0, param, anchors, anchor, &stage,
 					   VOS_ITER_STAGE_POST, &probe_flags);
 			JUMP_TO_STAGE(rc, next, probe, out);
@@ -830,9 +861,14 @@ probe:
 
 		if (post_cb) {
 			acts = 0;
+			anchors->ia_probe_level = 0;
 			rc = vos_iter_cb(post_cb, ih, &iter_ent, type, param, arg, &acts);
 			if (rc != 0)
 				break;
+
+			if (anchors->ia_probe_level != 0 &&
+			    anchors->ia_probe_level != iter->it_type)
+				goto finish;
 
 			/** Make sure we advance to next entry on re-probe */
 			if ((acts & (VOS_ITER_CB_SKIP | VOS_ITER_CB_DELETE)) == 0)
@@ -867,6 +903,7 @@ out:
 	VOS_TX_LOG_FAIL(rc, "abort iteration type:%d, "DF_RC"\n", type,
 			DP_RC(rc));
 
+finish:
 	vos_iter_finish(ih);
 
 	return rc;
@@ -925,4 +962,63 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 
 	return vos_iterate_internal(param, type, recursive, false, anchors,
 				    pre_cb, post_cb, arg, dth);
+}
+
+static int
+vos_iter_validate_internal(struct vos_iterator *iter)
+{
+	daos_anchor_t     *anchor;
+	int                rc;
+	struct dtx_handle *old;
+
+	D_ASSERT(iter->it_anchors != NULL);
+
+	if (!vos_iter_sched_check(iter))
+		return 0; /* No interleaving operations so no need to revalidate */
+
+	if (iter->it_parent) {
+		rc = vos_iter_validate_internal(iter->it_parent);
+		if (rc != 0)
+			return rc;
+	} else {
+		D_ASSERT(iter->it_type == VOS_ITER_OBJ);
+	}
+
+	switch (iter->it_type) {
+	case VOS_ITER_OBJ:
+		anchor = &iter->it_anchors->ia_obj;
+		break;
+	case VOS_ITER_DKEY:
+		anchor = &iter->it_anchors->ia_dkey;
+		break;
+	case VOS_ITER_AKEY:
+		anchor = &iter->it_anchors->ia_akey;
+		break;
+	case VOS_ITER_SINGLE:
+		anchor = &iter->it_anchors->ia_sv;
+		break;
+	case VOS_ITER_RECX:
+		anchor = &iter->it_anchors->ia_sv;
+		break;
+	default:
+		D_ASSERTF(0, "Unexpected iterator type %d\n", iter->it_type);
+	}
+
+	old = vos_dth_get();
+	vos_dth_set(iter->it_dth);
+	rc = iter->it_ops->iop_probe(iter, anchor, VOS_ITER_PROBE_AGAIN);
+	vos_dth_set(old);
+
+	if (rc == 0)
+		return 0;
+
+	iter->it_anchors->ia_probe_level = iter->it_type;
+
+	return iter->it_type;
+}
+
+int
+vos_iter_validate(daos_handle_t ih)
+{
+	return vos_iter_validate_internal(vos_hdl2iter(ih));
 }


### PR DESCRIPTION
In some cases, we may yield in the middle of a callback and need to request a full reprobe.  The checksum scrubber is such a case. It could, in theory, read a value, start processing it for checksum scrubbing, and have the value deleted before it is able to continue.  If this happens, we can end up reading bad data, or worse, causing a system crash.

Features: scrubber

Required-githooks: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
