### PR TITLE
DAOS-14527 dfuse: Refine O_APPEND handling.

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -4212,6 +4212,8 @@ dfs_dup(dfs_t *dfs, dfs_obj_t *obj, int flags, dfs_obj_t **_new_obj)
 		return EINVAL;
 	if (obj == NULL || _new_obj == NULL)
 		return EINVAL;
+	if (flags & O_APPEND)
+		return ENOTSUP;
 
 	daos_mode = get_daos_obj_mode(flags);
 	if (daos_mode == -1)

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -108,6 +108,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent, const char *na
 	struct fuse_file_info     fi_out     = {0};
 	struct dfuse_cont        *dfs        = parent->ie_dfs;
 	int                       rc;
+	int                       flags;
 
 	DFUSE_TRA_DEBUG(parent, "Parent:%#lx " DF_DE, parent->ie_stat.st_ino, DP_DE(name));
 
@@ -161,6 +162,14 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent, const char *na
 	dfuse_ie_init(dfuse_info, ie);
 	dfuse_open_handle_init(dfuse_info, oh, ie);
 
+	LOG_FLAGS(ie, fi->flags);
+	LOG_MODES(ie, mode);
+
+	flags = fi->flags;
+
+	if (flags & O_APPEND)
+		flags &= ~O_APPEND;
+
 	oh->doh_linear_read = false;
 
 	if (!dfuse_info->di_multi_user) {
@@ -171,8 +180,8 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent, const char *na
 
 	DFUSE_TRA_DEBUG(ie, "file " DF_DE " flags 0%o mode 0%o", DP_DE(name), fi->flags, mode);
 
-	rc = dfs_open_stat(dfs->dfs_ns, parent->ie_obj, name, mode, fi->flags, 0, 0, NULL,
-			   &oh->doh_obj, &ie->ie_stat);
+	rc = dfs_open_stat(dfs->dfs_ns, parent->ie_obj, name, mode, flags, 0, 0, NULL, &oh->doh_obj,
+			   &ie->ie_stat);
 	if (rc)
 		D_GOTO(err, rc);
 
@@ -204,9 +213,6 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent, const char *na
 	strncpy(ie->ie_name, name, NAME_MAX);
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_truncated = false;
-
-	LOG_FLAGS(ie, fi->flags);
-	LOG_MODES(ie, mode);
 
 	dfs_obj2id(ie->ie_obj, &ie->ie_oid);
 

--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -16,6 +16,7 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	struct fuse_file_info     fi_out = {0};
 	int                       rc;
 	bool                      prefetch = false;
+	int                       flags;
 
 	ie = dfuse_inode_lookup(dfuse_info, ino);
 	if (!ie) {
@@ -42,8 +43,15 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		fi->flags |= O_RDWR;
 	}
 
+	LOG_FLAGS(ie, fi->flags);
+
+	flags = fi->flags;
+
+	if (flags & O_APPEND)
+		flags &= ~O_APPEND;
+
 	/** duplicate the file handle for the fuse handle */
-	rc = dfs_dup(ie->ie_dfs->dfs_ns, ie->ie_obj, fi->flags, &oh->doh_obj);
+	rc = dfs_dup(ie->ie_dfs->dfs_ns, ie->ie_obj, flags, &oh->doh_obj);
 	if (rc)
 		D_GOTO(err, rc);
 
@@ -76,8 +84,6 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		oh->doh_caching = true;
 
 	fi_out.fh = (uint64_t)oh;
-
-	LOG_FLAGS(ie, fi->flags);
 
 	/*
 	 * dfs_dup() just locally duplicates the file handle. If we have


### PR DESCRIPTION
Do not pass O_APPEND flag onto dfs.
Add missing check for O_APPEND in dfs_dup.

Test-tag: dfuse
Skip-func-test-el9: false

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
