### PR TITLE
Revert "DAOS-12833 build: Avoid updating to SCons 4.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ ninja
 pyelftools
 pyxattr
 pyyaml
-scons<4.5        # 4.5 has some serious issues
+scons        # Works around a bug in scons on EL 8.
 tabulate
 wheel


### PR DESCRIPTION
Issue is now fixed upstream.

Reverts daos-stack/daos#11620