### PR TITLE
DAOS-13259 engine: Check return values

### DIFF
--- a/src/common/tests/drpc_tests.c
+++ b/src/common/tests/drpc_tests.c
@@ -228,7 +228,7 @@ test_drpc_call_sends_call_as_mesg(void **state)
 	ctx->sequence = 10; /* arbitrary but nonzero */
 	call->sequence = 0;
 
-	drpc_call(ctx, 0, call, &resp);
+	assert_rc_equal(drpc_call(ctx, 0, call, &resp), 0);
 
 	/* drpc_call updated call seq number and incremented ctx seq num */
 	assert_int_equal(ctx->sequence, call->sequence + 1);

--- a/src/engine/drpc_handler.c
+++ b/src/engine/drpc_handler.c
@@ -158,7 +158,12 @@ drpc_hdlr_unregister_all(struct dss_drpc_handler *handlers)
 
 	current = handlers;
 	while (current->handler != NULL) {
-		drpc_hdlr_unregister(current->module_id);
+		int rc;
+
+		rc = drpc_hdlr_unregister(current->module_id);
+		if (rc != 0)
+			D_ERROR("failed to unregister dRPC handler for module %d: "DF_RC"\n",
+				current->module_id, DP_RC(rc));
 
 		current++;
 	}

--- a/src/engine/drpc_progress.c
+++ b/src/engine/drpc_progress.c
@@ -333,8 +333,13 @@ handle_incoming_call(struct drpc *session_ctx)
 
 	/* Incoming message was garbage */
 	if (rc == -DER_PROTO) {
+		int tmp_rc;
+
 		resp->status = DRPC__STATUS__FAILED_UNMARSHAL_CALL;
-		drpc_send_response(session_ctx, resp);
+		tmp_rc = drpc_send_response(session_ctx, resp);
+		if (tmp_rc != 0)
+			D_ERROR("unable to send response to bad incoming dRPC: "DF_RC"\n",
+				DP_RC(tmp_rc));
 		drpc_response_free(resp);
 		return rc;
 	}

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1195,11 +1195,15 @@ enum {
 int
 dss_srv_fini(bool force)
 {
+	int rc;
+
 	switch (xstream_data.xd_init_step) {
 	default:
 		D_ASSERT(0);
 	case XD_INIT_DRPC:
-		drpc_listener_fini();
+		rc = drpc_listener_fini();
+		if (rc != 0)
+			D_ERROR("failed to finalize dRPC listener: "DF_RC"\n", DP_RC(rc));
 		/* fall through */
 	case XD_INIT_XSTREAMS:
 		dss_xstreams_fini(force);


### PR DESCRIPTION
Fix issues discovered in static analysis, in which some return values weren't being checked.

Also fixes DAOS-13258, DAOS-13257, and DAOS-12355.

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
