### PR TITLE
DAOS-12892 test: control/dmg_system_reformat.py test issue

### DIFF
--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -51,7 +51,7 @@ class DmgSystemReformatTest(TestWithServers):
             pools[-1].create()
         except TestFail as error:
             self.log.info("Pool create failed: %s", str(error))
-            if "-1007" not in dmg.result.stderr_text:
+            if "-1007" not in str(error):
                 self.fail("Pool create did not fail due to DER_NOSPACE!")
         dmg.exit_status_exception = True
 

--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -51,7 +51,7 @@ class DmgSystemReformatTest(TestWithServers):
             pools[-1].create()
         except TestFail as error:
             self.log.info("Pool create failed: %s", str(error))
-            if "-1007" not in error:
+            if "-1007" not in dmg.result.stderr_text:
                 self.fail("Pool create did not fail due to DER_NOSPACE!")
         dmg.exit_status_exception = True
 

--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -39,25 +39,27 @@ class DmgSystemReformatTest(TestWithServers):
         :avocado: tags=control,dmg,system_reformat
         :avocado: tags=DmgSystemReformatTest,test_dmg_system_reformat
         """
+        dmg = self.get_dmg_command().copy()
+
         # Create pool using 90% of the available NVMe capacity
-        pools = [add_pool(self)]
+        pools = [add_pool(self, dmg=dmg)]
 
         self.log.info("Check that new pool will fail with DER_NOSPACE")
-        self.get_dmg_command().exit_status_exception = False
+        dmg.exit_status_exception = False
         pools.append(add_pool(self, create=False, **get_size_params(pools[0])))
         try:
             pools[-1].create()
         except TestFail as error:
             self.log.info("Pool create failed: %s", str(error))
-            if "-1007" not in self.get_dmg_command().result.stderr_text:
+            if "-1007" not in error:
                 self.fail("Pool create did not fail due to DER_NOSPACE!")
-        self.get_dmg_command().exit_status_exception = True
+        dmg.exit_status_exception = True
 
         self.log.info("Stop running engine instances: 'dmg system stop'")
-        self.get_dmg_command().system_stop(force=True)
-        if self.get_dmg_command().result.exit_status != 0:
+        dmg.system_stop(force=True)
+        if dmg.result.exit_status != 0:
             self.fail("Detected issues performing a system stop: {}".format(
-                self.get_dmg_command().result.stderr_text))
+                dmg.result.stderr_text))
 
         # Remove pools and disable removing pools that about to be removed by formatting
         for pool in pools:
@@ -66,10 +68,10 @@ class DmgSystemReformatTest(TestWithServers):
 
         # Perform a dmg system erase to allow the dmg storage format to succeed
         self.log.info("Perform dmg system erase on all system ranks:")
-        self.get_dmg_command().system_erase()
-        if self.get_dmg_command().result.exit_status != 0:
+        dmg.system_erase()
+        if dmg.result.exit_status != 0:
             self.fail("Issues performing system erase: {}".format(
-                self.get_dmg_command().result.stderr_text))
+                dmg.result.stderr_text))
 
         self.log.info("Perform dmg storage format on all system ranks:")
 
@@ -78,11 +80,11 @@ class DmgSystemReformatTest(TestWithServers):
         count = 0
         while count < 4:
             try:
-                self.get_dmg_command().storage_format(force=True)
-                if self.get_dmg_command().result.exit_status != 0:
+                dmg.storage_format(force=True)
+                if dmg.result.exit_status != 0:
                     self.fail(
                         "Issues performing storage format --force: {}".format(
-                            self.get_dmg_command().result.stderr_text))
+                            dmg.result.stderr_text))
                 break
             except CommandFailure as error:
                 self.log.info("Storage format failed. Wait 10 sec and retry. %s", error)
@@ -94,14 +96,14 @@ class DmgSystemReformatTest(TestWithServers):
         self.server_managers[-1].detect_engine_start()
 
         # Check that we have cleared storage by checking pool list
-        if self.get_dmg_command().get_pool_list_uuids():
+        if dmg.get_pool_list_uuids():
             self.fail("Detected pools in storage after reformat: {}".format(
-                self.get_dmg_command().result.stdout_text))
+                dmg.result.stdout_text))
 
         # Create last pool now that memory has been wiped.
-        pools.append(add_pool(self, connect=False))
+        pools.append(add_pool(self, connect=False), dmg=dmg)
 
         # Lastly, verify that last created pool is in the list
-        pool_uuids = self.get_dmg_command().get_pool_list_uuids()
+        pool_uuids = dmg.get_pool_list_uuids()
         self.assertEqual(
             pool_uuids[0].lower(), pools[-1].uuid.lower(), "{} missing from list".format(pools[-1]))

--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -101,7 +101,7 @@ class DmgSystemReformatTest(TestWithServers):
                 dmg.result.stdout_text))
 
         # Create last pool now that memory has been wiped.
-        pools.append(add_pool(self, connect=False), dmg=dmg)
+        pools.append(add_pool(self, connect=False, dmg=dmg))
 
         # Lastly, verify that last created pool is in the list
         pool_uuids = dmg.get_pool_list_uuids()


### PR DESCRIPTION
Update dmg_get_command timeout issue and check for no-space from execption error.

Test-tag: test_dmg_system_reformat
Test-repeat: 5
Doc-only: false
Required-githooks: true
Signed-off-by: Ding Ho ding-hwa.ho@intel.com

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
