### PR TITLE
DAOS-14716 dfuse: Add a inode lock for readdir and remove assert.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -147,9 +147,6 @@ struct dfuse_obj_hdl {
 
 	ATOMIC uint32_t           doh_il_calls;
 
-	/** Number of active readdir operations */
-	ATOMIC uint32_t           doh_readdir_number;
-
 	ATOMIC uint64_t           doh_write_count;
 
 	/* Next offset we expect from readdir */
@@ -907,9 +904,6 @@ struct dfuse_inode_entry {
 
 	/* Readdir handle, if present.  May be shared */
 	struct dfuse_readdir_hdl *ie_rd_hdl;
-
-	/** Number of active readdir operations */
-	ATOMIC uint32_t           ie_readdir_number;
 
 	/** file was truncated from 0 to a certain size */
 	bool                      ie_truncated;

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -876,6 +876,9 @@ struct dfuse_inode_entry {
 
 	struct dfuse_cont        *ie_dfs;
 
+	/* Lock, used to protect readdir calls */
+	pthread_mutex_t           ie_lock;
+
 	/** Hash table of inodes
 	 * All valid inodes are kept in a hash table, using the hash table locking.
 	 */

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1112,6 +1112,8 @@ dfuse_ie_init(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 	atomic_init(&ie->ie_il_count, 0);
 	atomic_init(&ie->ie_readdir_number, 0);
 	atomic_fetch_add_relaxed(&dfuse_info->di_inode_count, 1);
+
+	D_MUTEX_INIT(&ie->ie_lock, NULL);
 }
 
 void
@@ -1147,6 +1149,8 @@ dfuse_ie_close(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 
 		d_hash_rec_decref(&dfp->dfp_cont_table, &dfc->dfs_entry);
 	}
+
+	D_MUTEX_DESTROY(&ie->ie_lock);
 
 	dfuse_ie_free(dfuse_info, ie);
 }

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1098,7 +1098,6 @@ dfuse_open_handle_init(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh,
 	oh->doh_linear_read     = true;
 	oh->doh_linear_read_pos = 0;
 	atomic_init(&oh->doh_il_calls, 0);
-	atomic_init(&oh->doh_readdir_number, 0);
 	atomic_init(&oh->doh_write_count, 0);
 	atomic_fetch_add_relaxed(&dfuse_info->di_fh_count, 1);
 }
@@ -1110,7 +1109,6 @@ dfuse_ie_init(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 	atomic_init(&ie->ie_open_count, 0);
 	atomic_init(&ie->ie_open_write_count, 0);
 	atomic_init(&ie->ie_il_count, 0);
-	atomic_init(&ie->ie_readdir_number, 0);
 	atomic_fetch_add_relaxed(&dfuse_info->di_inode_count, 1);
 
 	D_MUTEX_INIT(&ie->ie_lock, NULL);
@@ -1127,8 +1125,6 @@ dfuse_ie_close(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 			ie->ie_stat.st_ino, ref, DP_DE(ie->ie_name), ie->ie_parent);
 
 	D_ASSERTF(ref == 0, "Reference is %d", ref);
-	D_ASSERTF(atomic_load_relaxed(&ie->ie_readdir_number) == 0, "readdir_number is %d",
-		  atomic_load_relaxed(&ie->ie_readdir_number));
 	D_ASSERTF(atomic_load_relaxed(&ie->ie_il_count) == 0, "il_count is %d",
 		  atomic_load_relaxed(&ie->ie_il_count));
 	D_ASSERTF(atomic_load_relaxed(&ie->ie_open_count) == 0, "open_count is %d",

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -817,8 +817,6 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh, size_t size, off_t of
 	rc = dfuse_do_readdir(dfuse_info, req, oh, reply_buff, &size, offset, plus);
 
 out:
-	atomic_fetch_sub_relaxed(&oh->doh_readdir_number, 1);
-	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_readdir_number, 1);
 
 	D_MUTEX_UNLOCK(&oh->doh_ie->ie_lock);
 

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -789,11 +789,7 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh, size_t size, off_t of
 	char              *reply_buff = NULL;
 	int                rc         = EIO;
 
-	D_ASSERTF(atomic_fetch_add_relaxed(&oh->doh_readdir_number, 1) == 0,
-		  "Multiple readdir per handle");
-
-	D_ASSERTF(atomic_fetch_add_relaxed(&oh->doh_ie->ie_readdir_number, 1) == 0,
-		  "Multiple readdir per inode");
+	D_MUTEX_LOCK(&oh->doh_ie->ie_lock);
 
 	/* Handle the EOD case, the kernel will keep reading until it receives zero replies so
 	 * reply early in this case.
@@ -823,6 +819,8 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh, size_t size, off_t of
 out:
 	atomic_fetch_sub_relaxed(&oh->doh_readdir_number, 1);
 	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_readdir_number, 1);
+
+	D_MUTEX_UNLOCK(&oh->doh_ie->ie_lock);
 
 	if (rc)
 		DFUSE_REPLY_ERR_RAW(oh, req, rc);


### PR DESCRIPTION
Remove the usee of assert for detecting unexpected kernel behaviour.
Add a lock to protect against concurrent readdir calls.
Features: dfuse

Required-githooks: true
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
