### PR TITLE
DAOS-13194 common: prealloc bunch of environment vars slots

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -794,7 +794,11 @@ daos_grow_env_array(void)
 	}
 
 	env_var_str = malloc(strlen("DAOS_") + strlen(env_var_num) + 1);
-	if (
+	if (env_var_str == NULL) {
+		D_ERROR("failed to allocate env var buffer: rc = %d (%s)\n",
+			rc, strerror(errno));
+		return;
+	}
 
 	/* setenv() MORE_ENV_VARS dummy env vars.
 	 *

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -786,6 +786,8 @@ daos_grow_env_array(void)
 	char *env_var_str;
 	char env_var_num[10];
 
+	D_INFO("Pre-allocating %d slots in env vars array.\n", MORE_ENV_VARS);
+
 	rc = sprintf(env_var_num, "%d", MORE_ENV_VARS);
 	if (rc < 0) {
 		D_ERROR("failed to generate max env num string: rc = %d (%s)\n",


### PR DESCRIPTION
Since late setenv()s are racy with getenv()s, and can occur in DAOS and pre-reqs/3rd-parties, try to preallocate a bunch of environment vars slots by calling setenv() hundreds of times for dummy env vars, and then unsetenv() them all in a raw. Doing so will allow for the environ vars pointers array not to be re-allocated and thus prevent crashes.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
