### PR TITLE
DAOS-14101 control: Retry SMD manage request on DER_BUSY (#12779)

### DIFF
--- a/src/control/lib/daos/status.go
+++ b/src/control/lib/daos/status.go
@@ -26,6 +26,10 @@ func (ds Status) Error() string {
 	return fmt.Sprintf("%s(%d): %s", dErrStr, ds, dErrDesc)
 }
 
+func (ds Status) Int32() int32 {
+	return int32(ds)
+}
+
 const (
 	// Success indicates no error
 	Success Status = 0

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -465,11 +465,6 @@ func (svc *ControlService) SetEngineLogMasks(ctx context.Context, req *ctlpb.Set
 				idx, ei.Index())
 		}
 
-		if !ei.IsReady() {
-			resp.Errors[idx] = "not ready"
-			continue
-		}
-
 		if err := updateSetLogMasksReq(svc.srvCfg.Engines[idx], &eReq); err != nil {
 			resp.Errors[idx] = err.Error()
 			continue

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -995,8 +995,8 @@ func TestServer_CtlSvc_SetEngineLogMasks(t *testing.T) {
 			instancesStopped: true,
 			expResp: &ctlpb.SetLogMasksResp{
 				Errors: []string{
-					"not ready",
-					"not ready",
+					FaultDataPlaneNotStarted.Error(),
+					FaultDataPlaneNotStarted.Error(),
 				},
 			},
 		},

--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -238,7 +238,7 @@ type devID struct {
 	uuid   string
 }
 
-type engineDevMap map[*Engine][]devID
+type engineDevMap map[Engine][]devID
 
 // Map requested device IDs provided in comma-separated string to the engine that controls the given
 // device. Device can be identified either by UUID or transport (PCI) address.
@@ -258,14 +258,14 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 	edm := make(engineDevMap)
 
 	for _, rr := range resp.Ranks {
-		eis, err := svc.harness.FilterInstancesByRankSet(fmt.Sprintf("%d", rr.Rank))
+		engines, err := svc.harness.FilterInstancesByRankSet(fmt.Sprintf("%d", rr.Rank))
 		if err != nil {
 			return nil, err
 		}
-		if len(eis) == 0 {
+		if len(engines) == 0 {
 			return nil, errors.Errorf("failed to retrieve instance for rank %d", rr.Rank)
 		}
-		eisPtr := &eis[0]
+		engine := engines[0]
 		for _, dev := range rr.Devices {
 			if dev == nil {
 				return nil, errors.New("nil device in smd query resp")
@@ -282,7 +282,7 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 				if trAddrs[dds.TrAddr] || uuidMatch {
 					// If UUID matches, add by TrAddr rather than UUID which
 					// should avoid duplicate UUID entries for the same TrAddr.
-					edm[eisPtr] = append(edm[eisPtr], devID{trAddr: dds.TrAddr})
+					edm[engine] = append(edm[engine], devID{trAddr: dds.TrAddr})
 					delete(trAddrs, dds.TrAddr)
 					delete(devUUIDs, dds.Uuid)
 					continue
@@ -291,7 +291,7 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 
 			if uuidMatch {
 				// Only add UUID entry if TrAddr is not available for a device.
-				edm[eisPtr] = append(edm[eisPtr], devID{uuid: dds.Uuid})
+				edm[engine] = append(edm[engine], devID{uuid: dds.Uuid})
 				delete(devUUIDs, dds.Uuid)
 			}
 		}
@@ -306,8 +306,14 @@ func (svc *ControlService) mapIDsToEngine(ctx context.Context, ids string, useTr
 	return edm, nil
 }
 
-func sendManageReq(c context.Context, e *Engine, m drpc.Method, b proto.Message) (*ctlpb.SmdManageResp_Result, error) {
-	dResp, err := (*e).CallDrpc(c, m, b)
+func sendManageReq(c context.Context, e Engine, m drpc.Method, b proto.Message) (*ctlpb.SmdManageResp_Result, error) {
+	if !e.IsReady() {
+		return &ctlpb.SmdManageResp_Result{
+			Status: daos.Unreachable.Int32(),
+		}, nil
+	}
+
+	dResp, err := e.CallDrpc(c, m, b)
 	if err != nil {
 		return nil, errors.Wrap(err, "call drpc")
 	}
@@ -372,7 +378,7 @@ func (svc *ControlService) SmdManage(ctx context.Context, req *ctlpb.SmdManageRe
 	for engine, devs := range engineDevMap {
 		devResults := []*ctlpb.SmdManageResp_Result{}
 
-		rank, err := (*engine).GetRank()
+		rank, err := engine.GetRank()
 		if err != nil {
 			return nil, errors.Wrap(err, "retrieving engine rank")
 		}

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -511,7 +511,7 @@ func checkEnginesReady(instances []Engine) error {
 		if !inst.IsReady() {
 			var err error = FaultDataPlaneNotStarted
 			if inst.IsStarted() {
-				err = errInstanceNotReady
+				err = errEngineNotReady
 			}
 
 			return errors.Wrapf(err, "instance %d", inst.Index())

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -1440,7 +1440,7 @@ func TestServer_CtlSvc_StorageScan_PostEngineStart(t *testing.T) {
 					{Message: newBioHealthResp(2)},
 				},
 			},
-			expErr: errInstanceNotReady,
+			expErr: errEngineNotReady,
 		},
 		// Sometimes when more than a few ssds are assigned to engine without many targets,
 		// some of the smd entries for the latter ssds are in state "NEW" rather than

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -166,7 +166,7 @@ func (h *EngineHarness) CallDrpc(ctx context.Context, method drpc.Method, body p
 		}
 		// Don't trigger callbacks for these errors which can happen when
 		// things are still starting up.
-		if err == FaultHarnessNotStarted || err == errInstanceNotReady {
+		if err == FaultHarnessNotStarted || err == errEngineNotReady {
 			return
 		}
 
@@ -186,22 +186,10 @@ func (h *EngineHarness) CallDrpc(ctx context.Context, method drpc.Method, body p
 	// the first one that is available to service the request.
 	// If the request fails, that error will be returned.
 	for _, i := range h.Instances() {
-		if !i.IsReady() {
-			if i.IsStarted() {
-				if err == nil {
-					err = errInstanceNotReady
-				}
-			} else {
-				if err == nil {
-					err = FaultDataPlaneNotStarted
-				}
-			}
-			continue
-		}
 		resp, err = i.CallDrpc(ctx, method, body)
 
 		switch errors.Cause(err) {
-		case errDRPCNotReady, FaultDataPlaneNotStarted:
+		case errEngineNotReady, errDRPCNotReady, FaultDataPlaneNotStarted:
 			continue
 		default:
 			return

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -537,10 +537,11 @@ func TestServer_Harness_CallDrpc(t *testing.T) {
 		"instance not ready": {
 			mics: []*MockInstanceConfig{
 				{
-					Started: atm.NewBool(true),
+					Started:     atm.NewBool(true),
+					CallDrpcErr: errEngineNotReady,
 				},
 			},
-			expErr: errInstanceNotReady,
+			expErr: errEngineNotReady,
 		},
 		"harness not started": {
 			mics:       []*MockInstanceConfig{},

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -287,7 +287,7 @@ func (ei *EngineInstance) SetupRank(ctx context.Context, rank ranklist.Rank, map
 }
 
 func (ei *EngineInstance) callSetRank(ctx context.Context, rank ranklist.Rank, map_version uint32) error {
-	dresp, err := ei.CallDrpc(ctx, drpc.MethodSetRank, &mgmtpb.SetRankReq{Rank: rank.Uint32(), MapVersion: map_version})
+	dresp, err := ei.callDrpc(ctx, drpc.MethodSetRank, &mgmtpb.SetRankReq{Rank: rank.Uint32(), MapVersion: map_version})
 	if err != nil {
 		return err
 	}
@@ -355,7 +355,7 @@ func (ei *EngineInstance) GetTargetCount() int {
 }
 
 func (ei *EngineInstance) callSetUp(ctx context.Context) error {
-	dresp, err := ei.CallDrpc(ctx, drpc.MethodSetUp, nil)
+	dresp, err := ei.callDrpc(ctx, drpc.MethodSetUp, nil)
 	if err != nil {
 		return err
 	}

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -455,7 +455,7 @@ func (svc *mgmtSvc) poolCreate(parent context.Context, req *mgmtpb.PoolCreateReq
 		}
 
 		switch errors.Cause(err) {
-		case errInstanceNotReady:
+		case errEngineNotReady:
 			// If the pool create failed because there was no available instance
 			// to service the request, signal to the client that it should try again.
 			resp.Status = int32(daos.TryAgain)

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -251,7 +251,7 @@ func (svc *mgmtSvc) doGroupUpdate(ctx context.Context, forced bool) error {
 	svc.log.Debugf("group update request: version: %d, ranks: %s", req.MapVersion, rankSet)
 	dResp, err := svc.harness.CallDrpc(ctx, drpc.MethodGroupUpdate, req)
 	if err != nil {
-		if err == errInstanceNotReady {
+		if err == errEngineNotReady {
 			return err
 		}
 		svc.log.Errorf("dRPC GroupUpdate call failed: %s", err)


### PR DESCRIPTION
When calling dmg storage set nvme-faulty, device state transitions can take multiple seconds to propagate in engine-internal state machines. As a result, a subsequent call to dmg storage replace nvme call issued immediately after will return -DER_BUSY if state transitions are not complete. For convenience, this change allows the replace call to retry the drpc call internally if -DER_BUSY is received. The retry mechanism employed uses exponential backoff and a fixed retry limit.

Also fix two VMD-LED issues:
- Cancel identify timer when setting LED state.
- Set LED to OFF state when device is physically replaced.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
