### PR TITLE
DAOS-13129 vos: refresh lru entry key with DTX epoch renew - b24

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1006,6 +1006,7 @@ dtx_renew_epoch(struct dtx_epoch *epoch, struct dtx_handle *dth)
 {
 	dth->dth_epoch = epoch->oe_value;
 	dth->dth_epoch_bound = dtx_epoch_bound(epoch);
+	vos_dtx_renew_epoch(dth);
 }
 
 /**
@@ -1147,9 +1148,9 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 	if (rc == 0 && sub_modification_cnt > 0)
 		rc = vos_dtx_attach(dth, false, (flags & DTX_PREPARED) ? true : false);
 
-	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, leader "
+	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, epoch "DF_X64", leader "
 		DF_UOID", dti_cos_cnt %d, tgt_cnt %d, flags %x: "DF_RC"\n",
-		DP_DTI(dti), sub_modification_cnt, dth->dth_ver,
+		DP_DTI(dti), sub_modification_cnt, dth->dth_ver, epoch->oe_value,
 		DP_UOID(*leader_oid), dti_cos_cnt, tgt_cnt, flags, DP_RC(rc));
 
 	if (rc != 0) {
@@ -1483,9 +1484,9 @@ dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 		rc = vos_dtx_attach(dth, false, false);
 
 	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, "
-		"dti_cos_cnt %d, flags %x: "DF_RC"\n",
+		"epoch "DF_X64", dti_cos_cnt %d, flags %x: "DF_RC"\n",
 		DP_DTI(dti), sub_modification_cnt,
-		dth->dth_ver, dti_cos_cnt, flags, DP_RC(rc));
+		dth->dth_ver, epoch->oe_value, dti_cos_cnt, flags, DP_RC(rc));
 
 	if (rc != 0)
 		D_FREE(dth);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -123,6 +123,7 @@ struct dtx_handle {
 	struct dtx_rsrvd_uint		 dth_rsrvd_inline;
 	struct dtx_rsrvd_uint		*dth_rsrvds;
 	void				**dth_deferred;
+	void				*dth_local_stub;
 	/* NVME extents to release */
 	d_list_t			 dth_deferred_nvme;
 	/* Committed or comittable DTX list */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -853,6 +853,14 @@ void
 vos_update_renew_epoch(daos_handle_t ioh, struct dtx_handle *dth);
 
 /**
+ * Renew the epoch for the DTX entry.
+ *
+ * \param dth	[IN]	Pointer to the DTX handle.
+ */
+void
+vos_dtx_renew_epoch(struct dtx_handle *dth);
+
+/**
  * Get the recx/epoch list.
  *
  * \param ioh	[IN]	The I/O handle.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1785,7 +1785,7 @@ out:
 			vos_update_renew_epoch(ioh, dth);
 
 			D_DEBUG(DB_IO,
-				"update rpc %p renew epoch "DF_U64" => "DF_U64" for "DF_DTI"\n",
+				"update rpc %p renew epoch "DF_X64" => "DF_X64" for "DF_DTI"\n",
 				rpc, orw->orw_epoch, dth->dth_epoch, DP_DTI(&orw->orw_dti));
 
 			orw->orw_epoch = dth->dth_epoch;
@@ -3483,8 +3483,9 @@ static int
 obj_local_punch(struct obj_punch_in *opi, crt_opcode_t opc,
 		struct obj_io_context *ioc, struct dtx_handle *dth)
 {
-	struct ds_cont_child *cont = ioc->ioc_coc;
-	int	rc = 0;
+	struct ds_cont_child	*cont = ioc->ioc_coc;
+	uint64_t		 sched_seq;
+	int			 rc = 0;
 
 	if (daos_is_zero_dti(&opi->opi_dti)) {
 		D_DEBUG(DB_TRACE, "disable dtx\n");
@@ -3495,6 +3496,8 @@ again:
 	rc = dtx_sub_init(dth, &opi->opi_oid, opi->opi_dkey_hash);
 	if (rc != 0)
 		goto out;
+
+	sched_seq = sched_cur_seq();
 
 	switch (opc) {
 	case DAOS_OBJ_RPC_PUNCH:
@@ -3528,8 +3531,60 @@ again:
 
 	if (dth != NULL && obj_dtx_need_refresh(dth, rc)) {
 		rc = dtx_refresh(dth, ioc->ioc_coc);
-		if (rc == -DER_AGAIN)
+		if (rc != -DER_AGAIN)
+			goto out;
+
+		if (unlikely(sched_cur_seq() == sched_seq))
 			goto again;
+
+		/*
+		 * There is CPU yield after DTX start, and the resent RPC may be handled
+		 * during that. Let's check resent again before further process.
+		 */
+
+		if (dth->dth_need_validation) {
+			daos_epoch_t	epoch = 0;
+			int		rc1;
+
+			rc1 = dtx_handle_resend(ioc->ioc_vos_coh, &opi->opi_dti, &epoch, NULL);
+			switch (rc1) {
+			case 0:
+				opi->opi_epoch = epoch;
+				/* Fall through */
+			case -DER_ALREADY:
+				rc = -DER_ALREADY;
+				break;
+			case -DER_NONEXIST:
+			case -DER_EP_OLD:
+				break;
+			default:
+				rc = rc1;
+				break;
+			}
+		}
+
+		/*
+		 * For solo punch, it will be handled via one-phase transaction. If there is CPU
+		 * yield after its epoch generated, we will renew the epoch, then we can use the
+		 * epoch to sort related solo DTXs based on their epochs.
+		 */
+		if (rc == -DER_AGAIN && dth->dth_solo) {
+			struct dtx_epoch	epoch;
+
+			epoch.oe_value = d_hlc_get();
+			epoch.oe_first = epoch.oe_value;
+			epoch.oe_flags = orf_to_dtx_epoch_flags(opi->opi_flags);
+
+			dtx_renew_epoch(&epoch, dth);
+
+			D_DEBUG(DB_IO,
+				"punch rpc %u renew epoch "DF_X64" => "DF_X64" for "DF_DTI"\n",
+				opc, opi->opi_epoch, dth->dth_epoch, DP_DTI(&opi->opi_dti));
+
+			opi->opi_epoch = dth->dth_epoch;
+		}
+
+		goto again;
 	}
 
 out:
@@ -4463,10 +4518,11 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			dcsh->dcsh_epoch.oe_value = d_hlc_get();
 
 			dtx_renew_epoch(&dcsh->dcsh_epoch, dth);
-			vos_update_renew_epoch(iohs[0], dth);
+			if (daos_handle_is_valid(iohs[0]))
+				vos_update_renew_epoch(iohs[0], dth);
 
 			D_DEBUG(DB_IO,
-				"CPD rpc %p renew epoch "DF_U64" => "DF_U64" for "DF_DTI"\n",
+				"CPD rpc %p renew epoch "DF_X64" => "DF_X64" for "DF_DTI"\n",
 				rpc, epoch, dcsh->dcsh_epoch.oe_value, DP_DTI(&dcsh->dcsh_xid));
 		}
 	}

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -561,7 +561,7 @@ class TelemetryUtils():
         "engine_mem_vos_dtx_cmt_ent_48",
         "engine_mem_vos_vos_obj_360",
         "engine_mem_vos_vos_lru_size",
-        "engine_mem_dtx_dtx_leader_handle_336",
+        "engine_mem_dtx_dtx_leader_handle_344",
         "engine_mem_dtx_dtx_entry_40"]
     ENGINE_MEM_TOTAL_USAGE_METRICS = [
         "engine_mem_total_mem"]

--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -334,11 +334,11 @@ lrua_peek_(struct lru_array *array, const uint32_t *idx, void **entryp)
  *		-DER_BUSY	Entries need to be evicted to free up
  *				entries in the table
  */
-#define lrua_allocx(array, idx, key, entryp)	\
-	lrua_allocx_(array, idx, key, (void **)(entryp))
+#define lrua_allocx(array, idx, key, entryp, stub)	\
+	lrua_allocx_(array, idx, key, (void **)(entryp), (void **)(stub))
 static inline int
 lrua_allocx_(struct lru_array *array, uint32_t *idx, uint64_t key,
-	     void **entryp)
+	     void **entryp, void **stub)
 {
 	struct lru_entry	*new_entry;
 	int			 rc;
@@ -354,6 +354,8 @@ lrua_allocx_(struct lru_array *array, uint32_t *idx, uint64_t key,
 		return rc;
 
 	*entryp = new_entry->le_payload;
+	if (stub != NULL)
+		*stub = new_entry;
 
 	return 0;
 }
@@ -378,7 +380,7 @@ lrua_allocx_(struct lru_array *array, uint32_t *idx, uint64_t key,
 static inline int
 lrua_alloc_(struct lru_array *array, uint32_t *idx, void **entryp)
 {
-	return lrua_allocx_(array, idx, (uint64_t)idx, entryp);
+	return lrua_allocx_(array, idx, (uint64_t)idx, entryp, NULL);
 }
 
 /** Allocate an entry in place.  Used for recreating an old array.
@@ -496,5 +498,13 @@ lrua_array_free(struct lru_array *array);
  */
 void
 lrua_array_aggregate(struct lru_array *array);
+
+static inline void
+lrua_refresh_key(struct lru_entry *entry, uint64_t key)
+{
+	D_ASSERT(entry != NULL);
+
+	entry->le_key = key;
+}
 
 #endif /* __LRU_ARRAY__ */

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -158,7 +158,7 @@ fake_tx_log_add(struct umem_instance *umm, umem_off_t offset, uint32_t *tx_id,
 	uint32_t		 idx;
 	int			 rc;
 
-	rc = lrua_allocx(array, &idx, epoch, &entry);
+	rc = lrua_allocx(array, &idx, epoch, &entry, NULL);
 	assert_rc_equal(rc, 0);
 	assert_non_null(entry);
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -40,8 +40,8 @@ enum {
 			D_ASSERT(dae->dae_dth->dth_ent == dae);				\
 			dae->dae_dth->dth_ent = NULL;					\
 		}									\
-		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%d\n",			\
-			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));				\
+		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%lx\n",			\
+			DP_DTI(&DAE_XID(dae)), DAE_LID(dae) & DTX_LID_SOLO_MASK);	\
 		d_list_del_init(&dae->dae_link);					\
 		lrua_evictx(cont->vc_dtx_array,						\
 			    (DAE_LID(dae) & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,	\
@@ -963,7 +963,7 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 	cont = vos_hdl2cont(dth->dth_coh);
 	D_ASSERT(cont != NULL);
 
-	rc = lrua_allocx(cont->vc_dtx_array, &idx, dth->dth_epoch, &dae);
+	rc = lrua_allocx(cont->vc_dtx_array, &idx, dth->dth_epoch, &dae, &dth->dth_local_stub);
 	if (rc != 0) {
 		/* The array is full, need to commit some transactions first */
 		if (rc == -DER_BUSY)
@@ -1007,8 +1007,8 @@ vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 	dae->dae_dbd = dbd;
 	dae->dae_dth = dth;
 
-	D_DEBUG(DB_IO, "Allocated new lid DTX: "DF_DTI" lid=%d dae=%p"
-		" dae_dbd=%p\n", DP_DTI(&dth->dth_xid), DAE_LID(dae), dae, dbd);
+	D_DEBUG(DB_IO, "Allocated new lid DTX: "DF_DTI" lid=%lx, dae=%p, dae_dbd=%p\n",
+		DP_DTI(&dth->dth_xid), DAE_LID(dae) & DTX_LID_SOLO_MASK, dae, dbd);
 
 	d_iov_set(&kiov, &DAE_XID(dae), sizeof(DAE_XID(dae)));
 	d_iov_set(&riov, dae, sizeof(*dae));
@@ -1155,6 +1155,10 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	found = lrua_lookupx(cont->vc_dtx_array, (entry & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,
 			     epoch, &dae);
 	if (!found) {
+		D_ASSERTF(!(entry & DTX_LID_SOLO_FLAG),
+			  "non-committed solo entry %lu must be there, epoch "DF_X64", boundary "
+			  DF_X64"\n", entry & DTX_LID_SOLO_MASK, epoch, cont->vc_solo_dtx_epoch);
+
 		D_DEBUG(DB_TRACE,
 			"Entry %d "DF_U64" not in lru array, it must be committed\n",
 			entry, epoch);
@@ -3237,4 +3241,16 @@ cmt:
 	D_DEBUG(DB_TRACE, "Reset DTX cache for "DF_UUID"\n", DP_UUID(cont->vc_id));
 
 	return 0;
+}
+
+void
+vos_dtx_renew_epoch(struct dtx_handle *dth)
+{
+	struct vos_dtx_act_ent	*dae = dth->dth_ent;
+
+	if (dae != NULL)
+		DAE_EPOCH(dae) = dth->dth_epoch;
+
+	if (dth->dth_local_stub != NULL)
+		lrua_refresh_key(dth->dth_local_stub, dth->dth_epoch);
 }


### PR DESCRIPTION
The transaction epoch maybe renewed after DTX entry allocated. Under such case, related lru entry for the DTX entry needs to be refreshed for its key. Otherwise, we cannot locate such lru entry with the new DTX epoch.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
