### PR TITLE
DAOS-623 test: Remove bandit checks B309,b325 . (#11742)

### DIFF
--- a/ci/bandit.config
+++ b/ci/bandit.config
@@ -30,7 +30,6 @@
 # B306 : mktemp_q
 # B307 : eval
 # B308 : mark_safe
-# B309 : httpsconnection
 # B310 : urllib_urlopen
 # B311 : random
 # B312 : telnetlib
@@ -45,7 +44,6 @@
 # B321 : ftplib
 # B323 : unverified_context
 # B324 : hashlib_new_insecure_functions
-# B325 : tempnam
 # B401 : import_telnetlib
 # B402 : import_ftplib
 # B403 : import_pickle
@@ -85,7 +83,7 @@
 # IPAS Required Checkers. Do not disable these
 # Additional checkers may be added if desired
 tests:
-  [ 'B301', 'B302', 'B303', 'B304', 'B305', 'B306', 'B308', 'B309', 'B310', 'B311', 'B312', 'B313', 'B314', 'B315', 'B316', 'B317', 'B318', 'B319', 'B320', 'B321', 'B323', 'B324', 'B325', 'B401', 'B402', 'B403', 'B404', 'B405', 'B406', 'B407', 'B408', 'B409', 'B410', 'B411', 'B412', 'B413']
+  [ 'B301', 'B302', 'B303', 'B304', 'B305', 'B306', 'B308', 'B310', 'B311', 'B312', 'B313', 'B314', 'B315', 'B316', 'B317', 'B318', 'B319', 'B320', 'B321', 'B323', 'B324', 'B401', 'B402', 'B403', 'B404', 'B405', 'B406', 'B407', 'B408', 'B409', 'B410', 'B411', 'B412', 'B413']
 
 # (optional) list skipped test IDs here, eg '[B101, B406]':
 # The following checkers are not required but be added to tests list if desired


### PR DESCRIPTION
This check is no longer used and has been removed from bandit
so do not tell bandit to use this.

There is no change in coverage here, bandit has been updated to remove
a no-longer-valid check so daos needs updating for the new bandit version.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>