### PR TITLE
DAOS-14052 test: Update cart_logtest usage in launch.py (#13005)

### DIFF
--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -361,8 +361,9 @@ class LogTest():
             cb_list.append((mem_r, None))
 
         for line in self._li.new_iter(pid=pid, stateful=True):
-            if rpc_r:
-                rpc_r.add_line(line)
+            for (cbe, facs) in cb_list:
+                if facs is None or line.fac in facs:
+                    cbe.add_line(line)
             self.save_log_line(line)
             try:
                 msg = ''.join(line._fields[2:])
@@ -498,8 +499,8 @@ class LogTest():
             mem_r.active_desc = active_desc
 
         del active_desc['root']
-        if rpc_r:
-            rpc_r.report()
+        for (cbe, _) in cb_list:
+            cbe.report()
 
         if not self.ftest_mode:
             active_desc = mem_r.active_desc

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -226,6 +226,8 @@ class LogTest():
         self.fi_triggered = False
         self.fi_location = None
         self.skip_suffixes = []
+        self._tracers = []
+        self.ftest_mode = False
 
         # Records on number, type and frequency of logging.
         self.log_locs = Counter()
@@ -334,11 +336,6 @@ class LogTest():
         warnings_mode = False
         server_shutdown = False
 
-        regions = OrderedDict()
-        memsize = HwmCounter()
-
-        old_regions = {}
-
         error_files = set()
 
         have_debug = False
@@ -346,10 +343,22 @@ class LogTest():
         trace_lines = 0
         non_trace_lines = 0
 
-        if self.quiet:
-            rpc_r = None
-        else:
+        cb_list = []
+
+        if not self.quiet:
             rpc_r = RpcReporting()
+            if self.ftest_mode:
+                rpc_r.dynamic_level = True
+
+            cb_list.append((rpc_r, ('hg', 'rpc')))
+        for tracer in self._tracers:
+            cb_list.append((tracer[0], tracer[1]))
+
+        if not self.ftest_mode:
+            mem_r = MemReporting()
+            mem_r.wf = leak_wf
+            mem_r.show_memleaks = show_memleaks
+            cb_list.append((mem_r, None))
 
         for line in self._li.new_iter(pid=pid, stateful=True):
             if rpc_r:
@@ -442,8 +451,8 @@ class LogTest():
                         err_count += 1
                     if line.parent not in active_desc:
                         show_line(line, 'error', 'add with bad parent')
-                        if line.parent in regions:
-                            show_line(regions[line.parent], 'NORMAL',
+                        if not self.ftest_mode and line.parent in mem_r.regions:
+                            show_line(mem_r.regions[line.parent], 'NORMAL',
                                       'used as parent without registering')
                         err_count += 1
                     active_desc[desc] = line
@@ -465,78 +474,36 @@ class LogTest():
                     if desc in active_rpcs:
                         del active_rpcs[desc]
                     else:
-                        show_line(line, 'NORMAL', 'invalid rpc remove')
-                        err_count += 1
+                        if not self.ftest_mode:
+                            show_line(line, 'NORMAL', 'invalid rpc remove')
+                            err_count += 1
                 else:
                     if have_debug and desc not in active_desc and desc not in active_rpcs:
                         show_line(line, 'NORMAL', 'inactive desc')
-                        if line.descriptor in regions:
-                            show_line(regions[line.descriptor], 'NORMAL',
+                        if not self.ftest_mode and line.descriptor in mem_r.regions:
+                            show_line(mem_r.regions[line.descriptor], 'NORMAL',
                                       'Used as descriptor without registering')
                         error_files.add(line.filename)
                         err_count += 1
-            elif len(line._fields) > 2:
-                # is_calloc() doesn't work on truncated output so only test if
-                # there are more than two fields to work with.
+            else:
                 non_trace_lines += 1
-                if line.is_calloc():
-                    pointer = line.calloc_pointer()
-                    if pointer in regions:
-                        # Report both the old and new allocation points here.
-                        show_line(regions[pointer], 'NORMAL',
-                                  'new allocation seen for same pointer (old)')
-                        show_line(line, 'NORMAL',
-                                  'new allocation seen for same pointer (new)')
-                        err_count += 1
-                    regions[pointer] = line
-                    memsize.add(line.calloc_size())
-                elif line.is_free():
-                    pointer = line.free_pointer()
-                    # If a pointer is freed then automatically remove the
-                    # descriptor
-                    if pointer in active_desc:
-                        del active_desc[pointer]
-                    if pointer in regions:
-                        memsize.subtract(regions[pointer].calloc_size())
-                        old_regions[pointer] = [regions[pointer], line]
-                        del regions[pointer]
-                    elif pointer != '(nil)':
-                        # Logs no longer contain free(NULL) however old logs might so continue
-                        # to handle this case.
-                        if pointer in old_regions:
-                            show_line(old_regions[pointer][0], 'ERROR',
-                                      'double-free allocation point')
-                            show_line(old_regions[pointer][1], 'ERROR', '1st double-free location')
-                            show_line(line, 'ERROR', '2nd double-free location')
-                        else:
-                            show_line(line, 'HIGH', 'free of unknown memory')
-                        err_count += 1
-                elif line.is_realloc():
-                    (new_pointer, old_pointer) = line.realloc_pointers()
-                    (new_size, old_size) = line.realloc_sizes()
-                    if new_pointer != '(nil)' and old_pointer != '(nil)':
-                        if old_pointer not in regions:
-                            show_line(line, 'HIGH', 'realloc of unknown memory')
-                        else:
-                            # Use calloc_size() here as the memory might not
-                            # come from a realloc() call.
-                            exp_sz = regions[old_pointer].calloc_size()
-                            if old_size not in (0, exp_sz, new_size):
-                                show_line(line, 'HIGH', 'realloc used invalid old size')
-                            memsize.subtract(exp_sz)
-                    regions[new_pointer] = line
-                    memsize.add(new_size)
-                    if old_pointer not in (new_pointer, '(nil)'):
-                        if old_pointer in regions:
-                            old_regions[old_pointer] = [regions[old_pointer], line]
-                            del regions[old_pointer]
-                        else:
-                            show_line(line, 'NORMAL', 'realloc of unknown memory')
-                            err_count += 1
+                if len(line._fields) > 2:
+                    if line.is_free():
+                        pointer = line.free_pointer()
+                        # If a pointer is freed then automatically remove the descriptor
+                        if pointer in active_desc:
+                            del active_desc[pointer]
+
+        if not self.ftest_mode:
+            mem_r.active_desc = active_desc
 
         del active_desc['root']
         if rpc_r:
             rpc_r.report()
+
+        if not self.ftest_mode:
+            active_desc = mem_r.active_desc
+            err_count += mem_r.err_count
 
         # This isn't currently used anyway.
         # if not have_debug:
@@ -549,24 +516,6 @@ class LogTest():
             print("Pid {}, {} lines total, {} trace ({:.2f}%)".format(
                 pid, total_lines, trace_lines, p_trace))
 
-        if memsize.has_data():
-            print("Memsize: {}".format(memsize))
-
-        # Special case the fuse arg values as these are allocated by IOF
-        # but freed by fuse itself.
-        # Skip over CaRT issues for now to get this landed, we can enable them
-        # once this is stable.
-        lost_memory = False
-        if show_memleaks:
-            for (_, line) in list(regions.items()):
-                pointer = line.get_field(-1).rstrip('.')
-                if pointer in active_desc:
-                    show_line(line, 'NORMAL', 'descriptor not freed', custom=leak_wf)
-                    del active_desc[pointer]
-                else:
-                    show_line(line, 'NORMAL', 'memory not freed', custom=leak_wf)
-                lost_memory = True
-
         if active_desc:
             for (_, line) in list(active_desc.items()):
                 show_line(line, 'NORMAL', 'desc not deregistered', custom=leak_wf)
@@ -577,12 +526,102 @@ class LogTest():
                 show_line(line, 'NORMAL', 'rpc not deregistered')
         if error_files or err_count:
             raise LogError()
-        if lost_memory:
+        if not self.ftest_mode and mem_r.lost_memory:
             raise NotAllFreed()
         if warnings_strict:
             raise WarningStrict()
         if warnings_mode:
             raise WarningMode()
+
+
+class MemReporting():
+    """Class for checking memory allocations"""
+
+    def __init__(self):
+        self.memsize = HwmCounter()
+        self.regions = {}
+        self._old_regions = {}
+        self.err_count = 0
+        self.wf = None
+        self.lost_memory = False
+        self.show_memleaks = True
+        self.active_desc = None
+
+    def add_line(self, line):
+        """Parse an output line"""
+        err_count = 0
+        if line.is_calloc():
+            pointer = line.calloc_pointer()
+            if pointer in self.regions:
+                # Report both the old and new allocation points here.
+                show_line(self.regions[pointer], 'NORMAL',
+                          'new allocation seen for same pointer (old)')
+                show_line(line, 'NORMAL', 'new allocation seen for same pointer (new)')
+                err_count += 1
+            self.regions[pointer] = line
+            self.memsize.add(line.calloc_size())
+        elif line.is_free():
+            pointer = line.free_pointer()
+            if pointer in self.regions:
+                self.memsize.subtract(self.regions[pointer].calloc_size())
+                self._old_regions[pointer] = [self.regions[pointer], line]
+                del self.regions[pointer]
+            elif pointer != '(nil)':
+                # Logs no longer contain free(NULL) however old logs might so continue to handle
+                # this case.
+                if pointer in self._old_regions:
+                    if show_line(self._old_regions[pointer][0], 'ERROR',
+                                 'double-free allocation point'):
+                        print(f'Memory address is {pointer}')
+
+                    show_line(self._old_regions[pointer][1], 'ERROR', '1st double-free location')
+                    show_line(line, 'ERROR', '2nd double-free location')
+                else:
+                    show_line(line, 'HIGH', 'free of unknown memory')
+                err_count += 1
+        elif line.is_realloc():
+            (new_pointer, old_pointer) = line.realloc_pointers()
+            (new_size, old_size) = line.realloc_sizes()
+            if new_pointer != '(nil)' and old_pointer != '(nil)':
+                if old_pointer not in self.regions:
+                    show_line(line, 'HIGH', 'realloc of unknown memory')
+                else:
+                    # Use calloc_size() here as the memory might not come from a realloc() call.
+                    exp_sz = self.regions[old_pointer].calloc_size()
+                    if old_size not in (0, exp_sz, new_size):
+                        show_line(line, 'HIGH', 'realloc used invalid old size')
+                    self.memsize.subtract(exp_sz)
+            self.regions[new_pointer] = line
+            self.memsize.add(new_size)
+            if old_pointer not in (new_pointer, '(nil)'):
+                if old_pointer in self.regions:
+                    self._old_regions[old_pointer] = [self.regions[old_pointer], line]
+                    del self.regions[old_pointer]
+                else:
+                    show_line(line, 'NORMAL', 'realloc of unknown memory')
+                    err_count += 1
+        self.err_count += err_count
+
+    def report(self):
+        """Report the results"""
+        if self.memsize.has_data():
+            print("Memsize: {}".format(self.memsize))
+
+        if self.show_memleaks:
+            for (_, line) in list(self.regions.items()):
+                if line.is_calloc():
+                    pointer = line.calloc_pointer()
+                else:
+                    assert line.is_realloc()
+                    (pointer, _) = line.realloc_pointers()
+                if pointer in self.active_desc:
+                    if show_line(line, 'NORMAL', 'descriptor not freed', custom=self.wf):
+                        print(f'Memory address is {pointer}')
+                    del self.active_desc[pointer]
+                else:
+                    if show_line(line, 'NORMAL', 'memory not freed', custom=self.wf):
+                        print(f'Memory address is {pointer}')
+                self.lost_memory = True
 
 
 class RpcReporting():
@@ -602,6 +641,7 @@ class RpcReporting():
         self._c_states = {}
         self._c_state_names = set()
         self._current_opcodes = {}
+        self.dynamic_level = False
 
     def add_line(self, line):
         """Parse a output line"""
@@ -641,9 +681,18 @@ class RpcReporting():
         if rpc_state == 'ALLOCATED':
             self._current_opcodes[rpc] = opcode
         else:
-            opcode = self._current_opcodes[rpc]
+            try:
+                opcode = self._current_opcodes[rpc]
+            except KeyError:
+                if not self.dynamic_level:
+                    raise
+                opcode = 'unknown'
         if rpc_state == 'DEALLOCATED':
-            del self._current_opcodes[rpc]
+            try:
+                del self._current_opcodes[rpc]
+            except KeyError:
+                if not self.dynamic_level:
+                    raise
 
         if opcode not in self._op_state_counters:
             self._op_state_counters[opcode] = {'ALLOCATED': 0,
@@ -708,6 +757,7 @@ def run():
     parser = argparse.ArgumentParser()
     parser.add_argument('--dfuse', help='Summarise dfuse I/O', action='store_true')
     parser.add_argument('--warnings', action='store_true')
+    parser.add_argument('--ftest-mode', action='store_true')
     parser.add_argument('file', help='input file')
     args = parser.parse_args()
     try:
@@ -722,7 +772,21 @@ def run():
         # the encoding on, in which case this second attempt would fail with
         # an out-of-memory error.
         log_iter = cart_logparse.LogIter(args.file, check_encoding=True)
+
+    # ftest mode is called from launch.py for logs after functional testing.
+    # It logs everything to a output file, and does not perform memory leak or double-free checks.
+    if args.ftest_mode:
+        in_file = args.file
+        if in_file.endswith('.bz2'):
+            in_file = args.file[:-4]
+        out_fd = open(f'{in_file}.cart_logtest', 'w')  # pylint: disable=consider-using-with
+        real_stdout = sys.stdout
+        sys.stdout = out_fd
+        print(f'Logging to {in_file}.cart_logtest', file=real_stdout)
+
     test_iter = LogTest(log_iter)
+    if args.ftest_mode:
+        test_iter.ftest_mode = True
     if args.dfuse:
         test_iter.check_dfuse_io()
     else:

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -2761,7 +2761,7 @@ class Launch():
         logger.debug("-" * 80)
         logger.debug("Running %s on %s files on %s", cart_logtest, source_files, hosts)
         other = ["-print0", "|", "xargs", "-0", "-r0", "-n1", "-I", "%", "sh", "-c",
-                 f"'{cart_logtest} % > %.cart_logtest 2>&1'"]
+                 f"'{cart_logtest} --ftest-mode %'"]
         result = run_remote(
             logger, hosts, find_command(source, pattern, depth, other), timeout=4800)
         if not result.passed:


### PR DESCRIPTION
Update log_test to not check for descriptor consistency when parsing
ftest logs. As ftest debug masks change on live systems these tests
aren't valid and will fail if RPCs are in flight during the change.

Required-githooks: true

Signed-off-by: Ashley Pittman ashley.m.pittman@intel.com>
