### PR TITLE
DAOS-13980 control: Misc. unit test fixups

### DIFF
--- a/src/control/cmd/daos_agent/security_rpc_test.go
+++ b/src/control/cmd/daos_agent/security_rpc_test.go
@@ -105,6 +105,7 @@ func TestAgentSecurityModule_RequestCreds_OK(t *testing.T) {
 	defer cleanup()
 
 	mod := NewSecurityModule(log, defaultTestTransportConfig())
+	mod.ext = auth.NewMockExtWithUser("agent-test", 0, 0)
 	respBytes, err := callRequestCreds(mod, t, log, conn)
 
 	if err != nil {

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -153,8 +153,11 @@ func (pcr *PoolCreateReq) MarshalJSON() ([]byte, error) {
 
 // request, filling in any missing fields with reasonable defaults.
 func genPoolCreateRequest(in *PoolCreateReq) (out *mgmtpb.PoolCreateReq, err error) {
+	if in.userExt == nil {
+		in.userExt = &auth.External{}
+	}
 	// ensure pool ownership is set up correctly
-	in.User, in.UserGroup, err = formatNameGroup(&auth.External{}, in.User, in.UserGroup)
+	in.User, in.UserGroup, err = formatNameGroup(in.userExt, in.User, in.UserGroup)
 	if err != nil {
 		return
 	}
@@ -232,6 +235,7 @@ type (
 	// PoolCreateReq contains the parameters for a pool create request.
 	PoolCreateReq struct {
 		poolRequest
+		userExt    auth.UserExt
 		User       string
 		UserGroup  string
 		ACL        *AccessControlList `json:"-"`

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/security/auth"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -349,6 +350,7 @@ func TestControl_PoolEvict(t *testing.T) {
 }
 
 func TestControl_PoolCreate(t *testing.T) {
+	mockExt := auth.NewMockExtWithUser("poolTest", 0, 0)
 	strVal := func(s string) daos.PoolPropertyValue {
 		v := daos.PoolPropertyValue{}
 		v.SetString(s)
@@ -493,6 +495,9 @@ func TestControl_PoolCreate(t *testing.T) {
 			ctx := test.Context(t)
 			mi := NewMockInvoker(log, mic)
 
+			if tc.req.userExt == nil {
+				tc.req.userExt = mockExt
+			}
 			gotResp, gotErr := PoolCreate(ctx, mi, tc.req)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {

--- a/src/control/lib/support/log_test.go
+++ b/src/control/lib/support/log_test.go
@@ -245,7 +245,7 @@ func TestSupport_cpOutputToFile(t *testing.T) {
 			cmd:       "hostnamefoo",
 			option:    "",
 			expResult: "",
-			expErr:    errors.New("sh: hostnamefoo: command not found"),
+			expErr:    errors.New("command not found"),
 		},
 		"Check valid Command with invalid target directory": {
 			target:    targetTestDir + "/dir1",

--- a/src/control/security/domain_info_test.go
+++ b/src/control/security/domain_info_test.go
@@ -7,15 +7,23 @@
 package security_test
 
 import (
+	"fmt"
 	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
 func TestSecurity_DomainInfo_String(t *testing.T) {
+	pid1Str := "systemd"
+	sysDistro := system.GetDistribution()
+	if sysDistro.ID == "debian" {
+		pid1Str = "init"
+	}
+
 	ucred_noPid := &syscall.Ucred{
 		Pid: 0,
 		Uid: 123456,
@@ -48,7 +56,7 @@ func TestSecurity_DomainInfo_String(t *testing.T) {
 		},
 		"creds (PID)": {
 			di:     security.InitDomainInfo(ucred_Pid, "ctx"),
-			expStr: "pid: 1 (systemd) uid: 0 (root) gid: 0 (root)",
+			expStr: fmt.Sprintf("pid: 1 (%s) uid: 0 (root) gid: 0 (root)", pid1Str),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
* Use a mock test user to avoid exposure to environments
  where a very large number of supplementary groups may
  cause spurious test failures.
* Adjust expected pid 1 process name based on platform.

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac@google.com>
