### PR TITLE
DAOS-13505 control: Add external storage path in MD-on-SSD confgen tests

### DIFF
--- a/src/control/cmd/daos_server/auto_test.go
+++ b/src/control/cmd/daos_server/auto_test.go
@@ -381,7 +381,7 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 					storage.MockNvmeController(4),
 				},
 			},
-			expErr: storage.FaultBdevConfigRolesNoControlMetadata,
+			expErr: ErrTmpfsNoExtMDPath,
 		},
 		"tmpfs scm; low mem": {
 			tmpfsSCM:        true,

--- a/src/control/cmd/dmg/auto.go
+++ b/src/control/cmd/dmg/auto.go
@@ -19,6 +19,9 @@ import (
 	"github.com/daos-stack/daos/src/control/server/config"
 )
 
+var ErrTmpfsNoExtMDPath = errors.New("--use-tmpfs-scm will generate an md-on-ssd config and so " +
+	"--control-metadata-path must also be set")
+
 // configCmd is the struct representing the top-level config subcommand.
 type configCmd struct {
 	Generate configGenCmd `command:"generate" alias:"gen" description:"Generate DAOS server configuration file based on discoverable hardware devices"`
@@ -42,6 +45,10 @@ type configGenCmd struct {
 
 func (cmd *configGenCmd) confGen(ctx context.Context) (*config.Server, error) {
 	cmd.Debugf("ConfGen called with command parameters %+v", cmd)
+
+	if cmd.UseTmpfsSCM && cmd.ExtMetadataPath == "" {
+		return nil, ErrTmpfsNoExtMDPath
+	}
 
 	accessPoints := strings.Split(cmd.AccessPoints, ",")
 

--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -265,7 +265,7 @@ func TestAuto_confGen(t *testing.T) {
 				{netHostResp},
 				{storHostRespHighMem},
 			},
-			expErr: storage.FaultBdevConfigRolesNoControlMetadata,
+			expErr: ErrTmpfsNoExtMDPath,
 		},
 		"successful fetch of host storage and fabric; ram scm tier; low mem": {
 			tmpfsSCM:        true,

--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -108,8 +108,6 @@ func DefaultEngineCfg(idx int) *engine.Config {
 
 // ConfGenerate derives an optimal server config file from details of network, storage and CPU
 // hardware by evaluating affinity matches for NUMA node combinations.
-//
-// TODO DAOS-11859: When enabling tmpfs SCM, enumerate them in the same map NumaSCMs.
 func ConfGenerate(req ConfGenerateReq, newEngineCfg newEngineCfgFn, hf *HostFabric, hs *HostStorage) (*ConfGenerateResp, error) {
 	// process host fabric scan results to retrieve network details
 	nd, err := getNetworkDetails(req.Log, req.NetClass, req.NetProvider, hf)
@@ -1134,6 +1132,9 @@ func genServerConfig(log logging.Logger, accessPoints []string, extMetadataPath 
 		}
 		// Add default control_metadata path if roles have been assigned.
 		if idx == 0 && tiers.HasBdevRoleMeta() {
+			if extMetadataPath == "" {
+				return nil, errors.New("no external metadata path specified in request")
+			}
 			cfg.Metadata = storage.ControlMetadata{
 				Path: extMetadataPath,
 			}

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -1532,7 +1532,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			},
 			hpSize:   defHpSizeKb,
 			memTotal: (52 * humanize.GiByte) / humanize.KiByte,
-			expErr:   storage.FaultBdevConfigRolesNoControlMetadata,
+			expErr:   errors.New("no external metadata path"),
 		},
 		"dual engine tmpfs; no hugepage size": {
 			extMetadataPath: metadataMountPath,

--- a/src/tests/ftest/control/config_generate_output.py
+++ b/src/tests/ftest/control/config_generate_output.py
@@ -275,7 +275,8 @@ class ConfigGenerateOutput(TestWithServers):
 
         # Call dmg config generate.
         result = self.get_dmg_command().config_generate(
-            access_points="wolf-a", net_provider=self.def_provider, use_tmpfs_scm=True)
+            access_points="wolf-a", net_provider=self.def_provider, use_tmpfs_scm=True,
+            control_metadata_path=self.test_dir)
         if result.exit_status != 0:
             errors.append("Config generate failed with use_tmpfs_scm = True!")
         generated_yaml = yaml.safe_load(result.stdout)

--- a/src/tests/ftest/control/config_generate_run.py
+++ b/src/tests/ftest/control/config_generate_run.py
@@ -44,11 +44,18 @@ class ConfigGenerateRun(TestWithServers):
         net_provider = self.params.get("net_provider", "/run/config_generate_params/*/")
         use_tmpfs_scm = self.params.get("use_tmpfs_scm", "/run/config_generate_params/*/")
 
+        # use_tmpfs_scm specifies that a MD-on-SSD conf should be generated and control metadata
+        # path needs to be set in that case.
+        ext_md_path = ""
+        if use_tmpfs_scm:
+            ext_md_path = self.test_dir
+
         # Call dmg config generate. AP is always the first server host.
         server_host = self.hostlist_servers[0]
         result = self.get_dmg_command().config_generate(
             access_points=server_host, num_engines=num_engines, scm_only=scm_only,
-            net_class=net_class, net_provider=net_provider, use_tmpfs_scm=use_tmpfs_scm)
+            net_class=net_class, net_provider=net_provider, use_tmpfs_scm=use_tmpfs_scm,
+            control_metadata_path=ext_md_path)
 
         try:
             generated_yaml = yaml.safe_load(result.stdout)

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -1118,7 +1118,8 @@ class DmgCommand(DmgCommandBase):
         return self._get_result(("pool", "evict"), pool=pool)
 
     def config_generate(self, access_points, num_engines=None, scm_only=False,
-                        net_class=None, net_provider=None, use_tmpfs_scm=False):
+                        net_class=None, net_provider=None, use_tmpfs_scm=False,
+                        control_metadata_path=None):
         """Produce a server configuration.
 
         Args:
@@ -1133,6 +1134,8 @@ class DmgCommand(DmgCommandBase):
                 i.e. "ofi+tcp;ofi_rxm"|"ofi+psm2" etc.
             use_tmpfs_scm (bool, optional): Whether to use a ramdisk instead of PMem
                 as SCM. Defaults to False.
+            control_metadata_path (str): External directory provided to store control
+                metadata in MD-on-SSD mode.
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -1142,7 +1145,8 @@ class DmgCommand(DmgCommandBase):
         return self._get_result(
             ("config", "generate"), access_points=access_points,
             num_engines=num_engines, scm_only=scm_only, net_class=net_class,
-            net_provider=net_provider, use_tmpfs_scm=use_tmpfs_scm)
+            net_provider=net_provider, use_tmpfs_scm=use_tmpfs_scm,
+            control_metadata_path=control_metadata_path)
 
     def telemetry_metrics_list(self, host):
         """List telemetry metrics.

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -226,6 +226,8 @@ class DmgCommandBase(YamlCommand):
                 self.net_class = FormattedParameter("--net-class={}", None)
                 self.net_provider = FormattedParameter("--net-provider={}", None)
                 self.use_tmpfs_scm = FormattedParameter("--use-tmpfs-scm", False)
+                self.control_metadata_path = FormattedParameter(
+                    "--control-metadata-path={}", None)
 
     class ContSubCommand(CommandWithSubCommand):
         """Defines an object for the dmg cont sub command."""


### PR DESCRIPTION
Update config generate functional tests to provide external metadata
path to dmg. Also provide more useful errors.

Test-tag: dmg_config_generate
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
