### PR TITLE
DAOS-12612 pool: fixes for checkpoint

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1270,7 +1270,7 @@ struct chkpt_ctx {
 	uint64_t                cc_commit_id;
 	uint64_t                cc_wait_id;
 	void                   *cc_sched_arg;
-	void                   *cc_eventual;
+	ABT_eventual		cc_eventual;
 };
 
 /**

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -165,8 +165,10 @@ vos_wal_on_commit(struct umem_store *store, uint64_t id)
 
 	ctx->cc_commit_id = id;
 
-	if (store->stor_ops->so_wal_id_cmp(store, id, ctx->cc_wait_id) >= 0)
+	if (store->stor_ops->so_wal_id_cmp(store, id, ctx->cc_wait_id) >= 0) {
 		ctx->cc_wake_fn(ctx);
+		store->chkpt_ctx = NULL;
+	}
 }
 
 static inline int
@@ -213,6 +215,7 @@ chkpt_wait(struct umem_store *store, uint64_t chkpt_tx, uint64_t *committed_tx, 
 	}
 
 	ctx->cc_wait_id = chkpt_tx;
+	store->chkpt_ctx = ctx;
 	ctx->cc_wait_fn(ctx);
 done:
 	*committed_tx = ctx->cc_commit_id;


### PR DESCRIPTION
1. @chkpt_ctx need be set and cleared properly.
2. ABT_eventual_set() accept ABT_eventual rather than ABT_eventual *, refine
to reuse ABT_eventual

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Signed-off-by: Wang Shilong <shilong.wang@intel.com>