### PR TITLE
DAOS-14442 control: Make NVMe auto-faulty configurable

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -480,7 +480,7 @@ boro-11
 
 - Automatic exclusion of an NVMe SSD:
 
-Automatic exclusion based on faulty criteria is the default behaviour in DAOS
+Automatic exclusion based on faulty criteria is the default behavior in DAOS
 release 2.6. The default criteria parameters are `max_io_errs: 10` and
 `max_csum_errs: <uint32_max>` (essentially eviction due to checksum errors is
 disabled by default).

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -478,6 +478,59 @@ boro-11
 ```
 #### Exclusion and Hotplug
 
+- Automatic exclusion of an NVMe SSD:
+
+Automatic exclusion based on faulty criteria is the default behaviour in DAOS
+release 2.6. The default criteria parameters are `max_io_errs: 10` and
+`max_csum_errs: <uint32_max>` (essentially eviction due to checksum errors is
+disabled by default).
+
+Setting auto-faulty criteria parameters can be done through the server config
+file by adding the following YAML to the engine section of the server config
+file.
+
+```yaml
+engines:
+-  bdev_auto_faulty:
+     enable: true
+     max_io_errs: 1
+     max_csum_errs: 2
+```
+
+On formatting the storage for the engine, these settings result in the
+following `daos_server` log entries to indicate the parameters are written to
+the engine's NVMe config:
+
+```bash
+DEBUG 13:59:29.229795 provider.go:592: BdevWriteConfigRequest: &{ForwardableRequest:{Forwarded:false} ConfigOutputPath:/mnt/daos0/daos_nvme.conf OwnerUID:10695475 OwnerGID:10695475 TierProps:[{Class:nvme DeviceList:0000:5e:00.0 DeviceFileSize:0 Tier:1 DeviceRoles:{OptionBits:0}}] HotplugEnabled:false HotplugBusidBegin:0 HotplugBusidEnd:0 Hostname:wolf-310.wolf.hpdd.intel.com AccelProps:{Engine: Options:0} SpdkRpcSrvProps:{Enable:false SockAddr:} AutoFaultyProps:{Enable:true MaxIoErrs:1 MaxCsumErrs:2} VMDEnabled:false ScannedBdevs:}
+Writing NVMe config file for engine instance 0 to "/mnt/daos0/daos_nvme.conf"
+```
+
+The engine's NVMe config (produced during format) then contains the following
+JSON to apply the criteria:
+
+```json
+[tanabarr@wolf-310 ~]$ cat /mnt/daos0/daos_nvme.conf
+{
+  "daos_data": {
+    "config": [
+      {
+        "params": {
+          "enable": true,
+          "max_io_errs": 1,
+          "max_csum_errs": 2
+        },
+        "method": "auto_faulty"
+ ...
+```
+
+These engine logfile entries indicate that the settings have been read and
+applied:
+
+```bash
+01/12-13:59:41.36 wolf-310 DAOS[1299350/-1/0] bio  INFO src/bio/bio_config.c:1016 bio_read_auto_faulty_criteria() NVMe auto faulty is enabled. Criteria: max_io_errs:1, max_csum_errs:2
+```
+
 - Manually exclude an NVMe SSD:
 ```bash
 $ dmg storage set nvme-faulty --help
@@ -491,7 +544,7 @@ Usage:
       -f, --force     Do not require confirmation
 ```
 
-To manually evict an NVMe SSD (auto eviction will be supported in a future release),
+To manually evict an NVMe SSD (auto eviction is covered later in this section),
 the device state needs to be set faulty by running the following command:
 ```bash
 $ dmg -l boro-11 storage set nvme-faulty --uuid=5bd91603-d3c7-4fb7-9a71-76bc25690c19

--- a/src/bio/README.md
+++ b/src/bio/README.md
@@ -81,7 +81,7 @@ While monitoring this health data, an admin can now make the determination to ma
 
 <a id="7"></a>
 ## Faulty Device Detection (SSD Eviction)
-Faulty device detection and reaction can be referred to as NVMe SSD eviction. This involves all affected pool targets being marked as down and the rebuild of all affected pool targets being automatically triggered. A persistent device state is maintained in SMD and the device state is updated from NORMAL to FAULTY upon SSD eviction. The faulty device reaction will involve various SPDK cleanup, including all I/O channels released, SPDK allocations (termed 'blobs') closed, and the SPDK blobstore created on the NVMe SSD unloaded. Currently only manual SSD eviction is supported, and a future release will support automatic SSD eviction.
+Faulty device detection and reaction can be referred to as NVMe SSD eviction. This involves all affected pool targets being marked as down and the rebuild of all affected pool targets being automatically triggered. A persistent device state is maintained in SMD and the device state is updated from NORMAL to FAULTY upon SSD eviction. The faulty device reaction involves various SPDK cleanup, including all I/O channels released, SPDK allocations (termed 'blobs') closed, and the SPDK blobstore created on the NVMe SSD unloaded. Automatic SSD eviction is enabled by default and can be disabled using the `bdev_auto_faulty` server config file engine parameter.
 
  Useful admin commands to manually evict an NVMe SSD:
   - <a href="#82">dmg storage set nvme-faulty</a> [used to manually set an NVMe SSD to FAULTY (ie evict the device)]
@@ -89,15 +89,15 @@ Faulty device detection and reaction can be referred to as NVMe SSD eviction. Th
 <a id="8"></a>
 ## NVMe SSD Hot Plug
 
-**Full NVMe hot plug capability will be available and supported in DAOS 2.0 release. Use is currently intended for testing only and is not supported for production.**
+NVMe hot plug with Intel VMD devices is supported in this release.
+
+**Full hot plug capability when using non-Intel-VMD devices is to be supported in DAOS 2.8 release. Use is currently intended for testing only and is not supported for production.**
 
 The NVMe hot plug feature includes device removal (an NVMe hot remove event) and device reintegration (an NVMe hotplug event) when a faulty device is replaced with a new device.
 
 For device removal, if the device is a faulty or previously evicted device, then nothing further would be done when the device is removed. The device state would be displayed as UNPLUGGED. If a healthy device that is currently in use by DAOS is removed, then all SPDK memory stubs would be deconstructed, and the device state would also display as UNPLUGGED.
 
 For device reintegration, if a new device is plugged to replace a faulty device, the admin would need to issue a device replacement command. All SPDK in-memory stubs would be created and all affected pool targets automatically reintegrated on the new device. The device state would be displayed as NEW initially and NORMAL after the replacement event occurred. If a faulty device or previously evicted device is re-plugged, the device will remain evicted, and the device state would display EVICTED. If a faulty device is desired to be reused (NOTE: this is not advised, mainly used for testing purposes), the admin can run the same device replacement command setting the new and old device IDs to be the same device ID. Reintegration will not occur on the device, as DAOS does not currently support incremental reintegration.
-
-NVMe hot plug with Intel VMD devices is currently not supported in this release, but will be supported in a future release.
 
  Useful admin commands to replace an evicted device:
   - <a href="#83">dmg storage replace nvme</a> [used to replace an evicted device with a new device]

--- a/src/bio/bio_config.c
+++ b/src/bio/bio_config.c
@@ -422,7 +422,6 @@ add_traddrs_from_bdev_subsys(struct json_config_ctx *ctx, bool vmd_enabled,
 	}
 
 	if (strcmp(cfg.method, NVME_CONF_ATTACH_CONTROLLER) != 0) {
-		D_DEBUG(DB_MGMT, "skip config entry %s\n", cfg.method);
 		goto free_method;
 	}
 
@@ -510,7 +509,6 @@ check_name_from_bdev_subsys(struct json_config_ctx *ctx)
 
 	if (strcmp(cfg.method, NVME_CONF_ATTACH_CONTROLLER) != 0 &&
 	    strcmp(cfg.method, NVME_CONF_AIO_CREATE) != 0) {
-		D_DEBUG(DB_MGMT, "skip config entry %s\n", cfg.method);
 		goto free_method;
 	}
 
@@ -754,7 +752,7 @@ decode_daos_data(const char *nvme_conf, const char *method_name, struct config_e
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	/* Capture daos object */
+	/* Capture daos_data JSON object */
 	rc = spdk_json_find(ctx->values, "daos_data", NULL, &daos_data,
 			    SPDK_JSON_VAL_OBJECT_BEGIN);
 	if (rc < 0) {
@@ -773,7 +771,6 @@ decode_daos_data(const char *nvme_conf, const char *method_name, struct config_e
 	/* Get 'config' array first configuration entry */
 	ctx->config_it = spdk_json_array_first(ctx->config);
 	if (ctx->config_it == NULL) {
-		D_DEBUG(DB_MGMT, "Empty 'daos_data' section\n");
 		/* Entry not-found so return positive RC */
 		D_GOTO(out, rc = 1);
 	}
@@ -794,7 +791,6 @@ decode_daos_data(const char *nvme_conf, const char *method_name, struct config_e
 	}
 
 	if (ctx->config_it == NULL) {
-		D_DEBUG(DB_MGMT, "No '%s' entry\n", method_name);
 		/* Entry not-found so return positive RC */
 		rc = 1;
 	}
@@ -824,8 +820,8 @@ get_hotplug_busid_range(const char *nvme_conf)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	D_DEBUG(DB_MGMT, "'%s' read from config: %X-%X\n", NVME_CONF_SET_HOTPLUG_RANGE,
-		hotplug_busid_range.begin, hotplug_busid_range.end);
+	D_INFO("'%s' read from config: %X-%X\n", NVME_CONF_SET_HOTPLUG_RANGE,
+	       hotplug_busid_range.begin, hotplug_busid_range.end);
 out:
 	if (cfg.method != NULL)
 		D_FREE(cfg.method);
@@ -907,7 +903,7 @@ bio_read_accel_props(const char *nvme_conf)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	D_DEBUG(DB_MGMT, "'%s' read from config, setting: %s, capabilities: move=%s,crc=%s\n",
+	D_INFO("'%s' read from config, setting: %s, capabilities: move=%s,crc=%s\n",
 	       NVME_CONF_SET_ACCEL_PROPS, accel_props.engine,
 	       CHK_FLAG(accel_props.opt_mask, NVME_ACCEL_FLAG_MOVE) ? "true" : "false",
 	       CHK_FLAG(accel_props.opt_mask, NVME_ACCEL_FLAG_CRC) ? "true" : "false");
@@ -960,8 +956,8 @@ bio_read_rpc_srv_settings(const char *nvme_conf, bool *enable, const char **sock
 	*enable = rpc_srv_settings.enable;
 	*sock_addr = rpc_srv_settings.sock_addr;
 
-	D_DEBUG(DB_MGMT, "'%s' read from config: enabled=%d, addr %s\n",
-		NVME_CONF_SET_SPDK_RPC_SERVER, *enable, (char *)*sock_addr);
+	D_INFO("'%s' read from config: enabled=%d, addr %s\n", NVME_CONF_SET_SPDK_RPC_SERVER,
+	       *enable, (char *)*sock_addr);
 out:
 	if (cfg.method != NULL)
 		D_FREE(cfg.method);

--- a/src/bio/bio_config.c
+++ b/src/bio/bio_config.c
@@ -982,9 +982,9 @@ int
 bio_read_auto_faulty_criteria(const char *nvme_conf, bool *enable, uint32_t *max_io_errs,
 			      uint32_t *max_csum_errs)
 {
-	struct config_entry cfg = {};
+	struct config_entry     cfg                  = {};
 	struct auto_faulty_info auto_faulty_criteria = {};
-	int                 rc;
+	int                     rc;
 
 	rc = decode_daos_data(nvme_conf, NVME_CONF_SET_AUTO_FAULTY, &cfg);
 	if (rc != 0)

--- a/src/bio/bio_config.c
+++ b/src/bio/bio_config.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2021-2023 Intel Corporation.
+ * (C) Copyright 2021-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -117,9 +117,6 @@ struct busid_range_info {
 	uint8_t	end;
 };
 
-/* PCI address bus-ID range to be used to filter hotplug events */
-struct busid_range_info hotplug_busid_range = {};
-
 static struct spdk_json_object_decoder
 busid_range_decoders[] = {
 	{"begin", offsetof(struct busid_range_info, begin), spdk_json_decode_uint8},
@@ -130,9 +127,6 @@ struct accel_props_info {
 	char		*engine;
 	uint16_t	 opt_mask;
 };
-
-/* Acceleration properties to specify engine to use and optional capabilities to enable */
-struct accel_props_info accel_props = {};
 
 static struct spdk_json_object_decoder
 accel_props_decoders[] = {
@@ -145,13 +139,22 @@ struct rpc_srv_info {
 	char	*sock_addr;
 };
 
-/* Settings to enable an SPDK JSON-RPC server to run in current process */
-struct rpc_srv_info rpc_srv_settings = {};
-
 static struct spdk_json_object_decoder
 rpc_srv_decoders[] = {
 	{"enable", offsetof(struct rpc_srv_info, enable), spdk_json_decode_bool},
 	{"sock_addr", offsetof(struct rpc_srv_info, sock_addr), spdk_json_decode_string},
+};
+
+struct auto_faulty_info {
+	bool     enable;
+	uint32_t max_io_errs;
+	uint32_t max_csum_errs;
+};
+
+static struct spdk_json_object_decoder auto_faulty_decoders[] = {
+    {"enable", offsetof(struct auto_faulty_info, enable), spdk_json_decode_bool},
+    {"max_io_errs", offsetof(struct auto_faulty_info, max_io_errs), spdk_json_decode_uint32},
+    {"max_csum_errs", offsetof(struct auto_faulty_info, max_csum_errs), spdk_json_decode_uint32},
 };
 
 static int
@@ -479,6 +482,7 @@ free_traddr:
 free_method:
 	D_FREE(cfg.method);
 
+	/* Decode functions return positive RC for success or not-found */
 	if (rc > 0)
 		rc = 0;
 	return rc;
@@ -770,7 +774,8 @@ decode_daos_data(const char *nvme_conf, const char *method_name, struct config_e
 	ctx->config_it = spdk_json_array_first(ctx->config);
 	if (ctx->config_it == NULL) {
 		D_DEBUG(DB_MGMT, "Empty 'daos_data' section\n");
-		D_GOTO(out, rc = 1); /* non-fatal */
+		/* Entry not-found so return positive RC */
+		D_GOTO(out, rc = 1);
 	}
 
 	while (ctx->config_it != NULL) {
@@ -790,12 +795,15 @@ decode_daos_data(const char *nvme_conf, const char *method_name, struct config_e
 
 	if (ctx->config_it == NULL) {
 		D_DEBUG(DB_MGMT, "No '%s' entry\n", method_name);
-		rc = 1; /* non-fatal */
+		/* Entry not-found so return positive RC */
+		rc = 1;
 	}
 out:
 	free_json_config_ctx(ctx);
 	return rc;
 }
+
+struct busid_range_info hotplug_busid_range = {};
 
 static int
 get_hotplug_busid_range(const char *nvme_conf)
@@ -821,6 +829,7 @@ get_hotplug_busid_range(const char *nvme_conf)
 out:
 	if (cfg.method != NULL)
 		D_FREE(cfg.method);
+	/* Decode functions return positive RC for success or not-found */
 	if (rc > 0)
 		rc = 0;
 	return 0;
@@ -846,6 +855,7 @@ hotplug_filter_fn(const struct spdk_pci_addr *addr)
 
 /**
  * Set hotplug bus-ID ranges in SPDK filter based on values read from JSON config file.
+ * The PCI bus-ID ranges will be used to filter hotplug events.
  *
  * \param[in]	nvme_conf	JSON config file path
  *
@@ -855,6 +865,8 @@ int
 bio_set_hotplug_filter(const char *nvme_conf)
 {
 	int	rc;
+
+	D_ASSERT(nvme_conf != NULL);
 
 	rc = get_hotplug_busid_range(nvme_conf);
 	if (rc != 0)
@@ -866,7 +878,8 @@ bio_set_hotplug_filter(const char *nvme_conf)
 }
 
 /**
- * Read optional acceleration properties from JSON config file.
+ * Read acceleration properties from JSON config file to specify which acceleration engine to use
+ * and selections of optional capabilities to enable.
  *
  * \param[in]	nvme_conf	JSON config file path
  *
@@ -876,7 +889,10 @@ int
 bio_read_accel_props(const char *nvme_conf)
 {
 	struct config_entry	 cfg = {};
+	struct accel_props_info  accel_props = {};
 	int			 rc;
+
+	D_ASSERT(nvme_conf != NULL);
 
 	rc = decode_daos_data(nvme_conf, NVME_CONF_SET_ACCEL_PROPS, &cfg);
 	if (rc != 0)
@@ -900,13 +916,16 @@ bio_read_accel_props(const char *nvme_conf)
 out:
 	if (cfg.method != NULL)
 		D_FREE(cfg.method);
+	/* Decode functions return positive RC for success or not-found */
 	if (rc > 0)
 		rc = 0;
 	return rc;
 }
 
 /**
- * Set output parameters based on JSON config settings for option SPDK JSON-RPC server.
+ * Retrieve JSON config settings for option SPDK JSON-RPC server. Read flag to indicate whether to
+ * enable the SPDK JSON-RPC server and the socket file address from the JSON config used to
+ * initialize SPDK subsystems.
  *
  * \param[in]	nvme_conf	JSON config file path
  * \param[out]	enable		Flag to enable the RPC server
@@ -918,14 +937,19 @@ int
 bio_read_rpc_srv_settings(const char *nvme_conf, bool *enable, const char **sock_addr)
 {
 	struct config_entry	 cfg = {};
+	struct rpc_srv_info      rpc_srv_settings = {};
 	int			 rc;
+
+	D_ASSERT(nvme_conf != NULL);
+	D_ASSERT(enable != NULL);
+	D_ASSERT(sock_addr != NULL);
+	D_ASSERT(*sock_addr == NULL);
 
 	rc = decode_daos_data(nvme_conf, NVME_CONF_SET_SPDK_RPC_SERVER, &cfg);
 	if (rc != 0)
 		goto out;
 
-	rc = spdk_json_decode_object(cfg.params, rpc_srv_decoders,
-				     SPDK_COUNTOF(rpc_srv_decoders),
+	rc = spdk_json_decode_object(cfg.params, rpc_srv_decoders, SPDK_COUNTOF(rpc_srv_decoders),
 				     &rpc_srv_settings);
 	if (rc < 0) {
 		D_ERROR("Failed to decode '%s' entry: %s)\n", NVME_CONF_SET_SPDK_RPC_SERVER,
@@ -941,6 +965,63 @@ bio_read_rpc_srv_settings(const char *nvme_conf, bool *enable, const char **sock
 out:
 	if (cfg.method != NULL)
 		D_FREE(cfg.method);
+	/* Decode functions return positive RC for success or not-found */
+	if (rc > 0)
+		rc = 0;
+	return rc;
+}
+
+/**
+ * Set output parameters based on JSON config settings for NVMe auto-faulty feature and threshold
+ * criteria.
+ *
+ * \param[in]	nvme_conf	JSON config file path
+ * \param[out]	enable		Flag to enable the auto-faulty feature
+ * \param[out]	max_io_errs	Max IO errors (threshold) before marking as faulty
+ * \param[out]	max_csum_errs	Max checksum errors (threshold) before marking as faulty
+ *
+ * \returns	 Zero on success, negative on failure (DER)
+ */
+int
+bio_read_auto_faulty_criteria(const char *nvme_conf, bool *enable, uint32_t *max_io_errs,
+			      uint32_t *max_csum_errs)
+{
+	struct config_entry cfg = {};
+	struct auto_faulty_info auto_faulty_criteria = {};
+	int                 rc;
+
+	rc = decode_daos_data(nvme_conf, NVME_CONF_SET_AUTO_FAULTY, &cfg);
+	if (rc != 0)
+		goto out;
+
+	rc = spdk_json_decode_object(cfg.params, auto_faulty_decoders,
+				     SPDK_COUNTOF(auto_faulty_decoders), &auto_faulty_criteria);
+	if (rc < 0) {
+		D_ERROR("Failed to decode '%s' entry: %s)\n", NVME_CONF_SET_AUTO_FAULTY,
+			spdk_strerror(-rc));
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	*enable = auto_faulty_criteria.enable;
+	if (*enable == false) {
+		*max_io_errs   = 0;
+		*max_csum_errs = 0;
+		goto out;
+	}
+	*max_io_errs = auto_faulty_criteria.max_io_errs;
+	if (*max_io_errs == 0)
+		*max_io_errs = UINT32_MAX;
+	*max_csum_errs = auto_faulty_criteria.max_csum_errs;
+	if (*max_csum_errs == 0)
+		*max_csum_errs = UINT32_MAX;
+
+out:
+	D_INFO("NVMe auto faulty is %s. Criteria: max_io_errs:%u, max_csum_errs:%u\n",
+	       *enable ? "enabled" : "disabled", *max_io_errs, *max_csum_errs);
+
+	if (cfg.method != NULL)
+		D_FREE(cfg.method);
+	/* Decode functions return positive RC for success or not-found */
 	if (rc > 0)
 		rc = 0;
 	return rc;

--- a/src/bio/bio_config.c
+++ b/src/bio/bio_config.c
@@ -1000,8 +1000,8 @@ bio_read_auto_faulty_criteria(const char *nvme_conf, bool *enable, uint32_t *max
 
 	*enable = auto_faulty_criteria.enable;
 	if (*enable == false) {
-		*max_io_errs   = 0;
-		*max_csum_errs = 0;
+		*max_io_errs   = UINT32_MAX;
+		*max_csum_errs = UINT32_MAX;
 		goto out;
 	}
 	*max_io_errs = auto_faulty_criteria.max_io_errs;

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -656,11 +656,17 @@ int fill_in_traddr(struct bio_dev_info *b_info, char *dev_name);
 
 /* bio_config.c */
 int
-    bio_add_allowed_alloc(const char *nvme_conf, struct spdk_env_opts *opts, int *roles,
-			  bool *vmd_enabled);
-int bio_set_hotplug_filter(const char *nvme_conf);
-int bio_read_accel_props(const char *nvme_conf);
-int bio_read_rpc_srv_settings(const char *nvme_conf, bool *enable, const char **sock_addr);
+bio_add_allowed_alloc(const char *nvme_conf, struct spdk_env_opts *opts, int *roles,
+		      bool *vmd_enabled);
+int
+bio_set_hotplug_filter(const char *nvme_conf);
+int
+bio_read_accel_props(const char *nvme_conf);
+int
+bio_read_rpc_srv_settings(const char *nvme_conf, bool *enable, const char **sock_addr);
+int
+bio_read_auto_faulty_criteria(const char *nvme_conf, bool *enable, uint32_t *max_io_errs,
+			      uint32_t *max_csum_errs);
 int
 bio_decode_bdev_params(struct bio_dev_info *b_info, const void *json, int json_size);
 #endif /* __BIO_INTERNAL_H__ */

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -89,15 +89,66 @@ struct bio_nvme_data {
 };
 
 static struct bio_nvme_data nvme_glb;
+struct bio_faulty_criteria  glb_criteria;
+
+static int
+bio_spdk_conf_read(struct spdk_env_opts *opts)
+{
+	bool			enable_rpc_srv = false;
+	bool                    vmd_enabled    = false;
+	int			roles = 0;
+	int                     rc;
+
+	rc = bio_add_allowed_alloc(nvme_glb.bd_nvme_conf, opts, &roles, &vmd_enabled);
+	if (rc != 0) {
+		DL_ERROR(rc, "Failed to add allowed devices to SPDK env");
+		return rc;
+	}
+	nvme_glb.bd_nvme_roles = roles;
+	bio_vmd_enabled        = vmd_enabled;
+
+	rc = bio_set_hotplug_filter(nvme_glb.bd_nvme_conf);
+	if (rc != 0) {
+		DL_ERROR(rc, "Failed to set hotplug filter");
+		return rc;
+	}
+
+	rc = bio_read_accel_props(nvme_glb.bd_nvme_conf);
+	if (rc != 0) {
+		DL_ERROR(rc, "Failed to read acceleration properties");
+		return rc;
+	}
+
+	rc = bio_read_rpc_srv_settings(nvme_glb.bd_nvme_conf, &enable_rpc_srv,
+				       &nvme_glb.bd_rpc_srv_addr);
+	if (rc != 0) {
+		DL_ERROR(rc, "Failed to read SPDK JSON-RPC server settings");
+		return rc;
+	}
+#ifdef DAOS_BUILD_RELEASE
+	if (enable_rpc_srv) {
+		D_ERROR("SPDK JSON-RPC server may not be enabled for release builds.\n");
+		return -DER_INVAL;
+	}
+#endif
+	nvme_glb.bd_enable_rpc_srv = enable_rpc_srv;
+
+	rc = bio_read_auto_faulty_criteria(nvme_glb.bd_nvme_conf, &glb_criteria.fc_enabled,
+					   &glb_criteria.fc_max_io_errs,
+					   &glb_criteria.fc_max_csum_errs);
+	if (rc != 0) {
+		DL_ERROR(rc, "Failed to read NVMe auto-faulty criteria");
+		return rc;
+	}
+
+	return 0;
+}
 
 static int
 bio_spdk_env_init(void)
 {
-	struct spdk_env_opts	opts;
-	bool			enable_rpc_srv = false;
-	bool                    vmd_enabled    = false;
-	int			rc;
-	int			roles = 0;
+	struct spdk_env_opts opts;
+	int                  rc;
 
 	/* Only print error and more severe to stderr. */
 	spdk_log_set_print_level(SPDK_LOG_ERROR);
@@ -114,45 +165,11 @@ bio_spdk_env_init(void)
 	 */
 
 	if (bio_nvme_configured(SMD_DEV_TYPE_MAX)) {
-		rc = bio_add_allowed_alloc(nvme_glb.bd_nvme_conf, &opts, &roles, &vmd_enabled);
+		rc = bio_spdk_conf_read(&opts);
 		if (rc != 0) {
-			D_ERROR("Failed to add allowed devices to SPDK env, "DF_RC"\n",
-				DP_RC(rc));
+			DL_ERROR(rc, "Failed to process nvme config");
 			goto out;
 		}
-		nvme_glb.bd_nvme_roles = roles;
-		bio_vmd_enabled        = vmd_enabled;
-
-		rc = bio_set_hotplug_filter(nvme_glb.bd_nvme_conf);
-		if (rc != 0) {
-			D_ERROR("Failed to set hotplug filter, "DF_RC"\n", DP_RC(rc));
-			goto out;
-		}
-
-		rc = bio_read_accel_props(nvme_glb.bd_nvme_conf);
-		if (rc != 0) {
-			D_ERROR("Failed to read acceleration properties, "DF_RC"\n", DP_RC(rc));
-			goto out;
-		}
-
-		/**
-		 * Read flag to indicate whether to enable the SPDK JSON-RPC server and the
-		 * socket file address from the JSON config used to initialize SPDK subsystems.
-		 */
-		rc = bio_read_rpc_srv_settings(nvme_glb.bd_nvme_conf, &enable_rpc_srv,
-					       &nvme_glb.bd_rpc_srv_addr);
-		if (rc != 0) {
-			D_ERROR("Failed to read SPDK JSON-RPC server settings, "DF_RC"\n",
-				DP_RC(rc));
-			goto out;
-		}
-#ifdef DAOS_BUILD_RELEASE
-		if (enable_rpc_srv) {
-			D_ERROR("SPDK JSON-RPC server may not be enabled for release builds.\n");
-			D_GOTO(out, rc = -DER_INVAL);
-		}
-#endif
-		nvme_glb.bd_enable_rpc_srv = enable_rpc_srv;
 	}
 
 	rc = spdk_env_init(&opts);
@@ -179,29 +196,6 @@ bool
 bypass_health_collect()
 {
 	return nvme_glb.bd_bypass_health_collect;
-}
-
-struct bio_faulty_criteria	glb_criteria;
-
-/* TODO: Make it configurable through control plane */
-static inline void
-set_faulty_criteria(void)
-{
-	glb_criteria.fc_enabled = true;
-	glb_criteria.fc_max_io_errs = 10;
-	/*
-	 * FIXME: Don't enable csum error criterion for now, otherwise, targets
-	 *	  be unexpectedly down in CSUM tests.
-	 */
-	glb_criteria.fc_max_csum_errs = UINT32_MAX;
-
-	d_getenv_bool("DAOS_NVME_AUTO_FAULTY_ENABLED", &glb_criteria.fc_enabled);
-	d_getenv_uint32_t("DAOS_NVME_AUTO_FAULTY_IO", &glb_criteria.fc_max_io_errs);
-	d_getenv_uint32_t("DAOS_NVME_AUTO_FAULTY_CSUM", &glb_criteria.fc_max_csum_errs);
-
-	D_INFO("NVMe auto faulty is %s. Criteria: max_io_errs:%u, max_csum_errs:%u\n",
-	       glb_criteria.fc_enabled ? "enabled" : "disabled",
-	       glb_criteria.fc_max_io_errs, glb_criteria.fc_max_csum_errs);
 }
 
 int
@@ -241,6 +235,14 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 		rc = dss_abterr2der(rc);
 		goto free_mutex;
 	}
+
+	glb_criteria.fc_enabled     = true;
+	glb_criteria.fc_max_io_errs = 10;
+	/*
+	 * FIXME: Don't enable csum error criterion by default otherwise targets will be
+	 *	  unexpectedly down in CSUM tests.
+	 */
+	glb_criteria.fc_max_csum_errs = UINT32_MAX;
 
 	bio_chk_cnt_init = DAOS_DMA_CHUNK_CNT_INIT;
 	bio_chk_cnt_max = DAOS_DMA_CHUNK_CNT_MAX;
@@ -332,7 +334,6 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 	       bio_nvme_configured(SMD_DEV_TYPE_META) ? "enabled" : "disabled");
 
 	bio_spdk_inited = true;
-	set_faulty_criteria();
 
 	return 0;
 

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2023 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -289,7 +289,8 @@ func TestServerConfig_Constructed(t *testing.T) {
 			WithEnvVars("CRT_TIMEOUT=30").
 			WithLogFile("/tmp/daos_engine.0.log").
 			WithLogMask("INFO").
-			WithStorageEnableHotplug(true),
+			WithStorageEnableHotplug(true).
+			WithStorageAutoFaultyCriteria(true, 100, 200),
 		engine.MockConfig().
 			WithSystemName("daos_server").
 			WithSocketDir("./.daos/daos_server").
@@ -316,7 +317,8 @@ func TestServerConfig_Constructed(t *testing.T) {
 			WithEnvVars("CRT_TIMEOUT=100").
 			WithLogFile("/tmp/daos_engine.1.log").
 			WithLogMask("INFO").
-			WithStorageEnableHotplug(true),
+			WithStorageEnableHotplug(true).
+			WithStorageAutoFaultyCriteria(false, 0, 0),
 	}
 	constructed.Path = testFile // just to avoid failing the cmp
 

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -543,8 +543,8 @@ func (c *Config) WithStorageSpdkRpcSrvProps(enable bool, sockAddr string) *Confi
 	return c
 }
 
-// WithStorageAutoFaultyProps specifies NVMe auto-faulty settings in the I/O Engine.
-func (c *Config) WithStorageAutoFaultyProps(enable bool, maxIoErrs, maxCsumErrs uint32) *Config {
+// WithStorageAutoFaultyCriteria specifies NVMe auto-faulty settings in the I/O Engine.
+func (c *Config) WithStorageAutoFaultyCriteria(enable bool, maxIoErrs, maxCsumErrs uint32) *Config {
 	c.Storage.AutoFaultyProps.Enable = enable
 	c.Storage.AutoFaultyProps.MaxIoErrs = maxIoErrs
 	c.Storage.AutoFaultyProps.MaxCsumErrs = maxCsumErrs

--- a/src/control/server/engine/config.go
+++ b/src/control/server/engine/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -540,6 +540,14 @@ func (c *Config) WithStorageAccelProps(name string, mask storage.AccelOptionBits
 func (c *Config) WithStorageSpdkRpcSrvProps(enable bool, sockAddr string) *Config {
 	c.Storage.SpdkRpcSrvProps.Enable = enable
 	c.Storage.SpdkRpcSrvProps.SockAddr = sockAddr
+	return c
+}
+
+// WithStorageAutoFaultyProps specifies NVMe auto-faulty settings in the I/O Engine.
+func (c *Config) WithStorageAutoFaultyProps(enable bool, maxIoErrs, maxCsumErrs uint32) *Config {
+	c.Storage.AutoFaultyProps.Enable = enable
+	c.Storage.AutoFaultyProps.MaxIoErrs = maxIoErrs
+	c.Storage.AutoFaultyProps.MaxCsumErrs = maxCsumErrs
 	return c
 }
 

--- a/src/control/server/storage/bdev.go
+++ b/src/control/server/storage/bdev.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -52,6 +52,7 @@ const (
 	ConfSetHotplugBusidRange     = C.NVME_CONF_SET_HOTPLUG_RANGE
 	ConfSetAccelProps            = C.NVME_CONF_SET_ACCEL_PROPS
 	ConfSetSpdkRpcServer         = C.NVME_CONF_SET_SPDK_RPC_SERVER
+	ConfSetAutoFaultyProps       = C.NVME_CONF_SET_AUTO_FAULTY
 )
 
 // Acceleration related constants for engine setting and optional capabilities.
@@ -545,6 +546,7 @@ type (
 		Hostname          string
 		AccelProps        AccelProps
 		SpdkRpcSrvProps   SpdkRpcServer
+		AutoFaultyProps   BdevAutoFaulty
 		VMDEnabled        bool
 		ScannedBdevs      NvmeControllers // VMD needs address mapping for backing devices.
 	}

--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2021-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -107,28 +107,19 @@ func TestBackend_writeJSONFile(t *testing.T) {
 	host, _ := os.Hostname()
 
 	tests := map[string]struct {
-		confIn            storage.TierConfig
-		enableVmd         bool
-		enableHotplug     bool
-		hotplugBusidRange string
-		accelEngine       string
-		accelOptMask      storage.AccelOptionBits
-		rpcSrvEnable      bool
-		rpcSrvSockAddr    string
-		autoFaultyEnable  bool
-		autoFaultyMaxIo   uint32
-		autoFaultyMaxCsum uint32
-		expErr            error
-		expOut            string
+		confIn    *engine.Config
+		enableVmd bool
+		expErr    error
+		expOut    string
 	}{
 		"nvme; single ssds": {
-			confIn: storage.TierConfig{
+			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1)...),
 				},
-			},
+			}),
 			expOut: `
 {
   "daos_data": {
@@ -177,7 +168,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 `,
 		},
 		"nvme; multiple ssds": {
-			confIn: storage.TierConfig{
+			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
@@ -186,7 +177,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 						OptionBits: storage.OptionBits(storage.BdevRoleAll),
 					},
 				},
-			},
+			}),
 			expOut: `
 {
   "daos_data": {
@@ -243,14 +234,14 @@ func TestBackend_writeJSONFile(t *testing.T) {
 `,
 		},
 		"nvme; multiple ssds; vmd enabled; bus-id range": {
-			confIn: storage.TierConfig{
+			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1, 2)...),
 					BusidRange: storage.MustNewBdevBusRange("0x80-0x8f"),
 				},
-			},
+			}),
 			enableVmd: true,
 			expOut: `
 {
@@ -317,15 +308,14 @@ func TestBackend_writeJSONFile(t *testing.T) {
 `,
 		},
 		"nvme; multiple ssds; hotplug enabled; bus-id range": {
-			confIn: storage.TierConfig{
+			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1, 2)...),
 					BusidRange: storage.MustNewBdevBusRange("0x80-0x8f"),
 				},
-			},
-			enableHotplug: true,
+			}).WithStorageEnableHotplug(true),
 			expOut: `
 {
   "daos_data": {
@@ -390,15 +380,14 @@ func TestBackend_writeJSONFile(t *testing.T) {
 `,
 		},
 		"nvme; multiple ssds; vmd and hotplug enabled": {
-			confIn: storage.TierConfig{
+			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1, 2)...),
 				},
-			},
-			enableHotplug: true,
-			enableVmd:     true,
+			}).WithStorageEnableHotplug(true),
+			enableVmd: true,
 			expOut: `
 {
   "daos_data": {
@@ -472,16 +461,15 @@ func TestBackend_writeJSONFile(t *testing.T) {
 `,
 		},
 		"nvme; single controller; acceleration set to none; move and crc opts specified": {
-			confIn: storage.TierConfig{
+			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1)...),
 				},
-			},
-			// Verify default "none" acceleration setting is ignored.
-			accelEngine:  storage.AccelEngineNone,
-			accelOptMask: storage.AccelOptCRCFlag | storage.AccelOptMoveFlag,
+				// Verify default "none" acceleration setting is ignored.
+			}).WithStorageAccelProps(storage.AccelEngineNone,
+				storage.AccelOptCRCFlag|storage.AccelOptMoveFlag),
 			expOut: `
 {
   "daos_data": {
@@ -530,15 +518,14 @@ func TestBackend_writeJSONFile(t *testing.T) {
 `,
 		},
 		"nvme; single controller; acceleration set to spdk; no opts specified": {
-			confIn: storage.TierConfig{
+			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1)...),
 				},
-			},
-			// Verify default "spdk" acceleration setting with no enable options is ignored.
-			accelEngine: storage.AccelEngineSPDK,
+				// Verify default "spdk" acceleration setting with no enable options is ignored.
+			}).WithStorageAccelProps(storage.AccelEngineSPDK, 0),
 			expOut: `
 {
   "daos_data": {
@@ -586,18 +573,74 @@ func TestBackend_writeJSONFile(t *testing.T) {
 }
 `,
 		},
-		"nvme; single controller; accel set with opts; rpc srv set": {
-			confIn: storage.TierConfig{
+		"nvme; single controller; auto faulty disabled but criteria set": {
+			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1)...),
 				},
-			},
-			accelEngine:    storage.AccelEngineSPDK,
-			accelOptMask:   storage.AccelOptCRCFlag | storage.AccelOptMoveFlag,
-			rpcSrvEnable:   true,
-			rpcSrvSockAddr: "/tmp/spdk.sock",
+				// Verify "false" auto faulty setting is ignored.
+			}).WithStorageAutoFaultyCriteria(false, 100, 200),
+			expOut: `
+{
+  "daos_data": {
+    "config": []
+  },
+  "subsystems": [
+    {
+      "subsystem": "bdev",
+      "config": [
+        {
+          "params": {
+            "bdev_io_pool_size": 65536,
+            "bdev_io_cache_size": 256
+          },
+          "method": "bdev_set_options"
+        },
+        {
+          "params": {
+            "retry_count": 4,
+            "timeout_us": 0,
+            "nvme_adminq_poll_period_us": 100000,
+            "action_on_timeout": "none",
+            "nvme_ioq_poll_period_us": 0
+          },
+          "method": "bdev_nvme_set_options"
+        },
+        {
+          "params": {
+            "enable": false,
+            "period_us": 0
+          },
+          "method": "bdev_nvme_set_hotplug"
+        },
+        {
+          "params": {
+            "trtype": "PCIe",
+            "name": "Nvme_hostfoo_0_84_0",
+            "traddr": "0000:01:00.0"
+          },
+          "method": "bdev_nvme_attach_controller"
+        }
+      ]
+    }
+  ]
+}
+`,
+		},
+		"nvme; single controller; accel set with opts; rpc srv set; auto faulty criteria": {
+			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
+				Tier:  tierID,
+				Class: storage.ClassNvme,
+				Bdev: storage.BdevConfig{
+					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1)...),
+				},
+			}).
+				WithStorageAccelProps(storage.AccelEngineSPDK,
+					storage.AccelOptCRCFlag|storage.AccelOptMoveFlag).
+				WithStorageSpdkRpcSrvProps(true, "/tmp/spdk.sock").
+				WithStorageAutoFaultyCriteria(true, 100, 200),
 			expOut: `
 {
   "daos_data": {
@@ -615,6 +658,14 @@ func TestBackend_writeJSONFile(t *testing.T) {
           "sock_addr": "/tmp/spdk.sock"
         },
         "method": "spdk_rpc_srv"
+      },
+      {
+        "params": {
+          "enable": true,
+          "max_io_errs": 100,
+          "max_csum_errs": 200
+        },
+        "method": "auto_faulty"
       }
     ]
   },
@@ -671,27 +722,10 @@ func TestBackend_writeJSONFile(t *testing.T) {
 			defer clean()
 
 			cfgOutputPath := filepath.Join(testDir, "outfile")
-			engineConfig := engine.MockConfig().
-				WithFabricProvider("test"). // valid enough to pass "not-blank" test
-				WithFabricInterface("test").
-				WithFabricInterfacePort(42).
-				WithStorage(
-					storage.NewTierConfig().
-						WithStorageClass("dcpm").
-						WithScmDeviceList("foo").
-						WithScmMountPoint("scmmnt"),
-					&tc.confIn,
-				).
-				WithStorageConfigOutputPath(cfgOutputPath).
-				WithStorageEnableHotplug(tc.enableHotplug).
-				WithStorageAccelProps(tc.accelEngine, tc.accelOptMask).
-				WithStorageSpdkRpcSrvProps(tc.rpcSrvEnable, tc.rpcSrvSockAddr).
-				WithStorageSpdkRpcSrvProps(tc.rpcSrvEnable, tc.rpcSrvSockAddr)
-			WithStorageAutoFaultyCriteria(tc.autoFaulty, tc.autoFaultyMaxIo,
-				tc.autoFaultyMaxCsum)
 
 			req, err := storage.BdevWriteConfigRequestFromConfig(test.Context(t), log,
-				&engineConfig.Storage, tc.enableVmd, storage.MockGetTopology)
+				&(tc.confIn.WithStorageConfigOutputPath(cfgOutputPath)).Storage,
+				tc.enableVmd, storage.MockGetTopology)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -115,6 +115,9 @@ func TestBackend_writeJSONFile(t *testing.T) {
 		accelOptMask      storage.AccelOptionBits
 		rpcSrvEnable      bool
 		rpcSrvSockAddr    string
+		autoFaultyEnable  bool
+		autoFaultyMaxIo   uint32
+		autoFaultyMaxCsum uint32
 		expErr            error
 		expOut            string
 	}{
@@ -682,7 +685,10 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				WithStorageConfigOutputPath(cfgOutputPath).
 				WithStorageEnableHotplug(tc.enableHotplug).
 				WithStorageAccelProps(tc.accelEngine, tc.accelOptMask).
+				WithStorageSpdkRpcSrvProps(tc.rpcSrvEnable, tc.rpcSrvSockAddr).
 				WithStorageSpdkRpcSrvProps(tc.rpcSrvEnable, tc.rpcSrvSockAddr)
+			WithStorageAutoFaultyCriteria(tc.autoFaulty, tc.autoFaultyMaxIo,
+				tc.autoFaultyMaxCsum)
 
 			req, err := storage.BdevWriteConfigRequestFromConfig(test.Context(t), log,
 				&engineConfig.Storage, tc.enableVmd, storage.MockGetTopology)

--- a/src/control/server/storage/bdev/backend_json.go
+++ b/src/control/server/storage/bdev/backend_json.go
@@ -354,6 +354,7 @@ func newSpdkConfig(log logging.Logger, req *storage.BdevWriteConfigRequest) (*Sp
 
 	accelPropSet(req, sc.DaosData)
 	rpcSrvSet(req, sc.DaosData)
+	autoFaultySet(req, sc.DaosData)
 
 	return sc.WithBdevConfigs(log, req), nil
 }

--- a/src/control/server/storage/bdev/backend_json.go
+++ b/src/control/server/storage/bdev/backend_json.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2021-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -40,7 +40,7 @@ type SetOptionsParams struct {
 	BdevIoCacheSize uint64 `json:"bdev_io_cache_size"`
 }
 
-func (sop SetOptionsParams) isSpdkSubsystemConfigParams() {}
+func (_ SetOptionsParams) isSpdkSubsystemConfigParams() {}
 
 // NvmeSetOptionsParams specifies details for a storage.ConfBdevNvmeSetOptions method.
 type NvmeSetOptionsParams struct {
@@ -51,7 +51,7 @@ type NvmeSetOptionsParams struct {
 	NvmeIoqPollPeriodUsec    uint32 `json:"nvme_ioq_poll_period_us"`
 }
 
-func (nsop NvmeSetOptionsParams) isSpdkSubsystemConfigParams() {}
+func (_ NvmeSetOptionsParams) isSpdkSubsystemConfigParams() {}
 
 // NvmeAttachControllerParams specifies details for a storage.ConfBdevNvmeAttachController
 // method.
@@ -61,7 +61,7 @@ type NvmeAttachControllerParams struct {
 	TransportAddress string `json:"traddr"`
 }
 
-func (napp NvmeAttachControllerParams) isSpdkSubsystemConfigParams() {}
+func (_ NvmeAttachControllerParams) isSpdkSubsystemConfigParams() {}
 
 // NvmeSetHotplugParams specifies details for a storage.ConfBdevNvmeSetHotplug method.
 type NvmeSetHotplugParams struct {
@@ -69,7 +69,7 @@ type NvmeSetHotplugParams struct {
 	PeriodUsec uint64 `json:"period_us"`
 }
 
-func (nshp NvmeSetHotplugParams) isSpdkSubsystemConfigParams() {}
+func (_ NvmeSetHotplugParams) isSpdkSubsystemConfigParams() {}
 
 // VmdEnableParams specifies details for a storage.ConfVmdEnable method.
 type VmdEnableParams struct{}
@@ -83,7 +83,7 @@ type AioCreateParams struct {
 	Filename   string `json:"filename"`
 }
 
-func (acp AioCreateParams) isSpdkSubsystemConfigParams() {}
+func (_ AioCreateParams) isSpdkSubsystemConfigParams() {}
 
 // HotplugBusidRangeParams specifies details for a storage.ConfSetHotplugBusidRange method.
 type HotplugBusidRangeParams struct {
@@ -91,17 +91,22 @@ type HotplugBusidRangeParams struct {
 	End   uint8 `json:"end"`
 }
 
-func (hbrp HotplugBusidRangeParams) isDaosConfigParams() {}
+func (_ HotplugBusidRangeParams) isDaosConfigParams() {}
 
 // AccelPropsParams specifies details for a storage.ConfSetAccelProps method.
 type AccelPropsParams storage.AccelProps
 
-func (app AccelPropsParams) isDaosConfigParams() {}
+func (_ AccelPropsParams) isDaosConfigParams() {}
 
 // SpdkRpcServerParams specifies details for a storage.ConfSetSpdkRpcServer method.
 type SpdkRpcServerParams storage.SpdkRpcServer
 
-func (srsp SpdkRpcServerParams) isDaosConfigParams() {}
+func (_ SpdkRpcServerParams) isDaosConfigParams() {}
+
+// AutoFaultyParams specifies details for a storage.ConfSetAutoFaultyProp method.
+type AutoFaultyParams storage.BdevAutoFaulty
+
+func (_ AutoFaultyParams) isDaosConfigParams() {}
 
 // SpdkSubsystemConfig entries apply to any SpdkSubsystem.
 type SpdkSubsystemConfig struct {
@@ -297,6 +302,17 @@ func rpcSrvSet(req *storage.BdevWriteConfigRequest, data *DaosData) {
 		data.Configs = append(data.Configs, &DaosConfig{
 			Method: storage.ConfSetSpdkRpcServer,
 			Params: SpdkRpcServerParams(props),
+		})
+	}
+}
+
+// Add NVMe auto-faulty settings to DAOS config data.
+func autoFaultySet(req *storage.BdevWriteConfigRequest, data *DaosData) {
+	props := req.AutoFaultyProps
+	if props.Enable {
+		data.Configs = append(data.Configs, &DaosConfig{
+			Method: storage.ConfSetAutoFaultyProps,
+			Params: AutoFaultyParams(props),
 		})
 	}
 }

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -1060,6 +1060,14 @@ type SpdkRpcServer struct {
 	SockAddr string `yaml:"sock_addr,omitempty" json:"sock_addr"`
 }
 
+// BdevAutoFaulty struct describes settings for detection of faulty NVMe devices within the BIO
+// module of the engine process.
+type BdevAutoFaulty struct {
+	Enable      bool   `yaml:"enable,omitempty" json:"enable"`
+	MaxIoErrs   uint32 `yaml:"max_io_errs,omitempty" json:"max_io_errs"`
+	MaxCsumErrs uint32 `yaml:"max_csum_errs,omitempty" json:"max_csum_errs"`
+}
+
 type Config struct {
 	ControlMetadata  ControlMetadata `yaml:"-"` // inherited from server
 	EngineIdx        uint            `yaml:"-"`
@@ -1070,6 +1078,7 @@ type Config struct {
 	NumaNodeIndex    uint            `yaml:"-"`
 	AccelProps       AccelProps      `yaml:"acceleration,omitempty"`
 	SpdkRpcSrvProps  SpdkRpcServer   `yaml:"spdk_rpc_server,omitempty"`
+	AutoFaultyProps  BdevAutoFaulty  `yaml:"bdev_auto_faulty,omitempty"`
 }
 
 func (c *Config) SetNUMAAffinity(node uint) {

--- a/src/control/server/storage/provider.go
+++ b/src/control/server/storage/provider.go
@@ -573,6 +573,7 @@ func BdevWriteConfigRequestFromConfig(ctx context.Context, log logging.Logger, c
 		TierProps:        []BdevTierProperties{},
 		AccelProps:       cfg.AccelProps,
 		SpdkRpcSrvProps:  cfg.SpdkRpcSrvProps,
+		AutoFaultyProps:  cfg.AutoFaultyProps,
 	}
 
 	for idx, tier := range cfg.Tiers.BdevConfigs() {

--- a/src/control/server/storage/provider_test.go
+++ b/src/control/server/storage/provider_test.go
@@ -222,6 +222,33 @@ func Test_BdevWriteRequestFromConfig(t *testing.T) {
 				},
 			},
 		},
+		"auto faulty criteria applied": {
+			cfg: &Config{
+				Tiers: TierConfigs{
+					mockScmTier,
+					NewTierConfig().WithStorageClass(ClassNvme.String()),
+				},
+				AutoFaultyProps: BdevAutoFaulty{
+					Enable:      true,
+					MaxIoErrs:   10000,
+					MaxCsumErrs: 20000,
+				},
+			},
+			getTopoFn: MockGetTopology,
+			expReq: &BdevWriteConfigRequest{
+				OwnerUID: os.Geteuid(),
+				OwnerGID: os.Getegid(),
+				TierProps: []BdevTierProperties{
+					{Class: ClassNvme},
+				},
+				Hostname: hostname,
+				AutoFaultyProps: BdevAutoFaulty{
+					Enable:      true,
+					MaxIoErrs:   10000,
+					MaxCsumErrs: 20000,
+				},
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(name)

--- a/src/include/daos_srv/control.h
+++ b/src/include/daos_srv/control.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2023 Intel Corporation.
+ * (C) Copyright 2020-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -51,6 +51,7 @@ dpdk_cli_override_opts;
 #define NVME_CONF_SET_HOTPLUG_RANGE	"hotplug_busid_range"
 #define NVME_CONF_SET_ACCEL_PROPS	"accel_props"
 #define NVME_CONF_SET_SPDK_RPC_SERVER	"spdk_rpc_srv"
+#define NVME_CONF_SET_AUTO_FAULTY       "auto_faulty"
 
 /** Supported acceleration engine settings */
 #define NVME_ACCEL_NONE		"none"

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -202,16 +202,12 @@
 #
 ## Number of hugepages to allocate for DMA buffer memory
 #
-## Optional parameter that should only be set if overriding the automatically calculated value is
-## necessary.
-#
-## Specifies the number (not size) of hugepages to allocate for use by NVMe
-## through SPDK. Note that each target requires 1 GiB of hugepage space.
-## In DAOS version 2.2 and newer, nr_hugepages specifies the total across all
-## engines on a host. It needs to represent the total amount of hugepages memory
-## required for all targets across all engines on a host, divided by the system
-## hugepage size. If not set here, it will be automatically calculated based on
-## the number of targets (using the default system hugepage size).
+## Optional parameter that should only be set if overriding the automatically calculated value is #
+## #necessary. Specifies the number (not size) of hugepages to allocate for use by NVMe through
+## #SPDK. For optimum performance each target requires 1 GiB of hugepage space. The provided value
+## should be calculated by dividing the total amount of hugepages memory required for all targets
+## across all engines on a host by the system hugepage size. If not set here, the value will be
+## automatically calculated based on the number of targets (using the default system hugepage size).
 #
 ## Example: (2 engines * (16 targets/engine * 1GiB)) / 2MiB hugepage size = 16834
 #
@@ -219,8 +215,7 @@
 #nr_hugepages: 0
 #
 ## Hugepages are mandatory with NVME SSDs configured and optional without.
-## To disable the use of hugepages when no NVMe SSDs are configured, set
-## disable_hugepages to true.
+## To disable the use of hugepages when no NVMe SSDs are configured, set disable_hugepages to true.
 #
 ## default: false
 #disable_hugepages: false

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -443,6 +443,13 @@
 #    - meta
 #    - wal
 #
+#  # Set criteria for automatic detection and eviction of faulty NVMe devices.
+#
+#  bdev_auto_faulty:
+#    enable: true
+#    max_io_errs: 100
+#    max_csum_errs: 200
+#
 #
 #-
 #  # Number of I/O service threads (and network endpoints) per engine.
@@ -591,3 +598,8 @@
 #
 #    # See about bdev_roles above.
 #    bdev_roles: [wal, meta, data]
+#
+#  # Disable automatic detection and eviction of faulty NVMe devices.
+#
+#  bdev_auto_faulty:
+#    enable: false

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -443,8 +443,10 @@
 #    - meta
 #    - wal
 #
-#  # Set criteria for automatic detection and eviction of faulty NVMe devices.
-#
+#  # Set criteria for automatic detection and eviction of faulty NVMe devices. The
+#  # default criteria parameters are `enable: true`, `max_io_errs: 10` and
+#  # `max_csum_errs: <uint32_max>` (essentially eviction due to checksum errors is
+#  # disabled by default).
 #  bdev_auto_faulty:
 #    enable: true
 #    max_io_errs: 100
@@ -599,7 +601,10 @@
 #    # See about bdev_roles above.
 #    bdev_roles: [wal, meta, data]
 #
-#  # Disable automatic detection and eviction of faulty NVMe devices.
+#  # Disable automatic detection and eviction of faulty NVMe devices. The default
+#  # criteria parameters are `enable: true`, `max_io_errs: 10` and
+#  # `max_csum_errs: <uint32_max>` (essentially eviction due to checksum errors is
+#  # disabled by default).
 #
 #  bdev_auto_faulty:
 #    enable: false


### PR DESCRIPTION
SSD auto faulty is enabled by default and criteria set  through
environment variables. Make criteria settable through the server
configuration file instead of environment variables. bdev_auto_faulty
parameter can be used to set enable, max_io_errs and max_csum_errs.

Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
