### PR TITLE
DAOS-13215 dfuse: Use separate values for data and metadata caches.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -125,13 +125,6 @@ struct dfuse_obj_hdl {
 	/** True if caching is enabled for this file. */
 	bool                      doh_caching;
 
-	/* True if the kernel may have been told to keep the cache for this open.  This is used
-	 * for knowing if we need to reset the cache timer on close so it's OK to be conservative
-	 * here and this flag may be set on create even if the kernel flag isn't provided.
-	 * TODO: Remove this?
-	 */
-	bool                      doh_keep_cache;
-
 	/* True if the file handle is writeable - used for cache invalidation */
 	bool                      doh_writeable;
 
@@ -624,10 +617,10 @@ struct dfuse_inode_entry {
 	 */
 	d_list_t                 ie_htl;
 
-	/* Time of last kernel cache update.
-	 */
+	/* Time of last kernel cache metadata update */
 	struct timespec          ie_mcache_last_update;
 
+	/* Time of last kernel cache data update, also used for kernel readdir caching. */
 	struct timespec          ie_dcache_last_update;
 
 	/** written region for truncated files (i.e. ie_truncated set) */

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -194,7 +194,7 @@ df_ll_getattr(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	    (atomic_load_relaxed(&inode->ie_il_count) == 0)) {
 		double timeout;
 
-		if (dfuse_cache_get_valid(inode, inode->ie_dfs->dfc_attr_timeout, &timeout)) {
+		if (dfuse_mcache_get_valid(inode, inode->ie_dfs->dfc_attr_timeout, &timeout)) {
 			DFUSE_REPLY_ATTR_FORCE(inode, req, timeout);
 			D_GOTO(done, 0);
 		}

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -187,10 +187,6 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 		if (fi->flags & O_DIRECT)
 			fi_out.direct_io = 1;
 
-		/* keep_cache cannot be set here as ie is new and create might be being called
-		 * to open an existing file so the check needs to happen in reply_create()
-		 * after the hash table lookup.
-		 */
 	} else {
 		fi_out.direct_io = 1;
 	}
@@ -198,10 +194,8 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	if (dfs->dfc_direct_io_disable)
 		fi_out.direct_io = 0;
 
-	if (!fi_out.direct_io) {
+	if (!fi_out.direct_io)
 		oh->doh_caching = true;
-		oh->doh_keep_cache = true;
-	}
 
 	fi_out.fh = (uint64_t)oh;
 

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -143,7 +143,7 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		 */
 		if (atomic_load_relaxed(&ie->ie_open_count) > 1) {
 			fi_out->keep_cache = 1;
-		} else if (dfuse_cache_get_valid(ie, ie->ie_dfs->dfc_data_timeout, NULL)) {
+		} else if (dfuse_dcache_get_valid(ie, ie->ie_dfs->dfc_data_timeout)) {
 			fi_out->keep_cache = 1;
 		}
 

--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -59,9 +59,6 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		} else if (dfuse_dcache_get_valid(ie, ie->ie_dfs->dfc_data_timeout)) {
 			fi_out.keep_cache = 1;
 		}
-
-		if (fi_out.keep_cache)
-			oh->doh_keep_cache = true;
 	} else {
 		fi_out.direct_io = 1;
 	}
@@ -110,7 +107,7 @@ dfuse_cb_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	 * but the inode only tracks number of open handles with non-zero ioctl counts
 	 */
 
-	DFUSE_TRA_DEBUG(oh, "Closing %d %d", oh->doh_caching, oh->doh_keep_cache);
+	DFUSE_TRA_DEBUG(oh, "Closing %d", oh->doh_caching);
 
 	/* If the file was read from then set the data cache time for future use, however if the
 	 * file was written to then evict the metadata cache.

--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -56,7 +56,7 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 
 		if (atomic_load_relaxed(&ie->ie_open_count) > 0) {
 			fi_out.keep_cache = 1;
-		} else if (dfuse_cache_get_valid(ie, ie->ie_dfs->dfc_data_timeout, NULL)) {
+		} else if (dfuse_dcache_get_valid(ie, ie->ie_dfs->dfc_data_timeout)) {
 			fi_out.keep_cache = 1;
 		}
 
@@ -84,7 +84,7 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		rc = dfs_punch(ie->ie_dfs->dfs_ns, ie->ie_obj, 0, DFS_MAX_FSIZE);
 		if (rc)
 			D_GOTO(err, rc);
-		dfuse_cache_evict(oh->doh_ie);
+		dfuse_dcache_evict(oh->doh_ie);
 	}
 
 	atomic_fetch_add_relaxed(&ie->ie_open_count, 1);
@@ -112,23 +112,24 @@ dfuse_cb_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 
 	DFUSE_TRA_DEBUG(oh, "Closing %d %d", oh->doh_caching, oh->doh_keep_cache);
 
-	/* If the file was read from then set the cache time for future use, however if the
-	 * file was written to then evict the cache.
+	/* If the file was read from then set the data cache time for future use, however if the
+	 * file was written to then evict the metadata cache.
 	 * The problem here is that if the file was written to then the contents will be in the
 	 * kernel cache however dfuse has no visibility over file size and before replying with
 	 * data from the cache the kernel will call stat() to get an up-to-date file size, so
-	 * after write dfuse may continue to tell the kernel incorrect file sizes.  The fix
-	 * would be to store metadata but not cache data.
-	 *
-	 * Additionally, with caching enabled then dfuse may see create(), release(), open() calls
-	 * and neither release nor open update the cache, so do not set it valid on read.
+	 * after write dfuse may continue to tell the kernel incorrect file sizes.  To avoid this
+	 * evict the metadata cache so the size is refreshed on next access.
 	 */
 	if (atomic_load_relaxed(&oh->doh_write_count) != 0) {
 		if (oh->doh_caching) {
 			DFUSE_TRA_DEBUG(oh, "Evicting cache");
-			dfuse_cache_evict(oh->doh_ie);
+			dfuse_mcache_evict(oh->doh_ie);
 		}
 		atomic_fetch_sub_relaxed(&oh->doh_ie->ie_open_write_count, 1);
+	} else {
+		if (oh->doh_caching) {
+			dfuse_dcache_set_time(oh->doh_ie);
+		}
 	}
 	il_calls = atomic_load_relaxed(&oh->doh_il_calls);
 	DFUSE_TRA_DEBUG(oh, "il_calls %d, caching %d,", il_calls, oh->doh_caching);

--- a/src/client/dfuse/ops/opendir.c
+++ b/src/client/dfuse/ops/opendir.c
@@ -31,7 +31,8 @@ dfuse_cb_opendir(fuse_req_t req, struct dfuse_inode_entry *ie, struct fuse_file_
 	if (ie->ie_dfs->dfc_dentry_timeout > 0) {
 		fi_out.cache_readdir = 1;
 
-		if (dfuse_cache_get_valid(ie, ie->ie_dfs->dfc_dentry_timeout, NULL))
+		/* TODO: dcache needs a timeout input. */
+		if (dfuse_mcache_get_valid(ie, ie->ie_dfs->dfc_dentry_timeout, NULL))
 			fi_out.keep_cache = 1;
 	}
 #endif
@@ -64,7 +65,7 @@ dfuse_cb_releasedir(fuse_req_t req, struct dfuse_inode_entry *ino, struct fuse_f
 
 	if ((!oh->doh_kreaddir_invalid) && oh->doh_kreaddir_finished) {
 		DFUSE_TRA_DEBUG(oh, "Directory handle may have populated cache, saving");
-		dfuse_cache_set_time(oh->doh_ie);
+		dfuse_dcache_set_time(oh->doh_ie);
 	}
 
 	DFUSE_REPLY_ZERO(oh, req);

--- a/src/client/dfuse/ops/write.c
+++ b/src/client/dfuse/ops/write.c
@@ -41,9 +41,10 @@ dfuse_cb_write(fuse_req_t req, fuse_ino_t ino, struct fuse_bufvec *bufv, off_t p
 	DFUSE_TRA_DEBUG(oh, "%#zx-%#zx requested flags %#x pid=%d", position, position + len - 1,
 			bufv->buf[0].flags, fc->pid);
 
+	/* Evict the metadata cache here so the lookup doesn't return stale size/time info */
 	if (atomic_fetch_add_relaxed(&oh->doh_write_count, 1) == 0) {
 		if (atomic_fetch_add_relaxed(&oh->doh_ie->ie_open_write_count, 1) == 0) {
-			dfuse_cache_evict(oh->doh_ie);
+			dfuse_mcache_evict(oh->doh_ie);
 		}
 	}
 

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -3704,7 +3704,7 @@ def run_in_fg(server, conf, args):
             break
 
     if not container:
-        cont = create_cont(conf, pool, label=label, ctype="POSIX")
+        container = create_cont(conf, pool, label=label, ctype="POSIX")
 
         # Only set the container cache attributes when the container is initially created so they
         # can be modified later.
@@ -3716,7 +3716,7 @@ def run_in_fg(server, conf, args):
         cont_attrs['dfuse-direct-io-disable'] = False
 
         container.set_attrs(cont_attrs)
-        cont = container.id()
+        container = container.uuid
 
     dfuse = DFuse(server,
                   conf,


### PR DESCRIPTION
Test-tag: dfuse

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
