### PR TITLE
DAOS-14353 object: check permission before retry (#13451)

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2392,14 +2392,14 @@ obj_ioc_begin(daos_obj_id_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 	if (rc != 0)
 		return rc;
 
-	rc = obj_inflight_io_check(ioc->ioc_coc, opc, flags);
-	if (rc != 0)
-		goto failed;
-
 	rc = obj_capa_check(ioc->ioc_coh, obj_is_modification_opc(opc),
 			    obj_is_ec_agg_opc(opc) ||
 			    (flags & ORF_FOR_MIGRATION) ||
 			    (flags & ORF_FOR_EC_AGG));
+	if (rc != 0)
+		goto failed;
+
+	rc = obj_inflight_io_check(ioc->ioc_coc, opc, flags);
 	if (rc != 0)
 		goto failed;
 

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2399,15 +2399,12 @@ co_rf_simple(void **state)
 	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_HEALTHY);
 
 	if (arg->myrank == 0) {
-		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC,
-				      DAOS_REBUILD_DELAY | DAOS_FAIL_ALWAYS,
-				      0, NULL);
-		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
-				      arg->group, 5, -1);
-		assert_success(rc);
-		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
-				      arg->group, 4, -1);
-		assert_success(rc);
+		unsigned int ranks[2];
+
+		ranks[0] = 5;
+		ranks[1] = 4;
+		arg->no_rebuild = 1;
+		rebuild_pools_ranks(&arg, 1, ranks, 2, false);
 	}
 	par_barrier(PAR_COMM_WORLD);
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
@@ -2421,6 +2418,8 @@ co_rf_simple(void **state)
 	rc = daos_cont_close(coh, NULL);
 	assert_rc_equal(rc, 0);
 
+	/* Hang the rebuild */
+	test_set_engine_fail_loc(arg, CRT_NO_RANK, DAOS_REBUILD_TGT_REBUILD_HANG | DAOS_FAIL_ALWAYS);
 	/* IO testing */
 	io_oid = daos_test_oid_gen(arg->coh, OC_RP_4G1, 0, 0, arg->myrank);
 	rc = daos_obj_open(arg->coh, io_oid, DAOS_OO_RW, &io_oh, NULL);
@@ -2445,8 +2444,8 @@ co_rf_simple(void **state)
 	assert_rc_equal(rc, 0);
 
 	if (arg->myrank == 0) {
-		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
-				      arg->group, 3, -1);
+		arg->no_rebuild = 1;
+		rebuild_single_pool_rank(arg, 3, false);
 		assert_success(rc);
 	}
 	par_barrier(PAR_COMM_WORLD);
@@ -2468,18 +2467,17 @@ co_rf_simple(void **state)
 	assert_rc_equal(rc, -DER_RF);
 
 	if (arg->myrank == 0) {
-		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+		unsigned int ranks[3];
+
+		arg->no_rebuild = 0;
+		print_message("sleep 10 seconds for rebuild resume and wait\n");
+		sleep(10);
 		test_rebuild_wait(&arg, 1);
-		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
-					  3, -1);
-		assert_success(rc);
-		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
-					  4, -1);
-		assert_success(rc);
-		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
-					  5, -1);
-		assert_success(rc);
-		test_rebuild_wait(&arg, 1);
+		ranks[0] = 3;
+		ranks[1] = 4;
+		ranks[2] = 5;
+
+		reintegrate_pools_ranks(&arg, 1, ranks, 3, false);
 	}
 	par_barrier(PAR_COMM_WORLD);
 
@@ -2685,7 +2683,7 @@ nrank_per_node_get(struct pool_map *poolmap)
 }
 
 static int
-ranks_on_same_node(struct pool_map *poolmap, int src_rank, int *ranks)
+ranks_on_same_node(struct pool_map *poolmap, int src_rank, d_rank_t *ranks)
 {
 	struct pool_domain	*node_doms;
 	struct pool_domain	*rank_doms;
@@ -2745,7 +2743,7 @@ co_redun_lvl(void **state)
 	daos_iod_t		 iod;
 	daos_recx_t		 recx;
 	int			 nrank_per_node, ndom;
-	int			 ranks[3];
+	d_rank_t		 ranks[3];
 	int			 i, rc;
 
 	if (!test_runable(arg0, 8))
@@ -2831,15 +2829,10 @@ co_redun_lvl(void **state)
 	 * should not cause RF broken.
 	 */
 	if (arg->myrank == 0) {
-		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC,
-				      DAOS_REBUILD_DELAY | DAOS_FAIL_ALWAYS, 0, NULL);
-		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
-				      ranks[0], -1);
-		assert_success(rc);
-		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid, arg->group,
-				      ranks[1], -1);
-		assert_success(rc);
+		arg->no_rebuild = 1;
+		rebuild_pools_ranks(&arg, 1, ranks, 2, false);
 	}
+
 	par_barrier(PAR_COMM_WORLD);
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
 	assert_rc_equal(rc, 0);
@@ -2875,6 +2868,7 @@ co_redun_lvl(void **state)
 		assert_rc_equal(rc, -DER_INVAL);
 	}
 
+	test_set_engine_fail_loc(arg, CRT_NO_RANK, DAOS_REBUILD_TGT_REBUILD_HANG | DAOS_FAIL_ALWAYS);
 	print_message("obj update should success before RF broken\n");
 	io_oid = daos_test_oid_gen(arg->coh, OC_EC_2P2G1, 0, 0, arg->myrank);
 	rc = daos_obj_open(arg->coh, io_oid, DAOS_OO_RW, &io_oh, NULL);
@@ -2885,17 +2879,15 @@ co_redun_lvl(void **state)
 	assert_rc_equal(rc, 0);
 
 	/* exclude one more rank on another NODE dom */
-	if (arg->myrank == 0) {
-		rc = dmg_pool_exclude(arg->dmg_config, arg->pool.pool_uuid,
-				      arg->group, ranks[2], -1);
-		assert_success(rc);
-	}
+	if (arg->myrank == 0)
+		rebuild_single_pool_rank(arg, ranks[2], false);
 
 	par_barrier(PAR_COMM_WORLD);
 	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
 	assert_rc_equal(rc, 0);
 	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
 	daos_prop_val_2_co_status(entry->dpe_val, &stat);
+
 	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_UNCLEAN);
 	rc = daos_cont_open(arg->pool.poh, arg->co_str, arg->cont_open_flags, &coh, NULL, NULL);
 	assert_rc_equal(rc, -DER_RF);
@@ -2907,19 +2899,13 @@ co_redun_lvl(void **state)
 	assert_rc_equal(rc, -DER_RF);
 
 	if (arg->myrank == 0) {
-		daos_debug_set_params(NULL, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
+		arg->no_rebuild = 0;
+		print_message("sleep 10 seconds for rebuild resume and wait\n");
+		sleep(10);
 		test_rebuild_wait(&arg, 1);
-		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
-					  ranks[2], -1);
-		assert_success(rc);
-		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
-					  ranks[1], -1);
-		assert_success(rc);
-		rc = dmg_pool_reintegrate(arg->dmg_config, arg->pool.pool_uuid, arg->group,
-					  ranks[0], -1);
-		assert_success(rc);
-		test_rebuild_wait(&arg, 1);
+		reintegrate_pools_ranks(&arg, 1, ranks, 3, false);
 	}
+
 	par_barrier(PAR_COMM_WORLD);
 
 	print_message("obj update should still fail with DER_RF after re-integrate\n");


### PR DESCRIPTION
Check RF and other performance before retry check, so non-allowed write should return failuer immediately, instead of retrying endless.

Use rebuild/reintegrate_pool_rank in daos_container test to avoid DER_BUSY failure.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
