### PR TITLE
DAOS-13439 object: fix a bug of csum corrupt injection

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -292,9 +292,19 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	/** fault injection - corrupt data after getting from server and before
 	 * verifying on client - simulates corruption over network
 	 */
-	if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_FETCH))
+	if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_FETCH)) {
+		struct dcs_iod_csums	*tmp_iod_csum;
+
 		/** Got csum successfully from server. Now poison it!! */
-		orwo->orw_iod_csums.ca_arrays->ic_data->cs_csum[0]++;
+		for (i = 0; i < orw->orw_iod_array.oia_iod_nr; i++) {
+			tmp_iod_csum = &iods_csums[i];
+			if (tmp_iod_csum->ic_data != NULL &&
+			    tmp_iod_csum->ic_data->cs_csum != NULL) {
+				tmp_iod_csum->ic_data->cs_csum[0]++;
+				break;
+			}
+		}
+	}
 
 	reasb_req = rw_args->shard_args->reasb_req;
 	oca = &rw_args->shard_args->auxi.obj_auxi->obj->cob_oca;

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2624,6 +2624,86 @@ scrubbing_with_large_sleep(void **state)
 	basic_scrubbing_test(state, "100000");
 }
 
+static void
+multiple_ec_singv_csum(void **state)
+{
+	test_arg_t		*arg = *state;
+	struct csum_test_ctx	 ctx = {0};
+	daos_oclass_id_t	 oc = dts_csum_oc;
+	daos_handle_t		 oh;
+	d_iov_t			 dkey;
+	d_sg_list_t		 sgl[3];
+	d_iov_t			 sg_iov[3];
+	daos_iod_t		 iod[3];
+	char			*buf[3];
+	size_t			 len[3];
+	int			 i, rc;
+
+	FAULT_INJECTION_REQUIRED();
+
+	if (csum_ec_enabled() && !test_runable(arg, csum_ec_grp_size()))
+		skip();
+
+	setup_from_test_args(&ctx, *state);
+	setup_cont_obj(&ctx, dts_csum_prop_type, true, 0, oc);
+
+	for (i = 0; i < 3; i++) {
+		buf[i] = NULL;
+		len[i] = 0;
+	}
+
+	len[0] = 195;
+	len[1] = 5822;
+	len[2] = 6162;
+	for (i = 0; i < 3; i++) {
+		D_ALLOC(buf[i], len[i]);
+		assert_non_null(buf[i]);
+		dts_buf_render(buf[i], len[i]);
+	}
+
+	oh = ctx.oh;
+	/** init dkey */
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+
+	/** init scatter/gather */
+	for (i = 0; i < 3; i++)
+		d_iov_set(&sg_iov[i], buf[i], len[i]);
+
+	d_iov_set(&iod[0].iod_name, "akey1", strlen("akey1"));
+	d_iov_set(&iod[1].iod_name, "akey2", strlen("akey2"));
+	d_iov_set(&iod[2].iod_name, "akey3", strlen("akey2"));
+
+	for (i = 0; i < 3; i++) {
+		sgl[i].sg_nr = 1;
+		sgl[i].sg_nr_out = 0;
+		sgl[i].sg_iovs = &sg_iov[i];
+		iod[i].iod_nr = 1;
+		iod[i].iod_recxs = NULL;
+		iod[i].iod_type = DAOS_IOD_SINGLE;
+		iod[i].iod_size = len[i];
+	}
+
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 3, iod, sgl, NULL);
+	assert_rc_equal(rc, 0);
+
+	iod[0].iod_size = 0;
+	daos_fail_loc_set(DAOS_CSUM_CORRUPT_FETCH | DAOS_FAIL_ALWAYS);
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 3, iod, sgl, NULL, NULL);
+	assert_rc_equal(rc, -DER_CSUM);
+	assert_rc_equal(iod[0].iod_size, 195);
+
+	daos_fail_loc_set(0);
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 3, iod, sgl, NULL, NULL);
+	assert_rc_equal(rc, 0);
+
+	for (i = 0; i < 3; i++)
+		D_FREE(buf[i]);
+	client_clear_fault();
+	cleanup_cont_obj(&ctx);
+	cleanup_data(&ctx);
+
+}
+
 static int
 setup(void **state)
 {
@@ -2723,6 +2803,7 @@ static const struct CMUnitTest csum_tests[] = {
 		  "EC chunk", ec_chunk_plus_one),
 	CSUM_TEST("DAOS_EC_CSUM04: Single extent that is 1 byte larger than "
 		  "2 EC chunks", ec_two_chunk_plus_one),
+	EC_CSUM_TEST("DAOS_EC_CSUM05: multiple EC single value csum", multiple_ec_singv_csum),
 	CSUM_TEST("DAOS_SCRUBBING00: A basic scrubbing test with scrubbing "
 		  "running very frequently",
 		  scrubbing_a_lot),


### PR DESCRIPTION
    Fix a bug of DAOS_CSUM_CORRUPT_FETCH corrupt csum in multiple
    akeys cases, add a test case to reproduce/verify it.
    
    Required-githooks: true
    
    Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
