### PR TITLE
DAOS-13410 bio: fix smd_pool_list() without data blobs

### DIFF
--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -342,19 +342,27 @@ smd_pool_list_cb(struct sys_db *db, char *table, d_iov_t *key, void *args)
 	enum smd_dev_type	 st;
 	struct d_uuid            id;
 	int                      rc;
-	int			 count = 0;
+	bool			 meta_pool = false;
+
+	if (!strncmp(table, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX))
+		meta_pool = true;
 
 	D_ASSERT(key->iov_len == sizeof(id));
 	id = *(struct d_uuid *)key->iov_buf;
 	memset(pools, 0, sizeof(struct smd_pool) * SMD_DEV_TYPE_MAX);
 	for (st = SMD_DEV_TYPE_DATA; st < SMD_DEV_TYPE_MAX; st++) {
 		rc = smd_db_fetch(TABLE_POOLS[st], &id, sizeof(id), &pools[st], sizeof(pools[st]));
-		if (rc && rc != -DER_NONEXIST)
+		/* PMDK case, only check data blob */
+		if (!meta_pool) {
+			if (rc)
+				return rc;
+			break;
+		}
+
+		/* MD-ON-SSD case, data blob might not exist */
+		if (rc && (rc != -DER_NONEXIST || st != SMD_DEV_TYPE_DATA))
 			return rc;
 	}
-
-	if (count == 0)
-		return -DER_NONEXIST;
 
 	info = smd_pool_alloc_info(&id, pools);
 	if (!info)


### PR DESCRIPTION
smd_pool_list() only iterate Data type, it will miss pools which were created with SCM only under MD-on-SSD case.

Required-githooks: true
Test-nvme: auto_md_on_ssd