### PR TITLE
Enable io-uring in SPDK

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -335,6 +335,8 @@ def define_components(reqs):
                            '--without-isal',
                            '--without-vtune',
                            '--with-shared',
+                           '--with-uring',
+                           '--without-uring-zns',
                            f'--target-arch={spdk_arch}'],
                           ['make', f'CONFIG_ARCH={spdk_arch}'],
                           ['make', 'install'],

--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -336,7 +336,6 @@ def define_components(reqs):
                            '--without-vtune',
                            '--with-shared',
                            '--with-uring',
-                           '--without-uring-zns',
                            f'--target-arch={spdk_arch}'],
                           ['make', f'CONFIG_ARCH={spdk_arch}'],
                           ['make', 'install'],

--- a/src/control/server/storage/bdev/backend_json.go
+++ b/src/control/server/storage/bdev/backend_json.go
@@ -85,6 +85,15 @@ type AioCreateParams struct {
 
 func (acp AioCreateParams) isSpdkSubsystemConfigParams() {}
 
+// UringCreateParams specifies details for a storage.ConfUringCreate method.
+type UringCreateParams struct {
+	BlockSize  uint64 `json:"block_size"`
+	DeviceName string `json:"name"`
+	Filename   string `json:"filename"`
+}
+
+func (acp UringCreateParams) isSpdkSubsystemConfigParams() {}
+
 // HotplugBusidRangeParams specifies details for a storage.ConfSetHotplugBusidRange method.
 type HotplugBusidRangeParams struct {
 	Begin uint8 `json:"begin"`
@@ -208,6 +217,16 @@ func getAioKdevCreateMethod(name, path string) *SpdkSubsystemConfig {
 	}
 }
 
+func getUringCreateMethod(name, path string) *SpdkSubsystemConfig {
+	return &SpdkSubsystemConfig{
+		Method: storage.ConfBdevUringCreate,
+		Params: UringCreateParams{
+			DeviceName: fmt.Sprintf("URING_%s", name),
+			Filename:   path,
+		},
+	}
+}
+
 func getSpdkConfigMethods(req *storage.BdevWriteConfigRequest) (sscs []*SpdkSubsystemConfig) {
 	for _, tier := range req.TierProps {
 		var f configMethodGetter
@@ -219,6 +238,8 @@ func getSpdkConfigMethods(req *storage.BdevWriteConfigRequest) (sscs []*SpdkSubs
 			f = getAioFileCreateMethod
 		case storage.ClassKdev:
 			f = getAioKdevCreateMethod
+		case storage.ClassUring:
+			f = getUringCreateMethod
 		}
 
 		for index, dev := range tier.DeviceList.Devices() {

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -90,7 +90,7 @@ func (c *Class) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	class := Class(tmp)
 	switch class {
-	case ClassDcpm, ClassRam, ClassNvme, ClassFile, ClassKdev:
+	case ClassDcpm, ClassRam, ClassNvme, ClassFile, ClassKdev, ClassUring:
 		*c = class
 	default:
 		return errors.Errorf("unsupported storage class %q", tmp)
@@ -110,6 +110,7 @@ const (
 	ClassNvme Class = "nvme"
 	ClassKdev Class = "kdev"
 	ClassFile Class = "file"
+	ClassUring Class = "uring"
 )
 
 type TierConfig struct {
@@ -134,7 +135,7 @@ func (tc *TierConfig) IsSCM() bool {
 
 func (tc *TierConfig) IsBdev() bool {
 	switch tc.Class {
-	case ClassNvme, ClassFile, ClassKdev:
+	case ClassNvme, ClassFile, ClassKdev, ClassUring:
 		return true
 	default:
 		return false
@@ -946,6 +947,7 @@ func (bc *BdevConfig) Validate(class Class) error {
 			return err
 		}
 	case ClassKdev:
+	case ClassUring:
 		if err := bc.checkNonEmptyDevList(class); err != nil {
 			return err
 		}
@@ -955,7 +957,7 @@ func (bc *BdevConfig) Validate(class Class) error {
 			return errors.New("bdev_class nvme requires valid PCI addresses in bdev_list")
 		}
 	default:
-		return errors.Errorf("bdev_class value %q not supported (valid: nvme/kdev/file)", class)
+		return errors.Errorf("bdev_class value %q not supported (valid: nvme/kdev/file/uring)", class)
 	}
 
 	return nil
@@ -1111,6 +1113,8 @@ func (c *Config) Validate() error {
 		c.VosEnv = "NVME"
 	case ClassFile, ClassKdev:
 		c.VosEnv = "AIO"
+	case ClassUring:
+		c.VosEnv = "URING"
 	}
 
 	var nvmeConfigRoot string

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -410,6 +410,7 @@
 #    # - "nvme" for NVMe SSDs (preferred option), bdev_size ignored
 #    # - "file" to emulate a NVMe SSD with a regular file
 #    # - "kdev" to use a kernel block device, bdev_size ignored
+#    # - "uring" to use the IO_uring interface to a kernel block device
 #    # Immutable after running "dmg storage format".
 #
 #    class: nvme

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -43,6 +43,7 @@ dnf --nodocs install \
     libtool \
     libtool-ltdl-devel \
     libunwind-devel \
+    liburing-devel \
     libuuid-devel \
     libyaml-devel \
     Lmod \

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -44,6 +44,7 @@ dnf --nodocs install \
     libtool-ltdl-devel \
     libunwind-devel \
     libuuid-devel \
+    liburing-devel \
     libyaml-devel \
     lz4-devel \
     make \

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -44,6 +44,7 @@ dnf --nodocs install \
     libtool \
     libunwind-devel \
     libuuid-devel \
+    liburing-devel \
     libyaml-devel \
     lua-lmod \
     make \

--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -42,6 +42,7 @@ apt-get install \
     libssl-dev \
     libtool-bin \
     libunwind-dev \
+    liburing-dev \
     libyaml-dev \
     locales \
     maven \


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
