### PR TITLE
DAOS-12961 cart: return error if crt_provider_get_ctx_idx() failed

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -223,10 +223,10 @@ crt_context_provider_create(crt_context_t *crt_ctx, crt_provider_t provider, boo
 	}
 
 	D_RWLOCK_WRLOCK(&crt_gdata.cg_rwlock);
-	max_ctx_num = crt_provider_get_max_ctx_num(primary, provider);
 	ctx_idx = crt_provider_get_ctx_idx(primary, provider);
 
-	if (ctx_idx < 0 || ctx_idx >= max_ctx_num) {
+	if (ctx_idx < 0) {
+		max_ctx_num = crt_provider_get_max_ctx_num(primary, provider);
 		D_WARN("Provider: %d; Context limit (%d) reached\n",
 		       provider, max_ctx_num);
 		D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -619,7 +619,7 @@ crt_provider_get_ctx_idx(bool primary, int provider)
 	struct crt_prov_gdata	*prov_data = crt_get_prov_gdata(primary, provider);
 	int			i;
 
-	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
+	for (i = 0; i < prov_data->cpg_ctx_max_num; i++) {
 		if (prov_data->cpg_used_idx[i] == false) {
 			prov_data->cpg_used_idx[i] = true;
 			prov_data->cpg_ctx_num++;


### PR DESCRIPTION
Fix to return error for crt_provider_get_ctx_idx(), so we don't need
call crt_provider_put_ctx_idx() if it failed to avoid assertion in crt_finalize().

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
