### PR TITLE
DAOS-12751 dfuse: Improve evict command.

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1042,6 +1042,8 @@ dfuse_fs_init(struct dfuse_info *fs_handle)
 
 	D_SPIN_INIT(&fs_handle->di_lock, 0);
 
+	D_RWLOCK_INIT(&fs_handle->di_forget_lock, 0);
+
 	for (i = 0; i < fs_handle->di_eq_count; i++) {
 		struct dfuse_eq *eqt = &fs_handle->di_eqt[i];
 
@@ -1071,6 +1073,7 @@ dfuse_fs_init(struct dfuse_info *fs_handle)
 
 err_eq:
 	D_SPIN_DESTROY(&fs_handle->di_lock);
+	D_RWLOCK_DESTROY(&fs_handle->di_forget_lock);
 
 	for (i = 0; i < fs_handle->di_eq_count; i++) {
 		struct dfuse_eq *eqt = &fs_handle->di_eqt[i];
@@ -1529,6 +1532,7 @@ dfuse_fs_fini(struct dfuse_info *dfuse_info)
 	int i;
 
 	D_SPIN_DESTROY(&dfuse_info->di_lock);
+	D_RWLOCK_DESTROY(&dfuse_info->di_forget_lock);
 
 	for (i = 0; i < dfuse_info->di_eq_count; i++) {
 		struct dfuse_eq *eqt = &dfuse_info->di_eqt[i];

--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -499,9 +499,9 @@ func (cmd *fsDfuseQueryCmd) Execute(_ []string) error {
 	cmd.Infof(" Open files: %d", ap.dfuse_mem.fh_count)
 	if cmd.Ino != 0 {
 		if ap.dfuse_mem.found {
-			cmd.Infof(" Inode %#lx resident", cmd.Ino)
+			cmd.Infof(" Inode %d resident", cmd.Ino)
 		} else {
-			cmd.Infof(" Inode %#lx not resident", cmd.Ino)
+			cmd.Infof(" Inode %d not resident", cmd.Ino)
 		}
 	}
 

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -203,6 +203,9 @@ class DaosBuild(DfuseTestBase):
                 'python3 -m pip install pip --upgrade',
                 'python3 -m pip install -r {}/requirements.txt'.format(build_dir),
                 'scons -C {} --jobs {} --build-deps=only'.format(build_dir, build_jobs),
+                'daos filesystem query {}'.format(mount_dir),
+                'daos filesystem evict {}'.format(build_dir),
+                'daos filesystem query {}'.format(mount_dir),
                 'scons -C {} --jobs {}'.format(build_dir, intercept_jobs)]
         for cmd in cmds:
             command = '{};{}'.format(preload_cmd, cmd)

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2452,8 +2452,7 @@ dfuse_count_query(struct cmd_args_s *ap)
 	if (rc < 0) {
 		rc = errno;
 		if (rc == ENOTTY) {
-			/* TODO: What is the correct error here? */
-			rc = -DER_INVAL;
+			rc = -DER_NOTAPPLICABLE;
 		} else {
 			DH_PERROR_SYS(ap, rc, "ioctl failed");
 			rc = daos_errno2der(errno);
@@ -2549,7 +2548,7 @@ dfuse_evict(struct cmd_args_s *ap)
 	if (rc < 0) {
 		rc = errno;
 		if (rc == ENOTTY) {
-			rc = -DER_INVAL;
+			rc = -DER_NOTAPPLICABLE;
 		} else {
 			DH_PERROR_SYS(ap, rc, "ioctl failed");
 			rc = daos_errno2der(errno);

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2450,7 +2450,7 @@ dfuse_count_query(struct cmd_args_s *ap)
 	if (rc < 0) {
 		rc = errno;
 		if (rc == ENOTTY) {
-			rc = -DER_NOTAPPLICABLE;
+			rc = -DER_MISC;
 		} else {
 			DH_PERROR_SYS(ap, rc, "ioctl failed");
 			rc = daos_errno2der(errno);
@@ -2546,7 +2546,7 @@ dfuse_evict(struct cmd_args_s *ap)
 	if (rc < 0) {
 		rc = errno;
 		if (rc == ENOTTY) {
-			rc = -DER_NOTAPPLICABLE;
+			rc = -DER_MISC;
 		} else {
 			DH_PERROR_SYS(ap, rc, "ioctl failed");
 			rc = daos_errno2der(errno);

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -5424,7 +5424,7 @@ def test_alloc_fail_copy(server, conf, wf):
         os.symlink('broken', join(sub_dir, 'broken_s'))
         os.symlink('file.0', join(sub_dir, 'link'))
 
-        rc = run_daos_cmd(conf, ['filesystem', 'copy', '--src', src_dir,
+        rc = run_daos_cmd(conf, ['filesystem', 'copy', '--src', sub_dir,
                                  '--dst', f'daos://{pool.id()}/aft_base'])
         assert rc.returncode == 0, rc
 


### PR DESCRIPTION
Improve error cases where path is not backed by dfuse.
Lock forget commands against inode query.
Print and accept inodes as integers only.

Evict the build tree as part of the DaosBuild test.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
