### PR TITLE
DAOS-12531 ddb: Add Epoch to VOS Tree Path

### DIFF
--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -61,13 +61,14 @@ func ddbPoolIsOpen(ctx *DdbContext) bool {
 	return bool(C.ddb_pool_is_open(&ctx.ctx))
 }
 
-func ddbLs(ctx *DdbContext, path string, recursive bool, details bool) error {
+func ddbLs(ctx *DdbContext, path string, recursive bool, details bool, all_recx bool) error {
 	/* Set up the options */
 	options := C.struct_ls_options{}
 	options.path = C.CString(path)
 	defer freeString(options.path)
 	options.recursive = C.bool(recursive)
 	options.details = C.bool(details)
+	options.all_recx = C.bool(all_recx)
 	/* Run the c code command */
 	return daosError(C.ddb_run_ls(&ctx.ctx, &options))
 }

--- a/src/control/cmd/ddb/ddb_commands.go
+++ b/src/control/cmd/ddb/ddb_commands.go
@@ -21,12 +21,13 @@ func addAppCommands(app *grumble.App, ctx *DdbContext) {
 		Flags: func(f *grumble.Flags) {
 			f.Bool("r", "recursive", false, "Recursively list the contents of the path")
 			f.Bool("d", "details", false, "List more details of items in path")
+			f.Bool("a", "all_recx", false, "List all record extents instead of just visible ones")
 		},
 		Args: func(a *grumble.Args) {
 			a.String("path", "Optional, list contents of the provided path", grumble.Default(""))
 		},
 		Run: func(c *grumble.Context) error {
-			return ddbLs(ctx, c.Args.String("path"), c.Flags.Bool("recursive"), c.Flags.Bool("details"))
+			return ddbLs(ctx, c.Args.String("path"), c.Flags.Bool("recursive"), c.Flags.Bool("details"), c.Flags.Bool("all_recx"))
 		},
 		Completer: nil,
 	})

--- a/src/ddb/ddb.c
+++ b/src/ddb/ddb.c
@@ -40,13 +40,12 @@ static int
 ls_option_parse(struct ddb_ctx *ctx, struct ls_options *cmd_args,
 		uint32_t argc, char **argv)
 {
-	char		 *options_short = "rd";
+	char             *options_short  = "rda";
 	int		  index = 0, opt;
-	struct option	  options_long[] = {
-		{ "recursive", no_argument, NULL, 'r' },
-		{ "details", no_argument, NULL, 'd' },
-		{ NULL }
-	};
+	struct option     options_long[] = {{"recursive", no_argument, NULL, 'r'},
+					    {"details", no_argument, NULL, 'd'},
+					    {"all_recx", no_argument, NULL, 'a'},
+					    {NULL}};
 
 	memset(cmd_args, 0, sizeof(*cmd_args));
 
@@ -60,6 +59,9 @@ ls_option_parse(struct ddb_ctx *ctx, struct ls_options *cmd_args,
 			break;
 		case 'd':
 			cmd_args->details = true;
+			break;
+		case 'a':
+			cmd_args->all_recx = true;
 			break;
 		case '?':
 			ddb_printf(ctx, "Unknown option: '%c'\n", optopt);
@@ -902,6 +904,8 @@ ddb_commands_help(struct ddb_ctx *ctx)
 	ddb_print(ctx, "\tRecursively list the contents of the path\n");
 	ddb_print(ctx, "    -d, --details\n");
 	ddb_print(ctx, "\tList more details of items in path\n");
+	ddb_print(ctx, "    -a, --all_recx\n");
+	ddb_print(ctx, "\tList all record extents instead of just visible ones\n");
 	ddb_print(ctx, "\n");
 
 	/* Command: open */

--- a/src/ddb/ddb.h
+++ b/src/ddb/ddb.h
@@ -120,6 +120,7 @@ enum ddb_cmd {
 struct ls_options {
 	bool recursive;
 	bool details;
+	bool  all_recx;
 	char *path;
 };
 

--- a/src/ddb/ddb_common.h
+++ b/src/ddb/ddb_common.h
@@ -48,4 +48,11 @@ struct argv_parsed {
 	uint32_t	  ap_argc;
 };
 
+/* similar to daos_recx_t, but includes the epoch */
+struct ddb_recx {
+	uint64_t     drx_idx;
+	uint64_t     drx_nr;
+	daos_epoch_t drx_epoch;
+};
+
 #endif /* __DAOS_DDB_COMMON_H */

--- a/src/ddb/ddb_parse.h
+++ b/src/ddb/ddb_parse.h
@@ -45,6 +45,10 @@ int ddb_parse_program_args(struct ddb_ctx *ctx, uint32_t argc, char **argv,
 /* See ddb_iov_to_printable_buf for how the keys will be printed */
 int ddb_parse_key(const char *input, daos_key_t *key);
 
+/* Parse a hex value. Must start with '0x' and be able to fit into an uint64_t */
+int
+    ddb_parse_hex(const char *input, uint64_t *value);
+
 /* Parse a string into the parts of a dtx_id. See DF_DTIF for how the format of the dtx_id is
  * expected to be.
  */

--- a/src/ddb/ddb_printer.c
+++ b/src/ddb/ddb_printer.c
@@ -7,7 +7,7 @@
 #include "ddb_printer.h"
 
 static void
-print_indent(struct ddb_ctx *ctx, int c)
+print_indent(struct ddb_ctx *ctx, uint32_t c)
 {
 	int i;
 
@@ -135,9 +135,7 @@ void
 ddb_print_sv(struct ddb_ctx *ctx, struct ddb_sv *sv, uint32_t indent)
 {
 	print_indent(ctx, indent);
-	ddb_printf(ctx, DF_IDX" Single Value (Length: "DF_U64" bytes)\n",
-		   sv->ddbs_idx,
-		   sv->ddbs_record_size);
+	ddb_printf(ctx, "Single Value Length: " DF_U64 " bytes\n", sv->ddbs_record_size);
 }
 
 void

--- a/src/ddb/ddb_tree_path.h
+++ b/src/ddb/ddb_tree_path.h
@@ -9,8 +9,8 @@
 
 #include "ddb_common.h"
 
-#define DF_DDB_RECX	"{"DF_U64"-"DF_U64"}"
-#define DP_DDB_RECX(r)	(r).rx_idx, ((r).rx_idx + (r).rx_nr - 1)
+#define DF_DDB_RECX          "{" DF_U64 "-" DF_U64 "}.0x" DF_X64 ""
+#define DP_DDB_RECX(r)       (r).drx_idx, ((r).drx_idx + (r).drx_nr - 1), (r).drx_epoch
 
 #define INVALID_IDX          (-1)
 #define INVALID_PATH "INVALID PATH"
@@ -50,7 +50,7 @@ struct indexed_tree_path_part {
 		uuid_t		itp_uuid;
 		daos_unit_oid_t itp_oid;
 		daos_key_t	itp_key; /* akey or dkey */
-		daos_recx_t	itp_recx;
+		struct ddb_recx itp_recx;
 	}		itp_part_value;
 	uint32_t        itp_part_idx;
 	bool            itp_has_part_idx;
@@ -108,8 +108,10 @@ bool itp_set_dkey(struct dv_indexed_tree_path *itp, daos_key_t *key, uint32_t id
 bool itp_set_dkey_part_value(struct dv_indexed_tree_path *itp, daos_key_t *key);
 bool itp_set_akey(struct dv_indexed_tree_path *itp, daos_key_t *key, uint32_t idx);
 bool itp_set_akey_part_value(struct dv_indexed_tree_path *itp, daos_key_t *key);
-bool itp_set_recx(struct dv_indexed_tree_path *itp, daos_recx_t *recx, uint32_t idx);
-bool itp_set_recx_part_value(struct dv_indexed_tree_path *itp, daos_recx_t *recx);
+bool
+itp_set_recx(struct dv_indexed_tree_path *itp, struct ddb_recx *recx, uint32_t idx);
+bool
+     itp_set_recx_part_value(struct dv_indexed_tree_path *itp, struct ddb_recx *recx);
 
 void itp_unset_recx(struct dv_indexed_tree_path *itp);
 void itp_unset_akey(struct dv_indexed_tree_path *itp);
@@ -158,7 +160,8 @@ uint8_t *itp_cont(struct dv_indexed_tree_path *itp);
 daos_unit_oid_t *itp_oid(struct dv_indexed_tree_path *itp);
 daos_key_t *itp_dkey(struct dv_indexed_tree_path *itp);
 daos_key_t *itp_akey(struct dv_indexed_tree_path *itp);
-daos_recx_t *itp_recx(struct dv_indexed_tree_path *itp);
+struct ddb_recx      *
+itp_recx(struct dv_indexed_tree_path *itp);
 
 /* Functions for getting specific parts' index */
 int itp_cont_idx(struct dv_indexed_tree_path *itp);
@@ -188,7 +191,7 @@ struct dv_tree_path {
 	daos_unit_oid_t vtp_oid;
 	daos_key_t	vtp_dkey;
 	daos_key_t	vtp_akey;
-	daos_recx_t	vtp_recx;
+	struct ddb_recx vtp_recx;
 	bool		vtp_is_recx;
 };
 

--- a/src/ddb/ddb_vos.h
+++ b/src/ddb/ddb_vos.h
@@ -43,8 +43,7 @@ struct ddb_array {
 	uint64_t			ddba_record_size;
 	daos_recx_t			ddba_recx;
 	uint32_t			ddba_idx;
-	struct dv_indexed_tree_path	*ddba_path;
-
+	struct dv_indexed_tree_path    *ddba_path;
 };
 
 /* Open and close a pool for a ddb_ctx */
@@ -81,9 +80,10 @@ struct vos_tree_handlers {
  * @param handler_args	arguments to the handlers
  * @return		0 if success, else error
  */
-int dv_iterate(daos_handle_t poh, struct dv_tree_path *path, bool recursive,
-	       struct vos_tree_handlers *handlers, void *handler_args,
-	       struct dv_indexed_tree_path *itp);
+int
+    dv_iterate(daos_handle_t poh, struct dv_tree_path *path, bool recursive,
+	       struct vos_tree_handlers *handlers, void *handler_args, struct dv_indexed_tree_path *itp,
+	       bool all_recx);
 
 /* need a special function to get a container idx */
 int dv_get_cont_idx(daos_handle_t poh, uuid_t uuid);
@@ -93,8 +93,9 @@ int dv_get_object_oid(daos_handle_t coh, uint32_t idx, daos_unit_oid_t *uoid);
 int dv_get_dkey(daos_handle_t coh, daos_unit_oid_t uoid, uint32_t idx, daos_key_t *dkey);
 int dv_get_akey(daos_handle_t coh, daos_unit_oid_t uoid, daos_key_t *dkey, uint32_t idx,
 		daos_key_t *akey);
-int dv_get_recx(daos_handle_t coh, daos_unit_oid_t uoid, daos_key_t *dkey, daos_key_t *akey,
-		uint32_t idx, daos_recx_t *recx);
+int
+    dv_get_recx(daos_handle_t coh, daos_unit_oid_t uoid, daos_key_t *dkey, daos_key_t *akey,
+		uint32_t idx, struct ddb_recx *recx);
 
 /**
  * Verify and update the tree path within the builder. For any indexes set in the builder, will
@@ -189,7 +190,8 @@ typedef int (*dv_vea_extent_handler)(void *cb_arg, struct vea_free_extent *free_
 int dv_enumerate_vea(daos_handle_t poh, dv_vea_extent_handler cb, void *cb_arg);
 int dv_vea_free_region(daos_handle_t poh, uint32_t offset, uint32_t blk_cnt);
 int dv_delete(daos_handle_t poh, struct dv_tree_path *vtp);
-int dv_update(daos_handle_t poh, struct dv_tree_path *vtp, d_iov_t *iov);
+int
+     dv_update(daos_handle_t poh, struct dv_tree_path *vtp, d_iov_t *iov, daos_size_t rec_size);
 
 void dv_oid_to_obj(daos_obj_id_t oid, struct ddb_obj *obj);
 

--- a/src/ddb/tests/ddb_cmocka.h
+++ b/src/ddb/tests/ddb_cmocka.h
@@ -54,10 +54,11 @@
 			assert_memory_not_equal(a.iov_buf, b.iov_buf, a.iov_len); \
 	} while (0)
 
-#define assert_recx_equal(a, b) \
-	do { \
-		assert_int_equal((a).rx_nr, (b).rx_nr); \
-		assert_int_equal((a).rx_idx, (b).rx_idx); \
+#define assert_recx_equal(a, b)                                                                    \
+	do {                                                                                       \
+		assert_int_equal((a).drx_nr, (b).drx_nr);                                          \
+		assert_int_equal((a).drx_idx, (b).drx_idx);                                        \
+		assert_int_equal((a).drx_epoch, (b).drx_epoch);                                    \
 	} while (0)
 
 #define assert_string_contains(str, substr) \

--- a/src/ddb/tests/ddb_commands_print_tests.c
+++ b/src/ddb/tests/ddb_commands_print_tests.c
@@ -149,7 +149,7 @@ print_sv_test(void **state)
 	struct ddb_sv sv = {.ddbs_record_size = 19089555};
 
 	ddb_print_sv(&g_ctx, &sv, 0);
-	assert_printed_exact("[0] Single Value (Length: 19089555 bytes)\n");
+	assert_printed_exact("Single Value Length: 19089555 bytes\n");
 }
 
 static void

--- a/src/ddb/tests/ddb_commands_tests.c
+++ b/src/ddb/tests/ddb_commands_tests.c
@@ -235,10 +235,10 @@ rm_cmd_tests(void **state)
 	dvt_fake_print_reset();
 
 	/* Delete RECX */
-	opt.path = "[0]/[0]/[0]/[0]/[0]";
+	opt.path = "[0]/[0]/[0]/[1]/[0]";
 	assert_success(ddb_run_rm(&g_ctx, &opt));
 	assert_string_equal(dvt_fake_print_buffer,
-			    "RECX: (/[0]/[0]/[0]/[0]/[0]) /12345678-1234-1234-1234-123456789001/"
+			    "RECX: (/[0]/[0]/[0]/[1]/[0]) /12345678-1234-1234-1234-123456789001/"
 			    "281479271743488.4294967296.0.0/dkey-1/akey-1/{0-9}.0x5 deleted\n");
 	dvt_fake_print_reset();
 
@@ -247,7 +247,7 @@ rm_cmd_tests(void **state)
 	assert_success(ddb_run_rm(&g_ctx, &opt));
 	assert_string_equal(dvt_fake_print_buffer,
 			    "AKEY: (/[0]/[0]/[0]/[0]) /12345678-1234-1234-1234-123456789001/"
-			    "281479271743488.4294967296.0.0/dkey-1/akey-1 deleted\n");
+			    "281479271743488.4294967296.0.0/dkey-1/akey{5} deleted\n");
 	dvt_fake_print_reset();
 
 	/* Delete DKey */
@@ -283,7 +283,7 @@ load_cmd_tests(void **state)
 
 	assert_invalid(ddb_run_value_load(&g_ctx, &opt));
 
-	opt.dst = "/[0]/[0]/[0]/[1]";
+	opt.dst                         = "/[0]/[1]/[0]/[1]";
 	opt.src = "/tmp/value_src";
 	dvt_fake_get_file_exists_result = true;
 	snprintf(dvt_fake_read_file_buf, ARRAY_SIZE(dvt_fake_read_file_buf), "Some text!!");

--- a/src/ddb/tests/ddb_main_tests.c
+++ b/src/ddb/tests/ddb_main_tests.c
@@ -235,13 +235,7 @@ get_help_tests(void **state)
 static int
 ddb_main_suit_setup(void **state)
 {
-	struct dt_vos_pool_ctx *tctx;
-
 	assert_success(ddb_test_setup_vos(state));
-
-	/* test setup creates the pool, but doesn't open it ... leave it open for these tests */
-	tctx = *state;
-	assert_success(dv_pool_open(tctx->dvt_pmem_file, &tctx->dvt_poh));
 
 	return 0;
 }
@@ -253,7 +247,6 @@ ddb_main_suit_teardown(void **state)
 
 	if (tctx == NULL)
 		fail_msg("Test not setup correctly");
-	assert_success(dv_pool_close(tctx->dvt_poh));
 	ddb_teardown_vos(state);
 
 	return 0;

--- a/src/ddb/tests/ddb_path_tests.c
+++ b/src/ddb/tests/ddb_path_tests.c
@@ -337,9 +337,9 @@ string_to_path_to_string(void **state)
 
 	assert_path_parsed_equals("/12345678-1234-1234-1234-123456789012/1.2.3.4/\\/",
 				  "/12345678-1234-1234-1234-123456789012/1.2.3.4/\\/");
-	assert_path_parsed_equals("/7a63a764-f2ad-4791-8a5d-dff44e2fd2dc/281479271677952.0.0.1///"
+	assert_path_parsed_equals("/7a63a764-f2ad-4791-8a5d-dff44e2fd2dc/281479271677952.0.0.1/\\//"
 				  "DFS_INODE/{0-87}.0x123dac613de00000",
-				  "/7a63a764-f2ad-4791-8a5d-dff44e2fd2dc/281479271677952.0.0.1///"
+				  "/7a63a764-f2ad-4791-8a5d-dff44e2fd2dc/281479271677952.0.0.1/\\//"
 				  "DFS_INODE/{0-87}.0x123dac613de00000");
 }
 

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -296,10 +296,10 @@ ddb_test_setup_vos(void **state)
 
 	if (DAOS_ON_VALGRIND || DDB_FORCE_VALGRIND)
 		/* smaller test data for valgrind */
-		dvt_insert_data(poh, 8, 4, 4, 4, tctx);
+		dvt_insert_data(poh, 8, 4, 4, 4, 4, tctx);
 	else
 		/* default test data */
-		dvt_insert_data(poh, 0, 0, 0, 0, tctx);
+		dvt_insert_data(poh, 0, 0, 0, 0, 0, tctx);
 
 	vos_pool_close(poh);
 	vos_self_fini();
@@ -364,7 +364,7 @@ create_object_data(daos_handle_t *coh, uint32_t obj_to_create, uint32_t dkeys_to
 
 void
 dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys, uint32_t akeys,
-		struct dt_vos_pool_ctx *tctx)
+		uint32_t recxes, struct dt_vos_pool_ctx *tctx)
 {
 	daos_handle_t		coh;
 	uint32_t		cont_to_create = ARRAY_SIZE(g_uuids);
@@ -382,7 +382,8 @@ dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys
 		dkeys_to_create = dkeys;
 	if (akeys > 0)
 		akeys_to_create = akeys;
-
+	if (recxes > 0)
+		recx_to_create = recxes;
 	tctx->dvt_cont_count = cont_to_create;
 	tctx->dvt_obj_count = obj_to_create;
 	tctx->dvt_dkey_count = dkeys_to_create;
@@ -561,6 +562,7 @@ create_test_vos_file()
 	int			objs = 5;
 	int			dkeys = 5;
 	int			akeys = 5;
+	int                     recex = 5;
 	int			rc;
 
 	rc = vos_self_init("/mnt/daos", false, 0);
@@ -576,7 +578,7 @@ create_test_vos_file()
 		return rc;
 	}
 	assert_success(vos_pool_open(tctx.dvt_pmem_file, tctx.dvt_pool_uuid, 0, &poh));
-	dvt_insert_data(poh, conts, objs, dkeys, akeys, &tctx);
+	dvt_insert_data(poh, conts, objs, dkeys, akeys, recex, &tctx);
 
 	assert_success(vos_cont_open(poh, g_uuids[0], &coh));
 	dvt_vos_insert_2_records_with_dtx(coh);

--- a/src/ddb/tests/ddb_test_driver.c
+++ b/src/ddb/tests/ddb_test_driver.c
@@ -272,8 +272,8 @@ setup_global_arrays()
 	d_iov_set(&g_invalid_key, g_invalid_key_str, strlen(g_invalid_key_str));
 
 	for (i = 0; i < ARRAY_SIZE(g_recxs); i++) {
-		g_recxs[0].rx_idx = i;
-		g_recxs[0].rx_nr = 10;
+		g_recxs[i].rx_idx = i;
+		g_recxs[i].rx_nr  = 10;
 	}
 
 	return 0;
@@ -349,9 +349,8 @@ create_object_data(daos_handle_t *coh, uint32_t obj_to_create, uint32_t dkeys_to
 				if (a % 2 == 0) {
 					for (r = 0; r < recx_to_create; r++)
 						dvt_vos_insert_recx((*coh), g_oids[o],
-								    g_dkeys_str[d],
-								    g_akeys_str[a],
-								    &g_recxs[r], 1);
+								    g_dkeys_str[d], g_akeys_str[a],
+								    &g_recxs[r], 5 + r);
 				} else {
 					dvt_vos_insert_single((*coh), g_oids[o],
 							      g_dkeys_str[d],
@@ -388,6 +387,7 @@ dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys
 	tctx->dvt_obj_count = obj_to_create;
 	tctx->dvt_dkey_count = dkeys_to_create;
 	tctx->dvt_akey_count = akeys_to_create;
+	tctx->dvt_recx_count = recx_to_create;
 
 	/* Setup by creating containers */
 	for (c = 0; c < cont_to_create; c++) {
@@ -640,17 +640,17 @@ int main(int argc, char *argv[])
 		rc += func(); } while (0)
 
 		/* filtering suites and tests */
-		char test_suites[] = "";
+	char test_suites[] = "";
 #if CMOCKA_FILTER_SUPPORTED == 1 /** requires cmocka 1.1.5 */
-		cmocka_set_test_filter("**");
+	cmocka_set_test_filter("**");
 #endif
-		RUN_TEST_SUIT('a', ddb_parse_tests_run);
-		RUN_TEST_SUIT('b', ddb_cmd_options_tests_run);
-		RUN_TEST_SUIT('c', ddb_vos_tests_run);
-		RUN_TEST_SUIT('d', ddb_commands_tests_run);
-		RUN_TEST_SUIT('e', ddb_main_tests_run);
-		RUN_TEST_SUIT('f', ddb_commands_print_tests_run);
-		RUN_TEST_SUIT('g', ddb_path_tests_run);
+	RUN_TEST_SUIT('a', ddb_parse_tests_run);
+	RUN_TEST_SUIT('b', ddb_cmd_options_tests_run);
+	RUN_TEST_SUIT('c', ddb_vos_tests_run);
+	RUN_TEST_SUIT('d', ddb_commands_tests_run);
+	RUN_TEST_SUIT('e', ddb_main_tests_run);
+	RUN_TEST_SUIT('f', ddb_commands_print_tests_run);
+	RUN_TEST_SUIT('g', ddb_path_tests_run);
 
 done:
 	ddb_fini();

--- a/src/ddb/tests/ddb_test_driver.h
+++ b/src/ddb/tests/ddb_test_driver.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -58,8 +58,9 @@ int ddb_path_tests_run(void);
  * Insert data into the pool. The cont, objs, ... parameters indicate how many of each to
  * insert into its parent. If numbers are 0, then it will use a default number.
  */
-void dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys,
-		     uint32_t akeys, struct dt_vos_pool_ctx *tctx);
+void
+dvt_insert_data(daos_handle_t poh, uint32_t conts, uint32_t objs, uint32_t dkeys, uint32_t akeys,
+		uint32_t recxes, struct dt_vos_pool_ctx *tctx);
 
 int ddb_test_pool_setup(struct dt_vos_pool_ctx *tctx);
 

--- a/src/ddb/tests/ddb_test_driver.h
+++ b/src/ddb/tests/ddb_test_driver.h
@@ -29,6 +29,7 @@ struct dt_vos_pool_ctx {
 	uint32_t	dvt_obj_count;
 	uint32_t	dvt_dkey_count;
 	uint32_t	dvt_akey_count;
+	uint32_t        dvt_recx_count;
 };
 
 daos_unit_oid_t dvt_gen_uoid(uint32_t i);

--- a/src/ddb/tests/ddb_vos_tests.c
+++ b/src/ddb/tests/ddb_vos_tests.c
@@ -72,7 +72,7 @@ int fake_sv_handler(struct ddb_sv *sv, void *args)
 }
 
 static int fake_array_handler_call_count;
-static struct ddb_array fake_array_handler_arrays[2048 * 10];
+static struct ddb_array fake_array_handler_arrays[2048 * 100];
 int fake_array_handler(struct ddb_array *array, void *args)
 {
 	assert_true(fake_array_handler_call_count < ARRAY_SIZE(fake_array_handler_arrays));

--- a/src/tests/ftest/util/ddb_utils.py
+++ b/src/tests/ftest/util/ddb_utils.py
@@ -35,10 +35,11 @@ class DdbCommandBase(CommandWithParameters):
         self.write_mode = FormattedParameter("-w", default=False)
 
         # Command to run on the VOS file that contains container, object info, etc.
-        self.single_command = BasicParameter(None, position=2)
+        self.single_command = BasicParameter(None, position=3)
 
         # VOS file path.
-        self.vos_path = BasicParameter(None, position=1)
+        self.ddb_param = BasicParameter("-p", default=True, position=1)
+        self.vos_path = BasicParameter(None, position=2)
 
         # Members needed for run_pcmd().
         self.verbose = verbose


### PR DESCRIPTION
For record extents it's important to understand epochs. Added a new ddb type for record extents (struct ddb_recx) which is used instead of the daos_recx_t. Adds the epoch to the end of the recx in the vos tree path.

Some other fixes:
- when listing contents of akeys that are single value, the path doesn't need to be printed again.
- Loading values, if the path doesn't already exist and it can be created by the vos_obj_update, then handle the output to the user differently so it's more obvious what it's doing.
- Removed ability to load a value into an object that doesn't exist.
- Fixed the creation of recx's in the tests
- Improved printing of paths and details
- Added ability to delete a specific RECX (really inserts a delete record)
- Fixed a bug with keys that are '/'
- ls command can show all record extents with '-a' option
- Changed vos path argument to be a flag so can handle commands that don't need a vos connection better (help, smd_sync)

Test-tag: ddb_cmd
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
