### PR TITLE
DAOS-8938 tools: Remove unused pool label field

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -447,9 +447,6 @@ func (cmd *existingContainerCmd) resolveContainerPath(ap *C.struct_cmd_args_s) (
 	}
 	cmd.poolBaseCmd.poolUUID = cmd.poolBaseCmd.Args.Pool.UUID
 	cmd.poolBaseCmd.Args.Pool.Label = C.GoString(&ap.pool_str[0])
-	if cmd.poolBaseCmd.Args.Pool.Label != "" {
-		cmd.poolBaseCmd.poolLabel = C.CString(cmd.poolBaseCmd.Args.Pool.Label)
-	}
 
 	cmd.Args.Container.UUID, err = uuidFromC(ap.c_uuid)
 	if err != nil {

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -70,8 +70,7 @@ type PoolID struct {
 
 type poolBaseCmd struct {
 	daosCmd
-	poolUUID  uuid.UUID
-	poolLabel *C.char
+	poolUUID uuid.UUID
 
 	cPoolHandle C.daos_handle_t
 


### PR DESCRIPTION
After the refactoring of the daos cont tool's --path handling
logic, a leak was detected upon landing. This patch removes
a useless allocation and assignment.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
