### PR TITLE
DAOS-13001 test: Add pool_query_delay support to YAML.

### DIFF
--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -203,6 +203,7 @@ class TestPool(TestDaosApiBase):
         self.properties = BasicParameter(None)      # string of cs name:value
         self.rebuild_timeout = BasicParameter(None)
         self.pool_query_timeout = BasicParameter(None)
+        self.pool_query_delay = BasicParameter(None)
         self.acl_file = BasicParameter(None)
         self.label = BasicParameter(None, "TestPool")
         self.label_generator = label_generator
@@ -673,6 +674,12 @@ class TestPool(TestDaosApiBase):
                         "response. This timeout can be adjusted via the 'pool/pool_query_timeout' "
                         "test yaml parameter.".format(
                             self.pool_query_timeout.value, self.identifier)) from error
+
+                if self.pool_query_delay:
+                    self.log.info(
+                        "Waiting %s seconds before issuing next dmg pool query",
+                        self.pool_query_delay)
+                    sleep(self.pool_query_delay.value)
 
     @fail_on(CommandFailure)
     def query_targets(self, *args, **kwargs):

--- a/src/tests/ftest/util/yaml_utils.py
+++ b/src/tests/ftest/util/yaml_utils.py
@@ -85,6 +85,7 @@ class YamlUpdater():
         ("job_manager_timeout", "_timeout", int),
         ("pattern_timeout", "_timeout", int),
         ("pool_query_timeout", "_timeout", int),
+        ("pool_query_delay", "_timeout", int),
         ("rebuild_timeout", "_timeout", int),
         ("srv_timeout", "_timeout", int),
         ("storage_prepare_timeout", "_timeout", int),


### PR DESCRIPTION
Summary: Add support to insert delay between pool queries. User can add pool_query_delay: 5 (for insserting 5 second) delay between pool queries in the YAML file.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [x] You are the appropriate gatekeeper to be landing the patch.
* [x] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [x] Githooks were used. If not, request that user install them and check copyright dates.
* [x] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [x] All builds have passed.  Check non-required builds for any new compiler warnings.
* [x] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [x] If applicable, the PR has addressed any potential version compatibility issues.
* [x] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [x] Extra checks if forced landing is requested
  * [x] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [x] No new NLT or valgrind warnings.  Check the classic view.
  * [x] Quick-build or Quick-functional is not used.
* [x] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
