### PR TITLE
DAOS-12643 security: Loosen ACL validation (#11499)

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -378,7 +378,7 @@ daos_cont_overwrite_acl(daos_handle_t coh, struct daos_acl *acl,
 	daos_prop_t	*prop;
 	int		rc;
 
-	if (daos_acl_cont_validate(acl) != 0) {
+	if (daos_acl_validate(acl) != 0) {
 		D_ERROR("invalid acl parameter\n");
 		return -DER_INVAL;
 	}

--- a/src/common/acl_api.c
+++ b/src/common/acl_api.c
@@ -762,50 +762,6 @@ daos_acl_validate(struct daos_acl *acl)
 }
 
 static bool
-perms_valid_for_ace(struct daos_ace *ace, uint64_t valid_perms)
-{
-	if ((ace->dae_allow_perms & ~valid_perms) ||
-	    (ace->dae_audit_perms & ~valid_perms) ||
-	    (ace->dae_alarm_perms & ~valid_perms))
-		return false;
-
-	return true;
-}
-
-static int
-validate_acl_with_special_perms(struct daos_acl *acl, uint64_t valid_perms)
-{
-	int		rc;
-	struct daos_ace	*ace;
-
-	rc = daos_acl_validate(acl);
-	if (rc != 0)
-		return rc;
-
-	ace = daos_acl_get_next_ace(acl, NULL);
-	while (ace != NULL) {
-		if (!perms_valid_for_ace(ace, valid_perms))
-			return -DER_INVAL;
-
-		ace = daos_acl_get_next_ace(acl, ace);
-	}
-
-	return 0;
-}
-
-int
-daos_acl_pool_validate(struct daos_acl *acl)
-{
-	return validate_acl_with_special_perms(acl, DAOS_ACL_PERM_POOL_ALL);
-}
-
-int
-daos_acl_cont_validate(struct daos_acl *acl)
-{
-	return validate_acl_with_special_perms(acl, DAOS_ACL_PERM_CONT_ALL);
-}
-
-static bool
 type_is_group(enum daos_acl_principal_type type)
 {
 	if (type == DAOS_ACL_GROUP || type == DAOS_ACL_OWNER_GROUP) {
@@ -1181,8 +1137,6 @@ bool
 daos_ace_is_valid(struct daos_ace *ace)
 {
 	uint8_t		valid_types = DAOS_ACL_ACCESS_ALL;
-	uint16_t	valid_flags = DAOS_ACL_FLAG_ALL;
-	uint64_t	valid_perms = DAOS_ACL_PERM_ALL;
 	bool		name_exists;
 	bool		flag_exists;
 
@@ -1195,12 +1149,6 @@ daos_ace_is_valid(struct daos_ace *ace)
 
 	/* No access type defined */
 	if (ace->dae_access_types == 0)
-		return false;
-
-	if (ace->dae_access_flags & ~valid_flags)
-		return false;
-
-	if (!perms_valid_for_ace(ace, valid_perms))
 		return false;
 
 	/* Name should only exist for types that require it */

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -3069,7 +3069,7 @@ ds_cont_acl_update(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		DP_UUID(in->caui_op.ci_hdl));
 
 	acl_in = in->caui_acl;
-	if (daos_acl_cont_validate(acl_in) != 0)
+	if (daos_acl_validate(acl_in) != 0)
 		D_GOTO(out, rc = -DER_INVAL);
 
 	rc = get_acl(tx, cont, &acl);

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -334,34 +334,6 @@ int
 daos_acl_validate(struct daos_acl *acl);
 
 /**
- * Check that the Access Control List is valid for use with a DAOS pool.
- *
- * This includes the checks in daos_acl_validate().
- *
- * \param	acl	Access Control List to sanity check
- *
- * \return	0		ACL is valid
- *		-DER_INVAL	ACL is not valid
- *		-DER_NOMEM	Ran out of memory while checking
- */
-int
-daos_acl_pool_validate(struct daos_acl *acl);
-
-/**
- * Check that the Access Control List is valid for use with a DAOS container.
- *
- * This includes the checks in daos_acl_validate().
- *
- * \param	acl	Access Control List to sanity check
- *
- * \return	0		ACL is valid
- *		-DER_INVAL	ACL is not valid
- *		-DER_NOMEM	Ran out of memory while checking
- */
-int
-daos_acl_cont_validate(struct daos_acl *acl);
-
-/**
  * Allocate a new Access Control Entry with an appropriately aligned principal
  * name, if applicable.
  *

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -506,7 +506,7 @@ test_default_pool_acl(void **state)
 	acl = ds_sec_alloc_default_daos_pool_acl();
 
 	assert_non_null(acl);
-	assert_rc_equal(daos_acl_pool_validate(acl), 0); /* valid pool ACL */
+	assert_rc_equal(daos_acl_validate(acl), 0); /* valid pool ACL */
 
 	current = daos_acl_get_next_ace(acl, NULL);
 	assert_non_null(current);
@@ -538,7 +538,7 @@ test_default_cont_acl(void **state)
 	acl = ds_sec_alloc_default_daos_cont_acl();
 
 	assert_non_null(acl);
-	assert_rc_equal(daos_acl_cont_validate(acl), 0); /* valid cont ACL */
+	assert_rc_equal(daos_acl_validate(acl), 0); /* valid cont ACL */
 
 	current = daos_acl_get_next_ace(acl, NULL);
 	assert_non_null(current);

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -698,7 +698,7 @@ co_acl(void **state)
 			   DAOS_ACL_PERM_GET_ACL | DAOS_ACL_PERM_SET_ACL);
 	add_ace_with_perms(&exp_acl, DAOS_ACL_EVERYONE, NULL,
 			   DAOS_ACL_PERM_READ);
-	assert_rc_equal(daos_acl_cont_validate(exp_acl), 0);
+	assert_rc_equal(daos_acl_validate(exp_acl), 0);
 
 	/*
 	 * Set up the container with non-default owner/group and ACL values
@@ -756,7 +756,7 @@ co_acl(void **state)
 	assert_rc_equal(rc, 0);
 	ace->dae_allow_perms |= DAOS_ACL_PERM_SET_OWNER;
 
-	assert_rc_equal(daos_acl_cont_validate(exp_acl), 0);
+	assert_rc_equal(daos_acl_validate(exp_acl), 0);
 
 	rc = daos_cont_overwrite_acl(arg->coh, exp_acl, NULL);
 	assert_rc_equal(rc, 0);
@@ -777,7 +777,7 @@ co_acl(void **state)
 	add_ace_with_perms(&update_acl, DAOS_ACL_GROUP, "testgroup2@",
 			   DAOS_ACL_PERM_READ);
 
-	assert_rc_equal(daos_acl_cont_validate(update_acl), 0);
+	assert_rc_equal(daos_acl_validate(update_acl), 0);
 
 	/* Update expected ACL to include changes */
 	ace = daos_acl_get_next_ace(update_acl, NULL);


### PR DESCRIPTION
The ACL validation was so strict that adding a new permissions bit would have caused a failure between code versions. We should not be validating the content of the permissions and flags fields.

- Remove pool and container specific ACL validation, which was focused on the permissions bits.
- Remove logic checking the permissions and flags bits.
- Remove tests that are now irrelevant.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
