### PR TITLE
DAOS-8938 test: fix str conversion for set_attr

### DIFF
--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -296,7 +296,7 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("pool", "set-attr"), pool=pool, attr=':'.join([attr, value]),
+            ("pool", "set-attr"), pool=pool, attr=':'.join([str(attr), str(value)]),
             sys_name=sys_name)
 
     def pool_set_attrs(self, pool, attrs, sys_name=None):
@@ -315,7 +315,7 @@ class DaosCommand(DaosCommandBase):
             CommandFailure: if the daos pool set-attr command fails.
 
         """
-        attr_list = [':'.join([key, value]) for key, value in attrs.items()]
+        attr_list = [':'.join([str(key), str(value)]) for key, value in attrs.items()]
         return self._get_result(
             ("pool", "set-attr"), pool=pool, attr=','.join(attr_list),
             sys_name=sys_name)
@@ -605,7 +605,7 @@ class DaosCommand(DaosCommandBase):
         """
         return self._get_result(
             ("container", "set-attr"), pool=pool, cont=cont,
-            sys_name=sys_name, attr=':'.join([attr, val]))
+            sys_name=sys_name, attr=':'.join([str(attr), str(val)]))
 
     def container_set_attrs(self, pool, cont, attrs, sys_name=None):
         """Set multiple container attributes.
@@ -624,7 +624,7 @@ class DaosCommand(DaosCommandBase):
             CommandFailure: if the daos pool set-attr command fails.
 
         """
-        attr_list = [':'.join([key, val]) for key, val in attrs.items()]
+        attr_list = [':'.join([str(key), str(val)]) for key, val in attrs.items()]
         return self._get_result(
             ("container", "set-attr"), pool=pool, cont=cont,
             attr=','.join(attr_list), sys_name=sys_name)


### PR DESCRIPTION
Test-tag: pr daos_cmd DaosBuild
Skip-unit-tests: true
Skip-fault-injection-test: true

Commit 3934417 accidentally removed the implicit string conversion for set_attr, so make it explicit to cover all cases.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
