### PR TITLE
Tanabarr/control drpc check ready 2

### DIFF
--- a/src/control/lib/daos/status.go
+++ b/src/control/lib/daos/status.go
@@ -26,6 +26,10 @@ func (ds Status) Error() string {
 	return fmt.Sprintf("%s(%d): %s", dErrStr, ds, dErrDesc)
 }
 
+func (ds Status) Int32() int32 {
+	return int32(ds)
+}
+
 const (
 	// Success indicates no error
 	Success Status = 0

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -434,11 +434,6 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 				idx, ei.Index())
 		}
 
-		if !ei.IsReady() {
-			resp.Errors[idx] = "not ready"
-			continue
-		}
-
 		if err := updateSetLogMasksReq(svc.srvCfg.Engines[idx], &eReq); err != nil {
 			resp.Errors[idx] = err.Error()
 			continue

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -991,8 +991,8 @@ func TestServer_CtlSvc_SetEngineLogMasks(t *testing.T) {
 			instancesStopped: true,
 			expResp: &ctlpb.SetLogMasksResp{
 				Errors: []string{
-					"not ready",
-					"not ready",
+					errEngineNotReady.Error(),
+					errEngineNotReady.Error(),
 				},
 			},
 		},

--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -238,7 +238,7 @@ type devID struct {
 	uuid   string
 }
 
-type engineDevMap map[*Engine][]devID
+type engineDevMap map[Engine][]devID
 
 // Map requested device IDs provided in comma-separated string to the engine that controls the given
 // device. Device can be identified either by UUID or transport (PCI) address.
@@ -258,14 +258,14 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 	edm := make(engineDevMap)
 
 	for _, rr := range resp.Ranks {
-		eis, err := svc.harness.FilterInstancesByRankSet(fmt.Sprintf("%d", rr.Rank))
+		engines, err := svc.harness.FilterInstancesByRankSet(fmt.Sprintf("%d", rr.Rank))
 		if err != nil {
 			return nil, err
 		}
-		if len(eis) == 0 {
+		if len(engines) == 0 {
 			return nil, errors.Errorf("failed to retrieve instance for rank %d", rr.Rank)
 		}
-		eisPtr := &eis[0]
+		engine := engines[0]
 		for _, dev := range rr.Devices {
 			if dev == nil {
 				return nil, errors.New("nil device in smd query resp")
@@ -282,7 +282,7 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 				if trAddrs[dds.TrAddr] || uuidMatch {
 					// If UUID matches, add by TrAddr rather than UUID which
 					// should avoid duplicate UUID entries for the same TrAddr.
-					edm[eisPtr] = append(edm[eisPtr], devID{trAddr: dds.TrAddr})
+					edm[engine] = append(edm[engine], devID{trAddr: dds.TrAddr})
 					delete(trAddrs, dds.TrAddr)
 					delete(devUUIDs, dds.Uuid)
 					continue
@@ -291,7 +291,7 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 
 			if uuidMatch {
 				// Only add UUID entry if TrAddr is not available for a device.
-				edm[eisPtr] = append(edm[eisPtr], devID{uuid: dds.Uuid})
+				edm[engine] = append(edm[engine], devID{uuid: dds.Uuid})
 				delete(devUUIDs, dds.Uuid)
 			}
 		}
@@ -306,8 +306,14 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 	return edm, nil
 }
 
-func sendManageReq(c context.Context, e *Engine, m drpc.Method, b proto.Message) (*ctlpb.SmdManageResp_Result, error) {
-	dResp, err := (*e).CallDrpc(c, m, b)
+func sendManageReq(c context.Context, e Engine, m drpc.Method, b proto.Message) (*ctlpb.SmdManageResp_Result, error) {
+	if !e.IsReady() {
+		return &ctlpb.SmdManageResp_Result{
+			Status: daos.Unreachable.Int32(),
+		}, nil
+	}
+
+	dResp, err := e.CallDrpc(c, m, b)
 	if err != nil {
 		return nil, errors.Wrap(err, "call drpc")
 	}
@@ -372,7 +378,7 @@ func (svc *ControlService) SmdManage(ctx context.Context, req *ctlpb.SmdManageRe
 	for engine, devs := range engineDevMap {
 		devResults := []*ctlpb.SmdManageResp_Result{}
 
-		rank, err := (*engine).GetRank()
+		rank, err := engine.GetRank()
 		if err != nil {
 			return nil, errors.Wrap(err, "retrieving engine rank")
 		}

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -511,7 +511,7 @@ func checkEnginesReady(instances []Engine) error {
 		if !inst.IsReady() {
 			var err error = FaultDataPlaneNotStarted
 			if inst.IsStarted() {
-				err = errInstanceNotReady
+				err = errEngineNotReady
 			}
 
 			return errors.Wrapf(err, "instance %d", inst.Index())

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -1440,7 +1440,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 					{Message: newBioHealthResp(2)},
 				},
 			},
-			expErr: errInstanceNotReady,
+			expErr: errEngineNotReady,
 		},
 		// Sometimes when more than a few ssds are assigned to engine without many targets,
 		// some of the smd entries for the latter ssds are in state "NEW" rather than

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -189,7 +189,7 @@ func (h *EngineHarness) CallDrpc(ctx context.Context, method drpc.Method, body p
 		resp, err = i.CallDrpc(ctx, method, body)
 
 		switch errors.Cause(err) {
-		case errEngineNotReady, errDRPCNotReady, FaultDataPlaneNotStarted:
+		case errEngineNotReady, errDRPCNotReady:
 			continue
 		default:
 			return

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -166,7 +166,7 @@ func (h *EngineHarness) CallDrpc(ctx context.Context, method drpc.Method, body p
 		}
 		// Don't trigger callbacks for these errors which can happen when
 		// things are still starting up.
-		if err == FaultHarnessNotStarted || err == errInstanceNotReady {
+		if err == FaultHarnessNotStarted || err == errEngineNotReady {
 			return
 		}
 
@@ -186,22 +186,10 @@ func (h *EngineHarness) CallDrpc(ctx context.Context, method drpc.Method, body p
 	// the first one that is available to service the request.
 	// If the request fails, that error will be returned.
 	for _, i := range h.Instances() {
-		if !i.IsReady() {
-			if i.IsStarted() {
-				if err == nil {
-					err = errInstanceNotReady
-				}
-			} else {
-				if err == nil {
-					err = FaultDataPlaneNotStarted
-				}
-			}
-			continue
-		}
 		resp, err = i.CallDrpc(ctx, method, body)
 
 		switch errors.Cause(err) {
-		case errDRPCNotReady, FaultDataPlaneNotStarted:
+		case errEngineNotReady, errDRPCNotReady, FaultDataPlaneNotStarted:
 			continue
 		default:
 			return

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -537,10 +537,11 @@ func TestServer_Harness_CallDrpc(t *testing.T) {
 		"instance not ready": {
 			mics: []*MockInstanceConfig{
 				{
-					Started: atm.NewBool(true),
+					Started:     atm.NewBool(true),
+					CallDrpcErr: errEngineNotReady,
 				},
 			},
-			expErr: errInstanceNotReady,
+			expErr: errEngineNotReady,
 		},
 		"harness not started": {
 			mics:       []*MockInstanceConfig{},

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -273,16 +273,22 @@ func (ei *EngineInstance) handleReady(ctx context.Context, ready *srvpb.NotifyRe
 	return ei.SetupRank(ctx, r, mapVersion)
 }
 
-func (ei *EngineInstance) SetupRank(ctx context.Context, rank ranklist.Rank, map_version uint32) error {
-	if err := ei.callSetRank(ctx, rank, map_version); err != nil {
+func (ei *EngineInstance) SetupRank(ctx context.Context, rank ranklist.Rank, map_version uint32) (err error) {
+	ei.ready.SetTrue()
+	defer func() {
+		if err != nil {
+			ei.ready.SetFalse()
+		}
+	}()
+
+	if err = ei.callSetRank(ctx, rank, map_version); err != nil {
 		return errors.Wrap(err, "SetRank failed")
 	}
 
-	if err := ei.callSetUp(ctx); err != nil {
+	if err = ei.callSetUp(ctx); err != nil {
 		return errors.Wrap(err, "SetUp failed")
 	}
 
-	ei.ready.SetTrue()
 	return nil
 }
 

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -273,27 +273,21 @@ func (ei *EngineInstance) handleReady(ctx context.Context, ready *srvpb.NotifyRe
 	return ei.SetupRank(ctx, r, mapVersion)
 }
 
-func (ei *EngineInstance) SetupRank(ctx context.Context, rank ranklist.Rank, map_version uint32) (err error) {
-	ei.ready.SetTrue()
-	defer func() {
-		if err != nil {
-			ei.ready.SetFalse()
-		}
-	}()
-
-	if err = ei.callSetRank(ctx, rank, map_version); err != nil {
+func (ei *EngineInstance) SetupRank(ctx context.Context, rank ranklist.Rank, map_version uint32) error {
+	if err := ei.callSetRank(ctx, rank, map_version); err != nil {
 		return errors.Wrap(err, "SetRank failed")
 	}
 
-	if err = ei.callSetUp(ctx); err != nil {
+	if err := ei.callSetUp(ctx); err != nil {
 		return errors.Wrap(err, "SetUp failed")
 	}
 
+	ei.ready.SetTrue()
 	return nil
 }
 
 func (ei *EngineInstance) callSetRank(ctx context.Context, rank ranklist.Rank, map_version uint32) error {
-	dresp, err := ei.CallDrpc(ctx, drpc.MethodSetRank, &mgmtpb.SetRankReq{Rank: rank.Uint32(), MapVersion: map_version})
+	dresp, err := ei.callDrpc(ctx, drpc.MethodSetRank, &mgmtpb.SetRankReq{Rank: rank.Uint32(), MapVersion: map_version})
 	if err != nil {
 		return err
 	}
@@ -361,7 +355,7 @@ func (ei *EngineInstance) GetTargetCount() int {
 }
 
 func (ei *EngineInstance) callSetUp(ctx context.Context) error {
-	dresp, err := ei.CallDrpc(ctx, drpc.MethodSetUp, nil)
+	dresp, err := ei.callDrpc(ctx, drpc.MethodSetUp, nil)
 	if err != nil {
 		return err
 	}

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -67,12 +67,7 @@ func (ei *EngineInstance) awaitDrpcReady() chan *srvpb.NotifyReadyReq {
 	return ei.drpcReady
 }
 
-// CallDrpc makes the supplied dRPC call via this instance's dRPC client.
-func (ei *EngineInstance) CallDrpc(ctx context.Context, method drpc.Method, body proto.Message) (*drpc.Response, error) {
-	if !ei.IsReady() {
-		return nil, errEngineNotReady
-	}
-
+func (ei *EngineInstance) callDrpc(ctx context.Context, method drpc.Method, body proto.Message) (*drpc.Response, error) {
 	dc, err := ei.getDrpcClient()
 	if err != nil {
 		return nil, err
@@ -89,6 +84,15 @@ func (ei *EngineInstance) CallDrpc(ctx context.Context, method drpc.Method, body
 	}()
 
 	return makeDrpcCall(ctx, ei.log, dc, method, body)
+}
+
+// CallDrpc makes the supplied dRPC call via this instance's dRPC client.
+func (ei *EngineInstance) CallDrpc(ctx context.Context, method drpc.Method, body proto.Message) (*drpc.Response, error) {
+	if !ei.IsReady() {
+		return nil, errEngineNotReady
+	}
+
+	return ei.callDrpc(ctx, method, body)
 }
 
 // drespToMemberResult converts drpc.Response to system.MemberResult.

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -28,8 +28,8 @@ import (
 )
 
 var (
-	errDRPCNotReady     = errors.New("no dRPC client set (data plane not started?)")
-	errInstanceNotReady = errors.New("instance not ready yet")
+	errDRPCNotReady   = errors.New("no dRPC client set (data plane not started?)")
+	errEngineNotReady = errors.New("engine not ready yet")
 )
 
 func (ei *EngineInstance) setDrpcClient(c drpc.DomainSocketClient) {
@@ -69,6 +69,10 @@ func (ei *EngineInstance) awaitDrpcReady() chan *srvpb.NotifyReadyReq {
 
 // CallDrpc makes the supplied dRPC call via this instance's dRPC client.
 func (ei *EngineInstance) CallDrpc(ctx context.Context, method drpc.Method, body proto.Message) (*drpc.Response, error) {
+	if !ei.IsReady() {
+		return nil, errEngineNotReady
+	}
+
 	dc, err := ei.getDrpcClient()
 	if err != nil {
 		return nil, err

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -455,7 +455,7 @@ func (svc *mgmtSvc) poolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 		}
 
 		switch errors.Cause(err) {
-		case errInstanceNotReady:
+		case errEngineNotReady:
 			// If the pool create failed because there was no available instance
 			// to service the request, signal to the client that it should try again.
 			resp.Status = int32(daos.TryAgain)

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -251,7 +251,7 @@ func (svc *mgmtSvc) doGroupUpdate(ctx context.Context, forced bool) error {
 	svc.log.Debugf("group update request: version: %d, ranks: %s", req.MapVersion, rankSet)
 	dResp, err := svc.harness.CallDrpc(ctx, drpc.MethodGroupUpdate, req)
 	if err != nil {
-		if err == errInstanceNotReady {
+		if err == errEngineNotReady {
 			return err
 		}
 		svc.log.Errorf("dRPC GroupUpdate call failed: %s", err)


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
