### PR TITLE
DAOS-12002 control: General logging cleanup

### DIFF
--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -150,7 +150,7 @@ or query/manage an object inside a container.`
 		}
 
 		if opts.Debug {
-			log.WithLogLevel(logging.LogLevelDebug)
+			log.SetLevel(logging.LogLevelTrace)
 			if os.Getenv("D_LOG_MASK") == "" {
 				os.Setenv("D_LOG_MASK", "DEBUG,OBJECT=ERR,PLACEMENT=ERR")
 			}

--- a/src/control/cmd/daos_agent/fabric.go
+++ b/src/control/cmd/daos_agent/fabric.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -96,7 +96,9 @@ func (n *NUMAFabric) Add(numaNode int, fi *FabricInterface) error {
 // selecting a device.
 func (n *NUMAFabric) WithIgnoredDevices(ifaces common.StringSet) *NUMAFabric {
 	n.ignoreIfaces = ifaces
-	n.log.Debugf("NUMAFabric ignoring devices: %s", n.ignoreIfaces)
+	if len(ifaces) > 0 {
+		n.log.Tracef("ignoring fabric devices: %s", n.ignoreIfaces)
+	}
 	return n
 }
 
@@ -188,28 +190,25 @@ func (n *NUMAFabric) getDeviceFromNUMA(numaNode int, netDevClass hardware.NetDev
 		fabricIF := n.getNextDevice(numaNode)
 
 		if n.ignoreIfaces.Has(fabricIF.Name) {
-			n.log.Debugf("Excluding device: %q (domain: %q). Device is on ignore list: %s", fabricIF.Name,
-				fabricIF.Domain, n.ignoreIfaces.String())
+			n.log.Tracef("device %s: ignored (ignore list %s)", fabricIF, n.ignoreIfaces)
 			continue
 		}
 
 		// Manually-provided interfaces can be assumed to support what's needed by the system.
 		if fabricIF.NetDevClass != FabricDevClassManual {
 			if fabricIF.NetDevClass != netDevClass {
-				n.log.Debugf("Excluding device: %q (domain: %q), network device class: %s. Does not match requested network device class: %s",
-					fabricIF.Name, fabricIF.Domain, fabricIF.NetDevClass, netDevClass)
+				n.log.Tracef("device %s: excluded (netDevClass %s != %s)", fabricIF, fabricIF.NetDevClass, netDevClass)
 				continue
 			}
 
 			if !fabricIF.HasProvider(provider) {
-				n.log.Debugf("Excluding device: %q (domain: %q), network device class: %s. Doesn't support provider",
-					fabricIF.Name, fabricIF.Domain, fabricIF.NetDevClass)
+				n.log.Tracef("device %s: excluded (provider %s not supported)", fabricIF, provider)
 				continue
 			}
 		}
 
 		if err := n.validateDevice(fabricIF); err != nil {
-			n.log.Infof("Excluding device %q: %s", fabricIF.Name, err.Error())
+			n.log.Noticef("device %s: excluded (%s)", fabricIF, err)
 			continue
 		}
 
@@ -240,7 +239,7 @@ func (n *NUMAFabric) validateDevice(fi *FabricInterface) error {
 	}
 
 	for _, a := range addrs {
-		n.log.Debugf("Interface: %s, Addr: %s %s", fi.Name, a.Network(), a.String())
+		n.log.Tracef("device %s: %s/%s", fi.Name, a.Network(), a.String())
 		if ipAddr, isIP := a.(*net.IPNet); isIP && ipAddr.IP != nil && !ipAddr.IP.IsUnspecified() {
 			return nil
 		}
@@ -262,7 +261,7 @@ func (n *NUMAFabric) findOnAnyNUMA(netDevClass hardware.NetDevClass, provider st
 		n.currentNUMANode = (n.currentNUMANode + 1) % numNodes
 		fi, err := n.getDeviceFromNUMA(nodes[n.currentNUMANode], netDevClass, provider)
 		if err == nil {
-			n.log.Debugf("Suitable fabric interface %q found on NUMA node %d", fi.Name, n.currentNUMANode)
+			n.log.Tracef("device %s: selected on NUMA node %d)", fi, n.currentNUMANode)
 			return fi, nil
 		}
 	}
@@ -320,13 +319,12 @@ func NUMAFabricFromScan(ctx context.Context, log logging.Logger, scan *hardware.
 			numa := int(fi.NUMANode)
 			fabric.Add(numa, newIF)
 
-			log.Debugf("Added device %q, domain %q for NUMA %d, device number %d",
-				newIF.Name, newIF.Domain, numa, fabric.NumDevices(numa)-1)
+			log.Tracef("device %s: [%d] added to NUMA node %d", newIF, fabric.NumDevices(numa)-1, numa)
 		}
 	}
 
 	if fabric.NumNUMANodes() == 0 {
-		log.Info("No network devices detected in fabric scan")
+		log.Notice("no network devices detected in fabric scan")
 	}
 
 	return fabric

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -19,13 +19,6 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-const (
-	invalidIndex         = -1
-	verbsProvider        = "ofi+verbs"
-	defaultNetworkDevice = "lo"
-	defaultDomain        = "lo"
-)
-
 // NotCachedErr is the error returned when trying to fetch data that is not cached.
 var NotCachedErr = errors.New("not cached")
 
@@ -172,7 +165,6 @@ func (c *localFabricCache) setCache(nf *NUMAFabric) {
 	}
 
 	c.initialized.SetTrue()
-	c.log.Debugf("cached:\n%+v", c.localNUMAFabric.numaMap)
 }
 
 // GetDevices fetches an appropriate fabric device from the cache.

--- a/src/control/cmd/daos_agent/main.go
+++ b/src/control/cmd/daos_agent/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2022 Intel Corporation.
+// (C) Copyright 2018-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -137,7 +137,7 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, log *lo
 		}
 
 		if opts.Debug {
-			log.WithLogLevel(logging.LogLevelDebug)
+			log.SetLevel(logging.LogLevelTrace)
 		}
 
 		if opts.JSONLogs {
@@ -202,8 +202,10 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, log *lo
 			// Create an additional set of loggers which append everything
 			// to the specified file.
 			log.WithErrorLogger(logging.NewErrorLogger("agent", f)).
+				WithNoticeLogger(logging.NewNoticeLogger("agent", f)).
 				WithInfoLogger(logging.NewInfoLogger("agent", f)).
-				WithDebugLogger(logging.NewDebugLogger(f))
+				WithDebugLogger(logging.NewDebugLogger(f)).
+				WithTraceLogger(logging.NewTraceLogger(f))
 		}
 
 		if err := cfg.TransportConfig.PreLoadCertData(); err != nil {

--- a/src/control/cmd/daos_agent/mgmt_rpc_test.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc_test.go
@@ -75,7 +75,7 @@ func TestAgent_mgmtModule_getAttachInfo(t *testing.T) {
 
 	hintResp := func(resp *mgmtpb.GetAttachInfoResp) *mgmtpb.GetAttachInfoResp {
 		withHint := new(mgmtpb.GetAttachInfoResp)
-		*withHint = *resp
+		withHint = proto.Clone(resp).(*mgmtpb.GetAttachInfoResp)
 		withHint.ClientNetHint.Interface = testFI[0].Name
 		withHint.ClientNetHint.Domain = testFI[0].Name
 

--- a/src/control/cmd/daos_agent/security_rpc.go
+++ b/src/control/cmd/daos_agent/security_rpc.go
@@ -59,17 +59,18 @@ func (m *SecurityModule) getCredential(session *drpc.Session) ([]byte, error) {
 
 	signingKey, err := m.config.PrivateKey()
 	if err != nil {
-		m.log.Error(err.Error())
+		m.log.Errorf("%s: failed to get signing key: %s", info, err)
 		// something is wrong with the cert config
 		return m.credRespWithStatus(daos.BadCert)
 	}
 
 	cred, err := auth.AuthSysRequestFromCreds(m.ext, info, signingKey)
 	if err != nil {
-		m.log.Errorf("Failed to get AuthSys struct: %s", err)
+		m.log.Errorf("%s: failed to get AuthSys struct: %s", info, err)
 		return m.credRespWithStatus(daos.MiscError)
 	}
 
+	m.log.Tracef("%s: successfully signed credential", info)
 	resp := &auth.GetCredResp{Cred: cred}
 	return drpc.Marshal(resp)
 }

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -51,7 +51,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 		return err
 	}
 
-	cmd.Debugf("Starting %s (pid %d)", versionString(), os.Getpid())
+	cmd.Infof("Starting %s (pid %d)", versionString(), os.Getpid())
 	startedAt := time.Now()
 
 	parent, shutdown := context.WithCancel(context.Background())

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -95,7 +95,7 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 			common.ScrubProxyVariables()
 		}
 		if opts.Debug {
-			log.SetLevel(logging.LogLevelDebug)
+			log.SetLevel(logging.LogLevelTrace)
 		}
 		if opts.JSONLog {
 			log.WithJSONOutput()
@@ -103,6 +103,7 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 		if opts.Syslog {
 			// Don't log debug stuff to syslog.
 			log.WithInfoLogger((&logging.DefaultInfoLogger{}).WithSyslogOutput())
+			log.WithNoticeLogger((&logging.DefaultNoticeLogger{}).WithSyslogOutput())
 			log.WithErrorLogger((&logging.DefaultErrorLogger{}).WithSyslogOutput())
 		}
 

--- a/src/control/cmd/daos_server/start.go
+++ b/src/control/cmd/daos_server/start.go
@@ -91,9 +91,15 @@ func (cmd *startCmd) configureLogging() error {
 	// unless it was explicitly set to debug via CLI flag.
 	applyLogConfig := func() error {
 		switch logging.LogLevel(cmd.config.ControlLogMask) {
+		case logging.LogLevelTrace:
+			log.SetLevel(logging.LogLevelTrace)
+			cmd.Debugf("Switching control log level to TRACE")
 		case logging.LogLevelDebug:
 			log.SetLevel(logging.LogLevelDebug)
 			cmd.Debugf("Switching control log level to DEBUG")
+		case logging.LogLevelNotice:
+			log.SetLevel(logging.LogLevelNotice)
+			cmd.Debugf("Switching control log level to NOTICE")
 		case logging.LogLevelError:
 			cmd.Debugf("Switching control log level to ERROR")
 			log.SetLevel(logging.LogLevelError)
@@ -131,8 +137,10 @@ func (cmd *startCmd) configureLogging() error {
 		// to the specified file.
 		cmd.Logger = log.
 			WithErrorLogger(logging.NewErrorLogger(hostname, f)).
+			WithNoticeLogger(logging.NewNoticeLogger(hostname, f)).
 			WithInfoLogger(logging.NewInfoLogger(hostname, f)).
-			WithDebugLogger(logging.NewDebugLogger(f))
+			WithDebugLogger(logging.NewDebugLogger(f)).
+			WithTraceLogger(logging.NewTraceLogger(f))
 
 		return applyLogConfig()
 	}

--- a/src/control/cmd/daos_server/start_test.go
+++ b/src/control/cmd/daos_server/start_test.go
@@ -349,6 +349,14 @@ func TestStartLoggingConfiguration(t *testing.T) {
 			input:     "hello",
 			wantRe:    regexp.MustCompile(`"message":"hello"`),
 		},
+		"Trace": {
+			configFn: func(cfg *config.Server) *config.Server {
+				return cfg.WithControlLogMask(common.ControlLogLevelTrace)
+			},
+			logFnName: "Trace",
+			input:     "hello",
+			wantRe:    regexp.MustCompile(`hello`),
+		},
 		"Debug": {
 			configFn: func(cfg *config.Server) *config.Server {
 				return cfg.WithControlLogMask(common.ControlLogLevelDebug)
@@ -357,11 +365,19 @@ func TestStartLoggingConfiguration(t *testing.T) {
 			input:     "hello",
 			wantRe:    regexp.MustCompile(`hello`),
 		},
+		"Notice": {
+			configFn: func(cfg *config.Server) *config.Server {
+				return cfg.WithControlLogMask(common.ControlLogLevelNotice)
+			},
+			logFnName: "Info",
+			input:     "hello",
+			wantRe:    regexp.MustCompile(`^$`),
+		},
 		"Error": {
 			configFn: func(cfg *config.Server) *config.Server {
 				return cfg.WithControlLogMask(common.ControlLogLevelError)
 			},
-			logFnName: "Info",
+			logFnName: "Notice",
 			input:     "hello",
 			wantRe:    regexp.MustCompile(`^$`),
 		},

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -262,12 +262,14 @@ and access control settings, along with system wide operations.`
 			// to the specified file.
 			log = log.
 				WithErrorLogger(logging.NewErrorLogger("dmg", f)).
+				WithNoticeLogger(logging.NewNoticeLogger("dmg", f)).
 				WithInfoLogger(logging.NewInfoLogger("dmg", f)).
-				WithDebugLogger(logging.NewDebugLogger(f))
+				WithDebugLogger(logging.NewDebugLogger(f)).
+				WithTraceLogger(logging.NewTraceLogger(f))
 		}
 
 		if opts.Debug {
-			log.WithLogLevel(logging.LogLevelDebug)
+			log.SetLevel(logging.LogLevelTrace)
 			log.Debug("debug output enabled")
 		}
 

--- a/src/control/common/loglevel.go
+++ b/src/control/common/loglevel.go
@@ -14,9 +14,11 @@ type ControlLogLevel logging.LogLevel
 // TODO(mjmac): Evaluate whether or not this layer of indirection
 // adds any value.
 const (
-	ControlLogLevelDebug = ControlLogLevel(logging.LogLevelDebug)
-	ControlLogLevelInfo  = ControlLogLevel(logging.LogLevelInfo)
-	ControlLogLevelError = ControlLogLevel(logging.LogLevelError)
+	ControlLogLevelTrace  = ControlLogLevel(logging.LogLevelTrace)
+	ControlLogLevelDebug  = ControlLogLevel(logging.LogLevelDebug)
+	ControlLogLevelInfo   = ControlLogLevel(logging.LogLevelInfo)
+	ControlLogLevelNotice = ControlLogLevel(logging.LogLevelNotice)
+	ControlLogLevelError  = ControlLogLevel(logging.LogLevelError)
 
 	DefaultControlLogLevel = ControlLogLevel(logging.DefaultLogLevel)
 )

--- a/src/control/common/proto/logging.go
+++ b/src/control/common/proto/logging.go
@@ -96,6 +96,24 @@ func Debug(msg proto.Message) string {
 		for i, b := range m.TierBytes {
 			fmt.Fprintf(&bld, "%d:%d ", i, b)
 		}
+	case *mgmtpb.PoolEvictReq:
+		fmt.Fprintf(&bld, "%T pool:%s", m, m.Id)
+		if len(m.Handles) > 0 {
+			shortHdls := make([]string, 0, len(m.Handles))
+			for _, h := range m.Handles {
+				shortHdls = append(shortHdls, h[:8])
+			}
+			fmt.Fprintf(&bld, " handles:%s", strings.Join(shortHdls, ","))
+		}
+		if m.Destroy {
+			fmt.Fprint(&bld, " destroy:true")
+		}
+		if m.ForceDestroy {
+			fmt.Fprint(&bld, " force_destroy:true")
+		}
+		if m.Machine != "" {
+			fmt.Fprintf(&bld, " machine:%s", m.Machine)
+		}
 	case *mgmtpb.ListPoolsResp:
 		fmt.Fprintf(&bld, "%T%d %d pools:", m, m.DataVersion, len(m.Pools))
 		for _, p := range m.Pools {

--- a/src/control/lib/hardware/fabric.go
+++ b/src/control/lib/hardware/fabric.go
@@ -668,7 +668,7 @@ func (o *NetworkDeviceBuilder) BuildPart(ctx context.Context, fis *FabricInterfa
 
 		dev, exists := devsByName[topoName]
 		if !exists {
-			o.log.Debugf("ignoring fabric interface %q (%s) not found in topology", name, topoName)
+			o.log.Tracef("ignoring fabric interface %q (%s) not found in topology", name, topoName)
 			fis.Remove(name)
 			continue
 		}
@@ -772,7 +772,7 @@ func (n *NUMAAffinityBuilder) BuildPart(ctx context.Context, fis *FabricInterfac
 
 		dev, exists := devsByName[topoName]
 		if !exists {
-			n.log.Debugf("fabric interface %q (%s) not found in topology", name, topoName)
+			n.log.Tracef("fabric interface %q (%s) not found in topology", name, topoName)
 			continue
 		}
 
@@ -819,13 +819,13 @@ func (n *NetDevClassBuilder) BuildPart(ctx context.Context, fis *FabricInterface
 		}
 
 		if len(fi.NetInterfaces) == 0 {
-			n.log.Debugf("fabric interface %q has no corresponding OS-level device", name)
+			n.log.Tracef("fabric interface %q has no corresponding OS-level device", name)
 			continue
 		}
 
 		ndc, err := n.provider.GetNetDevClass(fi.NetInterfaces.ToSlice()[0])
 		if err != nil {
-			n.log.Debugf("failed to get device class for %q: %s", name, err.Error())
+			n.log.Tracef("failed to get device class for %q: %s", name, err.Error())
 		}
 
 		fi.DeviceClass = ndc
@@ -1064,7 +1064,7 @@ func loopFabricReady(log logging.Logger, params WaitFabricReadyParams, ch chan e
 			case NetDevStateDown, NetDevStateUnknown:
 				// Down or unknown can be interpreted as disabled/unusable
 				if params.IgnoreUnusable {
-					log.Debugf("ignoring unusable fabric interface %q", iface)
+					log.Tracef("ignoring unusable fabric interface %q", iface)
 					unusableSet.Add(iface)
 				} else {
 					ch <- errors.Errorf("requested fabric interface %q is unusable", iface)

--- a/src/control/lib/hardware/hwloc/provider.go
+++ b/src/control/lib/hardware/hwloc/provider.go
@@ -391,7 +391,7 @@ func (p *Provider) getDeviceNUMANodeID(dev *object, topo *topology) uint {
 		}
 	}
 
-	p.log.Debugf("Unable to determine NUMA socket ID for device %q, using NUMA 0", dev.name())
+	p.log.Tracef("device %q: using NUMA 0", dev.name())
 	return 0
 
 }

--- a/src/control/lib/hardware/libfabric/provider.go
+++ b/src/control/lib/hardware/libfabric/provider.go
@@ -79,7 +79,7 @@ func (p *Provider) getFabricInterfaces(provider string, ch chan *fabricResult) {
 		fis.Update(newFI)
 	}
 
-	p.log.Debugf("found fabric interfaces:\n%s", fis)
+	p.log.Tracef("found fabric interfaces:\n%s", fis)
 
 	ch <- &fabricResult{
 		fiSet: fis,

--- a/src/control/lib/hardware/sysfs/provider.go
+++ b/src/control/lib/hardware/sysfs/provider.go
@@ -123,7 +123,7 @@ func (s *Provider) addPCIDevices(topo *hardware.Topology, subsystem string) erro
 		case isNetwork(subsystem):
 			dev, err = s.getNetworkDevice(path, subsystem)
 			if err != nil {
-				s.log.Debug(err.Error())
+				s.log.Tracef(err.Error())
 				return nil
 			}
 		default:
@@ -132,7 +132,7 @@ func (s *Provider) addPCIDevices(topo *hardware.Topology, subsystem string) erro
 
 		numaID, err := s.getNUMANode(path)
 		if err != nil {
-			s.log.Debugf("using default NUMA node, unable to get: %s", err.Error())
+			s.log.Tracef("using default NUMA node, unable to get: %s", err.Error())
 			numaID = 0
 		}
 
@@ -143,7 +143,7 @@ func (s *Provider) addPCIDevices(topo *hardware.Topology, subsystem string) erro
 		}
 		dev.PCIAddr = *pciAddr
 
-		s.log.Debugf("adding device found at %q (type %s, NUMA node %d)", path, dev.Type, numaID)
+		s.log.Tracef("adding device found at %q (type %s, NUMA node %d)", path, dev.Type, numaID)
 
 		return topo.AddDevice(uint(numaID), dev)
 	})
@@ -191,7 +191,7 @@ func (s *Provider) getNUMANode(path string) (uint, error) {
 
 	numaID, err := strconv.Atoi(numaStr)
 	if err != nil || numaID < 0 {
-		s.log.Debugf("invalid NUMA node ID %q, using NUMA node 0", numaStr)
+		s.log.Tracef("invalid NUMA node ID %q, using NUMA node 0", numaStr)
 		numaID = 0
 	}
 	return uint(numaID), nil
@@ -223,7 +223,7 @@ func (s *Provider) addVirtualNetDevices(topo *hardware.Topology) error {
 	netPath := s.sysPath("devices", "virtual", "net")
 	netIfaces, err := ioutil.ReadDir(netPath)
 	if err != nil {
-		s.log.Debugf("unable to read any virtual net interfaces: %s", err.Error())
+		s.log.Tracef("unable to read any virtual net interfaces: %s", err.Error())
 		return nil
 	}
 
@@ -236,11 +236,11 @@ func (s *Provider) addVirtualNetDevices(topo *hardware.Topology) error {
 		ifacePath := filepath.Join(netPath, iface.Name())
 
 		if backingDev, err := s.getBackingDevice(ifacePath, addedDevices); err == nil {
-			s.log.Debugf("virtual device %q has physical backing device %q", iface.Name(), backingDev.DeviceName())
+			s.log.Tracef("virtual device %q has physical backing device %q", iface.Name(), backingDev.DeviceName())
 			virt.BackingDevice = backingDev
 		}
 
-		s.log.Debugf("adding virtual device at %q", ifacePath)
+		s.log.Tracef("adding virtual device at %q", ifacePath)
 		virtualDevices = append(virtualDevices, virt)
 	}
 
@@ -268,7 +268,7 @@ func (s *Provider) getBackingDevice(ifacePath string, devices map[string]hardwar
 
 	ifaceFiles, err := ioutil.ReadDir(ifacePath)
 	if err != nil {
-		s.log.Debugf("unable to read contents of %s", ifacePath)
+		s.log.Tracef("unable to read contents of %s", ifacePath)
 		return nil, err
 	}
 
@@ -324,14 +324,14 @@ func (s *Provider) GetFabricInterfaces(ctx context.Context, provider string) (*h
 func (s *Provider) getCXIFabricInterfaces() ([]*hardware.FabricInterface, error) {
 	cxiDevs, err := ioutil.ReadDir(s.sysPath("class", "cxi"))
 	if os.IsNotExist(err) {
-		s.log.Debugf("no cxi subsystem in sysfs")
+		s.log.Tracef("no cxi subsystem in sysfs")
 		return []*hardware.FabricInterface{}, nil
 	} else if err != nil {
 		return nil, err
 	}
 
 	if len(cxiDevs) == 0 {
-		s.log.Debugf("no cxi devices in sysfs")
+		s.log.Tracef("no cxi devices in sysfs")
 		return []*hardware.FabricInterface{}, nil
 	}
 
@@ -484,7 +484,7 @@ func (s *Provider) ibStateToNetDevState(stateStr string) hardware.NetDevState {
 	stateSubstrs := strings.Split(string(stateStr), ": ")
 	stateNum, err := strconv.Atoi(stateSubstrs[0])
 	if err != nil {
-		s.log.Debugf("unable to parse IB state %q: %s", stateStr, err.Error())
+		s.log.Tracef("unable to parse IB state %q: %s", stateStr, err.Error())
 		return hardware.NetDevStateUnknown
 	}
 

--- a/src/control/logging/debug.go
+++ b/src/control/logging/debug.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -13,6 +13,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 var (
@@ -36,6 +38,26 @@ var (
 )
 
 const debugLogFlags = log.Lmicroseconds | log.Lshortfile
+
+// DefaultTraceLogger implements the TraceLogger interface by
+// wrapping the DefaultDebugLogger implementation.
+type DefaultTraceLogger DefaultDebugLogger
+
+// Tracef emits a formatted trace message.
+func (l *DefaultTraceLogger) Tracef(format string, args ...interface{}) {
+	(*DefaultDebugLogger)(l).Debugf(format, args...)
+}
+
+// NewTraceLogger returns a DebugLogger configured for outputting
+// trace-level messages.
+func NewTraceLogger(dest io.Writer) *DefaultTraceLogger {
+	return &DefaultTraceLogger{
+		baseLogger{
+			dest: dest,
+			log:  log.New(dest, "TRACE ", debugLogFlags),
+		},
+	}
+}
 
 // NewDebugLogger returns a DebugLogger configured for outputting
 // debugging messages.
@@ -80,4 +102,9 @@ func (l *DefaultDebugLogger) Debugf(format string, args ...interface{}) {
 	if err := l.log.Output(depth, out); err != nil {
 		fmt.Fprintf(os.Stderr, "logger Debugf() failed: %s\n", err)
 	}
+}
+
+// ShortUUID returns a truncated UUID string suitable for debug logging.
+func ShortUUID(u uuid.UUID) string {
+	return u.String()[:8]
 }

--- a/src/control/logging/defaults.go
+++ b/src/control/logging/defaults.go
@@ -25,6 +25,9 @@ const (
 func NewCommandLineLogger() *LeveledLogger {
 	return &LeveledLogger{
 		level: DefaultLogLevel,
+		traceLoggers: []TraceLogger{
+			NewTraceLogger(os.Stderr),
+		},
 		debugLoggers: []DebugLogger{
 			NewDebugLogger(os.Stderr),
 		},
@@ -52,6 +55,9 @@ func NewStdoutLogger(prefix string) *LeveledLogger {
 func NewCombinedLogger(prefix string, output io.Writer) *LeveledLogger {
 	return &LeveledLogger{
 		level: DefaultLogLevel,
+		traceLoggers: []TraceLogger{
+			NewTraceLogger(output),
+		},
 		debugLoggers: []DebugLogger{
 			NewDebugLogger(output),
 		},
@@ -69,9 +75,9 @@ func NewCombinedLogger(prefix string, output io.Writer) *LeveledLogger {
 
 // NewTestLogger returns a logger and a *LogBuffer,
 // with the logger configured to send all output into
-// the buffer. The logger's level is set to DEBUG by default.
+// the buffer. The logger's level is set to TRACE by default.
 func NewTestLogger(prefix string) (*LeveledLogger, *LogBuffer) {
 	var buf LogBuffer
 	return NewCombinedLogger(prefix, &buf).
-		WithLogLevel(LogLevelDebug), &buf
+		WithLogLevel(LogLevelTrace), &buf
 }

--- a/src/control/logging/level.go
+++ b/src/control/logging/level.go
@@ -23,12 +23,15 @@ const (
 	LogLevelInfo
 	// LogLevelDebug emits messages at DEBUG or higher
 	LogLevelDebug
+	// LogLevelTrace emits messages at TRACE or higher
+	LogLevelTrace
 
 	strDisabled = "DISABLED"
 	strError    = "ERROR"
 	strNotice   = "NOTICE"
 	strInfo     = "INFO"
 	strDebug    = "DEBUG"
+	strTrace    = "TRACE"
 )
 
 // LogLevel represents the level at which the logger will emit log messages
@@ -59,6 +62,8 @@ func (ll *LogLevel) SetString(in string) error {
 		level = LogLevelInfo
 	case strings.EqualFold(in, strDebug):
 		level = LogLevelDebug
+	case strings.EqualFold(in, strTrace):
+		level = LogLevelTrace
 	default:
 		return fmt.Errorf("%q is not a valid log level", in)
 	}
@@ -79,6 +84,8 @@ func (ll LogLevel) String() string {
 		return strInfo
 	case LogLevelDebug:
 		return strDebug
+	case LogLevelTrace:
+		return strTrace
 	default:
 		return "UNKNOWN"
 	}

--- a/src/control/logging/level_test.go
+++ b/src/control/logging/level_test.go
@@ -23,6 +23,7 @@ func TestLogLevelToString(t *testing.T) {
 		"Notice":     {expected: "NOTICE", level: logging.LogLevelNotice},
 		"Info":       {expected: "INFO", level: logging.LogLevelInfo},
 		"Debug":      {expected: "DEBUG", level: logging.LogLevelDebug},
+		"Trace":      {expected: "TRACE", level: logging.LogLevelTrace},
 		"Unknown":    {expected: "UNKNOWN", level: logging.LogLevel(42)},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -51,6 +52,8 @@ func TestLogLevelFromString(t *testing.T) {
 		"info":      {expected: logging.LogLevelInfo},
 		"Debug":     {expected: logging.LogLevelDebug},
 		"debug":     {expected: logging.LogLevelDebug},
+		"Trace":     {expected: logging.LogLevelTrace},
+		"trace":     {expected: logging.LogLevelTrace},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var level logging.LogLevel

--- a/src/control/logging/logger.go
+++ b/src/control/logging/logger.go
@@ -16,6 +16,8 @@ type (
 	// Logger defines a standard logging interface
 	Logger interface {
 		EnabledFor(level LogLevel) bool
+		TraceLogger
+		Trace(msg string)
 		DebugLogger
 		Debug(msg string)
 		InfoLogger
@@ -24,6 +26,12 @@ type (
 		Notice(msg string)
 		ErrorLogger
 		Error(msg string)
+	}
+
+	// TraceLogger defines an interface to be implemented
+	// by Trace loggers.
+	TraceLogger interface {
+		Tracef(format string, args ...interface{})
 	}
 
 	// DebugLogger defines an interface to be implemented
@@ -63,6 +71,7 @@ type (
 		sync.RWMutex
 
 		level         LogLevel
+		traceLoggers  []TraceLogger
 		debugLoggers  []DebugLogger
 		infoLoggers   []InfoLogger
 		noticeLoggers []NoticeLogger
@@ -96,6 +105,8 @@ func (ll *LeveledLogger) EnabledFor(level LogLevel) bool {
 // ClearLevel clears all loggers for the specified level.
 func (ll *LeveledLogger) ClearLevel(level LogLevel) {
 	switch level {
+	case LogLevelTrace:
+		ll.traceLoggers = nil
 	case LogLevelDebug:
 		ll.debugLoggers = nil
 	case LogLevelInfo:
@@ -114,6 +125,35 @@ func (ll *LeveledLogger) ClearLevel(level LogLevel) {
 func (ll *LeveledLogger) WithLogLevel(level LogLevel) *LeveledLogger {
 	ll.SetLevel(level)
 	return ll
+}
+
+// WithTraceLogger adds the specified Trace logger to
+// the logger as part of a chained method call.
+func (ll *LeveledLogger) WithTraceLogger(newLogger TraceLogger) *LeveledLogger {
+	ll.AddTraceLogger(newLogger)
+	return ll
+}
+
+// Trace emits an unformatted message at Trace level, if
+// the logger is configured to do so.
+func (ll *LeveledLogger) Trace(msg string) {
+	ll.Tracef("%s", msg)
+}
+
+// Tracef emits a formatted message at Trace level, if
+// the logger is configured to do so.
+func (ll *LeveledLogger) Tracef(format string, args ...interface{}) {
+	if ll.Level() < LogLevelTrace {
+		return
+	}
+
+	ll.RLock()
+	loggers := ll.traceLoggers
+	ll.RUnlock()
+
+	for _, l := range loggers {
+		l.Tracef(format, args...)
+	}
 }
 
 // WithDebugLogger adds the specified Debug logger to
@@ -142,6 +182,13 @@ func (ll *LeveledLogger) WithNoticeLogger(newLogger NoticeLogger) *LeveledLogger
 func (ll *LeveledLogger) WithErrorLogger(newLogger ErrorLogger) *LeveledLogger {
 	ll.AddErrorLogger(newLogger)
 	return ll
+}
+
+// AddTraceLogger adds the specified Trace logger to the logger.
+func (ll *LeveledLogger) AddTraceLogger(newLogger TraceLogger) {
+	ll.Lock()
+	defer ll.Unlock()
+	ll.traceLoggers = append(ll.traceLoggers, newLogger)
 }
 
 // AddDebugLogger adds the specified Debug logger to the logger.

--- a/src/control/logging/logging_test.go
+++ b/src/control/logging/logging_test.go
@@ -95,6 +95,10 @@ func TestLogging_StandardFormat(t *testing.T) {
 		fmtFnArgs []interface{}
 		expected  *regexp.Regexp
 	}{
+		"Trace": {fn: logger.Trace, fnInput: "test",
+			expected: regexp.MustCompile(`^TRACE \d{2}:\d{2}:\d{2}\.\d{6} [^:]+:\d+: test\n$`)},
+		"Tracef": {fmtFn: logger.Tracef, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},
+			expected: regexp.MustCompile(`^TRACE \d{2}:\d{2}:\d{2}\.\d{6} [^:]+:\d+: test: 42\n$`)},
 		"Debug": {fn: logger.Debug, fnInput: "test",
 			expected: regexp.MustCompile(`^DEBUG \d{2}:\d{2}:\d{2}\.\d{6} [^:]+:\d+: test\n$`)},
 		"Debugf": {fmtFn: logger.Debugf, fmtFnFmt: "test: %d", fmtFnArgs: []interface{}{42},

--- a/src/control/security/domain_info.go
+++ b/src/control/security/domain_info.go
@@ -7,12 +7,15 @@
 package security
 
 import (
+	"fmt"
 	"net"
+	"os/user"
 	"syscall"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -20,6 +23,44 @@ import (
 type DomainInfo struct {
 	creds *syscall.Ucred
 	ctx   string
+}
+
+func getUserName(uid uint32) (string, error) {
+	u, err := user.LookupId(fmt.Sprintf("%d", uid))
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to lookup user")
+	}
+	return u.Username, nil
+}
+
+func getGroupName(gid uint32) (string, error) {
+	g, err := user.LookupGroupId(fmt.Sprintf("%d", gid))
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to lookup group")
+	}
+	return g.Name, nil
+}
+
+func (d *DomainInfo) String() string {
+	if d == nil {
+		return "nil"
+	}
+	if d.creds == nil {
+		return "nil creds"
+	}
+	outStr := fmt.Sprintf("%s pid: %d", d.ctx, d.creds.Pid)
+	if pName, err := common.GetProcName(int(d.creds.Pid)); err == nil {
+		outStr += fmt.Sprintf(" (%s)", pName)
+	}
+	outStr += fmt.Sprintf(" uid: %d", d.creds.Uid)
+	if uName, err := getUserName(d.creds.Uid); err == nil {
+		outStr += fmt.Sprintf(" (%s)", uName)
+	}
+	outStr += fmt.Sprintf(" gid: %d", d.creds.Gid)
+	if gName, err := getGroupName(d.creds.Gid); err == nil {
+		outStr += fmt.Sprintf(" (%s)", gName)
+	}
+	return outStr
 }
 
 // Uid returns the UID obtained from the domain socket

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -137,7 +137,7 @@ func getPeerListenAddr(ctx context.Context, listenAddrStr string) (*net.TCPAddr,
 
 const (
 	groupUpdateInterval = 500 * time.Millisecond
-	batchJoinInterval   = 250 * time.Millisecond
+	batchLoopInterval   = 250 * time.Millisecond
 )
 
 type (
@@ -156,20 +156,16 @@ type (
 	joinReqChan chan *batchJoinRequest
 )
 
-func (svc *mgmtSvc) startJoinLoop(ctx context.Context) {
-	svc.log.Debug("starting joinLoop")
-	go svc.joinLoop(ctx)
-}
-
 func (svc *mgmtSvc) joinLoop(parent context.Context) {
 	var joinReqs []*batchJoinRequest
 	var groupUpdateNeeded bool
 
-	joinTimer := time.NewTicker(batchJoinInterval)
+	joinTimer := time.NewTicker(batchLoopInterval)
 	defer joinTimer.Stop()
 	groupUpdateTimer := time.NewTicker(groupUpdateInterval)
 	defer groupUpdateTimer.Stop()
 
+	svc.log.Debug("starting joinLoop")
 	for {
 		select {
 		case <-parent.Done():

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -2001,7 +2001,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			svc.startJoinLoop(ctx)
+			svc.startBatchLoops(ctx)
 
 			if tc.req.Sys == "" {
 				tc.req.Sys = build.DefaultSystemName

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -420,7 +420,7 @@ func (srv *server) registerEvents() {
 	srv.sysdb.OnLeadershipGained(
 		func(ctx context.Context) error {
 			srv.log.Infof("MS leader running on %s", srv.hostname)
-			srv.mgmtSvc.startJoinLoop(ctx)
+			srv.mgmtSvc.startBatchLoops(ctx)
 			registerLeaderSubscriptions(srv)
 			srv.log.Debugf("requesting sync GroupUpdate after leader change")
 			go func() {

--- a/src/control/system/raft/database.go
+++ b/src/control/system/raft/database.go
@@ -33,6 +33,10 @@ const (
 	CurrentSchemaVersion = 0
 )
 
+var (
+	dbgUuidStr = logging.ShortUUID
+)
+
 type (
 	onLeadershipGainedFn func(context.Context) error
 	onLeadershipLostFn   func() error
@@ -1153,8 +1157,4 @@ func (db *Database) GetSystemAttrs(keys []string, filterFn func(string) bool) (m
 		return nil, system.ErrSystemAttrNotFound(k)
 	}
 	return out, nil
-}
-
-func dbgUuidStr(u uuid.UUID) string {
-	return u.String()[0:8]
 }

--- a/src/tests/ftest/control/dmg_network_scan.yaml
+++ b/src/tests/ftest/control/dmg_network_scan.yaml
@@ -6,7 +6,7 @@ timeout: 180
 server_config:
   name: daos_server
   port: 10001
-  control_log_mask: INFO
+  control_log_mask: TRACE
   engines_per_host: 1
   engines:
     0:

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -748,7 +748,10 @@ class DaosServer():
 
         agent_config = join(self.agent_dir, 'nlt_agent.yaml')
         with open(agent_config, 'w') as fd:
-            agent_data = {'access_points': scyaml['access_points']}
+            agent_data = {
+                    'access_points': scyaml['access_points'],
+                    'control_log_mask': 'NOTICE', # INFO logs every client process connection
+            }
             json.dump(agent_data, fd)
 
         agent_bin = join(self.conf['PREFIX'], 'bin', 'daos_agent')


### PR DESCRIPTION
Improve density and relevance of agent logging for client
process monitoring. Important messages should be logged
at INFO or ERROR, and DEBUG messages should avoid excess
verbosity.

Standardizes a number of debug messages to make grepping
easier and improves log density/relevance. Adds client
process info to attachInfo logs. Removes some unused symbols.

Adds a new TRACE log level for highly-verbose output that
does not normally need to be displayed at DEBUG level.

Fixes log configuration for daos_server, daos_agent, dmg,
and daos to properly handle logging NOTICE/TRACE to
logfiles. If the --debug flag is used, set loglevel to
TRACE, as the intention in this case is usually to get
maximum logging.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>