### PR TITLE
Tanabarr/control evt debounce test fix 2

### DIFF
--- a/src/control/events/pubsub.go
+++ b/src/control/events/pubsub.go
@@ -192,13 +192,20 @@ func (ps *PubSub) debounceEvent(event *RASEvent) bool {
 
 	key := ctrl.keyFn(event)
 	if lastSeen, found := ps.dbncEvts[event.ID][key]; found {
-		if ctrl.cooldown == 0 || time.Since(lastSeen) < ctrl.cooldown {
+		interval := ctrl.cooldown
+		last := time.Since(lastSeen)
+		if interval == 0 || last < interval {
 			ps.dbncEvts.updateLastSeen(event.ID, key)
+			ps.log.Debugf("last seen %s ago (ignore) cooldown: %s", last, interval)
 			return true
+		} else {
+			ps.log.Debugf("debounce interval exceeded (lastSeen %s > %s) for %q",
+				last, interval, key)
 		}
 	}
 
 	ps.dbncEvts.updateLastSeen(event.ID, key)
+	ps.log.Debugf("event accepted")
 	return false
 }
 

--- a/src/control/events/pubsub.go
+++ b/src/control/events/pubsub.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -196,11 +196,11 @@ func (ps *PubSub) debounceEvent(event *RASEvent) bool {
 		last := time.Since(lastSeen)
 		if interval == 0 || last < interval {
 			ps.dbncEvts.updateLastSeen(event.ID, key)
-			ps.log.Debugf("last seen %s ago (ignore) cooldown: %s", last, interval)
+			ps.log.Debugf("ignored as %s since last", last)
 			return true
 		} else {
-			ps.log.Debugf("debounce interval exceeded (lastSeen %s > %s) for %q",
-				last, interval, key)
+			ps.log.Debugf("debounce interval exceeded (lastSeen %s > %s)",
+				last, interval)
 		}
 	}
 

--- a/src/control/events/pubsub_test.go
+++ b/src/control/events/pubsub_test.go
@@ -235,30 +235,42 @@ func TestEvents_PubSub_Debounce_NoCooldown(t *testing.T) {
 }
 
 func TestEvents_PubSub_Debounce_Cooldown(t *testing.T) {
-	test := func(t *testing.T, iter int) {
+	test := func(t *testing.T, iter int) bool {
 		log, buf := logging.NewTestLogger(t.Name())
 		defer test.ShowBufferOnFailure(t, buf)
 
 		ps := NewPubSub(test.Context(t), log)
 		defer ps.Close()
 
-		evt1 := mockSwimRankDeadEvt(1, 1)
-		debounceType := evt1.ID
+		debounceType := RASSwimRankDead
 		debounceCooldown := 25 * time.Millisecond
 		tally := newTally(3)
 
 		ps.Subscribe(RASTypeStateChange, tally)
 		ps.Debounce(debounceType, debounceCooldown, func(ev *RASEvent) string {
-			return fmt.Sprintf("%d:%x", ev.Rank, ev.Incarnation)
+			// Debounce should match all events sent in test.
+			return fmt.Sprintf("%d", ev.Rank)
 		})
 
-		// We should only see this event three times, after the cooldown
-		// timer expires on each loop.
+		// Send 16 (var j) events per incarnation (var i). We should only see this event
+		// three times as a new event will only be registered after the cooldown timer
+		// expires at the end of each incarnation loop iteration.
 		for i := 0; i < 3; i++ {
 			log.Debugf("start loop %d", i+1)
+
+			e := mockSwimRankDeadEvt(1, uint32(i+1))
+			t := time.Now()
 			for j := 0; j < 16; j++ {
-				ps.Publish(evt1)
+				l := time.Since(t)
+				if l > debounceCooldown {
+					// Test loop was stalled, print warning
+					log.Noticef("test loop stalled for %s, restart iteration", l)
+					return true
+				}
+				t = time.Now()
+				ps.Publish(e)
 			}
+
 			log.Debugf("sleep for cooldown")
 			time.Sleep(debounceCooldown)
 		}
@@ -266,11 +278,21 @@ func TestEvents_PubSub_Debounce_Cooldown(t *testing.T) {
 		<-tally.finished
 
 		log.Debugf("test iteration %d", iter)
-		test.AssertStringsEqual(t, []string{evt1.String(), evt1.String(), evt1.String()},
-			tally.getRx(), "unexpected slice of received events")
+
+		// Expect one message from each incarnation loop, other repeated messages for the
+		// same incarnation should get ignored by debounce Logic.
+		test.AssertStringsEqual(t, []string{
+			mockSwimRankDeadEvt(1, 1).String(),
+			mockSwimRankDeadEvt(1, 2).String(),
+			mockSwimRankDeadEvt(1, 3).String(),
+		}, tally.getRx(), "unexpected slice of received events")
+
+		return false
 	}
 
-	for tn := 0; tn < 4000; tn++ {
-		test(t, tn)
+	for tn := 0; tn < 4096; tn++ {
+		if restart := test(t, tn); restart {
+			tn--
+		}
 	}
 }

--- a/src/control/events/pubsub_test.go
+++ b/src/control/events/pubsub_test.go
@@ -35,9 +35,7 @@ func (tly *tally) OnEvent(_ context.Context, evt *RASEvent) {
 	tly.Lock()
 	defer tly.Unlock()
 
-	if len(tly.rx) < tly.expectedRx {
-		tly.rx = append(tly.rx, evt.String())
-	}
+	tly.rx = append(tly.rx, evt.String())
 	if len(tly.rx) == tly.expectedRx {
 		close(tly.finished)
 	}

--- a/src/control/events/pubsub_test.go
+++ b/src/control/events/pubsub_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -244,7 +244,7 @@ func TestEvents_PubSub_Debounce_Cooldown(t *testing.T) {
 
 		evt1 := mockSwimRankDeadEvt(1, 1)
 		debounceType := evt1.ID
-		debounceCooldown := 10 * time.Millisecond
+		debounceCooldown := 25 * time.Millisecond
 		tally := newTally(3)
 
 		ps.Subscribe(RASTypeStateChange, tally)

--- a/src/control/events/pubsub_test.go
+++ b/src/control/events/pubsub_test.go
@@ -35,7 +35,9 @@ func (tly *tally) OnEvent(_ context.Context, evt *RASEvent) {
 	tly.Lock()
 	defer tly.Unlock()
 
-	tly.rx = append(tly.rx, evt.String())
+	if len(tly.rx) < tly.expectedRx {
+		tly.rx = append(tly.rx, evt.String())
+	}
 	if len(tly.rx) == tly.expectedRx {
 		close(tly.finished)
 	}


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
