### PR TITLE
DAOS-14332 control: Use gRPC metadata for interop (#13018)

### DIFF
--- a/src/control/cmd/daos_agent/main.go
+++ b/src/control/cmd/daos_agent/main.go
@@ -233,6 +233,7 @@ func main() {
 
 	ctlInvoker := control.NewClient(
 		control.WithClientLogger(log),
+		control.WithClientComponent(build.ComponentAgent),
 	)
 
 	if err := parseOpts(os.Args[1:], &opts, ctlInvoker, log); err != nil {

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -301,6 +301,7 @@ func main() {
 
 	ctlInvoker := control.NewClient(
 		control.WithClientLogger(log),
+		control.WithClientComponent(build.ComponentAdmin),
 	)
 
 	if err := parseOpts(os.Args[1:], &opts, ctlInvoker, log); err != nil {

--- a/src/control/common/proto/consts.go
+++ b/src/control/common/proto/consts.go
@@ -1,0 +1,14 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package proto
+
+const (
+	// DaosComponentHeader defines the header name used to convey the component name.
+	DaosComponentHeader = "x-daos-component"
+	// DaosVersionHeader defines the header name used to convey the component version.
+	DaosVersionHeader = "x-daos-version"
+)

--- a/src/control/lib/control/interceptors.go
+++ b/src/control/lib/control/interceptors.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -12,8 +12,10 @@ import (
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/security"
 )
@@ -59,8 +61,8 @@ func streamErrorInterceptor() grpc.DialOption {
 }
 
 // unaryErrorInterceptor calls the specified unary RPC and returns any unwrapped errors.
-func unaryErrorInterceptor() grpc.DialOption {
-	return grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func unaryErrorInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		if err != nil {
 			st := status.Convert(err)
@@ -71,5 +73,25 @@ func unaryErrorInterceptor() grpc.DialOption {
 			return connErrToFault(st, cc.Target())
 		}
 		return nil
-	})
+	}
+}
+
+// unaryVersionedComponentInterceptor appends the component name and version to the
+// outgoing request headers.
+func unaryVersionedComponentInterceptor(comp build.Component) grpc.UnaryClientInterceptor {
+	return func(parent context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		// NB: The caller should specify its component, but as a fallback, we
+		// can make a decent guess about the calling component based on the method.
+		if comp == build.ComponentAny {
+			var err error
+			if comp, err = security.MethodToComponent(method); err != nil {
+				return errors.Wrap(err, "unable to determine component from method")
+			}
+		}
+		ctx := metadata.AppendToOutgoingContext(parent,
+			proto.DaosComponentHeader, comp.String(),
+			proto.DaosVersionHeader, build.DaosVersion,
+		)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
 }

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/runtime/protoimpl"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	commonpb "github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
@@ -50,6 +51,7 @@ type (
 	// for a MockInvoker.
 	MockInvokerConfig struct {
 		Sys                 string
+		Component           build.Component
 		UnaryError          error
 		UnaryResponse       *UnaryResponse
 		UnaryResponseSet    []*UnaryResponse
@@ -100,6 +102,10 @@ func (mi *MockInvoker) Debugf(fmtStr string, args ...interface{}) {
 
 func (mi *MockInvoker) GetSystem() string {
 	return mi.cfg.Sys
+}
+
+func (mi *MockInvoker) GetComponent() build.Component {
+	return mi.cfg.Component
 }
 
 func (mi *MockInvoker) InvokeUnaryRPC(ctx context.Context, uReq UnaryRequest) (*UnaryResponse, error) {

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
@@ -88,6 +89,7 @@ type (
 	UnaryInvoker interface {
 		sysGetter
 		debugLogger
+		GetComponent() build.Component
 		InvokeUnaryRPC(ctx context.Context, req UnaryRequest) (*UnaryResponse, error)
 		InvokeUnaryRPCAsync(ctx context.Context, req UnaryRequest) (HostResponseChan, error)
 	}
@@ -122,13 +124,21 @@ type (
 	// Client implements the Invoker interface and should be provided to
 	// API methods to invoke RPCs.
 	Client struct {
-		config *Config
-		log    debugLogger
+		config    *Config
+		log       debugLogger
+		component build.Component
 	}
 
 	// ClientOption defines the signature for functional Client options.
 	ClientOption func(c *Client)
 )
+
+// WithClientComponent sets the client's component.
+func WithClientComponent(comp build.Component) ClientOption {
+	return func(c *Client) {
+		c.component = comp
+	}
+}
 
 // WithClientLogger sets the client's debugLogger.
 func WithClientLogger(log debugLogger) ClientOption {
@@ -171,6 +181,11 @@ func DefaultClient() *Client {
 	)
 }
 
+// GetComponent returns the client's component.
+func (c *Client) GetComponent() build.Component {
+	return c.component
+}
+
 // SetConfig sets the client configuration for an
 // existing Client.
 func (c *Client) SetConfig(cfg *Config) {
@@ -196,7 +211,10 @@ func (c *Client) Debugf(fmtStr string, args ...interface{}) {
 func (c *Client) dialOptions() ([]grpc.DialOption, error) {
 	opts := []grpc.DialOption{
 		streamErrorInterceptor(),
-		unaryErrorInterceptor(),
+		grpc.WithChainUnaryInterceptor(
+			unaryErrorInterceptor(),
+			unaryVersionedComponentInterceptor(c.GetComponent()),
+		),
 		grpc.FailOnNonTempDialError(true),
 	}
 

--- a/src/control/security/grpc_authorization.go
+++ b/src/control/security/grpc_authorization.go
@@ -6,6 +6,12 @@
 
 package security
 
+import (
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/build"
+)
+
 // Component represents the DAOS component being granted authorization.
 type Component int
 
@@ -75,6 +81,24 @@ var methodAuthorizations = map[string][]Component{
 	"/RaftTransport/RequestVote":           {ComponentServer},
 	"/RaftTransport/TimeoutNow":            {ComponentServer},
 	"/RaftTransport/InstallSnapshot":       {ComponentServer},
+}
+
+func methodToComponent(method string, methodAuthorizations map[string][]Component) (build.Component, error) {
+	comps, found := methodAuthorizations[method]
+	if !found || len(comps) == 0 {
+		return build.ComponentAny, errors.Errorf("method %q does not map to a known authorized component", method)
+	} else if len(comps) > 1 {
+		// In this case, the caller must explicitly set the component and cannot
+		// rely on this helper to resolve it.
+		return build.ComponentAny, errors.Errorf("method %q maps to multiple authorized components", method)
+	}
+
+	return build.Component(comps[0].String()), nil
+}
+
+// MethodToComponent resolves a gRPC method string to a build.Component.
+func MethodToComponent(method string) (build.Component, error) {
+	return methodToComponent(method, methodAuthorizations)
 }
 
 // HasAccess check if the given component has access to method given in FullMethod

--- a/src/control/security/grpc_authorization_test.go
+++ b/src/control/security/grpc_authorization_test.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/build"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/common/test"
@@ -215,6 +218,59 @@ func TestSecurity_AuthorizedRpcsAreValid(t *testing.T) {
 			if len(invalid) > 0 {
 				t.Fatalf("authorized RPCs without server methods (remove from methodAuthorizations):\n%s", strings.Join(invalid, "\n"))
 			}
+		})
+	}
+}
+
+func TestSecurity_MethodToCompnent(t *testing.T) {
+	for name, tc := range map[string]struct {
+		method  string
+		authMap map[string][]Component
+		expComp build.Component
+		expErr  error
+	}{
+		"method maps to an unknown component": {
+			method: "/unknown",
+			expErr: errors.New("does not map"),
+		},
+		"method maps to 0 components": {
+			method: "/zero",
+			authMap: map[string][]Component{
+				"/zero": nil,
+			},
+			expErr: errors.New("does not map"),
+		},
+		"method maps to 2 components": {
+			method: "/two",
+			authMap: map[string][]Component{
+				"/two": {ComponentAdmin, ComponentAgent},
+			},
+			expErr: errors.New("multiple authorized"),
+		},
+		"method maps to 1 component": {
+			method: "/one",
+			authMap: map[string][]Component{
+				"/one": {ComponentServer},
+			},
+			expComp: build.ComponentServer,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var gotComp build.Component
+			var gotErr error
+
+			if tc.authMap != nil {
+				gotComp, gotErr = methodToComponent(tc.method, tc.authMap)
+			} else {
+				gotComp, gotErr = MethodToComponent(tc.method)
+			}
+
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			test.AssertEqual(t, tc.expComp, gotComp, "unexpected component")
 		})
 	}
 }

--- a/src/control/server/interceptors_test.go
+++ b/src/control/server/interceptors_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -16,12 +16,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 type testStatus struct {
@@ -141,9 +144,95 @@ func TestServer_checkVersion(t *testing.T) {
 			otherVersion: "2.4.0",
 			ctx:          newTestAuthCtx(test.Context(t), "agent"),
 		},
-		"non-sys msg bypasses version checks": {
+		"non-sys msg bypasses version checks in secure mode": {
 			selfVersion: "2.4.0",
+			ctx:         newTestAuthCtx(test.Context(t), "agent"),
 			nonSysMsg:   true,
+		},
+		"insecure prelease agent with 2.4.0 server": {
+			selfVersion: "2.4.0",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAgent.String(),
+				proto.DaosVersionHeader, "2.3.108",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.4.1 agent with 2.4.0 server": {
+			selfVersion: "2.4.0",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAgent.String(),
+				proto.DaosVersionHeader, "2.4.1",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.4.0 agent with 2.4.1 server": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAgent.String(),
+				proto.DaosVersionHeader, "2.4.0",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.6.0 agent with 2.4.1 server": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAgent.String(),
+				proto.DaosVersionHeader, "2.6.0",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.4.1 dmg with 2.4.0 server": {
+			selfVersion: "2.4.0",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAdmin.String(),
+				proto.DaosVersionHeader, "2.4.1",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.6.0 dmg with 2.4.0 server": {
+			selfVersion: "2.4.0",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentAdmin.String(),
+				proto.DaosVersionHeader, "2.6.0",
+			)),
+			nonSysMsg: true,
+			expErr:    errors.New("not compatible"),
+		},
+		"insecure 2.4.0 server with 2.4.1 server": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentServer.String(),
+				proto.DaosVersionHeader, "2.4.0",
+			)),
+			nonSysMsg: true,
+		},
+		"insecure 2.6.0 server with 2.4.1 server": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, build.ComponentServer.String(),
+				proto.DaosVersionHeader, "2.6.0",
+			)),
+			nonSysMsg: true,
+			expErr:    errors.New("not compatible"),
+		},
+		"invalid component": {
+			selfVersion: "2.4.1",
+			ctx: metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+				proto.DaosComponentHeader, "banana",
+				proto.DaosVersionHeader, "2.6.0",
+			)),
+			nonSysMsg: true,
+			expErr:    errors.New("invalid component"),
+		},
+		"header/certificate component mismatch": {
+			selfVersion: "2.4.0",
+			ctx: newTestAuthCtx(
+				metadata.NewIncomingContext(test.Context(t), metadata.Pairs(
+					proto.DaosComponentHeader, build.ComponentServer.String(),
+					proto.DaosVersionHeader, "2.6.0"),
+				), "agent"),
+			nonSysMsg: true,
+			expErr:    errors.New("component mismatch"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -169,7 +258,10 @@ func TestServer_checkVersion(t *testing.T) {
 				req = verReq
 			}
 
-			gotErr := checkVersion(ctx, selfComp, req)
+			log, buf := logging.NewTestLogger(name)
+			test.ShowBufferOnFailure(t, buf)
+
+			gotErr := checkVersion(ctx, log, selfComp, req)
 			test.CmpErr(t, tc.expErr, gotErr)
 		})
 	}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -188,6 +188,7 @@ func (srv *server) createServices(ctx context.Context) (err error) {
 	cliCfg := control.DefaultConfig()
 	cliCfg.TransportConfig = srv.cfg.TransportConfig
 	rpcClient := control.NewClient(
+		control.WithClientComponent(build.ComponentServer),
 		control.WithConfig(cliCfg),
 		control.WithClientLogger(srv.log))
 

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -714,7 +714,7 @@ func getGrpcOpts(log logging.Logger, cfgTransport *security.TransportConfig, ldr
 		unaryLoggingInterceptor(log, ldrChk), // must be first in order to properly log errors
 		unaryErrorInterceptor,
 		unaryStatusInterceptor,
-		unaryVersionInterceptor,
+		unaryVersionInterceptor(log),
 	}
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		streamErrorInterceptor,


### PR DESCRIPTION
The interoperability checking code relies on getting the
peer component from the peer certificate. When running
in insecure mode, the peer component information is
unavailable, and the interoperability check defaults
to the most stringent requirements.

This patch adds new component/version headers to the
grpc client request to allow the server to perform
interoperability checks without the peer certificate.

Signed-off-by: Michael MacDonald <mjmac@google.com>