### PR TITLE
DAOS-12398 object: Check punch epoch before migration punch (#11667)

### DIFF
--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -47,4 +47,5 @@ int ds_rebuild_regenerate_task(struct ds_pool *pool, daos_prop_t *prop);
 void ds_rebuild_leader_stop_all(void);
 void ds_rebuild_abort(uuid_t pool_uuid, unsigned int version, uint32_t rebuild_gen,
 		      uint64_t term);
+void ds_rebuild_running_query(uuid_t pool_uuid, uint32_t *upper_ver);
 #endif

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1423,7 +1423,7 @@ migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 	int	i;
 
 	/* Punch dkey */
-	if (mrone->mo_dkey_punch_eph != 0) {
+	if (mrone->mo_dkey_punch_eph != 0 && mrone->mo_dkey_punch_eph <= tls->mpt_max_eph) {
 		D_DEBUG(DB_REBUILD, DF_UOID" punch dkey "DF_KEY"/"DF_U64"\n",
 			DP_UOID(mrone->mo_oid), DP_KEY(&mrone->mo_dkey),
 			mrone->mo_dkey_punch_eph);
@@ -1443,8 +1443,13 @@ migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 
 		eph = mrone->mo_akey_punch_ephs[i];
 		D_ASSERT(eph != DAOS_EPOCH_MAX);
-		if (eph == 0)
+		if (eph == 0 || eph > tls->mpt_max_eph) {
+			D_DEBUG(DB_REBUILD, DF_UOID" skip mrone %p punch dkey "
+				DF_KEY" akey "DF_KEY" eph "DF_X64" current "DF_X64"\n",
+				DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
+				DP_KEY(&mrone->mo_iods[i].iod_name), eph, mrone->mo_epoch);
 			continue;
+		}
 
 		D_DEBUG(DB_REBUILD, DF_UOID" mrone %p punch dkey "
 			DF_KEY" akey "DF_KEY" eph "DF_U64"\n",
@@ -1465,7 +1470,7 @@ migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 	}
 
 	/* punch records */
-	if (mrone->mo_punch_iod_num > 0) {
+	if (mrone->mo_punch_iod_num > 0 && mrone->mo_rec_punch_eph <= tls->mpt_max_eph) {
 		rc = vos_obj_update(cont->sc_hdl, mrone->mo_oid,
 				    mrone->mo_rec_punch_eph,
 				    mrone->mo_version, 0, &mrone->mo_dkey,
@@ -1672,8 +1677,8 @@ migrate_one_ult(void *arg)
 	daos_size_t		data_size;
 	int			rc = 0;
 
-	if (daos_fail_check(DAOS_REBUILD_TGT_REBUILD_HANG))
-		dss_sleep(daos_fail_value_get() * 1000000);
+	while (daos_fail_check(DAOS_REBUILD_TGT_REBUILD_HANG))
+		dss_sleep(0);
 
 	tls = migrate_pool_tls_lookup(mrone->mo_pool_uuid,
 				      mrone->mo_pool_tls_version, mrone->mo_generation);
@@ -2896,6 +2901,8 @@ migrate_obj_ult(void *data)
 	for (i = 0; i < arg->snap_cnt; i++) {
 		epr.epr_lo = i > 0 ? arg->snaps[i-1] + 1 : 0;
 		epr.epr_hi = arg->snaps[i];
+		D_DEBUG(DB_REBUILD, "rebuild_snap %d "DF_X64"-"DF_X64"\n",
+			i, epr.epr_lo, epr.epr_hi);
 		rc = migrate_one_epoch_object(&epr, tls, arg);
 		if (rc)
 			D_GOTO(free, rc);

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -1,6 +1,6 @@
 /**
  *
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1094,7 +1094,6 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
 	 * to be added to the layout. But this is only needed for update.
 	 */
 	if (unlikely(is_extending || is_adding_new) && !(mode & DAOS_OO_RO)) {
-		/* Needed to check if domains are being added to pool map */
 		D_DEBUG(DB_PL, DF_OID"/%d is being added: %s or extended: %s\n",
 			DP_OID(oid), md->omd_ver, is_adding_new ? "yes" : "no",
 			is_extending ? "yes" : "no");

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -470,6 +470,19 @@ out:
 	return rc;
 }
 
+void
+ds_rebuild_running_query(uuid_t pool_uuid, uint32_t *upper_ver)
+{
+	struct rebuild_tgt_pool_tracker	*rpt;
+
+	*upper_ver = 0;
+	rpt = rpt_lookup(pool_uuid, -1, -1);
+	if (rpt != NULL && !rpt->rt_global_done && !rpt->rt_abort)
+		*upper_ver = rpt->rt_rebuild_ver;
+	if (rpt)
+		rpt_put(rpt);
+}
+
 /* TODO: Add something about what the current operation is for output status */
 int
 ds_rebuild_query(uuid_t pool_uuid, struct daos_rebuild_status *status)

--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python3
 """
-  (C) Copyright 2022 Intel Corporation.
+  (C) Copyright 2022-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import random
+import time
 
+from exception_utils import CommandFailure
 from control_test_base import ControlTestBase
 
 
@@ -134,8 +136,21 @@ class DmgPoolQueryRanks(ControlTestBase):
         self.log.info("Starting reintegrating ranks: all_ranks=%s", all_ranks)
         for rank in all_ranks:
             self.log.debug("Reintegrating rank %d", rank)
-            self.pool.reintegrate(rank)
 
+            counter = 0
+            cmd_succeed = False
+            while counter < 3:
+                try:
+                    result = self.pool.reintegrate(rank)
+                except CommandFailure:
+                    self.log.debug("dmg command failed retry")
+                else:
+                    cmd_succeed = True
+                    break
+                counter += 1
+                time.sleep(3)
+
+            self.assertTrue(cmd_succeed, result)
             enabled_ranks = sorted(enabled_ranks + [rank])
             disabled_ranks.remove(rank)
 

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -377,6 +377,8 @@ rebuild_destroy_pool_cb(void *data)
 		/* Disable fail_loc and start rebuild */
 		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
+		daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_VALUE,
+				      0, 0, NULL);
 		rc = dmg_pool_destroy(dmg_config_file, arg->pool.pool_uuid,
 				      NULL, true);
 		if (rc) {

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -109,8 +109,8 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 		int *tgts, int rank_nr, bool kill,
 		enum REBUILD_TEST_OP_TYPE op_type)
 {
-	int   i;
-	int   rc;
+	int	i;
+	int	rc;
 
 	for (i = 0; i < args_cnt; i++) {
 		daos_pool_info_t	pool_info;
@@ -129,19 +129,44 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 		if (args[i]->rebuild_pre_cb)
 			args[i]->rebuild_pre_cb(args[i]);
 
-	MPI_Barrier(MPI_COMM_WORLD);
 	/** include or exclude the target from the pool */
-	if (args[0]->myrank == 0) {
-		for (i = 0; i < rank_nr; i++) {
+	if (op_type == RB_OP_TYPE_FAIL) {
+		MPI_Barrier(MPI_COMM_WORLD);
+		if (args[0]->myrank == 0) {
+			for (i = 0; i < rank_nr; i++)
+				rebuild_exclude_tgt(args, args_cnt, ranks[i],
+						    tgts ? tgts[i] : -1, kill);
+		}
+		MPI_Barrier(MPI_COMM_WORLD);
+
+		for (i = 0; i < args_cnt; i++)
+			if (args[i]->rebuild_cb)
+				args[i]->rebuild_cb(args[i]);
+
+		if (args[0]->myrank == 0 && !args[0]->no_rebuild)
+			test_rebuild_wait(args, args_cnt);
+
+		MPI_Barrier(MPI_COMM_WORLD);
+		for (i = 0; i < args_cnt; i++) {
+			if (args[i]->rebuild_post_cb)
+				args[i]->rebuild_post_cb(args[i]);
+		}
+		return;
+
+	}
+
+	for (i = 0; i < rank_nr; i++) {
+		int j;
+
+		/* No concurrent drain/extend/reintegration are allowed, so
+		 * it has to reintegrate/extend one by one.
+		 */
+		MPI_Barrier(MPI_COMM_WORLD);
+		if (args[0]->myrank == 0) {
 			switch (op_type) {
-			case RB_OP_TYPE_FAIL:
-				rebuild_exclude_tgt(args, args_cnt,
-						ranks[i], tgts ? tgts[i] : -1,
-						kill);
-				break;
 			case RB_OP_TYPE_REINT:
 				rebuild_reint_tgt(args, args_cnt, ranks[i],
-						tgts ? tgts[i] : -1);
+						  tgts ? tgts[i] : -1);
 				break;
 			case RB_OP_TYPE_ADD:
 				rebuild_extend_tgt(args, args_cnt, ranks[i],
@@ -160,22 +185,22 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *ranks,
 				 */
 				D_ASSERT(op_type != RB_OP_TYPE_RECLAIM);
 				break;
+			default:
+				break;
 			}
 		}
-	}
-	MPI_Barrier(MPI_COMM_WORLD);
+		MPI_Barrier(MPI_COMM_WORLD);
+		for (j = 0; j < args_cnt; j++)
+			if (args[j]->rebuild_cb)
+				args[j]->rebuild_cb(args[j]);
 
-	for (i = 0; i < args_cnt; i++)
-		if (args[i]->rebuild_cb)
-			args[i]->rebuild_cb(args[i]);
+		if (args[0]->myrank == 0 && !args[0]->no_rebuild)
+			test_rebuild_wait(args, args_cnt);
 
-	if (args[0]->myrank == 0 && !args[0]->no_rebuild)
-		test_rebuild_wait(args, args_cnt);
-
-	MPI_Barrier(MPI_COMM_WORLD);
-	for (i = 0; i < args_cnt; i++) {
-		if (args[i]->rebuild_post_cb)
-			args[i]->rebuild_post_cb(args[i]);
+		for (j = 0; j < args_cnt; j++) {
+			if (args[j]->rebuild_post_cb)
+				args[j]->rebuild_post_cb(args[j]);
+		}
 	}
 }
 

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -35,6 +35,10 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	int i;
 	int rc = 0;
 
+	/* Increase pre_pool_ver to make sure the rebuild caused by this
+	 * exclude/kill to be waited in the following rebuild_pool_wait().
+	 */
+	args[0]->rebuild_pre_pool_ver++;
 	if (kill) {
 		daos_kill_server(args[0], args[0]->pool.pool_uuid,
 				 args[0]->group, args[0]->pool.alive_svc,

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -738,25 +738,22 @@ rebuild_pool_wait(test_arg_t *arg)
 	pinfo.pi_bits = DPI_REBUILD_STATUS;
 	rc = test_pool_get_info(arg, &pinfo, NULL /* engine_ranks */);
 	rst = &pinfo.pi_rebuild_st;
-	if ((rst->rs_state == DRS_COMPLETED || rc != 0) && rst->rs_version != 0 &&
-	    ((rst->rs_version > arg->rebuild_pre_pool_ver) ||
+	if ((rst->rs_state == DRS_COMPLETED || rc != 0) &&
+	    (rst->rs_version > arg->rebuild_pre_pool_ver ||
+	     pinfo.pi_map_ver > arg->rebuild_pre_pool_ver ||
 	     (rst->rs_version == arg->rebuild_pre_pool_ver &&
 	      arg->no_rebuild_version_change))) {
-		print_message("Rebuild "DF_UUIDF" (ver=%u orig_ver=%u) is done %d/%d, "
-			      "obj="DF_U64", rec="DF_U64".\n",
-			       DP_UUID(arg->pool.pool_uuid), rst->rs_version,
-			       arg->rebuild_pre_pool_ver,
-			       rc, rst->rs_errno, rst->rs_obj_nr,
-			       rst->rs_rec_nr);
+		print_message("Rebuild "DF_UUIDF" (ver=%u pi_ver = %u orig_ver=%u) is done %d/%d,"
+			      "obj="DF_U64", rec="DF_U64".\n", DP_UUID(arg->pool.pool_uuid),
+			      rst->rs_version, pinfo.pi_map_ver, arg->rebuild_pre_pool_ver,
+			      rc, rst->rs_errno, rst->rs_obj_nr, rst->rs_rec_nr);
 		done = true;
 	} else {
-		print_message("wait for rebuild pool "DF_UUIDF"(ver=%u orig_ver=%u), "
-			      "to-be-rebuilt obj="DF_U64", already rebuilt obj="
-			      DF_U64", rec="DF_U64"\n",
-			      DP_UUID(arg->pool.pool_uuid), rst->rs_version,
-			      arg->rebuild_pre_pool_ver,
-			      rst->rs_toberb_obj_nr, rst->rs_obj_nr,
-			      rst->rs_rec_nr);
+		print_message("wait for rebuild pool "DF_UUIDF"(ver=%u pi_ver=%u orig_ver=%u),"
+			      "to-be-rebuilt obj="DF_U64", already rebuilt obj="DF_U64","
+			      "rec="DF_U64"\n", DP_UUID(arg->pool.pool_uuid), rst->rs_version,
+			      pinfo.pi_map_ver, arg->rebuild_pre_pool_ver, rst->rs_toberb_obj_nr,
+			      rst->rs_obj_nr, rst->rs_rec_nr);
 	}
 
 	return done;


### PR DESCRIPTION
Since object enumeration might return next punch epoch of the current object/key/rec, so let's compare the punch epoch with rebuild/reintegration stable epoch before migrate punch.

Do not allow reint/drain/extend if there are other rebuild job going on to avoid screwing up the object layout.

Fix converting task error reset in dc_tx_check_update()

Retry UPDATE_AGAIN with delay, similar as INPROGRESS.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
