### PR TITLE
DAOS-13198 control: Improve error for insecure incompatibility

### DIFF
--- a/src/control/build/interop.go
+++ b/src/control/build/interop.go
@@ -53,7 +53,7 @@ func NewVersionedComponent(comp Component, version string) (*VersionedComponent,
 	case ComponentServer, ComponentAdmin, ComponentAgent, ComponentAny:
 		return &VersionedComponent{
 			Component: comp,
-			Version:   *v,
+			Version:   v,
 		}, nil
 	default:
 		return nil, errors.Errorf("invalid component %q", comp)

--- a/src/control/build/version.go
+++ b/src/control/build/version.go
@@ -35,39 +35,40 @@ func MustNewVersion(in string) Version {
 		panic(err)
 	}
 
-	return *v
+	return v
 }
 
 // NewVersion creates a new version from a string.
-func NewVersion(in string) (*Version, error) {
+func NewVersion(in string) (Version, error) {
 	var (
 		major, minor, patch int
 		err                 error
 	)
+	nilVersion := Version{}
 
 	in = strings.TrimPrefix(in, "v")
 
 	parts := strings.Split(in, ".")
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid version format %q", in)
+		return nilVersion, fmt.Errorf("invalid version format %q", in)
 	}
 
 	major, err = strconv.Atoi(parts[0])
 	if err != nil {
-		return nil, fmt.Errorf("invalid major version %q: %v", parts[0], err)
+		return nilVersion, fmt.Errorf("invalid major version %q: %v", parts[0], err)
 	}
 
 	minor, err = strconv.Atoi(parts[1])
 	if err != nil {
-		return nil, fmt.Errorf("invalid minor version %q: %v", parts[1], err)
+		return nilVersion, fmt.Errorf("invalid minor version %q: %v", parts[1], err)
 	}
 
 	patch, err = strconv.Atoi(parts[2])
 	if err != nil {
-		return nil, fmt.Errorf("invalid patch version %q: %v", parts[2], err)
+		return nilVersion, fmt.Errorf("invalid patch version %q: %v", parts[2], err)
 	}
 
-	return &Version{
+	return Version{
 		Major: major,
 		Minor: minor,
 		Patch: patch,

--- a/src/control/build/version_test.go
+++ b/src/control/build/version_test.go
@@ -69,7 +69,7 @@ func TestBuild_NewVersion(t *testing.T) {
 				return
 			}
 
-			if !tc.expVer.Equals(*gotVer) {
+			if !tc.expVer.Equals(gotVer) {
 				t.Fatalf("expected version %v, got %v", tc.expVer, gotVer)
 			}
 		})

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -138,6 +138,7 @@ const (
 	ServerVfioDisabled
 	ServerPoolNoLabel
 	ServerIncompatibleComponents
+	ServerNoCompatibilityInsecure
 	ServerPoolHasContainers
 )
 

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -158,6 +158,14 @@ func FaultIncompatibleComponents(self, other *build.VersionedComponent) *fault.F
 	)
 }
 
+func FaultNoCompatibilityInsecure(self, other build.Version) *fault.Fault {
+	return serverFault(
+		code.ServerNoCompatibilityInsecure,
+		fmt.Sprintf("versions %s and %s are not compatible in insecure mode", self, other),
+		"enable certificates or use identical component versions",
+	)
+}
+
 func serverFault(code code.Code, desc, res string) *fault.Fault {
 	return &fault.Fault{
 		Domain:      "server",

--- a/src/control/server/interceptors_test.go
+++ b/src/control/server/interceptors_test.go
@@ -131,9 +131,10 @@ func TestServer_checkVersion(t *testing.T) {
 			ctx:          newTestAuthCtx(context.TODO(), "3v1l"),
 			expErr:       errors.New("not compatible"),
 		},
-		"insecure versioned component defaults to server": {
+		"insecure components not compatible": {
 			selfVersion:  "2.4.0",
 			otherVersion: "2.4.1",
+			expErr:       errors.New("not compatible in insecure mode"),
 		},
 		"secure versioned component": {
 			selfVersion:  "2.4.0",


### PR DESCRIPTION
When running without certificates, the interoperability checks
cannot verify the peer component, and therefore inter-version
compatibility cannot be determined. The current error message
is a little confusing, so this commit adds a new fault with
a clearer description of the problem and proposed solution.

e.g.
$ dmg storage format
ERROR: dmg: server: code = 617 description = "versions 2.3.106 and 1.2.3 are not compatible in insecure mode"
ERROR: dmg: server: code = 617 resolution = "enable certificates or use identical component versions"

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
