### PR TITLE
DAOS-13801 array: fix possible double free with FI (#12507)

### DIFF
--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -2478,6 +2478,7 @@ dc_array_set_size(tse_task_t *task)
 	daos_obj_list_dkey_t	*enum_args;
 	struct set_size_props	*set_size_props = NULL;
 	tse_task_t		*enum_task;
+	bool			cleanup = true;
 	int			rc;
 
 	args = daos_task_get_args(task);
@@ -2537,8 +2538,14 @@ dc_array_set_size(tse_task_t *task)
 	enum_args->sgl		= &set_size_props->sgl;
 	enum_args->dkey_anchor	= &set_size_props->anchor;
 
-	rc = tse_task_register_cbs(enum_task, NULL, NULL, 0, adjust_array_size_cb, &set_size_props,
-				   sizeof(set_size_props));
+	rc = tse_task_register_comp_cb(task, free_set_size_cb, &set_size_props,
+				       sizeof(set_size_props));
+	if (rc)
+		D_GOTO(err_enum_task, rc);
+	cleanup = false;
+
+	rc = tse_task_register_comp_cb(enum_task, adjust_array_size_cb, &set_size_props,
+				       sizeof(set_size_props));
 	if (rc)
 		D_GOTO(err_enum_task, rc);
 
@@ -2546,22 +2553,19 @@ dc_array_set_size(tse_task_t *task)
 	if (rc)
 		D_GOTO(err_enum_task, rc);
 
-	rc = tse_task_register_comp_cb(task, free_set_size_cb, &set_size_props,
-				       sizeof(set_size_props));
-	if (rc)
-		D_GOTO(err_enum_task, rc);
-
 	rc = tse_task_schedule(enum_task, true);
 	if (rc)
-		D_GOTO(err_enum_task, rc);
+		D_GOTO(err_task, rc);
 
 	return 0;
 err_enum_task:
 	tse_task_complete(enum_task, rc);
 err_task:
-	D_FREE(set_size_props);
-	if (array)
-		array_decref(array);
 	tse_task_complete(task, rc);
+	if (cleanup) {
+		D_FREE(set_size_props);
+		if (array)
+			array_decref(array);
+	}
 	return rc;
 } /* end daos_array_set_size */

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1246,8 +1246,14 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 		rc = insert_entry(dfs->layout_v, parent->oh, DAOS_TX_NONE, file->name, len,
 				  DAOS_COND_DKEY_INSERT, entry);
 		if (rc == EEXIST && !oexcl) {
+			int rc2;
+
 			/** just try fetching entry to open the file */
-			daos_array_close(file->oh, NULL);
+			rc2 = daos_array_close(file->oh, NULL);
+			if (rc2 == -DER_NOMEM)
+				rc2 = daos_array_close(file->oh, NULL);
+			if (rc2)
+				return daos_der2errno(rc2);
 		} else if (rc) {
 			int rc2;
 


### PR DESCRIPTION
Fix issue when truncating arrays.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
