### PR TITLE
DAOS-13451 cart: Don't drain queue for cart clients (#12535)

### DIFF
--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -134,18 +134,19 @@ crtu_progress_fn(void *data)
 	while (opts.shutdown == 0)
 		crt_progress(*p_ctx, 1000);
 
-	if (opts.is_swim_enabled && idx == 0)
-		crt_swim_disable_all();
+	if (opts.is_server) {
+		if (opts.is_swim_enabled && idx == 0)
+			crt_swim_disable_all();
 
-	rc = crtu_drain_queue(*p_ctx);
-	D_ASSERTF(rc == 0, "crtu_drain_queue() failed with rc=%d\n", rc);
+		rc = crtu_drain_queue(*p_ctx);
+		D_ASSERTF(rc == 0, "crtu_drain_queue() failed with rc=%d\n", rc);
 
-	if (opts.delay_shutdown_sec > 0)
-		sleep(opts.delay_shutdown_sec);
+		if (opts.delay_shutdown_sec > 0)
+			sleep(opts.delay_shutdown_sec);
+	}
 
 	rc = crt_context_destroy(*p_ctx, 1);
-	D_ASSERTF(rc == 0, "Failed to destroy context %p rc=%d\n",
-		  p_ctx, rc);
+	D_ASSERTF(rc == 0, "Failed to destroy context %p rc=%d\n", p_ctx, rc);
 
 	pthread_exit(rc ? *p_ctx : NULL);
 


### PR DESCRIPTION
- Avoid context queue draining for clients. This reduces cart_ctl run by ~5 seconds.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
