### PR TITLE
DAOS-13193 test: Enabling extra yamls to update storage configs

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -3118,7 +3118,7 @@ def main():
         type=str,
         help="the scm_mount base path to use in each server engine tier 0 storage config when "
              "generating an automatic storage config (test yaml includes 'storage: auto'). The "
-             "engine number will be added at the end of this string, e.g. '/mnt/daos0'.)
+             "engine number will be added at the end of this string, e.g. '/mnt/daos0'.")
     parser.add_argument(
         "-ss", "--slurm_setup",
         action="store_true",

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1484,7 +1484,6 @@ class Launch():
         storage = None
         storage_info = StorageInfo(logger, args.test_servers)
         tier_0_type = "pmem"
-        scm_size = 16
         max_nvme_tiers = 1
         if args.nvme:
             kwargs = {"device_filter": f"'({'|'.join(args.nvme.split(','))})'"}
@@ -1516,7 +1515,8 @@ class Launch():
                 test.extra_yaml.extend(common_extra_yaml)
 
         # Generate storage configuration extra yaml files if requested
-        self._add_auto_storage_yaml(storage_info, yaml_dir, tier_0_type, scm_size, max_nvme_tiers)
+        self._add_auto_storage_yaml(
+            storage_info, yaml_dir, tier_0_type, args.scm_size, args.scm_mount, max_nvme_tiers)
 
         # Replace any placeholders in the test yaml file
         for test in self.tests:
@@ -1537,7 +1537,8 @@ class Launch():
             # Collect the host information from the updated test yaml
             test.set_yaml_info(args.include_localhost)
 
-    def _add_auto_storage_yaml(self, storage_info, yaml_dir, tier_0_type, scm_size, max_nvme_tiers):
+    def _add_auto_storage_yaml(self, storage_info, yaml_dir, tier_0_type, scm_size, scm_mount,
+                               max_nvme_tiers):
         """Add extra storage yaml definitions for tests requesting automatic storage configurations.
 
         Args:
@@ -1545,6 +1546,7 @@ class Launch():
             yaml_dir (str): path in which to create the extra storage yaml files
             tier_0_type (str): storage tier 0 type to define; 'pmem' or 'ram'
             scm_size (int): scm_size to use with ram storage tiers
+            scm_mount (str): the base path for the storage tier 0 scm_mount.
             max_nvme_tiers (int): maximum number of NVMe tiers to generate
 
         Raises:
@@ -1570,12 +1572,13 @@ class Launch():
                 if engines not in engine_storage_yaml:
                     logger.debug("-" * 80)
                     storage_info.write_storage_yaml(
-                        yaml_file, engines, tier_0_type, scm_size, max_nvme_tiers)
+                        yaml_file, engines, tier_0_type, scm_size, scm_mount, max_nvme_tiers)
                     engine_storage_yaml[engines] = yaml_file
                 logger.debug(
                     "  - Adding auto-storage extra yaml %s for %s",
                     engine_storage_yaml[engines], str(test))
-                test.extra_yaml.append(engine_storage_yaml[engines])
+                # Allow extra yaml files to be to override the generated storage yaml
+                test.extra_yaml.insert(0, engine_storage_yaml[engines])
 
     @staticmethod
     def _query_create_group(hosts, group, create=False):
@@ -3101,6 +3104,21 @@ def main():
         type=str,
         help="slurm control node where scontrol commands will be issued to check for the existence "
              "of any slurm partitions required by the tests")
+    parser.add_argument(
+        "--scm_size",
+        action="store",
+        default=16,
+        type=int,
+        help="the scm_size value to use in each server engine tier 0 ram storage config when "
+             "generating an automatic storage config (test yaml includes 'storage: auto').")
+    parser.add_argument(
+        "--scm_mount",
+        action="store",
+        default="/mnt/daos",
+        type=str,
+        help="the scm_mount base path to use in each server engine tier 0 storage config when "
+             "generating an automatic storage config (test yaml includes 'storage: auto'). The "
+             "engine number will be added at the end of this string, e.g. '/mnt/daos0'.)
     parser.add_argument(
         "-ss", "--slurm_setup",
         action="store_true",

--- a/src/tests/ftest/util/storage_utils.py
+++ b/src/tests/ftest/util/storage_utils.py
@@ -495,7 +495,8 @@ class StorageInfo():
 
         return controllers
 
-    def write_storage_yaml(self, yaml_file, engines, tier_0_type, scm_size=100, max_nvme_tiers=1):
+    def write_storage_yaml(self, yaml_file, engines, tier_0_type, scm_size=100,
+                           scm_mount='/mnt/daos', max_nvme_tiers=1):
         """Generate a storage test yaml sub-section.
 
         Args:
@@ -503,6 +504,7 @@ class StorageInfo():
             engines (int): number of engines
             tier_0_type (str): storage tier 0 type: 'pmem' or 'ram'
             scm_size (int, optional): scm_size to use with ram storage tiers. Defaults to 100.
+            scm_mount (str): the base path for the storage tier 0 scm_mount.
             max_nvme_tiers (int): maximum number of nvme storage tiers. Defaults to 1.
 
         Raises:
@@ -572,10 +574,10 @@ class StorageInfo():
                 if tier == 0 and pmem_list:
                     lines.append('          class: dcpm')
                     lines.append(f'          scm_list: ["{pmem_list[engine]}"]')
-                    lines.append(f'          scm_mount: /mnt/daos{engine}')
+                    lines.append(f'          scm_mount: {scm_mount}{engine}')
                 elif tier == 0:
                     lines.append('          class: ram')
-                    lines.append(f'          scm_mount: /mnt/daos{engine}')
+                    lines.append(f'          scm_mount: {scm_mount}{engine}')
                     lines.append(f'          scm_size: {scm_size}')
                 else:
                     lines.append('          class: nvme')


### PR DESCRIPTION
Allowing extra yaml file entries to update generated storage configuration yaml files.  Also adding --scm_size and --scm_mount launch.py arguments to finer tune the generated storage configuration yaml files.

Test-tag: test_always_passes

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
