### PR TITLE
DAOS-13558 control: Fix bdev count check on scan with vmd (#12305)

### DIFF
--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -891,7 +891,7 @@ func correctSSDCounts(log logging.Logger, sd *storageDetails) error {
 		if ssds.HasVMD() {
 			// If addresses are for VMD backing devices, convert to the logical VMD
 			// endpoint address as this is what is expected in the server config.
-			newAddrSet, err := ssds.BackingToVMDAddresses(log)
+			newAddrSet, err := ssds.BackingToVMDAddresses()
 			if err != nil {
 				return errors.Wrap(err, "converting backing addresses to vmd")
 			}

--- a/src/control/lib/hardware/pci.go
+++ b/src/control/lib/hardware/pci.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
-
-	"github.com/daos-stack/daos/src/control/logging"
 )
 
 const (
@@ -374,7 +372,7 @@ func (pas *PCIAddressSet) HasVMD() bool {
 // e.g. [5d0505:01:00.0, 5d0505:03:00.0] -> [0000:5d:05.5].
 //
 // Many assumptions are made as to the input and output PCI address structure in the conversion.
-func (pas *PCIAddressSet) BackingToVMDAddresses(log logging.Logger) (*PCIAddressSet, error) {
+func (pas *PCIAddressSet) BackingToVMDAddresses() (*PCIAddressSet, error) {
 	if pas == nil {
 		return nil, errors.New("PCIAddressSet is nil")
 	}
@@ -394,7 +392,6 @@ func (pas *PCIAddressSet) BackingToVMDAddresses(log logging.Logger) (*PCIAddress
 			return nil, err
 		}
 
-		log.Debugf("replacing backing device %s with vmd %s", inAddr, vmdAddr)
 		if err := outAddrs.Add(vmdAddr); err != nil {
 			return nil, err
 		}

--- a/src/control/lib/hardware/pci_test.go
+++ b/src/control/lib/hardware/pci_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common/test"
-	"github.com/daos-stack/daos/src/control/logging"
 )
 
 func mockPCIBus(args ...uint8) *PCIBus {
@@ -315,16 +314,13 @@ func TestHardware_PCIAddressSet_BackingToVMDAddresses(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
-
 			addrSet, gotErr := NewPCIAddressSet(tc.inAddrs...)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
 			}
 
-			gotAddrs, gotErr := addrSet.BackingToVMDAddresses(log)
+			gotAddrs, gotErr := addrSet.BackingToVMDAddresses()
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -30,7 +30,7 @@ type EnvOptions struct {
 	EnableVMD    bool                    // flag if VMD functionality should be enabled
 }
 
-func (eo *EnvOptions) sanitizeAllowList(log logging.Logger) error {
+func (eo *EnvOptions) sanitizeAllowList() error {
 	if eo == nil {
 		return errors.New("nil EnvOptions")
 	}
@@ -39,7 +39,7 @@ func (eo *EnvOptions) sanitizeAllowList(log logging.Logger) error {
 	}
 
 	// DPDK will not accept VMD backing device addresses so convert to VMD addresses
-	newSet, err := eo.PCIAllowList.BackingToVMDAddresses(log)
+	newSet, err := eo.PCIAllowList.BackingToVMDAddresses()
 	if err != nil {
 		return err
 	}

--- a/src/control/lib/spdk/spdk_default.go
+++ b/src/control/lib/spdk/spdk_default.go
@@ -86,7 +86,7 @@ func (ei *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
 	// Only print error and more severe to stderr.
 	C.spdk_log_set_print_level(C.SPDK_LOG_ERROR)
 
-	if err := opts.sanitizeAllowList(log); err != nil {
+	if err := opts.sanitizeAllowList(); err != nil {
 		return errors.Wrap(err, "sanitizing PCI include list")
 	}
 

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -340,6 +340,9 @@ type NvmeController struct {
 
 // UpdateSmd adds or updates SMD device entry for an NVMe Controller.
 func (nc *NvmeController) UpdateSmd(newDev *SmdDevice) {
+	if nc == nil {
+		return
+	}
 	for _, exstDev := range nc.SmdDevices {
 		if newDev.UUID == exstDev.UUID {
 			*exstDev = *newDev
@@ -352,6 +355,9 @@ func (nc *NvmeController) UpdateSmd(newDev *SmdDevice) {
 
 // Capacity returns the cumulative total bytes of all namespace sizes.
 func (nc *NvmeController) Capacity() (tb uint64) {
+	if nc == nil {
+		return 0
+	}
 	for _, n := range nc.Namespaces {
 		tb += n.Size
 	}
@@ -440,6 +446,17 @@ func (ncs *NvmeControllers) Update(ctrlrs ...NvmeController) {
 			*ncs = append(*ncs, &newCtrlr)
 		}
 	}
+}
+
+// Addresses returns a hardware.PCIAddressSet pointer to controller addresses.
+func (ncs NvmeControllers) Addresses() (*hardware.PCIAddressSet, error) {
+	pas := hardware.MustNewPCIAddressSet()
+	for _, c := range ncs {
+		if err := pas.AddStrings(c.PciAddr); err != nil {
+			return nil, err
+		}
+	}
+	return pas, nil
 }
 
 // NvmeAioDevice returns struct representing an emulated NVMe AIO device (file or kdev).

--- a/src/control/server/storage/bdev/backend_vmd.go
+++ b/src/control/server/storage/bdev/backend_vmd.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2021-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -21,24 +21,17 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
-// getVMD returns VMD endpoint address when provided string is a VMD backing device PCI address.
-// If the input string is not a VMD backing device PCI address, hardware.ErrNotVMDBackingAddress
-// is returned.
-func getVMD(inAddr string) (*hardware.PCIAddress, error) {
-	addr, err := hardware.NewPCIAddress(inAddr)
-	if err != nil {
-		return nil, errors.Wrap(err, "controller pci address invalid")
-	}
-
-	return addr.BackingToVMDAddress()
-}
-
 // mapVMDToBackingDevs stores found vmd backing device details under vmd address key.
 func mapVMDToBackingDevs(foundCtrlrs storage.NvmeControllers) (map[string]storage.NvmeControllers, error) {
 	vmds := make(map[string]storage.NvmeControllers)
 
 	for _, ctrlr := range foundCtrlrs {
-		vmdAddr, err := getVMD(ctrlr.PciAddr)
+		addr, err := hardware.NewPCIAddress(ctrlr.PciAddr)
+		if err != nil {
+			return nil, errors.Wrap(err, "controller pci address invalid")
+		}
+
+		vmdAddr, err := addr.BackingToVMDAddress()
 		if err != nil {
 			if err == hardware.ErrNotVMDBackingAddress {
 				continue
@@ -61,8 +54,13 @@ func mapVMDToBackingDevs(foundCtrlrs storage.NvmeControllers) (map[string]storag
 func mapVMDToBackingAddrs(foundCtrlrs storage.NvmeControllers) (map[string]*hardware.PCIAddressSet, error) {
 	vmds := make(map[string]*hardware.PCIAddressSet)
 
-	for _, ctrlr := range foundCtrlrs {
-		vmdAddr, err := getVMD(ctrlr.PciAddr)
+	ctrlrAddrs, err := foundCtrlrs.Addresses()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, addr := range ctrlrAddrs.Addresses() {
+		vmdAddr, err := addr.BackingToVMDAddress()
 		if err != nil {
 			if err == hardware.ErrNotVMDBackingAddress {
 				continue
@@ -75,7 +73,7 @@ func mapVMDToBackingAddrs(foundCtrlrs storage.NvmeControllers) (map[string]*hard
 		}
 
 		// add backing device address to vmd address key in map
-		if err := vmds[vmdAddr.String()].AddStrings(ctrlr.PciAddr); err != nil {
+		if err := vmds[vmdAddr.String()].Add(addr); err != nil {
 			return nil, err
 		}
 	}
@@ -218,14 +216,13 @@ func vmdFilterAddresses(log logging.Logger, inReq *storage.BdevPrepareRequest, v
 	}
 
 	// Convert any VMD backing device addresses to endpoint addresses as the input vmdPCIAddrs
-	// are what we are using for filters and these are VMD endpoint addresses.
-	// FIXME: This imposes a limitation in that individual backing devices cannot be allowed or
-	//        blocked independently, see if this can be mitigated against.
-	inAllowList, err = inAllowList.BackingToVMDAddresses(log)
+	// are what we are using for filters and these are VMD endpoint addresses. This imposes a
+	// limitation in that individual backing devices cannot be allowed or blocked independently.
+	inAllowList, err = inAllowList.BackingToVMDAddresses()
 	if err != nil {
 		return
 	}
-	inBlockList, err = inBlockList.BackingToVMDAddresses(log)
+	inBlockList, err = inBlockList.BackingToVMDAddresses()
 	if err != nil {
 		return
 	}

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -644,6 +644,7 @@ func scanBdevTiers(log logging.Logger, vmdEnabled, direct bool, cfg *Config, cac
 	}
 
 	var bsr BdevScanResponse
+	scanOrCache := "scanned"
 	if direct {
 		req := BdevScanRequest{
 			DeviceList: bdevs,
@@ -658,14 +659,16 @@ func scanBdevTiers(log logging.Logger, vmdEnabled, direct bool, cfg *Config, cac
 		if cache == nil {
 			cache = &BdevScanResponse{}
 		}
-		log.Debugf("using controllers from cache %q", cache.Controllers)
 		bsr = *cache
+		scanOrCache = "cached"
 	}
-	log.Debugf("bdevs in cfg: %s, scanned: %+v (direct=%v)", bdevs, bsr, direct)
+	log.Debugf("bdevs in cfg: %s, %s: %+v", bdevs, scanOrCache, bsr)
+
+	// Build slice of bdevs-per-tier from the entire scan response.
 
 	bdevCfgs := cfg.Tiers.BdevConfigs()
 	results := make([]BdevTierScanResult, 0, len(bdevCfgs))
-	resultBdevs := 0
+	resultBdevCount := 0
 	for _, bc := range bdevCfgs {
 		if bc.Bdev.DeviceList.Len() == 0 {
 			continue
@@ -674,15 +677,25 @@ func scanBdevTiers(log logging.Logger, vmdEnabled, direct bool, cfg *Config, cac
 		if err != nil {
 			return nil, errors.Wrapf(err, "filter scan cache for tier-%d", bc.Tier)
 		}
-		resultBdevs += len(fbsr.Controllers)
 		results = append(results, BdevTierScanResult{
 			Tier: bc.Tier, Result: fbsr,
 		})
+
+		// Keep tally of total number of controllers added to results.
+		cpas, err := fbsr.Controllers.Addresses()
+		if err != nil {
+			return nil, errors.Wrap(err, "get controller pci addresses")
+		}
+		cpas, err = cpas.BackingToVMDAddresses()
+		if err != nil {
+			return nil, errors.Wrap(err, "convert backing device to vmd domain addresses")
+		}
+		resultBdevCount += cpas.Len()
 	}
 
-	if resultBdevs != bdevs.Len() {
-		log.Errorf("Unexpected scan results, wanted %d controllers got %d", bdevs.Len(),
-			resultBdevs)
+	if resultBdevCount != bdevs.Len() {
+		log.Noticef("Unexpected scan results, wanted %d controllers got %d", bdevs.Len(),
+			resultBdevCount)
 	}
 
 	return results, nil


### PR DESCRIPTION
Bdev count check fails during dmg storage query usage when scanning
storage because the comparison is made between the number of detected
backing devices behind VMD rather than the number of VMDs (as
specified in the config file). Fix by resolving the backing devices
back to the VMD devices before comparing the counts.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
