### PR TITLE
Jvolivie/test run test

### DIFF
--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -56,7 +56,7 @@ if [ "$WITH_VALGRIND" = "memcheck" ]; then
     RUN_TEST_VALGRIND="--memcheck"
 fi
 VDB_ARG=""
-if [ -d "/dev/vdb" ]; then
+if [ -b "/dev/vdb" ]; then
     VDB_ARG="--bdev=/dev/vdb"
 fi
 utils/run_utest.py $RUN_TEST_VALGRIND --no-fail-on-error $VDB_ARG

--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -59,4 +59,11 @@ RUN_TEST_VALGRIND=""
 if [ "$WITH_VALGRIND" = "memcheck" ]; then
     RUN_TEST_VALGRIND="--memcheck"
 fi
-utils/run_utest.py $RUN_TEST_VALGRIND --no-fail-on-error
+VDB_ARG=""
+if [ -d "/dev/vdb" ]; then
+    VDB_ARG="--bdev=/dev/vdb"
+fi
+
+
+
+utils/run_utest.py $RUN_TEST_VALGRIND --no-fail-on-error $VDB_ARG

--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -51,5 +51,12 @@ else
 fi
 
 sudo mount -t tmpfs -o size=16G tmpfs /mnt/daos
-USE_DEV=/dev/vdb IS_CI=true RUN_TEST_VALGRIND="$WITH_VALGRIND" DAOS_BASE="$SL_SRC_DIR" \
-    utils/run_test.sh
+# Save the old command line to avoid merge conflicts when merging to other branches
+# that may have added more testing
+# USE_DEV=/dev/vdb IS_CI=true RUN_TEST_VALGRIND="$WITH_VALGRIND" DAOS_BASE="$SL_SRC_DIR" \
+#     utils/run_test.sh
+RUN_TEST_VALGRIND=""
+if [ "$WITH_VALGRIND" = "memcheck" ]; then
+    RUN_TEST_VALGRIND="--memcheck"
+fi
+utils/run_utest.py $RUN_TEST_VALGRIND --no-fail-on-error

--- a/ci/unit/test_main_node.sh
+++ b/ci/unit/test_main_node.sh
@@ -51,10 +51,6 @@ else
 fi
 
 sudo mount -t tmpfs -o size=16G tmpfs /mnt/daos
-# Save the old command line to avoid merge conflicts when merging to other branches
-# that may have added more testing
-# USE_DEV=/dev/vdb IS_CI=true RUN_TEST_VALGRIND="$WITH_VALGRIND" DAOS_BASE="$SL_SRC_DIR" \
-#     utils/run_test.sh
 RUN_TEST_VALGRIND=""
 if [ "$WITH_VALGRIND" = "memcheck" ]; then
     RUN_TEST_VALGRIND="--memcheck"
@@ -63,7 +59,4 @@ VDB_ARG=""
 if [ -d "/dev/vdb" ]; then
     VDB_ARG="--bdev=/dev/vdb"
 fi
-
-
-
 utils/run_utest.py $RUN_TEST_VALGRIND --no-fail-on-error $VDB_ARG

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -183,9 +183,13 @@ struct bio_faulty_criteria	glb_criteria;
 static inline void
 set_faulty_criteria(void)
 {
-	glb_criteria.fc_enabled = false;
-	glb_criteria.fc_max_io_errs = 5;
-	glb_criteria.fc_max_csum_errs = 5;
+	glb_criteria.fc_enabled = true;
+	glb_criteria.fc_max_io_errs = 10;
+	/*
+	 * FIXME: Don't enable csum error criterion for now, otherwise, targets
+	 *	  be unexpectedly down in CSUM tests.
+	 */
+	glb_criteria.fc_max_csum_errs = UINT32_MAX;
 
 	d_getenv_bool("DAOS_NVME_AUTO_FAULTY_ENABLED", &glb_criteria.fc_enabled);
 	d_getenv_int("DAOS_NVME_AUTO_FAULTY_IO", &glb_criteria.fc_max_io_errs);

--- a/src/common/tests/btree.sh
+++ b/src/common/tests/btree.sh
@@ -5,7 +5,9 @@ DAOS_DIR=${DAOS_DIR:-$(cd "$cwd/../../.." && echo "$PWD")}
 source "${DAOS_DIR}/.build_vars.sh"
 BTR=${SL_BUILD_DIR}/src/common/tests/btree
 VCMD=()
+BAT_NUM=${BAT_NUM:-"20000"}
 if [ "$USE_VALGRIND" = "memcheck" ]; then
+    BAT_NUM="200"
     VCMD="valgrind --leak-check=full --show-reachable=yes --error-limit=no \
           --suppressions=${VALGRIND_SUPP} --error-exitcode=42 --xml=yes \
           --xml-file=unit-test-btree-%p.memcheck.xml"
@@ -15,7 +17,6 @@ fi
 
 ORDER=${ORDER:-3}
 DDEBUG=${DDEBUG:-0}
-BAT_NUM=${BAT_NUM:-"200000"}
 
 
 KEYS=${KEYS:-"3,6,5,7,2,1,4"}

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -547,18 +547,25 @@ func (m *Membership) handleEngineFailure(evt *events.RASEvent) {
 	//
 	// e.g. if member.Addr.IP.Equal(net.ResolveIPAddr(evt.Hostname))
 
-	ns := MemberStateErrored
-	if member.State.isTransitionIllegal(ns) {
-		m.log.Debugf("skipping %s", msgBadStateTransition(member, ns))
+	newState := MemberStateErrored
+	if member.State.isTransitionIllegal(newState) {
+		m.log.Debugf("skipping %s", msgBadStateTransition(member, newState))
 		return
 	}
 
-	member.State = ns
+	oldState := member.State
+	member.State = newState
 	member.Info = evt.Msg
 
 	if err := m.db.UpdateMember(member); err != nil {
 		m.log.Errorf("updating member with rank %d: %s", member.Rank, err)
 	}
+
+	var msg string
+	if evt.Msg != "" {
+		msg = fmt.Sprintf(" (%s)", evt.Msg)
+	}
+	m.log.Errorf("rank %d: %s->%s%s", member.Rank, oldState, newState, msg)
 }
 
 // OnEvent handles events on channel and updates member states accordingly.

--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -1094,6 +1094,9 @@ func (db *Database) handlePoolRepsUpdate(evt *events.RASEvent) {
 	if err := db.UpdatePoolService(lock.InContext(ctx), ps); err != nil {
 		db.log.Errorf("failed to apply pool service update: %s", err)
 	}
+
+	newRanks := ranklist.RankSetFromRanks(ps.Replicas)
+	db.log.Infof("pool %s: service ranks set to %s", ps.PoolLabel, newRanks)
 }
 
 // OnEvent handles events and updates system database accordingly.

--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -1527,6 +1527,7 @@ update_fetch_sv(void **state)
 			    from_vos_begin.cs_len);
 
 	daos_csummer_destroy(&csummer);
+	dcs_csum_info_list_fini(&from_vos_begin_list);
 }
 
 #define	TS(desc, test_fn) \

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -301,6 +301,11 @@ if [ -d "/mnt/daos" ]; then
              -n 10 -A -i -I -D /mnt/daos
     run_test "${SL_PREFIX}/bin/jump_pl_map"
 
+    COMP="UTEST_csum"
+    run_test "${SL_PREFIX}/bin/srv_checksum_tests"
+    run_test "${SL_PREFIX}/bin/pool_scrubbing_tests"
+    run_test "${SL_PREFIX}/bin/rpc_tests"
+
     # Tests launched by scripts
     export USE_VALGRIND=${RUN_TEST_VALGRIND}
     export VALGRIND_SUPP=${VALGRIND_SUPP}
@@ -311,11 +316,6 @@ if [ -d "/mnt/daos" ]; then
     run_test src/common/tests/btree.sh -s ${BTREE_SIZE}
     run_test src/common/tests/btree.sh dyn ukey -s ${BTREE_SIZE}
     run_test src/common/tests/btree.sh dyn -s ${BTREE_SIZE}
-
-    COMP="UTEST_csum"
-    run_test "${SL_PREFIX}/bin/srv_checksum_tests"
-    run_test "${SL_PREFIX}/bin/pool_scrubbing_tests"
-    run_test "${SL_PREFIX}/bin/rpc_tests"
 
     COMP="UTEST_vos"
     run_test src/vos/tests/evt_ctl.sh

--- a/utils/run_utest.py
+++ b/utils/run_utest.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Test script for running all DAOS unit tests
+"""
+# pylint: disable=broad-except
+import os
+import sys
+import json
+import argparse
+import shutil
+import re
+import subprocess  # nosec
+import tempfile
+import traceback
+from junit_xml import TestSuite, TestCase
+import yaml
+
+
+def write_xml_result(name, suite_junit):
+    """Write an junit result"""
+    with open(f"test_results/test_{name}.xml", "w", encoding='UTF-8') as file:
+        TestSuite.to_file(file, [suite_junit], prettyprint=True)
+
+
+def junit_name(memcheck):
+    """Get name of junit test"""
+    typestr = "native"
+    if memcheck:
+        typestr = "memcheck"
+    return f"run_utest.py.{typestr}"
+
+
+def setup_junit(memcheck):
+    """Setup single junit for whole suite"""
+    name = junit_name(memcheck)
+    test = TestCase("run_utest", name)
+    suite = TestSuite(name, [test])
+    return (suite, test)
+
+
+class BaseResults():
+    """Keep track of test results"""
+    def __init__(self):
+        """Initializes the values"""
+        self.results = {"tests": 0, "errors": 0, "failures": 0, "fail_msg": "", "error_msg": ""}
+
+    def has_failures(self):
+        """Return true if there are test failures or errors"""
+        return self.results["errors"] or self.results["failures"]
+
+    def merge(self, other):
+        """Merge results from other into self"""
+        self.results["tests"] += other.results["tests"]
+        self.results["errors"] += other.results["errors"]
+        self.results["failures"] += other.results["failures"]
+        if other.results["failures"]:
+            self.results["fail_msg"] += other.results["fail_msg"]
+        if other.results["error_msg"]:
+            self.results["error_msg"] += other.results["error_msg"]
+
+    def add_test(self):
+        """Add a test stat"""
+        self.results["tests"] += 1
+
+    def add_failure(self, fail_str):
+        """Add a failure stat"""
+        self.results["failures"] += 1
+        self.results["fail_msg"] += f"{fail_str}\n"
+
+    def add_error(self, error_str):
+        """Add an error stat"""
+        self.results["errors"] += 1
+        self.results["error_msg"] += f"{error_str}\n"
+
+
+class Results(BaseResults):
+    """Keep track of test results to produce final report"""
+    def __init__(self, memcheck):
+        """Class to keep track of results"""
+        super().__init__()
+        self.name = junit_name(memcheck)
+        self.test = TestCase("run_utest", self.name)
+        self.suite = TestSuite(self.name, [self.test])
+
+    def create_junit(self):
+        """Create the junit output"""
+        if os.environ.get("CMOCKA_XML_FILE", None) is None:
+            return
+        if self.results["failures"]:
+            self.test.add_failure_info(message=f"{self.results['failures']} of "
+                                               + f"{self.results['tests']} failed",
+                                       output=self.results["fail_msg"])
+        if self.results["errors"]:
+            self.test.add_error_info(message=f"{self.results['errors']} of "
+                                             + f"{self.results['tests']} failed",
+                                     output=self.results["error_msg"])
+        write_xml_result(self.name, self.suite)
+
+    def print_results(self):
+        """Print the output"""
+        print(f"Ran {self.results['tests']} tests, {self.results['failures']} tests failed, "
+              + f"{self.results['errors']} tests had errors")
+        if self.results["failures"]:
+            print("FAILURES:")
+            print(self.results["fail_msg"])
+        if self.results["errors"]:
+            print("ERRORS:")
+            print(self.results["error_msg"])
+
+
+class ValgrindHelper():
+    """Helper class to setup xml command"""
+    @staticmethod
+    def get_xml_name(name):
+        """Get the xml file name"""
+        return f"unit-test-{name}.memcheck.xml"
+
+    @staticmethod
+    def get_supp(base):
+        """Get suppression file"""
+        return os.path.join(base, 'utils', 'test_memcheck.supp')
+
+    @staticmethod
+    def setup_cmd(base, cmd, name):
+        """Return a new command using valgrind"""
+        cmd_prefix = ["valgrind", "--leak-check=full", "--show-reachable=yes", "--num-callers=20",
+                      "--error-limit=no", "--fair-sched=try",
+                      f"--suppressions={ValgrindHelper.get_supp(base)}",
+                      "--gen-suppressions=all", "--error-exitcode=42", "--xml=yes",
+                      f"--xml-file={ValgrindHelper.get_xml_name(name)}"]
+        return cmd_prefix + cmd
+
+
+def run_cmd(cmd, env=None):
+    """Run a command"""
+    print(f"RUNNING COMMAND {' '.join(cmd)}")
+    ret = subprocess.run(cmd, check=False, env=env)
+    print(f'rc is {ret.returncode}')
+    return ret.returncode
+
+
+class TestSkipped(Exception):
+    """Used to indicate a test is skipped"""
+
+
+class SuiteSkipped(Exception):
+    """Used to indicate a test is skipped"""
+
+
+class SuiteConfigError(Exception):
+    """Used to indicate a test is skipped"""
+
+
+def change_ownership(fname, _arg):
+    """For files created by sudo process, change the permissions and ownership"""
+    if not os.path.isfile(fname):
+        return
+    uname = os.getlogin()
+    run_cmd(["sudo", "-E", "chgrp", uname, fname])
+    run_cmd(["sudo", "-E", "chown", uname, fname])
+
+
+def process_cmocka(fname, suite_name):
+    """For files created by sudo process, change the permissions and ownership"""
+    dirname = os.path.dirname(fname)
+    basename = os.path.basename(fname)
+
+    if re.search("run_utest.py", basename):
+        return
+    if re.search("UTEST_", basename):
+        return
+    print(f"Processing cmocka {basename}")
+    target = os.path.join(dirname, f"UTEST_{suite_name}.{basename}")
+    suite = None
+    with open(target, "w", encoding='UTF-8') as outfile:
+        with open(fname, "r", encoding='UTF-8') as infile:
+            for line in infile.readlines():
+                line = line.strip()
+                if suite is None:
+                    match = re.search(r"testsuite.*name=\"(\w+)", line)
+                    if match:
+                        suite = match.group(1)
+                else:
+                    match = re.search("^(.*case )name(.*$)", line)
+                    if match:
+                        outfile.write(f"{match.group(1)}classname=\"UTEST_{suite_name}.{suite}\""
+                                      + f" name{match.group(2)}\n")
+                        continue
+                outfile.write(f"{line}\n")
+    os.unlink(fname)
+
+
+def for_each_xml(path, operate, arg):
+    """Find cmocka files, run some operation on each"""
+    for file in os.listdir(path):
+        full_path = os.path.join(path, file)
+        if not os.path.isfile(full_path):
+            continue
+        if ".xml" == os.path.splitext(file)[-1]:
+            operate(full_path, arg)
+
+
+class AIO():
+    """Handle AIO specific setup and teardown"""
+    def __init__(self, mount, device=None):
+        """Initialize an AIO device"""
+        self.config_name = os.path.join(mount, "daos_nvme.conf")
+        self.device = device
+        self.current_info = {}
+        self.fname = None
+        self.ready = False
+
+    def initialize(self):
+        """Initialize global AIO information"""
+        if self.ready:
+            return
+        if self.device is not None:
+            self.fname = self.device
+            print(f"Using aio device {self.fname}")
+            return
+        (_fd, self.fname) = tempfile.mkstemp(prefix="aio_", dir="/tmp")
+        self.ready = True
+        print(f"Using aio file {self.fname}")
+
+    def create_config(self, name):
+        """Create the AIO config file"""
+
+        contents = f"""
+{{
+  "daos_data": {{
+    "config": []
+  }},
+  "subsystems": [
+    {{
+      "subsystem": "bdev",
+      "config": [
+        {{
+          "params": {{
+            "bdev_io_pool_size": 65536,
+            "bdev_io_cache_size": 256
+          }},
+          "method": "bdev_set_options"
+        }},
+        {{
+          "params": {{
+            "retry_count": 4,
+            "timeout_us": 0,
+            "nvme_adminq_poll_period_us": 100000,
+            "action_on_timeout": "none",
+            "nvme_ioq_poll_period_us": 0
+          }},
+          "method": "bdev_nvme_set_options"
+        }},
+        {{
+          "params": {{
+            "enable": false,
+            "period_us": 0
+          }},
+          "method": "bdev_nvme_set_hotplug"
+        }},
+        {{
+          "params": {{
+            "block_size": 4096,
+            "name": "{name}",
+            "filename": "{self.fname}"
+          }},
+          "method": "bdev_aio_create"
+        }}
+      ]
+    }}
+  ]
+}}
+"""
+        with open(self.config_name, "w", encoding='UTF-8') as config_file:
+            config_file.write(contents)
+
+    def prepare_test(self, name="AIO_1", min_size=4):
+        """Prepare AIO for a test, min_size in GB"""
+        if self.device is None:
+            run_cmd(["dd", "if=/dev/zero", f"of={self.fname}", "bs=1G", f"count={min_size}"])
+        else:
+            run_cmd(["dd", "if=/dev/zero", f"of={self.fname}", "bs=4K", "count=1"])
+        self.create_config(name)
+
+    def finalize_test(self):
+        """Finalize AIO for a test"""
+        if self.device is None:
+            os.unlink(self.fname)
+        if os.path.exists(self.config_name):
+            os.unlink(self.config_name)
+
+    def finalize(self):
+        """Finalize global AIO information"""
+        if self.ready and self.device is None:
+            if os.path.exists(self.fname):
+                os.unlink(self.fname)
+        if os.path.exists(self.config_name):
+            os.unlink(self.config_name)
+
+
+class Test():
+    """Define a test"""
+
+    test_num = 1
+
+    def __init__(self, config, build_info, args):
+        """Initialize a test"""
+        self.cmd = config["cmd"]
+        self.env = os.environ.copy()
+        self.last = []
+        env_vars = config.get("env_vars", {})
+        if env_vars:
+            self.env.update(env_vars)
+        self.warn_if_missing = config.get("warn_if_missing", None)
+        self.aio = {"aio": config.get("aio", None),
+                    "size": config.get("size", 4)}
+        if self.filter(args.test_filter):
+            print(f"Filtered test  {' '.join(self.cmd)}")
+            raise TestSkipped()
+
+        self.root = build_info["DAOS_BASE"]
+        self.res_path = os.path.join(self.root, "test_results")
+        self.env["D_LOG_FILE"] = os.path.join("/tmp", f"{self.name}.log")
+        Test.test_num = Test.test_num + 1
+
+        if self.needs_aio():
+            self.env["VOS_BDEV_CLASS"] = "AIO"
+
+    def filter(self, test_filter):
+        """Determine if the test should run"""
+        if test_filter is None:
+            return False
+
+        if re.search(test_filter, ' '.join(self.cmd), re.IGNORECASE):
+            return False
+
+        return True
+
+    def name(self):
+        """Return derived name"""
+        return '-'.join(self.cmd).replace(';', '-').replace('/', '-') + f"_{Test.test_num}"
+
+    def needs_aio(self):
+        """Returns true if the test uses aio"""
+        return self.aio["aio"] is not None
+
+    def get_last(self):
+        """Retrieve the last command run"""
+        return self.last
+
+    def setup(self, base, aio):
+        """Setup the test"""
+        fname = os.path.join(base, self.cmd[0])
+        if not os.path.isfile(fname):
+            if self.warn_if_missing:
+                print(f"{fname} is not found\n{self.warn_if_missing}")
+                return False
+            raise FileNotFoundError(fname)
+        if self.needs_aio():
+            aio.prepare_test(self.aio["aio"], self.aio["size"])
+
+        return True
+
+    def run(self, base, memcheck, sudo):
+        """Run the test"""
+        cmd = [os.path.join(base, self.cmd[0])] + self.cmd[1:]
+        if memcheck:
+            if os.path.splitext(cmd[0])[-1] in [".sh", ".py"]:
+                self.env.update({"USE_VALGRIND": "memcheck",
+                                 "VALGRIND_SUPP": ValgrindHelper.get_supp(self.root)})
+            else:
+                cmd = ValgrindHelper.setup_cmd(self.root, cmd, self.name())
+        if sudo:
+            new_cmd = ["sudo", "-E"]
+            new_cmd.extend(cmd)
+            cmd = new_cmd
+        self.last = cmd
+
+        return run_cmd(cmd, self.env)
+
+    def teardown(self, suite_name, aio, sudo):
+        """Teardown the test"""
+        if self.needs_aio():
+            aio.finalize_test()
+        if sudo:
+            change_ownership(ValgrindHelper.get_xml_name(self.name()), None)
+            change_ownership(self.env["D_LOG_FILE"], None)
+            if self.env.get("CMOCKA_XML_FILE", None):
+                for_each_xml(self.res_path, change_ownership, None)
+        for_each_xml(self.res_path, process_cmocka, suite_name)
+
+
+class Suite():
+    """Define a suite"""
+    def __init__(self, build_info, config, args):
+        """Initialize a test suite"""
+        self.name = config["name"]
+        val = config.get("base", "DAOS_BASE")
+        self.base = build_info.get(val, None)
+        if self.base is None:
+            print(f"{val} not found in build_info")
+            raise SuiteConfigError()
+        self.sudo = config.get("sudo", None)
+        self.memcheck = config.get("memcheck", True)
+        self.tests = []
+        self.has_aio = False
+
+        if self.filter(args.suite_filter):
+            print(f"Filtered suite {self.name}")
+            raise SuiteSkipped()
+
+        if args.no_sudo and self.sudo:
+            print(f"Skipped  suite {self.name}, requires sudo")
+            raise SuiteSkipped()
+
+        if args.memcheck and not self.memcheck:
+            print(f"Skipped  suite {self.name}, valgrind not supported")
+            raise SuiteSkipped()
+
+        for test in config["tests"]:
+            try:
+                real_test = Test(test, build_info, args)
+            except TestSkipped:
+                continue
+            if real_test.needs_aio():
+                self.has_aio = True
+            self.tests.append(real_test)
+        if not self.tests:
+            print(f"Skipped  suite {self.name}, no tests matched filters")
+            raise SuiteSkipped()
+
+    def needs_aio(self):
+        """The suite needs to use aio"""
+        return self.has_aio
+
+    def filter(self, suite_filter):
+        """Determine if suite should run"""
+        if suite_filter is None:
+            return False
+
+        if re.search(suite_filter, self.name, re.IGNORECASE):
+            return False
+
+        return True
+
+    def run_suite(self, args, aio):
+        """Run the test suite"""
+        print(f"\nRunning suite {self.name}")
+        results = BaseResults()
+
+        if self.needs_aio() and aio is not None:
+            aio.initialize()
+        for test in self.tests:
+            run_test = True
+            ret = 0
+            try:
+                if not test.setup(self.base, aio):
+                    continue
+            except Exception:
+                results.add_error(f"{traceback.format_exc()}")
+                run_test = False
+            results.add_test()
+            if run_test:
+                try:
+                    ret = test.run(self.base, args.memcheck, self.sudo)
+                    if ret != 0:
+                        results.add_failure(f"{' '.join(test.get_last())}")
+                except Exception:
+                    results.add_error(f"{traceback.format_exc()}")
+                    ret = 1  # prevent reporting errors on teardown too
+            try:
+                test.teardown(self.name, aio, self.sudo)
+            except Exception:
+                if not run_test or ret != 0:
+                    pass
+                results.add_error(f"{traceback.format_exc()}")
+
+        if self.needs_aio() and aio is not None:
+            aio.finalize()
+        return results
+
+
+def run_suites(args, suites, results, aio):
+    """Run a set of suites"""
+    for suite in suites:
+        results.merge(suite.run_suite(args, aio))
+
+
+def move_codecov(base):
+    """Move any code coverage results"""
+    try:
+        target = "/tmp/test.cov"
+        if os.path.isfile(target):
+            os.unlink(target)
+        src = os.path.join(base, "test.cov")
+        if os.path.isfile(target):
+            shutil.move(src, target)
+    except Exception:
+        print("Exception trying to copy test.cov")
+        traceback.print_exc()
+
+
+def get_args():
+    """Parse the arguments"""
+    parser = argparse.ArgumentParser(description='Run DAOS unit tests')
+    parser.add_argument('--memcheck', action='store_true', help='Run tests with Valgrind memcheck')
+    parser.add_argument('--test_filter', default=None,
+                        help='Regular expression to select tests to run')
+    parser.add_argument('--suite_filter', default=None,
+                        help='Regular expression to select suites to run')
+    parser.add_argument('--no-fail-on-error', action='store_true',
+                        help='Disable non-zero return code on failure')
+    parser.add_argument('--no_sudo', action='store_true', help='Disable tests requiring sudo')
+    parser.add_argument('--mount', default="/mnt/daos",
+                        help="Specify location of mounted dax system to use")
+    parser.add_argument('--bdev', default=None,
+                        help="Device to use for AIO, will create file by default")
+    return parser.parse_args()
+
+
+def get_build_info():
+    """Retrieve the build variables"""
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    daos_base = os.path.realpath(os.path.join(script_dir, '..'))
+    build_vars_file = os.path.join(daos_base, '.build_vars.json')
+    build_info = {"DAOS_BASE": daos_base,
+                  "UTEST_YAML": os.path.join(daos_base, "utils", "utest.yaml")}
+    try:
+        with open(build_vars_file, "r", encoding="UTF-8") as vars_file:
+            build_vars = json.load(vars_file)
+        build_info.update(build_vars)
+    except ValueError as error:
+        print(f"Could not load json build info {build_vars_file}, have you built DAOS")
+        print(f"{error}")
+        sys.exit(-1)
+
+    return build_info
+
+
+def main():
+    """Run the the core tests"""
+    args = get_args()
+    build_info = get_build_info()
+
+    os.makedirs(os.path.join(build_info["DAOS_BASE"], "test_results"), exist_ok=True)
+
+    aio = None
+
+    if not args.no_sudo:
+        aio = AIO(args.mount, args.bdev)
+
+    suites = []
+    with open(build_info["UTEST_YAML"], "r", encoding="UTF-8") as file:
+        all_suites = yaml.safe_load(file)
+
+    for suite_yaml in all_suites:
+        try:
+            real_suite = Suite(build_info, suite_yaml, args)
+        except SuiteSkipped:
+            continue
+        except SuiteConfigError as exception:
+            print(f"Error processing {build_info['UTEST_YAML']} {exception}")
+            raise exception
+        except (KeyError, ValueError) as exception:
+            print(f"Error processing {build_info['UTEST_YAML']}")
+            raise exception
+        suites.append(real_suite)
+    results = Results(args.memcheck)
+    run_suites(args, suites, results, aio=aio)
+
+    results.print_results()
+
+    results.create_junit()
+
+    move_codecov(build_info["DAOS_BASE"])
+
+    if args.no_fail_on_error:
+        return
+
+    if results.has_failures():
+        sys.exit(-1)
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/run_utest.py
+++ b/utils/run_utest.py
@@ -326,7 +326,7 @@ class Test():
             self.env["VOS_BDEV_CLASS"] = "AIO"
 
     def subst(self, cmd, replacements, path_info):
-        """Make any substituations for variables in path_info"""
+        """Make any substitutions for variables in path_info"""
         if not replacements:
             return cmd
 

--- a/utils/utest.yaml
+++ b/utils/utest.yaml
@@ -3,7 +3,6 @@
   tests:
     - cmd: ["src/common/tests/umem_test"]
     - cmd: ["src/common/tests/sched"]
-    - cmd: ["src/common/tests/drpc_tests"]
     - cmd: ["src/common/tests/acl_api_tests"]
     - cmd: ["src/common/tests/acl_valid_tests"]
     - cmd: ["src/common/tests/acl_util_tests"]
@@ -36,13 +35,15 @@
     - cmd: ["src/common/tests/btree.sh", "ukey"]
     - cmd: ["src/common/tests/btree.sh", "dyn", "ukey"]
     - cmd: ["src/common/tests/btree.sh", "dyn"]
-- name: engine
+- name: drpc
   base: "BUILD_DIR"
   tests:
+    - cmd: ["src/common/tests/drpc_tests"]
     - cmd: ["src/engine/tests/drpc_client_tests"]
     - cmd: ["src/engine/tests/drpc_progress_tests"]
     - cmd: ["src/engine/tests/drpc_handler_tests"]
     - cmd: ["src/engine/tests/drpc_listener_tests"]
+    - cmd: ["src/mgmt/tests/srv_drpc_tests"]
 - name: gurt
   base: "BUILD_DIR"
   tests:

--- a/utils/utest.yaml
+++ b/utils/utest.yaml
@@ -1,0 +1,147 @@
+- name: common
+  base: "BUILD_DIR"
+  tests:
+    - cmd: ["src/common/tests/umem_test"]
+    - cmd: ["src/common/tests/sched"]
+    - cmd: ["src/common/tests/drpc_tests"]
+    - cmd: ["src/common/tests/acl_api_tests"]
+    - cmd: ["src/common/tests/acl_valid_tests"]
+    - cmd: ["src/common/tests/acl_util_tests"]
+    - cmd: ["src/common/tests/acl_principal_tests"]
+    - cmd: ["src/common/tests/acl_real_tests"]
+    - cmd: ["src/common/tests/prop_tests"]
+    - cmd: ["src/common/tests/fault_domain_tests"]
+- name: btree_stress
+  memcheck: False
+  tests:
+    - cmd: ["src/common/tests/btree.sh", "perf"]
+    - cmd: ["src/common/tests/btree.sh", "perf", "direct"]
+    - cmd: ["src/common/tests/btree.sh", "perf", "ukey"]
+    - cmd: ["src/common/tests/btree.sh", "dyn", "perf"]
+    - cmd: ["src/common/tests/btree.sh", "dyn", "perf", "ukey"]
+- name: btree
+  tests:
+    - cmd: ["src/common/tests/btree.sh"]
+    - cmd: ["src/common/tests/btree.sh", "direct"]
+    - cmd: ["src/common/tests/btree.sh", "ukey"]
+    - cmd: ["src/common/tests/btree.sh", "dyn", "ukey"]
+    - cmd: ["src/common/tests/btree.sh", "dyn"]
+- name: engine
+  base: "BUILD_DIR"
+  tests:
+    - cmd: ["src/engine/tests/drpc_client_tests"]
+    - cmd: ["src/engine/tests/drpc_progress_tests"]
+    - cmd: ["src/engine/tests/drpc_handler_tests"]
+    - cmd: ["src/engine/tests/drpc_listener_tests"]
+- name: gurt
+  base: "BUILD_DIR"
+  tests:
+    - cmd: ["src/gurt/tests/test_gurt"]
+    - cmd: ["src/gurt/tests/test_gurt_telem_producer"]
+- name: mgmt
+  base: "BUILD_DIR"
+  tests:
+    - cmd: ["src/mgmt/tests/srv_drpc_tests"]
+- name: csum_server
+  base: "PREFIX"
+  tests:
+    - cmd: ["bin/srv_checksum_tests"]
+- name: placement
+  base: "PREFIX"
+  tests:
+    - cmd: ["bin/jump_pl_map"]
+- name: rdb
+  memcheck: False
+  tests:
+    - cmd: ["src/rdb/raft_tests/raft_tests.py"]
+- name: security
+  base: "BUILD_DIR"
+  tests:
+    - cmd: ["src/security/tests/cli_security_tests"]
+    - cmd: ["src/security/tests/srv_acl_tests"]
+- name: rpc
+  base: "PREFIX"
+  tests:
+    - cmd: ["bin/rpc_tests"]
+- name: vea
+  base: "PREFIX"
+  tests:
+    - cmd: ["bin/vea_ut"]
+    - cmd: ["bin/vea_stress", "-d", "60"]
+- name: vea_debug
+  base: "PREFIX"
+  tests:
+    - cmd: ["bin/vea_ut"]
+      env_vars:
+        D_LOG_MASK: "debug"
+        DD_SUBSYS: "all"
+        DD_MASK: "all"
+- name: VOS
+  base: "PREFIX"
+  tests:
+    - cmd: ["bin/vos_perf", "-R", '"U;p F;p V"', "-o", "5", "-d", "5", "-a", "5", "-n", "10"]
+    - cmd: ["bin/vos_perf", "-R", '"U;p F;p V"', "-o", "5", "-d", "5", "-a", "5", "-n", "10",
+            "-A", "-D", "/mnt/../mnt/daos"]
+    - cmd: ["bin/vos_perf", "-R", '"U Q;p V"', "-o", "5", "-d", "5", "-n", "10", "-A", "-i",
+            "-I", "-D", "/mnt.daos"]
+    - cmd: ["bin/vos_tests", "-A", "500"]
+    - cmd: ["bin/vos_tests", "-r",
+            "-c pool -w key@0-4 -w key@3-4 -R key@3-3 -w key@5-4 -R key@5-3 -a -i -d -D"]
+    - cmd: ["bin/vos_tests", "-r",
+            "-c pool -w key@0-3 -w key@3-4 -w key@5-1 -w key@5-4 -R key@5-3 -a -i -d -D"]
+    - cmd: ["bin/vos_tests", "-r", "-c pool -x key@10-400 -i -d -o pool -a -i -d -D"]
+    - cmd: ["bin/vos_tests", "-C"]
+      env_vars:
+        DAOS_DKEY_PUNCH_PROPAGATE: "1"
+- name: VOS_evtree
+  tests:
+    - cmd: ["src/vos/tests/evt_ctl.sh"]
+- name: VOS_evtree_stress
+  memcheck: False
+  tests:
+    - cmd: ["src/vos/tests/evt_stress.py"]
+    - cmd: ["src/vos/tests/evt_stress.py", "--algo", "soff"]
+    - cmd: ["src/vos/tests/evt_stress.py", "--algo", "dist_even"]
+- name: VOS_NVMe
+  base: "PREFIX"
+  sudo: True
+  memcheck: False
+  tests:
+    - cmd: ["bin/vos_tests", "-a"]
+      aio: "AIO_1"
+      size: 4
+- name: csum_scrubber
+  base: "PREFIX"
+  tests:
+    - cmd: ["bin/pool_scrubbing_tests"]
+- name: bio
+  base: "BUILD_DIR"
+  tests:
+    - cmd: ["src/bio/smd/tests/smd_ut"]
+- name: client
+  base: "PREFIX"
+  tests:
+    - cmd: ["bin/eq_tests"]
+    - cmd: ["bin/agent_tests"]
+    - cmd: ["bin/job_tests"]
+- name: cart
+  base: "BUILD_DIR"
+  tests:
+    - cmd: ["src/tests/ftest/cart/utest/test_linkage"]
+    - cmd: ["src/tests/ftest/cart/utest/utest_hlc"]
+    - cmd: ["src/tests/ftest/cart/utest/utest_swim"]
+- name: storage_estimator
+  base: "DAOS_BASE"
+  memcheck: False
+  tests:
+    - cmd: ["src/vos/storage_estimator/common/tests/storage_estimator.sh"]
+- name: control
+  memcheck: False
+  tests:
+    - cmd: ["src/control/run_go_tests.sh"]
+- name: spdk
+  base: "PREFIX"
+  memcheck: False
+  tests:
+    - cmd: ["bin/nvme_control_ctests"]
+      warn_if_missing: "bin/nvme_control_ctests is missing, SPDK_SRC not available when built?"

--- a/utils/utest.yaml
+++ b/utils/utest.yaml
@@ -11,6 +11,16 @@
     - cmd: ["src/common/tests/acl_real_tests"]
     - cmd: ["src/common/tests/prop_tests"]
     - cmd: ["src/common/tests/fault_domain_tests"]
+    - cmd: ["src/common/tests/ad_mem_tests"]
+      warn_if_missing: "ad_mem_tests is missing, are you on feature/vos_on_blob branch?"
+    - cmd: ["src/common/tests/umem_tests_bmem"]
+      warn_if_missing: "umem_tests_bmem is missing, are you on feature/vos_on_blob branch?"
+- name: common_md_on_ssd
+  base: "BUILD_DIR"
+  required_src: ["src/common/tests/ad_mem_tests.c"]
+  tests:
+    - cmd: ["src/common/tests/ad_mem_tests"]
+    - cmd: ["src/common/tests/umem_tests_bmem"]
 - name: btree_stress
   memcheck: False
   tests:
@@ -81,9 +91,11 @@
   tests:
     - cmd: ["bin/vos_perf", "-R", '"U;p F;p V"', "-o", "5", "-d", "5", "-a", "5", "-n", "10"]
     - cmd: ["bin/vos_perf", "-R", '"U;p F;p V"', "-o", "5", "-d", "5", "-a", "5", "-n", "10",
-            "-A", "-D", "/mnt/../mnt/daos"]
+            "-A", "-D", "/mnt/..MOUNT"]
+      replace_path: {"MOUNT": "MOUNT_DIR"}
     - cmd: ["bin/vos_perf", "-R", '"U Q;p V"', "-o", "5", "-d", "5", "-n", "10", "-A", "-i",
-            "-I", "-D", "/mnt.daos"]
+            "-I", "-D", "MOUNT"]
+      replace_path: {"MOUNT": "MOUNT_DIR"}
     - cmd: ["bin/vos_tests", "-A", "500"]
     - cmd: ["bin/vos_tests", "-r",
             "-c pool -w key@0-4 -w key@3-4 -R key@3-3 -w key@5-4 -R key@5-3 -a -i -d -D"]
@@ -109,6 +121,18 @@
   tests:
     - cmd: ["bin/vos_tests", "-a"]
       aio: "AIO_1"
+      size: 4
+- name: VOS_md_on_ssd
+  base: "PREFIX"
+  sudo: True
+  memcheck: False
+  required_src: ["src/bio/tests/bio_ut.c"]
+  tests:
+    - cmd: ["bin/vos_tests", "-A", "50"]
+      aio: "AIO_7"
+      size: 13
+    - cmd: ["bin/bio_ut"]
+      aio: "AIO_7"
       size: 4
 - name: csum_scrubber
   base: "PREFIX"
@@ -145,3 +169,8 @@
   tests:
     - cmd: ["bin/nvme_control_ctests"]
       warn_if_missing: "bin/nvme_control_ctests is missing, SPDK_SRC not available when built?"
+- name: ddb
+  base: "PREFIX"
+  required_src: ["src/ddb/tests/SConscript"]
+  tests:
+    - cmd: ["bin/ddb_tests"]

--- a/utils/utest.yaml
+++ b/utils/utest.yaml
@@ -19,7 +19,7 @@
   required_src: ["src/common/tests/ad_mem_tests.c"]
   tests:
     - cmd: ["src/common/tests/ad_mem_tests"]
-    - cmd: ["src/common/tests/umem_tests_bmem"]
+    - cmd: ["src/common/tests/umem_test_bmem"]
 - name: btree_stress
   memcheck: False
   tests:
@@ -49,14 +49,6 @@
   tests:
     - cmd: ["src/gurt/tests/test_gurt"]
     - cmd: ["src/gurt/tests/test_gurt_telem_producer"]
-- name: mgmt
-  base: "BUILD_DIR"
-  tests:
-    - cmd: ["src/mgmt/tests/srv_drpc_tests"]
-- name: csum_server
-  base: "PREFIX"
-  tests:
-    - cmd: ["bin/srv_checksum_tests"]
 - name: placement
   base: "PREFIX"
   tests:
@@ -70,10 +62,6 @@
   tests:
     - cmd: ["src/security/tests/cli_security_tests"]
     - cmd: ["src/security/tests/srv_acl_tests"]
-- name: rpc
-  base: "PREFIX"
-  tests:
-    - cmd: ["bin/rpc_tests"]
 - name: vea
   base: "PREFIX"
   tests:
@@ -135,10 +123,12 @@
     - cmd: ["bin/bio_ut"]
       aio: "AIO_7"
       size: 4
-- name: csum_scrubber
+- name: csum
   base: "PREFIX"
   tests:
+    - cmd: ["bin/rpc_tests"]
     - cmd: ["bin/pool_scrubbing_tests"]
+    - cmd: ["bin/srv_checksum_tests"]
 - name: bio
   base: "BUILD_DIR"
   tests:


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
