### PR TITLE
DAOS-14591 test: Avoid including xml CDATA in the job.log (#13310)

### DIFF
--- a/src/tests/ftest/util/collection_utils.py
+++ b/src/tests/ftest/util/collection_utils.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 from collections import OrderedDict
+from difflib import unified_diff
 
 from ClusterShell.NodeSet import NodeSet
 from process_core_files import CoreFileException, CoreFileProcessing
@@ -870,12 +871,6 @@ def replace_xml(logger, xml_file, pattern, replacement, xml_data, test_result):
         str: the updated xml_data; None if an error was detected
     """
     logger.debug("Replacing '%s' with '%s' in %s", pattern, replacement, xml_file)
-
-    logger.debug("  Contents of %s before replacement", xml_file)
-    for line in xml_data.splitlines():
-        logger.debug("    %s", line)
-    logger.debug("")
-
     try:
         with open(xml_file, "w", encoding="utf-8") as xml_buffer:
             xml_buffer.write(re.sub(pattern, replacement, xml_data))
@@ -886,8 +881,9 @@ def replace_xml(logger, xml_file, pattern, replacement, xml_data, test_result):
 
     new_xml_data = get_xml_data(logger, xml_file, test_result)
     if new_xml_data is not None:
-        logger.debug("  Contents of %s after replacement", xml_file)
-        for line in new_xml_data.splitlines():
+        logger.debug("  Diff of %s after replacement", xml_file)
+        for line in unified_diff(xml_data.splitlines(), new_xml_data.splitlines(),
+                                 fromfile=xml_file, tofile=xml_file, n=0, lineterm=""):
             logger.debug("    %s", line)
         logger.debug("")
 


### PR DESCRIPTION
TO prevent xml parsing errors do not include CDATA sections of other xml files in the launch.py job.log by only logging the diff of xml file changes.

Skip-unit-tests: true
Skip-fault-injection-test: true
Allow-unstable-test: true
Test-tag: test_daos_pool test_daos_management test_core_files test_launch_failures

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
