### PR TITLE
DAOS-13766 control: Fix dmg set-logmasks reset bug

### DIFF
--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -918,7 +918,7 @@ func TestServer_updateSetEngineLogMasksReq(t *testing.T) {
 			expMasks:   "ERR,MISC=DBUG",
 			expStreams: "MGMT",
 		},
-		"all values specified in config": {
+		"reset all masks; simple": {
 			req: ctlpb.SetLogMasksReq{
 				Masks:           "DEBUG",
 				Streams:         "MGMT",
@@ -932,6 +932,17 @@ func TestServer_updateSetEngineLogMasksReq(t *testing.T) {
 			cfgSubsystems: "misc",
 			expMasks:      "ERR",
 			expStreams:    "md",
+		},
+		"reset all masks; complex": {
+			req: ctlpb.SetLogMasksReq{
+				ResetMasks:      true,
+				ResetStreams:    true,
+				ResetSubsystems: true,
+			},
+			cfgMasks:   "info,dtx=debug,vos=debug,object=debug",
+			cfgStreams: "io,epc",
+			expMasks:   "INFO,dtx=DBUG,vos=DBUG,object=DBUG",
+			expStreams: "io,epc",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -958,6 +969,7 @@ func TestServer_updateSetEngineLogMasksReq(t *testing.T) {
 		})
 	}
 }
+
 func TestServer_CtlSvc_SetEngineLogMasks(t *testing.T) {
 	for name, tc := range map[string]struct {
 		missingRank      bool

--- a/src/control/server/engine/utils.go
+++ b/src/control/server/engine/utils.go
@@ -281,6 +281,7 @@ func getLogLevelAssignments(masks, subsystemsStr string, baseLevel LogLevel) ([]
 		})
 	}
 
+	// Build subsystems slice from input string.
 	var subsystems []string
 	for _, ss := range strings.Split(subsystemsStr, logMasksStrAssignSep) {
 		if ss == "" || strings.ToUpper(ss) == "ALL" {
@@ -289,13 +290,18 @@ func getLogLevelAssignments(masks, subsystemsStr string, baseLevel LogLevel) ([]
 		subsystems = append(subsystems, ss)
 	}
 
-	// Remove assignments if level < ERROR and subsystem not in subsystems slice.
-	for i, a := range assignments {
-		if a.level < LogLevelErr && !common.Includes(subsystems, a.subsys) {
-			assignments = append(assignments[:i], assignments[i+1:]...)
-			i-- // slice just got shorter
+	if len(subsystems) == 0 {
+		return assignments, nil
+	}
+
+	// Remove assignments if assignment level < ERROR and subsystem not in subsystems slice.
+	var newAssignments []logSubsysLevel
+	for _, a := range assignments {
+		if a.level >= LogLevelErr || common.Includes(subsystems, a.subsys) {
+			newAssignments = append(newAssignments, a)
 		}
 	}
+	assignments = newAssignments
 
 	if baseLevel >= LogLevelErr {
 		return assignments, nil

--- a/src/control/server/engine/utils_test.go
+++ b/src/control/server/engine/utils_test.go
@@ -173,6 +173,10 @@ func Test_MergeLogEnvVars(t *testing.T) {
 			subsystems: "all",
 			expMasks:   "DBUG",
 		},
+		"long mask string": {
+			masks:    "info,dtx=debug,vos=debug,object=debug",
+			expMasks: "INFO,dtx=DBUG,vos=DBUG,object=DBUG",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			gotMasks, gotErr := MergeLogEnvVars(tc.masks, tc.subsystems)


### PR DESCRIPTION
When dmg  server set-logmasks is called without arguments it will
return engine masks to those specified in the server config file. Some
mask combinations cause a failure in the parsing logic due to out of
range array access. This change fixes the bug and improves unit test
code coverage.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
