### PR TITLE
DAOS-14338 test: Verify pr13042

### DIFF
--- a/src/tests/ftest/osa/offline_extend.py
+++ b/src/tests/ftest/osa/offline_extend.py
@@ -3,6 +3,7 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import time
 from osa_utils import OSAUtils
 from test_utils_pool import add_pool
 from dmg_utils import check_system_query_status
@@ -58,7 +59,7 @@ class OSAOfflineExtend(OSAUtils):
             self.pool.set_property("reclaim", "disabled")
             if data:
                 self.run_ior_thread("Write", oclass[index], test_seq)
-                self.run_mdtest_thread(oclass[index])
+                # self.run_mdtest_thread(oclass[index])
                 if self.test_during_aggregation is True:
                     self.run_ior_thread("Write", oclass[index], test_seq)
                 if self.test_with_snapshot is True:
@@ -91,21 +92,27 @@ class OSAOfflineExtend(OSAUtils):
             self.log.info("Pool Version at the beginning %s", pver_begin)
             # Get initial total free space (scm+nvme)
             initial_free_space = self.pool.get_total_free_space(refresh=True)
+            self.log.info(initial_free_space)
             # Enable aggregation for multiple pool testing only.
             if self.test_during_aggregation is True and (num_pool > 1):
                 self.delete_extra_container(self.pool)
             output = self.pool.extend(rank_val)
+            self.log.info(output)
+            time.sleep(5)
+            self.log.info("Exclude rank 3 while rebuild is happening")
+            output = self.pool.exclude("3")
             self.print_and_assert_on_rebuild_failure(output)
             free_space_after_extend = self.pool.get_total_free_space(refresh=True)
+            self.log.info(free_space_after_extend)
 
             pver_extend = self.pool.get_version(True)
             self.log.info("Pool Version after extend %d", pver_extend)
             # Check pool version incremented after pool extend
-            self.assertTrue(pver_extend > pver_begin, "Pool Version Error:  After extend")
+            # self.assertTrue(pver_extend > pver_begin, "Pool Version Error:  After extend")
             display_string = "Pool{} space at the End".format(val)
             pool[val].display_pool_daos_space(display_string)
-            self.assertTrue(free_space_after_extend > initial_free_space,
-                            "Expected free space after extend is less than initial")
+            # self.assertTrue(free_space_after_extend > initial_free_space,
+            #                "Expected free space after extend is less than initial")
 
             if data:
                 # Perform the IOR read using the same
@@ -115,7 +122,7 @@ class OSAOfflineExtend(OSAUtils):
                 else:
                     index = 0
                 self.run_ior_thread("Read", oclass[index], test_seq)
-                self.run_mdtest_thread(oclass[index])
+                # self.run_mdtest_thread(oclass[index])
                 self.container = self.pool_cont_dict[self.pool][0]
                 self.container.check()
 
@@ -202,3 +209,4 @@ class OSAOfflineExtend(OSAUtils):
         self.test_with_snapshot = self.params.get("test_with_snapshot", '/run/snapshot/*')
         self.log.info("Offline Extend Testing: After taking snapshot")
         self.run_offline_extend_test(1, data=True)
+


### PR DESCRIPTION
Test-tag: test_osa_offline_extend
Test-repeat: 5

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
