### PR TITLE
DAOS-12628 control: Add non-debug event logging for daos_server

### DIFF
--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -547,18 +547,25 @@ func (m *Membership) handleEngineFailure(evt *events.RASEvent) {
 	//
 	// e.g. if member.Addr.IP.Equal(net.ResolveIPAddr(evt.Hostname))
 
-	ns := MemberStateErrored
-	if member.State.isTransitionIllegal(ns) {
-		m.log.Debugf("skipping %s", msgBadStateTransition(member, ns))
+	newState := MemberStateErrored
+	if member.State.isTransitionIllegal(newState) {
+		m.log.Debugf("skipping %s", msgBadStateTransition(member, newState))
 		return
 	}
 
-	member.State = ns
+	oldState := member.State
+	member.State = newState
 	member.Info = evt.Msg
 
 	if err := m.db.UpdateMember(member); err != nil {
 		m.log.Errorf("updating member with rank %d: %s", member.Rank, err)
 	}
+
+	var msg string
+	if evt.Msg != "" {
+		msg = fmt.Sprintf(" (%s)", evt.Msg)
+	}
+	m.log.Errorf("rank %d: %s->%s%s", member.Rank, oldState, newState, msg)
 }
 
 // OnEvent handles events on channel and updates member states accordingly.

--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -1094,6 +1094,9 @@ func (db *Database) handlePoolRepsUpdate(evt *events.RASEvent) {
 	if err := db.UpdatePoolService(lock.InContext(ctx), ps); err != nil {
 		db.log.Errorf("failed to apply pool service update: %s", err)
 	}
+
+	newRanks := ranklist.RankSetFromRanks(ps.Replicas)
+	db.log.Infof("pool %s: service ranks set to %s", ps.PoolLabel, newRanks)
 }
 
 // OnEvent handles events and updates system database accordingly.


### PR DESCRIPTION
When a rank exits unexpectedly, a RAS event is raised and should
be logged at ERROR level. When a pool's service ranks are updated,
the event should be logged at INFO level.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
