### PR TITLE
DAOS-13518 test: Handle logging no stdout correctly (#12223)

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -887,9 +887,8 @@ class Launch():
             try:
                 logger.debug("Creating results.xml: %s", results_xml_path)
                 create_xml(self.job, self.result)
-            except ModuleNotFoundError as error:
-                # When SRE-439 is fixed this should be an error
-                logger.warning("Unable to create results.xml file: %s", str(error))
+            except Exception as error:      # pylint: disable=broad-except
+                logger.error("Unable to create results.xml file: %s", str(error))
             else:
                 if not os.path.exists(results_xml_path):
                     logger.error("results.xml does not exist: %s", results_xml_path)
@@ -899,9 +898,8 @@ class Launch():
             try:
                 logger.debug("Creating results.html: %s", results_html_path)
                 create_html(self.job, self.result)
-            except ModuleNotFoundError as error:
-                # When SRE-439 is fixed this should be an error
-                logger.warning("Unable to create results.html file: %s", str(error))
+            except Exception as error:      # pylint: disable=broad-except
+                logger.error("Unable to create results.html file: %s", str(error))
             else:
                 if not os.path.exists(results_html_path):
                     logger.error("results.html does not exist: %s", results_html_path)

--- a/src/tests/ftest/util/results_utils.py
+++ b/src/tests/ftest/util/results_utils.py
@@ -320,6 +320,25 @@ class Job():
         self.status = "COMPLETE"
 
 
+def sanitize_results(results):
+    """Ensure each test status is set and all failure attributes are set for test failures.
+
+    Args:
+        results (Results): the test results to sanitize
+
+    Returns:
+        Results: sanitized test results
+    """
+    for test in results.tests:
+        if not test.status or test.status == TestResult.FAIL:
+            test.status = TestResult.FAIL
+            if not test.fail_class:
+                test.fail_class = 'Missing fail class'
+            if not test.fail_reason:
+                test.fail_reason = 'Missing fail reason'
+    return results
+
+
 def create_xml(job, results):
     """Create a xml file for the specified test results.
 
@@ -333,7 +352,7 @@ def create_xml(job, results):
     # pylint: disable=import-outside-toplevel
     from avocado.plugins.xunit import XUnitResult
     result_xml = XUnitResult()
-    result_xml.render(results, job)
+    result_xml.render(sanitize_results(results), job)
 
 
 def create_html(job, results):
@@ -349,4 +368,4 @@ def create_html(job, results):
     # pylint: disable=import-outside-toplevel
     from avocado_result_html import HTMLResult
     result_html = HTMLResult()
-    result_html.render(results, job)
+    result_html.render(sanitize_results(results), job)

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -152,18 +152,25 @@ class RemoteCommandResult():
 
         """
         for data in self.output:
-            if data.timeout and len(data.stdout) == 1:
-                log.debug(
-                    "  %s (rc=%s) timed out: %s", str(data.hosts), data.returncode, data.stdout[0])
-            elif len(data.stdout) == 1:
-                log.debug("  %s (rc=%s): %s", str(data.hosts), data.returncode, data.stdout[0])
-            elif data.timeout:
-                log.debug("  %s (rc=%s) timed out:", str(data.hosts), data.returncode)
-            else:
-                log.debug("  %s (rc=%s):", str(data.hosts), data.returncode)
-            if len(data.stdout) > 1:
-                for line in data.stdout:
-                    log.debug("    %s", line)
+            log_result_data(log, data)
+
+
+def log_result_data(log, data):
+    """Log a single command result data entry.
+
+    Args:
+        log (logger): logger for the messages produced by this method
+        data (ResultData): command result common to a set of hosts
+    """
+    info = " timed out" if data.timeout else ""
+    if not data.stdout:
+        log.debug("  %s (rc=%s)%s: <no output>", str(data.hosts), data.returncode, info)
+    elif len(data.stdout) == 1:
+        log.debug("  %s (rc=%s)%s: %s", str(data.hosts), data.returncode, info, data.stdout[0])
+    else:
+        log.debug("  %s (rc=%s)%s:", str(data.hosts), data.returncode, info)
+        for line in data.stdout:
+            log.debug("    %s", line)
 
 
 def get_switch_user(user="root"):


### PR DESCRIPTION
Fix an issue where logging a command w/o stdout would yield an exception. Also updated launch.py result file generation to handle exceptions that would otherwise prevent atrifact collection.

Adding santizing results before reporting.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
