### PR TITLE
DAOS-14185 test: Randomize server ranks for soak extend

### DIFF
--- a/src/tests/ftest/util/soak_test_base.py
+++ b/src/tests/ftest/util/soak_test_base.py
@@ -598,9 +598,8 @@ class SoakTestBase(TestWithServers):
             if not single_test_pool and "extend-pool" in self.harassers + self.offline_harassers:
                 # create a pool excluding the ranks from the selected host
                 self.selected_host = self.random.choice(self.hostlist_servers)
-                selected_ranks = self.server_managers[0].get_host_ranks(self.selected_host)
-                server_ranks = self.server_managers[0].get_host_ranks(self.hostlist_servers)
-                ranks = [i for i in server_ranks if i not in selected_ranks]
+                ranks = self.server_managers[0].get_host_ranks(
+                    self.hostlist_servers - NodeSet(self.selected_host))
                 add_pools(self, ["pool_jobs"], ranks)
             elif not single_test_pool:
                 add_pools(self, ["pool_jobs"])

--- a/src/tests/ftest/util/soak_test_base.py
+++ b/src/tests/ftest/util/soak_test_base.py
@@ -79,7 +79,6 @@ class SoakTestBase(TestWithServers):
         self.soak_log_dir = None
         self.soak_dir = None
 
-
     def setUp(self):
         """Define test setup to be done."""
         self.log.info("<<setUp Started>> at %s", time.ctime())

--- a/src/tests/ftest/util/soak_test_base.py
+++ b/src/tests/ftest/util/soak_test_base.py
@@ -596,8 +596,11 @@ class SoakTestBase(TestWithServers):
                 self.harasser_results = {}
                 self.harassers, self.offline_harassers = get_harassers(harasser)
             if not single_test_pool and "extend-pool" in self.harassers + self.offline_harassers:
+                # create a pool excluding the ranks from the selected host
                 self.selected_host = random.choice(self.hostlist_servers)
-                ranks = self.server_managers[0].get_host_ranks(self.selected_host)
+                selected_ranks = self.server_managers[0].get_host_ranks(self.selected_host)
+                server_ranks = self.server_managers[0].get_host_ranks(self.hostlist_servers)
+                ranks = [i for i in server_ranks if i not in selected_ranks]
                 add_pools(self, ["pool_jobs"], ranks)
             elif not single_test_pool:
                 add_pools(self, ["pool_jobs"])

--- a/src/tests/ftest/util/soak_test_base.py
+++ b/src/tests/ftest/util/soak_test_base.py
@@ -74,6 +74,7 @@ class SoakTestBase(TestWithServers):
         self.slurm_exclude_servers = True
         self.control = get_local_host()
         self.enable_il = False
+        self.selected_host = None
 
     def setUp(self):
         """Define test setup to be done."""
@@ -595,7 +596,8 @@ class SoakTestBase(TestWithServers):
                 self.harasser_results = {}
                 self.harassers, self.offline_harassers = get_harassers(harasser)
             if not single_test_pool and "extend-pool" in self.harassers + self.offline_harassers:
-                ranks = self.server_managers[0].get_host_ranks(self.hostlist_servers[:-1])
+                self.selected_host = random.choice(self.hostlist_servers)
+                ranks = self.server_managers[0].get_host_ranks(self.selected_host)
                 add_pools(self, ["pool_jobs"], ranks)
             elif not single_test_pool:
                 add_pools(self, ["pool_jobs"])

--- a/src/tests/ftest/util/soak_test_base.py
+++ b/src/tests/ftest/util/soak_test_base.py
@@ -597,7 +597,7 @@ class SoakTestBase(TestWithServers):
                 self.harassers, self.offline_harassers = get_harassers(harasser)
             if not single_test_pool and "extend-pool" in self.harassers + self.offline_harassers:
                 # create a pool excluding the ranks from the selected host
-                self.selected_host = random.choice(self.hostlist_servers)
+                self.selected_host = self.random.choice(self.hostlist_servers)
                 selected_ranks = self.server_managers[0].get_host_ranks(self.selected_host)
                 server_ranks = self.server_managers[0].get_host_ranks(self.hostlist_servers)
                 ranks = [i for i in server_ranks if i not in selected_ranks]

--- a/src/tests/ftest/util/soak_utils.py
+++ b/src/tests/ftest/util/soak_utils.py
@@ -457,31 +457,29 @@ def launch_extend(self, pool, name, results, args):
     status = False
     params = {}
     ranks = None
-    selected_host = None
 
-    # pool was created with self.hostlist_servers[:-1]
-    selected_host = self.hostlist_servers[-1]
-    ranklist = self.server_managers[0].get_host_ranks(selected_host)
+    if self.selected_host:
+        ranklist = self.server_managers[0].get_host_ranks(self.selected_host)
 
-    # init the status dictionary
-    params = {"name": name,
-              "status": status,
-              "vars": {"host": selected_host, "ranks": ranks}}
-    self.log.info(
-        "<<<PASS %s: %s started on ranks %s at %s >>>\n", self.loop, name, ranks, time.ctime())
-    ranks = ",".join(str(rank) for rank in ranklist)
-    try:
-        pool.extend(ranks)
-        status = True
-    except TestFail as error:
-        self.log.error("<<<FAILED:dmg pool extend failed", exc_info=error)
-        status = False
-    if status:
-        status = wait_for_pool_rebuild(self, pool, name)
+        # init the status dictionary
+        params = {"name": name,
+                  "status": status,
+                  "vars": {"host": self.selected_host, "ranks": ranks}}
+        self.log.info(
+            "<<<PASS %s: %s started on ranks %s at %s >>>\n", self.loop, name, ranks, time.ctime())
+        ranks = ",".join(str(rank) for rank in ranklist)
+        try:
+            pool.extend(ranks)
+            status = True
+        except TestFail as error:
+            self.log.error("<<<FAILED:dmg pool extend failed", exc_info=error)
+            status = False
+        if status:
+            status = wait_for_pool_rebuild(self, pool, name)
 
     params = {"name": name,
               "status": status,
-              "vars": {"host": selected_host, "ranks": ranks}}
+              "vars": {"host": self.selected_host, "ranks": ranks}}
     if not status:
         self.log.error("<<< %s failed - check logs for failure data>>>", name)
     self.harasser_job_done(params)


### PR DESCRIPTION
The ranks used for the "dmg pool extend" harasser should be random and currently the test uses the same ranks throughout the test.    This PR will randomize the server used to get the ranks.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: soak_smoke

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
