### PR TITLE
DAOS-12690 build: Add go runtime suppression

### DIFF
--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -423,6 +423,11 @@
 }
 {
    <insert_a_suppression_name_here>
+   Memcheck:Value8
+   fun:racecall
+}
+{
+   <insert_a_suppression_name_here>
    Memcheck:Cond
    fun:racecalladdr
 }


### PR DESCRIPTION
Fix a spurious Valgrind error.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
