### PR TITLE
DAOS-13684 test: Bump docker nlt system_ram_reserved (#12432)

### DIFF
--- a/ci/docker_nlt.sh
+++ b/ci/docker_nlt.sh
@@ -22,7 +22,7 @@ pushd "$TMP_DIR"
 set +e
 
 sudo --preserve-env=VIRTUAL_ENV,PATH ./node_local_test.py \
-    --no-root --memcheck no --system-ram-reserved 32 --server-debug WARN "$@"
+    --no-root --memcheck no --system-ram-reserved 48 --server-debug WARN "$@"
 
 RC=$?
 set -e


### PR DESCRIPTION
Increase system RAM reservation when calculating tmpfs size in NLT
docker tests to avoid intermittent available memory check failures on
engine start due to memory contention across multiple containers on
the same host.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
