### PR TITLE
DAOS-12595 vos: debug patch

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -336,9 +336,9 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte,
 		 * related RPC to the new leader, but such DTX is still not
 		 * committable yet. Here, the resync logic will abort it by
 		 * race during the new leader waiting for other replica(s).
-		 * The dtx_abort() logic will abort the local DTX firstly.
-		 * When the leader get replies from other replicas, it will
-		 * check whether local DTX is still valid or not.
+		 *
+		 * So when the leader get replies from other replicas, it
+		 * needs to check whether local DTX is still valid or not.
 		 *
 		 * If we abort multiple non-ready DTXs together, then there
 		 * is race that one DTX may become committable when we abort
@@ -652,7 +652,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver, b
 	}
 
 	cont->sc_dtx_resyncing = 1;
-	cont->sc_dtx_resync_ver = ver;
 	ABT_mutex_unlock(cont->sc_mutex);
 
 	dra.cont = cont;

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -227,6 +227,12 @@ enum dtx_status {
 	DTX_ST_COMMITTABLE	= 4,
 	/** The DTX is aborted. */
 	DTX_ST_ABORTED		= 5,
+	/** The DTX is in aborting, non-persistent status. */
+	DTX_ST_ABORTING		= 6,
+	/** The DTX is in committing, non-persistent status. */
+	DTX_ST_COMMITTING	= 7,
+	/** The DTX is in preparing, non-persistent status. */
+	DTX_ST_PREPARING	= 8,
 };
 
 enum daos_dtx_alb {

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2022 Intel Corporation.
+ * (C) Copyright 2015-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -123,8 +123,6 @@ struct ds_cont_child {
 	struct btr_root		 sc_dtx_cos_btr;
 	/* The global list for committable DTXs. */
 	d_list_t		 sc_dtx_cos_list;
-	/* The pool map version for the latest DTX resync on the container. */
-	uint32_t		 sc_dtx_resync_ver;
 	/* the pool map version of updating DAOS_PROP_CO_STATUS prop */
 	uint32_t		 sc_status_pm_ver;
 	/* flag of CONT_CAPA_READ_DATA/_WRITE_DATA disabled */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -217,6 +217,8 @@ enum dtx_flags {
 	DTX_DROP_CMT		= (1 << 8),
 };
 
+void
+dtx_renew_epoch(struct dtx_epoch *epoch, struct dtx_handle *dth);
 int
 dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash);
 int

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -801,6 +801,15 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	       daos_size_t *size, struct dtx_handle *dth);
 
 /**
+ * Renew the epoch for the update handle.
+ *
+ * \param ioh	[IN]	The I/O handle for update.
+ * \param dth	[IN]	Pointer to the DTX handle.
+ */
+void
+vos_update_renew_epoch(daos_handle_t ioh, struct dtx_handle *dth);
+
+/**
  * Get the recx/epoch list.
  *
  * \param ioh	[IN]	The I/O handle.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1255,6 +1255,16 @@ obj_ec_recov_need_try_again(struct obj_rw_in *orw, struct obj_rw_out *orwo,
 	return false;
 }
 
+static inline uint64_t
+orf_to_dtx_epoch_flags(enum obj_rpc_flags orf_flags)
+{
+	uint64_t flags = 0;
+
+	if (orf_flags & ORF_EPOCH_UNCERTAIN)
+		flags |= DTX_EPOCH_UNCERTAIN;
+	return flags;
+}
+
 static int
 obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		      daos_iod_t *iods, struct dcs_iod_csums *iod_csums,
@@ -1632,25 +1642,48 @@ out:
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.
 	 */
-	if (rc == 0 && obj_rpc_is_update(rpc) && dth->dth_need_validation &&
-	    sched_cur_seq() != sched_seq) {
-		daos_epoch_t	epoch = 0;
-		int		rc1;
+	if (rc == 0 && obj_rpc_is_update(rpc) && sched_cur_seq() != sched_seq) {
+		if (dth->dth_need_validation) {
+			daos_epoch_t	epoch = 0;
+			int		rc1;
 
-		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &orw->orw_dti, &epoch, NULL);
-		switch (rc1) {
-		case 0:
-			orw->orw_epoch = epoch;
-			/* Fall through */
-		case -DER_ALREADY:
-			rc = -DER_ALREADY;
-			break;
-		case -DER_NONEXIST:
-		case -DER_EP_OLD:
-			break;
-		default:
-			rc = rc1;
-			break;
+			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &orw->orw_dti, &epoch, NULL);
+			switch (rc1) {
+			case 0:
+				orw->orw_epoch = epoch;
+				/* Fall through */
+			case -DER_ALREADY:
+				rc = -DER_ALREADY;
+				break;
+			case -DER_NONEXIST:
+			case -DER_EP_OLD:
+				break;
+			default:
+				rc = rc1;
+				break;
+			}
+		}
+
+		/* For solo update, it will be handled via one-phase transaction.
+		 * If there is CPU yield after its epoch generated, we will renew
+		 * the epoch, then we can use the epoch to sort related solo DTXs
+		 * based on their epochs.
+		 */
+		if (rc == 0 && dth->dth_solo) {
+			struct dtx_epoch	epoch;
+
+			epoch.oe_value = d_hlc_get();
+			epoch.oe_first = orw->orw_epoch_first;
+			epoch.oe_flags = orf_to_dtx_epoch_flags(orw->orw_flags);
+
+			dtx_renew_epoch(&epoch, dth);
+			vos_update_renew_epoch(ioh, dth);
+
+			D_DEBUG(DB_IO,
+				"update rpc %p renew epoch "DF_U64" => "DF_U64" for "DF_DTI"\n",
+				rpc, orw->orw_epoch, dth->dth_epoch, DP_DTI(&orw->orw_dti));
+
+			orw->orw_epoch = dth->dth_epoch;
 		}
 	}
 
@@ -2198,16 +2231,6 @@ obj_ioc_begin(daos_obj_id_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 failed:
 	obj_ioc_end(ioc, rc);
 	return rc;
-}
-
-static uint64_t
-orf_to_dtx_epoch_flags(enum obj_rpc_flags orf_flags)
-{
-	uint64_t flags = 0;
-
-	if (orf_flags & ORF_EPOCH_UNCERTAIN)
-		flags |= DTX_EPOCH_UNCERTAIN;
-	return flags;
 }
 
 void
@@ -2827,6 +2850,7 @@ again2:
 		orw->orw_flags |= ORF_RESEND;
 		need_abort = true;
 		d_tm_inc_counter(opm->opm_update_retry, 1);
+		ABT_thread_yield();
 		goto again1;
 	default:
 		break;
@@ -3669,6 +3693,7 @@ again2:
 	case -DER_AGAIN:
 		opi->opi_flags |= ORF_RESEND;
 		need_abort = true;
+		ABT_thread_yield();
 		goto again1;
 	default:
 		break;
@@ -4226,21 +4251,38 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 	/* There is CPU yield after DTX start, and the resent RPC may be handled during that.
 	 * Let's check resent again before further process.
 	 */
-	if (rc == 0 && dth->dth_modification_cnt > 0 && dth->dth_need_validation &&
-	    sched_cur_seq() != sched_seq) {
-		daos_epoch_t	epoch = 0;
-		int		rc1;
+	if (rc == 0 && dth->dth_modification_cnt > 0 && sched_cur_seq() != sched_seq) {
+		if (dth->dth_need_validation) {
+			daos_epoch_t	epoch = 0;
+			int		rc1;
 
-		rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &epoch, NULL);
-		switch (rc1) {
-		case 0:
-		case -DER_ALREADY:
-			D_GOTO(out, rc = -DER_ALREADY);
-		case -DER_NONEXIST:
-		case -DER_EP_OLD:
-			break;
-		default:
-			D_GOTO(out, rc = rc1);
+			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &dcsh->dcsh_xid, &epoch, NULL);
+			switch (rc1) {
+			case 0:
+			case -DER_ALREADY:
+				D_GOTO(out, rc = -DER_ALREADY);
+			case -DER_NONEXIST:
+			case -DER_EP_OLD:
+				break;
+			default:
+				D_GOTO(out, rc = rc1);
+			}
+		}
+
+		if (rc == 0 && dth->dth_solo) {
+			daos_epoch_t	epoch = dcsh->dcsh_epoch.oe_value;
+
+			D_ASSERT(dcde->dcde_read_cnt == 0);
+			D_ASSERT(dcde->dcde_write_cnt == 1);
+
+			dcsh->dcsh_epoch.oe_value = d_hlc_get();
+
+			dtx_renew_epoch(&dcsh->dcsh_epoch, dth);
+			vos_update_renew_epoch(iohs[0], dth);
+
+			D_DEBUG(DB_IO,
+				"CPD rpc %p renew epoch "DF_U64" => "DF_U64" for "DF_DTI"\n",
+				rpc, epoch, dcsh->dcsh_epoch.oe_value, DP_DTI(&dcsh->dcsh_xid));
 		}
 	}
 
@@ -4659,7 +4701,7 @@ again:
 	else
 		tgts++;
 
-	if (tgt_cnt <= 1 && dcde->dcde_write_cnt <= 1)
+	if (tgt_cnt <= 1 && dcde->dcde_write_cnt == 1 && dcde->dcde_read_cnt == 0)
 		dtx_flags |= DTX_SOLO;
 	if (flags & ORF_RESEND)
 		dtx_flags |= DTX_PREPARED;
@@ -4694,6 +4736,7 @@ out:
 	if (rc == -DER_AGAIN) {
 		oci->oci_flags |= ORF_RESEND;
 		need_abort = true;
+		ABT_thread_yield();
 		goto again;
 	}
 

--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
@@ -21,6 +21,9 @@ server_config:
       fabric_iface: ib0
       fabric_iface_port: 31416
       log_file: daos_server0.log
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=mgmt,md,io
       storage: auto
     1:
       pinned_numa_node: 1
@@ -28,6 +31,9 @@ server_config:
       fabric_iface: ib1
       fabric_iface_port: 31517
       log_file: daos_server1.log
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=mgmt,md,io
       storage: auto
 pool:
   control_method: dmg

--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -226,7 +226,7 @@ lrua_lookup_idx(struct lru_array *array, uint32_t idx, uint64_t key,
  *
  * \param	array[in]	The lru array
  * \param	idx[in]		The index of the entry
- * \param	idx[in]		Unique identifier
+ * \param	key[in]		Unique identifier
  * \param	entryp[out]	Valid only if function returns true.
  *
  * \return true if the entry is in the array and set \p entryp accordingly

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -93,6 +93,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_shares_inited = 1;
 
 	vos_dtx_rsrvd_init(dth);
+	vos_dtx_attach(dth, false, false);
 
 	*dthp = dth;
 }

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -257,9 +257,11 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 	   bool started, int err)
 {
 	struct dtx_handle	*dth = dth_in;
+	struct vos_dtx_act_ent	*dae;
 	struct dtx_rsrvd_uint	*dru;
 	struct vos_dtx_cmt_ent	*dce = NULL;
 	struct dtx_handle	 tmp = {0};
+	int			 rc;
 
 	if (!dtx_is_valid_handle(dth)) {
 		/** Created a dummy dth handle for publishing extents */
@@ -303,19 +305,55 @@ vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
 	err = umem_tx_end(vos_cont2umm(cont), err);
 
 cancel:
+	if (dtx_is_valid_handle(dth_in)) {
+		if (unlikely(dth_in->dth_aborted)) {
+			/* Aborted by race during the yield for local TX commit. */
+			rc = vos_dtx_validation(dth_in);
+			switch (rc) {
+			case DTX_ST_INITED:
+			case DTX_ST_PREPARED:
+			case DTX_ST_PREPARING:
+				/* The DTX has been ever aborted and related resent RPC
+				 * is in processing. Return -DER_AGAIN to make this ULT
+				 * to retry sometime later without dtx_abort().
+				 */
+				D_GOTO(out, err = -DER_AGAIN);
+			case DTX_ST_ABORTED:
+				D_ASSERT(dth_in->dth_ent == NULL);
+				/* Aborted, return -DER_INPROGRESS for client retry.
+				 *
+				 * Fall through.
+				 */
+			case DTX_ST_ABORTING:
+				D_GOTO(out, err = -DER_INPROGRESS);
+			default:
+				D_ASSERTF(0, "Unexpected DTX "DF_DTI" status %d\n",
+					  DP_DTI(&dth_in->dth_xid), rc);
+			}
+		} else {
+			dae = dth_in->dth_ent;
+			D_ASSERT(dae != NULL);
+
+			dae->dae_preparing = 0;
+			if (dth_in->dth_solo) {
+				if (err == 0 && cont->vc_solo_dtx_epoch < dth_in->dth_epoch)
+					cont->vc_solo_dtx_epoch = dth_in->dth_epoch;
+
+				vos_dtx_post_handle(cont, &dae, &dce, 1, false, err != 0);
+			} else {
+				D_ASSERT(dce == NULL);
+				if (err == 0)
+					dae->dae_prepared = 1;
+			}
+		}
+	}
+
+out:
 	if (err != 0) {
 		/* The transaction aborted or failed to commit. */
 		vos_tx_publish(dth, false);
 		if (dtx_is_valid_handle(dth_in))
 			vos_dtx_cleanup_internal(dth);
-	}
-
-	if (dce != NULL) {
-		struct vos_dtx_act_ent	*dae = dth_in->dth_ent;
-
-		vos_dtx_post_handle(cont, &dae, &dce, 1, false,
-				    err != 0 ? true : false);
-		dth_in->dth_ent = NULL;
 	}
 
 	return err;

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -374,6 +374,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_cmt_dtx_reindex_pos = cont->vc_cont_df->cd_dtx_committed_head;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_act_list);
 	cont->vc_dtx_committed_count = 0;
+	cont->vc_solo_dtx_epoch = d_hlc_get();
 	gc_check_cont(cont);
 
 	/* Cache this btr object ID in container handle */

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -132,7 +132,7 @@ dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t next /
 		dae = rec_iov.iov_buf;
 	}
 
-	while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+	while (vos_dae_is_commit(dae) || vos_dae_is_abort(dae) || dae->dae_preparing ||
 	       dae->dae_dth != NULL) {
 		if (oiter->oit_linear) {
 			if (dae->dae_link.next ==
@@ -204,7 +204,7 @@ dtx_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 				 sizeof(struct vos_dtx_act_ent));
 			dae = rec_iov.iov_buf;
 		}
-	} while (dae->dae_committable || dae->dae_committed || dae->dae_aborted ||
+	} while (vos_dae_is_commit(dae) || vos_dae_is_abort(dae) || dae->dae_preparing ||
 		 dae->dae_dth != NULL);
 
 out:
@@ -241,9 +241,9 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	}
 
 	/* Only return prepared ones. */
-	D_ASSERT(!dae->dae_committable);
-	D_ASSERT(!dae->dae_committed);
-	D_ASSERT(!dae->dae_aborted);
+	D_ASSERT(!vos_dae_is_commit(dae));
+	D_ASSERT(!vos_dae_is_abort(dae));
+	D_ASSERT(!dae->dae_preparing);
 	D_ASSERT(dae->dae_dth == NULL);
 
 	/*

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -95,6 +95,14 @@ enum {
 	DTX_LID_RESERVED,
 };
 
+/**
+ * If the highest bit (31th) of the DTX entry offset is set, then it is for
+ * solo (single modification against single replicated object) transaction.
+ */
+#define DTX_LID_SOLO_BITS	31
+#define DTX_LID_SOLO_FLAG	(1UL << DTX_LID_SOLO_BITS)
+#define DTX_LID_SOLO_MASK	(DTX_LID_SOLO_FLAG - 1)
+
 /*
  * When aggregate merge window reaches this size threshold, it will stop
  * growing and trigger window flush immediately.
@@ -284,6 +292,10 @@ struct vos_container {
 	uint64_t		vc_io_nospc_ts;
 	/* The (next) position for committed DTX entries reindex. */
 	umem_off_t		vc_cmt_dtx_reindex_pos;
+	/* The epoch for the latest committed solo DTX. Any solo
+	 * * transaction with older epoch must has been committed.
+	 */
+	daos_epoch_t		vc_solo_dtx_epoch;
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,
@@ -328,11 +340,14 @@ struct vos_dtx_act_ent {
 	struct dtx_handle		*dae_dth;
 
 	unsigned int			 dae_committable:1,
+					 dae_committing:1,
 					 dae_committed:1,
+					 dae_aborting:1,
 					 dae_aborted:1,
 					 dae_maybe_shared:1,
 					 /* Need validation on leader before commit/committable. */
 					 dae_need_validation:1,
+					 dae_preparing:1,
 					 dae_prepared:1;
 };
 
@@ -405,6 +420,62 @@ D_CASSERT((VOS_AGG_TIME_MASK & (1ULL << (VOS_TF_AGG_BIT - VOS_AGG_NR_BITS))) == 
 CHECK_VOS_TREE_FLAG(VOS_KEY_CMP_LEXICAL);
 CHECK_VOS_TREE_FLAG(VOS_TF_AGG_OPT);
 CHECK_VOS_TREE_FLAG(VOS_AGG_TIME_MASK);
+
+/* For solo transaction (single modification against single replicated object),
+ * consider efficiency, we do not generate persistent DTX entry. Then we need
+ * some special mechanism to maintain the semantics: any readable data must be
+ * persistently visible unless it is over-written by newer modification. That
+ * is the same behavior as non-solo cases. So if the local backend TX for the
+ * solo transaction is in committing, then related modification is invisible
+ * until related local backend TX has been successfully committed. (NOTE: in
+ * committing modification maybe lost if engine crashed before commit done.)
+ *
+ * For this purpose, we will reuse the DTX entry index (uint32_t) in the data
+ * record (ilog/svt/evt). Originally, such 32-bits integer is used as the DTX
+ * entry offset in the DTX LRU array. Up to now, we only use the lower 20 bits
+ * (DTX_ARRAY_LEN). Now, the highest (31th) bit will be used as a solo flag to
+ * indicate a solo DTX. On the other hand, we will trace the epoch against the
+ * container for the latest committed solo DTX. Anytime, for a given solo DTX,
+ * if its epoch is newer than the one for the container known latest committed
+ * solo DTX, then it is in committing status; otherwise, it has been committed.
+ */
+static inline bool
+dtx_is_committed(uint32_t tx_lid, struct vos_container *cont, daos_epoch_t epoch)
+{
+	if (tx_lid == DTX_LID_COMMITTED)
+		return true;
+
+	D_ASSERT(cont != NULL);
+
+	if (tx_lid & DTX_LID_SOLO_FLAG && cont->vc_solo_dtx_epoch >= epoch)
+		return true;
+
+	return false;
+}
+
+static inline bool
+dtx_is_aborted(uint32_t tx_lid)
+{
+	return tx_lid == DTX_LID_ABORTED;
+}
+
+static inline bool
+vos_dtx_is_normal_entry(uint32_t tx_lid)
+{
+	return tx_lid >= DTX_LID_RESERVED && !(tx_lid & DTX_LID_SOLO_FLAG);
+}
+
+static inline void
+dtx_set_committed(uint32_t *tx_lid)
+{
+	*tx_lid = DTX_LID_COMMITTED;
+}
+
+static inline void
+dtx_set_aborted(uint32_t *tx_lid)
+{
+	*tx_lid = DTX_LID_ABORTED;
+}
 
 /** Get the aggregatable write timestamp within 1/4 ms granularity */
 static inline bool
@@ -557,21 +628,22 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
  * Get local entry DTX state. Only used by VOS aggregation.
  *
  * \param entry		[IN]	DTX local id
+ * \param cont		[IN]	Pointer to the vos container.
+ * \param epoch		[IN]	Epoch for the related entry.
  *
  * \return		DTX_ST_COMMITTED, DTX_ST_PREPARED or
  *			DTX_ST_ABORTED.
  */
 static inline unsigned int
-vos_dtx_ent_state(uint32_t entry)
+vos_dtx_ent_state(uint32_t entry, struct vos_container *cont, daos_epoch_t epoch)
 {
-	switch (entry) {
-	case DTX_LID_COMMITTED:
+	if (dtx_is_committed(entry, cont, epoch))
 		return DTX_ST_COMMITTED;
-	case DTX_LID_ABORTED:
+
+	if (dtx_is_aborted(entry))
 		return DTX_ST_ABORTED;
-	default:
-		return DTX_ST_PREPARED;
-	}
+
+	return DTX_ST_PREPARED;
 }
 
 /**
@@ -1488,6 +1560,30 @@ struct csum_recalc_args {
 };
 
 int vos_csum_recalc_fn(void *recalc_args);
+
+static inline bool
+vos_dae_is_commit(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_committable || dae->dae_committing || dae->dae_committed;
+}
+
+static inline bool
+vos_dae_is_abort(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_aborting || dae->dae_aborted;
+}
+
+static inline bool
+vos_dae_is_prepare(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_preparing || dae->dae_prepared;
+}
+
+static inline bool
+vos_dae_in_process(struct vos_dtx_act_ent *dae)
+{
+	return dae->dae_committing || dae->dae_aborting || dae->dae_preparing;
+}
 
 static inline struct dcs_csum_info *
 vos_csum_at(struct dcs_iod_csums *iod_csums, unsigned int idx)

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -526,27 +526,27 @@ reset:
 			rc = -DER_TX_RESTART;
 	}
 
-	rc = vos_tx_end(cont, dth, NULL, NULL, true, rc);
-
-	if (rc == 0) {
+	if (rc == 0)
 		vos_ts_set_upgrade(ts_set);
-		if (daes != NULL) {
-			vos_dtx_post_handle(cont, daes, dces,
-					    dth->dth_dti_cos_count,
-					    false, false);
-			dth->dth_cos_done = 1;
-		}
-	} else if (daes != NULL) {
-		vos_dtx_post_handle(cont, daes, dces,
-				    dth->dth_dti_cos_count, false, true);
-		dth->dth_cos_done = 1;
-	}
 
 	if (rc == -DER_NONEXIST || rc == 0) {
 		vos_punch_add_missing(ts_set, dkey, akey_nr, akeys);
 		vos_ts_set_update(ts_set, epr.epr_hi);
+	}
+
+	if (rc == 0)
+		vos_ts_set_wupdate(ts_set, epr.epr_hi);
+
+	rc = vos_tx_end(cont, dth, NULL, NULL, true, rc);
+	if (dtx_is_valid_handle(dth)) {
 		if (rc == 0)
-			vos_ts_set_wupdate(ts_set, epr.epr_hi);
+			dth->dth_cos_done = 1;
+		else
+			dth->dth_cos_done = 0;
+
+		if (daes != NULL)
+			vos_dtx_post_handle(cont, daes, dces, dth->dth_dti_cos_count,
+					    false, rc != 0);
 	}
 
 	D_FREE(daes);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -440,7 +440,7 @@ svt_rec_load(struct btr_instance *tins, struct btr_record *rec,
 	rbund->rb_rsize	= irec->ir_size;
 	rbund->rb_gsize	= irec->ir_gsize;
 	rbund->rb_ver	= irec->ir_ver;
-	rbund->rb_dtx_state = vos_dtx_ent_state(irec->ir_dtx);
+	rbund->rb_dtx_state = vos_dtx_ent_state(irec->ir_dtx, vos_hdl2cont(tins->ti_coh), *epc);
 	rbund->rb_off = rec->rec_off;
 	return 0;
 }


### PR DESCRIPTION
Only for test.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
