### PR TITLE
DAOS-10472 bio: Use hugepages from any NUMA in legacy mode (#11594)

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -250,8 +250,12 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 	vmd_led_period = env ? atoi(env) : 0;
 	vmd_led_period *= (NSEC_PER_SEC / NSEC_PER_USEC);
 
-	if (numa_node > 0)
+	if (numa_node > 0) {
 		bio_numa_node = (unsigned int)numa_node;
+	} else if (numa_node == -1) {
+		D_WARN("DMA buffer will be allocated from any NUMA node available\n");
+		bio_numa_node = SPDK_ENV_SOCKET_ID_ANY;
+	}
 
 	nvme_glb.bd_mem_size = mem_size;
 	nvme_glb.bd_nvme_conf = nvme_conf;

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -1591,7 +1591,7 @@ func TestConfig_SetEngineAffinities(t *testing.T) {
 			},
 			expNumaSet: []int{2, 1},
 		},
-		"multi engine with first_core set; detected affinities take precedence": {
+		"multi engine with first_core set; detected affinities overridden": {
 			cfg: baseSrvCfg().
 				WithEngines(
 					engine.MockConfig().
@@ -1608,7 +1608,7 @@ func TestConfig_SetEngineAffinities(t *testing.T) {
 				genAffFn("ib1", 2),
 			},
 			expNumaSet:  []int{-1, -1}, // PinnedNumaNode should not be set
-			expFabNumas: []int{1, 2},
+			expFabNumas: []int{0, 0},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Use memory from any NUMA node when allocating DMA buffer when the
engine is using the legacy core allocation algorithm. Enable legacy
mode whenever a non-zero first_core value is specified in the server
config file or if a single engine on NUMA-0 is unpinned.

Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
