### PR TITLE
DAOS-14101 control: Bump maximum number of retries for dev replace

### DIFF
--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -31,7 +31,7 @@ import (
 var (
 	baseDevReplaceBackoff      = 250 * time.Millisecond
 	maxDevReplaceBackoffFactor = 7 // 8s
-	maxDevReplaceRetries       = 5
+	maxDevReplaceRetries       = 20
 )
 
 func queryRank(reqRank uint32, engineRank ranklist.Rank) bool {


### PR DESCRIPTION
Increase the number of dRPC device replace retries made during dmg
storage replace nvme when DER_BUSY is returned because blobstore state
has not transitioned yet in SMD. This will prevent occasional command
failure when said state transitions take longer than usual when a host
is populated with a large number of devices or there is high load.

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
