### PR TITLE
DAOS-13433 test: increase timeout for dfuse/caching_check (#13355)

### DIFF
--- a/src/tests/ftest/dfuse/caching_check.py
+++ b/src/tests/ftest/dfuse/caching_check.py
@@ -43,34 +43,34 @@ class DfuseCachingCheck(IorTestBase):
         # update flag
         self.ior_cmd.update_params(flags=flags[0])
 
-        # run ior to write to the dfuse mount point
+        self.log_step('Write to the dfuse mount point')
         self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
 
-        # update ior flag to read
+        self.log_step('Get baseline read performance from dfuse with caching disabled')
         self.ior_cmd.update_params(flags=flags[1])
-        # run ior to read and store the read performance
         base_read_arr = []
         out = self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
         base_read_arr.append(IorCommand.get_ior_metrics(out))
-        # run ior again to read with caching disabled and store performance
         out = self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
         base_read_arr.append(IorCommand.get_ior_metrics(out))
 
         # the index of max_mib
         max_mib = IorMetrics.MAX_MIB
 
-        # unmount dfuse and mount again with caching enabled
+        self.log_step('Re-mount dfuse with caching enabled')
         self.dfuse.unmount(tries=1)
         self.dfuse.update_params(disable_caching=False)
         self.dfuse.run()
-        # run ior to obtain first read performance after mount
+
+        self.log_step('Get first read performance with caching enabled')
         out = self.run_ior_with_pool(fail_on_warning=False, stop_dfuse=False)
         base_read_arr.append(IorCommand.get_ior_metrics(out))
-        # run ior again to obtain second read performance with caching enabled
-        # second read should be multiple times greater than first read
+
+        self.log_step('Get cached read performance')
         out = self.run_ior_with_pool(fail_on_warning=False)
         with_caching = IorCommand.get_ior_metrics(out)
-        # verify cached read performance is multiple times greater than without caching
+
+        self.log_step('Verify cached read performance is greater than first read')
         # Log all the values first, then do the assert so that failures can be checked easily.
         for base_read in base_read_arr:
             actual_change = percent_change(base_read[0][max_mib], with_caching[0][max_mib])

--- a/src/tests/ftest/dfuse/caching_check.yaml
+++ b/src/tests/ftest/dfuse/caching_check.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 3
   test_clients: 1
-timeout: 240
+timeout: 300
 server_config:
   name: daos_server
   engines_per_host: 1
@@ -11,7 +11,6 @@ server_config:
       storage: auto
 pool:
   size: 50%
-  control_method: dmg
 container:
   type: POSIX
   control_method: daos


### PR DESCRIPTION
Test-tag: DfuseCachingCheck
Test-repeat: 5
Skip-unit-tests: true
Skip-fault-injection-test: true

Increase timeout for dfuse/caching_check.py and add more logging.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
