### PR TITLE
DAOS-12971 dfuse: Increase hash table size for dfuse inodes.

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -991,9 +991,8 @@ dfuse_fs_init(struct dfuse_info *dfuse_info, struct dfuse_projection_info **_fsh
 	if (rc != 0)
 		D_GOTO(err, rc);
 
-	rc = d_hash_table_create_inplace(D_HASH_FT_LRU | D_HASH_FT_EPHEMERAL,
-					 5, fs_handle, &ie_hops,
-					 &fs_handle->dpi_iet);
+	rc = d_hash_table_create_inplace(D_HASH_FT_LRU | D_HASH_FT_EPHEMERAL, 16, fs_handle,
+					 &ie_hops, &fs_handle->dpi_iet);
 	if (rc != 0)
 		D_GOTO(err_pt, rc);
 


### PR DESCRIPTION
At high file counts the hash table becomes a real performance bottleneck
so increase the size to accomodate.  With 1m files this can result in a
10x performance improvement for some workflows.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
