### PR TITLE
DAOS-14510 umem: dav_reserve now commits WAL immediately

### DIFF
--- a/src/common/dav_v2/dav_v2.h
+++ b/src/common/dav_v2/dav_v2.h
@@ -98,11 +98,6 @@ dav_free_v2(dav_obj_t *pop, uint64_t off);
  */
 void *
 dav_memcpy_persist_v2(dav_obj_t *pop, void *dest, const void *src, size_t len);
-/*
- * DAV version of memcpy with deferred commit to blob.
- */
-void *
-dav_memcpy_persist_relaxed_v2(dav_obj_t *pop, void *dest, const void *src, size_t len);
 
 /*
  * If called for the first time on a newly created dav heap, the root object

--- a/src/common/dav_v2/tx.c
+++ b/src/common/dav_v2/tx.c
@@ -463,8 +463,10 @@ lw_tx_begin(dav_obj_t *pop)
 	}
 	if (pop->do_utx == NULL) {
 		utx = dav_umem_wtx_new(pop);
-		if (utx == NULL)
-			return obj_tx_fail_err(EINVAL, 0);
+		if (utx == NULL) {
+			D_ERROR("dav_umem_wtx_new failed\n");
+			return ENOMEM;
+		}
 	}
 	pop->do_utx->utx_id = wal_id;
 	return rc;
@@ -1488,7 +1490,8 @@ static int
 obj_alloc_root(dav_obj_t *pop, size_t size)
 {
 	struct operation_context *ctx;
-	struct carg_realloc carg;
+	struct carg_realloc       carg;
+	int                       ret;
 
 	DAV_DBG("pop %p size %zu", pop, size);
 
@@ -1500,16 +1503,19 @@ obj_alloc_root(dav_obj_t *pop, size_t size)
 	carg.zero_init = 1;
 	carg.arg = NULL;
 
-	lw_tx_begin(pop);
+	ret = lw_tx_begin(pop);
+	if (ret)
+		return ret;
+
 	ctx = pop->external;
 	operation_start(ctx);
 
 	operation_add_entry(ctx, &pop->do_phdr->dp_root_size, size, ULOG_OPERATION_SET);
 
-	int ret = palloc_operation(pop->do_heap, pop->do_phdr->dp_root_offset,
-			&pop->do_phdr->dp_root_offset, size,
-			constructor_zrealloc_root, &carg,
-			0, 0, 0, 0, ctx); /* REVISIT: object_flags and type num ignored*/
+	ret =
+	    palloc_operation(pop->do_heap, pop->do_phdr->dp_root_offset,
+			     &pop->do_phdr->dp_root_offset, size, constructor_zrealloc_root, &carg,
+			     0, 0, 0, 0, ctx); /* REVISIT: object_flags and type num ignored*/
 
 	lw_tx_end(pop, NULL);
 	return ret;
@@ -1538,17 +1544,13 @@ dav_root_v2(dav_obj_t *pop, size_t size)
 		return 0;
 	}
 
-	/* REVISIT START
-	 * For thread safety the below block has to be protected by lock
-	 */
 	if (size > pop->do_phdr->dp_root_size &&
 			obj_alloc_root(pop, size)) {
 		ERR("dav_root failed");
+		errno = ENOMEM;
 		DAV_API_END();
 		return 0;
 	}
-
-	/* REVISIT END */
 
 	DAV_API_END();
 	return pop->do_phdr->dp_root_offset;
@@ -1591,7 +1593,8 @@ obj_alloc_construct(dav_obj_t *pop, uint64_t *offp, size_t size,
 	dav_constr constructor, void *arg)
 {
 	struct operation_context *ctx;
-	struct constr_args carg;
+	struct constr_args        carg;
+	int                       ret;
 
 	if (size > DAV_MAX_ALLOC_SIZE) {
 		ERR("requested size too large");
@@ -1603,12 +1606,14 @@ obj_alloc_construct(dav_obj_t *pop, uint64_t *offp, size_t size,
 	carg.constructor = constructor;
 	carg.arg = arg;
 
-	lw_tx_begin(pop);
+	ret = lw_tx_begin(pop);
+	if (ret)
+		return ret;
 	ctx = pop->external;
 	operation_start(ctx);
 
-	int ret = palloc_operation(pop->do_heap, 0, offp, size, constructor_alloc, &carg, type_num,
-				   0, CLASS_ID_FROM_FLAG(flags), EZONE_ID_FROM_FLAG(flags), ctx);
+	ret = palloc_operation(pop->do_heap, 0, offp, size, constructor_alloc, &carg, type_num, 0,
+			       CLASS_ID_FROM_FLAG(flags), EZONE_ID_FROM_FLAG(flags), ctx);
 
 	lw_tx_end(pop, NULL);
 	return ret;
@@ -1639,6 +1644,10 @@ dav_alloc_v2(dav_obj_t *pop, uint64_t *offp, size_t size, uint64_t type_num, uin
 
 	DAV_API_START();
 	int ret = obj_alloc_construct(pop, offp, size, type_num, flags, constructor, arg);
+	if (ret) {
+		errno = ret;
+		ret   = -1;
+	}
 
 	DAV_API_END();
 	return ret;
@@ -1651,6 +1660,7 @@ DAV_FUNC_EXPORT void
 dav_free_v2(dav_obj_t *pop, uint64_t off)
 {
 	struct operation_context *ctx;
+	int                       rc;
 
 	DAV_DBG("oid.off 0x%016" PRIx64, off);
 
@@ -1661,7 +1671,8 @@ dav_free_v2(dav_obj_t *pop, uint64_t off)
 
 	ASSERTne(pop, NULL);
 	ASSERT(OBJ_OFF_IS_VALID(pop, off));
-	lw_tx_begin(pop);
+	rc = lw_tx_begin(pop);
+	D_ASSERT(rc == 0);
 	ctx = pop->external;
 	operation_start(ctx);
 
@@ -1679,33 +1690,18 @@ DAV_FUNC_EXPORT void *
 dav_memcpy_persist_v2(dav_obj_t *pop, void *dest, const void *src,
 	size_t len)
 {
+	int rc;
+
 	DAV_DBG("pop %p dest %p src %p len %zu", pop, dest, src, len);
 	D_ASSERT((dav_tx_stage_v2() == DAV_TX_STAGE_NONE));
 
 	DAV_API_START();
-	lw_tx_begin(pop);
+	rc = lw_tx_begin(pop);
+	D_ASSERT(rc == 0);
 
 	void *ptr = mo_wal_memcpy(&pop->p_ops, dest, src, len, 0);
 
 	lw_tx_end(pop, NULL);
-	DAV_API_END();
-	return ptr;
-}
-
-/*
- * dav_memcpy_persist -- dav version of memcpy with deferrred commit to blob.
- */
-DAV_FUNC_EXPORT void *
-dav_memcpy_persist_relaxed_v2(dav_obj_t *pop, void *dest, const void *src,
-			   size_t len)
-{
-	DAV_DBG("pop %p dest %p src %p len %zu", pop, dest, src, len);
-	DAV_API_START();
-	if (pop->do_utx == NULL && dav_umem_wtx_new(pop) == NULL)
-		return 0;
-
-	void *ptr = mo_wal_memcpy(&pop->p_ops, dest, src, len, 0);
-
 	DAV_API_END();
 	return ptr;
 }
@@ -1718,6 +1714,8 @@ dav_reserve_v2(dav_obj_t *pop, struct dav_action *act, size_t size, uint64_t typ
 		uint64_t flags)
 {
 	struct constr_args carg;
+	int                tx_inprogress = 0;
+	int                rc;
 
 	DAV_DBG(3, "pop %p act %p size %zu type_num %llx flags %llx", pop, act, size,
 		(unsigned long long)type_num, (unsigned long long)flags);
@@ -1728,10 +1726,15 @@ dav_reserve_v2(dav_obj_t *pop, struct dav_action *act, size_t size, uint64_t typ
 		return 0;
 	}
 
-	DAV_API_START();
+	if (get_tx()->stage != DAV_TX_STAGE_NONE)
+		tx_inprogress = 1;
 
-	if (pop->do_utx == NULL && dav_umem_wtx_new(pop) == NULL)
-		return 0;
+	DAV_API_START();
+	if (!tx_inprogress) {
+		rc = lw_tx_begin(pop);
+		if (rc)
+			return 0;
+	}
 
 	carg.zero_init   = flags & DAV_FLAG_ZERO;
 	carg.constructor = NULL;
@@ -1743,6 +1746,8 @@ dav_reserve_v2(dav_obj_t *pop, struct dav_action *act, size_t size, uint64_t typ
 		return 0;
 	}
 
+	if (!tx_inprogress)
+		lw_tx_end(pop, NULL);
 	DAV_API_END();
 	return act->heap.offset;
 }

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -1506,10 +1506,8 @@ bmem_atomic_copy_v2(struct umem_instance *umm, void *dest, const void *src,
 	if (hint == UMEM_RESERVED_MEM) {
 		memcpy(dest, src, len);
 		return dest;
-	} else if (hint == UMEM_COMMIT_IMMEDIATE) {
+	} else { /* UMEM_COMMIT_IMMEDIATE */
 		return dav_memcpy_persist_v2(pop, dest, src, len);
-	} else { /* UMEM_COMMIT_DEFER */
-		return dav_memcpy_persist_relaxed_v2(pop, dest, src, len);
 	}
 }
 


### PR DESCRIPTION
Fixed a race involving dav_reserve which violated the rule of “checkpointing must be done after WAL is committed”. Additionally removed the atomic copy functionality with UMEM_COMMIT_DEFER flag.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
