### PR TITLE
DAOS-13157 test: nvme_fault_reintegration - not in expected NORMAL, OFF state

### DIFF
--- a/src/tests/ftest/vmd/fault_reintegration.py
+++ b/src/tests/ftest/vmd/fault_reintegration.py
@@ -103,7 +103,8 @@ class NvmeFaultReintegrate(TestWithServers):
             9. Replace the same drive back.
             10. Drive status LED should be off indicating good device is plugged-in.
 
-        :avocado: tags=manual
+        :avocado: tags=all,manual
+        :avocado: tags=hw,medium
         :avocado: tags=vmd,vmd_led
         :avocado: tags=NvmeFaultReintegrate,test_nvme_fault_reintegration
 

--- a/src/tests/ftest/vmd/fault_reintegration.py
+++ b/src/tests/ftest/vmd/fault_reintegration.py
@@ -103,8 +103,7 @@ class NvmeFaultReintegrate(TestWithServers):
             9. Replace the same drive back.
             10. Drive status LED should be off indicating good device is plugged-in.
 
-        :avocado: tags=all,daily_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=manual
         :avocado: tags=vmd,vmd_led
         :avocado: tags=NvmeFaultReintegrate,test_nvme_fault_reintegration
 


### PR DESCRIPTION

Hardware-medium led_state is NA, move this testcase to manual

Skip-unit-tests: true
Test-tag: test_nvme_fault_reintegration,-manual
Allow-unstable-test: true
Required-githooks: true
Signed-off-by: Ding Ho ding-hwa.ho@intel.com

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
