### PR TITLE
DAOS-13129 vea: don't do force free extents flush

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -845,8 +845,9 @@ set_req_limit(struct dss_xstream *dx, struct sched_pool_info *spi,
 
 	D_ASSERT(limit <= tot);
 	if (tot - limit > max_qds[req_type]) {
-		D_CRIT("Too large QD: %u/%u/%u for req:%d\n",
-		       tot, max_qds[req_type], limit, req_type);
+		D_CRIT("Too large QD: %u/%u/%u for req:%d, %d/%d GC ULTs for pool:"DF_UUID"\n",
+		       tot, max_qds[req_type], limit, req_type, spi->spi_gc_ults,
+		       spi->spi_gc_sleeping, DP_UUID(spi->spi_pool_id));
 		limit = tot - max_qds[req_type];
 	}
 	spi->spi_req_array[req_type].sri_req_limit = limit;

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -1124,7 +1124,7 @@ vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 	/* To accelerate flush on container destroy done */
 	if (!gc_have_pool(pool)) {
 		if (pool->vp_vea_info != NULL)
-			rc = vea_flush(pool->vp_vea_info, true, UINT32_MAX, &nr_flushed);
+			rc = vea_flush(pool->vp_vea_info, false, UINT32_MAX, &nr_flushed);
 		return rc < 0 ? rc : nr_flushed;
 	}
 


### PR DESCRIPTION
Don't do force free extents flush, ohterwise, the freed extents could be unmap'd & reused by new allocations.

Print more debug information when there are too many queued ULTs.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
