### PR TITLE
DAOS-13988 control: MemberResult state should reflect error (#12719)

### DIFF
--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -1277,7 +1277,7 @@ func TestControl_SystemErase(t *testing.T) {
 					Results: []*sharedpb.RankResult{
 						{
 							Rank: member1.Rank.Uint32(), Action: "system erase",
-							State:   system.MemberStateStopped.String(),
+							State:   system.MemberStateErrored.String(),
 							Addr:    member1.Addr.String(),
 							Errored: true, Msg: "erase failed",
 						},
@@ -1309,7 +1309,7 @@ func TestControl_SystemErase(t *testing.T) {
 					Results: []*sharedpb.RankResult{
 						{
 							Rank: member1.Rank.Uint32(), Action: "system erase",
-							State:   system.MemberStateStopped.String(),
+							State:   system.MemberStateErrored.String(),
 							Addr:    member1.Addr.String(),
 							Errored: true, Msg: "erase failed",
 						},
@@ -1330,7 +1330,7 @@ func TestControl_SystemErase(t *testing.T) {
 						},
 						{
 							Rank: member5.Rank.Uint32(), Action: "system erase",
-							State:   system.MemberStateStopped.String(),
+							State:   system.MemberStateErrored.String(),
 							Addr:    member5.Addr.String(),
 							Errored: true, Msg: "erase failed",
 						},
@@ -1342,7 +1342,7 @@ func TestControl_SystemErase(t *testing.T) {
 						},
 						{
 							Rank: member7.Rank.Uint32(), Action: "system erase",
-							State:   system.MemberStateStopped.String(),
+							State:   system.MemberStateErrored.String(),
 							Addr:    member7.Addr.String(),
 							Errored: true, Msg: "erase failed",
 						},

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -102,9 +102,13 @@ func TestServer_CtlSvc_PrepShutdownRanks(t *testing.T) {
 			// no results as rank cannot be read from superblock
 			expResults: []*sharedpb.RankResult{},
 		},
-		"instances stopped": {
+		"instances stopped already": {
 			req:              &ctlpb.RanksReq{Ranks: "0-3"},
 			instancesStopped: true,
+			drpcResps: []proto.Message{
+				&mgmtpb.DaosResp{Status: -1},
+				&mgmtpb.DaosResp{Status: -1},
+			},
 			expResults: []*sharedpb.RankResult{
 				{Rank: 1, State: msStopped},
 				{Rank: 2, State: msStopped},

--- a/src/control/system/member.go
+++ b/src/control/system/member.go
@@ -137,15 +137,6 @@ func (ms MemberState) isTransitionIllegal(to MemberState) bool {
 		MemberStateJoined: {
 			MemberStateReady: true,
 		},
-		MemberStateStopping: {
-			MemberStateReady: true,
-		},
-		MemberStateExcluded: {
-			MemberStateReady:    true,
-			MemberStateJoined:   true,
-			MemberStateStopping: true,
-			MemberStateErrored:  true,
-		},
 		MemberStateErrored: {
 			MemberStateReady:    true,
 			MemberStateJoined:   true,
@@ -322,6 +313,10 @@ func NewMemberResult(rank ranklist.Rank, err error, state MemberState, action ..
 	if err != nil {
 		result.Errored = true
 		result.Msg = err.Error()
+		// Any error should result in either an unresponsive or errored state.
+		if state != MemberStateUnresponsive {
+			result.State = MemberStateErrored
+		}
 	}
 	if len(action) > 0 {
 		result.Action = action[0]

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -561,7 +561,7 @@ func TestSystem_Membership_UpdateMemberStates(t *testing.T) {
 		results    MemberResults
 		expMembers Members
 		expResults MemberResults
-		expErrMsg  string
+		expErr     error
 	}{
 		"update result address from member": {
 			members: Members{
@@ -641,9 +641,14 @@ func TestSystem_Membership_UpdateMemberStates(t *testing.T) {
 			results: MemberResults{
 				NewMemberResult(1, nil, MemberStateStopped),
 				NewMemberResult(2, errors.New("can't stop"), MemberStateErrored),
-				NewMemberResult(3, errors.New("can't stop"), MemberStateJoined),
+				func() *MemberResult {
+					mr := NewMemberResult(3, errors.New("can't stop"),
+						MemberStateJoined)
+					mr.State = MemberStateJoined
+					return mr
+				}(),
 			},
-			expErrMsg: "errored result for rank 3 has conflicting state 'Joined'",
+			expErr: errors.New("rank 3 has conflicting state 'Joined'"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -653,9 +658,8 @@ func TestSystem_Membership_UpdateMemberStates(t *testing.T) {
 			ms := populateMembership(t, log, tc.members...)
 
 			// members should be updated with result state
-			err := ms.UpdateMemberStates(tc.results, !tc.ignoreErrs)
-			ExpectError(t, err, tc.expErrMsg, name)
-			if err != nil {
+			CmpErr(t, tc.expErr, ms.UpdateMemberStates(tc.results, !tc.ignoreErrs))
+			if tc.expErr != nil {
 				return
 			}
 


### PR DESCRIPTION
Change addresses the issue where dmg system stop fails if some ranks
have already been previously stopped. This is due to a couple of bugs.
First a situation exists where the state conveyed in a MemberResult
doesn't match the fact that the result was a failure. The consumer of
the results checks this and raises an error in the case that they
don't match. Secondly the PrepShutdown flow which is triggered as
stage-one of dmg system stop returns a failed result for an already
stopped rank.

* Return successful results when calling PrepShutdown on stopped ranks
* Ensure errored MemberResults convey a matching error state

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
