### PR TITLE
DAOS-13670 control: Add system name validation on startup

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
@@ -83,6 +84,11 @@ func LoadConfig(cfgPath string) (*Config, error) {
 	if err := yaml.UnmarshalStrict(data, cfg); err != nil {
 		return nil, err
 	}
+
+	if !daos.SystemNameIsValid(cfg.SystemName) {
+		return nil, fmt.Errorf("invalid system name: %q", cfg.SystemName)
+	}
+
 	return cfg, nil
 }
 

--- a/src/control/lib/control/config.go
+++ b/src/control/lib/control/config.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
@@ -92,6 +93,10 @@ func LoadConfig(cfgPath string) (*Config, error) {
 		return nil, err
 	}
 	cfg.Path = cfgPath
+
+	if !daos.SystemNameIsValid(cfg.SystemName) {
+		return nil, fmt.Errorf("invalid system name: %q", cfg.SystemName)
+	}
 
 	return cfg, nil
 }

--- a/src/control/lib/daos/system_prop.go
+++ b/src/control/lib/daos/system_prop.go
@@ -18,6 +18,21 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 )
 
+/*
+#include <daos_types.h>
+*/
+import "C"
+
+// SystemNameIsValid returns true if the given name is valid for a DAOS system.
+func SystemNameIsValid(name string) bool {
+	// NB: So far, this seems to be the only constraint on system names.
+	if name == "" || len(name) > C.DAOS_SYS_NAME_MAX {
+		return false
+	}
+
+	return true
+}
+
 // BoolPropVal is a boolean property value.
 type BoolPropVal bool
 

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/engine"
@@ -352,6 +353,10 @@ func (cfg *Server) Load() error {
 		return errors.WithMessagef(err, "parse of %q failed; config contains invalid "+
 			"parameters and may be out of date, see server config examples",
 			cfg.Path)
+	}
+
+	if !daos.SystemNameIsValid(cfg.SystemName) {
+		return errors.Errorf("invalid system name: %q", cfg.SystemName)
 	}
 
 	// Update server config based on legacy parameters.

--- a/src/tests/ftest/server/daos_server_config.py
+++ b/src/tests/ftest/server/daos_server_config.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2020-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -45,6 +45,14 @@ class DaosServerConfigTest(TestWithServers):
 
         # Get the input to verify
         c_val = self.params.get("config_val", "/run/server_config_val/*/")
+
+        if c_val[0] == "name":
+            # Set the dmg system name to match the server in order to avoid
+            # mismatch failures that aren't part of this test
+            self.assertTrue(
+                self.server_managers[-1].dmg.set_config_value(c_val[0], c_val[1]),
+                "Error setting the '{}' config file parameter to '{}'".format(
+                    c_val[0], c_val[1]))
 
         # Identify the attribute and modify its value to test value
         self.assertTrue(


### PR DESCRIPTION
Explicitly check the configured system name and fail if
it does not meet requirements.

Test-tag: pr test_daos_server_config_basic

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
