### PR TITLE
DAOS-12425 control: Add opt to auto-format on server start-up (#13074)

### DIFF
--- a/src/control/cmd/daos_server/start.go
+++ b/src/control/cmd/daos_server/start.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -27,13 +27,14 @@ type startCmd struct {
 	Port                uint16  `short:"p" long:"port" description:"Port for the gRPC management interfect to listen on"`
 	MountPath           string  `short:"s" long:"storage" description:"Storage path"`
 	Modules             *string `short:"m" long:"modules" description:"List of server modules to load"`
-	Targets             uint16  `short:"t" long:"targets" description:"number of targets to use (default use all cores)"`
-	NrXsHelpers         *uint16 `short:"x" long:"xshelpernr" description:"number of helper XS per VOS target"`
-	FirstCore           uint16  `short:"f" long:"firstcore" default:"0" description:"index of first core for service thread"`
+	Targets             uint16  `short:"t" long:"targets" description:"Number of targets to use (default use all cores)"`
+	NrXsHelpers         *uint16 `short:"x" long:"xshelpernr" description:"Number of helper XS per VOS target"`
+	FirstCore           uint16  `short:"f" long:"firstcore" default:"0" description:"Index of first core for service thread"`
 	Group               string  `short:"g" long:"group" description:"Server group name"`
 	SocketDir           string  `short:"d" long:"socket_dir" description:"Location for all daos_server & daos_engine sockets"`
-	Insecure            bool    `short:"i" long:"insecure" description:"allow for insecure connections"`
-	RecreateSuperblocks bool    `long:"recreate-superblocks" description:"recreate missing superblocks rather than failing"`
+	Insecure            bool    `short:"i" long:"insecure" description:"Allow for insecure connections"`
+	RecreateSuperblocks bool    `long:"recreate-superblocks" description:"Recreate missing superblocks rather than failing"`
+	AutoFormat          bool    `long:"auto-format" description:"Automatically format storage on server start to bring-up engines without requiring dmg storage format command"`
 }
 
 func (cmd *startCmd) setCLIOverrides() error {
@@ -160,6 +161,8 @@ func (cmd *startCmd) Execute(args []string) error {
 	if err := cmd.configureLogging(); err != nil {
 		return err
 	}
+
+	cmd.config.AutoFormat = cmd.AutoFormat
 
 	return cmd.start(cmd.Logger, cmd.config)
 }

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -78,6 +78,9 @@ type Server struct {
 
 	// Legacy config file parameters stored in a separate struct.
 	Legacy ServerLegacy `yaml:",inline"`
+
+	// Behavior flags
+	AutoFormat bool `yaml:"-"`
 }
 
 // WithCoreDumpFilter sets the core dump filter written to /proc/self/coredump_filter.

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -467,6 +467,14 @@ func (srv *server) start(ctx context.Context) error {
 	}()
 
 	srv.mgmtSvc.startAsyncLoops(ctx)
+
+	if srv.cfg.AutoFormat {
+		srv.log.Notice("--auto flag set on server start so formatting storage now")
+		if _, err := srv.ctlSvc.StorageFormat(ctx, &ctlpb.StorageFormatReq{}); err != nil {
+			return errors.WithMessage(err, "attempting to auto format")
+		}
+	}
+
 	return errors.Wrapf(srv.harness.Start(ctx, srv.sysdb, srv.cfg),
 		"%s harness exited", build.ControlPlaneName)
 }


### PR DESCRIPTION
Features: control

Add daos_server start --auto-format option to enable engines to start without having to trigger a storage format with an externally executed dmg storage format command. If the flag is detected the server will call the format API during its start-up routine and if the server config file used is valid the engines will be started after format completes.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
