### PR TITLE
use HBM for MD-on-SSD

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -259,6 +259,14 @@ def define_components(reqs):
                           ['make'],
                           ['make', 'install']],
                 libs=['isal_crypto'])
+    reqs.define('memkind',
+                retriever=GitRepoRetriever('https://github.com/memkind/memkind.git'),
+                commands=[['./autogen.sh'],
+                          ['./configure', '--prefix=$MEMKIND_PREFIX',
+                           '--libdir=$MEMKIND_PREFIX/lib'],
+                          ['make'],
+                          ['make', 'install']],
+                libs=['memkind'])
 
     reqs.define('pmdk',
                 retriever=GitRepoRetriever('https://github.com/pmem/pmdk.git'),

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -526,7 +526,7 @@ class PreReqComponent():
         """Build and dependencies"""
         # argobots is not really needed by client but it's difficult to separate
         common_reqs = ['argobots', 'ucx', 'ofi', 'hwloc', 'mercury', 'boost', 'uuid',
-                       'crypto', 'protobufc', 'lz4', 'isal', 'isal_crypto']
+                       'crypto', 'protobufc', 'lz4', 'isal', 'isal_crypto', 'memkind']
         client_reqs = ['fuse', 'json-c', 'capstone']
         server_reqs = ['pmdk', 'spdk', 'lmdb']
         test_reqs = ['cmocka']

--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -20,7 +20,7 @@ def build_daos_common(denv, client):
     dav_src = []
     sys_lmdb_files = []
 
-    common_libs = ['isal', 'isal_crypto', 'cart', 'gurt', 'lz4', 'protobuf-c', 'uuid', 'pthread']
+    common_libs = ['isal', 'isal_crypto', 'cart', 'gurt', 'lz4', 'protobuf-c', 'uuid', 'pthread', 'memkind']
     if client:
         libname = 'daos_common'
     else:
@@ -45,6 +45,7 @@ def build_daos_common(denv, client):
         benv.require('argobots')
         benv.Append(CCFLAGS=['-DULT_MMAP_STACK'])
 
+    benv.require('memkind')
     common = benv.d_library(libname, COMMON_FILES + dav_src + ad_mem_files + stack_mmap_files
                             + sys_lmdb_files, LIBS=common_libs)
     benv.Install('$PREFIX/lib64/', common)

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -14,6 +14,7 @@
 
 #include <daos/common.h>
 #include <daos/mem.h>
+#include <hbwmalloc.h>
 #ifdef DAOS_PMEM_BUILD
 #include <libpmemobj.h>
 #include <daos_srv/ad_mem.h>
@@ -269,6 +270,7 @@ umempobj_create(const char *path, const char *layout_name, int flags,
 	struct ad_blob_handle	 bh;
 	int			 enabled = 1;
 	int			 rc;
+
 
 	D_ALLOC(umm_pool, sizeof(*umm_pool) + sizeof(umm_pool->up_slabs[0]) * UMM_SLABS_CNT);
 	if (umm_pool == NULL)
@@ -1717,8 +1719,8 @@ umem_cache_alloc(struct umem_store *store, uint64_t max_mapped)
 
 	max_mapped = num_pages;
 
-	D_ALLOC(cache, sizeof(*cache) + sizeof(cache->ca_pages[0]) * num_pages +
-			   sizeof(cache->ca_pages[0].pg_info[0]) * max_mapped);
+	cache = hbw_calloc(1, sizeof(*cache) + sizeof(cache->ca_pages[0]) * num_pages +
+				sizeof(cache->ca_pages[0].pg_info[0]) * max_mapped);
 	if (cache == NULL)
 		D_GOTO(error, rc = -DER_NOMEM);
 
@@ -1758,7 +1760,7 @@ int
 umem_cache_free(struct umem_store *store)
 {
 	/** XXX: check reference counts? */
-	D_FREE(store->cache);
+	hbw_free(store->cache);
 	return 0;
 }
 

--- a/utils/build.config
+++ b/utils/build.config
@@ -11,6 +11,7 @@ OFI = v1.18.0
 MERCURY = v2.3.0
 PROTOBUFC = v1.3.3
 UCX=v1.13.0
+MEMKIND=master
 
 [patch_versions]
 spdk=https://github.com/spdk/spdk/commit/b0aba3fcd5aceceea530a702922153bc75664978.diff,https://github.com/spdk/spdk/commit/445a4c808badbad3942696ecf16fa60e8129a747.diff


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
