### PR TITLE
DAOS-13226 engine: fix sched_pool_info leak

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1892,13 +1892,15 @@ static int
 cont_svc_ec_agg_leader_start(struct cont_svc *svc)
 {
 	struct sched_req_attr	attr;
+	uuid_t			anonym_uuid;
 
 	D_INIT_LIST_HEAD(&svc->cs_ec_agg_list);
 	if (unlikely(ec_agg_disabled))
 		return 0;
 
 	D_ASSERT(svc->cs_ec_leader_ephs_req == NULL);
-	sched_req_attr_init(&attr, SCHED_REQ_GC, &svc->cs_pool_uuid);
+	uuid_clear(anonym_uuid);
+	sched_req_attr_init(&attr, SCHED_REQ_ANONYM, &anonym_uuid);
 	svc->cs_ec_leader_ephs_req = sched_create_ult(&attr, cont_agg_eph_leader_ult, svc, 0);
 	if (svc->cs_ec_leader_ephs_req == NULL) {
 		D_ERROR(DF_UUID" Failed to create EC leader eph ULT.\n",

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -1056,13 +1056,14 @@ process_pool_cb(d_list_t *rlink, void *arg)
 
 	/* Update stats window no matter if any pending ULT or not */
 	sw_window_update(&spi->spi_stats_window);
+	/* check_space_pressure() can't be skipped, otherwise, destroyed pool won't be detected */
+	press = check_space_pressure(dx, spi);
 	if (spi->spi_req_cnt == 0)
 		return 0;
 
 	for (i = SCHED_REQ_UPDATE; i < SCHED_REQ_MAX; i++)
 		kick[i] = pool2req_cnt(spi, i);
 
-	press = check_space_pressure(dx, spi);
 	pr = &pressure_gauge[press];
 
 	if (press == SCHED_SPACE_PRESS_NONE)

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -704,12 +704,14 @@ static int
 ds_pool_start_ec_eph_query_ult(struct ds_pool *pool)
 {
 	struct sched_req_attr	attr;
+	uuid_t			anonym_uuid;
 
 	if (unlikely(ec_agg_disabled))
 		return 0;
 
 	D_ASSERT(pool->sp_ec_ephs_req == NULL);
-	sched_req_attr_init(&attr, SCHED_REQ_GC, &pool->sp_uuid);
+	uuid_clear(anonym_uuid);
+	sched_req_attr_init(&attr, SCHED_REQ_ANONYM, &anonym_uuid);
 	pool->sp_ec_ephs_req = sched_create_ult(&attr, tgt_ec_eph_query_ult, pool,
 						DSS_DEEP_STACK_SZ);
 	if (pool->sp_ec_ephs_req == NULL) {

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -935,10 +935,8 @@ vos_pool_query_space(uuid_t pool_id, struct vos_pool_space *vps)
 	uuid_copy(ukey.uuid, pool_id);
 	rc = pool_lookup(&ukey, &pool);
 	if (rc) {
+		D_ASSERT(rc == -DER_NONEXIST);
 		return rc;
-	} else if (pool->vp_dying) {
-		vos_pool_decref(pool);
-		return -DER_NONEXIST;
 	}
 
 	D_ASSERT(pool != NULL);


### PR DESCRIPTION
Don't skip check_space_pressure(), otherwise, destroyed pool won't be detected and the sched_pool_info for destroyed pool won't be freed.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
