### PR TITLE
DAOS-14508 client: free memory *buf in case of error in read_map_file()

### DIFF
--- a/src/client/dfuse/pil4dfs/hook.c
+++ b/src/client/dfuse/pil4dfs/hook.c
@@ -165,6 +165,7 @@ read_map_file(char **buf)
 		fIn = fopen("/proc/self/maps", "r");
 		if (fIn == NULL) {
 			DS_ERROR(errno, "Fail to open /proc/self/maps");
+			D_FREE(*buf);
 			quit_hook_init();
 		}
 
@@ -175,6 +176,7 @@ read_map_file(char **buf)
 
 		if (read_size < 0) {
 			DS_ERROR(errno, "Error in reading file /proc/self/maps");
+			D_FREE(*buf);
 			quit_hook_init();
 		} else if (read_size == max_read_size) {
 			/* need to increase the buffer and try again */
@@ -190,6 +192,7 @@ read_map_file(char **buf)
 		if (max_read_size >= MAP_SIZE_LIMIT) {
 			/* not likely to be here */
 			DS_ERROR(EFBIG, "/proc/self/maps is TOO large");
+			D_FREE(*buf);
 			quit_hook_init();
 		}
 	}

--- a/src/tests/ftest/util/verify_perms.py
+++ b/src/tests/ftest/util/verify_perms.py
@@ -261,7 +261,10 @@ def _real_w(entry_type, path):
     if entry_type == 'file':
         try:
             # Write a newline to reduce likelihood of corrupting an executable file
-            with open(path, 'a', encoding='utf-8') as file:
+            with open(path, "w", encoding='utf-8') as file:
+                # O_APPEND is not supported by DFS, so "a" is not used in open. Need seek() here
+                # to move file pointer to the end of the file.
+                file.seek(0, 2)
                 return file.write('\n') == 1
         except PermissionError:
             return False


### PR DESCRIPTION
Features: pil4dfs

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
