### PR TITLE
DAOS-14010 object: various fixes for migration (#13448)

### DIFF
--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -100,6 +100,7 @@ struct migrate_pool_tls {
 	/* migrate leader ULT */
 	unsigned int		mpt_ult_running:1,
 				mpt_init_tls:1,
+				mpt_init_failed:1,
 				mpt_fini:1;
 };
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -477,10 +477,10 @@ out:
 	return rc;
 }
 
-static struct migrate_pool_tls*
+static int
 migrate_pool_tls_lookup_create(struct ds_pool *pool, unsigned int version, unsigned int generation,
 			       uuid_t pool_hdl_uuid, uuid_t co_hdl_uuid, uint64_t max_eph,
-			       uint32_t new_layout_ver, uint32_t opc)
+			       uint32_t new_layout_ver, uint32_t opc, struct migrate_pool_tls **p_tls)
 {
 	struct migrate_pool_tls *tls = NULL;
 	struct migrate_pool_tls_create_arg arg = { 0 };
@@ -495,8 +495,16 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, unsigned int version, unsig
 			ABT_mutex_lock(tls->mpt_init_mutex);
 			ABT_cond_wait(tls->mpt_init_cond, tls->mpt_init_mutex);
 			ABT_mutex_unlock(tls->mpt_init_mutex);
+			if (tls->mpt_init_failed) {
+				migrate_pool_tls_put(tls);
+				rc = -DER_NOMEM;
+			}
 		}
-		return tls;
+
+		if (rc == 0)
+			*p_tls = tls;
+
+		return rc;
 	}
 
 	D_ASSERT(generation != (unsigned int)(-1));
@@ -547,16 +555,27 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, unsigned int version, unsig
 out:
 	if (tls != NULL && tls->mpt_init_tls) {
 		tls->mpt_init_tls = 0;
+		/* Set init failed, so the waiting lookup(above) can be notified */
+		if (rc != 0)
+			tls->mpt_init_failed = 1;
 		ABT_mutex_lock(tls->mpt_init_mutex);
 		ABT_cond_broadcast(tls->mpt_init_cond);
 		ABT_mutex_unlock(tls->mpt_init_mutex);
 	}
 	D_DEBUG(DB_TRACE, "create tls "DF_UUID": "DF_RC"\n",
 		DP_UUID(pool->sp_uuid), DP_RC(rc));
+
+	if (rc != 0) {
+		if (tls != NULL)
+			migrate_pool_tls_put(tls);
+	} else {
+		*p_tls = tls;
+	}
+
 	if (prop != NULL)
 		daos_prop_free(prop);
 
-	return tls;
+	return rc;
 }
 
 static void
@@ -627,7 +646,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 	if (tls == NULL || tls->mpt_fini) {
 		D_WARN("some one abort the rebuild "DF_UUID"\n",
 		       DP_UUID(mrone->mo_pool_uuid));
-		D_GOTO(out, rc);
+		D_GOTO(out, rc = -DER_SHUTDOWN);
 	}
 
 	if (daos_oclass_grp_size(&mrone->mo_oca) > 1)
@@ -3440,15 +3459,15 @@ ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_
 		  unsigned int *shards, uint32_t count, unsigned int tgt_idx,
 		  uint32_t new_layout_ver)
 {
-	struct migrate_pool_tls	*tls;
+	struct migrate_pool_tls	*tls = NULL;
 	int			i;
 	int			rc;
 
 	/* Check if the pool tls exists */
-	tls = migrate_pool_tls_lookup_create(pool, version, generation, po_hdl, co_hdl, max_eph,
-					     new_layout_ver, opc);
-	if (tls == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
+	rc = migrate_pool_tls_lookup_create(pool, version, generation, po_hdl, co_hdl, max_eph,
+					    new_layout_ver, opc, &tls);
+	if (rc != 0)
+		D_GOTO(out, rc);
 	if (tls->mpt_fini)
 		D_GOTO(out, rc = -DER_SHUTDOWN);
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -2015,8 +2015,13 @@ regenerate_task_of_type(struct ds_pool *pool, pool_comp_state_t match_states,
 			RB_OP_STR(rebuild_op), DP_RC(rc));
 		return rc;
 	}
+	if (tgts_cnt == 0)
+		return 0;
 
-	return regenerate_task_internal(pool, tgts, tgts_cnt, rebuild_op);
+	rc = regenerate_task_internal(pool, tgts, tgts_cnt, rebuild_op);
+	D_FREE(tgts);
+
+	return rc;
 }
 
 


### PR DESCRIPTION
1. target count calculation should not use pool_tree_count, which might count the target count under other domain, thus corrupt the pool map during extending.

2. return correct error code in migrate_pool_tls_lookup_create() and mrone_one_fetch.

3. Missing free in regenerate_task_of_type.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
