### PR TITLE
DAOS-11178 container: move IV update out of svc lock

### DIFF
--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -503,14 +503,18 @@ ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid)
 		goto out_lock;
 	}
 
-	rc = cont_iv_snapshots_update(svc->cs_pool->sp_iv_ns, cont_uuid,
-				      snapshots, snap_count);
-	if (rc != 0)
-		D_ERROR(DF_CONT": Failed to update snapshots IV: %d\n",
-			DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
-
-	D_FREE(snapshots);
 out_lock:
 	ABT_rwlock_unlock(svc->cs_lock);
 	rdb_tx_end(&tx);
+	if (rc != 0) {
+		rc = cont_iv_snapshots_update(svc->cs_pool->sp_iv_ns, cont_uuid,
+					      snapshots, snap_count);
+		if (rc != 0)
+			D_ERROR(DF_CONT": Failed to update snapshots IV: %d\n",
+				DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
+	}
+
+	if (snapshots != NULL)
+		D_FREE(snapshots);
+
 }


### PR DESCRIPTION
Move conainer prop and snapsht IV sync out of svc_lock.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
