### PR TITLE
DAOS-12334 control: Do not print spurious errors on SPDK setup

### DIFF
--- a/src/control/server/init/setup_spdk.sh
+++ b/src/control/server/init/setup_spdk.sh
@@ -91,19 +91,10 @@ else
 	${scriptpath}
 	set +x
 
-	# build arglist manually to filter missing directories/files
-	# so we don't error on non-existent entities
-	for glob in '/dev/hugepages' '/dev/uio*'		\
-		'/sys/class/uio/uio*/device/config'	\
-		'/sys/class/uio/uio*/device/resource*'; do
-
-		# shellcheck disable=SC2086
-		if list=$(ls -d $glob); then
-			echo -n "RUN: ls -d $glob | xargs -r chown -R "
-			echo "$_TARGET_USER"
-			echo "$list" | xargs -r chown -R "$_TARGET_USER"
-		fi
-	done
+	if [ -d "/dev/hugepages/" ]; then
+		echo "RUN: chown -R ${_TARGET_USER} /dev/hugepages"
+		chown -R "${_TARGET_USER}" "/dev/hugepages"
+	fi
 
 	echo "Setting VFIO file permissions for unprivileged access"
 	set_vfio_permissions


### PR DESCRIPTION
Running DAOS/SPDK via UIO as an unprivileged user is no longer
supported so we don't need to modify the relevant file ownership.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
