### PR TITLE
DAOS-14158 pool: do not check iv valid for entry invalid

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -643,6 +643,7 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			if (rc)
 				D_GOTO(out, rc);
 		}
+		entry->iv_valid = false;
 	} else {
 		struct cont_iv_entry *iv_entry;
 

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -487,9 +487,8 @@ iv_on_update_internal(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 		D_GOTO(output, rc);
 	}
 
-	if (invalidate)
-		entry->iv_valid = false;
-	else
+	/* If the entry is being invalidate, then iv_valid is set inside the callback */
+	if (!invalidate)
 		entry->iv_valid = true;
 
 	D_DEBUG(DB_MD, "key id %d rank %d myrank %d valid %s\n",

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -928,11 +928,9 @@ pool_iv_ent_invalid(struct ds_iv_entry *entry, struct ds_iv_key *key)
 	struct ds_pool		*pool;
 	int			rc;
 
-	if (!entry->iv_valid)
-		return 0;
-
 	if (entry->iv_class->iv_class_id == IV_POOL_HDL) {
 		if (!uuid_is_null(iv_entry->piv_hdl.pih_cont_hdl)) {
+			entry->iv_valid = false;
 			rc = ds_pool_lookup(entry->ns->iv_pool_uuid, &pool);
 			if (rc) {
 				if (rc == -DER_NONEXIST)


### PR DESCRIPTION
It does not need to check invalid entry in pool_iv_ent_invalid(), because disconnection will remove entry locally on all nodes, so the entry is not really invalid, otherwise, disconnect handles will be left in the IV cache, then during extend, these handles might be fetched by the new rank incorrectly.

Move iv_valid check into the callback, because in some cases, if invalidate only invalid a single item under one entry, for example disconnect handle, it does not need set the entry to be invalid.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
