### PR TITLE
DAOS-13792 dfs: fix for coverity 1443161 (#12486)

### DIFF
--- a/src/client/dfs/dfs_internal.c
+++ b/src/client/dfs/dfs_internal.c
@@ -88,11 +88,15 @@ static d_hash_table_ops_t hdl_hash_ops = {
 	.hop_rec_hash = rec_hash
 };
 
-int
+bool
 dfs_is_init()
 {
-	if (module_initialized > 0)
+	D_MUTEX_LOCK(&module_lock);
+	if (module_initialized > 0) {
+		D_MUTEX_UNLOCK(&module_lock);
 		return true;
+	}
+	D_MUTEX_UNLOCK(&module_lock);
 	return false;
 }
 

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -43,7 +43,7 @@ dfs_hdl_insert(const char *str, int type, const char *pool, daos_handle_t *oh,
 	       struct dfs_mnt_hdls **_hdl);
 int
 dfs_hdl_cont_destroy(const char *pool, const char *cont, bool force);
-int
+bool
 dfs_is_init();
 
 /*


### PR DESCRIPTION
lock module when checking for dfs is_init.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
