### PR TITLE
DAOS-12826 control: Handle empty storage tier in config unmarshal (#1…

### DIFF
--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -933,7 +933,7 @@ func TestServerConfig_Parsing(t *testing.T) {
 			expCheck: func(c *Server) error {
 				nr := len(c.Engines[0].Storage.Tiers)
 				if nr != 1 {
-					return errors.Errorf("want %d storage tiers, got %d", 1, nr)
+					return errors.Errorf("want 1 storage tier, got %d", nr)
 				}
 				return nil
 			},
@@ -945,7 +945,7 @@ func TestServerConfig_Parsing(t *testing.T) {
 			expCheck: func(c *Server) error {
 				nr := len(c.Engines[0].Storage.Tiers)
 				if nr != 1 {
-					return errors.Errorf("want %d storage tiers, got %d", 1, nr)
+					return errors.Errorf("want 1 storage tier, got %d", nr)
 				}
 				return nil
 			},
@@ -957,7 +957,7 @@ func TestServerConfig_Parsing(t *testing.T) {
 			expCheck: func(c *Server) error {
 				nr := len(c.Engines[0].Storage.Tiers)
 				if nr != 1 {
-					return errors.Errorf("want %d storage tiers, got %d", 1, nr)
+					return errors.Errorf("want 1 storage tier, got %d", nr)
 				}
 				return nil
 			},
@@ -969,7 +969,7 @@ func TestServerConfig_Parsing(t *testing.T) {
 			expCheck: func(c *Server) error {
 				nr := len(c.Engines[0].Storage.Tiers)
 				if nr != 2 {
-					return errors.Errorf("want %d storage tiers, got %d", 2, nr)
+					return errors.Errorf("want 2 storage tiers, got %d", nr)
 				}
 				return nil
 			},
@@ -985,7 +985,7 @@ func TestServerConfig_Parsing(t *testing.T) {
 			expCheck: func(c *Server) error {
 				nr := len(c.Engines[0].Storage.Tiers)
 				if nr != 2 {
-					return errors.Errorf("want %d storage tiers, got %d", 2, nr)
+					return errors.Errorf("want 2 storage tiers, got %d", nr)
 				}
 				want := storage.MustNewBdevBusRange("0x00-0x80")
 				got := c.Engines[0].Storage.Tiers.BdevConfigs()[0].Bdev.BusidRange
@@ -1040,6 +1040,18 @@ func TestServerConfig_Parsing(t *testing.T) {
 			inTxt:       "disable_vfio: true",
 			outTxt:      "enable_vmd: true",
 			expParseErr: FaultConfigVMDSettingDuplicate,
+		},
+		"additional empty storage tier": {
+			// Add empty storage tier to engine-0 and verify it is ignored.
+			inTxt:  "    bdev_busid_range: 0x80-0x8f",
+			outTxt: "  -",
+			expCheck: func(c *Server) error {
+				nr := len(c.Engines[0].Storage.Tiers)
+				if nr != 2 {
+					return errors.Errorf("want 2 storage tiers, got %d", nr)
+				}
+				return nil
+			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -241,12 +241,17 @@ func (tcs *TierConfigs) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
+	tid := 0
+	tmp2 := make([]*TierConfig, 0, len(tmp))
 	for i := range tmp {
-		if tmp[i].Tier == 0 {
-			tmp[i].Tier = i
+		if tmp[i] == nil {
+			continue
 		}
+		tmp[i].Tier = tid
+		tmp2 = append(tmp2, tmp[i])
+		tid++
 	}
-	*tcs = tmp
+	*tcs = tmp2
 
 	return nil
 }

--- a/src/control/server/storage/config_test.go
+++ b/src/control/server/storage/config_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -315,6 +315,147 @@ func TestStorage_parsePCIBusRange(t *testing.T) {
 
 			test.AssertEqual(t, tc.expBegin, begin, "bad beginning limit")
 			test.AssertEqual(t, tc.expEnd, end, "bad ending limit")
+		})
+	}
+}
+
+func TestStorage_TierConfigs_FromYAML(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input    string
+		expTiers TierConfigs
+		expErr   error
+	}{
+		"single tier": {
+			input: `
+storage:
+-
+  class: ram
+  scm_mount: /mnt/daos/1
+  scm_size: 16
+`,
+			expTiers: TierConfigs{
+				&TierConfig{
+					Class: ClassRam,
+					Scm: ScmConfig{
+						MountPoint:  "/mnt/daos/1",
+						RamdiskSize: 16,
+					},
+				},
+			},
+		},
+		"empty tier first": {
+			input: `
+storage:
+-
+-
+  class: ram
+  scm_mount: /mnt/daos/1
+  scm_size: 16
+-
+  class: dcpm
+`,
+			expTiers: TierConfigs{
+				&TierConfig{
+					Class: ClassRam,
+					Scm: ScmConfig{
+						MountPoint:  "/mnt/daos/1",
+						RamdiskSize: 16,
+					},
+				},
+				&TierConfig{
+					Tier:  1,
+					Class: ClassDcpm,
+				},
+			},
+		},
+		"empty tier middle": {
+			input: `
+storage:
+-
+  class: ram
+  scm_mount: /mnt/daos/1
+  scm_size: 16
+-
+-
+  class: dcpm
+`,
+			expTiers: TierConfigs{
+				&TierConfig{
+					Class: ClassRam,
+					Scm: ScmConfig{
+						MountPoint:  "/mnt/daos/1",
+						RamdiskSize: 16,
+					},
+				},
+				&TierConfig{
+					Tier:  1,
+					Class: ClassDcpm,
+				},
+			},
+		},
+		"empty tier last": {
+			input: `
+storage:
+-
+  class: ram
+  scm_mount: /mnt/daos/1
+  scm_size: 16
+-
+  class: dcpm
+-
+`,
+			expTiers: TierConfigs{
+				&TierConfig{
+					Class: ClassRam,
+					Scm: ScmConfig{
+						MountPoint:  "/mnt/daos/1",
+						RamdiskSize: 16,
+					},
+				},
+				&TierConfig{
+					Tier:  1,
+					Class: ClassDcpm,
+				},
+			},
+		},
+		"two empty tiers last": {
+			input: `
+storage:
+-
+  class: ram
+  scm_mount: /mnt/daos/1
+  scm_size: 16
+-
+  class: dcpm
+-
+-
+`,
+			expTiers: TierConfigs{
+				&TierConfig{
+					Class: ClassRam,
+					Scm: ScmConfig{
+						MountPoint:  "/mnt/daos/1",
+						RamdiskSize: 16,
+					},
+				},
+				&TierConfig{
+					Tier:  1,
+					Class: ClassDcpm,
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := new(Config)
+			err := yaml.Unmarshal([]byte(tc.input), cfg)
+			test.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expTiers, cfg.Tiers, defConfigCmpOpts()...); diff != "" {
+				t.Fatalf("bad props (-want +got):\n%s", diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
…1647)

Avoid segfault when control-plane parses a server config file with an
empty storage tier yaml list entry by ignoring nil when iterating
tiers during custom unmarshal.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
