### PR TITLE
DAOS-11251 tools: Send daos cmd logging to stderr by default

### DIFF
--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -206,6 +206,16 @@ or query/manage an object inside a container.`
 		return nil
 	}
 
+	// Configure DAOS client logging to stderr. We don't
+	// want stdout logging because it will interfere with
+	// JSON output.
+	if os.Getenv("DD_STDERR") == "" {
+		os.Setenv("DD_STDERR", "debug")
+	}
+	if os.Getenv("D_LOG_FILE") == "" {
+		os.Setenv("D_LOG_FILE", "/dev/null")
+	}
+
 	// Initialize the daos debug system first so that
 	// any allocations made as part of argument parsing
 	// are logged when running under NLT.


### PR DESCRIPTION
If the user environment does not set D_LOG_FILE or DD_STDERR,
set them with values that ensure that all libdaos logging goes
to stderr in order to avoid interfering with JSON output.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
