### PR TITLE
DAOS-13493 rebuild: upgrate the whole group

### DIFF
--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -779,7 +779,7 @@ ds_migrate_stop(struct ds_pool *pool, uint32_t ver, unsigned int generation);
 
 int
 obj_layout_diff(struct pl_map *map, daos_unit_oid_t oid, uint32_t new_ver, uint32_t old_ver,
-		struct daos_obj_md *md, uint32_t *tgt, uint32_t *shard_p);
+		struct daos_obj_md *md, uint32_t *tgts, uint32_t *shards, int array_size);
 
 /** Server init state (see server_init) */
 enum dss_init_state {

--- a/src/object/obj_layout.c
+++ b/src/object/obj_layout.c
@@ -40,7 +40,7 @@ obj_pl_place(struct pl_map *map, uint16_t layout_gl_ver, struct daos_obj_md *md,
 /* Find out the difference between different layouts */
 int
 obj_layout_diff(struct pl_map *map, daos_unit_oid_t oid, uint32_t new_ver, uint32_t old_ver,
-		struct daos_obj_md *md, uint32_t *tgt, uint32_t *shard_p)
+		struct daos_obj_md *md, uint32_t *tgts, uint32_t *shards, int array_size)
 {
 	struct pl_obj_layout	*new_layout = NULL;
 	struct pl_obj_layout	*old_layout = NULL;
@@ -58,18 +58,32 @@ obj_layout_diff(struct pl_map *map, daos_unit_oid_t oid, uint32_t new_ver, uint3
 	if (rc)
 		D_GOTO(out, rc);
 
-	if (new_layout->ol_shards[shard].po_target != old_layout->ol_shards[shard].po_target) {
-		*tgt = new_layout->ol_shards[shard].po_target;
-		*shard_p = shard;
-		D_GOTO(out, rc = 1);
-	}
-
 	/* If the new layout changes dkey placement, i.e. dkey->grp, dkey->ec_start changes,
 	 * then all shards needs to be changed.
 	 */
 	if (new_ver == 1 && daos_obj_id_is_ec(oid.id_pub)) {
-		*tgt = new_layout->ol_shards[shard].po_target;
-		*shard_p = shard;
+		struct daos_oclass_attr	*oc;
+		unsigned int	grp_size;
+		unsigned int	grp_start;
+		int		i;
+
+		oc = daos_oclass_attr_find(oid.id_pub, NULL);
+		D_ASSERT(oc != NULL);
+		grp_size = daos_oclass_grp_size(oc);
+
+		D_ASSERT(grp_size < array_size);
+		grp_start = (shard / grp_size) * grp_size;
+		for (i = 0; i < grp_size; i++) {
+			tgts[i] = new_layout->ol_shards[grp_start + i].po_target;
+			shards[i] = grp_start + i;
+			D_DEBUG(DB_TRACE, "i %d tgts[i] %u shards %u grp_size %u\n", i, tgts[i], shards[i], grp_size);
+		}
+		D_GOTO(out, rc = grp_size);
+	}
+
+	if (new_layout->ol_shards[shard].po_target != old_layout->ol_shards[shard].po_target) {
+		*tgts = new_layout->ol_shards[shard].po_target;
+		*shards = shard;
 		D_GOTO(out, rc = 1);
 	}
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -2588,19 +2588,12 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	memset(&anchor, 0, sizeof(anchor));
 	memset(&akey_anchor, 0, sizeof(akey_anchor));
 	memset(&dkey_anchor, 0, sizeof(dkey_anchor));
-	if (tls->mpt_opc == RB_OP_UPGRADE) {
-		enum_flags = DIOF_TO_LEADER | DIOF_WITH_SPEC_EPOCH |
-			     DIOF_FOR_MIGRATION;
+	if (tls->mpt_opc == RB_OP_UPGRADE)
 		unpack_arg.new_layout_ver = tls->mpt_new_layout_ver;
-		if (!daos_oclass_is_ec(&unpack_arg.oc_attr)) {
-			dc_obj_shard2anchor(&dkey_anchor, arg->shard);
-			enum_flags |= DIOF_TO_SPEC_GROUP;
-		}
-	} else {
-		dc_obj_shard2anchor(&dkey_anchor, arg->shard);
-		enum_flags = DIOF_TO_LEADER | DIOF_WITH_SPEC_EPOCH |
-			     DIOF_TO_SPEC_GROUP | DIOF_FOR_MIGRATION;
-	}
+
+	dc_obj_shard2anchor(&dkey_anchor, arg->shard);
+	enum_flags = DIOF_TO_LEADER | DIOF_WITH_SPEC_EPOCH |
+		     DIOF_TO_SPEC_GROUP | DIOF_FOR_MIGRATION;
 
 
 	if (daos_oclass_is_ec(&unpack_arg.oc_attr)) {

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -738,7 +738,8 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	case RB_OP_UPGRADE:
 		if (oid.id_layout_ver < rpt->rt_new_layout_ver) {
 			rc = obj_layout_diff(map, oid, rpt->rt_new_layout_ver,
-					     arg->co_props.dcp_obj_version, &md, tgts, shards);
+					     arg->co_props.dcp_obj_version, &md,
+					     tgts, shards, LOCAL_ARRAY_SIZE);
 			/* Then only upgrade the layout version */
 			if (rc == 0) {
 				rc = vos_obj_layout_upgrade(param->ip_hdl, oid,
@@ -758,6 +759,7 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 		D_GOTO(out, rc);
 	}
 
+	D_DEBUG(DB_REBUILD, "rebuild obj "DF_UOID" rebuild_nr %d\n", DP_UOID(oid), rc);
 	rebuild_nr = rc;
 	rc = 0;
 	for (i = 0; i < rebuild_nr; i++) {

--- a/src/tests/suite/daos_upgrade.c
+++ b/src/tests/suite/daos_upgrade.c
@@ -88,6 +88,76 @@ upgrade_ec_parity_rotate(void **state)
 	test_teardown((void **)&new_arg);
 }
 
+static void
+upgrade_ec_parity_rotate_single_dkey(void **state)
+{
+	test_arg_t	*arg = *state;
+	test_arg_t	*new_arg = NULL;
+	struct ioreq	req;
+	daos_obj_id_t	oid;
+	char		buf[10];
+	int		rc;
+
+	if (!test_runable(arg, 6))
+		return;
+
+	if (arg->myrank == 0) {
+		rc = daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+					   DAOS_FAIL_POOL_CREATE_VERSION | DAOS_FAIL_ALWAYS,
+					   0, NULL);
+		assert_rc_equal(rc, 0);
+		rc = daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_VALUE,
+					   0, 0, 0);
+		assert_rc_equal(rc, 0);
+	}
+
+	/* create/connect another pool */
+	rc = test_setup((void **)&new_arg, SETUP_CONT_CONNECT, arg->multi_rank,
+			SMALL_POOL_SIZE, 0, NULL);
+	assert_rc_equal(rc, 0);
+
+	oid = daos_test_oid_gen(new_arg->coh, OC_EC_4P1GX, 0, 0, new_arg->myrank);
+	ioreq_init(&req, new_arg->coh, oid, DAOS_IOD_ARRAY, new_arg);
+
+	insert_single("upgrade_dkey", "upgrade_akey", 0, "data",
+		       strlen("data") + 1, DAOS_TX_NONE, &req);
+
+	insert_single("upgrade_dkey1", "upgrade_akey1", 0, "data",
+		       strlen("data") + 1, DAOS_TX_NONE, &req);
+
+
+	ioreq_fini(&req);
+
+	if (arg->myrank == 0) {
+		rc = daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+					   DAOS_FORCE_OBJ_UPGRADE | DAOS_FAIL_ALWAYS,
+					   0, NULL);
+		assert_rc_equal(rc, 0);
+	}
+
+	rc = daos_pool_upgrade(new_arg->pool.pool_uuid);
+	assert_rc_equal(rc, 0);
+
+	print_message("sleep 50 seconds for upgrade to finish!\n");
+	sleep(50);
+
+	rebuild_pool_connect_internal(new_arg);
+	ioreq_init(&req, new_arg->coh, oid, DAOS_IOD_ARRAY, new_arg);
+	memset(buf, 0, 10);
+	lookup_single("upgrade_dkey", "upgrade_akey", 0,
+		      buf, 10, DAOS_TX_NONE, &req);
+	assert_int_equal(req.iod[0].iod_size, strlen(buf) + 1);
+	assert_string_equal(buf, "data");
+
+	lookup_single("upgrade_dkey1", "upgrade_akey1", 0,
+		      buf, 10, DAOS_TX_NONE, &req);
+	assert_int_equal(req.iod[0].iod_size, strlen(buf) + 1);
+	assert_string_equal(buf, "data");
+
+	ioreq_fini(&req);
+	test_teardown((void **)&new_arg);
+}
+
 int
 upgrade_sub_setup(void **state)
 {
@@ -113,6 +183,8 @@ upgrade_sub_setup(void **state)
 static const struct CMUnitTest upgrade_tests[] = {
 	{"UPGRADE0: upgrade object ec parity layout",
 	upgrade_ec_parity_rotate, upgrade_sub_setup, test_teardown},
+	{"UPGRADE1: upgrade single dkey",
+	upgrade_ec_parity_rotate_single_dkey, upgrade_sub_setup, test_teardown},
 };
 
 int


### PR DESCRIPTION
During object upgrade, dkey might be migrate to
different shards within the group due to EC parity rotation, so all shards within the group should
do fetch and update during migration, otherwise
some dkeys might be missing after upgrade.

Upgrade should do group special enumeration for the moment, since 2.4 does not change dkey->group mapping.

Add tests to verify it.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
