### PR TITLE
DAOS-12727 cart: Update WAIT_OBJ default settings

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -534,6 +534,11 @@ prov_settings_apply(bool primary, crt_provider_t prov, crt_init_options_t *opt)
 	    prov == CRT_PROV_OFI_TCP_RXM) {
 		/* Use shared receive queues to avoid large mem consumption */
 		apply_if_not_set("FI_OFI_RXM_USE_SRX", "1");
+
+		/* Only apply on the server side */
+		if (prov == CRT_PROV_OFI_TCP_RXM && crt_is_service())
+			apply_if_not_set("FI_OFI_RXM_DEF_TCP_WAIT_OBJ", "pollfd");
+
 	}
 
 	/* Print notice that "ofi+psm2" will be deprecated*/

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -534,9 +534,6 @@ prov_settings_apply(bool primary, crt_provider_t prov, crt_init_options_t *opt)
 	    prov == CRT_PROV_OFI_TCP_RXM) {
 		/* Use shared receive queues to avoid large mem consumption */
 		apply_if_not_set("FI_OFI_RXM_USE_SRX", "1");
-
-		if (prov == CRT_PROV_OFI_TCP_RXM)
-			apply_if_not_set("FI_OFI_RXM_DEF_TCP_WAIT_OBJ", "pollfd");
 	}
 
 	/* Print notice that "ofi+psm2" will be deprecated*/


### PR DESCRIPTION
No longer set "FI_OFI_RXM_DEF_TCP_WAIT_OBJ" to pollfd by default on the client side. Setting this causes performance issues on some tests

Test-provider-hw-medium: ofi+tcp
Test-tag: test_pool_autotest

Required-githooks: true
Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
