### PR TITLE
DAOS-12638 array: fix cb order on array get_size and stat (#12204)

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1268,7 +1268,7 @@ daos_event_priv_wait()
 		/** progress succeeded, loop can exit if event completed */
 		if (rc == 0) {
 			rc = ev_thpriv.ev_error;
-			if (rc)
+			if (evx->evx_status == DAOS_EVS_READY)
 				break;
 			continue;
 		}
@@ -1283,6 +1283,7 @@ daos_event_priv_wait()
 		break;
 	}
 
+	D_ASSERT(evx->evx_status == DAOS_EVS_READY);
 	rc2 = daos_event_priv_reset();
 	if (rc2) {
 		if (rc == 0)

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1930,15 +1930,14 @@ dc_array_get_size(tse_task_t *task)
 	query_args->recx	= &kqp->recx;
 	query_args->max_epoch	= NULL;
 
-	rc = tse_task_register_comp_cb(query_task, get_array_size_cb, &kqp, sizeof(kqp));
-	if (rc != 0)
-		D_GOTO(err_task, rc);
-
 	rc = tse_task_register_comp_cb(task, free_query_cb, &kqp, sizeof(kqp));
 	if (rc != 0)
 		D_GOTO(err_task, rc);
-
 	cleanup = false;
+
+	rc = tse_task_register_comp_cb(query_task, get_array_size_cb, &kqp, sizeof(kqp));
+	if (rc != 0)
+		D_GOTO(err_task, rc);
 
 	rc = tse_task_register_deps(task, 1, &query_task);
 	if (rc == 0)
@@ -2006,15 +2005,14 @@ dc_array_stat(tse_task_t *task)
 	query_args->recx	= &kqp->recx;
 	query_args->max_epoch	= &args->stbuf->st_max_epoch;
 
-	rc = tse_task_register_comp_cb(query_task, get_array_size_cb, &kqp, sizeof(kqp));
-	if (rc != 0)
-		D_GOTO(err_task, rc);
-
 	rc = tse_task_register_comp_cb(task, free_query_cb, &kqp, sizeof(kqp));
 	if (rc != 0)
 		D_GOTO(err_task, rc);
-
 	cleanup = false;
+
+	rc = tse_task_register_comp_cb(query_task, get_array_size_cb, &kqp, sizeof(kqp));
+	if (rc != 0)
+		D_GOTO(err_task, rc);
 
 	rc = tse_task_register_deps(task, 1, &query_task);
 	if (rc == 0)

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -4002,7 +4002,7 @@ read_cb(tse_task_t *task, void *data)
 	D_ASSERT(params != NULL);
 
 	if (rc != 0) {
-		D_ERROR("Failed to read from array object (%d)\n", rc);
+		D_ERROR("Failed to read from array object: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
@@ -4053,7 +4053,7 @@ dfs_read_int(dfs_t *dfs, dfs_obj_t *obj, daos_off_t off, dfs_iod_t *iod,
 	args->iod	= &params->arr_iod;
 
 	daos_task_set_priv(task, params);
-	rc = tse_task_register_cbs(task, NULL, 0, 0, read_cb, NULL, 0);
+	rc = tse_task_register_cbs(task, NULL, NULL, 0, read_cb, NULL, 0);
 	if (rc)
 		D_GOTO(err_params, rc = daos_der2errno(rc));
 
@@ -4063,7 +4063,8 @@ err_params:
 	D_FREE(params);
 err_task:
 	tse_task_complete(task, rc);
-	return rc;
+	/** the event is completed with the proper rc */
+	return 0;
 }
 
 int


### PR DESCRIPTION
- free cb should be last (registered first)
- other minor fixes

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
