### PR TITLE
DAOS-12601 mercury: disable multi-recv for all providers

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -495,10 +495,7 @@ do_init:
 		 * Ensure multi-recv is disabled and tag msgs are used for all
 		 * providers to preserve backward compatibility
 		 */
-		if (getenv("NA_OFI_UNEXPECTED_TAG_MSG") == NULL) {
-			D_INFO("NA_OFI_UNEXPECTED_TAG_MSG not set, set=1\n");
-			setenv("NA_OFI_UNEXPECTED_TAG_MSG", "1", true);
-		}
+		apply_if_not_set("NA_OFI_UNEXPECTED_TAG_MSG", "1");
 
 		/* Enable mrc by default for CXI */
 		if (prov == CRT_NA_OFI_CXI)

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -491,6 +491,15 @@ do_init:
 			       prov, set_sep, max_num_ctx,
 			       max_expect_size, max_unexpect_size);
 
+		/*
+		 * Ensure multi-recv is disabled and tag msgs are used for all
+		 * providers to preserve backward compatibility
+		 */
+		if (getenv("NA_OFI_UNEXPECTED_TAG_MSG") == NULL) {
+			D_INFO("NA_OFI_UNEXPECTED_TAG_MSG not set, set=1\n");
+			setenv("NA_OFI_UNEXPECTED_TAG_MSG", "1", true);
+		}
+
 		/* Enable mrc by default for CXI */
 		if (prov == CRT_NA_OFI_CXI)
 			mrc_enable = 1;


### PR DESCRIPTION
In preparation of mercury update to 2.3.0

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
