### PR TITLE
DAOS-13485 client: fix several coverity issues in libpil4dfs

### DIFF
--- a/src/client/dfuse/pil4dfs/hook.c
+++ b/src/client/dfuse/pil4dfs/hook.c
@@ -882,7 +882,7 @@ register_a_hook(const char *module_name, const char *func_name, const void *new_
 {
 	void *module;
 	int   idx, idx_mod;
-	char  module_name_local[MAX_LEN_PATH_NAME];
+	char  module_name_local[MAX_LEN_PATH_NAME + 4];
 
 	/* make sure module_name[] and func_name[] are not too long. */
 	if (strnlen(module_name, MAX_LEN_PATH_NAME + 1) >= MAX_LEN_PATH_NAME)

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -3492,7 +3492,8 @@ rename(const char *old_name, const char *new_name)
 			link_len_libc = readlink(old_name, symlink_value, DFS_MAX_PATH - 1);
 			if (link_len_libc >= DFS_MAX_PATH) {
 				if (bLog)
-					D_ERROR("link is too long. link_len = %" PRIu64, link_len_libc);
+					D_ERROR("link is too long. link_len = %" PRIu64,
+						link_len_libc);
 				D_GOTO(out_err, rc = ENAMETOOLONG);
 			} else if (link_len_libc < 0) {
 				if (bLog)

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -3480,6 +3480,8 @@ rename(const char *old_name, const char *new_name)
 		}
 		/* New_name was removed, now create a new one from the old one */
 		switch (type_old) {
+			ssize_t link_len_libc;
+
 		case S_IFLNK:
 			D_ALLOC(symlink_value, DFS_MAX_PATH);
 			if (symlink_value == NULL) {
@@ -3487,12 +3489,12 @@ rename(const char *old_name, const char *new_name)
 					D_ERROR("failed to allocate memory for symlink_value");
 				D_GOTO(out_err, rc = ENOMEM);
 			}
-			link_len = readlink(old_name, symlink_value, DFS_MAX_PATH - 1);
-			if (link_len >= DFS_MAX_PATH) {
+			link_len_libc = readlink(old_name, symlink_value, DFS_MAX_PATH - 1);
+			if (link_len_libc >= DFS_MAX_PATH) {
 				if (bLog)
-					D_ERROR("link is too long. link_len = %" PRIu64, link_len);
+					D_ERROR("link is too long. link_len = %" PRIu64, link_len_libc);
 				D_GOTO(out_err, rc = ENAMETOOLONG);
-			} else if (link_len < 0) {
+			} else if (link_len_libc < 0) {
 				if (bLog)
 					D_ERROR("readlink failed: %s", strerror(errno));
 				D_GOTO(out_err, rc = errno);
@@ -4667,8 +4669,6 @@ dup2(int oldfd, int newfd)
 			return fd;
 		else
 			return idx;
-	} else {
-		next_dup2(oldfd, newfd);
 	}
 	return -1;
 }


### PR DESCRIPTION
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
