### PR TITLE
DAOS-623 cq: Do not run spelling check on go.sum

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Run check
         uses: codespell-project/actions-codespell@master
         with:
-          skip: ./src/control/vendor,./.git
+          skip: ./src/control/vendor,./src/control/go.sum,./.git
           ignore_words_file: ci/codespell.ignores
           builtin: clear,rare,informal,names,en-GB_to_en-US
       - name: Check DAOS logging macro use.


### PR DESCRIPTION
This file is a list of checksums, do not run spelling checks on it.

Required-githooks: true
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
