### PR TITLE
DAOS-13674 test: Bump pool size in container/snapshot.py (#13012)

### DIFF
--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -141,7 +141,7 @@ class Snapshot(TestWithServers):
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
         :avocado: tags=container,smoke,snap,snapshot
-        :avocado: tags=snapshot_negative,snapshotcreate_negative,test_snapshot_negativecases
+        :avocado: tags=Snapshot,test_snapshot_negativecases
         """
 
         # DAOS-1322 Create a new container, verify snapshot state as expected
@@ -315,7 +315,7 @@ class Snapshot(TestWithServers):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=container,smoke,snap,snapshot
-        :avocado: tags=snapshots,test_snapshots
+        :avocado: tags=Snapshot,test_snapshots
         """
 
         test_data = []

--- a/src/tests/ftest/container/snapshot.yaml
+++ b/src/tests/ftest/container/snapshot.yaml
@@ -17,7 +17,7 @@ server_config:
           scm_mount: /mnt/daos
   system_ram_reserved: 1
 pool:
-  scm_size: 1G
+  scm_size: 5G
   control_method: dmg
 snapshot:
   dkey: "dkey"


### PR DESCRIPTION
To avoid ENOSPACE failures with large single value writes the pool size has been increased in the container/snapshot.py test.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: Snapshot
Test-repeat: 10

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
