### PR TITLE
DAOS-623 build: Fail the build stage in Jenkins for rpm build failure.

### DIFF
--- a/ci/rpm/build_unsuccessful.sh
+++ b/ci/rpm/build_unsuccessful.sh
@@ -8,7 +8,7 @@ mydir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ci_envs="$mydir/../parse_ci_envs.sh"
 if [ -e "${ci_envs}" ]; then
   # at some point we want to use: shellcheck source=ci/parse_ci_envs.sh
-  # shellcheck disable=SC1091
+  # shellcheck disable=SC1091,SC1090
   source "${ci_envs}"
 fi
 
@@ -24,6 +24,9 @@ if [ -d /var/cache/pbuilder/ ]; then
     fi)
     exit 0
 fi
+
+rpm -q mock
+mock --debug-config
 
 mockroot="/var/lib/mock/$CHROOT_NAME"
 cat "$mockroot"/result/{root,build}.log 2>/dev/null || true

--- a/utils/rpms/packaging/rpm_chrootbuild
+++ b/utils/rpms/packaging/rpm_chrootbuild
@@ -117,11 +117,7 @@ echo "\"\"\"" >> "$cfg_file"
 if [ -n "$DISTRO_VERSION" ]; then
     releasever_opt=("--config-opts=releasever=$DISTRO_VERSION")
 fi
-# shellcheck disable=SC2086
-if ! eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}"           \
-          ${repo_dels[*]} ${repo_adds[*]} --disablerepo=\*-debug*           \
-          "${releasever_opt[@]}" $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"; then
-    # Debug information for filing bugs on mock
-    rpm -q mock
-    mock --debug-config
-fi
+
+# shellcheck disable=SC2086,SC2048,SC2294
+eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}" ${repo_dels[*]} ${repo_adds[*]}       \
+    --disablerepo=\*-debug* "${releasever_opt[@]}" $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"


### PR DESCRIPTION
Some debugging for failures meant that the actual result was being
masked.  Move the debugging to the "unsuccessful" script and
re-instate the fail-on-failure behaviour.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
