### PR TITLE
jgm/daos-13239-2.4 cart: Refactor RPC send error code mapping.

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1311,7 +1311,17 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 		break;
 	default:
 		rpc_priv->crp_state = RPC_STATE_COMPLETED;
-		rc = crt_hgret_2_der(hg_cbinfo->ret);
+
+		if (crt_is_service()) {
+			rc = crt_hgret_2_der(hg_cbinfo->ret);
+		} else {
+			if (hg_cbinfo->ret) {
+				rc = -DER_HG_SEND_FAILED;
+			} else {
+				rc = DER_SUCCESS;
+			}
+		}
+
 		hg_ret = hg_cbinfo->ret;
 		RPC_TRACE(DB_NET, rpc_priv, "hg_cbinfo->ret: " DF_HG_RC ".\n",
 			  DP_HG_RC(hg_cbinfo->ret));

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -207,6 +207,16 @@ void test_d_errstr(void **state)
 #else
 	test_d_errstr_v2(state);
 #endif
+
+	/* Check the boundary at the end of the GURT error numbers, this will need updating if
+	 * additional error numbers are added.
+	 */
+	value = d_errstr(-DER_HG_SEND_FAILED);
+	assert_string_equal(value, "DER_HG_SEND_FAILED");
+	value = d_errstr(-1046);
+	assert_string_equal(value, "DER_HG_SEND_FAILED");
+	value = d_errstr(-(DER_HG_SEND_FAILED + 1));
+	assert_string_equal(value, "DER_UNKNOWN");
 }
 
 void test_d_errdesc(void **state)

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -621,7 +621,7 @@ static inline bool
 daos_crt_network_error(int err)
 {
 	return err == -DER_HG || err == -DER_UNREACH || err == -DER_CANCELED ||
-	       err == -DER_NOREPLY || err == -DER_OOG;
+	       err == -DER_NOREPLY || err == -DER_OOG || err == -DER_HG_SEND_FAILED;
 }
 
 /** See crt_quiet_error. */

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -162,8 +162,8 @@ extern "C" {
 	/** Fatal (non-retry-able) transport layer mercury error */	\
 	ACTION(DER_HG_FATAL,		(DER_ERR_GURT_BASE + 45),	\
 	       Fatal transport layer mercury error)                     \
-        /** Failed to send rpc */                                       \
-        ACTION(DER_HG_SEND_FAILED,       (DER_ERR_GURT_BASE + 46),      \
+	/** Failed to send rpc */                                       \
+	ACTION(DER_HG_SEND_FAILED,       (DER_ERR_GURT_BASE + 46),      \
 	       Failed to send rpc)
 	/** TODO: add more error numbers */
 

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -161,7 +161,10 @@ extern "C" {
 	       incompatible user or group permissions)			\
 	/** Fatal (non-retry-able) transport layer mercury error */	\
 	ACTION(DER_HG_FATAL,		(DER_ERR_GURT_BASE + 45),	\
-	       Fatal transport layer mercury error)
+	       Fatal transport layer mercury error)                     \
+        /** Failed to send rpc */                                       \
+        ACTION(DER_HG_SEND_FAILED,       (DER_ERR_GURT_BASE + 46),      \
+	       Failed to send rpc)
 	/** TODO: add more error numbers */
 
 /** Preprocessor macro defining DAOS errno values and internal definition of d_errstr */


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
