### PR TITLE
DAOS-14716 dfuse: Add a inode lock for readdir and remove assert.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -749,6 +749,9 @@ struct dfuse_inode_entry {
 
 	struct dfuse_cont        *ie_dfs;
 
+	/* Lock, used to protect readdir calls */
+	pthread_mutex_t           ie_lock;
+
 	/** Hash table of inodes
 	 * All valid inodes are kept in a hash table, using the hash table locking.
 	 */

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -99,9 +99,6 @@ struct dfuse_obj_hdl {
 
 	ATOMIC uint32_t           doh_il_calls;
 
-	/** Number of active readdir operations */
-	ATOMIC uint32_t           doh_readdir_number;
-
 	ATOMIC uint64_t           doh_write_count;
 
 	/* Next offset we expect from readdir */
@@ -780,9 +777,6 @@ struct dfuse_inode_entry {
 
 	/* Readdir handle, if present.  May be shared */
 	struct dfuse_readdir_hdl *ie_rd_hdl;
-
-	/** Number of active readdir operations */
-	ATOMIC uint32_t           ie_readdir_number;
 
 	/** file was truncated from 0 to a certain size */
 	bool                      ie_truncated;

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1123,6 +1123,8 @@ dfuse_ie_init(struct dfuse_inode_entry *ie)
 	atomic_init(&ie->ie_open_write_count, 0);
 	atomic_init(&ie->ie_il_count, 0);
 	atomic_init(&ie->ie_readdir_number, 0);
+
+	D_MUTEX_INIT(&ie->ie_lock, NULL);
 }
 
 void
@@ -1155,6 +1157,8 @@ dfuse_ie_close(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry
 
 		d_hash_rec_decref(&dfp->dfp_cont_table, &dfc->dfs_entry);
 	}
+
+	D_MUTEX_DESTROY(&ie->ie_lock);
 
 	D_FREE(ie);
 }

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1111,7 +1111,6 @@ dfuse_open_handle_init(struct dfuse_obj_hdl *oh, struct dfuse_inode_entry *ie)
 	oh->doh_linear_read     = true;
 	oh->doh_linear_read_pos = 0;
 	atomic_init(&oh->doh_il_calls, 0);
-	atomic_init(&oh->doh_readdir_number, 0);
 	atomic_init(&oh->doh_write_count, 0);
 }
 
@@ -1122,7 +1121,6 @@ dfuse_ie_init(struct dfuse_inode_entry *ie)
 	atomic_init(&ie->ie_open_count, 0);
 	atomic_init(&ie->ie_open_write_count, 0);
 	atomic_init(&ie->ie_il_count, 0);
-	atomic_init(&ie->ie_readdir_number, 0);
 
 	D_MUTEX_INIT(&ie->ie_lock, NULL);
 }
@@ -1138,7 +1136,6 @@ dfuse_ie_close(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry
 			ie->ie_stat.st_ino, ref, ie->ie_name, ie->ie_parent);
 
 	D_ASSERT(ref == 0);
-	D_ASSERT(atomic_load_relaxed(&ie->ie_readdir_number) == 0);
 	D_ASSERT(atomic_load_relaxed(&ie->ie_il_count) == 0);
 	D_ASSERT(atomic_load_relaxed(&ie->ie_open_count) == 0);
 

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -816,9 +816,6 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_obj_hdl *oh, size_t size, off_t of
 	rc = dfuse_do_readdir(fs_handle, req, oh, reply_buff, &size, offset, plus);
 
 out:
-	atomic_fetch_sub_relaxed(&oh->doh_readdir_number, 1);
-	atomic_fetch_sub_relaxed(&oh->doh_ie->ie_readdir_number, 1);
-
 	D_MUTEX_UNLOCK(&oh->doh_ie->ie_lock);
 
 	if (rc)


### PR DESCRIPTION
Remove the usee of assert for detecting unexpected kernel behaviour.
Add a lock to protect against concurrent readdir calls.
Features: dfuse

Required-githooks: true
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
