### PR TITLE
DAOS-12904 tools: Close files in cleanup closure

### DIFF
--- a/src/control/cmd/daos/container_test.go
+++ b/src/control/cmd/daos/container_test.go
@@ -120,16 +120,12 @@ func TestDaos_existingContainerCmd_resolveContainer(t *testing.T) {
 			contPath: "bad-path",
 			expErr:   errors.New("DER_NONEXIST"),
 		},
-		/* FIXME (DAOS-12468): Temporarily disabled as it seems
-		 * to be failing intermittently in CI with bad fd errors.
-		 * Could be some kind of race in the tests?
 		"valid DUNS path (POSIX)": {
 			contType: "POSIX",
 			contPath: "valid-path",
 			poolID:   test.MockUUID(1),
 			contID:   test.MockUUID(2),
 		},
-		*/
 		"pool UUID + cont UUID": {
 			poolID: test.MockUUID(1),
 			contID: test.MockUUID(2),

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,6 +8,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -124,7 +125,7 @@ func fd2FILE(fd uintptr, modeStr string) (out *C.FILE, err error) {
 	defer freeString(cModeStr)
 	out = C.fdopen(C.int(fd), cModeStr)
 	if out == nil {
-		return nil, errors.New("fdopen() failed")
+		return nil, errors.Errorf("fdopen() failed (fd: %d, mode: %s)", fd, modeStr)
 	}
 	return
 }
@@ -136,7 +137,7 @@ func freeString(str *C.char) {
 	C.free(unsafe.Pointer(str))
 }
 
-func createWriteStream(prefix string, printLn func(line string)) (*C.FILE, func(), error) {
+func createWriteStream(ctx context.Context, prefix string, printLn func(line string)) (*C.FILE, func(), error) {
 	// Create a FILE object for the handler to use for
 	// printing output or errors, and call the callback
 	// for each line.
@@ -150,30 +151,34 @@ func createWriteStream(prefix string, printLn func(line string)) (*C.FILE, func(
 		return nil, nil, err
 	}
 
-	go func(prefix string) {
-		defer r.Close()
-		defer w.Close()
-
+	go func(ctx context.Context, prefix string) {
 		if prefix != "" {
 			prefix = ": "
 		}
 
 		rdr := bufio.NewReader(r)
 		for {
-			line, err := rdr.ReadString('\n')
-			if err != nil {
-				if err != io.EOF {
-					printLn(fmt.Sprintf("read err: %s", err))
-				}
+			select {
+			case <-ctx.Done():
 				return
+			default:
+				line, err := rdr.ReadString('\n')
+				if err != nil {
+					if !(errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed)) {
+						printLn(fmt.Sprintf("read err: %s", err))
+					}
+					return
+				}
+				printLn(fmt.Sprintf("%s%s", prefix, line))
 			}
-			printLn(fmt.Sprintf("%s%s", prefix, line))
 		}
-	}(prefix)
+	}(ctx, prefix)
 
 	return stream, func() {
 		C.fflush(stream)
 		C.fclose(stream)
+		r.Close()
+		w.Close()
 	}, nil
 }
 
@@ -206,17 +211,20 @@ func allocCmdArgs(log logging.Logger) (ap *C.struct_cmd_args_s, cleanFn func(), 
 	C.init_op_vals(ap)
 	ap.sysname = C.CString(build.DefaultSystemName)
 
-	outStream, outCleanup, err := createWriteStream("", log.Info)
+	ctx, cancel := context.WithCancel(context.Background())
+	outStream, outCleanup, err := createWriteStream(ctx, "", log.Info)
 	if err != nil {
 		freeCmdArgs(ap)
+		cancel()
 		return nil, nil, err
 	}
 	ap.outstream = outStream
 
-	errStream, errCleanup, err := createWriteStream("handler", log.Error)
+	errStream, errCleanup, err := createWriteStream(ctx, "handler", log.Error)
 	if err != nil {
 		outCleanup()
 		freeCmdArgs(ap)
+		cancel()
 		return nil, nil, err
 	}
 	ap.errstream = errStream
@@ -225,6 +233,7 @@ func allocCmdArgs(log logging.Logger) (ap *C.struct_cmd_args_s, cleanFn func(), 
 		outCleanup()
 		errCleanup()
 		freeCmdArgs(ap)
+		cancel()
 	}, nil
 }
 


### PR DESCRIPTION
Instead of closing them in the reader goroutine, close them
in the cleanup closure that is invoked by the caller. This
ensures that the file handles are released synchronously.

Also adds context-aware cleanup to avoid leaking goroutines.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
