### PR TITLE
DAOS-14228 tests: Adjust pool/create_all_vm.yaml (#12955)

### DIFF
--- a/src/tests/ftest/pool/create_all_vm.yaml
+++ b/src/tests/ftest/pool/create_all_vm.yaml
@@ -6,7 +6,7 @@ timeouts:
   test_one_pool_vm: 240
   test_rank_filter: 240
   test_two_pools_vm: 160
-  test_recycle_pools_vm: 1000
+  test_recycle_pools_vm: 800
 
 # DAOS-12750 NOTE External tools used by DAOS are creating sparse files (e.g. daos_system.db) which
 # could eventually be compacted when a pool is created.  To manage this, we add 9 MiB to the 17MiB
@@ -18,7 +18,7 @@ test_rank_filter:
   delta: 27262976             # 26MiB
 
 test_recycle_pools_vm:
-  pool_count: 50
+  pool_count: 20
 
 test_two_pools_vm:
   deltas:


### PR DESCRIPTION
See the Jira ticket for the context. This patch reduces the number iterations in test_recycle_pools_vm so that each iteration will get more time and the test will take less time.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: PoolCreateAllVmTests

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
