### PR TITLE
DAOS-14254 test: Improve test harness server file cleanup in startup (#12978)

### DIFF
--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -250,60 +250,89 @@ class DaosServerManager(SubprocessManager):
 
         Args:
             verbose (bool, optional): display clean commands. Defaults to True.
+
+        Raises:
+            ServerFailed: if there was an error cleaning up the daos server files
         """
-        clean_commands = []
-        for index, engine_params in enumerate(self.manager.job.yaml.engine_params):
-            scm_mount = engine_params.get_value("scm_mount")
-            self.log.info("Cleaning up the %s directory.", str(scm_mount))
-
-            # Remove the superblocks
-            cmd = "sudo rm -fr {}/*".format(scm_mount)
-            if cmd not in clean_commands:
-                clean_commands.append(cmd)
-
-            # Remove the shared memory segment associated with this io server
-            cmd = "sudo ipcrm -M {}".format(self.D_TM_SHARED_MEMORY_KEY + index)
-            clean_commands.append(cmd)
-
-            # Dismount the scm mount point
-            cmd = "while sudo umount {}; do continue; done".format(scm_mount)
-            if cmd not in clean_commands:
-                clean_commands.append(cmd)
-
+        scm_mounts = []
+        scm_lists = []
+        for engine_params in self.manager.job.yaml.engine_params:
+            scm_mounts.append(engine_params.get_value("scm_mount"))
             if self.manager.job.using_dcpm:
                 scm_list = engine_params.get_value("scm_list")
                 if isinstance(scm_list, list):
-                    self.log.info("Cleaning up the following device(s): %s.", ", ".join(scm_list))
-                    # Umount and wipefs the dcpm device
-                    cmd_list = [
-                        "for dev in {}".format(" ".join(scm_list)),
-                        "do mount=$(lsblk $dev -n -o MOUNTPOINT)",
-                        "if [ ! -z $mount ]",
-                        "then while sudo umount $mount",
-                        "do continue",
-                        "done",
-                        "fi",
-                        "sudo wipefs -a $dev",
-                        "done"
-                    ]
-                    cmd = "; ".join(cmd_list)
-                    if cmd not in clean_commands:
-                        clean_commands.append(cmd)
+                    scm_lists.append(scm_list)
+
+        for index, scm_mount in enumerate(scm_mounts):
+            # Remove the superblocks and dismount the scm mount point
+            self.log.info("Cleaning up the %s scm mount.", str(scm_mount))
+            self.clean_mount(self._hosts, scm_mount, verbose, index)
+
+        for scm_list in scm_lists:
+            # Umount and wipefs the dcpm device
+            self.log.info("Cleaning up the %s dcpm devices", str(scm_list))
+            command_list = [
+                "for dev in {}".format(" ".join(scm_list)),
+                "do mount=$(lsblk $dev -n -o MOUNTPOINT)",
+                "if [ ! -z $mount ]",
+                "then while sudo umount $mount",
+                "do continue",
+                "done",
+                "fi",
+                "sudo wipefs -a $dev",
+                "done"
+            ]
+            command = "; ".join(command_list)
+            result = run_remote(self.log, self._hosts, command, verbose)
+            if not result.passed:
+                raise ServerFailed("Failed cleaning {} on {}".format(scm_list, result.failed_hosts))
 
         if self.manager.job.using_control_metadata:
             # Remove the contents (superblocks) of the control plane metadata path
-            cmd = "sudo rm -fr {}/*".format(self.manager.job.control_metadata.path.value)
-            if cmd not in clean_commands:
-                clean_commands.append(cmd)
+            self.log.info(
+                "Cleaning up the control metadata path %s",
+                self.manager.job.control_metadata.path.value)
+            self.clean_mount(self._hosts, self.manager.job.control_metadata.path.value, verbose)
 
-            if self.manager.job.control_metadata.device.value is not None:
-                # Dismount the control plane metadata mount point
-                cmd = "while sudo umount {}; do continue; done".format(
-                    self.manager.job.control_metadata.device.value)
-                if cmd not in clean_commands:
-                    clean_commands.append(cmd)
+    def clean_mount(self, hosts, mount, verbose=True, index=None):
+        """Clean the mount point by removing the superblocks and dismounting.
 
-        pcmd(self._hosts, "; ".join(clean_commands), verbose)
+        Args:
+            hosts (NodeSet): the hosts on which to clean the mount point
+            mount (str): the mount point to clean
+            verbose (bool, optional): display clean commands. Defaults to True.
+            index (int, optional): Defaults to None.
+
+        Raises:
+            ServerFailed: if there is an error cleaning the mount point
+        """
+        self.log.debug("Checking for the existence of the %s mount point", mount)
+        command = "test -d {}".format(mount)
+        result = run_remote(self.log, hosts, command, verbose)
+        if result.passed:
+            mounted_hosts = result.passed_hosts
+
+            # Remove the superblocks
+            self.log.debug("Removing the %s superblocks", mount)
+            command = "sudo rm -fr {}/*".format(mount)
+            result = run_remote(self.log, mounted_hosts, command, verbose)
+            if not result.passed:
+                raise ServerFailed(
+                    "Failed to remove superblocks for {} on {}".format(mount, result.failed_hosts))
+
+            if index is not None:
+                # Remove the shared memory segment associated with this io server
+                self.log.debug("Removing the shared memory segment")
+                command = "sudo ipcrm -M {}".format(self.D_TM_SHARED_MEMORY_KEY + index)
+                run_remote(self.log, self._hosts, command, verbose)
+
+            # Dismount the scm mount point
+            self.log.debug("Dismount the %s mount point", mount)
+            command = "while sudo umount {}; do continue; done".format(mount)
+            result = run_remote(self.log, mounted_hosts, command, verbose)
+            if not result.passed:
+                raise ServerFailed(
+                    "Failed to dismount {} on {}".format(mount, result.failed_hosts))
 
     def prepare_storage(self, user, using_dcpm=None, using_nvme=None):
         """Prepare the server storage.

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -309,7 +309,7 @@ class DaosServerManager(SubprocessManager):
         self.log.debug("Checking for the existence of the %s mount point", mount)
         command = "test -d {}".format(mount)
         result = run_remote(self.log, hosts, command, verbose)
-        if result.passed:
+        if result.passed_hosts:
             mounted_hosts = result.passed_hosts
 
             # Remove the superblocks


### PR DESCRIPTION
Add raising exceptions for failed server file cleanup steps during
server startup and limiting mount cleanup to existing mount points.

Resolve an issue where cleanup commands need to be run on a subset of
the test hosts running servers.

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
