### PR TITLE
DAOS-14243 test: pool/list_verbose.py:ListVerboseTest.test_fields missing rebuild_state

### DIFF
--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -23,7 +23,7 @@ class ListVerboseTest(IorTestBase):
 
     def create_expected(self, pool, scm_free, nvme_free, scm_imbalance,
                         nvme_imbalance, targets_disabled=0, scm_size=None,
-                        nvme_size=None):
+                        state=None, rebuild_state=None, nvme_size=None):
         """Create expected dmg pool list output to compare against the actual.
 
         Args:
@@ -36,7 +36,8 @@ class ListVerboseTest(IorTestBase):
                 Defaults to 0.
             scm_size (int, optional): SCM size to fill in the output. Defaults to None.
             nvme_size (int, optional): NVMe size to fill in the output. Defaults to None.
-
+            state (str, optional): Expect pool state. Defaults to None.
+            rebuild_state (str, optional): Expect pool rebuild state. Defaults to None.
         Returns:
             dict: Expected in the same format of actual.
 
@@ -58,15 +59,15 @@ class ListVerboseTest(IorTestBase):
         return {
             "uuid": pool.uuid.lower(),
             "label": pool.label.value,
+            "svc_ldr": 0,
             "svc_reps": pool.svc_ranks,
+            "state": state,
             "targets_total": targets_total,
             "targets_disabled": targets_disabled,
             "upgrade_layout_ver": upgrade_layout_ver,
             "pool_layout_ver": pool_layout_ver,
             "query_error_msg": "",
             "query_status_msg": "",
-            "state": "Ready",
-            "svc_ldr": 0,
             "usage": [
                 {
                     "tier_name": "SCM",
@@ -79,8 +80,8 @@ class ListVerboseTest(IorTestBase):
                     "size": nvme_size,
                     "free": nvme_free,
                     "imbalance": nvme_imbalance
-                }
-            ]
+                }],
+            "rebuild_state": rebuild_state
         }
 
     @staticmethod
@@ -146,7 +147,7 @@ class ListVerboseTest(IorTestBase):
             threshold, diff)
         self.assertTrue(diff < threshold, msg)
 
-    def verify_pool_lists(self, targets_disabled, scm_size, nvme_size):
+    def verify_pool_lists(self, targets_disabled, scm_size, nvme_size, state, rebuild_state):
         """Call dmg pool list and verify.
 
         self.pool should be a list. The elements of the inputs should
@@ -156,7 +157,8 @@ class ListVerboseTest(IorTestBase):
             targets_disabled (list): List of targets disabled for pools.
             scm_size (list): List of SCM size for pools.
             nvme_size (list): List of NVMe size for pools.
-
+            state (list): List of pool state for pools.
+            rebuild_state (list): List of pool rebuild state for pools.
         Returns:
             list: a list of dictionaries containing information for each pool from the dmg
                 pool list json output. Used to verify free and imbalance to reduce the
@@ -193,12 +195,16 @@ class ListVerboseTest(IorTestBase):
                     nvme_imbalance=pool_free_data["nvme_imbalance"],
                     targets_disabled=targets_disabled[index],
                     scm_size=pool_free_data["scm_size"],
-                    nvme_size=nvme_size[index]))
+                    state=state[index],
+                    rebuild_state=rebuild_state[index],
+                    nvme_size[index]))
 
         # Sort pools by UUID.
         actual_pools.sort(key=lambda item: item.get("uuid"))
         expected_pools.sort(key=lambda item: item.get("uuid"))
 
+        self.log.info("actual_pools: %s", actual_pools)
+        self.log.info("expected_pools: %s", expected_pools)
         self.assertListEqual(expected_pools, actual_pools)
 
         # For convenience.
@@ -247,27 +253,38 @@ class ListVerboseTest(IorTestBase):
         self.pool = []
 
         # 1. Create first pool with a given SCM and NVMe size.
+        self.log_step("Create first pool")
         self.pool.append(self.get_pool(namespace="/run/pool_basic_1/*"))
 
         # 2. Verify the fields of pool 1.
+        self.log_step("Verify the field of first pool")
         targets_disabled = [0]
         scm_size = [None]
         nvme_size = [None]
+        state = ["Ready"]
+        rebuild_state = ["idle"]
         self.verify_pool_lists(
-            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size)
+            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size,
+            state=state, rebuild_state=rebuild_state)
 
         # 3. Create second pool.
+        self.log_step("Create second pool")
         self.pool.append(self.get_pool(namespace="/run/pool_basic_2/*"))
 
         # 4. Verify the fields for both pools.
         # Fill in the expected target and size and pass them into verify_pool_lists.
+        self.log_step("Verify the field of second pool")
         targets_disabled.append(0)
         scm_size.append(None)
         nvme_size.append(None)
+        state.append("Ready")
+        rebuild_state.append("idle")
         self.verify_pool_lists(
-            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size)
+            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size,
+            state=state, rebuild_state=rebuild_state)
 
         # 5. Exclude target 7 in rank 1 of pool 1.
+        self.log_step("Exclude target 7 in rank 1 of pool 1")
         self.pool[0].exclude(ranks=[1], tgt_idx="7")
 
         # Sizes are reduced by 1/8.
@@ -275,14 +292,20 @@ class ListVerboseTest(IorTestBase):
         reduced_nvme_size = self.pool[0].nvme_size.value * 0.875
 
         # 6. Verify the fields for both pools with expected disabled and size.
+        self.log_step("Verify the fields for both pools with expected disabled and size")
         targets_disabled[0] = 1
         scm_size[0] = reduced_scm_size
         nvme_size[0] = reduced_nvme_size
+        state[0] = "Degraded"
+        rebuild_state[0] = "busy"
+
         self.verify_pool_lists(
-            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size)
+            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size,
+            state=state, rebuild_state=rebuild_state)
 
         # 7-11. Destroy and verify until the pools are gone.
         while self.pool:
+            self.log_step("Destroy and verify until the pools are gone")
             self.pool[-1].destroy()
             self.pool.pop()
 
@@ -292,7 +315,8 @@ class ListVerboseTest(IorTestBase):
             nvme_size.pop()
 
             self.verify_pool_lists(
-                targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size)
+                targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size,
+                state=state, rebuild_state=rebuild_state)
 
     def verify_used_imbalance(self, storage):
         """Verification steps for test_used_imbalance.
@@ -317,8 +341,11 @@ class ListVerboseTest(IorTestBase):
         # 2. Verify the pool created.
         targets_disabled = [0]
         scm_size = [None]
+        state = ["Ready"]
+        rebuild_state = ["idle"]
         actual_pools_before = self.verify_pool_lists(
-            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size)
+            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size,
+            state=state, rebuild_state=rebuild_state)
 
         # 3. Store free.
         free_before, _ = self.get_free_imbalance(actual_pools_before[0], storage)
@@ -335,7 +362,8 @@ class ListVerboseTest(IorTestBase):
         # 6. Verify all fields except free and imbalance. Free and imbalance are
         # obtained from actual.
         actual_pools_after = self.verify_pool_lists(
-            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size)
+            targets_disabled=targets_disabled, scm_size=scm_size, nvme_size=nvme_size,
+            state=state, rebuild_state=rebuild_state)
 
         # Obtain the new free and imbalance.
         free_after, imbalance_after = self.get_free_imbalance(


### PR DESCRIPTION
Description: added pool state and rebuild_state to pool list verbose verification.

Allow-unstable-test: true
Doc-only: false
Test-tag: list_verbose
Required-githooks: true
Signed-off-by: Ding Ho ding-hwa.ho@intel.com

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
