### PR TITLE
DAOS-14788 pool: Fix some reinit usages

### DIFF
--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -2634,7 +2634,12 @@ dc_tx_restart(tse_task_t *task)
 			/*
 			 * Reinitialize task with a delay to implement the
 			 * backoff and call dc_tx_restart_end below.
+			 *
+			 * We don't need to get an extra tx reference, because
+			 * the reinitialized task must acquire tx->tx_lock
+			 * first.
 			 */
+			tse_task_set_priv_internal(task, tx);
 			rc = tse_task_reinit_with_delay(task, backoff);
 			if (rc != 0) {
 				/* Skip the backoff. */
@@ -2643,8 +2648,6 @@ dc_tx_restart(tse_task_t *task)
 				goto out_tx_lock;
 			}
 			D_MUTEX_UNLOCK(&tx->tx_lock);
-			/* Pass our tx reference to task. */
-			tse_task_set_priv_internal(task, tx);
 			return 0;
 		}
 

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1719,6 +1719,9 @@ map_refresh_cb(tse_task_t *task, void *varg)
 	bool				reinit = false;
 	int				rc = task->dt_result;
 
+	/* Get an extra reference for the reinit case. */
+	dc_pool_get(pool);
+
 	/*
 	 * If it turns out below that we do need to update the cached pool map,
 	 * then holding the lock while doing so will be okay, since we probably
@@ -1843,6 +1846,7 @@ out:
 		dc_pool_put(arg->mra_pool);
 	}
 
+	dc_pool_put(pool);
 	return rc;
 }
 
@@ -1856,6 +1860,9 @@ map_refresh(tse_task_t *task)
 	crt_rpc_t		       *rpc;
 	struct map_refresh_cb_arg	cb_arg;
 	int				rc;
+
+	/* Get an extra reference for the reinit cases. */
+	dc_pool_get(pool);
 
 	if (arg->mra_passive) {
 		/*
@@ -1921,7 +1928,7 @@ map_refresh(tse_task_t *task)
 				DP_UUID(pool->dp_pool), task, DP_RC(rc));
 			goto out_task;
 		}
-		goto out;
+		goto out_pool;
 	}
 
 	if (pool->dp_map_task == NULL) {
@@ -1969,7 +1976,7 @@ map_refresh(tse_task_t *task)
 				DP_UUID(pool->dp_pool), query_task, DP_RC(rc));
 			goto out_map_task;
 		}
-		goto out;
+		goto out_pool;
 	}
 
 	/*
@@ -2001,6 +2008,7 @@ map_refresh(tse_task_t *task)
 
 	D_DEBUG(DB_MD, DF_UUID": %p: asking rank %u for version > %u\n",
 		DP_UUID(pool->dp_pool), task, rank, version);
+	dc_pool_put(pool);
 	return daos_rpc_send(rpc, task);
 
 out_cb_arg:
@@ -2014,7 +2022,8 @@ out_task:
 	d_backoff_seq_fini(&arg->mra_backoff_seq);
 	dc_pool_put(arg->mra_pool);
 	tse_task_complete(task, rc);
-out:
+out_pool:
+	dc_pool_put(pool);
 	return rc;
 }
 


### PR DESCRIPTION
The map_refresh and map_refresh_cb functions access the pool variable after reinitializing the task. Since the dc_pool reference is stored in the task object, it may be released by the new incarnation of the task before being accessed by the current incarnation. This patch addresses the problem by getting an extra dc_pool reference for the pool variable.

The dc_tx_restart function sets the internal private data of the task after reinitialing the task. This causes a data race because the current thread may write the internal private data while another reads the data.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
