### PR TITLE
mjmac/dstress

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -129,6 +129,8 @@ def scons():
         dbenv.AppendENVPath("CGO_LDFLAGS", dblibs, sep=" ")
         install_go_bin(dbenv, 'daos', libs=['daos_cmd_hdlrs', 'dfs', 'duns', 'daos'],
                        install_man=True)
+        install_go_bin(dbenv, 'dstress', libs=['dfs', 'duns', 'daos'],
+                       install_man=False)
 
     if not prereqs.server_requested():
         return

--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
 )
 
 func dfsError(rc C.int) error {
@@ -171,7 +173,7 @@ func fsModifyAttr(cmd *fsAttrCmd, op uint32, updateAP func(*C.struct_cmd_args_s)
 	}
 	defer deallocCmdArgs()
 
-	flags := C.uint(C.DAOS_COO_RW)
+	flags := daosAPI.ContainerOpenFlag(C.DAOS_COO_RW)
 
 	ap.fs_op = op
 	if updateAP != nil {
@@ -201,7 +203,7 @@ type fsSetAttrCmd struct {
 func (cmd *fsSetAttrCmd) Execute(_ []string) error {
 	return fsModifyAttr(&cmd.fsAttrCmd, C.FS_SET_ATTR, func(ap *C.struct_cmd_args_s) {
 		if cmd.ObjectClass.Set {
-			ap.oclass = cmd.ObjectClass.Class
+			ap.oclass = C.uint(cmd.ObjectClass.Class)
 		}
 		if cmd.ChunkSize.Set {
 			ap.chunk_size = cmd.ChunkSize.Size
@@ -245,7 +247,7 @@ func (cmd *fsGetAttrCmd) Execute(_ []string) error {
 	defer deallocCmdArgs()
 
 	ap.fs_op = C.FS_GET_ATTR
-	flags := C.uint(C.DAOS_COO_RO)
+	flags := daosAPI.ContainerOpenFlag(C.DAOS_COO_RO)
 
 	cleanup, err := cmd.resolveAndConnect(flags, ap)
 	if err != nil {
@@ -330,7 +332,7 @@ func (cmd *fsFixEntryCmd) Execute(_ []string) error {
 	}
 	defer deallocCmdArgs()
 
-	flags := C.uint(C.DAOS_COO_EX)
+	flags := daosAPI.ContainerOpenFlag(C.DAOS_COO_EX)
 
 	ap.fs_op = C.FS_CHECK
 	cleanup, err := cmd.resolveAndConnect(flags, ap)
@@ -380,16 +382,16 @@ func (cmd *fsFixSBCmd) Execute(_ []string) error {
 		ap.chunk_size = cmd.ChunkSize.Size
 	}
 	if cmd.ObjectClass.Set {
-		ap.oclass = cmd.ObjectClass.Class
+		ap.oclass = C.uint(cmd.ObjectClass.Class)
 	}
 	if cmd.DirObjectClass.Set {
-		ap.dir_oclass = cmd.DirObjectClass.Class
+		ap.dir_oclass = C.uint(cmd.DirObjectClass.Class)
 	}
 	if cmd.FileObjectClass.Set {
-		ap.file_oclass = cmd.FileObjectClass.Class
+		ap.file_oclass = C.uint(cmd.FileObjectClass.Class)
 	}
 	if cmd.Mode.Set {
-		ap.mode = cmd.Mode.Mode
+		ap.mode = C.uint(cmd.Mode.Mode)
 	}
 	if cmd.CHints != "" {
 		ap.hints = C.CString(cmd.CHints)

--- a/src/control/cmd/daos/flags.go
+++ b/src/control/cmd/daos/flags.go
@@ -13,6 +13,9 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
+
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
+	"github.com/daos-stack/daos/src/control/lib/dfs"
 )
 
 /*
@@ -113,7 +116,7 @@ func (f *ChunkSizeFlag) String() string {
 
 type ObjClassFlag struct {
 	Set   bool
-	Class C.uint
+	Class daosAPI.ObjectClass
 }
 
 func (f *ObjClassFlag) UnmarshalFlag(fv string) error {
@@ -121,12 +124,8 @@ func (f *ObjClassFlag) UnmarshalFlag(fv string) error {
 		return errors.New("empty object class")
 	}
 
-	cObjClass := C.CString(fv)
-	defer freeString(cObjClass)
-
-	f.Class = (C.uint)(C.daos_oclass_name2id(cObjClass))
-	if f.Class == C.OC_UNKNOWN {
-		return errors.Errorf("unknown object class %q", fv)
+	if err := f.Class.FromString(fv); err != nil {
+		return err
 	}
 
 	f.Set = true
@@ -134,10 +133,7 @@ func (f *ObjClassFlag) UnmarshalFlag(fv string) error {
 }
 
 func (f *ObjClassFlag) String() string {
-	var oclass [10]C.char
-
-	C.daos_oclass_id2name(f.Class, &oclass[0])
-	return C.GoString(&oclass[0])
+	return f.Class.String()
 }
 
 func makeOid(hi, lo uint64) C.daos_obj_id_t {
@@ -185,18 +181,11 @@ func (f *OidFlag) UnmarshalFlag(fv string) error {
 
 type ConsModeFlag struct {
 	Set  bool
-	Mode C.uint32_t
+	Mode dfs.ConsistencyMode
 }
 
 func (f *ConsModeFlag) String() string {
-	switch f.Mode {
-	case C.DFS_RELAXED:
-		return "relaxed"
-	case C.DFS_BALANCED:
-		return "balanced"
-	default:
-		return fmt.Sprintf("unknown mode %d", f.Mode)
-	}
+	return f.Mode.String()
 }
 
 func (f *ConsModeFlag) UnmarshalFlag(fv string) error {
@@ -204,13 +193,8 @@ func (f *ConsModeFlag) UnmarshalFlag(fv string) error {
 		return errors.New("empty cons mode")
 	}
 
-	switch strings.ToLower(fv) {
-	case "relaxed":
-		f.Mode = C.DFS_RELAXED
-	case "balanced":
-		f.Mode = C.DFS_BALANCED
-	default:
-		return errors.Errorf("unknown consistency mode %q", fv)
+	if err := f.Mode.FromString(fv); err != nil {
+		return err
 	}
 
 	f.Set = true
@@ -219,14 +203,11 @@ func (f *ConsModeFlag) UnmarshalFlag(fv string) error {
 
 type ContTypeFlag struct {
 	Set  bool
-	Type C.ushort
+	Type daosAPI.ContainerLayout
 }
 
 func (f *ContTypeFlag) String() string {
-	cTypeStr := [16]C.char{}
-	C.daos_unparse_ctype(f.Type, &cTypeStr[0])
-
-	return C.GoString(&cTypeStr[0])
+	return f.Type.String()
 }
 
 func (f *ContTypeFlag) UnmarshalFlag(fv string) error {
@@ -234,12 +215,8 @@ func (f *ContTypeFlag) UnmarshalFlag(fv string) error {
 		return errors.New("empty container type")
 	}
 
-	cTypeStr := C.CString(strings.ToUpper(fv))
-	defer freeString(cTypeStr)
-
-	C.daos_parse_ctype(cTypeStr, &f.Type)
-	if f.Type == C.DAOS_PROP_CO_LAYOUT_UNKNOWN {
-		return errors.Errorf("unknown container type %q", fv)
+	if err := f.Type.FromString(fv); err != nil {
+		return err
 	}
 
 	f.Set = true

--- a/src/control/cmd/daos/flags_test.go
+++ b/src/control/cmd/daos/flags_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 )
 
 func TestFlags_EpochFlag(t *testing.T) {
@@ -316,7 +317,7 @@ func TestFlags_ObjClassFlag(t *testing.T) {
 		},
 		"invalid": {
 			arg:    "snausages",
-			expErr: errors.New("unknown object class"),
+			expErr: daos.InvalidInput,
 		},
 		"valid": {
 			arg: "S2",
@@ -362,7 +363,7 @@ func TestFlags_ConsModeFlag(t *testing.T) {
 		},
 		"invalid": {
 			arg:    "snausages",
-			expErr: errors.New("unknown consistency mode"),
+			expErr: errors.New("unknown DFS consistency mode"),
 		},
 		"relaxed": {
 			arg: "relaxed",
@@ -410,7 +411,7 @@ func TestFlags_ContTypeFlag(t *testing.T) {
 		},
 		"invalid": {
 			arg:    "snausages",
-			expErr: errors.New("unknown container type"),
+			expErr: errors.New("unknown container layout"),
 		},
 		"valid": {
 			arg: "pOsIx",

--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -63,7 +64,7 @@ func exitWithError(log logging.Logger, err error) {
 	os.Exit(1)
 }
 
-func parseOpts(args []string, opts *cliOptions, log *logging.LeveledLogger) error {
+func parseOpts(ctx context.Context, args []string, opts *cliOptions, log *logging.LeveledLogger) error {
 	var wroteJSON atm.Bool
 	p := flags.NewParser(opts, flags.Default)
 	p.Name = "daos"
@@ -105,7 +106,7 @@ or query/manage an object inside a container.`
 		}
 
 		if daosCmd, ok := cmd.(daosCaller); ok {
-			fini, err := daosCmd.initDAOS()
+			fini, err := daosCmd.initDAOS(ctx)
 			if err != nil {
 				return err
 			}
@@ -172,7 +173,8 @@ func main() {
 	var opts cliOptions
 	log := logging.NewCommandLineLogger()
 
-	if err := parseOpts(os.Args[1:], &opts, log); err != nil {
+	ctx := context.Background()
+	if err := parseOpts(ctx, os.Args[1:], &opts, log); err != nil {
 		if fe, ok := errors.Cause(err).(*flags.Error); ok && fe.Type == flags.ErrHelp {
 			log.Info(fe.Error())
 			os.Exit(0)

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -18,10 +19,10 @@ import (
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
 	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/common/proto/convert"
-	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/lib/control"
-	"github.com/daos-stack/daos/src/control/lib/ranklist"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
+	apiMocks "github.com/daos-stack/daos/src/control/lib/daos/client/mocks"
 	"github.com/daos-stack/daos/src/control/lib/ui"
 )
 
@@ -29,6 +30,61 @@ import (
 #include "util.h"
 */
 import "C"
+
+type (
+	wrappedPoolHandle struct {
+		*daosAPI.PoolHandle
+	}
+
+	wrappedPoolMock struct {
+		*apiMocks.PoolConn
+	}
+
+	poolConnection interface {
+		UUID() uuid.UUID
+		Pointer() unsafe.Pointer
+		Disconnect(context.Context) error
+		Query(context.Context, daosAPI.PoolQueryReq) (*daos.PoolInfo, error)
+		OpenContainer(context.Context, string, daosAPI.ContainerOpenFlag) (contConnection, error)
+		CreateContainer(context.Context, daosAPI.ContainerCreateReq) (*daosAPI.ContainerInfo, error)
+		DestroyContainer(context.Context, string, bool) error
+		ListContainers(context.Context, bool) ([]*daosAPI.ContainerInfo, error)
+		ListAttributes(context.Context) ([]string, error)
+		GetAttributes(context.Context, ...string) ([]*daos.Attribute, error)
+		SetAttributes(context.Context, []*daos.Attribute) error
+		DeleteAttribute(context.Context, string) error
+	}
+)
+
+func (wph *wrappedPoolHandle) UUID() uuid.UUID {
+	return wph.PoolHandle.UUID
+}
+
+func (wph *wrappedPoolHandle) OpenContainer(ctx context.Context, contID string, flags daosAPI.ContainerOpenFlag) (contConnection, error) {
+	ch, err := wph.PoolHandle.OpenContainer(ctx, contID, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	return &wrappedContHandle{ch}, nil
+}
+
+func (wpm *wrappedPoolMock) Pointer() unsafe.Pointer {
+	return unsafe.Pointer(&C.daos_handle_t{})
+}
+
+func (wpm *wrappedPoolMock) OpenContainer(ctx context.Context, contID string, flags daosAPI.ContainerOpenFlag) (contConnection, error) {
+	cm, err := wpm.PoolConn.OpenContainer(ctx, contID, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	return &wrappedContMock{cm}, nil
+}
+
+var (
+	_ poolConnection = (*wrappedPoolHandle)(nil)
+)
 
 // argOrID is used to handle a positional argument that can be a label or UUID,
 // or a non-ID positional argument to be consumed by the command handler if the
@@ -70,8 +126,8 @@ type PoolID struct {
 
 type poolBaseCmd struct {
 	daosCmd
-	poolUUID uuid.UUID
 
+	poolConn    poolConnection
 	cPoolHandle C.daos_handle_t
 
 	SysName string `long:"sys-name" short:"G" description:"DAOS system name"`
@@ -81,94 +137,73 @@ type poolBaseCmd struct {
 }
 
 func (cmd *poolBaseCmd) poolUUIDPtr() *C.uchar {
-	if cmd.poolUUID == uuid.Nil {
-		cmd.Errorf("poolUUIDPtr(): nil UUID")
-		return nil
+	poolUUID := cmd.poolUUID()
+	return (*C.uchar)(unsafe.Pointer(&poolUUID[0]))
+}
+
+func (cmd *poolBaseCmd) poolUUID() uuid.UUID {
+	if cmd.poolConn == nil || cmd.poolConn.UUID() == uuid.Nil {
+		cmd.Error("poolConn.UUID: nil UUID")
+		return uuid.Nil
 	}
-	return (*C.uchar)(unsafe.Pointer(&cmd.poolUUID[0]))
+
+	return cmd.poolConn.UUID()
 }
 
 func (cmd *poolBaseCmd) PoolID() ui.LabelOrUUIDFlag {
 	return cmd.Args.Pool.LabelOrUUIDFlag
 }
 
-func (cmd *poolBaseCmd) connectPool(flags C.uint) error {
+func (cmd *poolBaseCmd) connectPool(flags daosAPI.PoolConnectFlag) error {
 	sysName := cmd.SysName
 	if sysName == "" {
 		sysName = build.DefaultSystemName
 	}
-	cSysName := C.CString(sysName)
-	defer freeString(cSysName)
+	poolID := cmd.PoolID().String()
 
-	var rc C.int
-	switch {
-	case cmd.PoolID().HasLabel():
-		var poolInfo C.daos_pool_info_t
-		cLabel := C.CString(cmd.PoolID().Label)
-		defer freeString(cLabel)
-
-		cmd.Debugf("connecting to pool: %s", cmd.PoolID().Label)
-		rc = C.daos_pool_connect(cLabel, cSysName, flags,
-			&cmd.cPoolHandle, &poolInfo, nil)
-		if rc == 0 {
-			var err error
-			cmd.poolUUID, err = uuidFromC(poolInfo.pi_uuid)
-			if err != nil {
-				cmd.disconnectPool()
-				return err
-			}
+	if mpc := apiMocks.GetPoolConn(cmd.daosCtx); mpc != nil {
+		if err := mpc.Connect(cmd.daosCtx, poolID, sysName, flags); err != nil {
+			return err
 		}
-	case cmd.PoolID().HasUUID():
-		cmd.poolUUID = cmd.PoolID().UUID
-		cmd.Debugf("connecting to pool: %s", cmd.poolUUID)
-		cUUIDstr := C.CString(cmd.poolUUID.String())
-		defer freeString(cUUIDstr)
-		rc = C.daos_pool_connect(cUUIDstr, cSysName, flags,
-			&cmd.cPoolHandle, nil, nil)
-	default:
-		return errors.New("no pool UUID or label supplied")
+		cmd.poolConn = &wrappedPoolMock{mpc}
+	} else {
+		resp, err := daosAPI.PoolConnect(cmd.daosCtx, poolID, sysName, flags)
+		if err != nil {
+			return err
+		}
+		cmd.poolConn = &wrappedPoolHandle{resp.PoolConnection}
 	}
+	cmd.cPoolHandle = *conn2HdlPtr(cmd.poolConn)
 
-	return daosError(rc)
+	return nil
 }
 
 func (cmd *poolBaseCmd) disconnectPool() {
 	cmd.Debugf("disconnecting pool %s", cmd.PoolID())
-	// Hack for NLT fault injection testing: If the rc
-	// is -DER_NOMEM, retry once in order to actually
-	// shut down and release resources.
-	rc := C.daos_pool_disconnect(cmd.cPoolHandle, nil)
-	if rc == -C.DER_NOMEM {
-		rc = C.daos_pool_disconnect(cmd.cPoolHandle, nil)
-		// DAOS-8866, daos_pool_disconnect() might have failed, but worked anyway.
-		if rc == -C.DER_NO_HDL {
-			rc = -C.DER_SUCCESS
-		}
-	}
 
-	if err := daosError(rc); err != nil {
+	if err := cmd.poolConn.Disconnect(cmd.daosCtx); err != nil {
 		cmd.Errorf("pool disconnect failed: %s", err)
 	}
 }
 
-func (cmd *poolBaseCmd) resolveAndConnect(flags C.uint, ap *C.struct_cmd_args_s) (func(), error) {
+func (cmd *poolBaseCmd) resolveAndConnect(flags daosAPI.PoolConnectFlag, ap *C.struct_cmd_args_s) (func(), error) {
 	if err := cmd.connectPool(flags); err != nil {
 		return nil, errors.Wrapf(err,
 			"failed to connect to pool %s", cmd.PoolID())
 	}
 
 	if ap != nil {
-		if err := copyUUID(&ap.p_uuid, cmd.poolUUID); err != nil {
+		if err := copyUUID(&ap.p_uuid, cmd.poolUUID()); err != nil {
 			return nil, err
 		}
-		ap.pool = cmd.cPoolHandle
+		ap.pool = *conn2HdlPtr(cmd.poolConn)
 		switch {
 		case cmd.PoolID().HasLabel():
 			pLabel := C.CString(cmd.PoolID().Label)
 			defer freeString(pLabel)
 			C.strncpy(&ap.pool_str[0], pLabel, C.DAOS_PROP_LABEL_MAX_LEN)
 		case cmd.PoolID().HasUUID():
-			pUUIDstr := C.CString(cmd.poolUUID.String())
+			pUUIDstr := C.CString(cmd.poolUUID().String())
 			defer freeString(pUUIDstr)
 			C.strncpy(&ap.pool_str[0], pUUIDstr, C.DAOS_PROP_LABEL_MAX_LEN)
 		}
@@ -177,10 +212,6 @@ func (cmd *poolBaseCmd) resolveAndConnect(flags C.uint, ap *C.struct_cmd_args_s)
 	return func() {
 		cmd.disconnectPool()
 	}, nil
-}
-
-func (cmd *poolBaseCmd) getAttr(name string) (*attribute, error) {
-	return getDaosAttribute(cmd.cPoolHandle, poolAttr, name)
 }
 
 type poolCmd struct {
@@ -200,108 +231,9 @@ type poolQueryCmd struct {
 	ShowDisabledRanks bool `short:"b" long:"show-disabled" description:"Show engine unique identifiers (ranks) which are disabled"`
 }
 
-func convertPoolSpaceInfo(in *C.struct_daos_pool_space, mt C.uint) *mgmtpb.StorageUsageStats {
-	if in == nil {
-		return nil
-	}
-
-	return &mgmtpb.StorageUsageStats{
-		Total:     uint64(in.ps_space.s_total[mt]),
-		Free:      uint64(in.ps_space.s_free[mt]),
-		Min:       uint64(in.ps_free_min[mt]),
-		Max:       uint64(in.ps_free_max[mt]),
-		Mean:      uint64(in.ps_free_mean[mt]),
-		MediaType: mgmtpb.StorageMediaType(mt),
-	}
-}
-
-func convertPoolRebuildStatus(in *C.struct_daos_rebuild_status) *mgmtpb.PoolRebuildStatus {
-	if in == nil {
-		return nil
-	}
-
-	out := &mgmtpb.PoolRebuildStatus{
-		Status: int32(in.rs_errno),
-	}
-	if out.Status == 0 {
-		out.Objects = uint64(in.rs_obj_nr)
-		out.Records = uint64(in.rs_rec_nr)
-		switch {
-		case in.rs_version == 0:
-			out.State = mgmtpb.PoolRebuildStatus_IDLE
-		case C.get_rebuild_state(in) == C.DRS_COMPLETED:
-			out.State = mgmtpb.PoolRebuildStatus_DONE
-		default:
-			out.State = mgmtpb.PoolRebuildStatus_BUSY
-		}
-	}
-
-	return out
-}
-
-// This is not great... But it allows us to leverage the existing
-// pretty printer that dmg uses for this info. Better to find some
-// way to unify all of this and remove redundancy/manual conversion.
-//
-// We're basically doing the same thing as ds_mgmt_drpc_pool_query()
-// to stuff the info into a protobuf message and then using the
-// automatic conversion from proto to control. Kind of ugly but
-// gets the job done. We could potentially create some function
-// that's shared between this code and the drpc handlers to deal
-// with stuffing the protobuf message but it's probably overkill.
-func convertPoolInfo(pinfo *C.daos_pool_info_t) (*control.PoolQueryResp, error) {
-	pqp := new(mgmtpb.PoolQueryResp)
-
-	pqp.Uuid = uuid.Must(uuidFromC(pinfo.pi_uuid)).String()
-	pqp.TotalTargets = uint32(pinfo.pi_ntargets)
-	pqp.DisabledTargets = uint32(pinfo.pi_ndisabled)
-	pqp.ActiveTargets = uint32(pinfo.pi_space.ps_ntargets)
-	pqp.TotalEngines = uint32(pinfo.pi_nnodes)
-	pqp.Leader = uint32(pinfo.pi_leader)
-	pqp.Version = uint32(pinfo.pi_map_ver)
-
-	pqp.TierStats = []*mgmtpb.StorageUsageStats{
-		convertPoolSpaceInfo(&pinfo.pi_space, C.DAOS_MEDIA_SCM),
-		convertPoolSpaceInfo(&pinfo.pi_space, C.DAOS_MEDIA_NVME),
-	}
-	pqp.Rebuild = convertPoolRebuildStatus(&pinfo.pi_rebuild_st)
-
-	pqr := new(control.PoolQueryResp)
-	return pqr, convert.Types(pqp, pqr)
-}
-
-const (
-	dpiQuerySpace   = C.DPI_SPACE
-	dpiQueryRebuild = C.DPI_REBUILD_STATUS
-	dpiQueryAll     = C.uint64_t(^uint64(0)) // DPI_ALL is -1
-)
-
-func generateRankSet(ranklist *C.d_rank_list_t) string {
-	if ranklist.rl_nr == 0 {
-		return ""
-	}
-	ranks := uintptr(unsafe.Pointer(ranklist.rl_ranks))
-	const size = unsafe.Sizeof(uint32(0))
-	rankset := "["
-	for i := 0; i < int(ranklist.rl_nr); i++ {
-		if i > 0 {
-			rankset += ","
-		}
-		rankset += fmt.Sprint(*(*uint32)(unsafe.Pointer(ranks + uintptr(i)*size)))
-	}
-	rankset += "]"
-	return rankset
-}
-
 func (cmd *poolQueryCmd) Execute(_ []string) error {
 	if cmd.ShowEnabledRanks && cmd.ShowDisabledRanks {
 		return errors.New("show-enabled and show-disabled can't be used at the same time.")
-	}
-	var rlPtr **C.d_rank_list_t = nil
-	var rl *C.d_rank_list_t = nil
-
-	if cmd.ShowEnabledRanks || cmd.ShowDisabledRanks {
-		rlPtr = &rl
 	}
 
 	cleanup, err := cmd.resolveAndConnect(C.DAOS_PC_RO, nil)
@@ -310,40 +242,21 @@ func (cmd *poolQueryCmd) Execute(_ []string) error {
 	}
 	defer cleanup()
 
-	pinfo := C.daos_pool_info_t{
-		pi_bits: dpiQueryAll,
+	req := daosAPI.PoolQueryReq{
+		IncludeEnabled:  cmd.ShowEnabledRanks,
+		IncludeDisabled: cmd.ShowDisabledRanks,
 	}
-	if cmd.ShowDisabledRanks {
-		pinfo.pi_bits &= C.uint64_t(^(uint64(C.DPI_ENGINES_ENABLED)))
-	}
-
-	rc := C.daos_pool_query(cmd.cPoolHandle, rlPtr, &pinfo, nil, nil)
-	defer C.d_rank_list_free(rl)
-	if err := daosError(rc); err != nil {
-		return errors.Wrapf(err,
-			"failed to query pool %s", cmd.poolUUID)
-	}
-
-	pqr, err := convertPoolInfo(&pinfo)
+	poolInfo, err := cmd.poolConn.Query(cmd.daosCtx, req)
 	if err != nil {
 		return err
 	}
 
-	if rlPtr != nil {
-		if cmd.ShowEnabledRanks {
-			pqr.EnabledRanks = ranklist.MustCreateRankSet(generateRankSet(rl))
-		}
-		if cmd.ShowDisabledRanks {
-			pqr.DisabledRanks = ranklist.MustCreateRankSet(generateRankSet(rl))
-		}
-	}
-
 	if cmd.JSONOutputEnabled() {
-		return cmd.OutputJSON(pqr, nil)
+		return cmd.OutputJSON(poolInfo, nil)
 	}
 
 	var bld strings.Builder
-	if err := pretty.PrintPoolQueryResponse(pqr, &bld); err != nil {
+	if err := pretty.PrintPoolInfo(poolInfo, &bld); err != nil {
 		return err
 	}
 
@@ -360,11 +273,11 @@ type poolQueryTargetsCmd struct {
 }
 
 // For using the pretty printer that dmg uses for this target info.
-func convertPoolTargetInfo(ptinfo *C.daos_target_info_t) (*control.PoolQueryTargetInfo, error) {
-	pqti := new(control.PoolQueryTargetInfo)
-	pqti.Type = control.PoolQueryTargetType(ptinfo.ta_type)
-	pqti.State = control.PoolQueryTargetState(ptinfo.ta_state)
-	pqti.Space = []*control.StorageTargetUsage{
+func convertPoolTargetInfo(ptinfo *C.daos_target_info_t) (*daos.PoolQueryTargetInfo, error) {
+	pqti := new(daos.PoolQueryTargetInfo)
+	pqti.Type = daos.PoolQueryTargetType(ptinfo.ta_type)
+	pqti.State = daos.PoolQueryTargetState(ptinfo.ta_state)
+	pqti.Space = []*daos.StorageTargetUsage{
 		{
 			Total:     uint64(ptinfo.ta_space.s_total[C.DAOS_MEDIA_SCM]),
 			Free:      uint64(ptinfo.ta_space.s_free[C.DAOS_MEDIA_SCM]),
@@ -400,7 +313,7 @@ func (cmd *poolQueryTargetsCmd) Execute(_ []string) error {
 		rc = C.daos_pool_query_target(cmd.cPoolHandle, C.uint32_t(idxList[tgt]), C.uint32_t(cmd.Rank), ptInfo, nil)
 		if err := daosError(rc); err != nil {
 			return errors.Wrapf(err,
-				"failed to query pool %s rank:target %d:%d", cmd.poolUUID, cmd.Rank, idxList[tgt])
+				"failed to query pool %s rank:target %d:%d", cmd.poolUUID(), cmd.Rank, idxList[tgt])
 		}
 
 		tgtInfo, err := convertPoolTargetInfo(ptInfo)
@@ -424,8 +337,56 @@ func (cmd *poolQueryTargetsCmd) Execute(_ []string) error {
 	return nil
 }
 
-type poolListAttrsCmd struct {
+type poolGetOrListAttributesCmd struct {
 	poolBaseCmd
+}
+
+func (cmd *poolGetOrListAttributesCmd) listAttributes() error {
+	names, err := cmd.poolConn.ListAttributes(cmd.daosCtx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list attributes for pool %s", cmd.poolUUID())
+	}
+
+	attrList := make([]*daos.Attribute, len(names))
+	for i, name := range names {
+		attrList[i] = &daos.Attribute{Name: name}
+	}
+	var bld strings.Builder
+	title := fmt.Sprintf("Attributes for pool %s:", cmd.PoolID())
+	printAttributes(&bld, title, attrList...)
+
+	cmd.Info(bld.String())
+
+	return nil
+}
+
+func (cmd *poolGetOrListAttributesCmd) getAttributes(names ...string) error {
+	attrs, err := cmd.poolConn.GetAttributes(cmd.daosCtx, names...)
+	if err != nil {
+		return errors.Wrapf(err,
+			"failed to get attributes for pool %s",
+			cmd.PoolID())
+	}
+
+	if cmd.JSONOutputEnabled() {
+		// Maintain compatibility with older behavior.
+		if len(names) == 1 && len(attrs) == 1 {
+			return cmd.OutputJSON(attrs[0], nil)
+		}
+		return cmd.OutputJSON(attrs, nil)
+	}
+
+	var bld strings.Builder
+	title := fmt.Sprintf("Attributes for pool %s:", cmd.PoolID())
+	printAttributes(&bld, title, attrs...)
+
+	cmd.Info(bld.String())
+
+	return nil
+}
+
+type poolListAttrsCmd struct {
+	poolGetOrListAttributesCmd
 
 	Verbose bool `long:"verbose" short:"V" description:"Include values"`
 }
@@ -437,30 +398,15 @@ func (cmd *poolListAttrsCmd) Execute(_ []string) error {
 	}
 	defer cleanup()
 
-	attrs, err := listDaosAttributes(cmd.cPoolHandle, poolAttr, cmd.Verbose)
-	if err != nil {
-		return errors.Wrapf(err,
-			"failed to list attributes for pool %s", cmd.poolUUID)
+	if cmd.Verbose {
+		return cmd.getAttributes()
 	}
 
-	if cmd.JSONOutputEnabled() {
-		if cmd.Verbose {
-			return cmd.OutputJSON(attrs.asMap(), nil)
-		}
-		return cmd.OutputJSON(attrs.asList(), nil)
-	}
-
-	var bld strings.Builder
-	title := fmt.Sprintf("Attributes for pool %s:", cmd.poolUUID)
-	printAttributes(&bld, title, attrs...)
-
-	cmd.Info(bld.String())
-
-	return nil
+	return cmd.listAttributes()
 }
 
 type poolGetAttrCmd struct {
-	poolBaseCmd
+	poolGetOrListAttributesCmd
 
 	Args struct {
 		Attrs ui.GetPropertiesFlag `positional-arg-name:"key[,key...]"`
@@ -474,31 +420,11 @@ func (cmd *poolGetAttrCmd) Execute(_ []string) error {
 	}
 	defer cleanup()
 
-	var attrs attrList
 	if len(cmd.Args.Attrs.ParsedProps) == 0 {
-		attrs, err = listDaosAttributes(cmd.cPoolHandle, poolAttr, true)
+		return cmd.listAttributes()
 	} else {
-		attrs, err = getDaosAttributes(cmd.cPoolHandle, poolAttr, cmd.Args.Attrs.ParsedProps.ToSlice())
+		return cmd.getAttributes(cmd.Args.Attrs.ParsedProps.ToSlice()...)
 	}
-	if err != nil {
-		return errors.Wrapf(err, "failed to get attributes for pool %s", cmd.PoolID())
-	}
-
-	if cmd.JSONOutputEnabled() {
-		// Maintain compatibility with older behavior.
-		if len(cmd.Args.Attrs.ParsedProps) == 1 && len(attrs) == 1 {
-			return cmd.OutputJSON(attrs[0], nil)
-		}
-		return cmd.OutputJSON(attrs, nil)
-	}
-
-	var bld strings.Builder
-	title := fmt.Sprintf("Attributes for pool %s:", cmd.PoolID())
-	printAttributes(&bld, title, attrs...)
-
-	cmd.Info(bld.String())
-
-	return nil
 }
 
 type poolSetAttrCmd struct {
@@ -520,15 +446,15 @@ func (cmd *poolSetAttrCmd) Execute(_ []string) error {
 		return errors.New("attribute name and value are required")
 	}
 
-	attrs := make(attrList, 0, len(cmd.Args.Attrs.ParsedProps))
+	attrs := make([]*daos.Attribute, 0, len(cmd.Args.Attrs.ParsedProps))
 	for key, val := range cmd.Args.Attrs.ParsedProps {
-		attrs = append(attrs, &attribute{
+		attrs = append(attrs, &daos.Attribute{
 			Name:  key,
 			Value: []byte(val),
 		})
 	}
 
-	if err := setDaosAttributes(cmd.cPoolHandle, poolAttr, attrs); err != nil {
+	if err := cmd.poolConn.SetAttributes(cmd.daosCtx, attrs); err != nil {
 		return errors.Wrapf(err, "failed to set attributes on pool %s", cmd.PoolID())
 	}
 
@@ -550,10 +476,10 @@ func (cmd *poolDelAttrCmd) Execute(_ []string) error {
 	}
 	defer cleanup()
 
-	if err := delDaosAttribute(cmd.cPoolHandle, poolAttr, cmd.Args.Name); err != nil {
+	if err := cmd.poolConn.DeleteAttribute(cmd.daosCtx, cmd.Args.Name); err != nil {
 		return errors.Wrapf(err,
 			"failed to delete attribute %q on pool %s",
-			cmd.Args.Name, cmd.poolUUID)
+			cmd.Args.Name, cmd.poolUUID())
 	}
 
 	return nil
@@ -580,7 +506,7 @@ func (cmd *poolAutoTestCmd) Execute(_ []string) error {
 	defer cleanup()
 
 	ap.pool = cmd.cPoolHandle
-	if err := copyUUID(&ap.p_uuid, cmd.poolUUID); err != nil {
+	if err := copyUUID(&ap.p_uuid, cmd.poolUUID()); err != nil {
 		return err
 	}
 	ap.p_op = C.POOL_AUTOTEST
@@ -598,7 +524,7 @@ func (cmd *poolAutoTestCmd) Execute(_ []string) error {
 	rc := C.pool_autotest_hdlr(ap)
 	if err := daosError(rc); err != nil {
 		return errors.Wrapf(err, "failed to run autotest for pool %s",
-			cmd.poolUUID)
+			cmd.poolUUID())
 	}
 
 	return nil

--- a/src/control/cmd/daos/prop_flags.go
+++ b/src/control/cmd/daos/prop_flags.go
@@ -1,0 +1,219 @@
+//
+// (C) Copyright 2021-2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
+	"github.com/daos-stack/daos/src/control/lib/txtfmt"
+	"github.com/daos-stack/daos/src/control/lib/ui"
+)
+
+// PropertiesFlag implements the flags.Unmarshaler and flags.Completer
+// interfaces in order to provide a custom flag type for converting
+// command-line arguments into a *C.daos_prop_t array suitable for
+// creating a container. Use the SetPropertiesFlag type for setting
+// properties on an existing container and the GetPropertiesFlag type
+// for getting properties on an existing container.
+type PropertiesFlag struct {
+	ui.SetPropertiesFlag
+
+	props daosAPI.ContainerPropertySet
+}
+
+func (f *PropertiesFlag) Complete(match string) []flags.Completion {
+	comps := make(ui.CompletionMap)
+	for key, hdlr := range daosAPI.ContainerProperties {
+		if !f.IsSettable(key) {
+			continue
+		}
+		comps[key] = hdlr.ValueKeys()
+	}
+	f.SetCompletions(comps)
+
+	return f.SetPropertiesFlag.Complete(match)
+}
+
+func (f *PropertiesFlag) AddPropVal(key, val string) error {
+	if f.props == nil {
+		f.props = make(daosAPI.ContainerPropertySet)
+	}
+	if err := f.props.AddValue(key, val); err != nil {
+		return err
+	}
+
+	if f.ParsedProps == nil {
+		f.ParsedProps = make(map[string]string)
+	}
+	f.ParsedProps[key] = val
+
+	return nil
+}
+
+func (f *PropertiesFlag) UnmarshalFlag(fv string) error {
+	if err := f.SetPropertiesFlag.UnmarshalFlag(fv); err != nil {
+		return err
+	}
+
+	if f.props == nil {
+		f.props = make(daosAPI.ContainerPropertySet)
+	}
+	for key, val := range f.ParsedProps {
+		if err := f.props.AddValue(key, val); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// CreatePropertiesFlag embeds the base PropertiesFlag struct to
+// compose a flag that is used for setting properties on a
+// new container. It is intended to be used where only a subset of
+// properties are valid for setting on create.
+type CreatePropertiesFlag struct {
+	PropertiesFlag
+}
+
+func (f *CreatePropertiesFlag) setWritableKeys() {
+	keys := make([]string, 0, len(daosAPI.ContainerProperties))
+	for key, hdlr := range daosAPI.ContainerProperties {
+		if !hdlr.IsReadOnly() {
+			keys = append(keys, key)
+		}
+	}
+	f.SettableKeys(keys...)
+}
+
+func (f *CreatePropertiesFlag) Complete(match string) []flags.Completion {
+	f.setWritableKeys()
+
+	return f.PropertiesFlag.Complete(match)
+}
+
+func (f *CreatePropertiesFlag) UnmarshalFlag(fv string) error {
+	f.setWritableKeys()
+
+	if err := f.PropertiesFlag.UnmarshalFlag(fv); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SetPropertiesFlag embeds the base PropertiesFlag struct to
+// compose a flag that is used for setting properties on a
+// container. It is intended to be used where only a subset of
+// properties are valid for setting.
+type SetPropertiesFlag struct {
+	PropertiesFlag
+}
+
+func (f *SetPropertiesFlag) Complete(match string) []flags.Completion {
+	f.SettableKeys("label", "status")
+
+	return f.PropertiesFlag.Complete(match)
+}
+
+func (f *SetPropertiesFlag) UnmarshalFlag(fv string) error {
+	f.SettableKeys("label", "status")
+
+	if err := f.PropertiesFlag.UnmarshalFlag(fv); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type GetPropertiesFlag struct {
+	PropertiesFlag
+
+	names []string
+}
+
+func (f *GetPropertiesFlag) UnmarshalFlag(fv string) error {
+	// Accept a list of property names to fetch, if specified,
+	// otherwise just fetch all known properties.
+	f.names = strings.Split(fv, ",")
+	if fv == "" || len(f.names) == 0 || f.names[0] == "all" {
+		f.names = daosAPI.ContainerProperties.Keys()
+	}
+
+	maxNameLen := daos.MaxPropertyNameLength
+	for i, name := range f.names {
+		key := strings.TrimSpace(name)
+		if len(key) == 0 {
+			return errors.New("name must not be empty")
+		}
+		if len(key) > maxNameLen {
+			return errors.Errorf("%q: name too long (%d > %d)",
+				key, len(key), maxNameLen)
+		}
+		f.names[i] = key
+	}
+
+	return nil
+}
+
+func (f *GetPropertiesFlag) Complete(match string) (comps []flags.Completion) {
+	var prefix string
+	propNames := strings.Split(match, ",")
+	if len(propNames) > 1 {
+		match = propNames[len(propNames)-1:][0]
+		prefix = strings.Join(propNames[0:len(propNames)-1], ",")
+		prefix += ","
+	}
+
+	for propKey := range daosAPI.ContainerProperties {
+		if !f.IsSettable(propKey) {
+			continue
+		}
+
+		if strings.HasPrefix(propKey, match) {
+			comps = append(comps, flags.Completion{Item: prefix + propKey})
+		}
+	}
+
+	return
+}
+
+func printProperties(out io.Writer, header string, props daosAPI.ContainerPropertySet) {
+	fmt.Fprintf(out, "%s\n", header)
+
+	if len(props) == 0 {
+		fmt.Fprintln(out, "  No properties found.")
+		return
+	}
+
+	nameTitle := "Name"
+	valueTitle := "Value"
+	titles := []string{nameTitle}
+
+	table := []txtfmt.TableRow{}
+	for _, prop := range props {
+		row := txtfmt.TableRow{}
+		row[nameTitle] = fmt.Sprintf("%s (%s)", prop.Description, prop.Name)
+		if prop.String() != "" {
+			row[valueTitle] = prop.String()
+			if len(titles) == 1 {
+				titles = append(titles, valueTitle)
+			}
+		}
+		table = append(table, row)
+	}
+
+	tf := txtfmt.NewTableFormatter(titles...)
+	tf.InitWriter(out)
+	tf.Format(table)
+}

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -613,7 +613,7 @@ func (cmd *PoolQueryCmd) Execute(args []string) error {
 	}
 
 	var bld strings.Builder
-	if err := pretty.PrintPoolQueryResponse(resp, &bld); err != nil {
+	if err := pretty.PrintPoolInfo(&resp.PoolInfo, &bld); err != nil {
 		return err
 	}
 	cmd.Info(bld.String())

--- a/src/control/cmd/dmg/pretty/pool.go
+++ b/src/control/cmd/dmg/pretty/pool.go
@@ -21,40 +21,40 @@ import (
 
 func getTierNameText(tierIdx int) string {
 	switch tierIdx {
-	case int(control.StorageMediaTypeScm):
+	case int(daos.StorageMediaTypeScm):
 		return fmt.Sprintf("- Storage tier %d (SCM):", tierIdx)
-	case int(control.StorageMediaTypeNvme):
+	case int(daos.StorageMediaTypeNvme):
 		return fmt.Sprintf("- Storage tier %d (NVMe):", tierIdx)
 	default:
 		return fmt.Sprintf("- Storage tier %d (unknown):", tierIdx)
 	}
 }
 
-// PrintPoolQueryResponse generates a human-readable representation of the supplied
-// PoolQueryResp struct and writes it to the supplied io.Writer.
-func PrintPoolQueryResponse(pqr *control.PoolQueryResp, out io.Writer, opts ...PrintConfigOption) error {
-	if pqr == nil {
-		return errors.Errorf("nil %T", pqr)
+// PrintPoolInfo generates a human-readable representation of the supplied
+// PoolInfo struct and writes it to the supplied io.Writer.
+func PrintPoolInfo(pi *daos.PoolInfo, out io.Writer, opts ...PrintConfigOption) error {
+	if pi == nil {
+		return errors.Errorf("nil %T", pi)
 	}
 	w := txtfmt.NewErrWriter(out)
 
 	// Maintain output compatibility with the `daos pool query` output.
 	fmt.Fprintf(w, "Pool %s, ntarget=%d, disabled=%d, leader=%d, version=%d\n",
-		pqr.UUID, pqr.TotalTargets, pqr.DisabledTargets, pqr.Leader, pqr.Version)
-	if pqr.PoolLayoutVer != pqr.UpgradeLayoutVer {
+		pi.UUID, pi.TotalTargets, pi.DisabledTargets, pi.Leader, pi.Version)
+	if pi.PoolLayoutVer != pi.UpgradeLayoutVer {
 		fmt.Fprintf(w, "Pool layout out of date (%d < %d) -- see `dmg pool upgrade` for details.\n",
-			pqr.PoolLayoutVer, pqr.UpgradeLayoutVer)
+			pi.PoolLayoutVer, pi.UpgradeLayoutVer)
 	}
 	fmt.Fprintln(w, "Pool space info:")
-	if pqr.EnabledRanks != nil {
-		fmt.Fprintf(w, "- Enabled targets: %s\n", pqr.EnabledRanks)
+	if pi.EnabledRanks != nil {
+		fmt.Fprintf(w, "- Enabled targets: %s\n", pi.EnabledRanks)
 	}
-	if pqr.DisabledRanks != nil {
-		fmt.Fprintf(w, "- Disabled targets: %s\n", pqr.DisabledRanks)
+	if pi.DisabledRanks != nil {
+		fmt.Fprintf(w, "- Disabled targets: %s\n", pi.DisabledRanks)
 	}
-	fmt.Fprintf(w, "- Target(VOS) count:%d\n", pqr.ActiveTargets)
-	if pqr.TierStats != nil {
-		for tierIdx, tierStats := range pqr.TierStats {
+	fmt.Fprintf(w, "- Target(VOS) count:%d\n", pi.ActiveTargets)
+	if pi.TierStats != nil {
+		for tierIdx, tierStats := range pi.TierStats {
 			fmt.Fprintln(w, getTierNameText(tierIdx))
 			fmt.Fprintf(w, "  Total size: %s\n", humanize.Bytes(tierStats.Total))
 			fmt.Fprintf(w, "  Free: %s, min:%s, max:%s, mean:%s\n",
@@ -62,12 +62,12 @@ func PrintPoolQueryResponse(pqr *control.PoolQueryResp, out io.Writer, opts ...P
 				humanize.Bytes(tierStats.Max), humanize.Bytes(tierStats.Mean))
 		}
 	}
-	if pqr.Rebuild != nil {
-		if pqr.Rebuild.Status == 0 {
+	if pi.Rebuild != nil {
+		if pi.Rebuild.Status == 0 {
 			fmt.Fprintf(w, "Rebuild %s, %d objs, %d recs\n",
-				pqr.Rebuild.State, pqr.Rebuild.Objects, pqr.Rebuild.Records)
+				pi.Rebuild.State, pi.Rebuild.Objects, pi.Rebuild.Records)
 		} else {
-			fmt.Fprintf(w, "Rebuild failed, rc=%d, status=%d\n", pqr.Status, pqr.Rebuild.Status)
+			fmt.Fprintf(w, "Rebuild failed, status=%d\n", pi.Rebuild.Status)
 		}
 	}
 

--- a/src/control/cmd/dmg/pretty/pool_test.go
+++ b/src/control/cmd/dmg/pretty/pool_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -24,42 +25,40 @@ import (
 func TestPretty_PrintPoolQueryResp(t *testing.T) {
 	backtickStr := "`" + "dmg pool upgrade" + "`"
 	for name, tc := range map[string]struct {
-		pqr         *control.PoolQueryResp
+		pi          *daos.PoolInfo
 		expPrintStr string
 	}{
 		"empty response": {
-			pqr: &control.PoolQueryResp{},
-			expPrintStr: `
-Pool , ntarget=0, disabled=0, leader=0, version=0
+			pi: &daos.PoolInfo{},
+			expPrintStr: fmt.Sprintf(`
+Pool %s, ntarget=0, disabled=0, leader=0, version=0
 Pool space info:
 - Target(VOS) count:0
-`,
+`, test.MockUUID(0)),
 		},
 		"normal response": {
-			pqr: &control.PoolQueryResp{
-				UUID: test.MockUUID(),
-				PoolInfo: control.PoolInfo{
-					TotalTargets:     2,
-					DisabledTargets:  1,
-					ActiveTargets:    1,
-					Leader:           42,
-					Version:          100,
-					PoolLayoutVer:    1,
-					UpgradeLayoutVer: 2,
-					Rebuild: &control.PoolRebuildStatus{
-						State:   control.PoolRebuildStateBusy,
-						Objects: 42,
-						Records: 21,
+			pi: &daos.PoolInfo{
+				UUID:             test.MockPoolUUID(),
+				TotalTargets:     2,
+				DisabledTargets:  1,
+				ActiveTargets:    1,
+				Leader:           42,
+				Version:          100,
+				PoolLayoutVer:    1,
+				UpgradeLayoutVer: 2,
+				Rebuild: &daos.PoolRebuildStatus{
+					State:   daos.PoolRebuildStateBusy,
+					Objects: 42,
+					Records: 21,
+				},
+				TierStats: []*daos.StorageUsageStats{
+					{
+						Total: 2,
+						Free:  1,
 					},
-					TierStats: []*control.StorageUsageStats{
-						{
-							Total: 2,
-							Free:  1,
-						},
-						{
-							Total: 2,
-							Free:  1,
-						},
+					{
+						Total: 2,
+						Free:  1,
 					},
 				},
 			},
@@ -78,31 +77,29 @@ Rebuild busy, 42 objs, 21 recs
 `, test.MockUUID()),
 		},
 		"normal response; enabled ranks": {
-			pqr: &control.PoolQueryResp{
-				UUID: test.MockUUID(),
-				PoolInfo: control.PoolInfo{
-					TotalTargets:     2,
-					DisabledTargets:  1,
-					ActiveTargets:    1,
-					Leader:           42,
-					Version:          100,
-					PoolLayoutVer:    1,
-					UpgradeLayoutVer: 2,
-					EnabledRanks:     ranklist.MustCreateRankSet("[0,1,2]"),
-					Rebuild: &control.PoolRebuildStatus{
-						State:   control.PoolRebuildStateBusy,
-						Objects: 42,
-						Records: 21,
+			pi: &daos.PoolInfo{
+				UUID:             test.MockPoolUUID(),
+				TotalTargets:     2,
+				DisabledTargets:  1,
+				ActiveTargets:    1,
+				Leader:           42,
+				Version:          100,
+				PoolLayoutVer:    1,
+				UpgradeLayoutVer: 2,
+				EnabledRanks:     ranklist.MustCreateRankSet("[0,1,2]"),
+				Rebuild: &daos.PoolRebuildStatus{
+					State:   daos.PoolRebuildStateBusy,
+					Objects: 42,
+					Records: 21,
+				},
+				TierStats: []*daos.StorageUsageStats{
+					{
+						Total: 2,
+						Free:  1,
 					},
-					TierStats: []*control.StorageUsageStats{
-						{
-							Total: 2,
-							Free:  1,
-						},
-						{
-							Total: 2,
-							Free:  1,
-						},
+					{
+						Total: 2,
+						Free:  1,
 					},
 				},
 			},
@@ -122,31 +119,29 @@ Rebuild busy, 42 objs, 21 recs
 `, test.MockUUID()),
 		},
 		"normal response; disabled ranks": {
-			pqr: &control.PoolQueryResp{
-				UUID: test.MockUUID(),
-				PoolInfo: control.PoolInfo{
-					TotalTargets:     2,
-					DisabledTargets:  1,
-					ActiveTargets:    1,
-					Leader:           42,
-					Version:          100,
-					PoolLayoutVer:    1,
-					UpgradeLayoutVer: 2,
-					DisabledRanks:    ranklist.MustCreateRankSet("[0,1,3]"),
-					Rebuild: &control.PoolRebuildStatus{
-						State:   control.PoolRebuildStateBusy,
-						Objects: 42,
-						Records: 21,
+			pi: &daos.PoolInfo{
+				UUID:             test.MockPoolUUID(),
+				TotalTargets:     2,
+				DisabledTargets:  1,
+				ActiveTargets:    1,
+				Leader:           42,
+				Version:          100,
+				PoolLayoutVer:    1,
+				UpgradeLayoutVer: 2,
+				DisabledRanks:    ranklist.MustCreateRankSet("[0,1,3]"),
+				Rebuild: &daos.PoolRebuildStatus{
+					State:   daos.PoolRebuildStateBusy,
+					Objects: 42,
+					Records: 21,
+				},
+				TierStats: []*daos.StorageUsageStats{
+					{
+						Total: 2,
+						Free:  1,
 					},
-					TierStats: []*control.StorageUsageStats{
-						{
-							Total: 2,
-							Free:  1,
-						},
-						{
-							Total: 2,
-							Free:  1,
-						},
+					{
+						Total: 2,
+						Free:  1,
 					},
 				},
 			},
@@ -166,31 +161,29 @@ Rebuild busy, 42 objs, 21 recs
 `, test.MockUUID()),
 		},
 		"unknown/invalid rebuild state response": {
-			pqr: &control.PoolQueryResp{
-				UUID: test.MockUUID(),
-				PoolInfo: control.PoolInfo{
-					TotalTargets:     2,
-					DisabledTargets:  1,
-					ActiveTargets:    1,
-					Leader:           42,
-					Version:          100,
-					PoolLayoutVer:    1,
-					UpgradeLayoutVer: 2,
-					DisabledRanks:    ranklist.MustCreateRankSet("[0,1,3]"),
-					Rebuild: &control.PoolRebuildStatus{
-						State:   42,
-						Objects: 42,
-						Records: 21,
+			pi: &daos.PoolInfo{
+				UUID:             test.MockPoolUUID(),
+				TotalTargets:     2,
+				DisabledTargets:  1,
+				ActiveTargets:    1,
+				Leader:           42,
+				Version:          100,
+				PoolLayoutVer:    1,
+				UpgradeLayoutVer: 2,
+				DisabledRanks:    ranklist.MustCreateRankSet("[0,1,3]"),
+				Rebuild: &daos.PoolRebuildStatus{
+					State:   42,
+					Objects: 42,
+					Records: 21,
+				},
+				TierStats: []*daos.StorageUsageStats{
+					{
+						Total: 2,
+						Free:  1,
 					},
-					TierStats: []*control.StorageUsageStats{
-						{
-							Total: 2,
-							Free:  1,
-						},
-						{
-							Total: 2,
-							Free:  1,
-						},
+					{
+						Total: 2,
+						Free:  1,
 					},
 				},
 			},
@@ -210,31 +203,29 @@ Rebuild unknown, 42 objs, 21 recs
 `, test.MockUUID()),
 		},
 		"rebuild failed": {
-			pqr: &control.PoolQueryResp{
-				UUID: test.MockUUID(),
-				PoolInfo: control.PoolInfo{
-					TotalTargets:     2,
-					DisabledTargets:  1,
-					ActiveTargets:    1,
-					Leader:           42,
-					Version:          100,
-					PoolLayoutVer:    1,
-					UpgradeLayoutVer: 2,
-					Rebuild: &control.PoolRebuildStatus{
-						Status:  2,
-						State:   control.PoolRebuildStateBusy,
-						Objects: 42,
-						Records: 21,
+			pi: &daos.PoolInfo{
+				UUID:             test.MockPoolUUID(),
+				TotalTargets:     2,
+				DisabledTargets:  1,
+				ActiveTargets:    1,
+				Leader:           42,
+				Version:          100,
+				PoolLayoutVer:    1,
+				UpgradeLayoutVer: 2,
+				Rebuild: &daos.PoolRebuildStatus{
+					Status:  2,
+					State:   daos.PoolRebuildStateBusy,
+					Objects: 42,
+					Records: 21,
+				},
+				TierStats: []*daos.StorageUsageStats{
+					{
+						Total: 2,
+						Free:  1,
 					},
-					TierStats: []*control.StorageUsageStats{
-						{
-							Total: 2,
-							Free:  1,
-						},
-						{
-							Total: 2,
-							Free:  1,
-						},
+					{
+						Total: 2,
+						Free:  1,
 					},
 				},
 			},
@@ -249,13 +240,13 @@ Pool space info:
 - Storage tier 1 (NVMe):
   Total size: 2 B
   Free: 1 B, min:0 B, max:0 B, mean:0 B
-Rebuild failed, rc=0, status=2
+Rebuild failed, status=2
 `, test.MockUUID()),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var bld strings.Builder
-			if err := PrintPoolQueryResponse(tc.pqr, &bld); err != nil {
+			if err := PrintPoolInfo(tc.pi, &bld); err != nil {
 				t.Fatal(err)
 			}
 
@@ -284,11 +275,11 @@ func TestPretty_PrintPoolQueryTargetResp(t *testing.T) {
 		"valid: single target (unknown, down_out)": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  0,
-						State: control.PoolTargetStateDownOut,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDownOut,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -314,11 +305,11 @@ Target: type unknown, state down_out
 		"valid: single target (unknown, down)": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  0,
-						State: control.PoolTargetStateDown,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDown,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -344,11 +335,11 @@ Target: type unknown, state down
 		"valid: single target (unknown, up)": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  0,
-						State: control.PoolTargetStateUp,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUp,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -374,11 +365,11 @@ Target: type unknown, state up
 		"valid: single target (unknown, up_in)": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  0,
-						State: control.PoolTargetStateUpIn,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUpIn,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -404,11 +395,11 @@ Target: type unknown, state up_in
 		"valid: single target (unknown, new)": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  0,
-						State: control.PoolTargetStateNew,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateNew,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -434,11 +425,11 @@ Target: type unknown, state new
 		"valid: single target (unknown, drain)": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  0,
-						State: control.PoolTargetStateDrain,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDrain,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -464,11 +455,11 @@ Target: type unknown, state drain
 		"valid: multiple target (mixed statuses exclude 2 targets in progress)": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  0,
-						State: control.PoolTargetStateDown,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDown,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -481,8 +472,8 @@ Target: type unknown, state drain
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateUpIn,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUpIn,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -495,8 +486,8 @@ Target: type unknown, state drain
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateDownOut,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDownOut,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -509,8 +500,8 @@ Target: type unknown, state drain
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateUpIn,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUpIn,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -557,11 +548,11 @@ Target: type unknown, state up_in
 		"invalid target state": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  0,
 						State: 42,
-						Space: []*control.StorageTargetUsage{
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -574,8 +565,8 @@ Target: type unknown, state up_in
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateUpIn,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUpIn,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -588,8 +579,8 @@ Target: type unknown, state up_in
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateDownOut,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDownOut,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -602,8 +593,8 @@ Target: type unknown, state up_in
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateUpIn,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUpIn,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -650,11 +641,11 @@ Target: type unknown, state up_in
 		"invalid target type": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  42,
-						State: control.PoolTargetStateDown,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDown,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -667,8 +658,8 @@ Target: type unknown, state up_in
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateUpIn,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUpIn,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -681,8 +672,8 @@ Target: type unknown, state up_in
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateDownOut,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDownOut,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -695,8 +686,8 @@ Target: type unknown, state up_in
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateUpIn,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUpIn,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -743,11 +734,11 @@ Target: type unknown, state up_in
 		"three tiers; third tier unknown StorageMediaType": {
 			pqtr: &control.PoolQueryTargetResp{
 				Status: 0,
-				Infos: []*control.PoolQueryTargetInfo{
+				Infos: []*daos.PoolQueryTargetInfo{
 					{
 						Type:  0,
-						State: control.PoolTargetStateDown,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDown,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -764,8 +755,8 @@ Target: type unknown, state up_in
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateUpIn,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUpIn,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -782,8 +773,8 @@ Target: type unknown, state up_in
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateDownOut,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateDownOut,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,
@@ -800,8 +791,8 @@ Target: type unknown, state up_in
 					},
 					{
 						Type:  0,
-						State: control.PoolTargetStateUpIn,
-						Space: []*control.StorageTargetUsage{
+						State: daos.PoolTargetStateUpIn,
+						Space: []*daos.StorageTargetUsage{
 							{
 								Total: 6000000000,
 								Free:  5000000000,

--- a/src/control/cmd/dstress/connect.go
+++ b/src/control/cmd/dstress/connect.go
@@ -1,0 +1,416 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/pkg/errors"
+
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
+	"github.com/daos-stack/daos/src/control/lib/dfs"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+const (
+	defBufSize = 16*1024 + 1 // Big enough to not be inlined
+)
+
+type connectStressCmd struct {
+	daosCmd
+
+	Append  bool   `long:"append" short:"a" description:"Keep appending to the test file up to max size"`
+	Rewrite bool   `long:"rewrite" short:"r" description:"Rewrite the test file instead of recreating it"`
+	Check   bool   `long:"checksum" short:"k" description:"Enable checksum verification of read buffer"`
+	Dir     string `long:"test-dir" short:"d" description:"Parent directory for test files" default:"/testDir"`
+	Count   uint   `long:"count" short:"c" description:"Connection count for this pool"`
+	PerProc bool   `long:"per-proc" short:"p" description:"Each connection is made in a new process"`
+	Size    string `long:"size" short:"s" description:"Size of per-client test buffer or max file size"`
+	Args    struct {
+		Pool      string `positional-arg-name:"pool" required:"true"`
+		Container string `positional-arg-name:"container" required:"true"`
+	} `positional-args:"true"`
+}
+
+func newDaosClient(ctx context.Context, log logging.Logger, pool, cont string, cfg *clientCfg) (*daosClient, error) {
+	if cfg == nil {
+		cfg = &clientCfg{}
+	}
+	return &daosClient{
+		log:  log,
+		cfg:  cfg,
+		pool: pool,
+		cont: cont,
+	}, nil
+}
+
+type clientCfg struct {
+	testDir   string
+	append    bool
+	checkSums bool
+	rewrite   bool
+	fileSize  uint64
+	stats     *clientStats
+}
+
+type daosClient struct {
+	log  logging.Logger
+	cfg  *clientCfg
+	pool string
+	cont string
+}
+
+type statsReadWriter struct {
+	w     io.Writer
+	r     io.Reader
+	stats *clientStats
+}
+
+func (srw *statsReadWriter) Write(buf []byte) (int, error) {
+	n, err := srw.w.Write(buf)
+	srw.stats.AddWrite(uint64(n))
+	return n, err
+}
+
+func (srw *statsReadWriter) Read(buf []byte) (int, error) {
+	n, err := srw.r.Read(buf)
+	srw.stats.AddWrite(uint64(n))
+	return n, err
+}
+
+func (c *daosClient) Start(ctx context.Context, idx uint, testBuf []byte, errOut chan<- error) {
+	openResp, err := daosAPI.PoolConnect(ctx, c.pool, "", daosAPI.PoolConnectFlagReadWrite)
+	if err != nil {
+		errOut <- err
+		return
+	}
+	poolHdl := openResp.PoolConnection
+
+	contHdl, err := poolHdl.OpenContainer(ctx, c.cont, daosAPI.ContainerOpenFlagReadWrite)
+	if err != nil {
+		errOut <- err
+		return
+	}
+
+	fs, err := dfs.Mount(poolHdl, contHdl, os.O_RDWR, dfs.SysFlagNoCache)
+	if err != nil {
+		errOut <- err
+		return
+	}
+
+	if err := fs.MkdirAll(c.cfg.testDir, 0755); err != nil {
+		errOut <- err
+		return
+	}
+	testFile := fmt.Sprintf("/%s/test-%d", c.cfg.testDir, idx)
+	c.log.Debugf("connecting client %d to %s", idx, testFile)
+
+	var f *dfs.File
+	defer func() {
+		if f != nil {
+			if err := f.Close(); err != nil {
+				c.log.Errorf("failed to close %s: %s", testFile, err)
+			}
+		}
+		if fs != nil {
+			if err := fs.Unmount(); err != nil {
+				c.log.Errorf("failed to unmount DFS: %s", err)
+			}
+		}
+		if contHdl != nil {
+			if err := contHdl.Close(ctx); err != nil {
+				c.log.Errorf("failed to close container: %s", err)
+			}
+		}
+		if poolHdl != nil {
+			if err := poolHdl.Disconnect(ctx); err != nil {
+				c.log.Errorf("failed to disconnect pool: %s", err)
+			}
+		}
+	}()
+
+	if c.cfg.append {
+		f, err = fs.Create(testFile)
+		if err != nil {
+			c.log.Errorf("failed to open %s: %s", testFile, err)
+			errOut <- err
+			return
+		}
+
+		srw := &statsReadWriter{
+			stats: c.cfg.stats,
+			r:     io.LimitReader(rand.Reader, int64(c.cfg.fileSize)),
+		}
+		if _, err = f.ReadFrom(srw); err != nil {
+			c.log.Errorf("failed to write to %s: %s", testFile, err)
+			errOut <- err
+		} else {
+			errOut <- nil
+		}
+
+		return
+	}
+
+	var writeSum uint32
+	if c.cfg.checkSums {
+		writeSum = crc32.ChecksumIEEE(testBuf)
+	}
+
+	readBuf := make([]byte, len(testBuf))
+	for {
+		select {
+		case <-ctx.Done():
+			errOut <- nil
+			return
+		default:
+			if f == nil {
+				f, err = fs.Create(testFile)
+				if err != nil {
+					c.log.Errorf("failed to open %s: %s", testFile, err)
+					errOut <- err
+					return
+				}
+			}
+
+			writeCount, err := f.WriteAt(testBuf, 0)
+			if err != nil {
+				errOut <- errors.Wrap(err, "write error")
+				return
+			}
+			c.cfg.stats.AddWrite(uint64(writeCount))
+
+			readCount, err := f.ReadAt(readBuf, 0)
+			if err != nil {
+				errOut <- errors.Wrap(err, "read error")
+				return
+			}
+			c.cfg.stats.AddRead(uint64(readCount))
+			if readCount != len(testBuf) {
+				c.log.Errorf("%s: short read(%d < %d)", testFile, readCount, len(testBuf))
+				continue
+			}
+
+			if c.cfg.checkSums {
+				readSum := crc32.ChecksumIEEE(readBuf)
+				if readSum != writeSum {
+					c.log.Errorf("invalid checksum (%d != %d) on read", readSum, writeSum)
+					continue
+				}
+			}
+
+			if !c.cfg.rewrite {
+				if err := f.Close(); err != nil {
+					errOut <- errors.Wrapf(err, "failed to close %s", testFile)
+					return
+				}
+
+				if err := fs.Remove(testFile); err != nil {
+					errOut <- errors.Wrapf(err, "failed to remove %s", testFile)
+					return
+				}
+
+				f = nil
+			}
+		}
+	}
+}
+
+type clientStats struct {
+	readBytes  uint64
+	writeBytes uint64
+}
+
+func (cs *clientStats) AddRead(read uint64) {
+	if cs == nil {
+		return
+	}
+	atomic.AddUint64(&cs.readBytes, read)
+}
+
+func (cs *clientStats) GetRead() uint64 {
+	if cs == nil {
+		return 0
+	}
+	return atomic.LoadUint64(&cs.readBytes)
+}
+
+func (cs *clientStats) AddWrite(write uint64) {
+	if cs == nil {
+		return
+	}
+	atomic.AddUint64(&cs.writeBytes, write)
+}
+
+func (cs *clientStats) GetWrite() uint64 {
+	if cs == nil {
+		return 0
+	}
+	return atomic.LoadUint64(&cs.writeBytes)
+}
+
+func (cmd *connectStressCmd) Execute(args []string) error {
+	var quiet bool
+	for _, arg := range args {
+		if arg == "quiet" {
+			quiet = true
+		}
+	}
+
+	var connections uint
+	defer func() {
+		cmd.Infof("Connection count at exit: %d", connections)
+	}()
+	if cmd.Count == 0 {
+		cmd.Count = 1
+	}
+
+	if cmd.Size == "" {
+		cmd.Size = "0"
+	}
+	bufSize, err := humanize.ParseBytes(cmd.Size)
+	if err != nil {
+		return errors.Wrapf(err, "unable to parse %q", cmd.Size)
+	}
+	if bufSize == 0 {
+		bufSize = defBufSize
+	}
+
+	if cmd.Append && cmd.Rewrite {
+		return errors.New("--append and --rewrite are incompatible")
+	}
+	if cmd.Append && cmd.Check {
+		return errors.New("--check is not available with --append")
+	}
+
+	var testBuf []byte
+	if !cmd.Append {
+		testBuf = make([]byte, bufSize)
+		if _, err := rand.Reader.Read(testBuf); err != nil {
+			return errors.Wrap(err, "failed to fill testBuf")
+		}
+	}
+
+	cs := new(clientStats)
+	ctx, cancel := context.WithCancel(cmd.daosCtx)
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go func() {
+		sig := <-sigChan
+		cmd.Infof("\ncaught %s; cleaning up\n", sig)
+		cancel()
+	}()
+
+	var wg sync.WaitGroup
+	errChan := make(chan error)
+	go func() {
+		for {
+			err := <-errChan
+			wg.Done()
+			if err != nil {
+				cmd.Errorf("client error: %s", err)
+				cancel()
+			}
+		}
+	}()
+
+	if cmd.PerProc {
+		quiet = true
+	}
+
+	for ; ctx.Err() == nil && connections < cmd.Count; connections++ {
+		cfg := &clientCfg{
+			testDir:   filepath.Clean(cmd.Dir),
+			stats:     cs,
+			checkSums: cmd.Check,
+			rewrite:   cmd.Rewrite,
+			append:    cmd.Append,
+			fileSize:  bufSize,
+		}
+
+		if cmd.PerProc && cmd.Count > 1 {
+			idx := connections
+			args := []string{"connect", cmd.Args.Pool, cmd.Args.Container, "--quiet"}
+			if cfg.testDir != "" {
+				args = append(args, "-d", fmt.Sprintf("%s/%d", cfg.testDir, idx))
+			}
+			if cfg.checkSums {
+				args = append(args, "-k")
+			}
+			if cfg.rewrite {
+				args = append(args, "-r")
+			}
+			if cfg.append {
+				args = append(args, "-a")
+			}
+			if cmd.Size != "" {
+				args = append(args, "-s", cmd.Size)
+			}
+
+			go func() {
+				eCmd := exec.CommandContext(ctx, os.Args[0], args...)
+				eCmd.Stdout = os.Stdout
+				eCmd.Stderr = os.Stderr
+				eCmd.Cancel = func() error {
+					return eCmd.Process.Signal(os.Interrupt)
+				}
+				if err := eCmd.Run(); err != nil && !errors.Is(err, context.Canceled) {
+					errChan <- errors.Wrapf(err, "child %d run failed", idx)
+					return
+				}
+				errChan <- nil
+			}()
+			wg.Add(1)
+		} else {
+			client, err := newDaosClient(cmd.daosCtx, cmd, cmd.Args.Pool, cmd.Args.Container, cfg)
+			if err != nil {
+				return err
+			}
+			wg.Add(1)
+
+			go client.Start(ctx, connections, testBuf, errChan)
+			if !quiet {
+				fmt.Fprintf(os.Stderr, "Connections: %d\r", connections+1)
+			}
+		}
+	}
+
+	cmd.Infof("\nEstablished %d connections", connections)
+	if !quiet {
+		go func() {
+			interval := time.Second
+			var lastRead uint64
+			var lastWrite uint64
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					curRead := cs.GetRead()
+					readDelta := curRead - lastRead
+					lastRead = curRead
+					curWrite := cs.GetWrite()
+					writeDelta := curWrite - lastWrite
+					lastWrite = curWrite
+
+					fmt.Fprintf(os.Stderr, "read: %s/s, write: %s/s\r",
+						humanize.Bytes(readDelta), humanize.Bytes(writeDelta))
+					time.Sleep(interval)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	return nil
+}

--- a/src/control/cmd/dstress/main.go
+++ b/src/control/cmd/dstress/main.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path"
+	"runtime/debug"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/cmdutil"
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/lib/atm"
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+type daosCmd struct {
+	daosCtx context.Context
+	cmdutil.LogCmd
+	cmdutil.NoArgsCmd
+	cmdutil.JSONOutputCmd
+}
+
+func (cmd *daosCmd) setCtx(ctx context.Context) {
+	cmd.daosCtx = ctx
+}
+
+type cliOptions struct {
+	Quiet         bool             `long:"quiet" short:"q" description:"Only display output at ERROR or higher"`
+	Debug         bool             `long:"debug" description:"enable debug output"`
+	Verbose       bool             `long:"verbose" description:"enable verbose output (when applicable)"`
+	JSON          bool             `long:"json" short:"j" description:"enable JSON output"`
+	ManPage       cmdutil.ManCmd   `command:"manpage" hidden:"true"`
+	ConnectStress connectStressCmd `command:"connect" description:"connection stress tests"`
+}
+
+func exitWithError(log logging.Logger, err error) {
+	cmdName := path.Base(os.Args[0])
+	log.Errorf("%s: %v", cmdName, err)
+	if fault.HasResolution(err) {
+		log.Errorf("%s: %s", cmdName, fault.ShowResolutionFor(err))
+	}
+	os.Exit(1)
+}
+
+func initDaosDebug() (func(), error) {
+	if err := daosAPI.DebugInit(); err != nil {
+		return nil, err
+	}
+
+	return func() {
+		daosAPI.DebugFini()
+	}, nil
+}
+
+func parseOpts(parent context.Context, args []string, opts *cliOptions, log *logging.LeveledLogger) error {
+	var wroteJSON atm.Bool
+	p := flags.NewParser(opts, flags.Default)
+	p.Name = "dstress"
+	p.ShortDescription = "Command to stress test DAOS"
+	p.LongDescription = `the dstress tool can be used to stress test DAOS`
+	p.Options ^= flags.PrintErrors // Don't allow the library to print errors
+	p.CommandHandler = func(cmd flags.Commander, args []string) error {
+		if cmd == nil {
+			return nil
+		}
+
+		if manCmd, ok := cmd.(cmdutil.ManPageWriter); ok {
+			manCmd.SetWriteFunc(p.WriteManPage)
+			return cmd.Execute(args)
+		}
+
+		if opts.Debug && opts.Quiet {
+			return errors.New("--debug and --quiet are incompatible")
+		}
+
+		if opts.Quiet {
+			log.SetLevel(logging.LogLevelError)
+		}
+
+		if opts.Debug {
+			log.SetLevel(logging.LogLevelTrace)
+			if os.Getenv("D_LOG_MASK") == "" {
+				os.Setenv("D_LOG_MASK", "DEBUG,OBJECT=ERR,PLACEMENT=ERR")
+			}
+			if os.Getenv("DD_MASK") == "" {
+				os.Setenv("DD_MASK", "mgmt")
+			}
+			log.Debug("debug output enabled")
+			daosAPI.SetDebugLog(log)
+		}
+
+		if jsonCmd, ok := cmd.(cmdutil.JSONOutputter); ok && opts.JSON {
+			jsonCmd.EnableJSONOutput(os.Stdout, &wroteJSON)
+			// disable output on stdout other than JSON
+			log.ClearLevel(logging.LogLevelInfo)
+		}
+
+		if logCmd, ok := cmd.(cmdutil.LogSetter); ok {
+			logCmd.SetLog(log)
+		}
+
+		if daosCmd, ok := cmd.(interface{ setCtx(context.Context) }); ok {
+			ctx, err := daosAPI.Init(parent)
+			if err != nil {
+				return err
+			}
+			daosCmd.setCtx(ctx)
+			//defer daosAPI.Fini(ctx)
+		}
+
+		if argsCmd, ok := cmd.(cmdutil.ArgsHandler); ok {
+			if err := argsCmd.CheckArgs(args); err != nil {
+				return err
+			}
+		}
+
+		if opts.Quiet {
+			args = append(args, "quiet")
+		}
+		if err := cmd.Execute(args); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Configure DAOS client logging to stderr if no log file
+	// is specified. This is to avoid polluting the JSON output.
+	if os.Getenv("D_LOG_FILE") == "" {
+		os.Setenv("D_LOG_FILE", "/dev/null")
+		if os.Getenv("DD_STDERR") == "" {
+			os.Setenv("DD_STDERR", "debug")
+		}
+	} else if os.Getenv("DD_STDERR") == "" {
+		os.Setenv("DD_STDERR", "err")
+	}
+
+	// Initialize the daos debug system first so that
+	// any allocations made as part of argument parsing
+	// are logged when running under NLT.
+	debugFini, err := initDaosDebug()
+	if err != nil {
+		exitWithError(log, err)
+	}
+	defer debugFini()
+
+	// Set the traceback level such that a crash results in
+	// a coredump (when ulimit -c is set appropriately).
+	debug.SetTraceback("crash")
+
+	_, err = p.ParseArgs(args)
+	if opts.JSON && wroteJSON.IsFalse() {
+		return cmdutil.OutputJSON(os.Stdout, nil, err)
+	}
+	return err
+}
+
+func main() {
+	var opts cliOptions
+	log := logging.NewCommandLineLogger()
+
+	ctx := context.Background()
+	if err := parseOpts(ctx, os.Args[1:], &opts, log); err != nil {
+		if fe, ok := errors.Cause(err).(*flags.Error); ok && fe.Type == flags.ErrHelp {
+			log.Info(fe.Error())
+			os.Exit(0)
+		}
+		exitWithError(log, err)
+	}
+}

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -507,7 +507,9 @@ func TestControl_PoolCreate(t *testing.T) {
 	}
 }
 
-func TestControl_PoolQueryResp_MarshallJSON(t *testing.T) {
+func TestControl_PoolQueryResp_MarshalJSON(t *testing.T) {
+	poolUUID := test.MockPoolUUID()
+
 	for name, tc := range map[string]struct {
 		pqr *PoolQueryResp
 		exp string
@@ -518,8 +520,8 @@ func TestControl_PoolQueryResp_MarshallJSON(t *testing.T) {
 		"null rankset": {
 			pqr: &PoolQueryResp{
 				Status: 0,
-				UUID:   "foo",
-				PoolInfo: PoolInfo{
+				PoolInfo: daos.PoolInfo{
+					UUID:             poolUUID,
 					TotalTargets:     1,
 					ActiveTargets:    2,
 					TotalEngines:     3,
@@ -530,13 +532,13 @@ func TestControl_PoolQueryResp_MarshallJSON(t *testing.T) {
 					UpgradeLayoutVer: 8,
 				},
 			},
-			exp: `{"enabled_ranks":null,"disabled_ranks":null,"status":0,"uuid":"foo","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
+			exp: `{"status":0,"enabled_ranks":null,"disabled_ranks":null,"uuid":"` + poolUUID.String() + `","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
 		},
 		"valid rankset": {
 			pqr: &PoolQueryResp{
 				Status: 0,
-				UUID:   "foo",
-				PoolInfo: PoolInfo{
+				PoolInfo: daos.PoolInfo{
+					UUID:             poolUUID,
 					TotalTargets:     1,
 					ActiveTargets:    2,
 					TotalEngines:     3,
@@ -549,7 +551,7 @@ func TestControl_PoolQueryResp_MarshallJSON(t *testing.T) {
 					UpgradeLayoutVer: 8,
 				},
 			},
-			exp: `{"enabled_ranks":[0,1,2,3,5],"disabled_ranks":[],"status":0,"uuid":"foo","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
+			exp: `{"status":0,"enabled_ranks":[0,1,2,3,5],"disabled_ranks":[],"uuid":"` + poolUUID.String() + `","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -565,18 +567,20 @@ func TestControl_PoolQueryResp_MarshallJSON(t *testing.T) {
 	}
 }
 
-func TestControl_PoolQueryResp_UnmarshallJSON(t *testing.T) {
+func TestControl_PoolQueryResp_UnmarshalJSON(t *testing.T) {
+	poolUUID := test.MockPoolUUID()
+
 	for name, tc := range map[string]struct {
 		data    string
 		expResp PoolQueryResp
 		expErr  error
 	}{
 		"null rankset": {
-			data: `{"enabled_ranks":null,"disabled_ranks":null,"status":0,"uuid":"foo","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
+			data: `{"enabled_ranks":null,"disabled_ranks":null,"status":0,"uuid":"` + poolUUID.String() + `","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
 			expResp: PoolQueryResp{
 				Status: 0,
-				UUID:   "foo",
-				PoolInfo: PoolInfo{
+				PoolInfo: daos.PoolInfo{
+					UUID:             poolUUID,
 					TotalTargets:     1,
 					ActiveTargets:    2,
 					TotalEngines:     3,
@@ -589,11 +593,11 @@ func TestControl_PoolQueryResp_UnmarshallJSON(t *testing.T) {
 			},
 		},
 		"valid rankset": {
-			data: `{"enabled_ranks":"[0,1-3,5]","disabled_ranks":"[]","status":0,"uuid":"foo","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
+			data: `{"enabled_ranks":"[0,1-3,5]","disabled_ranks":"[]","status":0,"uuid":"` + poolUUID.String() + `","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
 			expResp: PoolQueryResp{
 				Status: 0,
-				UUID:   "foo",
-				PoolInfo: PoolInfo{
+				PoolInfo: daos.PoolInfo{
+					UUID:             poolUUID,
 					TotalTargets:     1,
 					ActiveTargets:    2,
 					TotalEngines:     3,
@@ -612,7 +616,7 @@ func TestControl_PoolQueryResp_UnmarshallJSON(t *testing.T) {
 			expErr: errors.New("invalid character"),
 		},
 		"invalid rankset": {
-			data:   `{"enabled_ranks":"a cow goes quack","disabled_ranks":null,"status":0,"uuid":"foo","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
+			data:   `{"enabled_ranks":"a cow goes quack","disabled_ranks":null,"status":0,"uuid":"` + poolUUID.String() + `","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"leader":6,"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
 			expErr: errors.New("unexpected alphabetic character(s)"),
 		},
 	} {
@@ -672,7 +676,7 @@ func TestControl_PoolQuery(t *testing.T) {
 								Min:       1,
 								Max:       2,
 								Mean:      3,
-								MediaType: mgmtpb.StorageMediaType(StorageMediaTypeScm),
+								MediaType: mgmtpb.StorageMediaType(daos.StorageMediaTypeScm),
 							},
 							{
 								Total:     123456,
@@ -680,33 +684,33 @@ func TestControl_PoolQuery(t *testing.T) {
 								Min:       1,
 								Max:       2,
 								Mean:      3,
-								MediaType: mgmtpb.StorageMediaType(StorageMediaTypeNvme),
+								MediaType: mgmtpb.StorageMediaType(daos.StorageMediaTypeNvme),
 							},
 						},
 					},
 				),
 			},
 			expResp: &PoolQueryResp{
-				UUID: test.MockUUID(),
-				PoolInfo: PoolInfo{
+				PoolInfo: daos.PoolInfo{
+					UUID:             test.MockPoolUUID(),
 					TotalTargets:     42,
 					ActiveTargets:    16,
 					DisabledTargets:  17,
 					PoolLayoutVer:    1,
 					UpgradeLayoutVer: 2,
-					Rebuild: &PoolRebuildStatus{
-						State:   PoolRebuildStateBusy,
+					Rebuild: &daos.PoolRebuildStatus{
+						State:   daos.PoolRebuildStateBusy,
 						Objects: 1,
 						Records: 2,
 					},
-					TierStats: []*StorageUsageStats{
+					TierStats: []*daos.StorageUsageStats{
 						{
 							Total:     123456,
 							Free:      0,
 							Min:       1,
 							Max:       2,
 							Mean:      3,
-							MediaType: StorageMediaTypeScm,
+							MediaType: daos.StorageMediaTypeScm,
 						},
 						{
 							Total:     123456,
@@ -714,7 +718,7 @@ func TestControl_PoolQuery(t *testing.T) {
 							Min:       1,
 							Max:       2,
 							Mean:      3,
-							MediaType: StorageMediaTypeNvme,
+							MediaType: daos.StorageMediaTypeNvme,
 						},
 					},
 				},
@@ -742,7 +746,7 @@ func TestControl_PoolQuery(t *testing.T) {
 								Min:       1,
 								Max:       2,
 								Mean:      3,
-								MediaType: mgmtpb.StorageMediaType(StorageMediaTypeScm),
+								MediaType: mgmtpb.StorageMediaType(daos.StorageMediaTypeScm),
 							},
 							{
 								Total:     123456,
@@ -750,7 +754,7 @@ func TestControl_PoolQuery(t *testing.T) {
 								Min:       1,
 								Max:       2,
 								Mean:      3,
-								MediaType: mgmtpb.StorageMediaType(StorageMediaTypeNvme),
+								MediaType: mgmtpb.StorageMediaType(daos.StorageMediaTypeNvme),
 							},
 						},
 						EnabledRanks: "[0,1,2,3,5]",
@@ -758,26 +762,26 @@ func TestControl_PoolQuery(t *testing.T) {
 				),
 			},
 			expResp: &PoolQueryResp{
-				UUID: test.MockUUID(),
-				PoolInfo: PoolInfo{
+				PoolInfo: daos.PoolInfo{
+					UUID:             test.MockPoolUUID(),
 					TotalTargets:     42,
 					ActiveTargets:    16,
 					DisabledTargets:  17,
 					PoolLayoutVer:    1,
 					UpgradeLayoutVer: 2,
-					Rebuild: &PoolRebuildStatus{
-						State:   PoolRebuildStateBusy,
+					Rebuild: &daos.PoolRebuildStatus{
+						State:   daos.PoolRebuildStateBusy,
 						Objects: 1,
 						Records: 2,
 					},
-					TierStats: []*StorageUsageStats{
+					TierStats: []*daos.StorageUsageStats{
 						{
 							Total:     123456,
 							Free:      0,
 							Min:       1,
 							Max:       2,
 							Mean:      3,
-							MediaType: StorageMediaTypeScm,
+							MediaType: daos.StorageMediaTypeScm,
 						},
 						{
 							Total:     123456,
@@ -785,7 +789,7 @@ func TestControl_PoolQuery(t *testing.T) {
 							Min:       1,
 							Max:       2,
 							Mean:      3,
-							MediaType: StorageMediaTypeNvme,
+							MediaType: daos.StorageMediaTypeNvme,
 						},
 					},
 					EnabledRanks: ranklist.MustCreateRankSet("[0-3,5]"),
@@ -814,7 +818,7 @@ func TestControl_PoolQuery(t *testing.T) {
 								Min:       1,
 								Max:       2,
 								Mean:      3,
-								MediaType: mgmtpb.StorageMediaType(StorageMediaTypeScm),
+								MediaType: mgmtpb.StorageMediaType(daos.StorageMediaTypeScm),
 							},
 							{
 								Total:     123456,
@@ -822,7 +826,7 @@ func TestControl_PoolQuery(t *testing.T) {
 								Min:       1,
 								Max:       2,
 								Mean:      3,
-								MediaType: mgmtpb.StorageMediaType(StorageMediaTypeNvme),
+								MediaType: mgmtpb.StorageMediaType(daos.StorageMediaTypeNvme),
 							},
 						},
 						DisabledRanks: "[]",
@@ -830,26 +834,26 @@ func TestControl_PoolQuery(t *testing.T) {
 				),
 			},
 			expResp: &PoolQueryResp{
-				UUID: test.MockUUID(),
-				PoolInfo: PoolInfo{
+				PoolInfo: daos.PoolInfo{
+					UUID:             test.MockPoolUUID(),
 					TotalTargets:     42,
 					ActiveTargets:    16,
 					DisabledTargets:  17,
 					PoolLayoutVer:    1,
 					UpgradeLayoutVer: 2,
-					Rebuild: &PoolRebuildStatus{
-						State:   PoolRebuildStateBusy,
+					Rebuild: &daos.PoolRebuildStatus{
+						State:   daos.PoolRebuildStateBusy,
 						Objects: 1,
 						Records: 2,
 					},
-					TierStats: []*StorageUsageStats{
+					TierStats: []*daos.StorageUsageStats{
 						{
 							Total:     123456,
 							Free:      0,
 							Min:       1,
 							Max:       2,
 							Mean:      3,
-							MediaType: StorageMediaTypeScm,
+							MediaType: daos.StorageMediaTypeScm,
 						},
 						{
 							Total:     123456,
@@ -857,7 +861,7 @@ func TestControl_PoolQuery(t *testing.T) {
 							Min:       1,
 							Max:       2,
 							Mean:      3,
-							MediaType: StorageMediaTypeNvme,
+							MediaType: daos.StorageMediaTypeNvme,
 						},
 					},
 					DisabledRanks: &ranklist.RankSet{},
@@ -1382,21 +1386,21 @@ func TestControl_PoolGetPropResp_MarshalJSON(t *testing.T) {
 func TestControl_Pool_setUsage(t *testing.T) {
 	for name, tc := range map[string]struct {
 		status        int32
-		scmStats      *StorageUsageStats
-		nvmeStats     *StorageUsageStats
+		scmStats      *daos.StorageUsageStats
+		nvmeStats     *daos.StorageUsageStats
 		totalTargets  uint32
 		activeTargets uint32
 		expPool       *Pool
 		expErr        error
 	}{
 		"successful query": {
-			scmStats: &StorageUsageStats{
+			scmStats: &daos.StorageUsageStats{
 				Total: humanize.GByte * 30,
 				Free:  humanize.GByte * 15,
 				Min:   humanize.GByte * 1.6,
 				Max:   humanize.GByte * 2,
 			},
-			nvmeStats: &StorageUsageStats{
+			nvmeStats: &daos.StorageUsageStats{
 				Total: humanize.GByte * 500,
 				Free:  humanize.GByte * 250,
 				Min:   humanize.GByte * 29.5,
@@ -1422,13 +1426,13 @@ func TestControl_Pool_setUsage(t *testing.T) {
 			},
 		},
 		"disabled targets": {
-			scmStats: &StorageUsageStats{
+			scmStats: &daos.StorageUsageStats{
 				Total: humanize.GByte * 30,
 				Free:  humanize.GByte * 15,
 				Min:   humanize.GByte * 1.6,
 				Max:   humanize.GByte * 2,
 			},
-			nvmeStats: &StorageUsageStats{
+			nvmeStats: &daos.StorageUsageStats{
 				Total: humanize.GByte * 500,
 				Free:  humanize.GByte * 250,
 				Min:   humanize.GByte * 29.5,

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -231,7 +231,11 @@ func (c *Client) dialOptions() ([]grpc.DialOption, error) {
 // one set. If the request does not define a specific deadline, then the
 // default timeout is used.
 func setDeadlineIfUnset(parent context.Context, req UnaryRequest) (context.Context, context.CancelFunc) {
-	if _, hasDeadline := parent.Deadline(); hasDeadline {
+	if deadline, hasDeadline := parent.Deadline(); hasDeadline {
+		// Set the request timeout based on the context deadline.
+		// NB: This is mostly just used for debug logging.
+		req.SetTimeout(time.Until(deadline))
+
 		return parent, func() {}
 	}
 

--- a/src/control/lib/daos/attribute.go
+++ b/src/control/lib/daos/attribute.go
@@ -1,0 +1,15 @@
+//
+// (C) Copyright 2023 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package daos
+
+type (
+	// Attribute is a pool or container attribute.
+	Attribute struct {
+		Name  string `json:"name"`
+		Value []byte `json:"value,omitempty"`
+	}
+)

--- a/src/control/lib/daos/client/acl.go
+++ b/src/control/lib/daos/client/acl.go
@@ -1,0 +1,76 @@
+package client
+
+/*
+#include <stdlib.h>
+
+#include <daos_cont.h>
+#include <daos_prop.h>
+
+#include "util.h"
+
+void
+free_ace_list(char **str, size_t str_count)
+{
+	int i;
+
+	for (i = 0; i < str_count; i++)
+		D_FREE(str[i]);
+	D_FREE(str);
+}
+*/
+import "C"
+import (
+	"strings"
+	"unsafe"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/control"
+)
+
+func getAclStrings(e *C.struct_daos_prop_entry) (out []string) {
+	acl := (*C.struct_daos_acl)(C.get_dpe_val_ptr(e))
+	if acl == nil {
+		return
+	}
+
+	var aces **C.char
+	var acesNr C.size_t
+
+	rc := C.daos_acl_to_strs(acl, &aces, &acesNr)
+	if err := daosError(rc); err != nil || aces == nil {
+		return
+	}
+	defer C.free_ace_list(aces, acesNr)
+
+	for _, ace := range (*[1 << 30]*C.char)(unsafe.Pointer(aces))[:acesNr:acesNr] {
+		out = append(out, C.GoString(ace))
+	}
+
+	return
+}
+
+func aclStringer(e *C.struct_daos_prop_entry, name string) string {
+	if e == nil {
+		return propNotFound(name)
+	}
+
+	return strings.Join(getAclStrings(e), ", ")
+}
+
+func aclToC(acl *control.AccessControlList) (*C.struct_daos_acl, func(), error) {
+	aceStrs := make([]*C.char, len(acl.Entries))
+	for i, ace := range acl.Entries {
+		aceStrs[i] = C.CString(ace)
+		defer C.free(unsafe.Pointer(aceStrs[i]))
+	}
+
+	var cACL *C.struct_daos_acl
+	rc := C.daos_acl_from_strs(&aceStrs[0], C.ulong(len(aceStrs)), &cACL)
+	if err := daosError(rc); err != nil {
+		return nil, nil, errors.Wrapf(err,
+			"unable to create ACL structure")
+	}
+
+	return cACL, func() { C.daos_acl_free(cACL) }, nil
+}

--- a/src/control/lib/daos/client/api.go
+++ b/src/control/lib/daos/client/api.go
@@ -1,0 +1,161 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"unsafe"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+/*
+#include <daos.h>
+#include <daos/debug.h>
+*/
+import "C"
+
+const (
+	apiClientKey ctxKey = "apiClientKey"
+)
+
+var (
+	log logging.DebugLogger = logging.NewDebugLogger(io.Discard)
+)
+
+type (
+	// connHandle is an opaque type used to represent a DAOS connection (pool or container).
+	connHandle struct {
+		UUID       uuid.UUID
+		daosHandle C.daos_handle_t
+	}
+
+	// PoolHandle is an opaque type used to represent a DAOS Pool connection.
+	PoolHandle struct {
+		connHandle
+	}
+
+	// ContainerHandle is an opaque type used to represent a DAOS Container connection.
+	// NB: A ContainerHandle contains the PoolHandle used to open the container.
+	ContainerHandle struct {
+		connHandle
+		PoolHandle *PoolHandle
+	}
+
+	ctxKey string
+)
+
+func (ch *connHandle) String() string {
+	return fmt.Sprintf("%s:%t", logging.ShortUUID(ch.UUID), ch.IsValid())
+}
+
+func (ch *connHandle) IsValid() bool {
+	return bool(C.daos_handle_is_valid(ch.daosHandle))
+}
+
+func (ch *connHandle) invalidate() {
+	ch.daosHandle.cookie = 0
+}
+
+func (ch *connHandle) Pointer() unsafe.Pointer {
+	return unsafe.Pointer(&ch.daosHandle)
+}
+
+func (ch *ContainerHandle) String() string {
+	return fmt.Sprintf("%s:%s:%t", logging.ShortUUID(ch.PoolHandle.UUID), logging.ShortUUID(ch.UUID), ch.IsValid())
+}
+
+var errNoApiClient = errors.Wrap(daos.NotInit, "no API client (call Init()?)")
+
+func getApiClient(ctx context.Context) (apiClient, error) {
+	if ctx == nil {
+		return nil, errors.Wrap(daos.InvalidInput, "nil context")
+	}
+	if client, ok := ctx.Value(apiClientKey).(apiClient); ok {
+		return client, nil
+	}
+
+	return nil, errNoApiClient
+}
+
+func setApiClient(parent context.Context, client apiClient) (context.Context, error) {
+	if parent == nil {
+		return nil, errors.Wrap(daos.InvalidInput, "nil context")
+	}
+	if parent.Err() != nil {
+		return nil, parent.Err()
+	}
+
+	if client == nil {
+		return nil, errors.Wrap(daos.InvalidInput, "nil API client")
+	}
+
+	if _, err := getApiClient(parent); err == nil {
+		return nil, errors.Wrap(daos.Already, "API client already set")
+	}
+
+	return context.WithValue(parent, apiClientKey, client), nil
+}
+
+// Init initializes the DAOS Client API. The returned Context
+// must be used for all API methods, and should be finalized
+// using the Fini() method.
+func Init(parent context.Context) (context.Context, error) {
+	if parent.Err() != nil {
+		return nil, parent.Err()
+	}
+
+	ctx := parent
+	client, err := getApiClient(parent)
+	if err == errNoApiClient {
+		apiCtx, cancel := context.WithCancel(parent)
+		client = &daosClientBinding{
+			cancelCtx: cancel,
+		}
+		if ctx, err = setApiClient(apiCtx, client); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	} else if _, ok := client.(*mockApiClient); !ok {
+		return nil, errors.Wrap(daos.Already, "DAOS API already initialized")
+	}
+
+	if err := daosError(client.daos_init()); err != nil {
+		// May have already been initialized by DFS.
+		if err != daos.Already {
+			return nil, err
+		}
+	}
+
+	return ctx, nil
+}
+
+// Fini deinitializes the DAOS Client API.
+func Fini(ctx context.Context) error {
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	return daosError(client.daos_fini())
+}
+
+// SetDebugLog sets the package-level debug logger.
+func SetDebugLog(dl logging.DebugLogger) {
+	log = dl
+}
+
+// DebugInit initializes the DAOS Client debug logging system.
+func DebugInit() error {
+	return daosError(C.daos_debug_init(nil))
+}
+
+// DebugFini deinitializes the DAOS Client debug logging system.
+func DebugFini() {
+	C.daos_debug_fini()
+}

--- a/src/control/lib/daos/client/api_test.go
+++ b/src/control/lib/daos/client/api_test.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/atm"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+)
+
+func TestClient_Init(t *testing.T) {
+	for name, tc := range map[string]struct {
+		ctx    context.Context
+		cfg    *MockApiClientConfig
+		expErr error
+	}{
+		"Init() already called": {
+			ctx: func() context.Context {
+				t.Helper()
+				b := &daosClientBinding{}
+				ctx, err := setApiClient(context.Background(), b)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return ctx
+			}(),
+			expErr: daos.Already,
+		},
+		"Init() called after Fini() (same context)": {
+			ctx: func() context.Context {
+				t.Helper()
+				parent, cancel := context.WithCancel(context.Background())
+				b := &daosClientBinding{
+					initialized: atm.NewBool(true),
+					cancelCtx:   cancel,
+				}
+				ctx, err := setApiClient(parent, b)
+				if err != nil {
+					t.Fatal(err)
+				}
+				Fini(ctx)
+				return ctx
+			}(),
+			expErr: context.Canceled,
+		},
+		"Init() fails with -DER_NOMEM": {
+			cfg: &MockApiClientConfig{
+				ReturnCodeMap: map[string]int{
+					"daos_init": int(daos.NoMemory),
+				},
+			},
+			expErr: daos.NoMemory,
+		},
+		"Init() (unmocked) fails with -DER_AGENT_COMM": {
+			ctx: func() context.Context {
+				// Ensure that we don't connect to a running agent
+				if err := os.Setenv("DAOS_AGENT_DRPC_DIR", "/nonexistent"); err != nil {
+					t.Fatal(err)
+				}
+				return context.Background()
+			}(),
+			expErr: daos.AgentCommErr,
+		},
+		"successful Init() (mocked)": {
+			cfg: &MockApiClientConfig{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.ctx == nil {
+				var err error
+				tc.ctx, err = MockApiClientContext(context.Background(), tc.cfg)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, gotErr := Init(tc.ctx)
+			test.CmpErr(t, tc.expErr, gotErr)
+		})
+	}
+}
+
+func TestClient_Fini(t *testing.T) {
+	for name, tc := range map[string]struct {
+		ctx    context.Context
+		cfg    *MockApiClientConfig
+		expErr error
+	}{
+		"Fini() already called is idempotent": {
+			ctx: func() context.Context {
+				t.Helper()
+				parent, cancel := context.WithCancel(context.Background())
+				b := &daosClientBinding{
+					cancelCtx: cancel,
+				}
+				ctx, err := setApiClient(parent, b)
+				if err != nil {
+					t.Fatal(err)
+				}
+				Fini(ctx)
+				return ctx
+			}(),
+		},
+		"Fini() fails with -DER_NOMEM": {
+			cfg: &MockApiClientConfig{
+				ReturnCodeMap: map[string]int{
+					"daos_fini": int(daos.NoMemory),
+				},
+			},
+			expErr: daos.NoMemory,
+		},
+		"successful Fini() (mocked)": {
+			cfg: &MockApiClientConfig{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.ctx == nil {
+				ctx, err := MockApiClientContext(context.Background(), tc.cfg)
+				if err != nil {
+					t.Fatal(err)
+				}
+				tc.ctx, err = Init(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			gotErr := Fini(tc.ctx)
+			test.CmpErr(t, tc.expErr, gotErr)
+		})
+	}
+}

--- a/src/control/lib/daos/client/binding.go
+++ b/src/control/lib/daos/client/binding.go
@@ -1,0 +1,66 @@
+package client
+
+/*
+#cgo LDFLAGS: -lgurt -lcart -ldaos -ldaos_common -lduns -ldfs -luuid
+
+#include <daos.h>
+#include <daos/debug.h>
+#include <daos_fs.h>
+*/
+import "C"
+import (
+	"context"
+
+	"github.com/daos-stack/daos/src/control/lib/atm"
+)
+
+type (
+	apiClient interface {
+		daos_init() C.int
+		daos_fini() C.int
+		dfuse_open(path *C.char, oflag C.int) (C.int, error)
+		dfuse_ioctl(fd C.int, reply *C.struct_dfuse_il_reply) (C.int, error)
+		close_fd(fd C.int) C.int
+		duns_resolve_path(path *C.char, dattr *C.struct_duns_attr_t) C.int
+		daos_pool_connect(poolID *C.char, sys *C.char, flags C.uint, poolHdl *C.daos_handle_t, poolInfo *C.daos_pool_info_t, ev *C.struct_daos_event) C.int
+		daos_pool_disconnect(poolHdl C.daos_handle_t) C.int
+		daos_pool_query(poolHdl C.daos_handle_t, rankList **C.d_rank_list_t, poolInfo *C.daos_pool_info_t, props *C.daos_prop_t, ev *C.struct_daos_event) C.int
+		daos_cont_create(poolHdl C.daos_handle_t, cUUID *C.uuid_t, props *C.daos_prop_t, ev *C.struct_daos_event) C.int
+		dfs_cont_create(poolHdl C.daos_handle_t, cUUID *C.uuid_t, attr *C.dfs_attr_t, contHdl *C.daos_handle_t, dfs **C.dfs_t) C.int
+		duns_create_path(poolHdl C.daos_handle_t, path *C.char, attr *C.struct_duns_attr_t) C.int
+		daos_cont_destroy(poolHdl C.daos_handle_t, contID *C.char, force C.int, ev *C.struct_daos_event) C.int
+		daos_cont_open(poolHdl C.daos_handle_t, contID *C.char, flags C.uint, contHdl *C.daos_handle_t, info *C.daos_cont_info_t, ev *C.struct_daos_event) C.int
+		daos_cont_close(contHdl C.daos_handle_t, ev *C.struct_daos_event) C.int
+		daos_cont_query(contHdl C.daos_handle_t, dci *C.daos_cont_info_t, props *C.daos_prop_t, ev *C.struct_daos_event) C.int
+	}
+
+	daosClientBinding struct {
+		cancelCtx   context.CancelFunc
+		initialized atm.Bool
+	}
+)
+
+func (b *daosClientBinding) daos_init() C.int {
+	if b.initialized.IsTrue() {
+		return -C.DER_ALREADY
+	}
+
+	if rc := C.daos_init(); rc != 0 {
+		return rc
+	}
+
+	b.initialized.SetTrue()
+	return 0
+}
+
+func (b *daosClientBinding) daos_fini() C.int {
+	if b.initialized.IsTrue() {
+		b.initialized.SetFalse()
+		if b.cancelCtx != nil {
+			b.cancelCtx()
+		}
+		return C.daos_fini()
+	}
+
+	return 0
+}

--- a/src/control/lib/daos/client/cont_prop_test.go
+++ b/src/control/lib/daos/client/cont_prop_test.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-package main
+package client
 
 import (
 	"strconv"
@@ -17,7 +17,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/daos"
 )
 
-func TestProperty_EcCellSize(t *testing.T) {
+func TestContainerProperty_EcCellSize(t *testing.T) {
 	for name, tc := range map[string]struct {
 		SizeStr    string
 		EntryBytes uint64
@@ -49,7 +49,7 @@ func TestProperty_EcCellSize(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			propEntry := newTestPropEntry()
-			err := propHdlrs[daos.PropEntryECCellSize].nameHdlr(nil,
+			err := ContainerProperties[daos.PropEntryECCellSize].nameHdlr(nil,
 				propEntry,
 				tc.SizeStr)
 			if err != nil {
@@ -64,7 +64,7 @@ func TestProperty_EcCellSize(t *testing.T) {
 				tc.EntryBytes,
 				"Invalid EC Cell size")
 
-			sizeStr := propHdlrs[daos.PropEntryECCellSize].toString(propEntry,
+			sizeStr := ContainerProperties[daos.PropEntryECCellSize].toString(propEntry,
 				daos.PropEntryECCellSize)
 			test.AssertEqual(t,
 				humanize.IBytes(tc.EntryBytes),
@@ -74,7 +74,7 @@ func TestProperty_EcCellSize(t *testing.T) {
 	}
 }
 
-func TestProperty_EcCellSize_Errors(t *testing.T) {
+func TestContainerProperty_EcCellSize_Errors(t *testing.T) {
 	for name, tc := range map[string]struct {
 		SizeStr     string
 		ExpectError error
@@ -90,7 +90,7 @@ func TestProperty_EcCellSize_Errors(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			propEntry := newTestPropEntry()
-			err := propHdlrs[daos.PropEntryECCellSize].nameHdlr(nil,
+			err := ContainerProperties[daos.PropEntryECCellSize].nameHdlr(nil,
 				propEntry,
 				tc.SizeStr)
 			test.CmpErr(t, tc.ExpectError, err)
@@ -98,7 +98,7 @@ func TestProperty_EcCellSize_Errors(t *testing.T) {
 	}
 
 	t.Run("Invalid Entry error message: nil entry", func(t *testing.T) {
-		sizeStr := propHdlrs[daos.PropEntryECCellSize].toString(nil,
+		sizeStr := ContainerProperties[daos.PropEntryECCellSize].toString(nil,
 			daos.PropEntryECCellSize)
 		test.AssertEqual(t,
 			"property \""+daos.PropEntryECCellSize+"\" not found",
@@ -108,7 +108,7 @@ func TestProperty_EcCellSize_Errors(t *testing.T) {
 
 	t.Run("Invalid Entry error message: invalid size", func(t *testing.T) {
 		propEntry := newTestPropEntry()
-		sizeStr := propHdlrs[daos.PropEntryECCellSize].toString(propEntry,
+		sizeStr := ContainerProperties[daos.PropEntryECCellSize].toString(propEntry,
 			daos.PropEntryECCellSize)
 		test.AssertEqual(t,
 			"invalid size 0",

--- a/src/control/lib/daos/client/container.go
+++ b/src/control/lib/daos/client/container.go
@@ -1,0 +1,832 @@
+package client
+
+import (
+	"context"
+	"unsafe"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+)
+
+/*
+#include <fcntl.h>
+
+#include <gurt/common.h>
+#include <daos/common.h>
+#include <daos_prop.h>
+#include <daos_cont.h>
+#include <daos_array.h>
+#include <daos_fs.h>
+#include <daos_uns.h>
+
+#include "util.h"
+*/
+import "C"
+
+type (
+	ContainerLayout   uint16
+	ContainerOpenFlag uint
+
+	POSIXAttributes struct {
+		ChunkSize       uint64      `json:"chunk_size,omitempty"`
+		ObjectClass     ObjectClass `json:"object_class,omitempty"`
+		DirObjectClass  ObjectClass `json:"dir_object_class,omitempty"`
+		FileObjectClass ObjectClass `json:"file_object_class,omitempty"`
+		ConsistencyMode uint32      `json:"cons_mode,omitempty"`
+		Hints           string      `json:"hints,omitempty"`
+	}
+
+	ContainerInfo struct {
+		PoolUUID         uuid.UUID        `json:"pool_uuid"`
+		UUID             uuid.UUID        `json:"container_uuid"`
+		Label            string           `json:"container_label,omitempty"`
+		LatestSnapshot   uint64           `json:"latest_snapshot"`
+		RedundancyFactor uint32           `json:"redundancy_factor"`
+		NumHandles       uint32           `json:"num_handles"`
+		NumSnapshots     uint32           `json:"num_snapshots"`
+		OpenTime         uint64           `json:"open_time"`
+		CloseModifyTime  uint64           `json:"close_modify_time"`
+		Type             ContainerLayout  `json:"container_type"`
+		POSIXAttributes  *POSIXAttributes `json:"posix_attributes,omitempty"`
+	}
+)
+
+const (
+	ContainerLayoutUnknown  ContainerLayout = C.DAOS_PROP_CO_LAYOUT_UNKNOWN
+	ContainerLayoutPOSIX    ContainerLayout = C.DAOS_PROP_CO_LAYOUT_POSIX
+	ContainerLayoutHDF5     ContainerLayout = C.DAOS_PROP_CO_LAYOUT_HDF5
+	ContainerLayoutPython   ContainerLayout = C.DAOS_PROP_CO_LAYOUT_PYTHON
+	ContainerLayoutSpark    ContainerLayout = C.DAOS_PROP_CO_LAYOUT_SPARK
+	ContainerLayoutDatabase ContainerLayout = C.DAOS_PROP_CO_LAYOUT_DATABASE
+	ContainerLayoutRoot     ContainerLayout = C.DAOS_PROP_CO_LAYOUT_ROOT
+	ContainerLayoutSeismic  ContainerLayout = C.DAOS_PROP_CO_LAYOUT_SEISMIC
+	ContainerLayoutMeteo    ContainerLayout = C.DAOS_PROP_CO_LAYOUT_METEO
+
+	ContainerOpenFlagReadOnly  ContainerOpenFlag = C.DAOS_COO_RO
+	ContainerOpenFlagReadWrite ContainerOpenFlag = C.DAOS_COO_RW
+	ContainerOpenFlagExclusive ContainerOpenFlag = C.DAOS_COO_EX
+	ContainerOpenFlagForce     ContainerOpenFlag = C.DAOS_COO_FORCE
+	ContainerOpenFlagMdStats   ContainerOpenFlag = C.DAOS_COO_RO_MDSTATS
+	ContainerOpenFlagEvict     ContainerOpenFlag = C.DAOS_COO_EVICT
+	ContainerOpenFlagEvictAll  ContainerOpenFlag = C.DAOS_COO_EVICT_ALL
+)
+
+func (l *ContainerLayout) FromString(in string) error {
+	cStr := C.CString(in)
+	defer freeString(cStr)
+	C.daos_parse_ctype(cStr, (*C.uint16_t)(l))
+
+	if *l == ContainerLayoutUnknown {
+		return errors.Errorf("unknown container layout %q", in)
+	}
+
+	return nil
+}
+
+func (l ContainerLayout) String() string {
+	var cType [10]C.char
+	C.daos_unparse_ctype(C.ushort(l), &cType[0])
+	return C.GoString(&cType[0])
+}
+
+func newContainerInfo(cUUID C.uuid_t, cInfo *C.daos_cont_info_t, props propSlice) *ContainerInfo {
+	contInfo := &ContainerInfo{
+		UUID: uuid.Must(uuidFromC(cUUID)),
+	}
+
+	if cInfo != nil {
+		contInfo.LatestSnapshot = uint64(cInfo.ci_lsnapshot)
+		contInfo.NumHandles = uint32(cInfo.ci_nhandles)
+		contInfo.NumSnapshots = uint32(cInfo.ci_nsnapshots)
+		contInfo.OpenTime = uint64(cInfo.ci_md_otime)
+		contInfo.CloseModifyTime = uint64(cInfo.ci_md_mtime)
+	}
+
+	for _, p := range props {
+		switch p.dpe_type {
+		case C.DAOS_PROP_CO_LAYOUT_TYPE:
+			contInfo.Type = ContainerLayout(C.get_dpe_val(&p))
+		case C.DAOS_PROP_CO_LABEL:
+			contInfo.Label = C.GoString(C.get_dpe_str(&p))
+		case C.DAOS_PROP_CO_REDUN_FAC:
+			contInfo.RedundancyFactor = uint32(C.get_dpe_val(&p))
+		}
+	}
+
+	return contInfo
+}
+
+func (b *daosClientBinding) duns_create_path(poolHdl C.daos_handle_t, path *C.char, attr *C.struct_duns_attr_t) C.int {
+	return C.duns_create_path(poolHdl, path, attr)
+}
+
+func (m *mockApiClient) duns_create_path(_ C.daos_handle_t, _ *C.char, attr *C.struct_duns_attr_t) C.int {
+	if rc := m.getRc("duns_create_path", 0); rc != 0 {
+		return rc
+	}
+
+	contStr := m.cfg.ConnectedCont.String()
+	for i := 0; i <= len(contStr); i++ {
+		if i == len(contStr) {
+			attr.da_cont[i] = C.char('\x00')
+			break
+		}
+		attr.da_cont[i] = C.char(contStr[i])
+	}
+	return 0
+}
+
+func dunsContainerCreate(client apiClient, poolConn *PoolHandle, req ContainerCreateReq, cInfo *ContainerInfo) error {
+	var attr C.struct_duns_attr_t
+
+	if req.UNSPath == "" {
+		return errors.Wrap(daos.InvalidInput, "UNS Path is required")
+	}
+	cPath := C.CString(req.UNSPath)
+	defer freeString(cPath)
+
+	if req.Type == ContainerLayoutUnknown {
+		return errors.Wrap(daos.InvalidInput, "container type is required for UNS")
+	}
+	attr.da_type = C.ushort(req.Type)
+
+	if req.POSIXAttributes != nil {
+		if req.POSIXAttributes.ChunkSize > 0 {
+			attr.da_chunk_size = C.uint64_t(req.POSIXAttributes.ChunkSize)
+		}
+		if req.POSIXAttributes.ObjectClass != 0 {
+			attr.da_oclass_id = C.uint32_t(req.POSIXAttributes.ObjectClass)
+		}
+		if req.POSIXAttributes.DirObjectClass != 0 {
+			attr.da_dir_oclass_id = C.uint32_t(req.POSIXAttributes.DirObjectClass)
+		}
+		if req.POSIXAttributes.FileObjectClass != 0 {
+			attr.da_file_oclass_id = C.uint32_t(req.POSIXAttributes.FileObjectClass)
+		}
+		if req.POSIXAttributes.Hints != "" {
+			cHint := C.CString(req.POSIXAttributes.Hints)
+			defer freeString(cHint)
+			C.strncpy(&attr.da_hints[0], cHint, C.DAOS_CONT_HINT_MAX_LEN-1)
+		}
+	}
+
+	props, cleanup, err := req.Properties.cArrPtr()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	attr.da_props = props
+
+	rc := client.duns_create_path(poolConn.daosHandle, cPath, &attr)
+	if err := daosError(C.daos_errno2der(rc)); err != nil {
+		return err
+	}
+	idStr := C.GoString(&attr.da_cont[0])
+	if contUUID, err := uuid.Parse(idStr); err == nil {
+		cInfo.UUID = contUUID
+	} else {
+		cInfo.Label = idStr
+	}
+
+	return err
+}
+
+func (b *daosClientBinding) dfs_cont_create(poolHdl C.daos_handle_t, cUUID *C.uuid_t, attr *C.dfs_attr_t, contHdl *C.daos_handle_t, dfs **C.dfs_t) C.int {
+	return C.dfs_cont_create(poolHdl, cUUID, attr, contHdl, dfs)
+}
+
+func (m *mockApiClient) dfs_cont_create(_ C.daos_handle_t, cUUID *C.uuid_t, _ *C.dfs_attr_t, _ *C.daos_handle_t, _ **C.dfs_t) C.int {
+	if rc := m.getRc("dfs_cont_create", 0); rc != 0 {
+		return rc
+	}
+
+	if err := copyUUID(cUUID, m.cfg.ConnectedCont); err != nil {
+		panic(err)
+	}
+	return 0
+}
+
+func posixContainerCreate(client apiClient, poolConn *PoolHandle, req ContainerCreateReq, cInfo *ContainerInfo) error {
+	var attr C.dfs_attr_t
+
+	if req.POSIXAttributes == nil {
+		return errors.Wrap(daos.InvalidInput, "POSIX attributes are required if container type is POSIX")
+	}
+	if req.POSIXAttributes.ChunkSize > 0 {
+		attr.da_chunk_size = C.uint64_t(req.POSIXAttributes.ChunkSize)
+	}
+	if req.POSIXAttributes.ObjectClass != 0 {
+		attr.da_oclass_id = C.uint32_t(req.POSIXAttributes.ObjectClass)
+	}
+	if req.POSIXAttributes.DirObjectClass != 0 {
+		attr.da_dir_oclass_id = C.uint32_t(req.POSIXAttributes.DirObjectClass)
+	}
+	if req.POSIXAttributes.FileObjectClass != 0 {
+		attr.da_file_oclass_id = C.uint32_t(req.POSIXAttributes.FileObjectClass)
+	}
+	if req.POSIXAttributes.ConsistencyMode != 0 {
+		attr.da_mode = C.uint32_t(req.POSIXAttributes.ConsistencyMode)
+	}
+	if req.POSIXAttributes.Hints != "" {
+		cHint := C.CString(req.POSIXAttributes.Hints)
+		defer freeString(cHint)
+		C.strncpy(&attr.da_hints[0], cHint, C.DAOS_CONT_HINT_MAX_LEN-1)
+	}
+
+	props, cleanup, err := req.Properties.cArrPtr()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	attr.da_props = props
+
+	var cUUID C.uuid_t
+	rc := client.dfs_cont_create(poolConn.daosHandle, &cUUID, &attr, nil, nil)
+	if err := daosError(C.daos_errno2der(rc)); err != nil {
+		return err
+	}
+	cInfo.UUID = uuid.Must(uuidFromC(cUUID))
+
+	return nil
+}
+
+func (b *daosClientBinding) daos_cont_create(poolHdl C.daos_handle_t, cUUID *C.uuid_t, props *C.daos_prop_t, ev *C.struct_daos_event) C.int {
+	return C.daos_cont_create(poolHdl, cUUID, props, ev)
+}
+
+func (m *mockApiClient) daos_cont_create(_ C.daos_handle_t, cUUID *C.uuid_t, _ *C.daos_prop_t, _ *C.struct_daos_event) C.int {
+	if rc := m.getRc("daos_cont_create", 0); rc != 0 {
+		return rc
+	}
+
+	if err := copyUUID(cUUID, m.cfg.ConnectedCont); err != nil {
+		panic(err)
+	}
+	return 0
+}
+
+func defaultContainerCreate(client apiClient, poolConn *PoolHandle, req ContainerCreateReq, cInfo *ContainerInfo) error {
+	props, cleanup, err := req.Properties.cArrPtr()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	var cUUID C.uuid_t
+	rc := client.daos_cont_create(poolConn.daosHandle, &cUUID, props, nil)
+	if err := daosError(rc); err != nil {
+		return err
+	}
+	cInfo.UUID = uuid.Must(uuidFromC(cUUID))
+
+	return nil
+}
+
+type ContainerCreateReq struct {
+	Label           string
+	UNSPath         string
+	ACL             *control.AccessControlList
+	Type            ContainerLayout
+	POSIXAttributes *POSIXAttributes
+	Properties      ContainerPropertySet
+}
+
+func ContainerCreate(ctx context.Context, poolConn *PoolHandle, req ContainerCreateReq) (*ContainerInfo, error) {
+	log.Debugf("ContainerCreate(%+v)", req)
+
+	if poolConn == nil {
+		return nil, errInvalidPoolHandle
+	}
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Properties == nil {
+		req.Properties = make(ContainerPropertySet)
+	}
+
+	if req.ACL != nil {
+		if len(req.ACL.Entries) > 0 {
+			cACL, cleanup, err := aclToC(req.ACL)
+			if err != nil {
+				return nil, err
+			}
+			defer cleanup()
+
+			var aclEntry C.struct_daos_prop_entry
+			aclEntry.dpe_type = C.DAOS_PROP_CO_ACL
+			C.set_dpe_val_ptr(&aclEntry, unsafe.Pointer(cACL))
+			req.Properties.addEntry("acl", &aclEntry)
+		}
+
+		if req.ACL.OwnerGroup != "" {
+			var groupEntry C.struct_daos_prop_entry
+			groupEntry.dpe_type = C.DAOS_PROP_CO_OWNER_GROUP
+			cGrpStr := C.CString(req.ACL.OwnerGroup)
+			defer freeString(cGrpStr)
+			C.set_dpe_str(&groupEntry, cGrpStr)
+			req.Properties.addEntry("ownerGroup", &groupEntry)
+		}
+	}
+
+	if req.Type != ContainerLayoutUnknown {
+		var typeEntry C.struct_daos_prop_entry
+		typeEntry.dpe_type = C.DAOS_PROP_CO_LAYOUT_TYPE
+		C.set_dpe_val(&typeEntry, C.ulong(req.Type))
+		req.Properties.addEntry("type", &typeEntry)
+	}
+
+	var cInfo ContainerInfo
+	var createErr error
+	if req.UNSPath != "" {
+		createErr = dunsContainerCreate(client, poolConn, req, &cInfo)
+	} else {
+		switch req.Type {
+		case ContainerLayoutPOSIX:
+			createErr = posixContainerCreate(client, poolConn, req, &cInfo)
+		default:
+			createErr = defaultContainerCreate(client, poolConn, req, &cInfo)
+		}
+	}
+
+	if createErr != nil {
+		return nil, errors.Wrap(createErr, "failed to create container")
+	}
+	if cInfo.Label == "" {
+		cInfo.Label = req.Label
+	}
+	if cInfo.Type == ContainerLayoutUnknown {
+		cInfo.Type = req.Type
+	}
+	cInfo.POSIXAttributes = req.POSIXAttributes
+
+	log.Debugf("created container %s", cInfo.UUID)
+
+	return &cInfo, nil
+}
+
+func (ch *ContainerHandle) Destroy(ctx context.Context, force bool) error {
+	return ContainerDestroy(ctx, ch.PoolHandle, ch.UUID.String(), force)
+}
+
+func (b *daosClientBinding) daos_cont_destroy(poolHdl C.daos_handle_t, contID *C.char, force C.int, ev *C.struct_daos_event) C.int {
+	return C.daos_cont_destroy(poolHdl, contID, force, ev)
+}
+
+func (m *mockApiClient) daos_cont_destroy(poolHdl C.daos_handle_t, contID *C.char, force C.int, ev *C.struct_daos_event) C.int {
+	return m.getRc("daos_cont_destroy", 0)
+}
+
+func ContainerDestroy(ctx context.Context, poolConn *PoolHandle, contID string, force bool) error {
+	log.Debugf("ContainerDestroy(%s:%s:%t)", poolConn, contID, force)
+
+	if poolConn == nil {
+		return errInvalidPoolHandle
+	}
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	/*if req.UNSPath != "" {
+		if req.PoolConn != nil || req.ContainerID != "" {
+			return errors.Wrap(InvalidInput, "UNSPath should not be used with PoolConn or ContainerID")
+		}
+
+		var err error
+		poolID, contID, err = ResolveUNSPath(req.UNSPath)
+		if err != nil {
+			return errors.Wrapf(err, "failed to resolve UNS path %q", req.UNSPath)
+		}
+
+		// If we're resolving via a mounted container, then we can
+		// reasonably assume that the caller wants to destroy it
+		// even though it's busy.
+		req.Force = true
+	}*/
+
+	/*} else if err == nil {
+		if !req.Force {
+			return errors.Wrap(Busy, "container is open and Force not set")
+		}
+		if err := daosError(C.daos_cont_close(contConn.daosHandle, nil)); err != nil {
+			return errors.Wrap(err, "failed to close container before destroy")
+		}
+	}*/
+
+	cID := C.CString(contID)
+	defer freeString(cID)
+
+	rc := client.daos_cont_destroy(poolConn.daosHandle, cID, goBool2int(force), nil)
+	if err := daosError(rc); err != nil {
+		return errors.Wrap(err, "failed to destroy container")
+	}
+
+	return nil
+}
+
+func (b *daosClientBinding) daos_cont_open(poolHdl C.daos_handle_t, contID *C.char, flags C.uint, contHdl *C.daos_handle_t, info *C.daos_cont_info_t, ev *C.struct_daos_event) C.int {
+	return C.daos_cont_open(poolHdl, contID, flags, contHdl, info, ev)
+}
+
+func (m *mockApiClient) daos_cont_open(_ C.daos_handle_t, _ *C.char, _ C.uint, contHdl *C.daos_handle_t, info *C.daos_cont_info_t, _ *C.struct_daos_event) C.int {
+	if rc := m.getRc("daos_cont_open", 0); rc != 0 {
+		return rc
+	}
+
+	contHdl.cookie = 42
+	if err := copyUUID(&info.ci_uuid, m.cfg.ConnectedCont); err != nil {
+		panic(err)
+	}
+	return 0
+}
+
+func ContainerOpen(ctx context.Context, poolConn *PoolHandle, contID string, flags ...ContainerOpenFlag) (*ContainerHandle, error) {
+	log.Debugf("ContainerOpen(%s:%s)", poolConn, contID)
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cID := C.CString(contID)
+	defer freeString(cID)
+
+	var contConn ContainerHandle
+	var contInfo C.daos_cont_info_t
+
+	if len(flags) == 0 {
+		flags = append(flags, ContainerOpenFlagReadOnly)
+	}
+	var cFlags C.uint
+	for _, flag := range flags {
+		cFlags |= C.uint(flag)
+	}
+	err = daosError(client.daos_cont_open(poolConn.daosHandle, cID,
+		cFlags, &contConn.daosHandle, &contInfo, nil))
+	if err != nil {
+		return nil, err
+	}
+
+	contConn.PoolHandle = poolConn
+	contConn.UUID, err = uuidFromC(contInfo.ci_uuid)
+	if err != nil {
+		if dErr := daosError(C.daos_cont_close(contConn.daosHandle, nil)); dErr != nil {
+			return nil, errors.Wrapf(dErr, "while handling %s", err)
+		}
+		return nil, err
+	}
+
+	return &contConn, nil
+}
+
+func (b *daosClientBinding) daos_cont_close(contHdl C.daos_handle_t, ev *C.struct_daos_event) C.int {
+	// Hack for NLT fault injection testing: If the rc
+	// is -DER_NOMEM, retry once in order to actually
+	// shut down and release resources.
+	rc := C.daos_cont_close(contHdl, ev)
+	if rc == -C.DER_NOMEM {
+		rc = C.daos_cont_close(contHdl, ev)
+	}
+
+	return rc
+}
+
+func (m *mockApiClient) daos_cont_close(contHdl C.daos_handle_t, _ *C.struct_daos_event) C.int {
+	if rc := m.getRc("daos_cont_close", 0); rc != 0 {
+		return rc
+	}
+
+	contHdl.cookie = 0
+	return 0
+}
+
+func (ch *ContainerHandle) Close(ctx context.Context) error {
+	return ContainerClose(ctx, ch)
+}
+
+func ContainerClose(ctx context.Context, contConn *ContainerHandle) error {
+	log.Debugf("ContainerClose(%s)", contConn)
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := daosError(client.daos_cont_close(contConn.daosHandle, nil)); err != nil {
+		return err
+	}
+	contConn.invalidate()
+
+	return nil
+}
+
+func containerQueryDFSAttrs(ctx context.Context, poolConn *PoolHandle, contConn *ContainerHandle) (*POSIXAttributes, error) {
+	var pa POSIXAttributes
+	var dfs *C.dfs_t
+	var attr C.dfs_attr_t
+
+	rc := C.dfs_mount(poolConn.daosHandle, contConn.daosHandle, C.O_RDONLY, &dfs)
+	if err := dfsError(rc); err != nil {
+		return nil, errors.Wrap(err, "failed to mount container")
+	}
+
+	rc = C.dfs_query(dfs, &attr)
+	if err := dfsError(rc); err != nil {
+		return nil, errors.Wrap(err, "failed to query container")
+	}
+	pa.ObjectClass = ObjectClass(attr.da_oclass_id)
+	pa.DirObjectClass = ObjectClass(attr.da_dir_oclass_id)
+	pa.FileObjectClass = ObjectClass(attr.da_file_oclass_id)
+	pa.Hints = C.GoString(&attr.da_hints[0])
+	pa.ChunkSize = uint64(attr.da_chunk_size)
+
+	if err := dfsError(C.dfs_umount(dfs)); err != nil {
+		return nil, errors.Wrap(err, "failed to unmount container")
+	}
+
+	return &pa, nil
+}
+
+func (b *daosClientBinding) daos_cont_query(contHdl C.daos_handle_t, dci *C.daos_cont_info_t, props *C.daos_prop_t, ev *C.struct_daos_event) C.int {
+	return C.daos_cont_query(contHdl, dci, props, ev)
+}
+
+func (m *mockApiClient) daos_cont_query(contHdl C.daos_handle_t, dci *C.daos_cont_info_t, props *C.daos_prop_t, ev *C.struct_daos_event) C.int {
+	if rc := m.getRc("daos_cont_query", 0); rc != 0 {
+		return rc
+	}
+
+	return 0
+}
+
+func (ch *ContainerHandle) Query(ctx context.Context) (*ContainerInfo, error) {
+	return ContainerQuery(ctx, ch)
+}
+
+func ContainerQuery(ctx context.Context, contConn *ContainerHandle) (*ContainerInfo, error) {
+	log.Debugf("ContainerQuery(%s)", contConn)
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	props, entries, err := allocProps(3)
+	if err != nil {
+		return nil, err
+	}
+	defer freeProps(props)
+
+	entries[0].dpe_type = C.DAOS_PROP_CO_LAYOUT_TYPE
+	props.dpp_nr++
+	entries[1].dpe_type = C.DAOS_PROP_CO_LABEL
+	props.dpp_nr++
+	entries[2].dpe_type = C.DAOS_PROP_CO_REDUN_FAC
+	props.dpp_nr++
+
+	var dci C.daos_cont_info_t
+	if err := daosError(client.daos_cont_query(contConn.daosHandle, &dci, props, nil)); err != nil {
+		return nil, errors.Wrap(err, "failed to query container")
+	}
+
+	info := newContainerInfo(dci.ci_uuid, &dci, entries)
+	info.PoolUUID = contConn.PoolHandle.UUID
+
+	if info.Type == ContainerLayoutPOSIX {
+		posixAttrs, err := containerQueryDFSAttrs(ctx, contConn.PoolHandle, contConn)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to query DFS attributes")
+		}
+		info.POSIXAttributes = posixAttrs
+	}
+
+	return info, nil
+}
+
+func containerGetACLProps(contConn *ContainerHandle, propSet ContainerPropertySet) (func(), error) {
+	expPropNr := 3 // ACL, user, group
+
+	var props *C.daos_prop_t
+	rc := C.daos_cont_get_acl(contConn.daosHandle, &props, nil)
+	if err := daosError(rc); err != nil {
+		return nil, err
+	}
+	if props.dpp_nr != C.uint(expPropNr) {
+		return nil, errors.Errorf("invalid number of ACL props (%d != %d)",
+			props.dpp_nr, expPropNr)
+	}
+	cleanup := func() { C.daos_prop_free(props) }
+
+	entries := createPropSlice(props, expPropNr)
+	for i, entry := range entries {
+		switch entry.dpe_type {
+		case C.DAOS_PROP_CO_ACL:
+			propSet.addProp("acl", &ContainerProperty{
+				entry:       &entries[i],
+				handler:     &contPropHandler{toString: aclStringer},
+				Name:        "acl",
+				Description: "Access Control List",
+			})
+		case C.DAOS_PROP_CO_OWNER:
+			propSet.addProp("user", &ContainerProperty{
+				entry:       &entries[i],
+				handler:     &contPropHandler{toString: strValStringer},
+				Name:        "user",
+				Description: "User",
+			})
+		case C.DAOS_PROP_CO_OWNER_GROUP:
+			propSet.addProp("group", &ContainerProperty{
+				entry:       &entries[i],
+				handler:     &contPropHandler{toString: strValStringer},
+				Name:        "group",
+				Description: "Group",
+			})
+		}
+	}
+
+	return cleanup, nil
+}
+
+func (ch *ContainerHandle) GetProperties(ctx context.Context, names ...string) (ContainerPropertySet, error) {
+	return ContainerGetProperties(ctx, ch, names...)
+}
+
+func ContainerGetProperties(ctx context.Context, contConn *ContainerHandle, names ...string) (ContainerPropertySet, error) {
+	log.Debugf("ContainerGetProperties(%s:%s)", contConn, names)
+
+	if err := ctx.Err(); err != nil {
+		return nil, ctxErr(err)
+	}
+
+	if len(names) == 0 {
+		names = ContainerProperties.Keys()
+	}
+	props, entries, err := allocProps(len(names))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { C.daos_prop_free(props) }()
+
+	propSet := make(ContainerPropertySet)
+	for _, name := range names {
+		var hdlr *contPropHandler
+		hdlr, err = ContainerProperties.get(name)
+		if err != nil {
+			return nil, err
+		}
+		entries[props.dpp_nr].dpe_type = C.uint(hdlr.dpeType)
+
+		propSet[name] = &ContainerProperty{
+			entry:       &entries[props.dpp_nr],
+			handler:     hdlr,
+			Name:        name,
+			Description: hdlr.shortDesc,
+		}
+
+		props.dpp_nr++
+	}
+
+	rc := C.daos_cont_query(contConn.daosHandle, nil, props, nil)
+	if err = daosError(rc); err != nil {
+		return nil, err
+	}
+
+	// FIXME: These ACL properties are synthesized on the fly and added
+	// into the results for an all-properties request. There is no way
+	// to query for them directly, however, as they do not have handlers
+	// configured in the property handler map.
+	//
+	// TODO (mjmac): Why can't/shouldn't these be set/get like other
+	// properties? I suspect that they could, and we could phase out
+	// direct use of the dedicated ACL management APIs in favor of calling
+	// them from the property management logic.
+	if len(names) == len(ContainerProperties) {
+		aclCleanup, err := containerGetACLProps(contConn, propSet)
+		if err != nil {
+			// Not a fatal error if we don't have permission to read the ACL.
+			if err != daos.NoPermission {
+				return nil, err
+			}
+		} else {
+			defer aclCleanup()
+		}
+	}
+
+	// Copy the entries to Go-managed memory so that we can free the C memory here.
+	for _, prop := range propSet {
+		var tmp C.struct_daos_prop_entry
+		if err := dupePropEntry(prop.entry, &tmp); err != nil {
+			return nil, err
+		}
+		prop.entry = &tmp
+	}
+
+	return propSet, nil
+}
+
+func (ch *ContainerHandle) SetProperties(ctx context.Context, propSet ContainerPropertySet) error {
+	return ContainerSetProperties(ctx, ch, propSet)
+}
+
+func ContainerSetProperties(ctx context.Context, contConn *ContainerHandle, propSet ContainerPropertySet) error {
+	log.Debugf("ContainerSetProperties(%s:%v)", contConn, propSet)
+
+	if err := ctx.Err(); err != nil {
+		return ctxErr(err)
+	}
+
+	if len(propSet) == 0 {
+		return errors.Wrap(daos.InvalidInput, "no properties to set")
+	}
+
+	cProps, cleanup, err := propSet.cArrPtr()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := daosError(C.daos_cont_set_prop(contConn.daosHandle, cProps, nil)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ch *ContainerHandle) ListAttributes(ctx context.Context) ([]string, error) {
+	return ContainerListAttributes(ctx, ch)
+}
+
+func ContainerListAttributes(ctx context.Context, contConn *ContainerHandle) ([]string, error) {
+	log.Debugf("ContainerListAttributes(%s)", contConn)
+
+	if contConn == nil {
+		return nil, errInvalidContainerHandle
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, ctxErr(err)
+	}
+
+	return listDaosAttributes(contConn.daosHandle, contAttr)
+}
+
+func (ch *ContainerHandle) GetAttributes(ctx context.Context, names ...string) ([]*daos.Attribute, error) {
+	return ContainerGetAttributes(ctx, ch, names...)
+}
+
+func ContainerGetAttributes(ctx context.Context, contConn *ContainerHandle, names ...string) ([]*daos.Attribute, error) {
+	log.Debugf("ContainerGetAttributes(%s:%v)", contConn, names)
+
+	if contConn == nil {
+		return nil, errInvalidContainerHandle
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, ctxErr(err)
+	}
+
+	return getDaosAttributes(contConn.daosHandle, contAttr, names)
+}
+
+func (ch *ContainerHandle) SetAttributes(ctx context.Context, attrs []*daos.Attribute) error {
+	return ContainerSetAttributes(ctx, ch, attrs)
+}
+
+func ContainerSetAttributes(ctx context.Context, contConn *ContainerHandle, attrs []*daos.Attribute) error {
+	log.Debugf("ContainerSetAttributes(%s:%v)", contConn, attrs)
+
+	if contConn == nil {
+		return errInvalidContainerHandle
+	}
+
+	if err := ctx.Err(); err != nil {
+		return ctxErr(err)
+	}
+
+	return setDaosAttributes(contConn.daosHandle, contAttr, attrs)
+}
+
+func (ch *ContainerHandle) DeleteAttribute(ctx context.Context, attrName string) error {
+	return ContainerDeleteAttribute(ctx, ch, attrName)
+}
+
+func ContainerDeleteAttribute(ctx context.Context, contConn *ContainerHandle, attrName string) error {
+	log.Debugf("ContainerDeleteAttribute(%s:%s)", contConn, attrName)
+
+	if contConn == nil {
+		return errInvalidContainerHandle
+	}
+
+	if err := ctx.Err(); err != nil {
+		return ctxErr(err)
+	}
+
+	return delDaosAttribute(contConn.daosHandle, contAttr, attrName)
+}

--- a/src/control/lib/daos/client/errors.go
+++ b/src/control/lib/daos/client/errors.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+)
+
+/*
+#include <string.h>
+*/
+import "C"
+
+var (
+	errInvalidContainerHandle = errors.New("container handle was nil or invalid")
+	errInvalidPoolHandle      = errors.New("pool handle was nil or invalid")
+)
+
+// dfsError converts a return code from a DFS API
+// call to a Go error.
+func dfsError(rc C.int) error {
+	if rc == 0 {
+		return nil
+	}
+
+	strErr := C.strerror(rc)
+	return errors.Errorf("DFS error %d: %s", rc, C.GoString(strErr))
+}
+
+// daosError converts a return code from a DAOS API
+// call to a Go error.
+func daosError(rc C.int) error {
+	if rc == 0 {
+		return nil
+	}
+	return daos.Status(rc)
+}
+
+func ctxErr(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled):
+		return errors.Wrap(daos.Canceled, "DAOS API context canceled")
+	case errors.Is(err, context.DeadlineExceeded):
+		return errors.Wrap(daos.TimedOut, "DAOS API context deadline exceeded")
+	default:
+		return errors.Wrap(daos.MiscError, "DAOS API context error")
+	}
+}

--- a/src/control/lib/daos/client/mocks.go
+++ b/src/control/lib/daos/client/mocks.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+import "C"
+
+type (
+	MockApiClientConfig struct {
+		ReturnCodeMap map[string]int
+		ConnectedPool uuid.UUID
+		ConnectedCont uuid.UUID
+	}
+
+	mockApiClient struct {
+		cfg *MockApiClientConfig
+	}
+)
+
+func MockApiClientContext(parent context.Context, cfg *MockApiClientConfig) (context.Context, error) {
+	if cfg == nil {
+		cfg = &MockApiClientConfig{
+			ReturnCodeMap: map[string]int{},
+		}
+	}
+
+	client := &mockApiClient{
+		cfg: cfg,
+	}
+
+	ctx, err := setApiClient(parent, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return ctx, nil
+}
+
+func (c *mockApiClient) getRc(key string, def int) C.int {
+	if rc, ok := c.cfg.ReturnCodeMap[key]; ok {
+		return C.int(rc)
+	}
+	return C.int(def)
+}
+
+func (c *mockApiClient) daos_init() C.int {
+	return c.getRc("daos_init", 0)
+}
+
+func (c *mockApiClient) daos_fini() C.int {
+	return c.getRc("daos_fini", 0)
+}
+
+func (c *mockApiClient) daos_debug_init(_ *C.char) C.int {
+	return c.getRc("daos_debug_init", 0)
+}
+
+func (c *mockApiClient) daos_debug_fini() {}

--- a/src/control/lib/daos/client/mocks/container.go
+++ b/src/control/lib/daos/client/mocks/container.go
@@ -1,0 +1,87 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
+)
+
+type (
+	GetPropertiesResp struct {
+		Err
+		Properties daosAPI.ContainerPropertySet
+	}
+
+	ContConnCfg struct {
+		ConnectedPool      uuid.UUID
+		ConnectedContainer uuid.UUID
+		Close              Err
+		ListAttributes     ListAttributesResp
+		GetAttributes      GetAttributesResp
+		SetAttributes      Err
+		DeleteAttribute    Err
+		GetProperties      GetPropertiesResp
+		SetProperties      Err
+		Query              ContainerInfoResp
+	}
+
+	ContConn struct {
+		cfg *ContConnCfg
+	}
+)
+
+func (mcc *ContConn) UUID() uuid.UUID {
+	if mcc.cfg == nil {
+		return uuid.Nil
+	}
+	return mcc.cfg.ConnectedContainer
+}
+
+func (mcc *ContConn) PoolUUID() uuid.UUID {
+	if mcc.cfg == nil {
+		return uuid.Nil
+	}
+	return mcc.cfg.ConnectedPool
+}
+
+func (mcc *ContConn) Close(context.Context) error {
+	return mcc.cfg.Close.Error
+}
+
+func (mcc *ContConn) ListAttributes(context.Context) ([]string, error) {
+	return mcc.cfg.ListAttributes.Attributes, mcc.cfg.ListAttributes.Error
+}
+
+func (mcc *ContConn) GetAttributes(context.Context, ...string) ([]*daos.Attribute, error) {
+	return mcc.cfg.GetAttributes.Attributes, mcc.cfg.GetAttributes.Error
+}
+
+func (mcc *ContConn) SetAttributes(context.Context, []*daos.Attribute) error {
+	return mcc.cfg.SetAttributes.Error
+}
+
+func (mcc *ContConn) DeleteAttribute(context.Context, string) error {
+	return mcc.cfg.DeleteAttribute.Error
+}
+
+func (mcc *ContConn) GetProperties(context.Context, ...string) (daosAPI.ContainerPropertySet, error) {
+	return mcc.cfg.GetProperties.Properties, mcc.cfg.GetProperties.Error
+}
+
+func (mcc *ContConn) SetProperties(context.Context, daosAPI.ContainerPropertySet) error {
+	return mcc.cfg.SetProperties.Error
+}
+
+func (mcc *ContConn) Query(context.Context) (*daosAPI.ContainerInfo, error) {
+	return mcc.cfg.Query.ContainerInfo, mcc.cfg.Query.Error
+}
+
+func newMockContConn(cfg *ContConnCfg) *ContConn {
+	if cfg == nil {
+		cfg = &ContConnCfg{}
+	}
+	return &ContConn{cfg: cfg}
+}

--- a/src/control/lib/daos/client/mocks/pool.go
+++ b/src/control/lib/daos/client/mocks/pool.go
@@ -1,0 +1,161 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
+)
+
+type (
+	Err struct {
+		Error error
+	}
+
+	ContainerInfoResp struct {
+		Err
+		ContainerInfo *daosAPI.ContainerInfo
+	}
+
+	ListContainersResp struct {
+		Err
+		Containers []*daosAPI.ContainerInfo
+	}
+
+	OpenContainerResp struct {
+		Err
+		Conn *ContConn
+	}
+
+	GetAttributesResp struct {
+		Err
+		Attributes []*daos.Attribute
+	}
+
+	ListAttributesResp struct {
+		Err
+		Attributes []string
+	}
+
+	PoolInfoResp struct {
+		Err
+		PoolInfo *daos.PoolInfo
+	}
+
+	PoolConnCfg struct {
+		ConnectedPool    uuid.UUID
+		ContConnCfg      *ContConnCfg
+		Connect          Err
+		Disconnect       Err
+		Query            PoolInfoResp
+		CreateContainer  ContainerInfoResp
+		OpenContainer    OpenContainerResp
+		ListContainers   ListContainersResp
+		DestroyContainer Err
+		GetAttributes    GetAttributesResp
+		SetAttributes    Err
+		ListAttributes   ListAttributesResp
+		DeleteAttribute  Err
+	}
+
+	PoolConn struct {
+		cfg *PoolConnCfg
+	}
+)
+
+func NewPoolConn(cfg *PoolConnCfg) *PoolConn {
+	if cfg == nil {
+		cfg = &PoolConnCfg{}
+	}
+	if cfg.ConnectedPool == uuid.Nil {
+		cfg.ConnectedPool = uuid.New()
+	}
+	return &PoolConn{
+		cfg: cfg,
+	}
+}
+
+func (mpc *PoolConn) Connect(context.Context, string, string, daosAPI.PoolConnectFlag) error {
+	return mpc.cfg.Connect.Error
+}
+
+func (mpc *PoolConn) Disconnect(context.Context) error {
+	return mpc.cfg.Disconnect.Error
+}
+
+func (mpc *PoolConn) Query(context.Context, daosAPI.PoolQueryReq) (*daos.PoolInfo, error) {
+	return mpc.cfg.Query.PoolInfo, mpc.cfg.Query.Error
+}
+
+func (mpc *PoolConn) CreateContainer(_ context.Context, req daosAPI.ContainerCreateReq) (*daosAPI.ContainerInfo, error) {
+	if mpc.cfg.CreateContainer.ContainerInfo != nil || mpc.cfg.CreateContainer.Error != nil {
+		return mpc.cfg.CreateContainer.ContainerInfo, mpc.cfg.CreateContainer.Error
+	}
+
+	if mpc.cfg.ContConnCfg == nil {
+		mpc.cfg.ContConnCfg = &ContConnCfg{
+			ConnectedPool:      mpc.cfg.ConnectedPool,
+			ConnectedContainer: uuid.New(),
+		}
+	}
+	newContInfo := &daosAPI.ContainerInfo{
+		PoolUUID:        mpc.cfg.ConnectedPool,
+		UUID:            mpc.cfg.ContConnCfg.ConnectedContainer,
+		Label:           req.Label,
+		Type:            req.Type,
+		POSIXAttributes: req.POSIXAttributes,
+	}
+	mpc.cfg.CreateContainer.ContainerInfo = newContInfo
+	if mpc.cfg.OpenContainer.Error == nil {
+		mpc.cfg.ContConnCfg.Query.ContainerInfo = newContInfo
+		mpc.cfg.ContConnCfg.GetProperties.Properties = req.Properties
+		mpc.cfg.OpenContainer.Conn = newMockContConn(mpc.cfg.ContConnCfg)
+	}
+
+	return mpc.cfg.CreateContainer.ContainerInfo, mpc.cfg.CreateContainer.Error
+}
+
+func (mpc *PoolConn) OpenContainer(context.Context, string, daosAPI.ContainerOpenFlag) (*ContConn, error) {
+	conn := mpc.cfg.OpenContainer.Conn
+	if conn == nil && mpc.cfg.OpenContainer.Error == nil {
+		conn = newMockContConn(&ContConnCfg{
+			ConnectedPool:      mpc.cfg.ConnectedPool,
+			ConnectedContainer: uuid.New(),
+		})
+	}
+
+	return conn, mpc.cfg.OpenContainer.Error
+}
+
+func (mpc *PoolConn) UUID() uuid.UUID {
+	if mpc.cfg == nil {
+		return uuid.Nil
+	}
+	return mpc.cfg.ConnectedPool
+}
+
+func (mpc *PoolConn) DestroyContainer(context.Context, string, bool) error {
+	return mpc.cfg.DestroyContainer.Error
+}
+
+func (mpc *PoolConn) ListContainers(context.Context, bool) ([]*daosAPI.ContainerInfo, error) {
+	return mpc.cfg.ListContainers.Containers, mpc.cfg.ListContainers.Error
+}
+
+func (mpc *PoolConn) ListAttributes(context.Context) ([]string, error) {
+	return mpc.cfg.ListAttributes.Attributes, mpc.cfg.ListAttributes.Error
+}
+
+func (mpc *PoolConn) GetAttributes(context.Context, ...string) ([]*daos.Attribute, error) {
+	return mpc.cfg.GetAttributes.Attributes, mpc.cfg.GetAttributes.Error
+}
+
+func (mpc *PoolConn) SetAttributes(context.Context, []*daos.Attribute) error {
+	return mpc.cfg.SetAttributes.Error
+}
+
+func (mpc *PoolConn) DeleteAttribute(context.Context, string) error {
+	return mpc.cfg.DeleteAttribute.Error
+}

--- a/src/control/lib/daos/client/mocks/util.go
+++ b/src/control/lib/daos/client/mocks/util.go
@@ -1,0 +1,47 @@
+package mocks
+
+import (
+	"context"
+
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
+)
+
+var (
+	mockContConnKey connKey = "mockContConn"
+	mockPoolConnKey connKey = "mockPoolConn"
+)
+
+func PoolConnCtx(parent context.Context, cfg *PoolConnCfg) context.Context {
+	if daosAPICtx, err := daosAPI.MockApiClientContext(parent, nil); err == nil {
+		parent = daosAPICtx
+	}
+	return context.WithValue(parent, mockPoolConnKey, NewPoolConn(cfg))
+}
+
+func GetPoolConn(ctx context.Context) *PoolConn {
+	if conn, ok := ctx.Value(mockPoolConnKey).(*PoolConn); ok {
+		return conn
+	}
+	return nil
+}
+
+func ContConnCtx(parent context.Context, cfg *ContConnCfg) context.Context {
+	if daosAPICtx, err := daosAPI.MockApiClientContext(parent, nil); err == nil {
+		parent = daosAPICtx
+	}
+	return context.WithValue(parent, mockContConnKey, newMockContConn(cfg))
+}
+
+func GetContConn(ctx context.Context) *ContConn {
+	if conn, ok := ctx.Value(mockContConnKey).(*ContConn); ok && conn != nil {
+		return conn
+	}
+	if poolConn := GetPoolConn(ctx); poolConn != nil {
+		return newMockContConn(poolConn.cfg.ContConnCfg)
+	}
+	return nil
+}
+
+type (
+	connKey string
+)

--- a/src/control/lib/daos/client/object.go
+++ b/src/control/lib/daos/client/object.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"strings"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/pkg/errors"
+)
+
+/*
+#include <daos.h>
+#include <daos_obj_class.h>
+*/
+import "C"
+
+type (
+	ObjectClass C.daos_oclass_id_t
+)
+
+func (oc *ObjectClass) FromString(cls string) error {
+	cStr := C.CString(strings.ToUpper(cls))
+	defer freeString(cStr)
+
+	*oc = ObjectClass(C.daos_oclass_name2id(cStr))
+	if *oc == C.OC_UNKNOWN {
+		return errors.Wrapf(daos.InvalidInput, "invalid object class %q", cls)
+	}
+
+	return nil
+}
+
+func (oc ObjectClass) String() string {
+	var oclass [10]C.char
+
+	C.daos_oclass_id2name(C.daos_oclass_id_t(oc), &oclass[0])
+	return C.GoString(&oclass[0])
+}

--- a/src/control/lib/daos/client/object_io.go
+++ b/src/control/lib/daos/client/object_io.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"unsafe"
+
+	"github.com/pkg/errors"
+)
+
+/*
+#include <daos.h>
+#include <daos/common.h>
+*/
+import "C"
+
+type (
+	// RequestBuffers is a slice of byte slices.
+	RequestBuffers [][]byte
+
+	// SGList wraps a C.daos_sg_list_t.
+	SGList struct {
+		complete bool
+		buffers  RequestBuffers
+		sgl      C.d_sg_list_t
+	}
+)
+
+// NewSGList initializes a DAOS scatter-gather list with the
+// provided RequestBuffers slices.
+func NewSGList(bufs RequestBuffers) (*SGList, error) {
+	if len(bufs) == 0 {
+		return nil, errors.New("empty RequestBuffers")
+	}
+
+	bufNr := C.size_t(len(bufs))
+	iovPtr := (*C.d_iov_t)(C.calloc(bufNr, C.sizeof_d_iov_t))
+
+	iovs := unsafe.Slice(iovPtr, bufNr)
+	for i := range iovs {
+		if len(bufs[i]) == 0 {
+			return nil, errors.Errorf("buffer %d is zero-length", i)
+		}
+		iovs[i].iov_len = C.daos_size_t(len(bufs[i]))
+		iovs[i].iov_buf_len = C.daos_size_t(cap(bufs[i]))
+		iovs[i].iov_buf = unsafe.Pointer(&bufs[i][0]) // zero copy
+	}
+
+	return &SGList{
+		buffers: bufs,
+		sgl: C.d_sg_list_t{
+			sg_nr:   C.uint32_t(bufNr),
+			sg_iovs: iovPtr,
+		},
+	}, nil
+}

--- a/src/control/lib/daos/client/pool.go
+++ b/src/control/lib/daos/client/pool.go
@@ -1,0 +1,430 @@
+package client
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"unsafe"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
+)
+
+/*
+#include <gurt/common.h>
+#include <daos.h>
+#include <daos_pool.h>
+
+static inline uint32_t
+get_rebuild_state(struct daos_rebuild_status *drs)
+{
+	if (drs == NULL)
+		return 0;
+
+	return drs->rs_state;
+}
+*/
+import "C"
+
+type (
+	PoolConnectFlag uint
+)
+
+const (
+	PoolConnectFlagReadOnly  PoolConnectFlag = C.DAOS_PC_RO
+	PoolConnectFlagReadWrite PoolConnectFlag = C.DAOS_PC_RW
+	PoolConnectFlagExclusive PoolConnectFlag = C.DAOS_PC_EX
+)
+
+func newPoolSpaceInfo(dps *C.struct_daos_pool_space, mt C.uint) *daos.StorageUsageStats {
+	if dps == nil {
+		return nil
+	}
+
+	return &daos.StorageUsageStats{
+		Total:     uint64(dps.ps_space.s_total[mt]),
+		Free:      uint64(dps.ps_space.s_free[mt]),
+		Min:       uint64(dps.ps_free_min[mt]),
+		Max:       uint64(dps.ps_free_max[mt]),
+		Mean:      uint64(dps.ps_free_mean[mt]),
+		MediaType: daos.StorageMediaType(mt),
+	}
+}
+
+func newPoolRebuildStatus(drs *C.struct_daos_rebuild_status) *daos.PoolRebuildStatus {
+	if drs == nil {
+		return nil
+	}
+
+	compatRebuildState := func() daos.PoolRebuildState {
+		switch {
+		case drs.rs_version == 0:
+			return daos.PoolRebuildStateIdle
+		case C.get_rebuild_state(drs) == C.DRS_COMPLETED:
+			return daos.PoolRebuildStateDone
+		default:
+			return daos.PoolRebuildStateBusy
+		}
+	}
+
+	return &daos.PoolRebuildStatus{
+		Status:  int32(drs.rs_errno),
+		Objects: uint64(drs.rs_obj_nr),
+		Records: uint64(drs.rs_rec_nr),
+		State:   compatRebuildState(),
+	}
+}
+
+func newPoolInfo(cpi *C.daos_pool_info_t) *daos.PoolInfo {
+	return &daos.PoolInfo{
+		UUID:            uuid.Must(uuidFromC(cpi.pi_uuid)),
+		TotalTargets:    uint32(cpi.pi_ntargets),
+		ActiveTargets:   uint32(cpi.pi_ntargets - cpi.pi_ndisabled),
+		TotalEngines:    uint32(cpi.pi_nnodes),
+		DisabledTargets: uint32(cpi.pi_ndisabled),
+		Version:         uint32(cpi.pi_map_ver),
+		Leader:          uint32(cpi.pi_leader),
+		Rebuild:         newPoolRebuildStatus(&cpi.pi_rebuild_st),
+		TierStats: []*daos.StorageUsageStats{
+			newPoolSpaceInfo(&cpi.pi_space, C.DAOS_MEDIA_SCM),
+			newPoolSpaceInfo(&cpi.pi_space, C.DAOS_MEDIA_NVME),
+		},
+	}
+}
+
+type (
+	PoolConnectResp struct {
+		PoolConnection *PoolHandle
+		PoolInfo       *daos.PoolInfo
+	}
+)
+
+func (ph *PoolHandle) CreateContainer(ctx context.Context, req ContainerCreateReq) (*ContainerInfo, error) {
+	return ContainerCreate(ctx, ph, req)
+}
+
+func (ph *PoolHandle) DestroyContainer(ctx context.Context, contID string, force bool) error {
+	return ContainerDestroy(ctx, ph, contID, force)
+}
+
+func (ph *PoolHandle) OpenContainer(ctx context.Context, contID string, flags ...ContainerOpenFlag) (*ContainerHandle, error) {
+	return ContainerOpen(ctx, ph, contID, flags...)
+}
+
+func (ph *PoolHandle) Query(ctx context.Context, req PoolQueryReq) (*daos.PoolInfo, error) {
+	return PoolQuery(ctx, ph, req)
+}
+
+func (ph *PoolHandle) Disconnect(ctx context.Context) error {
+	return PoolDisconnect(ctx, ph)
+}
+
+func (ph *PoolHandle) ListContainers(ctx context.Context, query bool) ([]*ContainerInfo, error) {
+	return PoolListContainers(ctx, ph, query)
+}
+
+func (ph *PoolHandle) ListAttributes(ctx context.Context) ([]string, error) {
+	return PoolListAttributes(ctx, ph)
+}
+
+func (ph *PoolHandle) GetAttributes(ctx context.Context, names ...string) ([]*daos.Attribute, error) {
+	return PoolGetAttributes(ctx, ph, names...)
+}
+
+func (ph *PoolHandle) SetAttributes(ctx context.Context, attrs []*daos.Attribute) error {
+	return PoolSetAttributes(ctx, ph, attrs)
+}
+
+func (ph *PoolHandle) DeleteAttribute(ctx context.Context, attrName string) error {
+	return PoolDeleteAttribute(ctx, ph, attrName)
+}
+
+func (b *daosClientBinding) daos_pool_connect(poolID *C.char, sys *C.char, flags C.uint, poolHdl *C.daos_handle_t, poolInfo *C.daos_pool_info_t, ev *C.struct_daos_event) C.int {
+	return C.daos_pool_connect(poolID, sys, flags, poolHdl, poolInfo, ev)
+}
+
+func (m *mockApiClient) daos_pool_connect(poolID *C.char, sys *C.char, flags C.uint, poolHdl *C.daos_handle_t, poolInfo *C.daos_pool_info_t, ev *C.struct_daos_event) C.int {
+	if rc := m.getRc("daos_pool_connect", 0); rc != 0 {
+		return rc
+	}
+
+	poolHdl.cookie = 42
+	poolInfo.pi_uuid = uuidToC(m.cfg.ConnectedPool)
+	return 0
+}
+
+func PoolConnect(ctx context.Context, poolID, sysID string, flags PoolConnectFlag) (*PoolConnectResp, error) {
+	log.Debugf("PoolConnect(%s)", poolID)
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if poolID == "" {
+		return nil, errors.Wrap(daos.InvalidInput, "no pool ID provided")
+	}
+	if sysID == "" {
+		sysID = build.DefaultSystemName
+	}
+	if flags == 0 {
+		flags = PoolConnectFlagReadOnly
+	}
+
+	var dpi C.daos_pool_info_t
+	var poolConn PoolHandle
+
+	cPoolID := C.CString(poolID)
+	defer freeString(cPoolID)
+	cSys := C.CString(sysID)
+	defer freeString(cSys)
+
+	if err := daosError(client.daos_pool_connect(cPoolID, cSys, C.uint(flags), &poolConn.daosHandle, &dpi, nil)); err != nil {
+		return nil, errors.Wrap(err, "failed to connect to pool")
+	}
+
+	poolInfo := newPoolInfo(&dpi)
+	poolConn.UUID = poolInfo.UUID
+	return &PoolConnectResp{
+		PoolConnection: &poolConn,
+		PoolInfo:       poolInfo,
+	}, nil
+}
+
+func generateRankSet(ranklist *C.d_rank_list_t) string {
+	if ranklist.rl_nr == 0 {
+		return ""
+	}
+
+	rankSlice := unsafe.Slice((*C.d_rank_t)(unsafe.Pointer(ranklist.rl_ranks)), ranklist.rl_nr)
+	ranks := make([]string, len(rankSlice))
+	for i, rank := range rankSlice {
+		ranks[i] = strconv.Itoa(int(rank))
+	}
+	return "[" + strings.Join(ranks, ",") + "]"
+}
+
+func (b *daosClientBinding) daos_pool_query(poolHdl C.daos_handle_t, rankList **C.d_rank_list_t, poolInfo *C.daos_pool_info_t, props *C.daos_prop_t, ev *C.struct_daos_event) C.int {
+	return C.daos_pool_query(poolHdl, rankList, poolInfo, props, ev)
+}
+
+func (m *mockApiClient) daos_pool_query(poolHdl C.daos_handle_t, rankList **C.d_rank_list_t, poolInfo *C.daos_pool_info_t, props *C.daos_prop_t, ev *C.struct_daos_event) C.int {
+	return m.getRc("daos_pool_query", 0)
+}
+
+const (
+	dpiQuerySpace   = C.DPI_SPACE
+	dpiQueryRebuild = C.DPI_REBUILD_STATUS
+	dpiQueryAll     = C.uint64_t(^uint64(0)) // DPI_ALL is -1
+)
+
+type (
+	PoolQueryReq struct {
+		IncludeEnabled  bool
+		IncludeDisabled bool
+	}
+)
+
+func PoolQuery(ctx context.Context, poolConn *PoolHandle, req PoolQueryReq) (*daos.PoolInfo, error) {
+	log.Debugf("PoolQuery(%s:%+v)", poolConn, req)
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var rlPtr **C.d_rank_list_t = nil
+	var rl *C.d_rank_list_t = nil
+	defer C.d_rank_list_free(rl)
+
+	if req.IncludeEnabled || req.IncludeDisabled {
+		rlPtr = &rl
+	}
+
+	cpi := &C.daos_pool_info_t{
+		pi_bits: dpiQueryAll,
+	}
+	if req.IncludeDisabled {
+		cpi.pi_bits &= C.uint64_t(^(uint64(C.DPI_ENGINES_ENABLED)))
+	}
+
+	rc := client.daos_pool_query(poolConn.daosHandle, rlPtr, cpi, nil, nil)
+	if err := daosError(rc); err != nil {
+		return nil, err
+	}
+
+	dpi := newPoolInfo(cpi)
+	if rlPtr != nil {
+		if req.IncludeEnabled {
+			dpi.EnabledRanks, err = ranklist.CreateRankSet(generateRankSet(rl))
+			if err != nil {
+				return nil, err
+			}
+		}
+		if req.IncludeDisabled {
+			dpi.DisabledRanks, err = ranklist.CreateRankSet(generateRankSet(rl))
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return dpi, nil
+}
+
+func (b *daosClientBinding) daos_pool_disconnect(poolHdl C.daos_handle_t) C.int {
+	// Hack for NLT fault injection testing: If the rc
+	// is -DER_NOMEM, retry once in order to actually
+	// shut down and release resources.
+	rc := C.daos_pool_disconnect(poolHdl, nil)
+	if rc == -C.DER_NOMEM {
+		rc = C.daos_pool_disconnect(poolHdl, nil)
+		// DAOS-8866, daos_pool_disconnect() might have failed, but worked anyway.
+		if rc == -C.DER_NO_HDL {
+			rc = -C.DER_SUCCESS
+		}
+	}
+
+	return rc
+}
+
+func (m *mockApiClient) daos_pool_disconnect(poolHdl C.daos_handle_t) C.int {
+	return m.getRc("daos_pool_disconnect", 0)
+}
+
+func PoolDisconnect(ctx context.Context, poolConn *PoolHandle) error {
+	log.Debugf("PoolDisconnect(%s)", poolConn)
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := daosError(client.daos_pool_disconnect(poolConn.daosHandle)); err != nil {
+		return errors.Wrap(err, "failed to disconnect from pool")
+	}
+	poolConn.invalidate()
+
+	return nil
+}
+
+func PoolListContainers(ctx context.Context, poolConn *PoolHandle, query bool) ([]*ContainerInfo, error) {
+	log.Debugf("PoolListContainers(%s:%t)", poolConn, query)
+
+	if err := ctx.Err(); err != nil {
+		return nil, ctxErr(err)
+	}
+
+	extra_cont_margin := C.size_t(16)
+
+	// First call gets the current number of containers.
+	var ncont C.daos_size_t
+	rc := C.daos_pool_list_cont(poolConn.daosHandle, &ncont, nil, nil)
+	if err := daosError(rc); err != nil {
+		return nil, errors.Wrap(err, "pool list containers failed")
+	}
+
+	// No containers.
+	if ncont == 0 {
+		return nil, nil
+	}
+
+	var cConts *C.struct_daos_pool_cont_info
+	// Extend ncont with a safety margin to account for containers
+	// that might have been created since the first API call.
+	ncont += extra_cont_margin
+	cConts = (*C.struct_daos_pool_cont_info)(C.calloc(C.sizeof_struct_daos_pool_cont_info, ncont))
+	if cConts == nil {
+		return nil, errors.New("calloc() for containers failed")
+	}
+	dpciSlice := unsafe.Slice(cConts, ncont)
+	cleanup := func() {
+		C.free(unsafe.Pointer(cConts))
+	}
+
+	rc = C.daos_pool_list_cont(poolConn.daosHandle, &ncont, cConts, nil)
+	if err := daosError(rc); err != nil {
+		cleanup()
+		return nil, err
+	}
+	defer C.free(unsafe.Pointer(cConts))
+
+	out := make([]*ContainerInfo, ncont)
+	for i := range out {
+		out[i] = new(ContainerInfo)
+		out[i].PoolUUID = poolConn.UUID
+		out[i].UUID = uuid.Must(uuidFromC(dpciSlice[i].pci_uuid))
+		out[i].Label = C.GoString(&dpciSlice[i].pci_label[0])
+		contLabel := out[i].Label
+
+		if query {
+			contConn, err := ContainerOpen(ctx, poolConn, contLabel, ContainerOpenFlagReadOnly)
+			if err != nil {
+				log.Debugf("unable to open container %q for query: %s", contLabel, err)
+				continue
+			}
+
+			closeCont := func() {
+				if err := ContainerClose(ctx, contConn); err != nil {
+					log.Debugf("unable to close container %q: %s", out[i].Label, err)
+				}
+			}
+
+			info, err := ContainerQuery(ctx, contConn)
+			if err != nil {
+				log.Debugf("unable to query container %q: %s", contLabel, err)
+				closeCont()
+				continue
+			}
+
+			out[i] = info
+			closeCont()
+		}
+	}
+
+	return out, nil
+}
+
+func PoolListAttributes(ctx context.Context, poolConn *PoolHandle) ([]string, error) {
+	log.Debugf("PoolListAttributes(%s)", poolConn)
+
+	if err := ctx.Err(); err != nil {
+		return nil, ctxErr(err)
+	}
+
+	return listDaosAttributes(poolConn.daosHandle, poolAttr)
+}
+
+func PoolGetAttributes(ctx context.Context, poolConn *PoolHandle, names ...string) ([]*daos.Attribute, error) {
+	log.Debugf("PoolGetAttributes(%s:%v)", poolConn, names)
+
+	if err := ctx.Err(); err != nil {
+		return nil, ctxErr(err)
+	}
+
+	return getDaosAttributes(poolConn.daosHandle, poolAttr, names)
+}
+
+func PoolSetAttributes(ctx context.Context, poolConn *PoolHandle, attrs []*daos.Attribute) error {
+	log.Debugf("PoolSetAttributes(%s:%v)", poolConn, attrs)
+
+	if err := ctx.Err(); err != nil {
+		return ctxErr(err)
+	}
+
+	return setDaosAttributes(poolConn.daosHandle, poolAttr, attrs)
+}
+
+func PoolDeleteAttribute(ctx context.Context, poolConn *PoolHandle, attrName string) error {
+	log.Debugf("PoolDeleteAttribute(%s:%s)", poolConn, attrName)
+
+	if err := ctx.Err(); err != nil {
+		return ctxErr(err)
+	}
+
+	return delDaosAttribute(poolConn.daosHandle, poolAttr, attrName)
+}

--- a/src/control/lib/daos/client/uns.go
+++ b/src/control/lib/daos/client/uns.go
@@ -1,0 +1,200 @@
+package client
+
+import (
+	"context"
+	"path/filepath"
+	"syscall"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+)
+
+/*
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include <daos/common.h>
+#include <daos_types.h>
+#include <daos_api.h>
+#include <daos_cont.h>
+#include <daos_array.h>
+#include <daos_fs.h>
+#include <daos_uns.h>
+#include <dfuse_ioctl.h>
+
+// cgo doesn't work with variadic functions, so we need to
+// wrap these.
+static int
+dfuse_open(char *path, int oflag)
+{
+	return open(path, oflag);
+}
+
+static int
+dfuse_ioctl(int fd, struct dfuse_il_reply *reply)
+{
+	return ioctl(fd, DFUSE_IOCTL_IL, reply);
+}
+*/
+import "C"
+
+func (b *daosClientBinding) dfuse_open(path *C.char, oflag C.int) (C.int, error) {
+	// use the two-value form to get at errno
+	fd, err := C.dfuse_open(path, oflag)
+	return fd, err
+}
+
+func (m *mockApiClient) dfuse_open(path *C.char, oflag C.int) (C.int, error) {
+	rc := m.getRc("dfuse_open", 0)
+	if rc != 0 {
+		return -1, syscall.Errno(rc)
+	}
+	return 3, nil
+}
+
+func (b *daosClientBinding) close_fd(fd C.int) C.int {
+	return C.close(fd)
+}
+
+func (m *mockApiClient) close_fd(fd C.int) C.int {
+	return m.getRc("close_fd", 0)
+}
+
+func (b *daosClientBinding) dfuse_ioctl(fd C.int, reply *C.struct_dfuse_il_reply) (C.int, error) {
+	// use the two-value form to get at errno
+	rc, err := C.dfuse_ioctl(fd, reply)
+	return rc, err
+}
+
+func (m *mockApiClient) dfuse_ioctl(fd C.int, reply *C.struct_dfuse_il_reply) (C.int, error) {
+	if rc := m.getRc("dfuse_ioctl", 0); rc != 0 {
+		return rc, syscall.Errno(rc)
+	}
+
+	reply.fir_pool = uuidToC(m.cfg.ConnectedPool)
+	reply.fir_cont = uuidToC(m.cfg.ConnectedCont)
+	reply.fir_version = C.DFUSE_IOCTL_VERSION
+
+	return 0, nil
+}
+
+func (b *daosClientBinding) duns_resolve_path(path *C.char, attr *C.struct_duns_attr_t) C.int {
+	return C.duns_resolve_path(path, attr)
+}
+
+func (m *mockApiClient) duns_resolve_path(path *C.char, attr *C.struct_duns_attr_t) C.int {
+	if rc := m.getRc("duns_resolve_path", 0); rc != 0 {
+		return rc
+	}
+
+	poolStr := C.CString(m.cfg.ConnectedPool.String())
+	defer freeString(poolStr)
+	C.strcpy(&attr.da_pool[0], poolStr)
+
+	contStr := C.CString(m.cfg.ConnectedCont.String())
+	defer freeString(contStr)
+	C.strcpy(&attr.da_cont[0], contStr)
+
+	return 0
+}
+
+func callDfuseIoctl(client apiClient, path *C.char, reply *C.struct_dfuse_il_reply) error {
+	fd, err := client.dfuse_open(path, C.O_RDONLY|C.O_DIRECTORY|C.O_NOFOLLOW)
+	if fd < 0 {
+		return err
+	}
+	defer client.close_fd(fd)
+
+	rc, err := client.dfuse_ioctl(fd, reply)
+	if rc != 0 {
+		return err
+	}
+
+	if reply.fir_version != C.DFUSE_IOCTL_VERSION {
+		return daosError(C.daos_errno2der(C.EIO))
+	}
+
+	return nil
+}
+
+// ResolveContainerPath resolves the given path to a set of pool and container IDs.
+func ResolveContainerPath(ctx context.Context, path string) (poolID string, containerID string, err error) {
+	var dattr C.struct_duns_attr_t
+	var ilReply C.struct_dfuse_il_reply
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return
+	}
+
+	cPath := C.CString(path)
+	defer freeString(cPath)
+
+	if err = callDfuseIoctl(client, cPath, &ilReply); err == nil {
+		var poolUUID uuid.UUID
+		var contUUID uuid.UUID
+
+		poolUUID, err = uuidFromC(ilReply.fir_pool)
+		if err != nil {
+			return
+		}
+		poolID = poolUUID.String()
+
+		contUUID, err = uuidFromC(ilReply.fir_cont)
+		if err != nil {
+			return
+		}
+		containerID = contUUID.String()
+
+		log.Debugf("resolved dfuse path %s to %s/%s", path, poolID, containerID)
+		return
+	} else if !errors.Is(err, syscall.ENOTTY) {
+		var der C.int = -C.DER_UNKNOWN
+		if errno, ok := err.(syscall.Errno); ok {
+			der = C.daos_errno2der(C.int(errno))
+		}
+		err = errors.Wrap(daosError(der), "dfuse_ioctl() failed")
+		return
+	}
+
+	if err = daosError(C.daos_errno2der(client.duns_resolve_path(cPath, &dattr))); err != nil {
+		return
+	}
+	defer C.duns_destroy_attr(&dattr)
+
+	poolID = C.GoString(&dattr.da_pool[0])
+	containerID = C.GoString(&dattr.da_cont[0])
+
+	log.Debugf("resolved duns path %s to %s/%s", path, poolID, containerID)
+
+	return
+}
+
+// ResolvePoolPath resolves the given path to a pool ID.
+func ResolvePoolPath(ctx context.Context, path string) (poolID string, err error) {
+	var ilReply C.struct_dfuse_il_reply
+
+	client, err := getApiClient(ctx)
+	if err != nil {
+		return
+	}
+
+	cDirPath := C.CString(filepath.Dir(path))
+	defer freeString(cDirPath)
+
+	if err = callDfuseIoctl(client, cDirPath, &ilReply); err != nil {
+		return
+	}
+
+	var poolUUID uuid.UUID
+	poolUUID, err = uuidFromC(ilReply.fir_pool)
+	if err != nil {
+		return
+	}
+
+	log.Debugf("resolved dfuse path %s to %s", path, poolUUID.String())
+
+	return poolUUID.String(), nil
+}

--- a/src/control/lib/daos/client/uns_test.go
+++ b/src/control/lib/daos/client/uns_test.go
@@ -1,0 +1,81 @@
+package client_test
+
+import (
+	"context"
+	"syscall"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/daos/client"
+)
+
+func TestClient_ResolveContainerPath(t *testing.T) {
+	connPool := uuid.New()
+	connCont := uuid.New()
+
+	for name, tc := range map[string]struct {
+		ctx    context.Context
+		path   string
+		cfg    *client.MockApiClientConfig
+		expErr error
+	}{
+		"nonexistent dfuse path": {
+			cfg: &client.MockApiClientConfig{
+				ReturnCodeMap: map[string]int{
+					"dfuse_ioctl": int(syscall.ENOENT),
+				},
+			},
+			expErr: daos.Nonexistent,
+		},
+		"successful dfuse path resolution": {
+			cfg: &client.MockApiClientConfig{
+				ConnectedPool: connPool,
+				ConnectedCont: connCont,
+			},
+		},
+		"duns path not valid": {
+			cfg: &client.MockApiClientConfig{
+				ReturnCodeMap: map[string]int{
+					"dfuse_ioctl":       int(syscall.ENOTTY),
+					"duns_resolve_path": int(syscall.ENODATA),
+				},
+			},
+			expErr: daos.BadPath,
+		},
+		"successful duns path resolution": {
+			cfg: &client.MockApiClientConfig{
+				ConnectedPool: connPool,
+				ConnectedCont: connCont,
+				ReturnCodeMap: map[string]int{
+					"dfuse_ioctl": int(syscall.ENOTTY),
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.ctx == nil {
+				var err error
+				tc.ctx, err = client.MockApiClientContext(context.Background(), tc.cfg)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			poolID, contID, err := client.ResolveContainerPath(tc.ctx, tc.path)
+			test.CmpErr(t, tc.expErr, err)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(connPool.String(), poolID); diff != "" {
+				t.Fatalf("unexpected pool (-want, +got):\n%s\n", diff)
+			}
+			if diff := cmp.Diff(connCont.String(), contID); diff != "" {
+				t.Fatalf("unexpected container (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/src/control/lib/daos/client/util.go
+++ b/src/control/lib/daos/client/util.go
@@ -1,0 +1,150 @@
+package client
+
+import (
+	"unsafe"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+)
+
+/*
+#include <stdlib.h>
+#include <uuid/uuid.h>
+
+#include <daos_prop.h>
+
+#include "util.h"
+*/
+import "C"
+
+func goBool2int(in bool) (out C.int) {
+	if in {
+		out = 1
+	}
+	return
+}
+
+func copyUUID(dst *C.uuid_t, src uuid.UUID) error {
+	if dst == nil {
+		return errors.New("nil dest uuid_t")
+	}
+
+	for i, v := range src {
+		dst[i] = C.uchar(v)
+	}
+
+	return nil
+}
+
+func uuidToC(in uuid.UUID) (out C.uuid_t) {
+	for i, v := range in {
+		out[i] = C.uchar(v)
+	}
+
+	return
+}
+
+func uuidFromC(cUUID C.uuid_t) (uuid.UUID, error) {
+	return uuid.FromBytes(C.GoBytes(unsafe.Pointer(&cUUID[0]), C.int(len(cUUID))))
+}
+
+func freeString(s *C.char) {
+	C.free(unsafe.Pointer(s))
+}
+
+type propSlice []C.struct_daos_prop_entry
+
+func (ps propSlice) getEntry(pType C.uint32_t) *C.struct_daos_prop_entry {
+	for _, entry := range ps {
+		if entry.dpe_type == pType {
+			return &entry
+		}
+	}
+	return nil
+}
+
+func createPropSlice(props *C.daos_prop_t, numProps int) propSlice {
+	// Create a Go slice backed by the props array for easier
+	// iteration.
+	return unsafe.Slice((*C.struct_daos_prop_entry)(unsafe.Pointer(props.dpp_entries)), numProps)
+}
+
+func allocProps(numProps int) (props *C.daos_prop_t, entries propSlice, err error) {
+	props = C.daos_prop_alloc(C.uint(numProps))
+	if props == nil {
+		return nil, nil, errors.Wrap(daos.NoMemory, "failed to allocate properties list")
+	}
+
+	props.dpp_nr = 0
+	entries = createPropSlice(props, numProps)
+
+	return
+}
+
+func freeProps(props *C.daos_prop_t) {
+	C.daos_prop_free(props)
+}
+
+// dupePropEntry copies an entry into Go-managed memory so that the
+// source entry can be safely deallocated.
+//
+// NB: This helper is loosely based on C.daos_prop_entry_copy(), but
+// is not intended to be as comprehensive. It should be used for getting
+// a property list into Go memory in order to cross API boundaries without
+// requiring memory management outside of this API.
+func dupePropEntry(src, dest *C.struct_daos_prop_entry) error {
+	if src == nil || dest == nil {
+		return errors.Wrap(daos.InvalidInput, "source and dest entries must not be nil")
+	}
+
+	dest.dpe_type = src.dpe_type
+
+	switch src.dpe_type {
+	case C.DAOS_PROP_PO_ACL, C.DAOS_PROP_CO_ACL:
+		cPtr := C.get_dpe_val_ptr(src)
+		if cPtr == nil {
+			return errors.Wrap(daos.InvalidInput, "bad prop value pointer")
+		}
+		goBuf := C.GoBytes(cPtr, C.int(C.daos_acl_get_size((*C.struct_daos_acl)(cPtr))))
+		C.set_dpe_val_ptr(dest, unsafe.Pointer(&goBuf[0]))
+	default:
+		// If there's a C string in the entry, copy it (along with the terminator)
+		// into a Go buffer.
+		if C.daos_prop_has_str(src) {
+			cStr := C.get_dpe_str(src)
+			if cStr == nil {
+				return errors.Wrap(daos.InvalidInput, "bad prop string")
+			}
+			goBuf := C.GoBytes(unsafe.Pointer(cStr), C.int(C.strlen(cStr)+1))
+			C.set_dpe_str(dest, (*C.char)(unsafe.Pointer(&goBuf[0])))
+			return nil
+		}
+
+		// No buffers to duplicate; just copy the uint64 value.
+		C.set_dpe_val(dest, C.get_dpe_val(src))
+	}
+
+	return nil
+}
+
+func iterStringsBuf(cBuf unsafe.Pointer, expected C.size_t, cb func(string)) error {
+	var curLen C.size_t
+
+	// Create a Go slice for easy iteration (no pointer arithmetic in Go).
+	bufSlice := (*[1 << 30]C.char)(cBuf)[:expected:expected]
+	for total := C.size_t(0); total < expected; total += curLen + 1 {
+		chunk := bufSlice[total:]
+		curLen = C.strnlen(&chunk[0], expected-total)
+
+		if curLen >= expected-total {
+			return errors.New("corrupt buffer")
+		}
+
+		chunk = bufSlice[total : total+curLen]
+		cb(C.GoString(&chunk[0]))
+	}
+
+	return nil
+}

--- a/src/control/lib/daos/client/util.h
+++ b/src/control/lib/daos/client/util.h
@@ -1,40 +1,12 @@
-/**
- * (C) Copyright 2021-2022 Intel Corporation.
- *
- * SPDX-License-Identifier: BSD-2-Clause-Patent
- */
+#ifndef __DAOS_CLIENT_UTIL_H__
+#define __DAOS_CLIENT_UTIL_H__
 
-#ifndef __CMD_DAOS_UTIL_H__
-#define __CMD_DAOS_UTIL_H__
-
-#define D_LOGFAC	DD_FAC(client)
+//#define D_LOGFAC	DD_FAC(client)
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/ioctl.h>
-#include <errno.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/xattr.h>
-#include <fcntl.h>
-#include <daos.h>
 #include <daos/common.h>
-#include <daos/debug.h>
-#include <gurt/common.h>
-
-#include "daos_types.h"
-#include "daos_api.h"
-#include "daos_fs.h"
-#include "daos_uns.h"
-#include "daos_mgmt.h"
-#include "dfuse_ioctl.h"
-
-#include "daos_hdlr.h"
-
-int resolve_duns_pool(struct cmd_args_s *ap);
 
 /* cgo is unable to work directly with preprocessor macros
  * so we have to provide these glue helpers.
@@ -43,6 +15,12 @@ static inline uint64_t
 daos_prop_co_status_val(uint32_t status, uint32_t flag, uint32_t ver)
 {
 	return DAOS_PROP_CO_STATUS_VAL(status, flag, ver);
+}
+
+static void
+daos_free(void *ptr)
+{
+	D_FREE(ptr);
 }
 
 /* cgo is unable to work directly with unions, so we have
@@ -111,14 +89,13 @@ set_dpe_val_ptr(struct daos_prop_entry *dpe, void *val_ptr)
 	dpe->dpe_val_ptr = val_ptr;
 }
 
-static inline uint32_t
+/*static inline uint32_t
 get_rebuild_state(struct daos_rebuild_status *drs)
 {
 	if (drs == NULL)
 		return 0;
 
 	return drs->rs_state;
-}
+}*/
 
-
-#endif /* __CMD_DAOS_UTIL_H__ */
+#endif /* __DAOS_CLIENT_UTIL_H__ */

--- a/src/control/lib/daos/constants.go
+++ b/src/control/lib/daos/constants.go
@@ -7,6 +7,7 @@
 package daos
 
 /*
+#include <daos_prop.h>
 #include <daos_types.h>
 */
 import "C"
@@ -19,4 +20,10 @@ const (
 
 	// MaxAttributeNameLength defines the maximum length of an attribute name.
 	MaxAttributeNameLength = C.DAOS_ATTR_NAME_MAX
+
+	// MaxPropertyNameLength defines the maximum length of a property name.
+	MaxPropertyNameLength = 20 // arbitrary; came from old daos tool
+
+	// MaxPropertyValueLength defines the maximum length of a property value string.
+	MaxPropertyValueLength = C.DAOS_PROP_LABEL_MAX_LEN
 )

--- a/src/control/lib/daos/pool.go
+++ b/src/control/lib/daos/pool.go
@@ -1,0 +1,271 @@
+package daos
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
+)
+
+/*
+#include <daos.h>
+#include <daos_pool.h>
+*/
+import "C"
+
+type (
+	StorageMediaType     int32
+	PoolQueryTargetType  int32
+	PoolQueryTargetState int32
+
+	// PoolQueryTargetInfo contains information about a single target
+	PoolQueryTargetInfo struct {
+		Type  PoolQueryTargetType  `json:"target_type"`
+		State PoolQueryTargetState `json:"target_state"`
+		Space []*StorageTargetUsage
+	}
+
+	// StorageTargetUsage represents DAOS target storage usage
+	StorageTargetUsage struct {
+		Total     uint64           `json:"total"`
+		Free      uint64           `json:"free"`
+		MediaType StorageMediaType `json:"media_type"`
+	}
+
+	// StorageUsageStats represents DAOS storage usage statistics.
+	StorageUsageStats struct {
+		Total     uint64           `json:"total"`
+		Free      uint64           `json:"free"`
+		Min       uint64           `json:"min"`
+		Max       uint64           `json:"max"`
+		Mean      uint64           `json:"mean"`
+		MediaType StorageMediaType `json:"media_type"`
+	}
+
+	// PoolRebuildState indicates the current state of the pool rebuild process.
+	PoolRebuildState int32
+
+	// PoolRebuildStatus contains detailed information about the pool rebuild process.
+	PoolRebuildStatus struct {
+		Status  int32            `json:"status"`
+		State   PoolRebuildState `json:"state"`
+		Objects uint64           `json:"objects"`
+		Records uint64           `json:"records"`
+	}
+
+	PoolInfo struct {
+		UUID             uuid.UUID            `json:"uuid"`
+		Label            string               `json:"label,omitempty"`
+		TotalTargets     uint32               `json:"total_targets"`
+		ActiveTargets    uint32               `json:"active_targets"`
+		TotalEngines     uint32               `json:"total_engines"`
+		DisabledTargets  uint32               `json:"disabled_targets"`
+		Version          uint32               `json:"version"`
+		Leader           uint32               `json:"leader"`
+		Rebuild          *PoolRebuildStatus   `json:"rebuild"`
+		TierStats        []*StorageUsageStats `json:"tier_stats"`
+		EnabledRanks     *ranklist.RankSet    `json:"-"`
+		DisabledRanks    *ranklist.RankSet    `json:"-"`
+		PoolLayoutVer    uint32               `json:"pool_layout_ver"`
+		UpgradeLayoutVer uint32               `json:"upgrade_layout_ver"`
+	}
+)
+
+const (
+	// StorageMediaTypeScm indicates that the media is storage class (persistent) memory
+	StorageMediaTypeScm StorageMediaType = iota
+	// StorageMediaTypeNvme indicates that the media is NVMe SSD
+	StorageMediaTypeNvme
+)
+
+const (
+	PoolRebuildStateIdle = 0
+	PoolRebuildStateBusy = 1
+	PoolRebuildStateDone = 2
+	// PoolRebuildStateInProgress indicates that the rebuild process is in progress.
+	PoolRebuildStateInProgress = C.DRS_IN_PROGRESS + 10
+	// PoolRebuildStateNotStarted indicates that the rebuild process has not started.
+	PoolRebuildStateNotStarted = C.DRS_NOT_STARTED + 10
+	// PoolRebuildStateCompleted indicates that the rebuild process has completed.
+	PoolRebuildStateCompleted = C.DRS_COMPLETED + 10
+)
+
+func (pi *PoolInfo) MarshalJSON() ([]byte, error) {
+	if pi == nil {
+		return []byte("null"), nil
+	}
+
+	type Alias PoolInfo
+	aux := &struct {
+		EnabledRanks  *[]ranklist.Rank `json:"enabled_ranks,omitempty"`
+		DisabledRanks *[]ranklist.Rank `json:"disabled_ranks,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(pi),
+	}
+
+	if pi.EnabledRanks != nil {
+		ranks := pi.EnabledRanks.Ranks()
+		aux.EnabledRanks = &ranks
+	}
+
+	if pi.DisabledRanks != nil {
+		ranks := pi.DisabledRanks.Ranks()
+		aux.DisabledRanks = &ranks
+	}
+
+	return json.Marshal(&aux)
+}
+
+func unmarshalRankSet(ranks string) (*ranklist.RankSet, error) {
+	switch ranks {
+	case "":
+		return nil, nil
+	case "[]":
+		return &ranklist.RankSet{}, nil
+	default:
+		return ranklist.CreateRankSet(ranks)
+	}
+}
+
+func (pi *PoolInfo) UnmarshalJSON(data []byte) error {
+	type Alias PoolInfo
+	aux := &struct {
+		EnabledRanks  string `json:"enabled_ranks"`
+		DisabledRanks string `json:"disabled_ranks"`
+		*Alias
+	}{
+		Alias: (*Alias)(pi),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if rankSet, err := unmarshalRankSet(aux.EnabledRanks); err != nil {
+		return err
+	} else {
+		pi.EnabledRanks = rankSet
+	}
+
+	if rankSet, err := unmarshalRankSet(aux.DisabledRanks); err != nil {
+		return err
+	} else {
+		pi.DisabledRanks = rankSet
+	}
+
+	return nil
+}
+
+func (prs PoolRebuildState) String() string {
+	switch prs {
+	case PoolRebuildStateInProgress:
+		return "in progress"
+	case PoolRebuildStateNotStarted:
+		return "not started"
+	case PoolRebuildStateCompleted:
+		return "completed"
+	case PoolRebuildStateBusy:
+		return "busy"
+	case PoolRebuildStateIdle:
+		return "idle"
+	case PoolRebuildStateDone:
+		return "done"
+	default:
+		return "unknown"
+	}
+}
+
+func (prs PoolRebuildState) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + prs.String() + `"`), nil
+}
+
+func (prs *PoolRebuildState) UnmarshalJSON(data []byte) error {
+	stateStr := strings.ToUpper(string(data))
+	state, ok := mgmtpb.PoolRebuildStatus_State_value[stateStr]
+	if !ok {
+		// Try converting the string to an int32, to handle the
+		// conversion from protobuf message using convert.Types().
+		si, err := strconv.ParseInt(stateStr, 0, 32)
+		if err != nil {
+			return errors.Errorf("invalid rebuild state %q", stateStr)
+		}
+
+		if _, ok = mgmtpb.PoolRebuildStatus_State_name[int32(si)]; !ok {
+			return errors.Errorf("invalid rebuild state %q", stateStr)
+		}
+		state = int32(si)
+	}
+	*prs = PoolRebuildState(state)
+
+	return nil
+}
+
+func (smt StorageMediaType) MarshalJSON() ([]byte, error) {
+	typeStr, ok := mgmtpb.StorageMediaType_name[int32(smt)]
+	if !ok {
+		return nil, errors.Errorf("invalid storage media type %d", smt)
+	}
+	return []byte(`"` + strings.ToLower(typeStr) + `"`), nil
+}
+
+func (smt StorageMediaType) String() string {
+	smts, ok := mgmtpb.StorageMediaType_name[int32(smt)]
+	if !ok {
+		return "unknown"
+	}
+	return strings.ToLower(smts)
+}
+
+func (pqtt PoolQueryTargetType) MarshalJSON() ([]byte, error) {
+	typeStr, ok := mgmtpb.PoolQueryTargetInfo_TargetType_name[int32(pqtt)]
+	if !ok {
+		return nil, errors.Errorf("invalid target type %d", pqtt)
+	}
+	return []byte(`"` + strings.ToLower(typeStr) + `"`), nil
+}
+
+func (ptt PoolQueryTargetType) String() string {
+	ptts, ok := mgmtpb.PoolQueryTargetInfo_TargetType_name[int32(ptt)]
+	if !ok {
+		return "invalid"
+	}
+	return strings.ToLower(ptts)
+}
+
+const (
+	PoolTargetStateUnknown PoolQueryTargetState = iota
+	// PoolTargetStateDownOut indicates the target is not available
+	PoolTargetStateDownOut
+	// PoolTargetStateDown indicates the target is not available, may need rebuild
+	PoolTargetStateDown
+	// PoolTargetStateUp indicates the target is up
+	PoolTargetStateUp
+	// PoolTargetStateUpIn indicates the target is up and running
+	PoolTargetStateUpIn
+	// PoolTargetStateNew indicates the target is in an intermediate state (pool map change)
+	PoolTargetStateNew
+	// PoolTargetStateDrain indicates the target is being drained
+	PoolTargetStateDrain
+)
+
+func (pqts PoolQueryTargetState) MarshalJSON() ([]byte, error) {
+	stateStr, ok := mgmtpb.PoolQueryTargetInfo_TargetState_name[int32(pqts)]
+	if !ok {
+		return nil, errors.Errorf("invalid target state %d", pqts)
+	}
+	return []byte(`"` + strings.ToLower(stateStr) + `"`), nil
+}
+
+func (pts PoolQueryTargetState) String() string {
+	ptss, ok := mgmtpb.PoolQueryTargetInfo_TargetState_name[int32(pts)]
+	if !ok {
+		return "invalid"
+	}
+	return strings.ToLower(ptss)
+}

--- a/src/control/lib/daos/status.go
+++ b/src/control/lib/daos/status.go
@@ -101,8 +101,6 @@ const (
 	BadTarget Status = -C.DER_BAD_TARGET
 	// GroupVersionMismatch indicates that group versions didn't match
 	GroupVersionMismatch Status = -C.DER_GRPVER
-	// NoService indicates the pool service is not up and didn't process the pool request
-	NoService Status = -C.DER_NO_SERVICE
 )
 
 const (
@@ -148,10 +146,19 @@ const (
 	NotReplica Status = -C.DER_NOTREPLICA
 	// ChecksumError indicates a checksum error
 	ChecksumError Status = -C.DER_CSUM
+	// AgentCommErr indicates a failure to communicate with the local agent.
+	AgentCommErr Status = -C.DER_AGENT_COMM
 	// ControlIncompatible indicates that one or more control plane components are incompatible
 	ControlIncompatible Status = -C.DER_CONTROL_INCOMPAT
+	// NoService indicates the pool service is not up and didn't process the pool request
+	NoService Status = -C.DER_NO_SERVICE
 	// NoCert indicates that one or more configured certificates could not be accessed.
 	NoCert Status = -C.DER_NO_CERT
 	// BadCert indicates that an invalid certificate was detected.
 	BadCert Status = -C.DER_BAD_CERT
+)
+
+const (
+	// Unknown indicates that the error was unknown.
+	Unknown Status = -C.DER_UNKNOWN
 )

--- a/src/control/lib/daos/util.go
+++ b/src/control/lib/daos/util.go
@@ -1,0 +1,26 @@
+package daos
+
+import (
+	"unsafe"
+)
+
+/*
+#include <stdlib.h>
+#include <uuid/uuid.h>
+
+#include <daos_prop.h>
+*/
+import "C"
+
+// daosError converts a return code from a DAOS API
+// call to a Go error.
+func daosError(rc C.int) error {
+	if rc == 0 {
+		return nil
+	}
+	return Status(rc)
+}
+
+func freeString(s *C.char) {
+	C.free(unsafe.Pointer(s))
+}

--- a/src/control/lib/dfs/constants.go
+++ b/src/control/lib/dfs/constants.go
@@ -1,0 +1,66 @@
+package dfs
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+/*
+#include <fcntl.h>
+
+#include <daos.h>
+#include <daos_fs.h>
+#include <daos_fs_sys.h>
+*/
+import "C"
+
+type (
+	ConsistencyMode uint32
+)
+
+var (
+	ConsistencyModeRelaxed   ConsistencyMode = C.DFS_RELAXED
+	ConsistencyModeBalanced  ConsistencyMode = C.DFS_BALANCED
+	ConsistencyModeReadOnly  ConsistencyMode = C.O_RDONLY
+	ConsistencyModeReadWrite ConsistencyMode = C.O_RDWR
+)
+
+func (m ConsistencyMode) String() string {
+	switch m {
+	case ConsistencyModeRelaxed:
+		return "relaxed"
+	case ConsistencyModeBalanced:
+		return "balanced"
+	case ConsistencyModeReadOnly:
+		return "readonly"
+	case ConsistencyModeReadWrite:
+		return "readwrite"
+	default:
+		return "unknown"
+	}
+}
+
+func (m *ConsistencyMode) FromString(in string) error {
+	switch strings.ToLower(in) {
+	case "relaxed":
+		*m = ConsistencyModeRelaxed
+	case "balanced":
+		*m = ConsistencyModeBalanced
+	case "readonly":
+		*m = ConsistencyModeReadOnly
+	case "readwrite":
+		*m = ConsistencyModeReadWrite
+	default:
+		return errors.Errorf("unknown DFS consistency mode %q", in)
+	}
+
+	return nil
+}
+
+type SysFlag C.int
+
+const (
+	SysFlagNoCache SysFlag = C.DFS_SYS_NO_CACHE
+	SysFlagNoLock  SysFlag = C.DFS_SYS_NO_LOCK
+)

--- a/src/control/lib/dfs/errors.go
+++ b/src/control/lib/dfs/errors.go
@@ -1,0 +1,39 @@
+package dfs
+
+import (
+	"fmt"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+)
+
+/*
+#include "string.h"
+*/
+import "C"
+
+type ErrnoErr struct {
+	Errno  int
+	Errstr string
+}
+
+func (e *ErrnoErr) Error() string {
+	return fmt.Sprintf("errno %d (%s)", e.Errno, e.Errstr)
+}
+
+func dfsError(rc C.int) error {
+	if rc == 0 {
+		return nil
+	}
+
+	strErr := C.strerror(rc)
+	return &ErrnoErr{int(rc), C.GoString(strErr)}
+}
+
+// daosError converts a return code from a DAOS API
+// call to a Go error.
+func daosError(rc C.int) error {
+	if rc == 0 {
+		return nil
+	}
+	return daos.Status(rc)
+}

--- a/src/control/lib/dfs/file.go
+++ b/src/control/lib/dfs/file.go
@@ -1,0 +1,183 @@
+package dfs
+
+import (
+	"io"
+	"io/fs"
+	"sync"
+	"unsafe"
+
+	"github.com/pkg/errors"
+)
+
+/*
+#include <daos.h>
+#include <daos_fs.h>
+#include <daos_fs_sys.h>
+*/
+import "C"
+
+const (
+	// readerBufSize is 1MB as this is what DAOS likes
+	readerBufSize = 1 << 20
+	// writerBufSize is 1MB as this is what DAOS likes
+	writerBufSize = 1 << 20
+)
+
+var (
+	_ fs.File            = (*File)(nil)
+	_ io.ReadWriteCloser = (*File)(nil)
+	_ io.WriterTo        = (*File)(nil)
+	_ io.WriterAt        = (*File)(nil)
+	_ io.ReaderFrom      = (*File)(nil)
+	_ io.ReaderAt        = (*File)(nil)
+	_ io.Seeker          = (*File)(nil)
+)
+
+type File struct {
+	sync.Mutex
+	dfsObject
+
+	openAppend bool
+	position   int64
+}
+
+func (f *File) read(buf []byte, off int64) (int, error) {
+	readSize := C.daos_size_t(len(buf))
+
+	err := dfsError(C.dfs_sys_read(f.dfs, f.obj, unsafe.Pointer(&buf[0]), C.daos_off_t(off), &readSize, nil))
+	if err != nil {
+		return 0, err
+	}
+
+	if int(readSize) < len(buf) {
+		err = errors.Wrapf(io.EOF, "read %d bytes, expected %d", readSize, len(buf))
+	}
+
+	f.position = off + int64(readSize)
+	return int(readSize), err
+}
+
+func (f *File) ReadFrom(r io.Reader) (total int64, _ error) {
+	f.Lock()
+	defer f.Unlock()
+
+	var err error
+	var n int
+	buf := make([]byte, writerBufSize)
+
+	for {
+		n, err = r.Read(buf)
+		total += int64(n)
+
+		if n > 0 {
+			_, err = f.write(buf[:n], f.position)
+			if err != nil {
+				return total, err
+			}
+		}
+
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+			return total, err
+		}
+	}
+}
+
+func (f *File) Read(buf []byte) (int, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	return f.read(buf, f.position)
+}
+
+func (f *File) ReadAt(buf []byte, off int64) (int, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	if off < 0 {
+		return 0, &fs.PathError{Op: "ReadAt", Path: f.name, Err: errors.New("negative offset")}
+	}
+
+	return f.read(buf, off)
+}
+
+func (f *File) write(buf []byte, off int64) (int, error) {
+	var writeSize C.daos_size_t = C.daos_size_t(len(buf))
+
+	err := dfsError(C.dfs_sys_write(f.dfs, f.obj, unsafe.Pointer(&buf[0]), C.daos_off_t(off), &writeSize, nil))
+	if err != nil {
+		return 0, err
+	}
+
+	if int(writeSize) < len(buf) {
+		err = errors.Wrapf(io.ErrShortWrite, "wrote %d bytes, expected %d", writeSize, len(buf))
+	}
+
+	f.position = off + int64(writeSize)
+	return int(writeSize), err
+}
+
+func (f *File) WriteTo(w io.Writer) (int64, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	var err error
+	var n int
+	buf := make([]byte, readerBufSize)
+
+	for {
+		n, err = f.read(buf, f.position)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+			return int64(n), err
+		}
+
+		_, err = w.Write(buf[:n])
+		if err != nil {
+			return int64(n), err
+		}
+	}
+}
+
+func (f *File) Write(buf []byte) (int, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	return f.write(buf, f.position)
+}
+
+func (f *File) WriteAt(buf []byte, off int64) (int, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	if f.openAppend {
+		return 0, errors.New("cannot WriteAt to append-only file")
+	}
+	if off < 0 {
+		return 0, &fs.PathError{Op: "WriteAt", Path: f.name, Err: errors.New("negative offset")}
+	}
+
+	return f.write(buf, off)
+}
+
+func (f *File) Seek(offset int64, whence int) (int64, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	switch whence {
+	case io.SeekStart:
+		f.position = offset
+	case io.SeekCurrent:
+		f.position += offset
+	case io.SeekEnd:
+		// end whence not supported for now
+		return 0, errors.New("end whence not supported")
+	default:
+		return 0, errors.New("invalid whence")
+	}
+	return f.position, nil
+}

--- a/src/control/lib/dfs/filesystem.go
+++ b/src/control/lib/dfs/filesystem.go
@@ -1,0 +1,304 @@
+package dfs
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/lib/atm"
+	"github.com/daos-stack/daos/src/control/lib/daos/client"
+)
+
+/*
+#include <fcntl.h>
+
+#include <daos.h>
+#include <daos_fs.h>
+#include <daos_fs_sys.h>
+*/
+import "C"
+
+var (
+	_ fs.FS         = (*Filesystem)(nil)
+	_ fs.ReadDirFS  = (*Filesystem)(nil)
+	_ fs.ReadFileFS = (*Filesystem)(nil)
+	_ fs.StatFS     = (*Filesystem)(nil)
+	_ fs.SubFS      = (*Filesystem)(nil)
+)
+
+type Filesystem struct {
+	dfs       *C.struct_dfs_sys
+	connected atm.Bool
+	mounted   atm.Bool
+}
+
+func cHandlePtr(ptrHdl interface{ Pointer() unsafe.Pointer }) (*C.daos_handle_t, error) {
+	if ptrHdl == nil || ptrHdl.Pointer() == nil {
+		return nil, errors.New("nil handle pointer")
+	}
+
+	return (*C.daos_handle_t)(ptrHdl.Pointer()), nil
+}
+
+func Connect(poolID, contID, sysID string, mFlags int, sFlags SysFlag) (*Filesystem, error) {
+	if poolID == "" || contID == "" {
+		return nil, errors.New("missing pool or container ID")
+	}
+	if sysID == "" {
+		sysID = build.DefaultSystemName
+	}
+	if mFlags == 0 {
+		mFlags = os.O_RDONLY
+	}
+
+	cPoolID := C.CString(poolID)
+	defer freeString(cPoolID)
+	cContID := C.CString(contID)
+	defer freeString(cContID)
+	cSysID := C.CString(sysID)
+	defer freeString(cSysID)
+
+	var f Filesystem
+	if err := dfsError(C.dfs_sys_connect(cPoolID, cSysID, cContID, C.int(mFlags), C.int(sFlags), nil, &f.dfs)); err != nil {
+		return nil, err
+	}
+
+	f.connected.SetTrue()
+	return &f, nil
+}
+
+func (f *Filesystem) Disconnect() error {
+	if f.connected.IsFalse() {
+		return errors.New("not connected")
+	}
+	if err := dfsError(C.dfs_sys_disconnect(f.dfs)); err != nil {
+		return err
+	}
+
+	f.connected.SetFalse()
+	return nil
+}
+
+func Mount(pool *client.PoolHandle, cont *client.ContainerHandle, mFlags int, sFlags SysFlag) (*Filesystem, error) {
+	if mFlags == 0 {
+		mFlags = os.O_RDONLY
+	}
+
+	poh, err := cHandlePtr(pool)
+	if err != nil {
+		return nil, err
+	}
+	coh, err := cHandlePtr(cont)
+	if err != nil {
+		return nil, err
+	}
+
+	var f Filesystem
+	if err := dfsError(C.dfs_sys_mount(*poh, *coh, C.int(mFlags), C.int(sFlags), &f.dfs)); err != nil {
+		return nil, err
+	}
+
+	f.mounted.SetTrue()
+	return &f, nil
+}
+
+func (f *Filesystem) Unmount() error {
+	if f.mounted.IsFalse() {
+		return errors.New("not mounted")
+	}
+
+	if err := dfsError(C.dfs_sys_umount(f.dfs)); err != nil {
+		return err
+	}
+
+	f.mounted.SetFalse()
+	return nil
+}
+
+type dfsOpenArgs struct {
+	oclassID     C.daos_oclass_id_t
+	chunkSize    C.daos_size_t
+	symlinkValue *C.char
+}
+
+type dfsOpenOption interface {
+	apply(*dfsOpenArgs)
+}
+
+type openObjectClass client.ObjectClass
+
+func (o openObjectClass) apply(args *dfsOpenArgs) {
+	args.oclassID = C.daos_oclass_id_t(o)
+}
+
+func WithOpenObjectClass(class client.ObjectClass) openObjectClass {
+	return openObjectClass(class)
+}
+
+type openChunkSize C.daos_size_t
+
+func (o openChunkSize) apply(args *dfsOpenArgs) {
+	args.chunkSize = C.daos_size_t(o)
+}
+
+func WithOpenChunkSize(size uint64) openChunkSize {
+	return openChunkSize(size)
+}
+
+func (f *Filesystem) OpenDFS(path string, mode fs.FileMode, flags int, opts ...dfsOpenOption) (*File, error) {
+	var args dfsOpenArgs
+	for _, opt := range opts {
+		opt.apply(&args)
+	}
+
+	cPath := C.CString(path)
+	defer freeString(cPath)
+
+	var fsObj dfsObject
+	err := dfsError(C.dfs_sys_open(f.dfs, cPath, C.uint(mode),
+		C.int(flags), args.oclassID, args.chunkSize, args.symlinkValue, &fsObj.obj))
+	if err != nil {
+		return nil, &fs.PathError{Op: "open", Path: path, Err: err}
+	}
+	fsObj.name = path
+
+	return &File{
+		dfsObject: dfsObject{
+			dfs: f.dfs,
+			obj: fsObj.obj,
+		},
+		openAppend: flags&os.O_APPEND != 0,
+	}, nil
+}
+
+// NB: Filesystem methods below implement the stdlib io/fs.FS interface and
+// follow the patterns in os/file.go.
+
+// OpenFile is the generalized Open call; most users will use Open or Create instead.
+func (f *Filesystem) OpenFile(name string, flags int, perm os.FileMode) (*File, error) {
+	return f.OpenDFS(name, perm|C.S_IFREG, flags)
+}
+
+// Open opens the named file for reading.
+func (f *Filesystem) Open(name string) (fs.File, error) {
+	return f.OpenFile(name, os.O_RDONLY, 0)
+}
+
+// Create creates or truncates the named file.
+func (f *Filesystem) Create(name string) (*File, error) {
+	return f.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+}
+
+func (f *Filesystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (f *Filesystem) ReadFile(name string) ([]byte, error) {
+	rf, err := f.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer rf.Close()
+
+	var size int
+	st, err := rf.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size = int(st.Size())
+
+	buf := make([]byte, size)
+	read, err := rf.Read(buf)
+	if err != nil {
+		if err == io.EOF {
+			err = nil
+		}
+	}
+	if read < size {
+		err = io.ErrUnexpectedEOF
+	}
+	return buf, err
+}
+
+func (f *Filesystem) Stat(path string) (fs.FileInfo, error) {
+	cPath := C.CString(path)
+	defer freeString(cPath)
+
+	var stat dfsStat_t
+	if err := dfsError(C.dfs_sys_stat(f.dfs, cPath, 0, &stat.cst)); err != nil {
+		return nil, err
+	}
+	stat.name = path
+	stat.fillMode()
+
+	return &stat, nil
+}
+
+func (f *Filesystem) Sub(name string) (fs.FS, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (f *Filesystem) MkdirDFS(path string, mode fs.FileMode, oclass client.ObjectClass) error {
+	if path == "" {
+		return &fs.PathError{Op: "mkdir", Err: fs.ErrNotExist}
+	}
+
+	cPath := C.CString(path)
+	defer freeString(cPath)
+
+	err := dfsError(C.dfs_sys_mkdir(f.dfs, cPath, C.mode_t(mode), C.daos_oclass_id_t(oclass)))
+	if err != nil {
+		var errnoErr *ErrnoErr
+		if errors.As(err, errnoErr) && errnoErr.Errno == C.EEXIST {
+			err = fs.ErrExist
+		}
+		return &fs.PathError{Op: "mkdir", Path: path, Err: err}
+	}
+
+	return nil
+}
+
+func (f *Filesystem) Mkdir(path string, mode fs.FileMode) error {
+	return f.MkdirDFS(path, mode, 0)
+}
+
+func (f *Filesystem) MkdirAll(path string, perm fs.FileMode) error {
+	// NB: This borrows heavily from the stdlib implemenation of os.MkdirAll().
+	dir, err := f.Stat(path)
+	if err == nil {
+		if dir.IsDir() {
+			return nil
+		}
+		return &fs.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
+	}
+
+	i := len(path)
+	for i > 0 && os.IsPathSeparator(path[i-1]) {
+		i--
+	}
+
+	j := i
+	for j > 0 && !os.IsPathSeparator(path[j-1]) {
+		j--
+	}
+
+	if j > 1 {
+		if err = f.MkdirAll(path[:j-1], perm); err != nil {
+			return err
+		}
+	}
+
+	return f.Mkdir(path, perm)
+}
+
+func (f *Filesystem) Remove(path string) error {
+	cPath := C.CString(path)
+	defer freeString(cPath)
+
+	return dfsError(C.dfs_sys_remove(f.dfs, cPath, false, nil))
+}

--- a/src/control/lib/dfs/object.go
+++ b/src/control/lib/dfs/object.go
@@ -1,0 +1,37 @@
+package dfs
+
+import "io/fs"
+
+/*
+#include <daos.h>
+#include <daos_fs.h>
+#include <daos_fs_sys.h>
+*/
+import "C"
+
+type dfsObject struct {
+	dfs  *C.struct_dfs_sys
+	obj  *C.dfs_obj_t
+	name string
+}
+
+func (o *dfsObject) Close() error {
+	return dfsError(C.dfs_release(o.obj))
+}
+
+func (o *dfsObject) Stat() (fs.FileInfo, error) {
+	var stat dfsStat_t
+	var dfs *C.dfs_t
+
+	if err := dfsError(C.dfs_sys2base(o.dfs, &dfs)); err != nil {
+		return nil, err
+	}
+
+	if err := dfsError(C.dfs_ostat(dfs, o.obj, &stat.cst)); err != nil {
+		return nil, err
+	}
+	stat.name = o.name
+	stat.fillMode()
+
+	return &stat, nil
+}

--- a/src/control/lib/dfs/stat.go
+++ b/src/control/lib/dfs/stat.go
@@ -1,0 +1,69 @@
+package dfs
+
+import (
+	"io/fs"
+	"syscall"
+	"time"
+)
+
+/*
+#include <sys/stat.h>
+*/
+import "C"
+
+type dfsStat_t struct {
+	name string
+	mode fs.FileMode
+	cst  C.struct_stat
+}
+
+func (st *dfsStat_t) fillMode() {
+	st.mode = fs.FileMode(st.cst.st_mode & 0777)
+	switch st.cst.st_mode & syscall.S_IFMT {
+	case syscall.S_IFBLK:
+		st.mode |= fs.ModeDevice
+	case syscall.S_IFCHR:
+		st.mode |= fs.ModeDevice | fs.ModeCharDevice
+	case syscall.S_IFDIR:
+		st.mode |= fs.ModeDir
+	case syscall.S_IFIFO:
+		st.mode |= fs.ModeNamedPipe
+	case syscall.S_IFLNK:
+		st.mode |= fs.ModeSymlink
+	case syscall.S_IFSOCK:
+		st.mode |= fs.ModeSocket
+	}
+	if st.cst.st_mode&syscall.S_ISGID != 0 {
+		st.mode |= fs.ModeSetgid
+	}
+	if st.cst.st_mode&syscall.S_ISUID != 0 {
+		st.mode |= fs.ModeSetuid
+	}
+	if st.cst.st_mode&syscall.S_ISVTX != 0 {
+		st.mode |= fs.ModeSticky
+	}
+}
+
+func (st *dfsStat_t) Mode() fs.FileMode {
+	return st.mode
+}
+
+func (st *dfsStat_t) IsDir() bool {
+	return st.Mode().IsDir()
+}
+
+func (st *dfsStat_t) Size() int64 {
+	return int64(st.cst.st_size)
+}
+
+func (st *dfsStat_t) ModTime() time.Time {
+	return time.Unix(int64(st.cst.st_mtim.tv_sec), int64(st.cst.st_mtim.tv_nsec))
+}
+
+func (st *dfsStat_t) Name() string {
+	return st.name
+}
+
+func (st *dfsStat_t) Sys() interface{} {
+	return nil
+}

--- a/src/control/lib/dfs/util.go
+++ b/src/control/lib/dfs/util.go
@@ -1,0 +1,31 @@
+package dfs
+
+import (
+	"context"
+	"unsafe"
+
+	daosAPI "github.com/daos-stack/daos/src/control/lib/daos/client"
+)
+
+/*
+#include <stdlib.h>
+
+#include <daos.h>
+#include <daos_fs.h>
+*/
+import "C"
+
+func freeString(s *C.char) {
+	C.free(unsafe.Pointer(s))
+}
+
+func Init(parent context.Context) (context.Context, error) {
+	if err := dfsError(C.dfs_init()); err != nil {
+		return nil, err
+	}
+	return daosAPI.Init(parent)
+}
+
+func Fini(_ context.Context) error {
+	return dfsError(C.dfs_fini())
+}

--- a/src/control/security/auth/auth_sys.go
+++ b/src/control/security/auth/auth_sys.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2022 Intel Corporation.
+// (C) Copyright 2018-2023 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -558,6 +558,7 @@ daos_errno2der(int err)
 	case EINVAL:		return -DER_INVAL;
 	case ENOTDIR:		return -DER_NOTDIR;
 	case EIO:		return -DER_IO;
+	case ENODATA:		return -DER_BADPATH;
 	case EFAULT:
 	case ENXIO:
 	case ENODEV:

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -751,6 +751,9 @@ class DaosServer():
                 'access_points': scyaml['access_points'],
                 'control_log_mask': 'NOTICE',  # INFO logs every client process connection
             }
+            if not self.conf.args.server_debug:
+                agent_data['control_log_mask'] = 'DEBUG'
+
             json.dump(agent_data, fd)
 
         agent_bin = join(self.conf['PREFIX'], 'bin', 'daos_agent')
@@ -760,9 +763,6 @@ class DaosServer():
                      '--insecure',
                      '--runtime_dir', self.agent_dir,
                      '--logfile', self.agent_log.name]
-
-        if not self.conf.args.server_debug:
-            agent_cmd.append('--debug')
 
         self._agent = subprocess.Popen(agent_cmd)
         self.conf.agent_dir = self.agent_dir


### PR DESCRIPTION
Add Go bindings for DAOS Client API. This is an
initial pass, and will be expanded incrementally.

Adds the following API methods:
  Init()
  Fini()
  PoolConnect()
  PoolQuery()
  PoolDisconnect()
  ContainerCreate()
  ContainerDestroy()
  ContainerOpen()
  ContainerQuery()
  ContainerGetProperties()
  ContinaerSetProperties()
  ContainerClose()

Also adds bindings for the DFS sys API, and a prototype
stress tool (dstress).