### PR TITLE
DAOS-12824 dtx: reindex committed DTX entries

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1660,14 +1660,17 @@ cont_close_hdl(uuid_t cont_hdl_uuid)
 	cont_child = hdl->sch_cont;
 	if (cont_child != NULL) {
 		D_DEBUG(DB_MD, DF_CONT": closing (%d): hdl="DF_UUID"\n",
-			DP_CONT(cont_child->sc_pool->spc_uuid,
-				cont_child->sc_uuid),
+			DP_CONT(cont_child->sc_pool->spc_uuid, cont_child->sc_uuid),
 			cont_child->sc_open, DP_UUID(cont_hdl_uuid));
 
 		D_ASSERT(cont_child->sc_open > 0);
 		cont_child->sc_open--;
 		if (cont_child->sc_open == 0)
 			dtx_cont_close(cont_child);
+
+		D_DEBUG(DB_MD, DF_CONT": closed (%d): hdl="DF_UUID"\n",
+			DP_CONT(cont_child->sc_pool->spc_uuid, cont_child->sc_uuid),
+			cont_child->sc_open, DP_UUID(cont_hdl_uuid));
 	}
 
 	cont_hdl_put_internal(&tls->dt_cont_hdl_hash, hdl);

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -637,13 +637,11 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 	}
 
 	if (myrank == daos_fail_value_get() && DAOS_FAIL_CHECK(DAOS_DTX_SRV_RESTART)) {
-		uint64_t	hint = 0;
-
 		dss_set_start_epoch();
 		vos_dtx_cache_reset(cont->sc_hdl, true);
 
 		while (1) {
-			rc = vos_dtx_cmt_reindex(cont->sc_hdl, &hint);
+			rc = vos_dtx_cmt_reindex(cont->sc_hdl);
 			if (rc > 0)
 				break;
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -194,15 +194,13 @@ vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch);
  * Establish the indexed committed DTX table in DRAM.
  *
  * \param coh	[IN]		Container open handle.
- * \param hint	[IN,OUT]	Pointer to the address (offset in SCM) that
- *				contains committed DTX entries to be handled.
  *
  * \return	Zero on success, need further re-index.
  *		Positive, re-index is completed.
  *		Negative value if error.
  */
 int
-vos_dtx_cmt_reindex(daos_handle_t coh, void *hint);
+vos_dtx_cmt_reindex(daos_handle_t coh);
 
 /**
  * Cleanup local DTX when local modification failed.

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -372,6 +372,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 		cont->vc_cmt_dtx_indexed = 1;
 	else
 		cont->vc_cmt_dtx_indexed = 0;
+	cont->vc_cmt_dtx_reindex_pos = cont->vc_cont_df->cd_dtx_committed_head;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_act_list);
 	cont->vc_dtx_committed_count = 0;
 	gc_check_cont(cont);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2309,6 +2309,7 @@ vos_dtx_aggregate(daos_handle_t coh)
 	struct vos_dtx_blob_df		*tmp;
 	uint64_t			 epoch;
 	umem_off_t			 dbd_off;
+	umem_off_t			 next = UMOFF_NULL;
 	int				 rc;
 	int				 i;
 
@@ -2368,7 +2369,8 @@ vos_dtx_aggregate(daos_handle_t coh)
 		cont_df->cd_newest_aggregated = epoch;
 	}
 
-	tmp = umem_off2ptr(umm, dbd->dbd_next);
+	next = dbd->dbd_next;
+	tmp = umem_off2ptr(umm, next);
 	if (tmp == NULL) {
 		/* The last blob for committed DTX blob. */
 		D_ASSERT(cont_df->cd_dtx_committed_tail ==
@@ -2406,7 +2408,7 @@ vos_dtx_aggregate(daos_handle_t coh)
 		goto out;
 	}
 
-	cont_df->cd_dtx_committed_head = dbd->dbd_next;
+	cont_df->cd_dtx_committed_head = next;
 
 	rc = umem_free(umm, dbd_off);
 
@@ -2415,6 +2417,8 @@ out:
 	if (rc != 0)
 		D_ERROR("Failed to aggregate DTX blob "UMOFF_PF": "
 			DF_RC"\n", UMOFF_P(dbd_off), DP_RC(rc));
+	else if (cont->vc_cmt_dtx_reindex_pos == dbd_off)
+		cont->vc_cmt_dtx_reindex_pos = next;
 
 	return rc;
 }
@@ -2645,14 +2649,12 @@ out:
 }
 
 int
-vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
+vos_dtx_cmt_reindex(daos_handle_t coh)
 {
 	struct umem_instance		*umm;
 	struct vos_container		*cont;
-	struct vos_cont_df		*cont_df;
 	struct vos_dtx_cmt_ent		*dce;
 	struct vos_dtx_blob_df		*dbd;
-	umem_off_t			*dbd_off = hint;
 	d_iov_t				 kiov;
 	d_iov_t				 riov;
 	int				 rc = 0;
@@ -2665,13 +2667,7 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
 		return 1;
 
 	umm = vos_cont2umm(cont);
-	cont_df = cont->vc_cont_df;
-
-	if (umoff_is_null(*dbd_off))
-		dbd = umem_off2ptr(umm, cont_df->cd_dtx_committed_head);
-	else
-		dbd = umem_off2ptr(umm, *dbd_off);
-
+	dbd = umem_off2ptr(umm, cont->vc_cmt_dtx_reindex_pos);
 	if (dbd == NULL)
 		D_GOTO(out, rc = 1);
 
@@ -2714,11 +2710,13 @@ vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
 	if (dbd->dbd_count < dbd->dbd_cap || umoff_is_null(dbd->dbd_next))
 		D_GOTO(out, rc = 1);
 
-	*dbd_off = dbd->dbd_next;
+	cont->vc_cmt_dtx_reindex_pos = dbd->dbd_next;
 
 out:
-	if (rc > 0)
+	if (rc > 0) {
+		cont->vc_cmt_dtx_reindex_pos = UMOFF_NULL;
 		cont->vc_cmt_dtx_indexed = 1;
+	}
 
 	return rc;
 }
@@ -3058,6 +3056,7 @@ cmt:
 		cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
 		cont->vc_dtx_committed_count = 0;
 		cont->vc_cmt_dtx_indexed = 0;
+		cont->vc_cmt_dtx_reindex_pos = cont->vc_cont_df->cd_dtx_committed_head;
 	}
 
 	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_CMT_TABLE, 0, DTX_BTREE_ORDER, &uma,

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -279,6 +279,8 @@ struct vos_container {
 	uint64_t		vc_agg_nospc_ts;
 	/* Last timestamp when IO reporting ENOSPACE */
 	uint64_t		vc_io_nospc_ts;
+	/* The (next) position for committed DTX entries reindex. */
+	umem_off_t		vc_cmt_dtx_reindex_pos;
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,


### PR DESCRIPTION
Change the process for committed DTX entries reindex as self-traced by the vos container inside VOS. Then even if related reindex ULT is stopped and restarted again and again (for container open/close, DTX resync/check), the committed DTX entries reindex process will always resume from former paused point instead of from scratch.

There is race between DTX reindex ULT start and stop. If someone is trying to stop the reindex process, then next starting reindex need to wait instead of return directly.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
