### PR TITLE
DAOS-13740 cart: fix coverity warning of unused rc

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -675,7 +675,8 @@ crt_corpc_reply_hdlr(const struct crt_cb_info *cb_info)
 				D_ERROR("co_ops->co_aggregate(opc: %#x) "
 					"failed: "DF_RC"\n",
 					child_req->cr_opc, DP_RC(rc));
-				rc = 0;
+				if (co_info->co_rc == 0)
+					co_info->co_rc = rc;
 			}
 			co_info->co_child_ack_num++;
 			D_DEBUG(DB_NET, "parent rpc %p, child rpc %p, "
@@ -713,7 +714,8 @@ crt_corpc_reply_hdlr(const struct crt_cb_info *cb_info)
 					D_ERROR("co_ops->co_aggregate(opc: %#x)"
 						" failed: "DF_RC"\n",
 						child_req->cr_opc, DP_RC(rc));
-					rc = 0;
+					if (co_info->co_rc == 0)
+						co_info->co_rc = rc;
 				}
 			}
 		}


### PR DESCRIPTION
Propagate err code from co_aggregate to co_info->co_rc.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
