### PR TITLE
DAOS-12922 pool: Fix checkpoint property upgrade

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -98,8 +98,8 @@ struct ds_pool {
 	uint64_t		sp_scrub_freq_sec;
 	uint64_t		sp_scrub_thresh;
 	/** WAL checkpointing properties */
-	uint64_t                 sp_checkpoint_mode;
-	uint64_t                 sp_checkpoint_freq;
+	uint32_t                 sp_checkpoint_mode;
+	uint32_t                 sp_checkpoint_freq;
 	uint32_t                 sp_checkpoint_thresh;
 };
 

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -73,8 +73,8 @@ struct pool_iv_prop {
 	uint32_t	pip_global_version;
 	uint32_t	pip_upgrade_status;
 	uint64_t	pip_svc_redun_fac;
-	uint64_t	pip_checkpoint_mode;
-	uint64_t	pip_checkpoint_freq;
+	uint32_t         pip_checkpoint_mode;
+	uint32_t         pip_checkpoint_freq;
 	uint32_t	pip_checkpoint_thresh;
 	uint32_t	pip_obj_version;
 	struct daos_acl	*pip_acl;

--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -73,8 +73,8 @@ extern d_iov_t ds_pool_prop_scrub_freq;		/* uint64_t */
 extern d_iov_t ds_pool_prop_scrub_thresh;	/* uint64_t */
 extern d_iov_t ds_pool_prop_svc_redun_fac;	/* uint64_t */
 extern d_iov_t ds_pool_prop_obj_version;	/* uint32_t */
-extern d_iov_t ds_pool_prop_checkpoint_mode;    /* uint64_t */
-extern d_iov_t ds_pool_prop_checkpoint_freq;    /* uint64_t */
+extern d_iov_t ds_pool_prop_checkpoint_mode;    /* uint32_t */
+extern d_iov_t ds_pool_prop_checkpoint_freq;    /* uint32_t */
 extern d_iov_t ds_pool_prop_checkpoint_thresh;  /* uin32_t */
 /* Please read the IMPORTANT notes above before adding new keys. */
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4981,10 +4981,14 @@ ds_pool_mark_upgrade_completed_internal(struct pool_svc *svc, int ret)
 {
 	int rc;
 
+	D_DEBUG(DB_REBUILD, "ret passed in is " DF_RC "\n", DP_RC(ret));
+
 	if (ret == 0)
 		ret = ds_cont_upgrade(svc->ps_uuid, svc->ps_cont_svc);
+	D_DEBUG(DB_REBUILD, "ret now is " DF_RC "\n", DP_RC(ret));
 
 	rc = __ds_pool_mark_upgrade_completed(svc->ps_uuid, svc, ret);
+	D_DEBUG(DB_REBUILD, "rc is " DF_RC "\n", DP_RC(rc));
 	if (rc == 0 && ret)
 		rc = ret;
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4617,6 +4617,11 @@ pool_upgrade_one_prop_int64(struct rdb_tx *tx, struct pool_svc *svc, uuid_t uuid
 	d_iov_set(&value, &val, sizeof(default_value));
 	rc = rdb_tx_lookup(tx, &svc->ps_root, prop_iov, &value);
 	if (rc && rc != -DER_NONEXIST) {
+		if (rc) {
+			D_ERROR(DF_UUID ": failed to upgrade '%s' of pool: %d.\n", DP_UUID(uuid),
+				friendly_name, rc);
+			return rc;
+		}
 		return rc;
 	} else if (rc == -DER_NONEXIST) {
 		val = default_value;
@@ -4642,6 +4647,11 @@ pool_upgrade_one_prop_int32(struct rdb_tx *tx, struct pool_svc *svc, uuid_t uuid
 	d_iov_set(&value, &val, sizeof(default_value));
 	rc = rdb_tx_lookup(tx, &svc->ps_root, prop_iov, &value);
 	if (rc && rc != -DER_NONEXIST) {
+		if (rc) {
+			D_ERROR(DF_UUID ": failed to upgrade '%s' of pool: %d.\n", DP_UUID(uuid),
+				friendly_name, rc);
+			return rc;
+		}
 		return rc;
 	} else if (rc == -DER_NONEXIST) {
 		val = default_value;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -591,13 +591,15 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_obj_version, &value);
 			break;
 		case DAOS_PROP_PO_CHECKPOINT_MODE:
-			d_iov_set(&value, &entry->dpe_val, sizeof(entry->dpe_val));
+			val32 = entry->dpe_val;
+			d_iov_set(&value, &val32, sizeof(val32));
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_checkpoint_mode, &value);
 			if (rc)
 				return rc;
 			break;
 		case DAOS_PROP_PO_CHECKPOINT_FREQ:
-			d_iov_set(&value, &entry->dpe_val, sizeof(entry->dpe_val));
+			val32 = entry->dpe_val;
+			d_iov_set(&value, &val32, sizeof(val32));
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_checkpoint_freq, &value);
 			if (rc)
 				return rc;
@@ -2454,33 +2456,33 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 	}
 
 	if (bits & DAOS_PO_QUERY_PROP_CHECKPOINT_MODE) {
-		d_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val32, sizeof(val32));
 		rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_checkpoint_mode, &value);
 		if (rc == -DER_NONEXIST && global_ver < 2) { /* needs to be upgraded */
 			rc  = 0;
-			val = DAOS_PROP_PO_CHECKPOINT_MODE_DEFAULT;
+			val32 = DAOS_PROP_PO_CHECKPOINT_MODE_DEFAULT;
 			prop->dpp_entries[idx].dpe_flags |= DAOS_PROP_ENTRY_NOT_SET;
 		} else if (rc != 0) {
 			D_GOTO(out_prop, rc);
 		}
 		D_ASSERT(idx < nr);
 		prop->dpp_entries[idx].dpe_type = DAOS_PROP_PO_CHECKPOINT_MODE;
-		prop->dpp_entries[idx].dpe_val  = val;
+		prop->dpp_entries[idx].dpe_val  = val32;
 		idx++;
 	}
 	if (bits & DAOS_PO_QUERY_PROP_CHECKPOINT_FREQ) {
-		d_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val32, sizeof(val32));
 		rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_checkpoint_freq, &value);
 		if (rc == -DER_NONEXIST && global_ver < 2) { /* needs to be upgraded */
 			rc  = 0;
-			val = DAOS_PROP_PO_CHECKPOINT_FREQ_DEFAULT;
+			val32 = DAOS_PROP_PO_CHECKPOINT_FREQ_DEFAULT;
 			prop->dpp_entries[idx].dpe_flags |= DAOS_PROP_ENTRY_NOT_SET;
 		} else if (rc != 0) {
 			D_GOTO(out_prop, rc);
 		}
 		D_ASSERT(idx < nr);
 		prop->dpp_entries[idx].dpe_type = DAOS_PROP_PO_CHECKPOINT_FREQ;
-		prop->dpp_entries[idx].dpe_val  = val;
+		prop->dpp_entries[idx].dpe_val  = val32;
 		idx++;
 	}
 	if (bits & DAOS_PO_QUERY_PROP_CHECKPOINT_THRESH) {

--- a/src/tests/suite/daos_upgrade.c
+++ b/src/tests/suite/daos_upgrade.c
@@ -127,9 +127,8 @@ run_daos_upgrade_test(int rank, int size, int *sub_tests,
 		sub_tests = NULL;
 	}
 
-	rc = run_daos_sub_tests_only("DAOS_Rebuild_Simple", upgrade_tests,
-				     ARRAY_SIZE(upgrade_tests), sub_tests,
-				     sub_tests_size);
+	rc = run_daos_sub_tests_only("DAOS_upgrade", upgrade_tests, ARRAY_SIZE(upgrade_tests),
+				     sub_tests, sub_tests_size);
 
 	par_barrier(PAR_COMM_WORLD);
 


### PR DESCRIPTION
There was a mismatch in upgrading the pool property for the size of the property.
Added a 32-bit version of the function
Made all checkpoint properties 32-bit

Quick-fucntional: true
Skip-unit-test: true
Skip-nlt: true
Test-tag: test_daos_upgrade
Test-repeat: 5
Test-Nvme: auto_md_on_ssd

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
