### PR TITLE
DAOS-13389 [Java] Open object class of daos file for configuration in hadoop-daos

### DIFF
--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/Constants.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/Constants.java
@@ -6,6 +6,8 @@
 
 package io.daos.fs.hadoop;
 
+import io.daos.DaosObjectClass;
+
 /**
  * ALL configuration and value constants.
  */
@@ -36,6 +38,9 @@ public final class Constants {
   public static final int DEFAULT_DAOS_CHUNK_SIZE = 1024 * 1024;
   public static final int MAXIMUM_DAOS_CHUNK_SIZE = Integer.MAX_VALUE;
   public static final int MINIMUM_DAOS_CHUNK_SIZE = 4 * 1024;
+
+  public static final String DAOS_OBJECT_CLASS = "fs.daos.object.class";
+  public static final String DEFAULT_DAOS_OBJECT_CLASS = DaosObjectClass.OC_SX.name();
 
   public static final int DAOS_MODLE = 0755;
 

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
@@ -37,6 +37,7 @@ public class DaosFileSystem extends FileSystem {
   private int writeBufferSize;
   private int blockSize;
   private int chunkSize;
+  private DaosObjectClass objectClass;
   private int minReadSize;
   private String bucket;
   private String unsPrefix;
@@ -181,6 +182,8 @@ public class DaosFileSystem extends FileSystem {
     this.readBufferSize = conf.getInt(Constants.DAOS_READ_BUFFER_SIZE, Constants.DEFAULT_DAOS_READ_BUFFER_SIZE);
     this.writeBufferSize = conf.getInt(Constants.DAOS_WRITE_BUFFER_SIZE, Constants.DEFAULT_DAOS_WRITE_BUFFER_SIZE);
     this.blockSize = conf.getInt(Constants.DAOS_BLOCK_SIZE, Constants.DEFAULT_DAOS_BLOCK_SIZE);
+    String objClsStr = conf.get(Constants.DAOS_OBJECT_CLASS, Constants.DEFAULT_DAOS_OBJECT_CLASS);
+    this.objectClass = DaosObjectClass.valueOf(objClsStr);
     this.chunkSize = conf.getInt(Constants.DAOS_CHUNK_SIZE, Constants.DEFAULT_DAOS_CHUNK_SIZE);
     this.minReadSize = conf.getInt(Constants.DAOS_READ_MINIMUM_SIZE, Constants.MINIMUM_DAOS_READ_BUFFER_SIZE);
     if (minReadSize > readBufferSize || minReadSize <= 0) {
@@ -380,7 +383,7 @@ public class DaosFileSystem extends FileSystem {
 
     daosFile.createNewFile(
             Constants.DAOS_MODLE,
-            DaosObjectClass.OC_SX,
+            this.objectClass,
             this.chunkSize,
             true);
 

--- a/src/client/java/hadoop-daos/src/main/resources/daos-config.txt
+++ b/src/client/java/hadoop-daos/src/main/resources/daos-config.txt
@@ -51,7 +51,9 @@
         11. fs.daos.chunk.size          1048576                 size of DAOS file chunk. Default is 1m. Value range is
                                                                 4k - 2g.
 
-        12. fs.daos.io.async            true                    perform DAOS IO asynchronously. Default is true.
+        12. fs.daos.object.class        OC_SX                   object class of DAOS file.
+
+        13. fs.daos.io.async            true                    perform DAOS IO asynchronously. Default is true.
                                                                 Set to false to use synchronous IO.
 
 

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFsConfigTest.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFsConfigTest.java
@@ -25,7 +25,7 @@ public class DaosFsConfigTest {
   @Test
   public void testFsConfigNamesSize() throws Exception {
     DaosFsConfig cf = DaosFsConfig.getInstance();
-    Assert.assertEquals(12, cf.getFsConfigNames().size());
+    Assert.assertEquals(13, cf.getFsConfigNames().size());
   }
 
   @Test
@@ -75,6 +75,7 @@ public class DaosFsConfigTest {
     daosConfig.put(Constants.DAOS_CHUNK_SIZE, "35678");
     daosConfig.put(Constants.DAOS_POOL_ID, "daos pid");
     daosConfig.put(Constants.DAOS_IO_ASYNC, "false");
+    daosConfig.put(Constants.DAOS_OBJECT_CLASS, "OC_S1");
 
     daosConfig.put("spark." + Constants.DAOS_IO_ASYNC, "true");
 
@@ -85,5 +86,6 @@ public class DaosFsConfigTest {
     Assert.assertEquals("9876", hadoopConfig.get(Constants.DAOS_READ_MINIMUM_SIZE));
     Assert.assertEquals("45678", hadoopConfig.get(Constants.DAOS_CHUNK_SIZE));
     Assert.assertEquals("true", hadoopConfig.get(Constants.DAOS_IO_ASYNC));
+    Assert.assertEquals("OC_S1", hadoopConfig.get(Constants.DAOS_OBJECT_CLASS));
   }
 }

--- a/src/client/java/hadoop-daos/src/test/resources/core-site.xml
+++ b/src/client/java/hadoop-daos/src/test/resources/core-site.xml
@@ -44,6 +44,13 @@
     </description>
   </property>
   <property>
+    <name>fs.daos.object.class</name>
+    <value>OC_SX</value>
+    <description>
+      object class of DAOS file.
+    </description>
+  </property>
+  <property>
     <name>fs.daos.read.min.size</name>
     <value>4194304</value>
   </property>


### PR DESCRIPTION
Currently, object class of daos file is hard-coded to OC_SX. To provide user choice of selecting other object classes, like replication, we make it configurable.