### PR TITLE
DAOS-13678 mgmt: use large RPC timeout for pool creation (#12462)

### DIFF
--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -65,7 +65,8 @@ pool_create_rpc_timeout(crt_rpc_t *tc_req, size_t scm_size)
 	uint32_t	default_timeout;
 	size_t		gib;
 	int		rc;
-	rc = crt_req_get_timeout(tc_req, &default_timeout);
+	int		rc;
+
 	D_ASSERTF(rc == 0, "crt_req_get_timeout: "DF_RC"\n", DP_RC(rc));
 
 	gib = scm_size / ((size_t)1024 * 1024 * 1024);

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -64,8 +64,7 @@ pool_create_rpc_timeout(crt_rpc_t *tc_req, size_t scm_size)
 	uint32_t	timeout;
 	uint32_t	default_timeout;
 	size_t		gib;
-	int		rc;
-	int		rc;
+	int		rc = crt_req_get_timeout(tc_req, &default_timeout);
 
 	D_ASSERTF(rc == 0, "crt_req_get_timeout: "DF_RC"\n", DP_RC(rc));
 

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -58,6 +58,29 @@ fini_ranks:
 	return rc;
 }
 
+static uint32_t
+pool_create_rpc_timeout(crt_rpc_t *tc_req, size_t scm_size)
+{
+	uint32_t	timeout;
+	uint32_t	default_timeout;
+	size_t		gib;
+	int		rc;
+	rc = crt_req_get_timeout(tc_req, &default_timeout);
+	D_ASSERTF(rc == 0, "crt_req_get_timeout: "DF_RC"\n", DP_RC(rc));
+
+	gib = scm_size / ((size_t)1024 * 1024 * 1024);
+	if (gib < 32)
+		timeout = 15;
+	else if (gib < 64)
+		timeout = 30;
+	else if (gib < 128)
+		timeout = 60;
+	else
+		timeout = 90;
+
+	return max(timeout, default_timeout);
+}
+
 static int
 ds_mgmt_tgt_pool_create_ranks(uuid_t pool_uuid, char *tgt_dev, d_rank_list_t *rank_list,
 			      size_t scm_size, size_t nvme_size)
@@ -69,6 +92,7 @@ ds_mgmt_tgt_pool_create_ranks(uuid_t pool_uuid, char *tgt_dev, d_rank_list_t *ra
 	int				topo;
 	int				rc;
 	int				rc_cleanup;
+	uint32_t			timeout;
 
 	/* Collective RPC to all of targets of the pool */
 	topo = crt_tree_topo(CRT_TREE_KNOMIAL, 4);
@@ -83,6 +107,10 @@ ds_mgmt_tgt_pool_create_ranks(uuid_t pool_uuid, char *tgt_dev, d_rank_list_t *ra
 		return rc;
 	}
 
+	timeout = pool_create_rpc_timeout(tc_req, scm_size);
+	crt_req_set_timeout(tc_req, timeout);
+	D_DEBUG(DB_MGMT, DF_UUID": pool create RPC timeout: %u\n",
+		DP_UUID(pool_uuid), timeout);
 	tc_in = crt_req_get(tc_req);
 	D_ASSERT(tc_in != NULL);
 	uuid_copy(tc_in->tc_pool_uuid, pool_uuid);


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
