### PR TITLE
DAOS-14157 test: Update storage timeouts based upon config (#12847)

### DIFF
--- a/src/tests/ftest/harness/setup_vm.py
+++ b/src/tests/ftest/harness/setup_vm.py
@@ -6,21 +6,21 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 from apricot import TestWithServers
 
 
-class HarnessSetupTest(TestWithServers):
+class HarnessSetupVmTest(TestWithServers):
     """Harness setup test cases.
 
     :avocado: recursive
     """
 
-    def test_setup(self):
+    def test_setup_vm(self):
         """Verify the TestWithServers.setUp() method.
 
         Useful for setting up the /etc/daos/daos_server.yml files on multiple hosts.
 
         :avocado: tags=all
-        :avocado: tags=hw,medium,large
+        :avocado: tags=vm
         :avocado: tags=harness
-        :avocado: tags=HarnessSetupTest,test_setup
+        :avocado: tags=HarnessSetupVmTest,test_setup_vm
         """
         prepare_timeout = self.params.get('storage_prepare_timeout')
         format_timeout = self.params.get('storage_format_timeout')

--- a/src/tests/ftest/harness/setup_vm.yaml
+++ b/src/tests/ftest/harness/setup_vm.yaml
@@ -1,0 +1,16 @@
+hosts:
+  test_servers: 1
+  test_clients: 1
+timeout: 120
+server_config:
+  name: daos_server
+  engines_per_host: 1
+  engines:
+    0:
+      targets: 1
+      nr_xs_helpers: 0
+      storage: auto
+  system_ram_reserved: 2
+server_manager:
+  storage_prepare_timeout: 60
+  storage_format_timeout: 60

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -25,6 +25,7 @@ from general_utils import check_file_exists, \
     get_subprocess_stdout
 from user_utils import get_primary_group
 from run_utils import command_as_user
+from yaml_utils import get_yaml_data
 
 
 class ExecutableCommand(CommandWithParameters):
@@ -871,6 +872,15 @@ class YamlCommand(SubProcessCommand):
 
         """
         return ".".join((self._command, "service"))
+
+    @property
+    def yaml_data(self):
+        """Get the yaml config file contents as a dictionary.
+
+        Returns:
+            dict: the yaml config file contents as a dictionary
+        """
+        return get_yaml_data(self.temporary_file)
 
     def get_params(self, test):
         """Get values for the daos command and its yaml config file.

--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -11,6 +11,7 @@ from ClusterShell.NodeSet import NodeSet
 
 from command_utils_base import FormattedParameter, CommandWithParameters
 from command_utils import YamlCommand, CommandWithSubCommand
+from data_utils import dict_extract_values, list_flatten
 from dmg_utils import get_dmg_response
 from exception_utils import CommandFailure
 from general_utils import get_display_size
@@ -143,6 +144,20 @@ class DaosServerCommand(YamlCommand):
         else:
             self.pattern = self.NORMAL_PATTERN
         self.pattern_count = host_qty * len(self.yaml.engine_params)
+
+    def update_pattern_timeout(self):
+        """Update the pattern timeout if undefined."""
+        if self.pattern_timeout.value is None:
+            self.log.debug('Updating pattern timeout based upon server config')
+            try:
+                data = self.yaml.get_yaml_data()
+                bdev_lists = list_flatten(dict_extract_values(data, ['storage', '*', 'bdev_list']))
+                self.log.debug('  Detected bdev_list entries: %s', bdev_lists)
+            except (AttributeError, TypeError, RecursionError):
+                # Default if the bdev_list cannot be obtained from the server configuration
+                bdev_lists = []
+            self.pattern_timeout.update(
+                max(len(bdev_lists), 2) * 20, 'DaosServerCommand.pattern_timeout')
 
     @property
     def using_nvme(self):


### PR DESCRIPTION
Functional test timeouts for the storage prepare and format steps in bringing up the server engines are now be based upon the number of NVMe devices defined in the server configuration.

Ensure a minimum 40 second pattern timeout is used.

Separate HarnessSetupTest tests into two files.

Skip-unit-tests: true
Skip-fault-injection-test: true
Allow-unstable-test: true
Test-tag: pr HarnessSetupTest HarnessSetupVmTest

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
