### PR TITLE
DAOS-13521 control: Reset unbound NVMe devs on daos_server nvme reset…

### DIFF
--- a/src/control/cmd/daos_server/storage_nvme.go
+++ b/src/control/cmd/daos_server/storage_nvme.go
@@ -305,21 +305,36 @@ func resetNVMe(resetReq storage.BdevPrepareRequest, cmd *nvmeCmd, resetBackend n
 	if err := processNVMePrepReq(cmd.Logger, cfgParam, cmd, &resetReq); err != nil {
 		return errors.Wrap(err, "processing request parameters")
 	}
-	// As reset nvme backend doesn't use NrHugepages, overwrite any set value with zero.
+
+	// Apply request parameter field values required specifically for reset operation.
 	resetReq.HugepageCount = 0
+	resetReq.HugeNodes = ""
+	resetReq.CleanHugepagesOnly = false
+	resetReq.Reset_ = true
 
 	cmd.Debugf("nvme reset request parameters: %+v", resetReq)
 
-	// TODO SPDK-2926: If VMD is enabled and PCI_ALLOWED list is set to a subset of VMD
-	//                 controllers (as specified in the server config file) then the backing
-	//                 devices of the unselected VMD controllers will be bound to no driver
-	//                 and therefore inaccessible from both OS and SPDK. Workaround is to run
-	//                 nvme scan --ignore-config to reset driver bindings.
+	resetResp, err := resetBackend(resetReq)
+	if err != nil {
+		return errors.Wrap(err, "nvme reset backend")
+	}
 
-	// Reset NVMe device access.
-	_, err := resetBackend(resetReq)
+	// SPDK-2926: If VMD has been detected, perform an extra SPDK reset (without PCI_ALLOWED)
+	//            to reset dangling NVMe devices left unbound after the DRIVER_OVERRIDE=none
+	//            setup call was used in nvme prepare.
+	if resetResp.VMDPrepared {
+		resetReq.PCIAllowList = ""
+		resetReq.PCIBlockList = ""
+		resetReq.EnableVMD = false // Prevents VMD endpoints being auto populated
 
-	return err
+		cmd.Debugf("vmd second nvme reset request parameters: %+v", resetReq)
+
+		if _, err := resetBackend(resetReq); err != nil {
+			return errors.Wrap(err, "nvme reset backend")
+		}
+	}
+
+	return nil
 }
 
 func (cmd *resetNVMeCmd) Execute(_ []string) error {
@@ -336,7 +351,6 @@ func (cmd *resetNVMeCmd) Execute(_ []string) error {
 		PCIAllowList: cmd.Args.PCIAllowList,
 		PCIBlockList: cmd.PCIBlockList,
 		DisableVFIO:  cmd.DisableVFIO,
-		Reset_:       true,
 	}
 
 	return resetNVMe(req, &cmd.nvmeCmd, scs.NvmePrepare)
@@ -391,16 +405,8 @@ func (cmd *scanNVMeCmd) scanNVMe(scanBackend nvmeScanFn, prepResetBackend nvmePr
 	cmd.Info(bld.String())
 
 	if !cmd.SkipPrep {
-		// TODO SPDK-2926: If VMD is enabled and PCI_ALLOWED list is set to a subset of VMD
-		//                 controllers (as specified in the server config file) then the
-		//                 backing devices of the unselected VMD controllers will be bound
-		//                 to no driver and therefore inaccessible from both OS and SPDK.
-		//                 Workaround is to run nvme scan --ignore-config to reset driver
-		//                 bindings.
-
 		req := storage.BdevPrepareRequest{
 			PCIAllowList: strings.Join(req.DeviceList.Devices(), storage.BdevPciAddrSep),
-			Reset_:       true,
 		}
 		if err := resetNVMe(req, &cmd.nvmeCmd, prepResetBackend); err != nil {
 			return errors.Wrap(err,

--- a/src/control/server/storage/bdev/backend_test.go
+++ b/src/control/server/storage/bdev/backend_test.go
@@ -961,6 +961,9 @@ func TestBackend_Prepare(t *testing.T) {
 					Args: []string{"reset"},
 				},
 			},
+			expResp: &storage.BdevPrepareResponse{
+				VMDPrepared: true,
+			},
 		},
 		"prepare setup; defaults": {
 			req: storage.BdevPrepareRequest{
@@ -1298,14 +1301,14 @@ func TestBackend_Prepare(t *testing.T) {
 			}
 
 			var gotErr error
+			var gotResp *storage.BdevPrepareResponse
 			if tc.reset {
-				gotErr = b.reset(tc.req, mockVmdDetect)
+				gotResp, gotErr = b.reset(tc.req, mockVmdDetect)
 			} else {
-				var gotResp *storage.BdevPrepareResponse
 				gotResp, gotErr = b.prepare(tc.req, mockVmdDetect, mockHpClean)
-				if diff := cmp.Diff(tc.expResp, gotResp); diff != "" {
-					t.Fatalf("\nunexpected prepare response (-want, +got):\n%s\n", diff)
-				}
+			}
+			if diff := cmp.Diff(tc.expResp, gotResp); diff != "" {
+				t.Fatalf("\nunexpected prepare response (-want, +got):\n%s\n", diff)
 			}
 			test.CmpErr(t, tc.expErr, gotErr)
 

--- a/src/control/server/storage/bdev/provider.go
+++ b/src/control/server/storage/bdev/provider.go
@@ -19,7 +19,7 @@ type (
 	// Backend defines a set of methods to be implemented by a Block Device backend.
 	Backend interface {
 		Prepare(storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error)
-		Reset(storage.BdevPrepareRequest) error
+		Reset(storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error)
 		Scan(storage.BdevScanRequest) (*storage.BdevScanResponse, error)
 		Format(storage.BdevFormatRequest) (*storage.BdevFormatResponse, error)
 		UpdateFirmware(pciAddr string, path string, slot int32) error
@@ -62,7 +62,7 @@ func (p *Provider) Scan(req storage.BdevScanRequest) (resp *storage.BdevScanResp
 func (p *Provider) Prepare(req storage.BdevPrepareRequest) (*storage.BdevPrepareResponse, error) {
 	if req.Reset_ {
 		p.log.Debug("run bdev storage provider prepare reset")
-		return &storage.BdevPrepareResponse{}, p.backend.Reset(req)
+		return p.backend.Reset(req)
 	}
 
 	p.log.Debug("run bdev storage provider prepare setup")


### PR DESCRIPTION
… (#12397)

To avoid undesired consequences related to
https://github.com/spdk/spdk/issues/2926, perform an extra SPDK reset
(without PCI_ALLOWED) at the end of the daos_server nvme reset command
when VMD is enabled. This will reset any dangling NVMe devices left
unbound after the DRIVER_OVERRIDE=none setup call was used in
daos_server nvme prepare.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
