### PR TITLE
DAOS-623 build: Treat public headers as public.

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -19,7 +19,7 @@
 #define D_LOGFAC	DD_FAC(iv)
 
 #include "crt_internal.h"
-#include "cart/iv.h"
+#include <cart/iv.h>
 
 #define IV_DBG(key, msg, ...) \
 	D_DEBUG(DB_TRACE, "[key=%p] " msg, (key)->iov_buf, ##__VA_ARGS__)

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -12,7 +12,7 @@
 #define __CRT_RPC_H__
 
 #include <gurt/heap.h>
-#include "gurt/common.h"
+#include <gurt/common.h>
 
 /* default RPC timeout 60 seconds */
 #define CRT_DEFAULT_TIMEOUT_S	(60) /* second */

--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -10,8 +10,8 @@
 #ifndef __CRT_SWIM_H__
 #define __CRT_SWIM_H__
 
-#include "gurt/list.h"
-#include "cart/swim.h"
+#include <gurt/list.h>
+#include <cart/swim.h>
 #include "swim/swim_internal.h"
 
 #define CRT_SWIM_NGLITCHES_TRESHOLD	10

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -18,8 +18,8 @@
 #include <daos/array.h>
 #include <daos/object.h>
 
-#include "daos.h"
-#include "daos_fs.h"
+#include <daos.h>
+#include <daos_fs.h>
 #include "dfs_internal.h"
 
 /** D-key name of SB metadata */

--- a/src/client/dfs/dfs_sys.c
+++ b/src/client/dfs/dfs_sys.c
@@ -14,10 +14,10 @@
 
 #include <gurt/atomic.h>
 
-#include "daos.h"
-#include "daos_fs.h"
+#include <daos.h>
+#include <daos_fs.h>
 
-#include "daos_fs_sys.h"
+#include <daos_fs_sys.h>
 
 /** Number of entries for readdir */
 #define DFS_SYS_NUM_DIRENTS 24

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -26,11 +26,11 @@
 #endif
 #include <daos/common.h>
 #include <daos/object.h>
-#include "dfuse_ioctl.h"
-#include "daos_types.h"
-#include "daos.h"
-#include "daos_fs.h"
-#include "daos_uns.h"
+#include <dfuse_ioctl.h>
+#include <daos_types.h>
+#include <daos.h>
+#include <daos_fs.h>
+#include <daos_uns.h>
 
 #ifndef FUSE_SUPER_MAGIC
 #define FUSE_SUPER_MAGIC	0x65735546

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -17,8 +17,8 @@
 #include <gurt/atomic.h>
 #include <gurt/slab.h>
 
-#include "daos.h"
-#include "daos_fs.h"
+#include <daos.h>
+#include <daos_fs.h>
 
 #include "dfs_internal.h"
 

--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -6,8 +6,8 @@
 
 #include "dfuse_common.h"
 #include "dfuse.h"
-#include "daos_fs.h"
-#include "daos_api.h"
+#include <daos_fs.h>
+#include <daos_api.h>
 
 /* Lookup a container within a pool */
 void

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -19,9 +19,9 @@
 
 #include "dfuse.h"
 
-#include "daos_fs.h"
-#include "daos_api.h"
-#include "daos_uns.h"
+#include <daos_fs.h>
+#include <daos_api.h>
+#include <daos_uns.h>
 
 #include <gurt/common.h>
 /* Signal handler for SIGCHLD, it doesn't need to do anything, but it's

--- a/src/client/dfuse/dfuse_pool.c
+++ b/src/client/dfuse/dfuse_pool.c
@@ -6,9 +6,9 @@
 
 #include "dfuse_common.h"
 #include "dfuse.h"
-#include "daos_fs.h"
-#include "daos_api.h"
-#include "daos_security.h"
+#include <daos_fs.h>
+#include <daos_api.h>
+#include <daos_security.h>
 
 /* Lookup a pool */
 void

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -21,12 +21,14 @@
 #include <sys/ioctl.h>
 #include <string.h>
 
-#include <daos/event.h>
-#include "dfuse_log.h"
 #include <gurt/list.h>
 #include <gurt/atomic.h>
+
+#include <daos/event.h>
+#include <dfuse_ioctl.h>
+
+#include "dfuse_log.h"
 #include "intercept.h"
-#include "dfuse_ioctl.h"
 #include "dfuse_vector.h"
 #include "dfuse_common.h"
 

--- a/src/client/dfuse/il/int_read.c
+++ b/src/client/dfuse/il/int_read.c
@@ -7,8 +7,8 @@
 #define D_LOGFAC DD_FAC(il)
 #include "dfuse_common.h"
 #include "intercept.h"
-#include "daos.h"
-#include "daos_array.h"
+#include <daos.h>
+#include <daos_array.h>
 
 #include "ioil.h"
 

--- a/src/client/dfuse/il/int_write.c
+++ b/src/client/dfuse/il/int_write.c
@@ -5,10 +5,12 @@
  */
 
 #define D_LOGFAC DD_FAC(il)
+
+#include <daos.h>
+#include <daos_array.h>
+
 #include "dfuse_common.h"
 #include "intercept.h"
-#include "daos.h"
-#include "daos_array.h"
 
 #include "ioil.h"
 

--- a/src/client/dfuse/il/ioil.h
+++ b/src/client/dfuse/il/ioil.h
@@ -11,7 +11,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "daos_fs.h"
+#include <daos_fs.h>
 
 struct ioil_cont {
 	/* Container open handle */

--- a/src/client/dfuse/ops/getxattr.c
+++ b/src/client/dfuse/ops/getxattr.c
@@ -7,7 +7,7 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
-#include "daos_uns.h"
+#include <daos_uns.h>
 
 static int
 _dfuse_attr_create(char *type, uuid_t pool, uuid_t cont, char **_value, daos_size_t *_out_size)

--- a/src/client/dfuse/ops/ioctl.c
+++ b/src/client/dfuse/ops/ioctl.c
@@ -9,7 +9,7 @@
 
 #include <sys/ioctl.h>
 
-#include "dfuse_ioctl.h"
+#include <dfuse_ioctl.h>
 
 #define MAX_IOCTL_SIZE ((1024 * 16) - 1)
 

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -7,7 +7,7 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
-#include "daos_uns.h"
+#include <daos_uns.h>
 
 char *duns_xattr_name = DUNS_XATTR_NAME;
 

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -7,7 +7,7 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
-#include "daos_uns.h"
+#include <daos_uns.h>
 
 /* Initial number of dentries to read when doing readdirplus */
 #define READDIR_PLUS_COUNT 26

--- a/src/client/dfuse/ops/setxattr.c
+++ b/src/client/dfuse/ops/setxattr.c
@@ -7,7 +7,7 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
-#include "daos_uns.h"
+#include <daos_uns.h>
 
 #define ACL_ACCESS	"system.posix_acl_access"
 #define ACL_DEFAULT	"system.posix_acl_default"

--- a/src/client/ds3/ds3_internal.h
+++ b/src/client/ds3/ds3_internal.h
@@ -10,9 +10,9 @@
 #define __DAOS_S3_INTERNAL_H__
 
 #include <fcntl.h>
-#include "daos.h"
-#include "daos_fs.h"
-#include "daos_s3.h"
+#include <daos.h>
+#include <daos_fs.h>
+#include <daos_s3.h>
 #include <daos/event.h>
 
 #define METADATA_BUCKET        "_METADATA"

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -25,8 +25,8 @@
 #include "rpc.h"
 #include "srv_internal.h"
 #include "srv_layout.h"
-#include "gurt/telemetry_common.h"
-#include "gurt/telemetry_producer.h"
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_producer.h>
 
 #define DAOS_POOL_GLOBAL_VERSION_WITH_CONT_MDTIMES 2
 #define DAOS_POOL_GLOBAL_VERSION_WITH_CONT_NHANDLES 2

--- a/src/control/cmd/daos/util.h
+++ b/src/control/cmd/daos/util.h
@@ -25,12 +25,12 @@
 #include <daos/debug.h>
 #include <gurt/common.h>
 
-#include "daos_types.h"
-#include "daos_api.h"
-#include "daos_fs.h"
-#include "daos_uns.h"
-#include "daos_mgmt.h"
-#include "dfuse_ioctl.h"
+#include <daos_types.h>
+#include <daos_api.h>
+#include <daos_fs.h>
+#include <daos_uns.h>
+#include <daos_mgmt.h>
+#include <dfuse_ioctl.h>
 
 #include "daos_hdlr.h"
 

--- a/src/gurt/examples/telem_consumer_example.c
+++ b/src/gurt/examples/telem_consumer_example.c
@@ -7,8 +7,8 @@
  * This file shows an example of using the telemetry API to consume metrics
  */
 
-#include "gurt/telemetry_common.h"
-#include "gurt/telemetry_consumer.h"
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_consumer.h>
 
 /**
  * An example that shows how metrics are read.

--- a/src/gurt/examples/telem_producer_example.c
+++ b/src/gurt/examples/telem_producer_example.c
@@ -7,8 +7,8 @@
  * This file shows an example of using the telemetry API to produce metrics
  */
 
-#include "gurt/telemetry_common.h"
-#include "gurt/telemetry_producer.h"
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_producer.h>
 
 /**
  * A sample function that creates and incremements a metric for a loop counter

--- a/src/gurt/slab.c
+++ b/src/gurt/slab.c
@@ -9,7 +9,7 @@
 #include <gurt/debug.h>
 #include <gurt/common.h>
 
-#include "gurt/slab.h"
+#include <gurt/slab.h>
 
 static void
 debug_dump(struct d_slab_type *type)

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -16,9 +16,9 @@
 #include <gurt/common.h>
 #include <gurt/list.h>
 #include <sys/shm.h>
-#include "gurt/telemetry_common.h"
-#include "gurt/telemetry_producer.h"
-#include "gurt/telemetry_consumer.h"
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_producer.h>
+#include <gurt/telemetry_consumer.h>
 
 /** minimal list of shared memory regions with a global ID */
 struct shmem_region_list {

--- a/src/gurt/tests/test_gurt_telem_producer.c
+++ b/src/gurt/tests/test_gurt_telem_producer.c
@@ -15,9 +15,9 @@
 #include <sys/shm.h>
 #include <daos/tests_lib.h>
 #include "wrap_cmocka.h"
-#include "gurt/telemetry_common.h"
-#include "gurt/telemetry_producer.h"
-#include "gurt/telemetry_consumer.h"
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_producer.h>
+#include <gurt/telemetry_consumer.h>
 
 #define STATS_EPSILON	(0.00001)
 #define TEST_IDX	(99)

--- a/src/include/dfuse_ioctl.h
+++ b/src/include/dfuse_ioctl.h
@@ -7,7 +7,7 @@
 #define __DFUSE_IOCTL_H__
 
 #include <asm/ioctl.h>
-#include "daos.h"
+#include <daos.h>
 
 #define DFUSE_IOCTL_TYPE         0xA3 /* Arbitrary "unique" type of the IOCTL */
 #define DFUSE_IOCTL_REPLY_BASE   0xC1 /* Number of the IOCTL.  Also arbitrary */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -25,7 +25,7 @@
 #include <daos_srv/dtx_srv.h>
 #include <daos_srv/security.h>
 #include <daos/checksum.h>
-#include "daos_srv/srv_csum.h"
+#include <daos_srv/srv_csum.h>
 #include "obj_rpc.h"
 #include "srv_internal.h"
 

--- a/src/pipeline/srv_pipeline.c
+++ b/src/pipeline/srv_pipeline.c
@@ -13,7 +13,7 @@
 #include <daos_srv/daos_engine.h>
 #include <daos_srv/vos.h>
 #include <daos_srv/bio.h>
-#include "daos_api.h"
+#include <daos_api.h>
 #include "pipeline_rpc.h"
 #include "pipeline_internal.h"
 

--- a/src/tests/ftest/cart/utest/utest_portnumber.c
+++ b/src/tests/ftest/cart/utest/utest_portnumber.c
@@ -41,7 +41,7 @@
 
 #include <cmocka.h>
 #include <cart/api.h>
-#include "gurt/debug.h"
+#include <gurt/debug.h>
 
 #define CHILD1_INIT_ERR			10
 #define CHILD1_CONTEXT_DESTROY_ERR	11

--- a/src/tests/ftest/cart/utest/utest_protocol.c
+++ b/src/tests/ftest/cart/utest/utest_protocol.c
@@ -9,7 +9,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <cart/api.h>
-#include "gurt/debug.h"
+#include <gurt/debug.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -29,7 +29,7 @@
 #include <sys/ioctl.h>
 #include <dirent.h>
 
-#include "dfuse_ioctl.h"
+#include <dfuse_ioctl.h>
 
 /* Tests can be run by specifying the appropriate argument for a test or all will be run if no test
  * is specified.

--- a/src/utils/daos_dfs_hdlr.c
+++ b/src/utils/daos_dfs_hdlr.c
@@ -19,10 +19,10 @@
 #include <daos/common.h>
 #include <daos/debug.h>
 
-#include "daos_types.h"
-#include "daos_fs.h"
+#include <daos_types.h>
+#include <daos_fs.h>
 #include "dfs_internal.h"
-#include "daos_uns.h"
+#include <daos_uns.h>
 #include "daos_hdlr.h"
 
 int

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -32,12 +32,12 @@
 #include <daos/debug.h>
 #include <daos/object.h>
 
-#include "daos_types.h"
-#include "daos_api.h"
-#include "daos_fs.h"
-#include "daos_uns.h"
-#include "daos_prop.h"
-#include "daos_fs_sys.h"
+#include <daos_types.h>
+#include <daos_api.h>
+#include <daos_fs.h>
+#include <daos_uns.h>
+#include <daos_prop.h>
+#include <daos_fs_sys.h>
 
 #include "daos_hdlr.h"
 

--- a/src/utils/daos_metrics/daos_metrics.c
+++ b/src/utils/daos_metrics/daos_metrics.c
@@ -10,8 +10,8 @@
 
 #include <getopt.h>
 #include <string.h>
-#include "gurt/telemetry_common.h"
-#include "gurt/telemetry_consumer.h"
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_consumer.h>
 
 static void
 print_usage(const char *prog_name)

--- a/src/utils/self_test/self_test.c
+++ b/src/utils/self_test/self_test.c
@@ -14,7 +14,7 @@
 #include <math.h>
 
 #include "crt_utils.h"
-#include "daos_errno.h"
+#include <daos_errno.h>
 
 #include <daos/agent.h>
 #include <daos/mgmt.h>


### PR DESCRIPTION
Use <> over "" in all cases for public daos header files.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
