### PR TITLE
DAOS-12636 container: set status property to unhealthy (#11467)

### DIFF
--- a/src/common/cont_props.c
+++ b/src/common/cont_props.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2020-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -17,60 +17,61 @@ daos_props_2cont_props(daos_prop_t *props, struct cont_props *cont_prop)
 		return;
 	}
 
-	/* input props should cover needed entries, see ds_get_cont_props() */
-	if (daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP_THRESHOLD) == NULL ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_SERVER_VERIFY)
-	    == NULL							     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_CHUNK_SIZE) == NULL ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_COMPRESS) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_ENCRYPT) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_FAC) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_ALLOCED_OID) == NULL     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_EC_CELL_SZ) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_EC_PDA) == NULL	     ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_GLOBAL_VERSION) == NULL  ||
-	    daos_prop_entry_get(props, DAOS_PROP_CO_RP_PDA) == NULL)
-		D_DEBUG(DB_TRACE, "some prop entry type not found, "
-			"use default value.\n");
-
 	/** deduplication */
-	cont_prop->dcp_dedup_enabled	= daos_cont_prop2dedup(props);
-	cont_prop->dcp_dedup_size	= daos_cont_prop2dedupsize(props);
-	cont_prop->dcp_dedup_verify	= daos_cont_prop2dedupverify(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP) != NULL) {
+		cont_prop->dcp_dedup_enabled = daos_cont_prop2dedup(props);
+		cont_prop->dcp_dedup_verify = daos_cont_prop2dedupverify(props);
+	}
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP_THRESHOLD) != NULL)
+		cont_prop->dcp_dedup_size = daos_cont_prop2dedupsize(props);
 
 	/** checksum */
-	cont_prop->dcp_srv_verify	= daos_cont_prop2serververify(props);
-	cont_prop->dcp_csum_type	= daos_cont_prop2csum(props);
-	cont_prop->dcp_csum_enabled =
-		daos_cont_csum_prop_is_enabled(cont_prop->dcp_csum_type);
-	cont_prop->dcp_chunksize	= daos_cont_prop2chunksize(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_SERVER_VERIFY) != NULL)
+		cont_prop->dcp_srv_verify = daos_cont_prop2serververify(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_CSUM)) {
+		cont_prop->dcp_csum_type = daos_cont_prop2csum(props);
+		cont_prop->dcp_csum_enabled =
+			daos_cont_csum_prop_is_enabled(cont_prop->dcp_csum_type);
+	}
+
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_CHUNK_SIZE) != NULL)
+		cont_prop->dcp_chunksize = daos_cont_prop2chunksize(props);
 
 	/** compression */
-	cont_prop->dcp_compress_type	= daos_cont_prop2compress(props);
-	cont_prop->dcp_compress_enabled	=
-	       daos_cont_compress_prop_is_enabled(cont_prop->dcp_compress_type);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_COMPRESS) != NULL) {
+		cont_prop->dcp_compress_type = daos_cont_prop2compress(props);
+		cont_prop->dcp_compress_enabled	=
+			daos_cont_compress_prop_is_enabled(cont_prop->dcp_compress_type);
+	}
 
 	/** encryption */
-	cont_prop->dcp_encrypt_type	= daos_cont_prop2encrypt(props);
-	cont_prop->dcp_encrypt_enabled	=
-		daos_cont_encrypt_prop_is_enabled(cont_prop->dcp_encrypt_type);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_ENCRYPT) != NULL) {
+		cont_prop->dcp_encrypt_type = daos_cont_prop2encrypt(props);
+		cont_prop->dcp_encrypt_enabled =
+			daos_cont_encrypt_prop_is_enabled(cont_prop->dcp_encrypt_type);
+	}
 
 	/** redundancy */
-	cont_prop->dcp_redun_fac	= daos_cont_prop2redunfac(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_FAC) != NULL)
+		cont_prop->dcp_redun_fac = daos_cont_prop2redunfac(props);
+
 	/** EC cell size */
-	cont_prop->dcp_ec_cell_sz	= daos_cont_prop2ec_cell_sz(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_EC_CELL_SZ) != NULL)
+		cont_prop->dcp_ec_cell_sz = daos_cont_prop2ec_cell_sz(props);
 
 	/** alloc'ed oid */
-	cont_prop->dcp_alloced_oid	= daos_cont_prop2allocedoid(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_ALLOCED_OID) != NULL)
+		cont_prop->dcp_alloced_oid = daos_cont_prop2allocedoid(props);
 
 	/** performance domain affinity level */
-	cont_prop->dcp_ec_pda		= daos_cont_prop2ec_pda(props);
-	cont_prop->dcp_rp_pda		= daos_cont_prop2rp_pda(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_EC_PDA) != NULL)
+		cont_prop->dcp_ec_pda = daos_cont_prop2ec_pda(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_RP_PDA) != NULL)
+		cont_prop->dcp_rp_pda = daos_cont_prop2rp_pda(props);
 
 	/** global version */
-	cont_prop->dcp_global_version   = daos_cont_prop2global_version(props);
+	if (daos_prop_entry_get(props, DAOS_PROP_CO_GLOBAL_VERSION) != NULL)
+		cont_prop->dcp_global_version   = daos_cont_prop2global_version(props);
 }
 
 uint16_t

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1430,18 +1430,6 @@ dc_cont_set_prop(tse_task_t *task)
 		D_GOTO(err, rc = -DER_NO_PERM);
 	}
 
-	entry = daos_prop_entry_get(args->prop, DAOS_PROP_CO_STATUS);
-	if (entry != NULL) {
-		daos_prop_val_2_co_status(entry->dpe_val, &co_stat);
-		if (co_stat.dcs_status != DAOS_PROP_CO_HEALTHY) {
-			rc = -DER_INVAL;
-			D_ERROR("To set DAOS_PROP_CO_STATUS property can-only "
-				"set dcs_status as DAOS_PROP_CO_HEALTHY to "
-				"clear UNCLEAN status, "DF_RC"\n", DP_RC(rc));
-			goto err;
-		}
-	}
-
 	cont = dc_hdl2cont(args->coh);
 	if (cont == NULL)
 		D_GOTO(err, rc = -DER_NO_HDL);
@@ -1452,6 +1440,20 @@ dc_cont_set_prop(tse_task_t *task)
 	D_DEBUG(DB_MD, DF_CONT": setting props: hdl="DF_UUID"\n",
 		DP_CONT(pool->dp_pool, cont->dc_uuid),
 		DP_UUID(cont->dc_cont_hdl));
+
+	entry = daos_prop_entry_get(args->prop, DAOS_PROP_CO_STATUS);
+	if (entry != NULL) {
+		daos_prop_val_2_co_status(entry->dpe_val, &co_stat);
+		if (co_stat.dcs_status != DAOS_PROP_CO_HEALTHY) {
+			rc = -DER_INVAL;
+			D_ERROR("To set DAOS_PROP_CO_STATUS property can-only "
+				"set dcs_status as DAOS_PROP_CO_HEALTHY to "
+				"clear UNCLEAN status, "DF_RC"\n", DP_RC(rc));
+			goto err_cont;
+		}
+		co_stat.dcs_pm_ver = dc_pool_get_version(pool);
+		entry->dpe_val = daos_prop_co_status_2_val(&co_stat);
+	}
 
 	ep.ep_grp  = pool->dp_sys->sy_group;
 	rc = dc_pool_choose_svc_rank(NULL /* label */, pool->dp_pool,

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -463,7 +463,24 @@ again:
 							     civ_key->cont_uuid, &chdl);
 				if (rc1 == 0) {
 					struct cont_iv_entry	iv_entry = { 0 };
+					daos_prop_t		*prop = NULL;
+					struct daos_prop_entry	*prop_entry;
+					struct daos_co_status	stat = { 0 };
 
+					rc = ds_cont_get_prop(entry->ns->iv_pool_uuid,
+							      civ_key->cont_uuid, &prop);
+					if (rc) {
+						D_ERROR(DF_CONT "get prop: "DF_RC"\n",
+							DP_CONT(entry->ns->iv_pool_uuid,
+								civ_key->cont_uuid), DP_RC(rc));
+						D_GOTO(out, rc);
+					}
+					prop_entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
+					D_ASSERT(prop_entry != NULL);
+
+					daos_prop_val_2_co_status(prop_entry->dpe_val, &stat);
+					iv_entry.iv_capa.status_pm_ver = stat.dcs_pm_ver;
+					daos_prop_free(prop);
 					/* Only happens on xstream 0 */
 					D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 					iv_entry.iv_capa.flags = chdl.ch_flags;
@@ -554,8 +571,6 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 				D_GOTO(out, rc);
 		} else if (entry->iv_class->iv_class_id == IV_CONT_PROP) {
 			daos_prop_t		*prop = NULL;
-			struct daos_prop_entry	*iv_entry;
-			struct daos_co_status	 co_stat = {0};
 
 			rc = cont_iv_prop_g2l(&civ_ent->iv_prop, &prop);
 			if (rc) {
@@ -563,21 +578,8 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 					DP_RC(rc));
 				D_GOTO(out, rc);
 			}
-
-			iv_entry = daos_prop_entry_get(prop,
-						       DAOS_PROP_CO_STATUS);
-			if (iv_entry != NULL) {
-				daos_prop_val_2_co_status(iv_entry->dpe_val,
-							  &co_stat);
-				rc = ds_cont_status_pm_ver_update(
-					entry->ns->iv_pool_uuid,
-					civ_ent->cont_uuid,
-					co_stat.dcs_pm_ver);
-				if (rc) {
-					daos_prop_free(prop);
-					goto out;
-				}
-			}
+			rc = ds_cont_tgt_prop_update(entry->ns->iv_pool_uuid,
+						     civ_ent->cont_uuid, prop);
 			daos_prop_free(prop);
 		} else if (entry->iv_class->iv_class_id == IV_CONT_SNAP &&
 			   civ_ent->iv_snap.snap_cnt != (uint64_t)(-1)) {
@@ -1308,7 +1310,7 @@ out:
 }
 
 int
-cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop)
+cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop, bool sync)
 {
 	struct cont_iv_entry	*iv_entry;
 	uint32_t		iv_entry_size;
@@ -1322,12 +1324,32 @@ cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop)
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
+	/* IV property should include all entries for the moment, since IV entry
+	 * cache can not tell individual entry, so it can not update single entry.
+	 */
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_DEDUP) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_DEDUP_THRESHOLD) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_CSUM_SERVER_VERIFY) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_CSUM) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_CSUM_CHUNK_SIZE) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_COMPRESS) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_ENCRYPT) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_REDUN_LVL) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_REDUN_FAC) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_ALLOCED_OID) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_EC_CELL_SZ) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_EC_PDA) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_GLOBAL_VERSION) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS) != NULL);
+	D_ASSERT(daos_prop_entry_get(prop, DAOS_PROP_CO_RP_PDA) != NULL);
+
 	uuid_copy(iv_entry->cont_uuid, cont_uuid);
 	cont_iv_prop_l2g(prop, &iv_entry->iv_prop);
 
 	rc = cont_iv_update(ns, IV_CONT_PROP, cont_uuid, iv_entry,
 			    iv_entry_size, CRT_IV_SHORTCUT_TO_ROOT,
-			    CRT_IV_SYNC_EAGER, false /* retry */);
+			    sync ? CRT_IV_SYNC_EAGER : CRT_IV_SYNC_LAZY,
+			    !sync/* retry */);
 	D_FREE(iv_entry);
 	return rc;
 }

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1790,7 +1790,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 
 	/* query the container properties from RDB and update to IV */
 	rc = cont_iv_prop_update(pool_hdl->sph_pool->sp_iv_ns,
-				 cont->c_uuid, prop);
+				 cont->c_uuid, prop, true);
 	daos_prop_free(prop);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": cont_iv_prop_update failed %d.\n",
@@ -2781,35 +2781,6 @@ capas_can_set_prop(struct cont *cont, uint64_t sec_capas,
 	return true;
 }
 
-/* pre-processing for DAOS_PROP_CO_STATUS, set the pool map version */
-static bool
-set_prop_co_status_pre_process(struct ds_pool *pool, struct cont *cont,
-			       daos_prop_t *prop_in)
-{
-	struct daos_prop_entry	*entry;
-	struct daos_co_status	 co_status = { 0 };
-	bool			 clear_stat;
-
-	entry = daos_prop_entry_get(prop_in, DAOS_PROP_CO_STATUS);
-	if (entry == NULL)
-		return false;
-
-	daos_prop_val_2_co_status(entry->dpe_val, &co_status);
-	D_ASSERT(co_status.dcs_status == DAOS_PROP_CO_HEALTHY ||
-		 co_status.dcs_status == DAOS_PROP_CO_UNCLEAN);
-	clear_stat = (co_status.dcs_status == DAOS_PROP_CO_HEALTHY);
-	co_status.dcs_pm_ver = ds_pool_get_version(pool);
-	co_status.dcs_flags = 0;
-	entry->dpe_val = daos_prop_co_status_2_val(&co_status);
-	D_DEBUG(DB_MD, DF_CONT" updating co_status - status %s, pm_ver %d.\n",
-		DP_CONT(pool->sp_uuid, cont->c_uuid),
-		co_status.dcs_status == DAOS_PROP_CO_HEALTHY ?
-		"DAOS_PROP_CO_HEALTHY" : "DAOS_PROP_CO_UNCLEAN",
-		co_status.dcs_pm_ver);
-
-	return clear_stat;
-}
-
 /* Sanity check set-prop label, and update cs_uuids KVS */
 static int
 check_set_prop_label(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont,
@@ -2918,7 +2889,6 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 	int			 rc;
 	daos_prop_t		*prop_old = NULL;
 	daos_prop_t		*prop_iv = NULL;
-	bool			 clear_stat;
 	struct daos_prop_entry	*entry;
 
 	entry = daos_prop_entry_get(prop_in, DAOS_PROP_CO_GLOBAL_VERSION);
@@ -2941,7 +2911,6 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 		D_GOTO(out, rc);
 	}
 	D_ASSERT(prop_old != NULL);
-	clear_stat = set_prop_co_status_pre_process(pool, cont, prop_in);
 	prop_iv = daos_prop_merge(prop_old, prop_in);
 	if (prop_iv == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -2954,22 +2923,6 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 	rc = cont_prop_write(tx, &cont->c_prop, prop_in, false);
 	if (rc != 0)
 		D_GOTO(out, rc);
-
-	/* Update prop IV with merged prop */
-	rc = cont_iv_prop_update(pool->sp_iv_ns, cont->c_uuid, prop_iv);
-	if (rc) {
-		D_ERROR(DF_UUID": failed to update prop IV for cont, "
-			DF_RC"\n", DP_UUID(cont->c_uuid), DP_RC(rc));
-		goto out;
-	}
-
-	if (clear_stat) {
-		/* to notify each tgt server to do ds_cont_rf_check() */
-		rc = ds_pool_iv_map_update(pool, NULL, 0);
-		if (rc)
-			D_ERROR(DF_UUID": ds_pool_iv_map_update failed, "
-				DF_RC"\n", DP_UUID(cont->c_uuid), DP_RC(rc));
-	}
 
 out:
 	daos_prop_free(prop_old);
@@ -3619,7 +3572,7 @@ out:
 			}
 			ap->cont_upgraded_nrs++;
 			rc = cont_iv_prop_update(ap->svc->cs_pool->sp_iv_ns,
-						 cont_uuid, prop);
+						 cont_uuid, prop, true);
 			if (rc)
 				D_ERROR(DF_UUID": failed to update prop IV for cont, "
 					DF_RC"\n", DP_UUID(cont_uuid), DP_RC(rc));
@@ -3673,6 +3626,156 @@ ds_cont_upgrade(uuid_t pool_uuid, struct cont_svc *svc)
 
 out_svc:
 	if (need_put_leader)
+		cont_svc_put_leader(svc);
+
+	return rc;
+}
+
+int
+ds_cont_rf_check(uuid_t pool_uuid, uuid_t cont_uuid, struct rdb_tx *tx)
+{
+	struct cont_svc		*svc = NULL;
+	struct cont		*cont = NULL;
+	struct ds_pool		*pool;
+	daos_prop_t		*prop = NULL;
+	daos_prop_t		*stat_prop = NULL;
+	struct daos_prop_entry	*entry;
+	struct daos_co_status	stat = { 0 };
+	int			rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL /* hint **/);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	rc = cont_lookup(tx, svc, cont_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": lookup cont failed, "DF_RC"\n",
+			DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	pool = svc->cs_pool;
+	rc = cont_prop_read(tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop, true);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": failed to read prop for cont, rc=%d\n",
+			DP_CONT(pool_uuid, cont_uuid), rc);
+		D_GOTO(out, rc);
+	}
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
+	D_ASSERT(entry != NULL);
+	daos_prop_val_2_co_status(entry->dpe_val, &stat);
+	if (stat.dcs_status == DAOS_PROP_CO_UNCLEAN) {
+		D_DEBUG(DB_MD, DF_CONT" %u status %u is unhealthy.\n",
+			DP_CONT(pool_uuid, cont_uuid), stat.dcs_pm_ver, stat.dcs_status);
+		D_GOTO(out, rc = -DER_RF);
+	}
+
+	rc = ds_pool_rf_verify(pool, stat.dcs_pm_ver, daos_cont_prop2redunfac(prop));
+	if (rc != -DER_RF) {
+		D_CDEBUG(rc == 0, DB_MD, DLOG_ERR, DF_CONT", verify" DF_RC"\n",
+			 DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	D_DEBUG(DB_MD, DF_CONT" ver %u set unhealthy.\n",
+		DP_CONT(pool_uuid, cont_uuid), ds_pool_get_version(pool));
+	stat_prop = daos_prop_alloc(1);
+	if (stat_prop == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	stat.dcs_pm_ver = ds_pool_get_version(pool);
+	stat.dcs_status = DAOS_PROP_CO_UNCLEAN;
+
+	/* Update healthy status RDB property */
+	stat_prop->dpp_entries[0].dpe_val = daos_prop_co_status_2_val(&stat);
+	stat_prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_STATUS;
+	rc = cont_prop_write(tx, &cont->c_prop, stat_prop, false);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	/* Update prop IV with merged prop */
+	entry->dpe_val = daos_prop_co_status_2_val(&stat);
+	rc = cont_iv_prop_update(pool->sp_iv_ns, cont_uuid, prop, false);
+	if (rc) {
+		D_ERROR(DF_UUID": failed to update prop IV for cont, "
+			DF_RC"\n", DP_UUID(cont_uuid), DP_RC(rc));
+		goto out;
+	}
+out:
+	if (cont != NULL)
+		cont_put(cont);
+	if (prop != NULL)
+		daos_prop_free(prop);
+	if (stat_prop != NULL)
+		daos_prop_free(stat_prop);
+	if (svc != NULL)
+		cont_svc_put_leader(svc);
+
+	D_DEBUG(DB_MD, "check pool/cont: "DF_CONT": "DF_RC"\n",
+		DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+
+	return rc;
+}
+
+struct cont_rdb_iter_arg {
+	struct cont_svc	*svc;
+	struct rdb_tx	*tx;
+	cont_rdb_iter_cb_t iter_cb;
+	void		*cb_arg;
+};
+
+static int
+cont_rdb_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
+{
+	struct cont_rdb_iter_arg *args = varg;
+	uuid_t			 cont_uuid;
+	int			 rc;
+
+	uuid_copy(cont_uuid, key->iov_buf);
+
+	rc = args->iter_cb(args->svc->cs_pool->sp_uuid, cont_uuid, args->tx, args->cb_arg);
+
+	return rc;
+}
+
+int
+ds_cont_rdb_iterate(uuid_t pool_uuid, cont_rdb_iter_cb_t iter_cb, void *cb_arg)
+{
+	struct cont_rdb_iter_arg	args = { 0 };
+	struct cont_svc			*svc = NULL;
+	struct rdb_tx			tx;
+	int				rc;
+
+	rc = cont_svc_lookup_leader(pool_uuid, 0 /* id */, &svc, NULL /* hint **/);
+	if (rc != 0)
+		D_GOTO(out_svc, rc);
+
+	args.svc = svc;
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0)
+		D_GOTO(out_svc, rc);
+
+	args.tx = &tx;
+	args.cb_arg = cb_arg;
+	args.iter_cb = iter_cb;
+	ABT_rwlock_wrlock(svc->cs_lock);
+	rc = rdb_tx_iterate(&tx, &svc->cs_conts, false /* !backward */, cont_rdb_iter_cb, &args);
+	ABT_rwlock_unlock(svc->cs_lock);
+	if (rc < 0) {
+		D_ERROR(DF_UUID" iterate error: %d\n", DP_UUID(pool_uuid), rc);
+		D_GOTO(tx_end, rc);
+	}
+
+	rc = rdb_tx_commit(&tx);
+	if (rc)
+		D_ERROR("rdb tx commit error: %d\n", rc);
+tx_end:
+	rdb_tx_end(&tx);
+
+out_svc:
+	D_DEBUG(DB_MD, DF_UUID" container iter: rc %d\n", DP_UUID(pool_uuid), rc);
+	if (svc != NULL)
 		cont_svc_put_leader(svc);
 
 	return rc;
@@ -3785,6 +3888,53 @@ out:
 	return rc;
 }
 
+void
+ds_cont_prop_iv_update(struct cont_svc *svc, uuid_t cont_uuid)
+{
+	struct rdb_tx	tx;
+	struct cont	*cont = NULL;
+	daos_prop_t	*prop = NULL;
+	int		rc;
+
+	/* Only happens on xstream 0 */
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": Failed to start rdb tx: %d\n",
+			DP_UUID(svc->cs_pool_uuid), rc);
+		return;
+	}
+
+	ABT_rwlock_rdlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": Failed to look container: %d\n",
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
+		D_GOTO(out_lock, rc);
+	}
+
+	rc = cont_prop_read(&tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop, true);
+	if (rc)
+		D_ERROR(DF_CONT": prop read failed:"DF_RC"\n",
+			DP_CONT(svc->cs_pool_uuid, cont_uuid), DP_RC(rc));
+	cont_put(cont);
+
+out_lock:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+	if (rc == 0) {
+		/* Update prop IV with merged prop */
+		rc = cont_iv_prop_update(svc->cs_pool->sp_iv_ns, cont_uuid, prop, true);
+		if (rc)
+			D_ERROR(DF_CONT": failed to update prop IV for cont, "
+				DF_RC"\n", DP_CONT(svc->cs_pool_uuid, cont_uuid),
+				DP_RC(rc));
+	}
+
+	if (prop != NULL)
+		daos_prop_free(prop);
+}
+
 /*
  * Look up the container, or if the RPC does not need this, call the final
  * handler.
@@ -3864,8 +4014,12 @@ out_lock:
 	rdb_tx_end(&tx);
 out:
 	/* Propagate new snapshot list by IV */
-	if (rc == 0 && (opc == CONT_SNAP_CREATE || opc == CONT_SNAP_DESTROY))
-		ds_cont_update_snap_iv(svc, in->ci_uuid);
+	if (rc == 0) {
+		if (opc == CONT_SNAP_CREATE || opc == CONT_SNAP_DESTROY)
+			ds_cont_update_snap_iv(svc, in->ci_uuid);
+		else if (opc == CONT_PROP_SET)
+			ds_cont_prop_iv_update(svc, in->ci_uuid);
+	}
 
 	return rc;
 }

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -506,14 +506,18 @@ ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid)
 		goto out_lock;
 	}
 
-	rc = cont_iv_snapshots_update(svc->cs_pool->sp_iv_ns, cont_uuid,
-				      snapshots, snap_count);
-	if (rc != 0)
-		D_ERROR(DF_CONT": Failed to update snapshots IV: %d\n",
-			DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
-
-	D_FREE(snapshots);
 out_lock:
 	ABT_rwlock_unlock(svc->cs_lock);
 	rdb_tx_end(&tx);
+	if (rc == 0) {
+		rc = cont_iv_snapshots_update(svc->cs_pool->sp_iv_ns, cont_uuid,
+					      snapshots, snap_count);
+		if (rc != 0)
+			D_ERROR(DF_CONT": Failed to update snapshots IV: %d\n",
+				DP_CONT(svc->cs_pool_uuid, cont_uuid), rc);
+	}
+
+	if (snapshots != NULL)
+		D_FREE(snapshots);
+
 }

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -250,8 +250,7 @@ int ds_cont_tgt_snapshots_refresh(uuid_t pool_uuid, uuid_t cont_uuid);
 int ds_cont_tgt_close(uuid_t cont_hdl_uuid);
 int ds_cont_tgt_refresh_agg_eph(uuid_t pool_uuid, uuid_t cont_uuid,
 				daos_epoch_t eph);
-int ds_cont_status_pm_ver_update(uuid_t pool_uuid, uuid_t cont_uuid,
-				 uint32_t pm_ver);
+int ds_cont_tgt_prop_update(uuid_t pool_uuid, uuid_t cont_uuid, daos_prop_t *prop);
 
 /* oid_iv.c */
 int ds_oid_iv_init(void);
@@ -270,7 +269,7 @@ int cont_iv_capability_invalidate(void *ns, uuid_t cont_hdl_uuid,
 				  int sync_mode);
 int cont_iv_prop_fetch(uuid_t pool_uuid, uuid_t cont_uuid,
 		       daos_prop_t *cont_prop);
-int cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop);
+int cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop, bool sync);
 int cont_iv_snapshots_refresh(void *ns, uuid_t cont_uuid);
 int cont_iv_snapshots_update(void *ns, uuid_t cont_uuid,
 			     uint64_t *snapshots, int snap_count);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -90,7 +90,7 @@ ds_cont_get_props(struct cont_props *cont_props, uuid_t pool_uuid,
 	/* The provided prop entry types should cover the types used in
 	 * daos_props_2cont_props().
 	 */
-	props = daos_prop_alloc(13);
+	props = daos_prop_alloc(14);
 	if (props == NULL)
 		return -DER_NOMEM;
 
@@ -107,6 +107,7 @@ ds_cont_get_props(struct cont_props *cont_props, uuid_t pool_uuid,
 	props->dpp_entries[10].dpe_type = DAOS_PROP_CO_EC_PDA;
 	props->dpp_entries[11].dpe_type = DAOS_PROP_CO_RP_PDA;
 	props->dpp_entries[12].dpe_type = DAOS_PROP_CO_GLOBAL_VERSION;
+	props->dpp_entries[13].dpe_type = DAOS_PROP_CO_STATUS;
 
 	rc = cont_iv_prop_fetch(pool_uuid, cont_uuid, props);
 	if (rc == DER_SUCCESS)
@@ -830,7 +831,7 @@ ds_cont_child_stop_all(struct ds_pool_child *pool_child)
 
 static int
 cont_child_start(struct ds_pool_child *pool_child, const uuid_t co_uuid,
-		 struct ds_cont_child **cont_out)
+		 bool *started, struct ds_cont_child **cont_out)
 {
 	struct dsm_tls		*tls = dsm_tls_get();
 	struct ds_cont_child	*cont_child;
@@ -873,6 +874,8 @@ cont_child_start(struct ds_pool_child *pool_child, const uuid_t co_uuid,
 
 		d_list_add_tail(&cont_child->sc_link, &pool_child->spc_cont_list);
 		ds_cont_child_get(cont_child);
+		if (started)
+			*started = true;
 	}
 
 	if (!rc && cont_out != NULL) {
@@ -893,7 +896,7 @@ cont_child_start_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 {
 	struct ds_pool_child	*pool_child = data;
 
-	return cont_child_start(pool_child, entry->ie_couuid, NULL);
+	return cont_child_start(pool_child, entry->ie_couuid, NULL, NULL);
 }
 
 int
@@ -1266,7 +1269,7 @@ ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
  **/
 static int
 cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver,
-			struct ds_cont_child **cont_out)
+			bool *started, struct ds_cont_child **cont_out)
 {
 	struct ds_pool_child	*pool_child;
 	int rc;
@@ -1278,7 +1281,7 @@ cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver,
 		return -DER_NO_HDL;
 	}
 
-	rc = cont_child_start(pool_child, cont_uuid, cont_out);
+	rc = cont_child_start(pool_child, cont_uuid, started, cont_out);
 	if (rc != -DER_NONEXIST) {
 		if (rc == 0) {
 			D_ASSERT(*cont_out != NULL);
@@ -1293,7 +1296,7 @@ cont_child_create_start(uuid_t pool_uuid, uuid_t cont_uuid, uint32_t pm_ver,
 
 	rc = vos_cont_create(pool_child->spc_hdl, cont_uuid);
 	if (!rc) {
-		rc = cont_child_start(pool_child, cont_uuid, cont_out);
+		rc = cont_child_start(pool_child, cont_uuid, started, cont_out);
 		if (rc == 0) {
 			(*cont_out)->sc_status_pm_ver = pm_ver;
 		} else {
@@ -1372,7 +1375,7 @@ ds_cont_child_open_create(uuid_t pool_uuid, uuid_t cont_uuid,
 	int rc;
 
 	/* status_pm_ver has no sense for rebuild container */
-	rc = cont_child_create_start(pool_uuid, cont_uuid, 0, cont);
+	rc = cont_child_create_start(pool_uuid, cont_uuid, 0, NULL, cont);
 	if (rc == 1)
 		rc = 0;
 
@@ -1382,7 +1385,7 @@ ds_cont_child_open_create(uuid_t pool_uuid, uuid_t cont_uuid,
 static int
 ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		   uint64_t flags, uint64_t sec_capas, uint32_t status_pm_ver,
-		   struct ds_cont_hdl **cont_hdl)
+		   bool *started, struct ds_cont_hdl **cont_hdl)
 {
 	struct dsm_tls		*tls = dsm_tls_get();
 	struct ds_cont_child	*cont = NULL;
@@ -1426,7 +1429,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	/* cont_uuid is NULL when open rebuild global cont handle */
 	if (cont_uuid != NULL && !uuid_is_null(cont_uuid)) {
 		rc = cont_child_create_start(pool_uuid, cont_uuid,
-					     status_pm_ver, &cont);
+					     status_pm_ver, started, &cont);
 		if (rc < 0)
 			D_GOTO(err_hdl, rc);
 
@@ -1566,6 +1569,7 @@ struct cont_tgt_open_arg {
 	uuid_t		pool_uuid;
 	uuid_t		cont_uuid;
 	uuid_t		cont_hdl_uuid;
+	bool		cont_started;
 	uint64_t	flags;
 	uint64_t	sec_capas;
 	uint32_t	status_pm_ver;
@@ -1582,7 +1586,7 @@ cont_open_one(void *vin)
 
 	return ds_cont_local_open(arg->pool_uuid, arg->cont_hdl_uuid,
 				  arg->cont_uuid, arg->flags, arg->sec_capas,
-				  arg->status_pm_ver, NULL);
+				  arg->status_pm_ver, &arg->cont_started, NULL);
 }
 
 int
@@ -2415,226 +2419,54 @@ out:
 		cont_ec_eph_destroy(ec_eph);
 }
 
-struct cont_rf_check_arg {
-	uuid_t			 crc_pool_uuid;
-	ABT_eventual		 crc_eventual;
-};
-
-struct cont_set_arg {
-	uuid_t			csa_pool_uuid;
-	uuid_t			csa_cont_uuid;
-	uint32_t		csa_status_pm_ver;
-	bool			csa_rw_disable;
+struct cont_prop_set_arg {
+	uuid_t	cpa_cont_uuid;
+	uuid_t	cpa_pool_uuid;
+	daos_prop_t *cpa_prop;
 };
 
 static int
-cont_rw_capa_set(void *data)
+cont_child_prop_update(void *data)
 {
 	struct dsm_tls		*tls = dsm_tls_get();
-	struct cont_set_arg	*arg = data;
+	struct cont_prop_set_arg *arg = data;
+	struct daos_prop_entry	*iv_entry;
 	struct ds_cont_child	*cont_child;
 	int			 rc = 0;
 
-	rc = cont_child_lookup(tls->dt_cont_cache, arg->csa_cont_uuid,
-			       arg->csa_pool_uuid, false /* create */,
+	rc = cont_child_lookup(tls->dt_cont_cache, arg->cpa_cont_uuid,
+			       arg->cpa_pool_uuid, false /* create */,
 			       &cont_child);
 	if (rc) {
 		if (rc == -DER_NONEXIST)
 			rc = 0;
 		else
 			D_ERROR(DF_CONT" cont_child_lookup failed, "DF_RC"\n",
-				DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
+				DP_CONT(arg->cpa_pool_uuid, arg->cpa_cont_uuid),
 				DP_RC(rc));
 		return rc;
 	}
 	D_ASSERT(cont_child != NULL);
+	daos_props_2cont_props(arg->cpa_prop, &cont_child->sc_props);
 
-	cont_child->sc_rw_disabled = arg->csa_rw_disable;
-	if (dss_get_module_info()->dmi_tgt_id == 0)
-		D_DEBUG(DB_IO, DF_CONT" read/write permission %s.\n",
-			DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
-			cont_child->sc_rw_disabled ? "disabled" : "enabled");
+	iv_entry = daos_prop_entry_get(arg->cpa_prop, DAOS_PROP_CO_STATUS);
+	if (iv_entry != NULL) {
+		struct daos_co_status co_stat = { 0 };
 
-	ds_cont_child_put(cont_child);
-	return rc;
-}
-
-static int
-cont_rf_check(struct ds_pool *ds_pool, struct ds_cont_child *cont_child)
-{
-	struct cont_set_arg		rw_arg;
-	int				rc = 0;
-
-	rc = ds_pool_rf_verify(ds_pool, cont_child->sc_status_pm_ver,
-			       cont_child->sc_props.dcp_redun_fac);
-	if (rc != 0 && rc != -DER_RF)
-		goto out;
-
-	rw_arg.csa_rw_disable = (rc == -DER_RF);
-	if (rc == -DER_RF)
-		D_ERROR(DF_CONT": RF broken, last_ver %d, rf %d, "DF_RC"\n",
-			DP_CONT(cont_child->sc_pool_uuid, cont_child->sc_uuid),
-			cont_child->sc_status_pm_ver, cont_child->sc_props.dcp_redun_fac,
-			DP_RC(rc));
-	if (rw_arg.csa_rw_disable == cont_child->sc_rw_disabled)
-		D_GOTO(out, rc = 0);
-
-	uuid_copy(rw_arg.csa_cont_uuid, cont_child->sc_uuid);
-	uuid_copy(rw_arg.csa_pool_uuid, ds_pool->sp_uuid);
-	rc = dss_task_collective(cont_rw_capa_set, &rw_arg, 0);
-	if (rc)
-		D_ERROR("collective cont_write_data_turn_off failed, "DF_RC"\n",
-			DP_RC(rc));
-
-out:
-	return rc;
-}
-
-static void
-cont_rf_check_ult(void *data)
-{
-	struct cont_rf_check_arg	*arg = data;
-	struct ds_pool			*ds_pool;
-	struct ds_pool_child		*pool_child;
-	struct ds_cont_child		*cont_child;
-	int				 rc = 0;
-
-	pool_child = ds_pool_child_lookup(arg->crc_pool_uuid);
-	D_ASSERTF(pool_child != NULL, DF_UUID" : failed to find pool child\n",
-		 DP_UUID(arg->crc_pool_uuid));
-
-	ds_pool = pool_child->spc_pool;
-	d_list_for_each_entry(cont_child, &pool_child->spc_cont_list, sc_link) {
-		if (cont_child->sc_stopping)
-			continue;
-		rc = cont_rf_check(ds_pool, cont_child);
-		if (rc) {
-			D_DEBUG(DB_TRACE, DF_CONT" cont_rf_check failed, "
-				DF_RC"\n",
-				DP_CONT(ds_pool->sp_uuid, cont_child->sc_uuid),
-				DP_RC(rc));
-			break;
-		}
+		daos_prop_val_2_co_status(iv_entry->dpe_val, &co_stat);
+		if (co_stat.dcs_pm_ver < cont_child->sc_status_pm_ver)
+			goto out;
+		if (dss_get_module_info()->dmi_tgt_id == 0)
+			D_DEBUG(DB_MD, DF_CONT" statu_pm_ver %d -> %d status %u\n",
+				DP_CONT(arg->cpa_pool_uuid, arg->cpa_cont_uuid),
+				cont_child->sc_status_pm_ver, co_stat.dcs_pm_ver,
+				co_stat.dcs_status);
+		cont_child->sc_status_pm_ver = co_stat.dcs_pm_ver;
+		if (co_stat.dcs_status == DAOS_PROP_CO_UNCLEAN)
+			cont_child->sc_rw_disabled = 1;
+		else if (co_stat.dcs_status == DAOS_PROP_CO_HEALTHY)
+			cont_child->sc_rw_disabled = 0;
 	}
-
-	ds_pool_child_put(pool_child);
-	ABT_eventual_set(arg->crc_eventual, (void *)&rc, sizeof(rc));
-}
-
-static int
-cont_rf_check_get_tgt(uuid_t pool_uuid)
-{
-	int		*failed_tgts = NULL;
-	unsigned int	 failed_tgts_cnt;
-	bool		 alive;
-	int		 rc, i, j;
-
-	rc = ds_pool_get_failed_tgt_idx(pool_uuid, &failed_tgts,
-					&failed_tgts_cnt);
-	if (rc) {
-		D_ERROR(DF_UUID "failed to get tgt_idx, "DF_RC"\n",
-			DP_UUID(pool_uuid), DP_RC(rc));
-		return rc;
-	}
-
-	D_ASSERTF(failed_tgts_cnt <= dss_tgt_nr,
-		  "BAD failed_tgts_cnt %d, dss_tgt_nr %d\n",
-		  failed_tgts_cnt, dss_tgt_nr);
-	if (failed_tgts_cnt == dss_tgt_nr) {
-		D_GOTO(out, rc = -DER_NONEXIST);
-	} else if (failed_tgts_cnt == 0) {
-		/* if all alive, select one random tgt */
-		rc = rand() % dss_tgt_nr;
-		goto out;
-	} else {
-		/* if partial failed, select first alive tgt */
-		for (i = 0; i < dss_tgt_nr; i++) {
-			alive = true;
-			for (j = 0; j < failed_tgts_cnt; j++) {
-				if (i == failed_tgts[j]) {
-					alive = false;
-					break;
-				}
-			}
-			if (alive) {
-				rc = i;
-				goto out;
-			}
-		}
-	}
-
-out:
-	if (failed_tgts != NULL)
-		D_FREE(failed_tgts);
-	return rc;
-}
-
-/** Check active container, if its RF value match with new pool map */
-int
-ds_cont_rf_check(uuid_t pool_uuid)
-{
-	struct cont_rf_check_arg	 check_arg;
-	int				*status;
-	int				 tgt_idx;
-	int				 rc = 0;
-
-	uuid_copy(check_arg.crc_pool_uuid, pool_uuid);
-	rc = ABT_eventual_create(sizeof(*status), &check_arg.crc_eventual);
-	if (rc != ABT_SUCCESS)
-		return dss_abterr2der(rc);
-
-	/* check RF on one alive tgt's VOS main XS */
-	rc = cont_rf_check_get_tgt(pool_uuid);
-	if (rc < 0) {
-		if (rc == -DER_NONEXIST)
-			rc = 0;
-		goto out;
-	}
-	tgt_idx = rc;
-	rc = dss_ult_create(cont_rf_check_ult, &check_arg, DSS_XS_VOS, tgt_idx,
-			    0, NULL);
-	if (rc)
-		D_GOTO(out, rc);
-
-	rc = ABT_eventual_wait(check_arg.crc_eventual, (void **)&status);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out, rc = dss_abterr2der(rc));
-	rc = *status;
-
-out:
-	ABT_eventual_free(&check_arg.crc_eventual);
-	return rc;
-}
-
-static int
-cont_status_pm_ver_set(void *data)
-{
-	struct dsm_tls		*tls = dsm_tls_get();
-	struct cont_set_arg	*arg = data;
-	struct ds_cont_child	*cont_child;
-	int			 rc = 0;
-
-	rc = cont_child_lookup(tls->dt_cont_cache, arg->csa_cont_uuid,
-			       arg->csa_pool_uuid, false /* create */,
-			       &cont_child);
-	if (rc) {
-		if (rc == -DER_NONEXIST)
-			rc = 0;
-		else
-			D_ERROR(DF_CONT" cont_child_lookup failed, "DF_RC"\n",
-				DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
-				DP_RC(rc));
-		return rc;
-	}
-	D_ASSERT(cont_child != NULL);
-
-	if (arg->csa_status_pm_ver <= cont_child->sc_status_pm_ver)
-		goto out;
-	if (dss_get_module_info()->dmi_tgt_id == 0)
-		D_DEBUG(DB_TRACE, DF_CONT" statu_pm_ver set from %d to %d.\n",
-			DP_CONT(arg->csa_pool_uuid, arg->csa_cont_uuid),
-			cont_child->sc_status_pm_ver, arg->csa_status_pm_ver);
-	cont_child->sc_status_pm_ver = arg->csa_status_pm_ver;
 
 out:
 	ds_cont_child_put(cont_child);
@@ -2642,16 +2474,19 @@ out:
 }
 
 int
-ds_cont_status_pm_ver_update(uuid_t pool_uuid, uuid_t cont_uuid,
-			     uint32_t pm_ver)
+ds_cont_tgt_prop_update(uuid_t pool_uuid, uuid_t cont_uuid, daos_prop_t *prop)
 {
-	struct cont_set_arg	arg;
-	int			rc = 0;
+	struct cont_prop_set_arg arg;
+	int			rc;
 
-	uuid_copy(arg.csa_cont_uuid, cont_uuid);
-	uuid_copy(arg.csa_pool_uuid, pool_uuid);
-	arg.csa_status_pm_ver = pm_ver;
-	rc = dss_task_collective(cont_status_pm_ver_set, &arg, 0);
+	if (daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS) == NULL)
+		return 0;
+
+	D_DEBUG(DB_MD, DF_CONT" property update.\n", DP_CONT(pool_uuid, cont_uuid));
+	uuid_copy(arg.cpa_cont_uuid, cont_uuid);
+	uuid_copy(arg.cpa_pool_uuid, pool_uuid);
+	arg.cpa_prop = prop;
+	rc = dss_task_collective(cont_child_prop_update, &arg, 0);
 	if (rc)
 		D_ERROR("collective cont_write_data_turn_off failed, "DF_RC"\n",
 			DP_RC(rc));

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2022 Intel Corporation.
+ * (C) Copyright 2015-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -186,7 +186,6 @@ void ds_cont_child_stop_all(struct ds_pool_child *pool_child);
 
 int ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
 			 struct ds_cont_child **ds_cont);
-int ds_cont_rf_check(uuid_t pool_uuid);
 
 /** initialize a csummer based on container properties. Will retrieve the
  * checksum related properties from IV
@@ -255,4 +254,7 @@ int ds_cont_ec_eph_delete(struct ds_pool *pool, uuid_t cont_uuid, int tgt_idx);
 
 void ds_cont_ec_timestamp_update(struct ds_cont_child *cont);
 
+typedef int(*cont_rdb_iter_cb_t)(uuid_t pool_uuid, uuid_t cont_uuid, struct rdb_tx *tx, void *arg);
+int ds_cont_rdb_iterate(uuid_t pool_uuid, cont_rdb_iter_cb_t iter_cb, void *cb_arg);
+int ds_cont_rf_check(uuid_t pool_uuid, uuid_t cont_uuid, struct rdb_tx *tx);
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -132,6 +132,9 @@ int ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
 int ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
 		      const d_rank_list_t *ranks, d_rank_list_t *excluded,
 		      bool destroy);
+char *ds_rsvc_state_str(enum ds_rsvc_state state);
+enum ds_rsvc_state ds_rsvc_get_state(struct ds_rsvc *svc);
+void ds_rsvc_set_state(struct ds_rsvc *svc, enum ds_rsvc_state state);
 int ds_rsvc_add_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks,
 			   size_t size);
 int ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3949,7 +3949,8 @@ obj_shard_comp_cb(tse_task_t *task, struct shard_auxi_args *shard_auxi,
 			   !obj_is_modification_opc(obj_auxi->opc) &&
 			   !obj_auxi->is_ec_obj && !obj_auxi->spec_shard &&
 			   !obj_auxi->spec_group && !obj_auxi->to_leader &&
-			   ret != -DER_TX_RESTART && !DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY)) {
+			   ret != -DER_TX_RESTART && ret != -DER_RF &&
+			   !DAOS_FAIL_CHECK(DAOS_DTX_NO_RETRY)) {
 			int new_tgt;
 
 			/* Check if there are other replicas available to

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -664,7 +664,7 @@ obj_ec_parity_lists_match(struct daos_recx_ep_list *lists_1,
 		if (list_1->re_nr != list_2->re_nr ||
 		    list_1->re_ep_valid != list_2->re_ep_valid) {
 			D_ERROR("got different parity recx in EC data recovery\n");
-			return -DER_IO;
+			return -DER_DATA_LOSS;
 		}
 		if (list_1->re_nr == 0)
 			continue;
@@ -674,7 +674,7 @@ obj_ec_parity_lists_match(struct daos_recx_ep_list *lists_1,
 			    (list_1->re_items[j].re_recx.rx_nr !=
 			     list_2->re_items[j].re_recx.rx_nr)) {
 				D_ERROR("got different parity recx in EC data recovery\n");
-				return -DER_IO;
+				return -DER_DATA_LOSS;
 			}
 			if (list_1->re_items[j].re_ep != list_2->re_items[j].re_ep)
 				return -DER_FETCH_AGAIN;

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1413,7 +1413,7 @@ obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 			if (orw->orw_flags & ORF_EC_RECOV_FROM_PARITY) {
 				if (shadows == NULL) {
-					rc = -DER_IO;
+					rc = -DER_DATA_LOSS;
 					D_ERROR(DF_UOID" ORF_EC_RECOV_FROM_PARITY should not with "
 						"NULL shadows, "DF_RC"\n", DP_UOID(orw->orw_oid),
 						DP_RC(rc));

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -61,6 +61,75 @@ struct pool_svc_events {
 	bool			pse_stop;
 };
 
+/* Pool service schedule state */
+struct pool_svc_sched {
+	int		psc_svc_rf;
+	bool		psc_force_notify;	/* for pool_svc_step_up_cb */
+	ABT_mutex	psc_mutex;		/* only for psc_cv */
+	ABT_cond	psc_cv;
+	bool		psc_in_progress;
+	bool		psc_canceled;
+};
+
+static int
+sched_init(struct pool_svc_sched *sched)
+{
+	int rc;
+
+	rc = ABT_mutex_create(&sched->psc_mutex);
+	if (rc != ABT_SUCCESS) {
+		return dss_abterr2der(rc);
+	}
+
+	rc = ABT_cond_create(&sched->psc_cv);
+	if (rc != ABT_SUCCESS) {
+		ABT_mutex_free(&sched->psc_mutex);
+		return dss_abterr2der(rc);
+	}
+
+	sched->psc_svc_rf = -1;
+	sched->psc_force_notify = false;
+	sched->psc_in_progress = false;
+	sched->psc_canceled = false;
+	return 0;
+}
+
+static void
+sched_fini(struct pool_svc_sched *sched)
+{
+	ABT_cond_free(&sched->psc_cv);
+	ABT_mutex_free(&sched->psc_mutex);
+}
+
+static void
+sched_begin(struct pool_svc_sched *sched)
+{
+	sched->psc_in_progress = true;
+	sched->psc_canceled = false;
+}
+
+static void
+sched_end(struct pool_svc_sched *sched)
+{
+	sched->psc_in_progress = false;
+	sched->psc_canceled = false;
+}
+
+static void
+sched_cancel_and_wait(struct pool_svc_sched *sched)
+{
+	/*
+	 * The CV requires a mutex. We don't otherwise need it for ULTs within
+	 * the same xstream.
+	 */
+	ABT_mutex_lock(sched->psc_mutex);
+	if (sched->psc_in_progress)
+		sched->psc_canceled = true;
+	while (sched->psc_in_progress)
+		ABT_cond_wait(sched->psc_cv, sched->psc_mutex);
+	ABT_mutex_unlock(sched->psc_mutex);
+}
+
 /* Pool service */
 struct pool_svc {
 	struct ds_rsvc		ps_rsvc;
@@ -73,6 +142,10 @@ struct pool_svc {
 	struct ds_pool	       *ps_pool;
 	struct pool_svc_events	ps_events;
 	uint32_t		ps_global_version;
+
+	/* Check all containers RF for the pool */
+	struct pool_svc_sched	ps_rfcheck_sched;
+
 	/* The global pool map version on all pool targets */
 	uint32_t		ps_global_map_version;
 };
@@ -868,14 +941,19 @@ pool_svc_alloc_cb(d_iov_t *id, struct ds_rsvc **rsvc)
 		goto err_events_mutex;
 	}
 
-	rc = ds_cont_svc_init(&svc->ps_cont_svc, svc->ps_uuid, 0 /* id */,
-			      &svc->ps_rsvc);
+	rc = sched_init(&svc->ps_rfcheck_sched);
 	if (rc != 0)
 		goto err_events_cv;
 
+	rc = ds_cont_svc_init(&svc->ps_cont_svc, svc->ps_uuid, 0 /* id */,
+			      &svc->ps_rsvc);
+	if (rc != 0)
+		goto err_cont_rf_sched;
+
 	*rsvc = &svc->ps_rsvc;
 	return 0;
-
+err_cont_rf_sched:
+	sched_fini(&svc->ps_rfcheck_sched);
 err_events_cv:
 	ABT_cond_free(&svc->ps_events.pse_cv);
 err_events_mutex:
@@ -1134,6 +1212,7 @@ pool_svc_free_cb(struct ds_rsvc *rsvc)
 	struct pool_svc *svc = pool_svc_obj(rsvc);
 
 	ds_cont_svc_fini(&svc->ps_cont_svc);
+	sched_fini(&svc->ps_rfcheck_sched);
 	ABT_cond_free(&svc->ps_events.pse_cv);
 	ABT_mutex_free(&svc->ps_events.pse_mutex);
 	rdb_path_fini(&svc->ps_user);
@@ -1343,7 +1422,19 @@ pool_svc_check_node_status(struct pool_svc *svc)
 	return rc;
 }
 
-/* up */
+/*
+ * Log a NOTE of as well as print a message. Arguments may be evaluated more
+ * than once.
+ */
+#define DS_POOL_NOTE_PRINT(fmt, ...) do {							\
+	D_NOTE(fmt, ## __VA_ARGS__);								\
+	D_PRINT(fmt, ## __VA_ARGS__);								\
+} while (0)
+
+static void pool_svc_schedule(struct pool_svc *svc, struct pool_svc_sched *sched,
+			      void (*func)(void *));
+static void pool_svc_rfcheck_ult(void *arg);
+
 static int
 pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 {
@@ -1356,6 +1447,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	bool			cont_svc_up = false;
 	bool			events_initialized = false;
 	d_rank_t		rank;
+	bool			svc_scheduled = false;
 	int			rc;
 
 	/*
@@ -1396,6 +1488,9 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc != 0)
 		goto out;
 	events_initialized = true;
+
+	pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult);
+	svc_scheduled = true;
 
 	rc = ds_pool_iv_prop_update(svc->ps_pool, prop);
 	if (rc) {
@@ -1439,6 +1534,9 @@ out:
 	if (rc != 0) {
 		if (events_initialized)
 			fini_events(svc);
+		if (svc_scheduled)
+			sched_cancel_and_wait(&svc->ps_rfcheck_sched);
+
 		if (cont_svc_up)
 			ds_cont_svc_step_down(svc->ps_cont_svc);
 		if (svc->ps_pool != NULL)
@@ -1465,6 +1563,7 @@ pool_svc_step_down_cb(struct ds_rsvc *rsvc)
 	ds_pool_iv_srv_hdl_invalidate(svc->ps_pool);
 
 	fini_events(svc);
+	sched_cancel_and_wait(&svc->ps_rfcheck_sched);
 	ds_cont_svc_step_down(svc->ps_cont_svc);
 	fini_svc_pool(svc);
 
@@ -4838,10 +4937,93 @@ out:
 	return rc;
 }
 
+static void
+pool_svc_schedule(struct pool_svc *svc, struct pool_svc_sched *sched,
+		  void (*func)(void *))
+{
+	enum ds_rsvc_state	state;
+	int			rc;
+
+	D_DEBUG(DB_MD, DF_UUID": begin\n", DP_UUID(svc->ps_uuid));
+
+	/*
+	 * Avoid scheduling when the PS is stepping down
+	 * and has already called sched_cancel_and_wait.
+	 */
+	state = ds_rsvc_get_state(&svc->ps_rsvc);
+	if (state == DS_RSVC_DRAINING) {
+		D_DEBUG(DB_MD, DF_UUID": end: service %s\n", DP_UUID(svc->ps_uuid),
+			ds_rsvc_state_str(state));
+		return;
+	}
+
+	D_ASSERT(&svc->ps_rfcheck_sched == sched);
+	sched_cancel_and_wait(sched);
+
+	sched_begin(sched);
+
+	/*
+	 * An extra svc leader reference is not required, because
+	 * pool_svc_step_down_cb waits for this ULT to terminate.
+	 *
+	 * ULT tracking is achieved through sched, not a ULT handle.
+	 */
+	rc = dss_ult_create(func, svc, DSS_XS_SELF, 0, 0, NULL /* ult */);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to create ULT: "DF_RC"\n",
+			DP_UUID(svc->ps_uuid), DP_RC(rc));
+		sched_end(sched);
+	}
+
+	D_DEBUG(DB_MD, DF_UUID": end: "DF_RC"\n", DP_UUID(svc->ps_uuid), DP_RC(rc));
+}
+
 static int pool_find_all_targets_by_addr(struct pool_map *map,
 					 struct pool_target_addr_list *list,
 					 struct pool_target_id_list *tgt_list,
 					 struct pool_target_addr_list *inval);
+
+static int
+cont_rf_check_cb(uuid_t pool_uuid, uuid_t cont_uuid, struct rdb_tx *tx, void *arg)
+{
+	struct pool_svc_sched *sched = arg;
+	int rc;
+
+	/* If anything happened during rf check, let's continue to check the next container
+	 * for the moment.
+	 */
+	rc = ds_cont_rf_check(pool_uuid, cont_uuid, tx);
+	if (rc)
+		D_CDEBUG(rc == -DER_RF, DB_MD, DLOG_ERR, DF_CONT" check_rf: "DF_RC"\n",
+			 DP_CONT(pool_uuid, cont_uuid), DP_RC(rc));
+
+	if (sched->psc_canceled) {
+		D_DEBUG(DB_MD, DF_CONT" is canceled.\n", DP_CONT(pool_uuid, cont_uuid));
+		return 1;
+	}
+
+	return 0;
+}
+
+static void
+pool_svc_rfcheck_ult(void *arg)
+{
+	struct pool_svc	*svc = arg;
+	int rc;
+
+	do {
+		/* retry until some one stop the pool svc(rc == 1) or succeed */
+		rc = ds_cont_rdb_iterate(svc->ps_uuid, cont_rf_check_cb,
+					 &svc->ps_rfcheck_sched);
+		if (rc >= 0)
+			break;
+		D_ERROR(DF_UUID" check rf with %d and retry\n", DP_UUID(svc->ps_uuid), rc);
+		dss_sleep(0);
+	} while (1);
+
+	sched_end(&svc->ps_rfcheck_sched);
+	ABT_cond_broadcast(svc->ps_rfcheck_sched.psc_cv);
+}
 
 /*
  * Perform an update to the pool map of \a svc.
@@ -4971,6 +5153,8 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 	ds_rsvc_request_map_dist(&svc->ps_rsvc);
 
 	replace_failed_replicas(svc, map);
+	if (opc == POOL_EXCLUDE)
+		pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult);
 
 out_map_buf:
 	pool_buf_free(map_buf);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1421,8 +1421,6 @@ out:
 	ABT_rwlock_unlock(pool->sp_lock);
 	if (map != NULL)
 		pool_map_decref(map);
-	if (rc == 0)
-		rc = ds_cont_rf_check(pool->sp_uuid);
 	return rc;
 }
 

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -42,8 +42,8 @@ rsvc_class(enum ds_rsvc_class_id id)
 	return rsvc_classes[id];
 }
 
-static char *
-state_str(enum ds_rsvc_state state)
+char *
+ds_rsvc_state_str(enum ds_rsvc_state state)
 {
 	switch (state) {
 	case DS_RSVC_UP_EMPTY:
@@ -387,7 +387,7 @@ static void
 change_state(struct ds_rsvc *svc, enum ds_rsvc_state state)
 {
 	D_DEBUG(DB_MD, "%s: term "DF_U64" state %s to %s\n", svc->s_name,
-		svc->s_term, state_str(svc->s_state), state_str(state));
+		svc->s_term, ds_rsvc_state_str(svc->s_state), ds_rsvc_state_str(state));
 	svc->s_state = state;
 	ABT_cond_broadcast(svc->s_state_cv);
 }
@@ -1056,6 +1056,18 @@ out_stop:
 				  NULL, true /* destroy */);
 	}
 	return rc;
+}
+
+enum ds_rsvc_state
+ds_rsvc_get_state(struct ds_rsvc *svc)
+{
+	return svc->s_state;
+}
+
+void
+ds_rsvc_set_state(struct ds_rsvc *svc, enum ds_rsvc_state state)
+{
+	change_state(svc, state);
 }
 
 int

--- a/src/tests/ftest/deployment/target_failure.py
+++ b/src/tests/ftest/deployment/target_failure.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2022 Intel Corporation.
+  (C) Copyright 2022-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/rebuild/basic.yaml
+++ b/src/tests/ftest/rebuild/basic.yaml
@@ -15,6 +15,7 @@ pool:
   scm_size: 1G
   control_method: dmg
   pool_query_timeout: 30
+  properties: rd_fac:2
 container:
   akey_size: 5
   dkey_size: 5
@@ -36,6 +37,7 @@ container:
     ten_records:
       record_qty: 10
   debug: True
+  properties: rd_fac:2
 testparams:
   ranks: !mux
     rank1:

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -15,6 +15,7 @@ pool:
   svcn: 2
   control_method: dmg
   pool_query_timeout: 30
+  properties: rd_fac:2
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/rebuild/delete_objects.yaml
+++ b/src/tests/ftest/rebuild/delete_objects.yaml
@@ -16,6 +16,7 @@ pool:
   debug: True
   control_method: dmg
   pool_query_timeout: 30
+  properties: rd_fac:2
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -19,6 +19,7 @@ pool:
   svcn: 2
   control_method: dmg
   pool_query_timeout: 30
+  properties: rd_fac:2
 container:
   object_qty: 10
   record_qty: 10

--- a/src/tests/suite/daos_base_tx.c
+++ b/src/tests/suite/daos_base_tx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2021 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -868,6 +868,26 @@ dtx_21(void **state)
 	ioreq_fini(&req);
 }
 
+static int
+dtx_base_rf0_setup(void **state)
+{
+	int	rc;
+
+	rc = rebuild_sub_setup_common(state, DEFAULT_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF0);
+	return rc;
+}
+
+static int
+dtx_base_rf1_setup(void **state)
+{
+	int	rc;
+
+	rc = rebuild_sub_setup_common(state, DEFAULT_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF1);
+	return rc;
+}
+
 static const struct CMUnitTest dtx_tests[] = {
 	{"DTX1: update/punch single value with DTX successfully",
 	 dtx_1, NULL, test_case_teardown},
@@ -908,9 +928,9 @@ static const struct CMUnitTest dtx_tests[] = {
 	{"DTX19: DTX resend during bulk data transfer - multiple reps",
 	 dtx_19, NULL, test_case_teardown},
 	{"DTX20: race between DTX refresh and DTX resync",
-	 dtx_20, NULL, test_case_teardown},
+	 dtx_20, dtx_base_rf1_setup, test_case_teardown},
 	{"DTX21: do not abort partially committed DTX",
-	 dtx_21, NULL, test_case_teardown},
+	 dtx_21, dtx_base_rf0_setup, test_case_teardown},
 };
 
 static int

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2350,10 +2350,10 @@ co_rf_simple(void **state)
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	print_message("obj update should success after re-integrate\n");
+	print_message("obj update should still fail with DER_RF after re-integrate\n");
 	rc = daos_obj_update(io_oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
 			     NULL);
-	assert_rc_equal(rc, 0);
+	assert_rc_equal(rc, -DER_RF);
 
 	/* clear the UNCLEAN status */
 	rc = daos_cont_status_clear(arg->coh, NULL);

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -28,8 +28,8 @@ degrade_small_sub_setup(void **state)
 	test_arg_t *arg;
 	int rc;
 
-	rc = test_setup(state, SETUP_CONT_CONNECT, true,
-			DEGRADE_SMALL_POOL_SIZE, DEGRADE_RANK_SIZE, NULL);
+	rc = rebuild_sub_setup_common(state, DEGRADE_SMALL_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF2);
 	if (rc) {
 		print_message("It can not create the pool with 6 ranks"
 			      " probably due to not enough ranks %d\n", rc);
@@ -49,8 +49,26 @@ degrade_sub_setup(void **state)
 	test_arg_t *arg;
 	int rc;
 
-	rc = test_setup(state, SETUP_CONT_CONNECT, true,
-			DEGRADE_POOL_SIZE, DEGRADE_RANK_SIZE, NULL);
+	rc = rebuild_sub_setup_common(state, DEGRADE_POOL_SIZE, 0,
+				      DAOS_PROP_CO_REDUN_RF2);
+	if (rc)
+		return rc;
+
+	arg = *state;
+	arg->no_rebuild = 1;
+	rc = daos_pool_set_prop(arg->pool.pool_uuid, "self_heal",
+				"exclude");
+	return rc;
+}
+
+int
+degrade_sub_rf1_setup(void **state)
+{
+	test_arg_t *arg;
+	int rc;
+
+	rc = rebuild_sub_setup_common(state, DEGRADE_POOL_SIZE, 0,
+				      DAOS_PROP_CO_REDUN_RF1);
 	if (rc)
 		return rc;
 
@@ -370,6 +388,7 @@ degrade_multi_conts_agg(void **state)
 	fail_shards[0] = 0;
 	fail_shards[1] = 2;
 
+	dt_redun_fac = DAOS_PROP_CO_REDUN_RF2;
 	memset(args, 0, sizeof(args[0]) * CONT_PER_POOL);
 	for (i = 0; i < CONT_PER_POOL; i++) {
 		rc = test_setup((void **)&args[i], SETUP_CONT_CONNECT,
@@ -412,7 +431,6 @@ degrade_multi_conts_agg(void **state)
 		fail_ranks[i] = get_rank_by_oid_shard(args[0], oids[0],
 						      fail_shards[i]);
 	rebuild_pools_ranks(&args[0], 1, fail_ranks, shards_nr, false);
-
 re_test:
 	if (!parity_checked)
 		daos_debug_set_params(args[0]->group, -1, DMG_KEY_FAIL_LOC,
@@ -797,7 +815,7 @@ static const struct CMUnitTest degrade_tests[] = {
 	{"DEGRADE25: degrade ec aggregation",
 	 degrade_ec_agg, degrade_sub_setup, test_teardown},
 	{"DEGRADE26: degrade ec update",
-	 degrade_ec_update, degrade_sub_setup, test_teardown},
+	 degrade_ec_update, degrade_sub_rf1_setup, test_teardown},
 	{"DEGRADE27: degrade ec update punch aggregation parity fail",
 	 degrade_ec_agg_punch_fail_parity, degrade_sub_setup, test_teardown},
 	{"DEGRADE28: degrade ec update punch aggregation data fail",

--- a/src/tests/suite/daos_degraded.c
+++ b/src/tests/suite/daos_degraded.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -250,8 +250,8 @@ static const struct CMUnitTest degraded_tests[] = {
 static int
 degraded_setup(void **state)
 {
-	return test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			  0, NULL);
+	return rebuild_sub_setup_common(state, DEFAULT_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF3);
 }
 
 static int

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2021 Intel Corporation.
+ * (C) Copyright 2020-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2887,7 +2887,9 @@ dtx_38(void **state)
 
 	rebuild_single_pool_rank(arg, kill_ranks[0], false);
 
+	daos_cont_status_clear(arg->coh, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
+
 	if (arg->myrank == 0) {
 		print_message("Verifying data after rebuild...\n");
 
@@ -3053,8 +3055,38 @@ dtx_sub_setup(void **state)
 
 	saved_dtx_arg = *state;
 	*state = NULL;
-	rc = test_setup(state, SETUP_CONT_CONNECT, true, SMALL_POOL_SIZE,
-			0, NULL);
+
+	rc = rebuild_sub_setup_common(state, SMALL_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF2);
+
+	return rc;
+}
+
+static int
+dtx_sub_rf0_setup(void **state)
+{
+	int	rc;
+
+	saved_dtx_arg = *state;
+	*state = NULL;
+
+	rc = rebuild_sub_setup_common(state, SMALL_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF0);
+
+	return rc;
+}
+
+static int
+dtx_sub_rf1_setup(void **state)
+{
+	int	rc;
+
+	saved_dtx_arg = *state;
+	*state = NULL;
+
+	rc = rebuild_sub_setup_common(state, SMALL_POOL_SIZE,
+				      0, DAOS_PROP_CO_REDUN_RF1);
+
 	return rc;
 }
 
@@ -3152,9 +3184,9 @@ static const struct CMUnitTest dtx_tests[] = {
 	{"DTX37: resync - leader failed during prepare",
 	 dtx_37, dtx_sub_setup, dtx_sub_teardown},
 	{"DTX38: resync - lost whole redundancy groups",
-	 dtx_38, dtx_sub_setup, dtx_sub_teardown},
+	 dtx_38, dtx_sub_rf0_setup, dtx_sub_teardown},
 	{"DTX39: not restart the transaction with fixed epoch",
-	 dtx_39, dtx_sub_setup, dtx_sub_teardown},
+	 dtx_39, dtx_sub_rf1_setup, dtx_sub_teardown},
 
 	{"DTX40: uncertain check - miss commit with delay",
 	 dtx_40, NULL, test_case_teardown},

--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -469,21 +469,21 @@ drain_objects(void **state)
 /** create a new pool/container for each test */
 static const struct CMUnitTest drain_tests[] = {
 	{"DRAIN1: drain small rec multiple dkeys",
-	 drain_dkeys, rebuild_small_sub_setup, test_teardown},
+	 drain_dkeys, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN2: drain small rec multiple akeys",
-	 drain_akeys, rebuild_small_sub_setup, test_teardown},
+	 drain_akeys, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN3: drain small rec multiple indexes",
-	 drain_indexes, rebuild_small_sub_setup, test_teardown},
+	 drain_indexes, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN4: drain small rec multiple keys/indexes",
-	 drain_multiple, rebuild_small_sub_setup, test_teardown},
+	 drain_multiple, rebuild_small_sub_rf0_setup, test_teardown},
 	{"DRAIN5: drain large rec single index",
-	 drain_large_rec, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN7: drain keys with multiple snapshots",
-	 drain_snap_update_keys, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN8: drain keys/punch with multiple snapshots",
+	 drain_large_rec, rebuild_small_sub_rf0_setup, test_teardown},
+	{"DRAIN6: drain keys with multiple snapshots",
+	 drain_snap_update_keys, rebuild_small_sub_rf0_setup, test_teardown},
+	{"DRAIN7: drain keys/punch with multiple snapshots",
 	 drain_snap_punch_keys, rebuild_small_sub_setup, test_teardown},
-	{"DRAIN9: drain multiple objects",
-	 drain_objects, rebuild_sub_setup, test_teardown},
+	{"DRAIN8: drain multiple objects",
+	 drain_objects, rebuild_sub_rf0_setup, test_teardown},
 };
 
 int

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3288,6 +3288,7 @@ fetch_replica_unavail(void **state)
 
 		/* wait until reintegration is done */
 		test_rebuild_wait(&arg, 1);
+		daos_cont_status_clear(arg->coh, NULL);
 	}
 	D_FREE(buf);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -4918,6 +4919,7 @@ obj_setup_internal(void **state)
 	else if (arg->obj_class != OC_UNKNOWN)
 		dts_obj_class = arg->obj_class;
 
+	dt_redun_lvl = DAOS_PROP_CO_REDUN_RANK;
 	return 0;
 }
 

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -408,8 +408,8 @@ static const struct CMUnitTest oid_alloc_tests[] = {
 int
 oid_alloc_setup(void **state)
 {
-	return test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			  0, NULL);
+	return rebuild_sub_setup_common(state, DEFAULT_POOL_SIZE, 0,
+					DAOS_PROP_CO_REDUN_RF2);
 }
 
 int

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1266,6 +1266,7 @@ static int
 pool_map_refreshes_setup(void **state)
 {
 	async_enable(state);
+	dt_redun_fac = DAOS_PROP_CO_REDUN_RF1;
 	return test_setup(state, SETUP_CONT_CONNECT, true, SMALL_POOL_SIZE, 0, NULL);
 }
 

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1405,7 +1405,7 @@ static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD25: rebuild with two failures",
 	 rebuild_multiple_failures, rebuild_sub_setup, rebuild_sub_teardown},
 	{"REBUILD26: rebuild fail all replicas before rebuild",
-	 rebuild_fail_all_replicas_before_rebuild, rebuild_sub_setup,
+	 rebuild_fail_all_replicas_before_rebuild, rebuild_sub_rf1_setup,
 	 rebuild_sub_teardown},
 	{"REBUILD27: rebuild fail all replicas",
 	 rebuild_fail_all_replicas, rebuild_sub_setup, rebuild_sub_teardown},

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -75,6 +75,8 @@ extern unsigned int dt_csum_chunksize;
 extern bool dt_csum_server_verify;
 extern int  dt_obj_class;
 extern unsigned int dt_cell_size;
+extern int dt_redun_lvl;
+extern int dt_redun_fac;
 
 /* the temporary IO dir*/
 extern char *test_io_dir;
@@ -451,8 +453,13 @@ int rebuild_pool_connect_internal(void *data);
 
 
 int rebuild_sub_setup(void **state);
+int rebuild_sub_rf1_setup(void **state);
+int rebuild_sub_rf0_setup(void **state);
 int rebuild_sub_teardown(void **state);
 int rebuild_small_sub_setup(void **state);
+int rebuild_small_sub_rf1_setup(void **state);
+int rebuild_small_sub_rf0_setup(void **state);
+int rebuild_sub_setup_common(void **state, daos_size_t pool_size, int node_nr, uint32_t rf);
 
 int get_server_config(char *host, char *server_config_file);
 int get_log_file(char *host, char *server_config_file,


### PR DESCRIPTION
Once failure nodes exceed RF, then set status property to unclean, and use IV sync to broadcast unclean property to all targets to disable container IO.

So reintegrate nodes will not change status property, i.e. unhealthy status will only be changed by container status clean cmd.

Add RF property for test_setup to remove daos_cont_clear, which might take extra time during rebuild test.

Move conainer prop and snapsht IV sync out of svc_lock.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
