### PR TITLE
DAOS-12843 ddb: Make sure VOS file is closed before exiting

### DIFF
--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -57,6 +57,10 @@ type DdbContext struct {
 	ctx C.struct_ddb_ctx
 }
 
+func ddbPoolIsOpen(ctx *DdbContext) bool {
+	return bool(C.ddb_pool_is_open(&ctx.ctx))
+}
+
 func ddbLs(ctx *DdbContext, path string, recursive bool) error {
 	/* Set up the options */
 	options := C.struct_ls_options{}

--- a/src/ddb/ddb.h
+++ b/src/ddb/ddb.h
@@ -209,6 +209,7 @@ int ddb_run_cmd(struct ddb_ctx *ctx, const char *cmd_str, bool write_mode);
 int ddb_run_help(struct ddb_ctx *ctx);
 int ddb_run_quit(struct ddb_ctx *ctx);
 int ddb_run_ls(struct ddb_ctx *ctx, struct ls_options *opt);
+bool ddb_pool_is_open(struct ddb_ctx *ctx);
 int ddb_run_open(struct ddb_ctx *ctx, struct open_options *opt);
 int ddb_run_version(struct ddb_ctx *ctx);
 int ddb_run_close(struct ddb_ctx *ctx);

--- a/src/ddb/ddb_commands.c
+++ b/src/ddb/ddb_commands.c
@@ -41,10 +41,16 @@ ddb_run_quit(struct ddb_ctx *ctx)
 	return 0;
 }
 
+bool
+ddb_pool_is_open(struct ddb_ctx *ctx)
+{
+	return daos_handle_is_valid(ctx->dc_poh);
+}
+
 int
 ddb_run_open(struct ddb_ctx *ctx, struct open_options *opt)
 {
-	if (daos_handle_is_valid(ctx->dc_poh)) {
+	if (ddb_pool_is_open(ctx)) {
 		ddb_error(ctx, "Must close pool before can open another\n");
 		return -DER_EXIST;
 	}
@@ -52,11 +58,12 @@ ddb_run_open(struct ddb_ctx *ctx, struct open_options *opt)
 	return dv_pool_open(opt->path, &ctx->dc_poh);
 }
 
-int ddb_run_close(struct ddb_ctx *ctx)
+int
+ddb_run_close(struct ddb_ctx *ctx)
 {
 	int rc;
 
-	if (daos_handle_is_inval(ctx->dc_poh)) {
+	if (!ddb_pool_is_open(ctx)) {
 		ddb_error(ctx, "No pool open to close\n");
 		return 0;
 	}


### PR DESCRIPTION
The VOS file being connected to when running in non-interactive mode was not being closed. By not closing the file, the system could have difficulty starting again.  This change fixes that.

Also checks that if the user didn't close the file in interactive mode it will be automatically closed.

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
