### PR TITLE
DAOS-13989 chk: embed label into repair options

### DIFF
--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -1230,7 +1230,7 @@ chk_engine_cont_set_label(struct chk_pool_rec *cpr, struct chk_cont_rec *ccr, st
 	struct chk_bookmark		*cbk = &cpr->cpr_bk;
 	daos_prop_t			*prop_tmp = NULL;
 	struct chk_report_unit		 cru = { 0 };
-	char				*strs[3];
+	char				 strs[3][CHK_MSG_BUFLEN];
 	d_iov_t				 iovs[3];
 	d_sg_list_t			 sgl;
 	d_sg_list_t			*details = NULL;
@@ -1343,12 +1343,18 @@ interact:
 		act = CHK__CHECK_INCONSIST_ACTION__CIA_INTERACT;
 
 		options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
-		strs[1] = "Keep the inconsistent container label, repair nothing.";
+		snprintf(strs[1], CHK_MSG_BUFLEN - 1,
+			 "Keep the inconsistent container label: %s (CS) vs %s (property), "
+			 "repair nothing.", daos_iov_empty(&ccr->ccr_label_cs) ? "(null)" :
+			 (char *)ccr->ccr_label_cs.iov_buf, ccr->ccr_label_prop != NULL ?
+			 (char *)ccr->ccr_label_prop->dpp_entries[0].dpe_str : "(null)");
 		d_iov_set(&iovs[1], strs[1], strlen(strs[1]));
 
 		if (rc > 0) {
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
-			strs[0] = "Trust the container label in container service [suggested].";
+			snprintf(strs[0], CHK_MSG_BUFLEN - 1,
+				 "Trust the container label %s in container service [suggested].",
+				 (char *)ccr->ccr_label_cs.iov_buf);
 			d_iov_set(&iovs[0], strs[0], strlen(strs[0]));
 
 			if (chk_engine_cont_target_label_empty(ccr)) {
@@ -1356,14 +1362,19 @@ interact:
 				sgl.sg_nr = 2;
 			} else {
 				options[2] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET;
-				strs[2] = "Trust the container label in container property.";
+				snprintf(strs[2], CHK_MSG_BUFLEN - 1,
+					 "Trust the container label %s in container property.",
+					 (char *)ccr->ccr_label_prop->dpp_entries[0].dpe_str);
 				d_iov_set(&iovs[2], strs[2], strlen(strs[2]));
 				option_nr = 3;
 				sgl.sg_nr = 3;
 			}
 		} else {
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_TARGET;
-			strs[0] = "Trust the container label in container property [suggested].";
+			snprintf(strs[0], CHK_MSG_BUFLEN - 1,
+				 "Trust the container label %s in container property [suggested].",
+				 ccr->ccr_label_prop != NULL ?
+				 (char *)ccr->ccr_label_prop->dpp_entries[0].dpe_str : "(null)");
 			d_iov_set(&iovs[0], strs[0], strlen(strs[0]));
 
 			D_ASSERT(chk_engine_cont_cs_label_empty(ccr));

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -1424,7 +1424,7 @@ chk_leader_handle_pool_label(struct chk_pool_rec *cpr, struct ds_pool_clue *clue
 	struct chk_instance		*ins = cpr->cpr_ins;
 	struct chk_property		*prop = &ins->ci_prop;
 	struct chk_bookmark		*cbk = &ins->ci_bk;
-	char				*strs[3];
+	char				 strs[3][CHK_MSG_BUFLEN] = { 0 };
 	char				 msg[CHK_MSG_BUFLEN] = { 0 };
 	d_iov_t				 iovs[3];
 	d_sg_list_t			 sgl;
@@ -1521,17 +1521,24 @@ try_ps:
 		if (cpr->cpr_label == NULL) {
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS;
-			strs[0] = "Trust PS pool label [suggested].";
-			strs[1] = "Trust MS pool label.";
+			snprintf(strs[0], CHK_MSG_BUFLEN - 1,
+				 "Trust PS pool label: %s [suggested].",
+				 clue->pc_label != NULL ? clue->pc_label : "(null)");
+			snprintf(strs[1], CHK_MSG_BUFLEN - 1, "Trust MS pool label: (null).");
 		} else {
 			options[0] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_MS;
 			options[1] = CHK__CHECK_INCONSIST_ACTION__CIA_TRUST_PS;
-			strs[0] = "Trust MS pool label [suggested].";
-			strs[1] = "Trust PS pool label.";
+			snprintf(strs[0], CHK_MSG_BUFLEN - 1,
+				 "Trust MS pool label: %s [suggested].", cpr->cpr_label);
+			snprintf(strs[1], CHK_MSG_BUFLEN - 1, "Trust PS pool label: %s.",
+				 clue->pc_label != NULL ? clue->pc_label : "(null)");
 		}
 
 		options[2] = CHK__CHECK_INCONSIST_ACTION__CIA_IGNORE;
-		strs[2] = "Keep the inconsistent pool label, repair nothing.";
+		snprintf(strs[2], CHK_MSG_BUFLEN - 1,
+			 "Keep the inconsistent pool label: %s (MS) vs %s (PS), repair nothing.",
+			 cpr->cpr_label != NULL ? cpr->cpr_label : "(null)",
+			 clue->pc_label != NULL ? clue->pc_label : "(null)");
 		option_nr = 3;
 
 		d_iov_set(&iovs[0], strs[0], strlen(strs[0]));


### PR DESCRIPTION
When need interaction for inconsistency pool label or container label, embedding the pool label or container label in related repair options will help the user to make the decision easily.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
