### PR TITLE
DAOS-12595 dtx: support CPU yield during local TX commit

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -821,7 +821,6 @@ dtx_handle_reinit(struct dtx_handle *dth)
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
 	dth->dth_cos_done = 0;
-	dth->dth_verified = 0;
 	dth->dth_aborted = 0;
 
 	dth->dth_op_seq = 0;
@@ -875,7 +874,6 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_for_migration = migration ? 1 : 0;
 	dth->dth_ignore_uncommitted = ignore_uncommitted ? 1 : 0;
 	dth->dth_prepared = prepared ? 1 : 0;
-	dth->dth_verified = 0;
 	dth->dth_aborted = 0;
 	dth->dth_already = 0;
 	dth->dth_need_validation = 0;
@@ -995,6 +993,13 @@ out:
 	return 0;
 }
 
+void
+dtx_renew_epoch(struct dtx_epoch *epoch, struct dtx_handle *dth)
+{
+	dth->dth_epoch = epoch->oe_value;
+	dth->dth_epoch_bound = dtx_epoch_bound(epoch);
+}
+
 /**
  * Initialize the DTX handle for per modification based part.
  *
@@ -1085,7 +1090,7 @@ out:
  * \param dti_cos	[IN]	The DTX array to be committed because of shared.
  * \param dti_cos_cnt	[IN]	The @dti_cos array size.
  * \param tgts		[IN]	targets for distribute transaction.
- * \param tgt_cnt	[IN]	number of targets.
+ * \param tgt_cnt	[IN]	number of targets (not count the leader itself).
  * \param flags		[IN]	See dtx_flags.
  * \param mbs		[IN]	DTX participants information.
  * \param p_dlh		[OUT]	Pointer to the DTX handle.
@@ -1134,9 +1139,9 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 		rc = vos_dtx_attach(dth, false, (flags & DTX_PREPARED) ? true : false);
 
 	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, leader "
-		DF_UOID", dti_cos_cnt %d, flags %x: "DF_RC"\n",
+		DF_UOID", dti_cos_cnt %d, tgt_cnt %d, flags %x: "DF_RC"\n",
 		DP_DTI(dti), sub_modification_cnt, dth->dth_ver,
-		DP_UOID(*leader_oid), dti_cos_cnt, flags, DP_RC(rc));
+		DP_UOID(*leader_oid), dti_cos_cnt, tgt_cnt, flags, DP_RC(rc));
 
 	if (rc != 0)
 		D_FREE(dlh);
@@ -1192,44 +1197,58 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 
 	dtx_shares_fini(dth);
 
-	if (unlikely(result == -DER_ALREADY))
-		result = 0;
+	if (daos_is_zero_dti(&dth->dth_xid) || unlikely(result == -DER_ALREADY))
+		goto out;
 
-	if (result == 0 && rc == 0 && unlikely(coh->sch_closed)) {
+	if (unlikely(coh->sch_closed)) {
 		D_ERROR("Cont hdl "DF_UUID" is closed/evicted unexpectedly\n",
 			DP_UUID(coh->sch_uuid));
-		result = -DER_IO;
+		if (result == -DER_AGAIN || result == -DER_INPROGRESS || result == -DER_TIMEDOUT ||
+		    result == -DER_STALE || daos_crt_network_error(result))
+			result = -DER_IO;
+		goto abort;
 	}
 
-	if (daos_is_zero_dti(&dth->dth_xid))
-		D_GOTO(out, result = result < 0 ? result : rc);
+	/* For solo transaction, the validation has already been processed inside vos
+	 * when necessary. That is enough, do not need to revalid again.
+	 */
+	if (dth->dth_solo)
+		goto out;
 
 	if (dth->dth_need_validation) {
 		/* During waiting for bulk data transfer or other non-leaders, the DTX
 		 * status may be changes by others (such as DTX resync or DTX refresh)
-		 * by race. Let's check it.
+		 * by race. Let's check it before handling the case of 'result < 0' to
+		 * avoid aborting 'ready' one.
 		 */
 		status = vos_dtx_validation(dth);
-		if (unlikely(status == DTX_ST_COMMITTED || status == DTX_ST_COMMITTABLE))
-			D_GOTO(out, result = 0);
+		if (unlikely(status == DTX_ST_COMMITTED || status == DTX_ST_COMMITTABLE ||
+			     status == DTX_ST_COMMITTING))
+			D_GOTO(out, result = -DER_ALREADY);
 	}
 
-	if (result < 0 || rc < 0 || dth->dth_solo)
-		D_GOTO(abort, result = result < 0 ? result : rc);
+	if (result < 0)
+		goto abort;
 
 	switch (status) {
 	case -1:
-	case DTX_ST_PREPARED:
 		break;
-	case DTX_ST_INITED:
-		if (dth->dth_modification_cnt == 0 || !dth->dth_active)
+	case DTX_ST_PREPARED:
+		if (likely(!dth->dth_aborted))
 			break;
 		/* Fall through */
-	case DTX_ST_ABORTED:
+	case DTX_ST_INITED:
+	case DTX_ST_PREPARING:
 		aborted = true;
-		D_GOTO(out, result = -DER_INPROGRESS);
+		result = -DER_AGAIN;
+		goto out;
+	case DTX_ST_ABORTED:
+	case DTX_ST_ABORTING:
+		aborted = true;
+		result = -DER_INPROGRESS;
+		goto out;
 	default:
-		D_ASSERT(0);
+		D_ASSERTF(0, "Unexpected DTX "DF_DTI" status %d\n", DP_DTI(&dth->dth_xid), status);
 	}
 
 	if ((!dth->dth_active && dth->dth_dist) || dth->dth_prepared || dtx_batched_ult_max == 0) {
@@ -1248,46 +1267,6 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 	if (!dth->dth_active) {
 		unpin = true;
 		D_GOTO(abort, result = 0);
-	}
-
-	/* If the DTX is started befoe DTX resync (for rebuild), then it is
-	 * possible that the DTX resync ULT may have aborted or committed
-	 * the DTX during current ULT waiting for other non-leaders' reply.
-	 * Let's check DTX status locally before marking as 'committable'.
-	 */
-	if (dth->dth_ver < cont->sc_dtx_resync_ver) {
-		rc = vos_dtx_check(cont->sc_hdl, &dth->dth_xid, NULL, NULL, NULL, NULL, false);
-		/* Committed by race, do nothing. */
-		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE)
-			D_GOTO(abort, result = 0);
-
-		/* The DTX is marked as 'corrupted' by DTX resync by race,
-		 * then let's abort it.
-		 */
-		if (rc == DTX_ST_CORRUPTED) {
-			D_WARN(DF_UUID": DTX "DF_DTI" is marked as corrupted "
-			       "by resync because of lost some participants\n",
-			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid));
-			D_GOTO(abort, result = -DER_TX_RESTART);
-		}
-
-		/* Aborted by race, restart it. */
-		if (rc == -DER_NONEXIST) {
-			D_WARN(DF_UUID": DTX "DF_DTI" is aborted with "
-			       "old epoch "DF_U64" by resync\n",
-			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
-			       dth->dth_epoch);
-			D_GOTO(abort, result = -DER_TX_RESTART);
-		}
-
-		if (rc != DTX_ST_PREPARED) {
-			D_ASSERTF(rc < 0, "Invalid status %d for DTX "DF_DTI"\n",
-				  rc, DP_DTI(&dth->dth_xid));
-
-			D_WARN(DF_UUID": Failed to check local DTX "DF_DTI" status: "DF_RC"\n",
-			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), DP_RC(rc));
-			D_GOTO(abort, result = rc);
-		}
 	}
 
 	if (DAOS_FAIL_CHECK(DAOS_DTX_SKIP_PREPARE))
@@ -1378,47 +1357,57 @@ sync:
 	}
 
 abort:
-	/* Some remote replica(s) ask retry. We do not make such replica
-	 * to locally retry for avoiding RPC timeout. The leader replica
-	 * will trigger retry globally without aborting 'prepared' ones.
+	/* If some remote participant ask retry. We do not make such participant
+	 * to locally retry for avoiding related forwarded RPC timeout, instead,
+	 * The leader will trigger retry globally without abort 'prepared' ones.
 	 */
 	if (unpin || (result < 0 && result != -DER_AGAIN && !dth->dth_solo)) {
-		/* Drop partial modification for distributed transaction. */
+		/* 1. Drop partial modification for distributed transaction.
+		 * 2. Remove the pinned DTX entry.
+		 */
 		vos_dtx_cleanup(dth, true);
 		dtx_abort(cont, &dth->dth_dte, dth->dth_epoch);
 		aborted = true;
 	}
 
 out:
+	if (unlikely(result == -DER_ALREADY))
+		result = 0;
+
 	if (!daos_is_zero_dti(&dth->dth_xid)) {
-		if (result < 0 && !aborted)
-			vos_dtx_cleanup(dth, true);
+		if (result < 0) {
+			/* 1. Drop partial modification for distributed transaction.
+			 * 2. Remove the pinned DTX entry.
+			 */
+			if (!aborted)
+				vos_dtx_cleanup(dth, true);
+
+			/* For solo DTX, just let client retry for DER_AGAIN case. */
+			if (result == -DER_AGAIN && dth->dth_solo)
+				result = -DER_INPROGRESS;
+		}
 
 		vos_dtx_rsrvd_fini(dth);
 		vos_dtx_detach(dth);
-
-		D_DEBUG(DB_IO,
-			"Stop the DTX "DF_DTI" ver %u, dkey %lu, %s, "
-			"%s participator(s), cos %d/%d: rc "DF_RC"\n",
-			DP_DTI(&dth->dth_xid), dth->dth_ver,
-			(unsigned long)dth->dth_dkey_hash,
-			dth->dth_sync ? "sync" : "async",
-			dth->dth_solo ? "single" : "multiple",
-			dth->dth_dti_cos_count,
-			dth->dth_cos_done ? dth->dth_dti_cos_count : 0,
-			DP_RC(result));
 	}
 
 	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
 
-	/* Local modification is done, then need to handle CoS cache. */
-	if (dth->dth_cos_done) {
+	/* If piggyback DTX has been done everywhere, then need to handle CoS cache.
+	 * It is harmless to keep some partially committed DTX entries in CoS cache.
+	 */
+	if (result == 0 && dth->dth_cos_done) {
 		int	i;
 
 		for (i = 0; i < dth->dth_dti_cos_count; i++)
 			dtx_del_cos(cont, &dth->dth_dti_cos[i],
 				    &dth->dth_leader_oid, dth->dth_dkey_hash);
 	}
+
+	D_DEBUG(DB_IO, "Stop the DTX "DF_DTI" ver %u, dkey %lu, %s, cos %d/%d: result "DF_RC"\n",
+		DP_DTI(&dth->dth_xid), dth->dth_ver, (unsigned long)dth->dth_dkey_hash,
+		dth->dth_sync ? "sync" : "async", dth->dth_dti_cos_count,
+		dth->dth_cos_done ? dth->dth_dti_cos_count : 0, DP_RC(result));
 
 	D_FREE(dth->dth_oid_array);
 	D_FREE(dlh);
@@ -1495,14 +1484,13 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 		if (dth->dth_dti_cos_count > 0 && !dth->dth_cos_done) {
 			int	rc;
 
-			/* XXX: For non-leader replica, even if we fail to
-			 *	make related modification for some reason,
-			 *	we still need to commit the DTXs for CoS.
-			 *	Because other replica may have already
-			 *	committed them. For leader case, it is
-			 *	not important even if we fail to commit
-			 *	the CoS DTXs, because they are still in
-			 *	CoS cache, and can be committed next time.
+			/* NOTE: For non-leader participant, even if we fail to make
+			 *	 related modification for some reason, we still need
+			 *	 to commit the piggyback DTXs those may have already
+			 *	 been committed on other participants.
+			 *	 For leader case, it is not important even if we fail
+			 *	 to commit them, because they are still in CoS cache,
+			 *	 and can be committed next time.
 			 */
 			rc = vos_dtx_commit(cont->sc_hdl, dth->dth_dti_cos,
 					    dth->dth_dti_cos_count, NULL);
@@ -1721,7 +1709,6 @@ dtx_cont_register(struct ds_cont_child *cont)
 
 	cont->sc_dtx_committable_count = 0;
 	D_INIT_LIST_HEAD(&cont->sc_dtx_cos_list);
-	cont->sc_dtx_resync_ver = cont->sc_pool->spc_map_version;
 	ds_cont_child_get(cont);
 	dbca->dbca_refs = 0;
 	dbca->dbca_cont = cont;

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -336,9 +336,9 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 		 * related RPC to the new leader, but such DTX is still not
 		 * committable yet. Here, the resync logic will abort it by
 		 * race during the new leader waiting for other replica(s).
-		 * The dtx_abort() logic will abort the local DTX firstly.
-		 * When the leader get replies from other replicas, it will
-		 * check whether local DTX is still valid or not.
+		 *
+		 * So when the leader get replies from other replicas, it
+		 * needs to check whether local DTX is still valid or not.
 		 *
 		 * If we abort multiple non-ready DTXs together, then there
 		 * is race that one DTX may become committable when we abort
@@ -652,7 +652,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 	}
 
 	cont->sc_dtx_resyncing = 1;
-	cont->sc_dtx_resync_ver = ver;
 	ABT_mutex_unlock(cont->sc_mutex);
 
 	dra.cont = cont;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1197,8 +1197,43 @@ dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
 	if (rc == 0) {
 		D_ASSERT(dth->dth_share_tbd_count == 0);
 
-		if (dth->dth_aborted) {
-			rc = -DER_CANCELED;
+		if (dth->dth_need_validation) {
+			rc = vos_dtx_validation(dth);
+			switch (rc) {
+			case DTX_ST_INITED:
+				if (!dth->dth_aborted)
+					break;
+				/* Fall through */
+			case DTX_ST_PREPARED:
+			case DTX_ST_PREPARING:
+				/* The DTX has been ever aborted and related resent RPC
+				 * is in processing. Return -DER_AGAIN to make this ULT
+				 * to retry sometime later without dtx_abort().
+				 */
+				rc = -DER_AGAIN;
+				break;
+			case DTX_ST_ABORTED:
+				D_ASSERT(dth->dth_ent == NULL);
+				/* Aborted, return -DER_INPROGRESS for client retry.
+				 *
+				 * Fall through.
+				 */
+			case DTX_ST_ABORTING:
+				rc = -DER_INPROGRESS;
+				break;
+			case DTX_ST_COMMITTED:
+			case DTX_ST_COMMITTING:
+			case DTX_ST_COMMITTABLE:
+				/* Aborted then prepared/committed by race.
+				 * Return -DER_ALREADY to avoid repeated modification.
+				 */
+				dth->dth_already = 1;
+				rc = -DER_ALREADY;
+				break;
+			default:
+				D_ASSERTF(0, "Unexpected DTX "DF_DTI" status %d\n",
+					  DP_DTI(&dth->dth_xid), rc);
+			}
 		} else {
 			vos_dtx_cleanup(dth, false);
 			dtx_handle_reinit(dth);

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -227,6 +227,12 @@ enum dtx_status {
 	DTX_ST_COMMITTABLE	= 4,
 	/** The DTX is aborted. */
 	DTX_ST_ABORTED		= 5,
+	/** The DTX is in aborting, non-persistent status. */
+	DTX_ST_ABORTING		= 6,
+	/** The DTX is in committing, non-persistent status. */
+	DTX_ST_COMMITTING	= 7,
+	/** The DTX is in preparing, non-persistent status. */
+	DTX_ST_PREPARING	= 8,
 };
 
 enum daos_dtx_alb {

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2022 Intel Corporation.
+ * (C) Copyright 2015-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -123,8 +123,6 @@ struct ds_cont_child {
 	struct btr_root		 sc_dtx_cos_btr;
 	/* The global list for committable DTXs. */
 	d_list_t		 sc_dtx_cos_list;
-	/* The pool map version for the latest DTX resync on the container. */
-	uint32_t		 sc_dtx_resync_ver;
 	/* the pool map version of updating DAOS_PROP_CO_STATUS prop */
 	uint32_t		 sc_status_pm_ver;
 	/* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -85,8 +85,6 @@ struct dtx_handle {
 					 dth_for_migration:1,
 					 /* Has prepared locally, for resend. */
 					 dth_prepared:1,
-					 /* The DTX handle has been verified. */
-					 dth_verified:1,
 					 /* The DTX handle is aborted. */
 					 dth_aborted:1,
 					 /* The modification is done by others. */
@@ -217,6 +215,8 @@ enum dtx_flags {
 	DTX_DROP_CMT		= (1 << 8),
 };
 
+void
+dtx_renew_epoch(struct dtx_epoch *epoch, struct dtx_handle *dth);
 int
 dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash);
 int

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -801,6 +801,15 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	       daos_size_t *size, struct dtx_handle *dth);
 
 /**
+ * Renew the epoch for the update handle.
+ *
+ * \param ioh	[IN]	The I/O handle for update.
+ * \param dth	[IN]	Pointer to the DTX handle.
+ */
+void
+vos_update_renew_epoch(daos_handle_t ioh, struct dtx_handle *dth);
+
+/**
  * Get the recx/epoch list.
  *
  * \param ioh	[IN]	The I/O handle.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1255,6 +1255,16 @@ obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_rw_out *orwo,
 	return false;
 }
 
+static inline uint64_t
+orf_to_dtx_epoch_flags(enum obj_rpc_flags orf_flags)
+{
+	uint64_t flags = 0;
+
+	if (orf_flags & ORF_EPOCH_UNCERTAIN)
+		flags |= DTX_EPOCH_UNCERTAIN;
+	return flags;
+}
+
 static int
 obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		      daos_iod_t *iods, struct dcs_iod_csums *iod_csums,
@@ -1630,25 +1640,48 @@ out:
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.
 	 */
-	if (rc == 0 && obj_rpc_is_update(rpc) && dth->dth_need_validation &&
-	    sched_cur_seq() != sched_seq) {
-		daos_epoch_t	epoch = 0;
-		int		rc1;
+	if (rc == 0 && obj_rpc_is_update(rpc) && sched_cur_seq() != sched_seq) {
+		if (dth->dth_need_validation) {
+			daos_epoch_t	epoch = 0;
+			int		rc1;
 
-		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &orw->orw_dti, &epoch, NULL);
-		switch (rc1) {
-		case 0:
-			orw->orw_epoch = epoch;
-			/* Fall through */
-		case -DER_ALREADY:
-			rc = -DER_ALREADY;
-			break;
-		case -DER_NONEXIST:
-		case -DER_EP_OLD:
-			break;
-		default:
-			rc = rc1;
-			break;
+			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &orw->orw_dti, &epoch, NULL);
+			switch (rc1) {
+			case 0:
+				orw->orw_epoch = epoch;
+				/* Fall through */
+			case -DER_ALREADY:
+				rc = -DER_ALREADY;
+				break;
+			case -DER_NONEXIST:
+			case -DER_EP_OLD:
+				break;
+			default:
+				rc = rc1;
+				break;
+			}
+		}
+
+		/* For solo update, it will be handled via one-phase transaction.
+		 * If there is CPU yield after its epoch generated, we will renew
+		 * the epoch, then we can use the epoch to sort related solo DTXs
+		 * based on their epochs.
+		 */
+		if (rc == 0 && dth->dth_solo) {
+			struct dtx_epoch	epoch;
+
+			epoch.oe_value = d_hlc_get();
+			epoch.oe_first = orw->orw_epoch_first;
+			epoch.oe_flags = orf_to_dtx_epoch_flags(orw->orw_flags);
+
+			dtx_renew_epoch(&epoch, dth);
+			vos_update_renew_epoch(ioh, dth);
+
+			D_DEBUG(DB_IO,
+				"update rpc %p renew epoch "DF_U64" => "DF_U64" for "DF_DTI"\n",
+				rpc, orw->orw_epoch, dth->dth_epoch, DP_DTI(&orw->orw_dti));
+
+			orw->orw_epoch = dth->dth_epoch;
 		}
 	}
 
@@ -2193,16 +2226,6 @@ obj_ioc_begin(daos_obj_id_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 failed:
 	obj_ioc_end(ioc, rc);
 	return rc;
-}
-
-static uint64_t
-orf_to_dtx_epoch_flags(enum obj_rpc_flags orf_flags)
-{
-	uint64_t flags = 0;
-
-	if (orf_flags & ORF_EPOCH_UNCERTAIN)
-		flags |= DTX_EPOCH_UNCERTAIN;
-	return flags;
 }
 
 void
@@ -2822,6 +2845,7 @@ again2:
 		orw->orw_flags |= ORF_RESEND;
 		need_abort = true;
 		d_tm_inc_counter(opm->opm_update_retry, 1);
+		ABT_thread_yield();
 		goto again1;
 	default:
 		break;
@@ -3664,6 +3688,7 @@ again2:
 	case -DER_AGAIN:
 		opi->opi_flags |= ORF_RESEND;
 		need_abort = true;
+		ABT_thread_yield();
 		goto again1;
 	default:
 		break;
@@ -4221,21 +4246,38 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.
 	 */
-	if (rc == 0 && dth->dth_modification_cnt > 0 && dth->dth_need_validation &&
-	    sched_cur_seq() != sched_seq) {
-		daos_epoch_t	epoch = 0;
-		int		rc1;
+	if (rc == 0 && dth->dth_modification_cnt > 0 && sched_cur_seq() != sched_seq) {
+		if (dth->dth_need_validation) {
+			daos_epoch_t	epoch = 0;
+			int		rc1;
 
-		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &epoch, NULL);
-		switch (rc1) {
-		case 0:
-		case -DER_ALREADY:
-			D_GOTO(out, rc = -DER_ALREADY);
-		case -DER_NONEXIST:
-		case -DER_EP_OLD:
-			break;
-		default:
-			D_GOTO(out, rc = rc1);
+			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &epoch, NULL);
+			switch (rc1) {
+			case 0:
+			case -DER_ALREADY:
+				D_GOTO(out, rc = -DER_ALREADY);
+			case -DER_NONEXIST:
+			case -DER_EP_OLD:
+				break;
+			default:
+				D_GOTO(out, rc = rc1);
+			}
+		}
+
+		if (rc == 0 && dth->dth_solo) {
+			daos_epoch_t	epoch = dcsh->dcsh_epoch.oe_value;
+
+			D_ASSERT(dcde->dcde_read_cnt == 0);
+			D_ASSERT(dcde->dcde_write_cnt == 1);
+
+			dcsh->dcsh_epoch.oe_value = d_hlc_get();
+
+			dtx_renew_epoch(&dcsh->dcsh_epoch, dth);
+			vos_update_renew_epoch(iohs[0], dth);
+
+			D_DEBUG(DB_IO,
+				"CPD rpc %p renew epoch "DF_U64" => "DF_U64" for "DF_DTI"\n",
+				rpc, epoch, dcsh->dcsh_epoch.oe_value, DP_DTI(&dcsh->dcsh_xid));
 		}
 	}
 
@@ -4654,7 +4696,7 @@ again:
 	else
 		tgts++;
 
-	if (tgt_cnt <= 1 && dcde->dcde_write_cnt <= 1)
+	if (tgt_cnt <= 1 && dcde->dcde_write_cnt == 1 && dcde->dcde_read_cnt == 0)
 		dtx_flags |= DTX_SOLO;
 	if (flags & ORF_RESEND)
 		dtx_flags |= DTX_PREPARED;
@@ -4689,6 +4731,7 @@ out:
 	if (rc == -DER_AGAIN) {
 		oci->oci_flags |= ORF_RESEND;
 		need_abort = true;
+		ABT_thread_yield();
 		goto again;
 	}
 

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -86,6 +86,19 @@ struct ilog_context {
 D_CASSERT(sizeof(struct ilog_id) == sizeof(struct ilog_tree));
 D_CASSERT(sizeof(struct ilog_root) == sizeof(struct ilog_df));
 
+static inline struct vos_container *
+ilog_ctx2cont(struct ilog_context *lctx)
+{
+	daos_handle_t	coh;
+
+	if (lctx->ic_cbs.dc_is_same_tx_args == NULL)
+		return NULL;
+
+	coh.cookie = (unsigned long)lctx->ic_cbs.dc_is_same_tx_args;
+
+	return vos_hdl2cont(coh);
+}
+
 /**
  * Customized functions for btree.
  */
@@ -109,9 +122,6 @@ ilog_status_get(struct ilog_context *lctx, const struct ilog_id *id, uint32_t in
 	struct ilog_desc_cbs	*cbs = &lctx->ic_cbs;
 	int			 rc;
 
-	if (id->id_tx_id == UMOFF_NULL)
-		return ILOG_COMMITTED;
-
 	if (!cbs->dc_log_status_cb)
 		return ILOG_COMMITTED;
 
@@ -134,6 +144,8 @@ ilog_log_add(struct ilog_context *lctx, struct ilog_id *id)
 	if (!cbs->dc_log_add_cb)
 		return 0;
 
+	D_ASSERT(id->id_epoch != 0);
+
 	rc = cbs->dc_log_add_cb(lctx->ic_umm, lctx->ic_root_off, &id->id_tx_id, id->id_epoch,
 				cbs->dc_log_add_args);
 	if (rc != 0) {
@@ -155,7 +167,7 @@ ilog_log_del(struct ilog_context *lctx, const struct ilog_id *id,
 	struct ilog_desc_cbs	*cbs = &lctx->ic_cbs;
 	int			 rc;
 
-	if (!cbs->dc_log_del_cb || !id->id_tx_id)
+	if (!cbs->dc_log_del_cb)
 		return 0;
 
 	rc = cbs->dc_log_del_cb(lctx->ic_umm, lctx->ic_root_off, id->id_tx_id, id->id_epoch,
@@ -575,7 +587,7 @@ check_equal(struct ilog_context *lctx, struct ilog_id *id_out, const struct ilog
 			D_DEBUG(DB_IO, "No entry found, done\n");
 			return 0;
 		}
-		if (id_in->id_tx_id == DTX_LID_COMMITTED) {
+		if (dtx_is_committed(id_in->id_tx_id, ilog_ctx2cont(lctx), id_in->id_epoch)) {
 			/** Need to differentiate between updates that are
 			 * overwrites and others that are conflicts.  Return
 			 * a different error code in this case if the result
@@ -881,6 +893,7 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 	}
 
 	D_ASSERT(!lctx->ic_in_txn);
+	D_ASSERTF(id_in->id_epoch != 0, "Invalid epoch for ilog opc %d\n", opc);
 
 	root = lctx->ic_root;
 
@@ -911,8 +924,6 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 		tmp.lr_magic = ilog_ver_inc(lctx);
 		tmp.lr_ts_idx = root->lr_ts_idx;
 		tmp.lr_id = *id_in;
-		D_ASSERTF(id_in->id_epoch != 0, "epoch "DF_U64" opc %d\n",
-			  id_in->id_epoch, opc);
 		rc = ilog_ptr_set(lctx, root, &tmp);
 		if (rc == 0)
 			rc = ilog_log_add(lctx, &root->lr_id);

--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -226,7 +226,7 @@ lrua_lookup_idx(struct lru_array *array, uint32_t idx, uint64_t key,
  *
  * \param	array[in]	The lru array
  * \param	idx[in]		The index of the entry
- * \param	idx[in]		Unique identifier
+ * \param	key[in]		Unique identifier
  * \param	entryp[out]	Valid only if function returns true.
  *
  * \return true if the entry is in the array and set \p entryp accordingly

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -67,7 +67,6 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_for_migration = 0;
 	dth->dth_ignore_uncommitted = 0;
 	dth->dth_prepared = 0;
-	dth->dth_verified = 0;
 	dth->dth_aborted = 0;
 	dth->dth_already = 0;
 	dth->dth_need_validation = 0;
@@ -93,6 +92,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_shares_inited = 1;
 
 	vos_dtx_rsrvd_init(dth);
+	vos_dtx_attach(dth, false, false);
 
 	*dthp = dth;
 }

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2020-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -244,6 +244,8 @@ stop_tx(daos_handle_t coh, struct tx_helper *txh, bool success, bool write)
 
 	if (txh->th_nr_ops == txh->th_op_seq) {
 		xid = dth->dth_xid;
+		if (txh->th_nr_mods != 0 && !success)
+			vos_dtx_cleanup(dth, true);
 		vts_dtx_end(dth);
 		if (txh->th_nr_mods != 0) {
 			if (success && !txh->th_skip_commit) {
@@ -252,7 +254,8 @@ stop_tx(daos_handle_t coh, struct tx_helper *txh, bool success, bool write)
 			} else {
 				if (!success)
 					txh->th_skip_commit = false;
-				daos_dti_copy(&txh->th_saved_xid, &xid);
+				else
+					daos_dti_copy(&txh->th_saved_xid, &xid);
 			}
 		}
 	}
@@ -1295,7 +1298,7 @@ conflicting_rw_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 		if (txh1.th_skip_commit) {
 			rc = vos_dtx_commit(arg->ctx.tc_co_hdl,
 					    &txh1.th_saved_xid, 1, NULL);
-			assert(rc >= 0 || rc == -DER_NONEXIST);
+			assert(rc >= 0);
 		}
 		if (expect_inprogress) {
 			print_message("  %s(%s, "DF_X64") (expect %s): ",
@@ -1558,21 +1561,19 @@ out:
 				      bound, mvcc_arg->i));
 
 	if (!daos_is_zero_dti(&wtx->th_saved_xid)) {
-		if (wtx->th_skip_commit)
+		if (wtx->th_skip_commit) {
 			rc = vos_dtx_commit(arg->ctx.tc_co_hdl,
 					    &wtx->th_saved_xid, 1, NULL);
-		else
-			rc = vos_dtx_abort(arg->ctx.tc_co_hdl, &wtx->th_saved_xid, DAOS_EPOCH_MAX);
-		assert(rc >= 0 || rc == -DER_NONEXIST);
+			assert(rc >= 0);
+		}
 	}
 
 	if (!daos_is_zero_dti(&atx->th_saved_xid)) {
-		if (atx->th_skip_commit)
+		if (atx->th_skip_commit) {
 			rc = vos_dtx_commit(arg->ctx.tc_co_hdl,
 					    &atx->th_saved_xid, 1, NULL);
-		else
-			rc = vos_dtx_abort(arg->ctx.tc_co_hdl, &atx->th_saved_xid, DAOS_EPOCH_MAX);
-		assert(rc >= 0 || rc == -DER_NONEXIST);
+			assert(rc >= 0);
+		}
 	}
 
 #undef DP_CASE

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -257,9 +257,11 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 	   bool started, int err)
 {
 	struct dtx_handle	*dth = dth_in;
+	struct vos_dtx_act_ent	*dae;
 	struct dtx_rsrvd_uint	*dru;
 	struct vos_dtx_cmt_ent	*dce = NULL;
 	struct dtx_handle	 tmp = {0};
+	int			 rc;
 
 	if (!dtx_is_valid_handle(dth)) {
 		/** Created a dummy dth handle for publishing extents */
@@ -303,19 +305,67 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 	err = umem_tx_end(vos_cont2umm(cont), err);
 
 cancel:
+	if (dtx_is_valid_handle(dth_in)) {
+		dae = dth->dth_ent;
+		if (dae != NULL)
+			dae->dae_preparing = 0;
+
+		if (unlikely(dth->dth_need_validation && dth->dth_active)) {
+			/* Aborted by race during the yield for local TX commit. */
+			rc = vos_dtx_validation(dth);
+			switch (rc) {
+			case DTX_ST_INITED:
+			case DTX_ST_PREPARED:
+			case DTX_ST_PREPARING:
+				/* The DTX has been ever aborted and related resent RPC
+				 * is in processing. Return -DER_AGAIN to make this ULT
+				 * to retry sometime later without dtx_abort().
+				 */
+				err = -DER_AGAIN;
+				break;
+			case DTX_ST_ABORTED:
+				D_ASSERT(dae == NULL);
+				/* Aborted, return -DER_INPROGRESS for client retry.
+				 *
+				 * Fall through.
+				 */
+			case DTX_ST_ABORTING:
+				err = -DER_INPROGRESS;
+				break;
+			case DTX_ST_COMMITTED:
+			case DTX_ST_COMMITTING:
+			case DTX_ST_COMMITTABLE:
+				/* Aborted then prepared/committed by race.
+				 * Return -DER_ALREADY to avoid repeated modification.
+				 */
+				dth->dth_already = 1;
+				err = -DER_ALREADY;
+				break;
+			default:
+				D_ASSERTF(0, "Unexpected DTX "DF_DTI" status %d\n",
+					  DP_DTI(&dth->dth_xid), rc);
+			}
+		} else if (dae != NULL) {
+			if (dth->dth_solo) {
+				if (err == 0 && cont->vc_solo_dtx_epoch < dth->dth_epoch)
+					cont->vc_solo_dtx_epoch = dth->dth_epoch;
+
+				vos_dtx_post_handle(cont, &dae, &dce, 1, false, err != 0);
+			} else {
+				D_ASSERT(dce == NULL);
+				if (err == 0)
+					dae->dae_prepared = 1;
+			}
+		}
+	}
+
 	if (err != 0) {
-		/* The transaction aborted or failed to commit. */
+		/* Do not set dth->dth_pinned. Upper layer caller can do that via
+		 * vos_dtx_cleanup() when necessary.
+		 */
 		vos_tx_publish(dth, false);
 		if (dtx_is_valid_handle(dth_in))
 			vos_dtx_cleanup_internal(dth);
-	}
-
-	if (dce != NULL) {
-		struct vos_dtx_act_ent	*dae = dth_in->dth_ent;
-
-		vos_dtx_post_handle(cont, &dae, &dce, 1, false,
-				    err != 0 ? true : false);
-		dth_in->dth_ent = NULL;
 	}
 
 	return err;

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -374,6 +374,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_cmt_dtx_reindex_pos = cont->vc_cont_df->cd_dtx_committed_head;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_act_list);
 	cont->vc_dtx_committed_count = 0;
+	cont->vc_solo_dtx_epoch = d_hlc_get();
 	gc_check_cont(cont);
 
 	/* Cache this btr object ID in container handle */

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -34,19 +34,18 @@ enum {
 #define DTX_UMOFF_TYPES		(DTX_UMOFF_ILOG | DTX_UMOFF_SVT | DTX_UMOFF_EVT)
 #define DTX_INDEX_INVAL		(int32_t)(-1)
 
-#define dtx_evict_lid(cont, dae)					\
-	do {								\
-		if (dae->dae_dth != NULL &&				\
-		    dae->dae_dth->dth_ent != NULL) {			\
-			D_ASSERT(dae->dae_dth->dth_ent == dae);		\
-			dae->dae_dth->dth_ent = NULL;			\
-		}							\
-		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%d\n",	\
-			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));		\
-		d_list_del_init(&dae->dae_link);			\
-		lrua_evictx(cont->vc_dtx_array,				\
-			    DAE_LID(dae) - DTX_LID_RESERVED,		\
-			    DAE_EPOCH(dae));				\
+#define dtx_evict_lid(cont, dae)							\
+	do {										\
+		if (dae->dae_dth != NULL && dae->dae_dth->dth_ent != NULL) {		\
+			D_ASSERT(dae->dae_dth->dth_ent == dae);				\
+			dae->dae_dth->dth_ent = NULL;					\
+		}									\
+		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%d\n",			\
+			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));				\
+		d_list_del_init(&dae->dae_link);					\
+		lrua_evictx(cont->vc_dtx_array,						\
+			    (DAE_LID(dae) & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,	\
+			    DAE_EPOCH(dae));						\
 	} while (0)
 
 static inline void
@@ -98,19 +97,7 @@ dtx_umoff_flag2type(umem_off_t umoff)
 	return 0;
 }
 
-static inline bool
-dtx_is_aborted(uint32_t tx_lid)
-{
-	return tx_lid == DTX_LID_ABORTED;
-}
-
-static void
-dtx_set_aborted(uint32_t *tx_lid)
-{
-	*tx_lid = DTX_LID_ABORTED;
-}
-
-static inline int
+static int
 dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 	       bool hit_again, bool retry, int pos)
 {
@@ -324,6 +311,9 @@ dtx_act_ent_update(struct btr_instance *tins, struct btr_record *rec,
 	dae_old = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 
 	D_ASSERT(dae_old != dae_new);
+
+	if (unlikely(dae_old->dae_aborting))
+		return -DER_INPROGRESS;
 
 	if (unlikely(!dae_old->dae_aborted)) {
 		/*
@@ -602,7 +592,7 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 			if (rc != 0)
 				return rc;
 
-			svt->ir_dtx = DTX_LID_COMMITTED;
+			dtx_set_committed(&svt->ir_dtx);
 		}
 		break;
 	}
@@ -625,7 +615,7 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 			if (rc != 0)
 				return rc;
 
-			evt->dc_dtx = DTX_LID_COMMITTED;
+			dtx_set_committed(&evt->dc_dtx);
 		}
 		break;
 	}
@@ -654,11 +644,17 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 	if (dae->dae_dbd == NULL)
 		return 0;
 
-	dbd = dae->dae_dbd;
-	D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
+	/* In spite of for commit or abort, the DTX must be local preparing/prepared. */
+	D_ASSERTF(vos_dae_is_prepare(dae), "Unexpected DTX "DF_DTI" status for %s\n",
+		  DP_DTI(&DAE_XID(dae)), abort ? "abort" : "commit");
 
+	dbd = dae->dae_dbd;
 	dae_df = umem_off2ptr(umm, dae->dae_df_off);
+
 	D_ASSERT(dae_df != NULL);
+	D_ASSERTF(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC,
+		  "Invalid blob %p magic %x for "DF_DTI" (lid %x)\n",
+		  dbd, dbd->dbd_magic, DP_DTI(&DAE_XID(dae)), DAE_LID(dae));
 
 	if (!umoff_is_null(dae_df->dae_mbs_off)) {
 		/* dae_mbs_off will be invalid via flag DTE_INVALID. */
@@ -677,12 +673,11 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 			if (rc != 0)
 				return rc;
 		}
-	}
 
-	if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT)
 		count = DTX_INLINE_REC_CNT;
-	else
+	} else {
 		count = DAE_REC_CNT(dae);
+	}
 
 	for (i = count - 1; i >= 0; i--) {
 		rc = do_dtx_rec_release(umm, cont, dae, DAE_REC_INLINE(dae)[i],
@@ -757,6 +752,10 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 		}
 
 		rc = umem_free(umm, dbd_off);
+
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
+			 "Release DTX active blob %p ("UMOFF_PF") for cont "DF_UUID": "DF_RC"\n",
+			 dbd, UMOFF_P(dbd_off), DP_UUID(cont->vc_id), DP_RC(rc));
 	}
 
 	return rc;
@@ -776,9 +775,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 	d_iov_set(&kiov, dti, sizeof(*dti));
 	/* For single replicated object, we trigger commit just after local
 	 * modification done. Under such case, the caller exactly knows the
-	 * @epoch and no need to lookup the active DTX table. On the other
-	 * hand, for modifying single replicated object, there is no DTX
-	 * entry in the active DTX table.
+	 * @epoch and no need to lookup the active DTX table.
 	 */
 	if (epoch == 0) {
 		d_iov_set(&riov, NULL, 0);
@@ -788,22 +785,21 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 					   &kiov, &riov);
 			if (rc == 0) {
 				dce = (struct vos_dtx_cmt_ent *)riov.iov_buf;
-				if (dce->dce_invalid) {
-					dce = NULL;
-					D_GOTO(out, rc = -DER_NONEXIST);
-				}
-
+				if (dce->dce_invalid)
+					rc = -DER_NONEXIST;
+				else
+					rc = -DER_ALREADY;
 				dce = NULL;
 			}
-
-			goto out;
 		}
 
 		if (rc != 0)
 			goto out;
 
 		dae = riov.iov_buf;
-		if (dae->dae_aborted) {
+		D_ASSERT(dae->dae_preparing == 0);
+
+		if (vos_dae_is_abort(dae)) {
 			D_ERROR("NOT allow to commit an aborted DTX "DF_DTI"\n",
 				DP_DTI(dti));
 			D_GOTO(out, rc = -DER_NONEXIST);
@@ -812,7 +808,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 		/* It has been committed before, but failed to be removed
 		 * from the active table, just remove it again.
 		 */
-		if (dae->dae_committed) {
+		if (unlikely(dae->dae_committed)) {
 			rc = dbtree_delete(cont->vc_dtx_active_hdl,
 					   BTR_PROBE_BYPASS, &kiov, &dae);
 			if (rc == 0) {
@@ -822,6 +818,12 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 
 			goto out;
 		}
+
+		/* Another ULT is committing the DTX, but yield, then regard it as 'committed'.
+		 * The former committing ULT will guarantee the DTX to be committed successfully.
+		 */
+		if (dae->dae_committing)
+			D_GOTO(out, rc = -DER_ALREADY);
 	}
 
 	D_ALLOC_PTR(dce);
@@ -836,6 +838,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 		struct dtx_handle	*dth = vos_dth_get();
 
 		D_ASSERT(dtx_is_valid_handle(dth));
+		D_ASSERT(dth->dth_solo);
 
 		DCE_XID(dce) = *dti;
 		DCE_EPOCH(dce) = dth->dth_epoch;
@@ -859,13 +862,16 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 		goto out;
 	}
 
+	dae->dae_committing = 1;
+
 	D_ASSERT(dae_p != NULL);
 	*dae_p = dae;
 
 out:
-	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_IO,
-		 "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
-		 DP_DTI(dti), DP_RC(rc));
+	if (rc != -DER_ALREADY && rc != -DER_NONEXIST)
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
+			 "Commit the DTX "DF_DTI": rc = "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
+
 	if (rc != 0)
 		D_FREE(dce);
 
@@ -890,15 +896,6 @@ vos_dtx_flags2name(uint32_t flags)
 	}
 
 	return NULL;
-}
-
-static bool
-vos_dtx_is_normal_entry(uint32_t entry)
-{
-	if (entry < DTX_LID_RESERVED)
-		return false;
-
-	return true;
 }
 
 static int
@@ -951,6 +948,9 @@ vos_dtx_extend_act_table(struct vos_container *cont)
 
 	cont_df->cd_dtx_active_tail = dbd_off;
 
+	D_DEBUG(DB_IO, "Allocated DTX active blob %p ("UMOFF_PF") for cont "DF_UUID"\n",
+		dbd, UMOFF_P(dbd_off), DP_UUID(cont->vc_id));
+
 	return 0;
 }
 
@@ -977,6 +977,8 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 
 	D_INIT_LIST_HEAD(&dae->dae_link);
 	DAE_LID(dae) = idx + DTX_LID_RESERVED;
+	if (dth->dth_solo)
+		DAE_LID(dae) |= DTX_LID_SOLO_FLAG;
 	DAE_XID(dae) = dth->dth_xid;
 	DAE_OID(dae) = dth->dth_leader_oid;
 	DAE_DKEY_HASH(dae) = dth->dth_dkey_hash;
@@ -1078,17 +1080,26 @@ vos_dtx_status(struct vos_dtx_act_ent *dae)
 	if (DAE_FLAGS(dae) & DTE_CORRUPTED)
 		return DTX_ST_CORRUPTED;
 
-	if (dae->dae_committed)
+	if (unlikely(dae->dae_committed))
 		return DTX_ST_COMMITTED;
 
-	if (dae->dae_committable)
-		return DTX_ST_COMMITTABLE;
+	if (dae->dae_committing)
+		return DTX_ST_COMMITTING;
 
 	if (dae->dae_committable)
 		return DTX_ST_COMMITTABLE;
 
 	if (dae->dae_prepared)
 		return DTX_ST_PREPARED;
+
+	if (dae->dae_preparing)
+		return DTX_ST_PREPARING;
+
+	if (unlikely(dae->dae_aborted))
+		return DTX_ST_ABORTED;
+
+	if (dae->dae_aborting)
+		return DTX_ST_ABORTING;
 
 	return DTX_ST_INITED;
 }
@@ -1107,6 +1118,9 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	struct vos_dtx_act_ent		*dae = NULL;
 	bool				 found;
 
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
 	if (dth != NULL && dth->dth_for_migration)
 		intent = DAOS_INTENT_MIGRATION;
 
@@ -1120,32 +1134,28 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		/* Everything is available to PURGE, even if it belongs to some
 		 * uncommitted DTX that may be garbage because of corruption.
 		 */
+		return intent == DAOS_INTENT_PURGE ? ALB_AVAILABLE_DIRTY : -DER_INVAL;
+	}
+
+	if (intent == DAOS_INTENT_CHECK)
+		return dtx_is_aborted(entry) ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
+
+	if (dtx_is_committed(entry, cont, epoch))
+		return ALB_AVAILABLE_CLEAN;
+
+	if (dtx_is_aborted(entry)) {
+		if (intent == DAOS_INTENT_DISCARD)
+			return ALB_AVAILABLE_CLEAN;
+
 		if (intent == DAOS_INTENT_PURGE)
-			return ALB_AVAILABLE_DIRTY;
+			return ALB_AVAILABLE_ABORTED;
 
-		return -DER_INVAL;
+		return ALB_UNAVAILABLE;
 	}
 
-	if (intent == DAOS_INTENT_CHECK) {
-		if (dtx_is_aborted(entry))
-			return ALB_UNAVAILABLE;
+	D_ASSERTF(epoch != 0, "Invalid epoch for DTX (lid: %x) availability check\n", entry);
 
-		return ALB_AVAILABLE_CLEAN;
-	}
-
-	/* Committed -or- being discarded */
-	if (entry == DTX_LID_COMMITTED || intent == DAOS_INTENT_DISCARD)
-		return ALB_AVAILABLE_CLEAN;
-
-	/* Aborted */
-	if (dtx_is_aborted(entry))
-		return intent == DAOS_INTENT_PURGE ?
-			ALB_AVAILABLE_ABORTED : ALB_UNAVAILABLE;
-
-	cont = vos_hdl2cont(coh);
-	D_ASSERT(cont != NULL);
-
-	found = lrua_lookupx(cont->vc_dtx_array, entry - DTX_LID_RESERVED,
+	found = lrua_lookupx(cont->vc_dtx_array, (entry & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,
 			     epoch, &dae);
 	if (!found) {
 		D_DEBUG(DB_TRACE,
@@ -1166,14 +1176,17 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		return ALB_AVAILABLE_DIRTY;
 	}
 
+	if (intent == DAOS_INTENT_DISCARD)
+		return vos_dae_in_process(dae) ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
+
 	/* The DTX owner can always see the DTX. */
 	if (dtx_is_valid_handle(dth) && dae == dth->dth_ent)
 		return ALB_AVAILABLE_CLEAN;
 
-	if (dae->dae_committable || dae->dae_committed || DAE_FLAGS(dae) & DTE_PARTIAL_COMMITTED)
+	if (vos_dae_is_commit(dae) || DAE_FLAGS(dae) & DTE_PARTIAL_COMMITTED)
 		return ALB_AVAILABLE_CLEAN;
 
-	if (dae->dae_aborted)
+	if (vos_dae_is_abort(dae))
 		return ALB_UNAVAILABLE;
 
 	/* Access corrupted DTX entry. */
@@ -1284,7 +1297,7 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 			return dtx_inprogress(dae, dth, false, true, 2);
 
 		/* Ignore non-prepared DTX in spite of on leader or not. */
-		if (dae->dae_dbd == NULL || dae->dae_dth != NULL)
+		if (dae->dae_dbd == NULL || dae->dae_dth != NULL || dae->dae_preparing)
 			return ALB_UNAVAILABLE;
 
 		if (!(DAE_FLAGS(dae) & DTE_LEADER))
@@ -1349,11 +1362,13 @@ int
 vos_dtx_validation(struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent	*dae;
+	struct vos_container	*cont;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	int			 rc = 0;
 
 	D_ASSERT(dtx_is_valid_handle(dth));
 
-	dth->dth_verified = 1;
 	dae = dth->dth_ent;
 
 	/* During current ULT waiting for some event, such as bulk data
@@ -1368,59 +1383,37 @@ vos_dtx_validation(struct dtx_handle *dth)
 	 * (or different) DTX LRU array slot.
 	 */
 
-	if (unlikely(dae == NULL || dth->dth_aborted)) {
-		struct vos_container	*cont;
-		d_iov_t			 kiov;
-		d_iov_t			 riov;
-
+	if (unlikely(dth->dth_aborted)) {
+		D_ASSERT(dae == NULL);
 		cont = vos_hdl2cont(dth->dth_coh);
 		D_ASSERT(cont != NULL);
 
 		d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
 		d_iov_set(&riov, NULL, 0);
 
-		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
-		if (rc == 0) {
-			D_DEBUG(DB_IO, "DTX "DF_DTI" is committed by race(1)\n",
-				DP_DTI(&dth->dth_xid));
-			return DTX_ST_COMMITTED;
-		}
-
 		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 		if (rc != 0) {
+			if (rc == -DER_NONEXIST) {
+				rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+				if (rc == 0)
+					return DTX_ST_COMMITTED;
+			}
+
 			/* Failed to lookup DTX entry, in spite of whether it is DER_NONEXIST
 			 * or not, then handle it as aborted that will cause client to retry.
 			 */
-			D_DEBUG(DB_IO, "DTX "DF_DTI" is aborted by race(1): "DF_RC"\n",
-				DP_DTI(&dth->dth_xid), DP_RC(rc));
 			return DTX_ST_ABORTED;
 		}
 
 		dae = riov.iov_buf;
-	}
-
-	if (dae->dae_committed) {
-		D_DEBUG(DB_IO, "DTX "DF_DTI" is committed by race(2)\n",
-			DP_DTI(&dth->dth_xid));
+	} else if (unlikely(dae == NULL)) {
 		return DTX_ST_COMMITTED;
 	}
 
-	if (dae->dae_aborted) {
-		D_DEBUG(DB_IO, "DTX "DF_DTI" is aborted by race(2)\n",
-			DP_DTI(&dth->dth_xid));
-		return DTX_ST_ABORTED;
-	}
-
-	if (dae->dae_committable)
-		return DTX_ST_COMMITTABLE;
-
-	if (dae->dae_prepared)
-		return DTX_ST_PREPARED;
-
-	return dth->dth_aborted ? DTX_ST_ABORTED : DTX_ST_INITED;
+	return vos_dtx_status(dae);
 }
 
-/* The caller has started PMDK transaction. */
+/* The caller has started local transaction. */
 int
 vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 			uint32_t type, uint32_t *tx_id)
@@ -1430,45 +1423,59 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 	int			 rc = 0;
 
 	if (!dtx_is_valid_handle(dth)) {
-		*tx_id = DTX_LID_COMMITTED;
+		dtx_set_committed(tx_id);
 		return 0;
 	}
 
-	/* For single participator case, we only hold committed DTX
-	 * entry for handling resend case, not trace modified target.
-	 */
-	if (dth->dth_solo) {
-		dth->dth_active = 1;
-		*tx_id = DTX_LID_COMMITTED;
-		return 0;
-	}
-
-	if (dth->dth_need_validation && !dth->dth_verified) {
+	if (unlikely(dth->dth_need_validation && !dth->dth_active)) {
 		rc = vos_dtx_validation(dth);
 		switch (rc) {
 		case DTX_ST_INITED:
-			break;
+			if (!dth->dth_aborted)
+				break;
+			/* Fall through */
 		case DTX_ST_PREPARED:
+		case DTX_ST_PREPARING:
+			/* The DTX has been ever aborted and related resent RPC
+			 * is in processing. Return -DER_AGAIN to make this ULT
+			 * to retry sometime later without dtx_abort().
+			 */
+			D_GOTO(out, rc = -DER_AGAIN);
 		case DTX_ST_COMMITTED:
+		case DTX_ST_COMMITTING:
 		case DTX_ST_COMMITTABLE:
 			/* Aborted then prepared/committed by race.
 			 * Return -DER_ALREADY to avoid repeated modification.
-			 *
-			 * Reset current dth->dth_ent to bypass cleanup.
 			 */
-			dth->dth_ent = NULL;
 			dth->dth_already = 1;
 			D_GOTO(out, rc = -DER_ALREADY);
 		case DTX_ST_ABORTED:
 			D_ASSERT(dth->dth_ent == NULL);
-			/* Aborted, return -DER_INPROGRESS for client retry. */
+			/* Aborted, return -DER_INPROGRESS for client retry.
+			 *
+			 * Fall through.
+			 */
+		case DTX_ST_ABORTING:
 			D_GOTO(out, rc = -DER_INPROGRESS);
 		default:
-			D_ASSERT(0);
+			D_ASSERTF(0, "Unexpected DTX "DF_DTI" status %d\n",
+				  DP_DTI(&dth->dth_xid), rc);
 		}
 	}
 
 	dae = dth->dth_ent;
+	/* There must has been vos_dtx_attach() before vos_dtx_register_record(). */
+	D_ASSERT(dae != NULL);
+
+	/* For single participator case, we only hold DTX entry
+	 * for handling resend case, not trace modified target.
+	 */
+	if (dth->dth_solo) {
+		dth->dth_active = 1;
+		*tx_id = DAE_LID(dae);
+		return 0;
+	}
+
 	if (!dth->dth_active) {
 		struct vos_container	*cont;
 		struct vos_cont_df	*cont_df;
@@ -1489,23 +1496,12 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 			dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
 		}
 
-		if (dae == NULL) {
-			rc = vos_dtx_alloc(dbd, dth);
-			if (rc != 0)
-				goto out;
+		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
-			dae = dth->dth_ent;
-		} else {
-			D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
-
-			dae->dae_df_off = cont_df->cd_dtx_active_tail +
-					offsetof(struct vos_dtx_blob_df,
-						 dbd_active_data) +
-					sizeof(struct vos_dtx_act_ent_df) *
-					dbd->dbd_index;
-			dae->dae_dbd = dbd;
-		}
-
+		dae->dae_df_off = cont_df->cd_dtx_active_tail +
+				offsetof(struct vos_dtx_blob_df, dbd_active_data) +
+				sizeof(struct vos_dtx_act_ent_df) * dbd->dbd_index;
+		dae->dae_dbd = dbd;
 		dth->dth_active = 1;
 	}
 
@@ -1526,7 +1522,7 @@ out:
 	return rc;
 }
 
-/* The caller has started PMDK transaction. */
+/* The caller has started local transaction. */
 void
 vos_dtx_deregister_record(struct umem_instance *umm, daos_handle_t coh,
 			  uint32_t entry, daos_epoch_t epoch, umem_off_t record)
@@ -1622,11 +1618,10 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 	struct vos_container		*cont;
 	struct umem_instance		*umm;
 	struct vos_dtx_blob_df		*dbd;
-	d_iov_t				 kiov;
 	umem_off_t			 rec_off;
 	size_t				 size;
 	int				 count;
-	int				 rc;
+	int				 rc = 0;
 
 	if (!dth->dth_active)
 		return 0;
@@ -1635,34 +1630,20 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 	D_ASSERT(cont != NULL);
 
 	dae = dth->dth_ent;
+	/* There must be vos_dtx_attach() before prepared. */
+	D_ASSERT(dae != NULL);
+	D_ASSERT(dae->dae_aborting == 0);
+	D_ASSERT(dae->dae_aborted == 0);
 
 	if (dth->dth_solo) {
-		if (dth->dth_drop_cmt) {
-			if (unlikely(dae == NULL))
-				D_GOTO(done, rc = 0);
-
-			d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
-			rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ, &kiov, NULL);
-			if (rc == 0 || rc == -DER_NONEXIST) {
-				dtx_evict_lid(cont, dae);
-				D_GOTO(done, rc = 0);
-			}
-
-			/*
-			 * We cannot remove the DTX entry from the active table, mark it
-			 * as 'committed'. That will consume some DRAM until server restart.
+		if (dth->dth_drop_cmt)
+			/* The active DTX entry will be removed via vos_dtx_post_handle()
+			 * after related local TX being committed successfully.
 			 */
-			D_WARN("Cannot remove DTX "DF_DTI" from active table: "DF_RC"\n",
-			       DP_DTI(&dth->dth_xid), DP_RC(rc));
-
-			dae->dae_committed = 1;
-			dtx_act_ent_cleanup(cont, dae, dth, false);
-		} else {
+			dae->dae_committing = 1;
+		else
 			rc = vos_dtx_commit_internal(cont, &dth->dth_xid, 1,
 						     dth->dth_epoch, NULL, NULL, dce_p);
-		}
-
-done:
 		dth->dth_active = 0;
 		dth->dth_pinned = 0;
 		if (rc >= 0) {
@@ -1672,8 +1653,6 @@ done:
 
 		return rc;
 	}
-
-	D_ASSERT(dae != NULL);
 
 	umm = vos_cont2umm(cont);
 	dbd = dae->dae_dbd;
@@ -1754,24 +1733,24 @@ done:
 
 	DAE_INDEX(dae) = dbd->dbd_index;
 	if (DAE_INDEX(dae) > 0) {
-		dtx_memcpy_nodrain(umm, umem_off2ptr(umm, dae->dae_df_off),
-				   &dae->dae_base,
-				   sizeof(struct vos_dtx_act_ent_df));
-		/* dbd_index is next to dbd_count */
-		rc = umem_tx_add_ptr(umm, &dbd->dbd_count,
-				     sizeof(dbd->dbd_count) +
-				     sizeof(dbd->dbd_index));
+		rc = umem_tx_add_ptr(umm, umem_off2ptr(umm, dae->dae_df_off),
+				     sizeof(struct vos_dtx_act_ent_df));
 		if (rc != 0)
 			return rc;
-	} else {
-		memcpy(umem_off2ptr(umm, dae->dae_df_off),
-		       &dae->dae_base, sizeof(struct vos_dtx_act_ent_df));
+
+		/* dbd_index is next to dbd_count */
+		rc = umem_tx_add_ptr(umm, &dbd->dbd_count,
+				     sizeof(dbd->dbd_count) + sizeof(dbd->dbd_index));
+		if (rc != 0)
+			return rc;
 	}
 
+	memcpy(umem_off2ptr(umm, dae->dae_df_off),
+	       &dae->dae_base, sizeof(struct vos_dtx_act_ent_df));
 	dbd->dbd_count++;
 	dbd->dbd_index++;
 
-	dae->dae_prepared = 1;
+	dae->dae_preparing = 1;
 
 	return 0;
 }
@@ -1835,7 +1814,14 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			dck->dkey_hash = DAE_DKEY_HASH(dae);
 		}
 
-		if (dae->dae_committed) {
+		if (dae->dae_committed || dae->dae_committing) {
+			/* For solo 'committing' DTX, do not return DTX_ST_COMMITTED. Otherwise,
+			 * it will misguide the caller as fake 'committed', but related data may
+			 * be invisible to the subsequent fetch until become real 'committed'.
+			 */
+			if (dae->dae_committing && DAE_LID(dae) & DTX_LID_SOLO_FLAG)
+				return -DER_INPROGRESS;
+
 			if (epoch != NULL)
 				*epoch = DAE_EPOCH(dae);
 
@@ -1852,7 +1838,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			return DTX_ST_COMMITTABLE;
 		}
 
-		if (dae->dae_aborted)
+		if (vos_dae_is_abort(dae))
 			return -DER_NONEXIST;
 
 		if (for_refresh) {
@@ -1866,7 +1852,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			if (!(DAE_FLAGS(dae) & DTE_LEADER))
 				return -DER_INPROGRESS;
 
-			return dae->dae_prepared ? DTX_ST_PREPARED : DTX_ST_INITED;
+			return vos_dae_is_prepare(dae) ? DTX_ST_PREPARED : DTX_ST_INITED;
 		}
 
 		/* Not committable yet, related RPC handler ULT is still running. */
@@ -1881,7 +1867,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 				return -DER_MISMATCH;
 		}
 
-		return dae->dae_prepared ? DTX_ST_PREPARED : DTX_ST_INITED;
+		return vos_dae_is_prepare(dae) ? DTX_ST_PREPARED : DTX_ST_INITED;
 	}
 
 	if (rc == -DER_NONEXIST) {
@@ -1986,7 +1972,7 @@ again:
 		if (rc == 0 && (daes == NULL || daes[cur] != NULL))
 			committed++;
 
-		if (rc == -DER_NONEXIST)
+		if (rc == -DER_ALREADY || rc == -DER_NONEXIST)
 			rc = 0;
 
 		if (rc1 == 0)
@@ -2054,6 +2040,9 @@ new_blob:
 			D_GOTO(out, fatal = true);
 	}
 
+	D_DEBUG(DB_IO, "Allocated DTX committed blob %p ("UMOFF_PF") for cont "DF_UUID"\n",
+		dbd, UMOFF_P(dbd_off), DP_UUID(cont->vc_id));
+
 	cont_df->cd_dtx_committed_tail = dbd_off;
 	allocated = true;
 	goto again;
@@ -2072,8 +2061,15 @@ vos_dtx_post_handle(struct vos_container *cont,
 	int		rc;
 	int		i;
 
+	D_ASSERT(daes != NULL);
+
 	if (rollback) {
 		D_ASSERT(!abort);
+
+		for (i = 0; i < count; i++) {
+			if (daes[i] != NULL)
+				daes[i]->dae_committing = 0;
+		}
 
 		if (dces == NULL)
 			return;
@@ -2127,12 +2123,18 @@ vos_dtx_post_handle(struct vos_container *cont,
 			D_WARN("Cannot remove DTX "DF_DTI" from active table: "
 			       DF_RC"\n", DP_DTI(&DAE_XID(daes[i])), DP_RC(rc));
 
+			daes[i]->dae_prepared = 0;
+			/* The 'dae_preparing' is set by the its owner who is not current ULT.
+			 * Since the 'dae' may be detached from the DTX handle, let's reset it.
+			 */
+			daes[i]->dae_preparing = 0;
 			if (abort) {
 				daes[i]->dae_aborted = 1;
-				daes[i]->dae_prepared = 0;
+				daes[i]->dae_aborting = 0;
 				dtx_act_ent_cleanup(cont, daes[i], NULL, true);
 			} else {
 				daes[i]->dae_committed = 1;
+				daes[i]->dae_committing = 0;
 				dtx_act_ent_cleanup(cont, daes[i], NULL, false);
 			}
 			DAE_FLAGS(daes[i]) &= ~(DTE_CORRUPTED | DTE_ORPHAN | DTE_PARTIAL_COMMITTED);
@@ -2162,18 +2164,17 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id dtis[], int count, bool rm_cos[]
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	/* Commit multiple DTXs via single PMDK transaction. */
+	/* Commit multiple DTXs via single local transaction. */
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
 		committed = vos_dtx_commit_internal(cont, dtis, count, 0, rm_cos, daes, dces);
-		rc = umem_tx_end(vos_cont2umm(cont),
-				 committed > 0 ? 0 : committed);
-		if (rc == 0)
-			vos_dtx_post_handle(cont, daes, dces,
-					    count, false, false);
-		else
-			vos_dtx_post_handle(cont, daes, dces,
-					    count, false, true);
+		if (committed >= 0) {
+			rc = umem_tx_commit(vos_cont2umm(cont));
+			D_ASSERT(rc == 0);
+		} else {
+			rc = umem_tx_abort(vos_cont2umm(cont), committed);
+		}
+		vos_dtx_post_handle(cont, daes, dces, count, false, rc != 0);
 	}
 
 out:
@@ -2212,47 +2213,76 @@ vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 		goto out;
 
 	dae = riov.iov_buf;
-	if (dae->dae_committable || dae->dae_committed) {
+	if (vos_dae_is_commit(dae)) {
 		D_ERROR("NOT allow to abort a committed DTX (2) "DF_DTI"\n", DP_DTI(dti));
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
-	/* It has been aborted before, but failed to be removed from the active table
-	 * at that time, then need to be removed again via vos_dtx_post_handle().
-	 */
-	if (dae->dae_aborted)
+	if (vos_dae_is_abort(dae))
 		D_GOTO(out, rc = -DER_ALREADY);
 
 	if (epoch != DAOS_EPOCH_MAX && epoch != DAE_EPOCH(dae))
 		D_GOTO(out, rc = -DER_NONEXIST);
 
+	/* NOTE: Abort in-preparing DTX entry. It may because the non-leader is some slow,
+	 *	 as to leader got timeout and then abort the DTX by race. Under such case,
+	 *	 the owner of 'preparing' need to handle the race case.
+	 */
+	if (unlikely(dae->dae_preparing))
+		D_WARN("Trying to abort in preparing DTX "DF_DTI" by race\n", DP_DTI(dti));
+
 	umm = vos_cont2umm(cont);
 	rc = umem_tx_begin(umm, NULL);
 	if (rc == 0) {
-		rc = dtx_rec_release(cont, dae, true);
-		rc = umem_tx_end(umm, rc);
-		if (rc == 0 && dae->dae_dth != NULL) {
-			struct dtx_handle	*dth = dae->dae_dth;
+		struct dtx_handle	*dth = dae->dae_dth;
 
+		if (dth != NULL) {
 			D_ASSERT(dth->dth_ent == dae || dth->dth_ent == NULL);
+			/* Not allow dtx_abort against solo DTX. */
+			D_ASSERT(!dth->dth_solo);
+			/* Set dth->dth_need_validation to notify the dth owner. */
+			dth->dth_need_validation = 1;
+		}
 
+		rc = dtx_rec_release(cont, dae, true);
+		if (rc == 0) {
+			dae->dae_aborting = 1;
+			rc = umem_tx_commit(umm);
+			D_ASSERTF(rc == 0, "local TX commit failure %d\n", rc);
+		} else {
+			rc = umem_tx_abort(umm, rc);
+		}
+
+		if (rc == 0 && dth != NULL) {
 			dae->dae_dth = NULL;
 			dth->dth_aborted = 1;
 			dth->dth_ent = NULL;
-			/*
-			 * dtx_act_ent_cleanup() will be triggered via vos_dtx_post_handle()
+			dth->dth_pinned = 0;
+			/* dtx_act_ent_cleanup() will be triggered via vos_dtx_post_handle()
 			 * when remove the DTX entry from active DTX table.
 			 */
 		}
+
+		/* NOTE: do not reset dth_need_validation for "else" case,
+		 *	 because it may be also co-set (shared) by others.
+		 */
 	}
 
 out:
-	D_DEBUG(DB_IO, "Abort the DTX "DF_DTI": "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
+	if (rc != -DER_ALREADY && rc != -DER_NONEXIST)
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
+			 "Abort the DTX "DF_DTI": "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
+
+	/* Aborting: The DTX is being aborted. The local transaction for abort itself is yield.
+	 *
+	 * Aborted: The DTX has been aborted before, but failed to be removed from the active
+	 *	    table at that time, then need to be removed again via vos_dtx_post_handle.
+	 */
+	if (dae != NULL && (rc == 0 || (rc == -DER_ALREADY && dae->dae_aborted)))
+		vos_dtx_post_handle(cont, &dae, NULL, 1, true, false);
 
 	if (rc == -DER_ALREADY)
 		rc = 0;
-	if (rc == 0)
-		vos_dtx_post_handle(cont, &dae, NULL, 1, true, false);
 
 	return rc;
 }
@@ -2287,10 +2317,10 @@ vos_dtx_set_flags_one(struct vos_container *cont, struct dtx_id *dti, uint32_t f
 		goto out;
 
 	if ((dae->dae_committable && (flags & (DTE_CORRUPTED | DTE_ORPHAN))) ||
-	    dae->dae_committed || dae->dae_aborted) {
+	    dae->dae_committing || dae->dae_committed || vos_dae_is_abort(dae)) {
 		D_ERROR("Not allow to set flag %s on the %s DTX entry "DF_DTI"\n",
-			vos_dtx_flags2name(flags), dae->dae_committable ? "committable" :
-			dae->dae_committed ? "committed (2)" : "aborted", DP_DTI(dti));
+			vos_dtx_flags2name(flags),
+			vos_dae_is_abort(dae) ? "abort" : "commit", DP_DTI(dti));
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
@@ -2469,11 +2499,12 @@ vos_dtx_aggregate(daos_handle_t coh)
 
 out:
 	rc = umem_tx_end(umm, rc);
-	if (rc != 0)
-		D_ERROR("Failed to aggregate DTX blob "UMOFF_PF": "
-			DF_RC"\n", UMOFF_P(dbd_off), DP_RC(rc));
-	else if (cont->vc_cmt_dtx_reindex_pos == dbd_off)
+	if (rc == 0 && cont->vc_cmt_dtx_reindex_pos == dbd_off)
 		cont->vc_cmt_dtx_reindex_pos = next;
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
+		 "Release DTX committed blob %p ("UMOFF_PF") for cont "DF_UUID": "DF_RC"\n",
+		 dbd, UMOFF_P(dbd_off), DP_UUID(cont->vc_id), DP_RC(rc));
 
 	return rc;
 }
@@ -2609,11 +2640,10 @@ vos_dtx_act_reindex(struct vos_container *cont)
 	int				 rc = 0;
 	int				 i;
 
-	while (1) {
-		dbd = umem_off2ptr(umm, dbd_off);
-		if (dbd == NULL)
-			break;
+	while (!UMOFF_IS_NULL(dbd_off)) {
+		int	dbd_count = 0;
 
+		dbd = umem_off2ptr(umm, dbd_off);
 		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
 		for (i = 0; i < dbd->dbd_index; i++) {
@@ -2694,7 +2724,15 @@ vos_dtx_act_reindex(struct vos_container *cont)
 
 			dae->dae_start_time = d_hlc_get();
 			d_list_add_tail(&dae->dae_link, &cont->vc_dtx_act_list);
+			dbd_count++;
 		}
+
+		D_ASSERTF(dbd_count == dbd->dbd_count,
+			  "Unmatched active DTX count %d/%d, cap %d, idx %d for blob %p ("
+			  UMOFF_PF"), head "UMOFF_PF", tail "UMOFF_PF"\n",
+			  dbd_count, dbd->dbd_count, dbd->dbd_cap, dbd->dbd_index, dbd,
+			  UMOFF_P(dbd_off), UMOFF_P(cont_df->cd_dtx_active_head),
+			  UMOFF_P(cont_df->cd_dtx_active_tail));
 
 		dbd_off = dbd->dbd_next;
 	}
@@ -2790,6 +2828,9 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 		return;
 
 	dth->dth_active = 0;
+	if (unlikely(dth->dth_already))
+		return;
+
 	cont = vos_hdl2cont(dth->dth_coh);
 
 	if (dth->dth_pinned) {
@@ -2797,9 +2838,8 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 		 * remove DTX records, purge related VOS objects from cache.
 		 */
 		dae = dth->dth_ent;
-		D_ASSERT(dae != NULL);
-
-		dtx_act_ent_cleanup(cont, dae, dth, true);
+		if (dae != NULL)
+			dtx_act_ent_cleanup(cont, dae, dth, true);
 	} else {
 		d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
 		d_iov_set(&riov, NULL, 0);
@@ -2819,8 +2859,11 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 
 				dae = dth->dth_ent;
 				if (dae != NULL) {
+					/* Cannot cleanup 'prepare'/'commit' DTX entry. */
+					if (vos_dae_is_prepare(dae) || vos_dae_is_commit(dae))
+						goto out;
+
 					dae->dae_aborted = 1;
-					dae->dae_prepared = 0;
 				}
 			} else {
 				rc = 0;
@@ -2830,8 +2873,8 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 			if (dth->dth_ent != NULL)
 				D_ASSERT(dth->dth_ent == dae);
 
-			/* Cannot cleanup 'committed' DTX entry. */
-			if (dae->dae_committable || dae->dae_committed)
+			/* Cannot cleanup 'prepare'/'commit' DTX entry. */
+			if (vos_dae_is_prepare(dae) || vos_dae_is_commit(dae))
 				goto out;
 
 			/* Skip the @dae if it belong to another instance for resent request. */
@@ -2859,7 +2902,7 @@ vos_dtx_cleanup(struct dtx_handle *dth, bool unpin)
 	struct vos_dtx_act_ent	*dae;
 	struct vos_container	*cont;
 
-	if (!dtx_is_valid_handle(dth))
+	if (!dtx_is_valid_handle(dth) || unlikely(dth->dth_already))
 		return;
 
 	dae = dth->dth_ent;
@@ -2867,10 +2910,8 @@ vos_dtx_cleanup(struct dtx_handle *dth, bool unpin)
 		if (!dth->dth_active)
 			return;
 	} else {
-		/* 'prepared' DTX can be either committed or aborted,
-		 * but not cleanup.
-		 */
-		if (dae->dae_prepared || dae->dae_committable || dae->dae_committed)
+		/* 'prepared'/'preparing' DTX can be either committed or aborted, not cleanup. */
+		if (vos_dae_is_prepare(dae) || vos_dae_is_commit(dae))
 			return;
 	}
 
@@ -2878,9 +2919,7 @@ vos_dtx_cleanup(struct dtx_handle *dth, bool unpin)
 		dth->dth_pinned = 0;
 
 	cont = vos_hdl2cont(dth->dth_coh);
-	/** This will abort the transaction and callback to
-	 *  vos_dtx_cleanup_internal
-	 */
+	/* This will abort the transaction and callback to vos_dtx_cleanup_internal(). */
 	vos_tx_end(cont, dth, NULL, NULL, true /* don't care */, -DER_CANCELED);
 }
 
@@ -2891,10 +2930,10 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist)
 	struct umem_instance	*umm = NULL;
 	struct vos_dtx_blob_df	*dbd = NULL;
 	struct vos_dtx_cmt_ent	*dce = NULL;
+	struct vos_cont_df	*cont_df = NULL;
 	struct vos_dtx_act_ent	*dae;
 	d_iov_t			 kiov;
 	d_iov_t			 riov;
-	bool			 began = false;
 	int			 rc = 0;
 
 	if (!dtx_is_valid_handle(dth))
@@ -2904,8 +2943,8 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist)
 	D_ASSERT(cont != NULL);
 
 	if (dth->dth_ent != NULL) {
-		if (!persistent || dth->dth_active)
-			return 0;
+		D_ASSERT(persistent);
+		D_ASSERT(dth->dth_active == 0);
 	} else {
 		D_ASSERT(dth->dth_pinned == 0);
 
@@ -2928,21 +2967,17 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist)
 	}
 
 	if (persistent) {
-		struct vos_cont_df	*cont_df;
-
 		umm = vos_cont2umm(cont);
-		cont_df = cont->vc_cont_df;
-
 		rc = umem_tx_begin(umm, NULL);
 		if (rc != 0)
 			goto out;
 
-		began = true;
+		cont_df = cont->vc_cont_df;
 		dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
 		if (dbd == NULL || dbd->dbd_index >= dbd->dbd_cap) {
 			rc = vos_dtx_extend_act_table(cont);
 			if (rc != 0)
-				return rc;
+				goto out;
 
 			dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
 		}
@@ -2950,10 +2985,13 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist)
 
 	if (dth->dth_ent == NULL) {
 		rc = vos_dtx_alloc(dbd, dth);
-	} else if (dbd != NULL) {
+	} else if (persistent) {
+		D_ASSERT(dbd != NULL);
 		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
 		dae = dth->dth_ent;
+		D_ASSERT(dae->dae_dbd == NULL);
+
 		dae->dae_df_off = cont->vc_cont_df->cd_dtx_active_tail +
 			offsetof(struct vos_dtx_blob_df, dbd_active_data) +
 			sizeof(struct vos_dtx_act_ent_df) * dbd->dbd_index;
@@ -2965,10 +3003,34 @@ out:
 		if (persistent) {
 			dth->dth_active = 1;
 			rc = vos_dtx_prepared(dth, &dce);
+			if (!dth->dth_solo)
+				D_ASSERT(dce == NULL);
 		} else {
 			dth->dth_pinned = 1;
 		}
-	} else {
+	}
+
+	if (persistent) {
+		if (cont_df != NULL) {
+			if (rc == 0) {
+				rc = umem_tx_commit(umm);
+				D_ASSERTF(rc == 0, "local TX commit failure %d\n", rc);
+			} else {
+				rc = umem_tx_abort(umm, rc);
+			}
+		}
+
+		dae = dth->dth_ent;
+		if (dae != NULL) {
+			dae->dae_preparing = 0;
+			if (dth->dth_solo)
+				vos_dtx_post_handle(cont, &dae, &dce, 1, false, rc != 0);
+			else if (rc == 0)
+				dae->dae_prepared = 1;
+		}
+	}
+
+	if (rc != 0) {
 		if (dth->dth_ent != NULL) {
 			dth->dth_pinned = 0;
 			vos_dtx_cleanup_internal(dth);
@@ -2976,16 +3038,6 @@ out:
 
 		D_ERROR("Failed to pin DTX entry for "DF_DTI": "DF_RC"\n",
 			DP_DTI(&dth->dth_xid), DP_RC(rc));
-	}
-
-	if (began) {
-		rc = umem_tx_end(umm, rc);
-		if (dce != NULL) {
-			dae = dth->dth_ent;
-			vos_dtx_post_handle(cont, &dae, &dce, 1,
-					    false, rc != 0 ? true : false);
-			dth->dth_ent = NULL;
-		}
 	}
 
 	return rc;

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -132,7 +132,7 @@ dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t next /
 		dae = rec_iov.iov_buf;
 	}
 
-	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+	while (vos_dae_is_commit(dae) || vos_dae_is_abort(dae) || dae->dae_preparing ||
 	       dae->dae_dth != NULL) {
 		if (oiter->oit_linear) {
 			if (dae->dae_link.next ==
@@ -204,7 +204,7 @@ dtx_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 				 sizeof(struct vos_dtx_act_ent));
 			dae = rec_iov.iov_buf;
 		}
-	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+	} while (vos_dae_is_commit(dae) || vos_dae_is_abort(dae) || dae->dae_preparing ||
 		 dae->dae_dth != NULL);
 
 out:
@@ -241,9 +241,9 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	}
 
 	/* Only return prepared ones. */
-	D_ASSERT(!dae->dae_committable);
-	D_ASSERT(!dae->dae_committed);
-	D_ASSERT(!dae->dae_aborted);
+	D_ASSERT(!vos_dae_is_commit(dae));
+	D_ASSERT(!vos_dae_is_abort(dae));
+	D_ASSERT(!dae->dae_preparing);
 	D_ASSERT(dae->dae_dth == NULL);
 
 	/*

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -46,10 +46,12 @@ vos_ilog_is_same_tx(struct umem_instance *umm, uint32_t tx_id,
 {
 	struct dtx_handle	*dth = vos_dth_get();
 	uint32_t		 dtx = vos_dtx_get();
+	daos_handle_t		 coh;
 
+	coh.cookie = (unsigned long)args;
 	*same = false;
 
-	if (tx_id == DTX_LID_COMMITTED) {
+	if (dtx_is_committed(tx_id, vos_hdl2cont(coh), epoch)) {
 		/** If it's committed and the current update is not
 		 * transactional, treat it as the same transaction and let the
 		 * minor epoch handle any conflicts.
@@ -90,7 +92,7 @@ vos_ilog_desc_cbs_init(struct ilog_desc_cbs *cbs, daos_handle_t coh)
 	cbs->dc_log_status_cb	= vos_ilog_status_get;
 	cbs->dc_log_status_args	= (void *)(unsigned long)coh.cookie;
 	cbs->dc_is_same_tx_cb = vos_ilog_is_same_tx;
-	cbs->dc_is_same_tx_args = NULL;
+	cbs->dc_is_same_tx_args = (void *)(unsigned long)coh.cookie;
 	cbs->dc_log_add_cb = vos_ilog_add;
 	cbs->dc_log_add_args = NULL;
 	cbs->dc_log_del_cb = vos_ilog_del;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -95,6 +95,14 @@ enum {
 	DTX_LID_RESERVED,
 };
 
+/**
+ * If the highest bit (31th) of the DTX entry offset is set, then it is for
+ * solo (single modification against single replicated object) transaction.
+ */
+#define DTX_LID_SOLO_BITS	31
+#define DTX_LID_SOLO_FLAG	(1UL << DTX_LID_SOLO_BITS)
+#define DTX_LID_SOLO_MASK	(DTX_LID_SOLO_FLAG - 1)
+
 /*
  * When aggregate merge window reaches this size threshold, it will stop
  * growing and trigger window flush immediately.
@@ -284,6 +292,10 @@ struct vos_container {
 	uint64_t		vc_io_nospc_ts;
 	/* The (next) position for committed DTX entries reindex. */
 	umem_off_t		vc_cmt_dtx_reindex_pos;
+	/* The epoch for the latest committed solo DTX. Any solo
+	 * * transaction with older epoch must have been committed.
+	 */
+	daos_epoch_t		vc_solo_dtx_epoch;
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,
@@ -328,11 +340,14 @@ struct vos_dtx_act_ent {
 	struct dtx_handle		*dae_dth;
 
 	unsigned int			 dae_committable:1,
+					 dae_committing:1,
 					 dae_committed:1,
+					 dae_aborting:1,
 					 dae_aborted:1,
 					 dae_maybe_shared:1,
 					 /* Need validation on leader before commit/committable. */
 					 dae_need_validation:1,
+					 dae_preparing:1,
 					 dae_prepared:1;
 };
 
@@ -405,6 +420,62 @@ D_CASSERT((VOS_AGG_TIME_MASK & (1ULL << (VOS_TF_AGG_BIT - VOS_AGG_NR_BITS))) == 
 CHECK_VOS_TREE_FLAG(VOS_KEY_CMP_LEXICAL);
 CHECK_VOS_TREE_FLAG(VOS_TF_AGG_OPT);
 CHECK_VOS_TREE_FLAG(VOS_AGG_TIME_MASK);
+
+/* For solo transaction (single modification against single replicated object),
+ * consider efficiency, we do not generate persistent DTX entry. Then we need
+ * some special mechanism to maintain the semantics: any readable data must be
+ * persistently visible unless it is over-written by newer modification. That
+ * is the same behavior as non-solo cases. So if the local backend TX for the
+ * solo transaction is in committing, then related modification is invisible
+ * until related local backend TX has been successfully committed. (NOTE: in
+ * committing modification maybe lost if engine crashed before commit done.)
+ *
+ * For this purpose, we will reuse the DTX entry index (uint32_t) in the data
+ * record (ilog/svt/evt). Originally, such 32-bits integer is used as the DTX
+ * entry offset in the DTX LRU array. Up to now, we only use the lower 20 bits
+ * (DTX_ARRAY_LEN). Now, the highest (31th) bit will be used as a solo flag to
+ * indicate a solo DTX. On the other hand, we will trace the epoch against the
+ * container for the latest committed solo DTX. Anytime, for a given solo DTX,
+ * if its epoch is newer than the one for the container known latest committed
+ * solo DTX, then it is in committing status; otherwise, it has been committed.
+ */
+static inline bool
+dtx_is_committed(uint32_t tx_lid, struct vos_container *cont, daos_epoch_t epoch)
+{
+	if (tx_lid == DTX_LID_COMMITTED)
+		return true;
+
+	D_ASSERT(cont != NULL);
+
+	if (tx_lid & DTX_LID_SOLO_FLAG && cont->vc_solo_dtx_epoch >= epoch)
+		return true;
+
+	return false;
+}
+
+static inline bool
+dtx_is_aborted(uint32_t tx_lid)
+{
+	return tx_lid == DTX_LID_ABORTED;
+}
+
+static inline bool
+vos_dtx_is_normal_entry(uint32_t tx_lid)
+{
+	return tx_lid >= DTX_LID_RESERVED && !(tx_lid & DTX_LID_SOLO_FLAG);
+}
+
+static inline void
+dtx_set_committed(uint32_t *tx_lid)
+{
+	*tx_lid = DTX_LID_COMMITTED;
+}
+
+static inline void
+dtx_set_aborted(uint32_t *tx_lid)
+{
+	*tx_lid = DTX_LID_ABORTED;
+}
 
 /** Get the aggregatable write timestamp within 1/4 ms granularity */
 static inline bool
@@ -557,21 +628,22 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
  * Get local entry DTX state. Only used by VOS aggregation.
  *
  * \param entry		[IN]	DTX local id
+ * \param cont		[IN]	Pointer to the vos container.
+ * \param epoch		[IN]	Epoch for the entry.
  *
  * \return		DTX_ST_COMMITTED, DTX_ST_PREPARED or
  *			DTX_ST_ABORTED.
  */
 static inline unsigned int
-vos_dtx_ent_state(uint32_t entry)
+vos_dtx_ent_state(uint32_t entry, struct vos_container *cont, daos_epoch_t epoch)
 {
-	switch (entry) {
-	case DTX_LID_COMMITTED:
+	if (dtx_is_committed(entry, cont, epoch))
 		return DTX_ST_COMMITTED;
-	case DTX_LID_ABORTED:
+
+	if (dtx_is_aborted(entry))
 		return DTX_ST_ABORTED;
-	default:
-		return DTX_ST_PREPARED;
-	}
+
+	return DTX_ST_PREPARED;
 }
 
 /**
@@ -1488,6 +1560,30 @@ struct csum_recalc_args {
 };
 
 int vos_csum_recalc_fn(void *recalc_args);
+
+static inline bool
+vos_dae_is_commit(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_committable || dae->dae_committing || dae->dae_committed;
+}
+
+static inline bool
+vos_dae_is_abort(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_aborting || dae->dae_aborted;
+}
+
+static inline bool
+vos_dae_is_prepare(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_preparing || dae->dae_prepared;
+}
+
+static inline bool
+vos_dae_in_process(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_committing || dae->dae_aborting || dae->dae_preparing;
+}
 
 static inline struct dcs_csum_info *
 vos_csum_at(struct dcs_iod_csums *iod_csums, unsigned int idx)

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -526,27 +526,27 @@ reset:
 			rc = -DER_TX_RESTART;
 	}
 
-	rc = vos_tx_end(cont, dth, NULL, NULL, true, rc);
-
-	if (rc == 0) {
+	if (rc == 0)
 		vos_ts_set_upgrade(ts_set);
-		if (daes != NULL) {
-			vos_dtx_post_handle(cont, daes, dces,
-					    dth->dth_dti_cos_count,
-					    false, false);
-			dth->dth_cos_done = 1;
-		}
-	} else if (daes != NULL) {
-		vos_dtx_post_handle(cont, daes, dces,
-				    dth->dth_dti_cos_count, false, true);
-		dth->dth_cos_done = 1;
-	}
 
 	if (rc == -DER_NONEXIST || rc == 0) {
 		vos_punch_add_missing(ts_set, dkey, akey_nr, akeys);
 		vos_ts_set_update(ts_set, epr.epr_hi);
+	}
+
+	if (rc == 0)
+		vos_ts_set_wupdate(ts_set, epr.epr_hi);
+
+	rc = vos_tx_end(cont, dth, NULL, NULL, true, rc);
+	if (dtx_is_valid_handle(dth)) {
 		if (rc == 0)
-			vos_ts_set_wupdate(ts_set, epr.epr_hi);
+			dth->dth_cos_done = 1;
+		else
+			dth->dth_cos_done = 0;
+
+		if (daes != NULL)
+			vos_dtx_post_handle(cont, daes, dces, dth->dth_dti_cos_count,
+					    false, rc != 0);
 	}
 
 	D_FREE(daes);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -440,7 +440,7 @@ svt_rec_load(struct btr_instance *tins, struct btr_record *rec,
 	rbund->rb_rsize	= irec->ir_size;
 	rbund->rb_gsize	= irec->ir_gsize;
 	rbund->rb_ver	= irec->ir_ver;
-	rbund->rb_dtx_state = vos_dtx_ent_state(irec->ir_dtx);
+	rbund->rb_dtx_state = vos_dtx_ent_state(irec->ir_dtx, vos_hdl2cont(tins->ti_coh), *epc);
 	rbund->rb_off = rec->rec_off;
 	return 0;
 }


### PR DESCRIPTION
Under original PMDK based local TX model, we assume that current ULT will not yield inside the local PMDK TX. But such assumption is not guaranteed under other backend local TX model, such as on SSD based system.

The patch introduces three temporary status for active DTX entry in DRAM: 'preparing', 'committing' and 'aborting'. Base on these, It adjusts related DTX logic to allow CPU yield during DTX status changes, including:

1. 'init' => 'preparing' => 'prepared'
2. 'init' => 'committing' => 'committed'
3. 'prepared' => 'committing' => 'committed'
4. 'prepared' => 'aborting' => 'aborted'

It works for both PMDK based local TX and metadata on SSD model. It does not change on-wire RPC protocol. As for the on-disk data layout, it is also compatible with old release. In the patch, we reuse the DTX entry local index (a 32-bits integer) in the data record (vos_irec_df::ir_dtx, evt_desc::dc_dtx, ilog_id::id_tx_id) to specially indicate whether related DTX is for solo transaction (single modification against single replicated object) or not via the highest (31th) one bit. For old release, it will not find any DTX entry if the DTX local index with such bit. Then according to old logic, related DTX will be regarded as 'committed', that just is correct and expected.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
