### PR TITLE
DAOS-12589 test: use correct oclass declaration

### DIFF
--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -108,7 +108,7 @@ racer_oid_gen(int random)
 	oid.lo	|= oclass;
 	oid.hi	= oclass;
 	rc = daos_obj_generate_oid(ts_ctx.tsc_coh, &oid, 0, oclass, 0, 0);
-	assert(rc == 0);
+	assert_success(rc);
 
 	return oid;
 }

--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -98,15 +98,17 @@ oclass_get(unsigned int random)
 daos_obj_id_t
 racer_oid_gen(int random)
 {
-	daos_obj_id_t	oid;
-	uint16_t	oclass;
+	daos_obj_id_t	 oid;
+	daos_oclass_id_t oclass;
+	int		 rc;
 
 	oclass = oclass_get(random);
 
 	oid.lo	= random % obj_cnt_per_class;
 	oid.lo	|= oclass;
 	oid.hi	= oclass;
-	daos_obj_generate_oid(ts_ctx.tsc_coh, &oid, 0, oclass, 0, 0);
+	rc = daos_obj_generate_oid(ts_ctx.tsc_coh, &oid, 0, oclass, 0, 0);
+	assert(rc == 0);
 
 	return oid;
 }

--- a/src/tests/dts.c
+++ b/src/tests/dts.c
@@ -105,8 +105,18 @@ engine_cont_init(struct credit_context *tsc)
 		char str[37];
 
 		if (tsc_create_cont(tsc)) {
+			daos_prop_t *cont_prop;
+
+			cont_prop = daos_prop_alloc(1);
+			if (cont_prop == NULL) {
+				rc = -DER_NOMEM;
+				goto bcast;
+			}
+			cont_prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+			cont_prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RANK;
 			rc = daos_cont_create(tsc->tsc_poh, &tsc->tsc_cont_uuid,
-					      NULL, NULL);
+					      cont_prop, NULL);
+			daos_prop_free(cont_prop);
 			if (rc != 0)
 				goto bcast;
 		}


### PR DESCRIPTION
1. now simple test are put in medium test, however it only tried to use 3 servers, after 
default fault domain was changed from rank to node, it was not enough to run all EC object class
for daos_race test, like what commit (DAOS-10215 container: set default fault domain level on NODE (#9631)) did,
change default domain to rank in tests  when creating containers.

2. oclass was declared as u32, fix to use correct declaration.

Required-githooks: true
Signed-off-by: Wang Shilong <shilong.wang@intel.com>