### PR TITLE
DAOS-14021 pool: undo clang-format on pool, container RPCs

### DIFF
--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -91,6 +91,8 @@ extern struct crt_proto_format cont_proto_fmt_v8;
 extern struct crt_proto_format cont_proto_fmt_v7;
 extern int dc_cont_proto_version;
 
+/* clang-format off */
+
 #define DAOS_ISEQ_CONT_OP	/* input fields */		 \
 				/* pool handle UUID */		 \
 	((uuid_t)		(ci_pool_hdl)		CRT_VAR) \
@@ -99,11 +101,15 @@ extern int dc_cont_proto_version;
 				/* container handle UUID */	 \
 	((uuid_t)		(ci_hdl)		CRT_VAR)
 
-#define DAOS_ISEQ_CONT_OP_V8           /* input fields */                                          \
-				       /* pool handle UUID */                                      \
-	((uuid_t)(ci_pool_hdl)CRT_VAR) /* container UUID */                                        \
-	    ((uuid_t)(ci_uuid)CRT_VAR) /* container handle UUID */                                 \
-	    ((uuid_t)(ci_hdl)CRT_VAR)((uuid_t)(ci_cli_id)CRT_VAR)((uint64_t)(ci_time)CRT_VAR)
+#define DAOS_ISEQ_CONT_OP_V8	/* input fields */		 \
+				/* pool handle UUID */		 \
+	((uuid_t)		(ci_pool_hdl)		CRT_VAR) \
+				/* container UUID */		 \
+	((uuid_t)		(ci_uuid)		CRT_VAR) \
+				/* container handle UUID */	 \
+	((uuid_t)		(ci_hdl)		CRT_VAR) \
+	((uuid_t)		(ci_cli_id)		CRT_VAR) \
+	((uint64_t)		(ci_time)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_OP	/* output fields */		 \
 				/* operation return code */	 \
@@ -116,20 +122,23 @@ extern int dc_cont_proto_version;
 CRT_RPC_DECLARE(cont_op, DAOS_ISEQ_CONT_OP, DAOS_OSEQ_CONT_OP)
 CRT_RPC_DECLARE(cont_op_v8, DAOS_ISEQ_CONT_OP_V8, DAOS_OSEQ_CONT_OP)
 
-#define DAOS_ISEQ_CONT_CREATE	/* input fields */		 \
-				/* .ci_hdl unused */		 \
-	((struct cont_op_in)	(cci_op)		CRT_VAR) \
-	((daos_prop_t)		(cci_prop)		CRT_PTR)
+#define DAOS_ISEQ_CONT_CREATE		/* input fields */		 \
+					/* .ci_hdl unused */		 \
+	((struct cont_op_in)		(cci_op)		CRT_VAR) \
+	((daos_prop_t)			(cci_prop)		CRT_PTR)
 
-#define DAOS_ISEQ_CONT_CREATE_V8 /* input fields */                                                \
-				 /* .ci_hdl unused */                                              \
-	((struct cont_op_v8_in)(cci_op)CRT_VAR)((daos_prop_t)(cci_prop)CRT_PTR)
+#define DAOS_ISEQ_CONT_CREATE_V8	/* input fields */		 \
+					/* .ci_hdl unused */		 \
+	((struct cont_op_v8_in)		(cci_op)		CRT_VAR) \
+	((daos_prop_t)			(cci_prop)		CRT_PTR)
 
-#define DAOS_OSEQ_CONT_CREATE	/* output fields */		 \
-	((struct cont_op_out)	(cco_op)		CRT_VAR)
+#define DAOS_OSEQ_CONT_CREATE		/* output fields */		 \
+	((struct cont_op_out)		(cco_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_create, DAOS_ISEQ_CONT_CREATE, DAOS_OSEQ_CONT_CREATE)
 CRT_RPC_DECLARE(cont_create_v8, DAOS_ISEQ_CONT_CREATE_V8, DAOS_OSEQ_CONT_CREATE)
+
+/* clang-format on */
 
 static inline void
 cont_create_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -154,19 +163,21 @@ cont_create_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, da
 		((struct cont_create_in *)in)->cci_prop = cci_prop;
 }
 
-#define DAOS_ISEQ_CONT_DESTROY	/* input fields */		 \
-				/* .ci_hdl unused */		 \
-	((struct cont_op_in)	(cdi_op)		CRT_VAR) \
-				/* evict all handles */		 \
-	((uint32_t)		(cdi_force)		CRT_VAR)
+/* clang-format off */
+#define DAOS_ISEQ_CONT_DESTROY		/* input fields */		 \
+					/* .ci_hdl unused */		 \
+	((struct cont_op_in)		(cdi_op)		CRT_VAR) \
+					/* evict all handles */		 \
+	((uint32_t)			(cdi_force)		CRT_VAR)
 
-#define DAOS_ISEQ_CONT_DESTROY_V8               /* input fields */                                 \
-						/* .ci_hdl unused */                               \
-	((struct cont_op_v8_in)(cdi_op)CRT_VAR) /* evict all handles */                            \
-	    ((uint32_t)(cdi_force)CRT_VAR)
+#define DAOS_ISEQ_CONT_DESTROY_V8	/* input fields */		 \
+					/* .ci_hdl unused */		 \
+	((struct cont_op_v8_in)		(cdi_op)		CRT_VAR) \
+					/* evict all handles */		 \
+	((uint32_t)			(cdi_force)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_DESTROY	/* output fields */		 \
-	((struct cont_op_out)	(cdo_op)		CRT_VAR)
+#define DAOS_OSEQ_CONT_DESTROY		/* output fields */		 \
+	((struct cont_op_out)		(cdo_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_destroy, DAOS_ISEQ_CONT_DESTROY, DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DECLARE(cont_destroy_v8, DAOS_ISEQ_CONT_DESTROY_V8, DAOS_OSEQ_CONT_DESTROY)
@@ -175,19 +186,21 @@ CRT_RPC_DECLARE(cont_destroy_v8, DAOS_ISEQ_CONT_DESTROY_V8, DAOS_OSEQ_CONT_DESTR
  * Must begin with what DAOS_ISEQ_CONT_DESTROY has, for reusing cont_destroy_in
  * in the common code. cdi_op.ci_uuid is ignored.
  */
-#define DAOS_ISEQ_CONT_DESTROY_BYLABEL	/* input fields */	 \
-	DAOS_ISEQ_CONT_DESTROY					 \
-	((uint32_t)		(cdli_pad32)		CRT_VAR) \
-	((d_const_string_t)	(cdli_label)		CRT_VAR)
+#define DAOS_ISEQ_CONT_DESTROY_BYLABEL		/* input fields */	 \
+	DAOS_ISEQ_CONT_DESTROY						 \
+	((uint32_t)				(cdli_pad32)	CRT_VAR) \
+	((d_const_string_t)			(cdli_label)	CRT_VAR)
 
-#define DAOS_ISEQ_CONT_DESTROY_BYLABEL_V8 /* input fields */                                       \
-	DAOS_ISEQ_CONT_DESTROY_V8((uint32_t)(cdli_pad32)CRT_VAR)                                   \
-	((d_const_string_t)(cdli_label)CRT_VAR)
+#define DAOS_ISEQ_CONT_DESTROY_BYLABEL_V8	/* input fields */	 \
+	DAOS_ISEQ_CONT_DESTROY_V8					 \
+	((uint32_t)				(cdli_pad32)	CRT_VAR) \
+	((d_const_string_t)			(cdli_label)	CRT_VAR)
 
 /* Container destroy bylabel output same as destroy by uuid. */
-CRT_RPC_DECLARE(cont_destroy_bylabel, DAOS_ISEQ_CONT_DESTROY_BYLABEL,
-		DAOS_OSEQ_CONT_DESTROY)
+CRT_RPC_DECLARE(cont_destroy_bylabel, DAOS_ISEQ_CONT_DESTROY_BYLABEL, DAOS_OSEQ_CONT_DESTROY)
 CRT_RPC_DECLARE(cont_destroy_bylabel_v8, DAOS_ISEQ_CONT_DESTROY_BYLABEL_V8, DAOS_OSEQ_CONT_DESTROY)
+
+/* clang-format on */
 
 static inline void
 cont_destroy_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint32_t *cdi_forcep,
@@ -239,21 +252,27 @@ cont_destroy_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, u
 	}
 }
 
+/* clang-format off */
+
 #define DAOS_ISEQ_CONT_OPEN	/* input fields */		 \
 	((struct cont_op_in)	(coi_op)		CRT_VAR) \
 	((uint64_t)		(coi_flags)		CRT_VAR) \
 	((uint64_t)		(coi_sec_capas)		CRT_VAR) \
 	((uint64_t)		(coi_prop_bits)		CRT_VAR)
 
-#define DAOS_ISEQ_CONT_OPEN_V8 /* input fields */                                                  \
-	((struct cont_op_v8_in)(coi_op)CRT_VAR)((uint64_t)(coi_flags)CRT_VAR)(                     \
-	    (uint64_t)(coi_prop_bits)CRT_VAR)
+#define DAOS_ISEQ_CONT_OPEN_V8	/* input fields */		 \
+	((struct cont_op_v8_in)	(coi_op)		CRT_VAR) \
+	((uint64_t)		(coi_flags)		CRT_VAR) \
+	((uint64_t)		(coi_prop_bits)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_OPEN /* common fields */                                                    \
-	((struct cont_op_out)(coo_op)CRT_VAR)((daos_prop_t)(coo_prop)CRT_PTR)(                     \
-	    (daos_epoch_t)(coo_lsnapshot)CRT_VAR)((uint32_t)(coo_snap_count)CRT_VAR)(              \
-	    (uint32_t)(coo_nhandles)CRT_VAR)((uint64_t)(coo_md_otime)CRT_VAR)(                     \
-	    (uint64_t)(coo_md_mtime)CRT_VAR)
+#define DAOS_OSEQ_CONT_OPEN	/* common fields */		 \
+	((struct cont_op_out)	(coo_op)		CRT_VAR) \
+	((daos_prop_t)		(coo_prop)		CRT_PTR) \
+	((daos_epoch_t)		(coo_lsnapshot)		CRT_VAR) \
+	((uint32_t)		(coo_snap_count)	CRT_VAR) \
+	((uint32_t)		(coo_nhandles)		CRT_VAR) \
+	((uint64_t)		(coo_md_otime)		CRT_VAR) \
+	((uint64_t)		(coo_md_mtime)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_open_v8, DAOS_ISEQ_CONT_OPEN_V8, DAOS_OSEQ_CONT_OPEN)
 CRT_RPC_DECLARE(cont_open, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN)
@@ -262,22 +281,29 @@ CRT_RPC_DECLARE(cont_open, DAOS_ISEQ_CONT_OPEN, DAOS_OSEQ_CONT_OPEN)
  * Must begin with what DAOS_ISEQ_CONT_OPEN has, for reusing cont_open_in
  * in the common code. coi_op.ci_uuid is ignored.
  */
-#define DAOS_ISEQ_CONT_OPEN_BYLABEL	/* input fields */	 \
-	DAOS_ISEQ_CONT_OPEN					 \
-	((d_const_string_t)	(coli_label)		CRT_VAR)
+#define DAOS_ISEQ_CONT_OPEN_BYLABEL	/* input fields */		 \
+	DAOS_ISEQ_CONT_OPEN				 		 \
+	((d_const_string_t)		(coli_label)		CRT_VAR)
 
-#define DAOS_ISEQ_CONT_OPEN_BYLABEL_V8 /* input fields */                                          \
-	DAOS_ISEQ_CONT_OPEN_V8((d_const_string_t)(coli_label)CRT_VAR)
+#define DAOS_ISEQ_CONT_OPEN_BYLABEL_V8	/* input fields */		 \
+	DAOS_ISEQ_CONT_OPEN_V8						 \
+	((d_const_string_t)		(coli_label)		CRT_VAR)
 
 /* Container open bylabel output */
-#define DAOS_OSEQ_CONT_OPEN_BYLABEL /* output fields */                                            \
-	((struct cont_op_out)(coo_op)CRT_VAR)((daos_prop_t)(coo_prop)CRT_PTR)(                     \
-	    (daos_epoch_t)(coo_lsnapshot)CRT_VAR)((uint32_t)(coo_snap_count)CRT_VAR)(              \
-	    (uint32_t)(coo_nhandles)CRT_VAR)((uuid_t)(colo_uuid)CRT_VAR)(                          \
-	    (uint64_t)(coo_md_otime)CRT_VAR)((uint64_t)(coo_md_mtime)CRT_VAR)
+#define DAOS_OSEQ_CONT_OPEN_BYLABEL	/* output fields */		 \
+	((struct cont_op_out)		(coo_op)		CRT_VAR) \
+	((daos_prop_t)			(coo_prop)		CRT_PTR) \
+	((daos_epoch_t)			(coo_lsnapshot)		CRT_VAR) \
+	((uint32_t)			(coo_snap_count)	CRT_VAR) \
+	((uint32_t)			(coo_nhandles)		CRT_VAR) \
+	((uuid_t)			(colo_uuid)		CRT_VAR) \
+	((uint64_t)			(coo_md_otime)		CRT_VAR) \
+	((uint64_t)			(coo_md_mtime)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_open_bylabel, DAOS_ISEQ_CONT_OPEN_BYLABEL, DAOS_OSEQ_CONT_OPEN_BYLABEL)
 CRT_RPC_DECLARE(cont_open_bylabel_v8, DAOS_ISEQ_CONT_OPEN_BYLABEL_V8, DAOS_OSEQ_CONT_OPEN_BYLABEL)
+
+/* clang-format on */
 
 static inline void
 cont_open_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t *coi_flagsp,
@@ -356,16 +382,21 @@ cont_op_in_get_label(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, const
 	}
 }
 
+/* clang-format off */
+
 #define DAOS_ISEQ_CONT_CLOSE	/* input fields */		 \
 	((struct cont_op_in)	(cci_op)		CRT_VAR)
 
-#define DAOS_ISEQ_CONT_CLOSE_V8 /* input fields */ ((struct cont_op_v8_in)(cci_op)CRT_VAR)
+#define DAOS_ISEQ_CONT_CLOSE_V8	/* input fields */		 \
+	((struct cont_op_v8_in)	(cci_op)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_CLOSE	/* output fields */		 \
 	((struct cont_op_out)	(cco_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_close, DAOS_ISEQ_CONT_CLOSE, DAOS_OSEQ_CONT_CLOSE)
 CRT_RPC_DECLARE(cont_close_v8, DAOS_ISEQ_CONT_CLOSE_V8, DAOS_OSEQ_CONT_CLOSE)
+
+/* clang-format on */
 
 /** container query request bits */
 #define DAOS_CO_QUERY_PROP_LABEL		(1ULL << 0)
@@ -402,21 +433,29 @@ CRT_RPC_DECLARE(cont_close_v8, DAOS_ISEQ_CONT_CLOSE_V8, DAOS_OSEQ_CONT_CLOSE)
 /** container query target bit, to satisfy querying of daos_cont_info_t */
 #define DAOS_CO_QUERY_TGT		(1ULL << 31)
 
+/* clang-format off */
+
 #define DAOS_ISEQ_CONT_QUERY	/* input fields */		 \
 	((struct cont_op_in)	(cqi_op)		CRT_VAR) \
 	((uint64_t)		(cqi_bits)		CRT_VAR)
 
-#define DAOS_ISEQ_CONT_QUERY_V8 /* input fields */                                                 \
-	((struct cont_op_v8_in)(cqi_op)CRT_VAR)((uint64_t)(cqi_bits)CRT_VAR)
+#define DAOS_ISEQ_CONT_QUERY_V8	/* input fields */		 \
+	((struct cont_op_v8_in)	(cqi_op)		CRT_VAR) \
+	((uint64_t)		(cqi_bits)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_QUERY /* common fields */                                                   \
-	((struct cont_op_out)(cqo_op)CRT_VAR)((daos_prop_t)(cqo_prop)CRT_PTR)(                     \
-	    (daos_epoch_t)(cqo_lsnapshot)CRT_VAR)((uint32_t)(cqo_snap_count)CRT_VAR)(              \
-	    (uint32_t)(cqo_nhandles)CRT_VAR)((uint64_t)(cqo_md_otime)CRT_VAR)(                     \
-	    (uint64_t)(cqo_md_mtime)CRT_VAR)
+#define DAOS_OSEQ_CONT_QUERY	/* common fields */		 \
+	((struct cont_op_out)	(cqo_op)		CRT_VAR) \
+	((daos_prop_t)		(cqo_prop)		CRT_PTR) \
+	((daos_epoch_t)		(cqo_lsnapshot)		CRT_VAR) \
+	((uint32_t)		(cqo_snap_count)	CRT_VAR) \
+	((uint32_t)		(cqo_nhandles)		CRT_VAR) \
+	((uint64_t)		(cqo_md_otime)		CRT_VAR) \
+	((uint64_t)		(cqo_md_mtime)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_query, DAOS_ISEQ_CONT_QUERY, DAOS_OSEQ_CONT_QUERY)
 CRT_RPC_DECLARE(cont_query_v8, DAOS_ISEQ_CONT_QUERY_V8, DAOS_OSEQ_CONT_QUERY)
+
+/* clang-format on */
 
 static inline void
 cont_query_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uint64_t *cqi_bitsp)
@@ -442,6 +481,8 @@ cont_query_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uin
 
 /** Add more items to query when needed */
 
+/* clang-format off */
+
 #define DAOS_ISEQ_CONT_OID_ALLOC /* input fields */		 \
 	((struct cont_op_in)	(coai_op)		CRT_VAR) \
 	((daos_size_t)		(num_oids)		CRT_VAR)
@@ -452,19 +493,22 @@ cont_query_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, uin
 
 CRT_RPC_DECLARE(cont_oid_alloc, DAOS_ISEQ_CONT_OID_ALLOC, DAOS_OSEQ_CONT_OID_ALLOC)
 
-#define DAOS_ISEQ_CONT_ATTR_LIST /* input fields */		 \
-	((struct cont_op_in)	(cali_op)		CRT_VAR) \
-	((crt_bulk_t)		(cali_bulk)		CRT_VAR)
+#define DAOS_ISEQ_CONT_ATTR_LIST 	/* input fields */		 \
+	((struct cont_op_in)		(cali_op)		CRT_VAR) \
+	((crt_bulk_t)			(cali_bulk)		CRT_VAR)
 
-#define DAOS_ISEQ_CONT_ATTR_LIST_V8 /* input fields */                                             \
-	((struct cont_op_v8_in)(cali_op)CRT_VAR)((crt_bulk_t)(cali_bulk)CRT_VAR)
+#define DAOS_ISEQ_CONT_ATTR_LIST_V8	/* input fields */		 \
+	((struct cont_op_v8_in)		(cali_op)		CRT_VAR) \
+	((crt_bulk_t)			(cali_bulk)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_ATTR_LIST /* output fields */		 \
-	((struct cont_op_out)	(calo_op)		CRT_VAR) \
-	((uint64_t)		(calo_size)		CRT_VAR)
+#define DAOS_OSEQ_CONT_ATTR_LIST	/* output fields */		 \
+	((struct cont_op_out)		(calo_op)		CRT_VAR) \
+	((uint64_t)			(calo_size)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_attr_list, DAOS_ISEQ_CONT_ATTR_LIST, DAOS_OSEQ_CONT_ATTR_LIST)
 CRT_RPC_DECLARE(cont_attr_list_v8, DAOS_ISEQ_CONT_ATTR_LIST_V8, DAOS_OSEQ_CONT_ATTR_LIST)
+
+/* clang-format on */
 
 static inline void
 cont_attr_list_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -490,21 +534,27 @@ cont_attr_list_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
 		((struct cont_attr_list_in *)in)->cali_bulk = cali_bulk;
 }
 
-#define DAOS_ISEQ_CONT_ATTR_GET	/* input fields */		 \
-	((struct cont_op_in)	(cagi_op)		CRT_VAR) \
-	((uint64_t)		(cagi_count)		CRT_VAR) \
-	((uint64_t)		(cagi_key_length)	CRT_VAR) \
-	((crt_bulk_t)		(cagi_bulk)		CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_CONT_ATTR_GET_V8 /* input fields */                                              \
-	((struct cont_op_v8_in)(cagi_op)CRT_VAR)((uint64_t)(cagi_count)CRT_VAR)(                   \
-	    (uint64_t)(cagi_key_length)CRT_VAR)((crt_bulk_t)(cagi_bulk)CRT_VAR)
+#define DAOS_ISEQ_CONT_ATTR_GET		/* input fields */		 \
+	((struct cont_op_in)		(cagi_op)		CRT_VAR) \
+	((uint64_t)			(cagi_count)		CRT_VAR) \
+	((uint64_t)			(cagi_key_length)	CRT_VAR) \
+	((crt_bulk_t)			(cagi_bulk)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_ATTR_GET	/* output fields */		 \
-	((struct cont_op_out)	(cago_op)		CRT_VAR)
+#define DAOS_ISEQ_CONT_ATTR_GET_V8	/* input fields */                                              \
+	((struct cont_op_v8_in)		(cagi_op)		CRT_VAR) \
+	((uint64_t)			(cagi_count)		CRT_VAR) \
+	((uint64_t)			(cagi_key_length)	CRT_VAR) \
+	((crt_bulk_t)			(cagi_bulk)		CRT_VAR)
+
+#define DAOS_OSEQ_CONT_ATTR_GET		/* output fields */		 \
+	((struct cont_op_out)		(cago_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_attr_get, DAOS_ISEQ_CONT_ATTR_GET, DAOS_OSEQ_CONT_ATTR_GET)
 CRT_RPC_DECLARE(cont_attr_get_v8, DAOS_ISEQ_CONT_ATTR_GET_V8, DAOS_OSEQ_CONT_ATTR_GET)
+
+/* clang-format on */
 
 static inline void
 cont_attr_get_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -540,20 +590,25 @@ cont_attr_get_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, 
 	}
 }
 
-#define DAOS_ISEQ_CONT_ATTR_SET	/* input fields */		 \
-	((struct cont_op_in)	(casi_op)		CRT_VAR) \
-	((uint64_t)		(casi_count)		CRT_VAR) \
-	((crt_bulk_t)		(casi_bulk)		CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_CONT_ATTR_SET_V8 /* input fields */                                              \
-	((struct cont_op_v8_in)(casi_op)CRT_VAR)((uint64_t)(casi_count)CRT_VAR)(                   \
-	    (crt_bulk_t)(casi_bulk)CRT_VAR)
+#define DAOS_ISEQ_CONT_ATTR_SET		/* input fields */		 \
+	((struct cont_op_in)		(casi_op)		CRT_VAR) \
+	((uint64_t)			(casi_count)		CRT_VAR) \
+	((crt_bulk_t)			(casi_bulk)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_ATTR_SET	/* output fields */		 \
-	((struct cont_op_out)	(caso_op)		CRT_VAR)
+#define DAOS_ISEQ_CONT_ATTR_SET_V8	/* input fields */		 \
+	((struct cont_op_v8_in)		(casi_op)		CRT_VAR) \
+	((uint64_t)			(casi_count)		CRT_VAR) \
+	((crt_bulk_t)			(casi_bulk)		CRT_VAR)
+
+#define DAOS_OSEQ_CONT_ATTR_SET		/* output fields */		 \
+	((struct cont_op_out)		(caso_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_attr_set, DAOS_ISEQ_CONT_ATTR_SET, DAOS_OSEQ_CONT_ATTR_SET)
 CRT_RPC_DECLARE(cont_attr_set_v8, DAOS_ISEQ_CONT_ATTR_SET_V8, DAOS_OSEQ_CONT_ATTR_SET)
+
+/* clang-format on */
 
 static inline void
 cont_attr_set_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -585,20 +640,25 @@ cont_attr_set_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, 
 	}
 }
 
-#define DAOS_ISEQ_CONT_ATTR_DEL	/* input fields */		 \
-	((struct cont_op_in)	(cadi_op)		CRT_VAR) \
-	((uint64_t)		(cadi_count)		CRT_VAR) \
-	((crt_bulk_t)		(cadi_bulk)		CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_CONT_ATTR_DEL_V8 /* input fields */                                              \
-	((struct cont_op_v8_in)(cadi_op)CRT_VAR)((uint64_t)(cadi_count)CRT_VAR)(                   \
-	    (crt_bulk_t)(cadi_bulk)CRT_VAR)
+#define DAOS_ISEQ_CONT_ATTR_DEL		/* input fields */		 \
+	((struct cont_op_in)		(cadi_op)		CRT_VAR) \
+	((uint64_t)			(cadi_count)		CRT_VAR) \
+	((crt_bulk_t)			(cadi_bulk)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_ATTR_DEL	/* output fields */		 \
-	((struct cont_op_out)	(cado_op)		CRT_VAR)
+#define DAOS_ISEQ_CONT_ATTR_DEL_V8	/* input fields */		 \
+	((struct cont_op_v8_in)		(cadi_op)		CRT_VAR) \
+	((uint64_t)			(cadi_count)		CRT_VAR) \
+	((crt_bulk_t)			(cadi_bulk)		CRT_VAR)
+
+#define DAOS_OSEQ_CONT_ATTR_DEL		/* output fields */		 \
+	((struct cont_op_out)		(cado_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_attr_del, DAOS_ISEQ_CONT_ATTR_DEL, DAOS_OSEQ_CONT_ATTR_DEL)
 CRT_RPC_DECLARE(cont_attr_del_v8, DAOS_ISEQ_CONT_ATTR_DEL_V8, DAOS_OSEQ_CONT_ATTR_DEL)
+
+/* clang-format on */
 
 static inline void
 cont_attr_del_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -630,21 +690,26 @@ cont_attr_del_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver, 
 	}
 }
 
-#define DAOS_ISEQ_CONT_EPOCH_OP	/* input fields */		 \
-	((struct cont_op_in)	(cei_op)		CRT_VAR) \
-	((daos_epoch_t)		(cei_epoch)		CRT_VAR) \
-	((uint64_t)		(cei_opts)		CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_CONT_EPOCH_OP_V8 /* input fields */                                              \
-	((struct cont_op_v8_in)(cei_op)CRT_VAR)((daos_epoch_t)(cei_epoch)CRT_VAR)(                 \
-	    (uint64_t)(cei_opts)CRT_VAR)
+#define DAOS_ISEQ_CONT_EPOCH_OP		/* input fields */		 \
+	((struct cont_op_in)		(cei_op)		CRT_VAR) \
+	((daos_epoch_t)			(cei_epoch)		CRT_VAR) \
+	((uint64_t)			(cei_opts)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_EPOCH_OP	/* output fields */		 \
-	((struct cont_op_out)	(ceo_op)		CRT_VAR) \
-	((daos_epoch_t)		(ceo_epoch)		CRT_VAR)
+#define DAOS_ISEQ_CONT_EPOCH_OP_V8	/* input fields */		 \
+	((struct cont_op_v8_in)		(cei_op)		CRT_VAR) \
+	((daos_epoch_t)			(cei_epoch)		CRT_VAR) \
+	((uint64_t)			(cei_opts)		CRT_VAR)
+
+#define DAOS_OSEQ_CONT_EPOCH_OP		/* output fields */		 \
+	((struct cont_op_out)		(ceo_op)		CRT_VAR) \
+	((daos_epoch_t)			(ceo_epoch)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_epoch_op, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DECLARE(cont_epoch_op_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
+
+/* clang-format on */
 
 static inline void
 cont_epoch_op_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -676,19 +741,24 @@ cont_epoch_op_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
 	}
 }
 
-#define DAOS_ISEQ_CONT_SNAP_LIST /* input fields */		 \
-	((struct cont_op_in)	(sli_op)		CRT_VAR) \
-	((crt_bulk_t)		(sli_bulk)		CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_CONT_SNAP_LIST_V8 /* input fields */                                             \
-	((struct cont_op_v8_in)(sli_op)CRT_VAR)((crt_bulk_t)(sli_bulk)CRT_VAR)
+#define DAOS_ISEQ_CONT_SNAP_LIST	/* input fields */		 \
+	((struct cont_op_in)		(sli_op)		CRT_VAR) \
+	((crt_bulk_t)			(sli_bulk)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_SNAP_LIST /* output fields */		 \
-	((struct cont_op_out)	(slo_op)		CRT_VAR) \
-	((uint32_t)		(slo_count)		CRT_VAR)
+#define DAOS_ISEQ_CONT_SNAP_LIST_V8	/* input fields */		 \
+	((struct cont_op_v8_in)		(sli_op)		CRT_VAR) \
+	((crt_bulk_t)			(sli_bulk)		CRT_VAR)
+
+#define DAOS_OSEQ_CONT_SNAP_LIST	/* output fields */		 \
+	((struct cont_op_out)		(slo_op)		CRT_VAR) \
+	((uint32_t)			(slo_count)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_snap_list, DAOS_ISEQ_CONT_SNAP_LIST, DAOS_OSEQ_CONT_SNAP_LIST)
 CRT_RPC_DECLARE(cont_snap_list_v8, DAOS_ISEQ_CONT_SNAP_LIST_V8, DAOS_OSEQ_CONT_SNAP_LIST)
+
+/* clang-format on */
 
 static inline void
 cont_snap_list_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -714,6 +784,8 @@ cont_snap_list_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
 		((struct cont_snap_list_in *)in)->sli_bulk = sli_bulk;
 }
 
+/* clang-format off */
+
 CRT_RPC_DECLARE(cont_snap_create, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DECLARE(cont_snap_create_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
 
@@ -726,21 +798,24 @@ CRT_RPC_DECLARE(cont_snap_oit_create_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_C
 CRT_RPC_DECLARE(cont_snap_oit_destroy, DAOS_ISEQ_CONT_EPOCH_OP, DAOS_OSEQ_CONT_EPOCH_OP)
 CRT_RPC_DECLARE(cont_snap_oit_destroy_v8, DAOS_ISEQ_CONT_EPOCH_OP_V8, DAOS_OSEQ_CONT_EPOCH_OP)
 
-#define DAOS_ISEQ_CONT_SNAP_OIT_OID_GET /* input fields */	 \
-	((struct cont_op_in)	(ogi_op)		CRT_VAR) \
-	((daos_epoch_t)		(ogi_epoch)		CRT_VAR)
+#define DAOS_ISEQ_CONT_SNAP_OIT_OID_GET		/* input fields */		 \
+	((struct cont_op_in)			(ogi_op)		CRT_VAR) \
+	((daos_epoch_t)				(ogi_epoch)		CRT_VAR)
 
-#define DAOS_ISEQ_CONT_SNAP_OIT_OID_GET_V8 /* input fields */                                      \
-	((struct cont_op_v8_in)(ogi_op)CRT_VAR)((daos_epoch_t)(ogi_epoch)CRT_VAR)
+#define DAOS_ISEQ_CONT_SNAP_OIT_OID_GET_V8	/* input fields */		 \
+	((struct cont_op_v8_in)			(ogi_op)		CRT_VAR) \
+	((daos_epoch_t)				(ogi_epoch)		CRT_VAR)
 
-#define DAOS_OSEQ_CONT_SNAP_OIT_OID_GET /* output fields */	 \
-	((struct cont_op_out)	(ogo_op)		CRT_VAR) \
-	((daos_obj_id_t)	(ogo_oid)		CRT_VAR)
+#define DAOS_OSEQ_CONT_SNAP_OIT_OID_GET 	/* output fields */		 \
+	((struct cont_op_out)			(ogo_op)		CRT_VAR) \
+	((daos_obj_id_t)			(ogo_oid)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_snap_oit_oid_get, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET,
 		DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
 CRT_RPC_DECLARE(cont_snap_oit_oid_get_v8, DAOS_ISEQ_CONT_SNAP_OIT_OID_GET_V8,
 		DAOS_OSEQ_CONT_SNAP_OIT_OID_GET)
+
+/* clang-format on */
 
 static inline void
 cont_snap_oit_oid_get_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -766,6 +841,8 @@ cont_snap_oit_oid_get_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_pro
 		((struct cont_snap_oit_oid_get_in *)in)->ogi_epoch = ogi_epoch;
 }
 
+/* clang-format off */
+
 #define DAOS_ISEQ_TGT_DESTROY	/* input fields */		 \
 	((uuid_t)		(tdi_pool_uuid)		CRT_VAR) \
 	((uuid_t)		(tdi_uuid)		CRT_VAR)
@@ -776,6 +853,8 @@ cont_snap_oit_oid_get_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_pro
 
 CRT_RPC_DECLARE(cont_tgt_destroy, DAOS_ISEQ_TGT_DESTROY, DAOS_OSEQ_TGT_DESTROY)
 
+/* clang-format on */
+
 struct cont_tgt_close_rec {
 	uuid_t		tcr_hdl;
 	daos_epoch_t	tcr_hce;
@@ -784,6 +863,8 @@ struct cont_tgt_close_rec {
 /* TODO: more tgt query information ; and decide if tqo_hae is needed at all
  * (e.g., CONT_QUERY cqo_hae has been removed).
  */
+
+/* clang-format off */
 #define DAOS_ISEQ_TGT_QUERY	/* input fields */		 \
 	((uuid_t)		(tqi_pool_uuid)		CRT_VAR) \
 	((uuid_t)		(tqi_cont_uuid)		CRT_VAR)
@@ -822,20 +903,23 @@ CRT_RPC_DECLARE(cont_tgt_epoch_aggregate, DAOS_ISEQ_CONT_TGT_EPOCH_AGGREGATE,
 CRT_RPC_DECLARE(cont_tgt_snapshot_notify, DAOS_ISEQ_CONT_TGT_SNAPSHOT_NOTIFY,
 		DAOS_OSEQ_CONT_TGT_SNAPSHOT_NOTIFY)
 
-#define DAOS_ISEQ_CONT_PROP_SET	/* input fields */		 \
-	((struct cont_op_in)	(cpsi_op)		CRT_VAR) \
-	((daos_prop_t)		(cpsi_prop)		CRT_PTR) \
-	((uuid_t)		(cpsi_pool_uuid)	CRT_VAR)
+#define DAOS_ISEQ_CONT_PROP_SET		/* input fields */		 \
+	((struct cont_op_in)		(cpsi_op)		CRT_VAR) \
+	((daos_prop_t)			(cpsi_prop)		CRT_PTR) \
+	((uuid_t)			(cpsi_pool_uuid)	CRT_VAR)
 
-#define DAOS_ISEQ_CONT_PROP_SET_V8 /* input fields */                                              \
-	((struct cont_op_v8_in)(cpsi_op)CRT_VAR)((daos_prop_t)(cpsi_prop)CRT_PTR)(                 \
-	    (uuid_t)(cpsi_pool_uuid)CRT_VAR)
+#define DAOS_ISEQ_CONT_PROP_SET_V8	/* input fields */		 \
+	((struct cont_op_v8_in)		(cpsi_op)		CRT_VAR) \
+	((daos_prop_t)			(cpsi_prop)		CRT_PTR) \
+	((uuid_t)			(cpsi_pool_uuid)	CRT_VAR)
 
-#define DAOS_OSEQ_CONT_PROP_SET	/* output fields */		 \
-	((struct cont_op_out)	(cpso_op)		CRT_VAR)
+#define DAOS_OSEQ_CONT_PROP_SET		/* output fields */		 \
+	((struct cont_op_out)		(cpso_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_prop_set, DAOS_ISEQ_CONT_PROP_SET, DAOS_OSEQ_CONT_PROP_SET)
 CRT_RPC_DECLARE(cont_prop_set_v8, DAOS_ISEQ_CONT_PROP_SET_V8, DAOS_OSEQ_CONT_PROP_SET)
+
+/* clang-format on */
 
 static inline void
 cont_prop_set_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -872,18 +956,23 @@ cont_prop_set_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
 	}
 }
 
-#define DAOS_ISEQ_CONT_ACL_UPDATE	/* input fields */	 \
-	((struct cont_op_in)	(caui_op)		CRT_VAR) \
-	((struct daos_acl)	(caui_acl)		CRT_PTR)
+/* clang-format off */
 
-#define DAOS_ISEQ_CONT_ACL_UPDATE_V8 /* input fields */                                            \
-	((struct cont_op_v8_in)(caui_op)CRT_VAR)((struct daos_acl)(caui_acl)CRT_PTR)
+#define DAOS_ISEQ_CONT_ACL_UPDATE	/* input fields */		 \
+	((struct cont_op_in)		(caui_op)		CRT_VAR) \
+	((struct daos_acl)		(caui_acl)		CRT_PTR)
 
-#define DAOS_OSEQ_CONT_ACL_UPDATE	/* output fields */	 \
-	((struct cont_op_out)	(cauo_op)		CRT_VAR)
+#define DAOS_ISEQ_CONT_ACL_UPDATE_V8 	/* input fields */		 \
+	((struct cont_op_v8_in)		(caui_op)		CRT_VAR) \
+	((struct daos_acl)		(caui_acl)		CRT_PTR)
+
+#define DAOS_OSEQ_CONT_ACL_UPDATE	/* output fields */		 \
+	((struct cont_op_out)		(cauo_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_acl_update, DAOS_ISEQ_CONT_ACL_UPDATE, DAOS_OSEQ_CONT_ACL_UPDATE)
 CRT_RPC_DECLARE(cont_acl_update_v8, DAOS_ISEQ_CONT_ACL_UPDATE_V8, DAOS_OSEQ_CONT_ACL_UPDATE)
+
+/* clang-format on */
 
 static inline void
 cont_acl_update_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,
@@ -909,20 +998,25 @@ cont_acl_update_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver
 		((struct cont_acl_update_in *)in)->caui_acl = caui_acl;
 }
 
-#define DAOS_ISEQ_CONT_ACL_DELETE	/* input fields */	 \
-	((struct cont_op_in)	(cadi_op)		CRT_VAR) \
-	((d_string_t)		(cadi_principal_name)	CRT_VAR) \
-	((uint8_t)		(cadi_principal_type)	CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_CONT_ACL_DELETE_V8 /* input fields */                                            \
-	((struct cont_op_v8_in)(cadi_op)CRT_VAR)((d_string_t)(cadi_principal_name)CRT_VAR)(        \
-	    (uint8_t)(cadi_principal_type)CRT_VAR)
+#define DAOS_ISEQ_CONT_ACL_DELETE	/* input fields */		 \
+	((struct cont_op_in)		(cadi_op)		CRT_VAR) \
+	((d_string_t)			(cadi_principal_name)	CRT_VAR) \
+	((uint8_t)			(cadi_principal_type)	CRT_VAR)
 
-#define DAOS_OSEQ_CONT_ACL_DELETE	/* output fields */	 \
-	((struct cont_op_out)	(cado_op)		CRT_VAR)
+#define DAOS_ISEQ_CONT_ACL_DELETE_V8	/* input fields */		 \
+	((struct cont_op_v8_in)		(cadi_op)		CRT_VAR) \
+	((d_string_t)			(cadi_principal_name)	CRT_VAR) \
+	((uint8_t)			(cadi_principal_type)	CRT_VAR)
+
+#define DAOS_OSEQ_CONT_ACL_DELETE	/* output fields */		 \
+	((struct cont_op_out)		(cado_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_acl_delete, DAOS_ISEQ_CONT_ACL_DELETE, DAOS_OSEQ_CONT_ACL_DELETE)
 CRT_RPC_DECLARE(cont_acl_delete_v8, DAOS_ISEQ_CONT_ACL_DELETE_V8, DAOS_OSEQ_CONT_ACL_DELETE)
+
+/* clang-format on */
 
 static inline void
 cont_acl_delete_in_get_data(crt_rpc_t *rpc, crt_opcode_t opc, int cont_proto_ver,

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -113,6 +113,8 @@ extern struct crt_proto_format pool_proto_fmt_v5;
 extern struct crt_proto_format pool_proto_fmt_v6;
 extern int dc_pool_proto_version;
 
+/* clang-format off */
+
 #define DAOS_ISEQ_POOL_OP	/* input fields */		 \
 	((uuid_t)		(pi_uuid)		CRT_VAR) \
 	((uuid_t)		(pi_hdl)		CRT_VAR)
@@ -130,15 +132,20 @@ CRT_RPC_DECLARE(pool_op_v6, DAOS_ISEQ_POOL_OP_V6, DAOS_OSEQ_POOL_OP)
 CRT_RPC_DECLARE(pool_op, DAOS_ISEQ_POOL_OP, DAOS_OSEQ_POOL_OP)
 
 /* If pri_op.pi_hdl is not null, call rdb_campaign. */
-#define DAOS_ISEQ_POOL_CREATE /* input fields */                                                   \
-	((struct pool_op_v6_in)(pri_op)CRT_VAR)((d_rank_list_t)(pri_tgt_ranks)CRT_PTR)(            \
-	    (daos_prop_t)(pri_prop)CRT_PTR)((uint32_t)(pri_ndomains)CRT_VAR)(                      \
-	    (uint32_t)(pri_ntgts)CRT_VAR)((uint32_t)(pri_domains)CRT_ARRAY)
+#define DAOS_ISEQ_POOL_CREATE	/* input fields */			\
+	((struct pool_op_v6_in)	(pri_op)		CRT_VAR)	\
+	((d_rank_list_t)	(pri_tgt_ranks)		CRT_PTR)	\
+	((daos_prop_t)		(pri_prop)		CRT_PTR)	\
+	((uint32_t)		(pri_ndomains)		CRT_VAR)	\
+	((uint32_t)		(pri_ntgts)		CRT_VAR)	\
+	((uint32_t)		(pri_domains)		CRT_ARRAY)
 
 #define DAOS_OSEQ_POOL_CREATE	/* output fields */		 \
 	((struct pool_op_out)	(pro_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_create, DAOS_ISEQ_POOL_CREATE, DAOS_OSEQ_POOL_CREATE)
+
+/* clang-format on */
 
 static inline void
 pool_create_in_get_data(crt_rpc_t *rpc, d_rank_list_t **pri_tgt_ranksp, daos_prop_t **pri_propp,
@@ -172,23 +179,35 @@ pool_create_in_set_data(crt_rpc_t *rpc, d_rank_list_t *pri_tgt_ranks, daos_prop_
 	in->pri_domains.ca_count  = pri_ndomains;
 }
 
-#define DAOS_OSEQ_POOL_CONNECT /* output fields */                                                 \
-	((struct pool_op_out)(pco_op)CRT_VAR)((struct daos_pool_space)(pco_space)CRT_RAW)(         \
-	    (struct daos_rebuild_status)(pco_rebuild_st)CRT_RAW) /* only set on -DER_TRUNC */      \
-	    ((uint32_t)(pco_map_buf_size)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_POOL_CONNECT /* input fields */                                                  \
-	((struct pool_op_in)(pci_op)CRT_VAR)((d_iov_t)(pci_cred)CRT_VAR)(                          \
-	    (uint64_t)(pci_flags)CRT_VAR)((uint64_t)(pci_query_bits)CRT_VAR)(                      \
-	    (crt_bulk_t)(pci_map_bulk)CRT_VAR)((uint32_t)(pci_pool_version)CRT_VAR)
+#define DAOS_OSEQ_POOL_CONNECT		/* output fields */		 \
+	((struct pool_op_out)		(pco_op)		CRT_VAR) \
+	((struct daos_pool_space)	(pco_space)		CRT_RAW) \
+	((struct daos_rebuild_status)	(pco_rebuild_st)	CRT_RAW) \
+	/* only set on -DER_TRUNC */					 \
+	((uint32_t)			(pco_map_buf_size)	CRT_VAR)
 
-#define DAOS_ISEQ_POOL_CONNECT_V6 /* input fields */                                               \
-	((struct pool_op_v6_in)(pci_op)CRT_VAR)((d_iov_t)(pci_cred)CRT_VAR)(                       \
-	    (uint64_t)(pci_flags)CRT_VAR)((uint64_t)(pci_query_bits)CRT_VAR)(                      \
-	    (crt_bulk_t)(pci_map_bulk)CRT_VAR)((uint32_t)(pci_pool_version)CRT_VAR)
+#define DAOS_ISEQ_POOL_CONNECT 		/* input fields */		 \
+	((struct pool_op_in)		(pci_op)		CRT_VAR) \
+	((d_iov_t)			(pci_cred)		CRT_VAR) \
+	((uint64_t)			(pci_flags)		CRT_VAR) \
+	((uint64_t)			(pci_query_bits)	CRT_VAR) \
+	((crt_bulk_t)			(pci_map_bulk)		CRT_VAR) \
+	((uint32_t)			(pci_pool_version)	CRT_VAR)
+
+#define DAOS_ISEQ_POOL_CONNECT_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pci_op)		CRT_VAR) \
+	((d_iov_t)			(pci_cred)		CRT_VAR) \
+	((uint64_t)			(pci_flags)		CRT_VAR) \
+	((uint64_t)			(pci_query_bits)	CRT_VAR) \
+	((crt_bulk_t)			(pci_map_bulk)		CRT_VAR) \
+	((uint32_t)			(pci_pool_version)	CRT_VAR)
 
 CRT_RPC_DECLARE(pool_connect, DAOS_ISEQ_POOL_CONNECT, DAOS_OSEQ_POOL_CONNECT)
 CRT_RPC_DECLARE(pool_connect_v6, DAOS_ISEQ_POOL_CONNECT_V6, DAOS_OSEQ_POOL_CONNECT)
+
+/* clang-format on */
 
 static inline bool
 rpc_ver_atleast(crt_rpc_t *rpc, int min_ver)
@@ -253,32 +272,44 @@ pool_connect_in_set_data(crt_rpc_t *rpc, uint64_t pci_flags, uint64_t pci_query_
 	}
 }
 
-#define DAOS_ISEQ_POOL_DISCONNECT    /* input fields */ ((struct pool_op_in)(pdi_op)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_POOL_DISCONNECT_V6 /* input fields */ ((struct pool_op_v6_in)(pdi_op)CRT_VAR)
+#define DAOS_ISEQ_POOL_DISCONNECT	/* input fields */		 \
+	((struct pool_op_in)		(pdi_op)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_DISCONNECT    /* output fields */ ((struct pool_op_out)(pdo_op)CRT_VAR)
+#define DAOS_ISEQ_POOL_DISCONNECT_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pdi_op)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_DISCONNECT	/* output fields */		 \
+	((struct pool_op_out)		(pdo_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_disconnect, DAOS_ISEQ_POOL_DISCONNECT, DAOS_OSEQ_POOL_DISCONNECT)
 CRT_RPC_DECLARE(pool_disconnect_v6, DAOS_ISEQ_POOL_DISCONNECT_V6, DAOS_OSEQ_POOL_DISCONNECT)
 
-#define DAOS_ISEQ_POOL_QUERY /* input fields */                                                    \
-	((struct pool_op_in)(pqi_op)CRT_VAR)((crt_bulk_t)(pqi_map_bulk)CRT_VAR)(                   \
-	    (uint64_t)(pqi_query_bits)CRT_VAR)
+#define DAOS_ISEQ_POOL_QUERY		/* input fields */			 \
+	((struct pool_op_in)		(pqi_op)			CRT_VAR) \
+	((crt_bulk_t)			(pqi_map_bulk)			CRT_VAR) \
+	((uint64_t)			(pqi_query_bits)		CRT_VAR)
 
-#define DAOS_ISEQ_POOL_QUERY_V6 /* input fields */                                                 \
-	((struct pool_op_v6_in)(pqi_op)CRT_VAR)((crt_bulk_t)(pqi_map_bulk)CRT_VAR)(                \
-	    (uint64_t)(pqi_query_bits)CRT_VAR)
+#define DAOS_ISEQ_POOL_QUERY_V6		/* input fields */			 \
+	((struct pool_op_v6_in)		(pqi_op)			CRT_VAR) \
+	((crt_bulk_t)			(pqi_map_bulk)			CRT_VAR) \
+	((uint64_t)			(pqi_query_bits)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_QUERY /* output fields */                                                   \
-	((struct pool_op_out)(pqo_op)CRT_VAR)((daos_prop_t)(pqo_prop)CRT_PTR)(                     \
-	    (struct daos_pool_space)(pqo_space)CRT_RAW)(                                           \
-	    (struct daos_rebuild_status)(pqo_rebuild_st)CRT_RAW) /* only set on -DER_TRUNC */      \
-	    ((uint32_t)(pqo_map_buf_size)CRT_VAR)((uint32_t)(pqo_pool_layout_ver)CRT_VAR)(         \
-		(uint32_t)(pqo_upgrade_layout_ver)CRT_VAR)
+#define DAOS_OSEQ_POOL_QUERY		/* output fields */			 \
+	((struct pool_op_out)		(pqo_op)			CRT_VAR) \
+	((daos_prop_t)			(pqo_prop)			CRT_PTR) \
+	((struct daos_pool_space)	(pqo_space)			CRT_RAW) \
+	((struct daos_rebuild_status)	(pqo_rebuild_st)		CRT_RAW) \
+	/* only set on -DER_TRUNC */						 \
+	((uint32_t)			(pqo_map_buf_size)		CRT_VAR) \
+	((uint32_t)			(pqo_pool_layout_ver)		CRT_VAR) \
+	((uint32_t)			(pqo_upgrade_layout_ver)	CRT_VAR)
 
 CRT_RPC_DECLARE(pool_query, DAOS_ISEQ_POOL_QUERY, DAOS_OSEQ_POOL_QUERY)
 CRT_RPC_DECLARE(pool_query_v6, DAOS_ISEQ_POOL_QUERY_V6, DAOS_OSEQ_POOL_QUERY)
+
+/* clang-format on */
 
 static inline void
 pool_query_in_get_data(crt_rpc_t *rpc, crt_bulk_t *pqi_map_bulkp, uint64_t *pqi_query_bitsp)
@@ -308,21 +339,29 @@ pool_query_in_set_data(crt_rpc_t *rpc, crt_bulk_t pqi_map_bulk, uint64_t pqi_que
 	}
 }
 
-#define DAOS_ISEQ_POOL_QUERY_INFO /* input fields */                                               \
-	((struct pool_op_in)(pqii_op)CRT_VAR)((d_rank_t)(pqii_rank)CRT_VAR)(                       \
-	    (uint32_t)(pqii_tgt)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_POOL_QUERY_INFO_V6 /* input fields */                                            \
-	((struct pool_op_v6_in)(pqii_op)CRT_VAR)((d_rank_t)(pqii_rank)CRT_VAR)(                    \
-	    (uint32_t)(pqii_tgt)CRT_VAR)
+#define DAOS_ISEQ_POOL_QUERY_INFO	/* input fields */		 \
+	((struct pool_op_in)		(pqii_op)		CRT_VAR) \
+	((d_rank_t)			(pqii_rank)		CRT_VAR) \
+	((uint32_t)			(pqii_tgt)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_QUERY_INFO /* output fields */                                              \
-	((struct pool_op_out)(pqio_op)CRT_VAR)((d_rank_t)(pqio_rank)CRT_VAR)(                      \
-	    (uint32_t)(pqio_tgt)CRT_VAR)((struct daos_space)(pqio_space)CRT_RAW)(                  \
-	    (daos_target_state_t)(pqio_state)CRT_VAR)
+#define DAOS_ISEQ_POOL_QUERY_INFO_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pqii_op)		CRT_VAR) \
+	((d_rank_t)			(pqii_rank)		CRT_VAR) \
+	((uint32_t)			(pqii_tgt)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_QUERY_INFO	/* output fields */		 \
+	((struct pool_op_out)		(pqio_op)		CRT_VAR) \
+	((d_rank_t)			(pqio_rank)		CRT_VAR) \
+	((uint32_t)			(pqio_tgt)		CRT_VAR) \
+	((struct daos_space)		(pqio_space)		CRT_RAW) \
+	((daos_target_state_t)		(pqio_state)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_query_info, DAOS_ISEQ_POOL_QUERY_INFO, DAOS_OSEQ_POOL_QUERY_INFO)
 CRT_RPC_DECLARE(pool_query_info_v6, DAOS_ISEQ_POOL_QUERY_INFO_V6, DAOS_OSEQ_POOL_QUERY_INFO)
+
+/* clang-format on */
 
 static inline void
 pool_query_info_in_get_data(crt_rpc_t *rpc, d_rank_t *pqii_rankp, uint32_t *pqii_tgtp)
@@ -352,17 +391,24 @@ pool_query_info_in_set_data(crt_rpc_t *rpc, d_rank_t pqii_rank, uint32_t pqii_tg
 	}
 }
 
-#define DAOS_ISEQ_POOL_ATTR_LIST /* input fields */                                                \
-	((struct pool_op_in)(pali_op)CRT_VAR)((crt_bulk_t)(pali_bulk)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_POOL_ATTR_LIST_V6 /* input fields */                                             \
-	((struct pool_op_v6_in)(pali_op)CRT_VAR)((crt_bulk_t)(pali_bulk)CRT_VAR)
+#define DAOS_ISEQ_POOL_ATTR_LIST	/* input fields */		 \
+	((struct pool_op_in)		(pali_op)		CRT_VAR) \
+	((crt_bulk_t)			(pali_bulk)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_ATTR_LIST /* output fields */                                               \
-	((struct pool_op_out)(palo_op)CRT_VAR)((uint64_t)(palo_size)CRT_VAR)
+#define DAOS_ISEQ_POOL_ATTR_LIST_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pali_op)		CRT_VAR) \
+	((crt_bulk_t)			(pali_bulk)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_ATTR_LIST	/* output fields */		 \
+	((struct pool_op_out)		(palo_op)		CRT_VAR) \
+	((uint64_t)			(palo_size)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_attr_list, DAOS_ISEQ_POOL_ATTR_LIST, DAOS_OSEQ_POOL_ATTR_LIST)
 CRT_RPC_DECLARE(pool_attr_list_v6, DAOS_ISEQ_POOL_ATTR_LIST_V6, DAOS_OSEQ_POOL_ATTR_LIST)
+
+/* clang-format on */
 
 static inline void
 pool_attr_list_in_get_data(crt_rpc_t *rpc, crt_bulk_t *pali_bulkp)
@@ -388,16 +434,24 @@ pool_attr_list_in_set_data(crt_rpc_t *rpc, crt_bulk_t pali_bulk)
 	}
 }
 
-#define DAOS_ISEQ_POOL_ATTR_GET /* input fields */                                                 \
-	((struct pool_op_in)(pagi_op)CRT_VAR)((uint64_t)(pagi_count)CRT_VAR)(                      \
-	    (uint64_t)(pagi_key_length)CRT_VAR)((crt_bulk_t)(pagi_bulk)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_POOL_ATTR_GET_V6 /* input fields */                                              \
-	((struct pool_op_v6_in)(pagi_op)CRT_VAR)((uint64_t)(pagi_count)CRT_VAR)(                   \
-	    (uint64_t)(pagi_key_length)CRT_VAR)((crt_bulk_t)(pagi_bulk)CRT_VAR)
+#define DAOS_ISEQ_POOL_ATTR_GET		/* input fields */		 \
+	((struct pool_op_in)		(pagi_op)		CRT_VAR) \
+	((uint64_t)			(pagi_count)		CRT_VAR) \
+	((uint64_t)			(pagi_key_length)	CRT_VAR) \
+	((crt_bulk_t)			(pagi_bulk)		CRT_VAR)
+
+#define DAOS_ISEQ_POOL_ATTR_GET_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pagi_op)		CRT_VAR) \
+	((uint64_t)			(pagi_count)		CRT_VAR) \
+	((uint64_t)			(pagi_key_length)	CRT_VAR) \
+	((crt_bulk_t)			(pagi_bulk)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_attr_get, DAOS_ISEQ_POOL_ATTR_GET, DAOS_OSEQ_POOL_OP)
 CRT_RPC_DECLARE(pool_attr_get_v6, DAOS_ISEQ_POOL_ATTR_GET_V6, DAOS_OSEQ_POOL_OP)
+
+/* clang-format on */
 
 static inline void
 pool_attr_get_in_get_data(crt_rpc_t *rpc, uint64_t *pagi_countp, uint64_t *pagi_key_lengthp,
@@ -434,16 +488,22 @@ pool_attr_get_in_set_data(crt_rpc_t *rpc, uint64_t pagi_count, uint64_t pagi_key
 	}
 }
 
-#define DAOS_ISEQ_POOL_ATTR_SET /* input fields */                                                 \
-	((struct pool_op_in)(pasi_op)CRT_VAR)((uint64_t)(pasi_count)CRT_VAR)(                      \
-	    (crt_bulk_t)(pasi_bulk)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_POOL_ATTR_SET_V6 /* input fields */                                              \
-	((struct pool_op_v6_in)(pasi_op)CRT_VAR)((uint64_t)(pasi_count)CRT_VAR)(                   \
-	    (crt_bulk_t)(pasi_bulk)CRT_VAR)
+#define DAOS_ISEQ_POOL_ATTR_SET		/* input fields */		 \
+	((struct pool_op_in)		(pasi_op)		CRT_VAR) \
+	((uint64_t)			(pasi_count)		CRT_VAR) \
+	((crt_bulk_t)			(pasi_bulk)		CRT_VAR)
+
+#define DAOS_ISEQ_POOL_ATTR_SET_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pasi_op)		CRT_VAR) \
+	((uint64_t)			(pasi_count)		CRT_VAR) \
+	((crt_bulk_t)			(pasi_bulk)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_attr_set, DAOS_ISEQ_POOL_ATTR_SET, DAOS_OSEQ_POOL_OP)
 CRT_RPC_DECLARE(pool_attr_set_v6, DAOS_ISEQ_POOL_ATTR_SET_V6, DAOS_OSEQ_POOL_OP)
+
+/* clang-format on */
 
 static inline void
 pool_attr_set_in_get_data(crt_rpc_t *rpc, uint64_t *pasi_countp, crt_bulk_t *pasi_bulkp)
@@ -473,16 +533,22 @@ pool_attr_set_in_set_data(crt_rpc_t *rpc, uint64_t pasi_count, crt_bulk_t pasi_b
 	}
 }
 
-#define DAOS_ISEQ_POOL_ATTR_DEL /* input fields */                                                 \
-	((struct pool_op_in)(padi_op)CRT_VAR)((uint64_t)(padi_count)CRT_VAR)(                      \
-	    (crt_bulk_t)(padi_bulk)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_POOL_ATTR_DEL_V6 /* input fields */                                              \
-	((struct pool_op_v6_in)(padi_op)CRT_VAR)((uint64_t)(padi_count)CRT_VAR)(                   \
-	    (crt_bulk_t)(padi_bulk)CRT_VAR)
+#define DAOS_ISEQ_POOL_ATTR_DEL		/* input fields */		 \
+	((struct pool_op_in)		(padi_op)		CRT_VAR) \
+	((uint64_t)			(padi_count)		CRT_VAR) \
+	((crt_bulk_t)			(padi_bulk)		CRT_VAR)
+
+#define DAOS_ISEQ_POOL_ATTR_DEL_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(padi_op)		CRT_VAR) \
+	((uint64_t)			(padi_count)		CRT_VAR) \
+	((crt_bulk_t)			(padi_bulk)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_attr_del, DAOS_ISEQ_POOL_ATTR_DEL, DAOS_OSEQ_POOL_OP)
 CRT_RPC_DECLARE(pool_attr_del_v6, DAOS_ISEQ_POOL_ATTR_DEL_V6, DAOS_OSEQ_POOL_OP)
+
+/* clang-format on */
 
 static inline void
 pool_attr_del_in_get_data(crt_rpc_t *rpc, uint64_t *padi_countp, crt_bulk_t *padi_bulkp)
@@ -512,32 +578,42 @@ pool_attr_del_in_set_data(crt_rpc_t *rpc, uint64_t padi_count, crt_bulk_t padi_b
 	}
 }
 
-#define DAOS_ISEQ_POOL_MEMBERSHIP /* input fields */                                               \
-	((uuid_t)(pmi_uuid)CRT_VAR)((d_rank_list_t)(pmi_targets)CRT_PTR)
+/* clang-format off */
 
-#define DAOS_OSEQ_POOL_MEMBERSHIP /* output fields */                                              \
-	((struct rsvc_hint)(pmo_hint)CRT_VAR)((d_rank_list_t)(pmo_failed)CRT_PTR)(                 \
-	    (int32_t)(pmo_rc)CRT_VAR)
+#define DAOS_ISEQ_POOL_MEMBERSHIP	/* input fields */		 \
+	((uuid_t)			(pmi_uuid)		CRT_VAR) \
+	((d_rank_list_t)		(pmi_targets)		CRT_PTR)
+
+#define DAOS_OSEQ_POOL_MEMBERSHIP	/* output fields */		 \
+	((struct rsvc_hint)		(pmo_hint)		CRT_VAR) \
+	((d_rank_list_t)		(pmo_failed)		CRT_PTR) \
+	((int32_t)			(pmo_rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_membership, DAOS_ISEQ_POOL_MEMBERSHIP, DAOS_OSEQ_POOL_MEMBERSHIP)
 CRT_RPC_DECLARE(pool_replicas_add, DAOS_ISEQ_POOL_MEMBERSHIP, DAOS_OSEQ_POOL_MEMBERSHIP)
 CRT_RPC_DECLARE(pool_replicas_remove, DAOS_ISEQ_POOL_MEMBERSHIP, DAOS_OSEQ_POOL_MEMBERSHIP)
 
-#define DAOS_ISEQ_POOL_TGT_UPDATE /* input fields */                                               \
-	((struct pool_op_in)(pti_op)CRT_VAR)((struct pool_target_addr)(pti_addr_list)CRT_ARRAY)
+#define DAOS_ISEQ_POOL_TGT_UPDATE	/* input fields */			\
+	((struct pool_op_in)		(pti_op)		CRT_VAR)	\
+	((struct pool_target_addr)	(pti_addr_list)		CRT_ARRAY)
 
-#define DAOS_ISEQ_POOL_TGT_UPDATE_V6 /* input fields */                                            \
-	((struct pool_op_v6_in)(pti_op)CRT_VAR)((struct pool_target_addr)(pti_addr_list)CRT_ARRAY)
+#define DAOS_ISEQ_POOL_TGT_UPDATE_V6	/* input fields */			\
+	((struct pool_op_v6_in)		(pti_op)		CRT_VAR)	\
+	((struct pool_target_addr)	(pti_addr_list)		CRT_ARRAY)
 
-#define DAOS_OSEQ_POOL_TGT_UPDATE /* output fields */                                              \
-	((struct pool_op_out)(pto_op)CRT_VAR)((struct pool_target_addr)(pto_addr_list)CRT_ARRAY)
+#define DAOS_OSEQ_POOL_TGT_UPDATE	/* output fields */			\
+	((struct pool_op_out)		(pto_op)		CRT_VAR)	\
+	((struct pool_target_addr)	(pto_addr_list)		CRT_ARRAY)
 
-#define DAOS_ISEQ_POOL_EXTEND_V6 /* input fields */                                                \
-	((struct pool_op_v6_in)(pei_op)CRT_VAR)((d_rank_list_t)(pei_tgt_ranks)CRT_PTR)(            \
-	    (uint32_t)(pei_ntgts)CRT_VAR)((uint32_t)(pei_ndomains)CRT_VAR)(                        \
-	    (uint32_t)(pei_domains)CRT_ARRAY)
+#define DAOS_ISEQ_POOL_EXTEND_V6	/* input fields */			\
+	((struct pool_op_v6_in)		(pei_op)		CRT_VAR)	\
+	((d_rank_list_t)		(pei_tgt_ranks)		CRT_PTR)	\
+	((uint32_t)			(pei_ntgts)		CRT_VAR)	\
+	((uint32_t)			(pei_ndomains)		CRT_VAR)	\
+	((uint32_t)			(pei_domains)		CRT_ARRAY)
 
-#define DAOS_OSEQ_POOL_EXTEND /* output fields */ ((struct pool_op_out)(peo_op)CRT_VAR)
+#define DAOS_OSEQ_POOL_EXTEND		/* output fields */			\
+	((struct pool_op_out)		(peo_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_tgt_update, DAOS_ISEQ_POOL_TGT_UPDATE, DAOS_OSEQ_POOL_TGT_UPDATE)
 CRT_RPC_DECLARE(pool_tgt_update_v6, DAOS_ISEQ_POOL_TGT_UPDATE_V6, DAOS_OSEQ_POOL_TGT_UPDATE)
@@ -553,6 +629,8 @@ CRT_RPC_DECLARE(pool_drain, DAOS_ISEQ_POOL_TGT_UPDATE, DAOS_OSEQ_POOL_TGT_UPDATE
 CRT_RPC_DECLARE(pool_drain_v6, DAOS_ISEQ_POOL_TGT_UPDATE_V6, DAOS_OSEQ_POOL_TGT_UPDATE)
 CRT_RPC_DECLARE(pool_exclude_out, DAOS_ISEQ_POOL_TGT_UPDATE, DAOS_OSEQ_POOL_TGT_UPDATE)
 CRT_RPC_DECLARE(pool_exclude_out_v6, DAOS_ISEQ_POOL_TGT_UPDATE_V6, DAOS_OSEQ_POOL_TGT_UPDATE)
+
+/* clang-format on */
 
 static inline void
 pool_tgt_update_in_get_data(crt_rpc_t *rpc, struct pool_target_addr **pti_addr_listp, int *countp)
@@ -582,53 +660,71 @@ pool_tgt_update_in_set_data(crt_rpc_t *rpc, struct pool_target_addr *pti_addr_li
 	}
 }
 
-#define DAOS_ISEQ_POOL_EVICT_V6 /* input fields */                                                 \
-	((struct pool_op_v6_in)(pvi_op)CRT_VAR)((uint32_t)(pvi_pool_destroy)CRT_VAR)(              \
-	    (uint32_t)(pvi_pool_destroy_force)CRT_VAR)((uuid_t)(pvi_hdls)CRT_ARRAY)(               \
-	    (d_string_t)(pvi_machine)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_OSEQ_POOL_EVICT /* output fields */                                                   \
-	((struct pool_op_out)(pvo_op)CRT_VAR)((uint32_t)(pvo_n_hdls_evicted)CRT_VAR)
+#define DAOS_ISEQ_POOL_EVICT_V6	/* input fields */				\
+	((struct pool_op_v6_in)	(pvi_op)			CRT_VAR)	\
+	((uint32_t)		(pvi_pool_destroy)		CRT_VAR)	\
+	((uint32_t)		(pvi_pool_destroy_force)	CRT_VAR)	\
+	((uuid_t)		(pvi_hdls)			CRT_ARRAY)	\
+	((d_string_t)		(pvi_machine)CRT_VAR)
+
+#define DAOS_OSEQ_POOL_EVICT	/* output fields */				\
+	((struct pool_op_out)	(pvo_op)			CRT_VAR)	\
+	((uint32_t)		(pvo_n_hdls_evicted)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_evict, DAOS_ISEQ_POOL_EVICT_V6, DAOS_OSEQ_POOL_EVICT)
 
-#define DAOS_ISEQ_POOL_SVC_STOP    /* input fields */ ((struct pool_op_in)(psi_op)CRT_VAR)
+#define DAOS_ISEQ_POOL_SVC_STOP		/* input fields */		 \
+	((struct pool_op_in)		(psi_op)		CRT_VAR)
 
-#define DAOS_ISEQ_POOL_SVC_STOP_V6 /* input fields */ ((struct pool_op_v6_in)(psi_op)CRT_VAR)
+#define DAOS_ISEQ_POOL_SVC_STOP_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(psi_op)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_SVC_STOP    /* output fields */ ((struct pool_op_out)(pso_op)CRT_VAR)
+#define DAOS_OSEQ_POOL_SVC_STOP		/* output fields */		 \
+	((struct pool_op_out)		(pso_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_svc_stop, DAOS_ISEQ_POOL_SVC_STOP, DAOS_OSEQ_POOL_SVC_STOP)
 CRT_RPC_DECLARE(pool_svc_stop_v6, DAOS_ISEQ_POOL_SVC_STOP_V6, DAOS_OSEQ_POOL_SVC_STOP)
 
-#define DAOS_ISEQ_POOL_TGT_DISCONNECT /* input fields */                                           \
-	((uuid_t)(tdi_uuid)CRT_VAR)((uuid_t)(tdi_hdls)CRT_ARRAY)
+#define DAOS_ISEQ_POOL_TGT_DISCONNECT	/* input fields */			\
+	((uuid_t)			(tdi_uuid)		CRT_VAR)	\
+	((uuid_t)			(tdi_hdls)		CRT_ARRAY)
 
-#define DAOS_OSEQ_POOL_TGT_DISCONNECT /* output fields */ ((int32_t)(tdo_rc)CRT_VAR)
+#define DAOS_OSEQ_POOL_TGT_DISCONNECT	/* output fields */			\
+	((int32_t)			(tdo_rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_tgt_disconnect, DAOS_ISEQ_POOL_TGT_DISCONNECT, DAOS_OSEQ_POOL_TGT_DISCONNECT)
 
-#define DAOS_ISEQ_POOL_TGT_QUERY /* input fields */ ((struct pool_op_in)(tqi_op)CRT_VAR)
+#define DAOS_ISEQ_POOL_TGT_QUERY	/* input fields */		 \
+	((struct pool_op_in)		(tqi_op)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_TGT_QUERY /* output fields */                                               \
-	((struct daos_pool_space)(tqo_space)CRT_RAW)((uint32_t)(tqo_rc)CRT_VAR)
+#define DAOS_OSEQ_POOL_TGT_QUERY	/* output fields */		 \
+	((struct daos_pool_space)	(tqo_space)		CRT_RAW) \
+	((uint32_t)			(tqo_rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_tgt_query, DAOS_ISEQ_POOL_TGT_QUERY, DAOS_OSEQ_POOL_TGT_QUERY)
 
-#define DAOS_ISEQ_POOL_TGT_DIST_HDLS /* input fields */                                            \
-	((uuid_t)(tfi_pool_uuid)CRT_VAR)((d_iov_t)(tfi_hdls)CRT_VAR)
+#define DAOS_ISEQ_POOL_TGT_DIST_HDLS	/* input fields */		 \
+	((uuid_t)			(tfi_pool_uuid)		CRT_VAR) \
+	((d_iov_t)			(tfi_hdls)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_TGT_DIST_HDLS /* output fields */ ((uint32_t)(tfo_rc)CRT_VAR)
+#define DAOS_OSEQ_POOL_TGT_DIST_HDLS	/* output fields */		 \
+	((uint32_t)			(tfo_rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_tgt_dist_hdls, DAOS_ISEQ_POOL_TGT_DIST_HDLS, DAOS_OSEQ_POOL_TGT_DIST_HDLS)
 
-#define DAOS_ISEQ_POOL_PROP_GET_V6 /* input fields */                                              \
-	((struct pool_op_v6_in)(pgi_op)CRT_VAR)((uint64_t)(pgi_query_bits)CRT_VAR)
+#define DAOS_ISEQ_POOL_PROP_GET_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pgi_op)		CRT_VAR) \
+	((uint64_t)			(pgi_query_bits)	CRT_VAR)
 
-#define DAOS_OSEQ_POOL_PROP_GET /* output fields */                                                \
-	((struct pool_op_out)(pgo_op)CRT_VAR)((daos_prop_t)(pgo_prop)CRT_PTR)
+#define DAOS_OSEQ_POOL_PROP_GET		/* output fields */		 \
+	((struct pool_op_out)		(pgo_op)		CRT_VAR) \
+	((daos_prop_t)			(pgo_prop)		CRT_PTR)
 
 CRT_RPC_DECLARE(pool_prop_get, DAOS_ISEQ_POOL_PROP_GET_V6, DAOS_OSEQ_POOL_PROP_GET)
+
+/* clang-format on */
 
 static inline void
 pool_prop_get_in_get_data(crt_rpc_t *rpc, uint64_t *pgi_query_bitsp)
@@ -647,12 +743,18 @@ pool_prop_get_in_set_data(crt_rpc_t *rpc, uint64_t pgi_query_bits)
 	((struct pool_prop_get_in *)in)->pgi_query_bits = pgi_query_bits;
 }
 
-#define DAOS_ISEQ_POOL_PROP_SET_V6 /* input fields */                                              \
-	((struct pool_op_v6_in)(psi_op)CRT_VAR)((daos_prop_t)(psi_prop)CRT_PTR)
+/* clang-format off */
 
-#define DAOS_OSEQ_POOL_PROP_SET /* output fields */ ((struct pool_op_out)(pso_op)CRT_VAR)
+#define DAOS_ISEQ_POOL_PROP_SET_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(psi_op)		CRT_VAR) \
+	((daos_prop_t)			(psi_prop)		CRT_PTR)
+
+#define DAOS_OSEQ_POOL_PROP_SET		/* output fields */		 \
+	((struct pool_op_out)		(pso_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_prop_set, DAOS_ISEQ_POOL_PROP_SET_V6, DAOS_OSEQ_POOL_PROP_SET)
+
+/* clang-format on */
 
 static inline void
 pool_prop_set_in_get_data(crt_rpc_t *rpc, daos_prop_t **psi_propp)
@@ -671,12 +773,18 @@ pool_prop_set_in_set_data(crt_rpc_t *rpc, daos_prop_t *psi_prop)
 	((struct pool_prop_set_in *)in)->psi_prop = psi_prop;
 }
 
-#define DAOS_ISEQ_POOL_ACL_UPDATE_V6 /* input fields */                                            \
-	((struct pool_op_v6_in)(pui_op)CRT_VAR)((struct daos_acl)(pui_acl)CRT_PTR)
+/* clang-format off */
 
-#define DAOS_OSEQ_POOL_ACL_UPDATE /* output fields */ ((struct pool_op_out)(puo_op)CRT_VAR)
+#define DAOS_ISEQ_POOL_ACL_UPDATE_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pui_op)		CRT_VAR) \
+	((struct daos_acl)		(pui_acl)		CRT_PTR)
+
+#define DAOS_OSEQ_POOL_ACL_UPDATE	/* output fields */		 \
+	((struct pool_op_out)		(puo_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_acl_update, DAOS_ISEQ_POOL_ACL_UPDATE_V6, DAOS_OSEQ_POOL_ACL_UPDATE)
+
+/* clang-format on */
 
 static inline void
 pool_acl_update_in_get_data(crt_rpc_t *rpc, struct daos_acl **pui_aclp)
@@ -695,13 +803,19 @@ pool_acl_update_in_set_data(crt_rpc_t *rpc, struct daos_acl *pui_acl)
 	((struct pool_acl_update_in *)in)->pui_acl = pui_acl;
 }
 
-#define DAOS_ISEQ_POOL_ACL_DELETE_V6 /* input fields */                                            \
-	((struct pool_op_v6_in)(pdi_op)CRT_VAR)((d_const_string_t)(pdi_principal)CRT_VAR)(         \
-	    (uint8_t)(pdi_type)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_OSEQ_POOL_ACL_DELETE /* output fields */ ((struct pool_op_out)(pdo_op)CRT_VAR)
+#define DAOS_ISEQ_POOL_ACL_DELETE_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pdi_op)		CRT_VAR) \
+	((d_const_string_t)		(pdi_principal)		CRT_VAR) \
+	((uint8_t)			(pdi_type)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_ACL_DELETE	/* output fields */		 \
+	((struct pool_op_out)		(pdo_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_acl_delete, DAOS_ISEQ_POOL_ACL_DELETE_V6, DAOS_OSEQ_POOL_ACL_DELETE)
+
+/* clang-format on */
 
 static inline void
 pool_acl_delete_in_get_data(crt_rpc_t *rpc, d_const_string_t *pdi_principalp, uint8_t *pdi_typep)
@@ -723,19 +837,26 @@ pool_acl_delete_in_set_data(crt_rpc_t *rpc, crt_opcode_t opc, d_const_string_t p
 	((struct pool_acl_delete_in *)in)->pdi_type      = pdi_type;
 }
 
-#define DAOS_ISEQ_POOL_LIST_CONT /* input fields */                                                \
-	((struct pool_op_in)(plci_op)CRT_VAR)((crt_bulk_t)(plci_cont_bulk)CRT_VAR)(                \
-	    (uint64_t)(plci_ncont)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_POOL_LIST_CONT_V6 /* input fields */                                             \
-	((struct pool_op_v6_in)(plci_op)CRT_VAR)((crt_bulk_t)(plci_cont_bulk)CRT_VAR)(             \
-	    (uint64_t)(plci_ncont)CRT_VAR)
+#define DAOS_ISEQ_POOL_LIST_CONT	/* input fields */		 \
+	((struct pool_op_in)		(plci_op)		CRT_VAR) \
+	((crt_bulk_t)			(plci_cont_bulk)	CRT_VAR) \
+	((uint64_t)			(plci_ncont)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_LIST_CONT /* output fields */                                               \
-	((struct pool_op_out)(plco_op)CRT_VAR)((uint64_t)(plco_ncont)CRT_VAR)
+#define DAOS_ISEQ_POOL_LIST_CONT_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(plci_op)		CRT_VAR) \
+	((crt_bulk_t)			(plci_cont_bulk)	CRT_VAR) \
+	((uint64_t)			(plci_ncont)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_LIST_CONT	/* output fields */		 \
+	((struct pool_op_out)		(plco_op)		CRT_VAR) \
+	((uint64_t)			(plco_ncont)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_list_cont, DAOS_ISEQ_POOL_LIST_CONT, DAOS_OSEQ_POOL_LIST_CONT)
 CRT_RPC_DECLARE(pool_list_cont_v6, DAOS_ISEQ_POOL_LIST_CONT_V6, DAOS_OSEQ_POOL_LIST_CONT)
+
+/* clang-format on */
 
 static inline void
 pool_list_cont_in_get_data(crt_rpc_t *rpc, crt_bulk_t *plci_cont_bulkp, uint64_t *plci_ncontp)
@@ -765,19 +886,28 @@ pool_list_cont_in_set_data(crt_rpc_t *rpc, crt_bulk_t plci_cont_bulk, uint64_t p
 	}
 }
 
-#define DAOS_ISEQ_POOL_FILTER_CONT /* input fields */                                              \
-	((struct pool_op_in)(pfci_op)CRT_VAR)((crt_bulk_t)(pfci_cont_bulk)CRT_VAR)(                \
-	    (uint64_t)(pfci_ncont)CRT_VAR)((daos_pool_cont_filter_t)(pfci_filt)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_ISEQ_POOL_FILTER_CONT_V6 /* input fields */                                           \
-	((struct pool_op_v6_in)(pfci_op)CRT_VAR)((crt_bulk_t)(pfci_cont_bulk)CRT_VAR)(             \
-	    (uint64_t)(pfci_ncont)CRT_VAR)((daos_pool_cont_filter_t)(pfci_filt)CRT_VAR)
+#define DAOS_ISEQ_POOL_FILTER_CONT	/* input fields */		 \
+	((struct pool_op_in)		(pfci_op)		CRT_VAR) \
+	((crt_bulk_t)			(pfci_cont_bulk)	CRT_VAR) \
+	((uint64_t)			(pfci_ncont)		CRT_VAR) \
+	((daos_pool_cont_filter_t)	(pfci_filt)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_FILTER_CONT /* output fields */                                             \
-	((struct pool_op_out)(pfco_op)CRT_VAR)((uint64_t)(pfco_ncont)CRT_VAR)
+#define DAOS_ISEQ_POOL_FILTER_CONT_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(pfci_op)		CRT_VAR) \
+	((crt_bulk_t)			(pfci_cont_bulk)	CRT_VAR) \
+	((uint64_t)			(pfci_ncont)		CRT_VAR) \
+	((daos_pool_cont_filter_t)	(pfci_filt)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_FILTER_CONT	/* output fields */		 \
+	((struct pool_op_out)		(pfco_op)		CRT_VAR) \
+	((uint64_t)			(pfco_ncont)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_filter_cont, DAOS_ISEQ_POOL_FILTER_CONT, DAOS_OSEQ_POOL_FILTER_CONT)
 CRT_RPC_DECLARE(pool_filter_cont_v6, DAOS_ISEQ_POOL_FILTER_CONT_V6, DAOS_OSEQ_POOL_FILTER_CONT)
+
+/* clang-format on */
 
 static inline void
 pool_filter_cont_in_get_data(crt_rpc_t *rpc, crt_bulk_t *pfci_cont_bulkp, uint64_t *pfci_ncontp,
@@ -822,37 +952,49 @@ pool_filter_cont_in_set_data(crt_rpc_t *rpc, crt_bulk_t pfci_cont_bulk, uint64_t
 	}
 }
 
-#define DAOS_ISEQ_POOL_RANKS_GET /* input fields */                                                \
-	((struct pool_op_in)(prgi_op)CRT_VAR)((crt_bulk_t)(prgi_ranks_bulk)CRT_VAR)(               \
-	    (uint32_t)(prgi_nranks)CRT_VAR)
+/* clang-format off */
 
-#define DAOS_OSEQ_POOL_RANKS_GET /* output fields */                                               \
-	((struct pool_op_out)(prgo_op)CRT_VAR)((uint32_t)(prgo_nranks)CRT_VAR)
+#define DAOS_ISEQ_POOL_RANKS_GET	/* input fields */		 \
+	((struct pool_op_in)		(prgi_op)		CRT_VAR) \
+	((crt_bulk_t)			(prgi_ranks_bulk)	CRT_VAR) \
+	((uint32_t)			(prgi_nranks)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_RANKS_GET	/* output fields */		 \
+	((struct pool_op_out)		(prgo_op)		CRT_VAR) \
+	((uint32_t)			(prgo_nranks)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_ranks_get, DAOS_ISEQ_POOL_RANKS_GET, DAOS_OSEQ_POOL_RANKS_GET)
 
-#define DAOS_ISEQ_POOL_UPGRADE_V6 /* input fields */ ((struct pool_op_v6_in)(poi_op)CRT_VAR)
+#define DAOS_ISEQ_POOL_UPGRADE_V6	/* input fields */		 \
+	((struct pool_op_v6_in)		(poi_op)		CRT_VAR)
 
-#define DAOS_OSEQ_POOL_UPGRADE    /* output fields */ ((struct pool_op_out)(poo_op)CRT_VAR)
+#define DAOS_OSEQ_POOL_UPGRADE		/* output fields */		 \
+	((struct pool_op_out)		(poo_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_upgrade, DAOS_ISEQ_POOL_UPGRADE_V6, DAOS_OSEQ_POOL_UPGRADE)
 
-#define DAOS_ISEQ_POOL_TGT_QUERY_MAP /* input fields */                                            \
-	((struct pool_op_in)(tmi_op)CRT_VAR)((crt_bulk_t)(tmi_map_bulk)CRT_VAR)(                   \
-	    (uint32_t)(tmi_map_version)CRT_VAR)
+#define DAOS_ISEQ_POOL_TGT_QUERY_MAP	/* input fields */		 \
+	((struct pool_op_in)		(tmi_op)		CRT_VAR) \
+	((crt_bulk_t)			(tmi_map_bulk)		CRT_VAR) \
+	((uint32_t)			(tmi_map_version)	CRT_VAR)
 
-#define DAOS_OSEQ_POOL_TGT_QUERY_MAP          /* output fields */                                  \
-	((struct pool_op_out)(tmo_op)CRT_VAR) /* only set on -DER_TRUNC */                         \
-	    ((uint32_t)(tmo_map_buf_size)CRT_VAR)
+#define DAOS_OSEQ_POOL_TGT_QUERY_MAP	/* output fields */		 \
+	((struct pool_op_out)		(tmo_op)		CRT_VAR) \
+	/* only set on -DER_TRUNC */					 \
+	((uint32_t)			(tmo_map_buf_size)	CRT_VAR)
 
 CRT_RPC_DECLARE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP, DAOS_OSEQ_POOL_TGT_QUERY_MAP)
 
-#define DAOS_ISEQ_POOL_TGT_DISCARD /* input fields */                                              \
-	((uuid_t)(ptdi_uuid)CRT_VAR)((struct pool_target_addr)(ptdi_addrs)CRT_ARRAY)
+#define DAOS_ISEQ_POOL_TGT_DISCARD	/* input fields */		 \
+	((uuid_t)			(ptdi_uuid)		CRT_VAR) \
+	((struct pool_target_addr)	(ptdi_addrs)		CRT_ARRAY)
 
-#define DAOS_OSEQ_POOL_TGT_DISCARD /* output fields */ ((int32_t)(ptdo_rc)CRT_VAR)
+#define DAOS_OSEQ_POOL_TGT_DISCARD	/* output fields */		 \
+	((int32_t)			(ptdo_rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(pool_tgt_discard, DAOS_ISEQ_POOL_TGT_DISCARD, DAOS_OSEQ_POOL_TGT_DISCARD)
+
+/* clang-format on */
 
 static inline int
 pool_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,


### PR DESCRIPTION
Use clang-format on and clang-format off code comments to control what sections of these rpc header files get formatted.

Previous code patches for this feature have resulted in some unreadable cart RPC definition macros in the code. This change restores the readable code alignments and prevents clang-format from attempting to make the unreadable changes in the future.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
