### PR TITLE
DAOS-13499 tools: fix datamover container create message (#12642)

### DIFF
--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -1095,7 +1095,6 @@ func (cmd *containerCloneCmd) Execute(_ []string) error {
 	}
 
 	// Compat with old-style output
-	cmd.Infof("Successfully created container %s", C.GoString(&ap.dm_args.dst_cont[0]))
 	cmd.Infof("Successfully copied to destination container %s", C.GoString(&ap.dm_args.dst_cont[0]))
 
 	return nil

--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -100,7 +100,6 @@ func (cmd *fsCopyCmd) Execute(_ []string) error {
 		fsType = "POSIX"
 	}
 	// Compat with old-style output
-	cmd.Infof("Successfully created container %s", C.GoString(&ap.dm_args.dst_cont[0]))
 	cmd.Infof("Successfully copied to %s: %s", fsType, cmd.Dest)
 	cmd.Infof("    Directories: %d", ap.fs_copy_stats.num_dirs)
 	cmd.Infof("    Files:       %d", ap.fs_copy_stats.num_files)

--- a/src/tests/ftest/deployment/basic_checkout.py
+++ b/src/tests/ftest/deployment/basic_checkout.py
@@ -110,7 +110,7 @@ class BasicCheckoutDm(DataMoverTestBase):
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
-        :avocado: tags=deployment,datamover,fs_copy,ior,basic_checkout
+        :avocado: tags=deployment,datamover,daos_fs_copy,ior,basic_checkout
         :avocado: tags=BasicCheckoutDm,test_basic_checkout_dm
         """
         # load ior params for dm test

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1567,6 +1567,7 @@ dm_connect(struct cmd_args_s *ap,
 				DH_PERROR_DER(ap, rc, "failed to open container");
 				D_GOTO(err, rc);
 			}
+			fprintf(ap->outstream, "Successfully created container %s\n", ca->dst_cont);
 		}
 		if (is_posix_copy) {
 			rc = dfs_sys_mount(ca->dst_poh, ca->dst_coh, O_RDWR, DFS_SYS_NO_LOCK,


### PR DESCRIPTION
Features: daos_fs_copy daos_cont_clone

PR #11189 moved the container create messages to the GO code, but this isn't correct because the container isn't *always* created.

The original logging issue was resolved by #12632, so the messages can be moved back to the C code where there is finer control.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
