### PR TITLE
DAOS-5912 rebuild: restore pool map if extend/drain fail (#11411)

### DIFF
--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2022 Intel Corporation.
+ * (C) Copyright 2017-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -21,7 +21,7 @@
  * associated targets
  */
 typedef enum {
-	RB_OP_FAIL,
+	RB_OP_EXCLUDE,
 	RB_OP_DRAIN,
 	RB_OP_REINT,
 	RB_OP_EXTEND,
@@ -29,7 +29,7 @@ typedef enum {
 	RB_OP_FAIL_RECLAIM,
 } daos_rebuild_opc_t;
 
-#define RB_OP_STR(rb_op) ((rb_op) == RB_OP_FAIL ? "Rebuild" : \
+#define RB_OP_STR(rb_op) ((rb_op) == RB_OP_EXCLUDE ? "Rebuild" : \
 			  (rb_op) == RB_OP_DRAIN ? "Drain" : \
 			  (rb_op) == RB_OP_REINT ? "Reintegrate" : \
 			  (rb_op) == RB_OP_EXTEND ? "Extend" : \

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2290,7 +2290,7 @@ migrate_enum_unpack_cb(struct dss_enum_unpack_io *io, void *data)
 
 	shard = arg->arg->shard % obj_ec_tgt_nr(&arg->oc_attr);
 	if ((rc == 1 && is_ec_data_shard(io->ui_oid.id_shard, &arg->oc_attr)) ||
-	    (tls->mpt_opc == RB_OP_FAIL && io->ui_oid.id_shard == shard)) {
+	    (tls->mpt_opc == RB_OP_EXCLUDE && io->ui_oid.id_shard == shard)) {
 		D_DEBUG(DB_REBUILD, DF_UOID" ignore shard "DF_KEY"/%u.\n",
 			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard);
 		D_GOTO(put, rc = 0);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -5314,7 +5314,7 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 
 	switch (opc) {
 	case POOL_EXCLUDE:
-		op = RB_OP_FAIL;
+		op = RB_OP_EXCLUDE;
 		break;
 	case POOL_DRAIN:
 		op = RB_OP_DRAIN;
@@ -5398,10 +5398,14 @@ pool_extend_map(struct rdb_tx *tx, struct pool_svc *svc, uint32_t nnodes,
 	if (rc != 0)
 		D_GOTO(out_map_buf, rc);
 
-	/* Extend the current pool map */
-	rc = pool_map_extend(map, map_version, map_buf);
-	if (rc != 0)
-		D_GOTO(out_map, rc);
+	if (map_buf != NULL) {
+		/* Extend the current pool map */
+		rc = pool_map_extend(map, map_version, map_buf);
+		pool_buf_free(map_buf);
+		map_buf = NULL;
+		if (rc != 0)
+			D_GOTO(out_map, rc);
+	}
 
 	/* Write the new pool map. */
 	rc = pool_buf_extract(map, &map_buf);

--- a/src/pool/srv_pool_map.c
+++ b/src/pool/srv_pool_map.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2021-2022 Intel Corporation.
+ * (C) Copyright 2021-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  *
@@ -142,11 +142,11 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 			       DP_TARGET(target));
 			break;
 		case PO_COMP_ST_DOWN:
-		case PO_COMP_ST_DRAIN:
 		case PO_COMP_ST_DOWNOUT:
 			D_ERROR("Can't ADD_IN non-up "DF_TARGET"\n",
 				DP_TARGET(target));
 			return -DER_INVAL;
+		case PO_COMP_ST_DRAIN:
 		case PO_COMP_ST_UP:
 		case PO_COMP_ST_NEW:
 			D_DEBUG(DB_MD, "change "DF_TARGET" to UPIN %p\n",
@@ -177,20 +177,30 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 			D_INFO("Skip EXCLUDE_OUT DOWNOUT "DF_TARGET"\n",
 			       DP_TARGET(target));
 			break;
-		case PO_COMP_ST_UP:
 		case PO_COMP_ST_UPIN:
-		case PO_COMP_ST_NEW:
 			D_ERROR("Can't EXCLUDE_OUT non-down "DF_TARGET"\n",
 				DP_TARGET(target));
 			return -DER_INVAL;
+		case PO_COMP_ST_NEW:
+		case PO_COMP_ST_UP:
 		case PO_COMP_ST_DOWN:
 		case PO_COMP_ST_DRAIN:
-			D_DEBUG(DB_MD, "change "DF_TARGET" to DOWNOUT %p\n",
-				DP_TARGET(target), map);
 			if (target->ta_comp.co_status == PO_COMP_ST_DOWN)
 				target->ta_comp.co_flags = PO_COMPF_DOWN2OUT;
-			target->ta_comp.co_status = PO_COMP_ST_DOWNOUT;
-			target->ta_comp.co_out_ver = ++(*version);
+			if ((target->ta_comp.co_status == PO_COMP_ST_UP ||
+			     target->ta_comp.co_status == PO_COMP_ST_NEW) &&
+			     target->ta_comp.co_fseq == 1) {
+				D_DEBUG(DB_MD, "change "DF_TARGET" to NEW %p\n",
+					DP_TARGET(target), map);
+				target->ta_comp.co_status = PO_COMP_ST_NEW;
+				target->ta_comp.co_in_ver = 0;
+				++(*version);
+			} else {
+				D_DEBUG(DB_MD, "change "DF_TARGET" to DOWNOUT %p fseq %u\n",
+					DP_TARGET(target), map, target->ta_comp.co_fseq);
+				target->ta_comp.co_status = PO_COMP_ST_DOWNOUT;
+				target->ta_comp.co_out_ver = ++(*version);
+			}
 			if (print_changes)
 				D_PRINT(DF_TARGET" is excluded.\n",
 					DP_TARGET(target));
@@ -254,6 +264,13 @@ ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 
 		if (tgt_map_ver != NULL && *tgt_map_ver < version)
 			*tgt_map_ver = version;
+
+
+		if (dom->do_comp.co_status == PO_COMP_ST_UP && opc == POOL_EXCLUDE_OUT &&
+		    dom->do_comp.co_fseq == 1) {
+			dom->do_comp.co_status = PO_COMP_ST_NEW;
+			dom->do_comp.co_in_ver = 0;
+		}
 
 		if (exclude_rank &&
 		    !(dom->do_comp.co_status & (PO_COMP_ST_DOWN |

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -492,7 +492,7 @@ find_rebuild_shards(unsigned int *tgt_stack_array,
 				D_GOTO(out, rc = -DER_NOMEM);
 		}
 
-		if (rebuild_op == RB_OP_FAIL) {
+		if (rebuild_op == RB_OP_EXCLUDE) {
 			rc = pl_obj_find_rebuild(map, md, NULL,
 						 rebuild_ver,
 						 *tgts, *shards,
@@ -511,7 +511,7 @@ find_rebuild_shards(unsigned int *tgt_stack_array,
 						  *tgts, *shards,
 						  max_shards);
 		} else {
-			D_ASSERT(rebuild_op == RB_OP_FAIL ||
+			D_ASSERT(rebuild_op == RB_OP_EXCLUDE ||
 				 rebuild_op == RB_OP_DRAIN ||
 				 rebuild_op == RB_OP_REINT ||
 				 rebuild_op == RB_OP_EXTEND);
@@ -586,7 +586,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	dc_obj_fetch_md(oid.id_pub, &md);
 	crt_group_rank(rpt->rt_pool->sp_group, &myrank);
 	md.omd_ver = rpt->rt_rebuild_ver;
-	if (rpt->rt_rebuild_op == RB_OP_FAIL ||
+	if (rpt->rt_rebuild_op == RB_OP_EXCLUDE ||
 	    rpt->rt_rebuild_op == RB_OP_DRAIN ||
 	    rpt->rt_rebuild_op == RB_OP_REINT ||
 	    rpt->rt_rebuild_op == RB_OP_EXTEND) {
@@ -671,7 +671,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 		/* Reclaim does not require sending any objects */
 		rebuild_nr = 0;
 	} else {
-		D_ASSERT(rpt->rt_rebuild_op == RB_OP_FAIL ||
+		D_ASSERT(rpt->rt_rebuild_op == RB_OP_EXCLUDE ||
 			 rpt->rt_rebuild_op == RB_OP_DRAIN ||
 			 rpt->rt_rebuild_op == RB_OP_REINT ||
 			 rpt->rt_rebuild_op == RB_OP_EXTEND ||

--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -514,10 +514,8 @@ static const struct CMUnitTest drain_tests[] = {
 	 drain_snap_punch_keys, rebuild_small_sub_setup, test_teardown},
 	{"DRAIN8: drain multiple objects",
 	 drain_objects, rebuild_sub_rf0_setup, test_teardown},
-	{"DRAIN9: drain multiple objects",
-	 drain_objects, rebuild_sub_setup, test_teardown},
-	{"DRAIN10: drain fail and retry",
-	 drain_fail_and_retry_objects, rebuild_sub_setup, test_teardown},
+	{"DRAIN9: drain fail and retry",
+	 drain_fail_and_retry_objects, rebuild_sub_rf0_setup, test_teardown},
 };
 
 int

--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -466,6 +466,36 @@ drain_objects(void **state)
 	rebuild_io_validate(arg, oids, OBJ_NR);
 }
 
+static void
+drain_fail_and_retry_objects(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	int		i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = daos_test_oid_gen(arg->coh, DAOS_OC_R1S_SPEC_RANK, 0,
+					    0, arg->myrank);
+		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
+		oids[i] = dts_oid_set_tgt(oids[i], DEFAULT_FAIL_TGT);
+	}
+
+	rebuild_io(arg, oids, OBJ_NR);
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+			      DAOS_REBUILD_OBJ_FAIL | DAOS_FAIL_ALWAYS, 0, NULL);
+
+	drain_single_pool_rank(arg, ranks_to_kill[0], false);
+
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+	rebuild_io_validate(arg, oids, OBJ_NR);
+
+	drain_single_pool_rank(arg, ranks_to_kill[0], false);
+	rebuild_io_validate(arg, oids, OBJ_NR);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest drain_tests[] = {
 	{"DRAIN1: drain small rec multiple dkeys",
@@ -484,6 +514,10 @@ static const struct CMUnitTest drain_tests[] = {
 	 drain_snap_punch_keys, rebuild_small_sub_setup, test_teardown},
 	{"DRAIN8: drain multiple objects",
 	 drain_objects, rebuild_sub_rf0_setup, test_teardown},
+	{"DRAIN9: drain multiple objects",
+	 drain_objects, rebuild_sub_setup, test_teardown},
+	{"DRAIN10: drain fail and retry",
+	 drain_fail_and_retry_objects, rebuild_sub_setup, test_teardown},
 };
 
 int

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1339,6 +1339,46 @@ rebuild_pool_destroy_during_rebuild_failure(void **state)
 						    DAOS_FAIL_ALWAYS);
 }
 
+static int
+reintegrate_failure_cb(void *arg)
+{
+	test_arg_t	*test_arg = arg;
+
+	daos_debug_set_params(test_arg->group, -1, DMG_KEY_FAIL_LOC,
+			      DAOS_REBUILD_OBJ_FAIL | DAOS_FAIL_ALWAYS, 0, NULL);
+
+	return 0;
+}
+
+static void
+reintegrate_failure_and_retry(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[20];
+	int		i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	for (i = 0; i < 20; i++)
+		oids[i] = daos_test_oid_gen(arg->coh, OC_RP_3GX, 0,
+					    0, arg->myrank);
+
+	rebuild_io(arg, oids, OBJ_NR);
+	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
+
+	arg->rebuild_cb = reintegrate_failure_cb;
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
+
+	arg->rebuild_cb = NULL;
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+	rebuild_io_validate(arg, oids, OBJ_NR);
+
+	reintegrate_single_pool_rank(arg, ranks_to_kill[0]);
+
+	rebuild_io_validate(arg, oids, OBJ_NR);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: drop rebuild scan reply",
@@ -1417,6 +1457,9 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_sub_teardown},
 	{"REBUILD30: destroy pool during rebuild failure and retry",
 	  rebuild_pool_destroy_during_rebuild_failure, rebuild_sub_setup,
+	 rebuild_sub_teardown},
+	{"REBUILD31: reintegrate failure and retry",
+	  reintegrate_failure_and_retry, rebuild_sub_setup,
 	 rebuild_sub_teardown},
 };
 

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -179,7 +179,6 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 	}
 }
 
-
 void
 rebuild_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill)
 {

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -149,7 +149,8 @@ typedef struct {
 	uint32_t		overlap:1,
 				not_check_result:1,
 				idx_no_jump:1,
-				no_rebuild:1;
+				no_rebuild:1,
+				no_rebuild_version_change:1;
 	int			expect_result;
 	daos_size_t		size;
 	int			nr;

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -739,7 +739,9 @@ rebuild_pool_wait(test_arg_t *arg)
 	rc = test_pool_get_info(arg, &pinfo, NULL /* engine_ranks */);
 	rst = &pinfo.pi_rebuild_st;
 	if ((rst->rs_state == DRS_COMPLETED || rc != 0) && rst->rs_version != 0 &&
-	    rst->rs_version > arg->rebuild_pre_pool_ver) {
+	    ((rst->rs_version > arg->rebuild_pre_pool_ver) ||
+	     (rst->rs_version == arg->rebuild_pre_pool_ver &&
+	      arg->no_rebuild_version_change))) {
 		print_message("Rebuild "DF_UUIDF" (ver=%u orig_ver=%u) is done %d/%d, "
 			      "obj="DF_U64", rec="DF_U64".\n",
 			       DP_UUID(arg->pool.pool_uuid), rst->rs_version,


### PR DESCRIPTION
restore the pool map if extend/drain fail.
Add tests to verify it.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
