### PR TITLE
DAOS-12636 container: set status property to unhealthy

### DIFF
--- a/src/common/cont_props.c
+++ b/src/common/cont_props.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2020-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -17,65 +17,67 @@ daos_props_2cont_props(daos_prop_t *props, struct cont_props *cont_prop)
 		return;
 	}
 
-	/* input props should cover needed entries, see ds_cont_get_props() */
-	if (daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP_THRESHOLD) == NULL ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_SERVER_VERIFY)
-	    == NULL							     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_CHUNK_SIZE) == NULL ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_COMPRESS) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_ENCRYPT) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_LVL) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_FAC) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_ALLOCED_OID) == NULL     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_EC_CELL_SZ) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_EC_PDA) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_GLOBAL_VERSION) == NULL  ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_OBJ_VERSION) == NULL     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_RP_PDA) == NULL)
-		D_DEBUG(DB_TRACE, "some prop entry type not found, "
-			"use default value.\n");
-
 	/** deduplication */
-	cont_prop->dcp_dedup_enabled	= daos_cont_prop2dedup(props);
-	cont_prop->dcp_dedup_size	= daos_cont_prop2dedupsize(props);
-	cont_prop->dcp_dedup_verify	= daos_cont_prop2dedupverify(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP) != NULL) {
+		cont_prop->dcp_dedup_enabled = daos_cont_prop2dedup(props);
+		cont_prop->dcp_dedup_verify = daos_cont_prop2dedupverify(props);
+	}
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP_THRESHOLD) != NULL)
+		cont_prop->dcp_dedup_size = daos_cont_prop2dedupsize(props);
 
 	/** checksum */
-	cont_prop->dcp_srv_verify	= daos_cont_prop2serververify(props);
-	cont_prop->dcp_csum_type	= daos_cont_prop2csum(props);
-	cont_prop->dcp_csum_enabled =
-		daos_cont_csum_prop_is_enabled(cont_prop->dcp_csum_type);
-	cont_prop->dcp_chunksize	= daos_cont_prop2chunksize(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_SERVER_VERIFY) != NULL)
+		cont_prop->dcp_srv_verify = daos_cont_prop2serververify(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_CSUM)) {
+		cont_prop->dcp_csum_type = daos_cont_prop2csum(props);
+		cont_prop->dcp_csum_enabled =
+			daos_cont_csum_prop_is_enabled(cont_prop->dcp_csum_type);
+	}
+
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_CHUNK_SIZE) != NULL)
+		cont_prop->dcp_chunksize = daos_cont_prop2chunksize(props);
 
 	/** compression */
-	cont_prop->dcp_compress_type	= daos_cont_prop2compress(props);
-	cont_prop->dcp_compress_enabled	=
-	       daos_cont_compress_prop_is_enabled(cont_prop->dcp_compress_type);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_COMPRESS) != NULL) {
+		cont_prop->dcp_compress_type = daos_cont_prop2compress(props);
+		cont_prop->dcp_compress_enabled	=
+			daos_cont_compress_prop_is_enabled(cont_prop->dcp_compress_type);
+	}
 
 	/** encryption */
-	cont_prop->dcp_encrypt_type	= daos_cont_prop2encrypt(props);
-	cont_prop->dcp_encrypt_enabled	=
-		daos_cont_encrypt_prop_is_enabled(cont_prop->dcp_encrypt_type);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_ENCRYPT) != NULL) {
+		cont_prop->dcp_encrypt_type = daos_cont_prop2encrypt(props);
+		cont_prop->dcp_encrypt_enabled =
+			daos_cont_encrypt_prop_is_enabled(cont_prop->dcp_encrypt_type);
+	}
 
 	/** redundancy */
-	cont_prop->dcp_redun_lvl	= daos_cont_prop2redunlvl(props);
-	cont_prop->dcp_redun_fac	= daos_cont_prop2redunfac(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_LVL) != NULL)
+		cont_prop->dcp_redun_lvl = daos_cont_prop2redunlvl(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_FAC) != NULL)
+		cont_prop->dcp_redun_fac = daos_cont_prop2redunfac(props);
+
 	/** EC cell size */
-	cont_prop->dcp_ec_cell_sz	= daos_cont_prop2ec_cell_sz(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_EC_CELL_SZ) != NULL)
+		cont_prop->dcp_ec_cell_sz = daos_cont_prop2ec_cell_sz(props);
 
 	/** alloc'ed oid */
-	cont_prop->dcp_alloced_oid	= daos_cont_prop2allocedoid(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_ALLOCED_OID) != NULL)
+		cont_prop->dcp_alloced_oid = daos_cont_prop2allocedoid(props);
 
 	/** performance domain affinity level */
-	cont_prop->dcp_ec_pda		= daos_cont_prop2ec_pda(props);
-	cont_prop->dcp_rp_pda		= daos_cont_prop2rp_pda(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_EC_PDA) != NULL)
+		cont_prop->dcp_ec_pda = daos_cont_prop2ec_pda(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_RP_PDA) != NULL)
+		cont_prop->dcp_rp_pda = daos_cont_prop2rp_pda(props);
 
 	/** global version */
-	cont_prop->dcp_global_version   = daos_cont_prop2global_version(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_GLOBAL_VERSION) != NULL)
+		cont_prop->dcp_global_version = daos_cont_prop2global_version(props);
+
 	/** object version */
-	cont_prop->dcp_obj_version   = daos_cont_prop2obj_version(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_OBJ_VERSION) != NULL)
+		cont_prop->dcp_obj_version = daos_cont_prop2obj_version(props);
 }
 
 uint16_t

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -470,7 +470,24 @@ again:
 							     civ_key->cont_uuid, &chdl);
 				if (rc1 == 0) {
 					struct cont_iv_entry	iv_entry = { 0 };
+					daos_prop_t		*prop = NULL;
+					struct daos_prop_entry	*prop_entry;
+					struct daos_co_status	stat = { 0 };
 
+					rc = ds_cont_get_prop(entry->ns->iv_pool_uuid,
+							      civ_key->cont_uuid, &prop);
+					if (rc) {
+						D_ERROR(DF_CONT "get prop: "DF_RC"\n",
+							DP_CONT(entry->ns->iv_pool_uuid,
+								civ_key->cont_uuid), DP_RC(rc));
+						D_GOTO(out, rc);
+					}
+					prop_entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
+					D_ASSERT(prop_entry != NULL);
+
+					daos_prop_val_2_co_status(prop_entry->dpe_val, &stat);
+					iv_entry.iv_capa.status_pm_ver = stat.dcs_pm_ver;
+					daos_prop_free(prop);
 					/* Only happens on xstream 0 */
 					D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 					iv_entry.iv_capa.flags = chdl.ch_flags;
@@ -1311,7 +1328,7 @@ out:
 }
 
 int
-cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop)
+cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop, bool sync)
 {
 	struct cont_iv_entry	*iv_entry;
 	uint32_t		iv_entry_size;
@@ -1325,12 +1342,33 @@ cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop)
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
+	/* IV property should include all entries for the moment, since IV entry
+	 * cache can not tell individual entry, so it can not update single entry.
+	 */
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_DEDUP) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_DEDUP_THRESHOLD) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_CSUM_SERVER_VERIFY) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_CSUM) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_CSUM_CHUNK_SIZE) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_COMPRESS) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_ENCRYPT) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_REDUN_LVL) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_REDUN_FAC) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_ALLOCED_OID) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_EC_CELL_SZ) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_EC_PDA) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_GLOBAL_VERSION) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_OBJ_VERSION) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_RP_PDA) != NULL);
+
 	uuid_copy(iv_entry->cont_uuid, cont_uuid);
 	cont_iv_prop_l2g(prop, &iv_entry->iv_prop);
 
 	rc = cont_iv_update(ns, IV_CONT_PROP, cont_uuid, iv_entry,
 			    iv_entry_size, CRT_IV_SHORTCUT_TO_ROOT,
-			    CRT_IV_SYNC_EAGER, false /* retry */);
+			    sync ? CRT_IV_SYNC_EAGER : CRT_IV_SYNC_LAZY,
+			    !sync/* retry */);
 	D_FREE(iv_entry);
 	return rc;
 }

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1998,7 +1998,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 
 	/* query the container properties from RDB and update to IV */
 	rc = cont_iv_prop_update(pool_hdl->sph_pool->sp_iv_ns,
-				 cont->c_uuid, prop);
+				 cont->c_uuid, prop, true);
 	daos_prop_free(prop);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": cont_iv_prop_update failed %d.\n",
@@ -3126,35 +3126,6 @@ capas_can_set_prop(struct cont *cont, uint64_t sec_capas,
 	return true;
 }
 
-/* pre-processing for DAOS_PROP_CO_STATUS, set the pool map version */
-static bool
-set_prop_co_status_pre_process(struct ds_pool *pool, struct cont *cont,
-			       daos_prop_t *prop_in)
-{
-	struct daos_prop_entry	*entry;
-	struct daos_co_status	 co_status = { 0 };
-	bool			 clear_stat;
-
-	entry = daos_prop_entry_get(prop_in, DAOS_PROP_CO_STATUS);
-	if (entry == NULL)
-		return false;
-
-	daos_prop_val_2_co_status(entry->dpe_val, &co_status);
-	D_ASSERT(co_status.dcs_status == DAOS_PROP_CO_HEALTHY ||
-		 co_status.dcs_status == DAOS_PROP_CO_UNCLEAN);
-	clear_stat = (co_status.dcs_status == DAOS_PROP_CO_HEALTHY);
-	co_status.dcs_pm_ver = ds_pool_get_version(pool);
-	co_status.dcs_flags = 0;
-	entry->dpe_val = daos_prop_co_status_2_val(&co_status);
-	D_DEBUG(DB_MD, DF_CONT" updating co_status - status %s, pm_ver %d.\n",
-		DP_CONT(pool->sp_uuid, cont->c_uuid),
-		co_status.dcs_status == DAOS_PROP_CO_HEALTHY ?
-		"DAOS_PROP_CO_HEALTHY" : "DAOS_PROP_CO_UNCLEAN",
-		co_status.dcs_pm_ver);
-
-	return clear_stat;
-}
-
 /* Sanity check set-prop label, and update cs_uuids KVS */
 static int
 check_set_prop_label(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont,
@@ -3263,7 +3234,6 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 	int			 rc;
 	daos_prop_t		*prop_old = NULL;
 	daos_prop_t		*prop_iv = NULL;
-	bool			 clear_stat;
 	struct daos_prop_entry	*entry;
 
 	entry = daos_prop_entry_get(prop_in, DAOS_PROP_CO_GLOBAL_VERSION);
@@ -3292,7 +3262,6 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 		D_GOTO(out, rc);
 	}
 	D_ASSERT(prop_old != NULL);
-	clear_stat = set_prop_co_status_pre_process(pool, cont, prop_in);
 	prop_iv = daos_prop_merge(prop_old, prop_in);
 	if (prop_iv == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -3305,22 +3274,6 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 	rc = cont_prop_write(tx, &cont->c_prop, prop_in, false);
 	if (rc != 0)
 		D_GOTO(out, rc);
-
-	/* Update prop IV with merged prop */
-	rc = cont_iv_prop_update(pool->sp_iv_ns, cont->c_uuid, prop_iv);
-	if (rc) {
-		D_ERROR(DF_UUID": failed to update prop IV for cont, "
-			DF_RC"\n", DP_UUID(cont->c_uuid), DP_RC(rc));
-		goto out;
-	}
-
-	if (clear_stat) {
-		/* to notify each tgt server to do ds_cont_rf_check() */
-		rc = ds_pool_iv_map_update(pool, NULL, 0);
-		if (rc)
-			D_ERROR(DF_UUID": ds_pool_iv_map_update failed, "
-				DF_RC"\n", DP_UUID(cont->c_uuid), DP_RC(rc));
-	}
 
 out:
 	daos_prop_free(prop_old);
@@ -4376,7 +4329,7 @@ out:
 			}
 			ap->cont_upgraded_nrs++;
 			rc = cont_iv_prop_update(ap->svc->cs_pool->sp_iv_ns,
-						 cont_uuid, prop);
+						 cont_uuid, prop, true);
 			if (rc)
 				D_ERROR(DF_UUID": failed to update prop IV for cont, "
 					DF_RC"\n", DP_UUID(cont_uuid), DP_RC(rc));
@@ -4433,6 +4386,157 @@ ds_cont_upgrade(uuid_t pool_uuid, struct cont_svc *svc)
 out_svc:
 	D_DEBUG(DB_MD, DF_UUID" upgrade all container: rc %d\n", DP_UUID(pool_uuid), rc);
 	if (need_put_leader)
+		cont_svc_put_leader(svc);
+
+	return rc;
+}
+
+int
+ds_cont_rf_check(uuid_t pool_uuid, uuid_t cont_uuid, struct rdb_tx *tx)
+{
+	struct cont_svc		*svc = NULL;
+	struct cont		*cont = NULL;
+	struct ds_pool		*pool;
+	daos_prop_t		*prop = NULL;
+	daos_prop_t		*stat_prop = NULL;
+	struct daos_prop_entry	*entry;
+	struct daos_co_status	stat = { 0 };
+	int			rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL /* hint **/);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	rc = cont_lookup(tx, svc, cont_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": lookup cont failed, "DF_RC"\n",
+			DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	pool = svc->cs_pool;
+	rc = cont_prop_read(tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop, true);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to read prop for cont, rc=%d\n",
+			DP_CONT(pool_uuid, cont_uuid), rc);
+		D_GOTO(out, rc);
+	}
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
+	D_ASSERT(entry != NULL);
+	daos_prop_val_2_co_status(entry->dpe_val, &stat);
+	if (stat.dcs_status == DAOS_PROP_CO_UNCLEAN) {
+		D_DEBUG(DB_MD, DF_CONT" %u status %u is unhealthy.\n",
+			DP_CONT(pool_uuid, cont_uuid), stat.dcs_pm_ver, stat.dcs_status);
+		D_GOTO(out, rc = -DER_RF);
+	}
+
+	rc = ds_pool_rf_verify(pool, stat.dcs_pm_ver, daos_cont_prop2redunlvl(prop),
+			       daos_cont_prop2redunfac(prop));
+	if (rc != -DER_RF) {
+		D_CDEBUG(rc == 0, DB_MD, DLOG_ERR, DF_CONT", verify" DF_RC"\n",
+			 DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	D_DEBUG(DB_MD, DF_CONT" ver %u set unhealthy.\n",
+		DP_CONT(pool_uuid, cont_uuid), ds_pool_get_version(pool));
+	stat_prop = daos_prop_alloc(1);
+	if (stat_prop == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	stat.dcs_pm_ver = ds_pool_get_version(pool);
+	stat.dcs_status = DAOS_PROP_CO_UNCLEAN;
+
+	/* Update healthy status RDB property */
+	stat_prop->dpp_entries[0].dpe_val = daos_prop_co_status_2_val(&stat);
+	stat_prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_STATUS;
+	rc = cont_prop_write(tx, &cont->c_prop, stat_prop, false);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	/* Update prop IV with merged prop */
+	entry->dpe_val = daos_prop_co_status_2_val(&stat);
+	rc = cont_iv_prop_update(pool->sp_iv_ns, cont_uuid, prop, false);
+	if (rc) {
+		D_ERROR(DF_UUID": failed to update prop IV for cont, "
+			DF_RC"\n", DP_UUID(cont_uuid), DP_RC(rc));
+		goto out;
+	}
+out:
+	if (cont != NULL)
+		cont_put(cont);
+	if (prop != NULL)
+		daos_prop_free(prop);
+	if (stat_prop != NULL)
+		daos_prop_free(stat_prop);
+	if (svc != NULL)
+		cont_svc_put_leader(svc);
+
+	D_DEBUG(DB_MD, "check pool/cont: "DF_CONT": "DF_RC"\n",
+		DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+
+	return rc;
+}
+
+struct cont_rdb_iter_arg {
+	struct cont_svc	*svc;
+	struct rdb_tx	*tx;
+	cont_rdb_iter_cb_t iter_cb;
+	void		*cb_arg;
+};
+
+static int
+cont_rdb_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
+{
+	struct cont_rdb_iter_arg *args = varg;
+	uuid_t			 cont_uuid;
+	int			 rc;
+
+	uuid_copy(cont_uuid, key->iov_buf);
+
+	rc = args->iter_cb(args->svc->cs_pool->sp_uuid, cont_uuid, args->tx, args->cb_arg);
+
+	return rc;
+}
+
+int
+ds_cont_rdb_iterate(uuid_t pool_uuid, cont_rdb_iter_cb_t iter_cb, void *cb_arg)
+{
+	struct cont_rdb_iter_arg	args = { 0 };
+	struct cont_svc			*svc = NULL;
+	struct rdb_tx			tx;
+	int				rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL /* hint **/);
+	if (rc != 0)
+		D_GOTO(out_svc, rc);
+
+	args.svc = svc;
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0)
+		D_GOTO(out_svc, rc);
+
+	args.tx = &tx;
+	args.cb_arg = cb_arg;
+	args.iter_cb = iter_cb;
+	ABT_rwlock_wrlock(svc->cs_lock);
+	rc = rdb_tx_iterate(&tx, &svc->cs_conts, false /* !backward */, cont_rdb_iter_cb, &args);
+	ABT_rwlock_unlock(svc->cs_lock);
+	if (rc < 0) {
+		D_ERROR(DF_UUID" iterate error: %d\n", DP_UUID(pool_uuid), rc);
+		D_GOTO(tx_end, rc);
+	}
+
+	rc = rdb_tx_commit(&tx);
+	if (rc)
+		D_ERROR("rdb tx commit error: %d\n", rc);
+tx_end:
+	rdb_tx_end(&tx);
+
+out_svc:
+	D_DEBUG(DB_MD, DF_UUID" container iter: rc %d\n", DP_UUID(pool_uuid), rc);
+	if (svc != NULL)
 		cont_svc_put_leader(svc);
 
 	return rc;
@@ -4562,6 +4666,53 @@ out:
 	return rc;
 }
 
+void
+ds_cont_prop_iv_update(struct cont_svc *svc, uuid_t cont_uuid)
+{
+	struct rdb_tx	tx;
+	struct cont	*cont = NULL;
+	daos_prop_t	*prop = NULL;
+	int		rc;
+
+	/* Only happens on xstream 0 */
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": Failed to start rdb tx: %d\n",
+			DP_UUID(svc->cs_pool_uuid), rc);
+		return;
+	}
+
+	ABT_rwlock_rdlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": Failed to look container: %d\n",
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
+		D_GOTO(out_lock, rc);
+	}
+
+	rc = cont_prop_read(&tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop, true);
+	if (rc)
+		D_ERROR(DF_CONT": prop read failed:"DF_RC"\n",
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), DP_RC(rc));
+	cont_put(cont);
+
+out_lock:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+	if (rc == 0) {
+		/* Update prop IV with merged prop */
+		rc = cont_iv_prop_update(svc->cs_pool->sp_iv_ns, cont_uuid, prop, true);
+		if (rc)
+			D_ERROR(DF_CONT": failed to update prop IV for cont, "
+				DF_RC"\n", DP_CONT(svc->cs_pool_uuid, cont_uuid),
+				DP_RC(rc));
+	}
+
+	if (prop != NULL)
+		daos_prop_free(prop);
+}
+
 /*
  * Look up the container, or if the RPC does not need this, call the final
  * handler.
@@ -4649,8 +4800,12 @@ out_lock:
 	rdb_tx_end(&tx);
 out:
 	/* Propagate new snapshot list by IV */
-	if (rc == 0 && (opc == CONT_SNAP_CREATE || opc == CONT_SNAP_DESTROY))
-		ds_cont_update_snap_iv(svc, in->ci_uuid);
+	if (rc == 0) {
+		if (opc == CONT_SNAP_CREATE || opc == CONT_SNAP_DESTROY)
+			ds_cont_update_snap_iv(svc, in->ci_uuid);
+		else if (opc == CONT_PROP_SET)
+			ds_cont_prop_iv_update(svc, in->ci_uuid);
+	}
 
 	D_DEBUG(DB_MD, DF_CONT": opc=%d returning, "DF_RC"\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ci_uuid), opc, DP_RC(rc));

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -503,14 +503,18 @@ ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid)
 		goto out_lock;
 	}
 
-	rc = cont_iv_snapshots_update(svc->cs_pool->sp_iv_ns, cont_uuid,
-				      snapshots, snap_count);
-	if (rc != 0)
-		D_ERROR(DF_CONT": Failed to update snapshots IV: %d\n",
-			DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
-
-	D_FREE(snapshots);
 out_lock:
 	ABT_rwlock_unlock(svc->cs_lock);
 	rdb_tx_end(&tx);
+	if (rc == 0) {
+		rc = cont_iv_snapshots_update(svc->cs_pool->sp_iv_ns, cont_uuid,
+					      snapshots, snap_count);
+		if (rc != 0)
+			D_ERROR(DF_CONT": Failed to update snapshots IV: %d\n",
+				DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
+	}
+
+	if (snapshots != NULL)
+		D_FREE(snapshots);
+
 }

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -272,7 +272,7 @@ int cont_iv_capability_invalidate(void *ns, uuid_t cont_hdl_uuid,
 				  int sync_mode);
 int cont_iv_prop_fetch(uuid_t pool_uuid, uuid_t cont_uuid,
 		       daos_prop_t *cont_prop);
-int cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop);
+int cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop, bool sync);
 int cont_iv_snapshots_refresh(void *ns, uuid_t cont_uuid);
 int cont_iv_snapshots_update(void *ns, uuid_t cont_uuid,
 			     uint64_t *snapshots, int snap_count);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -96,7 +96,7 @@ ds_cont_get_props(struct cont_props *cont_props, uuid_t pool_uuid,
 	/* The provided prop entry types should cover the types used in
 	 * daos_props_2cont_props().
 	 */
-	props = daos_prop_alloc(15);
+	props = daos_prop_alloc(16);
 	if (props == NULL)
 		return -DER_NOMEM;
 
@@ -115,6 +115,7 @@ ds_cont_get_props(struct cont_props *cont_props, uuid_t pool_uuid,
 	props->dpp_entries[12].dpe_type = DAOS_PROP_CO_GLOBAL_VERSION;
 	props->dpp_entries[13].dpe_type = DAOS_PROP_CO_REDUN_LVL;
 	props->dpp_entries[14].dpe_type = DAOS_PROP_CO_OBJ_VERSION;
+	props->dpp_entries[15].dpe_type = DAOS_PROP_CO_STATUS;
 
 	rc = cont_iv_prop_fetch(pool_uuid, cont_uuid, props);
 	if (rc == DER_SUCCESS)
@@ -844,7 +845,7 @@ ds_cont_child_stop_all(struct ds_pool_child *pool_child)
 
 static int
 cont_child_start(struct ds_pool_child *pool_child, const uuid_t co_uuid,
-		 struct ds_cont_child **cont_out)
+		 bool *started, struct ds_cont_child **cont_out)
 {
 	struct dsm_tls		*tls = dsm_tls_get();
 	struct ds_cont_child	*cont_child;
@@ -887,6 +888,8 @@ cont_child_start(struct ds_pool_child *pool_child, const uuid_t co_uuid,
 
 		d_list_add_tail(&cont_child->sc_link, &pool_child->spc_cont_list);
 		ds_cont_child_get(cont_child);
+		if (started)
+			*started = true;
 	}
 
 	if (!rc && cont_out != NULL) {
@@ -907,7 +910,7 @@ cont_child_start_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 {
 	struct ds_pool_child	*pool_child = data;
 
-	return cont_child_start(pool_child, entry->ie_couuid, NULL);
+	return cont_child_start(pool_child, entry->ie_couuid, NULL, NULL);
 }
 
 int
@@ -1287,7 +1290,7 @@ ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
  **/
 static int
 cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver,
-			struct ds_cont_child **cont_out)
+			bool *started, struct ds_cont_child **cont_out)
 {
 	struct ds_pool_child	*pool_child;
 	int rc;
@@ -1299,7 +1302,7 @@ cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver,
 		return -DER_NO_HDL;
 	}
 
-	rc = cont_child_start(pool_child, cont_uuid, cont_out);
+	rc = cont_child_start(pool_child, cont_uuid, started, cont_out);
 	if (rc != -DER_NONEXIST) {
 		if (rc == 0) {
 			D_ASSERT(*cont_out != NULL);
@@ -1314,7 +1317,7 @@ cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver,
 
 	rc = vos_cont_create(pool_child->spc_hdl, cont_uuid);
 	if (!rc) {
-		rc = cont_child_start(pool_child, cont_uuid, cont_out);
+		rc = cont_child_start(pool_child, cont_uuid, started, cont_out);
 		if (rc == 0) {
 			(*cont_out)->sc_status_pm_ver = pm_ver;
 		} else {
@@ -1392,7 +1395,7 @@ ds_cont_child_open_create(uuid_t pool_uuid, uuid_t cont_uuid,
 	int rc;
 
 	/* status_pm_ver has no sense for rebuild container */
-	rc = cont_child_create_start(pool_uuid, cont_uuid, 0, cont);
+	rc = cont_child_create_start(pool_uuid, cont_uuid, 0, NULL, cont);
 	if (rc == 1)
 		rc = 0;
 
@@ -1402,7 +1405,7 @@ ds_cont_child_open_create(uuid_t pool_uuid, uuid_t cont_uuid,
 static int
 ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		   uint64_t flags, uint64_t sec_capas, uint32_t status_pm_ver,
-		   struct ds_cont_hdl **cont_hdl)
+		   bool *started, struct ds_cont_hdl **cont_hdl)
 {
 	struct dsm_tls		*tls = dsm_tls_get();
 	struct ds_cont_child	*cont = NULL;
@@ -1446,7 +1449,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	/* cont_uuid is NULL when open rebuild global cont handle */
 	if (cont_uuid != NULL && !uuid_is_null(cont_uuid)) {
 		rc = cont_child_create_start(pool_uuid, cont_uuid,
-					     status_pm_ver, &cont);
+					     status_pm_ver, started, &cont);
 		if (rc < 0)
 			D_GOTO(err_hdl, rc);
 
@@ -1586,6 +1589,7 @@ struct cont_tgt_open_arg {
 	uuid_t		pool_uuid;
 	uuid_t		cont_uuid;
 	uuid_t		cont_hdl_uuid;
+	bool		cont_started;
 	uint64_t	flags;
 	uint64_t	sec_capas;
 	uint32_t	status_pm_ver;
@@ -1602,7 +1606,7 @@ cont_open_one(void *vin)
 
 	return ds_cont_local_open(arg->pool_uuid, arg->cont_hdl_uuid,
 				  arg->cont_uuid, arg->flags, arg->sec_capas,
-				  arg->status_pm_ver, NULL);
+				  arg->status_pm_ver, &arg->cont_started, NULL);
 }
 
 int
@@ -2429,197 +2433,6 @@ out:
 		cont_ec_eph_destroy(ec_eph);
 }
 
-struct cont_rf_check_arg {
-	uuid_t			 crc_pool_uuid;
-	ABT_eventual		 crc_eventual;
-};
-
-struct cont_set_arg {
-	uuid_t			csa_pool_uuid;
-	uuid_t			csa_cont_uuid;
-	uint32_t		csa_status_pm_ver;
-	bool			csa_rw_disable;
-};
-
-static int
-cont_rw_capa_set(void *data)
-{
-	struct dsm_tls		*tls = dsm_tls_get();
-	struct cont_set_arg	*arg = data;
-	struct ds_cont_child	*cont_child;
-	int			 rc = 0;
-
-	rc = cont_child_lookup(tls->dt_cont_cache, arg->csa_cont_uuid,
-			       arg->csa_pool_uuid, false /* create */,
-			       &cont_child);
-	if (rc) {
-		if (rc == -DER_NONEXIST)
-			rc = 0;
-		else
-			D_ERROR(DF_CONT" cont_child_lookup failed, "DF_RC"\n",
-				DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
-				DP_RC(rc));
-		return rc;
-	}
-	D_ASSERT(cont_child != NULL);
-
-	cont_child->sc_rw_disabled = arg->csa_rw_disable;
-	if (dss_get_module_info()->dmi_tgt_id == 0)
-		D_DEBUG(DB_IO, DF_CONT" read/write permission %s.\n",
-			DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
-			cont_child->sc_rw_disabled ? "disabled" : "enabled");
-
-	ds_cont_child_put(cont_child);
-	return rc;
-}
-
-static int
-cont_rf_check(struct ds_pool *ds_pool, struct ds_cont_child *cont_child)
-{
-	struct cont_set_arg		rw_arg;
-	int				rc = 0;
-
-	rc = ds_pool_rf_verify(ds_pool, cont_child->sc_status_pm_ver,
-			       cont_child->sc_props.dcp_redun_lvl,
-			       cont_child->sc_props.dcp_redun_fac);
-	if (rc != 0 && rc != -DER_RF)
-		goto out;
-
-	rw_arg.csa_rw_disable = (rc == -DER_RF);
-	if (rc == -DER_RF)
-		D_ERROR(DF_CONT": RF broken, last_ver %d, rlvl %d, rf %d, "DF_RC"\n",
-			DP_CONT(cont_child->sc_pool_uuid, cont_child->sc_uuid),
-			cont_child->sc_status_pm_ver, cont_child->sc_props.dcp_redun_lvl,
-			cont_child->sc_props.dcp_redun_fac, DP_RC(rc));
-	if (rw_arg.csa_rw_disable == cont_child->sc_rw_disabled)
-		D_GOTO(out, rc = 0);
-
-	uuid_copy(rw_arg.csa_cont_uuid, cont_child->sc_uuid);
-	uuid_copy(rw_arg.csa_pool_uuid, ds_pool->sp_uuid);
-	rc = dss_task_collective(cont_rw_capa_set, &rw_arg, 0);
-	if (rc)
-		D_ERROR("collective cont_write_data_turn_off failed, "DF_RC"\n",
-			DP_RC(rc));
-
-out:
-	return rc;
-}
-
-static void
-cont_rf_check_ult(void *data)
-{
-	struct cont_rf_check_arg	*arg = data;
-	struct ds_pool			*ds_pool;
-	struct ds_pool_child		*pool_child;
-	struct ds_cont_child		*cont_child;
-	int				 rc = 0;
-
-	pool_child = ds_pool_child_lookup(arg->crc_pool_uuid);
-	D_ASSERTF(pool_child != NULL, DF_UUID" : failed to find pool child\n",
-		 DP_UUID(arg->crc_pool_uuid));
-
-	ds_pool = pool_child->spc_pool;
-	d_list_for_each_entry(cont_child, &pool_child->spc_cont_list, sc_link) {
-		if (cont_child->sc_stopping)
-			continue;
-		rc = cont_rf_check(ds_pool, cont_child);
-		if (rc) {
-			D_DEBUG(DB_TRACE, DF_CONT" cont_rf_check failed, "
-				DF_RC"\n",
-				DP_CONT(ds_pool->sp_uuid, cont_child->sc_uuid),
-				DP_RC(rc));
-			break;
-		}
-	}
-
-	ds_pool_child_put(pool_child);
-	ABT_eventual_set(arg->crc_eventual, (void *)&rc, sizeof(rc));
-}
-
-static int
-cont_rf_check_get_tgt(uuid_t pool_uuid)
-{
-	int		*failed_tgts = NULL;
-	unsigned int	 failed_tgts_cnt;
-	bool		 alive;
-	int		 rc, i, j;
-
-	rc = ds_pool_get_failed_tgt_idx(pool_uuid, &failed_tgts,
-					&failed_tgts_cnt);
-	if (rc) {
-		D_ERROR(DF_UUID "failed to get tgt_idx, "DF_RC"\n",
-			DP_UUID(pool_uuid), DP_RC(rc));
-		return rc;
-	}
-
-	D_ASSERTF(failed_tgts_cnt <= dss_tgt_nr,
-		  "BAD failed_tgts_cnt %d, dss_tgt_nr %d\n",
-		  failed_tgts_cnt, dss_tgt_nr);
-	if (failed_tgts_cnt == dss_tgt_nr) {
-		D_GOTO(out, rc = -DER_NONEXIST);
-	} else if (failed_tgts_cnt == 0) {
-		/* if all alive, select one random tgt */
-		rc = rand() % dss_tgt_nr;
-		goto out;
-	} else {
-		/* if partial failed, select first alive tgt */
-		for (i = 0; i < dss_tgt_nr; i++) {
-			alive = true;
-			for (j = 0; j < failed_tgts_cnt; j++) {
-				if (i == failed_tgts[j]) {
-					alive = false;
-					break;
-				}
-			}
-			if (alive) {
-				rc = i;
-				goto out;
-			}
-		}
-	}
-
-out:
-	D_FREE(failed_tgts);
-	return rc;
-}
-
-/** Check active container, if its RF value match with new pool map */
-int
-ds_cont_rf_check(uuid_t pool_uuid)
-{
-	struct cont_rf_check_arg	 check_arg;
-	int				*status;
-	int				 tgt_idx;
-	int				 rc = 0;
-
-	uuid_copy(check_arg.crc_pool_uuid, pool_uuid);
-	rc = ABT_eventual_create(sizeof(*status), &check_arg.crc_eventual);
-	if (rc != ABT_SUCCESS)
-		return dss_abterr2der(rc);
-
-	/* check RF on one alive tgt's VOS main XS */
-	rc = cont_rf_check_get_tgt(pool_uuid);
-	if (rc < 0) {
-		if (rc == -DER_NONEXIST)
-			rc = 0;
-		goto out;
-	}
-	tgt_idx = rc;
-	rc = dss_ult_create(cont_rf_check_ult, &check_arg, DSS_XS_VOS, tgt_idx,
-			    0, NULL);
-	if (rc)
-		D_GOTO(out, rc);
-
-	rc = ABT_eventual_wait(check_arg.crc_eventual, (void **)&status);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out, rc = dss_abterr2der(rc));
-	rc = *status;
-
-out:
-	ABT_eventual_free(&check_arg.crc_eventual);
-	return rc;
-}
-
 struct cont_prop_set_arg {
 	uuid_t	cpa_cont_uuid;
 	uuid_t	cpa_pool_uuid;
@@ -2655,13 +2468,18 @@ cont_child_prop_update(void *data)
 		struct daos_co_status co_stat = { 0 };
 
 		daos_prop_val_2_co_status(iv_entry->dpe_val, &co_stat);
-		if (co_stat.dcs_pm_ver <= child->sc_status_pm_ver)
+		if (co_stat.dcs_pm_ver < child->sc_status_pm_ver)
 			goto out;
 		if (dss_get_module_info()->dmi_tgt_id == 0)
-			D_DEBUG(DB_TRACE, DF_CONT" statu_pm_ver set from %d to %d.\n",
+			D_DEBUG(DB_MD, DF_CONT" statu_pm_ver %d -> %d status %u\n",
 				DP_CONT(arg->cpa_pool_uuid, arg->cpa_cont_uuid),
-				child->sc_status_pm_ver, co_stat.dcs_pm_ver);
+				child->sc_status_pm_ver, co_stat.dcs_pm_ver,
+				co_stat.dcs_status);
 		child->sc_status_pm_ver = co_stat.dcs_pm_ver;
+		if (co_stat.dcs_status == DAOS_PROP_CO_UNCLEAN)
+			child->sc_rw_disabled = 1;
+		else if (co_stat.dcs_status == DAOS_PROP_CO_HEALTHY)
+			child->sc_rw_disabled = 0;
 	}
 
 out:
@@ -2680,6 +2498,7 @@ ds_cont_tgt_prop_update(uuid_t pool_uuid, uuid_t cont_uuid, daos_prop_t	*prop)
 	    daos_prop_entry_get(prop, DAOS_PROP_CO_OBJ_VERSION) == NULL)
 		return 0;
 
+	D_DEBUG(DB_MD, DF_CONT" property update.\n", DP_CONT(pool_uuid, cont_uuid));
 	uuid_copy(arg.cpa_cont_uuid, cont_uuid);
 	uuid_copy(arg.cpa_pool_uuid, pool_uuid);
 	arg.cpa_prop = prop;

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -187,7 +187,6 @@ void ds_cont_child_stop_all(struct ds_pool_child *pool_child);
 
 int ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
 			 struct ds_cont_child **ds_cont);
-int ds_cont_rf_check(uuid_t pool_uuid);
 
 /** initialize a csummer based on container properties. Will retrieve the
  * checksum related properties from IV
@@ -256,4 +255,7 @@ int ds_cont_ec_eph_delete(struct ds_pool *pool, uuid_t cont_uuid, int tgt_idx);
 
 void ds_cont_ec_timestamp_update(struct ds_cont_child *cont);
 
+typedef int(*cont_rdb_iter_cb_t)(uuid_t pool_uuid, uuid_t cont_uuid, struct rdb_tx *tx, void *arg);
+int ds_cont_rdb_iterate(uuid_t pool_uuid, cont_rdb_iter_cb_t iter_cb, void *cb_arg);
+int ds_cont_rf_check(uuid_t pool_uuid, uuid_t cont_uuid, struct rdb_tx *tx);
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3652,7 +3652,8 @@ obj_shard_comp_cb(tse_task_t *task, struct shard_auxi_args *shard_auxi,
 			   !obj_is_modification_opc(obj_auxi->opc) &&
 			   !obj_auxi->is_ec_obj && !obj_auxi->spec_shard &&
 			   !obj_auxi->spec_group && !obj_auxi->to_leader &&
-			   ret != -DER_TX_RESTART && !DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY)) {
+			   ret != -DER_TX_RESTART && ret != -DER_RF &&
+			   !DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY)) {
 			int new_tgt;
 
 			/* Check if there are other replicas available to

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -783,7 +783,7 @@ obj_ec_parity_lists_match(struct daos_recx_ep_list *lists_1,
 				return -DER_FETCH_AGAIN;
 			}
 			D_ERROR("got different parity recx in EC data recovery\n");
-			return -DER_IO;
+			return -DER_DATA_LOSS;
 		}
 		if (list_1->re_nr == 0)
 			continue;
@@ -793,7 +793,7 @@ obj_ec_parity_lists_match(struct daos_recx_ep_list *lists_1,
 			    (list_1->re_items[j].re_recx.rx_nr !=
 			     list_2->re_items[j].re_recx.rx_nr)) {
 				D_ERROR("got different parity recx in EC data recovery\n");
-				return -DER_IO;
+				return -DER_DATA_LOSS;
 			}
 			if (list_1->re_items[j].re_ep != list_2->re_items[j].re_ep)
 				return -DER_FETCH_AGAIN;

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1422,7 +1422,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 			if (orw->orw_flags & ORF_EC_RECOV_FROM_PARITY) {
 				if (shadows == NULL) {
-					rc = -DER_IO;
+					rc = -DER_DATA_LOSS;
 					D_ERROR(DF_UOID" ORF_EC_RECOV_FROM_PARITY should not with "
 						"NULL shadows, "DF_RC"\n", DP_UOID(orw->orw_oid),
 						DP_RC(rc));

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1507,8 +1507,6 @@ out:
 	ABT_rwlock_unlock(pool->sp_lock);
 	if (map != NULL)
 		pool_map_decref(map);
-	if (rc == 0)
-		rc = ds_cont_rf_check(pool->sp_uuid);
 	return rc;
 }
 

--- a/src/tests/ftest/deployment/target_failure.py
+++ b/src/tests/ftest/deployment/target_failure.py
@@ -141,6 +141,7 @@ class TargetFailure(IorTestBase):
         self.pool.reintegrate(rank="0", tgt_idx="1")
         self.pool.measure_rebuild_time(operation="Reintegrate rank 0 -> target 1", interval=5)
 
+        self.container.set_prop(prop='status', value="healthy")
         # 7. Verify that the container's Health property is HEALTHY.
         if not self.container.verify_prop({"status": "HEALTHY"}):
             errors.append("Container health isn't HEALTHY after reintegrate!")
@@ -245,6 +246,7 @@ class TargetFailure(IorTestBase):
         self.pool.reintegrate(rank="1", tgt_idx="0")
         self.pool.measure_rebuild_time(operation="Reintegrate 1 target", interval=5)
 
+        self.container.set_prop(prop='status', value="healthy")
         # 7. Verify that the container's Health property is HEALTHY.
         if not self.container.verify_prop({"status": "HEALTHY"}):
             errors.append("Container health isn't HEALTHY after reintegrate!")
@@ -388,6 +390,7 @@ class TargetFailure(IorTestBase):
         self.pool[excluded_pool_num].measure_rebuild_time(
             operation="Reintegrate 1 target", interval=5)
 
+        self.container[1].set_prop(prop='status', value="healthy")
         # 8. Verify that self.container[1]'s Health property is HEALTHY.
         if not self.container[1].verify_prop({"status": "HEALTHY"}):
             errors.append("Container health isn't HEALTHY after first IOR!")

--- a/src/tests/ftest/rebuild/basic.yaml
+++ b/src/tests/ftest/rebuild/basic.yaml
@@ -22,6 +22,7 @@ pool:
   scm_size: 1G
   control_method: dmg
   pool_query_timeout: 30
+  properties: rd_fac:2
 container:
   akey_size: 5
   dkey_size: 5
@@ -43,6 +44,7 @@ container:
     ten_records:
       record_qty: 10
   debug: true
+  properties: rd_fac:2
 testparams:
   ranks: !mux
     rank1:

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -19,6 +19,7 @@ pool:
   svcn: 2
   control_method: dmg
   pool_query_timeout: 30
+  properties: rd_fac:2
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/rebuild/delete_objects.yaml
+++ b/src/tests/ftest/rebuild/delete_objects.yaml
@@ -20,6 +20,7 @@ pool:
   debug: true
   control_method: dmg
   pool_query_timeout: 30
+  properties: rd_fac:2
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -23,6 +23,7 @@ pool:
   svcn: 2
   control_method: dmg
   pool_query_timeout: 30
+  properties: rd_fac:2
 container:
   object_qty: 10
   record_qty: 10

--- a/src/tests/suite/daos_base_tx.c
+++ b/src/tests/suite/daos_base_tx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -881,6 +881,26 @@ dtx_21(void **state)
 	ioreq_fini(&req);
 }
 
+static int
+dtx_base_rf0_setup(void **state)
+{
+	int	rc;
+
+	rc = rebuild_sub_setup_common(state, DEFAULT_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF0);
+	return rc;
+}
+
+static int
+dtx_base_rf1_setup(void **state)
+{
+	int	rc;
+
+	rc = rebuild_sub_setup_common(state, DEFAULT_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF1);
+	return rc;
+}
+
 static const struct CMUnitTest dtx_tests[] = {
 	{"DTX1: update/punch single value with DTX successfully",
 	 dtx_1, NULL, test_case_teardown},
@@ -921,9 +941,9 @@ static const struct CMUnitTest dtx_tests[] = {
 	{"DTX19: DTX resend during bulk data transfer - multiple reps",
 	 dtx_19, NULL, test_case_teardown},
 	{"DTX20: race between DTX refresh and DTX resync",
-	 dtx_20, NULL, test_case_teardown},
+	 dtx_20, dtx_base_rf1_setup, test_case_teardown},
 	{"DTX21: do not abort partially committed DTX",
-	 dtx_21, NULL, test_case_teardown},
+	 dtx_21, dtx_base_rf0_setup, test_case_teardown},
 };
 
 static int

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -2401,10 +2401,10 @@ co_rf_simple(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 
-	print_message("obj update should success after re-integrate\n");
+	print_message("obj update should still fail with DER_RF after re-integrate\n");
 	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
 			     NULL);
-	assert_rc_equal(rc, 0);
+	assert_rc_equal(rc, -DER_RF);
 
 	/* clear the UNCLEAN status */
 	rc = daos_cont_status_clear(arg->coh, NULL);
@@ -2840,9 +2840,9 @@ co_redun_lvl(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 
-	print_message("obj update should success after re-integrate\n");
+	print_message("obj update should still fail with DER_RF after re-integrate\n");
 	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
-	assert_rc_equal(rc, 0);
+	assert_rc_equal(rc, -DER_RF);
 
 	rc = daos_obj_close(io_oh, NULL);
 	assert_rc_equal(rc, 0);

--- a/src/tests/suite/daos_degraded.c
+++ b/src/tests/suite/daos_degraded.c
@@ -250,8 +250,8 @@ static const struct CMUnitTest degraded_tests[] = {
 static int
 degraded_setup(void **state)
 {
-	return test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			  0, NULL);
+	return rebuild_sub_setup_common(state, DEFAULT_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF3);
 }
 
 static int

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -2885,7 +2885,7 @@ dtx_38(void **state)
 	par_barrier(PAR_COMM_WORLD);
 
 	rebuild_single_pool_rank(arg, kill_ranks[0], false);
-
+	daos_cont_status_clear(arg->coh, NULL);
 	par_barrier(PAR_COMM_WORLD);
 	if (arg->myrank == 0) {
 		print_message("Verifying data after rebuild...\n");
@@ -3052,8 +3052,38 @@ dtx_sub_setup(void **state)
 
 	saved_dtx_arg = *state;
 	*state = NULL;
-	rc = test_setup(state, SETUP_CONT_CONNECT, true, SMALL_POOL_SIZE,
-			0, NULL);
+
+	rc = rebuild_sub_setup_common(state, SMALL_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF2);
+
+	return rc;
+}
+
+static int
+dtx_sub_rf0_setup(void **state)
+{
+	int	rc;
+
+	saved_dtx_arg = *state;
+	*state = NULL;
+
+	rc = rebuild_sub_setup_common(state, SMALL_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF0);
+
+	return rc;
+}
+
+static int
+dtx_sub_rf1_setup(void **state)
+{
+	int	rc;
+
+	saved_dtx_arg = *state;
+	*state = NULL;
+
+	rc = rebuild_sub_setup_common(state, SMALL_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF1);
+
 	return rc;
 }
 
@@ -3151,9 +3181,9 @@ static const struct CMUnitTest dtx_tests[] = {
 	{"DTX37: resync - leader failed during prepare",
 	 dtx_37, dtx_sub_setup, dtx_sub_teardown},
 	{"DTX38: resync - lost whole redundancy groups",
-	 dtx_38, dtx_sub_setup, dtx_sub_teardown},
+	 dtx_38, dtx_sub_rf0_setup, dtx_sub_teardown},
 	{"DTX39: not restart the transaction with fixed epoch",
-	 dtx_39, dtx_sub_setup, dtx_sub_teardown},
+	 dtx_39, dtx_sub_rf1_setup, dtx_sub_teardown},
 
 	{"DTX40: uncertain check - miss commit with delay",
 	 dtx_40, NULL, test_case_teardown},

--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -526,23 +526,23 @@ drain_fail_and_retry_objects(void **state)
 /** create a new pool/container for each test */
 static const struct CMUnitTest drain_tests[] = {
 	{"DRAIN1: drain small rec multiple dkeys",
-	 drain_dkeys, rebuild_small_sub_setup, test_teardown},
+	 drain_dkeys, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN2: drain small rec multiple akeys",
-	 drain_akeys, rebuild_small_sub_setup, test_teardown},
+	 drain_akeys, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN3: drain small rec multiple indexes",
-	 drain_indexes, rebuild_small_sub_setup, test_teardown},
+	 drain_indexes, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN4: drain small rec multiple keys/indexes",
-	 drain_multiple, rebuild_small_sub_setup, test_teardown},
+	 drain_multiple, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN5: drain large rec single index",
-	 drain_large_rec, rebuild_small_sub_setup, test_teardown},
+	 drain_large_rec, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN6: drain keys with multiple snapshots",
-	 drain_snap_update_keys, rebuild_small_sub_setup, test_teardown},
+	 drain_snap_update_keys, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN7: drain keys/punch with multiple snapshots",
 	 drain_snap_punch_keys, rebuild_small_sub_setup, test_teardown},
 	{"DRAIN8: drain multiple objects",
-	 drain_objects, rebuild_sub_setup, test_teardown},
+	 drain_objects, rebuild_sub_rf0_setup, test_teardown},
 	{"DRAIN9: drain fail and retry",
-	 drain_fail_and_retry_objects, rebuild_sub_setup, test_teardown},
+	 drain_fail_and_retry_objects, rebuild_sub_rf0_setup, test_teardown},
 };
 
 int

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3276,6 +3276,7 @@ fetch_replica_unavail(void **state)
 
 		/* wait until reintegration is done */
 		test_rebuild_wait(&arg, 1);
+		daos_cont_status_clear(arg->coh, NULL);
 	}
 	D_FREE(buf);
 	par_barrier(PAR_COMM_WORLD);
@@ -5118,6 +5119,7 @@ obj_setup_internal(void **state)
 	else if (arg->obj_class != OC_UNKNOWN)
 		dts_obj_class = arg->obj_class;
 
+	dt_redun_lvl = DAOS_PROP_CO_REDUN_RANK;
 	return 0;
 }
 

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -407,8 +407,8 @@ static const struct CMUnitTest oid_alloc_tests[] = {
 int
 oid_alloc_setup(void **state)
 {
-	return test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			  0, NULL);
+	return rebuild_sub_setup_common(state, DEFAULT_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF2);
 }
 
 int

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -2074,6 +2074,7 @@ static int
 pool_map_refreshes_setup(void **state)
 {
 	async_enable(state);
+	dt_redun_fac = DAOS_PROP_CO_REDUN_RF1;
 	return test_setup(state, SETUP_CONT_CONNECT, true, SMALL_POOL_SIZE, 0, NULL);
 }
 

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1386,6 +1386,58 @@ reintegrate_failure_and_retry(void **state)
 	rebuild_io_validate(arg, oids, OBJ_NR);
 }
 
+static void
+rebuild_kill_more_RF_ranks(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	struct ioreq	req;
+	d_rank_t	ranks[4] = {7, 6, 5, 4};
+	int		i;
+
+	if (!test_runable(arg, 7) || arg->pool.alive_svc->rl_nr < 5) {
+		print_message("need at least 5 svcs, -s5\n");
+		return;
+	}
+
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_3GX, 0, 0, arg->myrank);
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+		insert_single("dkey", "akey", 0, "data", strlen("data") + 1,
+			      DAOS_TX_NONE, &req);
+		ioreq_fini(&req);
+	}
+	rebuild_pools_ranks(&arg, 1, ranks, 4, true);
+
+	reintegrate_single_pool_rank(arg, 5, true);
+	reintegrate_single_pool_rank(arg, 6, true);
+	reintegrate_single_pool_rank(arg, 4, true);
+	reintegrate_single_pool_rank(arg, 7, true);
+
+	print_message("lookup and expect -DER_RF\n");
+	for (i = 0; i < OBJ_NR; i++) {
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+		arg->expect_result = -DER_RF;
+		D_DEBUG(DB_TRACE, "lookup single %d\n", i);
+		lookup_single("dkey", "akey", 0, "data", strlen("data") + 1,
+			      DAOS_TX_NONE, &req);
+		ioreq_fini(&req);
+	}
+
+	D_DEBUG(DB_TRACE, "cont status clear\n");
+	/* clear health status */
+	daos_cont_status_clear(arg->coh, NULL);
+
+	print_message("clear health status then retry.\n");
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_3GX, 0, 0, arg->myrank);
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+		lookup_single("dkey", "akey", 0, "data", strlen("data") + 1,
+			      DAOS_TX_NONE, &req);
+		ioreq_fini(&req);
+	}
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: drop rebuild scan reply",
@@ -1452,7 +1504,7 @@ static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD25: rebuild with two failures",
 	 rebuild_multiple_failures, rebuild_sub_setup, rebuild_sub_teardown},
 	{"REBUILD26: rebuild fail all replicas before rebuild",
-	 rebuild_fail_all_replicas_before_rebuild, rebuild_sub_setup,
+	 rebuild_fail_all_replicas_before_rebuild, rebuild_sub_rf1_setup,
 	 rebuild_sub_teardown},
 	{"REBUILD27: rebuild fail all replicas",
 	 rebuild_fail_all_replicas, rebuild_sub_setup, rebuild_sub_teardown},
@@ -1467,6 +1519,9 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_sub_teardown},
 	{"REBUILD31: reintegrate failure and retry",
 	  reintegrate_failure_and_retry, rebuild_sub_setup,
+	 rebuild_sub_teardown},
+	{"REBUILD32: kill more ranks than RF, then reintegrate",
+	  rebuild_kill_more_RF_ranks, rebuild_sub_setup,
 	 rebuild_sub_teardown},
 };
 

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -180,8 +180,6 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 
 	par_barrier(PAR_COMM_WORLD);
 	for (i = 0; i < args_cnt; i++) {
-		daos_cont_status_clear(args[i]->coh, NULL);
-
 		if (args[i]->rebuild_post_cb)
 			args[i]->rebuild_post_cb(args[i]);
 	}
@@ -550,9 +548,6 @@ rebuild_io_verify(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr)
 	int	rc;
 	int	i;
 
-	rc = daos_cont_status_clear(arg->coh, NULL);
-	assert_rc_equal(rc, 0);
-
 	print_message("rebuild io verify obj %d\n", oids_nr);
 	for (i = 0; i < oids_nr; i++) {
 		/* XXX: skip punch object. */
@@ -798,12 +793,14 @@ dfs_ec_rebuild_io(void **state, int *shards, int shards_nr)
 
 	dfs_attr_t attr = {};
 
-	attr.da_props = daos_prop_alloc(2);
+	attr.da_props = daos_prop_alloc(3);
 	assert_non_null(attr.da_props);
 	attr.da_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
 	attr.da_props->dpp_entries[0].dpe_val = 1 << 15;
 	attr.da_props->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_LVL;
 	attr.da_props->dpp_entries[1].dpe_val = DAOS_PROP_CO_REDUN_RANK;
+	attr.da_props->dpp_entries[2].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	attr.da_props->dpp_entries[2].dpe_val = DAOS_PROP_CO_REDUN_RF2;
 
 	rc = dfs_cont_create(arg->pool.poh, &co_uuid, &attr, &co_hdl,
 			     &dfs_mt);
@@ -997,15 +994,24 @@ int
 rebuild_pool_create(test_arg_t **new_arg, test_arg_t *old_arg, int flag,
 		    struct test_pool *pool)
 {
-	int rc;
+	daos_prop_t	*props = NULL;
+	int		rc;
 
-	/* create/connect another pool */
-	rc = test_setup((void **)new_arg, flag, old_arg->multi_rank,
-			REBUILD_SUBTEST_POOL_SIZE, 0, pool);
+	rc = test_setup((void **)new_arg, flag < SETUP_POOL_CONNECT ? flag : SETUP_POOL_CONNECT,
+			old_arg->multi_rank, REBUILD_SUBTEST_POOL_SIZE, 0, pool);
 	if (rc) {
 		print_message("open/connect another pool failed: rc %d\n", rc);
 		return rc;
 	}
+
+	/* sustain 2 failure here */
+	props = daos_prop_alloc(1);
+	props->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	props->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF2;
+	while (!rc && (*new_arg)->setup_state != flag)
+		rc = test_setup_next_step((void **)new_arg, NULL, NULL, props);
+	assert_int_equal(rc, 0);
+	daos_prop_free(props);
 
 	(*new_arg)->index = old_arg->index;
 	return 0;
@@ -1138,18 +1144,32 @@ restore_group_state(void **state)
 }
 
 int
-rebuild_sub_setup(void **state)
+rebuild_sub_setup_common(void **state, daos_size_t pool_size, int node_nr, uint32_t rf)
 {
 	test_arg_t	*arg;
+	daos_prop_t	*props = NULL;
 	int		rc;
 
 	save_group_state(state);
-	rc = test_setup(state, SETUP_CONT_CONNECT, true,
-			REBUILD_SUBTEST_POOL_SIZE, 0, NULL);
-	if (rc)
-		return rc;
+	rc = test_setup(state, SETUP_POOL_CONNECT, true,
+			pool_size, node_nr, NULL);
+	if (rc) {
+		/* Let's skip for this case, since it is possible there
+		 * is not enough ranks here.
+		 */
+		print_message("It can not create the pool, probably due"
+			      " to not enough ranks %d\n", rc);
+		return 0;
+	}
 
 	arg = *state;
+	props = daos_prop_alloc(1);
+	props->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	props->dpp_entries[0].dpe_val = rf;
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL, props);
+	assert_int_equal(rc, 0);
+	daos_prop_free(props);
 	if (dt_obj_class != DAOS_OC_UNKNOWN)
 		arg->obj_class = dt_obj_class;
 	else
@@ -1161,22 +1181,43 @@ rebuild_sub_setup(void **state)
 int
 rebuild_small_sub_setup(void **state)
 {
-	test_arg_t	*arg;
-	int rc;
+	return rebuild_sub_setup_common(state, REBUILD_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF2);
+}
 
-	save_group_state(state);
-	rc = test_setup(state, SETUP_CONT_CONNECT, true,
-			REBUILD_POOL_SIZE, 0, NULL);
-	if (rc)
-		return rc;
+int
+rebuild_small_sub_rf1_setup(void **state)
+{
+	return rebuild_sub_setup_common(state, REBUILD_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF1);
+}
 
-	arg = *state;
-	if (dt_obj_class != DAOS_OC_UNKNOWN)
-		arg->obj_class = dt_obj_class;
-	else
-		arg->obj_class = DAOS_OC_R3S_SPEC_RANK;
+int
+rebuild_small_sub_rf0_setup(void **state)
+{
+	return rebuild_sub_setup_common(state, REBUILD_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF0);
+}
 
-	return 0;
+int
+rebuild_sub_setup(void **state)
+{
+	return rebuild_sub_setup_common(state, REBUILD_SUBTEST_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF2);
+}
+
+int
+rebuild_sub_rf1_setup(void **state)
+{
+	return rebuild_sub_setup_common(state, REBUILD_SUBTEST_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF1);
+}
+
+int
+rebuild_sub_rf0_setup(void **state)
+{
+	return rebuild_sub_setup_common(state, REBUILD_SUBTEST_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF0);
 }
 
 int

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -251,7 +251,7 @@ rebuild_ec_multi_stripes(void **state)
 }
 
 static int
-rebuild_ec_setup(void  **state, int number)
+rebuild_ec_setup(void  **state, int number, uint32_t rf)
 {
 	test_arg_t	*arg;
 	daos_prop_t	*props = NULL;
@@ -274,7 +274,7 @@ rebuild_ec_setup(void  **state, int number)
 	/* sustain 2 failure here */
 	props = daos_prop_alloc(3);
 	props->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_FAC;
-	props->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RF1;
+	props->dpp_entries[0].dpe_val = rf;
 	props->dpp_entries[1].dpe_type = DAOS_PROP_CO_CSUM;
 	props->dpp_entries[1].dpe_val = DAOS_PROP_CO_CSUM_CRC32;
 	props->dpp_entries[2].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
@@ -294,15 +294,21 @@ rebuild_ec_setup(void  **state, int number)
 }
 
 static int
+rebuild_ec_8nodes_rf1_setup(void **state)
+{
+	return rebuild_ec_setup(state, 8, DAOS_PROP_CO_REDUN_RF1);
+}
+
+static int
 rebuild_ec_8nodes_setup(void **state)
 {
-	return rebuild_ec_setup(state, 8);
+	return rebuild_ec_setup(state, 8, DAOS_PROP_CO_REDUN_RF2);
 }
 
 static int
 rebuild_ec_6nodes_setup(void **state)
 {
-	return rebuild_ec_setup(state, 6);
+	return rebuild_ec_setup(state, 6, DAOS_PROP_CO_REDUN_RF2);
 }
 
 static void
@@ -556,10 +562,12 @@ dfs_ec_seq_fail(void **state, int *shards, int shards_nr)
 
 	dfs_attr_t attr = {};
 
-	attr.da_props = daos_prop_alloc(1);
+	attr.da_props = daos_prop_alloc(2);
 	assert_non_null(attr.da_props);
 	attr.da_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_LVL;
 	attr.da_props->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RANK;
+	attr.da_props->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	attr.da_props->dpp_entries[1].dpe_val = DAOS_PROP_CO_REDUN_RF2;
 
 	rc = dfs_cont_create(arg->pool.poh, &co_uuid, &attr, &co_hdl, &dfs_mt);
 	daos_prop_free(attr.da_props);
@@ -1126,6 +1134,7 @@ rebuild_ec_multiple_shards(void **state)
 			ioreq_fini(&req);
 		}
 		rebuild_pools_ranks(&arg, 1, &rank, 1, false);
+		daos_cont_status_clear(arg->coh, NULL);
 		rank++;
 	}
 
@@ -1209,24 +1218,24 @@ rebuild_ec_multiple_failure_tgts(void **state)
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: rebuild partial update with data tgt fail",
-	 rebuild_partial_fail_data, rebuild_ec_8nodes_setup, test_teardown},
+	 rebuild_partial_fail_data, rebuild_ec_8nodes_rf1_setup, test_teardown},
 	{"REBUILD1: rebuild partial update with parity tgt fail",
-	 rebuild_partial_fail_parity, rebuild_ec_8nodes_setup, test_teardown},
+	 rebuild_partial_fail_parity, rebuild_ec_8nodes_rf1_setup, test_teardown},
 	{"REBUILD2: rebuild full stripe update with data tgt fail",
-	 rebuild_full_fail_data, rebuild_ec_8nodes_setup, test_teardown},
+	 rebuild_full_fail_data, rebuild_ec_8nodes_rf1_setup, test_teardown},
 	{"REBUILD3: rebuild full stripe update with parity tgt fail",
-	 rebuild_full_fail_parity, rebuild_ec_8nodes_setup, test_teardown},
+	 rebuild_full_fail_parity, rebuild_ec_8nodes_rf1_setup, test_teardown},
 	{"REBUILD4: rebuild full then partial update with data tgt fail",
-	 rebuild_full_partial_fail_data, rebuild_ec_8nodes_setup,
+	 rebuild_full_partial_fail_data, rebuild_ec_8nodes_rf1_setup,
 	 test_teardown},
 	{"REBUILD5: rebuild full then partial update with parity tgt fail",
-	 rebuild_full_partial_fail_parity, rebuild_ec_8nodes_setup,
+	 rebuild_full_partial_fail_parity, rebuild_ec_8nodes_rf1_setup,
 	 test_teardown},
 	{"REBUILD6: rebuild partial then full update with data tgt fail",
-	 rebuild_partial_full_fail_data, rebuild_ec_8nodes_setup,
+	 rebuild_partial_full_fail_data, rebuild_ec_8nodes_rf1_setup,
 	 test_teardown},
 	{"REBUILD7: rebuild partial then full update with parity tgt fail",
-	 rebuild_partial_full_fail_parity, rebuild_ec_8nodes_setup,
+	 rebuild_partial_full_fail_parity, rebuild_ec_8nodes_rf1_setup,
 	 test_teardown},
 	{"REBUILD8: rebuild2p partial update with data tgt fail ",
 	 rebuild2p_partial_fail_data, rebuild_ec_8nodes_setup, test_teardown},
@@ -1309,16 +1318,16 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_dfs_fail_seq_p0p1, rebuild_ec_8nodes_setup,
 	 test_teardown},
 	{"REBUILD36: rebuild multiple group EC object",
-	 rebuild_multiple_group_ec_object, rebuild_ec_8nodes_setup,
+	 rebuild_multiple_group_ec_object, rebuild_ec_8nodes_rf1_setup,
 	 test_teardown},
 	{"REBUILD37: rebuild EC dkey enumeration",
-	 rebuild_ec_dkey_enumeration, rebuild_ec_8nodes_setup,
+	 rebuild_ec_dkey_enumeration, rebuild_ec_8nodes_rf1_setup,
 	 test_teardown},
 	{"REBUILD38: rebuild EC multi-stripes @ different epochs",
 	 rebuild_ec_multi_stripes, rebuild_ec_8nodes_setup,
 	 test_teardown},
 	{"REBUILD39: rebuild EC parity with multiple group",
-	 rebuild_ec_parity_multi_group, rebuild_ec_8nodes_setup,
+	 rebuild_ec_parity_multi_group, rebuild_ec_8nodes_rf1_setup,
 	 test_teardown},
 	{"REBUILD40: rebuild EC snapshot with data shard",
 	 rebuild_ec_snapshot_data_shard, rebuild_ec_8nodes_setup,

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -777,7 +777,7 @@ rebuild_sx_object_internal(void **state, daos_oclass_id_t oclass)
 	test_rebuild_wait(&arg, 1);
 
 	print_message("lookup 100 dkeys\n");
-	for (i = 0; i < 100; i++) {
+	for (i = 0; i < 100 && oclass != OC_SX; i++) {
 		char buffer[32];
 
 		memset(buffer, 0, 32);
@@ -787,8 +787,7 @@ rebuild_sx_object_internal(void **state, daos_oclass_id_t oclass)
 		 * data anyway, so it may lose data here, so do not need verify data
 		 * for SX object. Incremental reintegration might fix this.
 		 */
-		if (oclass != OC_SX)
-			assert_string_equal(buffer, rec);
+		assert_string_equal(buffer, rec);
 	}
 	ioreq_fini(&req);
 }
@@ -848,6 +847,34 @@ rebuild_large_object(void **state)
 
 	/* wait until reintegration is done */
 	test_rebuild_wait(&arg, 1);
+}
+
+int
+rebuild_small_pool_n4_rf1_setup(void **state)
+{
+	test_arg_t	*arg;
+	int rc;
+
+	save_group_state(state);
+	rc = rebuild_sub_setup_common(state, REBUILD_SMALL_POOL_SIZE, 4, DAOS_PROP_CO_REDUN_RF1);
+	rc = test_setup(state, SETUP_CONT_CONNECT, true,
+			REBUILD_SMALL_POOL_SIZE, 4, NULL);
+	if (rc) {
+		/* Let's skip for this case, since it is possible there
+		 * is not enough ranks here.
+		 */
+		print_message("It can not create the pool with 4 ranks"
+			      " probably due to not enough ranks %d\n", rc);
+		return 0;
+	}
+
+	arg = *state;
+	if (dt_obj_class != DAOS_OC_UNKNOWN)
+		arg->obj_class = dt_obj_class;
+	else
+		arg->obj_class = DAOS_OC_R3S_SPEC_RANK;
+
+	return 0;
 }
 
 int
@@ -1188,6 +1215,7 @@ rebuild_with_dfs_open_create_punch(void **state)
 	rank = get_rank_by_oid_shard(arg, oid, 0);
 	rebuild_single_pool_rank(arg, rank, false);
 	reintegrate_single_pool_rank(arg, rank, false);
+	daos_cont_status_clear(co_hdl, NULL);
 
 	for (i = 0; i < 20; i++) {
 		sprintf(filename, "degrade_file_%d", i);
@@ -1201,7 +1229,6 @@ rebuild_with_dfs_open_create_punch(void **state)
 		assert_int_equal(rc, 0);
 	}
 
-	daos_cont_status_clear(co_hdl, NULL);
 
 	rc = dfs_release(dir);
 	assert_int_equal(rc, 0);
@@ -1303,25 +1330,25 @@ static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD11: rebuild snapshotted punched object",
 	 rebuild_snap_punch_empty, rebuild_small_sub_setup, test_teardown},
 	{"REBUILD12: rebuild sx object",
-	 rebuild_sx_object, rebuild_small_sub_setup, test_teardown},
+	 rebuild_sx_object, rebuild_small_sub_rf0_setup, test_teardown},
 	{"REBUILD13: rebuild xsf object",
 	 rebuild_xsf_object, rebuild_small_sub_setup, test_teardown},
 	{"REBUILD14: rebuild large stripe object",
-	 rebuild_large_object, rebuild_small_pool_n4_setup, test_teardown},
+	 rebuild_large_object, rebuild_small_pool_n4_rf1_setup, test_teardown},
 	{"REBUILD15: rebuild with 100 snapshot",
 	 rebuild_large_snap, rebuild_small_sub_setup, test_teardown},
 	{"REBUILD16: rebuild with full stripe",
-	 rebuild_full_shards, rebuild_small_pool_n4_setup, test_teardown},
+	 rebuild_full_shards, rebuild_small_pool_n4_rf1_setup, test_teardown},
 	{"REBUILD17: rebuild with punch recxs",
 	 rebuild_punch_recs, rebuild_small_sub_setup, test_teardown},
 	{"REBUILD18: rebuild with multiple group",
-	 rebuild_multiple_group, rebuild_small_sub_setup, test_teardown},
+	 rebuild_multiple_group, rebuild_small_sub_rf1_setup, test_teardown},
 	{"REBUILD19: rebuild with large offset",
 	 rebuild_with_large_offset, rebuild_small_sub_setup, test_teardown},
 	{"REBUILD20: rebuild with large key",
 	 rebuild_with_large_key, rebuild_small_sub_setup, test_teardown},
 	{"REBUILD21: rebuild with dfs open create punch",
-	 rebuild_with_dfs_open_create_punch, rebuild_small_sub_setup, test_teardown},
+	 rebuild_with_dfs_open_create_punch, rebuild_small_sub_rf1_setup, test_teardown},
 	{"REBUILD22: rebuild lot of objects with failure",
 	 rebuild_many_objects_with_failure, rebuild_sub_setup, test_teardown},
 };

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -75,6 +75,8 @@ extern unsigned int dt_csum_chunksize;
 extern bool dt_csum_server_verify;
 extern int  dt_obj_class;
 extern unsigned int dt_cell_size;
+extern int dt_redun_lvl;
+extern int dt_redun_fac;
 
 /* the temporary IO dir*/
 extern char *test_io_dir;
@@ -455,8 +457,13 @@ int rebuild_pool_connect_internal(void *data);
 
 
 int rebuild_sub_setup(void **state);
+int rebuild_sub_rf1_setup(void **state);
+int rebuild_sub_rf0_setup(void **state);
 int rebuild_sub_teardown(void **state);
 int rebuild_small_sub_setup(void **state);
+int rebuild_small_sub_rf1_setup(void **state);
+int rebuild_small_sub_rf0_setup(void **state);
+int rebuild_sub_setup_common(void **state, daos_size_t pool_size, int node_nr, uint32_t rf);
 
 int get_server_config(char *host, char *server_config_file);
 int get_log_file(char *host, char *server_config_file,

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -29,7 +29,8 @@ bool		dt_csum_server_verify;
 /** container cell size */
 unsigned int	dt_cell_size;
 int		dt_obj_class;
-
+int		dt_redun_lvl;
+int		dt_redun_fac;
 
 /* Create or import a single pool with option to store info in arg->pool
  * or an alternate caller-specified test_pool structure.
@@ -344,7 +345,7 @@ test_setup(void **state, unsigned int step, bool multi_rank,
 	unsigned int		 seed;
 	int			 rc = 0;
 	daos_prop_t		 co_props = {0};
-	struct daos_prop_entry	 dpp_entry[4] = {0};
+	struct daos_prop_entry	 dpp_entry[6] = {0};
 	struct daos_prop_entry	*entry;
 
 	/* feed a seed for pseudo-random number generator */
@@ -425,6 +426,20 @@ test_setup(void **state, unsigned int step, bool multi_rank,
 		entry = &dpp_entry[co_props.dpp_nr];
 		entry->dpe_type = DAOS_PROP_CO_EC_CELL_SZ;
 		entry->dpe_val = dt_cell_size;
+		co_props.dpp_nr++;
+	}
+
+	if (dt_redun_lvl) {
+		entry = &dpp_entry[co_props.dpp_nr];
+		entry->dpe_type = DAOS_PROP_CO_REDUN_LVL;
+		entry->dpe_val = dt_redun_lvl;
+		co_props.dpp_nr++;
+	}
+
+	if (dt_redun_fac) {
+		entry = &dpp_entry[co_props.dpp_nr];
+		entry->dpe_type = DAOS_PROP_CO_REDUN_FAC;
+		entry->dpe_val = dt_redun_fac;
 		co_props.dpp_nr++;
 	}
 
@@ -618,6 +633,8 @@ test_teardown(void **state)
 	}
 
 free:
+	dt_redun_lvl = 0;
+	dt_redun_fac = 0;
 	if (arg->pool.svc)
 		d_rank_list_free(arg->pool.svc);
 	if (arg->pool.alive_svc)
@@ -746,7 +763,7 @@ rebuild_pool_wait(test_arg_t *arg)
 	rc = test_pool_get_info(arg, &pinfo, NULL /* engine_ranks */);
 	rst = &pinfo.pi_rebuild_st;
 	if ((rst->rs_state == DRS_COMPLETED || rc != 0) && rst->rs_version != 0 &&
-	     rst->rs_version != arg->rebuild_pre_pool_ver) {
+	    rst->rs_version > arg->rebuild_pre_pool_ver) {
 		print_message("Rebuild "DF_UUIDF" (ver=%u orig_ver=%u) is done %d/%d, "
 			      "obj="DF_U64", rec="DF_U64".\n",
 			       DP_UUID(arg->pool.pool_uuid), rst->rs_version,
@@ -918,8 +935,6 @@ daos_start_server(test_arg_t *arg, const uuid_t pool_uuid,
 	rc = dmg_system_start_rank(dmg_config_file, rank);
 	print_message(" dmg start: %d, rc %#x\n", rank, rc);
 	assert_rc_equal(rc, 0);
-
-	daos_cont_status_clear(arg->coh, NULL);
 }
 
 void
@@ -965,8 +980,6 @@ daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid,
 	print_message(" dmg stop, rc %#x\n", rc);
 
 	assert_rc_equal(rc, 0);
-
-	daos_cont_status_clear(arg->coh, NULL);
 }
 
 struct daos_acl *


### PR DESCRIPTION
Once failure nodes exceed RF, then set status property to unclean, and use IV sync to broadcast unclean property to all targets to disable container IO.

So reintegrate nodes will not change status property, i.e. unhealthy status will only be changed by container status clean cmd.

Test-feature: rebuild ec
Test-tag: pr rebuild ec
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
