### PR TITLE
DAOS-14784 dfs: do not use query_max_epoch if server is < 2.4

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1026,10 +1026,14 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 			return daos_der2errno(rc);
 		}
 
-		rc = daos_obj_query_max_epoch(dir_oh, th, &ep, NULL);
-		if (rc) {
-			daos_obj_close(dir_oh, NULL);
-			return daos_der2errno(rc);
+		if (dc_supports_epoch_query()) {
+			rc = daos_obj_query_max_epoch(dir_oh, th, &ep, NULL);
+			if (rc) {
+				daos_obj_close(dir_oh, NULL);
+				return daos_der2errno(rc);
+			}
+		} else {
+			ep = 0;
 		}
 
 		rc = daos_obj_close(dir_oh, NULL);
@@ -4130,10 +4134,14 @@ dfs_lookup_rel_int(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags,
 		if (stbuf) {
 			daos_epoch_t	ep;
 
-			rc = daos_obj_query_max_epoch(obj->oh, DAOS_TX_NONE, &ep, NULL);
-			if (rc) {
-				daos_obj_close(obj->oh, NULL);
-				D_GOTO(err_obj, rc = daos_der2errno(rc));
+			if (dc_supports_epoch_query()) {
+				rc = daos_obj_query_max_epoch(obj->oh, DAOS_TX_NONE, &ep, NULL);
+				if (rc) {
+					daos_obj_close(obj->oh, NULL);
+					D_GOTO(err_obj, rc = daos_der2errno(rc));
+				}
+			} else {
+				ep = 0;
 			}
 
 			rc = update_stbuf_times(entry, ep, stbuf, NULL);

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -830,4 +830,12 @@ int
 dc_obj_enum_unpack(daos_unit_oid_t oid, daos_key_desc_t *kds, int kds_num,
 		   d_sg_list_t *sgl, d_iov_t *csum, dc_obj_enum_unpack_cb_t cb,
 		   void *cb_arg);
+
+/** Check if server supports daos_obj_query_max_epoch */
+extern int dc_obj_proto_version;
+static inline bool
+dc_supports_epoch_query()
+{
+	return (dc_obj_proto_version >= 9);
+}
 #endif /* __DD_OBJ_H__ */


### PR DESCRIPTION
DAOS 2.2.0 and previous (OBJ_VERSION <= 8) do not support querying just the max epoch of an object. So when a 2.4.x client is talking to a 2.2.x server, avoid issuing that operation to prevent an error on stat() operations. What that means is that mtime on directory objects is not always accurate and will use the initial entry mtime in that scenario.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
