### PR TITLE
DAOS-13415 test: pool/destroy_rebuild.py update rebuild ranks

### DIFF
--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -3,6 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
+import random
+
 from apricot import TestWithServers
 from general_utils import list_to_str
 
@@ -33,7 +35,6 @@ class DestroyRebuild(TestWithServers):
         """
         # Get the test parameters
         targets = self.server_managers[0].get_config_value("targets")
-        ranks = self.params.get("rank_to_kill", "/run/testparams/*")
 
         # 1.
         self.log_step("Create a pool")
@@ -52,6 +53,27 @@ class DestroyRebuild(TestWithServers):
 
         # 3.
         self.log_step("Start rebuild, system stop")
+        all_ranks = self.server_managers[0].ranks.keys()
+        ap_ranks = self.server_managers[0].get_host_ranks(self.access_points)
+        non_ap_ranks = list(set(all_ranks) - set(ap_ranks))
+
+        # Get the pool leader rank
+        pool.set_query_data()
+        leader_rank = pool.query_data["response"]["leader"]
+        ap_ranks.remove(leader_rank)
+
+        # Select the following ranks to stop
+        #  - the pool leader rank
+        #  - a random rank that is not an access point
+        #  - a random rank this is an access point and not the pool leader
+        self.log.debug(
+            "Engine ranks:  pool leader=%s, access points=%s, other=%s",
+            leader_rank, ap_ranks, non_ap_ranks)
+        ranks = [leader_rank]
+        ranks.append(random.choice(ap_ranks))  # nosec
+        ranks.append(random.choice(non_ap_ranks))  # nosec
+        self.log.info("ranks to rebuild: %s", ranks)
+
         self.server_managers[0].stop_ranks(ranks, self.d_log, force=True)
         pool.wait_for_rebuild_to_start()
 

--- a/src/tests/ftest/pool/destroy_rebuild.yaml
+++ b/src/tests/ftest/pool/destroy_rebuild.yaml
@@ -23,8 +23,3 @@ pool:
   control_method: dmg
   pool_query_timeout: 30
   svcn: 7
-testparams:
-  rank_to_kill:
-    - 0
-    - 1
-    - 4


### PR DESCRIPTION
Description: 
  kill the pool leader rank and two other ranks, one of which is not a MS replica rank
Skip-unit-tests: true
Test-repeat: 5
Test-tag: test_destroy_while_rebuilding
Allow-unstable-test: true
Required-githooks: true
Signed-off-by: Ding Ho ding-hwa.ho@intel.com

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
