### PR TITLE
DAOS-13169 test: Adding support for custom test yaml files.

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -477,8 +477,11 @@ class TestInfo():
         self.name = TestName(test_file, order, 0)
         self.test_file = test_file
         self.yaml_file = ".".join([os.path.splitext(self.test_file)[0], "yaml"])
-        if yaml_extension and os.path.exists(".".join([self.yaml_file, str(yaml_extension)])):
-            self.yaml_file = ".".join([self.yaml_file, str(yaml_extension)])
+        if yaml_extension:
+            custom_yaml = ".".join(
+                [os.path.splitext(self.test_file)[0], str(yaml_extension), "yaml"])
+            if os.path.exists(custom_yaml):
+                self.yaml_file = custom_yaml
         parts = self.test_file.split(os.path.sep)[1:]
         self.python_file = parts.pop()
         self.directory = os.path.join(*parts)
@@ -3153,7 +3156,7 @@ def main():
         action="store",
         default=None,
         help="extension used to run custom test yaml files. If a test yaml file "
-             "exists with the specified extension - e.g. dtx/basic.yaml.custom "
+             "exists with the specified extension - e.g. dtx/basic.custom.yaml "
              "for --yaml_extension=custom - this file will be used instead of the "
              "standard test yaml file.")
     args = parser.parse_args()

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -3041,7 +3041,7 @@ def main():
         help="modify the test yaml files but do not run the tests")
     parser.add_argument(
         "-mo", "--mode",
-        choices=['normal', 'manual', 'ci', 'gcp'],
+        choices=['normal', 'manual', 'ci'],
         default='normal',
         help="provide the mode of test to be run under. Default is normal, "
              "in which the final return code of launch.py is still zero if "
@@ -3161,9 +3161,6 @@ def main():
              "standard test yaml file.")
     args = parser.parse_args()
 
-    # Setup the Launch object
-    launch = Launch(args.name, args.mode)
-
     # Override arguments via the mode
     if args.mode == "ci":
         args.archive = True
@@ -3176,10 +3173,9 @@ def main():
             args.logs_threshold = DEFAULT_LOGS_THRESHOLD
         args.slurm_setup = True
         args.user_create = True
-    elif args.mode == "gcp":
-        args.archive = True
-        args.include_local_host = True
-        args.yaml_extension = args.mode
+
+    # Setup the Launch object
+    launch = Launch(args.name, args.mode)
 
     # Perform the steps defined by the arguments specified
     try:


### PR DESCRIPTION
In order to support removing certain test yaml file entries a new --yaml_extension launch.py argument is being added to allow users to override using the default test yaml files with any yaml files with the specified extension.

Skip-unit-tests: true
Skip-func-hw-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
