### PR TITLE
DAOS-12857 csum: Initialize RPC object for CSUM Report

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -680,6 +680,9 @@ dc_shard_csum_report(tse_task_t *task, crt_endpoint_t *tgt_ep, crt_rpc_t *rpc)
 	csum_orw->orw_sgls.ca_arrays = NULL;
 	csum_orw->orw_bulks.ca_count = 0;
 	csum_orw->orw_bulks.ca_arrays = NULL;
+	csum_orw->orw_dkey_csum = NULL;
+	csum_orw->orw_iod_array.oia_iod_nr = 0;
+	csum_orw->orw_nr = 0;
 	crt_req_addref(csum_rpc);
 	crt_req_addref(rpc);
 	return crt_req_send(csum_rpc, csum_report_cb, rpc);

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1305,6 +1305,139 @@ rebuild_many_objects_with_failure(void **state)
 	D_FREE(oids);
 }
 
+#define KB 1024
+#define MB (KB * 1024)
+#define GB (MB * 1024)
+
+static void
+inject_corruption(const int my_rank, const int injection_rank, const char *injection_group,
+		  const int injection_count)
+{
+	int	fault_injection = DAOS_CSUM_CORRUPT_DISK | DAOS_FAIL_SOME;
+
+	if (my_rank == 0) {
+		daos_debug_set_params(injection_group, injection_rank, DMG_KEY_FAIL_NUM,
+				      injection_count, 0, NULL);
+		daos_debug_set_params(injection_group, injection_rank, DMG_KEY_FAIL_LOC,
+				      fault_injection, 0, NULL);
+	}
+}
+
+/*
+ * This test was introduced to troubleshoot hitting an assert in rpc_csum.c "csum->cs_csum != NULL".
+ * It tests that nothing breaks while the checksum scrubber detects data corruption and
+ * initiates a drain on multiple targets due to the corruption threshold being hit.
+ */
+static void
+rebuild_object_with_csum_error(void **state)
+{
+	test_arg_t	*arg = *state;
+	d_sg_list_t	 sgl = {0};
+	int		 rc = 0;
+	int		 i, j;
+	daos_handle_t	 poh = arg->pool.poh;
+	int		 ranks = 3; /* will inject corruption to ranks 0-2 */
+	daos_key_t	 dkey, akey;
+	uint64_t	 dkey_val;
+	char		*akey_val = "0";
+	daos_prop_t	*cont_props;
+	uuid_t		 cont_uuid;
+	char		 uuid_cont_str[DAOS_UUID_STR_SIZE];
+	daos_handle_t	 coh;
+	daos_handle_t	 oh;
+	daos_obj_id_t	 oid;
+	daos_recx_t	 recx;
+	daos_iod_t	 iod;
+	uint8_t		*pool_uuid = arg->pool.pool_uuid;
+
+	/* test params */
+	daos_size_t	transfer_size = 1 * MB;
+	daos_size_t	block_size = 2L * GB;
+	daos_size_t	io_count = block_size / transfer_size;
+	uint32_t	iterations = 2;
+
+	if (!test_runable(arg, 3)) {
+		skip();
+		return;
+	}
+
+	/* setup pool to have scrubbing turned on */
+	assert_success(dmg_pool_set_prop(dmg_config_file, "scrub", "timed", pool_uuid));
+	assert_success(dmg_pool_set_prop(dmg_config_file, "scrub-freq", "1", pool_uuid));
+	assert_success(dmg_pool_set_prop(dmg_config_file, "scrub-thresh", "2", pool_uuid));
+
+	/* setup container */
+	cont_props = daos_prop_alloc(3);
+	assert_non_null(cont_props);
+	cont_props->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_LVL;
+	cont_props->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_RANK;
+	cont_props->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_FAC;
+	cont_props->dpp_entries[1].dpe_val = 1;
+	cont_props->dpp_entries[2].dpe_type = DAOS_PROP_CO_CSUM;
+	cont_props->dpp_entries[2].dpe_val = DAOS_PROP_CO_CSUM_CRC16;
+
+	if (arg->myrank == 0) {
+		/* make sure corruption is disabled while creating cont ... */
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_NUM, 0, 0, NULL);
+	}
+
+	assert_success(daos_cont_create(poh, &cont_uuid, cont_props, NULL));
+	uuid_unparse(cont_uuid, uuid_cont_str);
+	assert_success(daos_cont_open(poh, uuid_cont_str, DAOS_COO_RW, &coh, NULL, NULL));
+
+	/* setup object */
+	oid = daos_test_oid_gen(coh, OC_RP_2GX, 0, 0, 0);
+	assert_success(daos_obj_open(coh, oid, DAOS_OO_RW, &oh, NULL));
+
+	/* setup keys */
+	d_iov_set(&dkey, &dkey_val, sizeof(dkey_val));
+	d_iov_set(&akey, akey_val, strlen(akey_val));
+
+	/* setup IOD and SGL */
+	recx.rx_idx = 0;
+	recx.rx_nr = transfer_size;
+
+	iod.iod_nr = 1;
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_size = 1;
+	iod.iod_name = akey;
+	iod.iod_recxs = &recx;
+
+	assert_success(d_sgl_init(&sgl, 1));
+	assert_success(daos_iov_alloc(&sgl.sg_iovs[0], transfer_size, true));
+	memset(sgl.sg_iovs[0].iov_buf, 0xa, transfer_size);
+
+	for (j = 0; j < iterations && rc == 0; j++) {
+		print_message("iteration: %d\n", j);
+		for (i = 0; i < io_count && rc == 0; i++) {
+			if (i % 100 == 0)
+				inject_corruption(arg->myrank, (i / 100) % ranks, arg->group, 2);
+			dkey_val = i;
+			rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+			if (rc != 0)
+				print_message("Error updating object: "DF_RC"\n", DP_RC(rc));
+		}
+		for (i = 0; i < io_count && rc == 0; i++) {
+			dkey_val = i;
+			rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL, NULL);
+			if (rc != 0)
+				print_message("Error fetching object: "DF_RC"\n", DP_RC(rc));
+		}
+	}
+
+	if (arg->myrank == 0) {
+		/* reset fault injection */
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_NUM, 0, 0, NULL);
+	}
+
+	/* clean up */
+	assert_success(daos_cont_close(coh, NULL));
+	assert_success(daos_cont_destroy(poh, uuid_cont_str, false, NULL));
+	assert_success(dmg_pool_set_prop(dmg_config_file, "scrub", "off", arg->pool.pool_uuid));
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD1: rebuild small rec multiple dkeys",
@@ -1351,6 +1484,8 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_with_dfs_open_create_punch, rebuild_small_sub_rf1_setup, test_teardown},
 	{"REBUILD22: rebuild lot of objects with failure",
 	 rebuild_many_objects_with_failure, rebuild_sub_setup, test_teardown},
+	{"REBUILD23: object corrupt rebuild",
+	 rebuild_object_with_csum_error, rebuild_small_sub_rf1_setup, test_teardown},
 };
 
 int


### PR DESCRIPTION
The structure for sending an RPC for the CSUM error report wasn't completely initialized and contained garbage data. This change fixes that. A test was also added to reproduce the issue.

Features: csum

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
