### PR TITLE
DAOS-623 gurt: Make daos error numbers a named enum and remove dead code.

### DIFF
--- a/src/gurt/errno.c
+++ b/src/gurt/errno.c
@@ -20,45 +20,27 @@ struct d_error_reg {
 	int			er_base;
 	int			er_limit;
 	const char * const	*er_strings;
-	const char * const	*er_strerror;
-	bool			er_alloc;
+	const char *const       *er_strerror;
 };
 
-#define D_DEFINE_COMP_ERRSTR(name, base)				\
-	static const char * const g_##name##_errstr[] = {		\
-		D_FOREACH_##name##_ERR(D_DEFINE_ERRSTR)			\
-	};								\
-	static const char * const g_##name##_errstr_desc[] = {		\
-		D_FOREACH_##name##_ERR(D_DEFINE_ERRDESC)		\
-	};								\
-	D_CASSERT((sizeof(g_##name##_errstr) /				\
-			 sizeof(g_##name##_errstr[0])) ==		\
-	      ((DER_ERR_##name##_LIMIT - DER_ERR_##name##_BASE - 1)),	\
-			#name "is not contiguous");			\
-	static struct d_error_reg g_##name##_errreg = {			\
-		.er_base	= DER_ERR_##name##_BASE,		\
-		.er_limit	= DER_ERR_##name##_LIMIT,		\
-		.er_strings	= g_##name##_errstr,			\
-		.er_strerror	= g_##name##_errstr_desc,		\
-		.er_alloc	= false,				\
+#define D_DEFINE_COMP_ERRSTR(name, base)                                                           \
+	static const char *const g_##name##_errstr[] = {D_FOREACH_##name##_ERR(D_DEFINE_ERRSTR)};  \
+	static const char *const g_##name##_errstr_desc[] = {                                      \
+	    D_FOREACH_##name##_ERR(D_DEFINE_ERRDESC)};                                             \
+	D_CASSERT((sizeof(g_##name##_errstr) / sizeof(g_##name##_errstr[0])) ==                    \
+		      ((DER_ERR_##name##_LIMIT - DER_ERR_##name##_BASE - 1)),                      \
+		  #name "is not contiguous");                                                      \
+	static struct d_error_reg g_##name##_errreg = {                                            \
+	    .er_base     = DER_ERR_##name##_BASE,                                                  \
+	    .er_limit    = DER_ERR_##name##_LIMIT,                                                 \
+	    .er_strings  = g_##name##_errstr,                                                      \
+	    .er_strerror = g_##name##_errstr_desc,                                                 \
 	};
-
 
 D_FOREACH_ERR_RANGE(D_DEFINE_COMP_ERRSTR)
 
-#define D_CHECK_RANGE(name, base)				\
-	do {							\
-		int first = DER_ERR_##name##_BASE + 1;		\
-		if (rc <= DER_ERR_##name##_BASE ||		\
-		    rc >= DER_ERR_##name##_LIMIT)		\
-			break;					\
-		return g_##name##_errstr[rc - first];		\
-	} while (0);
-
 #define D_ADD_LIST(name, base)					\
 		d_list_add_tail(&g_##name##_errreg.er_link, &g_error_reg_list);
-
-#define D_ABS(value) ((value) > 0 ? (value) : (-value))
 
 #define D_ERR_BUF_SIZE 32
 
@@ -68,75 +50,34 @@ d_err_init(void)
 	D_FOREACH_ERR_RANGE(D_ADD_LIST)
 }
 
-const char *d_errstr(int rc)
+const char *
+d_errstr(enum daos_error_number errnum)
 {
-	struct d_error_reg	*entry;
+	struct d_error_reg *entry;
 
-	if (rc == 0)
+	if (errnum == 0)
 		return "DER_SUCCESS";
 
-	if (rc > 0)
+	if (errnum > 0)
 		goto out;
 
-	rc = D_ABS(rc);
+	errnum = -errnum;
 
 	d_list_for_each_entry(entry, &g_error_reg_list, er_link) {
-		if (rc <= entry->er_base || rc >= entry->er_limit)
+		if (errnum <= entry->er_base || errnum >= entry->er_limit)
 			continue;
-		return entry->er_strings[rc - entry->er_base - 1];
+		return entry->er_strings[errnum - entry->er_base - 1];
 	}
 
 out:
 	return "DER_UNKNOWN";
 }
 
-int
-d_errno_register_range(int start, int end, const char * const *error_strings,
-		       const char * const *strerror)
-{
-	struct	d_error_reg	*entry;
-
-	D_ALLOC_PTR(entry);
-	if (entry == NULL) {
-		D_ERROR("No memory to register error code range %d - %d\n",
-			start, end);
-		/* Not fatal.  It just means we get DER_UNKNOWN from d_errstr */
-		return -DER_NOMEM;
-	}
-
-	entry->er_base = start;
-	entry->er_limit = end;
-	entry->er_strings = error_strings;
-	entry->er_strerror = strerror;
-	entry->er_alloc = true;
-	d_list_add(&entry->er_link, &g_error_reg_list);
-
-	return 0;
-}
-
-void
-d_errno_deregister_range(int start)
-{
-	struct d_error_reg	*entry;
-
-	d_list_for_each_entry(entry, &g_error_reg_list, er_link) {
-		if (!entry->er_alloc)
-			break;
-		if (entry->er_base == start) {
-			d_list_del(&entry->er_link);
-			D_FREE(entry);
-			return;
-		}
-	}
-	D_ERROR("Attempted to deregister non-existent error range from %d\n",
-		start);
-}
-
 const char *
-d_errdesc(int errnum)
+d_errdesc(enum daos_error_number errnum)
 {
 	struct d_error_reg *entry;
-	static char buf[D_ERR_BUF_SIZE];
+	static char         buf[D_ERR_BUF_SIZE];
 
 	if (errnum == DER_SUCCESS)
 		return "Success";
@@ -149,7 +90,7 @@ d_errdesc(int errnum)
 	if (errnum > 0)
 		goto out;
 
-	errnum = D_ABS(errnum);
+	errnum = -errnum;
 
 	d_list_for_each_entry(entry, &g_error_reg_list, er_link) {
 		if (errnum <= entry->er_base || errnum >= entry->er_limit)

--- a/src/gurt/errno.c
+++ b/src/gurt/errno.c
@@ -50,7 +50,7 @@ d_err_init(void)
 }
 
 const char *
-d_errstr(enum daos_error_number errnum)
+d_errstr(int errnum)
 {
 	struct d_error_reg *entry;
 
@@ -73,7 +73,7 @@ out:
 }
 
 const char *
-d_errdesc(enum daos_error_number errnum)
+d_errdesc(int errnum)
 {
 	struct d_error_reg *entry;
 	static char         buf[D_ERR_BUF_SIZE];

--- a/src/gurt/errno.c
+++ b/src/gurt/errno.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -16,11 +16,11 @@
 static D_LIST_HEAD(g_error_reg_list);
 
 struct d_error_reg {
-	d_list_t		er_link;
-	int			er_base;
-	int			er_limit;
-	const char * const	*er_strings;
-	const char *const       *er_strerror;
+	d_list_t           er_link;
+	int                er_base;
+	int                er_limit;
+	const char *const *er_strings;
+	const char *const *er_strerror;
 };
 
 #define D_DEFINE_COMP_ERRSTR(name, base)                                                           \
@@ -39,10 +39,9 @@ struct d_error_reg {
 
 D_FOREACH_ERR_RANGE(D_DEFINE_COMP_ERRSTR)
 
-#define D_ADD_LIST(name, base)					\
-		d_list_add_tail(&g_##name##_errreg.er_link, &g_error_reg_list);
+#define D_ADD_LIST(name, base) d_list_add_tail(&g_##name##_errreg.er_link, &g_error_reg_list);
 
-#define D_ERR_BUF_SIZE 32
+#define D_ERR_BUF_SIZE         32
 
 static __attribute__((constructor)) void
 d_err_init(void)

--- a/src/gurt/tests/SConscript
+++ b/src/gurt/tests/SConscript
@@ -7,7 +7,6 @@
 import os
 
 TEST_SRC = ['test_gurt.c', 'test_gurt_telem_producer.c']
-TEST_SRC = []
 
 
 def scons():

--- a/src/gurt/tests/SConscript
+++ b/src/gurt/tests/SConscript
@@ -7,6 +7,7 @@
 import os
 
 TEST_SRC = ['test_gurt.c', 'test_gurt_telem_producer.c']
+TEST_SRC = []
 
 
 def scons():

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -271,6 +271,7 @@ extern "C" {
 	DER_ERR_##name##_BASE = (base),                                                            \
 	D_FOREACH_##name##_ERR(D_DEFINE_ERRNO) DER_ERR_##name##_LIMIT,
 
+/** The actual error codes */
 enum daos_error_number {
 	/** Return value representing success */
 	DER_SUCCESS = 0,
@@ -286,7 +287,7 @@ enum daos_error_number {
  * \return	String value for error code or DER_UNKNOWN
  */
 const char *
-d_errstr(enum daos_error_number errnum);
+d_errstr(int errnum);
 
 /** Return an error description string associated with a registered gurt errno.
  *
@@ -296,7 +297,7 @@ d_errstr(enum daos_error_number errnum);
  * 			number is unknown.
  */
 const char *
-d_errdesc(enum daos_error_number errnum);
+d_errdesc(int errnum);
 
 /** @}
  */

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -267,79 +267,36 @@ extern "C" {
 #define D_DEFINE_ERRDESC(name, value, desc) #desc,
 
 /** Preprocessor machinery to define a consecutive range of error numbers */
-#define D_DEFINE_RANGE_ERRNO(name, base)			\
-	enum {							\
-		DER_ERR_##name##_BASE		=	(base),	\
-		D_FOREACH_##name##_ERR(D_DEFINE_ERRNO)		\
-		DER_ERR_##name##_LIMIT,				\
-	};
+#define D_DEFINE_RANGE_ERRNO(name, base)                                                           \
+	DER_ERR_##name##_BASE = (base),                                                            \
+	D_FOREACH_##name##_ERR(D_DEFINE_ERRNO) DER_ERR_##name##_LIMIT,
 
-/** Preprocessor machinery to define error strings for a consecutive range of error numbers */
-#define D_DEFINE_RANGE_ERRSTR(name)				\
-	static const char * const g_##name##_error_strings[] = {\
-		D_FOREACH_##name##_ERR(D_DEFINE_ERRSTR)		\
-	}; \
-	static const char * const g_##name##_strerror[] = {	\
-		D_FOREACH_##name##_ERR(D_DEFINE_ERRDESC)	\
-	};
-
-D_FOREACH_ERR_RANGE(D_DEFINE_RANGE_ERRNO)
-
-/** Macro to register a range defined using D_DEFINE_RANGE macros */
-#define D_REGISTER_RANGE(name)				\
-	d_errno_register_range(DER_ERR_##name##_BASE,	\
-			       DER_ERR_##name##_LIMIT,	\
-			       g_##name##_error_strings,\
-			       g_##name##_strerror)
-
-/** Macro to deregister a range defined using D_DEFINE_RANGE macros */
-#define D_DEREGISTER_RANGE(name)			\
-	d_errno_deregister_range(DER_ERR_##name##_BASE)
-
-/** Return value representing success */
-#define DER_SUCCESS	0
-/** Unknown error */
-#define DER_UNKNOWN	(DER_ERR_GURT_BASE + 500000)
+enum daos_error_number {
+	/** Return value representing success */
+	DER_SUCCESS = 0,
+	D_FOREACH_ERR_RANGE(D_DEFINE_RANGE_ERRNO)
+	/** Unknown error value */
+	DER_UNKNOWN = (DER_ERR_GURT_BASE + 500000),
+};
 
 /** Return a string associated with a registered gurt errno
  *
- * \param[in]	rc	The error code
+ * \param[in]	errnum	The error code
  *
  * \return	String value for error code or DER_UNKNOWN
  */
-const char *d_errstr(int rc);
-
-/** Register error codes with gurt.  Use D_REGISTER_RANGE.
- *
- * \param[in]	start		Start of error range. Actual errors start at
- *				\p start + 1
- * \param[in]	end		End of range. All error codes should be less
- *				than \p end
- * \param[in]	error_strings	Array of strings. Must be one per
- *				code in the range
- * \param[in]	strerror	Array of strings. Must be one per
- *				code in the range
- *
- * \return	0 on success, otherwise error code
- */
-int d_errno_register_range(int start, int end,
-			   const char * const *error_strings,
-			   const char * const *strerror);
-
-/** De-register error codes with gurt.  Use D_DEREGISTER_RANGE.
- *
- * \param[in]	start	Start of error range
- */
-void d_errno_deregister_range(int start);
+const char *
+d_errstr(enum daos_error_number errnum);
 
 /** Return an error description string associated with a registered gurt errno.
  *
  * \param[in]	errnum	The error code
  *
- * \return		The error description string, or an "Unknown
- *			error nnn" message if the error number is unknown.
+ * \return		The error description string, or an "Unknown error nnn" message if the error
+ * 			number is unknown.
  */
-const char *d_errdesc(int errnum);
+const char *
+d_errdesc(enum daos_error_number errnum);
 
 /** @}
  */


### PR DESCRIPTION
Newer versions of compilers can perform type checking of enums
so put daos error numbers in a named enum.

Remove some dead code for adding error numbers dynamically.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
