### PR TITLE
DAOS-14586 cart: failout when forward corpc hit failure

### DIFF
--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -464,12 +464,16 @@ struct crt_corpc_ops chk_pool_start_co_ops = {
 };
 
 static inline int
-chk_co_rpc_prepare(d_rank_list_t *rank_list, crt_opcode_t opc, crt_rpc_t **req)
+chk_co_rpc_prepare(d_rank_list_t *rank_list, crt_opcode_t opc, crt_rpc_t **req, bool failout)
 {
+	uint32_t	flags = CRT_RPC_FLAG_FILTER_INVERT;
+
+	if (failout)
+		flags |= CRT_RPC_FLAG_CO_FAILOUT;
+
 	return crt_corpc_req_create(dss_get_module_info()->dmi_ctx, NULL, rank_list,
 				    DAOS_RPC_OPCODE(opc, DAOS_CHK_MODULE, DAOS_CHK_VERSION),
-				    NULL, NULL, CRT_RPC_FLAG_FILTER_INVERT,
-				    crt_tree_topo(CRT_TREE_KNOMIAL, 32), req);
+				    NULL, NULL, flags, crt_tree_topo(CRT_TREE_KNOMIAL, 32), req);
 }
 
 static inline int
@@ -500,7 +504,7 @@ chk_start_remote(d_rank_list_t *rank_list, uint64_t gen, uint32_t rank_nr, d_ran
 	int				 rc1;
 	int				 i;
 
-	rc = chk_co_rpc_prepare(rank_list, CHK_START, &req);
+	rc = chk_co_rpc_prepare(rank_list, CHK_START, &req, true);
 	if (rc != 0)
 		goto out;
 
@@ -584,7 +588,7 @@ chk_stop_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t pool
 	int				 rc;
 	int				 i;
 
-	rc = chk_co_rpc_prepare(rank_list, CHK_STOP, &req);
+	rc = chk_co_rpc_prepare(rank_list, CHK_STOP, &req, false);
 	if (rc != 0)
 		goto out;
 
@@ -644,7 +648,7 @@ chk_query_remote(d_rank_list_t *rank_list, uint64_t gen, int pool_nr, uuid_t poo
 	struct chk_query_out		*cqo = NULL;
 	int				 rc;
 
-	rc = chk_co_rpc_prepare(rank_list, CHK_QUERY, &req);
+	rc = chk_co_rpc_prepare(rank_list, CHK_QUERY, &req, true);
 	if (rc != 0)
 		goto out;
 
@@ -695,7 +699,7 @@ chk_mark_remote(d_rank_list_t *rank_list, uint64_t gen, d_rank_t rank, uint32_t 
 	struct chk_mark_out	*cmo;
 	int			 rc;
 
-	rc = chk_co_rpc_prepare(rank_list, CHK_MARK, &req);
+	rc = chk_co_rpc_prepare(rank_list, CHK_MARK, &req, false);
 	if (rc != 0)
 		goto out;
 
@@ -732,7 +736,7 @@ chk_act_remote(d_rank_list_t *rank_list, uint64_t gen, uint64_t seq, uint32_t cl
 	int			 rc;
 
 	if (for_all)
-		rc = chk_co_rpc_prepare(rank_list, CHK_ACT, &req);
+		rc = chk_co_rpc_prepare(rank_list, CHK_ACT, &req, false);
 	else
 		rc = chk_sg_rpc_prepare(rank, CHK_ACT, &req);
 
@@ -826,7 +830,7 @@ chk_pool_start_remote(d_rank_list_t *rank_list, uint64_t gen, uuid_t uuid, uint3
 	struct chk_pool_start_out	*cpso;
 	int				 rc;
 
-	rc = chk_co_rpc_prepare(rank_list, CHK_POOL_START, &req);
+	rc = chk_co_rpc_prepare(rank_list, CHK_POOL_START, &req, true);
 	if (rc != 0)
 		goto out;
 

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -182,7 +182,9 @@ typedef void *crt_bulk_array_t; /**< abstract bulk array handle */
 /** RPC flags enumeration */
 enum crt_rpc_flags {
 	/** send CORPC to filter_ranks only */
-	CRT_RPC_FLAG_FILTER_INVERT	= (1U << 1)
+	CRT_RPC_FLAG_FILTER_INVERT	= (1U << 1),
+	/** Do not invoke RPC handler on local node when fail to forward corpc to children. */
+	CRT_RPC_FLAG_CO_FAILOUT		= (1U << 2),
 };
 
 struct crt_rpc;


### PR DESCRIPTION
For some corpc sponsor, some failures, such as -DER_GRPVER, are not acceptable when forward corpc to children. When hit related failure, the corpc sponsor may do cleanup and may retry. Under such case, we should skip the RPC handling on current local node, instead, we can directly return the failure to the caller.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
