### PR TITLE
DAOS-14624 gurt: Fix d_rank_list_del and friends (#13317)

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2404,10 +2404,11 @@ grp_regen_linear_list(struct crt_grp_priv *grp_priv)
 	/* If group size changed - reallocate the list */
 	if (!linear_list->rl_ranks ||
 	    linear_list->rl_nr != grp_priv->gp_size) {
-		linear_list = d_rank_list_realloc(linear_list,
-						  grp_priv->gp_size);
-		if (linear_list == NULL)
-			return -DER_NOMEM;
+		int rc;
+
+		rc = d_rank_list_resize(linear_list, grp_priv->gp_size);
+		if (rc != 0)
+			return rc;
 	}
 
 	index = 0;
@@ -2460,9 +2461,9 @@ grp_add_to_membs_list(struct crt_grp_priv *grp_priv, d_rank_t rank, uint64_t inc
 		first = membs->rl_nr;
 		new_amount = first + RANK_LIST_REALLOC_SIZE;
 
-		membs = d_rank_list_realloc(membs, new_amount);
-		if (membs == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
+		rc = d_rank_list_resize(membs, new_amount);
+		if (rc != 0)
+			D_GOTO(out, rc);
 
 		for (i = first; i < first + RANK_LIST_REALLOC_SIZE; i++) {
 			membs->rl_ranks[i] = CRT_NO_RANK;

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -388,26 +388,27 @@ d_rank_list_alloc(uint32_t size)
 	return rank_list;
 }
 
-d_rank_list_t *
-d_rank_list_realloc(d_rank_list_t *ptr, uint32_t size)
+int
+d_rank_list_resize(d_rank_list_t *ptr, uint32_t size)
 {
 	d_rank_t *new_rl_ranks;
 
 	if (ptr == NULL)
-		return d_rank_list_alloc(size);
+		return -DER_INVAL;
 	if (size == 0) {
-		d_rank_list_free(ptr);
-		return NULL;
+		D_FREE(ptr->rl_ranks);
+		ptr->rl_nr = 0;
+		return 0;
 	}
 	D_REALLOC_ARRAY(new_rl_ranks, ptr->rl_ranks, ptr->rl_nr, size);
 	if (new_rl_ranks != NULL) {
 		ptr->rl_ranks = new_rl_ranks;
 		ptr->rl_nr = size;
 	} else {
-		ptr = NULL;
+		return -DER_NOMEM;
 	}
 
-	return ptr;
+	return 0;
 }
 
 void
@@ -430,12 +431,11 @@ d_rank_list_copy(d_rank_list_t *dst, d_rank_list_t *src)
 	}
 
 	if (dst->rl_nr != src->rl_nr) {
-		dst = d_rank_list_realloc(dst, src->rl_nr);
-		if (dst == NULL) {
-			D_ERROR("d_rank_list_realloc() failed.\n");
-			D_GOTO(out, rc = -DER_NOMEM);
+		rc = d_rank_list_resize(dst, src->rl_nr);
+		if (rc != 0) {
+			D_ERROR("d_rank_list_resize() failed.\n");
+			D_GOTO(out, rc);
 		}
-		dst->rl_nr = src->rl_nr;
 	}
 
 	memcpy(dst->rl_ranks, src->rl_ranks, dst->rl_nr * sizeof(d_rank_t));
@@ -533,10 +533,10 @@ d_rank_list_del(d_rank_list_t *rank_list, d_rank_t rank)
 	D_ASSERT(idx <= new_num);
 	num_bytes = (new_num - idx) * sizeof(d_rank_t);
 	memmove(dest, src, num_bytes);
-	rank_list = d_rank_list_realloc(rank_list, new_num);
-	if (rank_list == NULL) {
-		D_ERROR("d_rank_list_realloc() failed.\n");
-		D_GOTO(out, rc = -DER_NOMEM);
+	rc = d_rank_list_resize(rank_list, new_num);
+	if (rc != 0) {
+		D_ERROR("d_rank_list_resize() failed.\n");
+		D_GOTO(out, rc);
 	}
 out:
 	return rc;
@@ -545,16 +545,15 @@ out:
 int
 d_rank_list_append(d_rank_list_t *rank_list, d_rank_t rank)
 {
-	uint32_t		 old_num = rank_list->rl_nr;
-	d_rank_list_t		*new_rank_list;
-	int			 rc = 0;
+	uint32_t	old_num = rank_list->rl_nr;
+	int		rc = 0;
 
-	new_rank_list = d_rank_list_realloc(rank_list, old_num + 1);
-	if (new_rank_list == NULL) {
-		D_ERROR("d_rank_list_realloc() failed.\n");
-		D_GOTO(out, rc = -DER_NOMEM);
+	rc = d_rank_list_resize(rank_list, old_num + 1);
+	if (rc != 0) {
+		D_ERROR("d_rank_list_resize() failed.\n");
+		D_GOTO(out, rc);
 	}
-	new_rank_list->rl_ranks[old_num] = rank;
+	rank_list->rl_ranks[old_num] = rank;
 
 out:
 	return rc;

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -406,7 +406,7 @@ void d_rank_list_filter(d_rank_list_t *src_set, d_rank_list_t *dst_set,
 			bool exclude);
 int d_rank_list_merge(d_rank_list_t *src_set, d_rank_list_t *merge_set);
 d_rank_list_t *d_rank_list_alloc(uint32_t size);
-d_rank_list_t *d_rank_list_realloc(d_rank_list_t *ptr, uint32_t size);
+int d_rank_list_resize(d_rank_list_t *ptr, uint32_t size);
 void d_rank_list_free(d_rank_list_t *rank_list);
 int d_rank_list_copy(d_rank_list_t *dst, d_rank_list_t *src);
 void d_rank_list_shuffle(d_rank_list_t *rank_list);

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -1093,18 +1093,10 @@ rdb_raft_update_node(struct rdb *db, uint64_t index, raft_entry_t *entry)
 		goto out_replicas;
 	}
 
-	if (entry->type == RAFT_LOGTYPE_ADD_NODE) {
+	if (entry->type == RAFT_LOGTYPE_ADD_NODE)
 		rc = d_rank_list_append(replicas, rank);
-	} else if (entry->type == RAFT_LOGTYPE_REMOVE_NODE) {
-		/* never expect 1->0 in practice, right? But protect against double-free. */
-		bool replicas_freed = (replicas->rl_nr == 1);
-
+	else if (entry->type == RAFT_LOGTYPE_REMOVE_NODE)
 		rc = d_rank_list_del(replicas, rank);
-		if (replicas_freed) {
-			D_ASSERT(rc == -DER_NOMEM);
-			replicas = NULL;
-		}
-	}
 	if (rc != 0)
 		goto out_replicas;
 


### PR DESCRIPTION
The function

  int d_rank_list_del(d_rank_list_t *rank_list, d_rank_t rank)

calls

  d_rank_list_t *d_rank_list_realloc(d_rank_list_t *ptr, uint32_t size)

which may free (or reallocate) the object ptr points and return NULL (or
the address of a new object). Due to d_rank_list_del’s signature, this
can’t be conveyed to the caller, who may continue using the freed
object. A similar pitfall exists in d_rank_list_append.

This patch renames d_rank_list_realloc to d_rank_list_resize and changes
its behavior so that it never frees the d_rank_list_t object.

Signed-off-by: Li Wei <wei.g.li@intel.com>