### PR TITLE
DAOS-13042 test: Check total space for offline drain.

### DIFF
--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -118,20 +118,20 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
                                    "Pool Version Error:  After drain")
                 if self.test_during_aggregation is False:
                     self.assertGreater(initial_total_space, total_space_after_drain,
-                                       "Expected total space after drain is more than initial")
+                                       "Expected space after drain is more than initial")
                 if num_pool > 1:
                     output = self.pool.reintegrate(rank, t_string)
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
                     self.assertGreater(total_space_after_reintegration, total_space_after_drain,
-                            "Expected total space after reintegration is less than drain")
+                                       "Expected space after reintegration is less than drain")
                 if (self.test_during_rebuild is True and val == 0):
                     # Reintegrate rank 3
                     output = self.pool.reintegrate("3")
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
                     self.assertGreater(total_space_after_reintegration, total_space_after_drain,
-                            "Expected total space after reintegration is less than drain")
+                                       "Expected space after reintegration is less than drain")
 
         for val in range(0, num_pool):
             display_string = "Pool{} space at the End".format(val)

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -93,7 +93,7 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
                 # the rank back and then drain.
                 self.pool.display_pool_daos_space("Pool space: Beginning")
                 # Get initial total free space (scm+nvme)
-                initial_free_space = self.pool.get_total_free_space(refresh=True)
+                initial_total_space = self.pool.get_total_space(refresh=True)
                 pver_begin = self.pool.get_version(True)
                 self.log.info("Pool Version at the beginning %s", pver_begin)
                 if self.test_during_aggregation is True and index == 0:
@@ -109,28 +109,28 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
                     continue
                 output = self.pool.drain(rank, t_string)
                 self.print_and_assert_on_rebuild_failure(output)
-                free_space_after_drain = self.pool.get_total_free_space(refresh=True)
+                total_space_after_drain = self.pool.get_total_space(refresh=True)
 
                 pver_drain = self.pool.get_version(True)
                 self.log.info("Pool Version after drain %d", pver_drain)
                 # Check pool version incremented after pool drain
                 self.assertTrue(pver_drain > (pver_begin + 1), "Pool Version Error:  After drain")
                 if self.test_during_aggregation is False:
-                    self.assertTrue(initial_free_space > free_space_after_drain,
-                                    "Expected free space after drain is less than initial")
+                    self.assertTrue(initial_total_space > total_space_after_drain,
+                                    "Expected total space after drain is less than initial")
                 if num_pool > 1:
                     output = self.pool.reintegrate(rank, t_string)
                     self.print_and_assert_on_rebuild_failure(output)
-                    free_space_after_reintegration = self.pool.get_total_free_space(refresh=True)
-                    self.assertTrue(free_space_after_reintegration > free_space_after_drain,
-                                    "Expected free space after reintegration is less than drain")
+                    total_space_after_reintegration = self.pool.get_total_space(refresh=True)
+                    self.assertTrue(total_space_after_reintegration > total_space_after_drain,
+                                    "Expected total space after reintegration is less than drain")
                 if (self.test_during_rebuild is True and val == 0):
                     # Reintegrate rank 3
                     output = self.pool.reintegrate("3")
                     self.print_and_assert_on_rebuild_failure(output)
-                    free_space_after_reintegration = self.pool.get_total_free_space(refresh=True)
-                    self.assertTrue(free_space_after_reintegration > free_space_after_drain,
-                                    "Expected free space after reintegration is less than drain")
+                    total_space_after_reintegration = self.pool.get_total_space(refresh=True)
+                    self.assertTrue(total_space_after_reintegration > total_space_after_drain,
+                                    "Expected total space after reintegration is less than drain")
 
         for val in range(0, num_pool):
             display_string = "Pool{} space at the End".format(val)

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -114,23 +114,23 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
                 pver_drain = self.pool.get_version(True)
                 self.log.info("Pool Version after drain %d", pver_drain)
                 # Check pool version incremented after pool drain
-                self.assertTrue(pver_drain > (pver_begin + 1), "Pool Version Error:  After drain")
+                self.assertGreater(pver_drain, (pver_begin + 1), "Pool Version Error:  After drain")
                 if self.test_during_aggregation is False:
-                    self.assertTrue(initial_total_space > total_space_after_drain,
-                                    "Expected total space after drain is less than initial")
+                    self.assertGreater(initial_total_space, total_space_after_drain,
+                                       "Expected total space after drain is more than initial")
                 if num_pool > 1:
                     output = self.pool.reintegrate(rank, t_string)
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
-                    self.assertTrue(total_space_after_reintegration > total_space_after_drain,
-                                    "Expected total space after reintegration is less than drain")
+                    self.assertGreater(total_space_after_reintegration, total_space_after_drain,
+                                       "Expected total space after reintegration is less than drain")
                 if (self.test_during_rebuild is True and val == 0):
                     # Reintegrate rank 3
                     output = self.pool.reintegrate("3")
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
-                    self.assertTrue(total_space_after_reintegration > total_space_after_drain,
-                                    "Expected total space after reintegration is less than drain")
+                    self.assertGreater(total_space_after_reintegration, total_space_after_drain,
+                                       "Expected total space after reintegration is less than drain")
 
         for val in range(0, num_pool):
             display_string = "Pool{} space at the End".format(val)

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -114,7 +114,8 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
                 pver_drain = self.pool.get_version(True)
                 self.log.info("Pool Version after drain %d", pver_drain)
                 # Check pool version incremented after pool drain
-                self.assertGreater(pver_drain, (pver_begin + 1), "Pool Version Error:  After drain")
+                self.assertGreater(pver_drain, (pver_begin + 1),
+                                   "Pool Version Error:  After drain")
                 if self.test_during_aggregation is False:
                     self.assertGreater(initial_total_space, total_space_after_drain,
                                        "Expected total space after drain is more than initial")
@@ -123,14 +124,16 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
                     self.assertGreater(total_space_after_reintegration, total_space_after_drain,
-                                       "Expected total space after reintegration is less than drain")
+                                       "Expected total space after reintegration \
+                                        is less than drain")
                 if (self.test_during_rebuild is True and val == 0):
                     # Reintegrate rank 3
                     output = self.pool.reintegrate("3")
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
                     self.assertGreater(total_space_after_reintegration, total_space_after_drain,
-                                       "Expected total space after reintegration is less than drain")
+                                       "Expected total space after reintegration \
+                                        is less than drain")
 
         for val in range(0, num_pool):
             display_string = "Pool{} space at the End".format(val)

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -124,16 +124,14 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
                     self.assertGreater(total_space_after_reintegration, total_space_after_drain,
-                                       "Expected total space after reintegration \
-                                        is less than drain")
+                            "Expected total space after reintegration is less than drain")
                 if (self.test_during_rebuild is True and val == 0):
                     # Reintegrate rank 3
                     output = self.pool.reintegrate("3")
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
                     self.assertGreater(total_space_after_reintegration, total_space_after_drain,
-                                       "Expected total space after reintegration \
-                                        is less than drain")
+                            "Expected total space after reintegration is less than drain")
 
         for val in range(0, num_pool):
             display_string = "Pool{} space at the End".format(val)

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -118,20 +118,22 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
                                    "Pool Version Error:  After drain")
                 if self.test_during_aggregation is False:
                     self.assertGreater(initial_total_space, total_space_after_drain,
-                                       "Expected space after drain is more than initial")
+                                       "Expected total space after drain is more than initial")
                 if num_pool > 1:
                     output = self.pool.reintegrate(rank, t_string)
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
-                    self.assertGreater(total_space_after_reintegration, total_space_after_drain,
-                                       "Expected space after reintegration is less than drain")
+                    self.assertGreater(
+                        total_space_after_reintegration, total_space_after_drain,
+                        "Expected total space after reintegration is less than drain")
                 if (self.test_during_rebuild is True and val == 0):
                     # Reintegrate rank 3
                     output = self.pool.reintegrate("3")
                     self.print_and_assert_on_rebuild_failure(output)
                     total_space_after_reintegration = self.pool.get_total_space(refresh=True)
-                    self.assertGreater(total_space_after_reintegration, total_space_after_drain,
-                                       "Expected space after reintegration is less than drain")
+                    self.assertGreater(
+                        total_space_after_reintegration, total_space_after_drain,
+                        "Expected total space after reintegration is less than drain")
 
         for val in range(0, num_pool):
             display_string = "Pool{} space at the End".format(val)

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -1195,7 +1195,6 @@ class TestPool(TestDaosApiBase):
         tier_stats = self.get_tier_stats(refresh)
         return sum(stat["total"] for stat in tier_stats.values())
 
-
     def get_version(self, refresh=False):
         """Get the pool version from the dmg pool query output.
 

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -1181,6 +1181,21 @@ class TestPool(TestDaosApiBase):
         tier_stats = self.get_tier_stats(refresh)
         return sum(stat["free"] for stat in tier_stats.values())
 
+    def get_total_space(self, refresh=False):
+        """Get the pool total space.
+
+        Args:
+            refresh (bool, optional): whether or not to issue a new dmg pool query before
+                collecting the data from its output. Defaults to False.
+
+        Return:
+            total_space (int): pool total space.
+
+        """
+        tier_stats = self.get_tier_stats(refresh)
+        return sum(stat["total"] for stat in tier_stats.values())
+
+
     def get_version(self, refresh=False):
         """Get the pool version from the dmg pool query output.
 


### PR DESCRIPTION
Test-tag: offline_drain
Test-repeat: 3

Required-githooks: true

Summary:
Based on developer's input, we are checking the total space available instead of free space. Sometimes, the GC (garbage collection) can reclaim space which can cause intermittent failures.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
