### PR TITLE
DAOS-9721 test: use container label by default with most tests

### DIFF
--- a/src/tests/ftest/datamover/posix_preserve_props.py
+++ b/src/tests/ftest/datamover/posix_preserve_props.py
@@ -9,6 +9,7 @@ from pydaos.raw import DaosApiError
 import avocado
 
 from data_mover_test_base import DataMoverTestBase
+from duns_utils import format_path
 
 
 class DmvrPreserveProps(DataMoverTestBase):
@@ -73,16 +74,16 @@ class DmvrPreserveProps(DataMoverTestBase):
         # move data from DAOS to POSIX path and record container properties in hdf5 file
         self.run_datamover(
             self.test_id + " cont1 to posix",
-            "DAOS", "/", pool1, cont1,
-            "POSIX", posix_path, None, None)
+            src_path=format_path(pool1, cont1),
+            dst_path=posix_path)
 
         # move data from POSIX path to DAOS and read container properties in hdf5 file to cont2
         # don't copy test directory back to DAOS, only test file needs to be verified with ior
         posix_file_path = join(posix_path, self.test_file)
         result = self.run_datamover(
             self.test_id + " posix to cont2 (empty cont)",
-            "POSIX", posix_file_path, None, None,
-            "DAOS", "/", pool1, None)
+            src_path=posix_file_path,
+            dst_path=format_path(pool1))
 
         cont2_label = self.parse_create_cont_label(result.stdout_text)
         cont2 = self.get_cont(pool1, cont2_label)
@@ -115,7 +116,7 @@ class DmvrPreserveProps(DataMoverTestBase):
         cont.close()
 
         # Return existing cont properties
-        return self.get_cont_prop(cont)
+        return cont.get_prop()["response"]
 
     def verify_cont(self, cont, api, check_attr_prop=True, prop_list=None):
         """Read-verify test data using either ior or the obj API.
@@ -124,12 +125,12 @@ class DmvrPreserveProps(DataMoverTestBase):
             cont (TestContainer): the container to verify.
             check_attr_prop (bool, optional): whether to verify user
                 attributes and cont properties. Defaults to False.
-            prop_list (list, optional): list of properties from get_cont_prop.
+            prop_list (list, optional): list of properties from container get-prop.
                 Required when check_attr_prop is True.
 
         """
         # It's important to check the properties first, since when ior
-        # mounts DFS the alloc'ed OID might be incremented.
+        # mounts DFS the allocated OID might be incremented.
         if check_attr_prop:
             cont.open()
             self.verify_cont_prop(cont, prop_list, api)
@@ -145,50 +146,35 @@ class DmvrPreserveProps(DataMoverTestBase):
             # Verify non-POSIX containers copied with the Object API
             self.dataset_verify(self.obj_list, cont, 1, 1, 1, 0, [1024], [])
 
-    def get_cont_prop(self, cont):
-        """Get all container properties with daos command.
-
-        Args:
-            cont (TestContainer): the container to get props of.
-
-        Returns:
-            list: list of dictionaries that contain properties and values from daos
-                command.
-
-        """
-        prop_result = self.daos_cmd.container_get_prop(cont.pool.uuid, cont.uuid)
-        return prop_result["response"]
-
     def verify_cont_prop(self, cont, prop_list, api):
         """Verify container properties against an input list.
         Expects the container to be open.
 
         Args:
             cont (TestContainer): the container to verify.
-            prop_list (list): list of properties from get_cont_prop.
+            prop_list (list): list of properties from container get-prop.
 
         """
-        actual_list = self.get_cont_prop(cont)
+        actual_list = cont.get_prop()["response"]
 
         # Make sure sizes match
         if len(prop_list) != len(actual_list):
-            self.log.info("Expected\n%s\nbut got\n%s\n",
-                          prop_list, actual_list)
+            self.log.info("Expected\n%s\nbut got\n%s\n", prop_list, actual_list)
             self.fail("Container property verification failed.")
 
         # Make sure each property matches
         for prop_idx, prop in enumerate(prop_list):
             # This one is not set
-            if (api == "DFS") and ("OID" in str(prop["description"]) or "ROOTS" in str(
-                    prop["description"])):
+            if (api == "DFS") and ("OID" in prop["description"] or "ROOTS" in prop["description"]):
+                continue
+            # Labels are unique, so can be different
+            if prop["name"] == "label":
                 continue
             if prop != actual_list[prop_idx]:
-                self.log.info("Expected\n%s\nbut got\n%s\n",
-                              prop_list, actual_list)
+                self.log.info("Expected\n%s\nbut got\n%s\n", prop_list, actual_list)
                 self.fail("Container property verification failed.")
 
-        self.log.info("Verified %d container properties:\n%s",
-                      len(actual_list), actual_list)
+        self.log.info("Verified %d container properties:\n%s", len(actual_list), actual_list)
 
     @staticmethod
     def get_cont_usr_attr():

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -276,7 +276,7 @@ class TestContainer(TestDaosApiBase):  # pylint: disable=too-many-public-methods
         self.chunk_size = BasicParameter(None)
         self.properties = BasicParameter(None)
         self.daos_timeout = BasicParameter(None)
-        self.label = BasicParameter(None)
+        self.label = BasicParameter(None, "TestContainer")
         self.label_generator = label_generator
 
         self.container = None
@@ -359,6 +359,10 @@ class TestContainer(TestDaosApiBase):  # pylint: disable=too-many-public-methods
         self.container = DaosContainer(self.pool.context)
 
         if self.control_method.value == self.USE_API:
+            # pydaos.raw doesn't support create with a label
+            self.log.info("Ignoring label for container created with API")
+            self.label.update(None)
+
             # Create a container with the API method
             kwargs = {"poh": self.pool.pool.handle}
             if uuid is not None:

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -204,7 +204,7 @@ class TestPool(TestDaosApiBase):
         self.rebuild_timeout = BasicParameter(None)
         self.pool_query_timeout = BasicParameter(None)
         self.acl_file = BasicParameter(None)
-        self.label = BasicParameter(None, "TestLabel")
+        self.label = BasicParameter(None, "TestPool")
         self.label_generator = label_generator
 
         # Optional TestPool parameters used to autosize the dmg pool create


### PR DESCRIPTION
Test-tag: pr daily_regression container pool
Skip-unit-tests: true
Skip-fault-injection-test: true

- Use a container label by default with all tests.
- Except for create through the pydaos.raw API
- Also rename the pool label of TestLabel to TestPool

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [x] You are the appropriate gatekeeper to be landing the patch.
* [x] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [x] Githooks were used. If not, request that user install them and check copyright dates.
* [x] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [x] All builds have passed.  Check non-required builds for any new compiler warnings.
* [x] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [x] If applicable, the PR has addressed any potential version compatibility issues.
* [x] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [x] Extra checks if forced landing is requested
  * [x] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [x] No new NLT or valgrind warnings.  Check the classic view.
  * [x] Quick-build or Quick-functional is not used.
* [x] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
