### PR TITLE
DAOS-13569 gurt: limit log size more accurate

### DIFF
--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -68,6 +68,8 @@ struct d_log_state {
 	int		 log_old_fd;
 	/** current size of log file */
 	uint64_t	 log_size;
+	/** log size of last time check */
+	uint64_t	 log_last_check_size;
 	/** max size of log file */
 	uint64_t	 log_size_max;
 	/** Callback to get thread id and ULT id */
@@ -358,6 +360,33 @@ static __thread uint64_t pre_err_time;
 
 #define LOG_BUF_SIZE	(16 << 10)
 
+static bool
+log_exceed_threshold(void)
+{
+	struct stat	st;
+	int		rc;
+
+	if (!merge_stderr)
+		goto out;
+
+	/**
+	 * if we merge stderr to log file which is not
+	 * calculated by log_size, to avoid exceeding threshold
+	 * too much, log_size will be updated with fstat if log
+	 * size increased by 2% of max size every time.
+	 */
+	if ((mst.log_size - mst.log_last_check_size) < (mst.log_size_max / 50))
+		goto out;
+
+	rc = fstat(mst.log_fd, &st);
+	if (!rc)
+		mst.log_size = st.st_size;
+
+	mst.log_last_check_size = mst.log_size;
+out:
+	return mst.log_size + mst.log_buf_nob >= mst.log_size_max;
+}
+
 /**
  * This function can do a few things:
  * - copy log message @msg to log buffer
@@ -405,7 +434,7 @@ d_log_write(char *msg, int len, bool flush)
 	if (mst.log_buf_nob == 0)
 		return 0; /* nothing to write */
 
-	if (mst.log_size + mst.log_buf_nob >= mst.log_size_max) {
+	if (log_exceed_threshold()) {
 		/* exceeds the size threshold, rename the current log file
 		 * as backup, create a new log file.
 		 */
@@ -464,6 +493,7 @@ d_log_write(char *msg, int len, bool flush)
 		}
 
 		mst.log_size = 0;
+		mst.log_last_check_size = 0;
 	}
 
 	/* flush the cached log messages */


### PR DESCRIPTION
if we merge stderr to log file which is not
calculated by log_size, to avoid exceeding threshold too much, log_size will be updated with fstat if log size increased by 2% of max size every time.

Test-tags: daos_test
Test-nvme: auto_md_on_ssd
Required-githooks: true

