### PR TITLE
DAOS-12755 common: fix merged ranges not flushed in DAV allocator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -731,7 +731,7 @@ pipeline {
                         expression { !skipStage() }
                     }
                     agent {
-                        label cachedCommitPragma(pragma: 'VM1-label', def_val: params.CI_UNIT_VM1_LABEL)
+                        label params.CI_NLT_1_LABEL
                     }
                     steps {
                         job_step_update(

--- a/src/common/dav/tx.c
+++ b/src/common/dav/tx.c
@@ -1419,6 +1419,7 @@ dav_tx_xfree(uint64_t off, uint64_t flags)
 				} else if (r->offset == roff) {
 					/* Retain the right portion. */
 					r->offset += usize;
+					r->size   -= usize;
 				} else {
 					/* Retain the left portion. */
 					uint64_t osize = r->size;

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -259,6 +259,24 @@ vos_self_fini(void);
  * \param uuid	[IN]    Pool UUID
  * \param scm_sz [IN]	Size of SCM for the pool
  * \param blob_sz[IN]	Size of blob for the pool
+ * \param wal_sz [IN]	Size of WAL blob for the pool
+ * \param flags [IN]	Pool open flags (see vos_pool_open_flags)
+ * \param poh	[OUT]	Returned pool handle if not NULL
+ *
+ * \return              Zero on success, negative value if error
+ */
+int
+vos_pool_create_ex(const char *path, uuid_t uuid, daos_size_t scm_sz,
+		   daos_size_t blob_sz, daos_size_t wal_sz,
+		   unsigned int flags, daos_handle_t *poh);
+/**
+ * Create a Versioning Object Storage Pool (VOSP), and open it if \a poh is not
+ * NULL
+ *
+ * \param path	[IN]	Path of the memory pool
+ * \param uuid	[IN]    Pool UUID
+ * \param scm_sz [IN]	Size of SCM for the pool
+ * \param blob_sz[IN]	Size of blob for the pool
  * \param flags [IN]	Pool open flags (see vos_pool_open_flags)
  * \param poh	[OUT]	Returned pool handle if not NULL
  *

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -39,7 +39,6 @@
 #define VPOOL_1G	(1ULL << 30)
 #define VPOOL_2G	(2ULL << 30)
 #define VPOOL_3G	(3ULL << 30)
-#define VPOOL_10G	(10ULL << 30)
 
 #define VPOOL_SIZE	VPOOL_3G
 

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1957,8 +1957,6 @@ many_keys(void **state)
 	if (DAOS_ON_VALGRIND)
 		num_keys /= 500;
 
-	test_args_reset(arg, VPOOL_10G);
-
 	memset(&rex, 0, sizeof(rex));
 	memset(&iod, 0, sizeof(iod));
 

--- a/src/vos/tests/vts_wal.c
+++ b/src/vos/tests/vts_wal.c
@@ -549,6 +549,7 @@ setup_wal_io(void **state)
 	if (rc == -1)
 		return rc;
 
+	test_args_reset((struct io_test_args *)*state, VPOOL_2G);
 	wal_args_reset((struct io_test_args *)*state);
 	return 0;
 }

--- a/src/vos/tests/vts_wal.c
+++ b/src/vos/tests/vts_wal.c
@@ -1149,7 +1149,7 @@ run_wal_tests(const char *cfg)
 		return 0;
 	}
 
-	dts_create_config(test_name, "WAL Pool & container tests %s", cfg);
+	dts_create_config(test_name, "WAL Pool and container tests %s", cfg);
 	D_PRINT("Running %s\n", test_name);
 	rc = cmocka_run_group_tests_name(test_name, wal_tests, setup_wal_test,
 					   teardown_wal_test);

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -678,8 +678,9 @@ static int pool_open(void *ph, struct vos_pool_df *pool_df,
 		     unsigned int flags, void *metrics, daos_handle_t *poh);
 
 int
-vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
-		daos_size_t nvme_sz, unsigned int flags, daos_handle_t *poh)
+vos_pool_create_ex(const char *path, uuid_t uuid, daos_size_t scm_sz,
+		   daos_size_t nvme_sz, daos_size_t wal_sz,
+		   unsigned int flags, daos_handle_t *poh)
 {
 	struct umem_pool	*ph;
 	struct umem_attr	 uma = {0};
@@ -716,7 +717,7 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 		return daos_errno2der(errno);
 	}
 
-	rc = vos_pmemobj_create(path, uuid, VOS_POOL_LAYOUT, scm_sz, nvme_sz, 0, flags, &ph);
+	rc = vos_pmemobj_create(path, uuid, VOS_POOL_LAYOUT, scm_sz, nvme_sz, wal_sz, flags, &ph);
 	if (rc) {
 		D_ERROR("Failed to create pool %s, scm_sz="DF_U64", nvme_sz="DF_U64". "DF_RC"\n",
 			path, scm_sz, nvme_sz, DP_RC(rc));
@@ -821,6 +822,14 @@ close:
 	if (ph != NULL)
 		vos_pmemobj_close(ph);
 	return rc;
+}
+
+int
+vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
+		daos_size_t nvme_sz, unsigned int flags, daos_handle_t *poh)
+{
+	/* create vos pool with default WAL size */
+	return vos_pool_create_ex(path, uuid, scm_sz, nvme_sz, 0, flags, poh);
 }
 
 /**

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -162,12 +162,12 @@ if [ -d "/mnt/daos" ]; then
         fi
 
         COMP="UTEST_vos_nvme_md_on_ssd"
-        if run_test_filter "sudo -E ${SL_PREFIX}/bin/vos_tests -A 50"; then
+        if run_test_filter "sudo -E ${SL_PREFIX}/bin/vos_tests -w"; then
             rm -f "${AIO_DEV}"
             dd if=/dev/zero of="${AIO_DEV}" bs=1G count=13
             sed -i "s+\"name\": \"AIO_1\"+\"name\": \"AIO_7\"+g" ${NVME_CONF}
 
-            run_test "sudo -E ${SL_PREFIX}/bin/vos_tests" -A 50
+            run_test "sudo -E ${SL_PREFIX}/bin/vos_tests" -w
         fi
         COMP="UTEST_nvme_bio_wal"
         if run_test_filter "sudo -E ${SL_PREFIX}/bin/bio_ut"; then

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -142,7 +142,7 @@ if [ -d "/mnt/daos" ]; then
         run_test src/common/tests/btree.sh dyn perf ukey -s 20000
         BTREE_SIZE=20000
 
-        COMP="UTEST_vos_nvme"
+        COMP="UTEST_vos_nvme_md_on_ssd_bio_wal_vos_tests"
         if run_test_filter "nvme"; then
             cat /proc/meminfo
             AIO_DEV=$(mktemp /tmp/aio_dev_XXXXX)
@@ -150,23 +150,24 @@ if [ -d "/mnt/daos" ]; then
             NVME_CONF="/mnt/daos/daos_nvme.conf"
             cp -f src/vos/tests/daos_nvme.conf ${NVME_CONF}
             sed -i "s+\"filename\": \".*\"+\"filename\": \"${AIO_DEV}\"+g" ${NVME_CONF}
+            export VOS_BDEV_CLASS="AIO"
         fi
+        COMP="UTEST_vos_nvme"
         if run_test_filter "sudo -E ${SL_PREFIX}/bin/vos_tests -a"; then
             cat /proc/meminfo
             # Setup AIO device
             dd if=/dev/zero of="${AIO_DEV}" bs=1G count=4
 
-            export VOS_BDEV_CLASS="AIO"
             run_test "sudo -E ${SL_PREFIX}/bin/vos_tests" -a
         fi
 
         COMP="UTEST_vos_nvme_md_on_ssd"
-        if run_test_filter "sudo -E ${SL_PREFIX}/bin/vos_tests -a"; then
+        if run_test_filter "sudo -E ${SL_PREFIX}/bin/vos_tests -A 50"; then
             rm -f "${AIO_DEV}"
-            dd if=/dev/zero of="${AIO_DEV}" bs=1G count=20
+            dd if=/dev/zero of="${AIO_DEV}" bs=1G count=13
             sed -i "s+\"name\": \"AIO_1\"+\"name\": \"AIO_7\"+g" ${NVME_CONF}
 
-            run_test "sudo -E ${SL_PREFIX}/bin/vos_tests" -a
+            run_test "sudo -E ${SL_PREFIX}/bin/vos_tests" -A 50
         fi
         COMP="UTEST_nvme_bio_wal"
         if run_test_filter "sudo -E ${SL_PREFIX}/bin/bio_ut"; then
@@ -176,6 +177,7 @@ if [ -d "/mnt/daos" ]; then
             run_test "sudo -E ${SL_PREFIX}/bin/bio_ut"
         fi
 
+        COMP="UTEST_vos_nvme_md_on_ssd_bio_wal_vos_tests"
         if run_test_filter "nvme"; then
             unset VOS_BDEV_CLASS
             rm -f "${NVME_CONF}"


### PR DESCRIPTION
This fix addresses a bug with DAV allocator when after the change to move all allocations to fixed slabs if they fit in a defined one, we hit a bug in tx_free which was causing an allocated range to not get flushed on commit if multiple ranges were merged at tx_alloc.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
