### PR TITLE
DAOS-12910 tools: Move daos cont list-snap logic to Go

### DIFF
--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -54,8 +54,7 @@ func outputJSON(out io.Writer, in interface{}, cmdErr error) error {
 	status := 0
 	var errStr *string
 	if cmdErr != nil {
-		errStr = new(string)
-		*errStr = cmdErr.Error()
+		errStr = func() *string { str := cmdErr.Error(); return &str }()
 		if s, ok := errors.Cause(cmdErr).(daos.Status); ok {
 			status = int(s)
 		} else {

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -200,6 +200,13 @@ func freeCmdArgs(ap *C.struct_cmd_args_s) {
 	C.free(unsafe.Pointer(ap))
 }
 
+func freeDaosStr(str *C.char) {
+	if str == nil {
+		return
+	}
+	C.free_daos_alloc(unsafe.Pointer(str))
+}
+
 func allocCmdArgs(log logging.Logger) (ap *C.struct_cmd_args_s, cleanFn func(), err error) {
 	// allocate the struct using C memory to avoid any issues with Go GC
 	ap = (*C.struct_cmd_args_s)(C.calloc(1, C.sizeof_struct_cmd_args_s))


### PR DESCRIPTION
In order to support JSON output for this command, the
listing logic needed to be ported to Go.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
