### PR TITLE
DAOS-13905 common: Fix return code from daos_sgl functions. (#12706)

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -131,7 +131,7 @@ out:
 		}
 	}
 
-	return 0;
+	return rc;
 }
 
 int

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -1111,7 +1111,7 @@ iv_op_async(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
 		rc = daos_sgl_alloc_copy_data(&ult_arg->iv_value, value);
 		if (rc) {
 			D_FREE(ult_arg);
-			return -DER_NOMEM;
+			return rc;
 		}
 	}
 


### PR DESCRIPTION
Errors in some sgl functions were not being propagated
which was leading to crashes in higher level code.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>