### PR TITLE
DAOS-14521 test: fix very_perms.py _real_w

### DIFF
--- a/src/tests/ftest/dfuse/mu_perms.py
+++ b/src/tests/ftest/dfuse/mu_perms.py
@@ -369,7 +369,7 @@ class DfuseMUPerms(DfuseTestBase):
             self.log.info('Verify - no perms - not using IL')
             _verify(use_il=False, expected_il_messages=0, expect_der_no_perm=False)
             self.log.info('Verify - no perms - using IL')
-            _verify(use_il=True, expected_il_messages=1, expect_der_no_perm=False)
+            _verify(use_il=True, expected_il_messages=2, expect_der_no_perm=False)
 
             # Give the user POSIX perms
             posix_perms = {'file': '606', 'dir': '505'}[entry_type]

--- a/src/tests/ftest/dfuse/mu_perms.py
+++ b/src/tests/ftest/dfuse/mu_perms.py
@@ -384,7 +384,7 @@ class DfuseMUPerms(DfuseTestBase):
             self.log.info('Verify - POSIX perms only - not using IL')
             _verify(use_il=False, expected_il_messages=0, expect_der_no_perm=False)
             self.log.info('Verify - POSIX perms only - using IL')
-            _verify(use_il=True, expected_il_messages=1, expect_der_no_perm=True)
+            _verify(use_il=True, expected_il_messages=2, expect_der_no_perm=True)
 
             # Give the user pool/container ACL perms
             self.log.info('Giving %s pool "r" ACL permissions', other_user)
@@ -396,7 +396,7 @@ class DfuseMUPerms(DfuseTestBase):
             self.log.info('Verify - POSIX and ACL perms - not using IL')
             _verify(use_il=False, expected_il_messages=0, expect_der_no_perm=False)
             self.log.info('Verify - POSIX and ACL perms - using IL')
-            _verify(use_il=True, expected_il_messages=2, expect_der_no_perm=False)
+            _verify(use_il=True, expected_il_messages=4, expect_der_no_perm=False)
 
             # Revoke POSIX permissions
             posix_perms = {'file': '600', 'dir': '00'}[entry_type]
@@ -411,7 +411,7 @@ class DfuseMUPerms(DfuseTestBase):
             self.log.info('Verify - ACLs only - not using IL')
             _verify(use_il=False, expected_il_messages=0, expect_der_no_perm=False)
             self.log.info('Verify - ACLs only - using IL')
-            _verify(use_il=True, expected_il_messages=1, expect_der_no_perm=False)
+            _verify(use_il=True, expected_il_messages=2, expect_der_no_perm=False)
 
         # Stop dfuse instances. Needed until containers are cleaned up with with register_cleanup
         dfuse.stop()

--- a/src/tests/ftest/util/verify_perms.py
+++ b/src/tests/ftest/util/verify_perms.py
@@ -260,12 +260,10 @@ def _real_w(entry_type, path):
     '''
     if entry_type == 'file':
         try:
-            # Write a newline to reduce likelihood of corrupting an executable file
+            # Always write a line that allows the file to be executable
             with open(path, "w", encoding='utf-8') as file:
-                # O_APPEND is not supported by DFS, so "a" is not used in open. Need seek() here
-                # to move file pointer to the end of the file.
-                file.seek(0, 2)
-                return file.write('\n') == 1
+                data = '#!/usr/bin/env bash\n'
+                return file.write(data) == len(data)
         except PermissionError:
             return False
     if entry_type == 'dir':


### PR DESCRIPTION
Test-tag: verify_perms
Skip-unit-tests: true
Skip-fault-injection-test: true

In _real_w, always write a line that allows the file to be executable since opening in "w" mode will truncate the file.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
