### PR TITLE
DAOS-14557 object: collectively query key

### DIFF
--- a/src/dtx/dtx_coll.c
+++ b/src/dtx/dtx_coll.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2023 Intel Corporation.
+ * (C) Copyright 2023-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -161,7 +161,6 @@ dtx_coll_prep(uuid_t po_uuid, daos_unit_oid_t oid, struct dtx_id *xid, struct dt
 			/* Skip non-healthy one. */
 			if (target->ta_comp.co_status != PO_COMP_ST_UP &&
 			    target->ta_comp.co_status != PO_COMP_ST_UPIN &&
-			    target->ta_comp.co_status != PO_COMP_ST_NEW &&
 			    target->ta_comp.co_status != PO_COMP_ST_DRAIN)
 				continue;
 
@@ -238,7 +237,6 @@ dtx_coll_prep(uuid_t po_uuid, daos_unit_oid_t oid, struct dtx_id *xid, struct dt
 		/* Skip non-healthy one. */
 		if (target->ta_comp.co_status != PO_COMP_ST_UP &&
 		    target->ta_comp.co_status != PO_COMP_ST_UPIN &&
-		    target->ta_comp.co_status != PO_COMP_ST_NEW &&
 		    target->ta_comp.co_status != PO_COMP_ST_DRAIN)
 			continue;
 

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1959,9 +1959,7 @@ dtx_comp_cb(void **arg)
 	uint32_t			 i;
 	uint32_t			 j;
 
-	if (dlh->dlh_agg_cb != NULL) {
-		dlh->dlh_result = dlh->dlh_agg_cb(dlh, dlh->dlh_allow_failure);
-	} else {
+	if (!dlh->dlh_need_agg) {
 		for (i = dlh->dlh_forward_idx, j = 0; j < dlh->dlh_forward_cnt; i++, j++) {
 			sub = &dlh->dlh_subs[i];
 
@@ -2098,16 +2096,15 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	dlh->dlh_normal_sub_done = 0;
 	dlh->dlh_drop_cond = 0;
 	dlh->dlh_forward_idx = 0;
+	dlh->dlh_need_agg = 0;
+	dlh->dlh_agg_done = 0;
 
 	if (sub_cnt > DTX_EXEC_STEP_LENGTH) {
 		dlh->dlh_forward_cnt = DTX_EXEC_STEP_LENGTH;
-		dlh->dlh_agg_cb = NULL;
 	} else {
 		dlh->dlh_forward_cnt = sub_cnt;
-		if (likely(dlh->dlh_delay_sub_cnt == 0))
-			dlh->dlh_agg_cb = agg_cb;
-		else
-			dlh->dlh_agg_cb = NULL;
+		if (likely(dlh->dlh_delay_sub_cnt == 0) && agg_cb != NULL)
+			dlh->dlh_need_agg = 1;
 	}
 
 	if (dlh->dlh_normal_sub_cnt == 0)
@@ -2162,8 +2159,8 @@ exec:
 		dlh->dlh_forward_idx += dlh->dlh_forward_cnt;
 		if (sub_cnt <= DTX_EXEC_STEP_LENGTH) {
 			dlh->dlh_forward_cnt = sub_cnt;
-			if (likely(dlh->dlh_delay_sub_cnt == 0))
-				dlh->dlh_agg_cb = agg_cb;
+			if (likely(dlh->dlh_delay_sub_cnt == 0) && agg_cb != NULL)
+				dlh->dlh_need_agg = 1;
 		}
 
 		D_DEBUG(DB_IO, "More dispatch sub-requests for "DF_DTI", normal %u, "
@@ -2176,17 +2173,24 @@ exec:
 	}
 
 	dlh->dlh_normal_sub_done = 1;
+	dlh->dlh_drop_cond = 1;
+
+	if (agg_cb != NULL) {
+		remote_rc = agg_cb(dlh, func_arg);
+		dlh->dlh_agg_done = 1;
+		if (remote_rc == allow_failure)
+			dlh->dlh_drop_cond = 0;
+		else if (remote_rc != 0)
+			D_GOTO(out, rc = remote_rc);
+	}
 
 	if (likely(dlh->dlh_delay_sub_cnt == 0))
 		goto out;
 
-	dlh->dlh_drop_cond = 1;
-
-	if (agg_cb != 0 && allow_failure != 0) {
-		rc = agg_cb(dlh, allow_failure);
-		if (rc == allow_failure)
-			dlh->dlh_drop_cond = 0;
-	}
+	/* Need more aggregation for delayed sub-requests. */
+	dlh->dlh_agg_done = 0;
+	if (agg_cb != NULL)
+		dlh->dlh_need_agg = 1;
 
 	D_ASSERT(dlh->dlh_future == ABT_FUTURE_NULL);
 
@@ -2200,7 +2204,6 @@ exec:
 		D_GOTO(out, rc = dss_abterr2der(rc));
 	}
 
-	dlh->dlh_agg_cb = agg_cb;
 	dlh->dlh_forward_idx = 0;
 	/* The ones without DELAY flag will be skipped when scan the targets array. */
 	dlh->dlh_forward_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
@@ -2224,6 +2227,15 @@ exec:
 		allow_failure, local_rc, remote_rc);
 
 out:
+	/* The agg_cb may contain cleanup, let's do it even if hit failure at some former step. */
+	if (agg_cb != NULL && !dlh->dlh_agg_done) {
+		remote_rc = agg_cb(dlh, func_arg);
+		dlh->dlh_agg_done = 1;
+		if (remote_rc != 0 && remote_rc != allow_failure &&
+		    (rc == 0 || rc == allow_failure))
+			rc = remote_rc;
+	}
+
 	if (rc == 0 && local_rc == allow_failure &&
 	    (dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt == 0 || remote_rc == allow_failure))
 		rc = allow_failure;
@@ -2335,7 +2347,7 @@ dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs, daos_unit_oid_
 			D_GOTO(out, rc);
 
 		/* The target that (re-)joined the system after DTX cannot be the leader. */
-		if (rc == 1 && (*p_tgt)->ta_comp.co_ver <= version)
+		if (rc == 1 && (*p_tgt)->ta_comp.co_in_ver <= version)
 			D_GOTO(out, rc = 0);
 	}
 
@@ -2371,7 +2383,7 @@ dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs, daos_unit_oid_
 		D_ASSERT(rc == 1);
 
 		/* The target that (re-)joined the system after DTX cannot be the leader. */
-		if ((*p_tgt)->ta_comp.co_ver <= version)
+		if ((*p_tgt)->ta_comp.co_in_ver <= version)
 			D_GOTO(out, rc = 0);
 	}
 

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -180,7 +180,12 @@ extern uint32_t dtx_batched_ult_max;
  */
 #define DTX_INLINE_MBS_SIZE		512
 
-#define DTX_COLL_TREE_WIDTH		16
+/*
+ * The branch ratio for the KNOMIAL tree when bcast collective DTX RPC (commit/abort/check)
+ * to related engines. Based on the experience, the value which is not less than 4 may give
+ * relative better performance, cannot be too large (such as more than 10).
+ */
+#define DTX_COLL_TREE_WIDTH		8
 
 extern struct crt_corpc_ops	dtx_coll_commit_co_ops;
 extern struct crt_corpc_ops	dtx_coll_abort_co_ops;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -517,7 +517,6 @@ dtx_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head, int *
 		/* Skip non-healthy one. */
 		if (target->ta_comp.co_status != PO_COMP_ST_UP &&
 		    target->ta_comp.co_status != PO_COMP_ST_UPIN &&
-		    target->ta_comp.co_status != PO_COMP_ST_NEW &&
 		    target->ta_comp.co_status != PO_COMP_ST_DRAIN)
 			continue;
 

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -143,6 +143,7 @@ struct dtx_sub_status {
 	int				dss_result;
 	uint32_t			dss_version;
 	uint32_t			dss_comp:1;
+	void				*dss_data;
 };
 
 struct dtx_coll_entry {
@@ -157,7 +158,7 @@ struct dtx_coll_entry {
 };
 
 struct dtx_leader_handle;
-typedef int (*dtx_agg_cb_t)(struct dtx_leader_handle *dlh, int allow_failure);
+typedef int (*dtx_agg_cb_t)(struct dtx_leader_handle *dlh, void *arg);
 
 /* Transaction handle on the leader node to manage the transaction */
 struct dtx_leader_handle {
@@ -176,10 +177,11 @@ struct dtx_leader_handle {
 	/* The future to wait for sub requests to finish. */
 	ABT_future			dlh_future;
 
-	dtx_agg_cb_t			dlh_agg_cb;
 	int32_t				dlh_allow_failure;
 					/* Normal sub requests have been processed. */
 	uint32_t			dlh_normal_sub_done:1,
+					dlh_need_agg:1,
+					dlh_agg_done:1,
 					/* For collective DTX. */
 					dlh_coll:1,
 					/* Only forward RPC, but neither commit nor abort DTX. */

--- a/src/object/SConscript
+++ b/src/object/SConscript
@@ -17,7 +17,7 @@ def scons():
                                      'obj_enum.c', 'obj_class_def.c', "obj_layout.c"])
 
     # Object client library
-    dc_obj_tgts = denv.SharedObject(['cli_obj.c', 'cli_shard.c',
+    dc_obj_tgts = denv.SharedObject(['cli_obj.c', 'cli_shard.c', 'cli_coll.c',
                                      'cli_mod.c', 'cli_ec.c', 'cli_csum.c',
                                      'obj_verify.c'])
     libdaos_tgts.extend(dc_obj_tgts + common_tgts)
@@ -32,7 +32,7 @@ def scons():
 
     senv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
     srv = senv.d_library('obj',
-                         common_tgts + ['srv_obj.c', 'srv_mod.c',
+                         common_tgts + ['srv_obj.c', 'srv_coll.c', 'srv_mod.c',
                                         'srv_obj_remote.c', 'srv_ec.c',
                                         'srv_obj_migrate.c', 'srv_enum.c',
                                         'srv_cli.c', 'srv_ec_aggregate.c',

--- a/src/object/cli_coll.c
+++ b/src/object/cli_coll.c
@@ -1,0 +1,587 @@
+/**
+ * (C) Copyright 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * src/object/cli_coll.c
+ *
+ * For client side collecitve operation.
+ */
+#define D_LOGFAC	DD_FAC(object)
+
+#include <daos/object.h>
+#include <daos/container.h>
+#include <daos/pool.h>
+#include <daos/task.h>
+#include <daos_task.h>
+#include <daos_types.h>
+#include <daos_obj.h>
+#include "obj_rpc.h"
+#include "obj_internal.h"
+
+int
+obj_coll_oper_args_init(struct coll_oper_args *coa, struct dc_object *obj, bool for_modify)
+{
+	struct dc_pool	*pool = obj->cob_pool;
+	uint32_t	 node_nr;
+	int		 rc = 0;
+
+	D_ASSERT(pool != NULL);
+	D_ASSERT(coa->coa_dcts == NULL);
+
+	D_RWLOCK_RDLOCK(&pool->dp_map_lock);
+	node_nr = pool_map_node_nr(pool->dp_map);
+	D_RWLOCK_UNLOCK(&pool->dp_map_lock);
+
+	D_ALLOC_ARRAY(coa->coa_dcts, node_nr);
+	if (coa->coa_dcts == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	/*
+	 * Set coa_dct_nr as -1 to indicate that the coa_dcts array may be sparse until
+	 * obj_coll_oper_args_collapse(). That is useful for obj_coll_oper_args_fini().
+	 */
+	coa->coa_dct_nr = -1;
+	coa->coa_dct_cap = node_nr;
+	coa->coa_max_dct_sz = 0;
+	coa->coa_max_shard_nr = 0;
+	coa->coa_max_bitmap_sz = 0;
+	coa->coa_target_nr = 0;
+	coa->coa_for_modify = for_modify ? 1 : 0;
+
+out:
+	return rc;
+}
+
+void
+obj_coll_oper_args_fini(struct coll_oper_args *coa)
+{
+	daos_coll_target_cleanup(coa->coa_dcts,
+				 coa->coa_dct_nr < 0 ? coa->coa_dct_cap : coa->coa_dct_nr);
+	coa->coa_dcts = NULL;
+	coa->coa_dct_cap = 0;
+	coa->coa_dct_nr = 0;
+}
+
+int
+obj_coll_oper_args_collapse(struct coll_oper_args *coa, uint32_t *size)
+{
+	struct daos_coll_target	*dct;
+	struct daos_coll_shard	*dcs;
+	uint32_t		 dct_size;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+
+	for (i = 0, *size = 0, coa->coa_dct_nr = 0; i < coa->coa_dct_cap; i++) {
+		dct = &coa->coa_dcts[i];
+		if (dct->dct_bitmap != NULL) {
+			/* The size may be over estimated, no matter. */
+			dct_size = sizeof(*dct) + dct->dct_bitmap_sz +
+				   sizeof(dct->dct_shards[0]) * (dct->dct_max_shard + 1);
+
+			for (j = 0; j <= dct->dct_max_shard; j++) {
+				dcs = &dct->dct_shards[j];
+				if (dcs->dcs_nr > 1)
+					dct_size += sizeof(dcs->dcs_buf[0]) * dcs->dcs_nr;
+			}
+
+			if (coa->coa_for_modify)
+				dct_size += sizeof(dct->dct_tgt_ids[0]) * dct->dct_tgt_nr;
+
+			if (coa->coa_max_dct_sz < dct_size)
+				coa->coa_max_dct_sz = dct_size;
+
+			if (coa->coa_dct_nr < i)
+				memcpy(&coa->coa_dcts[coa->coa_dct_nr], dct, sizeof(*dct));
+
+			coa->coa_dct_nr++;
+			*size += dct_size;
+		}
+	}
+
+	if (unlikely(coa->coa_dct_nr == 0))
+		/* If all shards are NONEXIST, then need not to send RPC(s). */
+		rc = 1;
+	else if (coa->coa_dct_cap > coa->coa_dct_nr)
+		/* Reset the other dct slots to avoid double free during cleanup. */
+		memset(&coa->coa_dcts[coa->coa_dct_nr], 0,
+		       sizeof(*dct) * (coa->coa_dct_cap - coa->coa_dct_nr));
+
+	return rc;
+}
+
+int
+obj_coll_prep_one(struct coll_oper_args *coa, struct dc_object *obj,
+		  uint32_t map_ver, uint32_t idx)
+{
+	struct dc_obj_shard	*shard = NULL;
+	struct daos_coll_target	*dct;
+	struct daos_coll_shard	*dcs;
+	uint32_t		*tmp;
+	uint8_t			*new_bm;
+	int			 size;
+	int			 rc = 0;
+	int			 i;
+
+	rc = obj_shard_open(obj, idx, map_ver, &shard);
+	if (rc == -DER_NONEXIST)
+		D_GOTO(out, rc = 0);
+
+	if (rc != 0 || (shard->do_rebuilding && !coa->coa_for_modify))
+		goto out;
+
+	/*
+	 * More ranks joined after obj_coll_oper_args_init().
+	 * The object layout may be changed, need to re-scan.
+	 */
+	if (unlikely(shard->do_target_rank >= coa->coa_dct_cap))
+		D_GOTO(out, rc = -DER_AGAIN);
+
+	dct = &coa->coa_dcts[shard->do_target_rank];
+	dct->dct_rank = shard->do_target_rank;
+
+	if (shard->do_target_idx >= dct->dct_bitmap_sz << 3) {
+		size = (shard->do_target_idx >> 3) + 1;
+
+		D_ALLOC_ARRAY(dcs, size << 3);
+		if (dcs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		if (dct->dct_shards != NULL) {
+			memcpy(dcs, dct->dct_shards, sizeof(*dcs) * (dct->dct_max_shard + 1));
+			for (i = 0; i <= dct->dct_max_shard; i++) {
+				if (dcs[i].dcs_nr == 1)
+					dcs[i].dcs_buf = &dcs[i].dcs_inline;
+			}
+			D_FREE(dct->dct_shards);
+		}
+		dct->dct_shards = dcs;
+
+		D_REALLOC(new_bm, dct->dct_bitmap, dct->dct_bitmap_sz, size);
+		if (new_bm == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		dct->dct_bitmap = new_bm;
+		dct->dct_bitmap_sz = size;
+	}
+
+	dcs = &dct->dct_shards[shard->do_target_idx];
+
+	if (unlikely(isset(dct->dct_bitmap, shard->do_target_idx))) {
+		/* More than one shards reside on the same VOS target. */
+		D_ASSERT(dcs->dcs_nr >= 1);
+
+		if (dcs->dcs_nr >= dcs->dcs_cap) {
+			D_ALLOC_ARRAY(tmp, dcs->dcs_nr << 1);
+			if (tmp == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			memcpy(tmp, dcs->dcs_buf, sizeof(*tmp) * dcs->dcs_nr);
+			if (dcs->dcs_buf != &dcs->dcs_inline)
+				D_FREE(dcs->dcs_buf);
+			dcs->dcs_buf = tmp;
+			dcs->dcs_cap = dcs->dcs_nr << 1;
+		}
+	} else {
+		D_ASSERT(dcs->dcs_nr == 0);
+
+		dcs->dcs_idx = idx;
+		dcs->dcs_buf = &dcs->dcs_inline;
+		setbit(dct->dct_bitmap, shard->do_target_idx);
+		if (dct->dct_max_shard < shard->do_target_idx)
+			dct->dct_max_shard = shard->do_target_idx;
+	}
+
+	dcs->dcs_buf[dcs->dcs_nr++] = shard->do_id.id_shard;
+
+	if (unlikely(dct->dct_tgt_nr == (uint8_t)(-1)))
+		goto out;
+
+	if (coa->coa_for_modify) {
+		if (dct->dct_tgt_nr >= dct->dct_tgt_cap) {
+			if (dct->dct_tgt_cap == 0)
+				size = 4;
+			else if (dct->dct_tgt_cap <= 8)
+				size = dct->dct_tgt_cap << 1;
+			else
+				size = dct->dct_tgt_cap + 8;
+
+			D_REALLOC_ARRAY(tmp, dct->dct_tgt_ids, dct->dct_tgt_cap, size);
+			if (tmp == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			dct->dct_tgt_ids = tmp;
+			dct->dct_tgt_cap = size;
+		}
+
+		/*
+		 * There may be repeated elements in the dct->dct_tgt_ids array because multiple
+		 * object shards reside on the same VOS target. It is no matter to store them in
+		 * DTX MBS. Related DTX check logic will handle that.
+		 */
+		dct->dct_tgt_ids[dct->dct_tgt_nr++] = shard->do_target_id;
+		if (coa->coa_max_shard_nr < dct->dct_tgt_nr)
+			coa->coa_max_shard_nr = dct->dct_tgt_nr;
+
+		if (coa->coa_target_nr < DTX_COLL_INLINE_TARGETS &&
+		    !shard->do_rebuilding && !shard->do_reintegrating)
+			coa->coa_targets[coa->coa_target_nr++] = shard->do_target_id;
+
+		if (coa->coa_max_bitmap_sz < dct->dct_bitmap_sz)
+			coa->coa_max_bitmap_sz = dct->dct_bitmap_sz;
+	} else {
+		/* "dct_tgt_cap" is zero, then will not send dct_tgt_ids to server. */
+		dct->dct_tgt_nr++;
+	}
+
+out:
+	if (shard != NULL)
+		obj_shard_close(shard);
+
+	return rc;
+}
+
+struct obj_coll_punch_cb_args {
+	unsigned char		*cpca_buf;
+	struct dtx_memberships	*cpca_mbs;
+	struct dc_obj_shard	*cpca_shard;
+	crt_bulk_t		*cpca_bulks;
+	crt_proc_t		 cpca_proc;
+	d_sg_list_t		 cpca_sgl;
+	d_iov_t			 cpca_iov;
+};
+
+static int
+dc_obj_coll_punch_cb(tse_task_t *task, void *data)
+{
+	struct obj_coll_punch_cb_args	*cpca = data;
+
+	if (cpca->cpca_bulks != NULL) {
+		if (cpca->cpca_bulks[0] != CRT_BULK_NULL)
+			crt_bulk_free(cpca->cpca_bulks[0]);
+		D_FREE(cpca->cpca_bulks);
+	}
+
+	if (cpca->cpca_proc != NULL)
+		crt_proc_destroy(cpca->cpca_proc);
+
+	D_FREE(cpca->cpca_mbs);
+	D_FREE(cpca->cpca_buf);
+	obj_shard_close(cpca->cpca_shard);
+
+	return 0;
+}
+
+static int
+dc_obj_coll_punch_mbs(struct coll_oper_args *coa, struct dc_object *obj, uint32_t leader_id,
+		      struct dtx_memberships **p_mbs)
+{
+	struct dtx_memberships	*mbs;
+	struct dtx_daos_target	*ddt;
+	struct dtx_coll_target	*dct;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+
+	D_ALLOC(mbs, sizeof(*mbs) + sizeof(*ddt) * coa->coa_target_nr + sizeof(*dct));
+	if (mbs == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	/*
+	 * For object collective punch, even if we lost some redundancy groups when DTX resync,
+	 * we still continue to punch remaining shards. So let's set dm_grp_cnt as 1 to bypass
+	 * redundancy group check.
+	 */
+	mbs->dm_grp_cnt = 1;
+	mbs->dm_tgt_cnt = coa->coa_target_nr;
+	mbs->dm_data_size = sizeof(*ddt) * coa->coa_target_nr + sizeof(*dct);
+	mbs->dm_flags = DMF_CONTAIN_LEADER | DMF_COLL_TARGET;
+
+	/* ddt[0] will be the lead target. */
+	ddt = &mbs->dm_tgts[0];
+	ddt[0].ddt_id = leader_id;
+
+	for (i = 0, j = 1; i < coa->coa_target_nr && j < coa->coa_target_nr; i++) {
+		if (coa->coa_targets[i] != ddt[0].ddt_id)
+			ddt[j++].ddt_id = coa->coa_targets[i];
+	}
+
+	dct = (struct dtx_coll_target *)(ddt + coa->coa_target_nr);
+	dct->dct_fdom_lvl = obj->cob_md.omd_fdom_lvl;
+	dct->dct_pda = obj->cob_md.omd_pda;
+	dct->dct_pdom_lvl = obj->cob_md.omd_pdom_lvl;
+	dct->dct_layout_ver = obj->cob_layout_version;
+
+	/* The other fields will not be packed on-wire. Related engine will fill them in future. */
+
+	*p_mbs = mbs;
+
+out:
+	return rc;
+}
+
+static int
+dc_obj_coll_punch_bulk(tse_task_t *task, struct coll_oper_args *coa,
+		       struct obj_coll_punch_cb_args *cpca, uint32_t *p_size)
+{
+	/* The proc function may pack more information inside the buffer, enlarge the size a bit. */
+	uint32_t	size = (*p_size * 9) >> 3;
+	uint32_t	used = 0;
+	int		rc = 0;
+	int		i;
+
+again:
+	D_ALLOC(cpca->cpca_buf, size);
+	if (cpca->cpca_buf == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	rc = crt_proc_create(daos_task2ctx(task), cpca->cpca_buf, size, CRT_PROC_ENCODE,
+			     &cpca->cpca_proc);
+	if (rc != 0)
+		goto out;
+
+	for (i = 0; i < coa->coa_dct_nr; i++) {
+		rc = crt_proc_struct_daos_coll_target(cpca->cpca_proc, CRT_PROC_ENCODE,
+						      &coa->coa_dcts[i]);
+		if (rc != 0)
+			goto out;
+	}
+
+	used = crp_proc_get_size_used(cpca->cpca_proc);
+	if (unlikely(used > size)) {
+		crt_proc_destroy(cpca->cpca_proc);
+		cpca->cpca_proc = NULL;
+		D_FREE(cpca->cpca_buf);
+		size = used;
+		goto again;
+	}
+
+	cpca->cpca_iov.iov_buf = cpca->cpca_buf;
+	cpca->cpca_iov.iov_buf_len = used;
+	cpca->cpca_iov.iov_len = used;
+
+	cpca->cpca_sgl.sg_nr = 1;
+	cpca->cpca_sgl.sg_nr_out = 1;
+	cpca->cpca_sgl.sg_iovs = &cpca->cpca_iov;
+
+	rc = obj_bulk_prep(&cpca->cpca_sgl, 1, false, CRT_BULK_RO, task, &cpca->cpca_bulks);
+
+out:
+	if (rc != 0) {
+		if (cpca->cpca_proc != NULL) {
+			crt_proc_destroy(cpca->cpca_proc);
+			cpca->cpca_proc = NULL;
+		}
+		D_FREE(cpca->cpca_buf);
+	} else {
+		*p_size = used;
+	}
+
+	return rc;
+}
+
+int
+dc_obj_coll_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
+		  uint32_t map_ver, daos_obj_punch_t *args, struct obj_auxi_args *auxi)
+{
+	struct shard_punch_args		*spa = &auxi->p_args;
+	struct coll_oper_args		*coa = &spa->pa_coa;
+	struct dc_obj_shard		*shard = NULL;
+	struct dtx_memberships		*mbs = NULL;
+	struct daos_coll_target		*dct;
+	struct daos_coll_target		 tmp_tgt;
+	struct obj_coll_punch_cb_args	 cpca = { 0 };
+	uint32_t			 tgt_size = 0;
+	uint32_t			 mbs_max_size;
+	uint32_t			 inline_size;
+	uint32_t			 flags = ORF_LEADER;
+	uint32_t			 leader;
+	uint32_t			 len;
+	int				 rc;
+	int				 i;
+
+re_scan:
+	rc = obj_coll_oper_args_init(coa, obj, true);
+	if (rc != 0)
+		goto out;
+
+	for (i = 0; i < obj->cob_shards_nr; i++) {
+		rc = obj_coll_prep_one(coa, obj, map_ver, i);
+		if (rc != 0) {
+			if (unlikely(rc == -DER_AGAIN)) {
+				obj_coll_oper_args_fini(coa);
+				goto re_scan;
+			}
+
+			goto out;
+		}
+	}
+
+	rc = obj_coll_oper_args_collapse(coa, &tgt_size);
+	if (rc != 0)
+		goto out;
+
+	leader = coa->coa_dct_nr;
+
+	if (auxi->io_retry) {
+		if (unlikely(spa->pa_auxi.shard >= obj->cob_shards_nr))
+			goto new_leader;
+
+		/* Try to reuse the same leader. */
+		rc = obj_shard_open(obj, spa->pa_auxi.shard, map_ver, &shard);
+		if (rc == 0) {
+			if (!shard->do_rebuilding && !shard->do_reintegrating) {
+				leader = shard->do_target_rank;
+				goto gen_mbs;
+			}
+
+			obj_shard_close(shard);
+			shard = NULL;
+		} else if (rc != -DER_NONEXIST) {
+			goto out;
+		}
+
+		/* Then change to new leader for retry. */
+	}
+
+new_leader:
+	if (leader == coa->coa_dct_nr)
+		/* Randomly select a rank as the leader. */
+		leader = d_rand() % coa->coa_dct_nr;
+	else
+		leader = (leader + 1) % coa->coa_dct_nr;
+
+	dct = &coa->coa_dcts[leader];
+	len = dct->dct_bitmap_sz << 3;
+
+	for (i = 0; i < len; i++) {
+		if (isset(dct->dct_bitmap, i)) {
+			rc = obj_shard_open(obj, dct->dct_shards[i].dcs_idx, map_ver, &shard);
+			D_ASSERT(rc == 0);
+
+			if (!shard->do_rebuilding && !shard->do_reintegrating)
+				goto gen_mbs;
+
+			obj_shard_close(shard);
+			shard = NULL;
+		}
+	}
+
+	goto new_leader;
+
+gen_mbs:
+	if (leader != 0) {
+		memcpy(&tmp_tgt, &coa->coa_dcts[0], sizeof(tmp_tgt));
+		memcpy(&coa->coa_dcts[0], &coa->coa_dcts[leader], sizeof(tmp_tgt));
+		memcpy(&coa->coa_dcts[leader], &tmp_tgt, sizeof(tmp_tgt));
+	}
+
+	rc = dc_obj_coll_punch_mbs(coa, obj, shard->do_target_id, &mbs);
+	if (rc < 0)
+		goto out;
+
+	inline_size = sizeof(*mbs) + mbs->dm_data_size + sizeof(struct obj_coll_punch_in);
+	D_ASSERTF(inline_size < DAOS_BULK_LIMIT,
+		  "Too much data to be held inside coll punch RPC body: %u vs %u\n",
+		  inline_size, DAOS_BULK_LIMIT);
+
+	if (inline_size + tgt_size >= DAOS_BULK_LIMIT) {
+		rc = dc_obj_coll_punch_bulk(task, coa, &cpca, &tgt_size);
+		if (rc != 0)
+			goto out;
+	}
+
+	cpca.cpca_shard = shard;
+	cpca.cpca_mbs = mbs;
+	rc = tse_task_register_comp_cb(task, dc_obj_coll_punch_cb, &cpca, sizeof(cpca));
+	if (rc != 0)
+		goto out;
+
+	if (auxi->io_retry) {
+		flags |= ORF_RESEND;
+		/* Reset @enqueue_id if resend to new leader. */
+		if (spa->pa_auxi.target != shard->do_target_id)
+			spa->pa_auxi.enqueue_id = 0;
+	} else {
+		spa->pa_auxi.obj_auxi = auxi;
+		daos_dti_gen(&spa->pa_dti, false);
+	}
+
+	spa->pa_auxi.target = shard->do_target_id;
+	spa->pa_auxi.shard = shard->do_shard_idx;
+
+	if (obj_is_ec(obj))
+		flags |= ORF_EC;
+
+	mbs_max_size = sizeof(*mbs) + mbs->dm_data_size +
+		       sizeof(coa->coa_targets[0]) * coa->coa_max_shard_nr + coa->coa_max_bitmap_sz;
+
+	return dc_obj_shard_coll_punch(shard, spa, mbs, mbs_max_size, cpca.cpca_bulks, tgt_size,
+				       coa->coa_dcts, coa->coa_dct_nr, coa->coa_max_dct_sz, epoch,
+				       args->flags, flags, map_ver, &auxi->map_ver_reply, task);
+
+out:
+	if (rc > 0)
+		rc = 0;
+
+	DL_CDEBUG(rc == 0, DB_IO, DLOG_ERR, rc,
+		  "DAOS_OBJ_RPC_COLL_PUNCH for "DF_OID" map_ver %u, task %p",
+		  DP_OID(obj->cob_md.omd_id), map_ver, task);
+
+	if (cpca.cpca_bulks != NULL) {
+		if (cpca.cpca_bulks[0] != CRT_BULK_NULL)
+			crt_bulk_free(cpca.cpca_bulks[0]);
+		D_FREE(cpca.cpca_bulks);
+	}
+
+	if (cpca.cpca_proc != NULL)
+		crt_proc_destroy(cpca.cpca_proc);
+	D_FREE(cpca.cpca_buf);
+
+	if (shard != NULL)
+		obj_shard_close(shard);
+	D_FREE(mbs);
+
+	/* obj_coll_oper_args_fini() will be triggered via complete callback. */
+	tse_task_complete(task, rc);
+
+	return rc;
+}
+
+int
+queue_coll_query_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi, struct dc_object *obj,
+		      struct dtx_id *xid, struct dtx_epoch *epoch, uint32_t map_ver)
+{
+	struct coll_oper_args		*coa = &obj_auxi->cq_args.cqa_coa;
+	struct obj_coll_disp_cursor	*ocdc = &obj_auxi->cq_args.cqa_cur;
+	struct dc_cont			*cont = obj->cob_co;
+	crt_endpoint_t			 tgt_ep = { 0 };
+	uint32_t			 tmp;
+	int				 rc = 0;
+	int				 i;
+
+	rc = obj_coll_oper_args_collapse(coa, &tmp);
+	if (rc != 0)
+		goto out;
+
+	obj_coll_disp_init(coa->coa_dct_nr, coa->coa_max_dct_sz, sizeof(struct obj_coll_query_in),
+			   0, 0, ocdc);
+
+	for (i = 0; i < ocdc->grp_nr; i++) {
+		obj_coll_disp_dest(ocdc, coa->coa_dcts, &tgt_ep);
+
+		tmp = coa->coa_dcts[ocdc->cur_pos].dct_shards[tgt_ep.ep_tag].dcs_idx;
+		rc = queue_shard_query_key_task(api_task, obj_auxi, epoch, tmp, map_ver,
+						obj, xid, cont->dc_cont_hdl, cont->dc_uuid,
+						&coa->coa_dcts[ocdc->cur_pos], ocdc->cur_step);
+		if (rc != 0)
+			goto out;
+
+		obj_coll_disp_move(ocdc);
+	}
+
+out:
+	return rc;
+}

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2346,98 +2346,6 @@ check_query_flags(daos_obj_id_t oid, uint32_t flags, daos_key_t *dkey,
 	return 0;
 }
 
-static int
-obj_coll_oper_args_init(struct coll_oper_args *coa, struct dc_object *obj, bool for_modify)
-{
-	struct dc_pool	*pool = obj->cob_pool;
-	uint32_t	 node_nr;
-	int		 rc = 0;
-
-	D_ASSERT(pool != NULL);
-	D_ASSERT(coa->coa_dcts == NULL);
-
-	D_RWLOCK_RDLOCK(&pool->dp_map_lock);
-	node_nr = pool_map_node_nr(pool->dp_map);
-	D_RWLOCK_UNLOCK(&pool->dp_map_lock);
-
-	D_ALLOC_ARRAY(coa->coa_dcts, node_nr);
-	if (coa->coa_dcts == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	/*
-	 * Set coa_dct_nr as -1 to indicate that the coa_dcts array may be sparse until
-	 * obj_coll_oper_args_collapse(). That is useful for obj_coll_oper_args_fini().
-	 */
-	coa->coa_dct_nr = -1;
-	coa->coa_dct_cap = node_nr;
-	coa->coa_max_dct_sz = 0;
-	coa->coa_max_shard_nr = 0;
-	coa->coa_max_bitmap_sz = 0;
-	coa->coa_target_nr = 0;
-	coa->coa_for_modify = for_modify ? 1 : 0;
-
-out:
-	return rc;
-}
-
-static void
-obj_coll_oper_args_fini(struct coll_oper_args *coa)
-{
-	daos_coll_target_cleanup(coa->coa_dcts,
-				 coa->coa_dct_nr < 0 ? coa->coa_dct_cap : coa->coa_dct_nr);
-	coa->coa_dcts = NULL;
-	coa->coa_dct_cap = 0;
-	coa->coa_dct_nr = 0;
-}
-
-static int
-obj_coll_oper_args_collapse(struct coll_oper_args *coa, uint32_t *size)
-{
-	struct daos_coll_target	*dct;
-	struct daos_coll_shard	*dcs;
-	uint32_t		 dct_size;
-	int			 rc = 0;
-	int			 i;
-	int			 j;
-
-	for (i = 0, *size = 0, coa->coa_dct_nr = 0; i < coa->coa_dct_cap; i++) {
-		dct = &coa->coa_dcts[i];
-		if (dct->dct_bitmap != NULL) {
-			/* The size may be over estimated, no matter. */
-			dct_size = sizeof(*dct) + dct->dct_bitmap_sz +
-				   sizeof(dct->dct_shards[0]) * (dct->dct_max_shard + 1);
-
-			for (j = 0; j <= dct->dct_max_shard; j++) {
-				dcs = &dct->dct_shards[j];
-				if (dcs->dcs_nr > 1)
-					dct_size += sizeof(dcs->dcs_buf[0]) * dcs->dcs_nr;
-			}
-
-			if (coa->coa_for_modify)
-				dct_size += sizeof(dct->dct_tgt_ids[0]) * dct->dct_tgt_nr;
-
-			if (coa->coa_max_dct_sz < dct_size)
-				coa->coa_max_dct_sz = dct_size;
-
-			if (coa->coa_dct_nr < i)
-				memcpy(&coa->coa_dcts[coa->coa_dct_nr], dct, sizeof(*dct));
-
-			coa->coa_dct_nr++;
-			*size += dct_size;
-		}
-	}
-
-	if (unlikely(coa->coa_dct_nr == 0))
-		/* If all shards are NONEXIST, then need not to send RPC(s). */
-		rc = 1;
-	else if (coa->coa_dct_cap > coa->coa_dct_nr)
-		/* Reset the other dct slots to avoid double free during cleanup. */
-		memset(&coa->coa_dcts[coa->coa_dct_nr], 0,
-		       sizeof(*dct) * (coa->coa_dct_cap - coa->coa_dct_nr));
-
-	return rc;
-}
-
 static inline bool
 obj_key_valid(daos_obj_id_t oid, daos_key_t *key, bool check_dkey)
 {
@@ -2938,6 +2846,7 @@ obj_embedded_shard_arg(struct obj_auxi_args *obj_auxi)
 		return &obj_auxi->s_args.sa_auxi;
 	case DAOS_OBJ_RPC_QUERY_KEY:
 	case DAOS_OBJ_RPC_COLL_PUNCH:
+	case DAOS_OBJ_RPC_COLL_QUERY:
 		/*
 		 * called from obj_comp_cb_internal() and
 		 * checked in obj_shard_comp_cb() correctly
@@ -4921,6 +4830,9 @@ obj_comp_cb(tse_task_t *task, void *data)
 	if (obj_auxi->opc == DAOS_OBJ_RPC_COLL_PUNCH)
 		obj_coll_oper_args_fini(&obj_auxi->p_args.pa_coa);
 
+	if (obj_auxi->opc == DAOS_OBJ_RPC_COLL_QUERY)
+		obj_coll_oper_args_fini(&obj_auxi->cq_args.cqa_coa);
+
 	if ((!obj_auxi->no_retry || task->dt_result == -DER_FETCH_AGAIN) &&
 	     (pm_stale || obj_auxi->io_retry)) {
 		rc = obj_retry_cb(task, obj, obj_auxi, pm_stale, &io_task_reinited);
@@ -4973,6 +4885,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 			D_ASSERT(daos_handle_is_inval(obj_auxi->th));
 			break;
 		case DAOS_OBJ_RPC_QUERY_KEY:
+		case DAOS_OBJ_RPC_COLL_QUERY:
 		case DAOS_OBJ_RECX_RPC_ENUMERATE:
 		case DAOS_OBJ_AKEY_RPC_ENUMERATE:
 		case DAOS_OBJ_DKEY_RPC_ENUMERATE:
@@ -6754,440 +6667,6 @@ shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 }
 
 static int
-obj_coll_prep_one(struct coll_oper_args *coa, struct dc_object *obj,
-		  uint32_t map_ver, uint32_t idx)
-{
-	struct dc_obj_shard	*shard = NULL;
-	struct daos_coll_target	*dct;
-	struct daos_coll_shard	*dcs;
-	uint32_t		*tmp;
-	uint8_t			*new_bm;
-	int			 size;
-	int			 rc = 0;
-	int			 i;
-
-	rc = obj_shard_open(obj, idx, map_ver, &shard);
-	if (rc == -DER_NONEXIST)
-		D_GOTO(out, rc = 0);
-
-	if (rc != 0 || (shard->do_rebuilding && !coa->coa_for_modify))
-		goto out;
-
-	/* More ranks joined after obj_coll_oper_args_init(). */
-	if (unlikely(shard->do_target_rank >= coa->coa_dct_cap)) {
-		D_REALLOC_ARRAY(dct, coa->coa_dcts, coa->coa_dct_cap, shard->do_target_rank + 2);
-		if (dct == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		coa->coa_dcts = dct;
-		coa->coa_dct_cap = shard->do_target_rank + 2;
-	}
-
-	dct = &coa->coa_dcts[shard->do_target_rank];
-	dct->dct_rank = shard->do_target_rank;
-
-	if (shard->do_target_idx >= dct->dct_bitmap_sz << 3) {
-		size = (shard->do_target_idx >> 3) + 1;
-
-		D_ALLOC_ARRAY(dcs, size << 3);
-		if (dcs == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		if (dct->dct_shards != NULL) {
-			memcpy(dcs, dct->dct_shards, sizeof(*dcs) * (dct->dct_max_shard + 1));
-			for (i = 0; i <= dct->dct_max_shard; i++) {
-				if (dcs[i].dcs_nr == 1)
-					dcs[i].dcs_buf = &dcs[i].dcs_inline;
-			}
-			D_FREE(dct->dct_shards);
-		}
-		dct->dct_shards = dcs;
-
-		D_REALLOC(new_bm, dct->dct_bitmap, dct->dct_bitmap_sz, size);
-		if (new_bm == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		dct->dct_bitmap = new_bm;
-		dct->dct_bitmap_sz = size;
-	}
-
-	dcs = &dct->dct_shards[shard->do_target_idx];
-
-	if (unlikely(isset(dct->dct_bitmap, shard->do_target_idx))) {
-		/* More than one shards reside on the same VOS target. */
-		D_ASSERT(dcs->dcs_nr >= 1);
-
-		if (dcs->dcs_nr >= dcs->dcs_cap) {
-			D_ALLOC_ARRAY(tmp, dcs->dcs_nr << 1);
-			if (tmp == NULL)
-				D_GOTO(out, rc = -DER_NOMEM);
-
-			memcpy(tmp, dcs->dcs_buf, sizeof(*tmp) * dcs->dcs_nr);
-			if (dcs->dcs_buf != &dcs->dcs_inline)
-				D_FREE(dcs->dcs_buf);
-			dcs->dcs_buf = tmp;
-			dcs->dcs_cap = dcs->dcs_nr << 1;
-		}
-	} else {
-		D_ASSERT(dcs->dcs_nr == 0);
-
-		dcs->dcs_idx = idx;
-		dcs->dcs_buf = &dcs->dcs_inline;
-		setbit(dct->dct_bitmap, shard->do_target_idx);
-		if (dct->dct_max_shard < shard->do_target_idx)
-			dct->dct_max_shard = shard->do_target_idx;
-	}
-
-	dcs->dcs_buf[dcs->dcs_nr++] = shard->do_id.id_shard;
-
-	if (unlikely(dct->dct_tgt_nr == (uint8_t)(-1)))
-		goto out;
-
-	if (coa->coa_for_modify) {
-		if (dct->dct_tgt_nr >= dct->dct_tgt_cap) {
-			if (dct->dct_tgt_cap == 0)
-				size = 4;
-			else if (dct->dct_tgt_cap <= 8)
-				size = dct->dct_tgt_cap << 1;
-			else
-				size = dct->dct_tgt_cap + 8;
-
-			D_REALLOC_ARRAY(tmp, dct->dct_tgt_ids, dct->dct_tgt_cap, size);
-			if (tmp == NULL)
-				D_GOTO(out, rc = -DER_NOMEM);
-
-			dct->dct_tgt_ids = tmp;
-			dct->dct_tgt_cap = size;
-		}
-
-		/*
-		 * There may be repeated elements in the dct->dct_tgt_ids array because multiple
-		 * object shards reside on the same VOS target. It is no matter to store them in
-		 * DTX MBS. Related DTX check logic will handle that.
-		 */
-		dct->dct_tgt_ids[dct->dct_tgt_nr++] = shard->do_target_id;
-		if (coa->coa_max_shard_nr < dct->dct_tgt_nr)
-			coa->coa_max_shard_nr = dct->dct_tgt_nr;
-
-		if (coa->coa_target_nr < DTX_COLL_INLINE_TARGETS &&
-		    !shard->do_rebuilding && !shard->do_reintegrating)
-			coa->coa_targets[coa->coa_target_nr++] = shard->do_target_id;
-
-		if (coa->coa_max_bitmap_sz < dct->dct_bitmap_sz)
-			coa->coa_max_bitmap_sz = dct->dct_bitmap_sz;
-	} else {
-		/* "dct_tgt_cap" is zero, then will not send dct_tgt_ids to server. */
-		dct->dct_tgt_nr++;
-	}
-
-out:
-	if (shard != NULL)
-		obj_shard_close(shard);
-
-	return rc;
-}
-
-struct obj_coll_punch_cb_args {
-	unsigned char		*cpca_buf;
-	struct dtx_memberships	*cpca_mbs;
-	struct dc_obj_shard	*cpca_shard;
-	crt_bulk_t		*cpca_bulks;
-	crt_proc_t		 cpca_proc;
-	d_sg_list_t		 cpca_sgl;
-	d_iov_t			 cpca_iov;
-};
-
-static int
-dc_obj_coll_punch_cb(tse_task_t *task, void *data)
-{
-	struct obj_coll_punch_cb_args	*cpca = data;
-
-	if (cpca->cpca_bulks != NULL) {
-		if (cpca->cpca_bulks[0] != CRT_BULK_NULL)
-			crt_bulk_free(cpca->cpca_bulks[0]);
-		D_FREE(cpca->cpca_bulks);
-	}
-
-	if (cpca->cpca_proc != NULL)
-		crt_proc_destroy(cpca->cpca_proc);
-
-	D_FREE(cpca->cpca_mbs);
-	D_FREE(cpca->cpca_buf);
-	obj_shard_close(cpca->cpca_shard);
-
-	return 0;
-}
-
-static int
-dc_obj_coll_punch_mbs(struct coll_oper_args *coa, struct dc_object *obj, uint32_t leader_id,
-		      struct dtx_memberships **p_mbs)
-{
-	struct dtx_memberships	*mbs;
-	struct dtx_daos_target	*ddt;
-	struct dtx_coll_target	*dct;
-	int			 rc = 0;
-	int			 i;
-	int			 j;
-
-	D_ALLOC(mbs, sizeof(*mbs) + sizeof(*ddt) * coa->coa_target_nr + sizeof(*dct));
-	if (mbs == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	/*
-	 * For object collective punch, even if we lost some redundancy groups when DTX resync,
-	 * we still continue to punch remaining shards. So let's set dm_grp_cnt as 1 to bypass
-	 * redundancy group check.
-	 */
-	mbs->dm_grp_cnt = 1;
-	mbs->dm_tgt_cnt = coa->coa_target_nr;
-	mbs->dm_data_size = sizeof(*ddt) * coa->coa_target_nr + sizeof(*dct);
-	mbs->dm_flags = DMF_CONTAIN_LEADER | DMF_COLL_TARGET;
-
-	/* ddt[0] will be the lead target. */
-	ddt = &mbs->dm_tgts[0];
-	ddt[0].ddt_id = leader_id;
-
-	for (i = 0, j = 1; i < coa->coa_target_nr && j < coa->coa_target_nr; i++) {
-		if (coa->coa_targets[i] != ddt[0].ddt_id)
-			ddt[j++].ddt_id = coa->coa_targets[i];
-	}
-
-	dct = (struct dtx_coll_target *)(ddt + coa->coa_target_nr);
-	dct->dct_fdom_lvl = obj->cob_md.omd_fdom_lvl;
-	dct->dct_pda = obj->cob_md.omd_pda;
-	dct->dct_pdom_lvl = obj->cob_md.omd_pdom_lvl;
-	dct->dct_layout_ver = obj->cob_layout_version;
-
-	/* The other fields will not be packed on-wire. Related engine will fill them in future. */
-
-	*p_mbs = mbs;
-
-out:
-	return rc;
-}
-
-static int
-dc_obj_coll_punch_bulk(tse_task_t *task, struct coll_oper_args *coa,
-		       struct obj_coll_punch_cb_args *cpca, uint32_t *p_size)
-{
-	/* The proc function may pack more information inside the buffer, enlarge the size a bit. */
-	uint32_t	size = (*p_size * 9) >> 3;
-	uint32_t	used = 0;
-	int		rc = 0;
-	int		i;
-
-again:
-	D_ALLOC(cpca->cpca_buf, size);
-	if (cpca->cpca_buf == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	rc = crt_proc_create(daos_task2ctx(task), cpca->cpca_buf, size, CRT_PROC_ENCODE,
-			     &cpca->cpca_proc);
-	if (rc != 0)
-		goto out;
-
-	for (i = 0; i < coa->coa_dct_nr; i++) {
-		rc = crt_proc_struct_daos_coll_target(cpca->cpca_proc, CRT_PROC_ENCODE,
-						      &coa->coa_dcts[i]);
-		if (rc != 0)
-			goto out;
-	}
-
-	used = crp_proc_get_size_used(cpca->cpca_proc);
-	if (unlikely(used > size)) {
-		crt_proc_destroy(cpca->cpca_proc);
-		cpca->cpca_proc = NULL;
-		D_FREE(cpca->cpca_buf);
-		size = used;
-		goto again;
-	}
-
-	cpca->cpca_iov.iov_buf = cpca->cpca_buf;
-	cpca->cpca_iov.iov_buf_len = used;
-	cpca->cpca_iov.iov_len = used;
-
-	cpca->cpca_sgl.sg_nr = 1;
-	cpca->cpca_sgl.sg_nr_out = 1;
-	cpca->cpca_sgl.sg_iovs = &cpca->cpca_iov;
-
-	rc = obj_bulk_prep(&cpca->cpca_sgl, 1, false, CRT_BULK_RO, task, &cpca->cpca_bulks);
-
-out:
-	if (rc != 0) {
-		if (cpca->cpca_proc != NULL) {
-			crt_proc_destroy(cpca->cpca_proc);
-			cpca->cpca_proc = NULL;
-		}
-		D_FREE(cpca->cpca_buf);
-	} else {
-		*p_size = used;
-	}
-
-	return rc;
-}
-
-static int
-dc_obj_coll_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
-		  uint32_t map_ver, daos_obj_punch_t *args, struct obj_auxi_args *auxi)
-{
-	struct shard_punch_args		*spa = &auxi->p_args;
-	struct coll_oper_args		*coa = &spa->pa_coa;
-	struct dc_obj_shard		*shard = NULL;
-	struct dtx_memberships		*mbs = NULL;
-	struct daos_coll_target		*dct;
-	struct daos_coll_target		 tmp_tgt;
-	struct obj_coll_punch_cb_args	 cpca = { 0 };
-	uint32_t			 tgt_size = 0;
-	uint32_t			 mbs_max_size;
-	uint32_t			 inline_size;
-	uint32_t			 flags = ORF_LEADER;
-	uint32_t			 leader;
-	uint32_t			 len;
-	int				 rc;
-	int				 i;
-
-	rc = obj_coll_oper_args_init(coa, obj, true);
-	if (rc != 0)
-		goto out;
-
-	for (i = 0; i < obj->cob_shards_nr; i++) {
-		rc = obj_coll_prep_one(coa, obj, map_ver, i);
-		if (rc != 0)
-			goto out;
-	}
-
-	rc = obj_coll_oper_args_collapse(coa, &tgt_size);
-	if (rc != 0)
-		goto out;
-
-	leader = coa->coa_dct_nr;
-
-	if (auxi->io_retry) {
-		if (unlikely(spa->pa_auxi.shard >= obj->cob_shards_nr))
-			goto new_leader;
-
-		/* Try to reuse the same leader. */
-		rc = obj_shard_open(obj, spa->pa_auxi.shard, map_ver, &shard);
-		if (rc == 0) {
-			if (!shard->do_rebuilding && !shard->do_reintegrating) {
-				leader = shard->do_target_rank;
-				goto gen_mbs;
-			}
-
-			obj_shard_close(shard);
-			shard = NULL;
-		} else if (rc != -DER_NONEXIST) {
-			goto out;
-		}
-
-		/* Then change to new leader for retry. */
-	}
-
-new_leader:
-	if (leader == coa->coa_dct_nr)
-		/* Randomly select a rank as the leader. */
-		leader = d_rand() % coa->coa_dct_nr;
-	else
-		leader = (leader + 1) % coa->coa_dct_nr;
-
-	dct = &coa->coa_dcts[leader];
-	len = dct->dct_bitmap_sz << 3;
-
-	for (i = 0; i < len; i++) {
-		if (isset(dct->dct_bitmap, i)) {
-			rc = obj_shard_open(obj, dct->dct_shards[i].dcs_idx, map_ver, &shard);
-			D_ASSERT(rc == 0);
-
-			if (!shard->do_rebuilding && !shard->do_reintegrating)
-				goto gen_mbs;
-
-			obj_shard_close(shard);
-			shard = NULL;
-		}
-	}
-
-	goto new_leader;
-
-gen_mbs:
-	if (leader != 0) {
-		memcpy(&tmp_tgt, &coa->coa_dcts[0], sizeof(tmp_tgt));
-		memcpy(&coa->coa_dcts[0], &coa->coa_dcts[leader], sizeof(tmp_tgt));
-		memcpy(&coa->coa_dcts[leader], &tmp_tgt, sizeof(tmp_tgt));
-	}
-
-	rc = dc_obj_coll_punch_mbs(coa, obj, shard->do_target_id, &mbs);
-	if (rc < 0)
-		goto out;
-
-	inline_size = sizeof(*mbs) + mbs->dm_data_size + sizeof(struct obj_coll_punch_in);
-	D_ASSERTF(inline_size < DAOS_BULK_LIMIT,
-		  "Too much data to be held inside coll punch RPC body: %u vs %u\n",
-		  inline_size, DAOS_BULK_LIMIT);
-
-	if (inline_size + tgt_size >= DAOS_BULK_LIMIT) {
-		rc = dc_obj_coll_punch_bulk(task, coa, &cpca, &tgt_size);
-		if (rc != 0)
-			goto out;
-	}
-
-	cpca.cpca_shard = shard;
-	cpca.cpca_mbs = mbs;
-	rc = tse_task_register_comp_cb(task, dc_obj_coll_punch_cb, &cpca, sizeof(cpca));
-	if (rc != 0)
-		goto out;
-
-	if (auxi->io_retry) {
-		flags |= ORF_RESEND;
-		/* Reset @enqueue_id if resend to new leader. */
-		if (spa->pa_auxi.target != shard->do_target_id)
-			spa->pa_auxi.enqueue_id = 0;
-	} else {
-		spa->pa_auxi.obj_auxi = auxi;
-		daos_dti_gen(&spa->pa_dti, false);
-	}
-
-	spa->pa_auxi.target = shard->do_target_id;
-	spa->pa_auxi.shard = shard->do_shard_idx;
-
-	if (obj_is_ec(obj))
-		flags |= ORF_EC;
-
-	mbs_max_size = sizeof(*mbs) + mbs->dm_data_size +
-		       sizeof(coa->coa_targets[0]) * coa->coa_max_shard_nr + coa->coa_max_bitmap_sz;
-
-	return dc_obj_shard_coll_punch(shard, spa, mbs, mbs_max_size, cpca.cpca_bulks, tgt_size,
-				       coa->coa_dcts, coa->coa_dct_nr, coa->coa_max_dct_sz, epoch,
-				       args->flags, flags, map_ver, &auxi->map_ver_reply, task);
-
-out:
-	if (rc > 0)
-		rc = 0;
-
-	DL_CDEBUG(rc == 0, DB_IO, DLOG_ERR, rc,
-		  "DAOS_OBJ_RPC_COLL_PUNCH for "DF_OID" map_ver %u, task %p",
-		  DP_OID(obj->cob_md.omd_id), map_ver, task);
-
-	if (cpca.cpca_bulks != NULL) {
-		if (cpca.cpca_bulks[0] != CRT_BULK_NULL)
-			crt_bulk_free(cpca.cpca_bulks[0]);
-		D_FREE(cpca.cpca_bulks);
-	}
-
-	if (cpca.cpca_proc != NULL)
-		crt_proc_destroy(cpca.cpca_proc);
-	D_FREE(cpca.cpca_buf);
-
-	if (shard != NULL)
-		obj_shard_close(shard);
-	D_FREE(mbs);
-
-	/* obj_coll_oper_args_fini() will be triggered via complete callback. */
-	obj_task_complete(task, rc);
-
-	return rc;
-}
-
-static int
 dc_obj_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
 	     uint32_t map_ver, enum obj_rpc_opc opc, daos_obj_punch_t *api_args)
 {
@@ -7349,6 +6828,8 @@ struct shard_query_key_args {
 	uuid_t			 kqa_coh_uuid;
 	uuid_t			 kqa_cont_uuid;
 	struct dtx_id		 kqa_dti;
+	uint32_t		 kqa_dct_nr;
+	struct daos_coll_target	*kqa_dcts;
 };
 
 static int
@@ -7356,6 +6837,7 @@ shard_query_key_task(tse_task_t *task)
 {
 	struct shard_query_key_args	*args;
 	daos_obj_query_key_t		*api_args;
+	struct obj_auxi_args		*auxi;
 	struct dc_object		*obj;
 	struct dc_obj_shard		*obj_shard;
 	daos_handle_t			 th;
@@ -7363,8 +6845,9 @@ shard_query_key_task(tse_task_t *task)
 	int				 rc;
 
 	args = tse_task_buf_embedded(task, sizeof(*args));
-	obj = args->kqa_auxi.obj_auxi->obj;
-	th = args->kqa_auxi.obj_auxi->th;
+	auxi = args->kqa_auxi.obj_auxi;
+	obj = auxi->obj;
+	th = auxi->th;
 	epoch = &args->kqa_auxi.epoch;
 
 	/* See the similar shard_io_task. */
@@ -7381,9 +6864,17 @@ shard_query_key_task(tse_task_t *task)
 
 	rc = obj_shard_open(obj, args->kqa_auxi.shard, args->kqa_auxi.map_ver, &obj_shard);
 	if (rc != 0) {
-		/* skip a failed target */
-		if (rc == -DER_NONEXIST)
-			rc = 0;
+		if (rc == -DER_NONEXIST) {
+			/*
+			 * For collective query, the shard was just opened, so there
+			 * must be something wrong. Otherwise, skip a failed target.
+			 */
+			if (args->kqa_dcts != NULL)
+				D_ASSERTF(0, "Something wrong on %u shard\n",
+					  args->kqa_auxi.shard);
+			else
+				rc = 0;
+		}
 
 		obj_task_complete(task, rc);
 		return rc;
@@ -7396,24 +6887,33 @@ shard_query_key_task(tse_task_t *task)
 		return rc;
 	}
 
-	api_args = dc_task_get_args(args->kqa_auxi.obj_auxi->obj_task);
-	rc = dc_obj_shard_query_key(obj_shard, epoch, api_args->flags,
-				    args->kqa_auxi.obj_auxi->map_ver_req, obj,
-				    api_args->dkey, api_args->akey,
-				    api_args->recx, api_args->max_epoch, args->kqa_coh_uuid,
-				    args->kqa_cont_uuid, &args->kqa_dti,
-				    &args->kqa_auxi.obj_auxi->map_ver_reply, th, task,
-				    &args->kqa_auxi.obj_auxi->max_delay,
-				    &args->kqa_auxi.enqueue_id);
+	api_args = dc_task_get_args(auxi->obj_task);
+	if (args->kqa_dcts != NULL)
+		rc = dc_obj_shard_coll_query(obj_shard, epoch, api_args->flags, auxi->map_ver_req,
+					     obj, api_args->dkey, api_args->akey, api_args->recx,
+					     api_args->max_epoch, args->kqa_coh_uuid,
+					     args->kqa_cont_uuid, &args->kqa_dti,
+					     &auxi->map_ver_reply, args->kqa_dcts, args->kqa_dct_nr,
+					     auxi->cq_args.cqa_coa.coa_max_dct_sz,
+					     auxi->cq_args.cqa_cur.grp_nr, th, task,
+					     &auxi->max_delay, &args->kqa_auxi.enqueue_id);
+	else
+		rc = dc_obj_shard_query_key(obj_shard, epoch, api_args->flags, auxi->map_ver_req,
+					    obj, api_args->dkey, api_args->akey, api_args->recx,
+					    api_args->max_epoch, args->kqa_coh_uuid,
+					    args->kqa_cont_uuid, &args->kqa_dti,
+					    &auxi->map_ver_reply, th, task, &auxi->max_delay,
+					    &args->kqa_auxi.enqueue_id);
 
 	return rc;
 }
 
-static int
+int
 queue_shard_query_key_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi,
 			   struct dtx_epoch *epoch, int shard, unsigned int map_ver,
 			   struct dc_object *obj, struct dtx_id *dti,
-			   uuid_t coh_uuid, uuid_t cont_uuid)
+			   uuid_t coh_uuid, uuid_t cont_uuid,
+			   struct daos_coll_target *dcts, uint32_t dct_nr)
 {
 	tse_sched_t			*sched = tse_task2sched(api_task);
 	tse_task_t			*task;
@@ -7434,6 +6934,8 @@ queue_shard_query_key_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi,
 	args->kqa_dti		= *dti;
 	uuid_copy(args->kqa_coh_uuid, coh_uuid);
 	uuid_copy(args->kqa_cont_uuid, cont_uuid);
+	args->kqa_dcts = dcts;
+	args->kqa_dct_nr = dct_nr;
 
 	rc = obj_shard2tgtid(obj, shard, map_ver, &target);
 	if (rc != 0)
@@ -7467,8 +6969,9 @@ dc_obj_query_key(tse_task_t *api_task)
 	struct obj_auxi_args	*obj_auxi;
 	struct dc_object	*obj;
 	d_list_t		*head = NULL;
-	uuid_t			coh_uuid;
-	uuid_t			cont_uuid;
+	uuid_t			co_hdl;
+	uuid_t			co_uuid;
+	uint32_t		grp_size;
 	int			grp_idx;
 	uint32_t		grp_nr;
 	unsigned int		map_ver = 0;
@@ -7476,6 +6979,7 @@ dc_obj_query_key(tse_task_t *api_task)
 	struct dtx_id		dti;
 	int			i = 0;
 	int			rc;
+	bool			coll = false;
 
 	D_ASSERTF(api_args != NULL,
 		  "Task Argument OPC does not match DC OPC\n");
@@ -7508,7 +7012,7 @@ dc_obj_query_key(tse_task_t *api_task)
 	obj_auxi->spec_shard = 0;
 	obj_auxi->spec_group = 0;
 
-	rc = dc_cont2uuid(obj->cob_co, &coh_uuid, &cont_uuid);
+	rc = dc_cont2uuid(obj->cob_co, &co_hdl, &co_uuid);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 
@@ -7557,13 +7061,26 @@ dc_obj_query_key(tse_task_t *api_task)
 	D_ASSERT(!obj_auxi->args_initialized);
 	D_ASSERT(d_list_empty(head));
 
+	/* Some optimization for get dkey collectively since 2.6 which version is 10. */
+	if (api_args->flags & DAOS_GET_DKEY && grp_nr > 1 && dc_obj_proto_version >= 10) {
+re_scan:
+		rc = obj_coll_oper_args_init(&obj_auxi->cq_args.cqa_coa, obj, false);
+		if (rc != 0)
+			goto out_task;
+
+		obj_auxi->opc = DAOS_OBJ_RPC_COLL_QUERY;
+		coll = true;
+	}
+
+	grp_size = daos_oclass_grp_size(&obj->cob_oca);
+
 	for (i = grp_idx; i < grp_idx + grp_nr; i++) {
 		int start_shard;
 		int j;
 		int shard_cnt = 0;
 
 		/* Try leader for current group */
-		if (!obj_is_ec(obj) || (obj_is_ec(obj) && !obj_ec_parity_rotate_enabled(obj))) {
+		if (!obj_is_ec(obj) || !obj_ec_parity_rotate_enabled(obj)) {
 			int leader;
 
 			leader = obj_grp_leader_get(obj, i, (uint64_t)d_rand(),
@@ -7573,10 +7090,19 @@ dc_obj_query_key(tse_task_t *api_task)
 				    !is_ec_parity_shard(obj, obj_auxi->dkey_hash, leader))
 					goto non_leader;
 
-				rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, leader,
-								map_ver, obj, &dti, coh_uuid,
-								cont_uuid);
-				if (rc)
+				if (coll) {
+					rc = obj_coll_prep_one(&obj_auxi->cq_args.cqa_coa, obj,
+							       map_ver, leader);
+					if (unlikely(rc == -DER_AGAIN)) {
+						obj_coll_oper_args_fini(&obj_auxi->cq_args.cqa_coa);
+						goto re_scan;
+					}
+				} else {
+					rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch,
+									leader, map_ver, obj, &dti,
+									co_hdl, co_uuid, NULL, 0);
+				}
+				if (rc != 0)
 					D_GOTO(out_task, rc);
 
 				D_DEBUG(DB_IO, DF_OID" try leader %d for group %d.\n",
@@ -7596,12 +7122,22 @@ non_leader:
 		start_shard = i * obj_get_grp_size(obj);
 		D_DEBUG(DB_IO, DF_OID" EC needs to try all shards for group %d.\n",
 			DP_OID(obj->cob_md.omd_id), i);
-		for (j = start_shard; j < start_shard + daos_oclass_grp_size(&obj->cob_oca); j++) {
+		for (j = start_shard; j < start_shard + grp_size; j++) {
 			if (obj_shard_is_invalid(obj, j, DAOS_OBJ_RPC_QUERY_KEY))
 				continue;
-			rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, j, map_ver,
-							obj, &dti, coh_uuid, cont_uuid);
-			if (rc)
+
+			if (coll) {
+				rc = obj_coll_prep_one(&obj_auxi->cq_args.cqa_coa, obj, map_ver, j);
+				if (unlikely(rc == -DER_AGAIN)) {
+					obj_coll_oper_args_fini(&obj_auxi->cq_args.cqa_coa);
+					goto re_scan;
+				}
+			} else {
+				rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, j,
+								map_ver, obj, &dti, co_hdl, co_uuid,
+								NULL, 0);
+			}
+			if (rc != 0)
 				D_GOTO(out_task, rc);
 
 			if (++shard_cnt >= obj_ec_data_tgt_nr(&obj->cob_oca))
@@ -7615,6 +7151,12 @@ non_leader:
 		}
 	}
 
+	if (coll) {
+		rc = queue_coll_query_task(api_task, obj_auxi, obj, &dti, &epoch, map_ver);
+		if (rc != 0)
+			goto out_task;
+	}
+
 	obj_auxi->args_initialized = 1;
 	obj_shard_task_sched(obj_auxi, &epoch);
 
@@ -7626,6 +7168,8 @@ out_task:
 		/* abort/complete sub-tasks will complete api_task */
 		tse_task_list_traverse(head, shard_task_abort, &rc);
 	} else {
+		if (rc > 0)
+			rc = 0;
 		obj_task_complete(api_task, rc);
 	}
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1,5 +1,5 @@
 /*
- *  (C) Copyright 2016-2023 Intel Corporation.
+ *  (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1959,98 +1959,31 @@ out_put:
 struct obj_query_key_cb_args {
 	crt_rpc_t		*rpc;
 	unsigned int		*map_ver;
-	daos_unit_oid_t		oid;
 	daos_key_t		*dkey;
 	daos_key_t		*akey;
 	daos_recx_t		*recx;
 	daos_epoch_t		*max_epoch;
 	struct dc_object	*obj;
-	struct dc_obj_shard	*shard;
 	struct dtx_epoch	epoch;
 	daos_handle_t		th;
 	uint32_t		*max_delay;
 	uint64_t		*queue_id;
 };
 
-static void
-obj_shard_query_recx_post(struct obj_query_key_cb_args *cb_args, uint32_t shard, daos_key_t *dkey,
-			  daos_recx_t *reply_recx, bool get_max, bool changed)
-{
-	daos_recx_t		*result_recx = cb_args->recx;
-	daos_recx_t		 tmp_recx = {0};
-	uint64_t		 tmp_end;
-	uint32_t		 tgt_off;
-	bool			 from_data_tgt;
-	struct daos_oclass_attr	*oca;
-	uint64_t		dkey_hash;
-	uint64_t		 stripe_rec_nr, cell_rec_nr;
-
-	oca = obj_get_oca(cb_args->obj);
-	if (oca == NULL || !daos_oclass_is_ec(oca)) {
-		*result_recx = *reply_recx;
-		return;
-	}
-
-	dkey_hash = obj_dkey2hash(cb_args->obj->cob_md.omd_id, dkey);
-	tgt_off = obj_ec_shard_off(cb_args->obj, dkey_hash, shard);
-	from_data_tgt = is_ec_data_shard_by_tgt_off(tgt_off, oca);
-	stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
-	cell_rec_nr = obj_ec_cell_rec_nr(oca);
-	D_ASSERT(!(reply_recx->rx_idx & PARITY_INDICATOR));
-	/* data ext from data shard needs to convert to daos ext,
-	 * replica ext from parity shard needs not to convert.
-	 */
-	tmp_recx = *reply_recx;
-	tmp_end = DAOS_RECX_END(tmp_recx);
-	D_DEBUG(DB_IO, "shard %d/%u get recx "DF_U64" "DF_U64"\n",
-		shard, tgt_off, tmp_recx.rx_idx, tmp_recx.rx_nr);
-	if (tmp_end > 0 && from_data_tgt) {
-		if (get_max) {
-			tmp_recx.rx_idx = max(tmp_recx.rx_idx, rounddown(tmp_end - 1, cell_rec_nr));
-			tmp_recx.rx_nr = tmp_end - tmp_recx.rx_idx;
-		} else {
-			tmp_recx.rx_nr = min(tmp_end, roundup(tmp_recx.rx_idx + 1, cell_rec_nr)) -
-					 tmp_recx.rx_idx;
-		}
-
-		tmp_recx.rx_idx = obj_ec_idx_vos2daos(tmp_recx.rx_idx, stripe_rec_nr,
-							      cell_rec_nr, tgt_off);
-		tmp_end = DAOS_RECX_END(tmp_recx);
-	}
-
-	if (get_max) {
-		if (DAOS_RECX_END(*result_recx) < tmp_end || changed)
-			*result_recx = tmp_recx;
-	} else {
-		if (DAOS_RECX_END(*result_recx) > tmp_end || changed)
-			*result_recx = tmp_recx;
-	}
-}
-
 static int
 obj_shard_query_key_cb(tse_task_t *task, void *data)
 {
-	struct obj_query_key_cb_args	*cb_args;
-	struct obj_query_key_in		*okqi;
+	struct obj_query_key_cb_args	*cb_args = data;
+	crt_rpc_t			*rpc = cb_args->rpc;
+	struct obj_query_key_in		*okqi = crt_req_get(cb_args->rpc);
 	struct obj_query_key_out	*okqo;
-	uint32_t			flags;
-	int				opc;
-	int				ret = task->dt_result;
-	int				rc = 0;
-	crt_rpc_t			*rpc;
+	struct obj_query_merge_args	 oqma = { 0 };
+	int				 rc = task->dt_result;
+	int				 rc1;
 
-	cb_args = (struct obj_query_key_cb_args *)data;
-	rpc = cb_args->rpc;
-
-	okqi = crt_req_get(cb_args->rpc);
-	D_ASSERT(okqi != NULL);
-
-	flags = okqi->okqi_api_flags;
-	opc = opc_get(cb_args->rpc->cr_opc);
-
-	if (ret != 0) {
-		D_ERROR("RPC %d failed, "DF_RC"\n", opc, DP_RC(ret));
-		D_GOTO(out, ret);
+	if (rc != 0) {
+		D_ERROR("Regular query failed: "DF_RC"\n", DP_RC(rc));
+		goto out;
 	}
 
 	okqo = crt_reply_get(cb_args->rpc);
@@ -2058,132 +1991,41 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 
 	/* See the similar dc_rw_cb. */
 	if (daos_handle_is_valid(cb_args->th)) {
-		int rc_tmp;
-
-		rc_tmp = dc_tx_op_end(task, cb_args->th, &cb_args->epoch, rc,
-				      okqo->okqo_epoch);
-		if (rc_tmp != 0) {
-			D_ERROR("failed to end transaction operation (rc=%d "
-				"epoch="DF_U64": "DF_RC"\n", rc,
-				okqo->okqo_epoch, DP_RC(rc_tmp));
-			goto out;
+		rc1 = dc_tx_op_end(task, cb_args->th, &cb_args->epoch, rc, okqo->okqo_epoch);
+		if (rc1 != 0) {
+			D_ERROR("Failed to end TX (rc=%d, epoch="DF_U64", opc = %u): "DF_RC"\n",
+				rc, okqo->okqo_epoch, DAOS_OBJ_RPC_QUERY_KEY, DP_RC(rc1));
+			D_GOTO(out, rc = (rc != 0 ? rc : rc1));
 		}
 	}
 
-	if (rc != 0) {
-		if (rc == -DER_NONEXIST) {
-			D_SPIN_LOCK(&cb_args->obj->cob_spin);
-			D_GOTO(set_max_epoch, rc = 0);
-		}
-
-		if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY || rc == -DER_OVERLOAD_RETRY)
-			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: %d\n",
-				cb_args->rpc, opc, rc);
-		else
-			D_ERROR("rpc %p RPC %d failed: %d\n",
-				cb_args->rpc, opc, rc);
-
-		if (rc == -DER_OVERLOAD_RETRY) {
-			uint32_t			 timeout = 0;
-			struct obj_query_key_v10_out	*okqo_v10;
-
-			okqo_v10 = crt_reply_get(cb_args->rpc);
-			if (*cb_args->queue_id == 0)
-				*cb_args->queue_id = okqo_v10->okqo_comm_out.req_out_enqueue_id;
-			crt_req_get_timeout(cb_args->rpc, &timeout);
-			if (timeout > *cb_args->max_delay)
-				*cb_args->max_delay = timeout;
-
-		}
-		D_GOTO(out, rc);
-	}
+	oqma.oca = &cb_args->obj->cob_oca;
+	oqma.oid = okqi->okqi_oid;
+	oqma.src_epoch = okqo->okqo_max_epoch;
+	oqma.in_dkey = &okqi->okqi_dkey;
+	oqma.src_dkey = &okqo->okqo_dkey;
+	oqma.tgt_dkey = cb_args->dkey;
+	oqma.src_akey = &okqo->okqo_akey;
+	oqma.tgt_akey = cb_args->akey;
+	oqma.src_recx = &okqo->okqo_recx;
+	oqma.tgt_recx = cb_args->recx;
+	oqma.tgt_epoch = cb_args->max_epoch;
+	oqma.tgt_map_ver = cb_args->map_ver;
+	oqma.max_delay = cb_args->max_delay;
+	oqma.queue_id = cb_args->queue_id;
+	oqma.rpc = cb_args->rpc;
+	oqma.flags = okqi->okqi_api_flags;
+	oqma.opc = DAOS_OBJ_RPC_QUERY_KEY;
+	oqma.src_map_ver = obj_reply_map_version_get(rpc);
+	oqma.ret = rc;
 
 	D_SPIN_LOCK(&cb_args->obj->cob_spin);
-	*cb_args->map_ver = obj_reply_map_version_get(rpc);
-
-	if (flags == 0)
-		goto set_max_epoch;
-
-	bool check = true;
-	bool changed = false;
-	bool first = (cb_args->dkey->iov_len == 0);
-	bool is_ec_obj = obj_is_ec(cb_args->obj);
-
-	if (flags & DAOS_GET_DKEY) {
-		uint64_t *val = (uint64_t *)okqo->okqo_dkey.iov_buf;
-		uint64_t *cur = (uint64_t *)cb_args->dkey->iov_buf;
-
-		if (okqo->okqo_dkey.iov_len != sizeof(uint64_t)) {
-			D_ERROR("Invalid Dkey obtained\n");
-			D_SPIN_UNLOCK(&cb_args->obj->cob_spin);
-			D_GOTO(out, rc = -DER_IO);
-		}
-
-		/** for first cb, just set the dkey */
-		if (first) {
-			*cur = *val;
-			cb_args->dkey->iov_len = okqo->okqo_dkey.iov_len;
-			changed = true;
-		} else if (flags & DAOS_GET_MAX) {
-			if (*val > *cur) {
-				D_DEBUG(DB_IO, "dkey update "DF_U64"->"
-					DF_U64"\n", *cur, *val);
-				*cur = *val;
-				/** set to change akey and recx */
-				changed = true;
-			} else {
-				/** no change, don't check akey and recx for
-				 * replica obj, for EC obj need to check again
-				 * as it possibly from different data shards.
-				 */
-				if (!is_ec_obj || *val < *cur)
-					check = false;
-			}
-		} else if (flags & DAOS_GET_MIN) {
-			if (*val < *cur) {
-				*cur = *val;
-				/** set to change akey and recx */
-				changed = true;
-			} else {
-				if (!is_ec_obj)
-					check = false;
-			}
-		} else {
-			D_ASSERT(0);
-		}
-	}
-
-	if (check && flags & DAOS_GET_AKEY) {
-		uint64_t *val = (uint64_t *)okqo->okqo_akey.iov_buf;
-		uint64_t *cur = (uint64_t *)cb_args->akey->iov_buf;
-
-		/** if first cb, or dkey changed, set akey */
-		if (first || changed)
-			*cur = *val;
-	}
-
-	if (check && flags & DAOS_GET_RECX) {
-		bool		 get_max = (okqi->okqi_api_flags & DAOS_GET_MAX);
-		daos_key_t	*dkey;
-
-		if (okqi->okqi_api_flags & DAOS_GET_DKEY)
-			dkey = &okqo->okqo_dkey;
-		else
-			dkey = &okqi->okqi_dkey;
-		obj_shard_query_recx_post(cb_args, okqi->okqi_oid.id_shard,
-					  dkey, &okqo->okqo_recx, get_max, changed);
-	}
-
-set_max_epoch:
-	if (cb_args->max_epoch && *cb_args->max_epoch < okqo->okqo_max_epoch)
-		*cb_args->max_epoch = okqo->okqo_max_epoch;
+	rc = daos_obj_merge_query_merge(&oqma);
 	D_SPIN_UNLOCK(&cb_args->obj->cob_spin);
 
 out:
 	crt_req_decref(rpc);
-	if (ret == 0 || obj_retry_error(rc))
-		ret = rc;
-	return ret;
+	return rc;
 }
 
 int
@@ -2194,19 +2036,15 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 		       struct dtx_id *dti, uint32_t *map_ver, daos_handle_t th, tse_task_t *task,
 		       uint32_t *max_delay, uint64_t *queue_id)
 {
-	struct dc_pool			*pool = NULL;
+	struct dc_pool			*pool = obj_shard_ptr2pool(shard);
 	struct obj_query_key_v10_in	*okqi;
 	crt_rpc_t			*req;
-	struct obj_query_key_cb_args	 cb_args;
-	daos_unit_oid_t			 oid;
+	struct obj_query_key_cb_args	 cb_args = { 0 };
 	crt_endpoint_t			 tgt_ep;
 	int				 rc;
 
-	pool = obj_shard_ptr2pool(shard);
-	if (pool == NULL)
-		D_GOTO(out, rc = -DER_NO_HDL);
+	D_ASSERT(pool != NULL);
 
-	oid = shard->do_id;
 	tgt_ep.ep_grp	= pool->dp_sys->sy_group;
 	tgt_ep.ep_tag	= shard->do_target_idx;
 	tgt_ep.ep_rank = shard->do_target_rank;
@@ -2222,12 +2060,10 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 	crt_req_addref(req);
 	cb_args.rpc		= req;
 	cb_args.map_ver		= map_ver;
-	cb_args.oid		= shard->do_id;
 	cb_args.dkey		= dkey;
 	cb_args.akey		= akey;
 	cb_args.recx		= recx;
 	cb_args.obj		= obj;
-	cb_args.shard		= shard;
 	cb_args.epoch		= *epoch;
 	cb_args.th		= th;
 	cb_args.max_epoch	= max_epoch;
@@ -2245,7 +2081,7 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 	okqi->okqi_epoch		= epoch->oe_value;
 	okqi->okqi_epoch_first		= epoch->oe_first;
 	okqi->okqi_api_flags		= flags;
-	okqi->okqi_oid			= oid;
+	okqi->okqi_oid			= shard->do_id;
 	d_iov_set(&okqi->okqi_dkey, NULL, 0);
 	d_iov_set(&okqi->okqi_akey, NULL, 0);
 	if (dkey != NULL && !(flags & DAOS_GET_DKEY))
@@ -2262,8 +2098,169 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint
 	daos_dti_copy(&okqi->okqi_dti, dti);
 	okqi->okqi_comm_in.req_in_enqueue_id = *queue_id;
 
-	rc = daos_rpc_send(req, task);
+	return daos_rpc_send(req, task);
+
+out_req:
+	crt_req_decref(req);
+	crt_req_decref(req);
+out:
+	tse_task_complete(task, rc);
 	return rc;
+}
+
+static int
+obj_shard_coll_query_cb(tse_task_t *task, void *data)
+{
+	struct obj_query_key_cb_args	*cb_args = data;
+	crt_rpc_t			*rpc = cb_args->rpc;
+	struct obj_coll_query_in	*ocqi = crt_req_get(cb_args->rpc);
+	struct obj_coll_query_out	*ocqo;
+	struct obj_query_merge_args	 oqma = { 0 };
+	int				 rc = task->dt_result;
+	int				 rc1;
+
+	if (rc != 0) {
+		D_ERROR("Collective query failed: "DF_RC"\n", DP_RC(rc));
+		goto out;
+	}
+
+	ocqo = crt_reply_get(cb_args->rpc);
+	rc = obj_reply_get_status(rpc);
+
+	if (daos_handle_is_valid(cb_args->th)) {
+		rc1 = dc_tx_op_end(task, cb_args->th, &cb_args->epoch, rc, ocqo->ocqo_epoch);
+		if (rc1 != 0) {
+			D_ERROR("Failed to end TX (rc=%d, epoch="DF_U64", opc = %u): "DF_RC"\n",
+				rc, ocqo->ocqo_epoch, DAOS_OBJ_RPC_COLL_QUERY, DP_RC(rc1));
+			D_GOTO(out, rc = (rc != 0 ? rc : rc1));
+		}
+	}
+
+	oqma.oca = &cb_args->obj->cob_oca;
+	oqma.oid = ocqi->ocqi_oid;
+	oqma.src_epoch = ocqo->ocqo_max_epoch;
+	oqma.in_dkey = &ocqi->ocqi_dkey;
+	oqma.src_dkey = &ocqo->ocqo_dkey;
+	oqma.tgt_dkey = cb_args->dkey;
+	oqma.src_akey = &ocqo->ocqo_akey;
+	oqma.tgt_akey = cb_args->akey;
+	oqma.src_recx = &ocqo->ocqo_recx;
+	oqma.tgt_recx = cb_args->recx;
+	oqma.tgt_epoch = cb_args->max_epoch;
+	oqma.tgt_map_ver = cb_args->map_ver;
+	oqma.max_delay = cb_args->max_delay;
+	oqma.queue_id = cb_args->queue_id;
+	oqma.rpc = cb_args->rpc;
+	oqma.flags = ocqi->ocqi_api_flags;
+	oqma.opc = DAOS_OBJ_RPC_COLL_QUERY;
+	oqma.src_map_ver = obj_reply_map_version_get(rpc);
+	oqma.ret = rc;
+
+	/*
+	 * The RPC reply may be aggregated results from multiple VOS targets, as to related max/min
+	 * dkey/recx are not from the direct target. The ocqo->ocqo_shard indicates the right one.
+	 */
+	oqma.oid.id_shard = ocqo->ocqo_shard;
+
+	/*
+	 * Merge (L4) the results from engine that may be single shard or aggregated results from
+	 * multuple shards from single or multiple engines.
+	 */
+	D_SPIN_LOCK(&cb_args->obj->cob_spin);
+	rc = daos_obj_merge_query_merge(&oqma);
+	D_SPIN_UNLOCK(&cb_args->obj->cob_spin);
+
+out:
+	crt_req_decref(rpc);
+	return rc;
+}
+
+int
+dc_obj_shard_coll_query(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint32_t flags,
+			uint32_t req_map_ver, struct dc_object *obj, daos_key_t *dkey,
+			daos_key_t *akey, daos_recx_t *recx, daos_epoch_t *max_epoch,
+			const uuid_t coh_uuid, const uuid_t cont_uuid, struct dtx_id *dti,
+			uint32_t *map_ver, struct daos_coll_target *tgts, uint32_t tgt_nr,
+			uint32_t max_tgt_size, uint32_t disp_width, daos_handle_t th,
+			tse_task_t *task, uint32_t *max_delay, uint64_t *queue_id)
+{
+	struct dc_pool			*pool = obj->cob_pool;
+	struct obj_coll_query_in	*ocqi;
+	crt_rpc_t			*req = NULL;
+	struct obj_query_key_cb_args	 cb_args = { 0 };
+	crt_endpoint_t			 tgt_ep = { 0 };
+	int				 rc;
+
+	D_ASSERT(pool != NULL);
+
+	tgt_ep.ep_grp = pool->dp_sys->sy_group;
+	tgt_ep.ep_rank = shard->do_target_rank;
+	tgt_ep.ep_tag = shard->do_target_idx;
+
+	D_DEBUG(DB_IO, "OBJ_COLL_QUERY_RPC, rank=%d tag=%d.\n", tgt_ep.ep_rank, tgt_ep.ep_tag);
+
+	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, DAOS_OBJ_RPC_COLL_QUERY, &req);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	crt_req_addref(req);
+	cb_args.rpc = req;
+	cb_args.map_ver = map_ver;
+	cb_args.dkey = dkey;
+	cb_args.akey = akey;
+	cb_args.recx = recx;
+	cb_args.max_epoch = max_epoch;
+	cb_args.obj = obj;
+	cb_args.epoch = *epoch;
+	cb_args.th = th;
+	cb_args.queue_id = queue_id;
+	cb_args.max_delay = max_delay;
+
+	rc = tse_task_register_comp_cb(task, obj_shard_coll_query_cb, &cb_args, sizeof(cb_args));
+	if (rc != 0)
+		D_GOTO(out_req, rc);
+
+	ocqi = crt_req_get(req);
+	D_ASSERT(ocqi != NULL);
+
+	daos_dti_copy(&ocqi->ocqi_xid, dti);
+	uuid_copy(ocqi->ocqi_po_uuid, pool->dp_pool);
+	uuid_copy(ocqi->ocqi_co_hdl, coh_uuid);
+	uuid_copy(ocqi->ocqi_co_uuid, cont_uuid);
+	ocqi->ocqi_oid = shard->do_id;
+	ocqi->ocqi_epoch = epoch->oe_value;
+	ocqi->ocqi_epoch_first = epoch->oe_first;
+	ocqi->ocqi_api_flags = flags;
+	ocqi->ocqi_map_ver = req_map_ver;
+
+	ocqi->ocqi_flags = 0;
+	if (epoch->oe_flags & DTX_EPOCH_UNCERTAIN)
+		ocqi->ocqi_flags |= ORF_EPOCH_UNCERTAIN;
+	if (obj_is_ec(obj))
+		ocqi->ocqi_flags |= ORF_EC;
+
+	d_iov_set(&ocqi->ocqi_dkey, NULL, 0);
+	if (dkey != NULL && !(flags & DAOS_GET_DKEY))
+		ocqi->ocqi_dkey = *dkey;
+
+	d_iov_set(&ocqi->ocqi_akey, NULL, 0);
+	if (akey != NULL && !(flags & DAOS_GET_AKEY))
+		ocqi->ocqi_akey = *akey;
+
+	ocqi->ocqi_max_tgt_sz = max_tgt_size;
+	if (disp_width < COLL_DISP_WIDTH_MIN) {
+		ocqi->ocqi_disp_width = disp_width;
+	} else {
+		ocqi->ocqi_disp_width = disp_width - COLL_DISP_WIDTH_DIF;
+		if (ocqi->ocqi_disp_width < COLL_DISP_WIDTH_MIN)
+			ocqi->ocqi_disp_width = COLL_DISP_WIDTH_MIN;
+	}
+	ocqi->ocqi_disp_depth = 0;
+	ocqi->ocqi_tgts.ca_count = tgt_nr;
+	ocqi->ocqi_tgts.ca_arrays = tgts;
+	ocqi->ocqi_comm_in.req_in_enqueue_id = *queue_id;
+
+	return daos_rpc_send(req, task);
 
 out_req:
 	crt_req_decref(req);

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -317,6 +317,11 @@ struct obj_reasb_req;
 #define obj_ec_shard_off(obj, dkey_hash, shard)				\
 	((shard % obj_ec_tgt_nr(&obj->cob_oca) + obj_ec_tgt_nr(&obj->cob_oca) -		\
 	 obj_ec_shard_idx(obj, dkey_hash, 0)) % obj_ec_tgt_nr(&obj->cob_oca))
+
+/* Get the logical offset of shard within one group by oca, physical idx -> logical idx */
+#define obj_ec_shard_off_by_oca(layout_ver, dkey_hash, oca, shard)				\
+	((shard % obj_ec_tgt_nr(oca) + obj_ec_tgt_nr(oca) -					\
+	 obj_ec_shard_idx_by_layout_ver(layout_ver, dkey_hash, oca, 0)) % obj_ec_tgt_nr(oca))
 
 /* Get the logical offset of the tgt_idx by start target of EC, physical idx -> logical idx */
 #define obj_ec_shard_off_by_start(tgt_idx, oca, start_tgt)		\

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -405,6 +405,14 @@ struct obj_auxi_tgt_list {
 	uint32_t	tl_nr;
 };
 
+struct coll_query_args {
+	union {
+		struct shard_auxi_args	cqa_auxi;
+		struct coll_oper_args	cqa_coa;
+	};
+	struct obj_coll_disp_cursor	cqa_cur;
+};
+
 /* Auxiliary args for object I/O */
 struct obj_auxi_args {
 	tse_task_t			*obj_task;
@@ -470,6 +478,7 @@ struct obj_auxi_args {
 		struct shard_list_args		l_args;
 		struct shard_k2a_args		k_args;
 		struct shard_sync_args		s_args;
+		struct coll_query_args		cq_args;
 	};
 };
 
@@ -636,8 +645,16 @@ int dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dtx_epoch *epoch, 
 			   uint32_t req_map_ver, struct dc_object *obj,
 			   daos_key_t *dkey, daos_key_t *akey, daos_recx_t *recx,
 			   daos_epoch_t *max_epoch, const uuid_t coh_uuid, const uuid_t cont_uuid,
-			   struct dtx_id *dti, uint32_t *map_ver,
-			   daos_handle_t th, tse_task_t *task, uint32_t *max_delay, uint64_t *queue_id);
+			   struct dtx_id *dti, uint32_t *map_ver, daos_handle_t th,
+			   tse_task_t *task, uint32_t *max_delay, uint64_t *queue_id);
+
+int dc_obj_shard_coll_query(struct dc_obj_shard *shard, struct dtx_epoch *epoch, uint32_t flags,
+			    uint32_t req_map_ver, struct dc_object *obj, daos_key_t *dkey,
+			    daos_key_t *akey, daos_recx_t *recx, daos_epoch_t *max_epoch,
+			    const uuid_t coh_uuid, const uuid_t cont_uuid, struct dtx_id *dti,
+			    uint32_t *map_ver, struct daos_coll_target *tgts, uint32_t tgt_nr,
+			    uint32_t max_tgt_size, uint32_t disp_width, daos_handle_t th,
+			    tse_task_t *task, uint32_t *max_delay, uint64_t *queue_id);
 
 int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		      void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
@@ -665,6 +682,11 @@ int obj_pool_query_task(tse_sched_t *sched, struct dc_object *obj,
 			unsigned int map_ver, tse_task_t **taskp);
 bool obj_csum_dedup_candidate(struct cont_props *props, daos_iod_t *iods,
 			      uint32_t iod_nr);
+
+int queue_shard_query_key_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi,
+			       struct dtx_epoch *epoch, int shard, unsigned int map_ver,
+			       struct dc_object *obj, struct dtx_id *dti, uuid_t coh_uuid,
+			       uuid_t cont_uuid, struct daos_coll_target *dcts, uint32_t dct_nr);
 
 int obj_grp_leader_get(struct dc_object *obj, int grp_idx, uint64_t dkey_hash,
 		       bool has_condition, unsigned int map_ver, uint8_t *bit_map);
@@ -917,7 +939,31 @@ void obj_class_fini(void);
 #define COLL_DISP_WIDTH_MIN	8
 #define COLL_DISP_WIDTH_DIF	4
 
+struct obj_query_merge_args {
+	struct daos_oclass_attr	*oca;
+	daos_unit_oid_t		 oid;
+	daos_epoch_t		 src_epoch;
+	daos_key_t		*in_dkey;
+	daos_key_t		*src_dkey;
+	daos_key_t		*tgt_dkey; /* output */
+	daos_key_t		*src_akey;
+	daos_key_t		*tgt_akey; /* output */
+	daos_recx_t		*src_recx;
+	daos_recx_t		*tgt_recx; /* output */
+	daos_epoch_t		*tgt_epoch; /* output */
+	uint32_t		*tgt_map_ver; /* output */
+	uint32_t		*shard; /* output */
+	uint32_t		*max_delay; /* output */
+	uint64_t		*queue_id; /* output */
+	crt_rpc_t		*rpc;
+	uint64_t		 flags;
+	uint32_t		 opc;
+	uint32_t		 src_map_ver;
+	int			 ret;
+};
+
 /* obj_utils.c */
+int daos_obj_merge_query_merge(struct obj_query_merge_args *args);
 void obj_coll_disp_init(uint32_t tgt_nr, uint32_t max_tgt_size, uint32_t inline_size,
 			uint32_t start, uint32_t max_width, struct obj_coll_disp_cursor *ocdc);
 void obj_coll_disp_dest(struct obj_coll_disp_cursor *ocdc, struct daos_coll_target *tgts,
@@ -933,6 +979,28 @@ dc_tx_check_pmv(daos_handle_t th);
 int
 dc_tx_hdl2epoch_and_pmv(daos_handle_t th, struct dtx_epoch *epoch,
 			uint32_t *pmv);
+
+/* cli_coll.c */
+int
+obj_coll_oper_args_init(struct coll_oper_args *coa, struct dc_object *obj, bool for_modify);
+
+void
+obj_coll_oper_args_fini(struct coll_oper_args *coa);
+
+int
+obj_coll_oper_args_collapse(struct coll_oper_args *coa, uint32_t *size);
+
+int
+obj_coll_prep_one(struct coll_oper_args *coa, struct dc_object *obj,
+		  uint32_t map_ver, uint32_t idx);
+
+int
+dc_obj_coll_punch(tse_task_t *task, struct dc_object *obj, struct dtx_epoch *epoch,
+		  uint32_t map_ver, daos_obj_punch_t *args, struct obj_auxi_args *auxi);
+
+int
+queue_coll_query_task(tse_task_t *api_task, struct obj_auxi_args *obj_auxi, struct dc_object *obj,
+		      struct dtx_id *xid, struct dtx_epoch *epoch, uint32_t map_ver);
 
 /** See dc_tx_get_epoch. */
 enum dc_tx_get_epoch_rc {

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1266,6 +1266,7 @@ CRT_RPC_DEFINE(obj_ec_rep, DAOS_ISEQ_OBJ_EC_REP, DAOS_OSEQ_OBJ_EC_REP)
 CRT_RPC_DEFINE(obj_key2anchor, DAOS_ISEQ_OBJ_KEY2ANCHOR, DAOS_OSEQ_OBJ_KEY2ANCHOR)
 CRT_RPC_DEFINE(obj_key2anchor_v10, DAOS_ISEQ_OBJ_KEY2ANCHOR_V10, DAOS_OSEQ_OBJ_KEY2ANCHOR_V10)
 CRT_RPC_DEFINE(obj_coll_punch, DAOS_ISEQ_OBJ_COLL_PUNCH, DAOS_OSEQ_OBJ_COLL_PUNCH)
+CRT_RPC_DEFINE(obj_coll_query, DAOS_ISEQ_OBJ_COLL_QUERY, DAOS_OSEQ_OBJ_COLL_QUERY)
 
 /* Define for obj_proto_rpc_fmt[] array population below.
  * See OBJ_PROTO_*_RPC_LIST macro definition
@@ -1350,6 +1351,9 @@ obj_reply_set_status(crt_rpc_t *rpc, int status)
 	case DAOS_OBJ_RPC_COLL_PUNCH:
 		((struct obj_coll_punch_out *)reply)->ocpo_ret = status;
 		break;
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		((struct obj_coll_query_out *)reply)->ocqo_ret = status;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -1391,6 +1395,8 @@ obj_reply_get_status(crt_rpc_t *rpc)
 		return ((struct obj_ec_rep_out *)reply)->er_status;
 	case DAOS_OBJ_RPC_COLL_PUNCH:
 		return ((struct obj_coll_punch_out *)reply)->ocpo_ret;
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		return ((struct obj_coll_query_out *)reply)->ocqo_ret;
 	default:
 		D_ASSERT(0);
 	}
@@ -1443,6 +1449,9 @@ obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version)
 	case DAOS_OBJ_RPC_COLL_PUNCH:
 		((struct obj_coll_punch_out *)reply)->ocpo_map_version = map_version;
 		break;
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		((struct obj_coll_query_out *)reply)->ocqo_map_version = map_version;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -1480,6 +1489,8 @@ obj_reply_map_version_get(crt_rpc_t *rpc)
 		return ((struct obj_cpd_out *)reply)->oco_map_version;
 	case DAOS_OBJ_RPC_COLL_PUNCH:
 		return ((struct obj_coll_punch_out *)reply)->ocpo_map_version;
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		return ((struct obj_coll_query_out *)reply)->ocqo_map_version;
 	default:
 		D_ASSERT(0);
 	}

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -101,7 +101,10 @@
 		ds_obj_key2anchor_handler, NULL, "key2anchor")		\
 	X(DAOS_OBJ_RPC_COLL_PUNCH,					\
 		0, &CQF_obj_coll_punch, ds_obj_coll_punch_handler,	\
-		NULL, "obj_coll_punch")
+		NULL, "obj_coll_punch")					\
+	X(DAOS_OBJ_RPC_COLL_QUERY,					\
+		0, &CQF_obj_coll_query, ds_obj_coll_query_handler,	\
+		NULL, "obj_coll_query")
 
 /* Define for RPC enum population below */
 #define X(a, b, c, d, e, f) a,
@@ -745,6 +748,42 @@ CRT_RPC_DECLARE(obj_coll_punch, DAOS_ISEQ_OBJ_COLL_PUNCH, DAOS_OSEQ_OBJ_COLL_PUN
 
 #define ocpi_xid	ocpi_odm.odm_xid
 #define ocpi_mbs	ocpi_odm.odm_mbs
+
+#define DAOS_ISEQ_OBJ_COLL_QUERY	/* input fields */				\
+	((struct dtx_id)		(ocqi_xid)			CRT_VAR)	\
+	((uuid_t)			(ocqi_po_uuid)			CRT_VAR)	\
+	((uuid_t)			(ocqi_co_hdl)			CRT_VAR)	\
+	((uuid_t)			(ocqi_co_uuid)			CRT_VAR)	\
+	((daos_unit_oid_t)		(ocqi_oid)			CRT_RAW)	\
+	((uint64_t)			(ocqi_epoch)			CRT_VAR)	\
+	((uint64_t)			(ocqi_epoch_first)		CRT_VAR)	\
+	((uint64_t)			(ocqi_api_flags)		CRT_VAR)	\
+	((uint32_t)			(ocqi_map_ver)			CRT_VAR)	\
+	((uint32_t)			(ocqi_flags)			CRT_VAR)	\
+	((daos_key_t)			(ocqi_dkey)			CRT_VAR)	\
+	((daos_key_t)			(ocqi_akey)			CRT_VAR)	\
+	((uint32_t)			(ocqi_max_tgt_sz)		CRT_VAR)	\
+	((uint16_t)			(ocqi_disp_width)		CRT_VAR)	\
+	((uint16_t)			(ocqi_disp_depth)		CRT_VAR)	\
+	((struct daos_coll_target)	(ocqi_tgts)			CRT_ARRAY)	\
+	((struct daos_req_comm_in)	(ocqi_comm_in)			CRT_VAR)
+
+#define DAOS_OSEQ_OBJ_COLL_QUERY	/* output fields */				\
+	((int32_t)			(ocqo_ret)			CRT_VAR)	\
+	((uint32_t)			(ocqo_map_version)		CRT_VAR)	\
+	/* The id_shard corresponding to ocqo_recx */					\
+	((uint32_t)			(ocqo_shard)			CRT_VAR)	\
+	((uint32_t)			(ocqo_padding)			CRT_VAR)	\
+	((uint64_t)			(ocqo_epoch)			CRT_VAR)	\
+	((daos_key_t)			(ocqo_dkey)			CRT_VAR)	\
+	((daos_key_t)			(ocqo_akey)			CRT_VAR)	\
+	/* recx for visible extent */							\
+	((daos_recx_t)			(ocqo_recx)			CRT_VAR)	\
+	/* epoch for max write */							\
+	((uint64_t)			(ocqo_max_epoch)		CRT_VAR)	\
+	((struct daos_req_comm_out)	(ocqo_comm_out)			CRT_VAR)
+
+CRT_RPC_DECLARE(obj_coll_query, DAOS_ISEQ_OBJ_COLL_QUERY, DAOS_OSEQ_OBJ_COLL_QUERY)
 
 static inline int
 obj_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2023 Intel Corporation.
+ * (C) Copyright 2020-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -3531,6 +3531,8 @@ dc_tx_attach(daos_handle_t th, struct dc_object *obj, enum obj_rpc_opc opc, tse_
 				    fe->nr != 1 ? fe->iods : (void *)&fe->iods[0].iod_name);
 		break;
 	}
+	case DAOS_OBJ_RPC_COLL_QUERY:
+		/* Fall through. */
 	case DAOS_OBJ_RPC_QUERY_KEY: {
 		daos_obj_query_key_t	*qu = dc_task_get_args(task);
 		daos_key_t		*dkey;

--- a/src/object/obj_utils.c
+++ b/src/object/obj_utils.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -84,6 +84,197 @@ daos_iods_free(daos_iod_t *iods, int nr, bool need_free)
 
 	if (need_free)
 		D_FREE(iods);
+}
+
+static void
+obj_query_merge_recx(struct daos_oclass_attr *oca, daos_unit_oid_t oid, daos_key_t *dkey,
+		     daos_recx_t *src_recx, daos_recx_t *tgt_recx, bool get_max, bool changed,
+		     uint32_t *shard)
+{
+	daos_recx_t	tmp_recx = *src_recx;
+	uint64_t	tmp_end;
+	uint32_t	tgt_off;
+	bool		from_data_tgt;
+	uint64_t	dkey_hash;
+	uint64_t	stripe_rec_nr;
+	uint64_t	cell_rec_nr;
+
+	if (!daos_oclass_is_ec(oca))
+		D_GOTO(out, changed = true);
+
+	dkey_hash = obj_dkey2hash(oid.id_pub, dkey);
+	tgt_off = obj_ec_shard_off_by_oca(oid.id_layout_ver, dkey_hash, oca, oid.id_shard);
+	from_data_tgt = is_ec_data_shard_by_tgt_off(tgt_off, oca);
+	stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
+	cell_rec_nr = obj_ec_cell_rec_nr(oca);
+	D_ASSERT(!(src_recx->rx_idx & PARITY_INDICATOR));
+
+	/*
+	 * Data ext from data shard needs to be converted to daos ext,
+	 * replica ext from parity shard needs not to convert.
+	 */
+	tmp_end = DAOS_RECX_END(tmp_recx);
+	D_DEBUG(DB_IO, "shard %d/%u get recx "DF_U64" "DF_U64"\n",
+		oid.id_shard, tgt_off, tmp_recx.rx_idx, tmp_recx.rx_nr);
+
+	if (tmp_end > 0 && from_data_tgt) {
+		if (get_max) {
+			tmp_recx.rx_idx = max(tmp_recx.rx_idx, rounddown(tmp_end - 1, cell_rec_nr));
+			tmp_recx.rx_nr = tmp_end - tmp_recx.rx_idx;
+		} else {
+			tmp_recx.rx_nr = min(tmp_end, roundup(tmp_recx.rx_idx + 1, cell_rec_nr)) -
+					 tmp_recx.rx_idx;
+		}
+
+		tmp_recx.rx_idx = obj_ec_idx_vos2daos(tmp_recx.rx_idx, stripe_rec_nr, cell_rec_nr,
+						      tgt_off);
+		tmp_end = DAOS_RECX_END(tmp_recx);
+	}
+
+	if ((get_max && DAOS_RECX_END(*tgt_recx) < tmp_end) ||
+	    (!get_max && DAOS_RECX_END(*tgt_recx) > tmp_end))
+		changed = true;
+
+out:
+	if (changed) {
+		*tgt_recx = tmp_recx;
+		if (shard != NULL)
+			*shard = oid.id_shard;
+	}
+}
+
+static inline void
+obj_query_merge_key(uint64_t *tgt_val, uint64_t src_val, bool *changed, bool dkey,
+		    uint32_t *tgt_shard, uint32_t src_shard)
+{
+	D_DEBUG(DB_TRACE, "%s update "DF_U64"->"DF_U64"\n",
+		dkey ? "dkey" : "akey", *tgt_val, src_val);
+
+	*tgt_val = src_val;
+	/* Set to change akey and recx. */
+	*changed = true;
+	if (tgt_shard != NULL)
+		*tgt_shard = src_shard;
+}
+
+int
+daos_obj_merge_query_merge(struct obj_query_merge_args *args)
+{
+	uint64_t	*val;
+	uint64_t	*cur;
+	uint32_t	 timeout = 0;
+	bool		 check = true;
+	bool		 changed = false;
+	bool		 get_max = (args->flags & DAOS_GET_MAX) ? true : false;
+	bool		 first = false;
+	int		 rc = 0;
+
+	D_ASSERT(args->oca != NULL);
+	args->opc = opc_get(args->opc);
+
+	if (args->ret != 0) {
+		if (args->ret == -DER_NONEXIST)
+			D_GOTO(set_max_epoch, rc = 0);
+
+		if (args->ret == -DER_INPROGRESS || args->ret == -DER_TX_BUSY ||
+		    args->ret == -DER_OVERLOAD_RETRY)
+			D_DEBUG(DB_TRACE, "%s query rpc needs retry: "DF_RC"\n",
+				args->opc == DAOS_OBJ_RPC_COLL_QUERY ? "Collective" : "Regular",
+				DP_RC(args->ret));
+		else
+			D_ERROR("%s query rpc failed: "DF_RC"\n",
+				args->opc == DAOS_OBJ_RPC_COLL_QUERY ? "Collective" : "Regular",
+				DP_RC(args->ret));
+
+		if (args->ret == -DER_OVERLOAD_RETRY && args->rpc != NULL) {
+			D_ASSERT(args->max_delay != NULL);
+			D_ASSERT(args->queue_id != NULL);
+
+			if (args->opc == DAOS_OBJ_RPC_COLL_QUERY) {
+				struct obj_coll_query_out	*ocqo = crt_reply_get(args->rpc);
+
+				if (*args->queue_id == 0)
+					*args->queue_id = ocqo->ocqo_comm_out.req_out_enqueue_id;
+			} else {
+				struct obj_query_key_v10_out	*okqo = crt_reply_get(args->rpc);
+
+				if (*args->queue_id == 0)
+					*args->queue_id = okqo->okqo_comm_out.req_out_enqueue_id;
+			}
+
+			crt_req_get_timeout(args->rpc, &timeout);
+			if (timeout > *args->max_delay)
+				*args->max_delay = timeout;
+		}
+
+		D_GOTO(out, rc = args->ret);
+	}
+
+	if (*args->tgt_map_ver < args->src_map_ver)
+		*args->tgt_map_ver = args->src_map_ver;
+
+	if (args->flags == 0)
+		goto set_max_epoch;
+
+	if (args->tgt_dkey->iov_len == 0)
+		first = true;
+
+	if (args->flags & DAOS_GET_DKEY) {
+		val = (uint64_t *)args->src_dkey->iov_buf;
+		cur = (uint64_t *)args->tgt_dkey->iov_buf;
+
+		D_ASSERT(cur != NULL);
+
+		if (args->src_dkey->iov_len != sizeof(uint64_t)) {
+			D_ERROR("Invalid dkey obtained: %d\n", (int)args->src_dkey->iov_len);
+			D_GOTO(out, rc = -DER_IO);
+		}
+
+		/* For first merge, just set the dkey. */
+		if (first) {
+			args->tgt_dkey->iov_len = args->src_dkey->iov_len;
+			obj_query_merge_key(cur, *val, &changed, true, args->shard,
+					    args->oid.id_shard);
+		} else if (get_max) {
+			if (*val > *cur)
+				obj_query_merge_key(cur, *val, &changed, true, args->shard,
+						    args->oid.id_shard);
+			else if (!daos_oclass_is_ec(args->oca) || *val < *cur)
+				/*
+				 * No change, don't check akey and recx for replica obj. EC obj
+				 * needs to check again as it maybe from different data shards.
+				 */
+				check = false;
+		} else if (args->flags & DAOS_GET_MIN) {
+			if (*val < *cur)
+				obj_query_merge_key(cur, *val, &changed, true, args->shard,
+						    args->oid.id_shard);
+			else if (!daos_oclass_is_ec(args->oca))
+				check = false;
+		} else {
+			D_ASSERT(0);
+		}
+	}
+
+	if (check && args->flags & DAOS_GET_AKEY) {
+		val = (uint64_t *)args->src_akey->iov_buf;
+		cur = (uint64_t *)args->tgt_akey->iov_buf;
+
+		/* If first merge or dkey changed, set akey. */
+		if (first || changed)
+			obj_query_merge_key(cur, *val, &changed, false, NULL, args->oid.id_shard);
+	}
+
+	if (check && args->flags & DAOS_GET_RECX)
+		obj_query_merge_recx(args->oca, args->oid,
+				     (args->flags & DAOS_GET_DKEY) ? args->src_dkey : args->in_dkey,
+				     args->src_recx, args->tgt_recx, get_max, changed, args->shard);
+
+set_max_epoch:
+	if (args->tgt_epoch != NULL && *args->tgt_epoch < args->src_epoch)
+		*args->tgt_epoch = args->src_epoch;
+out:
+	return rc;
 }
 
 struct recx_rec {

--- a/src/object/srv_coll.c
+++ b/src/object/srv_coll.c
@@ -1,0 +1,607 @@
+/**
+ * (C) Copyright 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * src/object/srv_coll.c
+ *
+ * For client side collecitve operation.
+ */
+#define D_LOGFAC	DD_FAC(object)
+
+#include <uuid/uuid.h>
+
+#include <daos_srv/pool.h>
+#include <daos_srv/container.h>
+#include <daos_srv/daos_engine.h>
+#include <daos_srv/dtx_srv.h>
+#include "obj_rpc.h"
+#include "srv_internal.h"
+
+struct obj_coll_tgt_args {
+	crt_rpc_t				*octa_rpc;
+	struct daos_coll_shard			*octa_shards;
+	uint32_t				*octa_versions;
+	uint32_t				 octa_sponsor_tgt;
+	struct obj_io_context			*octa_sponsor_ioc;
+	struct dtx_handle			*octa_sponsor_dth;
+	union {
+		void				*octa_misc;
+		/* Different collective operations may need different parameters. */
+		struct dtx_memberships		*octa_mbs;
+		struct obj_tgt_query_args	*octa_otqas;
+	};
+};
+
+int
+obj_coll_local(crt_rpc_t *rpc, struct daos_coll_shard *shards, struct dtx_coll_entry *dce,
+	       uint32_t *version, struct obj_io_context *ioc, struct dtx_handle *dth, void *args,
+	       obj_coll_func_t func)
+{
+	struct obj_coll_tgt_args	octa = { 0 };
+	struct dss_coll_ops		coll_ops = { 0 };
+	struct dss_coll_args		coll_args = { 0 };
+	uint32_t			size = dce->dce_bitmap_sz << 3;
+	int				rc = 0;
+	int				i;
+
+	D_ASSERT(dce->dce_bitmap != NULL);
+	D_ASSERT(ioc != NULL);
+
+	if (version != NULL) {
+		if (size > dss_tgt_nr)
+			size = dss_tgt_nr;
+		D_ALLOC_ARRAY(octa.octa_versions, size);
+		if (octa.octa_versions == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	octa.octa_rpc = rpc;
+	octa.octa_shards = shards;
+	octa.octa_misc = args;
+	octa.octa_sponsor_ioc = ioc;
+	octa.octa_sponsor_dth = dth;
+	octa.octa_sponsor_tgt = dss_get_module_info()->dmi_tgt_id;
+
+	coll_ops.co_func = func;
+	coll_args.ca_func_args = &octa;
+	coll_args.ca_tgt_bitmap = dce->dce_bitmap;
+	coll_args.ca_tgt_bitmap_sz = dce->dce_bitmap_sz;
+
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, DSS_USE_CURRENT_ULT);
+
+out:
+	if (octa.octa_versions != NULL) {
+		for (i = 0, *version = 0; i < size; i++) {
+			if (isset(dce->dce_bitmap, i) && *version < octa.octa_versions[i])
+				*version = octa.octa_versions[i];
+		}
+		D_FREE(octa.octa_versions);
+	}
+
+	return rc;
+}
+
+int
+obj_coll_tgt_punch(void *args)
+{
+	struct obj_coll_tgt_args	*octa = args;
+	crt_rpc_t			*rpc = octa->octa_rpc;
+	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
+	struct obj_punch_in		*opi = NULL;
+	struct obj_tgt_punch_args	 otpa = { 0 };
+	uint32_t			 tgt_id = dss_get_module_info()->dmi_tgt_id;
+	int				 rc;
+
+	D_ALLOC_PTR(opi);
+	if (opi == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	opi->opi_dti = ocpi->ocpi_xid;
+	uuid_copy(opi->opi_pool_uuid, ocpi->ocpi_po_uuid);
+	uuid_copy(opi->opi_co_hdl, ocpi->ocpi_co_hdl);
+	uuid_copy(opi->opi_co_uuid, ocpi->ocpi_co_uuid);
+	opi->opi_oid = ocpi->ocpi_oid;
+	opi->opi_oid.id_shard = octa->octa_shards[tgt_id].dcs_buf[0];
+	opi->opi_epoch = ocpi->ocpi_epoch;
+	opi->opi_api_flags = ocpi->ocpi_api_flags;
+	opi->opi_map_ver = ocpi->ocpi_map_ver;
+	opi->opi_flags = ocpi->ocpi_flags & ~ORF_LEADER;
+
+	otpa.opi = opi;
+	otpa.opc = opc_get(rpc->cr_opc);
+	if (tgt_id == octa->octa_sponsor_tgt) {
+		otpa.sponsor_ioc = octa->octa_sponsor_ioc;
+		otpa.sponsor_dth = octa->octa_sponsor_dth;
+	}
+	otpa.mbs = octa->octa_mbs;
+	if (octa->octa_versions != NULL)
+		otpa.ver = &octa->octa_versions[tgt_id];
+	otpa.data = rpc;
+
+	rc = obj_tgt_punch(&otpa, octa->octa_shards[tgt_id].dcs_buf,
+			   octa->octa_shards[tgt_id].dcs_nr);
+	D_FREE(opi);
+
+out:
+	DL_CDEBUG(rc == 0 || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR, rc,
+		  "Collective punch obj shard "DF_UOID" with "DF_DTI" on tgt %u",
+		  DP_OID(ocpi->ocpi_oid.id_pub), octa->octa_shards[tgt_id].dcs_buf[0],
+		  ocpi->ocpi_oid.id_layout_ver, DP_DTI(&ocpi->ocpi_xid), tgt_id);
+
+	return rc;
+}
+
+int
+obj_coll_punch_disp(struct dtx_leader_handle *dlh, void *arg, int idx, dtx_sub_comp_cb_t comp_cb)
+{
+	struct ds_obj_exec_arg		*exec_arg = arg;
+	crt_rpc_t			*rpc = exec_arg->rpc;
+	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
+	int				 rc;
+
+	if (idx != -1)
+		return ds_obj_coll_punch_remote(dlh, arg, idx, comp_cb);
+
+	/* Local punch on current rank, including the leader target. */
+	rc = obj_coll_local(rpc, exec_arg->coll_shards, dlh->dlh_coll_entry, NULL, exec_arg->ioc,
+			    &dlh->dlh_handle, dlh->dlh_handle.dth_mbs, obj_coll_tgt_punch);
+
+	DL_CDEBUG(rc == 0 || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR, rc,
+		  "Collective punch obj "DF_UOID" with "DF_DTI" on rank %u",
+		  DP_UOID(ocpi->ocpi_oid), DP_DTI(&ocpi->ocpi_xid), dss_self_rank());
+
+	if (comp_cb != NULL)
+		comp_cb(dlh, idx, rc);
+
+	return rc;
+}
+
+int
+obj_coll_punch_bulk(crt_rpc_t *rpc, d_iov_t *iov, crt_proc_t *p_proc,
+		    struct daos_coll_target **p_dcts, uint32_t *dct_nr)
+{
+	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
+	struct daos_coll_target		*dcts = NULL;
+	crt_proc_t			 proc = NULL;
+	d_sg_list_t			 sgl;
+	d_sg_list_t			*sgls = &sgl;
+	int				 rc = 0;
+	int				 i;
+	int				 j;
+
+	D_ALLOC(iov->iov_buf, ocpi->ocpi_bulk_tgt_sz);
+	if (iov->iov_buf == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	iov->iov_buf_len = ocpi->ocpi_bulk_tgt_sz;
+	iov->iov_len = ocpi->ocpi_bulk_tgt_sz;
+
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs = iov;
+
+	rc = obj_bulk_transfer(rpc, CRT_BULK_GET, false, &ocpi->ocpi_tgt_bulk, NULL, NULL,
+			       DAOS_HDL_INVAL, &sgls, 1, NULL, NULL);
+	if (rc != 0)
+		goto out;
+
+	rc = crt_proc_create(dss_get_module_info()->dmi_ctx, iov->iov_buf, iov->iov_len,
+			     CRT_PROC_DECODE, &proc);
+	if (rc != 0)
+		goto out;
+
+	D_ALLOC_ARRAY(dcts, ocpi->ocpi_bulk_tgt_nr);
+	if (dcts == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	for (i = 0; i < ocpi->ocpi_bulk_tgt_nr; i++) {
+		rc = crt_proc_struct_daos_coll_target(proc, CRT_PROC_DECODE, &dcts[i]);
+		if (rc != 0) {
+			crt_proc_reset(proc, iov->iov_buf, iov->iov_len, CRT_PROC_FREE);
+			for (j = 0; j < i; j++)
+				crt_proc_struct_daos_coll_target(proc, CRT_PROC_FREE, &dcts[j]);
+			goto out;
+		}
+	}
+
+out:
+	if (rc != 0) {
+		D_FREE(dcts);
+		if (proc != NULL)
+			crt_proc_destroy(proc);
+		daos_iov_free(iov);
+	} else {
+		*p_proc = proc;
+		*p_dcts = dcts;
+		*dct_nr = ocpi->ocpi_bulk_tgt_nr;
+	}
+
+	return rc;
+}
+
+int
+obj_coll_punch_prep(struct obj_coll_punch_in *ocpi, struct daos_coll_target *dcts, uint32_t dct_nr,
+		    struct dtx_coll_entry **p_dce)
+{
+	struct pl_map		*map = NULL;
+	struct dtx_memberships	*mbs = ocpi->ocpi_mbs;
+	struct dtx_daos_target	*ddt = mbs->dm_tgts;
+	struct dtx_coll_entry	*dce = NULL;
+	struct dtx_coll_target	*target;
+	d_rank_t		 max_rank = 0;
+	uint32_t		 size;
+	int			 rc = 0;
+	int			 i;
+	int			 j;
+
+	/* dcts[0] is for current engine. */
+	if (dcts[0].dct_bitmap == NULL || dcts[0].dct_bitmap_sz == 0 ||
+	    dcts[0].dct_shards == NULL)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	/* Already allocated enough space in MBS when decode to hold the targets and bitmap. */
+	target = (struct dtx_coll_target *)(ddt + mbs->dm_tgt_cnt);
+
+	size = sizeof(*ddt) * mbs->dm_tgt_cnt + sizeof(*target) +
+	       sizeof(dcts[0].dct_tgt_ids[0]) * dcts[0].dct_tgt_nr + dcts[0].dct_bitmap_sz;
+	if (unlikely(ocpi->ocpi_odm.odm_mbs_max_sz < sizeof(*mbs) + size)) {
+		D_ERROR("Pre-allocated MBS buffer is too small: %u vs %ld + %u\n",
+			ocpi->ocpi_odm.odm_mbs_max_sz, sizeof(*mbs), size);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	target->dct_tgt_nr = dcts[0].dct_tgt_nr;
+	memcpy(target->dct_tgts, dcts[0].dct_tgt_ids,
+	       sizeof(dcts[0].dct_tgt_ids[0]) * dcts[0].dct_tgt_nr);
+	target->dct_bitmap_sz = dcts[0].dct_bitmap_sz;
+	memcpy(target->dct_tgts + target->dct_tgt_nr, dcts[0].dct_bitmap, dcts[0].dct_bitmap_sz);
+	mbs->dm_data_size = size;
+
+	D_ALLOC_PTR(dce);
+	if (dce == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	dce->dce_xid = ocpi->ocpi_xid;
+	dce->dce_ver = ocpi->ocpi_map_ver;
+	dce->dce_refs = 1;
+
+	D_ALLOC(dce->dce_bitmap, dcts[0].dct_bitmap_sz);
+	if (dce->dce_bitmap == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	dce->dce_bitmap_sz = dcts[0].dct_bitmap_sz;
+	memcpy(dce->dce_bitmap, dcts[0].dct_bitmap, dcts[0].dct_bitmap_sz);
+
+	if (!(ocpi->ocpi_flags & ORF_LEADER) || unlikely(dct_nr <= 1))
+		D_GOTO(out, rc = 0);
+
+	map = pl_map_find(ocpi->ocpi_po_uuid, ocpi->ocpi_oid.id_pub);
+	if (map == NULL) {
+		D_ERROR("Failed to find valid placement map in pool "DF_UUID"\n",
+			DP_UUID(ocpi->ocpi_po_uuid));
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
+	size = pool_map_node_nr(map->pl_poolmap);
+	D_ALLOC_ARRAY(dce->dce_hints, size);
+	if (dce->dce_hints == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	dce->dce_ranks = d_rank_list_alloc(dct_nr - 1);
+	if (dce->dce_ranks == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	/* Set i = 1 to skip leader_rank. */
+	for (i = 1; i < dct_nr; i++) {
+		dce->dce_ranks->rl_ranks[i - 1] = dcts[i].dct_rank;
+		if (max_rank < dcts[i].dct_rank)
+			max_rank = dcts[i].dct_rank;
+
+		size = dcts[i].dct_bitmap_sz << 3;
+		if (size > dss_tgt_nr)
+			size = dss_tgt_nr;
+
+		for (j = 0; j < size; j++) {
+			if (isset(dcts[i].dct_bitmap, j)) {
+				dce->dce_hints[dcts[i].dct_rank] = j;
+				break;
+			}
+		}
+	}
+
+	dce->dce_hint_sz = max_rank + 1;
+
+out:
+	if (map != NULL)
+		pl_map_decref(map);
+
+	if (rc != 0 && dce != NULL)
+		dtx_coll_entry_put(dce);
+	else
+		*p_dce = dce;
+
+	return rc;
+}
+
+int
+obj_coll_tgt_query(void *args)
+{
+	struct obj_coll_tgt_args	*octa = args;
+	struct obj_tgt_query_args	*otqa;
+	crt_rpc_t			*rpc = octa->octa_rpc;
+	struct obj_coll_query_in	*ocqi = crt_req_get(rpc);
+	struct obj_coll_query_out	*ocqo = crt_reply_get(rpc);
+	struct daos_coll_target		*dct = ocqi->ocqi_tgts.ca_arrays;
+	uint32_t			 tgt_id = dss_get_module_info()->dmi_tgt_id;
+	uint32_t			 version = ocqi->ocqi_map_ver;
+	int				 rc;
+
+	otqa = &octa->octa_otqas[tgt_id];
+	otqa->in_dkey = &ocqi->ocqi_dkey;
+	otqa->in_akey = &ocqi->ocqi_akey;
+	otqa->out_dkey = &ocqo->ocqo_dkey;
+	otqa->out_akey = &ocqo->ocqo_akey;
+	if (tgt_id == octa->octa_sponsor_tgt) {
+		otqa->ioc = octa->octa_sponsor_ioc;
+		otqa->dth = octa->octa_sponsor_dth;
+	}
+
+	if (ocqi->ocqi_tgts.ca_count > 1 || dct->dct_tgt_nr > 1)
+		otqa->need_copy = 1;
+
+	rc = obj_tgt_query(otqa, ocqi->ocqi_po_uuid, ocqi->ocqi_co_hdl, ocqi->ocqi_co_uuid,
+			   ocqi->ocqi_oid, ocqi->ocqi_epoch, ocqi->ocqi_epoch_first,
+			   ocqi->ocqi_api_flags, ocqi->ocqi_flags, &version, rpc,
+			   octa->octa_shards[tgt_id].dcs_nr, octa->octa_shards[tgt_id].dcs_buf,
+			   &ocqi->ocqi_xid);
+
+	DL_CDEBUG(rc == 0 || rc == -DER_NONEXIST || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART,
+		  DB_IO, DLOG_ERR, rc, "Collective query obj shard "DF_OID".%u.%u with "
+		  DF_DTI" on tgt %u", DP_OID(ocqi->ocqi_oid.id_pub),
+		  octa->octa_shards[tgt_id].dcs_buf[0], ocqi->ocqi_oid.id_layout_ver,
+		  DP_DTI(&ocqi->ocqi_xid), tgt_id);
+
+	if (octa->octa_versions != NULL)
+		octa->octa_versions[tgt_id] = version;
+
+	return rc;
+}
+
+int
+obj_coll_query_merge_tgts(struct obj_coll_query_in *ocqi, struct daos_oclass_attr *oca,
+			  struct obj_tgt_query_args *otqas, uint8_t *bitmap, uint32_t bitmap_sz,
+			  uint32_t tgt_id, int allow_failure)
+{
+	struct obj_query_merge_args	 oqma = { 0 };
+	struct obj_tgt_query_args	*otqa = &otqas[tgt_id];
+	struct obj_tgt_query_args	*tmp;
+	int				 size = bitmap_sz << 3;
+	int				 allow_failure_cnt;
+	int				 succeeds;
+	int				 rc = 0;
+	int				 i;
+
+	D_ASSERT(otqa->need_copy);
+	D_ASSERT(otqa->keys_copied);
+
+	oqma.oca = oca;
+	oqma.oid = ocqi->ocqi_oid;
+	oqma.in_dkey = &ocqi->ocqi_dkey;
+	oqma.tgt_dkey = &otqa->dkey_copy;
+	oqma.tgt_akey = &otqa->akey_copy;
+	oqma.tgt_recx = &otqa->recx;
+	oqma.tgt_epoch = &otqa->max_epoch;
+	oqma.tgt_map_ver = &otqa->version;
+	oqma.shard = &otqa->shard;
+	oqma.flags = ocqi->ocqi_api_flags;
+	oqma.opc = DAOS_OBJ_RPC_COLL_QUERY;
+
+	if (size > dss_tgt_nr)
+		size = dss_tgt_nr;
+
+	for (i = 0, allow_failure_cnt = 0, succeeds = 0; i < size; i++) {
+		if (isclr(bitmap, i))
+			continue;
+
+		tmp = &otqas[i];
+		if (!tmp->completed)
+			continue;
+
+		if (tmp->result == allow_failure) {
+			if (otqa->max_epoch < tmp->max_epoch)
+				otqa->max_epoch = tmp->max_epoch;
+			allow_failure_cnt++;
+			continue;
+		}
+
+		/* Stop subsequent merge when hit one unallowed failure. */
+		if (tmp->result != 0)
+			D_GOTO(out, rc = tmp->result);
+
+		succeeds++;
+
+		if (i == tgt_id)
+			continue;
+
+		oqma.oid.id_shard = tmp->shard;
+		oqma.src_epoch = tmp->max_epoch;
+		oqma.src_dkey = &tmp->dkey_copy;
+		oqma.src_akey = &tmp->akey_copy;
+		oqma.src_recx = &tmp->recx;
+		oqma.src_map_ver = tmp->version;
+		/*
+		 * Merge (L2) the results from other VOS targets on the same engine
+		 * into current otqa that stands for the results for current engine.
+		 */
+		rc = daos_obj_merge_query_merge(&oqma);
+		if (rc != 0)
+			goto out;
+	}
+
+	D_DEBUG(DB_IO, " sub_requests %d/%d, allow_failure %d, result %d\n",
+		allow_failure_cnt, succeeds, allow_failure, rc);
+
+	if (allow_failure_cnt > 0 && rc == 0 && succeeds == 0)
+		rc = allow_failure;
+
+out:
+	return rc;
+}
+
+int
+obj_coll_query_disp(struct dtx_leader_handle *dlh, void *arg, int idx, dtx_sub_comp_cb_t comp_cb)
+{
+	struct ds_obj_exec_arg		*exec_arg = arg;
+	crt_rpc_t			*rpc = exec_arg->rpc;
+	struct obj_coll_query_in	*ocqi = crt_req_get(rpc);
+	struct obj_tgt_query_args	*otqa;
+	uint32_t			 tgt_id = dss_get_module_info()->dmi_tgt_id;
+	int				 rc = 0;
+
+	if (idx != -1)
+		return ds_obj_coll_query_remote(dlh, arg, idx, comp_cb);
+
+	rc = obj_coll_local(rpc, exec_arg->coll_shards, dlh->dlh_coll_entry, NULL, exec_arg->ioc,
+			    &dlh->dlh_handle, exec_arg->args, obj_coll_tgt_query);
+
+	DL_CDEBUG(rc == 0 || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR, rc,
+		  "Collective query obj "DF_OID".%u.%u with "DF_DTI" on rank %u",
+		  DP_OID(ocqi->ocqi_oid.id_pub), exec_arg->coll_shards[tgt_id].dcs_buf[0],
+		  ocqi->ocqi_oid.id_layout_ver, DP_DTI(&ocqi->ocqi_xid), dss_self_rank());
+
+	otqa = (struct obj_tgt_query_args *)exec_arg->args + tgt_id;
+	if (otqa->completed && otqa->keys_copied && (rc == 0 || rc == dlh->dlh_allow_failure))
+		rc = obj_coll_query_merge_tgts(ocqi, &exec_arg->ioc->ioc_oca, exec_arg->args,
+					       dlh->dlh_coll_entry->dce_bitmap,
+					       dlh->dlh_coll_entry->dce_bitmap_sz,
+					       tgt_id, dlh->dlh_allow_failure);
+
+	if (comp_cb != NULL)
+		comp_cb(dlh, idx, rc);
+
+	return rc;
+}
+
+int
+obj_coll_query_agg_cb(struct dtx_leader_handle *dlh, void *arg)
+{
+	struct obj_query_merge_args	 oqma = { 0 };
+	struct ds_obj_exec_arg		*exec_arg = arg;
+	struct obj_tgt_query_args	*otqa;
+	struct dtx_sub_status		*sub;
+	crt_rpc_t			*rpc;
+	struct obj_coll_query_in	*ocqi;
+	struct obj_coll_query_out	*ocqo;
+	int				 allow_failure = dlh->dlh_allow_failure;
+	int				 allow_failure_cnt;
+	int				 succeeds;
+	int				 rc = 0;
+	int				 i;
+	bool				 cleanup = false;
+
+	D_ASSERTF(allow_failure == -DER_NONEXIST, "Unexpected allow failure %d\n", allow_failure);
+
+	otqa = (struct obj_tgt_query_args *)exec_arg->args + dss_get_module_info()->dmi_tgt_id;
+	D_ASSERT(otqa->need_copy);
+
+	/*
+	 * If keys_copied is not set on current engine, then the query for current engine is either
+	 * not triggered because of some earlier failure or the query on current engine hit trouble
+	 * and cannot copy the keys. Under such cases, cleanup RPCs instead of merge query resutls.
+	 */
+	if (unlikely(!otqa->keys_copied)) {
+		cleanup = true;
+		/* otqa->result may be not initialized under such case. */
+	} else {
+		oqma.oca = &exec_arg->ioc->ioc_oca;
+		oqma.tgt_dkey = &otqa->dkey_copy;
+		oqma.tgt_akey = &otqa->akey_copy;
+		oqma.tgt_recx = &otqa->recx;
+		oqma.tgt_epoch = &otqa->max_epoch;
+		oqma.tgt_map_ver = &otqa->version;
+		oqma.shard = &otqa->shard;
+		oqma.opc = DAOS_OBJ_RPC_COLL_QUERY;
+	}
+
+	for (i = 0, allow_failure_cnt = 0, succeeds = 0; i < dlh->dlh_normal_sub_cnt; i++) {
+		sub = &dlh->dlh_subs[i];
+		if (unlikely(!sub->dss_comp)) {
+			D_ASSERT(sub->dss_data == NULL);
+			continue;
+		}
+
+		if (dlh->dlh_rmt_ver < sub->dss_version)
+			dlh->dlh_rmt_ver = sub->dss_version;
+
+		rpc = sub->dss_data;
+
+		if (sub->dss_result == allow_failure) {
+			D_ASSERT(rpc != NULL);
+
+			ocqo = crt_reply_get(rpc);
+			if (otqa->max_epoch < ocqo->ocqo_max_epoch)
+				otqa->max_epoch = ocqo->ocqo_max_epoch;
+			allow_failure_cnt++;
+			goto next;
+		}
+
+		if (sub->dss_result != 0) {
+			/* Ignore INPROGRESS if there is other failure. */
+			if (rc == -DER_INPROGRESS || rc == 0)
+				rc = sub->dss_result;
+			cleanup = true;
+		} else {
+			succeeds++;
+		}
+
+		/* Skip subsequent merge when hit one unallowed failure. */
+		if (cleanup)
+			goto next;
+
+		D_ASSERT(rpc != NULL);
+
+		ocqi = crt_req_get(rpc);
+		ocqo = crt_reply_get(rpc);
+
+		/*
+		 * The RPC reply may be aggregated results from multiple VOS targets, as to related
+		 * max/min dkey/recx are not from the direct target. The ocqo->ocqo_shard indicates
+		 * the right one.
+		 */
+		oqma.oid = ocqi->ocqi_oid;
+		oqma.oid.id_shard = ocqo->ocqo_shard;
+		oqma.src_epoch = ocqo->ocqo_max_epoch;
+		oqma.in_dkey = &ocqi->ocqi_dkey;
+		oqma.src_dkey = &ocqo->ocqo_dkey;
+		oqma.src_akey = &ocqo->ocqo_akey;
+		oqma.src_recx = &ocqo->ocqo_recx;
+		oqma.flags = ocqi->ocqi_api_flags;
+		oqma.src_map_ver = obj_reply_map_version_get(rpc);
+		/*
+		 * Merge (L3) the results from other engines into current otqa that stands for the
+		 * results for related engines' group, including current engine.
+		 */
+		rc = daos_obj_merge_query_merge(&oqma);
+
+next:
+		if (rpc != NULL)
+			crt_req_decref(rpc);
+		sub->dss_data = NULL;
+	}
+
+	D_DEBUG(DB_IO, DF_DTI" sub_requests %d/%d, allow_failure %d, result %d\n",
+		DP_DTI(&dlh->dlh_handle.dth_xid),
+		allow_failure_cnt, succeeds, allow_failure, rc);
+
+	/*
+	 * The agg_cb return value only stands for execution on remote engines.
+	 * It is unnecessary to consider local failure on current engine, that
+	 * will be returned via obj_coll_query_disp().
+	 */
+	if (allow_failure_cnt > 0 && rc == 0 && succeeds == 0)
+		rc = allow_failure;
+
+	return rc;
+}

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -102,6 +102,43 @@ struct migrate_pool_tls {
 				mpt_init_tls:1,
 				mpt_init_failed:1,
 				mpt_fini:1;
+};
+
+struct obj_bulk_args {
+	ABT_eventual	eventual;
+	uint64_t	bulk_size;
+	int		bulks_inflight;
+	int		result;
+	bool		inited;
+};
+
+struct obj_tgt_query_args {
+	struct obj_io_context	*ioc;
+	struct dtx_handle	*dth;
+	daos_key_t		*in_dkey;
+	daos_key_t		*in_akey;
+	daos_key_t		*out_dkey;
+	daos_key_t		*out_akey;
+	daos_key_t		 dkey_copy;
+	daos_key_t		 akey_copy;
+	daos_recx_t		 recx;
+	daos_epoch_t		 max_epoch;
+	int			 result;
+	uint32_t		 shard;
+	uint32_t		 version;
+	uint32_t		 completed:1,
+				 need_copy:1,
+				 keys_copied:1;
+};
+
+struct obj_tgt_punch_args {
+	uint32_t		 opc;
+	struct obj_io_context	*sponsor_ioc;
+	struct dtx_handle	*sponsor_dth;
+	struct obj_punch_in	*opi;
+	struct dtx_memberships	*mbs;
+	uint32_t		*ver;
+	void			*data;
 };
 
 void
@@ -258,6 +295,9 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dth, void *arg, int idx,
 int
 ds_obj_coll_punch_remote(struct dtx_leader_handle *dth, void *arg, int idx,
 			 dtx_sub_comp_cb_t comp_cb);
+int
+ds_obj_coll_query_remote(struct dtx_leader_handle *dlh, void *data, int idx,
+			 dtx_sub_comp_cb_t comp_cb);
 
 /* srv_obj.c */
 void ds_obj_rw_handler(crt_rpc_t *rpc);
@@ -267,6 +307,7 @@ void ds_obj_key2anchor_handler(crt_rpc_t *rpc);
 void ds_obj_punch_handler(crt_rpc_t *rpc);
 void ds_obj_tgt_punch_handler(crt_rpc_t *rpc);
 void ds_obj_query_key_handler(crt_rpc_t *rpc);
+void ds_obj_coll_query_handler(crt_rpc_t *rpc);
 void ds_obj_sync_handler(crt_rpc_t *rpc);
 void ds_obj_migrate_handler(crt_rpc_t *rpc);
 void ds_obj_ec_agg_handler(crt_rpc_t *rpc);
@@ -274,6 +315,16 @@ void ds_obj_ec_rep_handler(crt_rpc_t *rpc);
 void ds_obj_cpd_handler(crt_rpc_t *rpc);
 void ds_obj_coll_punch_handler(crt_rpc_t *rpc);
 typedef int (*ds_iofw_cb_t)(crt_rpc_t *req, void *arg);
+
+int obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
+		      crt_bulk_t *remote_bulks, uint64_t *remote_offs, uint8_t *skips,
+		      daos_handle_t ioh, d_sg_list_t **sgls, int sgl_nr,
+		      struct obj_bulk_args *p_arg, struct ds_cont_hdl *coh);
+int obj_tgt_punch(struct obj_tgt_punch_args *otpa, uint32_t *shards, uint32_t count);
+int obj_tgt_query(struct obj_tgt_query_args *otqa, uuid_t po_uuid, uuid_t co_hdl, uuid_t co_uuid,
+		  daos_unit_oid_t oid, daos_epoch_t epoch, daos_epoch_t epoch_first,
+		  uint64_t api_flags, uint32_t rpc_flags, uint32_t *map_ver, crt_rpc_t *rpc,
+		  uint32_t count, uint32_t *shards, struct dtx_id *xid);
 
 struct daos_cpd_args {
 	struct obj_io_context	*dca_ioc;
@@ -523,6 +574,43 @@ obj_dtx_need_refresh(struct dtx_handle *dth, int rc)
 {
 	return rc == -DER_INPROGRESS && dth->dth_share_tbd_count > 0;
 }
+
+static inline void
+obj_tgt_query_cleanup(struct obj_tgt_query_args *otqa)
+{
+	if (otqa->need_copy) {
+		daos_iov_free(&otqa->dkey_copy);
+		daos_iov_free(&otqa->akey_copy);
+	}
+}
+
+/* srv_coll.c */
+typedef int (*obj_coll_func_t)(void *args);
+
+int
+obj_coll_local(crt_rpc_t *rpc, struct daos_coll_shard *shards, struct dtx_coll_entry *dce,
+	       uint32_t *version, struct obj_io_context *ioc, struct dtx_handle *dth, void *args,
+	       obj_coll_func_t func);
+int
+obj_coll_tgt_punch(void *args);
+int
+obj_coll_punch_disp(struct dtx_leader_handle *dlh, void *arg, int idx, dtx_sub_comp_cb_t comp_cb);
+int
+obj_coll_punch_bulk(crt_rpc_t *rpc, d_iov_t *iov, crt_proc_t *p_proc,
+		    struct daos_coll_target **p_dcts, uint32_t *dct_nr);
+int
+obj_coll_punch_prep(struct obj_coll_punch_in *ocpi, struct daos_coll_target *dcts, uint32_t dct_nr,
+		    struct dtx_coll_entry **p_dce);
+int
+obj_coll_tgt_query(void *args);
+int
+obj_coll_query_merge_tgts(struct obj_coll_query_in *ocqi, struct daos_oclass_attr *oca,
+			  struct obj_tgt_query_args *otqas, uint8_t *bitmap, uint32_t bitmap_sz,
+			  uint32_t tgt_id, int allow_failure);
+int
+obj_coll_query_disp(struct dtx_leader_handle *dlh, void *arg, int idx, dtx_sub_comp_cb_t comp_cb);
+int
+obj_coll_query_agg_cb(struct dtx_leader_handle *dlh, void *arg);
 
 /* obj_enum.c */
 int

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -342,6 +342,13 @@ obj_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
 		sched_req_attr_init(attr, SCHED_REQ_UPDATE, &ocpi->ocpi_po_uuid);
 		break;
 	}
+	case DAOS_OBJ_RPC_COLL_QUERY: {
+		struct obj_coll_query_in *ocqi = crt_req_get(rpc);
+
+		attr->sra_enqueue_id = ocqi->ocqi_comm_in.req_in_enqueue_id;
+		sched_req_attr_init(attr, SCHED_REQ_FETCH, &ocqi->ocqi_po_uuid);
+		break;
+	}
 	default:
 		/* Other requests will not be queued, see dss_rpc_hdlr() */
 		rc = -DER_NOSYS;
@@ -444,6 +451,13 @@ obj_set_req(crt_rpc_t *rpc, struct sched_req_attr *attr)
 
 		ocpo->ocpo_comm_out.req_out_enqueue_id = attr->sra_enqueue_id;
 		ocpo->ocpo_ret = -DER_OVERLOAD_RETRY;
+		break;
+	}
+	case DAOS_OBJ_RPC_COLL_QUERY: {
+		struct obj_coll_query_out *ocqo = crt_reply_get(rpc);
+
+		ocqo->ocqo_comm_out.req_out_enqueue_id = attr->sra_enqueue_id;
+		ocqo->ocqo_ret = -DER_OVERLOAD_RETRY;
 		break;
 	}
 	default:

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -226,14 +226,6 @@ obj_rw_reply(crt_rpc_t *rpc, int status, uint64_t epoch,
 		}
 	}
 }
-
-struct obj_bulk_args {
-	ABT_eventual	eventual;
-	uint64_t	bulk_size;
-	int		bulks_inflight;
-	int		result;
-	bool		inited;
-};
 
 static int
 obj_bulk_comp_cb(const struct crt_bulk_cb_info *cb_info)
@@ -490,7 +482,7 @@ bulk_transfer_sgl(daos_handle_t ioh, crt_rpc_t *rpc, crt_bulk_t remote_bulk,
 	return rc;
 }
 
-static int
+int
 obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind, crt_bulk_t *remote_bulks,
 		  uint64_t *remote_offs, uint8_t *skips, daos_handle_t ioh, d_sg_list_t **sgls,
 		  int sgl_nr, struct obj_bulk_args *p_arg, struct ds_cont_hdl *coh)
@@ -3548,17 +3540,7 @@ out:
 	return rc;
 }
 
-struct obj_tgt_punch_args {
-	uint32_t		 opc;
-	struct obj_io_context	*sponsor_ioc;
-	struct dtx_handle	*sponsor_dth;
-	struct obj_punch_in	*opi;
-	struct dtx_memberships	*mbs;
-	uint32_t		*ver;
-	void			*data;
-};
-
-static int
+int
 obj_tgt_punch(struct obj_tgt_punch_args *otpa, uint32_t *shards, uint32_t count)
 {
 	struct obj_io_context	 ioc = { 0 };
@@ -3677,12 +3659,13 @@ out:
 }
 
 static int
-obj_punch_agg_cb(struct dtx_leader_handle *dlh, int allow_failure)
+obj_punch_agg_cb(struct dtx_leader_handle *dlh, void *arg)
 {
 	struct dtx_sub_status	*sub;
 	uint32_t		 sub_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
-	int			 allow_failure_cnt = 0;
-	int			 succeeds = 0;
+	int			 allow_failure = dlh->dlh_allow_failure;
+	int			 allow_failure_cnt;
+	int			 succeeds;
 	int			 result = 0;
 	int			 i;
 
@@ -3690,11 +3673,9 @@ obj_punch_agg_cb(struct dtx_leader_handle *dlh, int allow_failure)
 	 * For conditional punch, let's ignore DER_NONEXIST if some shard succeed,
 	 * since the object may not exist on some shards due to EC partial update.
 	 */
-	if (allow_failure != 0)
-		D_ASSERTF(allow_failure == -DER_NONEXIST,
-			  "Unexpected allow failure %d\n", allow_failure);
+	D_ASSERTF(allow_failure == -DER_NONEXIST, "Unexpected allow failure %d\n", allow_failure);
 
-	for (i = 0; i < sub_cnt; i++) {
+	for (i = 0, allow_failure_cnt = 0, succeeds = 0; i < sub_cnt; i++) {
 		sub = &dlh->dlh_subs[i];
 		if (sub->dss_tgt.st_rank != DAOS_TGT_IGNORE && sub->dss_comp) {
 			if (sub->dss_result == 0) {
@@ -3716,7 +3697,7 @@ obj_punch_agg_cb(struct dtx_leader_handle *dlh, int allow_failure)
 		DP_DTI(&dlh->dlh_handle.dth_xid),
 		allow_failure_cnt, succeeds, allow_failure, result);
 
-	if (allow_failure != 0 && allow_failure_cnt > 0 && result == 0 && succeeds == 0)
+	if (allow_failure_cnt > 0 && result == 0 && succeeds == 0)
 		result = allow_failure;
 
 	return result;
@@ -3906,9 +3887,11 @@ again2:
 	exec_arg.flags = flags;
 
 	/* Execute the operation on all shards */
-	rc = dtx_leader_exec_ops(dlh, obj_tgt_punch_disp, obj_punch_agg_cb,
-				 (opi->opi_api_flags & DAOS_COND_PUNCH) ? -DER_NONEXIST : 0,
-				 &exec_arg);
+	if (opi->opi_api_flags & DAOS_COND_PUNCH)
+		rc = dtx_leader_exec_ops(dlh, obj_tgt_punch_disp, obj_punch_agg_cb, -DER_NONEXIST,
+					 &exec_arg);
+	else
+		rc = dtx_leader_exec_ops(dlh, obj_tgt_punch_disp, NULL, 0, &exec_arg);
 
 	if (max_ver < dlh->dlh_rmt_ver)
 		max_ver = dlh->dlh_rmt_ver;
@@ -3961,83 +3944,248 @@ cleanup:
 	obj_ioc_end(&ioc, rc);
 }
 
+static int
+obj_local_query(struct obj_tgt_query_args *otqa, struct obj_io_context *ioc, daos_unit_oid_t oid,
+		daos_epoch_t epoch, uint64_t api_flags, uint32_t map_ver, uint32_t opc,
+		uint32_t count, uint32_t *shards, struct dtx_handle *dth)
+{
+	struct obj_query_merge_args	 oqma = { 0 };
+	daos_key_t			 dkey;
+	daos_key_t			 akey;
+	daos_key_t			*p_dkey;
+	daos_key_t			*p_akey;
+	daos_recx_t			*p_recx;
+	daos_epoch_t			*p_epoch;
+	daos_unit_oid_t			 t_oid = oid;
+	uint32_t			 query_flags = api_flags;
+	uint32_t			 cell_size = 0;
+	uint64_t			 stripe_size = 0;
+	daos_epoch_t			 max_epoch = 0;
+	daos_recx_t			 recx = { 0 };
+	int				 allow_failure = -DER_NONEXIST;
+	int				 allow_failure_cnt;
+	int				 succeeds;
+	int				 rc = 0;
+	int				 i;
+
+	if (count > 1)
+		D_ASSERT(otqa->need_copy);
+
+	if (daos_oclass_is_ec(&ioc->ioc_oca) && api_flags & DAOS_GET_RECX) {
+		query_flags |= VOS_GET_RECX_EC;
+		cell_size = obj_ec_cell_rec_nr(&ioc->ioc_oca);
+		stripe_size = obj_ec_stripe_rec_nr(&ioc->ioc_oca);
+	}
+
+	if (otqa->need_copy) {
+		oqma.oca = &ioc->ioc_oca;
+		oqma.oid = oid;
+		oqma.in_dkey = otqa->in_dkey;
+		oqma.tgt_dkey = &otqa->dkey_copy;
+		oqma.tgt_akey = &otqa->akey_copy;
+		oqma.tgt_recx = &otqa->recx;
+		oqma.tgt_epoch = &otqa->max_epoch;
+		oqma.tgt_map_ver = &otqa->version;
+		oqma.shard = &otqa->shard;
+		oqma.flags = api_flags;
+		oqma.opc = opc;
+		oqma.src_map_ver = map_ver;
+	}
+
+	for (i = 0, allow_failure_cnt = 0, succeeds = 0; i < count; i++ ) {
+		if (api_flags & DAOS_GET_DKEY) {
+			if (otqa->need_copy)
+				p_dkey = &dkey;
+			else
+				p_dkey = otqa->out_dkey;
+			d_iov_set(p_dkey, NULL, 0);
+		} else {
+			p_dkey = otqa->in_dkey;
+		}
+
+		if (api_flags & DAOS_GET_AKEY) {
+			if (otqa->need_copy)
+				p_akey = &akey;
+			else
+				p_akey = otqa->out_akey;
+			d_iov_set(p_akey, NULL, 0);
+		} else {
+			p_akey = otqa->in_akey;
+		}
+
+		if (otqa->need_copy) {
+			p_recx = &recx;
+			p_epoch = &max_epoch;
+		} else {
+			p_recx = &otqa->recx;
+			p_epoch = &otqa->max_epoch;
+		}
+
+		t_oid.id_shard = shards[i];
+
+again:
+		rc = vos_obj_query_key(ioc->ioc_vos_coh, t_oid, query_flags, epoch, p_dkey, p_akey,
+				       p_recx, p_epoch, cell_size, stripe_size, dth);
+		if (obj_dtx_need_refresh(dth, rc)) {
+			rc = dtx_refresh(dth, ioc->ioc_coc);
+			if (rc == -DER_AGAIN)
+				goto again;
+		}
+
+		if (rc == allow_failure) {
+			if (otqa->need_copy && otqa->max_epoch < *p_epoch)
+				otqa->max_epoch = *p_epoch;
+			allow_failure_cnt++;
+			continue;
+		}
+
+		if (rc != 0)
+			goto out;
+
+		succeeds++;
+
+		if (!otqa->need_copy) {
+			otqa->shard = shards[i];
+			goto out;
+		}
+
+		if (succeeds == 1) {
+			rc = daos_iov_copy(&otqa->dkey_copy, p_dkey);
+			if (rc != 0)
+				goto out;
+
+			rc = daos_iov_copy(&otqa->akey_copy, p_akey);
+			if (rc != 0)
+				goto out;
+
+			otqa->recx = *p_recx;
+			if (otqa->max_epoch < *p_epoch)
+				otqa->max_epoch = *p_epoch;
+			otqa->shard = shards[i];
+			otqa->keys_copied = 1;
+		} else {
+			oqma.oid.id_shard = shards[i];
+			oqma.src_epoch = *p_epoch;
+			oqma.src_dkey = p_dkey;
+			oqma.src_akey = p_akey;
+			oqma.src_recx = p_recx;
+			/*
+			 * Merge (L1) the results from different shards on the same VOS target
+			 * into current otqa that stands for the result for current VOS target.
+			 */
+			rc = daos_obj_merge_query_merge(&oqma);
+			if (rc != 0)
+				goto out;
+		}
+	}
+
+	if (allow_failure_cnt > 0 && rc == 0 && succeeds == 0)
+		rc = allow_failure;
+
+out:
+	if (rc == allow_failure && otqa->need_copy && !otqa->keys_copied) {
+		/* Allocate key buffer for subsequent merge. */
+		rc = daos_iov_alloc(&otqa->dkey_copy, sizeof(uint64_t), true);
+		if (rc != 0)
+			goto out;
+
+		rc = daos_iov_alloc(&otqa->akey_copy, sizeof(uint64_t), true);
+		if (rc != 0)
+			goto out;
+
+		otqa->keys_copied = 1;
+	}
+
+	otqa->result = rc;
+	otqa->completed = 1;
+
+	return rc;
+}
+
+int
+obj_tgt_query(struct obj_tgt_query_args *otqa, uuid_t po_uuid, uuid_t co_hdl, uuid_t co_uuid,
+	      daos_unit_oid_t oid, daos_epoch_t epoch, daos_epoch_t epoch_first,
+	      uint64_t api_flags, uint32_t rpc_flags, uint32_t *map_ver, crt_rpc_t *rpc,
+	      uint32_t count, uint32_t *shards, struct dtx_id *xid)
+{
+	struct dtx_epoch	 dtx_epoch = { 0 };
+	struct obj_io_context	 ioc = { 0 };
+	struct obj_io_context	*p_ioc = otqa->ioc;
+	struct dtx_handle	*dth = otqa->dth;
+	int			 rc = 0;
+
+	if (p_ioc == NULL)
+		p_ioc = &ioc;
+
+	if (!p_ioc->ioc_began) {
+		rc = obj_ioc_begin(oid.id_pub, *map_ver, po_uuid, co_hdl, co_uuid, rpc, rpc_flags,
+				   p_ioc);
+		if (rc != 0)
+			goto out;
+	}
+
+	if (dth == NULL) {
+		dtx_epoch.oe_value = epoch;
+		dtx_epoch.oe_first = epoch_first;
+		dtx_epoch.oe_flags = orf_to_dtx_epoch_flags(rpc_flags);
+
+		rc = dtx_begin(p_ioc->ioc_vos_coh, xid, &dtx_epoch, 0, *map_ver, &oid, NULL, 0, 0,
+			       NULL, &dth);
+		if (rc != 0)
+			goto out;
+	}
+
+	rc = obj_local_query(otqa, p_ioc, oid, epoch, api_flags, *map_ver, opc_get(rpc->cr_opc),
+			     count, shards, dth);
+
+	if (dth != otqa->dth)
+		rc = dtx_end(dth, p_ioc->ioc_coc, rc);
+
+out:
+	*map_ver = p_ioc->ioc_map_ver;
+	if (p_ioc != otqa->ioc)
+		obj_ioc_end(p_ioc, rc);
+
+	return rc;
+}
+
 void
 ds_obj_query_key_handler(crt_rpc_t *rpc)
 {
-	struct obj_query_key_in		*okqi;
-	struct obj_query_key_out	*okqo;
-	daos_key_t			*dkey;
-	daos_key_t			*akey;
-	struct dtx_handle		*dth = NULL;
-	struct obj_io_context		 ioc;
-	struct dtx_epoch		 epoch = {0};
-	uint32_t			 query_flags;
-	unsigned int			 cell_size = 0;
-	uint64_t			 stripe_size = 0;
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct obj_query_key_in		*okqi = crt_req_get(rpc);
+	struct obj_query_key_out	*okqo = crt_reply_get(rpc);
+	struct obj_tgt_query_args	 otqa = { 0 };
+	uint32_t			 version = okqi->okqi_map_ver;
 	int				 rc;
 
-	okqi = crt_req_get(rpc);
-	D_ASSERT(okqi != NULL);
-	okqo = crt_reply_get(rpc);
-	D_ASSERT(okqo != NULL);
-
-	D_DEBUG(DB_IO, "flags = "DF_U64"\n", okqi->okqi_api_flags);
-
-	rc = obj_ioc_begin(okqi->okqi_oid.id_pub, okqi->okqi_map_ver,
-			   okqi->okqi_pool_uuid, okqi->okqi_co_hdl,
-			   okqi->okqi_co_uuid, rpc, okqi->okqi_flags, &ioc);
-	if (rc)
-		D_GOTO(failed, rc);
-
-	rc = process_epoch(&okqi->okqi_epoch, &okqi->okqi_epoch_first,
-			   &okqi->okqi_flags);
+	rc = process_epoch(&okqi->okqi_epoch, &okqi->okqi_epoch_first, &okqi->okqi_flags);
 	if (rc == PE_OK_LOCAL)
 		okqi->okqi_flags &= ~ORF_EPOCH_UNCERTAIN;
 
-	dkey = &okqi->okqi_dkey;
-	akey = &okqi->okqi_akey;
-	d_iov_set(&okqo->okqo_akey, NULL, 0);
-	d_iov_set(&okqo->okqo_dkey, NULL, 0);
-	if (okqi->okqi_api_flags & DAOS_GET_DKEY)
-		dkey = &okqo->okqo_dkey;
-	if (okqi->okqi_api_flags & DAOS_GET_AKEY)
-		akey = &okqo->okqo_akey;
+	otqa.in_dkey = &okqi->okqi_dkey;
+	otqa.in_akey = &okqi->okqi_akey;
+	otqa.out_dkey = &okqo->okqo_dkey;
+	otqa.out_akey = &okqo->okqo_akey;
 
-	epoch.oe_value = okqi->okqi_epoch;
-	epoch.oe_first = okqi->okqi_epoch_first;
-	epoch.oe_flags = orf_to_dtx_epoch_flags(okqi->okqi_flags);
+	rc = obj_tgt_query(&otqa, okqi->okqi_pool_uuid, okqi->okqi_co_hdl, okqi->okqi_co_uuid,
+			   okqi->okqi_oid, okqi->okqi_epoch, okqi->okqi_epoch_first,
+			   okqi->okqi_api_flags, okqi->okqi_flags, &version, rpc, 1,
+			   &okqi->okqi_oid.id_shard, &okqi->okqi_dti);
+	okqo->okqo_max_epoch = otqa.max_epoch;
+	if (rc == 0)
+		okqo->okqo_recx = otqa.recx;
+	else
+		DL_CDEBUG(rc != -DER_NONEXIST && rc != -DER_INPROGRESS && rc != -DER_TX_RESTART,
+			  DLOG_ERR, DB_IO, rc, "Failed to handle reqular query RPC %p on XS %u/%u "
+			  "for obj "DF_UOID" epc "DF_X64" pmv %u/%u, api_flags "DF_X64" with dti "
+			  DF_DTI, rpc, dmi->dmi_xs_id, dmi->dmi_tgt_id, DP_UOID(okqi->okqi_oid),
+			  okqi->okqi_epoch, okqi->okqi_map_ver, version, okqi->okqi_api_flags,
+			  DP_DTI(&okqi->okqi_dti));
 
-	rc = dtx_begin(ioc.ioc_vos_coh, &okqi->okqi_dti, &epoch, 0,
-		       okqi->okqi_map_ver, &okqi->okqi_oid, NULL, 0, 0, NULL,
-		       &dth);
-	if (rc != 0)
-		goto failed;
-
-	query_flags = okqi->okqi_api_flags;
-	if ((okqi->okqi_flags & ORF_EC) && (okqi->okqi_api_flags & DAOS_GET_RECX)) {
-		query_flags |= VOS_GET_RECX_EC;
-		cell_size = obj_ec_cell_rec_nr(&ioc.ioc_oca);
-		stripe_size = obj_ec_stripe_rec_nr(&ioc.ioc_oca);
-	}
-
-re_query:
-	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid, query_flags,
-			       okqi->okqi_epoch, dkey, akey, &okqo->okqo_recx,
-			       &okqo->okqo_max_epoch,
-			       cell_size, stripe_size, dth);
-	if (obj_dtx_need_refresh(dth, rc)) {
-		rc = dtx_refresh(dth, ioc.ioc_coc);
-		if (rc == -DER_AGAIN)
-			goto re_query;
-	}
-
-	rc = dtx_end(dth, ioc.ioc_coc, rc);
-
-failed:
 	obj_reply_set_status(rpc, rc);
-	obj_reply_map_version_set(rpc, ioc.ioc_map_ver);
-	okqo->okqo_epoch = epoch.oe_value;
-	obj_ioc_end(&ioc, rc);
+	obj_reply_map_version_set(rpc, version);
+	okqo->okqo_epoch = okqi->okqi_epoch;
 
 	rc = crt_reply_send(rpc);
 	if (rc != 0)
@@ -5397,313 +5545,6 @@ out:
 		D_ERROR("send reply failed: "DF_RC"\n", DP_RC(rc));
 }
 
-struct obj_coll_tgt_args {
-	crt_rpc_t				*octa_rpc;
-	struct daos_coll_shard			*octa_shards;
-	uint32_t				*octa_versions;
-	uint32_t				 octa_sponsor_tgt;
-	struct obj_io_context			*octa_sponsor_ioc;
-	struct dtx_handle			*octa_sponsor_dth;
-	union {
-		void				*octa_misc;
-		/* Different collective operations may need different parameters. */
-		struct dtx_memberships		*octa_mbs;
-	};
-};
-
-static int
-obj_coll_tgt_punch(void *args)
-{
-	struct obj_coll_tgt_args	*octa = args;
-	crt_rpc_t			*rpc = octa->octa_rpc;
-	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
-	struct obj_punch_in		*opi = NULL;
-	struct obj_tgt_punch_args	 otpa = { 0 };
-	uint32_t			 tgt_id = dss_get_module_info()->dmi_tgt_id;
-	int				 rc;
-
-	D_ALLOC_PTR(opi);
-	if (opi == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	opi->opi_dti = ocpi->ocpi_xid;
-	uuid_copy(opi->opi_pool_uuid, ocpi->ocpi_po_uuid);
-	uuid_copy(opi->opi_co_hdl, ocpi->ocpi_co_hdl);
-	uuid_copy(opi->opi_co_uuid, ocpi->ocpi_co_uuid);
-	opi->opi_oid = ocpi->ocpi_oid;
-	opi->opi_oid.id_shard = octa->octa_shards[tgt_id].dcs_buf[0];
-	opi->opi_epoch = ocpi->ocpi_epoch;
-	opi->opi_api_flags = ocpi->ocpi_api_flags;
-	opi->opi_map_ver = ocpi->ocpi_map_ver;
-	opi->opi_flags = ocpi->ocpi_flags & ~ORF_LEADER;
-
-	otpa.opi = opi;
-	otpa.opc = opc_get(rpc->cr_opc);
-	if (tgt_id == octa->octa_sponsor_tgt) {
-		otpa.sponsor_ioc = octa->octa_sponsor_ioc;
-		otpa.sponsor_dth = octa->octa_sponsor_dth;
-	}
-	otpa.mbs = octa->octa_mbs;
-	if (octa->octa_versions != NULL)
-		otpa.ver = &octa->octa_versions[tgt_id];
-	otpa.data = rpc;
-
-	rc = obj_tgt_punch(&otpa, octa->octa_shards[tgt_id].dcs_buf,
-			   octa->octa_shards[tgt_id].dcs_nr);
-	D_FREE(opi);
-
-out:
-	DL_CDEBUG(rc == 0 || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR, rc,
-		  "Collective punch obj shard "DF_UOID" with "DF_DTI" on tgt %u",
-		  DP_OID(ocpi->ocpi_oid.id_pub), octa->octa_shards[tgt_id].dcs_buf[0],
-		  ocpi->ocpi_oid.id_layout_ver, DP_DTI(&ocpi->ocpi_xid), tgt_id);
-
-	return rc;
-}
-
-typedef int (*obj_coll_func_t)(void *args);
-
-static int
-obj_coll_local(crt_rpc_t *rpc, struct daos_coll_shard *shards, struct dtx_coll_entry *dce,
-	       uint32_t *version, struct obj_io_context *ioc, struct dtx_handle *dth, void *args,
-	       obj_coll_func_t func)
-{
-	struct obj_coll_tgt_args	octa = { 0 };
-	struct dss_coll_ops		coll_ops = { 0 };
-	struct dss_coll_args		coll_args = { 0 };
-	uint32_t			size = dce->dce_bitmap_sz << 3;
-	int				rc = 0;
-	int				i;
-
-	D_ASSERT(dce->dce_bitmap != NULL);
-	D_ASSERT(ioc != NULL);
-
-	if (version != NULL) {
-		if (size > dss_tgt_nr)
-			size = dss_tgt_nr;
-		D_ALLOC_ARRAY(octa.octa_versions, size);
-		if (octa.octa_versions == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-	}
-
-	octa.octa_rpc = rpc;
-	octa.octa_shards = shards;
-	octa.octa_misc = args;
-	octa.octa_sponsor_ioc = ioc;
-	octa.octa_sponsor_dth = dth;
-	octa.octa_sponsor_tgt = dss_get_module_info()->dmi_tgt_id;
-
-	coll_ops.co_func = func;
-	coll_args.ca_func_args = &octa;
-	coll_args.ca_tgt_bitmap = dce->dce_bitmap;
-	coll_args.ca_tgt_bitmap_sz = dce->dce_bitmap_sz;
-
-	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, DSS_USE_CURRENT_ULT);
-
-out:
-	if (octa.octa_versions != NULL) {
-		for (i = 0, *version = 0; i < size; i++) {
-			if (isset(dce->dce_bitmap, i) && *version < octa.octa_versions[i])
-				*version = octa.octa_versions[i];
-		}
-		D_FREE(octa.octa_versions);
-	}
-
-	return rc;
-}
-
-static int
-obj_coll_punch_disp(struct dtx_leader_handle *dlh, void *arg, int idx, dtx_sub_comp_cb_t comp_cb)
-{
-	struct ds_obj_exec_arg		*exec_arg = arg;
-	crt_rpc_t			*rpc = exec_arg->rpc;
-	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
-	int				 rc;
-
-	if (idx != -1)
-		return ds_obj_coll_punch_remote(dlh, arg, idx, comp_cb);
-
-	/* Local punch on current rank, including the leader target. */
-	rc = obj_coll_local(rpc, exec_arg->coll_shards, dlh->dlh_coll_entry, NULL, exec_arg->ioc,
-			    &dlh->dlh_handle, dlh->dlh_handle.dth_mbs, obj_coll_tgt_punch);
-
-	DL_CDEBUG(rc == 0 || rc == -DER_INPROGRESS || rc == -DER_TX_RESTART, DB_IO, DLOG_ERR, rc,
-		  "Collective punch obj "DF_UOID" with "DF_DTI" on rank %u",
-		  DP_UOID(ocpi->ocpi_oid), DP_DTI(&ocpi->ocpi_xid), dss_self_rank());
-
-	if (comp_cb != NULL)
-		comp_cb(dlh, idx, rc);
-
-	return rc;
-}
-
-static int
-obj_coll_punch_bulk(crt_rpc_t *rpc, d_iov_t *iov, crt_proc_t *p_proc,
-		    struct daos_coll_target **p_dcts, uint32_t *dct_nr)
-{
-	struct obj_coll_punch_in	*ocpi = crt_req_get(rpc);
-	struct daos_coll_target		*dcts = NULL;
-	crt_proc_t			 proc = NULL;
-	d_sg_list_t			 sgl;
-	d_sg_list_t			*sgls = &sgl;
-	int				 rc = 0;
-	int				 i;
-	int				 j;
-
-	D_ALLOC(iov->iov_buf, ocpi->ocpi_bulk_tgt_sz);
-	if (iov->iov_buf == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	iov->iov_buf_len = ocpi->ocpi_bulk_tgt_sz;
-	iov->iov_len = ocpi->ocpi_bulk_tgt_sz;
-
-	sgl.sg_nr = 1;
-	sgl.sg_nr_out = 1;
-	sgl.sg_iovs = iov;
-
-	rc = obj_bulk_transfer(rpc, CRT_BULK_GET, false, &ocpi->ocpi_tgt_bulk, NULL, NULL,
-			       DAOS_HDL_INVAL, &sgls, 1, NULL, NULL);
-	if (rc != 0)
-		goto out;
-
-	rc = crt_proc_create(dss_get_module_info()->dmi_ctx, iov->iov_buf, iov->iov_len,
-			     CRT_PROC_DECODE, &proc);
-	if (rc != 0)
-		goto out;
-
-	D_ALLOC_ARRAY(dcts, ocpi->ocpi_bulk_tgt_nr);
-	if (dcts == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	for (i = 0; i < ocpi->ocpi_bulk_tgt_nr; i++) {
-		rc = crt_proc_struct_daos_coll_target(proc, CRT_PROC_DECODE, &dcts[i]);
-		if (rc != 0) {
-			crt_proc_reset(proc, iov->iov_buf, iov->iov_len, CRT_PROC_FREE);
-			for (j = 0; j < i; j++)
-				crt_proc_struct_daos_coll_target(proc, CRT_PROC_FREE, &dcts[j]);
-			goto out;
-		}
-	}
-
-out:
-	if (rc != 0) {
-		D_FREE(dcts);
-		if (proc != NULL)
-			crt_proc_destroy(proc);
-		daos_iov_free(iov);
-	} else {
-		*p_proc = proc;
-		*p_dcts = dcts;
-		*dct_nr = ocpi->ocpi_bulk_tgt_nr;
-	}
-
-	return rc;
-}
-
-static int
-obj_coll_punch_prep(struct obj_coll_punch_in *ocpi, struct daos_coll_target *dcts, uint32_t dct_nr,
-		    struct dtx_coll_entry **p_dce)
-{
-	struct pl_map		*map = NULL;
-	struct dtx_memberships	*mbs = ocpi->ocpi_mbs;
-	struct dtx_daos_target	*ddt = mbs->dm_tgts;
-	struct dtx_coll_entry	*dce = NULL;
-	struct dtx_coll_target	*target;
-	d_rank_t		 max_rank = 0;
-	uint32_t		 size;
-	int			 rc = 0;
-	int			 i;
-	int			 j;
-
-	/* dcts[0] is for current engine. */
-	if (dcts[0].dct_bitmap == NULL || dcts[0].dct_bitmap_sz == 0 ||
-	    dcts[0].dct_shards == NULL)
-		D_GOTO(out, rc = -DER_INVAL);
-
-	/* Already allocated enough space in MBS when decode to hold the targets and bitmap. */
-	target = (struct dtx_coll_target *)(ddt + mbs->dm_tgt_cnt);
-
-	size = sizeof(*ddt) * mbs->dm_tgt_cnt + sizeof(*target) +
-	       sizeof(dcts[0].dct_tgt_ids[0]) * dcts[0].dct_tgt_nr + dcts[0].dct_bitmap_sz;
-	if (unlikely(ocpi->ocpi_odm.odm_mbs_max_sz < sizeof(*mbs) + size)) {
-		D_ERROR("Pre-allocated MBS buffer is too small: %u vs %ld + %u\n",
-			ocpi->ocpi_odm.odm_mbs_max_sz, sizeof(*mbs), size);
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	target->dct_tgt_nr = dcts[0].dct_tgt_nr;
-	memcpy(target->dct_tgts, dcts[0].dct_tgt_ids,
-	       sizeof(dcts[0].dct_tgt_ids[0]) * dcts[0].dct_tgt_nr);
-	target->dct_bitmap_sz = dcts[0].dct_bitmap_sz;
-	memcpy(target->dct_tgts + target->dct_tgt_nr, dcts[0].dct_bitmap, dcts[0].dct_bitmap_sz);
-	mbs->dm_data_size = size;
-
-	D_ALLOC_PTR(dce);
-	if (dce == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	dce->dce_xid = ocpi->ocpi_xid;
-	dce->dce_ver = ocpi->ocpi_map_ver;
-	dce->dce_refs = 1;
-
-	D_ALLOC(dce->dce_bitmap, dcts[0].dct_bitmap_sz);
-	if (dce->dce_bitmap == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	dce->dce_bitmap_sz = dcts[0].dct_bitmap_sz;
-	memcpy(dce->dce_bitmap, dcts[0].dct_bitmap, dcts[0].dct_bitmap_sz);
-
-	if (!(ocpi->ocpi_flags & ORF_LEADER) || unlikely(dct_nr <= 1))
-		D_GOTO(out, rc = 0);
-
-	map = pl_map_find(ocpi->ocpi_po_uuid, ocpi->ocpi_oid.id_pub);
-	if (map == NULL) {
-		D_ERROR("Failed to find valid placement map in pool "DF_UUID"\n",
-			DP_UUID(ocpi->ocpi_po_uuid));
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	size = pool_map_node_nr(map->pl_poolmap);
-	D_ALLOC_ARRAY(dce->dce_hints, size);
-	if (dce->dce_hints == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	dce->dce_ranks = d_rank_list_alloc(dct_nr - 1);
-	if (dce->dce_ranks == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	/* Set i = 1 to skip leader_rank. */
-	for (i = 1; i < dct_nr; i++) {
-		dce->dce_ranks->rl_ranks[i - 1] = dcts[i].dct_rank;
-		if (max_rank < dcts[i].dct_rank)
-			max_rank = dcts[i].dct_rank;
-
-		size = dcts[i].dct_bitmap_sz << 3;
-		if (size > dss_tgt_nr)
-			size = dss_tgt_nr;
-
-		for (j = 0; j < size; j++) {
-			if (isset(dcts[i].dct_bitmap, j)) {
-				dce->dce_hints[dcts[i].dct_rank] = j;
-				break;
-			}
-		}
-	}
-
-	dce->dce_hint_sz = max_rank + 1;
-
-out:
-	if (map != NULL)
-		pl_map_decref(map);
-
-	if (rc != 0 && dce != NULL)
-		dtx_coll_entry_put(dce);
-	else
-		*p_dce = dce;
-
-	return rc;
-}
-
 void
 ds_obj_coll_punch_handler(crt_rpc_t *rpc)
 {
@@ -5895,5 +5736,151 @@ out:
 	}
 
 	/* It is no matter even if obj_ioc_begin() was not called. */
+	obj_ioc_end(&ioc, rc);
+}
+
+void
+ds_obj_coll_query_handler(crt_rpc_t *rpc)
+{
+	struct dss_module_info		*dmi = dss_get_module_info();
+	struct obj_coll_query_in	*ocqi = crt_req_get(rpc);
+	struct obj_coll_query_out	*ocqo = crt_reply_get(rpc);
+	struct daos_coll_target		*dcts;
+	struct dtx_leader_handle	*dlh = NULL;
+	struct ds_obj_exec_arg		 exec_arg = { 0 };
+	struct dtx_coll_entry		 dce = { 0 };
+	struct obj_tgt_query_args	*otqas = NULL;
+	struct obj_tgt_query_args	*otqa = NULL;
+	struct obj_io_context		 ioc = { 0 };
+	struct dtx_epoch		 epoch = { 0 };
+	uint32_t			 dct_nr;
+	uint32_t			 version = 0;
+	uint32_t			 tgt_id = dmi->dmi_tgt_id;
+	d_rank_t			 myrank = dss_self_rank();
+	int				 rc = 0;
+	int				 i;
+
+	D_ASSERT(ocqi != NULL);
+	D_ASSERT(ocqo != NULL);
+
+	D_DEBUG(DB_IO, "Handling collective query RPC %p %s forwarding for obj "
+		DF_UOID" on rank %d XS %u/%u epc "DF_X64" pmv %u, with dti "DF_DTI
+		", dct_nr %u, forward width %u, forward depth %u\n",
+		rpc, ocqi->ocqi_tgts.ca_count <= 1 ? "without" : "with", DP_UOID(ocqi->ocqi_oid),
+		myrank, dmi->dmi_xs_id, tgt_id, ocqi->ocqi_epoch, ocqi->ocqi_map_ver,
+		DP_DTI(&ocqi->ocqi_xid), (unsigned int)ocqi->ocqi_tgts.ca_count,
+		ocqi->ocqi_disp_width, ocqi->ocqi_disp_depth);
+
+	D_ASSERT(dmi->dmi_xs_id != 0);
+
+	if (unlikely(ocqi->ocqi_tgts.ca_count <= 0 || ocqi->ocqi_tgts.ca_arrays == NULL))
+		D_GOTO(out, rc = -DER_INVAL);
+
+	dcts = ocqi->ocqi_tgts.ca_arrays;
+	dct_nr = ocqi->ocqi_tgts.ca_count;
+
+	if (unlikely(dcts[0].dct_bitmap == NULL || dcts[0].dct_bitmap_sz == 0 ||
+		     dcts[0].dct_shards == NULL || dcts[0].dct_tgt_nr == 0))
+		D_GOTO(out, rc = -DER_INVAL);
+
+	rc = obj_ioc_begin(ocqi->ocqi_oid.id_pub, ocqi->ocqi_map_ver, ocqi->ocqi_po_uuid,
+			   ocqi->ocqi_co_hdl, ocqi->ocqi_co_uuid, rpc, ocqi->ocqi_flags, &ioc);
+	if (rc != 0)
+		goto out;
+
+	rc = process_epoch(&ocqi->ocqi_epoch, &ocqi->ocqi_epoch_first, &ocqi->ocqi_flags);
+	if (rc == PE_OK_LOCAL)
+		ocqi->ocqi_flags &= ~ORF_EPOCH_UNCERTAIN;
+
+	D_ALLOC_ARRAY(otqas, dss_tgt_nr);
+	if (otqas == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	otqa = &otqas[tgt_id];
+
+	dce.dce_xid = ocqi->ocqi_xid;
+	dce.dce_ver = ocqi->ocqi_map_ver;
+	dce.dce_refs = 1;
+	dce.dce_bitmap = dcts[0].dct_bitmap;
+	dce.dce_bitmap_sz = dcts[0].dct_bitmap_sz;
+
+	if (ocqi->ocqi_tgts.ca_count == 1) {
+		rc = obj_coll_local(rpc, dcts[0].dct_shards, &dce, &version, &ioc, NULL, otqas,
+				    obj_coll_tgt_query);
+		if (otqa->completed && otqa->keys_copied && (rc == 0 || rc == -DER_NONEXIST)) {
+			D_ASSERT(ioc.ioc_began);
+			rc = obj_coll_query_merge_tgts(ocqi, &ioc.ioc_oca, otqas, dce.dce_bitmap,
+						       dce.dce_bitmap_sz, tgt_id, -DER_NONEXIST);
+		}
+
+		goto out;
+	}
+
+	version = ioc.ioc_map_ver;
+
+	epoch.oe_value = ocqi->ocqi_epoch;
+	epoch.oe_first = ocqi->ocqi_epoch_first;
+	epoch.oe_flags = orf_to_dtx_epoch_flags(ocqi->ocqi_flags);
+
+	exec_arg.rpc = rpc;
+	exec_arg.ioc = &ioc;
+	exec_arg.args = otqas;
+	exec_arg.coll_shards = dcts[0].dct_shards;
+	exec_arg.coll_tgts = dcts;
+	obj_coll_disp_init(dct_nr, ocqi->ocqi_max_tgt_sz, sizeof(*ocqi),
+			   1 /* start, [0] is for current engine */, ocqi->ocqi_disp_width,
+			   &exec_arg.coll_cur);
+
+	rc = dtx_leader_begin(ioc.ioc_vos_coh, &ocqi->ocqi_xid, &epoch, 0, ocqi->ocqi_map_ver,
+			      &ocqi->ocqi_oid, NULL /* dti_cos */, 0 /* dti_cos_cnt */,
+			      NULL /* tgts */, exec_arg.coll_cur.grp_nr /* tgt_cnt */,
+			      DTX_TGT_COLL | DTX_RELAY, NULL /* mbs */, &dce, &dlh);
+	if (rc != 0)
+		goto out;
+
+	rc = dtx_leader_exec_ops(dlh, obj_coll_query_disp, obj_coll_query_agg_cb, -DER_NONEXIST,
+				 &exec_arg);
+
+	if (version < dlh->dlh_rmt_ver)
+		version = dlh->dlh_rmt_ver;
+
+	rc = dtx_leader_end(dlh, ioc.ioc_coh, rc);
+
+out:
+	D_DEBUG(DB_IO, "Handled collective query RPC %p %s forwarding for obj "DF_UOID
+		" on rank %u XS %u/%u epc "DF_X64" pmv %u, with dti "DF_DTI", dct_nr %u, "
+		"forward width %u, forward depth %u\n: "DF_RC"\n", rpc,
+		ocqi->ocqi_tgts.ca_count <= 1 ? "without" : "with", DP_UOID(ocqi->ocqi_oid),
+		myrank, dmi->dmi_xs_id, tgt_id, ocqi->ocqi_epoch, ocqi->ocqi_map_ver,
+		DP_DTI(&ocqi->ocqi_xid), (unsigned int)ocqi->ocqi_tgts.ca_count,
+		ocqi->ocqi_disp_width, ocqi->ocqi_disp_depth, DP_RC(rc));
+
+	obj_reply_set_status(rpc, rc);
+	obj_reply_map_version_set(rpc, version);
+	ocqo->ocqo_epoch = epoch.oe_value;
+
+	if (rc == 0 || rc == -DER_NONEXIST) {
+		D_ASSERT(otqa != NULL);
+
+		ocqo->ocqo_shard = otqa->shard;
+		ocqo->ocqo_recx = otqa->recx;
+		ocqo->ocqo_max_epoch = otqa->max_epoch;
+		if (otqa->keys_copied) {
+			ocqo->ocqo_dkey = otqa->dkey_copy;
+			ocqo->ocqo_akey = otqa->akey_copy;
+		}
+	}
+
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("send reply failed: "DF_RC"\n", DP_RC(rc));
+
+	/* Keep otqas until RPC replied, because the reply may use some keys in otqas array. */
+	if (otqas != NULL) {
+		for (i = 0; i < dss_tgt_nr; i++)
+			obj_tgt_query_cleanup(&otqas[i]);
+		D_FREE(otqas);
+	}
+
 	obj_ioc_end(&ioc, rc);
 }

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -1,5 +1,5 @@
 """
-(C) Copyright 2021-2023 Intel Corporation.
+(C) Copyright 2021-2024 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -368,6 +368,18 @@ class TelemetryUtils():
         "engine_io_ops_obj_coll_punch_latency_mean",
         "engine_io_ops_obj_coll_punch_latency_min",
         "engine_io_ops_obj_coll_punch_latency_stddev"]
+    ENGINE_IO_OPS_OBJ_COLL_QUERY_ACTIVE_METRICS = [
+        "engine_io_ops_obj_coll_query_active",
+        "engine_io_ops_obj_coll_query_active_max",
+        "engine_io_ops_obj_coll_query_active_mean",
+        "engine_io_ops_obj_coll_query_active_min",
+        "engine_io_ops_obj_coll_query_active_stddev"]
+    ENGINE_IO_OPS_OBJ_COLL_QUERY_LATENCY_METRICS = [
+        "engine_io_ops_obj_coll_query_latency",
+        "engine_io_ops_obj_coll_query_latency_max",
+        "engine_io_ops_obj_coll_query_latency_mean",
+        "engine_io_ops_obj_coll_query_latency_min",
+        "engine_io_ops_obj_coll_query_latency_stddev"]
     ENGINE_IO_OPS_OBJ_ENUM_ACTIVE_METRICS = [
         "engine_io_ops_obj_enum_active",
         "engine_io_ops_obj_enum_active_max",
@@ -498,6 +510,8 @@ class TelemetryUtils():
         ENGINE_IO_OPS_MIGRATE_LATENCY_METRICS +\
         ENGINE_IO_OPS_OBJ_COLL_PUNCH_ACTIVE_METRICS +\
         ENGINE_IO_OPS_OBJ_COLL_PUNCH_LATENCY_METRICS +\
+        ENGINE_IO_OPS_OBJ_COLL_QUERY_ACTIVE_METRICS +\
+        ENGINE_IO_OPS_OBJ_COLL_QUERY_LATENCY_METRICS +\
         ENGINE_IO_OPS_OBJ_ENUM_ACTIVE_METRICS +\
         ENGINE_IO_OPS_OBJ_ENUM_LATENCY_METRICS +\
         ENGINE_IO_OPS_OBJ_PUNCH_ACTIVE_METRICS +\
@@ -580,7 +594,7 @@ class TelemetryUtils():
         "engine_mem_vos_dtx_cmt_ent_48",
         "engine_mem_vos_vos_obj_360",
         "engine_mem_vos_vos_lru_size",
-        "engine_mem_dtx_dtx_leader_handle_360"]
+        "engine_mem_dtx_dtx_leader_handle_352"]
     ENGINE_MEM_TOTAL_USAGE_METRICS = [
         "engine_mem_total_mem"]
 

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -5188,6 +5188,124 @@ io_52(void **state)
 	obj_coll_punch(arg, OC_EC_4P1GX);
 }
 
+static void
+obj_coll_query(test_arg_t *arg, daos_oclass_id_t oclass)
+{
+	daos_obj_id_t	oid;
+	daos_handle_t	oh;
+	daos_iod_t	iod = { 0 };
+	d_sg_list_t	sgl = { 0 };
+	daos_recx_t	recx = { 0 };
+	d_iov_t		val_iov;
+	d_iov_t		dkey;
+	d_iov_t		akey;
+	uint64_t	dkey_val;
+	uint64_t	akey_val;
+	uint32_t	update_var = 0xdeadbeef;
+	uint32_t	flags;
+	int		rc;
+
+	/** init dkey, akey */
+	dkey_val = akey_val = 0;
+	d_iov_set(&dkey, &dkey_val, sizeof(uint64_t));
+	d_iov_set(&akey, &akey_val, sizeof(uint64_t));
+
+	oid = daos_test_oid_gen(arg->coh, oclass, DAOS_OT_MULTI_UINT64, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, oid, DAOS_OO_RW, &oh, NULL);
+	assert_rc_equal(rc, 0);
+
+	dkey_val = 5;
+	akey_val = 10;
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_name = akey;
+	iod.iod_recxs = &recx;
+	iod.iod_nr = 1;
+	iod.iod_size = sizeof(update_var);
+
+	d_iov_set(&val_iov, &update_var, sizeof(update_var));
+	sgl.sg_iovs = &val_iov;
+	sgl.sg_nr = 1;
+
+	recx.rx_idx = 5;
+	recx.rx_nr = 1;
+
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, 0);
+
+	dkey_val = 10;
+	val_iov.iov_buf_len += 1024;
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, 0);
+	d_iov_set(&val_iov, &update_var, sizeof(update_var));
+
+	recx.rx_idx = 50;
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_rc_equal(rc, 0);
+
+	flags = DAOS_GET_DKEY | DAOS_GET_AKEY | DAOS_GET_RECX | DAOS_GET_MAX;
+	rc = daos_obj_query_key(oh, DAOS_TX_NONE, flags, &dkey, &akey, &recx, NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(*(uint64_t *)dkey.iov_buf, 10);
+	assert_int_equal(*(uint64_t *)akey.iov_buf, 10);
+	assert_int_equal(recx.rx_idx, 50);
+	assert_int_equal(recx.rx_nr, 1);
+
+	flags = DAOS_GET_AKEY | DAOS_GET_RECX | DAOS_GET_MAX;
+	rc = daos_obj_query_key(oh, DAOS_TX_NONE, flags, &dkey, &akey, &recx, NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(*(uint64_t *)akey.iov_buf, 10);
+	assert_int_equal(recx.rx_idx, 50);
+	assert_int_equal(recx.rx_nr, 1);
+
+	flags = DAOS_GET_RECX | DAOS_GET_MAX;
+	rc = daos_obj_query_key(oh, DAOS_TX_NONE, flags, &dkey, &akey, &recx, NULL);
+	assert_rc_equal(rc, 0);
+	assert_int_equal(recx.rx_idx, 50);
+	assert_int_equal(recx.rx_nr, 1);
+
+	rc = daos_obj_close(oh, NULL);
+	assert_rc_equal(rc, 0);
+}
+
+static void
+io_53(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	print_message("Collective object query - OC_SX\n");
+
+	if (!test_runable(arg, 2))
+		return;
+
+	obj_coll_query(arg, OC_SX);
+}
+
+static void
+io_54(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	print_message("Collective object query - OC_EC_2P1G2\n");
+
+	if (!test_runable(arg, 3))
+		return;
+
+	obj_coll_query(arg, OC_EC_2P1G2);
+}
+
+static void
+io_55(void **state)
+{
+	test_arg_t	*arg = *state;
+
+	print_message("Collective object query - OC_EC_4P1GX\n");
+
+	if (!test_runable(arg, 5))
+		return;
+
+	obj_coll_query(arg, OC_EC_4P1GX);
+}
+
 static const struct CMUnitTest io_tests[] = {
 	{ "IO1: simple update/fetch/verify",
 	  io_simple, async_disable, test_case_teardown},
@@ -5292,6 +5410,12 @@ static const struct CMUnitTest io_tests[] = {
 	  io_51, NULL, test_case_teardown},
 	{ "IO52: collective punch object - OC_EC_4P1GX",
 	  io_52, NULL, test_case_teardown},
+	{ "IO53: collective object query - OC_SX",
+	  io_53, async_disable, test_case_teardown},
+	{ "IO54: collective object query - OC_EC_2P1G2",
+	  io_54, async_disable, test_case_teardown},
+	{ "IO55: collective object query - OC_EC_4P1GX",
+	  io_55, async_disable, test_case_teardown},
 };
 
 int


### PR DESCRIPTION
Currently, get file size (query key) for large-scaled object is very slow. Because DAOS does not has logic (metadata) center to store the file size. The client needs to send query RPCs to all related redundancy groups, then aggregate related query results. For EC object with parity rotation, it is worse, the client has to send query RPCs to all shards in every redundancy group. It will cause a lot of query RPCs. For large-scaled object (such as the "GX" object class), current method is too heavy loaded for both client and servers.

To resolve such bad situation, we introduce new mechanism: collective query. The basic idea is that: before sending query RPCs to related engines, based on the shards to be queried, the client will generate the bitmap for related VOS targets on each involved engine. For each engine with non-empty bitmap, the client only sends one OBJ_COLL_QUERY RPC to it, then the engine generates collective tasks (based on the bitmap) to query related object shards on each own local VOS targets. That can save many query RPCs if multiple VOS targets reside on relative concentrated engines.

On the other hand, it is inefficient for single client to send out hundreds or even thousands of query RPCs concurrently, that will cause a lot of DRAM resource being occupied for relative long time. To speedup, once the RPCs count exceeds some threshold, the client will ask some engine(s) to help to forward the collective query RPC to other related engine(s), and reply the aggregated query results to the client. From client perspective, forwarding causes one additional RPC round-trip, but it is better than single client handling hundreds or thousands of query RPCs by itself.

{cli,srv}_obj.c are too large to be read, split collective operation related logic from them into {cli,srv}_coll.c for help reading.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
