### PR TITLE
DAOS-14568 control: dmg pool query info change targets to ranks

### DIFF
--- a/docs/overview/transaction.md
+++ b/docs/overview/transaction.md
@@ -68,7 +68,7 @@ accessed concurrently by uncoordinated clients. All I/O operations
 the same epoch. The DAOS transaction mechanism automatically detects the
 traditional read/write, write/read and write/write conflicts and aborts
 one of the conflicting transactions (the transaction fails to commit
-with `-DER_RESTART`). The failed transaction then has to be restarted
+with `-DER_TX_RESTART`). The failed transaction then has to be restarted
 by the user/application.
 
 In the initial implementation, the transaction API does not support reading

--- a/src/control/cmd/dmg/pretty/pool.go
+++ b/src/control/cmd/dmg/pretty/pool.go
@@ -50,10 +50,10 @@ func PrintPoolQueryResponse(pqr *control.PoolQueryResp, out io.Writer, opts ...P
 	}
 	fmt.Fprintln(w, "Pool space info:")
 	if pqr.EnabledRanks != nil {
-		fmt.Fprintf(w, "- Enabled targets: %s\n", pqr.EnabledRanks)
+		fmt.Fprintf(w, "- Enabled ranks: %s\n", pqr.EnabledRanks)
 	}
 	if pqr.DisabledRanks != nil {
-		fmt.Fprintf(w, "- Disabled targets: %s\n", pqr.DisabledRanks)
+		fmt.Fprintf(w, "- Disabled ranks: %s\n", pqr.DisabledRanks)
 	}
 	fmt.Fprintf(w, "- Target(VOS) count:%d\n", pqr.ActiveTargets)
 	if pqr.TierStats != nil {

--- a/src/control/cmd/dmg/pretty/pool_test.go
+++ b/src/control/cmd/dmg/pretty/pool_test.go
@@ -112,7 +112,7 @@ Rebuild busy, 42 objs, 21 recs
 Pool %s, ntarget=2, disabled=1, leader=42, version=100, state=Degraded
 Pool layout out of date (1 < 2) -- see `+backtickStr+` for details.
 Pool space info:
-- Enabled targets: 0-2
+- Enabled ranks: 0-2
 - Target(VOS) count:1
 - Storage tier 0 (SCM):
   Total size: 2 B

--- a/src/control/cmd/dmg/pretty/pool_test.go
+++ b/src/control/cmd/dmg/pretty/pool_test.go
@@ -157,7 +157,7 @@ Rebuild busy, 42 objs, 21 recs
 Pool %s, ntarget=2, disabled=1, leader=42, version=100, state=Degraded
 Pool layout out of date (1 < 2) -- see `+backtickStr+` for details.
 Pool space info:
-- Disabled targets: 0-1,3
+- Disabled ranks: 0-1,3
 - Target(VOS) count:1
 - Storage tier 0 (SCM):
   Total size: 2 B
@@ -202,7 +202,7 @@ Rebuild busy, 42 objs, 21 recs
 Pool %s, ntarget=2, disabled=1, leader=42, version=100, state=Degraded
 Pool layout out of date (1 < 2) -- see `+backtickStr+` for details.
 Pool space info:
-- Disabled targets: 0-1,3
+- Disabled ranks: 0-1,3
 - Target(VOS) count:1
 - Storage tier 0 (SCM):
   Total size: 2 B


### PR DESCRIPTION
### Description

dmg pool query -e: reports ranks as targets

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
