### PR TITLE
DAOS-12002 control: Fix DomainInfo stringer

### DIFF
--- a/src/control/cmd/daos_agent/security_rpc_test.go
+++ b/src/control/cmd/daos_agent/security_rpc_test.go
@@ -74,10 +74,8 @@ func setupTestUnixConn(t *testing.T) (*net.UnixConn, func()) {
 }
 
 func getClientConn(t *testing.T, path string) *drpc.ClientConnection {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 	client := drpc.NewClientConnection(path)
-	if err := client.Connect(ctx); err != nil {
+	if err := client.Connect(test.Context(t)); err != nil {
 		t.Fatalf("Failed to connect: %v", err)
 	}
 	return client

--- a/src/control/security/domain_info.go
+++ b/src/control/security/domain_info.go
@@ -48,7 +48,7 @@ func (d *DomainInfo) String() string {
 	if d.creds == nil {
 		return "nil creds"
 	}
-	outStr := fmt.Sprintf("%s pid: %d", d.ctx, d.creds.Pid)
+	outStr := fmt.Sprintf("pid: %d", d.creds.Pid)
 	if pName, err := common.GetProcName(int(d.creds.Pid)); err == nil {
 		outStr += fmt.Sprintf(" (%s)", pName)
 	}

--- a/src/control/security/domain_info_test.go
+++ b/src/control/security/domain_info_test.go
@@ -1,0 +1,60 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package security_test
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/daos-stack/daos/src/control/security"
+)
+
+func TestSecurity_DomainInfo_String(t *testing.T) {
+	ucred_noPid := &syscall.Ucred{
+		Pid: 0,
+		Uid: 123456,
+		Gid: 789012,
+	}
+	ucred_Pid := &syscall.Ucred{
+		Pid: 1, // should be systemd on any modern system
+		Uid: 0,
+		Gid: 0,
+	}
+	for name, tc := range map[string]struct {
+		di     *security.DomainInfo
+		expStr string
+	}{
+		"nil": {
+			di:     nil,
+			expStr: "nil",
+		},
+		"empty": {
+			di:     &security.DomainInfo{},
+			expStr: "nil creds",
+		},
+		"nil creds": {
+			di:     security.InitDomainInfo(nil, "ctx"),
+			expStr: "nil creds",
+		},
+		"creds (no PID)": {
+			di:     security.InitDomainInfo(ucred_noPid, "ctx"),
+			expStr: "pid: 0 uid: 123456 gid: 789012",
+		},
+		"creds (PID)": {
+			di:     security.InitDomainInfo(ucred_Pid, "ctx"),
+			expStr: "pid: 1 (systemd) uid: 0 (root) gid: 0 (root)",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.expStr, tc.di.String()); diff != "" {
+				t.Fatalf("unexpected DomainInfo string (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Don't include the context string in the human-readable output.

Also fixes a bad merge in daos_agent/security_rpc_test.go

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
