### PR TITLE
DAOS-13284 control: Increase dRPC buffer size to 1MB

### DIFF
--- a/src/control/drpc/drpc_server.go
+++ b/src/control/drpc/drpc_server.go
@@ -24,7 +24,7 @@ import (
 // we need to restrict the maximum message size so we can preallocate a
 // buffer to put all of the information in. Corresponding C definition is
 // found in include/daos/drpc.h
-const MaxMsgSize = 1 << 17
+const MaxMsgSize = 1 << 20
 
 // DomainSocketServer is the object that listens for incoming dRPC connections,
 // maintains the connections for sessions, and manages the message processing.


### PR DESCRIPTION
The previous size of 128kB is not large enough for some
response messages on large-scale systems.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
