### PR TITLE
DAOS-13776 cart: Inherit CORPC timeout across children (#12585)

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -94,6 +94,7 @@ crt_corpc_initiate(struct crt_rpc_priv *rpc_priv)
 	struct crt_grp_gdata	*grp_gdata;
 	struct crt_grp_priv	*grp_priv;
 	struct crt_corpc_hdr	*co_hdr;
+	int			 src_timeout;
 	bool			 grp_ref_taken = false;
 	int			 rc = 0;
 
@@ -120,6 +121,10 @@ crt_corpc_initiate(struct crt_rpc_priv *rpc_priv)
 			D_GOTO(out, rc = -DER_GRPVER);
 		}
 	}
+
+	/* Inherit a timeout from a source */
+	src_timeout = rpc_priv->crp_req_hdr.cch_src_timeout;
+	rpc_priv->crp_timeout_sec = src_timeout;
 
 	rc = crt_corpc_info_init(rpc_priv, grp_priv, grp_ref_taken,
 				 co_hdr->coh_filter_ranks,
@@ -874,6 +879,7 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 		child_rpc_priv = container_of(child_rpc, struct crt_rpc_priv,
 					      crp_pub);
 
+		child_rpc_priv->crp_timeout_sec = rpc_priv->crp_timeout_sec;
 		corpc_add_child_rpc(rpc_priv, child_rpc_priv);
 
 		child_rpc_priv->crp_grp_priv = co_info->co_grp_priv;

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -542,6 +542,7 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 						);
 			hdr->cch_dst_tag = rpc_priv->crp_pub.cr_ep.ep_tag;
 
+			hdr->cch_src_timeout = rpc_priv->crp_timeout_sec;
 			if (crt_is_service()) {
 				hdr->cch_src_rank =
 					crt_grp_priv_get_primary_rank(

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1898,6 +1898,28 @@ out:
 }
 
 int
+crt_req_src_timeout_get(crt_rpc_t *rpc, uint16_t *timeout)
+{
+	struct crt_rpc_priv	*rpc_priv = NULL;
+	int			rc = 0;
+
+	if (rpc == NULL) {
+		D_ERROR("NULL rpc passed\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	if (timeout == NULL) {
+		D_ERROR("NULL timeout passed\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
+	*timeout = rpc_priv->crp_req_hdr.cch_src_timeout;
+out:
+	return rc;
+}
+
+int
 crt_register_hlc_error_cb(crt_hlc_error_cb event_handler, void *arg)
 {
 	int rc = 0;

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -65,11 +65,14 @@ struct crt_common_hdr {
 	d_rank_t	cch_dst_rank;
 	/* originator rank in default primary group */
 	d_rank_t	cch_src_rank;
-	/* tag to which rpc request was sent to */
-	uint32_t	cch_dst_tag;
+	/* destination tag */
+	uint16_t	cch_dst_tag;
+	/* source timeout, to be replaced by deadline eventually */
+	uint16_t	cch_src_timeout;
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */
 	uint32_t	cch_rc;
 };
+
 
 typedef enum {
 	RPC_STATE_INITED = 0x36,

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -430,6 +430,18 @@ int
 crt_req_dst_tag_get(crt_rpc_t *req, uint32_t *tag);
 
 /**
+ * Return source timeout in seconds
+ *
+ * \param[in] req              Pointer to RPC request
+ * \param[out] timeout         Returned timeout
+ *
+ * \return                     DER_SUCCESS on success or error
+ *                             on failure
+ */
+int
+crt_req_src_timeout_get(crt_rpc_t *rpc, uint16_t *timeout);
+
+/**
  * Return reply buffer
  *
  * \param[in] req              pointer to RPC request


### PR DESCRIPTION
- split uint32_t cch_dst_tag into two uint16_t inside of the header
- src_timeout field added to the header (to be replaced by deadline later)
- CORPC children inherit timeouts from the parents header/source

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
