### PR TITLE
DAOS-623 engine: Update a warning in the IV code.

### DIFF
--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -1066,9 +1066,8 @@ retry:
 		 * but inflight fetch request return IVCB_FORWARD, then queued RPC will
 		 * reply IVCB_FORWARD.
 		 */
-		D_WARN("ns %u retry upon %d for class %d opc %d rank %u/%u\n",
-		       ns->iv_ns_id, rc, key->class_id, opc, key->rank,
-		       ns->iv_master_rank);
+		D_WARN("ns %u retry for class %d opc %d rank %u/%u: " DF_RC "\n", ns->iv_ns_id,
+		       key->class_id, opc, key->rank, ns->iv_master_rank, DP_RC(rc));
 		/* sleep 1sec and retry */
 		dss_sleep(1000);
 		goto retry;


### PR DESCRIPTION
Use proper formatting of errors with the DF_RC macro as
the last option in error messages.  This puts a string
in addition to just the error number.

This change avoids some CI failures where this log mesage
is occasionally reported during shutdown and wasn't being
correctly ignored as it was not well formatted.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
