### PR TITLE
DAOS-13703 umem: touch page on commit

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -1876,6 +1876,10 @@ touch_page(struct umem_store *store, struct umem_page_info *pinfo, uint64_t wr_t
 	uint64_t bit;
 	uint64_t idx;
 
+	D_ASSERT(wr_tx != -1ULL);
+	D_ASSERTF(store->stor_ops->so_wal_id_cmp(store, wr_tx, pinfo->pi_last_inflight) >= 0,
+		  "tx_id:"DF_U64" < last_inflight:"DF_U64"\n", wr_tx, pinfo->pi_last_inflight);
+
 	for (bit_nr = start_bit; bit_nr <= end_bit; bit_nr++) {
 		idx = bit_nr >> UMEM_CHUNK_IDX_SHIFT; /** uint64_t index */
 		bit = bit_nr & UMEM_CHUNK_IDX_MASK;
@@ -1889,10 +1893,6 @@ touch_page(struct umem_store *store, struct umem_page_info *pinfo, uint64_t wr_t
 		d_list_del(&pinfo->pi_link);
 		d_list_add_tail(&pinfo->pi_link, &cache->ca_pgs_dirty);
 	}
-
-	if (store->stor_ops->so_wal_id_cmp(store, wr_tx, pinfo->pi_last_inflight) <= 0 ||
-	    wr_tx == -1ULL)
-		return;
 
 	pinfo->pi_last_inflight = wr_tx;
 }


### PR DESCRIPTION
Defer the umem_cache_touch() call from WAL log entry generating time to WAL commit time, so that the transaction ID passed to umem_cache_touch() will always be valid (and in ascending order).

This change will be helpful in phase II (then we could always tell if a page is dirty or not by comparing the last inflight ID with the last checkpointed ID).

Test-nvme: auto_md_on_ssd
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
