### PR TITLE
DAOS-12647 doc: Update LED instructions with custom timeout

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -683,7 +683,7 @@ state, representing a quick, 4Hz blinking amber light.
 The device will quickly blink by default for 2 minutes and then return to the default "OFF" state.
 Upon issuing a device identify command with specified device IDs and optional custom timeout value,
 an admin now can quickly identify a device in question.
-The timeout value will be 2 minutes if unspecified on the commandline and any value specifieed
+The timeout value will be 2 minutes if unspecified on the commandline and any value specified
 should be in units of a minute.
 The status LED on the VMD device will be set to an IDENTIFY state, represented by a quick, 4Hz
 blinking amber light.

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -521,7 +521,7 @@ faulty device reaction will have been triggered (all targets on the SSD will be 
 The SSD will remain evicted until device replacement occurs.
 
 If an NVMe SSD is faulty, the status LED on the VMD device will be set to an ON state,
-epresented by a solidly ON amber light.
+represented by a solidly ON amber light.
 This LED activity visually indicates a fault and that the device needs to be replaced and is no
 longer in use by DAOS.
 The LED of the VMD device will remain in this state until replaced by a new device.

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -656,10 +656,10 @@ boro-11
     TrAddr:850505:0b:00.0 LED:QUICK_BLINK
 ```
 
-To identify multiple SSDs, supply a comma separated list of Device-UUIDs and/or PCI
-addresses:
+To identify multiple SSDs, supply a comma separated list of Device-UUIDs and/or PCI addresses,
+adding custom timeout of 5 minutes for LED identification (time to flash LED for):
 ```bash
-$ dmg -l boro-11 storage led identify 850505:0a:00.0,6fccb374-413b-441a-bfbe-860099ac5e8d,850505:11:00.0
+$ dmg -l boro-11 storage led identify --timeout 5 850505:0a:00.0,6fccb374-413b-441a-bfbe-860099ac5e8d,850505:11:00.0
 ---------
 boro-11
 ---------
@@ -678,21 +678,18 @@ Mappings of Device-UUIDs to PCI address can be found in the output of the
 An error will be returned if the Device-UUID or PCI address of a non-VMD enabled SSD is specified
 in the command.
 
-After issuing the identify command, the status LED on the VMD device is now set to a "QUICK_BLINK"
-state, representing a quick, 4Hz blinking amber light.
-The device will quickly blink by default for 2 minutes and then return to the default "OFF" state.
 Upon issuing a device identify command with specified device IDs and optional custom timeout value,
 an admin now can quickly identify a device in question.
-The timeout value will be 2 minutes if unspecified on the commandline and any value specified
-should be in units of a minute.
-The status LED on the VMD device will be set to an IDENTIFY state, represented by a quick, 4Hz
-blinking amber light.
-The device will quickly blink until the timeout value is reached, after which the LED state will
-return to the default OFF state.
+After issuing the identify command, the status LED on the VMD device is now set to a "QUICK_BLINK"
+state, representing a quick, 4Hz blinking amber light.
+The device will quickly blink for the specified timeout (in minutes) or the default (2 minutes) if
+no value is specified on the command line, after which the LED state will return to the previous
+state (faulty "ON" or default "OFF").
 
 - Check LED state of SSDs:
 
-To verify the LED state of SSDs the following command can be used in a similar way to the identify command:
+To verify the LED state of SSDs the following command can be used in a similar way to the identify
+command:
 ```bash
 $ dmg -l boro-11 storage led check 850505:0a:00.0,6fccb374-413b-441a-bfbe-860099ac5e8d,850505:11:00.0
 ---------

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -358,15 +358,15 @@ boro-11
 -------
   Devices
     UUID:5bd91603-d3c7-4fb7-9a71-76bc25690c19 [TrAddr:0000:8a:00.0]
-      Targets:[0 2] Rank:0 State:NORMAL
+      Targets:[0 2] Rank:0 State:NORMAL LED:OFF
     UUID:80c9f1be-84b9-4318-a1be-c416c96ca48b [TrAddr:0000:8b:00.0]
-      Targets:[1 3] Rank:0 State:NORMAL
+      Targets:[1 3] Rank:0 State:NORMAL LED:OFF
     UUID:051b77e4-1524-4662-9f32-f8e4d2542c2d [TrAddr:0000:8c:00.0]
-      Targets:[] Rank:0 State:NEW
+      Targets:[] Rank:0 State:NEW LED:OFF
     UUID:81905b24-be44-4106-8ff9-03002e9dd86a [TrAddr:5d0505:01:00.0]
-      Targets:[0 2] Rank:1 State:EVICTED
+      Targets:[0 2] Rank:1 State:EVICTED LED:ON
     UUID:2ccb8afb-5d32-454e-86e3-762ec5dca7be [TrAddr:5d0505:03:00.0]
-      Targets:[1 3] Rank:1 State:NORMAL
+      Targets:[1 3] Rank:1 State:NORMAL LED:OFF
 ```
 ```bash
 $ dmg -l boro-11,boro-13 storage query list-pools
@@ -516,12 +516,18 @@ boro-11
     UUID:5bd91603-d3c7-4fb7-9a71-76bc25690c19 [TrAddr:]
             Targets:[] Rank:0 State:EVICTED LED:ON
 ```
-The device state will transition from "NORMAL" to "FAULTY" (shown above), which will
-trigger the faulty device reaction (all targets on the SSD will be rebuilt, and the SSD
-will remain evicted until device replacement occurs).
+The device state will transition from "NORMAL" to "EVICTED" (shown above), during which time the
+faulty device reaction will have been triggered (all targets on the SSD will be rebuilt).
+The SSD will remain evicted until device replacement occurs.
+
+If an NVMe SSD is faulty, the status LED on the VMD device will be set to an ON state,
+epresented by a solidly ON amber light.
+This LED activity visually indicates a fault and that the device needs to be replaced and is no
+longer in use by DAOS.
+The LED of the VMD device will remain in this state until replaced by a new device.
 
 !!! note
-    Full NVMe hot plug capability will be available and supported in DAOS 2.2 release.
+    Full NVMe hot plug capability will be available and supported in DAOS 2.6 release.
     Use is currently intended for testing only and is not supported for production.
 
 - To use a newly added (hot-inserted) SSD it needs to be unbound from the kernel driver
@@ -672,11 +678,17 @@ Mappings of Device-UUIDs to PCI address can be found in the output of the
 An error will be returned if the Device-UUID or PCI address of a non-VMD enabled SSD is specified
 in the command.
 
-After issuing the identify command, the status LED on the VMD device is now set to an "QUICK_BLINK"
+After issuing the identify command, the status LED on the VMD device is now set to a "QUICK_BLINK"
 state, representing a quick, 4Hz blinking amber light.
-The device will quickly blink by default for about 2 minutes and then return to the default "OFF" state.
-The LED event duration can be customized by setting the VMD_LED_PERIOD environment variable if a duration
-other than the default value is desired.
+The device will quickly blink by default for 2 minutes and then return to the default "OFF" state.
+Upon issuing a device identify command with specified device IDs and optional custom timeout value,
+an admin now can quickly identify a device in question.
+The timeout value will be 2 minutes if unspecified on the commandline and any value specifieed
+should be in units of a minute.
+The status LED on the VMD device will be set to an IDENTIFY state, represented by a quick, 4Hz
+blinking amber light.
+The device will quickly blink until the timeout value is reached, after which the LED state will
+return to the default OFF state.
 
 - Check LED state of SSDs:
 

--- a/src/bio/README.md
+++ b/src/bio/README.md
@@ -122,7 +122,7 @@ The status LED on the VMD device has four states: OFF, FAULT, REBUILD, and IDENT
 
 #### Locate a Healthy Device
 Upon issuing a device identify command with a specified device ID and optional custom timeout value, an admin now can quickly identify a device in question.
-The timeout value will be 2 minutes if unspecified on the commandline, any value specifieed should be in units of a minute.
+The timeout value will be 2 minutes if unspecified on the commandline, any value specified should be in units of a minute.
 The status LED on the VMD device would be set to an IDENTIFY state, represented by a quick, 4Hz blinking amber light.
 The device will quickly blink until the timeout value is reached, after which returning to the default OFF state.
 

--- a/src/bio/README.md
+++ b/src/bio/README.md
@@ -120,13 +120,19 @@ The Amber LED (status LED) is what VMD provides. It represents the LED coming fr
 The status LED on the VMD device has four states: OFF, FAULT, REBUILD, and IDENTIFY. These are communicated by blinking patterns specified in the IBPI standard (SFF-8489).
 ![/docs/graph/VMD_LED_states.png](/docs/graph/VMD_LED_states.png "Status LED states")
 
-#### Locate a Health Device
-Upon issuing a device identify command with a specified device ID, an admin now can quickly identify a device in question. The status LED on the VMD device would be set to an IDENTIFY state, represented by a quick, 4Hz blinking amber light. The device would quickly blink by default for 60 seconds and then return to the default OFF state. The LED event duration can be customized by setting the VMD_LED_PERIOD environment variable if a duration other than the default value is desired.
+#### Locate a Healthy Device
+Upon issuing a device identify command with a specified device ID and optional custom timeout value, an admin now can quickly identify a device in question.
+The timeout value will be 2 minutes if unspecified on the commandline, any value specifieed should be in units of a minute.
+The status LED on the VMD device would be set to an IDENTIFY state, represented by a quick, 4Hz blinking amber light.
+The device will quickly blink until the timeout value is reached, after which returning to the default OFF state.
+
 #### Locate an Evicted Device
-If an NVMe SSD is evicted, the status LED on the VMD device will be set to a FAULT state, represented by a solidly ON amber light. No additional command apart from the SSD eviction would be needed, and this would visually indicate that the device needs to be replaced and is no longer in use by DAOS. The LED of the VMD device will remain in this state until replaced by a new device.
+If an NVMe SSD is faulty, the status LED on the VMD device will be set to a EVICTED state, represented by a solidly ON amber light.
+This LED activity visually indicates a fault and that the device needs to be replaced and is no longer in use by DAOS.
+The LED of the VMD device will remain in this state until replaced by a new device.
 
  Useful admin command to locate a VMD-enabled NVMe SSD:
-  - <a href="#85">dmg storage identify vmd</a> [used to change the status LED state on the VMD device to quickly blink for 60 seconds]
+  - <a href="#85">dmg storage identify vmd</a> [used to change the status LED state on the VMD device to quickly blink until timeout expires]
 
 <a id="11"></a>
 ## Device States

--- a/src/control/cmd/dmg/storage_query.go
+++ b/src/control/cmd/dmg/storage_query.go
@@ -287,7 +287,7 @@ type ledManageCmd struct {
 
 type ledIdentifyCmd struct {
 	ledCmd
-	Timeout uint32 `long:"timeout" description:"Length of time to blink the status LED for"`
+	Timeout uint32 `long:"timeout" description:"Number of minutes to blink the status LED for"`
 	Reset   bool   `long:"reset" description:"Reset blinking LED on specified VMD device back to previous state"`
 }
 


### PR DESCRIPTION
Correct instructions regarding specifying LED identify time period by
removing references to environment variable and instead recommending
the use of --timeout dmg option.

Required-githooks: true

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
