### PR TITLE
DAOS-13973 cart: Fix interop breakage between 2.2 and 2.4

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -124,7 +124,9 @@ crt_corpc_initiate(struct crt_rpc_priv *rpc_priv)
 
 	/* Inherit a timeout from a source */
 	src_timeout = rpc_priv->crp_req_hdr.cch_src_timeout;
-	rpc_priv->crp_timeout_sec = src_timeout;
+
+	if (src_timeout != 0)
+		rpc_priv->crp_timeout_sec = src_timeout;
 
 	rc = crt_corpc_info_init(rpc_priv, grp_priv, grp_ref_taken,
 				 co_hdr->coh_filter_ranks,

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -66,11 +66,15 @@ struct crt_common_hdr {
 	/* originator rank in default primary group */
 	d_rank_t	cch_src_rank;
 	/* destination tag */
-	uint16_t	cch_dst_tag;
-	/* source timeout, to be replaced by deadline eventually */
-	uint16_t	cch_src_timeout;
+	uint32_t	cch_dst_tag;
+
+
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */
-	uint32_t	cch_rc;
+	/* TODO: workaround for DAOS-13973 */
+	union {
+		uint32_t	cch_src_timeout;
+		uint32_t	cch_rc;
+	};
 };
 
 


### PR DESCRIPTION
- overload cch_rc field in the request header to be used as a source timeout
- 2.4 clients will set it, but 2.2 server will not use that field as cch_rc is unused in the request header.
- 2.2 clients sending rpc request to 2.4 servers will have this field as 0. as such crt_corpc modified to not inherit source timeout if it is set as 0

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
