### PR TITLE
DAOS-13721 cart: Fix coverity cid 1426658

### DIFF
--- a/src/cart/crt_ctl.c
+++ b/src/cart/crt_ctl.c
@@ -117,11 +117,11 @@ crt_hdlr_ctl_get_uri_cache(crt_rpc_t *rpc_req)
 	out_args->cguc_grp_cache.ca_count  = uri_cache.idx; /* actual count */
 	rc = 0;
 out:
+	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 	out_args->cguc_rc = rc;
 	rc = crt_reply_send(rpc_req);
 	D_ASSERTF(rc == 0, "crt_reply_send() failed. rc: %d\n", rc);
 	D_DEBUG(DB_TRACE, "sent reply to get uri cache request\n");
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 	D_FREE(uri_cache.grp_cache);
 }
 


### PR DESCRIPTION
- Fix coverity cid 1426658 Thread dedlock

- Issuing 'get uri cache' command at the wrong time could end up in a deadlock due to latest changes to lockings

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
