### PR TITLE
DAOS-13901 client: need to query whether a fd is redirected

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -1467,7 +1467,7 @@ free_map(int idx)
 }
 
 static int
-Get_Fd_Redirected(int fd)
+get_fd_redirected(int fd)
 {
 	int i, fd_ret = fd;
 
@@ -1937,18 +1937,17 @@ new_open_pthread(const char *pathname, int oflags, ...)
 static int
 new_close_common(int (*next_close)(int fd), int fd)
 {
-	int fd_Directed;
+	int fd_directed;
 
 	if (!hook_enabled)
 		return next_close(fd);
 
-	fd_Directed = Get_Fd_Redirected(fd);
-
-	if (fd_Directed >= FD_DIR_BASE) {
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed >= FD_DIR_BASE) {
 		/* directory */
-		free_dirfd(fd_Directed - FD_DIR_BASE);
+		free_dirfd(fd_directed - FD_DIR_BASE);
 		return 0;
-	} else if (fd_Directed >= FD_FILE_BASE) {
+	} else if (fd_directed >= FD_FILE_BASE) {
 		/* This fd is a kernel fd. There was a duplicate fd created. */
 		if (fd < FD_FILE_BASE)
 			return close_dup_fd_src(next_close, fd);
@@ -1983,17 +1982,19 @@ static ssize_t
 read_comm(ssize_t (*next_read)(int fd, void *buf, size_t size), int fd, void *buf, size_t size)
 {
 	ssize_t rc;
+	int	fd_directed;
 
 	if (!hook_enabled)
 		return next_read(fd, buf, size);
 
-	if (fd >= FD_FILE_BASE) {
-		rc = pread(fd, buf, size, file_list[fd - FD_FILE_BASE]->offset);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed >= FD_FILE_BASE) {
+		rc = pread(fd_directed, buf, size, file_list[fd_directed - FD_FILE_BASE]->offset);
 		if (rc >= 0)
-			file_list[fd - FD_FILE_BASE]->offset += rc;
+			file_list[fd_directed - FD_FILE_BASE]->offset += rc;
 		return rc;
 	} else {
-		return next_read(fd, buf, size);
+		return next_read(fd_directed, buf, size);
 	}
 }
 
@@ -2015,6 +2016,7 @@ pread(int fd, void *buf, size_t size, off_t offset)
 	daos_size_t bytes_read;
 	char       *ptr = (char *)buf;
 	int         rc;
+	int         fd_directed;
 	d_iov_t     iov;
 	d_sg_list_t sgl;
 
@@ -2025,16 +2027,19 @@ pread(int fd, void *buf, size_t size, off_t offset)
 		next_pread = dlsym(RTLD_NEXT, "pread64");
 		D_ASSERT(next_pread != NULL);
 	}
+	if (!hook_enabled)
+		return next_pread(fd, buf, size, offset);
 
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_pread(fd, buf, size, offset);
 
 	sgl.sg_nr     = 1;
 	sgl.sg_nr_out = 0;
 	d_iov_set(&iov, (void *)ptr, size);
 	sgl.sg_iovs = &iov;
-	rc          = dfs_read(file_list[fd - FD_FILE_BASE]->dfs_mt->dfs,
-			       file_list[fd - FD_FILE_BASE]->file, &sgl,
+	rc          = dfs_read(file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+			       file_list[fd_directed - FD_FILE_BASE]->file, &sgl,
 			       offset, &bytes_read, NULL);
 	if (rc) {
 		D_ERROR("dfs_read(%p, %zu) failed: %d (%s)\n", (void *)ptr, size, rc, strerror(rc));
@@ -2057,18 +2062,20 @@ ssize_t
 write_comm(ssize_t (*next_write)(int fd, const void *buf, size_t size), int fd, const void *buf,
 	   size_t size)
 {
-	ssize_t rc;
+	ssize_t	rc;
+	int	fd_directed;
 
 	if (!hook_enabled)
 		return next_write(fd, buf, size);
 
-	if (fd >= FD_FILE_BASE) {
-		rc = pwrite(fd, buf, size, file_list[fd - FD_FILE_BASE]->offset);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed >= FD_FILE_BASE) {
+		rc = pwrite(fd_directed, buf, size, file_list[fd_directed - FD_FILE_BASE]->offset);
 		if (rc >= 0)
-			file_list[fd - FD_FILE_BASE]->offset += rc;
+			file_list[fd_directed - FD_FILE_BASE]->offset += rc;
 		return rc;
 	} else {
-		return next_write(fd, buf, size);
+		return next_write(fd_directed, buf, size);
 	}
 }
 
@@ -2089,6 +2096,7 @@ pwrite(int fd, const void *buf, size_t size, off_t offset)
 {
 	char       *ptr = (char *)buf;
 	int         rc;
+	int         fd_directed;
 	d_iov_t     iov;
 	d_sg_list_t sgl;
 
@@ -2099,15 +2107,19 @@ pwrite(int fd, const void *buf, size_t size, off_t offset)
 		next_pwrite = dlsym(RTLD_NEXT, "pwrite64");
 		D_ASSERT(next_pwrite != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_pwrite(fd, buf, size, offset);
+
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_pwrite(fd, buf, size, offset);
 
 	sgl.sg_nr     = 1;
 	sgl.sg_nr_out = 0;
 	d_iov_set(&iov, (void *)ptr, size);
 	sgl.sg_iovs = &iov;
-	rc          = dfs_write(file_list[fd - FD_FILE_BASE]->dfs_mt->dfs,
-				file_list[fd - FD_FILE_BASE]->file, &sgl, offset, NULL);
+	rc          = dfs_write(file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+				file_list[fd_directed - FD_FILE_BASE]->file, &sgl, offset, NULL);
 	if (rc) {
 		D_ERROR("dfs_write(%p, %zu) failed: %d (%s)\n", (void *)ptr, size, rc,
 			strerror(rc));
@@ -2128,19 +2140,23 @@ __pwrite64(int fd, const void *buf, size_t size, off_t offset) __attribute__((al
 static int
 new_fxstat(int vers, int fd, struct stat *buf)
 {
-	int rc;
+	int rc, fd_directed;
 
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
 		return next_fxstat(vers, fd, buf);
 
-	if (fd < FD_DIR_BASE) {
-		rc          = dfs_ostat(file_list[fd - FD_FILE_BASE]->dfs_mt->dfs,
-					file_list[fd - FD_FILE_BASE]->file, buf);
-		buf->st_ino = file_list[fd - FD_FILE_BASE]->st_ino;
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
+		return next_fxstat(vers, fd, buf);
+
+	if (fd_directed < FD_DIR_BASE) {
+		rc          = dfs_ostat(file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+					file_list[fd_directed - FD_FILE_BASE]->file, buf);
+		buf->st_ino = file_list[fd_directed - FD_FILE_BASE]->st_ino;
 	} else {
-		rc          = dfs_ostat(dir_list[fd - FD_DIR_BASE]->dfs_mt->dfs,
-					dir_list[fd - FD_DIR_BASE]->dir, buf);
-		buf->st_ino = dir_list[fd - FD_DIR_BASE]->st_ino;
+		rc          = dfs_ostat(dir_list[fd_directed - FD_DIR_BASE]->dfs_mt->dfs,
+					dir_list[fd_directed - FD_DIR_BASE]->dir, buf);
+		buf->st_ino = dir_list[fd_directed - FD_DIR_BASE]->st_ino;
 	}
 
 	if (rc) {
@@ -2368,10 +2384,14 @@ static off_t
 lseek_comm(off_t (*next_lseek)(int fd, off_t offset, int whence), int fd, off_t offset, int whence)
 {
 	int         rc;
+	int         fd_directed;
 	off_t       new_offset;
 	struct stat fstat;
 
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_lseek(fd, offset, whence);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_lseek(fd, offset, whence);
 
 	atomic_fetch_add_relaxed(&num_seek, 1);
@@ -2381,11 +2401,11 @@ lseek_comm(off_t (*next_lseek)(int fd, off_t offset, int whence), int fd, off_t 
 		new_offset = offset;
 		break;
 	case SEEK_CUR:
-		new_offset = file_list[fd - FD_FILE_BASE]->offset + offset;
+		new_offset = file_list[fd_directed - FD_FILE_BASE]->offset + offset;
 		break;
 	case SEEK_END:
 		fstat.st_size = 0;
-		rc            = new_fxstat(1, fd, &fstat);
+		rc            = new_fxstat(1, fd_directed, &fstat);
 		if (rc != 0)
 			return (-1);
 		new_offset = fstat.st_size + offset;
@@ -2400,7 +2420,7 @@ lseek_comm(off_t (*next_lseek)(int fd, off_t offset, int whence), int fd, off_t 
 		return (-1);
 	}
 
-	file_list[fd - FD_FILE_BASE]->offset = new_offset;
+	file_list[fd_directed - FD_FILE_BASE]->offset = new_offset;
 	return new_offset;
 }
 
@@ -2472,6 +2492,7 @@ int
 fstatfs(int fd, struct statfs *sfs)
 {
 	int              rc;
+	int              fd_directed;
 	struct dfs_mt   *dfs_mt;
 	daos_pool_info_t info = {.pi_bits = DPI_SPACE};
 
@@ -2483,13 +2504,14 @@ fstatfs(int fd, struct statfs *sfs)
 	if (!hook_enabled)
 		return next_fstatfs(fd, sfs);
 
-	if (fd < FD_FILE_BASE)
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_fstatfs(fd, sfs);
 
-	if (fd < FD_DIR_BASE)
-		dfs_mt = file_list[fd - FD_FILE_BASE]->dfs_mt;
+	if (fd_directed < FD_DIR_BASE)
+		dfs_mt = file_list[fd_directed - FD_FILE_BASE]->dfs_mt;
 	else
-		dfs_mt = dir_list[fd - FD_DIR_BASE]->dfs_mt;
+		dfs_mt = dir_list[fd_directed - FD_DIR_BASE]->dfs_mt;
 	rc = daos_pool_query(dfs_mt->poh, NULL, &info, NULL, NULL);
 	if (rc != 0) {
 		errno = rc;
@@ -3255,9 +3277,11 @@ write_all(int fd, const void *buf, size_t count)
 	ssize_t rc, byte_written = 0;
 	char   *p_buf = (char *)buf;
 	int     errno_save;
+	int     fd_directed;
 
-	if (fd >= FD_FILE_BASE)
-		return write(fd, buf, count);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed >= FD_FILE_BASE)
+		return write(fd_directed, buf, count);
 
 	while (count != 0 && (rc = write(fd, p_buf, count)) != 0) {
 		if (rc == -1) {
@@ -3681,18 +3705,22 @@ getcwd(char *buf, size_t size)
 int
 isatty(int fd)
 {
+	int fd_directed;
+
 	if (next_isatty == NULL) {
 		next_isatty = dlsym(RTLD_NEXT, "isatty");
 		D_ASSERT(next_isatty != NULL);
 	}
 	if (!hook_enabled)
 		return next_isatty(fd);
-
-	if (fd >= FD_FILE_BASE)
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed >= FD_FILE_BASE) {
 		/* non-terminal */
+		errno = ENOTTY;
 		return 0;
-	else
+	} else {
 		return next_isatty(fd);
+	}
 }
 
 int
@@ -3982,40 +4010,48 @@ out_err:
 int
 fsync(int fd)
 {
+	int fd_directed;
+
 	if (next_fsync == NULL) {
 		next_fsync = dlsym(RTLD_NEXT, "fsync");
 		D_ASSERT(next_fsync != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_fsync(fd);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_fsync(fd);
 
-	if (fd >= FD_DIR_BASE) {
+	if (fd_directed >= FD_DIR_BASE) {
 		errno = EINVAL;
 		return (-1);
 	}
 
-	return dfs_sync(file_list[fd - FD_FILE_BASE]->dfs_mt->dfs);
+	return dfs_sync(file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs);
 }
 
 int
 ftruncate(int fd, off_t length)
 {
-	int rc;
+	int rc, fd_directed;
 
 	if (next_ftruncate == NULL) {
 		next_ftruncate = dlsym(RTLD_NEXT, "ftruncate");
 		D_ASSERT(next_ftruncate != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_ftruncate(fd, length);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_ftruncate(fd, length);
 
-	if (fd >= FD_DIR_BASE) {
+	if (fd_directed >= FD_DIR_BASE) {
 		errno = EINVAL;
 		return (-1);
 	}
 
-	rc = dfs_punch(file_list[fd - FD_FILE_BASE]->dfs_mt->dfs,
-		       file_list[fd - FD_FILE_BASE]->file, length, DFS_MAX_FSIZE);
+	rc = dfs_punch(file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+		       file_list[fd_directed - FD_FILE_BASE]->file, length, DFS_MAX_FSIZE);
 	if (rc) {
 		errno = rc;
 		return (-1);
@@ -4145,25 +4181,28 @@ chmod(const char *path, mode_t mode)
 int
 fchmod(int fd, mode_t mode)
 {
-	int rc;
+	int rc, fd_directed;
 
 	if (next_fchmod == NULL) {
 		next_fchmod = dlsym(RTLD_NEXT, "fchmod");
 		D_ASSERT(next_fchmod != NULL);
 	}
 
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_fchmod(fd, mode);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_fchmod(fd, mode);
 
-	if (fd >= FD_DIR_BASE) {
+	if (fd_directed >= FD_DIR_BASE) {
 		errno = EINVAL;
 		return (-1);
 	}
 
 	rc =
-	    dfs_chmod(file_list[fd - FD_FILE_BASE]->dfs_mt->dfs,
-		      file_list[fd - FD_FILE_BASE]->parent,
-		      file_list[fd - FD_FILE_BASE]->item_name, mode);
+	    dfs_chmod(file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+		      file_list[fd_directed - FD_FILE_BASE]->parent,
+		      file_list[fd_directed - FD_FILE_BASE]->item_name, mode);
 	if (rc) {
 		errno = rc;
 		return (-1);
@@ -4259,7 +4298,7 @@ utime(const char *path, const struct utimbuf *times)
 		stbuf.st_mtim.tv_nsec = 0;
 	}
 
-	rc = dfs_osetattr(dfs_mt->dfs, obj, &stbuf, DFS_SET_ATTR_ATIME | DFS_SET_ATTR_MTIME);
+	rc = dfs_osetattr(dfs_mt->dfs, obj, &stbuf, DFS_SET_ATTR_MTIME);
 	if (rc) {
 		dfs_release(obj);
 		D_GOTO(out_err, rc);
@@ -4331,7 +4370,7 @@ utimes(const char *path, const struct timeval times[2])
 		stbuf.st_mtim.tv_nsec = times[1].tv_usec * 1000;
 	}
 
-	rc = dfs_osetattr(dfs_mt->dfs, obj, &stbuf, DFS_SET_ATTR_ATIME | DFS_SET_ATTR_MTIME);
+	rc = dfs_osetattr(dfs_mt->dfs, obj, &stbuf, DFS_SET_ATTR_MTIME);
 	if (rc) {
 		D_ERROR("dfs_osetattr() failed: %d (%s)\n", rc, strerror(rc));
 		dfs_release(obj);
@@ -4406,7 +4445,7 @@ utimens_timespec(const char *path, const struct timespec times[2], int flags)
 		stbuf.st_mtim.tv_nsec = times[1].tv_nsec;
 	}
 
-	rc = dfs_osetattr(dfs_mt->dfs, obj, &stbuf, DFS_SET_ATTR_ATIME | DFS_SET_ATTR_MTIME);
+	rc = dfs_osetattr(dfs_mt->dfs, obj, &stbuf, DFS_SET_ATTR_MTIME);
 	if (rc) {
 		dfs_release(obj);
 		D_GOTO(out_err, rc);
@@ -4476,6 +4515,7 @@ int
 futimens(int fd, const struct timespec times[2])
 {
 	int             rc;
+	int             fd_directed;
 	struct timespec times_loc;
 	struct stat     stbuf;
 
@@ -4483,7 +4523,10 @@ futimens(int fd, const struct timespec times[2])
 		next_futimens = dlsym(RTLD_NEXT, "futimens");
 		D_ASSERT(next_futimens != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_futimens(fd, times);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_futimens(fd, times);
 
 	if (times == NULL) {
@@ -4499,9 +4542,9 @@ futimens(int fd, const struct timespec times[2])
 		stbuf.st_mtim.tv_nsec = times[1].tv_nsec;
 	}
 
-	rc = dfs_osetattr(file_list[fd - FD_FILE_BASE]->dfs_mt->dfs,
-			  file_list[fd - FD_FILE_BASE]->file, &stbuf,
-			  DFS_SET_ATTR_ATIME | DFS_SET_ATTR_MTIME);
+	rc = dfs_osetattr(file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+			  file_list[fd_directed - FD_FILE_BASE]->file, &stbuf,
+			  DFS_SET_ATTR_MTIME);
 	if (rc) {
 		errno = rc;
 		return (-1);
@@ -4524,7 +4567,7 @@ futimens(int fd, const struct timespec times[2])
 static int
 new_fcntl(int fd, int cmd, ...)
 {
-	int     fd_Directed, param, OrgFunc = 1;
+	int     fd_directed, param, OrgFunc = 1;
 	int     Next_Dirfd, Next_fd, rc;
 	va_list arg;
 
@@ -4545,40 +4588,40 @@ new_fcntl(int fd, int cmd, ...)
 		param = va_arg(arg, int);
 		va_end(arg);
 
-		fd_Directed = Get_Fd_Redirected(fd);
+		fd_directed = get_fd_redirected(fd);
 
 		if (!hook_enabled)
 			return libc_fcntl(fd, cmd, param);
 
 		if (cmd == F_GETFL) {
-			if (fd_Directed >= FD_DIR_BASE)
-				return dir_list[fd_Directed - FD_DIR_BASE]->open_flag;
-			else if (fd_Directed >= FD_FILE_BASE)
-				return file_list[fd_Directed - FD_FILE_BASE]->open_flag;
+			if (fd_directed >= FD_DIR_BASE)
+				return dir_list[fd_directed - FD_DIR_BASE]->open_flag;
+			else if (fd_directed >= FD_FILE_BASE)
+				return file_list[fd_directed - FD_FILE_BASE]->open_flag;
 			else
 				return libc_fcntl(fd, cmd);
 		}
 
-		if (fd_Directed >= FD_FILE_BASE) {
+		if (fd_directed >= FD_FILE_BASE) {
 			if (cmd == F_SETFD)
 				return 0;
 		}
 
-		if (fd_Directed >= FD_FILE_BASE)
+		if (fd_directed >= FD_FILE_BASE)
 			OrgFunc = 0;
 
 		if ((cmd == F_DUPFD) || (cmd == F_DUPFD_CLOEXEC)) {
-			if (fd_Directed >= FD_DIR_BASE) {
+			if (fd_directed >= FD_DIR_BASE) {
 				rc = find_next_available_dirfd(
-						dir_list[fd_Directed - FD_DIR_BASE], &Next_Dirfd);
+						dir_list[fd_directed - FD_DIR_BASE], &Next_Dirfd);
 				if (rc) {
 					errno = rc;
 					return (-1);
 				}
 				return (Next_Dirfd + FD_DIR_BASE);
-			} else if (fd_Directed >= FD_FILE_BASE) {
+			} else if (fd_directed >= FD_FILE_BASE) {
 				rc = find_next_available_fd(
-						file_list[fd_Directed - FD_FILE_BASE], &Next_fd);
+						file_list[fd_directed - FD_FILE_BASE], &Next_fd);
 				if (rc) {
 					errno = rc;
 					return (-1);
@@ -4620,6 +4663,7 @@ ioctl(int fd, unsigned long request, ...)
 	va_list                         arg;
 	void                           *param;
 	struct dfuse_user_reply        *reply;
+	int                             fd_directed;
 
 	va_start(arg, request);
 	param = va_arg(arg, void *);
@@ -4629,7 +4673,10 @@ ioctl(int fd, unsigned long request, ...)
 		next_ioctl = dlsym(RTLD_NEXT, "ioctl");
 		D_ASSERT(next_ioctl != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_ioctl(fd, request, param);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_ioctl(fd, request, param);
 
 	/* To pass existing test of ioctl() with DFUSE_IOCTL_DFUSE_USER */
@@ -4660,8 +4707,7 @@ dup(int oldfd)
 	}
 	if (!hook_enabled)
 		return next_dup(oldfd);
-
-	fd_directed = Get_Fd_Redirected(oldfd);
+	fd_directed = get_fd_redirected(oldfd);
 	if (fd_directed >= FD_FILE_BASE)
 		return new_fcntl(oldfd, F_DUPFD, 0);
 
@@ -4671,7 +4717,7 @@ dup(int oldfd)
 int
 dup2(int oldfd, int newfd)
 {
-	int fd, fd_Directed, idx, rc, errno_save;
+	int fd, fd_directed, idx, rc, errno_save;
 
 	/* Need more work later. */
 	if (next_dup2 == NULL) {
@@ -4696,19 +4742,19 @@ dup2(int oldfd, int newfd)
 		errno = ENOTSUP;
 		return -1;
 	}
-	fd_Directed = query_fd_forward_dest(newfd);
-	if (fd_Directed >= FD_FILE_BASE) {
-		D_ERROR("unimplemented yet for fd_Directed >= FD_FILE_BASE: %d (%s)\n", ENOTSUP,
+	fd_directed = query_fd_forward_dest(newfd);
+	if (fd_directed >= FD_FILE_BASE) {
+		D_ERROR("unimplemented yet for fd_directed >= FD_FILE_BASE: %d (%s)\n", ENOTSUP,
 			strerror(ENOTSUP));
 		errno = ENOTSUP;
 		return -1;
 	}
 
 	if (oldfd >= FD_FILE_BASE)
-		fd_Directed = oldfd;
+		fd_directed = oldfd;
 	else
-		fd_Directed = query_fd_forward_dest(oldfd);
-	if (fd_Directed >= FD_FILE_BASE) {
+		fd_directed = query_fd_forward_dest(oldfd);
+	if (fd_directed >= FD_FILE_BASE) {
 		rc = close(newfd);
 		if (rc != 0 && errno != EBADF)
 			return -1;
@@ -4727,7 +4773,7 @@ dup2(int oldfd, int newfd)
 			errno = EBUSY;
 			return (-1);
 		}
-		idx = allocate_dup2ed_fd(fd, fd_Directed);
+		idx = allocate_dup2ed_fd(fd, fd_directed);
 		if (idx >= 0)
 			return fd;
 		else
@@ -4800,11 +4846,14 @@ __dup2(int oldfd, int newfd) __attribute__((alias("dup2"), leaf, nothrow));
 void *
 new_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 {
-	int             rc, idx_map;
+	int             rc, idx_map, fd_directed;
 	struct stat     stat_buf;
 	void            *addr_ret;
 
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_mmap(addr, length, prot, flags, fd, offset);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_mmap(addr, length, prot, flags, fd, offset);
 
 	atomic_fetch_add_relaxed(&num_mmap, 1);
@@ -4813,8 +4862,8 @@ new_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 	if (addr_ret == MAP_FAILED)
 		return MAP_FAILED;
 
-	rc = dfs_ostat(file_list[fd - FD_FILE_BASE]->dfs_mt->dfs,
-		       file_list[fd - FD_FILE_BASE]->file, &stat_buf);
+	rc = dfs_ostat(file_list[fd_directed - FD_FILE_BASE]->dfs_mt->dfs,
+		       file_list[fd_directed - FD_FILE_BASE]->file, &stat_buf);
 	if (rc) {
 		errno = rc;
 		return MAP_FAILED;
@@ -4827,13 +4876,13 @@ new_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 		return MAP_FAILED;
 	}
 
-	file_list[fd - FD_FILE_BASE]->idx_mmap = idx_map;
+	file_list[fd_directed - FD_FILE_BASE]->idx_mmap = idx_map;
 	mmap_list[idx_map].addr = (char *)addr_ret;
 	mmap_list[idx_map].length = length;
 	mmap_list[idx_map].file_size = stat_buf.st_size;
 	mmap_list[idx_map].prot = prot;
 	mmap_list[idx_map].flags = flags;
-	mmap_list[idx_map].fd = fd;
+	mmap_list[idx_map].fd = fd_directed;
 	mmap_list[idx_map].num_pages = length & (page_size - 1) ?
 				       (length / page_size + 1) :
 				       (length / page_size);
@@ -4929,11 +4978,16 @@ new_munmap(void *addr, size_t length)
 int
 posix_fadvise(int fd, off_t offset, off_t len, int advice)
 {
+	int fd_directed;
+
 	if (next_posix_fadvise == NULL) {
 		next_posix_fadvise = dlsym(RTLD_NEXT, "posix_fadvise");
 		D_ASSERT(next_posix_fadvise != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_posix_fadvise(fd, offset, len, advice);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_posix_fadvise(fd, offset, len, advice);
 
 	/* Hint to turn off caching. */
@@ -4954,11 +5008,16 @@ posix_fadvise64(int fd, off_t offset, off_t len, int advice)
 int
 flock(int fd, int operation)
 {
+	int fd_directed;
+
 	if (next_flock == NULL) {
 		next_flock = dlsym(RTLD_NEXT, "flock");
 		D_ASSERT(next_flock != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_flock(fd, operation);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_flock(fd, operation);
 
 	/* We output the message only if env "D_IL_REPORT" is set. */
@@ -4971,11 +5030,16 @@ flock(int fd, int operation)
 int
 fallocate(int fd, int mode, off_t offset, off_t len)
 {
+	int fd_directed;
+
 	if (next_fallocate == NULL) {
 		next_fallocate = dlsym(RTLD_NEXT, "fallocate");
 		D_ASSERT(next_fallocate != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_fallocate(fd, mode, offset, len);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_fallocate(fd, mode, offset, len);
 
 	/* We output the message only if env "D_IL_REPORT" is set. */
@@ -4989,11 +5053,16 @@ fallocate(int fd, int mode, off_t offset, off_t len)
 int
 posix_fallocate(int fd, off_t offset, off_t len)
 {
+	int fd_directed;
+
 	if (next_posix_fallocate == NULL) {
 		next_posix_fallocate = dlsym(RTLD_NEXT, "posix_fallocate");
 		D_ASSERT(next_posix_fallocate != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_posix_fallocate(fd, offset, len);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_posix_fallocate(fd, offset, len);
 
 	/* We output the message only if env "D_IL_REPORT" is set. */
@@ -5007,11 +5076,16 @@ posix_fallocate(int fd, off_t offset, off_t len)
 int
 posix_fallocate64(int fd, off64_t offset, off64_t len)
 {
+	int fd_directed;
+
 	if (next_posix_fallocate64 == NULL) {
 		next_posix_fallocate64 = dlsym(RTLD_NEXT, "posix_fallocate64");
 		D_ASSERT(next_posix_fallocate64 != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_posix_fallocate64(fd, offset, len);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_posix_fallocate64(fd, offset, len);
 
 	/* We output the message only if env "D_IL_REPORT" is set. */
@@ -5025,11 +5099,16 @@ posix_fallocate64(int fd, off64_t offset, off64_t len)
 int
 tcgetattr(int fd, void *termios_p)
 {
+	int fd_directed;
+
 	if (next_tcgetattr == NULL) {
 		next_tcgetattr = dlsym(RTLD_NEXT, "tcgetattr");
 		D_ASSERT(next_tcgetattr != NULL);
 	}
-	if (!hook_enabled || fd < FD_FILE_BASE)
+	if (!hook_enabled)
+		return next_tcgetattr(fd, termios_p);
+	fd_directed = get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
 		return next_tcgetattr(fd, termios_p);
 
 	/* We output the message only if env "D_IL_REPORT" is set. */

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -3816,15 +3816,10 @@ class PosixTests():
         print(rc.stdout)
         assert rc.stdout == b'sh\n', rc
 
+    @needs_dfuse
     def test_pil4dfs(self):
         """Test interception library libpil4dfs.so"""
-        dfuse = DFuse(self.server,
-                      self.conf,
-                      pool=self.pool.id(),
-                      container=self.container,
-                      caching=False)
-        dfuse.start(v_hint='pil4dfs')
-        path = dfuse.dir
+        path = self.dfuse.dir
 
         # Create a file natively.
         file1 = join(path, 'file1')
@@ -3868,8 +3863,10 @@ class PosixTests():
         self.server.run_daos_client_cmd_pil4dfs(['ln', '-s', file4, link1])
         self.server.run_daos_client_cmd_pil4dfs(['rm', '-Rf', dir1])
 
-        if dfuse.stop():
-            self.fatal_errors = True
+        # dd to write a file
+        file5 = join(path, 'newfile')
+        self.server.run_daos_client_cmd_pil4dfs(['dd', 'if=/dev/zero', f'of={file5}', 'bs=1',
+                                                'count=1'])
 
 
 class NltStdoutWrapper():


### PR DESCRIPTION
When a fd allocated by libpil4dfs is dupplicated by dup(), dup2(), and fcntl(, F_DUPFD, ), a real fd allocated by kernel would be returned. In those POSIX functions taking fd as parameters, fd should be checked whether it should be redirected to a fake fd allocated by libpil4dfs.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
