### PR TITLE
DAOS-623 test: Only use open remote PR for base

### DIFF
--- a/utils/githooks/find_base.sh
+++ b/utils/githooks/find_base.sh
@@ -16,6 +16,11 @@ if command -v gh > /dev/null 2>&1; then
     # If there is no PR created yet then do not check anything.
     if ! TARGET="$ORIGIN"/$(gh pr view "$BRANCH" --json baseRefName -t "{{.baseRefName}}"); then
         TARGET=HEAD
+    else
+        state="$ORIGIN"/$(gh pr view "$BRANCH" --json state -t "{{.state}}")
+        if [ "$state" = "MERGED" ]; then
+            TARGET=HEAD
+        fi
     fi
 else
     # With no 'gh' command installed then check against origin/master.

--- a/utils/githooks/find_base.sh
+++ b/utils/githooks/find_base.sh
@@ -17,8 +17,9 @@ if command -v gh > /dev/null 2>&1; then
     if ! TARGET="$ORIGIN"/$(gh pr view "$BRANCH" --json baseRefName -t "{{.baseRefName}}"); then
         TARGET=HEAD
     else
-        state="$ORIGIN"/$(gh pr view "$BRANCH" --json state -t "{{.state}}")
-        if [ "$state" != "OPEN" ]; then
+        state=$(gh pr view "$BRANCH" --json state -t "{{.state}}")
+        if [ ! "$state" = "OPEN" ]; then
+            echo "Thinks state is not OPEN, $state"
             TARGET=HEAD
         fi
     fi

--- a/utils/githooks/find_base.sh
+++ b/utils/githooks/find_base.sh
@@ -19,7 +19,6 @@ if command -v gh > /dev/null 2>&1; then
     else
         state=$(gh pr view "$BRANCH" --json state -t "{{.state}}")
         if [ ! "$state" = "OPEN" ]; then
-            echo "Thinks state is not OPEN, $state"
             TARGET=HEAD
         fi
     fi

--- a/utils/githooks/find_base.sh
+++ b/utils/githooks/find_base.sh
@@ -18,7 +18,7 @@ if command -v gh > /dev/null 2>&1; then
         TARGET=HEAD
     else
         state="$ORIGIN"/$(gh pr view "$BRANCH" --json state -t "{{.state}}")
-        if [ "$state" = "MERGED" ]; then
+        if [ "$state" != "OPEN" ]; then
             TARGET=HEAD
         fi
     fi


### PR DESCRIPTION
I hit a situation where I resused a remote branch
from a PR that had been merged and the branch
deleted.  This caused my new PR to use a testbuild branch for the base calculation.

Add a check to find_base.sh that the branch it
finds is an open PR.

Skip-build: true
Skip-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
