### PR TITLE
DAOS-13118 chk: Update pool info in check query output

### DIFF
--- a/src/control/cmd/dmg/pretty/check.go
+++ b/src/control/cmd/dmg/pretty/check.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/dustin/go-humanize/english"
 
-	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/txtfmt"
 )
@@ -71,7 +70,9 @@ func PrintCheckQueryResp(out io.Writer, resp *control.SystemCheckQueryResp, verb
 
 	statusMsg := fmt.Sprintf("Current status: %s", resp.Status)
 	if resp.Status > control.SystemCheckStatusInit && resp.Status < control.SystemCheckStatusCompleted {
-		statusMsg += fmt.Sprintf(" (started at: %s)", common.FormatTime(resp.StartTime))
+		statusMsg += fmt.Sprintf(" (%s)", resp.Time.String())
+	} else if resp.Status == control.SystemCheckStatusCompleted && !resp.Time.StopTime.IsZero() {
+		statusMsg += fmt.Sprintf(" (%s)", resp.Time.StopString())
 	}
 	fmt.Fprintf(out, "  %s\n", statusMsg)
 	fmt.Fprintf(out, "  Current phase: %s (%s)\n", resp.ScanPhase, resp.ScanPhase.Description())

--- a/src/control/cmd/dmg/pretty/check_test.go
+++ b/src/control/cmd/dmg/pretty/check_test.go
@@ -40,26 +40,26 @@ DAOS System Checker Info
 			resp: &control.SystemCheckQueryResp{
 				Status:    control.SystemCheckStatusRunning,
 				ScanPhase: control.SystemCheckScanPhaseContainerList,
-				StartTime: checkTime,
+				Time:      control.CheckTime{StartTime: checkTime},
 				Pools: map[string]*control.SystemCheckPoolInfo{
 					"pool-1": {
-						UUID:      "pool-1",
-						Status:    chkpb.CheckPoolStatus_CPS_CHECKING.String(),
-						Phase:     chkpb.CheckScanPhase_CSP_PREPARE.String(),
-						StartTime: checkTime,
+						UUID:   "pool-1",
+						Status: chkpb.CheckPoolStatus_CPS_CHECKING.String(),
+						Phase:  chkpb.CheckScanPhase_CSP_PREPARE.String(),
+						Time:   control.CheckTime{StartTime: checkTime},
 					},
 					"pool-2": {
-						UUID:      "pool-2",
-						Status:    chkpb.CheckPoolStatus_CPS_CHECKING.String(),
-						Phase:     chkpb.CheckScanPhase_CSP_PREPARE.String(),
-						StartTime: checkTime,
+						UUID:   "pool-2",
+						Status: chkpb.CheckPoolStatus_CPS_CHECKING.String(),
+						Phase:  chkpb.CheckScanPhase_CSP_PREPARE.String(),
+						Time:   control.CheckTime{StartTime: checkTime},
 					},
 				},
 			},
 			verbose: true,
 			expOut: `
 DAOS System Checker Info
-  Current status: RUNNING (started at: 2023-03-20T10:07:00.000-05:00)
+  Current status: RUNNING (started: 2023-03-20T10:07:00.000-05:00)
   Current phase: CONT_LIST (Comparing container list on PS and storage nodes)
   Checking 2 pools
 
@@ -74,24 +74,25 @@ No reports to display.
 			resp: &control.SystemCheckQueryResp{
 				Status:    control.SystemCheckStatusCompleted,
 				ScanPhase: control.SystemCheckScanPhaseDone,
+				Time:      control.CheckTime{StartTime: checkTime, StopTime: checkTime.Add(1 * time.Minute)},
 				Pools: map[string]*control.SystemCheckPoolInfo{
 					"pool-1": {
-						UUID:      "pool-1",
-						Status:    chkpb.CheckPoolStatus_CPS_CHECKED.String(),
-						Phase:     chkpb.CheckScanPhase_CSP_DONE.String(),
-						StartTime: checkTime,
+						UUID:   "pool-1",
+						Status: chkpb.CheckPoolStatus_CPS_CHECKED.String(),
+						Phase:  chkpb.CheckScanPhase_CSP_DONE.String(),
+						Time:   control.CheckTime{StartTime: checkTime},
 					},
 					"pool-2": {
-						UUID:      "pool-2",
-						Status:    chkpb.CheckPoolStatus_CPS_CHECKED.String(),
-						Phase:     chkpb.CheckScanPhase_CSP_DONE.String(),
-						StartTime: checkTime,
+						UUID:   "pool-2",
+						Status: chkpb.CheckPoolStatus_CPS_CHECKED.String(),
+						Phase:  chkpb.CheckScanPhase_CSP_DONE.String(),
+						Time:   control.CheckTime{StartTime: checkTime},
 					},
 					"pool-3": {
-						UUID:      "pool-3",
-						Status:    chkpb.CheckPoolStatus_CPS_CHECKED.String(),
-						Phase:     chkpb.CheckScanPhase_CSP_DONE.String(),
-						StartTime: checkTime,
+						UUID:   "pool-3",
+						Status: chkpb.CheckPoolStatus_CPS_CHECKED.String(),
+						Phase:  chkpb.CheckScanPhase_CSP_DONE.String(),
+						Time:   control.CheckTime{StartTime: checkTime},
 					},
 					"pool-5": {
 						UUID:   "pool-5",
@@ -141,7 +142,7 @@ No reports to display.
 			verbose: true,
 			expOut: `
 DAOS System Checker Info
-  Current status: COMPLETED
+  Current status: COMPLETED (stopped: 2023-03-20T10:08:00.000-05:00 (1m0s))
   Current phase: DSP_DONE (Check completed)
   Checked 4 pools
 

--- a/src/control/lib/control/check_test.go
+++ b/src/control/lib/control/check_test.go
@@ -1,0 +1,253 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package control
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/daos-stack/daos/src/control/common"
+	chkpb "github.com/daos-stack/daos/src/control/common/proto/chk"
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
+)
+
+func Test_Control_SystemCheckPoolInfo_JSON(t *testing.T) {
+	startTime := time.Now()
+	stopTime := startTime.Add(10 * time.Second)
+	testUUID := test.MockUUID()
+
+	for name, tc := range map[string]struct {
+		in      *SystemCheckPoolInfo
+		expJSON string
+	}{
+		"remaining": {
+			in: &SystemCheckPoolInfo{
+				RawRankInfo: map[ranklist.Rank]*mgmtpb.CheckQueryPool{
+					0: {},
+					1: {},
+				},
+				UUID:   testUUID,
+				Status: "test",
+				Phase:  "test",
+				Time: CheckTime{
+					StartTime: startTime,
+					Remaining: 1 * time.Second,
+				},
+			},
+			expJSON: `
+{
+  "uuid": "` + testUUID + `",
+  "status": "test",
+  "phase": "test",
+  "time": {
+    "started": "` + common.FormatTime(startTime) + `",
+    "remaining": 1
+  },
+  "rank_count": 2
+}`,
+		},
+		"stopped": {
+			in: &SystemCheckPoolInfo{
+				RawRankInfo: map[ranklist.Rank]*mgmtpb.CheckQueryPool{
+					0: {},
+					1: {},
+				},
+				UUID:   testUUID,
+				Status: "test",
+				Phase:  "test",
+				Time: CheckTime{
+					StartTime: startTime,
+					StopTime:  stopTime,
+				},
+			},
+			expJSON: `
+{
+  "uuid": "` + testUUID + `",
+  "status": "test",
+  "phase": "test",
+  "time": {
+    "started": "` + common.FormatTime(startTime) + `",
+    "stopped": "` + common.FormatTime(stopTime) + `"
+  },
+  "rank_count": 2
+}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			actJSON, err := json.MarshalIndent(tc.in, "", "  ")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(strings.TrimLeft(tc.expJSON, "\n"), string(actJSON)); diff != "" {
+				t.Fatalf("unexpected JSON (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_Control_SystemCheckPoolInfo_String(t *testing.T) {
+	startTime := time.Now()
+	stopTime := startTime.Add(10 * time.Second)
+	testUUID := test.MockUUID()
+
+	for name, tc := range map[string]struct {
+		in     *SystemCheckPoolInfo
+		expStr string
+	}{
+		"remaining": {
+			in: &SystemCheckPoolInfo{
+				RawRankInfo: map[ranklist.Rank]*mgmtpb.CheckQueryPool{
+					0: {},
+					1: {},
+				},
+				UUID:   testUUID,
+				Status: "test",
+				Phase:  "test",
+				Time: CheckTime{
+					StartTime: startTime,
+					Remaining: 1 * time.Second,
+				},
+			},
+			expStr: fmt.Sprintf("Pool %s: 2 ranks, status: test, phase: test, started: %s, remaining: 1s", testUUID, common.FormatTime(startTime)),
+		},
+		"elapsed": {
+			in: &SystemCheckPoolInfo{
+				RawRankInfo: map[ranklist.Rank]*mgmtpb.CheckQueryPool{
+					0: {},
+					1: {},
+				},
+				UUID:   testUUID,
+				Status: "test",
+				Phase:  "test",
+				Time: CheckTime{
+					StartTime: startTime,
+					StopTime:  stopTime,
+				},
+			},
+			expStr: fmt.Sprintf("Pool %s: 2 ranks, status: test, phase: test, started: %s, stopped: %s (%s)", testUUID, common.FormatTime(startTime), common.FormatTime(stopTime), stopTime.Sub(startTime)),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.expStr, tc.in.String()); diff != "" {
+				t.Fatalf("unexpected String() output (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_Control_getPoolCheckInfo(t *testing.T) {
+	testUuid1 := test.MockUUID(1)
+	testUuid2 := test.MockUUID(2)
+	startTime := time.Now()
+	stopTime := startTime.Add(10 * time.Second)
+
+	pbPool0_0 := &mgmtpb.CheckQueryPool{
+		Uuid:   testUuid1,
+		Status: chkpb.CheckPoolStatus_CPS_CHECKING,
+		Phase:  chkpb.CheckScanPhase_CSP_POOL_LIST,
+		Time: &mgmtpb.CheckQueryTime{
+			StartTime: uint64(startTime.Unix()),
+			MiscTime:  uint64(stopTime.Sub(startTime).Seconds()),
+		},
+		Targets: []*mgmtpb.CheckQueryTarget{
+			{
+				Rank: 1,
+			},
+		},
+	}
+	pbPool0_1 := &mgmtpb.CheckQueryPool{
+		Uuid:   testUuid1,
+		Status: chkpb.CheckPoolStatus_CPS_CHECKING,
+		Phase:  chkpb.CheckScanPhase_CSP_POOL_LIST,
+		Time: &mgmtpb.CheckQueryTime{
+			StartTime: uint64(startTime.Unix()),
+			MiscTime:  uint64(stopTime.Sub(startTime).Seconds()),
+		},
+		Targets: []*mgmtpb.CheckQueryTarget{
+			{
+				Rank: 2,
+			},
+		},
+	}
+	pbPool1_0 := &mgmtpb.CheckQueryPool{
+		Uuid:   testUuid2,
+		Status: chkpb.CheckPoolStatus_CPS_CHECKED,
+		Phase:  chkpb.CheckScanPhase_CSP_DONE,
+		Time: &mgmtpb.CheckQueryTime{
+			StartTime: uint64(startTime.Unix()),
+			MiscTime:  uint64(stopTime.Unix()),
+		},
+		Targets: []*mgmtpb.CheckQueryTarget{
+			{
+				Rank: 3,
+			},
+		},
+	}
+
+	for name, tc := range map[string]struct {
+		pbPools  []*mgmtpb.CheckQueryPool
+		expPools map[string]*SystemCheckPoolInfo
+	}{
+		"empty": {
+			expPools: map[string]*SystemCheckPoolInfo{},
+		},
+		"two pools": {
+			pbPools: []*mgmtpb.CheckQueryPool{
+				pbPool0_0, pbPool1_0, pbPool0_1,
+			},
+			expPools: func() map[string]*SystemCheckPoolInfo {
+				return map[string]*SystemCheckPoolInfo{
+					testUuid1: {
+						UUID:   testUuid1,
+						Status: pbPool0_0.Status.String(),
+						Phase:  pbPool0_0.Phase.String(),
+						Time: CheckTime{
+							StartTime: startTime,
+							Remaining: stopTime.Sub(startTime),
+						},
+						RawRankInfo: map[ranklist.Rank]*mgmtpb.CheckQueryPool{
+							1: pbPool0_0,
+							2: pbPool0_1,
+						},
+					},
+					testUuid2: {
+						UUID:   testUuid2,
+						Status: pbPool1_0.Status.String(),
+						Phase:  pbPool1_0.Phase.String(),
+						Time: CheckTime{
+							StartTime: startTime,
+							StopTime:  stopTime,
+						},
+						RawRankInfo: map[ranklist.Rank]*mgmtpb.CheckQueryPool{
+							3: pbPool1_0,
+						},
+					},
+				}
+			}(),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			actPools := getPoolCheckInfo(tc.pbPools)
+			cmpOpts := []cmp.Option{
+				cmpopts.EquateApproxTime(1 * time.Second),
+				protocmp.Transform(),
+			}
+			if diff := cmp.Diff(tc.expPools, actPools, cmpOpts...); diff != "" {
+				t.Fatalf("unexpected pool info (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Use the ",omitempty" directive to avoid including
empty fields in the JSON output. Updates the time
display for overall checker status and per-pool
checker status to show either time remaining
or time completed.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
