### PR TITLE
DAOS-13540 object: handle TX_RESTART during TX convert

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -710,7 +710,7 @@ dc_sgl_out_set(d_sg_list_t *sgl, daos_size_t data_size)
 
 void obj_shard_decref(struct dc_obj_shard *shard);
 void obj_shard_addref(struct dc_obj_shard *shard);
-void obj_addref(struct dc_object *obj);
+struct dc_object *obj_addref(struct dc_object *obj);
 void obj_decref(struct dc_object *obj);
 int obj_get_grp_size(struct dc_object *obj);
 struct dc_object *obj_hdl2ptr(daos_handle_t oh);
@@ -868,8 +868,8 @@ int
 dc_tx_get_dti(daos_handle_t th, struct dtx_id *dti);
 
 int
-dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
-	     tse_task_t *task, bool comp);
+dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task,
+	     uint32_t backoff, bool comp);
 
 int
 dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task);

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -73,6 +73,8 @@ struct dc_tx {
 	struct dtx_epoch	 tx_epoch;
 	/** The task choosing the TX epoch. */
 	tse_task_t		*tx_epoch_task;
+	/** The original task for conversion. */
+	tse_task_t		*tx_orig_task;
 	/** Transaction flags (DAOS_TF_RDONLY, DAOS_TF_ZERO_COPY, etc.) */
 	uint64_t		 tx_flags;
 	uint32_t		 tx_fixed_epoch:1, /** epoch is specified. */
@@ -509,6 +511,7 @@ dc_tx_cleanup(struct dc_tx *tx)
 	tx->tx_read_cnt = 0;
 	tx->tx_write_cnt = 0;
 	tx->tx_retry = 0;
+	tx->tx_has_cond = 0;
 
 	/* Keep 'tx_set_resend'. */
 
@@ -702,6 +705,9 @@ dc_tx_check_pmv_internal(daos_handle_t th, struct dc_tx **ptx)
 
 	if (rc != 0 || ptx == NULL) {
 		D_MUTEX_UNLOCK(&tx->tx_lock);
+		if (rc != 0)
+			D_ERROR("PM version check for TX " DF_DTI " failed, version %u vs %u: %d\n",
+				DP_DTI(&tx->tx_id), tx->tx_pm_ver, pm_ver, rc);
 		dc_tx_decref(tx);
 	} else {
 		*ptx = tx;
@@ -966,8 +972,6 @@ dc_tx_commit_cb(tse_task_t *task, void *data)
 	int			  rc1;
 	bool			  locked = true;
 
-	D_MUTEX_LOCK(&tx->tx_lock);
-
 	if (rc == 0) {
 		rc = oco->oco_ret;
 		if (rc == 0) {
@@ -977,6 +981,11 @@ dc_tx_commit_cb(tse_task_t *task, void *data)
 			rc = sub_rets[0];
 		}
 	}
+
+	D_DEBUG(DB_IO, "TX " DF_DTI " commit (%p) with version %u get result: %d, %d\n",
+		DP_DTI(&tx->tx_id), task, tx->tx_pm_ver, task->dt_result, rc);
+
+	D_MUTEX_LOCK(&tx->tx_lock);
 
 	if (rc == 0) {
 		uint64_t	*sub_epochs = oco->oco_sub_epochs.ca_arrays;
@@ -1032,6 +1041,8 @@ dc_tx_commit_cb(tse_task_t *task, void *data)
 		goto out;
 	}
 
+	tx->tx_set_resend = 1;
+
 	/* Need to refresh the local pool map. */
 	if (tx->tx_pm_ver < oco->oco_map_version || daos_crt_network_error(rc) ||
 	    rc == -DER_TIMEDOUT || rc == -DER_EXCLUDED || rc == -DER_STALE) {
@@ -1041,71 +1052,60 @@ dc_tx_commit_cb(tse_task_t *task, void *data)
 		rc1 = obj_pool_query_task(tse_task2sched(task), dcsr->dcsr_obj,
 					  oco->oco_map_version, &pool_task);
 		if (rc1 != 0) {
-			D_ERROR("Failed to refresh the pool map: "
-				DF_RC", original error: "DF_RC"\n",
-				DP_RC(rc1), DP_RC(rc));
+			D_ERROR("Failed to refresh pool map: %d, %d\n", rc1, rc);
 			tx->tx_status = TX_ABORTED;
-			D_GOTO(out, rc = rc1);
+			D_GOTO(out, rc = (rc != 0 ? rc : rc1));
+		}
+
+		rc1 = dc_task_depend(task, 1, &pool_task);
+		if (rc1 != 0) {
+			D_WARN("Failed to dep on pool query: %d, %d\n", rc1, rc);
+			/*
+			 * It is not fatal if failed to add dep to pool query task. Let's restart
+			 * the TX. If the pool query task does not refresh the pool map in time,
+			 * then the original task with restarted TX may hit DER_TX_RESTART again.
+			 */
+			tx->tx_status = TX_FAILED;
+			rc = -DER_TX_RESTART;
 		}
 	}
 
 	/* Need to restart the TX with newer epoch. */
 	if (rc == -DER_TX_RESTART || rc == -DER_STALE || rc == -DER_UPDATE_AGAIN) {
-		tx->tx_set_resend = 1;
 		tx->tx_status = TX_FAILED;
-
-		if (pool_task != NULL) {
-			D_MUTEX_UNLOCK(&tx->tx_lock);
-			locked = false;
-
-			tse_task_schedule(pool_task, true);
-		}
-
-		D_GOTO(out, rc = -DER_TX_RESTART);
+		rc = -DER_TX_RESTART;
+	} else {
+		tx->tx_retry = 1;
+		tcca->tcca_args->flags |= DTF_RETRY_COMMIT;
 	}
-
-	tx->tx_retry = 1;
-	tx->tx_set_resend = 1;
-	tcca->tcca_args->flags |= DTF_RETRY_COMMIT;
 
 	D_MUTEX_UNLOCK(&tx->tx_lock);
 	locked = false;
 
-	if (pool_task != NULL) {
-		rc1 = dc_task_depend(task, 1, &pool_task);
+	if (rc != -DER_TX_RESTART) {
+		rc1 = dc_task_resched(task);
 		if (rc1 != 0) {
-			D_ERROR("Failed to add dependency on pool query: "
-				DF_RC", original error: "DF_RC"\n",
-				DP_RC(rc1), DP_RC(rc));
-			dc_pool_abandon_map_refresh_task(pool_task);
+			D_ERROR("Failed to reinit task %p: %d, %d\n", task, rc1, rc);
 			tx->tx_status = TX_ABORTED;
-
-			D_GOTO(out, rc = rc1);
+		} else {
+			rc = 0;
 		}
 	}
-
-	rc1 = dc_task_resched(task);
-	if (rc1 != 0) {
-		D_ERROR("Failed to re-init task (%p): "DF_RC", original error: "
-			DF_RC"\n", task, DP_RC(rc1), DP_RC(rc));
-		if (pool_task != NULL)
-			dc_pool_abandon_map_refresh_task(pool_task);
-		tx->tx_status = TX_ABORTED;
-
-		D_GOTO(out, rc = rc1);
-	}
-
-	if (pool_task != NULL)
-		tse_task_schedule(pool_task, true);
-
-	rc = 0;
 
 out:
 	if (locked)
 		D_MUTEX_UNLOCK(&tx->tx_lock);
 
-	if (rc != 0)
-		task->dt_result = rc;
+	/*
+	 * NOTE: Must set commit_task->dt_result before schedule the pool_task. Otherwise the
+	 *	 pool_task may complete very quickly as to its completion callback may trigger
+	 *	 the left callback registered to the commit_task which dt_result is not set as
+	 *	 the commit result yet.
+	 */
+	task->dt_result = rc;
+
+	if (pool_task != NULL)
+		tse_task_schedule(pool_task, true);
 
 	crt_req_decref(req);
 	/* -1 for dc_tx_commit() held */
@@ -2216,12 +2216,15 @@ dc_tx_commit_trigger(tse_task_t *task, struct dc_tx *tx, daos_tx_commit_t *args)
 	struct daos_cpd_sub_req		*dcsr;
 	struct tx_commit_cb_args	 tcca;
 	crt_endpoint_t			 tgt_ep;
+	uint32_t			 ver;
 	int				 rc = 0;
-	bool				 locked = true;
 
-	if (tx->tx_pm_ver != 0 && tx->tx_pm_ver != dc_pool_get_version(tx->tx_pool) &&
-	    (tx->tx_retry || tx->tx_read_cnt > 0))
+	ver = dc_pool_get_version(tx->tx_pool);
+	if (tx->tx_pm_ver != 0 && tx->tx_pm_ver != ver && (tx->tx_retry || tx->tx_read_cnt > 0)) {
+		D_DEBUG(DB_IO, "TX " DF_DTI " with pm ver %u vs %u need restart (1)\n",
+			DP_DTI(&tx->tx_id), tx->tx_pm_ver, ver);
 		D_GOTO(out, rc = -DER_TX_RESTART);
+	}
 
 	if (!tx->tx_retry) {
 		rc = dc_tx_commit_prepare(tx, task);
@@ -2293,24 +2296,41 @@ out:
 			 */
 			D_ERROR("Failed to refresh pool map for "DF_DTI": "DF_RC"\n",
 				DP_DTI(&tx->tx_id), DP_RC(rc));
-		} else {
-			rc = -DER_TX_RESTART;
-			tx->tx_status = TX_FAILED;
-			/* Unlock for dc_tx_commit held. */
-			D_MUTEX_UNLOCK(&tx->tx_lock);
-			locked = false;
-			tse_task_schedule(pool_task, true);
+			goto unlock;
 		}
-	}
 
-	if (locked) {
-		if (rc == -DER_TX_RESTART)
-			tx->tx_status = TX_FAILED;
-		else if (rc != 0)
-			tx->tx_status = TX_ABORTED;
+		rc = dc_task_depend(task, 1, &pool_task);
+		if (rc != 0)
+			/*
+			 * It is not fatal if failed to add dep to pool query task. Let's restart
+			 * the TX. If the pool query task does not refresh the pool map in time,
+			 * then the original task with restarted TX may hit DER_TX_RESTART again.
+			 */
+			D_WARN("Failed to dep on pool query: %d\n", rc);
+
+		rc = -DER_TX_RESTART;
+		tx->tx_status = TX_FAILED;
 		/* Unlock for dc_tx_commit held. */
 		D_MUTEX_UNLOCK(&tx->tx_lock);
+
+		D_DEBUG(DB_IO, "TX " DF_DTI " with pm ver %u vs %u need restart (2)\n",
+			DP_DTI(&tx->tx_id), tx->tx_pm_ver, ver);
+
+		/* Do not call tse_task_complete() that will be triggered when pool_task done. */
+		task->dt_result = rc;
+		/* -1 for dc_tx_commit() held */
+		dc_tx_decref(tx);
+
+		return tse_task_schedule(pool_task, true);
 	}
+
+unlock:
+	if (rc == -DER_TX_RESTART)
+		tx->tx_status = TX_FAILED;
+	else if (rc != 0)
+		tx->tx_status = TX_ABORTED;
+	/* Unlock for dc_tx_commit held. */
+	D_MUTEX_UNLOCK(&tx->tx_lock);
 
 	/* -1 for dc_tx_commit() held */
 	dc_tx_decref(tx);
@@ -2651,9 +2671,8 @@ dc_tx_dcsr2oid(struct daos_cpd_sub_req *dcsr)
 }
 
 static int
-dc_tx_add_update(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
-		 daos_key_t *dkey, uint32_t nr, daos_iod_t *iods,
-		 d_sg_list_t *sgls)
+dc_tx_add_update(struct dc_tx *tx, struct dc_object *obj, uint64_t flags, daos_key_t *dkey,
+		 uint32_t nr, daos_iod_t *iods, d_sg_list_t *sgls)
 {
 	struct daos_cpd_sub_req *dcsr;
 	struct daos_cpd_update  *dcu;
@@ -2662,9 +2681,8 @@ dc_tx_add_update(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 	int                      i;
 
 	D_ASSERT(nr != 0);
-	D_ASSERT(obj != NULL);
 
-	if (*obj == NULL)
+	if (obj == NULL)
 		return -DER_NO_HDL;
 
 	/*
@@ -2681,9 +2699,7 @@ dc_tx_add_update(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 	if (rc != 0)
 		return rc;
 
-	dcsr->dcsr_obj = *obj;
-	*obj = NULL;
-
+	dcsr->dcsr_obj = obj_addref(obj);
 	rc = daos_iov_copy(&dcsr->dcsr_dkey, dkey);
 	if (rc != 0)
 		D_GOTO(fail, rc);
@@ -2766,23 +2782,19 @@ fail:
 }
 
 static int
-dc_tx_add_punch_obj(struct dc_tx *tx, struct dc_object **obj, uint64_t flags)
+dc_tx_add_punch_obj(struct dc_tx *tx, struct dc_object *obj, uint64_t flags)
 {
 	struct daos_cpd_sub_req	*dcsr;
 	int			 rc;
 
-	D_ASSERT(obj != NULL);
-
-	if (*obj == NULL)
+	if (obj == NULL)
 		return -DER_NO_HDL;
 
 	rc = dc_tx_get_next_slot(tx, false, &dcsr);
 	if (rc != 0)
 		return rc;
 
-	dcsr->dcsr_obj = *obj;
-	*obj = NULL;
-
+	dcsr->dcsr_obj = obj_addref(obj);
 	dcsr->dcsr_opc = DCSO_PUNCH_OBJ;
 	dcsr->dcsr_api_flags = flags & ~DAOS_COND_MASK;
 
@@ -2797,24 +2809,19 @@ dc_tx_add_punch_obj(struct dc_tx *tx, struct dc_object **obj, uint64_t flags)
 }
 
 static int
-dc_tx_add_punch_dkey(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
-		     daos_key_t *dkey)
+dc_tx_add_punch_dkey(struct dc_tx *tx, struct dc_object *obj, uint64_t flags, daos_key_t *dkey)
 {
 	struct daos_cpd_sub_req	*dcsr;
 	int			 rc;
 
-	D_ASSERT(obj != NULL);
-
-	if (*obj == NULL)
+	if (obj == NULL)
 		return -DER_NO_HDL;
 
 	rc = dc_tx_get_next_slot(tx, false, &dcsr);
 	if (rc != 0)
 		return rc;
 
-	dcsr->dcsr_obj = *obj;
-	*obj = NULL;
-
+	dcsr->dcsr_obj = obj_addref(obj);
 	rc = daos_iov_copy(&dcsr->dcsr_dkey, dkey);
 	if (rc != 0) {
 		obj_decref(dcsr->dcsr_obj);
@@ -2836,8 +2843,8 @@ dc_tx_add_punch_dkey(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 }
 
 static int
-dc_tx_add_punch_akeys(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
-		      daos_key_t *dkey, uint32_t nr, daos_key_t *akeys)
+dc_tx_add_punch_akeys(struct dc_tx *tx, struct dc_object *obj, uint64_t flags, daos_key_t *dkey,
+		      uint32_t nr, daos_key_t *akeys)
 {
 	struct daos_cpd_sub_req	*dcsr = NULL;
 	struct daos_cpd_punch	*dcp = NULL;
@@ -2845,18 +2852,15 @@ dc_tx_add_punch_akeys(struct dc_tx *tx, struct dc_object **obj, uint64_t flags,
 	int			 i;
 
 	D_ASSERT(nr != 0);
-	D_ASSERT(obj != NULL);
 
-	if (*obj == NULL)
+	if (obj == NULL)
 		return -DER_NO_HDL;
 
 	rc = dc_tx_get_next_slot(tx, false, &dcsr);
 	if (rc != 0)
 		return rc;
 
-	dcsr->dcsr_obj = *obj;
-	*obj = NULL;
-
+	dcsr->dcsr_obj = obj_addref(obj);
 	rc = daos_iov_copy(&dcsr->dcsr_dkey, dkey);
 	if (rc != 0)
 		goto fail;
@@ -2901,9 +2905,8 @@ fail:
 }
 
 static int
-dc_tx_add_read(struct dc_tx *tx, struct dc_object **obj, int opc,
-	       uint64_t flags, daos_key_t *dkey, uint32_t nr,
-	       void *iods_or_akey)
+dc_tx_add_read(struct dc_tx *tx, struct dc_object *obj, int opc, uint64_t flags, daos_key_t *dkey,
+	       uint32_t nr, void *iods_or_akey)
 {
 	struct daos_cpd_sub_req	*dcsr = NULL;
 	struct daos_cpd_read	*dcr = NULL;
@@ -2916,17 +2919,14 @@ dc_tx_add_read(struct dc_tx *tx, struct dc_object **obj, int opc,
 	if (tx->tx_fixed_epoch)
 		return 0;
 
-	D_ASSERT(obj != NULL);
-
-	if (*obj == NULL)
+	if (obj == NULL)
 		return -DER_NO_HDL;
 
 	rc = dc_tx_get_next_slot(tx, true, &dcsr);
 	if (rc != 0)
 		return rc;
 
-	dcsr->dcsr_obj = *obj;
-	*obj = NULL;
+	dcsr->dcsr_obj = obj_addref(obj);
 
 	/* Set read TS on object shard. */
 	if (dkey == NULL)
@@ -2999,7 +2999,9 @@ fail:
 	return rc;
 }
 
-static int dc_tx_convert_post(struct dc_tx *tx, tse_task_t *task, enum obj_rpc_opc opc, int result);
+static int
+dc_tx_convert_post(struct dc_tx *tx, struct dc_object *obj, enum obj_rpc_opc opc, int result,
+		   uint32_t backoff);
 
 struct dc_tx_check_existence_cb_args {
 	enum obj_rpc_opc	opc;
@@ -3016,10 +3018,11 @@ struct dc_tx_check_existence_cb_args {
 };
 
 static inline int
-dc_tx_post(struct dc_tx *tx, tse_task_t *task, enum obj_rpc_opc opc, int result)
+dc_tx_post(struct dc_tx *tx, struct dc_object *obj, tse_task_t *task, enum obj_rpc_opc opc,
+	   int result, uint32_t backoff)
 {
 	if (tx->tx_for_convert)
-		result = dc_tx_convert_post(tx, task, opc, result);
+		result = dc_tx_convert_post(tx, obj, opc, result, backoff);
 	else
 		tse_task_complete(task, result);
 
@@ -3080,16 +3083,16 @@ dc_tx_per_akey_existence_parent_cb(tse_task_t *task, void *data)
 	D_ASSERT(args->opc == DAOS_OBJ_RPC_UPDATE);
 	D_ASSERT(args->flags & DAOS_COND_PER_AKEY);
 
+	obj = obj_hdl2ptr(args->oh);
 	if (rc == 0) {
-		obj = obj_hdl2ptr(args->oh);
 		D_MUTEX_LOCK(&tx->tx_lock);
-		rc = dc_tx_add_update(tx, &obj, args->flags, args->dkey, args->nr,
+		rc = dc_tx_add_update(tx, obj, args->flags, args->dkey, args->nr,
 				      args->iods_or_akeys, args->sgls);
 		D_MUTEX_UNLOCK(&tx->tx_lock);
-		obj_decref(obj);
 	}
 
-	dc_tx_post(tx, args->task, args->opc, rc);
+	dc_tx_post(tx, obj, args->task, args->opc, rc, 0);
+	obj_decref(obj);
 
 	/* Drop the reference that is held via dc_tx_attach(). */
 	dc_tx_decref(tx);
@@ -3115,8 +3118,7 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 		if (rc != 0)
 			D_GOTO(out, rc);
 
-		rc = dc_tx_add_update(tx, &obj, args->flags,
-				      args->dkey, args->nr,
+		rc = dc_tx_add_update(tx, obj, args->flags, args->dkey, args->nr,
 				      args->iods_or_akeys, args->sgls);
 		break;
 	case DAOS_OBJ_RPC_PUNCH_DKEYS:
@@ -3125,8 +3127,7 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 		if (task->dt_result != 0)
 			D_GOTO(out, rc = task->dt_result);
 
-		rc = dc_tx_add_punch_dkey(tx, &obj, args->flags,
-					  args->dkey);
+		rc = dc_tx_add_punch_dkey(tx, obj, args->flags, args->dkey);
 		break;
 	case DAOS_OBJ_RPC_PUNCH_AKEYS:
 		D_ASSERT(args->flags & DAOS_COND_PUNCH);
@@ -3134,8 +3135,7 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 		if (task->dt_result != 0)
 			D_GOTO(out, rc = task->dt_result);
 
-		rc = dc_tx_add_punch_akeys(tx, &obj, args->flags,
-					   args->dkey, args->nr,
+		rc = dc_tx_add_punch_akeys(tx, obj, args->flags, args->dkey, args->nr,
 					   args->iods_or_akeys);
 		break;
 	default:
@@ -3144,7 +3144,6 @@ dc_tx_check_existence_cb(tse_task_t *task, void *data)
 
 out:
 	D_MUTEX_UNLOCK(&tx->tx_lock);
-	obj_decref(obj);
 
 	if (args->tmp_iods != NULL) {
 		for (i = 0; i < args->nr; i++)
@@ -3153,7 +3152,8 @@ out:
 		D_FREE(args->tmp_iods);
 	}
 
-	dc_tx_post(tx, args->task, args->opc, rc);
+	dc_tx_post(tx, obj, args->task, args->opc, rc, 0);
+	obj_decref(obj);
 
 	/* Drop the reference that is held via dc_tx_attach(). */
 	dc_tx_decref(tx);
@@ -3164,7 +3164,7 @@ out:
 static int
 dc_tx_per_akey_existence_task(enum obj_rpc_opc opc, daos_handle_t oh, struct dc_tx *tx,
 			      uint64_t flags, daos_key_t *dkey, uint32_t nr, void *iods_or_akeys,
-			      d_sg_list_t *sgls, tse_task_t *parent)
+			      d_sg_list_t *sgls, tse_task_t *parent, uint32_t backoff)
 {
 	struct dc_tx_check_existence_cb_args	 cb_args = { 0 };
 	daos_iod_t				*in_iods = iods_or_akeys;
@@ -3244,11 +3244,11 @@ out:
 
 			obj = obj_hdl2ptr(oh);
 			D_MUTEX_LOCK(&tx->tx_lock);
-			rc = dc_tx_add_update(tx, &obj, flags, dkey, nr, iods_or_akeys, sgls);
+			rc = dc_tx_add_update(tx, obj, flags, dkey, nr, iods_or_akeys, sgls);
 			D_MUTEX_UNLOCK(&tx->tx_lock);
-			obj_decref(obj);
 
-			rc = dc_tx_post(tx, parent, opc, rc);
+			rc = dc_tx_post(tx, obj, parent, opc, rc, backoff);
+			obj_decref(obj);
 
 			/* Drop the reference that is held via dc_tx_attach(). */
 			dc_tx_decref(tx);
@@ -3272,7 +3272,7 @@ out:
 fail:
 		tse_task_list_traverse(&task_list, shard_task_abort, &rc);
 
-		rc = dc_tx_post(tx, parent, opc, rc);
+		rc = dc_tx_post(tx, NULL, parent, opc, rc, 0);
 
 		/* Drop the reference that is held via dc_tx_attach(). */
 		dc_tx_decref(tx);
@@ -3282,10 +3282,9 @@ fail:
 }
 
 static int
-dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
-			   struct dc_tx *tx, uint64_t flags, daos_key_t *dkey,
-			   uint32_t nr, void *iods_or_akeys, d_sg_list_t *sgls,
-			   tse_task_t *parent)
+dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh, struct dc_tx *tx, uint64_t flags,
+			   daos_key_t *dkey, uint32_t nr, void *iods_or_akeys, d_sg_list_t *sgls,
+			   tse_task_t *parent, uint32_t backoff)
 {
 	struct dc_tx_check_existence_cb_args	 cb_args = { 0 };
 	daos_iod_t				*iods = NULL;
@@ -3363,7 +3362,11 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 		goto out;
 	}
 
-	return tse_task_schedule(task, true);
+	/* Reset status for the converted task. */
+	if (tx->tx_for_convert)
+		parent->dt_result = 0;
+
+	return tse_task_schedule_with_delay(task, backoff == 0 ? true : false, backoff);
 
 out:
 	if (task != NULL)
@@ -3376,7 +3379,7 @@ out:
 		D_FREE(iods);
 	}
 
-	rc = dc_tx_post(tx, parent, opc, rc);
+	rc = dc_tx_post(tx, NULL, parent, opc, rc, 0);
 
 	/* Drop the reference that is held via dc_tx_attach(). */
 	dc_tx_decref(tx);
@@ -3385,8 +3388,8 @@ out:
 }
 
 int
-dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
-	     tse_task_t *task, bool comp)
+dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task,
+	     uint32_t backoff, bool comp)
 {
 	struct dc_tx	*tx;
 	int		 rc;
@@ -3405,24 +3408,26 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 				 DAOS_COND_AKEY_UPDATE)) {
 			tx->tx_has_cond = 1;
 			D_MUTEX_UNLOCK(&tx->tx_lock);
-			obj_decref(obj);
+			if (comp)
+				obj_decref(obj);
 
-			return dc_tx_check_existence_task(opc, up->oh, tx,
-						up->flags, up->dkey, up->nr,
-						up->iods, up->sgls, task);
+			return dc_tx_check_existence_task(opc, up->oh, tx, up->flags, up->dkey,
+							  up->nr, up->iods, up->sgls, task,
+							  backoff);
 		}
 
 		if (up->flags & DAOS_COND_PER_AKEY) {
 			tx->tx_has_cond = 1;
 			D_MUTEX_UNLOCK(&tx->tx_lock);
-			obj_decref(obj);
+			if (comp)
+				obj_decref(obj);
 
 			return dc_tx_per_akey_existence_task(opc, up->oh, tx, up->flags, up->dkey,
-							     up->nr, up->iods, up->sgls, task);
+							     up->nr, up->iods, up->sgls, task,
+							     backoff);
 		}
 
-		rc = dc_tx_add_update(tx, &obj, up->flags, up->dkey,
-				      up->nr, up->iods, up->sgls);
+		rc = dc_tx_add_update(tx, obj, up->flags, up->dkey, up->nr, up->iods, up->sgls);
 		break;
 	}
 	case DAOS_OBJ_RPC_PUNCH: {
@@ -3432,7 +3437,7 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 			  "Unexpected cond flag %lx for punch obj\n",
 			  pu->flags);
 
-		rc = dc_tx_add_punch_obj(tx, &obj, pu->flags);
+		rc = dc_tx_add_punch_obj(tx, obj, pu->flags);
 		break;
 	}
 	case DAOS_OBJ_RPC_PUNCH_DKEYS: {
@@ -3441,14 +3446,14 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 		if (pu->flags & DAOS_COND_PUNCH) {
 			tx->tx_has_cond = 1;
 			D_MUTEX_UNLOCK(&tx->tx_lock);
-			obj_decref(obj);
+			if (comp)
+				obj_decref(obj);
 
-			return dc_tx_check_existence_task(opc, pu->oh, tx,
-							  pu->flags, pu->dkey,
-							  0, NULL, NULL, task);
+			return dc_tx_check_existence_task(opc, pu->oh, tx, pu->flags, pu->dkey, 0,
+							  NULL, NULL, task, backoff);
 		}
 
-		rc = dc_tx_add_punch_dkey(tx, &obj, pu->flags, pu->dkey);
+		rc = dc_tx_add_punch_dkey(tx, obj, pu->flags, pu->dkey);
 		break;
 	}
 	case DAOS_OBJ_RPC_PUNCH_AKEYS: {
@@ -3457,23 +3462,22 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 		if (pu->flags & DAOS_COND_PUNCH) {
 			tx->tx_has_cond = 1;
 			D_MUTEX_UNLOCK(&tx->tx_lock);
-			obj_decref(obj);
+			if (comp)
+				obj_decref(obj);
 
-			return dc_tx_check_existence_task(opc, pu->oh, tx,
-					pu->flags, pu->dkey, pu->akey_nr,
-					pu->akeys, NULL, task);
+			return dc_tx_check_existence_task(opc, pu->oh, tx, pu->flags, pu->dkey,
+							  pu->akey_nr, pu->akeys, NULL, task,
+							  backoff);
 		}
 
-		rc = dc_tx_add_punch_akeys(tx, &obj, pu->flags, pu->dkey,
-					   pu->akey_nr, pu->akeys);
+		rc = dc_tx_add_punch_akeys(tx, obj, pu->flags, pu->dkey, pu->akey_nr, pu->akeys);
 		break;
 	}
 	case DAOS_OBJ_RPC_FETCH: {
 		daos_obj_fetch_t	*fe = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, &obj, opc, fe->flags, fe->dkey,
-				    fe->nr, fe->nr != 1 ? fe->iods :
-				    (void *)&fe->iods[0].iod_name);
+		rc = dc_tx_add_read(tx, obj, opc, fe->flags, fe->dkey, fe->nr,
+				    fe->nr != 1 ? fe->iods : (void *)&fe->iods[0].iod_name);
 		break;
 	}
 	case DAOS_OBJ_RPC_QUERY_KEY: {
@@ -3492,23 +3496,23 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 			nr = 1;
 		}
 
-		rc = dc_tx_add_read(tx, &obj, opc, 0, dkey, nr, qu->akey);
+		rc = dc_tx_add_read(tx, obj, opc, 0, dkey, nr, qu->akey);
 		break;
 	}
 	case DAOS_OBJ_RECX_RPC_ENUMERATE: {
 		daos_obj_list_recx_t	*lr = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, &obj, opc, 0, lr->dkey, 1, lr->akey);
+		rc = dc_tx_add_read(tx, obj, opc, 0, lr->dkey, 1, lr->akey);
 		break;
 	}
 	case DAOS_OBJ_AKEY_RPC_ENUMERATE: {
 		daos_obj_list_akey_t	*la = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, &obj, opc, 0, la->dkey, 0, NULL);
+		rc = dc_tx_add_read(tx, obj, opc, 0, la->dkey, 0, NULL);
 		break;
 	}
 	case DAOS_OBJ_DKEY_RPC_ENUMERATE:
-		rc = dc_tx_add_read(tx, &obj, opc, 0, NULL, 0, NULL);
+		rc = dc_tx_add_read(tx, obj, opc, 0, NULL, 0, NULL);
 		break;
 	default:
 		D_ERROR("Unsupportted TX attach opc %d\n", opc);
@@ -3522,122 +3526,111 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc,
 	dc_tx_decref(tx);
 
 out_obj:
-	obj_decref(obj);
-
-	if (comp)
+	if (comp) {
+		obj_decref(obj);
 		tse_task_complete(task, rc);
+	}
 
 	return rc;
 }
 
 struct tx_convert_cb_args {
 	struct dc_tx		*conv_tx;
-	tse_task_t		*conv_task;
+	struct dc_object	*conv_obj;
 	enum obj_rpc_opc	 conv_opc;
 };
+
+static int
+dc_tx_convert_restart(struct dc_tx *tx, struct dc_object *obj, enum obj_rpc_opc opc,
+		      uint32_t *backoff)
+{
+	daos_handle_t	th = dc_tx_ptr2hdl(tx);
+	int		rc;
+
+again:
+	D_MUTEX_LOCK(&tx->tx_lock);
+	rc = dc_tx_restart_begin(tx, backoff);
+	if (rc != 0) {
+		D_ASSERT(rc != -DER_TX_RESTART);
+
+		D_ERROR("Fail to restart TX for convert task %p: %d\n", tx->tx_orig_task, rc);
+		D_MUTEX_UNLOCK(&tx->tx_lock);
+		goto out;
+	}
+
+	/* Since tx is internal, it is okay to end the restart before the backoff. */
+	dc_tx_restart_end(tx);
+	D_MUTEX_UNLOCK(&tx->tx_lock);
+
+	tx->tx_pm_ver = dc_pool_get_version(tx->tx_pool);
+
+	/* dc_tx_restart_begin() will trigger dc_tx_cleanup() internally, let's re-attach. */
+	rc = dc_tx_attach(th, obj, opc, tx->tx_orig_task, *backoff, false);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
+		 "Restart convert task %p with DTX " DF_DTI ", pm_ver %u, backoff %u: rc = %d\n",
+		 tx->tx_orig_task, DP_DTI(&tx->tx_id), tx->tx_pm_ver, *backoff, rc);
+
+	if (unlikely(rc == -DER_TX_RESTART))
+		goto again;
+
+out:
+	if (rc != 0 && tx->tx_has_cond)
+		dc_tx_close_internal(tx);
+
+	return rc;
+}
 
 static int
 dc_tx_convert_cb(tse_task_t *task, void *data)
 {
 	struct tx_convert_cb_args	*conv = data;
-	struct dc_object		*obj = NULL;
 	struct dc_tx			*tx = conv->conv_tx;
-	tse_task_t			*parent = conv->conv_task;
+	struct dc_object		*obj = conv->conv_obj;
+	enum obj_rpc_opc		 opc = conv->conv_opc;
+	uint32_t			 backoff = 0;
 	int				 rc = task->dt_result;
+	bool				 tx_need_close = true;
+
+	D_DEBUG(DB_IO, "Convert task %p/%p with DTX " DF_DTI ", pm_ver %u: %d\n", task,
+		tx->tx_orig_task, DP_DTI(&tx->tx_id), tx->tx_pm_ver, rc);
 
 	if (rc == -DER_TX_RESTART) {
-		struct tx_convert_cb_args	new_conv;
-		uint32_t			backoff;
-
-		D_MUTEX_LOCK(&tx->tx_lock);
-		rc = dc_tx_restart_begin(tx, &backoff);
-		if (rc != 0) {
-			D_ERROR("Fail to restart TX for convert task "DF_RC"\n",
-				DP_RC(rc));
-			D_MUTEX_UNLOCK(&tx->tx_lock);
-			goto out;
-		}
 		/*
-		 * Since tx is internal, it is okay to end the restart before
-		 * the backoff.
+		 * Reset current task->dt_result, otherwise -DER_TX_RESTART will be propagated to
+		 * the parent task (tx->tx_orig_task) even if we force reset parent->dt_result in
+		 * dc_tx_convert_post().
 		 */
-		dc_tx_restart_end(tx);
-		D_MUTEX_UNLOCK(&tx->tx_lock);
+		task->dt_result = 0;
+		tx_need_close = false;
 
-		tx->tx_pm_ver = dc_pool_get_version(tx->tx_pool);
-
-		switch (conv->conv_opc) {
-		case DAOS_OBJ_RPC_UPDATE: {
-			daos_obj_update_t	*up = dc_task_get_args(parent);
-
-			obj = obj_hdl2ptr(up->oh);
-			rc = dc_tx_add_update(tx, &obj, up->flags, up->dkey,
-					      up->nr, up->iods, up->sgls);
-			break;
-		}
-		case DAOS_OBJ_RPC_PUNCH: {
-			daos_obj_punch_t	*pu = dc_task_get_args(parent);
-
-			obj = obj_hdl2ptr(pu->oh);
-			rc = dc_tx_add_punch_obj(tx, &obj, pu->flags);
-			break;
-		}
-		case DAOS_OBJ_RPC_PUNCH_DKEYS: {
-			daos_obj_punch_t	*pu = dc_task_get_args(parent);
-
-			obj = obj_hdl2ptr(pu->oh);
-			rc = dc_tx_add_punch_dkey(tx, &obj, pu->flags,
-						  pu->dkey);
-			break;
-		}
-		case DAOS_OBJ_RPC_PUNCH_AKEYS: {
-			daos_obj_punch_t	*pu = dc_task_get_args(parent);
-
-			obj = obj_hdl2ptr(pu->oh);
-			rc = dc_tx_add_punch_akeys(tx, &obj, pu->flags,
-						   pu->dkey, pu->akey_nr,
-						   pu->akeys);
-			break;
-		}
-		default:
-			D_ASSERT(0);
-		}
-
-		if (rc != 0) {
-			D_ERROR("Fail to re-attach TX for convert task "
-				DF_RC"\n", DP_RC(rc));
-			goto out;
-		}
-
-		new_conv = *conv;
-		rc = tse_task_register_comp_cb(task, dc_tx_convert_cb,
-					       &new_conv, sizeof(new_conv));
-		if (rc != 0) {
-			D_ERROR("Fail to re-add CB for TX convert task: "
-				DF_RC"\n", DP_RC(rc));
-			goto out;
-		}
-
-		return tse_task_reinit_with_delay(task, backoff);
+		rc = dc_tx_convert_restart(tx, obj, opc, &backoff);
+		if (!tx->tx_has_cond)
+			rc = dc_tx_convert_post(tx, obj, opc, rc, backoff);
 	}
 
-out:
-	dc_tx_close_internal(tx);
+	if (tx_need_close)
+		dc_tx_close_internal(tx);
+
+	/* Drop object reference held via dc_tx_convert_post(). */
 	obj_decref(obj);
 
 	return rc;
 }
 
 static int
-dc_tx_convert_post(struct dc_tx *tx, tse_task_t *task, enum obj_rpc_opc opc, int result)
+dc_tx_convert_post(struct dc_tx *tx, struct dc_object *obj, enum obj_rpc_opc opc, int result,
+		   uint32_t backoff)
 {
 	struct tx_convert_cb_args	 conv_args = { .conv_tx = tx,
-						       .conv_task = task,
 						       .conv_opc = opc };
 	daos_tx_commit_t		*cmt_args;
+	tse_task_t			*task = tx->tx_orig_task;
 	tse_task_t			*cmt_task = NULL;
 	int				 rc = 0;
 	bool				 tx_need_close = true;
+
+	D_ASSERT(result != -DER_TX_RESTART);
 
 	if (result != 0)
 		D_GOTO(out, rc = result);
@@ -3653,22 +3646,29 @@ dc_tx_convert_post(struct dc_tx *tx, tse_task_t *task, enum obj_rpc_opc opc, int
 	cmt_args->th = dc_tx_ptr2hdl(tx);
 	cmt_args->flags = 0;
 
+	conv_args.conv_obj = obj_addref(obj);
+
 	rc = tse_task_register_comp_cb(cmt_task, dc_tx_convert_cb, &conv_args, sizeof(conv_args));
 	if (rc != 0) {
+		obj_decref(obj);
 		D_ERROR("Fail to add CB for TX convert task commit: "DF_RC"\n", DP_RC(rc));
 		goto out;
 	}
 
+	/* dc_tx_convert_cb will close tx */
+	tx_need_close = false;
+
 	rc = dc_task_depend(task, 1, &cmt_task);
 	if (rc != 0) {
-		D_ERROR("Fail to add dep for TX convert task on commit: "DF_RC"\n", DP_RC(rc));
-		/* dc_tx_convert will close tx */
-		tx_need_close = false;
+		D_ERROR("Fail to add dep for TX convert task on commit: " DF_RC "\n", DP_RC(rc));
 		goto out;
 	}
 
+	/* Reset status for the (resending) converted task. */
+	task->dt_result = 0;
+
 	/* 'task' (the parent one) will be completed after 'cmt_task' completed. */
-	return tse_task_schedule(cmt_task, true);
+	return tse_task_schedule_with_delay(cmt_task, backoff == 0 ? true : false, backoff);
 
 out:
 	if (cmt_task != NULL)
@@ -3687,7 +3687,8 @@ dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task)
 {
 	struct dc_tx	*tx = NULL;
 	int		 rc = 0;
-	daos_handle_t	coh;
+	uint32_t	 backoff = 0;
+	daos_handle_t	 coh;
 
 	D_ASSERT(obj != NULL);
 
@@ -3706,23 +3707,25 @@ dc_tx_convert(struct dc_object *obj, enum obj_rpc_opc opc, tse_task_t *task)
 	/* Hold another reference on TX to avoid being freed duing dc_tx_attach(). */
 	dc_tx_addref(tx);
 	tx->tx_for_convert = 1;
-	rc = dc_tx_attach(dc_tx_ptr2hdl(tx), obj, opc, task, false);
+	tx->tx_orig_task = task;
+	rc = dc_tx_attach(dc_tx_ptr2hdl(tx), obj, opc, task, 0, false);
+	if (unlikely(rc == -DER_TX_RESTART))
+		rc = dc_tx_convert_restart(tx, obj, opc, &backoff);
 
 	/* The 'task' will be completed via dc_tx_convert_post(). For condition case,
 	 * dc_tx_convert_post() will be triggered via condition callback; otherwise,
 	 * call dc_tx_convert_post() directly.
 	 */
 	if (!tx->tx_has_cond)
-		rc = dc_tx_convert_post(tx, task, opc, rc);
+		rc = dc_tx_convert_post(tx, obj, opc, rc, backoff);
 
 out:
-	if (tx != NULL) {
+	if (tx != NULL)
 		/* -1 for above dc_tx_addref(). */
 		dc_tx_decref(tx);
-	} else {
+	else
 		tse_task_complete(task, rc);
-		obj_decref(obj);
-	}
+	obj_decref(obj);
 
 	return rc;
 }


### PR DESCRIPTION
During TX convert, if -DER_TX_RESTART is returned, in spite of it is caused by stale pool map or transaction conflict, the TX convert logic needs to restart the internal transaction instead of forwarding the failure to upper layer caller.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
