### PR TITLE
DAOS-12387 cart: Improve swim rankless operation

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -428,8 +428,30 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 		  SWIM_RPC_TYPE_STR[rpc_type], rpc_in->upds.ca_count, rcv_delay,
 		  self_id, to_id, from_id);
 
-	if (self_id == SWIM_ID_INVALID)
-		D_GOTO(out_reply, rc = -DER_UNINIT);
+	if (self_id == SWIM_ID_INVALID) {
+		uint64_t incarnation;
+
+		if (ctx == NULL)
+			D_GOTO(out_reply, rc = -DER_UNINIT);
+
+		crt_swim_csm_lock(csm);
+		incarnation = csm->csm_incarnation;
+		crt_swim_csm_unlock(csm);
+
+		/*
+		 * Infer my rank from rpc->cr_ep.ep_rank, and simulate a reply,
+		 * shorting the local swim state. If there is a suspicion on me
+		 * in rpc_in->upds, this call will clarify it and bump my
+		 * incarnation.
+		 */
+		rc = swim_updates_short(ctx, rpc->cr_ep.ep_rank, incarnation, from_id, to_id,
+					rpc_in->upds.ca_arrays, rpc_in->upds.ca_count,
+					&rpc_out->upds.ca_arrays, &rpc_out->upds.ca_count);
+		if (rc != 0)
+			RPC_ERROR(rpc_priv, "updates short: %lu: %lu <= %lu failed: "DF_RC"\n",
+				  self_id, to_id, from_id, DP_RC(rc));
+		D_GOTO(out_reply, rc);
+	}
 
 	snd_delay = crt_swim_update_delays(csm, hlc, from_id, rcv_delay,
 					   rpc_in->upds.ca_arrays,
@@ -957,11 +979,11 @@ static void crt_swim_new_incarnation(struct swim_context *ctx,
 {
 	struct crt_grp_priv	*grp_priv = crt_gdata.cg_grp->gg_primary_grp;
 	struct crt_swim_membs	*csm = &grp_priv->gp_membs_swim;
+	swim_id_t		 self_id = swim_self_get(ctx);
 	uint64_t		 incarnation = d_hlc_get();
 
 	D_ASSERT(state != NULL);
-	D_ASSERTF(id == swim_self_get(ctx), DF_U64" == "DF_U64"\n",
-		  id, swim_self_get(ctx));
+	D_ASSERTF(self_id == SWIM_ID_INVALID || id == self_id, DF_U64" == "DF_U64"\n", id, self_id);
 	crt_swim_csm_lock(csm);
 	csm->csm_incarnation = incarnation;
 	crt_swim_csm_unlock(csm);

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -1174,6 +1174,76 @@ out:
 	return rc;
 }
 
+int
+swim_updates_short(struct swim_context *ctx, swim_id_t self_id, uint64_t self_incarnation,
+		   swim_id_t from_id, swim_id_t id, struct swim_member_update *upds_in,
+		   size_t nupds_in, struct swim_member_update **upds_out, size_t *nupds_out)
+{
+	struct swim_member_state	 self_state = {
+		.sms_incarnation	= self_incarnation,
+		.sms_status		= SWIM_MEMBER_ALIVE,
+		.sms_delay		= 0
+	};
+	struct swim_member_update	*id_upd = NULL;
+	struct swim_member_update	*upds;
+	size_t				 nupds;
+	size_t				 i;
+
+	swim_dump_updates(self_id, from_id, self_id, upds_in, nupds_in);
+
+	swim_ctx_lock(ctx);
+	for (i = 0; i < nupds_in; i++) {
+		if (upds_in[i].smu_id == self_id) {
+			if (upds_in[i].smu_state.sms_incarnation < self_incarnation ||
+			    (upds_in[i].smu_state.sms_status != SWIM_MEMBER_SUSPECT &&
+			     upds_in[i].smu_state.sms_status != SWIM_MEMBER_DEAD))
+				continue;
+
+			SWIM_ERROR("{%lu %c %lu} self %s received {%lu %c %lu} from %lu\n",
+				   self_id, 'A', self_incarnation,
+				   SWIM_STATUS_STR[upds_in[i].smu_state.sms_status],
+				   upds_in[i].smu_id,
+				   SWIM_STATUS_CHARS[upds_in[i].smu_state.sms_status],
+				   upds_in[i].smu_state.sms_incarnation, from_id);
+
+			ctx->sc_ops->new_incarnation(ctx, self_id, &self_state);
+		} else if (upds_in[i].smu_id == id) {
+			id_upd = &upds_in[i];
+		}
+	}
+	swim_ctx_unlock(ctx);
+
+	nupds = 1 /* self_id */;
+	if (id != self_id && id_upd != NULL)
+		nupds++; /* id */
+
+	D_ALLOC_ARRAY(upds, nupds);
+	if (upds == NULL)
+		return -DER_NOMEM;
+
+	i = 0;
+
+	upds[i].smu_state.sms_incarnation = self_state.sms_incarnation;
+	upds[i].smu_state.sms_status = SWIM_MEMBER_ALIVE;
+	upds[i].smu_state.sms_delay = 0;
+	upds[i++].smu_id = self_id;
+
+	if (id != self_id && id_upd != NULL) {
+		upds[i].smu_state.sms_incarnation = id_upd->smu_state.sms_incarnation;
+		upds[i].smu_state.sms_status = SWIM_MEMBER_ALIVE;
+		upds[i].smu_state.sms_delay = 0;
+		upds[i++].smu_id = id;
+	}
+
+	D_ASSERTF(i == nupds, "%zu == %zu\n", i, nupds);
+
+	swim_dump_updates(self_id, self_id, from_id, upds, nupds);
+
+	*upds_out = upds;
+	*nupds_out = nupds;
+	return 0;
+}
+
 void
 swim_member_del(struct swim_context *ctx, swim_id_t id)
 {

--- a/src/include/cart/swim.h
+++ b/src/include/cart/swim.h
@@ -212,6 +212,28 @@ int swim_updates_prepare(struct swim_context *ctx, swim_id_t id, swim_id_t to,
 			 struct swim_member_update **pupds, size_t *pnupds);
 
 /**
+ * Parse a SWIM message from other group member and prepare a reply, shorting
+ * the local SWIM state. This is a special API for handling incoming RPCs when
+ * the self ID in \a ctx is SWIM_ID_INVALID.
+ *
+ * @param[in]  ctx	SWIM context pointer from swim_init()
+ * @param[in]  self_id	Self member ID to used instead of the one in \a ctx
+ * @param[in]  self_incarnation
+ *			Self incarnation to used instead of the one in \a ctx
+ * @param[in]  from_id	IDs where message is from
+ * @param[in]  id	IDs of selected target for message
+ * @param[in]  upds_in	SWIM updates from other group member
+ * @param[in]  nupds_in	the count of SWIM updates in \a upds_in
+ * @param[out] upds_out	Pointer to SWIM updates for other group member
+ * @param[out] nupds_out
+ *			Pointer to the count of SWIM updates in \a upds_out
+ * @returns		0 on success, negative error ID otherwise
+ */
+int swim_updates_short(struct swim_context *ctx, swim_id_t self_id, uint64_t self_incarnation,
+		       swim_id_t from_id, swim_id_t id, struct swim_member_update *upds_in,
+		       size_t nupds_in, struct swim_member_update **upds_out, size_t *nupds_out);
+
+/**
  * Send a SWIM message for other group member.
  *
  * @param[in]  ctx	SWIM context pointer from swim_init()


### PR DESCRIPTION
When a swim member whose self ID is SWIM_ID_INVALID (e.g., before the
engine receives its rank from the MS) receives an incoming swim RPC, it
replies with -DER_UNINIT. When a swim member receives such a -DER_UNINIT
reply, it simulates an ALIVE update to indicate that the sender of the
reply is alive. This turns out to be insufficient if a rankless swim
member becomes suspected. The simulated ALIVE update cannot override the
SUSPECT update, as they have the same incarnation. Consequently, there
will eventually be a DEAD update about the rankless swim member, even
though it is actually alive.

This patch changes the swim RPC handler so that the rankless swim member
will simulate the ALIVE update itself, shorting its local swim state,
instead of replying with -DER_UNINIT. The rankless swim member will
infer its rank (only for handling this one RPC) from the RPC header. If
the incoming RPC contains a suspicion about it, this swim member will
have a chance to bump its incarnation and simulate an ALIVE update that
can override the SUSPECT update.

Signed-off-by: Li Wei <wei.g.li@intel.com>
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
