### PR TITLE
DAOS-14332 control: Use gRPC metadata for interop

### DIFF
--- a/src/control/cmd/daos_agent/main.go
+++ b/src/control/cmd/daos_agent/main.go
@@ -257,6 +257,7 @@ func main() {
 
 	ctlInvoker := control.NewClient(
 		control.WithClientLogger(log),
+		control.WithClientComponent(build.ComponentAgent),
 	)
 
 	if err := parseOpts(os.Args[1:], &opts, ctlInvoker, log); err != nil {

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -302,6 +302,7 @@ func main() {
 
 	ctlInvoker := control.NewClient(
 		control.WithClientLogger(log),
+		control.WithClientComponent(build.ComponentAdmin),
 	)
 
 	if err := parseOpts(os.Args[1:], &opts, ctlInvoker, log); err != nil {

--- a/src/control/common/proto/consts.go
+++ b/src/control/common/proto/consts.go
@@ -1,0 +1,14 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package proto
+
+const (
+	// DaosComponentHeader defines the header name used to convey the component name.
+	DaosComponentHeader = "x-daos-component"
+	// DaosVersionHeader defines the header name used to convey the component version.
+	DaosVersionHeader = "x-daos-version"
+)

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/runtime/protoimpl"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	commonpb "github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
@@ -50,6 +51,7 @@ type (
 	// for a MockInvoker.
 	MockInvokerConfig struct {
 		Sys                 string
+		Component           build.Component
 		UnaryError          error
 		UnaryResponse       *UnaryResponse
 		UnaryResponseSet    []*UnaryResponse
@@ -100,6 +102,10 @@ func (mi *MockInvoker) Debugf(fmtStr string, args ...interface{}) {
 
 func (mi *MockInvoker) GetSystem() string {
 	return mi.cfg.Sys
+}
+
+func (mi *MockInvoker) GetComponent() build.Component {
+	return mi.cfg.Component
 }
 
 func (mi *MockInvoker) InvokeUnaryRPC(ctx context.Context, uReq UnaryRequest) (*UnaryResponse, error) {

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -196,7 +196,10 @@ func (c *Client) Debugf(fmtStr string, args ...interface{}) {
 func (c *Client) dialOptions() ([]grpc.DialOption, error) {
 	opts := []grpc.DialOption{
 		streamErrorInterceptor(),
-		unaryErrorInterceptor(),
+		grpc.WithChainUnaryInterceptor(
+			unaryErrorInterceptor(),
+			unaryVersionedComponentInterceptor(),
+		),
 		grpc.FailOnNonTempDialError(true),
 	}
 

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
@@ -88,6 +89,7 @@ type (
 	UnaryInvoker interface {
 		sysGetter
 		debugLogger
+		GetComponent() build.Component
 		InvokeUnaryRPC(ctx context.Context, req UnaryRequest) (*UnaryResponse, error)
 		InvokeUnaryRPCAsync(ctx context.Context, req UnaryRequest) (HostResponseChan, error)
 	}
@@ -122,13 +124,21 @@ type (
 	// Client implements the Invoker interface and should be provided to
 	// API methods to invoke RPCs.
 	Client struct {
-		config *Config
-		log    debugLogger
+		config    *Config
+		log       debugLogger
+		component build.Component
 	}
 
 	// ClientOption defines the signature for functional Client options.
 	ClientOption func(c *Client)
 )
+
+// WithClientComponent sets the client's component.
+func WithClientComponent(comp build.Component) ClientOption {
+	return func(c *Client) {
+		c.component = comp
+	}
+}
 
 // WithClientLogger sets the client's debugLogger.
 func WithClientLogger(log debugLogger) ClientOption {
@@ -171,6 +181,11 @@ func DefaultClient() *Client {
 	)
 }
 
+// GetComponent returns the client's component.
+func (c *Client) GetComponent() build.Component {
+	return c.component
+}
+
 // SetConfig sets the client configuration for an
 // existing Client.
 func (c *Client) SetConfig(cfg *Config) {
@@ -198,7 +213,7 @@ func (c *Client) dialOptions() ([]grpc.DialOption, error) {
 		streamErrorInterceptor(),
 		grpc.WithChainUnaryInterceptor(
 			unaryErrorInterceptor(),
-			unaryVersionedComponentInterceptor(),
+			unaryVersionedComponentInterceptor(c.GetComponent()),
 		),
 		grpc.FailOnNonTempDialError(true),
 	}

--- a/src/control/security/grpc_authorization.go
+++ b/src/control/security/grpc_authorization.go
@@ -6,6 +6,12 @@
 
 package security
 
+import (
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/build"
+)
+
 // Component represents the DAOS component being granted authorization.
 type Component int
 
@@ -75,6 +81,16 @@ var methodAuthorizations = map[string][]Component{
 	"/RaftTransport/RequestVote":           {ComponentServer},
 	"/RaftTransport/TimeoutNow":            {ComponentServer},
 	"/RaftTransport/InstallSnapshot":       {ComponentServer},
+}
+
+// MethodToComponent resolves a gRPC method string to a build.Component.
+func MethodToComponent(method string) (build.Component, error) {
+	comps, found := methodAuthorizations[method]
+	if !found || len(comps) == 0 {
+		return build.ComponentAny, errors.Errorf("method %s does not map to a known authorized component", method)
+	}
+
+	return build.Component(comps[0].String()), nil
 }
 
 // HasAccess check if the given component has access to method given in FullMethod

--- a/src/control/security/grpc_authorization.go
+++ b/src/control/security/grpc_authorization.go
@@ -87,7 +87,7 @@ var methodAuthorizations = map[string][]Component{
 func MethodToComponent(method string) (build.Component, error) {
 	comps, found := methodAuthorizations[method]
 	if !found || len(comps) == 0 {
-		return build.ComponentAny, errors.Errorf("method %s does not map to a known authorized component", method)
+		return build.ComponentAny, errors.Errorf("method %q does not map to a known authorized component", method)
 	}
 
 	return build.Component(comps[0].String()), nil

--- a/src/control/security/grpc_authorization_test.go
+++ b/src/control/security/grpc_authorization_test.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/build"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/common/test"
@@ -215,6 +218,59 @@ func TestSecurity_AuthorizedRpcsAreValid(t *testing.T) {
 			if len(invalid) > 0 {
 				t.Fatalf("authorized RPCs without server methods (remove from methodAuthorizations):\n%s", strings.Join(invalid, "\n"))
 			}
+		})
+	}
+}
+
+func TestSecurity_MethodToCompnent(t *testing.T) {
+	for name, tc := range map[string]struct {
+		method  string
+		authMap map[string][]Component
+		expComp build.Component
+		expErr  error
+	}{
+		"method maps to an unknown component": {
+			method: "/unknown",
+			expErr: errors.New("does not map"),
+		},
+		"method maps to 0 components": {
+			method: "/zero",
+			authMap: map[string][]Component{
+				"/zero": nil,
+			},
+			expErr: errors.New("does not map"),
+		},
+		"method maps to 2 components": {
+			method: "/two",
+			authMap: map[string][]Component{
+				"/two": {ComponentAdmin, ComponentAgent},
+			},
+			expErr: errors.New("multiple authorized"),
+		},
+		"method maps to 1 component": {
+			method: "/one",
+			authMap: map[string][]Component{
+				"/one": {ComponentServer},
+			},
+			expComp: build.ComponentServer,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var gotComp build.Component
+			var gotErr error
+
+			if tc.authMap != nil {
+				gotComp, gotErr = methodToComponent(tc.method, tc.authMap)
+			} else {
+				gotComp, gotErr = MethodToComponent(tc.method)
+			}
+
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			test.AssertEqual(t, tc.expComp, gotComp, "unexpected component")
 		})
 	}
 }

--- a/src/control/server/interceptors.go
+++ b/src/control/server/interceptors.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -116,7 +117,32 @@ var selfServerComponent = func() *build.VersionedComponent {
 	return self
 }()
 
-func checkVersion(ctx context.Context, self *build.VersionedComponent, req interface{}) error {
+func compVersionFromHeaders(ctx context.Context) *build.VersionedComponent {
+	md, hasMD := metadata.FromIncomingContext(ctx)
+	if !hasMD {
+		return nil
+	}
+	compName, hasName := md[proto.DaosComponentHeader]
+	if !hasName {
+		return nil
+	}
+	comp := build.Component(compName[0])
+	compVersion, hasVersion := md[proto.DaosVersionHeader]
+	if !hasVersion {
+		return nil
+	}
+	ver, err := build.NewVersion(compVersion[0])
+	if err != nil {
+		return nil
+	}
+
+	return &build.VersionedComponent{
+		Component: comp,
+		Version:   ver,
+	}
+}
+
+func checkVersion(ctx context.Context, log logging.Logger, self *build.VersionedComponent, req interface{}) error {
 	// If we can't determine our own version, then there's no
 	// checking to be done.
 	if self.Version.IsZero() {
@@ -127,33 +153,53 @@ func checkVersion(ctx context.Context, self *build.VersionedComponent, req inter
 	// are most stringent for server/server communication. We have
 	// to set a default because this security component lookup
 	// will fail if certificates are disabled.
-	buildComponent := build.ComponentServer
+	otherComponent := build.ComponentServer
+	otherVersion := build.MustNewVersion("0.0.0")
 	secComponent, err := componentFromContext(ctx)
 	if err == nil {
-		buildComponent = build.Component(secComponent.String())
+		otherComponent = build.Component(secComponent.String())
 	}
 	isInsecure := status.Code(err) == codes.Unauthenticated
 
-	otherVersion := build.MustNewVersion("0.0.0")
-	if sReq, ok := req.(interface{ GetSys() string }); ok {
-		comps := strings.Split(sReq.GetSys(), "-")
-		if len(comps) > 1 {
-			if ver, err := build.NewVersion(comps[len(comps)-1]); err == nil {
-				otherVersion = ver
-			}
+	// Prefer the new header-based component/version mechanism.
+	// If we are in secure mode, verify that the component presented
+	// in the header matches the certificate's component.
+	fromHeaders := compVersionFromHeaders(ctx)
+	if fromHeaders != nil {
+		otherVersion = fromHeaders.Version
+		if isInsecure {
+			otherComponent = fromHeaders.Component
+		} else if otherComponent != fromHeaders.Component {
+			return status.Errorf(codes.PermissionDenied, "invalid component %q for request", fromHeaders.Component)
 		}
 	} else {
-		// If the request message type does not implement GetSys(), then
-		// there is no version to check. We leave message compatibility
-		// to lower layers.
-		return nil
+		// If we did not receive a version via request header, then we need to fall back
+		// to trying to pick it out of the overloaded system name field.
+		//
+		// TODO (DAOS-14336): Remove this once the compatibility window has closed (e.g. for 2.8+).
+		if sReq, ok := req.(interface{ GetSys() string }); ok {
+			comps := strings.Split(sReq.GetSys(), "-")
+			if len(comps) > 1 {
+				if ver, err := build.NewVersion(comps[len(comps)-1]); err == nil {
+					otherVersion = ver
+				}
+			}
+		} else {
+			// If the request message type does not implement GetSys(), then
+			// there is no version to check. We leave message compatibility
+			// to lower layers.
+			return nil
+		}
+
+		// If we're running without certificates and we didn't receive a component
+		// via headers, then we have to enforce the strictest compatibility requirements,
+		// i.e. exact same version.
+		if isInsecure && !self.Version.Equals(otherVersion) {
+			return FaultNoCompatibilityInsecure(self.Version, otherVersion)
+		}
 	}
 
-	if isInsecure && !self.Version.Equals(otherVersion) {
-		return FaultNoCompatibilityInsecure(self.Version, otherVersion)
-	}
-
-	other, err := build.NewVersionedComponent(buildComponent, otherVersion.String())
+	other, err := build.NewVersionedComponent(otherComponent, otherVersion.String())
 	if err != nil {
 		other = &build.VersionedComponent{
 			Component: "unknown",
@@ -163,18 +209,22 @@ func checkVersion(ctx context.Context, self *build.VersionedComponent, req inter
 	}
 
 	if err := build.CheckCompatibility(self, other); err != nil {
+		log.Errorf("%s is incompatible with %s", other, self)
 		return FaultIncompatibleComponents(self, other)
 	}
 
+	log.Debugf("%s is compatible with %s", other, self)
 	return nil
 }
 
-func unaryVersionInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	if err := checkVersion(ctx, selfServerComponent, req); err != nil {
-		return nil, errors.Wrapf(err, "version check failed for %T", req)
-	}
+func unaryVersionInterceptor(log logging.Logger) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if err := checkVersion(ctx, log, selfServerComponent, req); err != nil {
+			return nil, errors.Wrapf(err, "version check failed for %T", req)
+		}
 
-	return handler(ctx, req)
+		return handler(ctx, req)
+	}
 }
 
 func unaryErrorInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {

--- a/src/control/server/interceptors_test.go
+++ b/src/control/server/interceptors_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -173,6 +173,14 @@ func TestServer_checkVersion(t *testing.T) {
 			)),
 			nonSysMsg: true,
 		},
+		"insecure 2.6.0 agent with 2.4.1 server": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAgent.String(),
+				proto.DaosVersionHeader, "2.6.0",
+			)),
+			nonSysMsg: true,
+		},
 		"insecure 2.4.1 dmg with 2.4.0 server": {
 			selfVersion: "2.4.0",
 			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
@@ -207,6 +215,15 @@ func TestServer_checkVersion(t *testing.T) {
 			nonSysMsg: true,
 			expErr:    errors.New("not compatible"),
 		},
+		"invalid component": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, "banana",
+				proto.DaosVersionHeader, "2.6.0",
+			)),
+			nonSysMsg: true,
+			expErr:    errors.New("invalid component"),
+		},
 		"header/certificate component mismatch": {
 			selfVersion: "2.4.0",
 			ctx: newTestAuthCtx(
@@ -215,7 +232,7 @@ func TestServer_checkVersion(t *testing.T) {
 					proto.DaosVersionHeader, "2.6.0"),
 				), "agent"),
 			nonSysMsg: true,
-			expErr:    errors.New("invalid component"),
+			expErr:    errors.New("component mismatch"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/server/interceptors_test.go
+++ b/src/control/server/interceptors_test.go
@@ -16,12 +16,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 type testStatus struct {
@@ -141,9 +144,78 @@ func TestServer_checkVersion(t *testing.T) {
 			otherVersion: "2.4.0",
 			ctx:          newTestAuthCtx(test.Context(t), "agent"),
 		},
-		"non-sys msg bypasses version checks": {
+		"non-sys msg bypasses version checks in secure mode": {
 			selfVersion: "2.4.0",
+			ctx:         newTestAuthCtx(test.Context(t), "agent"),
 			nonSysMsg:   true,
+		},
+		"insecure prelease agent with 2.4.0 server": {
+			selfVersion: "2.4.0",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAgent.String(),
+				proto.DaosVersionHeader, "2.3.108",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.4.1 agent with 2.4.0 server": {
+			selfVersion: "2.4.0",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAgent.String(),
+				proto.DaosVersionHeader, "2.4.1",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.4.0 agent with 2.4.1 server": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAgent.String(),
+				proto.DaosVersionHeader, "2.4.0",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.4.1 dmg with 2.4.0 server": {
+			selfVersion: "2.4.0",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAdmin.String(),
+				proto.DaosVersionHeader, "2.4.1",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.6.0 dmg with 2.4.0 server": {
+			selfVersion: "2.4.0",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAdmin.String(),
+				proto.DaosVersionHeader, "2.6.0",
+			)),
+			nonSysMsg: true,
+			expErr:    errors.New("not compatible"),
+		},
+		"insecure 2.4.0 server with 2.4.1 server": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentServer.String(),
+				proto.DaosVersionHeader, "2.4.0",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.6.0 server with 2.4.1 server": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentServer.String(),
+				proto.DaosVersionHeader, "2.6.0",
+			)),
+			nonSysMsg: true,
+			expErr:    errors.New("not compatible"),
+		},
+		"header/certificate component mismatch": {
+			selfVersion: "2.4.0",
+			ctx: newTestAuthCtx(
+				metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+					proto.DaosComponentHeader, build.ComponentServer.String(),
+					proto.DaosVersionHeader, "2.6.0"),
+				), "agent"),
+			nonSysMsg: true,
+			expErr:    errors.New("invalid component"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -169,7 +241,10 @@ func TestServer_checkVersion(t *testing.T) {
 				req = verReq
 			}
 
-			gotErr := checkVersion(ctx, selfComp, req)
+			log, buf := logging.NewTestLogger(name)
+			test.ShowBufferOnFailure(t, buf)
+
+			gotErr := checkVersion(ctx, log, selfComp, req)
 			test.CmpErr(t, tc.expErr, gotErr)
 		})
 	}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -188,6 +188,7 @@ func (srv *server) createServices(ctx context.Context) (err error) {
 	cliCfg := control.DefaultConfig()
 	cliCfg.TransportConfig = srv.cfg.TransportConfig
 	rpcClient := control.NewClient(
+		control.WithClientComponent(build.ComponentServer),
 		control.WithConfig(cliCfg),
 		control.WithClientLogger(srv.log))
 

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -714,7 +714,7 @@ func getGrpcOpts(log logging.Logger, cfgTransport *security.TransportConfig, ldr
 		unaryLoggingInterceptor(log, ldrChk), // must be first in order to properly log errors
 		unaryErrorInterceptor,
 		unaryStatusInterceptor,
-		unaryVersionInterceptor,
+		unaryVersionInterceptor(log),
 	}
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		streamErrorInterceptor,


### PR DESCRIPTION
The interoperability checking code relies on getting the
peer component from the peer certificate. When running
in insecure mode, the peer component information is
unavailable, and the interoperability check defaults
to the most stringent requirements.

This patch adds new component/version headers to the
grpc client request to allow the server to perform
interoperability checks without the peer certificate.

Features: control

Required-githooks: true
Change-Id: I1d9a6d171ecadded3bf041a36e2a156881d93f57
Signed-off-by: Michael MacDonald <mjmac@google.com>
