### PR TITLE
DAOS-13119 chk: check stop while some interaction in pending

### DIFF
--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -187,6 +187,7 @@ chk_engine_exit(struct chk_instance *ins, uint32_t ins_status, uint32_t pool_sta
 	}
 
 	if (ins_status != CHK__CHECK_INST_STATUS__CIS_PAUSED &&
+	    ins_status != CHK__CHECK_INST_STATUS__CIS_STOPPED &&
 	    ins_status != CHK__CHECK_INST_STATUS__CIS_IMPLICATED && ins->ci_iv_ns != NULL) {
 		iv.ci_gen = cbk->cb_gen;
 		iv.ci_phase = cbk->cb_phase;
@@ -1827,12 +1828,12 @@ chk_engine_sched(void *args)
 	D_INFO(DF_ENGINE" scheduler on rank %u entry at phase %u\n",
 	       DP_ENGINE(ins), myrank, cbk->cb_phase);
 
-	while (1) {
+	while (ins->ci_sched_running) {
+		dss_sleep(300);
+
 		/* Someone wants to stop the check. */
 		if (!ins->ci_sched_running)
 			D_GOTO(out, rc = 0);
-
-		dss_sleep(300);
 
 		phase = chk_pools_find_slowest(ins, &done, NULL);
 		if (done) {
@@ -2125,7 +2126,6 @@ chk_engine_start(uint64_t gen, uint32_t rank_nr, d_rank_t *ranks, uint32_t polic
 	D_ASSERT(d_list_empty(&ins->ci_pool_list));
 
 	D_ASSERT(daos_handle_is_inval(ins->ci_pending_hdl));
-	D_ASSERT(d_list_empty(&ins->ci_pending_list));
 
 	if (ins->ci_sched != ABT_THREAD_NULL)
 		ABT_thread_free(&ins->ci_sched);
@@ -2954,8 +2954,8 @@ chk_engine_report(struct chk_report_unit *cru, int *decision, uint64_t *seq)
 		pool = (struct chk_pool_rec *)riov.iov_buf;
 		pool->cpr_bk.cb_pool_status = CHK__CHECK_POOL_STATUS__CPS_PENDING;
 
-		rc = chk_pending_add(ins, NULL, *cru->cru_pool, *seq, cru->cru_rank,
-				     cru->cru_cla, &cpr);
+		rc = chk_pending_add(ins, &pool->cpr_pending_list, NULL, *cru->cru_pool, *seq,
+				     cru->cru_rank, cru->cru_cla, &cpr);
 	}
 
 log:
@@ -3094,7 +3094,6 @@ chk_engine_rejoin(void *args)
 	D_ASSERT(daos_handle_is_inval(ins->ci_pool_hdl));
 	D_ASSERT(d_list_empty(&ins->ci_pool_list));
 	D_ASSERT(daos_handle_is_inval(ins->ci_pending_hdl));
-	D_ASSERT(d_list_empty(&ins->ci_pending_list));
 
 	ins->ci_starting = 1;
 	ins->ci_started = 0;
@@ -3201,7 +3200,6 @@ chk_engine_pause(void)
 	struct chk_instance	*ins = chk_engine;
 
 	chk_stop_sched(ins);
-	D_ASSERT(d_list_empty(&ins->ci_pending_list));
 	D_ASSERT(d_list_empty(&ins->ci_pool_list));
 }
 

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -196,35 +196,9 @@ chk_rank_del(struct chk_instance *ins, d_rank_t rank)
 	/* Cleanup all pending records belong to this rank. */
 	ABT_rwlock_wrlock(ins->ci_abt_lock);
 	d_list_for_each_entry_safe(cpr, tmp, &crr->crr_pending_list, cpr_rank_link) {
-		d_iov_set(&riov, NULL, 0);
-		d_iov_set(&kiov, &cpr->cpr_seq, sizeof(cpr->cpr_seq));
-		rc1 = dbtree_delete(ins->ci_pending_hdl, BTR_PROBE_EQ, &kiov, &riov);
-		if (rc1 != 0) {
-			D_ASSERT(rc1 != -DER_NONEXIST);
-
-			D_ERROR(DF_LEADER" failed to remove pending rec for rank %u, seq "
-				DF_X64": "DF_RC"\n",
-				DP_LEADER(ins), crr->crr_rank, cpr->cpr_seq, DP_RC(rc1));
-
-			if (rc == 0)
-				rc = rc1;
-		} else {
-			D_ASSERT(cpr == riov.iov_buf);
-
-			ABT_mutex_lock(cpr->cpr_mutex);
-			if (cpr->cpr_busy) {
-				/*
-				 * Notify the owner who is blocked on the pending record
-				 * and will release the pending record after using it.
-				 */
-				cpr->cpr_exiting = 1;
-				ABT_cond_broadcast(cpr->cpr_cond);
-				ABT_mutex_unlock(cpr->cpr_mutex);
-			} else {
-				ABT_mutex_unlock(cpr->cpr_mutex);
-				chk_pending_destroy(cpr);
-			}
-		}
+		rc1 = chk_pending_wakeup(ins, cpr);
+		if (rc1 != 0 && rc == 0)
+			rc = rc1;
 	}
 	ABT_rwlock_unlock(ins->ci_abt_lock);
 
@@ -2688,7 +2662,6 @@ chk_leader_start(uint32_t rank_nr, d_rank_t *ranks, uint32_t policy_nr, struct c
 	D_ASSERT(d_list_empty(&ins->ci_pool_list));
 
 	D_ASSERT(daos_handle_is_inval(ins->ci_pending_hdl));
-	D_ASSERT(d_list_empty(&ins->ci_pending_list));
 
 	if (ins->ci_sched != ABT_THREAD_NULL)
 		ABT_thread_free(&ins->ci_sched);
@@ -2871,7 +2844,10 @@ chk_leader_stop(int pool_nr, uuid_t pools[])
 {
 	struct chk_instance	*ins = chk_leader;
 	struct chk_bookmark	*cbk = &ins->ci_bk;
+	struct chk_pool_rec	*cpr;
+	struct chk_pool_rec	*tmp;
 	int			 rc = 0;
+	int			 i;
 
 	if (ins->ci_starting)
 		D_GOTO(out, rc = -DER_BUSY);
@@ -2916,6 +2892,22 @@ chk_leader_stop(int pool_nr, uuid_t pools[])
 	rc = chk_stop_remote(ins->ci_ranks, cbk->cb_gen, pool_nr, pools, chk_leader_stop_cb, ins);
 	if (rc != 0)
 		goto out;
+
+	if (pool_nr == 0) {
+		d_list_for_each_entry_safe(cpr, tmp, &ins->ci_pool_list, cpr_link) {
+			chk_pool_stop_one(ins, cpr->cpr_uuid, CHK__CHECK_POOL_STATUS__CPS_STOPPED,
+					  CHK_INVAL_PHASE, &rc);
+			if (rc != 0)
+				D_GOTO(out, rc);
+		}
+	} else {
+		for (i = 0; i < pool_nr; i++) {
+			chk_pool_stop_one(ins, pools[i], CHK__CHECK_POOL_STATUS__CPS_STOPPED,
+					  CHK_INVAL_PHASE, &rc);
+			if (rc != 0)
+				D_GOTO(out, rc);
+		}
+	}
 
 	if (cbk->cb_ins_status == CHK__CHECK_INST_STATUS__CIS_RUNNING &&
 	    d_list_empty(&ins->ci_rank_list))
@@ -3330,7 +3322,8 @@ chk_leader_report(struct chk_report_unit *cru, uint64_t *seq, int *decision)
 			crr = (struct chk_rank_rec *)riov.iov_buf;
 		}
 
-		rc = chk_pending_add(ins, crr != NULL ? &crr->crr_pending_list : NULL,
+		rc = chk_pending_add(ins, &pool->cpr_pending_list,
+				     crr != NULL ? &crr->crr_pending_list : NULL,
 				     *cru->cru_pool, *seq, cru->cru_rank, cru->cru_cla, &cpr);
 		if (rc != 0)
 			goto log;
@@ -3511,7 +3504,6 @@ chk_leader_pause(void)
 	struct chk_instance	*ins = chk_leader;
 
 	chk_stop_sched(ins);
-	D_ASSERT(d_list_empty(&ins->ci_pending_list));
 	D_ASSERT(d_list_empty(&ins->ci_rank_list));
 }
 


### PR DESCRIPTION
The sponsor of CR interaction will hold reference on related pool record to prevent the pool record being released. If "check stop" is triggered during such waiting, we need wakeup related interaction sponsor instead of block the "check stop".

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
