### PR TITLE
crt tree type usgae fix

### DIFF
--- a/src/cart/crt_tree.h
+++ b/src/cart/crt_tree.h
@@ -114,7 +114,7 @@ crt_treerank_2_grprank(uint32_t grp_size, uint32_t grp_root, uint32_t tree_rank)
 }
 
 static inline uint32_t
-crt_grprank_2_teerank(uint32_t grp_size, uint32_t grp_root, uint32_t grp_rank)
+crt_grprank_2_treerank(uint32_t grp_size, uint32_t grp_root, uint32_t grp_rank)
 {
 	D_ASSERT(grp_size > 0);
 	D_ASSERT(grp_root < grp_size);

--- a/src/cart/crt_tree_kary.c
+++ b/src/cart/crt_tree_kary.c
@@ -44,7 +44,7 @@ crt_kary_get_children_cnt(uint32_t grp_size, uint32_t tree_ratio,
 	D_ASSERT(tree_ratio >= CRT_TREE_MIN_RATIO &&
 		 tree_ratio <= CRT_TREE_MAX_RATIO);
 
-	tree_self = crt_grprank_2_teerank(grp_size, grp_root, grp_self);
+	tree_self = crt_grprank_2_treerank(grp_size, grp_root, grp_self);
 
 	*nchildren = kary_get_children(NULL, tree_self, grp_size, tree_ratio);
 
@@ -64,7 +64,7 @@ crt_kary_get_children(uint32_t grp_size, uint32_t tree_ratio,
 	D_ASSERT(tree_ratio >= CRT_TREE_MIN_RATIO &&
 		 tree_ratio <= CRT_TREE_MAX_RATIO);
 
-	tree_self = crt_grprank_2_teerank(grp_size, grp_root, grp_self);
+	tree_self = crt_grprank_2_treerank(grp_size, grp_root, grp_self);
 
 	nchildren = kary_get_children(children, tree_self, grp_size,
 				      tree_ratio);
@@ -90,7 +90,7 @@ crt_kary_get_parent(uint32_t grp_size, uint32_t tree_ratio, uint32_t grp_root,
 	if (grp_self == grp_root)
 		return -DER_INVAL;
 
-	tree_self = crt_grprank_2_teerank(grp_size, grp_root, grp_self);
+	tree_self = crt_grprank_2_treerank(grp_size, grp_root, grp_self);
 	D_ASSERT(tree_self != 0);
 
 	tree_parent = (tree_self - 1) / tree_ratio;

--- a/src/cart/crt_tree_knomial.c
+++ b/src/cart/crt_tree_knomial.c
@@ -111,7 +111,7 @@ crt_knomial_get_children_cnt(uint32_t grp_size, uint32_t tree_ratio,
 	D_ASSERT(tree_ratio >= CRT_TREE_MIN_RATIO &&
 		 tree_ratio <= CRT_TREE_MAX_RATIO);
 
-	tree_self = crt_grprank_2_teerank(grp_size, grp_root, grp_self);
+	tree_self = crt_grprank_2_treerank(grp_size, grp_root, grp_self);
 
 	*nchildren = knomial_get_children(NULL, tree_self, grp_size,
 					  tree_ratio);
@@ -133,7 +133,7 @@ crt_knomial_get_children(uint32_t grp_size, uint32_t tree_ratio,
 	D_ASSERT(tree_ratio >= CRT_TREE_MIN_RATIO &&
 		 tree_ratio <= CRT_TREE_MAX_RATIO);
 
-	tree_self = crt_grprank_2_teerank(grp_size, grp_root, grp_self);
+	tree_self = crt_grprank_2_treerank(grp_size, grp_root, grp_self);
 
 	nchildren = knomial_get_children(children, tree_self, grp_size,
 					 tree_ratio);
@@ -158,7 +158,7 @@ crt_knomial_get_parent(uint32_t grp_size, uint32_t tree_ratio,
 	if (grp_self == grp_root)
 		return -DER_INVAL;
 
-	tree_self = crt_grprank_2_teerank(grp_size, grp_root, grp_self);
+	tree_self = crt_grprank_2_treerank(grp_size, grp_root, grp_self);
 	D_ASSERT(tree_self != 0);
 
 	tree_parent = knomial_get_parent(tree_self, tree_ratio);

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1153,7 +1153,7 @@ bcast_create(crt_opcode_t opc, bool filter_invert, d_rank_list_t *filter_ranks,
 				    NULL /* co_bulk_hdl */, NULL /* priv */,
 				    filter_invert ?
 				    CRT_RPC_FLAG_FILTER_INVERT : 0,
-				    crt_tree_topo(CRT_TREE_FLAT, 0), rpc);
+				    crt_tree_topo(CRT_TREE_KNOMIAL, 0), rpc);
 }
 
 /**


### PR DESCRIPTION
DAOS-14544 CaRT: crt tree type usgae fix (#13238)
fix CRT_TREE_FLAT to CRT_TREE_KNOMIAL & fix spell error
Signed-off-by: shiying yshi1210@gmail.com