### PR TITLE
DAOS-13086 cart: enable new tcp provider

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -38,9 +38,13 @@ struct crt_na_dict crt_na_dict[] = {
 		.nad_contig_eps	= true,
 		.nad_port_bind  = false,
 	}, {
+		.nad_type	= CRT_PROV_OFI_TCP,
+		.nad_str	= "ofi+tcp",
+		.nad_contig_eps	= true,
+		.nad_port_bind  = true,
+	}, {
 		.nad_type	= CRT_PROV_OFI_TCP_RXM,
 		.nad_str	= "ofi+tcp;ofi_rxm",
-		.nad_alt_str	= "ofi+tcp",
 		.nad_contig_eps	= true,
 		.nad_port_bind  = true,
 	}, {

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -545,16 +545,16 @@ prov_settings_apply(bool primary, crt_provider_t prov, crt_init_options_t *opt)
 
 	if (prov == CRT_PROV_OFI_CXI)
 		mrc_enable = 1;
-	else {
-		/* Use tagged messages for other providers, disable multi-recv */
-		apply_if_not_set("NA_OFI_UNEXPECTED_TAG_MSG", "1");
-	}
 
 	d_getenv_int("CRT_MRC_ENABLE", &mrc_enable);
 	if (mrc_enable == 0) {
 		D_INFO("Disabling MR CACHE (FI_MR_CACHE_MAX_COUNT=0)\n");
 		setenv("FI_MR_CACHE_MAX_COUNT", "0", 1);
 	}
+
+	/* Use tagged messages for other providers, disable multi-recv */
+	if (prov != CRT_PROV_OFI_CXI && prov != CRT_PROV_OFI_TCP)
+		apply_if_not_set("NA_OFI_UNEXPECTED_TAG_MSG", "1");
 
 	g_prov_settings_applied[prov] = true;
 }

--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -482,6 +482,7 @@
    Tcp provider on fi_tsend
    Memcheck:Param
    sendmsg(msg.msg_iov[2])
+   ...
    fun:sendmsg
    fun:ofi_sockapi_sendv_socket
    fun:ofi_bsock_sendv
@@ -493,6 +494,7 @@
    Tcp provider on fi_senddata
    Memcheck:Param
    sendmsg(msg.msg_iov[1])
+   ...
    fun:sendmsg
    fun:ofi_sockapi_sendv_socket
    fun:ofi_bsock_sendv

--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -479,16 +479,7 @@
    fun:crt_hg_class_init
 }
 {
-   Tcp provider with ofi rxm
-   Memcheck:Param
-   sendmsg(msg.msg_iov[1])
-   ...
-   fun:ofi_bsock_sendv
-   ...
-   fun:fi_tsend
-}
-{
-   Tcp provider with ofi rxm 2
+   Tcp provider on fi_tsend
    Memcheck:Param
    sendmsg(msg.msg_iov[2])
    fun:sendmsg
@@ -496,6 +487,17 @@
    fun:ofi_bsock_sendv
    ...
    fun:fi_tsend
+   ...
+}
+{
+   Tcp provider on fi_senddata
+   Memcheck:Param
+   sendmsg(msg.msg_iov[1])
+   fun:sendmsg
+   fun:ofi_sockapi_sendv_socket
+   fun:ofi_bsock_sendv
+   ...
+   fun:fi_senddata
    ...
 }
 {

--- a/src/control/lib/hardware/libfabric/provider_test.go
+++ b/src/control/lib/hardware/libfabric/provider_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/control/lib/telemetry/promexp/collector_test.go
+++ b/src/control/lib/telemetry/promexp/collector_test.go
@@ -531,10 +531,10 @@ func TestPromExp_extractLabels(t *testing.T) {
 			expLabels: labelMap{},
 		},
 		"net_provider_req_timeout": {
-			input:   "ID: 0/net/ofi+tcp;ofi_rxm/req_timeout/ctx_0",
+			input:   "ID: 0/net/ofi+tcp/req_timeout/ctx_0",
 			expName: "net_req_timeout",
 			expLabels: labelMap{
-				"provider": "ofi+tcp;ofi_rxm",
+				"provider": "ofi+tcp",
 				"context":  "0",
 			},
 		},

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -85,7 +85,7 @@ func processFabricProvider(cfg *config.Server) {
 }
 
 func shouldAppendRXM(provider string) bool {
-	for _, rxmProv := range []string{"ofi+verbs", "ofi+tcp"} {
+	for _, rxmProv := range []string{"ofi+verbs"} {
 		if rxmProv == provider {
 			return true
 		}

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -94,14 +94,15 @@ typedef struct crt_init_options {
  * Enumeration specifying providers supported by the library
  */
 typedef enum {
-	CRT_PROV_SM		= 0,
+	CRT_PROV_SM = 0,
 	CRT_PROV_OFI_SOCKETS,
 	CRT_PROV_OFI_VERBS_RXM,
 	CRT_PROV_OFI_GNI,
+	CRT_PROV_OFI_TCP,
 	CRT_PROV_OFI_TCP_RXM,
 	CRT_PROV_OFI_CXI,
 	CRT_PROV_OFI_OPX,
-	CRT_PROV_OFI_LAST	= CRT_PROV_OFI_OPX,
+	CRT_PROV_OFI_LAST = CRT_PROV_OFI_OPX,
 	CRT_PROV_UCX_RC,
 	CRT_PROV_UCX_UD,
 	CRT_PROV_UCX_RC_UD,
@@ -113,12 +114,11 @@ typedef enum {
 	CRT_PROV_UCX_RC_UD_X,
 	CRT_PROV_UCX_DC_X,
 	CRT_PROV_UCX_TCP,
-	CRT_PROV_UCX_LAST	= CRT_PROV_UCX_TCP,
+	CRT_PROV_UCX_LAST = CRT_PROV_UCX_TCP,
 	/* Note: This entry should be the last valid one in enum */
 	CRT_PROV_COUNT,
 	CRT_PROV_UNKNOWN = -1,
 } crt_provider_t;
-
 
 typedef int		crt_status_t;
 /**

--- a/src/tests/ftest/cart/corpc/corpc_five_node.yaml
+++ b/src/tests/ftest/cart/corpc/corpc_five_node.yaml
@@ -10,7 +10,7 @@ ENV:
     - test_servers_CRT_CTX_NUM: "0"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/corpc/corpc_two_node.yaml
+++ b/src/tests/ftest/cart/corpc/corpc_two_node.yaml
@@ -10,7 +10,7 @@ ENV:
     - test_servers_CRT_CTX_NUM: "16"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/ctl/ctl_five_node.yaml
+++ b/src/tests/ftest/cart/ctl/ctl_five_node.yaml
@@ -11,7 +11,7 @@ ENV:
     - test_clients_CRT_CTX_NUM: "0"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/ghost_rank_rpc/ghost_rank_rpc_one_node.yaml
+++ b/src/tests/ftest/cart/ghost_rank_rpc/ghost_rank_rpc_one_node.yaml
@@ -10,7 +10,7 @@ ENV:
     - test_servers_CRT_CTX_NUM: "16"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/group_test/group_test.yaml
+++ b/src/tests/ftest/cart/group_test/group_test.yaml
@@ -8,7 +8,7 @@ ENV:
     - OFI_INTERFACE: "eth0"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/src/tests/ftest/cart/iv/iv_one_node.yaml
+++ b/src/tests/ftest/cart/iv/iv_one_node.yaml
@@ -18,7 +18,7 @@ env_CRT_PHY_ADDR_STR: !mux
   sm:
     CRT_PHY_ADDR_STR: "sm"
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/src/tests/ftest/cart/iv/iv_two_node.yaml
+++ b/src/tests/ftest/cart/iv/iv_two_node.yaml
@@ -12,7 +12,7 @@ ENV:
     - CRT_TEST_CONT: "1"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/no_pmix/multictx_one_node.yaml
+++ b/src/tests/ftest/cart/no_pmix/multictx_one_node.yaml
@@ -13,7 +13,7 @@ env_CRT_PHY_ADDR_STR: !mux
   sm:
     CRT_PHY_ADDR_STR: "sm"
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 tests: !mux
   no_pmix_multi_ctx:
     name: no_pmix_multi_ctx

--- a/src/tests/ftest/cart/no_pmix_group_test.c
+++ b/src/tests/ftest/cart/no_pmix_group_test.c
@@ -684,7 +684,7 @@ int main(int argc, char **argv)
 	}
 
 	for (i = 0; i < 10; i++) {
-		rc = asprintf(&uris[i], "ofi+tcp;ofi_rxm://127.0.0.1:%d",
+		rc = asprintf(&uris[i], "ofi+tcp://127.0.0.1:%d",
 				10000 + i);
 		if (rc == -1) {
 			D_ERROR("asprintf() failed\n");

--- a/src/tests/ftest/cart/nopmix_launcher/launcher_one_node.yaml
+++ b/src/tests/ftest/cart/nopmix_launcher/launcher_one_node.yaml
@@ -8,7 +8,7 @@ ENV:
     - OFI_INTERFACE: "eth0"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/src/tests/ftest/cart/rpc/multisend_one_node.yaml
+++ b/src/tests/ftest/cart/rpc/multisend_one_node.yaml
@@ -17,7 +17,7 @@ env_CRT_CTX_SHARE_ADDR: !mux
     CRT_CTX_SHARE_ADDR: "0"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/src/tests/ftest/cart/rpc/rpc_one_node.yaml
+++ b/src/tests/ftest/cart/rpc/rpc_one_node.yaml
@@ -19,7 +19,7 @@ env_CRT_PHY_ADDR_STR: !mux
   sm:
     CRT_PHY_ADDR_STR: "sm"
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 hosts: !mux
   hosts_1:
     config: one_node

--- a/src/tests/ftest/cart/rpc/rpc_two_node.yaml
+++ b/src/tests/ftest/cart/rpc/rpc_two_node.yaml
@@ -11,7 +11,7 @@ ENV:
     - test_clients_CRT_CTX_NUM: "16"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/rpc/swim_notification.yaml
+++ b/src/tests/ftest/cart/rpc/swim_notification.yaml
@@ -12,7 +12,7 @@ ENV:
     - test_clients_CRT_CTX_NUM: "16"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/selftest/selftest_three_node.yaml
+++ b/src/tests/ftest/cart/selftest/selftest_three_node.yaml
@@ -11,7 +11,7 @@ ENV:
     - test_clients_CRT_CTX_NUM: "16"
 env_CRT_PHY_ADDR_STR: !mux
   ofi_tcp:
-    CRT_PHY_ADDR_STR: "ofi+tcp;ofi_rxm"
+    CRT_PHY_ADDR_STR: "ofi+tcp"
 env_CRT_CTX_SHARE_ADDR: !mux
   no_sep:
     env: no_sep

--- a/src/tests/ftest/cart/utest/utest_portnumber.c
+++ b/src/tests/ftest/cart/utest/utest_portnumber.c
@@ -192,7 +192,7 @@ static void
 test_port_tcp(void **state)
 {
 	setenv("OFI_INTERFACE", "lo", 1);
-	setenv("CRT_PHY_ADDR_STR", "ofi+tcp;ofi_rxm", 1);
+	setenv("CRT_PHY_ADDR_STR", "ofi+tcp", 1);
 	run_test_fork(state);
 }
 

--- a/src/tests/ftest/control/config_generate_output.py
+++ b/src/tests/ftest/control/config_generate_output.py
@@ -23,7 +23,7 @@ class ConfigGenerateOutput(TestWithServers):
         """Initialize a ConfigGenerateOutput object."""
         super().__init__(*args, **kwargs)
 
-        self.def_provider = "ofi+tcp;ofi_rxm"
+        self.def_provider = "ofi+tcp"
 
         # Data structure that store expected values.
         self.numa_node_to_pci_addrs = defaultdict(set)

--- a/src/tests/ftest/control/config_generate_run.yaml
+++ b/src/tests/ftest/control/config_generate_run.yaml
@@ -16,34 +16,34 @@ setup:
 config_generate_params: !mux
   # 1. Access points only. Use default for others.
   all_default:
-    net_provider: ofi+tcp;ofi_rxm
+    net_provider: ofi+tcp
   # 2. Use one engine.
   single_engine:
     num_engines: 1
-    net_provider: ofi+tcp;ofi_rxm
+    net_provider: ofi+tcp
   # 3. Use scm_only=false. This will use the maximum number of SSDs, so the
   # generated config file should be identical to all_default.
   scm_only_false:
     scm_only: false
-    net_provider: ofi+tcp;ofi_rxm
+    net_provider: ofi+tcp
   # 4. Use scm_only=true. No NVMe entry. SCM only.
   scm_only_true:
     scm_only: true
-    net_provider: ofi+tcp;ofi_rxm
+    net_provider: ofi+tcp
   # 5. Use infiniband. This is usually the default behavior, so the generated
   # config file would be identical to all_default if the feature is working
   # correctly.
   infiniband:
     net_class: infiniband
-    net_provider: ofi+tcp;ofi_rxm
+    net_provider: ofi+tcp
   # 6. Use ethernet. There's usually only one ethernet interface available, so
   # use one engine. Each engine would need different interface. We could come up
   # with the maximum usable count, but that's out of scope.
   ethernet:
     net_class: ethernet
     num_engines: 1
-    net_provider: ofi+tcp;ofi_rxm
+    net_provider: ofi+tcp
   # 7. Use tmpfs for scm instead of pmem.
   tmpfs_scm_true:
     use_tmpfs_scm: true
-    net_provider: ofi+tcp;ofi_rxm
+    net_provider: ofi+tcp

--- a/src/tests/ftest/server/multiengine_persocket.yaml
+++ b/src/tests/ftest/server/multiengine_persocket.yaml
@@ -85,7 +85,7 @@ agent_config:
 dmg:
   transport_config:
     allow_insecure: false
-provider: ofi+tcp;ofi_rxm
+provider: ofi+tcp
 pool:
   control_method: dmg
   scm_size: 1G

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -120,7 +120,7 @@ class DmgCommand(DmgCommandBase):
         #           ],
         #           "Providers": [
         #             "ofi+verbs;ofi_rxm",
-        #             "ofi+tcp;ofi_rxm",
+        #             "ofi+tcp",
         #             "ofi+verbs",
         #             "ofi+tcp",
         #             "ofi+sockets"
@@ -1138,7 +1138,7 @@ class DmgCommand(DmgCommandBase):
             net_class (str): Network class preferred. Defaults to None.
                 i.e. "ethernet"|"infiniband"
             net_provider (str): Network provider preferred. Defaults to None.
-                i.e. "ofi+tcp;ofi_rxm" etc.
+                i.e. "ofi+tcp" etc.
             use_tmpfs_scm (bool, optional): Whether to use a ramdisk instead of PMem
                 as SCM. Defaults to False.
             control_metadata_path (str): External directory provided to store control

--- a/src/tests/ftest/util/network_utils.py
+++ b/src/tests/ftest/util/network_utils.py
@@ -13,7 +13,7 @@ from ClusterShell.NodeSet import NodeSet
 from exception_utils import CommandFailure
 from general_utils import run_task, display_task, run_pcmd
 
-SUPPORTED_PROVIDERS = ("ofi+sockets", "ofi+tcp;ofi_rxm", "ofi+verbs;ofi_rxm", "ucx+dc_x", "ofi+cxi")
+SUPPORTED_PROVIDERS = ("ofi+sockets", "ofi+tcp", "ofi+verbs;ofi_rxm", "ucx+dc_x", "ofi+cxi")
 
 
 class NetworkDevice():

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -91,7 +91,7 @@
 ## providers that are supported on the fabric interfaces. Examples:
 ##
 ##   ofi+verbs;ofi_rxm  for libfabric with Infiniband/RoCE
-##   ofi+tcp;ofi_rxm    for libfabric with non-RDMA-capable fabrics
+##   ofi+tcp    for libfabric with non-RDMA-capable fabrics
 ##
 ## (Starting with DAOS 2.2, ofi_rxm will be automatically added to the
 ## libfabric verbs and tcp providers, if not explicitly specified.)

--- a/utils/docker/vcluster/daos-server/el8/daos_server.yml.in
+++ b/utils/docker/vcluster/daos-server/el8/daos_server.yml.in
@@ -4,7 +4,7 @@ name: daos_server
 access_points: ['daos-server']
 port: 10001
 
-provider: ofi+tcp;ofi_rxm
+provider: ofi+tcp
 socket_dir: /var/run/daos_server
 nr_hugepages: @DAOS_HUGEPAGES_NBR@
 

--- a/utils/nlt_server.yaml
+++ b/utils/nlt_server.yaml
@@ -1,6 +1,6 @@
 name: daos_server
 port: 10001
-provider: ofi+tcp;ofi_rxm
+provider: ofi+tcp
 disable_hugepages: true
 control_log_mask: DEBUG
 access_points: ['localhost:10001']

--- a/utils/test_memcheck.supp
+++ b/utils/test_memcheck.supp
@@ -247,17 +247,7 @@
    ...
 }
 {
-   Tcp provider with ofi rxm
-   Memcheck:Param
-   sendmsg(msg.msg_iov[1])
-   obj:*
-   fun:ofi_bsock_sendv
-   ...
-   fun:fi_tsend
-   ...
-}
-{
-   Tcp provider with ofi rxm 2
+   Tcp provider on fi_tsend
    Memcheck:Param
    sendmsg(msg.msg_iov[2])
    fun:sendmsg
@@ -265,6 +255,17 @@
    fun:ofi_bsock_sendv
    ...
    fun:fi_tsend
+   ...
+}
+{
+   Tcp provider on fi_senddata
+   Memcheck:Param
+   sendmsg(msg.msg_iov[1])
+   fun:sendmsg
+   fun:ofi_sockapi_sendv_socket
+   fun:ofi_bsock_sendv
+   ...
+   fun:fi_senddata
    ...
 }
 {

--- a/utils/test_memcheck.supp
+++ b/utils/test_memcheck.supp
@@ -250,6 +250,7 @@
    Tcp provider on fi_tsend
    Memcheck:Param
    sendmsg(msg.msg_iov[2])
+   ...
    fun:sendmsg
    fun:ofi_sockapi_sendv_socket
    fun:ofi_bsock_sendv
@@ -261,6 +262,7 @@
    Tcp provider on fi_senddata
    Memcheck:Param
    sendmsg(msg.msg_iov[1])
+   ...
    fun:sendmsg
    fun:ofi_sockapi_sendv_socket
    fun:ofi_bsock_sendv


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
