### PR TITLE
DAOS-13114 control: Add batching support for PoolEvict requests

### DIFF
--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -137,7 +137,7 @@ func getPeerListenAddr(ctx context.Context, listenAddrStr string) (*net.TCPAddr,
 
 const (
 	groupUpdateInterval = 500 * time.Millisecond
-	batchJoinInterval   = 250 * time.Millisecond
+	batchLoopInterval   = 250 * time.Millisecond
 )
 
 type (
@@ -156,20 +156,16 @@ type (
 	joinReqChan chan *batchJoinRequest
 )
 
-func (svc *mgmtSvc) startJoinLoop(ctx context.Context) {
-	svc.log.Debug("starting joinLoop")
-	go svc.joinLoop(ctx)
-}
-
 func (svc *mgmtSvc) joinLoop(parent context.Context) {
 	var joinReqs []*batchJoinRequest
 	var groupUpdateNeeded bool
 
-	joinTimer := time.NewTicker(batchJoinInterval)
+	joinTimer := time.NewTicker(batchLoopInterval)
 	defer joinTimer.Stop()
 	groupUpdateTimer := time.NewTicker(groupUpdateInterval)
 	defer groupUpdateTimer.Stop()
 
+	svc.log.Debug("starting joinLoop")
 	for {
 		select {
 		case <-parent.Done():

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -2001,7 +2001,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			svc.startJoinLoop(ctx)
+			svc.startBatchLoops(ctx)
 
 			if tc.req.Sys == "" {
 				tc.req.Sys = build.DefaultSystemName

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -420,7 +420,7 @@ func (srv *server) registerEvents() {
 	srv.sysdb.OnLeadershipGained(
 		func(ctx context.Context) error {
 			srv.log.Infof("MS leader running on %s", srv.hostname)
-			srv.mgmtSvc.startJoinLoop(ctx)
+			srv.mgmtSvc.startBatchLoops(ctx)
 			registerLeaderSubscriptions(srv)
 			srv.log.Debugf("requesting sync GroupUpdate after leader change")
 			go func() {


### PR DESCRIPTION
The PoolEvict gRPC handler may be invoked from N agents in the
event of a large-scale application crash. This would result in
N dRPC requests from the MS leader to its local engine in order
to evict the pool handles in those requests. With this commit,
a batching mechanism is added to improve performance in these
large-scale events so that N agent requests are consolidated
into a smaller number of dRPC requests containing multiple
handles.

Also improves agent logging of evicted handles due to application
crash by including the process name and logging a single line
at INFO level instead of DEBUG.

Features: pool control
Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
