### PR TITLE
DAOS-14473 pool: Fix merge conflict resolution

### DIFF
--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -1773,7 +1773,7 @@ cont:
 	if (rc != 0)
 		goto out;
 
-	ds_pool_svc_schedule_reconf(svc);
+	rc = ds_pool_svc_schedule_reconf(svc);
 
 out:
 	chk_engine_cont_list_fini(&aggregator);

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -299,7 +299,7 @@ int ds_pool_target_status_check(struct ds_pool *pool, uint32_t id,
 int ds_pool_mark_connectable(struct ds_pool_svc *ds_svc);
 int ds_pool_svc_load_map(struct ds_pool_svc *ds_svc, struct pool_map **map);
 int ds_pool_svc_flush_map(struct ds_pool_svc *ds_svc, struct pool_map *map);
-void ds_pool_svc_schedule_reconf(struct ds_pool_svc *svc);
+int ds_pool_svc_schedule_reconf(struct ds_pool_svc *svc);
 int ds_pool_svc_update_label(struct ds_pool_svc *ds_svc, const char *label);
 int ds_pool_svc_evict_all(struct ds_pool_svc *ds_svc);
 struct ds_pool *ds_pool_svc2pool(struct ds_pool_svc *ds_svc);


### PR DESCRIPTION
Fix the merge conflict resolution around pool_svc_schedule.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
