### PR TITLE
DAOS-8722 dfuse: Use a common buffer for readdir replies.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -172,6 +172,9 @@ struct dfuse_readdir_hdl {
 	/** an anchor to track listing in readdir */
 	daos_anchor_t              drh_anchor;
 
+	char                      *drh_buff;
+	size_t                     drh_buff_size;
+
 	/** Array of entries returned by dfs but not reported to kernel */
 	struct dfuse_readdir_entry drh_dre[READDIR_MAX_COUNT];
 	/** Current index into doh_dre array */

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -2008,6 +2008,9 @@ class PosixTests():
         assert files == files2, 'inconsistent file names'
         assert len(files) == count, 'incoorect file count'
         assert set(files) == src_files, 'incorrect file names'
+        # Finally remove the test dir, this should cause dfuse to forget everything therefore
+        # be able to verify reference counting.
+        shutil.rmtree(test_dir)
 
     @needs_dfuse
     def test_readdir_cache_short(self):


### PR DESCRIPTION
Save a common reply buffer on the readdir handle rather than allocing one every call.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>