### PR TITLE
DAOS-0000 dfs: Keep a handle on dfs objects if release fails.

### DIFF
--- a/src/client/dfs/dfs_sys.c
+++ b/src/client/dfs/dfs_sys.c
@@ -126,13 +126,10 @@ static void
 hash_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 {
 	struct hash_hdl *hdl = hash_hdl_obj(rlink);
-	int		rc = 0;
 
 	D_DEBUG(DB_TRACE, "name=%s\n", hdl->name);
 
-	rc = dfs_release(hdl->obj);
-	if (rc == ENOMEM)
-		dfs_release(hdl->obj);
+	dfs_release(hdl->obj);
 	D_FREE(hdl->name);
 	D_FREE(hdl);
 }
@@ -795,7 +792,6 @@ dfs_sys_stat(dfs_sys_t *dfs_sys, const char *path, int flags,
 	     struct stat *buf)
 {
 	int             rc;
-	int             rc2;
 	struct sys_path sys_path;
 	dfs_obj_t      *obj;
 	int             lookup_flags = O_RDWR;
@@ -826,9 +822,7 @@ dfs_sys_stat(dfs_sys_t *dfs_sys, const char *path, int flags,
 		D_GOTO(out_free_path, rc);
 	}
 
-	rc2 = dfs_release(obj);
-	if (rc2 == ENOMEM)
-		dfs_release(obj);
+	dfs_release(obj);
 
 out_free_path:
 	sys_path_free(dfs_sys, &sys_path);
@@ -1219,8 +1213,6 @@ dfs_sys_close(dfs_obj_t *obj)
 	int rc = 0;
 
 	rc = dfs_release(obj);
-	if (rc == ENOMEM)
-		dfs_release(obj);
 	return rc;
 }
 
@@ -1475,8 +1467,6 @@ dfs_sys_closedir(DIR *dirp)
 	sys_dir = (struct dfs_sys_dir *)dirp;
 
 	rc = dfs_release(sys_dir->obj);
-	if (rc == ENOMEM)
-		dfs_release(sys_dir->obj);
 
 	D_FREE(sys_dir);
 

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1001,7 +1001,6 @@ dfuse_dcache_get_valid(struct dfuse_inode_entry *ie, double max_age)
 
 		DFUSE_TRA_DEBUG(ie, "Allowing cache use");
 	}
-
 	return use;
 }
 
@@ -1136,11 +1135,8 @@ dfuse_ie_close(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 
 	if (ie->ie_obj) {
 		rc = dfs_release(ie->ie_obj);
-		if (rc == ENOMEM)
-			rc = dfs_release(ie->ie_obj);
-		if (rc) {
+		if (rc)
 			DFUSE_TRA_ERROR(ie, "dfs_release() failed: %d (%s)", rc, strerror(rc));
-		}
 	}
 
 	if (ie->ie_root) {
@@ -1482,6 +1478,10 @@ dfuse_fs_stop(struct dfuse_info *fs_handle)
 
 	DFUSE_TRA_INFO(fs_handle, "Flush complete: "DF_RC, DP_RC(rc));
 
+	/* TODO: Note this isn't safe, inodes are flushed in order but that may mean that the
+	 * dfs is unmounted before all objects are closed.  Inodes should probably hold a reference
+	 * on their parent container.
+	 */
 	DFUSE_TRA_INFO(fs_handle, "Draining inode table");
 	do {
 		struct dfuse_inode_entry *ie;

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -149,12 +149,9 @@ ioil_shrink_cont(struct ioil_cont *cont, bool shrink_pool, bool force)
 static void
 entry_array_close(void *arg) {
 	struct fd_entry *entry = arg;
-	int              rc;
 
 	DFUSE_TRA_DOWN(entry->fd_dfsoh);
-	rc = dfs_release(entry->fd_dfsoh);
-	if (rc == ENOMEM)
-		dfs_release(entry->fd_dfsoh);
+	dfs_release(entry->fd_dfsoh);
 
 	entry->fd_cont->ioc_open_count -= 1;
 


### PR DESCRIPTION
Rather than return an error code from release keep if the operation
fails then hang it on a list from the dfs object itself.
This removes the need to check the return code from dfs_release
and tidies up a lot of code.

The only places that were doing anything with the return code
were simply re-trying in order to pass the NLT test.

This PR highlights an issue with dfuse that inodes are not
closed in an orderly manner so therefore dfs can be unmounted
before all the inodes are releaseed.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
