### PR TITLE
DAOS-14075 bio: Sync LED state on engine start

### DIFF
--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -31,8 +31,7 @@ struct led_opts {
 static int
 revive_dev(struct bio_xs_context *xs_ctxt, struct bio_bdev *d_bdev)
 {
-	struct bio_blobstore	*bbs;
-	unsigned int		 led_state = (unsigned int)CTL__LED_STATE__OFF;
+	struct bio_blobstore    *bbs;
 	int			 rc;
 
 	D_ASSERT(d_bdev);
@@ -55,13 +54,13 @@ revive_dev(struct bio_xs_context *xs_ctxt, struct bio_bdev *d_bdev)
 
 	spdk_thread_send_msg(owner_thread(bbs), setup_bio_bdev, d_bdev);
 
-	/* Set the LED of the VMD device to OFF state (regardless of any FAULT state) */
-	rc = bio_led_manage(xs_ctxt, NULL, d_bdev->bb_uuid, (unsigned int)CTL__LED_ACTION__SET,
-			    &led_state, 0);
+	/* Reset the LED of the VMD device once revived */
+	rc = bio_led_manage(xs_ctxt, NULL, d_bdev->bb_uuid, (unsigned int)CTL__LED_ACTION__RESET,
+			    NULL, 0);
 	if (rc != 0)
 		D_CDEBUG(rc == -DER_NOSYS, DB_MGMT, DLOG_ERR,
-			 "Set LED on device:"DF_UUID" failed, "DF_RC"\n", DP_UUID(d_bdev->bb_uuid),
-			 DP_RC(rc));
+			 "Reset LED on device:" DF_UUID " failed, " DF_RC "\n",
+			 DP_UUID(d_bdev->bb_uuid), DP_RC(rc));
 
 	return 0;
 }
@@ -871,11 +870,6 @@ led_manage(struct bio_xs_context *xs_ctxt, struct spdk_pci_addr pci_addr, Ctl__L
 
 	D_ASSERT(is_init_xstream(xs_ctxt));
 
-	if (state == NULL) {
-		D_ERROR("LED state receiver is NULL\n");
-		return -DER_INVAL;
-	}
-
 	/* Init context to be used by led_device_action() */
 	opts.all_devices = false;
 	opts.finished = false;
@@ -890,6 +884,10 @@ led_manage(struct bio_xs_context *xs_ctxt, struct spdk_pci_addr pci_addr, Ctl__L
 		break;
 	case CTL__LED_ACTION__SET:
 		opts.action = action;
+		if (state == NULL) {
+			D_ERROR("LED state not set for SET action\n");
+			return -DER_INVAL;
+		}
 		opts.led_state = *state;
 		break;
 	case CTL__LED_ACTION__RESET:
@@ -914,11 +912,18 @@ led_manage(struct bio_xs_context *xs_ctxt, struct spdk_pci_addr pci_addr, Ctl__L
 	spdk_pci_for_each_device(&opts, led_device_action);
 
 	if (opts.status != 0) {
-		if (opts.status != -DER_NOSYS)
-			D_ERROR("LED %s failed (target state: %s): %s\n", LED_ACTION_NAME(action),
-				LED_STATE_NAME(*state), spdk_strerror(opts.status));
+		if (opts.status != -DER_NOSYS) {
+			if (state != NULL)
+				D_ERROR("LED %s failed (target state: %s): %s\n",
+					LED_ACTION_NAME(action), LED_STATE_NAME(*state),
+					spdk_strerror(opts.status));
+			else
+				D_ERROR("LED %s failed: %s\n", LED_ACTION_NAME(action),
+					spdk_strerror(opts.status));
+		}
 		return opts.status;
 	}
+
 	if (!opts.all_devices && !opts.finished) {
 		D_ERROR("Device could not be found\n");
 		return -DER_NONEXIST;
@@ -953,7 +958,8 @@ led_manage(struct bio_xs_context *xs_ctxt, struct spdk_pci_addr pci_addr, Ctl__L
 		return -DER_NONEXIST;
 	}
 
-	*state = opts.led_state;
+	if (state != NULL)
+		*state = opts.led_state;
 
 	return 0;
 }

--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -993,15 +993,15 @@ dev_uuid2pci_addr(struct spdk_pci_addr *pci_addr, uuid_t dev_uuid)
 
 	rc = fill_in_traddr(&b_info, d_bdev->bb_name);
 	if (rc) {
-		D_ERROR("Unable to get traddr for device:%s\n", d_bdev->bb_name);
-		return -DER_INVAL;
+		D_DEBUG(DB_MGMT, "Unable to get traddr for device %s\n", d_bdev->bb_name);
+		return -DER_NOSYS;
 	}
 
 	rc = spdk_pci_addr_parse(pci_addr, b_info.bdi_traddr);
 	if (rc != 0) {
-		D_ERROR("Unable to parse PCI address for device %s (%s)\n", b_info.bdi_traddr,
-			spdk_strerror(-rc));
-		rc = -DER_INVAL;
+		D_DEBUG(DB_MGMT, "Unable to parse PCI address for device %s (%s)\n",
+			b_info.bdi_traddr, spdk_strerror(-rc));
+		rc = -DER_NOSYS;
 	}
 
 	D_FREE(b_info.bdi_traddr);

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -956,6 +956,7 @@ error:
 static int
 init_bio_bdevs(struct bio_xs_context *ctxt)
 {
+	struct bio_bdev  *d_bdev;
 	struct spdk_bdev *bdev;
 	int rc = 0;
 
@@ -972,9 +973,32 @@ init_bio_bdevs(struct bio_xs_context *ctxt)
 
 		rc = create_bio_bdev(ctxt, spdk_bdev_get_name(bdev), NULL);
 		if (rc)
-			break;
+			return rc;
 	}
-	return rc;
+
+	for (bdev = spdk_bdev_first(); bdev != NULL; bdev = spdk_bdev_next(bdev)) {
+		if (nvme_glb.bd_bdev_class != get_bdev_type(bdev))
+			continue;
+
+		d_bdev = lookup_dev_by_name(spdk_bdev_get_name(bdev));
+		if (d_bdev == NULL) {
+			D_ERROR("Device %s doesn't exist\n", spdk_bdev_get_name(bdev));
+			return -DER_EXIST;
+		}
+
+		D_INFO("Resetting LED on dev " DF_UUID " \n", DP_UUID(d_bdev->bb_uuid));
+		rc = bio_led_manage(ctxt, NULL, d_bdev->bb_uuid,
+				    (unsigned int)CTL__LED_ACTION__RESET, NULL, 0);
+		if (rc != 0) {
+			if (rc != -DER_NOSYS) {
+				D_ERROR("Reset LED on device:" DF_UUID " failed, " DF_RC "\n",
+					DP_UUID(d_bdev->bb_uuid), DP_RC(rc));
+				return rc;
+			}
+		}
+	}
+
+	return 0;
 }
 
 static void
@@ -1837,8 +1861,7 @@ scan_bio_bdevs(struct bio_xs_context *ctxt, uint64_t now)
 void
 bio_led_event_monitor(struct bio_xs_context *ctxt, uint64_t now)
 {
-	struct bio_bdev		*d_bdev;
-	unsigned int		 led_state;
+	struct bio_bdev         *d_bdev;
 	int			 rc;
 
 	/* Scan all devices present in bio_bdev list */
@@ -1849,7 +1872,7 @@ bio_led_event_monitor(struct bio_xs_context *ctxt, uint64_t now)
 
 			/* LED will be reset to faulty or normal state based on SSDs bio_bdevs */
 			rc = bio_led_manage(ctxt, NULL, d_bdev->bb_uuid,
-					    (unsigned int)CTL__LED_ACTION__RESET, &led_state, 0);
+					    (unsigned int)CTL__LED_ACTION__RESET, NULL, 0);
 			if (rc != 0)
 				D_ERROR("Reset LED identify state after timeout failed on device:"
 					DF_UUID", "DF_RC"\n", DP_UUID(d_bdev->bb_uuid), DP_RC(rc));

--- a/src/vos/tests/bio_ut.c
+++ b/src/vos/tests/bio_ut.c
@@ -34,6 +34,8 @@ ut_init(struct bio_ut_args *args)
 {
 	int rc;
 
+	daos_debug_init(DAOS_LOG_DEFAULT);
+
 	rc = vos_self_init(db_path, false, BIO_STANDALONE_TGT_ID);
 	if (rc)
 		daos_debug_fini();

--- a/src/vos/tests/bio_ut.c
+++ b/src/vos/tests/bio_ut.c
@@ -34,8 +34,6 @@ ut_init(struct bio_ut_args *args)
 {
 	int rc;
 
-	daos_debug_init(DAOS_LOG_DEFAULT);
-
 	rc = vos_self_init(db_path, false, BIO_STANDALONE_TGT_ID);
 	if (rc)
 		daos_debug_fini();

--- a/utils/run_utest.py
+++ b/utils/run_utest.py
@@ -299,11 +299,15 @@ class AIO():
             config_file.write(contents)
 
     def prepare_test(self, name="AIO_1", min_size=4):
-        """Prepare AIO for a test, min_size in GB"""
+        """Prepare AIO for a test, min_size in GB. Erase 4K header if device exists (notrunc opt
+        makes dd behavior consistent across device disks and files enabling unit tests to be run
+        locally with /dev/vdb filt).
+        """
         if self.device is None:
             run_cmd(["dd", "if=/dev/zero", f"of={self.fname}", "bs=1G", f"count={min_size}"])
         else:
-            run_cmd(["sudo", "-E", "dd", "if=/dev/zero", f"of={self.fname}", "bs=4K", "count=1"])
+            run_cmd(["sudo", "-E", "dd", "if=/dev/zero", f"of={self.fname}", "bs=4K", "count=1",
+                     "conv=notrunc"])
         self.create_config(name)
 
     def finalize_test(self):

--- a/utils/run_utest.py
+++ b/utils/run_utest.py
@@ -299,11 +299,12 @@ class AIO():
             config_file.write(contents)
 
     def prepare_test(self, name="AIO_1", min_size=4):
-        """Prepare AIO for a test, min_size in GB"""
+        """Prepare AIO for a test, min_size in GB. Erase 4K header if device exists"""
         if self.device is None:
             run_cmd(["dd", "if=/dev/zero", f"of={self.fname}", "bs=1G", f"count={min_size}"])
         else:
-            run_cmd(["sudo", "-E", "dd", "if=/dev/zero", f"of={self.fname}", "bs=4K", "count=1"])
+            run_cmd(["sudo", "-E", "dd", "if=/dev/zero", f"of={self.fname}", "bs=4K", "count=1",
+                     "conv=notrunc"])
         self.create_config(name)
 
     def finalize_test(self):

--- a/utils/run_utest.py
+++ b/utils/run_utest.py
@@ -299,9 +299,9 @@ class AIO():
             config_file.write(contents)
 
     def prepare_test(self, name="AIO_1", min_size=4):
-        """Prepare AIO for a test, min_size in GB. Erase 4K header if device exists (notrunc opt
-        makes dd behavior consistent across device disks and files enabling unit tests to be run
-        locally with /dev/vdb filt).
+        """Prepare AIO for a test, min_size in GB. Erase 4K header if device exists (no truncate
+        opt makes dd behavior consistent across device disks and files enabling unit tests to be
+        run locally with /dev/vdb filt).
         """
         if self.device is None:
             run_cmd(["dd", "if=/dev/zero", f"of={self.fname}", "bs=1G", f"count={min_size}"])

--- a/utils/run_utest.py
+++ b/utils/run_utest.py
@@ -299,12 +299,11 @@ class AIO():
             config_file.write(contents)
 
     def prepare_test(self, name="AIO_1", min_size=4):
-        """Prepare AIO for a test, min_size in GB. Erase 4K header if device exists"""
+        """Prepare AIO for a test, min_size in GB"""
         if self.device is None:
             run_cmd(["dd", "if=/dev/zero", f"of={self.fname}", "bs=1G", f"count={min_size}"])
         else:
-            run_cmd(["sudo", "-E", "dd", "if=/dev/zero", f"of={self.fname}", "bs=4K", "count=1",
-                     "conv=notrunc"])
+            run_cmd(["sudo", "-E", "dd", "if=/dev/zero", f"of={self.fname}", "bs=4K", "count=1"])
         self.create_config(name)
 
     def finalize_test(self):


### PR DESCRIPTION
SSDs can store LED state between server restarts so load state for
each bdevs after they have all been created. Additionally, don't
require state receiver in bio_led_manage.

Includes some small bio_ut fixes to enable logging in test and run 
in a local environment with linux file written to /dev/vdb.

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
