### PR TITLE
DAOS-12835 dfs: getxattr shouldn't return error if value wasn't set

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -6152,13 +6152,13 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 		sgl.sg_nr_out	= 0;
 		sgl.sg_iovs	= &sg_iov;
 
-		rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
-				    NULL, NULL);
+		rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_AKEY_FETCH, &dkey, 1,
+							&iod, &sgl,NULL, NULL);
 	} else {
 		iod.iod_size	= DAOS_REC_ANY;
 
-		rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, NULL,
-				    NULL, NULL);
+		rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_AKEY_FETCH, &dkey, 1,
+							&iod, NULL, NULL, NULL);
 	}
 	if (rc) {
 		D_ERROR("Failed to fetch xattr %s "DF_RC"\n", name, DP_RC(rc));

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -6153,16 +6153,16 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 		sgl.sg_iovs	= &sg_iov;
 
 		rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_AKEY_FETCH, &dkey, 1,
-							&iod, &sgl,NULL, NULL);
+				    &iod, &sgl, NULL, NULL);
 	} else {
 		iod.iod_size	= DAOS_REC_ANY;
 
 		rc = daos_obj_fetch(oh, DAOS_TX_NONE, DAOS_COND_AKEY_FETCH, &dkey, 1,
-							&iod, NULL, NULL, NULL);
+				    &iod, NULL, NULL, NULL);
 	}
 	if (rc) {
 		D_CDEBUG(rc == -DER_NONEXIST, DLOG_DBG, DLOG_ERR,
-			 "Failed to fetch xattr %s "DF_RC"\n", name, DP_RC(rc));
+			 "Failed to fetch xattr '%s' " DF_RC "\n", name, DP_RC(rc));
 		D_GOTO(close, rc = daos_der2errno(rc));
 	}
 

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -6166,8 +6166,6 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 	}
 
 	*size = iod.iod_size;
-	if (iod.iod_size == 0)
-		D_GOTO(close, rc = ENODATA);
 
 close:
 	daos_obj_close(oh, NULL);

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -6161,7 +6161,8 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 							&iod, NULL, NULL, NULL);
 	}
 	if (rc) {
-		D_ERROR("Failed to fetch xattr %s "DF_RC"\n", name, DP_RC(rc));
+		D_CDEBUG(rc == -DER_NONEXIST, DLOG_DBG, DLOG_ERR,
+			 "Failed to fetch xattr %s "DF_RC"\n", name, DP_RC(rc));
 		D_GOTO(close, rc = daos_der2errno(rc));
 	}
 

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -2301,6 +2301,93 @@ dfs_test_multiple_pools(void **state)
 	assert_rc_equal(rc, 0);
 }
 
+static void
+dfs_test_xattrs(void **state)
+{
+	test_arg_t		*arg = *state;
+	dfs_obj_t		*obj;
+	char			*dir = "xdir";
+	mode_t			create_mode = S_IWUSR | S_IRUSR;
+	int			create_flags = O_RDWR | O_CREAT;
+	const char		*xname1 = "user.empty";
+	const char		*xname2 = "user.with_value";
+	const char		*xval2  = "some value";
+	daos_size_t		size;
+	char			buf[32];
+	int			rc;
+
+	if (arg->myrank != 0)
+		return;
+
+	rc = dfs_open(dfs_mt, NULL, dir, create_mode | S_IFDIR, create_flags,
+		      0, 0, NULL, &obj);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_getxattr(dfs_mt, obj, xname1, NULL, &size);
+	assert_int_equal(rc, ENODATA);
+
+	size = 0;
+	rc = dfs_setxattr(dfs_mt, obj, xname1, NULL, size, 0);
+	assert_int_equal(rc, 0);
+
+	size = sizeof(buf);
+	rc = dfs_getxattr(dfs_mt, obj, xname1, buf, &size);
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, 0);
+
+	rc = dfs_getxattr(dfs_mt, obj, xname2, NULL, &size);
+	assert_int_equal(rc, ENODATA);
+
+	size = strlen(xval2) + 1;
+	rc = dfs_setxattr(dfs_mt, obj, xname2, xval2, size, 0);
+	assert_int_equal(rc, 0);
+
+	size = sizeof(buf);
+	memset(buf, 0, sizeof(buf));
+	rc = dfs_getxattr(dfs_mt, obj, xname2, buf, &size);
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, strlen(xval2) + 1);
+	assert_string_equal(xval2, buf);
+
+	size = sizeof(buf);
+	memset(buf, 0, sizeof(buf));
+	rc = dfs_listxattr(dfs_mt, obj, buf, &size);
+
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, strlen(xname1) + 1 + strlen(xname2) + 1);
+	assert_string_equal(buf, xname1);
+	assert_string_equal(buf + strlen(xname1) + 1, xname2);
+
+	rc = dfs_removexattr(dfs_mt, obj, xname1);
+	assert_int_equal(rc, 0);
+
+	size = 0;
+	rc = dfs_getxattr(dfs_mt, obj, xname1, NULL, &size);
+	assert_int_equal(rc, ENODATA);
+
+	size = sizeof(buf);
+	memset(buf, 0, sizeof(buf));
+	rc = dfs_listxattr(dfs_mt, obj, buf, &size);
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, strlen(xname2) + 1);
+	assert_string_equal(buf, xname2);
+
+	rc = dfs_removexattr(dfs_mt, obj, xname2);
+	assert_int_equal(rc, 0);
+
+	size = 0;
+	rc = dfs_getxattr(dfs_mt, obj, xname2, NULL, &size);
+	assert_int_equal(rc, ENODATA);
+
+	size = sizeof(buf);
+	rc = dfs_listxattr(dfs_mt, obj, buf, &size);
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, 0);
+
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+}
+
 static const struct CMUnitTest dfs_unit_tests[] = {
 	{ "DFS_UNIT_TEST1: DFS mount / umount",
 	  dfs_test_mount, async_disable, test_case_teardown},
@@ -2344,6 +2431,8 @@ static const struct CMUnitTest dfs_unit_tests[] = {
 	  dfs_test_oclass_hints, async_disable, test_case_teardown},
 	{ "DFS_UNIT_TEST21: dfs multiple pools",
 	  dfs_test_multiple_pools, async_disable, test_case_teardown},
+	{ "DFS_UNIT_TEST22: dfs extended attributes",
+	  dfs_test_xattrs, test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
Retrieving an attribute that was set without any data should not return an error.
Experiments and man page seem to indicate that this is the correct.

Features: dfs,dfuse
Required-githooks: true

Signed-off-by: Denis Barakhtanov denis.barahtanov@croit.io

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
