### PR TITLE
DAOS-13170 chk: dmg check enable should not restart ranks

### DIFF
--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -823,12 +823,16 @@ func (svc *mgmtSvc) checkMemberStates(requiredStates ...system.MemberState) erro
 		}
 	}
 
+	stopRequired := false
+	if stateMask&system.MemberStateStopped != 0 {
+		stopRequired = true
+	}
 	if invalidMembers.Count() > 0 {
 		states := make([]string, len(requiredStates))
 		for i, state := range requiredStates {
 			states[i] = state.String()
 		}
-		return checker.FaultIncorrectMemberStates(invalidMembers.String(), strings.Join(states, "|"))
+		return checker.FaultIncorrectMemberStates(stopRequired, invalidMembers.String(), strings.Join(states, "|"))
 	}
 
 	return nil

--- a/src/control/system/checker/faults.go
+++ b/src/control/system/checker/faults.go
@@ -7,12 +7,14 @@
 package checker
 
 import (
+	"fmt"
+
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
 
 func IsIncorrectMemberStates(err error) bool {
-	return FaultIncorrectMemberStates("", "").Equals(err)
+	return fault.IsFaultCode(err, code.SystemCheckerInvalidMemberStates)
 }
 
 var (
@@ -28,11 +30,15 @@ var (
 	)
 )
 
-func FaultIncorrectMemberStates(members, expectedStates string) *fault.Fault {
+func FaultIncorrectMemberStates(stopRequired bool, members, expectedStates string) *fault.Fault {
+	remedy := "enable checker mode"
+	if stopRequired {
+		remedy = "stop system before enabling checker mode"
+	}
 	return checkerFault(
 		code.SystemCheckerInvalidMemberStates,
 		"members not in expected states ("+expectedStates+"): "+members,
-		"restart system after enabling checker mode or administratively exclude members as appropriate",
+		fmt.Sprintf("%s and/or administratively exclude members as appropriate", remedy),
 	)
 }
 

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -1347,16 +1347,20 @@ class DmgCommand(DmgCommandBase):
         """
         return self._get_result(["version"])
 
-    def check_enable(self, pool=None):
+    def check_enable(self, pool=None, stop=True):
         """Call dmg check enable.
 
         Args:
             pool (str): Pool label or UUID. Defaults to None.
+            stop (bool): Stop the system first before enabling checker. Defaults to True.
 
         Returns:
             dict: the dmg json command output converted to a python dictionary
 
         """
+        if stop:
+            self.system_stop(force=True)
+
         return self._get_json_result(("check", "enable"), pool=pool)
 
     def check_start(self, pool=None, dry_run=False, reset=False, failout=None, auto=None,
@@ -1393,17 +1397,23 @@ class DmgCommand(DmgCommandBase):
         """
         return self._get_json_result(("check", "query"), pool=pool)
 
-    def check_disable(self, pool=None):
+    def check_disable(self, pool=None, start=True):
         """Call dmg check disable.
 
         Args:
             pool (str): Pool label or UUID. Defaults to None.
+            start (bool): Start the system after disabling checker. Defaults to True.
 
         Returns:
             dict: the dmg json command output converted to a python dictionary
 
         """
-        return self._get_json_result(("check", "disable"), pool=pool)
+        res = self._get_json_result(("check", "disable"), pool=pool)
+
+        if start:
+            self.system_start()
+
+        return res
 
     def faults_mgmt_svc_pool(self, pool, checker_report_class):
         """Call dmg faults mgmt-svc pool <pool> <checker_report_class>


### PR DESCRIPTION
In order to avoid unexpected behavior, the `dmg check enable`
command now requires the system to be stopped first. Likewise,
the `dmg check disable` command just disables the checker
and stops the ranks. The admin will need to use `dmg system start`
again in order to restart the ranks in normal mode.

Features: recovery

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
