### PR TITLE
DAOS-12174 control: Query all device-health by default (#12701)

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -401,7 +401,7 @@ Usage:
 ...
 
 [device-health command options]
-      -u, --uuid=     Device UUID
+      -u, --uuid=     Device UUID. All devices queried if arg not set
 ```
 ```bash
 $ dmg storage scan --nvme-health --help

--- a/src/control/cmd/dmg/storage_query.go
+++ b/src/control/cmd/dmg/storage_query.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -71,7 +71,7 @@ type storageQueryCmd struct {
 
 type devHealthQueryCmd struct {
 	smdQueryCmd
-	UUID string `short:"u" long:"uuid" required:"1" description:"Device UUID"`
+	UUID string `short:"u" long:"uuid" description:"Device UUID. All devices queried if arg not set"`
 }
 
 func (cmd *devHealthQueryCmd) Execute(_ []string) error {

--- a/src/control/cmd/dmg/storage_query_test.go
+++ b/src/control/cmd/dmg/storage_query_test.go
@@ -32,8 +32,12 @@ func TestStorageQueryCommands(t *testing.T) {
 		{
 			"per-server metadata device health query (missing uuid)",
 			"storage query device-health",
-			printRequest(t, &control.SmdQueryReq{}),
-			errors.New("required flag"),
+			printRequest(t, &control.SmdQueryReq{
+				Rank:             ranklist.NilRank,
+				OmitPools:        true,
+				IncludeBioHealth: true,
+			}),
+			nil,
 		},
 		{
 			"per-server metadata query pools",

--- a/src/control/server/ctl_smd_rpc_test.go
+++ b/src/control/server/ctl_smd_rpc_test.go
@@ -512,6 +512,86 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 				},
 			},
 		},
+		"device-health; no uuid in request": {
+			req: &ctlpb.SmdQueryReq{
+				OmitPools:        true,
+				Rank:             uint32(ranklist.NilRank),
+				IncludeBioHealth: true,
+			},
+			drpcResps: map[int][]*mockDrpcResponse{
+				0: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{
+								{
+									Uuid:     test.MockUUID(0),
+									DevState: devStateNormal,
+									LedState: ledStateNormal,
+								},
+							},
+						},
+					},
+					{
+						Message: &ctlpb.BioHealthResp{
+							Temperature: 100000,
+						},
+					},
+				},
+				1: {
+					{
+						Message: &ctlpb.SmdDevResp{
+							Devices: []*ctlpb.SmdDevice{
+								{
+									Uuid:     test.MockUUID(1),
+									DevState: devStateFaulty,
+									LedState: ledStateFault,
+								},
+							},
+						},
+					},
+					{
+						Message: &ctlpb.BioHealthResp{
+							Temperature: 1000000,
+							TempWarn:    true,
+						},
+					},
+				},
+			},
+			expResp: &ctlpb.SmdQueryResp{
+				Ranks: []*ctlpb.SmdQueryResp_RankResp{
+					{
+						Devices: []*ctlpb.SmdQueryResp_SmdDeviceWithHealth{
+							{
+								Details: &ctlpb.SmdDevice{
+									Uuid:     test.MockUUID(0),
+									DevState: devStateNormal,
+									LedState: ledStateNormal,
+								},
+								Health: &ctlpb.BioHealthResp{
+									Temperature: 100000,
+								},
+							},
+						},
+					},
+					{
+						Rank: 1,
+						Devices: []*ctlpb.SmdQueryResp_SmdDeviceWithHealth{
+							{
+								Details: &ctlpb.SmdDevice{
+									Uuid:     test.MockUUID(1),
+									DevState: devStateFaulty,
+									LedState: ledStateFault,
+								},
+								Health: &ctlpb.BioHealthResp{
+									Temperature: 1000000,
+									TempWarn:    true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"device-health (NEW SMD); skip health collection": {
 			req: &ctlpb.SmdQueryReq{
 				OmitPools:        true,


### PR DESCRIPTION
Report health of all devices on a given host by default when calling
dmg storage query device-health.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
