### PR TITLE
DAOS-13189 test: propagate client/env_vars to daos command

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1674,7 +1674,9 @@ class TestWithServers(TestWithoutServers):
             DaosCommand: a new DaosCommand object
 
         """
-        return DaosCommand(self.bin)
+        daos_command = DaosCommand(self.bin)
+        daos_command.get_params(self)
+        return daos_command
 
     def prepare_pool(self):
         """Prepare the self.pool TestPool object.

--- a/src/tests/ftest/util/mdtest_test_base.py
+++ b/src/tests/ftest/util/mdtest_test_base.py
@@ -43,11 +43,12 @@ class MdtestBase(DfuseTestBase):
         self.log.info('Clients %s', self.hostlist_clients)
         self.log.info('Servers %s', self.hostlist_servers)
 
-    def execute_mdtest(self, out_queue=None):
+    def execute_mdtest(self, out_queue=None, display_space=True):
         """Runner method for Mdtest.
 
         Args:
             out_queue (queue, optional): Pass any exceptions in a queue. Defaults to None.
+            display_space (bool, optional): Whether to display the pool space. Defaults to True.
         """
         # Create a pool if one does not already exist
         if self.pool is None:
@@ -65,7 +66,7 @@ class MdtestBase(DfuseTestBase):
 
         # Run Mdtest
         self.run_mdtest(self.get_mdtest_job_manager_command(self.manager),
-                        self.processes, out_queue=out_queue)
+                        self.processes, display_space=display_space, out_queue=out_queue)
 
         if self.subprocess:
             return

--- a/src/tests/ftest/util/performance_test_base.py
+++ b/src/tests/ftest/util/performance_test_base.py
@@ -487,7 +487,7 @@ class PerformanceTestBase(IorTestBase, MdtestBase):
         self.subprocess = True
 
         self.log.info("Running MDTEST")
-        self.execute_mdtest()
+        self.execute_mdtest(display_space=False)
         if stop_rank_s:
             time.sleep(stop_rank_s)
             self.server_managers[0].stop_random_rank(self.d_log, force=True, exclude_ranks=[0])


### PR DESCRIPTION
Test-tag: pr MdtestEasy,-manual MdtestHard,-manual MdtestSmall
Skip-unit-tests: true
Skip-fault-injection-test: true

- Call get_params when initializing a DaosCommand
- Add display_space arg to execute mdtest
  - Works around client env not being propagated to pydaos
  - 
Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
