### PR TITLE
DAOS-13981 test: Resolve version check issue in critical integration test

### DIFF
--- a/src/tests/ftest/deployment/critical_integration.py
+++ b/src/tests/ftest/deployment/critical_integration.py
@@ -4,6 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
+import json
+
 from ClusterShell.NodeSet import NodeSet
 
 from general_utils import run_command, DaosTestError, get_journalctl, journalctl_time
@@ -13,8 +15,6 @@ from exception_utils import CommandFailure
 # Imports need to be split or python fails to import
 from apricot import TestWithServers
 from apricot import TestWithoutServers
-
-import json
 
 
 # pylint: disable-next=fixme

--- a/src/tests/ftest/deployment/critical_integration.py
+++ b/src/tests/ftest/deployment/critical_integration.py
@@ -74,7 +74,7 @@ class CriticalIntegrationWithoutServers(TestWithoutServers):
                 if check_remote_root_access:
                     run_command(remote_root_access)
                 IorTestBase._execute_command(self, command_for_inter_node, hosts=[host])
-            except (DaosTestError, CommandFailure) as error:
+            except (DaosTestError, CommandFailure, KeyError) as error:
                 self.log.error("Error: %s", error)
                 failed_nodes.add(host)
         if failed_nodes:
@@ -82,14 +82,14 @@ class CriticalIntegrationWithoutServers(TestWithoutServers):
 
         for host in self.hostlist_clients:
             dmg_version_cmd = ("ssh -oNumberOfPasswordPrompts=0 {}"
-                               " 'dmg version -i' -j".format(host))
+                               " dmg version -i -j".format(host))
 
             try:
                 out = json.loads((run_command(dmg_version_cmd)).stdout)
                 if 'response' in out:
                     if 'version' in out['response']:
                         dmg_version_list.append(out['response']['version'])
-            except DaosTestError as error:
+            except (DaosTestError, KeyError) as error:
                 self.log.error("Error: %s", error)
                 failed_nodes.add(host)
         if failed_nodes:

--- a/src/tests/ftest/deployment/critical_integration.py
+++ b/src/tests/ftest/deployment/critical_integration.py
@@ -68,9 +68,7 @@ class CriticalIntegrationWithoutServers(TestWithoutServers):
                                       " 'echo hello'".format(str(self.hostlist_servers)))
             try:
                 out = json.loads((run_command(daos_server_cmd)).stdout)
-                if 'response' in out:
-                    if 'version' in out['response']:
-                        daos_server_version_list.append(out['response']['version'])
+                daos_server_version_list.append(out['response']['version'])
                 if check_remote_root_access:
                     run_command(remote_root_access)
                 IorTestBase._execute_command(self, command_for_inter_node, hosts=[host])
@@ -86,9 +84,7 @@ class CriticalIntegrationWithoutServers(TestWithoutServers):
 
             try:
                 out = json.loads((run_command(dmg_version_cmd)).stdout)
-                if 'response' in out:
-                    if 'version' in out['response']:
-                        dmg_version_list.append(out['response']['version'])
+                dmg_version_list.append(out['response']['version'])
             except (DaosTestError, KeyError) as error:
                 self.log.error("Error: %s", error)
                 failed_nodes.add(host)


### PR DESCRIPTION
Resolving version check issue reported after changes in daos_server and dmg version output.
To be more flexible in future, moved to json output

Test-tag: test_passwdlessssh_versioncheck

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
