### PR TITLE
DAOS-0000 container: improve OIT table scability

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -719,6 +719,28 @@ daos_cont_create_snap_opt(daos_handle_t coh, daos_epoch_t *epoch, char *name,
 }
 
 int
+daos_cont_snap_oit_dump(daos_handle_t coh, daos_epoch_t epoch, char *name,
+			daos_event_t *ev)
+{
+	daos_cont_snap_oit_dump_t *args;
+	tse_task_t		  *task;
+	int			   rc;
+
+	DAOS_API_ARG_ASSERT(*args, CONT_SNAP_OIT_DUMP);
+
+	rc = dc_task_create(dc_cont_snap_oit_dump, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->coh	= coh;
+	args->epoch	= epoch;
+	args->name	= name;
+
+	return dc_task_schedule(task, true);
+}
+
+int
 daos_cont_create_snap(daos_handle_t coh, daos_epoch_t *epoch, char *name,
 		      daos_event_t *ev)
 {

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -126,6 +126,8 @@ const struct daos_task_api dc_funcs[] = {
 
 	{dc_pool_filter_cont, sizeof(daos_pool_filter_cont_t)},
 	{dc_obj_key2anchor, sizeof(daos_obj_key2anchor_t)},
+	{dc_cont_snap_oit_oid_get, sizeof(daos_cont_snap_oit_oid_get_t)},
+	{dc_cont_snap_oit_dump, sizeof(daos_cont_snap_oit_dump_t)},
 };
 
 /**

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2972,6 +2972,88 @@ dc_cont_create_snap(tse_task_t *task)
 }
 
 int
+dc_cont_snap_oit_dump(tse_task_t *task)
+{
+	daos_cont_snap_oit_dump_t *args;
+
+	args = dc_task_get_args(task);
+	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
+
+	if (args->name != NULL) {
+		D_ERROR("Named Snapshots not yet supported\n");
+		tse_task_complete(task, -DER_NOSYS);
+		return -DER_NOSYS;
+	}
+
+	return dc_epoch_op(args->coh, CONT_SNAP_OIT_DUMP, &args->epoch,
+			   0, task);
+}
+
+struct get_oit_oid_arg {
+	/* eoa_req must always be the first member of epoch_op_arg */
+	struct cont_req_arg	 goo_req;
+	daos_obj_id_t		*goo_oid;
+	uint32_t		*goo_ver;
+};
+
+static int
+cont_get_oit_oid_req_complete(tse_task_t *task, void *data)
+{
+	struct get_oit_oid_arg			*arg = data;
+	struct cont_snap_oit_oid_get_out	*oit_out;
+	int rc;
+
+	rc = cont_req_complete(task, &arg->goo_req);
+	if (rc)
+		return rc;
+
+	oit_out = crt_reply_get(arg->goo_req.cra_rpc);
+	*arg->goo_oid = oit_out->ogo_oid;
+	*arg->goo_ver = oit_out->ogo_ver;
+
+	return 0;
+}
+
+int dc_cont_snap_oit_oid_get(tse_task_t *task)
+{
+	daos_cont_snap_oit_oid_get_t	*dc_args;
+	struct cont_snap_oit_oid_get_in	*in;
+	struct get_oit_oid_arg		arg;
+	int				 rc;
+
+	dc_args = dc_task_get_args(task);
+	D_ASSERTF(dc_args != NULL, "Task Argument OPC does not match DC OPC\n");
+
+	rc = cont_req_prepare(dc_args->coh, CONT_SNAP_OIT_OID_GET,
+			      daos_task2ctx(task), &arg.goo_req);
+	if (rc != 0)
+		goto out;
+
+	D_DEBUG(DB_MD, DF_CONT": op=%u; hdl="DF_UUID";\n",
+		DP_CONT(arg.goo_req.cra_pool->dp_pool_hdl,
+			arg.goo_req.cra_cont->dc_uuid), CONT_SNAP_OIT_OID_GET,
+		DP_UUID(arg.goo_req.cra_cont->dc_cont_hdl));
+
+	in = crt_req_get(arg.goo_req.cra_rpc);
+	in->ogi_epoch = dc_args->epoch;
+	arg.goo_oid = dc_args->oid;
+	arg.goo_ver = dc_args->ver;
+	rc = tse_task_register_comp_cb(task, cont_get_oit_oid_req_complete,
+				       &arg, sizeof(arg));
+	if (rc != 0) {
+		cont_req_cleanup(CLEANUP_RPC, &arg.goo_req);
+		goto out;
+	}
+
+	crt_req_addref(arg.goo_req.cra_rpc);
+	return daos_rpc_send(arg.goo_req.cra_rpc, task);
+
+out:
+	tse_task_complete(task, rc);
+	return rc;
+}
+
+int
 dc_cont_destroy_snap(tse_task_t *task)
 {
 	daos_cont_destroy_snap_t	*args;
@@ -3212,6 +3294,40 @@ dc_cont_hdl2redunfac(daos_handle_t coh, uint32_t *rf)
 		return -DER_NO_HDL;
 
 	*rf = dc->dc_props.dcp_redun_fac;
+	dc_cont_put(dc);
+
+	return 0;
+}
+
+int
+dc_cont_hdl2globalver(daos_handle_t coh, uint32_t *ver)
+{
+	struct dc_cont	*dc;
+
+	dc = dc_hdl2cont(coh);
+	if (dc == NULL)
+		return -DER_NO_HDL;
+
+	*ver = dc->dc_props.dcp_global_version;
+	dc_cont_put(dc);
+
+	return 0;
+}
+
+int
+dc_cont_oid2bid(daos_handle_t coh, daos_obj_id_t oid, uint32_t *bid)
+{
+	struct dc_cont	*dc;
+
+	dc = dc_hdl2cont(coh);
+	if (dc == NULL)
+		return -DER_NO_HDL;
+
+	if (dc->dc_props.dcp_global_version < 2)
+		*bid = 0;
+	else
+		*bid = d_hash_murmur64((unsigned char *)&oid,
+				       sizeof(oid), 0) % DAOS_OIT_BUCKET_MAX;
 	dc_cont_put(dc);
 
 	return 0;

--- a/src/container/rpc.c
+++ b/src/container/rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -43,6 +43,23 @@ crt_proc_daos_epoch_range_t(crt_proc_t proc, crt_proc_op_t proc_op,
 		return -DER_HG;
 
 	rc = crt_proc_uint64_t(proc, proc_op, &erange->epr_hi);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
+
+static int
+crt_proc_daos_obj_id_t(crt_proc_t proc, crt_proc_op_t proc_op,
+		       daos_obj_id_t *oid)
+{
+	int rc;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &oid->lo);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, proc_op, &oid->hi);
 	if (rc != 0)
 		return -DER_HG;
 
@@ -96,6 +113,8 @@ CRT_RPC_DEFINE(cont_snap_create, DAOS_ISEQ_CONT_EPOCH_OP,
 		DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DEFINE(cont_snap_destroy, DAOS_ISEQ_CONT_EPOCH_OP,
 		DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DEFINE(cont_snap_oit_oid_get, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET,
+		DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
 CRT_RPC_DEFINE(cont_tgt_destroy, DAOS_ISEQ_TGT_DESTROY, DAOS_OSEQ_TGT_DESTROY)
 CRT_RPC_DEFINE(cont_tgt_query, DAOS_ISEQ_TGT_QUERY, DAOS_OSEQ_TGT_QUERY)
 CRT_RPC_DEFINE(cont_tgt_epoch_aggregate, DAOS_ISEQ_CONT_TGT_EPOCH_AGGREGATE,

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -85,6 +85,12 @@
 		hdlr, NULL),								\
 	X(CONT_DESTROY_BYLABEL,								\
 		0, &CQF_cont_destroy_bylabel,						\
+		hdlr, NULL),								\
+	X(CONT_SNAP_OIT_OID_GET,							\
+		0, &CQF_cont_snap_oit_oid_get,						\
+		hdlr, NULL),								\
+	X(CONT_SNAP_OIT_DUMP,								\
+		0, &CQF_cont_epoch_op,							\
 		hdlr, NULL)
 
 #define CONT_PROTO_SRV_RPC_LIST						\
@@ -384,6 +390,21 @@ CRT_RPC_DECLARE(cont_snap_create, DAOS_ISEQ_CONT_EPOCH_OP,
 		DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DECLARE(cont_snap_destroy, DAOS_ISEQ_CONT_EPOCH_OP,
 		DAOS_OSEQ_CONT_EPOCH_OP)
+CRT_RPC_DECLARE(cont_snap_oit_dump, DAOS_ISEQ_CONT_EPOCH_OP,
+		DAOS_OSEQ_CONT_EPOCH_OP)
+
+#define DAOS_ISEQ_CONT_SNAP_OIT_OID_GET /* input fields */	 \
+	((struct cont_op_in)	(ogi_op)		CRT_VAR) \
+	((daos_epoch_t)		(ogi_epoch)		CRT_VAR)
+
+#define DAOS_OSEQ_CONT_SNAP_OIT_OID_GET /* output fields */	 \
+	((struct cont_op_out)	(ogo_op)		CRT_VAR) \
+	((daos_obj_id_t)	(ogo_oid)		CRT_VAR) \
+	((uint32_t)		(ogo_ver)		CRT_VAR)
+
+CRT_RPC_DECLARE(cont_snap_oit_oid_get, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET,
+		DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
+
 
 #define DAOS_ISEQ_TGT_DESTROY	/* input fields */		 \
 	((uuid_t)		(tdi_pool_uuid)		CRT_VAR) \
@@ -431,7 +452,8 @@ CRT_RPC_DECLARE(cont_tgt_epoch_aggregate, DAOS_ISEQ_CONT_TGT_EPOCH_AGGREGATE,
 	((uuid_t)		(tsi_pool_uuid)		CRT_VAR) \
 	((uuid_t)		(tsi_coh_uuid)		CRT_VAR) \
 	((daos_epoch_t)		(tsi_epoch)		CRT_VAR) \
-	((uint64_t)		(tsi_opts)		CRT_VAR)
+	((uint64_t)		(tsi_opts)		CRT_VAR) \
+	((daos_obj_id_t)	(tsi_oit_oid)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_TGT_SNAPSHOT_NOTIFY /* output fields */	 \
 				/* number of errors */		 \

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1213,6 +1213,18 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		D_GOTO(out_kvs, rc);
 	}
 
+	/* Create the oit oids index KVS. */
+	attr.dsa_class = RDB_KVS_GENERIC;
+	attr.dsa_order = 16;
+	rc = rdb_tx_create_kvs(tx, &kvs, &ds_cont_prop_oit_oids, &attr);
+	if (rc != 0) {
+		D_ERROR(DF_CONT" failed to create container oit oids KVS: "
+			""DF_RC"\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid,
+				in->cci_op.ci_uuid), DP_RC(rc));
+		D_GOTO(out_kvs, rc);
+	}
+
 out_kvs:
 	rdb_path_fini(&kvs);
 out:
@@ -1537,6 +1549,11 @@ cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		goto out_prop;
 
 	cont_ec_agg_delete(cont->c_svc, cont->c_uuid);
+
+	/* Destroy oit oids index KVS. */
+	rc = rdb_tx_destroy_kvs(tx, &cont->c_prop, &ds_cont_prop_oit_oids);
+	if (rc != 0)
+		goto out_prop;
 
 	/* Destroy the handle index KVS. */
 	rc = rdb_tx_destroy_kvs(tx, &cont->c_prop, &ds_cont_prop_handles);
@@ -1965,9 +1982,19 @@ cont_lookup(struct rdb_tx *tx, const struct cont_svc *svc, const uuid_t uuid, st
 	if (rc != 0)
 		D_GOTO(err_hdls, rc);
 
+	/* c_oit_oids */
+	rc = rdb_path_clone(&p->c_prop, &p->c_oit_oids);
+	if (rc != 0)
+		D_GOTO(err_hdls, rc);
+	rc = rdb_path_push(&p->c_oit_oids, &ds_cont_prop_oit_oids);
+	if (rc != 0)
+		D_GOTO(err_oit_oids, rc);
+
 	*cont = p;
 	return 0;
 
+err_oit_oids:
+	rdb_path_fini(&p->c_oit_oids);
 err_hdls:
 	rdb_path_fini(&p->c_hdls);
 err_user:
@@ -2019,6 +2046,7 @@ cont_lookup_bylabel(struct rdb_tx *tx, const struct cont_svc *svc,
 void
 cont_put(struct cont *cont)
 {
+	rdb_path_fini(&cont->c_oit_oids);
 	rdb_path_fini(&cont->c_hdls);
 	rdb_path_fini(&cont->c_user);
 	rdb_path_fini(&cont->c_snaps);
@@ -4511,6 +4539,21 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		goto out;
 	}
 
+	if (from_global_ver < 2) {
+		struct rdb_kvs_attr	attr;
+
+		/* Create the oit oids index KVS. */
+		attr.dsa_class = RDB_KVS_GENERIC;
+		attr.dsa_order = 16;
+		rc = rdb_tx_create_kvs(ap->tx, &cont->c_prop, &ds_cont_prop_oit_oids, &attr);
+		if (rc != 0) {
+			D_ERROR(DF_CONT" failed to create container oit oids KVS: "
+				""DF_RC"\n",
+				DP_CONT(ap->pool_uuid, cont_uuid), DP_RC(rc));
+			goto out;
+		}
+	}
+
 	obj_ver = DS_POOL_OBJ_VERSION;
 	d_iov_set(&value, &obj_ver, sizeof(obj_ver));
 	rc = rdb_tx_update(ap->tx, &cont->c_prop,
@@ -4905,6 +4948,11 @@ cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *c
 	case CONT_ACL_DELETE:
 		*update_mtime = true;
 		return ds_cont_acl_delete(tx, pool_hdl, cont, hdl, rpc);
+	case CONT_SNAP_OIT_OID_GET:
+		return ds_cont_snap_oit_oid_get(tx, pool_hdl, cont, hdl, rpc);
+	case CONT_SNAP_OIT_DUMP:
+		*update_mtime = true;
+		return ds_cont_snap_oit_dump(tx, pool_hdl, cont, hdl, rpc);
 	default:
 		D_ASSERT(0);
 	}
@@ -5152,6 +5200,8 @@ cont_cli_opc_name(crt_opcode_t opc)
 	case CONT_ACL_DELETE:		return "ACL_DELETE";
 	case CONT_OPEN_BYLABEL:		return "OPEN_BYLABEL";
 	case CONT_DESTROY_BYLABEL:	return "DESTROY_BYLABEL";
+	case CONT_SNAP_OIT_OID_GET:	return "SNAP_OIT_OID_GET";
+	case CONT_SNAP_OIT_DUMP:	return "SNAP_OIT_DUMP";
 	default:			return "?";
 	}
 }

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -126,29 +126,95 @@ out:
 }
 
 static int
-snap_create_bcast(struct rdb_tx *tx, struct cont *cont, uuid_t coh_uuid,
-		  uint64_t opts, crt_context_t *ctx, daos_epoch_t *epoch)
+gen_oit_oid(struct rdb_tx *tx, struct cont *cont, daos_epoch_t epoch, daos_obj_id_t *oid,
+	    uint32_t *ret_cont_ver)
+{
+	d_iov_t					value;
+	uint64_t				redun_fac;
+	uint64_t				redun_lvl;
+	struct pl_map_attr			attr = {0};
+	enum daos_obj_redun			ord;
+	uint32_t				nr_grp;
+	int					rc;
+	uint32_t				grp_size;
+
+	memset(oid, 0, sizeof(*oid));
+	/* From release 2.2, version should exist */
+	d_iov_set(&value, ret_cont_ver, sizeof(*ret_cont_ver));
+	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_cont_global_version, &value);
+	if (rc != 0)
+		return rc;
+
+	d_iov_set(&value, &redun_fac, sizeof(redun_fac));
+	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_redun_fac, &value);
+	if (rc != 0)
+		return rc;
+
+	ord = daos_cont_rf2oit_ord(redun_fac);
+	if (ord < 0)
+		return ord;
+
+	if (*ret_cont_ver < 2) {
+		*oid = daos_oit_gen_id(epoch, redun_fac);
+		return 0;
+	}
+
+	d_iov_set(&value, &redun_lvl, sizeof(redun_lvl));
+	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_redun_lvl, &value);
+	if (rc != 0)
+		return rc;
+
+	attr.pa_domain = redun_lvl;
+	rc = pl_map_query(cont->c_svc->cs_pool->sp_uuid, &attr);
+	grp_size = redun_fac + 1;
+	if (grp_size > attr.pa_domain_nr) {
+		D_ERROR("grp size (%u) (%u) is larger than domain nr (%u)\n",
+			grp_size, DAOS_OBJ_REPL_MAX, attr.pa_domain_nr);
+		return -DER_INVAL;
+	}
+
+	nr_grp = max(1, (attr.pa_target_nr / grp_size));
+	if (nr_grp > DAOS_OIT_BUCKET_MAX)
+		nr_grp = DAOS_OIT_BUCKET_MAX;
+
+	daos_obj_set_oid(oid, DAOS_OT_OIT_V2, ord, nr_grp, 0);
+	oid->lo = epoch;
+
+	return 0;
+}
+
+struct oit_oid_value {
+	daos_obj_id_t	oov_id;	/* OIT OID */
+	uint32_t	oov_ver; /* pool map version */
+};
+
+static int
+snap_oit_dump(struct rdb_tx *tx, struct cont *cont, uuid_t coh_uuid,
+	      uint64_t opts, crt_context_t *ctx, daos_epoch_t *epoch)
 {
 	struct cont_tgt_snapshot_notify_in	*in;
 	struct cont_tgt_snapshot_notify_out	*out;
 	crt_rpc_t				*rpc;
-	char					 zero = 0;
 	d_iov_t					 key;
 	d_iov_t					 value;
-	uint32_t				 nsnapshots;
 	int					 rc;
+	uint32_t				 cont_ver;
+	struct oit_oid_value			 oov;
 
 	rc = ds_cont_bcast_create(ctx, cont->c_svc,
 				  CONT_TGT_SNAPSHOT_NOTIFY, &rpc);
 	if (rc != 0)
-		goto out;
+		return rc;
 
 	in = crt_req_get(rpc);
 	uuid_copy(in->tsi_pool_uuid, cont->c_svc->cs_pool_uuid);
 	uuid_copy(in->tsi_cont_uuid, cont->c_uuid);
 	uuid_copy(in->tsi_coh_uuid, coh_uuid);
-	in->tsi_epoch = d_hlc_get();
+	in->tsi_epoch = opts & DAOS_SNAP_OPT_CR ? d_hlc_get() : *epoch;
 	in->tsi_opts = opts;
+	rc = gen_oit_oid(tx, cont, in->tsi_epoch, &in->tsi_oit_oid, &cont_ver);
+	if (rc)
+		goto out_rpc;
 
 	rc = dss_rpc_send(rpc);
 	if (rc != 0)
@@ -162,15 +228,47 @@ snap_create_bcast(struct rdb_tx *tx, struct cont *cont, uuid_t coh_uuid,
 		rc = -DER_IO;
 		goto out_rpc;
 	}
-
 	*epoch = in->tsi_epoch;
+	/* oit oids index kvs not existed for containers created before release2.4 */
+	if (cont_ver >= 2) {
+		d_iov_set(&key, epoch, sizeof(*epoch));
+		oov.oov_id = in->tsi_oit_oid;
+		oov.oov_ver = pool_map_get_version(cont->c_svc->cs_pool->sp_map);
+		d_iov_set(&value, &oov, sizeof(oov));
+		rc = rdb_tx_update(tx, &cont->c_oit_oids, &key, &value);
+		if (rc != 0) {
+			D_ERROR(DF_CONT": failed to store oit oid: %d\n",
+				DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
+			goto out_rpc;
+		}
+	}
+out_rpc:
+	crt_req_decref(rpc);
+
+	return rc;
+}
+
+static int
+snap_create_bcast(struct rdb_tx *tx, struct cont *cont, uuid_t coh_uuid,
+		  uint64_t opts, crt_context_t *ctx, daos_epoch_t *epoch)
+{
+	char					 zero = 0;
+	d_iov_t					 key;
+	d_iov_t					 value;
+	uint32_t				 nsnapshots;
+	int					 rc;
+
+	rc = snap_oit_dump(tx, cont, coh_uuid, opts, ctx, epoch);
+	if (rc)
+		return rc;
+
 	d_iov_set(&key, epoch, sizeof(*epoch));
 	d_iov_set(&value, &zero, sizeof(zero));
 	rc = rdb_tx_update(tx, &cont->c_snaps, &key, &value);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": failed to create snapshot: %d\n",
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
-		goto out_rpc;
+		goto out;
 	}
 	/* Update number of snapshots */
 	d_iov_set(&value, &nsnapshots, sizeof(nsnapshots));
@@ -178,20 +276,18 @@ snap_create_bcast(struct rdb_tx *tx, struct cont *cont, uuid_t coh_uuid,
 	if (rc != 0) {
 		D_ERROR(DF_CONT": failed to lookup nsnapshots, "DF_RC"\n",
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
-		goto out_rpc;
+		goto out;
 	}
 	nsnapshots++;
 	rc = rdb_tx_update(tx, &cont->c_prop, &ds_cont_prop_nsnapshots, &value);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": failed to update nsnapshots, "DF_RC"\n",
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
-		goto out_rpc;
+		goto out;
 	}
 
 	D_DEBUG(DB_MD, DF_CONT": created snapshot "DF_U64"\n",
 		DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), *epoch);
-out_rpc:
-	crt_req_decref(rpc);
 out:
 	return rc;
 }
@@ -221,6 +317,32 @@ ds_cont_snap_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			       rpc->cr_ctx, &snap_eph);
 	if (rc == 0)
 		out->ceo_epoch = snap_eph;
+out:
+	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, DP_RC(rc));
+	return rc;
+}
+
+int
+ds_cont_oit_dump(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+		 struct cont *cont, struct container_hdl *hdl, crt_rpc_t *rpc)
+{
+	struct cont_epoch_op_in	       *in = crt_req_get(rpc);
+	int				rc;
+
+	D_DEBUG(DB_MD, DF_CONT": processing rpc %p\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc);
+
+	/* Verify handle has write access */
+	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
+		D_ERROR(DF_CONT": permission denied to dump oit\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
+		rc = -DER_NO_PERM;
+		goto out;
+	}
+
+	rc = snap_oit_dump(tx, cont, in->cei_op.ci_hdl, DAOS_SNAP_OPT_OIT,
+			   rpc->cr_ctx, &in->cei_epoch);
 out:
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, DP_RC(rc));
@@ -267,6 +389,22 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		goto out;
 	}
 
+	d_iov_set(&value, NULL, 0);
+	rc = rdb_tx_lookup(tx, &cont->c_oit_oids, &key, &value);
+	if (rc != 0 && rc != -DER_NONEXIST) {
+		D_ERROR(DF_CONT": failed to lookup oit oid for snapshot [%lu]: "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), in->cei_epoch, DP_RC(rc));
+		goto out;
+	} else if (rc == 0) {
+		rc = rdb_tx_delete(tx, &cont->c_oit_oids, &key);
+		if (rc != 0) {
+			D_ERROR(DF_CONT": failed to delete oit oid for snapshot [%lu]: %d\n",
+				DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid),
+				in->cei_epoch, rc);
+			goto out;
+		}
+	}
+
 	/* Update number of snapshots */
 	d_iov_set(&value, &nsnapshots, sizeof(nsnapshots));
 	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_nsnapshots, &value);
@@ -289,6 +427,45 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 out:
 	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc, DP_RC(rc));
+	return rc;
+}
+
+int
+ds_cont_snap_oit_oid_get(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+			 struct cont *cont, struct container_hdl *hdl, crt_rpc_t *rpc)
+{
+	d_iov_t				  key;
+	d_iov_t				  value;
+	int				  rc;
+	struct oit_oid_value		  oov;
+	struct cont_snap_oit_oid_get_in	 *in = crt_req_get(rpc);
+	struct cont_snap_oit_oid_get_out *out = crt_reply_get(rpc);
+
+	D_DEBUG(DB_MD, DF_CONT ": processing rpc: %p epoch=" DF_U64 "\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ogi_op.ci_uuid), rpc, in->ogi_epoch);
+
+	/* Verify the handle has read access */
+	if (!ds_sec_cont_can_read_data(hdl->ch_sec_capas)) {
+		D_ERROR(DF_CONT": permission denied to list snapshots\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
+		rc = -DER_NO_PERM;
+		goto out;
+	}
+
+	d_iov_set(&key, &in->ogi_epoch, sizeof(daos_epoch_t));
+	d_iov_set(&value, &oov, sizeof(oov));
+	rc = rdb_tx_lookup(tx, &cont->c_oit_oids, &key, &value);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to lookup snapshot [%lu]: "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), in->ogi_epoch, DP_RC(rc));
+		goto out;
+	}
+	out->ogo_oid = oov.oov_id;
+	out->ogo_ver = oov.oov_ver;
+
+out:
+	D_DEBUG(DB_MD, DF_CONT ": replying rpc: %p " DF_RC "\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->ogi_op.ci_uuid), rpc, DP_RC(rc));
 	return rc;
 }
 

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -101,6 +101,7 @@ struct cont {
 	rdb_path_t		c_snaps;	/* snapshot KVS */
 	rdb_path_t		c_user;		/* user attribute KVS */
 	rdb_path_t		c_hdls;		/* handle index KVS */
+	rdb_path_t		c_oit_oids;	/* snapshot oit oids */
 };
 
 /* OID range for allocator */
@@ -221,6 +222,10 @@ int ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 int ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid, daos_epoch_t **snapshots,
 			  int *snap_count);
 void ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid);
+int ds_cont_snap_oit_oid_get(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+			     struct cont *cont, struct container_hdl *hdl, crt_rpc_t *rpc);
+int ds_cont_snap_oit_dump(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+			  struct cont *cont, struct container_hdl *hdl, crt_rpc_t *rpc);
 
 /* srv_target.c */
 int ds_cont_tgt_destroy(uuid_t pool_uuid, uuid_t cont_uuid);
@@ -286,7 +291,7 @@ void ds_cont_metrics_free(void *data);
 int ds_cont_metrics_count(void);
 
 int cont_child_gather_oids(struct ds_cont_child *cont, uuid_t coh_uuid,
-			   daos_epoch_t epoch);
+			   daos_epoch_t epoch, daos_obj_id_t oit_oid);
 
 int ds_cont_hdl_rdb_lookup(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 			   struct container_hdl *chdl);

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -16,6 +16,7 @@
 RDB_STRING_KEY(ds_cont_prop_, cuuids);
 RDB_STRING_KEY(ds_cont_prop_, conts);
 RDB_STRING_KEY(ds_cont_prop_, cont_handles);
+RDB_STRING_KEY(ds_cont_prop_, oit_oids);
 
 /* Container properties KVS */
 RDB_STRING_KEY(ds_cont_prop_, ghce);

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -111,6 +111,7 @@ extern d_iov_t ds_cont_prop_scrubber_disabled;	/* uint64_t */
 extern d_iov_t ds_cont_prop_co_md_times;	/* co_md_times */
 extern d_iov_t ds_cont_prop_cont_obj_version;	/* uint32_t */
 extern d_iov_t ds_cont_prop_nhandles;		/* uint32_t */
+extern d_iov_t ds_cont_prop_oit_oids;		/* snapshot OIT oids KVS */
 /* Please read the IMPORTANT notes above before adding new keys. */
 
 struct co_md_times {

--- a/src/container/srv_oi_table.c
+++ b/src/container/srv_oi_table.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2020-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -23,12 +23,6 @@
 
 #define OID_SEND_MAX	128
 
-/* NB: simplify client implementation, all OIDs are stored under one dkey,
- * this should be changed in the future, e.g. bump it to 1024 dkeys so OIDs
- * can scatter to more targets.
- */
-#define OIT_BUCKET_MAX	1
-
 /* All OIDs within a bucket are stored under the same dkey of OIT */
 struct oit_bucket {
 	daos_obj_id_t		*ob_oids;
@@ -47,12 +41,13 @@ struct oit_scan_args {
 	daos_obj_id_t		oa_pre_id;
 	d_iov_t			oa_iov;
 	int			oa_hash;
+	int			oa_max_buckets;
 	/** sgl for OID each bucket */
 	d_sg_list_t		oa_sgls[OID_SEND_MAX];
 	/** IOD for OID each bucket */
 	daos_iod_t		oa_iods[OID_SEND_MAX];
 	/** OID buckets, OIDs are hashed into different buckets */
-	struct oit_bucket	oa_buckets[OIT_BUCKET_MAX];
+	struct oit_bucket	oa_buckets[DAOS_OIT_BUCKET_MAX];
 };
 
 static int
@@ -120,9 +115,8 @@ cont_iter_obj_cb(daos_handle_t ch, vos_iter_entry_t *ent, vos_iter_type_t type,
 	oa->oa_pre_id = oid;
 
 	D_DEBUG(DB_TRACE, "enumerate OID="DF_OID"\n", DP_OID(oid));
-
 	bid = d_hash_murmur64((unsigned char *)&oid, sizeof(oid), 0) %
-			      OIT_BUCKET_MAX;
+			      oa->oa_max_buckets;
 	bucket = &oa->oa_buckets[bid];
 	if (bucket->ob_nr < OID_SEND_MAX) {
 		bucket->ob_oids[bucket->ob_nr] = oid;
@@ -143,7 +137,7 @@ cont_iter_obj_cb(daos_handle_t ch, vos_iter_entry_t *ent, vos_iter_type_t type,
 
 int
 cont_child_gather_oids(struct ds_cont_child *coc, uuid_t coh_uuid,
-		       daos_epoch_t epoch)
+		       daos_epoch_t epoch, daos_obj_id_t oit_oid)
 {
 	struct ds_pool_child	*poc = coc->sc_pool;
 	struct oit_scan_args	*oa;
@@ -154,12 +148,13 @@ cont_child_gather_oids(struct ds_cont_child *coc, uuid_t coh_uuid,
 	uuid_t			 uuid;
 	int			 i;
 	int			 rc;
+	uint32_t		 co_ver;
 
 	D_ALLOC_PTR(oa); /* NB: too large to be stack */
 	if (!oa)
 		return -DER_NOMEM;
 
-	for (i = 0; i < OIT_BUCKET_MAX; i++) {
+	for (i = 0; i < DAOS_OIT_BUCKET_MAX; i++) {
 		daos_obj_id_t *oids;
 
 		D_ALLOC_ARRAY(oids, OID_SEND_MAX);
@@ -171,9 +166,6 @@ cont_child_gather_oids(struct ds_cont_child *coc, uuid_t coh_uuid,
 	rc = ds_pool_iv_svc_fetch(poc->spc_pool, &svc);
 	if (rc)
 		D_GOTO(out, rc);
-
-	oa->oa_oit_id = daos_oit_gen_id(epoch, coc->sc_props.dcp_redun_fac);
-	D_DEBUG(DB_IO, "OIT="DF_OID"\n", DP_OID(oa->oa_oit_id));
 
 	uuid_generate(uuid);
 	rc = dsc_pool_open(poc->spc_uuid, uuid, 0, NULL,
@@ -187,6 +179,14 @@ cont_child_gather_oids(struct ds_cont_child *coc, uuid_t coh_uuid,
 	rc = dsc_cont_open(oa->oa_poh, coc->sc_uuid, coh_uuid, 0, &oa->oa_coh);
 	if (rc)
 		D_GOTO(out, rc);
+
+	rc = dc_cont_hdl2globalver(oa->oa_coh, &co_ver);
+	if (rc)
+		D_GOTO(out, rc);
+
+	oa->oa_oit_id = oit_oid;
+	oa->oa_max_buckets = co_ver < 2 ? 1 : DAOS_OIT_BUCKET_MAX;
+	D_DEBUG(DB_IO, "OIT="DF_OID"\n", DP_OID(oa->oa_oit_id));
 
 	rc = dsc_obj_open(oa->oa_coh, oa->oa_oit_id, DAOS_OO_RW, &oa->oa_oh);
 	if (rc)
@@ -204,7 +204,7 @@ cont_child_gather_oids(struct ds_cont_child *coc, uuid_t coh_uuid,
 		D_GOTO(out, rc);
 
 	/* send out remaining OIDs */
-	for (i = 0; i < OIT_BUCKET_MAX; i++) {
+	for (i = 0; i < DAOS_OIT_BUCKET_MAX; i++) {
 		if (oa->oa_buckets[i].ob_nr > 0) {
 			rc = cont_send_oit_bucket(oa, i);
 			oa->oa_buckets[i].ob_nr = 0;
@@ -220,7 +220,7 @@ out:
 	if (svc)
 		d_rank_list_free(svc);
 
-	for (i = 0; i < OIT_BUCKET_MAX; i++) {
+	for (i = 0; i < DAOS_OIT_BUCKET_MAX; i++) {
 		bucket = &oa->oa_buckets[i];
 		D_FREE(bucket->ob_oids);
 	}

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1870,6 +1870,7 @@ struct cont_snap_args {
 	uint64_t	 snap_epoch;
 	uint64_t	 snap_opts;
 	int		 snap_count;
+	daos_obj_id_t	 oit_oid;
 	uint64_t	*snapshots;
 };
 
@@ -1985,12 +1986,13 @@ cont_snap_notify_one(void *vin)
 
 	if (args->snap_opts & DAOS_SNAP_OPT_OIT) {
 		rc = cont_child_gather_oids(cont, args->coh_uuid,
-					    args->snap_epoch);
+					    args->snap_epoch, args->oit_oid);
 		if (rc)
 			goto out_cont;
 	}
 
-	cont->sc_aggregation_max = d_hlc_get();
+	if (args->snap_opts & DAOS_SNAP_OPT_CR)
+		cont->sc_aggregation_max = d_hlc_get();
 out_cont:
 	ds_cont_child_put(cont);
 	return rc;
@@ -2011,6 +2013,7 @@ ds_cont_tgt_snapshot_notify_handler(crt_rpc_t *rpc)
 	uuid_copy(args.coh_uuid, in->tsi_coh_uuid);
 	args.snap_epoch = in->tsi_epoch;
 	args.snap_opts = in->tsi_opts;
+	args.oit_oid = in->tsi_oit_oid;
 
 	out->tso_rc = dss_thread_collective(cont_snap_notify_one, &args, 0);
 	if (out->tso_rc != 0)

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -86,6 +86,8 @@ struct daos_csummer *dc_cont_hdl2csummer(daos_handle_t coh);
 struct cont_props dc_cont_hdl2props(daos_handle_t coh);
 int dc_cont_hdl2redunlvl(daos_handle_t coh, uint32_t *rl);
 int dc_cont_hdl2redunfac(daos_handle_t coh, uint32_t *rf);
+int dc_cont_hdl2globalver(daos_handle_t coh, uint32_t *ver);
+int dc_cont_oid2bid(daos_handle_t coh, daos_obj_id_t oid, uint32_t *bid);
 
 int dc_cont_local2global(daos_handle_t coh, d_iov_t *glob);
 int dc_cont_global2local(daos_handle_t poh, d_iov_t glob,
@@ -110,6 +112,8 @@ int dc_cont_alloc_oids(tse_task_t *task);
 int dc_cont_list_snap(tse_task_t *task);
 int dc_cont_create_snap(tse_task_t *task);
 int dc_cont_destroy_snap(tse_task_t *task);
+int dc_cont_snap_oit_oid_get(tse_task_t *task);
+int dc_cont_snap_oit_dump(tse_task_t *task);
 
 static inline bool
 dc_cont_open_flags_valid(uint64_t flags)

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -52,6 +52,8 @@ enum {
 
 /* Temporarily keep it to minimize change, remove it in the future */
 #define DAOS_OC_ECHO_TINY_RW	DAOS_OC_ECHO_R1S_RW
+
+#define DAOS_OIT_BUCKET_MAX	1024
 
 static inline bool
 daos_obj_is_echo(daos_obj_id_t oid)
@@ -341,7 +343,8 @@ daos_obj_set_oid(daos_obj_id_t *oid, enum daos_otype_t type,
 static inline bool
 daos_oid_is_oit(daos_obj_id_t oid)
 {
-	return daos_obj_id2type(oid) == DAOS_OT_OIT;
+	return daos_obj_id2type(oid) == DAOS_OT_OIT ||
+	       daos_obj_id2type(oid) == DAOS_OT_OIT_V2;
 }
 
 static inline int
@@ -377,16 +380,10 @@ is_daos_obj_type_set(enum daos_otype_t type, enum daos_otype_t sub_type)
 	return is_type_set;
 }
 
-/*
- * generate ID for Object ID Table which is just an object, caller should
- * provide valid cont_rf value (DAOS_PROP_CO_REDUN_RF0 ~ DAOS_PROP_CO_REDUN_RF4)
- * or it possibly assert it internally
- */
-static inline daos_obj_id_t
-daos_oit_gen_id(daos_epoch_t epoch, uint32_t cont_rf)
+static inline int
+daos_cont_rf2oit_ord(uint32_t cont_rf)
 {
 	enum daos_obj_redun	ord;
-	daos_obj_id_t		oid = {0};
 
 	switch (cont_rf) {
 	case DAOS_PROP_CO_REDUN_RF0:
@@ -405,9 +402,26 @@ daos_oit_gen_id(daos_epoch_t epoch, uint32_t cont_rf)
 		ord = OR_RP_5;
 		break;
 	default:
-		D_ASSERTF(0, "bad cont_rf %d\n", cont_rf);
-		break;
+		D_ERROR("bad cont_rf %d\n", cont_rf);
+		return -DER_INVAL;
 	};
+
+	return ord;
+}
+
+/*
+ * generate ID for Object ID Table which is just an object, caller should
+ * provide valid cont_rf value (DAOS_PROP_CO_REDUN_RF0 ~ DAOS_PROP_CO_REDUN_RF4)
+ * or it possibly assert it internally
+ */
+static inline daos_obj_id_t
+daos_oit_gen_id(daos_epoch_t epoch, uint32_t cont_rf)
+{
+	daos_obj_id_t		oid = {0};
+	int			ord;
+
+	ord = daos_cont_rf2oit_ord(cont_rf);
+	D_ASSERT(ord >= 0);
 
 	/** use 1 group for simplicity, it should be more scalable */
 	daos_obj_set_oid(&oid, DAOS_OT_OIT, ord, 1, 0);

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2022 Intel Corporation.
+ * (C) Copyright 2015-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -55,6 +55,8 @@ struct daos_task_args {
 		daos_cont_list_snap_t	cont_list_snap;
 		daos_cont_create_snap_t	cont_create_snap;
 		daos_cont_destroy_snap_t cont_destroy_snap;
+		daos_cont_snap_oit_oid_get_t cont_get_oit_oid;
+		daos_cont_snap_oit_dump_t cont_snap_oit_dump;
 
 		/** Transaction */
 		daos_tx_open_t		tx_open;

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -705,6 +705,19 @@ int
 daos_cont_get_perms(daos_prop_t *cont_prop, uid_t uid, gid_t *gids, size_t nr_gids,
 		    uint64_t *perms);
 
+/**
+ * Dump object ID table (OIT) for the snapshot
+ *
+ * \param[in]	coh	Container handle
+ * \param[out]	epoch	epoch of snapshot
+ * \param[in]	name	Optional null terminated name for snapshot.
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ */
+int
+daos_cont_snap_oit_dump(daos_handle_t coh, daos_epoch_t epoch, char *name,
+			daos_event_t *ev);
+
 #if defined(__cplusplus)
 }
 #endif /* __cplusplus */

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -95,7 +95,12 @@ enum daos_otype_t {
 	/** Byte Array with no metadata (eg DFS/POSIX) */
 	DAOS_OT_ARRAY_BYTE	= 13,
 
-	DAOS_OT_MAX		= 13,
+	/**
+	 * Second version of Object ID table.
+	 */
+	DAOS_OT_OIT_V2		= 14,
+
+	DAOS_OT_MAX		= 14,
 
 	/**
 	 * reserved: Multi Dimensional Array

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2022 Intel Corporation.
+ * (C) Copyright 2017-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -120,6 +120,8 @@ typedef enum {
 
 	DAOS_OPC_POOL_FILTER_CONT,
 	DAOS_OPC_OBJ_KEY2ANCHOR,
+	DAOS_OPC_CONT_SNAP_OIT_OID_GET,
+	DAOS_OPC_CONT_SNAP_OIT_DUMP,
 	DAOS_OPC_MAX
 } daos_opc_t;
 
@@ -518,6 +520,28 @@ typedef struct {
 	/** Epoch range of snapshots to destroy. */
 	daos_epoch_range_t	epr;
 } daos_cont_destroy_snap_t;
+
+/** Container snapshot oit oid get args */
+typedef struct {
+	/** Container open handle. */
+	daos_handle_t		 coh;
+	/* Epoch of snapshot for getting oit oid */
+	daos_epoch_t		 epoch;
+	/* Returned OIT OID for the epoch snapshot */
+	daos_obj_id_t		*oid;
+	/* Returned pool map version when generating OIT oid */
+	uint32_t		*ver;
+} daos_cont_snap_oit_oid_get_t;
+
+/** Container snapshot oit dump args */
+typedef struct {
+	/** Container open handle. */
+	daos_handle_t		 coh;
+	/** epoch of persistent snapshot taken. */
+	daos_epoch_t		 epoch;
+	/** Optional null terminated name for snapshot. */
+	char			*name;
+} daos_cont_snap_oit_dump_t;
 
 /** Transaction Open args */
 typedef struct {

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -178,11 +178,13 @@ pf_oit(struct pf_test *pf, struct pf_param *param)
 	if (ts_mode != TS_MODE_DAOS)
 		return 0; /* cannot support */
 
-	rc = daos_cont_create_snap_opt(ts_ctx.tsc_coh, &epoch, NULL,
-				       DAOS_SNAP_OPT_CR | DAOS_SNAP_OPT_OIT,
-				       NULL);
+	rc = daos_cont_create_snap(ts_ctx.tsc_coh, &epoch, NULL, NULL);
 	if (rc)
 		fprintf(stderr, "failed to create snapshot\n");
+
+	rc = daos_cont_snap_oit_dump(ts_ctx.tsc_coh, epoch, NULL, NULL);
+	if (rc)
+		fprintf(stderr, "failed to dump oit\n");
 
 	rc = daos_oit_open(ts_ctx.tsc_coh, epoch, &toh, NULL);
 	D_ASSERT(rc == 0);

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -4903,7 +4903,7 @@ oit_list_filter(void **state)
 		oids_nr = OIT_TEST_OID_NR;
 		rc = daos_oit_list(toh, oid_list, &oids_nr, &anchor, NULL);
 		assert_rc_equal(rc, 0);
-		assert_int_equal(oids_nr, OIT_TEST_OID_NR);
+		assert_int_equal(oids_nr + total, OIT_TEST_OID_NR);
 		for (i = 0; i < oids_nr; i++) {
 			print_message("list oid[%d] ="DF_OID"\n", total, DP_OID(oid_list[i]));
 			total++;
@@ -4938,16 +4938,18 @@ oit_list_filter(void **state)
 		oids_nr = OIT_TEST_OID_NR;
 		rc = daos_oit_list_unmarked(toh, oid_list, &oids_nr, &anchor, NULL);
 		assert_rc_equal(rc, 0);
-		assert_int_equal(oids_nr, OIT_TEST_OID_NR - 4);
+		assert_int_equal(oids_nr + total, OIT_TEST_OID_NR - 4);
 		for (i = 0; i < oids_nr; i++) {
 			print_message("list oid[%d] ="DF_OID"\n", total, DP_OID(oid_list[i]));
 			total++;
 			D_ASSERT(oid_in_list(oid_list[i], oid, OIT_TEST_OID_NR));
 		}
-		D_ASSERT(!oid_in_list(oid[0], oid_list, oids_nr));
-		D_ASSERT(!oid_in_list(oid[1], oid_list, oids_nr));
-		D_ASSERT(!oid_in_list(oid[7], oid_list, oids_nr));
-		D_ASSERT(!oid_in_list(oid[15], oid_list, oids_nr));
+		if (oids_nr > 0) {
+			D_ASSERT(!oid_in_list(oid[0], oid_list, oids_nr));
+			D_ASSERT(!oid_in_list(oid[1], oid_list, oids_nr));
+			D_ASSERT(!oid_in_list(oid[7], oid_list, oids_nr));
+			D_ASSERT(!oid_in_list(oid[15], oid_list, oids_nr));
+		}
 		if (daos_anchor_is_eof(&anchor)) {
 			print_message("listed %d objects\n", total);
 			break;
@@ -4963,16 +4965,18 @@ oit_list_filter(void **state)
 		oids_nr = OIT_TEST_OID_NR;
 		rc = daos_oit_list_unmarked(toh, oid_list, &oids_nr, &anchor, NULL);
 		assert_rc_equal(rc, 0);
-		assert_int_equal(oids_nr, OIT_TEST_OID_NR - 3);
+		assert_int_equal(oids_nr + total, OIT_TEST_OID_NR - 3);
 		for (i = 0; i < oids_nr; i++) {
 			print_message("list oid[%d] ="DF_OID"\n", total, DP_OID(oid_list[i]));
 			total++;
 			D_ASSERT(oid_in_list(oid_list[i], oid, OIT_TEST_OID_NR));
 		}
-		D_ASSERT(!oid_in_list(oid[0], oid_list, oids_nr));
-		D_ASSERT(!oid_in_list(oid[1], oid_list, oids_nr));
-		D_ASSERT(!oid_in_list(oid[7], oid_list, oids_nr));
-		D_ASSERT(oid_in_list(oid[15], oid_list, oids_nr));
+		if (oids_nr > 0) {
+			D_ASSERT(!oid_in_list(oid[0], oid_list, oids_nr));
+			D_ASSERT(!oid_in_list(oid[1], oid_list, oids_nr));
+			D_ASSERT(!oid_in_list(oid[7], oid_list, oids_nr));
+			D_ASSERT(oid_in_list(oid[15], oid_list, oids_nr));
+		}
 		if (daos_anchor_is_eof(&anchor)) {
 			print_message("listed %d objects\n", total);
 			break;
@@ -4986,14 +4990,16 @@ oit_list_filter(void **state)
 		rc = daos_oit_list_filter(toh, oid_list, &oids_nr, &anchor, oit_get_markdata_as1,
 					  NULL);
 		assert_rc_equal(rc, 0);
-		assert_int_equal(oids_nr, 2);
+		assert_int_equal(oids_nr + total, 2);
 		for (i = 0; i < oids_nr; i++) {
 			print_message("list oid[%d] ="DF_OID"\n", total, DP_OID(oid_list[i]));
 			total++;
 			D_ASSERT(oid_in_list(oid_list[i], oid, OIT_TEST_OID_NR));
 		}
-		D_ASSERT(oid_in_list(oid[0], oid_list, oids_nr));
-		D_ASSERT(oid_in_list(oid[1], oid_list, oids_nr));
+		if (oids_nr > 0) {
+			D_ASSERT(oid_in_list(oid[0], oid_list, oids_nr));
+			D_ASSERT(oid_in_list(oid[1], oid_list, oids_nr));
+		}
 		if (daos_anchor_is_eof(&anchor)) {
 			print_message("listed %d objects\n", total);
 			break;


### PR DESCRIPTION
Use multiple dkeys/groups to store OIT table objects.

Todo:
1. Store OIT OID in the RDB.
2. seperate OIT creation from snapshot.

Required-githooks: true