### PR TITLE
amd/logging system

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1117,8 +1117,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 			rpc_pub->cr_ep.ep_grp = NULL;
 			/* TODO lookup by rpc_priv->crp_req_hdr.cch_grp_id */
 		} else {
-			D_ERROR("_unpack_body failed, rc: %d, opc: %#x.\n",
-				rc, rpc_pub->cr_opc);
+			DHL_ERROR(rpc_priv, rc, "_unpack_body failed, opc: %#x", rpc_pub->cr_opc);
 			crt_hg_reply_error_send(rpc_priv, -DER_MISC);
 			D_GOTO(decref, hg_ret = HG_SUCCESS);
 		}

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -117,24 +117,21 @@ mem_pin_workaround(void)
 	/* Disable fastbins; this option is not available on all systems */
 	rc = mallopt(M_MXFAST, 0);
 	if (rc != 1)
-		D_WARN("Failed to disable malloc fastbins: %d (%s)\n", errno, strerror(errno));
+		DS_WARN(errno, "Failed to disable malloc fastbins");
 
 	rc = getrlimit(RLIMIT_MEMLOCK, &rlim);
 	if (rc != 0) {
-		D_WARN("getrlimit() failed; errno=%d (%s)\n",
-		       errno, strerror(errno));
+		DS_WARN(errno, "getrlimit() failed");
 		goto exit;
 	}
 
-	if (rlim.rlim_cur == RLIM_INFINITY &&
-	    rlim.rlim_max == RLIM_INFINITY) {
+	if (rlim.rlim_cur == RLIM_INFINITY && rlim.rlim_max == RLIM_INFINITY) {
 		D_INFO("Infinite rlimit detected; performing mlockall()\n");
 
 		/* Lock all pages */
 		rc = mlockall(MCL_CURRENT | MCL_FUTURE);
 		if (rc)
-			D_WARN("Failed to mlockall(); errno=%d (%s)\n",
-			       errno, strerror(errno));
+			DS_WARN(errno, "mlockall() failed");
 
 	} else {
 		D_INFO("mlockall() skipped\n");
@@ -1068,7 +1065,7 @@ crt_na_fill_ip_addr(struct crt_na_config *na_cfg)
 
 	rc = getifaddrs(&if_addrs);
 	if (rc != 0) {
-		D_ERROR("cannot getifaddrs, errno: %d(%s).\n", errno, strerror(errno));
+		DS_ERROR(rc, "getifaddrs() failed");
 		D_GOTO(out, rc = -DER_PROTO);
 	}
 
@@ -1085,7 +1082,7 @@ crt_na_fill_ip_addr(struct crt_na_config *na_cfg)
 			tmp_ptr = &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
 			ip_str = inet_ntop(AF_INET, tmp_ptr, na_cfg->noc_ip_str, INET_ADDRSTRLEN);
 			if (ip_str == NULL) {
-				D_ERROR("inet_ntop errno: %d(%s).\n", errno, strerror(errno));
+				DS_ERROR(errno, "inet_ntop() failed");
 				freeifaddrs(if_addrs);
 				D_GOTO(out, rc = -DER_PROTO);
 			}

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2353,7 +2353,7 @@ exit:
 			D_FREE(iv_sync_cb->isc_iv_key.iov_buf);
 			D_FREE(iv_sync_cb);
 		}
-		if (corpc_req)
+		if (corpc_req != NULL)
 			RPC_PUB_DECREF(corpc_req);
 	}
 	return rc;

--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -60,7 +60,7 @@ crt_swim_csm_lock(struct crt_swim_membs *csm)
 
 	rc = D_SPIN_LOCK(&csm->csm_lock);
 	if (rc != 0)
-		D_ERROR("D_SPIN_LOCK(): %s\n", strerror(rc));
+		DS_ERROR(rc, "D_SPIN_LOCK()");
 }
 
 static inline void
@@ -70,7 +70,7 @@ crt_swim_csm_unlock(struct crt_swim_membs *csm)
 
 	rc = D_SPIN_UNLOCK(&csm->csm_lock);
 	if (rc != 0)
-		D_ERROR("D_SPIN_UNLOCK(): %s\n", strerror(rc));
+		DS_ERROR(rc, "D_SPIN_UNLOCK()");
 }
 
 static inline uint32_t

--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -53,7 +53,7 @@ dfuse_cont_lookup(fuse_req_t req, struct dfuse_inode_entry *parent, const char *
 		/* Update the stat information, but copy in the inode value afterwards. */
 		rc = dfs_ostat(ie->ie_dfs->dfs_ns, ie->ie_obj, &entry.attr);
 		if (rc) {
-			DFUSE_TRA_ERROR(ie, "dfs_ostat() failed: (%s)", strerror(rc));
+			DHS_ERROR(ie, rc, "dfs_ostat() failed");
 			D_GOTO(decref, rc);
 		}
 
@@ -77,7 +77,7 @@ dfuse_cont_lookup(fuse_req_t req, struct dfuse_inode_entry *parent, const char *
 
 	rc = dfs_lookup(dfc->dfs_ns, "/", O_RDWR, &ie->ie_obj, NULL, &ie->ie_stat);
 	if (rc) {
-		DFUSE_TRA_ERROR(ie, "dfs_lookup() failed: (%s)", strerror(rc));
+		DHS_ERROR(ie, rc, "dfs_lookup() failed");
 		D_GOTO(close, rc);
 	}
 

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -358,13 +358,13 @@ _ch_free(struct dfuse_info *dfuse_info, struct dfuse_cont *dfc)
 
 		rc = dfs_umount(dfc->dfs_ns);
 		if (rc != 0)
-			DFUSE_TRA_ERROR(dfc, "dfs_umount() failed: %d (%s)", rc, strerror(rc));
+			DHS_ERROR(dfc, rc, "dfs_umount() failed");
 
 		rc = daos_cont_close(dfc->dfs_coh, NULL);
 		if (rc == -DER_NOMEM)
 			rc = daos_cont_close(dfc->dfs_coh, NULL);
 		if (rc != 0)
-			DFUSE_TRA_ERROR(dfc, "daos_cont_close() failed, " DF_RC, DP_RC(rc));
+			DHL_ERROR(dfc, rc, "daos_cont_close() failed");
 	}
 
 	atomic_fetch_sub_relaxed(&dfuse_info->di_container_count, 1);
@@ -716,7 +716,7 @@ dfuse_cont_open_by_label(struct dfuse_info *dfuse_info, struct dfuse_pool *dfp, 
 
 	rc = dfs_mount(dfp->dfp_poh, dfc->dfs_coh, dfs_flags, &dfc->dfs_ns);
 	if (rc) {
-		DFUSE_TRA_ERROR(dfc, "dfs_mount() failed: %d (%s)", rc, strerror(rc));
+		DHS_ERROR(dfc, rc, "dfs_mount failed");
 		D_GOTO(err_close, rc);
 	}
 
@@ -839,7 +839,7 @@ dfuse_cont_open(struct dfuse_info *dfuse_info, struct dfuse_pool *dfp, uuid_t *c
 		}
 		rc = dfs_mount(dfp->dfp_poh, dfc->dfs_coh, dfs_flags, &dfc->dfs_ns);
 		if (rc) {
-			DFUSE_TRA_ERROR(dfc, "dfs_mount() failed: %d (%s)", rc, strerror(rc));
+			DHS_ERROR(dfc, rc, "dfs mount() failed");
 			D_GOTO(err_close, rc);
 		}
 
@@ -1140,7 +1140,7 @@ dfuse_ie_close(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 	if (ie->ie_obj) {
 		rc = dfs_release(ie->ie_obj);
 		if (rc)
-			DFUSE_TRA_ERROR(ie, "dfs_release() failed: %d (%s)", rc, strerror(rc));
+			DHS_ERROR(ie, rc, "dfs_release() failed");
 	}
 
 	if (ie->ie_root) {
@@ -1290,7 +1290,7 @@ dfuse_fs_start(struct dfuse_info *fs_handle, struct dfuse_cont *dfs)
 	if (dfs->dfs_ops == &dfuse_dfs_ops) {
 		rc = dfs_lookup(dfs->dfs_ns, "/", O_RDWR, &ie->ie_obj, NULL, &ie->ie_stat);
 		if (rc) {
-			DFUSE_TRA_ERROR(ie, "dfs_lookup() failed: %d (%s)", rc, strerror(rc));
+			DHS_ERROR(ie, rc, "dfs_lookup() failed");
 			D_GOTO(err_ie, rc = daos_errno2der(rc));
 		}
 	} else {
@@ -1380,11 +1380,11 @@ ino_flush(d_list_t *rlink, void *arg)
 	rc = fuse_lowlevel_notify_inval_entry(dfuse_info->di_session, ie->ie_parent, ie->ie_name,
 					      strlen(ie->ie_name));
 	if (rc != 0 && rc != -EBADF)
-		DFUSE_TRA_WARNING(ie, "%#lx %#lx " DF_DE ": %d %s", ie->ie_parent,
-				  ie->ie_stat.st_ino, DP_DE(ie->ie_name), rc, strerror(-rc));
+		DHS_WARN(ie, -rc, "%#lx %#lx " DF_DE, ie->ie_parent, ie->ie_stat.st_ino,
+			 DP_DE(ie->ie_name));
 	else
-		DFUSE_TRA_INFO(ie, "%#lx %#lx " DF_DE ": %d %s", ie->ie_parent, ie->ie_stat.st_ino,
-			       DP_DE(ie->ie_name), rc, strerror(-rc));
+		DHS_INFO(ie, -rc, "%#lx %#lx " DF_DE, ie->ie_parent, ie->ie_stat.st_ino,
+			 DP_DE(ie->ie_name));
 
 	/* If the FUSE connection is dead then do not traverse further, it
 	 * doesn't matter what gets returned here, as long as it's negative

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -202,8 +202,7 @@ dfuse_launch_fuse(struct dfuse_info *dfuse_info, struct fuse_args *args)
 	else
 		rc = fuse_session_loop(dfuse_info->di_session);
 	if (rc != 0)
-		DFUSE_TRA_ERROR(dfuse_info,
-				"Fuse loop exited with return code: %d (%s)", rc, strerror(rc));
+		DHS_ERROR(dfuse_info, rc, "Fuse loop exited");
 
 	fuse_session_unmount(dfuse_info->di_session);
 
@@ -584,8 +583,7 @@ main(int argc, char **argv)
 		}
 
 		rc = duns_resolve_path(path, &path_attr);
-		DFUSE_TRA_INFO(dfuse_info, "duns_resolve_path() on path: %d (%s)", rc,
-			       strerror(rc));
+		DHS_INFO(dfuse_info, rc, "duns_resolve_path() on path");
 		if (rc == ENOENT) {
 			printf("Attr path does not exist\n");
 			D_GOTO(out_daos, rc = daos_errno2der(rc));

--- a/src/common/drpc.c
+++ b/src/common/drpc.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -275,26 +275,6 @@ unixcomm_listen(char *sockaddr, int flags, struct unixcomm **newcommp)
 	return 0;
 }
 
-static struct unixcomm *
-unixcomm_accept(struct unixcomm *listener)
-{
-	struct unixcomm *comm;
-
-	D_ALLOC_PTR(comm);
-	if (comm == NULL)
-		return NULL;
-
-	comm->fd = accept(listener->fd, NULL, NULL);
-	if (comm->fd < 0) {
-		D_ERROR("Failed to accept connection on listener fd %d, "
-			"errno=%d\n", listener->fd, errno);
-		D_FREE(comm);
-		return NULL;
-	}
-
-	return comm;
-}
-
 static int
 unixcomm_send(struct unixcomm *hndl, uint8_t *buffer, size_t buflen,
 		ssize_t *sent)
@@ -538,13 +518,13 @@ drpc_is_valid_listener(struct drpc *ctx)
  * Wait for a client to connect to a listening drpc context, and return the
  * context for the client's session.
  *
- * \param	ctx	drpc context created by drpc_listen()
+ * \param[in]	ctx	drpc context created by drpc_listen()
+ * \param[out]  drpc    New drpc context;
  *
- * \return	new drpc context for the accepted client session, or
- *			NULL if failed to get one
+ * \return		daos errno
  */
-struct drpc *
-drpc_accept(struct drpc *listener_ctx)
+int
+drpc_accept(struct drpc *listener_ctx, struct drpc **drpc)
 {
 	struct drpc	*session_ctx;
 	struct unixcomm	*comm;
@@ -556,16 +536,28 @@ drpc_accept(struct drpc *listener_ctx)
 
 	D_ALLOC_PTR(session_ctx);
 	if (session_ctx == NULL)
-		return NULL;
+		return -DER_NOMEM;
 
-	comm = unixcomm_accept(listener_ctx->comm);
+	D_ALLOC_PTR(comm);
 	if (comm == NULL) {
 		D_FREE(session_ctx);
-		return NULL;
+		return -DER_NOMEM;
+	}
+
+	comm->fd = accept(listener_ctx->comm->fd, NULL, NULL);
+	if (comm->fd < 0) {
+		int rc = daos_errno2der(errno);
+
+		DL_ERROR(rc, "Failed to accept connection on listener fd %d",
+			 listener_ctx->comm->fd);
+		D_FREE(comm);
+		D_FREE(session_ctx);
+		return rc;
 	}
 
 	init_drpc_ctx(session_ctx, comm, listener_ctx->handler);
-	return session_ctx;
+	*drpc = session_ctx;
+	return 0;
 }
 
 static int

--- a/src/common/drpc.c
+++ b/src/common/drpc.c
@@ -531,7 +531,7 @@ drpc_accept(struct drpc *listener_ctx, struct drpc **drpc)
 
 	if (!drpc_is_valid_listener(listener_ctx)) {
 		D_ERROR("dRPC context is not a listener\n");
-		return NULL;
+		return -DER_INVAL;
 	}
 
 	D_ALLOC_PTR(session_ctx);

--- a/src/common/tests/drpc_tests.c
+++ b/src/common/tests/drpc_tests.c
@@ -491,7 +491,7 @@ test_drpc_accept_fails_if_accept_fails(void **state)
 	accept_return = -1;
 
 	rc = drpc_accept(ctx, NULL);
-	assert_rc_equal(rc, -DER_INVAL);
+	assert_rc_equal(rc, -DER_NONEXIST);
 
 	free_drpc(ctx);
 }

--- a/src/common/tests/drpc_tests.c
+++ b/src/common/tests/drpc_tests.c
@@ -434,17 +434,22 @@ test_drpc_listen_fails_if_listen_fails(void **state)
 static void
 test_drpc_accept_fails_with_null_ctx(void **state)
 {
-	assert_null(drpc_accept(NULL));
+	int rc;
+
+	rc = drpc_accept(NULL, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
 }
 
 static void
 test_drpc_accept_fails_with_null_handler(void **state)
 {
 	struct drpc *ctx = new_drpc_with_fd(15);
+	int          rc;
 
 	ctx->handler = NULL;
 
-	assert_null(drpc_accept(ctx));
+	rc = drpc_accept(ctx, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
 
 	free_drpc(ctx);
 }
@@ -452,10 +457,12 @@ test_drpc_accept_fails_with_null_handler(void **state)
 static void
 test_drpc_accept_success(void **state)
 {
-	struct drpc	*ctx = new_drpc_with_fd(15);
-	struct drpc	*session_ctx;
+	struct drpc *ctx = new_drpc_with_fd(15);
+	struct drpc *session_ctx;
+	int          rc;
 
-	session_ctx = drpc_accept(ctx);
+	rc = drpc_accept(ctx, &session_ctx);
+	assert_rc_equal(rc, -DER_SUCCESS);
 
 	/* got context back for the new accepted connection */
 	assert_non_null(session_ctx);
@@ -479,10 +486,12 @@ static void
 test_drpc_accept_fails_if_accept_fails(void **state)
 {
 	struct drpc *ctx = new_drpc_with_fd(15);
+	int          rc;
 
 	accept_return = -1;
 
-	assert_null(drpc_accept(ctx));
+	rc = drpc_accept(ctx, NULL);
+	assert_rc_equal(rc, -DER_INVAL);
 
 	free_drpc(ctx);
 }

--- a/src/common/tests/drpc_tests.c
+++ b/src/common/tests/drpc_tests.c
@@ -488,10 +488,10 @@ test_drpc_accept_fails_if_accept_fails(void **state)
 	struct drpc *ctx = new_drpc_with_fd(15);
 	int          rc;
 
-	accept_return = -1;
+	accept_return = -EIO;
 
 	rc = drpc_accept(ctx, NULL);
-	assert_rc_equal(rc, -DER_NONEXIST);
+	assert_rc_equal(rc, -DER_IO);
 
 	free_drpc(ctx);
 }

--- a/src/common/tests/test_mocks.c
+++ b/src/common/tests/test_mocks.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -196,8 +196,10 @@ __wrap_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 	accept_addr_ptr = addr;
 	accept_addrlen_ptr = addrlen;
 	accept_call_count++;
-	if (accept_return < 0)
-		errno = EIO;
+	if (accept_return < 0) {
+		errno = -accept_return;
+		return -1;
+	}
 	return accept_return;
 }
 

--- a/src/common/tests/test_mocks.c
+++ b/src/common/tests/test_mocks.c
@@ -196,6 +196,8 @@ __wrap_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 	accept_addr_ptr = addr;
 	accept_addrlen_ptr = addrlen;
 	accept_call_count++;
+	if (accept_return < 0)
+		errno = EIO;
 	return accept_return;
 }
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -345,8 +345,8 @@ get_metadata_times(struct rdb_tx *tx, struct cont *cont, bool update_otime, bool
 
 		rc = rdb_tx_update(tx, &cont->c_prop, &ds_cont_prop_co_md_times, &value);
 		if (rc != 0) {
-			D_ERROR(DF_CONT": failed to update metadata times, "DF_RC"\n",
-				DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+			DL_ERROR(rc, DF_CONT ": failed to update metadata times",
+				 DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
 			goto out;
 		}
 	}
@@ -525,8 +525,8 @@ get_nhandles(struct rdb_tx *tx, struct d_hash_table *nhc, struct cont *cont, enu
 		d_iov_set(&value, &result, sizeof(result));
 		rc = rdb_tx_update(tx, &cont->c_prop, &ds_cont_prop_nhandles, &value);
 		if (rc != 0) {
-			D_ERROR(DF_CONT": rdb_tx_update nhandles failed, "DF_RC"\n",
-				DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), DP_RC(rc));
+			DL_ERROR(rc, DF_CONT ": rdb_tx_update nhandles failed",
+				 DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
 			goto out;
 		}
 
@@ -1111,9 +1111,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	d_iov_set(&value, &ghce, sizeof(ghce));
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_ghce, &value);
 	if (rc != 0) {
-		D_ERROR(DF_CONT": create ghce property failed: "DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid), DP_RC(rc));
+		DL_ERROR(rc, DF_CONT ": create ghce property failed",
+			 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
 		D_GOTO(out_kvs, rc);
 	}
 
@@ -1121,9 +1120,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	d_iov_set(&value, &alloced_oid, sizeof(alloced_oid));
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_alloced_oid, &value);
 	if (rc != 0) {
-		D_ERROR(DF_CONT": create alloced_oid prop failed: "DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid,
-				in->cci_op.ci_uuid), DP_RC(rc));
+		DL_ERROR(rc, DF_CONT ": create alloced_oid prop failed",
+			 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
 		D_GOTO(out_kvs, rc);
 	}
 
@@ -1136,9 +1134,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		d_iov_set(&value, &mdtimes, sizeof(mdtimes));
 		rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_co_md_times, &value);
 		if (rc != 0) {
-			D_ERROR(DF_CONT": create co_md_times failed: "DF_RC"\n",
-				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid),
-				DP_RC(rc));
+			DL_ERROR(rc, DF_CONT ": create co_md_times failed",
+				 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
 			D_GOTO(out_kvs, rc);
 		}
 		D_DEBUG(DB_MD, DF_CONT": set metadata times: open="DF_X64", modify="DF_X64"\n",
@@ -1153,9 +1150,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		d_iov_set(&value, &nhandles, sizeof(nhandles));
 		rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_nhandles, &value);
 		if (rc != 0) {
-			D_ERROR(DF_CONT": create nhandles failed: "DF_RC"\n",
-				DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid),
-				DP_RC(rc));
+			DL_ERROR(rc, DF_CONT ": create nhandles failed",
+				 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
 			goto out_kvs;
 		}
 	}
@@ -1178,9 +1174,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		d_iov_set(&value, in->cci_op.ci_uuid, sizeof(uuid_t));
 		rc = rdb_tx_update(tx, &svc->cs_uuids, &key, &value);
 		if (rc != 0) {
-			D_ERROR(DF_CONT": update cs_uuids failed: "DF_RC"\n",
-				DP_CONT(pool_hdl->sph_pool->sp_uuid,
-					in->cci_op.ci_uuid), DP_RC(rc));
+			DL_ERROR(rc, DF_CONT ": update cs_uuids failed",
+				 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
 			D_GOTO(out_kvs, rc);
 		}
 		D_DEBUG(DB_MD, DF_CONT": creating container, label: %s\n",
@@ -1191,8 +1186,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	d_iov_set(&value, &nsnapshots, sizeof(nsnapshots));
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_nsnapshots, &value);
 	if (rc != 0) {
-		D_ERROR(DF_CONT": failed to update nsnapshots, "DF_RC"\n",
-			DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), DP_RC(rc));
+		DL_ERROR(rc, DF_CONT ": failed to update nsnapshots",
+			 DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid));
 		D_GOTO(out_kvs, rc);
 	}
 	attr.dsa_class = RDB_KVS_INTEGER;
@@ -2322,8 +2317,8 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 				 cont->c_uuid, prop, true);
 	daos_prop_free(prop);
 	if (rc != 0) {
-		D_ERROR(DF_CONT": cont_iv_prop_update failed %d.\n",
-			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
+		DL_ERROR(rc, DF_CONT ": cont_iv_prop_update failed",
+			 DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
 		D_GOTO(out, rc);
 	}
 
@@ -2332,8 +2327,8 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 				       in->coi_op.ci_hdl, cont->c_uuid,
 				       in->coi_flags, sec_capas, stat_pm_ver);
 	if (rc != 0) {
-		D_ERROR(DF_CONT": cont_iv_capability_update failed %d.\n",
-			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
+		DL_ERROR(rc, DF_CONT ": cont_iv_capability_update failed",
+			 DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
 		D_GOTO(out, rc);
 	}
 	cont_hdl_opened = true;
@@ -3575,8 +3570,7 @@ check_set_prop_label(struct rdb_tx *tx, struct ds_pool *pool, struct cont *cont,
 	d_iov_set(&val, cont->c_uuid, sizeof(uuid_t));
 	rc = rdb_tx_update(tx, &cont->c_svc->cs_uuids, &key, &val);
 	if (rc != 0) {
-		D_ERROR(DF_UUID": update cs_uuids failed: "DF_RC"\n",
-			DP_UUID(cont->c_uuid), DP_RC(rc));
+		DL_ERROR(rc, DF_UUID ": update cs_uuids failed", DP_UUID(cont->c_uuid));
 		return rc;
 	}
 	D_DEBUG(DB_MD, DF_UUID": inserted new label in cs_uuids KVS: %s\n",
@@ -4524,8 +4518,8 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		rc = rdb_tx_update(ap->tx, &cont->c_prop,
 				   &ds_cont_prop_cont_obj_version, &value);
 		if (rc) {
-			D_ERROR("failed to upgrade container obj version pool/cont: "DF_CONTF"\n",
-				DP_CONT(ap->pool_uuid, cont_uuid));
+			DL_ERROR(rc, "failed to upgrade container obj version pool/cont: " DF_CONTF,
+				 DP_CONT(ap->pool_uuid, cont_uuid));
 			goto out;
 		}
 		upgraded = true;
@@ -4581,8 +4575,8 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	rc = rdb_tx_update(ap->tx, &cont->c_prop,
 			   &ds_cont_prop_cont_global_version, &value);
 	if (rc) {
-		D_ERROR("failed to upgrade container global version pool/cont: "DF_CONTF"\n",
-			DP_CONT(ap->pool_uuid, cont_uuid));
+		DL_ERROR(rc, "failed to upgrade container global version pool/cont: " DF_CONTF,
+			 DP_CONT(ap->pool_uuid, cont_uuid));
 		goto out;
 	}
 
@@ -4607,11 +4601,10 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	entry->dpe_flags &= ~DAOS_PROP_ENTRY_NOT_SET;
 	obj_ver = DS_POOL_OBJ_VERSION;
 	d_iov_set(&value, &obj_ver, sizeof(obj_ver));
-	rc = rdb_tx_update(ap->tx, &cont->c_prop,
-			   &ds_cont_prop_cont_obj_version, &value);
+	rc = rdb_tx_update(ap->tx, &cont->c_prop, &ds_cont_prop_cont_obj_version, &value);
 	if (rc) {
-		D_ERROR("failed to upgrade container obj version pool/cont: "DF_CONTF"\n",
-			DP_CONT(ap->pool_uuid, cont_uuid));
+		DL_ERROR(rc, "failed to upgrade container obj version pool/cont: " DF_CONTF,
+			 DP_CONT(ap->pool_uuid, cont_uuid));
 		goto out;
 	}
 
@@ -4624,11 +4617,10 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		goto out;
 	if (rc == -DER_NONEXIST) {
 		pda = DAOS_PROP_PO_EC_PDA_DEFAULT;
-		rc = rdb_tx_update(ap->tx, &cont->c_prop,
-				   &ds_cont_prop_ec_pda, &value);
+		rc  = rdb_tx_update(ap->tx, &cont->c_prop, &ds_cont_prop_ec_pda, &value);
 		if (rc) {
-			D_ERROR("failed to upgrade container ec_pda pool/cont: "DF_CONTF"\n",
-				DP_CONT(ap->pool_uuid, cont_uuid));
+			DL_ERROR(rc, "failed to upgrade container ec_pda pool/cont: " DF_CONTF,
+				 DP_CONT(ap->pool_uuid, cont_uuid));
 			goto out;
 		}
 		upgraded = true;
@@ -4645,11 +4637,10 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		goto out;
 	if (rc == -DER_NONEXIST) {
 		pda = DAOS_PROP_PO_RP_PDA_DEFAULT;
-		rc = rdb_tx_update(ap->tx, &cont->c_prop, &ds_cont_prop_rp_pda,
-				   &value);
+		rc  = rdb_tx_update(ap->tx, &cont->c_prop, &ds_cont_prop_rp_pda, &value);
 		if (rc) {
-			D_ERROR("failed to upgrade container rp_pda pool/cont: "DF_CONTF"\n",
-				DP_CONT(ap->pool_uuid, cont_uuid));
+			DL_ERROR(rc, "failed to upgrade container rp_pda pool/cont: " DF_CONTF,
+				 DP_CONT(ap->pool_uuid, cont_uuid));
 			goto out;
 		}
 		upgraded = true;
@@ -4668,8 +4659,8 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		perf_domain = DAOS_PROP_CO_PERF_DOMAIN_DEFAULT;
 		rc = rdb_tx_update(ap->tx, &cont->c_prop, &ds_cont_prop_perf_domain, &value);
 		if (rc) {
-			D_ERROR("failed to upgrade container perf_domain pool/cont: "DF_CONTF"\n",
-				DP_CONT(ap->pool_uuid, cont_uuid));
+			DL_ERROR(rc, "failed to upgrade container perf_domain pool/cont: " DF_CONTF,
+				 DP_CONT(ap->pool_uuid, cont_uuid));
 			goto out;
 		}
 		upgraded = true;
@@ -4687,8 +4678,9 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 		pda = 0;
 		rc = rdb_tx_update(ap->tx, &cont->c_prop, &ds_cont_prop_scrubber_disabled, &value);
 		if (rc) {
-			D_ERROR("failed to upgrade container scrubbing disabled prop: "DF_CONTF"\n",
-				DP_CONT(ap->pool_uuid, cont_uuid));
+			DL_ERROR(rc,
+				 "failed to upgrade container scrubbing disabled prop: " DF_CONTF,
+				 DP_CONT(ap->pool_uuid, cont_uuid));
 			goto out;
 		}
 		upgraded = true;
@@ -4702,8 +4694,8 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	if (rc == -DER_NONEXIST) {
 		rc = rdb_tx_update(ap->tx, &cont->c_prop, &ds_cont_prop_nhandles, &value);
 		if (rc) {
-			D_ERROR("failed to upgrade container nhandles pool/cont: "DF_CONTF
-				", "DF_RC"\n", DP_CONT(ap->pool_uuid, cont_uuid), DP_RC(rc));
+			DL_ERROR(rc, "failed to upgrade container nhandles pool/cont: " DF_CONTF,
+				 DP_CONT(ap->pool_uuid, cont_uuid));
 			goto out;
 		}
 		upgraded = true;
@@ -4730,8 +4722,8 @@ upgrade_cont_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	mdtimes.mtime = d_hlc_get();
 	rc = rdb_tx_update(ap->tx, &cont->c_prop, &ds_cont_prop_co_md_times, &value);
 	if (rc) {
-		D_ERROR("failed to upgrade container co_md_times/cont: "DF_CONTF"\n",
-			DP_CONT(ap->pool_uuid, cont_uuid));
+		DL_ERROR(rc, "failed to upgrade container co_md_times/cont: " DF_CONTF,
+			 DP_CONT(ap->pool_uuid, cont_uuid));
 		goto out;
 	}
 	upgraded = true;
@@ -5070,18 +5062,15 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		rc = rdb_tx_lookup(tx, &cont->c_svc->cs_hdls, &key, &value);
 		if (rc != 0) {
 			if (rc == -DER_NONEXIST) {
-				D_ERROR(DF_CONT": rejecting unauthorized "
-					"operation: "DF_UUID"\n",
-					DP_CONT(cont->c_svc->cs_pool_uuid,
-						cont->c_uuid),
-					DP_UUID(in->ci_hdl));
 				rc = -DER_NO_HDL;
+				DL_ERROR(rc, DF_CONT ": rejecting unauthorized operation: " DF_UUID,
+					 DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid),
+					 DP_UUID(in->ci_hdl));
 			} else {
-				D_ERROR(DF_CONT": failed to look up container "
-					"handle "DF_UUID": %d\n",
-					DP_CONT(cont->c_svc->cs_pool_uuid,
-						cont->c_uuid),
-					DP_UUID(in->ci_hdl), rc);
+				DL_ERROR(rc,
+					 DF_CONT ": failed to look up container handle " DF_UUID,
+					 DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid),
+					 DP_UUID(in->ci_hdl));
 			}
 			goto out;
 		}
@@ -5406,8 +5395,8 @@ ds_cont_oid_fetch_add(uuid_t po_uuid, uuid_t co_uuid, uint64_t num_oids, uint64_
 	/* Update the max OID */
 	rc = rdb_tx_update(&tx, &cont->c_prop, &ds_cont_prop_alloced_oid, &value);
 	if (rc != 0) {
-		D_ERROR(DF_CONT": failed to update alloced_oid: %d\n",
-			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
+		DL_ERROR(rc, DF_CONT ": failed to update alloced_oid",
+			 DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
 		D_GOTO(out_cont, rc);
 	}
 

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -338,11 +338,11 @@ dtx_req_list_cb(void **args)
 
 		drr = args[0];
 		D_CDEBUG(dra->dra_result < 0 && dra->dra_result != -DER_NONEXIST &&
-			 dra->dra_result != -DER_INPROGRESS, DLOG_ERR, DB_TRACE,
-			 "DTX req for opc %x ("DF_DTI") %s, count %d: %d.\n",
-			 dra->dra_opc, DP_DTI(&drr->drr_dti[0]),
-			 dra->dra_result < 0 ? "failed" : "succeed",
-			 dra->dra_length, dra->dra_result);
+			     dra->dra_result != -DER_INPROGRESS,
+			 DLOG_ERR, DB_TRACE,
+			 "DTX req for opc %x (" DF_DTI ") %s, count %d: " DF_RC "\n", dra->dra_opc,
+			 DP_DTI(&drr->drr_dti[0]), dra->dra_result < 0 ? "failed" : "succeed",
+			 dra->dra_length, DP_RC(dra->dra_result));
 	}
 }
 

--- a/src/engine/drpc_progress.c
+++ b/src/engine/drpc_progress.c
@@ -193,22 +193,21 @@ drpc_progress_context_is_valid(struct drpc_progress_context *ctx)
 static int
 drpc_progress_context_accept(struct drpc_progress_context *ctx)
 {
-	struct drpc		*session;
-	struct drpc_list	*session_node;
-
-	session = drpc_accept(ctx->listener_ctx);
-	if (session == NULL) {
-		/*
-		 * Any failure to accept is weird and surprising
-		 */
-		D_ERROR("Failed to accept new drpc connection\n");
-		return -DER_MISC;
-	}
+	struct drpc      *session;
+	struct drpc_list *session_node;
+	int               rc;
 
 	D_ALLOC_PTR(session_node);
 	if (session_node == NULL) {
-		D_FREE(session);
 		return -DER_NOMEM;
+	}
+
+	rc = drpc_accept(ctx->listener_ctx, &session);
+	if (rc != -DER_SUCCESS) {
+		/* Any failure to accept is weird and surprising */
+		DL_ERROR(rc, "Failed to accept new drpc connection");
+		D_FREE(session_node);
+		return rc;
 	}
 
 	session_node->ctx = session;

--- a/src/engine/tests/drpc_progress_tests.c
+++ b/src/engine/tests/drpc_progress_tests.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -372,7 +372,7 @@ test_drpc_progress_listener_accept_failed(void **state)
 	accept_return          = -EIO;
 
 	/* No clear reason why accept would fail if we got data on it */
-	assert_rc_equal(drpc_progress(&ctx, 100), -DER_MISC);
+	assert_rc_equal(drpc_progress(&ctx, 100), -DER_IO);
 
 	cleanup_drpc_progress_context(&ctx);
 }

--- a/src/engine/tests/drpc_progress_tests.c
+++ b/src/engine/tests/drpc_progress_tests.c
@@ -369,7 +369,7 @@ test_drpc_progress_listener_accept_failed(void **state)
 
 	init_drpc_progress_context(&ctx, new_drpc_with_fd(15));
 	poll_revents_return[0] = POLLIN;
-	accept_return = -1;
+	accept_return          = -EIO;
 
 	/* No clear reason why accept would fail if we got data on it */
 	assert_rc_equal(drpc_progress(&ctx, 100), -DER_MISC);

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -612,6 +612,7 @@ daos_der2errno(int err)
 	case -DER_UNREACH:	return EHOSTUNREACH;
 	case -DER_NOSPACE:	return ENOSPC;
 	case -DER_ALREADY:	return EALREADY;
+	case -DER_DOS:
 	case -DER_NOMEM:	return ENOMEM;
 	case -DER_TIMEDOUT:	return ETIMEDOUT;
 	case -DER_BUSY:

--- a/src/include/daos/drpc.h
+++ b/src/include/daos/drpc.h
@@ -66,23 +66,43 @@ enum rpcflags {
 	R_SYNC = 1
 };
 
-int drpc_call_create(struct drpc *ctx, int32_t module, int32_t method,
-		     Drpc__Call **callp);
-void drpc_call_free(Drpc__Call *call);
+int
+drpc_call_create(struct drpc *ctx, int32_t module, int32_t method, Drpc__Call **callp);
 
-Drpc__Response *drpc_response_create(Drpc__Call *call);
-void drpc_response_free(Drpc__Response *resp);
+void
+drpc_call_free(Drpc__Call *call);
 
-int drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg,
-		Drpc__Response **resp);
-int drpc_connect(char *sockaddr, struct drpc **);
-struct drpc *drpc_listen(char *sockaddr, drpc_handler_t handler);
-bool drpc_is_valid_listener(struct drpc *ctx);
-struct drpc *drpc_accept(struct drpc *listener_ctx);
-int drpc_recv_call(struct drpc *ctx, Drpc__Call **call);
-int drpc_send_response(struct drpc *ctx, Drpc__Response *resp);
-int drpc_close(struct drpc *ctx);
+Drpc__Response *
+drpc_response_create(Drpc__Call *call);
 
-int drpc_add_ref(struct drpc *ctx);
+void
+drpc_response_free(Drpc__Response *resp);
+
+int
+drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg, Drpc__Response **resp);
+
+int
+drpc_connect(char *sockaddr, struct drpc **);
+
+struct drpc *
+drpc_listen(char *sockaddr, drpc_handler_t handler);
+
+bool
+drpc_is_valid_listener(struct drpc *ctx);
+
+int
+drpc_accept(struct drpc *listener_ctx, struct drpc **drpc);
+
+int
+drpc_recv_call(struct drpc *ctx, Drpc__Call **call);
+
+int
+drpc_send_response(struct drpc *ctx, Drpc__Response *resp);
+
+int
+drpc_close(struct drpc *ctx);
+
+int
+drpc_add_ref(struct drpc *ctx);
 
 #endif /* __DAOS_DRPC_H__ */

--- a/src/include/daos/drpc.h
+++ b/src/include/daos/drpc.h
@@ -66,43 +66,24 @@ enum rpcflags {
 	R_SYNC = 1
 };
 
+int drpc_call_create(struct drpc *ctx, int32_t module, int32_t method,
+		     Drpc__Call **callp);
+void drpc_call_free(Drpc__Call *call);
+
+Drpc__Response *drpc_response_create(Drpc__Call *call);
+void drpc_response_free(Drpc__Response *resp);
+
+int drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg,
+		Drpc__Response **resp);
+int drpc_connect(char *sockaddr, struct drpc **);
+struct drpc *drpc_listen(char *sockaddr, drpc_handler_t handler);
+bool drpc_is_valid_listener(struct drpc *ctx);
 int
-drpc_call_create(struct drpc *ctx, int32_t module, int32_t method, Drpc__Call **callp);
+    drpc_accept(struct drpc *listener_ctx, struct drpc *drpc);
+int drpc_recv_call(struct drpc *ctx, Drpc__Call **call);
+int drpc_send_response(struct drpc *ctx, Drpc__Response *resp);
+int drpc_close(struct drpc *ctx);
 
-void
-drpc_call_free(Drpc__Call *call);
-
-Drpc__Response *
-drpc_response_create(Drpc__Call *call);
-
-void
-drpc_response_free(Drpc__Response *resp);
-
-int
-drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg, Drpc__Response **resp);
-
-int
-drpc_connect(char *sockaddr, struct drpc **);
-
-struct drpc *
-drpc_listen(char *sockaddr, drpc_handler_t handler);
-
-bool
-drpc_is_valid_listener(struct drpc *ctx);
-
-int
-drpc_accept(struct drpc *listener_ctx, struct drpc **drpc);
-
-int
-drpc_recv_call(struct drpc *ctx, Drpc__Call **call);
-
-int
-drpc_send_response(struct drpc *ctx, Drpc__Response *resp);
-
-int
-drpc_close(struct drpc *ctx);
-
-int
-drpc_add_ref(struct drpc *ctx);
+int drpc_add_ref(struct drpc *ctx);
 
 #endif /* __DAOS_DRPC_H__ */

--- a/src/include/daos/drpc.h
+++ b/src/include/daos/drpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2021 Intel Corporation.
+ * (C) Copyright 2018-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -79,7 +79,7 @@ int drpc_connect(char *sockaddr, struct drpc **);
 struct drpc *drpc_listen(char *sockaddr, drpc_handler_t handler);
 bool drpc_is_valid_listener(struct drpc *ctx);
 int
-    drpc_accept(struct drpc *listener_ctx, struct drpc *drpc);
+    drpc_accept(struct drpc *listener_ctx, struct drpc **drpc);
 int drpc_recv_call(struct drpc *ctx, Drpc__Call **call);
 int drpc_send_response(struct drpc *ctx, Drpc__Response *resp);
 int drpc_close(struct drpc *ctx);

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -215,6 +215,23 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
 #define DL_WARN(_rc, _fmt, ...)  D_DEBUG(DLOG_WARN, _fmt ": " DF_RC "\n", ##__VA_ARGS__, DP_RC(_rc))
 #define DL_ERROR(_rc, _fmt, ...) D_DEBUG(DLOG_ERR, _fmt ": " DF_RC "\n", ##__VA_ARGS__, DP_RC(_rc))
 
+#define DHS_INFO(_desc, _rc, _fmt, ...)                                                            \
+	_D_DEBUG(_D_TRACE_NOCHECK, DLOG_INFO, (_desc), _fmt ": %d (%s)\n", ##__VA_ARGS__, _rc,     \
+		 strerror(_rc))
+#define DHS_WARN(_desc, _rc, _fmt, ...)                                                            \
+	_D_DEBUG(_D_TRACE_NOCHECK, DLOG_WARN, (_desc), _fmt ": %d (%s)\n", ##__VA_ARGS__, _rc,     \
+		 strerror(_rc))
+#define DHS_ERROR(_desc, _rc, _fmt, ...)                                                           \
+	_D_DEBUG(_D_TRACE_NOCHECK, DLOG_ERR, (_desc), _fmt ": %d (%s)\n", ##__VA_ARGS__, _rc,      \
+		 strerror(_rc))
+
+#define DS_INFO(_rc, _fmt, ...)                                                                    \
+	D_DEBUG(DLOG_INFO, _fmt ": %d (%s)\n", ##__VA_ARGS__, _rc, strerror(_rc))
+#define DS_WARN(_rc, _fmt, ...)                                                                    \
+	D_DEBUG(DLOG_WARN, _fmt ": %d (%s)\n", ##__VA_ARGS__, _rc, strerror(_rc))
+#define DS_ERROR(_rc, _fmt, ...)                                                                   \
+	D_DEBUG(DLOG_ERR, _fmt ": %d (%s)\n", ##__VA_ARGS__, _rc, strerror(_rc))
+
 #ifdef D_USE_GURT_FAC
 D_FOREACH_GURT_FAC(D_LOG_DECLARE_FAC, D_NOOP)
 #endif /* D_USE_GURT_FAC */

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1802,15 +1802,14 @@ pool_svc_map_dist_cb(struct ds_rsvc *rsvc)
 	ABT_rwlock_unlock(svc->ps_lock);
 	rdb_tx_end(&tx);
 	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to read pool map buffer: %d\n",
-			DP_UUID(svc->ps_uuid), rc);
+		DL_ERROR(rc, DF_UUID ": failed to read pool map buffer", DP_UUID(svc->ps_uuid));
 		goto out;
 	}
 
 	rc = ds_pool_iv_map_update(svc->ps_pool, map_buf, map_version);
 	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to distribute pool map %u: %d\n",
-			DP_UUID(svc->ps_uuid), map_version, rc);
+		DL_ERROR(rc, DF_UUID ": failed to distribute pool map %u", DP_UUID(svc->ps_uuid),
+			 map_version);
 		D_GOTO(out, rc);
 	}
 	svc->ps_global_map_version = max(svc->ps_global_map_version, map_version);
@@ -6697,8 +6696,7 @@ rechoose:
 
 	rc = pool_req_create(info->dmi_ctx, &ep, POOL_EVICT, &rpc);
 	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to create pool evict rpc: %d\n",
-			DP_UUID(pool_uuid), rc);
+		DL_ERROR(rc, DF_UUID ": failed to create pool evict rpc", DP_UUID(pool_uuid));
 		D_GOTO(out_client, rc);
 	}
 
@@ -6728,8 +6726,7 @@ rechoose:
 
 	rc = out->pvo_op.po_rc;
 	if (rc != 0)
-		D_ERROR(DF_UUID ": pool destroy failed to evict handles, rc: " DF_RC "\n",
-			DP_UUID(pool_uuid), DP_RC(rc));
+		DL_ERROR(rc, DF_UUID ": pool destroy failed to evict handles", DP_UUID(pool_uuid));
 	if (count)
 		*count = out->pvo_n_hdls_evicted;
 

--- a/src/rdb/rdb_tx.c
+++ b/src/rdb/rdb_tx.c
@@ -792,8 +792,7 @@ rdb_tx_apply_delete(struct rdb *db, uint64_t index, rdb_oid_t kvs,
 
 	rc = rdb_lc_punch(db->d_lc, index, kvs, 1 /* n */, key);
 	if (rc != 0)
-		D_ERROR(DF_DB": failed to update KVS "DF_X64": %d\n", DP_DB(db),
-			kvs, rc);
+		DL_ERROR(rc, DF_DB ": failed to update KVS " DF_X64, DP_DB(db), kvs);
 	return rc;
 }
 

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -115,10 +115,7 @@ auth_token_dup(Auth__Token *orig)
 	uint8_t			*packed;
 	size_t			len;
 
-	/*
-	 * The most straightforward way to copy a protobuf struct is to pack
-	 * and unpack it.
-	 */
+	/* The most straightforward way to copy a protobuf struct is to pack and unpack it. */
 	len = auth__token__get_packed_size(orig);
 	D_ALLOC(packed, len);
 	if (packed == NULL)
@@ -474,27 +471,27 @@ ds_sec_pool_get_capabilities(uint64_t flags, d_iov_t *cred,
 	}
 
 	if (!is_ownership_valid(ownership)) {
-		D_ERROR("Invalid ownership\n");
-		return -DER_INVAL;
+		rc = -DER_INVAL;
+		DL_ERROR(rc, "Invalid ownership");
+		return rc;
 	}
 
 	/* Pool flags are mutually exclusive */
-	if ((flags != DAOS_PC_RO) && (flags != DAOS_PC_RW) &&
-	    (flags != DAOS_PC_EX)) {
-		D_ERROR("Invalid flags\n");
-		return -DER_INVAL;
+	if ((flags != DAOS_PC_RO) && (flags != DAOS_PC_RW) && (flags != DAOS_PC_EX)) {
+		rc = -DER_INVAL;
+		DL_ERROR(rc, "Invalid flags");
+		return rc;
 	}
 
 	rc = daos_acl_validate(acl);
 	if (rc != -DER_SUCCESS) {
-		D_ERROR("Invalid ACL: " DF_RC "\n", DP_RC(rc));
+		DL_ERROR(rc, "Invalid ACL");
 		return rc;
 	}
 
 	rc = ds_sec_validate_credentials(cred, &token);
 	if (rc != 0) {
-		D_ERROR("Failed to validate credentials, rc="DF_RC"\n",
-			DP_RC(rc));
+		DL_ERROR(rc, "Failed to validate credentials");
 		return rc;
 	}
 
@@ -557,35 +554,41 @@ filter_cont_capas_based_on_flags(uint64_t flags, uint64_t *capas)
 		*capas &= ~(uint64_t)CONT_CAPA_EVICT_ALL;
 }
 
-static Auth__Token *
-unpack_token_from_cred(d_iov_t *cred)
+static int
+unpack_token_from_cred(d_iov_t *cred, Auth__Token **_token)
 {
-	struct drpc_alloc	alloc = PROTO_ALLOCATOR_INIT(alloc);
-	Auth__Credential	*unpacked;
-	Auth__Token		*token = NULL;
+	struct drpc_alloc alloc = PROTO_ALLOCATOR_INIT(alloc);
+	Auth__Credential *unpacked;
+	Auth__Token      *token = NULL;
 
-	unpacked = auth__credential__unpack(&alloc.alloc, cred->iov_buf_len,
-					    cred->iov_buf);
-	if (alloc.oom || unpacked == NULL) {
-		D_ERROR("Couldn't unpack credential\n");
-		return NULL;
+	unpacked = auth__credential__unpack(&alloc.alloc, cred->iov_buf_len, cred->iov_buf);
+	if (alloc.oom)
+		return -DER_NOMEM;
+
+	if (unpacked == NULL) {
+		DL_ERROR(-DER_INVAL, "Couldn't unpack credential");
+		return -DER_INVAL;
 	}
 
-	if (unpacked->token != NULL)
+	if (unpacked->token != NULL) {
 		token = auth_token_dup(unpacked->token);
+		if (token == NULL)
+			return -DER_NOMEM;
+	}
 
 	auth__credential__free_unpacked(unpacked, &alloc.alloc);
-	return token;
+	*_token = token;
+	return 0;
 }
 
 int
 ds_sec_cont_get_capabilities(uint64_t flags, d_iov_t *cred, struct d_ownership *ownership,
 			     struct daos_acl *acl, uint64_t *capas)
 {
-	struct drpc_alloc	alloc = PROTO_ALLOCATOR_INIT(alloc);
-	Auth__Token	*token;
-	int		rc;
-	uint64_t	owner_min_perms = CONT_OWNER_MIN_PERMS;
+	struct drpc_alloc alloc = PROTO_ALLOCATOR_INIT(alloc);
+	Auth__Token      *token;
+	int               rc;
+	uint64_t          owner_min_perms = CONT_OWNER_MIN_PERMS;
 
 	if (cred == NULL || ownership == NULL || acl == NULL || capas == NULL) {
 		D_ERROR("NULL input\n");
@@ -602,9 +605,10 @@ ds_sec_cont_get_capabilities(uint64_t flags, d_iov_t *cred, struct d_ownership *
 		return -DER_INVAL;
 	}
 
-	if (daos_acl_validate(acl) != 0) {
-		D_ERROR("Invalid ACL\n");
-		return -DER_INVAL;
+	rc = daos_acl_validate(acl);
+	if (rc != -DER_SUCCESS) {
+		DL_ERROR(rc, "Invalid ACL");
+		return rc;
 	}
 
 	if (cred->iov_buf == NULL) {
@@ -612,10 +616,11 @@ ds_sec_cont_get_capabilities(uint64_t flags, d_iov_t *cred, struct d_ownership *
 		return -DER_INVAL;
 	}
 
-	/*
-	 * The credential has already been validated at pool connect.
-	 */
-	token = unpack_token_from_cred(cred);
+	rc = unpack_token_from_cred(cred, &token);
+	if (rc != -DER_SUCCESS)
+		return rc;
+
+	/* The credential has already been validated at pool connect. */
 	if (token == NULL)
 		return -DER_INVAL;
 
@@ -783,17 +788,13 @@ ds_sec_creds_are_same_user(d_iov_t *cred_x, d_iov_t *cred_y)
 		goto out;
 	}
 
-	token_x = unpack_token_from_cred(cred_x);
-	if (token_x == NULL) {
-		rc = -DER_INVAL;
+	rc = unpack_token_from_cred(cred_x, &token_x);
+	if (rc != -DER_SUCCESS)
 		goto out;
-	}
 
-	token_y = unpack_token_from_cred(cred_y);
-	if (token_y == NULL) {
-		rc = -DER_INVAL;
+	rc = unpack_token_from_cred(cred_y, &token_y);
+	if (rc != -DER_SUCCESS)
 		goto out_token_x;
-	}
 
 	rc = get_auth_sys_payload(token_x, &authsys_x);
 	if (rc != 0)

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -115,7 +115,10 @@ auth_token_dup(Auth__Token *orig)
 	uint8_t			*packed;
 	size_t			len;
 
-	/* The most straightforward way to copy a protobuf struct is to pack and unpack it. */
+	/*
+	 * The most straightforward way to copy a protobuf struct is to pack
+	 * and unpack it.
+	 */
 	len = auth__token__get_packed_size(orig);
 	D_ALLOC(packed, len);
 	if (packed == NULL)

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -368,6 +368,8 @@ class LogTest():
 
                 if 'DER_UNKNOWN' in msg:
                     show_line(line, 'NORMAL', 'Use of DER_UNKNOWN')
+                if 'Unknown error' in msg:
+                    show_line(line, 'NORMAL', 'Invalid strerror value')
                 # Warn if a line references the name of the function it was in,
                 # but skip short function names or _internal suffixes.
                 if line.function in msg and len(line.function) > 6 and \

--- a/utils/cq/d_logging_check.py
+++ b/utils/cq/d_logging_check.py
@@ -132,9 +132,11 @@ PREFIXES = ['D_ERROR', 'D_WARN', 'D_INFO', 'D_NOTE', 'D_ALERT', 'D_CRIT', 'D_FAT
 # Logging macros where a new-line is always added.
 PREFIXES_NNL = ['DFUSE_LOG_WARNING', 'DFUSE_LOG_ERROR', 'DFUSE_LOG_DEBUG', 'DFUSE_LOG_INFO',
                 'DFUSE_TRA_WARNING', 'DFUSE_TRA_ERROR', 'DFUSE_TRA_DEBUG', 'DFUSE_TRA_INFO',
-                'DH_PERROR_SYS', 'DH_PERROR_DER',
-                'DL_ERROR', 'DHL_ERROR', 'DHL_WARN', 'DL_WARN', 'DL_INFO', 'DHL_INFO']
+                'DH_PERROR_SYS', 'DH_PERROR_DER']
 
+for prefix in ['DL', 'DHL', 'DS', 'DHS']:
+    for suffix in ['ERROR', 'WARN', 'INFO']:
+        PREFIXES_NNL.append(f'{prefix}_{suffix}')
 
 PREFIXES_ALL = PREFIXES.copy()
 PREFIXES_ALL.extend(PREFIXES_NNL)
@@ -183,6 +185,7 @@ class AllChecks():
             self.check_df_rc(line)
             self.remove_trailing_period(line)
             self.check_quote(line)
+            self.check_failed(line)
 
             line.write(self._output)
             if line.modified:
@@ -368,6 +371,23 @@ class AllChecks():
 
         if new_code != code:
             line.correct(new_code)
+
+    def check_failed(self, line):
+        """Check for 'Failed' with uppercase F
+
+        Lots of message are of the form 'function() failed' but some use Failed.
+        """
+        code = line.raw()
+
+        if 'Failed' not in code:
+            return
+        if '"Failed' in code:
+            return
+        if 'Failed to' in code:
+            return
+
+        print(code)
+        line.note('Failed')
 
 
 def one_entry(fname):


### PR DESCRIPTION
- DAOS-14207 engine: Improve error reporting in case of faults.
- Fix compile.
- Fix unit tests.
- Update tests again.
- Fix mock logic.
- Fix some more iossyues and two memory leaks.
- Take on review feedback.
- Fix compile
- DAOS-14155 gurt: add macros for logging of system error codes.
