### PR TITLE
DAOS-12577 dfuse: Update dfuse cache on lookup.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -505,7 +505,8 @@ struct fuse_lowlevel_ops dfuse_ops;
 		int __rc;                                                                          \
 		DFUSE_TRA_DEBUG(inode, "Returning entry inode %#lx mode %#o size %zi",             \
 				(entry).attr.st_ino, (entry).attr.st_mode, (entry).attr.st_size);  \
-		if (atomic_load_relaxed(&(inode)->ie_open_count) == 0) {                           \
+		if (entry.attr_timeout > 0) {                                                      \
+			(inode)->ie_stat = entry.attr;                                             \
 			dfuse_cache_set_time(inode);                                               \
 		}                                                                                  \
 		__rc = fuse_reply_entry(req, &entry);                                              \

--- a/src/tests/ftest/dfuse/mu_perms.yaml
+++ b/src/tests/ftest/dfuse/mu_perms.yaml
@@ -24,7 +24,6 @@ dfuse:
   disable_caching: true
   multi_user: true
 dfuse_with_caching:
-  disable_caching: true  # To be removed bby DAOS-12577
   multi_user: true
   mount_dir: "/tmp/daos_dfuse"
 client_users:


### PR DESCRIPTION
When dfuse replies to a lookup request then save the data it passes
to the kernel.  Previously only getattr requests were updating the
cache so it was possible to populate the cache, have a remote update
and then have loopup mark the cache as valid without updating it's
contents.  This was particuarly visable for writeback cache where
the kernel queries dfuse to check the file-size before read and dfuse
could return known-stale cache data.

Test-tag: dfuse

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
