### PR TITLE
DAOS-13964 test: use hg_info instead of fi_info

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -57,15 +57,13 @@ FAILURE_TRIGGER = "00_trigger-launch-failure_00"
 LOG_FILE_FORMAT = "%(asctime)s %(levelname)-5s %(funcName)30s: %(message)s"
 MAX_CI_REPETITIONS = 10
 TEST_EXPECT_CORE_FILES = ["./harness/core_files.py"]
-PROVIDER_KEYS = OrderedDict(
-    [
-        ("cxi", "ofi+cxi"),
-        ("verbs", "ofi+verbs"),
-        ("ucx", "ucx+dc_x"),
-        ("tcp", "ofi+tcp;ofi_rxm"),
-        ("opx", "ofi+opx"),
-    ]
-)
+SUPPORTED_PROVIDERS = [
+    "ofi+cxi",
+    "ofi+verbs",
+    "ucx+dc_x",
+    "ofi+tcp;ofi_rxm",
+    "ofi+opx",
+]
 # Temporary pipeline-lib workaround until DAOS-13934 is implemented
 PROVIDER_ALIAS = {
     "ofi+tcp": "ofi+tcp;ofi_rxm"
@@ -1299,41 +1297,46 @@ class Launch():
             if result.passed:
                 # Omni-Path adapter found; remove verbs as it will not work with OPA devices.
                 logger.debug("  Excluding verbs provider for Omni-Path adapters")
-                PROVIDER_KEYS.pop("verbs")
+                for index, _provider in enumerate(SUPPORTED_PROVIDERS.copy()):
+                    if "verbs" in _provider:
+                        SUPPORTED_PROVIDERS.pop(index)
 
             # Detect all supported providers
-            command = f"fi_info -d {interface} -l | grep -v 'version:'"
+            command = "hg_info"
             result = run_remote(logger, servers, command)
             if result.passed:
                 # Find all supported providers
-                keys_found = defaultdict(NodeSet)
+                providers_found = defaultdict(NodeSet)
                 for data in result.output:
-                    for line in data.stdout:
-                        provider_name = line.replace(":", "")
-                        if provider_name in PROVIDER_KEYS:
-                            keys_found[provider_name].update(data.hosts)
+                    # Output as:
+                    # <Class>  <Protocol>  <Device>
+                    class_protocol = re.findall(
+                        fr'(\S+) +([\S]+) +{interface}$', '\n'.join(data.stdout), re.MULTILINE)
+                    supported_providers = set(map('+'.join, class_protocol))
+                    for _provider in supported_providers.intersection(SUPPORTED_PROVIDERS):
+                        providers_found[_provider].update(data.hosts)
 
                 # Only use providers available on all the server hosts
-                if keys_found:
-                    logger.debug("Detected supported providers:")
-                provider_name_keys = list(keys_found)
-                for provider_name in provider_name_keys:
-                    logger.debug("  %4s: %s", provider_name, str(keys_found[provider_name]))
-                    if keys_found[provider_name] != servers:
-                        keys_found.pop(provider_name)
+                if providers_found:
+                    logger.debug("Detected supported providers for %s:", interface)
+                for _provider, hosts in providers_found.items():
+                    logger.debug("  %4s: %s", _provider, str(hosts))
+                    if hosts != servers:
+                        providers_found.pop(_provider)
 
-                # Select the preferred found provider based upon PROVIDER_KEYS order
-                logger.debug("Supported providers detected: %s", list(keys_found))
-                for key in PROVIDER_KEYS:
-                    if key in keys_found:
-                        provider = PROVIDER_KEYS[key]
+                # Select the preferred found provider based upon SUPPORTED_PROVIDERS order
+                logger.debug(
+                    "Supported providers detected for %s: %s", interface, list(providers_found))
+                for _provider in SUPPORTED_PROVIDERS:
+                    if _provider in providers_found:
+                        provider = _provider
                         break
 
             # Report an error if a provider cannot be found
             if not provider:
                 raise LaunchException(
                     f"Error obtaining a supported provider for {interface} "
-                    f"from: {list(PROVIDER_KEYS)}")
+                    f"from: {SUPPORTED_PROVIDERS}")
 
             logger.debug("  Found %s provider for %s", provider, interface)
 
@@ -3191,11 +3194,11 @@ def main():
     parser.add_argument(
         "-pr", "--provider",
         action="store",
-        choices=[None] + list(PROVIDER_KEYS.values()) + list(PROVIDER_ALIAS.keys()),
+        choices=[None] + SUPPORTED_PROVIDERS + list(PROVIDER_ALIAS.keys()),
         default=None,
         type=str,
         help="default provider to use in the test daos_server config file, "
-             f"e.g. {', '.join(list(PROVIDER_KEYS.values()))}")
+             f"e.g. {', '.join(SUPPORTED_PROVIDERS)}")
     parser.add_argument(
         "-r", "--rename",
         action="store_true",


### PR DESCRIPTION
Test-tag: pr
Skip-func-test-leap15: false

- newer versions of fi_info show providers that aren't actually supported for our uses.
- We want to move to hg_info anyway
- Just replace usage of fi_info with hg_info

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
