### PR TITLE
DAOS-13781 dfuse: Remove a pointless assignment. (#12468)

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -727,7 +727,6 @@ dfuse_cont_open_by_label(struct dfuse_projection_info *fs_handle, struct dfuse_p
 			DFUSE_TRA_INFO(dfc,
 				"Using default caching values");
 			dfuse_set_default_cont_cache_values(dfc);
-			rc = 0;
 		} else if (rc != 0) {
 			D_GOTO(err_close, rc);
 		}


### PR DESCRIPTION
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
