### PR TITLE
DAOS-13884 vos: Avoid updating HAE when entries are skipped. (#12557)

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -162,10 +162,8 @@ struct vos_agg_param {
 	/* Boundary for aggregatable write filter */
 	daos_epoch_t		ap_filter_epoch;
 	uint32_t		ap_flags;
-	unsigned int		ap_discard:1,
-				ap_csum_err:1,
-				ap_nospc_err:1,
-				ap_discard_obj:1;
+	unsigned int ap_discard : 1, ap_csum_err : 1, ap_nospc_err : 1, ap_in_progress : 1,
+	    ap_discard_obj : 1;
 	struct umem_instance	*ap_umm;
 	int			(*ap_yield_func)(void *arg);
 	void			*ap_yield_arg;
@@ -2324,7 +2322,7 @@ vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 
 			*acts |= VOS_ITER_CB_ABORT;
 			if (rc == -DER_CSUM) {
-				agg_param->ap_csum_err = true;
+				agg_param->ap_csum_err = 1;
 				if (vam && vam->vam_csum_errs)
 					d_tm_inc_counter(vam->vam_csum_errs, 1);
 			} else if (rc == -DER_NOSPACE) {
@@ -2334,6 +2332,7 @@ vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 				 *  this entry to avoid orphaned tree
 				 *  assertion
 				 */
+				agg_param->ap_in_progress = 1;
 				agg_param->ap_skip_akey = true;
 				agg_param->ap_skip_dkey = true;
 				agg_param->ap_skip_obj = true;
@@ -2437,6 +2436,7 @@ vos_aggregate_post_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		if (rc == -DER_TX_BUSY) {
 			struct vos_agg_metrics	*vam = agg_cont2metrics(cont);
 
+			agg_param->ap_in_progress = 1;
 			rc = 0;
 			switch (type) {
 			default:
@@ -2689,6 +2689,15 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 		rc = -DER_CSUM;	/* Inform caller the csum error */
 		close_merge_window(&ad->ad_agg_param.ap_window, rc);
 		/* HAE needs be updated for csum error case */
+	} else if (ad->ad_agg_param.ap_in_progress) {
+		/* Don't update HAE when there were in-progress entries. Otherwise,
+		 * we will never aggregate anything in those subtrees until there is
+		 * a new write.
+		 *
+		 * NB: We may be able to improve this by tracking the lowest epoch
+		 * of such  entries and updating the HAE to that value - 1.
+		 */
+		goto exit;
 	}
 
 update_hae:


### PR DESCRIPTION
Without this patch, the HAE gets updated meaning that any such entries will never be aggregated until either a full scan happens or another update occurs in the subtree. If HAE is not updated, the entries will be re-scanned.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
