### PR TITLE
DAOS-623 common: Don't add array metadata for empty files

### DIFF
--- a/src/vos/storage_estimator/common/explorer.py
+++ b/src/vos/storage_estimator/common/explorer.py
@@ -443,6 +443,8 @@ class DFS(CommonBase):
         return oid
 
     def create_file_obj(self, file_size, identical_files=1):
+        if file_size == 0:
+            return
         parity_stats = CellStats(self._verbose)
 
         self._debug(

--- a/src/vos/storage_estimator/common/vos_size.py
+++ b/src/vos/storage_estimator/common/vos_size.py
@@ -266,9 +266,10 @@ class MetaOverhead():
 
     def get_dynamic(self, key, num_values):
         """Handle dynamic tree ordering.  Retrieve number of nodes and size"""
+        if num_values == 0:
+            return 0, 0, 0
         order = self.meta["trees"][key]["order"]
         max_dyn = 0
-
         if self.meta["trees"][key]["num_dynamic"] != 0:
             max_dyn = self.meta["trees"][key]["dynamic"][-1]["order"]
         if num_values > max_dyn:
@@ -276,12 +277,11 @@ class MetaOverhead():
             int_node_size = self.meta["trees"][key]["int_node_size"]
             mult = 1
             if num_values > order:
-                mult = 2 # assume 50% capacity
+                mult = 2  # assume 50% capacity
             tree_nodes = (num_values * mult + order - 1) // order
             return leaf_node_size, int_node_size, tree_nodes
 
-        if self.meta["trees"][key]["num_dynamic"] == 0:
-            return 0, 0, 0
+        assert self.meta["trees"][key]["num_dynamic"] != 0
 
         for item in self.meta["trees"][key]["dynamic"]:
             if item["order"] >= num_values:

--- a/src/vos/storage_estimator/daos_storage_estimator.py
+++ b/src/vos/storage_estimator/daos_storage_estimator.py
@@ -132,7 +132,7 @@ example = subparsers.add_parser(
     description=example_description,
     formatter_class=MyFormatter)
 example.add_argument('-a', '--alloc_overhead', type=int,
-                     help='Vos alloc overhead', default=16)
+                     help='Vos alloc overhead', default=0)
 example.add_argument(
     '-f',
     '--dfs_file_name',
@@ -231,7 +231,7 @@ explore.add_argument(
     help='Number of VOS Pools',
     default=1000)
 explore.add_argument('-a', '--alloc_overhead', type=int,
-                     help='Vos alloc overhead', default=16)
+                     help='Vos alloc overhead', default=0)
 explore.add_argument(
     '-k',
     '--checksum',
@@ -273,7 +273,7 @@ yaml_file.add_argument(
 yaml_file.add_argument('config', metavar='CONFIG', type=str, nargs=1,
                        help='Path to the input yaml configuration file')
 yaml_file.add_argument('-a', '--alloc_overhead', type=int,
-                       help='Vos alloc overhead', default=16)
+                       help='Vos alloc overhead', default=0)
 yaml_file.add_argument(
     '-s',
     '--scm_cutoff',
@@ -359,7 +359,7 @@ csv_file.add_argument(
     action='store_true',
     help='Explain what is being done')
 csv_file.add_argument('-a', '--alloc_overhead', type=int,
-                      help='Vos alloc overhead', default=16)
+                      help='Vos alloc overhead', default=0)
 csv_file.add_argument(
     '-t',
     '--dir_oclass',

--- a/src/vos/vos_size.c
+++ b/src/vos/vos_size.c
@@ -63,7 +63,7 @@ print_dynamic(struct d_string_buffer_t *buf, const char *name,
 		d_write_string_buffer(buf, "  order: %d\n",
 				      ovhd->to_dyn_overhead[i].no_order);
 		d_write_string_buffer(buf, "  size: %d\n",
-				      ovhd->to_dyn_overhead[i].no_size);
+				      D_ALIGNUP(ovhd->to_dyn_overhead[i].no_size, 32));
 	}
 }
 
@@ -78,13 +78,12 @@ print_record(struct d_string_buffer_t *buf, const char *name,
 	d_write_string_buffer(buf, "    order: %d\n",
 			      ovhd->to_leaf_overhead.no_order);
 	d_write_string_buffer(buf, "    leaf_node_size: %d\n",
-			      ovhd->to_leaf_overhead.no_size);
+			      D_ALIGNUP(ovhd->to_leaf_overhead.no_size, 32));
 	d_write_string_buffer(buf, "    int_node_size: %d\n",
-			      ovhd->to_int_node_size);
-	d_write_string_buffer(buf, "    record_msize: %d\n",
-			      ovhd->to_record_msize);
+			      D_ALIGNUP(ovhd->to_int_node_size, 32));
+	d_write_string_buffer(buf, "    record_msize: %d\n", D_ALIGNUP(ovhd->to_record_msize, 32));
 	d_write_string_buffer(buf, "    node_rec_msize: %d\n",
-			      ovhd->to_node_rec_msize);
+			      D_ALIGNUP(ovhd->to_node_rec_msize, 32));
 	d_write_string_buffer(buf, "    num_dynamic: %d\n", ovhd->to_dyn_count);
 	if (ovhd->to_dyn_count == 0)
 		return;
@@ -155,9 +154,8 @@ get_vos_structure_sizes_yaml(int alloc_overhead, struct d_string_buffer_t *buf,
 	FOREACH_TYPE(CHECK_CALL)
 
 	d_write_string_buffer(buf, "---\n# VOS tree overheads\n");
-	d_write_string_buffer(buf, "root: %d\n", vos_pool_get_msize());
-	d_write_string_buffer(buf, "container: %d\n",
-			      vos_container_get_msize());
+	d_write_string_buffer(buf, "root: %d\n", D_ALIGNUP(vos_pool_get_msize(), 32));
+	d_write_string_buffer(buf, "container: %d\n", D_ALIGNUP(vos_container_get_msize(), 32));
 	d_write_string_buffer(buf, "scm_cutoff: %d\n",
 			      vos_pool_get_scm_cutoff());
 


### PR DESCRIPTION
It appears dfs doesn't write dkey0, for array metadata, until there is actually data written to a file.  Modify the storage estimator to handle this case
Align up vos_size values to 32 bytes since that's what we do internally. Change alloc_overhead default to 0 since we use slabs.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
