### PR TITLE
cr: Use all non-excluded ranks in CR FI for missing pool

### DIFF
--- a/src/control/system/member.go
+++ b/src/control/system/member.go
@@ -58,6 +58,8 @@ const (
 	AvailableMemberFilter = MemberStateReady | MemberStateJoined
 	// AllMemberFilter will match all valid member states.
 	AllMemberFilter = MemberState(0xFFFF)
+	// NonExcludedMemberFilter matches all members that don't match the ExcludedMemberFilter.
+	NonExcludedMemberFilter = AllMemberFilter ^ ExcludedMemberFilter
 )
 
 func (ms MemberState) String() string {

--- a/src/control/system/raft/database_test.go
+++ b/src/control/system/raft/database_test.go
@@ -62,7 +62,7 @@ func TestSystem_Database_filterMembers(t *testing.T) {
 	memberStates := []MemberState{
 		MemberStateUnknown, MemberStateAwaitFormat, MemberStateStarting,
 		MemberStateReady, MemberStateJoined, MemberStateStopping, MemberStateStopped,
-		MemberStateExcluded, MemberStateErrored, MemberStateUnresponsive,
+		MemberStateExcluded, MemberStateErrored, MemberStateUnresponsive, MemberStateAdminExcluded,
 	}
 
 	for i, ms := range memberStates {
@@ -104,6 +104,13 @@ func TestSystem_Database_filterMembers(t *testing.T) {
 				if matches[i].State != ms {
 					t.Fatalf("filtered member %d doesn't match requested state (%s != %s)", i, matches[i].State, ms)
 				}
+			}
+		},
+		"nonexcluded filter": func(t *testing.T) {
+			matches := db.filterMembers(NonExcludedMemberFilter)
+			matchLen := len(matches)
+			if matchLen != len(memberStates)-4 {
+				t.Fatalf("expected %d members to match; got %d", len(memberStates)-4, matchLen)
 			}
 		},
 	} {


### PR DESCRIPTION
Destroy the pool targets on all ranks, not just the service
ranks.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
