### PR TITLE
DAOS-13219 control: Improve dRPC client implementation

### DIFF
--- a/src/control/cmd/daos_agent/security_rpc_test.go
+++ b/src/control/cmd/daos_agent/security_rpc_test.go
@@ -75,8 +75,10 @@ func setupTestUnixConn(t *testing.T) (*net.UnixConn, func()) {
 }
 
 func getClientConn(t *testing.T, path string) *drpc.ClientConnection {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 	client := drpc.NewClientConnection(path)
-	if err := client.Connect(); err != nil {
+	if err := client.Connect(ctx); err != nil {
 		t.Fatalf("Failed to connect: %v", err)
 	}
 	return client

--- a/src/control/cmd/hello_drpc/main.go
+++ b/src/control/cmd/hello_drpc/main.go
@@ -80,7 +80,9 @@ func runDrpcServer(log logging.Logger) error {
 func runDrpcClient(log logging.Logger) error {
 	client := drpc.NewClientConnection(*unixSocket)
 
-	err := client.Connect()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := client.Connect(ctx)
 	if err != nil {
 		return errors.Wrap(err, "connecting to socket")
 	}

--- a/src/control/drpc/drpc_server_test.go
+++ b/src/control/drpc/drpc_server_test.go
@@ -314,7 +314,7 @@ func TestServer_IntegrationNoMethod(t *testing.T) {
 
 	// Now start a client...
 	client := NewClientConnection(path)
-	if err := client.Connect(); err != nil {
+	if err := client.Connect(context.Background()); err != nil {
 		t.Fatalf("failed to connect client: %v", err)
 	}
 	defer client.Close()

--- a/src/control/server/util_test.go
+++ b/src/control/server/util_test.go
@@ -92,7 +92,10 @@ func (c *mockDrpcClient) IsConnected() bool {
 	return c.cfg.IsConnectedBool
 }
 
-func (c *mockDrpcClient) Connect() error {
+func (c *mockDrpcClient) Connect(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return c.cfg.ConnectError
 }
 


### PR DESCRIPTION
  * Modify Connect() to accept a context that is used for
    DialContext() in order to avoid making a connection with
    a canceled context
  * Ignore already-closed error on connection close

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
