### PR TITLE
DAOS-9755 test: Update server logging in NLT.

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -158,11 +158,11 @@ class CulmTimer():
 
     def start(self):
         """Start the timer"""
-        self._start = time.time()
+        self._start = time.perf_counter()
 
     def stop(self):
         """Stop the timer, and add elapsed to total"""
-        self.total += time.time() - self._start
+        self.total += time.perf_counter() - self._start
 
 
 class BoolRatchet():
@@ -547,7 +547,7 @@ class DaosServer():
                                                      delete=False)
         self.server_logs = []
         for engine in range(self.engines):
-            prefix = f'dnt_server_{engine}_'
+            prefix = f'dnt_server_{self._test_class}_{engine}_'
             self.server_logs.append(tempfile.NamedTemporaryFile(prefix=prefix,
                                                                 suffix='.log',
                                                                 dir=conf.tmp_dir,
@@ -629,7 +629,7 @@ class DaosServer():
                                    test_class=self._test_class)
 
     def _check_timing(self, name, start, max_time):
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if elapsed > max_time:
             res = f'{name} failed after {elapsed:.2f}s (max {max_time:.2f}s)'
             self._add_test_case(name, duration=elapsed, failure=res)
@@ -715,7 +715,9 @@ class DaosServer():
         scyaml['socket_dir'] = self.agent_dir
 
         for (key, value) in server_env.items():
-            scyaml['engines'][0]['env_vars'].append(f'{key}={value}')
+            # If server log is set via server_debug then do not also set env settings.
+            if self.conf.args.server_debug and key not in ('DD_MASK', 'DD_SUBSYS', 'D_LOG_MASK'):
+                scyaml['engines'][0]['env_vars'].append(f'{key}={value}')
 
         ref_engine = copy.deepcopy(scyaml['engines'][0])
         ref_engine['storage'][0]['scm_size'] = int(
@@ -777,7 +779,7 @@ class DaosServer():
         # /mnt/daos exists and has data in.  It will be used as is.
         # /mnt/daos is mounted but empty.  It will be used-as is.
         # In this last case the --no-root option must be used.
-        start = time.time()
+        start = time.perf_counter()
 
         cmd = ['storage', 'format', '--json']
         start_timeout = 0.5
@@ -805,7 +807,7 @@ class DaosServer():
                 start_timeout *= 2
 
             self._check_timing('format', start, self.max_start_time)
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         self._add_test_case('format', duration=duration)
         print(f'Format completion in {duration:.2f} seconds')
         self.running = True
@@ -821,7 +823,7 @@ class DaosServer():
                 start_timeout *= 2
 
             self._check_timing("start", start, self.max_start_time)
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         self._add_test_case('start', duration=duration)
         print(f'Server started in {duration:.2f} seconds')
         self.fetch_pools()
@@ -889,7 +891,7 @@ class DaosServer():
             entry['message'] = message
             self.conf.wf.issues.append(entry)
             self._add_test_case('server_stop', failure=message)
-        start = time.time()
+        start = time.perf_counter()
         rc = self.run_dmg(['system', 'stop'])
         if rc.returncode != 0:
             print(rc)
@@ -909,7 +911,7 @@ class DaosServer():
                 break
             self._check_timing("stop", start, self.max_stop_time)
 
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         self._add_test_case('stop', duration=duration)
         print(f'Server stopped in {duration:.2f} seconds')
 
@@ -1759,7 +1761,7 @@ class PrintStat():
     def dir_add(self, dirname):
         """Add a directory contents
 
-        This differs from .add(dirname, show_dir=True) as it does not add the dir itself can the
+        This differs from .add(dirname, show_dir=True) as it does not add the dir itself and the
         result can be compared across mounts.
         """
         with os.scandir(dirname) as dirfd:
@@ -1895,12 +1897,10 @@ class PosixTests():
                       self.pool.id(), self.container.id()],
                      show_stdout=True)
 
-        cont_attrs = {}
-        cont_attrs['dfuse-attr-time'] = '2'
-        cont_attrs['dfuse-dentry-time'] = '100s'
-        cont_attrs['dfuse-dentry-dir-time'] = '100s'
-        cont_attrs['dfuse-ndentry-time'] = '100s'
-
+        cont_attrs = {'dfuse-attr-time': 2,
+                      'dfuse-dentry-time': '100s',
+                      'dfuse-dentry-dir-time': '100s',
+                      'dfuse-ndentry-time': '100s'}
         self.container.set_attrs(cont_attrs)
 
         run_daos_cmd(self.conf,
@@ -2028,11 +2028,10 @@ class PosixTests():
         """
         cache_time = 20
 
-        cont_attrs = {}
-        cont_attrs['dfuse-data-cache'] = False
-        cont_attrs['dfuse-attr-time'] = cache_time
-        cont_attrs['dfuse-dentry-time'] = cache_time
-        cont_attrs['dfuse-ndentry-time'] = cache_time
+        cont_attrs = {'dfuse-data-cache': False,
+                      'dfuse-attr-time': cache_time,
+                      'dfuse-dentry-time': cache_time,
+                      'dfuse-ndentry-time': cache_time}
         self.container.set_attrs(cont_attrs)
 
         dfuse0 = DFuse(self.server,
@@ -2053,7 +2052,7 @@ class PosixTests():
             with open(join(dfuse0.dir, f'batch0.{idx}'), 'w') as ofd:
                 ofd.write('hello')
 
-        start = time.time()
+        start = time.perf_counter()
 
         stat_log = PrintStat()
         stat_log.dir_add(dfuse0.dir)
@@ -2081,7 +2080,7 @@ class PosixTests():
         stat_log1.dir_add(dfuse0.dir)
         print(stat_log1)
 
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
 
         assert elapsed < cache_time / 2, f'Test ran to slow, increase timeout {elapsed}'
 
@@ -2132,39 +2131,39 @@ class PosixTests():
     def readdir_test(self, count, test_all=False):
         """Run a rudimentary readdir test"""
         wide_dir = tempfile.mkdtemp(dir=self.dfuse.dir)
-        start = time.time()
+        start = time.perf_counter()
         for idx in range(count):
             with open(join(wide_dir, f'file_{idx}'), 'w'):
                 pass
             if test_all:
                 files = os.listdir(wide_dir)
                 assert len(files) == idx + 1
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         rate = count / duration
         print(f'Created {count} files in {duration:.1f} seconds rate {rate:.1f}')
         print('Listing dir contents')
-        start = time.time()
+        start = time.perf_counter()
         files = os.listdir(wide_dir)
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         rate = count / duration
         print(f'Listed {count} files in {duration:.1f} seconds rate {rate:.1f}')
         print(files)
         print(len(files))
         assert len(files) == count
         print('Listing dir contents again')
-        start = time.time()
+        start = time.perf_counter()
         files = os.listdir(wide_dir)
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         print(f'Listed {count} files in {duration:.1f} seconds rate {count / duration:.1f}')
         print(files)
         print(len(files))
         assert len(files) == count
         files = []
-        start = time.time()
+        start = time.perf_counter()
         with os.scandir(wide_dir) as entries:
             for entry in entries:
                 files.append(entry.name)
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         print(f'Scanned {count} files in {duration:.1f} seconds rate {count / duration:.1f}')
         print(files)
         print(len(files))
@@ -2172,14 +2171,14 @@ class PosixTests():
 
         files = []
         files2 = []
-        start = time.time()
+        start = time.perf_counter()
         with os.scandir(wide_dir) as entries:
             with os.scandir(wide_dir) as second:
                 for entry in entries:
                     files.append(entry.name)
                 for entry in second:
                     files2.append(entry.name)
-        duration = time.time() - start
+        duration = time.perf_counter() - start
         print(f'Double scanned {count} files in {duration:.1f} seconds rate {count / duration:.1f}')
         print(files)
         print(len(files))
@@ -3331,12 +3330,10 @@ class PosixTests():
         """Test permissions caching for DAOS-12577"""
         cache_time = 10
 
-        cont_attrs = {}
-        cont_attrs['dfuse-data-cache'] = False
-        cont_attrs['dfuse-attr-time'] = cache_time
-        cont_attrs['dfuse-dentry-time'] = cache_time
-        cont_attrs['dfuse-ndentry-time'] = cache_time
-
+        cont_attrs = {'dfuse-data-cache': False,
+                      'dfuse-attr-time': cache_time,
+                      'dfuse-dentry-time': cache_time,
+                      'dfuse-ndentry-time': cache_time}
         self.container.set_attrs(cont_attrs)
 
         dfuse = DFuse(self.server, self.conf, container=self.container, wbcache=False)
@@ -3800,7 +3797,6 @@ class PosixTests():
 
     def test_pil4dfs(self):
         """Test interception library libpil4dfs.so"""
-
         dfuse = DFuse(self.server,
                       self.conf,
                       pool=self.pool.id(),
@@ -3935,7 +3931,7 @@ def run_posix_tests(server, conf, test=None):
         while True:
             ptl.needs_more = False
             ptl.test_name = function
-            start = time.time()
+            start = time.perf_counter()
             out_wrapper.sprint(f'Calling {function}')
             print(f'Calling {function}')
 
@@ -3955,7 +3951,7 @@ def run_posix_tests(server, conf, test=None):
                 ptl.container = None
             except Exception as inst:
                 trace = ''.join(traceback.format_tb(inst.__traceback__))
-                duration = time.time() - start
+                duration = time.perf_counter() - start
                 out_wrapper.sprint(f'{ptl.test_name} Failed')
                 conf.wf.add_test_case(ptl.test_name,
                                       repr(inst),
@@ -3965,7 +3961,7 @@ def run_posix_tests(server, conf, test=None):
                                       test_class='test',
                                       duration=duration)
                 raise
-            duration = time.time() - start
+            duration = time.perf_counter() - start
             out_wrapper.sprint(f'Test {ptl.test_name} took {duration:.1f} seconds')
             conf.wf.add_test_case(ptl.test_name,
                                   stdout=out_wrapper.get_thread_output(),
@@ -4447,13 +4443,11 @@ def run_in_fg(server, conf, args):
 
         # Only set the container cache attributes when the container is initially created so they
         # can be modified later.
-        cont_attrs = {}
-        cont_attrs['dfuse-data-cache'] = False
-        cont_attrs['dfuse-attr-time'] = 60
-        cont_attrs['dfuse-dentry-time'] = 60
-        cont_attrs['dfuse-ndentry-time'] = 60
-        cont_attrs['dfuse-direct-io-disable'] = False
-
+        cont_attrs = {'dfuse-data-cache': False,
+                      'dfuse-attr-time': 60,
+                      'dfuse-dentry-time': 60,
+                      'dfuse-ndentry-time': 60,
+                      'dfuse-direct-io-disable': False}
         container.set_attrs(cont_attrs)
         container = container.uuid
 
@@ -4482,13 +4476,13 @@ def run_in_fg(server, conf, args):
 
     try:
         if args.launch_cmd:
-            start = time.time()
+            start = time.perf_counter()
             # Set the PATH and agent dir.
             agent_env = os.environ.copy()
             agent_env['DAOS_AGENT_DRPC_DIR'] = conf.agent_dir
             agent_env['PATH'] = f'{join(conf["PREFIX"], "bin")}:{agent_env["PATH"]}'
             rc = subprocess.run(args.launch_cmd, check=False, cwd=t_dir, env=agent_env)
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             dfuse.stop()
             (minutes, seconds) = divmod(elapsed, 60)
             print(f'Completed in {int(minutes):d}:{int(seconds):02d}')
@@ -4525,7 +4519,7 @@ def check_readdir_perf(server, conf):
         file_dir = join(parent, f'files.{count}.in')
         t_file = join(parent, f'files.{count}')
 
-        start_all = time.time()
+        start_all = time.perf_counter()
         if not os.path.exists(t_dir):
             try:
                 os.mkdir(dir_dir)
@@ -4536,7 +4530,7 @@ def check_readdir_perf(server, conf):
                     os.mkdir(join(dir_dir, str(idx)))
                 except FileExistsError:
                     pass
-            dir_time = time.time() - start_all
+            dir_time = time.perf_counter() - start_all
             print(f'Creating {count} dirs took {dir_time:.2f}')
             os.rename(dir_dir, t_dir)
 
@@ -4545,11 +4539,11 @@ def check_readdir_perf(server, conf):
                 os.mkdir(file_dir)
             except FileExistsError:
                 pass
-            start = time.time()
+            start = time.perf_counter()
             for idx in range(count):
                 with open(join(file_dir, str(idx)), 'w'):
                     pass
-            file_time = time.time() - start
+            file_time = time.perf_counter() - start
             print(f'Creating {count} files took {file_time:.2f}')
             os.rename(file_dir, t_file)
 
@@ -4576,7 +4570,7 @@ def check_readdir_perf(server, conf):
     create_times = make_dirs(parent, count)
     dfuse.stop()
 
-    all_start = time.time()
+    all_start = time.perf_counter()
 
     while True:
 
@@ -4587,19 +4581,19 @@ def check_readdir_perf(server, conf):
         dir_dir = join(dfuse.dir, f'dirs.{count}')
         file_dir = join(dfuse.dir, f'files.{count}')
         dfuse.start()
-        start = time.time()
+        start = time.perf_counter()
         subprocess.run(['/bin/ls', dir_dir], stdout=subprocess.PIPE, check=True)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         print(f'processed {count} dirs in {elapsed:.2f} seconds')
         row.append(elapsed)
         dfuse.stop()
         dfuse = DFuse(server, conf, pool=pool, container=container,
                       caching=False)
         dfuse.start()
-        start = time.time()
+        start = time.perf_counter()
         subprocess.run(['/bin/ls', file_dir], stdout=subprocess.PIPE,
                        check=True)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         print(f'processed {count} dirs in {elapsed:.2f} seconds')
         row.append(elapsed)
         dfuse.stop()
@@ -4607,22 +4601,22 @@ def check_readdir_perf(server, conf):
         dfuse = DFuse(server, conf, pool=pool, container=container,
                       caching=False)
         dfuse.start()
-        start = time.time()
+        start = time.perf_counter()
         subprocess.run(['/bin/ls', '-t', dir_dir], stdout=subprocess.PIPE,
                        check=True)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         print(f'processed {count} dirs in {elapsed:.2f} seconds')
         row.append(elapsed)
         dfuse.stop()
         dfuse = DFuse(server, conf, pool=pool, container=container,
                       caching=False)
         dfuse.start()
-        start = time.time()
+        start = time.perf_counter()
         # Use sort by time here so ls calls stat, if you run ls -l then it will
         # also call getxattr twice which skews the figures.
         subprocess.run(['/bin/ls', '-t', file_dir], stdout=subprocess.PIPE,
                        check=True)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         print(f'processed {count} dirs in {elapsed:.2f} seconds')
         row.append(elapsed)
         dfuse.stop()
@@ -4636,21 +4630,21 @@ def check_readdir_perf(server, conf):
                       container=container,
                       caching=True)
         dfuse.start()
-        start = time.time()
+        start = time.perf_counter()
         subprocess.run(['/bin/ls', '-t', file_dir], stdout=subprocess.PIPE,
                        check=True)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         print(f'processed {count} dirs in {elapsed:.2f} seconds')
         row.append(elapsed)
-        start = time.time()
+        start = time.perf_counter()
         subprocess.run(['/bin/ls', '-t', file_dir], stdout=subprocess.PIPE,
                        check=True)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         print(f'processed {count} dirs in {elapsed:.2f} seconds')
         row.append(elapsed)
         results.append(row)
 
-        elapsed = time.time() - all_start
+        elapsed = time.perf_counter() - all_start
         if elapsed > 5 * 60:
             dfuse.stop()
             break
@@ -5579,15 +5573,16 @@ def run(wf, args):
                 fatal_errors.add_result(set_server_fi(server))
 
     if args.mode == 'all':
-        with DaosServer(conf, wf=wf_server, fatal_errors=fatal_errors) as server:
+        with DaosServer(conf, test_class='restart', wf=wf_server,
+                        fatal_errors=fatal_errors) as server:
             pass
 
     # If running all tests then restart the server under valgrind.
     # This is really, really slow so just do cont list, then
     # exit again.
     if args.server_valgrind:
-        with DaosServer(conf, valgrind=True, test_class='valgrind',
-                        wf=wf_server, fatal_errors=fatal_errors) as server:
+        with DaosServer(conf, test_class='valgrind', wf=wf_server, valgrind=True,
+                        fatal_errors=fatal_errors) as server:
             pools = server.fetch_pools()
             for pool in pools:
                 cmd = ['pool', 'query', pool.id()]

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -716,8 +716,9 @@ class DaosServer():
 
         for (key, value) in server_env.items():
             # If server log is set via server_debug then do not also set env settings.
-            if self.conf.args.server_debug and key not in ('DD_MASK', 'DD_SUBSYS', 'D_LOG_MASK'):
-                scyaml['engines'][0]['env_vars'].append(f'{key}={value}')
+            if self.conf.args.server_debug and key in ('DD_MASK', 'DD_SUBSYS', 'D_LOG_MASK'):
+                continue
+            scyaml['engines'][0]['env_vars'].append(f'{key}={value}')
 
         ref_engine = copy.deepcopy(scyaml['engines'][0])
         ref_engine['storage'][0]['scm_size'] = int(


### PR DESCRIPTION
Do not set logging via log_mask and env vars, only
use one or the other.
Put the class hint in server log name.
Change from time.time to change.perf_counter globally.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
