### PR TITLE
DAOS-12153 cart: Correct mapping of HG_PROTOCOL_ERROR to DER_PROTO. (…

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1371,7 +1371,7 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 			  hg_ret);
 		/* should success as addref above */
 		RPC_DECREF(rpc_priv);
-		rc = (hg_ret == HG_PROTOCOL_ERROR) ? -DER_PROTO : -DER_HG;
+		rc = crt_hgret_2_der(hg_ret);
 	}
 
 	return rc;

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -179,6 +179,14 @@ crt_hgret_2_der(int hg_ret)
 		return -DER_NOMEM;
 	case HG_CANCELED:
 		return -DER_CANCELED;
+	case HG_BUSY:
+		return -DER_BUSY;
+	case HG_FAULT:
+	case HG_PROTOCOL_ERROR:
+		return -DER_HG_FATAL;
+	case HG_PERMISSION:
+	case HG_ACCESS:
+		return -DER_NO_PERM;
 	default:
 		return -DER_HG;
 	};

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -65,7 +65,7 @@ extern "C" {
 	/** Try again */						\
 	ACTION(DER_AGAIN,		(DER_ERR_GURT_BASE + 13),	\
 	       Try again)						\
-	/** incompatible protocol */					\
+	/** Incompatible protocol */					\
 	ACTION(DER_PROTO,		(DER_ERR_GURT_BASE + 14),	\
 	       Incompatible protocol)					\
 	/** not initialized */						\
@@ -158,7 +158,10 @@ extern "C" {
 	/** Invalid user/group permissions.*/				\
 	ACTION(DER_SHMEM_PERMS,         (DER_ERR_GURT_BASE + 44),	\
 	       Unable to access shared memory segment due to		\
-	       incompatible user or group permissions)
+	       incompatible user or group permissions)			\
+	/** Fatal (non-retry-able) transport layer mercury error */	\
+	ACTION(DER_HG_FATAL,		(DER_ERR_GURT_BASE + 45),	\
+	       Fatal transport layer mercury error)
 	/** TODO: add more error numbers */
 
 /** Preprocessor macro defining DAOS errno values and internal definition of d_errstr */


### PR DESCRIPTION
…#11887)

The DAOS error code mapping of HG__PROTOCOL_ERROR (a generic, catch-all error) to DER_PROTO was put in place to resolve specific issue with a bulk handling error returned from Mercury. The mapping allowed the bulk failure to be handled correctly, since DER_PROTO is not a retry-able error. The change to mapping has resulted in the incorrect reporting of “Incompatible Protocol” (the intended meaning of DER_PROTO) for some network errors. The fix for this in linked PR is to remap HG_PROTOCOL_ERROR to a newly-added error code: DER_HG_FATAL, meaning a non-retry-able Mercury error has occurred.

Note that this fix will not fully resolve the potential overuse of DER_PROTO in code. It is used in security (credential errors), object (srv_obj.c for several conditions), and a few other modules. Note that although the text for the error message (and the comment with the declaration) state the error as “Incompatible Protocol” this error is not returned on incompatibility by the CaRT protocol_query RPC, which instead returns -DER_MISMATCH. A related PR will eliminate the separate protocol query RPC, and will thus will address any ambiguity for that functionality. My suggestion for further improvement is to either define “incompatibility” properly, or apply more specific error codes to the various places in the code where it is currently used.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
