### PR TITLE
DAOS-13214 control: Check engines are ready before fetching usage (#1…

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -506,12 +506,38 @@ func (c *ControlService) adjustScmSize(resp *ctlpb.ScanScmResp) {
 	}
 }
 
+func checkEnginesReady(instances []Engine) error {
+	for _, inst := range instances {
+		if !inst.IsReady() {
+			var err error = FaultDataPlaneNotStarted
+			if inst.IsStarted() {
+				err = errInstanceNotReady
+			}
+
+			return errors.Wrapf(err, "instance %d", inst.Index())
+		}
+	}
+
+	return nil
+}
+
 // StorageScan discovers non-volatile storage hardware on node.
 func (c *ControlService) StorageScan(ctx context.Context, req *ctlpb.StorageScanReq) (*ctlpb.StorageScanResp, error) {
 	if req == nil {
 		return nil, errors.New("nil request")
 	}
 	resp := new(ctlpb.StorageScanResp)
+
+	// In the case that usage stats are being requested, relevant flags for both SCM and NVMe
+	// will be set and so fail if engines are not ready for comms. This restriction should not
+	// be applied if only the Meta flag is set in the NVMe component of the request to continue
+	// to support off-line storage scan functionality which uses cached stats (e.g. dmg storage
+	// scan --nvme-meta).
+	if req.Scm.Usage && req.Nvme.Meta {
+		if err := checkEnginesReady(c.harness.Instances()); err != nil {
+			return nil, err
+		}
+	}
 
 	respScm, err := c.scanScm(ctx, req.Scm)
 	if err != nil {

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -73,6 +73,7 @@ func TestServer_CtlSvc_StorageScan_PreEngineStart(t *testing.T) {
 		smbc        *scm.MockBackendConfig
 		tierCfgs    storage.TierConfigs
 		expResp     *ctlpb.StorageScanResp
+		expErr      error
 	}{
 		"successful scan; scm namespaces": {
 			bmbc: &bdev.MockBackendConfig{
@@ -403,6 +404,17 @@ func TestServer_CtlSvc_StorageScan_PreEngineStart(t *testing.T) {
 				MemInfo: proto.MockPBMemInfo(),
 			},
 		},
+		"scan usage": {
+			req: &ctlpb.StorageScanReq{
+				Scm: &ctlpb.ScanScmReq{
+					Usage: true,
+				},
+				Nvme: &ctlpb.ScanNvmeReq{
+					Meta: true,
+				},
+			},
+			expErr: FaultDataPlaneNotStarted,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -434,8 +446,9 @@ func TestServer_CtlSvc_StorageScan_PreEngineStart(t *testing.T) {
 			}
 
 			resp, err := cs.StorageScan(test.Context(t), tc.req)
+			test.CmpErr(t, tc.expErr, err)
 			if err != nil {
-				t.Fatal(err)
+				return
 			}
 
 			if tc.req.Nvme.Health || tc.req.Nvme.Meta {
@@ -680,6 +693,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 		smsc              *system.MockSysConfig
 		storageCfgs       []storage.TierConfigs
 		engineTargetCount []int
+		enginesNotReady   bool
 		scanTwice         bool
 		junkResp          bool
 		drpcResps         map[int][]*mockDrpcResponse
@@ -1389,6 +1403,45 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				MemInfo: proto.MockPBMemInfo(),
 			},
 		},
+		"multi-engine; multi-tier; with usage; engines not ready": {
+			req: &ctlpb.StorageScanReq{
+				Scm:  &ctlpb.ScanScmReq{Usage: true},
+				Nvme: &ctlpb.ScanNvmeReq{Meta: true},
+			},
+			storageCfgs: []storage.TierConfigs{
+				{
+					storage.NewTierConfig().
+						WithStorageClass(storage.ClassDcpm.String()).
+						WithScmMountPoint(mockPbScmMount0.Path).
+						WithScmDeviceList(mockPbScmNamespace0.Blockdev),
+					storage.NewTierConfig().
+						WithStorageClass(storage.ClassNvme.String()).
+						WithBdevDeviceList(newCtrlr(1).PciAddr),
+				},
+				{
+					storage.NewTierConfig().
+						WithStorageClass(storage.ClassDcpm.String()).
+						WithScmMountPoint(mockPbScmMount1.Path).
+						WithScmDeviceList(mockPbScmNamespace1.Blockdev),
+					storage.NewTierConfig().
+						WithStorageClass(storage.ClassNvme.String()).
+						WithBdevDeviceList(newCtrlr(2).PciAddr),
+				},
+			},
+			engineTargetCount: []int{4, 4},
+			enginesNotReady:   true,
+			drpcResps: map[int][]*mockDrpcResponse{
+				0: {
+					{Message: newSmdDevResp(1)},
+					{Message: newBioHealthResp(1)},
+				},
+				1: {
+					{Message: newSmdDevResp(2)},
+					{Message: newBioHealthResp(2)},
+				},
+			},
+			expErr: errInstanceNotReady,
+		},
 		// Sometimes when more than a few ssds are assigned to engine without many targets,
 		// some of the smd entries for the latter ssds are in state "NEW" rather than
 		// "NORMAL", when in this state, health is unavailable and DER_NONEXIST is returned.
@@ -1552,7 +1605,11 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 						Controllers: *tc.eCtrlrs[idx],
 					})
 				}
-				ne := newTestEngine(log, false, sp, ec)
+				te := newTestEngine(log, false, sp, ec)
+
+				if tc.enginesNotReady {
+					te.ready.SetFalse()
+				}
 
 				// mock drpc responses
 				dcc := new(mockDrpcClientConfig)
@@ -1566,17 +1623,17 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 				} else {
 					t.Fatal("drpc response mocks unpopulated")
 				}
-				ne.setDrpcClient(newMockDrpcClient(dcc))
-				ne._superblock.Rank = ranklist.NewRankPtr(uint32(idx + 1))
-				ne.setTargetCount(tc.engineTargetCount[idx])
-				for _, tc := range ne.storage.GetBdevConfigs() {
+				te.setDrpcClient(newMockDrpcClient(dcc))
+				te._superblock.Rank = ranklist.NewRankPtr(uint32(idx + 1))
+				te.setTargetCount(tc.engineTargetCount[idx])
+				for _, tc := range te.storage.GetBdevConfigs() {
 					tc.Bdev.DeviceRoles.OptionBits = storage.OptionBits(storage.BdevRoleAll)
 				}
-				md := ne.storage.GetControlMetadata()
+				md := te.storage.GetControlMetadata()
 				md.Path = "/foo"
 				md.DevicePath = md.Path
 
-				cs.harness.instances[idx] = ne
+				cs.harness.instances[idx] = te
 			}
 			cs.harness.started.SetTrue()
 

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -185,12 +185,12 @@ func (ei *EngineInstance) logScmStorage() error {
 // ScanBdevTiers calls in to the private engine storage provider to scan bdev
 // tiers. Scan will avoid using any cached results if direct is set to true.
 func (ei *EngineInstance) ScanBdevTiers() ([]storage.BdevTierScanResult, error) {
-	isStarted := ei.IsStarted()
+	isUp := ei.IsReady()
 	upDn := "down"
-	if isStarted {
+	if isUp {
 		upDn = "up"
 	}
 	ei.log.Debugf("scanning engine-%d bdev tiers while engine is %s", ei.Index(), upDn)
 
-	return ei.storage.ScanBdevTiers(!isStarted)
+	return ei.storage.ScanBdevTiers(!isUp)
 }


### PR DESCRIPTION
…2448)

Engines send a notify ready message to indicate dRPC server is up and
running. Refuse to service a storage scan request with usage flag set
when a host's engines are not ready to enforce deterministic behavior.
Differentiate between a dmg storage query usage command request and
dmg storage scan --nvme-meta as the latter should be able to be called
when engines are off-line (in which case cached data will be returned).

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
