### PR TITLE
DAOS-623 cq: Re-run the jira-query trigger if the PR is modified

### DIFF
--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -3,7 +3,12 @@ name: Jira Report
 on:
   # Having this be pull_request_target rather than pull_request means it runs in the context of the
   # target branch rather than the PR, which in turn means the checkout is of the target.
+  # Trigger for the defaults plus "edited" so that it re-runs if a PR title is modified as that's
+  # what it's checking.  This probably doesn't need to run on synchronize however if a PR is being
+  # worked then re-checking the Jira metadata is no bad thing.
   pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
 
 jobs:
   example_comment_pr:


### PR DESCRIPTION
This check verifies the PR title so run the check when the PR
title is modified.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
