### PR TITLE
DAOS-14537 control: Re-create PMem regions even if state cannot be de…

### DIFF
--- a/src/control/server/storage/scm/ipmctl_region.go
+++ b/src/control/server/storage/scm/ipmctl_region.go
@@ -162,10 +162,6 @@ var (
 		BinaryName: ipmctlName,
 		Args:       []string{"create", "-f", "-goal", "PersistentMemoryType=AppDirect"},
 	}
-	cmdRemoveRegions = pmemCmd{
-		BinaryName: ipmctlName,
-		Args:       []string{"create", "-f", "-goal", "MemoryMode=100"},
-	}
 	cmdDeleteGoals = pmemCmd{
 		BinaryName: ipmctlName,
 		Args:       []string{"delete", "-goal"},
@@ -264,16 +260,6 @@ func (cr *cmdRunner) createRegions(sockID int) error {
 	cr.log.Debug("set interleaved appdirect goal to create regions")
 
 	_, err := cr.runRegionCmd(sockID, cmdCreateRegions)
-	return err
-}
-
-func (cr *cmdRunner) removeRegions(sockID int) error {
-	if err := cr.checkIpmctl(badIpmctlVers); err != nil {
-		return errors.WithMessage(err, "checkIpmctl")
-	}
-	cr.log.Debug("set memory mode goal to remove regions")
-
-	_, err := cr.runRegionCmd(sockID, cmdRemoveRegions)
 	return err
 }
 

--- a/src/control/server/storage/scm/ipmctl_test.go
+++ b/src/control/server/storage/scm/ipmctl_test.go
@@ -766,13 +766,20 @@ func TestIpmctl_prepReset(t *testing.T) {
 				cmdShowIpmctlVersion, mockCmdShowRegionsWithSock(1),
 			},
 		},
-		"get pmem state fails": {
+		"get pmem state fails; continue to remove regions": {
 			runOut: []string{
-				verStr, mockXMLRegions(t, "same-sock"),
+				verStr, mockXMLRegions(t, "same-sock"), "", "",
 			},
-			expErr: errors.New("multiple regions assigned to the same socket"),
+			expPrepResp: &storage.ScmPrepareResponse{
+				Namespaces: storage.ScmNamespaces{},
+				Socket: &storage.ScmSocketState{
+					State: storage.ScmUnknownMode,
+				},
+				RebootRequired: true,
+			},
 			expCalls: []pmemCmd{
-				cmdShowIpmctlVersion, cmdShowRegions,
+				cmdShowIpmctlVersion, cmdShowRegions, cmdDeleteGoals,
+				cmdCreateRegions,
 			},
 		},
 		"delete goals fails": {
@@ -833,7 +840,7 @@ func TestIpmctl_prepReset(t *testing.T) {
 			},
 			expCalls: []pmemCmd{
 				cmdShowIpmctlVersion, cmdShowRegions, cmdDeleteGoals,
-				cmdRemoveRegions,
+				cmdCreateRegions,
 			},
 		},
 		"remove regions; with namespaces": {
@@ -857,7 +864,7 @@ func TestIpmctl_prepReset(t *testing.T) {
 				mockCmdDestroyNamespace("namespace0.0"),
 				mockCmdDisableNamespace("namespace1.0"),
 				mockCmdDestroyNamespace("namespace1.0"),
-				cmdRemoveRegions,
+				cmdCreateRegions,
 			},
 		},
 	} {


### PR DESCRIPTION
…termined (#13213)

In cases where errors with PMem causes region socket affinity problems
proceed to remove regions despite errors reported when evaluating PMem
state. Log failure to NOTICE when state cannot be evaluated.

Change daos_server scm reset behaviour to re-create the AppDirect goal
rather than changing the resource allocation to MemoryMode as before.
Re-setting AppDirect mode resolves the most common situations where
previously un-healthy modules have been replaced. There aren't any
clearly identified benefits of resetting the resource allocation to
MemoryMode.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
