### PR TITLE
DAOS-13660 client: fixes to tse, array, and KV for thread safety (#11…

### DIFF
--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -590,10 +590,8 @@ dc_array_create(tse_task_t *task)
 		D_GOTO(err_put2, rc);
 	}
 
-	tse_task_schedule(open_task, false);
-	tse_task_schedule(update_task, false);
-	tse_sched_progress(tse_task2sched(task));
-
+	tse_task_schedule(open_task, true);
+	tse_task_schedule(update_task, true);
 	return rc;
 
 err_put2:
@@ -739,11 +737,9 @@ dc_array_open(tse_task_t *task)
 	}
 
 	/** Create task to open object */
-	rc = daos_task_create(DAOS_OPC_OBJ_OPEN, tse_task2sched(task),
-			      0, NULL, &open_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_OPEN, tse_task2sched(task), 0, NULL, &open_task);
 	if (rc != 0) {
-		D_ERROR("Failed to open object_open task "DF_RC"\n",
-			DP_RC(rc));
+		D_ERROR("Failed to open object_open task "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_ptask, rc);
 	}
 
@@ -762,54 +758,48 @@ dc_array_open(tse_task_t *task)
 			D_GOTO(err_put1, rc);
 		}
 
-		rc = tse_task_register_comp_cb(task, open_handle_cb, &args,
-					       sizeof(args));
+		rc = tse_task_register_comp_cb(task, open_handle_cb, &args, sizeof(args));
 		if (rc != 0) {
 			D_ERROR("Failed to register completion cb "DF_RC"\n", DP_RC(rc));
 			D_GOTO(err_put1, rc);
 		}
 
-		tse_task_schedule(open_task, false);
-		tse_sched_progress(tse_task2sched(task));
+		tse_task_schedule(open_task, true);
 		return rc;
 	}
 
-	/** Create task to fetch object metadata */
-	rc = daos_task_create(DAOS_OPC_OBJ_FETCH, tse_task2sched(task),
-			      1, &open_task, &fetch_task);
+	/** Create task to fetch object metadata depending on the open task to complete first. */
+	rc = daos_task_create(DAOS_OPC_OBJ_FETCH, tse_task2sched(task), 1, &open_task, &fetch_task);
 	if (rc != 0) {
-		D_ERROR("Failed to open object_fetch task\n");
+		D_ERROR("daos_task_create() failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_put1, rc);
 	}
 
 	/** add a prepare CB to set the args for the metadata fetch */
-	rc = tse_task_register_cbs(fetch_task, fetch_md_cb, &args,
-				   sizeof(args), NULL, NULL, 0);
+	rc = tse_task_register_cbs(fetch_task, fetch_md_cb, &args, sizeof(args), NULL, NULL, 0);
 	if (rc != 0) {
-		D_ERROR("Failed to register prep CB\n");
+		D_ERROR("tse_task_register_cbs() failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_put2, rc);
 	}
 
-	/** The upper task completes when the fetch task completes */
+	/** The API task completes when the fetch task completes */
 	rc = tse_task_register_deps(task, 1, &fetch_task);
 	if (rc != 0) {
-		D_ERROR("Failed to register dependency\n");
+		D_ERROR("tse_task_register_deps() failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_put2, rc);
 	}
 
 	/*
-	 * Allocate params for fetch task. need to do that here since we use
-	 * that as priv value for upper task to verify metadata before creating
-	 * the open handle.
+	 * Allocate params for fetch task. need to do that here since we use that as priv value for
+	 * upper task to verify metadata before creating the open handle.
 	 */
 	D_ALLOC_PTR(params);
 	if (params == NULL)
 		D_GOTO(err_put2, rc = -DER_NOMEM);
 
-	rc = tse_task_register_comp_cb(task, free_md_params_cb, &params,
-				       sizeof(params));
+	rc = tse_task_register_comp_cb(task, free_md_params_cb, &params, sizeof(params));
 	if (rc != 0) {
-		D_ERROR("Failed to register completion cb\n");
+		D_ERROR("tse_task_register_cbs() failed: "DF_RC"\n", DP_RC(rc));
 		D_FREE(params);
 		D_GOTO(err_put2, rc);
 	}
@@ -819,17 +809,14 @@ dc_array_open(tse_task_t *task)
 	daos_task_set_priv(task, params);
 
 	/** Add a completion CB on the upper task to generate the array OH */
-	rc = tse_task_register_comp_cb(task, open_handle_cb, &args,
-				       sizeof(args));
+	rc = tse_task_register_comp_cb(task, open_handle_cb, &args, sizeof(args));
 	if (rc != 0) {
-		D_ERROR("Failed to register completion cb\n");
+		D_ERROR("tse_task_register_comp_cb() failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_put2, rc);
 	}
 
-	tse_task_schedule(open_task, false);
-	tse_task_schedule(fetch_task, false);
-	tse_sched_progress(tse_task2sched(task));
-
+	tse_task_schedule(open_task, true);
+	tse_task_schedule(fetch_task, true);
 	return rc;
 err_put2:
 	tse_task_complete(fetch_task, rc);
@@ -879,9 +866,7 @@ dc_array_close(tse_task_t *task)
 		D_GOTO(err_put2, rc);
 	}
 
-	tse_task_schedule(close_task, false);
-	tse_sched_progress(tse_task2sched(task));
-
+	tse_task_schedule(close_task, true);
 	return rc;
 err_put2:
 	tse_task_complete(close_task, rc);
@@ -926,10 +911,8 @@ dc_array_destroy(tse_task_t *task)
 		D_GOTO(err_put2, rc);
 	}
 
-	tse_task_schedule(punch_task, false);
-	tse_sched_progress(tse_task2sched(task));
+	tse_task_schedule(punch_task, true);
 	array_decref(array);
-
 	return rc;
 err_put2:
 	tse_task_complete(punch_task, rc);
@@ -1128,29 +1111,27 @@ process_iod(daos_off_t start_off, daos_size_t array_size,
 
 			if (array_size <= start_off + idx) {
 				/** Don't touch buf if beyond EOF */
-				rc = daos_sgl_processor(sgl, true, sg_idx,
-							bytes_proc, noop_cb,
+				rc = daos_sgl_processor(sgl, true, sg_idx, bytes_proc, noop_cb,
 							NULL);
 			} else if (array_size > start_off + end) {
 				/** all 0s if within array size */
-				rc = daos_sgl_processor(sgl, true, sg_idx,
-							bytes_proc, zero_out_cb,
+				rc = daos_sgl_processor(sgl, true, sg_idx, bytes_proc, zero_out_cb,
 							NULL);
 			} else {
 				daos_size_t temp;
 
 				/** partial fetch in regards to EOF */
 				temp = array_size - (start_off + idx);
-				rc = daos_sgl_processor(sgl, true, sg_idx,
-							temp, noop_cb, NULL);
+				rc = daos_sgl_processor(sgl, true, sg_idx, temp, noop_cb, NULL);
 				if (rc)
 					return rc;
-				rc = daos_sgl_processor(sgl, true, sg_idx,
-							bytes_proc - temp,
+				rc = daos_sgl_processor(sgl, true, sg_idx, bytes_proc - temp,
 							zero_out_cb, NULL);
 			}
-			if (rc)
+			if (rc) {
+				D_ERROR("daos_sgl_processor() failed: "DF_RC"\n", DP_RC(rc));
 				return rc;
+			}
 			break;
 		}
 
@@ -1161,31 +1142,31 @@ process_iod(daos_off_t start_off, daos_size_t array_size,
 				" end "DF_U64" iom idx "DF_U64" idx "DF_U64"\n",
 				sg_idx->iov_idx, sg_idx->iov_offset,
 				end, iom->iom_recxs[i].rx_idx, idx);
-			rc = daos_sgl_processor(sgl, true, sg_idx, bytes_proc,
-						zero_out_cb, NULL);
-			if (rc)
+			rc = daos_sgl_processor(sgl, true, sg_idx, bytes_proc, zero_out_cb, NULL);
+			if (rc) {
+				D_ERROR("daos_sgl_processor() failed: "DF_RC"\n", DP_RC(rc));
 				return rc;
+			}
 			break;
 		}
 
 		if (idx == iom->iom_recxs[i].rx_idx) {
 			/** iom at current index, this is a valid extent */
 			bytes_proc = iom->iom_recxs[i].rx_nr;
-			rc = daos_sgl_processor(sgl, true, sg_idx, bytes_proc,
-						noop_cb, NULL);
+			rc = daos_sgl_processor(sgl, true, sg_idx, bytes_proc, noop_cb, NULL);
 			i++;
 		} else {
 			/** iom beyond current index, this is a hole */
 			bytes_proc = iom->iom_recxs[i].rx_idx - idx;
 			D_DEBUG(DB_IO, "zero out sg_idx %u/"DF_U64"/"DF_U64"\n",
-				sg_idx->iov_idx, sg_idx->iov_offset,
-				bytes_proc);
-			rc = daos_sgl_processor(sgl, true, sg_idx, bytes_proc,
-						zero_out_cb, NULL);
+				sg_idx->iov_idx, sg_idx->iov_offset, bytes_proc);
+			rc = daos_sgl_processor(sgl, true, sg_idx, bytes_proc, zero_out_cb, NULL);
 		}
 
-		if (rc)
+		if (rc) {
+			D_ERROR("daos_sgl_processor() failed: "DF_RC"\n", DP_RC(rc));
 			return rc;
+		}
 		idx += bytes_proc;
 	}
 
@@ -1223,9 +1204,8 @@ process_iomap(struct hole_params *params, daos_array_io_t *args)
 
 		iom_nr = 0;
 		for (i = 0; i < current->iod.iod_nr; i++) {
-			rc = process_iod(start_off, params->array_size, sgl,
-					 &idx, &current->iod.iod_recxs[i],
-					 &current->iom, &iom_nr);
+			rc = process_iod(start_off, params->array_size, sgl, &idx,
+					 &current->iod.iod_recxs[i], &current->iom, &iom_nr);
 			if (rc)
 				return rc;
 		}
@@ -1430,8 +1410,10 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 	}
 
 	array = array_hdl2ptr(array_oh);
-	if (array == NULL)
+	if (array == NULL) {
+		D_ERROR("Invalid array handle: "DF_RC"\n", DP_RC(-DER_NO_HDL));
 		D_GOTO(err_task, rc = -DER_NO_HDL);
+	}
 
 	if (op_type == DAOS_OPC_ARRAY_PUNCH) {
 		D_ASSERT(user_sgl == NULL);
@@ -1497,16 +1479,14 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 			continue;
 		}
 
-		rc = compute_dkey(array, array_idx, &num_records, &record_i,
-				  &dkey_val);
+		rc = compute_dkey(array, array_idx, &num_records, &record_i, &dkey_val);
 		if (rc != 0) {
 			D_ERROR("Failed to compute dkey\n");
 			D_GOTO(err_iotask, rc);
 		}
 
 		D_DEBUG(DB_IO, "DKEY IOD "DF_U64": idx = "DF_U64"\t num_records = %zu"
-			"\t record_i = "DF_U64"\n", dkey_val, array_idx, num_records,
-			record_i);
+			"\t record_i = "DF_U64"\n", dkey_val, array_idx, num_records, record_i);
 
 		/** allocate params for this dkey io */
 		D_ALLOC_PTR(params);
@@ -1515,9 +1495,8 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 		params->dkey_val = dkey_val;
 
 		/*
-		 * since we probably have multiple dkey ios, put them in linked
-		 * list to free later. Insert in decreasing order for easier
-		 * short fetch detection.
+		 * since we probably have multiple dkey ios, put them in linked list to free
+		 * later. Insert in decreasing order for easier short fetch detection.
 		 */
 		if (num_ios == 0) {
 			head = params;
@@ -1560,7 +1539,7 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 
 		/** Set integer dkey descriptor */
 		d_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
-		/** Set character akey descriptor - TODO: should be NULL*/
+		/** Set character akey descriptor - TODO: should be NULL */
 		d_iov_set(&iod->iod_name, &params->akey_val, 1);
 		/** Initialize the rest of the IOD fields */
 		iod->iod_nr	= 0;
@@ -1579,17 +1558,16 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 		dkey_records = 0;
 
 		/*
-		 * Create the IO descriptor for this dkey. If the entire range
-		 * fits in the dkey, continue to the next range to see if we can
-		 * combine it fully or partially in the current dkey IOD.
+		 * Create the IO descriptor for this dkey. If the entire range fits in the dkey,
+		 * continue to the next range to see if we can combine it fully or partially in the
+		 * current dkey IOD.
 		 */
 		do {
 			daos_off_t	old_array_idx;
 			daos_recx_t	*new_recxs;
 
 			/** add another element to recxs */
-			D_REALLOC_ARRAY(new_recxs, iod->iod_recxs,
-					iod->iod_nr, iod->iod_nr + 1);
+			D_REALLOC_ARRAY(new_recxs, iod->iod_recxs, iod->iod_nr, iod->iod_nr + 1);
 			if (new_recxs == NULL)
 				D_GOTO(err_iotask, rc = -DER_NOMEM);
 
@@ -1598,18 +1576,15 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 
 			/** set the record access for this range */
 			iod->iod_recxs[i].rx_idx = record_i;
-			iod->iod_recxs[i].rx_nr = (num_records > records) ?
-				records : num_records;
+			iod->iod_recxs[i].rx_nr = (num_records > records) ? records : num_records;
 
 			D_DEBUG(DB_IO, "%zu: index = "DF_U64", size = %zu\n",
-				u, iod->iod_recxs[i].rx_idx,
-				iod->iod_recxs[i].rx_nr);
+				u, iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr);
 
 			/*
-			 * if the current range is bigger than what the dkey can
-			 * hold, update the array index and number of records in
-			 * the current range and break to issue the I/O on the
-			 * current dkey.
+			 * If the current range is bigger than what the dkey can hold, update the
+			 * array index and number of records in the current range and break to issue
+			 * the I/O on the current dkey.
 			 */
 			if (records > num_records) {
 				array_idx += num_records;
@@ -1632,25 +1607,21 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 			array_idx = rg_iod->arr_rgs[u].rg_idx;
 
 			/*
-			 * Boundary case where number of records align with the
-			 * end boundary of the dkey. break after we have
-			 * advanced to the next range in the array iod.
+			 * Boundary case where number of records align with the end boundary of the
+			 * dkey. break after we have advanced to the next range in the array iod.
 			 */
 			if (records == num_records)
 				break;
 
 			/** process the next range in the cur dkey */
 			if (array_idx < old_array_idx + num_records &&
-			    array_idx >= ((old_array_idx + num_records) -
-					  array->chunk_size)) {
+			    array_idx >= ((old_array_idx + num_records) - array->chunk_size)) {
 				/*
-				 * verify that the dkey is the same as the one
-				 * we are working on given the array index, and
-				 * also compute the number of records left in
-				 * the dkey and the record indexin the dkey.
+				 * verify that the dkey is the same as the one we are working on
+				 * given the array index, and also compute the number of records
+				 * left in the dkey and the record indexin the dkey.
 				 */
-				rc = compute_dkey(array, array_idx,
-						  &num_records, &record_i,
+				rc = compute_dkey(array, array_idx, &num_records, &record_i,
 						  &dkey_val);
 				if (rc != 0) {
 					D_ERROR("Failed to compute dkey\n");
@@ -1666,8 +1637,7 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 		D_DEBUG(DB_IO, "DKEY IOD "DF_U64" ---------------\n", dkey_val);
 
 		/*
-		 * if the user sgl maps directly to the array range, no need to
-		 * partition it.
+		 * if the user sgl maps directly to the array range, no need to partition it.
 		 */
 		if ((op_type == DAOS_OPC_ARRAY_PUNCH) ||
 		    (1 == rg_iod->arr_nr && 1 == user_sgl->sg_nr &&
@@ -1678,27 +1648,24 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 		/** create an sgl from the user sgl for the current IOD */
 		else {
 			/* set sgl for current dkey */
-			rc = create_sgl(user_sgl, array->cell_size,
-					dkey_records, &cur_off, &cur_i, sgl);
+			rc = create_sgl(user_sgl, array->cell_size, dkey_records, &cur_off, &cur_i,
+					sgl);
 			if (rc != 0) {
-				D_ERROR("Failed to create sgl "DF_RC"\n",
-					DP_RC(rc));
+				D_ERROR("Failed to create sgl "DF_RC"\n", DP_RC(rc));
 				D_GOTO(err_iotask, rc);
 			}
 		}
-
 		params->num_records = dkey_records;
 
 		/* Create the Fetch or Update task */
 		if (op_type == DAOS_OPC_ARRAY_READ) {
 			daos_obj_fetch_t *io_arg;
 
-			rc = daos_task_create(DAOS_OPC_OBJ_FETCH,
-					      tse_task2sched(task),
-					      0, NULL, &io_task);
+			rc = daos_task_create(DAOS_OPC_OBJ_FETCH, tse_task2sched(task), 0, NULL,
+					      &io_task);
 			if (rc != 0) {
-				D_ERROR("Fetch dkey "DF_U64" failed "DF_RC"\n",
-					params->dkey_val, DP_RC(rc));
+				D_ERROR("Fetch dkey "DF_U64" failed "DF_RC"\n", params->dkey_val,
+					DP_RC(rc));
 				D_GOTO(err_iotask, rc);
 			}
 			io_arg = daos_task_get_args(io_task);
@@ -1728,16 +1695,14 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 					D_GOTO(err_iotask, rc);
 				}
 			}
-		} else if (op_type == DAOS_OPC_ARRAY_WRITE ||
-			   op_type == DAOS_OPC_ARRAY_PUNCH) {
+		} else if (op_type == DAOS_OPC_ARRAY_WRITE || op_type == DAOS_OPC_ARRAY_PUNCH) {
 			daos_obj_update_t *io_arg;
 
-			rc = daos_task_create(DAOS_OPC_OBJ_UPDATE,
-					      tse_task2sched(task),
-					      0, NULL, &io_task);
+			rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(task), 0, NULL,
+					      &io_task);
 			if (rc != 0) {
-				D_ERROR("Update dkey "DF_U64" failed "DF_RC"\n",
-					params->dkey_val, DP_RC(rc));
+				D_ERROR("Update dkey "DF_U64" failed "DF_RC"\n", params->dkey_val,
+					DP_RC(rc));
 				D_GOTO(err_iotask, rc);
 			}
 			io_arg = daos_task_get_args(io_task);
@@ -1764,9 +1729,9 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 	head_cb_registered = true;
 
 	/*
-	 * If this is a byte array, schedule the get_size task with a prep
-	 * callback that decides if the get size is necessary for short read
-	 * handling. The prep callback also handles the hole management.
+	 * If this is a byte array, schedule the get_size task with a prep callback that decides if
+	 * the get size is necessary for short read handling. The prep callback also handles the
+	 * hole management.
 	 */
 	if (op_type == DAOS_OPC_ARRAY_READ && array->byte_array) {
 		if (head == NULL) {
@@ -1790,20 +1755,18 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 			}
 
 			daos_task_set_priv(stask, sparams);
-			rc = tse_task_register_cbs(stask, check_short_read_cb,
-						   NULL, 0, NULL, NULL, 0);
+			rc = tse_task_register_cbs(stask, check_short_read_cb, NULL, 0, NULL, NULL,
+						   0);
 			if (rc) {
 				D_FREE(sparams);
 				D_GOTO(err_iotask, rc);
 			}
-
 			tse_task_list_add(stask, &io_task_list);
 		}
 	}
 
-	tse_task_list_sched(&io_task_list, false);
+	tse_task_list_sched(&io_task_list, true);
 	array_decref(array);
-	tse_sched_progress(tse_task2sched(task));
 	return 0;
 
 err_iotask:
@@ -1930,8 +1893,7 @@ dc_array_get_size(tse_task_t *task)
 	kqp->size	= args->size;
 	kqp->array	= array;
 
-	rc = daos_task_create(DAOS_OPC_OBJ_QUERY_KEY, tse_task2sched(task),
-			      0, NULL, &query_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_QUERY_KEY, tse_task2sched(task), 0, NULL, &query_task);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 
@@ -2190,8 +2152,7 @@ check_record_cb(tse_task_t *task, void *data)
 	D_DEBUG(DB_IO, "update record (%zu, %zu), iod_size %zu.\n",
 		iod->iod_recxs[0].rx_idx, iod->iod_recxs[0].rx_nr,
 		iod->iod_size);
-	rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(task), 0,
-			      NULL, &io_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(task), 0, NULL, &io_task);
 	if (rc) {
 		D_ERROR("Task create failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
@@ -2205,8 +2166,7 @@ check_record_cb(tse_task_t *task, void *data)
 	io_arg->iods	= iod;
 	io_arg->sgls	= sgl;
 
-	rc = tse_task_register_comp_cb(io_task, free_io_params_cb, &params,
-				       sizeof(params));
+	rc = tse_task_register_comp_cb(io_task, free_io_params_cb, &params, sizeof(params));
 	if (rc)
 		D_GOTO(err, rc);
 
@@ -2223,7 +2183,7 @@ check_record_cb(tse_task_t *task, void *data)
 	if (rc)
 		D_GOTO(err, rc);
 
-	rc = tse_task_schedule(io_task, false);
+	rc = tse_task_schedule(io_task, true);
 	if (rc)
 		D_GOTO(err, rc);
 
@@ -2271,8 +2231,7 @@ check_record(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val, daos_off_
 	iod->iod_recxs[0].rx_idx = record_i;
 	iod->iod_recxs[0].rx_nr = 1;
 
-	rc = daos_task_create(DAOS_OPC_OBJ_FETCH, tse_task2sched(task), 0, NULL,
-			      &io_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_FETCH, tse_task2sched(task), 0, NULL, &io_task);
 	if (rc) {
 		D_ERROR("Task create failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err, rc);
@@ -2287,8 +2246,7 @@ check_record(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val, daos_off_
 	io_arg->sgls	= sgl;
 	io_arg->ioms	= NULL;
 
-	rc = tse_task_register_comp_cb(io_task, check_record_cb, &params,
-				       sizeof(params));
+	rc = tse_task_register_comp_cb(io_task, check_record_cb, &params, sizeof(params));
 	if (rc)
 		D_GOTO(err, rc);
 
@@ -2348,8 +2306,7 @@ add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props, d_l
 	iod->iod_recxs[0].rx_idx = props->record_i;
 	iod->iod_recxs[0].rx_nr = 1;
 
-	rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(props->ptask),
-			      0, NULL, &io_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(props->ptask), 0, NULL, &io_task);
 	if (rc) {
 		D_FREE(sgl->sg_iovs);
 		D_GOTO(err, rc);
@@ -2362,8 +2319,7 @@ add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props, d_l
 	io_arg->iods	= iod;
 	io_arg->sgls	= sgl;
 
-	rc = tse_task_register_comp_cb(io_task, free_io_params_cb, &params,
-				       sizeof(params));
+	rc = tse_task_register_comp_cb(io_task, free_io_params_cb, &params, sizeof(params));
 	if (rc)
 		D_GOTO(err, rc);
 
@@ -2391,7 +2347,7 @@ adjust_array_size_task_process(tse_task_t *task, void *arg)
 	tse_task_list_del(task);
 
 	if (rc == 0)
-		tse_task_schedule(task, false);
+		tse_task_schedule(task, true);
 	else
 		tse_task_complete(task, rc);
 
@@ -2442,8 +2398,7 @@ adjust_array_size_cb(tse_task_t *task, void *data)
 				D_ASSERT(props->record_i + 1 <
 					 props->chunk_size);
 				/** Punch all records above record_i */
-				D_DEBUG(DB_IO, "Punch extent in key "DF_U64"\n",
-					dkey_val);
+				D_DEBUG(DB_IO, "Punch extent in key "DF_U64"\n", dkey_val);
 				rc = punch_extent(args->oh, args->th, dkey_val, props->record_i,
 						  props->num_records, props->ptask, &task_list);
 				if (rc)
@@ -2465,8 +2420,7 @@ adjust_array_size_cb(tse_task_t *task, void *data)
 		args->sgl->sg_nr = 1;
 		d_iov_set(&args->sgl->sg_iovs[0], props->buf, ENUM_DESC_BUF);
 
-		rc = tse_task_register_cbs(task, NULL, NULL, 0,
-					   adjust_array_size_cb, &props,
+		rc = tse_task_register_cbs(task, NULL, NULL, 0, adjust_array_size_cb, &props,
 					   sizeof(props));
 		if (rc)
 			goto out;
@@ -2521,8 +2475,7 @@ dc_array_set_size(tse_task_t *task)
 		num_records = array->chunk_size;
 		record_i = 0;
 	} else {
-		rc = compute_dkey(array, args->size - 1, &num_records,
-				  &record_i, &dkey_val);
+		rc = compute_dkey(array, args->size - 1, &num_records, &record_i, &dkey_val);
 		if (rc) {
 			D_ERROR("Failed to compute dkey\n");
 			D_GOTO(err_task, rc);
@@ -2552,11 +2505,9 @@ dc_array_set_size(tse_task_t *task)
 	memset(&set_size_props->anchor, 0, sizeof(set_size_props->anchor));
 	set_size_props->sgl.sg_nr = 1;
 	set_size_props->sgl.sg_iovs = &set_size_props->iov;
-	d_iov_set(&set_size_props->sgl.sg_iovs[0], set_size_props->buf,
-		     ENUM_DESC_BUF);
+	d_iov_set(&set_size_props->sgl.sg_iovs[0], set_size_props->buf, ENUM_DESC_BUF);
 
-	rc = daos_task_create(DAOS_OPC_OBJ_LIST_DKEY, tse_task2sched(task),
-			      0, NULL, &enum_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_LIST_DKEY, tse_task2sched(task), 0, NULL, &enum_task);
 	if (rc)
 		D_GOTO(err_task, rc);
 
@@ -2568,8 +2519,7 @@ dc_array_set_size(tse_task_t *task)
 	enum_args->sgl		= &set_size_props->sgl;
 	enum_args->dkey_anchor	= &set_size_props->anchor;
 
-	rc = tse_task_register_cbs(enum_task, NULL, NULL, 0,
-				   adjust_array_size_cb, &set_size_props,
+	rc = tse_task_register_cbs(enum_task, NULL, NULL, 0, adjust_array_size_cb, &set_size_props,
 				   sizeof(set_size_props));
 	if (rc)
 		D_GOTO(err_enum_task, rc);
@@ -2583,14 +2533,11 @@ dc_array_set_size(tse_task_t *task)
 	if (rc)
 		D_GOTO(err_enum_task, rc);
 
-	rc = tse_task_schedule(enum_task, false);
+	rc = tse_task_schedule(enum_task, true);
 	if (rc)
 		D_GOTO(err_enum_task, rc);
 
-	tse_sched_progress(tse_task2sched(task));
-
 	return 0;
-
 err_enum_task:
 	tse_task_complete(enum_task, rc);
 err_task:

--- a/src/client/kv/dc_kv.c
+++ b/src/client/kv/dc_kv.c
@@ -223,8 +223,7 @@ dc_kv_open(tse_task_t *task)
 		D_GOTO(err_put1, rc);
 	}
 
-	tse_task_schedule(open_task, false);
-	tse_sched_progress(tse_task2sched(task));
+	tse_task_schedule(open_task, true);
 	return rc;
 
 err_put1:
@@ -273,9 +272,7 @@ dc_kv_close(tse_task_t *task)
 		D_GOTO(err_put2, rc);
 	}
 
-	tse_task_schedule(close_task, false);
-	tse_sched_progress(tse_task2sched(task));
-
+	tse_task_schedule(close_task, true);
 	return rc;
 err_put2:
 	tse_task_complete(close_task, rc);
@@ -320,10 +317,8 @@ dc_kv_destroy(tse_task_t *task)
 		D_GOTO(err_put2, rc);
 	}
 
-	tse_task_schedule(punch_task, false);
-	tse_sched_progress(tse_task2sched(task));
+	tse_task_schedule(punch_task, true);
 	kv_decref(kv);
-
 	return rc;
 err_put2:
 	tse_task_complete(punch_task, rc);
@@ -414,14 +409,11 @@ dc_kv_put(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 
-	rc = tse_task_schedule(update_task, false);
+	rc = tse_task_schedule(update_task, true);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
-
-	tse_sched_progress(tse_task2sched(task));
 	kv_decref(kv);
 	return 0;
-
 err_task:
 	D_FREE(params);
 	if (update_task)
@@ -509,15 +501,11 @@ dc_kv_get(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 
-	rc = tse_task_schedule(fetch_task, false);
+	rc = tse_task_schedule(fetch_task, true);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
-
-	tse_sched_progress(tse_task2sched(task));
 	kv_decref(kv);
-
 	return 0;
-
 err_task:
 	D_FREE(params);
 	if (fetch_task)
@@ -574,15 +562,11 @@ dc_kv_remove(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 
-	rc = tse_task_schedule(punch_task, false);
+	rc = tse_task_schedule(punch_task, true);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
-
-	tse_sched_progress(tse_task2sched(task));
 	kv_decref(kv);
-
 	return 0;
-
 err_task:
 	D_FREE(params);
 	if (punch_task)
@@ -623,15 +607,11 @@ dc_kv_list(tse_task_t *task)
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 
-	rc = tse_task_schedule(list_task, false);
+	rc = tse_task_schedule(list_task, true);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
-
-	tse_sched_progress(tse_task2sched(task));
 	kv_decref(kv);
-
 	return 0;
-
 err_task:
 	if (list_task)
 		tse_task_complete(list_task, rc);

--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1018,15 +1018,17 @@ tse_task_insert_sleeping(struct tse_task_private *dtp,
 int
 tse_task_schedule_with_delay(tse_task_t *task, bool instant, uint64_t delay)
 {
-	struct tse_task_private  *dtp = tse_task2priv(task);
-	struct tse_sched_private *dsp = dtp->dtp_sched;
-	int rc = 0;
+	struct tse_task_private		*dtp = tse_task2priv(task);
+	struct tse_sched_private	*dsp = dtp->dtp_sched;
+	bool				ready;
+	int				rc = 0;
 
 	D_ASSERT(!instant || (dtp->dtp_func && delay == 0));
 
 	/* Add task to scheduler */
 	D_MUTEX_LOCK(&dsp->dsp_lock);
-	if (dtp->dtp_func == NULL || instant) {
+	ready = (dtp->dtp_dep_cnt == 0 && d_list_empty(&dtp->dtp_prep_cb_list));
+	if ((dtp->dtp_func == NULL || instant) && ready) {
 		/** If task has no body function, mark it as running */
 		dsp->dsp_inflight++;
 		dtp->dtp_running = 1;
@@ -1049,10 +1051,8 @@ tse_task_schedule_with_delay(tse_task_t *task, bool instant, uint64_t delay)
 	tse_sched_priv_addref_locked(dsp);
 	D_MUTEX_UNLOCK(&dsp->dsp_lock);
 
-	/* if caller wants to run the task instantly, call the task body
-	 * function now.
-	 */
-	if (instant) {
+	/** if caller wants to run the task instantly, call the task body function now. */
+	if (instant && ready) {
 		dtp->dtp_func(task);
 
 		/** If task was completed return the task result */
@@ -1061,7 +1061,6 @@ tse_task_schedule_with_delay(tse_task_t *task, bool instant, uint64_t delay)
 
 		tse_task_decref(task);
 	}
-
 	return rc;
 }
 


### PR DESCRIPTION
…963)

- change array tasks to be inserted with instant == true, since instant==false + progress can potentially cause issues due to possibly the task being gone before the progress call.
- fix bug in tse to not schedule instant tasks that are not ready.
- Some code cleanup and formatting.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
