### PR TITLE
DAOS-14163 cart: Do not access rpc after decref.

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -684,40 +684,16 @@ crt_req_destroy(struct crt_rpc_priv *rpc_priv)
 	crt_hg_req_destroy(rpc_priv);
 }
 
-int
+void
 crt_req_addref(crt_rpc_t *req)
 {
-	struct crt_rpc_priv	*rpc_priv;
-	int			rc = 0;
-
-	if (req == NULL) {
-		D_ERROR("invalid parameter (NULL req).\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	rpc_priv = container_of(req, struct crt_rpc_priv, crp_pub);
-	RPC_ADDREF(rpc_priv);
-
-out:
-	return rc;
+	RPC_PUB_ADDREF(req);
 }
 
-int
+void
 crt_req_decref(crt_rpc_t *req)
 {
-	struct crt_rpc_priv	*rpc_priv;
-	int			rc = 0;
-
-	if (req == NULL) {
-		D_ERROR("invalid parameter (NULL req).\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	rpc_priv = container_of(req, struct crt_rpc_priv, crp_pub);
-	RPC_DECREF(rpc_priv);
-
-out:
-	return rc;
+	RPC_PUB_DECREF(req);
 }
 
 static inline int

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -609,20 +609,23 @@ CRT_RPC_DECLARE(crt_ctl_log_add_msg, CRT_ISEQ_CTL_LOG_ADD_MSG,
  * Note that we conservatively use the default, strict memory order for both
  * RPC_ADDREF and RPC_DECREF, leaving relaxations to future work.
  */
-#define RPC_ADDREF(RPC) do {						\
-		int __ref;						\
-		__ref = atomic_fetch_add(&(RPC)->crp_refcount, 1);	\
-		D_ASSERTF(__ref != 0, "%p addref from zero\n", (RPC));	\
-		RPC_TRACE(DB_NET, RPC, "addref to %u.\n", __ref + 1);	\
+#define RPC_ADDREF(RPC)                                                                            \
+	do {                                                                                       \
+		int __ref;                                                                         \
+		__ref = atomic_fetch_add(&(RPC)->crp_refcount, 1);                                 \
+		D_ASSERTF(__ref != 0, "%p addref from zero\n", (RPC));                             \
+		RPC_TRACE(DB_NET, (RPC), "addref to %u.\n", __ref + 1);                            \
 	} while (0)
 
-#define RPC_DECREF(RPC) do {						\
-		int __ref;						\
-		__ref = atomic_fetch_sub(&(RPC)->crp_refcount, 1);	\
-		D_ASSERTF(__ref != 0, "%p decref from zero\n", (RPC));	\
-		RPC_TRACE(DB_NET, RPC, "decref to %u.\n", __ref - 1);	\
-		if (__ref == 1)						\
-			crt_req_destroy(RPC);				\
+/* Avoid the use of RPC_TRACE here as after the decref then RPC may no longer be valid */
+#define RPC_DECREF(RPC)                                                                            \
+	do {                                                                                       \
+		int __ref;                                                                         \
+		__ref = atomic_fetch_sub(&(RPC)->crp_refcount, 1);                                 \
+		D_ASSERTF(__ref != 0, "%p decref from zero\n", (RPC));                             \
+		D_DEBUG(DB_NET, "%p: decref to %u", (RPC), __ref - 1);                             \
+		if (__ref == 1)                                                                    \
+			crt_req_destroy(RPC);                                                      \
 	} while (0)
 
 #define RPC_PUB_ADDREF(RPC) do {					\

--- a/src/cart/crt_self_test_service.c
+++ b/src/cart/crt_self_test_service.c
@@ -488,9 +488,7 @@ void crt_self_test_msg_send_reply(crt_rpc_t *rpc_req,
 	 * Decrement the reference counter. This is where cleanup for the RPC
 	 * always happens.
 	 */
-	ret = crt_req_decref(rpc_req);
-	if (ret != 0)
-		D_ERROR("crt_req_decref failed; ret=%d\n", ret);
+	crt_req_decref(rpc_req);
 }
 
 int crt_self_test_msg_bulk_put_cb(const struct crt_bulk_cb_info *cb_info)
@@ -581,8 +579,7 @@ crt_self_test_msg_handler(crt_rpc_t *rpc_req)
 	 * Increment the reference counter for this RPC
 	 * It is decremented by crt_self_test_msg_send_reply
 	 */
-	ret = crt_req_addref(rpc_req);
-	D_ASSERT(ret == 0);
+	crt_req_addref(rpc_req);
 
 	/*
 	 * For messages that do not use bulk and have no reply data, skip

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -326,9 +326,8 @@ crt_req_get_timeout(crt_rpc_t *req, uint32_t *timeout_sec);
  *
  * \param[in] req              pointer to RPC request
  *
- * \return                     DER_SUCCESS on success, negative value if error
  */
-int
+void
 crt_req_addref(crt_rpc_t *req);
 
 /**
@@ -336,9 +335,8 @@ crt_req_addref(crt_rpc_t *req);
  *
  * \param[in] req              pointer to RPC request
  *
- * \return                     DER_SUCCESS on success, negative value if error
  */
-int
+void
 crt_req_decref(crt_rpc_t *req);
 
 /**

--- a/src/tests/ftest/cart/iv/iv_one_node.py
+++ b/src/tests/ftest/cart/iv/iv_one_node.py
@@ -1,8 +1,8 @@
-"""
+'''
   (C) Copyright 2018-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
-"""
+'''
 import time
 import tempfile
 import json
@@ -158,12 +158,7 @@ class CartIvOneNodeTest(CartTest):
 
                 # Read the result into test_result and remove the temp file
                 with open(log_path, 'r') as log_file:
-                    data = log_file.read()
-                    try:
-                        test_result = json.loads(data)
-                    except json.JSONDecodeError:
-                        print(data)
-                        raise
+                    test_result = json.load(log_file)
 
                 os.close(log_fd)
                 os.remove(log_path)
@@ -485,7 +480,7 @@ class CartIvOneNodeTest(CartTest):
             self._iv_test_actions(clicmd, actions)
         except ValueError as exception:
             failed = True
-            traceback.print_tb(exception)
+            traceback.print_stack()
             self.print("TEST FAILED: %s" % str(exception))
 
         # Shutdown Servers

--- a/src/tests/ftest/cart/iv/iv_one_node.py
+++ b/src/tests/ftest/cart/iv/iv_one_node.py
@@ -1,8 +1,8 @@
-'''
+"""
   (C) Copyright 2018-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
-'''
+"""
 import time
 import tempfile
 import json
@@ -158,7 +158,12 @@ class CartIvOneNodeTest(CartTest):
 
                 # Read the result into test_result and remove the temp file
                 with open(log_path, 'r') as log_file:
-                    test_result = json.load(log_file)
+                    data = log_file.read()
+                    try:
+                        test_result = json.load(data)
+                    except json.JSONDecodeError:
+                        print(data)
+                        raise
 
                 os.close(log_fd)
                 os.remove(log_path)
@@ -480,7 +485,7 @@ class CartIvOneNodeTest(CartTest):
             self._iv_test_actions(clicmd, actions)
         except ValueError as exception:
             failed = True
-            traceback.print_stack()
+            traceback.print_tb(exception)
             self.print("TEST FAILED: %s" % str(exception))
 
         # Shutdown Servers

--- a/src/tests/ftest/cart/iv/iv_one_node.py
+++ b/src/tests/ftest/cart/iv/iv_one_node.py
@@ -160,7 +160,7 @@ class CartIvOneNodeTest(CartTest):
                 with open(log_path, 'r') as log_file:
                     data = log_file.read()
                     try:
-                        test_result = json.load(data)
+                        test_result = json.loads(data)
                     except json.JSONDecodeError:
                         print(data)
                         raise

--- a/src/tests/ftest/cart/iv_client.c
+++ b/src/tests/ftest/cart/iv_client.c
@@ -68,8 +68,7 @@ test_iv_shutdown()
 {
 	struct RPC_SHUTDOWN_in	*input;
 	struct RPC_SHUTDOWN_out	*output;
-	crt_rpc_t		*rpc_req;
-	int			 rc;
+	crt_rpc_t               *rpc_req;
 
 	DBG_PRINT("Requesting rank %d shut down\n", g_server_ep.ep_rank);
 
@@ -84,8 +83,7 @@ test_iv_shutdown()
 		DBG_PRINT("Shutdown of rank %d FAILED; rc = %u\n",
 			  g_server_ep.ep_rank, output->rc);
 
-	rc = crt_req_decref(rpc_req);
-	assert(rc == 0);
+	crt_req_decref(rpc_req);
 }
 
 static int
@@ -159,7 +157,7 @@ test_iv_invalidate(struct iv_key_struct *key, char *arg_sync)
 		DBG_PRINT("Invalidate of key=[%d:%d] FAILED; rc = %d\n",
 			  key->rank, key->key_id, output->rc);
 
-	rc = crt_req_decref(rpc_req);
+	crt_req_decref(rpc_req);
 	D_FREE(sync);
 exit_code:
 	assert(rc == 0);
@@ -324,8 +322,7 @@ test_iv_fetch(struct iv_key_struct *key, FILE *log_file)
 	rc = crt_bulk_free(input->bulk_hdl);
 	assert(rc == 0);
 
-	rc = crt_req_decref(rpc_req);
-	assert(rc == 0);
+	crt_req_decref(rpc_req);
 
 	/* Frees the IOV buf also */
 	d_sgl_fini(&sg_list, true);
@@ -336,12 +333,12 @@ static int
 test_iv_update(struct iv_key_struct *key, char *str_value, bool value_is_hex,
 	       char *arg_sync)
 {
-	struct RPC_TEST_UPDATE_IV_in	*input;
-	struct RPC_TEST_UPDATE_IV_out	*output;
-	crt_rpc_t			*rpc_req;
-	size_t				 len;
-	int				 rc;
-	crt_iv_sync_t				*sync = NULL;
+	struct RPC_TEST_UPDATE_IV_in  *input;
+	struct RPC_TEST_UPDATE_IV_out *output;
+	crt_rpc_t                     *rpc_req;
+	size_t                         len;
+	int                            rc;
+	crt_iv_sync_t                 *sync = NULL;
 
 	rc = create_sync(arg_sync, &sync);
 	if (rc != 0) {
@@ -374,7 +371,7 @@ test_iv_update(struct iv_key_struct *key, char *str_value, bool value_is_hex,
 	else
 		DBG_PRINT("Update FAILED; rc = %ld\n", output->rc);
 
-	rc = crt_req_decref(rpc_req);
+	crt_req_decref(rpc_req);
 exit_code:
 	assert(rc == 0);
 	return 0;
@@ -404,8 +401,7 @@ test_iv_set_grp_version(char *arg_version, char *arg_timing)
 {
 	struct RPC_SET_GRP_VERSION_in		*input;
 	struct RPC_SET_GRP_VERSION_out		*output;
-	crt_rpc_t				*rpc_req;
-	int					 rc;
+	crt_rpc_t                               *rpc_req;
 	int					 version;
 	int					 time = 0;
 	char					*tmp;
@@ -446,20 +442,18 @@ test_iv_set_grp_version(char *arg_version, char *arg_timing)
 		DBG_PRINT("Grp Set Version FAILED 0x%x : %d\n",
 			  version, version);
 
-	rc = crt_req_decref(rpc_req);
+	crt_req_decref(rpc_req);
 
-	assert(rc == 0);
 	return 0;
 }
 
 static int
 test_iv_get_grp_version()
 {
-	struct RPC_GET_GRP_VERSION_in		*input;
-	struct RPC_GET_GRP_VERSION_out		*output;
-	crt_rpc_t				*rpc_req;
-	int					 rc;
-	int					 version = 0;
+	struct RPC_GET_GRP_VERSION_in  *input;
+	struct RPC_GET_GRP_VERSION_out *output;
+	crt_rpc_t                      *rpc_req;
+	int                             version = 0;
 
 	prepare_rpc_request(g_crt_ctx, RPC_GET_GRP_VERSION, &g_server_ep,
 			    (void **)&input, &rpc_req);
@@ -476,8 +470,7 @@ test_iv_get_grp_version()
 		DBG_PRINT("Grp Get Version PASSED 0x%08x : %d\n",
 			  version, version);
 
-	rc = crt_req_decref(rpc_req);
-	assert(rc == 0);
+	crt_req_decref(rpc_req);
 	return 0;
 }
 

--- a/src/tests/ftest/cart/iv_server.c
+++ b/src/tests/ftest/cart/iv_server.c
@@ -1084,8 +1084,7 @@ iv_get_grp_version(crt_rpc_t *rpc)
 int
 iv_test_fetch_iv(crt_rpc_t *rpc)
 {
-	struct RPC_TEST_FETCH_IV_in	*input;
-	int				 rc;
+	struct RPC_TEST_FETCH_IV_in *input;
 
 	DBG_ENTRY();
 	wait_for_namespace();
@@ -1095,8 +1094,7 @@ iv_test_fetch_iv(crt_rpc_t *rpc)
 
 	crt_req_addref(rpc);
 
-	rc = crt_iv_fetch(g_ivns, 0, &input->key, 0, 0, fetch_done, rpc);
-	assert(rc == 0);
+	crt_iv_fetch(g_ivns, 0, &input->key, 0, 0, fetch_done, rpc);
 
 	/*
 	 * Test break case:
@@ -1172,8 +1170,7 @@ int iv_test_invalidate_iv(crt_rpc_t *rpc)
 	crt_iv_key_t				*key;
 	struct invalidate_cb_info		*cb_info;
 	crt_iv_sync_t				 dsync = CRT_IV_SYNC_MODE_NONE;
-	crt_iv_sync_t				*sync = &dsync;
-	int					 rc;
+	crt_iv_sync_t                           *sync  = &dsync;
 
 	DBG_ENTRY();
 
@@ -1197,9 +1194,7 @@ int iv_test_invalidate_iv(crt_rpc_t *rpc)
 	if (input->iov_sync.iov_buf != NULL)
 		sync = (crt_iv_sync_t *)input->iov_sync.iov_buf;
 
-	rc = crt_iv_invalidate(g_ivns, 0, key, 0, CRT_IV_SHORTCUT_NONE,
-			       *sync, invalidate_done, cb_info);
-	assert(rc == 0);
+	crt_iv_invalidate(g_ivns, 0, key, 0, CRT_IV_SHORTCUT_NONE, *sync, invalidate_done, cb_info);
 	DBG_EXIT();
 	return 0;
 }

--- a/src/tests/ftest/cart/iv_server.c
+++ b/src/tests/ftest/cart/iv_server.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1199,6 +1199,7 @@ int iv_test_invalidate_iv(crt_rpc_t *rpc)
 
 	rc = crt_iv_invalidate(g_ivns, 0, key, 0, CRT_IV_SHORTCUT_NONE,
 			       *sync, invalidate_done, cb_info);
+	assert(rc == 0);
 	DBG_EXIT();
 	return 0;
 }

--- a/src/tests/ftest/cart/iv_server.c
+++ b/src/tests/ftest/cart/iv_server.c
@@ -717,8 +717,7 @@ init_iv(void)
 			assert(rc == 0);
 			assert(output->rc == 0);
 
-			rc = crt_req_decref(rpc);
-			assert(rc == 0);
+			crt_req_decref(rpc);
 		}
 	}
 }
@@ -800,8 +799,7 @@ static int fetch_bulk_put_cb(const struct crt_bulk_cb_info *cb_info)
 	rc = crt_reply_send(rpc);
 	assert(rc == 0);
 
-	rc = crt_req_decref(rpc);
-	assert(rc == 0);
+	crt_req_decref(rpc);
 
 	rc = crt_bulk_free(cb_info->bci_bulk_desc->bd_local_hdl);
 	assert(rc == 0);
@@ -905,8 +903,7 @@ fail_reply:
 	rc = crt_reply_send(rpc);
 	assert(rc == 0);
 
-	rc = crt_req_decref(rpc);
-	assert(rc == 0);
+	crt_req_decref(rpc);
 
 	return 0;
 }
@@ -939,8 +936,7 @@ update_done(crt_iv_namespace_t ivns, uint32_t class_id,
 	rc = crt_reply_send(cb_info->rpc);
 	assert(rc == 0);
 
-	rc = crt_req_decref(cb_info->rpc);
-	assert(rc == 0);
+	crt_req_decref(cb_info->rpc);
 
 	D_FREE(cb_info);
 
@@ -1005,8 +1001,7 @@ iv_test_update_iv(crt_rpc_t *rpc)
 	update_cb_info->key = key;
 	update_cb_info->rpc = rpc;
 
-	rc = crt_req_addref(rpc);
-	assert(rc == 0);
+	crt_req_addref(rpc);
 
 	rc = crt_iv_update(g_ivns, 0, key, 0, &iv_value, 0, *sync, update_done,
 			   update_cb_info);
@@ -1098,10 +1093,10 @@ iv_test_fetch_iv(crt_rpc_t *rpc)
 	input = crt_req_get(rpc);
 	assert(input != NULL);
 
-	rc = crt_req_addref(rpc);
-	assert(rc == 0);
+	crt_req_addref(rpc);
 
 	rc = crt_iv_fetch(g_ivns, 0, &input->key, 0, 0, fetch_done, rpc);
+	assert(rc == 0);
 
 	/*
 	 * Test break case:
@@ -1160,8 +1155,7 @@ invalidate_done(crt_iv_namespace_t ivns, uint32_t class_id,
 	rc = crt_reply_send(cb_info->rpc);
 	assert(rc == 0);
 
-	rc = crt_req_decref(cb_info->rpc);
-	assert(rc == 0);
+	crt_req_decref(cb_info->rpc);
 
 	D_FREE(cb_info->expect_key->iov_buf);
 	D_FREE(cb_info->expect_key);
@@ -1192,8 +1186,7 @@ int iv_test_invalidate_iv(crt_rpc_t *rpc)
 	key = alloc_key(key_struct->rank, key_struct->key_id);
 	assert(key != NULL);
 
-	rc = crt_req_addref(rpc);
-	assert(rc == 0);
+	crt_req_addref(rpc);
 
 	D_ALLOC_PTR(cb_info);
 	assert(cb_info != NULL);


### PR DESCRIPTION
Do not read the vales from RPC desc after decref.
Only log address in decref, not contents.
Change rpc addref and decref to be void functions.
  rc was only checked in test code.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
