### PR TITLE
DAOS-13123 control: Increase pool timeout to 5 minutes

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -40,7 +40,7 @@ const (
 	// request can take before being timed out.
 	PoolCreateTimeout = 10 * time.Minute // be generous for large pools
 	// DefaultPoolTimeout is the default timeout for a pool request.
-	DefaultPoolTimeout = daos.DefaultCartTimeout * 3
+	DefaultPoolTimeout = 5 * time.Minute
 )
 
 // checkUUID is a helper function for validating that the supplied

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -160,6 +160,10 @@ func (h *EngineHarness) CallDrpc(ctx context.Context, method drpc.Method, body p
 		if err == nil {
 			return
 		}
+		// If the context was canceled, don't trigger callbacks.
+		if errors.Cause(err) == context.Canceled {
+			return
+		}
 		// Don't trigger callbacks for these errors which can happen when
 		// things are still starting up.
 		if err == FaultHarnessNotStarted || err == errInstanceNotReady {


### PR DESCRIPTION
The current timeout of 3 minutes may be causing intermittent
failures in CI when a pool query happens during a rebuild.

Also updates the dRPC client implementation to return a
context.Canceled error when the dRPC connection is closed
due to timeout. This allows the harness to avoid incorrectly
invoking dRPC failure handlers for a canceled gRPC request.

Features: rebuild

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
