### PR TITLE
DAOS-14105 object: collectively punch object

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1621,6 +1621,8 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 		 uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas,
 		 uint32_t status_pm_ver)
 {
+	int			*exclude_tgts = NULL;
+	uint32_t		exclude_tgt_nr = 0;
 	struct cont_tgt_open_arg arg = { 0 };
 	struct dss_coll_ops	coll_ops = { 0 };
 	struct dss_coll_args	coll_args = { 0 };
@@ -1657,18 +1659,22 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 	coll_args.ca_func_args	= &arg;
 
 	/* setting aggregator args */
-	rc = ds_pool_get_failed_tgt_idx(pool_uuid, &coll_args.ca_exclude_tgts,
-					&coll_args.ca_exclude_tgts_cnt);
-	if (rc) {
+	rc = ds_pool_get_failed_tgt_idx(pool_uuid, &exclude_tgts, &exclude_tgt_nr);
+	if (rc != 0) {
 		D_ERROR(DF_UUID "failed to get index : rc "DF_RC"\n",
 			DP_UUID(pool_uuid), DP_RC(rc));
-		return rc;
+		goto out;
+	}
+
+	if (exclude_tgts != NULL) {
+		rc = dss_build_coll_bitmap(exclude_tgts, exclude_tgt_nr, &coll_args.ca_tgt_bitmap,
+					   &coll_args.ca_tgt_bitmap_sz);
+		if (rc != 0)
+			goto out;
 	}
 
 	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0);
-	D_FREE(coll_args.ca_exclude_tgts);
-
-	if (rc != 0) {
+	if (rc != 0)
 		/* Once it exclude the target from the pool, since the target
 		 * might still in the cart group, so IV cont open might still
 		 * come to this target, especially if cont open/close will be
@@ -1678,9 +1684,10 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 		D_ERROR("open "DF_UUID"/"DF_UUID"/"DF_UUID":"DF_RC"\n",
 			DP_UUID(pool_uuid), DP_UUID(cont_uuid),
 			DP_UUID(cont_hdl_uuid), DP_RC(rc));
-		return rc;
-	}
 
+out:
+	D_FREE(coll_args.ca_tgt_bitmap);
+	D_FREE(exclude_tgts);
 	return rc;
 }
 

--- a/src/dtx/SConscript
+++ b/src/dtx/SConscript
@@ -18,7 +18,8 @@ def scons():
     # dtx
     denv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
     dtx = denv.d_library('dtx',
-                         ['dtx_srv.c', 'dtx_rpc.c', 'dtx_resync.c', 'dtx_common.c', 'dtx_cos.c'],
+                         ['dtx_srv.c', 'dtx_rpc.c', 'dtx_resync.c', 'dtx_common.c', 'dtx_cos.c',
+                          'dtx_coll.c'],
                          install_off="../..")
     denv.Install('$PREFIX/lib64/daos_srv', dtx)
 

--- a/src/dtx/dtx_coll.c
+++ b/src/dtx/dtx_coll.c
@@ -1,0 +1,350 @@
+/**
+ * (C) Copyright 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * dtx: DTX collective RPC logic
+ */
+#define D_LOGFAC	DD_FAC(dtx)
+
+#include <stdlib.h>
+#include <daos/placement.h>
+#include <daos/pool_map.h>
+#include <daos_srv/daos_engine.h>
+#include <daos_srv/container.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/dtx_srv.h>
+#include "dtx_internal.h"
+
+/*
+ * For collective DTX, when commit/abort/check the DTX on system XS (on non-leader), we cannot
+ * directly locate the DTX entry since no VOS target is attached to system XS. Under such case,
+ * we have two options:
+ *
+ * 1. The DTX leader (on IO XS) knows on which VOS target the non-leader can find out the DTX,
+ *    so DTX leader can send related information (IO XS index) to the non-leader.
+ *
+ * 2. The non-leader can start ULT on every local XS collectively to find the DTX by force in
+ *    spite of whether related DTX entry really exists on the VOS target or not.
+ *
+ * Usually, the 2nd option may cause more overhead, should be avoid. Then the 1st is relative
+ * better choice. On the other hand, if there are a lot of VOS targets in the system, then it
+ * maybe inefficient to send all VOS targets information to all related non-leaders via bcast.
+ * Instead, we will only send one VOS target information for each non-leader, then non-leader
+ * can load mbs (dtx_memberships) from the DTX entry and then calculate the other VOS targets
+ * information by itself.
+ */
+
+struct dtx_coll_local_args {
+	uuid_t			 dcla_po_uuid;
+	uuid_t			 dcla_co_uuid;
+	struct dtx_id		 dcla_xid;
+	daos_epoch_t		 dcla_epoch;
+	uint32_t		 dcla_opc;
+	int			*dcla_results;
+};
+
+void
+dtx_coll_load_mbs_ult(void *arg)
+{
+	struct dtx_coll_load_mbs_args	*dclma = arg;
+	struct dtx_coll_in		*dci = dclma->dclma_params;
+	struct ds_cont_child		*cont = NULL;
+	int				 rc = 0;
+
+	rc = ds_cont_child_lookup(dci->dci_po_uuid, dci->dci_co_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR("Failed to locate pool="DF_UUID" cont="DF_UUID" for DTX "
+			DF_DTI" with opc %u: "DF_RC"\n",
+			DP_UUID(dci->dci_po_uuid), DP_UUID(dci->dci_co_uuid),
+			DP_DTI(&dci->dci_xid), dclma->dclma_opc, DP_RC(rc));
+		/*
+		 * Convert the case of container non-exist as -DER_IO to distinguish
+		 * the case of DTX entry does not exist. The latter one is normal.
+		 */
+		if (rc == -DER_NONEXIST)
+			rc = -DER_IO;
+		dclma->dclma_result = rc;
+	} else {
+		rc = vos_dtx_load_mbs(cont->sc_hdl, &dci->dci_xid, &dclma->dclma_oid,
+				      &dclma->dclma_mbs);
+		dclma->dclma_result = rc;
+		if (rc == -DER_INPROGRESS && !dtx_cont_opened(cont) &&
+		    dclma->dclma_opc == DTX_COLL_CHECK) {
+			rc = start_dtx_reindex_ult(cont);
+			if (rc != 0)
+				D_ERROR(DF_UUID": Failed to trigger DTX reindex: "DF_RC"\n",
+					DP_UUID(cont->sc_uuid), DP_RC(rc));
+		}
+		ds_cont_child_put(cont);
+	}
+
+	rc = ABT_future_set(dclma->dclma_future, NULL);
+	D_ASSERT(rc == ABT_SUCCESS);
+}
+
+static int
+dtx_coll_dtg_cmp(const void *m1, const void *m2)
+{
+	const struct dtx_target_group	*dtg1 = m1;
+	const struct dtx_target_group	*dtg2 = m2;
+
+	if (dtg1->dtg_rank > dtg2->dtg_rank)
+		return 1;
+
+	if (dtg1->dtg_rank < dtg2->dtg_rank)
+		return -1;
+
+	return 0;
+}
+
+int
+dtx_coll_prep(uuid_t po_uuid, daos_unit_oid_t oid, struct dtx_memberships *mbs, d_rank_t my_rank,
+	      uint32_t my_tgtid, uint32_t version, uint8_t **p_hints, uint32_t *hint_sz,
+	      uint8_t **p_bitmap, uint32_t *bitmap_sz, d_rank_list_t **p_ranks)
+{
+	struct pl_map		*map = NULL;
+	struct pool_target	*target;
+	struct dtx_daos_target	*ddt;
+	struct dtx_target_group	*base;
+	struct dtx_target_group	*dtg = NULL;
+	struct dtx_target_group	 key = { 0 };
+	uint8_t			*hints = NULL;
+	uint8_t			*bitmap = NULL;
+	size_t			 size = ((dss_tgt_nr - 1) >> 3) + 1;
+	uint32_t		 node_nr;
+	d_rank_t		 max_rank;
+	int			 count;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+	int			 k;
+
+	D_ASSERT(mbs->dm_flags & DMF_CONTAIN_TARGET_GRP);
+
+	*p_bitmap = NULL;
+	*bitmap_sz = 0;
+
+	ddt = &mbs->dm_tgts[0];
+	base = (struct dtx_target_group *)(ddt + mbs->dm_tgt_cnt);
+	count = (mbs->dm_data_size - sizeof(*ddt) * mbs->dm_tgt_cnt) / sizeof(*dtg);
+
+	/*
+	 * The first dtg is for the original leader group. The others groups are sorted against
+	 * ranks ID.
+	 */
+
+	if (base->dtg_rank == my_rank) {
+		dtg = base;
+	} else {
+		key.dtg_rank = my_rank;
+		dtg = bsearch(&key, base + 1, count - 1, sizeof(*dtg), dtx_coll_dtg_cmp);
+		if (dtg == NULL) {
+			D_ERROR("Cannot locate rank %u in the mbs\n", my_rank);
+			D_GOTO(out, rc = -DER_IO);
+		}
+	}
+
+	D_ALLOC_ARRAY(bitmap, size);
+	if (bitmap == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	map = pl_map_find(po_uuid, oid.id_pub);
+	if (map == NULL) {
+		D_ERROR("Failed to find valid placement map for "DF_OID"\n", DP_OID(oid.id_pub));
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	for (i = dtg->dtg_start_idx; i < dtg->dtg_start_idx + dtg->dtg_tgt_nr; i++) {
+		rc = pool_map_find_target(map->pl_poolmap, ddt[i].ddt_id, &target);
+		D_ASSERT(rc == 1);
+
+		/* Skip the targets that reside on other engines. */
+		if (unlikely(my_rank != target->ta_comp.co_rank))
+			continue;
+
+		/* Skip the target that (re-)joined the system after the DTX. */
+		if (target->ta_comp.co_ver > version)
+			continue;
+
+		/* Skip non-healthy one. */
+		if (target->ta_comp.co_status != PO_COMP_ST_UP &&
+		    target->ta_comp.co_status != PO_COMP_ST_UPIN &&
+		    target->ta_comp.co_status != PO_COMP_ST_NEW &&
+		    target->ta_comp.co_status != PO_COMP_ST_DRAIN)
+			continue;
+
+		/* Skip current (new) leader target. */
+		if (my_tgtid != target->ta_comp.co_index)
+			setbit(bitmap, target->ta_comp.co_index);
+	}
+
+	if (p_hints == NULL)
+		D_GOTO(out, rc = 0);
+
+	D_ASSERT(hint_sz != NULL);
+	D_ASSERT(p_ranks != NULL);
+
+	if (unlikely(count == 1)) {
+		*p_ranks = NULL;
+		*p_hints = NULL;
+		*hint_sz = 0;
+		goto out;
+	}
+
+	*p_ranks = d_rank_list_alloc(count - 1);
+	if (*p_ranks == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	node_nr = pool_map_node_nr(map->pl_poolmap);
+	D_ALLOC_ARRAY(hints, node_nr);
+	if (hints == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	for (i = 0, j = 0, max_rank = 0, dtg = base; i < count; i++, dtg++) {
+		/* Skip current leader rank. */
+		if (my_rank == dtg->dtg_rank)
+			continue;
+
+		for (k = dtg->dtg_start_idx; k < dtg->dtg_start_idx + dtg->dtg_tgt_nr; k++) {
+			rc = pool_map_find_target(map->pl_poolmap, ddt[k].ddt_id, &target);
+			D_ASSERT(rc == 1);
+
+			if ((target->ta_comp.co_ver <= version) &&
+			    (target->ta_comp.co_status == PO_COMP_ST_UP ||
+			     target->ta_comp.co_status == PO_COMP_ST_UPIN ||
+			     target->ta_comp.co_status == PO_COMP_ST_NEW ||
+			     target->ta_comp.co_status == PO_COMP_ST_DRAIN)) {
+				if (max_rank < dtg->dtg_rank)
+					max_rank = dtg->dtg_rank;
+
+				(*p_ranks)->rl_ranks[j++] = dtg->dtg_rank;
+				hints[dtg->dtg_rank] = target->ta_comp.co_index;
+				break;
+			}
+		}
+	}
+
+	/*
+	 * It is no matter that the real size of rl_ranks array is larger than rl_nr.
+	 * Then reduce rl_nr to skip those non-defined ranks at the tail in rl_ranks.
+	 */
+	(*p_ranks)->rl_nr = j;
+
+	*p_hints = hints;
+	*hint_sz = max_rank + 1;
+
+out:
+	if (map != NULL)
+		pl_map_decref(map);
+
+	if (rc != 0) {
+		D_FREE(bitmap);
+		if (p_ranks != NULL) {
+			d_rank_list_free(*p_ranks);
+			*p_ranks = NULL;
+		}
+		D_FREE(hints);
+		if (p_hints != NULL) {
+			*p_hints = NULL;
+			*hint_sz = 0;
+		}
+	} else {
+		*p_bitmap = bitmap;
+		*bitmap_sz = size;
+	}
+
+	return rc;
+}
+
+static int
+dtx_coll_local_one(void *args)
+{
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct dtx_coll_local_args	*dcla = args;
+	struct ds_cont_child		*cont = NULL;
+	uint32_t			 opc = dcla->dcla_opc;
+	int				 rc;
+	int				 rc1;
+
+	rc = ds_cont_child_lookup(dcla->dcla_po_uuid, dcla->dcla_co_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR("Failed to locate "DF_UUID"/"DF_UUID" for collective DTX "
+			DF_DTI" rpc %u: "DF_RC"\n", DP_UUID(dcla->dcla_po_uuid),
+			DP_UUID(dcla->dcla_co_uuid), DP_DTI(&dcla->dcla_xid), opc, DP_RC(rc));
+		goto out;
+	}
+
+	switch (opc) {
+	case DTX_COLL_COMMIT:
+		rc = vos_dtx_commit(cont->sc_hdl, &dcla->dcla_xid, 1, NULL);
+		break;
+	case DTX_COLL_ABORT:
+		rc = vos_dtx_abort(cont->sc_hdl, &dcla->dcla_xid, dcla->dcla_epoch);
+		break;
+	case DTX_COLL_CHECK:
+		rc = vos_dtx_check(cont->sc_hdl, &dcla->dcla_xid, NULL, NULL, NULL, NULL, false);
+		if (rc == DTX_ST_INITED) {
+			/*
+			 * For DTX_CHECK, non-ready one is equal to non-exist. Do not directly
+			 * return 'DTX_ST_INITED' to avoid interoperability trouble if related
+			 * request is from old server.
+			 */
+			rc = -DER_NONEXIST;
+		} else if (rc == -DER_INPROGRESS && !dtx_cont_opened(cont)) {
+			/* Trigger DTX re-index for subsequent (retry) DTX_CHECK. */
+			rc1 = start_dtx_reindex_ult(cont);
+			if (rc1 != 0)
+				D_ERROR("Failed to trigger DTX reindex for "DF_UUID"/"DF_UUID
+					" on target %u/%u: "DF_RC"\n",
+					DP_UUID(dcla->dcla_po_uuid), DP_UUID(dcla->dcla_co_uuid),
+					dss_self_rank(), dmi->dmi_tgt_id, DP_RC(rc1));
+		}
+		break;
+	default:
+		D_ASSERTF(0, "Unknown collective DTX opc %u\n", opc);
+		D_GOTO(out, rc = -DER_NOTSUPPORTED);
+	}
+
+out:
+	dcla->dcla_results[dmi->dmi_tgt_id] = rc;
+	if (cont != NULL)
+		ds_cont_child_put(cont);
+
+	return 0;
+}
+
+int
+dtx_coll_local_exec(uuid_t po_uuid, uuid_t co_uuid, struct dtx_id *xid, daos_epoch_t epoch,
+		    uint32_t opc, uint32_t bitmap_sz, uint8_t *bitmap, int **p_results)
+{
+	struct dtx_coll_local_args	 dcla = { 0 };
+	struct dss_coll_ops		 coll_ops = { 0 };
+	struct dss_coll_args		 coll_args = { 0 };
+	int				 rc;
+
+	D_ALLOC_ARRAY(dcla.dcla_results, dss_tgt_nr);
+	if (dcla.dcla_results == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	uuid_copy(dcla.dcla_po_uuid, po_uuid);
+	uuid_copy(dcla.dcla_co_uuid, co_uuid);
+	dcla.dcla_xid = *xid;
+	dcla.dcla_epoch = epoch;
+	dcla.dcla_opc = opc;
+
+	coll_ops.co_func = dtx_coll_local_one;
+	coll_args.ca_func_args = &dcla;
+	coll_args.ca_tgt_bitmap_sz = bitmap_sz;
+	coll_args.ca_tgt_bitmap = bitmap;
+
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0);
+	D_CDEBUG(rc < 0, DLOG_ERR, DB_TRACE,
+		 "Locally exec collective DTX PRC %u for "DF_DTI": "DF_RC"\n",
+		 opc, DP_DTI(xid), DP_RC(rc));
+
+out:
+	*p_results = dcla.dcla_results;
+	return rc < 0 ? rc : dss_tgt_nr;
+}

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -23,6 +23,11 @@ uint32_t dtx_agg_thd_cnt_lo;
 uint32_t dtx_agg_thd_age_up;
 uint32_t dtx_agg_thd_age_lo;
 uint32_t dtx_batched_ult_max;
+/*
+ * Smaller bcast RPC tree width for collective transaction makes related RPC load to be distributed
+ * among more engines, but it may increase single transaction latency from the client perspective.
+ */
+uint32_t dtx_coll_tree_width;
 
 
 struct dtx_batched_pool_args {
@@ -303,12 +308,14 @@ dtx_dpci_free(struct dtx_partial_cmt_item *dpci)
 static void
 dtx_cleanup(void *arg)
 {
+	struct dss_module_info		*dmi = dss_get_module_info();
 	struct dtx_batched_cont_args	*dbca = arg;
 	struct ds_cont_child		*cont = dbca->dbca_cont;
 	struct dtx_share_peer		*dsp;
 	struct dtx_partial_cmt_item	*dpci;
 	struct dtx_entry		*dte;
 	struct dtx_cleanup_cb_args	 dcca;
+	daos_unit_oid_t			 oid;
 	d_list_t			 cmt_list;
 	d_list_t			 abt_list;
 	d_list_t			 act_list;
@@ -366,9 +373,28 @@ dtx_cleanup(void *arg)
 
 		dte = &dpci->dpci_dte;
 		if (dte->dte_mbs == NULL)
-			rc = vos_dtx_load_mbs(cont->sc_hdl, &dte->dte_xid, &dte->dte_mbs);
-		if (dte->dte_mbs != NULL)
-			rc = dtx_commit(cont, &dte, NULL, 1);
+			rc = vos_dtx_load_mbs(cont->sc_hdl, &dte->dte_xid, &oid, &dte->dte_mbs);
+		if (dte->dte_mbs != NULL) {
+			if (dte->dte_mbs->dm_flags & DMF_CONTAIN_TARGET_GRP) {
+				d_rank_list_t		*ranks = NULL;
+				uint8_t			*hints = NULL;
+				uint8_t			*bitmap = NULL;
+				uint32_t		 hint_sz = 0;
+				uint32_t		 bitmap_sz = 0;
+
+				rc = dtx_coll_prep(cont->sc_pool_uuid, oid, dte->dte_mbs,
+						   dss_self_rank(), dmi->dmi_tgt_id, dte->dte_ver,
+						   &hints, &hint_sz, &bitmap, &bitmap_sz, &ranks);
+				if (rc == 0)
+					rc = dtx_coll_commit(cont, &dte->dte_xid, ranks, hints,
+							     hint_sz, bitmap, bitmap_sz, dte->dte_ver);
+				d_rank_list_free(ranks);
+				D_FREE(hints);
+				D_FREE(bitmap);
+			} else {
+				rc = dtx_commit(cont, &dte, NULL, 1);
+			}
+		}
 
 		D_DEBUG(DB_IO, "Cleanup partial committed DTX "DF_DTI", left %d: %d\n",
 			DP_DTI(&dte->dte_xid), dcca.dcca_pc_count, rc);
@@ -846,11 +872,9 @@ dtx_handle_reinit(struct dtx_handle *dth)
  */
 static int
 dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
-		uint16_t sub_modification_cnt, uint32_t pm_ver,
-		daos_unit_oid_t *leader_oid, struct dtx_id *dti_cos,
-		int dti_cos_cnt, struct dtx_memberships *mbs, bool leader,
-		bool solo, bool sync, bool dist, bool migration, bool ignore_uncommitted,
-		bool resent, bool prepared, bool drop_cmt, struct dtx_handle *dth)
+		bool leader, uint16_t sub_modification_cnt, uint32_t pm_ver,
+		daos_unit_oid_t *leader_oid, struct dtx_id *dti_cos, int dti_cos_cnt,
+		uint32_t flags, struct dtx_memberships *mbs, struct dtx_handle *dth)
 {
 	if (sub_modification_cnt > DTX_SUB_MOD_MAX) {
 		D_ERROR("Too many modifications in a single transaction:"
@@ -871,17 +895,16 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 
 	dth->dth_pinned = 0;
 	dth->dth_cos_done = 0;
-	dth->dth_resent = resent ? 1 : 0;
-	dth->dth_solo = solo ? 1 : 0;
-	dth->dth_drop_cmt = drop_cmt ? 1 : 0;
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
-	dth->dth_dist = dist ? 1 : 0;
-	dth->dth_for_migration = migration ? 1 : 0;
-	dth->dth_ignore_uncommitted = ignore_uncommitted ? 1 : 0;
-	dth->dth_prepared = prepared ? 1 : 0;
+	dth->dth_solo = (flags & DTX_SOLO) ? 1 : 0;
+	dth->dth_drop_cmt = (flags & DTX_DROP_CMT) ? 1 : 0;
+	dth->dth_dist = (flags & DTX_DIST) ? 1 : 0;
+	dth->dth_for_migration = (flags & DTX_FOR_MIGRATION) ? 1 : 0;
+	dth->dth_ignore_uncommitted = (flags & DTX_IGNORE_UNCOMMITTED) ? 1 : 0;
+	dth->dth_prepared = (flags & DTX_PREPARED) ? 1 : 0;
 	dth->dth_aborted = 0;
 	dth->dth_already = 0;
 	dth->dth_need_validation = 0;
@@ -891,7 +914,7 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_ent = NULL;
 	dth->dth_flags = leader ? DTE_LEADER : 0;
 
-	if (sync) {
+	if (flags & DTX_SYNC) {
 		dth->dth_flags |= DTE_BLOCK;
 		dth->dth_sync = 1;
 	} else {
@@ -1097,58 +1120,84 @@ out:
  * \param leader_oid	[IN]	The object ID is used to elect the DTX leader.
  * \param dti_cos	[IN]	The DTX array to be committed because of shared.
  * \param dti_cos_cnt	[IN]	The @dti_cos array size.
+ * \param hints		[IN]	VOS targets hint for collective modification.
+ * \param hint_sz	[IN]	The size of hints array.
+ * \param bitmap	[IN]	Bitmap for collective modification on local VOS targets.
+ * \param bitmap_sz	[IN]	The size of bitmap for local VOS targets.
  * \param tgts		[IN]	targets for distribute transaction.
  * \param tgt_cnt	[IN]	number of targets (not count the leader itself).
  * \param flags		[IN]	See dtx_flags.
+ * \param ranks		[IN]	Ranks list for collective modification.
  * \param mbs		[IN]	DTX participants information.
  * \param p_dlh		[OUT]	Pointer to the DTX handle.
  *
  * \return			Zero on success, negative value if error.
  */
 int
-dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
-		 struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
-		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
-		 struct dtx_id *dti_cos, int dti_cos_cnt,
-		 struct daos_shard_tgt *tgts, int tgt_cnt, uint32_t flags,
-		 struct dtx_memberships *mbs, struct dtx_leader_handle **p_dlh)
+dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti, struct dtx_epoch *epoch,
+		 uint16_t sub_modification_cnt, uint32_t pm_ver, daos_unit_oid_t *leader_oid,
+		 struct dtx_id *dti_cos, int dti_cos_cnt, uint8_t *hints, uint32_t hint_sz,
+		 uint8_t *bitmap, uint32_t bitmap_sz, struct daos_shard_tgt *tgts, int tgt_cnt,
+		 uint32_t flags, d_rank_list_t *ranks, struct dtx_memberships *mbs,
+		 struct dtx_leader_handle **p_dlh)
 {
 	struct dtx_leader_handle	*dlh;
 	struct dtx_tls			*tls = dtx_tls_get();
 	struct dtx_handle		*dth;
+	int				 cnt;
 	int				 rc;
 	int				 i;
 
-	D_ALLOC(dlh, sizeof(*dlh) + sizeof(struct dtx_sub_status) * tgt_cnt);
+	if (flags & DTX_COLL)
+		/* For collective RPC, the leader just need at most one bcast request. */
+		cnt = (ranks != NULL) ? 1 : 0;
+	else
+		cnt = tgt_cnt;
+
+	D_ALLOC(dlh, sizeof(*dlh) + sizeof(struct dtx_sub_status) * cnt);
 	if (dlh == NULL)
 		return -DER_NOMEM;
 
-	if (tgt_cnt > 0) {
-		dlh->dlh_future = ABT_FUTURE_NULL;
+	dlh->dlh_future = ABT_FUTURE_NULL;
+
+	if (cnt > 0) {
 		dlh->dlh_subs = (struct dtx_sub_status *)(dlh + 1);
-		for (i = 0; i < tgt_cnt; i++) {
-			dlh->dlh_subs[i].dss_tgt = tgts[i];
-			if (unlikely(tgts[i].st_flags & DTF_DELAY_FORWARD))
-				dlh->dlh_delay_sub_cnt++;
+
+		if (ranks != NULL) {
+			/* NOTE: do not support DTF_DELAY_FORWARD for collective DTX. */
+			dlh->dlh_delay_sub_cnt = 0;
+			dlh->dlh_normal_sub_cnt = cnt;
+		} else {
+			for (i = 0; i < cnt; i++) {
+				dlh->dlh_subs[i].dss_tgt = tgts[i];
+				if (unlikely(tgts[i].st_flags & DTF_DELAY_FORWARD))
+					dlh->dlh_delay_sub_cnt++;
+			}
+
+			dlh->dlh_normal_sub_cnt = cnt - dlh->dlh_delay_sub_cnt;
 		}
-		dlh->dlh_normal_sub_cnt = tgt_cnt - dlh->dlh_delay_sub_cnt;
 	}
 
+	if (flags & DTX_COLL) {
+		dlh->dlh_coll = 1;
+		dlh->dlh_coll_tree_width = dtx_coll_tree_width;
+	}
+
+	dlh->dlh_coll_ranks = ranks;
+	dlh->dlh_coll_hints = hints;
+	dlh->dlh_coll_hint_sz = hint_sz;
+	dlh->dlh_coll_bitmap = bitmap;
+	dlh->dlh_coll_bitmap_sz = bitmap_sz;
+
 	dth = &dlh->dlh_handle;
-	rc = dtx_handle_init(dti, coh, epoch, sub_modification_cnt, pm_ver,
-			     leader_oid, dti_cos, dti_cos_cnt, mbs, true,
-			     (flags & DTX_SOLO) ? true : false,
-			     (flags & DTX_SYNC) ? true : false,
-			     (flags & DTX_DIST) ? true : false,
-			     (flags & DTX_FOR_MIGRATION) ? true : false, false,
-			     (flags & DTX_RESEND) ? true : false,
-			     (flags & DTX_PREPARED) ? true : false,
-			     (flags & DTX_DROP_CMT) ? true : false, dth);
+	rc = dtx_handle_init(dti, coh, epoch, true, sub_modification_cnt, pm_ver,
+			     leader_oid, dti_cos, dti_cos_cnt, flags, mbs, dth);
 	if (rc == 0 && sub_modification_cnt > 0)
 		rc = vos_dtx_attach(dth, false, (flags & DTX_PREPARED) ? true : false);
 
-	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, leader "
+	D_DEBUG(DB_IO, "Start (%s) DTX "DF_DTI" sub modification %d, ver %u, leader "
 		DF_UOID", dti_cos_cnt %d, tgt_cnt %d, flags %x: "DF_RC"\n",
+		(flags & DTX_COLL) ? "collective" : "regular",
 		DP_DTI(dti), sub_modification_cnt, dth->dth_ver,
 		DP_UOID(*leader_oid), dti_cos_cnt, tgt_cnt, flags, DP_RC(rc));
 
@@ -1301,6 +1350,10 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 	if (DAOS_FAIL_CHECK(DAOS_DTX_MISS_COMMIT))
 		dth->dth_sync = 1;
 
+	 /* NOTE: Currently, we synchronously commit collective DTX. */
+	if (dlh->dlh_coll)
+		dth->dth_sync = 1;
+
 	/* For synchronous DTX, do not add it into CoS cache, otherwise,
 	 * we may have no way to remove it from the cache.
 	 */
@@ -1361,11 +1414,21 @@ sync:
 		 *	batched commit.
 		 */
 		vos_dtx_mark_committable(dth);
-		dte = &dth->dth_dte;
-		rc = dtx_commit(cont, &dte, NULL, 1);
+
+		if (dlh->dlh_coll) {
+			rc = dtx_coll_commit(cont, &dth->dth_xid, dlh->dlh_coll_ranks,
+					     dlh->dlh_coll_hints, dlh->dlh_coll_hint_sz,
+					     dlh->dlh_coll_bitmap, dlh->dlh_coll_bitmap_sz,
+					     dth->dth_ver);
+		} else {
+			dte = &dth->dth_dte;
+			rc = dtx_commit(cont, &dte, NULL, 1);
+		}
+
 		if (rc != 0)
-			D_WARN(DF_UUID": Fail to sync commit DTX "DF_DTI": "DF_RC"\n",
-			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), DP_RC(rc));
+			D_WARN(DF_UUID": Fail to sync %s commit DTX "DF_DTI": "DF_RC"\n",
+			       DP_UUID(cont->sc_uuid), dlh->dlh_coll ? "collective" : "regular",
+			       DP_DTI(&dth->dth_xid), DP_RC(rc));
 
 		/*
 		 * NOTE: The semantics of 'sync' commit does not guarantee that all
@@ -1390,7 +1453,13 @@ abort:
 		 * 2. Remove the pinned DTX entry.
 		 */
 		vos_dtx_cleanup(dth, true);
-		dtx_abort(cont, &dth->dth_dte, dth->dth_epoch);
+		if (dlh->dlh_coll)
+			dtx_coll_abort(cont, &dth->dth_xid, dlh->dlh_coll_ranks,
+				       dlh->dlh_coll_hints, dlh->dlh_coll_hint_sz,
+				       dlh->dlh_coll_bitmap, dlh->dlh_coll_bitmap_sz,
+				       dth->dth_ver, dth->dth_epoch);
+		else
+			dtx_abort(cont, &dth->dth_dte, dth->dth_epoch);
 		aborted = true;
 	}
 
@@ -1472,13 +1541,8 @@ dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 	if (dth == NULL)
 		return -DER_NOMEM;
 
-	rc = dtx_handle_init(dti, coh, epoch, sub_modification_cnt,
-			     pm_ver, leader_oid, dti_cos, dti_cos_cnt, mbs,
-			     false, false, false,
-			     (flags & DTX_DIST) ? true : false,
-			     (flags & DTX_FOR_MIGRATION) ? true : false,
-			     (flags & DTX_IGNORE_UNCOMMITTED) ? true : false,
-			     (flags & DTX_RESEND) ? true : false, false, false, dth);
+	rc = dtx_handle_init(dti, coh, epoch, false, sub_modification_cnt, pm_ver,
+			     leader_oid, dti_cos, dti_cos_cnt, flags, mbs, dth);
 	if (rc == 0 && sub_modification_cnt > 0)
 		rc = vos_dtx_attach(dth, false, false);
 
@@ -1938,8 +2002,12 @@ dtx_comp_cb(void **arg)
 			    sub->dss_result == dlh->dlh_allow_failure)
 				continue;
 
-			/* Ignore DER_INPROGRESS if there is other failure. */
-			if (dlh->dlh_result == 0 || dlh->dlh_result == -DER_INPROGRESS)
+			if (dlh->dlh_rmt_ver < sub->dss_version)
+				dlh->dlh_rmt_ver = sub->dss_version;
+
+			/* Ignore DER_INPROGRESS and DER_AGAIN if there is other failure. */
+			if (dlh->dlh_result == 0 || dlh->dlh_result == -DER_INPROGRESS ||
+			    dlh->dlh_result == -DER_AGAIN)
 				dlh->dlh_result = sub->dss_result;
 		}
 	}
@@ -2228,4 +2296,45 @@ dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 		rc = vos_dtx_mark_sync(cont->sc_hdl, *oid, epoch);
 
 	return rc;
+}
+
+void
+dtx_merge_check_result(int *tgt, int src)
+{
+	/* As long as one target has committed, then the DTX is committable on all targets. */
+	if (*tgt != DTX_ST_COMMITTED && *tgt != DTX_ST_COMMITTABLE) {
+		switch (src) {
+		case DTX_ST_COMMITTED:
+		case DTX_ST_COMMITTABLE:
+			*tgt = src;
+			break;
+		case -DER_EXCLUDED:
+			/*
+			 * If non-leader is excluded, handle it as 'prepared'. If other
+			 * non-leaders are also 'prepared' then related DTX maybe still
+			 * committable or 'corrupted'. The subsequent DTX resync logic
+			 * will handle related things, see dtx_verify_groups().
+			 *
+			 * Fall through.
+			 */
+		case DTX_ST_PREPARED:
+			if (*tgt == 0 || *tgt == DTX_ST_CORRUPTED)
+				*tgt = src;
+			break;
+		case DTX_ST_CORRUPTED:
+			if (*tgt == 0)
+				*tgt = src;
+			break;
+		default:
+			if (src >= 0) {
+				if (*tgt != -DER_NONEXIST)
+					*tgt = -DER_IO;
+			} else {
+				if (src == -DER_NONEXIST || *tgt >= 0 ||
+				    (*tgt != -DER_IO && *tgt != -DER_NONEXIST))
+					*tgt = src;
+			}
+			break;
+		}
+	}
 }

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -20,6 +20,7 @@
 #include "dtx_internal.h"
 
 CRT_RPC_DEFINE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
+CRT_RPC_DEFINE(dtx_coll, DAOS_ISEQ_COLL_DTX, DAOS_OSEQ_COLL_DTX);
 
 #define X(a, b, c, d, e, f)	\
 {				\
@@ -206,18 +207,16 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	}
 
 out:
+	D_DEBUG(DB_TRACE, "DTX req for opc %x (req %p future %p) got reply from %d/%d: "
+		"epoch :"DF_X64", result %d\n", dra->dra_opc, req, dra->dra_future,
+		drr->drr_rank, drr->drr_tag, din != NULL ? din->di_epoch : 0, rc);
+
 	drr->drr_comp = 1;
 	drr->drr_result = rc;
 	rc = ABT_future_set(dra->dra_future, drr);
 	D_ASSERTF(rc == ABT_SUCCESS,
 		  "ABT_future_set failed for opc %x to %d/%d: rc = %d.\n",
 		  dra->dra_opc, drr->drr_rank, drr->drr_tag, rc);
-
-	D_DEBUG(DB_TRACE,
-		"DTX req for opc %x (req %p future %p) got reply from %d/%d: "
-		"epoch :"DF_X64", rc %d.\n", dra->dra_opc, req,
-		dra->dra_future, drr->drr_rank, drr->drr_tag,
-		din != NULL ? din->di_epoch : 0, drr->drr_result);
 }
 
 static int
@@ -291,41 +290,7 @@ dtx_req_list_cb(void **args)
 	if (dra->dra_opc == DTX_CHECK) {
 		for (i = 0; i < dra->dra_length; i++) {
 			drr = args[i];
-			switch (drr->drr_result) {
-			case DTX_ST_COMMITTED:
-			case DTX_ST_COMMITTABLE:
-				dra->dra_result = DTX_ST_COMMITTED;
-				/* As long as one target has committed the DTX,
-				 * then the DTX is committable on all targets.
-				 */
-				D_DEBUG(DB_TRACE,
-					"The DTX "DF_DTI" has been committed on %d/%d.\n",
-					DP_DTI(&drr->drr_dti[0]), drr->drr_rank, drr->drr_tag);
-				return;
-			case -DER_EXCLUDED:
-				/*
-				 * If non-leader is excluded, handle it as 'prepared'. If other
-				 * non-leaders are also 'prepared' then related DTX maybe still
-				 * committable or 'corrupted'. The subsequent DTX resync logic
-				 * will handle related things, see dtx_verify_groups().
-				 *
-				 * Fall through.
-				 */
-			case DTX_ST_PREPARED:
-				if (dra->dra_result == 0 ||
-				    dra->dra_result == DTX_ST_CORRUPTED)
-					dra->dra_result = DTX_ST_PREPARED;
-				break;
-			case DTX_ST_CORRUPTED:
-				if (dra->dra_result == 0)
-					dra->dra_result = drr->drr_result;
-				break;
-			default:
-				dra->dra_result = drr->drr_result >= 0 ?
-					-DER_IO : drr->drr_result;
-				break;
-			}
-
+			dtx_merge_check_result(&dra->dra_result, drr->drr_result);
 			D_DEBUG(DB_TRACE, "The DTX "DF_DTI" RPC req result %d, status is %d.\n",
 				DP_DTI(&drr->drr_dti[0]), drr->drr_result, dra->dra_result);
 		}
@@ -608,7 +573,7 @@ dtx_rpc_internal(struct dtx_common_args *dca)
 	int			 rc;
 	int			 i;
 
-	if (dca->dca_dra.dra_opc != DTX_REFRESH) {
+	if (dca->dca_dtes != NULL) {
 		D_ASSERT(dca->dca_dtis != NULL);
 
 		if (dca->dca_count > 1) {
@@ -778,7 +743,7 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	 * Some RPC may has been sent, so need to wait even if dtx_rpc_prep hit failure.
 	 */
 	rc = dtx_rpc_post(&dca, rc, false);
-	if (rc > 0 || rc == -DER_NONEXIST || rc == -DER_EXCLUDED)
+	if (rc > 0 || rc == -DER_NONEXIST || rc == -DER_EXCLUDED || rc == -DER_OOG)
 		rc = 0;
 
 	if (rc != 0) {
@@ -833,7 +798,7 @@ out:
 			DP_DTI(&dtes[0]->dte_xid), count,
 			dra->dra_committed > 0 ? "partial" : "nothing", rc, rc1);
 	else
-		D_DEBUG(DB_IO, "Commit DTXs " DF_DTI", count %d\n",
+		D_DEBUG(DB_TRACE, "Commit DTXs " DF_DTI", count %d\n",
 			DP_DTI(&dtes[0]->dte_xid), count);
 
 	return rc != 0 ? rc : rc1;
@@ -870,7 +835,7 @@ dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	if (rc1 > 0 || rc1 == -DER_NONEXIST)
 		rc1 = 0;
 
-	D_CDEBUG(rc1 != 0 || rc2 != 0, DLOG_ERR, DB_IO, "Abort DTX "DF_DTI": rc %d %d %d\n",
+	D_CDEBUG(rc1 != 0 || rc2 != 0, DLOG_ERR, DB_TRACE, "Abort DTX "DF_DTI": rc %d %d %d\n",
 		 DP_DTI(&dte->dte_xid), rc, rc1, rc2);
 
 	return rc1 != 0 ? rc1 : rc2;
@@ -893,8 +858,8 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 
 	rc1 = dtx_rpc_post(&dca, rc, false);
 
-	D_CDEBUG(rc1 < 0, DLOG_ERR, DB_IO, "Check DTX "DF_DTI": rc %d %d\n",
-		 DP_DTI(&dte->dte_xid), rc, rc1);
+	D_CDEBUG(rc1 < 0 && rc1 != -DER_NONEXIST, DLOG_ERR, DB_TRACE,
+		 "Check DTX "DF_DTI": rc %d %d\n", DP_DTI(&dte->dte_xid), rc, rc1);
 
 	return rc1;
 }
@@ -929,9 +894,9 @@ dtx_refresh_internal(struct ds_cont_child *cont, int *check_count, d_list_t *che
 		drop = false;
 
 		if (dsp->dsp_mbs == NULL) {
-			rc = vos_dtx_load_mbs(cont->sc_hdl, &dsp->dsp_xid, &dsp->dsp_mbs);
+			rc = vos_dtx_load_mbs(cont->sc_hdl, &dsp->dsp_xid, NULL, &dsp->dsp_mbs);
 			if (rc != 0) {
-				if (rc != -DER_NONEXIST && for_io)
+				if (rc < 0 && rc != -DER_NONEXIST && for_io)
 					goto out;
 
 				drop = true;
@@ -1166,8 +1131,7 @@ next2:
 		dte.dte_refs = 1;
 		dte.dte_mbs = dsp->dsp_mbs;
 
-		rc = dtx_status_handle_one(cont, &dte, dsp->dsp_epoch,
-					   NULL, NULL);
+		rc = dtx_status_handle_one(cont, &dte, dsp->dsp_oid, dsp->dsp_epoch, NULL, NULL);
 		switch (rc) {
 		case DSHR_NEED_COMMIT: {
 			struct dtx_entry	*pdte = &dte;
@@ -1187,6 +1151,7 @@ next2:
 			if (for_io)
 				D_GOTO(out, rc = -DER_INPROGRESS);
 			continue;
+		case 0:
 		case DSHR_IGNORE:
 			dtx_dsp_free(dsp);
 			continue;
@@ -1296,4 +1261,364 @@ dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
 	}
 
 	return rc;
+}
+
+static int
+dtx_coll_commit_aggregator(crt_rpc_t *source, crt_rpc_t *target, void *priv)
+{
+	struct dtx_coll_out	*out_source = crt_reply_get(source);
+	struct dtx_coll_out	*out_target = crt_reply_get(target);
+
+	out_target->dco_misc += out_source->dco_misc;
+	if (out_target->dco_status == 0)
+		out_target->dco_status = out_source->dco_status;
+
+	return 0;
+}
+
+static int
+dtx_coll_abort_aggregator(crt_rpc_t *source, crt_rpc_t *target, void *priv)
+{
+	struct dtx_coll_out	*out_source = crt_reply_get(source);
+	struct dtx_coll_out	*out_target = crt_reply_get(target);
+
+	if (out_source->dco_status != 0 &&
+	    (out_target->dco_status == 0 || out_target->dco_status == -DER_NONEXIST))
+		out_target->dco_status = out_source->dco_status;
+
+	return 0;
+}
+
+static int
+dtx_coll_check_aggregator(crt_rpc_t *source, crt_rpc_t *target, void *priv)
+{
+	struct dtx_coll_out	*out_source = crt_reply_get(source);
+	struct dtx_coll_out	*out_target = crt_reply_get(target);
+
+	dtx_merge_check_result(&out_target->dco_status, out_source->dco_status);
+
+	return 0;
+}
+
+struct crt_corpc_ops dtx_coll_commit_co_ops = {
+	.co_aggregate = dtx_coll_commit_aggregator,
+	.co_pre_forward = NULL,
+	.co_post_reply = NULL,
+};
+
+struct crt_corpc_ops dtx_coll_abort_co_ops = {
+	.co_aggregate = dtx_coll_abort_aggregator,
+	.co_pre_forward = NULL,
+	.co_post_reply = NULL,
+};
+
+struct crt_corpc_ops dtx_coll_check_co_ops = {
+	.co_aggregate = dtx_coll_check_aggregator,
+	.co_pre_forward = NULL,
+	.co_post_reply = NULL,
+};
+
+struct dtx_coll_rpc_args {
+	struct ds_cont_child	*dcra_cont;
+	struct dtx_id		 dcra_xid;
+	uint32_t		 dcra_opc;
+	uint32_t		 dcra_ver;
+	daos_epoch_t		 dcra_epoch;
+	d_rank_list_t		*dcra_ranks;
+	uint8_t			*dcra_hints;
+	uint32_t		 dcra_hint_sz;
+	uint32_t		 dcra_committed;
+	uint32_t		 dcra_completed:1;
+	int			 dcra_result;
+	ABT_thread		 dcra_helper;
+	ABT_future		 dcra_future;
+};
+
+static void
+dtx_coll_rpc_cb(const struct crt_cb_info *cb_info)
+{
+	struct dtx_coll_rpc_args	*dcra = cb_info->cci_arg;
+	crt_rpc_t			*req = cb_info->cci_rpc;
+	struct dtx_coll_out		*dco;
+	int				 rc = cb_info->cci_rc;
+
+	if (rc != 0) {
+		dcra->dcra_result = rc;
+	} else {
+		dco = crt_reply_get(req);
+		dcra->dcra_result = dco->dco_status;
+		dcra->dcra_committed = dco->dco_misc;
+	}
+
+	dcra->dcra_completed = 1;
+	rc = ABT_future_set(dcra->dcra_future, NULL);
+	D_ASSERTF(rc == ABT_SUCCESS,
+		  "ABT_future_set failed for opc %u: rc = %d\n", dcra->dcra_opc, rc);
+}
+
+static int
+dtx_coll_rpc(struct dtx_coll_rpc_args *dcra)
+{
+	crt_rpc_t		*req = NULL;
+	struct dtx_coll_in	*dci;
+	int			 rc;
+
+	rc = ABT_future_create(1, NULL, &dcra->dcra_future);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR("ABT_future_create failed for coll DTX ("DF_DTI") RPC %u: rc = %d\n",
+			DP_DTI(&dcra->dcra_xid), dcra->dcra_opc, rc);
+		D_GOTO(out, rc = dss_abterr2der(rc));
+	}
+
+	rc = crt_corpc_req_create(dss_get_module_info()->dmi_ctx, NULL, dcra->dcra_ranks,
+				  DAOS_RPC_OPCODE(dcra->dcra_opc, DAOS_DTX_MODULE,
+						  DAOS_DTX_VERSION),
+				  NULL, NULL, CRT_RPC_FLAG_FILTER_INVERT,
+				  crt_tree_topo(CRT_TREE_KNOMIAL, dtx_coll_tree_width), &req);
+	if (rc != 0) {
+		D_ERROR("crt_corpc_req_create failed for coll DTX ("DF_DTI") RPC %u: "DF_RC"\n",
+			DP_DTI(&dcra->dcra_xid), dcra->dcra_opc, DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	dci = crt_req_get(req);
+
+	uuid_copy(dci->dci_po_uuid, dcra->dcra_cont->sc_pool->spc_pool->sp_uuid);
+	uuid_copy(dci->dci_co_uuid, dcra->dcra_cont->sc_uuid);
+	dci->dci_xid = dcra->dcra_xid;
+	dci->dci_version = dcra->dcra_ver;
+	dci->dci_epoch = dcra->dcra_epoch;
+	dci->dci_hints.ca_count = dcra->dcra_hint_sz;
+	dci->dci_hints.ca_arrays = dcra->dcra_hints;
+
+	rc = crt_req_send(req, dtx_coll_rpc_cb, dcra);
+	if (rc != 0)
+		D_ERROR("crt_req_send failed for coll DTX ("DF_DTI") RPC %u: "DF_RC"\n",
+			DP_DTI(&dcra->dcra_xid), dcra->dcra_opc, DP_RC(rc));
+
+out:
+	if (rc != 0 && !dcra->dcra_completed) {
+		dcra->dcra_result = rc;
+		dcra->dcra_completed = 1;
+		if (dcra->dcra_future != ABT_FUTURE_NULL)
+			ABT_future_set(dcra->dcra_future, NULL);
+	}
+
+	return rc;
+}
+
+static void
+dtx_coll_rpc_helper(void *arg)
+{
+	struct dtx_coll_rpc_args	*dcra = arg;
+	int				 rc;
+
+	rc = dtx_coll_rpc(dcra);
+
+	D_CDEBUG(rc < 0, DLOG_ERR, DB_TRACE,
+		 "Collective DTX helper ULT for %u exit: %d\n", dcra->dcra_opc, rc);
+}
+
+static int
+dtx_coll_rpc_prep(struct ds_cont_child *cont, struct dtx_id *xid, uint32_t opc, uint32_t version,
+		  daos_epoch_t epoch, uint8_t *hints, uint32_t hint_sz,
+		  d_rank_list_t *ranks, struct dtx_coll_rpc_args *dcra)
+{
+	int	rc;
+
+	dcra->dcra_cont = cont;
+	dcra->dcra_xid = *xid;
+	dcra->dcra_opc = opc;
+	dcra->dcra_ver = version;
+	dcra->dcra_epoch = epoch;
+	dcra->dcra_ranks = ranks;
+	dcra->dcra_hints = hints;
+	dcra->dcra_hint_sz = hint_sz;
+	dcra->dcra_future = ABT_FUTURE_NULL;
+	dcra->dcra_helper = ABT_THREAD_NULL;
+
+	if (dss_has_enough_helper())
+		rc = dss_ult_create(dtx_coll_rpc_helper, dcra, DSS_XS_IOFW,
+				    dss_get_module_info()->dmi_tgt_id, 0, &dcra->dcra_helper);
+	else
+		rc = dtx_coll_rpc(dcra);
+
+	return rc;
+}
+
+static int
+dtx_coll_rpc_post(struct dtx_coll_rpc_args *dcra, int ret)
+{
+	int	rc;
+
+	if (dcra->dcra_helper != ABT_THREAD_NULL)
+		ABT_thread_free(&dcra->dcra_helper);
+
+	if (dcra->dcra_future != ABT_FUTURE_NULL) {
+		rc = ABT_future_wait(dcra->dcra_future);
+		D_CDEBUG(rc != ABT_SUCCESS, DLOG_ERR, DB_TRACE,
+			 "Collective DTX wait req for opc %u, future %p done, rc %d, result %d\n",
+			 dcra->dcra_opc, dcra->dcra_future, rc, dcra->dcra_result);
+		ABT_future_free(&dcra->dcra_future);
+	}
+
+	return ret != 0 ? ret : dcra->dcra_result;
+}
+
+int
+dtx_coll_commit(struct ds_cont_child *cont, struct dtx_id *xid, d_rank_list_t *ranks,
+		uint8_t *hints, uint32_t hint_sz, uint8_t *bitmap, uint32_t bitmap_sz,
+		uint32_t version)
+{
+	struct dtx_coll_rpc_args	 dcra = { 0 };
+	int				*results = NULL;
+	uint32_t			 committed = 0;
+	int				 len;
+	int				 rc = 0;
+	int				 rc1 = 0;
+	int				 rc2 = 0;
+	int				 i;
+
+	if (ranks != NULL)
+		rc = dtx_coll_rpc_prep(cont, xid, DTX_COLL_COMMIT, version, 0, hints, hint_sz,
+				       ranks, &dcra);
+
+	if (bitmap != NULL) {
+		len = dtx_coll_local_exec(cont->sc_pool_uuid, cont->sc_uuid, xid, 0,
+					  DTX_COLL_COMMIT, bitmap_sz, bitmap, &results);
+		if (len < 0) {
+			rc1 = len;
+		} else {
+			D_ASSERT(results != NULL);
+			for (i = 0; i < len; i++) {
+				if (results[i] > 0)
+					committed += results[i];
+				else if (results[i] < 0 && results[i] != -DER_NONEXIST && rc1 == 0)
+					rc1 = results[i];
+			}
+		}
+		D_FREE(results);
+	}
+
+	if (ranks != NULL) {
+		rc = dtx_coll_rpc_post(&dcra, rc);
+		if (rc > 0 || rc == -DER_NONEXIST || rc == -DER_EXCLUDED || rc == -DER_OOG)
+			rc = 0;
+
+		committed += dcra.dcra_committed;
+	}
+
+	if (rc == 0 && rc1 == 0)
+		rc2 = vos_dtx_commit(cont->sc_hdl, xid, 1, NULL);
+	else if (committed > 0)
+		/* Mark the DTX as "PARTIAL_COMMITTED" and re-commit it later. */
+		rc2 = vos_dtx_set_flags(cont->sc_hdl, xid, 1, DTE_PARTIAL_COMMITTED);
+	if (rc2 > 0 || rc2 == -DER_NONEXIST)
+		rc2 = 0;
+
+	D_CDEBUG(rc != 0 || rc1 != 0 || rc2 != 0, DLOG_ERR, DB_TRACE,
+		 "Collectively commit DTX "DF_DTI": %d/%d/%d\n", DP_DTI(xid), rc, rc1, rc2);
+
+	return rc != 0 ? rc : rc1 != 0 ? rc1 : rc2;
+}
+
+int
+dtx_coll_abort(struct ds_cont_child *cont, struct dtx_id *xid, d_rank_list_t *ranks,
+	       uint8_t *hints, uint32_t hint_sz, uint8_t *bitmap, uint32_t bitmap_sz,
+	       uint32_t version, daos_epoch_t epoch)
+{
+	struct dtx_coll_rpc_args	 dcra = { 0 };
+	int				*results = NULL;
+	int				 len;
+	int				 rc = 0;
+	int				 rc1 = 0;
+	int				 rc2 = 0;
+	int				 i;
+
+	if (ranks != NULL)
+		rc = dtx_coll_rpc_prep(cont, xid, DTX_COLL_ABORT, version, epoch, hints, hint_sz,
+				       ranks, &dcra);
+
+	if (bitmap != NULL) {
+		len = dtx_coll_local_exec(cont->sc_pool_uuid, cont->sc_uuid, xid, epoch,
+					  DTX_COLL_ABORT, bitmap_sz, bitmap, &results);
+		if (len < 0) {
+			rc1 = len;
+		} else {
+			D_ASSERT(results != NULL);
+			for (i = 0; i < len; i++) {
+				if (results[i] < 0 && results[i] != -DER_NONEXIST && rc1 == 0)
+					rc1 = results[i];
+			}
+		}
+		D_FREE(results);
+	}
+
+	if (ranks != NULL) {
+		rc = dtx_coll_rpc_post(&dcra, rc);
+		if (rc > 0 || rc == -DER_NONEXIST || rc == -DER_EXCLUDED || rc == -DER_OOG)
+			rc = 0;
+	}
+
+	if (epoch != 0)
+		rc2 = vos_dtx_abort(cont->sc_hdl, xid, epoch);
+	else
+		rc2 = vos_dtx_set_flags(cont->sc_hdl, xid, 1, DTE_CORRUPTED);
+	if (rc2 > 0 || rc2 == -DER_NONEXIST)
+		rc2 = 0;
+
+	D_CDEBUG(rc != 0 || rc1 != 0 || rc2 != 0, DLOG_ERR, DB_TRACE,
+		 "Collectively abort DTX "DF_DTI": %d/%d/%d\n", DP_DTI(xid), rc, rc1, rc2);
+
+	return rc != 0 ? rc : rc1 != 0 ? rc1 : rc2;
+}
+
+int
+dtx_coll_check(struct ds_cont_child *cont, struct dtx_id *xid, d_rank_list_t *ranks,
+	       uint8_t *hints, uint32_t hint_sz, uint8_t *bitmap, uint32_t bitmap_sz,
+	       uint32_t version, daos_epoch_t epoch)
+{
+	struct dtx_coll_rpc_args	 dcra = { 0 };
+	int				*results = NULL;
+	int				 len;
+	int				 rc = 0;
+	int				 rc1 = 0;
+	int				 i;
+
+	/*
+	 * If no other target, then current target is the unique
+	 * one and 'prepared', then related DTX can be committed.
+	 */
+	if (unlikely(ranks == NULL && bitmap == NULL))
+		return DTX_ST_PREPARED;
+
+	if (ranks != NULL)
+		rc = dtx_coll_rpc_prep(cont, xid, DTX_COLL_CHECK, version, epoch, hints, hint_sz,
+				       ranks, &dcra);
+
+	if (bitmap != NULL) {
+		len = dtx_coll_local_exec(cont->sc_pool_uuid, cont->sc_uuid, xid, epoch,
+					  DTX_COLL_CHECK, bitmap_sz, bitmap, &results);
+		if (len < 0) {
+			rc1 = len;
+		} else {
+			D_ASSERT(results != NULL);
+			for (i = 0; i < len; i++) {
+				if (isset(bitmap, i))
+					dtx_merge_check_result(&rc1, results[i]);
+			}
+		}
+		D_FREE(results);
+	}
+
+	if (ranks != NULL) {
+		rc = dtx_coll_rpc_post(&dcra, rc);
+		if (bitmap != NULL)
+			dtx_merge_check_result(&rc, rc1);
+	}
+
+	D_CDEBUG((rc < 0 && rc != -DER_NONEXIST) || (rc1 < 0 && rc1 != -DER_NONEXIST), DLOG_ERR,
+		 DB_TRACE, "Collectively check DTX "DF_DTI": %d/%d/\n", DP_DTI(xid), rc, rc1);
+
+	return ranks != NULL  ? rc : rc1;
 }

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -247,7 +247,7 @@ dtx_handler(crt_rpc_t *rpc)
 			rc1 = start_dtx_reindex_ult(cont);
 			if (rc1 != 0)
 				D_ERROR(DF_UUID": Failed to trigger DTX reindex: "DF_RC"\n",
-					DP_UUID(cont->sc_uuid), DP_RC(rc));
+					DP_UUID(cont->sc_uuid), DP_RC(rc1));
 		}
 
 		break;
@@ -341,9 +341,14 @@ out:
 			if (mbs[i] == NULL)
 				continue;
 
+			/* For collective DTX, it will be synchronously committed soon. */
+			if (mbs[i]->dm_flags & DMF_CONTAIN_TARGET_GRP) {
+				D_FREE(mbs[i]);
+				continue;
+			}
+
 			daos_dti_copy(&dtes[j].dte_xid,
-				      (struct dtx_id *)
-				      din->di_dtx_array.ca_arrays + i);
+				      (struct dtx_id *)din->di_dtx_array.ca_arrays + i);
 			dtes[j].dte_ver = vers[i];
 			dtes[j].dte_refs = 1;
 			dtes[j].dte_mbs = mbs[i];
@@ -353,19 +358,19 @@ out:
 			j++;
 		}
 
-		D_ASSERT(j == rc1);
+		if (j > 0) {
+			/*
+			 * Commit the DTX after replied the original refresh request to
+			 * avoid further query the same DTX.
+			 */
+			rc = dtx_commit(cont, pdte, dcks, j);
+			if (rc < 0)
+				D_WARN("Failed to commit DTX "DF_DTI", count %d: "
+				       DF_RC"\n", DP_DTI(&dtes[0].dte_xid), j, DP_RC(rc));
 
-		/* Commit the DTX after replied the original refresh request to
-		 * avoid further query the same DTX.
-		 */
-		rc = dtx_commit(cont, pdte, dcks, j);
-		if (rc < 0)
-			D_WARN("Failed to commit DTX "DF_DTI", count %d: "
-			       DF_RC"\n", DP_DTI(&dtes[0].dte_xid), j,
-			       DP_RC(rc));
-
-		for (i = 0; i < j; i++)
-			D_FREE(pdte[i]->dte_mbs);
+			for (i = 0; i < j; i++)
+				D_FREE(pdte[i]->dte_mbs);
+		}
 	}
 
 	D_FREE(dout->do_sub_rets.ca_arrays);
@@ -375,10 +380,153 @@ out:
 		ds_cont_child_put(cont);
 }
 
+static void
+dtx_coll_handler(crt_rpc_t *rpc)
+{
+	struct dtx_coll_in		*dci = crt_req_get(rpc);
+	struct dtx_coll_out		*dco = crt_reply_get(rpc);
+	struct dtx_coll_load_mbs_args	 dclma = { 0 };
+	d_rank_t			 myrank = dss_self_rank();
+	uint32_t			 bitmap_sz = 0;
+	uint32_t			 opc = opc_get(rpc->cr_opc);
+	uint8_t				*hints = dci->dci_hints.ca_arrays;
+	uint8_t				*bitmap = NULL;
+	int				*results = NULL;
+	bool				 force_check = false;
+	int				 len;
+	int				 rc;
+	int				 i;
+
+	D_DEBUG(DB_TRACE, "Handling collective DTX PRC %u on rank %d for "DF_DTI"\n",
+		opc, myrank, DP_DTI(&dci->dci_xid));
+
+	D_ASSERT(hints != NULL);
+	D_ASSERT(dci->dci_hints.ca_count > myrank);
+
+	dclma.dclma_params = dci;
+	dclma.dclma_opc = opc;
+	rc = ABT_future_create(1, NULL, &dclma.dclma_future);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR("ABT_future_create failed: rc = %d\n", rc);
+		D_GOTO(out, rc = dss_abterr2der(rc));
+	}
+
+	rc = dss_ult_create(dtx_coll_load_mbs_ult, &dclma, DSS_XS_VOS, hints[myrank], 0, NULL);
+	if (rc != 0) {
+		ABT_future_free(&dclma.dclma_future);
+		D_ERROR("Failed to create ult on XS %u: "DF_RC"\n", hints[myrank], DP_RC(rc));
+		goto out;
+	}
+
+	rc = ABT_future_wait(dclma.dclma_future);
+	D_ASSERT(rc == ABT_SUCCESS);
+
+	ABT_future_free(&dclma.dclma_future);
+
+	switch (dclma.dclma_result) {
+	case 0:
+		rc = dtx_coll_prep(dci->dci_po_uuid, dclma.dclma_oid, dclma.dclma_mbs, myrank, -1,
+				   dci->dci_version, NULL /* p_hints */, NULL /* hint_sz */,
+				   &bitmap, &bitmap_sz, NULL /* p_ranks */);
+		if (rc != 0) {
+			D_ERROR("Failed to prepare the bitmap (and hints) for collective DTX "
+				DF_DTI" opc %u: "DF_RC"\n", DP_DTI(&dci->dci_xid), opc, DP_RC(rc));
+			goto out;
+		}
+		break;
+	case 1:
+		/* The DTX has been committed, then depends on the RPC type. */
+		if (opc == DTX_COLL_ABORT) {
+			D_ERROR("NOT allow to abort committed DTX "DF_DTI"\n",
+				DP_DTI(&dci->dci_xid));
+			D_GOTO(out, rc = -DER_NO_PERM);
+		}
+
+		if (opc == DTX_COLL_CHECK)
+			D_GOTO(out, rc = DTX_ST_COMMITTED);
+
+		D_ASSERT(opc == DTX_COLL_COMMIT);
+		/*
+		 * We do not know whether the DTX on the other VOS targets has been committed
+		 * or not, let's continue the commit on the other local VOS targets by force.
+		 */
+		break;
+	case -DER_INPROGRESS:
+		/* Fall through. */
+	case -DER_NONEXIST:
+		/* The shard on the hint VOS target may not exist, then depends on the RPC type. */
+		if (opc == DTX_COLL_CHECK)
+			force_check = true;
+
+		/*
+		 * It is unknown whether the DTX on the other VOS targets has been committed/aborted
+		 * or not, let's continue related operation on the other local VOS targets by force.
+		 */
+		break;
+	default:
+		D_ASSERTF(dclma.dclma_result < 0, "Unexpected result when load MBS for DTX "
+			  DF_DTI": "DF_RC"\n", DP_DTI(&dci->dci_xid), DP_RC(dclma.dclma_result));
+		D_GOTO(out, rc = dclma.dclma_result);
+	}
+
+	len = dtx_coll_local_exec(dci->dci_po_uuid, dci->dci_co_uuid, &dci->dci_xid, dci->dci_epoch,
+				  opc, bitmap_sz, bitmap, &results);
+	if (len < 0)
+		D_GOTO(out, rc = len);
+
+	if (opc == DTX_COLL_CHECK) {
+		for (i = 0; i < len; i++) {
+			if (bitmap == NULL || isset(bitmap, i))
+				dtx_merge_check_result(&rc, results[i]);
+		}
+
+		/*
+		 * For force check case, if no shard has been committed, we cannot trust the result
+		 * of -DER_NONEXIST, instead, returning -DER_INPROGRESS to make the leader to retry.
+		 */
+		if (force_check && rc == -DER_NONEXIST)
+			D_GOTO(out, rc = -DER_INPROGRESS);
+	} else {
+		for (i = 0; i < len; i++) {
+			if (bitmap == NULL || isset(bitmap, i)) {
+				if (results[i] >= 0)
+					dco->dco_misc += results[i];
+				else if (results[i] != -DER_NONEXIST && rc == 0)
+					rc = results[i];
+			}
+		}
+	}
+
+out:
+	D_CDEBUG(rc < 0, DLOG_ERR, DB_TRACE,
+		 "Handled collective DTX PRC %u on rank %u for "DF_DTI": "DF_RC"\n",
+		 opc, myrank, DP_DTI(&dci->dci_xid), DP_RC(rc));
+
+	dco->dco_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc < 0)
+		D_ERROR("Failed to send collective RPC %p reply: "DF_RC"\n", rpc, DP_RC(rc));
+
+	D_FREE(dclma.dclma_mbs);
+	D_FREE(bitmap);
+	D_FREE(results);
+}
+
 static int
 dtx_init(void)
 {
 	int	rc;
+
+	dtx_coll_tree_width = DTX_COLL_TREE_WIDTH_DEF;
+	d_getenv_int("DTX_COLL_TREE_WIDTH", &dtx_coll_tree_width);
+	if (dtx_coll_tree_width < DTX_COLL_TREE_WIDTH_MIN ||
+	    dtx_coll_tree_width > DTX_COLL_TREE_WIDTH_MAX) {
+		D_WARN("Invalid bcast RPC tree width %u, the valid range is [%u, %u], "
+		       "use the default value %u\n", dtx_coll_tree_width,
+		       DTX_COLL_TREE_WIDTH_MIN, DTX_COLL_TREE_WIDTH_MAX, DTX_COLL_TREE_WIDTH_DEF);
+		dtx_coll_tree_width = DTX_COLL_TREE_WIDTH_DEF;
+	}
+	D_INFO("Set bcast RPC tree width for collective transaction as %u\n", dtx_coll_tree_width);
 
 	dtx_agg_thd_cnt_up = DTX_AGG_THD_CNT_DEF;
 	d_getenv_int("DAOS_DTX_AGG_THD_CNT", &dtx_agg_thd_cnt_up);

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -97,6 +97,8 @@ dss_collective_reduce_internal(struct dss_coll_ops *ops,
 	int				xs_nr;
 	int				rc;
 	int				tid;
+	uint32_t			tgt_id = dss_get_module_info()->dmi_tgt_id;
+	bool				self = false;
 
 	if (ops == NULL || args == NULL || ops->co_func == NULL) {
 		D_DEBUG(DB_MD, "mandatory args missing dss_collective_reduce");
@@ -156,17 +158,17 @@ dss_collective_reduce_internal(struct dss_coll_ops *ops,
 		stream			= &stream_args->csa_streams[tid];
 		stream->st_coll_args	= &carg;
 
-		if (args->ca_exclude_tgts_cnt) {
-			int i;
-
-			for (i = 0; i < args->ca_exclude_tgts_cnt; i++)
-				if (args->ca_exclude_tgts[i] == tid)
-					break;
-
-			if (i < args->ca_exclude_tgts_cnt) {
+		if (args->ca_tgt_bitmap != NULL) {
+			if (tid >= args->ca_tgt_bitmap_sz << 3 ||
+			    isclr(args->ca_tgt_bitmap, tid)) {
 				D_DEBUG(DB_TRACE, "Skip tgt %d\n", tid);
 				rc = ABT_future_set(future, (void *)stream);
 				D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
+				continue;
+			}
+
+			if (tgt_id == tid && flags & DSS_USE_CURRENT_ULT) {
+				self = true;
 				continue;
 			}
 		}
@@ -208,6 +210,9 @@ next:
 			D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
 		}
 	}
+
+	if (self)
+		collective_func(&stream_args->csa_streams[tgt_id]);
 
 	ABT_future_wait(future);
 
@@ -320,6 +325,44 @@ int
 dss_thread_collective(int (*func)(void *), void *arg, unsigned int flags)
 {
 	return dss_collective_internal(func, arg, true, flags);
+}
+
+int
+dss_build_coll_bitmap(int *exclude_tgts, uint32_t exclude_cnt, uint8_t **p_bitmap,
+		      uint32_t *bitmap_sz)
+{
+	uint8_t		*bitmap = NULL;
+	uint32_t	 size = ((dss_tgt_nr - 1) >> 3) + 1;
+	int		 rc = 0;
+	int		 i;
+
+	D_ALLOC(bitmap, size);
+	if (bitmap == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	for (i = 0; i < size; i++)
+		bitmap[i] = 0xff;
+
+	for (i = dss_tgt_nr; i < (size << 3); i++)
+		clrbit(bitmap, i);
+
+	if (exclude_tgts == NULL)
+		goto out;
+
+	for (i = 0; i < exclude_cnt; i++) {
+		D_ASSERT(exclude_tgts[i] < dss_tgt_nr);
+		clrbit(bitmap, exclude_tgts[i]);
+	}
+
+out:
+	if (rc == 0) {
+		*p_bitmap = bitmap;
+		*bitmap_sz = size;
+	} else {
+		D_ERROR("Failed to build bitmap for collective task: "DF_RC"\n", DP_RC(rc));
+	}
+
+	return rc;
 }
 
 /* ============== ULT create functions =================================== */

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -62,6 +62,8 @@ enum dtx_mbs_flags {
 	 * shard index to sort the dtx_memberships::dm_tgts. Obsolete.
 	 */
 	DMF_SORTED_SAD_IDX		= (1 << 3),
+	/* The dtx_target_group information is appended after dtx_daos_target in dm_tgts. */
+	DMF_CONTAIN_TARGET_GRP		= (1 << 4),
 };
 
 /**
@@ -128,6 +130,20 @@ struct dtx_redundancy_group {
 	uint32_t			drg_ids[0];
 };
 
+/**
+ * Classify the shards that are described in dtx_daos_target based on the rank.
+ * With these information, the caller can easily know which shard(s) reside on
+ * the given daos engine (rank).
+ */
+struct dtx_target_group {
+	uint32_t			dtg_rank;
+	/* The index for the first shard on the given rank in dtx_memberships::dm_tgts. */
+	uint32_t			dtg_start_idx;
+	/* How many shards on the given rank that take part in the transaction. */
+	uint32_t			dtg_tgt_nr;
+	uint32_t			dtg_padding;
+};
+
 struct dtx_memberships {
 	/* How many touched shards in the DTX. */
 	uint32_t			dm_tgt_cnt;
@@ -153,7 +169,8 @@ struct dtx_memberships {
 	};
 
 	/* The first 'sizeof(struct dtx_daos_target) * dm_tgt_cnt' is the
-	 * dtx_daos_target array. The subsequent are modification groups.
+	 * dtx_daos_target array. The subsequent are redundancy groups or
+	 * dtx_target_group, depends on dm_flags.
 	 */
 	union {
 		char			dm_data[0];

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -206,6 +206,73 @@ struct daos_shard_tgt {
 	uint8_t			st_flags;	/* see daos_tgt_flags */
 };
 
+struct daos_coll_shard {
+	uint16_t		 dcs_nr;
+	uint16_t		 dcs_cap;
+	uint32_t		 dcs_inline;
+	/* The shards in the buffer locate on the same VOS target. */
+	uint32_t		*dcs_buf;
+};
+
+struct daos_coll_target {
+	uint32_t		 dct_rank;
+	/*
+	 * The size (in byte) of dct_bitmap. It (s << 3) may be smaller than dss_tgt_nr if only
+	 * some VOS targets are involved. It also maybe larger than dss_tgt_nr if dss_tgt_nr is
+	 * not 2 ^ n aligned.
+	 */
+	uint8_t			 dct_bitmap_sz;
+	uint8_t			 dct_padding;
+	/* How many valid items in dct_shards, it may be smaller than the sparse array length. */
+	uint16_t		 dct_shard_nr;
+	/* Bitmap for the vos targets (on the rank) that are involved in the operation. */
+	uint8_t			*dct_bitmap;
+	/* Sparse array for object shards' identifiers, sorted with vos targets index. */
+	struct daos_coll_shard	*dct_shards;
+
+	/* The following fields are only used on server side, not transferred on-wire. */
+
+	/* How many valid shards ID in dct_tgt_ids array. */
+	uint16_t		 dct_tgt_nr;
+	/* The capacity for the dct_tgt_ids array. */
+	uint16_t		 dct_tgt_cap;
+	/* ID array for shards on the engine, in spite of on which VOS target. */
+	uint32_t		*dct_tgt_ids;
+};
+
+static inline void
+daos_coll_shard_cleanup(struct daos_coll_shard *shards, uint32_t count)
+{
+	struct daos_coll_shard	*shard;
+	int			 i;
+
+	if (shards != NULL) {
+		for (i = 0; i < count; i++) {
+			shard = &shards[i];
+			if (shard->dcs_buf != &shard->dcs_inline)
+				D_FREE(shard->dcs_buf);
+		}
+		D_FREE(shards);
+	}
+}
+
+static inline void
+daos_coll_target_cleanup(struct daos_coll_target *dcts, uint32_t count)
+{
+	struct daos_coll_target	*dct;
+	int			 i;
+
+	if (dcts != NULL) {
+		for (i = 0; i < count; i++) {
+			dct = &dcts[i];
+			daos_coll_shard_cleanup(dct->dct_shards, dct->dct_bitmap_sz << 3);
+			D_FREE(dct->dct_bitmap);
+			D_FREE(dct->dct_tgt_ids);
+		}
+		D_FREE(dcts);
+	}
+}
+
 static inline bool
 daos_oid_is_null(daos_obj_id_t oid)
 {

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -506,6 +506,8 @@ enum dss_ult_flags {
 	DSS_ULT_FL_PERIODIC	= (1 << 0),
 	/* Use DSS_DEEP_STACK_SZ as the stack size */
 	DSS_ULT_DEEP_STACK	= (1 << 1),
+	/* Use current ULT (instead of creating new one) for the task. */
+	DSS_USE_CURRENT_ULT	= (1 << 2),
 };
 
 int dss_ult_create(void (*func)(void *), void *arg, int xs_type, int tgt_id,
@@ -575,8 +577,14 @@ struct dss_coll_args {
 	/** Arguments for dss_collective func (Mandatory) */
 	void				*ca_func_args;
 	void				*ca_aggregator;
-	int				*ca_exclude_tgts;
-	unsigned int			ca_exclude_tgts_cnt;
+	/* Specify on which targets to execute the task. */
+	uint8_t				*ca_tgt_bitmap;
+	/*
+	 * The size (in byte) of ca_tgt_bitmap. It may be smaller than dss_tgt_nr if only some
+	 * VOS targets are involved. It also may be larger than dss_tgt_nr if dss_tgt_nr is not
+	 * 2 ^ n aligned.
+	 */
+	uint32_t			 ca_tgt_bitmap_sz;
 	/** Stream arguments for all streams */
 	struct dss_coll_stream_args	ca_stream_args;
 };
@@ -598,6 +606,8 @@ dss_thread_collective_reduce(struct dss_coll_ops *ops,
 			     unsigned int flags);
 int dss_task_collective(int (*func)(void *), void *arg, unsigned int flags);
 int dss_thread_collective(int (*func)(void *), void *arg, unsigned int flags);
+int dss_build_coll_bitmap(int *exclude_tgts, uint32_t exclude_cnt, uint8_t **p_bitmap,
+			  uint32_t *bitmap_sz);
 
 /**
  * Loaded module management metholds

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -64,7 +64,6 @@ struct dtx_handle {
 					 dth_pinned:1,
 					 /* DTXs in CoS list are committed. */
 					 dth_cos_done:1,
-					 dth_resent:1, /* For resent case. */
 					 /* Only one participator in the DTX. */
 					 dth_solo:1,
 					 /* Do not keep committed entry. */
@@ -140,6 +139,7 @@ struct dtx_handle {
 struct dtx_sub_status {
 	struct daos_shard_tgt		dss_tgt;
 	int				dss_result;
+	uint32_t			dss_version;
 	uint32_t			dss_comp:1;
 };
 
@@ -152,6 +152,7 @@ struct dtx_leader_handle {
 	struct dtx_handle		dlh_handle;
 	/* result for the distribute transaction */
 	int				dlh_result;
+	uint32_t			dlh_rmt_ver;
 
 	/* The array of the DTX COS entries */
 	uint32_t			dlh_dti_cos_count;
@@ -164,12 +165,26 @@ struct dtx_leader_handle {
 	int32_t				dlh_allow_failure;
 					/* Normal sub requests have been processed. */
 	uint32_t			dlh_normal_sub_done:1,
+					 /* Collective DTX. */
+					 dlh_coll:1,
 					/* Drop conditional flags when forward RPC. */
 					dlh_drop_cond:1;
+	/* Ranks list for collective modification. */
+	d_rank_list_t			*dlh_coll_ranks;
+	/* VOS targets hint for collective modification. */
+	uint8_t				*dlh_coll_hints;
+	/* Bitmap for collective modification on local VOS targets. */
+	uint8_t				*dlh_coll_bitmap;
+	/* The size of dlh_coll_hints array. */
+	uint32_t			dlh_coll_hint_sz;
+	/* The size of dlh_coll_bitmap in bytes. */
+	uint32_t			dlh_coll_bitmap_sz;
+	/* The bcast RPC tree width for collective transaction */
+	uint16_t			dlh_coll_tree_width;
+	/* How many delay forward sub request. */
+	uint16_t			dlh_delay_sub_cnt;
 	/* How many normal sub request. */
 	uint32_t			dlh_normal_sub_cnt;
-	/* How many delay forward sub request. */
-	uint32_t			dlh_delay_sub_cnt;
 	/* The index of the first target that forward sub-request to. */
 	uint32_t			dlh_forward_idx;
 	/* The count of the targets that forward sub-request to. */
@@ -205,7 +220,7 @@ enum dtx_flags {
 	DTX_FOR_MIGRATION	= (1 << 3),
 	/** Ignore other uncommitted DTXs. */
 	DTX_IGNORE_UNCOMMITTED	= (1 << 4),
-	/** Resent request. */
+	/** Resent request. Out-of-date. */
 	DTX_RESEND		= (1 << 5),
 	/** Force DTX refresh if hit non-committed DTX on non-leader. Out-of-date DAOS-7878. */
 	DTX_FORCE_REFRESH	= (1 << 6),
@@ -213,6 +228,8 @@ enum dtx_flags {
 	DTX_PREPARED		= (1 << 7),
 	/** Do not keep committed entry. */
 	DTX_DROP_CMT		= (1 << 8),
+	/** Collective DTX. */
+	DTX_COLL		= (1 << 9),
 };
 
 void
@@ -220,12 +237,12 @@ dtx_renew_epoch(struct dtx_epoch *epoch, struct dtx_handle *dth);
 int
 dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash);
 int
-dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
-		 struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
-		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
-		 struct dtx_id *dti_cos, int dti_cos_cnt,
-		 struct daos_shard_tgt *tgts, int tgt_cnt, uint32_t flags,
-		 struct dtx_memberships *mbs, struct dtx_leader_handle **p_dlh);
+dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti, struct dtx_epoch *epoch,
+		 uint16_t sub_modification_cnt, uint32_t pm_ver, daos_unit_oid_t *leader_oid,
+		 struct dtx_id *dti_cos, int dti_cos_cnt, uint8_t *hints, uint32_t hint_sz,
+		 uint8_t *bitmap, uint32_t bitmap_sz, struct daos_shard_tgt *tgts, int tgt_cnt,
+		 uint32_t flags, d_rank_list_t *ranks, struct dtx_memberships *mbs,
+		 struct dtx_leader_handle **p_dlh);
 int
 dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int result);
 
@@ -260,9 +277,20 @@ void dtx_cont_deregister(struct ds_cont_child *cont);
 int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 		 daos_epoch_t epoch);
 
+int dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
+	       struct dtx_cos_key *dcks, int count);
+
 int dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch);
 
 int dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont);
+
+int dtx_coll_commit(struct ds_cont_child *cont, struct dtx_id *xid, d_rank_list_t *ranks,
+		    uint8_t *hints, uint32_t hint_sz, uint8_t *bitmap, uint32_t bitmap_sz,
+		    uint32_t version);
+
+int dtx_coll_abort(struct ds_cont_child *cont, struct dtx_id *xid, d_rank_list_t *ranks,
+		   uint8_t *hints, uint32_t hint_sz, uint8_t *bitmap, uint32_t bitmap_sz,
+		   uint32_t version, daos_epoch_t epoch);
 
 /**
  * Check whether the given DTX is resent one or not.

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -289,9 +289,9 @@ int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
 int ds_pool_svc_global_map_version_get(uuid_t uuid, uint32_t *global_ver);
 
 int
-ds_pool_child_map_refresh_sync(struct ds_pool_child *dpc);
+ds_pool_child_map_refresh_sync(uuid_t uuid, uint32_t version);
 int
-ds_pool_child_map_refresh_async(struct ds_pool_child *dpc);
+ds_pool_child_map_refresh_async(uuid_t uuid, uint32_t version);
 
 int
 map_ranks_init(const struct pool_map *map, unsigned int status, d_rank_list_t *ranks);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -103,12 +103,16 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
  *
  * \param coh		[IN]	Container open handle.
  * \param dti		[IN]	Pointer to the DTX identifier.
+ * \param oid		[OUT]	Pointer to the ID for the DTX leader object shard.
  * \param mbs		[OUT]	Pointer to the DTX participants information.
  *
- * \return		Zero on success, negative value if error.
+ * \return		Zero on success.
+ *			Positive if DTX has been committed.
+ *			Negative value if error.
  */
 int
-vos_dtx_load_mbs(daos_handle_t coh, struct dtx_id *dti, struct dtx_memberships **mbs);
+vos_dtx_load_mbs(daos_handle_t coh, struct dtx_id *dti, daos_unit_oid_t *oid,
+		 struct dtx_memberships **mbs);
 
 /**
  * Commit the specified DTXs.

--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -16,7 +16,10 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
+#define OBJ_COLL_PUNCH_THRESHOLD_MIN	16
+
 unsigned int	srv_io_mode = DIM_DTX_FULL_ENABLED;
+unsigned int	obj_coll_punch_thd;
 int		dc_obj_proto_version;
 
 /**
@@ -67,6 +70,16 @@ dc_obj_init(void)
 			daos_rpc_unregister(&obj_proto_fmt_1);
 		D_GOTO(out_class, rc);
 	}
+
+	obj_coll_punch_thd = OBJ_COLL_PUNCH_THRESHOLD_MIN;
+	d_getenv_int("OBJ_COLL_PUNCH_THRESHOLD", &obj_coll_punch_thd);
+	if (obj_coll_punch_thd < OBJ_COLL_PUNCH_THRESHOLD_MIN) {
+		D_WARN("Invalid collective punch threshold %u, it cannot be smaller than %u, "
+		       "use the default value %u\n", obj_coll_punch_thd,
+		       OBJ_COLL_PUNCH_THRESHOLD_MIN, OBJ_COLL_PUNCH_THRESHOLD_MIN);
+		obj_coll_punch_thd = OBJ_COLL_PUNCH_THRESHOLD_MIN;
+	}
+	D_INFO("Set object collective punch threshold as %u\n", obj_coll_punch_thd);
 
 	tx_verify_rdg = false;
 	d_getenv_bool("DAOS_TX_VERIFY_RDG", &tx_verify_rdg);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -17,6 +17,7 @@
 #include <daos/task.h>
 #include <daos_task.h>
 #include <daos_types.h>
+#include <daos/mgmt.h>
 #include <daos_obj.h>
 #include "obj_rpc.h"
 #include "obj_internal.h"
@@ -2833,6 +2834,7 @@ obj_embedded_shard_arg(struct obj_auxi_args *obj_auxi)
 	case DAOS_OBJ_RPC_SYNC:
 		return &obj_auxi->s_args.sa_auxi;
 	case DAOS_OBJ_RPC_QUERY_KEY:
+	case DAOS_OBJ_RPC_COLL_PUNCH:
 		/*
 		 * called from obj_comp_cb_internal() and
 		 * checked in obj_shard_comp_cb() correctly
@@ -4858,6 +4860,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 				dc_tx_attach(obj_auxi->th, obj, DAOS_OBJ_RPC_FETCH, task, 0, false);
 			break;
 		}
+		case DAOS_OBJ_RPC_COLL_PUNCH:
 		case DAOS_OBJ_RPC_PUNCH:
 		case DAOS_OBJ_RPC_PUNCH_DKEYS:
 		case DAOS_OBJ_RPC_PUNCH_AKEYS:
@@ -6654,21 +6657,66 @@ shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 }
 
 static int
+dc_obj_coll_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
+		  uint32_t map_ver, daos_obj_punch_t *args, struct obj_auxi_args *auxi)
+{
+	struct shard_punch_args	*spa = &auxi->p_args;
+	struct dc_obj_shard	*shard = NULL;
+	uint32_t		 flags = ORF_LEADER;
+	uint32_t		 off;
+	int			 rc;
+	int			 i;
+
+	for (i = 0, off = obj->cob_md.omd_id.lo % obj->cob_shards_nr; i < obj->cob_shards_nr;
+	     i++, off = (off + 1) % obj->cob_shards_nr) {
+		rc = obj_shard_open(obj, off, map_ver, &shard);
+		if (rc == 0) {
+			if (!shard->do_rebuilding && !shard->do_reintegrating)
+				break;
+
+			obj_shard_close(shard);
+		}
+
+		if (rc != -DER_NONEXIST)
+			goto out;
+	}
+
+	/* If all shards are NONEXIST, then need not send collective punch RPC. */
+	if (unlikely(i == obj->cob_shards_nr))
+		D_GOTO(out, rc = 0);
+
+	if (auxi->io_retry)
+		flags |= ORF_RESEND;
+	else
+		daos_dti_gen(&spa->pa_dti, false);
+	if (obj_is_ec(obj))
+		flags |= ORF_EC;
+
+	/* The shard will be closed via RPC callback in dc_obj_shard_coll_punch(). */
+	return dc_obj_shard_coll_punch(shard, spa, epoch, args->flags, flags, map_ver,
+				       &auxi->map_ver_reply, task);
+
+out:
+	DL_CDEBUG(rc == 0, DB_IO, DLOG_ERR, rc,
+		  "DAOS_OBJ_RPC_COLL_PUNCH for "DF_OID" map_ver %u, task %p",
+		  DP_OID(obj->cob_md.omd_id), map_ver, task);
+
+	obj_task_complete(task, rc);
+
+	return rc;
+}
+
+static int
 dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
 	     uint32_t map_ver, enum obj_rpc_opc opc, daos_obj_punch_t *api_args)
 {
 	struct obj_auxi_args	*obj_auxi;
+	struct dc_pool		*pool;
 	uint32_t		shard;
 	uint32_t		shard_cnt;
 	uint32_t		grp_cnt;
+	uint32_t		node_cnt;
 	int			rc;
-
-	if (opc == DAOS_OBJ_RPC_PUNCH && obj->cob_grp_nr > 1)
-		/* The object have multiple redundancy groups, use DAOS
-		 * internal transaction to handle that to guarantee the
-		 * atomicity of punch object.
-		 */
-		return dc_tx_convert(obj, opc, task);
 
 	rc = obj_task_init(task, opc, map_ver, api_args->th, &obj_auxi, obj);
 	if (rc != 0) {
@@ -6683,6 +6731,40 @@ dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
 
 	if (opc == DAOS_OBJ_RPC_PUNCH) {
 		obj_ptr2shards(obj, &shard, &shard_cnt, &grp_cnt);
+
+		if (grp_cnt > 1) {
+			/*
+			 * We support object collective punch since release-2.6 (and may 2.4.x)
+			 * (version 10). The conditions to trigger object collective punch are:
+			 *
+			 * 1. The shards count exceeds the engines count. Means that there are
+			 *    some shards reside on the same engine. Collectively punch object
+			 *    will save some RPCs. Or
+			 *
+			 * 2. The shards count exceeds the threshold for collective punch (16
+			 *    by default). Collectively punch object will distribute the RPCs
+			 *    load among more engines even if the total RPCs count may be not
+			 *    decreased too much.
+			 *
+			 * If the object has multiple redundancy groups, but cannot match any
+			 * above condition, then we will use internal distributed transaction
+			 * to guarantee the atomicity of punch all object shards.
+			 */
+			if (dc_obj_proto_version <= 9)
+				D_GOTO(out_task, rc = -DER_NEED_TX);
+
+			pool = obj->cob_pool;
+			D_RWLOCK_RDLOCK(&pool->dp_map_lock);
+			node_cnt = pool_map_node_nr(pool->dp_map);
+			D_RWLOCK_UNLOCK(&pool->dp_map_lock);
+
+			if (shard_cnt <= obj_coll_punch_thd && shard_cnt <= node_cnt)
+				D_GOTO(out_task, rc = -DER_NEED_TX);
+
+			obj_auxi->opc = DAOS_OBJ_RPC_COLL_PUNCH;
+
+			return dc_obj_coll_punch(task, obj, epoch, map_ver, api_args, obj_auxi);
+		}
 	} else {
 		grp_cnt = 1;
 		obj_auxi->dkey_hash = obj_dkey2hash(obj->cob_md.omd_id, api_args->dkey);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1278,6 +1278,105 @@ out:
 	return rc;
 }
 
+struct obj_coll_punch_cb_args {
+	crt_rpc_t		*ocpca_rpc;
+	uint32_t		*ocpca_ver;
+	struct dc_obj_shard	*ocpca_shard;
+};
+
+static int
+obj_shard_coll_punch_cb(tse_task_t *task, void *data)
+{
+	struct obj_coll_punch_cb_args	*cb_args = data;
+	crt_rpc_t			*rpc = cb_args->ocpca_rpc;
+	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
+
+	if (task->dt_result == 0) {
+		task->dt_result = obj_reply_get_status(rpc);
+		*cb_args->ocpca_ver = obj_reply_map_version_get(rpc);
+	}
+
+	DL_CDEBUG(task->dt_result < 0, DLOG_ERR, DB_IO, task->dt_result,
+		  "DAOS_OBJ_RPC_COLL_PUNCH RPC %p for "DF_UOID" on leader %u with DTX "
+		  DF_DTI" for task %p, map_ver %u/%u, flags %lx/%x\n",
+		  rpc, DP_UOID(ocpi->ocpi_oid), ocpi->ocpi_leader_id, DP_DTI(&ocpi->ocpi_xid),
+		  task, ocpi->ocpi_map_ver, *cb_args->ocpca_ver,
+		  (unsigned long)ocpi->ocpi_api_flags, ocpi->ocpi_flags);
+
+	crt_req_decref(rpc);
+	obj_shard_decref(cb_args->ocpca_shard);
+
+	return task->dt_result;
+}
+
+int
+dc_obj_shard_coll_punch(struct dc_obj_shard *shard, struct shard_punch_args *args,
+			struct dtx_epoch *epoch, uint64_t api_flags, uint32_t rpc_flags,
+			uint32_t map_ver, uint32_t *rep_ver, tse_task_t *task)
+{
+	struct dc_pool			*pool = obj_shard_ptr2pool(shard);
+	crt_rpc_t			*req = NULL;
+	struct obj_coll_punch_in	*ocpi = NULL;
+	struct obj_coll_punch_cb_args	 cb_args = { 0 };
+	crt_endpoint_t			 tgt_ep = { 0 };
+	int				 rc = 0;
+
+	D_ASSERT(pool != NULL);
+
+	tgt_ep.ep_grp = pool->dp_sys->sy_group;
+	tgt_ep.ep_rank = shard->do_target_rank;
+	tgt_ep.ep_tag = shard->do_target_idx;
+
+	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, DAOS_OBJ_RPC_COLL_PUNCH, &req);
+	if (rc != 0)
+		goto out;
+
+	ocpi = crt_req_get(req);
+	D_ASSERT(ocpi != NULL);
+
+	uuid_copy(ocpi->ocpi_po_uuid, pool->dp_pool);
+	uuid_copy(ocpi->ocpi_co_hdl, shard->do_co->dc_cont_hdl);
+	uuid_copy(ocpi->ocpi_co_uuid, shard->do_co->dc_uuid);
+	ocpi->ocpi_oid = shard->do_id;
+	ocpi->ocpi_epoch = epoch->oe_value;
+	ocpi->ocpi_api_flags = api_flags;
+	ocpi->ocpi_map_ver = map_ver;
+	ocpi->ocpi_leader_id = shard->do_target_id;
+	ocpi->ocpi_flags = rpc_flags;
+	daos_dti_copy(&ocpi->ocpi_xid, &args->pa_dti);
+
+	crt_req_addref(req);
+	cb_args.ocpca_rpc = req;
+	cb_args.ocpca_ver = rep_ver;
+	cb_args.ocpca_shard = shard;
+
+	rc = tse_task_register_comp_cb(task, obj_shard_coll_punch_cb, &cb_args, sizeof(cb_args));
+	if (rc != 0)
+		D_GOTO(out_req, rc);
+
+	D_DEBUG(DB_IO, "Sending DAOS_OBJ_RPC_COLL_PUNCH RPC %p for "DF_UOID" with DTX "
+		DF_DTI" for task %p, map_ver %u, flags %lx/%x, leader %u/%u\n",
+		req, DP_UOID(shard->do_id), DP_DTI(&args->pa_dti), task, map_ver,
+		(unsigned long)api_flags, rpc_flags, tgt_ep.ep_rank, tgt_ep.ep_tag);
+
+	return daos_rpc_send(req, task);
+
+out_req:
+	/* -1 for crt_req_addref(). */
+	crt_req_decref(req);
+	/* -1 for obj_req_create(). */
+	crt_req_decref(req);
+out:
+	D_ERROR("DAOS_OBJ_RPC_COLL_PUNCH RPC failed for "DF_UOID" with DTX "
+		DF_DTI" for task %p, map_ver %u, flags %lx/%x, leader %u/%u: "DF_RC"\n",
+		DP_UOID(shard->do_id), DP_DTI(&args->pa_dti), task, map_ver,
+		(unsigned long)api_flags, rpc_flags, tgt_ep.ep_rank, tgt_ep.ep_tag, DP_RC(rc));
+
+	obj_shard_decref(shard);
+	tse_task_complete(task, rc);
+	return rc;
+}
+
 struct obj_enum_args {
 	crt_rpc_t		*rpc;
 	daos_handle_t		*hdlp;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -41,6 +41,7 @@ struct obj_io_context;
 extern bool	cli_bypass_rpc;
 /** Switch of server-side IO dispatch */
 extern unsigned int	srv_io_mode;
+extern unsigned int	obj_coll_punch_thd;
 
 /* Whether check redundancy group validation when DTX resync. */
 extern bool	tx_verify_rdg;
@@ -567,6 +568,10 @@ ec_obj_update_encode(tse_task_t *task, daos_obj_id_t oid,
 int dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		       void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
 		       uint32_t fw_cnt, tse_task_t *task);
+
+int dc_obj_shard_coll_punch(struct dc_obj_shard *shard, struct shard_punch_args *args,
+			    struct dtx_epoch *epoch, uint64_t api_flags, uint32_t rpc_flags,
+			    uint32_t map_ver, uint32_t *rep_ver, tse_task_t *task);
 
 int dc_obj_shard_list(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		      void *shard_args, struct daos_shard_tgt *fw_shard_tgts,

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2023 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -546,13 +546,10 @@ crt_proc_struct_daos_cpd_sub_head(crt_proc_t proc, crt_proc_op_t proc_op,
 	}
 
 	rc = crt_proc_memcpy(proc, proc_op, dcsh->dcsh_mbs, size);
-	if (unlikely(rc)) {
-		if (DECODING(proc_op))
-			D_FREE(dcsh->dcsh_mbs);
-		return rc;
-	}
+	if (unlikely(rc) && DECODING(proc_op))
+		D_FREE(dcsh->dcsh_mbs);
 
-	return 0;
+	return rc;
 }
 
 static int
@@ -848,11 +845,6 @@ crt_proc_struct_daos_cpd_bulk(crt_proc_t proc, crt_proc_op_t proc_op,
 			return rc;
 	}
 
-	if (FREEING(proc_op)) {
-		D_FREE(dcb->dcb_bulk);
-		return 0;
-	}
-
 	rc = crt_proc_uint32_t(proc, proc_op, &dcb->dcb_size);
 	if (unlikely(rc))
 		return rc;
@@ -870,6 +862,9 @@ crt_proc_struct_daos_cpd_bulk(crt_proc_t proc, crt_proc_op_t proc_op,
 	rc = crt_proc_crt_bulk_t(proc, proc_op, dcb->dcb_bulk);
 	if (unlikely(rc))
 		return rc;
+
+	if (FREEING(proc_op))
+		D_FREE(dcb->dcb_bulk);
 
 	/* The other fields will not be packed on-wire. */
 
@@ -1039,6 +1034,7 @@ CRT_RPC_DEFINE(obj_ec_agg, DAOS_ISEQ_OBJ_EC_AGG, DAOS_OSEQ_OBJ_EC_AGG)
 CRT_RPC_DEFINE(obj_cpd, DAOS_ISEQ_OBJ_CPD, DAOS_OSEQ_OBJ_CPD)
 CRT_RPC_DEFINE(obj_ec_rep, DAOS_ISEQ_OBJ_EC_REP, DAOS_OSEQ_OBJ_EC_REP)
 CRT_RPC_DEFINE(obj_key2anchor, DAOS_ISEQ_OBJ_KEY2ANCHOR, DAOS_OSEQ_OBJ_KEY2ANCHOR)
+CRT_RPC_DEFINE(obj_coll_punch, DAOS_ISEQ_OBJ_COLL_PUNCH, DAOS_OSEQ_OBJ_COLL_PUNCH)
 
 /* Define for obj_proto_rpc_fmt[] array population below.
  * See OBJ_PROTO_*_RPC_LIST macro definition
@@ -1116,6 +1112,9 @@ obj_reply_set_status(crt_rpc_t *rpc, int status)
 	case DAOS_OBJ_RPC_EC_REPLICATE:
 		((struct obj_ec_rep_out *)reply)->er_status = status;
 		break;
+	case DAOS_OBJ_RPC_COLL_PUNCH:
+		((struct obj_coll_punch_out *)reply)->ocpo_ret = status;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -1155,6 +1154,8 @@ obj_reply_get_status(crt_rpc_t *rpc)
 		return ((struct obj_cpd_out *)reply)->oco_ret;
 	case DAOS_OBJ_RPC_EC_REPLICATE:
 		return ((struct obj_ec_rep_out *)reply)->er_status;
+	case DAOS_OBJ_RPC_COLL_PUNCH:
+		return ((struct obj_coll_punch_out *)reply)->ocpo_ret;
 	default:
 		D_ASSERT(0);
 	}
@@ -1204,6 +1205,9 @@ obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version)
 	case DAOS_OBJ_RPC_EC_REPLICATE:
 		((struct obj_ec_rep_out *)reply)->er_map_ver = map_version;
 		break;
+	case DAOS_OBJ_RPC_COLL_PUNCH:
+		((struct obj_coll_punch_out *)reply)->ocpo_map_version = map_version;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -1239,6 +1243,8 @@ obj_reply_map_version_get(crt_rpc_t *rpc)
 		return ((struct obj_sync_out *)reply)->oso_map_version;
 	case DAOS_OBJ_RPC_CPD:
 		return ((struct obj_cpd_out *)reply)->oco_map_version;
+	case DAOS_OBJ_RPC_COLL_PUNCH:
+		return ((struct obj_coll_punch_out *)reply)->ocpo_map_version;
 	default:
 		D_ASSERT(0);
 	}

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -31,7 +31,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See daos_rpc.h.
  */
-#define DAOS_OBJ_VERSION 9
+#define DAOS_OBJ_VERSION 10
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr and name
  */
@@ -96,7 +96,10 @@
 		ds_obj_cpd_handler, NULL, "compound")			\
 	X(DAOS_OBJ_RPC_KEY2ANCHOR,					\
 		0, &CQF_obj_key2anchor,					\
-		ds_obj_key2anchor_handler, NULL, "key2anchor")
+		ds_obj_key2anchor_handler, NULL, "key2anchor")		\
+	X(DAOS_OBJ_RPC_COLL_PUNCH,					\
+		0, &CQF_obj_coll_punch, ds_obj_coll_punch_handler,	\
+		&obj_coll_punch_co_ops, "obj_coll_punch")
 
 /* Define for RPC enum population below */
 #define X(a, b, c, d, e, f) a,
@@ -107,6 +110,7 @@ enum obj_rpc_opc {
 };
 #undef X
 
+extern struct crt_corpc_ops obj_coll_punch_co_ops;
 extern struct crt_proto_format obj_proto_fmt_0;
 extern struct crt_proto_format obj_proto_fmt_1;
 extern int dc_obj_proto_version;
@@ -147,8 +151,8 @@ enum obj_rpc_flags {
 	 * oei_epr.epr_hi is epoch.
 	 */
 	ORF_ENUM_WITHOUT_EPR	= (1 << 8),
-	/* CPD RPC leader */
-	ORF_CPD_LEADER		= (1 << 9),
+	/* RPC leader */
+	ORF_LEADER		= (1 << 9),
 	/* Bulk data transfer for CPD RPC. */
 	ORF_CPD_BULK		= (1 << 10),
 	/* Contain EC split req, only used on CPD leader locally. Obsolete - DAOS-10348. */
@@ -636,6 +640,27 @@ struct daos_cpd_sg {
 
 CRT_RPC_DECLARE(obj_cpd, DAOS_ISEQ_OBJ_CPD, DAOS_OSEQ_OBJ_CPD)
 
+#define DAOS_ISEQ_OBJ_COLL_PUNCH	/* input fields */				\
+	((struct dtx_id)		(ocpi_xid)			CRT_VAR)	\
+	((uuid_t)			(ocpi_po_uuid)			CRT_VAR)	\
+	((uuid_t)			(ocpi_co_hdl)			CRT_VAR)	\
+	((uuid_t)			(ocpi_co_uuid)			CRT_VAR)	\
+	((daos_unit_oid_t)		(ocpi_oid)			CRT_RAW)	\
+	((uint64_t)			(ocpi_epoch)			CRT_VAR)	\
+	((uint64_t)			(ocpi_api_flags)		CRT_VAR)	\
+	((uint32_t)			(ocpi_map_ver)			CRT_VAR)	\
+	((uint32_t)			(ocpi_flags)			CRT_VAR)	\
+	((uint32_t)			(ocpi_fdom_lvl)			CRT_VAR)	\
+	((uint32_t)			(ocpi_pdom_lvl)			CRT_VAR)	\
+	((uint32_t)			(ocpi_pda)			CRT_VAR)	\
+	((uint32_t)			(ocpi_leader_id)		CRT_VAR)
+
+#define DAOS_OSEQ_OBJ_COLL_PUNCH	/* output fields */				\
+	((int32_t)			(ocpo_ret)			CRT_VAR)	\
+	((uint32_t)			(ocpo_map_version)		CRT_VAR)
+
+CRT_RPC_DECLARE(obj_coll_punch, DAOS_ISEQ_OBJ_COLL_PUNCH, DAOS_OSEQ_OBJ_COLL_PUNCH)
+
 static inline int
 obj_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,
 	       crt_rpc_t **req)
@@ -668,7 +693,7 @@ obj_is_modification_opc(uint32_t opc)
 		opc == DAOS_OBJ_RPC_PUNCH_DKEYS ||
 		opc == DAOS_OBJ_RPC_TGT_PUNCH_DKEYS ||
 		opc == DAOS_OBJ_RPC_PUNCH_AKEYS ||
-		opc == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS;
+		opc == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS || opc == DAOS_OBJ_RPC_COLL_PUNCH;
 }
 
 #define DAOS_OBJ_UPDATE_MODE_MASK	(DAOS_OO_RW | DAOS_OO_EXCL |	\

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -2305,7 +2305,7 @@ dc_tx_commit_trigger(tse_task_t *task, struct dc_tx *tx, daos_tx_commit_t *args)
 
 	uuid_copy(oci->oci_pool_uuid, tx->tx_pool->dp_pool);
 	oci->oci_map_ver = tx->tx_pm_ver;
-	oci->oci_flags = ORF_CPD_LEADER;
+	oci->oci_flags = ORF_LEADER;
 	if (tx->tx_set_resend && !tx->tx_renew)
 		oci->oci_flags |= ORF_RESEND;
 	tx->tx_renew = 0;

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -238,6 +238,7 @@ struct ds_obj_exec_arg {
 	crt_rpc_t		*rpc;
 	struct obj_io_context	*ioc;
 	void			*args;
+	struct daos_coll_shard	*shards;
 	uint32_t		 flags;
 	uint32_t		 start; /* The start shard for EC obj. */
 };
@@ -251,6 +252,9 @@ ds_obj_remote_punch(struct dtx_leader_handle *dth, void *arg, int idx,
 int
 ds_obj_cpd_dispatch(struct dtx_leader_handle *dth, void *arg, int idx,
 		    dtx_sub_comp_cb_t comp_cb);
+int
+ds_obj_coll_punch_remote(struct dtx_leader_handle *dth, void *arg, int idx,
+			 dtx_sub_comp_cb_t comp_cb);
 
 /* srv_obj.c */
 void ds_obj_rw_handler(crt_rpc_t *rpc);
@@ -265,6 +269,7 @@ void ds_obj_migrate_handler(crt_rpc_t *rpc);
 void ds_obj_ec_agg_handler(crt_rpc_t *rpc);
 void ds_obj_ec_rep_handler(crt_rpc_t *rpc);
 void ds_obj_cpd_handler(crt_rpc_t *rpc);
+void ds_obj_coll_punch_handler(crt_rpc_t *rpc);
 typedef int (*ds_iofw_cb_t)(crt_rpc_t *req, void *arg);
 
 struct daos_cpd_args {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -15,6 +15,8 @@
 
 #include <abt.h>
 #include <daos/rpc.h>
+#include <daos/placement.h>
+#include <daos/pool_map.h>
 #include <daos/cont_props.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/rebuild.h>
@@ -2143,6 +2145,7 @@ obj_ioc_begin_lite(uint32_t rpc_map_ver, uuid_t pool_uuid,
 	struct obj_tls		*tls;
 	struct ds_pool_child	*poc;
 	int			rc;
+	bool			once = false;
 
 	rc = obj_ioc_init(pool_uuid, coh_uuid, cont_uuid, rpc, ioc);
 	if (rc)
@@ -2176,14 +2179,17 @@ obj_ioc_begin_lite(uint32_t rpc_map_ver, uuid_t pool_uuid,
 		 */
 		D_DEBUG(DB_IO, "stale server map_version %d req %d\n",
 			ioc->ioc_map_ver, rpc_map_ver);
-		rc = ds_pool_child_map_refresh_async(poc);
+		rc = ds_pool_child_map_refresh_async(poc->spc_uuid, poc->spc_map_version);
 		if (rc == 0) {
 			ioc->ioc_map_ver = poc->spc_map_version;
 			rc = -DER_STALE;
 		}
 
 		D_GOTO(out, rc);
-	} else if (unlikely(rpc_map_ver < ioc->ioc_map_ver)) {
+	}
+
+again:
+	if (unlikely(rpc_map_ver < ioc->ioc_map_ver)) {
 		D_DEBUG(DB_IO, "stale version req %d map_version %d\n",
 			rpc_map_ver, ioc->ioc_map_ver);
 
@@ -2194,9 +2200,32 @@ obj_ioc_begin_lite(uint32_t rpc_map_ver, uuid_t pool_uuid,
 			D_GOTO(out, rc = -DER_TX_RESTART);
 
 		D_GOTO(out, rc = -DER_STALE);
-	} else if (DAOS_FAIL_CHECK(DAOS_DTX_STALE_PM)) {
-		D_GOTO(out, rc = -DER_STALE);
 	}
+
+	if (rpc_map_ver > ioc->ioc_map_ver && opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_COLL_PUNCH) {
+		if (unlikely(once)) {
+			D_WARN("Still hold stale map %u vs %u for pool "DF_UUID" after refresh. "
+			       "Please check whether client offers version is correct or not.\n",
+			       rpc_map_ver, ioc->ioc_map_ver, DP_UUID(poc->spc_uuid));
+			D_GOTO(out, rc = -DER_INVAL);
+		}
+
+		/*
+		 * For collective punch, the map version must be matched among client and
+		 * engines, otherwise, different engines may get different object layouts.
+		 */
+		rc = ds_pool_child_map_refresh_sync(poc->spc_uuid, rpc_map_ver);
+		if (rc != 0)
+			goto out;
+
+		ioc->ioc_map_ver = poc->spc_map_version;
+		once = true;
+
+		goto again;
+	}
+
+	if (DAOS_FAIL_CHECK(DAOS_DTX_STALE_PM))
+		D_GOTO(out, rc = -DER_STALE);
 
 out:
 	dss_rpc_cntr_enter(DSS_RC_OBJ);
@@ -2596,8 +2625,6 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 		if (rc < 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
-
-		dtx_flags |= DTX_RESEND;
 	}
 
 	/* Inject failure for test to simulate the case of lost some
@@ -2787,6 +2814,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	int				dti_cos_cnt;
 	uint32_t			tgt_cnt;
 	uint32_t			version = 0;
+	uint32_t			max_ver = 0;
 	struct dtx_epoch		epoch = {0};
 	int				rc;
 	bool				need_abort = false;
@@ -2857,6 +2885,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	}
 
 	version = orw->orw_map_ver;
+	max_ver = orw->orw_map_ver;
 
 	if (tgt_cnt == 0) {
 		if (!(orw->orw_api_flags & DAOS_COND_MASK))
@@ -2873,7 +2902,6 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	if (orw->orw_flags & ORF_RESEND) {
 		daos_epoch_t		 e;
 
-		dtx_flags |= DTX_RESEND;
 		d_tm_inc_counter(opm->opm_update_resent, 1);
 
 again1:
@@ -2934,9 +2962,10 @@ again2:
 	else
 		dtx_flags &= ~DTX_PREPARED;
 
-	rc = dtx_leader_begin(ioc.ioc_vos_coh, &orw->orw_dti, &epoch, 1,
-			      version, &orw->orw_oid, dti_cos, dti_cos_cnt,
-			      tgts, tgt_cnt, dtx_flags, mbs, &dlh);
+	rc = dtx_leader_begin(ioc.ioc_vos_coh, &orw->orw_dti, &epoch, 1, version, &orw->orw_oid,
+			      dti_cos, dti_cos_cnt, NULL /* hints */, 0 /* hint_sz */,
+			      NULL /* bitmap */, 0 /* bitmap_sz */, tgts, tgt_cnt, dtx_flags,
+			      NULL /* ranks */, mbs, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID ": Failed to start DTX for update " DF_RC "\n",
 			DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -2950,6 +2979,9 @@ again2:
 
 	/* Execute the operation on all targets */
 	rc = dtx_leader_exec_ops(dlh, obj_tgt_update, NULL, 0, &exec_arg);
+
+	if (max_ver < dlh->dlh_rmt_ver)
+		max_ver = dlh->dlh_rmt_ver;
 
 	/* Stop the distributed transaction */
 	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
@@ -3003,6 +3035,9 @@ out:
 			D_WARN("Failed to abort DTX "DF_DTI": "DF_RC"\n",
 			       DP_DTI(&orw->orw_dti), DP_RC(rc1));
 	}
+
+	if (ioc.ioc_map_ver < max_ver)
+		ioc.ioc_map_ver = max_ver;
 
 	obj_rw_reply(rpc, rc, epoch.oe_value, &ioc);
 	D_FREE(mbs);
@@ -3450,6 +3485,7 @@ again:
 	switch (opc) {
 	case DAOS_OBJ_RPC_PUNCH:
 	case DAOS_OBJ_RPC_TGT_PUNCH:
+	case DAOS_OBJ_RPC_COLL_PUNCH:
 		rc = vos_obj_punch(cont->sc_hdl, opi->opi_oid,
 				   opi->opi_epoch, opi->opi_map_ver,
 				   0, NULL, 0, NULL, dth);
@@ -3487,58 +3523,55 @@ out:
 	return rc;
 }
 
-/* Handle the punch requests on non-leader */
-void
-ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
-{
-	struct dtx_handle		*dth = NULL;
-	struct obj_io_context		 ioc;
-	struct obj_punch_in		*opi;
-	struct dtx_memberships		*mbs = NULL;
-	struct daos_shard_tgt		*tgts = NULL;
-	uint32_t			 dtx_flags = 0;
-	uint32_t			 tgt_cnt;
-	struct dtx_epoch		 epoch;
-	int				 rc;
+struct obj_tgt_punch_args {
+	uint32_t		 opc;
+	struct obj_io_context	*sponsor_ioc;
+	struct dtx_handle	*sponsor_dth;
+	struct obj_punch_in	*opi;
+	struct dtx_memberships	*mbs;
+	uint32_t		*ver;
+	void			*data;
+};
 
-	opi = crt_req_get(rpc);
-	D_ASSERT(opi != NULL);
-	rc = obj_ioc_begin(opi->opi_oid.id_pub, opi->opi_map_ver,
-			   opi->opi_pool_uuid, opi->opi_co_hdl,
-			   opi->opi_co_uuid, rpc, opi->opi_flags, &ioc);
-	if (rc)
+static int
+obj_tgt_punch(struct obj_tgt_punch_args *otpa, uint32_t *shards, uint32_t count)
+{
+	struct obj_io_context	 ioc = { 0 };
+	struct obj_io_context	*p_ioc = &ioc;
+	struct obj_punch_in	*opi = otpa->opi;
+	struct dtx_handle	*dth = NULL;
+	struct dtx_epoch	 epoch;
+	daos_epoch_t		 tmp;
+	uint32_t		 dtx_flags = 0;
+	int			 rc = 0;
+	int			 i;
+
+	if (otpa->sponsor_ioc != NULL) {
+		p_ioc = otpa->sponsor_ioc;
+		dth = otpa->sponsor_dth;
+		goto exec;
+	}
+
+	rc = obj_ioc_begin(opi->opi_oid.id_pub, opi->opi_map_ver, opi->opi_pool_uuid,
+			   opi->opi_co_hdl, opi->opi_co_uuid, otpa->data, opi->opi_flags, &ioc);
+	if (rc != 0)
 		goto out;
 
-	/* Handle resend. */
 	if (opi->opi_flags & ORF_RESEND) {
-		daos_epoch_t	e = opi->opi_epoch;
-
-		rc = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_dti, &e, NULL);
+		tmp = opi->opi_epoch;
+		rc = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_dti, &tmp, NULL);
 		/* Do nothing if 'prepared' or 'committed'. */
 		if (rc == -DER_ALREADY || rc == 0)
 			D_GOTO(out, rc = 0);
 
-		/* Abort it firstly if exist but with different epoch,
-		 * then re-execute with new epoch.
-		 */
+		/* Abort old one with different epoch, then re-execute with new epoch. */
 		if (rc == -DER_MISMATCH)
 			/* Abort it by force with MAX epoch to guarantee
 			 * that it can be aborted.
 			 */
-			rc = vos_dtx_abort(ioc.ioc_vos_coh, &opi->opi_dti, e);
+			rc = vos_dtx_abort(ioc.ioc_vos_coh, &opi->opi_dti, tmp);
 
 		if (rc < 0 && rc != -DER_NONEXIST)
-			D_GOTO(out, rc);
-
-		dtx_flags |= DTX_RESEND;
-	}
-
-	tgts = opi->opi_shard_tgts.ca_arrays;
-	tgt_cnt = opi->opi_shard_tgts.ca_count;
-
-	if (!daos_is_zero_dti(&opi->opi_dti) && tgt_cnt != 0) {
-		rc = obj_gen_dtx_mbs(opi->opi_flags, &tgt_cnt, &tgts, &mbs);
-		if (rc != 0)
 			D_GOTO(out, rc);
 	}
 
@@ -3550,10 +3583,9 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 		dtx_flags |= DTX_SYNC;
 
 	/* Start the local transaction */
-	rc = dtx_begin(ioc.ioc_vos_coh, &opi->opi_dti, &epoch, 1,
-		       opi->opi_map_ver, &opi->opi_oid,
-		       opi->opi_dti_cos.ca_arrays,
-		       opi->opi_dti_cos.ca_count, dtx_flags, mbs, &dth);
+	rc = dtx_begin(ioc.ioc_vos_coh, &opi->opi_dti, &epoch, count, opi->opi_map_ver,
+		       &opi->opi_oid, opi->opi_dti_cos.ca_arrays, opi->opi_dti_cos.ca_count,
+		       dtx_flags, otpa->mbs, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID ": Failed to start DTX for punch " DF_RC "\n",
 			DP_UOID(opi->opi_oid), DP_RC(rc));
@@ -3563,19 +3595,58 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	if (DAOS_FAIL_CHECK(DAOS_DTX_NONLEADER_ERROR))
 		D_GOTO(out, rc = -DER_IO);
 
-	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), &ioc, dth);
-	if (rc != 0)
-		DL_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
-			      (rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
-			  DB_IO, DLOG_ERR, rc, DF_UOID, DP_UOID(opi->opi_oid));
+exec:
+	/* There may be multiple shards reside on the same VOS target. */
+	for (i = 0; i < count; i++) {
+		opi->opi_oid.id_shard = shards[i];
+		rc = obj_local_punch(opi, otpa->opc, p_ioc, dth);
+		if (rc != 0) {
+			DL_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
+				  (rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
+				  DB_IO, DLOG_ERR, rc, DF_UOID, DP_UOID(opi->opi_oid));
+			goto out;
+		}
+	}
 
 out:
-	/* Stop the local transaction */
-	if (dth != NULL)
-		rc = dtx_end(dth, ioc.ioc_coc, rc);
-	obj_punch_complete(rpc, rc, ioc.ioc_map_ver);
-	D_FREE(mbs);
-	obj_ioc_end(&ioc, rc);
+	if (otpa->ver != NULL)
+		*otpa->ver = p_ioc->ioc_map_ver;
+	if (p_ioc == &ioc) {
+		if (dth != NULL)
+			rc = dtx_end(dth, p_ioc->ioc_coc, rc);
+		obj_ioc_end(p_ioc, rc);
+	}
+
+	return rc;
+}
+
+/* Handle the punch requests on non-leader */
+void
+ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
+{
+	struct obj_tgt_punch_args	 otpa = { 0 };
+	struct obj_punch_in		*opi = crt_req_get(rpc);
+	struct daos_shard_tgt		*tgts = opi->opi_shard_tgts.ca_arrays;
+	uint32_t			 tgt_cnt = opi->opi_shard_tgts.ca_count;
+	uint32_t			 version = 0;
+	int				 rc;
+
+	if (!daos_is_zero_dti(&opi->opi_dti) && tgt_cnt != 0) {
+		rc = obj_gen_dtx_mbs(opi->opi_flags, &tgt_cnt, &tgts, &otpa.mbs);
+		if (rc != 0)
+			D_GOTO(out, rc);
+	}
+
+	otpa.opc = opc_get(rpc->cr_opc);
+	otpa.opi = opi;
+	otpa.ver = &version;
+	otpa.data = rpc;
+
+	rc = obj_tgt_punch(&otpa, &opi->opi_oid.id_shard, 1);
+
+out:
+	obj_punch_complete(rpc, rc, version);
+	D_FREE(otpa.mbs);
 }
 
 static int
@@ -3599,13 +3670,18 @@ obj_punch_agg_cb(struct dtx_leader_handle *dlh, int allow_failure)
 	for (i = 0; i < sub_cnt; i++) {
 		sub = &dlh->dlh_subs[i];
 		if (sub->dss_tgt.st_rank != DAOS_TGT_IGNORE && sub->dss_comp) {
-			if (sub->dss_result == 0)
+			if (sub->dss_result == 0) {
 				succeeds++;
-			else if (sub->dss_result == allow_failure)
+			} else if (sub->dss_result == allow_failure) {
 				allow_failure_cnt++;
-			else if (result == -DER_INPROGRESS || result == 0)
-				/* Ignore INPROGRESS if there is other failure. */
+			} else if (result == -DER_INPROGRESS || result == -DER_AGAIN ||
+				   result == 0) {
+				/* Ignore INPROGRESS and AGAIN if there is other failure. */
 				result = sub->dss_result;
+
+				if (dlh->dlh_rmt_ver < sub->dss_version)
+					dlh->dlh_rmt_ver = sub->dss_version;
+			}
 		}
 	}
 
@@ -3620,8 +3696,7 @@ obj_punch_agg_cb(struct dtx_leader_handle *dlh, int allow_failure)
 }
 
 static int
-obj_tgt_punch(struct dtx_leader_handle *dlh, void *arg, int idx,
-	      dtx_sub_comp_cb_t comp_cb)
+obj_tgt_punch_disp(struct dtx_leader_handle *dlh, void *arg, int idx, dtx_sub_comp_cb_t comp_cb)
 {
 	struct ds_obj_exec_arg	*exec_arg = arg;
 
@@ -3639,10 +3714,9 @@ obj_tgt_punch(struct dtx_leader_handle *dlh, void *arg, int idx,
 
 		rc = obj_local_punch(opi, opc_get(rpc->cr_opc), exec_arg->ioc, &dlh->dlh_handle);
 		if (rc != 0)
-			DL_CDEBUG(
-			    rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
-				(rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
-			    DB_IO, DLOG_ERR, rc, DF_UOID, DP_UOID(opi->opi_oid));
+			DL_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_RESTART ||
+				  (rc == -DER_NONEXIST && (opi->opi_api_flags & DAOS_COND_PUNCH)),
+				  DB_IO, DLOG_ERR, rc, DF_UOID, DP_UOID(opi->opi_oid));
 
 comp:
 		if (comp_cb != NULL)
@@ -3671,6 +3745,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	uint32_t			flags = 0;
 	uint32_t			dtx_flags = 0;
 	uint32_t			version = 0;
+	uint32_t			max_ver = 0;
 	struct dtx_epoch		epoch;
 	int				rc;
 	bool				need_abort = false;
@@ -3710,6 +3785,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 		opi->opi_flags &= ~ORF_EPOCH_UNCERTAIN;
 
 	version = opi->opi_map_ver;
+	max_ver = opi->opi_map_ver;
 	tgts = opi->opi_shard_tgts.ca_arrays;
 	tgt_cnt = opi->opi_shard_tgts.ca_count;
 
@@ -3730,8 +3806,6 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	/* Handle resend. */
 	if (opi->opi_flags & ORF_RESEND) {
 		daos_epoch_t	e;
-
-		dtx_flags |= DTX_RESEND;
 
 again1:
 		e = 0;
@@ -3791,9 +3865,10 @@ again2:
 	else
 		dtx_flags &= ~DTX_PREPARED;
 
-	rc = dtx_leader_begin(ioc.ioc_vos_coh, &opi->opi_dti, &epoch, 1,
-			      version, &opi->opi_oid, dti_cos, dti_cos_cnt,
-			      tgts, tgt_cnt, dtx_flags, mbs, &dlh);
+	rc = dtx_leader_begin(ioc.ioc_vos_coh, &opi->opi_dti, &epoch, 1, version, &opi->opi_oid,
+			      dti_cos, dti_cos_cnt, NULL /* hints */, 0 /* hint_sz */,
+			      NULL /* bitmap */, 0 /* bitmap_sz */, tgts, tgt_cnt, dtx_flags,
+			      NULL /* rank */, mbs, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID ": Failed to start DTX for punch " DF_RC "\n",
 			DP_UOID(opi->opi_oid), DP_RC(rc));
@@ -3805,9 +3880,12 @@ again2:
 	exec_arg.flags = flags;
 
 	/* Execute the operation on all shards */
-	rc = dtx_leader_exec_ops(dlh, obj_tgt_punch, obj_punch_agg_cb,
+	rc = dtx_leader_exec_ops(dlh, obj_tgt_punch_disp, obj_punch_agg_cb,
 				 (opi->opi_api_flags & DAOS_COND_PUNCH) ? -DER_NONEXIST : 0,
 				 &exec_arg);
+
+	if (max_ver < dlh->dlh_rmt_ver)
+		max_ver = dlh->dlh_rmt_ver;
 
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
@@ -3849,7 +3927,7 @@ out:
 			       DP_DTI(&opi->opi_dti), DP_RC(rc1));
 	}
 
-	obj_punch_complete(rpc, rc, ioc.ioc_map_ver);
+	obj_punch_complete(rpc, rc, max_ver);
 
 cleanup:
 	D_FREE(mbs);
@@ -4593,8 +4671,6 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 		/* Do nothing if 'prepared' or 'committed'. */
 		if (rc1 == -DER_ALREADY || rc1 == 0)
 			D_GOTO(out, rc = 0);
-
-		dtx_flags |= DTX_RESEND;
 	}
 
 	/* Refuse any modification with old epoch. */
@@ -4766,8 +4842,6 @@ ds_obj_dtx_leader(struct daos_cpd_args *dca)
 	D_ASSERT(dcsh->dcsh_epoch.oe_value != DAOS_EPOCH_MAX);
 
 	if (oci->oci_flags & ORF_RESEND) {
-		dtx_flags |= DTX_RESEND;
-
 again:
 		/* For distributed transaction, the 'ORF_RESEND' may means
 		 * that the DTX has been restarted with newer epoch.
@@ -4844,11 +4918,11 @@ again:
 	else
 		dtx_flags &= ~DTX_PREPARED;
 
-	rc = dtx_leader_begin(dca->dca_ioc->ioc_vos_coh, &dcsh->dcsh_xid,
-			      &dcsh->dcsh_epoch, dcde->dcde_write_cnt,
-			      oci->oci_map_ver, &dcsh->dcsh_leader_oid,
-			      NULL, 0, tgts, tgt_cnt - 1, dtx_flags,
-			      dcsh->dcsh_mbs, &dlh);
+	rc = dtx_leader_begin(dca->dca_ioc->ioc_vos_coh, &dcsh->dcsh_xid, &dcsh->dcsh_epoch,
+			      dcde->dcde_write_cnt, oci->oci_map_ver, &dcsh->dcsh_leader_oid,
+			      NULL /* dti_cos */, 0 /* dti_cos_cnt */, NULL /* hints */,
+			      0 /* hint_sz */, NULL /* bitmap */, 0 /* bitmap_sz */, tgts,
+			      tgt_cnt - 1, dtx_flags, NULL /* ranks */, dcsh->dcsh_mbs, &dlh);
 	if (rc != 0)
 		goto out;
 
@@ -5107,7 +5181,7 @@ ds_obj_cpd_handler(crt_rpc_t *rpc)
 
 	D_ASSERT(oci != NULL);
 
-	if (oci->oci_flags & ORF_CPD_LEADER)
+	if (oci->oci_flags & ORF_LEADER)
 		leader = true;
 	else
 		leader = false;
@@ -5295,4 +5369,656 @@ out:
 	rc = crt_reply_send(rpc);
 	if (rc != 0)
 		D_ERROR("send reply failed: "DF_RC"\n", DP_RC(rc));
+}
+
+struct obj_coll_tgt_args {
+	crt_rpc_t				*octa_rpc;
+	struct daos_coll_shard			*octa_shards;
+	uint32_t				*octa_versions;
+	int					 octa_sponsor_tgt;
+	struct obj_io_context			*octa_sponsor_ioc;
+	struct dtx_handle			*octa_sponsor_dth;
+	union {
+		void				*octa_misc;
+		/* Different collective operations may need different parameters. */
+		struct dtx_memberships		*octa_mbs;
+	};
+};
+
+static int
+obj_coll_tgt_punch(void *args)
+{
+	struct obj_coll_tgt_args	*octa = args;
+	crt_rpc_t			*rpc = octa->octa_rpc;
+	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
+	struct obj_punch_in		 opi = { 0 };
+	struct obj_tgt_punch_args	 otpa = { 0 };
+	uint32_t			 tgt_id = dss_get_module_info()->dmi_tgt_id;
+	int				 rc;
+
+	opi.opi_dti = ocpi->ocpi_xid;
+	uuid_copy(opi.opi_pool_uuid, ocpi->ocpi_po_uuid);
+	uuid_copy(opi.opi_co_hdl, ocpi->ocpi_co_hdl);
+	uuid_copy(opi.opi_co_uuid, ocpi->ocpi_co_uuid);
+	opi.opi_oid = ocpi->ocpi_oid;
+	opi.opi_oid.id_shard = octa->octa_shards[tgt_id].dcs_buf[0];
+	opi.opi_epoch = ocpi->ocpi_epoch;
+	opi.opi_api_flags = ocpi->ocpi_api_flags;
+	opi.opi_map_ver = ocpi->ocpi_map_ver;
+	opi.opi_flags = ocpi->ocpi_flags & ~ORF_LEADER;
+
+	otpa.opc = opc_get(rpc->cr_opc);
+	if (tgt_id == octa->octa_sponsor_tgt) {
+		otpa.sponsor_ioc = octa->octa_sponsor_ioc;
+		otpa.sponsor_dth = octa->octa_sponsor_dth;
+	}
+	otpa.opi = &opi;
+	otpa.mbs = octa->octa_mbs;
+	if (octa->octa_versions != NULL)
+		otpa.ver = &octa->octa_versions[tgt_id];
+	otpa.data = rpc;
+
+	rc = obj_tgt_punch(&otpa, octa->octa_shards[tgt_id].dcs_buf,
+			   octa->octa_shards[tgt_id].dcs_nr);
+
+	DL_CDEBUG(rc == 0 || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR, rc,
+		  "Collective punch obj shard "DF_UOID" with "DF_DTI" on tgt %u",
+		  DP_UOID(opi.opi_oid), DP_DTI(&opi.opi_dti), tgt_id);
+
+	return rc;
+}
+
+typedef int (*obj_coll_func_t)(void *args);
+
+static int
+obj_coll_local(crt_rpc_t *rpc, struct daos_coll_shard *shards, uint8_t *bitmap, uint32_t bitmap_sz,
+	       uint32_t *version, struct obj_io_context *ioc, struct dtx_handle *dth, void *args,
+	       obj_coll_func_t func)
+{
+	struct obj_coll_tgt_args	 octa = { 0 };
+	struct dss_coll_ops		 coll_ops = { 0 };
+	struct dss_coll_args		 coll_args = { 0 };
+	uint32_t			 size = bitmap_sz << 3;
+	int				 rc = 0;
+	int				 i;
+
+	D_ASSERT(bitmap != NULL);
+
+	if (version != NULL) {
+		if (size > dss_tgt_nr)
+			size = dss_tgt_nr;
+		D_ALLOC_ARRAY(octa.octa_versions, size);
+		if (octa.octa_versions == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	octa.octa_rpc = rpc;
+	octa.octa_shards = shards;
+	octa.octa_misc = args;
+	octa.octa_sponsor_ioc = ioc;
+	octa.octa_sponsor_dth = dth;
+	if (ioc != NULL)
+		octa.octa_sponsor_tgt = dss_get_module_info()->dmi_tgt_id;
+	else
+		octa.octa_sponsor_tgt = -1;
+
+	coll_ops.co_func = func;
+	coll_args.ca_func_args = &octa;
+	coll_args.ca_tgt_bitmap = bitmap;
+	coll_args.ca_tgt_bitmap_sz = bitmap_sz;
+
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, DSS_USE_CURRENT_ULT);
+
+out:
+	if (octa.octa_versions != NULL) {
+		for (i = 0, *version = 0; i < size; i++) {
+			if (isset(bitmap, i) && *version < octa.octa_versions[i])
+				*version = octa.octa_versions[i];
+		}
+		D_FREE(octa.octa_versions);
+	}
+
+	return rc;
+}
+
+static int
+obj_coll_punch_disp(struct dtx_leader_handle *dlh, void *arg, int idx, dtx_sub_comp_cb_t comp_cb)
+{
+	struct ds_obj_exec_arg		*exec_arg = arg;
+	crt_rpc_t			*rpc = exec_arg->rpc;
+	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
+	int				 rc;
+
+	if (idx != -1)
+		return ds_obj_coll_punch_remote(dlh, arg, idx, comp_cb);
+
+	rc = obj_coll_local(rpc, exec_arg->shards, dlh->dlh_coll_bitmap, dlh->dlh_coll_bitmap_sz,
+			    NULL, exec_arg->ioc, &dlh->dlh_handle, dlh->dlh_handle.dth_mbs,
+			    obj_coll_tgt_punch);
+
+	DL_CDEBUG(rc == 0 || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR, rc,
+		  "Collective punch obj "DF_UOID" with "DF_DTI" on rank (leader) %u",
+		  DP_UOID(ocpi->ocpi_oid), DP_DTI(&ocpi->ocpi_xid), dss_self_rank());
+
+	if (comp_cb != NULL)
+		comp_cb(dlh, idx, rc);
+
+	return rc;
+}
+
+static int
+obj_coll_punch_prep(struct obj_coll_punch_in *ocpi, struct daos_coll_shard **p_shards,
+		    uint8_t **p_hints, uint32_t *hint_sz, uint8_t **p_bitmap, uint32_t *bitmap_sz,
+		    struct dtx_memberships **p_mbs, d_rank_list_t **p_ranks)
+{
+	struct pl_map		*map = NULL;
+	struct pl_obj_layout	*layout = NULL;
+	struct dtx_memberships	*mbs = NULL;
+	struct daos_coll_target	*dcts = NULL;
+	struct daos_coll_target	*dct;
+	struct daos_coll_shard	*dcs;
+	struct dtx_daos_target	*ddt;
+	struct dtx_target_group	*dtg;
+	struct pool_target	*tgt;
+	struct daos_obj_md	 md = { 0 };
+	uint8_t			*hints = NULL;
+	int			 leader_rank = -1;
+	int			 length = -1;
+	uint32_t		*tmp;
+	uint32_t		 rank_nr = 0;
+	uint32_t		 tgt_nr;
+	uint32_t		 size;
+	d_rank_t		 myrank = dss_self_rank();
+	d_rank_t		 max_rank = 0;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+	int			 k;
+	int			 m;
+
+	D_ASSERT(p_shards != NULL);
+	D_ASSERT(p_hints != NULL);
+	D_ASSERT(p_bitmap != NULL);
+	D_ASSERT(p_mbs != NULL);
+	D_ASSERT(p_ranks != NULL);
+
+	map = pl_map_find(ocpi->ocpi_po_uuid, ocpi->ocpi_oid.id_pub);
+	if (map == NULL) {
+		D_ERROR("Failed to find valid placement map for "DF_UUID"\n",
+			DP_UUID(ocpi->ocpi_po_uuid));
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	md.omd_id = ocpi->ocpi_oid.id_pub;
+	md.omd_ver = ocpi->ocpi_map_ver;
+	md.omd_fdom_lvl = ocpi->ocpi_fdom_lvl;
+	md.omd_pdom_lvl = ocpi->ocpi_pdom_lvl;
+	md.omd_pda = ocpi->ocpi_pda;
+
+	rc = pl_obj_place(map, ocpi->ocpi_oid.id_layout_ver, &md, DAOS_OO_RW, NULL, &layout);
+	if (rc != 0) {
+		D_ERROR("Failed to load object layout for "DF_OID" in pool "DF_UUID"\n",
+			DP_OID(ocpi->ocpi_oid.id_pub), DP_UUID(ocpi->ocpi_po_uuid));
+		goto out;
+	}
+
+	length = pool_map_node_nr(map->pl_poolmap);
+
+	D_ALLOC_ARRAY(dcts, length + 1);
+	if (dcts == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (ocpi->ocpi_flags & ORF_LEADER) {
+		D_ALLOC_ARRAY(hints, length);
+		if (hints == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	for (i = 0, rank_nr = 0, tgt_nr = 0; i < layout->ol_nr; i++) {
+		if (layout->ol_shards[i].po_target == -1 || layout->ol_shards[i].po_shard == -1)
+			continue;
+
+		rc = pool_map_find_target(map->pl_poolmap, layout->ol_shards[i].po_target, &tgt);
+		D_ASSERT(rc == 1);
+
+		dct = &dcts[tgt->ta_comp.co_rank];
+		dct->dct_rank = tgt->ta_comp.co_rank;
+
+		if (max_rank < dct->dct_rank)
+			max_rank = dct->dct_rank;
+
+		/*
+		 * There may be more shards than engines count on the same VOS targets because of
+		 * rebuild/reintegration. The size of dct->dct_tgt_ids maybe larger than dss_tgt_nr.
+		 */
+		if (dct->dct_tgt_nr >= dct->dct_tgt_cap) {
+			if (dct->dct_tgt_nr == 0)
+				m = dss_tgt_nr;
+			else
+				m = dct->dct_tgt_nr << 1;
+			D_ALLOC_ARRAY(tmp, m);
+			if (tmp == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			if (dct->dct_tgt_ids != NULL) {
+				memcpy(tmp, dct->dct_tgt_ids, sizeof(*tmp) * dct->dct_tgt_nr);
+				D_FREE(dct->dct_tgt_ids);
+			}
+
+			dct->dct_tgt_ids = tmp;
+			dct->dct_tgt_cap = m;
+		}
+
+		if (dct->dct_tgt_nr == 0) {
+			/* Assign the first available shard to the hint for this engine. */
+			if (hints != NULL)
+				hints[dct->dct_rank] = tgt->ta_comp.co_index;
+			rank_nr++;
+		}
+
+		if (tgt->ta_comp.co_id == ocpi->ocpi_leader_id &&
+		    !layout->ol_shards[i].po_rebuilding && !layout->ol_shards[i].po_reintegrating) {
+			if (ocpi->ocpi_flags & ORF_LEADER)
+				D_ASSERTF(myrank == dct->dct_rank,
+					  "Unmatched leader rank %u vs %u\n",
+					  myrank, dct->dct_rank);
+			else
+				D_ASSERTF(myrank != dct->dct_rank,
+					  "Unexpected target, rank %u, tgt_id %u\n",
+					  myrank, layout->ol_shards[i].po_target);
+
+			/* The leader target must be unique. */
+			D_ASSERTF(leader_rank == -1, "Repeated leader target %u/%u vs %u/%u\n",
+				  myrank, layout->ol_shards[i].po_target, leader_rank,
+				  dct->dct_tgt_ids[0]);
+
+			D_ASSERTF(ocpi->ocpi_leader_id == layout->ol_shards[i].po_target,
+				  "Found invalid target: leader_id %u, po_target %u\n",
+				  ocpi->ocpi_leader_id, layout->ol_shards[i].po_target);
+
+			leader_rank = dct->dct_rank;
+			if (dct->dct_tgt_nr > 0)
+				memmove(&dct->dct_tgt_ids[1], &dct->dct_tgt_ids[0],
+					sizeof(dct->dct_tgt_ids[0]) * dct->dct_tgt_nr);
+			dct->dct_tgt_ids[0] = layout->ol_shards[i].po_target;
+		} else {
+			dct->dct_tgt_ids[dct->dct_tgt_nr] = layout->ol_shards[i].po_target;
+		}
+
+		dct->dct_tgt_nr++;
+		tgt_nr++;
+
+		/* Only collect targets bitmap and shards for current engine. */
+		if (tgt->ta_comp.co_rank != myrank)
+			continue;
+
+		if (dct->dct_bitmap == NULL) {
+			size = ((dss_tgt_nr - 1) >> 3) + 1;
+			D_ALLOC_ARRAY(dct->dct_bitmap, size);
+			if (dct->dct_bitmap == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			dct->dct_bitmap_sz = size;
+		}
+
+		if (dct->dct_shards == NULL) {
+			D_ASSERT(dct->dct_bitmap_sz != 0);
+
+			D_ALLOC_ARRAY(dct->dct_shards, dct->dct_bitmap_sz << 3);
+			if (dct->dct_shards == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		dcs = &dct->dct_shards[tgt->ta_comp.co_index];
+
+		if (unlikely(isset(dct->dct_bitmap, tgt->ta_comp.co_index))) {
+			/* More than one shards reside on the same vos target. */
+			D_ASSERT(dcs->dcs_nr >= 1);
+
+			if (dcs->dcs_nr >= dcs->dcs_cap) {
+				D_ALLOC_ARRAY(tmp, dcs->dcs_nr << 1);
+				if (tmp == NULL)
+					D_GOTO(out, rc = -DER_NOMEM);
+
+				memcpy(tmp, dcs->dcs_buf, sizeof(*tmp) * dcs->dcs_nr);
+				if (dcs->dcs_buf != &dcs->dcs_inline)
+					D_FREE(dcs->dcs_buf);
+				dcs->dcs_buf = tmp;
+				dcs->dcs_cap = dcs->dcs_nr << 1;
+			}
+		} else {
+			D_ASSERT(dcs->dcs_nr == 0);
+
+			dcs->dcs_buf = &dcs->dcs_inline;
+			setbit(dct->dct_bitmap, tgt->ta_comp.co_index);
+		}
+
+		dcs->dcs_buf[dcs->dcs_nr++] = layout->ol_shards[i].po_shard;
+	}
+
+	D_ASSERT(leader_rank != -1);
+	D_ASSERT(rank_nr >= 1);
+
+	if (leader_rank != 0) {
+		memcpy(&dcts[length], &dcts[leader_rank], sizeof(*dct));
+		memmove(&dcts[1], &dcts[0], sizeof(*dct) * leader_rank);
+		memcpy(&dcts[0], &dcts[length], sizeof(*dct));
+		memset(&dcts[length], 0, sizeof(*dct));
+	}
+
+	size = sizeof(*ddt) * tgt_nr + sizeof(*dtg) * rank_nr;
+	D_ALLOC(mbs, sizeof(*mbs) + size);
+	if (mbs == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	/*
+	 * For object collective punch, we always commit related DTX synchronously. Even if we lost
+	 * some redundancy groups when DTX resync, we still continue to punch the remaining shards.
+	 * So set dm_grp_cnt as 1 to bypass redundancy group check.
+	 */
+	mbs->dm_grp_cnt = 1;
+	mbs->dm_tgt_cnt = tgt_nr;
+	mbs->dm_data_size = size;
+	mbs->dm_flags = DMF_CONTAIN_LEADER | DMF_CONTAIN_TARGET_GRP;
+
+	ddt = &mbs->dm_tgts[0];
+	dtg = (struct dtx_target_group *)(ddt + tgt_nr);
+
+	for (i = 0, j = 0, k = 0; i < length; i++) {
+		dct = &dcts[i];
+		if (dct->dct_tgt_ids == NULL)
+			continue;
+
+		dtg[k].dtg_start_idx = j;
+
+		for (m = 0; m < dct->dct_tgt_nr; m++)
+			ddt[j++].ddt_id = dct->dct_tgt_ids[m];
+
+		dtg[k].dtg_tgt_nr = dct->dct_tgt_nr;
+		dtg[k++].dtg_rank = dct->dct_rank;
+	}
+
+	/* ddt[0] is always the leader target. */
+	D_ASSERTF(ddt[0].ddt_id == ocpi->ocpi_leader_id,
+		  "Invalid leader target %u vs %u on rank %u vs %u\n",
+		  ddt[0].ddt_id, ocpi->ocpi_leader_id, myrank, leader_rank);
+
+	if (ocpi->ocpi_flags & ORF_LEADER) {
+		if (unlikely(rank_nr == 1)) {
+			/* Only one engine is involved in the collective punch. */
+			*p_ranks = NULL;
+			*p_hints = NULL;
+			*hint_sz = 0;
+		} else {
+			*p_ranks = d_rank_list_alloc(rank_nr - 1);
+			if (*p_ranks == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			/* Set i = 1 to skip leader_rank. */
+			for (i = 1, j = 0; i < length; i++) {
+				if (dcts[i].dct_tgt_ids != NULL)
+					(*p_ranks)->rl_ranks[j++] = dcts[i].dct_rank;
+			}
+
+			*p_hints = hints;
+			*hint_sz = max_rank + 1;
+		}
+	} else {
+		*p_ranks = NULL;
+		*p_hints = NULL;
+		*hint_sz = 0;
+	}
+
+	*p_mbs = mbs;
+
+out:
+	if (rc < 0) {
+		d_rank_list_free(*p_ranks);
+		D_FREE(mbs);
+		*p_ranks = NULL;
+		*p_hints = NULL;
+		*hint_sz = 0;
+		*p_bitmap = NULL;
+		*bitmap_sz = 0;
+		*p_shards = NULL;
+	} else {
+		if (myrank == leader_rank)
+			dct = &dcts[0];
+		else if (myrank > leader_rank)
+			dct = &dcts[myrank];
+		else
+			dct = &dcts[myrank + 1];
+
+		D_ASSERT(dct->dct_rank == myrank);
+
+		*p_shards = dct->dct_shards;
+		*p_bitmap = dct->dct_bitmap;
+		*bitmap_sz = dct->dct_bitmap_sz;
+
+		/*
+		 * We have checked the pool map version. It is impossible that current pool map
+		 * version does not match the RPC given version as to the expected object shard
+		 * has been migrated to other engine.
+		 */
+		D_ASSERT(*p_bitmap != NULL);
+
+		dct->dct_shards = NULL;
+		dct->dct_bitmap = NULL;
+		dct->dct_bitmap_sz = 0;
+		dct->dct_shard_nr = 0;
+	}
+
+	daos_coll_target_cleanup(dcts, length + 1);
+
+	if (*p_hints != hints)
+		D_FREE(hints);
+
+	if (layout != NULL)
+		pl_obj_layout_free(layout);
+
+	if (map != NULL)
+		pl_map_decref(map);
+
+	return rc > 0 ? 0 : rc;
+}
+
+void
+ds_obj_coll_punch_handler(crt_rpc_t *rpc)
+{
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct ds_pool			*pool = NULL;
+	struct dtx_leader_handle	*dlh = NULL;
+	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
+	struct ds_obj_exec_arg		 exec_arg = { 0 };
+	struct obj_io_context		 ioc = { 0 };
+	struct cont_props		 co_props = { 0 };
+	d_rank_list_t			*ranks = NULL;
+	struct dtx_memberships		*mbs = NULL;
+	struct daos_coll_shard		*shards = NULL;
+	uint8_t				*hints = NULL;
+	uint8_t				*bitmap = NULL;
+	uint32_t			 bitmap_sz = 0;
+	uint32_t			 hint_sz = 0;
+	uint32_t			 flags = 0;
+	uint32_t			 dtx_flags = DTX_COLL;
+	uint32_t			 version = 0;
+	uint32_t			 max_ver = 0;
+	struct dtx_epoch		 epoch;
+	daos_epoch_t			 tmp;
+	int				 rc;
+	int				 rc1;
+	bool				 need_abort = false;
+
+	D_DEBUG(DB_IO, "(%s) handling collective punch RPC %p for obj "
+		DF_UOID" on XS %u/%u epc "DF_X64" pmv %u, with dti "DF_DTI"\n",
+		(ocpi->ocpi_flags & ORF_LEADER) ? "leader" : "non-leader", rpc,
+		DP_UOID(ocpi->ocpi_oid), dmi->dmi_xs_id, dmi->dmi_tgt_id,
+		ocpi->ocpi_epoch, ocpi->ocpi_map_ver, DP_DTI(&ocpi->ocpi_xid));
+
+	if (ocpi->ocpi_flags & ORF_LEADER) {
+		rc = obj_ioc_begin(ocpi->ocpi_oid.id_pub, ocpi->ocpi_map_ver, ocpi->ocpi_po_uuid,
+				   ocpi->ocpi_co_hdl, ocpi->ocpi_co_uuid, rpc, ocpi->ocpi_flags,
+				   &ioc);
+		if (rc != 0)
+			goto out;
+
+		rc = ds_cont_get_props(&co_props, ocpi->ocpi_po_uuid, ocpi->ocpi_co_uuid);
+		if (rc != 0)
+			goto out;
+
+		ocpi->ocpi_fdom_lvl = co_props.dcp_redun_lvl;
+		ocpi->ocpi_pdom_lvl = co_props.dcp_perf_domain;
+		ocpi->ocpi_pda = daos_cont_props2pda(&co_props, ocpi->ocpi_flags & ORF_EC);
+	} else {
+		D_ASSERT(dmi->dmi_xs_id == 0);
+
+		/*
+		 * For collective punch, the map version must be matched among client and
+		 * engines, otherwise, different engines may get different object layouts.
+		 */
+
+		rc = ds_pool_lookup(ocpi->ocpi_po_uuid, &pool);
+		if (rc != 0) {
+			D_ERROR("Failed to locate pool "DF_UUID": "DF_RC"\n",
+				DP_UUID(ocpi->ocpi_po_uuid), DP_RC(rc));
+			goto out;
+		}
+
+		if (pool->sp_map_version > ocpi->ocpi_map_ver)
+			D_GOTO(out, rc = -DER_STALE);
+
+		if (pool->sp_map_version < ocpi->ocpi_map_ver) {
+			rc = ds_pool_child_map_refresh_sync(ocpi->ocpi_po_uuid, ocpi->ocpi_map_ver);
+			if (rc != 0)
+				goto out;
+
+			if (pool->sp_map_version > ocpi->ocpi_map_ver)
+				D_GOTO(out, rc = -DER_STALE);
+		}
+	}
+
+	rc = obj_coll_punch_prep(ocpi, &shards, &hints, &hint_sz, &bitmap, &bitmap_sz, &mbs,
+				 &ranks);
+	if (rc != 0)
+		goto out;
+
+	if (!(ocpi->ocpi_flags & ORF_LEADER)) {
+		rc = obj_coll_local(rpc, shards, bitmap, bitmap_sz, &version, NULL, NULL, mbs,
+				    obj_coll_tgt_punch);
+		goto out;
+	}
+
+	version = ocpi->ocpi_map_ver;
+	max_ver = ocpi->ocpi_map_ver;
+
+	rc = process_epoch(&ocpi->ocpi_epoch, NULL /* epoch_first */, &ocpi->ocpi_flags);
+	if (rc == PE_OK_LOCAL)
+		ocpi->ocpi_flags &= ~ORF_EPOCH_UNCERTAIN;
+
+	if (ocpi->ocpi_flags & ORF_DTX_SYNC)
+		dtx_flags |= DTX_SYNC;
+
+	if (ocpi->ocpi_flags & ORF_RESEND) {
+
+again1:
+		tmp = 0;
+		rc = dtx_handle_resend(ioc.ioc_vos_coh, &ocpi->ocpi_xid, &tmp, &version);
+		switch (rc) {
+		case -DER_ALREADY:
+			D_GOTO(out, rc = 0);
+		case 0:
+			ocpi->ocpi_epoch = tmp;
+			flags |= ORF_RESEND;
+			/* TODO: Also recovery the epoch uncertainty. */
+			break;
+		case -DER_NONEXIST:
+			rc = 0;
+			break;
+		default:
+			D_GOTO(out, rc);
+		}
+	}
+
+again2:
+	epoch.oe_value = ocpi->ocpi_epoch;
+	epoch.oe_first = epoch.oe_value;
+	epoch.oe_flags = orf_to_dtx_epoch_flags(ocpi->ocpi_flags);
+
+	if (flags & ORF_RESEND)
+		dtx_flags |= DTX_PREPARED;
+	else
+		dtx_flags &= ~DTX_PREPARED;
+
+	rc = dtx_leader_begin(ioc.ioc_vos_coh, &ocpi->ocpi_xid, &epoch, 1, version, &ocpi->ocpi_oid,
+			      NULL /* dti_cos */, 0 /* dti_cos_cnt */, hints, hint_sz, bitmap,
+			      bitmap_sz, NULL /* tgts */, 0 /* tgt_cnt */, dtx_flags, ranks,
+			      mbs, &dlh);
+	if (rc != 0) {
+		D_ERROR(DF_UOID ": Failed to start DTX for collective punch: "DF_RC"\n",
+			DP_UOID(ocpi->ocpi_oid), DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	exec_arg.rpc = rpc;
+	exec_arg.ioc = &ioc;
+	exec_arg.shards = shards;
+	exec_arg.flags = flags;
+
+	/* Execute the operation on all shards */
+	rc = dtx_leader_exec_ops(dlh, obj_coll_punch_disp, NULL, 0, &exec_arg);
+
+	if (max_ver < dlh->dlh_rmt_ver)
+		max_ver = dlh->dlh_rmt_ver;
+
+	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
+	switch (rc) {
+	case -DER_TX_RESTART:
+		ocpi->ocpi_epoch = d_hlc_get();
+		ocpi->ocpi_flags &= ~ORF_RESEND;
+		flags = 0;
+		goto again2;
+	case -DER_AGAIN:
+		ocpi->ocpi_flags |= ORF_RESEND;
+		need_abort = true;
+		ABT_thread_yield();
+		goto again1;
+	default:
+		break;
+	}
+
+out:
+	if (rc != 0 && need_abort) {
+		rc1 = dtx_coll_abort(ioc.ioc_coc, &ocpi->ocpi_xid, ranks, hints, hint_sz, bitmap,
+				     bitmap_sz, version, ocpi->ocpi_epoch);
+		if (rc1 != 0 && rc1 != -DER_NONEXIST)
+			D_WARN("Failed to collective abort DTX "DF_DTI": "DF_RC"\n",
+			       DP_DTI(&ocpi->ocpi_xid), DP_RC(rc1));
+	}
+
+	if (max_ver < ioc.ioc_map_ver)
+		max_ver = ioc.ioc_map_ver;
+
+	if (pool != NULL && max_ver < pool->sp_map_version)
+		max_ver = pool->sp_map_version;
+
+	DL_CDEBUG(rc != 0 && rc != -DER_INPROGRESS && rc != -DER_TX_RESTART, DLOG_ERR, DB_IO, rc,
+		  "(%s) handled collective punch RPC %p for obj "
+		  DF_UOID" on XS %u/%u epc "DF_X64" pmv %u/%u, with dti "DF_DTI,
+		  (ocpi->ocpi_flags & ORF_LEADER) ? "leader" : "non-leader", rpc,
+		  DP_UOID(ocpi->ocpi_oid), dmi->dmi_xs_id, dmi->dmi_tgt_id, ocpi->ocpi_epoch,
+		  ocpi->ocpi_map_ver, version, DP_DTI(&ocpi->ocpi_xid));
+
+	obj_punch_complete(rpc, rc, max_ver);
+
+	d_rank_list_free(ranks);
+	daos_coll_shard_cleanup(shards, bitmap_sz << 3);
+	D_FREE(bitmap);
+	D_FREE(hints);
+	D_FREE(mbs);
+
+	/* It is no matter even if obj_ioc_begin() was not called. */
+	obj_ioc_end(&ioc, rc);
+
+	if (pool != NULL)
+		ds_pool_put(pool);
 }

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -242,6 +242,7 @@ extern struct bio_reaction_ops nvme_reaction_ops;
 uint32_t pool_iv_map_ent_size(int nr);
 int ds_pool_iv_init(void);
 int ds_pool_iv_fini(void);
+int ds_pool_map_refresh_internal(uuid_t uuid, uint32_t version);
 void ds_pool_map_refresh_ult(void *arg);
 
 int ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7650,39 +7650,44 @@ out:
 
 /* Update pool map version for current xstream. */
 int
-ds_pool_child_map_refresh_sync(struct ds_pool_child *dpc)
+ds_pool_child_map_refresh_sync(uuid_t uuid, uint32_t version)
 {
 	struct pool_map_refresh_ult_arg	arg;
 	ABT_eventual			eventual;
 	int				*status;
 	int				rc;
 
-	rc = ABT_eventual_create(sizeof(*status), &eventual);
-	if (rc != ABT_SUCCESS)
-		return dss_abterr2der(rc);
+	if (dss_get_module_info()->dmi_xs_id != 0) {
+		rc = ABT_eventual_create(sizeof(*status), &eventual);
+		if (rc != ABT_SUCCESS)
+			return dss_abterr2der(rc);
 
-	arg.iua_pool_version = dpc->spc_map_version;
-	uuid_copy(arg.iua_pool_uuid, dpc->spc_uuid);
-	arg.iua_eventual = eventual;
+		arg.iua_pool_version = version;
+		uuid_copy(arg.iua_pool_uuid, uuid);
+		arg.iua_eventual = eventual;
 
-	rc = dss_ult_create(ds_pool_map_refresh_ult, &arg, DSS_XS_SYS,
-			    0, 0, NULL);
-	if (rc)
-		D_GOTO(out_eventual, rc);
+		rc = dss_ult_create(ds_pool_map_refresh_ult, &arg, DSS_XS_SYS,
+				    0, 0, NULL);
+		if (rc != 0)
+			D_GOTO(out_eventual, rc);
 
-	rc = ABT_eventual_wait(eventual, (void **)&status);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out_eventual, rc = dss_abterr2der(rc));
-	if (*status != 0)
-		D_GOTO(out_eventual, rc = *status);
+		rc = ABT_eventual_wait(eventual, (void **)&status);
+		if (rc != ABT_SUCCESS)
+			rc = dss_abterr2der(rc);
+		else
+			rc = *status;
 
 out_eventual:
-	ABT_eventual_free(&eventual);
+		ABT_eventual_free(&eventual);
+	} else {
+		rc = ds_pool_map_refresh_internal(uuid, version);
+	}
+
 	return rc;
 }
 
 int
-ds_pool_child_map_refresh_async(struct ds_pool_child *dpc)
+ds_pool_child_map_refresh_async(uuid_t uuid, uint32_t version)
 {
 	struct pool_map_refresh_ult_arg	*arg;
 	int				rc;
@@ -7690,8 +7695,8 @@ ds_pool_child_map_refresh_async(struct ds_pool_child *dpc)
 	D_ALLOC_PTR(arg);
 	if (arg == NULL)
 		return -DER_NOMEM;
-	arg->iua_pool_version = dpc->spc_map_version;
-	uuid_copy(arg->iua_pool_uuid, dpc->spc_uuid);
+	arg->iua_pool_version = version;
+	uuid_copy(arg->iua_pool_uuid, uuid);
 
 	rc = dss_ult_create(ds_pool_map_refresh_ult, arg, DSS_XS_SYS,
 			    0, 0, NULL);

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -34,6 +34,9 @@ class TelemetryUtils():
         "engine_pool_ops_dkey_punch",
         "engine_pool_ops_dtx_abort",
         "engine_pool_ops_dtx_check",
+        "engine_pool_ops_dtx_coll_abort",
+        "engine_pool_ops_dtx_coll_check",
+        "engine_pool_ops_dtx_coll_commit",
         "engine_pool_ops_dtx_commit",
         "engine_pool_ops_dtx_refresh",
         "engine_pool_ops_ec_agg",
@@ -352,6 +355,18 @@ class TelemetryUtils():
         "engine_io_ops_migrate_latency_mean",
         "engine_io_ops_migrate_latency_min",
         "engine_io_ops_migrate_latency_stddev"]
+    ENGINE_IO_OPS_OBJ_COLL_PUNCH_ACTIVE_METRICS = [
+        "engine_io_ops_obj_coll_punch_active",
+        "engine_io_ops_obj_coll_punch_active_max",
+        "engine_io_ops_obj_coll_punch_active_mean",
+        "engine_io_ops_obj_coll_punch_active_min",
+        "engine_io_ops_obj_coll_punch_active_stddev"]
+    ENGINE_IO_OPS_OBJ_COLL_PUNCH_LATENCY_METRICS = [
+        "engine_io_ops_obj_coll_punch_latency",
+        "engine_io_ops_obj_coll_punch_latency_max",
+        "engine_io_ops_obj_coll_punch_latency_mean",
+        "engine_io_ops_obj_coll_punch_latency_min",
+        "engine_io_ops_obj_coll_punch_latency_stddev"]
     ENGINE_IO_OPS_OBJ_ENUM_ACTIVE_METRICS = [
         "engine_io_ops_obj_enum_active",
         "engine_io_ops_obj_enum_active_max",
@@ -480,6 +495,8 @@ class TelemetryUtils():
         ENGINE_IO_OPS_KEY2ANCHOR_LATENCY_METRICS +\
         ENGINE_IO_OPS_MIGRATE_ACTIVE_METRICS +\
         ENGINE_IO_OPS_MIGRATE_LATENCY_METRICS +\
+        ENGINE_IO_OPS_OBJ_COLL_PUNCH_ACTIVE_METRICS +\
+        ENGINE_IO_OPS_OBJ_COLL_PUNCH_LATENCY_METRICS +\
         ENGINE_IO_OPS_OBJ_ENUM_ACTIVE_METRICS +\
         ENGINE_IO_OPS_OBJ_ENUM_LATENCY_METRICS +\
         ENGINE_IO_OPS_OBJ_PUNCH_ACTIVE_METRICS +\
@@ -562,7 +579,7 @@ class TelemetryUtils():
         "engine_mem_vos_dtx_cmt_ent_48",
         "engine_mem_vos_vos_obj_360",
         "engine_mem_vos_vos_lru_size",
-        "engine_mem_dtx_dtx_leader_handle_336",
+        "engine_mem_dtx_dtx_leader_handle_376",
         "engine_mem_dtx_dtx_entry_40"]
     ENGINE_MEM_TOTAL_USAGE_METRICS = [
         "engine_mem_total_mem"]

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -5115,6 +5115,79 @@ oit_list_filter(void **state)
 	test_teardown((void **)&arg);
 }
 
+#define DTS_DKEY_CNT	8
+#define DTS_DKEY_SIZE	16
+#define DTS_IOSIZE	64
+
+static void
+obj_coll_punch(test_arg_t *arg, daos_oclass_id_t oclass)
+{
+	char		 buf[DTS_IOSIZE];
+	char		 dkeys[DTS_DKEY_CNT][DTS_DKEY_SIZE];
+	const char	*akey = "daos_io_akey";
+	daos_obj_id_t	 oid;
+	struct ioreq	 req;
+	int		 i;
+
+	oid = daos_test_oid_gen(arg->coh, oclass, 0, 0, arg->myrank);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	for (i = 0; i < DTS_DKEY_CNT; i++) {
+		dts_buf_render(dkeys[i], DTS_DKEY_SIZE);
+		dts_buf_render(buf, DTS_IOSIZE);
+		insert_single(dkeys[i], akey, 0, buf, DTS_IOSIZE, DAOS_TX_NONE, &req);
+	}
+
+	print_message("Collective punch object\n");
+	punch_obj(DAOS_TX_NONE, &req);
+
+	print_message("Fetch after punch\n");
+	arg->expect_result = -DER_NONEXIST;
+	for (i = 0; i < DTS_DKEY_CNT; i++)
+		lookup_empty_single(dkeys[i], akey, 0, buf, DTS_IOSIZE, DAOS_TX_NONE, &req);
+
+	ioreq_fini(&req);
+}
+
+static void
+io_50(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	print_message("Collective punch object - OC_SX\n");
+
+	if (!test_runable(arg, 2))
+		return;
+
+	obj_coll_punch(arg, OC_SX);
+}
+
+static void
+io_51(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	print_message("Collective punch object - OC_EC_2P1G2\n");
+
+	if (!test_runable(arg, 3))
+		return;
+
+	obj_coll_punch(arg, OC_EC_2P1G2);
+}
+
+static void
+io_52(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	print_message("Collective punch object - OC_EC_4P1GX\n");
+
+	if (!test_runable(arg, 5))
+		return;
+
+	obj_coll_punch(arg, OC_EC_4P1GX);
+}
+
 static const struct CMUnitTest io_tests[] = {
 	{ "IO1: simple update/fetch/verify",
 	  io_simple, async_disable, test_case_teardown},
@@ -5213,6 +5286,12 @@ static const struct CMUnitTest io_tests[] = {
 	{ "IO47: obj_open perf", obj_open_perf, async_disable, test_case_teardown},
 	{ "IO48: oit_list_filter", oit_list_filter, async_disable, test_case_teardown},
 	{ "IO49: oit_list_filter async", oit_list_filter, async_enable, test_case_teardown},
+	{ "IO50: collective punch object - OC_SX",
+	  io_50, NULL, test_case_teardown},
+	{ "IO51: collective punch object - OC_EC_2P1G2",
+	  io_51, NULL, test_case_teardown},
+	{ "IO52: collective punch object - OC_EC_4P1GX",
+	  io_52, NULL, test_case_teardown},
 };
 
 int

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -56,7 +56,6 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_pinned = 0;
 	dth->dth_sync = 0;
 	dth->dth_cos_done = 0;
-	dth->dth_resent = 0;
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
 	dth->dth_solo = 0;


### PR DESCRIPTION
Currently, when punch an object with multiple redundancy groups, to guarantee the atomicity, we handle the whole punch via single internal distributed transaction. The DTX leader will forward the CPD RPC to every object shard within the same transaction. For a large-scaled object, such as a SX object, punching it will generate N RPCs (N is equal to the count of all the vos targets in the system). That will be very slow and hold a lot of system resource for relative long time. If the system is under heavy load, related RPC(s) may get timeout, then trigger DTX abort, and then client will resend RPC to the DTX leader for retry, that will make the situation to be worse and worse.

To resolve such bad situation, we will collectively punch the object.

The basic idea is that: when punch an object with multiple redundancy groups, the client will send OBJ_COLL_PUNCH RPC to the DTX leader. On the DTX leader, instead of forwarding the request to all related vos targets, it uses bcast RPC to spread the OBJ_COLL_PUNCH request to all involved engines. And then related engines will generate collective tasks to punch the object shards on each own local vos targets. That will save a lot of RPCs and resources.

On the other hand, for large-scaled object, transferring related DTX participants information (that will be huge) will be heavy burden in spite of via RPC body or RDMA (for bulk data). So OBJ_COLL_PUNCH RPC does not transfer dtx_memberships, instead, related engines in spite leader or not, will calculate the dtx_memberships data based on the obejct layout by themselves. That will cause some overhead. Compare with broadcast huge DTX participants information on network, it may be better choice.

Introduce two environment varilables to control the collective punch:

DTX_COLL_TREE_WIDTH: the bcast RPC tree width for collective transaction on server. The valid range is [4, 64], the default value is 16.

OBJ_COLL_PUNCH_THRESHOLD: the threshold for triggerring collectively punch object on client. The default (and also the min) value is 16.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
