### PR TITLE
DAOS-623 common: Fix array metadata in storage estimator

### DIFF
--- a/src/vos/storage_estimator/common/dfs_sb.py
+++ b/src/vos/storage_estimator/common/dfs_sb.py
@@ -40,14 +40,14 @@ array_meta: &file_meta
   count: 1
   type: integer
   overhead: meta
-  value_type: single_value
-  values: [{'count': 3, 'size': 64, 'aligned': 'Yes'}]
+  value_type: array
+  values: [{'count': 1, 'size': 192, 'aligned': 'Yes'}]
 
 file_dkey_key0: &file_dkey0
   count: 1
   type: integer
   overhead: user
-  akeys: [*file_data, *file_meta]
+  akeys: [*file_meta]
 
 file_dkey_key: &file_dkey
   count: 1

--- a/src/vos/storage_estimator/common/explorer.py
+++ b/src/vos/storage_estimator/common/explorer.py
@@ -256,8 +256,8 @@ class DFS(CommonBase):
         akey = AKey(
             key_type=KeyType.INTEGER,
             overhead=Overhead.META,
-            value_type=ValType.SINGLE)
-        value = VosValue(count=3, size=64)
+            value_type=ValType.ARRAY)
+        value = VosValue(count=1, size=192)
         akey.add_value(value)
         dkey = DKey(
             key_type=KeyType.INTEGER,

--- a/src/vos/storage_estimator/common/util.py
+++ b/src/vos/storage_estimator/common/util.py
@@ -419,9 +419,6 @@ class ProcessBase(Common):
         chunk_size = self._parse_num_value('chunk_size', '1MiB')
         self._debug('using scm_cutoff of {0} bytes'.format(scm_cutoff))
 
-        if io_size % scm_cutoff:
-            raise ValueError('io_size must be multiple of scm_cutoff')
-
         self._debug('using io_size of {0} bytes'.format(io_size))
 
         if chunk_size % io_size:


### PR DESCRIPTION
Array metadata is stored in an array value now rather than a single value.
Also, remove limitation on io_size setting

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
