### PR TITLE
DAOS-12638 tse: splice completion CBs list to reduce locking

### DIFF
--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -670,10 +670,7 @@ tse_task_post_process(tse_task_t *task)
 			 * it is completed when they completed in this code
 			 * block.
 			 */
-			/** release lock for CB */
-			D_MUTEX_UNLOCK(&dsp_tmp->dsp_lock);
 			done = tse_task_complete_callback(task_tmp);
-			D_MUTEX_LOCK(&dsp_tmp->dsp_lock);
 
 			/*
 			 * task reinserted itself in scheduler by
@@ -866,10 +863,10 @@ tse_task_complete(tse_task_t *task, int ret)
 	if (task->dt_result == 0)
 		task->dt_result = ret;
 
+	D_MUTEX_LOCK(&dsp->dsp_lock);
+
 	/** Execute task completion callbacks first. */
 	done = tse_task_complete_callback(task);
-
-	D_MUTEX_LOCK(&dsp->dsp_lock);
 
 	if (!dsp->dsp_cancelling) {
 		/** if task reinserted itself in scheduler, don't complete */

--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -536,6 +536,10 @@ tse_task_complete_callback(tse_task_t *task)
 		new_gen = dtp_generation_get(dtp);
 		if (new_gen != gen) {
 			D_DEBUG(DB_TRACE, "task %p re-inited or new dep-task added\n", task);
+			D_MUTEX_LOCK(&dsp->dsp_lock);
+			/* splice any remaining completion CBs back in front of task's list */
+			d_list_splice(&comp_cb_list, &dtp->dtp_comp_cb_list);
+			D_MUTEX_UNLOCK(&dsp->dsp_lock);
 			tse_task_decref(task);
 			return false;
 		}

--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -518,7 +518,7 @@ tse_task_complete_callback(tse_task_t *task)
 	D_INIT_LIST_HEAD(&comp_cb_list);
 	/* just grab lock to get list */
 	D_MUTEX_LOCK(&dsp->dsp_lock);
-	d_list_splice_init(&dsp->dsp_complete_list, &comp_cb_list);
+	d_list_splice_init(&dtp->dtp_comp_cb_list, &comp_cb_list);
 	D_MUTEX_UNLOCK(&dsp->dsp_lock);
 
 	d_list_for_each_entry_safe(dtc, tmp, &comp_cb_list, dtc_list) {


### PR DESCRIPTION
tse_task_complete_callback() must be called with associated (struct tse_sched_private *)->dsp_lock granted in order to prevent dtp_comp_cb_list link-list of struct tse_task_private being corrupted.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
