### PR TITLE
DAOS-14559 ci: use isort to organize python imports (#13243)

### DIFF
--- a/ci/functional/junit_list_unsuccessful
+++ b/ci/functional/junit_list_unsuccessful
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """ list JUnit failures """
 
-from glob import glob
 import sys
-from junitparser import JUnitXml, Error, Failure
+from glob import glob
+
+from junitparser import Error, Failure, JUnitXml
 
 for file in glob(sys.argv[1]):
     for case in JUnitXml.fromfile(file):

--- a/ci/gha_helper.py
+++ b/ci/gha_helper.py
@@ -3,11 +3,11 @@
 """Helper module to choose build/cache keys to use for GitHub actions"""
 
 import os
-import sys
-from os.path import join
 import random
 import string
 import subprocess  # nosec
+import sys
+from os.path import join
 
 BUILD_FILES = ['site_scons/prereq_tools',
                'site_scons/components',

--- a/ci/jira_query.py
+++ b/ci/jira_query.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """Interface between CI and bug-tracking tools"""
 
-import os
-import sys
 import json
-import time
-import urllib
+import os
 import random
 import string
+import sys
+import time
+import urllib
+
 import jira
 
 # Script to improve interaction with Jenkins, GitHub and Jira.  This is intended to work in several

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.isort]
+supported_extensions = ["py"]
+skip = [".git/", "src/rdb/raft", "build", "install"]

--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -21,9 +21,10 @@
 """Defines common components used by HPDD projects"""
 
 import platform
+
 import distro
-from SCons.Script import GetOption
 from prereq_tools import GitRepoRetriever
+from SCons.Script import GetOption
 
 # Check if this is an ARM platform
 PROCESSOR = platform.machine()

--- a/site_scons/env_modules.py
+++ b/site_scons/env_modules.py
@@ -19,12 +19,13 @@
 # SOFTWARE.
 """Wrapper for Modules so we can load an MPI before builds or tests"""
 
-import os
-import sys
 import errno
-import subprocess  # nosec
+import os
 import shutil
+import subprocess  # nosec
+import sys
 from subprocess import PIPE, Popen  # nosec
+
 import distro
 
 

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -20,28 +20,23 @@
 # -*- coding: utf-8 -*-
 """Classes for building external prerequisite components"""
 
+import configparser
+import datetime
+import errno
+import json
 # pylint: disable=too-many-lines
 import os
-from copy import deepcopy
-import sys
-import json
-import datetime
-import traceback
-import errno
 import shutil
 import subprocess  # nosec
-import configparser
-from SCons.Variables import BoolVariable
-from SCons.Variables import EnumVariable
-from SCons.Variables import ListVariable
-from SCons.Variables import PathVariable
-from SCons.Script import Dir
-from SCons.Script import Exit
-from SCons.Script import GetOption
-from SCons.Script import SetOption
-from SCons.Script import WhereIs
-from SCons.Script import BUILD_TARGETS
+import sys
+import traceback
+from copy import deepcopy
+
 from SCons.Errors import InternalError
+from SCons.Script import (BUILD_TARGETS, Dir, Exit, GetOption, SetOption,
+                          WhereIs)
+from SCons.Variables import (BoolVariable, EnumVariable, ListVariable,
+                             PathVariable)
 
 
 class DownloadFailure(Exception):

--- a/site_scons/site_tools/compiler_setup.py
+++ b/site_scons/site_tools/compiler_setup.py
@@ -1,8 +1,6 @@
 """Common DAOS library for setting up the compiler"""
 
-from SCons.Script import GetOption, Exit
-from SCons.Script import Configure
-
+from SCons.Script import Configure, Exit, GetOption
 
 DESIRED_FLAGS = ['-fstack-usage',
                  '-Wno-sign-compare',

--- a/site_scons/site_tools/daos_builder.py
+++ b/site_scons/site_tools/daos_builder.py
@@ -1,13 +1,9 @@
 """Common DAOS build functions"""
 import os
 
-from SCons.Subst import Literal
-from SCons.Script import Dir
-from SCons.Script import GetOption
-from SCons.Script import WhereIs
-from SCons.Script import Depends
-from SCons.Script import Exit
 from env_modules import load_mpi
+from SCons.Script import Depends, Dir, Exit, GetOption, WhereIs
+from SCons.Subst import Literal
 
 libraries = {}
 missing = set()

--- a/site_scons/site_tools/doneapi.py
+++ b/site_scons/site_tools/doneapi.py
@@ -3,13 +3,13 @@
 Hack to support oneapi version of Intel compilers
 
 """
-import sys
 import os
+import sys
 
+import SCons.Errors
 import SCons.Tool.gcc
 import SCons.Util
 import SCons.Warnings
-import SCons.Errors
 
 
 # pylint: disable=too-few-public-methods

--- a/site_scons/site_tools/extra/__init__.py
+++ b/site_scons/site_tools/extra/__init__.py
@@ -7,4 +7,4 @@ SCons Tools for useful features"""
 
 
 # pylint: disable=unused-import
-from .extra import generate, exists  # noqa: F401
+from .extra import exists, generate  # noqa: F401

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -9,9 +9,9 @@ Code to handle clang-format when used in the build.
 This is used by scons to reformat automatically generated header files to be readable, but also
 outside of scons by the clang-format commit hook to check the version.
 """
-import subprocess  # nosec
-import re
 import os
+import re
+import subprocess  # nosec
 import sys
 
 from SCons.Builder import Builder

--- a/site_scons/site_tools/go_builder.py
+++ b/site_scons/site_tools/go_builder.py
@@ -1,11 +1,11 @@
 """DAOS functions for building go"""
 
-import subprocess  # nosec B404
+import json
 import os
 import re
-import json
+import subprocess  # nosec B404
 
-from SCons.Script import Configure, GetOption, Scanner, Glob, Exit, File
+from SCons.Script import Configure, Exit, File, GetOption, Glob, Scanner
 
 GO_COMPILER = 'go'
 MIN_GO_VERSION = '1.18.0'

--- a/site_scons/site_tools/protoc/__init__.py
+++ b/site_scons/site_tools/protoc/__init__.py
@@ -20,7 +20,9 @@
 # SOFTWARE.
 
 import os
+
 import SCons.Builder
+
 # pylint: disable=too-few-public-methods,missing-class-docstring
 
 

--- a/site_scons/site_tools/stack_analyzer.py
+++ b/site_scons/site_tools/stack_analyzer.py
@@ -5,9 +5,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 Analyze stack usage output
 """
-import os
 import argparse
 import atexit
+import os
+
 from SCons.Script import Exit
 
 

--- a/src/client/pydaos/__init__.py
+++ b/src/client/pydaos/__init__.py
@@ -8,7 +8,9 @@ PyDAOS Module allowing global access to the DAOS containers and objects.
 """
 
 import atexit
-from . import pydaos_shim  # pylint: disable=relative-beyond-top-level,import-self
+
+from . import \
+    pydaos_shim  # pylint: disable=relative-beyond-top-level,import-self
 
 DAOS_MAGIC = 0x7A8A
 

--- a/src/client/pydaos/pydaos_core.py
+++ b/src/client/pydaos/pydaos_core.py
@@ -11,10 +11,7 @@ PyDAOS Module allowing global access to the DAOS containers and objects.
 import enum
 
 # pylint: disable-next=relative-beyond-top-level
-from . import pydaos_shim
-from . import DAOS_MAGIC
-from . import PyDError
-from . import DaosClient
+from . import DAOS_MAGIC, DaosClient, PyDError, pydaos_shim
 
 # Import Object class as an enumeration
 ObjClassID = enum.Enum(

--- a/src/client/pydaos/raw/__init__.py
+++ b/src/client/pydaos/raw/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2019-2021 Intel Corporation.
+# (C) Copyright 2019-2023 Intel Corporation.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -7,9 +7,10 @@ ctypes-based DAOS wrapper used mostly for testing
 """
 
 # pylint: disable=wildcard-import
-from .conversion import *
-from .daos_cref import *
-from .daos_api import *
+from .conversion import *  # noqa: F403
+from .daos_api import *  # noqa: F403
+from .daos_cref import *  # noqa: F403
+
 # pylint: enable=wildcard-import
 
-__all__ = ["daos_api", "conversion", "daos_cref"]
+__all__ = ["daos_api", "conversion", "daos_cref"]  # noqa: F405

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -8,19 +8,16 @@
 # pylint: disable=consider-using-f-string
 
 import ctypes
-import threading
-import os
-import inspect
-import sys
-import time
 import enum
+import inspect
+import os
+import sys
+import threading
+import time
 
 from .. import pydaos_shim  # pylint: disable=relative-beyond-top-level
-
-from . import daos_cref
-from . import conversion
 from .. import DaosClient
-
+from . import conversion, daos_cref
 
 DaosObjClass = enum.Enum(
     "DaosObjClass",

--- a/src/client/setup.py
+++ b/src/client/setup.py
@@ -8,9 +8,10 @@ python3 setup.py install
 If run from within a compiled DAOS source tree this it will detect the
 install path automatically, otherwise it'll use the defaults.
 """
-import os
 import json
-from setuptools import setup, find_packages, Extension
+import os
+
+from setuptools import Extension, find_packages, setup
 
 
 def load_conf():

--- a/src/control/vendor/github.com/hashicorp/go-msgpack/codec/test.py
+++ b/src/control/vendor/github.com/hashicorp/go-msgpack/codec/test.py
@@ -11,7 +11,14 @@
 
 # Ensure all "string" keys are utf strings (else encoded as bytes)
 
-import cbor, msgpack, msgpackrpc, sys, os, threading
+import os
+import sys
+import threading
+
+import cbor
+import msgpack
+import msgpackrpc
+
 
 def get_test_data_list():
     # get list with all primitive types, and a combo type

--- a/src/rdb/raft_tests/raft_tests.py
+++ b/src/rdb/raft_tests/raft_tests.py
@@ -8,10 +8,10 @@ Run the raft tests using make -C DIR tests, where DIR is the path to the raft
 Makefile. Check the output for the number of "not ok" occurrences and return
 this number as the return code.
 '''
+import json
+import os
 import subprocess  # nosec
 import sys
-import os
-import json
 
 TEST_NOT_RUN = -1
 DIR = os.path.join(os.path.dirname(os.path.relpath(os.path.dirname(__file__))), 'raft')

--- a/src/tests/ftest/__init__.py
+++ b/src/tests/ftest/__init__.py
@@ -1,3 +1,4 @@
 """ftest __init__.py."""
 import pkg_resources
+
 pkg_resources.declare_namespace(__name__)

--- a/src/tests/ftest/aggregation/basic.py
+++ b/src/tests/ftest/aggregation/basic.py
@@ -5,6 +5,7 @@
 """
 
 import time
+
 from ior_test_base import IorTestBase
 
 

--- a/src/tests/ftest/aggregation/dfuse_space_check.py
+++ b/src/tests/ftest/aggregation/dfuse_space_check.py
@@ -4,8 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import time
 import os
+import time
+
 from ior_test_base import IorTestBase
 
 

--- a/src/tests/ftest/aggregation/io_small.py
+++ b/src/tests/ftest/aggregation/io_small.py
@@ -5,8 +5,9 @@
 """
 
 import time
-from ior_test_base import IorTestBase
+
 from general_utils import human_to_bytes
+from ior_test_base import IorTestBase
 
 
 class DaosAggregationIOSmall(IorTestBase):

--- a/src/tests/ftest/aggregation/multiple_pool_cont.py
+++ b/src/tests/ftest/aggregation/multiple_pool_cont.py
@@ -5,9 +5,9 @@
 """
 import time
 
-from ior_utils import run_ior
-from ior_test_base import IorTestBase
 from exception_utils import CommandFailure
+from ior_test_base import IorTestBase
+from ior_utils import run_ior
 from job_manager_utils import get_job_manager
 
 

--- a/src/tests/ftest/aggregation/punching.py
+++ b/src/tests/ftest/aggregation/punching.py
@@ -5,6 +5,7 @@
 """
 
 import time
+
 from mdtest_test_base import MdtestBase
 
 

--- a/src/tests/ftest/aggregation/shutdown_restart.py
+++ b/src/tests/ftest/aggregation/shutdown_restart.py
@@ -5,8 +5,8 @@
 """
 import time
 
-from ior_test_base import IorTestBase
 from dmg_utils import check_system_query_status
+from ior_test_base import IorTestBase
 
 
 class IoAggregation(IorTestBase):

--- a/src/tests/ftest/aggregation/throttling.py
+++ b/src/tests/ftest/aggregation/throttling.py
@@ -5,6 +5,7 @@
 """
 
 import time
+
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand, IorMetrics
 

--- a/src/tests/ftest/avocado_tests.py
+++ b/src/tests/ftest/avocado_tests.py
@@ -5,6 +5,7 @@
 """
 
 import time
+
 from apricot import Test
 
 

--- a/src/tests/ftest/cart/iv/iv_one_node.py
+++ b/src/tests/ftest/cart/iv/iv_one_node.py
@@ -3,14 +3,14 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import time
-import tempfile
+import codecs
 import json
 import os
-import struct
-import codecs
-import subprocess  # nosec
 import shlex
+import struct
+import subprocess  # nosec
+import tempfile
+import time
 import traceback
 
 from cart_utils import CartTest

--- a/src/tests/ftest/cart/iv/iv_two_node.py
+++ b/src/tests/ftest/cart/iv/iv_two_node.py
@@ -3,14 +3,14 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import time
-import tempfile
+import codecs
 import json
 import os
-import struct
-import codecs
-import subprocess  # nosec
 import shlex
+import struct
+import subprocess  # nosec
+import tempfile
+import time
 
 from cart_utils import CartTest
 

--- a/src/tests/ftest/cart/util/cart_logparse.py
+++ b/src/tests/ftest/cart/util/cart_logparse.py
@@ -10,10 +10,10 @@ LogIter and LogLine class definitions.
 This provides a way of querying CaRT logfiles for processing.
 """
 
-from collections import OrderedDict
 import bz2
 import os
 import re
+from collections import OrderedDict
 
 
 class InvalidPid(Exception):

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -6,13 +6,14 @@
 
 """This provides consistency checking for CaRT log files."""
 
+import argparse
 import re
 import sys
 import time
-import argparse
-from collections import OrderedDict, Counter
+from collections import Counter, OrderedDict
 
 import cart_logparse
+
 HAVE_TABULATE = True
 try:
     import tabulate

--- a/src/tests/ftest/cart/util/cart_logusage.py
+++ b/src/tests/ftest/cart/util/cart_logusage.py
@@ -10,8 +10,8 @@ can be rendered in Jenkins and used to identify areas which are not exercised.
 Registered as a callback for all log tracing but saves results across the entire run.
 """
 
-import os
 import json
+import os
 
 
 class CodeLoc():

--- a/src/tests/ftest/cart/util/cart_utils.py
+++ b/src/tests/ftest/cart/util/cart_utils.py
@@ -3,23 +3,22 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import time
+import glob
+import logging
 import os
+import re
 import shlex
 import subprocess  # nosec
-import logging
-import re
-import glob
-
-from ClusterShell.NodeSet import NodeSet
+import time
 
 import cart_logparse
 import cart_logtest
 from apricot import TestWithoutServers
-from run_utils import stop_processes
+from ClusterShell.NodeSet import NodeSet
 from host_utils import get_local_host
-from write_host_file import write_host_file
 from job_manager_utils import Orterun
+from run_utils import stop_processes
+from write_host_file import write_host_file
 
 
 class CartTest(TestWithoutServers):

--- a/src/tests/ftest/checksum/csum_basic.py
+++ b/src/tests/ftest/checksum/csum_basic.py
@@ -5,10 +5,10 @@
 """
 
 import ctypes
-from pydaos.raw import (DaosContainer, IORequest,
-                        DaosObj)
+
 from apricot import TestWithServers
 from general_utils import create_string_buffer
+from pydaos.raw import DaosContainer, DaosObj, IORequest
 
 
 class CsumContainerValidation(TestWithServers):

--- a/src/tests/ftest/checksum/csum_error_logging.py
+++ b/src/tests/ftest/checksum/csum_error_logging.py
@@ -5,7 +5,6 @@
 """
 
 from avocado import fail_on
-
 from daos_core_base import DaosCoreBase
 from dmg_utils import get_dmg_smd_info
 from exception_utils import CommandFailure

--- a/src/tests/ftest/config_file_gen.py
+++ b/src/tests/ftest/config_file_gen.py
@@ -10,16 +10,15 @@
 
 import logging
 import sys
-
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
+
+from util.agent_utils_params import (DaosAgentTransportCredentials,
+                                     DaosAgentYamlParameters)
 from util.command_utils_base import CommonConfig
+from util.dmg_utils_params import DmgTransportCredentials, DmgYamlParameters
 from util.exception_utils import CommandFailure
-from util.agent_utils_params import \
-    DaosAgentYamlParameters, DaosAgentTransportCredentials
-from util.server_utils_params import \
-    DaosServerYamlParameters, DaosServerTransportCredentials
-from util.dmg_utils_params import \
-    DmgYamlParameters, DmgTransportCredentials
+from util.server_utils_params import (DaosServerTransportCredentials,
+                                      DaosServerYamlParameters)
 
 
 def generate_agent_config(args):

--- a/src/tests/ftest/container/api_basic_attribute.py
+++ b/src/tests/ftest/container/api_basic_attribute.py
@@ -5,10 +5,9 @@
 '''
 import traceback
 
-from pydaos.raw import DaosApiError
-
 from apricot import TestWithServers
 from general_utils import DaosTestError
+from pydaos.raw import DaosApiError
 from test_utils_base import CallbackHandler
 
 

--- a/src/tests/ftest/container/auto_oc_selection.py
+++ b/src/tests/ftest/container/auto_oc_selection.py
@@ -3,9 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 
 
 class AutoOCSelectionTest(TestWithServers):

--- a/src/tests/ftest/container/basic_snapshot.py
+++ b/src/tests/ftest/container/basic_snapshot.py
@@ -3,10 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from pydaos.raw import DaosContainer, DaosSnapshot, DaosApiError
-
 from apricot import TestWithServers
 from general_utils import get_random_bytes
+from pydaos.raw import DaosApiError, DaosContainer, DaosSnapshot
 
 
 class BasicSnapshot(TestWithServers):

--- a/src/tests/ftest/container/boundary.py
+++ b/src/tests/ftest/container/boundary.py
@@ -4,13 +4,12 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import time
 import itertools
 import random
-
-from avocado.core.exceptions import TestFail
+import time
 
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 from general_utils import DaosTestError
 from thread_manager import ThreadManager
 

--- a/src/tests/ftest/container/destroy.py
+++ b/src/tests/ftest/container/destroy.py
@@ -6,9 +6,8 @@
 import traceback
 import uuid
 
-from pydaos.raw import DaosApiError
-
 from apricot import TestWithServers
+from pydaos.raw import DaosApiError
 
 
 class ContainerDestroyTest(TestWithServers):

--- a/src/tests/ftest/container/fill_destroy_loop.py
+++ b/src/tests/ftest/container/fill_destroy_loop.py
@@ -5,9 +5,8 @@
 """
 import random
 
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 
 
 class BoundaryPoolContainerSpace(TestWithServers):

--- a/src/tests/ftest/container/full_pool_container_create.py
+++ b/src/tests/ftest/container/full_pool_container_create.py
@@ -4,8 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import time
+
 from apricot import TestWithServers
-from general_utils import get_random_bytes, DaosTestError
+from general_utils import DaosTestError, get_random_bytes
 from test_utils_container import TestContainerData
 
 

--- a/src/tests/ftest/container/label.py
+++ b/src/tests/ftest/container/label.py
@@ -6,11 +6,10 @@
 import string
 import uuid
 
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
-from general_utils import report_errors, get_random_string
+from avocado.core.exceptions import TestFail
 from exception_utils import CommandFailure
+from general_utils import get_random_string, report_errors
 
 
 class ContainerLabelTest(TestWithServers):

--- a/src/tests/ftest/container/multiple_delete.py
+++ b/src/tests/ftest/container/multiple_delete.py
@@ -5,8 +5,8 @@
 """
 import time
 
-from ior_test_base import IorTestBase
 from general_utils import DaosTestError
+from ior_test_base import IorTestBase
 
 SCM_THRESHOLD = 400000
 

--- a/src/tests/ftest/container/open.py
+++ b/src/tests/ftest/container/open.py
@@ -6,9 +6,8 @@
 import traceback
 import uuid
 
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 
 RESULT_PASS = "PASS"  # nosec
 RESULT_FAIL = "FAIL"

--- a/src/tests/ftest/container/query_attribute.py
+++ b/src/tests/ftest/container/query_attribute.py
@@ -4,9 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import base64
+
 from apricot import TestWithServers
 from general_utils import report_errors
-
 
 # Test container set-attr, get-attr, and list-attrs with different
 # types of characters.

--- a/src/tests/ftest/container/query_properties.py
+++ b/src/tests/ftest/container/query_properties.py
@@ -5,9 +5,8 @@
 '''
 import ctypes
 
-from pydaos.raw import daos_cref, DaosApiError, conversion, DaosContPropEnum
-
 from apricot import TestWithServers
+from pydaos.raw import DaosApiError, DaosContPropEnum, conversion, daos_cref
 from test_utils_container import TestContainer
 
 

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -5,10 +5,9 @@
 """
 import traceback
 
-from pydaos.raw import DaosContainer, DaosSnapshot, DaosApiError, c_uuid_to_str
-
 from apricot import TestWithServers
 from general_utils import get_random_bytes
+from pydaos.raw import DaosApiError, DaosContainer, DaosSnapshot, c_uuid_to_str
 
 
 # pylint: disable=broad-except

--- a/src/tests/ftest/control/config_generate_output.py
+++ b/src/tests/ftest/control/config_generate_output.py
@@ -4,11 +4,11 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from collections import defaultdict
-import yaml
 
+import yaml
 from apricot import TestWithServers
-from exception_utils import CommandFailure
 from dmg_utils import DmgCommand
+from exception_utils import CommandFailure
 
 
 class ConfigGenerateOutput(TestWithServers):

--- a/src/tests/ftest/control/config_generate_run.py
+++ b/src/tests/ftest/control/config_generate_run.py
@@ -5,7 +5,6 @@
 '''
 
 import yaml
-
 from apricot import TestWithServers
 from server_utils import ServerFailed
 

--- a/src/tests/ftest/control/daos_agent_config.py
+++ b/src/tests/ftest/control/daos_agent_config.py
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from apricot import TestWithServers
 from agent_utils import include_local_host
+from apricot import TestWithServers
 from exception_utils import CommandFailure
 
 

--- a/src/tests/ftest/control/daos_server_helper.py
+++ b/src/tests/ftest/control/daos_server_helper.py
@@ -3,9 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import getpass
 import os
 import stat
-import getpass
 
 from apricot import TestWithServers
 from server_utils import ServerFailed

--- a/src/tests/ftest/control/dmg_network_scan.py
+++ b/src/tests/ftest/control/dmg_network_scan.py
@@ -4,8 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from apricot import TestWithServers
-
-from network_utils import get_network_information, get_dmg_network_information, SUPPORTED_PROVIDERS
+from network_utils import (SUPPORTED_PROVIDERS, get_dmg_network_information,
+                           get_network_information)
 
 
 class DmgNetworkScanTest(TestWithServers):

--- a/src/tests/ftest/control/dmg_nvme_scan_test.py
+++ b/src/tests/ftest/control/dmg_nvme_scan_test.py
@@ -5,10 +5,9 @@
 """
 import os
 
-from avocado.utils import process
-
-from dmg_utils import DmgCommand
 from apricot import TestWithServers
+from avocado.utils import process
+from dmg_utils import DmgCommand
 
 
 class DmgNvmeScanTest(TestWithServers):

--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -5,8 +5,8 @@
 """
 import time
 
-from exception_utils import CommandFailure
 from control_test_base import ControlTestBase
+from exception_utils import CommandFailure
 
 
 class DmgPoolQueryRanks(ControlTestBase):

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -5,8 +5,8 @@
 """
 from copy import deepcopy
 
-from ior_test_base import IorTestBase
 from control_test_base import ControlTestBase
+from ior_test_base import IorTestBase
 
 
 class DmgPoolQueryTest(ControlTestBase, IorTestBase):

--- a/src/tests/ftest/control/dmg_storage_query.py
+++ b/src/tests/ftest/control/dmg_storage_query.py
@@ -7,11 +7,11 @@
 import re
 
 import avocado
-
 from control_test_base import ControlTestBase
-from dmg_utils import get_storage_query_pool_info, get_storage_query_device_info
+from dmg_utils import (get_storage_query_device_info,
+                       get_storage_query_pool_info)
 from exception_utils import CommandFailure
-from general_utils import list_to_str, dict_to_str
+from general_utils import dict_to_str, list_to_str
 
 
 class DmgStorageQuery(ControlTestBase):

--- a/src/tests/ftest/control/dmg_storage_scan_scm.py
+++ b/src/tests/ftest/control/dmg_storage_scan_scm.py
@@ -5,8 +5,8 @@
 """
 import os
 
-from general_utils import pcmd, run_pcmd
 from control_test_base import ControlTestBase
+from general_utils import pcmd, run_pcmd
 
 
 class DmgStorageScanSCMTest(ControlTestBase):

--- a/src/tests/ftest/control/dmg_system_cleanup.py
+++ b/src/tests/ftest/control/dmg_system_cleanup.py
@@ -4,9 +4,10 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from socket import gethostname
+
+from apricot import TestWithServers
 from avocado.core.exceptions import TestFail
 from pydaos.raw import DaosPool
-from apricot import TestWithServers
 
 
 class DmgSystemCleanupTest(TestWithServers):

--- a/src/tests/ftest/control/dmg_system_reformat.py
+++ b/src/tests/ftest/control/dmg_system_reformat.py
@@ -5,9 +5,8 @@
 """
 import time
 
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 from exception_utils import CommandFailure
 from test_utils_pool import add_pool, get_size_params
 

--- a/src/tests/ftest/control/dmg_telemetry_io_latency.py
+++ b/src/tests/ftest/control/dmg_telemetry_io_latency.py
@@ -4,11 +4,11 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
+from general_utils import report_errors
 from ior_test_base import IorTestBase
+from oclass_utils import extract_redundancy_factor
 from telemetry_test_base import TestWithTelemetry
 from telemetry_utils import TelemetryUtils
-from oclass_utils import extract_redundancy_factor
-from general_utils import report_errors
 
 
 def convert_to_number(size):

--- a/src/tests/ftest/control/dmg_telemetry_nvme.py
+++ b/src/tests/ftest/control/dmg_telemetry_nvme.py
@@ -3,8 +3,8 @@
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from telemetry_test_base import TestWithTelemetry
 from apricot import TestWithServers
+from telemetry_test_base import TestWithTelemetry
 from telemetry_utils import TelemetryUtils
 
 

--- a/src/tests/ftest/control/log_entry.py
+++ b/src/tests/ftest/control/log_entry.py
@@ -6,9 +6,8 @@
 import contextlib
 import re
 
-from ClusterShell.NodeSet import NodeSet
-
 from apricot import TestWithServers
+from ClusterShell.NodeSet import NodeSet
 from general_utils import get_journalctl, journalctl_time, wait_for_result
 from run_utils import run_remote
 

--- a/src/tests/ftest/control/ms_failover.py
+++ b/src/tests/ftest/control/ms_failover.py
@@ -6,9 +6,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 import socket
 import time
 
-from ClusterShell.NodeSet import NodeSet
-
 from apricot import TestWithServers
+from ClusterShell.NodeSet import NodeSet
 
 
 class ManagementServiceFailover(TestWithServers):

--- a/src/tests/ftest/control/ms_resilience.py
+++ b/src/tests/ftest/control/ms_resilience.py
@@ -6,9 +6,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 import socket
 import time
 
-from ClusterShell.NodeSet import NodeSet
-
 from apricot import TestWithServers
+from ClusterShell.NodeSet import NodeSet
 from run_utils import stop_processes
 
 

--- a/src/tests/ftest/control/ssd_socket.py
+++ b/src/tests/ftest/control/ssd_socket.py
@@ -5,8 +5,9 @@
 """
 import os
 from textwrap import wrap
-from general_utils import pcmd, run_pcmd
+
 from control_test_base import ControlTestBase
+from general_utils import pcmd, run_pcmd
 
 
 class SSDSocketTest(ControlTestBase):

--- a/src/tests/ftest/control/super_block_versioning.py
+++ b/src/tests/ftest/control/super_block_versioning.py
@@ -7,8 +7,8 @@
 
 import os
 
-from general_utils import check_file_exists, pcmd
 from apricot import TestWithServers
+from general_utils import check_file_exists, pcmd
 
 
 class SuperBlockVersioning(TestWithServers):

--- a/src/tests/ftest/control/version.py
+++ b/src/tests/ftest/control/version.py
@@ -3,11 +3,11 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import re
 import json
+import re
 
 from apricot import TestWithServers
-from general_utils import run_pcmd, report_errors, append_error
+from general_utils import append_error, report_errors, run_pcmd
 from server_utils_base import DaosServerCommandRunner
 
 

--- a/src/tests/ftest/daos_racer/parallel.py
+++ b/src/tests/ftest/daos_racer/parallel.py
@@ -6,8 +6,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
 from apricot import TestWithServers
-from exception_utils import CommandFailure
 from daos_racer_utils import DaosRacerCommand
+from exception_utils import CommandFailure
 
 
 class DaosRacerParallelTest(TestWithServers):

--- a/src/tests/ftest/daos_test/dfs.py
+++ b/src/tests/ftest/daos_test/dfs.py
@@ -5,6 +5,7 @@
 """
 
 import os
+
 from daos_core_base import DaosCoreBase
 
 

--- a/src/tests/ftest/daos_vol/bigio.py
+++ b/src/tests/ftest/daos_vol/bigio.py
@@ -3,8 +3,8 @@
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from vol_test_base import VolTestBase
 from job_manager_utils import get_job_manager
+from vol_test_base import VolTestBase
 
 
 class DaosVolBigIO(VolTestBase):

--- a/src/tests/ftest/daos_vol/h5_suite.py
+++ b/src/tests/ftest/daos_vol/h5_suite.py
@@ -3,8 +3,8 @@
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from vol_test_base import VolTestBase
 from job_manager_utils import get_job_manager
+from vol_test_base import VolTestBase
 
 
 class DaosVol(VolTestBase):

--- a/src/tests/ftest/datamover/copy_procs.py
+++ b/src/tests/ftest/datamover/copy_procs.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from os.path import join
+
 from data_mover_test_base import DataMoverTestBase
 
 

--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -6,10 +6,9 @@
 from os.path import join
 
 import avocado
-from pydaos.raw import DaosApiError
-
 from data_mover_test_base import DataMoverTestBase
 from duns_utils import format_path
+from pydaos.raw import DaosApiError
 
 
 class DmvrDstCreate(DataMoverTestBase):

--- a/src/tests/ftest/datamover/large_dir.py
+++ b/src/tests/ftest/datamover/large_dir.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import os
+
 from data_mover_test_base import DataMoverTestBase
 from duns_utils import format_path
 

--- a/src/tests/ftest/datamover/large_file.py
+++ b/src/tests/ftest/datamover/large_file.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import os
+
 from data_mover_test_base import DataMoverTestBase
 
 

--- a/src/tests/ftest/datamover/negative.py
+++ b/src/tests/ftest/datamover/negative.py
@@ -4,8 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 
-from os.path import join
 import uuid
+from os.path import join
 
 from data_mover_test_base import DataMoverTestBase
 from duns_utils import format_path

--- a/src/tests/ftest/datamover/negative_space.py
+++ b/src/tests/ftest/datamover/negative_space.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from os.path import join
+
 from data_mover_test_base import DataMoverTestBase
 
 

--- a/src/tests/ftest/datamover/obj_small.py
+++ b/src/tests/ftest/datamover/obj_small.py
@@ -3,10 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from pydaos.raw import DaosApiError
 import avocado
-
 from data_mover_test_base import DataMoverTestBase
+from pydaos.raw import DaosApiError
 
 
 class DmvrObjSmallTest(DataMoverTestBase):

--- a/src/tests/ftest/datamover/posix_meta_entry.py
+++ b/src/tests/ftest/datamover/posix_meta_entry.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from os.path import join
+
 from data_mover_test_base import DataMoverTestBase
 from exception_utils import CommandFailure
 

--- a/src/tests/ftest/datamover/posix_preserve_props.py
+++ b/src/tests/ftest/datamover/posix_preserve_props.py
@@ -5,11 +5,10 @@
 '''
 from os.path import join
 
-from pydaos.raw import DaosApiError
 import avocado
-
 from data_mover_test_base import DataMoverTestBase
 from duns_utils import format_path
+from pydaos.raw import DaosApiError
 
 
 class DmvrPreserveProps(DataMoverTestBase):

--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -3,8 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from os.path import join
 import re
+from os.path import join
+
 from data_mover_test_base import DataMoverTestBase
 
 

--- a/src/tests/ftest/datamover/posix_symlinks.py
+++ b/src/tests/ftest/datamover/posix_symlinks.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 from os.path import join
+
 from data_mover_test_base import DataMoverTestBase
 
 

--- a/src/tests/ftest/datamover/serial_small.py
+++ b/src/tests/ftest/datamover/serial_small.py
@@ -3,10 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from pydaos.raw import DaosApiError
 import avocado
-
 from data_mover_test_base import DataMoverTestBase
+from pydaos.raw import DaosApiError
 
 
 class DmvrSerialSmall(DataMoverTestBase):

--- a/src/tests/ftest/dbench/dbench.py
+++ b/src/tests/ftest/dbench/dbench.py
@@ -5,9 +5,9 @@
 """
 
 from ClusterShell.NodeSet import NodeSet
+from dbench_utils import Dbench
 from dfuse_test_base import DfuseTestBase
 from exception_utils import CommandFailure
-from dbench_utils import Dbench
 
 
 class DbenchTest(DfuseTestBase):

--- a/src/tests/ftest/deployment/agent_failure.py
+++ b/src/tests/ftest/deployment/agent_failure.py
@@ -3,16 +3,15 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
 import os
 import threading
+import time
 
 from ClusterShell.NodeSet import NodeSet
-
+from command_utils_base import CommandFailure
+from general_utils import get_journalctl, journalctl_time, report_errors
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand
-from general_utils import report_errors, get_journalctl, journalctl_time
-from command_utils_base import CommandFailure
 from job_manager_utils import get_job_manager
 from run_utils import stop_processes
 

--- a/src/tests/ftest/deployment/basic_checkout.py
+++ b/src/tests/ftest/deployment/basic_checkout.py
@@ -4,9 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from performance_test_base import PerformanceTestBase
 from data_mover_test_base import DataMoverTestBase
 from exception_utils import CommandFailure
+from performance_test_base import PerformanceTestBase
 
 
 class BasicCheckout(PerformanceTestBase):

--- a/src/tests/ftest/deployment/critical_integration.py
+++ b/src/tests/ftest/deployment/critical_integration.py
@@ -6,16 +6,13 @@
 
 import json
 
-from ClusterShell.NodeSet import NodeSet
-
-from general_utils import run_command, DaosTestError, get_journalctl, journalctl_time
-from ior_test_base import IorTestBase
-from exception_utils import CommandFailure
-
 # Imports need to be split or python fails to import
-from apricot import TestWithServers
-from apricot import TestWithoutServers
-
+from apricot import TestWithoutServers, TestWithServers
+from ClusterShell.NodeSet import NodeSet
+from exception_utils import CommandFailure
+from general_utils import (DaosTestError, get_journalctl, journalctl_time,
+                           run_command)
+from ior_test_base import IorTestBase
 
 # pylint: disable-next=fixme
 # TODO Provision all daos nodes using provisioning tool provided by HPCM

--- a/src/tests/ftest/deployment/disk_failure.py
+++ b/src/tests/ftest/deployment/disk_failure.py
@@ -9,12 +9,11 @@ import time
 
 from avocado import fail_on
 from ClusterShell.NodeSet import NodeSet
-
-from dmg_utils import get_storage_query_device_info, get_dmg_response
+from dmg_utils import get_dmg_response, get_storage_query_device_info
 from exception_utils import CommandFailure
 from general_utils import list_to_str
-from test_utils_pool import add_pool
 from osa_utils import OSAUtils
+from test_utils_pool import add_pool
 
 
 class DiskFailureTest(OSAUtils):

--- a/src/tests/ftest/deployment/io_sys_admin.py
+++ b/src/tests/ftest/deployment/io_sys_admin.py
@@ -6,10 +6,10 @@
 
 import time
 
-from file_count_test_base import FileCountTestBase
-from data_mover_test_base import DataMoverTestBase
-from general_utils import human_to_bytes
 import security_test_base as secTestBase
+from data_mover_test_base import DataMoverTestBase
+from file_count_test_base import FileCountTestBase
+from general_utils import human_to_bytes
 from test_utils_pool import check_pool_creation
 
 

--- a/src/tests/ftest/deployment/ior_per_rank.py
+++ b/src/tests/ftest/deployment/ior_per_rank.py
@@ -5,10 +5,9 @@
 """
 
 from avocado.core.exceptions import TestFail
-
+from general_utils import DaosTestError, percent_change
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand, IorMetrics
-from general_utils import percent_change, DaosTestError
 
 
 class IorPerRank(IorTestBase):

--- a/src/tests/ftest/deployment/network_failure.py
+++ b/src/tests/ftest/deployment/network_failure.py
@@ -6,15 +6,15 @@
 import os
 import time
 from collections import defaultdict
-from ClusterShell.NodeSet import NodeSet
 
+from ClusterShell.NodeSet import NodeSet
+from command_utils_base import CommandFailure
+from dmg_utils import check_system_query_status
+from general_utils import report_errors, run_pcmd
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand
-from general_utils import report_errors, run_pcmd
-from command_utils_base import CommandFailure
 from job_manager_utils import get_job_manager
 from network_utils import update_network_interface
-from dmg_utils import check_system_query_status
 
 
 class NetworkFailureTest(IorTestBase):

--- a/src/tests/ftest/deployment/server_rank_failure.py
+++ b/src/tests/ftest/deployment/server_rank_failure.py
@@ -3,16 +3,15 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
 import os
 import threading
+import time
 
 from ClusterShell.NodeSet import NodeSet
-
+from command_utils_base import CommandFailure
+from general_utils import report_errors
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand
-from general_utils import report_errors
-from command_utils_base import CommandFailure
 from job_manager_utils import get_job_manager
 from run_utils import stop_processes
 

--- a/src/tests/ftest/deployment/target_failure.py
+++ b/src/tests/ftest/deployment/target_failure.py
@@ -3,14 +3,14 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
 import os
 import threading
+import time
 
+from command_utils_base import CommandFailure
+from general_utils import report_errors
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand
-from general_utils import report_errors
-from command_utils_base import CommandFailure
 from job_manager_utils import get_job_manager
 
 

--- a/src/tests/ftest/dfuse/bash.py
+++ b/src/tests/ftest/dfuse/bash.py
@@ -4,9 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
-from ClusterShell.NodeSet import NodeSet
 
 import general_utils
+from ClusterShell.NodeSet import NodeSet
 from dfuse_test_base import DfuseTestBase
 from exception_utils import CommandFailure
 

--- a/src/tests/ftest/dfuse/caching_check.py
+++ b/src/tests/ftest/dfuse/caching_check.py
@@ -4,9 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
+from general_utils import percent_change
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand, IorMetrics
-from general_utils import percent_change
 
 
 class DfuseCachingCheck(IorTestBase):

--- a/src/tests/ftest/dfuse/container_type.py
+++ b/src/tests/ftest/dfuse/container_type.py
@@ -4,7 +4,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from avocado.core.exceptions import TestFail
-
 from dfuse_test_base import DfuseTestBase
 
 

--- a/src/tests/ftest/dfuse/enospace.py
+++ b/src/tests/ftest/dfuse/enospace.py
@@ -4,8 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import os
 import errno
+import os
 
 from dfuse_test_base import DfuseTestBase
 

--- a/src/tests/ftest/dfuse/find.py
+++ b/src/tests/ftest/dfuse/find.py
@@ -4,12 +4,12 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
-import sys
-import string
 import random
-from ClusterShell.NodeSet import NodeSet
+import string
+import sys
 
 import general_utils
+from ClusterShell.NodeSet import NodeSet
 from dfuse_test_base import DfuseTestBase
 from dfuse_utils import get_dfuse, start_dfuse
 from exception_utils import CommandFailure

--- a/src/tests/ftest/dfuse/mu_mount.py
+++ b/src/tests/ftest/dfuse/mu_mount.py
@@ -7,9 +7,8 @@ import os
 from getpass import getuser
 
 from ClusterShell.NodeSet import NodeSet
-
-from run_utils import run_remote, command_as_user
 from dfuse_test_base import DfuseTestBase
+from run_utils import command_as_user, run_remote
 
 
 class DfuseMUMount(DfuseTestBase):

--- a/src/tests/ftest/dfuse/mu_perms.py
+++ b/src/tests/ftest/dfuse/mu_perms.py
@@ -3,16 +3,15 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
-from itertools import product
-import time
 import re
+import time
+from itertools import product
 
 from ClusterShell.NodeSet import NodeSet
-
 from dfuse_test_base import DfuseTestBase
-from dfuse_utils import get_dfuse, start_dfuse, VerifyPermsCommand
+from dfuse_utils import VerifyPermsCommand, get_dfuse, start_dfuse
+from run_utils import command_as_user, run_remote
 from user_utils import get_chown_command
-from run_utils import run_remote, command_as_user
 
 
 class DfuseMUPerms(DfuseTestBase):

--- a/src/tests/ftest/dfuse/posix_stat.py
+++ b/src/tests/ftest/dfuse/posix_stat.py
@@ -4,8 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from ior_test_base import IorTestBase
 from general_utils import get_remote_file_size, run_pcmd
+from ior_test_base import IorTestBase
 
 
 class POSIXStatTest(IorTestBase):

--- a/src/tests/ftest/dfuse/simul.py
+++ b/src/tests/ftest/dfuse/simul.py
@@ -5,10 +5,11 @@
 """
 
 import os
+
 from avocado import fail_on
-from exception_utils import MPILoadError
 from dfuse_test_base import DfuseTestBase
 from env_modules import load_mpi
+from exception_utils import MPILoadError
 from general_utils import DaosTestError, run_command
 
 

--- a/src/tests/ftest/dfuse/sparse_file.py
+++ b/src/tests/ftest/dfuse/sparse_file.py
@@ -4,10 +4,10 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from getpass import getuser
 import os
-import paramiko
+from getpass import getuser
 
+import paramiko
 from general_utils import get_remote_file_size
 from ior_test_base import IorTestBase
 

--- a/src/tests/ftest/dtx/basic.py
+++ b/src/tests/ftest/dtx/basic.py
@@ -6,9 +6,8 @@
 import time
 import traceback
 
-from pydaos.raw import DaosContainer, DaosApiError, c_uuid_to_str
-
 from apricot import TestWithServers
+from pydaos.raw import DaosApiError, DaosContainer, c_uuid_to_str
 
 
 class BasicTxTest(TestWithServers):

--- a/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
+++ b/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import time
+
 from ec_utils import ErasureCodeIor
 
 

--- a/src/tests/ftest/erasurecode/rebuild_disabled.py
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import time
+
 from ec_utils import ErasureCodeIor
 
 

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.py
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import time
+
 from ec_utils import ErasureCodeSingle
 
 

--- a/src/tests/ftest/erasurecode/space_usage.py
+++ b/src/tests/ftest/erasurecode/space_usage.py
@@ -3,9 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from ior_test_base import IorTestBase
-from data_utils import list_stats, dict_subtract, dict_extract_values
+from data_utils import dict_extract_values, dict_subtract, list_stats
 from general_utils import percent_change
+from ior_test_base import IorTestBase
 from oclass_utils import calculate_ec_targets_used
 
 

--- a/src/tests/ftest/erasurecode/truncate.py
+++ b/src/tests/ftest/erasurecode/truncate.py
@@ -6,7 +6,7 @@
 import os
 
 from fio_test_base import FioBase
-from general_utils import run_pcmd, get_remote_file_size
+from general_utils import get_remote_file_size, run_pcmd
 
 
 class Ecodtruncate(FioBase):

--- a/src/tests/ftest/fault_domain/fault_domain.py
+++ b/src/tests/ftest/fault_domain/fault_domain.py
@@ -3,9 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from ClusterShell.NodeSet import NodeSet
-
 from apricot import TestWithServers, skipForTicket
+from ClusterShell.NodeSet import NodeSet
 
 
 class FaultDomain(TestWithServers):

--- a/src/tests/ftest/fault_injection/ec.py
+++ b/src/tests/ftest/fault_injection/ec.py
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from ior_test_base import IorTestBase
 from fio_test_base import FioBase
+from ior_test_base import IorTestBase
 
 
 class EcodFaultInjection(IorTestBase, FioBase):

--- a/src/tests/ftest/fault_injection/pool.py
+++ b/src/tests/ftest/fault_injection/pool.py
@@ -5,6 +5,7 @@
 """
 
 from random import randint
+
 from apricot import TestWithServers
 from exception_utils import CommandFailure
 from general_utils import DaosTestError

--- a/src/tests/ftest/harness/advanced.py
+++ b/src/tests/ftest/harness/advanced.py
@@ -6,14 +6,13 @@
 import os
 from random import choice
 
-from ClusterShell.NodeSet import NodeSet
 from apricot import TestWithServers
-
+from ClusterShell.NodeSet import NodeSet
+from dfuse_utils import get_dfuse, start_dfuse
 from general_utils import get_avocado_config_value
 from run_utils import run_remote
 from test_utils_pool import POOL_TIMEOUT_INCREMENT
 from user_utils import get_chown_command
-from dfuse_utils import get_dfuse, start_dfuse
 
 
 class HarnessAdvancedTest(TestWithServers):

--- a/src/tests/ftest/harness/basic.py
+++ b/src/tests/ftest/harness/basic.py
@@ -9,7 +9,7 @@ from apricot import TestWithoutServers
 from cmocka_utils import CmockaUtils
 from command_utils import SubProcessCommand
 from exception_utils import CommandFailure
-from job_manager_utils import Orterun, Mpirun
+from job_manager_utils import Mpirun, Orterun
 
 
 class HarnessBasicTest(TestWithoutServers):

--- a/src/tests/ftest/harness/config.py
+++ b/src/tests/ftest/harness/config.py
@@ -4,11 +4,9 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import yaml
-
 from apricot import TestWithServers
-
-from general_utils import nodeset_append_suffix
 from dmg_utils import DmgCommand
+from general_utils import nodeset_append_suffix
 
 
 class HarnessConfigTest(TestWithServers):

--- a/src/tests/ftest/harness/core_files.py
+++ b/src/tests/ftest/harness/core_files.py
@@ -7,10 +7,9 @@ import os
 from random import choice
 from re import findall
 
-from ClusterShell.NodeSet import NodeSet
-
 from apricot import TestWithServers
-from run_utils import run_remote, run_local, RunException
+from ClusterShell.NodeSet import NodeSet
+from run_utils import RunException, run_local, run_remote
 
 
 class HarnessCoreFilesTest(TestWithServers):

--- a/src/tests/ftest/harness/launch_setup.py
+++ b/src/tests/ftest/harness/launch_setup.py
@@ -4,8 +4,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from apricot import TestWithoutServers
-
-from run_utils import run_remote, command_as_user
+from run_utils import command_as_user, run_remote
 from user_utils import get_group_id, get_user_groups
 
 

--- a/src/tests/ftest/harness/skip_list.py
+++ b/src/tests/ftest/harness/skip_list.py
@@ -3,8 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import os
 import errno
+import os
+
 from apricot import Test
 
 

--- a/src/tests/ftest/harness/slurm.py
+++ b/src/tests/ftest/harness/slurm.py
@@ -4,7 +4,6 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from apricot import TestWithoutServers
-
 from host_utils import get_local_host
 from slurm_utils import sinfo
 

--- a/src/tests/ftest/harness/unit.py
+++ b/src/tests/ftest/harness/unit.py
@@ -3,12 +3,11 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from ClusterShell.NodeSet import NodeSet
-
 from apricot import TestWithoutServers
-from data_utils import list_unique, list_flatten, list_stats, \
-    dict_extract_values, dict_subtract
-from run_utils import run_remote, ResultData
+from ClusterShell.NodeSet import NodeSet
+from data_utils import (dict_extract_values, dict_subtract, list_flatten,
+                        list_stats, list_unique)
+from run_utils import ResultData, run_remote
 
 
 class HarnessUnitTest(TestWithoutServers):

--- a/src/tests/ftest/interoperability/upgrade_downgrade_base.py
+++ b/src/tests/ftest/interoperability/upgrade_downgrade_base.py
@@ -3,17 +3,17 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import os
-import traceback
-import random
 import base64
+import os
+import random
 import time
+import traceback
 
-from pydaos.raw import DaosApiError
-from general_utils import get_random_bytes, pcmd, run_pcmd
 from agent_utils import include_local_host
 from command_utils_base import CommandFailure
+from general_utils import get_random_bytes, pcmd, run_pcmd
 from ior_test_base import IorTestBase
+from pydaos.raw import DaosApiError
 
 
 class UpgradeDowngradeBase(IorTestBase):

--- a/src/tests/ftest/io/macsio_test.py
+++ b/src/tests/ftest/io/macsio_test.py
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from general_utils import list_to_str
 from dfuse_test_base import DfuseTestBase
+from general_utils import list_to_str
 from macsio_test_base import MacsioTestBase
 
 

--- a/src/tests/ftest/io/parallel_io.py
+++ b/src/tests/ftest/io/parallel_io.py
@@ -4,12 +4,11 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import threading
+import os
 import subprocess  # nosec
+import threading
 import time
 from getpass import getuser
-import os
-
 
 from exception_utils import CommandFailure
 from fio_test_base import FioBase

--- a/src/tests/ftest/ior/crash.py
+++ b/src/tests/ftest/ior/crash.py
@@ -6,8 +6,8 @@
 
 import time
 
-from ior_test_base import IorTestBase
 from dmg_utils import check_system_query_status
+from ior_test_base import IorTestBase
 
 
 class IorCrash(IorTestBase):

--- a/src/tests/ftest/ior/intercept_messages.py
+++ b/src/tests/ftest/ior/intercept_messages.py
@@ -4,8 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import re
 import os
+import re
+
 from ior_test_base import IorTestBase
 
 

--- a/src/tests/ftest/ior/intercept_messages_pil4dfs.py
+++ b/src/tests/ftest/ior/intercept_messages_pil4dfs.py
@@ -4,8 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import re
 import os
+import re
 
 from ior_test_base import IorTestBase
 

--- a/src/tests/ftest/ior/small.py
+++ b/src/tests/ftest/ior/small.py
@@ -4,7 +4,6 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from avocado.core.exceptions import TestFail
-
 from ior_test_base import IorTestBase
 
 

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -6,9 +6,6 @@
 """
 # pylint: disable=too-many-lines
 
-from argparse import ArgumentParser, RawDescriptionHelpFormatter
-from collections import OrderedDict, defaultdict
-from tempfile import TemporaryDirectory
 import errno
 import getpass
 import json
@@ -18,34 +15,44 @@ import re
 import site
 import sys
 import time
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from collections import OrderedDict, defaultdict
+from tempfile import TemporaryDirectory
 
 # When SRE-439 is fixed we should be able to include these import statements here
 # from avocado.core.settings import settings
 # from avocado.core.version import MAJOR, MINOR
 # from avocado.utils.stacktrace import prepare_exc_info
 from ClusterShell.NodeSet import NodeSet
-
 # When SRE-439 is fixed we should be able to include these import statements here
 # from util.distro_utils import detect
 # pylint: disable=import-error,no-name-in-module
-from process_core_files import CoreFileProcessing, CoreFileException
+from process_core_files import CoreFileException, CoreFileProcessing
 from slurm_setup import SlurmSetup, SlurmSetupException
 
 # Update the path to support utils files that import other utils files
+# This is not good coding practice. Should use package paths and remove alls these E402.
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "util"))
+from data_utils import (dict_extract_values, list_flatten,  # noqa: E402
+                        list_unique)
 # pylint: disable=import-outside-toplevel
-from host_utils import get_node_set, get_local_host, HostInfo, HostException  # noqa: E402
-from logger_utils import get_console_handler, get_file_handler                # noqa: E402
-from results_utils import create_html, create_xml, Job, Results, TestResult   # noqa: E402
-from run_utils import run_local, run_remote, find_command, RunException, \
-    stop_processes   # noqa: E402
-from slurm_utils import show_partition, create_partition, delete_partition    # noqa: E402
-from storage_utils import StorageInfo, StorageException                       # noqa: E402
-from user_utils import get_chown_command, groupadd, useradd, userdel, get_group_id, \
-    get_user_groups  # noqa: E402
-from yaml_utils import get_test_category, get_yaml_data, YamlUpdater, \
-    YamlException    # noqa: E402
-from data_utils import list_unique, list_flatten, dict_extract_values  # noqa: E402
+from host_utils import (HostException, HostInfo, get_local_host,  # noqa: E402
+                        get_node_set)
+from logger_utils import get_console_handler, get_file_handler  # noqa: E402
+from results_utils import (Job, Results, TestResult, create_html,  # noqa: E402
+                           create_xml)
+from run_utils import stop_processes  # noqa: E402
+from run_utils import (RunException, find_command, run_local,  # noqa: E402
+                       run_remote)
+from slurm_utils import (create_partition, delete_partition,  # noqa: E402
+                         show_partition)
+from storage_utils import StorageException, StorageInfo  # noqa: E402
+from user_utils import get_user_groups  # noqa: E402
+from user_utils import (get_chown_command, get_group_id,  # noqa: E402
+                        groupadd, useradd, userdel)
+from yaml_utils import YamlException  # noqa: E402
+from yaml_utils import (YamlUpdater, get_test_category,  # noqa: E402
+                        get_yaml_data)
 
 BULLSEYE_SRC = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test.cov")
 BULLSEYE_FILE = os.path.join(os.sep, "tmp", "test.cov")
@@ -232,7 +239,7 @@ class AvocadoInfo():
         """
         try:
             # pylint: disable=import-outside-toplevel
-            from avocado.core.settings import settings, SettingsError
+            from avocado.core.settings import SettingsError, settings
             try:
                 # Newer versions of avocado use this approach
                 config = settings.as_dict()

--- a/src/tests/ftest/network/cart_self_test.py
+++ b/src/tests/ftest/network/cart_self_test.py
@@ -4,10 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from apricot import TestWithServers
-
+from command_utils import ExecutableCommand
 from command_utils_base import EnvironmentVariables, FormattedParameter
 from exception_utils import CommandFailure
-from command_utils import ExecutableCommand
 from host_utils import get_local_host
 from job_manager_utils import get_job_manager
 

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -3,18 +3,17 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import time
 import threading
-
-from avocado.core.exceptions import TestFail
+import time
 
 from apricot import skipForTicket
-from nvme_utils import ServerFillUp
+from avocado.core.exceptions import TestFail
 from daos_utils import DaosCommand
-from job_manager_utils import get_job_manager
-from ior_utils import IorCommand, IorMetrics
 from exception_utils import CommandFailure
 from general_utils import error_count
+from ior_utils import IorCommand, IorMetrics
+from job_manager_utils import get_job_manager
+from nvme_utils import ServerFillUp
 
 
 class NvmeEnospace(ServerFillUp):

--- a/src/tests/ftest/nvme/fault.py
+++ b/src/tests/ftest/nvme/fault.py
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from nvme_utils import ServerFillUp
 from exception_utils import CommandFailure
+from nvme_utils import ServerFillUp
 
 
 class NvmeFault(ServerFillUp):

--- a/src/tests/ftest/nvme/fragmentation.py
+++ b/src/tests/ftest/nvme/fragmentation.py
@@ -3,16 +3,16 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
-from threading import Thread
-from itertools import product
 import queue
+import time
+from itertools import product
+from threading import Thread
 
 from apricot import TestWithServers
-from write_host_file import write_host_file
-from ior_utils import IorCommand
 from exception_utils import CommandFailure
+from ior_utils import IorCommand
 from job_manager_utils import get_job_manager
+from write_host_file import write_host_file
 
 
 class NvmeFragmentation(TestWithServers):

--- a/src/tests/ftest/nvme/health.py
+++ b/src/tests/ftest/nvme/health.py
@@ -7,10 +7,9 @@ from __future__ import division
 
 from avocado import fail_on
 from avocado.core.exceptions import TestFail
-
-from dmg_utils import get_storage_query_pool_info, get_dmg_smd_info
-from nvme_utils import ServerFillUp, get_device_ids
+from dmg_utils import get_dmg_smd_info, get_storage_query_pool_info
 from exception_utils import CommandFailure
+from nvme_utils import ServerFillUp, get_device_ids
 
 
 class NvmeHealth(ServerFillUp):

--- a/src/tests/ftest/nvme/io_verification.py
+++ b/src/tests/ftest/nvme/io_verification.py
@@ -4,10 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import avocado
-
-from pydaos.raw import DaosApiError
-from ior_test_base import IorTestBase
 from dmg_utils import check_system_query_status
+from ior_test_base import IorTestBase
+from pydaos.raw import DaosApiError
 
 
 class NvmeIoVerification(IorTestBase):

--- a/src/tests/ftest/nvme/object.py
+++ b/src/tests/ftest/nvme/object.py
@@ -4,12 +4,10 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import avocado
-
-from pydaos.raw import DaosApiError
-
 from apricot import TestWithServers
-from thread_manager import ThreadManager
 from general_utils import report_errors
+from pydaos.raw import DaosApiError
+from thread_manager import ThreadManager
 
 
 class NvmeObject(TestWithServers):

--- a/src/tests/ftest/nvme/pool_capacity.py
+++ b/src/tests/ftest/nvme/pool_capacity.py
@@ -3,16 +3,16 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
-import threading
-from itertools import product
 import queue
+import threading
+import time
+from itertools import product
 
 from apricot import TestWithServers
-from write_host_file import write_host_file
+from exception_utils import CommandFailure
 from ior_utils import IorCommand
 from job_manager_utils import get_job_manager
-from exception_utils import CommandFailure
+from write_host_file import write_host_file
 
 
 class NvmePoolCapacity(TestWithServers):

--- a/src/tests/ftest/nvme/pool_exclude.py
+++ b/src/tests/ftest/nvme/pool_exclude.py
@@ -3,17 +3,17 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from multiprocessing import Queue
-import time
 import random
-import threading
 import re
+import threading
+import time
+from multiprocessing import Queue
 
 from exception_utils import CommandFailure
 from ior_utils import run_ior, thread_run_ior
 from job_manager_utils import get_job_manager
-from test_utils_pool import add_pool
 from osa_utils import OSAUtils
+from test_utils_pool import add_pool
 from write_host_file import write_host_file
 
 

--- a/src/tests/ftest/nvme/pool_extend.py
+++ b/src/tests/ftest/nvme/pool_extend.py
@@ -3,12 +3,12 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
 import threading
+import time
 
+from dmg_utils import check_system_query_status
 from osa_utils import OSAUtils
 from write_host_file import write_host_file
-from dmg_utils import check_system_query_status
 
 
 class NvmePoolExtend(OSAUtils):

--- a/src/tests/ftest/object/array.py
+++ b/src/tests/ftest/object/array.py
@@ -3,13 +3,12 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
+import logging
 import time
 import traceback
-import logging
-
-from pydaos.raw import DaosContainer, DaosApiError, c_uuid_to_str
 
 from apricot import TestWithServers
+from pydaos.raw import DaosApiError, DaosContainer, c_uuid_to_str
 
 
 class ArrayObjTest(TestWithServers):

--- a/src/tests/ftest/object/create_many_dkeys.py
+++ b/src/tests/ftest/object/create_many_dkeys.py
@@ -3,14 +3,13 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import sys
 import ctypes
+import sys
+
 import avocado
-
-from pydaos.raw import DaosContainer, IORequest, DaosApiError
-
 from apricot import TestWithServers
 from general_utils import create_string_buffer
+from pydaos.raw import DaosApiError, DaosContainer, IORequest
 
 
 class CreateManyDkeys(TestWithServers):

--- a/src/tests/ftest/object/fetch_bad_param.py
+++ b/src/tests/ftest/object/fetch_bad_param.py
@@ -6,9 +6,8 @@
 import time
 import traceback
 
-from pydaos.raw import DaosContainer, DaosApiError
-
 from apricot import TestWithServers
+from pydaos.raw import DaosApiError, DaosContainer
 
 
 class ObjFetchBadParam(TestWithServers):

--- a/src/tests/ftest/object/integrity.py
+++ b/src/tests/ftest/object/integrity.py
@@ -5,11 +5,11 @@
 """
 import ctypes
 import time
-import avocado
 
-from pydaos.raw import (DaosContainer, IORequest, DaosObj, DaosApiError)
+import avocado
 from apricot import TestWithServers
 from general_utils import create_string_buffer
+from pydaos.raw import DaosApiError, DaosContainer, DaosObj, IORequest
 
 
 class ObjectDataValidation(TestWithServers):

--- a/src/tests/ftest/object/open_bad_param.py
+++ b/src/tests/ftest/object/open_bad_param.py
@@ -5,9 +5,8 @@
 """
 import traceback
 
-from pydaos.raw import DaosContainer, DaosApiError, DaosObjId
-
 from apricot import TestWithServers
+from pydaos.raw import DaosApiError, DaosContainer, DaosObjId
 
 
 class ObjOpenBadParam(TestWithServers):

--- a/src/tests/ftest/object/punch_test.py
+++ b/src/tests/ftest/object/punch_test.py
@@ -5,9 +5,8 @@
 '''
 import traceback
 
-from pydaos.raw import DaosContainer, DaosApiError
-
 from apricot import TestWithServers
+from pydaos.raw import DaosApiError, DaosContainer
 
 
 class PunchTest(TestWithServers):

--- a/src/tests/ftest/object/same_key_different_value.py
+++ b/src/tests/ftest/object/same_key_different_value.py
@@ -3,9 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from pydaos.raw import DaosApiError
-
 from apricot import TestWithServers
+from pydaos.raw import DaosApiError
 
 
 class SameKeyDifferentValue(TestWithServers):

--- a/src/tests/ftest/object/update_bad_param.py
+++ b/src/tests/ftest/object/update_bad_param.py
@@ -5,9 +5,8 @@
 '''
 import traceback
 
-from pydaos.raw import DaosContainer, DaosApiError
-
 from apricot import TestWithServers
+from pydaos.raw import DaosApiError, DaosContainer
 
 
 class ObjUpdateBadParam(TestWithServers):

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -5,9 +5,9 @@
 """
 import random
 
+from nvme_utils import ServerFillUp
 from osa_utils import OSAUtils
 from test_utils_pool import add_pool
-from nvme_utils import ServerFillUp
 from write_host_file import write_host_file
 
 

--- a/src/tests/ftest/osa/offline_extend.py
+++ b/src/tests/ftest/osa/offline_extend.py
@@ -4,9 +4,10 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from time import sleep
+
+from dmg_utils import check_system_query_status
 from osa_utils import OSAUtils
 from test_utils_pool import add_pool
-from dmg_utils import check_system_query_status
 
 
 class OSAOfflineExtend(OSAUtils):

--- a/src/tests/ftest/osa/offline_parallel_test.py
+++ b/src/tests/ftest/osa/offline_parallel_test.py
@@ -3,13 +3,14 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
-import random
-import threading
 import copy
 import queue
-from osa_utils import OSAUtils
+import random
+import threading
+import time
+
 from dmg_utils import check_system_query_status
+from osa_utils import OSAUtils
 from test_utils_pool import add_pool
 
 

--- a/src/tests/ftest/osa/offline_reintegration.py
+++ b/src/tests/ftest/osa/offline_reintegration.py
@@ -5,8 +5,8 @@
 """
 import random
 
-from osa_utils import OSAUtils
 from nvme_utils import ServerFillUp
+from osa_utils import OSAUtils
 from test_utils_pool import add_pool
 from write_host_file import write_host_file
 

--- a/src/tests/ftest/osa/online_drain.py
+++ b/src/tests/ftest/osa/online_drain.py
@@ -3,13 +3,13 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
 import random
 import threading
+import time
 
-from write_host_file import write_host_file
 from osa_utils import OSAUtils
 from test_utils_pool import add_pool
+from write_host_file import write_host_file
 
 
 class OSAOnlineDrain(OSAUtils):

--- a/src/tests/ftest/osa/online_extend.py
+++ b/src/tests/ftest/osa/online_extend.py
@@ -3,14 +3,14 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
 import threading
+import time
 
-from test_utils_pool import add_pool
-from write_host_file import write_host_file
 from daos_racer_utils import DaosRacerCommand
 from dmg_utils import check_system_query_status
 from osa_utils import OSAUtils
+from test_utils_pool import add_pool
+from write_host_file import write_host_file
 
 
 class OSAOnlineExtend(OSAUtils):

--- a/src/tests/ftest/osa/online_parallel_test.py
+++ b/src/tests/ftest/osa/online_parallel_test.py
@@ -3,18 +3,18 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
+import copy
+import queue
 import random
 import threading
-import copy
-
+import time
 from itertools import product
-import queue
-from write_host_file import write_host_file
-from exception_utils import CommandFailure
-from daos_racer_utils import DaosRacerCommand
-from osa_utils import OSAUtils
+
 from apricot import skipForTicket
+from daos_racer_utils import DaosRacerCommand
+from exception_utils import CommandFailure
+from osa_utils import OSAUtils
+from write_host_file import write_host_file
 
 
 class OSAOnlineParallelTest(OSAUtils):

--- a/src/tests/ftest/osa/online_reintegration.py
+++ b/src/tests/ftest/osa/online_reintegration.py
@@ -3,15 +3,15 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
+import queue
 import random
 import threading
-import queue
+import time
 
-from test_utils_pool import add_pool
-from write_host_file import write_host_file
 from daos_racer_utils import DaosRacerCommand
 from osa_utils import OSAUtils
+from test_utils_pool import add_pool
+from write_host_file import write_host_file
 
 
 class OSAOnlineReintegration(OSAUtils):

--- a/src/tests/ftest/performance/mdtest_hard.py
+++ b/src/tests/ftest/performance/mdtest_hard.py
@@ -5,6 +5,7 @@
 '''
 
 import os
+
 from performance_test_base import PerformanceTestBase
 
 

--- a/src/tests/ftest/pool/api_attribute.py
+++ b/src/tests/ftest/pool/api_attribute.py
@@ -5,10 +5,9 @@
 '''
 import traceback
 
-from pydaos.raw import DaosApiError
-
 from apricot import TestWithServers
 from general_utils import get_random_bytes
+from pydaos.raw import DaosApiError
 from test_utils_base import CallbackHandler
 
 

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -3,10 +3,11 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import traceback
 import ctypes
-from avocado.core.exceptions import TestFail
+import traceback
+
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 
 
 class BadConnectTest(TestWithServers):

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -5,9 +5,8 @@
 '''
 import traceback
 
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 
 
 class BadQueryTest(TestWithServers):

--- a/src/tests/ftest/pool/create.py
+++ b/src/tests/ftest/pool/create.py
@@ -4,7 +4,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from apricot import TestWithServers
-from test_utils_pool import add_pool, get_size_params, check_pool_creation
+from test_utils_pool import add_pool, check_pool_creation, get_size_params
 
 
 class PoolCreateTests(TestWithServers):

--- a/src/tests/ftest/pool/destroy.py
+++ b/src/tests/ftest/pool/destroy.py
@@ -5,11 +5,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
 
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
-from general_utils import get_default_config_file, check_pool_files
+from avocado.core.exceptions import TestFail
 from dmg_utils import get_dmg_command
+from general_utils import check_pool_files, get_default_config_file
 
 
 class DestroyTests(TestWithServers):

--- a/src/tests/ftest/pool/dynamic_server_pool.py
+++ b/src/tests/ftest/pool/dynamic_server_pool.py
@@ -3,9 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from ClusterShell.NodeSet import NodeSet
-
 from apricot import TestWithServers
+from ClusterShell.NodeSet import NodeSet
 from general_utils import check_for_pool
 
 

--- a/src/tests/ftest/pool/evict.py
+++ b/src/tests/ftest/pool/evict.py
@@ -3,11 +3,10 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+from apricot import TestWithServers
 from avocado.core.exceptions import TestFail
 from ClusterShell.NodeSet import NodeSet
 from pydaos.raw import DaosApiError, c_uuid_to_str
-
-from apricot import TestWithServers
 
 
 class PoolEvictTest(TestWithServers):

--- a/src/tests/ftest/pool/label.py
+++ b/src/tests/ftest/pool/label.py
@@ -5,11 +5,10 @@
 """
 import string
 
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
-from general_utils import report_errors, get_random_string
+from avocado.core.exceptions import TestFail
 from exception_utils import CommandFailure
+from general_utils import get_random_string, report_errors
 
 
 class Label(TestWithServers):

--- a/src/tests/ftest/pool/list_pools.py
+++ b/src/tests/ftest/pool/list_pools.py
@@ -3,9 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 from exception_utils import CommandFailure
 
 

--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from ior_test_base import IorTestBase
 from general_utils import report_errors
+from ior_test_base import IorTestBase
 
 
 class ListVerboseTest(IorTestBase):

--- a/src/tests/ftest/pool/management_race.py
+++ b/src/tests/ftest/pool/management_race.py
@@ -3,14 +3,13 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import time
 import random
-
-from pydaos.raw import DaosApiError
+import time
 
 from apricot import TestWithServers
-from thread_manager import ThreadManager
 from command_utils_base import CommandFailure
+from pydaos.raw import DaosApiError
+from thread_manager import ThreadManager
 
 
 class PoolManagementRace(TestWithServers):

--- a/src/tests/ftest/pool/multi_server_create_delete.py
+++ b/src/tests/ftest/pool/multi_server_create_delete.py
@@ -5,11 +5,9 @@
 """
 import os
 
-from ClusterShell.NodeSet import NodeSet
-
 from apricot import TestWithServers
+from ClusterShell.NodeSet import NodeSet
 from general_utils import check_for_pool
-
 
 RESULT_PASS = "PASS"  # nosec
 RESULT_FAIL = "FAIL"

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -3,10 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from pydaos.raw import DaosContainer, DaosApiError
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
+from pydaos.raw import DaosApiError, DaosContainer
 
 RESULT_PASS = "PASS"  # nosec
 RESULT_FAIL = "FAIL"

--- a/src/tests/ftest/pool/query_attribute.py
+++ b/src/tests/ftest/pool/query_attribute.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import base64
+
 from apricot import TestWithServers
 
 

--- a/src/tests/ftest/pool/svc.py
+++ b/src/tests/ftest/pool/svc.py
@@ -3,9 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 
 
 class PoolSvc(TestWithServers):

--- a/src/tests/ftest/pool/verify_space.py
+++ b/src/tests/ftest/pool/verify_space.py
@@ -7,7 +7,6 @@ import os
 import re
 
 from apricot import TestWithServers
-
 from exception_utils import CommandFailure
 from general_utils import human_to_bytes
 from ior_utils import run_ior

--- a/src/tests/ftest/process_core_files.py
+++ b/src/tests/ftest/process_core_files.py
@@ -3,16 +3,16 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from argparse import ArgumentParser
-from collections import defaultdict
-from fnmatch import fnmatch
 import logging
 import os
 import sys
+from argparse import ArgumentParser
+from collections import defaultdict
+from fnmatch import fnmatch
 
 # pylint: disable=import-error,no-name-in-module
 from util.logger_utils import get_console_handler
-from util.run_utils import run_local, find_command, RunException
+from util.run_utils import RunException, find_command, run_local
 
 # Set up a logger for the console messages
 logger = logging.getLogger(__name__)

--- a/src/tests/ftest/rebuild/cascading_failures.py
+++ b/src/tests/ftest/rebuild/cascading_failures.py
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from rebuild_test_base import RebuildTestBase
 from daos_utils import DaosCommand
+from rebuild_test_base import RebuildTestBase
 
 
 class RbldCascadingFailures(RebuildTestBase):

--- a/src/tests/ftest/rebuild/container_create_race.py
+++ b/src/tests/ftest/rebuild/container_create_race.py
@@ -4,7 +4,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from avocado.core.exceptions import TestFail
-
 from ior_test_base import IorTestBase
 
 

--- a/src/tests/ftest/rebuild/no_cap.py
+++ b/src/tests/ftest/rebuild/no_cap.py
@@ -5,8 +5,9 @@
 '''
 
 from time import sleep, time
+
 from apricot import TestWithServers
-from general_utils import get_random_bytes, DaosTestError
+from general_utils import DaosTestError, get_random_bytes
 from test_utils_container import TestContainerData
 
 

--- a/src/tests/ftest/rebuild/read_array.py
+++ b/src/tests/ftest/rebuild/read_array.py
@@ -3,9 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from rebuild_test_base import RebuildTestBase
 from daos_utils import DaosCommand
 from general_utils import DaosTestError
+from rebuild_test_base import RebuildTestBase
 
 
 class RbldReadArrayTest(RebuildTestBase):

--- a/src/tests/ftest/rebuild/widely_striped.py
+++ b/src/tests/ftest/rebuild/widely_striped.py
@@ -4,6 +4,7 @@
     SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import time
+
 from mdtest_test_base import MdtestBase
 
 

--- a/src/tests/ftest/scrubber/csum_fault.py
+++ b/src/tests/ftest/scrubber/csum_fault.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import time
+
 from scrubber_test_base import TestWithScrubber
 
 

--- a/src/tests/ftest/security/cont_acl.py
+++ b/src/tests/ftest/security/cont_acl.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
+
 import security_test_base as secTestBase
 from cont_security_test_base import ContSecurityTestBase
 from pool_security_test_base import PoolSecurityTestBase

--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -4,7 +4,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from avocado import fail_on
-
 from cont_security_test_base import ContSecurityTestBase
 from exception_utils import CommandFailure
 

--- a/src/tests/ftest/security/cont_get_acl.py
+++ b/src/tests/ftest/security/cont_get_acl.py
@@ -6,10 +6,9 @@
 import os
 
 from avocado import fail_on
-
 from cont_security_test_base import ContSecurityTestBase
-from security_test_base import read_acl_file
 from exception_utils import CommandFailure
+from security_test_base import read_acl_file
 
 
 class GetContainerACLTest(ContSecurityTestBase):

--- a/src/tests/ftest/security/cont_overwrite_acl.py
+++ b/src/tests/ftest/security/cont_overwrite_acl.py
@@ -6,10 +6,9 @@
 import os
 
 from avocado import fail_on
-
 from cont_security_test_base import ContSecurityTestBase
-from security_test_base import create_acl_file
 from exception_utils import CommandFailure
+from security_test_base import create_acl_file
 
 
 class OverwriteContainerACLTest(ContSecurityTestBase):

--- a/src/tests/ftest/security/cont_update_acl.py
+++ b/src/tests/ftest/security/cont_update_acl.py
@@ -6,10 +6,9 @@
 import os
 
 from avocado import fail_on
-
 from cont_security_test_base import ContSecurityTestBase
-from security_test_base import create_acl_file
 from exception_utils import CommandFailure
+from security_test_base import create_acl_file
 
 
 class UpdateContainerACLTest(ContSecurityTestBase):

--- a/src/tests/ftest/security/pool_acl.py
+++ b/src/tests/ftest/security/pool_acl.py
@@ -3,12 +3,12 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
+import grp
 import os
 import pwd
-import grp
 
-from security_test_base import acl_entry
 from pool_security_test_base import PoolSecurityTestBase
+from security_test_base import acl_entry
 
 PERMISSIONS = ["", "r", "w", "rw"]
 

--- a/src/tests/ftest/security/pool_connect_init.py
+++ b/src/tests/ftest/security/pool_connect_init.py
@@ -6,9 +6,8 @@
 import os
 import traceback
 
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 
 
 class PoolSecurityTest(TestWithServers):

--- a/src/tests/ftest/security/pool_groups.py
+++ b/src/tests/ftest/security/pool_groups.py
@@ -3,11 +3,11 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import os
 import grp
+import os
 
-from security_test_base import acl_entry
 from pool_security_test_base import PoolSecurityTestBase
+from security_test_base import acl_entry
 
 PERMISSIONS = ["", "r", "w", "rw"]
 

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from avocado import fail_on
 from apricot import TestWithServers
+from avocado import fail_on
 from exception_utils import CommandFailure
 from server_utils import ServerFailed
 

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -3,14 +3,13 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import traceback
 import time
-
-from avocado.core.exceptions import TestFail
+import traceback
 
 from apricot import TestWithServers
-from ior_utils import IorCommand
+from avocado.core.exceptions import TestFail
 from exception_utils import CommandFailure
+from ior_utils import IorCommand
 from job_manager_utils import get_job_manager
 from thread_manager import ThreadManager
 

--- a/src/tests/ftest/server/multiengine_persocket.py
+++ b/src/tests/ftest/server/multiengine_persocket.py
@@ -6,14 +6,14 @@
 import base64
 import traceback
 
-from pydaos.raw import DaosApiError
-
-from general_utils import get_random_bytes, wait_for_result, check_ping, check_ssh
-from run_utils import run_remote, run_local
+from general_utils import (check_ping, check_ssh, get_random_bytes,
+                           wait_for_result)
 from ior_test_base import IorTestBase
 from mdtest_test_base import MdtestBase
+from pydaos.raw import DaosApiError
+from run_utils import run_local, run_remote
 from server_utils_base import DaosServerCommand
-from storage_utils import StorageInfo, StorageException
+from storage_utils import StorageException, StorageInfo
 
 
 class MultiEnginesPerSocketTest(IorTestBase, MdtestBase):

--- a/src/tests/ftest/server/replay.py
+++ b/src/tests/ftest/server/replay.py
@@ -7,7 +7,6 @@ import random
 import time
 
 from apricot import TestWithServers
-
 from dfuse_utils import get_dfuse, start_dfuse, stop_dfuse
 from general_utils import join
 from ior_utils import get_ior

--- a/src/tests/ftest/server/storage_tiers.py
+++ b/src/tests/ftest/server/storage_tiers.py
@@ -4,11 +4,12 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
-import yaml
 
+import yaml
 from apricot import TestWithServers
 from command_utils_base import CommonConfig
-from server_utils import DaosServerTransportCredentials, DaosServerYamlParameters
+from server_utils import (DaosServerTransportCredentials,
+                          DaosServerYamlParameters)
 
 
 class StorageTiers(TestWithServers):

--- a/src/tests/ftest/slurm_setup.py
+++ b/src/tests/ftest/slurm_setup.py
@@ -20,9 +20,10 @@ from ClusterShell.NodeSet import NodeSet
 # Update the path to support utils files that import other utils files
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "util"))
 # pylint: disable=import-outside-toplevel
-from logger_utils import get_console_handler                            # noqa: E402
-from package_utils import install_packages, remove_packages             # noqa: E402
-from run_utils import get_clush_command, run_remote, command_as_user    # noqa: E402
+from logger_utils import get_console_handler  # noqa: E402
+from package_utils import install_packages, remove_packages  # noqa: E402
+from run_utils import (command_as_user, get_clush_command,  # noqa: E402
+                       run_remote)
 
 # Set up a logger for the console messages
 logger = logging.getLogger(__name__)

--- a/src/tests/ftest/telemetry/dkey_akey_enum_punch.py
+++ b/src/tests/ftest/telemetry/dkey_akey_enum_punch.py
@@ -5,10 +5,9 @@
 '''
 import ctypes
 
-from pydaos.raw import DaosContainer, IORequest, DaosObjClass
-
-from telemetry_test_base import TestWithTelemetry
 from general_utils import create_string_buffer
+from pydaos.raw import DaosContainer, DaosObjClass, IORequest
+from telemetry_test_base import TestWithTelemetry
 
 
 class DkeyAkeyEnumPunch(TestWithTelemetry):

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -3,21 +3,19 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import socket
-import re
 import os
+import re
+import socket
 from getpass import getuser
 
+from agent_utils_params import (DaosAgentTransportCredentials,
+                                DaosAgentYamlParameters)
 from ClusterShell.NodeSet import NodeSet
-
-from command_utils_base import \
-    FormattedParameter, EnvironmentVariables, \
-    CommonConfig, CommandWithParameters
+from command_utils import CommandWithSubCommand, SubprocessManager, YamlCommand
+from command_utils_base import (CommandWithParameters, CommonConfig,
+                                EnvironmentVariables, FormattedParameter)
 from exception_utils import CommandFailure
-from command_utils import YamlCommand, CommandWithSubCommand, SubprocessManager
-from general_utils import get_log_file, run_pcmd, get_default_config_file
-from agent_utils_params import \
-    DaosAgentTransportCredentials, DaosAgentYamlParameters
+from general_utils import get_default_config_file, get_log_file, run_pcmd
 from run_utils import run_remote
 
 

--- a/src/tests/ftest/util/agent_utils_params.py
+++ b/src/tests/ftest/util/agent_utils_params.py
@@ -5,7 +5,8 @@
 """
 import os
 
-from command_utils_base import BasicParameter, LogParameter, YamlParameters, TransportCredentials
+from command_utils_base import (BasicParameter, LogParameter,
+                                TransportCredentials, YamlParameters)
 
 
 class DaosAgentTransportCredentials(TransportCredentials):

--- a/src/tests/ftest/util/apricot/apricot/__init__.py
+++ b/src/tests/ftest/util/apricot/apricot/__init__.py
@@ -1,5 +1,5 @@
 """apricot __init__."""
 __all__ = ['Test', 'TestWithServers', 'TestWithoutServers', 'skipForTicket']
 
-from apricot.test import Test, TestWithServers, TestWithoutServers
-from apricot.test import skipForTicket
+from apricot.test import (Test, TestWithoutServers, TestWithServers,
+                          skipForTicket)

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -5,41 +5,41 @@
 """
 # pylint: disable=too-many-lines
 
-from ast import literal_eval
-import os
 import json
+import os
+import random
 import re
 import sys
+from ast import literal_eval
 from time import time
-import random
-
-from avocado import fail_on, skip, TestFail
-from avocado import Test as avocadoTest
-from avocado.core import exceptions
-from ClusterShell.NodeSet import NodeSet
-from pydaos.raw import DaosContext, DaosLog, DaosApiError
 
 from agent_utils import DaosAgentManager, include_local_host
+from avocado import Test as avocadoTest
+from avocado import TestFail, fail_on, skip
+from avocado.core import exceptions
 from cart_ctl_utils import CartCtl
+from ClusterShell.NodeSet import NodeSet
 from command_utils_base import EnvironmentVariables
-from exception_utils import CommandFailure
 from daos_utils import DaosCommand
 from distro_utils import detect
 from dmg_utils import get_dmg_command
+from exception_utils import CommandFailure
 from fault_config_utils import FaultInjection
-from general_utils import \
-    get_default_config_file, pcmd, get_file_listing, DaosTestError, run_command, \
-    dump_engines_stacks, get_avocado_config_value, set_avocado_config_value, \
-    nodeset_append_suffix, dict_to_str
-from host_utils import get_local_host, get_host_parameters, HostRole, HostInfo, HostException
-from logger_utils import TestLogger
-from server_utils import DaosServerManager
-from run_utils import stop_processes, run_remote, command_as_user
-from slurm_utils import get_partition_hosts, get_reservation_hosts, SlurmFailed
-from test_utils_container import TestContainer
-from test_utils_pool import LabelGenerator, add_pool, POOL_NAMESPACE
-from write_host_file import write_host_file
+from general_utils import (DaosTestError, dict_to_str, dump_engines_stacks,
+                           get_avocado_config_value, get_default_config_file,
+                           get_file_listing, nodeset_append_suffix, pcmd,
+                           run_command, set_avocado_config_value)
+from host_utils import (HostException, HostInfo, HostRole, get_host_parameters,
+                        get_local_host)
 from job_manager_utils import get_job_manager
+from logger_utils import TestLogger
+from pydaos.raw import DaosApiError, DaosContext, DaosLog
+from run_utils import command_as_user, run_remote, stop_processes
+from server_utils import DaosServerManager
+from slurm_utils import SlurmFailed, get_partition_hosts, get_reservation_hosts
+from test_utils_container import TestContainer
+from test_utils_pool import POOL_NAMESPACE, LabelGenerator, add_pool
+from write_host_file import write_host_file
 
 
 def skipForTicket(ticket):  # pylint: disable=invalid-name

--- a/src/tests/ftest/util/cart_ctl_utils.py
+++ b/src/tests/ftest/util/cart_ctl_utils.py
@@ -4,9 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from command_utils_base import FormattedParameter
-from command_utils_base import BasicParameter
 from command_utils import ExecutableCommand
+from command_utils_base import BasicParameter, FormattedParameter
 
 
 # pylint: disable=too-few-public-methods,too-many-instance-attributes

--- a/src/tests/ftest/util/cmocka_utils.py
+++ b/src/tests/ftest/util/cmocka_utils.py
@@ -9,7 +9,7 @@ from agent_utils import include_local_host
 from command_utils import ExecutableCommand
 from command_utils_base import EnvironmentVariables
 from exception_utils import CommandFailure
-from results_utils import TestName, TestResult, Results, Job, create_xml
+from results_utils import Job, Results, TestName, TestResult, create_xml
 from run_utils import get_clush_command, run_local, run_remote
 
 

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -5,27 +5,27 @@
 """
 # pylint: disable=too-many-lines
 import contextlib
-from datetime import datetime
-from getpass import getuser
 import json
-from logging import getLogger
 import os
 import re
 import signal
 import time
+from datetime import datetime
+from getpass import getuser
+from logging import getLogger
 
 from avocado.utils import process
 from ClusterShell.NodeSet import NodeSet
-
-from command_utils_base import \
-    BasicParameter, CommandWithParameters, EnvironmentVariables, LogParameter, ObjectWithParameters
+from command_utils_base import (BasicParameter, CommandWithParameters,
+                                EnvironmentVariables, LogParameter,
+                                ObjectWithParameters)
 from exception_utils import CommandFailure
-from general_utils import check_file_exists, \
-    run_command, DaosTestError, get_job_manager_class, create_directory, \
-    distribute_files, change_file_owner, get_file_listing, run_pcmd, \
-    get_subprocess_stdout
-from user_utils import get_primary_group
+from general_utils import (DaosTestError, change_file_owner, check_file_exists,
+                           create_directory, distribute_files,
+                           get_file_listing, get_job_manager_class,
+                           get_subprocess_stdout, run_command, run_pcmd)
 from run_utils import command_as_user
+from user_utils import get_primary_group
 from yaml_utils import get_yaml_data
 
 

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -3,8 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from logging import getLogger
 import os
+from logging import getLogger
+
 import yaml
 from exception_utils import CommandFailure
 

--- a/src/tests/ftest/util/configuration_utils.py
+++ b/src/tests/ftest/util/configuration_utils.py
@@ -3,12 +3,11 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from logging import getLogger
 import re
+from logging import getLogger
 
 from command_utils_base import BasicParameter, ObjectWithParameters
 from general_utils import get_host_data
-
 
 DATA_ERROR = "[ERROR]"
 

--- a/src/tests/ftest/util/cont_security_test_base.py
+++ b/src/tests/ftest/util/cont_security_test_base.py
@@ -3,15 +3,14 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import grp
 import os
 import pwd
-import grp
 import re
 
-from avocado.core.exceptions import TestFail
-
-from apricot import TestWithServers
 import general_utils
+from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 from general_utils import DaosTestError
 from security_test_base import acl_entry
 

--- a/src/tests/ftest/util/container_rf_test_base.py
+++ b/src/tests/ftest/util/container_rf_test_base.py
@@ -5,9 +5,9 @@
 """
 import re
 
-from rebuild_test_base import RebuildTestBase
-from general_utils import DaosTestError
 from daos_utils import DaosCommand
+from general_utils import DaosTestError
+from rebuild_test_base import RebuildTestBase
 
 
 class ContRedundancyFactor(RebuildTestBase):

--- a/src/tests/ftest/util/control_test_base.py
+++ b/src/tests/ftest/util/control_test_base.py
@@ -4,9 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from ClusterShell.NodeSet import NodeSet
-
 from apricot import TestWithServers
+from ClusterShell.NodeSet import NodeSet
 
 
 class ControlTestBase(TestWithServers):

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -6,12 +6,12 @@
 
 import os
 import shutil
-from avocado import fail_on
 
 from apricot import TestWithServers
-from general_utils import get_log_file
+from avocado import fail_on
 from cmocka_utils import CmockaUtils
 from exception_utils import CommandFailure
+from general_utils import get_log_file
 from job_manager_utils import get_job_manager
 from test_utils_pool import POOL_TIMEOUT_INCREMENT
 

--- a/src/tests/ftest/util/daos_io_conf.py
+++ b/src/tests/ftest/util/daos_io_conf.py
@@ -9,8 +9,8 @@ import random
 from apricot import TestWithServers
 from command_utils import ExecutableCommand
 from command_utils_base import BasicParameter, FormattedParameter
-from exception_utils import CommandFailure, MPILoadError
 from env_modules import load_mpi
+from exception_utils import CommandFailure, MPILoadError
 from job_manager_utils import Orterun
 
 

--- a/src/tests/ftest/util/daos_perf_utils.py
+++ b/src/tests/ftest/util/daos_perf_utils.py
@@ -5,8 +5,8 @@
 """
 import os
 
-from command_utils_base import FormattedParameter
 from command_utils import ExecutableCommand
+from command_utils_base import FormattedParameter
 
 
 class DaosPerfCommand(ExecutableCommand):

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -6,12 +6,11 @@
 import os
 
 from ClusterShell.NodeSet import NodeSet
-
-from command_utils_base import BasicParameter, FormattedParameter
-from exception_utils import CommandFailure, MPILoadError
 from command_utils import ExecutableCommand
-from general_utils import pcmd, get_log_file
+from command_utils_base import BasicParameter, FormattedParameter
 from env_modules import load_mpi
+from exception_utils import CommandFailure, MPILoadError
+from general_utils import get_log_file, pcmd
 
 
 class DaosRacerCommand(ExecutableCommand):

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -7,7 +7,7 @@ import re
 import traceback
 
 from daos_utils_base import DaosCommandBase
-from general_utils import list_to_str, dict_to_str
+from general_utils import dict_to_str, list_to_str
 
 
 class DaosCommand(DaosCommandBase):

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -3,8 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from command_utils_base import FormattedParameter, CommandWithParameters, BasicParameter
 from command_utils import CommandWithSubCommand
+from command_utils_base import (BasicParameter, CommandWithParameters,
+                                FormattedParameter)
 
 
 class DaosCommandBase(CommandWithSubCommand):

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -3,24 +3,23 @@
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import ctypes
 # pylint: disable=too-many-lines
 import os
-from os.path import join
 import re
-import ctypes
+from os.path import join
 
-from pydaos.raw import str_to_c_uuid, DaosContainer, DaosObj, IORequest
-
+from command_utils_base import BasicParameter, EnvironmentVariables
+from data_mover_utils import (ContClone, DcpCommand, DdeserializeCommand,
+                              DserializeCommand, DsyncCommand, FsCopy,
+                              uuid_from_obj)
+from duns_utils import format_path
 from exception_utils import CommandFailure
-from test_utils_container import TestContainer
+from general_utils import create_string_buffer, get_log_file
 from ior_test_base import IorTestBase
 from mdtest_test_base import MdtestBase
-from data_mover_utils import DcpCommand, DsyncCommand, FsCopy, ContClone
-from data_mover_utils import DserializeCommand, DdeserializeCommand
-from data_mover_utils import uuid_from_obj
-from duns_utils import format_path
-from general_utils import create_string_buffer, get_log_file
-from command_utils_base import BasicParameter, EnvironmentVariables
+from pydaos.raw import DaosContainer, DaosObj, IORequest, str_to_c_uuid
+from test_utils_container import TestContainer
 
 
 class DataMoverTestBase(IorTestBase, MdtestBase):

--- a/src/tests/ftest/util/data_mover_utils.py
+++ b/src/tests/ftest/util/data_mover_utils.py
@@ -4,9 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from command_utils_base import FormattedParameter
-from command_utils_base import BasicParameter
 from command_utils import ExecutableCommand
+from command_utils_base import BasicParameter, FormattedParameter
 from job_manager_utils import Mpirun
 
 

--- a/src/tests/ftest/util/dbench_utils.py
+++ b/src/tests/ftest/util/dbench_utils.py
@@ -5,9 +5,8 @@
 """
 
 
-from command_utils_base import FormattedParameter
-from command_utils_base import BasicParameter
 from command_utils import ExecutableCommand
+from command_utils_base import BasicParameter, FormattedParameter
 from job_manager_utils import Mpirun
 
 

--- a/src/tests/ftest/util/dfuse_test_base.py
+++ b/src/tests/ftest/util/dfuse_test_base.py
@@ -4,10 +4,9 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from agent_utils import include_local_host
-
 from apricot import TestWithServers
-from exception_utils import CommandFailure
 from dfuse_utils import get_dfuse, start_dfuse
+from exception_utils import CommandFailure
 
 
 class DfuseTestBase(TestWithServers):

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -4,15 +4,15 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-import time
 import os
-from ClusterShell.NodeSet import NodeSet
+import time
 
-from command_utils_base import FormattedParameter, BasicParameter
-from exception_utils import CommandFailure
+from ClusterShell.NodeSet import NodeSet
 from command_utils import ExecutableCommand
+from command_utils_base import BasicParameter, FormattedParameter
+from exception_utils import CommandFailure
 from general_utils import check_file_exists, get_log_file
-from run_utils import run_remote, command_as_user
+from run_utils import command_as_user, run_remote
 
 
 class DfuseCommand(ExecutableCommand):

--- a/src/tests/ftest/util/distro_utils.py
+++ b/src/tests/ftest/util/distro_utils.py
@@ -4,6 +4,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import re
+
 # pylint: disable-next=wildcard-import, unused-wildcard-import
 from avocado.utils.distro import *  # noqa: F403
 

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -3,16 +3,16 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import re
+from grp import getgrgid
 # pylint: disable=too-many-lines
 from logging import getLogger
-from grp import getgrgid
 from pwd import getpwuid
-import re
 
-from exception_utils import CommandFailure
 from dmg_utils_base import DmgCommandBase
-from general_utils import get_numeric_list, dict_to_str
-from dmg_utils_params import DmgYamlParameters, DmgTransportCredentials
+from dmg_utils_params import DmgTransportCredentials, DmgYamlParameters
+from exception_utils import CommandFailure
+from general_utils import dict_to_str, get_numeric_list
 
 
 class DmgJsonCommandFailure(CommandFailure):

--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -6,9 +6,9 @@
 from socket import gethostname
 
 from ClusterShell.NodeSet import NodeSet
-
-from command_utils_base import FormattedParameter, CommandWithParameters, BasicParameter
 from command_utils import CommandWithSubCommand, YamlCommand
+from command_utils_base import (BasicParameter, CommandWithParameters,
+                                FormattedParameter)
 from general_utils import nodeset_append_suffix
 
 

--- a/src/tests/ftest/util/dmg_utils_params.py
+++ b/src/tests/ftest/util/dmg_utils_params.py
@@ -4,8 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from command_utils_base import \
-    BasicParameter, LogParameter, YamlParameters, TransportCredentials
+from command_utils_base import (BasicParameter, LogParameter,
+                                TransportCredentials, YamlParameters)
 
 
 class DmgTransportCredentials(TransportCredentials):

--- a/src/tests/ftest/util/ec_utils.py
+++ b/src/tests/ftest/util/ec_utils.py
@@ -3,20 +3,19 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import queue
 import re
 import threading
-import queue
 import time
 
-from pydaos.raw import DaosApiError
-
-from nvme_utils import ServerFillUp
-from daos_utils import DaosCommand
 from apricot import TestWithServers
-from mdtest_test_base import MdtestBase
-from fio_test_base import FioBase
+from daos_utils import DaosCommand
 from exception_utils import CommandFailure
+from fio_test_base import FioBase
 from general_utils import DaosTestError, run_pcmd
+from mdtest_test_base import MdtestBase
+from nvme_utils import ServerFillUp
+from pydaos.raw import DaosApiError
 
 
 def get_data_parity_number(log, oclass):

--- a/src/tests/ftest/util/exception_utils.py
+++ b/src/tests/ftest/util/exception_utils.py
@@ -5,7 +5,8 @@
 """
 
 import os
-from env_modules import show_avail, get_module_list
+
+from env_modules import get_module_list, show_avail
 from general_utils import run_command
 
 

--- a/src/tests/ftest/util/fault_config_utils.py
+++ b/src/tests/ftest/util/fault_config_utils.py
@@ -5,8 +5,9 @@
 """
 
 import os
+
 import yaml
-from general_utils import distribute_files, run_command, DaosTestError
+from general_utils import DaosTestError, distribute_files, run_command
 from run_utils import get_clush_command
 
 # a lookup table of predefined faults

--- a/src/tests/ftest/util/file_count_test_base.py
+++ b/src/tests/ftest/util/file_count_test_base.py
@@ -4,7 +4,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from avocado.core.exceptions import TestFail
-
 from ior_test_base import IorTestBase
 from mdtest_test_base import MdtestBase
 from oclass_utils import extract_redundancy_factor

--- a/src/tests/ftest/util/fio_utils.py
+++ b/src/tests/ftest/util/fio_utils.py
@@ -4,11 +4,11 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from ClusterShell.NodeSet import NodeSet
-
-from run_utils import run_remote
-from command_utils_base import BasicParameter, FormattedParameter, CommandWithParameters
-from exception_utils import CommandFailure
 from command_utils import ExecutableCommand
+from command_utils_base import (BasicParameter, CommandWithParameters,
+                                FormattedParameter)
+from exception_utils import CommandFailure
+from run_utils import run_remote
 
 
 class FioCommand(ExecutableCommand):

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -5,28 +5,28 @@
 """
 # pylint: disable=too-many-lines
 
-from logging import getLogger
-import os
-import re
-import random
-import string
-import time
 import ctypes
 import math
+import os
+import random
+import re
+import string
+import time
+from datetime import datetime
 from getpass import getuser
 from importlib import import_module
+from logging import getLogger
 from socket import gethostname
-from datetime import datetime
 
 from avocado.core.settings import settings
 from avocado.core.version import MAJOR
 from avocado.utils import process
-from ClusterShell.Task import task_self
 from ClusterShell.NodeSet import NodeSet
 from pydaos.raw import IORequest, DaosObjClass
 
+from ClusterShell.Task import task_self
+from run_utils import RunException, get_clush_command, run_local, run_remote
 from user_utils import get_chown_command, get_primary_group
-from run_utils import get_clush_command, run_remote, run_local, RunException
 
 
 class DaosTestError(Exception):

--- a/src/tests/ftest/util/host_utils.py
+++ b/src/tests/ftest/util/host_utils.py
@@ -7,8 +7,7 @@ import os
 from socket import gethostname
 
 from ClusterShell.NodeSet import NodeSet
-
-from slurm_utils import get_partition_hosts, get_reservation_hosts, SlurmFailed
+from slurm_utils import SlurmFailed, get_partition_hosts, get_reservation_hosts
 
 
 class HostException(Exception):

--- a/src/tests/ftest/util/io_utilities.py
+++ b/src/tests/ftest/util/io_utilities.py
@@ -3,16 +3,15 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from logging import getLogger
 import os
 import random
 import shutil
 import tempfile
 import time
+from logging import getLogger
 
+from general_utils import DaosTestError, get_random_bytes
 from pydaos.raw import DaosApiError
-
-from general_utils import get_random_bytes, DaosTestError
 
 
 class DirTree():

--- a/src/tests/ftest/util/ior_intercept_test_base.py
+++ b/src/tests/ftest/util/ior_intercept_test_base.py
@@ -5,9 +5,10 @@
 """
 
 import os
+
+from general_utils import percent_change
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand, IorMetrics
-from general_utils import percent_change
 
 
 class IorInterceptTestBase(IorTestBase):

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -6,12 +6,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 import os
 
 from ClusterShell.NodeSet import NodeSet
-
 from dfuse_test_base import DfuseTestBase
-from ior_utils import IorCommand
 from exception_utils import CommandFailure
+from general_utils import get_random_string, pcmd
+from ior_utils import IorCommand
 from job_manager_utils import get_job_manager
-from general_utils import pcmd, get_random_string
 
 
 class IorTestBase(DfuseTestBase):

--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -8,11 +8,11 @@ import re
 from enum import IntEnum
 
 from avocado.utils.process import CmdResult
-from command_utils_base import FormattedParameter, BasicParameter
-from exception_utils import CommandFailure
 from command_utils import SubProcessCommand
-from general_utils import get_log_file
+from command_utils_base import BasicParameter, FormattedParameter
 from duns_utils import format_path
+from exception_utils import CommandFailure
+from general_utils import get_log_file
 
 
 def get_ior(test, manager, hosts, path, slots, namespace="/run/ior/*", ior_params=None):

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -3,20 +3,20 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-# pylint: disable=too-many-lines
-from distutils.spawn import find_executable  # pylint: disable=deprecated-module
 import os
 import re
 import time
+# pylint: disable=too-many-lines
+from distutils.spawn import \
+    find_executable  # pylint: disable=deprecated-module
 
 from ClusterShell.NodeSet import NodeSet
-
 from command_utils import ExecutableCommand, SystemctlCommand
-from command_utils_base import FormattedParameter, EnvironmentVariables
-from exception_utils import CommandFailure, MPILoadError
+from command_utils_base import EnvironmentVariables, FormattedParameter
 from env_modules import load_mpi
-from general_utils import pcmd, run_pcmd, get_job_manager_class, get_journalctl_command, \
-    journalctl_time
+from exception_utils import CommandFailure, MPILoadError
+from general_utils import (get_job_manager_class, get_journalctl_command,
+                           journalctl_time, pcmd, run_pcmd)
 from run_utils import run_remote, stop_processes
 from write_host_file import write_host_file
 

--- a/src/tests/ftest/util/macsio_test_base.py
+++ b/src/tests/ftest/util/macsio_test_base.py
@@ -5,8 +5,8 @@
 """
 from apricot import TestWithServers
 from exception_utils import CommandFailure
-from macsio_util import MacsioCommand
 from general_utils import get_log_file
+from macsio_util import MacsioCommand
 
 
 class MacsioTestBase(TestWithServers):

--- a/src/tests/ftest/util/macsio_util.py
+++ b/src/tests/ftest/util/macsio_util.py
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from command_utils_base import FormattedParameter
 from command_utils import ExecutableCommand
+from command_utils_base import FormattedParameter
 from general_utils import get_log_file, pcmd
 
 

--- a/src/tests/ftest/util/mdtest_test_base.py
+++ b/src/tests/ftest/util/mdtest_test_base.py
@@ -5,10 +5,11 @@
 """
 
 import os
+
 from dfuse_test_base import DfuseTestBase
-from mdtest_utils import MdtestCommand
 from exception_utils import CommandFailure
 from job_manager_utils import get_job_manager
+from mdtest_utils import MdtestCommand
 
 
 class MdtestBase(DfuseTestBase):

--- a/src/tests/ftest/util/mdtest_utils.py
+++ b/src/tests/ftest/util/mdtest_utils.py
@@ -7,8 +7,8 @@
 import os
 import re
 
-from command_utils_base import FormattedParameter
 from command_utils import ExecutableCommand
+from command_utils_base import FormattedParameter
 from general_utils import get_log_file
 
 

--- a/src/tests/ftest/util/mpiio_test_base.py
+++ b/src/tests/ftest/util/mpiio_test_base.py
@@ -7,11 +7,10 @@
 import os
 
 from apricot import TestWithServers
-
 from command_utils_base import CommandFailure, EnvironmentVariables
-from job_manager_utils import get_job_manager
-from mpiio_utils import LLNLCommand, Mpi4pyCommand, RomioCommand, Hdf5Command
 from duns_utils import format_path
+from job_manager_utils import get_job_manager
+from mpiio_utils import Hdf5Command, LLNLCommand, Mpi4pyCommand, RomioCommand
 
 
 class MpiioTests(TestWithServers):

--- a/src/tests/ftest/util/mpiio_utils.py
+++ b/src/tests/ftest/util/mpiio_utils.py
@@ -4,8 +4,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from sys import version_info
-from command_utils_base import FormattedParameter
+
 from command_utils import ExecutableCommand
+from command_utils_base import FormattedParameter
 
 
 class LLNLCommand(ExecutableCommand):

--- a/src/tests/ftest/util/network_utils.py
+++ b/src/tests/ftest/util/network_utils.py
@@ -4,14 +4,13 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import errno
-from logging import getLogger
 import os
 import re
+from logging import getLogger
 
 from ClusterShell.NodeSet import NodeSet
-
 from exception_utils import CommandFailure
-from general_utils import run_task, display_task, run_pcmd
+from general_utils import display_task, run_pcmd, run_task
 
 SUPPORTED_PROVIDERS = ("ofi+sockets", "ofi+tcp;ofi_rxm", "ofi+verbs;ofi_rxm", "ucx+dc_x", "ofi+cxi")
 

--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -3,14 +3,13 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import threading
 import re
+import threading
 import time
 
 from avocado import fail_on
 from avocado.core.exceptions import TestFail
-
-from dmg_utils import get_storage_query_device_uuids, get_dmg_response
+from dmg_utils import get_dmg_response, get_storage_query_device_uuids
 from exception_utils import CommandFailure
 from ior_test_base import IorTestBase
 from ior_utils import IorCommand

--- a/src/tests/ftest/util/osa_utils.py
+++ b/src/tests/ftest/util/osa_utils.py
@@ -5,17 +5,16 @@
 """
 import ctypes
 import queue
-import time
-import threading
 import re
-
-from pydaos.raw import DaosContainer, IORequest, DaosObj, DaosApiError
+import threading
+import time
 
 from avocado import fail_on
-from ior_test_base import IorTestBase
-from mdtest_test_base import MdtestBase
 from exception_utils import CommandFailure
 from general_utils import create_string_buffer, run_command
+from ior_test_base import IorTestBase
+from mdtest_test_base import MdtestBase
+from pydaos.raw import DaosApiError, DaosContainer, DaosObj, IORequest
 
 
 class OSAUtils(MdtestBase, IorTestBase):

--- a/src/tests/ftest/util/package_utils.py
+++ b/src/tests/ftest/util/package_utils.py
@@ -4,7 +4,7 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from run_utils import run_remote, command_as_user
+from run_utils import command_as_user, run_remote
 
 
 def find_packages(log, hosts, pattern, user=None):

--- a/src/tests/ftest/util/performance_test_base.py
+++ b/src/tests/ftest/util/performance_test_base.py
@@ -6,15 +6,14 @@
 import os
 import time
 
+import oclass_utils
 from avocado.core.exceptions import TestFail
-
+from exception_utils import CommandFailure
+from general_utils import get_subprocess_stdout
 from ior_test_base import IorTestBase
+from ior_utils import IorMetrics
 from mdtest_test_base import MdtestBase
 from mdtest_utils import MdtestMetrics
-from general_utils import get_subprocess_stdout
-from ior_utils import IorMetrics
-import oclass_utils
-from exception_utils import CommandFailure
 
 
 class PerformanceTestBase(IorTestBase, MdtestBase):

--- a/src/tests/ftest/util/pool_create_all_base.py
+++ b/src/tests/ftest/util/pool_create_all_base.py
@@ -6,9 +6,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 import sys
 import time
 
-from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers
+from avocado.core.exceptions import TestFail
 from general_utils import bytes_to_human
 
 

--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -3,14 +3,14 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import grp
 import os
 import random
-import grp
 import re
 
-from apricot import TestWithServers
 import agent_utils as agu
 import security_test_base as secTestBase
+from apricot import TestWithServers
 
 PERMISSIONS = ["", "r", "w", "rw"]
 DENY_ACCESS = "-1001"

--- a/src/tests/ftest/util/rebuild_test_base.py
+++ b/src/tests/ftest/util/rebuild_test_base.py
@@ -4,7 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 from apricot import TestWithServers
-from command_utils_base import ObjectWithParameters, BasicParameter
+from command_utils_base import BasicParameter, ObjectWithParameters
 from daos_utils import DaosCommand
 
 

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -3,10 +3,11 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from socket import gethostname
-import subprocess   # nosec
 import shlex
+import subprocess  # nosec
 import time
+from socket import gethostname
+
 from ClusterShell.NodeSet import NodeSet
 from ClusterShell.Task import task_self
 

--- a/src/tests/ftest/util/scrubber_test_base.py
+++ b/src/tests/ftest/util/scrubber_test_base.py
@@ -5,8 +5,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import threading
 
-from scrubber_utils import ScrubberUtils
 from ior_test_base import IorTestBase
+from scrubber_utils import ScrubberUtils
 
 
 class TestWithScrubber(IorTestBase):

--- a/src/tests/ftest/util/security_test_base.py
+++ b/src/tests/ftest/util/security_test_base.py
@@ -6,6 +6,7 @@
 
 import os
 import random
+
 from general_utils import pcmd
 
 

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -5,27 +5,28 @@
 """
 # pylint: disable=too-many-lines
 
-from collections import defaultdict
-from getpass import getuser
 import os
+import random
 import re
 import time
-import random
+from collections import defaultdict
+from getpass import getuser
 
 from avocado import fail_on
-
 from ClusterShell.NodeSet import NodeSet
-from command_utils_base import CommonConfig, BasicParameter
 from command_utils import SubprocessManager
+from command_utils_base import BasicParameter, CommonConfig
 from dmg_utils import get_dmg_command
 from exception_utils import CommandFailure
-from general_utils import pcmd, get_log_file, list_to_str, get_display_size, run_pcmd
-from general_utils import get_default_config_file
+from general_utils import (get_default_config_file, get_display_size,
+                           get_log_file, list_to_str, pcmd, run_pcmd)
 from host_utils import get_local_host
-from server_utils_base import ServerFailed, DaosServerCommand, DaosServerInformation
-from server_utils_params import DaosServerTransportCredentials, DaosServerYamlParameters
-from user_utils import get_chown_command
 from run_utils import run_remote, stop_processes
+from server_utils_base import (DaosServerCommand, DaosServerInformation,
+                               ServerFailed)
+from server_utils_params import (DaosServerTransportCredentials,
+                                 DaosServerYamlParameters)
+from user_utils import get_chown_command
 
 
 def get_server_command(group, cert_dir, bin_dir, config_file, config_temp=None):

--- a/src/tests/ftest/util/server_utils_base.py
+++ b/src/tests/ftest/util/server_utils_base.py
@@ -3,14 +3,13 @@
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from logging import getLogger
 import os
 import re
+from logging import getLogger
 
 from ClusterShell.NodeSet import NodeSet
-
-from command_utils_base import FormattedParameter, CommandWithParameters
-from command_utils import YamlCommand, CommandWithSubCommand
+from command_utils import CommandWithSubCommand, YamlCommand
+from command_utils_base import CommandWithParameters, FormattedParameter
 from data_utils import dict_extract_values, list_flatten
 from dmg_utils import get_dmg_response
 from exception_utils import CommandFailure

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -5,8 +5,8 @@
 """
 import os
 
-from command_utils_base import \
-    BasicParameter, LogParameter, YamlParameters, TransportCredentials
+from command_utils_base import (BasicParameter, LogParameter,
+                                TransportCredentials, YamlParameters)
 
 MAX_STORAGE_TIERS = 5
 

--- a/src/tests/ftest/util/slurm_utils.py
+++ b/src/tests/ftest/util/slurm_utils.py
@@ -7,13 +7,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 import os
 import random
-import time
-import threading
 import re
+import threading
+import time
 
 from ClusterShell.NodeSet import NodeSet, NodeSetParseError
-
-from run_utils import run_remote, run_local, RunException
+from run_utils import RunException, run_local, run_remote
 
 PACKAGES = ['slurm', 'slurm-example-configs', 'slurm-slurmctld', 'slurm-slurmd']
 W_LOCK = threading.Lock()

--- a/src/tests/ftest/util/soak_test_base.py
+++ b/src/tests/ftest/util/soak_test_base.py
@@ -4,33 +4,35 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
+import multiprocessing
 import os
+import random
+import socket
+import threading
 import time
 from datetime import datetime, timedelta
-import multiprocessing
-import threading
-import random
 from filecmp import cmp
 from getpass import getuser
-import socket
 
+import slurm_utils
+from agent_utils import include_local_host
 from apricot import TestWithServers
 from ClusterShell.NodeSet import NodeSet
-from agent_utils import include_local_host
+from dmg_utils import DmgCommand
 from exception_utils import CommandFailure
 from general_utils import journalctl_time
 from host_utils import get_local_host
-import slurm_utils
-from dmg_utils import DmgCommand
-from run_utils import run_local, run_remote, RunException
-from soak_utils import ddhhmmss_format, add_pools, \
-    launch_snapshot, launch_exclude_reintegrate, launch_extend, \
-    create_ior_cmdline, cleanup_dfuse, create_fio_cmdline, \
-    build_job_script, SoakTestError, launch_server_stop_start, get_harassers, \
-    create_racer_cmdline, run_event_check, run_monitor_check, \
-    create_mdtest_cmdline, reserved_file_copy, run_metrics_check, \
-    get_journalctl, get_daos_server_logs, create_macsio_cmdline, \
-    create_app_cmdline, create_dm_cmdline, launch_vmd_identify_check
+from run_utils import RunException, run_local, run_remote
+from soak_utils import (SoakTestError, add_pools, build_job_script,
+                        cleanup_dfuse, create_app_cmdline, create_dm_cmdline,
+                        create_fio_cmdline, create_ior_cmdline,
+                        create_macsio_cmdline, create_mdtest_cmdline,
+                        create_racer_cmdline, ddhhmmss_format,
+                        get_daos_server_logs, get_harassers, get_journalctl,
+                        launch_exclude_reintegrate, launch_extend,
+                        launch_server_stop_start, launch_snapshot,
+                        launch_vmd_identify_check, reserved_file_copy,
+                        run_event_check, run_metrics_check, run_monitor_check)
 
 
 class SoakTestBase(TestWithServers):

--- a/src/tests/ftest/util/soak_utils.py
+++ b/src/tests/ftest/util/soak_utils.py
@@ -6,33 +6,32 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 # pylint: disable=too-many-lines
 
 import os
-import time
 import random
-import threading
 import re
+import threading
+import time
 from itertools import product
 
+import slurm_utils
 from avocado.core.exceptions import TestFail
-from pydaos.raw import DaosSnapshot, DaosApiError
-
-from ior_utils import IorCommand
-from fio_utils import FioCommand
-from mdtest_utils import MdtestCommand
+from command_utils_base import EnvironmentVariables
 from daos_racer_utils import DaosRacerCommand
 from data_mover_utils import DcpCommand, FsCopy
 from dfuse_utils import Dfuse
 from dmg_utils import get_storage_query_device_info
+from duns_utils import format_path
+from fio_utils import FioCommand
+from general_utils import (DaosTestError, get_host_data, get_log_file,
+                           get_random_bytes, get_random_string, list_to_str,
+                           pcmd, run_command, run_pcmd)
+from ior_utils import IorCommand
 from job_manager_utils import Mpirun
-from general_utils import get_host_data, get_random_string, \
-    run_command, DaosTestError, pcmd, get_random_bytes, \
-    run_pcmd, list_to_str, get_log_file
-from command_utils_base import EnvironmentVariables
-import slurm_utils
+from macsio_util import MacsioCommand
+from mdtest_utils import MdtestCommand
+from oclass_utils import extract_redundancy_factor
+from pydaos.raw import DaosApiError, DaosSnapshot
 from run_utils import run_remote
 from test_utils_container import TestContainer
-from macsio_util import MacsioCommand
-from oclass_utils import extract_redundancy_factor
-from duns_utils import format_path
 
 H_LOCK = threading.Lock()
 

--- a/src/tests/ftest/util/storage_utils.py
+++ b/src/tests/ftest/util/storage_utils.py
@@ -3,16 +3,15 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from collections import OrderedDict
-from functools import partial
 import itertools
-from operator import is_not
 import os
 import re
+from collections import OrderedDict
+from functools import partial
+from operator import is_not
+
 import yaml
-
 from ClusterShell.NodeSet import NodeSet
-
 from run_utils import run_remote
 
 

--- a/src/tests/ftest/util/support_test_base.py
+++ b/src/tests/ftest/util/support_test_base.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 
 from control_test_base import ControlTestBase
-from run_utils import run_remote, command_as_user
+from run_utils import command_as_user, run_remote
 
 
 class SupportTestBase(ControlTestBase):

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -3,8 +3,9 @@
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from logging import getLogger
 import re
+from logging import getLogger
+
 from ClusterShell.NodeSet import NodeSet
 
 

--- a/src/tests/ftest/util/test_utils_base.py
+++ b/src/tests/ftest/util/test_utils_base.py
@@ -3,14 +3,13 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from logging import getLogger
-from time import sleep
-from threading import Lock
 from collections import defaultdict
+from logging import getLogger
+from threading import Lock
+from time import sleep
 
+from command_utils_base import BasicParameter, ObjectWithParameters
 from pydaos.raw import DaosApiError
-
-from command_utils_base import ObjectWithParameters, BasicParameter
 
 
 class CallbackHandler():

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -10,13 +10,12 @@ from logging import getLogger
 from time import time
 
 from avocado import fail_on
-from pydaos.raw import (DaosApiError, DaosContainer, DaosInputParams,
-                        c_uuid_to_str, str_to_c_uuid)
-
-from test_utils_base import TestDaosApiBase
 from command_utils_base import BasicParameter
 from exception_utils import CommandFailure
-from general_utils import get_random_bytes, DaosTestError
+from general_utils import DaosTestError, get_random_bytes
+from pydaos.raw import (DaosApiError, DaosContainer, DaosInputParams,
+                        c_uuid_to_str, str_to_c_uuid)
+from test_utils_base import TestDaosApiBase
 
 
 class TestContainerData():

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -3,20 +3,19 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
+import ctypes
+import json
 # pylint: disable=too-many-lines
 import os
 from time import sleep, time
-import ctypes
-import json
 
-from avocado import fail_on, TestFail
-from pydaos.raw import (DaosApiError, DaosPool, c_uuid_to_str, daos_cref)
-
-from test_utils_base import TestDaosApiBase, LabelGenerator
+from avocado import TestFail, fail_on
 from command_utils import BasicParameter
-from exception_utils import CommandFailure
-from general_utils import check_pool_files, DaosTestError
 from dmg_utils import DmgCommand, DmgJsonCommandFailure
+from exception_utils import CommandFailure
+from general_utils import DaosTestError, check_pool_files
+from pydaos.raw import DaosApiError, DaosPool, c_uuid_to_str, daos_cref
+from test_utils_base import LabelGenerator, TestDaosApiBase
 
 POOL_NAMESPACE = "/run/pool/*"
 POOL_TIMEOUT_INCREMENT = 200

--- a/src/tests/ftest/util/thread_manager.py
+++ b/src/tests/ftest/util/thread_manager.py
@@ -3,8 +3,9 @@
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from concurrent.futures import as_completed
 from logging import getLogger
 
 from avocado.utils.process import CmdResult

--- a/src/tests/ftest/util/user_utils.py
+++ b/src/tests/ftest/util/user_utils.py
@@ -3,15 +3,14 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from getpass import getuser
-from grp import getgrgid
-from pwd import getpwnam
 import os
 import re
 from collections import defaultdict
+from getpass import getuser
+from grp import getgrgid
+from pwd import getpwnam
 
 from ClusterShell.NodeSet import NodeSet
-
 from run_utils import run_remote
 
 

--- a/src/tests/ftest/util/verify_perms.py
+++ b/src/tests/ftest/util/verify_perms.py
@@ -4,20 +4,20 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import sys
-import os
 import getpass
-from argparse import ArgumentParser
-from multiprocessing import Process, Queue  # MUST be a multiprocessing Queue
-import traceback
-import tempfile
-from itertools import product
 import logging
+import os
+import sys
+import tempfile
+import traceback
+from argparse import ArgumentParser
 from functools import partial
+from itertools import product
+from multiprocessing import Process, Queue  # MUST be a multiprocessing Queue
 
 from logger_utils import get_console_handler
+from run_utils import RunException, run_local
 from user_utils import get_user_uid_gid
-from run_utils import run_local, RunException
 
 # Set up a logger for the console messages
 logger = logging.getLogger(__name__)

--- a/src/tests/ftest/util/vol_test_base.py
+++ b/src/tests/ftest/util/vol_test_base.py
@@ -4,10 +4,10 @@
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
-from dfuse_test_base import DfuseTestBase
-from command_utils_base import EnvironmentVariables
-from exception_utils import CommandFailure
 from command_utils import ExecutableCommand
+from command_utils_base import EnvironmentVariables
+from dfuse_test_base import DfuseTestBase
+from exception_utils import CommandFailure
 
 
 class VolTestBase(DfuseTestBase):

--- a/src/tests/ftest/util/write_host_file.py
+++ b/src/tests/ftest/util/write_host_file.py
@@ -3,9 +3,9 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from logging import getLogger
 import os
 import random
+from logging import getLogger
 
 
 def write_host_file(hosts, path='/tmp', slots=1):

--- a/src/tests/ftest/util/yaml_utils.py
+++ b/src/tests/ftest/util/yaml_utils.py
@@ -3,14 +3,13 @@
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from collections import OrderedDict
 import os
 import re
+from collections import OrderedDict
+
 import yaml
-
 from ClusterShell.NodeSet import NodeSet
-
-from data_utils import list_unique, list_flatten, dict_extract_values
+from data_utils import dict_extract_values, list_flatten, list_unique
 
 
 class YamlException(BaseException):

--- a/src/tests/ftest/vmd/fault_reintegration.py
+++ b/src/tests/ftest/vmd/fault_reintegration.py
@@ -3,17 +3,16 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-from multiprocessing import Queue
 import threading
+from multiprocessing import Queue
 
+from apricot import TestWithServers
 from avocado import fail_on
-
-from dmg_utils import get_storage_query_device_info, get_dmg_response
+from dmg_utils import get_dmg_response, get_storage_query_device_info
 from exception_utils import CommandFailure
 from ior_utils import run_ior, thread_run_ior
 from job_manager_utils import get_job_manager
 from nvme_utils import set_device_faulty
-from apricot import TestWithServers
 
 
 class NvmeFaultReintegrate(TestWithServers):

--- a/src/tests/ftest/vmd/led.py
+++ b/src/tests/ftest/vmd/led.py
@@ -6,7 +6,6 @@
 import time
 
 from avocado import fail_on
-
 from dmg_utils import get_storage_query_device_uuids
 from exception_utils import CommandFailure
 from nvme_utils import set_device_faulty

--- a/src/vos/storage_estimator/common/dfs_sb.py
+++ b/src/vos/storage_estimator/common/dfs_sb.py
@@ -4,11 +4,12 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 
-import os
 import ctypes
+import os
 
 from pydaos.raw import daos_cref
-from storage_estimator.vos_structures import ValType, Overhead, AKey, VosValue, DKey, VosObject
+from storage_estimator.vos_structures import (AKey, DKey, Overhead, ValType,
+                                              VosObject, VosValue)
 
 header = '''---
 # Sample conflig file DFS files and directories

--- a/src/vos/storage_estimator/common/explorer.py
+++ b/src/vos/storage_estimator/common/explorer.py
@@ -4,13 +4,14 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 
-import os
 import copy
+import os
 import sys
 
-from storage_estimator.vos_structures import VosObject, AKey, DKey, Container, \
-    VosValue, Overhead, ValType, KeyType
 from storage_estimator.util import CommonBase, ObjectClass
+from storage_estimator.vos_structures import (AKey, Container, DKey, KeyType,
+                                              Overhead, ValType, VosObject,
+                                              VosValue)
 
 
 class FileInfo():

--- a/src/vos/storage_estimator/common/parse_csv.py
+++ b/src/vos/storage_estimator/common/parse_csv.py
@@ -4,8 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 
-from storage_estimator.explorer import AverageFS
 from storage_estimator.dfs_sb import get_dfs_inode_akey
+from storage_estimator.explorer import AverageFS
 from storage_estimator.util import ProcessBase
 
 FILE_SIZES = ['4k', '64k', '128k', '256k', '512k', '768k', '1m', '8m', '64m',

--- a/src/vos/storage_estimator/common/tests/storage_estimator_test.py
+++ b/src/vos/storage_estimator/common/tests/storage_estimator_test.py
@@ -3,16 +3,19 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import pytest
-import unittest
-import yaml
 import os
+import unittest
 
-from storage_estimator.vos_structures import VosObject, AKey, DKey, Container, Containers, \
-    VosValue, Overhead, ValType, VosValueError
+import pytest
+import yaml
 from storage_estimator.explorer import FileSystemExplorer
-from storage_estimator.util import ObjectClass
 from storage_estimator.parse_csv import ProcessCSV
+from storage_estimator.util import ObjectClass
+from storage_estimator.vos_structures import (AKey, Container, Containers,
+                                              DKey, Overhead, ValType,
+                                              VosObject, VosValue,
+                                              VosValueError)
+
 from .util import FileGenerator
 
 

--- a/src/vos/storage_estimator/common/tests/util.py
+++ b/src/vos/storage_estimator/common/tests/util.py
@@ -4,8 +4,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
 import os
-import tempfile
 import shutil
+import tempfile
 
 
 class FileGenerator():

--- a/src/vos/storage_estimator/common/util.py
+++ b/src/vos/storage_estimator/common/util.py
@@ -6,8 +6,8 @@
 
 
 import os
-import yaml
 
+import yaml
 from storage_estimator.dfs_sb import VOS_SIZE, get_dfs_sb_obj
 from storage_estimator.vos_size import MetaOverhead
 from storage_estimator.vos_structures import Containers

--- a/src/vos/storage_estimator/common/vos_size.py
+++ b/src/vos/storage_estimator/common/vos_size.py
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-import random
 import math
+import random
 
 
 def convert(stat):

--- a/src/vos/storage_estimator/daos_storage_estimator.py
+++ b/src/vos/storage_estimator/daos_storage_estimator.py
@@ -7,9 +7,10 @@
 import argparse
 import sys
 
-from storage_estimator.dfs_sb import get_dfs_example, print_daos_version, get_dfs_inode_akey
-from storage_estimator.parse_csv import ProcessCSV
+from storage_estimator.dfs_sb import (get_dfs_example, get_dfs_inode_akey,
+                                      print_daos_version)
 from storage_estimator.explorer import FileSystemExplorer
+from storage_estimator.parse_csv import ProcessCSV
 from storage_estimator.util import Common, ProcessBase
 
 tool_description = '''DAOS estimation tool

--- a/src/vos/tests/evt_stress.py
+++ b/src/vos/tests/evt_stress.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Run evt_ctl with a specific pattern that causes a segfault with the default sort algorithm"""
+import argparse
+import json
 import os
 from os.path import join
-import json
-import argparse
 
 
 class EVTStress():

--- a/utils/ansible/ftest/library/daos_hugepages.py
+++ b/utils/ansible/ftest/library/daos_hugepages.py
@@ -9,9 +9,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
+import datetime
 import os
 import re
-import datetime
 import subprocess  # nosec B404
 
 from ansible.module_utils.basic import AnsibleModule

--- a/utils/cq/d_logging_check.py
+++ b/utils/cq/d_logging_check.py
@@ -13,10 +13,10 @@ if fixes are being applied.
 
 import argparse
 import inspect
-import sys
-import re
 import io
 import os
+import re
+import sys
 
 ARGS = None
 

--- a/utils/cq/daos_pylint.py
+++ b/utils/cq/daos_pylint.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python3
 """Wrapper script for calling pylint"""
 
-import os
-import sys
-import re
-from collections import Counter
-import tempfile
-import subprocess  # nosec
 import argparse
 import json
+import os
+import re
+import subprocess  # nosec
+import sys
+import tempfile
+from collections import Counter
+
 for arg in sys.argv:
     if arg.startswith('--import='):
         sys.path.append(arg[9:])
 try:
+    from pylint.constants import full_version
     from pylint.lint import Run
     from pylint.reporters.collecting_reporter import CollectingReporter
-    from pylint.constants import full_version
 except ImportError:
 
     if os.path.exists('venv'):
@@ -23,9 +24,9 @@ except ImportError:
                                      f'python{sys.version_info.major}.{sys.version_info.minor}',
                                      'site-packages'))
         try:
+            from pylint.constants import full_version
             from pylint.lint import Run
             from pylint.reporters.collecting_reporter import CollectingReporter
-            from pylint.constants import full_version
         except ImportError:
             print('detected venv unusable, install pylint to enable this check')
             sys.exit(0)

--- a/utils/cq/requirements.txt
+++ b/utils/cq/requirements.txt
@@ -4,6 +4,11 @@ avocado-framework<94
 avocado-framework-plugin-result-html<94
 avocado-framework-plugin-varianter-yaml-to-mux<94
 clustershell
+## flake8 6 removed --diff option which breaks flake precommit hook.
+## https://github.com/pycqa/flake8/issues/1389 https://github.com/PyCQA/flake8/pull/1720
+flake8<6.0.0
+isort
 paramiko
 pyenchant
 pylint
+yamllint

--- a/utils/githooks/pre-commit.d/20-isort.sh
+++ b/utils/githooks/pre-commit.d/20-isort.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Runs isort for the DAOS project.
+
+set -ue
+
+if ! command -v isort > /dev/null 2>&1
+then
+    echo "No isort checking, install isort command to improve pre-commit checks"
+    echo "python3 -m pip install isort"
+    exit 0
+fi
+
+echo "isort:"
+
+echo "  Running isort for python imports."
+isort --jobs 8 --check-only .

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -10,30 +10,31 @@ the client with fault injection of D_ALLOC() usage.
 
 # pylint: disable=too-many-lines
 
-import os
-from os.path import join
-import sys
-import time
-import uuid
-import json
-import copy
-import signal
-import pprint
-import stat
-import errno
 import argparse
-import random
-import threading
+import copy
+import errno
 import functools
-import traceback
-import subprocess  # nosec
-import tempfile
+import json
+import os
 import pickle  # nosec
+import pprint
+import random
 import re
 import shutil
-import xattr
+import signal
+import stat
+import subprocess  # nosec
+import sys
+import tempfile
+import threading
+import time
+import traceback
+import uuid
+from os.path import join
+
 import junit_xml
 import tabulate
+import xattr
 import yaml
 
 
@@ -687,7 +688,7 @@ class DaosServer():
 
             with open(join(self._io_server_dir.name, 'daos_engine'), 'w') as fd:
                 fd.write('#!/bin/sh\n')
-                fd.write(f"export PATH={join(self.conf['PREFIX'],'bin')}:$PATH\n")
+                fd.write(f"export PATH={join(self.conf['PREFIX'], 'bin')}:$PATH\n")
                 fd.write(f'exec valgrind {" ".join(valgrind_args)} daos_engine "$@"\n')
 
             os.chmod(join(self._io_server_dir.name, 'daos_engine'),

--- a/utils/run_utest.py
+++ b/utils/run_utest.py
@@ -6,18 +6,19 @@
 
   Test script for running all DAOS unit tests
 """
+import argparse
+import json
 # pylint: disable=broad-except
 import os
-import sys
-import json
-import argparse
-import shutil
 import re
+import shutil
 import subprocess  # nosec
+import sys
 import tempfile
 import traceback
-from junit_xml import TestSuite, TestCase
+
 import yaml
+from junit_xml import TestCase, TestSuite
 
 
 def check_version():


### PR DESCRIPTION
The unclean part is to keep the following import in general_utils.py for the methods that are needed for the ddb tests.
`from pydaos.raw import IORequest, DaosObjClass`
(The conflict occurred because git didn't know whether to keep this line.)

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: pr
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
