### PR TITLE
DAOS-14707 control: Allow multiple agents simultaneously (#13465)

### DIFF
--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -48,7 +48,7 @@ type startCmd struct {
 
 func (cmd *startCmd) Execute(_ []string) error {
 	if err := common.CheckDupeProcess(); err != nil {
-		return err
+		cmd.Notice(err.Error())
 	}
 
 	cmd.Infof("Starting %s (pid %d)", versionString(), os.Getpid())
@@ -123,8 +123,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 	drpcSrvStart := time.Now()
 	err = drpcServer.Start(hwlocCtx)
 	if err != nil {
-		cmd.Errorf("Unable to start socket server on %s: %v", sockPath, err)
-		return err
+		return errors.Wrap(err, "unable to start dRPC server")
 	}
 	cmd.Debugf("dRPC socket server started: %s", time.Since(drpcSrvStart))
 

--- a/src/control/drpc/fault.go
+++ b/src/control/drpc/fault.go
@@ -1,0 +1,27 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package drpc
+
+import (
+	"fmt"
+
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
+)
+
+// FaultSocketFileInUse indicates that the dRPC socket file was already in use when we tried
+// to start the dRPC server.
+func FaultSocketFileInUse(path string) *fault.Fault {
+	return &fault.Fault{
+		Domain:      "drpc",
+		Code:        code.SocketFileInUse,
+		Description: fmt.Sprintf("Configured dRPC socket file '%s' is already in use.", path),
+		Reason:      "dRPC socket file already in use",
+		Resolution: "If another process is using the socket file, configure a different socket directory. " +
+			"Otherwise, delete the existing socket file and try again.",
+	}
+}

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -50,6 +50,7 @@ const (
 	PrivilegedHelperNotPrivileged
 	PrivilegedHelperNotAvailable
 	PrivilegedHelperRequestFailed
+	SocketFileInUse
 )
 
 // generic storage fault codes

--- a/utils/test_memcheck.supp
+++ b/utils/test_memcheck.supp
@@ -383,3 +383,9 @@
    ...
    fun:mdb_txn_commit
 }
+{
+   go_runtime_syscall_param
+   Memcheck:Param
+   write(buf)
+   fun:runtime/internal/syscall.Syscall6
+}


### PR DESCRIPTION
This allows for the case where multiple agents are used to allow a client connections to multiple systems. The agent log prints a NOTICE-level message to indicate the presence of other daos_agent processes on startup.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
