### PR TITLE
DAOS-12394 test: do not land, test with libfabric1.17.1

### DIFF
--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -659,11 +659,23 @@ class TestPool(TestDaosApiBase):
                 self.identifier, self.pool_query_timeout.value)
             end_time = time() + self.pool_query_timeout.value
 
+        if self.set_logmasks.value is True:
+            self.dmg.server_set_logmasks("DEBUG", raise_exception=False)
+
         while True:
             try:
-                return self.dmg.pool_query(self.identifier, show_enabled, show_disabled)
+                data = self.dmg.pool_query(self.identifier, show_enabled, show_disabled)
+                pquery_res = self.dmg.result
+                if self.set_logmasks.value is True:
+                    self.dmg.server_set_logmasks(raise_exception=False)
+
+                # dmg exit status needs to be that of pool query not set-logmasks
+                self.dmg.result = pquery_res
+                return data
 
             except CommandFailure as error:
+                if self.set_logmasks.value is True:
+                    self.dmg.server_set_logmasks(raise_exception=False)
                 if end_time is None:
                     raise
 


### PR DESCRIPTION
Also, temporarily elevate engine log_mask to DEBUG before pool query, and restore after the command runs.

Quick-Functional: true
Test-tag: per_server_fault_domain
Test-repeat: 5

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
