### PR TITLE
DAOS-12638 event: add more restrictive locking in the ev progress

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -505,42 +505,39 @@ ev_progress_cb(void *arg)
 	struct ev_progress_arg		*epa = (struct ev_progress_arg  *)arg;
 	struct daos_event_private       *evx = epa->evx;
 	struct daos_eq_private		*eqx = epa->eqx;
+	int				rc;
 
 	tse_sched_progress(evx->evx_sched);
 
+	if (daos_handle_is_inval(evx->evx_eqh))
+		D_MUTEX_LOCK(&evx->evx_lock);
+	else
+		D_MUTEX_LOCK(&eqx->eqx_lock);
+
 	/** If another thread progressed this, get out now. */
 	if (evx->evx_status == DAOS_EVS_READY)
-		return 1;
+		D_GOTO(unlock, rc = 1);
 
 	/** Event is still in-flight */
 	if (evx->evx_status != DAOS_EVS_COMPLETED && evx->evx_status != DAOS_EVS_ABORTED)
-		return 0;
+		D_GOTO(unlock, rc = 0);
 
 	/** If there are children in flight, then return in-flight */
 	if (evx->evx_nchild_running > 0)
-		return 0;
+		D_GOTO(unlock, rc = 0);
 
 	/** Change status of event to INIT only if event is not in EQ and get out. */
 	if (daos_handle_is_inval(evx->evx_eqh)) {
-		D_MUTEX_LOCK(&evx->evx_lock);
 		if (evx->evx_status == DAOS_EVS_COMPLETED || evx->evx_status == DAOS_EVS_ABORTED)
 			evx->evx_status = DAOS_EVS_READY;
-		D_MUTEX_UNLOCK(&evx->evx_lock);
-		return 1;
+		D_GOTO(unlock, rc = 1);
 	}
 
-	/** Grab the lock so we don't race with eq_progress_cb. */
-	D_MUTEX_LOCK(&eqx->eqx_lock);
-
-	/*
-	 * if the EQ was finalized from under us, just update the event status
-	 * and return.
-	 */
+	/** if the EQ was finalized from under us, just update the event status and return. */
 	if (eqx->eqx_finalizing) {
 		evx->evx_status = DAOS_EVS_READY;
 		D_ASSERT(d_list_empty(&evx->evx_link));
-		D_MUTEX_UNLOCK(&eqx->eqx_lock);
-		return 1;
+		D_GOTO(unlock, rc = 1);
 	}
 
 	/*
@@ -555,11 +552,15 @@ ev_progress_cb(void *arg)
 		eq->eq_n_comp--;
 		d_list_del_init(&evx->evx_link);
 	}
-
+	rc = 1;
 	D_ASSERT(evx->evx_status == DAOS_EVS_READY);
-	D_MUTEX_UNLOCK(&eqx->eqx_lock);
 
-	return 1;
+unlock:
+	if (daos_handle_is_inval(evx->evx_eqh))
+		D_MUTEX_UNLOCK(&evx->evx_lock);
+	else
+		D_MUTEX_UNLOCK(&eqx->eqx_lock);
+	return rc;
 }
 
 int


### PR DESCRIPTION
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
