### PR TITLE
DAOS-12702 vos: Update logging and includes for vos/object.

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1376,11 +1376,10 @@ ds_dtx_resync(void *arg)
 	rc = dtx_resync(ddra->pool->spc_hdl, ddra->pool->spc_uuid,
 			ddra->co_uuid, ddra->pool->spc_map_version, false);
 	if (rc != 0)
-		D_WARN("Fail to resync some DTX(s) for the pool/cont "
-		       DF_UUID"/"DF_UUID" that may affect subsequent "
-		       "operations: rc = "DF_RC".\n",
-		       DP_UUID(ddra->pool->spc_uuid),
-		       DP_UUID(ddra->co_uuid), DP_RC(rc));
+		D_WARN("Fail to resync some DTX(s) for the pool/cont " DF_UUID "/" DF_UUID
+		       " that may affect subsequent "
+		       "operations: rc = " DF_RC "\n",
+		       DP_UUID(ddra->pool->spc_uuid), DP_UUID(ddra->co_uuid), DP_RC(rc));
 
 	ds_pool_child_put(ddra->pool);
 	D_FREE(ddra);

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -552,7 +552,7 @@ sched_info_init(struct dss_xstream *dx)
 				 NULL, &sched_pool_hash_ops,
 				 &info->si_pool_hash);
 	if (rc) {
-		D_ERROR("Create sched pool hash failed. "DF_RC".\n", DP_RC(rc));
+		D_ERROR("Create sched pool hash failed. " DF_RC "\n", DP_RC(rc));
 		return rc;
 	}
 

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -242,8 +242,8 @@ ds_mgmt_destroy_pool(uuid_t pool_uuid, d_rank_list_t *ranks)
 
 	rc = ds_mgmt_tgt_pool_destroy_ranks(pool_uuid, ranks);
 	if (rc != 0) {
-		D_ERROR("Destroying pool "DF_UUID" failed, " DF_RC ".\n",
-			DP_UUID(pool_uuid), DP_RC(rc));
+		D_ERROR("Destroying pool " DF_UUID " failed, " DF_RC "\n", DP_UUID(pool_uuid),
+			DP_RC(rc));
 		goto out;
 	}
 

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1534,8 +1534,8 @@ obj_ec_singv_req_reasb(struct dc_object *obj, uint64_t dkey_hash, daos_iod_t *io
 			rc = obj_ec_fail_info_parity_get(obj, reasb_req, dkey_hash, &idx,
 							 NIL_BITMAP);
 			if (rc) {
-				D_ERROR(DF_OID" can not get parity failed, "
-					DF_RC".\n", DP_OID(reasb_req->orr_oid), DP_RC(rc));
+				D_ERROR(DF_OID " can not get parity failed, " DF_RC "\n",
+					DP_OID(reasb_req->orr_oid), DP_RC(rc));
 				goto out;
 			}
 		} else {
@@ -2154,7 +2154,7 @@ obj_ec_recov_codec_init(struct dc_object *obj, struct obj_reasb_req *reasb_req,
 	D_ASSERT(nerrs > 0 && err_list != NULL);
 	if (nerrs > p) {
 		rc = -DER_DATA_LOSS;
-		D_ERROR(DF_OID" nerrs %d > p %d, "DF_RC".\n", DP_OID(obj->cob_md.omd_id), nerrs,
+		D_ERROR(DF_OID " nerrs %d > p %d, " DF_RC "\n", DP_OID(obj->cob_md.omd_id), nerrs,
 			p, DP_RC(rc));
 		return rc;
 	}
@@ -2582,8 +2582,8 @@ obj_ec_recov_prep(struct dc_object *obj, struct obj_reasb_req *reasb_req,
 
 out:
 	if (rc)
-		D_ERROR(DF_OID" obj_ec_recov_prep failed, "DF_RC".\n",
-			DP_OID(obj->cob_md.omd_id), DP_RC(rc));
+		D_ERROR(DF_OID " obj_ec_recov_prep failed, " DF_RC "\n", DP_OID(obj->cob_md.omd_id),
+			DP_RC(rc));
 	return rc;
 }
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -965,7 +965,7 @@ obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
 	rc = obj_shard_open(obj, shard, map_ver, &obj_shard);
 	if (rc != 0) {
 		D_CDEBUG(rc == -DER_STALE || rc == -DER_NONEXIST, DB_IO, DLOG_ERR,
-			 DF_OID" obj_shard_open %u opc %u, rc "DF_RC".\n",
+			 DF_OID " obj_shard_open %u opc %u, rc " DF_RC "\n",
 			 DP_OID(obj->cob_md.omd_id), obj_auxi->opc, shard, DP_RC(rc));
 		D_GOTO(out, rc);
 	}

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1014,9 +1014,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 					      orwo->orw_rels.ca_arrays,
 					      orwo->orw_rels.ca_count);
 			if (rc) {
-				D_ERROR(DF_UOID" obj_ec_recov_add failed, "
-					DF_RC".\n", DP_UOID(orw->orw_oid),
-					DP_RC(rc));
+				D_ERROR(DF_UOID " obj_ec_recov_add failed, " DF_RC "\n",
+					DP_UOID(orw->orw_oid), DP_RC(rc));
 				goto out;
 			}
 		} else if (is_ec_obj && reasb_req->orr_recov &&
@@ -1025,7 +1024,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 						 orwo->orw_rels.ca_arrays,
 						 orwo->orw_rels.ca_count);
 			if (rc) {
-				D_ERROR(DF_UOID" obj_ec_parity_check failed, "DF_RC".\n",
+				D_ERROR(DF_UOID " obj_ec_parity_check failed, " DF_RC "\n",
 					DP_UOID(orw->orw_oid), DP_RC(rc));
 				goto out;
 			}
@@ -1033,7 +1032,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 
 		rc = dc_shard_update_size(rw_args, 0);
 		if (rc) {
-			D_ERROR(DF_UOID" dc_shard_update_size failed, "DF_RC".\n",
+			D_ERROR(DF_UOID " dc_shard_update_size failed, " DF_RC "\n",
 				DP_UOID(orw->orw_oid), DP_RC(rc));
 			goto out;
 		}

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -961,8 +961,8 @@ agg_fetch_remote_parity(struct ec_agg_entry *entry)
 				   &entry->ae_dkey, 1, &iod, &sgl, NULL,
 				   DIOF_TO_SPEC_SHARD | DIOF_FOR_EC_AGG,
 				   &peer_shard, NULL);
-		D_CDEBUG(rc != 0, DLOG_ERR, DB_TRACE, DF_UOID
-			 " fetch parity from peer shard %d, "DF_RC".\n",
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_TRACE,
+			 DF_UOID " fetch parity from peer shard %d, " DF_RC "\n",
 			 DP_UOID(entry->ae_oid), peer_shard, DP_RC(rc));
 		if (rc)
 			goto out;

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -44,7 +44,7 @@ out_class:
 out_utils:
 	obj_utils_fini();
 out:
-	D_ERROR("Object module init error: %s\n", d_errstr(rc));
+	D_ERROR("Object module init error: " DF_RC "\n", DP_RC(rc));
 	return rc;
 }
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -434,8 +434,7 @@ bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 			rc = crt_bulk_create(rpc->cr_ctx, &sgl_sent, bulk_perm,
 					     &local_bulk);
 			if (rc != 0) {
-				D_ERROR("crt_bulk_create %d error "DF_RC".\n",
-					sgl_idx, DP_RC(rc));
+				D_ERROR("crt_bulk_create %d error " DF_RC "\n", sgl_idx, DP_RC(rc));
 				break;
 			}
 			D_ASSERT(local_bulk != NULL);
@@ -471,8 +470,7 @@ bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 				cached_bulk ? cached_bulk_cp : bulk_cp, p_arg,
 				&bulk_opid);
 		if (rc < 0) {
-			D_ERROR("crt_bulk_transfer %d error "DF_RC".\n",
-				sgl_idx, DP_RC(rc));
+			D_ERROR("crt_bulk_transfer %d error " DF_RC "\n", sgl_idx, DP_RC(rc));
 			p_arg->bulks_inflight--;
 			if (!cached_bulk)
 				crt_bulk_free(local_bulk);
@@ -1384,11 +1382,10 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		if (unlikely(ec_recov &&
 			     obj_ec_recov_need_try_again(orw, orwo, ioc))) {
 			rc = -DER_FETCH_AGAIN;
-			D_DEBUG(DB_IO, DF_UOID" "DF_X64"<"DF_X64
-				" ec_recov needs redo, "DF_RC".\n",
+			D_DEBUG(DB_IO,
+				DF_UOID " " DF_X64 "<" DF_X64 " ec_recov needs redo, " DF_RC "\n",
 				DP_UOID(orw->orw_oid), orw->orw_epoch,
-				ioc->ioc_coc->sc_ec_agg_eph_boundary,
-				DP_RC(rc));
+				ioc->ioc_coc->sc_ec_agg_eph_boundary, DP_RC(rc));
 			goto out;
 		}
 		if (ec_deg_fetch && !spec_fetch) {
@@ -1488,8 +1485,8 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 					    iods, offs, orw->orw_epoch, orw->orw_flags,
 					    iods_nr, false, ec_deg_fetch, &recov_lists);
 		if (rc != 0) {
-			D_ERROR(DF_UOID" obj_singv_ec_rw_filter failed: "
-				DF_RC".\n", DP_UOID(orw->orw_oid), DP_RC(rc));
+			D_ERROR(DF_UOID " obj_singv_ec_rw_filter failed: " DF_RC "\n",
+				DP_UOID(orw->orw_oid), DP_RC(rc));
 			goto out;
 		}
 		if (recov_lists != NULL) {
@@ -1523,11 +1520,10 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 	time = daos_get_ntime();
 	biod = vos_ioh2desc(ioh);
-	rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO, rma ? rpc->cr_ctx : NULL,
-			  CRT_BULK_RW);
+	rc   = bio_iod_prep(biod, BIO_CHK_TYPE_IO, rma ? rpc->cr_ctx : NULL, CRT_BULK_RW);
 	if (rc) {
-		D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
-			DP_UOID(orw->orw_oid), DP_RC(rc));
+		D_ERROR(DF_UOID " bio_iod_prep failed: " DF_RC "\n", DP_UOID(orw->orw_oid),
+			DP_RC(rc));
 		goto out;
 	}
 
@@ -2258,26 +2254,25 @@ ds_obj_ec_rep_handler(crt_rpc_t *rpc)
 	biod = vos_ioh2desc(ioh);
 	rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO, rpc->cr_ctx, CRT_BULK_RW);
 	if (rc) {
-		D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
-			DP_UOID(oer->er_oid), DP_RC(rc));
+		D_ERROR(DF_UOID " bio_iod_prep failed: " DF_RC "\n", DP_UOID(oer->er_oid),
+			DP_RC(rc));
 		goto end;
 	}
 	rc = obj_bulk_transfer(rpc, CRT_BULK_PUT, false, &oer->er_bulk, NULL,
 			       ioh, NULL, 1, NULL, ioc.ioc_coh);
 	if (rc)
-		D_ERROR(DF_UOID" bulk transfer failed: "DF_RC".\n",
-			DP_UOID(oer->er_oid), DP_RC(rc));
+		D_ERROR(DF_UOID " bulk transfer failed: " DF_RC "\n", DP_UOID(oer->er_oid),
+			DP_RC(rc));
 
 	rc = bio_iod_post(biod, rc);
 	if (rc)
-		D_ERROR(DF_UOID" bio_iod_post failed: "DF_RC".\n",
-			DP_UOID(oer->er_oid), DP_RC(rc));
+		D_ERROR(DF_UOID " bio_iod_post failed: " DF_RC "\n", DP_UOID(oer->er_oid),
+			DP_RC(rc));
 end:
-	rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc,
-			    &ioc.ioc_io_size, NULL);
+	rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc, &ioc.ioc_io_size, NULL);
 	if (rc) {
-		D_ERROR(DF_UOID" vos_update_end failed: "DF_RC".\n",
-			DP_UOID(oer->er_oid), DP_RC(rc));
+		D_ERROR(DF_UOID " vos_update_end failed: " DF_RC "\n", DP_UOID(oer->er_oid),
+			DP_RC(rc));
 		goto out;
 	}
 	recx.rx_nr = obj_ioc2ec_cs(&ioc);
@@ -2337,35 +2332,33 @@ ds_obj_ec_agg_handler(crt_rpc_t *rpc)
 		rc = bio_iod_prep(biod, BIO_CHK_TYPE_IO, rpc->cr_ctx,
 				  CRT_BULK_RW);
 		if (rc) {
-			D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",
-				DP_UOID(oea->ea_oid), DP_RC(rc));
+			D_ERROR(DF_UOID " bio_iod_prep failed: " DF_RC "\n", DP_UOID(oea->ea_oid),
+				DP_RC(rc));
 			goto end;
 		}
 		rc = obj_bulk_transfer(rpc, CRT_BULK_GET, false, &oea->ea_bulk,
 				       NULL, ioh, NULL, 1, NULL, ioc.ioc_coh);
 		if (rc)
-			D_ERROR(DF_UOID" bulk transfer failed: "DF_RC".\n",
-				DP_UOID(oea->ea_oid), DP_RC(rc));
+			D_ERROR(DF_UOID " bulk transfer failed: " DF_RC "\n", DP_UOID(oea->ea_oid),
+				DP_RC(rc));
 
 		rc = bio_iod_post(biod, rc);
 		if (rc)
-			D_ERROR(DF_UOID" bio_iod_post failed: "DF_RC".\n",
-				DP_UOID(oea->ea_oid), DP_RC(rc));
+			D_ERROR(DF_UOID " bio_iod_post failed: " DF_RC "\n", DP_UOID(oea->ea_oid),
+				DP_RC(rc));
 end:
-		rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc,
-				    &ioc.ioc_io_size, NULL);
+		rc = vos_update_end(ioh, ioc.ioc_map_ver, dkey, rc, &ioc.ioc_io_size, NULL);
 		if (rc) {
 			if (rc == -DER_NO_PERM) {
 				/* Parity already exists, May need a
 				 * different error code.
 				 */
-				D_DEBUG(DB_EPC, DF_UOID" parity already"
-					" exists\n", DP_UOID(oea->ea_oid));
+				D_DEBUG(DB_EPC, DF_UOID " parity already exists\n",
+					DP_UOID(oea->ea_oid));
 				rc = 0;
 			} else {
-				D_ERROR(DF_UOID" vos_update_end failed: "
-					DF_RC".\n", DP_UOID(oea->ea_oid),
-					DP_RC(rc));
+				D_ERROR(DF_UOID " vos_update_end failed: " DF_RC "\n",
+					DP_UOID(oea->ea_oid), DP_RC(rc));
 				D_GOTO(out, rc);
 			}
 		}
@@ -2461,7 +2454,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 					    orw->orw_dti_cos.ca_arrays,
 					    orw->orw_dti_cos.ca_count, NULL);
 			if (rc < 0) {
-				D_WARN(DF_UOID": Failed to DTX CoS commit "DF_RC".\n",
+				D_WARN(DF_UOID ": Failed to DTX CoS commit " DF_RC "\n",
 				       DP_UOID(orw->orw_oid), DP_RC(rc));
 			} else if (rc < orw->orw_dti_cos.ca_count) {
 				D_WARN(DF_UOID": Incomplete DTX CoS commit rc = %d expected "
@@ -2493,7 +2486,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 		       orw->orw_dti_cos.ca_arrays,
 		       orw->orw_dti_cos.ca_count, dtx_flags, mbs, &dth);
 	if (rc != 0) {
-		D_ERROR(DF_UOID": Failed to start DTX for update "DF_RC".\n",
+		D_ERROR(DF_UOID ": Failed to start DTX for update " DF_RC "\n",
 			DP_UOID(orw->orw_oid), DP_RC(rc));
 		D_GOTO(out, rc);
 	}
@@ -2506,13 +2499,14 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	 */
 	rc = obj_local_rw(rpc, &ioc, dth);
 	if (rc != 0)
-		D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
-			 (rc == -DER_EXIST &&
-			  (orw->orw_api_flags & (DAOS_COND_DKEY_INSERT | DAOS_COND_AKEY_INSERT))) ||
-			 (rc == -DER_NONEXIST &&
-			  (orw->orw_api_flags & (DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_UPDATE))),
-			 DB_IO, DLOG_ERR,
-			 DF_UOID": error="DF_RC".\n", DP_UOID(orw->orw_oid), DP_RC(rc));
+		D_CDEBUG(
+		    rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
+			(rc == -DER_EXIST &&
+			 (orw->orw_api_flags & (DAOS_COND_DKEY_INSERT | DAOS_COND_AKEY_INSERT))) ||
+			(rc == -DER_NONEXIST &&
+			 (orw->orw_api_flags & (DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_UPDATE))),
+		    DB_IO, DLOG_ERR, DF_UOID ": error=" DF_RC "\n", DP_UOID(orw->orw_oid),
+		    DP_RC(rc));
 
 out:
 	if (dth != NULL)
@@ -2570,12 +2564,14 @@ obj_tgt_update(struct dtx_leader_handle *dlh, void *arg, int idx,
 		rc = obj_local_rw(exec_arg->rpc, exec_arg->ioc, &dlh->dlh_handle);
 		if (rc != 0)
 			D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
-				 (rc == -DER_EXIST && (orw->orw_api_flags &
-				  (DAOS_COND_DKEY_INSERT | DAOS_COND_AKEY_INSERT))) ||
-				 (rc == -DER_NONEXIST && (orw->orw_api_flags &
-				  (DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_UPDATE))),
-				 DB_IO, DLOG_ERR,
-				 DF_UOID": error="DF_RC".\n", DP_UOID(orw->orw_oid), DP_RC(rc));
+				     (rc == -DER_EXIST &&
+				      (orw->orw_api_flags &
+				       (DAOS_COND_DKEY_INSERT | DAOS_COND_AKEY_INSERT))) ||
+				     (rc == -DER_NONEXIST &&
+				      (orw->orw_api_flags &
+				       (DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_UPDATE))),
+				 DB_IO, DLOG_ERR, DF_UOID ": error=" DF_RC "\n",
+				 DP_UOID(orw->orw_oid), DP_RC(rc));
 
 comp:
 		if (comp_cb != NULL)
@@ -2789,7 +2785,7 @@ again2:
 			      version, &orw->orw_oid, dti_cos, dti_cos_cnt,
 			      tgts, tgt_cnt, dtx_flags, mbs, &dlh);
 	if (rc != 0) {
-		D_ERROR(DF_UOID": Failed to start DTX for update "DF_RC".\n",
+		D_ERROR(DF_UOID ": Failed to start DTX for update " DF_RC "\n",
 			DP_UOID(orw->orw_oid), DP_RC(rc));
 		D_GOTO(out, rc);
 	}
@@ -3401,7 +3397,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 		       opi->opi_dti_cos.ca_arrays,
 		       opi->opi_dti_cos.ca_count, dtx_flags, mbs, &dth);
 	if (rc != 0) {
-		D_ERROR(DF_UOID": Failed to start DTX for punch "DF_RC".\n",
+		D_ERROR(DF_UOID ": Failed to start DTX for punch " DF_RC "\n",
 			DP_UOID(opi->opi_oid), DP_RC(rc));
 		D_GOTO(out, rc);
 	}
@@ -3412,9 +3408,9 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), &ioc, dth);
 	if (rc != 0)
 		D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
-			 (rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
-			 DB_IO, DLOG_ERR,
-			 DF_UOID": error="DF_RC".\n", DP_UOID(opi->opi_oid), DP_RC(rc));
+			     (rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
+			 DB_IO, DLOG_ERR, DF_UOID ": error=" DF_RC "\n", DP_UOID(opi->opi_oid),
+			 DP_RC(rc));
 
 out:
 	/* Stop the local transaction */
@@ -3486,10 +3482,11 @@ obj_tgt_punch(struct dtx_leader_handle *dlh, void *arg, int idx,
 
 		rc = obj_local_punch(opi, opc_get(rpc->cr_opc), exec_arg->ioc, &dlh->dlh_handle);
 		if (rc != 0)
-			D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
-				 (rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
-				 DB_IO, DLOG_ERR,
-				 DF_UOID": error="DF_RC".\n", DP_UOID(opi->opi_oid), DP_RC(rc));
+			D_CDEBUG(
+			    rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
+				(rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
+			    DB_IO, DLOG_ERR, DF_UOID ": error=" DF_RC "\n", DP_UOID(opi->opi_oid),
+			    DP_RC(rc));
 
 comp:
 		if (comp_cb != NULL)
@@ -3642,7 +3639,7 @@ again2:
 			      version, &opi->opi_oid, dti_cos, dti_cos_cnt,
 			      tgts, tgt_cnt, dtx_flags, mbs, &dlh);
 	if (rc != 0) {
-		D_ERROR(DF_UOID": Failed to start DTX for punch "DF_RC".\n",
+		D_ERROR(DF_UOID ": Failed to start DTX for punch " DF_RC "\n",
 			DP_UOID(opi->opi_oid), DP_RC(rc));
 		D_GOTO(out, rc);
 	}

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -59,7 +59,6 @@ def scons():
     denv.require('pmdk', 'argobots', 'protobufc')
 
     # Compiler options
-    denv.Append(CPPPATH=[Dir('.').srcnode()])
     denv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
     build_vos(denv, False)
     build_vos(denv, True)

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1320,7 +1320,7 @@ evt_node_entry_free(struct evt_context *tcx, struct evt_node_entry *ne)
 
 	return 0;
 out:
-	D_ERROR("Failed to release entry: %s\n", d_errstr(rc));
+	D_ERROR("Failed to release entry: " DF_RC "\n", DP_RC(rc));
 	return rc;
 }
 
@@ -1501,7 +1501,7 @@ evt_node_destroy(struct evt_context *tcx, umem_off_t nd_off, int level,
 			rc = evt_node_destroy(tcx, nd->tn_child[i], level + 1,
 					      &empty);
 			if (rc) {
-				D_ERROR("destroy failed: %s\n", d_errstr(rc));
+				D_ERROR("destroy failed: " DF_RC "\n", DP_RC(rc));
 				goto out;
 			}
 

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -336,8 +336,7 @@ ilog_ptr_set_full(struct ilog_context *lctx, void *dest, const void *src,
 
 	rc = ilog_tx_begin(lctx);
 	if (rc != 0) {
-		D_ERROR("Failed to start PMDK transaction: rc = %s\n",
-			d_errstr(rc));
+		D_ERROR("Failed to start PMDK transaction: " DF_RC "\n", DP_RC(rc));
 		goto done;
 	}
 
@@ -464,8 +463,7 @@ ilog_destroy(struct umem_instance *umm,
 
 	rc = ilog_tx_begin(&lctx);
 	if (rc != 0) {
-		D_ERROR("Failed to start PMDK transaction: rc = %s\n",
-			d_errstr(rc));
+		D_ERROR("Failed to start PMDK transaction: " DF_RC "\n", DP_RC(rc));
 		return rc;
 	}
 
@@ -514,8 +512,7 @@ ilog_root_migrate(struct ilog_context *lctx, const struct ilog_id *id_in)
 
 	rc = ilog_tx_begin(lctx);
 	if (rc != 0) {
-		D_ERROR("Failed to start PMDK transaction: rc = %s\n",
-			d_errstr(rc));
+		D_ERROR("Failed to start PMDK transaction: " DF_RC "\n", DP_RC(rc));
 		return rc;
 	}
 
@@ -961,10 +958,9 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 	}
 done:
 	rc = ilog_tx_end(lctx, rc);
-	D_DEBUG(DB_TRACE, "%s in incarnation log "DF_X64
-		" status: rc=%s tree_version: %d\n",
-		opc_str[opc], id_in->id_epoch, d_errstr(rc),
-		ilog_mag2ver(lctx->ic_root->lr_magic));
+	D_DEBUG(DB_TRACE,
+		"%s in incarnation log " DF_X64 " status: rc=" DF_RC " tree_version: %d\n",
+		opc_str[opc], id_in->id_epoch, DP_RC(rc), ilog_mag2ver(lctx->ic_root->lr_magic));
 
 	if (rc == 0 && version != ilog_mag2ver(lctx->ic_root->lr_magic) &&
 	    (opc == ILOG_OP_PERSIST || opc == ILOG_OP_ABORT)) {
@@ -1431,17 +1427,14 @@ collapse_tree(struct ilog_context *lctx, struct ilog_array_cache *cache,
 
 		dest = &cache->ac_entries[i];
 
-		D_DEBUG(DB_TRACE, "Removing ilog entry at "DF_X64"\n",
-			dest->id_epoch);
+		D_DEBUG(DB_TRACE, "Removing ilog entry at " DF_X64 "\n", dest->id_epoch);
 
 		rc = ilog_log_del(lctx, dest, true);
 		if (rc != 0) {
-			D_ERROR("Could not remove entry from tree: "DF_RC"\n",
-				DP_RC(rc));
+			D_ERROR("Could not remove entry from tree: " DF_RC "\n", DP_RC(rc));
 			return rc;
 		}
-		D_DEBUG(DB_TRACE, "Removed ilog entry at "DF_X64"\n",
-			dest->id_epoch);
+		D_DEBUG(DB_TRACE, "Removed ilog entry at " DF_X64 "\n", dest->id_epoch);
 	}
 	if (cache->ac_nr == removed)
 		return reset_root(lctx, cache, -1);

--- a/src/vos/tests/SConscript
+++ b/src/vos/tests/SConscript
@@ -9,25 +9,28 @@ def scons():
                  'daos_tests', 'gurt', 'uuid', 'pthread',
                  'pmemobj', 'cmocka', 'gomp']
 
-    prereqs.require(denv, 'argobots')
+    tenv = denv.Clone()
+    tenv.Append(CPPPATH=[Dir('..').srcnode()])
+
+    prereqs.require(tenv, 'argobots')
 
     # Add runtime paths for daos libraries
-    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
-    denv.Append(OBJPREFIX="b_")
+    tenv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
+    tenv.Append(OBJPREFIX="b_")
 
     vos_test_src = ['vos_tests.c', 'vts_io.c', 'vts_pool.c', 'vts_container.c',
-                    denv.Object("vts_common.c"), 'vts_aggregate.c', 'vts_dtx.c',
+                    tenv.Object("vts_common.c"), 'vts_aggregate.c', 'vts_dtx.c',
                     'vts_gc.c', 'vts_checksum.c', 'vts_ilog.c', 'vts_array.c',
                     'vts_pm.c', 'vts_ts.c', 'vts_mvcc.c', 'vos_cmd.c',
                     '../../object/srv_csum.c', '../../object/srv_io_map.c']
-    vos_tests = denv.d_program('vos_tests', vos_test_src, LIBS=libraries)
-    denv.AppendUnique(CPPPATH=[Dir('../../common/tests').srcnode()])
-    evt_ctl = denv.d_program('evt_ctl', ['evt_ctl.c', utest_utils, cmd_parser], LIBS=libraries)
+    vos_tests = tenv.d_program('vos_tests', vos_test_src, LIBS=libraries)
+    tenv.AppendUnique(CPPPATH=[Dir('../../common/tests').srcnode()])
+    evt_ctl = tenv.d_program('evt_ctl', ['evt_ctl.c', utest_utils, cmd_parser], LIBS=libraries)
 
-    denv.Install('$PREFIX/bin/', [vos_tests, evt_ctl])
-    denv.Install(conf_dir, ['vos_size_input.yaml'])
+    tenv.Install('$PREFIX/bin/', [vos_tests, evt_ctl])
+    tenv.Install(conf_dir, ['vos_size_input.yaml'])
 
-    unit_env = denv.Clone()
+    unit_env = tenv.Clone()
     unit_env.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
 
     libraries = ['daos_common_pmem', 'daos_tests', 'gurt', 'cart', 'cmocka',

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -19,7 +19,7 @@
 #include <daos_srv/vos.h>
 #include <daos_srv/ras.h>
 #include <daos_srv/daos_engine.h>
-#include <vos_internal.h>
+#include "vos_internal.h"
 
 struct vos_self_mode {
 	struct vos_tls		*self_tls;

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -18,7 +18,7 @@
 #include <gurt/hash.h>
 #include <daos/btree.h>
 #include <daos_types.h>
-#include <vos_obj.h>
+#include "vos_obj.h"
 #include <daos/checksum.h>
 
 #include "vos_internal.h"

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -103,7 +103,7 @@ gc_drain_btr(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 	D_DEBUG(DB_TRACE, "empty=%d, remainded creds=%d\n", *empty, *credits);
 	return 0;
  failed:
-	D_ERROR("Failed to drain %s btree: %s\n", gc->gc_name, d_errstr(rc));
+	D_ERROR("Failed to drain %s btree: " DF_RC "\n", gc->gc_name, DP_RC(rc));
 	return rc;
 }
 
@@ -139,7 +139,7 @@ gc_drain_evt(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 	D_DEBUG(DB_TRACE, "empty=%d, remainded creds=%d\n", *empty, *credits);
 	return 0;
  failed:
-	D_ERROR("Failed to drain evtree %s: %s\n", gc->gc_name, d_errstr(rc));
+	D_ERROR("Failed to drain evtree %s: " DF_RC "\n", gc->gc_name, DP_RC(rc));
 	return rc;
 }
 
@@ -646,8 +646,8 @@ gc_add_item(struct vos_pool *pool, daos_handle_t coh,
 		 * immediately.
 		 */
 		if (rc != -DER_NOSPACE) {
-			D_CRIT("Failed to add item, pool="DF_UUID", rc=%s\n",
-			       DP_UUID(pool->vp_id), d_errstr(rc));
+			D_CRIT("Failed to add item, pool=" DF_UUID ", rc=" DF_RC "\n",
+			       DP_UUID(pool->vp_id), DP_RC(rc));
 			return rc;
 		}
 
@@ -660,13 +660,13 @@ gc_add_item(struct vos_pool *pool, daos_handle_t coh,
 
 		rc = gc_reclaim_pool(pool, &creds, &empty);
 		if (rc) {
-			D_CRIT("Cannot run RC for pool="DF_UUID", rc=%s\n",
-			       DP_UUID(pool->vp_id), d_errstr(rc));
+			D_CRIT("Cannot run RC for pool=" DF_UUID ", rc=" DF_RC "\n",
+			       DP_UUID(pool->vp_id), DP_RC(rc));
 			return rc;
 		}
 
 		if (creds == GC_CREDS_TIGHT) { /* recliamed nothing? */
-			D_CRIT("Failed to recliam space for pool="DF_UUID"\n",
+			D_CRIT("Failed to recliam space for pool=" DF_UUID "\n",
 			       DP_UUID(pool->vp_id));
 			return -DER_NOSPACE;
 		}
@@ -712,8 +712,8 @@ gc_reclaim_pool(struct vos_pool *pool, int *credits, bool *empty_ret)
 
 	rc = umem_tx_begin(&pool->vp_umm, NULL);
 	if (rc) {
-		D_ERROR("Failed to start transacton for "DF_UUID": %s\n",
-			DP_UUID(pool->vp_id), d_errstr(rc));
+		D_ERROR("Failed to start transacton for " DF_UUID ": " DF_RC "\n",
+			DP_UUID(pool->vp_id), DP_RC(rc));
 		if (cont != NULL)
 			vos_cont_decref(cont);
 		return rc;
@@ -758,7 +758,7 @@ gc_reclaim_pool(struct vos_pool *pool, int *credits, bool *empty_ret)
 		rc = gc_drain_item(gc, pool, vos_cont2hdl(cont), item, &creds,
 				   &empty);
 		if (rc < 0) {
-			D_ERROR("GC=%s error=%s\n", gc->gc_name, d_errstr(rc));
+			D_ERROR("GC=%s error: " DF_RC "\n", gc->gc_name, DP_RC(rc));
 			break;
 		}
 
@@ -1078,7 +1078,7 @@ vos_gc_pool_tight(daos_handle_t poh, int *credits)
 	total = *credits;
 	rc = gc_reclaim_pool(pool, credits, &empty);
 	if (rc) {
-		D_CRIT("GC failed %s\n", d_errstr(rc));
+		D_CRIT("gc_reclaim_pool failed " DF_RC "\n", DP_RC(rc));
 		return 0; /* caller can't do anything for it */
 	}
 	total -= *credits; /* subtract the remained credits */
@@ -1163,7 +1163,7 @@ vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 		total += creds;
 		rc = vos_gc_pool_tight(poh, &creds);
 		if (rc) {
-			D_ERROR("GC pool failed: %s\n", d_errstr(rc));
+			D_ERROR("GC pool failed: " DF_RC "\n", DP_RC(rc));
 			break;
 		}
 		total -= creds; /* subtract the remainded credits */

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -191,8 +191,8 @@ vos_dedup_init(struct vos_pool *pool)
 				 &pool->vp_dedup_hash);
 
 	if (rc)
-		D_ERROR(DF_UUID": Init dedup hash failed. "DF_RC".\n",
-			DP_UUID(pool->vp_id), DP_RC(rc));
+		D_ERROR(DF_UUID ": Init dedup hash failed. " DF_RC "\n", DP_UUID(pool->vp_id),
+			DP_RC(rc));
 	return rc;
 }
 
@@ -2498,7 +2498,7 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	rc = dkey_update_begin(ioc);
 	if (rc != 0) {
-		D_ERROR(DF_UOID ": dkey update begin failed. %d\n", DP_UOID(oid), rc);
+		D_ERROR(DF_UOID ": dkey update begin failed. " DF_RC "\n", DP_UOID(oid), DP_RC(rc));
 		goto error;
 	}
 	*ioh = vos_ioc2ioh(ioc);

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -13,7 +13,7 @@
 #include <daos/btree.h>
 #include <daos_srv/vos.h>
 #include <daos_api.h>
-#include <vos_internal.h>
+#include "vos_internal.h"
 
 /** Dictionary for all known vos iterators */
 struct vos_iter_dict {

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -15,7 +15,7 @@
 #include <daos/btree.h>
 #include <daos_types.h>
 #include <daos_srv/vos.h>
-#include <vos_internal.h>
+#include "vos_internal.h"
 
 /** Ensure the values of recx flags map to those exported by evtree */
 D_CASSERT((uint32_t)VOS_VIS_FLAG_UNKNOWN == (uint32_t)EVT_UNKNOWN);
@@ -637,7 +637,7 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 		return 0;
 
 	if (rc) {
-		D_ERROR("Failed to hold object: %s\n", d_errstr(rc));
+		D_ERROR("Failed to hold object: " DF_RC "\n", DP_RC(rc));
 		return rc;
 	}
 
@@ -647,7 +647,7 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 
 	rc = vos_oi_delete(cont, obj->obj_id);
 	if (rc)
-		D_ERROR("Failed to delete object: %s\n", d_errstr(rc));
+		D_ERROR("Failed to delete object: " DF_RC "\n", DP_RC(rc));
 
 	rc = umem_tx_end(umm, rc);
 

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -22,8 +22,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <inttypes.h>
-#include <vos_obj.h>
-#include <vos_internal.h>
+#include "vos_obj.h"
+#include "vos_internal.h"
 #include <daos_errno.h>
 
 /**

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -15,9 +15,9 @@
 #include <daos/btree.h>
 #include <daos/object.h>
 #include <daos_types.h>
-#include <vos_internal.h>
-#include <vos_ilog.h>
-#include <vos_obj.h>
+#include "vos_internal.h"
+#include "vos_ilog.h"
+#include "vos_obj.h"
 #include <daos_srv/vos.h>
 
 /** iterator for oid */

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -22,8 +22,8 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <vos_layout.h>
-#include <vos_internal.h>
+#include "vos_layout.h"
+#include "vos_internal.h"
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -672,7 +672,7 @@ query_write:
 			  &obj_epr, query->qt_bound, VOS_OBJ_VISIBLE,
 			  DAOS_INTENT_DEFAULT, &obj, query->qt_ts_set);
 	if (rc != 0) {
-		LOG_RC(rc, "Could not hold object: %s\n", d_errstr(rc));
+		LOG_RC(rc, "Could not hold object: " DF_RC "\n", DP_RC(rc));
 		goto out;
 	}
 
@@ -721,7 +721,7 @@ query_write:
 		rc = open_and_query_key(query, dkey, VOS_GET_DKEY,
 					&query->qt_dkey_anchor);
 		if (rc != 0) {
-			LOG_RC(rc, "Could not query dkey: %s\n", d_errstr(rc));
+			LOG_RC(rc, "Could not query dkey: " DF_RC "\n", DP_RC(rc));
 			break;
 		}
 
@@ -738,8 +738,7 @@ query_write:
 			rc = open_and_query_key(query, akey, VOS_GET_AKEY,
 						&query->qt_akey_anchor);
 			if (rc != 0) {
-				LOG_RC(rc, "Could not query akey: %s\n",
-				       d_errstr(rc));
+				LOG_RC(rc, "Could not query akey: " DF_RC "\n", DP_RC(rc));
 				break;
 			}
 
@@ -749,8 +748,7 @@ query_write:
 			rc = query_recx(query, recx);
 
 			if (rc != 0) {
-				LOG_RC(rc, "Could not query recx: %s\n",
-				       d_errstr(rc));
+				LOG_RC(rc, "Could not query recx: " DF_RC "\n", DP_RC(rc));
 				if (rc == -DER_NONEXIST &&
 				    query->qt_flags & VOS_GET_AKEY) {
 					/* Reset the epoch range to last dkey */

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -14,8 +14,8 @@
 #define __VOS_TS__
 
 #include <daos/dtx.h>
-#include <lru_array.h>
-#include <vos_tls.h>
+#include "lru_array.h"
+#include "vos_tls.h"
 
 struct vos_ts_table;
 struct vos_ts_entry;


### PR DESCRIPTION
Make correct use of DF_RC in D_ERROR calls
Fix an issue with vos internal header files, remove the -I option
and use "" rather than <> for internal headers.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
