### PR TITLE
DAOS-13553 test: Fix using bdev_roles with non-pmem nvme=auto.

### DIFF
--- a/src/tests/ftest/util/storage_utils.py
+++ b/src/tests/ftest/util/storage_utils.py
@@ -620,7 +620,7 @@ class StorageInfo():
                 else:
                     lines.append('          class: nvme')
                     lines.append(f'          bdev_list: [{", ".join(bdev_list[engine][tier])}]')
-                    if not pmem_list:
+                    if control_metadata:
                         lines.append(
                             f'          bdev_roles: [{", ".join(get_tier_roles(tier, tiers))}]')
 

--- a/src/tests/ftest/util/storage_utils.py
+++ b/src/tests/ftest/util/storage_utils.py
@@ -553,6 +553,8 @@ class StorageInfo():
             self._raise_error(f'Error: Invalid storage type \'{tier_0_type}\'')
 
         pmem_list = {}
+        bdev_list = {}
+
         if tier_0_type == self.TIER_0_TYPES[0] and self.pmem_devices:
             # Sort the detected devices and place then in lists by NUMA node
             numa_devices = self._get_numa_devices(self.pmem_devices)
@@ -588,7 +590,6 @@ class StorageInfo():
             self._log.debug('  NVMe/VMD tier_placement: %s', tier_placement)
             tiers += max(tier_placement)
 
-            bdev_list = {}
             for device_set in device_sets:
                 tier = tier_placement.pop(0)
                 for engine, device in enumerate(device_set):
@@ -600,7 +601,7 @@ class StorageInfo():
             self._log.debug('  NVMe/VMD bdev_list:      %s', bdev_list)
 
         lines = ['server_config:']
-        if control_metadata:
+        if control_metadata and bdev_list:
             lines.append('  control_metadata:')
             lines.append(f'    path: {control_metadata}')
         lines.append('  engines:')


### PR DESCRIPTION
Launch.py will incorrectly include bdev_roles for the bdev_tiers when using '--nvme auto' if there are no pmem devices found on the server hosts.  This patch resolves this issue.

Skip-unit-tests: true
Skip-fault-injection-test: true
Allow-unstable-test: true
Test-nvme: auto_md_on_ssd
Test-tag: HarnessSetupTest

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
