### PR TITLE
DAOS-623 build: fix build when lustre APIs are installed (#13069)

### DIFF
--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -859,7 +859,7 @@ duns_link_lustre_path(const char *pool, const char *cont, daos_cont_layout_t typ
 {
 	char			str[DUNS_MAX_XATTR_LEN + 1];
 	int			len;
-	int			rc, rc2;
+	int			rc;
 
 	/* XXX if liblustreapi is not binded, do it now ! */
 	if (liblustre_binded == false && liblustre_notfound == false) {
@@ -1247,7 +1247,9 @@ duns_link_cont(daos_handle_t poh, const char *cont, const char *path)
 #ifdef LUSTRE_INCLUDE
 		struct statfs   fs;
 		char            *dir, *dirp;
+		size_t          path_len;
 
+		path_len = strnlen(path, PATH_MAX);
 		D_STRNDUP(dir, path, path_len);
 		if (dir == NULL)
 			D_GOTO(out_cont, rc = ENOMEM);


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
