### PR TITLE
DAOS-14251 control: Allow premounted empty tmpfs (#12968)

### DIFF
--- a/src/control/cmd/daos_server/start.go
+++ b/src/control/cmd/daos_server/start.go
@@ -64,7 +64,9 @@ func (cmd *startCmd) setCLIOverrides() error {
 	if cmd.Modules != nil {
 		cmd.config.WithModules(*cmd.Modules)
 	}
-	cmd.config.RecreateSuperblocks = cmd.RecreateSuperblocks
+	if cmd.RecreateSuperblocks {
+		cmd.Notice("--recreate-superblocks is deprecated and no longer needed to use externally-managed tmpfs")
+	}
 
 	for _, srv := range cmd.config.Engines {
 		if cmd.Targets > 0 {

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -79,6 +79,7 @@ const (
 	ScmBadRegion
 	ScmInvalidPMem
 	ScmRamdiskLowMem
+	ScmRamdiskBadSize
 	ScmConfigTierMissing
 )
 

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -40,26 +40,25 @@ const (
 // See utils/config/daos_server.yml for parameter descriptions.
 type Server struct {
 	// control-specific
-	ControlPort         int                       `yaml:"port"`
-	TransportConfig     *security.TransportConfig `yaml:"transport_config"`
-	Engines             []*engine.Config          `yaml:"engines"`
-	BdevExclude         []string                  `yaml:"bdev_exclude,omitempty"`
-	DisableVFIO         bool                      `yaml:"disable_vfio"`
-	DisableVMD          *bool                     `yaml:"disable_vmd"`
-	EnableHotplug       bool                      `yaml:"enable_hotplug"`
-	NrHugepages         int                       `yaml:"nr_hugepages"`        // total for all engines
-	SystemRamReserved   int                       `yaml:"system_ram_reserved"` // total for all engines
-	DisableHugepages    bool                      `yaml:"disable_hugepages"`
-	ControlLogMask      common.ControlLogLevel    `yaml:"control_log_mask"`
-	ControlLogFile      string                    `yaml:"control_log_file,omitempty"`
-	ControlLogJSON      bool                      `yaml:"control_log_json,omitempty"`
-	HelperLogFile       string                    `yaml:"helper_log_file,omitempty"`
-	FWHelperLogFile     string                    `yaml:"firmware_helper_log_file,omitempty"`
-	RecreateSuperblocks bool                      `yaml:"recreate_superblocks,omitempty"`
-	FaultPath           string                    `yaml:"fault_path,omitempty"`
-	TelemetryPort       int                       `yaml:"telemetry_port,omitempty"`
-	CoreDumpFilter      uint8                     `yaml:"core_dump_filter,omitempty"`
-	ClientEnvVars       []string                  `yaml:"client_env_vars,omitempty"`
+	ControlPort       int                       `yaml:"port"`
+	TransportConfig   *security.TransportConfig `yaml:"transport_config"`
+	Engines           []*engine.Config          `yaml:"engines"`
+	BdevExclude       []string                  `yaml:"bdev_exclude,omitempty"`
+	DisableVFIO       bool                      `yaml:"disable_vfio"`
+	DisableVMD        *bool                     `yaml:"disable_vmd"`
+	EnableHotplug     bool                      `yaml:"enable_hotplug"`
+	NrHugepages       int                       `yaml:"nr_hugepages"`        // total for all engines
+	SystemRamReserved int                       `yaml:"system_ram_reserved"` // total for all engines
+	DisableHugepages  bool                      `yaml:"disable_hugepages"`
+	ControlLogMask    common.ControlLogLevel    `yaml:"control_log_mask"`
+	ControlLogFile    string                    `yaml:"control_log_file,omitempty"`
+	ControlLogJSON    bool                      `yaml:"control_log_json,omitempty"`
+	HelperLogFile     string                    `yaml:"helper_log_file,omitempty"`
+	FWHelperLogFile   string                    `yaml:"firmware_helper_log_file,omitempty"`
+	FaultPath         string                    `yaml:"fault_path,omitempty"`
+	TelemetryPort     int                       `yaml:"telemetry_port,omitempty"`
+	CoreDumpFilter    uint8                     `yaml:"core_dump_filter,omitempty"`
+	ClientEnvVars     []string                  `yaml:"client_env_vars,omitempty"`
 
 	// duplicated in engine.Config
 	SystemName string              `yaml:"name"`
@@ -84,13 +83,6 @@ type Server struct {
 // WithCoreDumpFilter sets the core dump filter written to /proc/self/coredump_filter.
 func (cfg *Server) WithCoreDumpFilter(filter uint8) *Server {
 	cfg.CoreDumpFilter = filter
-	return cfg
-}
-
-// WithRecreateSuperblocks indicates that a missing superblock should not be treated as
-// an error. The server will create new superblocks as necessary.
-func (cfg *Server) WithRecreateSuperblocks() *Server {
-	cfg.RecreateSuperblocks = true
 	return cfg
 }
 

--- a/src/control/server/config/server_legacy.go
+++ b/src/control/server/config/server_legacy.go
@@ -18,12 +18,21 @@ type ServerLegacy struct {
 	EnableVMD *bool `yaml:"enable_vmd,omitempty"`
 	// Detect outdated "servers" config, to direct users to change their config file.
 	Servers []*engine.Config `yaml:"servers,omitempty"`
+	// Detect outdated "recreate_superblocks" config, to direct users to change their config file.
+	RecreateSuperblocks bool `yaml:"recreate_superblocks,omitempty"`
 }
 
 // WithEnableVMD can be used to set the state of VMD functionality,
 // if not enabled then VMD devices will not be used if they exist.
 func (sl *ServerLegacy) WithEnableVMD(enabled bool) *ServerLegacy {
 	sl.EnableVMD = &enabled
+	return sl
+}
+
+// WithRecreateSuperblocks indicates that a missing superblock should not be treated as
+// an error. The server will create new superblocks as necessary.
+func (sl *ServerLegacy) WithRecreateSuperblocks() *ServerLegacy {
+	sl.RecreateSuperblocks = true
 	return sl
 }
 

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -622,6 +622,7 @@ type formatScmReq struct {
 
 func formatScm(ctx context.Context, req formatScmReq, resp *ctlpb.StorageFormatResp) (map[int]string, map[int]bool, error) {
 	needFormat := make(map[int]bool)
+	emptyTmpfs := make(map[int]bool)
 	scmCfgs := make(map[int]*storage.TierConfig)
 	allNeedFormat := true
 
@@ -640,6 +641,15 @@ func formatScm(ctx context.Context, req formatScmReq, resp *ctlpb.StorageFormatR
 			return nil, nil, errors.Wrap(err, "retrieving SCM config")
 		}
 		scmCfgs[idx] = scmCfg
+
+		// If the tmpfs was already mounted but empty, record that fact for later usage.
+		if scmCfg.Class == storage.ClassRam && !needs {
+			info, err := ei.GetStorage().GetScmUsage()
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "failed to check SCM usage for instance %d", idx)
+			}
+			emptyTmpfs[idx] = info.TotalBytes-info.AvailBytes == 0
+		}
 	}
 
 	if allNeedFormat {
@@ -672,7 +682,15 @@ func formatScm(ctx context.Context, req formatScmReq, resp *ctlpb.StorageFormatR
 			},
 		})
 
-		skipped[idx] = true
+		// In the normal case, where SCM wasn't already mounted, we want
+		// to trigger NVMe format. In the case where SCM was mounted and
+		// wasn't empty, we want to skip NVMe format, as we're using
+		// mountedness as a proxy for already-formatted. In the special
+		// case where tmpfs was already mounted but empty, we will treat it
+		// as an indication that the NVMe format needs to occur.
+		if !emptyTmpfs[idx] {
+			skipped[idx] = true
+		}
 	}
 
 	for formatting > 0 {
@@ -707,7 +725,7 @@ func formatNvme(ctx context.Context, req formatNvmeReq, resp *ctlpb.StorageForma
 		_, hasError := req.errored[idx]
 		_, skipped := req.skipped[idx]
 		if hasError || (skipped && !req.mdFormatted) {
-			// if scm errored or was already formatted, indicate skipping bdev format
+			// if scm failed to format or was already formatted, indicate skipping bdev format
 			ret := ei.newCret(storage.NilBdevAddress, nil)
 			ret.State.Info = fmt.Sprintf(msgNvmeFormatSkip, ei.Index())
 			resp.Crets = append(resp.Crets, ret)

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -1775,6 +1775,7 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		scmMounted       bool // if scmMounted we emulate ext4 fs is mounted
+		tmpfsEmpty       bool // if false, an already-mounted ramdisk is not empty
 		superblockExists bool
 		instancesStarted bool // engine already started
 		sMounts          []string
@@ -1980,6 +1981,44 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 							Status: ctlpb.ResponseStatus_CTL_SUCCESS,
 							Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),
 						},
+					},
+				},
+				Mrets: []*ctlpb.ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State: &ctlpb.ResponseState{
+							Status: ctlpb.ResponseStatus_CTL_SUCCESS,
+							Info:   "SCM is already formatted",
+						},
+					},
+				},
+			},
+		},
+		"ram already mounted but empty": {
+			scmMounted: true,
+			tmpfsEmpty: true,
+			sMounts:    []string{"/mnt/daos"},
+			sClass:     storage.ClassRam,
+			sSize:      6,
+			bClass:     storage.ClassNvme,
+			bDevs:      [][]string{{mockNvmeController0.PciAddr}},
+			bmbc: &bdev.MockBackendConfig{
+				ScanRes: &storage.BdevScanResponse{
+					Controllers: storage.NvmeControllers{mockNvmeController0},
+				},
+				FormatRes: &storage.BdevFormatResponse{
+					DeviceResponses: storage.BdevDeviceFormatResponses{
+						mockNvmeController0.PciAddr: &storage.BdevDeviceFormatResponse{
+							Formatted: true,
+						},
+					},
+				},
+			},
+			expResp: &ctlpb.StorageFormatResp{
+				Crets: []*ctlpb.NvmeControllerResult{
+					{
+						PciAddr: mockNvmeController0.PciAddr,
+						State:   new(ctlpb.ResponseState),
 					},
 				},
 				Mrets: []*ctlpb.ScmMountResult{
@@ -2245,6 +2284,19 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 				GetfsStr:       getFsRetStr,
 				SourceToTarget: devToMount,
 			}
+			if tc.sClass == storage.ClassRam {
+				total := uint64(1234)
+				avail := total
+				if !tc.tmpfsEmpty {
+					avail--
+				}
+				smsc.GetfsUsageResps = []system.GetfsUsageRetval{
+					{
+						Total: total,
+						Avail: avail,
+					},
+				}
+			}
 			sysProv := system.NewMockSysProvider(log, smsc)
 			mounter := mount.NewProvider(log, sysProv)
 			scmProv := scm.NewProvider(log, nil, sysProv, mounter)
@@ -2299,7 +2351,7 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 
 				// if the instance is expected to have a valid superblock, create one
 				if tc.superblockExists {
-					if err := ei.createSuperblock(false); err != nil {
+					if err := ei.createSuperblock(); err != nil {
 						t.Fatal(err)
 					}
 				} else {
@@ -2330,7 +2382,7 @@ func TestServer_CtlSvc_StorageFormat(t *testing.T) {
 				go func(ctx context.Context, e *EngineInstance) {
 					select {
 					case <-ctx.Done():
-					case awaitCh <- e.awaitStorageReady(ctx, false):
+					case awaitCh <- e.awaitStorageReady(ctx):
 					}
 				}(ctx, ei.(*EngineInstance))
 			}

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -62,7 +62,7 @@ type Engine interface {
 	IsReady() bool
 	LocalState() system.MemberState
 	RemoveSuperblock() error
-	Run(context.Context, bool)
+	Run(context.Context)
 	SetupRank(context.Context, ranklist.Rank, uint32) error
 	Stop(os.Signal) error
 	OnInstanceExit(...onInstanceExitFn)
@@ -260,7 +260,7 @@ func (h *EngineHarness) Start(ctx context.Context, db dbLeader, cfg *config.Serv
 	defer h.started.SetFalse()
 
 	for _, ei := range h.Instances() {
-		ei.Run(ctx, cfg.RecreateSuperblocks)
+		ei.Run(ctx)
 	}
 
 	h.OnDrpcFailure(newOnDrpcFailureFn(h.log, db))

--- a/src/control/server/instance_exec.go
+++ b/src/control/server/instance_exec.go
@@ -30,14 +30,14 @@ type EngineRunner interface {
 	GetConfig() *engine.Config
 }
 
-func (ei *EngineInstance) format(ctx context.Context, recreateSBs bool) error {
+func (ei *EngineInstance) format(ctx context.Context) error {
 	idx := ei.Index()
 
 	ei.log.Debugf("instance %d: checking if storage is formatted", idx)
-	if err := ei.awaitStorageReady(ctx, recreateSBs); err != nil {
+	if err := ei.awaitStorageReady(ctx); err != nil {
 		return err
 	}
-	if err := ei.createSuperblock(recreateSBs); err != nil {
+	if err := ei.createSuperblock(); err != nil {
 		return err
 	}
 
@@ -164,7 +164,7 @@ func (ei *EngineInstance) handleExit(ctx context.Context, exitPid int, exitErr e
 // will only return (if no errors are returned during setup) on I/O Engine
 // process exit (triggered by harness shutdown through context cancellation
 // or abnormal I/O Engine process termination).
-func (ei *EngineInstance) startRunner(parent context.Context, recreateSBs bool) (_ chan *engine.RunnerExitInfo, err error) {
+func (ei *EngineInstance) startRunner(parent context.Context) (_ chan *engine.RunnerExitInfo, err error) {
 	ctx, cancel := context.WithCancel(parent)
 	defer func() {
 		if err != nil {
@@ -174,7 +174,7 @@ func (ei *EngineInstance) startRunner(parent context.Context, recreateSBs bool) 
 		}
 	}()
 
-	if err = ei.format(ctx, recreateSBs); err != nil {
+	if err = ei.format(ctx); err != nil {
 		return
 	}
 
@@ -198,7 +198,7 @@ func (ei *EngineInstance) requestStart(ctx context.Context) {
 
 // Run starts the control loop for an EngineInstance. Engine starts are triggered by
 // calling requestStart() on the instance.
-func (ei *EngineInstance) Run(ctx context.Context, recreateSBs bool) {
+func (ei *EngineInstance) Run(ctx context.Context) {
 	// Start the instance control loop.
 	go func() {
 		var runnerExitCh engine.RunnerExitChan
@@ -218,7 +218,7 @@ func (ei *EngineInstance) Run(ctx context.Context, recreateSBs bool) {
 					continue
 				}
 
-				runnerExitCh, err = ei.startRunner(ctx, recreateSBs)
+				runnerExitCh, err = ei.startRunner(ctx)
 				if err != nil {
 					ei.log.Errorf("runner exited without starting process: %s", err)
 					ei.handleExit(ctx, 0, err)

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -76,7 +76,7 @@ func createPublishFormatRequiredFunc(publish func(*events.RASEvent), hostname st
 }
 
 // awaitStorageReady blocks until instance has storage available and ready to be used.
-func (ei *EngineInstance) awaitStorageReady(ctx context.Context, skipMissingSuperblock bool) error {
+func (ei *EngineInstance) awaitStorageReady(ctx context.Context) error {
 	idx := ei.Index()
 
 	if ei.IsStarted() {
@@ -117,9 +117,6 @@ func (ei *EngineInstance) awaitStorageReady(ctx context.Context, skipMissingSupe
 	}
 
 	if !needsMetaFormat && !needsScmFormat {
-		if skipMissingSuperblock {
-			return nil
-		}
 		ei.log.Debugf("instance %d: no SCM format required; checking for superblock", idx)
 		needsSuperblock, err := ei.NeedsSuperblock()
 		if err != nil {
@@ -130,16 +127,6 @@ func (ei *EngineInstance) awaitStorageReady(ctx context.Context, skipMissingSupe
 			return nil
 		}
 		ei.log.Debugf("instance %d: superblock needed", idx)
-	}
-
-	if needsScmFormat {
-		cfg, err := ei.storage.GetScmConfig()
-		if err != nil {
-			return err
-		}
-		if skipMissingSuperblock {
-			return FaultScmUnmanaged(cfg.Scm.MountPoint)
-		}
 	}
 
 	// by this point we need superblock and possibly scm format

--- a/src/control/server/instance_storage_test.go
+++ b/src/control/server/instance_storage_test.go
@@ -361,7 +361,6 @@ func TestIOEngineInstance_awaitStorageReady(t *testing.T) {
 		engineStarted  bool
 		needsScmFormat bool
 		hasSB          bool
-		skipMissingSB  bool
 		engineIndex    uint32
 		expFmtType     string
 		expErr         error
@@ -369,14 +368,6 @@ func TestIOEngineInstance_awaitStorageReady(t *testing.T) {
 		"already started": {
 			engineStarted: true,
 			expErr:        errStarted,
-		},
-		"needs format but skip missing superblock": {
-			needsScmFormat: true,
-			skipMissingSB:  true,
-			expErr:         FaultScmUnmanaged("/mnt/test"),
-		},
-		"no need to format and skip missing superblock": {
-			skipMissingSB: true,
 		},
 		"no need to format and existing superblock": {
 			hasSB: true,
@@ -432,9 +423,9 @@ func TestIOEngineInstance_awaitStorageReady(t *testing.T) {
 			ctx, cancel := context.WithTimeout(test.Context(t), time.Millisecond*100)
 			defer cancel()
 
-			gotErr := engine.awaitStorageReady(ctx, tc.skipMissingSB)
+			gotErr := engine.awaitStorageReady(ctx)
 			test.CmpErr(t, tc.expErr, gotErr)
-			if tc.expErr == errStarted || tc.skipMissingSB == true || tc.hasSB == true {
+			if tc.expErr == errStarted || tc.hasSB == true {
 				return
 			}
 

--- a/src/control/server/instance_superblock.go
+++ b/src/control/server/instance_superblock.go
@@ -111,7 +111,7 @@ func (ei *EngineInstance) NeedsSuperblock() (bool, error) {
 }
 
 // createSuperblock creates instance superblock if needed.
-func (ei *EngineInstance) createSuperblock(recreate bool) error {
+func (ei *EngineInstance) createSuperblock() error {
 	if ei.IsStarted() {
 		return errors.Errorf("can't create superblock: instance %d already started", ei.Index())
 	}
@@ -120,7 +120,7 @@ func (ei *EngineInstance) createSuperblock(recreate bool) error {
 	if !needsSuperblock {
 		return nil
 	}
-	if err != nil && !recreate {
+	if err != nil {
 		return err
 	}
 

--- a/src/control/server/instance_superblock_test.go
+++ b/src/control/server/instance_superblock_test.go
@@ -56,7 +56,7 @@ func TestServer_Instance_createSuperblock(t *testing.T) {
 	}
 
 	for _, e := range h.Instances() {
-		if err := e.(*EngineInstance).createSuperblock(false); err != nil {
+		if err := e.(*EngineInstance).createSuperblock(); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/src/control/server/instance_test.go
+++ b/src/control/server/instance_test.go
@@ -248,7 +248,7 @@ func (mi *MockInstance) RemoveSuperblock() error {
 	return mi.cfg.RemoveSuperblockErr
 }
 
-func (mi *MockInstance) Run(_ context.Context, _ bool) {}
+func (mi *MockInstance) Run(_ context.Context) {}
 
 func (mi *MockInstance) SetupRank(_ context.Context, _ ranklist.Rank, _ uint32) error {
 	return mi.cfg.SetupRankErr

--- a/src/control/server/server_utils.go
+++ b/src/control/server/server_utils.go
@@ -540,6 +540,25 @@ func checkEngineTmpfsMem(srv *server, ei *EngineInstance, mi *common.MemInfo) er
 	memRamdisk := uint64(sc.Scm.RamdiskSize) * humanize.GiByte
 	memAvail := uint64(mi.MemAvailableKiB) * humanize.KiByte
 
+	// In the event that tmpfs was already mounted, we need to verify that it
+	// is the correct size and that the memory usage still makes sense.
+	if isMounted, err := ei.storage.ScmIsMounted(); err == nil && isMounted {
+		usage, err := ei.storage.GetScmUsage()
+		if err != nil {
+			return errors.Wrap(err, "unable to check tmpfs usage")
+		}
+		// Ensure that the existing ramdisk is not larger than the calculated
+		// optimal size, in order to avoid potential OOM situations.
+		if usage.TotalBytes > memRamdisk {
+			return storage.FaultRamdiskBadSize(usage.TotalBytes, memRamdisk)
+		}
+		// Looks OK, so we can return early and bypass additional checks.
+		srv.log.Debugf("using existing tmpfs of size %s", humanize.IBytes(usage.TotalBytes))
+		return nil
+	} else if err != nil {
+		return errors.Wrap(err, "unable to check for mounted tmpfs")
+	}
+
 	if err := checkMemForRamdisk(srv.log, memRamdisk, memAvail); err != nil {
 		return err
 	}

--- a/src/control/server/server_utils_test.go
+++ b/src/control/server/server_utils_test.go
@@ -753,9 +753,11 @@ func TestServer_prepBdevStorage(t *testing.T) {
 
 func TestServer_checkEngineTmpfsMem(t *testing.T) {
 	for name, tc := range map[string]struct {
-		srvCfgExtra func(*config.Server) *config.Server
-		memAvailGiB int
-		expErr      error
+		srvCfgExtra  func(*config.Server) *config.Server
+		memAvailGiB  int
+		tmpfsMounted bool
+		tmpfsSize    uint64
+		expErr       error
 	}{
 		"pmem tier; skip check": {
 			srvCfgExtra: func(sc *config.Server) *config.Server {
@@ -780,6 +782,21 @@ func TestServer_checkEngineTmpfsMem(t *testing.T) {
 			expErr: storage.FaultRamdiskLowMem("Available", 10*humanize.GiByte,
 				9*humanize.GiByte, 8*humanize.GiByte),
 		},
+		"tmpfs already mounted; more than calculated": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithEngines(ramEngine(0, 10))
+			},
+			tmpfsMounted: true,
+			tmpfsSize:    11,
+			expErr:       errors.New("ramdisk size"),
+		},
+		"tmpfs already mounted; less than calculated": {
+			srvCfgExtra: func(sc *config.Server) *config.Server {
+				return sc.WithEngines(ramEngine(0, 10))
+			},
+			tmpfsMounted: true,
+			tmpfsSize:    9,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(name)
@@ -799,7 +816,19 @@ func TestServer_checkEngineTmpfsMem(t *testing.T) {
 
 			ec := cfg.Engines[0]
 			runner := engine.NewRunner(log, ec)
-			provider := storage.MockProvider(log, 0, &ec.Storage, nil, nil, nil, nil)
+			sysMockCfg := &sysprov.MockSysConfig{
+				IsMountedBool: tc.tmpfsMounted,
+			}
+			if tc.tmpfsMounted {
+				sysMockCfg.GetfsUsageResps = []sysprov.GetfsUsageRetval{
+					{
+						Total: tc.tmpfsSize * humanize.GiByte,
+					},
+				}
+			}
+			sysMock := sysprov.NewMockSysProvider(log, sysMockCfg)
+			scmMock := &storage.MockScmProvider{}
+			provider := storage.MockProvider(log, 0, &ec.Storage, sysMock, scmMock, nil, nil)
 			instance := NewEngineInstance(log, provider, nil, runner)
 
 			srv, err := newServer(log, cfg, &system.FaultDomain{})

--- a/src/control/server/storage/faults.go
+++ b/src/control/server/storage/faults.go
@@ -78,6 +78,17 @@ func FaultRamdiskLowMem(memType string, confRamdiskSize, memNeed, memHave uint64
 			"file if reducing the requested amount of RAM is not possible")
 }
 
+// FaultRamdiskBadSize indicates that the already-mounted ramdisk is out
+// of spec with the calculated ramdisk size for the engine.
+func FaultRamdiskBadSize(existingSize, calcSize uint64) *fault.Fault {
+	return storageFault(
+		code.ScmRamdiskBadSize,
+		fmt.Sprintf("already-mounted ramdisk size %s is too far from optimal size of %s",
+			humanize.IBytes(existingSize), humanize.IBytes(calcSize)),
+		fmt.Sprintf("unmount the ramdisk and allow DAOS to manage it, or remount with size %s",
+			humanize.IBytes(calcSize)))
+}
+
 // FaultConfigRamdiskUnderMinMem indicates that the tmpfs size requested in config is less than
 // minimum allowed.
 func FaultConfigRamdiskUnderMinMem(confSize, memRamdiskMin uint64) *fault.Fault {


### PR DESCRIPTION
In the special case where the tmpfs has already been
mounted but is empty, don't skip NVMe format and
configuration. Enables the use case of running
daos_server in a container with an external tmpfs.

Signed-off-by: Michael MacDonald <mjmac@google.com>