### PR TITLE
DAOS-13503 object: skip redundancy group verification when DTX resync

### DIFF
--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -61,6 +61,11 @@ dc_obj_init(void)
 		daos_rpc_unregister(&obj_proto_fmt);
 		D_GOTO(out_class, rc);
 	}
+
+	tx_verify_rdg = false;
+	d_getenv_bool("DAOS_TX_VERIFY_RDG", &tx_verify_rdg);
+	D_INFO("%s TX redundancy group verification\n", tx_verify_rdg ? "Enable" : "Disable");
+
 out_class:
 	if (rc)
 		obj_class_fini();

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -42,6 +42,9 @@ extern bool	cli_bypass_rpc;
 /** Switch of server-side IO dispatch */
 extern unsigned int	srv_io_mode;
 
+/* Whether check redundancy group validation when DTX resync. */
+extern bool	tx_verify_rdg;
+
 /** client object shard */
 struct dc_obj_shard {
 	/** refcount */

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -31,6 +31,9 @@
 #define DTX_SUB_REQ_MAX		((1ULL << 32) - 1)
 #define DTX_SUB_REQ_DEF		16
 
+/* Whether check redundancy group validation when DTX resync. */
+bool tx_verify_rdg;
+
 enum dc_tx_status {
 	TX_OPEN,
 	TX_COMMITTING,
@@ -1904,7 +1907,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 	 * are in the same redundancy group, be as optimization, we will
 	 * not store modification group information inside 'dm_data'.
 	 */
-	if (act_grp_cnt == 1)
+	if (act_grp_cnt == 1 || !tx_verify_rdg)
 		size = 0;
 
 	size += sizeof(*ddt) * act_tgt_cnt;
@@ -1988,7 +1991,11 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		dcsh->dcsh_epoch.oe_rpc_flags &= ~ORF_EPOCH_UNCERTAIN;
 
 	mbs->dm_tgt_cnt = act_tgt_cnt;
-	mbs->dm_grp_cnt = act_grp_cnt;
+	if (!tx_verify_rdg)
+		/* Set dm_grp_cnt as 1 to bypass redundancy group check. */
+		mbs->dm_grp_cnt = 1;
+	else
+		mbs->dm_grp_cnt = act_grp_cnt;
 	mbs->dm_data_size = size;
 
 	ddt = &mbs->dm_tgts[0];
@@ -2034,6 +2041,9 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		 */
 		dtr = d_list_pop_entry(&dtr_list, struct dc_tx_rdg, dtr_link);
 		D_FREE(dtr);
+	} else if (!tx_verify_rdg) {
+		while ((dtr = d_list_pop_entry(&dtr_list, struct dc_tx_rdg, dtr_link)) != NULL)
+			D_FREE(dtr);
 	} else {
 		ptr = ddt;
 		while ((dtr = d_list_pop_entry(&dtr_list, struct dc_tx_rdg,

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -2788,6 +2788,7 @@ dtx_38(void **state)
 	uint64_t	 val;
 	daos_handle_t	 th = { 0 };
 	d_rank_t	 kill_ranks[2];
+	bool		 rdg_verify = false;
 	int		 i;
 
 	FAULT_INJECTION_REQUIRED();
@@ -2795,6 +2796,10 @@ dtx_38(void **state)
 	print_message("DTX38: resync - lost whole redundancy groups\n");
 
 	if (!test_runable(arg, 7))
+		skip();
+
+	d_getenv_bool("DAOS_TX_VERIFY_RDG", &rdg_verify);
+	if (!rdg_verify)
 		skip();
 
 	if (arg->myrank == 0) {


### PR DESCRIPTION
Currently, the redundancy group information in the DTX header is only used for checking whether we lost some redundancy group or not during DTX resync. It allows DTX resync logic to detect corrupted DTX. It is not fatal if not support such functionality.

On the other hand, the redundancy group information may take more than half space in the DTX header. Consider DRAM usage on DTX leader, that may become burden for very large transaction. So the patch makes such redundancy group verification as optional. User can control that via client side environment variable "DAOS_TX_VERIFY_RDG" when start the client. By default, it is disabled.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
