### PR TITLE
DAOS-13536 test: Fix csum_error_logging.py when running w/ pmem

### DIFF
--- a/src/tests/ftest/checksum/csum_error_logging.py
+++ b/src/tests/ftest/checksum/csum_error_logging.py
@@ -46,7 +46,7 @@ class CsumErrorLog(DaosCoreBase):
 
     @fail_on(CommandFailure)
     def test_csum_error_logging(self):
-        """Jira ID: DAOS-3927
+        """Jira ID: DAOS-3927.
 
         Test Description: Write Avocado Test to verify single data after
                           pool/container disconnect/reconnect.

--- a/src/tests/ftest/checksum/csum_error_logging.py
+++ b/src/tests/ftest/checksum/csum_error_logging.py
@@ -65,16 +65,18 @@ class CsumErrorLog(DaosCoreBase):
             for device in devices:
                 for entry in ('uuid', 'tgt_ids', 'role_bits', 'roles'):
                     if entry not in device:
-                        self.fail(f'Missing {entry} info from dmg storage query list devices')
+                        self.fail(
+                            'Missing {} info from dmg storage query list devices'.format(entry))
                 self.log.info(
                     'Host %s device: uuid=%s, targets=%s, role=%s, role_bits=%s',
                     host, device['uuid'], device['tgt_ids'], device['roles'], device['role_bits'])
                 if not device['tgt_ids']:
-                    self.log_step(f"Skipping device without targets on {device['uuid']}")
+                    self.log_step('Skipping device without targets on {}'.format(device['uuid']))
                     continue
                 if device['roles'] and not int(device['role_bits']) & 1:
                     self.log_step(
-                        f"Skipping {device['role_bits']} device without data on {device['uuid']}")
+                        'Skipping {} device without data on {}'.format(
+                            device['role_bits'], device['uuid']))
                     continue
                 if not device['uuid']:
                     self.fail('Device uuid undefined')

--- a/src/tests/ftest/checksum/csum_error_logging.py
+++ b/src/tests/ftest/checksum/csum_error_logging.py
@@ -56,33 +56,42 @@ class CsumErrorLog(DaosCoreBase):
         :avocado: tags=checksum,faults,daos_test
         :avocado: tags=CsumErrorLog,test_csum_error_logging
         """
+        self.log_step('Detecting server devices (dmg storage query list-devices)')
+        test_run = False
         dmg = self.get_dmg_command()
         dmg.hostlist = self.hostlist_servers[0]
         host_devices = get_dmg_smd_info(dmg.storage_query_list_devices, 'devices')
         for host, devices in host_devices.items():
             for device in devices:
-                if 'tgt_ids' not in device or 'uuid' not in device:
-                    self.fail(
-                        'Missing uuid and/or tgt_ids info from dmg storage query list devices')
-                if 'role_bits' not in device:
-                    self.fail(
-                        'Missing role bits info from dmg storage query list devices')
+                for entry in ('uuid', 'tgt_ids', 'role_bits', 'roles'):
+                    if entry not in device:
+                        self.fail(f'Missing {entry} info from dmg storage query list devices')
                 self.log.info(
-                    "Host %s device: uuid=%s, targets=%s", host, device['uuid'], device['tgt_ids'])
+                    'Host %s device: uuid=%s, targets=%s, role=%s, role_bits=%s',
+                    host, device['uuid'], device['tgt_ids'], device['roles'], device['role_bits'])
                 if not device['tgt_ids']:
-                    self.log.info('Skipping device without targets on %s', device['uuid'])
+                    self.log_step(f"Skipping device without targets on {device['uuid']}")
                     continue
-                if not int(device['role_bits']) & 1:
-                    self.log.info('Skipping device without data on %s', device['uuid'])
+                if device['roles'] and not int(device['role_bits']) & 1:
+                    self.log_step(
+                        f"Skipping {device['role_bits']} device without data on {device['uuid']}")
                     continue
                 if not device['uuid']:
-                    self.fail("Device uuid undefined")
+                    self.fail('Device uuid undefined')
+                self.log_step(
+                    'Get checksum errors before running the test (dmg storage query device-health)')
                 check_sum = self.get_checksum_error_value(dmg, device['uuid'])
                 dmg.copy_certificates(get_log_file("daosCA/certs"), self.hostlist_clients)
                 dmg.copy_configuration(self.hostlist_clients)
                 self.log.info("Checksum Errors before: %d", check_sum)
+                self.log_step('Run the test (daos_test -z)')
                 self.run_subtest()
+                test_run = True
+                self.log_step(
+                    'Get checksum errors after running the test (dmg storage query device-health)')
                 check_sum_latest = self.get_checksum_error_value(dmg, device['uuid'])
-                self.log.info("Checksum Errors after:  %d", check_sum_latest)
-                self.assertTrue(check_sum_latest > check_sum, "Checksum Error Log not incremented")
-        self.log.info("Checksum Error Logging Test Passed")
+                self.log.info('Checksum Errors after:  %d', check_sum_latest)
+                self.assertTrue(check_sum_latest > check_sum, 'Checksum Error Log not incremented')
+        if not test_run:
+            self.fail('No tests run for the devices found')
+        self.log_step('Test Passed')


### PR DESCRIPTION
Do not skip the running daos_test -z in the csum_error_logging.py test when running with pmem.

Skip-unit-tests: true
Skip-fault-injection-test: true
Allow-unstable-test: true
Test-tag: test_csum_error_logging

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
