### PR TITLE
DAOS-12719 test: Ignore missing expected stack trace on el7

### DIFF
--- a/src/tests/ftest/harness/core_files.py
+++ b/src/tests/ftest/harness/core_files.py
@@ -34,7 +34,7 @@ class HarnessCoreFilesTest(TestWithServers):
         that it will create a core file, allowing the core file collection code
         in launch.py to be tested.
 
-        :avocado: tags=all
+        :avocado: tags=all,pr
         :avocado: tags=vm
         :avocado: tags=harness,core_files
         :avocado: tags=HarnessCoreFilesTest,test_core_files

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2772,15 +2772,22 @@ class Launch():
             self._fail_test(self.result.tests[-1], "Process", message, sys.exc_info())
             return 256
 
-        if not core_file_processing.is_el7():
-            if corefiles_processed > 0 and str(test) not in TEST_EXPECT_CORE_FILES:
-                message = "One or more core files detected after test execution"
-                self._fail_test(self.result.tests[-1], "Process", message, None)
-                return 2048
-            if corefiles_processed == 0 and str(test) in TEST_EXPECT_CORE_FILES:
-                message = "No core files detected when expected"
-                self._fail_test(self.result.tests[-1], "Process", message, None)
-                return 256
+        if core_file_processing.is_el7() and str(test) in TEST_EXPECT_CORE_FILES:
+            logger.debug(
+                "Skipping checking core file detection for %s as it is not supported on this OS",
+                str(test))
+            return 0
+
+        if corefiles_processed > 0 and str(test) not in TEST_EXPECT_CORE_FILES:
+            message = "One or more core files detected after test execution"
+            self._fail_test(self.result.tests[-1], "Process", message, None)
+            return 2048
+
+        if corefiles_processed == 0 and str(test) in TEST_EXPECT_CORE_FILES:
+            message = "No core files detected when expected"
+            self._fail_test(self.result.tests[-1], "Process", message, None)
+            return 256
+
         return 0
 
     def _rename_avocado_test_dir(self, test, jenkinslog):

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2772,14 +2772,15 @@ class Launch():
             self._fail_test(self.result.tests[-1], "Process", message, sys.exc_info())
             return 256
 
-        if corefiles_processed > 0 and str(test) not in TEST_EXPECT_CORE_FILES:
-            message = "One or more core files detected after test execution"
-            self._fail_test(self.result.tests[-1], "Process", message, None)
-            return 2048
-        if corefiles_processed == 0 and str(test) in TEST_EXPECT_CORE_FILES:
-            message = "No core files detected when expected"
-            self._fail_test(self.result.tests[-1], "Process", message, None)
-            return 256
+        if not core_file_processing.is_el7():
+            if corefiles_processed > 0 and str(test) not in TEST_EXPECT_CORE_FILES:
+                message = "One or more core files detected after test execution"
+                self._fail_test(self.result.tests[-1], "Process", message, None)
+                return 2048
+            if corefiles_processed == 0 and str(test) in TEST_EXPECT_CORE_FILES:
+                message = "No core files detected when expected"
+                self._fail_test(self.result.tests[-1], "Process", message, None)
+                return 256
         return 0
 
     def _rename_avocado_test_dir(self, test, jenkinslog):


### PR DESCRIPTION
We do not generate stack traces on el7 so the harness/core_test.py should not expect to see a stack trace when run on el7.

Also adding the pr taq to the harness/core_test.py to get early detection of any issues in stack trace generation.

Skip-unit-tests: true
Skip-func-hw-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
