### PR TITLE
DAOS-13074 test: target_failure.py - Set container property to health…

### DIFF
--- a/src/tests/ftest/deployment/target_failure.py
+++ b/src/tests/ftest/deployment/target_failure.py
@@ -144,6 +144,10 @@ class TargetFailure(IorTestBase):
         self.pool.measure_rebuild_time(
             operation="Reintegrate rank 0 -> target 1", interval=5)
 
+        # Container status doesn't automatically go back to healthy after reintegrate. We
+        # need to manually set it.
+        self.container.set_prop(prop='status', value="healthy")
+
         # 7. Verify that the container's Health property is HEALTHY.
         if not self.container.verify_health(expected_health="HEALTHY"):
             errors.append("Container health isn't HEALTHY after reintegrate!")
@@ -202,7 +206,7 @@ class TargetFailure(IorTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium,ib2
         :avocado: tags=deployment,target_failure
-        :avocado: tags=target_failure_wo_rf
+        :avocado: tags=TargetFailure,target_failure_wo_rf
         """
         # 1. Create a pool and a container.
         self.add_pool(namespace="/run/pool_size_ratio_80/*")
@@ -248,6 +252,10 @@ class TargetFailure(IorTestBase):
         self.pool.reintegrate(rank="1", tgt_idx="0")
         self.pool.measure_rebuild_time(operation="Reintegrate 1 target", interval=5)
 
+        # Container status doesn't automatically go back to healthy after reintegrate. We
+        # need to manually set it.
+        self.container.set_prop(prop='status', value="healthy")
+
         # 7. Verify that the container's Health property is HEALTHY.
         if not self.container.verify_health(expected_health="HEALTHY"):
             errors.append("Container health isn't HEALTHY after reintegrate!")
@@ -281,7 +289,7 @@ class TargetFailure(IorTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium,ib2
         :avocado: tags=deployment,target_failure
-        :avocado: tags=target_failure_with_rp
+        :avocado: tags=TargetFailure,target_failure_with_rp
         """
         self.verify_failure_with_protection(ior_namespace="/run/ior_with_rp/*")
 
@@ -297,7 +305,7 @@ class TargetFailure(IorTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium,ib2
         :avocado: tags=deployment,target_failure
-        :avocado: tags=target_failure_with_ec
+        :avocado: tags=TargetFailure,target_failure_with_ec
         """
         self.verify_failure_with_protection(ior_namespace="/run/ior_with_ec/*")
 
@@ -320,7 +328,7 @@ class TargetFailure(IorTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=hw,medium,ib2
         :avocado: tags=deployment,target_failure
-        :avocado: tags=target_failure_parallel
+        :avocado: tags=TargetFailure,target_failure_parallel
         """
         self.pool = []
         self.container = []
@@ -390,6 +398,10 @@ class TargetFailure(IorTestBase):
         self.pool[excluded_pool_num].reintegrate(rank="1", tgt_idx="0")
         self.pool[excluded_pool_num].measure_rebuild_time(
             operation="Reintegrate 1 target", interval=5)
+
+        # Container status doesn't automatically go back to healthy after reintegrate. We
+        # need to manually set it.
+        self.container[1].set_prop(prop='status', value="healthy")
 
         # 8. Verify that self.container[1]'s Health property is HEALTHY.
         if not self.container[1].verify_health(expected_health="HEALTHY"):

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -902,7 +902,7 @@ class TestContainer(TestDaosApiBase):
         if not self.daos:
             raise DaosTestError("Undefined daos command")
         return self.daos.container_set_prop(
-            pool=self.pool.identifier, cont=self.identifier, *args, **kwargs)
+            pool=self.pool.identifier, cont=self.label.value, *args, **kwargs)
 
     @fail_on(CommandFailure)
     def get_prop(self, properties=None):

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -902,7 +902,7 @@ class TestContainer(TestDaosApiBase):
         if not self.daos:
             raise DaosTestError("Undefined daos command")
         return self.daos.container_set_prop(
-            pool=self.pool.identifier, cont=self.label.value, *args, **kwargs)
+            pool=self.pool.identifier, cont=self.uuid, *args, **kwargs)
 
     @fail_on(CommandFailure)
     def get_prop(self, properties=None):

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -884,6 +884,27 @@ class TestContainer(TestDaosApiBase):
         return count
 
     @fail_on(CommandFailure)
+    def set_prop(self, *args, **kwargs):
+        """Set container properties by calling daos container set-prop.
+
+        Args:
+            args (tuple, optional): positional arguments to DaosCommand.container_set_prop
+            kwargs (dict, optional): named arguments to DaosCommand.container_set_prop
+
+        Returns:
+            str: JSON output of daos container set-prop.
+
+        Raises:
+            DaosTestError: if params are invalid
+            CommandFailure: Raised from the daos command call.
+
+        """
+        if not self.daos:
+            raise DaosTestError("Undefined daos command")
+        return self.daos.container_set_prop(
+            pool=self.pool.identifier, cont=self.identifier, *args, **kwargs)
+
+    @fail_on(CommandFailure)
     def get_prop(self, properties=None):
         """Get container property by calling daos container get-prop.
 


### PR DESCRIPTION
…y after reintegrate

PR11467 updated the container behavior so that a pool reintegrate will not change the container status. The test was expecting the container status to automatically go back to healthy after the reintegrate. Update the test to manually set it to healthy.

PR11467 was cherry-picked to 2.2, but the change in target_failure.py hasn't been included probably because it needed some changes in the test util files. Updated test_utils_container.py to support daos container set-prop.

Added test tags.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: TargetFailure
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
