### PR TITLE
DAOS-13439 test: re-enabled IO30 test

### DIFF
--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3061,7 +3061,8 @@ echo_fetch_update(void **state)
 static void
 tgt_idx_change_retry(void **state)
 {
-	test_arg_t		*arg = *state;
+	test_arg_t		*arg0 = *state;
+	test_arg_t		*arg = NULL;
 	daos_obj_id_t		 oid;
 	struct ioreq		 req;
 	const char		 dkey[] = "tgt_change dkey";
@@ -3078,6 +3079,12 @@ tgt_idx_change_retry(void **state)
 	int			 i;
 	int			 rc;
 
+	dt_redun_fac = DAOS_PROP_CO_REDUN_RF1;
+	rc = test_setup((void **)&arg, SETUP_CONT_CONNECT, arg0->multi_rank,
+			SMALL_POOL_SIZE, 0, NULL);
+	assert_success(rc);
+	dt_redun_fac = 0;
+
 	/* create a 3 replica small object, to test the case that:
 	 * update:
 	 * 1) shard 0 IO finished, then the target x of shard 0 dead/excluded
@@ -3091,16 +3098,12 @@ tgt_idx_change_retry(void **state)
 	if (!test_runable(arg, 4))
 		skip();
 
-	if (1) {
-		print_message("Temporary disable IO30\n");
-		skip();
-	}
-
-	if (!arg->async) {
+	if (!arg0->async) {
 		if (arg->myrank == 0)
 			print_message("this test can-only run in async mode\n");
 		skip();
 	}
+	async_enable((void **)&arg);
 
 	oid = daos_test_oid_gen(arg->coh, DAOS_OC_R3S_SPEC_RANK, 0, 0,
 				arg->myrank);
@@ -3216,6 +3219,7 @@ tgt_idx_change_retry(void **state)
 	}
 	par_barrier(PAR_COMM_WORLD);
 	ioreq_fini(&req);
+	test_teardown((void **)&arg);
 }
 
 static void


### PR DESCRIPTION
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
