### PR TITLE
DAOS-10859 test: verify dfuse multi-user UNS

### DIFF
--- a/src/tests/ftest/dfuse/mu_mount.py
+++ b/src/tests/ftest/dfuse/mu_mount.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
+from getpass import getuser
 
 from ClusterShell.NodeSet import NodeSet
 
@@ -14,8 +15,8 @@ from dfuse_test_base import DfuseTestBase
 class DfuseMUMount(DfuseTestBase):
     """Verifies multi-user dfuse mounting"""
 
-    def test_dfuse_mu_mount(self):
-        """This test simply starts a filesystem and checks file ownership.
+    def test_dfuse_mu_mount_basic(self):
+        """JIRA ID: DAOS-6540, DAOS-8135.
 
         Use Cases:
             Verify non-dfuse user cannot mount the container without ACLs in single-user mode.
@@ -26,14 +27,13 @@ class DfuseMUMount(DfuseTestBase):
             Verify stat as non-dfuse user in multi-user mode fails.
             Verify non-dfuse user can mount the container with ACLs in single-user mode.
             Verify non-dfuse user can mount the container with ACLs in multi-user mode.
-            Verify UNS sub-container creation as non-root user in multi-user mode succeeds.
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=dfuse,dfuse_mu,daos_cmd
-        :avocado: tags=DfuseMUMount,test_dfuse_mu_mount
+        :avocado: tags=DfuseMUMount,test_dfuse_mu_mount_basic
         """
-        # Create a pool and container for dfuse
+        self.log.info('Creating a pool and container for dfuse')
         pool = self.get_pool(connect=False)
         cont = self.get_container(pool, label='root_cont')
 
@@ -111,31 +111,107 @@ class DfuseMUMount(DfuseTestBase):
         self.dfuse.run()
         self.dfuse.stop()
 
-        self.log.info('Re-mounting dfuse in multi-user mode')
-        self.dfuse.update_params(multi_user=True)
-        self.dfuse.run_user = None  # Current user
+    def test_dfuse_mu_mount_uns(self):
+        """JIRA ID: DAOS-10859.
+
+        Use Cases:
+            Verify a container created by non-dfuse user, with a UNS path in dfuse, automatically
+                grants container ACLs to the dfuse user.
+            Verify the non-dfuse user and dfuse user can access the container through dfuse.
+            Verify that revoking the container ACLs for only the dfuse user prevents access
+                through dfuse for both the dfuse user and non-dfuse user.
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=dfuse,dfuse_mu,daos_cmd
+        :avocado: tags=DfuseMUMount,test_dfuse_mu_mount_uns
+        """
+        dfuse_user = getuser()
+
+        self.log.info('Creating a pool and container for dfuse')
+        pool1 = self.get_pool(connect=False)
+        cont1 = self.get_container(pool1, label='root_cont')
+
+        self.log.info('Starting dfuse with the current user in multi-user mode')
+        self.load_dfuse(self.hostlist_clients)
+        self.dfuse.update_params(pool=pool1.identifier, cont=cont1.label.value, multi_user=True)
+        root_dir = self.dfuse.mount_dir.value
         self.dfuse.run()
 
-        # Give root permission to create containers in the pool
-        pool.update_acl(False, entry="A::root@:rw")
+        self.log.info('Creating a second pool')
+        pool2 = self.get_pool(connect=False)
 
-        self.log.info('Verify UNS sub-container creation as root in multi-user mode succeeds')
+        self.log.info('Giving root permission to create containers in both pools')
+        pool1.update_acl(False, entry="A::root@:rw")
+        pool2.update_acl(False, entry="A::root@:rw")
+
         # DaosCommand cannot be used directly because this needs to run remotely
         daos_command = self.get_daos_command()
         daos_path = os.path.join(daos_command.command_path, daos_command.command)
-        cont_path = os.path.join(root_dir, 'sub_cont')
         first_client = NodeSet(self.hostlist_clients[0])
-        command = command_as_user(
-            '{} container create --type POSIX --path {}'.format(daos_path, cont_path), 'root')
-        if not run_remote(self.log, first_client, command).passed:
-            self.fail('Failed to create sub-container as root in multi-user mode')
 
-        # Verify the container is created correctly
-        command = '{} container get-prop --path {}'.format(daos_path, cont_path)
-        if not run_remote(self.log, first_client, command).passed:
-            self.fail('Failed to get sub-container properties in multi-user mode')
+        def _verify_uns(pool_label, cont_label):
+            """Helper function for varying pool/container."""
+            cont_path = os.path.join(root_dir, cont_label)
+            command = command_as_user(
+                '{} container create {} --type POSIX --path {}'.format(
+                    daos_path, pool_label, cont_path),
+                'root')
+            if not run_remote(self.log, first_client, command).passed:
+                self.fail('Failed to create sub-container as root in multi-user mode')
 
-        # List dfuse entries
-        command = 'ls -l {}'.format(root_dir)
-        if not run_remote(self.log, self.hostlist_clients, command).passed:
-            self.fail('Failed to {}'.format(command))
+            self.log.info('Verify dfuse user was automatically given ACLs for the new container')
+            expected_acl = 'A::{}@:rwt'.format(dfuse_user)
+            self.log.info('Expected ACL: %s', expected_acl)
+            command = command_as_user(
+                '{} container get-acl --path {}'.format(daos_path, cont_path), 'root')
+            result = run_remote(self.log, first_client, command)
+            if not result.passed:
+                self.fail('Failed to get ACLs for container created by root')
+            for stdout in result.all_stdout.values():
+                if expected_acl not in stdout:
+                    self.fail('Expected ACL for container created by root: {}'.format(expected_acl))
+
+            self.log.info('Verify dfuse user can access the container created by root')
+            command = '{} container get-prop --path {}'.format(daos_path, cont_path)
+            if not run_remote(self.log, first_client, command).passed:
+                self.fail('Failed to get sub-container properties in multi-user mode')
+
+            self.log.info('Verify dfuse user can read the container created by root')
+            command = 'ls -l {}'.format(cont_path)
+            if not run_remote(self.log, first_client, command).passed:
+                self.fail('Failed to read container created by root, as dfuse user')
+
+            self.log.info('Verify root can read its own container')
+            command = command_as_user('ls -l {}'.format(cont_path), 'root')
+            if not run_remote(self.log, first_client, command).passed:
+                self.fail('Failed to read container created by root, as root')
+
+            self.log.info('Revoking ACLs for just dfuse user on the container created by root')
+            principal = 'u:{}@'.format(dfuse_user)
+            command = command_as_user(
+                '{} container delete-acl --path {} --principal {}'.format(
+                    daos_path, cont_path, principal),
+                'root')
+            if not run_remote(self.log, first_client, command).passed:
+                self.fail('Failed to revoke ACLs on container created by root')
+
+            self.log.info('Restarting dfuse to pick up ACL changes')
+            self.dfuse.stop()
+            self.dfuse.run()
+
+            self.log.info('Verifying dfuse user can no longer read the container through dfuse')
+            command = 'ls -l {}'.format(cont_path)
+            if run_remote(self.log, first_client, command).passed:
+                self.fail('Expected ls to fail on container created by root, as dfuse user')
+
+            self.log.info('Verifying root can no longer read the container through dfuse')
+            command = command_as_user('ls -l {}'.format(cont_path), 'root')
+            if run_remote(self.log, first_client, command).passed:
+                self.fail('Expected ls to fail on container created by root, as root')
+
+        self.log.info('Verify UNS sub-container create as root - in dfuse pool')
+        _verify_uns(pool_label="", cont_label='pool1_root_cont')
+
+        self.log.info('Verify UNS sub-container create as root - in different pool')
+        _verify_uns(pool_label=pool2.identifier, cont_label='pool2_root_cont')

--- a/src/tests/ftest/dfuse/mu_mount.yaml
+++ b/src/tests/ftest/dfuse/mu_mount.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 1
   test_clients: 1
-timeout: 240
+timeout: 180
 server_config:
   name: daos_server
   engines_per_host: 1
@@ -13,7 +13,7 @@ server_config:
         0:
           class: ram
           scm_mount: /mnt/daos
-          scm_size: 4
+          scm_size: 5
 pool:
   size: 1GiB
 container:


### PR DESCRIPTION
Test-tag: DfuseMUMount
Skip-unit-tests: true
Skip-fault-injection-test: true

Add case to verify dfuse multi-user UNS behavior.
  - Verify a container created by another user, with a UNS path in dfuse, automatically grants container ACLs to the dfuse user.
  -  Verify the other user and dfuse user can access the container through dfuse.
  -  Verify that revoking the container ACLs for the dfuse user only prevents access for

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
