### PR TITLE
DAOS-11551 control: Flush c output buffer.

### DIFF
--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -144,7 +144,7 @@ func createWriteStream(ctx context.Context, printLn func(line string)) (*C.FILE,
 	if err != nil {
 		return nil, nil, err
 	}
-	done := make(chan int)
+	done := make(chan bool)
 
 	stream, err := fd2FILE(w.Fd(), "w")
 	if err != nil {
@@ -152,7 +152,7 @@ func createWriteStream(ctx context.Context, printLn func(line string)) (*C.FILE,
 	}
 
 	go func(ctx context.Context) {
-		defer func() { done <- 1 }()
+		defer func() { done <- true }()
 
 		rdr := bufio.NewReader(r)
 		for {

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
+	"sync"
 	"unsafe"
 
 	"github.com/google/uuid"
@@ -138,24 +138,23 @@ func freeString(str *C.char) {
 	C.free(unsafe.Pointer(str))
 }
 
-func createWriteStream(ctx context.Context, prefix string, printLn func(line string)) (*C.FILE, func(), error) {
-	// Create a FILE object for the handler to use for
-	// printing output or errors, and call the callback
-	// for each line.
+func createWriteStream(ctx context.Context, printLn func(line string)) (*C.FILE, func(), error) {
+	// Create a FILE object for the handler to use for printing output or errors, and call the
+	// callback for each line.
 	r, w, err := os.Pipe()
 	if err != nil {
 		return nil, nil, err
 	}
+	var done = new(sync.Mutex)
+	done.Lock()
 
 	stream, err := fd2FILE(w.Fd(), "w")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	go func(ctx context.Context, prefix string) {
-		if prefix != "" {
-			prefix = ": "
-		}
+	go func(ctx context.Context) {
+		defer done.Unlock()
 
 		rdr := bufio.NewReader(r)
 		for {
@@ -165,21 +164,20 @@ func createWriteStream(ctx context.Context, prefix string, printLn func(line str
 			default:
 				line, err := rdr.ReadString('\n')
 				if err != nil {
-					if !(errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed)) {
+					if !(errors.Is(err, io.EOF)) {
 						printLn(fmt.Sprintf("read err: %s", err))
 					}
 					return
 				}
-				printLn(fmt.Sprintf("%s%s", prefix, line))
+				printLn(line)
 			}
 		}
-	}(ctx, prefix)
+	}(ctx)
 
 	return stream, func() {
-		C.fflush(stream)
 		C.fclose(stream)
-		r.Close()
 		w.Close()
+		done.Lock()
 	}, nil
 }
 
@@ -220,7 +218,7 @@ func allocCmdArgs(log logging.Logger) (ap *C.struct_cmd_args_s, cleanFn func(), 
 	ap.sysname = C.CString(build.DefaultSystemName)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	outStream, outCleanup, err := createWriteStream(ctx, "", log.Info)
+	outStream, outCleanup, err := createWriteStream(ctx, log.Info)
 	if err != nil {
 		freeCmdArgs(ap)
 		cancel()
@@ -228,7 +226,7 @@ func allocCmdArgs(log logging.Logger) (ap *C.struct_cmd_args_s, cleanFn func(), 
 	}
 	ap.outstream = outStream
 
-	errStream, errCleanup, err := createWriteStream(ctx, "handler", log.Error)
+	errStream, errCleanup, err := createWriteStream(ctx, log.Error)
 	if err != nil {
 		outCleanup()
 		freeCmdArgs(ap)
@@ -241,8 +239,6 @@ func allocCmdArgs(log logging.Logger) (ap *C.struct_cmd_args_s, cleanFn func(), 
 		outCleanup()
 		errCleanup()
 		freeCmdArgs(ap)
-		// Give the streams a chance to flush.
-		time.Sleep(250 * time.Millisecond)
 		cancel()
 	}, nil
 }

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -144,7 +144,7 @@ func createWriteStream(ctx context.Context, printLn func(line string)) (*C.FILE,
 	if err != nil {
 		return nil, nil, err
 	}
-	done := make(chan bool)
+	done := make(chan bool, 1)
 
 	stream, err := fd2FILE(w.Fd(), "w")
 	if err != nil {
@@ -152,7 +152,7 @@ func createWriteStream(ctx context.Context, printLn func(line string)) (*C.FILE,
 	}
 
 	go func(ctx context.Context) {
-		defer func() { done <- true }()
+		defer close(done)
 
 		rdr := bufio.NewReader(r)
 		for {

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -53,14 +53,12 @@ struct file_dfs {
 #define DH_PERROR_SYS(AP, RC, STR, ...)                                                            \
 	do {                                                                                       \
 		fprintf((AP)->errstream, STR ": %s (%d)\n", ##__VA_ARGS__, strerror(RC), (RC));    \
-		fflush((AP)->errstream);                                                           \
 	} while (0)
 
 /* Report an error with a daos error number using a standard output format */
 #define DH_PERROR_DER(AP, RC, STR, ...)                                                            \
 	do {                                                                                       \
 		fprintf((AP)->errstream, STR ": %s (%d)\n", ##__VA_ARGS__, d_errdesc(RC), (RC));   \
-		fflush((AP)->errstream);                                                           \
 	} while (0)
 
 static int


### PR DESCRIPTION
Update go code to flush and wait for completion on shutdown.

This avoids loosing any output from the c helper code.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>