### PR TITLE
DAOS-13595 utils: Check return codes (#12346)

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -271,17 +271,10 @@ _ph_free(struct dfuse_pool *dfp)
 	if (daos_handle_is_valid(dfp->dfp_poh)) {
 		rc = daos_pool_disconnect(dfp->dfp_poh, NULL);
 		/* Hook for fault injection testing, if the disconnect fails with out of memory
-		 * then simply try it again, only what might have happened is that the first
-		 * call might have disconnected, but then failed to notify about the disconnect,
-		 * in which case the subsequent call will return -DER_NO_HDL, if that's the case
-		 * then this is expected, if odd, behavior so silence that case and just return
-		 * success.
+		 * then simply try it again.
 		 */
-		if (rc == -DER_NOMEM) {
+		if (rc == -DER_NOMEM)
 			rc = daos_pool_disconnect(dfp->dfp_poh, NULL);
-			if (rc == -DER_NO_HDL)
-				rc = -DER_SUCCESS;
-		}
 		if (rc != -DER_SUCCESS)
 			DFUSE_TRA_ERROR(dfp, "daos_pool_disconnect() failed: " DF_RC, DP_RC(rc));
 	}

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -770,6 +770,7 @@ pool_disconnect_cp(tse_task_t *task, void *data)
 		 */
 		D_ERROR("failed to notify agent of pool disconnect: "DF_RC"\n",
 			DP_RC(rc));
+		rc = 0;
 	}
 
 	/* remove pool from hhash */

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1669,42 +1669,56 @@ dm_disconnect(struct cmd_args_s *ap,
 		if (is_posix_copy) {
 			rc = dfs_sys_umount(src_file_dfs->dfs_sys);
 			if (rc != 0) {
-				rc = daos_errno2der(rc);
-				DH_PERROR_DER(ap, rc, "failed to unmount source");
-				dfs_sys_umount(src_file_dfs->dfs_sys);
+				DH_PERROR_DER(ap, daos_errno2der(rc), "failed to unmount source");
+				rc = dfs_sys_umount(src_file_dfs->dfs_sys);
+				if (rc != 0)
+					DH_PERROR_DER(ap, daos_errno2der(rc),
+						      "failed to unmount source on retry");
 			}
 			src_file_dfs->dfs_sys = NULL;
 		}
 		rc = daos_cont_close(ca->src_coh, NULL);
 		if (rc != 0) {
 			DH_PERROR_DER(ap, rc, "failed to close source container");
-			daos_cont_close(ca->src_coh, NULL);
+			rc = daos_cont_close(ca->src_coh, NULL);
+			if (rc != 0)
+				DH_PERROR_DER(ap, rc, "failed to close source container on retry");
 		}
 		rc = daos_pool_disconnect(ca->src_poh, NULL);
 		if (rc != 0) {
 			DH_PERROR_DER(ap, rc, "failed to disconnect source pool");
-			daos_pool_disconnect(ca->src_poh, NULL);
+			rc = daos_pool_disconnect(ca->src_poh, NULL);
+			if (rc != 0)
+				DH_PERROR_DER(ap, rc, "failed to disconnect source pool on retry");
 		}
 	}
 	if (dst_file_dfs->type == DAOS) {
 		if (is_posix_copy) {
 			rc = dfs_sys_umount(dst_file_dfs->dfs_sys);
 			if (rc != 0) {
-				rc = daos_errno2der(rc);
-				DH_PERROR_DER(ap, rc, "failed to unmount source");
-				dfs_sys_umount(dst_file_dfs->dfs_sys);
+				DH_PERROR_DER(ap, daos_errno2der(rc), "failed to unmount source");
+				rc = dfs_sys_umount(dst_file_dfs->dfs_sys);
+				if (rc != 0)
+					DH_PERROR_DER(ap, daos_errno2der(rc),
+						      "failed to unmount source on retry");
 			}
 			dst_file_dfs->dfs_sys = NULL;
 		}
 		rc = daos_cont_close(ca->dst_coh, NULL);
 		if (rc != 0) {
 			DH_PERROR_DER(ap, rc, "failed to close destination container");
-			daos_cont_close(ca->dst_coh, NULL);
+			rc = daos_cont_close(ca->dst_coh, NULL);
+			if (rc != 0)
+				DH_PERROR_DER(ap, rc,
+					      "failed to close destination container on retry");
 		}
 		rc = daos_pool_disconnect(ca->dst_poh, NULL);
 		if (rc != 0) {
 			DH_PERROR_DER(ap, rc, "failed to disconnect destination pool");
-			daos_pool_disconnect(ca->dst_poh, NULL);
+			rc = daos_pool_disconnect(ca->dst_poh, NULL);
+			if (rc != 0)
+				DH_PERROR_DER(ap, rc,
+					      "failed to disconnect destination pool on retry");
 		}
 	}
 	return rc;


### PR DESCRIPTION
Check return codes for retried functions in daos_hdlr disconnect code.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
