### PR TITLE
DAOS-14263 vea: avoid unmap for tiny extents

### DIFF
--- a/src/include/daos_srv/vea.h
+++ b/src/include/daos_srv/vea.h
@@ -305,13 +305,12 @@ int vea_query(struct vea_space_info *vsi, struct vea_attr *attr,
  * Flushing the free frags in aging buffer
  *
  * \param vsi        [IN]	In-memory compound index
- * \param force      [IN]	Force flush no matter if there is qualified extent
  * \param nr_flush   [IN]	Flush at most @nr_flush frags
  * \param nr_flushed [OUT]	How many frags are actually flushed (optional)
  *
  * \return			Zero on success; Appropriated negative value on error
  */
-int vea_flush(struct vea_space_info *vsi, bool force, uint32_t nr_flush, uint32_t *nr_flushed);
+int vea_flush(struct vea_space_info *vsi, uint32_t nr_flush, uint32_t *nr_flushed);
 
 /**
  * Free metrcis

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1218,7 +1218,7 @@ int
 vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 	    void *yield_arg);
 int
-vos_flush_pool(daos_handle_t poh, bool force, uint32_t nr_flush, uint32_t *nr_flushed);
+vos_flush_pool(daos_handle_t poh, uint32_t nr_flush, uint32_t *nr_flushed);
 
 bool
 vos_gc_pool_idle(daos_handle_t poh);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -223,7 +223,7 @@ flush_ult(void *arg)
 	D_ASSERT(child->spc_flush_req != NULL);
 
 	while (!dss_ult_exiting(child->spc_flush_req)) {
-		rc = vos_flush_pool(child->spc_hdl, false, nr_flush, &nr_flushed);
+		rc = vos_flush_pool(child->spc_hdl, nr_flush, &nr_flushed);
 		if (rc < 0) {
 			D_ERROR(DF_UUID"[%d]: Flush pool failed. "DF_RC"\n",
 				DP_UUID(child->spc_uuid), dmi->dmi_tgt_id, DP_RC(rc));

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -534,8 +534,8 @@ ut_free(void **state)
 	print_message("persistent free extents:\n");
 	vea_dump(args->vua_vsi, false);
 
-	/* call vea_flush to trigger free extents migration */
-	rc = vea_flush(args->vua_vsi, true, UINT32_MAX, &nr_flushed);
+	/* force aging free extents flush */
+	rc = trigger_aging_flush(args->vua_vsi, true, UINT32_MAX, &nr_flushed);
 	assert_rc_equal(rc, 0);
 	assert_true(nr_flushed > 0);
 
@@ -775,13 +775,6 @@ ut_reserve_special(void **state)
 
 	/* free the allocated space */
 	rc = vea_free(args.vua_vsi, hdr_blks, blk_cnt);
-	assert_rc_equal(rc, 0);
-
-	/*
-	 * immediate reserve after free, the free extents should be made
-	 * visible for allocation immediately, reserve should succeed.
-	 */
-	rc = vea_reserve(args.vua_vsi, blk_cnt, NULL, r_list);
 	assert_rc_equal(rc, 0);
 
 	vea_unload(args.vua_vsi);

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -372,14 +372,50 @@ error:
 	return rc;
 }
 
-static inline void
-aging_flush(struct vea_space_info *vsi, bool force, uint32_t nr_flush, uint32_t *nr_flushed)
+#define FLUSH_INTVL		5	/* seconds */
+
+static inline bool
+need_aging_flush(struct vea_space_info *vsi, bool force)
 {
-	if (vsi->vsi_unmap_ctxt.vnc_ext_flush) {
-		if (nr_flushed != NULL)
-			*nr_flushed = 0;
-	} else {
-		trigger_aging_flush(vsi, force, nr_flush, nr_flushed);
+	int	i;
+	bool	empty_bitmap = false;
+
+	for (i = 0; i < VEA_MAX_BITMAP_CLASS; i++) {
+		if (!d_list_empty(&vsi->vsi_class.vfc_bitmap_empty[i])) {
+			empty_bitmap = true;
+			break;
+		}
+	}
+
+	if (!empty_bitmap && d_list_empty(&vsi->vsi_agg_lru))
+		return false;
+
+	if (!force && get_current_age() < (vsi->vsi_flush_time + FLUSH_INTVL))
+		return false;
+
+	return true;
+}
+
+static inline void
+inline_aging_flush(struct vea_space_info *vsi, bool force, uint32_t nr_flush, uint32_t *nr_flushed)
+{
+	int rc;
+
+	if (nr_flushed)
+		*nr_flushed = 0;
+
+	/* Don't do inline flush when external flush is specified */
+	if (vsi->vsi_unmap_ctxt.vnc_ext_flush)
+		return;
+
+	/* Don't do flush within a transaction */
+	if (!umem_tx_none(vsi->vsi_umem))
+		return;
+
+	if (need_aging_flush(vsi, force)) {
+		rc = trigger_aging_flush(vsi, force, nr_flush, nr_flushed);
+		if (rc)
+			DL_ERROR(rc, "Aging flush failed.");
 	}
 }
 
@@ -421,7 +457,7 @@ vea_reserve(struct vea_space_info *vsi, uint32_t blk_cnt,
 		hint_get(hint, &resrvd->vre_hint_off);
 
 	/* Trigger aging extents flush */
-	aging_flush(vsi, force, MAX_FLUSH_FRAGS, &nr_flushed);
+	inline_aging_flush(vsi, force, MAX_FLUSH_FRAGS, NULL);
 retry:
 	/* Reserve from hint offset */
 	if (try_hint) {
@@ -442,7 +478,7 @@ retry:
 	rc = -DER_NOSPACE;
 	if (!force) {
 		force = true;
-		trigger_aging_flush(vsi, force, MAX_FLUSH_FRAGS * 10, &nr_flushed);
+		inline_aging_flush(vsi, force, MAX_FLUSH_FRAGS * 10, &nr_flushed);
 		if (nr_flushed == 0)
 			goto error;
 		goto retry;
@@ -635,6 +671,53 @@ vea_tx_publish(struct vea_space_info *vsi, struct vea_hint_context *hint,
 	return process_resrvd_list(vsi, hint, resrvd_list, true);
 }
 
+static void
+flush_end_cb(void *data, bool noop)
+{
+	struct vea_space_info	*vsi = data;
+
+	if (!noop)
+		trigger_aging_flush(vsi, false, MAX_FLUSH_FRAGS * 20, NULL);
+
+	vsi->vsi_flush_scheduled = false;
+}
+
+static void
+schedule_aging_flush(struct vea_space_info *vsi)
+{
+	int	rc;
+
+	D_ASSERT(vsi != NULL);
+	/* Don't schedule aging flush when external flush is specified */
+	if (vsi->vsi_unmap_ctxt.vnc_ext_flush)
+		return;
+
+	/* Do inline flush immediately when it's not in a transaction */
+	if (umem_tx_none(vsi->vsi_umem)) {
+		inline_aging_flush(vsi, false, MAX_FLUSH_FRAGS * 20, NULL);
+		return;
+	}
+
+	/* Check flush condition in advance to avoid unnecessary umem_tx_add_callback() */
+	if (!need_aging_flush(vsi, false))
+		return;
+
+	/* Schedule one transaction end callback flush is enough */
+	if (vsi->vsi_flush_scheduled)
+		return;
+
+	/*
+	 * Perform the flush in transaction end callback, since the flush operation
+	 * could yield on blob unmap.
+	 */
+	rc = umem_tx_add_callback(vsi->vsi_umem, vsi->vsi_txd, UMEM_STAGE_NONE,
+				  flush_end_cb, vsi);
+	if (rc)
+		DL_ERROR(rc, "Add transaction end callback error.");
+	else
+		vsi->vsi_flush_scheduled = true;
+}
+
 /*
  * Free allocated extent.
  *
@@ -688,12 +771,8 @@ done:
 	/* Commit/Abort transaction on success/error */
 	rc = rc ? umem_tx_abort(umem, rc) : umem_tx_commit(umem);
 	/* Flush the expired aging free extents to compound index */
-	if (rc == 0) {
-		if (umem_tx_none(umem))
-			aging_flush(vsi, false, MAX_FLUSH_FRAGS * 20, NULL);
-		else
-			schedule_aging_flush(vsi);
-	}
+	if (rc == 0)
+		schedule_aging_flush(vsi);
 error:
 	/*
 	 * -DER_NONEXIST or -DER_ENOENT could be ignored by some caller,
@@ -878,12 +957,12 @@ vea_query(struct vea_space_info *vsi, struct vea_attr *attr,
 }
 
 int
-vea_flush(struct vea_space_info *vsi, bool force, uint32_t nr_flush, uint32_t *nr_flushed)
+vea_flush(struct vea_space_info *vsi, uint32_t nr_flush, uint32_t *nr_flushed)
 {
 	if (!umem_tx_none(vsi->vsi_umem)) {
 		D_ERROR("This function isn't supposed to be called in transaction!\n");
 		return -DER_INVAL;
 	}
 
-	return trigger_aging_flush(vsi, force, nr_flush, nr_flushed);
+	return trigger_aging_flush(vsi, false, nr_flush, nr_flushed);
 }

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -766,16 +766,17 @@ aggregated_free(struct vea_space_info *vsi, struct vea_free_entry *vfe)
 	return 0;
 }
 
-#define FLUSH_INTVL		5	/* seconds */
 #define EXPIRE_INTVL		10	/* seconds */
+#define UNMAP_SIZE_THRESH	(1UL << 20)	/* 1MB */
 
 static int
-flush_internal(struct vea_space_info *vsi, bool force, uint32_t cur_time, d_sg_list_t *unmap_sgl)
+flush_internal(struct vea_space_info *vsi, bool force, uint32_t cur_time, d_sg_list_t *unmap_sgl,
+	       d_sg_list_t *free_sgl)
 {
 	struct vea_free_entry	*entry, *tmp;
 	struct vea_free_extent	 vfe;
 	struct vea_free_entry	 free_entry;
-	d_iov_t			*unmap_iov;
+	d_iov_t			*ext_iov;
 	int			 i, rc = 0;
 	d_iov_t			 key;
 	struct vea_bitmap_entry	*bitmap;
@@ -784,6 +785,7 @@ flush_internal(struct vea_space_info *vsi, bool force, uint32_t cur_time, d_sg_l
 
 	D_ASSERT(umem_tx_none(vsi->vsi_umem));
 	D_ASSERT(unmap_sgl->sg_nr_out == 0);
+	D_ASSERT(free_sgl->sg_nr_out == 0);
 
 	D_ALLOC_ARRAY(flush_bitmaps, MAX_FLUSH_FRAGS);
 	if (!flush_bitmaps)
@@ -813,25 +815,37 @@ flush_internal(struct vea_space_info *vsi, bool force, uint32_t cur_time, d_sg_l
 			break;
 		}
 
-		flush_bitmaps[unmap_sgl->sg_nr_out] = bitmap;
-		/* Unmap callback may yield, so we can't call it directly in this tight loop */
-		unmap_sgl->sg_nr_out++;
-		unmap_iov = &unmap_sgl->sg_iovs[unmap_sgl->sg_nr_out - 1];
-		unmap_iov->iov_buf = (void *)vfe.vfe_blk_off;
-		unmap_iov->iov_len = vfe.vfe_blk_cnt;
+		flush_bitmaps[free_sgl->sg_nr_out] = bitmap;
+		ext_iov = &free_sgl->sg_iovs[free_sgl->sg_nr_out];
+		ext_iov->iov_buf = (void *)vfe.vfe_blk_off;
+		ext_iov->iov_len = vfe.vfe_blk_cnt;
+		free_sgl->sg_nr_out++;
+		/*
+		 * Unmap callback may yield, so we can't call it directly in this tight loop.
+		 *
+		 * Given that unmap a tiny extent (much smaller than a SSD erase block) doesn't
+		 * make sense and too many parallel unmap calls could impact I/O performance, we
+		 * opt to unmap only large enough extent.
+		 */
+		if (vfe.vfe_blk_cnt >= (UNMAP_SIZE_THRESH / vsi->vsi_md->vsd_blk_sz)) {
+			ext_iov = &unmap_sgl->sg_iovs[unmap_sgl->sg_nr_out];
+			ext_iov->iov_buf = (void *)vfe.vfe_blk_off;
+			ext_iov->iov_len = vfe.vfe_blk_cnt;
+			unmap_sgl->sg_nr_out++;
+		}
 
-		if (unmap_sgl->sg_nr_out == MAX_FLUSH_FRAGS)
+		if (free_sgl->sg_nr_out == MAX_FLUSH_FRAGS)
 			break;
 	}
 
 	vsi->vsi_flush_time = cur_time;
 
 	/*
-	 * According to NVMe spec, unmap isn't an expensive non-queue command
-	 * anymore, so we should just unmap as soon as the extent is freed.
+	 * According to NVMe spec, unmap isn't an expensive non-queue command anymore, so we
+	 * should just unmap as soon as the extent is freed.
 	 *
-	 * Since unmap could yield, it must be called before the compound_free(),
-	 * otherwise, the extent could be visible for allocation before unmap done.
+	 * Since unmap could yield, it must be called before the compound_free(), otherwise,
+	 * the extent could be visible for allocation before unmap done.
 	 */
 	if (vsi->vsi_unmap_ctxt.vnc_unmap != NULL && unmap_sgl->sg_nr_out > 0) {
 		rc = vsi->vsi_unmap_ctxt.vnc_unmap(unmap_sgl, vsi->vsi_md->vsd_blk_sz,
@@ -841,11 +855,11 @@ flush_internal(struct vea_space_info *vsi, bool force, uint32_t cur_time, d_sg_l
 				unmap_sgl->sg_nr_out, DP_RC(rc));
 	}
 
-	for (i = 0; i < unmap_sgl->sg_nr_out; i++) {
-		unmap_iov = &unmap_sgl->sg_iovs[i];
+	for (i = 0; i < free_sgl->sg_nr_out; i++) {
+		ext_iov = &free_sgl->sg_iovs[i];
 
-		free_entry.vfe_ext.vfe_blk_off = (uint64_t)unmap_iov->iov_buf;
-		free_entry.vfe_ext.vfe_blk_cnt = unmap_iov->iov_len;
+		free_entry.vfe_ext.vfe_blk_off = (uint64_t)ext_iov->iov_buf;
+		free_entry.vfe_ext.vfe_blk_cnt = ext_iov->iov_len;
 		free_entry.vfe_ext.vfe_age = cur_time;
 		free_entry.vfe_bitmap = flush_bitmaps[i];
 
@@ -858,22 +872,6 @@ flush_internal(struct vea_space_info *vsi, bool force, uint32_t cur_time, d_sg_l
 	D_FREE(flush_bitmaps);
 
 	return rc;
-}
-
-static inline bool
-need_aging_flush(struct vea_space_info *vsi, uint32_t cur_time, bool force)
-{
-	if (d_list_empty(&vsi->vsi_agg_lru))
-		return false;
-
-	/* External flush controls the flush rate externally */
-	if (vsi->vsi_unmap_ctxt.vnc_ext_flush)
-		return true;
-
-	if (!force && cur_time < (vsi->vsi_flush_time + FLUSH_INTVL))
-		return false;
-
-	return true;
 }
 
 void
@@ -906,7 +904,7 @@ free:
 }
 
 static int
-reclaim_unused_bitmap(struct vea_space_info *vsi, uint32_t nr_reclaim, uint32_t *nr_reclaimed)
+reclaim_unused_bitmap(struct vea_space_info *vsi, uint32_t nr_reclaim)
 {
 	int				 i;
 	struct vea_bitmap_entry		*bitmap_entry;
@@ -966,8 +964,8 @@ reclaim_unused_bitmap(struct vea_space_info *vsi, uint32_t nr_reclaim, uint32_t 
 					"tree error: "DF_RC"\n", blk_off, blk_cnt, DP_RC(rc));
 				goto abort;
 			}
-			/* call persistent_free_extent instead */
-			rc = persistent_free(vsi, &fca->fca_vfe);
+
+			rc = persistent_free_extent(vsi, &fca->fca_vfe.vfe_ext);
 			if (rc) {
 				D_ERROR("Remove ["DF_U64", %u] from persistent "
 					"extent tree error: "DF_RC"\n", blk_off,
@@ -986,102 +984,54 @@ abort:
 				return rc;
 			nr++;
 			if (nr >= nr_reclaim)
-				goto out;
+				return rc;
 		}
 	}
 
-out:
-	if (nr_reclaimed)
-		*nr_reclaimed = nr;
 	return rc;
 }
 
 int
-trigger_aging_flush(struct vea_space_info *vsi, bool force, uint32_t nr_flush,
-		    uint32_t *nr_flushed)
+trigger_aging_flush(struct vea_space_info *vsi, bool force, uint32_t nr_flush, uint32_t *nr_flushed)
 {
-	d_sg_list_t	 unmap_sgl;
+	d_sg_list_t	 unmap_sgl, free_sgl;
 	uint32_t	 cur_time, tot_flushed = 0;
 	int		 rc;
 
 	D_ASSERT(nr_flush > 0);
-	if (!umem_tx_none(vsi->vsi_umem)) {
-		rc = -DER_INVAL;
-		goto out;
-	}
+	D_ASSERT(umem_tx_none(vsi->vsi_umem));
 
 	cur_time = get_current_age();
-	if (!need_aging_flush(vsi, cur_time, force)) {
-		rc = 0;
+	rc = reclaim_unused_bitmap(vsi, 10);
+	if (rc)
 		goto out;
-	}
 
 	rc = d_sgl_init(&unmap_sgl, MAX_FLUSH_FRAGS);
 	if (rc)
 		goto out;
+	rc = d_sgl_init(&free_sgl, MAX_FLUSH_FRAGS);
+	if (rc) {
+		d_sgl_fini(&unmap_sgl, false);
+		goto out;
+	}
 
 	while (tot_flushed < nr_flush) {
-		rc = flush_internal(vsi, force, cur_time, &unmap_sgl);
+		rc = flush_internal(vsi, force, cur_time, &unmap_sgl, &free_sgl);
 
-		tot_flushed += unmap_sgl.sg_nr_out;
-		if (rc || unmap_sgl.sg_nr_out < MAX_FLUSH_FRAGS)
+		tot_flushed += free_sgl.sg_nr_out;
+		if (rc || free_sgl.sg_nr_out < MAX_FLUSH_FRAGS)
 			break;
 
 		unmap_sgl.sg_nr_out = 0;
+		free_sgl.sg_nr_out = 0;
 	}
 
 	d_sgl_fini(&unmap_sgl, false);
+	d_sgl_fini(&free_sgl, false);
 
-	rc = reclaim_unused_bitmap(vsi, MAX_FLUSH_FRAGS, NULL);
-	if (rc)
-		goto out;
 out:
 	if (nr_flushed != NULL)
 		*nr_flushed = tot_flushed;
 
 	return rc;
-}
-
-static void
-flush_end_cb(void *data, bool noop)
-{
-	struct vea_space_info	*vsi = data;
-
-	if (!noop)
-		trigger_aging_flush(vsi, false, MAX_FLUSH_FRAGS * 20, NULL);
-
-	vsi->vsi_flush_scheduled = false;
-}
-
-int
-schedule_aging_flush(struct vea_space_info *vsi)
-{
-	int	rc;
-
-	D_ASSERT(vsi != NULL);
-
-	if (vsi->vsi_unmap_ctxt.vnc_ext_flush)
-		return 0;
-
-	/* Check flush condition in advance to avoid unnecessary umem_tx_add_callback() */
-	if (!need_aging_flush(vsi, get_current_age(), false))
-		return 0;
-
-	/* Schedule one transaction end callback flush is enough */
-	if (vsi->vsi_flush_scheduled)
-		return 0;
-
-	/*
-	 * Perform the flush in transaction end callback, since the flush operation
-	 * could yield on blob unmap.
-	 */
-	rc = umem_tx_add_callback(vsi->vsi_umem, vsi->vsi_txd, UMEM_STAGE_NONE,
-				  flush_end_cb, vsi);
-	if (rc) {
-		D_ERROR("Add transaction end callback error "DF_RC"\n", DP_RC(rc));
-		return rc;
-	}
-	vsi->vsi_flush_scheduled = true;
-
-	return 0;
 }

--- a/src/vea/vea_internal.h
+++ b/src/vea/vea_internal.h
@@ -310,7 +310,6 @@ int persistent_free(struct vea_space_info *vsi, struct vea_free_entry *vfe);
 int aggregated_free(struct vea_space_info *vsi, struct vea_free_entry *vfe);
 int trigger_aging_flush(struct vea_space_info *vsi, bool force,
 			uint32_t nr_flush, uint32_t *nr_flushed);
-int schedule_aging_flush(struct vea_space_info *vsi);
 int bitmap_entry_insert(struct vea_space_info *vsi, struct vea_free_bitmap *vfb,
 			int state, struct vea_bitmap_entry **ret_entry, unsigned int flags);
 int free_type(struct vea_space_info *vsi, uint64_t blk_off, uint32_t blk_cnt,

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -1144,7 +1144,7 @@ vos_gc_pool(daos_handle_t poh, int credits, int (*yield_func)(void *arg),
 	/* To accelerate flush on container destroy done */
 	if (!gc_have_pool(pool)) {
 		if (pool->vp_vea_info != NULL)
-			rc = vea_flush(pool->vp_vea_info, true, UINT32_MAX, &nr_flushed);
+			rc = vea_flush(pool->vp_vea_info, UINT32_MAX, &nr_flushed);
 		return rc < 0 ? rc : nr_flushed;
 	}
 
@@ -1199,7 +1199,7 @@ gc_reserve_space(daos_size_t *rsrvd)
 
 /** Exported VOS API for explicit VEA flush */
 int
-vos_flush_pool(daos_handle_t poh, bool force, uint32_t nr_flush, uint32_t *nr_flushed)
+vos_flush_pool(daos_handle_t poh, uint32_t nr_flush, uint32_t *nr_flushed)
 {
 	struct vos_pool	*pool = vos_hdl2pool(poh);
 	int		 rc;
@@ -1212,7 +1212,7 @@ vos_flush_pool(daos_handle_t poh, bool force, uint32_t nr_flush, uint32_t *nr_fl
 		return 1;
 	}
 
-	rc = vea_flush(pool->vp_vea_info, force, nr_flush, nr_flushed);
+	rc = vea_flush(pool->vp_vea_info, nr_flush, nr_flushed);
 	if (rc)
 		D_ERROR("VEA flush failed. "DF_RC"\n", DP_RC(rc));
 


### PR DESCRIPTION
Given that it doesn't make sense to unmap tiny extents (much smaller than SSD erase block size), and too many parallel unmap calls could impact I/O performance, we opt to unmap only large enough extents.

This patch also removes 'force' aging flush and guarantees a free extent would never be made available for allocation unless it expires (10 seconds by default), so that following potential data corruption could be avoided:
 - Server starts NVMe DMA transfer over an NVMe extent for fetch request.
 - Aggregation freed the NVMe extent when coalesceing small extents.
 - The freed NVMe extent is immediately made available by 'force' aging flush.
 - The NVMe extent is allocated & being overwritten by others before the fetch done.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
