### PR TITLE
DAOS-14118 pool: Fix a race on pool upgrade

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -248,7 +248,8 @@ void ds_pool_iv_ns_update(struct ds_pool *pool, unsigned int master_rank, uint64
 
 int ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		       uint32_t map_ver);
-int ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop);
+int
+    ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop, bool sync);
 int ds_pool_iv_prop_fetch(struct ds_pool *pool, daos_prop_t *prop);
 int ds_pool_iv_svc_fetch(struct ds_pool *pool, d_rank_list_t **svc_p);
 

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1517,7 +1517,7 @@ out_eventual:
 }
 
 int
-ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop)
+ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop, bool sync)
 {
 	struct pool_iv_entry	*iv_entry = NULL;
 	uint32_t		 iv_entry_size;
@@ -1543,9 +1543,9 @@ ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop)
 
 	pool_iv_prop_l2g(prop, &iv_entry->piv_prop);
 
-	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_PROP, pool->sp_uuid,
-			    iv_entry, iv_entry_size, CRT_IV_SHORTCUT_NONE,
-			    CRT_IV_SYNC_LAZY, true);
+	rc =
+	    pool_iv_update(pool->sp_iv_ns, IV_POOL_PROP, pool->sp_uuid, iv_entry, iv_entry_size,
+			   CRT_IV_SHORTCUT_NONE, sync ? CRT_IV_SYNC_EAGER : CRT_IV_SYNC_LAZY, true);
 	if (rc != 0)
 		D_ERROR("pool_iv_update failed "DF_RC"\n", DP_RC(rc));
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1697,7 +1697,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult);
 	svc_scheduled = true;
 
-	rc = ds_pool_iv_prop_update(svc->ps_pool, prop);
+	rc = ds_pool_iv_prop_update(svc->ps_pool, prop, false);
 	if (rc) {
 		D_ERROR("ds_pool_iv_prop_update failed: " DF_RC "\n", DP_RC(rc));
 		D_GOTO(out, rc);
@@ -4459,7 +4459,7 @@ out_lock:
 	 *	 caused by the out of order IV sync.
 	 */
 	if (!rc && prop != NULL) {
-		rc = ds_pool_iv_prop_update(svc->ps_pool, prop);
+		rc = ds_pool_iv_prop_update(svc->ps_pool, prop, false);
 		if (rc)
 			D_ERROR(DF_UUID": failed to update prop IV for pool, "
 				"%d.\n", DP_UUID(in->psi_op.pi_uuid), rc);
@@ -4760,7 +4760,7 @@ pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
 		rc = pool_prop_read(tx, svc, DAOS_PO_QUERY_PROP_ALL, &prop);
 		if (rc)
 			D_GOTO(out_free, rc);
-		rc = ds_pool_iv_prop_update(svc->ps_pool, prop);
+		rc = ds_pool_iv_prop_update(svc->ps_pool, prop, true);
 		daos_prop_free(prop);
 	}
 
@@ -4851,7 +4851,7 @@ __ds_pool_mark_upgrade_completed(uuid_t pool_uuid, struct pool_svc *svc, int rc)
 	rc1 = pool_prop_read(&tx, svc, DAOS_PO_QUERY_PROP_ALL, &prop);
 	if (rc1)
 		D_GOTO(out_tx, rc1);
-	rc1 = ds_pool_iv_prop_update(svc->ps_pool, prop);
+	rc1 = ds_pool_iv_prop_update(svc->ps_pool, prop, false);
 	daos_prop_free(prop);
 	if (rc1)
 		D_GOTO(out_tx, rc1);


### PR DESCRIPTION
Subsequent calls to update pool properties can race, causing calls to vos_pool_upgrade with inconsistent values.

For example, in another PR, it was causing the DF to be updgraded and subsequently downgraded which caused an assertion.

Don't sync on pre-update check.

Signed-of-by Di Wang <di.wang@intel.com>

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
