### PR TITLE
DAOS-13563 test: Add no-recurse option to vos_perf

### DIFF
--- a/src/tests/perf_internal.h
+++ b/src/tests/perf_internal.h
@@ -45,6 +45,8 @@ struct pf_param {
 		struct {
 			/* visible iteration */
 			bool	visible;
+			/* recursive iteration */
+			bool    recurse;
 		} pa_iter;
 		/* private parameter for update, fetch and verify */
 		struct {

--- a/src/tests/vos_perf.c
+++ b/src/tests/vos_perf.c
@@ -324,7 +324,8 @@ obj_iter_records(daos_unit_oid_t oid, struct pf_param *ppa)
 	TS_TIME_START(&ppa->pa_duration, start);
 	if (ppa->pa_verbose)
 		D_PRINT("Iteration dkeys in "DF_UOID"\n", DP_UOID(oid));
-	rc = vos_iterate(&param, VOS_ITER_DKEY, true, &anchors, iter_cb, NULL, ppa, NULL);
+	rc = vos_iterate(&param, VOS_ITER_DKEY, ppa->pa_iter.recurse, &anchors, iter_cb, NULL, ppa,
+			 NULL);
 	TS_TIME_END(&ppa->pa_duration, start);
 	return rc;
 }
@@ -609,6 +610,10 @@ pf_parse_iterate_cb(char *str, struct pf_param *pa, char **strp)
 		pa->pa_iter.visible = true;
 		str++;
 		break;
+	case 's':
+		pa->pa_iter.recurse = false;
+		str++;
+		break;
 	}
 	*strp = str;
 	return 0;
@@ -617,6 +622,7 @@ pf_parse_iterate_cb(char *str, struct pf_param *pa, char **strp)
 static int
 pf_parse_iterate(char *str, struct pf_param *pa, char **strp)
 {
+	pa->pa_iter.recurse = true;
 	return pf_parse_common(str, pa, pf_parse_iterate_cb, strp);
 }
 

--- a/utils/utest.yaml
+++ b/utils/utest.yaml
@@ -77,6 +77,10 @@
 - name: VOS
   base: "PREFIX"
   tests:
+    - cmd: ["bin/vos_perf", "-i", "-d", "15", "-o", "5", "-f", "-a", "1", "-A", "-n", "5", "-R",
+            '"U;p F;p I;s;p, I;p; A;p"']
+    - cmd: ["bin/vos_perf", "-i", "-d", "15", "-o", "5", "-f", "-a", "1", "-n", "5", "-R",
+            '"U;p F;p I;s;p, I;p; A;p"']
     - cmd: ["bin/vos_perf", "-R", '"U;p F;p V"', "-o", "5", "-d", "5", "-a", "5", "-n", "10"]
     - cmd: ["bin/vos_perf", "-R", '"U;p F;p V"', "-o", "5", "-d", "5", "-a", "5", "-n", "10",
             "-A", "-D", "/mnt/..MOUNT"]


### PR DESCRIPTION
For vos_iterate test, add an option to avoid recursion. Also, run a couple of vos_perf tests in unit tests to touch test the new iterator option as well as the flat kv option.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
