### PR TITLE
DAOS-14031 client: change close functions with NULL ev to bypass tse (…

### DIFF
--- a/src/client/api/array.c
+++ b/src/client/api/array.c
@@ -115,6 +115,9 @@ daos_array_close(daos_handle_t oh, daos_event_t *ev)
 	tse_task_t		*task;
 	int			 rc;
 
+	if (ev == NULL)
+		return dc_array_close_direct(oh);
+
 	rc = dc_task_create(dc_array_close, NULL, ev, &task);
 	if (rc)
 		return rc;

--- a/src/client/api/kv.c
+++ b/src/client/api/kv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2021 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -42,6 +42,9 @@ daos_kv_close(daos_handle_t oh, daos_event_t *ev)
 	daos_kv_close_t	*args;
 	tse_task_t	*task;
 	int		rc;
+
+	if (ev == NULL)
+		return dc_kv_close_direct(oh);
 
 	rc = dc_task_create(dc_kv_close, NULL, ev, &task);
 	if (rc)

--- a/src/client/api/object.c
+++ b/src/client/api/object.c
@@ -55,6 +55,9 @@ daos_obj_close(daos_handle_t oh, daos_event_t *ev)
 	tse_task_t	*task;
 	int		rc;
 
+	if (ev == NULL)
+		return dc_obj_close_direct(oh);
+
 	rc = dc_obj_close_task_create(oh, ev, NULL, &task);
 	if (rc)
 		return rc;

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -829,6 +829,30 @@ err_ptask:
 }
 
 int
+dc_array_close_direct(daos_handle_t oh)
+{
+	struct dc_array		*array;
+	int			rc;
+
+	array = array_hdl2ptr(oh);
+	if (array == NULL)
+		return -DER_NO_HDL;
+
+	rc = daos_obj_close(array->daos_oh, NULL);
+	if (rc) {
+		D_ERROR("daos_obj_close() failed: "DF_RC"\n", DP_RC(rc));
+		array_decref(array);
+		return rc;
+	}
+
+	/* -1 for ref taken here */
+	array_decref(array);
+	/* -1 for array handle */
+	array_decref(array);
+	return 0;
+}
+
+int
 dc_array_close(tse_task_t *task)
 {
 	daos_array_close_t	*args = daos_task_get_args(task);

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1250,17 +1250,16 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid,
 
 			/** just try fetching entry to open the file */
 			rc2 = daos_array_close(file->oh, NULL);
-			if (rc2 == -DER_NOMEM)
-				rc2 = daos_array_close(file->oh, NULL);
-			if (rc2)
+			if (rc2) {
+				D_ERROR("daos_array_close() failed "DF_RC"\n", DP_RC(rc2));
 				return daos_der2errno(rc2);
+			}
 		} else if (rc) {
 			int rc2;
 
 			rc2 = daos_array_close(file->oh, NULL);
-			if (rc2 == -DER_NOMEM)
-				daos_array_close(file->oh, NULL);
-
+			if (rc2)
+				D_ERROR("daos_array_close() failed "DF_RC"\n", DP_RC(rc2));
 			D_DEBUG(DB_TRACE, "Insert file entry %s failed (%d)\n", file->name, rc);
 			return rc;
 		} else {

--- a/src/client/dfs/dfs_sys.c
+++ b/src/client/dfs/dfs_sys.c
@@ -126,13 +126,10 @@ static void
 hash_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 {
 	struct hash_hdl *hdl = hash_hdl_obj(rlink);
-	int		rc = 0;
 
 	D_DEBUG(DB_TRACE, "name=%s\n", hdl->name);
 
-	rc = dfs_release(hdl->obj);
-	if (rc == ENOMEM)
-		dfs_release(hdl->obj);
+	dfs_release(hdl->obj);
 	D_FREE(hdl->name);
 	D_FREE(hdl);
 }
@@ -795,7 +792,6 @@ dfs_sys_stat(dfs_sys_t *dfs_sys, const char *path, int flags,
 	     struct stat *buf)
 {
 	int             rc;
-	int             rc2;
 	struct sys_path sys_path;
 	dfs_obj_t      *obj;
 	int             lookup_flags = O_RDWR;
@@ -825,10 +821,7 @@ dfs_sys_stat(dfs_sys_t *dfs_sys, const char *path, int flags,
 			sys_path.name, rc);
 		D_GOTO(out_free_path, rc);
 	}
-
-	rc2 = dfs_release(obj);
-	if (rc2 == ENOMEM)
-		dfs_release(obj);
+	dfs_release(obj);
 
 out_free_path:
 	sys_path_free(dfs_sys, &sys_path);
@@ -1219,8 +1212,6 @@ dfs_sys_close(dfs_obj_t *obj)
 	int rc = 0;
 
 	rc = dfs_release(obj);
-	if (rc == ENOMEM)
-		dfs_release(obj);
 	return rc;
 }
 
@@ -1475,9 +1466,6 @@ dfs_sys_closedir(DIR *dirp)
 	sys_dir = (struct dfs_sys_dir *)dirp;
 
 	rc = dfs_release(sys_dir->obj);
-	if (rc == ENOMEM)
-		dfs_release(sys_dir->obj);
-
 	D_FREE(sys_dir);
 
 	return rc;

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1142,11 +1142,8 @@ dfuse_ie_close(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry
 
 	if (ie->ie_obj) {
 		rc = dfs_release(ie->ie_obj);
-		if (rc == ENOMEM)
-			rc = dfs_release(ie->ie_obj);
-		if (rc) {
+		if (rc)
 			DFUSE_TRA_ERROR(ie, "dfs_release() failed: %d (%s)", rc, strerror(rc));
-		}
 	}
 
 	if (ie->ie_root) {

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -149,13 +149,9 @@ ioil_shrink_cont(struct ioil_cont *cont, bool shrink_pool, bool force)
 static void
 entry_array_close(void *arg) {
 	struct fd_entry *entry = arg;
-	int              rc;
 
 	DFUSE_TRA_DOWN(entry->fd_dfsoh);
-	rc = dfs_release(entry->fd_dfsoh);
-	if (rc == ENOMEM)
-		dfs_release(entry->fd_dfsoh);
-
+	dfs_release(entry->fd_dfsoh);
 	entry->fd_cont->ioc_open_count -= 1;
 
 	/* Do not close container/pool handles at this point

--- a/src/client/kv/dc_kv.c
+++ b/src/client/kv/dc_kv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2022 Intel Corporation.
+ * (C) Copyright 2017-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -229,6 +229,30 @@ err_put1:
 err_ptask:
 	tse_task_complete(task, rc);
 	return rc;
+}
+
+int
+dc_kv_close_direct(daos_handle_t oh)
+{
+	struct dc_kv	*kv;
+	int		rc;
+
+	kv = kv_hdl2ptr(oh);
+	if (kv == NULL)
+		return -DER_NO_HDL;
+
+	rc = daos_obj_close(kv->daos_oh, NULL);
+	if (rc) {
+		D_ERROR("daos_obj_close() failed: "DF_RC"\n", DP_RC(rc));
+		kv_decref(kv);
+		return rc;
+	}
+
+	/* -1 for ref taken here */
+	kv_decref(kv);
+	/* -1 for kv handle */
+	kv_decref(kv);
+	return 0;
 }
 
 int

--- a/src/include/daos/array.h
+++ b/src/include/daos/array.h
@@ -14,6 +14,7 @@
 int dc_array_create(tse_task_t *task);
 int dc_array_open(tse_task_t *task);
 int dc_array_close(tse_task_t *task);
+int dc_array_close_direct(daos_handle_t oh);
 int dc_array_destroy(tse_task_t *task);
 int dc_array_get_attr(daos_handle_t oh, daos_size_t *chunk_size, daos_size_t *cell_size);
 int dc_array_read(tse_task_t *task);

--- a/src/include/daos/kv.h
+++ b/src/include/daos/kv.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2022 Intel Corporation.
+ * (C) Copyright 2017-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -13,6 +13,7 @@
 /* task function for HL operations */
 int dc_kv_open(tse_task_t *task);
 int dc_kv_close(tse_task_t *task);
+int dc_kv_close_direct(daos_handle_t oh);
 int dc_kv_destroy(tse_task_t *task);
 int dc_kv_get(tse_task_t *task);
 int dc_kv_put(tse_task_t *task);

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -479,6 +479,7 @@ int dc_obj_query_class(tse_task_t *task);
 int dc_obj_list_class(tse_task_t *task);
 int dc_obj_open(tse_task_t *task);
 int dc_obj_close(tse_task_t *task);
+int dc_obj_close_direct(daos_handle_t oh);
 int dc_obj_punch_task(tse_task_t *task);
 int dc_obj_punch_dkeys_task(tse_task_t *task);
 int dc_obj_punch_akeys_task(tse_task_t *task);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1461,23 +1461,27 @@ fail:
 }
 
 int
+dc_obj_close_direct(daos_handle_t oh)
+{
+	struct dc_object        *obj;
+
+	obj = obj_hdl2ptr(oh);
+	if (obj == NULL)
+		return -DER_NO_HDL;
+	obj_hdl_unlink(obj);
+	obj_decref(obj);
+	return 0;
+}
+
+int
 dc_obj_close(tse_task_t *task)
 {
 	daos_obj_close_t	*args;
-	struct dc_object	*obj;
 	int			 rc = 0;
 
 	args = dc_task_get_args(task);
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
-
-	obj = obj_hdl2ptr(args->oh);
-	if (obj == NULL)
-		D_GOTO(out, rc = -DER_NO_HDL);
-
-	obj_hdl_unlink(obj);
-	obj_decref(obj);
-
-out:
+	rc = dc_obj_close_direct(args->oh);
 	tse_task_complete(task, rc);
 	return 0;
 }


### PR DESCRIPTION
…#12687)

- All object close operations (obj, array, kv) are local operation and have no RPC associated with them. If user calls those with a NULL ev, there is no need to create a tse task and can just call directly the underlying close/free operations.
- Remove the close retry hack calls for fault injection testing since there is no malloc on that path anymore.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
