### PR TITLE
DAOS-14216 build: Build fail if home is under /usr

### DIFF
--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -1334,7 +1334,9 @@ class _Component():
         rpath = ["$$ORIGIN"]
         norigin = []
         comp_path = self.component_prefix
-        if not comp_path or comp_path.startswith("/usr"):
+        if not comp_path:
+            return
+        if comp_path.startswith('/usr') and '/prereq/' not in comp_path:
             return
         if not os.path.exists(comp_path):
             return

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-(C) Copyright 2018-2022 Intel Corporation.
+(C) Copyright 2018-2023 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -38,6 +38,10 @@ def _supports_custom_format(clang_exe):
     if match and int(match.group(1)) >= MIN_FORMAT_VERSION:
         return True
 
+    match = re.search(r"google3\-trunk", output)
+    if match:
+        return True
+
     print(f'Custom .clang-format wants version {MIN_FORMAT_VERSION}+. Using Mozilla style.')
     return False
 
@@ -52,6 +56,10 @@ def _supports_correct_style(clang_exe):
         output = rawbytes.decode('utf-8')
     except subprocess.CalledProcessError:
         return False
+
+    match = re.search(r"google3\-trunk", output)
+    if match:
+        return True
 
     match = re.search(r'version ([\d+\.]+)', output)
     if match:

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-(C) Copyright 2018-2023 Intel Corporation.
+(C) Copyright 2018-2022 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -38,10 +38,6 @@ def _supports_custom_format(clang_exe):
     if match and int(match.group(1)) >= MIN_FORMAT_VERSION:
         return True
 
-    match = re.search(r"google3\-trunk", output)
-    if match:
-        return True
-
     print(f'Custom .clang-format wants version {MIN_FORMAT_VERSION}+. Using Mozilla style.')
     return False
 
@@ -56,10 +52,6 @@ def _supports_correct_style(clang_exe):
         output = rawbytes.decode('utf-8')
     except subprocess.CalledProcessError:
         return False
-
-    match = re.search(r"google3\-trunk", output)
-    if match:
-        return True
 
     match = re.search(r'version ([\d+\.]+)', output)
     if match:


### PR DESCRIPTION
The DAOS build will fail if a user builds prerequisites under /usr such as when the home directory is nested within.  This patch simply changes the check for
whether to patch rpath to continue if prereq is in the path for the binary in question.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
