### PR TITLE
DAOS-13281 test: Fix dmg_storage_query.py bdev_role access

### DIFF
--- a/src/tests/ftest/control/dmg_storage_query.py
+++ b/src/tests/ftest/control/dmg_storage_query.py
@@ -45,15 +45,15 @@ class DmgStorageQuery(ControlTestBase):
                     for item, device in enumerate(tier.bdev_list.value):
                         bdev_info.append(
                             {'bdev': device,
-                             'bdev_roles': tier.bdev_roles.value,
+                             'roles': tier.bdev_roles.value,
                              'tier': index,
                              'tgt_ids': list(range(item, targets, len(tier.bdev_list.value)))})
         if md_on_ssd:
             for device in bdev_info:
-                if device['bdev_roles']:
+                if device['roles']:
                     # Use predefined roles
                     continue
-                device['bdev_roles'] = ','.join(get_tier_roles(device['tier'], bdev_tiers + 1))
+                device['roles'] = ','.join(get_tier_roles(device['tier'], bdev_tiers + 1))
 
         self.log.info('Detected NVMe devices in config')
         for bdev in bdev_info:
@@ -115,7 +115,7 @@ class DmgStorageQuery(ControlTestBase):
                 bdev_tr_addr = '{:02x}{:02x}{:02x}:'.format(
                     *list(map(int, re.split(r'[:.]', bdev['bdev'])[1:], [16] * 3)))
                 if device['tr_addr'] == bdev['bdev'] or device['tr_addr'].startswith(bdev_tr_addr):
-                    for key in ('tgt_ids', 'bdev_roles'):
+                    for key in ('tgt_ids', 'roles'):
                         messages.append(
                             '{}:   detected={}, expected={}'.format(key, device[key], bdev[key]))
                         if device[key] != bdev[key]:

--- a/src/tests/ftest/control/dmg_storage_query.py
+++ b/src/tests/ftest/control/dmg_storage_query.py
@@ -45,7 +45,7 @@ class DmgStorageQuery(ControlTestBase):
                     for item, device in enumerate(tier.bdev_list.value):
                         bdev_info.append(
                             {'bdev': device,
-                             'roles': tier.bdev_roles.value,
+                             'roles': ','.join(tier.bdev_roles.value or []),
                              'tier': index,
                              'tgt_ids': list(range(item, targets, len(tier.bdev_list.value)))})
         if md_on_ssd:

--- a/src/tests/ftest/control/dmg_storage_query.py
+++ b/src/tests/ftest/control/dmg_storage_query.py
@@ -45,15 +45,15 @@ class DmgStorageQuery(ControlTestBase):
                     for item, device in enumerate(tier.bdev_list.value):
                         bdev_info.append(
                             {'bdev': device,
-                             'roles': tier.roles.value,
+                             'bdev_roles': tier.bdev_roles.value,
                              'tier': index,
                              'tgt_ids': list(range(item, targets, len(tier.bdev_list.value)))})
         if md_on_ssd:
             for device in bdev_info:
-                if device['roles']:
+                if device['bdev_roles']:
                     # Use predefined roles
                     continue
-                device['roles'] = ','.join(get_tier_roles(device['tier'], bdev_tiers + 1))
+                device['bdev_roles'] = ','.join(get_tier_roles(device['tier'], bdev_tiers + 1))
 
         self.log.info('Detected NVMe devices in config')
         for bdev in bdev_info:
@@ -115,7 +115,7 @@ class DmgStorageQuery(ControlTestBase):
                 bdev_tr_addr = '{:02x}{:02x}{:02x}:'.format(
                     *list(map(int, re.split(r'[:.]', bdev['bdev'])[1:], [16] * 3)))
                 if device['tr_addr'] == bdev['bdev'] or device['tr_addr'].startswith(bdev_tr_addr):
-                    for key in ('tgt_ids', 'roles'):
+                    for key in ('tgt_ids', 'bdev_roles'):
                         messages.append(
                             '{}:   detected={}, expected={}'.format(key, device[key], bdev[key]))
                         if device[key] != bdev[key]:


### PR DESCRIPTION
Updating the control/dmg_storage_query.py to use the new bdev_role attribute which replaced the server config role attribute recently.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_dmg_storage_query_devices
Test-nvme: auto_md_on_ssd

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [x] You are the appropriate gatekeeper to be landing the patch.
* [x] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [x] Githooks were used. If not, request that user install them and check copyright dates.
* [x] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [x] All builds have passed.  Check non-required builds for any new compiler warnings.
* [x] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [x] If applicable, the PR has addressed any potential version compatibility issues.
* [x] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [x] Extra checks if forced landing is requested
  * [x] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [x] No new NLT or valgrind warnings.  Check the classic view.
  * [x] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
