### PR TITLE
DAOS-13878 test: Install golang >= 1.18 as a daos-tests dep

### DIFF
--- a/ci/provisioning/post_provision_config_common_functions.sh
+++ b/ci/provisioning/post_provision_config_common_functions.sh
@@ -196,6 +196,13 @@ set_local_repo() {
         dnf -y config-manager \
             --disable daos-stack-daos-"${DISTRO_GENERIC}"-"$version"-x86_64-stable-local-artifactory
     fi
+
+    if [ "$repo_server" = "artifactory" ]; then
+        # Disable module filtering for our deps repo
+	deps_repo="daos-stack-deps-${DISTRO_GENERIC}-$version-x86_64-stable-local-artifactory"
+	dnf config-manager --save --setopt "$deps_repo.module_hotfixes=true" "$deps_repo"
+    fi
+
     dnf repolist
 }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daos (2.5.100-6) unstable; urgency=medium
+  [Michael MacDonald]
+  * Add golang-go as a tests dependency for dfuse/daos_build.py
+
+ -- Michael MacDonald <mjmac.macdonald@intel.com> Thu, 29 Jun 2023 10:10:00 -0400
+
 daos (2.5.100-5) unstable; urgency=medium
   [ Li Wei ]
   * Update raft to 0.10.1-1408.g9524cdb

--- a/debian/control
+++ b/debian/control
@@ -115,6 +115,7 @@ Depends: python (>=3.8), python3, python-yaml, python3-yaml,
          ${shlibs:Depends}, ${misc:Depends},
          daos-client (= ${binary:Version}),
          daos-admin (= ${binary:Version}),
+         golang-go (>=1.18),
          libcapstone-dev
 Description: The Distributed Asynchronous Object Storage (DAOS) is an open-source
  software-defined object store designed from the ground up for

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -188,7 +188,6 @@ This is the package needed to run a DAOS client
 %package tests
 Summary: The entire DAOS test suite
 Requires: %{name}-client-tests%{?_isa} = %{version}-%{release}
-Requires: golang >= 1.18
 BuildArch: noarch
 
 %description tests
@@ -217,6 +216,7 @@ Requires: git
 Requires: dbench
 Requires: lbzip2
 Requires: attr
+Requires: golang >= 1.18
 %if (0%{?suse_version} >= 1315)
 Requires: lua-lmod
 Requires: libcapstone-devel
@@ -555,7 +555,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 
 %changelog
 * Thu Jun 29 2023 Michael MacDonald <mjmac.macdonald@intel.com> 2.3.105-6
-- Install golang >= 1.18 as a daos-tests dependency
+- Install golang >= 1.18 as a daos-client-tests dependency
 
 * Thu Jun 22 2023 Li Wei <wei.g.li@intel.com> 2.5.100-5
 - Update raft to 0.10.1-1.408.g9524cdb

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.5.100
-Release:       5%{?relval}%{?dist}
+Release:       6%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -188,6 +188,7 @@ This is the package needed to run a DAOS client
 %package tests
 Summary: The entire DAOS test suite
 Requires: %{name}-client-tests%{?_isa} = %{version}-%{release}
+Requires: golang >= 1.18
 BuildArch: noarch
 
 %description tests
@@ -553,6 +554,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Thu Jun 29 2023 Michael MacDonald <mjmac.macdonald@intel.com> 2.3.105-6
+- Install golang >= 1.18 as a daos-tests dependency
+
 * Thu Jun 22 2023 Li Wei <wei.g.li@intel.com> 2.5.100-5
 - Update raft to 0.10.1-1.408.g9524cdb
 


### PR DESCRIPTION
Needed for the dfuse/daos_build.py tests. Also disables
module filtering for the daos-stack-deps repository
in order to allow installation of newer golang RPMs.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
