### PR TITLE
DAOS-12945 object: choose minimum epoch correctly

### DIFF
--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -548,8 +548,8 @@ drain_then_exclude(void **state)
 	rebuild_io_validate(arg, &oid, 1);
 }
 
-#define EXTEND_DRAIN_OBJ_NR	10
-#define WRITE_SIZE		(1048576 * 50)
+#define EXTEND_DRAIN_OBJ_NR	5
+#define WRITE_SIZE		(1048576 * 5)
 struct extend_drain_cb_arg{
 	daos_obj_id_t	*oids;
 	dfs_t		*dfs_mt;


### PR DESCRIPTION
When rebuilding the data from parity shard, it should choose minimum epoch only from the parity epochs.

Shrink drain write size to avoid timeout.

Allow-unstable-test: true
Feature: ec rebuild
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
