### PR TITLE
DAOS-13445 test: debug test_dm_posix_types_fs_copy on EL8.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,7 +228,7 @@ pipeline {
                defaultValue: '',
                description: 'Distribution to use for CI Hardware Tests')
         string(name: 'CI_EL8_TARGET',
-               defaultValue: '',
+               defaultValue: 'el8.7',
                description: 'Image to used for EL 8 CI tests.  I.e. el8, el8.3, etc.')
         string(name: 'CI_LEAP15_TARGET',
                defaultValue: '',
@@ -934,7 +934,7 @@ pipeline {
                         }
                     }
                 } // stage('Functional on EL 8 with Valgrind')
-                stage('Functional on EL 8') {
+                stage('Functional on EL 8.7') {
                     when {
                         beforeAgent true
                         expression { !skipStage() }

--- a/src/tests/ftest/datamover/posix_types.py
+++ b/src/tests/ftest/datamover/posix_types.py
@@ -7,6 +7,7 @@ from os.path import basename, join
 
 from data_mover_test_base import DataMoverTestBase
 from duns_utils import format_path, parse_path
+from run_utils import run_remote
 
 
 class DmvrPosixTypesTest(DataMoverTestBase):
@@ -185,6 +186,11 @@ class DmvrPosixTypesTest(DataMoverTestBase):
             param_type = 'POSIX'
             pool = None
             cont = None
+            self.log.info('--HERE-- verifying directory')
+            run_remote(self.log, self.hostlist_clients, 'cat /proc/mounts | grep mnt')
+            run_remote(self.log, self.hostlist_clients, 'df -h /mnt/share')
+            run_remote(self.log, self.hostlist_clients, 'ls -las "{}"'.format(path))
+            run_remote(self.log, self.hostlist_clients, 'ls -las $dirname("{}")'.format(path))
         self.run_ior_with_params(param_type, path, pool, cont, self.test_file, self.ior_flags[1])
 
     def test_dm_posix_types_dcp(self):


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
