### PR TITLE
DAOS-13598 dfs: Convert a return code correctly in dfs_read. (#12382)

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -4653,7 +4653,8 @@ dfs_read_int(dfs_t *dfs, dfs_obj_t *obj, daos_off_t off, dfs_iod_t *iod,
 	if (rc)
 		D_GOTO(err_params, rc = daos_der2errno(rc));
 
-	return dc_task_schedule(task, true);
+	rc = dc_task_schedule(task, true);
+	return daos_der2errno(rc);
 
 err_params:
 	D_FREE(params);


### PR DESCRIPTION
Fix incorrect use of daos vs system error number.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
# ------------------------ >8 ------------------------
Skip-func-hw-test: true
Skip-func-test: true
Quick-Functional: true
Test-tag: dfuse
