### PR TITLE
DAOS-13295 rebuild: reverse recx enumeration order for rebuild (#12641)

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -55,10 +55,10 @@ agg_rate_ctl(void *arg)
 	if (dss_ult_exiting(req) || pool->sp_reclaim == DAOS_RECLAIM_DISABLED)
 		return -1;
 
-	/* If the container is discarding the object mostly due to rebuild failure
-	 * reclaim, let's abort the aggregation to let discard proceed.
-	 */
-	if (cont->sc_discarding)
+	/* EC aggregation needs to be parsed during rebuilding to avoid the race
+	 * between EC rebuild and EC aggregation.
+	 **/
+	if (pool->sp_rebuilding && cont->sc_ec_agg_active)
 		return -1;
 
 	/* System is idle, let aggregation run in tight mode */
@@ -190,14 +190,14 @@ cont_aggregate_runnable(struct ds_cont_child *cont, struct sched_request *req,
 		return false;
 	}
 
-	if (pool->sp_reintegrating) {
+	if (pool->sp_rebuilding) {
 		if (vos_agg)
 			cont->sc_vos_agg_active = 0;
 		else
 			cont->sc_ec_agg_active = 0;
-		D_DEBUG(DB_EPC, DF_CONT": skip %s aggregation during reintegration %d.\n",
+		D_DEBUG(DB_EPC, DF_CONT": skip %s aggregation during rebuild %d.\n",
 			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
-			vos_agg ? "VOS" : "EC", pool->sp_reintegrating);
+			vos_agg ? "VOS" : "EC", pool->sp_rebuilding);
 		return false;
 	}
 
@@ -477,9 +477,10 @@ cont_aggregate_interval(struct ds_cont_child *cont, cont_aggregate_cb_t cb,
 		if (rc == -DER_SHUTDOWN) {
 			break;	/* pool destroyed */
 		} else if (rc < 0) {
-			D_ERROR(DF_CONT": VOS aggregate failed. "DF_RC"\n",
-				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
-				DP_RC(rc));
+			D_CDEBUG(rc == -DER_BUSY, DB_EPC, DLOG_ERR,
+				 DF_CONT": VOS aggregate failed. "DF_RC"\n",
+				 DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+				 DP_RC(rc));
 		} else if (sched_req_space_check(req) != SCHED_SPACE_PRESS_NONE) {
 			/* Don't sleep too long when there is space pressure */
 			msecs = 2ULL * 100;

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -549,6 +549,8 @@ enum daos_io_flags {
 	DIOF_EC_RECOV_FROM_PARITY = 0x200,
 	/* Force fetch/list to do degraded enumeration/fetch */
 	DIOF_FOR_FORCE_DEGRADE = 0x400,
+	/* reverse enumeration for recx */
+	DIOF_RECX_REVERSE = 0x800,
 };
 
 /**

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -71,8 +71,7 @@ struct ds_cont_child {
 				 sc_stopping:1,
 				 sc_vos_agg_active:1,
 				 sc_ec_agg_active:1,
-				 sc_scrubbing:1,
-				 sc_discarding:1;
+				 sc_scrubbing:1;
 	uint32_t		 sc_dtx_batched_gen;
 	/* Tracks the schedule request for aggregation ULT */
 	struct sched_request	*sc_agg_req;

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -77,7 +77,7 @@ struct ds_pool {
 	 */
 	uint32_t		sp_rebuild_gen;
 
-	int			sp_reintegrating;
+	int			sp_rebuilding;
 
 	int			sp_discard_status;
 	/** path to ephemeral metrics */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1498,4 +1498,22 @@ vos_standalone_tls_init(int tags);
 void
 vos_standalone_tls_fini(void);
 
+/**
+ * Enter the aggregation, so other operation might be excluded at the same time.
+ * \param[in]	coh	container open handle.
+ * \param[in]	epr	epoch range.
+ *
+ * \return 0 on success, error otherwise.
+ */
+int
+vos_aggregate_enter(daos_handle_t coh, daos_epoch_range_t *epr);
+
+/**
+ * Exit the aggregation, so other operation can proceed.
+ * \param[in]	coh	container open handle.
+ *
+ */
+void
+vos_aggregate_exit(daos_handle_t coh);
+
 #endif /* __VOS_API_H */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -6110,6 +6110,7 @@ obj_shard_list_prep(struct obj_auxi_args *obj_auxi, struct dc_object *obj,
 		}
 		memcpy(shard_arg->la_dkey_anchor,
 		       &sub_anchors->sa_anchors[idx].ssa_anchor, sizeof(daos_anchor_t));
+		shard_arg->la_dkey_anchor->da_flags = obj_args->dkey_anchor->da_flags;
 	}
 
 	if (obj_args->akey_anchor) {
@@ -6124,6 +6125,7 @@ obj_shard_list_prep(struct obj_auxi_args *obj_auxi, struct dc_object *obj,
 		else
 			memcpy(shard_arg->la_akey_anchor,
 			       &sub_anchors->sa_anchors[idx].ssa_anchor, sizeof(daos_anchor_t));
+		shard_arg->la_akey_anchor->da_flags = obj_args->akey_anchor->da_flags;
 	}
 out:
 	return rc;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1955,6 +1955,8 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		if (daos_anchor_get_flags(args->la_dkey_anchor) &
 		    DIOF_FOR_MIGRATION)
 			oei->oei_flags |= ORF_FOR_MIGRATION;
+		if (daos_anchor_get_flags(args->la_dkey_anchor) & DIOF_RECX_REVERSE)
+			oei->oei_flags |= ORF_DESCENDING_ORDER;
 	}
 	if (args->la_akey_anchor != NULL)
 		enum_anchor_copy(&oei->oei_akey_anchor, args->la_akey_anchor);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2338,6 +2338,14 @@ obj_ioc_init_oca(struct obj_io_context *ioc, daos_obj_id_t oid)
 static int
 obj_inflight_io_check(struct ds_cont_child *child, uint32_t opc, uint32_t flags)
 {
+	if (opc == DAOS_OBJ_RPC_ENUMERATE && flags & ORF_FOR_MIGRATION) {
+		if (child->sc_ec_agg_active) {
+			D_ERROR(DF_UUID" ec aggregate still active\n",
+				DP_UUID(child->sc_pool->spc_uuid));
+			return -DER_UPDATE_AGAIN;
+		}
+	}
+
 	if (!obj_is_modification_opc(opc))
 		return 0;
 
@@ -3183,6 +3191,9 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 			param.ip_epc_expr = VOS_IT_EPC_RE;
 		}
 		recursive = true;
+
+		if (oei->oei_flags & ORF_DESCENDING_ORDER)
+			param.ip_flags |= VOS_IT_RECX_REVERSE;
 
 		if (daos_oclass_is_ec(&ioc->ioc_oca))
 			enum_arg->ec_cell_sz = ioc->ioc_oca.u.ec.e_len;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -515,8 +515,7 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, unsigned int version, unsig
 
 	tls = migrate_pool_tls_lookup(pool->sp_uuid, version, generation);
 	D_ASSERT(tls != NULL);
-	if (opc == RB_OP_REINT)
-		pool->sp_reintegrating++;
+	pool->sp_rebuilding++;
 
 	rc = ABT_cond_create(&tls->mpt_init_cond);
 	if (rc != ABT_SUCCESS)
@@ -1382,7 +1381,7 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 						 min_eph,
 						 DIOF_FOR_MIGRATION | DIOF_EC_RECOV_FROM_PARITY,
 						 ds_cont);
-		if (rc > 0)
+		if (rc != 0)
 			D_GOTO(out, rc);
 	}
 
@@ -1401,8 +1400,22 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 			rc = __migrate_fetch_update_bulk(mrone, oh, &iod, 1,
 							 mrone->mo_iods_update_ephs[i][j],
 							 DIOF_FOR_MIGRATION, ds_cont);
-			if (rc > 0)
-				D_GOTO(out, rc);
+			if (rc < 0) {
+				if (rc == -DER_VOS_PARTIAL_UPDATE) {
+					/* In some cases, EC aggregation failed to delete the
+					 * replicate recx, then during rebuild these replicate
+					 * recx might be rebuilt again. Since the data rebuilt
+					 * from parity will be rebuilt first. so let's ignore
+					 * this replicate recx for now.
+					 */
+					D_WARN(DF_UOID" "DF_RECX"/"DF_X64" already rebuilt\n",
+					       DP_UOID(mrone->mo_oid), DP_RECX(iod.iod_recxs[0]),
+					       mrone->mo_iods_update_ephs[i][j]);
+					rc = 0;
+				} else {
+					D_GOTO(out, rc);
+				}
+			}
 		}
 	}
 out:
@@ -2610,6 +2623,7 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 			minimum_nr = obj_ec_tgt_nr(&unpack_arg.oc_attr);
 		else
 			minimum_nr = 2;
+		enum_flags |= DIOF_RECX_REVERSE;
 	} else {
 		minimum_nr = 2;
 		p_csum = &csum;
@@ -2689,6 +2703,13 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 				D_DEBUG(DB_REBUILD, "retry leader "DF_UOID"\n",
 					DP_UOID(arg->oid));
 			}
+			continue;
+		} else if (rc == -DER_UPDATE_AGAIN) {
+			/* -DER_UPDATE_AGAIN means the remote target does not parse EC
+			 * aggregation yet, so let's retry.
+			 */
+			D_DEBUG(DB_REBUILD, DF_UOID "retry with %d\n", DP_UOID(arg->oid), rc);
+			rc = 0;
 			continue;
 		} else if (rc) {
 			/* container might have been destroyed. Or there is
@@ -2825,8 +2846,7 @@ ds_migrate_stop(struct ds_pool *pool, unsigned int version, unsigned int generat
 	if (rc)
 		D_ERROR(DF_UUID" migrate stop: %d\n", DP_UUID(pool->sp_uuid), rc);
 
-	if (tls->mpt_opc == RB_OP_REINT)
-		pool->sp_reintegrating--;
+	pool->sp_rebuilding--;
 	migrate_pool_tls_put(tls);
 	tls->mpt_fini = 1;
 	/* Wait for xstream 0 migrate ULT(migrate_ult) stop */
@@ -2892,7 +2912,6 @@ migrate_obj_ult(void *data)
 			if (tls->mpt_fini)
 				D_GOTO(free_notls, rc);
 		}
-		D_ASSERT(tls->mpt_pool->spc_pool->sp_need_discard == 0);
 		if (tls->mpt_pool->spc_pool->sp_discard_status) {
 			rc = tls->mpt_pool->spc_pool->sp_discard_status;
 			D_DEBUG(DB_REBUILD, DF_UUID" discard failure"DF_RC".\n",

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -854,31 +854,29 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		return rc;
 	}
 
-	if (rpt->rt_rebuild_op == RB_OP_RECLAIM ||
-	    rpt->rt_rebuild_op == RB_OP_FAIL_RECLAIM) {
-		rc = ds_cont_child_lookup(rpt->rt_pool_uuid, entry->ie_couuid, &cont_child);
-		if (rc != 0) {
-			D_ERROR("Container "DF_UUID", ds_cont_child_lookup failed: "DF_RC"\n",
-				DP_UUID(entry->ie_couuid), DP_RC(rc));
-			vos_cont_close(coh);
-			return rc;
-		}
-		cont_child->sc_discarding = 1;
-		while (cont_child->sc_ec_agg_active) {
-			D_ASSERTF(rpt->rt_pool->sp_reintegrating >= 0, DF_UUID" reintegrating %d\n",
-				  DP_UUID(rpt->rt_pool_uuid), rpt->rt_pool->sp_reintegrating);
+	rc = ds_cont_child_lookup(rpt->rt_pool_uuid, entry->ie_couuid, &cont_child);
+	if (rc != 0) {
+		D_ERROR("Container "DF_UUID", ds_cont_child_lookup failed: "DF_RC"\n",
+			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		vos_cont_close(coh);
+		return rc;
+	}
+
+	/* Wait for EC aggregation to finish. NB: migrate needs to wait for EC aggregation to finish */
+	while (cont_child->sc_ec_agg_active) {
+		D_ASSERTF(rpt->rt_pool->sp_rebuilding >= 0, DF_UUID" rebuilding %d\n",
+			  DP_UUID(rpt->rt_pool_uuid), rpt->rt_pool->sp_rebuilding);
 			/* Wait for EC aggregation to abort before discard the object */
-			D_DEBUG(DB_REBUILD, DF_UUID" wait for ec agg abort.\n",
-				DP_UUID(entry->ie_couuid));
-			dss_sleep(1000);
-			if (rpt->rt_abort || rpt->rt_finishing) {
-				D_DEBUG(DB_REBUILD, DF_CONT" rebuild op %s ver %u abort %u/%u.\n",
-					DP_CONT(rpt->rt_pool_uuid, entry->ie_couuid),
-					RB_OP_STR(rpt->rt_rebuild_op), rpt->rt_rebuild_ver,
-					rpt->rt_abort, rpt->rt_finishing);
-				*acts |= VOS_ITER_CB_ABORT;
-				D_GOTO(close, rc);
-			}
+		D_DEBUG(DB_REBUILD, DF_UUID" wait for ec agg abort.\n",
+			DP_UUID(entry->ie_couuid));
+		dss_sleep(1000);
+		if (rpt->rt_abort || rpt->rt_finishing) {
+			D_DEBUG(DB_REBUILD, DF_CONT" rebuild op %s ver %u abort %u/%u.\n",
+				DP_CONT(rpt->rt_pool_uuid, entry->ie_couuid),
+				RB_OP_STR(rpt->rt_rebuild_op), rpt->rt_rebuild_ver,
+				rpt->rt_abort, rpt->rt_finishing);
+			*acts |= VOS_ITER_CB_ABORT;
+			D_GOTO(close, rc);
 		}
 	}
 
@@ -908,10 +906,8 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 close:
 	vos_cont_close(coh);
 
-	if (cont_child != NULL) {
-		cont_child->sc_discarding = 0;
+	if (cont_child != NULL)
 		ds_cont_child_put(cont_child);
-	}
 
 	D_DEBUG(DB_REBUILD, DF_UUID"/"DF_UUID" iterate cont done: "DF_RC"\n",
 		DP_UUID(rpt->rt_pool_uuid), DP_UUID(entry->ie_couuid),
@@ -1171,9 +1167,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		D_GOTO(out, rc);
 	}
 
-	if (rpt->rt_rebuild_op == RB_OP_REINT || rpt->rt_rebuild_op == RB_OP_RECLAIM ||
-	    rpt->rt_rebuild_op == RB_OP_FAIL_RECLAIM)
-		rpt->rt_pool->sp_reintegrating++; /* reset in rebuild_tgt_fini */
+	rpt->rt_pool->sp_rebuilding++; /* reset in rebuild_tgt_fini */
 
 	rpt_get(rpt);
 	/* step-3: start scan leader */

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -2117,11 +2117,8 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	D_INFO("finishing rebuild for "DF_UUID", map_ver=%u refcount %u\n",
 	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver, rpt->rt_refcount);
 
-	if (rpt->rt_rebuild_op == RB_OP_REINT || rpt->rt_rebuild_op == RB_OP_RECLAIM ||
-	    rpt->rt_rebuild_op == RB_OP_FAIL_RECLAIM) {
-		D_ASSERT(rpt->rt_pool->sp_reintegrating > 0);
-		rpt->rt_pool->sp_reintegrating--;
-	}
+	D_ASSERT(rpt->rt_pool->sp_rebuilding > 0);
+	rpt->rt_pool->sp_rebuilding--;
 
 	ABT_mutex_lock(rpt->rt_lock);
 	ABT_cond_signal(rpt->rt_global_dtx_wait_cond);

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -2507,7 +2507,7 @@ aggregate_enter(struct vos_container *cont, int agg_mode, daos_epoch_range_t *ep
 		break;
 	case AGG_MODE_AGGREGATE:
 		if (cont->vc_in_aggregation) {
-			D_ERROR(DF_CONT": Already in aggregation epr["DF_U64", "DF_U64"]\n",
+			D_DEBUG(DB_EPC, DF_CONT": Already in aggregation epr["DF_U64", "DF_U64"]\n",
 				DP_CONT(cont->vc_pool->vp_id, cont->vc_id),
 				cont->vc_epr_aggregation.epr_lo, cont->vc_epr_aggregation.epr_hi);
 			return -DER_BUSY;
@@ -2614,6 +2614,18 @@ struct agg_data {
 	struct vos_agg_param	ad_agg_param;
 	struct vos_iter_anchors	ad_anchors;
 };
+
+int
+vos_aggregate_enter(daos_handle_t coh, daos_epoch_range_t *epr)
+{
+	return aggregate_enter(vos_hdl2cont(coh), AGG_MODE_AGGREGATE, epr);
+}
+
+void
+vos_aggregate_exit(daos_handle_t coh)
+{
+	aggregate_exit(vos_hdl2cont(coh), AGG_MODE_AGGREGATE);
+}
 
 int
 vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,


### PR DESCRIPTION
1. reverse recx enumeration order, so data from parity rebuild will be rebuilt first, then if any replicate data being left after EC aggregation, they will be ignored during rebuild.

2. Exclude EC aggregation with the whole rebuild process to avoid enumeration might enumerate any aggregating replicate recx.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
