### PR TITLE
DAOS-12573 test: wait on rebuild before teardown/cont destroy

### DIFF
--- a/src/tests/ftest/erasurecode/online_rebuild_single.py
+++ b/src/tests/ftest/erasurecode/online_rebuild_single.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2020-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -64,3 +64,5 @@ class EcodOnlineRebuildSingle(ErasureCodeSingle):
         # EC data was written with +2 parity so after killing Two servers data
         # should be intact and no data corruption observed.
         self.start_online_single_operation("READ", parity=2)
+        # Wait for rebuild to complete
+        self.pool.wait_for_rebuild(to_start=False)


### PR DESCRIPTION
Add wait_for_rebuild() call at the end of the test
(similar to how the test does on the master branch version).

With this change, the chance of an intermittent -DER_IO
returned by container destroy (due to pool rebuild in progress)
should be eliminated.

Quick-Functional: true
Test-tag: ec_online_rebuild_single
Test-repeat: 6

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [x] You are the appropriate gatekeeper to be landing the patch.
* [x] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [x] Githooks were used. If not, request that user install them and check copyright dates.
* [x] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [x] All builds have passed.  Check non-required builds for any new compiler warnings.
* [x] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [x] If applicable, the PR has addressed any potential version compatibility issues.
* [x] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [x] Extra checks if forced landing is requested
  * [x] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [x] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [x] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
