### PR TITLE
DAOS-14169 rebuild: revert PR-12679

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -123,9 +123,6 @@ struct rebuild_global_pool_tracker {
 	/** rebuild status for each server */
 	struct rebuild_server_status *rgt_servers;
 
-	/** rebuild opcode */
-	daos_rebuild_opc_t	rgt_opc;
-
 	/** the current version being rebuilt */
 	uint32_t	rgt_rebuild_ver;
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -530,8 +530,6 @@ ds_rebuild_query(uuid_t pool_uuid, struct daos_rebuild_status *status)
 		}
 	} else {
 		memcpy(status, &rgt->rgt_status, sizeof(*status));
-		if (rgt->rgt_opc == RB_OP_RECLAIM)
-			status->rs_state = DRS_COMPLETED;
 		status->rs_version = rgt->rgt_rebuild_ver;
 		rgt_put(rgt);
 	}
@@ -545,16 +543,14 @@ ds_rebuild_query(uuid_t pool_uuid, struct daos_rebuild_status *status)
 		struct rebuild_task *task;
 
 		d_list_for_each_entry(task, &rebuild_gst.rg_queue_list, dst_list) {
-			if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0 &&
-			    task->dst_rebuild_op != RB_OP_RECLAIM) {
+			if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0) {
 				status->rs_state = DRS_IN_PROGRESS;
 				D_GOTO(out, rc);
 			}
 		}
 
 		d_list_for_each_entry(task, &rebuild_gst.rg_running_list, dst_list) {
-			if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0 &&
-			    task->dst_rebuild_op != RB_OP_RECLAIM) {
+			if (uuid_compare(task->dst_pool_uuid, pool_uuid) == 0) {
 				status->rs_state = DRS_IN_PROGRESS;
 				D_GOTO(out, rc);
 			}
@@ -748,8 +744,8 @@ rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 }
 
 static int
-rebuild_global_pool_tracker_create(struct ds_pool *pool, daos_rebuild_opc_t opc, uint32_t ver,
-				   uint32_t rebuild_gen, uint64_t leader_term, daos_epoch_t reclaim_eph,
+rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t rebuild_gen,
+				   uint64_t leader_term, daos_epoch_t reclaim_eph,
 				   struct rebuild_global_pool_tracker **p_rgt)
 {
 	struct rebuild_global_pool_tracker *rgt;
@@ -784,7 +780,6 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, daos_rebuild_opc_t opc,
 	rgt->rgt_servers_number = node_nr;
 
 	uuid_copy(rgt->rgt_pool_uuid, pool->sp_uuid);
-	rgt->rgt_opc = opc;
 	rgt->rgt_rebuild_ver = ver;
 	rgt->rgt_status.rs_version = ver;
 	rgt->rgt_leader_term = leader_term;
@@ -907,7 +902,7 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 	/* Create global rgt on leader to track the rebuild status */
 	if (*actions & REBUILD_TARGET) {
 		/* Update pool iv ns for the pool */
-		rc = rebuild_global_pool_tracker_create(pool, rebuild_op, rebuild_ver, rebuild_gen,
+		rc = rebuild_global_pool_tracker_create(pool, rebuild_ver, rebuild_gen,
 							leader_term, reclaim_eph, rgt);
 		if (rc)
 			D_ERROR("rebuild_global_pool_tracker create failed: rc %d\n", rc);

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -59,20 +59,9 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	}
 
 	for (i = 0; i < arg_cnt; i++) {
-		int retry = 0;
-
-		while(1) {
-			rc = dmg_pool_exclude(args[i]->dmg_config, args[i]->pool.pool_uuid,
-					      args[i]->group, rank, tgt_idx);
-			if (rc == -DER_BUSY && retry < 5) {
-				print_message("retry after 5 seconds\n");
-				sleep(5);
-				retry++;
-			} else {
-				assert_success(rc);
-				break;
-			}
-		}
+		rc = dmg_pool_exclude(args[i]->dmg_config, args[i]->pool.pool_uuid,
+				      args[i]->group, rank, tgt_idx);
+		assert_success(rc);
 	}
 }
 
@@ -91,22 +80,9 @@ rebuild_reint_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 
 	for (i = 0; i < args_cnt; i++) {
 		if (!args[i]->pool.destroyed) {
-			int retry = 0;
-
-			while (1) {
-				rc = dmg_pool_reintegrate(args[i]->dmg_config,
-							  args[i]->pool.pool_uuid,
-							  args[i]->group, rank, tgt_idx);
-				if (rc == -DER_BUSY && retry < 5) {
-					print_message("retry after 5 seconds\n");
-					sleep(5);
-					retry++;
-				} else {
-					assert_success(rc);
-					break;
-				}
-			}
-
+			rc = dmg_pool_reintegrate(args[i]->dmg_config, args[i]->pool.pool_uuid,
+						  args[i]->group, rank, tgt_idx);
+			assert_success(rc);
 		}
 		sleep(2);
 	}
@@ -121,21 +97,9 @@ rebuild_extend_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 
 	for (i = 0; i < args_cnt; i++) {
 		if (!args[i]->pool.destroyed) {
-			int retry = 0;
-
-			while (1) {
-				rc = dmg_pool_extend(args[i]->dmg_config,
-						     args[i]->pool.pool_uuid,
-						     args[i]->group, &rank, 1);
-				if (rc == -DER_BUSY && retry < 5) {
-					print_message("retry after 5 seconds\n");
-					sleep(5);
-					retry++;
-				} else {
-					assert_success(rc);
-					break;
-				}
-			}
+			rc = dmg_pool_extend(args[i]->dmg_config, args[i]->pool.pool_uuid,
+					     args[i]->group, &rank, 1);
+			assert_success(rc);
 		}
 		sleep(2);
 	}
@@ -149,22 +113,10 @@ rebuild_drain_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 	int rc = 0;
 
 	for (i = 0; i < args_cnt; i++) {
-		int retry = 0;
-
 		if (!args[i]->pool.destroyed) {
-			while (1) {
-				rc = dmg_pool_drain(args[i]->dmg_config,
-						    args[i]->pool.pool_uuid,
-						    args[i]->group, rank, tgt_idx);
-				if (rc == -DER_BUSY && retry < 5) {
-					print_message("retry after 5 seconds\n");
-					sleep(5);
-					retry++;
-				} else {
-					assert_success(rc);
-					break;
-				}
-			}
+			rc = dmg_pool_drain(args[i]->dmg_config, args[i]->pool.pool_uuid,
+					    args[i]->group, rank, tgt_idx);
+			assert_success(rc);
 		}
 		sleep(2);
 	}
@@ -450,23 +402,10 @@ rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank, int *failed_tgts,
 		int i;
 
 		for (i = 0; i < nr; i++) {
-			int retry = 0;
-
-			while (1) {
-				rc = dmg_pool_reintegrate(arg->dmg_config,
-							  arg->pool.pool_uuid,
-							  arg->group, failed_rank,
-							  failed_tgts ? failed_tgts[i] : -1);
-				if (rc == -DER_BUSY && retry < 5) {
-					print_message("retry after 5 seconds\n");
-					sleep(5);
-					retry++;
-				} else {
-					assert_success(rc);
-					break;
-				}
-
-			}
+			rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid,
+						  arg->group, failed_rank,
+						  failed_tgts ? failed_tgts[i] : -1);
+			assert_success(rc);
 		}
 	}
 	par_barrier(PAR_COMM_WORLD);


### PR DESCRIPTION
Revert PR-12679, since it regard "reclaim" phase as rebuild/upgrade complete, though this cause a lot rebuild operation DER-BUSY failure, let's revert this PR for now.

DAOS-13941 rebuild: reclaim phase should be marked as complete (#12679)

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
