### PR TITLE
DAOS-12638 tse: increase lock granularity to all progress call

### DIFF
--- a/src/tests/ftest/soak/smoke.yaml
+++ b/src/tests/ftest/soak/smoke.yaml
@@ -117,7 +117,7 @@ ior_smoke:
     mount_dir: "/tmp/daos_dfuse/ior/"
     disable_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
 fio_smoke:
   job_timeout: 10
   names:
@@ -147,7 +147,7 @@ fio_smoke:
     mount_dir: "/tmp/daos_dfuse/fio/"
     disable_wb_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
 daos_racer:
   runtime: 120
 vpic_smoke:
@@ -163,7 +163,7 @@ vpic_smoke:
     mount_dir: "/tmp/daos_dfuse/vpic/"
     disable_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
 lammps_smoke:
@@ -179,7 +179,7 @@ lammps_smoke:
     mount_dir: "/tmp/daos_dfuse/lammps/"
     disable_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
 mdtest_smoke:
@@ -210,7 +210,7 @@ mdtest_smoke:
     mount_dir: "/tmp/daos_dfuse/mdtest/"
     disable_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
 macsio_smoke:
   job_timeout: 10
   nodesperjob:
@@ -234,7 +234,7 @@ macsio_smoke:
     mount_dir: "/tmp/daos_dfuse/macsio/"
     disable_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
 datamover_smoke:
   job_timeout: 10
   nodesperjob:

--- a/src/tests/ftest/soak/stress_48h.yaml
+++ b/src/tests/ftest/soak/stress_48h.yaml
@@ -124,7 +124,7 @@ ior_stress:
     mount_dir: "/tmp/daos_dfuse/ior/"
     disable_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
 fio_stress:
   job_timeout: 30
   names:
@@ -162,7 +162,7 @@ fio_stress:
     mount_dir: "/tmp/daos_dfuse/fio/"
     disable_wb_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
 daos_racer:
   runtime: 120
 vpic_stress:
@@ -193,7 +193,7 @@ lammps_stress:
     mount_dir: "/tmp/daos_dfuse/lammps/"
     disable_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
   oclass:
     - ["EC_2P1GX", "RP_2GX"]
 mdtest_stress:
@@ -232,7 +232,7 @@ mdtest_stress:
     mount_dir: "/tmp/daos_dfuse/mdtest/"
     disable_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
 macsio_stress:
   job_timeout: 30
   nodesperjob:
@@ -263,7 +263,7 @@ macsio_stress:
     mount_dir: "/tmp/daos_dfuse/macsio/"
     disable_caching: true
     thread_count: 8
-    cores: '0-7'
+    cores: '0-3'
 datamover_stress:
   job_timeout: 10
   nodesperjob:


### PR DESCRIPTION
The tse lock should be applied overall during the progress call and when the body function, prep, and completion cbs are being executed. In a multi-threaded application, without this lock, the app ends up crashing with memory heap corruption in the client stack which manifests in different assertions and segfaults.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
