### PR TITLE
DAOS-12911 dtx: handle stale pool map when prepare TX commit

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4725,8 +4725,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 				  task->dt_result == -DER_NONEXIST)) {
 				obj_addref(obj);
 				/* Cache transactional read if exist or not. */
-				dc_tx_attach(obj_auxi->th, obj,
-					     DAOS_OBJ_RPC_FETCH, task);
+				dc_tx_attach(obj_auxi->th, obj, DAOS_OBJ_RPC_FETCH, task, false);
 			}
 			break;
 		}
@@ -4746,8 +4745,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 				D_ASSERT(obj != NULL);
 				obj_addref(obj);
 				/* Cache transactional read if exist or not. */
-				dc_tx_attach(obj_auxi->th, obj,
-					     obj_auxi->opc, task);
+				dc_tx_attach(obj_auxi->th, obj, obj_auxi->opc, task, false);
 			}
 			break;
 		case DAOS_OBJ_RPC_ENUMERATE:
@@ -5760,18 +5758,16 @@ dc_obj_update_task(tse_task_t *task)
 	if (rc != 0)
 		goto comp;
 
-	if (daos_handle_is_valid(args->th)) {
+	if (daos_handle_is_valid(args->th))
 		/* add the operation to DTX and complete immediately */
-		rc = dc_tx_attach(args->th, obj, DAOS_OBJ_RPC_UPDATE, task);
-		goto comp;
-	}
+		return dc_tx_attach(args->th, obj, DAOS_OBJ_RPC_UPDATE, task, true);
 
 	/* submit the update */
 	return dc_obj_update(task, &epoch, map_ver, args, obj);
+
 comp:
-	if (rc <= 0)
-		obj_task_complete(task, rc);
-	return rc > 0 ? 0 : rc;
+	obj_task_complete(task, rc);
+	return rc;
 }
 
 static int
@@ -6642,17 +6638,16 @@ obj_punch_common(tse_task_t *task, enum obj_rpc_opc opc, daos_obj_punch_t *args)
 	if (rc != 0)
 		goto comp; /* invalid parameters */
 
-	if (daos_handle_is_valid(args->th)) {
+	if (daos_handle_is_valid(args->th))
 		/* add the operation to DTX and complete immediately */
-		rc = dc_tx_attach(args->th, obj, opc, task);
-		goto comp;
-	}
+		return dc_tx_attach(args->th, obj, opc, task, true);
+
 	/* submit the punch */
 	return dc_obj_punch(task, obj, &epoch, map_ver, opc, args);
+
 comp:
-	if (rc <= 0)
-		obj_task_complete(task, rc);
-	return rc > 0 ? 0 : rc;
+	obj_task_complete(task, rc);
+	return rc;
 }
 
 int

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -871,7 +871,7 @@ dc_tx_get_dti(daos_handle_t th, struct dtx_id *dti);
 
 int
 dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
-	     tse_task_t *task);
+	     tse_task_t *task, bool comp);
 
 int
 dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task);

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1305,8 +1305,12 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 			continue;
 		}
 
-		if (rc != 0)
+		if (rc != 0) {
+			if (rc == -DER_STALE)
+				D_WARN("Used stale pool map %u/%u for "DF_DTI"\n",
+				       obj->cob_version, tx->tx_pm_ver, DP_DTI(&tx->tx_id));
 			goto out;
+		}
 
 		if (reasb_req != NULL && reasb_req->tgt_bitmap != NIL_BITMAP &&
 		    isclr(reasb_req->tgt_bitmap, shard->do_shard % daos_oclass_grp_size(oca))) {
@@ -2125,11 +2129,14 @@ out:
 static int
 dc_tx_commit_trigger(tse_task_t *task, struct dc_tx *tx, daos_tx_commit_t *args)
 {
+	tse_task_t			*pool_task = NULL;
 	crt_rpc_t			*req = NULL;
 	struct obj_cpd_in		*oci;
+	struct daos_cpd_sub_req		*dcsr;
 	struct tx_commit_cb_args	 tcca;
 	crt_endpoint_t			 tgt_ep;
 	int				 rc = 0;
+	bool				 locked = true;
 
 	if (tx->tx_pm_ver != 0 && tx->tx_pm_ver != dc_pool_get_version(tx->tx_pool) &&
 	    (tx->tx_retry || tx->tx_read_cnt > 0))
@@ -2137,12 +2144,8 @@ dc_tx_commit_trigger(tse_task_t *task, struct dc_tx *tx, daos_tx_commit_t *args)
 
 	if (!tx->tx_retry) {
 		rc = dc_tx_commit_prepare(tx, task);
-		if (rc != 0) {
-			if (rc == -DER_STALE)
-				rc = -DER_TX_RESTART;
-
+		if (rc != 0)
 			goto out;
-		}
 	}
 
 	tgt_ep.ep_grp = tx->tx_pool->dp_sys->sy_group;
@@ -2200,13 +2203,34 @@ out_req:
 	crt_req_decref(req);
 	crt_req_decref(req);
 out:
-	if (rc == -DER_TX_RESTART)
-		tx->tx_status = TX_FAILED;
-	else if (rc != 0)
-		tx->tx_status = TX_ABORTED;
+	if (rc == -DER_STALE) {
+		dcsr = &tx->tx_req_cache[dc_tx_leftmost_req(tx, false)];
+		rc = obj_pool_query_task(tse_task2sched(task), dcsr->dcsr_obj, 0, &pool_task);
+		if (rc != 0) {
+			/* It is unnecessary to restart the TX if failed to
+			 * refresh pool map to avoid falling into deap loop.
+			 */
+			D_ERROR("Failed to refresh pool map for "DF_DTI": "DF_RC"\n",
+				DP_DTI(&tx->tx_id), DP_RC(rc));
+		} else {
+			rc = -DER_TX_RESTART;
+			tx->tx_status = TX_FAILED;
+			/* Unlock for dc_tx_commit held. */
+			D_MUTEX_UNLOCK(&tx->tx_lock);
+			locked = false;
+			tse_task_schedule(pool_task, true);
+		}
+	}
 
-	/* Unlock for dc_tx_commit held. */
-	D_MUTEX_UNLOCK(&tx->tx_lock);
+	if (locked) {
+		if (rc == -DER_TX_RESTART)
+			tx->tx_status = TX_FAILED;
+		else if (rc != 0)
+			tx->tx_status = TX_ABORTED;
+		/* Unlock for dc_tx_commit held. */
+		D_MUTEX_UNLOCK(&tx->tx_lock);
+	}
+
 	/* -1 for dc_tx_commit() held */
 	dc_tx_decref(tx);
 
@@ -2910,6 +2934,17 @@ struct dc_tx_check_existence_cb_args {
 	daos_iod_t		*tmp_iods;
 };
 
+static inline int
+dc_tx_post(struct dc_tx *tx, tse_task_t *task, enum obj_rpc_opc opc, int result)
+{
+	if (tx->tx_for_convert)
+		result = dc_tx_convert_post(tx, task, opc, result);
+	else
+		tse_task_complete(task, result);
+
+	return result;
+}
+
 static int
 dc_tx_check_update(uint64_t flags, int result)
 {
@@ -2967,13 +3002,12 @@ dc_tx_per_akey_existence_parent_cb(tse_task_t *task, void *data)
 		obj_decref(obj);
 	}
 
-	if (tx->tx_for_convert)
-		rc = dc_tx_convert_post(tx, args->task, args->opc, rc);
+	dc_tx_post(tx, args->task, args->opc, rc);
 
 	/* Drop the reference that is held via dc_tx_attach(). */
 	dc_tx_decref(tx);
 
-	return rc;
+	return 0;
 }
 
 static int
@@ -3023,6 +3057,7 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 
 out:
 	D_MUTEX_UNLOCK(&tx->tx_lock);
+	obj_decref(obj);
 
 	if (args->tmp_iods != NULL) {
 		for (i = 0; i < args->nr; i++)
@@ -3031,15 +3066,10 @@ out:
 		D_FREE(args->tmp_iods);
 	}
 
-	if (tx->tx_for_convert)
-		rc = dc_tx_convert_post(tx, args->task, args->opc, rc);
-
-	/* The errno will be auto propagated to the dependent task. */
-	task->dt_result = rc;
+	dc_tx_post(tx, args->task, args->opc, rc);
 
 	/* Drop the reference that is held via dc_tx_attach(). */
 	dc_tx_decref(tx);
-	obj_decref(obj);
 
 	return 0;
 }
@@ -3131,8 +3161,7 @@ out:
 			D_MUTEX_UNLOCK(&tx->tx_lock);
 			obj_decref(obj);
 
-			if (tx->tx_for_convert)
-				rc = dc_tx_convert_post(tx, parent, opc, rc);
+			rc = dc_tx_post(tx, parent, opc, rc);
 
 			/* Drop the reference that is held via dc_tx_attach(). */
 			dc_tx_decref(tx);
@@ -3143,12 +3172,6 @@ out:
 				goto fail;
 
 			tse_task_list_sched(&task_list, true);
-
-			/*
-			 * Return positive value to notify the sponsor to not call
-			 * complete() the task until the checking existence callback.
-			 */
-			rc = 1;
 		}
 	} else {
 		if (task != NULL)
@@ -3161,8 +3184,8 @@ out:
 
 fail:
 		tse_task_list_traverse(&task_list, shard_task_abort, &rc);
-		if (tx->tx_for_convert)
-			rc = dc_tx_convert_post(tx, parent, opc, rc);
+
+		rc = dc_tx_post(tx, parent, opc, rc);
 
 		/* Drop the reference that is held via dc_tx_attach(). */
 		dc_tx_decref(tx);
@@ -3253,12 +3276,7 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 		goto out;
 	}
 
-	rc = dc_task_schedule(task, true);
-
-	/* Return positive value to notify the sponsor to not call
-	 * complete() the task until the checking existence callback.
-	 */
-	return rc == 0 ? 1 : rc;
+	return tse_task_schedule(task, true);
 
 out:
 	if (task != NULL)
@@ -3271,8 +3289,7 @@ out:
 		D_FREE(iods);
 	}
 
-	if (tx->tx_for_convert)
-		rc = dc_tx_convert_post(tx, parent, opc, rc);
+	rc = dc_tx_post(tx, parent, opc, rc);
 
 	/* Drop the reference that is held via dc_tx_attach(). */
 	dc_tx_decref(tx);
@@ -3282,7 +3299,7 @@ out:
 
 int
 dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
-	     tse_task_t *task)
+	     tse_task_t *task, bool comp)
 {
 	struct dc_tx	*tx;
 	int		 rc;
@@ -3419,6 +3436,9 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 
 out_obj:
 	obj_decref(obj);
+
+	if (comp)
+		tse_task_complete(task, rc);
 
 	return rc;
 }
@@ -3557,12 +3577,14 @@ dc_tx_convert_post(struct dc_tx *tx, tse_task_t *task, enum obj_rpc_opc opc, int
 		goto out;
 	}
 
-	return dc_task_schedule(cmt_task, true);
+	/* 'task' (the parent one) will be completed after 'cmt_task' completed. */
+	return tse_task_schedule(cmt_task, true);
 
 out:
 	if (cmt_task != NULL)
 		tse_task_complete(cmt_task, rc);
 
+	/* Explicitly complete the original task. */
 	tse_task_complete(task, rc);
 	dc_tx_close_internal(tx);
 
@@ -3593,8 +3615,12 @@ dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task)
 	/* Hold another reference on TX to avoid being freed duing dc_tx_attach(). */
 	dc_tx_addref(tx);
 	tx->tx_for_convert = 1;
-	rc = dc_tx_attach(dc_tx_ptr2hdl(tx), obj, opc, task);
+	rc = dc_tx_attach(dc_tx_ptr2hdl(tx), obj, opc, task, false);
 
+	/* The 'task' will be completed via dc_tx_convert_post(). For condition case,
+	 * dc_tx_convert_post() will be triggered via condition callback; otherwise,
+	 * call dc_tx_convert_post() directly.
+	 */
 	if (!tx->tx_has_cond)
 		rc = dc_tx_convert_post(tx, task, opc, rc);
 


### PR DESCRIPTION
dc_tx_commit_prepare() may return -DER_STALE because of stale pool map. Under such case, we need to refresh the pool map to avoid subsequent TX restart falling into dead loop.

Some other code cleanup related with task completion.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
