### PR TITLE
DAOS-12989 test: do not land test only

### DIFF
--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -11,9 +11,13 @@
 #define __POOL_SRV_INTERNAL_H__
 
 #include <gurt/list.h>
+#include <daos/pool_map.h>
 #include <daos_srv/daos_engine.h>
 #include <daos_security.h>
 #include <gurt/telemetry_common.h>
+
+/* Map status of ranks that make up the pool group */
+#define POOL_GROUP_MAP_STATUS (PO_COMP_ST_UP | PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN)
 
 /**
  * Global pool metrics
@@ -169,6 +173,7 @@ void ds_pool_tgt_query_map_handler(crt_rpc_t *rpc);
  */
 int ds_pool_check_failed_replicas(struct pool_map *map, d_rank_list_t *replicas,
 				  d_rank_list_t *failed, d_rank_list_t *alt);
+bool ds_pool_map_rank_up(struct pool_map *map, d_rank_t rank);
 int ds_pool_transfer_map_buf(struct pool_buf *map_buf, uint32_t map_version,
 			     crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 			     uint32_t *required_buf_size);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1280,8 +1280,7 @@ update_pool_group(struct ds_pool *pool, struct pool_map *map)
 	D_DEBUG(DB_MD, DF_UUID": %u -> %u\n", DP_UUID(pool->sp_uuid), version,
 		pool_map_get_version(map));
 
-	rc = map_ranks_init(map, PO_COMP_ST_UP | PO_COMP_ST_UPIN |
-				 PO_COMP_ST_DRAIN | PO_COMP_ST_NEW, &ranks);
+	rc = map_ranks_init(map, POOL_GROUP_MAP_STATUS, &ranks);
 	if (rc != 0)
 		return rc;
 

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -75,6 +75,24 @@ map_ranks_fini(d_rank_list_t *ranks)
 	}
 }
 
+/**
+ * Is \a rank considered up in \a map? Note that when \a rank does not exist in
+ * \a map, false is returned.
+ */
+bool
+ds_pool_map_rank_up(struct pool_map *map, d_rank_t rank)
+{
+	struct pool_domain     *node;
+	int			rc;
+
+	rc = pool_map_find_nodes(map, rank, &node);
+	if (rc == 0)
+		return false;
+	D_ASSERTF(rc == 1, "%d\n", rc);
+
+	return node->do_comp.co_status & POOL_GROUP_MAP_STATUS;
+}
+
 int
 ds_pool_bcast_create(crt_context_t ctx, struct ds_pool *pool,
 		     enum daos_module_id module, crt_opcode_t opcode,

--- a/src/tests/ftest/erasurecode/online_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild.yaml
@@ -2,10 +2,10 @@ hosts:
   servers: !mux
     6_server:
       test_servers: server-[1-3]
-    8_server:
-      test_servers: server-[1-4]
-    12_server:
-      test_servers: server-[1-6]
+    #8_server:
+    #  test_servers: server-[1-4]
+    #12_server:
+    #  test_servers: server-[1-6]
   test_clients: 2
 timeout: 1000
 setup:


### PR DESCRIPTION
Testing whether cherry pick commit resolves pool destroy timeout
observed in release/2.2 testing of erasurecode/online_rebuild.py.

Quick-Functional: true
Test-tag: test_ec_online_rebuild_array
Test-repeat: 5
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
