### PR TITLE
DAOS-12595 dtx: support CPU yield during local TX commit

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -336,9 +336,9 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 		 * related RPC to the new leader, but such DTX is still not
 		 * committable yet. Here, the resync logic will abort it by
 		 * race during the new leader waiting for other replica(s).
-		 * The dtx_abort() logic will abort the local DTX firstly.
-		 * When the leader get replies from other replicas, it will
-		 * check whether local DTX is still valid or not.
+		 *
+		 * So when the leader get replies from other replicas, it
+		 * needs to check whether local DTX is still valid or not.
 		 *
 		 * If we abort multiple non-ready DTXs together, then there
 		 * is race that one DTX may become committable when we abort
@@ -652,7 +652,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 	}
 
 	cont->sc_dtx_resyncing = 1;
-	cont->sc_dtx_resync_ver = ver;
 	ABT_mutex_unlock(cont->sc_mutex);
 
 	dra.cont = cont;

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -227,6 +227,12 @@ enum dtx_status {
 	DTX_ST_COMMITTABLE	= 4,
 	/** The DTX is aborted. */
 	DTX_ST_ABORTED		= 5,
+	/** The DTX is in aborting, non-persistent status. */
+	DTX_ST_ABORTING		= 6,
+	/** The DTX is in committing, non-persistent status. */
+	DTX_ST_COMMITTING	= 7,
+	/** The DTX is in preparing, non-persistent status. */
+	DTX_ST_PREPARING	= 8,
 };
 
 enum daos_dtx_alb {

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2022 Intel Corporation.
+ * (C) Copyright 2015-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -123,8 +123,6 @@ struct ds_cont_child {
 	struct btr_root		 sc_dtx_cos_btr;
 	/* The global list for committable DTXs. */
 	d_list_t		 sc_dtx_cos_list;
-	/* The pool map version for the latest DTX resync on the container. */
-	uint32_t		 sc_dtx_resync_ver;
 	/* the pool map version of updating DAOS_PROP_CO_STATUS prop */
 	uint32_t		 sc_status_pm_ver;
 	/* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -217,6 +217,8 @@ enum dtx_flags {
 	DTX_DROP_CMT		= (1 << 8),
 };
 
+void
+dtx_renew_epoch(struct dtx_epoch *epoch, struct dtx_handle *dth);
 int
 dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash);
 int

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -801,6 +801,15 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	       daos_size_t *size, struct dtx_handle *dth);
 
 /**
+ * Renew the epoch for the update handle.
+ *
+ * \param ioh	[IN]	The I/O handle for update.
+ * \param dth	[IN]	Pointer to the DTX handle.
+ */
+void
+vos_update_renew_epoch(daos_handle_t ioh, struct dtx_handle *dth);
+
+/**
  * Get the recx/epoch list.
  *
  * \param ioh	[IN]	The I/O handle.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1255,6 +1255,16 @@ obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_rw_out *orwo,
 	return false;
 }
 
+static inline uint64_t
+orf_to_dtx_epoch_flags(enum obj_rpc_flags orf_flags)
+{
+	uint64_t flags = 0;
+
+	if (orf_flags & ORF_EPOCH_UNCERTAIN)
+		flags |= DTX_EPOCH_UNCERTAIN;
+	return flags;
+}
+
 static int
 obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		      daos_iod_t *iods, struct dcs_iod_csums *iod_csums,
@@ -1632,25 +1642,48 @@ out:
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.
 	 */
-	if (rc == 0 && obj_rpc_is_update(rpc) && dth->dth_need_validation &&
-	    sched_cur_seq() != sched_seq) {
-		daos_epoch_t	epoch = 0;
-		int		rc1;
+	if (rc == 0 && obj_rpc_is_update(rpc) && sched_cur_seq() != sched_seq) {
+		if (dth->dth_need_validation) {
+			daos_epoch_t	epoch = 0;
+			int		rc1;
 
-		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &orw->orw_dti, &epoch, NULL);
-		switch (rc1) {
-		case 0:
-			orw->orw_epoch = epoch;
-			/* Fall through */
-		case -DER_ALREADY:
-			rc = -DER_ALREADY;
-			break;
-		case -DER_NONEXIST:
-		case -DER_EP_OLD:
-			break;
-		default:
-			rc = rc1;
-			break;
+			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &orw->orw_dti, &epoch, NULL);
+			switch (rc1) {
+			case 0:
+				orw->orw_epoch = epoch;
+				/* Fall through */
+			case -DER_ALREADY:
+				rc = -DER_ALREADY;
+				break;
+			case -DER_NONEXIST:
+			case -DER_EP_OLD:
+				break;
+			default:
+				rc = rc1;
+				break;
+			}
+		}
+
+		/* For solo update, it will be handled via one-phase transaction.
+		 * If there is CPU yield after its epoch generated, we will renew
+		 * the epoch, then we can use the epoch to sort related solo DTXs
+		 * based on their epochs.
+		 */
+		if (rc == 0 && dth->dth_solo) {
+			struct dtx_epoch	epoch;
+
+			epoch.oe_value = d_hlc_get();
+			epoch.oe_first = orw->orw_epoch_first;
+			epoch.oe_flags = orf_to_dtx_epoch_flags(orw->orw_flags);
+
+			dtx_renew_epoch(&epoch, dth);
+			vos_update_renew_epoch(ioh, dth);
+
+			D_DEBUG(DB_IO,
+				"update rpc %p renew epoch "DF_U64" => "DF_U64" for "DF_DTI"\n",
+				rpc, orw->orw_epoch, dth->dth_epoch, DP_DTI(&orw->orw_dti));
+
+			orw->orw_epoch = dth->dth_epoch;
 		}
 	}
 
@@ -2198,16 +2231,6 @@ obj_ioc_begin(daos_obj_id_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 failed:
 	obj_ioc_end(ioc, rc);
 	return rc;
-}
-
-static uint64_t
-orf_to_dtx_epoch_flags(enum obj_rpc_flags orf_flags)
-{
-	uint64_t flags = 0;
-
-	if (orf_flags & ORF_EPOCH_UNCERTAIN)
-		flags |= DTX_EPOCH_UNCERTAIN;
-	return flags;
 }
 
 void
@@ -2827,6 +2850,7 @@ again2:
 		orw->orw_flags |= ORF_RESEND;
 		need_abort = true;
 		d_tm_inc_counter(opm->opm_update_retry, 1);
+		ABT_thread_yield();
 		goto again1;
 	default:
 		break;
@@ -3669,6 +3693,7 @@ again2:
 	case -DER_AGAIN:
 		opi->opi_flags |= ORF_RESEND;
 		need_abort = true;
+		ABT_thread_yield();
 		goto again1;
 	default:
 		break;
@@ -4226,21 +4251,38 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.
 	 */
-	if (rc == 0 && dth->dth_modification_cnt > 0 && dth->dth_need_validation &&
-	    sched_cur_seq() != sched_seq) {
-		daos_epoch_t	epoch = 0;
-		int		rc1;
+	if (rc == 0 && dth->dth_modification_cnt > 0 && sched_cur_seq() != sched_seq) {
+		if (dth->dth_need_validation) {
+			daos_epoch_t	epoch = 0;
+			int		rc1;
 
-		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &epoch, NULL);
-		switch (rc1) {
-		case 0:
-		case -DER_ALREADY:
-			D_GOTO(out, rc = -DER_ALREADY);
-		case -DER_NONEXIST:
-		case -DER_EP_OLD:
-			break;
-		default:
-			D_GOTO(out, rc = rc1);
+			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &epoch, NULL);
+			switch (rc1) {
+			case 0:
+			case -DER_ALREADY:
+				D_GOTO(out, rc = -DER_ALREADY);
+			case -DER_NONEXIST:
+			case -DER_EP_OLD:
+				break;
+			default:
+				D_GOTO(out, rc = rc1);
+			}
+		}
+
+		if (rc == 0 && dth->dth_solo) {
+			daos_epoch_t	epoch = dcsh->dcsh_epoch.oe_value;
+
+			D_ASSERT(dcde->dcde_read_cnt == 0);
+			D_ASSERT(dcde->dcde_write_cnt == 1);
+
+			dcsh->dcsh_epoch.oe_value = d_hlc_get();
+
+			dtx_renew_epoch(&dcsh->dcsh_epoch, dth);
+			vos_update_renew_epoch(iohs[0], dth);
+
+			D_DEBUG(DB_IO,
+				"CPD rpc %p renew epoch "DF_U64" => "DF_U64" for "DF_DTI"\n",
+				rpc, epoch, dcsh->dcsh_epoch.oe_value, DP_DTI(&dcsh->dcsh_xid));
 		}
 	}
 
@@ -4659,7 +4701,7 @@ again:
 	else
 		tgts++;
 
-	if (tgt_cnt <= 1 && dcde->dcde_write_cnt <= 1)
+	if (tgt_cnt <= 1 && dcde->dcde_write_cnt == 1 && dcde->dcde_read_cnt == 0)
 		dtx_flags |= DTX_SOLO;
 	if (flags & ORF_RESEND)
 		dtx_flags |= DTX_PREPARED;
@@ -4694,6 +4736,7 @@ out:
 	if (rc == -DER_AGAIN) {
 		oci->oci_flags |= ORF_RESEND;
 		need_abort = true;
+		ABT_thread_yield();
 		goto again;
 	}
 

--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -226,7 +226,7 @@ lrua_lookup_idx(struct lru_array *array, uint32_t idx, uint64_t key,
  *
  * \param	array[in]	The lru array
  * \param	idx[in]		The index of the entry
- * \param	idx[in]		Unique identifier
+ * \param	key[in]		Unique identifier
  * \param	entryp[out]	Valid only if function returns true.
  *
  * \return true if the entry is in the array and set \p entryp accordingly

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -93,6 +93,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_shares_inited = 1;
 
 	vos_dtx_rsrvd_init(dth);
+	vos_dtx_attach(dth, false, false);
 
 	*dthp = dth;
 }

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -257,9 +257,11 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 	   bool started, int err)
 {
 	struct dtx_handle	*dth = dth_in;
+	struct vos_dtx_act_ent	*dae;
 	struct dtx_rsrvd_uint	*dru;
 	struct vos_dtx_cmt_ent	*dce = NULL;
 	struct dtx_handle	 tmp = {0};
+	int			 rc;
 
 	if (!dtx_is_valid_handle(dth)) {
 		/** Created a dummy dth handle for publishing extents */
@@ -303,19 +305,55 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 	err = umem_tx_end(vos_cont2umm(cont), err);
 
 cancel:
+	if (dtx_is_valid_handle(dth_in)) {
+		if (unlikely(dth_in->dth_aborted)) {
+			/* Aborted by race during the yield for local TX commit. */
+			rc = vos_dtx_validation(dth_in);
+			switch (rc) {
+			case DTX_ST_INITED:
+			case DTX_ST_PREPARED:
+			case DTX_ST_PREPARING:
+				/* The DTX has been ever aborted and related resent RPC
+				 * is in processing. Return -DER_AGAIN to make this ULT
+				 * to retry sometime later without dtx_abort().
+				 */
+				D_GOTO(out, err = -DER_AGAIN);
+			case DTX_ST_ABORTED:
+				D_ASSERT(dth_in->dth_ent == NULL);
+				/* Aborted, return -DER_INPROGRESS for client retry.
+				 *
+				 * Fall through.
+				 */
+			case DTX_ST_ABORTING:
+				D_GOTO(out, err = -DER_INPROGRESS);
+			default:
+				D_ASSERTF(0, "Unexpected DTX "DF_DTI" status %d\n",
+					  DP_DTI(&dth_in->dth_xid), rc);
+			}
+		} else {
+			dae = dth_in->dth_ent;
+			D_ASSERT(dae != NULL);
+
+			dae->dae_preparing = 0;
+			if (dth_in->dth_solo) {
+				if (err == 0 && cont->vc_solo_dtx_epoch < dth_in->dth_epoch)
+					cont->vc_solo_dtx_epoch = dth_in->dth_epoch;
+
+				vos_dtx_post_handle(cont, &dae, &dce, 1, false, err != 0);
+			} else {
+				D_ASSERT(dce == NULL);
+				if (err == 0)
+					dae->dae_prepared = 1;
+			}
+		}
+	}
+
+out:
 	if (err != 0) {
 		/* The transaction aborted or failed to commit. */
 		vos_tx_publish(dth, false);
 		if (dtx_is_valid_handle(dth_in))
 			vos_dtx_cleanup_internal(dth);
-	}
-
-	if (dce != NULL) {
-		struct vos_dtx_act_ent	*dae = dth_in->dth_ent;
-
-		vos_dtx_post_handle(cont, &dae, &dce, 1, false,
-				    err != 0 ? true : false);
-		dth_in->dth_ent = NULL;
 	}
 
 	return err;

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -374,6 +374,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_cmt_dtx_reindex_pos = cont->vc_cont_df->cd_dtx_committed_head;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_act_list);
 	cont->vc_dtx_committed_count = 0;
+	cont->vc_solo_dtx_epoch = d_hlc_get();
 	gc_check_cont(cont);
 
 	/* Cache this btr object ID in container handle */

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -34,19 +34,18 @@ enum {
 #define DTX_UMOFF_TYPES		(DTX_UMOFF_ILOG | DTX_UMOFF_SVT | DTX_UMOFF_EVT)
 #define DTX_INDEX_INVAL		(int32_t)(-1)
 
-#define dtx_evict_lid(cont, dae)					\
-	do {								\
-		if (dae->dae_dth != NULL &&				\
-		    dae->dae_dth->dth_ent != NULL) {			\
-			D_ASSERT(dae->dae_dth->dth_ent == dae);		\
-			dae->dae_dth->dth_ent = NULL;			\
-		}							\
-		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%d\n",	\
-			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));		\
-		d_list_del_init(&dae->dae_link);			\
-		lrua_evictx(cont->vc_dtx_array,				\
-			    DAE_LID(dae) - DTX_LID_RESERVED,		\
-			    DAE_EPOCH(dae));				\
+#define dtx_evict_lid(cont, dae)							\
+	do {										\
+		if (dae->dae_dth != NULL && dae->dae_dth->dth_ent != NULL) {		\
+			D_ASSERT(dae->dae_dth->dth_ent == dae);				\
+			dae->dae_dth->dth_ent = NULL;					\
+		}									\
+		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%d\n",			\
+			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));				\
+		d_list_del_init(&dae->dae_link);					\
+		lrua_evictx(cont->vc_dtx_array,						\
+			    (DAE_LID(dae) & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,	\
+			    DAE_EPOCH(dae));						\
 	} while (0)
 
 static inline void
@@ -98,19 +97,7 @@ dtx_umoff_flag2type(umem_off_t umoff)
 	return 0;
 }
 
-static inline bool
-dtx_is_aborted(uint32_t tx_lid)
-{
-	return tx_lid == DTX_LID_ABORTED;
-}
-
-static void
-dtx_set_aborted(uint32_t *tx_lid)
-{
-	*tx_lid = DTX_LID_ABORTED;
-}
-
-static inline int
+static int
 dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 	       bool hit_again, bool retry, int pos)
 {
@@ -324,6 +311,9 @@ dtx_act_ent_update(struct btr_instance *tins, struct btr_record *rec,
 	dae_old = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 
 	D_ASSERT(dae_old != dae_new);
+
+	if (unlikely(dae_old->dae_aborting))
+		return -DER_INPROGRESS;
 
 	if (unlikely(!dae_old->dae_aborted)) {
 		/*
@@ -602,7 +592,7 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 			if (rc != 0)
 				return rc;
 
-			svt->ir_dtx = DTX_LID_COMMITTED;
+			dtx_set_committed(&svt->ir_dtx);
 		}
 		break;
 	}
@@ -625,7 +615,7 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 			if (rc != 0)
 				return rc;
 
-			evt->dc_dtx = DTX_LID_COMMITTED;
+			dtx_set_committed(&evt->dc_dtx);
 		}
 		break;
 	}
@@ -677,12 +667,11 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 			if (rc != 0)
 				return rc;
 		}
-	}
 
-	if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT)
 		count = DTX_INLINE_REC_CNT;
-	else
+	} else {
 		count = DAE_REC_CNT(dae);
+	}
 
 	for (i = count - 1; i >= 0; i--) {
 		rc = do_dtx_rec_release(umm, cont, dae, DAE_REC_INLINE(dae)[i],
@@ -776,9 +765,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 	d_iov_set(&kiov, dti, sizeof(*dti));
 	/* For single replicated object, we trigger commit just after local
 	 * modification done. Under such case, the caller exactly knows the
-	 * @epoch and no need to lookup the active DTX table. On the other
-	 * hand, for modifying single replicated object, there is no DTX
-	 * entry in the active DTX table.
+	 * @epoch and no need to lookup the active DTX table.
 	 */
 	if (epoch == 0) {
 		d_iov_set(&riov, NULL, 0);
@@ -788,22 +775,21 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 					   &kiov, &riov);
 			if (rc == 0) {
 				dce = (struct vos_dtx_cmt_ent *)riov.iov_buf;
-				if (dce->dce_invalid) {
-					dce = NULL;
-					D_GOTO(out, rc = -DER_NONEXIST);
-				}
-
+				if (dce->dce_invalid)
+					rc = -DER_NONEXIST;
+				else
+					rc = -DER_ALREADY;
 				dce = NULL;
 			}
-
-			goto out;
 		}
 
 		if (rc != 0)
 			goto out;
 
 		dae = riov.iov_buf;
-		if (dae->dae_aborted) {
+		D_ASSERT(dae->dae_preparing == 0);
+
+		if (vos_dae_is_abort(dae)) {
 			D_ERROR("NOT allow to commit an aborted DTX "DF_DTI"\n",
 				DP_DTI(dti));
 			D_GOTO(out, rc = -DER_NONEXIST);
@@ -812,7 +798,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 		/* It has been committed before, but failed to be removed
 		 * from the active table, just remove it again.
 		 */
-		if (dae->dae_committed) {
+		if (unlikely(dae->dae_committed)) {
 			rc = dbtree_delete(cont->vc_dtx_active_hdl,
 					   BTR_PROBE_BYPASS, &kiov, &dae);
 			if (rc == 0) {
@@ -822,6 +808,12 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 
 			goto out;
 		}
+
+		/* Another ULT is committing the DTX, but yield, then regard it as 'committed'.
+		 * The former committing ULT will guarantee the DTX to be committed successfully.
+		 */
+		if (dae->dae_committing)
+			D_GOTO(out, rc = -DER_ALREADY);
 	}
 
 	D_ALLOC_PTR(dce);
@@ -859,13 +851,16 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 		goto out;
 	}
 
+	dae->dae_committing = 1;
+
 	D_ASSERT(dae_p != NULL);
 	*dae_p = dae;
 
 out:
-	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_IO,
-		 "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
-		 DP_DTI(dti), DP_RC(rc));
+	if (rc != -DER_ALREADY && rc != -DER_NONEXIST)
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
+			 "Commit the DTX "DF_DTI": rc = "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
+
 	if (rc != 0)
 		D_FREE(dce);
 
@@ -890,15 +885,6 @@ vos_dtx_flags2name(uint32_t flags)
 	}
 
 	return NULL;
-}
-
-static bool
-vos_dtx_is_normal_entry(uint32_t entry)
-{
-	if (entry < DTX_LID_RESERVED)
-		return false;
-
-	return true;
 }
 
 static int
@@ -977,6 +963,8 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 
 	D_INIT_LIST_HEAD(&dae->dae_link);
 	DAE_LID(dae) = idx + DTX_LID_RESERVED;
+	if (dth->dth_solo)
+		DAE_LID(dae) |= DTX_LID_SOLO_FLAG;
 	DAE_XID(dae) = dth->dth_xid;
 	DAE_OID(dae) = dth->dth_leader_oid;
 	DAE_DKEY_HASH(dae) = dth->dth_dkey_hash;
@@ -1078,17 +1066,26 @@ vos_dtx_status(struct vos_dtx_act_ent *dae)
 	if (DAE_FLAGS(dae) & DTE_CORRUPTED)
 		return DTX_ST_CORRUPTED;
 
-	if (dae->dae_committed)
+	if (unlikely(dae->dae_committed))
 		return DTX_ST_COMMITTED;
 
-	if (dae->dae_committable)
-		return DTX_ST_COMMITTABLE;
+	if (dae->dae_committing)
+		return DTX_ST_COMMITTING;
 
 	if (dae->dae_committable)
 		return DTX_ST_COMMITTABLE;
 
 	if (dae->dae_prepared)
 		return DTX_ST_PREPARED;
+
+	if (dae->dae_preparing)
+		return DTX_ST_PREPARING;
+
+	if (unlikely(dae->dae_aborted))
+		return DTX_ST_ABORTED;
+
+	if (dae->dae_aborting)
+		return DTX_ST_ABORTING;
 
 	return DTX_ST_INITED;
 }
@@ -1107,6 +1104,9 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	struct vos_dtx_act_ent		*dae = NULL;
 	bool				 found;
 
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
 	if (dth != NULL && dth->dth_for_migration)
 		intent = DAOS_INTENT_MIGRATION;
 
@@ -1120,32 +1120,26 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		/* Everything is available to PURGE, even if it belongs to some
 		 * uncommitted DTX that may be garbage because of corruption.
 		 */
+		return intent == DAOS_INTENT_PURGE ? ALB_AVAILABLE_DIRTY : -DER_INVAL;
+	}
+
+	if (intent == DAOS_INTENT_CHECK)
+		return dtx_is_aborted(entry) ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
+
+	if (dtx_is_committed(entry, cont, epoch))
+		return ALB_AVAILABLE_CLEAN;
+
+	if (dtx_is_aborted(entry)) {
+		if (intent == DAOS_INTENT_DISCARD)
+			return ALB_AVAILABLE_CLEAN;
+
 		if (intent == DAOS_INTENT_PURGE)
-			return ALB_AVAILABLE_DIRTY;
+			return ALB_AVAILABLE_ABORTED;
 
-		return -DER_INVAL;
+		return ALB_UNAVAILABLE;
 	}
 
-	if (intent == DAOS_INTENT_CHECK) {
-		if (dtx_is_aborted(entry))
-			return ALB_UNAVAILABLE;
-
-		return ALB_AVAILABLE_CLEAN;
-	}
-
-	/* Committed -or- being discarded */
-	if (entry == DTX_LID_COMMITTED || intent == DAOS_INTENT_DISCARD)
-		return ALB_AVAILABLE_CLEAN;
-
-	/* Aborted */
-	if (dtx_is_aborted(entry))
-		return intent == DAOS_INTENT_PURGE ?
-			ALB_AVAILABLE_ABORTED : ALB_UNAVAILABLE;
-
-	cont = vos_hdl2cont(coh);
-	D_ASSERT(cont != NULL);
-
-	found = lrua_lookupx(cont->vc_dtx_array, entry - DTX_LID_RESERVED,
+	found = lrua_lookupx(cont->vc_dtx_array, (entry & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,
 			     epoch, &dae);
 	if (!found) {
 		D_DEBUG(DB_TRACE,
@@ -1166,14 +1160,17 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		return ALB_AVAILABLE_DIRTY;
 	}
 
+	if (intent == DAOS_INTENT_DISCARD)
+		return vos_dae_in_process(dae) ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
+
 	/* The DTX owner can always see the DTX. */
 	if (dtx_is_valid_handle(dth) && dae == dth->dth_ent)
 		return ALB_AVAILABLE_CLEAN;
 
-	if (dae->dae_committable || dae->dae_committed || DAE_FLAGS(dae) & DTE_PARTIAL_COMMITTED)
+	if (vos_dae_is_commit(dae) || DAE_FLAGS(dae) & DTE_PARTIAL_COMMITTED)
 		return ALB_AVAILABLE_CLEAN;
 
-	if (dae->dae_aborted)
+	if (vos_dae_is_abort(dae))
 		return ALB_UNAVAILABLE;
 
 	/* Access corrupted DTX entry. */
@@ -1284,7 +1281,7 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 			return dtx_inprogress(dae, dth, false, true, 2);
 
 		/* Ignore non-prepared DTX in spite of on leader or not. */
-		if (dae->dae_dbd == NULL || dae->dae_dth != NULL)
+		if (dae->dae_dbd == NULL || dae->dae_dth != NULL || dae->dae_preparing)
 			return ALB_UNAVAILABLE;
 
 		if (!(DAE_FLAGS(dae) & DTE_LEADER))
@@ -1349,6 +1346,9 @@ int
 vos_dtx_validation(struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent	*dae;
+	struct vos_container	*cont;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	int			 rc = 0;
 
 	D_ASSERT(dtx_is_valid_handle(dth));
@@ -1368,59 +1368,37 @@ vos_dtx_validation(struct dtx_handle *dth)
 	 * (or different) DTX LRU array slot.
 	 */
 
-	if (unlikely(dae == NULL || dth->dth_aborted)) {
-		struct vos_container	*cont;
-		d_iov_t			 kiov;
-		d_iov_t			 riov;
-
+	if (unlikely(dth->dth_aborted)) {
+		D_ASSERT(dae == NULL);
 		cont = vos_hdl2cont(dth->dth_coh);
 		D_ASSERT(cont != NULL);
 
 		d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
 		d_iov_set(&riov, NULL, 0);
 
-		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
-		if (rc == 0) {
-			D_DEBUG(DB_IO, "DTX "DF_DTI" is committed by race(1)\n",
-				DP_DTI(&dth->dth_xid));
-			return DTX_ST_COMMITTED;
-		}
-
 		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 		if (rc != 0) {
+			if (rc == -DER_NONEXIST) {
+				rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+				if (rc == 0)
+					return DTX_ST_COMMITTED;
+			}
+
 			/* Failed to lookup DTX entry, in spite of whether it is DER_NONEXIST
 			 * or not, then handle it as aborted that will cause client to retry.
 			 */
-			D_DEBUG(DB_IO, "DTX "DF_DTI" is aborted by race(1): "DF_RC"\n",
-				DP_DTI(&dth->dth_xid), DP_RC(rc));
 			return DTX_ST_ABORTED;
 		}
 
 		dae = riov.iov_buf;
-	}
-
-	if (dae->dae_committed) {
-		D_DEBUG(DB_IO, "DTX "DF_DTI" is committed by race(2)\n",
-			DP_DTI(&dth->dth_xid));
+	} else if (unlikely(dae == NULL)) {
 		return DTX_ST_COMMITTED;
 	}
 
-	if (dae->dae_aborted) {
-		D_DEBUG(DB_IO, "DTX "DF_DTI" is aborted by race(2)\n",
-			DP_DTI(&dth->dth_xid));
-		return DTX_ST_ABORTED;
-	}
-
-	if (dae->dae_committable)
-		return DTX_ST_COMMITTABLE;
-
-	if (dae->dae_prepared)
-		return DTX_ST_PREPARED;
-
-	return dth->dth_aborted ? DTX_ST_ABORTED : DTX_ST_INITED;
+	return vos_dtx_status(dae);
 }
 
-/* The caller has started PMDK transaction. */
+/* The caller has started local transaction. */
 int
 vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 			uint32_t type, uint32_t *tx_id)
@@ -1430,26 +1408,26 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 	int			 rc = 0;
 
 	if (!dtx_is_valid_handle(dth)) {
-		*tx_id = DTX_LID_COMMITTED;
+		dtx_set_committed(tx_id);
 		return 0;
 	}
 
-	/* For single participator case, we only hold committed DTX
-	 * entry for handling resend case, not trace modified target.
-	 */
-	if (dth->dth_solo) {
-		dth->dth_active = 1;
-		*tx_id = DTX_LID_COMMITTED;
-		return 0;
-	}
-
-	if (dth->dth_need_validation && !dth->dth_verified) {
+	if ((dth->dth_need_validation && !dth->dth_verified) || unlikely(dth->dth_aborted)) {
 		rc = vos_dtx_validation(dth);
 		switch (rc) {
 		case DTX_ST_INITED:
-			break;
+			if (!dth->dth_aborted)
+				break;
+			/* Fall through */
 		case DTX_ST_PREPARED:
+		case DTX_ST_PREPARING:
+			/* The DTX has been ever aborted and related resent RPC
+			 * is in processing. Return -DER_AGAIN to make this ULT
+			 * to retry sometime later without dtx_abort().
+			 */
+			D_GOTO(out, rc = -DER_AGAIN);
 		case DTX_ST_COMMITTED:
+		case DTX_ST_COMMITTING:
 		case DTX_ST_COMMITTABLE:
 			/* Aborted then prepared/committed by race.
 			 * Return -DER_ALREADY to avoid repeated modification.
@@ -1461,7 +1439,11 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 			D_GOTO(out, rc = -DER_ALREADY);
 		case DTX_ST_ABORTED:
 			D_ASSERT(dth->dth_ent == NULL);
-			/* Aborted, return -DER_INPROGRESS for client retry. */
+			/* Aborted, return -DER_INPROGRESS for client retry.
+			 *
+			 * Fall through.
+			 */
+		case DTX_ST_ABORTING:
 			D_GOTO(out, rc = -DER_INPROGRESS);
 		default:
 			D_ASSERT(0);
@@ -1469,6 +1451,18 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 	}
 
 	dae = dth->dth_ent;
+	/* There must has been vos_dtx_attach() before vos_dtx_register_record(). */
+	D_ASSERT(dae != NULL);
+
+	/* For single participator case, we only hold DTX entry
+	 * for handling resend case, not trace modified target.
+	 */
+	if (dth->dth_solo) {
+		dth->dth_active = 1;
+		*tx_id = DAE_LID(dae);
+		return 0;
+	}
+
 	if (!dth->dth_active) {
 		struct vos_container	*cont;
 		struct vos_cont_df	*cont_df;
@@ -1489,23 +1483,12 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 			dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
 		}
 
-		if (dae == NULL) {
-			rc = vos_dtx_alloc(dbd, dth);
-			if (rc != 0)
-				goto out;
+		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
-			dae = dth->dth_ent;
-		} else {
-			D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
-
-			dae->dae_df_off = cont_df->cd_dtx_active_tail +
-					offsetof(struct vos_dtx_blob_df,
-						 dbd_active_data) +
-					sizeof(struct vos_dtx_act_ent_df) *
-					dbd->dbd_index;
-			dae->dae_dbd = dbd;
-		}
-
+		dae->dae_df_off = cont_df->cd_dtx_active_tail +
+				offsetof(struct vos_dtx_blob_df, dbd_active_data) +
+				sizeof(struct vos_dtx_act_ent_df) * dbd->dbd_index;
+		dae->dae_dbd = dbd;
 		dth->dth_active = 1;
 	}
 
@@ -1526,7 +1509,7 @@ out:
 	return rc;
 }
 
-/* The caller has started PMDK transaction. */
+/* The caller has started local transaction. */
 void
 vos_dtx_deregister_record(struct umem_instance *umm, daos_handle_t coh,
 			  uint32_t entry, daos_epoch_t epoch, umem_off_t record)
@@ -1622,11 +1605,10 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 	struct vos_container		*cont;
 	struct umem_instance		*umm;
 	struct vos_dtx_blob_df		*dbd;
-	d_iov_t				 kiov;
 	umem_off_t			 rec_off;
 	size_t				 size;
 	int				 count;
-	int				 rc;
+	int				 rc = 0;
 
 	if (!dth->dth_active)
 		return 0;
@@ -1635,34 +1617,20 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 	D_ASSERT(cont != NULL);
 
 	dae = dth->dth_ent;
+	/* There must be vos_dtx_attach() before prepared. */
+	D_ASSERT(dae != NULL);
+	D_ASSERT(dae->dae_aborting == 0);
+	D_ASSERT(dae->dae_aborted == 0);
 
 	if (dth->dth_solo) {
-		if (dth->dth_drop_cmt) {
-			if (unlikely(dae == NULL))
-				D_GOTO(done, rc = 0);
-
-			d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
-			rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ, &kiov, NULL);
-			if (rc == 0 || rc == -DER_NONEXIST) {
-				dtx_evict_lid(cont, dae);
-				D_GOTO(done, rc = 0);
-			}
-
-			/*
-			 * We cannot remove the DTX entry from the active table, mark it
-			 * as 'committed'. That will consume some DRAM until server restart.
+		if (dth->dth_drop_cmt)
+			/* The active DTX entry will be removed via vos_dtx_post_handle()
+			 * after related local TX being committed successfully.
 			 */
-			D_WARN("Cannot remove DTX "DF_DTI" from active table: "DF_RC"\n",
-			       DP_DTI(&dth->dth_xid), DP_RC(rc));
-
-			dae->dae_committed = 1;
-			dtx_act_ent_cleanup(cont, dae, dth, false);
-		} else {
+			dae->dae_committing = 1;
+		else
 			rc = vos_dtx_commit_internal(cont, &dth->dth_xid, 1,
 						     dth->dth_epoch, NULL, NULL, dce_p);
-		}
-
-done:
 		dth->dth_active = 0;
 		dth->dth_pinned = 0;
 		if (rc >= 0) {
@@ -1672,8 +1640,6 @@ done:
 
 		return rc;
 	}
-
-	D_ASSERT(dae != NULL);
 
 	umm = vos_cont2umm(cont);
 	dbd = dae->dae_dbd;
@@ -1771,7 +1737,7 @@ done:
 	dbd->dbd_count++;
 	dbd->dbd_index++;
 
-	dae->dae_prepared = 1;
+	dae->dae_preparing = 1;
 
 	return 0;
 }
@@ -1835,7 +1801,14 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			dck->dkey_hash = DAE_DKEY_HASH(dae);
 		}
 
-		if (dae->dae_committed) {
+		if (dae->dae_committed || dae->dae_committing) {
+			/* For solo 'committing' DTX, do not return DTX_ST_COMMITTED. Otherwise,
+			 * it will misguide the caller as fake 'committed', but related data may
+			 * be invisible to the subsequent fetch until become real 'committed'.
+			 */
+			if (dae->dae_committing && DAE_LID(dae) & DTX_LID_SOLO_FLAG)
+				return -DER_INPROGRESS;
+
 			if (epoch != NULL)
 				*epoch = DAE_EPOCH(dae);
 
@@ -1852,7 +1825,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			return DTX_ST_COMMITTABLE;
 		}
 
-		if (dae->dae_aborted)
+		if (vos_dae_is_abort(dae))
 			return -DER_NONEXIST;
 
 		if (for_refresh) {
@@ -1866,7 +1839,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			if (!(DAE_FLAGS(dae) & DTE_LEADER))
 				return -DER_INPROGRESS;
 
-			return dae->dae_prepared ? DTX_ST_PREPARED : DTX_ST_INITED;
+			return vos_dae_is_prepare(dae) ? DTX_ST_PREPARED : DTX_ST_INITED;
 		}
 
 		/* Not committable yet, related RPC handler ULT is still running. */
@@ -1881,7 +1854,7 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 				return -DER_MISMATCH;
 		}
 
-		return dae->dae_prepared ? DTX_ST_PREPARED : DTX_ST_INITED;
+		return vos_dae_is_prepare(dae) ? DTX_ST_PREPARED : DTX_ST_INITED;
 	}
 
 	if (rc == -DER_NONEXIST) {
@@ -1986,7 +1959,7 @@ again:
 		if (rc == 0 && (daes == NULL || daes[cur] != NULL))
 			committed++;
 
-		if (rc == -DER_NONEXIST)
+		if (rc == -DER_ALREADY || rc == -DER_NONEXIST)
 			rc = 0;
 
 		if (rc1 == 0)
@@ -2072,8 +2045,15 @@ vos_dtx_post_handle(struct vos_container *cont,
 	int		rc;
 	int		i;
 
+	D_ASSERT(daes != NULL);
+
 	if (rollback) {
 		D_ASSERT(!abort);
+
+		for (i = 0; i < count; i++) {
+			if (daes[i] != NULL)
+				daes[i]->dae_committing = 0;
+		}
 
 		if (dces == NULL)
 			return;
@@ -2127,12 +2107,15 @@ vos_dtx_post_handle(struct vos_container *cont,
 			D_WARN("Cannot remove DTX "DF_DTI" from active table: "
 			       DF_RC"\n", DP_DTI(&DAE_XID(daes[i])), DP_RC(rc));
 
+			daes[i]->dae_prepared = 0;
+			daes[i]->dae_preparing = 0;
 			if (abort) {
 				daes[i]->dae_aborted = 1;
-				daes[i]->dae_prepared = 0;
+				daes[i]->dae_aborting = 0;
 				dtx_act_ent_cleanup(cont, daes[i], NULL, true);
 			} else {
 				daes[i]->dae_committed = 1;
+				daes[i]->dae_committing = 0;
 				dtx_act_ent_cleanup(cont, daes[i], NULL, false);
 			}
 			DAE_FLAGS(daes[i]) &= ~(DTE_CORRUPTED | DTE_ORPHAN | DTE_PARTIAL_COMMITTED);
@@ -2162,18 +2145,17 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id dtis[], int count, bool rm_cos[]
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	/* Commit multiple DTXs via single PMDK transaction. */
+	/* Commit multiple DTXs via single local transaction. */
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
 		committed = vos_dtx_commit_internal(cont, dtis, count, 0, rm_cos, daes, dces);
-		rc = umem_tx_end(vos_cont2umm(cont),
-				 committed > 0 ? 0 : committed);
-		if (rc == 0)
-			vos_dtx_post_handle(cont, daes, dces,
-					    count, false, false);
-		else
-			vos_dtx_post_handle(cont, daes, dces,
-					    count, false, true);
+		if (committed >= 0) {
+			rc = umem_tx_commit(vos_cont2umm(cont));
+			D_ASSERT(rc == 0);
+		} else {
+			rc = umem_tx_abort(vos_cont2umm(cont), committed);
+		}
+		vos_dtx_post_handle(cont, daes, dces, count, false, rc != 0);
 	}
 
 out:
@@ -2212,25 +2194,36 @@ vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 		goto out;
 
 	dae = riov.iov_buf;
-	if (dae->dae_committable || dae->dae_committed) {
+	if (vos_dae_is_commit(dae)) {
 		D_ERROR("NOT allow to abort a committed DTX (2) "DF_DTI"\n", DP_DTI(dti));
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
-	/* It has been aborted before, but failed to be removed from the active table
-	 * at that time, then need to be removed again via vos_dtx_post_handle().
-	 */
-	if (dae->dae_aborted)
+	if (vos_dae_is_abort(dae))
 		D_GOTO(out, rc = -DER_ALREADY);
 
 	if (epoch != DAOS_EPOCH_MAX && epoch != DAE_EPOCH(dae))
 		D_GOTO(out, rc = -DER_NONEXIST);
 
+	/* Abort in-preparing DTX entry. It may because the non-leader is some slow,
+	 * as to leader got timeout and then abort the DTX by race. Under such case,
+	 * the owner of 'preparing' need to handle the race case.
+	 */
+	if (unlikely(dae->dae_preparing))
+		D_WARN("Trying to abort in preparing DTX "DF_DTI" by race\n", DP_DTI(dti));
+
 	umm = vos_cont2umm(cont);
 	rc = umem_tx_begin(umm, NULL);
 	if (rc == 0) {
 		rc = dtx_rec_release(cont, dae, true);
-		rc = umem_tx_end(umm, rc);
+		if (rc == 0) {
+			dae->dae_aborting = 1;
+			rc = umem_tx_commit(umm);
+			D_ASSERTF(rc == 0, "local TX commit failure %d\n", rc);
+		} else {
+			rc = umem_tx_abort(umm, rc);
+		}
+
 		if (rc == 0 && dae->dae_dth != NULL) {
 			struct dtx_handle	*dth = dae->dae_dth;
 
@@ -2247,12 +2240,20 @@ vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 	}
 
 out:
-	D_DEBUG(DB_IO, "Abort the DTX "DF_DTI": "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
+	if (rc != -DER_ALREADY && rc != -DER_NONEXIST)
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
+			 "Abort the DTX "DF_DTI": "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
+
+	/* Aborting: The DTX is being aborted. The local transaction for abort itself is yield.
+	 *
+	 * Aborted: The DTX has been aborted before, but failed to be removed from the active
+	 *	    table at that time, then need to be removed again via vos_dtx_post_handle.
+	 */
+	if (dae != NULL && (rc == 0 || (rc == -DER_ALREADY && dae->dae_aborted)))
+		vos_dtx_post_handle(cont, &dae, NULL, 1, true, false);
 
 	if (rc == -DER_ALREADY)
 		rc = 0;
-	if (rc == 0)
-		vos_dtx_post_handle(cont, &dae, NULL, 1, true, false);
 
 	return rc;
 }
@@ -2287,10 +2288,10 @@ vos_dtx_set_flags_one(struct vos_container *cont, struct dtx_id *dti, uint32_t f
 		goto out;
 
 	if ((dae->dae_committable && (flags & (DTE_CORRUPTED | DTE_ORPHAN))) ||
-	    dae->dae_committed || dae->dae_aborted) {
+	    dae->dae_committing || dae->dae_committed || vos_dae_is_abort(dae)) {
 		D_ERROR("Not allow to set flag %s on the %s DTX entry "DF_DTI"\n",
-			vos_dtx_flags2name(flags), dae->dae_committable ? "committable" :
-			dae->dae_committed ? "committed (2)" : "aborted", DP_DTI(dti));
+			vos_dtx_flags2name(flags),
+			vos_dae_is_abort(dae) ? "abort" : "commit", DP_DTI(dti));
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
@@ -2819,8 +2820,11 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 
 				dae = dth->dth_ent;
 				if (dae != NULL) {
+					/* Cannot cleanup 'prepare'/'commit' DTX entry. */
+					if (vos_dae_is_prepare(dae) || vos_dae_is_commit(dae))
+						goto out;
+
 					dae->dae_aborted = 1;
-					dae->dae_prepared = 0;
 				}
 			} else {
 				rc = 0;
@@ -2830,8 +2834,8 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 			if (dth->dth_ent != NULL)
 				D_ASSERT(dth->dth_ent == dae);
 
-			/* Cannot cleanup 'committed' DTX entry. */
-			if (dae->dae_committable || dae->dae_committed)
+			/* Cannot cleanup 'prepare'/'commit' DTX entry. */
+			if (vos_dae_is_prepare(dae) || vos_dae_is_commit(dae))
 				goto out;
 
 			/* Skip the @dae if it belong to another instance for resent request. */
@@ -2867,10 +2871,8 @@ vos_dtx_cleanup(struct dtx_handle *dth, bool unpin)
 		if (!dth->dth_active)
 			return;
 	} else {
-		/* 'prepared' DTX can be either committed or aborted,
-		 * but not cleanup.
-		 */
-		if (dae->dae_prepared || dae->dae_committable || dae->dae_committed)
+		/* 'prepared'/'preparing' DTX can be either committed or aborted, not cleanup. */
+		if (vos_dae_is_prepare(dae) || vos_dae_is_commit(dae))
 			return;
 	}
 
@@ -2878,9 +2880,7 @@ vos_dtx_cleanup(struct dtx_handle *dth, bool unpin)
 		dth->dth_pinned = 0;
 
 	cont = vos_hdl2cont(dth->dth_coh);
-	/** This will abort the transaction and callback to
-	 *  vos_dtx_cleanup_internal
-	 */
+	/* This will abort the transaction and callback to vos_dtx_cleanup_internal(). */
 	vos_tx_end(cont, dth, NULL, NULL, true /* don't care */, -DER_CANCELED);
 }
 
@@ -2891,10 +2891,10 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist)
 	struct umem_instance	*umm = NULL;
 	struct vos_dtx_blob_df	*dbd = NULL;
 	struct vos_dtx_cmt_ent	*dce = NULL;
+	struct vos_cont_df	*cont_df = NULL;
 	struct vos_dtx_act_ent	*dae;
 	d_iov_t			 kiov;
 	d_iov_t			 riov;
-	bool			 began = false;
 	int			 rc = 0;
 
 	if (!dtx_is_valid_handle(dth))
@@ -2904,8 +2904,8 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist)
 	D_ASSERT(cont != NULL);
 
 	if (dth->dth_ent != NULL) {
-		if (!persistent || dth->dth_active)
-			return 0;
+		D_ASSERT(persistent);
+		D_ASSERT(dth->dth_active == 0);
 	} else {
 		D_ASSERT(dth->dth_pinned == 0);
 
@@ -2928,21 +2928,17 @@ vos_dtx_attach(struct dtx_handle *dth, bool persistent, bool exist)
 	}
 
 	if (persistent) {
-		struct vos_cont_df	*cont_df;
-
 		umm = vos_cont2umm(cont);
-		cont_df = cont->vc_cont_df;
-
 		rc = umem_tx_begin(umm, NULL);
 		if (rc != 0)
 			goto out;
 
-		began = true;
+		cont_df = cont->vc_cont_df;
 		dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
 		if (dbd == NULL || dbd->dbd_index >= dbd->dbd_cap) {
 			rc = vos_dtx_extend_act_table(cont);
 			if (rc != 0)
-				return rc;
+				goto out;
 
 			dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
 		}
@@ -2965,10 +2961,32 @@ out:
 		if (persistent) {
 			dth->dth_active = 1;
 			rc = vos_dtx_prepared(dth, &dce);
+			if (!dth->dth_solo)
+				D_ASSERT(dce == NULL);
 		} else {
 			dth->dth_pinned = 1;
 		}
-	} else {
+	}
+
+	if (cont_df != NULL) {
+		if (rc == 0) {
+			rc = umem_tx_commit(umm);
+			D_ASSERTF(rc == 0, "local TX commit failure %d\n", rc);
+		} else {
+			rc = umem_tx_abort(umm, rc);
+		}
+
+		dae = dth->dth_ent;
+		if (dae != NULL)
+			dae->dae_preparing = 0;
+
+		if (dth->dth_solo)
+			vos_dtx_post_handle(cont, &dae, &dce, 1, false, rc != 0);
+		else if (dae != NULL && rc == 0)
+			dae->dae_prepared = 1;
+	}
+
+	if (rc != 0) {
 		if (dth->dth_ent != NULL) {
 			dth->dth_pinned = 0;
 			vos_dtx_cleanup_internal(dth);
@@ -2976,16 +2994,6 @@ out:
 
 		D_ERROR("Failed to pin DTX entry for "DF_DTI": "DF_RC"\n",
 			DP_DTI(&dth->dth_xid), DP_RC(rc));
-	}
-
-	if (began) {
-		rc = umem_tx_end(umm, rc);
-		if (dce != NULL) {
-			dae = dth->dth_ent;
-			vos_dtx_post_handle(cont, &dae, &dce, 1,
-					    false, rc != 0 ? true : false);
-			dth->dth_ent = NULL;
-		}
 	}
 
 	return rc;

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -132,7 +132,7 @@ dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t next /
 		dae = rec_iov.iov_buf;
 	}
 
-	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+	while (vos_dae_is_commit(dae) || vos_dae_is_abort(dae) || dae->dae_preparing ||
 	       dae->dae_dth != NULL) {
 		if (oiter->oit_linear) {
 			if (dae->dae_link.next ==
@@ -204,7 +204,7 @@ dtx_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 				 sizeof(struct vos_dtx_act_ent));
 			dae = rec_iov.iov_buf;
 		}
-	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+	} while (vos_dae_is_commit(dae) || vos_dae_is_abort(dae) || dae->dae_preparing ||
 		 dae->dae_dth != NULL);
 
 out:
@@ -241,9 +241,9 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	}
 
 	/* Only return prepared ones. */
-	D_ASSERT(!dae->dae_committable);
-	D_ASSERT(!dae->dae_committed);
-	D_ASSERT(!dae->dae_aborted);
+	D_ASSERT(!vos_dae_is_commit(dae));
+	D_ASSERT(!vos_dae_is_abort(dae));
+	D_ASSERT(!dae->dae_preparing);
 	D_ASSERT(dae->dae_dth == NULL);
 
 	/*

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -95,6 +95,14 @@ enum {
 	DTX_LID_RESERVED,
 };
 
+/**
+ * If the highest bit (31th) of the DTX entry offset is set, then it is for
+ * solo (single modification against single replicated object) transaction.
+ */
+#define DTX_LID_SOLO_BITS	(31)
+#define DTX_LID_SOLO_FLAG	(1UL << DTX_LID_SOLO_BITS)
+#define DTX_LID_SOLO_MASK	(DTX_LID_SOLO_FLAG - 1)
+
 /*
  * When aggregate merge window reaches this size threshold, it will stop
  * growing and trigger window flush immediately.
@@ -284,6 +292,10 @@ struct vos_container {
 	uint64_t		vc_io_nospc_ts;
 	/* The (next) position for committed DTX entries reindex. */
 	umem_off_t		vc_cmt_dtx_reindex_pos;
+	/* The epoch for the latest committed solo DTX. Any solo
+	 * * transaction with older epoch must has been committed.
+	 */
+	daos_epoch_t		vc_solo_dtx_epoch;
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,
@@ -328,11 +340,14 @@ struct vos_dtx_act_ent {
 	struct dtx_handle		*dae_dth;
 
 	unsigned int			 dae_committable:1,
+					 dae_committing:1,
 					 dae_committed:1,
+					 dae_aborting:1,
 					 dae_aborted:1,
 					 dae_maybe_shared:1,
 					 /* Need validation on leader before commit/committable. */
 					 dae_need_validation:1,
+					 dae_preparing:1,
 					 dae_prepared:1;
 };
 
@@ -405,6 +420,62 @@ D_CASSERT((VOS_AGG_TIME_MASK & (1ULL << (VOS_TF_AGG_BIT - VOS_AGG_NR_BITS))) == 
 CHECK_VOS_TREE_FLAG(VOS_KEY_CMP_LEXICAL);
 CHECK_VOS_TREE_FLAG(VOS_TF_AGG_OPT);
 CHECK_VOS_TREE_FLAG(VOS_AGG_TIME_MASK);
+
+/* For solo transaction (single modification against single replicated object),
+ * consider efficiency, we do not generate persistent DTX entry. Then we need
+ * some special mechanism to maintain the semantics: any readable data must be
+ * persistently visible unless it is over-written by newer modification. That
+ * is the same behavior as non-solo cases. So if the local backend TX for the
+ * solo transaction is in committing, then related modification is invisible
+ * until related local backend TX has been successfully committed. (NOTE: in
+ * committing modification maybe lost if engine crashed before commit done.)
+ *
+ * For this purpose, we will reuse the DTX entry index (uint32_t) in the data
+ * record (ilog/svt/evt). Originally, such 32-bits integer is used as the DTX
+ * entry offset in the DTX LRU array. Up to now, we only use the lower 20 bits
+ * (DTX_ARRAY_LEN). Now, the highest (31th) bit will be used as a solo flag to
+ * indicate a solo DTX. On the other hand, we will trace the epoch against the
+ * container for the latest committed solo DTX. Anytime, for a given solo DTX,
+ * if its epoch is newer than the one for the container known latest committed
+ * solo DTX, then it is in committing status; otherwise, it has been committed.
+ */
+static inline bool
+dtx_is_committed(uint32_t tx_lid, struct vos_container *cont, daos_epoch_t epoch)
+{
+	if (tx_lid == DTX_LID_COMMITTED)
+		return true;
+
+	D_ASSERT(cont != NULL);
+
+	if (tx_lid & DTX_LID_SOLO_FLAG && cont->vc_solo_dtx_epoch >= epoch)
+		return true;
+
+	return false;
+}
+
+static inline bool
+dtx_is_aborted(uint32_t tx_lid)
+{
+	return tx_lid == DTX_LID_ABORTED;
+}
+
+static inline bool
+vos_dtx_is_normal_entry(uint32_t tx_lid)
+{
+	return tx_lid >= DTX_LID_RESERVED && !(tx_lid & DTX_LID_SOLO_FLAG);
+}
+
+static inline void
+dtx_set_committed(uint32_t *tx_lid)
+{
+	*tx_lid = DTX_LID_COMMITTED;
+}
+
+static inline void
+dtx_set_aborted(uint32_t *tx_lid)
+{
+	*tx_lid = DTX_LID_ABORTED;
+}
 
 /** Get the aggregatable write timestamp within 1/4 ms granularity */
 static inline bool
@@ -557,21 +628,22 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
  * Get local entry DTX state. Only used by VOS aggregation.
  *
  * \param entry		[IN]	DTX local id
+ * \param cont		[IN]	Pointer to the vos container.
+ * \param epoch		[IN]	Epoch for the related entry.
  *
  * \return		DTX_ST_COMMITTED, DTX_ST_PREPARED or
  *			DTX_ST_ABORTED.
  */
 static inline unsigned int
-vos_dtx_ent_state(uint32_t entry)
+vos_dtx_ent_state(uint32_t entry, struct vos_container *cont, daos_epoch_t epoch)
 {
-	switch (entry) {
-	case DTX_LID_COMMITTED:
+	if (dtx_is_committed(entry, cont, epoch))
 		return DTX_ST_COMMITTED;
-	case DTX_LID_ABORTED:
+
+	if (dtx_is_aborted(entry))
 		return DTX_ST_ABORTED;
-	default:
-		return DTX_ST_PREPARED;
-	}
+
+	return DTX_ST_PREPARED;
 }
 
 /**
@@ -1488,6 +1560,30 @@ struct csum_recalc_args {
 };
 
 int vos_csum_recalc_fn(void *recalc_args);
+
+static inline bool
+vos_dae_is_commit(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_committable || dae->dae_committing || dae->dae_committed;
+}
+
+static inline bool
+vos_dae_is_abort(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_aborting || dae->dae_aborted;
+}
+
+static inline bool
+vos_dae_is_prepare(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_preparing || dae->dae_prepared;
+}
+
+static inline bool
+vos_dae_in_process(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_committing || dae->dae_aborting || dae->dae_preparing;
+}
 
 static inline struct dcs_csum_info *
 vos_csum_at(struct dcs_iod_csums *iod_csums, unsigned int idx)

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -526,27 +526,27 @@ reset:
 			rc = -DER_TX_RESTART;
 	}
 
-	rc = vos_tx_end(cont, dth, NULL, NULL, true, rc);
-
-	if (rc == 0) {
+	if (rc == 0)
 		vos_ts_set_upgrade(ts_set);
-		if (daes != NULL) {
-			vos_dtx_post_handle(cont, daes, dces,
-					    dth->dth_dti_cos_count,
-					    false, false);
-			dth->dth_cos_done = 1;
-		}
-	} else if (daes != NULL) {
-		vos_dtx_post_handle(cont, daes, dces,
-				    dth->dth_dti_cos_count, false, true);
-		dth->dth_cos_done = 1;
-	}
 
 	if (rc == -DER_NONEXIST || rc == 0) {
 		vos_punch_add_missing(ts_set, dkey, akey_nr, akeys);
 		vos_ts_set_update(ts_set, epr.epr_hi);
+	}
+
+	if (rc == 0)
+		vos_ts_set_wupdate(ts_set, epr.epr_hi);
+
+	rc = vos_tx_end(cont, dth, NULL, NULL, true, rc);
+	if (dtx_is_valid_handle(dth)) {
 		if (rc == 0)
-			vos_ts_set_wupdate(ts_set, epr.epr_hi);
+			dth->dth_cos_done = 1;
+		else
+			dth->dth_cos_done = 0;
+
+		if (daes != NULL)
+			vos_dtx_post_handle(cont, daes, dces, dth->dth_dti_cos_count,
+					    false, rc != 0);
 	}
 
 	D_FREE(daes);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -440,7 +440,7 @@ svt_rec_load(struct btr_instance *tins, struct btr_record *rec,
 	rbund->rb_rsize	= irec->ir_size;
 	rbund->rb_gsize	= irec->ir_gsize;
 	rbund->rb_ver	= irec->ir_ver;
-	rbund->rb_dtx_state = vos_dtx_ent_state(irec->ir_dtx);
+	rbund->rb_dtx_state = vos_dtx_ent_state(irec->ir_dtx, vos_hdl2cont(tins->ti_coh), *epc);
 	rbund->rb_off = rec->rec_off;
 	return 0;
 }


### PR DESCRIPTION
Under original PMDK based local TX model, we assume that current ULT will not yield inside the local PMDK TX. But such assumption is not guaranteed under other backend local TX model, such as on SSD based system.

The patch introduces three temporary status for active DTX entry in DRAM: 'preparing', 'committing' and 'aborting'. Base on these, It adjusts related DTX logic to allow CPU yield during DTX status changes, including:

1. 'init' => 'preparing' => 'prepared'
2. 'init' => 'committing' => 'committed'
3. 'prepared' => 'committing' => 'committed'
4. 'prepared' => 'aborting' => 'aborted'

It works for both PMDK based local TX and metadata on SSD model. It does not change on-wire RPC protocol. As for the on-disk data layout, it is also compatible with old release. In the patch, we reuse the DTX entry local index (a 32-bits integer) in the data record (vos_irec_df::ir_dtx, evt_desc::dc_dtx, ilog_id::id_tx_id) to specially indicate whether related DTX is for solo transaction (single modification against single replicated object) or not via the highest (31th) one bit. For old release, it will not find any DTX entry if the DTX local index with such bit. Then according to old logic, related DTX will be regarded as 'committed', that just is correct and expected.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
