### PR TITLE
DAOS-12674 test: nvme/enospace.py test not waiting for thread completion

### DIFF
--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -219,7 +219,7 @@ class NvmeEnospace(ServerFillUp):
 
         # Run IOR to fill the pool.
         self.run_enospace_with_bg_job()
-        self.info.log("Test passed")
+        self.log.info("Test passed")
 
     def test_enospace_lazy_with_fg(self):
         """Jira ID: DAOS-4756.

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -121,7 +121,7 @@ class NvmeEnospace(ServerFillUp):
 
         # run IOR Read Command in loop
         ior_bg_cmd.flags.update(self.ior_read_flags)
-        for count in range(1, bg_read_loop+1):
+        for count in range(1, bg_read_loop + 1):
             try:
                 self.log.info('----Start IOR read loop %d----', count)
                 job_manager.run()

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -123,7 +123,7 @@ class NvmeEnospace(ServerFillUp):
         count = 1
         while count <= 30:
             try:
-                self.log.info('----Start IOR read loop %s----', count)
+                self.log.info('----Start IOR read loop %d----', count)
                 job_manager.run()
             except (CommandFailure, TestFail):
                 break
@@ -244,7 +244,7 @@ class NvmeEnospace(ServerFillUp):
 
         # Repeat the test in loop.
         for _loop in range(10):
-            self.log.info("-------enospc_lazy_fg Loop--------- {}".format(_loop))
+            self.log.info("-------enospc_lazy_fg Loop--------- %d".format(_loop))
             # Run IOR to fill the pool.
             self.run_enospace_foreground()
             # Delete all the containers
@@ -308,7 +308,7 @@ class NvmeEnospace(ServerFillUp):
 
         # Repeat the test in loop.
         for _loop in range(10):
-            self.log.info("-------enospc_time_fg Loop--------- {}".format(_loop))
+            self.log.info("-------enospc_time_fg Loop--------- %d".format(_loop))
             self.log.info(self.pool.pool_percentage_used())
             # Run IOR to fill the pool.
             self.run_enospace_with_bg_job()
@@ -344,7 +344,7 @@ class NvmeEnospace(ServerFillUp):
         self.start_ior_load(storage='SCM', operation='Auto_Read', percent=1)
         max_mib_baseline = float(self.ior_matrix[0][int(IorMetrics.MAX_MIB)])
         baseline_cont_uuid = self.ior_cmd.dfs_cont.value
-        self.log.info("IOR Baseline Read MiB {}".format(max_mib_baseline))
+        self.log.info("IOR Baseline Read MiB %s".format(max_mib_baseline))
 
         # Run IOR to fill the pool.
         self.run_enospace_with_bg_job()
@@ -353,7 +353,7 @@ class NvmeEnospace(ServerFillUp):
         self.container.uuid = baseline_cont_uuid
         self.start_ior_load(storage='SCM', operation='Auto_Read', percent=1)
         max_mib_latest = float(self.ior_matrix[0][int(IorMetrics.MAX_MIB)])
-        self.log.info("IOR Latest Read MiB {}".format(max_mib_latest))
+        self.log.info("IOR Latest Read MiB %s".format(max_mib_latest))
 
         # Check if latest IOR read performance is in Tolerance of 5%, when
         # Storage space is full.
@@ -393,7 +393,7 @@ class NvmeEnospace(ServerFillUp):
 
         # Repeat the test in loop.
         for _loop in range(10):
-            self.log.info("-------enospc_no_aggregation Loop--------- {}".format(_loop))
+            self.log.info("-------enospc_no_aggregation Loop--------- %d".format(_loop))
             # Fill 75% of SCM pool
             self.start_ior_load(storage='SCM', operation="Auto_Write", percent=40)
 

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -97,6 +97,7 @@ class NvmeEnospace(ServerFillUp):
         ior_bg_cmd.block_size.update(self.ior_cmd.block_size.value)
         ior_bg_cmd.flags.update(self.ior_cmd.flags.value)
         ior_bg_cmd.test_file.update('/testfile_background')
+        bg_read_loop = self.params.get('bg_read_loop', '/run/enospace/*')
 
         # Define the job manager for the IOR command
         job_manager = get_job_manager(self, job=ior_bg_cmd)
@@ -120,14 +121,12 @@ class NvmeEnospace(ServerFillUp):
 
         # run IOR Read Command in loop
         ior_bg_cmd.flags.update(self.ior_read_flags)
-        count = 1
-        while count <= 30:
+        for count in range(1, bg_read_loop+1):
             try:
                 self.log.info('----Start IOR read loop %d----', count)
                 job_manager.run()
             except (CommandFailure, TestFail):
                 break
-            count += 1
 
     def run_enospace_foreground(self):
         """Run IOR to fill up SCM and NVMe. Verify that we see DER_NOSPACE while filling
@@ -220,6 +219,7 @@ class NvmeEnospace(ServerFillUp):
 
         # Run IOR to fill the pool.
         self.run_enospace_with_bg_job()
+        self.info.log("Test passed")
 
     def test_enospace_lazy_with_fg(self):
         """Jira ID: DAOS-4756.

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -190,7 +190,7 @@ class NvmeEnospace(ServerFillUp):
         # Run IOR in Foreground
         self.run_enospace_foreground()
 
-        # Wait unitl the IOR Background thread completed
+        # Wait until the IOR Background thread completed
         job.join()
 
         # Verify the background job result has no FAIL for any IOR run

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -128,7 +128,7 @@ class NvmeEnospace(ServerFillUp):
             except (CommandFailure, TestFail):
                 self.test_result.append("FAIL - ior read")
                 break
-        stop_looping = event.wait(1)
+            stop_looping = event.wait(1)
 
     def run_enospace_foreground(self):
         """Run IOR to fill up SCM and NVMe. Verify that we see DER_NOSPACE while filling
@@ -219,7 +219,7 @@ class NvmeEnospace(ServerFillUp):
                   continuously.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,medium
         :avocado: tags=nvme,der_enospace,enospc_lazy,enospc_lazy_bg
         :avocado: tags=NvmeEnospace,test_enospace_lazy_with_bg
         """
@@ -245,7 +245,7 @@ class NvmeEnospace(ServerFillUp):
                   Do this in loop for 10 times and verify space is released.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,medium
         :avocado: tags=nvme,der_enospace,enospc_lazy,enospc_lazy_fg
         :avocado: tags=NvmeEnospace,test_enospace_lazy_with_fg
         """
@@ -280,7 +280,7 @@ class NvmeEnospace(ServerFillUp):
                   continuously.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,medium
         :avocado: tags=nvme,der_enospace,enospc_time,enospc_time_bg
         :avocado: tags=NvmeEnospace,test_enospace_time_with_bg
         """
@@ -308,7 +308,7 @@ class NvmeEnospace(ServerFillUp):
                   Do this in loop for 10 times and verify space is released.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,medium
         :avocado: tags=nvme,der_enospace,enospc_time,enospc_time_fg
         :avocado: tags=NvmeEnospace,test_enospace_time_with_fg
         """
@@ -344,7 +344,7 @@ class NvmeEnospace(ServerFillUp):
                   to the number ran prior system storage was full.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,medium
         :avocado: tags=nvme,der_enospace,enospc_performance
         :avocado: tags=NvmeEnospace,test_performance_storage_full
         """
@@ -389,7 +389,7 @@ class NvmeEnospace(ServerFillUp):
                   free size after container destroy.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium,ib2
+        :avocado: tags=hw,medium
         :avocado: tags=nvme,der_enospace,enospc_no_aggregation
         :avocado: tags=NvmeEnospace,test_enospace_no_aggregation
         """

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -40,7 +40,7 @@ class NvmeEnospace(ServerFillUp):
         self.other_errors_count = 0
         self.test_result = []
 
-    def verify_enospace_log(self, der_nospace_err_count):
+    def verify_enspace_log(self, der_nospace_err_count):
         """
         Function to verify there are no other error except DER_NOSPACE and
         DER_NO_HDL in client log.Verify DER_NOSPACE count is higher.
@@ -117,56 +117,57 @@ class NvmeEnospace(ServerFillUp):
             self.test_result.append("FAIL")
             return
 
-        # run IOR Read Command in loop
+        # run IOR Read Command for 20 loops
         ior_bg_cmd.flags.update(self.ior_read_flags)
-        while True:
+        count = 1
+        while count <= 30:
             try:
+                self.log.info("Starting IOR read loop %s", count)
                 job_manager.run()
             except (CommandFailure, TestFail):
                 break
 
     def run_enospace_foreground(self):
-        """Run IOR to fill up SCM and NVMe. Verify that we see DER_NOSPACE while filling
-        up SCM. Then verify that the storage usage is near 100%.
         """
-        # Fill 75% of current SCM free space. Aggregation is Enabled so NVMe space will
-        # start to fill up.
-        self.log.info('Starting main IOR load')
+        Function to run test and validate DER_ENOSPACE and expected storage size
+        """
+        # Fill 75% more of SCM pool,Aggregation is Enabled so NVMe space will be
+        # start filling
+        print('Starting main IOR load')
         self.start_ior_load(storage='SCM', operation="Auto_Write", percent=75)
-        self.log.info(self.pool.pool_percentage_used())
+        print(self.pool.pool_percentage_used())
 
-        # Fill 50% of current SCM free space. Aggregation is Enabled so NVMe space will
-        # continue to fill up.
+        # Fill 50% more of SCM pool,Aggregation is Enabled so NVMe space will be
+        # filled
         self.start_ior_load(storage='SCM', operation="Auto_Write", percent=50)
-        self.log.info(self.pool.pool_percentage_used())
+        print(self.pool.pool_percentage_used())
 
-        # Fill 60% of current SCM free space. This time, NVMe will be Full so data will
-        # not be moved to NVMe and continue to fill up SCM. SCM will be full and this
-        # command is expected to fail with DER_NOSPACE.
+        # Fill 60% more of SCM pool, now NVMe will be Full so data will not be
+        # moved to NVMe but it will start filling SCM. SCM size will be going to
+        # full and this command expected to fail with DER_NOSPACE
         try:
             self.start_ior_load(storage='SCM', operation="Auto_Write", percent=60)
-            self.fail('This test is suppose to FAIL because of DER_NOSPACE'
-                      'but it Passed')
+            self.fail('This test suppose to FAIL because of DER_NOSPACE'
+                      'but it got Passed')
         except TestFail:
-            self.log.info('Test is expected to fail because of DER_NOSPACE')
+            self.log.info('Test expected to fail because of DER_NOSPACE')
 
-        # Display the pool usage %
-        self.log.info(self.pool.pool_percentage_used())
+        # Display the pool%
+        print(self.pool.pool_percentage_used())
 
         # verify the DER_NO_SAPCE error count is expected and no other Error in client log
-        self.verify_enospace_log(self.der_nospace_count)
+        self.verify_enspace_log(self.der_nospace_count)
 
         # Check both NVMe and SCM are full.
         pool_usage = self.pool.pool_percentage_used()
-        # NVMe should be almost full. If not, fail the test.
-        if pool_usage['nvme'] <= 95:
-            msg = (f"Pool NVMe used percentage should be > 95%, instead "
-                   f"{pool_usage['nvme']}")
-            self.fail(msg)
-        # SCM usage will not be 100% because some space (<1%) is used for the system.
-        if pool_usage['scm'] <= 95:
-            msg = f"Pool SCM used percentage should be > 95%, instead {pool_usage['scm']}"
-            self.fail(msg)
+        # NVMe should be almost full if not test will fail.
+        if pool_usage['nvme'] > 8:
+            self.fail('Pool NVMe used percentage should be < 8%, instead {}'.
+                      format(pool_usage['nvme']))
+        # For SCM some % space used for system so it won't be 100% full.
+        if pool_usage['scm'] > 50:
+            self.fail('Pool SCM used percentage should be < 50%, instead {}'.
+                      format(pool_usage['scm']))
 
     def run_enospace_with_bg_job(self):
         """
@@ -185,6 +186,10 @@ class NvmeEnospace(ServerFillUp):
 
         # Run IOR in Foreground
         self.run_enospace_foreground()
+
+        # Wait until IOR Background thread completed
+        job.join()
+
         # Verify the background job result has no FAIL for any IOR run
         for _result in self.test_result:
             if "FAIL" in _result:
@@ -400,27 +405,21 @@ class NvmeEnospace(ServerFillUp):
                 self.log.info('Expected to fail because of DER_NOSPACE')
 
             # Verify DER_NO_SAPCE error count is expected and no other Error in client log.
-            self.verify_enospace_log(self.der_nospace_count)
+            self.verify_enspace_log(self.der_nospace_count)
 
             # Delete all the containers
             self.delete_all_containers()
 
-            # Wait for the SCM space to be released. (Usage goes below 60%)
-            scm_released = False
-            pool_usage = None
-            for count in range(6):
-                time.sleep(10)
-                pool_usage = self.pool.pool_percentage_used()
-                self.log.info("Pool usage at iter %d: %s", count, pool_usage)
-                if pool_usage["scm"] < 60:
-                    scm_released = True
-                    break
-
-            # Verify that the SCM usage has gone down below 60%.
-            if not scm_released:
-                msg = (f"Pool SCM used percentage should be < 60%. Actual = "
-                       f"{pool_usage['scm']}")
-                self.fail(msg)
+            # Get the pool usage
+            pool_usage = self.pool.pool_percentage_used()
+            # Delay to release the SCM size.
+            time.sleep(60)
+            print(pool_usage)
+            # SCM pool size should be released (some still be used for system)
+            # Pool SCM free % should not be less than 62%
+            if pool_usage['scm'] > 62:
+                self.fail('SCM pool used percentage should be < 62, instead {}'.
+                          format(pool_usage['scm']))
 
         # Run last IO
         self.start_ior_load(storage='SCM', operation="Auto_Write", percent=1)

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -244,7 +244,7 @@ class NvmeEnospace(ServerFillUp):
 
         # Repeat the test in loop.
         for _loop in range(10):
-            self.log.info("-------enospc_lazy_fg Loop--------- %d".format(_loop))
+            self.log.info("-------enospc_lazy_fg Loop--------- %d", _loop)
             # Run IOR to fill the pool.
             self.run_enospace_foreground()
             # Delete all the containers
@@ -308,7 +308,7 @@ class NvmeEnospace(ServerFillUp):
 
         # Repeat the test in loop.
         for _loop in range(10):
-            self.log.info("-------enospc_time_fg Loop--------- %d".format(_loop))
+            self.log.info("-------enospc_time_fg Loop--------- %d", _loop)
             self.log.info(self.pool.pool_percentage_used())
             # Run IOR to fill the pool.
             self.run_enospace_with_bg_job()
@@ -344,7 +344,7 @@ class NvmeEnospace(ServerFillUp):
         self.start_ior_load(storage='SCM', operation='Auto_Read', percent=1)
         max_mib_baseline = float(self.ior_matrix[0][int(IorMetrics.MAX_MIB)])
         baseline_cont_uuid = self.ior_cmd.dfs_cont.value
-        self.log.info("IOR Baseline Read MiB %s".format(max_mib_baseline))
+        self.log.info("IOR Baseline Read MiB %s", max_mib_baseline)
 
         # Run IOR to fill the pool.
         self.run_enospace_with_bg_job()
@@ -353,7 +353,7 @@ class NvmeEnospace(ServerFillUp):
         self.container.uuid = baseline_cont_uuid
         self.start_ior_load(storage='SCM', operation='Auto_Read', percent=1)
         max_mib_latest = float(self.ior_matrix[0][int(IorMetrics.MAX_MIB)])
-        self.log.info("IOR Latest Read MiB %s".format(max_mib_latest))
+        self.log.info("IOR Latest Read MiB %s", max_mib_latest)
 
         # Check if latest IOR read performance is in Tolerance of 5%, when
         # Storage space is full.
@@ -393,7 +393,7 @@ class NvmeEnospace(ServerFillUp):
 
         # Repeat the test in loop.
         for _loop in range(10):
-            self.log.info("-------enospc_no_aggregation Loop--------- %d".format(_loop))
+            self.log.info("-------enospc_no_aggregation Loop--------- %d", _loop)
             # Fill 75% of SCM pool
             self.start_ior_load(storage='SCM', operation="Auto_Write", percent=40)
 

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -51,5 +51,3 @@ ior:
       transfer_size: 2048  # 2K
     16M:
       nvme_transfer_size: 16777216  # 16M
-enospace:
-  bg_read_loop: 15

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -51,3 +51,5 @@ ior:
       transfer_size: 2048  # 2K
     16M:
       nvme_transfer_size: 16777216  # 16M
+enospace:
+  bg_read_loop: 15


### PR DESCRIPTION
Description: update script enospace.py to complete the job before exit.

Test-tag: der_enospace
Test-repeat: 30
Doc-only: false
Required-githooks: true
Signed-off-by: Ding Ho ding-hwa.ho@intel.com

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
