### PR TITLE
DAOS-13919 control: Fix dmg pool get-prop compat with v2.2 pools (#12…

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -833,7 +833,6 @@ func PoolGetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetPropRe
 		return nil, errors.New("unable to extract PoolGetPropResp from MS response")
 	}
 
-	resp := req.Properties
 	pbMap := make(map[uint32]*mgmtpb.PoolProperty)
 	for _, prop := range pbResp.GetProperties() {
 		if _, found := pbMap[prop.GetNumber()]; found {
@@ -842,10 +841,12 @@ func PoolGetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetPropRe
 		pbMap[prop.GetNumber()] = prop
 	}
 
-	for _, prop := range resp {
+	resp := make([]*daos.PoolProperty, 0, len(req.Properties))
+	for _, prop := range req.Properties {
 		pbProp, found := pbMap[prop.Number]
 		if !found {
-			rpcClient.Debugf("DAOS-11418: Unable to find prop %d (%s) in resp", prop.Number, prop.Name)
+			// Properties can be missing due to DAOS-11418 and DAOS-13919
+			rpcClient.Debugf("can't find prop %d (%s) in resp", prop.Number, prop.Name)
 			continue
 		}
 		switch v := pbProp.GetValue().(type) {
@@ -856,6 +857,7 @@ func PoolGetProp(ctx context.Context, rpcClient UnaryInvoker, req *PoolGetPropRe
 		default:
 			return nil, errors.Errorf("unable to represent response value %+v", v)
 		}
+		resp = append(resp, prop)
 	}
 
 	return resp, nil

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -907,7 +907,7 @@ func propWithVal(key, val string) *daos.PoolProperty {
 	return prop
 }
 
-func TestPoolSetProp(t *testing.T) {
+func TestControl_PoolSetProp(t *testing.T) {
 	defaultReq := &PoolSetPropReq{
 		ID:         test.MockUUID(),
 		Properties: []*daos.PoolProperty{propWithVal("label", "foo")},
@@ -993,12 +993,102 @@ func TestPoolSetProp(t *testing.T) {
 	}
 }
 
-func TestPoolGetProp(t *testing.T) {
+func propWithNoVal(s string) *daos.PoolProperty {
+	p := propWithVal(s, "")
+	p.Value = daos.PoolPropertyValue{}
+	return p
+}
+
+func TestControl_PoolGetProp(t *testing.T) {
 	defaultReq := &PoolGetPropReq{
 		ID: test.MockUUID(),
 		Properties: []*daos.PoolProperty{propWithVal("label", ""),
 			propWithVal("policy", "type=io_size")},
 	}
+	props2_2 := []*mgmtpb.PoolProperty{
+		{
+			Number: propWithVal("label", "").Number,
+			Value:  &mgmtpb.PoolProperty_Strval{"foo"},
+		},
+		{
+			Number: propWithVal("space_rb", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{42},
+		},
+		{
+			Number: propWithVal("upgrade_status", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{1},
+		},
+		{
+			Number: propWithVal("reclaim", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{daos.PoolSpaceReclaimDisabled},
+		},
+		{
+			Number: propWithVal("self_heal", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{daos.PoolSelfHealingAutoExclude},
+		},
+		{
+			Number: propWithVal("ec_cell_sz", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{4096},
+		},
+		{
+			Number: propWithVal("rd_fac", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{1},
+		},
+		{
+			Number: propWithVal("ec_pda", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{1},
+		},
+		{
+			Number: propWithVal("global_version", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{1},
+		},
+		{
+			Number: propWithVal("rp_pda", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{2},
+		},
+		{
+			Number: propWithVal("policy", "").Number,
+			Value:  &mgmtpb.PoolProperty_Strval{"type=io_size"},
+		},
+		{
+			Number: propWithVal("perf_domain", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{255},
+		},
+		{
+			Number: propWithVal("svc_list", "").Number,
+			Value:  &mgmtpb.PoolProperty_Strval{"[0-3]"},
+		},
+	}
+	props2_4 := append(props2_2, []*mgmtpb.PoolProperty{
+		{
+			Number: propWithVal("scrub", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{daos.PoolScrubModeTimed},
+		},
+		{
+			Number: propWithVal("scrub-freq", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{1024},
+		},
+		{
+			Number: propWithVal("scrub-thresh", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{0},
+		},
+		{
+			Number: propWithVal("svc_rf", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{3},
+		},
+		{
+			Number: propWithVal("checkpoint", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{daos.PoolCheckpointTimed},
+		},
+		{
+			Number: propWithVal("checkpoint_freq", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{10000},
+		},
+		{
+			Number: propWithVal("checkpoint_thresh", "").Number,
+			Value:  &mgmtpb.PoolProperty_Numval{20},
+		},
+	}...)
 
 	for name, tc := range map[string]struct {
 		mic     *MockInvokerConfig
@@ -1071,88 +1161,7 @@ func TestPoolGetProp(t *testing.T) {
 		"all props requested": {
 			mic: &MockInvokerConfig{
 				UnaryResponse: MockMSResponse("host1", nil, &mgmtpb.PoolGetPropResp{
-					Properties: []*mgmtpb.PoolProperty{
-						{
-							Number: propWithVal("label", "").Number,
-							Value:  &mgmtpb.PoolProperty_Strval{"foo"},
-						},
-						{
-							Number: propWithVal("space_rb", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{42},
-						},
-						{
-							Number: propWithVal("upgrade_status", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{1},
-						},
-						{
-							Number: propWithVal("reclaim", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{daos.PoolSpaceReclaimDisabled},
-						},
-						{
-							Number: propWithVal("self_heal", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{daos.PoolSelfHealingAutoExclude},
-						},
-						{
-							Number: propWithVal("ec_cell_sz", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{4096},
-						},
-						{
-							Number: propWithVal("rd_fac", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{1},
-						},
-						{
-							Number: propWithVal("ec_pda", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{1},
-						},
-						{
-							Number: propWithVal("global_version", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{1},
-						},
-						{
-							Number: propWithVal("rp_pda", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{2},
-						},
-						{
-							Number: propWithVal("policy", "").Number,
-							Value:  &mgmtpb.PoolProperty_Strval{"type=io_size"},
-						},
-						{
-							Number: propWithVal("perf_domain", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{255},
-						},
-						{
-							Number: propWithVal("scrub", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{daos.PoolScrubModeTimed},
-						},
-						{
-							Number: propWithVal("scrub-freq", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{1024},
-						},
-						{
-							Number: propWithVal("scrub-thresh", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{0},
-						},
-						{
-							Number: propWithVal("svc_rf", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{3},
-						},
-						{
-							Number: propWithVal("svc_list", "").Number,
-							Value:  &mgmtpb.PoolProperty_Strval{"[0-3]"},
-						},
-						{
-							Number: propWithVal("checkpoint", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{daos.PoolCheckpointTimed},
-						},
-						{
-							Number: propWithVal("checkpoint_freq", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{10000},
-						},
-						{
-							Number: propWithVal("checkpoint_thresh", "").Number,
-							Value:  &mgmtpb.PoolProperty_Numval{20},
-						},
-					},
+					Properties: props2_4,
 				}),
 			},
 			req: &PoolGetPropReq{
@@ -1212,6 +1221,35 @@ func TestPoolGetProp(t *testing.T) {
 				propWithVal("space_rb", "42"),
 			},
 		},
+		"missing props in response; compatibility with old pool": {
+			mic: &MockInvokerConfig{
+				UnaryResponse: MockMSResponse("host1", nil, &mgmtpb.PoolGetPropResp{
+					Properties: props2_2,
+				}),
+			},
+			req: &PoolGetPropReq{
+				ID: test.MockUUID(),
+			},
+			expResp: []*daos.PoolProperty{
+				propWithVal("ec_cell_sz", "4096"),
+				propWithVal("ec_pda", "1"),
+				propWithVal("global_version", "1"),
+				propWithVal("label", "foo"),
+				propWithVal("perf_domain", "root"),
+				propWithVal("policy", "type=io_size"),
+				propWithVal("rd_fac", "1"),
+				propWithVal("reclaim", "disabled"),
+				propWithVal("rp_pda", "2"),
+				propWithVal("self_heal", "exclude"),
+				propWithVal("space_rb", "42"),
+				func() *daos.PoolProperty {
+					p := propWithVal("svc_list", "")
+					p.Value.SetString("[0-3]")
+					return p
+				}(),
+				propWithVal("upgrade_status", "in progress"),
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -1243,6 +1281,94 @@ func TestPoolGetProp(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expResp, gotResp, cmpOpts...); diff != "" {
 				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+
+			// Verify response can be marshalled without error.
+			_, err := json.Marshal(gotResp)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s\n", err.Error())
+			}
+		})
+	}
+}
+
+func TestControl_PoolGetPropResp_MarshalJSON(t *testing.T) {
+	for name, tc := range map[string]struct {
+		resp    []*daos.PoolProperty
+		expData string
+		expErr  error
+	}{
+		"nil": {
+			expData: "null",
+		},
+		"all props": {
+			resp: []*daos.PoolProperty{
+				propWithVal("checkpoint", "timed"),
+				propWithVal("checkpoint_freq", "10000"),
+				propWithVal("checkpoint_thresh", "20"),
+				propWithVal("ec_cell_sz", "4096"),
+				propWithVal("ec_pda", "1"),
+				propWithVal("global_version", "1"),
+				propWithVal("label", "foo"),
+				propWithVal("perf_domain", "root"),
+				propWithVal("policy", "type=io_size"),
+				propWithVal("rd_fac", "1"),
+				propWithVal("reclaim", "disabled"),
+				propWithVal("rp_pda", "2"),
+				propWithVal("scrub", "timed"),
+				propWithVal("scrub-freq", "1024"),
+				propWithVal("scrub-thresh", "0"),
+				propWithVal("self_heal", "exclude"),
+				propWithVal("space_rb", "42"),
+				func() *daos.PoolProperty {
+					p := propWithVal("svc_list", "")
+					p.Value.SetString("[0-3]")
+					return p
+				}(),
+				propWithVal("svc_rf", "3"),
+				propWithVal("upgrade_status", "in progress"),
+			},
+			expData: `[{"name":"checkpoint","description":"WAL Checkpointing behavior","value":"timed"},{"name":"checkpoint_freq","description":"WAL Checkpointing frequency, in seconds","value":10000},{"name":"checkpoint_thresh","description":"Usage of WAL before checkpoint is triggered, as a percentage","value":20},{"name":"ec_cell_sz","description":"EC cell size","value":4096},{"name":"ec_pda","description":"Performance domain affinity level of EC","value":1},{"name":"global_version","description":"Global Version","value":1},{"name":"label","description":"Pool label","value":"foo"},{"name":"perf_domain","description":"Pool performance domain","value":"root"},{"name":"policy","description":"Tier placement policy","value":"type=io_size"},{"name":"rd_fac","description":"Pool redundancy factor","value":1},{"name":"reclaim","description":"Reclaim strategy","value":"disabled"},{"name":"rp_pda","description":"Performance domain affinity level of RP","value":2},{"name":"scrub","description":"Checksum scrubbing mode","value":"timed"},{"name":"scrub-freq","description":"Checksum scrubbing frequency","value":1024},{"name":"scrub-thresh","description":"Checksum scrubbing threshold","value":0},{"name":"self_heal","description":"Self-healing policy","value":"exclude"},{"name":"space_rb","description":"Rebuild space ratio","value":42},{"name":"svc_list","description":"Pool service replica list","value":[0,1,2,3]},{"name":"svc_rf","description":"Pool service redundancy factor","value":3},{"name":"upgrade_status","description":"Upgrade Status","value":"in progress"}]`,
+		},
+		"missing props; v2_2 pool": {
+			resp: []*daos.PoolProperty{
+				propWithNoVal("checkpoint"),
+				propWithNoVal("checkpoint_freq"),
+				propWithNoVal("checkpoint_thresh"),
+				propWithVal("ec_cell_sz", "4096"),
+				propWithVal("ec_pda", "1"),
+				propWithVal("global_version", "1"),
+				propWithVal("label", "foo"),
+				propWithVal("perf_domain", "root"),
+				propWithVal("policy", "type=io_size"),
+				propWithVal("rd_fac", "1"),
+				propWithVal("reclaim", "disabled"),
+				propWithVal("rp_pda", "2"),
+				propWithNoVal("scrub"),
+				propWithNoVal("scrub-freq"),
+				propWithNoVal("scrub-thresh"),
+				propWithVal("self_heal", "exclude"),
+				propWithVal("space_rb", "42"),
+				func() *daos.PoolProperty {
+					p := propWithVal("svc_list", "")
+					p.Value.SetString("[0-3]")
+					return p
+				}(),
+				propWithNoVal("svc_rf"),
+				propWithVal("upgrade_status", "in progress"),
+			},
+			expErr: errors.New("value not set"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotData, gotErr := json.Marshal(tc.resp)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expData, string(gotData)); diff != "" {
+				t.Fatalf("Unexpected response (-want, +got):\n%s\n", diff)
 			}
 		})
 	}


### PR DESCRIPTION
…708)

JSON marshalling fails when attempting to print PoolGetProps()
control-API response as some of the returned properties have no
associated value set. This can occur when dmg pool get-prop is called
from a >= v2.4 dmg/daos_server using a pool that was created with
v2.2. This occurs because the old pool has a reduced set of properties
and so those that don't have an associated value in the RPC response
end up as PoolProperty objects with no associated value (which is not
allowed in the JSON marshal implementation for the type).

Solution is to remove the missing properties from the response before
sending to dmg, the control-API consumer. This does mean that get-prop
calls can return a different property list depending on which DAOS
version was used to create the pool.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
