### PR TITLE
DAOS-12638 test: Increase number of cores for dfuse

### DIFF
--- a/src/tests/ftest/soak/smoke.yaml
+++ b/src/tests/ftest/soak/smoke.yaml
@@ -118,7 +118,7 @@ ior_smoke:
     mount_dir: "/tmp/daos_dfuse/ior/"
     disable_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
 fio_smoke:
   job_timeout: 10
   names:
@@ -148,7 +148,7 @@ fio_smoke:
     mount_dir: "/tmp/daos_dfuse/fio/"
     disable_wb_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
 daos_racer:
   runtime: 120
 vpic_smoke:
@@ -164,7 +164,7 @@ vpic_smoke:
     mount_dir: "/tmp/daos_dfuse/vpic/"
     disable_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
 lammps_smoke:
@@ -180,7 +180,7 @@ lammps_smoke:
     mount_dir: "/tmp/daos_dfuse/lammps/"
     disable_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
 mdtest_smoke:
@@ -211,7 +211,7 @@ mdtest_smoke:
     mount_dir: "/tmp/daos_dfuse/mdtest/"
     disable_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
 macsio_smoke:
   job_timeout: 10
   nodesperjob:
@@ -235,7 +235,7 @@ macsio_smoke:
     mount_dir: "/tmp/daos_dfuse/macsio/"
     disable_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
 hdf5_vol:
   plugin_path: "/usr/lib64/mpich/lib"
 events:

--- a/src/tests/ftest/soak/stress_48h.yaml
+++ b/src/tests/ftest/soak/stress_48h.yaml
@@ -125,7 +125,7 @@ ior_stress:
     mount_dir: "/tmp/daos_dfuse/ior/"
     disable_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
 fio_stress:
   job_timeout: 30
   names:
@@ -163,7 +163,7 @@ fio_stress:
     mount_dir: "/tmp/daos_dfuse/fio/"
     disable_wb_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
 daos_racer:
   runtime: 120
 vpic_stress:
@@ -194,7 +194,7 @@ lammps_stress:
     mount_dir: "/tmp/daos_dfuse/lammps/"
     disable_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
 mdtest_stress:
@@ -233,7 +233,7 @@ mdtest_stress:
     mount_dir: "/tmp/daos_dfuse/mdtest/"
     disable_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
 macsio_stress:
   job_timeout: 30
   nodesperjob:
@@ -264,7 +264,7 @@ macsio_stress:
     mount_dir: "/tmp/daos_dfuse/macsio/"
     disable_caching: true
     thread_count: 8
-    cores: '0-3'
+    cores: '0-7'
 hdf5_vol:
   plugin_path: "/usr/lib64/mpich/lib"
 events:


### PR DESCRIPTION
The dfuse threads were oversubscribed in soak and appears to have caused dfuse to segfault.  Increase the numb of core that dfuse uses so that num cores = num threads.

Test-tag: soak_smoke

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
