### PR TITLE
DAOS-12163 test: increase rf test timeout

### DIFF
--- a/src/tests/ftest/pool/rf.yaml
+++ b/src/tests/ftest/pool/rf.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 5
   test_clients: 1
 
-timeout: 90
+timeout: 300
 
 server_config:
   engines_per_host: 1


### PR DESCRIPTION
Skip-checkpatch: true
Quick-Functional: true
Skip-unit-tests: true
Test-tag: test_rf_pool_property
Required-githooks: true
Test-repeat: 5