### PR TITLE
DAOS-12471 chk: Query output should only count checked pools

### DIFF
--- a/src/control/cmd/dmg/pretty/check.go
+++ b/src/control/cmd/dmg/pretty/check.go
@@ -44,8 +44,12 @@ func countResultPools(resp *control.SystemCheckQueryResp) int {
 	}
 
 	poolMap := make(map[string]struct{})
-	for _, report := range resp.Reports {
-		poolMap[report.PoolUuid] = struct{}{}
+	for _, pool := range resp.Pools {
+		// Don't include pools that were not checked.
+		if pool.Unchecked() {
+			continue
+		}
+		poolMap[pool.UUID] = struct{}{}
 	}
 
 	return len(poolMap)
@@ -65,10 +69,9 @@ func PrintCheckQueryResp(out io.Writer, resp *control.SystemCheckQueryResp, verb
 	// should show the number of pools being checked. If the checker has completed,
 	// we should show the number of unique pools found in the reports.
 	action := "Checking"
-	poolCount := len(resp.Pools)
+	poolCount := countResultPools(resp)
 	if resp.Status == control.SystemCheckStatusCompleted {
 		action = "Checked"
-		poolCount = countResultPools(resp)
 	}
 	if poolCount > 0 {
 		fmt.Fprintf(out, "  %s %s\n", action, english.Plural(poolCount, "pool", ""))

--- a/src/control/lib/control/check.go
+++ b/src/control/lib/control/check.go
@@ -454,6 +454,10 @@ func (p *SystemCheckPoolInfo) String() string {
 		p.UUID, len(p.RawRankInfo), p.Status, p.Phase, p.StartTime, remOrElapsed)
 }
 
+func (p *SystemCheckPoolInfo) Unchecked() bool {
+	return p.Status == chkpb.CheckPoolStatus_CPS_UNCHECKED.String()
+}
+
 func getQueryPoolRank(pool *mgmtpb.CheckQueryPool) ranklist.Rank {
 	if len(pool.Targets) == 0 {
 		return ranklist.NilRank


### PR DESCRIPTION
If a pool is unchecked, don't include it in the count of
checking/checked pools.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
