### PR TITLE
DAOS-14718 test: Fix reading of DAOS_TEST_INSECURE_MODE envar (#13441)

### DIFF
--- a/src/tests/ftest/control/config_generate_run.yaml
+++ b/src/tests/ftest/control/config_generate_run.yaml
@@ -2,6 +2,8 @@ hosts:
   test_servers: 1
 timeout: 250
 server_config:
+  transport_config:
+    allow_insecure: False
   engines_per_host: 1
   engines:
     0:
@@ -9,8 +11,17 @@ server_config:
         0:
           class: ram
           scm_mount: /mnt/daos0
+# Force the use of certificates regardless of the launch.py --insecure setting.
 pool:
   control_method: dmg
+  transport_config:
+    allow_insecure: False
+agent_config:
+  transport_config:
+    allow_insecure: False
+dmg:
+  transport_config:
+    allow_insecure: False
 setup:
   start_servers_once: False
 config_generate_params: !mux

--- a/src/tests/ftest/util/command_utils_base.py
+++ b/src/tests/ftest/util/command_utils_base.py
@@ -715,7 +715,7 @@ class TransportCredentials(YamlParameters):
         """
         super().__init__(namespace, None, title)
         self._log_dir = log_dir
-        default_insecure = str(os.environ.get("DAOS_INSECURE_MODE", True))
+        default_insecure = str(os.environ.get("DAOS_TEST_INSECURE_MODE", True))
         default_insecure = default_insecure.lower() == "true"
         self.ca_cert = LogParameter(self._log_dir, None, "daosCA.crt")
         self.allow_insecure = BasicParameter(None, default_insecure)

--- a/src/tests/ftest/util/environment_utils.py
+++ b/src/tests/ftest/util/environment_utils.py
@@ -155,6 +155,9 @@ class TestEnvironment():
         all_hosts = NodeSet()
         all_hosts.update(servers)
         all_hosts.update(clients)
+        self.provider = provider
+        self.insecure_mode = insecure_mode
+
         if self.log_dir is None:
             self.log_dir = self.default_log_dir()
         if self.shared_dir is None:
@@ -166,11 +169,7 @@ class TestEnvironment():
         if self.interface is None:
             self.interface = self.default_interface(logger, all_hosts)
         if self.provider is None:
-            self.provider = provider
-        if self.provider is None:
             self.provider = self.default_provider(logger, servers)
-        if self.insecure_mode is None:
-            self.insecure_mode = insecure_mode
         if self.insecure_mode is None:
             self.insecure_mode = self.default_insecure_mode()
         if self.bullseye_src is None:


### PR DESCRIPTION
The ConfigGenerateRun tests fail to use certs because insecure mode is
enabled when trying to access non-existent DAOS_INSECURE_MODE env. Fix
by updating env keyname to DAOS_TEST_INSECURE_MODE.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
