### PR TITLE
DAOS-13968 vos: handle race between DTX prepare and DTX abort

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2137,11 +2137,9 @@ vos_dtx_post_handle(struct vos_container *cont,
 			D_WARN("Cannot remove DTX "DF_DTI" from active table: "
 			       DF_RC"\n", DP_DTI(&DAE_XID(daes[i])), DP_RC(rc));
 
+			D_ASSERT(daes[i]->dae_preparing == 0);
+
 			daes[i]->dae_prepared = 0;
-			/* The 'dae_preparing' is set by the its owner who is not current ULT.
-			 * Since the 'dae' may be detached from the DTX handle, let's reset it.
-			 */
-			daes[i]->dae_preparing = 0;
 			if (abort) {
 				daes[i]->dae_aborted = 1;
 				daes[i]->dae_aborting = 0;
@@ -2199,10 +2197,61 @@ out:
 }
 
 int
+vos_dtx_abort_internal(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool force)
+{
+	struct dtx_handle	*dth = dae->dae_dth;
+	struct umem_instance	*umm;
+	int			 rc;
+
+	umm = vos_cont2umm(cont);
+	rc = umem_tx_begin(umm, NULL);
+	if (rc != 0)
+		goto out;
+
+	if (dth != NULL) {
+		D_ASSERT(dth->dth_ent == dae || dth->dth_ent == NULL);
+		/* Not allow dtx_abort against solo DTX. */
+		D_ASSERT(!dth->dth_solo);
+		/* Set dth->dth_need_validation to notify the dth owner. */
+		dth->dth_need_validation = 1;
+	}
+
+	rc = dtx_rec_release(cont, dae, true);
+	if (rc == 0) {
+		dae->dae_aborting = 1;
+		rc = umem_tx_commit(umm);
+		D_ASSERTF(rc == 0, "local TX commit failure %d\n", rc);
+	} else {
+		rc = umem_tx_abort(umm, rc);
+	}
+
+	if (rc == 0 && dth != NULL) {
+		dae->dae_dth = NULL;
+		dth->dth_aborted = 1;
+		dth->dth_ent = NULL;
+		dth->dth_pinned = 0;
+		/*
+		 * dtx_act_ent_cleanup() will be triggered via vos_dtx_post_handle()
+		 * when remove the DTX entry from active DTX table.
+		 */
+	}
+
+	/*
+	 * NOTE: Do not reset dth_need_validation for "else" case,
+	 *	 because it may be also co-set (shared) by others.
+	 */
+
+out:
+	if (rc == 0 || force)
+		vos_dtx_post_handle(cont, &dae, NULL, 1, true, false);
+
+	return rc;
+}
+
+int
 vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 {
 	struct vos_container	*cont;
-	struct umem_instance	*umm;
 	struct vos_dtx_act_ent	*dae = NULL;
 	d_iov_t			 riov;
 	d_iov_t			 kiov;
@@ -2232,71 +2281,39 @@ vos_dtx_abort(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t epoch)
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
-	if (vos_dae_is_abort(dae))
+	if (vos_dae_is_abort(dae)) {
+		/*
+		 * The DTX has been aborted before, but failed to be removed from the active
+		 * table at that time, then need to be removed again via vos_dtx_post_handle.
+		 */
+		if (dae->dae_aborted)
+			vos_dtx_post_handle(cont, &dae, NULL, 1, true, false);
+
 		D_GOTO(out, rc = -DER_ALREADY);
+	}
 
 	if (epoch != DAOS_EPOCH_MAX && epoch != DAE_EPOCH(dae))
 		D_GOTO(out, rc = -DER_NONEXIST);
 
-	/* NOTE: Abort in-preparing DTX entry. It may because the non-leader is some slow,
-	 *	 as to leader got timeout and then abort the DTX by race. Under such case,
-	 *	 the owner of 'preparing' need to handle the race case.
-	 */
-	if (unlikely(dae->dae_preparing))
-		D_WARN("Trying to abort in preparing DTX "DF_DTI" by race\n", DP_DTI(dti));
-
-	umm = vos_cont2umm(cont);
-	rc = umem_tx_begin(umm, NULL);
-	if (rc == 0) {
-		struct dtx_handle	*dth = dae->dae_dth;
-
-		if (dth != NULL) {
-			D_ASSERT(dth->dth_ent == dae || dth->dth_ent == NULL);
-			/* Not allow dtx_abort against solo DTX. */
-			D_ASSERT(!dth->dth_solo);
-			/* Set dth->dth_need_validation to notify the dth owner. */
-			dth->dth_need_validation = 1;
-		}
-
-		rc = dtx_rec_release(cont, dae, true);
-		if (rc == 0) {
-			dae->dae_aborting = 1;
-			rc = umem_tx_commit(umm);
-			D_ASSERTF(rc == 0, "local TX commit failure %d\n", rc);
-		} else {
-			rc = umem_tx_abort(umm, rc);
-		}
-
-		if (rc == 0 && dth != NULL) {
-			dae->dae_dth = NULL;
-			dth->dth_aborted = 1;
-			dth->dth_ent = NULL;
-			dth->dth_pinned = 0;
-			/* dtx_act_ent_cleanup() will be triggered via vos_dtx_post_handle()
-			 * when remove the DTX entry from active DTX table.
-			 */
-		}
-
-		/* NOTE: do not reset dth_need_validation for "else" case,
-		 *	 because it may be also co-set (shared) by others.
+	if (unlikely(dae->dae_preparing)) {
+		/*
+		 * NOTE: Abort in-preparing DTX entry. It may because the non-leader is some slow,
+		 *	 as to leader got timeout and then abort the DTX by race. Under such case,
+		 *	 directly set dae->dae_aborting to notify the prepare sponsor that the DTX
+		 *	 should be aborted after its prepare done.
 		 */
+		D_WARN("Trying to abort in preparing DTX "DF_DTI" by race\n", DP_DTI(dti));
+		dae->dae_aborting = 1;
+	} else {
+		rc = vos_dtx_abort_internal(cont, dae, false);
 	}
 
 out:
-	if (rc != -DER_ALREADY && rc != -DER_NONEXIST)
-		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
-			 "Abort the DTX "DF_DTI": "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
-
-	/* Aborting: The DTX is being aborted. The local transaction for abort itself is yield.
-	 *
-	 * Aborted: The DTX has been aborted before, but failed to be removed from the active
-	 *	    table at that time, then need to be removed again via vos_dtx_post_handle.
-	 */
-	if (dae != NULL && (rc == 0 || (rc == -DER_ALREADY && dae->dae_aborted)))
-		vos_dtx_post_handle(cont, &dae, NULL, 1, true, false);
-
 	if (rc == -DER_ALREADY)
 		rc = 0;
+	else if (rc != -DER_NONEXIST)
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
+			 "Abort the DTX "DF_DTI": "DF_RC"\n", DP_DTI(dti), DP_RC(rc));
 
 	return rc;
 }
@@ -3038,6 +3055,17 @@ out:
 
 		dae = dth->dth_ent;
 		if (dae != NULL) {
+			if (unlikely(dae->dae_preparing && dae->dae_aborting)) {
+				dae->dae_preparing = 0;
+				rc = vos_dtx_abort_internal(cont, dae, true);
+				D_CDEBUG(rc != 0, DLOG_ERR, DB_IO,
+					 "Delay abort DTX "DF_DTI" (2): rc = %d\n",
+					 DP_DTI(&dth->dth_xid), rc);
+
+				/* Aborted by race, return -DER_INPROGRESS for client retry. */
+				return -DER_INPROGRESS;
+			}
+
 			dae->dae_preparing = 0;
 			if (dth->dth_solo)
 				vos_dtx_post_handle(cont, &dae, &dce, 1, false, rc != 0);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -735,6 +735,9 @@ vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id dtis[],
 			int count, daos_epoch_t epoch, bool rm_cos[],
 			struct vos_dtx_act_ent **daes, struct vos_dtx_cmt_ent **dces);
 
+int
+vos_dtx_abort_internal(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool force);
+
 void
 vos_dtx_post_handle(struct vos_container *cont,
 		    struct vos_dtx_act_ent **daes,


### PR DESCRIPTION
master-commit: 4c2d296e70c9a383ba4a98403a0afafebb534f8d

Test-nvme: auto_md_on_ssd

For md_on_ssd case, the DTX abort logic may hit some slow DTX entry that is in preparing but yield for local TX commit. Under such case, the abort logic should not directly abort the busy DTX to avoid race, instead, it can notify the preparing sponsor to delay to abort the DTX entry via set dae->dae_aborting.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
