### PR TITLE
DAOS-12828 object: bug fix for multiple EC akeys update in one IO

### DIFF
--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -359,8 +359,11 @@ struct obj_ec_singv_local {
 	uint32_t	esl_bytes_pad;
 };
 
+/* logical shard index to store short single value */
+#define OBJ_EC_SHORT_SINGV_IDX	(0)
 /** Query the target index for small sing-value record */
-#define obj_ec_singv_small_idx(obj, dkey_hash, iod)	obj_ec_shard_idx(obj, dkey_hash, 0)
+#define obj_ec_singv_small_idx(obj, dkey_hash, iod)	\
+	obj_ec_shard_idx(obj, dkey_hash, OBJ_EC_SHORT_SINGV_IDX)
 
 /* check EC data shard by its logical offset */
 static inline bool

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -513,9 +513,9 @@ struct daos_cpd_sub_req {
 		daos_unit_oid_t		 dcsr_oid;
 		/* Used by client side cache. */
 		struct {
-			void		*dcsr_obj;
-			void		*dcsr_reasb;
-			d_sg_list_t	*dcsr_sgls;
+			void			*dcsr_obj;
+			d_sg_list_t		*dcsr_sgls;
+			struct obj_reasb_req	*dcsr_reasb;
 		};
 	};
 	daos_key_t			 dcsr_dkey;

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1859,7 +1859,9 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 			if (rc < 0)
 				goto out;
 
-			if (dcsr->dcsr_sgls != NULL && rc > (DAOS_BULK_LIMIT >> 2)) {
+			if (dcsr->dcsr_sgls != NULL &&
+			    (rc > (DAOS_BULK_LIMIT >> 2) ||
+			     (obj_is_ec(obj) && !dcsr->dcsr_reasb->orr_single_tgt))) {
 				rc = tx_bulk_prepare(dcsr, task);
 				if (rc != 0)
 					goto out;
@@ -1942,7 +1944,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 			D_GOTO(out, rc = grp_idx);
 
 		if (obj_is_ec(obj) && dcsr->dcsr_reasb != NULL)
-			bit_map = ((struct obj_reasb_req *)(dcsr->dcsr_reasb))->tgt_bitmap;
+			bit_map = dcsr->dcsr_reasb->tgt_bitmap;
 		else
 			bit_map = NIL_BITMAP;
 

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -653,7 +653,7 @@ dc_obj_verify_ec_cb(struct dc_obj_enum_unpack_io *io, void *arg)
 	D_ASSERT(obj != NULL);
 	tgt_off = obj_ec_shard_off(obj, io->ui_dkey_hash, io->ui_oid.id_shard);
 	D_DEBUG(DB_TRACE, "compare "DF_KEY" nr %d shard "DF_U64" dkey_hash "DF_U64
-		"tgt off %u\n", DP_KEY(&io->ui_dkey), nr, shard, io->ui_dkey_hash, tgt_off);
+		" tgt off %u\n", DP_KEY(&io->ui_dkey), nr, shard, io->ui_dkey_hash, tgt_off);
 	if (nr == 0 || is_ec_parity_shard_by_tgt_off(tgt_off, obj_get_oca(obj))) {
 		obj_decref(obj);
 		return 0;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1752,14 +1752,8 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 		DP_KEY(&iod->iod_name), is_array ? "array" : "single",
 		ioc->ic_epr.epr_hi);
 
-	if (is_array) {
-		if (iod->iod_nr == 0 || iod->iod_recxs == NULL) {
-			D_DEBUG(DB_TRACE, "akey "DF_KEY" update array bypassed - NULL iod_recxs.\n",
-				DP_KEY(&iod->iod_name));
-			return rc;
-		}
+	if (is_array)
 		flags |= SUBTR_EVT;
-	}
 
 	rc = key_tree_prepare(obj, ak_toh, VOS_BTR_AKEY,
 			      &iod->iod_name, flags, DAOS_INTENT_UPDATE,


### PR DESCRIPTION
1. Fix a bug of EC multiple singv update
    When there are multiple singv update (different akey) in one IO request,
     if the first singv distributed to all shards, it possibly cause other short singv
     being written to all shards. This patch fixed it by skip those update.
2. Fix a bug of EC multiple array update in obj_get_iods_offs_by_oid().

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
