### PR TITLE
DAOS-13134 pool: use primary context to do bcast

### DIFF
--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -218,7 +218,7 @@ ds_cont_snap_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	}
 
 	rc = snap_create_bcast(tx, cont, in->cei_op.ci_hdl, in->cei_opts,
-			       rpc->cr_ctx, &snap_eph);
+			       dss_get_module_info()->dmi_ctx, &snap_eph);
 	if (rc == 0)
 		out->ceo_epoch = snap_eph;
 out:

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -177,7 +177,7 @@ void ds_cont_hdl_put(struct ds_cont_hdl *hdl);
 void ds_cont_hdl_get(struct ds_cont_hdl *hdl);
 
 int ds_cont_close_by_pool_hdls(uuid_t pool_uuid, uuid_t *pool_hdls,
-			       int n_pool_hdls, crt_context_t ctx);
+			       int n_pool_hdls);
 int ds_cont_local_close(uuid_t cont_hdl_uuid);
 
 int ds_cont_child_start_all(struct ds_pool_child *pool_child);


### PR DESCRIPTION
Server to server communication has to go through primary context since servers are not aware of each others secondary addresses.

This patch changed bcast code to use the primary context stored in dss_module_info->dmi_ctx instead of rpc->cr_ctx which could be secondary context if the RPC is from secondary provider.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
