### PR TITLE
DAOS-14557 object: collectively query key

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1137,7 +1137,7 @@ int
 dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti, struct dtx_epoch *epoch,
 		 uint16_t sub_modification_cnt, uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 		 struct dtx_id *dti_cos, int dti_cos_cnt, uint8_t *hints, uint32_t hint_sz,
-		 uint8_t *bitmap, uint32_t bitmap_sz, struct daos_shard_tgt *tgts, int tgt_cnt,
+		 uint8_t *bitmap, uint32_t bitmap_sz, void *tgts, int tgt_cnt,
 		 uint32_t flags, d_rank_list_t *ranks, struct dtx_memberships *mbs,
 		 struct dtx_leader_handle **p_dlh)
 {
@@ -1168,16 +1168,49 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti, struct dtx_epoch *epoch,
 			dlh->dlh_delay_sub_cnt = 0;
 			dlh->dlh_normal_sub_cnt = cnt;
 		} else {
-			for (i = 0; i < cnt; i++) {
-				dlh->dlh_subs[i].dss_tgt = tgts[i];
-				if (unlikely(tgts[i].st_flags & DTF_DELAY_FORWARD))
-					dlh->dlh_delay_sub_cnt++;
-			}
+			if (flags & DTX_TGT_COLL) {
+				for (i = 0; i < cnt; i++) {
+					struct daos_coll_target	*dct;
+					struct daos_shard_tgt	*dst;
+					int			 size;
+					int			 j;
 
-			dlh->dlh_normal_sub_cnt = cnt - dlh->dlh_delay_sub_cnt;
+					dct = (struct daos_coll_target *)tgts + i;
+					dst = &dlh->dlh_subs[i].dss_tgt;
+
+					size = dct->dct_bitmap_sz << 3;
+					if (size > dss_tgt_nr)
+						size = dss_tgt_nr;
+
+					dst->st_rank = dct->dct_rank;
+					for (j = 0; j < size; j++) {
+						if (isset(dct->dct_bitmap, j)) {
+							dst->st_tgt_idx = j;
+							dst->st_shard_id =
+								dct->dct_shards[j].dcs_buf[0];
+							break;
+						}
+					}
+				}
+
+				dlh->dlh_normal_sub_cnt = cnt;
+				dlh->dlh_delay_sub_cnt = 0;
+			} else {
+				struct daos_shard_tgt	*shards = tgts;
+
+				for (i = 0; i < cnt; i++) {
+					dlh->dlh_subs[i].dss_tgt = shards[i];
+					if (unlikely(shards[i].st_flags & DTF_DELAY_FORWARD))
+						dlh->dlh_delay_sub_cnt++;
+				}
+
+				dlh->dlh_normal_sub_cnt = cnt - dlh->dlh_delay_sub_cnt;
+			}
 		}
 	}
 
+	if (flags & DTX_FAKE)
+		dlh->dlh_fake = 1;
 	if (flags & DTX_COLL) {
 		dlh->dlh_coll = 1;
 		dlh->dlh_coll_tree_topo = dtx_coll_tree_topo;
@@ -1269,7 +1302,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 
 	dtx_shares_fini(dth);
 
-	if (daos_is_zero_dti(&dth->dth_xid) || unlikely(result == -DER_ALREADY))
+	if (daos_is_zero_dti(&dth->dth_xid) || unlikely(result == -DER_ALREADY) || dlh->dlh_fake)
 		goto out;
 
 	if (unlikely(coh->sch_closed)) {
@@ -1991,9 +2024,7 @@ dtx_comp_cb(void **arg)
 	uint32_t			 i;
 	uint32_t			 j;
 
-	if (dlh->dlh_agg_cb != NULL) {
-		dlh->dlh_result = dlh->dlh_agg_cb(dlh, dlh->dlh_allow_failure);
-	} else {
+	if (!dlh->dlh_need_agg) {
 		for (i = dlh->dlh_forward_idx, j = 0; j < dlh->dlh_forward_cnt; i++, j++) {
 			sub = &dlh->dlh_subs[i];
 
@@ -2130,16 +2161,15 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	dlh->dlh_normal_sub_done = 0;
 	dlh->dlh_drop_cond = 0;
 	dlh->dlh_forward_idx = 0;
+	dlh->dlh_need_agg = 0;
+	dlh->dlh_agg_done = 0;
 
 	if (sub_cnt > DTX_EXEC_STEP_LENGTH) {
 		dlh->dlh_forward_cnt = DTX_EXEC_STEP_LENGTH;
-		dlh->dlh_agg_cb = NULL;
 	} else {
 		dlh->dlh_forward_cnt = sub_cnt;
-		if (likely(dlh->dlh_delay_sub_cnt == 0))
-			dlh->dlh_agg_cb = agg_cb;
-		else
-			dlh->dlh_agg_cb = NULL;
+		if (likely(dlh->dlh_delay_sub_cnt == 0) && agg_cb != NULL)
+			dlh->dlh_need_agg = 1;
 	}
 
 	if (dlh->dlh_normal_sub_cnt == 0)
@@ -2192,8 +2222,8 @@ exec:
 		dlh->dlh_forward_idx += dlh->dlh_forward_cnt;
 		if (sub_cnt <= DTX_EXEC_STEP_LENGTH) {
 			dlh->dlh_forward_cnt = sub_cnt;
-			if (likely(dlh->dlh_delay_sub_cnt == 0))
-				dlh->dlh_agg_cb = agg_cb;
+			if (likely(dlh->dlh_delay_sub_cnt == 0) && agg_cb != NULL)
+				dlh->dlh_need_agg = 1;
 		}
 
 		D_DEBUG(DB_IO, "More dispatch sub-requests for "DF_DTI", normal %u, "
@@ -2206,17 +2236,24 @@ exec:
 	}
 
 	dlh->dlh_normal_sub_done = 1;
+	dlh->dlh_drop_cond = 1;
+
+	if (agg_cb != NULL) {
+		remote_rc = agg_cb(dlh, func_arg);
+		dlh->dlh_agg_done = 1;
+		if (remote_rc == allow_failure)
+			dlh->dlh_drop_cond = 0;
+		else if (remote_rc != 0)
+			goto out;
+	}
 
 	if (likely(dlh->dlh_delay_sub_cnt == 0))
 		goto out;
 
-	dlh->dlh_drop_cond = 1;
-
-	if (agg_cb != 0 && allow_failure != 0) {
-		rc = agg_cb(dlh, allow_failure);
-		if (rc == allow_failure)
-			dlh->dlh_drop_cond = 0;
-	}
+	/* Need more aggregation for delayed sub-requests. */
+	dlh->dlh_agg_done = 0;
+	if (agg_cb != NULL)
+		dlh->dlh_need_agg = 1;
 
 	D_ASSERT(dlh->dlh_future == ABT_FUTURE_NULL);
 
@@ -2230,7 +2267,6 @@ exec:
 		D_GOTO(out, rc = dss_abterr2der(rc));
 	}
 
-	dlh->dlh_agg_cb = agg_cb;
 	dlh->dlh_forward_idx = 0;
 	/* The ones without DELAY flag will be skipped when scan the targets array. */
 	dlh->dlh_forward_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
@@ -2253,6 +2289,12 @@ exec:
 		allow_failure, local_rc, remote_rc);
 
 out:
+	/* The agg_cb may contain cleanup, let's do it even if hit failure on some former step. */
+	if (agg_cb != NULL && !dlh->dlh_agg_done) {
+		remote_rc = agg_cb(dlh, func_arg);
+		dlh->dlh_agg_done = 1;
+	}
+
 	if (rc == 0 && local_rc == allow_failure &&
 	    (dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt == 0 || remote_rc == allow_failure))
 		rc = allow_failure;

--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -17,9 +17,12 @@
 #include "obj_internal.h"
 
 #define OBJ_COLL_PUNCH_THRESHOLD_MIN	4
+#define OBJ_FWD_QUERY_THRESHOLD_MIN	4
 
 unsigned int	srv_io_mode = DIM_DTX_FULL_ENABLED;
 unsigned int	obj_coll_punch_thd;
+unsigned int	obj_fwd_query_thd;
+unsigned int	obj_fwd_query_cnt;
 int		dc_obj_proto_version;
 
 /**
@@ -80,6 +83,27 @@ dc_obj_init(void)
 		obj_coll_punch_thd = OBJ_COLL_PUNCH_THRESHOLD_MIN;
 	}
 	D_INFO("Set object collective punch threshold as %u\n", obj_coll_punch_thd);
+
+	obj_fwd_query_thd = OBJ_FWD_QUERY_THRESHOLD_MIN;
+	d_getenv_int("OBJ_FWD_QUERY_THRESHOLD", &obj_fwd_query_thd);
+	if (obj_fwd_query_thd < OBJ_FWD_QUERY_THRESHOLD_MIN) {
+		D_WARN("Invalid forward object collective query threshold %u, "
+		       "it cannot be smaller than %u, use the default value %u\n",
+		       obj_fwd_query_thd, OBJ_FWD_QUERY_THRESHOLD_MIN, OBJ_FWD_QUERY_THRESHOLD_MIN);
+		obj_fwd_query_thd = OBJ_FWD_QUERY_THRESHOLD_MIN;
+	}
+	D_INFO("Set threshold for forwarding object collective query as %u\n", obj_fwd_query_thd);
+
+	obj_fwd_query_cnt = obj_fwd_query_thd;
+	d_getenv_int("OBJ_FWD_QUERY_COUNT", &obj_fwd_query_cnt);
+	if (obj_fwd_query_cnt < 1 || obj_fwd_query_cnt > obj_fwd_query_thd) {
+		D_WARN("Invalid count %u for forwarding object collective query RPC, it should be "
+		       "at least 1, but cannot exceed the threshold for triggering forwarding RPC "
+		       "(%d by default), use the default value %u\n",
+		       obj_fwd_query_cnt, OBJ_FWD_QUERY_THRESHOLD_MIN, obj_fwd_query_thd);
+		obj_fwd_query_cnt = obj_fwd_query_thd;
+	}
+	D_INFO("Set count for forwarding object collective query RPC as %u\n", obj_fwd_query_cnt);
 
 	tx_verify_rdg = false;
 	d_getenv_bool("DAOS_TX_VERIFY_RDG", &tx_verify_rdg);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2338,6 +2338,18 @@ check_query_flags(daos_obj_id_t oid, uint32_t flags, daos_key_t *dkey,
 	return 0;
 }
 
+static inline void
+obj_coll_query_cleanup(tse_task_t *task)
+{
+	struct shard_query_key_args	*args = dc_task_get_args(task);
+
+	daos_coll_target_cleanup(args->kqa_dcts,
+				 args->kqa_dct_nr < 0 ? args->kqa_dct_cap : args->kqa_dct_nr);
+	args->kqa_dcts = NULL;
+	args->kqa_dct_cap = 0;
+	args->kqa_dct_nr = 0;
+}
+
 static inline bool
 obj_key_valid(daos_obj_id_t oid, daos_key_t *key, bool check_dkey)
 {
@@ -2835,6 +2847,7 @@ obj_embedded_shard_arg(struct obj_auxi_args *obj_auxi)
 		return &obj_auxi->s_args.sa_auxi;
 	case DAOS_OBJ_RPC_QUERY_KEY:
 	case DAOS_OBJ_RPC_COLL_PUNCH:
+	case DAOS_OBJ_RPC_COLL_QUERY:
 		/*
 		 * called from obj_comp_cb_internal() and
 		 * checked in obj_shard_comp_cb() correctly
@@ -4824,6 +4837,9 @@ obj_comp_cb(tse_task_t *task, void *data)
 		}
 	}
 
+	if (obj_auxi->opc == DAOS_OBJ_RPC_COLL_QUERY)
+		obj_coll_query_cleanup(task);
+
 	if (!io_task_reinited) {
 		d_list_t *head = &obj_auxi->shard_task_head;
 
@@ -4867,6 +4883,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 			D_ASSERT(daos_handle_is_inval(obj_auxi->th));
 			break;
 		case DAOS_OBJ_RPC_QUERY_KEY:
+		case DAOS_OBJ_RPC_COLL_QUERY:
 		case DAOS_OBJ_RECX_RPC_ENUMERATE:
 		case DAOS_OBJ_AKEY_RPC_ENUMERATE:
 		case DAOS_OBJ_DKEY_RPC_ENUMERATE:
@@ -6858,19 +6875,12 @@ dc_obj_punch_akeys_task(tse_task_t *task)
 	return obj_punch_common(task, DAOS_OBJ_RPC_PUNCH_AKEYS, args);
 }
 
-struct shard_query_key_args {
-	/* shard_auxi_args must be the first for shard_task_sched(). */
-	struct shard_auxi_args	 kqa_auxi;
-	uuid_t			 kqa_coh_uuid;
-	uuid_t			 kqa_cont_uuid;
-	struct dtx_id		 kqa_dti;
-};
-
 static int
 shard_query_key_task(tse_task_t *task)
 {
 	struct shard_query_key_args	*args;
 	daos_obj_query_key_t		*api_args;
+	struct obj_auxi_args		*obj_auxi;
 	struct dc_object		*obj;
 	struct dc_obj_shard		*obj_shard;
 	daos_handle_t			 th;
@@ -6878,8 +6888,9 @@ shard_query_key_task(tse_task_t *task)
 	int				 rc;
 
 	args = tse_task_buf_embedded(task, sizeof(*args));
-	obj = args->kqa_auxi.obj_auxi->obj;
-	th = args->kqa_auxi.obj_auxi->th;
+	obj_auxi = args->kqa_auxi.obj_auxi;
+	obj = obj_auxi->obj;
+	th = obj_auxi->th;
 	epoch = &args->kqa_auxi.epoch;
 
 	/* See the similar shard_io_task. */
@@ -6893,6 +6904,15 @@ shard_query_key_task(tse_task_t *task)
 		if (rc == DC_TX_GE_REINITED)
 			return 0;
 	}
+
+	api_args = dc_task_get_args(obj_auxi->obj_task);
+	if (args->kqa_dcts != NULL)
+		return dc_obj_shard_coll_query(epoch, api_args->flags, obj_auxi->map_ver_req, obj,
+					       api_args->dkey, api_args->akey, api_args->recx,
+					       api_args->max_epoch, args->kqa_coh_uuid,
+					       args->kqa_cont_uuid, &args->kqa_dti,
+					       &obj_auxi->map_ver_reply, args->kqa_dcts,
+					       args->kqa_dct_nr, th, task);
 
 	rc = obj_shard_open(obj, args->kqa_auxi.shard, args->kqa_auxi.map_ver, &obj_shard);
 	if (rc != 0) {
@@ -6911,13 +6931,10 @@ shard_query_key_task(tse_task_t *task)
 		return rc;
 	}
 
-	api_args = dc_task_get_args(args->kqa_auxi.obj_auxi->obj_task);
-	rc = dc_obj_shard_query_key(obj_shard, epoch, api_args->flags,
-				    args->kqa_auxi.obj_auxi->map_ver_req, obj,
-				    api_args->dkey, api_args->akey,
-				    api_args->recx, api_args->max_epoch, args->kqa_coh_uuid,
-				    args->kqa_cont_uuid, &args->kqa_dti,
-				    &args->kqa_auxi.obj_auxi->map_ver_reply, th, task);
+	rc = dc_obj_shard_query_key(obj_shard, epoch, api_args->flags, obj_auxi->map_ver_req, obj,
+				    api_args->dkey, api_args->akey, api_args->recx,
+				    api_args->max_epoch, args->kqa_coh_uuid, args->kqa_cont_uuid,
+				    &args->kqa_dti, &obj_auxi->map_ver_reply, th, task);
 
 	return rc;
 }
@@ -6926,7 +6943,8 @@ static int
 queue_shard_query_key_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi,
 			   struct dtx_epoch *epoch, int shard, unsigned int map_ver,
 			   struct dc_object *obj, struct dtx_id *dti,
-			   uuid_t coh_uuid, uuid_t cont_uuid)
+			   uuid_t coh_uuid, uuid_t cont_uuid,
+			   struct daos_coll_target *dcts, uint32_t dct_nr)
 {
 	tse_sched_t			*sched = tse_task2sched(api_task);
 	tse_task_t			*task;
@@ -6940,17 +6958,20 @@ queue_shard_query_key_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi,
 
 	args = tse_task_buf_embedded(task, sizeof(*args));
 	args->kqa_auxi.epoch	= *epoch;
-	args->kqa_auxi.shard	= shard;
 	args->kqa_auxi.map_ver	= map_ver;
 	args->kqa_auxi.obj_auxi	= obj_auxi;
 	args->kqa_dti		= *dti;
 	uuid_copy(args->kqa_coh_uuid, coh_uuid);
 	uuid_copy(args->kqa_cont_uuid, cont_uuid);
+	args->kqa_dcts = dcts;
+	args->kqa_dct_nr = dct_nr;
 
-	rc = obj_shard2tgtid(obj, shard, map_ver,
-			     &args->kqa_auxi.target);
-	if (rc != 0)
-		D_GOTO(out_task, rc);
+	if (dcts == NULL) {
+		args->kqa_auxi.shard = shard;
+		rc = obj_shard2tgtid(obj, shard, map_ver, &args->kqa_auxi.target);
+		if (rc != 0)
+			D_GOTO(out_task, rc);
+	}
 
 	rc = tse_task_register_deps(api_task, 1, &task);
 	if (rc != 0)
@@ -6967,6 +6988,202 @@ out_task:
 	return rc;
 }
 
+static int
+obj_coll_query_prep_one(tse_task_t *api_task, struct dc_object *obj, uint32_t map_ver, uint32_t idx)
+{
+	struct shard_query_key_args	*args = dc_task_get_args(api_task);
+	struct dc_obj_shard		*shard = NULL;
+	struct daos_coll_target		*dct;
+	struct daos_coll_shard		*dcs;
+	uint32_t			*tmp;
+	uint8_t				*new_bm;
+	int				 size;
+	int				 rc = 0;
+
+	rc = obj_shard_open(obj, idx, map_ver, &shard);
+	if (rc == -DER_NONEXIST)
+		D_GOTO(out, rc = 0);
+
+	if (rc != 0 || shard->do_rebuilding)
+		goto out;
+
+	dct = &args->kqa_dcts[shard->do_target_rank];
+	dct->dct_rank = shard->do_target_rank;
+
+	if (shard->do_target_idx >= dct->dct_bitmap_sz << 3) {
+		size = (shard->do_target_idx >> 3) + 1;
+
+		D_REALLOC_ARRAY(dcs, dct->dct_shards, dct->dct_bitmap_sz << 3, size << 3);
+		if (dcs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		dct->dct_shards = dcs;
+
+		D_REALLOC_ARRAY(new_bm, dct->dct_bitmap, dct->dct_bitmap_sz, size);
+		if (new_bm == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		dct->dct_bitmap = new_bm;
+		dct->dct_bitmap_sz = size;
+	}
+
+	dcs = &dct->dct_shards[shard->do_target_idx];
+
+	if (unlikely(isset(dct->dct_bitmap, shard->do_target_idx))) {
+		/* More than one shards reside on the same VOS target. */
+		D_ASSERT(dcs->dcs_nr >= 1);
+
+		if (dcs->dcs_nr >= dcs->dcs_cap) {
+			D_ALLOC_ARRAY(tmp, dcs->dcs_nr << 1);
+			if (tmp == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			memcpy(tmp, dcs->dcs_buf, sizeof(*tmp) * dcs->dcs_nr);
+			if (dcs->dcs_buf != &dcs->dcs_inline)
+				D_FREE(dcs->dcs_buf);
+			dcs->dcs_buf = tmp;
+			dcs->dcs_cap = dcs->dcs_nr << 1;
+		}
+	} else {
+		D_ASSERT(dcs->dcs_nr == 0);
+
+		dcs->dcs_buf = &dcs->dcs_inline;
+		setbit(dct->dct_bitmap, shard->do_target_idx);
+		dct->dct_shard_nr++;
+	}
+
+	dcs->dcs_buf[dcs->dcs_nr++] = shard->do_id.id_shard;
+
+out:
+	if (shard != NULL)
+		obj_shard_close(shard);
+
+	return rc;
+}
+
+static int
+obj_coll_query_prep(tse_task_t *api_task, struct dc_object *obj)
+{
+	struct shard_query_key_args	*args = dc_task_get_args(api_task);
+	struct dc_pool			*pool = obj->cob_pool;
+	uint32_t			 node_nr;
+	int				 rc = 0;
+
+	D_ASSERT(pool != NULL);
+
+	D_RWLOCK_RDLOCK(&pool->dp_map_lock);
+	node_nr = pool_map_node_nr(pool->dp_map);
+	D_RWLOCK_UNLOCK(&pool->dp_map_lock);
+
+	D_ALLOC_ARRAY(args->kqa_dcts, node_nr);
+	if (args->kqa_dcts == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	/*
+	 * Set kqa_dct_nr as -1 to indicate that the kqa_dcts array may be sparse until
+	 * queue_coll_query_task() is done. That is useful when obj_coll_query_cleanup.
+	 */
+	args->kqa_dct_nr = -1;
+	args->kqa_dct_cap = node_nr;
+
+out:
+	return rc;
+}
+
+static int
+queue_coll_query_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi, struct dc_object *obj,
+		      struct dtx_id *xid, struct dtx_epoch *epoch, uint32_t map_ver)
+{
+	struct shard_query_key_args	*args = dc_task_get_args(api_task);
+	struct dc_cont			*cont = obj->cob_co;
+	struct daos_coll_target		*dct;
+	struct daos_coll_target		 tmp;
+	int				 rc = 0;
+	int				 len;
+	int				 pos;
+	int				 i;
+
+	D_ASSERT(args->kqa_dcts != NULL);
+
+	for (i = 0, args->kqa_dct_nr = 0; i < args->kqa_dct_cap; i++) {
+		dct = &args->kqa_dcts[i];
+		if (dct->dct_bitmap != NULL) {
+			if (args->kqa_dct_nr < i)
+				memcpy(&args->kqa_dcts[args->kqa_dct_nr], dct, sizeof(*dct));
+			args->kqa_dct_nr++;
+		}
+	}
+
+	/* If all shards are NONEXIST, then need not send query RPC(s). */
+	if (unlikely(args->kqa_dct_nr == 0))
+		D_GOTO(out, rc = 1);
+
+	/* Reset the other dct slots to avoid double free during cleanup. */
+	if (args->kqa_dct_cap > args->kqa_dct_nr)
+		memset(&args->kqa_dcts[args->kqa_dct_nr], 0,
+		       sizeof(*dct) * (args->kqa_dct_cap - args->kqa_dct_nr));
+
+	for (i = 0; i < args->kqa_dct_nr; i += len) {
+		/*
+		 * As long as the left engines exceeds obj_fwd_query_thd, then ask next engine to
+		 * help forward to some other engines. If the left ones is less than the threshold,
+		 * then in spite of how many RPCs have ever been sent by the client, the left ones
+		 * will be sent by the client itself, because waiting on the client is better than
+		 * on servers. Means that obj_fwd_query_cnt is not larger than obj_fwd_query_thd.
+		 *
+		 * Small obj_fwd_query_cnt will distribute the load of forwarding object collective
+		 * query RPC among more engines, seems more balanaced. But smaller obj_fwd_query_cnt
+		 * also means client will send more RPCs by itself, it may decrease the whole query
+		 * efficiency. So need some compromise consideration.
+		 *
+		 * On server side, the engine may only need to query single shard, or collectively
+		 * query multiple shards and forward the collective query RPC to the other engines
+		 * if required. Currently, CaRT does not support to broadcast different content to
+		 * different targets, the relay engine needs to forward related query RPC to others
+		 * one by one. On the other hand, multiple level broadcast RPC will cause additional
+		 * RPC round-trips, from application's perspective, the query latency is increased.
+		 * That is not expected, especially under interaction mode.
+		 *
+		 * If obj_fwd_query_thd exceeds the args->kqa_dct_nr, then disable the functionality
+		 * of engine forwarding object collective query RPCs.
+		 *
+		 * It is not suggested to use too small obj_fwd_query_thd, that will cause more RPC
+		 * load to be moved from client to server.
+		 */
+		if (args->kqa_dct_nr - i > obj_fwd_query_thd) {
+			/*
+			 * The left obj_fwd_query_thd RPCs will be sent by the client itself.
+			 * "+1" is for the RPC to the relay engine.
+			 */
+			len = args->kqa_dct_nr - i - obj_fwd_query_thd + 1;
+			if (len > obj_fwd_query_cnt + 1)
+				len = obj_fwd_query_cnt + 1;
+
+			/*
+			 * Randomly (avoid load imbalance) choose an engine for helping forward
+			 * the collective query RPC to other engines.
+			 */
+			pos = d_rand() % (args->kqa_dct_nr - i)  + i;
+			if (pos != i) {
+				memcpy(&tmp, &args->kqa_dcts[i], sizeof(tmp));
+				memcpy(&args->kqa_dcts[i], &args->kqa_dcts[pos], sizeof(tmp));
+				memcpy(&args->kqa_dcts[pos], &tmp, sizeof(tmp));
+			}
+		} else {
+			len = 1;
+		}
+
+		rc = queue_shard_query_key_task(api_task, obj_auxi, epoch, 0 /* shard, useless */,
+						map_ver, obj, xid, cont->dc_cont_hdl, cont->dc_uuid,
+						&args->kqa_dcts[i], len);
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	return rc;
+}
+
 int
 dc_obj_query_key(tse_task_t *api_task)
 {
@@ -6974,8 +7191,9 @@ dc_obj_query_key(tse_task_t *api_task)
 	struct obj_auxi_args	*obj_auxi;
 	struct dc_object	*obj;
 	d_list_t		*head = NULL;
-	uuid_t			coh_uuid;
-	uuid_t			cont_uuid;
+	uuid_t			co_hdl;
+	uuid_t			co_uuid;
+	uint32_t		grp_size;
 	int			grp_idx;
 	uint32_t		grp_nr;
 	unsigned int		map_ver = 0;
@@ -6983,6 +7201,7 @@ dc_obj_query_key(tse_task_t *api_task)
 	struct dtx_id		dti;
 	int			i = 0;
 	int			rc;
+	bool			coll = false;
 
 	D_ASSERTF(api_args != NULL,
 		  "Task Argument OPC does not match DC OPC\n");
@@ -7015,7 +7234,7 @@ dc_obj_query_key(tse_task_t *api_task)
 	obj_auxi->spec_shard = 0;
 	obj_auxi->spec_group = 0;
 
-	rc = dc_cont2uuid(obj->cob_co, &coh_uuid, &cont_uuid);
+	rc = dc_cont2uuid(obj->cob_co, &co_hdl, &co_uuid);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 
@@ -7064,13 +7283,25 @@ dc_obj_query_key(tse_task_t *api_task)
 	D_ASSERT(!obj_auxi->args_initialized);
 	D_ASSERT(d_list_empty(head));
 
+	/* Some optimization for get dkey since 2.6 */
+	if (api_args->flags & DAOS_GET_DKEY && grp_nr > 1 && dc_obj_proto_version > 9) {
+		rc = obj_coll_query_prep(api_task, obj);
+		if (rc != 0)
+			goto out_task;
+
+		obj_auxi->opc = DAOS_OBJ_RPC_COLL_QUERY;
+		coll = true;
+	}
+
+	grp_size = daos_oclass_grp_size(&obj->cob_oca);
+
 	for (i = grp_idx; i < grp_idx + grp_nr; i++) {
 		int start_shard;
 		int j;
 		int shard_cnt = 0;
 
 		/* Try leader for current group */
-		if (!obj_is_ec(obj) || (obj_is_ec(obj) && !obj_ec_parity_rotate_enabled(obj))) {
+		if (!obj_is_ec(obj) || !obj_ec_parity_rotate_enabled(obj)) {
 			int leader;
 
 			leader = obj_grp_leader_get(obj, i, (uint64_t)d_rand(),
@@ -7080,10 +7311,14 @@ dc_obj_query_key(tse_task_t *api_task)
 				    !is_ec_parity_shard(obj, obj_auxi->dkey_hash, leader))
 					goto non_leader;
 
-				rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, leader,
-								map_ver, obj, &dti, coh_uuid,
-								cont_uuid);
-				if (rc)
+				if (coll)
+					rc = obj_coll_query_prep_one(api_task, obj,
+								     map_ver, leader);
+				else
+					rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch,
+									leader, map_ver, obj, &dti,
+									co_hdl, co_uuid, NULL, 0);
+				if (rc != 0)
 					D_GOTO(out_task, rc);
 
 				D_DEBUG(DB_IO, DF_OID" try leader %d for group %d.\n",
@@ -7103,12 +7338,17 @@ non_leader:
 		start_shard = i * obj_get_grp_size(obj);
 		D_DEBUG(DB_IO, DF_OID" EC needs to try all shards for group %d.\n",
 			DP_OID(obj->cob_md.omd_id), i);
-		for (j = start_shard; j < start_shard + daos_oclass_grp_size(&obj->cob_oca); j++) {
+		for (j = start_shard; j < start_shard + grp_size; j++) {
 			if (obj_shard_is_invalid(obj, j, DAOS_OBJ_RPC_QUERY_KEY))
 				continue;
-			rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, j, map_ver,
-							obj, &dti, coh_uuid, cont_uuid);
-			if (rc)
+
+			if (coll)
+				rc = obj_coll_query_prep_one(api_task, obj, map_ver, j);
+			else
+				rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, j,
+								map_ver, obj, &dti, co_hdl, co_uuid,
+								NULL, 0);
+			if (rc != 0)
 				D_GOTO(out_task, rc);
 
 			if (++shard_cnt >= obj_ec_data_tgt_nr(&obj->cob_oca))
@@ -7122,6 +7362,12 @@ non_leader:
 		}
 	}
 
+	if (coll) {
+		rc = queue_coll_query_task(api_task, obj_auxi, obj, &dti, &epoch, map_ver);
+		if (rc != 0)
+			goto out_task;
+	}
+
 	obj_auxi->args_initialized = 1;
 	obj_shard_task_sched(obj_auxi, &epoch);
 
@@ -7133,6 +7379,8 @@ out_task:
 		/* abort/complete sub-tasks will complete api_task */
 		tse_task_list_traverse(head, shard_task_abort, &rc);
 	} else {
+		if (rc > 0)
+			rc = 0;
 		obj_task_complete(api_task, rc);
 	}
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1881,96 +1881,29 @@ out_put:
 struct obj_query_key_cb_args {
 	crt_rpc_t		*rpc;
 	unsigned int		*map_ver;
-	daos_unit_oid_t		oid;
 	daos_key_t		*dkey;
 	daos_key_t		*akey;
 	daos_recx_t		*recx;
 	daos_epoch_t		*max_epoch;
 	struct dc_object	*obj;
-	struct dc_obj_shard	*shard;
 	struct dtx_epoch	epoch;
 	daos_handle_t		th;
 };
 
-static void
-obj_shard_query_recx_post(struct obj_query_key_cb_args *cb_args, uint32_t shard, daos_key_t *dkey,
-			  daos_recx_t *reply_recx, bool get_max, bool changed)
-{
-	daos_recx_t		*result_recx = cb_args->recx;
-	daos_recx_t		 tmp_recx = {0};
-	uint64_t		 tmp_end;
-	uint32_t		 tgt_off;
-	bool			 from_data_tgt;
-	struct daos_oclass_attr	*oca;
-	uint64_t		dkey_hash;
-	uint64_t		 stripe_rec_nr, cell_rec_nr;
-
-	oca = obj_get_oca(cb_args->obj);
-	if (oca == NULL || !daos_oclass_is_ec(oca)) {
-		*result_recx = *reply_recx;
-		return;
-	}
-
-	dkey_hash = obj_dkey2hash(cb_args->obj->cob_md.omd_id, dkey);
-	tgt_off = obj_ec_shard_off(cb_args->obj, dkey_hash, shard);
-	from_data_tgt = is_ec_data_shard_by_tgt_off(tgt_off, oca);
-	stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
-	cell_rec_nr = obj_ec_cell_rec_nr(oca);
-	D_ASSERT(!(reply_recx->rx_idx & PARITY_INDICATOR));
-	/* data ext from data shard needs to convert to daos ext,
-	 * replica ext from parity shard needs not to convert.
-	 */
-	tmp_recx = *reply_recx;
-	tmp_end = DAOS_RECX_END(tmp_recx);
-	D_DEBUG(DB_IO, "shard %d/%u get recx "DF_U64" "DF_U64"\n",
-		shard, tgt_off, tmp_recx.rx_idx, tmp_recx.rx_nr);
-	if (tmp_end > 0 && from_data_tgt) {
-		if (get_max) {
-			tmp_recx.rx_idx = max(tmp_recx.rx_idx, rounddown(tmp_end - 1, cell_rec_nr));
-			tmp_recx.rx_nr = tmp_end - tmp_recx.rx_idx;
-		} else {
-			tmp_recx.rx_nr = min(tmp_end, roundup(tmp_recx.rx_idx + 1, cell_rec_nr)) -
-					 tmp_recx.rx_idx;
-		}
-
-		tmp_recx.rx_idx = obj_ec_idx_vos2daos(tmp_recx.rx_idx, stripe_rec_nr,
-							      cell_rec_nr, tgt_off);
-		tmp_end = DAOS_RECX_END(tmp_recx);
-	}
-
-	if (get_max) {
-		if (DAOS_RECX_END(*result_recx) < tmp_end || changed)
-			*result_recx = tmp_recx;
-	} else {
-		if (DAOS_RECX_END(*result_recx) > tmp_end || changed)
-			*result_recx = tmp_recx;
-	}
-}
-
 static int
 obj_shard_query_key_cb(tse_task_t *task, void *data)
 {
-	struct obj_query_key_cb_args	*cb_args;
-	struct obj_query_key_in		*okqi;
+	struct obj_query_key_cb_args	*cb_args = data;
+	crt_rpc_t			*rpc = cb_args->rpc;
+	struct obj_query_key_in		*okqi = crt_req_get(cb_args->rpc);
 	struct obj_query_key_out	*okqo;
-	uint32_t			flags;
-	int				opc;
-	int				ret = task->dt_result;
-	int				rc = 0;
-	crt_rpc_t			*rpc;
+	struct obj_query_merge_args	 oqma = { 0 };
+	int				 rc = task->dt_result;
+	int				 rc1;
 
-	cb_args = (struct obj_query_key_cb_args *)data;
-	rpc = cb_args->rpc;
-
-	okqi = crt_req_get(cb_args->rpc);
-	D_ASSERT(okqi != NULL);
-
-	flags = okqi->okqi_api_flags;
-	opc = opc_get(cb_args->rpc->cr_opc);
-
-	if (ret != 0) {
-		D_ERROR("RPC %d failed, "DF_RC"\n", opc, DP_RC(ret));
-		D_GOTO(out, ret);
+	if (rc != 0) {
+		D_ERROR("Regular query failed: "DF_RC"\n", DP_RC(rc));
+		goto out;
 	}
 
 	okqo = crt_reply_get(cb_args->rpc);
@@ -1978,119 +1911,38 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 
 	/* See the similar dc_rw_cb. */
 	if (daos_handle_is_valid(cb_args->th)) {
-		int rc_tmp;
-
-		rc_tmp = dc_tx_op_end(task, cb_args->th, &cb_args->epoch, rc,
-				      okqo->okqo_epoch);
-		if (rc_tmp != 0) {
-			D_ERROR("failed to end transaction operation (rc=%d "
-				"epoch="DF_U64": "DF_RC"\n", rc,
-				okqo->okqo_epoch, DP_RC(rc_tmp));
-			goto out;
+		rc1 = dc_tx_op_end(task, cb_args->th, &cb_args->epoch, rc, okqo->okqo_epoch);
+		if (rc1 != 0) {
+			D_ERROR("Failed to end TX (rc=%d, epoch="DF_U64", opc = %u): "DF_RC"\n",
+				rc, okqo->okqo_epoch, DAOS_OBJ_RPC_QUERY_KEY, DP_RC(rc1));
+			D_GOTO(out, rc = (rc != 0 ? rc : rc1));
 		}
 	}
 
-	if (rc != 0) {
-		if (rc == -DER_NONEXIST) {
-			D_SPIN_LOCK(&cb_args->obj->cob_spin);
-			D_GOTO(set_max_epoch, rc = 0);
-		}
-
-		if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY)
-			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: %d\n",
-				cb_args->rpc, opc, rc);
-		else
-			D_ERROR("rpc %p RPC %d failed: %d\n",
-				cb_args->rpc, opc, rc);
-		D_GOTO(out, rc);
-	}
+	oqma.oca = &cb_args->obj->cob_oca;
+	oqma.oid = okqi->okqi_oid;
+	oqma.src_epoch = okqo->okqo_max_epoch;
+	oqma.in_dkey = &okqi->okqi_dkey;
+	oqma.src_dkey = &okqo->okqo_dkey;
+	oqma.tgt_dkey = cb_args->dkey;
+	oqma.src_akey = &okqo->okqo_akey;
+	oqma.tgt_akey = cb_args->akey;
+	oqma.src_recx = &okqo->okqo_recx;
+	oqma.tgt_recx = cb_args->recx;
+	oqma.tgt_epoch = cb_args->max_epoch;
+	oqma.tgt_map_ver = cb_args->map_ver;
+	oqma.flags = okqi->okqi_api_flags;
+	oqma.opc = DAOS_OBJ_RPC_QUERY_KEY;
+	oqma.src_map_ver = obj_reply_map_version_get(rpc);
+	oqma.ret = rc;
 
 	D_SPIN_LOCK(&cb_args->obj->cob_spin);
-	*cb_args->map_ver = obj_reply_map_version_get(rpc);
-
-	if (flags == 0)
-		goto set_max_epoch;
-
-	bool check = true;
-	bool changed = false;
-	bool first = (cb_args->dkey->iov_len == 0);
-	bool is_ec_obj = obj_is_ec(cb_args->obj);
-
-	if (flags & DAOS_GET_DKEY) {
-		uint64_t *val = (uint64_t *)okqo->okqo_dkey.iov_buf;
-		uint64_t *cur = (uint64_t *)cb_args->dkey->iov_buf;
-
-		if (okqo->okqo_dkey.iov_len != sizeof(uint64_t)) {
-			D_ERROR("Invalid Dkey obtained\n");
-			D_SPIN_UNLOCK(&cb_args->obj->cob_spin);
-			D_GOTO(out, rc = -DER_IO);
-		}
-
-		/** for first cb, just set the dkey */
-		if (first) {
-			*cur = *val;
-			cb_args->dkey->iov_len = okqo->okqo_dkey.iov_len;
-			changed = true;
-		} else if (flags & DAOS_GET_MAX) {
-			if (*val > *cur) {
-				D_DEBUG(DB_IO, "dkey update "DF_U64"->"
-					DF_U64"\n", *cur, *val);
-				*cur = *val;
-				/** set to change akey and recx */
-				changed = true;
-			} else {
-				/** no change, don't check akey and recx for
-				 * replica obj, for EC obj need to check again
-				 * as it possibly from different data shards.
-				 */
-				if (!is_ec_obj || *val < *cur)
-					check = false;
-			}
-		} else if (flags & DAOS_GET_MIN) {
-			if (*val < *cur) {
-				*cur = *val;
-				/** set to change akey and recx */
-				changed = true;
-			} else {
-				if (!is_ec_obj)
-					check = false;
-			}
-		} else {
-			D_ASSERT(0);
-		}
-	}
-
-	if (check && flags & DAOS_GET_AKEY) {
-		uint64_t *val = (uint64_t *)okqo->okqo_akey.iov_buf;
-		uint64_t *cur = (uint64_t *)cb_args->akey->iov_buf;
-
-		/** if first cb, or dkey changed, set akey */
-		if (first || changed)
-			*cur = *val;
-	}
-
-	if (check && flags & DAOS_GET_RECX) {
-		bool		 get_max = (okqi->okqi_api_flags & DAOS_GET_MAX);
-		daos_key_t	*dkey;
-
-		if (okqi->okqi_api_flags & DAOS_GET_DKEY)
-			dkey = &okqo->okqo_dkey;
-		else
-			dkey = &okqi->okqi_dkey;
-		obj_shard_query_recx_post(cb_args, okqi->okqi_oid.id_shard,
-					  dkey, &okqo->okqo_recx, get_max, changed);
-	}
-
-set_max_epoch:
-	if (cb_args->max_epoch && *cb_args->max_epoch < okqo->okqo_max_epoch)
-		*cb_args->max_epoch = okqo->okqo_max_epoch;
+	rc = daos_obj_merge_query_merge(&oqma);
 	D_SPIN_UNLOCK(&cb_args->obj->cob_spin);
 
 out:
 	crt_req_decref(rpc);
-	if (ret == 0 || obj_retry_error(rc))
-		ret = rc;
-	return ret;
+	return rc;
 }
 
 int
@@ -2100,19 +1952,15 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 		       daos_epoch_t *max_epoch, const uuid_t coh_uuid, const uuid_t cont_uuid,
 		       struct dtx_id *dti, uint32_t *map_ver, daos_handle_t th, tse_task_t *task)
 {
-	struct dc_pool			*pool = NULL;
+	struct dc_pool			*pool = obj_shard_ptr2pool(shard);
 	struct obj_query_key_in		*okqi;
 	crt_rpc_t			*req;
-	struct obj_query_key_cb_args	 cb_args;
-	daos_unit_oid_t			 oid;
+	struct obj_query_key_cb_args	 cb_args = { 0 };
 	crt_endpoint_t			 tgt_ep;
 	int				 rc;
 
-	pool = obj_shard_ptr2pool(shard);
-	if (pool == NULL)
-		D_GOTO(out, rc = -DER_NO_HDL);
+	D_ASSERT(pool != NULL);
 
-	oid = shard->do_id;
 	tgt_ep.ep_grp	= pool->dp_sys->sy_group;
 	tgt_ep.ep_tag	= shard->do_target_idx;
 	tgt_ep.ep_rank = shard->do_target_rank;
@@ -2128,12 +1976,10 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 	crt_req_addref(req);
 	cb_args.rpc		= req;
 	cb_args.map_ver		= map_ver;
-	cb_args.oid		= shard->do_id;
 	cb_args.dkey		= dkey;
 	cb_args.akey		= akey;
 	cb_args.recx		= recx;
 	cb_args.obj		= obj;
-	cb_args.shard		= shard;
 	cb_args.epoch		= *epoch;
 	cb_args.th		= th;
 	cb_args.max_epoch	= max_epoch;
@@ -2149,7 +1995,7 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 	okqi->okqi_epoch		= epoch->oe_value;
 	okqi->okqi_epoch_first		= epoch->oe_first;
 	okqi->okqi_api_flags		= flags;
-	okqi->okqi_oid			= oid;
+	okqi->okqi_oid			= shard->do_id;
 	d_iov_set(&okqi->okqi_dkey, NULL, 0);
 	d_iov_set(&okqi->okqi_akey, NULL, 0);
 	if (dkey != NULL && !(flags & DAOS_GET_DKEY))
@@ -2165,8 +2011,168 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 	uuid_copy(okqi->okqi_co_uuid, cont_uuid);
 	daos_dti_copy(&okqi->okqi_dti, dti);
 
-	rc = daos_rpc_send(req, task);
+	return daos_rpc_send(req, task);
+
+out_req:
+	crt_req_decref(req);
+	crt_req_decref(req);
+out:
+	tse_task_complete(task, rc);
 	return rc;
+}
+
+static int
+obj_shard_coll_query_cb(tse_task_t *task, void *data)
+{
+	struct obj_query_key_cb_args	*cb_args = data;
+	crt_rpc_t			*rpc = cb_args->rpc;
+	struct obj_coll_query_in	*ocqi = crt_req_get(cb_args->rpc);
+	struct obj_coll_query_out	*ocqo;
+	struct obj_query_merge_args	 oqma = { 0 };
+	int				 rc = task->dt_result;
+	int				 rc1;
+
+	if (rc != 0) {
+		D_ERROR("Collective query failed: "DF_RC"\n", DP_RC(rc));
+		goto out;
+	}
+
+	ocqo = crt_reply_get(cb_args->rpc);
+	rc = obj_reply_get_status(rpc);
+
+	if (daos_handle_is_valid(cb_args->th)) {
+		rc1 = dc_tx_op_end(task, cb_args->th, &cb_args->epoch, rc, ocqo->ocqo_epoch);
+		if (rc1 != 0) {
+			D_ERROR("Failed to end TX (rc=%d, epoch="DF_U64", opc = %u): "DF_RC"\n",
+				rc, ocqo->ocqo_epoch, DAOS_OBJ_RPC_COLL_QUERY, DP_RC(rc1));
+			D_GOTO(out, rc = (rc != 0 ? rc : rc1));
+		}
+	}
+
+	oqma.oca = &cb_args->obj->cob_oca;
+	oqma.oid = ocqi->ocqi_oid;
+	oqma.src_epoch = ocqo->ocqo_max_epoch;
+	oqma.in_dkey = &ocqi->ocqi_dkey;
+	oqma.src_dkey = &ocqo->ocqo_dkey;
+	oqma.tgt_dkey = cb_args->dkey;
+	oqma.src_akey = &ocqo->ocqo_akey;
+	oqma.tgt_akey = cb_args->akey;
+	oqma.src_recx = &ocqo->ocqo_recx;
+	oqma.tgt_recx = cb_args->recx;
+	oqma.tgt_epoch = cb_args->max_epoch;
+	oqma.tgt_map_ver = cb_args->map_ver;
+	oqma.flags = ocqi->ocqi_api_flags;
+	oqma.opc = DAOS_OBJ_RPC_COLL_QUERY;
+	oqma.src_map_ver = obj_reply_map_version_get(rpc);
+	oqma.ret = rc;
+
+	/*
+	 * The RPC reply may be aggregated results from multiple VOS targets, as to related max/min
+	 * dkey/recx are not from the direct target. The ocqo->ocqo_shard indicates the right one.
+	 */
+	oqma.oid.id_shard = ocqo->ocqo_shard;
+
+	D_SPIN_LOCK(&cb_args->obj->cob_spin);
+	/*
+	 * Merge (L4) the results from engine that may be single shard or aggregated results from
+	 * multuple shards from single or multiple engines.
+	 */
+	rc = daos_obj_merge_query_merge(&oqma);
+	D_SPIN_UNLOCK(&cb_args->obj->cob_spin);
+
+out:
+	crt_req_decref(rpc);
+	return rc;
+}
+
+int
+dc_obj_shard_coll_query(struct dtx_epoch *epoch, uint32_t flags, uint32_t req_map_ver,
+			struct dc_object *obj, daos_key_t *dkey, daos_key_t *akey,
+			daos_recx_t *recx, daos_epoch_t *max_epoch, const uuid_t coh_uuid,
+			const uuid_t cont_uuid, struct dtx_id *dti, uint32_t *map_ver,
+			struct daos_coll_target *dcts, uint32_t dct_nr, daos_handle_t th,
+			tse_task_t *task)
+{
+	struct dc_pool			*pool = obj->cob_pool;
+	struct obj_coll_query_in	*ocqi;
+	crt_rpc_t			*req = NULL;
+	struct obj_query_key_cb_args	 cb_args = { 0 };
+	crt_endpoint_t			 tgt_ep = { 0 };
+	int				 shard = -1;
+	int				 size = dcts[0].dct_bitmap_sz << 3;
+	int				 rc;
+	int				 i;
+
+	D_ASSERT(pool != NULL);
+	D_ASSERT(dcts != NULL);
+	D_ASSERT(dct_nr >= 1);
+
+	tgt_ep.ep_grp = pool->dp_sys->sy_group;
+	tgt_ep.ep_rank = dcts[0].dct_rank;
+	for (i = 0; i < size; i++) {
+		if (isset(dcts[0].dct_bitmap, i)) {
+			tgt_ep.ep_tag = i;
+			shard = dcts[0].dct_shards[i].dcs_buf[0];
+			break;
+		}
+	}
+
+	D_ASSERT(shard >= 0);
+
+	D_DEBUG(DB_IO, "OBJ_COLL_QUERY_RPC, rank=%d tag=%d shard = %d.\n",
+		tgt_ep.ep_rank, tgt_ep.ep_tag, shard);
+
+	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, DAOS_OBJ_RPC_COLL_QUERY, &req);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	crt_req_addref(req);
+	cb_args.rpc = req;
+	cb_args.map_ver = map_ver;
+	cb_args.dkey = dkey;
+	cb_args.akey = akey;
+	cb_args.recx = recx;
+	cb_args.max_epoch = max_epoch;
+	cb_args.obj = obj;
+	cb_args.epoch = *epoch;
+	cb_args.th = th;
+
+	rc = tse_task_register_comp_cb(task, obj_shard_coll_query_cb, &cb_args, sizeof(cb_args));
+	if (rc != 0)
+		D_GOTO(out_req, rc);
+
+	ocqi = crt_req_get(req);
+	D_ASSERT(ocqi != NULL);
+
+	daos_dti_copy(&ocqi->ocqi_xid, dti);
+	uuid_copy(ocqi->ocqi_po_uuid, pool->dp_pool);
+	uuid_copy(ocqi->ocqi_co_hdl, coh_uuid);
+	uuid_copy(ocqi->ocqi_co_uuid, cont_uuid);
+	daos_dc_obj2id(obj, &ocqi->ocqi_oid);
+	ocqi->ocqi_oid.id_shard = shard;
+	ocqi->ocqi_epoch = epoch->oe_value;
+	ocqi->ocqi_epoch_first = epoch->oe_first;
+	ocqi->ocqi_api_flags = flags;
+	ocqi->ocqi_map_ver = req_map_ver;
+
+	ocqi->ocqi_flags = 0;
+	if (epoch->oe_flags & DTX_EPOCH_UNCERTAIN)
+		ocqi->ocqi_flags |= ORF_EPOCH_UNCERTAIN;
+	if (obj_is_ec(obj))
+		ocqi->ocqi_flags |= ORF_EC;
+
+	d_iov_set(&ocqi->ocqi_dkey, NULL, 0);
+	if (dkey != NULL && !(flags & DAOS_GET_DKEY))
+		ocqi->ocqi_dkey = *dkey;
+
+	d_iov_set(&ocqi->ocqi_akey, NULL, 0);
+	if (akey != NULL && !(flags & DAOS_GET_AKEY))
+		ocqi->ocqi_akey = *akey;
+
+	ocqi->ocqi_tgts.ca_count = dct_nr;
+	ocqi->ocqi_tgts.ca_arrays = dcts;
+
+	return daos_rpc_send(req, task);
 
 out_req:
 	crt_req_decref(req);

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -318,6 +318,11 @@ struct obj_reasb_req;
 	((shard % obj_ec_tgt_nr(&obj->cob_oca) + obj_ec_tgt_nr(&obj->cob_oca) -		\
 	 obj_ec_shard_idx(obj, dkey_hash, 0)) % obj_ec_tgt_nr(&obj->cob_oca))
 
+/* Get the logical offset of shard within one group by oca, physical idx -> logical idx */
+#define obj_ec_shard_off_by_oca(layout_ver, dkey_hash, oca, shard)				\
+	((shard % obj_ec_tgt_nr(oca) + obj_ec_tgt_nr(oca) -					\
+	 obj_ec_shard_idx_by_layout_ver(layout_ver, dkey_hash, oca, 0)) % obj_ec_tgt_nr(oca))
+
 /* Get the logical offset of the tgt_idx by start target of EC, physical idx -> logical idx */
 #define obj_ec_shard_off_by_start(tgt_idx, oca, start_tgt)		\
 	((tgt_idx + obj_ec_tgt_nr(oca) - start_tgt) % obj_ec_tgt_nr(oca))

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -42,6 +42,8 @@ extern bool	cli_bypass_rpc;
 /** Switch of server-side IO dispatch */
 extern unsigned int	srv_io_mode;
 extern unsigned int	obj_coll_punch_thd;
+extern unsigned int	obj_fwd_query_thd;
+extern unsigned int	obj_fwd_query_cnt;
 
 /* Whether check redundancy group validation when DTX resync. */
 extern bool	tx_verify_rdg;
@@ -255,6 +257,17 @@ struct shard_punch_args {
 	uint32_t		 pa_opc;
 };
 
+struct shard_query_key_args {
+	/* shard_auxi_args must be the first for shard_task_sched(). */
+	struct shard_auxi_args	 kqa_auxi;
+	uuid_t			 kqa_coh_uuid;
+	uuid_t			 kqa_cont_uuid;
+	struct dtx_id		 kqa_dti;
+	uint32_t		 kqa_dct_cap;
+	int			 kqa_dct_nr;
+	struct daos_coll_target	*kqa_dcts;
+};
+
 struct shard_sub_anchor {
 	daos_anchor_t	ssa_anchor;
 	/* These two extra anchors are for migration enumeration */
@@ -419,6 +432,7 @@ struct obj_auxi_args {
 	union {
 		struct shard_rw_args		rw_args;
 		struct shard_punch_args		p_args;
+		struct shard_query_key_args	q_args;
 		struct shard_list_args		l_args;
 		struct shard_k2a_args		k_args;
 		struct shard_sync_args		s_args;
@@ -587,6 +601,13 @@ int dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, 
 			   daos_epoch_t *max_epoch, const uuid_t coh_uuid, const uuid_t cont_uuid,
 			   struct dtx_id *dti, uint32_t *map_ver,
 			   daos_handle_t th, tse_task_t *task);
+
+int dc_obj_shard_coll_query(struct dtx_epoch *epoch, uint32_t flags, uint32_t req_map_ver,
+			    struct dc_object *obj, daos_key_t *dkey, daos_key_t *akey,
+			    daos_recx_t *recx, daos_epoch_t *max_epoch, const uuid_t coh_uuid,
+			    const uuid_t cont_uuid, struct dtx_id *dti, uint32_t *map_ver,
+			    struct daos_coll_target *dcts, uint32_t dct_nr, daos_handle_t th,
+			    tse_task_t *task);
 
 int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		      void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
@@ -847,9 +868,32 @@ daos_recx_ep_list_ep_valid(struct daos_recx_ep_list *list)
 	return (list->re_ep_valid == 1);
 }
 
-int  obj_class_init(void);
+int obj_class_init(void);
 void obj_class_fini(void);
-int  obj_utils_init(void);
+
+struct obj_query_merge_args {
+	struct daos_oclass_attr	*oca;
+	daos_unit_oid_t		 oid;
+	daos_epoch_t		 src_epoch;
+	daos_key_t		*in_dkey;
+	daos_key_t		*src_dkey;
+	daos_key_t		*tgt_dkey;
+	daos_key_t		*src_akey;
+	daos_key_t		*tgt_akey;
+	daos_recx_t		*src_recx;
+	daos_recx_t		*tgt_recx;
+	daos_epoch_t		*tgt_epoch;
+	uint32_t		*tgt_map_ver;
+	uint32_t		*shard;
+	uint64_t		 flags;
+	uint32_t		 opc;
+	uint32_t		 src_map_ver;
+	int			 ret;
+};
+
+/* obj_utils.c */
+int daos_obj_merge_query_merge(struct obj_query_merge_args *args);
+int obj_utils_init(void);
 void obj_utils_fini(void);
 
 /* obj_tx.c */

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -611,6 +611,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 {
 	int		rc;
 	int		i;
+	int		j;
 
 	rc = crt_proc_uint16_t(proc, proc_op, &dcsr->dcsr_opc);
 	if (unlikely(rc))
@@ -703,8 +704,14 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 			for (i = 0; i < dcsr->dcsr_nr; i++) {
 				rc = crt_proc_crt_bulk_t(proc, proc_op,
 							 &dcu->dcu_bulks[i]);
-				if (unlikely(rc))
+				if (unlikely(rc)) {
+					if (DECODING(proc_op)) {
+						for (j = 0; j < i; j++)
+							crt_proc_crt_bulk_t(proc, CRT_PROC_FREE,
+									    &dcu->dcu_bulks[j]);
+					}
 					D_GOTO(out, rc);
+				}
 			}
 		} else if (!(dcu->dcu_flags & ORF_EMPTY_SGL)) {
 			if (DECODING(proc_op)) {
@@ -716,8 +723,14 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 			for (i = 0; i < dcsr->dcsr_nr; i++) {
 				rc = crt_proc_d_sg_list_t(proc, proc_op,
 							  &dcu->dcu_sgls[i]);
-				if (unlikely(rc))
+				if (unlikely(rc)) {
+					if (DECODING(proc_op)) {
+						for (j = 0; j < i; j++)
+							crt_proc_d_sg_list_t(proc, CRT_PROC_FREE,
+									     &dcu->dcu_sgls[j]);
+					}
 					D_GOTO(out, rc);
+				}
 			}
 		}
 
@@ -740,8 +753,14 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 		for (i = 0; i < dcsr->dcsr_nr; i++) {
 			rc = crt_proc_daos_key_t(proc, proc_op,
 						 &dcp->dcp_akeys[i]);
-			if (unlikely(rc))
+			if (unlikely(rc)) {
+				if (DECODING(proc_op)) {
+					for (j = 0; j < i; j++)
+						crt_proc_daos_key_t(proc, CRT_PROC_FREE,
+								    &dcp->dcp_akeys[j]);
+				}
 				D_GOTO(out, rc);
+			}
 		}
 
 		break;
@@ -761,8 +780,14 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc, crt_proc_op_t proc_op,
 		for (i = 0; i < dcsr->dcsr_nr; i++) {
 			rc = crt_proc_daos_iod_t(proc, proc_op,
 						 &dcr->dcr_iods[i]);
-			if (unlikely(rc))
+			if (unlikely(rc)) {
+				if (DECODING(proc_op)) {
+					for (j = 0; j < i; j++)
+						crt_proc_daos_iod_t(proc, CRT_PROC_FREE,
+								    &dcr->dcr_iods[j]);
+				}
 				D_GOTO(out, rc);
+			}
 		}
 
 		break;
@@ -877,6 +902,7 @@ crt_proc_struct_daos_cpd_sg(crt_proc_t proc, crt_proc_op_t proc_op,
 {
 	int		rc;
 	int		i;
+	int		j;
 
 	rc = crt_proc_uint32_t(proc, proc_op, &dcs->dcs_type);
 	if (unlikely(rc))
@@ -902,8 +928,15 @@ crt_proc_struct_daos_cpd_sg(crt_proc_t proc, crt_proc_op_t proc_op,
 
 		for (i = 0; i < dcs->dcs_nr; i++) {
 			rc = crt_proc_struct_daos_cpd_sub_head(proc, proc_op, &dcsh[i], true);
-			if (unlikely(rc))
+			if (unlikely(rc)) {
+				if (DECODING(proc_op)) {
+					for (j = 0; j < i; j++)
+						crt_proc_struct_daos_cpd_sub_head(proc,
+										  CRT_PROC_FREE,
+										  &dcsh[j], true);
+				}
 				D_GOTO(out, rc);
+			}
 		}
 
 		break;
@@ -929,11 +962,17 @@ crt_proc_struct_daos_cpd_sg(crt_proc_t proc, crt_proc_op_t proc_op,
 		}
 
 		for (i = 0; i < dcs->dcs_nr; i++) {
-			rc = crt_proc_struct_daos_cpd_sub_req(proc, proc_op,
-							      &dcsr[i],
-							      with_oid);
-			if (unlikely(rc))
+			rc = crt_proc_struct_daos_cpd_sub_req(proc, proc_op, &dcsr[i], with_oid);
+			if (unlikely(rc)) {
+				if (DECODING(proc_op)) {
+					for (j = 0; j < i; j++)
+						crt_proc_struct_daos_cpd_sub_req(proc,
+										 CRT_PROC_FREE,
+										 &dcsr[j],
+										 with_oid);
+				}
 				D_GOTO(out, rc);
+			}
 		}
 
 		break;
@@ -952,10 +991,16 @@ crt_proc_struct_daos_cpd_sg(crt_proc_t proc, crt_proc_op_t proc_op,
 		}
 
 		for (i = 0; i < dcs->dcs_nr; i++) {
-			rc = crt_proc_struct_daos_cpd_disp_ent(proc, proc_op,
-							       &dcde[i]);
-			if (unlikely(rc))
+			rc = crt_proc_struct_daos_cpd_disp_ent(proc, proc_op, &dcde[i]);
+			if (unlikely(rc)) {
+				if (DECODING(proc_op)) {
+					for (j = 0; j < i; j++)
+						crt_proc_struct_daos_cpd_disp_ent(proc,
+										  CRT_PROC_FREE,
+										  &dcde[j]);
+				}
 				D_GOTO(out, rc);
+			}
 		}
 
 		break;
@@ -974,10 +1019,15 @@ crt_proc_struct_daos_cpd_sg(crt_proc_t proc, crt_proc_op_t proc_op,
 		}
 
 		for (i = 0; i < dcs->dcs_nr; i++) {
-			rc = crt_proc_struct_daos_shard_tgt(proc, proc_op,
-							    &dst[i]);
-			if (unlikely(rc))
+			rc = crt_proc_struct_daos_shard_tgt(proc, proc_op, &dst[i]);
+			if (unlikely(rc)) {
+				if (DECODING(proc_op)) {
+					for (j = 0; j < i; j++)
+						crt_proc_struct_daos_shard_tgt(proc, CRT_PROC_FREE,
+									       &dst[j]);
+				}
 				D_GOTO(out, rc);
+			}
 		}
 
 		break;
@@ -1024,6 +1074,125 @@ out:
 	return rc;
 }
 
+static int
+crt_proc_struct_daos_coll_shard(crt_proc_t proc, crt_proc_op_t proc_op, struct daos_coll_shard *dcs)
+{
+	int	rc = 0;
+	int	i;
+
+	if (FREEING(proc_op)) {
+		if (dcs->dcs_buf != &dcs->dcs_inline)
+			D_FREE(dcs->dcs_buf);
+		return 0;
+	}
+
+	rc = crt_proc_uint16_t(proc, proc_op, &dcs->dcs_nr);
+	if (unlikely(rc))
+		return rc;
+
+	/* dct_shards is sparse array, skip the hole. */
+	if (dcs->dcs_nr == 0)
+		return 0;
+
+	if (DECODING(proc_op))
+		dcs->dcs_cap = dcs->dcs_nr;
+
+	if (dcs->dcs_nr == 1) {
+		rc = crt_proc_uint32_t(proc, proc_op, &dcs->dcs_inline);
+		if (unlikely(rc))
+			return rc;
+
+		if (DECODING(proc_op))
+			dcs->dcs_buf = &dcs->dcs_inline;
+
+		return 0;
+	}
+
+	if (DECODING(proc_op)) {
+		D_ALLOC_ARRAY(dcs->dcs_buf, dcs->dcs_nr);
+		if (dcs->dcs_buf == NULL)
+			return -DER_NOMEM;
+	}
+
+	for (i = 0; i < dcs->dcs_nr; i++) {
+		rc = crt_proc_uint32_t(proc, proc_op, &dcs->dcs_buf[i]);
+		if (unlikely(rc))
+			goto out;
+	}
+
+out:
+	if (unlikely(rc) && DECODING(proc_op) && dcs->dcs_buf != &dcs->dcs_inline)
+		D_FREE(dcs->dcs_buf);
+	return rc;
+}
+
+static int
+crt_proc_struct_daos_coll_target(crt_proc_t proc, crt_proc_op_t proc_op, struct daos_coll_target *dct)
+{
+	int	size;
+	int	rc;
+	int	i;
+	int	j;
+
+	rc = crt_proc_uint32_t(proc, proc_op, &dct->dct_rank);
+	if (unlikely(rc))
+		return rc;
+
+	rc = crt_proc_uint8_t(proc, proc_op, &dct->dct_bitmap_sz);
+	if (unlikely(rc))
+		return rc;
+
+	rc = crt_proc_uint8_t(proc, proc_op, &dct->dct_padding);
+	if (unlikely(rc))
+		return rc;
+
+	rc = crt_proc_uint16_t(proc, proc_op, &dct->dct_shard_nr);
+	if (unlikely(rc))
+		return rc;
+
+	size = dct->dct_bitmap_sz << 3;
+
+	if (DECODING(proc_op)) {
+		D_ALLOC_ARRAY(dct->dct_bitmap, dct->dct_bitmap_sz);
+		if (dct->dct_bitmap == NULL)
+			return -DER_NOMEM;
+
+		D_ALLOC_ARRAY(dct->dct_shards, size);
+		if (dct->dct_shards == NULL)
+			goto out;
+	}
+
+	if (FREEING(proc_op)) {
+		D_FREE(dct->dct_bitmap);
+	} else {
+		rc = crt_proc_memcpy(proc, proc_op, dct->dct_bitmap, dct->dct_bitmap_sz);
+		if (unlikely(rc))
+			goto out;
+	}
+
+	for (i = 0; i < size; i++) {
+		rc = crt_proc_struct_daos_coll_shard(proc, proc_op, &dct->dct_shards[i]);
+		if (unlikely(rc)) {
+			if (DECODING(proc_op)) {
+				for (j = 0; j < i; j++)
+					crt_proc_struct_daos_coll_shard(proc, CRT_PROC_FREE,
+									&dct->dct_shards[j]);
+			}
+			goto out;
+		}
+	}
+
+	if (FREEING(proc_op))
+		D_FREE(dct->dct_shards);
+
+out:
+	if (unlikely(rc) && DECODING(proc_op)) {
+		D_FREE(dct->dct_bitmap);
+		D_FREE(dct->dct_shards);
+	}
+	return rc;
+}
+
 CRT_RPC_DEFINE(obj_rw, DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 CRT_RPC_DEFINE(obj_key_enum, DAOS_ISEQ_OBJ_KEY_ENUM, DAOS_OSEQ_OBJ_KEY_ENUM)
 CRT_RPC_DEFINE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
@@ -1035,6 +1204,7 @@ CRT_RPC_DEFINE(obj_cpd, DAOS_ISEQ_OBJ_CPD, DAOS_OSEQ_OBJ_CPD)
 CRT_RPC_DEFINE(obj_ec_rep, DAOS_ISEQ_OBJ_EC_REP, DAOS_OSEQ_OBJ_EC_REP)
 CRT_RPC_DEFINE(obj_key2anchor, DAOS_ISEQ_OBJ_KEY2ANCHOR, DAOS_OSEQ_OBJ_KEY2ANCHOR)
 CRT_RPC_DEFINE(obj_coll_punch, DAOS_ISEQ_OBJ_COLL_PUNCH, DAOS_OSEQ_OBJ_COLL_PUNCH)
+CRT_RPC_DEFINE(obj_coll_query, DAOS_ISEQ_OBJ_COLL_QUERY, DAOS_OSEQ_OBJ_COLL_QUERY)
 
 /* Define for obj_proto_rpc_fmt[] array population below.
  * See OBJ_PROTO_*_RPC_LIST macro definition
@@ -1115,6 +1285,9 @@ obj_reply_set_status(crt_rpc_t *rpc, int status)
 	case DAOS_OBJ_RPC_COLL_PUNCH:
 		((struct obj_coll_punch_out *)reply)->ocpo_ret = status;
 		break;
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		((struct obj_coll_query_out *)reply)->ocqo_ret = status;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -1156,6 +1329,8 @@ obj_reply_get_status(crt_rpc_t *rpc)
 		return ((struct obj_ec_rep_out *)reply)->er_status;
 	case DAOS_OBJ_RPC_COLL_PUNCH:
 		return ((struct obj_coll_punch_out *)reply)->ocpo_ret;
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		return ((struct obj_coll_query_out *)reply)->ocqo_ret;
 	default:
 		D_ASSERT(0);
 	}
@@ -1208,6 +1383,9 @@ obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version)
 	case DAOS_OBJ_RPC_COLL_PUNCH:
 		((struct obj_coll_punch_out *)reply)->ocpo_map_version = map_version;
 		break;
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		((struct obj_coll_query_out *)reply)->ocqo_map_version = map_version;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -1245,6 +1423,8 @@ obj_reply_map_version_get(crt_rpc_t *rpc)
 		return ((struct obj_cpd_out *)reply)->oco_map_version;
 	case DAOS_OBJ_RPC_COLL_PUNCH:
 		return ((struct obj_coll_punch_out *)reply)->ocpo_map_version;
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		return ((struct obj_coll_query_out *)reply)->ocqo_map_version;
 	default:
 		D_ASSERT(0);
 	}

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -99,7 +99,10 @@
 		ds_obj_key2anchor_handler, NULL, "key2anchor")		\
 	X(DAOS_OBJ_RPC_COLL_PUNCH,					\
 		0, &CQF_obj_coll_punch, ds_obj_coll_punch_handler,	\
-		&obj_coll_punch_co_ops, "obj_coll_punch")
+		&obj_coll_punch_co_ops, "obj_coll_punch")		\
+	X(DAOS_OBJ_RPC_COLL_QUERY,					\
+		0, &CQF_obj_coll_query, ds_obj_coll_query_handler,	\
+		NULL, "obj_coll_query")
 
 /* Define for RPC enum population below */
 #define X(a, b, c, d, e, f) a,
@@ -660,6 +663,37 @@ CRT_RPC_DECLARE(obj_cpd, DAOS_ISEQ_OBJ_CPD, DAOS_OSEQ_OBJ_CPD)
 	((uint32_t)			(ocpo_map_version)		CRT_VAR)
 
 CRT_RPC_DECLARE(obj_coll_punch, DAOS_ISEQ_OBJ_COLL_PUNCH, DAOS_OSEQ_OBJ_COLL_PUNCH)
+
+#define DAOS_ISEQ_OBJ_COLL_QUERY	/* input fields */				\
+	((struct dtx_id)		(ocqi_xid)			CRT_VAR)	\
+	((uuid_t)			(ocqi_po_uuid)			CRT_VAR)	\
+	((uuid_t)			(ocqi_co_hdl)			CRT_VAR)	\
+	((uuid_t)			(ocqi_co_uuid)			CRT_VAR)	\
+	((daos_unit_oid_t)		(ocqi_oid)			CRT_RAW)	\
+	((uint64_t)			(ocqi_epoch)			CRT_VAR)	\
+	((uint64_t)			(ocqi_epoch_first)		CRT_VAR)	\
+	((uint64_t)			(ocqi_api_flags)		CRT_VAR)	\
+	((uint32_t)			(ocqi_map_ver)			CRT_VAR)	\
+	((uint32_t)			(ocqi_flags)			CRT_VAR)	\
+	((daos_key_t)			(ocqi_dkey)			CRT_VAR)	\
+	((daos_key_t)			(ocqi_akey)			CRT_VAR)	\
+	((struct daos_coll_target)	(ocqi_tgts)			CRT_ARRAY)
+
+#define DAOS_OSEQ_OBJ_COLL_QUERY	/* output fields */				\
+	((int32_t)			(ocqo_ret)			CRT_VAR)	\
+	((uint32_t)			(ocqo_map_version)		CRT_VAR)	\
+	/* The id_shard corresponding to ocqo_recx */					\
+	((uint32_t)			(ocqo_shard)			CRT_VAR)	\
+	((uint32_t)			(ocqo_padding)			CRT_VAR)	\
+	((uint64_t)			(ocqo_epoch)			CRT_VAR)	\
+	((daos_key_t)			(ocqo_dkey)			CRT_VAR)	\
+	((daos_key_t)			(ocqo_akey)			CRT_VAR)	\
+	/* recx for visible extent */							\
+	((daos_recx_t)			(ocqo_recx)			CRT_VAR)	\
+	/* epoch for max write */							\
+	((uint64_t)			(ocqo_max_epoch)		CRT_VAR)
+
+CRT_RPC_DECLARE(obj_coll_query, DAOS_ISEQ_OBJ_COLL_QUERY, DAOS_OSEQ_OBJ_COLL_QUERY)
 
 static inline int
 obj_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -3528,6 +3528,8 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc, tse_
 				    fe->nr != 1 ? fe->iods : (void *)&fe->iods[0].iod_name);
 		break;
 	}
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		/* Fall through. */
 	case DAOS_OBJ_RPC_QUERY_KEY: {
 		daos_obj_query_key_t	*qu = dc_task_get_args(task);
 		daos_key_t		*dkey;

--- a/src/object/obj_utils.c
+++ b/src/object/obj_utils.c
@@ -86,6 +86,173 @@ daos_iods_free(daos_iod_t *iods, int nr, bool need_free)
 		D_FREE(iods);
 }
 
+static void
+obj_query_merge_recx(struct daos_oclass_attr *oca, daos_unit_oid_t oid, daos_key_t *dkey,
+		     daos_recx_t *src_recx, daos_recx_t *tgt_recx, bool get_max, bool changed,
+		     uint32_t *shard)
+{
+	daos_recx_t	tmp_recx = *src_recx;
+	uint64_t	tmp_end;
+	uint32_t	tgt_off;
+	bool		from_data_tgt;
+	uint64_t	dkey_hash;
+	uint64_t	stripe_rec_nr;
+	uint64_t	cell_rec_nr;
+
+	if (!daos_oclass_is_ec(oca))
+		D_GOTO(out, changed = true);
+
+	dkey_hash = obj_dkey2hash(oid.id_pub, dkey);
+	tgt_off = obj_ec_shard_off_by_oca(oid.id_layout_ver, dkey_hash, oca, oid.id_shard);
+	from_data_tgt = is_ec_data_shard_by_tgt_off(tgt_off, oca);
+	stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
+	cell_rec_nr = obj_ec_cell_rec_nr(oca);
+	D_ASSERT(!(src_recx->rx_idx & PARITY_INDICATOR));
+
+	/*
+	 * Data ext from data shard needs to be converted to daos ext,
+	 * replica ext from parity shard needs not to convert.
+	 */
+	tmp_end = DAOS_RECX_END(tmp_recx);
+	D_DEBUG(DB_IO, "shard %d/%u get recx "DF_U64" "DF_U64"\n",
+		oid.id_shard, tgt_off, tmp_recx.rx_idx, tmp_recx.rx_nr);
+
+	if (tmp_end > 0 && from_data_tgt) {
+		if (get_max) {
+			tmp_recx.rx_idx = max(tmp_recx.rx_idx, rounddown(tmp_end - 1, cell_rec_nr));
+			tmp_recx.rx_nr = tmp_end - tmp_recx.rx_idx;
+		} else {
+			tmp_recx.rx_nr = min(tmp_end, roundup(tmp_recx.rx_idx + 1, cell_rec_nr)) -
+					 tmp_recx.rx_idx;
+		}
+
+		tmp_recx.rx_idx = obj_ec_idx_vos2daos(tmp_recx.rx_idx, stripe_rec_nr, cell_rec_nr,
+						      tgt_off);
+		tmp_end = DAOS_RECX_END(tmp_recx);
+	}
+
+	if ((get_max && DAOS_RECX_END(*tgt_recx) < tmp_end) ||
+	    (!get_max && DAOS_RECX_END(*tgt_recx) > tmp_end))
+		changed = true;
+
+out:
+	if (changed) {
+		*tgt_recx = tmp_recx;
+		if (shard != NULL)
+			*shard = oid.id_shard;
+	}
+}
+
+static inline void
+obj_query_merge_key(uint64_t *tgt_val, uint64_t src_val, bool *changed, bool dkey,
+		    uint32_t *tgt_shard, uint32_t src_shard)
+{
+	D_DEBUG(DB_TRACE, "%s update "DF_U64"->"DF_U64"\n",
+		dkey ? "dkey" : "akey", *tgt_val, src_val);
+
+	*tgt_val = src_val;
+	/* Set to change akey and recx. */
+	*changed = true;
+	if (tgt_shard != NULL)
+		*tgt_shard = src_shard;
+}
+
+int
+daos_obj_merge_query_merge(struct obj_query_merge_args *args)
+{
+	uint64_t	*val;
+	uint64_t	*cur;
+	bool		 check = true;
+	bool		 changed = false;
+	bool		 get_max = (args->flags & DAOS_GET_MAX) ? true : false;
+	bool		 first = false;
+	int		 rc = 0;
+
+	D_ASSERT(args->oca != NULL);
+	args->opc = opc_get(args->opc);
+
+	if (args->ret != 0) {
+		if (args->ret == -DER_NONEXIST)
+			D_GOTO(set_max_epoch, rc = 0);
+
+		if (args->ret == -DER_INPROGRESS || args->ret == -DER_TX_BUSY)
+			D_DEBUG(DB_TRACE, "%s query rpc needs retry: "DF_RC"\n",
+				args->opc == DAOS_OBJ_RPC_COLL_QUERY ? "Collective" : "Regular",
+				DP_RC(args->ret));
+		else
+			D_ERROR("%s query rpc failed: "DF_RC"\n",
+				args->opc == DAOS_OBJ_RPC_COLL_QUERY ? "Collective" : "Regular",
+				DP_RC(args->ret));
+		D_GOTO(out, rc = args->ret);
+	}
+
+	if (*args->tgt_map_ver < args->src_map_ver)
+		*args->tgt_map_ver = args->src_map_ver;
+
+	if (args->flags == 0)
+		goto set_max_epoch;
+
+	if (args->tgt_dkey->iov_len == 0)
+		first = true;
+
+	if (args->flags & DAOS_GET_DKEY) {
+		val = (uint64_t *)args->src_dkey->iov_buf;
+		cur = (uint64_t *)args->tgt_dkey->iov_buf;
+
+		D_ASSERT(cur != NULL);
+
+		if (args->src_dkey->iov_len != sizeof(uint64_t)) {
+			D_ERROR("Invalid Dkey obtained: %d\n", (int)args->src_dkey->iov_len);
+			D_GOTO(out, rc = -DER_IO);
+		}
+
+		/* For first merge, just set the dkey. */
+		if (first) {
+			args->tgt_dkey->iov_len = args->src_dkey->iov_len;
+			obj_query_merge_key(cur, *val, &changed, true, args->shard,
+					    args->oid.id_shard);
+		} else if (get_max) {
+			if (*val > *cur)
+				obj_query_merge_key(cur, *val, &changed, true, args->shard,
+						    args->oid.id_shard);
+			else if (!daos_oclass_is_ec(args->oca) || *val < *cur)
+				/*
+				 * No change, don't check akey and recx for replica obj. EC obj
+				 * needs to check again as it maybe from different data shards.
+				 */
+				check = false;
+		} else if (args->flags & DAOS_GET_MIN) {
+			if (*val < *cur)
+				obj_query_merge_key(cur, *val, &changed, true, args->shard,
+						    args->oid.id_shard);
+			else if (!daos_oclass_is_ec(args->oca))
+				check = false;
+		} else {
+			D_ASSERT(0);
+		}
+	}
+
+	if (check && args->flags & DAOS_GET_AKEY) {
+		val = (uint64_t *)args->src_akey->iov_buf;
+		cur = (uint64_t *)args->tgt_akey->iov_buf;
+
+		/* If first merge or dkey changed, set akey. */
+		if (first || changed)
+			obj_query_merge_key(cur, *val, &changed, false, NULL, args->oid.id_shard);
+	}
+
+	if (check && args->flags & DAOS_GET_RECX)
+		obj_query_merge_recx(args->oca, args->oid,
+				     (args->flags & DAOS_GET_DKEY) ? args->src_dkey : args->in_dkey,
+				     args->src_recx, args->tgt_recx, get_max, changed, args->shard);
+
+set_max_epoch:
+	if (args->tgt_epoch != NULL && *args->tgt_epoch < args->src_epoch)
+		*args->tgt_epoch = args->src_epoch;
+out:
+	return rc;
+}
+
 struct recx_rec {
 	daos_recx_t	*rr_recx;
 };

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -255,6 +255,9 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dth, void *arg, int idx,
 int
 ds_obj_coll_punch_remote(struct dtx_leader_handle *dth, void *arg, int idx,
 			 dtx_sub_comp_cb_t comp_cb);
+int
+ds_obj_coll_query_remote(struct dtx_leader_handle *dlh, void *data, int idx,
+			 dtx_sub_comp_cb_t comp_cb);
 
 /* srv_obj.c */
 void ds_obj_rw_handler(crt_rpc_t *rpc);
@@ -264,6 +267,7 @@ void ds_obj_key2anchor_handler(crt_rpc_t *rpc);
 void ds_obj_punch_handler(crt_rpc_t *rpc);
 void ds_obj_tgt_punch_handler(crt_rpc_t *rpc);
 void ds_obj_query_key_handler(crt_rpc_t *rpc);
+void ds_obj_coll_query_handler(crt_rpc_t *rpc);
 void ds_obj_sync_handler(crt_rpc_t *rpc);
 void ds_obj_migrate_handler(crt_rpc_t *rpc);
 void ds_obj_ec_agg_handler(crt_rpc_t *rpc);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3647,12 +3647,13 @@ out:
 }
 
 static int
-obj_punch_agg_cb(struct dtx_leader_handle *dlh, int allow_failure)
+obj_punch_agg_cb(struct dtx_leader_handle *dlh, void *arg)
 {
 	struct dtx_sub_status	*sub;
 	uint32_t		 sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
-	int			 allow_failure_cnt = 0;
-	int			 succeeds = 0;
+	int			 allow_failure = dlh->dlh_allow_failure;
+	int			 allow_failure_cnt;
+	int			 succeeds;
 	int			 result = 0;
 	int			 i;
 
@@ -3660,11 +3661,9 @@ obj_punch_agg_cb(struct dtx_leader_handle *dlh, int allow_failure)
 	 * For conditional punch, let's ignore DER_NONEXIST if some shard succeed,
 	 * since the object may not exist on some shards due to EC partial update.
 	 */
-	if (allow_failure != 0)
-		D_ASSERTF(allow_failure == -DER_NONEXIST,
-			  "Unexpected allow failure %d\n", allow_failure);
+	D_ASSERTF(allow_failure == -DER_NONEXIST, "Unexpected allow failure %d\n", allow_failure);
 
-	for (i = 0; i < sub_cnt; i++) {
+	for (i = 0, allow_failure_cnt = 0, succeeds = 0; i < sub_cnt; i++) {
 		sub = &dlh->dlh_subs[i];
 		if (sub->dss_tgt.st_rank != DAOS_TGT_IGNORE && sub->dss_comp) {
 			if (sub->dss_result == 0) {
@@ -3686,7 +3685,7 @@ obj_punch_agg_cb(struct dtx_leader_handle *dlh, int allow_failure)
 		DP_DTI(&dlh->dlh_handle.dth_xid),
 		allow_failure_cnt, succeeds, allow_failure, result);
 
-	if (allow_failure != 0 && allow_failure_cnt > 0 && result == 0 && succeeds == 0)
+	if (allow_failure_cnt > 0 && result == 0 && succeeds == 0)
 		result = allow_failure;
 
 	return result;
@@ -3877,9 +3876,11 @@ again2:
 	exec_arg.flags = flags;
 
 	/* Execute the operation on all shards */
-	rc = dtx_leader_exec_ops(dlh, obj_tgt_punch_disp, obj_punch_agg_cb,
-				 (opi->opi_api_flags & DAOS_COND_PUNCH) ? -DER_NONEXIST : 0,
-				 &exec_arg);
+	if (opi->opi_api_flags & DAOS_COND_PUNCH)
+		rc = dtx_leader_exec_ops(dlh, obj_tgt_punch_disp, obj_punch_agg_cb, -DER_NONEXIST,
+					 &exec_arg);
+	else
+		rc = dtx_leader_exec_ops(dlh, obj_tgt_punch_disp, NULL, 0, &exec_arg);
 
 	if (max_ver < dlh->dlh_rmt_ver)
 		max_ver = dlh->dlh_rmt_ver;
@@ -3932,83 +3933,273 @@ cleanup:
 	obj_ioc_end(&ioc, rc);
 }
 
+struct obj_tgt_query_args {
+	struct obj_io_context	*ioc;
+	struct dtx_handle	*dth;
+	daos_key_t		*in_dkey;
+	daos_key_t		*in_akey;
+	daos_key_t		*out_dkey;
+	daos_key_t		*out_akey;
+	daos_key_t		 dkey_copy;
+	daos_key_t		 akey_copy;
+	daos_recx_t		 recx;
+	daos_epoch_t		 max_epoch;
+	int			 result;
+	uint32_t		 shard;
+	uint32_t		 version;
+	uint32_t		 completed:1,
+				 need_copy:1,
+				 keys_copied:1;
+};
+
+static inline void
+obj_tgt_query_cleanup(struct obj_tgt_query_args *otqa)
+{
+	if (otqa->need_copy) {
+		daos_iov_free(&otqa->dkey_copy);
+		daos_iov_free(&otqa->akey_copy);
+	}
+}
+
+static int
+obj_local_query(struct obj_tgt_query_args *otqa, struct obj_io_context *ioc, daos_unit_oid_t oid,
+		daos_epoch_t epoch, uint64_t api_flags, uint32_t map_ver, uint32_t opc,
+		uint32_t count, uint32_t *shards, struct dtx_handle *dth)
+{
+	struct obj_query_merge_args	 oqma = { 0 };
+	daos_key_t			 dkey;
+	daos_key_t			 akey;
+	daos_key_t			*p_dkey;
+	daos_key_t			*p_akey;
+	daos_recx_t			*p_recx;
+	daos_epoch_t			*p_epoch;
+	daos_unit_oid_t			 t_oid = oid;
+	uint32_t			 query_flags = api_flags;
+	uint32_t			 cell_size = 0;
+	uint64_t			 stripe_size = 0;
+	daos_epoch_t			 max_epoch = 0;
+	daos_recx_t			 recx = { 0 };
+	int				 allow_failure = -DER_NONEXIST;
+	int				 allow_failure_cnt;
+	int				 succeeds;
+	int				 rc = 0;
+	int				 i;
+
+	if (count > 1)
+		D_ASSERT(otqa->need_copy);
+
+	if (daos_oclass_is_ec(&ioc->ioc_oca) && api_flags & DAOS_GET_RECX) {
+		query_flags |= VOS_GET_RECX_EC;
+		cell_size = obj_ec_cell_rec_nr(&ioc->ioc_oca);
+		stripe_size = obj_ec_stripe_rec_nr(&ioc->ioc_oca);
+	}
+
+	if (otqa->need_copy) {
+		oqma.oca = &ioc->ioc_oca;
+		oqma.oid = oid;
+		oqma.in_dkey = otqa->in_dkey;
+		oqma.tgt_dkey = &otqa->dkey_copy;
+		oqma.tgt_akey = &otqa->akey_copy;
+		oqma.tgt_recx = &otqa->recx;
+		oqma.tgt_epoch = &otqa->max_epoch;
+		oqma.tgt_map_ver = &otqa->version;
+		oqma.shard = &otqa->shard;
+		oqma.flags = api_flags;
+		oqma.opc = opc;
+		oqma.src_map_ver = map_ver;
+	}
+
+	for (i = 0, allow_failure_cnt = 0, succeeds = 0; i < count; i++ ) {
+		if (api_flags & DAOS_GET_DKEY) {
+			if (otqa->need_copy)
+				p_dkey = &dkey;
+			else
+				p_dkey = otqa->out_dkey;
+			d_iov_set(p_dkey, NULL, 0);
+		} else {
+			p_dkey = otqa->in_dkey;
+		}
+
+		if (api_flags & DAOS_GET_AKEY) {
+			if (otqa->need_copy)
+				p_akey = &akey;
+			else
+				p_akey = otqa->out_akey;
+			d_iov_set(p_akey, NULL, 0);
+		} else {
+			p_akey = otqa->in_akey;
+		}
+
+		if (otqa->need_copy) {
+			p_recx = &recx;
+			p_epoch = &max_epoch;
+		} else {
+			p_recx = &otqa->recx;
+			p_epoch = &otqa->max_epoch;
+		}
+
+		t_oid.id_shard = shards[i];
+
+again:
+		rc = vos_obj_query_key(ioc->ioc_vos_coh, t_oid, query_flags, epoch, p_dkey, p_akey,
+				       p_recx, p_epoch, cell_size, stripe_size, dth);
+		if (obj_dtx_need_refresh(dth, rc)) {
+			rc = dtx_refresh(dth, ioc->ioc_coc);
+			if (rc == -DER_AGAIN)
+				goto again;
+		}
+
+		if (rc == allow_failure) {
+			if (otqa->need_copy && otqa->max_epoch < *p_epoch)
+				otqa->max_epoch = *p_epoch;
+			allow_failure_cnt++;
+			continue;
+		}
+
+		if (rc != 0 || !otqa->need_copy) {
+			otqa->shard = shards[i];
+			goto out;
+		}
+
+		succeeds++;
+
+		if (succeeds == 1) {
+			rc = daos_iov_copy(&otqa->dkey_copy, p_dkey);
+			if (rc != 0)
+				goto out;
+
+			rc = daos_iov_copy(&otqa->akey_copy, p_akey);
+			if (rc != 0)
+				goto out;
+
+			otqa->recx = *p_recx;
+			if (otqa->max_epoch < *p_epoch)
+				otqa->max_epoch = *p_epoch;
+			otqa->shard = shards[i];
+			otqa->keys_copied = 1;
+		} else {
+			oqma.oid.id_shard = shards[i];
+			oqma.src_epoch = *p_epoch;
+			oqma.src_dkey = p_dkey;
+			oqma.src_akey = p_akey;
+			oqma.src_recx = p_recx;
+			/*
+			 * Merge (L1) the results from different shards on the same VOS target
+			 * into current otqa that stands for the result for current VOS target.
+			 */
+			rc = daos_obj_merge_query_merge(&oqma);
+			if (rc != 0)
+				goto out;
+		}
+	}
+
+	if (allow_failure_cnt > 0 && rc == 0 && succeeds == 0)
+		rc = allow_failure;
+
+out:
+	if (rc == allow_failure && otqa->need_copy && !otqa->keys_copied) {
+		/* Allocate key buffer for subsequent merge. */
+		rc = daos_iov_alloc(&otqa->dkey_copy, sizeof(uint64_t), true);
+		if (rc != 0)
+			goto out;
+
+		rc = daos_iov_alloc(&otqa->akey_copy, sizeof(uint64_t), true);
+		if (rc != 0)
+			goto out;
+
+		otqa->keys_copied = 1;
+	}
+
+	otqa->result = rc;
+	otqa->completed = 1;
+
+	return rc;
+}
+
+static int
+obj_tgt_query(struct obj_tgt_query_args *otqa, uuid_t po_uuid, uuid_t co_hdl, uuid_t co_uuid,
+	      daos_unit_oid_t oid, daos_epoch_t epoch, daos_epoch_t epoch_first,
+	      uint64_t api_flags, uint32_t rpc_flags, uint32_t *map_ver, crt_rpc_t *rpc,
+	      uint32_t count, uint32_t *shards, struct dtx_id *xid)
+{
+	struct dtx_epoch	 dtx_epoch = { 0 };
+	struct obj_io_context	 ioc = { 0 };
+	struct obj_io_context	*p_ioc = otqa->ioc;
+	struct dtx_handle	*dth = otqa->dth;
+	int			 rc = 0;
+
+	if (p_ioc == NULL)
+		p_ioc = &ioc;
+
+	if (!p_ioc->ioc_began) {
+		rc = obj_ioc_begin(oid.id_pub, *map_ver, po_uuid, co_hdl, co_uuid, rpc, rpc_flags,
+				   p_ioc);
+		if (rc != 0)
+			goto out;
+	}
+
+	if (dth == NULL) {
+		dtx_epoch.oe_value = epoch;
+		dtx_epoch.oe_first = epoch_first;
+		dtx_epoch.oe_flags = orf_to_dtx_epoch_flags(rpc_flags);
+
+		rc = dtx_begin(p_ioc->ioc_vos_coh, xid, &dtx_epoch, 0, *map_ver, &oid, NULL, 0, 0,
+			       NULL, &dth);
+		if (rc != 0)
+			goto out;
+	}
+
+	rc = obj_local_query(otqa, p_ioc, oid, epoch, api_flags, *map_ver, opc_get(rpc->cr_opc),
+			     count, shards, dth);
+
+	if (dth != otqa->dth)
+		rc = dtx_end(dth, p_ioc->ioc_coc, rc);
+
+out:
+	*map_ver = p_ioc->ioc_map_ver;
+	if (p_ioc != otqa->ioc)
+		obj_ioc_end(p_ioc, rc);
+
+	return rc;
+}
+
 void
 ds_obj_query_key_handler(crt_rpc_t *rpc)
 {
-	struct obj_query_key_in		*okqi;
-	struct obj_query_key_out	*okqo;
-	daos_key_t			*dkey;
-	daos_key_t			*akey;
-	struct dtx_handle		*dth = NULL;
-	struct obj_io_context		 ioc;
-	struct dtx_epoch		 epoch = {0};
-	uint32_t			 query_flags;
-	unsigned int			 cell_size = 0;
-	uint64_t			 stripe_size = 0;
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct obj_query_key_in		*okqi = crt_req_get(rpc);
+	struct obj_query_key_out	*okqo = crt_reply_get(rpc);
+	struct obj_tgt_query_args	 otqa = { 0 };
+	uint32_t			 version = okqi->okqi_map_ver;
 	int				 rc;
 
-	okqi = crt_req_get(rpc);
-	D_ASSERT(okqi != NULL);
-	okqo = crt_reply_get(rpc);
-	D_ASSERT(okqo != NULL);
-
-	D_DEBUG(DB_IO, "flags = "DF_U64"\n", okqi->okqi_api_flags);
-
-	rc = obj_ioc_begin(okqi->okqi_oid.id_pub, okqi->okqi_map_ver,
-			   okqi->okqi_pool_uuid, okqi->okqi_co_hdl,
-			   okqi->okqi_co_uuid, rpc, okqi->okqi_flags, &ioc);
-	if (rc)
-		D_GOTO(failed, rc);
-
-	rc = process_epoch(&okqi->okqi_epoch, &okqi->okqi_epoch_first,
-			   &okqi->okqi_flags);
+	rc = process_epoch(&okqi->okqi_epoch, &okqi->okqi_epoch_first, &okqi->okqi_flags);
 	if (rc == PE_OK_LOCAL)
 		okqi->okqi_flags &= ~ORF_EPOCH_UNCERTAIN;
 
-	dkey = &okqi->okqi_dkey;
-	akey = &okqi->okqi_akey;
-	d_iov_set(&okqo->okqo_akey, NULL, 0);
-	d_iov_set(&okqo->okqo_dkey, NULL, 0);
-	if (okqi->okqi_api_flags & DAOS_GET_DKEY)
-		dkey = &okqo->okqo_dkey;
-	if (okqi->okqi_api_flags & DAOS_GET_AKEY)
-		akey = &okqo->okqo_akey;
+	otqa.in_dkey = &okqi->okqi_dkey;
+	otqa.in_akey = &okqi->okqi_akey;
+	otqa.out_dkey = &okqo->okqo_dkey;
+	otqa.out_akey = &okqo->okqo_akey;
 
-	epoch.oe_value = okqi->okqi_epoch;
-	epoch.oe_first = okqi->okqi_epoch_first;
-	epoch.oe_flags = orf_to_dtx_epoch_flags(okqi->okqi_flags);
+	rc = obj_tgt_query(&otqa, okqi->okqi_pool_uuid, okqi->okqi_co_hdl, okqi->okqi_co_uuid,
+			   okqi->okqi_oid, okqi->okqi_epoch, okqi->okqi_epoch_first,
+			   okqi->okqi_api_flags, okqi->okqi_flags, &version, rpc, 1,
+			   &okqi->okqi_oid.id_shard, &okqi->okqi_dti);
+	okqo->okqo_max_epoch = otqa.max_epoch;
+	if (rc == 0)
+		okqo->okqo_recx = otqa.recx;
+	else
+		DL_CDEBUG(rc != -DER_NONEXIST && rc != -DER_INPROGRESS && rc != -DER_TX_RESTART,
+			  DLOG_ERR, DB_IO, rc, "Failed to handle reqular query RPC %p on XS %u/%u "
+			  "for obj "DF_UOID" epc "DF_X64" pmv %u/%u, api_flags "DF_X64" with dti "
+			  DF_DTI, rpc, dmi->dmi_xs_id, dmi->dmi_tgt_id, DP_UOID(okqi->okqi_oid),
+			  okqi->okqi_epoch, okqi->okqi_map_ver, version, okqi->okqi_api_flags,
+			  DP_DTI(&okqi->okqi_dti));
 
-	rc = dtx_begin(ioc.ioc_vos_coh, &okqi->okqi_dti, &epoch, 0,
-		       okqi->okqi_map_ver, &okqi->okqi_oid, NULL, 0, 0, NULL,
-		       &dth);
-	if (rc != 0)
-		goto failed;
-
-	query_flags = okqi->okqi_api_flags;
-	if ((okqi->okqi_flags & ORF_EC) && (okqi->okqi_api_flags & DAOS_GET_RECX)) {
-		query_flags |= VOS_GET_RECX_EC;
-		cell_size = obj_ec_cell_rec_nr(&ioc.ioc_oca);
-		stripe_size = obj_ec_stripe_rec_nr(&ioc.ioc_oca);
-	}
-
-re_query:
-	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid, query_flags,
-			       okqi->okqi_epoch, dkey, akey, &okqo->okqo_recx,
-			       &okqo->okqo_max_epoch,
-			       cell_size, stripe_size, dth);
-	if (obj_dtx_need_refresh(dth, rc)) {
-		rc = dtx_refresh(dth, ioc.ioc_coc);
-		if (rc == -DER_AGAIN)
-			goto re_query;
-	}
-
-	rc = dtx_end(dth, ioc.ioc_coc, rc);
-
-failed:
 	obj_reply_set_status(rpc, rc);
-	obj_reply_map_version_set(rpc, ioc.ioc_map_ver);
-	okqo->okqo_epoch = epoch.oe_value;
-	obj_ioc_end(&ioc, rc);
+	obj_reply_map_version_set(rpc, version);
+	okqo->okqo_epoch = okqi->okqi_epoch;
 
 	rc = crt_reply_send(rpc);
 	if (rc != 0)
@@ -5379,6 +5570,7 @@ struct obj_coll_tgt_args {
 		void				*octa_misc;
 		/* Different collective operations may need different parameters. */
 		struct dtx_memberships		*octa_mbs;
+		struct obj_tgt_query_args	*octa_otqas;
 	};
 };
 
@@ -5997,4 +6189,413 @@ out:
 
 	if (pool != NULL)
 		ds_pool_put(pool);
+}
+
+static int
+obj_coll_tgt_query(void *args)
+{
+	struct obj_coll_tgt_args	*octa = args;
+	struct obj_tgt_query_args	*otqa;
+	crt_rpc_t			*rpc = octa->octa_rpc;
+	struct obj_coll_query_in	*ocqi = crt_req_get(rpc);
+	struct obj_coll_query_out	*ocqo = crt_reply_get(rpc);
+	struct daos_coll_target		*dct = ocqi->ocqi_tgts.ca_arrays;
+	uint32_t			 tgt_id = dss_get_module_info()->dmi_tgt_id;
+	uint32_t			 version = ocqi->ocqi_map_ver;
+	int				 rc;
+
+	otqa = &octa->octa_otqas[tgt_id];
+	otqa->in_dkey = &ocqi->ocqi_dkey;
+	otqa->in_akey = &ocqi->ocqi_akey;
+	otqa->out_dkey = &ocqo->ocqo_dkey;
+	otqa->out_akey = &ocqo->ocqo_akey;
+	if (tgt_id == octa->octa_sponsor_tgt) {
+		otqa->ioc = octa->octa_sponsor_ioc;
+		otqa->dth = octa->octa_sponsor_dth;
+	}
+
+	if (ocqi->ocqi_tgts.ca_count > 1 || dct->dct_shard_nr > 1 ||
+	    dct->dct_shards[tgt_id].dcs_nr > 1)
+		otqa->need_copy = 1;
+
+	rc = obj_tgt_query(otqa, ocqi->ocqi_po_uuid, ocqi->ocqi_co_hdl, ocqi->ocqi_co_uuid,
+			   ocqi->ocqi_oid, ocqi->ocqi_epoch, ocqi->ocqi_epoch_first,
+			   ocqi->ocqi_api_flags, ocqi->ocqi_flags, &version, rpc,
+			   octa->octa_shards[tgt_id].dcs_nr, octa->octa_shards[tgt_id].dcs_buf,
+			   &ocqi->ocqi_xid);
+
+	DL_CDEBUG(rc == 0 || rc == -DER_NONEXIST || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART,
+		  DB_IO, DLOG_ERR, rc, "Collective query obj shard "DF_OID".%u.%u with "
+		  DF_DTI" on tgt %u", DP_OID(ocqi->ocqi_oid.id_pub),
+		  octa->octa_shards[tgt_id].dcs_buf[0], ocqi->ocqi_oid.id_layout_ver,
+		  DP_DTI(&ocqi->ocqi_xid), tgt_id);
+
+	if (octa->octa_versions != NULL)
+		octa->octa_versions[tgt_id] = version;
+
+	return rc;
+}
+
+static int
+obj_coll_query_agg_cb(struct dtx_leader_handle *dlh, void *arg)
+{
+	struct obj_query_merge_args	 oqma = { 0 };
+	struct ds_obj_exec_arg		*exec_arg = arg;
+	struct obj_tgt_query_args	*otqa;
+	struct dtx_sub_status		*sub;
+	crt_rpc_t			*rpc;
+	struct obj_coll_query_in	*ocqi;
+	struct obj_coll_query_out	*ocqo;
+	int				 allow_failure = dlh->dlh_allow_failure;
+	int				 allow_failure_cnt;
+	int				 succeeds;
+	int				 rc = 0;
+	int				 i;
+	bool				 cleanup = false;
+
+	D_ASSERTF(allow_failure == -DER_NONEXIST, "Unexpected allow failure %d\n", allow_failure);
+
+	otqa = (struct obj_tgt_query_args *)exec_arg->args + dss_get_module_info()->dmi_tgt_id;
+	D_ASSERT(otqa->need_copy);
+
+	/*
+	 * If keys_copied is not set on current engine, then the query for current engine is either
+	 * not triggered because of some earlier failure or the query on current engine hit trouble
+	 * and cannot copy the keys. Under such cases, cleanup RPCs instead of merge query resutls.
+	 */
+	if (unlikely(!otqa->keys_copied)) {
+		cleanup = true;
+		/* otqa->result may be not initialized under such case. */
+	} else {
+		oqma.oca = &exec_arg->ioc->ioc_oca;
+		oqma.tgt_dkey = &otqa->dkey_copy;
+		oqma.tgt_akey = &otqa->akey_copy;
+		oqma.tgt_recx = &otqa->recx;
+		oqma.tgt_epoch = &otqa->max_epoch;
+		oqma.tgt_map_ver = &otqa->version;
+		oqma.shard = &otqa->shard;
+		oqma.opc = DAOS_OBJ_RPC_COLL_QUERY;
+	}
+
+	for (i = 0, allow_failure_cnt = 0, succeeds = 0; i < dlh->dlh_normal_sub_cnt; i++) {
+		sub = &dlh->dlh_subs[i];
+		if (unlikely(!sub->dss_comp)) {
+			D_ASSERT(sub->dss_data == NULL);
+			continue;
+		}
+
+		rpc = sub->dss_data;
+
+		if (sub->dss_result == allow_failure) {
+			D_ASSERT(rpc != NULL);
+
+			ocqo = crt_reply_get(rpc);
+			if (otqa->max_epoch < ocqo->ocqo_max_epoch)
+				otqa->max_epoch = ocqo->ocqo_max_epoch;
+			allow_failure_cnt++;
+			goto next;
+		}
+
+		if (sub->dss_result != 0) {
+			/* Ignore INPROGRESS if there is other failure. */
+			if (rc == -DER_INPROGRESS || rc == 0)
+				rc = sub->dss_result;
+			if (dlh->dlh_rmt_ver < sub->dss_version)
+				dlh->dlh_rmt_ver = sub->dss_version;
+			cleanup = true;
+		} else {
+			succeeds++;
+		}
+
+		/* Skip subsequent merge when hit one unallowed failure. */
+		if (cleanup)
+			goto next;
+
+		D_ASSERT(rpc != NULL);
+
+		ocqi = crt_req_get(rpc);
+		ocqo = crt_reply_get(rpc);
+
+		/*
+		 * The RPC reply may be aggregated results from multiple VOS targets, as to related
+		 * max/min dkey/recx are not from the direct target. The ocqo->ocqo_shard indicates
+		 * the right one.
+		 */
+		oqma.oid = ocqi->ocqi_oid;
+		oqma.oid.id_shard = ocqo->ocqo_shard;
+		oqma.src_epoch = ocqo->ocqo_max_epoch;
+		oqma.in_dkey = &ocqi->ocqi_dkey;
+		oqma.src_dkey = &ocqo->ocqo_dkey;
+		oqma.src_akey = &ocqo->ocqo_akey;
+		oqma.src_recx = &ocqo->ocqo_recx;
+		oqma.flags = ocqi->ocqi_api_flags;
+		oqma.src_map_ver = obj_reply_map_version_get(rpc);
+		/*
+		 * Merge (L3) the results from other engines into current otqa that stands for the
+		 * results for related engines' group, including current engine.
+		 */
+		rc = daos_obj_merge_query_merge(&oqma);
+
+next:
+		if (rpc != NULL)
+			crt_req_decref(rpc);
+		sub->dss_data = NULL;
+	}
+
+	D_DEBUG(DB_IO, DF_DTI" sub_requests %d/%d, allow_failure %d, result %d\n",
+		DP_DTI(&dlh->dlh_handle.dth_xid),
+		allow_failure_cnt, succeeds, allow_failure, rc);
+
+	/*
+	 * The agg_cb return value only stands for execution on remote engines.
+	 * It is unnecessary to consider local failure on current engine, that
+	 * will be returned via obj_coll_query_disp().
+	 */
+	if (allow_failure_cnt > 0 && rc == 0 && succeeds == 0)
+		rc = allow_failure;
+
+	return rc;
+}
+
+static int
+obj_coll_query_merge_tgts(struct obj_coll_query_in *ocqi, struct daos_oclass_attr *oca,
+			  struct obj_tgt_query_args *otqas, uint8_t *bitmap, uint32_t bitmap_sz,
+			  uint32_t tgt_id, int allow_failure)
+{
+	struct obj_query_merge_args	 oqma = { 0 };
+	struct obj_tgt_query_args	*otqa = &otqas[tgt_id];
+	struct obj_tgt_query_args	*tmp;
+	int				 size = bitmap_sz << 3;
+	int				 allow_failure_cnt;
+	int				 succeeds;
+	int				 rc = 0;
+	int				 i;
+
+	D_ASSERT(otqa->need_copy);
+	D_ASSERT(otqa->keys_copied);
+
+	oqma.oca = oca;
+	oqma.oid = ocqi->ocqi_oid;
+	oqma.in_dkey = &ocqi->ocqi_dkey;
+	oqma.tgt_dkey = &otqa->dkey_copy;
+	oqma.tgt_akey = &otqa->akey_copy;
+	oqma.tgt_recx = &otqa->recx;
+	oqma.tgt_epoch = &otqa->max_epoch;
+	oqma.tgt_map_ver = &otqa->version;
+	oqma.shard = &otqa->shard;
+	oqma.flags = ocqi->ocqi_api_flags;
+	oqma.opc = DAOS_OBJ_RPC_COLL_QUERY;
+
+	if (size > dss_tgt_nr)
+		size = dss_tgt_nr;
+
+	for (i = 0, allow_failure_cnt = 0, succeeds = 0; i < size; i++) {
+		if (isclr(bitmap, i))
+			continue;
+
+		tmp = &otqas[i];
+		if (!tmp->completed)
+			continue;
+
+		if (tmp->result == allow_failure) {
+			if (otqa->max_epoch < tmp->max_epoch)
+				otqa->max_epoch = tmp->max_epoch;
+			allow_failure_cnt++;
+			continue;
+		}
+
+		/* Stop subsequent merge when hit one unallowed failure. */
+		if (tmp->result != 0)
+			D_GOTO(out, rc = tmp->result);
+
+		succeeds++;
+
+		if (i == tgt_id)
+			continue;
+
+		oqma.oid.id_shard = tmp->shard;
+		oqma.src_epoch = tmp->max_epoch;
+		oqma.src_dkey = &tmp->dkey_copy;
+		oqma.src_akey = &tmp->akey_copy;
+		oqma.src_recx = &tmp->recx;
+		oqma.src_map_ver = tmp->version;
+		/*
+		 * Merge (L2) the results from other VOS targets on the same engine
+		 * into current otqa that stands for the results for current engine.
+		 */
+		rc = daos_obj_merge_query_merge(&oqma);
+		if (rc != 0)
+			goto out;
+	}
+
+	D_DEBUG(DB_IO, " sub_requests %d/%d, allow_failure %d, result %d\n",
+		allow_failure_cnt, succeeds, allow_failure, rc);
+
+	if (allow_failure_cnt > 0 && rc == 0 && succeeds == 0)
+		rc = allow_failure;
+
+out:
+	return rc;
+}
+
+static int
+obj_coll_query_disp(struct dtx_leader_handle *dlh, void *arg, int idx, dtx_sub_comp_cb_t comp_cb)
+{
+	struct ds_obj_exec_arg		*exec_arg = arg;
+	crt_rpc_t			*rpc = exec_arg->rpc;
+	struct obj_coll_query_in	*ocqi = crt_req_get(rpc);
+	struct obj_tgt_query_args	*otqa;
+	uint32_t			 tgt_id = dss_get_module_info()->dmi_tgt_id;
+	int				 rc = 0;
+
+	if (idx != -1)
+		return ds_obj_coll_query_remote(dlh, arg, idx, comp_cb);
+
+	rc = obj_coll_local(rpc, exec_arg->shards, dlh->dlh_coll_bitmap, dlh->dlh_coll_bitmap_sz,
+			    NULL, exec_arg->ioc, &dlh->dlh_handle, exec_arg->args,
+			    obj_coll_tgt_query);
+
+	DL_CDEBUG(rc == 0 || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR, rc,
+		  "Collective query obj "DF_OID".%u.%u with "DF_DTI" on rank %u",
+		  DP_OID(ocqi->ocqi_oid.id_pub), exec_arg->shards[tgt_id].dcs_buf[0],
+		  ocqi->ocqi_oid.id_layout_ver, DP_DTI(&ocqi->ocqi_xid), dss_self_rank());
+
+	otqa = (struct obj_tgt_query_args *)exec_arg->args + tgt_id;
+	if (otqa->completed && otqa->keys_copied && (rc == 0 || rc == dlh->dlh_allow_failure))
+		rc = obj_coll_query_merge_tgts(ocqi, &exec_arg->ioc->ioc_oca, exec_arg->args,
+					       dlh->dlh_coll_bitmap, dlh->dlh_coll_bitmap_sz,
+					       tgt_id, dlh->dlh_allow_failure);
+
+	if (comp_cb != NULL)
+		comp_cb(dlh, idx, rc);
+
+	return rc;
+}
+
+void
+ds_obj_coll_query_handler(crt_rpc_t *rpc)
+{
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct obj_coll_query_in	*ocqi = crt_req_get(rpc);
+	struct obj_coll_query_out	*ocqo = crt_reply_get(rpc);
+	struct daos_coll_target		*dct;
+	struct dtx_leader_handle	*dlh = NULL;
+	struct ds_obj_exec_arg		 exec_arg = { 0 };
+	struct obj_tgt_query_args	*otqas = NULL;
+	struct obj_tgt_query_args	*otqa = NULL;
+	struct obj_io_context		 ioc = { 0 };
+	struct dtx_epoch		 epoch = { 0 };
+	uint32_t			 version = 0;
+	uint32_t			 tgt_id = dmi->dmi_tgt_id;
+	d_rank_t			 myrank = dss_self_rank();
+	int				 rc = 0;
+	int				 i;
+
+	D_ASSERT(ocqi != NULL);
+	D_ASSERT(ocqo != NULL);
+
+	D_DEBUG(DB_IO, "Handling collective query RPC %p %s forwarding for obj "
+		DF_UOID" on rank %d XS %u/%u epc "DF_X64" pmv %u, with dti "DF_DTI", dct_nr %u\n",
+		rpc, ocqi->ocqi_tgts.ca_count <= 1 ? "without" : "with", DP_UOID(ocqi->ocqi_oid),
+		myrank, dmi->dmi_xs_id, tgt_id, ocqi->ocqi_epoch, ocqi->ocqi_map_ver,
+		DP_DTI(&ocqi->ocqi_xid), (unsigned int)ocqi->ocqi_tgts.ca_count);
+
+	if (unlikely(ocqi->ocqi_tgts.ca_count <= 0 || ocqi->ocqi_tgts.ca_arrays == NULL))
+		D_GOTO(out, rc = -DER_INVAL);
+
+	dct = ocqi->ocqi_tgts.ca_arrays;
+	if (unlikely(dct->dct_bitmap_sz <= 0 || dct->dct_bitmap == NULL ||
+		     dct->dct_shard_nr <= 0 || dct->dct_shards == NULL))
+		D_GOTO(out, rc = -DER_INVAL);
+
+	rc = process_epoch(&ocqi->ocqi_epoch, &ocqi->ocqi_epoch_first, &ocqi->ocqi_flags);
+	if (rc == PE_OK_LOCAL)
+		ocqi->ocqi_flags &= ~ORF_EPOCH_UNCERTAIN;
+
+	D_ALLOC_ARRAY(otqas, dss_tgt_nr);
+	if (otqas == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	otqa = &otqas[tgt_id];
+	if (ocqi->ocqi_tgts.ca_count == 1) {
+		rc = obj_coll_local(rpc, dct->dct_shards, dct->dct_bitmap, dct->dct_bitmap_sz,
+				    &version, &ioc, NULL, otqas, obj_coll_tgt_query);
+		if (otqa->completed && otqa->keys_copied && (rc == 0 || rc == -DER_NONEXIST)) {
+			D_ASSERT(ioc.ioc_began);
+			rc = obj_coll_query_merge_tgts(ocqi, &ioc.ioc_oca, otqas, dct->dct_bitmap,
+						       dct->dct_bitmap_sz, tgt_id, -DER_NONEXIST);
+		}
+
+		goto out;
+	}
+
+	rc = obj_ioc_begin(ocqi->ocqi_oid.id_pub, ocqi->ocqi_map_ver, ocqi->ocqi_po_uuid,
+			   ocqi->ocqi_co_hdl, ocqi->ocqi_co_uuid, rpc, ocqi->ocqi_flags, &ioc);
+	if (rc != 0)
+		goto out;
+
+	version = ioc.ioc_map_ver;
+
+	epoch.oe_value = ocqi->ocqi_epoch;
+	epoch.oe_first = ocqi->ocqi_epoch_first;
+	epoch.oe_flags = orf_to_dtx_epoch_flags(ocqi->ocqi_flags);
+
+	rc = dtx_leader_begin(ioc.ioc_vos_coh, &ocqi->ocqi_xid, &epoch, 0,
+			      ocqi->ocqi_map_ver, &ocqi->ocqi_oid, NULL /* dti_cos */,
+			      0 /* dti_cos_cnt */, NULL /* hints */, 0 /* hint_sz */,
+			      dct->dct_bitmap, dct->dct_bitmap_sz,
+			      (struct daos_coll_target *)ocqi->ocqi_tgts.ca_arrays + 1 /* tgts */,
+			      ocqi->ocqi_tgts.ca_count - 1 /* tgt_cnt */, DTX_TGT_COLL | DTX_FAKE,
+			      NULL /* ranks */, NULL /* mbs */, &dlh);
+	if (rc != 0)
+		goto out;
+
+	exec_arg.rpc = rpc;
+	exec_arg.ioc = &ioc;
+	exec_arg.args = otqas;
+	exec_arg.shards = dct->dct_shards;
+
+	rc = dtx_leader_exec_ops(dlh, obj_coll_query_disp, obj_coll_query_agg_cb, -DER_NONEXIST,
+				 &exec_arg);
+
+	if (version < dlh->dlh_rmt_ver)
+		version = dlh->dlh_rmt_ver;
+
+	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
+
+out:
+	D_DEBUG(DB_IO, "Handled collective query RPC %p %s forwarding for obj "DF_UOID" on rank %u "
+		"XS %u/%u epc "DF_X64" pmv %u, with dti "DF_DTI", dct_nr %u: "DF_RC"\n",
+		rpc, ocqi->ocqi_tgts.ca_count <= 1 ? "without" : "with", DP_UOID(ocqi->ocqi_oid),
+		myrank, dmi->dmi_xs_id, tgt_id, ocqi->ocqi_epoch, ocqi->ocqi_map_ver,
+		DP_DTI(&ocqi->ocqi_xid), (unsigned int)ocqi->ocqi_tgts.ca_count, DP_RC(rc));
+
+	obj_reply_set_status(rpc, rc);
+	obj_reply_map_version_set(rpc, version);
+	ocqo->ocqo_epoch = epoch.oe_value;
+
+	if (rc == 0 || rc == -DER_NONEXIST) {
+		D_ASSERT(otqa != NULL);
+
+		ocqo->ocqo_shard = otqa->shard;
+		ocqo->ocqo_recx = otqa->recx;
+		ocqo->ocqo_max_epoch = otqa->max_epoch;
+		if (otqa->keys_copied) {
+			ocqo->ocqo_dkey = otqa->dkey_copy;
+			ocqo->ocqo_akey = otqa->akey_copy;
+		}
+	}
+
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("send reply failed: "DF_RC"\n", DP_RC(rc));
+
+	/* Keep otqas until RPC replied, because the reply may use some keys in otqas array. */
+	if (otqas != NULL) {
+		for (i = 0; i < dss_tgt_nr; i++)
+			obj_tgt_query_cleanup(&otqas[i]);
+		D_FREE(otqas);
+	}
+
+	obj_ioc_end(&ioc, rc);
 }

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -139,7 +139,6 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	sent_rpc = true;
 out:
 	if (!sent_rpc) {
-		sub->dss_result = rc;
 		comp_cb(dlh, idx, rc);
 		if (remote_arg) {
 			crt_req_decref(parent_req);
@@ -254,7 +253,6 @@ ds_obj_remote_punch(struct dtx_leader_handle *dlh, void *data, int idx,
 
 out:
 	if (!sent_rpc) {
-		sub->dss_result = rc;
 		comp_cb(dlh, idx, rc);
 		if (remote_arg) {
 			crt_req_decref(parent_req);
@@ -552,7 +550,114 @@ ds_obj_coll_punch_remote(struct dtx_leader_handle *dlh, void *data, int idx,
 
 out:
 	if (!sent_rpc) {
-		sub->dss_result = rc;
+		comp_cb(dlh, idx, rc);
+		if (remote_arg != NULL) {
+			crt_req_decref(parent_req);
+			D_FREE(remote_arg);
+		}
+	}
+	return rc;
+}
+
+static void
+shard_coll_query_req_cb(const struct crt_cb_info *cb_info)
+{
+	struct obj_remote_cb_arg	*arg = cb_info->cci_arg;
+	crt_rpc_t			*req = cb_info->cci_rpc;
+	crt_rpc_t			*parent_req = arg->parent_req;
+	struct obj_coll_query_out	*ocqo = crt_reply_get(req);
+	struct obj_coll_query_in	*ocqi = crt_req_get(req);
+	struct dtx_leader_handle	*dlh = arg->dlh;
+	struct dtx_sub_status		*sub;
+	int				 rc = cb_info->cci_rc;
+	int				 rc1;
+
+	if (ocqi->ocqi_map_ver < ocqo->ocqo_map_version) {
+		D_DEBUG(DB_IO, DF_UOID": map_ver stale (%d < %d).\n",
+			DP_UOID(ocqi->ocqi_oid), ocqi->ocqi_map_ver, ocqo->ocqo_map_version);
+		rc1 = -DER_STALE;
+	} else {
+		rc1 = ocqo->ocqo_ret;
+	}
+
+	if (rc >= 0)
+		rc = rc1;
+
+	sub = &dlh->dlh_subs[arg->idx];
+	/* Hold reference on child RPC until the result is aggregated. */
+	crt_req_addref(req);
+	sub->dss_data = req;
+	arg->comp_cb(dlh, arg->idx, rc);
+	crt_req_decref(parent_req);
+	D_FREE(arg);
+}
+
+int
+ds_obj_coll_query_remote(struct dtx_leader_handle *dlh, void *data, int idx,
+			 dtx_sub_comp_cb_t comp_cb)
+{
+	struct ds_obj_exec_arg		*obj_exec_arg = data;
+	struct obj_remote_cb_arg	*remote_arg = NULL;
+	struct dtx_sub_status		*sub;
+	struct daos_shard_tgt		*shard_tgt;
+	crt_endpoint_t			 tgt_ep = { 0 };
+	crt_rpc_t			*parent_req = obj_exec_arg->rpc;
+	crt_rpc_t			*req = NULL;
+	struct obj_coll_query_in	*ocqi_parent = crt_req_get(parent_req);
+	struct obj_coll_query_in	*ocqi;
+	int				rc = 0;
+	bool				sent_rpc = false;
+
+	D_ASSERT(idx < dlh->dlh_normal_sub_cnt);
+	/* dct[0] is for current engine. */
+	D_ASSERT(idx < ocqi_parent->ocqi_tgts.ca_count - 1);
+
+	sub = &dlh->dlh_subs[idx];
+	shard_tgt = &sub->dss_tgt;
+
+	D_ALLOC_PTR(remote_arg);
+	if (remote_arg == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	remote_arg->dlh = dlh;
+	remote_arg->comp_cb = comp_cb;
+	remote_arg->idx = idx;
+	crt_req_addref(parent_req);
+	remote_arg->parent_req = parent_req;
+
+	tgt_ep.ep_grp = NULL;
+	tgt_ep.ep_rank = shard_tgt->st_rank;
+	tgt_ep.ep_tag = shard_tgt->st_tgt_idx;
+
+	rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep, DAOS_OBJ_RPC_COLL_QUERY, &req);
+	if (rc != 0) {
+		D_ERROR("Failed to create RPC to forward collective query: "DF_RC"\n", DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	ocqi = crt_req_get(req);
+	*ocqi = *ocqi_parent;
+
+	ocqi->ocqi_oid.id_shard = shard_tgt->st_shard_id;
+	ocqi->ocqi_flags |= obj_exec_arg->flags;
+	ocqi->ocqi_tgts.ca_count = 1;
+	ocqi->ocqi_tgts.ca_arrays = (struct daos_coll_target *)ocqi_parent->ocqi_tgts.ca_arrays +
+				    idx + 1;
+
+	D_DEBUG(DB_IO, DF_UOID" forward collective query to rank:%d tag:%d, flags %x.\n",
+		DP_UOID(ocqi->ocqi_oid), tgt_ep.ep_rank, tgt_ep.ep_tag, ocqi->ocqi_flags);
+
+	rc = crt_req_send(req, shard_coll_query_req_cb, remote_arg);
+	if (rc != 0) {
+		D_ASSERT(sub->dss_comp == 1);
+		D_ERROR("Failed to forward collective query to rank:%d tag:%d: "DF_RC"\n",
+			tgt_ep.ep_rank, tgt_ep.ep_tag, DP_RC(rc));
+	}
+
+	sent_rpc = true;
+
+out:
+	if (!sent_rpc) {
 		comp_cb(dlh, idx, rc);
 		if (remote_arg != NULL) {
 			crt_req_decref(parent_req);

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -367,6 +367,18 @@ class TelemetryUtils():
         "engine_io_ops_obj_coll_punch_latency_mean",
         "engine_io_ops_obj_coll_punch_latency_min",
         "engine_io_ops_obj_coll_punch_latency_stddev"]
+    ENGINE_IO_OPS_OBJ_COLL_QUERY_ACTIVE_METRICS = [
+        "engine_io_ops_obj_coll_query_active",
+        "engine_io_ops_obj_coll_query_active_max",
+        "engine_io_ops_obj_coll_query_active_mean",
+        "engine_io_ops_obj_coll_query_active_min",
+        "engine_io_ops_obj_coll_query_active_stddev"]
+    ENGINE_IO_OPS_OBJ_COLL_QUERY_LATENCY_METRICS = [
+        "engine_io_ops_obj_coll_query_latency",
+        "engine_io_ops_obj_coll_query_latency_max",
+        "engine_io_ops_obj_coll_query_latency_mean",
+        "engine_io_ops_obj_coll_query_latency_min",
+        "engine_io_ops_obj_coll_query_latency_stddev"]
     ENGINE_IO_OPS_OBJ_ENUM_ACTIVE_METRICS = [
         "engine_io_ops_obj_enum_active",
         "engine_io_ops_obj_enum_active_max",
@@ -497,6 +509,8 @@ class TelemetryUtils():
         ENGINE_IO_OPS_MIGRATE_LATENCY_METRICS +\
         ENGINE_IO_OPS_OBJ_COLL_PUNCH_ACTIVE_METRICS +\
         ENGINE_IO_OPS_OBJ_COLL_PUNCH_LATENCY_METRICS +\
+        ENGINE_IO_OPS_OBJ_COLL_QUERY_ACTIVE_METRICS +\
+        ENGINE_IO_OPS_OBJ_COLL_QUERY_LATENCY_METRICS +\
         ENGINE_IO_OPS_OBJ_ENUM_ACTIVE_METRICS +\
         ENGINE_IO_OPS_OBJ_ENUM_LATENCY_METRICS +\
         ENGINE_IO_OPS_OBJ_PUNCH_ACTIVE_METRICS +\
@@ -579,7 +593,7 @@ class TelemetryUtils():
         "engine_mem_vos_dtx_cmt_ent_48",
         "engine_mem_vos_vos_obj_360",
         "engine_mem_vos_vos_lru_size",
-        "engine_mem_dtx_dtx_leader_handle_376",
+        "engine_mem_dtx_dtx_leader_handle_368",
         "engine_mem_dtx_dtx_entry_40"]
     ENGINE_MEM_TOTAL_USAGE_METRICS = [
         "engine_mem_total_mem"]

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -5188,6 +5188,124 @@ io_52(void **state)
 	obj_coll_punch(arg, OC_EC_4P1GX);
 }
 
+static void
+obj_coll_query(test_arg_t *arg, daos_oclass_id_t oclass)
+{
+	daos_obj_id_t	oid;
+	daos_handle_t	oh;
+	daos_iod_t	iod = { 0 };
+	d_sg_list_t	sgl = { 0 };
+	daos_recx_t	recx = { 0 };
+	d_iov_t		val_iov;
+	d_iov_t		dkey;
+	d_iov_t		akey;
+	uint64_t	dkey_val;
+	uint64_t	akey_val;
+	uint32_t	update_var = 0xdeadbeef;
+	uint32_t	flags;
+	int		rc;
+
+	/** init dkey, akey */
+	dkey_val = akey_val = 0;
+	d_iov_set(&dkey, &dkey_val, sizeof(uint64_t));
+	d_iov_set(&akey, &akey_val, sizeof(uint64_t));
+
+	oid = daos_test_oid_gen(arg->coh, oclass, DAOS_OT_MULTI_UINT64, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, oid, DAOS_OO_RW, &oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	dkey_val = 5;
+	akey_val = 10;
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_name = akey;
+	iod.iod_recxs = &recx;
+	iod.iod_nr = 1;
+	iod.iod_size = sizeof(update_var);
+
+	d_iov_set(&val_iov, &update_var, sizeof(update_var));
+	sgl.sg_iovs = &val_iov;
+	sgl.sg_nr = 1;
+
+	recx.rx_idx = 5;
+	recx.rx_nr = 1;
+
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, 0);
+
+	dkey_val = 10;
+	val_iov.iov_buf_len += 1024;
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, 0);
+	d_iov_set(&val_iov, &update_var, sizeof(update_var));
+
+	recx.rx_idx = 50;
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, 0);
+
+	flags = DAOS_GET_DKEY | DAOS_GET_AKEY | DAOS_GET_RECX | DAOS_GET_MAX;
+	rc = daos_obj_query_key(oh, DAOS_TX_NONE, flags, &dkey, &akey, &recx, NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(*(uint64_t *)dkey.iov_buf, 10);
+	assert_int_equal(*(uint64_t *)akey.iov_buf, 10);
+	assert_int_equal(recx.rx_idx, 50);
+	assert_int_equal(recx.rx_nr, 1);
+
+	flags = DAOS_GET_AKEY | DAOS_GET_RECX | DAOS_GET_MAX;
+	rc = daos_obj_query_key(oh, DAOS_TX_NONE, flags, &dkey, &akey, &recx, NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(*(uint64_t *)akey.iov_buf, 10);
+	assert_int_equal(recx.rx_idx, 50);
+	assert_int_equal(recx.rx_nr, 1);
+
+	flags = DAOS_GET_RECX | DAOS_GET_MAX;
+	rc = daos_obj_query_key(oh, DAOS_TX_NONE, flags, &dkey, &akey, &recx, NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(recx.rx_idx, 50);
+	assert_int_equal(recx.rx_nr, 1);
+
+	rc = daos_obj_close(oh, NULL);
+	assert_rc_equal(rc, 0);
+}
+
+static void
+io_53(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	print_message("Collective object query - OC_SX\n");
+
+	if (!test_runable(arg, 2))
+		return;
+
+	obj_coll_query(arg, OC_SX);
+}
+
+static void
+io_54(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	print_message("Collective object query - OC_EC_2P1G2\n");
+
+	if (!test_runable(arg, 3))
+		return;
+
+	obj_coll_query(arg, OC_EC_2P1G2);
+}
+
+static void
+io_55(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	print_message("Collective object query - OC_EC_4P1GX\n");
+
+	if (!test_runable(arg, 5))
+		return;
+
+	obj_coll_query(arg, OC_EC_4P1GX);
+}
+
 static const struct CMUnitTest io_tests[] = {
 	{ "IO1: simple update/fetch/verify",
 	  io_simple, async_disable, test_case_teardown},
@@ -5292,6 +5410,12 @@ static const struct CMUnitTest io_tests[] = {
 	  io_51, NULL, test_case_teardown},
 	{ "IO52: collective punch object - OC_EC_4P1GX",
 	  io_52, NULL, test_case_teardown},
+	{ "IO53: collective object query - OC_SX",
+	  io_53, async_disable, test_case_teardown},
+	{ "IO54: collective object query - OC_EC_2P1G2",
+	  io_54, async_disable, test_case_teardown},
+	{ "IO55: collective object query - OC_EC_4P1GX",
+	  io_55, async_disable, test_case_teardown},
 };
 
 int


### PR DESCRIPTION
Currently, get file size (query key) for large-scaled object is very slow.
Because DAOS does not has logic (metadata) center to store the file size.
The client needs to send query RPCs to all related redundancy groups, then
aggregate related query results. For EC object with parity rotation, it is
worse, the client has to send query RPCs to all shards in every redundancy
group. It will cause a lot of query RPCs. For large-scaled object (such as
the "GX" object class), current method is too heavy loaded for both client
and servers.

To resolve such bad situation, we will introduce new mechanism: collective
query. The basic idea is that: before sending query RPCs to related engines,
based on the shards to be queried, the client will generate the bitmap for
related VOS targets on each involved engine. For each engine with non-empty
bitmap, the client only sends one OBJ_COLL_QUERY RPC to it, then the engine
will generate collective tasks (based on the bitmap) to query related object
shards on each own local VOS targets. That will save a lot of query RPCs if
multiple VOS targets reside on relative concentrated engines.

On the other hand, it is inefficient for single client to send out hundreds
or even thousands of query RPCs concurrently, that will cause a lot of DRAM
resource being occupied for relative long time. To speedup, once the RPCs
count exceeds some threshold, the client will ask some engine(s) to help to
forward the query RPCs to other related engine(s), and reply the aggregated
query results to the client. From client perspective, such forwarding causes
one additional RPC round-trip, but it is better than single client handling
hundreds or thousands of query RPCs by itself.

The threshold for triggering engine to forward collective query RPC can be
configured via environment variable "OBJ_FWD_QUERY_THRESHOLD" when start the
client. The default value is 32. Another tunable varilable for that is about
how many RPCs will be forwarded by the relay engine is "OBJ_FWD_QUERY_COUNT".
It is at most equal to above threshold. The default value is 32.

Signed-off-by: Fan Yong <fan.yong@intel.com>
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
