### PR TITLE
Revert "DAOS-13239 cart: Fix send failure error mapping.."

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1309,17 +1309,7 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 		break;
 	default:
 		rpc_priv->crp_state = RPC_STATE_COMPLETED;
-
-		if (crt_is_service()) {
-			rc = crt_hgret_2_der(hg_cbinfo->ret);
-		} else {
-			if (hg_cbinfo->ret) {
-				rc = -DER_HG_SEND_FAILED;
-			} else {
-				rc = DER_SUCCESS;
-			}
-		}
-
+		rc = crt_hgret_2_der(hg_cbinfo->ret);
 		hg_ret = hg_cbinfo->ret;
 		RPC_TRACE(DB_NET, rpc_priv, "hg_cbinfo->ret: " DF_HG_RC ".\n",
 			  DP_HG_RC(hg_cbinfo->ret));

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -120,11 +120,11 @@ test_d_errstr(void **state)
 	/* Check the boundary at the end of the GURT error numbers, this will need updating if
 	 * additional error numbers are added.
 	 */
-	value = d_errstr(-DER_HG_SEND_FAILED);
-	assert_string_equal(value, "DER_HG_SEND_FAILED");
-	value = d_errstr(-1046);
-	assert_string_equal(value, "DER_HG_SEND_FAILED");
-	value = d_errstr(-(DER_HG_SEND_FAILED + 1));
+	value = d_errstr(-DER_HG_FATAL);
+	assert_string_equal(value, "DER_HG_FATAL");
+	value = d_errstr(-1045);
+	assert_string_equal(value, "DER_HG_FATAL");
+	value = d_errstr(-(DER_HG_FATAL + 1));
 	assert_string_equal(value, "DER_UNKNOWN");
 
 	/* Check the end of the DAOS error numbers. */

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -633,7 +633,7 @@ static inline bool
 daos_crt_network_error(int err)
 {
 	return err == -DER_HG || err == -DER_UNREACH || err == -DER_CANCELED ||
-	       err == -DER_NOREPLY || err == -DER_OOG || err == -DER_HG_SEND_FAILED;
+	       err == -DER_NOREPLY || err == -DER_OOG;
 }
 
 /** See crt_quiet_error. */

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -117,9 +117,7 @@ extern "C" {
 	/** Invalid user/group permissions.*/                                                      \
 	ACTION(DER_SHMEM_PERMS, Unable to access shared memory segment due to incompatible user or group permissions) \
 	/** Fatal (non-retry-able) transport layer mercury error */                                \
-	ACTION(DER_HG_FATAL, Fatal transport layer mercury error)                                  \
-        /** Failed to send rpc */                                                                  \
-        ACTION(DER_HG_SEND_FAILED, Failed to send rpc)
+	ACTION(DER_HG_FATAL, Fatal transport layer mercury error)
 	/** TODO: add more error numbers */
 
 /** Preprocessor macro defining DAOS errno values and internal definition of d_errstr */


### PR DESCRIPTION
Reverts daos-stack/daos#12199

Reverting to test DAOS-14182.

Test-tag: dfuse