### PR TITLE
DAOS-13683 control: Work around 2.2.0 version detection bug

### DIFF
--- a/src/control/common/proto/logging.go
+++ b/src/control/common/proto/logging.go
@@ -31,8 +31,7 @@ func ShouldDebug(msg proto.Message, ldrChk func() bool) bool {
 		*grpcpb.InstallSnapshotRequest, *grpcpb.InstallSnapshotResponse,
 		*mgmtpb.LeaderQueryReq, *mgmtpb.SystemQueryReq,
 		*ctlpb.StorageScanResp, *ctlpb.NetworkScanResp,
-		*ctlpb.StorageFormatResp, *ctlpb.PrepareScmResp,
-		*mgmtpb.GetAttachInfoReq:
+		*ctlpb.StorageFormatResp, *ctlpb.PrepareScmResp:
 		return false
 	default:
 		// Most mgmt messages must be processed by the leader, so if this node

--- a/src/control/lib/control/http.go
+++ b/src/control/lib/control/http.go
@@ -61,7 +61,7 @@ func (r *httpReq) canRetry(err error, cur uint) bool {
 	return false
 }
 
-func (r *httpReq) onRetry(ctx context.Context, _ uint) error {
+func (r *httpReq) onRetry(ctx context.Context, _ error, _ uint) error {
 	return nil
 }
 
@@ -105,7 +105,7 @@ func httpGetBodyRetry(ctx context.Context, req httpGetter) ([]byte, error) {
 		}
 
 		time.Sleep(req.retryAfter(0))
-		if err = req.onRetry(ctx, i); err != nil {
+		if err = req.onRetry(ctx, err, i); err != nil {
 			return nil, err
 		}
 	}

--- a/src/control/lib/control/http_test.go
+++ b/src/control/lib/control/http_test.go
@@ -75,7 +75,7 @@ func TestControl_httpReq_canRetry(t *testing.T) {
 
 func TestControl_httpReq_onRetry(t *testing.T) {
 	req := &httpReq{}
-	err := req.onRetry(test.Context(t), 0)
+	err := req.onRetry(test.Context(t), nil, 0)
 	if err != nil {
 		t.Fatalf("expected nil, got: %s", err.Error())
 	}
@@ -254,7 +254,7 @@ func (r *mockHTTPGetter) canRetry(err error, cur uint) bool {
 	return r.canRetryCalled <= r.numTimesToRetry
 }
 
-func (r *mockHTTPGetter) onRetry(ctx context.Context, _ uint) error {
+func (r *mockHTTPGetter) onRetry(ctx context.Context, _ error, _ uint) error {
 	return r.onRetryErr
 }
 

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -368,10 +368,12 @@ func PoolEvict(ctx context.Context, rpcClient UnaryInvoker, req *PoolEvictReq) e
 		Handles: req.Handles,
 	}
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
+		rpcClient.Debugf("Evict DAOS pool request: %s\n", pbUtil.Debug(pbReq))
 		return mgmtpb.NewMgmtSvcClient(conn).PoolEvict(ctx, pbReq)
 	})
+	req.retryTestFn = agentRetryTestFn(nil)
+	req.retryFn = agentRetryFn(&pbReq.Sys)
 
-	rpcClient.Debugf("Evict DAOS pool request: %s\n", pbUtil.Debug(pbReq))
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
 		return err

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -427,7 +427,7 @@ func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, 
 		// and run that if so. Otherwise, let the usual retry
 		// logic below handle the error.
 		if req.canRetry(err, try) {
-			err := req.onRetry(tryCtx, try)
+			err := req.onRetry(tryCtx, err, try)
 			if err == nil {
 				return ur, nil
 			}

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -247,7 +247,7 @@ func SystemQuery(ctx context.Context, rpcClient UnaryInvoker, req *SystemQueryRe
 			(system.IsUnavailable(err) || IsRetryableConnErr(err) ||
 				system.IsNotLeader(err) || system.IsNotReplica(err))
 	}
-	req.retryFn = func(_ context.Context, _ uint) error {
+	req.retryFn = func(_ context.Context, _ error, _ uint) error {
 		if req.FailOnUnavailable {
 			return system.ErrRaftUnavail
 		}
@@ -569,7 +569,7 @@ func SystemErase(ctx context.Context, rpcClient UnaryInvoker, req *SystemEraseRe
 	req.retryTestFn = func(err error, _ uint) bool {
 		return system.IsUnavailable(err)
 	}
-	req.retryFn = func(_ context.Context, _ uint) error {
+	req.retryFn = func(_ context.Context, _ error, _ uint) error {
 		return system.ErrRaftUnavail
 	}
 


### PR DESCRIPTION
The 2.2.0 server will reject connections from pre-2.4 (e.g.
2.3.108) agents due to a bug that has been fixed but not
released. As a workaround, add some retry logic to the
client-side of agent RPCs so that a rejected connection
is retried with a fudged 2.4.0 version.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
