### PR TITLE
DAOS-14680 ci: Update go suppressions.

### DIFF
--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -523,4 +523,28 @@
    write(buf)
    fun:syscall.Syscall.abi0
 }
-
+{
+   DAOS-14680-1
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_cgo_0edd79296193_Cfunc__Cmalloc
+   fun:runtime.asmcgocall.abi0
+   ...
+   fun:racecall
+}
+{
+   DAOS-14680-2
+   Memcheck:Value8
+   fun:memeqbody
+}
+{
+   DAOS-14680-3
+   Memcheck:Cond
+   fun:aeshashbody
+}
+{
+   DAOS-14680-4
+   Memcheck:Value8
+   fun:aeshashbody
+}


### PR DESCRIPTION
Rocky 8.9 has brought in a new go version which is reporting
spurious leaks so add suppressions for them.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
