### PR TITLE
DAOS-13144 common: fix to free lmdb memory

### DIFF
--- a/src/common/sys_lmdb.c
+++ b/src/common/sys_lmdb.c
@@ -434,10 +434,10 @@ lmm_db_fini(void)
 				mdb_dbi_close(lmm_db.db_env, lmm_db.db_dbi);
 			mdb_env_close(lmm_db.db_env);
 		}
-		free(lmm_db.db_file);
+		D_FREE(lmm_db.db_file);
 	}
 
-	free(lmm_db.db_path);
+	D_FREE(lmm_db.db_path);
 	memset(&lmm_db, 0, sizeof(lmm_db));
 }
 
@@ -455,8 +455,8 @@ lmm_db_init_ex(const char *db_path, const char *db_name, bool force_create, bool
 	if (rc != ABT_SUCCESS)
 		return -DER_NOMEM;
 
-	rc = asprintf(&lmm_db.db_path, "%s", db_path);
-	if (rc < 0) {
+	D_ASPRINTF(lmm_db.db_path, "%s", db_path);
+	if (lmm_db.db_path == NULL) {
 		D_ERROR("Generate sysdb path failed. %d\n", rc);
 		rc = -DER_NOMEM;
 		goto failed;
@@ -465,8 +465,8 @@ lmm_db_init_ex(const char *db_path, const char *db_name, bool force_create, bool
 	if (!db_name)
 		db_name = SYS_DB_NAME;
 
-	rc = asprintf(&lmm_db.db_file, "%s/%s", lmm_db.db_path, db_name);
-	if (rc < 0) {
+	D_ASPRINTF(lmm_db.db_file, "%s/%s", lmm_db.db_path, db_name);
+	if (lmm_db.db_file == NULL) {
 		D_ERROR("Generate sysdb filename failed. %d\n", rc);
 		rc = -DER_NOMEM;
 		goto failed;

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -888,6 +888,8 @@ server_fini(bool force)
 	 */
 	dss_srv_fini(force);
 	D_INFO("dss_srv_fini() done\n");
+	bio_nvme_fini();
+	D_INFO("bio_nvme_fini() done\n");
 	ds_iv_fini();
 	D_INFO("ds_iv_fini() done\n");
 	dss_module_unload_all();

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -804,11 +804,11 @@ vos_self_fini_locked(void)
 		self_mode.self_xs_ctxt = NULL;
 	}
 
-	vos_self_nvme_fini();
 	if (!bio_nvme_configured(SMD_DEV_TYPE_META))
 		vos_db_fini();
 	else
 		lmm_db_fini();
+	vos_self_nvme_fini();
 
 	if (self_mode.self_tls) {
 		vos_tls_fini(self_mode.self_tls);


### PR DESCRIPTION
1. In vos_self_fini_locked() bio_nvme_fini() need be called after sys db cleanup, because we need bio_nvme_configure() to check if MD on SSD enabled or not.
2. in lmm_db_fini() env need be destroyed after dbi closed to avoid use-after-free.
3. refactored lmm_db_init_ex() a bit to avoid potential memory leaks if lmm_db_open_create() return NOEXIST but it is not file not existed case.
4. add missed bio_nvme_fini() in the engine mode.