### PR TITLE
DAOS-12670 control: Select all devices by default in led manage cmds

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -619,7 +619,7 @@ Usage:
 
 [identify command arguments]
   ids:                Comma-separated list of identifiers which could be either VMD backing device
-                      (NVMe SSD) PCI addresses or device
+                      (NVMe SSD) PCI addresses or device. All SSDs selected if arg not provided.
 ```
 
 To identify a single SSD, any of the Device-UUIDs can be used which can be found from
@@ -669,11 +669,16 @@ in the command.
 
 Upon issuing a device identify command with specified device IDs and optional custom timeout value,
 an admin now can quickly identify a device in question.
+
 After issuing the identify command, the status LED on the VMD device is now set to a "QUICK_BLINK"
 state, representing a quick, 4Hz blinking amber light.
+
 The device will quickly blink for the specified timeout (in minutes) or the default (2 minutes) if
 no value is specified on the command line, after which the LED state will return to the previous
 state (faulty "ON" or default "OFF").
+
+The led identify command will set (or --reset) the state of all devices on the specified host(s) if
+no positional arguments are supplied.
 
 - Check LED state of SSDs:
 
@@ -689,6 +694,9 @@ boro-11
     TrAddr:850505:0b:00.0 LED:QUICK_BLINK
     TrAddr:850505:11:00.0 LED:QUICK_BLINK
 ```
+
+The led check command will return the state of all devices on the specified host(s) if no positional
+arguments are supplied.
 
 - Locate an Evicted SSD:
 

--- a/src/control/cmd/dmg/storage_query.go
+++ b/src/control/cmd/dmg/storage_query.go
@@ -258,7 +258,7 @@ type ledCmd struct {
 	smdManageCmd
 
 	Args struct {
-		IDs string `positional-arg-name:"ids" description:"Comma-separated list of identifiers which could be either VMD backing device (NVMe SSD) PCI addresses or device UUIDs"`
+		IDs string `positional-arg-name:"ids" description:"Comma-separated list of identifiers which could be either VMD backing device (NVMe SSD) PCI addresses or device UUIDs. All SSDs selected if arg not provided."`
 	} `positional-args:"yes"`
 }
 

--- a/src/control/cmd/dmg/storage_query.go
+++ b/src/control/cmd/dmg/storage_query.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -278,7 +278,7 @@ type ledIdentifyCmd struct {
 // Runs SPDK VMD API commands to set the LED state on the VMD to "IDENTIFY" (4Hz blink).
 func (cmd *ledIdentifyCmd) Execute(_ []string) error {
 	if cmd.Args.IDs == "" {
-		return errors.New("neither a pci address or a uuid has been supplied")
+		cmd.Debugf("neither a pci address or a uuid has been supplied so select all")
 	}
 	req := &control.SmdManageReq{
 		Operation:       control.LedBlinkOp,
@@ -303,7 +303,7 @@ type ledCheckCmd struct {
 // Runs SPDK VMD API commands to query the LED state on VMD devices
 func (cmd *ledCheckCmd) Execute(_ []string) error {
 	if cmd.Args.IDs == "" {
-		return errors.New("neither a pci address or a uuid has been supplied")
+		cmd.Debugf("neither a pci address or a uuid has been supplied so select all")
 	}
 	req := &control.SmdManageReq{
 		Operation: control.LedCheckOp,

--- a/src/control/cmd/dmg/storage_query_test.go
+++ b/src/control/cmd/dmg/storage_query_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -191,8 +191,10 @@ func TestStorageQueryCommands(t *testing.T) {
 		{
 			"Identify device without device UUID or PCI address specified",
 			"storage led identify",
-			"",
-			errors.New("neither a pci address or a uuid has been supplied"),
+			printRequest(t, &control.SmdManageReq{
+				Operation: control.LedBlinkOp,
+			}),
+			nil,
 		},
 		{
 			"Identify a device",
@@ -252,6 +254,14 @@ func TestStorageQueryCommands(t *testing.T) {
 			printRequest(t, &control.SmdManageReq{
 				Operation: control.LedCheckOp,
 				IDs:       "842c739b-86b5-462f-a7ba-b4a91b674f3d,d50505:01:00.0",
+			}),
+			nil,
+		},
+		{
+			"check LED state without device UUID or PCI address specified",
+			"storage led check",
+			printRequest(t, &control.SmdManageReq{
+				Operation: control.LedCheckOp,
 			}),
 			nil,
 		},

--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -214,32 +214,25 @@ func (im idMap) Keys() (keys []string) {
 }
 
 // Split IDs in comma separated string and assign each token to relevant return list.
-func extractReqIDs(log logging.Logger, ids string) (idMap, idMap, error) {
-	if ids == "" {
-		return nil, nil, errors.New("empty id string")
-	}
-
+func extractReqIDs(log logging.Logger, ids string, addrs idMap, uuids idMap) error {
 	tokens := strings.Split(ids, ",")
 
-	addrs := make(idMap)
-	uuids := make(idMap)
-
 	for _, token := range tokens {
-		if addr, err := hardware.NewPCIAddress(token); err == nil && addr.IsVMDBackingAddress() {
+		if addr, e := hardware.NewPCIAddress(token); e == nil && addr.IsVMDBackingAddress() {
 			addrs[addr.String()] = true
 			continue
 		}
 
-		if uuid, err := uuid.Parse(token); err == nil {
+		if uuid, e := uuid.Parse(token); e == nil {
 			uuids[uuid.String()] = true
 			continue
 		}
 
-		return nil, nil, errors.Errorf("req id entry %q is neither a valid vmd backing "+
-			"device pci address or uuid", token)
+		return errors.Errorf("req id entry %q is neither a valid vmd backing device pci "+
+			"address or uuid", token)
 	}
 
-	return addrs, uuids, nil
+	return nil
 }
 
 type devID struct {
@@ -247,15 +240,51 @@ type devID struct {
 	uuid   string
 }
 
-type engineDevMap map[Engine][]devID
+func (id *devID) String() string {
+	if id.trAddr != "" {
+		return id.trAddr
+	}
+	return id.uuid
+}
+
+type devIDMap map[string]devID
+
+func (dim devIDMap) getFirst() *devID {
+	for _, id := range dim {
+		return &id
+	}
+	return nil
+}
+
+type engineDevMap map[Engine]devIDMap
+
+func (edm engineDevMap) add(e Engine, id devID) {
+	if _, exists := edm[e]; !exists {
+		edm[e] = make(devIDMap)
+	}
+	if _, exists := edm[e][id.String()]; !exists {
+		edm[e][id.String()] = id
+	}
+}
 
 // Map requested device IDs provided in comma-separated string to the engine that controls the given
 // device. Device can be identified either by UUID or transport (PCI) address.
 func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTrAddr bool) (engineDevMap, error) {
-	// Extract transport addresses and device UUIDs from IDs string.
-	trAddrs, devUUIDs, err := extractReqIDs(svc.log, ids)
-	if err != nil {
-		return nil, err
+	trAddrs := make(idMap)
+	devUUIDs := make(idMap)
+	matchAll := false
+
+	if ids == "" {
+		// Selecting all is not supported unless using transport addresses.
+		if !useTrAddr {
+			return nil, errors.New("empty id string")
+		}
+		matchAll = true
+	} else {
+		// Extract transport addresses and device UUIDs from IDs string.
+		if err := extractReqIDs(svc.log, ids, trAddrs, devUUIDs); err != nil {
+			return nil, err
+		}
 	}
 
 	req := &ctlpb.SmdQueryReq{Rank: uint32(ranklist.NilRank)}
@@ -272,7 +301,8 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 			return nil, err
 		}
 		if len(engines) == 0 {
-			return nil, errors.Errorf("failed to retrieve instance for rank %d", rr.Rank)
+			return nil, errors.Errorf("failed to retrieve instance for rank %d",
+				rr.Rank)
 		}
 		engine := engines[0]
 		for _, dev := range rr.Devices {
@@ -283,24 +313,29 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 			if dds == nil {
 				return nil, errors.New("device with nil details in smd query resp")
 			}
+			if dds.TrAddr == "" {
+				svc.log.Errorf("No transport address associated with device %s",
+					dds.Uuid)
+			}
 
-			uuidMatch := dds.Uuid != "" && devUUIDs[dds.Uuid]
+			matchUUID := dds.Uuid != "" && devUUIDs[dds.Uuid]
+
 			// Where possible specify the TrAddr over UUID as there may be multiple
 			// UUIDs mapping to the same TrAddr.
 			if useTrAddr && dds.TrAddr != "" {
-				if trAddrs[dds.TrAddr] || uuidMatch {
+				if matchAll || matchUUID || trAddrs[dds.TrAddr] {
 					// If UUID matches, add by TrAddr rather than UUID which
 					// should avoid duplicate UUID entries for the same TrAddr.
-					edm[engine] = append(edm[engine], devID{trAddr: dds.TrAddr})
+					edm.add(engine, devID{trAddr: dds.TrAddr})
 					delete(trAddrs, dds.TrAddr)
 					delete(devUUIDs, dds.Uuid)
 					continue
 				}
 			}
 
-			if uuidMatch {
+			if matchUUID {
 				// Only add UUID entry if TrAddr is not available for a device.
-				edm[engine] = append(edm[engine], devID{uuid: dds.Uuid})
+				edm.add(engine, devID{uuid: dds.Uuid})
 				delete(devUUIDs, dds.Uuid)
 			}
 		}
@@ -337,14 +372,16 @@ func sendManageReq(c context.Context, e Engine, m drpc.Method, b proto.Message) 
 	}, nil
 }
 
-func addManageRespIDOnFail(log logging.Logger, res *ctlpb.SmdManageResp_Result, dev devID) {
-	if res.Status != 0 {
-		log.Errorf("drpc returned status %q on dev %+v", daos.Status(res.Status), dev)
-		if res.Device == nil {
-			// Populate id so failure can be mapped to a device.
-			res.Device = &ctlpb.SmdDevice{
-				TrAddr: dev.trAddr, Uuid: dev.uuid,
-			}
+func addManageRespIDOnFail(log logging.Logger, res *ctlpb.SmdManageResp_Result, dev *devID) {
+	if res == nil || dev == nil || res.Status == 0 {
+		return
+	}
+
+	log.Errorf("drpc returned status %q on dev %+v", daos.Status(res.Status), dev)
+	if res.Device == nil {
+		// Populate id so failure can be mapped to a device.
+		res.Device = &ctlpb.SmdDevice{
+			TrAddr: dev.trAddr, Uuid: dev.uuid,
 		}
 	}
 }
@@ -433,7 +470,7 @@ func (svc *ControlService) SmdManage(ctx context.Context, req *ctlpb.SmdManageRe
 			if err != nil {
 				return nil, errors.Wrap(err, msg)
 			}
-			addManageRespIDOnFail(svc.log, devRes, devs[0])
+			addManageRespIDOnFail(svc.log, devRes, devs.getFirst())
 			devResults = append(devResults, devRes)
 		case *ctlpb.SmdManageReq_Faulty:
 			if len(devs) != 1 {
@@ -445,11 +482,11 @@ func (svc *ControlService) SmdManage(ctx context.Context, req *ctlpb.SmdManageRe
 			if err != nil {
 				return nil, errors.Wrap(err, msg)
 			}
-			addManageRespIDOnFail(svc.log, devRes, devs[0])
+			addManageRespIDOnFail(svc.log, devRes, devs.getFirst())
 			devResults = append(devResults, devRes)
 		case *ctlpb.SmdManageReq_Led:
 			if len(devs) == 0 {
-				// TODO DAOS-12670: Enable all LEDs to be acted upon by default.
+				// Operate on all devices by default.
 				return nil, errors.New("led-manage request expects one or more IDs")
 			}
 			// Multiple addresses are supported in LED request.
@@ -466,7 +503,7 @@ func (svc *ControlService) SmdManage(ctx context.Context, req *ctlpb.SmdManageRe
 				if err != nil {
 					return nil, errors.Wrap(err, msg)
 				}
-				addManageRespIDOnFail(svc.log, devRes, dev)
+				addManageRespIDOnFail(svc.log, devRes, &dev)
 				devResults = append(devResults, devRes)
 			}
 		default:

--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -235,6 +235,7 @@ func extractReqIDs(log logging.Logger, ids string, addrs idMap, uuids idMap) err
 	return nil
 }
 
+// Union type containing either traddr or uuid.
 type devID struct {
 	trAddr string
 	uuid   string
@@ -250,10 +251,18 @@ func (id *devID) String() string {
 type devIDMap map[string]devID
 
 func (dim devIDMap) getFirst() *devID {
-	for _, id := range dim {
-		return &id
+	if len(dim) == 0 {
+		return nil
 	}
-	return nil
+
+	var keys []string
+	for key := range dim {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	d := dim[keys[0]]
+	return &d
 }
 
 type engineDevMap map[Engine]devIDMap

--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -672,7 +672,7 @@ ds_mgmt_dev_manage_led(Ctl__LedManageReq *req, Ctl__DevManageResp *resp)
 	if (resp->device->tr_addr == NULL)
 		return -DER_NOMEM;
 
-	if (strlen(req->ids) == 0) {
+	if (((req->ids) == NULL) || (strlen(req->ids) == 0)) {
 		D_ERROR("Transport address not provided in request\n");
 		return -DER_INVAL;
 	}


### PR DESCRIPTION
To make identifying multiple SSDs (or whole nodes in a rack) easy, all
SSDs on all hosts specified in the commandline or config file hostlist
will be selected if no identifiers are provided in the commandline
positional arguments. This changes applied to dmg storage led
(identify|check) commands.

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
