### PR TITLE
Wangdi/release 24 13909

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1323,14 +1323,17 @@ pool_map_merge(struct pool_map *map, uint32_t version,
 			/* new buffer may have changes for this domain */
 			if (sdom->do_children != NULL) {
 				struct pool_domain *child = addr;
+				struct pool_comp_cntr	s_cntr;
 
-				D_DEBUG(DB_TRACE, "Scan children of %s[%d]\n",
+				pool_tree_count(sdom, &s_cntr);
+				D_DEBUG(DB_TRACE, "Scan children of %s[%d] tgt_nr %u\n",
 					pool_domain_name(ddom),
-					ddom->do_comp.co_id);
+					ddom->do_comp.co_id, s_cntr.cc_targets);
 
 				if (ddom->do_children == NULL)
 					ddom->do_children = child;
 
+				ddom->do_target_nr += s_cntr.cc_targets;
 				/* copy new child domains to dest buffer */
 				for (j = 0; j < sdom->do_child_nr; j++) {
 					struct pool_component *dc;

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -620,7 +620,6 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 		d_iov_t *csum_iov_fetch)
 {
 	struct migrate_pool_tls	*tls;
-	struct dc_object	*obj;
 	int			rc = 0;
 
 	tls = migrate_pool_tls_lookup(mrone->mo_pool_uuid,
@@ -634,21 +633,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 	if (daos_oclass_grp_size(&mrone->mo_oca) > 1)
 		flags |= DIOF_TO_LEADER;
 
-	/**
-	 * For EC data migration, let's force it to do degraded fetch,
-	 * make sure reintegration will not fetch from the original
-	 * shard, which might cause parity corruption.
-	 */
-	obj = obj_hdl2ptr(oh);
-	if (iods[0].iod_type != DAOS_IOD_SINGLE &&
-	    daos_oclass_is_ec(&mrone->mo_oca) &&
-	    is_ec_data_shard(obj, mrone->mo_dkey_hash, mrone->mo_oid.id_shard) &&
-	    obj_ec_parity_alive(oh, mrone->mo_dkey_hash, NULL))
-		flags |= DIOF_FOR_FORCE_DEGRADE;
-
-	obj_decref(obj);
-
-	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
+	rc = dsc_obj_fetch(oh, eph, &mrone->mo_dkey,
 			   iod_num, iods, sgls, NULL,
 			   flags, NULL, csum_iov_fetch);
 	if (rc != 0)
@@ -669,7 +654,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 		csum_iov_fetch->iov_len = 0;
 		csum_iov_fetch->iov_buf = p;
 
-		rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey, iod_num, iods, sgls,
+		rc = dsc_obj_fetch(oh, eph, &mrone->mo_dkey, iod_num, iods, sgls,
 				   NULL, flags, NULL, csum_iov_fetch);
 	}
 
@@ -1223,7 +1208,8 @@ out:
 
 static int
 __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
-			    daos_iod_t *iods, int iod_num, daos_epoch_t update_eph,
+			    daos_iod_t *iods, int iod_num, daos_epoch_t fetch_eph,
+			    daos_epoch_t update_eph,
 			    uint32_t flags, struct ds_cont_child *ds_cont)
 {
 	d_sg_list_t		 sgls[OBJ_ENUM_UNPACK_MAX_IODS];
@@ -1282,8 +1268,7 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 		p_csum_iov = &csum_iov;
 	}
 
-	rc = mrone_obj_fetch(mrone, oh, sgls, iods, iod_num, mrone->mo_epoch,
-			     flags, p_csum_iov);
+	rc = mrone_obj_fetch(mrone, oh, sgls, iods, iod_num, fetch_eph, flags, p_csum_iov);
 	if (rc) {
 		D_ERROR("migrate dkey "DF_KEY" failed: "DF_RC"\n",
 			DP_KEY(&mrone->mo_dkey), DP_RC(rc));
@@ -1358,6 +1343,7 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	if (!daos_oclass_is_ec(&mrone->mo_oca))
 		return __migrate_fetch_update_bulk(mrone, oh, mrone->mo_iods,
 						   mrone->mo_iod_num,
+						   mrone->mo_epoch,
 						   mrone->mo_min_epoch,
 						   DIOF_FOR_MIGRATION, ds_cont);
 
@@ -1370,22 +1356,19 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	 * this data shard.
 	 */
 
-	if (mrone->mo_iods_num_from_parity > 0) {
-		daos_epoch_t min_eph = DAOS_EPOCH_MAX;
+	for (i = 0; i < mrone->mo_iods_num_from_parity; i++) {
+		for (j = 0; j < mrone->mo_iods_from_parity[i].iod_nr; j++) {
+			daos_iod_t iod = mrone->mo_iods_from_parity[i];
 
-		for (i = 0; i < mrone->mo_iods_num_from_parity; i++) {
-			for (j = 0; j < mrone->mo_iods_from_parity[i].iod_nr; j++)
-				min_eph = min(min_eph,
-					      mrone->mo_iods_update_ephs_from_parity[i][j]);
+			iod.iod_nr = 1;
+			iod.iod_recxs = &mrone->mo_iods_from_parity[i].iod_recxs[j];
+			rc = __migrate_fetch_update_bulk(mrone, oh, &iod, 1,
+							 mrone->mo_iods_update_ephs_from_parity[i][j],
+							 mrone->mo_iods_update_ephs_from_parity[i][j],
+							 DIOF_EC_RECOV_FROM_PARITY, ds_cont);
+			if (rc != 0)
+				D_GOTO(out, rc);
 		}
-
-		rc = __migrate_fetch_update_bulk(mrone, oh, mrone->mo_iods_from_parity,
-						 mrone->mo_iods_num_from_parity,
-						 min_eph,
-						 DIOF_FOR_MIGRATION | DIOF_EC_RECOV_FROM_PARITY,
-						 ds_cont);
-		if (rc != 0)
-			D_GOTO(out, rc);
 	}
 
 	/* The data, rebuilt from replication, needs to keep the same epoch during rebuild,
@@ -1401,6 +1384,7 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 			iod.iod_nr = 1;
 			iod.iod_recxs = &mrone->mo_iods[i].iod_recxs[j];
 			rc = __migrate_fetch_update_bulk(mrone, oh, &iod, 1,
+							 mrone->mo_epoch,
 							 mrone->mo_iods_update_ephs[i][j],
 							 DIOF_FOR_MIGRATION, ds_cont);
 			if (rc < 0) {
@@ -2343,10 +2327,9 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	migrate_tgt_off = obj_ec_shard_off_by_layout_ver(layout_ver, io->ui_dkey_hash,
 							 &arg->oc_attr, shard);
 	unpack_tgt_off = obj_ec_shard_off(obj, io->ui_dkey_hash, io->ui_oid.id_shard);
-	if ((rc == 1 &&
+	if (rc == 1 &&
 	     (is_ec_data_shard_by_tgt_off(unpack_tgt_off, &arg->oc_attr) ||
-	     (io->ui_oid.id_layout_ver > 0 && io->ui_oid.id_shard != parity_shard))) ||
-	    (tls->mpt_opc == RB_OP_EXCLUDE && io->ui_oid.id_shard == shard)) {
+	     (io->ui_oid.id_layout_ver > 0 && io->ui_oid.id_shard != parity_shard))) {
 		D_DEBUG(DB_REBUILD, DF_UOID" ignore shard "DF_KEY"/%u/%d/%u/%d.\n",
 			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
 			(int)obj_ec_shard_off(obj, io->ui_dkey_hash, 0), parity_shard, rc);
@@ -2579,7 +2562,7 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	/* Only open with RW flag, reintegrating flag will be set, which is needed
 	 * during unpack_cb to check if parity shard alive.
 	 */
-	rc = dsc_obj_open(coh, arg->oid.id_pub, DAOS_OO_RW, &oh);
+	rc = dsc_obj_open(coh, arg->oid.id_pub, DAOS_OO_RO, &oh);
 	if (rc) {
 		D_ERROR("dsc_obj_open failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out_cont, rc);

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -635,6 +635,8 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 			} else {
 				if (domain != NULL)
 					setbit(dom_cur_grp_real, domain - root);
+				if (pool_target_down(target))
+					layout->ol_shards[k].po_rebuilding = 1;
 			}
 
 			if (is_extending != NULL && pool_target_is_up_or_drain(target))
@@ -644,7 +646,7 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 
 	if (fail_tgt_cnt > 0)
 		rc = obj_remap_shards(jmap, layout_ver, md, layout, jmop, &remap_list, out_list,
-				      allow_status, md->omd_ver, tgts_used, dom_used, dom_full,
+				      allow_status, allow_version, tgts_used, dom_used, dom_full,
 				      fail_tgt_cnt, is_extending, fdom_lvl);
 out:
 	if (rc)
@@ -917,7 +919,12 @@ jump_map_obj_place(struct pl_map *map, uint32_t layout_version, struct daos_obj_
 		return rc;
 	}
 
-	allow_status = PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN;
+	if (mode & DAOS_OO_RO)
+		allow_status = PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN |
+			       PO_COMP_ST_DOWN;
+	else
+		allow_status = PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN;
+
 	rc = obj_layout_alloc_and_get(jmap, layout_version, &jmop, md, allow_status,
 				      md->omd_ver, &layout, NULL, &is_extending);
 	if (rc != 0) {
@@ -981,65 +988,16 @@ out:
  *                              another target, Or 0 if none need to be rebuilt.
  */
 static int
-jump_map_obj_find_rebuild(struct pl_map *map, uint32_t layout_ver, struct daos_obj_md *md,
-			  struct daos_obj_shard_md *shard_md, uint32_t rebuild_ver,
-			  uint32_t *tgt_id, uint32_t *shard_idx, unsigned int array_size)
-{
-	struct pl_jump_map              *jmap;
-	struct pl_obj_layout            *layout;
-	d_list_t                        remap_list;
-	struct jm_obj_placement         jmop;
-	daos_obj_id_t                   oid;
-	int                             rc;
-
-	int idx = 0;
-
-	D_DEBUG(DB_PL, "Finding Rebuild at version: %u\n", rebuild_ver);
-
-	/* Caller should guarantee the pl_map is up-to-date */
-	if (pl_map_version(map) < rebuild_ver) {
-		D_ERROR("pl_map version(%u) < rebuild version(%u)\n",
-			pl_map_version(map), rebuild_ver);
-		return -DER_INVAL;
-	}
-
-	jmap = pl_map2jmap(map);
-	oid = md->omd_id;
-
-	rc = jm_obj_placement_get(jmap, md, shard_md, &jmop);
-	if (rc) {
-		D_ERROR("jm_obj_placement_get failed, rc "DF_RC"\n", DP_RC(rc));
-		return rc;
-	}
-
-	D_INIT_LIST_HEAD(&remap_list);
-	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jmop, md, PO_COMP_ST_UPIN,
-				      rebuild_ver, &layout, &remap_list, NULL);
-	if (rc < 0)
-		D_GOTO(out, rc);
-
-	obj_layout_dump(oid, layout);
-	rc = remap_list_fill(map, md, shard_md, rebuild_ver, tgt_id, shard_idx,
-			     array_size, &idx, layout, &remap_list, false);
-
-out:
-	remap_list_free_all(&remap_list);
-	if (layout != NULL)
-		pl_obj_layout_free(layout);
-	return rc < 0 ? rc : idx;
-}
-
-static int
-jump_map_obj_find_reint(struct pl_map *map, uint32_t layout_ver, struct daos_obj_md *md,
-			struct daos_obj_shard_md *shard_md, uint32_t reint_ver,
-			uint32_t *tgt_rank, uint32_t *shard_id, unsigned int array_size)
+jump_map_obj_find_diff(struct pl_map *map, uint32_t layout_ver, struct daos_obj_md *md,
+		       struct daos_obj_shard_md *shard_md, uint32_t reint_ver,
+		       uint32_t old_status, uint32_t new_status,
+		       uint32_t *tgt_rank, uint32_t *shard_id, unsigned int array_size)
 {
 	struct pl_jump_map              *jmap;
 	struct pl_obj_layout            *layout = NULL;
 	struct pl_obj_layout            *reint_layout = NULL;
 	d_list_t			reint_list;
 	struct jm_obj_placement         jop;
-	uint32_t			allow_status;
 	int                             rc;
 
 	int idx = 0;
@@ -1060,16 +1018,14 @@ jump_map_obj_find_reint(struct pl_map *map, uint32_t layout_ver, struct daos_obj
 		return rc;
 	}
 
-	allow_status = PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN;
 	D_INIT_LIST_HEAD(&reint_list);
-	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, allow_status,
+	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, old_status,
 				      reint_ver, &layout, NULL, NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
 
 	obj_layout_dump(md->omd_id, layout);
-	allow_status |= PO_COMP_ST_UP;
-	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, allow_status,
+	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, new_status,
 				      reint_ver, &reint_layout, NULL, NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
@@ -1087,6 +1043,27 @@ out:
 		pl_obj_layout_free(reint_layout);
 
 	return rc < 0 ? rc : idx;
+}
+
+static int
+jump_map_obj_find_reint(struct pl_map *map, uint32_t layout_ver, struct daos_obj_md *md,
+			struct daos_obj_shard_md *shard_md, uint32_t reint_ver,
+			uint32_t *tgt_id, uint32_t *shard_id, unsigned int array_size)
+{
+	return jump_map_obj_find_diff(map, layout_ver, md, shard_md, reint_ver,
+				      PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN,
+				      PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN | PO_COMP_ST_UP,
+				      tgt_id, shard_id, array_size);
+}
+
+static int
+jump_map_obj_find_rebuild(struct pl_map *map, uint32_t layout_ver, struct daos_obj_md *md,
+			  struct daos_obj_shard_md *shard_md, uint32_t rebuild_ver,
+			  uint32_t *tgt_id, uint32_t *shard_id, unsigned int array_size)
+{
+	return jump_map_obj_find_diff(map, layout_ver, md, shard_md, rebuild_ver,
+				      PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN | PO_COMP_ST_DOWN,
+				      PO_COMP_ST_UPIN, tgt_id, shard_id, array_size);
 }
 
 /** API for generic placement map functionality */

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -351,7 +351,6 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 				   dom_used, dom_full, dgu->dgu_used, dgu->dgu_real,
 				   tgts_used, shard_id, allow_status, allow_version, fdom_lvl,
 				   &spares_left, &spare_avail);
-			D_ASSERT(spare_tgt != NULL);
 			D_DEBUG(DB_PL, "Trying new target: "DF_TARGET"\n",
 				DP_TARGET(spare_tgt));
 			if (layout_ver > 0) {

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -259,6 +259,7 @@ count_available_spares(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 
 struct dom_grp_used {
 	uint8_t		*dgu_used;
+	uint8_t		*dgu_real;
 	d_list_t	dgu_list;
 };
 
@@ -276,6 +277,9 @@ struct dom_grp_used {
 *                               layout characteristics.
 * \paramp[in]   remap_list      List containing shards to be remapped sorted
 *                               by failure sequence.
+* \paramp[in]	allow_status	the target status allowed to be in the layout.
+* \paramp[in]	allow_version	the target status needs to be restored to its
+*                               original status by version, then check.
 * \paramp[in]   dom_used        Bookkeeping array used to keep track of which
 *                               domain components have already been used.
 *
@@ -286,12 +290,14 @@ static int
 obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_md *md,
 		 struct pl_obj_layout *layout, struct jm_obj_placement *jmop,
 		 d_list_t *remap_list, d_list_t *out_list, uint32_t allow_status,
-		 uint8_t *tgts_used, uint8_t *dom_used, uint8_t *dom_full,
-		 uint32_t failed_in_layout, bool *is_extending, uint32_t fdom_lvl)
+		 uint32_t allow_version, uint8_t *tgts_used, uint8_t *dom_used,
+		 uint8_t *dom_full, uint32_t failed_in_layout, bool *is_extending,
+		 uint32_t fdom_lvl)
 {
 	struct failed_shard     *f_shard;
 	struct pl_obj_shard     *l_shard;
-	struct pool_target      *spare_tgt;
+	struct pool_target      *spare_tgt = NULL;
+	struct pool_domain      *spare_dom = NULL;
 	struct pool_domain      *root;
 	d_list_t                *current;
 	daos_obj_id_t           oid;
@@ -315,6 +321,7 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 	while (current != remap_list) {
 		uint64_t rebuild_key;
 		uint32_t shard_id;
+		struct dom_grp_used *dgu = NULL;
 
 		f_shard = d_list_entry(current, struct failed_shard, fs_list);
 
@@ -334,13 +341,16 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 		 * on a non-redundant other fault domain won't make this worse.
 		 */
 		if (spare_avail) {
-			struct dom_grp_used *dgu = f_shard->fs_data;
+			dgu = f_shard->fs_data;
 
 			D_ASSERT(dgu != NULL);
 			rebuild_key = crc(key, f_shard->fs_shard_idx);
-			get_target(root, layout_ver, &spare_tgt, crc(key, rebuild_key),
-				   dom_used, dom_full, dgu->dgu_used, tgts_used, shard_id,
-				   allow_status, fdom_lvl, &spares_left, &spare_avail);
+
+			get_target(root, layout_ver, &spare_tgt, &spare_dom,
+				   crc(key, rebuild_key),
+				   dom_used, dom_full, dgu->dgu_used, dgu->dgu_real,
+				   tgts_used, shard_id, allow_status, allow_version, fdom_lvl,
+				   &spares_left, &spare_avail);
 			D_ASSERT(spare_tgt != NULL);
 			D_DEBUG(DB_PL, "Trying new target: "DF_TARGET"\n",
 				DP_TARGET(spare_tgt));
@@ -370,6 +380,9 @@ obj_remap_shards(struct pl_jump_map *jmap, uint32_t layout_ver, struct daos_obj_
 				d_list_del(&f_shard->fs_list);
 				D_FREE(f_shard);
 			}
+
+			if (spare_dom != NULL && dgu != NULL)
+				setbit(dgu->dgu_real, spare_dom - root);
 		}
 		current = remap_list->next;
 	}
@@ -435,7 +448,8 @@ jump_map_obj_spec_place_get(struct pl_jump_map *jmap, daos_obj_id_t oid,
 }
 
 static struct dom_grp_used*
-remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used)
+remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used,
+		    uint8_t *dom_cur_grp_real)
 {
 	struct dom_grp_used	*dgu;
 
@@ -444,6 +458,7 @@ remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used)
 		return NULL;
 
 	dgu->dgu_used = dom_cur_grp_used;
+	dgu->dgu_real = dom_cur_grp_real;
 	d_list_add_tail(&dgu->dgu_list, remap_list);
 	return dgu;
 }
@@ -472,7 +487,7 @@ remap_gpu_alloc_one(d_list_t *remap_list, uint8_t *dom_cur_grp_used)
 static int
 get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_layout *layout,
 		  struct jm_obj_placement *jmop, d_list_t *out_list, uint32_t allow_status,
-		  struct daos_obj_md *md, bool *is_extending)
+		  uint32_t allow_version, struct daos_obj_md *md, bool *is_extending)
 {
 	struct pool_target      *target;
 	struct pool_domain      *domain;
@@ -482,10 +497,12 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 	uint8_t                 *dom_full = NULL;
 	uint8_t                 *tgts_used = NULL;
 	uint8_t			*dom_cur_grp_used = NULL;
+	uint8_t			*dom_cur_grp_real = NULL;
 	uint8_t			dom_used_array[LOCAL_DOM_ARRAY_SIZE] = { 0 };
 	uint8_t			dom_full_array[LOCAL_DOM_ARRAY_SIZE] = { 0 };
 	uint8_t			tgts_used_array[LOCAL_TGT_ARRAY_SIZE] = { 0 };
 	uint8_t			dom_cur_grp_used_array[LOCAL_TGT_ARRAY_SIZE] = { 0 };
+	uint8_t			dom_cur_grp_real_array[LOCAL_TGT_ARRAY_SIZE] = { 0 };
 	d_list_t		dgu_remap_list;
 	uint32_t                dom_size;
 	uint32_t                dom_array_size;
@@ -500,7 +517,8 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 
 	/* Set the pool map version */
 	layout->ol_ver = pl_map_version(&(jmap->jmp_map));
-	D_DEBUG(DB_PL, "Building layout. map version: %d/%u\n", layout->ol_ver, layout_ver);
+	D_DEBUG(DB_PL, "Building layout. map version: %d/%u/%u\n", layout->ol_ver,
+		layout_ver, allow_version);
 	debug_print_allow_status(allow_status);
 
 	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_ROOT,
@@ -520,10 +538,12 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 		D_ALLOC_ARRAY(dom_used, dom_array_size);
 		D_ALLOC_ARRAY(dom_full, dom_array_size);
 		D_ALLOC_ARRAY(dom_cur_grp_used, dom_array_size);
+		D_ALLOC_ARRAY(dom_cur_grp_real, dom_array_size);
 	} else {
 		dom_used = dom_used_array;
 		dom_full = dom_full_array;
 		dom_cur_grp_used = dom_cur_grp_used_array;
+		dom_cur_grp_real = dom_cur_grp_real_array;
 	}
 
 	if (root->do_target_nr / NBBY + 1 > LOCAL_TGT_ARRAY_SIZE)
@@ -550,8 +570,12 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 			D_ALLOC_ARRAY(dom_cur_grp_used, dom_array_size);
 			if (dom_cur_grp_used == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
+			D_ALLOC_ARRAY(dom_cur_grp_real, dom_array_size);
+			if (dom_cur_grp_real == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
 		} else {
 			memset(dom_cur_grp_used, 0, dom_array_size);
+			memset(dom_cur_grp_real, 0, dom_array_size);
 		}
 
 		for (j = 0; j < jmop->jmop_grp_size; j++, k++) {
@@ -572,9 +596,9 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 				setbit(tgts_used, target->ta_comp.co_id);
 				setbit(dom_cur_grp_used, domain - root);
 			} else {
-				get_target(root, layout_ver, &target, key, dom_used,
-					   dom_full, dom_cur_grp_used, tgts_used, k,
-					   allow_status, fdom_lvl, NULL, NULL);
+				get_target(root, layout_ver, &target, &domain, key, dom_used,
+					   dom_full, dom_cur_grp_used, dom_cur_grp_real, tgts_used, k,
+					   allow_status, allow_version, fdom_lvl, NULL, NULL);
 			}
 
 			if (target == NULL) {
@@ -598,7 +622,8 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 
 				if (remap_grp_used == NULL) {
 					remap_grp_used = remap_gpu_alloc_one(&dgu_remap_list,
-									     dom_cur_grp_used);
+									     dom_cur_grp_used,
+									     dom_cur_grp_real);
 					if (remap_grp_used == NULL)
 						D_GOTO(out, rc = -DER_NOMEM);
 					realloc_grp_used = true;
@@ -607,6 +632,9 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 				rc = remap_alloc_one(&remap_list, k, target, false, remap_grp_used);
 				if (rc)
 					D_GOTO(out, rc);
+			} else {
+				if (domain != NULL)
+					setbit(dom_cur_grp_real, domain - root);
 			}
 
 			if (is_extending != NULL && pool_target_is_up_or_drain(target))
@@ -615,9 +643,9 @@ get_object_layout(struct pl_jump_map *jmap, uint32_t layout_ver, struct pl_obj_l
 	}
 
 	if (fail_tgt_cnt > 0)
-		rc = obj_remap_shards(jmap, layout_ver, md, layout, jmop, &remap_list,
-				      out_list, allow_status, tgts_used, dom_used,
-				      dom_full, fail_tgt_cnt, is_extending, fdom_lvl);
+		rc = obj_remap_shards(jmap, layout_ver, md, layout, jmop, &remap_list, out_list,
+				      allow_status, md->omd_ver, tgts_used, dom_used, dom_full,
+				      fail_tgt_cnt, is_extending, fdom_lvl);
 out:
 	if (rc)
 		D_ERROR("jump_map_obj_layout_fill failed, rc "DF_RC"\n", DP_RC(rc));
@@ -633,8 +661,12 @@ out:
 			if (dgu->dgu_used) {
 				if (dgu->dgu_used == dom_cur_grp_used)
 					dom_cur_grp_used = NULL;
+				if (dgu->dgu_real == dom_cur_grp_real)
+					dom_cur_grp_real = NULL;
 				if (dgu->dgu_used != dom_cur_grp_used_array)
 					D_FREE(dgu->dgu_used);
+				if (dgu->dgu_real != dom_cur_grp_real_array)
+					D_FREE(dgu->dgu_real);
 			}
 			D_FREE(dgu);
 		}
@@ -650,14 +682,19 @@ out:
 	if (dom_cur_grp_used && dom_cur_grp_used != dom_cur_grp_used_array)
 		D_FREE(dom_cur_grp_used);
 
+	if (dom_cur_grp_real && dom_cur_grp_real != dom_cur_grp_real_array)
+		D_FREE(dom_cur_grp_real);
+
+
 	return rc;
 }
 
 static int
 obj_layout_alloc_and_get(struct pl_jump_map *jmap, uint32_t layout_ver,
 			 struct jm_obj_placement *jmop, struct daos_obj_md *md,
-			 uint32_t allow_status, struct pl_obj_layout **layout_p,
-			 d_list_t *remap_list, bool *is_extending)
+			 uint32_t allow_status, uint32_t allow_version,
+			 struct pl_obj_layout **layout_p, d_list_t *remap_list,
+			 bool *is_extending)
 {
 	int rc;
 
@@ -673,7 +710,7 @@ obj_layout_alloc_and_get(struct pl_jump_map *jmap, uint32_t layout_ver,
 	}
 
 	rc = get_object_layout(jmap, layout_ver, *layout_p, jmop, remap_list, allow_status,
-			       md, is_extending);
+			       allow_version, md, is_extending);
 	if (rc) {
 		D_ERROR("get object layout failed, rc "DF_RC"\n",
 			DP_RC(rc));
@@ -811,7 +848,7 @@ jump_map_obj_extend_layout(struct pl_jump_map *jmap, struct jm_obj_placement *jm
 	D_INIT_LIST_HEAD(&extend_list);
 	allow_status = PO_COMP_ST_UPIN | /*PO_COMP_ST_DRAIN |*/ PO_COMP_ST_UP;
 	rc = obj_layout_alloc_and_get(jmap, layout_version, jmop, md, allow_status,
-				      &new_layout, NULL, NULL);
+				      md->omd_ver, &new_layout, NULL, NULL);
 	if (rc != 0) {
 		D_ERROR(DF_OID" get_layout_alloc failed, rc "DF_RC"\n",
 			DP_OID(md->omd_id), DP_RC(rc));
@@ -882,7 +919,7 @@ jump_map_obj_place(struct pl_map *map, uint32_t layout_version, struct daos_obj_
 
 	allow_status = PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN;
 	rc = obj_layout_alloc_and_get(jmap, layout_version, &jmop, md, allow_status,
-				      &layout, NULL, &is_extending);
+				      md->omd_ver, &layout, NULL, &is_extending);
 	if (rc != 0) {
 		D_ERROR("get_layout_alloc failed, rc "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
@@ -977,7 +1014,7 @@ jump_map_obj_find_rebuild(struct pl_map *map, uint32_t layout_ver, struct daos_o
 
 	D_INIT_LIST_HEAD(&remap_list);
 	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jmop, md, PO_COMP_ST_UPIN,
-				      &layout, &remap_list, NULL);
+				      rebuild_ver, &layout, &remap_list, NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
 
@@ -1026,14 +1063,14 @@ jump_map_obj_find_reint(struct pl_map *map, uint32_t layout_ver, struct daos_obj
 	allow_status = PO_COMP_ST_UPIN | PO_COMP_ST_DRAIN;
 	D_INIT_LIST_HEAD(&reint_list);
 	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, allow_status,
-				      &layout, NULL, NULL);
+				      reint_ver, &layout, NULL, NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
 
 	obj_layout_dump(md->omd_id, layout);
 	allow_status |= PO_COMP_ST_UP;
 	rc = obj_layout_alloc_and_get(jmap, layout_ver, &jop, md, allow_status,
-				      &reint_layout, NULL, NULL);
+				      reint_ver, &reint_layout, NULL, NULL);
 	if (rc < 0)
 		D_GOTO(out, rc);
 

--- a/src/placement/jump_map.h
+++ b/src/placement/jump_map.h
@@ -1,0 +1,65 @@
+/**
+ * (C) Copyright 2022-2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * src/placement/jump_map.h
+ */
+
+#ifndef __JUMP_MAP_H__
+#define __JUMP_MAP_H__
+
+#include <daos/placement.h>
+
+#define JMOP_PD_INLINE	(8)
+/**
+ * Contains information related to object layout size.
+ */
+struct jm_obj_placement {
+	/* root domain, used when no PD defined */
+	struct pool_domain	 *jmop_root;
+	unsigned int		  jmop_grp_size;
+	unsigned int		  jmop_grp_nr;
+	pool_comp_type_t	  jmop_fdom_lvl;
+	uint32_t		  jmop_dom_nr;
+	/* #PDs to-be-used for the obj */
+	unsigned int		  jmop_pd_nr;
+	/* For zero jmop_pd_nr, non-sense for below fields */
+	/* PD group size (min(pda, doms_per_pd)) */
+	unsigned int		  jmop_pd_grp_size;
+	/* PD domain pointers array */
+	struct pool_domain	**jmop_pd_ptrs;
+	struct pool_domain	 *jmop_pd_ptrs_inline[JMOP_PD_INLINE];
+};
+
+/**
+ * jump_map Placement map structure used to place objects.
+ * The map is returned as a struct pl_map and then converted back into a
+ * pl_jump_map once passed from the caller into the object placement
+ * functions.
+ */
+struct pl_jump_map {
+	/** placement map interface */
+	struct pl_map		jmp_map;
+	/** Number of performance domains (can be zero) */
+	unsigned int		jmp_pd_nr;
+	/* Total size of domain type specified during map creation */
+	unsigned int		jmp_domain_nr;
+	/* # UPIN targets */
+	unsigned int		jmp_target_nr;
+	/* The dom that will contain no colocated shards */
+	pool_comp_type_t	jmp_redundant_dom;
+};
+
+struct pool_domain *
+jm_obj_shard_pd(struct jm_obj_placement *jmop, uint32_t shard);
+
+void
+get_target(struct pool_domain *root, struct pool_domain *curr_pd, uint32_t layout_ver,
+	   struct pool_target **target, struct pool_domain **dom, uint64_t key,
+	   uint8_t *dom_used, uint8_t *dom_full, uint8_t *dom_cur_grp_used,
+	   uint8_t *dom_cur_grp_real, uint8_t *tgts_used, int shard_num,
+	   uint32_t allow_status, uint32_t allow_version, pool_comp_type_t fdom_lvl,
+	   uint32_t grp_size, uint32_t *spare_left, bool *spare_avail);
+#endif /* __JUMP_MAP_H__ */

--- a/src/placement/jump_map_versions.c
+++ b/src/placement/jump_map_versions.c
@@ -8,7 +8,6 @@
  * src/placement/jump_map_version.c
  */
 #define D_LOGFAC        DD_FAC(placement)
-
 #include "pl_map.h"
 #include <inttypes.h>
 #include <daos/pool_map.h>
@@ -43,6 +42,7 @@ get_num_domains(struct pool_domain *curr_dom, bool exclude_new, pool_comp_type_t
 	else
 		num_dom = curr_dom->do_child_nr;
 
+	D_ASSERTF(num_dom > 0, "num dom %u\n", num_dom);
 	if (curr_dom->do_children == NULL || curr_dom->do_comp.co_type == fdom_lvl) {
 		next_target = &curr_dom->do_targets[num_dom - 1];
 
@@ -166,6 +166,8 @@ _get_dom(struct pool_domain *doms, uint32_t dom_idx, bool exclude_new)
  *                              initially the root node of the pool map.
  * \param[out]  target          This variable is used when returning the
  *                              selected target for this shard.
+ * \param[out]  dom             This variable is used when returning the
+ *                              selected domain for this shard.
  * \param[in]   obj_key         a unique key generated using the object ID.
  *                              This is used in jump consistent hash.
  * \param[in]   dom_used        This is a contiguous array that contains
@@ -191,9 +193,9 @@ _get_dom(struct pool_domain *doms, uint32_t dom_idx, bool exclude_new)
 #define MAX_STACK	5
 static void
 __get_target_v1(struct pool_domain *curr_dom, struct pool_target **target,
-		uint64_t obj_key, uint8_t *dom_used, uint8_t *dom_full,
-		uint8_t *dom_cur_grp_used, uint8_t *tgts_used, int shard_num,
-		bool exclude_new, pool_comp_type_t fdom_lvl)
+		struct pool_domain **dom, uint64_t obj_key, uint8_t *dom_used,
+		uint8_t *dom_full, uint8_t *dom_cur_grp_used, uint8_t *tgts_used,
+		int shard_num, bool exclude_new, pool_comp_type_t fdom_lvl)
 {
 	int                     range_set;
 	uint8_t                 found_target = 0;
@@ -266,7 +268,7 @@ __get_target_v1(struct pool_domain *curr_dom, struct pool_target **target,
 					--top;
 				}
 			}
-
+			*dom = curr_dom;
 			/* Found target (which may be available or not) */
 			found_target = 1;
 		} else {
@@ -401,10 +403,35 @@ dom_reset_full(struct pool_domain *dom, uint8_t *dom_bits, uint8_t *tgts_used,
 		clrbit(tgts_used, &dom->do_targets[i] - root->do_targets);
 }
 
+static bool
+dom_tgts_are_avaible(struct pool_domain *dom, uint32_t allow_status, uint32_t allow_version)
+{
+	int i;
+
+	for (i = 0; i < dom->do_target_nr; i++) {
+		struct pool_target *tgt;
+		uint32_t status;
+
+		tgt = &dom->do_targets[i];
+		status = tgt->ta_comp.co_status;
+		if (tgt->ta_comp.co_status == PO_COMP_ST_DOWN) {
+			if (tgt->ta_comp.co_fseq > allow_version)
+				status = PO_COMP_ST_UPIN;
+		} else if (tgt->ta_comp.co_status == PO_COMP_ST_UP) {
+			if (tgt->ta_comp.co_in_ver > allow_version)
+				status = PO_COMP_ST_DOWNOUT;
+		}
+		if (status & allow_status)
+			return true;
+	}
+	return false;
+}
+
 /* Reset dom/targets tracking bits for remapping the layout */
 static void
 reset_dom_cur_grp_v1(struct pool_domain *root, uint8_t *dom_cur_grp_used,
-		     uint8_t *dom_full, uint8_t *tgts_used, bool exclude_new,
+		     uint8_t *dom_cur_grp_real, uint8_t *dom_full, uint8_t *tgts_used,
+		     bool exclude_new, uint32_t allow_status, uint32_t allow_version,
 		     uint32_t fdom_lvl)
 {
 	struct pool_domain	*tree;
@@ -418,6 +445,7 @@ reset_dom_cur_grp_v1(struct pool_domain *root, uint8_t *dom_cur_grp_used,
 		uint32_t end_dom = start_dom + dom_nr - 1;
 		uint32_t next_dom_nr = 0;
 		bool	reset_full = false;
+		bool	reset = false;
 		int	i;
 
 		/* reset all bits if it is above failure domain */
@@ -459,7 +487,50 @@ reset_dom_cur_grp_v1(struct pool_domain *root, uint8_t *dom_cur_grp_used,
 			break;
 		}
 
-		/* Then reset the cur_group used, which will cause multiple shards
+		/* Since then all domains have been tried, then let's check if any domain
+		 * are not really used due to the chosen target is not available.
+		 */
+		for (i = 0; i < dom_nr; i++) {
+			struct pool_domain *dom = &root[start_dom + i];
+
+			if (!isset(dom_cur_grp_real, start_dom + i)) {
+				uint32_t start_tgt;
+				uint32_t end_tgt;
+
+				start_tgt = dom->do_targets - root->do_targets;
+				end_tgt = start_tgt + dom->do_target_nr - 1;
+				if (!tgt_isset_range(root->do_targets, tgts_used,
+						     start_tgt, end_tgt, exclude_new)) {
+					dom_reset_bit(dom, dom_cur_grp_used, root,
+						      exclude_new, fdom_lvl);
+					reset = true;
+				}
+			}
+		}
+
+		if (reset)
+			break;
+
+		reset = false;
+		/* All targets other than on the real used domain has been used up, let's
+		 * reset these domain and tgt used bits */
+		for (i = 0; i < dom_nr; i++) {
+			struct pool_domain *dom = &root[start_dom + i];
+
+			if (!isset(dom_cur_grp_real, start_dom + i) &&
+			    dom_tgts_are_avaible(dom, allow_status, allow_version)) {
+				dom_reset_full(dom, dom_full, tgts_used, root,
+					       exclude_new, fdom_lvl);
+				dom_reset_bit(dom, dom_cur_grp_used, root,
+					      exclude_new, fdom_lvl);
+				reset = true;
+			}
+		}
+
+		if (reset)
+			break;
+
+		/* Finally reset cur_group_used, which  multiple shards
 		 * from the same group be in the same domain.
 		 */
 		if (dom_isset_range(root, dom_full, start_dom, end_dom, exclude_new))
@@ -480,9 +551,10 @@ reset_dom_cur_grp_v1(struct pool_domain *root, uint8_t *dom_cur_grp_used,
 
 static void
 get_target_v1(struct pool_domain *root, struct pool_target **target,
-	      uint64_t key, uint8_t *dom_used, uint8_t *dom_full,
-	      uint8_t *dom_cur_grp_used, uint8_t *tgts_used, int shard_num,
-	      uint32_t allow_status, pool_comp_type_t fdom_lvl)
+	      struct pool_domain **dom, uint64_t key, uint8_t *dom_used, uint8_t *dom_full,
+	      uint8_t *dom_cur_grp_used, uint8_t *dom_cur_grp_real, uint8_t *tgts_used,
+	      int shard_num, uint32_t allow_status, uint32_t allow_version,
+	      pool_comp_type_t fdom_lvl)
 {
 	struct pool_target	*found = NULL;
 	bool			exclude_new = true;
@@ -498,13 +570,13 @@ get_target_v1(struct pool_domain *root, struct pool_target **target,
 		exclude_new = false;
 
 	while (found == NULL) {
-		__get_target_v1(root, &found, key, dom_used, dom_full, dom_cur_grp_used, tgts_used,
-				shard_num, exclude_new, fdom_lvl);
+		__get_target_v1(root, &found, dom, key, dom_used, dom_full, dom_cur_grp_used,
+				tgts_used, shard_num, exclude_new, fdom_lvl);
 		if (found == NULL)
-			reset_dom_cur_grp_v1(root, dom_cur_grp_used, dom_full, tgts_used,
-					     exclude_new, fdom_lvl);
+			reset_dom_cur_grp_v1(root, dom_cur_grp_used, dom_cur_grp_real, dom_full,
+					     tgts_used, exclude_new, allow_status, allow_version,
+					     fdom_lvl);
 	}
-
 	*target = found;
 }
 
@@ -742,8 +814,9 @@ retry:
 
 void
 get_target(struct pool_domain *root, uint32_t layout_ver, struct pool_target **target,
-	   uint64_t key, uint8_t *dom_used, uint8_t *dom_full, uint8_t *dom_cur_grp_used,
-	   uint8_t *tgts_used, int shard_num, uint32_t allow_status,
+	   struct pool_domain **dom, uint64_t key, uint8_t *dom_used, uint8_t *dom_full,
+	   uint8_t *dom_cur_grp_used, uint8_t *dom_cur_grp_real,
+	   uint8_t *tgts_used, int shard_num, uint32_t allow_status, uint32_t allow_version,
 	   pool_comp_type_t fdom_lvl, uint32_t *spare_left, bool *spare_avail)
 {
 	switch(layout_ver) {
@@ -774,8 +847,9 @@ get_target(struct pool_domain *root, uint32_t layout_ver, struct pool_target **t
 		 * overhead of the EC degraded fetch, so it might put multiple shards in the
 		 * same target, i.e. it will never check the spare target here.
 		 */
-		get_target_v1(root, target, key, dom_used, dom_full, dom_cur_grp_used,
-			      tgts_used, shard_num, allow_status, fdom_lvl);
+		get_target_v1(root, target, dom, key, dom_used, dom_full, dom_cur_grp_used,
+			      dom_cur_grp_real, tgts_used, shard_num, allow_status, allow_version,
+			      fdom_lvl);
 		if (spare_avail)
 			*spare_avail = true;
 		break;

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -152,7 +152,8 @@ need_remap_comp(struct pool_component *comp, uint32_t allow_status);
 
 void
 get_target(struct pool_domain *root, uint32_t layout_ver, struct pool_target **target,
-	   uint64_t key, uint8_t *dom_used, uint8_t *dom_full, uint8_t *dom_cur_grp_used,
-	   uint8_t *tgts_used, int shard_num, uint32_t allow_status, pool_comp_type_t fdom_lvl,
-	   uint32_t *spare_left, bool *spare_avail);
+	   struct pool_domain **dom, uint64_t key, uint8_t *dom_used, uint8_t *dom_full,
+	   uint8_t *dom_cur_grp_used, uint8_t *dom_cur_grp_real,
+	   uint8_t *tgts_used, int shard_num, uint32_t allow_status, uint32_t allow_version,
+	   pool_comp_type_t fdom_lvl, uint32_t *spare_left, bool *spare_avail);
 #endif /* __PL_MAP_H__ */

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -327,7 +327,8 @@ next_fail:
 		 * skip this shard.
 		 */
 		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
-		    f_shard->fs_status == PO_COMP_ST_DRAIN)
+		    f_shard->fs_status == PO_COMP_ST_DRAIN ||
+		    pool_target_down(spare_tgt))
 			l_shard->po_rebuilding = 1;
 	} else {
 		l_shard->po_shard = -1;

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -1676,7 +1676,7 @@ placement_handles_multiple_states(void **state)
 	 */
 	ctx.ver = ver_after_fail;
 	jtc_scan(&ctx);
-	assert_int_equal(ctx.rebuild.out_nr, 1);
+	assert_int_equal(ctx.rebuild.out_nr, 2);
 
 	/* Complete the rebuild */
 	ctx.ver = ver_after_reint_complete; /* Restore the version first */

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -17,6 +17,7 @@
 #include <cmocka.h>
 #include <daos/tests_lib.h>
 
+bool fail_domain_node;
 void
 print_layout(struct pl_obj_layout *layout)
 {
@@ -605,8 +606,10 @@ gen_pool_and_placement_map(int num_domains, int nodes_per_domain,
 
 	mia.ia_type         = pl_type;
 	mia.ia_ring.ring_nr = 1;
-	mia.ia_ring.domain  = PO_COMP_TP_RANK;
-
+	if (fail_domain_node)
+		mia.ia_ring.domain  = PO_COMP_TP_NODE;
+	else
+		mia.ia_ring.domain = PO_COMP_TP_RANK;
 	rc = pl_map_create(*po_map_out, &mia, pl_map_out);
 	assert_success(rc);
 }

--- a/src/placement/tests/place_obj_common.h
+++ b/src/placement/tests/place_obj_common.h
@@ -13,6 +13,7 @@
 #include <daos.h>
 
 #define PLT_LAYOUT_VERSION	1
+extern bool fail_domain_node;
 void
 print_layout(struct pl_obj_layout *layout);
 

--- a/src/placement/tests/placement_test.c
+++ b/src/placement/tests/placement_test.c
@@ -15,11 +15,12 @@
 #include <daos/tests_lib.h>
 
 
-const char *s_opts = "he:f:v";
+const char *s_opts = "he:f:vo";
 static int idx;
 static struct option l_opts[] = {
 	{"exclude", required_argument, NULL, 'e'},
 	{"filter",  required_argument, NULL, 'f'},
+	{"nlvl",    no_argument,	NULL, 'o'},
 	{"help",    no_argument,       NULL, 'h'},
 	{"verbose", no_argument,       NULL, 'v'},
 };
@@ -53,6 +54,7 @@ print_usage(char *name)
 		"\n\nCOMMON TESTS\n==========================\n");
 	print_message("%s -e|--exclude <TESTS>\n", name);
 	print_message("%s -f|--filter <TESTS>\n", name);
+	print_message("%s -o|--nlvl failure domain as node, engine by default\n", name);
 	print_message("%s -h|--help\n", name);
 	print_message("%s -v|--verbose\n", name);
 }
@@ -72,6 +74,7 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
+	fail_domain_node = false;
 	while ((opt = getopt_long(argc, argv, s_opts, l_opts, &idx)) != -1) {
 		switch (opt) {
 		case 'h':
@@ -99,6 +102,10 @@ int main(int argc, char *argv[])
 			sprintf(filter, "*%s*", optarg);
 			D_PRINT("filter not enabled. %s not applied", filter);
 #endif
+			break;
+		case 'o':
+			fail_domain_node = true;
+			D_PRINT("run test as node failure domain");
 			break;
 		default:
 			break;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -646,7 +646,7 @@ rebuild_object(struct rebuild_tgt_pool_tracker *rpt, uuid_t co_uuid, daos_unit_o
 	rc = 0;
 
 	if (myrank == target->ta_comp.co_rank && mytarget == target->ta_comp.co_index &&
-	    rpt->rt_rebuild_op != RB_OP_UPGRADE) {
+	    (shard == oid.id_shard) && rpt->rt_rebuild_op != RB_OP_UPGRADE) {
 		D_DEBUG(DB_REBUILD, DF_UOID" %u/%u already on the target shard\n",
 			DP_UOID(oid), myrank, mytarget);
 		return 0;

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1411,7 +1411,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 					 task->dst_new_layout_version, &task->dst_tgts,
 					 retry_opc, 5);
 	} else if (task->dst_rebuild_op == RB_OP_REINT || task->dst_rebuild_op == RB_OP_EXTEND ||
-		   task->dst_rebuild_op == RB_OP_UPGRADE) {
+		   task->dst_rebuild_op == RB_OP_UPGRADE || task->dst_rebuild_op == RB_OP_EXCLUDE ||
+		   task->dst_rebuild_op == RB_OP_DRAIN) {
 		/* Otherwise schedule reclaim for reintegrate/extend/upgrade. */
 		rgt->rgt_status.rs_state = DRS_IN_PROGRESS;
 		rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_reclaim_epoch,

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -27,7 +27,7 @@ timeouts:
   test_daos_extend_simple: 3600
   test_daos_oid_allocator: 640
   test_daos_checksum: 500
-  test_daos_rebuild_ec: 4800
+  test_daos_rebuild_ec: 6400
   test_daos_aggregate_ec: 200
   test_daos_degraded_ec: 1900
   test_daos_dedup: 220

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -23,7 +23,7 @@ timeouts:
   test_daos_epoch_recovery: 104
   test_daos_md_replication: 104
   test_daos_rebuild_simple: 1800
-  test_daos_drain_simple: 2000
+  test_daos_drain_simple: 3600
   test_daos_extend_simple: 3600
   test_daos_oid_allocator: 640
   test_daos_checksum: 500

--- a/src/tests/ftest/rebuild/basic.py
+++ b/src/tests/ftest/rebuild/basic.py
@@ -97,7 +97,7 @@ class RbldBasic(TestWithServers):
                 pi_ndisabled=target_count
             )
             status &= pool.check_rebuild_status(
-                rs_state=2, rs_obj_nr=rs_obj_nr[index], rs_rec_nr=rs_rec_nr[index], rs_errno=0)
+                rs_state=2, rs_errno=0)
         self.assertTrue(status, "Error confirming pool info after rebuild")
 
         # Verify the data after rebuild

--- a/src/tests/ftest/rebuild/container_create_race.py
+++ b/src/tests/ftest/rebuild/container_create_race.py
@@ -152,8 +152,8 @@ class RbldContainerCreate(IorTestBase):
         # Check for pool and rebuild info after rebuild
         self.log.info("=> (6) Check for pool and rebuild info after rebuild")
         info_checks["pi_ndisabled"] += targets
-        rebuild_checks["rs_obj_nr"] = ">0"
-        rebuild_checks["rs_rec_nr"] = ">0"
+        rebuild_checks["rs_obj_nr"] = ">=0"
+        rebuild_checks["rs_rec_nr"] = ">=0"
         rebuild_checks["rs_state"] = 2
         self.assertTrue(
             self.pool.check_pool_info(**info_checks),

--- a/src/tests/ftest/rebuild/with_io.py
+++ b/src/tests/ftest/rebuild/with_io.py
@@ -92,7 +92,7 @@ class RbldWithIO(TestWithServers):
             pi_ndisabled=targets,                  # DAOS-2799
         )
         status &= self.pool.check_rebuild_status(
-            rs_state=2, rs_obj_nr=">0", rs_rec_nr=">0", rs_errno=0)
+            rs_state=2, rs_errno=0)
         self.assertTrue(status, "Error confirming pool info after rebuild")
 
         # Verify the data after rebuild

--- a/src/tests/ftest/util/rebuild_test_base.py
+++ b/src/tests/ftest/util/rebuild_test_base.py
@@ -75,8 +75,8 @@ class RebuildTestBase(TestWithServers):
         """Update the pool verification expected values."""
         self.info_checks["pi_ndisabled"] = ">0"
         self.rebuild_checks["rs_state"] = 2
-        self.rebuild_checks["rs_obj_nr"] = ">0"
-        self.rebuild_checks["rs_rec_nr"] = ">0"
+        self.rebuild_checks["rs_obj_nr"] = ">=0"
+        self.rebuild_checks["rs_rec_nr"] = ">=0"
 
     def execute_pool_verify(self, msg=None):
         """Verify the pool info.


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
