### PR TITLE
DAOS-12638 object: obj_shard_task_sched refine

### DIFF
--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -1325,6 +1325,32 @@ tse_task_list_traverse(d_list_t *head, tse_task_cb_t cb, void *arg)
 	return ret;
 }
 
+int
+tse_task_list_traverse_adv(d_list_t *head, tse_task_cb_t cb, void *arg)
+{
+	struct tse_task_private	*dtp;
+	struct tse_task_private	*dtp_exec;
+	struct tse_task_private	*tmp;
+	int			 ret = 0;
+	int			 rc;
+	bool			 done;
+
+	for (dtp = d_list_entry(head->next, struct tse_task_private, dtp_task_list),
+	     tmp = d_list_entry(dtp->dtp_task_list.next, struct tse_task_private, dtp_task_list),
+	     done = (&dtp->dtp_task_list == head); !done;) {
+		dtp_exec = dtp;
+		dtp = tmp,
+		tmp = d_list_entry(tmp->dtp_task_list.next, struct tse_task_private,
+				   dtp_task_list);
+		done = (&dtp->dtp_task_list == head);
+		rc = cb(tse_priv2task(dtp_exec), arg);
+		if (rc != 0)
+			ret = rc;
+	}
+
+	return ret;
+}
+
 void
 tse_disable_propagate(tse_task_t *task)
 {

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2022 Intel Corporation.
+ * (C) Copyright 2015-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -404,6 +404,13 @@ tse_task_depend_list(tse_task_t *task, d_list_t *head);
  */
 int
 tse_task_list_traverse(d_list_t *head, tse_task_cb_t cb, void *arg);
+
+/**
+ * Advanced tse_task_list_traverse, the task's dtp_task_list or head list possibly
+ * be changed/zeroed after \a cb executed.
+ */
+int
+tse_task_list_traverse_adv(d_list_t *head, tse_task_cb_t cb, void *arg);
 
 /**
  * Set the task don't propagate err-code from dependent tasks.

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2802,8 +2802,7 @@ obj_shard_task_sched(struct obj_auxi_args *obj_auxi, struct dtx_epoch *epoch)
 	sched_arg.tsa_scheded = false;
 	sched_arg.tsa_prev_scheded = obj_auxi->shards_scheded;
 	sched_arg.tsa_epoch = *epoch;
-	tse_task_list_traverse(&obj_auxi->shard_task_head, shard_task_sched,
-			       &sched_arg);
+	tse_task_list_traverse_adv(&obj_auxi->shard_task_head, shard_task_sched, &sched_arg);
 	/* It is possible that the IO retried by stale pm version found, but
 	 * the IO involved shards' targets not changed. No any shard task
 	 * re-scheduled for this case, can complete the obj IO task.


### PR DESCRIPTION
In obj_shard_task_sched(), tse_task_list_traverse schedules shard tasks but once the last shard task scheduled it possibly cause the obj task completed and in obj_comp_cb() it may zero the head list. This patch provides tse_task_list_traverse_adv() that is safe if task's dtp_task_list or head list changed after scheduled shard task. The problem found by Mohamad.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
