### PR TITLE
DAOS-12308 control: Fix dmg system stop RC (#11483)

### DIFF
--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -143,9 +143,9 @@ func (svc *ControlService) memberStateResults(instances []Engine, tgtState syste
 			continue
 		}
 
-		results = append(results, &system.MemberResult{
-			Rank: rank, Msg: okMsg, State: state,
-		})
+		res := system.NewMemberResult(rank, nil, state)
+		res.Msg = okMsg
+		results = append(results, res)
 	}
 
 	return results, nil
@@ -226,9 +226,8 @@ func (svc *ControlService) queryLocalRanks(ctx context.Context, req *ctlpb.Ranks
 			// shouldn't happen, instances already filtered by ranks
 			return nil, err
 		}
-		results = append(results, &system.MemberResult{
-			Rank: rank, State: srv.LocalState(),
-		})
+		// Note this does not set Errored field in member result based on state.
+		results = append(results, system.NewMemberResult(rank, nil, srv.LocalState()))
 	}
 
 	return results, nil

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -138,8 +138,8 @@ func TestServer_CtlSvc_PrepShutdownRanks(t *testing.T) {
 				&mgmtpb.DaosResp{Status: 0},
 			},
 			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: stateString(system.MemberStateUnresponsive)},
-				{Rank: 2, State: stateString(system.MemberStateUnresponsive)},
+				{Rank: 1, Errored: true, State: stateString(system.MemberStateUnresponsive)},
+				{Rank: 2, Errored: true, State: stateString(system.MemberStateUnresponsive)},
 			},
 		},
 		"context cancel": { // dRPC req-resp duration > when parent context is canceled
@@ -497,8 +497,8 @@ func TestServer_CtlSvc_PingRanks(t *testing.T) {
 				&mgmtpb.DaosResp{Status: 0},
 			},
 			expResults: []*sharedpb.RankResult{
-				{Rank: 1, State: stateString(system.MemberStateUnresponsive)},
-				{Rank: 2, State: stateString(system.MemberStateUnresponsive)},
+				{Rank: 1, Errored: true, State: stateString(system.MemberStateUnresponsive)},
+				{Rank: 2, Errored: true, State: stateString(system.MemberStateUnresponsive)},
 			},
 		},
 		"dRPC context cancel": { // dRPC req-resp duration > when parent context is canceled

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -121,13 +121,12 @@ func (ei *EngineInstance) tryDrpc(ctx context.Context, method drpc.Method) *syst
 
 	localState := ei.LocalState()
 	if localState != system.MemberStateReady {
-		// member not ready for dRPC comms, annotate result with last
-		// error as Msg field if found to be stopped
-		result := &system.MemberResult{Rank: rank, State: localState}
+		// member not ready for dRPC comms, annotate result with last error if stopped
+		var err error
 		if localState == system.MemberStateStopped && ei._lastErr != nil {
-			result.Msg = ei._lastErr.Error()
+			err = ei._lastErr
 		}
-		return result
+		return system.NewMemberResult(rank, err, localState)
 	}
 
 	// system member state that should be set on dRPC success
@@ -152,10 +151,7 @@ func (ei *EngineInstance) tryDrpc(ctx context.Context, method drpc.Method) *syst
 	select {
 	case <-ctx.Done():
 		if ctx.Err() == context.DeadlineExceeded {
-			return &system.MemberResult{
-				Rank: rank, Msg: ctx.Err().Error(),
-				State: system.MemberStateUnresponsive,
-			}
+			return system.NewMemberResult(rank, ctx.Err(), system.MemberStateUnresponsive)
 		}
 		return nil // shutdown
 	case result := <-resChan:

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -519,11 +519,8 @@ func addUnresponsiveResults(log logging.Logger, hostRanks map[string][]system.Ra
 	for _, hes := range rr.HostErrors {
 		for _, addr := range strings.Split(hes.HostSet.DerangedString(), ",") {
 			for _, rank := range hostRanks[addr] {
-				resp.Results = append(resp.Results,
-					&system.MemberResult{
-						Rank: rank, Msg: hes.HostError.Error(),
-						State: system.MemberStateUnresponsive,
-					})
+				resp.Results = append(resp.Results, system.NewMemberResult(rank,
+					hes.HostError, system.MemberStateUnresponsive))
 			}
 			log.Debugf("harness %s (ranks %v) host error: %s", addr, hostRanks[addr],
 				hes.HostError)

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -675,22 +675,22 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 					State: system.MemberStateJoined,
 				},
 				{
-					Rank: 4, Msg: "connection refused",
+					Rank: 4, Msg: "connection refused", Errored: true,
 					Addr:  test.MockHostAddr(3).String(),
 					State: system.MemberStateUnresponsive,
 				},
 				{
-					Rank: 5, Msg: "connection refused",
+					Rank: 5, Msg: "connection refused", Errored: true,
 					Addr:  test.MockHostAddr(3).String(),
 					State: system.MemberStateUnresponsive,
 				},
 				{
-					Rank: 6, Msg: "connection refused",
+					Rank: 6, Msg: "connection refused", Errored: true,
 					Addr:  test.MockHostAddr(4).String(),
 					State: system.MemberStateUnresponsive,
 				},
 				{
-					Rank: 7, Msg: "connection refused",
+					Rank: 7, Msg: "connection refused", Errored: true,
 					Addr:  test.MockHostAddr(4).String(),
 					State: system.MemberStateUnresponsive,
 				},
@@ -775,12 +775,12 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 					State: system.MemberStateJoined,
 				},
 				{
-					Rank: 6, Msg: "connection refused",
+					Rank: 6, Msg: "connection refused", Errored: true,
 					Addr:  test.MockHostAddr(4).String(),
 					State: system.MemberStateUnresponsive,
 				},
 				{
-					Rank: 7, Msg: "connection refused",
+					Rank: 7, Msg: "connection refused", Errored: true,
 					Addr:  test.MockHostAddr(4).String(),
 					State: system.MemberStateUnresponsive,
 				},
@@ -866,12 +866,12 @@ func TestServer_MgmtSvc_rpcFanout(t *testing.T) {
 					State: system.MemberStateJoined,
 				},
 				{
-					Rank: 4, Msg: "connection refused",
+					Rank: 4, Msg: "connection refused", Errored: true,
 					Addr:  test.MockHostAddr(3).String(),
 					State: system.MemberStateUnresponsive,
 				},
 				{
-					Rank: 5, Msg: "connection refused",
+					Rank: 5, Msg: "connection refused", Errored: true,
 					Addr:  test.MockHostAddr(3).String(),
 					State: system.MemberStateUnresponsive,
 				},

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -368,7 +368,8 @@ func (m *Membership) UpdateMemberStates(results MemberResults, updateOnFail bool
 		// - if transition from current to result state is illegal
 
 		if result.Errored {
-			if result.State != MemberStateErrored {
+			// Check state matches errored flag.
+			if result.State != MemberStateErrored && result.State != MemberStateUnresponsive {
 				// result content mismatch (programming error)
 				return errors.Errorf(
 					"errored result for rank %d has conflicting state '%s'",


### PR DESCRIPTION
Return code should be non-zero if sys stop fails due to non-responsive
ranks. To fix, ensure the Errored field is set appropriately in a
MemberResult struct each time the NonResponsive state is set. Change
all create calls to use the NewMemberResult() helper which will do
this for us.

- MemberResults with unresponsive state have errored flag set
- RC reflects member state error appropriately
- Updated unit tests

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
