### PR TITLE
DAOS-623 test: update some missing docstrings

### DIFF
--- a/src/tests/ftest/io/parallel_io.py
+++ b/src/tests/ftest/io/parallel_io.py
@@ -244,9 +244,9 @@ class ParallelIo(FioBase, IorTestBase):
             self.dfuse.mount_dir.value)
 
         # Create 10 containers for each pool. Container create process cannot
-        # be parallelised as different container create could complete at
+        # be parallelized as different container create could complete at
         # different times and get appended in the self.container variable in
-        # unorderly manner, causing problems during the write process.
+        # unordered manner, causing problems during the write process.
         for _, pool in enumerate(self.pool):
             self.add_container_qty(self.cont_count, pool)
 

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -778,7 +778,7 @@ def list_to_str(value, joiner=","):
 
     Args:
         value (list): list to convert to a string
-        joiner (str, optional): _description_. Defaults to ",".
+        joiner (str, optional): string to use to join items. Defaults to ",".
 
     Returns:
         str: a string of each list entry joined by the joiner string

--- a/src/tests/ftest/util/results_utils.py
+++ b/src/tests/ftest/util/results_utils.py
@@ -285,7 +285,7 @@ class Job():
                 writing xml files with different names and/or file locations. Defaults to None.
             html_enabled (str, optional): if set to 'on' results will be written to
                 {logdir}/results.html. Defaults to None.
-            html_output (_type_, optional): optional full path of an html file to generate.  Used
+            html_output (str, optional): optional full path of an html file to generate.  Used
                 for writing html files with different names and/or file locations. Defaults to None.
             log_dir (str, optional): directory in which to write the results.[xml|html] if
                 [xml|html]_enabled is set to 'on'. Defaults to None.

--- a/src/tests/ftest/util/slurm_utils.py
+++ b/src/tests/ftest/util/slurm_utils.py
@@ -49,9 +49,9 @@ def create_partition(log, control, name, hosts, default='yes', max_time='UNLIMIT
         control (NodeSet): slurm control host
         name (str): slurm partition name
         hosts (NodeSet): hosts to include in the partition
-        default (str, optional): _description_. Defaults to 'yes'.
-        max_time (str, optional): _description_. Defaults to 'UNLIMITED'.
-        state (str, optional): _description_. Defaults to 'up'.
+        default (str, optional): whether this partition should be the default. Defaults to 'yes'.
+        max_time (str, optional): maximum run time for jobs. Defaults to 'UNLIMITED'.
+        state (str, optional): state of jobs that can be allocated. Defaults to 'up'.
 
     Returns:
         RemoteCommandResult: results from the scontrol command

--- a/src/tests/ftest/util/yaml_utils.py
+++ b/src/tests/ftest/util/yaml_utils.py
@@ -296,11 +296,11 @@ class YamlUpdater():
         """Replace the server or client placeholders.
 
         Args:
-            replacements (_type_): _description_
-            placeholder_data (_type_): _description_
-            key (_type_): _description_
-            replacement (_type_): _description_
-            node_mapping (_type_): _description_
+            replacements (dict): dictionary in which to add replacements for test yaml entries
+            placeholder_data (dict): test yaml values requesting replacements
+            key (str): test yaml entry key
+            replacement (list): available values to use as replacements for the test yaml entries
+            node_mapping (dict): dictionary of nodes and their replacement values
 
         Raises:
             YamlException: if there was a problem replacing any of the placeholders
@@ -421,7 +421,7 @@ class YamlUpdater():
         Args:
             yaml_file (str): test yaml file to update
             yaml_dir (str): directory in which to write the updated test yaml file
-            replacements (dict): _description_
+            replacements (dict): dictionary in which to add replacements for test yaml entries
 
         Raises:
             YamlException: if any placeholders are found without a replacement


### PR DESCRIPTION
Test-tag: pr,vm
Skip-unit-tests: true
Skip-fault-injection-test: true

- Fill in auto-generated _description_ doc strings
- Fill in auto-generated _type_ doc strings
- Fix some spelling mistakes

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
