### PR TITLE
DAOS-14010 vos: Ignore overwrite extents

### DIFF
--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -29,6 +29,8 @@
 			((addr)->ba_flags &= ~(BIO_FLAG_DEDUP_BUF))
 #define BIO_ADDR_IS_CORRUPTED(addr) ((addr)->ba_flags & BIO_FLAG_CORRUPTED)
 #define BIO_ADDR_SET_CORRUPTED(addr) ((addr)->ba_flags |= BIO_FLAG_CORRUPTED)
+#define BIO_ADDR_IS_CANCELLED(addr)  ((addr)->ba_flags & BIO_FLAG_CANCELLED)
+#define BIO_ADDR_SET_CANCELLED(addr) ((addr)->ba_flags |= BIO_FLAG_CANCELLED)
 
 /* Can support up to 16 flags for a BIO address */
 enum BIO_FLAG {
@@ -39,6 +41,8 @@ enum BIO_FLAG {
 	/* The address is a buffer for dedup verify */
 	BIO_FLAG_DEDUP_BUF = (1 << 2),
 	BIO_FLAG_CORRUPTED = (1 << 3),
+	/** Mark a bio_addr as cancelled, for convenience */
+	BIO_FLAG_CANCELLED = (1 << 4),
 };
 
 typedef struct {

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -103,8 +103,7 @@ struct dtx_handle {
 	/** The flags, see dtx_entry_flags. */
 	uint32_t			 dth_flags;
 	/** The count of reserved items in the dth_rsrvds array. */
-	uint16_t			 dth_rsrvd_cnt;
-	uint16_t			 dth_deferred_cnt;
+	uint32_t                         dth_rsrvd_cnt;
 	/** The total sub modifications count. */
 	uint16_t			 dth_modification_cnt;
 	/** Modification sequence in the distributed transaction. */
@@ -121,8 +120,8 @@ struct dtx_handle {
 	uint64_t			 dth_dkey_hash;
 
 	struct dtx_rsrvd_uint		 dth_rsrvd_inline;
-	struct dtx_rsrvd_uint		*dth_rsrvds;
-	void				**dth_deferred;
+	struct dtx_rsrvd_uint           *dth_rsrvds;
+	void                            *dth_current_rsrvd;
 	/* NVME extents to release */
 	d_list_t			 dth_deferred_nvme;
 	/* Committed or comittable DTX list */

--- a/src/vos/tests/evt_ctl.sh
+++ b/src/vos/tests/evt_ctl.sh
@@ -31,7 +31,7 @@ function word_set {
  -a 90-95@$np2:coffee	\
  -a 50-56@$n:scarlet	\
  -a 57-61@$n:witch		\
- -a 57-61@$n:witch		\
+ -a -57-61@$n:witch		\
  -a 96-99@$n:blue		\
  -a 78-82@$np2:hello	\
  -a 25-29@$np1:widow	\

--- a/src/vos/tests/pool_scrubbing_tests.c
+++ b/src/vos/tests/pool_scrubbing_tests.c
@@ -673,9 +673,9 @@ scrubbing_with_good_akey_then_bad_akey(void **state)
 	assert_success(sts_ctx_fetch(ctx, 1, TEST_IOD_SINGLE, "dkey", "akey", 1));
 	ctx->tsc_scrub_ctx.sc_pool_start_scrub.tv_sec -= 10;
 
-	sts_ctx_update(ctx, 1, TEST_IOD_SINGLE, "dkey", "akey", 1, true);
+	sts_ctx_update(ctx, 1, TEST_IOD_SINGLE, "dkey", "akey", 2, true);
 	sts_ctx_do_scrub(ctx);
-	assert_csum_error(sts_ctx_fetch(ctx, 1, TEST_IOD_SINGLE, "dkey", "akey", 1));
+	assert_csum_error(sts_ctx_fetch(ctx, 1, TEST_IOD_SINGLE, "dkey", "akey", 2));
 }
 
 static int

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -35,6 +35,7 @@ static bool			vts_nest_iterators;
  */
 char		last_dkey[UPDATE_DKEY_SIZE];
 char		last_akey[UPDATE_AKEY_SIZE];
+char                            last_value[UPDATE_BUF_SIZE];
 
 struct io_test_flag {
 	char			*tf_str;
@@ -827,12 +828,15 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 		if (arg->ta_flags & TF_OVERWRITE) {
 			memcpy(dkey_buf, last_dkey, arg->dkey_size);
 			memcpy(akey_buf, last_akey, arg->akey_size);
+			memcpy(update_buf, last_value, UPDATE_BUF_SIZE);
 		} else {
 			vts_key_gen(&dkey_buf[0], arg->dkey_size, true, arg);
 			memcpy(last_dkey, dkey_buf, arg->dkey_size);
 
 			vts_key_gen(&akey_buf[0], arg->akey_size, false, arg);
 			memcpy(last_akey, akey_buf, arg->akey_size);
+			dts_buf_render(update_buf, UPDATE_BUF_SIZE);
+			memcpy(last_value, update_buf, UPDATE_BUF_SIZE);
 		}
 
 		set_iov(&dkey, &dkey_buf[0],
@@ -840,7 +844,6 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 		set_iov(&akey, &akey_buf[0],
 			is_daos_obj_type_set(arg->otype, DAOS_OT_AKEY_UINT64));
 
-		dts_buf_render(update_buf, UPDATE_BUF_SIZE);
 		d_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
 		iod.iod_size = recx_size;
 		rex.rx_nr    = recx_nr;

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -816,12 +816,10 @@ simple_multi_update(void **state)
 			  strlen(overwrite[i]) + 1);
 	}
 
-	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 2, 0, 0, NULL, 0, NULL,
-			   NULL);
+	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 3, 0, 0, NULL, 0, NULL, NULL);
 	assert_rc_equal(rc, 0);
 
-	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0,
-			    0, &dkey, 2, iod, NULL, sgl);
+	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 2, 0, 0, &dkey, 2, iod, NULL, sgl);
 	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 2; i++) {
@@ -829,8 +827,7 @@ simple_multi_update(void **state)
 		d_iov_set(&sgl[i].sg_iovs[0], (void *)buf[i], sizeof(buf[i]));
 	}
 
-	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 1, 0, &dkey, 2,
-			   iod, sgl);
+	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 2, 0, &dkey, 2, iod, sgl);
 	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 2; i++) {

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2955,7 +2955,7 @@ vos_dtx_cleanup(struct dtx_handle *dth, bool unpin)
 
 	cont = vos_hdl2cont(dth->dth_coh);
 	/* This will abort the transaction and callback to vos_dtx_cleanup_internal(). */
-	vos_tx_end(cont, dth, NULL, NULL, true /* don't care */, NULL, -DER_CANCELED);
+	vos_tx_end(cont, dth, NULL, NULL, NULL, true /* don't care */, NULL, -DER_CANCELED);
 }
 
 int
@@ -3107,7 +3107,6 @@ int
 vos_dtx_rsrvd_init(struct dtx_handle *dth)
 {
 	dth->dth_rsrvd_cnt = 0;
-	dth->dth_deferred_cnt = 0;
 	D_INIT_LIST_HEAD(&dth->dth_deferred_nvme);
 
 	if (dth->dth_modification_cnt <= 1) {
@@ -3119,12 +3118,6 @@ vos_dtx_rsrvd_init(struct dtx_handle *dth)
 	if (dth->dth_rsrvds == NULL)
 		return -DER_NOMEM;
 
-	D_ALLOC_ARRAY(dth->dth_deferred, dth->dth_modification_cnt);
-	if (dth->dth_deferred == NULL) {
-		D_FREE(dth->dth_rsrvds);
-		return -DER_NOMEM;
-	}
-
 	return 0;
 }
 
@@ -3133,7 +3126,6 @@ vos_dtx_rsrvd_fini(struct dtx_handle *dth)
 {
 	if (dth->dth_rsrvds != NULL) {
 		D_ASSERT(d_list_empty(&dth->dth_deferred_nvme));
-		D_FREE(dth->dth_deferred);
 		if (dth->dth_rsrvds != &dth->dth_rsrvd_inline)
 			D_FREE(dth->dth_rsrvds);
 	}

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1263,8 +1263,9 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb);
  *
  * \param[in]	cont		the VOS container
  * \param[in]	dth_in		The dtx handle, if applicable
- * \param[in]	rsrvd_scmp	Pointer to reserved scm, will be consumed
- * \param[in]	nvme_exts	List of resreved nvme extents
+ * \param[in]	rsrvd_actp	Pointer to reserved scm, will be consumed
+ * \param[in]	nvme_exts	List of reserved nvme extents
+ * \param[in]	cancel_exts	List of reserved nvme extents to cancel
  * \param[in]	started		Only applies when dth_in is invalid,
  *				indicates if vos_tx_begin was successful
  * \param[in]	biod		bio_desc for data I/O
@@ -1274,8 +1275,8 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm, bool is_sysdb);
  */
 int
 vos_tx_end(struct vos_container *cont, struct dtx_handle *dth_in,
-	   struct umem_rsrvd_act **rsrvd_actp, d_list_t *nvme_exts, bool started,
-	   struct bio_desc *biod, int err);
+	   struct umem_rsrvd_act **rsrvd_actp, d_list_t *nvme_exts, d_list_t *cancel_exts,
+	   bool started, struct bio_desc *biod, int err);
 
 /* vos_obj.c */
 int
@@ -1790,5 +1791,10 @@ vos_fake_anchor_create(daos_anchor_t *anchor)
 	memset(&anchor->da_buf[0], 0, sizeof(anchor->da_buf));
 	anchor->da_type = DAOS_ANCHOR_TYPE_HKEY;
 }
+
+/** Cancel the current allocation, assume overwrite is always the same */
+void
+vos_handle_overwrite(struct dtx_handle *dth, struct umem_instance *umm, bio_addr_t *addr,
+		     umem_off_t off);
 
 #endif /* __VOS_INTERNAL_H__ */

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -557,7 +557,7 @@ reset:
 	if (rc == 0)
 		vos_ts_set_wupdate(ts_set, epr.epr_hi);
 
-	rc = vos_tx_end(cont, dth, NULL, NULL, true, NULL, rc);
+	rc = vos_tx_end(cont, dth, NULL, NULL, NULL, true, NULL, rc);
 	if (dtx_is_valid_handle(dth)) {
 		if (rc == 0)
 			dth->dth_cos_done = 1;

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -658,11 +658,15 @@ svt_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	skey  = (struct vos_svt_key *)key_iov->iov_buf;
 	irec  = vos_rec2irec(tins, rec);
 
-	if (skey->sk_minor_epc <= irec->ir_minor_epc) {
+	if (skey->sk_minor_epc < irec->ir_minor_epc) {
 		/* This must be an overwrite by migration */
 		BIO_ADDR_SET_CANCELLED(&rbund->rb_biov->bi_addr);
 		return 0;
 	}
+
+	/** NB: let the overwrite happen when minor_epc is equal.  This is
+	 *  because SMD uses db_upsert which just writes at epoch 1.
+	 */
 
 	/* In the normal DTX case, a later minor epoch will actually overwrite
 	 * the value that is in the tree since the major epoch is the key.


### PR DESCRIPTION
DTX should reject updates from multiple sources that happen to get assigned the same epoch.  Therefore, let's simplify VOS a little and just skip updates that are same epoch overwrites.

Also, simplify dtx handle a little

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
