### PR TITLE
DAOS-13115 rdb: coverity CID 1347786

### DIFF
--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -1093,10 +1093,18 @@ rdb_raft_update_node(struct rdb *db, uint64_t index, raft_entry_t *entry)
 		goto out_replicas;
 	}
 
-	if (entry->type == RAFT_LOGTYPE_ADD_NODE)
+	if (entry->type == RAFT_LOGTYPE_ADD_NODE) {
 		rc = d_rank_list_append(replicas, rank);
-	else if (entry->type == RAFT_LOGTYPE_REMOVE_NODE)
+	} else if (entry->type == RAFT_LOGTYPE_REMOVE_NODE) {
+		/* never expect 1->0 in practice, right? But protect against double-free. */
+		bool replicas_freed = (replicas->rl_nr == 1);
+
 		rc = d_rank_list_del(replicas, rank);
+		if (replicas_freed) {
+			D_ASSERT(rc == -DER_NOMEM);
+			replicas = NULL;
+		}
+	}
 	if (rc != 0)
 		goto out_replicas;
 


### PR DESCRIPTION
In rdb_raft_update_node(), avoid a double free of the replicas rank list when handling a RAFT_LOGTYPE_REMOVE_NODE raft log entry would result in the list going from 1 to 0 items.

Features: pool



Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
