### PR TITLE
DAOS-14573 bio: Skip role assignment for hotplugged bdev (#13280)

### DIFF
--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -699,20 +699,6 @@ led_device_action(void *ctx, struct spdk_pci_device *pci_device)
 	if (opts->finished)
 		return;
 
-	pci_dev_type = spdk_pci_device_get_type(pci_device);
-	if (pci_dev_type == NULL) {
-		D_ERROR("nil pci device type returned\n");
-		opts->status = -DER_MISC;
-		return;
-	}
-
-	if (strncmp(pci_dev_type, BIO_DEV_TYPE_VMD, strlen(BIO_DEV_TYPE_VMD)) != 0) {
-		D_DEBUG(DB_MGMT, "Found non-VMD device type (%s), can't manage LEDs\n",
-			pci_dev_type);
-		opts->status = -DER_NOSYS;
-		return;
-	}
-
 	if (!opts->all_devices) {
 		if (spdk_pci_addr_compare(&opts->pci_addr, &pci_device->addr) != 0)
 			return;
@@ -723,6 +709,20 @@ led_device_action(void *ctx, struct spdk_pci_device *pci_device)
 	if (rc != 0) {
 		D_ERROR("Failed to format VMD's PCI address (%s)\n", spdk_strerror(-rc));
 		opts->status = -DER_INVAL;
+		return;
+	}
+
+	pci_dev_type = spdk_pci_device_get_type(pci_device);
+	if (pci_dev_type == NULL) {
+		D_ERROR("nil pci device type returned\n");
+		opts->status = -DER_MISC;
+		return;
+	}
+
+	if (strncmp(pci_dev_type, BIO_DEV_TYPE_VMD, strlen(BIO_DEV_TYPE_VMD)) != 0) {
+		D_DEBUG(DB_MGMT, "Found non-VMD device type (%s:%s), can't manage LED\n",
+			pci_dev_type, addr_buf);
+		opts->status = -DER_NOSYS;
 		return;
 	}
 

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -815,7 +815,7 @@ bdev_name2roles(const char *name)
  * xstream for this device hasn't been established yet.
  */
 static int
-create_bio_bdev(struct bio_xs_context *ctxt, const char *bdev_name,
+create_bio_bdev(struct bio_xs_context *ctxt, const char *bdev_name, unsigned int roles,
 		struct bio_bdev **dev_out)
 {
 	struct bio_bdev			*d_bdev, *old_dev;
@@ -843,13 +843,8 @@ create_bio_bdev(struct bio_xs_context *ctxt, const char *bdev_name,
 	}
 
 	D_INIT_LIST_HEAD(&d_bdev->bb_link);
-	rc = bdev_name2roles(bdev_name);
-	if (rc < 0) {
-		D_ERROR("Failed to get role from bdev name, "DF_RC"\n", DP_RC(rc));
-		goto error;
-	}
 
-	d_bdev->bb_roles = rc;
+	d_bdev->bb_roles = roles;
 	D_STRNDUP(d_bdev->bb_name, bdev_name, strlen(bdev_name));
 	if (d_bdev->bb_name == NULL) {
 		D_GOTO(error, rc = -DER_NOMEM);
@@ -958,6 +953,7 @@ init_bio_bdevs(struct bio_xs_context *ctxt)
 {
 	struct bio_bdev  *d_bdev;
 	struct spdk_bdev *bdev;
+	const char       *bdev_name;
 	int rc = 0;
 
 	D_ASSERT(!is_server_started());
@@ -966,12 +962,20 @@ init_bio_bdevs(struct bio_xs_context *ctxt)
 		rc = -DER_NONEXIST;
 	}
 
-	for (bdev = spdk_bdev_first(); bdev != NULL;
-	     bdev = spdk_bdev_next(bdev)) {
+	for (bdev = spdk_bdev_first(); bdev != NULL; bdev = spdk_bdev_next(bdev)) {
 		if (nvme_glb.bd_bdev_class != get_bdev_type(bdev))
 			continue;
 
-		rc = create_bio_bdev(ctxt, spdk_bdev_get_name(bdev), NULL);
+		bdev_name = spdk_bdev_get_name(bdev);
+
+		rc = bdev_name2roles(bdev_name);
+		if (rc < 0) {
+			D_ERROR("Failed to get role from bdev name '%s', " DF_RC "\n", bdev_name,
+				DP_RC(rc));
+			return rc;
+		}
+
+		rc = create_bio_bdev(ctxt, bdev_name, rc, NULL);
 		if (rc)
 			return rc;
 	}
@@ -1773,6 +1777,8 @@ scan_bio_bdevs(struct bio_xs_context *ctxt, uint64_t now)
 	struct bio_blobstore	*bbs;
 	struct bio_bdev		*d_bdev, *tmp;
 	struct spdk_bdev	*bdev;
+	const char              *bdev_name;
+	unsigned int             roles       = 0;
 	static uint64_t		 scan_period = NVME_MONITOR_PERIOD;
 	int			 rc;
 
@@ -1780,28 +1786,33 @@ scan_bio_bdevs(struct bio_xs_context *ctxt, uint64_t now)
 		return;
 
 	/* Iterate SPDK bdevs to detect hot plugged device */
-	for (bdev = spdk_bdev_first(); bdev != NULL;
-	     bdev = spdk_bdev_next(bdev)) {
+	for (bdev = spdk_bdev_first(); bdev != NULL; bdev = spdk_bdev_next(bdev)) {
 		if (nvme_glb.bd_bdev_class != get_bdev_type(bdev))
 			continue;
 
-		d_bdev = lookup_dev_by_name(spdk_bdev_get_name(bdev));
+		bdev_name = spdk_bdev_get_name(bdev);
+
+		d_bdev = lookup_dev_by_name(bdev_name);
 		if (d_bdev != NULL)
 			continue;
 
-		D_INFO("Detected hot plugged device %s\n",
-		       spdk_bdev_get_name(bdev));
+		D_INFO("Detected hot plugged device %s\n", bdev_name);
 		/* Print a console message */
-		D_PRINT("Detected hot plugged device %s\n",
-			spdk_bdev_get_name(bdev));
+		D_PRINT("Detected hot plugged device %s\n", bdev_name);
 
 		scan_period = 0;
 
-		/* don't support hot plug for sys device yet */
-		rc = create_bio_bdev(ctxt, spdk_bdev_get_name(bdev), &d_bdev);
+		/*
+		 * Assign default roles based on operating mode (MD-on-SSD or PMem), roles will
+		 * subsequently be updated based on "old" device on "replace".
+		 */
+
+		if (bio_nvme_configured(SMD_DEV_TYPE_META))
+			roles = NVME_ROLE_DATA;
+
+		rc = create_bio_bdev(ctxt, bdev_name, roles, &d_bdev);
 		if (rc) {
-			D_ERROR("Failed to init hot plugged device %s\n",
-				spdk_bdev_get_name(bdev));
+			D_ERROR("Failed to init hot plugged device %s\n", bdev_name);
 			break;
 		}
 


### PR DESCRIPTION
In VMD mode with PMem SCM, hotplug add event (triggered through SPDK
rpc in engine) was not resulting in bdev being reinstated in DAOS. The
cause was a regression related to MD-on-SSD code changes where role
could not be decoded from bdev_name. In the case where SPDK is being
initialised through daos_nvme.conf, role info is encoded into the name
whereas during hotplug scanning, the name is generic and doesn't
include the role info.

Fix by passing roles into create_bio_bdev and decode as before for
init case but use a default value for scan/hotplug case (as the
bdev_name doesn't have role info). In the latter scenario make default
role assignment consistent with operating mode (unset for PMem and
DATA for MD-on-SSD).

Also fix LED reporting by performing pci address match before checking
type.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
