### PR TITLE
DAOS-12433 csum: Scrubber Lazy to Timed Mode Fix

### DIFF
--- a/src/vos/tests/pool_scrubbing_tests.c
+++ b/src/vos/tests/pool_scrubbing_tests.c
@@ -881,6 +881,84 @@ multiple_overlapping_extents(void **state)
 	assert_success(sts_ctx_fetch(ctx, 1, TEST_IOD_ARRAY_1, "dkey", "akey", 3));
 }
 
+void *scrub_wrapper_thread(void *arg) {
+	struct sts_context *ctx = (struct sts_context *)arg;
+	sts_ctx_do_scrub(ctx);
+	return NULL;
+}
+
+/*
+ * The following is a test to make sure can switch from lazy to timed, even when the system is
+ * not idle for a long time.
+ * - Start the scrubber in lazy mode and set the 'system' to idle so that
+ *   the pool starts to scrub.
+ * - In a separate thread run the vos_scrub_pool.
+ * - On the first yield/sleep call the system will be set to busy. (It should get into the
+ *   is idle check and will stay there because the system is busy.)
+ * - Change the scrub mode to timed. This should get the scrubber out of the
+ *   "is idle" check.
+ *
+ * The first two of the following functions will force the system to appear busy after
+ * they are called.
+ */
+
+int
+mock_sleep_changes_to_be_busy(void *args, uint32_t msec)
+{
+	fake_is_idle_result = false;
+	/* don't actually need to sleep any */
+	return 0;
+}
+
+static int
+mock_yield_changes_to_be_busy(void *arg)
+{
+	fake_is_idle_result = false;
+	return 0;
+}
+
+static void
+scrubber_doesnot_get_stuck_in_lazy_mode(void **state)
+{
+	struct sts_context *ctx = *state;
+
+	/* Insert some data */
+	sts_ctx_update(ctx, 1, TEST_IOD_SINGLE, "dkey", "akey0", 1, true);
+	sts_ctx_update(ctx, 1, TEST_IOD_SINGLE, "dkey", "akey1", 1, true);
+	sts_ctx_update(ctx, 1, TEST_IOD_SINGLE, "dkey", "akey2", 1, true);
+
+	/* start in lazy mode */
+	ctx->tsc_pool.sp_scrub_mode = DAOS_SCRUB_MODE_LAZY;
+
+	/*
+	 * system is starts in idle so that the pool will begin to be scrubbed, but then after
+	 * first yield/sleep call it will be switched to busy.
+	 */
+	ctx->tsc_is_idle_fn = fake_is_idle;
+	fake_is_idle_result = true;
+	ctx->tsc_sleep_fn = mock_sleep_changes_to_be_busy;
+	ctx->tsc_yield_fn = mock_yield_changes_to_be_busy;
+
+	/** Run vos_scrub_pool in a separate thread so can change the mode while it's running */
+	pthread_t scrub_thread_id;
+	if (pthread_create(&scrub_thread_id, NULL, &scrub_wrapper_thread, ctx) != 0)
+		fail();
+
+	/* Give the pool time to start being scrubbed */
+	sleep(1);
+
+	/*
+	 * Now the pool will be stuck in a loop until the system becomes IDLE again ... or until
+	 * mode is changed to TIMED, or OFF
+	 */
+	ctx->tsc_pool.sp_scrub_mode = DAOS_SCRUB_MODE_TIMED;
+	ctx->tsc_pool.sp_scrub_freq_sec = 1;
+
+	/* Wait for the thread to finish which should be pretty quick once scrub mode is TIMED */
+	if (pthread_join(scrub_thread_id, NULL) != 0)
+		fail();
+}
+
 static int
 sts_setup(void **state)
 {
@@ -955,6 +1033,8 @@ static const struct CMUnitTest scrubbing_tests[] = {
 	   multiple_overlapping_extents),
 	TS("CSUM_SCRUBBING_13: Evict pool target when threshold is exceeded",
 	   drain_target),
+	TS("CSUM_SCRUBBING_14: Scrubber doesn't get stuck in lazy mode when system is busy and "
+	   "mode is changed to TIMED", scrubber_doesnot_get_stuck_in_lazy_mode),
 };
 
 int

--- a/src/vos/vos_pool_scrub.c
+++ b/src/vos/vos_pool_scrub.c
@@ -283,7 +283,7 @@ sc_wait_until_should_continue(struct scrub_ctx *ctx)
 		}
 	} else if (sc_mode(ctx) == DAOS_SCRUB_MODE_LAZY) {
 		sc_sleep(ctx, 0);
-		while (!ctx->sc_is_idle_fn()) {
+		while (!sc_is_idle(ctx) && sc_mode(ctx) == DAOS_SCRUB_MODE_LAZY) {
 			sc_m_track_busy(ctx);
 			/* Don't actually know how long it will be but wait for 1 second before
 			 * trying again


### PR DESCRIPTION
This change fixes the following issue ...
When the scrubber is lazy mode and the system gets really busy, the scrubber will get wait until the system is not busy before continuing. If the user decides to change the mode to timed in this state, the is_idle check doesn't look at the mode anymore so a change to timed mode would be ignored.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>
Feature: scrubber

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
