### PR TITLE
DAOS-14418 cart: Retry am_send for UCX out-of-memory error.

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -304,6 +304,8 @@ static int data_init(int server, crt_init_options_t *opt)
 	}
 	if (server)
 		setenv("UCX_IB_FORK_INIT", "n", 1);
+	else
+		setenv("NA_UCX_REMAP_SEND_NOMEM", "1", 1);
 
 	/* This is a workaround for CART-871 if universe size is not set */
 	d_getenv_int("FI_UNIVERSE_SIZE", &fi_univ_size);

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -61,6 +61,7 @@ SUPPORTED_PROVIDERS = [
     "ofi+cxi",
     "ofi+verbs;ofi_rxm",
     "ucx+dc_x",
+    "ucx+ud_x",
     "ofi+tcp;ofi_rxm",
     "ofi+opx",
 ]

--- a/src/tests/ftest/util/network_utils.py
+++ b/src/tests/ftest/util/network_utils.py
@@ -13,7 +13,7 @@ from ClusterShell.NodeSet import NodeSet
 from exception_utils import CommandFailure
 from general_utils import run_task, display_task, run_pcmd
 
-SUPPORTED_PROVIDERS = ("ofi+sockets", "ofi+tcp;ofi_rxm", "ofi+verbs;ofi_rxm", "ucx+dc_x", "ofi+cxi")
+SUPPORTED_PROVIDERS = ("ofi+sockets", "ofi+tcp;ofi_rxm", "ofi+verbs;ofi_rxm", "ucx+dc_x", "ucx+ud_x", "ofi+cxi")
 
 
 class NetworkDevice():


### PR DESCRIPTION
Skip-build-leap15-icc: true
Skip-build-el8-gcc: true
Skip-func-test-vm: true
Skip-unit-tests: true
Test-tag: pr daily_regression
PR-repos: mercury@PR-107:1
Test-provider: ucx+dc_x
Skip-func-hw-test-medium-ucx-provider: false
Skip-func-hw-test-medium-verbs-provider: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
