### PR TITLE
DAOS-11421 test: Use explicit bdev tier roles.

### DIFF
--- a/src/tests/ftest/control/dmg_storage_query.py
+++ b/src/tests/ftest/control/dmg_storage_query.py
@@ -12,6 +12,7 @@ from control_test_base import ControlTestBase
 from dmg_utils import get_storage_query_pool_info, get_storage_query_device_info
 from exception_utils import CommandFailure
 from general_utils import list_to_str, dict_to_str
+from storage_utils import get_tier_roles
 
 
 class DmgStorageQuery(ControlTestBase):
@@ -52,15 +53,7 @@ class DmgStorageQuery(ControlTestBase):
                 if device['roles']:
                     # Use predefined roles
                     continue
-                if device['tier'] == 1:
-                    # Roles of 1st bdev storage tier of 1 tier is wal,data,meta; of 2+ tiers is wal
-                    device['roles'] = 'wal,data,meta' if bdev_tiers == 1 else 'wal'
-                elif device['tier'] == 2:
-                    # Roles of 2nd bdev storage tier of 2 tiers is data,meta; of 2+ tiers is meta
-                    device['roles'] = 'data,meta' if bdev_tiers == 2 else 'meta'
-                else:
-                    # Roles of additional bdev storage tiers is data
-                    device['roles'] = 'data'
+                device['roles'] = ','.join(get_tier_roles(device['tier'], bdev_tiers + 1))
 
         self.log.info('Detected NVMe devices in config')
         for bdev in bdev_info:

--- a/src/tests/ftest/util/storage_utils.py
+++ b/src/tests/ftest/util/storage_utils.py
@@ -613,7 +613,8 @@ class StorageInfo():
                     lines.append('          class: nvme')
                     lines.append(f'          bdev_list: [{", ".join(bdev_list[engine][tier])}]')
                     if not pmem_list:
-                        lines.append(f'          roles: [{", ".join(get_tier_roles(tier, tiers))}]')
+                        lines.append(
+                            f'          bdev_roles: [{", ".join(get_tier_roles(tier, tiers))}]')
 
         self._log.debug('  Creating %s', yaml_file)
         for line in lines:

--- a/src/tests/ftest/util/storage_utils.py
+++ b/src/tests/ftest/util/storage_utils.py
@@ -30,6 +30,39 @@ def find_pci_address(value):
     return re.findall(pattern, str(value))
 
 
+@staticmethod
+def get_tier_roles(tier, total_tiers):
+    """Get the roles for the specified bdev storage tier.
+
+    Args:
+        tier (int): the storage bdev tier number
+        total_tiers (int): total number of storage tiers
+
+    Raises:
+        ValueError: if the specified tier is not a bdev tier
+
+    Returns:
+        list: the roles for specified bdev tier
+
+    """
+    if tier == 0:
+        raise ValueError(f'Inappropriate bdev tier number: {tier}')
+    if tier == 1 and total_tiers == 2:
+        # A single bdev tier is assigned all roles
+        return ['wal', 'data', 'meta']
+    if tier == 1:
+        # The first of multiple bdev tiers in is assigned the wal role
+        return ['wal']
+    if tier == 2 and total_tiers == 3:
+        # The second of two bdev tiers in is assigned the data and meta role
+        return ['data', 'meta']
+    if tier == 2:
+        # The second of three or more bdev tiers in is assigned the meta
+        return ['meta']
+    # Any additional bdev tiers are assigned the data role
+    return ['data']
+
+
 class StorageException(Exception):
     """Exception for the StorageInfo class."""
 
@@ -580,6 +613,8 @@ class StorageInfo():
                 else:
                     lines.append('          class: nvme')
                     lines.append(f'          bdev_list: [{", ".join(bdev_list[engine][tier])}]')
+                    if not pmem_list:
+                        lines.append(f'          roles: [{", ".join(get_tier_roles(tier, tiers))}]')
 
         self._log.debug('  Creating %s', yaml_file)
         for line in lines:

--- a/src/tests/ftest/util/storage_utils.py
+++ b/src/tests/ftest/util/storage_utils.py
@@ -30,7 +30,6 @@ def find_pci_address(value):
     return re.findall(pattern, str(value))
 
 
-@staticmethod
 def get_tier_roles(tier, total_tiers):
     """Get the roles for the specified bdev storage tier.
 


### PR DESCRIPTION
When generating server storage configurations use explicit storage tier roles instead of implicit ones.

Skip-unit-tests: true
Test-tag: pr test_dmg_storage_query_devices
Test-nvme: auto_md_on_ssd

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
