### PR TITLE
DAOS-14805 dfuse: Correctly propagate errors in ioil.

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -2178,7 +2178,7 @@ dfuse_fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
 		if (nread != nmemb)
 			entry->fd_eof = true;
 	} else if (bytes_read < 0) {
-		entry->fd_err = bytes_read;
+		entry->fd_err = errcode;
 	} else {
 		entry->fd_eof = true;
 	}
@@ -2237,7 +2237,7 @@ dfuse_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
 		nwrite        = bytes_written / size;
 		entry->fd_pos = oldpos + (nwrite * size);
 	} else if (bytes_written < 0) {
-		entry->fd_err = bytes_written;
+		entry->fd_err = errcode;
 	}
 
 	vector_decref(&fd_table, entry);


### PR DESCRIPTION
Fix an issue where all errors would be mapped to 1 (EPERM)

Features: dfuse
Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
