### PR TITLE
DAOS-9918 test: Remove small pool (128MB) variant from container/full…

### DIFF
--- a/src/tests/ftest/container/full_pool_container_create.yaml
+++ b/src/tests/ftest/container/full_pool_container_create.yaml
@@ -1,5 +1,3 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers: 1
   test_clients: 1
@@ -10,13 +8,7 @@ server_config:
      scm_list: ["/dev/pmem0"]
 timeout: 900
 pool:
-  control_method: dmg
-  mode: 511
-  pool_size: !mux
-    small_pool:
-      size: 134217728 # 128Mb
-    larger_pool:
-      size: 53687091200  # 50G
-  threshold_percent: 0.1 # 10%
+  size: 53687091200  # 50G
+  threshold_percent: 0.1  # 10%
 container:
   control_method: daos


### PR DESCRIPTION
…_pool_container_create.py (#12130)

Based on Yawei's comment in DAOS-9918, this test doesn't work with small pool size.

Cherry-pick to release/2.2

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_no_space_cont_create
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
