### PR TITLE
DAOS-13218 bio: adjust daos_nvme_recovery test

### DIFF
--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -675,7 +675,7 @@ nvme_test_simulate_IO_error(void **state)
 
 	/*
 	 * Read the data which will induce the READ Error and expected to fail
-	 * with DER_NVME_IO Error.
+	 * with DER_NVME_IO Error (no replica for retry).
 	 */
 	arg->expect_result = -DER_NVME_IO;
 	lookup_single_with_rxnr(dkey, akey, /*idx*/0, fbuf,
@@ -689,10 +689,10 @@ nvme_test_simulate_IO_error(void **state)
 
 	/*
 	 * Insert the 4K record again which will induce WRITE Error and
-	 * expected to fail with DER_IO Error.
+	 * expected write succeeded (on retry).
 	 */
 	rx_nr = size / OW_IOD_SIZE;
-	arg->expect_result = -DER_IO;
+	arg->expect_result = -DER_SUCCESS;
 	insert_single_with_rxnr(dkey, akey, /*idx*/0, ow_buf, OW_IOD_SIZE,
 				rx_nr, DAOS_TX_NONE, &req);
 


### PR DESCRIPTION
Adjust daos_nvme_recovery test since now auto faulty is enabled by default.

When auto faulty is enabled, a -DER_NVME_IO write error will be retried on client until the write succeeded or auto faulty is triggered (affected target is marked as DOWN).

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
