### PR TITLE
DAOS-8781 client: allow polling timeout to be modified via env

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -20,6 +20,12 @@
 static __thread daos_event_t	ev_thpriv;
 static __thread bool		ev_thpriv_is_init;
 
+/**
+ * Global progress timeout for synchronous operation
+ * busy-polling by default (0), timeout in us otherwise
+ */
+static uint32_t ev_prog_timeout = 0;
+
 #define EQ_WITH_CRT
 
 #if !defined(EQ_WITH_CRT)
@@ -90,6 +96,8 @@ daos_eq_lib_init()
 		D_GOTO(crt, rc);
 
 	eq_ref = 1;
+
+	d_getenv_int("D_POLL_TIMEOUT", &ev_prog_timeout);
 
 unlock:
 	D_MUTEX_UNLOCK(&daos_eq_lock);
@@ -1262,7 +1270,7 @@ daos_event_priv_wait()
 
 	/* Wait on the event to complete */
 	while (evx->evx_status != DAOS_EVS_READY) {
-		rc = crt_progress_cond(evx->evx_ctx, 0, ev_progress_cb, &epa);
+		rc = crt_progress_cond(evx->evx_ctx, ev_prog_timeout, ev_progress_cb, &epa);
 
 		/** progress succeeded, loop can exit if event completed */
 		if (rc == 0) {


### PR DESCRIPTION
Introduce a new env variable called D_POLL_TIMEOUT in libdaos to tune how aggressive the polling on network progress is for synchronous operation. For asynchronous operations, the caller already passes a timeout to eq_poll or event_test.
The default value (0) is not changed and means busy polling. This can be modified to a value in micro-seconds.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
