### PR TITLE
DAOS-13288 test: don't ignore pool creation failure

### DIFF
--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -611,11 +611,9 @@ extend_small_sub_setup(void **state)
 	save_group_state(state);
 	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			EXTEND_SMALL_POOL_SIZE, 3, NULL);
-	if (rc) {
+	if (rc)
 		print_message("It can not create the pool with 3 ranks"
 			      " probably due to not enough ranks %d\n", rc);
-		return 0;
-	}
 
 	return rc;
 }

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -1182,12 +1182,9 @@ rebuild_sub_setup_common(void **state, daos_size_t pool_size, int node_nr, uint3
 	rc = test_setup(state, SETUP_POOL_CONNECT, true,
 			pool_size, node_nr, NULL);
 	if (rc) {
-		/* Let's skip for this case, since it is possible there
-		 * is not enough ranks here.
-		 */
 		print_message("It can not create the pool, probably due"
 			      " to not enough ranks %d\n", rc);
-		return 0;
+		return rc;
 	}
 
 	arg = *state;

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -267,7 +267,7 @@ rebuild_ec_setup(void  **state, int number, uint32_t rf)
 		print_message("It can not create the pool with %d ranks"
 			      " probably due to not enough ranks %d\n",
 			      number, rc);
-		return 0;
+		return rc;
 	}
 
 	arg = *state;

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -860,12 +860,9 @@ rebuild_small_pool_n4_rf1_setup(void **state)
 	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			REBUILD_SMALL_POOL_SIZE, 4, NULL);
 	if (rc) {
-		/* Let's skip for this case, since it is possible there
-		 * is not enough ranks here.
-		 */
 		print_message("It can not create the pool with 4 ranks"
 			      " probably due to not enough ranks %d\n", rc);
-		return 0;
+		return rc;
 	}
 
 	arg = *state;
@@ -887,12 +884,9 @@ rebuild_small_pool_n4_setup(void **state)
 	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			REBUILD_SMALL_POOL_SIZE, 4, NULL);
 	if (rc) {
-		/* Let's skip for this case, since it is possible there
-		 * is not enough ranks here.
-		 */
 		print_message("It can not create the pool with 4 ranks"
 			      " probably due to not enough ranks %d\n", rc);
-		return 0;
+		return rc;
 	}
 
 	arg = *state;


### PR DESCRIPTION
It is not easy to know if error really comes from not enough ranks, we hit some real bugs, but test was not marked as failure.

Required-githooks: true
