### PR TITLE
DAOS-14714 vos: return fetch handle only when vos_fetch_begin succeed

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1554,28 +1554,24 @@ vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		       &rc, false)) {
 		if (rc == 0) {
 			if (ioc->ic_read_ts_only)
-				goto set_ioc;
+				goto out;
+
 			if (ioc->ic_obj != NULL &&
 			    has_uncertainty(ioc, &ioc->ic_obj->obj_ilog_info))
 				goto fetch_dkey;
 			for (i = 0; i < iod_nr; i++)
 				iod_empty_sgl(ioc, i);
-			goto set_ioc;
 		}
 		goto out;
 	}
 fetch_dkey:
 	if (dkey == NULL || dkey->iov_len == 0) {
-		if (ioc->ic_read_ts_only)
-			goto set_ioc;
-		D_GOTO(out, rc = -DER_INVAL);
+		if (!ioc->ic_read_ts_only)
+			rc = -DER_INVAL;
+	} else {
+		rc = dkey_fetch(ioc, dkey);
 	}
 
-	rc = dkey_fetch(ioc, dkey);
-	if (rc != 0)
-		goto out;
-set_ioc:
-	*ioh = vos_ioc2ioh(ioc);
 out:
 	vos_dth_set(NULL, ioc->ic_cont->vc_pool->vp_sysdb);
 
@@ -1594,9 +1590,13 @@ out:
 	if (rc != 0) {
 		daos_recx_ep_list_free(ioc->ic_recx_lists, ioc->ic_iod_nr);
 		ioc->ic_recx_lists = NULL;
-		return vos_fetch_end(vos_ioc2ioh(ioc), NULL, rc);
+		rc = vos_fetch_end(vos_ioc2ioh(ioc), NULL, rc);
+		*ioh = DAOS_HDL_INVAL;
+	} else {
+		*ioh = vos_ioc2ioh(ioc);
 	}
-	return 0;
+
+	return rc;
 }
 
 static umem_off_t


### PR DESCRIPTION
The old logic in vos_fetch_begin() may assign io_context handle to the
output parameter too early, but some subsequent logic may destroy such
handle after that because of some failure. That can cause the returned
handle to be invalid as to related memory to be double freed.

Priority: 2

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
