### PR TITLE
DAOS-13575 control: Do not allow zero system_ram_reserved in config (…

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -188,6 +188,7 @@ const (
 	ServerConfigRamdiskOverMaxMem
 	ServerConfigScmDiffClass
 	ServerConfigEngineBdevRolesMismatch
+	ServerConfigSysRsvdZero
 )
 
 // SPDK library bindings codes

--- a/src/control/server/config/faults.go
+++ b/src/control/server/config/faults.go
@@ -111,6 +111,11 @@ var (
 		"md-on-ssd bdev roles have been set in some but not all engine configs",
 		"set bdev roles on all engines or remove all bdev role assignments in config",
 	)
+	FaultConfigSysRsvdZero = serverConfigFault(
+		code.ServerConfigSysRsvdZero,
+		"`system_ram_reserved` is set to zero in server config",
+		"set `system_ram_reserved` to a positive integer value in config",
+	)
 )
 
 func FaultConfigDuplicateFabric(curIdx, seenIdx int) *fault.Fault {

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -640,6 +640,10 @@ func (cfg *Server) Validate(log logging.Logger) (err error) {
 		return FaultConfigControlMetadataNoPath
 	}
 
+	if cfg.SystemRamReserved <= 0 {
+		return FaultConfigSysRsvdZero
+	}
+
 	// A config without engines is valid when initially discovering hardware prior to adding
 	// per-engine sections with device allocations.
 	if len(cfg.Engines) == 0 {

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -528,6 +528,12 @@ func TestServerConfig_Validation(t *testing.T) {
 			expErr: storage.FaultConfigRamdiskUnderMinMem(humanize.GiByte*3,
 				storage.MinRamdiskMem),
 		},
+		"zero system ram reserved": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithSystemRamReserved(0)
+			},
+			expErr: FaultConfigSysRsvdZero,
+		},
 		"control metadata multi-engine": {
 			extraConfig: func(c *Server) *Server {
 				return c.WithControlMetadata(storage.ControlMetadata{


### PR DESCRIPTION
…#12292)

Currently the value can be set to 0, this should be disallowed as some space should be reserved for the system when calculating RAM-disk sizes.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
