### PR TITLE
Revert "DAOS-13558 control: Fix bdev count check on scan with vmd"

### DIFF
--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -891,7 +891,7 @@ func correctSSDCounts(log logging.Logger, sd *storageDetails) error {
 		if ssds.HasVMD() {
 			// If addresses are for VMD backing devices, convert to the logical VMD
 			// endpoint address as this is what is expected in the server config.
-			newAddrSet, err := ssds.BackingToVMDAddresses()
+			newAddrSet, err := ssds.BackingToVMDAddresses(log)
 			if err != nil {
 				return errors.Wrap(err, "converting backing addresses to vmd")
 			}

--- a/src/control/lib/hardware/pci.go
+++ b/src/control/lib/hardware/pci.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 const (
@@ -372,7 +374,7 @@ func (pas *PCIAddressSet) HasVMD() bool {
 // e.g. [5d0505:01:00.0, 5d0505:03:00.0] -> [0000:5d:05.5].
 //
 // Many assumptions are made as to the input and output PCI address structure in the conversion.
-func (pas *PCIAddressSet) BackingToVMDAddresses() (*PCIAddressSet, error) {
+func (pas *PCIAddressSet) BackingToVMDAddresses(log logging.Logger) (*PCIAddressSet, error) {
 	if pas == nil {
 		return nil, errors.New("PCIAddressSet is nil")
 	}
@@ -392,6 +394,7 @@ func (pas *PCIAddressSet) BackingToVMDAddresses() (*PCIAddressSet, error) {
 			return nil, err
 		}
 
+		log.Debugf("replacing backing device %s with vmd %s", inAddr, vmdAddr)
 		if err := outAddrs.Add(vmdAddr); err != nil {
 			return nil, err
 		}

--- a/src/control/lib/hardware/pci_test.go
+++ b/src/control/lib/hardware/pci_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 func mockPCIBus(args ...uint8) *PCIBus {
@@ -314,13 +315,16 @@ func TestHardware_PCIAddressSet_BackingToVMDAddresses(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
 			addrSet, gotErr := NewPCIAddressSet(tc.inAddrs...)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
 			}
 
-			gotAddrs, gotErr := addrSet.BackingToVMDAddresses()
+			gotAddrs, gotErr := addrSet.BackingToVMDAddresses(log)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -30,7 +30,7 @@ type EnvOptions struct {
 	EnableVMD    bool                    // flag if VMD functionality should be enabled
 }
 
-func (eo *EnvOptions) sanitizeAllowList() error {
+func (eo *EnvOptions) sanitizeAllowList(log logging.Logger) error {
 	if eo == nil {
 		return errors.New("nil EnvOptions")
 	}
@@ -39,7 +39,7 @@ func (eo *EnvOptions) sanitizeAllowList() error {
 	}
 
 	// DPDK will not accept VMD backing device addresses so convert to VMD addresses
-	newSet, err := eo.PCIAllowList.BackingToVMDAddresses()
+	newSet, err := eo.PCIAllowList.BackingToVMDAddresses(log)
 	if err != nil {
 		return err
 	}

--- a/src/control/lib/spdk/spdk_default.go
+++ b/src/control/lib/spdk/spdk_default.go
@@ -86,7 +86,7 @@ func (ei *EnvImpl) InitSPDKEnv(log logging.Logger, opts *EnvOptions) error {
 	// Only print error and more severe to stderr.
 	C.spdk_log_set_print_level(C.SPDK_LOG_ERROR)
 
-	if err := opts.sanitizeAllowList(); err != nil {
+	if err := opts.sanitizeAllowList(log); err != nil {
 		return errors.Wrap(err, "sanitizing PCI include list")
 	}
 

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -340,9 +340,6 @@ type NvmeController struct {
 
 // UpdateSmd adds or updates SMD device entry for an NVMe Controller.
 func (nc *NvmeController) UpdateSmd(newDev *SmdDevice) {
-	if nc == nil {
-		return
-	}
 	for _, exstDev := range nc.SmdDevices {
 		if newDev.UUID == exstDev.UUID {
 			*exstDev = *newDev
@@ -355,9 +352,6 @@ func (nc *NvmeController) UpdateSmd(newDev *SmdDevice) {
 
 // Capacity returns the cumulative total bytes of all namespace sizes.
 func (nc *NvmeController) Capacity() (tb uint64) {
-	if nc == nil {
-		return 0
-	}
 	for _, n := range nc.Namespaces {
 		tb += n.Size
 	}
@@ -446,17 +440,6 @@ func (ncs *NvmeControllers) Update(ctrlrs ...NvmeController) {
 			*ncs = append(*ncs, &newCtrlr)
 		}
 	}
-}
-
-// Addresses returns a hardware.PCIAddressSet pointer to controller addresses.
-func (ncs NvmeControllers) Addresses() (*hardware.PCIAddressSet, error) {
-	pas := hardware.MustNewPCIAddressSet()
-	for _, c := range ncs {
-		if err := pas.AddStrings(c.PciAddr); err != nil {
-			return nil, err
-		}
-	}
-	return pas, nil
 }
 
 // NvmeAioDevice returns struct representing an emulated NVMe AIO device (file or kdev).

--- a/src/control/server/storage/bdev/backend_vmd.go
+++ b/src/control/server/storage/bdev/backend_vmd.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2021-2022 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -21,17 +21,24 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
+// getVMD returns VMD endpoint address when provided string is a VMD backing device PCI address.
+// If the input string is not a VMD backing device PCI address, hardware.ErrNotVMDBackingAddress
+// is returned.
+func getVMD(inAddr string) (*hardware.PCIAddress, error) {
+	addr, err := hardware.NewPCIAddress(inAddr)
+	if err != nil {
+		return nil, errors.Wrap(err, "controller pci address invalid")
+	}
+
+	return addr.BackingToVMDAddress()
+}
+
 // mapVMDToBackingDevs stores found vmd backing device details under vmd address key.
 func mapVMDToBackingDevs(foundCtrlrs storage.NvmeControllers) (map[string]storage.NvmeControllers, error) {
 	vmds := make(map[string]storage.NvmeControllers)
 
 	for _, ctrlr := range foundCtrlrs {
-		addr, err := hardware.NewPCIAddress(ctrlr.PciAddr)
-		if err != nil {
-			return nil, errors.Wrap(err, "controller pci address invalid")
-		}
-
-		vmdAddr, err := addr.BackingToVMDAddress()
+		vmdAddr, err := getVMD(ctrlr.PciAddr)
 		if err != nil {
 			if err == hardware.ErrNotVMDBackingAddress {
 				continue
@@ -54,13 +61,8 @@ func mapVMDToBackingDevs(foundCtrlrs storage.NvmeControllers) (map[string]storag
 func mapVMDToBackingAddrs(foundCtrlrs storage.NvmeControllers) (map[string]*hardware.PCIAddressSet, error) {
 	vmds := make(map[string]*hardware.PCIAddressSet)
 
-	ctrlrAddrs, err := foundCtrlrs.Addresses()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, addr := range ctrlrAddrs.Addresses() {
-		vmdAddr, err := addr.BackingToVMDAddress()
+	for _, ctrlr := range foundCtrlrs {
+		vmdAddr, err := getVMD(ctrlr.PciAddr)
 		if err != nil {
 			if err == hardware.ErrNotVMDBackingAddress {
 				continue
@@ -73,7 +75,7 @@ func mapVMDToBackingAddrs(foundCtrlrs storage.NvmeControllers) (map[string]*hard
 		}
 
 		// add backing device address to vmd address key in map
-		if err := vmds[vmdAddr.String()].Add(addr); err != nil {
+		if err := vmds[vmdAddr.String()].AddStrings(ctrlr.PciAddr); err != nil {
 			return nil, err
 		}
 	}
@@ -216,13 +218,14 @@ func vmdFilterAddresses(log logging.Logger, inReq *storage.BdevPrepareRequest, v
 	}
 
 	// Convert any VMD backing device addresses to endpoint addresses as the input vmdPCIAddrs
-	// are what we are using for filters and these are VMD endpoint addresses. This imposes a
-	// limitation in that individual backing devices cannot be allowed or blocked independently.
-	inAllowList, err = inAllowList.BackingToVMDAddresses()
+	// are what we are using for filters and these are VMD endpoint addresses.
+	// FIXME: This imposes a limitation in that individual backing devices cannot be allowed or
+	//        blocked independently, see if this can be mitigated against.
+	inAllowList, err = inAllowList.BackingToVMDAddresses(log)
 	if err != nil {
 		return
 	}
-	inBlockList, err = inBlockList.BackingToVMDAddresses()
+	inBlockList, err = inBlockList.BackingToVMDAddresses(log)
 	if err != nil {
 		return
 	}

--- a/src/control/server/storage/bdev_test.go
+++ b/src/control/server/storage/bdev_test.go
@@ -20,21 +20,6 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 )
 
-const (
-	vmdBackingAddr1a = "5d0505:01:00.0"
-	vmdBackingAddr1b = "5d0505:03:00.0"
-	vmdAddr2         = "0000:7d:05.5"
-	vmdBackingAddr2a = "7d0505:01:00.0"
-	vmdBackingAddr2b = "7d0505:03:00.0"
-)
-
-func ctrlrsFromPCIAddrs(addrs ...string) (ncs NvmeControllers) {
-	for _, addr := range addrs {
-		ncs = append(ncs, &NvmeController{PciAddr: addr})
-	}
-	return
-}
-
 func Test_NvmeDevState(t *testing.T) {
 	for name, tc := range map[string]struct {
 		state  NvmeDevState
@@ -200,45 +185,22 @@ func Test_NvmeController_Update(t *testing.T) {
 	test.AssertEqual(t, len(mockCtrlrs), 7, "expected 7")
 }
 
-func Test_NvmeController_Addresses(t *testing.T) {
-	for name, tc := range map[string]struct {
-		ctrlrs   NvmeControllers
-		expAddrs []string
-		expErr   error
-	}{
-		"two vmd endpoints with two backing devices": {
-			ctrlrs: ctrlrsFromPCIAddrs(vmdBackingAddr1a, vmdBackingAddr1b,
-				vmdBackingAddr2a, vmdBackingAddr2b),
-			expAddrs: []string{
-				vmdBackingAddr1a,
-				vmdBackingAddr2a,
-				vmdBackingAddr1b,
-				vmdBackingAddr2b,
-			},
-		},
-		"no addresses": {
-			expAddrs: []string{},
-		},
-		"invalid address": {
-			ctrlrs: ctrlrsFromPCIAddrs("a"),
-			expErr: errors.New("unable to parse"),
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			gotAddrs, gotErr := tc.ctrlrs.Addresses()
-			test.CmpErr(t, tc.expErr, gotErr)
-			if gotErr != nil {
-				return
-			}
-
-			if diff := cmp.Diff(tc.expAddrs, gotAddrs.Strings()); diff != "" {
-				t.Fatalf("unexpected output address set (-want, +got):\n%s\n", diff)
-			}
-		})
-	}
-}
-
 func Test_filterBdevScanResponse(t *testing.T) {
+	const (
+		vmdAddr1         = "0000:5d:05.5"
+		vmdBackingAddr1a = "5d0505:01:00.0"
+		vmdBackingAddr1b = "5d0505:03:00.0"
+		vmdAddr2         = "0000:7d:05.5"
+		vmdBackingAddr2a = "7d0505:01:00.0"
+		vmdBackingAddr2b = "7d0505:03:00.0"
+	)
+	ctrlrsFromPCIAddrs := func(addrs ...string) (ncs NvmeControllers) {
+		for _, addr := range addrs {
+			ncs = append(ncs, &NvmeController{PciAddr: addr})
+		}
+		return
+	}
+
 	for name, tc := range map[string]struct {
 		addrs    []string
 		scanResp *BdevScanResponse


### PR DESCRIPTION
Reverts daos-stack/daos#12305