### PR TITLE
DAOS-13175 dfs: print progress of dfs mwc checker (#12470)

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -6453,6 +6453,7 @@ dfs_dir_anchor_set(dfs_obj_t *obj, const char name[], daos_anchor_t *anchor)
 #define DFS_ITER_NR		128
 #define DFS_ITER_DKEY_BUF	(DFS_ITER_NR * sizeof(uint64_t))
 #define DFS_ITER_ENTRY_BUF	(DFS_ITER_NR * DFS_MAX_NAME)
+#define DFS_ELAPSED_TIME	30
 
 struct dfs_oit_args {
 	daos_handle_t	oit;
@@ -6460,6 +6461,9 @@ struct dfs_oit_args {
 	uint64_t	snap_epoch;
 	uint64_t	skipped;
 	uint64_t	failed;
+	time_t		start_time;
+	time_t		print_time;
+	uint64_t	num_scanned;
 };
 
 static int
@@ -6555,7 +6559,18 @@ oit_mark_cb(dfs_t *dfs, dfs_obj_t *parent, const char name[], void *args)
 	daos_obj_id_t		oid;
 	d_iov_t			marker;
 	bool			mark_data = true;
+	struct timespec		current_time;
 	int			rc;
+
+	rc = clock_gettime(CLOCK_REALTIME, &current_time);
+	if (rc)
+		return errno;
+	oit_args->num_scanned ++;
+	if (current_time.tv_sec - oit_args->print_time >= DFS_ELAPSED_TIME) {
+		D_PRINT("DFS checker: Scanned "DF_U64" files/directories (runtime: "DF_U64" sec)\n",
+			oit_args->num_scanned, current_time.tv_sec - oit_args->start_time);
+		oit_args->print_time = current_time.tv_sec;
+	}
 
 	/** open the entry name and get the oid */
 	rc = dfs_lookup_rel(dfs, parent, name, O_RDONLY, &obj, NULL, NULL);
@@ -6702,11 +6717,23 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 	d_iov_t			marker;
 	bool			mark_data = true;
 	daos_epoch_range_t	epr;
-	struct timespec		now;
+	struct timespec		now, current_time;
 	uid_t			uid = geteuid();
 	gid_t			gid = getegid();
 	unsigned int		co_flags = DAOS_COO_EX;
+	char			now_name[24];
+	struct tm		*now_tm;
+	daos_size_t		len;
 	int			rc, rc2;
+
+	rc = clock_gettime(CLOCK_REALTIME, &now);
+	if (rc)
+		return errno;
+	now_tm = localtime(&now.tv_sec);
+	len = strftime(now_name, sizeof(now_name), "%Y-%m-%d-%H:%M:%S", now_tm);
+	if (len == 0)
+		return EINVAL;
+	D_PRINT("DFS checker: Start (%s)\n", now_name);
 
 	if (flags & DFS_CHECK_RELINK && flags & DFS_CHECK_REMOVE) {
 		D_ERROR("can't request remove and link to l+f at the same time\n");
@@ -6728,6 +6755,7 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 		D_GOTO(out_cont, rc);
 	}
 
+	D_PRINT("DFS checker: Create OIT table\n");
 	/** create snapshot for OIT */
 	rc = daos_cont_create_snap_opt(coh, &snap_epoch, NULL, DAOS_SNAP_OPT_CR | DAOS_SNAP_OPT_OIT,
 				       NULL);
@@ -6741,6 +6769,8 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 		D_GOTO(out_dfs, rc = ENOMEM);
 	oit_args->flags = flags;
 	oit_args->snap_epoch = snap_epoch;
+	oit_args->start_time = now.tv_sec;
+	oit_args->print_time = now.tv_sec;
 
 	/** Open OIT table */
 	rc = daos_oit_open(coh, snap_epoch, &oit_args->oit, NULL);
@@ -6757,10 +6787,11 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 		D_GOTO(out_oit, rc = daos_der2errno(rc));
 	}
 	rc = daos_oit_mark(oit_args->oit, dfs->root.oid, &marker, NULL);
-	if (rc) {
+	if (rc && rc != -DER_NONEXIST) {
 		D_ERROR("Failed to mark ROOT OID in OIT: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out_oit, rc = daos_der2errno(rc));
 	}
+	rc = 0;
 
 	if (flags & DFS_CHECK_VERIFY) {
 		rc = daos_obj_verify(coh, dfs->super_oid, snap_epoch);
@@ -6790,6 +6821,8 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 		}
 	}
 
+	D_PRINT("DFS checker: Iterating namespace and marking objects\n");
+	oit_args->num_scanned = 2;
 	/** iterate through the namespace and mark OITs starting from the root object */
 	while (!daos_anchor_is_eof(&anchor)) {
 		rc = dfs_iterate(dfs, &dfs->root, &anchor, &nr_entries, DFS_MAX_NAME * nr_entries,
@@ -6802,14 +6835,14 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 		nr_entries = DFS_ITER_NR;
 	}
 
-	/** Create lost+found directory and properly link unmarked oids there. */
+	rc = clock_gettime(CLOCK_REALTIME, &current_time);
+	if (rc)
+		D_GOTO(out_oit, rc = errno);
+	D_PRINT("DFS checker: marked "DF_U64" files/directories (runtime: "DF_U64" sec))\n",
+		oit_args->num_scanned, current_time.tv_sec - oit_args->start_time);
+
+	/** Create lost+found directory to link unmarked oids there. */
 	if (flags & DFS_CHECK_RELINK) {
-		char		now_name[24];
-
-		rc = clock_gettime(CLOCK_REALTIME, &now);
-		if (rc)
-			D_GOTO(out_oit, rc = errno);
-
 		rc = dfs_open(dfs, NULL, "lost+found", S_IFDIR | 0755, O_CREAT | O_RDWR, 0, 0, NULL,
 			      &lf);
 		if (rc) {
@@ -6818,21 +6851,15 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 		}
 
 		if (name == NULL) {
-			struct tm	*now_tm;
-			size_t		len;
 			/*
 			 * Create a directory with current timestamp in l+f where leaked oids will
 			 * be linked in this run.
 			 */
-			now_tm = localtime(&now.tv_sec);
-			len = strftime(now_name, sizeof(now_name), "%Y-%m-%d-%H:%M:%S", now_tm);
-			if (len == 0) {
-				D_ERROR("Invalid time format\n");
-				D_GOTO(out_lf1, rc = EINVAL);
-			}
-			D_PRINT("Leaked OIDs will be inserted in /lost+found/%s\n", now_name);
+			D_PRINT("DFS checker: Leaked OIDs will be inserted in /lost+found/%s\n",
+				now_name);
 		} else {
-			D_PRINT("Leaked OIDs will be inserted in /lost+found/%s\n", name);
+			D_PRINT("DFS checker: Leaked OIDs will be inserted in /lost+found/%s\n",
+				name);
 		}
 
 		rc = dfs_open(dfs, lf, name ? name : now_name, S_IFDIR | 0755,
@@ -6864,6 +6891,8 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 	 * Pass 1: check directories only and descend to mark all oids in the namespace of each dir.
 	 * Pass 2: relink remaining oids in the L+F root that are unmarked still after first pass.
 	 */
+	D_PRINT("DFS checker: Checking unmarked OIDs (Pass 1)\n");
+	oit_args->num_scanned = 0;
 	memset(&anchor, 0, sizeof(anchor));
 	/** Start Pass 1 */
 	while (!daos_anchor_is_eof(&anchor)) {
@@ -6872,6 +6901,16 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 		if (rc) {
 			D_ERROR("daos_oit_list_unmarked() failed: "DF_RC"\n", DP_RC(rc));
 			D_GOTO(out_lf2, rc = daos_der2errno(rc));
+		}
+
+		clock_gettime(CLOCK_REALTIME, &current_time);
+		if (rc)
+			D_GOTO(out_lf2, rc = errno);
+		oit_args->num_scanned += nr_entries;
+		if (current_time.tv_sec - oit_args->print_time >= DFS_ELAPSED_TIME) {
+			D_PRINT("DFS checker: Checked "DF_U64" objects (runtime: "DF_U64" sec)\n",
+				oit_args->num_scanned, current_time.tv_sec - oit_args->start_time);
+			oit_args->print_time = current_time.tv_sec;
 		}
 
 		for (i = 0; i < nr_entries; i++) {
@@ -6934,6 +6973,8 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 	if (!(flags & DFS_CHECK_RELINK))
 		goto done;
 
+	D_PRINT("DFS checker: Checking unmarked OIDs (Pass 2)\n");
+	oit_args->num_scanned = 0;
 	memset(&anchor, 0, sizeof(anchor));
 	while (!daos_anchor_is_eof(&anchor)) {
 		nr_entries = DFS_ITER_NR;
@@ -6943,11 +6984,20 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 			D_GOTO(out_lf2, rc = daos_der2errno(rc));
 		}
 
+		clock_gettime(CLOCK_REALTIME, &current_time);
+		if (rc)
+			D_GOTO(out_lf2, rc = errno);
+		oit_args->num_scanned += nr_entries;
+		if (current_time.tv_sec - oit_args->print_time >= DFS_ELAPSED_TIME) {
+			D_PRINT("DFS checker: Checked "DF_U64" objects (runtime: "DF_U64" sec)\n",
+				oit_args->num_scanned, current_time.tv_sec - oit_args->start_time);
+			oit_args->print_time = current_time.tv_sec;
+		}
+
 		for (i = 0; i < nr_entries; i++) {
 			struct dfs_entry	entry = {0};
 			enum daos_otype_t	otype = daos_obj_id2type(oids[i]);
 			char			oid_name[DFS_MAX_NAME + 1];
-			daos_size_t		len;
 
 			if (flags & DFS_CHECK_PRINT)
 				D_PRINT("oid["DF_U64"]: "DF_OID"\n", unmarked_entries,
@@ -7016,8 +7066,12 @@ dfs_cont_check(daos_handle_t poh, const char *cont, uint64_t flags, const char *
 	}
 
 done:
-	if (flags & DFS_CHECK_PRINT)
-		D_PRINT("Number of Leaked OIDs in Namespace = "DF_U64"\n", unmarked_entries);
+	rc = clock_gettime(CLOCK_REALTIME, &current_time);
+	if (rc)
+		D_GOTO(out_lf2, rc = errno);
+	D_PRINT("DFS checker: Done! (runtime: "DF_U64" sec)\n",
+		current_time.tv_sec - oit_args->start_time);
+	D_PRINT("DFS checker: Number of leaked OIDs in namespace = "DF_U64"\n", unmarked_entries);
 	if (flags & DFS_CHECK_VERIFY) {
 		if (oit_args->failed) {
 			D_ERROR(""DF_U64" OIDs failed data consistency check!\n", oit_args->failed);
@@ -7057,6 +7111,7 @@ out_cont:
 	rc2 = daos_cont_close(coh, NULL);
 	if (rc == 0)
 		rc = daos_der2errno(rc2);
+
 	return rc;
 }
 

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -3548,7 +3548,7 @@ class PosixTests():
         assert rc.returncode == 0
         output = rc.stdout.decode('utf-8')
         line = output.splitlines()
-        if line[-1] != 'Number of Leaked OIDs in Namespace = 2':
+        if line[-1] != 'DFS checker: Number of leaked OIDs in namespace = 2':
             raise NLTestFail('Wrong number of Leaked OIDs')
 
         # run again to check nothing is detected
@@ -3558,7 +3558,7 @@ class PosixTests():
         assert rc.returncode == 0
         output = rc.stdout.decode('utf-8')
         line = output.splitlines()
-        if line[-1] != 'Number of Leaked OIDs in Namespace = 0':
+        if line[-1] != 'DFS checker: Number of leaked OIDs in namespace = 0':
             raise NLTestFail('Wrong number of Leaked OIDs')
 
         # remount dfuse
@@ -3613,7 +3613,7 @@ class PosixTests():
         assert rc.returncode == 0
         output = rc.stdout.decode('utf-8')
         line = output.splitlines()
-        if line[-1] != 'Number of Leaked OIDs in Namespace = 4':
+        if line[-1] != 'DFS checker: Number of leaked OIDs in namespace = 4':
             raise NLTestFail('Wrong number of Leaked OIDs')
 
         # run again to check nothing is detected
@@ -3623,7 +3623,7 @@ class PosixTests():
         assert rc.returncode == 0
         output = rc.stdout.decode('utf-8')
         line = output.splitlines()
-        if line[-1] != 'Number of Leaked OIDs in Namespace = 0':
+        if line[-1] != 'DFS checker: Number of leaked OIDs in namespace = 0':
             raise NLTestFail('Wrong number of Leaked OIDs')
 
         # remount dfuse


### PR DESCRIPTION
Every 30 seconds print how many objects have been scanned in the dfs namespace or marked in the OIT. This informs users that there is some progress being done by the checker and it's not hung in case of a large namespace.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
