### PR TITLE
DAOS-14639 dfuse: Do not allow security. xattr to be set.

### DIFF
--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -447,6 +447,9 @@ err:
 	DFUSE_REPLY_ERR_RAW(dfuse_info, req, rc);
 }
 
+/* Do not allow security xattrs to be set or read, see DAOS-14639 */
+#define XATTR_SEC "security."
+
 void
 df_ll_setxattr(fuse_req_t req, fuse_ino_t ino, const char *name, const char *value, size_t size,
 	       int flags)
@@ -459,6 +462,9 @@ df_ll_setxattr(fuse_req_t req, fuse_ino_t ino, const char *name, const char *val
 	if (strncmp(name, DFUSE_XATTR_PREFIX, sizeof(DFUSE_XATTR_PREFIX) - 1) == 0) {
 		D_GOTO(err, rc = EPERM);
 	}
+
+	if (strncmp(name, XATTR_SEC, sizeof(XATTR_SEC) - 1) == 0)
+		D_GOTO(err, rc = ENODATA);
 
 	inode = dfuse_inode_lookup(dfuse_info, ino);
 	if (!inode) {
@@ -487,6 +493,9 @@ df_ll_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name, size_t size)
 	struct dfuse_info        *dfuse_info = fuse_req_userdata(req);
 	struct dfuse_inode_entry *inode;
 	int                       rc;
+
+	if (strncmp(name, XATTR_SEC, sizeof(XATTR_SEC) - 1) == 0)
+		D_GOTO(err, rc = ENODATA);
 
 	inode = dfuse_inode_lookup(dfuse_info, ino);
 	if (!inode) {

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -216,7 +216,9 @@ class DaosBuild(DfuseTestBase):
                 'daos filesystem query {}'.format(mount_dir),
                 'daos filesystem evict {}'.format(build_dir),
                 'daos filesystem query {}'.format(mount_dir),
-                'scons -C {} --jobs {}'.format(build_dir, intercept_jobs)]
+                'scons -C {} --jobs {}'.format(build_dir, intercept_jobs),
+                'scons -C {} --jobs {} install'.format(build_dir, intercept_jobs),
+                'daos filesystem query {}'.format(mount_dir)]
         for cmd in cmds:
             command = '{};{}'.format(preload_cmd, cmd)
             # Use a short timeout for most commands, but vary the build timeout based on dfuse mode.


### PR DESCRIPTION
fuse will call this often to read non-existent xattrs for every write request
so short-circuit these to avoid server round-trips.

Required-githooks: true
Test-tag: dfuse

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
