### PR TITLE
DAOS-623 doc: fix code spell errors

### DIFF
--- a/src/cart/crt_self_test_client.c
+++ b/src/cart/crt_self_test_client.c
@@ -877,7 +877,7 @@ crt_self_test_start_handler(crt_rpc_t *rpc_req)
 
 	/*
 	 * Set up a bulk descriptor to use later to send the latencies back
-	 * to the self-test requestor
+	 * to the self-test requester
 	 */
 	d_iov_set(&g_data->rep_latencies_iov, g_data->rep_latencies,
 		 g_data->rep_count * sizeof(g_data->rep_latencies[0]));

--- a/src/rebuild/README.md
+++ b/src/rebuild/README.md
@@ -156,7 +156,7 @@ is 30.
 ## Rebuild status
 
 As described earlier, each target will report its rebuild status to
-the pool leader by IV, then the leader will summurize the status of
+the pool leader by IV, then the leader will summarize the status of
 all targets, and print out the whole rebuild status by every 2 seconds,
 for example these messages.
 

--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -131,7 +131,7 @@ Otherwise, a "miss" is returned, meaning that this key has never been updated in
 This ensures that the most recent value in the epoch history of is returned irrespective of the time-order in which they were integrated and that all updates after the requested epoch are ignored.
 
 Similarly, when reading an array object, its index is traversed to create a gather descriptor that collects all object extent fragments in the requested extent with the highest epoch number less than or equal to the requested epoch.
-Entries in the gather descriptor either reference an extent containing data, a punched extent that the requestor can interpret as all zeroes, or a "miss", meaning that this VOS has received no updates in this extent.
+Entries in the gather descriptor either reference an extent containing data, a punched extent that the requester can interpret as all zeroes, or a "miss", meaning that this VOS has received no updates in this extent.
 Again, this ensures that the most recent data in the epoch history of the array is returned for all offsets in the requested extent, irrespective of the time-order in which they were written, and that all updates after the requested epoch are ignored.
 
 <a id="711"></a>


### PR DESCRIPTION
Doc-only: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
