### PR TITLE
DAOS-13642 mgmt: Fix ds_mgmt_drpc_pool_create leak

### DIFF
--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -486,13 +486,12 @@ ds_mgmt_drpc_pool_create(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 
 	if (req->n_properties > 0) {
 		prop = daos_prop_merge(base_props, req_props);
-		daos_prop_free(req_props);
-		daos_prop_free(base_props);
 		if (prop == NULL) {
 			D_GOTO(out, rc = -DER_NOMEM);
 		}
 	} else {
 		prop = base_props;
+		base_props = NULL;
 	}
 
 	/* Ranks to allocate targets (in) & svc for pool replicas (out). */
@@ -521,7 +520,10 @@ out:
 
 	mgmt__pool_create_req__free_unpacked(req, &alloc.alloc);
 
+	daos_prop_free(base_props);
+	daos_prop_free(req_props);
 	daos_prop_free(prop);
+
 	if (targets != NULL)
 		d_rank_list_free(targets);
 


### PR DESCRIPTION
The ds_mgmt_drpc_pool_create function may leak req_props.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
