### PR TITLE
 DAOS-13697 doc: add documentation for pool upgrade

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -947,3 +947,8 @@ required that all engines in the same system run the same DAOS version.
 
 !!! warning
     Rolling upgrade is not supporting at this time.
+
+DAOS v2.2 client connections to pools which were created by DAOS v2.4
+will be rejected. DAOS v2.4 client should work with DAOS v2.4 and DAOS v2.2
+server. To upgrade all pools to latest format after software upgrade, run
+`dmg pool upgrade <pool>`

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -388,6 +388,10 @@ So `dmg pool upgrade` will return within seconds, but it might take hours to see
 change from 'in progress' to 'completed'. The pool will stay offline and deny any pool connection until
 pool upgrade status becomes 'completed'.
 
+NB: once upgrade status is "completed", then the container/pool can do normal I/O,
+but rebuild status might not finish due to reclaim. pool reintegrate/drain/extend can
+only proceed once rebuild status is "done".
+
 !!! warning
     Once upgrade was done, upgraded pools will become unavailable if downgrading software.
 

--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -290,6 +290,107 @@ The example below shows a rebuild in progress and NVMe space allocated.
 Additional status and telemetry data is planned to be exported through
 management tools and will be documented here once available.
 
+### Upgrading a Pool
+
+The pool upgrade operation upgrades a pool's disk format to the latest
+pool format while preserving its data. The existing containers should
+be accessible after the upgrade with the same level of functionality as
+before the upgrade. New features available at the pool, container or
+object level won’t be automatically enabled on existing pools unless
+upgrade is performed.
+
+NB: The pool upgrade operation will evict any existing connections
+to this pool - pool will be unavailable to connect during pool upgrading.
+
+To see all UpgradeNeeded pools:
+
+```bash
+$ dmg pool list
+```
+
+Below is an example of pool list
+
+```bash
+   Pool  Size   State Used Imbalance Disabled UpgradeNeeded?
+   ----  ----   ----- ---- --------- -------- --------------
+   pool1 1.0 GB Ready 0%   0%        0/4      1->2
+   pool2 1.0 GB Ready 0%   0%        0/4      1->2
+```
+
+For the above example, pool1 and pool2 need to be upgraded from pool
+version 1 to pool version 2.
+
+NB: jump upgrading is not supported; e.g. upgrading pools created from
+DAOS v2.0 to DAOS v2.2 is ok, but not for DAOS v2.0 to v2.4 directly.
+
+The example below shows before and after pool upgrade.
+
+```bash
+$ dmg pool get-prop pool1
+
+   Pool pool1 properties:
+   Name                                                                             Value
+   ----                                                                             -----
+   WAL Checkpointing behavior (checkpoint)                                          value not set
+   WAL Checkpointing frequency, in seconds (checkpoint_freq)                        not set
+   Usage of WAL before checkpoint is triggered, as a percentage (checkpoint_thresh) not set
+   EC cell size (ec_cell_sz)                                                        64 KiB
+   Performance domain affinity level of EC (ec_pda)                                 1
+   Global Version (global_version)                                                  1
+   Pool label (label)                                                               pool1
+   Pool performance domain (perf_domain)                                            value not set
+   Tier placement policy (policy)                                                   type=io_size
+   Pool redundancy factor (rd_fac)                                                  0
+   Reclaim strategy (reclaim)                                                       lazy
+   Performance domain affinity level of RP (rp_pda)                                 3
+   Checksum scrubbing mode (scrub)                                                  value not set
+   Checksum scrubbing frequency (scrub-freq)                                        not set
+   Checksum scrubbing threshold (scrub-thresh)                                      not set
+   Self-healing policy (self_heal)                                                  exclude
+   Rebuild space ratio (space_rb)                                                   0%
+   Pool service replica list (svc_list)                                             [0]
+   Pool service redundancy factor (svc_rf)                                          not set
+   Upgrade Status (upgrade_status)                                                  not started
+
+$ dmg pool upgrade pool1
+   Pool-upgrade command succeeded
+
+$ dmg pool get-prop pool1
+
+   Pool pool1 properties:
+   Name                                                                             Value
+   ----                                                                             -----
+   WAL Checkpointing behavior (checkpoint)                                          timed
+   WAL Checkpointing frequency, in seconds (checkpoint_freq)                        5
+   Usage of WAL before checkpoint is triggered, as a percentage (checkpoint_thresh) 50
+   EC cell size (ec_cell_sz)                                                        64 KiB
+   Performance domain affinity level of EC (ec_pda)                                 1
+   Global Version (global_version)                                                  1
+   Pool label (label)                                                               pool1
+   Pool performance domain (perf_domain)                                            root
+   Tier placement policy (policy)                                                   type=io_size
+   Pool redundancy factor (rd_fac)                                                  0
+   Reclaim strategy (reclaim)                                                       lazy
+   Performance domain affinity level of RP (rp_pda)                                 3
+   Checksum scrubbing mode (scrub)                                                  off
+   Checksum scrubbing frequency (scrub-freq)                                        604800
+   Checksum scrubbing threshold (scrub-thresh)                                      0
+   Self-healing policy (self_heal)                                                  exclude
+   Rebuild space ratio (space_rb)                                                   0%
+   Pool service replica list (svc_list)                                             [0]
+   Pool service redundancy factor (svc_rf)                                          2
+   Upgrade Status (upgrade_status)                                                  in progress
+```
+
+Duration of upgrade depends on possible format change across different DAOS releases.
+It might trigger rebuild to re-place objects data which might be time-consuming.
+So `dmg pool upgrade` will return within seconds, but it might take hours to see Pool Status
+change from 'in progress' to 'completed'. The pool will stay offline and deny any pool connection until
+pool upgrade status becomes 'completed'.
+
+!!! warning
+    Once upgrade was done, upgraded pools will become unavailable if downgrading software.
+
 ### Evicting Users
 
 To evict handles/connections to a pool labeled `tank`:


### PR DESCRIPTION
This patch ports following two master commits:

master-commit: 8209b47fce9b9f749abaf45e06f299b1f68fb220
DAOS-13697 doc: add documentation for pool upgrade

and
master-commit: 6ed01bf03769939e88fbce2a8cea2e99d7009aa9
DAOS-13697 document: update pool upgrade limit

Signed-off-by: Wang Shilong <shilong.wang@intel.com>