### PR TITLE
DAOS-14671 vos: cleanup active DTX entry by force

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2870,64 +2870,44 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 		return;
 
 	cont = vos_hdl2cont(dth->dth_coh);
+	dae = dth->dth_ent;
 
 	if (dth->dth_pinned) {
 		/* Only keep the DTX entry (header) for handling resend RPC,
 		 * remove DTX records, purge related VOS objects from cache.
 		 */
-		dae = dth->dth_ent;
 		if (dae != NULL)
 			dtx_act_ent_cleanup(cont, dae, dth, true);
 	} else {
 		d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
 		d_iov_set(&riov, NULL, 0);
-		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
-		if (rc == -DER_NONEXIST) {
-			rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
-			/* Cannot cleanup 'committed' DTX entry. */
-			if (rc == 0)
-				goto out;
-		}
 
-		if (rc != 0) {
-			if (rc != -DER_NONEXIST) {
-				D_ERROR("Fail to remove DTX entry "DF_DTI":"
-					DF_RC"\n",
-					DP_DTI(&dth->dth_xid), DP_RC(rc));
+		if (dae == NULL) {
+			rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+			/* Need not search committed table, since cannot cleanup 'committed' one. */
+			if (rc != 0)
+				return;
 
-				dae = dth->dth_ent;
-				if (dae != NULL) {
-					/* Cannot cleanup 'prepare'/'commit' DTX entry. */
-					if (vos_dae_is_prepare(dae) || vos_dae_is_commit(dae))
-						goto out;
-
-					dae->dae_aborted = 1;
-				}
-			} else {
-				rc = 0;
-			}
-		} else {
 			dae = (struct vos_dtx_act_ent *)riov.iov_buf;
-			if (dth->dth_ent != NULL)
-				D_ASSERT(dth->dth_ent == dae);
-
-			/* Cannot cleanup 'prepare'/'commit' DTX entry. */
-			if (vos_dae_is_prepare(dae) || vos_dae_is_commit(dae))
-				goto out;
-
-			/* Skip the @dae if it belong to another instance for resent request. */
-			if (DAE_EPOCH(dae) != dth->dth_epoch)
-				goto out;
-
-			rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_BYPASS, &kiov, &dae);
-			D_ASSERT(rc == 0);
 		}
 
-		if (dae != NULL) {
-			dtx_act_ent_cleanup(cont, dae, dth, true);
-			if (rc == 0)
-				dtx_evict_lid(cont, dae);
-		}
+		/* Cannot cleanup 'prepare'/'commit' DTX entry. */
+		if (vos_dae_is_prepare(dae) || vos_dae_is_commit(dae))
+			goto out;
+
+		/* Skip the @dae if it belong to another instance for resent request. */
+		if (DAE_EPOCH(dae) != dth->dth_epoch)
+			goto out;
+
+		dtx_act_ent_cleanup(cont, dae, dth, true);
+
+		rc = dbtree_delete(cont->vc_dtx_active_hdl,
+				   riov.iov_buf != NULL ? BTR_PROBE_BYPASS : BTR_PROBE_EQ,
+				   &kiov, &dae);
+		if (rc == 0 || rc == -DER_NONEXIST)
+			dtx_evict_lid(cont, dae);
+		else
+			dae->dae_aborted = 1;
 
 out:
 		dth->dth_ent = NULL;
@@ -2945,7 +2925,7 @@ vos_dtx_cleanup(struct dtx_handle *dth, bool unpin)
 
 	dae = dth->dth_ent;
 	if (dae == NULL) {
-		if (!dth->dth_active)
+		if (!dth->dth_active && !unpin)
 			return;
 	} else {
 		/* 'prepared'/'preparing' DTX can be either committed or aborted, not cleanup. */


### PR DESCRIPTION
In vos, when the modification hit failure, it may firstly reset related dth->dth_active and dht->dth_ent before returning to upper layer caller. And then, the caller will further handle the failure, such as abort the transaction or retry after DTX refresh. If it is not the DTX leader, it needs to cleanup related DTX entry via invoking vos_dtx_cleanup(). Such cleanup logic may be misguided by the "dth_active" and "dth_ent", as to leak the active DTX entry in DRAM. If no further DTX abort from related (dead) DTX leader, the stale DXT entry will block subsequent resent RPC with the same transaction ID.

This patch makes vos_dtx_cleanup() to check related DTX entry existence by force to cleanup.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
