### PR TITLE
DAOS-9057 security: Don't consider delete a cont write perm

### DIFF
--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -538,7 +538,7 @@ filter_cont_capas_based_on_flags(uint64_t flags, uint64_t *capas)
 	if (flags & DAOS_COO_RO)
 		*capas &= CONT_CAPAS_RO_MASK;
 	else if (!(*capas & CONT_CAPAS_RO_MASK) ||
-		 !(*capas & ~CONT_CAPAS_RO_MASK))
+		 !(*capas & CONT_CAPAS_W_MASK))
 		/*
 		 * User requested RW - if they don't have permissions for both
 		 * read and write capas of some kind, we won't grant them any.

--- a/src/security/srv_internal.h
+++ b/src/security/srv_internal.h
@@ -48,13 +48,12 @@ extern char *ds_sec_server_socket_path;
 #define CONT_CAPAS_RO_MASK	(CONT_CAPA_READ_DATA |			\
 				 CONT_CAPA_GET_PROP |			\
 				 CONT_CAPA_GET_ACL)
-#define CONT_CAPAS_ALL		(CONT_CAPA_READ_DATA |			\
-				 CONT_CAPA_WRITE_DATA |			\
-				 CONT_CAPA_GET_PROP |			\
+#define CONT_CAPAS_W_MASK	(CONT_CAPA_WRITE_DATA |			\
 				 CONT_CAPA_SET_PROP |			\
-				 CONT_CAPA_GET_ACL |			\
 				 CONT_CAPA_SET_ACL |			\
-				 CONT_CAPA_SET_OWNER |			\
+				 CONT_CAPA_SET_OWNER)
+#define CONT_CAPAS_ALL		(CONT_CAPAS_RO_MASK |			\
+				 CONT_CAPAS_W_MASK |			\
 				 CONT_CAPA_DELETE)
 
 int ds_sec_validate_credentials(d_iov_t *creds, Auth__Token **token);

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -1750,11 +1750,6 @@ test_cont_get_capas_success(void **state)
 				     CONT_CAPA_SET_ACL |
 				     CONT_CAPA_GET_ACL |
 				     CONT_CAPA_SET_OWNER);
-	expect_cont_capas_with_perms(DAOS_ACL_PERM_READ |
-				     DAOS_ACL_PERM_DEL_CONT,
-				     DAOS_COO_RW,
-				     CONT_CAPA_READ_DATA |
-				     CONT_CAPA_DELETE);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_CONT_ALL,
 				     DAOS_COO_RW,
 				     CONT_CAPAS_ALL);
@@ -1776,6 +1771,7 @@ test_cont_get_capas_denied(void **state)
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_PROP, DAOS_COO_RW, 0);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_ACL, DAOS_COO_RW, 0);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_OWNER, DAOS_COO_RW, 0);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_DEL_CONT, DAOS_COO_RW, 0);
 }
 
 

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1143,6 +1143,10 @@ co_open_access(void **state)
 	expect_cont_open_access(arg, DAOS_ACL_PERM_READ, DAOS_COO_RW,
 				-DER_NO_PERM);
 
+	print_message("cont ACL gives the user RO + DEL, they want RW\n");
+	expect_cont_open_access(arg, DAOS_ACL_PERM_READ | DAOS_ACL_PERM_DEL_CONT, DAOS_COO_RW,
+				-DER_NO_PERM);
+
 	print_message("cont ACL gives the user RO, they want RO\n");
 	expect_cont_open_access(arg, DAOS_ACL_PERM_READ, DAOS_COO_RO,
 				0);


### PR DESCRIPTION
- Don't allow containers to be opened with RW access if the only non-read permission is "Delete Container." Delete is not performed while holding the container handle, so it isn't the same as other data/metadata write permissions.

Features: security

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
