### PR TITLE
DAOS-14214 control: Fix potential missed call to drpc failure handler…

### DIFF
--- a/src/bio/smd.pb-c.c
+++ b/src/bio/smd.pb-c.c
@@ -2570,33 +2570,39 @@ const ProtobufCMessageDescriptor ctl__smd_manage_resp__descriptor =
   (ProtobufCMessageInit) ctl__smd_manage_resp__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCEnumValue ctl__nvme_dev_state__enum_values_by_number[5] = {
-    {"UNKNOWN", "CTL__NVME_DEV_STATE__UNKNOWN", 0},
-    {"NORMAL", "CTL__NVME_DEV_STATE__NORMAL", 1},
-    {"NEW", "CTL__NVME_DEV_STATE__NEW", 2},
-    {"EVICTED", "CTL__NVME_DEV_STATE__EVICTED", 3},
-    {"UNPLUGGED", "CTL__NVME_DEV_STATE__UNPLUGGED", 4},
+static const ProtobufCEnumValue ctl__nvme_dev_state__enum_values_by_number[5] =
+{
+  { "UNKNOWN", "CTL__NVME_DEV_STATE__UNKNOWN", 0 },
+  { "NORMAL", "CTL__NVME_DEV_STATE__NORMAL", 1 },
+  { "NEW", "CTL__NVME_DEV_STATE__NEW", 2 },
+  { "EVICTED", "CTL__NVME_DEV_STATE__EVICTED", 3 },
+  { "UNPLUGGED", "CTL__NVME_DEV_STATE__UNPLUGGED", 4 },
 };
-static const ProtobufCIntRange       ctl__nvme_dev_state__value_ranges[]         = {{0, 0}, {0, 5}};
-static const ProtobufCEnumValueIndex ctl__nvme_dev_state__enum_values_by_name[5] = {
-    {"EVICTED", 3}, {"NEW", 2}, {"NORMAL", 1}, {"UNKNOWN", 0}, {"UNPLUGGED", 4},
+static const ProtobufCIntRange ctl__nvme_dev_state__value_ranges[] = {
+{0, 0},{0, 5}
 };
-const ProtobufCEnumDescriptor ctl__nvme_dev_state__descriptor = {
-    PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,
-    "ctl.NvmeDevState",
-    "NvmeDevState",
-    "Ctl__NvmeDevState",
-    "ctl",
-    5,
-    ctl__nvme_dev_state__enum_values_by_number,
-    5,
-    ctl__nvme_dev_state__enum_values_by_name,
-    1,
-    ctl__nvme_dev_state__value_ranges,
-    NULL,
-    NULL,
-    NULL,
-    NULL /* reserved[1234] */
+static const ProtobufCEnumValueIndex ctl__nvme_dev_state__enum_values_by_name[5] =
+{
+  { "EVICTED", 3 },
+  { "NEW", 2 },
+  { "NORMAL", 1 },
+  { "UNKNOWN", 0 },
+  { "UNPLUGGED", 4 },
+};
+const ProtobufCEnumDescriptor ctl__nvme_dev_state__descriptor =
+{
+  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,
+  "ctl.NvmeDevState",
+  "NvmeDevState",
+  "Ctl__NvmeDevState",
+  "ctl",
+  5,
+  ctl__nvme_dev_state__enum_values_by_number,
+  5,
+  ctl__nvme_dev_state__enum_values_by_name,
+  1,
+  ctl__nvme_dev_state__value_ranges,
+  NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
 static const ProtobufCEnumValue ctl__led_state__enum_values_by_number[5] =
 {

--- a/src/bio/smd.pb-c.h
+++ b/src/bio/smd.pb-c.h
@@ -41,27 +41,27 @@ typedef struct _Ctl__SmdManageResp__RankResp Ctl__SmdManageResp__RankResp;
 /* --- enums --- */
 
 typedef enum _Ctl__NvmeDevState {
-	/*
-	 * Device state is unknown, zer6o value
-	 */
-	CTL__NVME_DEV_STATE__UNKNOWN = 0,
-	/*
-	 * Device is in a normal operational state
-	 */
-	CTL__NVME_DEV_STATE__NORMAL = 1,
-	/*
-	 * Device is new and is not yet in-use
-	 */
-	CTL__NVME_DEV_STATE__NEW = 2,
-	/*
-	 * Device is faulty and has been evicted
-	 */
-	CTL__NVME_DEV_STATE__EVICTED = 3,
-	/*
-	 * Device has been physically removed
-	 */
-	CTL__NVME_DEV_STATE__UNPLUGGED =
-	    4 PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(CTL__NVME_DEV_STATE)
+  /*
+   * Device state is unknown, zero value
+   */
+  CTL__NVME_DEV_STATE__UNKNOWN = 0,
+  /*
+   * Device is in a normal operational state
+   */
+  CTL__NVME_DEV_STATE__NORMAL = 1,
+  /*
+   * Device is new and is not yet in-use
+   */
+  CTL__NVME_DEV_STATE__NEW = 2,
+  /*
+   * Device is faulty and has been evicted
+   */
+  CTL__NVME_DEV_STATE__EVICTED = 3,
+  /*
+   * Device has been physically removed
+   */
+  CTL__NVME_DEV_STATE__UNPLUGGED = 4
+    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(CTL__NVME_DEV_STATE)
 } Ctl__NvmeDevState;
 typedef enum _Ctl__LedState {
   /*
@@ -284,13 +284,10 @@ struct  _Ctl__SmdDevice
    */
   uint64_t usable_bytes;
 };
-#define CTL__SMD_DEVICE__INIT                                                                      \
-	{                                                                                          \
-		PROTOBUF_C_MESSAGE_INIT(&ctl__smd_device__descriptor)                              \
-		, (char *)protobuf_c_empty_string, 0, NULL, (char *)protobuf_c_empty_string,       \
-		    CTL__NVME_DEV_STATE__UNKNOWN, CTL__LED_STATE__OFF, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-		    0                                                                              \
-	}
+#define CTL__SMD_DEVICE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&ctl__smd_device__descriptor) \
+    , (char *)protobuf_c_empty_string, 0,NULL, (char *)protobuf_c_empty_string, CTL__NVME_DEV_STATE__UNKNOWN, CTL__LED_STATE__OFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+
 
 struct  _Ctl__SmdDevReq
 {

--- a/src/control/common/proto/ctl/smd.pb.go
+++ b/src/control/common/proto/ctl/smd.pb.go
@@ -29,7 +29,7 @@ const (
 type NvmeDevState int32
 
 const (
-	NvmeDevState_UNKNOWN   NvmeDevState = 0 // Device state is unknown, zer6o value
+	NvmeDevState_UNKNOWN   NvmeDevState = 0 // Device state is unknown, zero value
 	NvmeDevState_NORMAL    NvmeDevState = 1 // Device is in a normal operational state
 	NvmeDevState_NEW       NvmeDevState = 2 // Device is new and is not yet in-use
 	NvmeDevState_EVICTED   NvmeDevState = 3 // Device is faulty and has been evicted

--- a/src/control/server/ctl_smd_rpc.go
+++ b/src/control/server/ctl_smd_rpc.go
@@ -398,12 +398,12 @@ func addManageRespIDOnFail(log logging.Logger, res *ctlpb.SmdManageResp_Result, 
 // Retry dev-replace requests as state propagation may take some time after set-faulty call has
 // been made to manually trigger a faulty device state.
 func replaceDevRetryBusy(ctx context.Context, log logging.Logger, e Engine, req proto.Message) (res *ctlpb.SmdManageResp_Result, err error) {
-	for try := uint(0); try < uint(maxDevReplaceRetries); try++ {
+	for try := 0; try < maxDevReplaceRetries; try++ {
 		res, err = sendManageReq(ctx, e, drpc.MethodReplaceStorage, req)
 		if err != nil {
 			return
 		}
-		if daos.Status(res.Status) != daos.Busy {
+		if daos.Status(res.Status) != daos.Busy || try == maxDevReplaceRetries-1 {
 			break
 		}
 

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 
@@ -76,7 +77,7 @@ type EngineHarness struct {
 	instances     []Engine
 	started       atm.Bool
 	faultDomain   *system.FaultDomain
-	onDrpcFailure []func(context.Context, error)
+	onDrpcFailure []onDrpcFailureFn
 }
 
 // NewEngineHarness returns an initialized *EngineHarness.
@@ -146,8 +147,10 @@ func (h *EngineHarness) AddInstance(ei Engine) error {
 	return nil
 }
 
+type onDrpcFailureFn func(ctx context.Context, err error)
+
 // OnDrpcFailure registers callbacks to be invoked on dRPC call failure.
-func (h *EngineHarness) OnDrpcFailure(fns ...func(ctx context.Context, err error)) {
+func (h *EngineHarness) OnDrpcFailure(fns ...onDrpcFailureFn) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -156,44 +159,62 @@ func (h *EngineHarness) OnDrpcFailure(fns ...func(ctx context.Context, err error
 
 // CallDrpc calls the supplied dRPC method on a managed I/O Engine instance.
 func (h *EngineHarness) CallDrpc(ctx context.Context, method drpc.Method, body proto.Message) (resp *drpc.Response, err error) {
-	defer func() {
-		if err == nil {
-			return
-		}
-		// If the context was canceled, don't trigger callbacks.
-		if errors.Cause(err) == context.Canceled {
-			return
-		}
-		// Don't trigger callbacks for these errors which can happen when
-		// things are still starting up.
-		if err == FaultHarnessNotStarted || err == errEngineNotReady {
-			return
-		}
-
-		h.log.Debugf("invoking dRPC failure handlers for %s", err)
-		h.RLock()
-		defer h.RUnlock()
-		for _, fn := range h.onDrpcFailure {
-			fn(ctx, err)
-		}
-	}()
-
 	if !h.isStarted() {
 		return nil, FaultHarnessNotStarted
 	}
 
-	// Iterate through the managed instances, looking for
-	// the first one that is available to service the request.
-	// If the request fails, that error will be returned.
-	for _, i := range h.Instances() {
+	instances := h.Instances()
+	if len(instances) == 0 {
+		return nil, errors.New("no engine instances to service drpc call")
+	}
+
+	// Iterate through the managed instances, looking for the first one that is available to
+	// service the request. If non-transient error is returned from CallDrpc, that error will
+	// be returned immediately. If a transient error is returned, continue to the next engine.
+	drpcErrs := make([]error, 0, len(instances))
+	for _, i := range instances {
 		resp, err = i.CallDrpc(ctx, method, body)
+		if err == nil {
+			break
+		}
+
+		drpcErrs = append(drpcErrs, errors.Cause(err))
+		msg := fmt.Sprintf("failure on engine instance %d: %s", i.Index(), err)
 
 		switch errors.Cause(err) {
 		case errEngineNotReady, errDRPCNotReady, FaultDataPlaneNotStarted:
+			h.log.Debug("drpc call transient " + msg)
 			continue
-		default:
-			return
 		}
+
+		h.log.Debug("drpc call hard " + msg)
+		break
+	}
+
+	if err == nil {
+		return // Request sent.
+	}
+
+	var e error
+	hasDRPCErr := false
+	for _, e = range drpcErrs {
+		switch e {
+		case errDRPCNotReady, FaultDataPlaneNotStarted:
+			// If no engines can service request and drpc specific error has
+			// been returned then pass that error to the failure handlers.
+			hasDRPCErr = true
+			break
+		}
+	}
+	if !hasDRPCErr {
+		return // Don't trigger handlers on failures not related to dRPC comms.
+	}
+
+	h.log.Debugf("invoking dRPC failure handlers for %s", e)
+	h.RLock()
+	defer h.RUnlock()
+	for _, fn := range h.onDrpcFailure {
+		fn(ctx, e)
 	}
 
 	return
@@ -203,6 +224,20 @@ type dbLeader interface {
 	IsLeader() bool
 	ShutdownRaft() error
 	ResignLeadership(error) error
+}
+
+func newOnDrpcFailureFn(log logging.Logger, db dbLeader) onDrpcFailureFn {
+	return func(_ context.Context, errIn error) {
+		if !db.IsLeader() {
+			return
+		}
+
+		// If we cannot service a dRPC request on this node, we should resign as leader in
+		// order to force a new leader election.
+		if err := db.ResignLeadership(errIn); err != nil {
+			log.Errorf("failed to resign leadership after dRPC failure: %s", err)
+		}
+	}
 }
 
 // Start starts harness by setting up and starting dRPC before initiating
@@ -228,27 +263,7 @@ func (h *EngineHarness) Start(ctx context.Context, db dbLeader, cfg *config.Serv
 		ei.Run(ctx, cfg.RecreateSuperblocks)
 	}
 
-	h.OnDrpcFailure(func(_ context.Context, errIn error) {
-		if !db.IsLeader() {
-			return
-		}
-
-		switch errors.Cause(errIn) {
-		case errDRPCNotReady, FaultDataPlaneNotStarted:
-			break
-		default:
-			// Don't shutdown on other failures which are
-			// not related to dRPC communications.
-			return
-		}
-
-		// If we cannot service a dRPC request on this node,
-		// we should resign as leader in order to force a new
-		// leader election.
-		if err := db.ResignLeadership(errIn); err != nil {
-			h.log.Errorf("failed to resign leadership after dRPC failure: %s", err)
-		}
-	})
+	h.OnDrpcFailure(newOnDrpcFailureFn(h.log, db))
 
 	<-ctx.Done()
 	h.log.Debug("shutting down harness")

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -519,20 +519,6 @@ func TestServer_Harness_CallDrpc(t *testing.T) {
 				},
 			},
 		},
-		"one not ready, one fails": {
-			mics: []*MockInstanceConfig{
-				{
-					Ready:       atm.NewBool(true),
-					CallDrpcErr: errDRPCNotReady,
-				},
-				{
-					Ready:       atm.NewBool(true),
-					CallDrpcErr: errors.New("whoops"),
-				},
-			},
-			expErr:         errors.New("whoops"),
-			expFailHandler: true,
-		},
 		"instance not ready": {
 			mics: []*MockInstanceConfig{
 				{
@@ -557,8 +543,7 @@ func TestServer_Harness_CallDrpc(t *testing.T) {
 					Ready: atm.NewBool(true),
 				},
 			},
-			expErr:         errors.New("whoops"),
-			expFailHandler: true,
+			expErr: errors.New("whoops"),
 		},
 		"none available": {
 			mics: []*MockInstanceConfig{
@@ -573,6 +558,79 @@ func TestServer_Harness_CallDrpc(t *testing.T) {
 			},
 			expNotLeader:   true,
 			expErr:         FaultDataPlaneNotStarted,
+			expFailHandler: true,
+		},
+		"none available; not leader": {
+			notLeader: true,
+			mics: []*MockInstanceConfig{
+				{
+					Ready:       atm.NewBool(true),
+					CallDrpcErr: errDRPCNotReady,
+				},
+				{
+					Ready:       atm.NewBool(true),
+					CallDrpcErr: FaultDataPlaneNotStarted,
+				},
+			},
+			expNotLeader:   true,
+			expErr:         FaultDataPlaneNotStarted,
+			expFailHandler: true,
+		},
+		"none available; no drpc related errors": {
+			mics: []*MockInstanceConfig{
+				{
+					Started:     atm.NewBool(true),
+					CallDrpcErr: errEngineNotReady,
+				},
+				{
+					Ready:       atm.NewBool(true),
+					CallDrpcErr: errors.New("whoops"),
+				},
+			},
+			expErr: errors.New("whoops"),
+		},
+		"none available; one engine not ready, one drpc not ready": {
+			mics: []*MockInstanceConfig{
+				{
+					Started:     atm.NewBool(true),
+					CallDrpcErr: errEngineNotReady,
+				},
+				{
+					Ready:       atm.NewBool(true),
+					CallDrpcErr: errDRPCNotReady,
+				},
+			},
+			expNotLeader:   true,
+			expErr:         errDRPCNotReady,
+			expFailHandler: true,
+		},
+		"none available; one drpc not ready, one engine not ready": {
+			mics: []*MockInstanceConfig{
+				{
+					Ready:       atm.NewBool(true),
+					CallDrpcErr: errDRPCNotReady,
+				},
+				{
+					Started:     atm.NewBool(true),
+					CallDrpcErr: errEngineNotReady,
+				},
+			},
+			expNotLeader:   true,
+			expErr:         errEngineNotReady,
+			expFailHandler: true,
+		},
+		"none available; one data-plane not ready, one engine not ready": {
+			mics: []*MockInstanceConfig{
+				{
+					CallDrpcErr: FaultDataPlaneNotStarted,
+				},
+				{
+					Started:     atm.NewBool(true),
+					CallDrpcErr: errEngineNotReady,
+				},
+			},
+			expNotLeader:   true,
+			expErr:         errEngineNotReady,
 			expFailHandler: true,
 		},
 		"context canceled": {
@@ -596,15 +654,17 @@ func TestServer_Harness_CallDrpc(t *testing.T) {
 				}
 			}
 
-			var drpcFailureInvoked atm.Bool
-			h.OnDrpcFailure(func(_ context.Context, err error) {
-				drpcFailureInvoked.SetTrue()
-			})
-
-			ctx, cancel := context.WithCancel(test.Context(t))
 			db := &mockdb{
 				isLeader: !tc.notLeader,
 			}
+
+			var drpcFailureInvoked atm.Bool
+			h.OnDrpcFailure(func(ctx context.Context, err error) {
+				drpcFailureInvoked.SetTrue()
+				newOnDrpcFailureFn(log, db)(ctx, err)
+			})
+
+			ctx, cancel := context.WithCancel(test.Context(t))
 
 			startErr := make(chan error)
 			go func() {

--- a/src/mgmt/smd.pb-c.c
+++ b/src/mgmt/smd.pb-c.c
@@ -2570,33 +2570,39 @@ const ProtobufCMessageDescriptor ctl__smd_manage_resp__descriptor =
   (ProtobufCMessageInit) ctl__smd_manage_resp__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCEnumValue ctl__nvme_dev_state__enum_values_by_number[5] = {
-    {"UNKNOWN", "CTL__NVME_DEV_STATE__UNKNOWN", 0},
-    {"NORMAL", "CTL__NVME_DEV_STATE__NORMAL", 1},
-    {"NEW", "CTL__NVME_DEV_STATE__NEW", 2},
-    {"EVICTED", "CTL__NVME_DEV_STATE__EVICTED", 3},
-    {"UNPLUGGED", "CTL__NVME_DEV_STATE__UNPLUGGED", 4},
+static const ProtobufCEnumValue ctl__nvme_dev_state__enum_values_by_number[5] =
+{
+  { "UNKNOWN", "CTL__NVME_DEV_STATE__UNKNOWN", 0 },
+  { "NORMAL", "CTL__NVME_DEV_STATE__NORMAL", 1 },
+  { "NEW", "CTL__NVME_DEV_STATE__NEW", 2 },
+  { "EVICTED", "CTL__NVME_DEV_STATE__EVICTED", 3 },
+  { "UNPLUGGED", "CTL__NVME_DEV_STATE__UNPLUGGED", 4 },
 };
-static const ProtobufCIntRange       ctl__nvme_dev_state__value_ranges[]         = {{0, 0}, {0, 5}};
-static const ProtobufCEnumValueIndex ctl__nvme_dev_state__enum_values_by_name[5] = {
-    {"EVICTED", 3}, {"NEW", 2}, {"NORMAL", 1}, {"UNKNOWN", 0}, {"UNPLUGGED", 4},
+static const ProtobufCIntRange ctl__nvme_dev_state__value_ranges[] = {
+{0, 0},{0, 5}
 };
-const ProtobufCEnumDescriptor ctl__nvme_dev_state__descriptor = {
-    PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,
-    "ctl.NvmeDevState",
-    "NvmeDevState",
-    "Ctl__NvmeDevState",
-    "ctl",
-    5,
-    ctl__nvme_dev_state__enum_values_by_number,
-    5,
-    ctl__nvme_dev_state__enum_values_by_name,
-    1,
-    ctl__nvme_dev_state__value_ranges,
-    NULL,
-    NULL,
-    NULL,
-    NULL /* reserved[1234] */
+static const ProtobufCEnumValueIndex ctl__nvme_dev_state__enum_values_by_name[5] =
+{
+  { "EVICTED", 3 },
+  { "NEW", 2 },
+  { "NORMAL", 1 },
+  { "UNKNOWN", 0 },
+  { "UNPLUGGED", 4 },
+};
+const ProtobufCEnumDescriptor ctl__nvme_dev_state__descriptor =
+{
+  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,
+  "ctl.NvmeDevState",
+  "NvmeDevState",
+  "Ctl__NvmeDevState",
+  "ctl",
+  5,
+  ctl__nvme_dev_state__enum_values_by_number,
+  5,
+  ctl__nvme_dev_state__enum_values_by_name,
+  1,
+  ctl__nvme_dev_state__value_ranges,
+  NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
 static const ProtobufCEnumValue ctl__led_state__enum_values_by_number[5] =
 {

--- a/src/mgmt/smd.pb-c.h
+++ b/src/mgmt/smd.pb-c.h
@@ -41,27 +41,27 @@ typedef struct _Ctl__SmdManageResp__RankResp Ctl__SmdManageResp__RankResp;
 /* --- enums --- */
 
 typedef enum _Ctl__NvmeDevState {
-	/*
-	 * Device state is unknown, zer6o value
-	 */
-	CTL__NVME_DEV_STATE__UNKNOWN = 0,
-	/*
-	 * Device is in a normal operational state
-	 */
-	CTL__NVME_DEV_STATE__NORMAL = 1,
-	/*
-	 * Device is new and is not yet in-use
-	 */
-	CTL__NVME_DEV_STATE__NEW = 2,
-	/*
-	 * Device is faulty and has been evicted
-	 */
-	CTL__NVME_DEV_STATE__EVICTED = 3,
-	/*
-	 * Device has been physically removed
-	 */
-	CTL__NVME_DEV_STATE__UNPLUGGED =
-	    4 PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(CTL__NVME_DEV_STATE)
+  /*
+   * Device state is unknown, zero value
+   */
+  CTL__NVME_DEV_STATE__UNKNOWN = 0,
+  /*
+   * Device is in a normal operational state
+   */
+  CTL__NVME_DEV_STATE__NORMAL = 1,
+  /*
+   * Device is new and is not yet in-use
+   */
+  CTL__NVME_DEV_STATE__NEW = 2,
+  /*
+   * Device is faulty and has been evicted
+   */
+  CTL__NVME_DEV_STATE__EVICTED = 3,
+  /*
+   * Device has been physically removed
+   */
+  CTL__NVME_DEV_STATE__UNPLUGGED = 4
+    PROTOBUF_C__FORCE_ENUM_TO_BE_INT_SIZE(CTL__NVME_DEV_STATE)
 } Ctl__NvmeDevState;
 typedef enum _Ctl__LedState {
   /*
@@ -284,13 +284,10 @@ struct  _Ctl__SmdDevice
    */
   uint64_t usable_bytes;
 };
-#define CTL__SMD_DEVICE__INIT                                                                      \
-	{                                                                                          \
-		PROTOBUF_C_MESSAGE_INIT(&ctl__smd_device__descriptor)                              \
-		, (char *)protobuf_c_empty_string, 0, NULL, (char *)protobuf_c_empty_string,       \
-		    CTL__NVME_DEV_STATE__UNKNOWN, CTL__LED_STATE__OFF, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-		    0                                                                              \
-	}
+#define CTL__SMD_DEVICE__INIT \
+ { PROTOBUF_C_MESSAGE_INIT (&ctl__smd_device__descriptor) \
+    , (char *)protobuf_c_empty_string, 0,NULL, (char *)protobuf_c_empty_string, CTL__NVME_DEV_STATE__UNKNOWN, CTL__LED_STATE__OFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+
 
 struct  _Ctl__SmdDevReq
 {

--- a/src/proto/ctl/smd.proto
+++ b/src/proto/ctl/smd.proto
@@ -76,7 +76,7 @@ message BioHealthResp {
 }
 
 enum NvmeDevState {
-	UNKNOWN   = 0; // Device state is unknown, zer6o value
+	UNKNOWN   = 0; // Device state is unknown, zero value
 	NORMAL    = 1; // Device is in a normal operational state
 	NEW       = 2; // Device is new and is not yet in-use
 	EVICTED   = 3; // Device is faulty and has been evicted


### PR DESCRIPTION
…s (#12944)

Refactor harness CallDrpc method to simplify and try to improve
clarity of intent. Remove potential for failure handlers not to get
called on a dRPC comms related error. Also provide minor fixes related
to review comments on previously landed PRs 12858 and 12871.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
