### PR TITLE
DAOS-14838 gc: run in tight mode under space pressure

### DIFF
--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -1002,7 +1002,7 @@ trigger_aging_flush(struct vea_space_info *vsi, bool force, uint32_t nr_flush, u
 	D_ASSERT(umem_tx_none(vsi->vsi_umem));
 
 	cur_time = get_current_age();
-	rc = reclaim_unused_bitmap(vsi, 10);
+	rc = reclaim_unused_bitmap(vsi, MAX_FLUSH_FRAGS);
 	if (rc)
 		goto out;
 


### PR DESCRIPTION
Two fixes to accelerate space reclaiming under space pressure:

- Make VOS aggregation & GC run in tight mode when the pool is under
  space pressure, no matter if the system is busy or not.

- Bump the max number of reclaimed bitmap chunks from 10 to 256 for
  single VEA flush.

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Signed-off-by: Wang Shilong <shilong.wang@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
