### PR TITLE
DAOS-12693 object: a few fixes for pool extending (#11541)

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1758,11 +1758,11 @@ obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
 		D_GOTO(failed, rc);
 	}
 
+out:
 	/* load csummer on demand for rebuild if not already loaded */
 	rc = ds_cont_csummer_init(coc);
 	if (rc)
 		D_GOTO(failed, rc);
-out:
 	D_ASSERT(coc->sc_pool != NULL);
 	ioc->ioc_map_ver = coc->sc_pool->spc_map_version;
 	ioc->ioc_vos_coh = coc->sc_hdl;
@@ -3066,7 +3066,8 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 			 enum_arg.eprs_len == enum_arg.kds_len);
 		oeo->oeo_kds.ca_count = enum_arg.kds_len;
 		oeo->oeo_num = enum_arg.kds_len;
-		oeo->oeo_size = oeo->oeo_sgl.sg_iovs[0].iov_len;
+		if (oeo->oeo_sgl.sg_iovs != NULL)
+			oeo->oeo_size = oeo->oeo_sgl.sg_iovs[0].iov_len;
 		oeo->oeo_csum_iov = enum_arg.csum_iov;
 	}
 

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -378,21 +378,23 @@ grp_map_is_set(uint32_t *grp_map, uint32_t grp_map_size, uint32_t tgt_id)
 	return false;
 }
 
-uint32_t*
+static uint32_t*
 grp_map_extend(uint32_t *grp_map, uint32_t *grp_map_size)
 {
 	uint32_t *new_grp_map;
 	uint32_t new_grp_size = *grp_map_size + STACK_TGTS_SIZE;
 	int	 i;
 
-	if (*grp_map_size > STACK_TGTS_SIZE)
+	if (*grp_map_size > STACK_TGTS_SIZE) {
 		D_REALLOC_ARRAY(new_grp_map, grp_map, *grp_map_size,
 				new_grp_size);
-	else
+	} else {
 		D_ALLOC_ARRAY(new_grp_map, new_grp_size);
+		memcpy(new_grp_map, grp_map, *grp_map_size * sizeof(*grp_map));
+	}
 
 	for (i = *grp_map_size; i < new_grp_size; i++)
-		grp_map[i] = -1;
+		new_grp_map[i] = -1;
 
 	*grp_map_size = new_grp_size;
 	return new_grp_map;


### PR DESCRIPTION
Typo fix in pool_map_extend(), especially if there are a lot groups.

Check ptr in enum_handler.

Make sure container property is retrieved before capability check, especially during pool extending.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
