### PR TITLE
DAOS-13206 chk: properly set pool status when stop check

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -487,6 +487,8 @@ chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, int status, uint32_t ph
 			if (phase != CHK_INVAL_PHASE && phase > cbk->cb_phase)
 				cbk->cb_phase = phase;
 			cbk->cb_pool_status = status;
+			if (status == CHK__CHECK_POOL_STATUS__CPS_STOPPED)
+				ins->ci_pool_stopped = 1;
 			cbk->cb_time.ct_stop_time = time(NULL);
 			uuid_unparse_lower(uuid, uuid_str);
 			rc = chk_bk_update_pool(cbk, uuid_str);

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -175,6 +175,8 @@ chk_stop_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
 
 		return 0;
 	}
+
+	out_result->cso_flags |= out_source->cso_flags;
 
 	if (out_source->cso_ranks.ca_count == 0)
 		return 0;
@@ -592,7 +594,7 @@ chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pool
 		D_GOTO(out, rc = 0);
 
 	for (i = 0, rank = cso->cso_ranks.ca_arrays; i < cso->cso_ranks.ca_count; i++, rank++) {
-		rc = stop_cb(args, *rank, 1, NULL /* unused data */, 0 /* unused nr */);
+		rc = stop_cb(args, *rank, 1, &cso->cso_flags, 0 /* unused nr */);
 		if (rc != 0)
 			goto out;
 	}

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -65,7 +65,8 @@ ds_chk_stop_hdlr(crt_rpc_t *rpc)
 	d_rank_t		*rank;
 	int			 rc;
 
-	rc = chk_engine_stop(csi->csi_gen, csi->csi_uuids.ca_count, csi->csi_uuids.ca_arrays);
+	rc = chk_engine_stop(csi->csi_gen, csi->csi_uuids.ca_count, csi->csi_uuids.ca_arrays,
+			     &cso->cso_flags);
 	if (rc > 0) {
 		D_ALLOC_PTR(rank);
 		if (rank == NULL) {


### PR DESCRIPTION
When the check against the pool is stopped, related pool's status should be set as 'STOPPPED' intead of 'COMPLETED'. If there is no more pools in checking, then check instance status should also be set as 'STOPPED'.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
