### PR TITLE
DAOS-13902 pool: Avoid double-free on error. (#12586)

### DIFF
--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -227,17 +227,12 @@ pool_iv_prop_l2g(daos_prop_t *prop, struct pool_iv_prop *iv_prop)
 static int
 pool_iv_prop_g2l(struct pool_iv_prop *iv_prop, daos_prop_t *prop)
 {
-	struct daos_prop_entry	*prop_entry;
-	struct daos_acl		*acl;
-	void			*label_alloc = NULL;
-	void			*owner_alloc = NULL;
-	void			*owner_grp_alloc = NULL;
-	void			*acl_alloc = NULL;
-	void			*policy_str_alloc = NULL;
-	d_rank_list_t		*svc_list = NULL;
-	d_rank_list_t		*dst_list;
-	int			i;
-	int			rc = 0;
+	struct daos_prop_entry *prop_entry;
+	struct daos_acl        *acl;
+	d_rank_list_t          *svc_list;
+	d_rank_list_t          *dst_list;
+	int                     i;
+	int                     rc = 0;
 
 	D_ASSERT(prop->dpp_nr == DAOS_PROP_PO_NUM);
 	for (i = 0; i < DAOS_PROP_PO_NUM; i++) {
@@ -251,7 +246,6 @@ pool_iv_prop_g2l(struct pool_iv_prop *iv_prop, daos_prop_t *prop)
 				  DAOS_PROP_LABEL_MAX_LEN);
 			if (prop_entry->dpe_str == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
-			label_alloc = prop_entry->dpe_str;
 			break;
 		case DAOS_PROP_PO_OWNER:
 			D_ASSERT(strlen(iv_prop->pip_owner) <=
@@ -260,7 +254,6 @@ pool_iv_prop_g2l(struct pool_iv_prop *iv_prop, daos_prop_t *prop)
 				  DAOS_ACL_MAX_PRINCIPAL_LEN);
 			if (prop_entry->dpe_str == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
-			owner_alloc = prop_entry->dpe_str;
 			break;
 		case DAOS_PROP_PO_OWNER_GROUP:
 			D_ASSERT(strlen(iv_prop->pip_owner_grp) <=
@@ -301,10 +294,8 @@ pool_iv_prop_g2l(struct pool_iv_prop *iv_prop, daos_prop_t *prop)
 			acl = iv_prop->pip_acl;
 			if (acl->dal_len > 0) {
 				D_ASSERT(daos_acl_validate(acl) == 0);
-				acl_alloc = daos_acl_dup(acl);
-				if (acl_alloc != NULL)
-					prop_entry->dpe_val_ptr = acl_alloc;
-				else
+				prop_entry->dpe_val_ptr = daos_acl_dup(acl);
+				if (prop_entry->dpe_val_ptr == NULL)
 					D_GOTO(out, rc = -DER_NOMEM);
 			} else {
 				prop_entry->dpe_val_ptr = NULL;
@@ -334,9 +325,7 @@ pool_iv_prop_g2l(struct pool_iv_prop *iv_prop, daos_prop_t *prop)
 				 DAOS_PROP_POLICYSTR_MAX_LEN);
 			D_STRNDUP(prop_entry->dpe_str, iv_prop->pip_policy_str,
 				  DAOS_PROP_POLICYSTR_MAX_LEN);
-			if (prop_entry->dpe_str)
-				policy_str_alloc = prop_entry->dpe_str;
-			else
+			if (prop_entry->dpe_str == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 			break;
 		case DAOS_PROP_PO_GLOBAL_VERSION:
@@ -370,17 +359,6 @@ pool_iv_prop_g2l(struct pool_iv_prop *iv_prop, daos_prop_t *prop)
 	}
 
 out:
-	if (rc) {
-		if (acl_alloc)
-			daos_acl_free(acl_alloc);
-		D_FREE(label_alloc);
-		D_FREE(owner_alloc);
-		D_FREE(owner_grp_alloc);
-		if (svc_list)
-			d_rank_list_free(dst_list);
-		if (policy_str_alloc)
-			D_FREE(policy_str_alloc);
-	}
 	return rc;
 }
 
@@ -715,11 +693,10 @@ pool_iv_map_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 }
 
 static int
-pool_iv_prop_ent_copy(struct pool_iv_entry *dst_iv,
-		      struct pool_iv_entry *src_iv)
+pool_iv_prop_ent_copy(struct pool_iv_entry *dst_iv, struct pool_iv_entry *src_iv)
 {
-	daos_prop_t	*prop_fetch;
-	int		rc = 0;
+	daos_prop_t *prop_fetch;
+	int          rc;
 
 	prop_fetch = daos_prop_alloc(DAOS_PROP_PO_NUM);
 	if (prop_fetch == NULL)
@@ -727,12 +704,12 @@ pool_iv_prop_ent_copy(struct pool_iv_entry *dst_iv,
 
 	rc = pool_iv_prop_g2l(&src_iv->piv_prop, prop_fetch);
 	if (rc) {
-		daos_prop_free(prop_fetch);
-		D_ERROR("prop g2l failed: rc %d\n", rc);
-		return rc;
+		D_ERROR("pool_iv_prop_g2l failed: " DF_RC "\n", DP_RC(rc));
+		goto out;
 	}
 
 	pool_iv_prop_l2g(prop_fetch, &dst_iv->piv_prop);
+out:
 	daos_prop_free(prop_fetch);
 
 	return rc;
@@ -1686,8 +1663,7 @@ ds_pool_iv_prop_fetch(struct ds_pool *pool, daos_prop_t *prop)
 
 out:
 	D_FREE(iv_entry);
-	if (prop_fetch)
-		daos_prop_free(prop_fetch);
+	daos_prop_free(prop_fetch);
 	return rc;
 }
 


### PR DESCRIPTION
The callers of pool_iv_prop_g2l() call daos_prop_free() on
failure so it does not need to free anything itself.

Move logging to log the failure before calling prop_free().

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>