### PR TITLE
DAOS-5936 control: Remove -u flag from daos cont create

### DIFF
--- a/docs/user/container.md
+++ b/docs/user/container.md
@@ -764,15 +764,15 @@ explicitly granted by the `GROUP@` entry in the ACL.
 #### Setting Ownership at Creation
 
 The default owner user and group are the effective user and group of the user
-creating the container. However, a specific user and/or group may be specified
-at container creation time.
+creating the container. However, an owner-group may be specified at container
+creation time.
 
 ```bash
-$ daos cont create $DAOS_POOL --label $DAOS_CONT --user=<owner-user> --group=<owner-group>
+$ daos cont create --group=<owner-group> $DAOS_POOL $DAOS_CONT
 ```
 
-The user and group names are case sensitive and must be formatted as
-[DAOS ACL user/group principals](https://docs.daos.io/v2.4/overview/security/#principal).
+The group names are case sensitive and must be formatted as
+[DAOS ACL group principals](https://docs.daos.io/v2.4/overview/security/#principal).
 
 #### Changing Ownership
 

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -226,7 +226,6 @@ type containerCreateCmd struct {
 	Properties      CreatePropertiesFlag `long:"properties" description:"container properties"`
 	Mode            ConsModeFlag         `long:"mode" short:"M" description:"DFS consistency mode"`
 	ACLFile         string               `long:"acl-file" short:"A" description:"input file containing ACL"`
-	User            ui.ACLPrincipalFlag  `long:"user" short:"u" description:"user who will own the container (username@[domain])"`
 	Group           ui.ACLPrincipalFlag  `long:"group" short:"g" description:"group who will own the container (group@[domain])"`
 	Args            struct {
 		Label string `positional-arg-name:"label"`
@@ -283,10 +282,6 @@ func (cmd *containerCreateCmd) Execute(_ []string) (err error) {
 
 	ap.c_op = C.CONT_CREATE
 
-	if cmd.User != "" {
-		ap.user = C.CString(cmd.User.String())
-		defer freeString(ap.user)
-	}
 	if cmd.Group != "" {
 		ap.group = C.CString(cmd.Group.String())
 		defer freeString(ap.group)


### PR DESCRIPTION
The DAOS tool should not allow users to create containers for users other than themselves. If the owner decides to transfer ownership later, they can use the daos cont set-owner command.

It is still possible to:

- Create a container with a specified owner-group via the daos tool.
- Create a container with a specified owner-user via the C API.

Features: control container

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
