### PR TITLE
DAOS-14347 control: Enable setting of port numbers in config generate…

### DIFF
--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -123,6 +123,7 @@ Application Options:
       --allow-proxy                         Allow proxy configuration via environment
   -o, --config=                             Server config file path
   -b, --debug                               Enable debug output
+  -j, --json                                enable JSON output
   -J, --json-logging                        Enable JSON-formatted log output
       --syslog                              Enable logging to syslog
 
@@ -137,9 +138,15 @@ Help Options:
                                             config file output. If unset then the value will be set to the
                                             number of NUMA nodes on storage hosts in the DAOS system.
       -s, --scm-only                        Create a SCM-only config without NVMe SSDs.
-      -c, --net-class=[ethernet|infiniband] Set the network class to be used (default: infiniband)
-      -p, --net-provider=                   Set the network provider to be used
+      -c, --net-class=[ethernet|infiniband] Set the network device class to be used (default: infiniband)
+      -p, --net-provider=                   Set the network fabric provider to be used
       -t, --use-tmpfs-scm                   Use tmpfs for scm rather than PMem
+      -m, --control-metadata-path=          External storage path to store control metadata. Set this to
+                                            a persistent location and specify --use-tmpfs-scm to create an
+                                            MD-on-SSD config
+      -f, --fabric-ports=                   Allow custom fabric interface ports to be specified for each engine
+                                            config section. Comma separated port numbers, one per engine
+          --skip-prep                       Skip preparation of devices during scan.
 ```
 
 Note the `--helper-log-file` which can be used to provide a log file path to output debug level
@@ -159,8 +166,6 @@ Usage:
 
 Application Options:
       --allow-proxy                         Allow proxy configuration via environment
-  -l, --host-list=                          A comma separated list of addresses <ipv4addr/hostname> to
-                                            connect to
   -i, --insecure                            Have dmg attempt to connect without certificates
   -d, --debug                               Enable debug output
       --log-file=                           Log command output to the specified file
@@ -172,15 +177,21 @@ Help Options:
   -h, --help                                Show this help message
 
 [generate command options]
-      -a, --access-points=                  Comma separated list of access point addresses
-                                            <ipv4addr/hostname> (default: localhost)
+      -l, --host-list=                      A comma separated list of addresses <ipv4addr/hostname> to connect to
+      -a, --access-points=                  Comma separated list of access point addresses <ipv4addr/hostname>
+                                            to host management service (default: localhost)
       -e, --num-engines=                    Set the number of DAOS Engine sections to be populated in the
                                             config file output. If unset then the value will be set to the
                                             number of NUMA nodes on storage hosts in the DAOS system.
       -s, --scm-only                        Create a SCM-only config without NVMe SSDs.
-      -c, --net-class=[ethernet|infiniband] Set the network class to be used (default: infiniband)
-      -p, --net-provider=                   Set the network provider to be used
+      -c, --net-class=[ethernet|infiniband] Set the network device class to be used (default: infiniband)
+      -p, --net-provider=                   Set the network fabric provider to be used
       -t, --use-tmpfs-scm                   Use tmpfs for scm rather than PMem
+      -m, --control-metadata-path=          External storage path to store control metadata. Set this to
+                                            a persistent location and specify --use-tmpfs-scm to create an
+                                            MD-on-SSD config
+      -f, --fabric-ports=                   Allow custom fabric interface ports to be specified for each engine
+                                            config section. Comma separated port numbers, one per engine
 ```
 
 The `daos_server` service must be running on the remote storage servers and as such a minimal
@@ -216,7 +227,7 @@ Each generated engine section will specify a SCM storage tier (PMem or tmpfs) in
 more NVMe storage tiers. All hardware components specified in an engine config section should be
 bound to the same NUMA node (PMem bdev, SSDs and host fabric interface).
 
-- `--scm-only` request that a config without NVMe should be generated. This flag will override the
+- `--scm-only` requests that a config without NVMe should be generated. This flag will override the
 command's normal behavior and should be used only in circumstances where NVMe SSDs are unavailable
 or not balanced across NUMA nodes and multiple engines are required per host. Note that DAOS
 performance will be suboptimal without NVMe SSDs.
@@ -224,7 +235,6 @@ performance will be suboptimal without NVMe SSDs.
 - `--net-class` selects a specific network device class, options are `ethernet` or `infiniband`.
 If not set explicitly on the commandline, default is `infiniband`. This option will alter the
 command's behavior and should only be used when normal command operation is not sufficient.
-Note that DAOS performance may be suboptimal if ethernet devices are used instead of infiniband.
 
 - `--net-provider` selects a specific network provider , this can be set to any provider string
 supported on the hosts e.g. ofi+tcp. This option will alter the command's behavior and should only
@@ -232,8 +242,15 @@ be used when normal command operation is not sufficient. Note that specifying a 
 prevent the command from selecting the best available.
 
 - `--use-tmpfs-scm` will produce a config specifying RAM-disk (tmpfs) devices in the first (SCM)
-storage tier. The RAM-disk sizes will be calculated based on using 75% of the host's total
-memory (as reported by `/proc/meminfo`).
+storage tier. The RAM-disk sizes will be calculated based on the host's total memory (as reported
+by `/proc/meminfo`).
+
+- `--control-metadata-path` specifies a persistent location to store control-plane metadata which
+allows MD-on-SSD DAOS deployments to survive without data loss over 'daos_server' restarts. If
+this option is set then a MD-on-SSD config will be generated.
+
+- `--fabric-ports` enables custom port numbers to be assigned to each engine's fabric settings.
+Comma separated list must contain enough numbers to cover all engines generated in config.
 
 The text generated by the command and output to stdout can be copied and used as the server config
 file on relevant hosts (normally by copying to `/etc/daos/daos_server.yml` and (re)starting service).
@@ -353,10 +370,15 @@ SCM format required on instance 0
 SCM format required on instance 1
 ```
 
-To format the storage and start the engine processes, we run the following on a separate
+The `daos_server start --auto-format` option has now been added to allow automatic formatting on
+startup in the event that externally triggered format is not desirable. When using this option
+the storage format will occur on `daos_server` startup without any user intervention assuming the
+supplied config file is valid.
+
+To manually format the storage and start the engine processes, we run the following on a separate
 terminal window and verify that engine processes (ranks) have registered with the system.
-Note the subsequent system query command may not show ranks started immediately after the
-storage format command returns so leave a short period before invoking.
+Note the subsequent system query command may not show ranks started immediately after the storage
+format command returns so it is recommended to leave a short delay (~5s) before invoking.
 
 ```bash
 [user@wolf-226 daos]$ install/bin/dmg storage format -i
@@ -370,8 +392,7 @@ Rank  State
 [0-1] Joined
 ```
 
-The format of storage enables the `daos_server` service started before to format the storage and
-launch the engine processes.
+Engine I/O processes will be launched by the `daos_server` service following storage format.
 
 ```bash
 Instance 0: starting format of nvme block devices 0000:2b:00.0,0000:2c:00.0,0000:2d:00.0,0000:2e:00.0,0000:63:00.0,0000:64:00.0,0000:65:00.0,0000:66:00.0

--- a/src/control/cmd/daos_server/auto.go
+++ b/src/control/cmd/daos_server/auto.go
@@ -9,15 +9,14 @@ package main
 import (
 	"context"
 	"os"
-	"strings"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
+	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	"github.com/daos-stack/daos/src/control/lib/control"
-	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server"
@@ -25,25 +24,17 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
-var ErrTmpfsNoExtMDPath = errors.New("--use-tmpfs-scm will generate an md-on-ssd config and so " +
-	"--control-metadata-path must also be set")
-
 // configCmd is the struct representing the top-level config subcommand.
 type configCmd struct {
 	Generate configGenCmd `command:"generate" alias:"gen" description:"Generate DAOS server configuration file based on discoverable locally-attached hardware devices"`
 }
 
 type configGenCmd struct {
-	cmdutil.LogCmd  `json:"-"`
-	helperLogCmd    `json:"-"`
-	AccessPoints    string `default:"localhost" short:"a" long:"access-points" description:"Comma separated list of access point addresses <ipv4addr/hostname>"`
-	NrEngines       int    `short:"e" long:"num-engines" description:"Set the number of DAOS Engine sections to be populated in the config file output. If unset then the value will be set to the number of NUMA nodes on storage hosts in the DAOS system."`
-	SCMOnly         bool   `short:"s" long:"scm-only" description:"Create a SCM-only config without NVMe SSDs."`
-	NetClass        string `default:"infiniband" short:"c" long:"net-class" description:"Set the network class to be used" choice:"ethernet" choice:"infiniband"`
-	NetProvider     string `short:"p" long:"net-provider" description:"Set the network provider to be used"`
-	UseTmpfsSCM     bool   `short:"t" long:"use-tmpfs-scm" description:"Use tmpfs for scm rather than PMem"`
-	ExtMetadataPath string `short:"m" long:"control-metadata-path" description:"External storage path to store control metadata in MD-on-SSD mode"`
-	SkipPrep        bool   `long:"skip-prep" description:"Skip preparation of devices during scan."`
+	helperLogCmd
+	cmdutil.LogCmd
+	cmdutil.ConfGenCmd
+
+	SkipPrep bool `long:"skip-prep" description:"Skip preparation of devices during scan."`
 }
 
 type getFabricFn func(context.Context, logging.Logger, string) (*control.HostFabric, error)
@@ -128,22 +119,6 @@ func getLocalStorage(ctx context.Context, log logging.Logger, skipPrep bool) (*c
 func (cmd *configGenCmd) confGen(ctx context.Context, getFabric getFabricFn, getStorage getStorageFn) (*config.Server, error) {
 	cmd.Debugf("ConfGen called with command parameters %+v", cmd)
 
-	if cmd.UseTmpfsSCM && cmd.ExtMetadataPath == "" {
-		return nil, ErrTmpfsNoExtMDPath
-	}
-
-	accessPoints := strings.Split(cmd.AccessPoints, ",")
-
-	var ndc hardware.NetDevClass
-	switch cmd.NetClass {
-	case "ethernet":
-		ndc = hardware.Ether
-	case "infiniband":
-		ndc = hardware.Infiniband
-	default:
-		return nil, errors.Errorf("unrecognized net-class value %s", cmd.NetClass)
-	}
-
 	prov := cmd.NetProvider
 	if prov == allProviders {
 		prov = ""
@@ -153,6 +128,7 @@ func (cmd *configGenCmd) confGen(ctx context.Context, getFabric getFabricFn, get
 	if err != nil {
 		return nil, err
 	}
+
 	cmd.Debugf("fetched host fabric info on localhost: %+v", hf)
 
 	hs, err := getStorage(ctx, cmd.Logger, cmd.SkipPrep)
@@ -161,26 +137,27 @@ func (cmd *configGenCmd) confGen(ctx context.Context, getFabric getFabricFn, get
 	}
 	cmd.Debugf("fetched host storage info on localhost: %+v", hs)
 
-	req := control.ConfGenerateReq{
-		NrEngines:       cmd.NrEngines,
-		SCMOnly:         cmd.SCMOnly,
-		NetClass:        ndc,
-		NetProvider:     cmd.NetProvider,
-		AccessPoints:    accessPoints,
-		UseTmpfsSCM:     cmd.UseTmpfsSCM,
-		ExtMetadataPath: cmd.ExtMetadataPath,
+	req := new(control.ConfGenerateReq)
+	if err := convert.Types(cmd, req); err != nil {
+		return nil, err
 	}
 	cmd.Debugf("control API ConfGenerate called with req: %+v", req)
 
-	// Use a modified commandline logger to send all log messages to stderr during the
-	// generation of server config file parameters so stdout can be reserved for config file
-	// output only.
-	logStderr := logging.NewCommandLineLogger()
-	logStderr.ClearLevel(logging.LogLevelInfo)
-	logStderr.WithInfoLogger(logging.NewCommandLineInfoLogger(os.Stderr))
-	req.Log = logStderr
+	// Use a modified commandline logger to send all log messages to stderr in debug mode
+	// during the generation of server config file parameters so stdout can be reserved for
+	// config file output only. If not in debug mode, only log >=error to stderr.
+	logger := logging.NewCommandLineLogger()
+	if cmd.Logger.EnabledFor(logging.LogLevelTrace) {
+		cmd.Debug("debug mode detected, writing all logs to stderr")
+		logger.ClearLevel(logging.LogLevelInfo)
+		logger.WithInfoLogger(logging.NewCommandLineInfoLogger(os.Stderr))
+	} else {
+		// Suppress info logging when not in debug mode.
+		logger.SetLevel(logging.LogLevelError)
+	}
+	req.Log = logger
 
-	resp, err := control.ConfGenerate(req, control.DefaultEngineCfg, hf, hs)
+	resp, err := control.ConfGenerate(*req, control.DefaultEngineCfg, hf, hs)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/cmd/daos_server/auto_test.go
+++ b/src/control/cmd/daos_server/auto_test.go
@@ -19,8 +19,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/config"
@@ -35,68 +37,82 @@ func TestDaosServer_Auto_Commands(t *testing.T) {
 		{
 			"Generate with no access point",
 			"config generate",
-			printCommand(t, &configGenCmd{
-				AccessPoints: "localhost",
-				NetClass:     "infiniband",
-			}),
+			printCommand(t, func() *configGenCmd {
+				cmd := &configGenCmd{}
+				cmd.AccessPoints = "localhost"
+				cmd.NetClass = "infiniband"
+				return cmd
+			}()),
 			nil,
 		},
 		{
 			"Generate with defaults",
 			"config generate -a foo",
-			printCommand(t, &configGenCmd{
-				AccessPoints: "foo",
-				NetClass:     "infiniband",
-			}),
+			printCommand(t, func() *configGenCmd {
+				cmd := &configGenCmd{}
+				cmd.AccessPoints = "foo"
+				cmd.NetClass = "infiniband"
+				return cmd
+			}()),
 			nil,
 		},
 		{
 			"Generate with no nvme",
 			"config generate -a foo --scm-only",
-			printCommand(t, &configGenCmd{
-				AccessPoints: "foo",
-				SCMOnly:      true,
-				NetClass:     "infiniband",
-			}),
+			printCommand(t, func() *configGenCmd {
+				cmd := &configGenCmd{}
+				cmd.AccessPoints = "foo"
+				cmd.NetClass = "infiniband"
+				cmd.SCMOnly = true
+				return cmd
+			}()),
 			nil,
 		},
 		{
 			"Generate with storage parameters",
 			"config generate -a foo --num-engines 2",
-			printCommand(t, &configGenCmd{
-				AccessPoints: "foo",
-				NrEngines:    2,
-				NetClass:     "infiniband",
-			}),
+			printCommand(t, func() *configGenCmd {
+				cmd := &configGenCmd{}
+				cmd.AccessPoints = "foo"
+				cmd.NetClass = "infiniband"
+				cmd.NrEngines = 2
+				return cmd
+			}()),
 			nil,
 		},
 		{
 			"Generate with short option storage parameters",
 			"config generate -a foo -e 2 -s",
-			printCommand(t, &configGenCmd{
-				AccessPoints: "foo",
-				NrEngines:    2,
-				NetClass:     "infiniband",
-				SCMOnly:      true,
-			}),
+			printCommand(t, func() *configGenCmd {
+				cmd := &configGenCmd{}
+				cmd.AccessPoints = "foo"
+				cmd.NetClass = "infiniband"
+				cmd.NrEngines = 2
+				cmd.SCMOnly = true
+				return cmd
+			}()),
 			nil,
 		},
 		{
 			"Generate with ethernet network device class",
 			"config generate -a foo --net-class ethernet",
-			printCommand(t, &configGenCmd{
-				AccessPoints: "foo",
-				NetClass:     "ethernet",
-			}),
+			printCommand(t, func() *configGenCmd {
+				cmd := &configGenCmd{}
+				cmd.AccessPoints = "foo"
+				cmd.NetClass = "ethernet"
+				return cmd
+			}()),
 			nil,
 		},
 		{
 			"Generate with infiniband network device class",
 			"config generate -a foo --net-class infiniband",
-			printCommand(t, &configGenCmd{
-				AccessPoints: "foo",
-				NetClass:     "infiniband",
-			}),
+			printCommand(t, func() *configGenCmd {
+				cmd := &configGenCmd{}
+				cmd.AccessPoints = "foo"
+				cmd.NetClass = "infiniband"
+				return cmd
+			}()),
 			nil,
 		},
 		{
@@ -112,14 +128,28 @@ func TestDaosServer_Auto_Commands(t *testing.T) {
 			errors.New("Invalid value"),
 		},
 		{
+			"Generate tmpfs non-MD-on-SSD config",
+			"config generate -a foo --use-tmpfs-scm",
+			printCommand(t, func() *configGenCmd {
+				cmd := &configGenCmd{}
+				cmd.AccessPoints = "foo"
+				cmd.NetClass = "infiniband"
+				cmd.UseTmpfsSCM = true
+				return cmd
+			}()),
+			nil,
+		},
+		{
 			"Generate MD-on-SSD config",
 			"config generate -a foo --use-tmpfs-scm --control-metadata-path /opt/daos_md",
-			printCommand(t, &configGenCmd{
-				AccessPoints:    "foo",
-				NetClass:        "infiniband",
-				UseTmpfsSCM:     true,
-				ExtMetadataPath: "/opt/daos_md",
-			}),
+			printCommand(t, func() *configGenCmd {
+				cmd := &configGenCmd{}
+				cmd.AccessPoints = "foo"
+				cmd.NetClass = "infiniband"
+				cmd.UseTmpfsSCM = true
+				cmd.ExtMetadataPath = "/opt/daos_md"
+				return cmd
+			}()),
 			nil,
 		},
 		{
@@ -129,6 +159,38 @@ func TestDaosServer_Auto_Commands(t *testing.T) {
 			errors.New("Unknown command"),
 		},
 	})
+}
+
+func TestDaosServer_Auto_confGenCmd_Convert(t *testing.T) {
+	cmd := &configGenCmd{}
+	cmd.NrEngines = 1
+	cmd.NetProvider = "ofi+tcp"
+	cmd.SCMOnly = true
+	cmd.AccessPoints = "foo,bar"
+	cmd.NetClass = "infiniband"
+	cmd.UseTmpfsSCM = true
+	cmd.ExtMetadataPath = "/opt/daos_md"
+	cmd.FabricPorts = "12345,13345"
+
+	req := new(control.ConfGenerateReq)
+	if err := convert.Types(cmd, req); err != nil {
+		t.Fatal(err)
+	}
+
+	expReq := &control.ConfGenerateReq{
+		NrEngines:       1,
+		NetProvider:     "ofi+tcp",
+		SCMOnly:         true,
+		AccessPoints:    []string{"foo", "bar"},
+		NetClass:        hardware.Infiniband,
+		UseTmpfsSCM:     true,
+		ExtMetadataPath: "/opt/daos_md",
+		FabricPorts:     []int{12345, 13345},
+	}
+
+	if diff := cmp.Diff(expReq, req); diff != "" {
+		t.Fatalf("unexpected request converted (-want, +got):\n%s\n", diff)
+	}
 }
 
 // The Control API calls made in configGenCmd.confGen() are already well tested so just do some
@@ -149,23 +211,38 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 	e0 := control.MockEngineCfg(0, 2, 4).WithTargetCount(18).WithHelperStreamCount(4)
 	e1 := control.MockEngineCfg(1, 1, 3).WithTargetCount(18).WithHelperStreamCount(4)
 	exmplEngineCfgs := []*engine.Config{e0, e1}
+
+	engRsvdGiB := 2 /* calculated based on 18 targets */
+	sysRsvdGiB := storage.DefaultSysMemRsvd / humanize.GiByte
+	ramdiskGiB := storage.MinRamdiskMem / humanize.GiByte
+	// Nr hugepages expected with 18 targets * 2 engines * 512 pages-per-target.
+	defNrHugepages := 18 * 2 * 512
+	tmpfsHugeMemGiB := (humanize.MiByte * 2 * defNrHugepages) / humanize.GiByte
+	// Total mem to meet requirements 38GiB hugeMem, 2GiB per engine rsvd, 6GiB sys rsvd, 4GiB
+	// per engine RAM-disk.
+	tmpfsMemTotalGiB := humanize.GiByte * (tmpfsHugeMemGiB + (2 * engRsvdGiB) + sysRsvdGiB +
+		(2 * ramdiskGiB) + 1 /* add 1GiB buffer */)
+	tmpfsEngineCfgs := []*engine.Config{
+		control.MockEngineCfgTmpfs(0, ramdiskGiB, control.MockBdevTier(0, 2, 4)).
+			WithTargetCount(18).WithHelperStreamCount(4),
+		control.MockEngineCfgTmpfs(1, ramdiskGiB, control.MockBdevTier(1, 1, 3)).
+			WithTargetCount(18).WithHelperStreamCount(4),
+	}
+
 	metadataMountPath := "/mnt/daos_md"
 	controlMetadata := storage.ControlMetadata{
 		Path: metadataMountPath,
 	}
 	// Nr hugepages expected with 18+1 (extra MD-on-SSD sys-xstream) targets * 2 engines * 512
 	// pages-per-target.
-	tmpfsNrHugepages := 19 * 2 * 512
-	tmpfsHugeMemGiB := (humanize.MiByte * 2 * tmpfsNrHugepages) / humanize.GiByte
-	tmpfsEngRsvdGiB := 2 /* calculated based on 18 targets */
-	tmpfsSysRsvdGiB := storage.DefaultSysMemRsvd / humanize.GiByte
-	tmpfsRamdiskGiB := storage.MinRamdiskMem / humanize.GiByte
+	mdonssdNrHugepages := 19 * 2 * 512
+	mdonssdHugeMemGiB := (humanize.MiByte * 2 * mdonssdNrHugepages) / humanize.GiByte
 	// Total mem to meet requirements 39GiB hugeMem, 2GiB per engine rsvd, 6GiB sys rsvd, 4GiB
 	// per engine RAM-disk.
-	tmpfsMemTotalGiB := humanize.GiByte * (tmpfsHugeMemGiB + (2 * tmpfsEngRsvdGiB) + tmpfsSysRsvdGiB +
-		(2 * tmpfsRamdiskGiB) + 1 /* add 1GiB buffer */)
-	tmpfsEngineCfgs := []*engine.Config{
-		control.MockEngineCfgTmpfs(0, tmpfsRamdiskGiB,
+	mdonssdMemTotalGiB := humanize.GiByte * (mdonssdHugeMemGiB + (2 * engRsvdGiB) + sysRsvdGiB +
+		(2 * ramdiskGiB) + 1 /* add 1GiB buffer */)
+	mdonssdEngineCfgs := []*engine.Config{
+		control.MockEngineCfgTmpfs(0, ramdiskGiB,
 			control.MockBdevTierWithRole(0, storage.BdevRoleWAL, 2),
 			control.MockBdevTierWithRole(0, storage.BdevRoleMeta|storage.BdevRoleData, 4)).
 			WithStorageControlMetadataPath(metadataMountPath).
@@ -173,7 +250,7 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 				filepath.Join(controlMetadata.EngineDirectory(0), storage.BdevOutConfName),
 			).
 			WithTargetCount(18).WithHelperStreamCount(4),
-		control.MockEngineCfgTmpfs(1, tmpfsRamdiskGiB,
+		control.MockEngineCfgTmpfs(1, ramdiskGiB,
 			control.MockBdevTierWithRole(1, storage.BdevRoleWAL, 1),
 			control.MockBdevTierWithRole(1, storage.BdevRoleMeta|storage.BdevRoleData, 3)).
 			WithStorageControlMetadataPath(metadataMountPath).
@@ -267,8 +344,7 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 				},
 			},
 			expCfg: control.MockServerCfg("ofi+psm2", exmplEngineCfgs).
-				// 18 targets * 2 engines * 512 pages
-				WithNrHugepages(18 * 2 * 512).
+				WithNrHugepages(defNrHugepages).
 				WithAccessPoints("localhost:10001").
 				WithControlLogFile("/tmp/daos_server.log"),
 		},
@@ -295,8 +371,7 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 				},
 			},
 			expCfg: control.MockServerCfg("ofi+psm2", exmplEngineCfgs).
-				// 18 targets * 2 engines * 512 pages
-				WithNrHugepages(18*2*512).
+				WithNrHugepages(defNrHugepages).
 				WithAccessPoints("localhost:10001").
 				WithAccessPoints("moon-111:10001", "mars-115:10001", "jupiter-119:10001").
 				WithControlLogFile("/tmp/daos_server.log"),
@@ -381,6 +456,36 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 					storage.MockScmNamespace(0),
 					storage.MockScmNamespace(1),
 				},
+				MemInfo: &common.MemInfo{
+					HugepageSizeKiB: 2048,
+					MemTotalKiB:     tmpfsMemTotalGiB / humanize.KiByte,
+				},
+				NvmeDevices: storage.NvmeControllers{
+					storage.MockNvmeController(1),
+					storage.MockNvmeController(2),
+					storage.MockNvmeController(3),
+					storage.MockNvmeController(4),
+				},
+			},
+			expCfg: control.MockServerCfg("ofi+psm2", tmpfsEngineCfgs).
+				WithNrHugepages(defNrHugepages).
+				WithAccessPoints("localhost:10001").
+				WithControlLogFile("/tmp/daos_server.log"),
+		},
+		"dcpm scm; control_metadata path set": {
+			extMetadataPath: metadataMountPath,
+			hf: &control.HostFabric{
+				Interfaces: []*control.HostFabricInterface{
+					eth0, eth1, ib0, ib1,
+				},
+				NumaCount:    2,
+				CoresPerNuma: 24,
+			},
+			hs: &control.HostStorage{
+				ScmNamespaces: storage.ScmNamespaces{
+					storage.MockScmNamespace(0),
+					storage.MockScmNamespace(1),
+				},
 				MemInfo: &defMemInfo,
 				NvmeDevices: storage.NvmeControllers{
 					storage.MockNvmeController(1),
@@ -389,9 +494,9 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 					storage.MockNvmeController(4),
 				},
 			},
-			expErr: ErrTmpfsNoExtMDPath,
+			expErr: errors.New("only supported with scm class ram"),
 		},
-		"tmpfs scm; low mem": {
+		"tmpfs scm; md-on-ssd; low mem": {
 			tmpfsSCM:        true,
 			extMetadataPath: metadataMountPath,
 			hf: &control.HostFabric{
@@ -419,7 +524,7 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 			},
 			expErr: errors.New("insufficient ram"),
 		},
-		"tmpfs scm": {
+		"tmpfs scm; md-on-ssd": {
 			tmpfsSCM:        true,
 			extMetadataPath: metadataMountPath,
 			hf: &control.HostFabric{
@@ -436,7 +541,7 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 				},
 				MemInfo: &common.MemInfo{
 					HugepageSizeKiB: 2048,
-					MemTotalKiB:     tmpfsMemTotalGiB / humanize.KiByte,
+					MemTotalKiB:     mdonssdMemTotalGiB / humanize.KiByte,
 				},
 				NvmeDevices: storage.NvmeControllers{
 					storage.MockNvmeController(1),
@@ -445,13 +550,13 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 					storage.MockNvmeController(4),
 				},
 			},
-			expCfg: control.MockServerCfg("ofi+psm2", tmpfsEngineCfgs).
-				WithNrHugepages(tmpfsNrHugepages).
+			expCfg: control.MockServerCfg("ofi+psm2", mdonssdEngineCfgs).
+				WithNrHugepages(mdonssdNrHugepages).
 				WithAccessPoints("localhost:10001").
 				WithControlLogFile("/tmp/daos_server.log").
 				WithControlMetadata(controlMetadata),
 		},
-		"tmpfs scm; no logging to stdout": {
+		"tmpfs scm; md-on-ssd; no logging to stdout": {
 			tmpfsSCM:        true,
 			extMetadataPath: metadataMountPath,
 			hf: &control.HostFabric{
@@ -468,7 +573,7 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 				},
 				MemInfo: &common.MemInfo{
 					HugepageSizeKiB: 2048,
-					MemTotalKiB:     tmpfsMemTotalGiB / humanize.KiByte,
+					MemTotalKiB:     mdonssdMemTotalGiB / humanize.KiByte,
 				},
 				NvmeDevices: storage.NvmeControllers{
 					storage.MockNvmeController(1),
@@ -492,14 +597,13 @@ func TestDaosServer_Auto_confGen(t *testing.T) {
 				tc.accessPoints = "localhost"
 			}
 
-			cmd := &configGenCmd{
-				AccessPoints:    tc.accessPoints,
-				NrEngines:       tc.nrEngines,
-				SCMOnly:         tc.scmOnly,
-				NetClass:        tc.netClass,
-				UseTmpfsSCM:     tc.tmpfsSCM,
-				ExtMetadataPath: tc.extMetadataPath,
-			}
+			cmd := &configGenCmd{}
+			cmd.AccessPoints = tc.accessPoints
+			cmd.NrEngines = tc.nrEngines
+			cmd.SCMOnly = tc.scmOnly
+			cmd.NetClass = tc.netClass
+			cmd.UseTmpfsSCM = tc.tmpfsSCM
+			cmd.ExtMetadataPath = tc.extMetadataPath
 			log.SetLevel(logging.LogLevelInfo)
 			cmd.Logger = log
 

--- a/src/control/cmd/dmg/auto.go
+++ b/src/control/cmd/dmg/auto.go
@@ -16,14 +16,17 @@ import (
 
 	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
+	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	"github.com/daos-stack/daos/src/control/lib/control"
-	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
 )
 
-var ErrTmpfsNoExtMDPath = errors.New("--use-tmpfs-scm will generate an md-on-ssd config and so " +
-	"--control-metadata-path must also be set")
+type confGenRemoteFn func(ctx context.Context, req control.ConfGenerateRemoteReq) (*control.ConfGenerateRemoteResp, error)
+
+// Package-local function pointer for backend API call. Enables mocking out package-external calls
+// in unit tests.
+var confGenRemoteCall confGenRemoteFn = control.ConfGenerateRemote
 
 // configCmd is the struct representing the top-level config subcommand.
 type configCmd struct {
@@ -36,34 +39,11 @@ type configGenCmd struct {
 	ctlInvokerCmd
 	hostListCmd
 	cmdutil.JSONOutputCmd
-
-	AccessPoints    string `default:"localhost" short:"a" long:"access-points" description:"Comma separated list of access point addresses <ipv4addr/hostname>"`
-	NrEngines       int    `short:"e" long:"num-engines" description:"Set the number of DAOS Engine sections to be populated in the config file output. If unset then the value will be set to the number of NUMA nodes on storage hosts in the DAOS system."`
-	SCMOnly         bool   `short:"s" long:"scm-only" description:"Create a SCM-only config without NVMe SSDs."`
-	NetClass        string `default:"infiniband" short:"c" long:"net-class" description:"Set the network class to be used" choice:"ethernet" choice:"infiniband"`
-	NetProvider     string `short:"p" long:"net-provider" description:"Set the network provider to be used"`
-	UseTmpfsSCM     bool   `short:"t" long:"use-tmpfs-scm" description:"Use tmpfs for scm rather than PMem"`
-	ExtMetadataPath string `short:"m" long:"control-metadata-path" description:"External storage path to store control metadata in MD-on-SSD mode"`
+	cmdutil.ConfGenCmd
 }
 
 func (cmd *configGenCmd) confGen(ctx context.Context) (*config.Server, error) {
 	cmd.Debugf("ConfGen called with command parameters %+v", cmd)
-
-	if cmd.UseTmpfsSCM && cmd.ExtMetadataPath == "" {
-		return nil, ErrTmpfsNoExtMDPath
-	}
-
-	accessPoints := strings.Split(cmd.AccessPoints, ",")
-
-	var ndc hardware.NetDevClass
-	switch cmd.NetClass {
-	case "ethernet":
-		ndc = hardware.Ether
-	case "infiniband":
-		ndc = hardware.Infiniband
-	default:
-		return nil, errors.Errorf("unrecognized net-class value %s", cmd.NetClass)
-	}
 
 	// check cli then config for hostlist, default to localhost
 	hl := cmd.getHostList()
@@ -75,30 +55,30 @@ func (cmd *configGenCmd) confGen(ctx context.Context) (*config.Server, error) {
 	}
 
 	req := control.ConfGenerateRemoteReq{
-		ConfGenerateReq: control.ConfGenerateReq{
-			Log:             cmd.Logger,
-			NrEngines:       cmd.NrEngines,
-			SCMOnly:         cmd.SCMOnly,
-			NetClass:        ndc,
-			NetProvider:     cmd.NetProvider,
-			AccessPoints:    accessPoints,
-			UseTmpfsSCM:     cmd.UseTmpfsSCM,
-			ExtMetadataPath: cmd.ExtMetadataPath,
-		},
-		Client:   cmd.ctlInvoker,
-		HostList: hl,
+		ConfGenerateReq: control.ConfGenerateReq{},
+		Client:          cmd.ctlInvoker,
+		HostList:        hl,
+	}
+	if err := convert.Types(&cmd.ConfGenCmd, &req.ConfGenerateReq); err != nil {
+		return nil, err
 	}
 	cmd.Debugf("control API ConfGenerateRemote called with req: %+v", req)
 
-	// Use a modified commandline logger to send all log messages to stderr during the
-	// generation of server config file parameters so stdout can be reserved for config file
-	// output only.
-	logStderr := logging.NewCommandLineLogger()
-	logStderr.ClearLevel(logging.LogLevelInfo)
-	logStderr.WithInfoLogger(logging.NewCommandLineInfoLogger(os.Stderr))
-	req.Log = logStderr
+	// Use a modified commandline logger to send all log messages to stderr in debug mode
+	// during the generation of server config file parameters so stdout can be reserved for
+	// config file output only. If not in debug mode, only log >=error to stderr.
+	logger := logging.NewCommandLineLogger()
+	if cmd.Logger.EnabledFor(logging.LogLevelTrace) {
+		cmd.Debug("debug mode detected, writing all logs to stderr")
+		logger.ClearLevel(logging.LogLevelInfo)
+		logger.WithInfoLogger(logging.NewCommandLineInfoLogger(os.Stderr))
+	} else {
+		// Suppress info logging.
+		logger.SetLevel(logging.LogLevelError)
+	}
+	req.Log = logger
 
-	resp, err := control.ConfGenerateRemote(ctx, req)
+	resp, err := confGenRemoteCall(ctx, req)
 
 	if cmd.JSONOutputEnabled() {
 		return nil, cmd.OutputJSON(resp, err)

--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -18,9 +19,11 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
+	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/config"
@@ -28,87 +31,216 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
+var cgReqCalls []string
+
+func runConfGenCmdTests(t *testing.T, cmdTests []cmdTest) {
+	t.Helper()
+
+	for _, st := range cmdTests {
+		t.Run(st.name, func(t *testing.T) {
+			cgReqCalls = nil // Clear before running test case.
+
+			runCmdTest(t, st.cmd, "", st.expectedErr) // Invoker calls not checked.
+
+			if st.expectedCalls == "" && cgReqCalls == nil {
+				return
+			}
+
+			// Validate ConfGenerate control API requests.
+			callsStr := strings.Join(cgReqCalls, " ")
+			if diff := cmp.Diff(st.expectedCalls, callsStr); diff != "" {
+				t.Fatalf("unexpected other calls (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
 func TestAuto_ConfigCommands(t *testing.T) {
-	runCmdTests(t, []cmdTest{
+	printCGRReq := func(t *testing.T, req control.ConfGenerateRemoteReq) string {
+		req2 := req
+		req2.Log = nil
+		req2.Client = nil
+		return fmt.Sprintf("%T-%+v", req2, req2)
+	}
+
+	mockConfGenRemCall := func(_ context.Context, req control.ConfGenerateRemoteReq) (*control.ConfGenerateRemoteResp, error) {
+		cgReqCalls = append(cgReqCalls, printCGRReq(t, req))
+		return &control.ConfGenerateRemoteResp{}, nil
+	}
+
+	// Mock external API calls and restore after tests.
+	origGenRemCall := confGenRemoteCall
+	confGenRemoteCall = mockConfGenRemCall
+	defer func() {
+		confGenRemoteCall = origGenRemCall
+	}()
+
+	runConfGenCmdTests(t, []cmdTest{
 		{
 			"Generate with no access point",
 			"config generate",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
-			errors.New("no host responses"),
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"localhost"}
+				return req
+			}()),
+			nil,
+		},
+		{
+			"Generate with hostlist",
+			"config generate -a foo -l bar-[1-10]",
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{
+						"bar-1", "bar-2", "bar-3", "bar-4", "bar-5",
+						"bar-6", "bar-7", "bar-8", "bar-9", "bar-10",
+					},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				return req
+			}()),
+			nil,
 		},
 		{
 			"Generate with defaults",
 			"config generate -a foo",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
-			errors.New("no host responses"),
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				return req
+			}()),
+			nil,
 		},
 		{
 			"Generate with no nvme",
 			"config generate -a foo --scm-only",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
-			errors.New("no host responses"),
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				req.ConfGenerateReq.SCMOnly = true
+				return req
+			}()),
+			nil,
 		},
 		{
 			"Generate with storage parameters",
 			"config generate -a foo --num-engines 2",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
-			errors.New("no host responses"),
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				req.ConfGenerateReq.NrEngines = 2
+				return req
+			}()),
+			nil,
 		},
 		{
 			"Generate with short option storage parameters",
 			"config generate -a foo -e 2 -s",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
-			errors.New("no host responses"),
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				req.ConfGenerateReq.NrEngines = 2
+				req.ConfGenerateReq.SCMOnly = true
+				return req
+			}()),
+			nil,
 		},
 		{
 			"Generate with ethernet network device class",
 			"config generate -a foo --net-class ethernet",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
-			errors.New("no host responses"),
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Ether
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				return req
+			}()),
+			nil,
 		},
 		{
 			"Generate with infiniband network device class",
 			"config generate -a foo --net-class infiniband",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
-			errors.New("no host responses"),
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				return req
+			}()),
+			nil,
 		},
 		{
 			"Generate with deprecated network device class",
 			"config generate -a foo --net-class best-available",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
+			"",
 			errors.New("Invalid value"),
 		},
 		{
 			"Generate with unsupported network device class",
 			"config generate -a foo --net-class loopback",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
+			"",
 			errors.New("Invalid value"),
 		},
 		{
+			"Generate with custom network fabric ports",
+			"config generate -a foo --fabric-ports 12345,13345",
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				req.ConfGenerateReq.FabricPorts = []int{12345, 13345}
+				return req
+			}()),
+			nil,
+		},
+		{
+			"Generate tmpfs non-MD-on-SSD config",
+			"config generate -a foo --use-tmpfs-scm",
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				req.ConfGenerateReq.UseTmpfsSCM = true
+				return req
+			}()),
+			nil,
+		},
+		{
 			"Generate MD-on-SSD config",
-			"config generate -a foo --use-tmpfs-scm --control-metadata-path /opt/daos_md",
-			strings.Join([]string{
-				printRequest(t, &control.NetworkScanReq{}),
-			}, " "),
-			errors.New("no host responses"),
+			"config generate -a foo --use-tmpfs-scm --control-metadata-path /opt/daos",
+			printCGRReq(t, func() control.ConfGenerateRemoteReq {
+				req := control.ConfGenerateRemoteReq{
+					HostList: []string{"localhost:10001"},
+				}
+				req.ConfGenerateReq.NetClass = hardware.Infiniband
+				req.ConfGenerateReq.AccessPoints = []string{"foo"}
+				req.ConfGenerateReq.UseTmpfsSCM = true
+				req.ConfGenerateReq.ExtMetadataPath = "/opt/daos"
+				return req
+			}()),
+			nil,
 		},
 		{
 			"Nonexistent subcommand",
@@ -119,7 +251,39 @@ func TestAuto_ConfigCommands(t *testing.T) {
 	})
 }
 
-// The Control API calls made in configGenCmd.confGen() are already well tested so just do some
+func TestAuto_confGenCmd_Convert(t *testing.T) {
+	cmd := &configGenCmd{}
+	cmd.NrEngines = 1
+	cmd.NetProvider = "ofi+tcp"
+	cmd.SCMOnly = true
+	cmd.AccessPoints = "foo,bar"
+	cmd.NetClass = "infiniband"
+	cmd.UseTmpfsSCM = true
+	cmd.ExtMetadataPath = "/opt/daos_md"
+	cmd.FabricPorts = "12345,13345"
+
+	req := new(control.ConfGenerateReq)
+	if err := convert.Types(cmd.ConfGenCmd, req); err != nil {
+		t.Fatal(err)
+	}
+
+	expReq := &control.ConfGenerateReq{
+		NrEngines:       1,
+		NetProvider:     "ofi+tcp",
+		SCMOnly:         true,
+		AccessPoints:    []string{"foo", "bar"},
+		NetClass:        hardware.Infiniband,
+		UseTmpfsSCM:     true,
+		ExtMetadataPath: "/opt/daos_md",
+		FabricPorts:     []int{12345, 13345},
+	}
+
+	if diff := cmp.Diff(expReq, req); diff != "" {
+		t.Fatalf("unexpected request converted (-want, +got):\n%s\n", diff)
+	}
+}
+
+// The Control API calls made in ConfigGenCmd.confGen() are already well tested so just do some
 // sanity checking here to prevent regressions.
 func TestAuto_confGen(t *testing.T) {
 	ib0 := &ctlpb.FabricInterface{
@@ -152,11 +316,17 @@ func TestAuto_confGen(t *testing.T) {
 	e0 := control.MockEngineCfg(0, 2, 4, 6, 8).WithHelperStreamCount(4)
 	e1 := control.MockEngineCfg(1, 1, 3, 5, 7).WithHelperStreamCount(4)
 	exmplEngineCfgs := []*engine.Config{e0, e1}
+	tmpfsEngineCfgs := []*engine.Config{
+		control.MockEngineCfgTmpfs(0, mockRamdiskSize+1, control.MockBdevTier(0, 2, 4, 6, 8)).
+			WithHelperStreamCount(4),
+		control.MockEngineCfgTmpfs(1, mockRamdiskSize+1, control.MockBdevTier(1, 1, 3, 5, 7)).
+			WithHelperStreamCount(4),
+	}
 	metadataMountPath := "/mnt/daos_md"
 	controlMetadata := storage.ControlMetadata{
 		Path: metadataMountPath,
 	}
-	tmpfsEngineCfgs := []*engine.Config{
+	mdonssdEngineCfgs := []*engine.Config{
 		control.MockEngineCfgTmpfs(0, mockRamdiskSize,
 			control.MockBdevTierWithRole(0, storage.BdevRoleWAL, 2),
 			control.MockBdevTierWithRole(0, storage.BdevRoleMeta|storage.BdevRoleData, 4, 6, 8)).
@@ -209,7 +379,7 @@ func TestAuto_confGen(t *testing.T) {
 			},
 			expErr: errors.New("1 host"),
 		},
-		"successful fetch of host storage and fabric": {
+		"dcpm scm": {
 			hostResponsesSet: [][]*control.HostResponse{
 				{netHostResp},
 				{storHostResp},
@@ -220,7 +390,7 @@ func TestAuto_confGen(t *testing.T) {
 				WithAccessPoints("localhost:10001").
 				WithControlLogFile("/tmp/daos_server.log"),
 		},
-		"successful fetch of host storage and fabric; access points set": {
+		"dcpm scm; access points set": {
 			accessPoints: "moon-111,mars-115,jupiter-119",
 			hostResponsesSet: [][]*control.HostResponse{
 				{netHostResp},
@@ -232,7 +402,7 @@ func TestAuto_confGen(t *testing.T) {
 				WithAccessPoints("moon-111:10001", "mars-115:10001", "jupiter-119:10001").
 				WithControlLogFile("/tmp/daos_server.log"),
 		},
-		"successful fetch of host storage and fabric; unmet min nr ssds": {
+		"dcpm scm; unmet min nr ssds": {
 			hostResponsesSet: [][]*control.HostResponse{
 				{netHostResp},
 				{
@@ -244,7 +414,7 @@ func TestAuto_confGen(t *testing.T) {
 			},
 			expErr: errors.New("insufficient number of ssds"),
 		},
-		"successful fetch of host storage and fabric; unmet nr engines": {
+		"dcpm scm; unmet nr engines": {
 			nrEngines: 8,
 			hostResponsesSet: [][]*control.HostResponse{
 				{netHostResp},
@@ -252,7 +422,7 @@ func TestAuto_confGen(t *testing.T) {
 			},
 			expErr: errors.New("insufficient number of pmem"),
 		},
-		"successful fetch of host storage and fabric; bad net class": {
+		"dcpm scm; bad net class": {
 			netClass: "foo",
 			hostResponsesSet: [][]*control.HostResponse{
 				{netHostResp},
@@ -260,15 +430,26 @@ func TestAuto_confGen(t *testing.T) {
 			},
 			expErr: errors.New("unrecognized net-class"),
 		},
-		"successful fetch of host storage and fabric; tmpfs scm; no control_metadata path": {
+		"tmpfs scm; no control_metadata path": {
 			tmpfsSCM: true,
 			hostResponsesSet: [][]*control.HostResponse{
 				{netHostResp},
 				{storHostRespHighMem},
 			},
-			expErr: ErrTmpfsNoExtMDPath,
+			expCfg: control.MockServerCfg("ofi+psm2", tmpfsEngineCfgs).
+				// 16 targets * 2 engines * 512 pages
+				WithNrHugepages(16 * 2 * 512).
+				WithControlLogFile("/tmp/daos_server.log"),
 		},
-		"successful fetch of host storage and fabric; ram scm tier; low mem": {
+		"dcpm scm; control_metadata path set": {
+			extMetadataPath: metadataMountPath,
+			hostResponsesSet: [][]*control.HostResponse{
+				{netHostResp},
+				{storHostResp},
+			},
+			expErr: errors.New("only supported with scm class ram"),
+		},
+		"tmpfs scm; md-on-ssd; low mem": {
 			tmpfsSCM:        true,
 			extMetadataPath: metadataMountPath,
 			hostResponsesSet: [][]*control.HostResponse{
@@ -277,27 +458,27 @@ func TestAuto_confGen(t *testing.T) {
 			},
 			expErr: errors.New("insufficient ram"),
 		},
-		"successful fetch of host storage and fabric; tmpfs scm": {
+		"tmpfs scm; md-on-ssd": {
 			tmpfsSCM:        true,
 			extMetadataPath: metadataMountPath,
 			hostResponsesSet: [][]*control.HostResponse{
 				{netHostResp},
 				{storHostRespHighMem},
 			},
-			expCfg: control.MockServerCfg("ofi+psm2", tmpfsEngineCfgs).
+			expCfg: control.MockServerCfg("ofi+psm2", mdonssdEngineCfgs).
 				// 16+1 (MD-on-SSD extra sys-XS) targets * 2 engines * 512 pages
 				WithNrHugepages(17 * 2 * 512).
 				WithControlLogFile("/tmp/daos_server.log").
 				WithControlMetadata(controlMetadata),
 		},
-		"successful tmpfs scm; no logging to stdout": {
+		"tmpfs scm; md-on-ssd; no logging to stdout": {
 			tmpfsSCM:        true,
 			extMetadataPath: metadataMountPath,
 			hostResponsesSet: [][]*control.HostResponse{
 				{netHostResp},
 				{storHostRespHighMem},
 			},
-			expCfg: control.MockServerCfg("ofi+psm2", tmpfsEngineCfgs).
+			expCfg: control.MockServerCfg("ofi+psm2", mdonssdEngineCfgs).
 				// 16+1 (MD-on-SSD extra sys-XS) targets * 2 engines * 512 pages
 				WithNrHugepages(17 * 2 * 512).
 				WithControlLogFile("/tmp/daos_server.log").
@@ -316,14 +497,13 @@ func TestAuto_confGen(t *testing.T) {
 			if tc.accessPoints == "" {
 				tc.accessPoints = "localhost"
 			}
-			cmd := &configGenCmd{
-				AccessPoints:    tc.accessPoints,
-				NrEngines:       tc.nrEngines,
-				SCMOnly:         tc.scmOnly,
-				NetClass:        tc.netClass,
-				UseTmpfsSCM:     tc.tmpfsSCM,
-				ExtMetadataPath: tc.extMetadataPath,
-			}
+			cmd := &configGenCmd{}
+			cmd.AccessPoints = tc.accessPoints
+			cmd.NrEngines = tc.nrEngines
+			cmd.SCMOnly = tc.scmOnly
+			cmd.NetClass = tc.netClass
+			cmd.UseTmpfsSCM = tc.tmpfsSCM
+			cmd.ExtMetadataPath = tc.extMetadataPath
 			log.SetLevel(logging.LogLevelInfo)
 			cmd.Logger = log
 			cmd.hostlist = tc.hostlist

--- a/src/control/cmd/dmg/command_test.go
+++ b/src/control/cmd/dmg/command_test.go
@@ -16,9 +16,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -171,9 +173,81 @@ func (bci *bridgeConnInvoker) InvokeUnaryRPC(ctx context.Context, uReq control.U
 		resp = control.MockMSResponse("", nil, &mgmtpb.DaosResp{})
 	case *control.SystemGetPropReq:
 		resp = control.MockMSResponse("", nil, &mgmtpb.SystemGetPropResp{})
+	case *control.NetworkScanReq:
+		resp = &control.UnaryResponse{
+			Responses: []*control.HostResponse{
+				{
+					Addr: "host1",
+					Message: &ctlpb.NetworkScanResp{
+						Interfaces: []*ctlpb.FabricInterface{
+							{
+								Provider:    "test-provider",
+								Device:      "test-device",
+								Netdevclass: uint32(hardware.Infiniband),
+							},
+						},
+						Numacount:    1,
+						Corespernuma: 2,
+					},
+				},
+			},
+		}
+	case *control.StorageScanReq:
+		resp = &control.UnaryResponse{
+			Responses: []*control.HostResponse{
+				{
+					Addr: "host1",
+					Message: &ctlpb.StorageScanResp{
+						Scm: &ctlpb.ScanScmResp{
+							Namespaces: []*ctlpb.ScmNamespace{
+								{},
+							},
+						},
+						Nvme: &ctlpb.ScanNvmeResp{
+							Ctrlrs: []*ctlpb.NvmeController{
+								{PciAddr: "0000:80:0.0"},
+							},
+						},
+						MemInfo: &ctlpb.MemInfo{
+							HugepageSizeKb: 2048,
+						},
+					},
+				},
+			},
+		}
 	}
 
 	return resp, nil
+}
+
+func runCmdTest(t *testing.T, cmd, expectedCalls string, expectedErr error) {
+	t.Helper()
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	ctlClient := control.DefaultMockInvoker(log)
+	conn := newTestConn(t)
+	bridge := &bridgeConnInvoker{
+		MockInvoker: *ctlClient,
+		t:           t,
+		conn:        conn,
+	}
+	err := runCmd(t, cmd, log, bridge)
+	if err != expectedErr {
+		if expectedErr == nil {
+			t.Fatalf("expected nil error, got %+v", err)
+		}
+
+		if err == nil {
+			t.Fatalf("expected err '%v', got nil", expectedErr)
+		}
+
+		testExpectedError(t, expectedErr, err)
+		return
+	}
+	if diff := cmp.Diff(expectedCalls, strings.Join(conn.called, " ")); diff != "" {
+		t.Fatalf("unexpected function calls (-want, +got):\n%s\n", diff)
+	}
 }
 
 func runCmdTests(t *testing.T, cmdTests []cmdTest) {
@@ -181,33 +255,7 @@ func runCmdTests(t *testing.T, cmdTests []cmdTest) {
 
 	for _, st := range cmdTests {
 		t.Run(st.name, func(t *testing.T) {
-			t.Helper()
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
-
-			ctlClient := control.DefaultMockInvoker(log)
-			conn := newTestConn(t)
-			bridge := &bridgeConnInvoker{
-				MockInvoker: *ctlClient,
-				t:           t,
-				conn:        conn,
-			}
-			err := runCmd(t, st.cmd, log, bridge)
-			if err != st.expectedErr {
-				if st.expectedErr == nil {
-					t.Fatalf("expected nil error, got %+v", err)
-				}
-
-				if err == nil {
-					t.Fatalf("expected err '%v', got nil", st.expectedErr)
-				}
-
-				testExpectedError(t, st.expectedErr, err)
-				return
-			}
-			if diff := cmp.Diff(st.expectedCalls, strings.Join(conn.called, " ")); diff != "" {
-				t.Fatalf("unexpected function calls (-want, +got):\n%s\n", diff)
-			}
+			runCmdTest(t, st.cmd, st.expectedCalls, st.expectedErr)
 		})
 	}
 }

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -535,7 +535,8 @@ func (cmd *PoolExtendCmd) Execute(args []string) error {
 	msg := "succeeded"
 
 	req := &control.PoolExtendReq{
-		ID: cmd.PoolID().String(), Ranks: cmd.RankList.Ranks(),
+		ID:    cmd.PoolID().String(),
+		Ranks: cmd.RankList.Ranks(),
 	}
 
 	err := control.PoolExtend(context.Background(), cmd.ctlInvoker, req)
@@ -565,7 +566,11 @@ func (cmd *PoolReintegrateCmd) Execute(args []string) error {
 		return err
 	}
 
-	req := &control.PoolReintegrateReq{ID: cmd.PoolID().String(), Rank: ranklist.Rank(cmd.Rank), Targetidx: idxlist}
+	req := &control.PoolReintegrateReq{
+		ID:        cmd.PoolID().String(),
+		Rank:      ranklist.Rank(cmd.Rank),
+		Targetidx: idxlist,
+	}
 
 	err := control.PoolReintegrate(context.Background(), cmd.ctlInvoker, req)
 	if err != nil {

--- a/src/control/common/cmdutil/auto.go
+++ b/src/control/common/cmdutil/auto.go
@@ -1,0 +1,12 @@
+package cmdutil
+
+type ConfGenCmd struct {
+	AccessPoints    string `default:"localhost" short:"a" long:"access-points" description:"Comma separated list of access point addresses <ipv4addr/hostname> to host management service"`
+	NrEngines       int    `short:"e" long:"num-engines" description:"Set the number of DAOS Engine sections to be populated in the config file output. If unset then the value will be set to the number of NUMA nodes on storage hosts in the DAOS system."`
+	SCMOnly         bool   `short:"s" long:"scm-only" description:"Create a SCM-only config without NVMe SSDs."`
+	NetClass        string `default:"infiniband" short:"c" long:"net-class" description:"Set the network device class to be used" choice:"ethernet" choice:"infiniband"`
+	NetProvider     string `short:"p" long:"net-provider" description:"Set the network fabric provider to be used"`
+	UseTmpfsSCM     bool   `short:"t" long:"use-tmpfs-scm" description:"Use tmpfs for scm rather than PMem"`
+	ExtMetadataPath string `short:"m" long:"control-metadata-path" description:"External storage path to store control metadata. Set this to a persistent location and specify --use-tmpfs-scm to create an MD-on-SSD config"`
+	FabricPorts     string `short:"f" long:"fabric-ports" description:"Allow custom fabric interface ports to be specified for each engine config section. Comma separated port numbers, one per engine"`
+}

--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -8,10 +8,13 @@ package control
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/bits"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -50,14 +53,23 @@ var errNoNuma = errors.New("zero numa nodes reported on hosts")
 type (
 	// ConGenerateReq contains the inputs for the request.
 	ConfGenerateReq struct {
-		NrEngines       int
-		NetClass        hardware.NetDevClass
-		NetProvider     string
-		SCMOnly         bool // generate a config without nvme
-		UseTmpfsSCM     bool
-		AccessPoints    []string
-		ExtMetadataPath string
-		Log             logging.Logger
+		// Number of engines to include in generated config.
+		NrEngines int `json:"NrEngines"`
+		// Force use of a specific network device class for fabric comms.
+		NetClass hardware.NetDevClass `json:"-"`
+		// Force use of a specific fabric provider.
+		NetProvider string `json:"NetProvider"`
+		// Generate a config without NVMe.
+		SCMOnly bool `json:"SCMOnly"`
+		// Hosts to run the management service.
+		AccessPoints []string `json:"-"`
+		// Ports to use for fabric comms (one needed per engine).
+		FabricPorts []int `json:"-"`
+		// Generate config with a tmpfs RAM-disk SCM.
+		UseTmpfsSCM bool `json:"UseTmpfsSCM"`
+		// Location to persist control-plane metadata, will generate MD-on-SSD config.
+		ExtMetadataPath string         `json:"ExtMetadataPath"`
+		Log             logging.Logger `json:"-"`
 	}
 
 	// ConfGenerateResp contains the generated server config.
@@ -83,6 +95,47 @@ type (
 		HostErrorsResp
 	}
 )
+
+// UnmarshalJSON unpacks JSON message into ConfGenerateReq struct.
+func (cgr *ConfGenerateReq) UnmarshalJSON(data []byte) error {
+	type Alias ConfGenerateReq
+	aux := &struct {
+		AccessPoints string
+		FabricPorts  string
+		NetClass     string
+		*Alias
+	}{
+		Alias: (*Alias)(cgr),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	cgr.AccessPoints = strings.Split(aux.AccessPoints, ",")
+	fabricPorts := strings.Split(aux.FabricPorts, ",")
+	for _, s := range fabricPorts {
+		if s == "" {
+			continue
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return errors.Wrap(err, "fabric ports")
+		}
+		cgr.FabricPorts = append(cgr.FabricPorts, n)
+	}
+
+	switch aux.NetClass {
+	case "ethernet":
+		cgr.NetClass = hardware.Ether
+	case "infiniband":
+		cgr.NetClass = hardware.Infiniband
+	default:
+		return errors.Errorf("unrecognized net-class value %s", aux.NetClass)
+	}
+
+	return nil
+}
 
 func (cge *ConfGenerateError) Error() string {
 	return cge.Errors().Error()
@@ -110,25 +163,25 @@ func DefaultEngineCfg(idx int) *engine.Config {
 // hardware by evaluating affinity matches for NUMA node combinations.
 func ConfGenerate(req ConfGenerateReq, newEngineCfg newEngineCfgFn, hf *HostFabric, hs *HostStorage) (*ConfGenerateResp, error) {
 	// process host fabric scan results to retrieve network details
-	nd, err := getNetworkDetails(req.Log, req.NetClass, req.NetProvider, hf)
+	nd, err := getNetworkDetails(req, hf)
 	if err != nil {
 		return nil, err
 	}
 
 	// process host storage scan results to retrieve storage details
-	sd, err := getStorageDetails(req.Log, req.UseTmpfsSCM, nd.NumaCount, hs)
+	sd, err := getStorageDetails(req, nd.NumaCount, hs)
 	if err != nil {
 		return nil, err
 	}
 
 	// evaluate device affinities to enforce locality constraints
-	nodeSet, err := filterDevicesByAffinity(req.Log, req.NrEngines, req.SCMOnly, nd, sd)
+	nodeSet, err := filterDevicesByAffinity(req, nd, sd)
 	if err != nil {
 		return nil, err
 	}
 
 	// populate engine configs with storage and network devices
-	ecs, err := genEngineConfigs(req.Log, req.SCMOnly, newEngineCfg, nodeSet, nd, sd)
+	ecs, err := genEngineConfigs(req, newEngineCfg, nodeSet, nd, sd)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +193,7 @@ func ConfGenerate(req ConfGenerateReq, newEngineCfg newEngineCfgFn, hf *HostFabr
 	}
 
 	// populate server config using engine configs
-	sc, err := genServerConfig(req.Log, req.AccessPoints, req.ExtMetadataPath, ecs, sd.MemInfo, tc)
+	sc, err := genServerConfig(req, ecs, sd.MemInfo, tc)
 	if err != nil {
 		return nil, err
 	}
@@ -162,12 +215,12 @@ func ConfGenerateRemote(ctx context.Context, req ConfGenerateRemoteReq) (*ConfGe
 		return nil, errors.New("no access points specified")
 	}
 
-	ns, err := getNetworkSet(ctx, req.Log, req.HostList, req.Client)
+	ns, err := getNetworkSet(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
-	ss, err := getStorageSet(ctx, req.Log, req.HostList, req.Client)
+	ss, err := getStorageSet(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -185,15 +238,15 @@ func ConfGenerateRemote(ctx context.Context, req ConfGenerateRemoteReq) (*ConfGe
 // getNetworkSet retrieves the result of network scan over host list and verifies that there is
 // only a single network set in response which indicates that network hardware setup is homogeneous
 // across all hosts.  Return host errors, network scan results for the host set or error.
-func getNetworkSet(ctx context.Context, log logging.Logger, hostList []string, client UnaryInvoker) (*HostFabricSet, error) {
-	log.Debugf("fetching host fabric info on hosts %v", hostList)
+func getNetworkSet(ctx context.Context, req ConfGenerateRemoteReq) (*HostFabricSet, error) {
+	req.Log.Debugf("fetching host fabric info on hosts %v", req.HostList)
 
 	scanReq := &NetworkScanReq{
 		Provider: "all", // explicitly request all providers
 	}
-	scanReq.SetHostList(hostList)
+	scanReq.SetHostList(req.HostList)
 
-	scanResp, err := NetworkScan(ctx, client, scanReq)
+	scanResp, err := NetworkScan(ctx, req.Client, scanReq)
 	if err != nil {
 		return nil, err
 	}
@@ -210,11 +263,11 @@ func getNetworkSet(ctx context.Context, log logging.Logger, hostList []string, c
 		// success
 	default:
 		// more than one means non-homogeneous hardware
-		log.Info("Heterogeneous network hardware configurations detected, " +
+		req.Log.Info("Heterogeneous network hardware configurations detected, " +
 			"cannot proceed. The following sets of hosts have different " +
 			"network hardware:")
 		for _, hns := range scanResp.HostFabrics {
-			log.Info(hns.HostSet.String())
+			req.Log.Info(hns.HostSet.String())
 		}
 
 		return nil, errors.New("network hardware not consistent across hosts")
@@ -222,7 +275,7 @@ func getNetworkSet(ctx context.Context, log logging.Logger, hostList []string, c
 
 	networkSet := scanResp.HostFabrics[scanResp.HostFabrics.Keys()[0]]
 
-	log.Debugf("Network hardware is consistent for hosts %s:\n\t%v",
+	req.Log.Debugf("Network hardware is consistent for hosts %s:\n\t%v",
 		networkSet.HostSet, networkSet.HostFabric.Interfaces)
 
 	return networkSet, nil
@@ -303,22 +356,23 @@ type networkDetails struct {
 
 // getNetworkDetails retrieves fabric network interfaces that can be used in server config file.
 // Return interfaces mapped first by NUMA then provider and per-NUMA core count.
-func getNetworkDetails(log logging.Logger, ndc hardware.NetDevClass, prov string, hf *HostFabric) (*networkDetails, error) {
+func getNetworkDetails(req ConfGenerateReq, hf *HostFabric) (*networkDetails, error) {
+
 	if hf == nil {
 		return nil, errors.New("nil HostFabric")
 	}
 
-	switch ndc {
+	switch req.NetClass {
 	case hardware.Ether, hardware.Infiniband:
 	default:
-		return nil, errors.Errorf(errUnsupNetDevClass, ndc.String())
+		return nil, errors.Errorf(errUnsupNetDevClass, req.NetClass.String())
 	}
 
 	provIfaces := make(providerIfaceMap)
-	if err := provIfaces.fromFabric(ndc, prov, hf.Interfaces); err != nil {
+	if err := provIfaces.fromFabric(req.NetClass, req.NetProvider, hf.Interfaces); err != nil {
 		return nil, err
 	}
-	log.Debugf("numa nodes: %d, numa core count: %d, available interfaces %v", hf.NumaCount,
+	req.Log.Debugf("numa nodes: %d, numa core count: %d, available interfaces %v", hf.NumaCount,
 		hf.CoresPerNuma, provIfaces)
 
 	return &networkDetails{
@@ -334,13 +388,13 @@ func getNetworkDetails(log logging.Logger, ndc hardware.NetDevClass, prov string
 // account by supplying NvmeBasic flag in scan request. This enables configuration to work with
 // different combinations of SSD models.  Return host errors, storage scan results for the host set
 // or error.
-func getStorageSet(ctx context.Context, log logging.Logger, hostList []string, client UnaryInvoker) (*HostStorageSet, error) {
-	log.Debugf("fetching host storage info on hosts %v", hostList)
+func getStorageSet(ctx context.Context, req ConfGenerateRemoteReq) (*HostStorageSet, error) {
+	req.Log.Debugf("fetching host storage info on hosts %v", req.HostList)
 
 	scanReq := &StorageScanReq{NvmeBasic: true}
-	scanReq.SetHostList(hostList)
+	scanReq.SetHostList(req.HostList)
 
-	scanResp, err := StorageScan(ctx, client, scanReq)
+	scanResp, err := StorageScan(ctx, req.Client, scanReq)
 	if err != nil {
 		return nil, err
 	}
@@ -356,11 +410,11 @@ func getStorageSet(ctx context.Context, log logging.Logger, hostList []string, c
 		// success
 	default:
 		// more than one means non-homogeneous hardware
-		log.Info("Heterogeneous storage hardware configurations detected, " +
+		req.Log.Info("Heterogeneous storage hardware configurations detected, " +
 			"cannot proceed. The following sets of hosts have different " +
 			"storage hardware:")
 		for _, hss := range scanResp.HostStorage {
-			log.Info(hss.HostSet.String())
+			req.Log.Info(hss.HostSet.String())
 		}
 
 		return nil, errors.New("storage hardware not consistent across hosts")
@@ -369,7 +423,7 @@ func getStorageSet(ctx context.Context, log logging.Logger, hostList []string, c
 	storageSet := scanResp.HostStorage[scanResp.HostStorage.Keys()[0]]
 	hostStorage := storageSet.HostStorage
 
-	log.Debugf("Storage hardware is consistent for hosts %s:\n\t%s\n\t%s\n\t%s",
+	req.Log.Debugf("Storage hardware is consistent for hosts %s:\n\t%s\n\t%s\n\t%s",
 		storageSet.HostSet.String(), hostStorage.ScmNamespaces.Summary(),
 		hostStorage.NvmeDevices.Summary(), hostStorage.MemInfo.Summary())
 
@@ -454,7 +508,7 @@ type storageDetails struct {
 
 // getStorageDetails retrieves mappings of NUMA node to PMem and NVMe SSD devices.  Returns storage
 // details struct or host error response and outer error.
-func getStorageDetails(log logging.Logger, useTmpfs bool, numaCount int, hs *HostStorage) (*storageDetails, error) {
+func getStorageDetails(req ConfGenerateReq, numaCount int, hs *HostStorage) (*storageDetails, error) {
 	if hs == nil {
 		return nil, errors.New("nil HostStorage")
 	}
@@ -480,7 +534,7 @@ func getStorageDetails(log logging.Logger, useTmpfs bool, numaCount int, hs *Hos
 	}
 
 	// if tmpfs scm mode is requested, init scm map to init entry for each numa node
-	if useTmpfs {
+	if req.UseTmpfsSCM {
 		if numaCount <= 0 {
 			return nil, errors.New("requires nonzero numaCount")
 		}
@@ -488,7 +542,7 @@ func getStorageDetails(log logging.Logger, useTmpfs bool, numaCount int, hs *Hos
 			return nil, errors.New("requires nonzero MemTotalKiB")
 		}
 
-		log.Debugf("using tmpfs for scm, one for each numa node [0-%d]", numaCount-1)
+		req.Log.Debugf("using tmpfs for scm, one for each numa node [0-%d]", numaCount-1)
 		for i := 0; i < numaCount; i++ {
 			sd.NumaSCMs[i] = sort.StringSlice{""}
 		}
@@ -507,16 +561,17 @@ func getStorageDetails(log logging.Logger, useTmpfs bool, numaCount int, hs *Hos
 // Filters PMem and SSD groups to include only the NUMA IDs that have sufficient number of devices
 // with appropriate affinity. Returns error if not enough satisfied NUMA ID groupings for required
 // engine count.
-func checkNvmeAffinity(log logging.Logger, engineCount int, scmOnly bool, sd *storageDetails) error {
-	log.Debugf("numa to pmem mappings: %v", sd.NumaSCMs)
-	log.Debugf("numa to nvme mappings: %v", sd.NumaSSDs)
+func checkNvmeAffinity(req ConfGenerateReq, sd *storageDetails) error {
+	req.Log.Debugf("numa to pmem mappings: %v", sd.NumaSCMs)
+	req.Log.Debugf("numa to nvme mappings: %v", sd.NumaSSDs)
 
-	if len(sd.NumaSCMs) < engineCount {
-		return errors.Errorf(errInsufNrPMemGroups, sd.NumaSCMs, engineCount, len(sd.NumaSCMs))
+	if len(sd.NumaSCMs) < req.NrEngines {
+		return errors.Errorf(errInsufNrPMemGroups, sd.NumaSCMs, req.NrEngines,
+			len(sd.NumaSCMs))
 	}
 
-	if scmOnly {
-		log.Debug("nvme disabled, skip validation")
+	if req.SCMOnly {
+		req.Log.Debug("nvme disabled, skip validation")
 
 		// set empty ssd lists for relevant numa ids
 		sd.NumaSSDs = make(numaSSDsMap)
@@ -538,18 +593,18 @@ func checkNvmeAffinity(log logging.Logger, engineCount int, scmOnly bool, sd *st
 
 	switch {
 	case len(pass) > 0 && len(fail) > 0:
-		log.Debugf("ssd requirements met for numa ids %v but not for %v", pass, fail)
+		req.Log.Debugf("ssd requirements met for numa ids %v but not for %v", pass, fail)
 	case len(pass) > 0:
-		log.Debugf("ssd requirements met for numa ids %v", pass)
+		req.Log.Debugf("ssd requirements met for numa ids %v", pass)
 	default:
-		log.Debugf("ssd requirements not met for numa ids %v", fail)
+		req.Log.Debugf("ssd requirements not met for numa ids %v", fail)
 	}
 
-	if len(pass) < engineCount {
+	if len(pass) < req.NrEngines {
 		// fail if the number of passing numa id groups is less than required
-		log.Errorf("ssd-to-numa mapping validation failed, not enough numaID groupings "+
+		req.Log.Errorf("ssd-to-numa mapping validation failed, not enough numaID groupings "+
 			"satisfy SSD requirements (%d per-engine) to meet the number of required "+
-			"engines (%d)", minNrSSDs, engineCount)
+			"engines (%d)", minNrSSDs, req.NrEngines)
 
 		// print first failing numa id details in returned error
 		for _, numaID := range sd.NumaSCMs.keys() {
@@ -569,7 +624,7 @@ func checkNvmeAffinity(log logging.Logger, engineCount int, scmOnly bool, sd *st
 		delete(sd.NumaSCMs, idx)
 		delete(sd.NumaSSDs, idx)
 	}
-	log.Debugf("storage validation passed, scm: %+v, nvme: %+v", sd.NumaSCMs,
+	req.Log.Debugf("storage validation passed, scm: %+v, nvme: %+v", sd.NumaSCMs,
 		sd.NumaSSDs)
 
 	return nil
@@ -746,17 +801,18 @@ func lowestCommonNrSSDs(nodeSet []int, numaSSDs numaSSDsMap) (int, error) {
 
 // Generate scores for interfaces supporting a specific provider across a set of NUMA nodes whose
 // length matches engineCount. Score is sum of interface priority values. Choose lowest score.
-func chooseEngineAffinity(log logging.Logger, engineCount int, nd *networkDetails, sd *storageDetails) ([]int, error) {
+func chooseEngineAffinity(req ConfGenerateReq, nd *networkDetails, sd *storageDetails) ([]int, error) {
 	nodes := sd.NumaSCMs.keys()
 
 	// retrieve numa node combinations that meet storage requirements for an engine config
-	nodeSets := combinations(nodes, engineCount)
+	nodeSets := combinations(nodes, req.NrEngines)
 	if len(nodeSets) == 0 {
 		return nil, errors.New("no numa node sets found in scm map")
 	}
-	log.Debugf("numasets for possible engine configs: %v (from superset %v)", nodeSets, nodes)
+	req.Log.Debugf("numasets for possible engine configs: %v (from superset %v)", nodeSets,
+		nodes)
 
-	fabricScores, err := getFabricScores(log, nodeSets, nd)
+	fabricScores, err := getFabricScores(req.Log, nodeSets, nd)
 	if err != nil {
 		return nil, err
 	}
@@ -798,7 +854,8 @@ func chooseEngineAffinity(log logging.Logger, engineCount int, nd *networkDetail
 	if len(bestNumaSet) == 0 || bestFabric == nil {
 		return nil, errors.New(errInsufNrProvGroups)
 	}
-	log.Debugf("fabric provider %s chosen on numa nodes %v", bestFabric.provider, bestNumaSet)
+	req.Log.Debugf("fabric provider %s chosen on numa nodes %v", bestFabric.provider,
+		bestNumaSet)
 
 	// populate specific fabric interfaces to use for each numa node
 	nd.NumaIfaces = make(numaNetIfaceMap)
@@ -813,17 +870,17 @@ func chooseEngineAffinity(log logging.Logger, engineCount int, nd *networkDetail
 	// trim any storage device groupings for numa ids that are unsuitable for engine configs
 	trimStorageDeviceMaps(bestNumaSet, sd)
 
-	// sanity check that the number of satisfied numa id groups matches number of engines required
-	if len(nd.NumaIfaces) != engineCount {
-		return nil, errors.Errorf(errInsufNrIfaces, engineCount, len(nd.NumaIfaces),
+	// sanity check number of satisfied numa id groups matches number of engines required
+	if len(nd.NumaIfaces) != req.NrEngines {
+		return nil, errors.Errorf(errInsufNrIfaces, req.NrEngines, len(nd.NumaIfaces),
 			nd.NumaIfaces)
 	}
-	if len(sd.NumaSCMs) != engineCount {
-		return nil, errors.Errorf(errInsufNrPMemGroups, sd.NumaSCMs, engineCount,
+	if len(sd.NumaSCMs) != req.NrEngines {
+		return nil, errors.Errorf(errInsufNrPMemGroups, sd.NumaSCMs, req.NrEngines,
 			len(sd.NumaSCMs))
 	}
-	if len(sd.NumaSSDs) != engineCount {
-		return nil, errors.Errorf(errInsufNrSSDGroups, sd.NumaSSDs, engineCount,
+	if len(sd.NumaSSDs) != req.NrEngines {
+		return nil, errors.Errorf(errInsufNrSSDGroups, sd.NumaSSDs, req.NrEngines,
 			len(sd.NumaSSDs))
 	}
 
@@ -831,22 +888,22 @@ func chooseEngineAffinity(log logging.Logger, engineCount int, nd *networkDetail
 	return bestNumaSet, nil
 }
 
-func filterDevicesByAffinity(log logging.Logger, nrEngines int, scmOnly bool, nd *networkDetails, sd *storageDetails) ([]int, error) {
+func filterDevicesByAffinity(req ConfGenerateReq, nd *networkDetails, sd *storageDetails) ([]int, error) {
 	// if unset, assign number of engines based on number of NUMA nodes
-	if nrEngines == 0 {
-		nrEngines = nd.NumaCount
+	if req.NrEngines == 0 {
+		req.NrEngines = nd.NumaCount
 	}
-	if nrEngines == 0 {
+	if req.NrEngines == 0 {
 		return nil, errNoNuma
 	}
 
-	log.Debugf("attempting to generate config with %d engines", nrEngines)
+	req.Log.Debugf("attempting to generate config with %d engines", req.NrEngines)
 
-	if err := checkNvmeAffinity(log, nrEngines, scmOnly, sd); err != nil {
+	if err := checkNvmeAffinity(req, sd); err != nil {
 		return nil, err
 	}
 
-	nodeSet, err := chooseEngineAffinity(log, nrEngines, nd, sd)
+	nodeSet, err := chooseEngineAffinity(req, nd, sd)
 	if err != nil {
 		return nil, err
 	}
@@ -918,22 +975,19 @@ func getSCMTier(log logging.Logger, numaID, nrNumaNodes int, sd *storageDetails)
 	return scmTier, nil
 }
 
-func getBdevTiers(log logging.Logger, scmCls storage.Class, ssds *hardware.PCIAddressSet) (storage.TierConfigs, error) {
+func getBdevTiers(log logging.Logger, mdOnSSD bool, ssds *hardware.PCIAddressSet) (storage.TierConfigs, error) {
 	nrSSDs := ssds.Len()
 	if nrSSDs == 0 {
 		log.Debugf("skip assigning ssd tiers as no ssds are available")
 		return nil, nil
 	}
 
-	if scmCls == storage.ClassDcpm {
+	if !mdOnSSD {
 		return storage.TierConfigs{
 			storage.NewTierConfig().
 				WithStorageClass(storage.ClassNvme.String()).
 				WithBdevDeviceList(ssds.Strings()...),
 		}, nil
-	}
-	if scmCls != storage.ClassRam {
-		return nil, errors.New("only scm classes dcpm (pmem) and ram supported")
 	}
 
 	// Assign SSDs to multiple tiers for MD-on-SSD, NVMe SSDs on same NUMA as
@@ -973,7 +1027,13 @@ func getBdevTiers(log logging.Logger, scmCls storage.Class, ssds *hardware.PCIAd
 
 type newEngineCfgFn func(int) *engine.Config
 
-func genEngineConfigs(log logging.Logger, scmOnly bool, newEngineCfg newEngineCfgFn, nodeSet []int, nd *networkDetails, sd *storageDetails) ([]*engine.Config, error) {
+func genEngineConfigs(req ConfGenerateReq, newEngineCfg newEngineCfgFn, nodeSet []int, nd *networkDetails, sd *storageDetails) ([]*engine.Config, error) {
+	nrFabPorts := len(req.FabricPorts)
+	if nrFabPorts > 0 && nrFabPorts < len(nodeSet) {
+		return nil, errors.Errorf("insufficient fabric ports for nr engines, want %d got %d",
+			len(nodeSet), nrFabPorts)
+	}
+
 	// first sanity check required component groups
 	for _, numaID := range nodeSet {
 		if len(sd.NumaSCMs[numaID]) == 0 {
@@ -988,27 +1048,32 @@ func genEngineConfigs(log logging.Logger, scmOnly bool, newEngineCfg newEngineCf
 	}
 
 	// if nvme is enabled, make ssd counts consistent across numa groupings
-	if !scmOnly {
-		if err := correctSSDCounts(log, sd); err != nil {
+	if !req.SCMOnly {
+		if err := correctSSDCounts(req.Log, sd); err != nil {
 			return nil, err
 		}
 	}
 
 	cfgs := make([]*engine.Config, 0, len(nodeSet))
 
-	log.Debugf("calculating storage tiers for engines based on scm class %q", sd.scmCls)
+	req.Log.Debugf("calculating storage tiers for engines based on scm class %q", sd.scmCls)
 
-	for _, numaID := range nodeSet {
+	mdOnSSD := req.ExtMetadataPath != ""
+	if mdOnSSD && sd.scmCls != storage.ClassRam {
+		return nil, errors.New("md-on-ssd mode is only supported with scm class ram")
+	}
+
+	for idx, numaID := range nodeSet {
 		ssds := sd.NumaSSDs[numaID]
 		iface := nd.NumaIfaces[numaID]
 
-		scmTier, err := getSCMTier(log, numaID, len(nodeSet), sd)
+		scmTier, err := getSCMTier(req.Log, numaID, len(nodeSet), sd)
 		if err != nil {
 			return nil, err
 		}
 		tiers := storage.TierConfigs{scmTier}
 
-		bdevTiers, err := getBdevTiers(log, sd.scmCls, ssds)
+		bdevTiers, err := getBdevTiers(req.Log, mdOnSSD, ssds)
 		if err != nil {
 			return nil, errors.Wrapf(err, "calculating bdev tiers")
 		}
@@ -1016,12 +1081,17 @@ func genEngineConfigs(log logging.Logger, scmOnly bool, newEngineCfg newEngineCf
 
 		cfg := newEngineCfg(len(cfgs)).WithStorage(tiers...)
 
+		ifPort := int(defaultFiPort + (idx * defaultFiPortInterval))
+		if nrFabPorts > 0 {
+			ifPort = req.FabricPorts[idx]
+		}
+
 		pnn := uint(numaID)
 		cfg.PinnedNumaNode = &pnn
 		cfg.Fabric = engine.FabricConfig{
 			Provider:      iface.Provider,
 			Interface:     iface.Device,
-			InterfacePort: int(defaultFiPort + (numaID * defaultFiPortInterval)),
+			InterfacePort: ifPort,
 		}
 		if err := cfg.SetNUMAAffinity(pnn); err != nil {
 			return nil, errors.Wrapf(err, "setting numa %d affinity on engine config",
@@ -1103,53 +1173,81 @@ func getThreadCounts(log logging.Logger, ec *engine.Config, coresPerEngine int) 
 	return &tc, nil
 }
 
+// check that all access points either have no port specified or have the same port number.
+func checkAccessPointPorts(log logging.Logger, aps []string) (int, error) {
+	if len(aps) == 0 {
+		return 0, errors.New("no access points")
+	}
+
+	port := -1
+	for _, ap := range aps {
+		apPort, err := config.GetAccessPointPort(log, ap)
+		if err != nil {
+			return 0, errors.Wrapf(err, "access point %q", ap)
+		}
+		if port == -1 {
+			port = apPort
+			continue
+		}
+		if apPort != port {
+			return 0, errors.New("access point port numbers do not match")
+		}
+	}
+
+	return port, nil
+}
+
 // Generate a server config file from the constituent hardware components. Enforce consistent
 // target and helper count across engine configs necessary for optimum performance and populate
 // config parameters. Set NUMA affinity on the generated config and then run through validation.
-func genServerConfig(log logging.Logger, accessPoints []string, extMetadataPath string, ecs []*engine.Config, mi *common.MemInfo, tc *threadCounts) (*config.Server, error) {
+func genServerConfig(req ConfGenerateReq, ecs []*engine.Config, mi *common.MemInfo, tc *threadCounts) (*config.Server, error) {
 	if len(ecs) == 0 {
 		return nil, errors.New("expected non-zero number of engine configs")
 	}
 
-	log.Debugf("setting %d targets and %d helper threads per engine", tc.nrTgts, tc.nrHlprs)
+	req.Log.Debugf("setting %d targets and %d helper threads per engine", tc.nrTgts, tc.nrHlprs)
 	for _, ec := range ecs {
 		ec.WithTargetCount(tc.nrTgts).WithHelperStreamCount(tc.nrHlprs)
 	}
 
 	cfg := config.DefaultServer().
-		WithAccessPoints(accessPoints...).
+		WithAccessPoints(req.AccessPoints...).
 		WithFabricProvider(ecs[0].Fabric.Provider).
 		WithEngines(ecs...).
 		WithControlLogFile(defaultControlLogFile)
 
-	// TODO: Add capability to create an ephemeral RAM-disk based configuration as currently
-	//       MD-on-SSD enabled conf will be generated whenever scm tier is tmpfs.
 	for idx := range cfg.Engines {
 		tiers := cfg.Engines[idx].Storage.Tiers
-		if err := tiers.AssignBdevTierRoles(); err != nil {
+		if err := tiers.AssignBdevTierRoles(req.ExtMetadataPath); err != nil {
 			return nil, errors.Wrapf(err, "assigning engine %d storage bdev tier roles",
 				idx)
 		}
 		// Add default control_metadata path if roles have been assigned.
 		if idx == 0 && tiers.HasBdevRoleMeta() {
-			if extMetadataPath == "" {
-				return nil, errors.New("no external metadata path specified in request")
-			}
 			cfg.Metadata = storage.ControlMetadata{
-				Path: extMetadataPath,
+				Path: req.ExtMetadataPath,
 			}
 		}
 	}
 
-	if err := cfg.Validate(log); err != nil {
+	portNum, err := checkAccessPointPorts(req.Log, cfg.AccessPoints)
+	if err != nil {
+		return nil, err
+	}
+	if portNum != 0 {
+		// Custom access point port number specified so set server port to the same.
+		cfg.WithControlPort(portNum)
+	}
+
+	if err := cfg.Validate(req.Log); err != nil {
 		return nil, errors.Wrap(err, "validating engine config")
 	}
 
-	if err := cfg.SetNrHugepages(log, mi); err != nil {
+	if err := cfg.SetNrHugepages(req.Log, mi); err != nil {
 		return nil, err
 	}
 
-	if err := cfg.SetRamdiskSize(log, mi); err != nil {
+	if err := cfg.SetRamdiskSize(req.Log, mi); err != nil {
 		return nil, err
 	}
 

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -125,7 +125,11 @@ func pbIfs2ProvMap(t *testing.T, ifs []*ctlpb.FabricInterface, ndc hardware.NetD
 		t.Fatal(err)
 	}
 
-	nd, err := getNetworkDetails(log, ndc, "", ns.HostFabric)
+	req := ConfGenerateReq{
+		Log:      log,
+		NetClass: ndc,
+	}
+	nd, err := getNetworkDetails(req, ns.HostFabric)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +147,13 @@ func fabricFromHostResp(t *testing.T, log logging.Logger, uErr error, hostRespon
 		},
 	})
 
-	return getNetworkSet(test.Context(t), log, []string{}, mi)
+	req := ConfGenerateRemoteReq{
+		HostList: []string{},
+		Client:   mi,
+	}
+	req.ConfGenerateReq.Log = log
+
+	return getNetworkSet(test.Context(t), req)
 }
 
 func cmpHostErrs(t *testing.T, expErrs []*MockHostError, gotErrs *HostErrorsResp) {
@@ -342,7 +352,12 @@ func TestControl_AutoConfig_getNetworkDetails(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gotNetDetails, gotErr := getNetworkDetails(log, tc.netDevClass, tc.netProvider, netSet.HostFabric)
+			req := ConfGenerateReq{
+				Log:         log,
+				NetClass:    tc.netDevClass,
+				NetProvider: tc.netProvider,
+			}
+			gotNetDetails, gotErr := getNetworkDetails(req, netSet.HostFabric)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -526,7 +541,13 @@ func TestControl_AutoConfig_getStorageSet(t *testing.T) {
 				},
 			})
 
-			storageSet, err := getStorageSet(test.Context(t), log, []string{}, mi)
+			req := ConfGenerateRemoteReq{
+				HostList: []string{},
+				Client:   mi,
+			}
+			req.ConfGenerateReq.Log = log
+
+			storageSet, err := getStorageSet(test.Context(t), req)
 			test.CmpErr(t, tc.expErr, err)
 
 			// Additionally verify any internal error details.
@@ -632,12 +653,19 @@ func TestControl_AutoConfig_getStorageDetails(t *testing.T) {
 				},
 			})
 
-			storageSet, err := getStorageSet(test.Context(t), log, []string{}, mi)
+			req := ConfGenerateRemoteReq{
+				HostList: []string{},
+				Client:   mi,
+			}
+			req.ConfGenerateReq.Log = log
+			req.UseTmpfsSCM = tc.useTmpfs
+
+			storageSet, err := getStorageSet(test.Context(t), req)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			gotStorage, gotErr := getStorageDetails(log, tc.useTmpfs, tc.numaCount,
+			gotStorage, gotErr := getStorageDetails(req.ConfGenerateReq, tc.numaCount,
 				storageSet.HostStorage)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
@@ -1013,8 +1041,13 @@ func TestControl_AutoConfig_filterDevicesByAffinity(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer test.ShowBufferOnFailure(t, buf)
 
-			gotNumaSet, gotErr := filterDevicesByAffinity(log, tc.nrEngines,
-				tc.scmOnly, &tc.nd, &tc.sd)
+			req := ConfGenerateReq{
+				Log:       log,
+				NrEngines: tc.nrEngines,
+				SCMOnly:   tc.scmOnly,
+			}
+
+			gotNumaSet, gotErr := filterDevicesByAffinity(req, &tc.nd, &tc.sd)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -1096,15 +1129,17 @@ func testEngineCfg(idx int) *engine.Config {
 
 func TestControl_AutoConfig_genEngineConfigs(t *testing.T) {
 	for name, tc := range map[string]struct {
-		scmCls     storage.Class
-		scmOnly    bool
-		memTotal   int              // available system memory for ramdisks in units of bytes
-		numaSet    []int            // set of numa nodes (by-ID) to be used for engine configs
-		numaPMems  numaSCMsMap      // numa to pmem mappings
-		numaSSDs   numaSSDsMap      // numa to ssds mappings
-		numaIfaces numaNetIfaceMap  // numa to network interface mappings
-		expCfgs    []*engine.Config // expected generated engine configs
-		expErr     error
+		scmCls          storage.Class
+		scmOnly         bool
+		extMetadataPath string
+		memTotal        int              // available system memory for ramdisks in units of bytes
+		numaSet         []int            // set of numa nodes (by-ID) to be used for engine configs
+		numaPMems       numaSCMsMap      // numa to pmem mappings
+		numaSSDs        numaSSDsMap      // numa to ssds mappings
+		numaIfaces      numaNetIfaceMap  // numa to network interface mappings
+		fabricPorts     []int            // custom fabric port numbers
+		expCfgs         []*engine.Config // expected generated engine configs
+		expErr          error
 	}{
 		"missing scm": {
 			numaSet:    []int{0},
@@ -1229,6 +1264,20 @@ func TestControl_AutoConfig_genEngineConfigs(t *testing.T) {
 				MockEngineCfg(1, 3, 4, 5),
 			},
 		},
+		"dual pmem multiple ssd; md-on-ssd": {
+			extMetadataPath: "/var/daos_md",
+			numaSet:         []int{0, 1},
+			numaPMems: numaSCMsMap{
+				0: []string{"/dev/pmem0"},
+				1: []string{"/dev/pmem1"},
+			},
+			numaIfaces: numaNetIfaceMap{0: ib0, 1: ib1},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(0, 1, 2)...),
+				1: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(3, 4, 5)...),
+			},
+			expErr: errors.New("md-on-ssd mode"),
+		},
 		"dual tmpfs; single ssd per numa": {
 			scmCls:     storage.ClassRam,
 			memTotal:   humanize.GiByte * 25,
@@ -1240,8 +1289,24 @@ func TestControl_AutoConfig_genEngineConfigs(t *testing.T) {
 				1: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(1)...),
 			},
 			expCfgs: []*engine.Config{
-				MockEngineCfgTmpfs(0, 0, mockBdevTier(0, 0)),
-				MockEngineCfgTmpfs(1, 0, mockBdevTier(1, 1)),
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 1)),
+			},
+		},
+		"dual tmpfs; single ssd per numa; md-on-ssd": {
+			scmCls:          storage.ClassRam,
+			extMetadataPath: "/var/daos_md",
+			memTotal:        humanize.GiByte * 25,
+			numaSet:         []int{0, 1},
+			numaPMems:       numaSCMsMap{0: []string{""}, 1: []string{""}},
+			numaIfaces:      numaNetIfaceMap{0: ib0, 1: ib1},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(0)...),
+				1: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(1)...),
+			},
+			expCfgs: []*engine.Config{
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 1)),
 			},
 		},
 		"dual tmpfs; three ssds per numa": {
@@ -1255,8 +1320,24 @@ func TestControl_AutoConfig_genEngineConfigs(t *testing.T) {
 				1: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(3, 4, 5)...),
 			},
 			expCfgs: []*engine.Config{
-				MockEngineCfgTmpfs(0, 0, mockBdevTier(0, 0), mockBdevTier(0, 1, 2)),
-				MockEngineCfgTmpfs(1, 0, mockBdevTier(1, 3), mockBdevTier(1, 4, 5)),
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0, 1, 2)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 3, 4, 5)),
+			},
+		},
+		"dual tmpfs; three ssds per numa; md-on-ssd": {
+			scmCls:          storage.ClassRam,
+			extMetadataPath: "/var/daos_md",
+			memTotal:        humanize.GiByte * 25,
+			numaSet:         []int{0, 1},
+			numaPMems:       numaSCMsMap{0: []string{""}, 1: []string{""}},
+			numaIfaces:      numaNetIfaceMap{0: ib0, 1: ib1},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(0, 1, 2)...),
+				1: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(3, 4, 5)...),
+			},
+			expCfgs: []*engine.Config{
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0), MockBdevTier(0, 1, 2)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 3), MockBdevTier(1, 4, 5)),
 			},
 		},
 		"dual tmpfs; six ssds per numa": {
@@ -1270,11 +1351,40 @@ func TestControl_AutoConfig_genEngineConfigs(t *testing.T) {
 				1: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(6, 7, 8, 9, 10, 11)...),
 			},
 			expCfgs: []*engine.Config{
-				MockEngineCfgTmpfs(0, 0, mockBdevTier(0, 0, 1), mockBdevTier(0, 2, 3, 4, 5)),
-				MockEngineCfgTmpfs(1, 0, mockBdevTier(1, 6, 7), mockBdevTier(1, 8, 9, 10, 11)),
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0, 1, 2, 3, 4, 5)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 6, 7, 8, 9, 10, 11)),
 			},
 		},
-		"vmd enabled; balanced nr ssds": {
+		"dual tmpfs; six ssds per numa; md-on-ssd": {
+			scmCls:          storage.ClassRam,
+			extMetadataPath: "/var/daos_md",
+			memTotal:        humanize.GiByte * 25,
+			numaSet:         []int{0, 1},
+			numaPMems:       numaSCMsMap{0: []string{""}, 1: []string{""}},
+			numaIfaces:      numaNetIfaceMap{0: ib0, 1: ib1},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(0, 1, 2, 3, 4, 5)...),
+				1: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(6, 7, 8, 9, 10, 11)...),
+			},
+			expCfgs: []*engine.Config{
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0, 1), MockBdevTier(0, 2, 3, 4, 5)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 6, 7), MockBdevTier(1, 8, 9, 10, 11)),
+			},
+		},
+		"dual tmpfs; insufficient fabric port numbers": {
+			scmCls:     storage.ClassRam,
+			memTotal:   humanize.GiByte * 25,
+			numaSet:    []int{0, 1},
+			numaPMems:  numaSCMsMap{0: []string{""}, 1: []string{""}},
+			numaIfaces: numaNetIfaceMap{0: ib0, 1: ib1},
+			numaSSDs: numaSSDsMap{
+				0: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(0, 1, 2, 3, 4, 5)...),
+				1: hardware.MustNewPCIAddressSet(test.MockPCIAddrs(6, 7, 8, 9, 10, 11)...),
+			},
+			fabricPorts: []int{12345},
+			expErr:      errors.New("insufficient fabric ports"),
+		},
+		"vmd enabled; balanced nr ssds; custom fabric port numbers": {
 			numaSet:    []int{0, 1},
 			numaPMems:  numaSCMsMap{0: []string{"/dev/pmem0"}, 1: []string{"/dev/pmem1"}},
 			numaIfaces: numaNetIfaceMap{0: ib0, 1: ib1},
@@ -1282,11 +1392,12 @@ func TestControl_AutoConfig_genEngineConfigs(t *testing.T) {
 				0: hardware.MustNewPCIAddressSet("5d0505:01:00.0", "5d0505:02:00.0"),
 				1: hardware.MustNewPCIAddressSet("d70701:03:00.0", "d70701:05:00.0"),
 			},
+			fabricPorts: []int{12345, 13345},
 			expCfgs: []*engine.Config{
 				DefaultEngineCfg(0).
 					WithPinnedNumaNode(0).
 					WithFabricInterface("ib0").
-					WithFabricInterfacePort(defaultFiPort).
+					WithFabricInterfacePort(12345).
 					WithFabricProvider("ofi+psm2").
 					WithStorage(
 						storage.NewTierConfig().
@@ -1304,8 +1415,7 @@ func TestControl_AutoConfig_genEngineConfigs(t *testing.T) {
 				DefaultEngineCfg(1).
 					WithPinnedNumaNode(1).
 					WithFabricInterface("ib1").
-					WithFabricInterfacePort(
-						int(defaultFiPort+defaultFiPortInterval)).
+					WithFabricInterfacePort(13345).
 					WithFabricProvider("ofi+psm2").
 					WithFabricNumaNodeIndex(1).
 					WithStorage(
@@ -1357,7 +1467,13 @@ func TestControl_AutoConfig_genEngineConfigs(t *testing.T) {
 				sd.scmCls = storage.ClassDcpm
 			}
 
-			gotCfgs, gotErr := genEngineConfigs(log, false, testEngineCfg, tc.numaSet, nd, sd)
+			req := ConfGenerateReq{
+				Log:             log,
+				FabricPorts:     tc.fabricPorts,
+				ExtMetadataPath: tc.extMetadataPath,
+			}
+
+			gotCfgs, gotErr := genEngineConfigs(req, testEngineCfg, tc.numaSet, nd, sd)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -1450,7 +1566,7 @@ func TestControl_AutoConfig_getThreadCounts(t *testing.T) {
 	}
 }
 
-func TestControl_AutoConfig_genConfig(t *testing.T) {
+func TestControl_AutoConfig_genServerConfig(t *testing.T) {
 	defHpSizeKb := 2048
 	exmplEngineCfg0 := MockEngineCfg(0, 0, 1, 2)
 	exmplEngineCfg1 := MockEngineCfg(1, 3, 4, 5)
@@ -1486,7 +1602,29 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			hpSize: defHpSizeKb,
 			expErr: errors.New("provider not specified"),
 		},
-		"single engine config": {
+		"no access points": {
+			accessPoints: []string{},
+			threadCounts: &threadCounts{16, 0},
+			ecs:          []*engine.Config{exmplEngineCfg0},
+			hpSize:       defHpSizeKb,
+			expErr:       errors.New("no access points"),
+		},
+		"access points without the same port": {
+			accessPoints: []string{"bob:1", "joe:2"},
+			threadCounts: &threadCounts{16, 0},
+			ecs:          []*engine.Config{exmplEngineCfg0},
+			hpSize:       defHpSizeKb,
+			expErr:       errors.New("numbers do not match"),
+		},
+		"access points some with port specified": {
+			accessPoints: []string{"bob:1", "joe"},
+			threadCounts: &threadCounts{16, 0},
+			ecs:          []*engine.Config{exmplEngineCfg0},
+			hpSize:       defHpSizeKb,
+			expErr:       errors.New("numbers do not match"),
+		},
+		"single engine config; default port number": {
+			accessPoints: []string{"hostX"},
 			threadCounts: &threadCounts{16, 0},
 			ecs:          []*engine.Config{exmplEngineCfg0},
 			hpSize:       defHpSizeKb,
@@ -1496,9 +1634,23 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 				}).
 				// 16 targets * 1 engine * 512 pages
 				WithNrHugepages(16 * 512).
-				WithAccessPoints("hostX:10002"),
+				WithAccessPoints("hostX:10001"), // Default applied.
 		},
-		"dual engine config": {
+		"single engine config; default port number specified": {
+			accessPoints: []string{"hostX:10001"},
+			threadCounts: &threadCounts{16, 0},
+			ecs:          []*engine.Config{exmplEngineCfg0},
+			hpSize:       defHpSizeKb,
+			expCfg: MockServerCfg(exmplEngineCfg0.Fabric.Provider,
+				[]*engine.Config{
+					exmplEngineCfg0.WithHelperStreamCount(0),
+				}).
+				// 16 targets * 1 engine * 512 pages
+				WithNrHugepages(16 * 512).
+				WithAccessPoints("hostX:10001"), // ControlPort remains at 10001.
+		},
+		"dual engine config; custom access point port number": {
+			accessPoints: []string{"hostX:10002"},
 			threadCounts: &threadCounts{16, 0},
 			ecs: []*engine.Config{
 				exmplEngineCfg0,
@@ -1512,7 +1664,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 				}).
 				// 16 targets * 2 engines * 512 pages
 				WithNrHugepages(16 * 2 * 512).
-				WithAccessPoints("hostX:10002"),
+				WithAccessPoints("hostX:10002").
+				WithControlPort(10002), // ControlPort updated to AP port.
 		},
 		"bad accesspoint port": {
 			accessPoints: []string{"hostX:-10001"},
@@ -1524,22 +1677,22 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			hpSize: defHpSizeKb,
 			expErr: config.FaultConfigBadControlPort,
 		},
-		"dual engine tmpfs; no control metadata path": {
+		"dual engine tmpfs; multiple bdev tiers; no control metadata path": {
 			threadCounts: &threadCounts{16, 0},
 			ecs: []*engine.Config{
-				MockEngineCfgTmpfs(0, 0, mockBdevTier(0, 0), mockBdevTier(0, 1, 2)),
-				MockEngineCfgTmpfs(1, 0, mockBdevTier(1, 3), mockBdevTier(1, 4, 5)),
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0), MockBdevTier(0, 1, 2)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 3), MockBdevTier(1, 4, 5)),
 			},
 			hpSize:   defHpSizeKb,
 			memTotal: (52 * humanize.GiByte) / humanize.KiByte,
-			expErr:   errors.New("no external metadata path"),
+			expErr:   errors.New("multiple bdev tiers"),
 		},
 		"dual engine tmpfs; no hugepage size": {
 			extMetadataPath: metadataMountPath,
 			threadCounts:    &threadCounts{16, 0},
 			ecs: []*engine.Config{
-				MockEngineCfgTmpfs(0, 0, mockBdevTier(0, 0), mockBdevTier(0, 1, 2)),
-				MockEngineCfgTmpfs(1, 0, mockBdevTier(1, 3), mockBdevTier(1, 4, 5)),
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0), MockBdevTier(0, 1, 2)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 3), MockBdevTier(1, 4, 5)),
 			},
 			memTotal: humanize.GiByte,
 			expErr:   errors.New("invalid system hugepage size"),
@@ -1548,8 +1701,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			extMetadataPath: metadataMountPath,
 			threadCounts:    &threadCounts{16, 0},
 			ecs: []*engine.Config{
-				MockEngineCfgTmpfs(0, 0, mockBdevTier(0, 0), mockBdevTier(0, 1, 2)),
-				MockEngineCfgTmpfs(1, 0, mockBdevTier(1, 3), mockBdevTier(1, 4, 5)),
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0), MockBdevTier(0, 1, 2)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 3), MockBdevTier(1, 4, 5)),
 			},
 			hpSize: defHpSizeKb,
 			expErr: errors.New("requires nonzero total mem"),
@@ -1558,27 +1711,28 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			extMetadataPath: metadataMountPath,
 			threadCounts:    &threadCounts{16, 0},
 			ecs: []*engine.Config{
-				MockEngineCfgTmpfs(0, 0, mockBdevTier(0, 0), mockBdevTier(0, 1, 2)),
-				MockEngineCfgTmpfs(1, 0, mockBdevTier(1, 3), mockBdevTier(1, 4, 5)),
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0), MockBdevTier(0, 1, 2)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 3), MockBdevTier(1, 4, 5)),
 			},
 			hpSize:   defHpSizeKb,
 			memTotal: humanize.GiByte / humanize.KiByte,
 			expErr:   errors.New("insufficient ram"),
 		},
 		"dual engine tmpfs; high mem": {
+			accessPoints:    []string{"hostX:10002", "hostY:10002", "hostZ:10002"},
 			extMetadataPath: metadataMountPath,
 			threadCounts:    &threadCounts{16, 0},
 			ecs: []*engine.Config{
-				MockEngineCfgTmpfs(0, 0, mockBdevTier(0, 0), mockBdevTier(0, 1, 2)),
-				MockEngineCfgTmpfs(1, 0, mockBdevTier(1, 3), mockBdevTier(1, 4, 5)),
+				MockEngineCfgTmpfs(0, 0, MockBdevTier(0, 0), MockBdevTier(0, 1, 2)),
+				MockEngineCfgTmpfs(1, 0, MockBdevTier(1, 3), MockBdevTier(1, 4, 5)),
 			},
 			hpSize:   defHpSizeKb,
 			memTotal: (64 * humanize.GiByte) / humanize.KiByte,
 			expCfg: MockServerCfg(exmplEngineCfg0.Fabric.Provider,
 				[]*engine.Config{
 					MockEngineCfgTmpfs(0, 5, /* tmpfs size in gib */
-						mockBdevTier(0, 0).WithBdevDeviceRoles(4),
-						mockBdevTier(0, 1, 2).WithBdevDeviceRoles(3)).
+						MockBdevTier(0, 0).WithBdevDeviceRoles(4),
+						MockBdevTier(0, 1, 2).WithBdevDeviceRoles(3)).
 						WithHelperStreamCount(0).
 						WithStorageControlMetadataPath(metadataMountPath).
 						WithStorageConfigOutputPath(
@@ -1586,8 +1740,8 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 								storage.BdevOutConfName),
 						),
 					MockEngineCfgTmpfs(1, 5, /* tmpfs size in gib */
-						mockBdevTier(1, 3).WithBdevDeviceRoles(4),
-						mockBdevTier(1, 4, 5).WithBdevDeviceRoles(3)).
+						MockBdevTier(1, 3).WithBdevDeviceRoles(4),
+						MockBdevTier(1, 4, 5).WithBdevDeviceRoles(3)).
 						WithHelperStreamCount(0).
 						WithStorageControlMetadataPath(metadataMountPath).
 						WithStorageConfigOutputPath(
@@ -1596,8 +1750,9 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 						),
 				}).
 				// 16+1 (MD-on-SSD) targets * 2 engines * 512 pages
-				WithNrHugepages(17 * 2 * 512).
-				WithAccessPoints("hostX:10002").
+				WithNrHugepages(17*2*512).
+				WithAccessPoints("hostX:10002", "hostY:10002", "hostZ:10002").
+				WithControlPort(10002). // ControlPort updated to AP port.
 				WithControlMetadata(controlMetadata),
 		},
 	} {
@@ -1606,7 +1761,7 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 			defer test.ShowBufferOnFailure(t, buf)
 
 			if tc.accessPoints == nil {
-				tc.accessPoints = []string{"hostX:10002"}
+				tc.accessPoints = []string{"localhost"} // Matches default in mock config.
 			}
 			if tc.threadCounts == nil {
 				tc.threadCounts = &threadCounts{}
@@ -1617,7 +1772,13 @@ func TestControl_AutoConfig_genConfig(t *testing.T) {
 				MemTotalKiB:     tc.memTotal,
 			}
 
-			getCfg, gotErr := genServerConfig(log, tc.accessPoints, tc.extMetadataPath, tc.ecs, mi, tc.threadCounts)
+			req := ConfGenerateReq{
+				Log:             log,
+				AccessPoints:    tc.accessPoints,
+				ExtMetadataPath: tc.extMetadataPath,
+			}
+
+			getCfg, gotErr := genServerConfig(req, tc.ecs, mi, tc.threadCounts)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -721,7 +721,7 @@ func MockPoolCreateResp(t *testing.T, config *MockPoolRespConfig) *mgmtpb.PoolCr
 	return poolCreateRespMsg
 }
 
-func mockBdevTier(numaID int, pciAddrIDs ...int) *storage.TierConfig {
+func MockBdevTier(numaID int, pciAddrIDs ...int) *storage.TierConfig {
 	return storage.NewTierConfig().
 		WithNumaNodeIndex(uint(numaID)).
 		WithStorageClass(storage.ClassNvme.String()).
@@ -748,14 +748,14 @@ func MockEngineCfg(numaID int, pciAddrIDs ...int) *engine.Config {
 			WithScmMountPoint(fmt.Sprintf("/mnt/daos%d", numaID)),
 	}
 	if len(pciAddrIDs) > 0 {
-		tcs = append(tcs, mockBdevTier(numaID, pciAddrIDs...))
+		tcs = append(tcs, MockBdevTier(numaID, pciAddrIDs...))
 	}
 
 	return mockEngineCfg(numaID, tcs...)
 }
 
 func MockBdevTierWithRole(numaID, role int, pciAddrIDs ...int) *storage.TierConfig {
-	return mockBdevTier(numaID, pciAddrIDs...).WithBdevDeviceRoles(role)
+	return MockBdevTier(numaID, pciAddrIDs...).WithBdevDeviceRoles(role)
 }
 
 // MockEngineCfgTmpfs generates ramdisk engine config with pciAddrIDs defining bdev tier device

--- a/src/control/lib/ui/list_flags.go
+++ b/src/control/lib/ui/list_flags.go
@@ -68,6 +68,7 @@ func (f *HostSetFlag) UnmarshalFlag(fv string) error {
 	return nil
 }
 
+// MarshalFlag implements the go-flags.Marshaler interface.
 func (f *HostSetFlag) MarshalJSON() ([]byte, error) {
 	return []byte(f.String()), nil
 }

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -414,21 +414,23 @@ func (cfg *Server) SaveActiveConfig(log logging.Logger) {
 	log.Debugf("active config saved to %s (read-only)", activeConfig)
 }
 
-func getAccessPointAddrWithPort(log logging.Logger, addr string, portDefault int) (string, error) {
+// GetAccessPointPort returns port number suffixed to AP address after its validation or 0 if no
+// port number specified. Error returned if validation fails.
+func GetAccessPointPort(log logging.Logger, addr string) (int, error) {
 	if !common.HasPort(addr) {
-		return fmt.Sprintf("%s:%d", addr, portDefault), nil
+		return 0, nil
 	}
 
-	host, port, err := net.SplitHostPort(addr)
+	_, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		log.Errorf("invalid access point %q: %s", addr, err)
-		return "", FaultConfigBadAccessPoints
+		return 0, FaultConfigBadAccessPoints
 	}
 
 	portNum, err := strconv.Atoi(port)
 	if err != nil {
 		log.Errorf("invalid access point port: %s", err)
-		return "", FaultConfigBadControlPort
+		return 0, FaultConfigBadControlPort
 	}
 	if portNum <= 0 {
 		m := "zero"
@@ -436,13 +438,27 @@ func getAccessPointAddrWithPort(log logging.Logger, addr string, portDefault int
 			m = "negative"
 		}
 		log.Errorf("access point port cannot be %s", m)
-		return "", FaultConfigBadControlPort
+		return 0, FaultConfigBadControlPort
 	}
 
-	// warn if access point port differs from config control port
+	return portNum, nil
+}
+
+// getAccessPointAddrWithPort appends default port number to address if custom port is not
+// specified, otherwise custom specified port is validated.
+func getAccessPointAddrWithPort(log logging.Logger, addr string, portDefault int) (string, error) {
+	portNum, err := GetAccessPointPort(log, addr)
+	if err != nil {
+		return "", err
+	}
+	if portNum == 0 {
+		return fmt.Sprintf("%s:%d", addr, portDefault), nil
+	}
+
+	// Warn if access point port differs from config control port.
 	if portDefault != portNum {
-		log.Debugf("access point (%s) port (%s) differs from default port (%d)",
-			host, port, portDefault)
+		log.Debugf("access point %q port differs from default port %q",
+			addr, portDefault)
 	}
 
 	return addr, nil

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -309,7 +309,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 					WithBdevDeviceRoles(storage.BdevRoleAll),
 			).
 			WithFabricInterface("ib1").
-			WithFabricInterfacePort(20000).
+			WithFabricInterfacePort(21000).
 			WithFabricProvider("ofi+verbs;ofi_rxm").
 			WithFabricAuthKey("foo:bar").
 			WithCrtCtxShareAddr(0).

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -441,16 +441,18 @@ func (tcs TierConfigs) validateBdevRoles() error {
 //     second bdev tier and Data to all remaining bdev tiers.
 //   - If the scm tier is of class dcpm, the first (and only) bdev tier should have the Data role.
 //   - If emulated NVMe is present in bdev tiers, implicit role assignment is skipped.
-func (tcs TierConfigs) AssignBdevTierRoles() error {
+func (tcs TierConfigs) AssignBdevTierRoles(extMetadataPath string) error {
+	if extMetadataPath == "" {
+		return nil // MD-on-SSD not enabled.
+	}
+
 	scs := tcs.ScmConfigs()
 
-	// Require tier-0 to be a SCM tier.
 	if len(scs) != 1 || scs[0].Tier != 0 {
-		return errors.New("first storage tier is not scm")
+		return errors.New("first storage tier is not of type scm")
 	}
-	// No roles should be assigned if scm tier is DCPM.
 	if scs[0].Class == ClassDcpm {
-		return nil
+		return errors.New("external metadata path for md-on-ssd invalid with dcpm scm-class")
 	}
 	// Skip role assignment and validation if no real NVMe tiers exist.
 	if !tcs.HaveRealNVMe() {

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -346,11 +346,14 @@
 #
 #  bypass_health_chk: true
 #
-#  # Specify the fabric network interface and interface port that will
-#  # be used by this engine. The fabric_iface_port must be different
-#  # for each engine on a DAOS server.
+#  # Specify the fabric network interface used for this engine.
 #
 #  fabric_iface: ib0
+#
+#  # Specify the fabric network interface port that will be used by this engine.
+#  # The fabric_iface_port must be different for each engine on a DAOS server
+#  # if each engine is assigned to the same fabric_iface.
+#
 #  fabric_iface_port: 20000
 #
 #  # Force specific debug mask for the engine at start up time.
@@ -519,14 +522,15 @@
 #
 #  bypass_health_chk: true
 #
-#  # Use specific network interface.
-#  # Specify the fabric network interface that will be used by this engine.
-#  # Optionally specify the fabric network interface port that will be used
-#  # by this engine but please only if you have a specific need, this will
-#  # normally be chosen automatically.
+#  # Specify the fabric network interface used for this engine.
 #
 #  fabric_iface: ib1
-#  fabric_iface_port: 20000
+#
+#  # Specify the fabric network interface port that will be used by this engine.
+#  # The fabric_iface_port must be different for each engine on a DAOS server
+#  # if each engine is assigned to the same fabric_iface.
+#
+#  fabric_iface_port: 21000
 #
 #  # Force specific debug mask for the engine at start up time.
 #  # By default, just use the default debug mask used by DAOS.


### PR DESCRIPTION
… (#13054)

Allow config generate to produce output that contains custom port
numbers for both the control server and for fabric interfaces rather
than just using hardcoded values. This new behaviour will work in both
dmg and daos_server config generate commands.

Supplying a custom port number to all of the comma-separated access
point addresses in the commandline option will set the (control server)
port parameter in the output server config file
e.g. --access-points=bob:10002,jeff:10002,ben:10002.

Fabric interface port numbers can be set by specifying a comma
separated list in a new commandline option. There must be enough
values to supply all generated engines e.g. --fabric-ports=12460,13460.

Also:

Mock API backend call to improve dmg unit test coverage.
Reduce excessive parameters by passing request.
Only ERROR and more severe log levels are logged to stderr during
config generate command invocation unless --debug option specified.
Allow tmpfs non-MD-on-SSD mode (ephemeral) config generation by keying
MD-on-SSD mode off the control_metadata cli option.
Update docs to reflect changes.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
