### PR TITLE
DAOS-14064 control: INFO logging for ramdisk/hugepages

### DIFF
--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -448,6 +448,10 @@ func getAccessPointAddrWithPort(log logging.Logger, addr string, portDefault int
 	return addr, nil
 }
 
+func hugePageBytes(hpNr, hpSz int) uint64 {
+	return uint64(hpNr*hpSz) * humanize.KiByte
+}
+
 // SetNrHugepages calculates minimum based on total target count if using nvme.
 func (cfg *Server) SetNrHugepages(log logging.Logger, mi *common.MemInfo) error {
 	var cfgTargetCount int
@@ -492,6 +496,8 @@ func (cfg *Server) SetNrHugepages(log logging.Logger, mi *common.MemInfo) error 
 		log.Debugf("calculated nr_hugepages: %d for %d targets%s", minHugepages,
 			cfgTargetCount, msgSysXS)
 		cfg.NrHugepages = minHugepages
+		log.Infof("hugepage count automatically set to %d (%s)", minHugepages,
+			humanize.IBytes(hugePageBytes(minHugepages, mi.HugepageSizeKiB)))
 	}
 
 	if cfg.NrHugepages < minHugepages {
@@ -510,7 +516,7 @@ func (cfg *Server) CalcRamdiskSize(log logging.Logger, hpSizeKiB, memKiB int) (u
 	memTotal := uint64(memKiB * humanize.KiByte)
 
 	// Calculate assigned hugepage memory in bytes.
-	memHuge := uint64(cfg.NrHugepages * hpSizeKiB * humanize.KiByte)
+	memHuge := hugePageBytes(cfg.NrHugepages, hpSizeKiB)
 
 	// Calculate reserved system memory in bytes.
 	memSys := uint64(cfg.SystemRamReserved * humanize.GiByte)
@@ -590,6 +596,8 @@ func (cfg *Server) SetRamdiskSize(log logging.Logger, mi *common.MemInfo) error 
 			// Apply calculated size in config as not already set.
 			log.Debugf("%s: auto-sized ram-disk in engine-%d config", msg, idx)
 			scs[0].WithScmRamdiskSize(uint(maxRamdiskSize / humanize.GiByte))
+			log.Infof("engine-%d: ramdisk size automatically set to %s", idx,
+				humanize.IBytes(maxRamdiskSize))
 		} else if confSize > maxRamdiskSize {
 			// Total RAM is not enough to meet tmpfs size requested in config.
 			log.Errorf("%s: engine-%d config size too large for total memory", msg,


### PR DESCRIPTION
Log the following at INFO level so that they are visible
in production configurations:
  * Auto-calculated per-engine ramdisk size
  * Auto-caculated hugepage count

Required-githooks: true

Signed-off-by: Michael MacDonald <mjmac@google.com>
