### PR TITLE
DAOS-13164 API: to add parameter flag to handle O_NOFOLLOW in dfs_access

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -4880,7 +4880,7 @@ out:
 }
 
 int
-dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask)
+dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask, int flag)
 {
 	daos_handle_t		oh;
 	bool			exists;
@@ -4922,7 +4922,7 @@ dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask)
 	if (!exists)
 		return ENOENT;
 
-	if (!S_ISLNK(entry.mode)) {
+	if (!S_ISLNK(entry.mode) || (flag & O_NOFOLLOW)) {
 		if (mask == F_OK)
 			return 0;
 

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -5021,11 +5021,6 @@ dfs_chmod_wflag(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode, in
 	if (!exists)
 		return ENOENT;
 
-	/* Mimic the behavior of fchmodat() in libc. */
-	if (!S_ISLNK(entry.mode) && (flag & O_NOFOLLOW)) {
-		return EOPNOTSUPP;
-	}
-
 	/** resolve symlink */
 	if (S_ISLNK(entry.mode) && !(flag & O_NOFOLLOW)) {
 		D_ASSERT(entry.value);

--- a/src/client/dfs/dfs_sys.c
+++ b/src/client/dfs/dfs_sys.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2022 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/client/dfs/dfs_sys.c
+++ b/src/client/dfs/dfs_sys.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -672,7 +672,7 @@ dfs_sys_access(dfs_sys_t *dfs_sys, const char *path, int mask, int flags)
 	/* Either we are following symlinks, the obj is root,
 	 * or the obj is not a symlink. So just call dfs_access.
 	 */
-	rc = dfs_access(dfs_sys->dfs, sys_path.parent, sys_path.name, mask);
+	rc = dfs_access(dfs_sys->dfs, sys_path.parent, sys_path.name, mask, 0);
 
 out_free_path:
 	sys_path_free(dfs_sys, &sys_path);

--- a/src/client/dfs/dfs_sys.c
+++ b/src/client/dfs/dfs_sys.c
@@ -672,7 +672,7 @@ dfs_sys_access(dfs_sys_t *dfs_sys, const char *path, int mask, int flags)
 	/* Either we are following symlinks, the obj is root,
 	 * or the obj is not a symlink. So just call dfs_access.
 	 */
-	rc = dfs_access(dfs_sys->dfs, sys_path.parent, sys_path.name, mask, 0);
+	rc = dfs_access(dfs_sys->dfs, sys_path.parent, sys_path.name, mask);
 
 out_free_path:
 	sys_path_free(dfs_sys, &sys_path);

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -1015,12 +1015,29 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags);
  * \param[in]	mask	accessibility check(s) to be performed.
  *			It should be either the value F_OK, or a mask with
  *			bitwise OR of one or more of R_OK, W_OK, and X_OK.
+ *
+ * \return		0 on success, errno code on failure.
+ */
+int
+dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask);
+
+/**
+ * Check access permissions on an object. Symlinks are not dereferenced if
+ * O_NOFOLLOW is set in flag. Otherwise, it is same as dfs_access.
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ * \param[in]	parent	Opened parent directory object. If NULL, use root obj.
+ * \param[in]	name	Link name of the object. Can be NULL if parent is root,
+ * 			which means operation will be on root object.
+ * \param[in]	mask	accessibility check(s) to be performed.
+ * 			It should be either the value F_OK, or a mask with
+ * 			bitwise OR of one or more of R_OK, W_OK, and X_OK.
  * \param[in]	flag	bitwise flag. Handles O_NOFOLLOW.
  *
  * \return		0 on success, errno code on failure.
  */
 int
-dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask, int flag);
+dfs_access_wflag(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask, int flag);
 
 /**
  * Change permission access bits. Symlinks are dereferenced.
@@ -1036,6 +1053,22 @@ dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask, int flag);
  */
 int
 dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode);
+
+/**
+ * Change permission access bits. Symlinks are not dereferenced if O_NOFOLLOW
+ * is set in flag. Otherwise, it is same as dfs_chmod.
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ * \param[in]	parent	Opened parent directory object. If NULL, use root obj.
+ * \param[in]	name	Link name of the object. Can be NULL if parent is root,
+ * \param[in]	mode	New permission access modes. For now, we don't support
+ * 			the sticky bit, setuid, and setgid.
+ * \param[in]	flag	bitwise flag. Handles O_NOFOLLOW.
+ *
+ * \return		0 on success, errno code on failure.
+ */
+int
+dfs_chmod_wflag(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode, int flag);
 
 /**
  * Change owner and group. Since uid and gid are not enforced

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -1028,10 +1028,10 @@ dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask);
  * \param[in]	dfs	Pointer to the mounted file system.
  * \param[in]	parent	Opened parent directory object. If NULL, use root obj.
  * \param[in]	name	Link name of the object. Can be NULL if parent is root,
- * 			which means operation will be on root object.
+ *			which means operation will be on root object.
  * \param[in]	mask	accessibility check(s) to be performed.
- * 			It should be either the value F_OK, or a mask with
- * 			bitwise OR of one or more of R_OK, W_OK, and X_OK.
+ *			It should be either the value F_OK, or a mask with
+ *			bitwise OR of one or more of R_OK, W_OK, and X_OK.
  * \param[in]	flag	bitwise flag. Handles O_NOFOLLOW.
  *
  * \return		0 on success, errno code on failure.
@@ -1062,7 +1062,7 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode);
  * \param[in]	parent	Opened parent directory object. If NULL, use root obj.
  * \param[in]	name	Link name of the object. Can be NULL if parent is root,
  * \param[in]	mode	New permission access modes. For now, we don't support
- * 			the sticky bit, setuid, and setgid.
+ *			the sticky bit, setuid, and setgid.
  * \param[in]	flag	bitwise flag. Handles O_NOFOLLOW.
  *
  * \return		0 on success, errno code on failure.

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1015,11 +1015,12 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags);
  * \param[in]	mask	accessibility check(s) to be performed.
  *			It should be either the value F_OK, or a mask with
  *			bitwise OR of one or more of R_OK, W_OK, and X_OK.
+ * \param[in]	flag	bitwise flag. Handles O_NOFOLLOW.
  *
  * \return		0 on success, errno code on failure.
  */
 int
-dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask);
+dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask, int flag);
 
 /**
  * Change permission access bits. Symlinks are dereferenced.

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -452,6 +452,7 @@ dfs_test_syml_follow_hlpr(const char *name, mode_t mode)
 	dfs_obj_t	*obj;
 	mode_t		actual_mode;
 	mode_t		actual_mode_link;
+	mode_t		mode_new;
 	char		path[64];
 	int		rc;
 
@@ -509,7 +510,8 @@ dfs_test_syml_follow_hlpr(const char *name, mode_t mode)
 	assert_int_equal(rc, 0);
 
 	/* Remove the write permission for the link itself */
-	rc = dfs_chmod_wflag(dfs_mt, NULL, name, actual_mode_link & (~S_IWUSR), O_NOFOLLOW);
+	mode_new = actual_mode_link & (~(S_IWUSR | S_IWGRP | S_IWOTH));
+	rc = dfs_chmod_wflag(dfs_mt, NULL, name, mode_new, O_NOFOLLOW);
 	print_message("dfs_test_syml_follow_chmod_wflag(\"%s\") = %d\n", name, rc);
 	assert_int_equal(rc, 0);
 
@@ -519,7 +521,7 @@ dfs_test_syml_follow_hlpr(const char *name, mode_t mode)
 	assert_int_equal(rc, 0);
 	rc = dfs_release(obj);
 	assert_int_equal(rc, 0);
-	assert_int_equal(actual_mode, actual_mode_link & (~S_IWUSR));
+	assert_int_equal(actual_mode, mode_new);
 
 	/* Check with dfs_access_wflag() */
 	rc = dfs_access_wflag(dfs_mt, NULL, name, W_OK, O_NOFOLLOW);

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -496,7 +496,7 @@ dfs_test_syml_follow_hlpr(const char *name, mode_t mode)
 	assert_int_equal(actual_mode & S_IFMT, mode & S_IFMT);
 
 	/** Default access should follow the link */
-	rc = dfs_access(dfs_mt, NULL, name, R_OK | W_OK);
+	rc = dfs_access(dfs_mt, NULL, name, R_OK | W_OK, 0);
 	print_message("dfs_test_syml_follow_access(\"%s\") = %d\n", name, rc);
 	assert_int_equal(rc, 0);
 }


### PR DESCRIPTION
faccessat() in libc has a flag to handle AT_SYMLINK_NOFOLLOW. We need a similar parameter for DFS too.
Also replace EPERM with EACCESS in check_access() to be consistent with access() in glibc.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
