### PR TITLE
DAOS-13774 control: Don't append ofi_rxm to ofi+tcp provider (#12546)

### DIFF
--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -85,12 +85,7 @@ func processFabricProvider(cfg *config.Server) {
 }
 
 func shouldAppendRXM(provider string) bool {
-	for _, rxmProv := range []string{"ofi+verbs", "ofi+tcp"} {
-		if rxmProv == provider {
-			return true
-		}
-	}
-	return false
+	return provider == "ofi+verbs"
 }
 
 // server struct contains state and components of DAOS Server.

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -1247,3 +1247,43 @@ func TestServerUtils_getControlAddr(t *testing.T) {
 		})
 	}
 }
+
+func TestServer_processFabricProvider(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfgFabric string
+		expFabric string
+	}{
+		"ofi+verbs": {
+			cfgFabric: "ofi+verbs",
+			expFabric: "ofi+verbs;ofi_rxm",
+		},
+		"ofi+verbs;ofi_rxm": {
+			cfgFabric: "ofi+verbs;ofi_rxm",
+			expFabric: "ofi+verbs;ofi_rxm",
+		},
+		"ofi+tcp": {
+			cfgFabric: "ofi+tcp",
+			expFabric: "ofi+tcp",
+		},
+		"ofi+tcp;ofi_rxm": {
+			cfgFabric: "ofi+tcp;ofi_rxm",
+			expFabric: "ofi+tcp;ofi_rxm",
+		},
+		"ucx": {
+			cfgFabric: "ucx+ud",
+			expFabric: "ucx+ud",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := &config.Server{
+				Fabric: engine.FabricConfig{
+					Provider: tc.cfgFabric,
+				},
+			}
+
+			processFabricProvider(cfg)
+
+			test.AssertEqual(t, tc.expFabric, cfg.Fabric.Provider, "")
+		})
+	}
+}

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -62,10 +62,14 @@ PROVIDER_KEYS = OrderedDict(
         ("cxi", "ofi+cxi"),
         ("verbs", "ofi+verbs"),
         ("ucx", "ucx+dc_x"),
-        ("tcp", "ofi+tcp"),
+        ("tcp", "ofi+tcp;ofi_rxm"),
         ("opx", "ofi+opx"),
     ]
 )
+# Temporary pipeline-lib workaround until DAOS-13934 is implemented
+PROVIDER_ALIAS = {
+    "ofi+tcp": "ofi+tcp;ofi_rxm"
+}
 PROCS_TO_CLEANUP = [
     "daos_server", "daos_engine", "daos_agent", "cart_ctl", "orterun", "mpirun", "dfuse"]
 TYPES_TO_UNMOUNT = ["fuse.daos"]
@@ -1282,6 +1286,7 @@ class Launch():
         """
         logger.debug("-" * 80)
         # Use the detected provider if one is not set
+        provider = PROVIDER_ALIAS.get(provider, provider)
         if not provider:
             provider = os.environ.get("CRT_PHY_ADDR_STR")
         if provider is None:

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -437,7 +437,7 @@ class EngineYamlParameters(YamlParameters):
         "common": [
             "D_LOG_FILE_APPEND_PID=1",
             "COVFILE=/tmp/test.cov"],
-        "ofi+tcp": [],
+        "ofi+tcp;ofi_rxm": [],
         "ofi+verbs": [
             "FI_OFI_RXM_USE_SRX=1"],
         "ofi+cxi": [
@@ -459,7 +459,7 @@ class EngineYamlParameters(YamlParameters):
         namespace = [os.sep] + base_namespace.split(os.sep)[1:-1] + ["engines", str(index), "*"]
         self._base_namespace = base_namespace
         self._index = index
-        self._provider = provider or os.environ.get("CRT_PHY_ADDR_STR", "ofi+tcp")
+        self._provider = provider or os.environ.get("CRT_PHY_ADDR_STR", "ofi+tcp;ofi_rxm")
         self._max_storage_tiers = max_storage_tiers
         super().__init__(os.path.join(*namespace))
 


### PR DESCRIPTION
This change requires ofi_rxm to be specified manually if it is desired for ofi+tcp. There is now a non-RXM tcp provider available in libfabric.

Specify ofi_rxm explicitly in ftests.
We shouldn't use the non-RXM provider by default until it is more thoroughly tested with DAOS.

Add workaround for launch.py to alias ofi+tcp to ofi+tcp;ofi_rxm

Features: control

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
