### PR TITLE
DAOS-13689 chk: fix double free when handle chk RPC failure

### DIFF
--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -148,6 +148,7 @@ chk_start_post_reply(crt_rpc_t *rpc, void *arg)
 
 	if (cso != NULL) {
 		D_FREE(cso->cso_cmp_ranks.ca_arrays);
+
 		clues.pcs_len = cso->cso_clues.ca_count;
 		clues.pcs_array = cso->cso_clues.ca_arrays;
 		ds_pool_clues_fini(&clues);
@@ -1097,6 +1098,9 @@ crt_proc_struct_chk_query_pool_shard(crt_proc_t proc, crt_proc_op_t proc_op,
 	rc = crt_proc_uint32_t(proc, proc_op, &shard->cqps_target_nr);
 	if (unlikely(rc != 0))
 		return rc;
+
+	if (shard->cqps_target_nr == 0)
+		return 0;
 
 	if (FREEING(proc_op)) {
 		D_FREE(shard->cqps_targets);

--- a/src/chk/chk_srv.c
+++ b/src/chk/chk_srv.c
@@ -53,8 +53,7 @@ ds_chk_start_hdlr(crt_rpc_t *rpc)
 	if (rc != 0)
 		D_ERROR("Failed to reply check start: "DF_RC"\n", DP_RC(rc));
 
-	if (cso->cso_status < 0)
-		ds_pool_clues_fini(&clues);
+	/* @clues will be freed via chk_start_post_reply. Do not free it here. */
 }
 
 static void
@@ -118,8 +117,7 @@ ds_chk_query_hdlr(crt_rpc_t *rpc)
 	if (rc != 0)
 		D_ERROR("Failed to reply check query: "DF_RC"\n", DP_RC(rc));
 
-	if (cqo->cqo_status < 0)
-		chk_query_free(shards, shard_nr);
+	/* @shards will be freed via chk_query_post_reply. Do not free it here. */
 }
 
 static void
@@ -172,8 +170,7 @@ ds_chk_cont_list_hdlr(crt_rpc_t *rpc)
 	if (rc != 0)
 		D_ERROR("Failed to reply check cont list: "DF_RC"\n", DP_RC(rc));
 
-	if (cclo->cclo_status < 0)
-		D_FREE(conts);
+	/* @conts will be freed via chk_cont_list_post_reply. Do not free it here. */
 }
 
 static void

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -301,10 +301,12 @@ ds_pool_clues_fini(struct ds_pool_clues *clues)
 {
 	int i;
 
-	for (i = 0; i < clues->pcs_len; i++)
-		ds_pool_clue_fini(&clues->pcs_array[i]);
-	if (clues->pcs_array != NULL)
+	if (clues != NULL && clues->pcs_array != NULL) {
+		for (i = 0; i < clues->pcs_len; i++)
+			ds_pool_clue_fini(&clues->pcs_array[i]);
+
 		D_FREE(clues->pcs_array);
+	}
 }
 
 /**


### PR DESCRIPTION
For check engine, when handle CHK_QUERY RPC from check leader, the ds_chk_query_hdlr() logic does not need to free the memory allocated for "shards" under the case of failure. Related logic in crt_corpc_reply_hdlr() will trigger co_post_reply() that will finally call chk_query_free() to handle that.

Similar logic for CHK_{START,STOP,CONT_LIST}.

Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
