### PR TITLE
DAOS-14769 client: reset crt related global variables after fork()

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -52,6 +52,16 @@ crt_lib_init(void)
 	crt_gdata.cg_iv_inline_limit = 19456; /* 19KB */
 }
 
+void
+crt_reset_afterfork(void)
+{
+	gdata_init_flag = 0;
+	memset(&crt_gdata, 0, sizeof(struct crt_gdata));
+	memset(&crt_plugin_gdata, 0, sizeof(struct crt_plugin_gdata));
+	memset(g_prov_settings_applied, 0, sizeof(bool) * CRT_PROV_COUNT);
+	crt_lib_init();
+}
+
 /* Library deinit */
 static void
 crt_lib_fini(void)

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -97,4 +97,10 @@ crt_hdlr_ctl_get_pid(crt_rpc_t *rpc_req);
 
 void
 crt_iv_init(crt_init_options_t *ops);
+
+/** Reset global variables and call crt_lib_init() after fork().
+ */
+void
+crt_reset_afterfork(void);
+
 #endif /* __CRT_INTERNAL_H__ */

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -15,6 +15,7 @@
 
 #include "client_internal.h"
 #include <daos/rpc.h>
+#include <cart/api.h>
 
 /** thread-private event */
 static __thread daos_event_t	ev_thpriv;
@@ -110,6 +111,7 @@ crt:
 int
 daos_eq_lib_reset_after_fork(void)
 {
+	crt_reset_afterfork();
 	eq_ref            = 0;
 	ev_thpriv_is_init = false;
 	return daos_eq_lib_init();

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -15,7 +15,7 @@
 
 #include "client_internal.h"
 #include <daos/rpc.h>
-#include <cart/api.h>
+#include <../cart/crt_internal.h>
 
 /** thread-private event */
 static __thread daos_event_t	ev_thpriv;

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -2227,10 +2227,6 @@ int crt_swim_init(int crt_ctx_idx);
  */
 void crt_swim_fini(void);
 
-/** Reset global variables and call crt_lib_init() after fork().
- */
-void crt_reset_afterfork(void);
-
 #define crt_proc__Bool			crt_proc_bool
 #define crt_proc_d_rank_t		crt_proc_uint32_t
 #define crt_proc_int			crt_proc_int32_t

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -2227,6 +2227,10 @@ int crt_swim_init(int crt_ctx_idx);
  */
 void crt_swim_fini(void);
 
+/** Reset global variables and call crt_lib_init() after fork().
+ */
+void crt_reset_afterfork(void);
+
 #define crt_proc__Bool			crt_proc_bool
 #define crt_proc_d_rank_t		crt_proc_uint32_t
 #define crt_proc_int			crt_proc_int32_t


### PR DESCRIPTION
Once fork() is called, a child process is created and proceeds from the fork point. The parent process may still need to utilize the existing context. It is the parent process's responsibility to destroy the context when the parent process ends. The child process inherited the memory from its parent process due to fork. We do need to reset the global variables and create a fresh context inside the child process.

Features: pil4dfs

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
