### PR TITLE
DAOS-13146 tests: increase system ram reserved for ior smoke

### DIFF
--- a/src/tests/ftest/erasurecode/ior_smoke.yaml
+++ b/src/tests/ftest/erasurecode/ior_smoke.yaml
@@ -26,6 +26,7 @@ server_config:
       log_file: daos_server1.log
       log_mask: ERR
       storage: auto
+  system_ram_reserved: 16
 pool:
   control_method: dmg
   size: 93%


### PR DESCRIPTION
Test-tag: ec,ec_smoke,ior
Test-repeat: 10
Required-githooks: true
Test-nvme: auto_md_on_ssd