### PR TITLE
DAOS-13996 pool: Fix invalid D_FREE in pool_glance

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1540,8 +1540,6 @@ check_map:
 	*global_version_out = global_version;
 	*map_buf_out = map_buf;
 	*map_version_out = map_version;
-	if (rc != 0)
-		D_FREE(map_buf);
 out:
 	return rc;
 }

--- a/src/pool/srv_pool_check.c
+++ b/src/pool/srv_pool_check.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -84,7 +84,9 @@ pool_glance(uuid_t uuid, char *path, struct ds_pool_clue *clue_out)
 	}
 
 	rc = ds_pool_svc_load(&tx, uuid, &root, &global_version, &map_buf, &clue.psc_map_version);
-	if (rc == DER_UNINIT) {
+	if (rc == 0) {
+		D_FREE(map_buf);
+	} else if (rc == DER_UNINIT) {
 		clue.psc_map_version = 0;
 		rc = 0;
 	} else if (rc != 0) {
@@ -92,7 +94,6 @@ pool_glance(uuid_t uuid, char *path, struct ds_pool_clue *clue_out)
 	}
 
 	memcpy(clue_out->pc_svc_clue, &clue, sizeof(clue));
-	D_FREE(map_buf);
 out_label:
 	if (rc != 0) {
 		D_FREE(clue_out->pc_label);


### PR DESCRIPTION
pool_glance should only free map_buf if ds_pool_svc_load returns zero. The segfault might be triggered because ds_pool_svc_load returned DER_UNINIT; it is unknown that what actually happened. This patch fixes the D_FREE logic.

ds_pool_svc_load does not need to free map_buf in any case. It is likely a merge error. This patch removes the unnecessary D_FREE in ds_pool_svc_load.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
