### PR TITLE
DAOS-13295 rebuild: check dtx global version before wait

### DIFF
--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -203,8 +203,9 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		rpt->rt_global_scan_done = dst_iv->riv_global_scan_done;
 		if (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver &&
 		    dst_iv->riv_global_dtx_resyc_version >= rpt->rt_rebuild_ver) {
-			D_DEBUG(DB_REBUILD, DF_UUID" signal global wait cond\n",
-				DP_UUID(src_iv->riv_pool_uuid));
+			D_INFO(DF_UUID" global/iv/rebuild_ver %u/%u/%u signal wait cond\n",
+			       DP_UUID(src_iv->riv_pool_uuid), rpt->rt_global_dtx_resync_version,
+			       dst_iv->riv_global_dtx_resyc_version, rpt->rt_rebuild_ver);
 			ABT_mutex_lock(rpt->rt_lock);
 			ABT_cond_signal(rpt->rt_global_dtx_wait_cond);
 			ABT_mutex_unlock(rpt->rt_lock);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -1023,7 +1023,13 @@ rebuild_scan_leader(void *data)
 	while (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver) {
 		if (!rpt->rt_abort && !rpt->rt_finishing) {
 			ABT_mutex_lock(rpt->rt_lock);
-			ABT_cond_wait(rpt->rt_global_dtx_wait_cond, rpt->rt_lock);
+			if (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver) {
+				D_INFO(DF_UUID "wait for global dtx %u rebuild ver %u\n",
+				       DP_UUID(rpt->rt_pool_uuid),
+				       rpt->rt_global_dtx_resync_version,
+				       rpt->rt_rebuild_ver);
+				ABT_cond_wait(rpt->rt_global_dtx_wait_cond, rpt->rt_lock);
+			}
 			ABT_mutex_unlock(rpt->rt_lock);
 		}
 		if (rpt->rt_abort || rpt->rt_finishing) {
@@ -1031,7 +1037,6 @@ rebuild_scan_leader(void *data)
 			       DP_UUID(rpt->rt_pool_uuid), DP_RC(-DER_SHUTDOWN));
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 		}
-
 	}
 
 	D_DEBUG(DB_REBUILD, "rebuild scan collective "DF_UUID" begin.\n",


### PR DESCRIPTION
Since ABT_mutex_lock might yield, so it needs to check global dtx with current rebuild version before wait, in case condition sigal has been issued, then it may wait infinitely.

Features: rebuild
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
