### PR TITLE
DAOS-13236 control: Add commit sha to version for non-release binaries

### DIFF
--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -12,19 +12,30 @@ elif [[ "$distro" = *8 ]]; then
     OPENMPI_VER=""
     PY_MINOR_VER=""
 fi
-pkgs="gotestsum openmpi$OPENMPI_VER                \
-      hwloc-devel argobots                         \
-      fuse3-libs fuse3                             \
-      boost-python3$PY_MINOR_VER-devel             \
-      libisa-l-devel libpmem                       \
-      libpmemobj protobuf-c                        \
-      spdk-devel libfabric-devel                   \
-      pmix numactl-devel                           \
-      libipmctl-devel python3$PY_MINOR_VER-pyxattr \
-      python3$PY_MINOR_VER-junit_xml               \
-      python3$PY_MINOR_VER-tabulate numactl        \
-      libyaml-devel                                \
-      valgrind-devel patchelf capstone"
+pkgs="argobots                         \
+      boost-python3$PY_MINOR_VER-devel \
+      capstone                         \
+      fuse3                            \
+      fuse3-libs                       \
+      gotestsum                        \
+      hwloc-devel                      \
+      libipmctl-devel                  \
+      libisa-l-devel                   \
+      libfabric-devel                  \
+      libpmem                          \
+      libpmemobj                       \
+      libyaml-devel                    \
+      numactl                          \
+      numactl-devel                    \
+      openmpi$OPENMPI_VER              \
+      patchelf                         \
+      pmix                             \
+      protobuf-c                       \
+      python3$PY_MINOR_VER-junit_xml   \
+      python3$PY_MINOR_VER-pyxattr     \
+      python3$PY_MINOR_VER-tabulate    \
+      spdk-devel                       \
+      valgrind-devel"
 
 if $quick_build; then
     if ! read -r mercury_version < "$distro"-required-mercury-rpm-version; then

--- a/site_scons/site_tools/go_builder.py
+++ b/site_scons/site_tools/go_builder.py
@@ -8,7 +8,7 @@ import json
 from SCons.Script import Configure, GetOption, Scanner, Glob, Exit, File
 
 GO_COMPILER = 'go'
-MIN_GO_VERSION = '1.17.0'
+MIN_GO_VERSION = '1.18.0'
 include_re = re.compile(r'\#include [<"](\S+[>"])', re.M)
 
 

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -18,6 +18,8 @@ def get_build_tags(benv):
         tags.append("firmware")
     if not is_release_build(benv):
         tags.append("pprof")
+    else:
+        tags.append("release")
     return f"-tags {','.join(tags)}"
 
 

--- a/src/control/build/info.go
+++ b/src/control/build/info.go
@@ -1,0 +1,39 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+//go:build go1.18
+
+package build
+
+import (
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs":
+			VCS = setting.Value
+		case "vcs.revision":
+			Revision = setting.Value
+		case "vcs.modified":
+			DirtyBuild = setting.Value == "true"
+		case "vcs.time":
+			LastCommit, _ = time.Parse(time.RFC3339, setting.Value)
+		case "-tags":
+			if strings.Contains(setting.Value, "release") {
+				ReleaseBuild = true
+			}
+		}
+	}
+}

--- a/src/control/build/string.go
+++ b/src/control/build/string.go
@@ -1,0 +1,38 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package build
+
+import (
+	"fmt"
+	"strings"
+)
+
+func revString(version string) string {
+	if ReleaseBuild {
+		return version
+	}
+
+	revParts := []string{version}
+	if Revision != "" {
+		switch VCS {
+		case "git":
+			revParts = append(revParts, fmt.Sprintf("g%7s", Revision)[0:7])
+		default:
+			revParts = append(revParts, Revision)
+		}
+		if DirtyBuild {
+			revParts = append(revParts, "dirty")
+		}
+	}
+	return strings.Join(revParts, "-")
+}
+
+// String returns a string containing the name, version, and for non-release builds,
+// the revision of the binary.
+func String(name string) string {
+	return fmt.Sprintf("%s version %s", name, revString(DaosVersion))
+}

--- a/src/control/build/variables.go
+++ b/src/control/build/variables.go
@@ -1,11 +1,13 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
 // Package build provides an importable repository of variables set at build time.
 package build
+
+import "time"
 
 var (
 	// ConfigDir should be set via linker flag using the value of CONF_DIR.
@@ -20,10 +22,25 @@ var (
 	ManagementServiceName = "DAOS Management Service"
 	// AgentName defines a consistent name for the compute node agent.
 	AgentName = "DAOS Agent"
+	// CLIUtilName defines a consistent name for the daos CLI utility.
+	CLIUtilName = "DAOS CLI"
+	// AdminUtilName defines a consistent name for the dmg utility.
+	AdminUtilName = "DAOS Admin Tool"
 
 	// DefaultControlPort defines the default control plane listener port.
 	DefaultControlPort = 10001
 
 	// DefaultSystemName defines the default DAOS system name.
 	DefaultSystemName = "daos_server"
+
+	// VCS is the version control system used to build the binary.
+	VCS = ""
+	// Revision is the VCS revision of the binary.
+	Revision = ""
+	// LastCommit is the time of the last commit.
+	LastCommit time.Time
+	// ReleaseBuild is true if the binary was built with the release tag.
+	ReleaseBuild bool
+	// DirtyBuild is true if the binary was built with uncommitted changes.
+	DirtyBuild bool
 )

--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -96,10 +96,6 @@ func (cmd *jsonOutputCmd) errorJSON(err error) error {
 
 var _ jsonOutputter = (*jsonOutputCmd)(nil)
 
-type cmdLogger interface {
-	setLog(*logging.LeveledLogger)
-}
-
 type cliOptions struct {
 	Debug      bool           `long:"debug" description:"enable debug output"`
 	Verbose    bool           `long:"verbose" description:"enable verbose output (when applicable)"`
@@ -116,7 +112,7 @@ type cliOptions struct {
 type versionCmd struct{}
 
 func (cmd *versionCmd) Execute(_ []string) error {
-	fmt.Printf("daos version %s, libdaos %s\n", build.DaosVersion, apiVersion())
+	fmt.Printf("%s, libdaos v%s\n", build.String(build.CLIUtilName), apiVersion())
 	os.Exit(0)
 	return nil
 }

--- a/src/control/cmd/daos_agent/main.go
+++ b/src/control/cmd/daos_agent/main.go
@@ -100,7 +100,7 @@ func (cmd *jsonOutputCmd) outputJSON(out io.Writer, in interface{}) error {
 }
 
 func versionString() string {
-	return fmt.Sprintf("%s v%s", build.AgentName, build.DaosVersion)
+	return build.String(build.AgentName)
 }
 
 type versionCmd struct{}

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -57,7 +57,7 @@ type mainOpts struct {
 type versionCmd struct{}
 
 func (cmd *versionCmd) Execute(_ []string) error {
-	fmt.Printf("%s v%s\n", build.ControlPlaneName, build.DaosVersion)
+	fmt.Println(build.String(build.ControlPlaneName))
 	return nil
 }
 

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -208,7 +208,7 @@ type cliOptions struct {
 type versionCmd struct{}
 
 func (cmd *versionCmd) Execute(_ []string) error {
-	fmt.Printf("dmg version %s\n", build.DaosVersion)
+	fmt.Println(build.String(build.AdminUtilName))
 	os.Exit(0)
 	return nil
 }


### PR DESCRIPTION
The control plane (and daos CLI) binaries will now include the
git sha used for the build for non-release builds.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
