### PR TITLE
DAOS-12967 dtx: reduce the consume of HLC

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1017,7 +1017,7 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov, NULL);
 	if (rc == 0) {
-		dae->dae_start_time = d_hlc_get();
+		dae->dae_start_time = daos_gettime_coarse();
 		d_list_add_tail(&dae->dae_link, &cont->vc_dtx_act_list);
 		dth->dth_ent = dae;
 	} else {
@@ -1945,7 +1945,7 @@ vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id dtis[],
 	struct vos_dtx_blob_df		*dbd;
 	struct vos_dtx_blob_df		*dbd_prev;
 	umem_off_t			 dbd_off;
-	daos_epoch_t			 cmt_time = d_hlc_get();
+	uint64_t			 cmt_time = daos_gettime_coarse();
 	int				 committed = 0;
 	int				 cur = 0;
 	int				 rc = 0;
@@ -2606,6 +2606,7 @@ vos_dtx_act_reindex(struct vos_container *cont)
 	umem_off_t			 dbd_off = cont_df->cd_dtx_active_head;
 	d_iov_t				 kiov;
 	d_iov_t				 riov;
+	uint64_t			 start_time = daos_gettime_coarse();
 	int				 rc = 0;
 	int				 i;
 
@@ -2692,7 +2693,7 @@ vos_dtx_act_reindex(struct vos_container *cont)
 				goto out;
 			}
 
-			dae->dae_start_time = d_hlc_get();
+			dae->dae_start_time = start_time;
 			d_list_add_tail(&dae->dae_link, &cont->vc_dtx_act_list);
 		}
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -321,7 +321,7 @@ struct vos_dtx_act_ent {
 	 */
 	daos_unit_oid_t			*dae_oids;
 	/* The time (hlc) when the DTX entry is created. */
-	daos_epoch_t			 dae_start_time;
+	uint64_t			 dae_start_time;
 	/* Link into container::vc_dtx_act_list. */
 	d_list_t			 dae_link;
 	/* Back pointer to the DTX handle. */

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -169,7 +169,7 @@ struct vos_dtx_cmt_ent_df {
 	 *	vos_dtx_blob_df to shrink each committed DTX
 	 *	entry size.
 	 */
-	daos_epoch_t			dce_cmt_time;
+	uint64_t			dce_cmt_time;
 };
 
 /** Active DTX entry on-disk layout in both SCM and DRAM. */


### PR DESCRIPTION
For convenience, some DTX logic directly uses d_hlc_get for local sequence timestamp, that is unnecessary but consumes more HLC and may cause the risk of HLC overflow (in the future) if we may have higher physical clock resolution.

The patch replaces HLC with local timestamp for those unnecessary cases of using HLC.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
