### PR TITLE
DAOS-12412 test: Allow for log collection w/ No space left on device

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -574,6 +574,9 @@ class TestInfo():
 class Launch():
     """Class to launch avocado tests."""
 
+    RESULTS_DIRS = (
+        "daos_configs", "daos_logs", "cart_logs", "daos_dumps", "valgrind_logs", "stacktraces")
+
     def __init__(self, name, mode):
         """Initialize a Launch object.
 
@@ -2032,6 +2035,9 @@ class Launch():
             f"ls -al {test_dir}",
             f"mkdir -p {user_dir}"
         ]
+        # Predefine the sub directories used to collect the files process()/_archive_files()
+        for directory in self.RESULTS_DIRS:
+            commands.append(f"mkdir -p {user_dir}/{directory}")
         for command in commands:
             if not run_remote(logger, test.host_info.all_hosts, command).passed:
                 message = "Error setting up the DAOS_TEST_LOG_DIR directory on all hosts"
@@ -2186,7 +2192,7 @@ class Launch():
             remote_files = OrderedDict()
             remote_files["local configuration files"] = {
                 "source": daos_test_log_dir,
-                "destination": os.path.join(self.job_results_dir, "latest", "daos_configs"),
+                "destination": os.path.join(self.job_results_dir, "latest", self.RESULTS_DIRS[0]),
                 "pattern": "*_*_*.yaml",
                 "hosts": self.local_host,
                 "depth": 1,
@@ -2194,7 +2200,7 @@ class Launch():
             }
             remote_files["remote configuration files"] = {
                 "source": os.path.join(os.sep, "etc", "daos"),
-                "destination": os.path.join(self.job_results_dir, "latest", "daos_configs"),
+                "destination": os.path.join(self.job_results_dir, "latest", self.RESULTS_DIRS[0]),
                 "pattern": "daos_*.yml",
                 "hosts": test.host_info.all_hosts,
                 "depth": 1,
@@ -2202,7 +2208,7 @@ class Launch():
             }
             remote_files["daos log files"] = {
                 "source": daos_test_log_dir,
-                "destination": os.path.join(self.job_results_dir, "latest", "daos_logs"),
+                "destination": os.path.join(self.job_results_dir, "latest", self.RESULTS_DIRS[1]),
                 "pattern": "*log*",
                 "hosts": test.host_info.all_hosts,
                 "depth": 1,
@@ -2210,7 +2216,7 @@ class Launch():
             }
             remote_files["cart log files"] = {
                 "source": daos_test_log_dir,
-                "destination": os.path.join(self.job_results_dir, "latest", "cart_logs"),
+                "destination": os.path.join(self.job_results_dir, "latest", self.RESULTS_DIRS[2]),
                 "pattern": "*log*",
                 "hosts": test.host_info.all_hosts,
                 "depth": 2,
@@ -2218,7 +2224,7 @@ class Launch():
             }
             remote_files["ULTs stacks dump files"] = {
                 "source": os.path.join(os.sep, "tmp"),
-                "destination": os.path.join(self.job_results_dir, "latest", "daos_dumps"),
+                "destination": os.path.join(self.job_results_dir, "latest", self.RESULTS_DIRS[3]),
                 "pattern": "daos_dump*.txt*",
                 "hosts": test.host_info.servers.hosts,
                 "depth": 1,
@@ -2226,7 +2232,7 @@ class Launch():
             }
             remote_files["valgrind log files"] = {
                 "source": os.environ.get("DAOS_TEST_SHARED_DIR", DEFAULT_DAOS_TEST_SHARED_DIR),
-                "destination": os.path.join(self.job_results_dir, "latest", "valgrind_logs"),
+                "destination": os.path.join(self.job_results_dir, "latest", self.RESULTS_DIRS[4]),
                 "pattern": "valgrind*",
                 "hosts": test.host_info.servers.hosts,
                 "depth": 1,
@@ -2235,7 +2241,8 @@ class Launch():
             for index, hosts in enumerate(core_files):
                 remote_files[f"core files {index + 1}/{len(core_files)}"] = {
                     "source": core_files[hosts]["path"],
-                    "destination": os.path.join(self.job_results_dir, "latest", "stacktraces"),
+                    "destination": os.path.join(
+                        self.job_results_dir, "latest", self.RESULTS_DIRS[5]),
                     "pattern": core_files[hosts]["pattern"],
                     "hosts": NodeSet(hosts),
                     "depth": 1,
@@ -2711,7 +2718,7 @@ class Launch():
             tmp_copy_dir = os.path.join(source, tmp_copy_dir)
             sudo_command = ""
 
-        # Create a temporary remote directory
+        # Create a temporary remote directory - should already exist, see _setup_test_directory()
         command = f"mkdir -p {tmp_copy_dir}"
         if not run_remote(logger, hosts, command).passed:
             message = f"Error creating temporary remote copy directory {tmp_copy_dir}"


### PR DESCRIPTION
Test log collection can fail if there is not enough space left on the remote hosts to make a directory which is then used to clush --rcopy the files to the launch host.  To avoid this ituation these directories will be created prior to running the tests.

Skip-unit-tests:true
Test-tag-hw-large: dfs_test
Test-provider-hw-large: ucx+dc_x

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
