### PR TITLE
DAOS-14521 client: intercept __pread64_chk() and __read_chk()

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -2068,23 +2068,23 @@ pread64(int fd, void *buf, size_t size, off_t offset) __attribute__((alias("prea
 ssize_t
 __pread64(int fd, void *buf, size_t size, off_t offset) __attribute__((alias("pread")));
 
+extern void __chk_fail(void) __attribute__ ((__noreturn__));
+
 ssize_t
 __pread64_chk(int fd, void *buf, size_t size, off_t offset, size_t buflen)
 {
-	if (size > buflen) {
-		D_FATAL("buffer overflow detected in __pread64_chk().\n");
-		abort();
-	}
+	if (size > buflen)
+		__chk_fail();
+
 	return pread(fd, buf, size, offset);
 }
 
 ssize_t
-__read_chk (int fd, void *buf, size_t size, size_t buflen)
+__read_chk(int fd, void *buf, size_t size, size_t buflen)
 {
-	if (size > buflen) {
-		D_FATAL("buffer overflow detected in __read_chk().\n");
-		abort();
-	}
+	if (size > buflen)
+		__chk_fail();
+
 	return read(fd, buf, size);
 }
 

--- a/src/tests/ftest/util/cmocka_utils.py
+++ b/src/tests/ftest/util/cmocka_utils.py
@@ -90,7 +90,8 @@ class CmockaUtils():
             ExecutableCommand: the object setup to run the command
 
         """
-        keywords = ["Process received signal", "stack smashing detected", "End of error message"]
+        keywords = ["Process received signal", "stack smashing detected", "End of error message",
+                    "buffer overflow detected"]
         return ExecutableCommand(namespace=None, command=command, check_results=keywords)
 
     def run_cmocka_test(self, test, command):

--- a/src/tests/ftest/util/verify_perms.py
+++ b/src/tests/ftest/util/verify_perms.py
@@ -261,7 +261,10 @@ def _real_w(entry_type, path):
     if entry_type == 'file':
         try:
             # Write a newline to reduce likelihood of corrupting an executable file
-            with open(path, 'a', encoding='utf-8') as file:
+            with open(path, "w", encoding='utf-8') as file:
+                # O_APPEND is not supported by DFS, so "a" is not used in open. Need seek() here
+                # to move file pointer to the end of the file.
+                file.seek(0, 2)
                 return file.write('\n') == 1
         except PermissionError:
             return False

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -4114,6 +4114,7 @@ class PosixTests():
         self.server.run_daos_client_cmd_pil4dfs(['cp', '/usr/bin/mkdir', file6])
         self.server.run_daos_client_cmd_pil4dfs(['file', file6])
 
+
 class NltStdoutWrapper():
     """Class for capturing stdout from threads"""
 

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -4109,7 +4109,10 @@ class PosixTests():
         file5 = join(path, 'newfile')
         self.server.run_daos_client_cmd_pil4dfs(['dd', 'if=/dev/zero', f'of={file5}', 'bs=1',
                                                 'count=1'])
-
+        # cp "/usr/bin/mkdir" to DFS and call "/usr/bin/file" to analyze the binary file file6
+        file6 = join(path, 'elffile')
+        self.server.run_daos_client_cmd_pil4dfs(['cp', '/usr/bin/mkdir', file6])
+        self.server.run_daos_client_cmd_pil4dfs(['file', file6])
 
 class NltStdoutWrapper():
     """Class for capturing stdout from threads"""


### PR DESCRIPTION
Skip-func-test-el9: false
Features: pil4dfs

intercept fstatat() with trampoline. add nlt test for file. also replace "a" with "w" in open since O_APPEND is not supported by DFS.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
