### PR TITLE
DAOS-10540 dfuse: Only evict dfuse metadata cache on write

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -41,21 +41,21 @@ struct ioil_pool {
 };
 
 struct ioil_global {
-	pthread_mutex_t	iog_lock;
-	d_list_t	iog_pools_head;
+	pthread_mutex_t iog_lock;
+	d_list_t        iog_pools_head;
 	pid_t           iog_init_tid;
-	bool		iog_initialized;
-	bool		iog_no_daos;
-	bool		iog_daos_init;
+	bool            iog_initialized;
+	bool            iog_no_daos;
+	bool            iog_daos_init;
 
-	bool		iog_show_summary;	/**< Should a summary be shown at teardown */
+	bool            iog_show_summary; /**< Should a summary be shown at teardown */
 
-	unsigned	iog_report_count;	/**< Number of operations that should be logged */
+	unsigned        iog_report_count; /**< Number of operations that should be logged */
 
-	uint64_t	iog_file_count;		/**< Number of file opens intercepted */
-	uint64_t	iog_read_count;		/**< Number of read operations intercepted */
-	uint64_t	iog_write_count;	/**< Number of write operations intercepted */
-	uint64_t	iog_fstat_count;	/**< Number of fstat operations intercepted */
+	ATOMIC uint64_t iog_file_count;  /**< Number of file opens intercepted */
+	ATOMIC uint64_t iog_read_count;  /**< Number of read operations intercepted */
+	ATOMIC uint64_t iog_write_count; /**< Number of write operations intercepted */
+	ATOMIC uint64_t iog_fstat_count; /**< Number of fstat operations intercepted */
 };
 
 static vector_t	fd_table;

--- a/src/client/dfuse/il/int_write.c
+++ b/src/client/dfuse/il/int_write.c
@@ -18,6 +18,12 @@ ioil_do_writex(const char *buff, size_t len, off_t position, struct fd_entry *en
 	d_iov_t     iov = {};
 	d_sg_list_t sgl = {};
 	int         rc;
+	uint32_t    zero = 0;
+	uint32_t    one  = 1;
+
+	if (atomic_compare_exchange(&entry->fd_written, zero, one)) {
+		DFUSE_TRA_ERROR(entry->fd_dfsoh, "First write at %zi", position);
+	}
 
 	DFUSE_TRA_DEBUG(entry->fd_dfsoh, "%#zx-%#zx", position, position + len - 1);
 

--- a/src/client/dfuse/il/ioil.h
+++ b/src/client/dfuse/il/ioil.h
@@ -38,6 +38,7 @@ struct fd_entry {
 	int               fd_status;
 	bool              fd_fstat;
 
+	ATOMIC uint32_t   fd_written;
 	/* Used for streaming I/O only */
 	bool              fd_eof;
 	int               fd_err;


### PR DESCRIPTION
WIP

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
