### PR TITLE
DAOS-623 cq: Bump versions of isort and pylint.

### DIFF
--- a/utils/cq/requirements.txt
+++ b/utils/cq/requirements.txt
@@ -9,7 +9,7 @@ pyenchant
 ## flake8 6 removed --diff option which breaks flake precommit hook.
 ## https://github.com/pycqa/flake8/issues/1389 https://github.com/PyCQA/flake8/pull/1720
 flake8<6.0.0
-isort==5.12
-pylint==3.0.2
+isort==5.13.2
+pylint==3.0.3
 yamllint==1.33.0
 codespell==2.2.6


### PR DESCRIPTION
Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
