### PR TITLE
DAOS-12145 chk: output pool status as words instead of digits

### DIFF
--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -478,8 +478,8 @@ chk_engine_pm_dangling(struct chk_pool_rec *cpr, struct pool_map *map, struct po
 			option_nr = 2;
 
 			snprintf(suggested, CHK_MSG_BUFLEN - 1,
-				 "Change pool map for the dangling map entry as %u [suggested].",
-				 status);
+				 "Change pool map for the dangling map entry as %s [suggested].",
+				 pool_map_status2name(status));
 			strs[0] = suggested;
 			strs[1] = "Keep the dangling map entry in pool map, repair nothing.";
 
@@ -507,9 +507,10 @@ report:
 	cru.cru_pool_label = cpr->cpr_label;
 	snprintf(msg, CHK_MSG_BUFLEN - 1,
 		 "Check engine detects dangling %s entry in pool map for pool "
-		 DF_UUIDF", rank %u, index %u, (want) mark as %u\n",
+		 DF_UUIDF", rank %u, index %u, (want) mark as %s\n",
 		 comp->co_type == PO_COMP_TP_RANK ? "rank" : "target",
-		 DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index, status);
+		 DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index,
+		 pool_map_status2name(status));
 	cru.cru_msg = msg;
 	cru.cru_options = options;
 	cru.cru_details = details;
@@ -520,10 +521,11 @@ report:
 	D_CDEBUG(result != 0 || rc != 0, DLOG_ERR, DLOG_INFO,
 		 DF_ENGINE" detects dangling %s entry in pool map for pool "
 		 DF_UUIDF" rank %u, index %u, action %u (%s), handle_rc %d, report_rc %d, "
-		 "decision %d, (want) mark as %u\n",
+		 "decision %d, (want) mark as %s\n",
 		 DP_ENGINE(ins), comp->co_type == PO_COMP_TP_RANK ? "rank" : "target",
 		 DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index, act,
-		 option_nr ? "need interact" : "no interact", result, rc, decision, status);
+		 option_nr ? "need interact" : "no interact", result, rc, decision,
+		 pool_map_status2name(status));
 
 	if (rc != 0 && option_nr > 0) {
 		cbk->cb_statistics.cs_failed++;
@@ -544,10 +546,11 @@ report:
 	switch (decision) {
 	default:
 		D_ERROR(DF_ENGINE" got invalid decision %d for dangling %s entry in pool map "
-			"for pool "DF_UUIDF", rank %u, index %u, (want) mark as %u. Ignore.\n",
+			"for pool "DF_UUIDF", rank %u, index %u, (want) mark as %s. Ignore.\n",
 			DP_ENGINE(ins), decision,
 			comp->co_type == PO_COMP_TP_RANK ? "rank" : "target",
-			DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index, status);
+			DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index,
+			pool_map_status2name(status));
 		/*
 		 * Invalid option, ignore the inconsistency.
 		 *

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -220,6 +220,27 @@ static inline unsigned int pool_buf_nr(size_t size)
 		sizeof(struct pool_component);
 }
 
+static inline const char *
+pool_map_status2name(uint32_t status)
+{
+	switch (status) {
+	case PO_COMP_ST_UNKNOWN:
+		return "unknown";
+	case PO_COMP_ST_NEW:
+		return "new";
+	case PO_COMP_ST_UP:
+		return "up";
+	case PO_COMP_ST_DOWN:
+		return "down";
+	case PO_COMP_ST_DOWNOUT:
+		return "downout";
+	case PO_COMP_ST_DRAIN:
+		return "drain";
+	default:
+		D_ASSERTF(0, "Invalid status %u\n", status);
+	}
+}
+
 struct pool_map;
 
 struct pool_buf *pool_buf_alloc(unsigned int nr);


### PR DESCRIPTION
When the check engine repairs some pool map entry, it will report and log the change behavior with related entry status. It is more convenient for the user to understand the change if we output the pool entry status as works insted of internally used digits.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
