### PR TITLE
DAOS-13904 pool: don't assert ENOMEM for daos_acl_validate()

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1276,9 +1276,8 @@ cont_iv_prop_g2l(struct cont_iv_prop *iv_prop, daos_prop_t **prop_out)
 		acl = &iv_prop->cip_acl;
 		if (acl->dal_ver != 0) {
 			rc = daos_acl_validate(acl);
-			if (rc == -DER_NOMEM)
+			if (rc != -DER_SUCCESS)
 				D_GOTO(out, rc);
-			D_ASSERT(rc == 0);
 			prop_entry->dpe_val_ptr = daos_acl_dup(acl);
 			if (prop_entry->dpe_val_ptr == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1275,7 +1275,10 @@ cont_iv_prop_g2l(struct cont_iv_prop *iv_prop, daos_prop_t **prop_out)
 		prop_entry = &prop->dpp_entries[i++];
 		acl = &iv_prop->cip_acl;
 		if (acl->dal_ver != 0) {
-			D_ASSERT(daos_acl_validate(acl) == 0);
+			rc = daos_acl_validate(acl);
+			if (rc == -DER_NOMEM)
+				D_GOTO(out, rc);
+			D_ASSERT(rc == 0);
 			prop_entry->dpe_val_ptr = daos_acl_dup(acl);
 			if (prop_entry->dpe_val_ptr == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -294,9 +294,8 @@ pool_iv_prop_g2l(struct pool_iv_prop *iv_prop, daos_prop_t *prop)
 			acl = iv_prop->pip_acl;
 			if (acl->dal_len > 0) {
 				rc = daos_acl_validate(acl);
-				if (rc == -DER_NOMEM)
+				if (rc != -DER_SUCCESS)
 					D_GOTO(out, rc);
-				D_ASSERT(rc == 0);
 				prop_entry->dpe_val_ptr = daos_acl_dup(acl);
 				if (prop_entry->dpe_val_ptr == NULL)
 					D_GOTO(out, rc = -DER_NOMEM);

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -293,7 +293,10 @@ pool_iv_prop_g2l(struct pool_iv_prop *iv_prop, daos_prop_t *prop)
 				 roundup(iv_prop->pip_acl_offset, 8));
 			acl = iv_prop->pip_acl;
 			if (acl->dal_len > 0) {
-				D_ASSERT(daos_acl_validate(acl) == 0);
+				rc = daos_acl_validate(acl);
+				if (rc == -DER_NOMEM)
+					D_GOTO(out, rc);
+				D_ASSERT(rc == 0);
 				prop_entry->dpe_val_ptr = daos_acl_dup(acl);
 				if (prop_entry->dpe_val_ptr == NULL)
 					D_GOTO(out, rc = -DER_NOMEM);


### PR DESCRIPTION
daos_acl_validate() might fail because of out of memory (e.g.fault injection), don't assert them in the pool and container IV for this case.

Required-githooks: true

