### PR TITLE
GCP-215 vos: warning message for purging old non-committed DTX

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -625,7 +625,7 @@ dtx_batched_commit_one(void *arg)
 
 		if ((stat.dtx_committable_count <= DTX_THRESHOLD_COUNT) &&
 		    (stat.dtx_oldest_committable_time == 0 ||
-		     dtx_hlc_age2sec(stat.dtx_oldest_committable_time) <
+		     d_hlc_age2sec(stat.dtx_oldest_committable_time) <
 		     DTX_COMMIT_THRESHOLD_AGE))
 			break;
 	}
@@ -690,7 +690,7 @@ dtx_batched_commit(void *arg)
 		    (dtx_batched_ult_max != 0 && tls->dt_batched_ult_cnt < dtx_batched_ult_max) &&
 		    ((stat.dtx_committable_count > DTX_THRESHOLD_COUNT) ||
 		     (stat.dtx_oldest_committable_time != 0 &&
-		      dtx_hlc_age2sec(stat.dtx_oldest_committable_time) >=
+		      d_hlc_age2sec(stat.dtx_oldest_committable_time) >=
 		      DTX_COMMIT_THRESHOLD_AGE))) {
 			D_ASSERT(!dbca->dbca_commit_done);
 			sleep_time = 0;

--- a/src/gurt/hlc.c
+++ b/src/gurt/hlc.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -162,4 +162,14 @@ uint64_t d_hlc_epsilon_get(void)
 uint64_t d_hlc_epsilon_get_bound(uint64_t hlc)
 {
 	return (hlc + d_hlc_epsilon) | D_HLC_MASK;
+}
+
+uint64_t d_hlc_age2sec(uint64_t hlc)
+{
+	uint64_t pt = d_hlc_localtime_get();
+
+	if (unlikely(pt <= hlc))
+		return 0;
+
+	return d_hlc2sec(pt - hlc);
 }

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -298,17 +298,6 @@ dtx_dsp_free(struct dtx_share_peer *dsp)
 	D_FREE(dsp);
 }
 
-static inline uint64_t
-dtx_hlc_age2sec(uint64_t hlc)
-{
-	uint64_t now = d_hlc_get();
-
-	if (now <= hlc)
-		return 0;
-
-	return d_hlc2sec(now - hlc);
-}
-
 static inline struct dtx_entry *
 dtx_entry_get(struct dtx_entry *dte)
 {

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -969,6 +969,16 @@ d_hlc_epsilon_get(void);
 uint64_t
 d_hlc_epsilon_get_bound(uint64_t hlc);
 
+/**
+ * Get the age of the hlc in second.
+ *
+ * \param[in] hlc              HLC timestamp
+ *
+ * \return                     The age of the hlc in second
+ */
+uint64_t
+d_hlc_age2sec(uint64_t hlc);
+
 uint64_t d_hlct_get(void);
 void d_hlct_sync(uint64_t msg);
 


### PR DESCRIPTION
When try to purge old non-committed DTX which age exceeds VOS aggregation time threshold, then generate some warning message. That will much reduce fake warning messages.

The patch also removes some old debug-purposed check.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
