### PR TITLE
DAOS-13711 client: several coverity silencing fixes (#12415)

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -160,7 +160,6 @@ daos_eq_free(struct d_hlink *hlink)
 crt_context_t
 daos_get_crt_ctx()
 {
-	D_ASSERT(eq_ref > 0);
 	return daos_eq_ctx;
 }
 

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -57,6 +57,7 @@ struct io_params {
 	uint64_t		dkey_val;
 	daos_iod_t		iod;
 	d_sg_list_t		sgl;
+	d_iov_t			sg_iov; /** for 1 record updates on set_size */
 	daos_iom_t		iom; /** used on fetch only */
 	daos_size_t		cell_size;
 	daos_size_t		chunk_size;
@@ -739,7 +740,7 @@ dc_array_open(tse_task_t *task)
 	/** Create task to open object */
 	rc = daos_task_create(DAOS_OPC_OBJ_OPEN, tse_task2sched(task), 0, NULL, &open_task);
 	if (rc != 0) {
-		D_ERROR("Failed to open object_open task "DF_RC"\n", DP_RC(rc));
+		D_ERROR("Failed to create object_open task "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_ptask, rc);
 	}
 
@@ -2124,6 +2125,7 @@ check_record_cb(tse_task_t *task, void *data)
 	d_sg_list_t		*sgl;
 	daos_key_t		*dkey;
 	char			*val;
+	bool			free_params = true, free_val = true;
 	int			rc = task->dt_result;
 
 	D_ASSERT(params);
@@ -2132,7 +2134,6 @@ check_record_cb(tse_task_t *task, void *data)
 	/** Last record is there, no need to add it */
 	if (rc || params->iod.iod_size != 0) {
 		D_FREE(iod->iod_recxs);
-		D_FREE(params);
 		D_GOTO(out, rc);
 	}
 
@@ -2145,9 +2146,12 @@ check_record_cb(tse_task_t *task, void *data)
 
 	/** set memory location */
 	D_ALLOC(val, params->cell_size);
+	if (val == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 	sgl->sg_nr = 1;
-	D_ALLOC_PTR(sgl->sg_iovs);
+	sgl->sg_iovs = &params->sg_iov;
 	d_iov_set(&sgl->sg_iovs[0], val, params->cell_size);
+	params->user_sgl_used = true;
 
 	D_DEBUG(DB_IO, "update record (%zu, %zu), iod_size %zu.\n",
 		iod->iod_recxs[0].rx_idx, iod->iod_recxs[0].rx_nr,
@@ -2155,7 +2159,7 @@ check_record_cb(tse_task_t *task, void *data)
 	rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(task), 0, NULL, &io_task);
 	if (rc) {
 		D_ERROR("Task create failed "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out, rc);
+		D_GOTO(err_free, rc);
 	}
 
 	io_arg = daos_task_get_args(io_task);
@@ -2168,31 +2172,37 @@ check_record_cb(tse_task_t *task, void *data)
 
 	rc = tse_task_register_comp_cb(io_task, free_io_params_cb, &params, sizeof(params));
 	if (rc)
-		D_GOTO(err, rc);
-
+		D_GOTO(err_task, rc);
+	free_params = false;
 	rc = tse_task_register_comp_cb(io_task, free_val_cb, &val, sizeof(val));
 	if (rc)
-		D_GOTO(err, rc);
+		D_GOTO(err_task, rc);
+	free_val = false;
 
-	/* params->task is the original task of dc_array_set_size, should make
-	 * io_task as dep task of params->task rather than the passed in task
-	 * (which is the check_record's OBJ_FETCH task) to make sure the io_task
-	 * complete before original task of dc_array_set_size's completion.
+	/*
+	 * params->task is the original task of dc_array_set_size, should make io_task as dep task
+	 * of params->task rather than the passed in task (which is the check_record's OBJ_FETCH
+	 * task) to make sure the io_task complete before original task of dc_array_set_size's
+	 * completion.
 	 */
 	rc = tse_task_register_deps(params->task, 1, &io_task);
 	if (rc)
-		D_GOTO(err, rc);
+		D_GOTO(err_task, rc);
 
 	rc = tse_task_schedule(io_task, true);
 	if (rc)
-		D_GOTO(err, rc);
-
+		D_GOTO(err_free, rc);
 	return rc;
-err:
+
+err_task:
 	if (io_task)
 		tse_task_complete(io_task, rc);
+err_free:
+	if (free_val)
+		D_FREE(val);
 out:
-	D_FREE(params);
+	if (free_params)
+		D_FREE(params);
 	return rc;
 }
 
@@ -2274,7 +2284,8 @@ add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props, d_l
 	d_sg_list_t		*sgl;
 	daos_key_t		*dkey;
 	struct io_params	*params = NULL;
-	tse_task_t		*io_task = NULL;
+	tse_task_t		*io_task;
+	bool			free_iod_recxs = true;
 	int			rc;
 
 	D_ALLOC_PTR(params);
@@ -2287,30 +2298,33 @@ add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props, d_l
 
 	params->akey_val = '0';
 	params->next = NULL;
-	params->user_sgl_used = false;
 	params->dkey_val = props->dkey_val;
 	d_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
 
-	/** set memory location */
+	/** set memory location - freed in free_set_size_cb (already registered) */
 	D_ALLOC(props->val, props->cell_size);
+	if (props->val == NULL)
+		D_GOTO(err, rc = -DER_NOMEM);
 	sgl->sg_nr = 1;
-	D_ALLOC_PTR(sgl->sg_iovs);
+	sgl->sg_iovs = &params->sg_iov;
 	d_iov_set(&sgl->sg_iovs[0], props->val, props->cell_size);
+	params->user_sgl_used = true;
 
 	/* set descriptor for KV object */
 	d_iov_set(&iod->iod_name, &params->akey_val, 1);
 	iod->iod_nr = 1;
 	iod->iod_size = props->cell_size;
 	iod->iod_type = DAOS_IOD_ARRAY;
-	D_ALLOC_PTR(iod->iod_recxs);
+	D_ALLOC_PTR(iod->iod_recxs); /** freed in free_io_params_cb */
+	if (iod->iod_recxs == NULL)
+		D_GOTO(err, rc = -DER_NOMEM);
 	iod->iod_recxs[0].rx_idx = props->record_i;
 	iod->iod_recxs[0].rx_nr = 1;
 
 	rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(props->ptask), 0, NULL, &io_task);
-	if (rc) {
-		D_FREE(sgl->sg_iovs);
+	if (rc)
 		D_GOTO(err, rc);
-	}
+
 	io_arg = daos_task_get_args(io_task);
 	io_arg->oh	= oh;
 	io_arg->th	= th;
@@ -2321,21 +2335,25 @@ add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props, d_l
 
 	rc = tse_task_register_comp_cb(io_task, free_io_params_cb, &params, sizeof(params));
 	if (rc)
-		D_GOTO(err, rc);
+		D_GOTO(err_task, rc);
+	free_iod_recxs = false;
 
 	rc = tse_task_register_deps(props->ptask, 1, &io_task);
 	if (rc)
-		D_GOTO(err, rc);
+		D_GOTO(err_task, rc);
 
 	/* decref in adjust_array_size_task_process() */
 	tse_task_addref(io_task);
 	tse_task_list_add(io_task, task_list);
 	return rc;
 
-err:
-	D_FREE(params);
+err_task:
 	if (io_task)
 		tse_task_complete(io_task, rc);
+err:
+	D_FREE(params);
+	if (free_iod_recxs)
+		D_FREE(iod->iod_recxs);
 	return rc;
 }
 

--- a/src/client/ds3/bucket.c
+++ b/src/client/ds3/bucket.c
@@ -269,8 +269,6 @@ ds3_bucket_set_info(struct ds3_bucket_info *info, ds3_bucket_t *ds3b, daos_event
 {
 	int               rc       = 0;
 	char const *const names[]  = {RGW_BUCKET_INFO};
-	void const *const values[] = {info->encoded};
-	size_t const sizes[]       = {info->encoded_length};
 	daos_handle_t     coh;
 
 	if (ds3b == NULL || info == NULL)
@@ -280,7 +278,8 @@ ds3_bucket_set_info(struct ds3_bucket_info *info, ds3_bucket_t *ds3b, daos_event
 	if (rc != 0)
 		return -rc;
 
-	rc = daos_cont_set_attr(coh, 1, names, values, sizes, ev);
+	rc = daos_cont_set_attr(coh, 1, names, (void *const)(&info->encoded),
+				&info->encoded_length, ev);
 	rc = daos_der2errno(rc);
 	dfs_cont_put(ds3b->dfs, coh);
 	return -rc;

--- a/src/client/kv/dc_kv.c
+++ b/src/client/kv/dc_kv.c
@@ -196,10 +196,9 @@ dc_kv_open(tse_task_t *task)
 	}
 
 	/** Create task to open object */
-	rc = daos_task_create(DAOS_OPC_OBJ_OPEN, tse_task2sched(task),
-			      0, NULL, &open_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_OPEN, tse_task2sched(task), 0, NULL, &open_task);
 	if (rc != 0) {
-		D_ERROR("Failed to open object_open task\n");
+		D_ERROR("Failed to create object_open task "DF_RC"\n", DP_RC(rc));
 		D_GOTO(err_ptask, rc);
 	}
 
@@ -215,15 +214,14 @@ dc_kv_open(tse_task_t *task)
 		D_ERROR("Failed to register dependency\n");
 		D_GOTO(err_put1, rc);
 	}
-
-	rc = tse_task_register_comp_cb(task, open_handle_cb, &args,
-				       sizeof(args));
+	rc = tse_task_register_comp_cb(task, open_handle_cb, &args, sizeof(args));
 	if (rc != 0) {
 		D_ERROR("Failed to register completion cb\n");
 		D_GOTO(err_put1, rc);
 	}
-
-	tse_task_schedule(open_task, true);
+	rc = tse_task_schedule(open_task, true);
+	if (rc)
+		D_GOTO(err_ptask, rc);
 	return rc;
 
 err_put1:
@@ -248,8 +246,7 @@ dc_kv_close(tse_task_t *task)
 		D_GOTO(err_ptask, rc = -DER_NO_HDL);
 
 	/** Create task to close object */
-	rc = daos_task_create(DAOS_OPC_OBJ_CLOSE, tse_task2sched(task),
-			      0, NULL, &close_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_CLOSE, tse_task2sched(task), 0, NULL, &close_task);
 	if (rc != 0) {
 		D_ERROR("Failed to create object_close task\n");
 		D_GOTO(err_put1, rc);
@@ -272,7 +269,9 @@ dc_kv_close(tse_task_t *task)
 		D_GOTO(err_put2, rc);
 	}
 
-	tse_task_schedule(close_task, true);
+	rc = tse_task_schedule(close_task, true);
+	if (rc)
+		D_GOTO(err_put1, rc);
 	return rc;
 err_put2:
 	tse_task_complete(close_task, rc);
@@ -297,8 +296,7 @@ dc_kv_destroy(tse_task_t *task)
 		D_GOTO(err_ptask, rc = -DER_NO_HDL);
 
 	/** Create task to punch object */
-	rc = daos_task_create(DAOS_OPC_OBJ_PUNCH, tse_task2sched(task),
-			      0, NULL, &punch_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_PUNCH, tse_task2sched(task), 0, NULL, &punch_task);
 	if (rc != 0) {
 		D_ERROR("Failed to create object_punch task\n");
 		D_GOTO(err_put1, rc);
@@ -317,9 +315,12 @@ dc_kv_destroy(tse_task_t *task)
 		D_GOTO(err_put2, rc);
 	}
 
-	tse_task_schedule(punch_task, true);
+	rc = tse_task_schedule(punch_task, true);
+	if (rc)
+		D_GOTO(err_put1, rc);
 	kv_decref(kv);
 	return rc;
+
 err_put2:
 	tse_task_complete(punch_task, rc);
 err_put1:
@@ -355,7 +356,7 @@ dc_kv_put(tse_task_t *task)
 	daos_kv_put_t		*args = daos_task_get_args(task);
 	struct dc_kv		*kv = NULL;
 	daos_obj_update_t	*update_args;
-	tse_task_t		*update_task = NULL;
+	tse_task_t		*update_task;
 	struct io_params	*params = NULL;
 	int			rc;
 
@@ -386,8 +387,7 @@ dc_kv_put(tse_task_t *task)
 	params->sgl.sg_iovs = &params->iov;
 	d_iov_set(&params->sgl.sg_iovs[0], (void *)args->buf, args->buf_size);
 
-	rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(task),
-			      0, NULL, &update_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(task), 0, NULL, &update_task);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 
@@ -400,25 +400,25 @@ dc_kv_put(tse_task_t *task)
 	update_args->iods	= &params->iod;
 	update_args->sgls	= &params->sgl;
 
-	rc = tse_task_register_comp_cb(task, free_io_params_cb, &params,
-				       sizeof(params));
+	rc = tse_task_register_comp_cb(task, free_io_params_cb, &params, sizeof(params));
 	if (rc != 0)
-		D_GOTO(err_task, rc);
+		D_GOTO(err_utask, rc);
 
 	rc = tse_task_register_deps(task, 1, &update_task);
 	if (rc != 0)
-		D_GOTO(err_task, rc);
+		D_GOTO(err_utask, rc);
 
 	rc = tse_task_schedule(update_task, true);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 	kv_decref(kv);
 	return 0;
+
+err_utask:
+	tse_task_complete(update_task, rc);
 err_task:
-	D_FREE(params);
-	if (update_task)
-		tse_task_complete(update_task, rc);
 	tse_task_complete(task, rc);
+	D_FREE(params);
 	if (kv)
 		kv_decref(kv);
 	return rc;
@@ -430,7 +430,7 @@ dc_kv_get(tse_task_t *task)
 	daos_kv_get_t		*args = daos_task_get_args(task);
 	struct dc_kv		*kv = NULL;
 	daos_obj_fetch_t	*fetch_args;
-	tse_task_t		*fetch_task = NULL;
+	tse_task_t		*fetch_task;
 	struct io_params	*params = NULL;
 	void			*buf;
 	daos_size_t		*buf_size;
@@ -472,8 +472,7 @@ dc_kv_get(tse_task_t *task)
 		params->sgl.sg_nr = 1;
 	}
 
-	rc = daos_task_create(DAOS_OPC_OBJ_FETCH, tse_task2sched(task),
-			      0, NULL, &fetch_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_FETCH, tse_task2sched(task), 0, NULL, &fetch_task);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 
@@ -487,30 +486,29 @@ dc_kv_get(tse_task_t *task)
 	if (buf && *buf_size)
 		fetch_args->sgls = &params->sgl;
 
-	rc = tse_task_register_comp_cb(fetch_task, set_size_cb, &buf_size,
-					sizeof(buf_size));
+	rc = tse_task_register_comp_cb(fetch_task, set_size_cb, &buf_size, sizeof(buf_size));
 	if (rc != 0)
-		D_GOTO(err_task, rc);
+		D_GOTO(err_ftask, rc);
 
-	rc = tse_task_register_comp_cb(task, free_io_params_cb, &params,
-				       sizeof(params));
+	rc = tse_task_register_comp_cb(task, free_io_params_cb, &params, sizeof(params));
 	if (rc != 0)
-		D_GOTO(err_task, rc);
+		D_GOTO(err_ftask, rc);
 
 	rc = tse_task_register_deps(task, 1, &fetch_task);
 	if (rc != 0)
-		D_GOTO(err_task, rc);
+		D_GOTO(err_ftask, rc);
 
 	rc = tse_task_schedule(fetch_task, true);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 	kv_decref(kv);
 	return 0;
+
+err_ftask:
+	tse_task_complete(fetch_task, rc);
 err_task:
-	D_FREE(params);
-	if (fetch_task)
-		tse_task_complete(fetch_task, rc);
 	tse_task_complete(task, rc);
+	D_FREE(params);
 	if (kv)
 		kv_decref(kv);
 	return rc;
@@ -522,7 +520,7 @@ dc_kv_remove(tse_task_t *task)
 	daos_kv_remove_t	*args = daos_task_get_args(task);
 	struct dc_kv		*kv = NULL;
 	daos_obj_punch_t	*punch_args;
-	tse_task_t		*punch_task = NULL;
+	tse_task_t		*punch_task;
 	struct io_params	*params = NULL;
 	int			rc;
 
@@ -540,8 +538,7 @@ dc_kv_remove(tse_task_t *task)
 	/** init dkey */
 	d_iov_set(&params->dkey, (void *)args->key, strlen(args->key));
 
-	rc = daos_task_create(DAOS_OPC_OBJ_PUNCH_DKEYS, tse_task2sched(task),
-			      0, NULL, &punch_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_PUNCH_DKEYS, tse_task2sched(task), 0, NULL, &punch_task);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 
@@ -553,25 +550,25 @@ dc_kv_remove(tse_task_t *task)
 	punch_args->akeys	= NULL;
 	punch_args->akey_nr	= 0;
 
-	rc = tse_task_register_comp_cb(task, free_io_params_cb, &params,
-				       sizeof(params));
+	rc = tse_task_register_comp_cb(task, free_io_params_cb, &params, sizeof(params));
 	if (rc != 0)
-		D_GOTO(err_task, rc);
+		D_GOTO(err_ptask, rc);
 
 	rc = tse_task_register_deps(task, 1, &punch_task);
 	if (rc != 0)
-		D_GOTO(err_task, rc);
+		D_GOTO(err_ptask, rc);
 
 	rc = tse_task_schedule(punch_task, true);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 	kv_decref(kv);
 	return 0;
+
+err_ptask:
+	tse_task_complete(punch_task, rc);
 err_task:
-	D_FREE(params);
-	if (punch_task)
-		tse_task_complete(punch_task, rc);
 	tse_task_complete(task, rc);
+	D_FREE(params);
 	if (kv)
 		kv_decref(kv);
 	return rc;
@@ -583,15 +580,14 @@ dc_kv_list(tse_task_t *task)
 	daos_kv_list_t		*args = daos_task_get_args(task);
 	struct dc_kv		*kv = NULL;
 	daos_obj_list_dkey_t	*list_args;
-	tse_task_t		*list_task = NULL;
+	tse_task_t		*list_task;
 	int			rc;
 
 	kv = kv_hdl2ptr(args->oh);
 	if (kv == NULL)
 		D_GOTO(err_task, rc = -DER_NO_HDL);
 
-	rc = daos_task_create(DAOS_OPC_OBJ_LIST_DKEY, tse_task2sched(task),
-			      0, NULL, &list_task);
+	rc = daos_task_create(DAOS_OPC_OBJ_LIST_DKEY, tse_task2sched(task), 0, NULL, &list_task);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 
@@ -605,16 +601,17 @@ dc_kv_list(tse_task_t *task)
 
 	rc = tse_task_register_deps(task, 1, &list_task);
 	if (rc != 0)
-		D_GOTO(err_task, rc);
+		D_GOTO(err_ltask, rc);
 
 	rc = tse_task_schedule(list_task, true);
 	if (rc != 0)
 		D_GOTO(err_task, rc);
 	kv_decref(kv);
 	return 0;
+
+err_ltask:
+	tse_task_complete(list_task, rc);
 err_task:
-	if (list_task)
-		tse_task_complete(list_task, rc);
 	tse_task_complete(task, rc);
 	if (kv)
 		kv_decref(kv);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -6826,6 +6826,10 @@ dc_obj_query_key(tse_task_t *api_task)
 	D_ASSERTF(api_args != NULL,
 		  "Task Argument OPC does not match DC OPC\n");
 
+	/** for EC need to zero out user recx if passed */
+	if (api_args->recx)
+		memset(api_args->recx, 0, sizeof(*api_args->recx));
+
 	rc = obj_req_valid(api_task, api_args, DAOS_OBJ_RPC_QUERY_KEY, &epoch, &map_ver, &obj);
 	if (rc)
 		D_GOTO(out_task, rc);

--- a/src/tests/suite/daos_kv.c
+++ b/src/tests/suite/daos_kv.c
@@ -35,7 +35,7 @@ list_keys(daos_handle_t oh, int *num_keys)
 	d_sg_list_t	sgl;
 	d_iov_t		sg_iov;
 
-	buf = malloc(ENUM_DESC_BUF);
+	D_ALLOC(buf, ENUM_DESC_BUF);
 	d_iov_set(&sg_iov, buf, ENUM_DESC_BUF);
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
@@ -67,6 +67,7 @@ list_keys(daos_handle_t oh, int *num_keys)
 #endif
 		key_nr += nr;
 	}
+	D_FREE(buf);
 	*num_keys = key_nr;
 }
 


### PR DESCRIPTION
- Fix for coverity: 1449753 1449752 1449751 709506 1449749 1449748 1443160.
- Remove some uneeded allocations in array set size when adding 1 record.
- init recx to 0 for key query when passed by 0 since EC expects it to be.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
