### PR TITLE
Debug daos_test issue

### DIFF
--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -45,11 +45,13 @@ daos_fail_check(uint64_t fail_loc)
 		uint32_t id = DAOS_FAIL_ID_GET(fail_loc);
 
 		attr = d_fault_attr_lookup(id);
+		D_INFO("lookup id: %p\n", attr);
 	}
 
 	if (attr == NULL) {
 		grp = DAOS_FAIL_GROUP_GET(fail_loc);
 		attr = d_fault_attr_lookup(grp);
+		D_INFO("lookup grp: %p\n", attr);
 	}
 
 	if (attr == NULL) {
@@ -66,6 +68,7 @@ daos_fail_check(uint64_t fail_loc)
 		return 1;
 	}
 
+	D_INFO("should not fail\n");
 	return 0;
 }
 

--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -702,26 +702,36 @@ d_should_fail(struct d_fault_attr_t *fault_attr)
 
 	D_SPIN_LOCK(&fault_attr->fa_lock);
 
-	if (!fault_get_thread_enabled())
+	if (!fault_get_thread_enabled()) {
+		D_INFO("thread not enabled\n");
 		D_GOTO(out, rc = false);
+	}
 
-	if (fault_attr->fa_probability_x == 0)
+	if (fault_attr->fa_probability_x == 0) {
+		D_INFO("probability zero\n");
 		D_GOTO(out, rc = false);
+	}
 
 	if (fault_attr->fa_max_faults != 0 &&
-	    fault_attr->fa_max_faults <= fault_attr->fa_num_faults)
+	    fault_attr->fa_max_faults <= fault_attr->fa_num_faults) {
+		D_INFO("max faults\n");
 		D_GOTO(out, rc = false);
+	}
 
 	if (fault_attr->fa_interval > 1) {
 		fault_attr->fa_num_hits++;
-		if (fault_attr->fa_num_hits % fault_attr->fa_interval)
+		if (fault_attr->fa_num_hits % fault_attr->fa_interval) {
+			D_INFO("interval\n");
 			D_GOTO(out, rc = false);
+		}
 	}
 
 	if (fault_attr->fa_probability_y != 0 &&
 	    fault_attr->fa_probability_x <=
-		nrand48(fault_attr->fa_rand_state) % fault_attr->fa_probability_y)
+		nrand48(fault_attr->fa_rand_state) % fault_attr->fa_probability_y) {
+		D_INFO("probability y");
 		D_GOTO(out, rc = false);
+	}
 
 	fault_attr->fa_num_faults++;
 


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
