### PR TITLE
DAOS-623 build: Use leap-dnf Docker image (#13271)

### DIFF
--- a/site_scons/site_tools/doneapi.py
+++ b/site_scons/site_tools/doneapi.py
@@ -26,7 +26,7 @@ class DetectCompiler():
         sys.stdout.flush()
         for path in [root, binp, libp, include, icx]:
             if not os.path.exists(path):
-                print("oneapi compilter: %s doesn't exist" % path)
+                print("oneapi compiler: %s doesn't exist" % path)
                 return
         self.map = {'root': root,
                     'bin': binp,

--- a/site_scons/site_tools/doneapi.py
+++ b/site_scons/site_tools/doneapi.py
@@ -18,22 +18,19 @@ class DetectCompiler():
 
     def __init__(self):
         root = '/opt/intel/oneapi/compiler/latest'
-        binp = os.path.join(root, 'linux', 'bin')
-        libp = os.path.join(root, 'linux', 'lib')
-        include = os.path.join(root, 'linux', 'include')
-        binarch = os.path.join(binp, 'intel64')
-        libarch = os.path.join(root, 'linux', 'compiler', 'lib', 'intel64_lin')
+        binp = os.path.join(root, 'bin')
+        libp = os.path.join(root, 'lib')
+        include = os.path.join(root, 'include')
         icx = os.path.join(binp, 'icx')
         self.map = {}
         sys.stdout.flush()
-        for path in [root, binp, libp, binarch, libarch, include, icx]:
+        for path in [root, binp, libp, include, icx]:
             if not os.path.exists(path):
+                print("oneapi compilter: %s doesn't exist" % path)
                 return
         self.map = {'root': root,
                     'bin': binp,
                     'lib': libp,
-                    'binarch': binarch,
-                    'libarch': libarch,
                     'include': include,
                     'icx': icx}
 
@@ -53,8 +50,8 @@ def generate(env):
     env['INTEL_C_COMPILER_TOP'] = detector['root']
     paths = {'INCLUDE': 'include',
              'LIB': 'libarch',
-             'PATH': 'binarch',
-             'LD_LIBRARY_PATH': 'libarch'}
+             'PATH': 'bin',
+             'LD_LIBRARY_PATH': 'lib'}
     for (key, value) in paths.items():
         env.PrependENVPath(key, detector[value])
     env.PrependENVPath("PATH", detector["bin"])

--- a/site_scons/site_tools/doneapi.py
+++ b/site_scons/site_tools/doneapi.py
@@ -26,7 +26,7 @@ class DetectCompiler():
         sys.stdout.flush()
         for path in [root, binp, libp, include, icx]:
             if not os.path.exists(path):
-                print("oneapi compiler: %s doesn't exist" % path)
+                print(f"oneapi compiler: {path} doesn't exist")
                 return
         self.map = {'root': root,
                     'bin': binp,

--- a/utils/docker/Dockerfile.el.8
+++ b/utils/docker/Dockerfile.el.8
@@ -6,8 +6,9 @@
 #
 
 # Pull base image
-ARG BASE_DISTRO=rockylinux/rockylinux:8
-FROM $BASE_DISTRO
+ARG POINT_RELEASE=
+ARG BASE_DISTRO=rockylinux/rockylinux:8$POINT_RELEASE
+FROM $BASE_DISTRO as basic
 LABEL maintainer="daos@daos.groups.io"
 # Needed for later use of BASE_DISTRO
 ARG BASE_DISTRO
@@ -22,9 +23,17 @@ ARG REPOS
 COPY ./utils/scripts/install-el8.sh /tmp/install.sh
 # script to setup local repo if available
 COPY ./utils/scripts/helpers/repo-helper-el8.sh /tmp/repo-helper.sh
-RUN set -e;                                         \
-    chmod +x /tmp/repo-helper.sh /tmp/install.sh && \
-    /tmp/repo-helper.sh
+
+RUN chmod +x /tmp/repo-helper.sh /tmp/install.sh && \
+    /tmp/repo-helper.sh &&                          \
+    rm -f /tmp/repo-helper.sh
+
+FROM basic
+# Install OS updates and package.  Include basic tools and daos dependencies
+RUN dnf upgrade &&        \
+    /tmp/install.sh &&    \
+    dnf clean all &&      \
+    rm -f /tmp/install.sh
 
 # Add DAOS users
 ARG UID=1000

--- a/utils/docker/Dockerfile.el.9
+++ b/utils/docker/Dockerfile.el.9
@@ -6,65 +6,34 @@
 #
 
 # Pull base image
-ARG BASE_DISTRO=almalinux:9
-FROM $BASE_DISTRO
+ARG POINT_RELEASE=
+ARG BASE_DISTRO=almalinux:9$POINT_RELEASE
+FROM $BASE_DISTRO as basic
 LABEL maintainer="daos@daos.groups.io"
+# Needed for later use of BASE_DISTRO
+ARG BASE_DISTRO
 
 # Intermittent cache-bust.  Used to reduce load on the actual CB1 later.
 ARG CB0
 
-# Use local repo server if present
 ARG REPO_FILE_URL
-RUN set -e;                                                      \
-    if [ -n "$REPO_FILE_URL" ]; then                             \
-        cd /etc/yum.repos.d/ &&                                  \
-        curl -k -f -o daos_ci-el9-artifactory.repo.tmp           \
-             "$REPO_FILE_URL"daos_ci-el9-artifactory.repo &&     \
-        for file in *.repo; do                                   \
-            true > $file;                                        \
-        done;                                                    \
-        mv daos_ci-el9-artifactory.repo{.tmp,};                  \
-    fi;                                                          \
-    dnf --assumeyes --disablerepo \*epel\* install dnf-plugins-core;     \
-    dnf config-manager --save --setopt=assumeyes=True;           \
-    dnf config-manager --save --setopt=install_weak_deps=False;  \
-    dnf --disablerepo \*epel\* install epel-release;             \
-    dnf install epel-release;                                    \
-    if [ -n "$REPO_FILE_URL" ]; then                             \
-        PT_REPO=daos_ci-rocky8-crb-artifactory;                  \
-    else                                                         \
-        PT_REPO=crb;                                             \
-    fi;                                                          \
-    dnf -y config-manager --enable $PT_REPO;                     \
-    dnf -y clean all
-
 ARG JENKINS_URL
 ARG REPOS
-RUN for repo in $REPOS; do                                                \
-        branch="master";                                                  \
-        build_number="lastSuccessfulBuild";                               \
-        if [[ $repo = *@* ]]; then                                        \
-            branch="${repo#*@}";                                          \
-            repo="${repo%@*}";                                            \
-            if [[ $branch = *:* ]]; then                                  \
-                build_number="${branch#*:}";                              \
-                branch="${branch%:*}";                                    \
-            fi;                                                           \
-        fi;                                                               \
-        echo -e "[$repo:$branch:$build_number]\n\
-name=$repo:$branch:$build_number\n\
-baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/el9/\n\
-enabled=1\n\
-gpgcheck=False\n" >> /etc/yum.repos.d/$repo:$branch:$build_number.repo;   \
-        cat /etc/yum.repos.d/$repo:$branch:$build_number.repo; \
-    done
-
-# Install OS updates and package.  Include basic tools and daos dependencies
+# script to install OS updates basic tools and daos dependencies
 COPY ./utils/scripts/install-el9.sh /tmp/install.sh
-RUN chmod +x /tmp/install.sh && dnf upgrade && /tmp/install.sh && dnf clean all && \
-    rm -f /tmp/install.sh
+# script to setup local repo if available
+COPY ./utils/scripts/helpers/repo-helper-el9.sh /tmp/repo-helper.sh
 
-ARG UID=1000
+RUN chmod +x /tmp/repo-helper.sh /tmp/install.sh && \
+    /tmp/repo-helper.sh &&                          \
+    rm -f /tmp/repo-helper.sh
+
+FROM basic
+# Install OS updates and package.  Include basic tools and daos dependencies
+RUN dnf upgrade &&        \
+    /tmp/install.sh &&    \
+    dnf clean all &&      \
+    rm -f /tmp/install.sh
 
 # Add DAOS users
 ARG UID=1000
@@ -113,9 +82,9 @@ ARG DAOS_TARGET_TYPE=release
 # src hasn't changed then this won't do anything, but if it has then we want to
 # ensure that latest dependencies are used.
 USER root:root
-RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                       \
+RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                               \
         dnf upgrade --exclude=spdk,spdk-devel,dpdk-devel,dpdk,mercury-devel,mercury && \
-        dnf clean all;                                                         \
+        dnf clean all;                                                                 \
     }
 USER daos_server:daos_server
 

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -6,11 +6,12 @@
 #
 
 # Pull base image
-ARG BASE_DISTRO=opensuse/leap:15.5
-FROM $BASE_DISTRO
+ARG POINT_RELEASE=
+ARG BASE_DISTRO=registry.opensuse.org/opensuse/leap-dnf:15$POINT_RELEASE
+FROM $BASE_DISTRO as basic
+LABEL maintainer="daos@daos.groups.io"
 # Needed for later use of BASE_DISTRO
 ARG BASE_DISTRO
-LABEL maintainer="daos@daos.groups.io"
 
 # Intermittent cache-bust.  Used to reduce load on the actual CB1 later.
 ARG CB0
@@ -22,9 +23,17 @@ ARG REPOS
 COPY ./utils/scripts/install-leap15.sh /tmp/install.sh
 # script to setup local repo if available
 COPY ./utils/scripts/helpers/repo-helper-leap15.sh /tmp/repo-helper.sh
-RUN set -e;                                         \
-    chmod +x /tmp/repo-helper.sh /tmp/install.sh && \
-    /tmp/repo-helper.sh
+
+RUN chmod +x /tmp/repo-helper.sh /tmp/install.sh && \
+    /tmp/repo-helper.sh &&                          \
+    rm -f /tmp/repo-helper.sh
+
+FROM basic
+# Install OS updates and package.  Include basic tools and daos dependencies
+RUN dnf upgrade &&        \
+    /tmp/install.sh &&    \
+    dnf clean all &&      \
+    rm -f /tmp/install.sh
 
 # Add DAOS users
 ARG UID=1000
@@ -74,10 +83,9 @@ ARG DAOS_TARGET_TYPE=release
 # ensure that latest dependencies are used.
 # The dnf upgrade can add or re-enable distro repositories.
 USER root:root
-RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                                     \
-        dnf upgrade                                                                          \
-            --exclude=fuse,fuse-libs,fuse-devel,libraft0,raft-devel,mercury,mercury-devel && \
-        dnf clean all;                                                                       \
+RUN [ "$DAOS_DEPS_BUILD" != "yes" ] || {                                                             \
+        dnf upgrade --exclude=fuse,fuse-libs,fuse-devel,libraft0,raft-devel,mercury,mercury-devel && \
+        dnf clean all;                                                                               \
     }
 USER daos_server:daos_server
 

--- a/utils/scripts/helpers/repo-helper-el9.sh
+++ b/utils/scripts/helpers/repo-helper-el9.sh
@@ -66,13 +66,13 @@ dnf config-manager --save --setopt=install_weak_deps=False
 if [ ! -f /etc/fedora-release ]; then
     dnf --disablerepo \*epel\* install epel-release
     if [ -n "$REPO_FILE_URL" ]; then
-        PT_REPO="daos_ci-${DISTRO}${MAJOR_VER}-powertools-artifactory"
+        PT_REPO="daos_ci-${DISTRO}${MAJOR_VER}-crb-artifactory"
         true > /etc/yum.repos.d/epel.repo
         true > /etc/yum.repos.d/epel-modular.repo
         sed "s/^mirrorlist_expire=0*/mirrorlist_expire=99999999/" \
             -i /etc/dnf/dnf.conf
     else
-        PT_REPO=powertools
+        PT_REPO=crb
     fi
     dnf install epel-release
     dnf config-manager --enable $PT_REPO

--- a/utils/scripts/helpers/repo-helper-leap15.sh
+++ b/utils/scripts/helpers/repo-helper-leap15.sh
@@ -33,33 +33,43 @@ disable_repos () {
     fi
 }
 
+# Use local repo server if present
 install_curl() {
 
     if command -v curl; then
         return
     fi
 
-    zypper mr --all --disable
-    zypper addrepo                                                                           \
-        "${REPO_FILE_URL%/*/}/opensuse-proxy/distribution/leap/${BASE_DISTRO##*:}/repo/oss/" \
-          temp_opensuse_oss_proxy
-    zypper --non-interactive install curl
-    zypper removerepo temp_opensuse_oss_proxy
+    if command -v dnf; then
+        dnf -y install curl
+        return
+    fi
+
+    if command -v zypper; then
+        zypper mr --all --disable
+        zypper addrepo                                                                           \
+            "${REPO_FILE_URL%/*/}/opensuse-proxy/distribution/leap/${BASE_DISTRO##*:}/repo/oss/" \
+              temp_opensuse_oss_proxy
+        zypper --non-interactive install curl
+        zypper removerepo temp_opensuse_oss_proxy
+    fi
 }
 
 install_dnf() {
 
     if command -v dnf; then
+        dnf -y install dnf-plugins-core
         return
     fi
 
-    zypper mr --all --disable
-    zypper addrepo                                                                           \
-        "${REPO_FILE_URL%/*/}/opensuse-proxy/distribution/leap/${BASE_DISTRO##*:}/repo/oss/" \
-          temp_opensuse_oss_proxy
-    zypper --non-interactive install dnf{,-plugins-core}
+    # DO NOT do a "zypper mr --all --disable" here as it rewrites the repo
+    # files, removing options that zypper doesn't use but dnf does
+    if ! zypper --non-interactive --gpg-auto-import-keys install dnf{,-plugins-core}; then
+        rc=${PIPESTATUS[0]}
+        echo "Got an $rc error installing dnf?" >&2
+        exit "$rc"
+    fi
     zypper removerepo temp_opensuse_oss_proxy
-    zypper mr --all --enable
 }
 
 # Use local repo server if present
@@ -69,26 +79,41 @@ install_dnf() {
 
 MAJOR_VER="${BASE_DISTRO##*:}"
 MAJOR_VER="${MAJOR_VER%%.*}"
+if command -v dnf; then
+    repos_dir=/etc/yum.repos.d/
+else
+    repos_dir=/etc/zypp/repos.d/
+fi
 if [ -n "$REPO_FILE_URL" ]; then
     install_curl
-    mkdir -p /etc/zypp/repos.d
-    pushd /etc/zypp/repos.d/
-    curl -k -f -o daos_ci-leap$MAJOR_VER-artifactory.repo        \
-         "$REPO_FILE_URL"daos_ci-leap$MAJOR_VER-artifactory.repo
-    disable_repos /etc/zypp/repos.d/
+    mkdir -p "$repos_dir"
+    pushd "$repos_dir"
+    curl -k -f -o daos_ci-leap"$MAJOR_VER"-artifactory.repo        \
+         "$REPO_FILE_URL"daos_ci-leap"$MAJOR_VER"-artifactory.repo
+    disable_repos "$repos_dir"
     popd
     install_dnf
 else
-    zypper --non-interactive --gpg-auto-import-keys install \
-        dnf dnf-plugins-core
+    if ! command -v dnf; then
+        zypper --non-interactive --gpg-auto-import-keys install \
+            dnf dnf-plugins-core
+    fi
 fi
-mkdir -p /etc/dnf/repos.d
-pushd /etc/zypp/repos.d/
-for file in *.repo; do
-    sed -e '/type=NONE/d' < "$file" > "/etc/dnf/repos.d/$file"
-done
-popd
-zypper --non-interactive clean --all
+if [ ! -d /etc/yum.repos.d/ ]; then
+    mkdir -p /etc/yum.repos.d/
+    pushd "$repos_dir"
+    for file in *.repo; do
+        if [ ! -s "$file" ]; then
+            continue
+        fi
+        echo "Fixing $file"
+        sed -e '/type=NONE/d' < "$file" > "/etc/yum.repos.d/$file"
+    done
+    popd
+fi
+if command -v zypper; then
+    zypper --non-interactive clean --all
+fi
 dnf config-manager --save --setopt=assumeyes=True
 dnf config-manager --save --setopt=install_weak_deps=False
 
@@ -110,18 +135,12 @@ for repo in $REPOS; do
 name=$repo:$branch:$build_number\n\
 baseurl=${JENKINS_URL}$daos_base$repo/job/$branch/$build_number$artifacts\n\
 enabled=1\n\
-gpgcheck=False\n" >> /etc/dnf/repos.d/$repo:$branch:$build_number.repo
-    cat /etc/dnf/repos.d/$repo:$branch:$build_number.repo
+gpgcheck=False\n" >> $repos_dir$repo:$branch:$build_number.repo
+    cat $repos_dir$repo:$branch:$build_number.repo
     save_repos+=("$repo:$branch:$build_number")
 done
 
-if [ -e /tmp/install.sh ]; then
-    dnf upgrade
-    disable_repos /etc/dnf/repos.d/ "${save_repos[@]}"
-    /tmp/install.sh
-    dnf clean all
-    rm -f /tmp/install.sh
-fi
+disable_repos $repos_dir "${save_repos[@]}"
 
 if [ -e /etc/profile.d/lmod.sh ]; then
     if ! grep "MODULEPATH=.*/usr/share/modules" /etc/profile.d/lmod.sh; then

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -24,8 +24,8 @@ dnf --nodocs install \
     gcc \
     gcc-c++ \
     git \
-    go1.18 \
-    go1.18-race \
+    go \
+    go-race \
     graphviz \
     gzip \
     hwloc-devel \


### PR DESCRIPTION
Rather than using zypper to bootstrap dnf, use an image that has dnf
built in.

Remove version from go packages on Leap 15 to ensure we are alwys using
the latest version availalble for SDL requirements.

Add targets to our EL8 and Leap 15 Dockerfiles to allow building more
basic containers that are just configured to use our Artifactory repo
server.  This can be utilized by adding "--target basic" to your docker/
podman build command.

Sync EL9 Dockerfile to EL8 and Leap15 format.
