### PR TITLE
DAOS-12447 vos: fix LRU array free lru_sub list corruption

### DIFF
--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -113,8 +113,8 @@ lrua_find_free(struct lru_array *array, struct lru_entry **entry,
 
 /** Internal API: Remove an entry from the lru list */
 static inline void
-lrua_remove_entry(struct lru_sub *sub, uint32_t *head, struct lru_entry *entry,
-		  uint32_t idx)
+lrua_remove_entry(struct lru_array *array, struct lru_sub *sub, uint32_t *head,
+		  struct lru_entry *entry, uint32_t idx)
 {
 	struct lru_entry	*entries = &sub->ls_table[0];
 	struct lru_entry	*prev = &entries[entry->le_prev_idx];
@@ -123,14 +123,19 @@ lrua_remove_entry(struct lru_sub *sub, uint32_t *head, struct lru_entry *entry,
 	/** Last entry in the list */
 	if (prev == entry) {
 		*head = LRU_NO_IDX;
-		return;
+	} else {
+		prev->le_next_idx = entry->le_next_idx;
+		next->le_prev_idx = entry->le_prev_idx;
+		if (idx == *head)
+			*head = entry->le_next_idx;
 	}
 
-	prev->le_next_idx = entry->le_next_idx;
-	next->le_prev_idx = entry->le_prev_idx;
-
-	if (idx == *head)
-		*head = entry->le_next_idx;
+	/*
+	 * If no free entries in the sub, then remove it from array free list (array->la_free_sub)
+	 * to avoid being searched when try to find free entry next time.
+	 */
+	if (head == &sub->ls_free && *head == LRU_NO_IDX && array->la_flags & LRU_FLAG_EVICT_MANUAL)
+		d_list_del_init(&sub->ls_link);
 }
 
 /** Internal API: Insert an entry in the lru list */
@@ -164,7 +169,8 @@ lrua_insert(struct lru_sub *sub, uint32_t *head, struct lru_entry *entry,
 
 /** Internal API: Make the entry the mru */
 static inline void
-lrua_move_to_mru(struct lru_sub *sub, struct lru_entry *entry, uint32_t idx)
+lrua_move_to_mru(struct lru_array *array, struct lru_sub *sub,
+		 struct lru_entry *entry, uint32_t idx)
 {
 	if (entry->le_next_idx == sub->ls_lru) {
 		/** Already the mru */
@@ -180,7 +186,7 @@ lrua_move_to_mru(struct lru_sub *sub, struct lru_entry *entry, uint32_t idx)
 	}
 
 	/** First remove */
-	lrua_remove_entry(sub, &sub->ls_lru, entry, idx);
+	lrua_remove_entry(array, sub, &sub->ls_lru, entry, idx);
 
 	/** Insert at mru */
 	lrua_insert(sub, &sub->ls_lru, entry, idx, true);
@@ -208,7 +214,7 @@ lrua_lookup_idx(struct lru_array *array, uint32_t idx, uint64_t key,
 	if (entry->le_key == key) {
 		if (touch_mru && !array->la_evicting) {
 			/** Only make mru if we are not evicting it */
-			lrua_move_to_mru(sub, entry, ent_idx);
+			lrua_move_to_mru(array, sub, entry, ent_idx);
 		}
 		return entry;
 	}
@@ -423,7 +429,7 @@ lrua_allocx_inplace_(struct lru_array *array, uint32_t idx, uint64_t key,
 	entry->le_key = key;
 
 	/** First remove */
-	lrua_remove_entry(sub, &sub->ls_free, entry, ent_idx);
+	lrua_remove_entry(array, sub, &sub->ls_free, entry, ent_idx);
 
 	/** Insert at mru */
 	lrua_insert(sub, &sub->ls_lru, entry, ent_idx, true);


### PR DESCRIPTION
master-commit: f45b589bd0467e2fa6d8a11ed4068c32ecbcfa36

When there is no free entry in a lru_sub, it is expected to be removed from the free list of the LRU array. But under some cases, such as DTX reindex that may trigger lrua_remove_entry, it does not do that, as to related lru_sub may be added into the LRU array free lru_sub list more that once. Then when traverse such list, it may fall into dead loop.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
