### PR TITLE
DAOS-13981 test: Resolve version check issue in critical integration test (#12767)

### DIFF
--- a/src/tests/ftest/deployment/critical_integration.py
+++ b/src/tests/ftest/deployment/critical_integration.py
@@ -4,6 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
+import json
+
 from ClusterShell.NodeSet import NodeSet
 
 from general_utils import run_command, DaosTestError, get_journalctl, journalctl_time
@@ -59,18 +61,18 @@ class CriticalIntegrationWithoutServers(TestWithoutServers):
         failed_nodes = NodeSet()
         for host in self.hostlist_servers:
             daos_server_cmd = ("ssh -oNumberOfPasswordPrompts=0 {}"
-                               " 'daos_server version'".format(host))
+                               " 'daos_server version -j'".format(host))
             remote_root_access = ("ssh -oNumberOfPasswordPrompts=0 root@{}"
                                   " 'echo hello'".format(host))
             command_for_inter_node = ("clush --nostdin -S -b -w {}"
                                       " 'echo hello'".format(str(self.hostlist_servers)))
             try:
-                out = run_command(daos_server_cmd)
-                daos_server_version_list.append(out.stdout.split(b' ')[3])
+                out = json.loads((run_command(daos_server_cmd)).stdout)
+                daos_server_version_list.append(out['response']['version'])
                 if check_remote_root_access:
                     run_command(remote_root_access)
                 IorTestBase._execute_command(self, command_for_inter_node, hosts=[host])
-            except (DaosTestError, CommandFailure) as error:
+            except (DaosTestError, CommandFailure, KeyError) as error:
                 self.log.error("Error: %s", error)
                 failed_nodes.add(host)
         if failed_nodes:
@@ -78,12 +80,12 @@ class CriticalIntegrationWithoutServers(TestWithoutServers):
 
         for host in self.hostlist_clients:
             dmg_version_cmd = ("ssh -oNumberOfPasswordPrompts=0 {}"
-                               " 'dmg version -i'".format(host))
+                               " dmg version -i -j".format(host))
 
             try:
-                out = run_command(dmg_version_cmd)
-                dmg_version_list.append(out.stdout.split(b' ')[2])
-            except DaosTestError as error:
+                out = json.loads((run_command(dmg_version_cmd)).stdout)
+                dmg_version_list.append(out['response']['version'])
+            except (DaosTestError, KeyError) as error:
                 self.log.error("Error: %s", error)
                 failed_nodes.add(host)
         if failed_nodes:
@@ -92,7 +94,7 @@ class CriticalIntegrationWithoutServers(TestWithoutServers):
         result_daos_server = (daos_server_version_list.count(daos_server_version_list[0])
                               == len(daos_server_version_list))
         result_dmg = dmg_version_list.count(dmg_version_list[0]) == len(dmg_version_list)
-        result_client_server = daos_server_version_list[0][1:] == dmg_version_list[0]
+        result_client_server = daos_server_version_list[0] == dmg_version_list[0]
 
         # libfabric version check
         all_nodes = self.hostlist_servers | self.hostlist_clients
@@ -104,7 +106,6 @@ class CriticalIntegrationWithoutServers(TestWithoutServers):
         else:
             same_libfab_nodes = libfabric_output.stdout_text.split('\n')[1].split('(')[1][:-1]
         libfabric_version = libfabric_output.stdout_text.split('\n')[3].split(' ')[1]
-
         result_libfabric_version = int(same_libfab_nodes) == len(all_nodes)
 
         if (result_daos_server and result_dmg and result_client_server


### PR DESCRIPTION
Resolving version check issue reported after changes in daos_server and dmg version output.
To be more flexible in future, moved to json output

Test-tag: test_passwdlessssh_versioncheck

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
