### PR TITLE
DAOS-13510 chk: proper message for inconsistency report

### DIFF
--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -337,8 +337,9 @@ report:
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
 	cru.cru_pool_label = cpr->cpr_label;
 	snprintf(msg, CHK_MSG_BUFLEN - 1,
-		 "Check engine detects orphan %s entry in pool map for "
+		 "Check engine %s orphan %s entry in pool map for "
 		 DF_UUIDF", rank %u, index %d\n",
+		 prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN ? "dryrun-detects" : "detects",
 		 index < 0 ? "rank" : "target", DP_UUID(cpr->cpr_uuid), rank, index);
 	cru.cru_msg = msg;
 	cru.cru_options = options;
@@ -511,8 +512,9 @@ report:
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
 	cru.cru_pool_label = cpr->cpr_label;
 	snprintf(msg, CHK_MSG_BUFLEN - 1,
-		 "Check engine detects dangling %s entry in pool map for pool "
+		 "Check engine %s dangling %s entry in pool map for pool "
 		 DF_UUIDF", rank %u, index %u, (want) mark as %s\n",
+		 prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN ? "dryrun-detects" : "detects",
 		 comp->co_type == PO_COMP_TP_RANK ? "rank" : "target",
 		 DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index,
 		 pool_map_status2name(status));
@@ -590,6 +592,7 @@ chk_engine_pm_unknown_target(struct chk_pool_rec *cpr, struct pool_component *co
 {
 	struct chk_instance		*ins = cpr->cpr_ins;
 	struct chk_bookmark		*cbk = &cpr->cpr_bk;
+	struct chk_property		*prop = &ins->ci_prop;
 	struct chk_report_unit		 cru = { 0 };
 	Chk__CheckInconsistClass	 cla;
 	Chk__CheckInconsistAction	 act;
@@ -611,9 +614,10 @@ chk_engine_pm_unknown_target(struct chk_pool_rec *cpr, struct pool_component *co
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
 	cru.cru_pool_label = cpr->cpr_label;
 	snprintf(msg, CHK_MSG_BUFLEN - 1,
-		 "Check engine detects unknown target entry in pool map for pool "
+		 "Check engine %s unknown target entry in pool map for pool "
 		 DF_UUIDF", rank %u, index %u, status %u, skip it. You can change "
 		 "its status via DAOS debug tool if it is not for downgraded case.\n",
+		 prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN ? "dryrun-detects" : "detects",
 		 DP_UUID(cpr->cpr_uuid), comp->co_rank, comp->co_index, comp->co_status);
 	cru.cru_msg = msg;
 	cru.cru_result = 0;
@@ -814,6 +818,7 @@ chk_engine_bad_pool_label(struct chk_pool_rec *cpr, struct ds_pool_svc *svc)
 {
 	struct chk_instance		*ins = cpr->cpr_ins;
 	struct chk_bookmark		*cbk = &cpr->cpr_bk;
+	struct chk_property		*prop = &ins->ci_prop;
 	daos_prop_t			*label = NULL;
 	struct chk_report_unit		 cru = { 0 };
 	Chk__CheckInconsistClass	 cla;
@@ -849,7 +854,8 @@ report:
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
 	cru.cru_pool_label = cpr->cpr_label;
 	snprintf(msg, CHK_MSG_BUFLEN - 1,
-		 "Check engine detects corrupted pool label: %s (MS) vs %s (PS).\n",
+		 "Check engine %s corrupted pool label: %s (MS) vs %s (PS).\n",
+		 prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN ? "dryrun-detects" : "detects",
 		 cpr->cpr_label != NULL ? cpr->cpr_label : "(null)",
 		 label != NULL ? label->dpp_entries[0].dpe_str : "(null)");
 	cru.cru_msg = msg;
@@ -1033,7 +1039,8 @@ report:
 	if (ccr->ccr_label_prop != NULL)
 		cru.cru_cont_label = ccr->ccr_label_prop->dpp_entries[0].dpe_str;
 	snprintf(msg, CHK_MSG_BUFLEN - 1,
-		 "Check engine detects orphan container "DF_UUIDF"/"DF_UUIDF"\n",
+		 "Check engine %s orphan container "DF_UUIDF"/"DF_UUIDF"\n",
+		 prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN ? "dryrun-detects" : "detects",
 		 DP_UUID(cpr->cpr_uuid), DP_UUID(ccr->ccr_uuid));
 	cru.cru_msg = msg;
 	cru.cru_options = options;
@@ -1369,7 +1376,8 @@ report:
 	cru.cru_cont = (uuid_t *)&ccr->ccr_uuid;
 	cru.cru_cont_label = label;
 	snprintf(msg, CHK_MSG_BUFLEN - 1,
-		 "Check engine detects inconsistent container label: %s (CS) vs %s (property).\n",
+		 "Check engine %s inconsistent container label: %s (CS) vs %s (property).\n",
+		 prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN ? "dryrun-detects" : "detects",
 		 daos_iov_empty(&ccr->ccr_label_cs) ? "(null)" : (char *)ccr->ccr_label_cs.iov_buf,
 		 ccr->ccr_label_prop != NULL ? (char *)ccr->ccr_label_prop->dpp_entries[0].dpe_str :
 		 "(null)");

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -590,7 +590,10 @@ report:
 	cru.cru_detail_nr = detail_nr;
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
 	cru.cru_pool_label = cpr->cpr_label;
-	cru.cru_msg = "Check leader detects dangling pool.\n";
+	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN)
+		cru.cru_msg = "Check leader dryrun-detects dangling pool.\n";
+	else
+		cru.cru_msg = "Check leader detects dangling pool.\n";
 	cru.cru_options = options;
 	cru.cru_details = details;
 	cru.cru_result = result;
@@ -791,7 +794,10 @@ report:
 	cru.cru_detail_nr = detail_nr;
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
 	cru.cru_pool_label = clue->pc_label;
-	cru.cru_msg = "Check leader detects orphan pool.\n";
+	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN)
+		cru.cru_msg = "Check leader dryrun-detects orphan pool.\n";
+	else
+		cru.cru_msg = "Check leader detects orphan pool.\n";
 	cru.cru_options = options;
 	cru.cru_details = details;
 	cru.cru_result = result;
@@ -1107,7 +1113,10 @@ report:
 	cru.cru_detail_nr = detail_nr;
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
 	cru.cru_pool_label = cpr->cpr_label;
-	cru.cru_msg = "Check leader detects corrupted pool without quorum.\n";
+	if (prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN)
+		cru.cru_msg = "Check leader dryrun-detects corrupted pool without quorum.\n";
+	else
+		cru.cru_msg = "Check leader detects corrupted pool without quorum.\n";
 	cru.cru_options = options;
 	cru.cru_details = details;
 	cru.cru_result = result;
@@ -1449,7 +1458,8 @@ report:
 	cru.cru_pool = (uuid_t *)&cpr->cpr_uuid;
 	cru.cru_pool_label = label;
 	snprintf(msg, CHK_MSG_BUFLEN - 1,
-		 "Check leader detects corrupted pool label: %s (MS) vs %s (PS).\n",
+		 "Check leader %s corrupted pool label: %s (MS) vs %s (PS).\n",
+		 prop->cp_flags & CHK__CHECK_FLAG__CF_DRYRUN ? "dryrun-detects" : "detects",
 		 cpr->cpr_label != NULL ? cpr->cpr_label : "(null)",
 		 clue->pc_label != NULL ? clue->pc_label : "(null)");
 	cru.cru_msg = msg;


### PR DESCRIPTION
To avoid confusing under dryrun mode.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
