### PR TITLE
DAOS-13341 vos: few other error propagation issues (#12389)

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -1059,7 +1059,7 @@ btr_check_availability(struct btr_context *tcx, struct btr_check_alb *alb)
 	}
 }
 
-static void
+static int
 btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 			 struct btr_record *rec)
 {
@@ -1068,6 +1068,7 @@ btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 	bool		   leaf;
 	bool		   reuse = false;
 	char		   sbuf[BTR_PRINT_BUF];
+	int		   rc;
 
 	/* NB: assume trace->tr_node has been added to TX */
 	D_ASSERT(!btr_node_is_full(tcx, trace->tr_node));
@@ -1080,7 +1081,6 @@ btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 	nd = btr_off2ptr(tcx, trace->tr_node);
 	if (nd->tn_keyn > 0) {
 		struct btr_check_alb	alb;
-		int			rc;
 
 		if (trace->tr_at != nd->tn_keyn)
 			alb.at = trace->tr_at;
@@ -1102,7 +1102,9 @@ btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 	rec_a = btr_node_rec_at(tcx, trace->tr_node, trace->tr_at);
 
 	if (reuse) {
-		btr_rec_free(tcx, rec_a, NULL);
+		rc = btr_rec_free(tcx, rec_a, NULL);
+		if (rc)
+			return rc;
 	} else {
 		if (trace->tr_at != nd->tn_keyn) {
 			struct btr_record *rec_b;
@@ -1116,6 +1118,7 @@ btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 	}
 
 	btr_rec_copy(tcx, rec_a, rec, 1);
+	return 0;
 }
 
 /**
@@ -1194,7 +1197,9 @@ btr_node_split_and_insert(struct btr_context *tcx, struct btr_trace *trace,
 		D_DEBUG(DB_TRACE, "Splitting leaf node\n");
 
 		btr_rec_copy(tcx, rec_dst, rec_src, nd_right->tn_keyn);
-		btr_node_insert_rec_only(tcx, trace, rec);
+		rc = btr_node_insert_rec_only(tcx, trace, rec);
+		if (rc)
+			return rc;
 
 		/* insert the right node and the first key of the right
 		 * node to its parent
@@ -1241,7 +1246,9 @@ btr_node_split_and_insert(struct btr_context *tcx, struct btr_trace *trace,
 	 */
 	btr_hkey_copy(tcx, &hkey_buf[0], &rec_src->rec_hkey[0]);
 
-	btr_node_insert_rec_only(tcx, trace, rec);
+	rc = btr_node_insert_rec_only(tcx, trace, rec);
+	if (rc)
+		return rc;
 
 	btr_hkey_copy(tcx, &rec->rec_hkey[0], &hkey_buf[0]);
 
@@ -1347,7 +1354,7 @@ btr_node_insert_rec(struct btr_context *tcx, struct btr_trace *trace,
 	if (btr_node_is_full(tcx, trace->tr_node))
 		rc = btr_node_split_and_insert(tcx, trace, rec);
 	else
-		btr_node_insert_rec_only(tcx, trace, rec);
+		rc = btr_node_insert_rec_only(tcx, trace, rec);
 done:
 	return rc;
 }
@@ -2011,7 +2018,9 @@ btr_update(struct btr_context *tcx, d_iov_t *key, d_iov_t *val, d_iov_t *val_out
 		}
 
 		D_DEBUG(DB_TRACE, "Replace the original record\n");
-		btr_rec_free(tcx, rec, NULL);
+		rc = btr_rec_free(tcx, rec, NULL);
+		if (rc)
+			goto out;
 		rc = btr_rec_alloc(tcx, key, val, rec, val_out);
 	}
 out:


### PR DESCRIPTION
Fixed few error propagation issues in btree implementation.

Note: The error cleanup in current btree implementation mostly relies on PMDK transaction abort, so memory leak could happen during the error cleanup for VMEM based tree. This patch only fixes the error propagation issue which could lead to assertion on PMDK tx commit, it doesn't intend to fix the error cleanup issues for VMEM based tree.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
