### PR TITLE
DAOS-11816 test: wait for rebuild before container destroy

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_fio.py
+++ b/src/tests/ftest/erasurecode/rebuild_fio.py
@@ -101,6 +101,9 @@ class EcodFioRebuild(ErasureCodeFio):
             # Read and verify the original data.
             self.fio_cmd.run()
 
+        # Pre-teardown: make sure rebuild is done before too-quickly trying to destroy container.
+        self.pool.wait_for_rebuild_to_end()
+
     def test_ec_online_rebuild_fio(self):
         """Jira ID: DAOS-7320.
 


### PR DESCRIPTION
Before this change, ec offline and online rebuild fio tests failed
intermittently in tearDown during container destroy (with -DER_IO).
A suspicion was that the pool rebuild triggered by the test stopping
an engine may not have finished by the time the test went into
tearDown (just after running the fio read workload). i.e., the
container destroy target-level code may have reported -DER_BUSY
due to the ongoing (nearly-completed) rebuild.

With this change, rebuild+_fio.py code is udpated to, just before
tearDown, wait for pool rebuild to end.

Quick-Functional: true
Test-tag: test_ec_offline_rebuild_fio test_ec_online_rebuild_fio

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
