### PR TITLE
DAOS-14249 rebuild: wait for previous rebuild

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -3500,9 +3500,20 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	}
 
 	ds_rebuild_running_query(migrate_in->om_pool_uuid, &rebuild_ver, NULL, &rebuild_gen);
-	if (rebuild_ver == 0 || rebuild_gen != migrate_in->om_generation) {
-		D_ERROR(DF_UUID" rebuild service has been stopped.\n",
-			DP_UUID(migrate_in->om_pool_uuid));
+	if (rebuild_gen < migrate_in->om_generation || rebuild_ver < migrate_in->om_version) {
+		/* Either can not find the current rebuild status or there are previous rebuild
+		 * did not finish yet.
+		 */
+		D_INFO(DF_UUID" rebuild %u/%u wait for previous %u/%u\n",
+		       DP_UUID(migrate_in->om_pool_uuid), migrate_in->om_version,
+		       migrate_in->om_generation, rebuild_ver, rebuild_gen);
+		D_GOTO(out, rc = -DER_AGAIN);
+	}
+
+	if (rebuild_gen > migrate_in->om_generation || rebuild_ver > migrate_in->om_version) {
+		/* Advanced rebuild has been progressed, shutdown the current one */
+		D_ERROR(DF_UUID" rebuild service %u/%u has been stopped.\n",
+			DP_UUID(migrate_in->om_pool_uuid), rebuild_ver, rebuild_gen);
 		D_GOTO(out, rc = -DER_SHUTDOWN);
 	}
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -119,7 +119,7 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 					    arg->count, rpt->rt_new_layout_ver, rpt->rt_rebuild_op);
 		/* If it does not need retry */
 		if (rc == 0 || (rc != -DER_TIMEDOUT && rc != -DER_GRPVER &&
-		    rc != -DER_AGAIN && !daos_crt_network_error(rc)))
+		    rc != -DER_AGAIN && !daos_crt_network_error(rc)) || rpt->rt_abort)
 			break;
 
 		/* otherwise let's retry */
@@ -1038,6 +1038,34 @@ rebuild_scan_leader(void *data)
 		}
 	}
 
+	/* Check if any previous rebuild still not cleanup yet */
+	while (1) {
+		bool previous_aborted = true;
+		struct rebuild_tgt_pool_tracker *tmp;
+
+		d_list_for_each_entry(tmp, &rebuild_gst.rg_tgt_tracker_list, rt_list) {
+			if (uuid_compare(tmp->rt_pool_uuid, rpt->rt_pool_uuid) == 0 &&
+			    ((tmp->rt_rebuild_ver < rpt->rt_rebuild_ver) ||
+			    (tmp->rt_rebuild_op == rpt->rt_rebuild_op &&
+			     tmp->rt_rebuild_ver == rpt->rt_rebuild_ver &&
+			     tmp->rt_rebuild_gen < rpt->rt_rebuild_gen))) {
+				/* see rebuild_tgt_scan_handler(), all previous
+				 * rebuild should be set to abort.
+				 */
+				D_INFO(DF_UUID" wait for previous %s %u/%u/"DF_U64" \n",
+				       DP_UUID(tmp->rt_pool_uuid), RB_OP_STR(tmp->rt_rebuild_op),
+				       tmp->rt_rebuild_ver, tmp->rt_rebuild_gen, tmp->rt_leader_term);
+				previous_aborted = false;
+			}
+		}
+
+		if (!previous_aborted) {
+			dss_sleep(2000);
+			continue;
+		}
+		break;
+	}
+
 	D_DEBUG(DB_REBUILD, "rebuild scan collective "DF_UUID" begin.\n",
 		DP_UUID(rpt->rt_pool_uuid));
 
@@ -1078,7 +1106,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	struct rebuild_scan_out		*ro;
 	struct rebuild_pool_tls		*tls = NULL;
 	struct rebuild_tgt_pool_tracker	*rpt = NULL;
-	int				 rc;
+	int				 rc = 0;
 
 	rsi = crt_req_get(rpc);
 	D_ASSERT(rsi != NULL);
@@ -1098,10 +1126,11 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		    (rpt->rt_rebuild_op == rsi->rsi_rebuild_op &&
 		     rpt->rt_rebuild_ver == rsi->rsi_rebuild_ver &&
 		     rpt->rt_rebuild_gen < rsi->rsi_rebuild_gen))) {
-			D_INFO(DF_UUID" %s %u/"DF_U64" < incoming rebuild %u/"DF_U64"\n",
+			D_INFO(DF_UUID" %s %u/%u/"DF_U64" < incoming %s %u/%u/"DF_U64"\n",
 			       DP_UUID(rpt->rt_pool_uuid), RB_OP_STR(rpt->rt_rebuild_op),
-			       rpt->rt_rebuild_ver, rpt->rt_leader_term, rsi->rsi_rebuild_ver,
-			       rsi->rsi_leader_term);
+			       rpt->rt_rebuild_ver, rpt->rt_rebuild_gen, rpt->rt_leader_term,
+			       RB_OP_STR(rsi->rsi_rebuild_op), rsi->rsi_rebuild_ver,
+			       rsi->rsi_rebuild_gen, rsi->rsi_leader_term);
 			rpt->rt_abort = 1;
 		}
 	}


### PR DESCRIPTION
Wait for all previous rebuild finish, before scan
and migration, in case it might iterate some stale objects.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_rebuild_with_io
Test-repeat-vm: 30

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
