### PR TITLE
DAOS-13019 test: Kill one ranks twice in multiple_failure.py

### DIFF
--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -282,7 +282,7 @@ class ServerFillUp(IorTestBase):
         Args:
             rank: Rank number to kill the daos server
         """
-        self.server_managers[0].stop_ranks([rank], self.d_log, force=True)
+        self.server_managers[0].stop_ranks([rank], self.d_log, force=True, copy=True)
 
     def exclude_target_thread(self, rank, target):
         """Target kill thread function.

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -776,7 +776,10 @@ class DaosServerManager(SubprocessManager):
             valid_states.extend(extra_states)
         self.log.info("Stopping DAOS I/O Engines")
         self.check_system_state(valid_states)
-        self.dmg.system_stop(force=True)
+        if copy:
+            self.dmg.copy().system_stop(force=True)
+        else:
+            self.dmg.system_stop(force=True)
         if self.dmg.result.exit_status != 0:
             raise ServerFailed("Error stopping DAOS:\n{}".format(self.dmg.result))
 
@@ -810,7 +813,7 @@ class DaosServerManager(SubprocessManager):
         return data
 
     @fail_on(CommandFailure)
-    def stop_ranks(self, ranks, daos_log, force=False):
+    def stop_ranks(self, ranks, daos_log, force=False, copy=False):
         """Kill/Stop the specific server ranks using this pool.
 
         Args:
@@ -818,6 +821,7 @@ class DaosServerManager(SubprocessManager):
             daos_log (DaosLog): object for logging messages
             force (bool, optional): whether to use --force option to dmg system
                 stop. Defaults to False.
+            copy (bool, optional): Copy dmg command. Defaults to False.
 
         Raises:
             avocado.core.exceptions.TestFail: if there is an issue stopping the server ranks.
@@ -829,7 +833,10 @@ class DaosServerManager(SubprocessManager):
         daos_log.info(msg)
 
         # Stop desired ranks using dmg
-        self.dmg.system_stop(ranks=list_to_str(value=ranks), force=force)
+        if copy:
+            self.dmg.copy().system_stop(ranks=list_to_str(value=ranks), force=force)
+        else:
+            self.dmg.system_stop(ranks=list_to_str(value=ranks), force=force)
 
         # Update the expected status of the stopped/excluded ranks
         self.update_expected_states(ranks, ["stopped", "excluded"])


### PR DESCRIPTION
Description: Update server_utils stop_ranks with dmg copy option.
Skip-unit-tests: true
Test-tag: ec_multiple_failure
Test-repeat: 3
Required-githooks: true
Signed-off-by: Ding Ho ding-hwa.ho@intel.com

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
