### PR TITLE
DAOS-13114 control: Migrate Join handler to new batch style

### DIFF
--- a/src/control/cmd/hello_drpc/main.go
+++ b/src/control/cmd/hello_drpc/main.go
@@ -100,7 +100,7 @@ func runDrpcClient(log logging.Logger) error {
 		return errors.Wrap(err, "marshalling the Call body")
 	}
 
-	resp, err := client.SendMsg(context.Background(), message)
+	resp, err := client.SendMsg(ctx, message)
 	if err != nil {
 		return errors.Wrap(err, "sending message")
 	}

--- a/src/control/drpc/drpc_client_test.go
+++ b/src/control/drpc/drpc_client_test.go
@@ -85,7 +85,7 @@ func TestClient_Connect_Success(t *testing.T) {
 	client := newTestClientConnection(dialer, nil)
 	client.sequence = 10
 
-	err := client.Connect(context.Background())
+	err := client.Connect(test.Context(t))
 
 	test.AssertTrue(t, err == nil, "Expected no error")
 	test.AssertTrue(t, client.IsConnected(), "Should be connected")
@@ -102,7 +102,7 @@ func TestClient_Connect_Error(t *testing.T) {
 	dialer.SetError("mock dialer failure")
 	client := newTestClientConnection(dialer, nil)
 
-	err := client.Connect(context.Background())
+	err := client.Connect(test.Context(t))
 
 	test.CmpErr(t, dialer.OutputErr, err)
 	test.AssertFalse(t, client.IsConnected(), "Should not be connected")
@@ -113,7 +113,7 @@ func TestClient_Connect_ContextCanceled(t *testing.T) {
 	dialer := newMockDialer()
 	client := newTestClientConnection(dialer, nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(test.Context(t))
 	cancel()
 	err := client.Connect(ctx)
 
@@ -127,7 +127,7 @@ func TestClient_Connect_AlreadyConnected(t *testing.T) {
 	dialer := newMockDialer()
 	client := newTestClientConnection(dialer, originalConn)
 
-	err := client.Connect(context.Background())
+	err := client.Connect(test.Context(t))
 
 	test.AssertTrue(t, err == nil, "Expected no error")
 	test.AssertEqual(t, client.conn, originalConn,

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -147,10 +147,10 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 			if _, err := svc.membership.Add(system.MockMember(t, 1, system.MemberStateJoined)); err != nil {
 				t.Fatal(err)
 			}
+
 			poolUUID := test.MockPoolUUID(1)
 			lock, ctx := getPoolLockCtx(t, nil, svc.sysdb, poolUUID)
 			defer lock.Release()
-
 			if err := svc.sysdb.AddPoolService(ctx, &system.PoolService{
 				PoolUUID: poolUUID,
 				State:    tc.state,
@@ -303,10 +303,10 @@ func TestServer_MgmtSvc_calculateCreateStorage(t *testing.T) {
 }
 
 func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
-	testLog, _ := logging.NewTestLogger(t.Name())
-	missingSB := newTestMgmtSvc(t, testLog)
+	log, buf := logging.NewTestLogger(t.Name())
+	missingSB := newTestMgmtSvc(t, log)
 	missingSB.harness.instances[0].(*EngineInstance)._superblock = nil
-	notAP := newTestMgmtSvc(t, testLog)
+	notAP := newTestMgmtSvc(t, log)
 
 	for name, tc := range map[string]struct {
 		mgmtSvc       *mgmtSvc
@@ -471,7 +471,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
+			buf.Reset()
 			defer test.ShowBufferOnFailure(t, buf)
 
 			ctx := test.Context(t)
@@ -503,14 +503,14 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 				db := raft.MockDatabase(t, log)
 				ms := system.MockMembership(t, log, db, mockTCPResolver)
 				tc.mgmtSvc = newMgmtSvc(harness, ms, db, nil,
-					events.NewPubSub(test.Context(t), log))
+					events.NewPubSub(ctx, log))
+				tc.mgmtSvc.startAsyncLoops(ctx)
 			}
 
 			numMembers := tc.memberCount
 			if numMembers < 1 {
 				numMembers = 2
 			}
-			tc.mgmtSvc.log = log
 			for i := 0; i < numMembers; i++ {
 				if _, err := tc.mgmtSvc.membership.Add(system.MockMember(t, uint32(i), system.MemberStateJoined)); err != nil {
 					t.Fatal(err)
@@ -623,7 +623,7 @@ func TestServer_MgmtSvc_PoolCreateDownRanks(t *testing.T) {
 	})
 
 	gotReq := new(mgmtpb.PoolCreateReq)
-	if err := proto.Unmarshal(dc.calls[0].Body, gotReq); err != nil {
+	if err := proto.Unmarshal(dc.calls.get()[0].Body, gotReq); err != nil {
 		t.Fatal(err)
 	}
 
@@ -639,10 +639,10 @@ func TestServer_MgmtSvc_PoolCreateDownRanks(t *testing.T) {
 }
 
 func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
-	testLog, _ := logging.NewTestLogger(t.Name())
-	missingSB := newTestMgmtSvc(t, testLog)
+	log, buf := logging.NewTestLogger(t.Name())
+	missingSB := newTestMgmtSvc(t, log)
 	missingSB.harness.instances[0].(*EngineInstance)._superblock = nil
-	notAP := newTestMgmtSvc(t, testLog)
+	notAP := newTestMgmtSvc(t, log)
 	testPoolService := &system.PoolService{
 		PoolLabel: "test-pool",
 		PoolUUID:  uuid.MustParse(mockUUID),
@@ -925,13 +925,12 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
+			buf.Reset()
 			defer test.ShowBufferOnFailure(t, buf)
 
 			if tc.mgmtSvc == nil {
 				tc.mgmtSvc = newTestMgmtSvc(t, log)
 			}
-			tc.mgmtSvc.log = log
 
 			numMembers := 8
 			for i := 0; i < numMembers; i++ {
@@ -1022,10 +1021,10 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 }
 
 func TestServer_MgmtSvc_PoolExtend(t *testing.T) {
-	testLog, _ := logging.NewTestLogger(t.Name())
-	missingSB := newTestMgmtSvc(t, testLog)
+	log, buf := logging.NewTestLogger(t.Name())
+	missingSB := newTestMgmtSvc(t, log)
 	missingSB.harness.instances[0].(*EngineInstance)._superblock = nil
-	notAP := newTestMgmtSvc(t, testLog)
+	notAP := newTestMgmtSvc(t, log)
 	scmAllocation := uint64(1)
 	nvmeAllocation := uint64(2)
 	testPoolService := &system.PoolService{
@@ -1089,13 +1088,12 @@ func TestServer_MgmtSvc_PoolExtend(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
+			buf.Reset()
 			defer test.ShowBufferOnFailure(t, buf)
 
 			if tc.mgmtSvc == nil {
 				tc.mgmtSvc = newTestMgmtSvc(t, log)
 			}
-			tc.mgmtSvc.log = log
 			addTestPoolService(t, tc.mgmtSvc.sysdb, testPoolService)
 
 			if tc.setupMockDrpc == nil {
@@ -1128,10 +1126,10 @@ func TestServer_MgmtSvc_PoolExtend(t *testing.T) {
 }
 
 func TestServer_MgmtSvc_PoolDrain(t *testing.T) {
-	testLog, _ := logging.NewTestLogger(t.Name())
-	missingSB := newTestMgmtSvc(t, testLog)
+	log, buf := logging.NewTestLogger(t.Name())
+	missingSB := newTestMgmtSvc(t, log)
 	missingSB.harness.instances[0].(*EngineInstance)._superblock = nil
-	notAP := newTestMgmtSvc(t, testLog)
+	notAP := newTestMgmtSvc(t, log)
 	testPoolService := &system.PoolService{
 		PoolUUID: uuid.MustParse(mockUUID),
 		State:    system.PoolServiceStateReady,
@@ -1190,13 +1188,12 @@ func TestServer_MgmtSvc_PoolDrain(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
+			buf.Reset()
 			defer test.ShowBufferOnFailure(t, buf)
 
 			if tc.mgmtSvc == nil {
 				tc.mgmtSvc = newTestMgmtSvc(t, log)
 			}
-			tc.mgmtSvc.log = log
 			addTestPoolService(t, tc.mgmtSvc.sysdb, testPoolService)
 
 			if tc.setupMockDrpc == nil {
@@ -1225,10 +1222,10 @@ func TestServer_MgmtSvc_PoolDrain(t *testing.T) {
 }
 
 func TestServer_MgmtSvc_PoolEvict(t *testing.T) {
-	testLog, _ := logging.NewTestLogger(t.Name())
-	missingSB := newTestMgmtSvc(t, testLog)
+	log, buf := logging.NewTestLogger(t.Name())
+	missingSB := newTestMgmtSvc(t, log)
 	missingSB.harness.instances[0].(*EngineInstance)._superblock = nil
-	notAP := newTestMgmtSvc(t, testLog)
+	notAP := newTestMgmtSvc(t, log)
 	testPoolService := &system.PoolService{
 		PoolUUID: uuid.MustParse(mockUUID),
 		State:    system.PoolServiceStateReady,
@@ -1283,13 +1280,12 @@ func TestServer_MgmtSvc_PoolEvict(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
+			buf.Reset()
 			defer test.ShowBufferOnFailure(t, buf)
 
 			if tc.mgmtSvc == nil {
 				tc.mgmtSvc = newTestMgmtSvc(t, log)
 			}
-			tc.mgmtSvc.log = log
 			addTestPoolService(t, tc.mgmtSvc.sysdb, testPoolService)
 
 			if tc.setupMockDrpc == nil {
@@ -1740,11 +1736,11 @@ func TestPoolDeleteACL_Success(t *testing.T) {
 }
 
 func TestServer_MgmtSvc_PoolQuery(t *testing.T) {
-	testLog, _ := logging.NewTestLogger(t.Name())
-	missingSB := newTestMgmtSvc(t, testLog)
+	log, buf := logging.NewTestLogger(t.Name())
+	missingSB := newTestMgmtSvc(t, log)
 	missingSB.harness.instances[0].(*EngineInstance)._superblock = nil
 
-	allRanksDown := newTestMgmtSvc(t, testLog)
+	allRanksDown := newTestMgmtSvc(t, log)
 	downRanksPool := test.MockUUID(9)
 	addTestPools(t, allRanksDown.sysdb, downRanksPool)
 	if err := allRanksDown.membership.UpdateMemberStates(system.MemberResults{
@@ -1812,13 +1808,12 @@ func TestServer_MgmtSvc_PoolQuery(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
+			buf.Reset()
 			defer test.ShowBufferOnFailure(t, buf)
 
 			if tc.mgmtSvc == nil {
 				tc.mgmtSvc = newTestMgmtSvc(t, log)
 			}
-			tc.mgmtSvc.log = log
 			addTestPools(t, tc.mgmtSvc.sysdb, mockUUID)
 
 			if tc.setupMockDrpc == nil {
@@ -2069,10 +2064,10 @@ func TestServer_MgmtSvc_PoolGetProp(t *testing.T) {
 }
 
 func TestServer_MgmtSvc_PoolUpgrade(t *testing.T) {
-	testLog, _ := logging.NewTestLogger(t.Name())
-	missingSB := newTestMgmtSvc(t, testLog)
+	log, buf := logging.NewTestLogger(t.Name())
+	missingSB := newTestMgmtSvc(t, log)
 	missingSB.harness.instances[0].(*EngineInstance)._superblock = nil
-	notAP := newTestMgmtSvc(t, testLog)
+	notAP := newTestMgmtSvc(t, log)
 	testPoolService := &system.PoolService{
 		PoolUUID: uuid.MustParse(mockUUID),
 		State:    system.PoolServiceStateReady,
@@ -2127,13 +2122,12 @@ func TestServer_MgmtSvc_PoolUpgrade(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
+			buf.Reset()
 			defer test.ShowBufferOnFailure(t, buf)
 
 			if tc.mgmtSvc == nil {
 				tc.mgmtSvc = newTestMgmtSvc(t, log)
 			}
-			tc.mgmtSvc.log = log
 			addTestPoolService(t, tc.mgmtSvc.sysdb, testPoolService)
 
 			if tc.setupMockDrpc == nil {

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"time"
 
@@ -23,6 +24,11 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 	"github.com/daos-stack/daos/src/control/system/raft"
+)
+
+const (
+	groupUpdateInterval = 500 * time.Millisecond
+	batchLoopInterval   = 250 * time.Millisecond
 )
 
 type (
@@ -41,7 +47,7 @@ type (
 	batchReqChan  chan *batchRequest
 
 	batchProcessResp struct {
-		msgName       string
+		msgType       reflect.Type
 		retryableReqs []*batchRequest
 	}
 
@@ -70,7 +76,7 @@ type mgmtSvc struct {
 	events            *events.PubSub
 	systemProps       daos.SystemPropertyMap
 	clientNetworkHint *mgmtpb.ClientNetHint
-	joinReqs          joinReqChan
+	batchInterval     time.Duration
 	batchReqs         batchReqChan
 	groupUpdateReqs   chan bool
 	lastMapVer        uint32
@@ -86,7 +92,7 @@ func newMgmtSvc(h *EngineHarness, m *system.Membership, s *raft.Database, c cont
 		events:            p,
 		systemProps:       daos.SystemProperties(),
 		clientNetworkHint: new(mgmtpb.ClientNetHint),
-		joinReqs:          make(joinReqChan),
+		batchInterval:     batchLoopInterval,
 		batchReqs:         make(batchReqChan),
 		groupUpdateReqs:   make(chan bool),
 	}
@@ -134,10 +140,10 @@ func (svc *mgmtSvc) checkReplicaRequest(req proto.Message) error {
 	return svc.checkSystemRequest(req)
 }
 
-// startBatchLoops kicks off the asynchronous batch processing loops.
-func (svc *mgmtSvc) startBatchLoops(ctx context.Context) {
-	go svc.joinLoop(ctx)
-	go svc.batchLoop(ctx)
+// startAsyncLoops kicks off the asynchronous processing loops.
+func (svc *mgmtSvc) startAsyncLoops(ctx context.Context) {
+	go svc.leaderTaskLoop(ctx)
+	go svc.batchReqLoop(ctx)
 }
 
 // submitBatchRequest submits a message for batch processing and waits for a response.
@@ -166,7 +172,7 @@ func (svc *mgmtSvc) processBatchPoolEvictions(ctx context.Context, bprChan batch
 	for _, req := range reqs {
 		msg, ok := req.msg.(*mgmtpb.PoolEvictReq)
 		if !ok {
-			svc.log.Errorf("unexpected message type %T", req.msg)
+			req.sendResponse(ctx, nil, errors.Errorf("unexpected message type %T", req.msg))
 			continue
 		}
 		poolReqs[msg.Id] = append(poolReqs[msg.Id], req)
@@ -198,9 +204,41 @@ func (svc *mgmtSvc) processBatchPoolEvictions(ctx context.Context, bprChan batch
 	return nil
 }
 
+// processBatchJoins processes a batch of JoinReq messages.
+func (svc *mgmtSvc) processBatchJoins(ctx context.Context, bprChan batchProcessRespChan, reqs []*batchRequest) []*batchRequest {
+	var updateNeeded bool
+	for _, req := range reqs {
+		msg, ok := req.msg.(*mgmtpb.JoinReq)
+		if !ok {
+			req.sendResponse(ctx, nil, errors.Errorf("unexpected message type %T", req.msg))
+			continue
+		}
+
+		// Get the peer's address from the request context if it wasn't
+		// specified in the request message.
+		replyAddr, err := getPeerListenAddr(req.ctx, msg.Addr)
+		if err != nil {
+			req.sendResponse(ctx, nil, errors.Wrapf(err, "failed to parse %q into a peer control address", msg.Addr))
+			continue
+		}
+
+		resp, err := svc.join(ctx, msg, replyAddr)
+		req.sendResponse(ctx, resp, err)
+		if err == nil {
+			updateNeeded = true
+		}
+	}
+	if updateNeeded {
+		svc.log.Debug("requesting immediate group update after join(s)")
+		svc.reqGroupUpdate(ctx, true)
+	}
+
+	return nil
+}
+
 // processBatchedMsgRequests processes a batch of requests for a given message type.
-func (svc *mgmtSvc) processBatchedMsgRequests(ctx context.Context, bprChan batchProcessRespChan, msgName string, reqs []*batchRequest) {
-	bpr := &batchProcessResp{msgName: msgName}
+func (svc *mgmtSvc) processBatchedMsgRequests(ctx context.Context, bprChan batchProcessRespChan, msgType reflect.Type, reqs []*batchRequest) {
+	bpr := &batchProcessResp{msgType: msgType}
 	if len(reqs) == 0 {
 		select {
 		case <-ctx.Done():
@@ -210,11 +248,13 @@ func (svc *mgmtSvc) processBatchedMsgRequests(ctx context.Context, bprChan batch
 		return
 	}
 
-	switch msgName {
-	case string(proto.MessageName(new(mgmtpb.PoolEvictReq))):
+	switch reqs[0].msg.(type) {
+	case *mgmtpb.PoolEvictReq:
 		bpr.retryableReqs = svc.processBatchPoolEvictions(ctx, bprChan, reqs)
+	case *mgmtpb.JoinReq:
+		bpr.retryableReqs = svc.processBatchJoins(ctx, bprChan, reqs)
 	default:
-		svc.log.Errorf("no batch handler for message type %s", msgName)
+		svc.log.Errorf("no batch handler for message type %s", msgType)
 	}
 
 	select {
@@ -224,25 +264,25 @@ func (svc *mgmtSvc) processBatchedMsgRequests(ctx context.Context, bprChan batch
 	}
 }
 
-// batchLoop is the main loop for processing batched requests.
-func (svc *mgmtSvc) batchLoop(parent context.Context) {
-	batchedMsgReqs := make(map[string][]*batchRequest)
+// batchReqLoop is the main loop for processing batched requests.
+func (svc *mgmtSvc) batchReqLoop(parent context.Context) {
+	batchedMsgReqs := make(map[reflect.Type][]*batchRequest)
 
-	batchTimer := time.NewTicker(batchLoopInterval)
+	batchTimer := time.NewTicker(svc.batchInterval)
 	defer batchTimer.Stop()
 
-	svc.log.Debug("starting batchLoop")
+	svc.log.Debug("starting batchReqLoop")
 	for {
 		select {
 		case <-parent.Done():
-			svc.log.Debug("stopped batchLoop")
+			svc.log.Debug("stopped batchReqLoop")
 			return
 		case req := <-svc.batchReqs:
-			msgName := string(proto.MessageName(req.msg))
-			if _, ok := batchedMsgReqs[msgName]; !ok {
-				batchedMsgReqs[msgName] = []*batchRequest{}
+			msgType := reflect.TypeOf(req.msg)
+			if _, ok := batchedMsgReqs[msgType]; !ok {
+				batchedMsgReqs[msgType] = []*batchRequest{}
 			}
-			batchedMsgReqs[msgName] = append(batchedMsgReqs[msgName], req)
+			batchedMsgReqs[msgType] = append(batchedMsgReqs[msgType], req)
 		case <-batchTimer.C:
 			batchedMsgNr := len(batchedMsgReqs)
 			if batchedMsgNr == 0 {
@@ -250,19 +290,54 @@ func (svc *mgmtSvc) batchLoop(parent context.Context) {
 			}
 
 			bprChan := make(batchProcessRespChan, batchedMsgNr)
-			for msgName, reqs := range batchedMsgReqs {
-				svc.log.Debugf("processing %d %s requests", len(reqs), msgName)
-				go svc.processBatchedMsgRequests(parent, bprChan, msgName, reqs)
+			for msgType, reqs := range batchedMsgReqs {
+				svc.log.Debugf("processing %d %s requests", len(reqs), msgType)
+				go svc.processBatchedMsgRequests(parent, bprChan, msgType, reqs)
 			}
 
 			for i := 0; i < batchedMsgNr; i++ {
 				bpr := <-bprChan
 				if len(bpr.retryableReqs) > 0 {
-					batchedMsgReqs[bpr.msgName] = bpr.retryableReqs
+					batchedMsgReqs[bpr.msgType] = bpr.retryableReqs
 				} else {
-					delete(batchedMsgReqs, bpr.msgName)
+					delete(batchedMsgReqs, bpr.msgType)
 				}
 			}
+		}
+	}
+}
+
+// leaderTaskLoop is the main loop for handling MS leader tasks.
+func (svc *mgmtSvc) leaderTaskLoop(parent context.Context) {
+	var groupUpdateNeeded bool
+
+	groupUpdateTimer := time.NewTicker(groupUpdateInterval)
+	defer groupUpdateTimer.Stop()
+
+	svc.log.Debug("starting leaderTaskLoop")
+	for {
+		select {
+		case <-parent.Done():
+			svc.log.Debug("stopped leaderTaskLoop")
+			return
+		case immediate := <-svc.groupUpdateReqs:
+			groupUpdateNeeded = true
+			if immediate {
+				if err := svc.doGroupUpdate(parent, true); err != nil {
+					svc.log.Errorf("immediate GroupUpdate failed: %s", err)
+					continue
+				}
+				groupUpdateNeeded = false
+			}
+		case <-groupUpdateTimer.C:
+			if !groupUpdateNeeded {
+				continue
+			}
+			if err := svc.doGroupUpdate(parent, false); err != nil {
+				svc.log.Errorf("lazy GroupUpdate failed: %s", err)
+				continue
+			}
+			groupUpdateNeeded = false
 		}
 	}
 }

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -137,176 +137,63 @@ func getPeerListenAddr(ctx context.Context, listenAddrStr string) (*net.TCPAddr,
 		net.JoinHostPort(tcpAddr.IP.String(), portStr))
 }
 
-const (
-	groupUpdateInterval = 500 * time.Millisecond
-	batchLoopInterval   = 250 * time.Millisecond
-)
-
-type (
-	batchJoinRequest struct {
-		mgmtpb.JoinReq
-		peerAddr *net.TCPAddr
-		joinCtx  context.Context
-		respCh   chan *batchJoinResponse
-	}
-
-	batchJoinResponse struct {
-		mgmtpb.JoinResp
-		joinErr error
-	}
-
-	joinReqChan chan *batchJoinRequest
-)
-
-func (svc *mgmtSvc) joinLoop(parent context.Context) {
-	var joinReqs []*batchJoinRequest
-	var groupUpdateNeeded bool
-
-	joinTimer := time.NewTicker(batchLoopInterval)
-	defer joinTimer.Stop()
-	groupUpdateTimer := time.NewTicker(groupUpdateInterval)
-	defer groupUpdateTimer.Stop()
-
-	svc.log.Debug("starting joinLoop")
-	for {
-		select {
-		case <-parent.Done():
-			svc.log.Debug("stopped joinLoop")
-			return
-		case sync := <-svc.groupUpdateReqs:
-			groupUpdateNeeded = true
-			if sync {
-				if err := svc.doGroupUpdate(parent, true); err != nil {
-					svc.log.Errorf("sync GroupUpdate failed: %s", err)
-					continue
-				}
-				groupUpdateNeeded = false
-			}
-		case <-groupUpdateTimer.C:
-			if !groupUpdateNeeded {
-				continue
-			}
-			if err := svc.doGroupUpdate(parent, false); err != nil {
-				svc.log.Errorf("async GroupUpdate failed: %s", err)
-				continue
-			}
-			groupUpdateNeeded = false
-		case jr := <-svc.joinReqs:
-			joinReqs = append(joinReqs, jr)
-		case <-joinTimer.C:
-			if len(joinReqs) == 0 {
-				continue
-			}
-
-			svc.log.Debugf("processing %d join requests", len(joinReqs))
-			joinResps := make([]*batchJoinResponse, len(joinReqs))
-			for i, req := range joinReqs {
-				joinResps[i] = svc.join(parent, req)
-			}
-
-			// Reset groupUpdateNeeded here to avoid triggering it
-			// again by timer. Any requests that were made between
-			// the last timer and these join requests will be handled
-			// here.
-			groupUpdateNeeded = false
-			if err := svc.doGroupUpdate(parent, false); err != nil {
-				// If the call failed, however, make sure that
-				// it gets called again by the timer. We have to
-				// deal with the situation where a local MS service
-				// rank is joining but isn't ready to handle dRPC
-				// requests yet.
-				groupUpdateNeeded = true
-				if errors.Cause(err) != errInstanceNotReady {
-					err = errors.Wrap(err, "failed to perform CaRT group update")
-					for i, jr := range joinResps {
-						if jr.joinErr == nil {
-							joinResps[i] = &batchJoinResponse{joinErr: err}
-						}
-					}
-				}
-			}
-
-			svc.log.Debugf("sending %d join responses", len(joinReqs))
-			for i, req := range joinReqs {
-				select {
-				case <-parent.Done():
-					svc.log.Errorf("joinLoop shut down before response sent: %s", parent.Err())
-				case <-req.joinCtx.Done():
-					svc.log.Errorf("failed to send join response: %s", req.joinCtx.Err())
-				case req.respCh <- joinResps[i]:
-				}
-			}
-
-			joinReqs = nil
-		}
-	}
-}
-
-func (svc *mgmtSvc) join(ctx context.Context, req *batchJoinRequest) *batchJoinResponse {
-	uuid, err := uuid.Parse(req.GetUuid())
+// join handles a request to join the system and is called from
+// the batch processing goroutine.
+func (svc *mgmtSvc) join(ctx context.Context, req *mgmtpb.JoinReq, peerAddr *net.TCPAddr) (*mgmtpb.JoinResp, error) {
+	uuid, err := uuid.Parse(req.Uuid)
 	if err != nil {
-		return &batchJoinResponse{
-			joinErr: errors.Wrapf(err, "invalid uuid %q", req.GetUuid()),
-		}
+		return nil, errors.Wrapf(err, "invalid uuid %q", req.Uuid)
 	}
 
-	fd, err := system.NewFaultDomainFromString(req.GetSrvFaultDomain())
+	fd, err := system.NewFaultDomainFromString(req.SrvFaultDomain)
 	if err != nil {
-		return &batchJoinResponse{
-			joinErr: errors.Wrapf(err, "invalid server fault domain %q", req.GetSrvFaultDomain()),
-		}
+		return nil, errors.Wrapf(err, "invalid server fault domain %q", req.SrvFaultDomain)
 	}
 
 	joinResponse, err := svc.membership.Join(&system.JoinRequest{
 		Rank:           ranklist.Rank(req.Rank),
 		UUID:           uuid,
-		ControlAddr:    req.peerAddr,
-		FabricURI:      req.GetUri(),
-		FabricContexts: req.GetNctxs(),
+		ControlAddr:    peerAddr,
+		FabricURI:      req.Uri,
+		FabricContexts: req.Nctxs,
 		FaultDomain:    fd,
-		Incarnation:    req.GetIncarnation(),
+		Incarnation:    req.Incarnation,
 	})
 	if err != nil {
-		return &batchJoinResponse{joinErr: err}
+		return nil, errors.Wrap(err, "failed to join system")
 	}
 
 	member := joinResponse.Member
 	if joinResponse.Created {
 		svc.log.Debugf("new system member: rank %d, addr %s, uri %s",
-			member.Rank, req.peerAddr, member.FabricURI)
+			member.Rank, peerAddr, member.FabricURI)
 	} else {
 		svc.log.Debugf("updated system member: rank %d, uri %s, %s->%s",
 			member.Rank, member.FabricURI, joinResponse.PrevState, member.State)
 	}
 
-	resp := &batchJoinResponse{
-		JoinResp: mgmtpb.JoinResp{
-			State: mgmtpb.JoinResp_IN,
-			Rank:  member.Rank.Uint32(),
-		},
+	resp := &mgmtpb.JoinResp{
+		State: mgmtpb.JoinResp_IN,
+		Rank:  member.Rank.Uint32(),
 	}
 
 	// If the rank is local to the MS leader, then we need to wire up at least
 	// one in order to perform a CaRT group update.
-	if common.IsLocalAddr(req.peerAddr) && req.Idx == 0 {
+	if common.IsLocalAddr(peerAddr) && req.Idx == 0 {
 		resp.LocalJoin = true
 
 		srvs := svc.harness.Instances()
 		if len(srvs) == 0 {
-			return &batchJoinResponse{
-				joinErr: errors.New("invalid Join request (index 0 doesn't exist?!?)"),
-			}
+			return nil, errors.New("invalid Join request (index 0 doesn't exist?!?)")
 		}
 		srv := srvs[0]
 
 		if err := srv.SetupRank(ctx, joinResponse.Member.Rank); err != nil {
-			return &batchJoinResponse{
-				joinErr: errors.Wrap(err, "SetupRank on local instance failed"),
-			}
+			return nil, errors.Wrap(err, "SetupRank on local instance failed")
 		}
 	}
 
-	return resp
+	return resp, nil
 }
 
 // reqGroupUpdate requests a group update.
@@ -401,35 +288,11 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (resp *mgmtpb
 		return nil, err
 	}
 
-	replyAddr, err := getPeerListenAddr(ctx, req.GetAddr())
+	msg, err := svc.submitBatchRequest(ctx, req)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse %q into a peer control address", req.GetAddr())
+		return nil, err
 	}
-
-	bjr := &batchJoinRequest{
-		JoinReq:  *req,
-		peerAddr: replyAddr,
-		joinCtx:  ctx,
-		respCh:   make(chan *batchJoinResponse),
-	}
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case svc.joinReqs <- bjr:
-	}
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case r := <-bjr.respCh:
-		if r.joinErr != nil {
-			return nil, r.joinErr
-		}
-		resp = &r.JoinResp
-	}
-
-	return resp, nil
+	return msg.(*mgmtpb.JoinResp), nil
 }
 
 type (

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -28,6 +28,7 @@ import (
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	sharedpb "github.com/daos-stack/daos/src/control/common/proto/shared"
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
@@ -1902,7 +1903,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 				Incarnation: curMember.Incarnation + 1,
 			},
 			expGuReq: &mgmtpb.GroupUpdateReq{
-				MapVersion: 2,
+				MapVersion: 3,
 				Engines: []*mgmtpb.GroupUpdateReq_Engine{
 					{
 						Rank:        curMember.Rank.Uint32(),
@@ -1924,7 +1925,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 				Incarnation: curMember.Incarnation + 1,
 			},
 			expGuReq: &mgmtpb.GroupUpdateReq{
-				MapVersion: 2,
+				MapVersion: 3,
 				Engines: []*mgmtpb.GroupUpdateReq_Engine{
 					{
 						Rank:        curMember.Rank.Uint32(),
@@ -1945,7 +1946,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 				Incarnation: newMember.Incarnation,
 			},
 			expGuReq: &mgmtpb.GroupUpdateReq{
-				MapVersion: 2,
+				MapVersion: 3,
 				Engines: []*mgmtpb.GroupUpdateReq_Engine{
 					// rank 0 is excluded, so shouldn't be in the map
 					{
@@ -1970,7 +1971,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 				Incarnation: newMember.Incarnation,
 			},
 			expGuReq: &mgmtpb.GroupUpdateReq{
-				MapVersion: 2,
+				MapVersion: 3,
 				Engines: []*mgmtpb.GroupUpdateReq_Engine{
 					// rank 0 is excluded, so shouldn't be in the map
 					{
@@ -1999,9 +2000,6 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 
 			svc := mgmtSystemTestSetup(t, log, system.Members{curCopy}, nil)
 
-			ctx := test.Context(t)
-			svc.startBatchLoops(ctx)
-
 			if tc.req.Sys == "" {
 				tc.req.Sys = build.DefaultSystemName
 			}
@@ -2027,11 +2025,9 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			peerCtx := peer.NewContext(ctx, &peer.Peer{Addr: peerAddr})
+			peerCtx := peer.NewContext(test.Context(t), &peer.Peer{Addr: peerAddr})
 
 			setupMockDrpcClient(svc, tc.guResp, nil)
-			ei := svc.harness.instances[0].(*EngineInstance)
-			mdc := ei._drpcClient.(*mockDrpcClient)
 
 			gotResp, gotErr := svc.Join(peerCtx, tc.req)
 			test.CmpErr(t, tc.expErr, gotErr)
@@ -2039,8 +2035,28 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 				return
 			}
 
+			if diff := cmp.Diff(tc.expResp, gotResp, protocmp.Transform()); diff != "" {
+				t.Fatalf("unexpected response (-want, +got)\n%s\n", diff)
+			}
+
+			if tc.expGuReq == nil {
+				return
+			}
+
+			ei := svc.harness.instances[0].(*EngineInstance)
+			mdc := ei._drpcClient.(*mockDrpcClient)
 			gotGuReq := new(mgmtpb.GroupUpdateReq)
-			if err := proto.Unmarshal(mdc.calls[len(mdc.calls)-1].Body, gotGuReq); err != nil {
+			calls := mdc.calls.get()
+			// wait for GroupUpdate
+			for ; ; calls = mdc.calls.get() {
+				if len(calls) == 0 {
+					continue
+				}
+				if calls[len(calls)-1].Method == drpc.MethodGroupUpdate {
+					break
+				}
+			}
+			if err := proto.Unmarshal(calls[len(calls)-1].Body, gotGuReq); err != nil {
 				t.Fatal(err)
 			}
 			cmpOpts := cmp.Options{
@@ -2049,10 +2065,6 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expGuReq, gotGuReq, cmpOpts...); diff != "" {
 				t.Fatalf("unexpected GroupUpdate request (-want, +got):\n%s", diff)
-			}
-
-			if diff := cmp.Diff(tc.expResp, gotResp, protocmp.Transform()); diff != "" {
-				t.Fatalf("unexpected response (-want, +got)\n%s\n", diff)
 			}
 		})
 	}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -420,9 +420,9 @@ func (srv *server) registerEvents() {
 	srv.sysdb.OnLeadershipGained(
 		func(ctx context.Context) error {
 			srv.log.Infof("MS leader running on %s", srv.hostname)
-			srv.mgmtSvc.startBatchLoops(ctx)
+			srv.mgmtSvc.startAsyncLoops(ctx)
 			registerLeaderSubscriptions(srv)
-			srv.log.Debugf("requesting sync GroupUpdate after leader change")
+			srv.log.Debugf("requesting immediate GroupUpdate after leader change")
 			go func() {
 				for {
 					select {

--- a/src/control/server/util_test.go
+++ b/src/control/server/util_test.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"testing"
@@ -80,13 +81,34 @@ type mockDrpcCall struct {
 	Body   []byte
 }
 
+func (c *mockDrpcCall) String() string {
+	return fmt.Sprintf("%s: (%v)", c.Method, c.Body)
+}
+
+type mockDrpcCalls struct {
+	sync.RWMutex
+	calls []*mockDrpcCall
+}
+
+func (c *mockDrpcCalls) add(call *mockDrpcCall) {
+	c.Lock()
+	defer c.Unlock()
+	c.calls = append(c.calls, call)
+}
+
+func (c *mockDrpcCalls) get() []*mockDrpcCall {
+	c.RLock()
+	defer c.RUnlock()
+	return c.calls
+}
+
 // mockDrpcClient is a mock of the DomainSocketClient interface
 type mockDrpcClient struct {
 	sync.Mutex
 	cfg              mockDrpcClientConfig
 	CloseCallCount   int
 	SendMsgInputCall *drpc.Call
-	calls            []*mockDrpcCall
+	calls            mockDrpcCalls
 }
 
 func (c *mockDrpcClient) IsConnected() bool {
@@ -106,7 +128,7 @@ func (c *mockDrpcClient) Close() error {
 }
 
 func (c *mockDrpcClient) CalledMethods() (methods []drpc.Method) {
-	for _, call := range c.calls {
+	for _, call := range c.calls.get() {
 		methods = append(methods, call.Method)
 	}
 	return
@@ -118,12 +140,12 @@ func (c *mockDrpcClient) SendMsg(_ context.Context, call *drpc.Call) (*drpc.Resp
 	if err != nil {
 		return nil, err
 	}
-	c.calls = append(c.calls, &mockDrpcCall{method, call.Body})
+	c.calls.add(&mockDrpcCall{method, call.Body})
 
 	<-time.After(c.cfg.ResponseDelay)
 
 	if len(c.cfg.SendMsgResponseList) > 0 {
-		idx := len(c.calls) - 1
+		idx := len(c.calls.get()) - 1
 		if idx < 0 {
 			idx = 0
 		}
@@ -212,7 +234,11 @@ func newTestMgmtSvc(t *testing.T, log logging.Logger) *mgmtSvc {
 
 	db := raft.MockDatabase(t, log)
 	ms := system.MockMembership(t, log, db, mockTCPResolver)
-	return newMgmtSvc(harness, ms, db, nil, events.NewPubSub(test.Context(t), log))
+	ctx := test.Context(t)
+	svc := newMgmtSvc(harness, ms, db, nil, events.NewPubSub(ctx, log))
+	svc.batchInterval = 100 * time.Microsecond // Speed up tests
+	svc.startAsyncLoops(ctx)
+	return svc
 }
 
 // newTestMgmtSvcMulti creates a mgmtSvc that contains the requested


### PR DESCRIPTION
Remove the custom Join batch processing code in favor of using
the generalized batch processing code added for PoolEvict.

Also updates various names for clarity, and updates a few
more tests to use test.Context().

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>