### PR TITLE
DAOS-13409 tools: Ignore D_LOG_FILE=/dev/null

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -165,6 +165,9 @@ daos_debug_init_ex(char *logfile, d_dbug_t logmask)
 	logfile = getenv(D_LOG_FILE_ENV);
 	if (logfile == NULL || strlen(logfile) == 0) {
 		flags |= DLOG_FLV_STDOUT;
+		logfile = NULL;
+	} else if (!strncmp(logfile, "/dev/null", 9)) {
+		/* Don't set up logging or log to stdout if the log file is /dev/null */
 		logfile = NULL;
 	}
 


### PR DESCRIPTION
If the logfile is set to /dev/null (needed to ensure that
debug/error logs go to stderr, not stdout), don't bother
with all of the fd management. Also avoids a spurious
fsync failure on daos_debug_fini().

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
