### PR TITLE
DAOS-11409 mgmt: Improve pool create, startup time with md_on_ssd

### DIFF
--- a/src/common/dav/dav_iface.c
+++ b/src/common/dav/dav_iface.c
@@ -323,19 +323,6 @@ dav_obj_open(const char *path, int flags, struct umem_store *store)
 	}
 	size = (size_t)statbuf.st_size;
 
-	if (store->stor_priv != NULL) {
-		if (ftruncate(fd, 0) == -1) {
-			close(fd);
-			return NULL;
-		}
-
-		if (ftruncate(fd, (off_t)size) == -1) {
-			close(fd);
-			errno = ENOSPC;
-			return NULL;
-		}
-	}
-
 	hdl = dav_obj_open_internal(fd, 0, size, path, store);
 	if (hdl == NULL) {
 		close(fd);

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1557,3 +1557,15 @@ dss_has_enough_helper(void)
 {
 	return dss_tgt_offload_xs_nr > 1 && dss_tgt_offload_xs_nr >= dss_tgt_nr / 4;
 }
+
+/**
+ * Miscellaneous routines
+ */
+void
+dss_bind_to_xstream_cpuset(int tgt_id)
+{
+	struct dss_xstream *dx;
+
+	dx = dss_get_xstream(DSS_MAIN_XS_ID(tgt_id));
+	(void)dss_xstream_set_affinity(dx);
+}

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -37,6 +37,7 @@ void ds_mgmt_profile_hdlr(crt_rpc_t *rpc);
 void ds_mgmt_pool_get_svcranks_hdlr(crt_rpc_t *rpc);
 void ds_mgmt_pool_find_hdlr(crt_rpc_t *rpc);
 void ds_mgmt_mark_hdlr(crt_rpc_t *rpc);
+void dss_bind_to_xstream_cpuset(int tgt_id);
 
 /** srv_system.c */
 /* Management service (used only for map broadcast) */


### PR DESCRIPTION
- The umempobj_create/open/close serialization lock vos_pmemobj_lock is removed. The current pmdk code already serializes it using an internal global mutex lock. The md_on_ssd allocator does not require serialization.
- The vos file allocation during pool create is now parallized using threads for md_on_ssd as fallocate on tmpfs takes considerably long time to complete. These threads are bound to the cpus where the vos file will be hosted.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
