### PR TITLE
DAOS-14686 test: ior/crash.py fix race in ci_nhandles check

### DIFF
--- a/src/tests/ftest/ior/crash.py
+++ b/src/tests/ftest/ior/crash.py
@@ -26,6 +26,7 @@ class IorCrash(IorTestBase):
         for _ in range(attempts):
             if self.container.check_container_info(ci_nhandles=exp_nhandles):
                 return True
+            self.log.info("check_container_info does not match yet, sleep %d sec", delay_sec)
             time.sleep(delay_sec)
         return False
 
@@ -97,5 +98,7 @@ class IorCrash(IorTestBase):
             self.fail("One or more engines crashed")
 
         # Verify container handle opened by ior is closed (by ior before its graceful exit)
-        self.assertTrue(self.cont_nhandles_match(attempts=1, delay_sec=0),
+        # Give ior some time to get started and open the container!
+        # And, expect 2 open handles, one for this container open/query, and another for ior itself
+        self.assertTrue(self.cont_nhandles_match(exp_nhandles=2, attempts=5, delay_sec=2),
                         "Error confirming container info nhandles")


### PR DESCRIPTION
Before this change, the final container query ci_nhandle verification (done while ior is running without crash/interruption) would pass only if timing was fortunate. The code expected to see ci_nhandles=1 but the correct expectation is in fact ci_nhandles=2 (one for the test container handle open to perform the query, and another for the ior just launched). For a long time, the test would be lucky and always observe ci_nhandles=1. More recently, ci_nhandles=2 observations are occurring, presumably due to timing differences introduced in daos.

With this change, the test is updated to expect ci_nhandles=2, and is also modified to perform multiple (5) attempts with 2 second delays between attempts, to give time for ior to start up and open the container.

Test-tag: test_ior_crash
Test-repeat: 5
Skip-unit-tests: true
Skip-fault-injection-test: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
