### PR TITLE
DAOS-12709 object: Do not reset sgl size for EC data recovery

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -189,7 +189,9 @@ struct obj_reasb_req {
 	/* the flag of IOM re-allocable (used for EC IOM merge) */
 					 orr_iom_realloc:1,
 	/* orr_fail allocated flag, recovery task's orr_fail is inherited */
-					 orr_fail_alloc:1;
+					 orr_fail_alloc:1,
+	/* The fetch data/sgl is rebuilt by EC parity rebuild */
+					 orr_recov_data:1;
 };
 
 static inline void

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -745,8 +745,13 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 		if (sgls[i].sg_iovs[0].iov_len != sgls_verify[i].sg_iovs[0].iov_len ||
 		    memcmp(sgls[i].sg_iovs[0].iov_buf, sgls_verify[i].sg_iovs[0].iov_buf,
 			   sgls[i].sg_iovs[0].iov_len)) {
-			D_WARN(DF_OID" %d shard %u mismatch\n",
-			       DP_OID(obj->cob_md.omd_id), i, dova->current_shard);
+			char *ptr = sgls[i].sg_iovs[0].iov_buf;
+			char *verify_ptr = sgls_verify[i].sg_iovs[0].iov_buf;
+
+			D_ERROR(DF_OID" i %d shard %u mismatch sgl %d/%d verify %d/%d\n",
+				DP_OID(obj->cob_md.omd_id), i, dova->current_shard, (int)(*ptr),
+				(int)sgls[i].sg_iovs[0].iov_len, (int)(*verify_ptr),
+				(int)sgls_verify[i].sg_iovs[0].iov_len);
 
 			D_GOTO(out, rc = -DER_MISMATCH);
 		}


### PR DESCRIPTION
During EC data degraded fetch, it will reset the sgl buffer size by replied data size from 1st degraded parity fetch, but it might be shorter than the real size, since ioc_trim_tail_holes() might trim the tail size(see akey_fetch).

So let's set the sgl size in recovery fill back process, instead of relying on the data size.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
