### PR TITLE
DAOS-5101 test: Update control/dmg_pool_evict test logic

### DIFF
--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -748,13 +748,12 @@ func (svc *mgmtSvc) PoolDestroy(parent context.Context, req *mgmtpb.PoolDestroyR
 	return resp, nil
 }
 
-// PoolEvict implements the method defined for the Management Service.
-func (svc *mgmtSvc) PoolEvict(ctx context.Context, req *mgmtpb.PoolEvictReq) (*mgmtpb.PoolEvictResp, error) {
+func (svc *mgmtSvc) evictPoolConnections(ctx context.Context, req *mgmtpb.PoolEvictReq) (*mgmtpb.PoolEvictResp, error) {
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
 
-	dresp, err := svc.makeLockedPoolServiceCall(ctx, drpc.MethodPoolEvict, req)
+	dresp, err := svc.makePoolServiceCall(ctx, drpc.MethodPoolEvict, req)
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +763,29 @@ func (svc *mgmtSvc) PoolEvict(ctx context.Context, req *mgmtpb.PoolEvictReq) (*m
 		return nil, errors.Wrap(err, "unmarshal PoolEvict response")
 	}
 
+	svc.log.Infof("pool %s: evicted %d handles", req.Id, resp.Count)
 	return resp, nil
+}
+
+// PoolEvict handles requests to evict pool handles. When a request contains
+// multiple pool handles, it will be added to a batch request and processed
+// with other handle eviction requests in order to reduce the number of dRPCs.
+func (svc *mgmtSvc) PoolEvict(ctx context.Context, req *mgmtpb.PoolEvictReq) (*mgmtpb.PoolEvictResp, error) {
+	if err := svc.checkLeaderRequest(req); err != nil {
+		return nil, err
+	}
+
+	if len(req.Handles) == 0 {
+		// If we're not evicting a set of handles, then we shouldn't bother with trying
+		// to batch up the requests from multiple agents.
+		return svc.evictPoolConnections(ctx, req)
+	}
+
+	msg, err := svc.submitBatchRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return msg.(*mgmtpb.PoolEvictResp), nil
 }
 
 // PoolExclude implements the method defined for the Management Service.

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -137,7 +137,7 @@ func getPeerListenAddr(ctx context.Context, listenAddrStr string) (*net.TCPAddr,
 
 const (
 	groupUpdateInterval = 500 * time.Millisecond
-	batchJoinInterval   = 250 * time.Millisecond
+	batchLoopInterval   = 250 * time.Millisecond
 )
 
 type (
@@ -156,20 +156,16 @@ type (
 	joinReqChan chan *batchJoinRequest
 )
 
-func (svc *mgmtSvc) startJoinLoop(ctx context.Context) {
-	svc.log.Debug("starting joinLoop")
-	go svc.joinLoop(ctx)
-}
-
 func (svc *mgmtSvc) joinLoop(parent context.Context) {
 	var joinReqs []*batchJoinRequest
 	var groupUpdateNeeded bool
 
-	joinTimer := time.NewTicker(batchJoinInterval)
+	joinTimer := time.NewTicker(batchLoopInterval)
 	defer joinTimer.Stop()
 	groupUpdateTimer := time.NewTicker(groupUpdateInterval)
 	defer groupUpdateTimer.Stop()
 
+	svc.log.Debug("starting joinLoop")
 	for {
 		select {
 		case <-parent.Done():

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -2001,7 +2001,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			svc.startJoinLoop(ctx)
+			svc.startBatchLoops(ctx)
 
 			if tc.req.Sys == "" {
 				tc.req.Sys = build.DefaultSystemName

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -420,7 +420,7 @@ func (srv *server) registerEvents() {
 	srv.sysdb.OnLeadershipGained(
 		func(ctx context.Context) error {
 			srv.log.Infof("MS leader running on %s", srv.hostname)
-			srv.mgmtSvc.startJoinLoop(ctx)
+			srv.mgmtSvc.startBatchLoops(ctx)
 			registerLeaderSubscriptions(srv)
 			srv.log.Debugf("requesting sync GroupUpdate after leader change")
 			go func() {


### PR DESCRIPTION
The test purported to test handle eviction, but because it
was only using the daos tool, a new pool handle was being
created for each invocation of the tool. In order to properly
test eviction, the test needs to open a pool using the API and
hold the handle after eviction has occurred.

Features: control

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>