### PR TITLE
DAOS-14461 test: Fix ignoring ior/dfuse failures (#13207)

### DIFF
--- a/src/tests/ftest/control/dmg_telemetry_io_basic.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_basic.py
@@ -1,10 +1,8 @@
 """
-  (C) Copyright 2018-2022 Intel Corporation.
+  (C) Copyright 2018-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from avocado.core.exceptions import TestFail
-
 from ior_test_base import IorTestBase
 from telemetry_test_base import TestWithTelemetry
 from telemetry_utils import TelemetryUtils
@@ -77,7 +75,7 @@ class TestWithTelemetryIOBasic(IorTestBase, TestWithTelemetry):
                 "Initial " if key == 0 else "Test Loop {}".format(key),
                 metrics_data[key])
 
-    def test_io_telmetry_metrics_basic(self):
+    def test_io_telemetry_metrics_basic(self):
         """JIRA ID: DAOS-5241
 
             Create files of 500M and 1M with transfer size 1M to verify the
@@ -86,7 +84,7 @@ class TestWithTelemetryIOBasic(IorTestBase, TestWithTelemetry):
         :avocado: tags=all,pr,daily_regression
         :avocado: tags=hw,medium
         :avocado: tags=control,telemetry,basic
-        :avocado: tags=TestWithTelemetryIOBasic,test_io_telmetry_metrics_basic
+        :avocado: tags=TestWithTelemetryIOBasic,test_io_telemetry_metrics_basic
         """
         block_sizes = self.params.get("block_sizes", "/run/*")
         transfer_sizes = self.params.get("transfer_sizes", "/run/*")
@@ -109,12 +107,9 @@ class TestWithTelemetryIOBasic(IorTestBase, TestWithTelemetry):
                 self.ior_cmd.transfer_size.update(transfer_size)
                 test_file_suffix = "_{}".format(loop)
                 # Run ior command.
-                try:
-                    self.run_ior_with_pool(
-                        timeout=200, create_pool=False, create_cont=False,
-                        test_file_suffix=test_file_suffix)
-                except TestFail:
-                    self.log.info("#ior command failed!")
+                self.run_ior_with_pool(
+                    timeout=200, create_pool=False, create_cont=False,
+                    test_file_suffix=test_file_suffix)
         metrics_data[loop] = self.telemetry.get_io_metrics(test_metrics)
         self.display_io_test_metrics(metrics_data)
         self.verify_io_test_metrics(test_metrics, metrics_data, threshold)


### PR DESCRIPTION
The test_io_telmetry_metrics_basic test was ignoring failures from the run_ior_with_pool function, which will raise an error if there is a problem setting up dfuse.  Ignoring this failure can then result in issues running sunsequent ior commands.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_io_telmetry_metrics_basic

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
