### PR TITLE
DAOS-14091 control: Validate against negative ints in engine conf

### DIFF
--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -164,6 +164,25 @@ func (c *Config) Validate() error {
 		return errors.New("cannot specify both pinned_numa_node and first_core")
 	}
 
+	errNegative := func(s string) error {
+		return errors.New("memory size must not be negative")
+	}
+	if c.TargetCount < 0 {
+		return errNegative("target count")
+	}
+	if c.HelperStreamCount < 0 {
+		return errNegative("helper stream count")
+	}
+	if c.ServiceThreadCore < 0 {
+		return errNegative("service thread core index")
+	}
+	if c.MemSize < 0 {
+		return errNegative("mem size")
+	}
+	if c.HugepageSz < 0 {
+		return errNegative("hugepage size")
+	}
+
 	if c.TargetCount == 0 {
 		return errors.New("target count must be nonzero")
 	}

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -165,7 +165,7 @@ func (c *Config) Validate() error {
 	}
 
 	errNegative := func(s string) error {
-		return errors.New("memory size must not be negative")
+		return errors.Errorf("%s must not be negative", s)
 	}
 	if c.TargetCount < 0 {
 		return errNegative("target count")

--- a/src/control/server/engine/config_test.go
+++ b/src/control/server/engine/config_test.go
@@ -470,6 +470,30 @@ func TestConfig_Validation(t *testing.T) {
 			cfg:    validConfig().WithPinnedNumaNode(1).WithServiceThreadCore(1),
 			expErr: errors.New("cannot specify both"),
 		},
+		"config with negative target count should fail": {
+			cfg:    validConfig().WithTargetCount(-10),
+			expErr: errors.New("must not be negative"),
+		},
+		"config with negative helper stream count should fail": {
+			cfg:    validConfig().WithHelperStreamCount(-10),
+			expErr: errors.New("must not be negative"),
+		},
+		"config with negative service core index should fail": {
+			cfg: func() *Config {
+				c := validConfig().WithServiceThreadCore(-10)
+				c.PinnedNumaNode = nil
+				return c
+			}(),
+			expErr: errors.New("must not be negative"),
+		},
+		"config with negative memory size should fail": {
+			cfg:    validConfig().WithMemSize(-10),
+			expErr: errors.New("must not be negative"),
+		},
+		"config with negative hugepage size should fail": {
+			cfg:    validConfig().WithHugepageSize(-10),
+			expErr: errors.New("must not be negative"),
+		},
 		"config with zero target count should fail": {
 			cfg:    validConfig().WithTargetCount(0),
 			expErr: errors.New("target count must be nonzero"),


### PR DESCRIPTION
Ensure parameters in engine config section of server config file are
not populated with negative values.

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
