### PR TITLE
DAOS-13493 rebuild: various fixes for upgrade

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -4556,6 +4556,10 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		}
 	}
 
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_OBJ_VERSION);
+	D_ASSERT(entry != NULL);
+	entry->dpe_val = DS_POOL_OBJ_VERSION;
+	entry->dpe_flags &= ~DAOS_PROP_ENTRY_NOT_SET;
 	obj_ver = DS_POOL_OBJ_VERSION;
 	d_iov_set(&value, &obj_ver, sizeof(obj_ver));
 	rc = rdb_tx_update(ap->tx, &cont->c_prop,

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -344,6 +344,18 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 			D_ASSERT(spare_tgt != NULL);
 			D_DEBUG(DB_PL, "Trying new target: "DF_TARGET"\n",
 				DP_TARGET(spare_tgt));
+			if (layout_ver > 0) {
+				/*
+				 * After 2.4 (layout_ver > 0), it will always assign each shard
+				 * to one target, so it might put multiple shards in the same
+				 * target, if there are not enough targets.
+				 * Though before 2.4 (layout_ver == 0), it will set the shard as -1,
+				 * if there are no spare targets.
+				 */
+				D_ASSERT(spare_tgt != NULL);
+				D_DEBUG(DB_PL, "Trying new target: "DF_TARGET"\n",
+					DP_TARGET(spare_tgt));
+			}
 		}
 
 		rc = determine_valid_spares(spare_tgt, md, spare_avail, remap_list,

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -770,9 +770,9 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 			ent->ie_vis_flags & VOS_VIS_FLAG_COVERED ? "no" : "yes");
 
 		/* Ignore the shard if it is not in the same group of failure shard */
-		if (oid.id_shard / grp_size != shards[i] / grp_size) {
-			D_DEBUG(DB_REBUILD, "stale object "DF_UOID" shards %u grp_size %u\n",
-				DP_UOID(oid), shards[i], grp_size);
+		if ((int)tgts[i] == -1 || oid.id_shard / grp_size != shards[i] / grp_size) {
+			D_DEBUG(DB_REBUILD, "i %d stale object "DF_UOID" shards %u grp_size %u tgt %d\n",
+				i, DP_UOID(oid), shards[i], grp_size, (int)tgts[i]);
 			continue;
 		}
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1291,7 +1291,6 @@ retry_rebuild_task(struct rebuild_task *task, int error, daos_rebuild_opc_t *opc
 {
 	/* Only be called if rebuild task failed */
 
-	D_ASSERT(error != 0);
 	/* retry with network error, since the pool map will be changed accordingly, so
 	 * rebuild job can be fixed by the new pool map anyway.
 	 */
@@ -1326,16 +1325,38 @@ retry_rebuild_task(struct rebuild_task *task, int error, daos_rebuild_opc_t *opc
 
 static int
 rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
-			       struct rebuild_global_pool_tracker *rgt)
+			       struct rebuild_global_pool_tracker *rgt, int ret)
 {
 	int rc = 0;
 	int rc1;
 
+	/* The original job is not being started correctly, let's give another chance */
 	if (rgt == NULL) {
+		/* ret = 0, it do not need any rebuild, only update target status */
+		if (ret == 0) {
+			D_INFO(DF_UUID"opc %u/%u only update tgt status: %d\n",
+			       DP_UUID(task->dst_pool_uuid), task->dst_rebuild_op,
+			       task->dst_map_ver, ret);
+			return 0;
+		}
+		D_INFO(DF_UUID"retry opc %u/%u: %d\n", DP_UUID(task->dst_pool_uuid),
+		       task->dst_rebuild_op, task->dst_map_ver, ret);
 		rc = ds_rebuild_schedule(pool, task->dst_map_ver, task->dst_reclaim_eph,
 					 task->dst_new_layout_version,
 					 &task->dst_tgts, task->dst_rebuild_op, 5);
 		return rc;
+	}
+
+	/* Do not need reschedule for upgrade, let's mark the upgrade as complete */
+	if (task->dst_rebuild_op == RB_OP_UPGRADE) {
+		rc1 = ret;
+
+		if (rgt != NULL && rgt->rgt_status.rs_errno != 0)
+			rc1 = rgt->rgt_status.rs_errno;
+
+		rc = ds_pool_mark_upgrade_completed(pool->sp_uuid, rc1);
+
+		D_INFO("Mark upgraded complete "DF_UUID": %d\n", DP_UUID(task->dst_pool_uuid), rc1);
 	}
 
 	if (!is_rebuild_global_done(rgt) || rgt->rgt_status.rs_errno != 0) {
@@ -1542,29 +1563,22 @@ done:
 		}
 	} else if (rgt->rgt_status.rs_errno == 0) {
 update_tgts:
-		if (task->dst_rebuild_op == RB_OP_UPGRADE) {
-			rc = ds_pool_mark_upgrade_completed(pool->sp_uuid,
-							    rgt->rgt_status.rs_errno);
-			D_INFO("Mark upgraded complete "DF_UUID": %d\n",
-			       DP_UUID(task->dst_pool_uuid), rc);
-		} else {
-			if (task->dst_tgts.pti_number <= 0)
-				goto iv_stop;
+		if (task->dst_tgts.pti_number <= 0 || task->dst_rebuild_op == RB_OP_UPGRADE)
+			goto iv_stop;
 
-			if (task->dst_rebuild_op == RB_OP_EXCLUDE ||
-			    task->dst_rebuild_op == RB_OP_DRAIN) {
-				rc = ds_pool_tgt_exclude_out(pool->sp_uuid, &task->dst_tgts);
-				D_INFO("mark failed target %d of "DF_UUID " as DOWNOUT: "DF_RC"\n",
-				       task->dst_tgts.pti_ids[0].pti_id,
-				       DP_UUID(task->dst_pool_uuid), DP_RC(rc));
-			} else if (task->dst_rebuild_op == RB_OP_REINT ||
-				   task->dst_rebuild_op == RB_OP_EXTEND) {
-				rc = ds_pool_tgt_add_in(pool->sp_uuid, &task->dst_tgts);
-				D_INFO("mark added target %d of "DF_UUID " UPIN: "DF_RC"\n",
-				       task->dst_tgts.pti_ids[0].pti_id,
-				       DP_UUID(task->dst_pool_uuid), DP_RC(rc));
-			}
-		} /* No change needed for RB_OP_RECLAIM */
+		if (task->dst_rebuild_op == RB_OP_EXCLUDE ||
+		    task->dst_rebuild_op == RB_OP_DRAIN) {
+			rc = ds_pool_tgt_exclude_out(pool->sp_uuid, &task->dst_tgts);
+			D_INFO("mark failed target %d of "DF_UUID " as DOWNOUT: "DF_RC"\n",
+			       task->dst_tgts.pti_ids[0].pti_id,
+			       DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+		} else if (task->dst_rebuild_op == RB_OP_REINT ||
+			   task->dst_rebuild_op == RB_OP_EXTEND) {
+			rc = ds_pool_tgt_add_in(pool->sp_uuid, &task->dst_tgts);
+			D_INFO("mark added target %d of "DF_UUID " UPIN: "DF_RC"\n",
+			       task->dst_tgts.pti_ids[0].pti_id,
+			       DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+		}
 	}
 iv_stop:
 	/* NB: even if there are some failures, the leader should
@@ -1586,8 +1600,7 @@ iv_stop:
 	}
 
 try_reschedule:
-	if (rgt != NULL || rc != 0)
-		rebuild_task_complete_schedule(task, pool, rgt);
+	rebuild_task_complete_schedule(task, pool, rgt, rc);
 output:
 	rc = rebuild_notify_ras_end(&task->dst_pool_uuid, task->dst_map_ver,
 				    RB_OP_STR(task->dst_rebuild_op),
@@ -1863,6 +1876,7 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 
 	new_task->dst_schedule_time = cur_ts + delay_sec;
 	new_task->dst_map_ver = map_ver;
+	new_task->dst_reclaim_ver = map_ver;
 	new_task->dst_rebuild_op = rebuild_op;
 	new_task->dst_reclaim_eph = reclaim_eph;
 	new_task->dst_new_layout_version = layout_version;


### PR DESCRIPTION
Only check spare target if layout version > 0, since before 2.4, it will not assign the shard if there are no spare targets.

fix spare_tgt check.

Skip invalid shard and target for upgrade migration.

set reclaim ver for upgrade.

remove invalid assertion for rebuild retry.

Mark upgrade complete in any case.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
