### PR TITLE
DAOS-12863 cart: Fix bug in d_rank_list_dup_sort_uniq

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -534,6 +534,11 @@ prov_settings_apply(bool primary, crt_provider_t prov, crt_init_options_t *opt)
 	    prov == CRT_PROV_OFI_TCP_RXM) {
 		/* Use shared receive queues to avoid large mem consumption */
 		apply_if_not_set("FI_OFI_RXM_USE_SRX", "1");
+
+		/* Only apply on the server side */
+		if (prov == CRT_PROV_OFI_TCP_RXM && crt_is_service())
+			apply_if_not_set("FI_OFI_RXM_DEF_TCP_WAIT_OBJ", "pollfd");
+
 	}
 
 	/* Print notice that "ofi+psm2" will be deprecated*/

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -534,9 +534,6 @@ prov_settings_apply(bool primary, crt_provider_t prov, crt_init_options_t *opt)
 	    prov == CRT_PROV_OFI_TCP_RXM) {
 		/* Use shared receive queues to avoid large mem consumption */
 		apply_if_not_set("FI_OFI_RXM_USE_SRX", "1");
-
-		if (prov == CRT_PROV_OFI_TCP_RXM)
-			apply_if_not_set("FI_OFI_RXM_DEF_TCP_WAIT_OBJ", "pollfd");
 	}
 
 	/* Print notice that "ofi+psm2" will be deprecated*/

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -160,6 +160,9 @@ d_rank_list_dup_sort_uniq(d_rank_list_t **dst, const d_rank_list_t *src)
 			D_DEBUG(DB_TRACE, "%s:%d, rank_list %p, removed "
 				"identical rank[%d](%d).\n", __FILE__, __LINE__,
 				rank_list, i, rank_tmp);
+
+			i--;
+			rank_num--;
 		}
 		rank_tmp = rank_list->rl_ranks[i];
 	}

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -2067,6 +2067,82 @@ test_hash_perf(void **state)
 		hash_perf(HASH_JCH, 1 << i, el << i);
 }
 
+static void
+verify_rank_list_dup_uniq(int *src_ranks, int num_src_ranks,
+			  int *exp_ranks, int num_exp_ranks)
+{
+	d_rank_list_t	*orig_list;
+	d_rank_list_t	*ret_list = NULL;
+	int 		rc;
+	int		i;
+
+	orig_list = d_rank_list_alloc(num_src_ranks);
+	assert_non_null(orig_list);
+
+	fprintf(stdout, "dup_uniq: [");
+	for (i = 0; i < num_src_ranks; i++) {
+		fprintf(stdout, "%d%s", src_ranks[i], i == num_src_ranks - 1 ? "" : ","); 
+		orig_list->rl_ranks[i] = src_ranks[i];
+	}
+	fprintf(stdout, "] -> ");
+
+	rc = d_rank_list_dup_sort_uniq(&ret_list, orig_list);
+	assert_int_equal(rc, 0);
+	assert_non_null(ret_list);
+	assert_int_equal(ret_list->rl_nr, num_exp_ranks);
+
+	fprintf(stdout, "[");
+	for (i  = 0; i < ret_list->rl_nr; i++) {
+		fprintf(stdout, "%d%s", exp_ranks[i], i == ret_list->rl_nr - 1 ? "" : ",");
+		assert_int_equal(ret_list->rl_ranks[i], exp_ranks[i]);
+	}
+	fprintf(stdout, "]\n");
+}
+
+static void
+test_d_rank_list_dup_sort_uniq(void **state)
+{
+	{
+		int	src_ranks[] = {0, 0, 0, 1, 1};
+		int	exp_ranks[] = {0, 1};
+
+		verify_rank_list_dup_uniq(src_ranks, sizeof(src_ranks)/sizeof(src_ranks[0]),
+					  exp_ranks, sizeof(exp_ranks)/sizeof(exp_ranks[0]));
+	}
+
+	{
+		int	src_ranks[] = {0, 0, 0, 0, 1};
+		int	exp_ranks[] = {0, 1};
+
+		verify_rank_list_dup_uniq(src_ranks, sizeof(src_ranks)/sizeof(src_ranks[0]),
+					  exp_ranks, sizeof(exp_ranks)/sizeof(exp_ranks[0]));
+	}
+
+	{
+		int	src_ranks[] = {0, 0, 0, 1, 1, 1, 2, 3, 3, 5};
+		int	exp_ranks[] = {0, 1, 2, 3, 5};
+
+		verify_rank_list_dup_uniq(src_ranks, sizeof(src_ranks)/sizeof(src_ranks[0]),
+					  exp_ranks, sizeof(exp_ranks)/sizeof(exp_ranks[0]));
+	}
+
+	{
+		int	src_ranks[] = {1, 2, 1, 3, 1, 5};
+		int	exp_ranks[] = {1, 2, 3, 5};
+
+		verify_rank_list_dup_uniq(src_ranks, sizeof(src_ranks)/sizeof(src_ranks[0]),
+					  exp_ranks, sizeof(exp_ranks)/sizeof(exp_ranks[0]));
+	}
+
+	{
+		int	src_ranks[] = {5, 5, 2, 2, 1, 3, 4, 1, 1, 2};
+		int	exp_ranks[] = {1, 2, 3, 4, 5};
+
+		verify_rank_list_dup_uniq(src_ranks, sizeof(src_ranks)/sizeof(src_ranks[0]),
+					  exp_ranks, sizeof(exp_ranks)/sizeof(exp_ranks[0]));
+	}
+}
+
 int
 main(int argc, char **argv)
 {
@@ -2087,6 +2163,7 @@ main(int argc, char **argv)
 		cmocka_unit_test(test_gurt_hash_parallel_refcounting),
 		cmocka_unit_test(test_gurt_atomic),
 		cmocka_unit_test(test_gurt_string_buffer),
+		cmocka_unit_test(test_d_rank_list_dup_sort_uniq),
 		cmocka_unit_test(test_hash_perf),
 	};
 


### PR DESCRIPTION
DAOS-12863 cart: Fix bug in d_rank_list_dup_sort_uniq

    - Fix bug in d_rank_list_dup_sort_uniq
    - Add unit-tests for it

Required-githooks: true

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
