### PR TITLE
DAOS-14788 container: refine task process in pmap_refresh_cb

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -668,14 +668,6 @@ pmap_refresh_cb(tse_task_t *task, void *data)
 		else
 			delay = 0;
 
-		rc = tse_task_reinit_with_delay(task, delay);
-		if (rc) {
-			D_ERROR(DF_UUID": pmap_refresh version (%d:%d), resched"
-				" failed, "DF_RC"\n", DP_UUID(pool->dp_pool),
-				pm_ver, cb_arg->pra_pm_ver, DP_RC(rc));
-			goto out;
-		}
-
 		rc = tse_task_register_comp_cb(task, pmap_refresh_cb, cb_arg,
 					       sizeof(*cb_arg));
 		if (rc) {
@@ -683,6 +675,14 @@ pmap_refresh_cb(tse_task_t *task, void *data)
 				"to reg_comp_cb, "DF_RC"\n",
 				DP_UUID(pool->dp_pool), pm_ver,
 				cb_arg->pra_pm_ver, DP_RC(rc));
+			goto out;
+		}
+
+		rc = tse_task_reinit_with_delay(task, delay);
+		if (rc) {
+			D_ERROR(DF_UUID": pmap_refresh version (%d:%d), resched"
+				" failed, "DF_RC"\n", DP_UUID(pool->dp_pool),
+				pm_ver, cb_arg->pra_pm_ver, DP_RC(rc));
 			goto out;
 		}
 

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -678,6 +678,11 @@ pmap_refresh_cb(tse_task_t *task, void *data)
 			goto out;
 		}
 
+		cb_arg->pra_retry_nr++;
+		D_DEBUG(DB_TRACE, DF_UUID": pmap_refresh version (%d:%d), "
+			"in %d retry\n", DP_UUID(pool->dp_pool), pm_ver,
+			cb_arg->pra_pm_ver, cb_arg->pra_retry_nr);
+
 		rc = tse_task_reinit_with_delay(task, delay);
 		if (rc) {
 			D_ERROR(DF_UUID": pmap_refresh version (%d:%d), resched"
@@ -686,10 +691,6 @@ pmap_refresh_cb(tse_task_t *task, void *data)
 			goto out;
 		}
 
-		cb_arg->pra_retry_nr++;
-		D_DEBUG(DB_TRACE, DF_UUID": pmap_refresh version (%d:%d), "
-			"in %d retry\n", DP_UUID(pool->dp_pool), pm_ver,
-			cb_arg->pra_pm_ver, cb_arg->pra_retry_nr);
 		return rc;
 	}
 out:

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -307,10 +307,11 @@ tse_task_register_cbs(tse_task_t *task, tse_task_cb_t prep_cb,
 
 /**
  * Reinitialize a task and move it into the scheduler's initialize list. The
- * task must have a body function to be reinserted into the scheduler. If the
- * task is reintialzed in one of its completion CBs, that callback and the ones
- * that have already executed will have been removed from the cb list and will
- * need to be re-registered by the user after re-insertion.
+ * task must have a body function to be reinserted into the scheduler.
+ * Once the task being reinitialized, it possible be executed by other thread
+ * when it progresses the scheduler. So all accesses to the task must happen before
+ * the reinit call, for example task dependency/callback registration or task
+ * argument accessing.
  *
  * \param task	[IN]	Task to reinitialize
  *


### PR DESCRIPTION
should register completion callback before task reinit, or the complete cb possibly cannot be triggered.
(issue reported by Zhao Zhen <zp_8483@163.com>)

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
