### PR TITLE
DAOS-13625 dfuse: Remove dfuse_projection_info entirely.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -66,9 +66,6 @@ struct dfuse_info {
 	ATOMIC uint64_t      di_container_count;
 };
 
-/* legacy, allow the old name for easier migration */
-#define dfuse_projection_info dfuse_info
-
 struct dfuse_eq {
 	struct dfuse_info  *de_handle;
 
@@ -281,7 +278,7 @@ struct dfuse_readdir_hdl {
  * a reference only.
  */
 void
-dfuse_dre_drop(struct dfuse_projection_info *fs_handle, struct dfuse_obj_hdl *oh);
+dfuse_dre_drop(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh);
 
 /*
  * Set required initial state in dfuse_obj_hdl.

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -60,7 +60,7 @@ dfuse_show_flags(void *handle, unsigned int in)
 static void
 dfuse_fuse_init(void *arg, struct fuse_conn_info *conn)
 {
-	struct dfuse_projection_info *fs_handle = arg;
+	struct dfuse_info *fs_handle = arg;
 
 	DFUSE_TRA_INFO(fs_handle, "Fuse configuration");
 

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -98,16 +98,16 @@ _dfuse_mode_update(fuse_req_t req, struct dfuse_inode_entry *parent, mode_t *_mo
 }
 
 void
-dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
-		const char *name, mode_t mode, struct fuse_file_info *fi)
+dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent, const char *name, mode_t mode,
+		struct fuse_file_info *fi)
 {
-	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
-	const struct fuse_ctx		*ctx = fuse_req_ctx(req);
-	struct dfuse_inode_entry	*ie = NULL;
-	struct dfuse_obj_hdl		*oh = NULL;
-	struct fuse_file_info		fi_out = {0};
-	struct dfuse_cont		*dfs = parent->ie_dfs;
-	int				rc;
+	struct dfuse_info        *dfuse_info = fuse_req_userdata(req);
+	const struct fuse_ctx    *ctx        = fuse_req_ctx(req);
+	struct dfuse_inode_entry *ie         = NULL;
+	struct dfuse_obj_hdl     *oh         = NULL;
+	struct fuse_file_info     fi_out     = {0};
+	struct dfuse_cont        *dfs        = parent->ie_dfs;
+	int                       rc;
 
 	DFUSE_TRA_DEBUG(parent, "Parent:%#lx '%s'", parent->ie_stat.st_ino, name);
 
@@ -129,7 +129,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	/* Upgrade fd permissions from O_WRONLY to O_RDWR if wb caching is
 	 * enabled so the kernel can do read-modify-write
 	 */
-	if (parent->ie_dfs->dfc_data_timeout != 0 && fs_handle->di_wb_cache &&
+	if (parent->ie_dfs->dfc_data_timeout != 0 && dfuse_info->di_wb_cache &&
 	    (fi->flags & O_ACCMODE) == O_WRONLY) {
 		DFUSE_TRA_DEBUG(parent, "Upgrading fd to O_RDRW");
 		fi->flags &= ~O_ACCMODE;
@@ -156,12 +156,12 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	ie->ie_stat.st_uid = ctx->uid;
 	ie->ie_stat.st_gid = ctx->gid;
 
-	dfuse_ie_init(fs_handle, ie);
-	dfuse_open_handle_init(fs_handle, oh, ie);
+	dfuse_ie_init(dfuse_info, ie);
+	dfuse_open_handle_init(dfuse_info, oh, ie);
 
 	oh->doh_linear_read = false;
 
-	if (!fs_handle->di_multi_user) {
+	if (!dfuse_info->di_multi_user) {
 		rc = _dfuse_mode_update(req, parent, &mode);
 		if (rc != 0)
 			D_GOTO(err, rc);
@@ -174,7 +174,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	if (rc)
 		D_GOTO(err, rc);
 
-	dfuse_cache_evict_dir(fs_handle, parent);
+	dfuse_cache_evict_dir(dfuse_info, parent);
 
 	/** duplicate the file handle for the fuse handle */
 	rc = dfs_dup(dfs->dfs_ns, oh->doh_obj, O_RDWR, &ie->ie_obj);
@@ -213,13 +213,13 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	atomic_fetch_add_relaxed(&ie->ie_open_count, 1);
 
 	/* Return the new inode data, and keep the parent ref */
-	dfuse_reply_entry(fs_handle, ie, &fi_out, true, req);
+	dfuse_reply_entry(dfuse_info, ie, &fi_out, true, req);
 
 	return;
 release:
 	dfs_release(oh->doh_obj);
 err:
 	DFUSE_REPLY_ERR_RAW(parent, req, rc);
-	dfuse_oh_free(fs_handle, oh);
-	dfuse_ie_free(fs_handle, ie);
+	dfuse_oh_free(dfuse_info, oh);
+	dfuse_ie_free(dfuse_info, ie);
 }

--- a/src/client/dfuse/ops/ioctl.c
+++ b/src/client/dfuse/ops/ioctl.c
@@ -27,9 +27,9 @@ handle_user_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 static void
 handle_il_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 {
-	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
-	struct dfuse_il_reply         il_reply  = {0};
-	int                           rc;
+	struct dfuse_info    *dfuse_info = fuse_req_userdata(req);
+	struct dfuse_il_reply il_reply   = {0};
+	int                   rc;
 
 	rc = dfs_obj2id(oh->doh_ie->ie_obj, &il_reply.fir_oid);
 	if (rc)
@@ -44,7 +44,7 @@ handle_il_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 		il_reply.fir_flags |= DFUSE_IOCTL_FLAGS_MCACHE;
 
 	if (oh->doh_writeable) {
-		rc = fuse_lowlevel_notify_inval_inode(fs_handle->di_session,
+		rc = fuse_lowlevel_notify_inval_inode(dfuse_info->di_session,
 						      oh->doh_ie->ie_stat.st_ino, 0, 0);
 
 		if (rc == 0) {

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -12,13 +12,10 @@
 char *duns_xattr_name = DUNS_XATTR_NAME;
 
 void
-dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
-		  struct dfuse_inode_entry *ie,
-		  struct fuse_file_info *fi_out,
-		  bool is_new,
-		  fuse_req_t req)
+dfuse_reply_entry(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie,
+		  struct fuse_file_info *fi_out, bool is_new, fuse_req_t req)
 {
-	struct fuse_entry_param	entry = {0};
+	struct fuse_entry_param  entry = {0};
 	d_list_t		*rlink;
 	ino_t			wipe_parent = 0;
 	char			wipe_name[NAME_MAX + 1];
@@ -35,10 +32,8 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 	DFUSE_TRA_DEBUG(ie, "Inserting inode %#lx mode 0%o",
 			entry.ino, ie->ie_stat.st_mode);
 
-	rlink = d_hash_rec_find_insert(&fs_handle->dpi_iet,
-				       &ie->ie_stat.st_ino,
-				       sizeof(ie->ie_stat.st_ino),
-				       &ie->ie_htl);
+	rlink = d_hash_rec_find_insert(&dfuse_info->dpi_iet, &ie->ie_stat.st_ino,
+				       sizeof(ie->ie_stat.st_ino), &ie->ie_htl);
 
 	if (rlink != &ie->ie_htl) {
 		struct dfuse_inode_entry *inode;
@@ -118,7 +113,7 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 			strncpy(inode->ie_name, ie->ie_name, NAME_MAX + 1);
 		}
 		atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
-		dfuse_ie_close(fs_handle, ie);
+		dfuse_ie_close(dfuse_info, ie);
 		ie = inode;
 	}
 
@@ -154,14 +149,14 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 	if (wipe_parent == 0)
 		return;
 
-	rc = fuse_lowlevel_notify_inval_entry(fs_handle->di_session, wipe_parent, wipe_name,
+	rc = fuse_lowlevel_notify_inval_entry(dfuse_info->di_session, wipe_parent, wipe_name,
 					      strnlen(wipe_name, NAME_MAX));
 	if (rc && rc != -ENOENT)
 		DFUSE_TRA_ERROR(ie, "inval_entry() returned: %d (%s)", rc, strerror(-rc));
 
 	return;
 out_err:
-	DFUSE_REPLY_ERR_RAW(fs_handle, req, rc);
+	DFUSE_REPLY_ERR_RAW(ie, req, rc);
 	dfs_release(ie->ie_obj);
 }
 
@@ -175,8 +170,8 @@ out_err:
  *
  */
 int
-check_for_uns_ep(struct dfuse_projection_info *fs_handle,
-		 struct dfuse_inode_entry *ie, char *attr, daos_size_t len)
+check_for_uns_ep(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie, char *attr,
+		 daos_size_t len)
 {
 	int			rc;
 	struct duns_attr_t	dattr = {};
@@ -194,16 +189,16 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 	 * otherwise allocate a new one.
 	 */
 
-	rc = dfuse_pool_get_handle(fs_handle, dattr.da_puuid, &dfp);
+	rc = dfuse_pool_get_handle(dfuse_info, dattr.da_puuid, &dfp);
 	if (rc != 0)
 		D_GOTO(out_err, rc);
 
-	rc = dfuse_cont_open(fs_handle, dfp, &dattr.da_cuuid, &dfs);
+	rc = dfuse_cont_open(dfuse_info, dfp, &dattr.da_cuuid, &dfs);
 	if (rc != 0)
 		D_GOTO(out_dfp, rc);
 
 	/* The inode has a reference to the dfs, so keep that. */
-	d_hash_rec_decref(&fs_handle->di_pool_table, &dfp->dfp_entry);
+	d_hash_rec_decref(&dfuse_info->di_pool_table, &dfp->dfp_entry);
 
 	rc = dfs_release(ie->ie_obj);
 	if (rc) {
@@ -231,7 +226,7 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 out_dfs:
 	d_hash_rec_decref(&dfp->dfp_cont_table, &dfs->dfs_entry);
 out_dfp:
-	d_hash_rec_decref(&fs_handle->di_pool_table, &dfp->dfp_entry);
+	d_hash_rec_decref(&dfuse_info->di_pool_table, &dfp->dfp_entry);
 out_err:
 	duns_destroy_attr(&dattr);
 
@@ -242,12 +237,12 @@ void
 dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 		const char *name)
 {
-	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
-	struct dfuse_inode_entry	*ie;
-	int				rc;
-	char				out[DUNS_MAX_XATTR_LEN];
-	char				*outp = &out[0];
-	daos_size_t			attr_len = DUNS_MAX_XATTR_LEN;
+	struct dfuse_info        *dfuse_info = fuse_req_userdata(req);
+	struct dfuse_inode_entry *ie;
+	int                       rc;
+	char                      out[DUNS_MAX_XATTR_LEN];
+	char                     *outp     = &out[0];
+	daos_size_t               attr_len = DUNS_MAX_XATTR_LEN;
 
 	DFUSE_TRA_DEBUG(parent,
 			"Parent:%#lx '%s'", parent->ie_stat.st_ino, name);
@@ -258,7 +253,7 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	DFUSE_TRA_UP(ie, parent, "inode");
 
-	dfuse_ie_init(fs_handle, ie);
+	dfuse_ie_init(dfuse_info, ie);
 
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_dfs = parent->ie_dfs;
@@ -283,19 +278,19 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 			    &ie->ie_stat.st_ino);
 
 	if (S_ISDIR(ie->ie_stat.st_mode) && attr_len) {
-		rc = check_for_uns_ep(fs_handle, ie, out, attr_len);
+		rc = check_for_uns_ep(dfuse_info, ie, out, attr_len);
 		DFUSE_TRA_DEBUG(ie, "check_for_uns_ep() returned %d", rc);
 		if (rc != 0)
 			D_GOTO(out_release, rc);
 	}
 
-	dfuse_reply_entry(fs_handle, ie, NULL, false, req);
+	dfuse_reply_entry(dfuse_info, ie, NULL, false, req);
 	return;
 
 out_release:
 	dfs_release(ie->ie_obj);
 out_free:
-	dfuse_ie_free(fs_handle, ie);
+	dfuse_ie_free(dfuse_info, ie);
 out:
 	if (rc == ENOENT && parent->ie_dfs->dfc_ndentry_timeout > 0) {
 		struct fuse_entry_param entry = {};

--- a/src/client/dfuse/ops/mknod.c
+++ b/src/client/dfuse/ops/mknod.c
@@ -10,7 +10,7 @@
 void
 dfuse_cb_mknod(fuse_req_t req, struct dfuse_inode_entry *parent, const char *name, mode_t mode)
 {
-	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
+	struct dfuse_info            *dfuse_info = fuse_req_userdata(req);
 	const struct fuse_ctx        *ctx       = fuse_req_ctx(req);
 	struct dfuse_inode_entry     *ie;
 	int                           rc;
@@ -29,7 +29,7 @@ dfuse_cb_mknod(fuse_req_t req, struct dfuse_inode_entry *parent, const char *nam
 	if (rc != 0)
 		D_GOTO(err, rc);
 
-	dfuse_ie_init(fs_handle, ie);
+	dfuse_ie_init(dfuse_info, ie);
 
 	ie->ie_stat.st_uid = ctx->uid;
 	ie->ie_stat.st_gid = ctx->gid;
@@ -51,10 +51,10 @@ dfuse_cb_mknod(fuse_req_t req, struct dfuse_inode_entry *parent, const char *nam
 	dfuse_compute_inode(ie->ie_dfs, &ie->ie_oid, &ie->ie_stat.st_ino);
 
 	/* Return the new inode data, and keep the parent ref */
-	dfuse_reply_entry(fs_handle, ie, NULL, true, req);
+	dfuse_reply_entry(dfuse_info, ie, NULL, true, req);
 
 	return;
 err:
 	DFUSE_REPLY_ERR_RAW(parent, req, rc);
-	dfuse_ie_free(fs_handle, ie);
+	dfuse_ie_free(dfuse_info, ie);
 }

--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -54,13 +54,13 @@ release:
 void
 dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position, struct fuse_file_info *fi)
 {
-	struct dfuse_obj_hdl         *oh        = (struct dfuse_obj_hdl *)fi->fh;
-	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
-	bool                          mock_read = false;
-	struct dfuse_eq              *eqt;
-	int                           rc;
-	struct dfuse_event           *ev;
-	uint64_t                      eqt_idx;
+	struct dfuse_obj_hdl *oh         = (struct dfuse_obj_hdl *)fi->fh;
+	struct dfuse_info    *dfuse_info = fuse_req_userdata(req);
+	bool                  mock_read  = false;
+	struct dfuse_eq      *eqt;
+	int                   rc;
+	struct dfuse_event   *ev;
+	uint64_t              eqt_idx;
 
 	if (oh->doh_linear_read_eof && position == oh->doh_linear_read_pos) {
 		DFUSE_TRA_DEBUG(oh, "Returning EOF early without round trip %#zx", position);
@@ -70,9 +70,9 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position, struct
 		return;
 	}
 
-	eqt_idx = atomic_fetch_add_relaxed(&fs_handle->di_eqt_idx, 1);
+	eqt_idx = atomic_fetch_add_relaxed(&dfuse_info->di_eqt_idx, 1);
 
-	eqt = &fs_handle->di_eqt[eqt_idx % fs_handle->di_eq_count];
+	eqt = &dfuse_info->di_eqt[eqt_idx % dfuse_info->di_eq_count];
 
 	ev = d_slab_acquire(eqt->de_read_slab);
 	if (ev == NULL)

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -31,19 +31,19 @@ struct iterate_data {
  * the unlinked file, and a inval() call here does not change that.
  */
 void
-dfuse_cache_evict_dir(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *ie)
+dfuse_cache_evict_dir(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 {
 	uint32_t open_count = atomic_load_relaxed(&ie->ie_open_count);
 
 	if (open_count != 0)
 		DFUSE_TRA_DEBUG(ie, "Directory change whilst open");
 
-	D_SPIN_LOCK(&fs_handle->di_lock);
+	D_SPIN_LOCK(&dfuse_info->di_lock);
 	if (ie->ie_rd_hdl) {
 		DFUSE_TRA_DEBUG(ie, "Setting shared readdir handle as invalid");
 		ie->ie_rd_hdl->drh_valid = false;
 	}
-	D_SPIN_UNLOCK(&fs_handle->di_lock);
+	D_SPIN_UNLOCK(&dfuse_info->di_lock);
 
 	dfuse_cache_evict(ie);
 }
@@ -125,7 +125,7 @@ _handle_init(struct dfuse_cont *dfc)
 
 /* Drop a ref on a readdir handle and release if required. Handle will no longer be usable */
 void
-dfuse_dre_drop(struct dfuse_projection_info *fs_handle, struct dfuse_obj_hdl *oh)
+dfuse_dre_drop(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh)
 {
 	struct dfuse_readdir_hdl *hdl;
 	struct dfuse_readdir_c   *drc, *next;
@@ -143,7 +143,7 @@ dfuse_dre_drop(struct dfuse_projection_info *fs_handle, struct dfuse_obj_hdl *oh
 	oh->doh_rd_nextc = NULL;
 
 	/* Lock is to protect oh->doh_ie->ie_rd_hdl between readdir/closedir calls */
-	D_SPIN_LOCK(&fs_handle->di_lock);
+	D_SPIN_LOCK(&dfuse_info->di_lock);
 
 	oldref = atomic_fetch_sub_relaxed(&hdl->drh_ref, 1);
 	if (oldref != 1) {
@@ -163,18 +163,17 @@ dfuse_dre_drop(struct dfuse_projection_info *fs_handle, struct dfuse_obj_hdl *oh
 			 drc->drc_next_offset == READDIR_EOD);
 		expected_offset = drc->drc_next_offset;
 		if (drc->drc_rlink)
-			d_hash_rec_decref(&fs_handle->dpi_iet, drc->drc_rlink);
+			d_hash_rec_decref(&dfuse_info->dpi_iet, drc->drc_rlink);
 		D_FREE(drc);
 	}
 	D_FREE(hdl);
 unlock:
-	D_SPIN_UNLOCK(&fs_handle->di_lock);
+	D_SPIN_UNLOCK(&dfuse_info->di_lock);
 }
 
 static int
-create_entry(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *parent,
-	     struct stat *stbuf, dfs_obj_t *obj, char *name, char *attr, daos_size_t attr_len,
-	     d_list_t **rlinkp)
+create_entry(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *parent, struct stat *stbuf,
+	     dfs_obj_t *obj, char *name, char *attr, daos_size_t attr_len, d_list_t **rlinkp)
 {
 	struct dfuse_inode_entry *ie;
 	d_list_t                 *rlink;
@@ -188,7 +187,7 @@ create_entry(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *
 
 	DFUSE_TRA_UP(ie, parent, "inode");
 
-	dfuse_ie_init(fs_handle, ie);
+	dfuse_ie_init(dfuse_info, ie);
 	ie->ie_obj  = obj;
 	ie->ie_stat = *stbuf;
 
@@ -199,7 +198,7 @@ create_entry(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *
 
 	if (S_ISDIR(ie->ie_stat.st_mode) && attr_len) {
 		/* Check for UNS entry point, this will allocate a new inode number if successful */
-		rc = check_for_uns_ep(fs_handle, ie, attr, attr_len);
+		rc = check_for_uns_ep(dfuse_info, ie, attr, attr_len);
 		if (rc != 0) {
 			DFUSE_TRA_WARNING(ie, "check_for_uns_ep() returned %d, ignoring", rc);
 			rc = 0;
@@ -212,7 +211,7 @@ create_entry(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *
 
 	DFUSE_TRA_DEBUG(ie, "Inserting inode %#lx mode 0%o", stbuf->st_ino, ie->ie_stat.st_mode);
 
-	rlink = d_hash_rec_find_insert(&fs_handle->dpi_iet, &ie->ie_stat.st_ino,
+	rlink = d_hash_rec_find_insert(&dfuse_info->dpi_iet, &ie->ie_stat.st_ino,
 				       sizeof(ie->ie_stat.st_ino), &ie->ie_htl);
 
 	if (rlink != &ie->ie_htl) {
@@ -244,13 +243,13 @@ create_entry(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *
 		strncpy(inode->ie_name, ie->ie_name, NAME_MAX + 1);
 
 		atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
-		dfuse_ie_close(fs_handle, ie);
+		dfuse_ie_close(dfuse_info, ie);
 		ie = inode;
 	}
 
 	*rlinkp = rlink;
 	if (rc != 0)
-		dfuse_ie_close(fs_handle, ie);
+		dfuse_ie_close(dfuse_info, ie);
 out:
 	return rc;
 }
@@ -290,12 +289,12 @@ dfuse_readdir_reset(struct dfuse_readdir_hdl *hdl)
  * protect this section with a spinlock.
  */
 static int
-ensure_rd_handle(struct dfuse_projection_info *fs_handle, struct dfuse_obj_hdl *oh)
+ensure_rd_handle(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh)
 {
 	if (oh->doh_rd != NULL)
 		return 0;
 
-	D_SPIN_LOCK(&fs_handle->di_lock);
+	D_SPIN_LOCK(&dfuse_info->di_lock);
 
 	if (oh->doh_ie->ie_rd_hdl && oh->doh_ie->ie_rd_hdl->drh_valid) {
 		oh->doh_rd = oh->doh_ie->ie_rd_hdl;
@@ -304,7 +303,7 @@ ensure_rd_handle(struct dfuse_projection_info *fs_handle, struct dfuse_obj_hdl *
 	} else {
 		oh->doh_rd = _handle_init(oh->doh_ie->ie_dfs);
 		if (oh->doh_rd == NULL) {
-			D_SPIN_UNLOCK(&fs_handle->di_lock);
+			D_SPIN_UNLOCK(&dfuse_info->di_lock);
 			return ENOMEM;
 		}
 
@@ -315,7 +314,7 @@ ensure_rd_handle(struct dfuse_projection_info *fs_handle, struct dfuse_obj_hdl *
 			oh->doh_ie->ie_rd_hdl   = oh->doh_rd;
 		}
 	}
-	D_SPIN_UNLOCK(&fs_handle->di_lock);
+	D_SPIN_UNLOCK(&dfuse_info->di_lock);
 	return 0;
 }
 
@@ -323,7 +322,7 @@ ensure_rd_handle(struct dfuse_projection_info *fs_handle, struct dfuse_obj_hdl *
 #define FAD  fuse_add_direntry
 
 int
-dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct dfuse_obj_hdl *oh,
+dfuse_do_readdir(struct dfuse_info *dfuse_info, fuse_req_t req, struct dfuse_obj_hdl *oh,
 		 char *reply_buff, size_t *out_size, off_t offset, bool plus)
 {
 	off_t                     buff_offset = 0;
@@ -334,7 +333,7 @@ dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct
 	struct dfuse_readdir_hdl *hdl;
 	size_t                    size = *out_size;
 
-	rc = ensure_rd_handle(fs_handle, oh);
+	rc = ensure_rd_handle(dfuse_info, oh);
 	if (rc != 0)
 		return rc;
 
@@ -423,7 +422,7 @@ dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct
 				if (drc->drc_rlink) {
 					entry.attr = drc->drc_stbuf;
 
-					d_hash_rec_addref(&fs_handle->dpi_iet, drc->drc_rlink);
+					d_hash_rec_addref(&dfuse_info->dpi_iet, drc->drc_rlink);
 					ie = container_of(drc->drc_rlink, struct dfuse_inode_entry,
 							  ie_htl);
 				} else {
@@ -457,7 +456,7 @@ dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct
 					dfuse_compute_inode(oh->doh_ie->ie_dfs, &oid,
 							    &stbuf.st_ino);
 
-					rc = create_entry(fs_handle, oh->doh_ie, &stbuf, obj,
+					rc = create_entry(dfuse_info, oh->doh_ie, &stbuf, obj,
 							  drc->drc_name, out, attr_len, &rlink);
 					if (rc != 0) {
 						D_GOTO(reply, rc);
@@ -471,7 +470,7 @@ dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct
 						entry.attr = stbuf;
 					}
 					drc->drc_stbuf = entry.attr;
-					d_hash_rec_addref(&fs_handle->dpi_iet, rlink);
+					d_hash_rec_addref(&dfuse_info->dpi_iet, rlink);
 					drc->drc_rlink = rlink;
 				}
 
@@ -480,7 +479,7 @@ dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct
 				written = FADP(req, &reply_buff[buff_offset], size - buff_offset,
 					       drc->drc_name, &entry, drc->drc_next_offset);
 				if (written > size - buff_offset)
-					d_hash_rec_decref(&fs_handle->dpi_iet, drc->drc_rlink);
+					d_hash_rec_decref(&dfuse_info->dpi_iet, drc->drc_rlink);
 
 			} else {
 				written = FAD(req, &reply_buff[buff_offset], size - buff_offset,
@@ -537,7 +536,7 @@ dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct
 		/* Drop if shared */
 		if (oh->doh_rd->drh_caching) {
 			DFUSE_TRA_DEBUG(oh, "Switching to private handle");
-			dfuse_dre_drop(fs_handle, oh);
+			dfuse_dre_drop(dfuse_info, oh);
 			oh->doh_rd = _handle_init(oh->doh_ie->ie_dfs);
 			hdl        = oh->doh_rd;
 			if (oh->doh_rd == NULL)
@@ -666,8 +665,8 @@ dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct
 				struct dfuse_inode_entry *ie;
 				d_list_t                 *rlink;
 
-				rc = create_entry(fs_handle, oh->doh_ie, &stbuf, obj, dre->dre_name,
-						  out, attr_len, &rlink);
+				rc = create_entry(dfuse_info, oh->doh_ie, &stbuf, obj,
+						  dre->dre_name, out, attr_len, &rlink);
 				if (rc != 0) {
 					dfs_release(obj);
 					D_FREE(drc);
@@ -687,7 +686,7 @@ dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct
 				 */
 				if (drc) {
 					drc->drc_stbuf = entry.attr;
-					d_hash_rec_addref(&fs_handle->dpi_iet, rlink);
+					d_hash_rec_addref(&dfuse_info->dpi_iet, rlink);
 					drc->drc_rlink = rlink;
 				}
 
@@ -696,9 +695,9 @@ dfuse_do_readdir(struct dfuse_projection_info *fs_handle, fuse_req_t req, struct
 				written = FADP(req, &reply_buff[buff_offset], size - buff_offset,
 					       dre->dre_name, &entry, dre->dre_next_offset);
 				if (written > size - buff_offset) {
-					d_hash_rec_decref(&fs_handle->dpi_iet, rlink);
+					d_hash_rec_decref(&dfuse_info->dpi_iet, rlink);
 					if (drc)
-						d_hash_rec_decref(&fs_handle->dpi_iet, rlink);
+						d_hash_rec_decref(&dfuse_info->dpi_iet, rlink);
 				}
 			} else {
 				dfs_release(obj);
@@ -784,9 +783,9 @@ out_reset:
 void
 dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh, size_t size, off_t offset, bool plus)
 {
-	struct dfuse_projection_info *fs_handle  = fuse_req_userdata(req);
-	char                         *reply_buff = NULL;
-	int                           rc         = EIO;
+	struct dfuse_info *dfuse_info = fuse_req_userdata(req);
+	char              *reply_buff = NULL;
+	int                rc         = EIO;
 
 	D_ASSERTF(atomic_fetch_add_relaxed(&oh->doh_readdir_number, 1) == 0,
 		  "Multiple readdir per handle");
@@ -817,7 +816,7 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh, size_t size, off_t of
 	if (reply_buff == NULL)
 		D_GOTO(out, rc = ENOMEM);
 
-	rc = dfuse_do_readdir(fs_handle, req, oh, reply_buff, &size, offset, plus);
+	rc = dfuse_do_readdir(dfuse_info, req, oh, reply_buff, &size, offset, plus);
 
 out:
 	atomic_fetch_sub_relaxed(&oh->doh_readdir_number, 1);

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -11,10 +11,10 @@ void
 dfuse_cb_symlink(fuse_req_t req, const char *link, struct dfuse_inode_entry *parent,
 		 const char *name)
 {
-	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
-	const struct fuse_ctx        *ctx       = fuse_req_ctx(req);
-	struct dfuse_inode_entry     *ie;
-	int                           rc;
+	struct dfuse_info        *dfuse_info = fuse_req_userdata(req);
+	const struct fuse_ctx    *ctx        = fuse_req_ctx(req);
+	struct dfuse_inode_entry *ie;
+	int                       rc;
 
 	D_ALLOC_PTR(ie);
 	if (!ie)
@@ -22,7 +22,7 @@ dfuse_cb_symlink(fuse_req_t req, const char *link, struct dfuse_inode_entry *par
 
 	DFUSE_TRA_UP(ie, parent, "inode");
 
-	dfuse_ie_init(fs_handle, ie);
+	dfuse_ie_init(dfuse_info, ie);
 
 	ie->ie_stat.st_uid = ctx->uid;
 	ie->ie_stat.st_gid = ctx->gid;
@@ -42,7 +42,7 @@ dfuse_cb_symlink(fuse_req_t req, const char *link, struct dfuse_inode_entry *par
 
 	dfuse_compute_inode(ie->ie_dfs, &ie->ie_oid, &ie->ie_stat.st_ino);
 
-	dfuse_reply_entry(fs_handle, ie, NULL, true, req);
+	dfuse_reply_entry(dfuse_info, ie, NULL, true, req);
 
 	return;
 err:

--- a/src/client/dfuse/ops/unlink.c
+++ b/src/client/dfuse/ops/unlink.c
@@ -66,13 +66,11 @@ dfuse_oid_unlinked(struct dfuse_info *dfuse_info, fuse_req_t req, daos_obj_id_t 
 void
 dfuse_cb_unlink(fuse_req_t req, struct dfuse_inode_entry *parent, const char *name)
 {
-	struct dfuse_projection_info	*fs_handle;
-	int				rc;
-	daos_obj_id_t			oid = {};
+	struct dfuse_info *dfuse_info = fuse_req_userdata(req);
+	int                rc;
+	daos_obj_id_t      oid = {};
 
-	fs_handle = fuse_req_userdata(req);
-
-	dfuse_cache_evict_dir(fs_handle, parent);
+	dfuse_cache_evict_dir(dfuse_info, parent);
 
 	rc = dfs_remove(parent->ie_dfs->dfs_ns, parent->ie_obj, name, false, &oid);
 	if (rc != 0) {
@@ -82,6 +80,5 @@ dfuse_cb_unlink(fuse_req_t req, struct dfuse_inode_entry *parent, const char *na
 
 	D_ASSERT(oid.lo || oid.hi);
 
-	/* TODO: Need to do the first part of this and set ie->ie_unlinked before returning */
-	dfuse_oid_unlinked(fs_handle, req, &oid, parent, name);
+	dfuse_oid_unlinked(dfuse_info, req, &oid, parent, name);
 }

--- a/src/client/dfuse/ops/write.c
+++ b/src/client/dfuse/ops/write.c
@@ -22,21 +22,21 @@ void
 dfuse_cb_write(fuse_req_t req, fuse_ino_t ino, struct fuse_bufvec *bufv, off_t position,
 	       struct fuse_file_info *fi)
 {
-	struct dfuse_obj_hdl         *oh        = (struct dfuse_obj_hdl *)fi->fh;
-	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
-	const struct fuse_ctx        *fc        = fuse_req_ctx(req);
-	size_t                        len       = fuse_buf_size(bufv);
-	struct fuse_bufvec            ibuf      = FUSE_BUFVEC_INIT(len);
-	struct dfuse_eq              *eqt;
-	int                           rc;
-	struct dfuse_event           *ev;
-	uint64_t                      eqt_idx;
+	struct dfuse_obj_hdl  *oh         = (struct dfuse_obj_hdl *)fi->fh;
+	struct dfuse_info     *dfuse_info = fuse_req_userdata(req);
+	const struct fuse_ctx *fc         = fuse_req_ctx(req);
+	size_t                 len        = fuse_buf_size(bufv);
+	struct fuse_bufvec     ibuf       = FUSE_BUFVEC_INIT(len);
+	struct dfuse_eq       *eqt;
+	int                    rc;
+	struct dfuse_event    *ev;
+	uint64_t               eqt_idx;
 
 	oh->doh_linear_read = false;
 
-	eqt_idx = atomic_fetch_add_relaxed(&fs_handle->di_eqt_idx, 1);
+	eqt_idx = atomic_fetch_add_relaxed(&dfuse_info->di_eqt_idx, 1);
 
-	eqt = &fs_handle->di_eqt[eqt_idx % fs_handle->di_eq_count];
+	eqt = &dfuse_info->di_eqt[eqt_idx % dfuse_info->di_eq_count];
 
 	DFUSE_TRA_DEBUG(oh, "%#zx-%#zx requested flags %#x pid=%d", position, position + len - 1,
 			bufv->buf[0].flags, fc->pid);


### PR DESCRIPTION
Remove all remaining places that dfuse_projection_info was stil
used.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
