### PR TITLE
DAOS-12025 control: Make connection timeout retryable

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -113,6 +113,7 @@ const (
 	ClientConnectionNoRoute
 	ClientConnectionRefused
 	ClientConnectionClosed
+	ClientConnectionTimedOut
 	ClientFormatRunningSystem
 	ClientRpcTimeout
 	ClientConfigVMDImbalance

--- a/src/control/lib/control/faults.go
+++ b/src/control/lib/control/faults.go
@@ -56,6 +56,7 @@ func IsRetryableConnErr(err error) bool {
 	}
 
 	return f.Code == code.ClientConnectionRefused ||
+		f.Code == code.ClientConnectionTimedOut ||
 		f.Code == code.ClientConnectionClosed
 }
 
@@ -69,6 +70,7 @@ func IsConnErr(err error) bool {
 	for _, connCode := range []code.Code{
 		code.ClientConnectionBadHost, code.ClientConnectionClosed,
 		code.ClientConnectionNoRoute, code.ClientConnectionRefused,
+		code.ClientConnectionTimedOut,
 	} {
 		if f.Code == connCode {
 			return true
@@ -107,6 +109,14 @@ func FaultConnectionClosed(srvAddr string) *fault.Fault {
 		code.ClientConnectionClosed,
 		fmt.Sprintf("the server at %s closed the connection without accepting a request", srvAddr),
 		"verify that the configured address and your TLS configuration are correct (or disable transport security)",
+	)
+}
+
+func FaultConnectionTimedOut(srvAddr string) *fault.Fault {
+	return clientFault(
+		code.ClientConnectionTimedOut,
+		fmt.Sprintf("the connection to the server at %s timed out", srvAddr),
+		"verify that the configured address is correct and that the server is running",
 	)
 }
 

--- a/src/control/lib/control/interceptors.go
+++ b/src/control/lib/control/interceptors.go
@@ -35,6 +35,8 @@ func connErrToFault(st *status.Status, target string) error {
 		return FaultConnectionBadHost(target)
 	case strings.Contains(st.Message(), "certificate has expired"):
 		return security.FaultInvalidCert(errors.New(st.Message()))
+	case strings.Contains(st.Message(), "i/o timeout"):
+		return FaultConnectionTimedOut(target)
 	default:
 		return st.Err()
 	}

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -20,6 +20,8 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/system"
@@ -232,6 +234,7 @@ func isTimeout(err error) bool {
 	cause := errors.Cause(err)
 	return cause == context.DeadlineExceeded ||
 		cause == os.ErrDeadlineExceeded ||
+		fault.IsFaultCode(cause, code.ClientConnectionTimedOut) ||
 		status.Code(cause) == codes.DeadlineExceeded
 }
 


### PR DESCRIPTION
Properly exposes a gRPC connection timeout as a new
client fault, and adds it to the list of retryable
errors during a MS request. A connection timeout may
occur when a previously-reachable endpoint goes away
(e.g. server crashed, cable unplugged, etc).

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
