### PR TITLE
DAOS-3672 test: Verify pool space usage via sys commands

### DIFF
--- a/src/tests/ftest/pool/verify_space.py
+++ b/src/tests/ftest/pool/verify_space.py
@@ -1,0 +1,66 @@
+"""
+  (C) Copyright 2018-2023 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+import os
+
+from apricot import TestWithServers
+
+from run_utils import run_remote
+
+
+class VerifyPoolSpace(TestWithServers):
+    """Verify pool space with system commands.
+
+    :avocado: recursive"""
+
+    def test_verify_pool_space(self):
+        """Test ID: DAOS-3672.
+
+        Test steps:
+        1) Create a single pool on a single server and list associated storage, verify correctness
+        2) Use IOR to fill containers to varying degrees of fullness, verify storage listing
+        3) Create multiple pools on a single server, list associated storage, verify correctness
+        4) Use IOR to fill containers to varying degrees of fullness, verify storage listing for all
+           pools
+        5) Create a single pool that spans many servers, list associated storage, verify correctness
+        6) Use IOR to fill containers to varying degrees of fullness, verify storage listing
+        7) Create multiple pools that span many servers, list associated storage, verify correctness
+        8) Use IOR to fill containers to varying degrees of fullness, verify storage listing
+        9) Fail one of the servers for a pool spanning many servers.  Verify the storage listing.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=pool
+        :avocado: tags=VerifyPoolSpace,test_verify_pool_space
+        """
+        # ranks = self.server_managers[0].ranks
+        self.verify_pool_space('a single pool on a single server', [1])
+        self.verify_pool_space('multiple pools on a single server', [2, 3, 4])
+        self.verify_pool_space('a single pool that spans many servers', [5])
+        self.verify_pool_space('multiple pools that span many servers', [6, 7])
+
+    def verify_pool_space(self, description, indices):
+        """."""
+        pools = []
+        self.log_step(' '.join(['Create', description]), True)
+        for index in indices:
+            namespace = os.path.join(os.sep, 'run', '_'.join(['pool', index]))
+            pools.append(self.get_pool(namespace=namespace))
+
+        self.log_step(' '.join(['Write data to', description]))
+
+        self.verify_pool_size(description, pools)
+
+    def verify_pool_size(self, description, pools):
+        """."""
+        self.log_step(' '.join(['Collect system-level DAOS mount information for', description]))
+        command = 'df -h | grep daos'
+        result = run_remote(self.log, self.server_managers[0].hosts, command, stderr=True)
+        if not result.passed:
+            self.fail('Error collecting system level daos mount information')
+
+        self.log_step(' '.join(['Query pool information for', description]))
+        for pool in pools:
+            pool.query()

--- a/src/tests/ftest/pool/verify_space.yaml
+++ b/src/tests/ftest/pool/verify_space.yaml
@@ -1,0 +1,34 @@
+hosts:
+  test_servers: 3
+  test_clients: 1
+timeout: 90
+server_config:
+  engines_per_host: 1
+  engines:
+    0:
+      storage: auto
+  system_ram_reserved: 1
+pool_1:
+  size: 1G
+  target_list: 0
+  description: 'single pool on a single server (rank 0)'
+pool_2:
+  size: 2G
+  target_list: 1
+  description: 'multiple pools on a single server (rank 1)'
+pool_3:
+  size: 3G
+  target_list: 1
+  description: 'multiple pools on a single server (rank 1)'
+pool_4:
+  size: 4G
+  target_list: 1
+pool_5:
+  size: 5G
+  target_list: [1, 2]
+pool_6:
+  size: 1G
+  target_list: [0, 1, 2]
+pool_7:
+  size: 1G
+  target_list: [0, 1, 2]

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -452,13 +452,15 @@ class Test(avocadoTest):
                 "Incrementing %s from %s to %s seconds", section, value, value + increment)
             set_avocado_config_value(namespace, key, value + increment)
 
-    def log_step(self, message):
+    def log_step(self, message, marker=False):
         """Log a test step.
 
         Args:
             message (str): description of test step.
-
+            marker (bool, optional): whether to log a marker line in the log. Defaults to False.
         """
+        if marker:
+            self.log.info('-' * 80)
         self.log.info("==> Step %s: %s", self._test_step, message)
         self._test_step += 1
 

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -346,7 +346,7 @@ class DaosServerManager(SubprocessManager):
                 # Remove the shared memory segment associated with this io server
                 self.log.debug("Removing the shared memory segment")
                 command = "sudo ipcrm -M {}".format(self.D_TM_SHARED_MEMORY_KEY + index)
-                run_remote(self.log, self._hosts, command, verbose)
+                run_remote(self.log, mounted_hosts, command, verbose)
 
             # Dismount the scm mount point
             self.log.debug("Dismount the %s mount point", mount)


### PR DESCRIPTION
Automating a manual test that verifies the pool space usage with system commands.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_verify_pool_space

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
