### PR TITLE
DAOS-13213 control: Display exclude,rebuild for default self_heal

### DIFF
--- a/src/control/lib/daos/pool_property.go
+++ b/src/control/lib/daos/pool_property.go
@@ -51,19 +51,23 @@ func PoolProperties() PoolPropertyMap {
 					if err != nil {
 						return "not set"
 					}
-					switch {
-					case n&PoolSelfHealingAutoExclude > 0:
+					switch n {
+					case PoolSelfHealingAutoExclude:
 						return "exclude"
-					case n&PoolSelfHealingAutoRebuild > 0:
+					case PoolSelfHealingAutoRebuild:
 						return "rebuild"
+					case PoolSelfHealingAutoExclude | PoolSelfHealingAutoRebuild:
+						return "exclude,rebuild"
 					default:
 						return "unknown"
 					}
 				},
 			},
 			values: map[string]uint64{
-				"exclude": PoolSelfHealingAutoExclude,
-				"rebuild": PoolSelfHealingAutoRebuild,
+				"exclude":         PoolSelfHealingAutoExclude,
+				"rebuild":         PoolSelfHealingAutoRebuild,
+				"exclude,rebuild": PoolSelfHealingAutoExclude | PoolSelfHealingAutoRebuild,
+				"rebuild,exclude": PoolSelfHealingAutoExclude | PoolSelfHealingAutoRebuild,
 			},
 		},
 		"space_rb": {

--- a/src/control/lib/daos/pool_property_test.go
+++ b/src/control/lib/daos/pool_property_test.go
@@ -168,6 +168,18 @@ func TestControl_PoolProperties(t *testing.T) {
 			expStr:  "self_heal:rebuild",
 			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"rebuild"}`),
 		},
+		"self_heal-exclude,rebuild": {
+			name:    "self_heal",
+			value:   "exclude,rebuild",
+			expStr:  "self_heal:exclude,rebuild",
+			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"exclude,rebuild"}`),
+		},
+		"self_heal-rebuild,exclude": {
+			name:    "self_heal",
+			value:   "rebuild,exclude",
+			expStr:  "self_heal:exclude,rebuild",
+			expJson: []byte(`{"name":"self_heal","description":"Self-healing policy","value":"exclude,rebuild"}`),
+		},
 		"self_heal-invalid": {
 			name:   "self_heal",
 			value:  "wat",


### PR DESCRIPTION
The default value for the self_heal pool property is Exclude|Rebuild,
so the output should reflect this.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
