### PR TITLE
DAOS-14801 mgmt: Fix LedManage dRPC handler response cleanup

### DIFF
--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -324,6 +324,17 @@ copy_str2ctrlr(char **dst, const char *src)
 	return 0;
 }
 
+static void
+ctrlr_reset_str_fields(Ctl__NvmeController *ctrlr)
+{
+	ctrlr->pci_addr     = NULL;
+	ctrlr->model        = NULL;
+	ctrlr->serial       = NULL;
+	ctrlr->fw_rev       = NULL;
+	ctrlr->vendor_id    = NULL;
+	ctrlr->pci_dev_type = NULL;
+}
+
 static int
 add_ctrlr_details(Ctl__NvmeController *ctrlr, struct bio_dev_info *dev_info)
 {
@@ -429,6 +440,8 @@ ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 			break;
 		}
 		ctl__nvme_controller__init(resp->devices[i]->ctrlr);
+		/* Set string fields to NULL to allow D_FREE to work as expected on cleanup */
+		ctrlr_reset_str_fields(resp->devices[i]->ctrlr);
 
 		rc = add_ctrlr_details(resp->devices[i]->ctrlr, dev_info);
 		if (rc != 0)
@@ -767,6 +780,8 @@ ds_mgmt_dev_manage_led(Ctl__LedManageReq *req, Ctl__DevManageResp *resp)
 		return -DER_NOMEM;
 	}
 	ctl__nvme_controller__init(resp->device->ctrlr);
+	/* Set string fields to NULL to allow D_FREE to work as expected on cleanup */
+	ctrlr_reset_str_fields(resp->device->ctrlr);
 
 	D_ALLOC(resp->device->ctrlr->pci_addr, ADDR_STR_MAX_LEN + 1);
 	if (resp->device->ctrlr->pci_addr == NULL)


### PR DESCRIPTION
When attempting to free string memory in LedManage dRPC handler,
D_FREE is finding non-null pointers and attempting to free when no
memory has been allocated. This is due to the protobuf init functions
setting string values non-null. Solve by resetting string values to
NULL after controller message structure is initialized.

Skip-func-hw-medium-md-on-ssd: false
Skip-func-hw-medium-verbs-provider-md-on-ssd: false
Test-tag: VmdLedStatus,test_disk_failure_recover

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
