### PR TITLE
DAOS-14085 control: Fix config generate yaml printed to stdout (#12770)

### DIFF
--- a/src/control/cmd/daos_server/auto.go
+++ b/src/control/cmd/daos_server/auto.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -161,7 +162,6 @@ func (cmd *configGenCmd) confGen(ctx context.Context, getFabric getFabricFn, get
 	cmd.Debugf("fetched host storage info on localhost: %+v", hs)
 
 	req := control.ConfGenerateReq{
-		Log:             cmd.Logger,
 		NrEngines:       cmd.NrEngines,
 		SCMOnly:         cmd.SCMOnly,
 		NetClass:        ndc,
@@ -172,13 +172,37 @@ func (cmd *configGenCmd) confGen(ctx context.Context, getFabric getFabricFn, get
 	}
 	cmd.Debugf("control API ConfGenerate called with req: %+v", req)
 
+	// Use a modified commandline logger to send all log messages to stderr during the
+	// generation of server config file parameters so stdout can be reserved for config file
+	// output only.
+	logStderr := logging.NewCommandLineLogger()
+	logStderr.ClearLevel(logging.LogLevelInfo)
+	logStderr.WithInfoLogger(logging.NewCommandLineInfoLogger(os.Stderr))
+	req.Log = logStderr
+
 	resp, err := control.ConfGenerate(req, control.DefaultEngineCfg, hf, hs)
 	if err != nil {
 		return nil, err
 	}
-	cmd.Debugf("control API ConfGenerate resp: %+v", resp)
 
+	cmd.Debugf("control API ConfGenerate resp: %+v", resp)
 	return &resp.Server, nil
+}
+
+func (cmd *configGenCmd) confGenPrint(ctx context.Context, getFabric getFabricFn, getStorage getStorageFn) error {
+	cfg, err := cmd.confGen(ctx, getFabric, getStorage)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Print generated config yaml file contents to stdout.
+	cmd.Info(string(bytes))
+	return nil
 }
 
 // Execute is run when configGenCmd activates.
@@ -191,18 +215,5 @@ func (cmd *configGenCmd) Execute(_ []string) error {
 		return err
 	}
 
-	ctx := context.Background()
-	cfg, err := cmd.confGen(ctx, getLocalFabric, getLocalStorage)
-	if err != nil {
-		return err
-	}
-
-	bytes, err := yaml.Marshal(cfg)
-	if err != nil {
-		return err
-	}
-
-	// output recommended server config yaml file
-	cmd.Info(string(bytes))
-	return nil
+	return cmd.confGenPrint(context.Background(), getLocalFabric, getLocalStorage)
 }


### PR DESCRIPTION
INFO level log messages were being printed to stdout during the
execution of dmg config generate meaning that the output could not be
redirected to a .yml file and used as a daos_server config. Fix by
adjusting the effective log level to ERROR during execution of the
ConfigGenerate Control-API call. The INFO and NOTICE logging can
safely be ignored as these messages are intended for daos_server users
when running in daemon mode. In order to preserve --debug cmdline
functionality, don't adjust the log level if running with the flag set.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
