### PR TITLE
DAOS-14545 test: Fix pool list_verbose.py text match issue

### DIFF
--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -11,7 +11,7 @@ class ListVerboseTest(IorTestBase):
     """DAOS-8267: Test class for dmg pool list --verbose tests.
 
     Verify all fields of dmg pool list --verbose; Label, UUID, SvcReps, SCM
-    Size, SCM Used, SCM Imbalance, NVME Size, NVME Used, NVME Imbalance, and Disabled.
+    Size, SCM Used, SCM Imbalance, NVMe Size, NVMe Used, NVMe Imbalance, and Disabled.
 
     Control plane test and not the underlying algorithm test. Assume that a
     single non-zero output verifies all other non-zero output. e.g., if we can
@@ -78,7 +78,7 @@ class ListVerboseTest(IorTestBase):
                     "imbalance": scm_imbalance
                 },
                 {
-                    "tier_name": "NVME",
+                    "tier_name": "NVMe",
                     "size": nvme_size,
                     "free": nvme_free,
                     "imbalance": nvme_imbalance
@@ -112,7 +112,7 @@ class ListVerboseTest(IorTestBase):
                     scm_size = usage["size"]
                     scm_free = usage["free"]
                     scm_imbalance = usage["imbalance"]
-                elif usage["tier_name"] == "NVME":
+                elif usage["tier_name"] == "NVMe":
                     nvme_free = usage["free"]
                     nvme_imbalance = usage["imbalance"]
 
@@ -219,7 +219,7 @@ class ListVerboseTest(IorTestBase):
 
         Args:
             pool_dict (dict): Pool info from list pool.
-            storage (str): SCM or NVME.
+            storage (str): SCM or NVMe.
         """
         free = 0
         imbalance = 0
@@ -325,7 +325,7 @@ class ListVerboseTest(IorTestBase):
         """Verification steps for test_used_imbalance.
 
         Args:
-            storage (str): NVME or SCM.
+            storage (str): NVMe or SCM.
 
         Returns:
             list: Errors.
@@ -334,7 +334,7 @@ class ListVerboseTest(IorTestBase):
 
         # 1. Create a pool of 80GB.
         self.pool = []
-        if storage == "NVME":
+        if storage == "NVMe":
             self.pool.append(self.get_pool(namespace="/run/pool_both/*"))
             nvme_size = [None]
         else:
@@ -411,8 +411,8 @@ class ListVerboseTest(IorTestBase):
         :avocado: tags=list_verbose,list_verbose_imbalance,test_used_imbalance
         """
         errors = []
-        self.log.debug("---------- NVME test ----------")
-        errors.extend(self.verify_used_imbalance("NVME"))
+        self.log.debug("---------- NVMe test ----------")
+        errors.extend(self.verify_used_imbalance("NVMe"))
         self.log.debug("---------- SCM test ----------")
         errors.extend(self.verify_used_imbalance("SCM"))
 


### PR DESCRIPTION
Fix full_regression test failures caused by commit 6a99368a2bb18e0f0e90b2ff4891bbeffa346034.

Test-tag: list_verbose
Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-test-vm: true
Skip-func-hw-test-medium-verbs-provider: true
Skip-func-hw-test-medium-ucx-provider: true
Skip-func-hw-test-large: true
Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
