### PR TITLE
DAOS-13266 control: Serialize PoolCreate requests

### DIFF
--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -240,14 +240,26 @@ func (svc *mgmtSvc) calculateCreateStorage(req *mgmtpb.PoolCreateReq) error {
 
 // PoolCreate implements the method defined for the Management Service.
 //
-// Validate minimum SCM/NVMe pool size per VOS target, pool size request params
-// are per-engine so need to be larger than (minimum_target_allocation *
-// target_count).
-func (svc *mgmtSvc) PoolCreate(parent context.Context, req *mgmtpb.PoolCreateReq) (resp *mgmtpb.PoolCreateResp, err error) {
+// NB: Only one pool create request may be processed at a time.
+func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (*mgmtpb.PoolCreateResp, error) {
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
 
+	msg, err := svc.submitSerialRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return msg.(*mgmtpb.PoolCreateResp), nil
+}
+
+// poolCreate handles the actual pool creation request. This is separated from
+// PoolCreate() so that it can be called from the batch request handler.
+//
+// Validate minimum SCM/NVMe pool size per VOS target, pool size request params
+// are per-engine so need to be larger than (minimum_target_allocation *
+// target_count).
+func (svc *mgmtSvc) poolCreate(parent context.Context, req *mgmtpb.PoolCreateReq) (resp *mgmtpb.PoolCreateResp, err error) {
 	if err := svc.poolCreateAddSystemProps(req); err != nil {
 		return nil, err
 	}

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -150,7 +150,6 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 
 			poolUUID := test.MockPoolUUID(1)
 			lock, ctx := getPoolLockCtx(t, nil, svc.sysdb, poolUUID)
-			defer lock.Release()
 			if err := svc.sysdb.AddPoolService(ctx, &system.PoolService{
 				PoolUUID: poolUUID,
 				State:    tc.state,
@@ -162,6 +161,7 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 			}); err != nil {
 				t.Fatal(err)
 			}
+			lock.Release()
 
 			req := &mgmtpb.PoolCreateReq{
 				Sys:        build.DefaultSystemName,

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -403,7 +403,7 @@ func (srv *server) registerEvents() {
 	srv.sysdb.OnLeadershipGained(
 		func(ctx context.Context) error {
 			srv.log.Infof("MS leader running on %s", srv.hostname)
-			srv.mgmtSvc.startAsyncLoops(ctx)
+			srv.mgmtSvc.startLeaderLoops(ctx)
 			registerLeaderSubscriptions(srv)
 			srv.log.Debugf("requesting immediate GroupUpdate after leader change")
 			go func() {
@@ -470,6 +470,7 @@ func (srv *server) start(ctx context.Context) error {
 		}
 	}()
 
+	srv.mgmtSvc.startAsyncLoops(ctx)
 	return errors.Wrapf(srv.harness.Start(ctx, srv.sysdb, srv.cfg),
 		"%s harness exited", build.ControlPlaneName)
 }

--- a/src/control/server/util_test.go
+++ b/src/control/server/util_test.go
@@ -238,6 +238,7 @@ func newTestMgmtSvc(t *testing.T, log logging.Logger) *mgmtSvc {
 	svc := newMgmtSvc(harness, ms, db, nil, events.NewPubSub(ctx, log))
 	svc.batchInterval = 100 * time.Microsecond // Speed up tests
 	svc.startAsyncLoops(ctx)
+	svc.startLeaderLoops(ctx)
 	return svc
 }
 


### PR DESCRIPTION
Adds a new gRPC request serialization mechanism to handle
PoolCreate requests. Mitigates against a number of edge
cases that may occur during multiple concurrent PoolCreate
requests.

Moves non-leader async management out of leadership callback.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
