### PR TITLE
DAOS-623 build: Add telem-watchers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,3 +36,7 @@ utils/sl @daos-stack/dev-build-watchers
 
 # ftest-watchers: files affecting functional tests
 src/tests/ftest @daos-stack/ftest-watchers
+
+# telem-watchers: Changes related to the telemetry library
+src/utils/daos_metrics @daos-stack/telem-watchers
+src/gurt/telemetry.c @daos-stack/telem-watchers


### PR DESCRIPTION
Notify interested parties of any changes to the engine-side
telemetry library.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
