### PR TITLE
DAOS-14270 common: Workaround setenv reallocation

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -341,6 +341,8 @@ ioil_init(void)
 	}
 
 	ioil_iog.iog_initialized = true;
+
+	daos_init_environment();
 }
 
 static void

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -5389,6 +5389,8 @@ init_myhook(void)
 
 	install_hook();
 	hook_enabled = 1;
+
+	daos_init_environment();
 }
 
 static void

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -1088,4 +1088,13 @@ explicit_bzero(void *s, size_t count) {
 }
 #endif /* NEED_EXPLICIT_BZERO */
 
+static inline void
+daos_init_environment(void)
+{
+	d_set_env_invalid(11, "CRT_PHY_ADDR_STR", "CRT_CTX_SHARE_ADDR", "CRT_TIMEOUT",
+			  "FI_OFI_RXM_USE_SRX", "OFI_INTERFACE", "OFI_DOMAIN", "FI_UNIVERSE_SIZE",
+			  "UCX_IB_FORK_INIT", "FI_MR_CACHE_MAX_COUNT", "NA_OFI_UNEXPECTED_TAG_MSG",
+			  "FI_OFI_RXM_DEF_TCP_WAIT_OBJ");
+}
+
 #endif /* __DAOS_COMMON_H__ */

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -950,6 +950,11 @@ int d_vec_pointers_init(struct d_vec_pointers *pointers, uint32_t cap);
 void d_vec_pointers_fini(struct d_vec_pointers *pointers);
 int d_vec_pointers_append(struct d_vec_pointers *pointers, void *pointer);
 
+#define D_INVALID_ENVIRONMENT "DAOS_INVALID"
+/** Set count environment variables to invalid to reserve space */
+void
+d_set_env_invalid(int count, ...);
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
For interception libraries, deferring calls to daos_init can cause issues because DAOS calls setenv.  If the application is threaded at this point, this can cause a crash because the environment is global and may get reallocated. This patch enables a workaround where daos can pre-set environmentment variables to a
known "empty" value.  The wrappers treat this value as empty.  This enables the interception libraries to preallocate environment variables they may set
without causing a reallocation when they are set
at runtime.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
