### PR TITLE
DAOS-13539 control: Fix network related commands for multiprovider

### DIFF
--- a/src/control/cmd/daos_agent/attachinfo.go
+++ b/src/control/cmd/daos_agent/attachinfo.go
@@ -23,7 +23,7 @@ type dumpAttachInfoCmd struct {
 	ctlInvokerCmd
 	Output      string `short:"o" long:"output" default:"stdout" description:"Dump output to this location"`
 	JSON        bool   `short:"j" long:"json" description:"Enable JSON output"`
-	ProviderIdx uint   `short:"n" long:"provider_idx" description:"Index of provider to fetch (if multiple)"`
+	ProviderIdx *uint  `short:"n" long:"provider_idx" description:"Index of provider to fetch (if multiple)"`
 }
 
 func (cmd *dumpAttachInfoCmd) Execute(_ []string) error {
@@ -57,7 +57,12 @@ func (cmd *dumpAttachInfoCmd) Execute(_ []string) error {
 		return err
 	}
 
-	ranks, err := getServiceRanksForProviderIdx(resp, int(cmd.ProviderIdx))
+	providerIdx := cmd.cfg.ProviderIdx
+	if cmd.ProviderIdx != nil {
+		providerIdx = *cmd.ProviderIdx
+	}
+
+	ranks, err := getServiceRanksForProviderIdx(resp, int(providerIdx))
 	if err != nil {
 		return err
 	}

--- a/src/control/server/ctl_network_rpc.go
+++ b/src/control/server/ctl_network_rpc.go
@@ -18,16 +18,16 @@ import (
 
 // NetworkScan retrieves details of network interfaces on remote hosts.
 func (c *ControlService) NetworkScan(ctx context.Context, req *ctlpb.NetworkScanReq) (*ctlpb.NetworkScanResp, error) {
-	provider, err := c.srvCfg.Fabric.GetPrimaryProvider()
+	providers, err := c.srvCfg.Fabric.GetProviders()
 	if err != nil {
 		return nil, err
 	}
 
 	switch {
 	case strings.EqualFold(req.GetProvider(), "all"):
-		provider = ""
+		providers = []string{}
 	case req.GetProvider() != "":
-		provider = req.GetProvider()
+		providers = []string{req.GetProvider()}
 	}
 
 	topo, err := hwprov.DefaultTopologyProvider(c.log).GetTopology(ctx)
@@ -39,12 +39,12 @@ func (c *ControlService) NetworkScan(ctx context.Context, req *ctlpb.NetworkScan
 		return nil, err
 	}
 
-	result, err := c.fabric.Scan(ctx, provider)
+	result, err := c.fabric.Scan(ctx, providers...)
 	if err != nil {
 		return nil, err
 	}
 
-	resp := c.fabricInterfaceSetToNetworkScanResp(result, provider)
+	resp := c.fabricInterfaceSetToNetworkScanResp(result)
 
 	resp.Numacount = int32(topo.NumNUMANodes())
 	resp.Corespernuma = int32(topo.NumCoresPerNUMA())
@@ -52,7 +52,7 @@ func (c *ControlService) NetworkScan(ctx context.Context, req *ctlpb.NetworkScan
 	return resp, nil
 }
 
-func (c *ControlService) fabricInterfaceSetToNetworkScanResp(fis *hardware.FabricInterfaceSet, provider string) *ctlpb.NetworkScanResp {
+func (c *ControlService) fabricInterfaceSetToNetworkScanResp(fis *hardware.FabricInterfaceSet) *ctlpb.NetworkScanResp {
 	resp := new(ctlpb.NetworkScanResp)
 	resp.Interfaces = make([]*ctlpb.FabricInterface, 0, fis.NumNetDevices())
 	for _, name := range fis.Names() {
@@ -68,15 +68,13 @@ func (c *ControlService) fabricInterfaceSetToNetworkScanResp(fis *hardware.Fabri
 
 		for _, hwFI := range fi.NetInterfaces.ToSlice() {
 			for _, prov := range fi.Providers.ToSlice() {
-				if provider == "" || provider == prov.Name {
-					resp.Interfaces = append(resp.Interfaces, &ctlpb.FabricInterface{
-						Provider:    prov.Name,
-						Device:      hwFI,
-						Numanode:    uint32(fi.NUMANode),
-						Netdevclass: uint32(fi.DeviceClass),
-						Priority:    uint32(prov.Priority),
-					})
-				}
+				resp.Interfaces = append(resp.Interfaces, &ctlpb.FabricInterface{
+					Provider:    prov.Name,
+					Device:      hwFI,
+					Numanode:    uint32(fi.NUMANode),
+					Netdevclass: uint32(fi.DeviceClass),
+					Priority:    uint32(prov.Priority),
+				})
 			}
 		}
 	}

--- a/src/control/server/ctl_network_rpc_test.go
+++ b/src/control/server/ctl_network_rpc_test.go
@@ -22,7 +22,6 @@ import (
 func TestServer_ControlService_fabricInterfaceSetToNetworkScanResp(t *testing.T) {
 	for name, tc := range map[string]struct {
 		fis       *hardware.FabricInterfaceSet
-		provider  string
 		expResult *ctlpb.NetworkScanResp
 	}{
 		"empty": {
@@ -156,7 +155,7 @@ func TestServer_ControlService_fabricInterfaceSetToNetworkScanResp(t *testing.T)
 
 			cs := mockControlService(t, log, config.DefaultServer(), nil, nil, nil)
 
-			result := cs.fabricInterfaceSetToNetworkScanResp(tc.fis, tc.provider)
+			result := cs.fabricInterfaceSetToNetworkScanResp(tc.fis)
 
 			if diff := cmp.Diff(tc.expResult, result, test.DefaultCmpOpts()...); diff != "" {
 				t.Fatalf("(-want, +got)\n%s\n", diff)


### PR DESCRIPTION
- By default dmg network scan will include all configured providers, not just the primary provider.
- In daos_agent dump-attachinfo, use the agent config as the source for the provider index.

Features: control

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
