### PR TITLE
DAOS-9721 test: replace daos.container_create with self.get_container

### DIFF
--- a/src/tests/ftest/container/list.py
+++ b/src/tests/ftest/container/list.py
@@ -11,12 +11,12 @@ class ListContainerTest(TestWithServers):
     """
     Test Class Description:
         Tests daos pool list-cont. Test the following cases.
-        1. Create 1 container, list, and verify the listed container UUID
-            matches the UUID returned when created.
+        1. Create 1 container, list, and verify the listed container UUID and label
+            matches the UUID and label returned when created.
         2. Create 1 more container and verify list; 2 total containers
         3. Create 98 more containers and verify list; 100 total containers
         4. Create 2 additional pools and create 10 containers in each pool.
-            Verify the container UUIDs in these 2 new pools.
+            Verify the container UUIDs and labels in these 2 new pools.
 
     :avocado: recursive
     """
@@ -26,29 +26,33 @@ class ListContainerTest(TestWithServers):
         super().__init__(*args, **kwargs)
         self.daos_cmd = None
 
-    def create_list(self, count, pool_uuid, expected_uuids):
+    def create_list(self, count, pool, expected_uuids_labels):
         """Create container and call daos pool list-cont to list and verify.
 
         Args:
-            count (Integer): Number of containers to create.
-            pool_uuid (String): Pool UUID to create containers in.
-            expected_uuids (List of string): List that contains container UUID.
-                It should contain all the container UUIDs for the given pool.
+            count (int): Number of containers to create.
+            pool (TestPool): pool to create containers in.
+            expected_uuids_labels (list): list of tuples containing expected (uuid, label) for
+                all containers in the pool
         """
-        # Create containers and store the container UUIDs into expected_uuids.
+        # Create containers and store the container UUIDs and labels
         for _ in range(count):
-            expected_uuids.append(
-                self.daos_cmd.container_create(pool=pool_uuid)["response"]["container_uuid"])
-        expected_uuids.sort()
+            container = self.get_container(pool, create=False)
+            result = container.create()
+            expected_uuids_labels.append(
+                (result["response"]["container_uuid"], result["response"]["container_label"]))
+        expected_uuids_labels.sort()
 
         # Call container list and collect the UUIDs.
-        data = self.daos_cmd.container_list(pool=pool_uuid)
-        actual_uuids = []
+        data = self.daos_cmd.container_list(pool=pool.identifier)
+        actual_uuids_labels = []
         for uuid_label in data["response"]:
-            actual_uuids.append(uuid_label["uuid"])
-        actual_uuids.sort()
+            actual_uuids_labels.append((uuid_label["uuid"], uuid_label["label"]))
+        actual_uuids_labels.sort()
 
-        self.assertEqual(expected_uuids, actual_uuids)
+        self.assertEqual(
+            expected_uuids_labels, actual_uuids_labels,
+            "Containuer UUIDs and labels from list do not match those from create")
 
     def test_list_containers(self):
         """Jira ID: DAOS-3629
@@ -62,30 +66,30 @@ class ListContainerTest(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container
-        :avocado: tags=list_containers,test_list_containers
+        :avocado: tags=ListContainerTest,test_list_containers
         """
-        expected_uuids1 = []
+        expected_uuids_labels1 = []
         self.pool = []
         self.pool.append(self.get_pool(connect=False))
         self.daos_cmd = DaosCommand(self.bin)
 
         # 1. Create 1 container and list.
-        self.create_list(1, self.pool[0].uuid, expected_uuids1)
+        self.create_list(1, self.pool[0], expected_uuids_labels1)
 
         # 2. Create 1 more container and list; 2 total.
-        self.create_list(1, self.pool[0].uuid, expected_uuids1)
+        self.create_list(1, self.pool[0], expected_uuids_labels1)
 
         # 3. Create 98 more containers and list; 100 total.
-        self.create_list(98, self.pool[0].uuid, expected_uuids1)
+        self.create_list(98, self.pool[0], expected_uuids_labels1)
 
         # 4. Create 2 additional pools and create 10 containers in each pool.
         self.pool.append(self.get_pool(connect=False))
         self.pool.append(self.get_pool(connect=False))
 
         # Create 10 containers in pool 2 and verify.
-        expected_uuids2 = []
-        self.create_list(10, self.pool[1].uuid, expected_uuids2)
+        expected_uuids_labels2 = []
+        self.create_list(10, self.pool[1], expected_uuids_labels2)
 
         # Create 10 containers in pool 3 and verify.
-        expected_uuids3 = []
-        self.create_list(10, self.pool[2].uuid, expected_uuids3)
+        expected_uuids_labels3 = []
+        self.create_list(10, self.pool[2], expected_uuids_labels3)

--- a/src/tests/ftest/container/list.yaml
+++ b/src/tests/ftest/container/list.yaml
@@ -14,5 +14,6 @@ server_config:
           scm_mount: /mnt/daos
           scm_size: 4
 pool:
-  control_method: dmg
   size: 300MB
+container:
+  control_method: daos

--- a/src/tests/ftest/security/cont_acl.yaml
+++ b/src/tests/ftest/security/cont_acl.yaml
@@ -19,7 +19,6 @@ server_config:
           scm_size: 4
 pool:
   scm_size: 138374182
-  control_method: dmg
 container:
   control_method: daos
 container_acl:

--- a/src/tests/ftest/security/pool_acl.py
+++ b/src/tests/ftest/security/pool_acl.py
@@ -3,11 +3,10 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-
-
 import os
 import pwd
 import grp
+
 import security_test_base as secTestBase
 from pool_security_test_base import PoolSecurityTestBase
 
@@ -43,7 +42,7 @@ class DaosRunPoolSecurityTest(PoolSecurityTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=security,pool
-        :avocado: tags=pool_acl,sec_acl,test_daos_pool_acl_enforcement
+        :avocado: tags=DaosRunPoolSecurityTest,pool_acl,sec_acl,test_daos_pool_acl_enforcement
         """
         user_uid = os.geteuid()
         user_gid = os.getegid()

--- a/src/tests/ftest/security/pool_acl.yaml
+++ b/src/tests/ftest/security/pool_acl.yaml
@@ -15,10 +15,9 @@ server_config:
           class: ram
           scm_mount: /mnt/daos
           scm_size: 4
-pool:
-  control_method: dmg
 # Uncomment following to force the use of certificates
 # regardless of the launch.py --insecure setting.
+# pool:
 #   transport_config:
 #     allow_insecure: False
 # agent_config:
@@ -27,6 +26,8 @@ pool:
 # dmg:
 #   transport_config:
 #     allow_insecure: False
+container:
+  control_method: daos
 pool_acl:
   scm_size: 134217728
   user_prefix: daos_ci

--- a/src/tests/ftest/security/pool_groups.py
+++ b/src/tests/ftest/security/pool_groups.py
@@ -3,9 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-
 import os
 import grp
+
 import security_test_base as secTestBase
 from pool_security_test_base import PoolSecurityTestBase
 
@@ -40,7 +40,7 @@ class DaosRunPoolSecurityTest(PoolSecurityTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=security,pool
-        :avocado: tags=pool_acl,sec_acl_groups,test_daos_pool_acl_groups
+        :avocado: tags=DaosRunPoolSecurityTest,pool_acl,sec_acl_groups,test_daos_pool_acl_groups
         '''
         user_gid = os.getegid()
         current_group = grp.getgrgid(user_gid)[0]

--- a/src/tests/ftest/security/pool_groups.yaml
+++ b/src/tests/ftest/security/pool_groups.yaml
@@ -15,8 +15,8 @@ server_config:
           class: ram
           scm_mount: /mnt/daos
           scm_size: 4
-pool:
-  control_method: dmg
+container:
+  control_method: daos
 pool_acl:
   scm_size: 134217728
   user_prefix: daos_ci

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -59,7 +59,7 @@ class DaosCommand(DaosCommandBase):
         return self._get_result(
             ("pool", "autotest"), pool=pool)
 
-    def container_create(self, pool, sys_name=None, cont=None, path=None, cont_type=None,
+    def container_create(self, pool, sys_name=None, path=None, cont_type=None,
                          oclass=None, dir_oclass=None, file_oclass=None, chunk_size=None,
                          properties=None, acl_file=None, label=None):
         # pylint: disable=too-many-arguments
@@ -69,7 +69,6 @@ class DaosCommand(DaosCommandBase):
             pool (str): pool UUID or label in which to create the container
             sys_name (str, optional):  DAOS system name context for servers.
                 Defaults to None.
-            cont (str, optional): UUID or label. Defaults to None.
             path (str, optional): container namespace path. Defaults to None.
             cont_type (str, optional): the type of container to create. Defaults
                 to None.
@@ -98,7 +97,7 @@ class DaosCommand(DaosCommandBase):
         else:
             properties = 'rd_lvl:1'
         return self._get_json_result(
-            ("container", "create"), pool=pool, sys_name=sys_name, cont=cont, path=path,
+            ("container", "create"), pool=pool, sys_name=sys_name, path=path,
             type=cont_type, oclass=oclass, dir_oclass=dir_oclass, file_oclass=file_oclass,
             chunk_size=chunk_size, properties=properties, acl_file=acl_file, label=label)
 

--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -9,7 +9,6 @@ import grp
 import re
 
 from apricot import TestWithServers
-from daos_utils import DaosCommand
 import agent_utils as agu
 import security_test_base as secTestBase
 
@@ -311,11 +310,11 @@ class PoolSecurityTestBase(TestWithServers):
                 "##setup_container_acl_and_permission, fail on "
                 "update_container_acl, expected Pass, but Failed.")
 
-    def verify_pool_readwrite(self, uuid, action, expect='Pass'):
+    def verify_pool_readwrite(self, pool, action, expect='Pass'):
         """Verify client is able to perform read or write on a pool.
 
         Args:
-            uuid (str): pool uuid number.
+            pool (TestPool): pool to run verify in.
             action (str): read or write on pool.
             expect (str): expecting behavior pass or deny with RC -1001.
 
@@ -324,12 +323,13 @@ class PoolSecurityTestBase(TestWithServers):
 
         """
         deny_access = '-1001'
-        daos_cmd = DaosCommand(self.bin)
+        daos_cmd = self.get_daos_command()
         daos_cmd.exit_status_exception = False
         if action.lower() == "write":
-            result = daos_cmd.container_create(pool=uuid)
+            container = self.get_container(pool, create=False, daos_command=daos_cmd)
+            result = container.create()
         elif action.lower() == "read":
-            result = daos_cmd.pool_query(pool=uuid)
+            result = daos_cmd.pool_query(pool.identifier)
         else:
             self.fail(
                 "##In verify_pool_readwrite, invalid action: {}".format(action))
@@ -454,13 +454,13 @@ class PoolSecurityTestBase(TestWithServers):
         # daos pool query <pool name>
         self.log.info("  (8-6)Verify pool read by: daos pool query --pool")
         exp_read = sec_group_rw[0]
-        self.verify_pool_readwrite(self.pool.uuid, "read", expect=exp_read)
+        self.verify_pool_readwrite(self.pool, "read", expect=exp_read)
 
         # Verify pool write operation
-        # daos container create --pool <uuid>
+        # daos container create <pool>
         self.log.info("  (8-7)Verify pool write by: daos container create pool")
         exp_write = sec_group_rw[1]
-        self.verify_pool_readwrite(self.pool.uuid, "write", expect=exp_write)
+        self.verify_pool_readwrite(self.pool, "write", expect=exp_write)
 
         for group in sec_group:
             secTestBase.add_del_user(self.hostlist_clients, "groupdel", group)
@@ -538,14 +538,14 @@ class PoolSecurityTestBase(TestWithServers):
             self.update_pool_acl_entry("delete", principal)
 
         # (7)Verify pool read operation
-        #    daos pool query --pool <uuid>
+        #    daos pool query <pool>
         self.log.info("  (7)Verify pool read by: daos pool query --pool")
-        self.verify_pool_readwrite(self.pool.uuid, "read", expect=read)
+        self.verify_pool_readwrite(self.pool, "read", expect=read)
 
         # (8)Verify pool write operation
-        #    daos container create --pool <uuid>
+        #    daos container create <pool>
         self.log.info("  (8)Verify pool write by: daos container create --pool")
-        self.verify_pool_readwrite(self.pool.uuid, "write", expect=write)
+        self.verify_pool_readwrite(self.pool, "write", expect=write)
         if secondary_grp_test:
             self.log.info("  (8-0)Verifying verify_pool_acl_prim_sec_groups")
             self.verify_pool_acl_prim_sec_groups(pool_acl_list, acl_file)


### PR DESCRIPTION
Test-tag: pr container DaosContainterSecurityTest test_daos_pool_acl_enforcement test_daos_pool_acl_groups ListContainerTest
Skip-unit-tests: true
Skip-fault-injection-test: true

- Replace calls to daos.container_create with self.get_container
- Remove unused "cont" from TestContainer.create()
  - This used to be for the UUID but it's not possible to create a container with a user-supplied UUID

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
