### PR TITLE
DAOS-13058 engine: incorrect assertion in dss_main_exec()

### DIFF
--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -606,7 +606,7 @@ dss_main_exec(void (*func)(void *), void *arg)
 	struct dss_module_info *info = dss_get_module_info();
 
 	D_ASSERT(info != NULL);
-	D_ASSERT(info->dmi_xstream->dx_main_xs || info->dmi_tgt_id < 0);
+	D_ASSERT(info->dmi_xstream->dx_main_xs || info->dmi_xs_id == 0);
 
 	return dss_ult_create(func, arg, DSS_XS_SELF, info->dmi_tgt_id, 0, NULL);
 }

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -606,7 +606,7 @@ dss_main_exec(void (*func)(void *), void *arg)
 	struct dss_module_info *info = dss_get_module_info();
 
 	D_ASSERT(info != NULL);
-	D_ASSERT(info->dmi_xstream->dx_main_xs);
+	D_ASSERT(info->dmi_xstream->dx_main_xs || info->dmi_tgt_id < 0);
 
 	return dss_ult_create(func, arg, DSS_XS_SELF, info->dmi_tgt_id, 0, NULL);
 }


### PR DESCRIPTION
RDB pool loading executed on sys XS.

Required-githooks: true