### PR TITLE
DAOS-623 ci: Moving job status back to pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,6 @@ def unitTestPostEx(Map config = [:], List artifacts) {
 
   // Coverage instrumented tests and Vagrind are probably mutually exclusive
   if (stage_info['compiler'] == 'covc') {
-    job_status_update()
     return
   }
 
@@ -129,7 +128,6 @@ def unitTestPostEx(Map config = [:], List artifacts) {
       println "The recordIssues step changed result to ${currentBuild.result}."
     }
   }
-  job_status_update()
 }
 
 void job_status_write() {
@@ -858,6 +856,7 @@ pipeline {
                     post {
                         always {
                             unitTestPostEx(['unit_test_logs/'])
+                            job_status_update()
                         }
                     }
                 }
@@ -879,6 +878,7 @@ pipeline {
                     post {
                         always {
                             unitTestPostEx(['unit_test_bdev_logs/'])
+                            job_status_update()
                         }
                     }
                 }
@@ -942,6 +942,7 @@ pipeline {
                             // added.
                             unitTestPostEx(ignore_failure: true,
                                            ['covc_test_logs/', 'covc_vm_test/**'])
+                            job_status_update()
                         }
                     }
                 } // stage('Unit test Bullseye on EL 8')


### PR DESCRIPTION
We moved it to a function but it doesn't seem to be updating properly with this change.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
