### PR TITLE
DAOS-14828 test: Utilizing pool percentage for nvme/fault.py

### DIFF
--- a/src/tests/ftest/nvme/fault.py
+++ b/src/tests/ftest/nvme/fault.py
@@ -37,7 +37,7 @@ class NvmeFault(ServerFillUp):
         :avocado: tags=nvme_fault,test_nvme_fault
         """
         # Create the Pool with Maximum NVMe size
-        self.create_pool_max_size(nvme=True)
+        self.add_pool()
 
         # Start the IOR Command and generate the NVMe fault.
         self.start_ior_load(operation="Auto_Write", percent=self.capacity)

--- a/src/tests/ftest/nvme/fault.yaml
+++ b/src/tests/ftest/nvme/fault.yaml
@@ -31,7 +31,7 @@ dmg:
   transport_config:
     allow_insecure: True
 pool:
-  scm_size: 50GB
+  size: 96%
   control_method: dmg
 container:
   type: POSIX


### PR DESCRIPTION
To enable compatibility with server PMEM and MD on SSD modes, the pool created for the nvme/fault.py will now use a percentage for the size instead of calculating the maximum NVMe size.

Test-tag: test_nvme_fault
Skip-func-hw-medium-md-on-ssd: false

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
