### PR TITLE
DAOS-13475 doc: document fuse read bug in filesystem.md

### DIFF
--- a/docs/user/filesystem.md
+++ b/docs/user/filesystem.md
@@ -747,15 +747,12 @@ root cause is a bug in fuse Linux kernel module. The virtual address of user-spa
 read buffer was converted to physical page address. Once the data is ready, they
 are copied into the saved physical page address. Under certain circumstances such as
 page migration, the associated physical pages of the virtual address of read buffer
-has been changed. Consequently, fuse writes expected data into a wrong place and
-the read buffer holds wrong data. We speculate that such issue might be triggered
-by bad memory fragmentation. The issue has been reproduced under various versions
-of kernels, ranging from 3.10.0 to 6.3.6. Older kernels are not tested. We have
-a working patch to fix this bug under Linux kernel 6.3.6. This patch pins physical
-pages to avoid page migration when extracting physical pages from the virtual
-address of read buffer. We are working with Linux kernel community to upstream
-the patch to the latest Linux kernel. It may take some time to backport this patch
-to older kernels.
+has been changed. Consequently, fuse writes expected data into a wrong place and the
+read buffer holds wrong data. We have a patch for Linux kernel 6.3.6 to fix this issue.
+It pins physical pages to avoid page migration when extracting physical pages from
+the virtual address of read buffer. We are working with Linux kernel community to
+upstream the patch to the latest Linux kernel. It may take some time to backport
+this patch to older kernels.
 
 ## Interception Library `libioil`
 


### PR DESCRIPTION
Doc-only: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
