### PR TITLE
DAOS-13686 test: reduce pool NVME size for small_file_count

### DIFF
--- a/src/tests/ftest/io/small_file_count.yaml
+++ b/src/tests/ftest/io/small_file_count.yaml
@@ -22,7 +22,7 @@ server_config:
       storage: auto
 pool:
   scm_size: 40G
-  nvme_size: 350G
+  nvme_size: 300G
 container:
   type: POSIX
   control_method: daos


### PR DESCRIPTION
There is a possibility that our CI NVME only have about ~370GiB capacity which is not enough to store both 350GiB Data + 40GiB Meta on this SSD, reduce pool NVME size a bit to 300GiB. (test required 30G x 2 for IOR and 50K x 4KIB for mdtest), so it should be fine.

Test-tag: SmallFileCount,test_smallfilecount
Test-nvme: auto_md_on_ssd
Required-githooks: true
