### PR TITLE
DAOS-9653 control: Improve pool creation error message

### DIFF
--- a/src/control/cmd/daos/flags.go
+++ b/src/control/cmd/daos/flags.go
@@ -99,7 +99,7 @@ func (f *ChunkSizeFlag) UnmarshalFlag(fv string) error {
 
 	size, err := humanize.ParseBytes(fv)
 	if err != nil {
-		return err
+		return errors.Errorf("invalid chunk-size %q", fv)
 	}
 	f.Size = C.uint64_t(size)
 

--- a/src/control/cmd/daos/flags_test.go
+++ b/src/control/cmd/daos/flags_test.go
@@ -227,7 +227,7 @@ func TestFlags_ChunkSizeFlag(t *testing.T) {
 		},
 		"not a size": {
 			arg:    "snausages",
-			expErr: errors.New("ParseFloat"),
+			expErr: errors.New("invalid chunk-size \"snausages\""),
 		},
 		// TODO: More validation of allowed sizes?
 	} {

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -92,7 +92,7 @@ func (trf *tierRatioFlag) UnmarshalFlag(fv string) error {
 	for _, trStr := range strings.Split(fv, ",") {
 		tr, err := strconv.ParseFloat(strings.TrimSpace(strings.Trim(trStr, "%")), 64)
 		if err != nil {
-			return errors.Wrapf(err, "invalid tier ratio %s", trStr)
+			return errors.Errorf("invalid tier ratio %q", trStr)
 		}
 		trf.ratios = append(trf.ratios, roundFloatTo(tr, 2)/100)
 	}
@@ -137,7 +137,7 @@ func (sf *sizeFlag) UnmarshalFlag(fv string) (err error) {
 
 	sf.bytes, err = humanize.ParseBytes(fv)
 	if err != nil {
-		return errors.Wrapf(err, "invalid size %q", fv)
+		return errors.Errorf("invalid size %q", fv)
 	}
 
 	return nil

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -42,6 +42,10 @@ func Test_Dmg_PoolTierRatioFlag(t *testing.T) {
 		"empty": {
 			expErr: errors.New("no tier ratio specified"),
 		},
+		"invalid": {
+			input:  "ABCD",
+			expErr: errors.New("invalid tier ratio \"ABCD\""),
+		},
 		"less than 100%": {
 			input:  "10,80",
 			expErr: errors.New("must add up to"),


### PR DESCRIPTION
Updated the error message in case of wrong value or none is provided.

Code is trying to pass the command line value to ParseFloat(). If it's a string it returns ErrSyntax like "strconv.ParseFloat: parsing "": invalid syntax". Which is little bit more detailed coding error. So instead returning the ErrSyntax, it's wrapped with descriptive message.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
