### PR TITLE
DAOS-623 test: Simplify VOS unit tests a little

### DIFF
--- a/ci/codespell.ignores
+++ b/ci/codespell.ignores
@@ -22,6 +22,7 @@ controllerd
 ether
 expport
 coo
+otype
 spawnve
 inflight
 warmup

--- a/src/tests/perf_internal.h
+++ b/src/tests/perf_internal.h
@@ -43,8 +43,6 @@ struct pf_param {
 	union {
 		/* private parameter for iteration */
 		struct {
-			/* nested iterator */
-			bool	nested;
 			/* visible iteration */
 			bool	visible;
 		} pa_iter;

--- a/src/tests/vos_perf.c
+++ b/src/tests/vos_perf.c
@@ -30,8 +30,7 @@ uint64_t	ts_flags;
 
 char		ts_pmem_path[PATH_MAX - 32];
 char		ts_pmem_file[PATH_MAX];
-bool		ts_zero_copy;	/* use zero-copy API for VOS */
-bool		ts_nest_iterator;
+bool                    ts_zero_copy; /* use zero-copy API for VOS */
 
 daos_unit_oid_t	*ts_uoids;	/* object shard IDs */
 
@@ -546,7 +545,6 @@ pf_verify(struct pf_test *ts, struct pf_param *param)
 static int
 pf_iterate(struct pf_test *pf, struct pf_param *param)
 {
-	ts_nest_iterator = param->pa_iter.nested;
 	return obj_iter_records(ts_uoids[0], param);
 }
 
@@ -602,10 +600,6 @@ pf_parse_iterate_cb(char *str, struct pf_param *pa, char **strp)
 {
 	switch (*str) {
 	default:
-		str++;
-		break;
-	case 'n':
-		pa->pa_iter.nested = true;
 		str++;
 		break;
 	case 'V':

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -2552,8 +2552,7 @@ main(int argc, char **argv)
 	int		rc;
 	int		j;
 	int		start_idx;
-	char		*test_name;
-	bool		create_pmem;
+	char           *test_name;
 
 	d_register_alt_assert(mock_assert);
 
@@ -2566,33 +2565,19 @@ main(int argc, char **argv)
 	if (rc != 0)
 		return rc;
 
-	/* Capture test_name and pmem args if any */
+	/* Capture test_name args if any */
 	start_idx = 0;
 	test_name = "evtree default test suite name";
-	create_pmem = false;
 	if (argc > 1) {
 		/* Get test suite variables */
 		if (strcmp(argv[1], "--start-test") == 0) {
 			start_idx = 2;
 			test_name = argv[start_idx];
 		}
-
-		/* Capture pmem parameter */
-		if (argc > start_idx+1) {
-			if (strcmp(argv[start_idx+1], "pmem") == 0) {
-				create_pmem = true;
-				start_idx++;
-			}
-		}
 	}
 	optind = start_idx;
-	/* Create pool - pmem or vmem */
-	if (create_pmem) {
-		rc = utest_pmem_create(POOL_NAME, POOL_SIZE, sizeof(*ts_root),
-				       &ts_utx);
-	} else {
-		rc = utest_vmem_create(sizeof(*ts_root), &ts_utx);
-	}
+	/* Create pmem pool */
+	rc = utest_pmem_create(POOL_NAME, POOL_SIZE, sizeof(*ts_root), &ts_utx);
 	if (rc != 0) {
 		perror("Evtree test couldn't create pool");
 		return rc;

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -34,11 +34,11 @@
 	ACTION(DAOS_OT_AKEY_LEXICAL)                                                               \
 	ACTION(DAOS_OT_MULTI_LEXICAL)
 
-#define OT_ENUM_VALUE(ot) ot,
+#define OT_ENUM_VALUE(otype) otype,
 
 static int type_list[] = {FOREACH_OTYPE(OT_ENUM_VALUE)};
 
-#define OT_HELP_MESSAGE(ot) print_message("        %d: " #ot "\n", (ot));
+#define OT_HELP_MESSAGE(otype) print_message("        %d: " #otype "\n", (otype));
 
 static void
 print_usage()

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -25,6 +25,21 @@
 #define		FORCE_CSUM 0x1001
 #define		FORCE_NO_ZERO_COPY 0x1002
 
+#define FOREACH_OTYPE(ACTION)                                                                      \
+	ACTION(DAOS_OT_MULTI_HASHED)                                                               \
+	ACTION(DAOS_OT_DKEY_UINT64)                                                                \
+	ACTION(DAOS_OT_AKEY_UINT64)                                                                \
+	ACTION(DAOS_OT_MULTI_UINT64)                                                               \
+	ACTION(DAOS_OT_DKEY_LEXICAL)                                                               \
+	ACTION(DAOS_OT_AKEY_LEXICAL)                                                               \
+	ACTION(DAOS_OT_MULTI_LEXICAL)
+
+#define OT_ENUM_VALUE(ot) ot,
+
+static int type_list[] = {FOREACH_OTYPE(OT_ENUM_VALUE)};
+
+#define OT_HELP_MESSAGE(ot) print_message("        %d: " #ot "\n", (ot));
+
 static void
 print_usage()
 {
@@ -32,8 +47,8 @@ print_usage()
 	print_message("vos_tests -p|--pool\n");
 	print_message("vos_tests -c|--container\n");
 	print_message("vos_tests -i|--io <otype>\n");
-	print_message("otypes = DAOS_OT_DKEY_UINT64, DAOS_OT_DKEY_LEXICAL\n");
-	print_message("%8s DAOS_OT_AKEY_UINT64, DAOS_OT_AKEY_LEXICAL\n", " ");
+	print_message("    otype:\n");
+	FOREACH_OTYPE(OT_HELP_MESSAGE);
 	print_message("vos_tests -d |--discard\n");
 	print_message("vos_tests -a |--aggregate\n");
 	print_message("vos_tests -X|--dtx\n");
@@ -53,52 +68,27 @@ print_usage()
 	print_message("  --force_no_zero_copy\n");
 }
 
-static int type_list[] = {
-	0,
-	DAOS_OT_AKEY_UINT64,
-	DAOS_OT_AKEY_LEXICAL,
-	DAOS_OT_DKEY_UINT64,
-	DAOS_OT_DKEY_LEXICAL,
-	DAOS_OT_MULTI_UINT64,
-	DAOS_OT_MULTI_LEXICAL
-};
-
 static inline int
-run_all_tests(int keys, bool nest_iterators)
+run_all_tests(int keys)
 {
-	const char	*it;
 	char		 cfg_desc_io[DTS_CFG_MAX];
-	int		 failed = 0;
-	int		 i;
-
-	if (!nest_iterators) {
-		dts_create_config(cfg_desc_io, "keys=%d", keys);
-		failed += run_ts_tests(cfg_desc_io);
-		failed += run_mvcc_tests(cfg_desc_io);
-	}
+	int              failed = 0;
 
 	dts_create_config(cfg_desc_io, "keys=%d", keys);
 
-	if (nest_iterators == false) {
-		failed += run_pm_tests(cfg_desc_io);
-		failed += run_pool_test(cfg_desc_io);
-		failed += run_co_test(cfg_desc_io);
-		failed += run_discard_tests(cfg_desc_io);
-		failed += run_aggregate_tests(false, cfg_desc_io);
-		failed += run_gc_tests(cfg_desc_io);
-		failed += run_dtx_tests(cfg_desc_io);
-		failed += run_ilog_tests(cfg_desc_io);
-		failed += run_csum_extent_tests(cfg_desc_io);
+	failed += run_ts_tests(cfg_desc_io);
+	failed += run_mvcc_tests(cfg_desc_io);
+	failed += run_pm_tests(cfg_desc_io);
+	failed += run_pool_test(cfg_desc_io);
+	failed += run_co_test(cfg_desc_io);
+	failed += run_discard_tests(cfg_desc_io);
+	failed += run_aggregate_tests(false, cfg_desc_io);
+	failed += run_gc_tests(cfg_desc_io);
+	failed += run_dtx_tests(cfg_desc_io);
+	failed += run_ilog_tests(cfg_desc_io);
+	failed += run_csum_extent_tests(cfg_desc_io);
 
-		it = "standalone";
-	} else {
-		it = "nested";
-	}
-	dts_create_config(cfg_desc_io, "keys=%d iterator=%s", keys, it);
-
-	for (i = 0; i < (sizeof(type_list) / sizeof(int)); i++) {
-		failed += run_io_test(type_list[i], keys, nest_iterators, cfg_desc_io);
-	}
+	failed += run_io_test(&type_list[0], ARRAY_SIZE(type_list), keys, cfg_desc_io);
 
 	return failed;
 }
@@ -110,9 +100,8 @@ main(int argc, char **argv)
 	int	nr_failed = 0;
 	int	opt = 0;
 	int	index = 0;
-	int	otypes;
-	int	keys;
-	bool	nest_iterators = false;
+	int                  otype;
+	int                  keys;
 	const char          *vos_command    = NULL;
 	const char          *short_options  = "apcdglzni:mXA:S:hf:e:tCr:";
 	static struct option long_options[] = {
@@ -121,7 +110,6 @@ main(int argc, char **argv)
 	    {"container", no_argument, 0, 'c'},
 	    {"io", required_argument, 0, 'i'},
 	    {"discard", no_argument, 0, 'd'},
-	    {"nest_iterators", no_argument, 0, 'n'},
 	    {"aggregate", no_argument, 0, 'a'},
 	    {"dtx", no_argument, 0, 'X'},
 	    {"punch_model", no_argument, 0, 'm'},
@@ -228,14 +216,15 @@ main(int argc, char **argv)
 			vos_command = optarg;
 			test_run = true;
 			break;
-		case 'n':
-			nest_iterators = true;
-			break;
 		case 'i':
-			otypes = strtol(optarg, NULL, 16);
-			nr_failed += run_io_test(otypes, 0,
-						 nest_iterators,
-						 "");
+			otype = strtol(optarg, NULL, 10);
+			if (otype >= ARRAY_SIZE(type_list)) {
+				print_error("otype %d must be in range [0, %ld)\n\n", otype,
+					    ARRAY_SIZE(type_list));
+				print_usage();
+				goto exit_0;
+			}
+			nr_failed += run_io_test(&type_list[otype], 1, 0, "");
 			test_run = true;
 			break;
 		case 'a':
@@ -260,7 +249,7 @@ main(int argc, char **argv)
 			break;
 		case 'A':
 			keys = atoi(optarg);
-			nr_failed = run_all_tests(keys, nest_iterators);
+			nr_failed = run_all_tests(keys);
 			test_run = true;
 			break;
 		case 'l':
@@ -295,7 +284,7 @@ main(int argc, char **argv)
 
 	/** options didn't include specific tests, just run them all */
 	if (!test_run)
-		nr_failed = run_all_tests(0, false);
+		nr_failed = run_all_tests(0);
 
 	if (vos_command != NULL)
 		nr_failed += run_vos_command(argv[0], vos_command);

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2992,7 +2992,7 @@ run_aggregate_tests(bool slow, const char *cfg)
 {
 	char	test_name[DTS_CFG_MAX];
 
-	dts_create_config(test_name, "Aggregate Tests %s", cfg);
+	dts_create_config(test_name, "Aggregate Tests (%s) %s", cfg, slow ? "slow" : "fast");
 
 	slow_test = slow;
 	return cmocka_run_group_tests_name(test_name,

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -123,8 +123,8 @@ int run_aggregate_tests(bool slow, const char *cfg);
 int run_dtx_tests(const char *cfg);
 int run_gc_tests(const char *cfg);
 int run_pm_tests(const char *cfg);
-int run_io_test(enum daos_otype_t type, int keys, bool nest_iterators,
-		const char *cfg);
+int
+    run_io_test(int *types, int num_types, int keys, const char *cfg);
 int run_ts_tests(const char *cfg);
 
 int run_ilog_tests(const char *cfg);

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -3023,7 +3023,7 @@ static const struct CMUnitTest int_tests[] = {
 };
 
 static int
-run_oclass_tests(enum daos_otype_t type, const char *cfg)
+run_oclass_tests(const char *cfg)
 {
 	char        test_name[DTS_CFG_MAX];
 	const char *akey = "hashed";
@@ -3032,13 +3032,13 @@ run_oclass_tests(enum daos_otype_t type, const char *cfg)
 
 	vts_nest_iterators = false;
 
-	if (is_daos_obj_type_set(type, DAOS_OT_DKEY_UINT64))
+	if (is_daos_obj_type_set(init_type, DAOS_OT_DKEY_UINT64))
 		dkey = "uint";
-	if (is_daos_obj_type_set(type, DAOS_OT_DKEY_LEXICAL))
+	if (is_daos_obj_type_set(init_type, DAOS_OT_DKEY_LEXICAL))
 		dkey = "lex";
-	if (is_daos_obj_type_set(type, DAOS_OT_AKEY_UINT64))
+	if (is_daos_obj_type_set(init_type, DAOS_OT_AKEY_UINT64))
 		akey = "uint";
-	if (is_daos_obj_type_set(type, DAOS_OT_AKEY_LEXICAL))
+	if (is_daos_obj_type_set(init_type, DAOS_OT_AKEY_LEXICAL))
 		akey = "lex";
 
 	dts_create_config(test_name, "IO_oclass tests (dkey=%-6s akey=%s) %s", dkey, akey, cfg);
@@ -3088,7 +3088,7 @@ run_io_test(int *types, int num_types, int keys, const char *cfg)
 
 	for (int i = 0; i < num_types; i++) {
 		init_type = types[i];
-		rc += run_oclass_tests(type, cfg);
+		rc += run_oclass_tests(cfg);
 	}
 
 	return rc;

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2974,17 +2974,8 @@ io_allocbuf_failure(void **state)
 	arg->ta_flags &= ~TF_ZERO_COPY;
 }
 
-static const struct CMUnitTest io_tests[] = {
-    {"VOS201: VOS object IO index", io_oi_test, NULL, NULL},
-    {"VOS202: VOS object cache test", io_obj_cache_test, NULL, NULL},
-    {"VOS203: Simple update/fetch/verify test", io_simple_one_key, NULL, NULL},
-    {"VOS204: Simple Punch test", io_simple_punch, NULL, NULL},
-    {"VOS205: Simple near-epoch retrieval test", io_simple_near_epoch, NULL, NULL},
-    {"VOS206: Simple scatter-gather list test, multiple update buffers", io_sgl_update, NULL, NULL},
-    {"VOS207: Simple scatter-gather list test, multiple fetch buffers", io_sgl_fetch, NULL, NULL},
-    {"VOS208: Extent hole test", io_fetch_hole, NULL, NULL},
+static const struct CMUnitTest iterator_tests[] = {
     {"VOS220: 100K update/fetch/verify test", io_multiple_dkey, NULL, NULL},
-    {"VOS222: overwrite test", io_idx_overwrite, NULL, NULL},
     {"VOS240.0: KV Iter tests (for dkey)", io_iter_test, NULL, NULL},
     {"VOS240.1: KV Iter tests with anchor (for dkey)", io_iter_test_with_anchor, NULL, NULL},
     {"VOS240.7: key2anchor iterator test", io_iter_test_key2anchor, NULL, NULL},
@@ -2993,6 +2984,17 @@ static const struct CMUnitTest io_tests[] = {
     {"VOS240.5 KV range iteration tests (for recx)", io_obj_forward_recx_iter_test, NULL, NULL},
     {"VOS240.6 KV reverse range iteration tests (for recx)", io_obj_reverse_recx_iter_test, NULL,
      NULL},
+};
+
+static const struct CMUnitTest io_tests[] = {
+    {"VOS203: Simple update/fetch/verify test", io_simple_one_key, NULL, NULL},
+    {"VOS204: Simple Punch test", io_simple_punch, NULL, NULL},
+    {"VOS205: Simple near-epoch retrieval test", io_simple_near_epoch, NULL, NULL},
+    {"VOS206: Simple scatter-gather list test, multiple update buffers", io_sgl_update, NULL, NULL},
+    {"VOS207: Simple scatter-gather list test, multiple fetch buffers", io_sgl_fetch, NULL, NULL},
+    {"VOS208: Extent hole test", io_fetch_hole, NULL, NULL},
+    {"VOS220: 100K update/fetch/verify test", io_multiple_dkey, NULL, NULL},
+    {"VOS222: overwrite test", io_idx_overwrite, NULL, NULL},
     {"VOS245.0: Object iter test (for oid)", oid_iter_test, oid_iter_test_setup, NULL},
     {"VOS245.1: Object iter test with anchor (for oid)", oid_iter_test_with_anchor,
      oid_iter_test_setup, NULL},
@@ -3011,25 +3013,24 @@ static const struct CMUnitTest io_tests[] = {
 };
 
 static const struct CMUnitTest int_tests[] = {
-	{ "VOS300.1: Test key query punch with subsequent update",
-		io_query_key_punch_update, NULL, NULL},
-	{ "VOS300.2: Key query test", io_query_key, NULL, NULL},
-	{ "VOS300.3: Key query negative test",
-		io_query_key_negative, NULL, NULL},
-	{ "VOS300.4: Return error on DMA buffer allocation failure",
-		io_allocbuf_failure, NULL, NULL},
+    {"VOS201: VOS object IO index", io_oi_test, NULL, NULL},
+    {"VOS202: VOS object cache test", io_obj_cache_test, NULL, NULL},
+    {"VOS300.1: Test key query punch with subsequent update", io_query_key_punch_update, NULL,
+     NULL},
+    {"VOS300.2: Key query test", io_query_key, NULL, NULL},
+    {"VOS300.3: Key query negative test", io_query_key_negative, NULL, NULL},
+    {"VOS300.4: Return error on DMA buffer allocation failure", io_allocbuf_failure, NULL, NULL},
 };
 
-int
-run_io_test(enum daos_otype_t type, int keys, bool nest_iterators, const char *cfg)
+static int
+run_oclass_tests(enum daos_otype_t type, const char *cfg)
 {
-	char buf[VTS_BUF_SIZE];
+	char        test_name[DTS_CFG_MAX];
 	const char *akey = "hashed";
 	const char *dkey = "hashed";
-	vts_nest_iterators = nest_iterators;
-	int rc = 0;
+	int         rc;
 
-	init_num_keys = VTS_IO_KEYS;
+	vts_nest_iterators = false;
 
 	if (is_daos_obj_type_set(type, DAOS_OT_DKEY_UINT64))
 		dkey = "uint";
@@ -3040,18 +3041,55 @@ run_io_test(enum daos_otype_t type, int keys, bool nest_iterators, const char *c
 	if (is_daos_obj_type_set(type, DAOS_OT_AKEY_LEXICAL))
 		akey = "lex";
 
-	snprintf(buf, VTS_BUF_SIZE, "IO# tests (dkey=%-6s akey=%s) %s", dkey, akey, cfg);
-	init_type = type;
+	dts_create_config(test_name, "IO_oclass tests (dkey=%-6s akey=%s) %s", dkey, akey, cfg);
+	D_PRINT("Running %s\n", test_name);
+
+	rc = cmocka_run_group_tests_name(test_name, io_tests, setup_io, teardown_io);
+
+	dts_create_config(test_name, "IO_iterator tests (nested=false dkey=%-6s akey=%s) %s", dkey,
+			  akey, cfg);
+
+	rc += cmocka_run_group_tests_name(test_name, iterator_tests, setup_io, teardown_io);
+
+	dts_create_config(test_name, "IO_iterator tests (nested=true dkey=%-6s akey=%s) %s", dkey,
+			  akey, cfg);
+
+	vts_nest_iterators = true;
+
+	rc += cmocka_run_group_tests_name(test_name, iterator_tests, setup_io, teardown_io);
+
+	return rc;
+}
+
+static int
+run_single_class_tests(const char *cfg)
+{
+	char test_name[DTS_CFG_MAX];
+
+	dts_create_config(test_name, "IO single oclass tests %s", cfg);
+	D_PRINT("Running %s\n", test_name);
+
+	return cmocka_run_group_tests_name(test_name, int_tests, setup_io, teardown_io);
+}
+
+int
+run_io_test(int *types, int num_types, int keys, const char *cfg)
+{
+	int rc = 0;
+
+	init_num_keys = VTS_IO_KEYS;
 	if (keys)
 		init_num_keys = keys;
-	D_PRINT("Running %s\n", buf);
-	if (type == DAOS_OT_MULTI_UINT64) {
-		buf[2] = '2';
-		rc = cmocka_run_group_tests_name(buf, int_tests, setup_io,
-						 teardown_io);
-	}
-	buf[2] = '1';
 
-	return rc + cmocka_run_group_tests_name(buf, io_tests,
-						setup_io, teardown_io);
+	/** key query tests require integer classes, other general tests don't care */
+	init_type = DAOS_OT_MULTI_UINT64;
+
+	rc = run_single_class_tests(cfg);
+
+	for (int i = 0; i < num_types; i++) {
+		init_type = types[i];
+		rc += run_oclass_tests(type, cfg);
+	}
+
+	return rc;
 }

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -279,7 +279,6 @@ if [ -d "/mnt/daos" ]; then
 
     COMP="UTEST_vos"
     run_test src/vos/tests/evt_ctl.sh
-    run_test src/vos/tests/evt_ctl.sh pmem
     unset USE_VALGRIND
     unset VALGRIND_SUPP
 

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -199,7 +199,6 @@ if [ -d "/mnt/daos" ]; then
 
     COMP="UTEST_vos"
     run_test "${SL_PREFIX}/bin/vos_tests" -A 500
-    run_test "${SL_PREFIX}/bin/vos_tests" -n -A 500
     COMP="UTEST_vos"
     cmd="-c pool -w key@0-4 key@3-4 -R key@3-3 -w key@5-4 -R key@5-3 -a -i -d -D"
     run_test "${SL_PREFIX}/bin/vos_tests" -r "\"${cmd}\""


### PR DESCRIPTION
Since the nested iterator option is specific to a small subset of VOS IO tests, remove it and handle running those internally both ways.
Remove related dead code from vos_perf.
Don't run tests that are not affected by oclass more than once Make some minor naming adjustments.
Also, we don't support vmem for vos, so stop running vmem evtree tests

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
