### PR TITLE
DAOS-12637 dfs: update dfs checker to use exclusive container open

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -6684,6 +6684,7 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 	struct timespec		now;
 	uid_t			uid = geteuid();
 	gid_t			gid = getegid();
+	unsigned int		co_flags = DAOS_COO_EX;
 	int			rc, rc2;
 
 	if (flags & DFS_CHECK_RELINK && flags & DFS_CHECK_REMOVE) {
@@ -6691,8 +6692,10 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 		return EINVAL;
 	}
 
-	/** TODO - Update to use Exclusive open when available */
-	rc = daos_cont_open(poh, cont, DAOS_COO_RW, &coh, NULL, NULL);
+	if (flags & DFS_CHECK_EVICT_ALL)
+		co_flags |= DAOS_COO_EVICT_ALL;
+
+	rc = daos_cont_open(poh, cont, co_flags, &coh, NULL, NULL);
 	if (rc) {
 		D_ERROR("daos_cont_open() failed "DF_RC"\n", DP_RC(rc));
 		return daos_der2errno(rc);

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -42,6 +42,7 @@ type containerCmd struct {
 	Stat        containerStatCmd        `command:"stat" description:"get container statistics"`
 	Clone       containerCloneCmd       `command:"clone" description:"clone a container"`
 	Check       containerCheckCmd       `command:"check" description:"check objects' consistency in a container"`
+	Evict       containerEvictCmd       `command:"evict" description:"Evict open handles on a container"`
 
 	ListAttributes  containerListAttrsCmd `command:"list-attr" alias:"list-attrs" alias:"lsattr" description:"list container user-defined attributes"`
 	DeleteAttribute containerDelAttrCmd   `command:"del-attr" alias:"delattr" description:"delete container user-defined attribute"`
@@ -1441,6 +1442,35 @@ func (cmd *containerLinkCmd) Execute(_ []string) (err error) {
 			"failed to link container %s in the namespace",
 			cmd.ContainerID())
 	}
+
+	return nil
+}
+
+type containerEvictCmd struct {
+	existingContainerCmd
+
+	EvictAll bool `long:"evict-all" short:"a" description:"evict all handles from all users"`
+}
+
+func (cmd *containerEvictCmd) Execute(_ []string) (err error) {
+	ap, deallocCmdArgs, err := allocCmdArgs(cmd.Logger)
+	if err != nil {
+		return err
+	}
+	defer deallocCmdArgs()
+
+	var co_flags C.uint
+	if cmd.EvictAll {
+		co_flags = C.DAOS_COO_EVICT_ALL | C.DAOS_COO_EX
+	} else {
+		co_flags = C.DAOS_COO_EVICT | C.DAOS_COO_RO
+	}
+
+	cleanup, err := cmd.resolveAndConnect(co_flags, ap)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
 	return nil
 }

--- a/src/control/cmd/daos/flags.go
+++ b/src/control/cmd/daos/flags.go
@@ -256,6 +256,8 @@ func (f *FsCheckFlag) UnmarshalFlag(fv string) error {
 		switch strings.TrimSpace(strings.ToLower(cflag)) {
 		case "print":
 			f.Flags |= C.DFS_CHECK_PRINT
+		case "evict":
+			f.Flags |= C.DFS_CHECK_EVICT_ALL
 		case "remove":
 			f.Flags |= C.DFS_CHECK_REMOVE
 		case "relink":

--- a/src/control/cmd/daos/flags_test.go
+++ b/src/control/cmd/daos/flags_test.go
@@ -520,6 +520,20 @@ func TestFlags_FsCheckFlag(t *testing.T) {
 				Flags: 13,
 			},
 		},
+		"valid16": {
+			arg: "evict",
+			expFlag: &FsCheckFlag{
+				Set:   true,
+				Flags: 16,
+			},
+		},
+		"valid29": {
+			arg: "print,verify,relink,evict",
+			expFlag: &FsCheckFlag{
+				Set:   true,
+				Flags: 29,
+			},
+		},
 		"untrimmed, upper case": {
 			arg: "print, VeRiFy,relink",
 			expFlag: &FsCheckFlag{

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -1144,6 +1144,8 @@ enum {
 	DFS_CHECK_RELINK	= (1 << 2),
 	/** verify data consistency of each oid in the container (note that this will be slow) */
 	DFS_CHECK_VERIFY	= (1 << 3),
+	/** Evict all open container handles to ensure exclusive open works for the checker */
+	DFS_CHECK_EVICT_ALL	= (1 << 4),
 };
 
 /**


### PR DESCRIPTION
- the dfs checker and other related functions will now user exclusive container open to access the file.
- add an option for evicting all user handles with the exclusive open to ensure the checker does not fail with EBUSY.
- add a new container command that will evict open container handles.
- update unit test and nlt test

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
