### PR TITLE
DAOS-14101 control: Retry SMD manage request on DER_BUSY

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -1851,8 +1851,10 @@ bio_led_event_monitor(struct bio_xs_context *ctxt, uint64_t now)
 			rc = bio_led_manage(ctxt, NULL, d_bdev->bb_uuid,
 					    (unsigned int)CTL__LED_ACTION__RESET, &led_state, 0);
 			if (rc != 0)
-				D_ERROR("Reset LED identify state after timeout failed on device:"
-					DF_UUID", "DF_RC"\n", DP_UUID(d_bdev->bb_uuid), DP_RC(rc));
+				/* DER_NOSYS indicates that VMD-LED control is not enabled */
+				D_CDEBUG(rc == -DER_NOSYS, DB_MGMT, DLOG_ERR,
+					 "Reset LED on device:" DF_UUID " failed, " DF_RC "\n",
+					 DP_UUID(d_bdev->bb_uuid), DP_RC(rc));
 		}
 	}
 }

--- a/src/control/server/ctl_smd_rpc_test.go
+++ b/src/control/server/ctl_smd_rpc_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,6 +8,7 @@ package server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -709,6 +710,7 @@ func TestServer_CtlSvc_SmdManage(t *testing.T) {
 		DevState: devStateNormal,
 		LedState: ledStateIdentify,
 	}
+	devManageBusyResp := &ctlpb.DevManageResp{Status: int32(daos.Busy), Device: pbNormDev}
 
 	for name, tc := range map[string]struct {
 		setupAP        bool
@@ -1273,10 +1275,128 @@ func TestServer_CtlSvc_SmdManage(t *testing.T) {
 				},
 			},
 		},
+		"dev-replace; retry on busy": {
+			req: &ctlpb.SmdManageReq{
+				Op: &ctlpb.SmdManageReq_Replace{
+					Replace: &ctlpb.DevReplaceReq{
+						OldDevUuid: test.MockUUID(1),
+						NewDevUuid: test.MockUUID(2),
+					},
+				},
+			},
+			drpcResps: map[int][]*mockDrpcResponse{
+				0: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{pbNormDev},
+						},
+					},
+					{Message: devManageBusyResp},
+					{Message: devManageBusyResp},
+					{Message: &ctlpb.DevManageResp{Device: pbReplacedDev}},
+				},
+			},
+			expResp: &ctlpb.SmdManageResp{
+				Ranks: []*ctlpb.SmdManageResp_RankResp{
+					{
+						Results: []*ctlpb.SmdManageResp_Result{
+							{Device: pbReplacedDev},
+						},
+					},
+				},
+			},
+		},
+		"dev-replace; retry on busy; other error": {
+			req: &ctlpb.SmdManageReq{
+				Op: &ctlpb.SmdManageReq_Replace{
+					Replace: &ctlpb.DevReplaceReq{
+						OldDevUuid: test.MockUUID(1),
+						NewDevUuid: test.MockUUID(2),
+					},
+				},
+			},
+			drpcResps: map[int][]*mockDrpcResponse{
+				0: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{pbNormDev},
+						},
+					},
+					{Message: devManageBusyResp},
+					{
+						Message: &ctlpb.DevManageResp{
+							Status: int32(daos.TimedOut),
+							Device: pbNormDev,
+						},
+					},
+					{Message: devManageBusyResp},
+				},
+			},
+			expResp: &ctlpb.SmdManageResp{
+				Ranks: []*ctlpb.SmdManageResp_RankResp{
+					{
+						Results: []*ctlpb.SmdManageResp_Result{
+							{
+								Device: pbNormDev,
+								Status: int32(daos.TimedOut),
+							},
+						},
+					},
+				},
+			},
+		},
+		"dev-replace; retry on busy; keeps busy": {
+			req: &ctlpb.SmdManageReq{
+				Op: &ctlpb.SmdManageReq_Replace{
+					Replace: &ctlpb.DevReplaceReq{
+						OldDevUuid: test.MockUUID(1),
+						NewDevUuid: test.MockUUID(2),
+					},
+				},
+			},
+			drpcResps: map[int][]*mockDrpcResponse{
+				0: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{pbNormDev},
+						},
+					},
+					{Message: devManageBusyResp},
+					{Message: devManageBusyResp},
+					{Message: devManageBusyResp},
+					{Message: devManageBusyResp},
+					{Message: devManageBusyResp},
+				},
+			},
+			expResp: &ctlpb.SmdManageResp{
+				Ranks: []*ctlpb.SmdManageResp_RankResp{
+					{
+						Results: []*ctlpb.SmdManageResp_Result{
+							{
+								Device: pbNormDev,
+								Status: int32(daos.Busy),
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer test.ShowBufferOnFailure(t, buf)
+
+			origInterval := baseDevReplaceBackoff
+			origRetries := maxDevReplaceRetries
+			origFactor := maxDevReplaceBackoffFactor
+			baseDevReplaceBackoff = 50 * time.Millisecond
+			maxDevReplaceRetries = 5
+			maxDevReplaceBackoffFactor = 1
+			defer func() {
+				maxDevReplaceBackoffFactor = origFactor
+				maxDevReplaceRetries = origRetries
+				baseDevReplaceBackoff = origInterval
+			}()
 
 			engineCount := len(tc.drpcResps)
 			if engineCount == 0 {


### PR DESCRIPTION
When calling dmg storage set nvme-faulty, device state transitions can
take multiple seconds to propagate in engine-internal state machines.
As a result, a subsequent call to dmg storage replace nvme call issued
immediately after will return -DER_BUSY if state transitions are not
complete. For convenience, this change allows the replace call to
retry the drpc call internally if -DER_BUSY is received. The retry
mechanism employed uses exponential backoff and a fixed retry limit.

Also fix two VMD-LED issues:
- Cancel identify timer when setting LED state.
- Set LED to OFF state when device is physically replaced.

Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
