### PR TITLE
DAOS-11551 control: Flush c output buffers.

### DIFF
--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -138,9 +138,8 @@ func freeString(str *C.char) {
 }
 
 func createWriteStream(ctx context.Context, printLn func(line string)) (*C.FILE, func(), error) {
-	// Create a FILE object for the handler to use for
-	// printing output or errors, and call the callback
-	// for each line.
+	// Create a FILE object for the handler to use for printing output or errors, and call the
+	// callback for each line.
 	r, w, err := os.Pipe()
 	if err != nil {
 		return nil, nil, err
@@ -169,7 +168,6 @@ func createWriteStream(ctx context.Context, printLn func(line string)) (*C.FILE,
 
 	return stream, func() {
 		C.fclose(stream)
-		w.Sync()
 		w.Close()
 	}, nil
 }

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -176,12 +176,9 @@ func createWriteStream(ctx context.Context, prefix string, printLn func(line str
 	}(ctx, prefix)
 
 	return stream, func() {
+		C.fclose(stream)
 		w.WriteString("close\n")
 		w.Sync()
-		C.fflush(stream)
-		C.fflush(stream)
-		C.fflush(stream)
-		C.fclose(stream)
 	}, nil
 }
 

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -163,7 +163,7 @@ func createWriteStream(ctx context.Context, printLn func(line string)) (*C.FILE,
 				r.Close()
 				return
 			}
-			printLn(fmt.Sprintf("%s", line))
+			printLn(line)
 		}
 	}(ctx)
 

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -160,10 +160,6 @@ func createWriteStream(ctx context.Context, prefix string, printLn func(line str
 				if !(errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed)) {
 					printLn(fmt.Sprintf("read err: %s", err))
 				}
-				return
-			}
-			if line == "close\n" {
-				w.Close()
 				r.Close()
 				return
 			}
@@ -177,8 +173,8 @@ func createWriteStream(ctx context.Context, prefix string, printLn func(line str
 
 	return stream, func() {
 		C.fclose(stream)
-		w.WriteString("close\n")
 		w.Sync()
+		w.Close()
 	}, nil
 }
 


### PR DESCRIPTION
Ensure test written from C subroutines in go is printed.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
