### PR TITLE
DAOS-14302 test: Skip DAOS_Drain_Simple w/o fault injection (#13039)

### DIFF
--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -1003,6 +1003,8 @@ run_daos_drain_simple_test(int rank, int size, int *sub_tests,
 {
 	int rc = 0;
 
+	FAULT_INJECTION_REQUIRED();
+
 	par_barrier(PAR_COMM_WORLD);
 	if (sub_tests_size == 0) {
 		sub_tests_size = ARRAY_SIZE(drain_tests);

--- a/src/tests/suite/daos_drain_simple.c
+++ b/src/tests/suite/daos_drain_simple.c
@@ -38,6 +38,8 @@ drain_dkeys(void **state)
 	int			tgt = DEFAULT_FAIL_TGT;
 	int			i;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 4))
 		return;
 
@@ -103,6 +105,8 @@ cont_open_in_drain(void **state)
 	int			tgt = DEFAULT_FAIL_TGT;
 	int			i;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 4))
 		return;
 
@@ -157,6 +161,8 @@ drain_akeys(void **state)
 	int			tgt = DEFAULT_FAIL_TGT;
 	int			i;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 4))
 		return;
 
@@ -207,6 +213,8 @@ drain_indexes(void **state)
 	int			tgt = DEFAULT_FAIL_TGT;
 	int			i;
 	int			j;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 4))
 		return;
@@ -267,6 +275,7 @@ drain_snap_update_keys(void **state)
 	char		buf[256];
 	int		buf_len = 256;
 
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 4))
 		return;
@@ -342,6 +351,8 @@ drain_snap_punch_keys(void **state)
 	char		 buf[256];
 	int		 buf_len = 256;
 	uint32_t	 number;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 4))
 		return;
@@ -429,6 +440,8 @@ drain_multiple(void **state)
 	int		j;
 	int		k;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 4))
 		return;
 
@@ -495,6 +508,8 @@ drain_large_rec(void **state)
 	char			buffer[5000];
 	char			v_buffer[5000];
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 4))
 		return;
 
@@ -543,6 +558,8 @@ drain_objects(void **state)
 	int		tgt = DEFAULT_FAIL_TGT;
 	int		i;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 4))
 		return;
 
@@ -568,6 +585,8 @@ drain_fail_and_retry_objects(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 4))
 		return;
@@ -597,6 +616,8 @@ drain_then_exclude(void **state)
 {
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	oid;
+
+	FAULT_INJECTION_REQUIRED();
 
 	if (!test_runable(arg, 4))
 		return;
@@ -849,6 +870,8 @@ dfs_extend_drain_common(void **state, int opc, uint32_t objclass)
 	dfs_attr_t attr = {};
 	int		rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 4))
 		return;
 
@@ -1002,8 +1025,6 @@ run_daos_drain_simple_test(int rank, int size, int *sub_tests,
 			     int sub_tests_size)
 {
 	int rc = 0;
-
-	FAULT_INJECTION_REQUIRED();
 
 	par_barrier(PAR_COMM_WORLD);
 	if (sub_tests_size == 0) {

--- a/src/tests/suite/daos_extend_simple.c
+++ b/src/tests/suite/daos_extend_simple.c
@@ -499,6 +499,8 @@ dfs_extend_punch_kill(void **state)
 void
 dfs_extend_punch_extend(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	dfs_extend_internal(state, EXTEND_PUNCH, extend_cb_internal, false);
 }
 
@@ -511,6 +513,8 @@ dfs_extend_stat_kill(void **state)
 void
 dfs_extend_stat_extend(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	dfs_extend_internal(state, EXTEND_STAT, extend_cb_internal, false);
 }
 
@@ -523,6 +527,8 @@ dfs_extend_enumerate_kill(void **state)
 void
 dfs_extend_enumerate_extend(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	dfs_extend_internal(state, EXTEND_ENUMERATE, extend_cb_internal, false);
 }
 
@@ -535,6 +541,8 @@ dfs_extend_fetch_kill(void **state)
 void
 dfs_extend_fetch_extend(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	dfs_extend_internal(state, EXTEND_FETCH, extend_cb_internal, false);
 }
 
@@ -547,6 +555,8 @@ dfs_extend_write_kill(void **state)
 void
 dfs_extend_write_extend(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	dfs_extend_internal(state, EXTEND_UPDATE, extend_cb_internal, false);
 }
 
@@ -561,6 +571,8 @@ dfs_extend_fail_retry(void **state)
 	char		str[37];
 	dfs_attr_t attr = {};
 	int		rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	attr.da_props = daos_prop_alloc(1);
 	assert_non_null(attr.da_props);

--- a/src/tests/suite/daos_obj_ec.c
+++ b/src/tests/suite/daos_obj_ec.c
@@ -2464,6 +2464,8 @@ ec_three_stripes_nvme_io(void **state)
 	daos_recx_t	recx;
 	int		i;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (!test_runable(arg, 6))
 		return;
 


### PR DESCRIPTION
Do not run the DAOS_Drain_Simple test when DAOS is built without fault injection.

Also skipping the DAOS_Extend_Simple.EXTEND[7,9,11,13,15,16] and DAOS_EC.EC28 test when fault injection is disabled.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_daos_drain_simple test_daos_extend_simple test_daos_ec_obj

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
