### PR TITLE
DAOS-14532 gurt: fix environment APIs hook

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -291,11 +291,12 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 	nvme_glb.bd_bs_opts.cluster_sz = DAOS_BS_CLUSTER_SZ;
 	nvme_glb.bd_bs_opts.max_channel_ops = BIO_BS_MAX_CHANNEL_OPS;
 
-	env = getenv("VOS_BDEV_CLASS");
+	d_agetenv_str(&env, "VOS_BDEV_CLASS");
 	if (env && strcasecmp(env, "AIO") == 0) {
 		D_WARN("AIO device(s) will be used!\n");
 		nvme_glb.bd_bdev_class = BDEV_CLASS_AIO;
 	}
+	d_free_env_str(&env);
 
 	if (numa_node > 0) {
 		bio_numa_node = (unsigned int)numa_node;

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -296,7 +296,7 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 		D_WARN("AIO device(s) will be used!\n");
 		nvme_glb.bd_bdev_class = BDEV_CLASS_AIO;
 	}
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 
 	if (numa_node > 0) {
 		bio_numa_node = (unsigned int)numa_node;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -793,8 +793,7 @@ crt_hg_free_protocol_info(struct na_protocol_info *na_protocol_info)
 int
 crt_hg_init(void)
 {
-	int	rc = 0;
-	char	*env;
+	int rc = 0;
 
 	if (crt_initialized()) {
 		D_ERROR("CaRT already initialized.\n");
@@ -803,10 +802,8 @@ crt_hg_init(void)
 
 	#define EXT_FAC DD_FAC(external)
 
-	env = getenv("HG_LOG_SUBSYS");
-	if (!env) {
-		env = getenv("HG_LOG_LEVEL");
-		if (!env)
+	if (!d_isenv_def("HG_LOG_SUBSYS")) {
+		if (!d_isenv_def("HG_LOG_LEVEL"))
 			HG_Set_log_level("warning");
 		HG_Set_log_subsys("hg,na");
 	}

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -100,11 +100,12 @@ crt_lib_fini(void)
 static void
 dump_envariables(void)
 {
-	int   i;
-	char *val;
+	int i;
 
 	D_INFO("-- ENVARS: --\n");
 	for (i = 0; i < ARRAY_SIZE(crt_env_names); i++) {
+		char *val = NULL;
+
 		d_agetenv_str(&val, crt_env_names[i]);
 		if (val == NULL)
 			continue;

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -110,7 +110,7 @@ dump_envariables(void)
 			D_INFO("%s = %s\n", var_names[i], "********");
 		else
 			D_INFO("%s = %s\n", var_names[i], val);
-		d_free_env_str(&val);
+		d_freeenv_str(&val);
 	}
 }
 
@@ -693,7 +693,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 			else
 				D_DEBUG(DB_ALL, "set group_config_path as %s.\n", path);
 		}
-		d_free_env_str(&path);
+		d_freeenv_str(&path);
 
 		if (opt && opt->cio_auth_key)
 			D_STRNDUP(auth_key_env, opt->cio_auth_key, strlen(opt->cio_auth_key));
@@ -896,11 +896,11 @@ out:
 	D_FREE(domain0);
 	D_FREE(provider_str0);
 	D_FREE(auth_key0);
-	d_free_env_str(&port_str);
-	d_free_env_str(&domain_env);
-	d_free_env_str(&interface_env);
-	d_free_env_str(&provider_env);
-	d_free_env_str(&auth_key_env);
+	d_freeenv_str(&port_str);
+	d_freeenv_str(&domain_env);
+	d_freeenv_str(&interface_env);
+	d_freeenv_str(&provider_env);
+	d_freeenv_str(&auth_key_env);
 
 	if (rc != 0) {
 		D_ERROR("failed, "DF_RC"\n", DP_RC(rc));

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -19,42 +19,42 @@ struct crt_plugin_gdata crt_plugin_gdata;
 static bool		g_prov_settings_applied[CRT_PROV_COUNT];
 
 /* List of the environment variables used in CaRT */
-static const char *crt_env_names[] = {"D_PROVIDER",
-				      "D_INTERFACE",
-				      "D_DOMAIN",
-				      "D_PORT",
-				      "CRT_PHY_ADDR_STR",
-				      "D_LOG_STDERR_IN_LOG",
-				      "D_LOG_SIZE",
-				      "D_LOG_FILE",
-				      "D_LOG_FILE_APPEND_PID",
-				      "D_LOG_MASK",
-				      "DD_MASK",
-				      "DD_STDERR",
-				      "DD_SUBSYS",
-				      "CRT_TIMEOUT",
-				      "CRT_ATTACH_INFO_PATH",
-				      "OFI_PORT",
-				      "OFI_INTERFACE",
-				      "OFI_DOMAIN",
-				      "CRT_CREDIT_EP_CTX",
-				      "CRT_CTX_SHARE_ADDR",
-				      "CRT_CTX_NUM",
-				      "D_FI_CONFIG",
-				      "FI_UNIVERSE_SIZE",
-				      "CRT_ENABLE_MEM_PIN",
-				      "FI_OFI_RXM_USE_SRX",
-				      "D_LOG_FLUSH",
-				      "CRT_MRC_ENABLE",
-				      "CRT_SECONDARY_PROVIDER",
-				      "D_PROVIDER_AUTH_KEY",
-				      "D_PORT_AUTO_ADJUST",
-				      "D_POLL_TIMEOUT",
-				      "D_LOG_FILE_APPEND_RANK",
-				      "D_QUOTA_RPCS",
-				      "D_POST_INIT",
-				      "D_POST_INCR",
-				      "DAOS_SIGNAL_REGISTER"};
+static const char      *crt_env_names[] = {"D_PROVIDER",
+					   "D_INTERFACE",
+					   "D_DOMAIN",
+					   "D_PORT",
+					   "CRT_PHY_ADDR_STR",
+					   "D_LOG_STDERR_IN_LOG",
+					   "D_LOG_SIZE",
+					   "D_LOG_FILE",
+					   "D_LOG_FILE_APPEND_PID",
+					   "D_LOG_MASK",
+					   "DD_MASK",
+					   "DD_STDERR",
+					   "DD_SUBSYS",
+					   "CRT_TIMEOUT",
+					   "CRT_ATTACH_INFO_PATH",
+					   "OFI_PORT",
+					   "OFI_INTERFACE",
+					   "OFI_DOMAIN",
+					   "CRT_CREDIT_EP_CTX",
+					   "CRT_CTX_SHARE_ADDR",
+					   "CRT_CTX_NUM",
+					   "D_FI_CONFIG",
+					   "FI_UNIVERSE_SIZE",
+					   "CRT_ENABLE_MEM_PIN",
+					   "FI_OFI_RXM_USE_SRX",
+					   "D_LOG_FLUSH",
+					   "CRT_MRC_ENABLE",
+					   "CRT_SECONDARY_PROVIDER",
+					   "D_PROVIDER_AUTH_KEY",
+					   "D_PORT_AUTO_ADJUST",
+					   "D_POLL_TIMEOUT",
+					   "D_LOG_FILE_APPEND_RANK",
+					   "D_QUOTA_RPCS",
+					   "D_POST_INIT",
+					   "D_POST_INCR",
+					   "DAOS_SIGNAL_REGISTER"};
 
 static void
 crt_lib_init(void) __attribute__((__constructor__));
@@ -100,8 +100,8 @@ crt_lib_fini(void)
 static void
 dump_envariables(void)
 {
-	int                i;
-	char              *val;
+	int   i;
+	char *val;
 
 	D_INFO("-- ENVARS: --\n");
 	for (i = 0; i < ARRAY_SIZE(crt_env_names); i++) {

--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -413,15 +413,15 @@ err_group:
 int
 crtu_dc_mgmt_net_cfg_setenv(const char *name)
 {
-	int			 rc;
+	int                      rc;
 	char                    *crt_phy_addr_str;
 	char                    *crt_ctx_share_addr = NULL;
-	char			*cli_srx_set        = NULL;
-	char			*crt_timeout        = NULL;
-	char			*ofi_interface;
-	char			*ofi_interface_env = NULL;
-	char			*ofi_domain;
-	char			*ofi_domain_env   = NULL;
+	char                    *cli_srx_set        = NULL;
+	char                    *crt_timeout        = NULL;
+	char                    *ofi_interface;
+	char                    *ofi_interface_env = NULL;
+	char                    *ofi_domain;
+	char                    *ofi_domain_env   = NULL;
 	struct dc_mgmt_sys_info  crt_net_cfg_info = {0};
 	Mgmt__GetAttachInfoResp *crt_net_cfg_resp = NULL;
 
@@ -465,8 +465,7 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 
-		D_DEBUG(DB_MGMT, "Using server's value for FI_OFI_RXM_USE_SRX: %s\n",
-			cli_srx_set);
+		D_DEBUG(DB_MGMT, "Using server's value for FI_OFI_RXM_USE_SRX: %s\n", cli_srx_set);
 	} else {
 		/* Client may not set it if the server hasn't. */
 		d_agetenv_str(&cli_srx_set, "FI_OFI_RXM_USE_SRX");

--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -101,11 +101,12 @@ write_completion_file(void)
 	char	*dir;
 	char	*completion_file = NULL;
 
-	dir = getenv("DAOS_TEST_SHARED_DIR");
+	d_agetenv_str(&dir, "DAOS_TEST_SHARED_DIR");
 	D_ASSERTF(dir != NULL,
 		"DAOS_TEST_SHARED_DIR must be set for --write_completion_file "
 		"option.\n");
 	D_ASPRINTF(completion_file, "%s/test-servers-completed.txt.%d", dir, getpid());
+	d_free_env_str(&dir);
 	D_ASSERTF(completion_file != NULL, "Error allocating completion_file string\n");
 
 	unlink(completion_file);
@@ -409,6 +410,46 @@ err_group:
 	return rc;
 }
 
+static inline void
+crtu_dc_mgmt_net_print_env(void)
+{
+	static const char *var_names[] = {"OFI_INTERFACE", "OFI_DOMAIN", "CRT_PHY_ADDR_STR",
+					  "CRT_CTX_SHARE_ADDR", "CRT_TIMEOUT"};
+	int                idx;
+	char              *env;
+	char              *msg;
+	int                rc;
+
+	rc = d_agetenv_str(&env, var_names[0]);
+	D_ASSERTF(env != NULL, "Can not retrieve environment varirable %s: " DF_RC "\n",
+		  var_names[0], DP_RC(rc));
+	D_ASPRINTF(msg, "CaRT env setup with:\n\t%s=%s", var_names[0], env);
+	d_free_env_str(&env);
+	if (msg == NULL) {
+		D_INFO("Error allocating CaRT env setup message");
+		return;
+	}
+
+	for (idx = 1; idx < sizeof(var_names) / sizeof(char *); ++idx) {
+		char *tmp = msg;
+
+		rc = d_agetenv_str(&env, var_names[idx]);
+		D_ASSERTF(env != NULL, "Can not retrieve environment varirable %s: " DF_RC "\n",
+			  var_names[idx], DP_RC(rc));
+
+		D_ASPRINTF(msg, "%s, %s=%s", tmp, var_names[idx], env);
+		d_free_env_str(&env);
+		D_FREE(tmp);
+		if (msg == NULL) {
+			D_INFO("Error allocating CaRT env setup message");
+			return;
+		}
+	}
+
+	D_INFO("%s", msg);
+	D_FREE(msg);
+}
+
 int
 crtu_dc_mgmt_net_cfg_setenv(const char *name)
 {
@@ -455,16 +496,17 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 		D_DEBUG(DB_MGMT, "Using server's value for FI_OFI_RXM_USE_SRX: %s\n", buf);
 	} else {
 		/* Client may not set it if the server hasn't. */
-		cli_srx_set = getenv("FI_OFI_RXM_USE_SRX");
+		d_agetenv_str(&cli_srx_set, "FI_OFI_RXM_USE_SRX");
 		if (cli_srx_set) {
 			D_ERROR("Client set FI_OFI_RXM_USE_SRX to %s, "
 				"but server is unset!\n", cli_srx_set);
+			d_free_env_str(&cli_srx_set);
 			D_GOTO(cleanup, rc = -DER_INVAL);
 		}
 	}
 
 	/* Allow client env overrides for these three */
-	crt_timeout = getenv("CRT_TIMEOUT");
+	d_agetenv_str(&crt_timeout, "CRT_TIMEOUT");
 	if (!crt_timeout) {
 		sprintf(buf, "%d", crt_net_cfg_info.crt_timeout);
 		rc = d_setenv("CRT_TIMEOUT", buf, 1);
@@ -473,9 +515,10 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 	} else {
 		D_DEBUG(DB_MGMT, "Using client provided CRT_TIMEOUT: %s\n", crt_timeout);
+		d_free_env_str(&crt_timeout);
 	}
 
-	ofi_interface = getenv("OFI_INTERFACE");
+	d_agetenv_str(&ofi_interface, "OFI_INTERFACE");
 	if (!ofi_interface) {
 		rc = d_setenv("OFI_INTERFACE", crt_net_cfg_info.interface, 1);
 		D_INFO("Setting OFI_INTERFACE=%s\n", crt_net_cfg_info.interface);
@@ -485,9 +528,10 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 		D_DEBUG(DB_MGMT,
 			"Using client provided OFI_INTERFACE: %s\n",
 			ofi_interface);
+		d_free_env_str(&ofi_interface);
 	}
 
-	ofi_domain = getenv("OFI_DOMAIN");
+	d_agetenv_str(&ofi_domain, "OFI_DOMAIN");
 	if (!ofi_domain) {
 		rc = d_setenv("OFI_DOMAIN", crt_net_cfg_info.domain, 1);
 		D_INFO("Setting OFI_DOMAIN=%s\n", crt_net_cfg_info.domain);
@@ -495,14 +539,10 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 	} else {
 		D_DEBUG(DB_MGMT, "Using client provided OFI_DOMAIN: %s\n", ofi_domain);
+		d_free_env_str(&ofi_domain);
 	}
 
-	D_INFO("CaRT env setup with:\n"
-		"\tOFI_INTERFACE=%s, OFI_DOMAIN: %s, CRT_PHY_ADDR_STR: %s, "
-		"CRT_CTX_SHARE_ADDR: %s, CRT_TIMEOUT: %s\n",
-		getenv("OFI_INTERFACE"), getenv("OFI_DOMAIN"),
-		getenv("CRT_PHY_ADDR_STR"),
-		getenv("CRT_CTX_SHARE_ADDR"), getenv("CRT_TIMEOUT"));
+	crtu_dc_mgmt_net_print_env();
 
 cleanup:
 	dc_put_attach_info(&crt_net_cfg_info, crt_net_cfg_resp);
@@ -575,7 +615,7 @@ crtu_cli_start_basic(char *local_group_name, char *srv_group_name,
 			if (*grp == NULL)
 				D_GOTO(out, rc = -DER_INVAL);
 
-			grp_cfg_file = getenv("CRT_L_GRP_CFG");
+			d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 
 			/* load group info from a config file and
 			 * delete file upon return
@@ -583,6 +623,7 @@ crtu_cli_start_basic(char *local_group_name, char *srv_group_name,
 			rc = crtu_load_group_from_file(grp_cfg_file,
 						       *crt_ctx, *grp,
 						       -1, true);
+			d_free_env_str(&grp_cfg_file);
 			if (rc != 0)
 				D_GOTO(out, rc);
 		}
@@ -644,7 +685,6 @@ crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx,
 		     pthread_t *progress_thread, crt_group_t **grp,
 		     uint32_t *grp_size, crt_init_options_t *init_opt)
 {
-	char		*env_self_rank;
 	char		*grp_cfg_file;
 	char		*my_uri;
 	d_rank_t	 my_rank;
@@ -653,8 +693,8 @@ crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx,
 	if (opts.assert_on_error)
 		D_ASSERTF(opts.is_initialized == true, "crtu_test_init not called.\n");
 
-	env_self_rank = getenv("CRT_L_RANK");
-	my_rank = atoi(env_self_rank);
+	rc = d_getenv_uint32_t("CRT_L_RANK", &my_rank);
+	D_ASSERTF(rc == DER_SUCCESS, "Rank can not be retrieve: " DF_RC "\n", DP_RC(rc));
 
 	rc = d_log_init();
 	if (rc != 0)
@@ -695,18 +735,18 @@ crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx,
 			D_GOTO(out, rc);
 	}
 
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
-
 	rc = crt_rank_uri_get(*grp, my_rank, 0, &my_uri);
 	if (rc != 0)
 		D_GOTO(out, rc);
+	D_FREE(my_uri);
+
+	rc = d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 
 	/* load group info from a config file and delete file upon return */
 	rc = crtu_load_group_from_file(grp_cfg_file, crt_ctx[0], *grp, my_rank, true);
+	d_free_env_str(&grp_cfg_file);
 	if (rc != 0)
 		D_GOTO(out, rc);
-
-	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, grp_size);
 	if (rc != 0)

--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -106,7 +106,7 @@ write_completion_file(void)
 		"DAOS_TEST_SHARED_DIR must be set for --write_completion_file "
 		"option.\n");
 	D_ASPRINTF(completion_file, "%s/test-servers-completed.txt.%d", dir, getpid());
-	d_free_env_str(&dir);
+	d_freeenv_str(&dir);
 	D_ASSERTF(completion_file != NULL, "Error allocating completion_file string\n");
 
 	unlink(completion_file);
@@ -424,7 +424,7 @@ crtu_dc_mgmt_net_print_env(void)
 	D_ASSERTF(env != NULL, "Can not retrieve environment varirable %s: " DF_RC "\n",
 		  var_names[0], DP_RC(rc));
 	D_ASPRINTF(msg, "CaRT env setup with:\n\t%s=%s", var_names[0], env);
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 	if (msg == NULL) {
 		D_INFO("Error allocating CaRT env setup message");
 		return;
@@ -438,7 +438,7 @@ crtu_dc_mgmt_net_print_env(void)
 			  var_names[idx], DP_RC(rc));
 
 		D_ASPRINTF(msg, "%s, %s=%s", tmp, var_names[idx], env);
-		d_free_env_str(&env);
+		d_freeenv_str(&env);
 		D_FREE(tmp);
 		if (msg == NULL) {
 			D_INFO("Error allocating CaRT env setup message");
@@ -500,7 +500,7 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 		if (cli_srx_set) {
 			D_ERROR("Client set FI_OFI_RXM_USE_SRX to %s, "
 				"but server is unset!\n", cli_srx_set);
-			d_free_env_str(&cli_srx_set);
+			d_freeenv_str(&cli_srx_set);
 			D_GOTO(cleanup, rc = -DER_INVAL);
 		}
 	}
@@ -515,7 +515,7 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 	} else {
 		D_DEBUG(DB_MGMT, "Using client provided CRT_TIMEOUT: %s\n", crt_timeout);
-		d_free_env_str(&crt_timeout);
+		d_freeenv_str(&crt_timeout);
 	}
 
 	d_agetenv_str(&ofi_interface, "OFI_INTERFACE");
@@ -528,7 +528,7 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 		D_DEBUG(DB_MGMT,
 			"Using client provided OFI_INTERFACE: %s\n",
 			ofi_interface);
-		d_free_env_str(&ofi_interface);
+		d_freeenv_str(&ofi_interface);
 	}
 
 	d_agetenv_str(&ofi_domain, "OFI_DOMAIN");
@@ -539,7 +539,7 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 	} else {
 		D_DEBUG(DB_MGMT, "Using client provided OFI_DOMAIN: %s\n", ofi_domain);
-		d_free_env_str(&ofi_domain);
+		d_freeenv_str(&ofi_domain);
 	}
 
 	crtu_dc_mgmt_net_print_env();
@@ -623,7 +623,7 @@ crtu_cli_start_basic(char *local_group_name, char *srv_group_name,
 			rc = crtu_load_group_from_file(grp_cfg_file,
 						       *crt_ctx, *grp,
 						       -1, true);
-			d_free_env_str(&grp_cfg_file);
+			d_freeenv_str(&grp_cfg_file);
 			if (rc != 0)
 				D_GOTO(out, rc);
 		}
@@ -744,7 +744,7 @@ crtu_srv_start_basic(char *srv_group_name, crt_context_t *crt_ctx,
 
 	/* load group info from a config file and delete file upon return */
 	rc = crtu_load_group_from_file(grp_cfg_file, crt_ctx[0], *grp, my_rank, true);
-	d_free_env_str(&grp_cfg_file);
+	d_freeenv_str(&grp_cfg_file);
 	if (rc != 0)
 		D_GOTO(out, rc);
 

--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -519,9 +519,9 @@ crtu_dc_mgmt_net_cfg_setenv(const char *name)
 	}
 
 	D_INFO("CaRT env setup with:\n"
-		"\tOFI_INTERFACE=%s, OFI_DOMAIN: %s, CRT_PHY_ADDR_STR: %s, "
-		"CRT_CTX_SHARE_ADDR: %s, CRT_TIMEOUT: %s\n",
-		ofi_interface, ofi_domain, crt_phy_addr_str, crt_ctx_share_addr, crt_timeout);
+	       "\tOFI_INTERFACE=%s, OFI_DOMAIN: %s, CRT_PHY_ADDR_STR: %s, "
+	       "CRT_CTX_SHARE_ADDR: %s, CRT_TIMEOUT: %s\n",
+	       ofi_interface, ofi_domain, crt_phy_addr_str, crt_ctx_share_addr, crt_timeout);
 
 cleanup:
 	d_freeenv_str(&ofi_domain_env);

--- a/src/client/api/agent.c
+++ b/src/client/api/agent.c
@@ -21,7 +21,7 @@ dc_agent_init()
 				DAOS_AGENT_DRPC_SOCK_NAME);
 	else
 		D_STRNDUP_S(path, DEFAULT_DAOS_AGENT_DRPC_SOCK);
-	d_free_env_str(&envpath);
+	d_freeenv_str(&envpath);
 
 	if (path == NULL)
 		return -DER_NOMEM;

--- a/src/client/api/agent.c
+++ b/src/client/api/agent.c
@@ -12,14 +12,16 @@ char *dc_agent_sockpath;
 int
 dc_agent_init()
 {
-	char	*path = NULL;
-	char	*envpath = getenv(DAOS_AGENT_DRPC_DIR_ENV);
+	char *path = NULL;
+	char *envpath;
 
-	if (envpath)
+	d_agetenv_str(&envpath, DAOS_AGENT_DRPC_DIR_ENV);
+	if (envpath != NULL)
 		D_ASPRINTF(path, "%s/%s", envpath,
 				DAOS_AGENT_DRPC_SOCK_NAME);
 	else
 		D_STRNDUP_S(path, DEFAULT_DAOS_AGENT_DRPC_SOCK);
+	d_free_env_str(&envpath);
 
 	if (path == NULL)
 		return -DER_NOMEM;

--- a/src/client/api/job.c
+++ b/src/client/api/job.c
@@ -47,7 +47,7 @@ dc_job_init(void)
 		char *tmp_env = jobid_env;
 
 		D_STRNDUP(jobid_env, tmp_env, MAX_ENV_NAME);
-		d_free_env_str(&tmp_env);
+		d_freeenv_str(&tmp_env);
 	}
 	if (jobid_env == NULL)
 		D_GOTO(out_err, err = -DER_NOMEM);
@@ -63,7 +63,7 @@ dc_job_init(void)
 		char *tmp_jobid = jobid;
 
 		D_STRNDUP(jobid, tmp_jobid, MAX_JOBID_LEN);
-		d_free_env_str(&tmp_jobid);
+		d_freeenv_str(&tmp_jobid);
 		if (jobid == NULL)
 			D_GOTO(out_env, err = -DER_NOMEM);
 	}

--- a/src/client/api/job.c
+++ b/src/client/api/job.c
@@ -37,22 +37,24 @@ int
 dc_job_init(void)
 {
 	char *jobid;
-	char *jobid_env = getenv(JOBID_ENV);
+	char *jobid_env;
 	int   err = 0;
 
+	d_agetenv_str(&jobid_env, JOBID_ENV);
 	if (jobid_env == NULL) {
 		D_STRNDUP_S(jobid_env, DEFAULT_JOBID_ENV);
 	} else {
 		char *tmp_env = jobid_env;
 
 		D_STRNDUP(jobid_env, tmp_env, MAX_ENV_NAME);
+		d_free_env_str(&tmp_env);
 	}
 	if (jobid_env == NULL)
 		D_GOTO(out_err, err = -DER_NOMEM);
 
 	dc_jobid_env = jobid_env;
 
-	jobid = getenv(dc_jobid_env);
+	d_agetenv_str(&jobid, dc_jobid_env);
 	if (jobid == NULL) {
 		err = craft_default_jobid(&jobid);
 		if (err)
@@ -61,6 +63,7 @@ dc_job_init(void)
 		char *tmp_jobid = jobid;
 
 		D_STRNDUP(jobid, tmp_jobid, MAX_JOBID_LEN);
+		d_free_env_str(&tmp_jobid);
 		if (jobid == NULL)
 			D_GOTO(out_env, err = -DER_NOMEM);
 	}

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -521,7 +521,7 @@ main(int argc, char **argv)
 		}
 	}
 
-	if (!dfuse_info->di_foreground && getenv("PMIX_RANK")) {
+	if (!dfuse_info->di_foreground && d_isenv_def("PMIX_RANK")) {
 		DFUSE_TRA_WARNING(dfuse_info,
 				  "Not running in background under orterun");
 		dfuse_info->di_foreground = true;

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -681,9 +681,9 @@ free_pool:
 free_fs_root:
 	D_FREE(dfs_list[num_dfs].fs_root);
 out:
-	d_free_env_str(&container);
-	d_free_env_str(&pool);
-	d_free_env_str(&fs_root);
+	d_freeenv_str(&container);
+	d_freeenv_str(&pool);
+	d_freeenv_str(&fs_root);
 	return rc;
 }
 
@@ -5546,7 +5546,7 @@ init_myhook(void)
 		report = true;
 		if (strncmp(env_log, "0", 2) == 0 || strncasecmp(env_log, "false", 6) == 0)
 			report = false;
-		d_free_env_str(&env_log);
+		d_freeenv_str(&env_log);
 	}
 
 	/* Find dfuse mounts from /proc/mounts */

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -600,13 +600,14 @@ query_dfs_mount(const char *path)
 static int
 discover_daos_mount_with_env(void)
 {
-	int   idx, len_fs_root, rc;
-	char *fs_root   = NULL;
-	char *pool      = NULL;
-	char *container = NULL;
+	int    idx, rc;
+	char  *fs_root   = NULL;
+	char  *pool      = NULL;
+	char  *container = NULL;
+	size_t len_fs_root, len_pool, len_container;
 
 	/* Add the mount if env DAOS_MOUNT_POINT is set. */
-	fs_root = getenv("DAOS_MOUNT_POINT");
+	rc = d_agetenv_str(&fs_root, "DAOS_MOUNT_POINT");
 	if (fs_root == NULL)
 		/* env DAOS_MOUNT_POINT is undefined, return success (0) */
 		D_GOTO(out, rc = 0);
@@ -633,31 +634,56 @@ discover_daos_mount_with_env(void)
 		D_GOTO(out, rc = ENAMETOOLONG);
 	}
 
-	pool = getenv("DAOS_POOL");
+	d_agetenv_str(&pool, "DAOS_POOL");
 	if (pool == NULL) {
 		D_FATAL("DAOS_POOL is not set.\n");
 		D_GOTO(out, rc = EINVAL);
 	}
 
-	container = getenv("DAOS_CONTAINER");
+	len_pool = strnlen(pool, DAOS_PROP_MAX_LABEL_BUF_LEN);
+	if (len_pool >= DAOS_PROP_MAX_LABEL_BUF_LEN) {
+		D_FATAL("DAOS_POOL is too long.\n");
+		D_GOTO(out, rc = ENAMETOOLONG);
+	}
+
+	rc = d_agetenv_str(&container, "DAOS_CONTAINER");
 	if (container == NULL) {
 		D_FATAL("DAOS_CONTAINER is not set.\n");
 		D_GOTO(out, rc = EINVAL);
+	}
+
+	len_container = strnlen(container, DAOS_PROP_MAX_LABEL_BUF_LEN);
+	if (len_container >= DAOS_PROP_MAX_LABEL_BUF_LEN) {
+		D_FATAL("DAOS_CONTAINER is too long.\n");
+		D_GOTO(out, rc = ENAMETOOLONG);
 	}
 
 	D_STRNDUP(dfs_list[num_dfs].fs_root, fs_root, len_fs_root);
 	if (dfs_list[num_dfs].fs_root == NULL)
 		D_GOTO(out, rc = ENOMEM);
 
-	dfs_list[num_dfs].pool         = pool;
-	dfs_list[num_dfs].cont         = container;
+	D_STRNDUP(dfs_list[num_dfs].pool, pool, len_pool);
+	if (dfs_list[num_dfs].pool == NULL)
+		D_GOTO(free_fs_root, rc = ENOMEM);
+
+	D_STRNDUP(dfs_list[num_dfs].cont, container, len_container);
+	if (dfs_list[num_dfs].cont == NULL)
+		D_GOTO(free_pool, rc = ENOMEM);
+
 	dfs_list[num_dfs].dfs_dir_hash = NULL;
-	dfs_list[num_dfs].len_fs_root  = len_fs_root;
+	dfs_list[num_dfs].len_fs_root  = (int)len_fs_root;
 	atomic_init(&dfs_list[num_dfs].inited, 0);
 	num_dfs++;
-	rc = 0;
+	D_GOTO(out, rc = 0);
 
+free_pool:
+	D_FREE(dfs_list[num_dfs].pool);
+free_fs_root:
+	D_FREE(dfs_list[num_dfs].fs_root);
 out:
+	d_free_env_str(&container);
+	d_free_env_str(&pool);
+	d_free_env_str(&fs_root);
 	return rc;
 }
 
@@ -5515,11 +5541,12 @@ init_myhook(void)
 	else
 		daos_debug_inited = true;
 
-	env_log = getenv("D_IL_REPORT");
+	d_agetenv_str(&env_log, "D_IL_REPORT");
 	if (env_log) {
 		report = true;
 		if (strncmp(env_log, "0", 2) == 0 || strncasecmp(env_log, "false", 6) == 0)
 			report = false;
+		d_free_env_str(&env_log);
 	}
 
 	/* Find dfuse mounts from /proc/mounts */
@@ -5804,6 +5831,8 @@ finalize_dfs(void)
 	for (i = 0; i < num_dfs; i++) {
 		if (dfs_list[i].dfs_dir_hash == NULL) {
 			D_FREE(dfs_list[i].fs_root);
+			D_FREE(dfs_list[i].pool);
+			D_FREE(dfs_list[i].cont);
 			continue;
 		}
 
@@ -5835,6 +5864,8 @@ finalize_dfs(void)
 			continue;
 		}
 		D_FREE(dfs_list[i].fs_root);
+		D_FREE(dfs_list[i].pool);
+		D_FREE(dfs_list[i].cont);
 	}
 
 	if (daos_inited) {

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -106,7 +106,7 @@ __shim_handle__daos_init(PyObject *self, PyObject *args)
 
 	rc = daos_init();
 	if ((rc == 0) && (use_glob_eq == 0)) {
-		override = getenv("PYDAOS_GLOB_EQ");
+		d_agetenv_str(&override, "PYDAOS_GLOB_EQ");
 		if ((override == NULL) || strcmp(override, "0")) {
 			use_glob_eq = 1;
 			ret = daos_eq_create(&glob_eq);
@@ -115,6 +115,7 @@ __shim_handle__daos_init(PyObject *self, PyObject *args)
 				use_glob_eq = 0;
 			}
 		}
+		d_free_env_str(&override);
 	}
 
 	return PyInt_FromLong(rc);

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -115,7 +115,7 @@ __shim_handle__daos_init(PyObject *self, PyObject *args)
 				use_glob_eq = 0;
 			}
 		}
-		d_free_env_str(&override);
+		d_freeenv_str(&override);
 	}
 
 	return PyInt_FromLong(rc);

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -131,7 +131,7 @@ io_bypass_init(void)
 		}
 		tok = str;
 	};
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 }
 
 void
@@ -168,15 +168,15 @@ daos_debug_init_ex(char *logfile, d_dbug_t logmask)
 	rc = d_agetenv_str(&logfile, D_LOG_FILE_ENV);
 	if (logfile == NULL || strlen(logfile) == 0) {
 		flags |= DLOG_FLV_STDOUT;
-		d_free_env_str(&logfile);
+		d_freeenv_str(&logfile);
 	} else if (!strncmp(logfile, "/dev/null", 9)) {
 		/* Don't set up logging or log to stdout if the log file is /dev/null */
-		d_free_env_str(&logfile);
+		d_freeenv_str(&logfile);
 	}
 
 	rc = d_log_init_adv("DAOS", logfile, flags, logmask, DLOG_CRIT,
 			    log_id_cb);
-	d_free_env_str(&logfile);
+	d_freeenv_str(&logfile);
 	if (rc != 0) {
 		D_PRINT_ERR("Failed to init DAOS debug log: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -104,14 +104,16 @@ unsigned int daos_io_bypass;
 static void
 io_bypass_init(void)
 {
-	char	*str = getenv(DENV_IO_BYPASS);
-	char	*tok;
-	char	*saved_ptr;
+	char *str;
+	char *tok;
+	char *saved_ptr;
+	char *env;
 
-	if (!str)
+	d_agetenv_str(&env, DENV_IO_BYPASS);
+	if (env == NULL)
 		return;
 
-	tok = strtok_r(str, ",", &saved_ptr);
+	tok = strtok_r(env, ",", &saved_ptr);
 	while (tok) {
 		struct io_bypass *iob;
 
@@ -129,6 +131,7 @@ io_bypass_init(void)
 		}
 		tok = str;
 	};
+	d_free_env_str(&env);
 }
 
 void
@@ -162,17 +165,18 @@ daos_debug_init_ex(char *logfile, d_dbug_t logmask)
 	}
 
 	/* honor the env variable first */
-	logfile = getenv(D_LOG_FILE_ENV);
+	rc = d_agetenv_str(&logfile, D_LOG_FILE_ENV);
 	if (logfile == NULL || strlen(logfile) == 0) {
 		flags |= DLOG_FLV_STDOUT;
-		logfile = NULL;
+		d_free_env_str(&logfile);
 	} else if (!strncmp(logfile, "/dev/null", 9)) {
 		/* Don't set up logging or log to stdout if the log file is /dev/null */
-		logfile = NULL;
+		d_free_env_str(&logfile);
 	}
 
 	rc = d_log_init_adv("DAOS", logfile, flags, logmask, DLOG_CRIT,
 			    log_id_cb);
+	d_free_env_str(&logfile);
 	if (rc != 0) {
 		D_PRINT_ERR("Failed to init DAOS debug log: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -684,13 +684,15 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 	 * 1) now sockets provider cannot create more than 16 contexts for SEP
 	 * 2) some problems if SEP communicates with regular EP.
 	 */
-	addr_env = (crt_phy_addr_t)getenv(CRT_PHY_ADDR_ENV);
+	d_agetenv_str(&addr_env, CRT_PHY_ADDR_ENV);
 	if (addr_env != NULL &&
 	    strncmp(addr_env, CRT_SOCKET_PROV, strlen(CRT_SOCKET_PROV)) == 0) {
 		D_INFO("for sockets provider force it to use regular EP.\n");
 		daos_crt_init_opt.cio_use_sep = 0;
+		d_free_env_str(&addr_env);
 		goto out;
 	}
+	d_free_env_str(&addr_env);
 
 	daos_crt_init_opt.cio_use_sep = 1;
 

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -689,10 +689,10 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 	    strncmp(addr_env, CRT_SOCKET_PROV, strlen(CRT_SOCKET_PROV)) == 0) {
 		D_INFO("for sockets provider force it to use regular EP.\n");
 		daos_crt_init_opt.cio_use_sep = 0;
-		d_free_env_str(&addr_env);
+		d_freeenv_str(&addr_env);
 		goto out;
 	}
-	d_free_env_str(&addr_env);
+	d_freeenv_str(&addr_env);
 
 	daos_crt_init_opt.cio_use_sep = 1;
 

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -432,14 +432,15 @@ dss_init_state_set(enum dss_init_state state)
 static int
 abt_max_num_xstreams(void)
 {
-	char   *env;
+	unsigned num_xstreams = 0;
 
-	env = getenv("ABT_MAX_NUM_XSTREAMS");
-	if (env == NULL)
-		env = getenv("ABT_ENV_MAX_NUM_XSTREAMS");
-	if (env != NULL)
-		return atoi(env);
-	return 0;
+	if (d_isenv_def("ABT_MAX_NUM_XSTREAMS"))
+		d_getenv_uint("ABT_MAX_NUM_XSTREAMS", &num_xstreams);
+	else
+		d_getenv_uint("ABT_ENV_MAX_NUM_XSTREAMS", &num_xstreams);
+	D_ASSERT(num_xstreams <= INT_MAX);
+
+	return num_xstreams;
 }
 
 static int

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1055,7 +1055,7 @@ dss_xstreams_init(void)
 			D_WARN("Invalid relax mode [%s]\n", env);
 			sched_relax_mode = SCHED_RELAX_MODE_NET;
 		}
-		d_free_env_str(&env);
+		d_freeenv_str(&env);
 	}
 	D_INFO("CPU relax mode is set to [%s]\n",
 	       sched_relax_mode2str(sched_relax_mode));

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1048,13 +1048,14 @@ dss_xstreams_init(void)
 		       sched_relax_intvl);
 	}
 
-	env = getenv("DAOS_SCHED_RELAX_MODE");
+	d_agetenv_str(&env, "DAOS_SCHED_RELAX_MODE");
 	if (env) {
 		sched_relax_mode = sched_relax_str2mode(env);
 		if (sched_relax_mode == SCHED_RELAX_MODE_INVALID) {
 			D_WARN("Invalid relax mode [%s]\n", env);
 			sched_relax_mode = SCHED_RELAX_MODE_NET;
 		}
+		d_free_env_str(&env);
 	}
 	D_INFO("CPU relax mode is set to [%s]\n",
 	       sched_relax_mode2str(sched_relax_mode));

--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -395,7 +395,7 @@ debug_prio_err_load_env(void)
 	/* invalid DD_STDERR option */
 	if (d_dbglog_data.dd_prio_err == 0)
 		D_PRINT_ERR("DD_STDERR = %s - invalid option\n", env);
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 }
 
 void
@@ -424,8 +424,8 @@ d_log_sync_mask(void)
 
 	d_log_sync_mask_ex(log_mask, dd_mask);
 
-	d_free_env_str(&dd_mask);
-	d_free_env_str(&log_mask);
+	d_freeenv_str(&dd_mask);
+	d_freeenv_str(&log_mask);
 }
 
 /**
@@ -553,12 +553,12 @@ d_log_init(void)
 	d_agetenv_str(&log_file, D_LOG_FILE_ENV);
 	if (log_file == NULL || strlen(log_file) == 0) {
 		flags |= DLOG_FLV_STDOUT;
-		d_free_env_str(&log_file);
+		d_freeenv_str(&log_file);
 	}
 
 	rc = d_log_init_adv("CaRT", log_file, flags, DLOG_WARN, DLOG_EMERG,
 			    NULL);
-	d_free_env_str(&log_file);
+	d_freeenv_str(&log_file);
 	if (rc != DER_SUCCESS) {
 		D_PRINT_ERR("d_log_init_adv failed, rc: %d.\n", rc);
 		D_GOTO(out, rc);

--- a/src/gurt/debug.c
+++ b/src/gurt/debug.c
@@ -380,7 +380,7 @@ debug_prio_err_load_env(void)
 	char	*env;
 	int	i;
 
-	env = getenv(DD_STDERR_ENV);
+	d_agetenv_str(&env, DD_STDERR_ENV);
 	if (env == NULL)
 		return;
 
@@ -395,6 +395,7 @@ debug_prio_err_load_env(void)
 	/* invalid DD_STDERR option */
 	if (d_dbglog_data.dd_prio_err == 0)
 		D_PRINT_ERR("DD_STDERR = %s - invalid option\n", env);
+	d_free_env_str(&env);
 }
 
 void
@@ -415,7 +416,16 @@ d_log_sync_mask_ex(const char *log_mask, const char *dd_mask)
 void
 d_log_sync_mask(void)
 {
-	d_log_sync_mask_ex(getenv(D_LOG_MASK_ENV), getenv(DD_MASK_ENV));
+	char *log_mask;
+	char *dd_mask;
+
+	d_agetenv_str(&log_mask, D_LOG_MASK_ENV);
+	d_agetenv_str(&dd_mask, DD_MASK_ENV);
+
+	d_log_sync_mask_ex(log_mask, dd_mask);
+
+	d_free_env_str(&dd_mask);
+	d_free_env_str(&log_mask);
 }
 
 /**
@@ -540,14 +550,15 @@ d_log_init(void)
 	int	 flags = DLOG_FLV_LOGPID | DLOG_FLV_FAC | DLOG_FLV_TAG;
 	int	 rc;
 
-	log_file = getenv(D_LOG_FILE_ENV);
+	d_agetenv_str(&log_file, D_LOG_FILE_ENV);
 	if (log_file == NULL || strlen(log_file) == 0) {
 		flags |= DLOG_FLV_STDOUT;
-		log_file = NULL;
+		d_free_env_str(&log_file);
 	}
 
 	rc = d_log_init_adv("CaRT", log_file, flags, DLOG_WARN, DLOG_EMERG,
 			    NULL);
+	d_free_env_str(&log_file);
 	if (rc != DER_SUCCESS) {
 		D_PRINT_ERR("d_log_init_adv failed, rc: %d.\n", rc);
 		D_GOTO(out, rc);

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -847,20 +847,20 @@ d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 
 		if (pri != -1)
 			mst.flush_pri = pri;
-		d_free_env_str(&env);
+		d_freeenv_str(&env);
 	}
 
 	d_agetenv_str(&env, D_LOG_TRUNCATE_ENV);
 	if (env != NULL && atoi(env) > 0)
 		truncate = 1;
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 
 	d_agetenv_str(&env, D_LOG_SIZE_ENV);
 	if (env != NULL) {
 		log_size = d_getenv_size(env);
 		if (log_size < LOG_SIZE_MIN)
 			log_size = LOG_SIZE_MIN;
-		d_free_env_str(&env);
+		d_freeenv_str(&env);
 	}
 
 	d_agetenv_str(&env, D_LOG_FILE_APPEND_PID_ENV);
@@ -875,12 +875,12 @@ d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 					    "continuing.\n");
 		}
 	}
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 
 	d_agetenv_str(&env, D_LOG_FILE_APPEND_RANK_ENV);
 	if (env && strcmp(env, "0") != 0)
 		mst.append_rank = true;
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 
 	/* quick sanity check (mst.tag is non-null if already open) */
 	if (d_log_xst.tag || !tag ||
@@ -918,7 +918,7 @@ d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 		d_agetenv_str(&env, D_LOG_STDERR_IN_LOG_ENV);
 		if (env != NULL && atoi(env) > 0)
 			merge_stderr = true;
-		d_free_env_str(&env);
+		d_freeenv_str(&env);
 
 		if (!truncate)
 			log_flags |= O_APPEND;
@@ -1107,7 +1107,7 @@ bool d_logfac_is_enabled(const char *fac_name)
 	rc = true;
 
 out:
-	d_free_env_str(&ddsubsys_env);
+	d_freeenv_str(&ddsubsys_env);
 	return rc;
 }
 

--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -616,7 +616,7 @@ d_fault_inject_init(void)
 out:
 	if (fp)
 		fclose(fp);
-	d_free_env_str(&config_file);
+	d_freeenv_str(&config_file);
 	return rc;
 }
 

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -1120,7 +1120,7 @@ out:
  * \param[in,out]	str_val		Copy of an environment string value.
  */
 void
-d_free_env_str(char **str_val)
+d_freeenv_str(char **str_val)
 {
 	assert(str_val != NULL);
 

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -2140,7 +2140,7 @@ test_d_agetenv_str(void **state)
 	assert_int_equal(rc, -DER_SUCCESS);
 	assert_non_null(env);
 	assert_string_equal(env, "bar");
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 	assert_null(env);
 
 	getenv_return = "";
@@ -2148,7 +2148,7 @@ test_d_agetenv_str(void **state)
 	assert_int_equal(rc, -DER_SUCCESS);
 	assert_non_null(env);
 	assert_string_equal(env, "");
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 	assert_null(env);
 
 	getenv_return = NULL;

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -581,7 +581,7 @@ d_getenv_str(char *str_val, size_t str_size, const char *name);
 int
 d_agetenv_str(char **str_val, const char *name);
 void
-d_free_env_str(char **str_val);
+d_freeenv_str(char **str_val);
 int
 d_getenv_bool(const char *name, bool *bool_val);
 int

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -452,12 +452,12 @@ int dc_mgmt_net_cfg(const char *name)
 	int                      rc;
 	char                    *crt_phy_addr_str;
 	char                    *crt_ctx_share_addr = NULL;
-	char			*cli_srx_set        = NULL;
+	char                    *cli_srx_set        = NULL;
 	char                    *crt_timeout        = NULL;
 	char                    *ofi_interface;
 	char                    *ofi_interface_env = NULL;
-	char                    *ofi_domain = "";
-	char                    *ofi_domain_env = NULL;
+	char                    *ofi_domain        = "";
+	char                    *ofi_domain_env    = NULL;
 	struct dc_mgmt_sys_info  info;
 	Mgmt__GetAttachInfoResp *resp;
 
@@ -495,7 +495,7 @@ int dc_mgmt_net_cfg(const char *name)
 	D_INFO("Setting number of server ranks to %d\n", g_num_serv_ranks);
 	/* These two are always set */
 	crt_phy_addr_str = info.provider;
-	rc = d_setenv("CRT_PHY_ADDR_STR", crt_phy_addr_str, 1);
+	rc               = d_setenv("CRT_PHY_ADDR_STR", crt_phy_addr_str, 1);
 	if (rc != 0)
 		D_GOTO(cleanup, rc = d_errno2der(errno));
 
@@ -518,8 +518,7 @@ int dc_mgmt_net_cfg(const char *name)
 		rc = d_setenv("FI_OFI_RXM_USE_SRX", cli_srx_set, 1);
 		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
-		D_INFO("Using server's value for FI_OFI_RXM_USE_SRX: %s\n",
-		       cli_srx_set);
+		D_INFO("Using server's value for FI_OFI_RXM_USE_SRX: %s\n", cli_srx_set);
 	} else {
 		/* Client may not set it if the server hasn't. */
 		d_agetenv_str(&cli_srx_set, "FI_OFI_RXM_USE_SRX");
@@ -550,7 +549,7 @@ int dc_mgmt_net_cfg(const char *name)
 	d_agetenv_str(&ofi_domain_env, "OFI_DOMAIN");
 	if (!ofi_interface_env) {
 		ofi_interface = info.interface;
-		rc = d_setenv("OFI_INTERFACE", ofi_interface, 1);
+		rc            = d_setenv("OFI_INTERFACE", ofi_interface, 1);
 		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -442,6 +442,62 @@ _split_env(char *env, char **name, char **value)
 	return 0;
 }
 
+static void
+print_mgmt_net_env()
+{
+	static const char *var_names[] = {"CRT_PHY_ADDR_STR", "CRT_CTX_SHARE_ADDR", "CRT_TIMEOUT"};
+	int                idx;
+	char              *env;
+	char              *msg;
+	int                rc;
+
+	rc = d_agetenv_str(&env, "OFI_INTERFACE");
+	D_ASSERTF(env != NULL, "Can not retrieve environment varirable OFI_INTERFACE: " DF_RC "\n",
+		  DP_RC(rc));
+	D_ASPRINTF(msg, "Network Interface: %s", env);
+	d_free_env_str(&env);
+	if (msg == NULL) {
+		D_INFO("Error allocating CaRT initialization message");
+		return;
+	}
+	d_agetenv_str(&env, "OFI_DOMAIN");
+	if (env == NULL)
+		D_INFO("%s, Domain: NA", msg);
+	else
+		D_INFO("%s, Domain: %s", msg, env);
+	d_free_env_str(&env);
+	D_FREE(msg);
+
+	rc = d_agetenv_str(&env, var_names[0]);
+	D_ASSERTF(env != NULL, "Can not retrieve environment varirable %s: " DF_RC "\n",
+		  var_names[0], DP_RC(rc));
+	D_ASPRINTF(msg, "CaRT initialization with:\n\t%s=%s", var_names[0], env);
+	d_free_env_str(&env);
+	if (msg == NULL) {
+		D_INFO("Error allocating CaRT initialization message");
+		return;
+	}
+
+	for (idx = 1; idx < sizeof(var_names) / sizeof(char *); ++idx) {
+		char *tmp = msg;
+
+		rc = d_agetenv_str(&env, var_names[idx]);
+		D_ASSERTF(env != NULL, "Can not retrieve environment varirable %s: " DF_RC "\n",
+			  var_names[idx], DP_RC(rc));
+
+		D_ASPRINTF(msg, "%s, %s=%s", tmp, var_names[idx], env);
+		d_free_env_str(&env);
+		D_FREE(tmp);
+		if (msg == NULL) {
+			D_INFO("Error allocating CaRT initialization message");
+			return;
+		}
+	}
+
+	D_DEBUG(DB_MGMT, "%s", msg);
+	D_FREE(msg);
+}
+
 /*
  * Get the CaRT network configuration for this client node
  * via the get_attach_info() dRPC.
@@ -510,16 +566,17 @@ int dc_mgmt_net_cfg(const char *name)
 		       buf);
 	} else {
 		/* Client may not set it if the server hasn't. */
-		cli_srx_set = getenv("FI_OFI_RXM_USE_SRX");
+		d_agetenv_str(&cli_srx_set, "FI_OFI_RXM_USE_SRX");
 		if (cli_srx_set) {
 			D_ERROR("Client set FI_OFI_RXM_USE_SRX to %s, "
 				"but server is unset!\n", cli_srx_set);
+			d_free_env_str(&cli_srx_set);
 			D_GOTO(cleanup, rc = -DER_INVAL);
 		}
 	}
 
 	/* Allow client env overrides for these three */
-	crt_timeout = getenv("CRT_TIMEOUT");
+	d_agetenv_str(&crt_timeout, "CRT_TIMEOUT");
 	if (!crt_timeout) {
 		sprintf(buf, "%d", info.crt_timeout);
 		rc = d_setenv("CRT_TIMEOUT", buf, 1);
@@ -528,14 +585,17 @@ int dc_mgmt_net_cfg(const char *name)
 	} else {
 		D_INFO("Using client provided CRT_TIMEOUT: %s\n",
 			crt_timeout);
+		d_free_env_str(&crt_timeout);
 	}
 
-	ofi_interface = getenv("OFI_INTERFACE");
-	ofi_domain = getenv("OFI_DOMAIN");
+	d_agetenv_str(&ofi_interface, "OFI_INTERFACE");
+	d_agetenv_str(&ofi_domain, "OFI_DOMAIN");
 	if (!ofi_interface) {
 		rc = d_setenv("OFI_INTERFACE", info.interface, 1);
-		if (rc != 0)
+		if (rc != 0) {
+			d_free_env_str(&ofi_domain);
 			D_GOTO(cleanup, rc = d_errno2der(errno));
+		}
 
 		/*
 		 * If we use the agent as the source, client env shouldn't be allowed to override
@@ -546,8 +606,10 @@ int dc_mgmt_net_cfg(const char *name)
 			       "automatic configuration instead\n", ofi_domain);
 
 		rc = d_setenv("OFI_DOMAIN", info.domain, 1);
-		if (rc != 0)
+		if (rc != 0) {
+			d_free_env_str(&ofi_domain);
 			D_GOTO(cleanup, rc = d_errno2der(errno));
+		}
 	} else {
 		D_INFO("Using client provided OFI_INTERFACE: %s\n", ofi_interface);
 
@@ -555,15 +617,10 @@ int dc_mgmt_net_cfg(const char *name)
 		if (ofi_domain)
 			D_INFO("Using client provided OFI_DOMAIN: %s\n", ofi_domain);
 	}
+	d_free_env_str(&ofi_domain);
+	d_free_env_str(&ofi_interface);
 
-	D_INFO("Network interface: %s, Domain: %s\n", getenv("OFI_INTERFACE"),
-	       getenv("OFI_DOMAIN"));
-	D_DEBUG(DB_MGMT,
-		"CaRT initialization with:\n"
-		"\tCRT_PHY_ADDR_STR: %s, "
-		"CRT_CTX_SHARE_ADDR: %s, CRT_TIMEOUT: %s\n",
-		getenv("CRT_PHY_ADDR_STR"),
-		getenv("CRT_CTX_SHARE_ADDR"), getenv("CRT_TIMEOUT"));
+	print_mgmt_net_env();
 
 cleanup:
 	put_attach_info(&info, resp);
@@ -585,14 +642,16 @@ int dc_mgmt_net_cfg_check(const char *name)
 
 	/* Client may not set it if the server hasn't. */
 	if (info.srv_srx_set == -1) {
-		cli_srx_set = getenv("FI_OFI_RXM_USE_SRX");
+		d_agetenv_str(&cli_srx_set, "FI_OFI_RXM_USE_SRX");
 		if (cli_srx_set) {
 			D_ERROR("Client set FI_OFI_RXM_USE_SRX to %s, "
 				"but server is unset!\n", cli_srx_set);
+			d_free_env_str(&cli_srx_set);
 			rc = -DER_INVAL;
 			goto out;
 		}
 	}
+	rc = 0;
 
 out:
 	put_attach_info(&info, resp);

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -442,62 +442,6 @@ _split_env(char *env, char **name, char **value)
 	return 0;
 }
 
-static void
-print_mgmt_net_env()
-{
-	static const char *var_names[] = {"CRT_PHY_ADDR_STR", "CRT_CTX_SHARE_ADDR", "CRT_TIMEOUT"};
-	int                idx;
-	char              *env;
-	char              *msg;
-	int                rc;
-
-	rc = d_agetenv_str(&env, "OFI_INTERFACE");
-	D_ASSERTF(env != NULL, "Can not retrieve environment varirable OFI_INTERFACE: " DF_RC "\n",
-		  DP_RC(rc));
-	D_ASPRINTF(msg, "Network Interface: %s", env);
-	d_freeenv_str(&env);
-	if (msg == NULL) {
-		D_INFO("Error allocating CaRT initialization message");
-		return;
-	}
-	d_agetenv_str(&env, "OFI_DOMAIN");
-	if (env == NULL)
-		D_INFO("%s, Domain: NA", msg);
-	else
-		D_INFO("%s, Domain: %s", msg, env);
-	d_freeenv_str(&env);
-	D_FREE(msg);
-
-	rc = d_agetenv_str(&env, var_names[0]);
-	D_ASSERTF(env != NULL, "Can not retrieve environment varirable %s: " DF_RC "\n",
-		  var_names[0], DP_RC(rc));
-	D_ASPRINTF(msg, "CaRT initialization with:\n\t%s=%s", var_names[0], env);
-	d_freeenv_str(&env);
-	if (msg == NULL) {
-		D_INFO("Error allocating CaRT initialization message");
-		return;
-	}
-
-	for (idx = 1; idx < sizeof(var_names) / sizeof(char *); ++idx) {
-		char *tmp = msg;
-
-		rc = d_agetenv_str(&env, var_names[idx]);
-		D_ASSERTF(env != NULL, "Can not retrieve environment varirable %s: " DF_RC "\n",
-			  var_names[idx], DP_RC(rc));
-
-		D_ASPRINTF(msg, "%s, %s=%s", tmp, var_names[idx], env);
-		d_freeenv_str(&env);
-		D_FREE(tmp);
-		if (msg == NULL) {
-			D_INFO("Error allocating CaRT initialization message");
-			return;
-		}
-	}
-
-	D_DEBUG(DB_MGMT, "%s", msg);
-	D_FREE(msg);
-}
-
 /*
  * Get the CaRT network configuration for this client node
  * via the get_attach_info() dRPC.
@@ -505,13 +449,16 @@ print_mgmt_net_env()
  */
 int dc_mgmt_net_cfg(const char *name)
 {
-	int rc;
-	char buf[SYS_INFO_BUF_SIZE];
-	char *crt_timeout;
-	char *ofi_interface;
-	char *ofi_domain;
-	char *cli_srx_set;
-	struct dc_mgmt_sys_info info;
+	int                      rc;
+	char                    *crt_phy_addr_str;
+	char                    *crt_ctx_share_addr = NULL;
+	char			*cli_srx_set        = NULL;
+	char                    *crt_timeout        = NULL;
+	char                    *ofi_interface;
+	char                    *ofi_interface_env = NULL;
+	char                    *ofi_domain = "";
+	char                    *ofi_domain_env = NULL;
+	struct dc_mgmt_sys_info  info;
 	Mgmt__GetAttachInfoResp *resp;
 
 	/* Query the agent for the CaRT network configuration parameters */
@@ -547,30 +494,38 @@ int dc_mgmt_net_cfg(const char *name)
 	g_num_serv_ranks = resp->n_rank_uris;
 	D_INFO("Setting number of server ranks to %d\n", g_num_serv_ranks);
 	/* These two are always set */
-	rc = d_setenv("CRT_PHY_ADDR_STR", info.provider, 1);
+	crt_phy_addr_str = info.provider;
+	rc = d_setenv("CRT_PHY_ADDR_STR", crt_phy_addr_str, 1);
 	if (rc != 0)
 		D_GOTO(cleanup, rc = d_errno2der(errno));
 
-	sprintf(buf, "%d", info.crt_ctx_share_addr);
-	rc = d_setenv("CRT_CTX_SHARE_ADDR", buf, 1);
+	rc = asprintf(&crt_ctx_share_addr, "%d", info.crt_ctx_share_addr);
+	if (rc < 0) {
+		crt_ctx_share_addr = NULL;
+		D_GOTO(cleanup, rc = -DER_NOMEM);
+	}
+	rc = d_setenv("CRT_CTX_SHARE_ADDR", crt_ctx_share_addr, 1);
 	if (rc != 0)
 		D_GOTO(cleanup, rc = d_errno2der(errno));
 
 	/* If the server has set this, the client must use the same value. */
 	if (info.srv_srx_set != -1) {
-		sprintf(buf, "%d", info.srv_srx_set);
-		rc = d_setenv("FI_OFI_RXM_USE_SRX", buf, 1);
+		rc = asprintf(&cli_srx_set, "%d", info.srv_srx_set);
+		if (rc < 0) {
+			cli_srx_set = NULL;
+			D_GOTO(cleanup, rc = -DER_NOMEM);
+		}
+		rc = d_setenv("FI_OFI_RXM_USE_SRX", cli_srx_set, 1);
 		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 		D_INFO("Using server's value for FI_OFI_RXM_USE_SRX: %s\n",
-		       buf);
+		       cli_srx_set);
 	} else {
 		/* Client may not set it if the server hasn't. */
 		d_agetenv_str(&cli_srx_set, "FI_OFI_RXM_USE_SRX");
 		if (cli_srx_set) {
 			D_ERROR("Client set FI_OFI_RXM_USE_SRX to %s, "
 				"but server is unset!\n", cli_srx_set);
-			d_freeenv_str(&cli_srx_set);
 			D_GOTO(cleanup, rc = -DER_INVAL);
 		}
 	}
@@ -578,51 +533,64 @@ int dc_mgmt_net_cfg(const char *name)
 	/* Allow client env overrides for these three */
 	d_agetenv_str(&crt_timeout, "CRT_TIMEOUT");
 	if (!crt_timeout) {
-		sprintf(buf, "%d", info.crt_timeout);
-		rc = d_setenv("CRT_TIMEOUT", buf, 1);
+		rc = asprintf(&crt_timeout, "%d", info.crt_timeout);
+		if (rc < 0) {
+			crt_timeout = NULL;
+			D_GOTO(cleanup, rc = -DER_NOMEM);
+		}
+		D_INFO("setenv CRT_TIMEOUT=%s\n", crt_timeout);
+		rc = d_setenv("CRT_TIMEOUT", crt_timeout, 1);
 		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 	} else {
-		D_INFO("Using client provided CRT_TIMEOUT: %s\n",
-			crt_timeout);
-		d_freeenv_str(&crt_timeout);
+		D_DEBUG(DB_MGMT, "Using client provided CRT_TIMEOUT: %s\n", crt_timeout);
 	}
 
-	d_agetenv_str(&ofi_interface, "OFI_INTERFACE");
-	d_agetenv_str(&ofi_domain, "OFI_DOMAIN");
-	if (!ofi_interface) {
-		rc = d_setenv("OFI_INTERFACE", info.interface, 1);
-		if (rc != 0) {
-			d_freeenv_str(&ofi_domain);
+	d_agetenv_str(&ofi_interface_env, "OFI_INTERFACE");
+	d_agetenv_str(&ofi_domain_env, "OFI_DOMAIN");
+	if (!ofi_interface_env) {
+		ofi_interface = info.interface;
+		rc = d_setenv("OFI_INTERFACE", ofi_interface, 1);
+		if (rc != 0)
 			D_GOTO(cleanup, rc = d_errno2der(errno));
-		}
 
 		/*
 		 * If we use the agent as the source, client env shouldn't be allowed to override
 		 * the domain. Otherwise we could get a mismatch between interface and domain.
 		 */
-		if (ofi_domain)
+		ofi_domain = info.domain;
+		if (ofi_domain_env)
 			D_WARN("Ignoring OFI_DOMAIN '%s' because OFI_INTERFACE is not set; using "
 			       "automatic configuration instead\n", ofi_domain);
 
-		rc = d_setenv("OFI_DOMAIN", info.domain, 1);
+		rc = d_setenv("OFI_DOMAIN", ofi_domain, 1);
 		if (rc != 0) {
-			d_freeenv_str(&ofi_domain);
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 		}
 	} else {
+		ofi_interface = ofi_interface_env;
 		D_INFO("Using client provided OFI_INTERFACE: %s\n", ofi_interface);
 
 		/* If the client env didn't provide a domain, we can assume we don't need one. */
-		if (ofi_domain)
+		if (ofi_domain_env) {
+			ofi_domain = ofi_domain_env;
 			D_INFO("Using client provided OFI_DOMAIN: %s\n", ofi_domain);
+		}
 	}
-	d_freeenv_str(&ofi_domain);
-	d_freeenv_str(&ofi_interface);
 
-	print_mgmt_net_env();
+	D_INFO("Network interface: %s, Domain: %s\n", ofi_interface, ofi_domain);
+	D_DEBUG(DB_MGMT,
+		"CaRT initialization with:\n"
+		"\tCRT_PHY_ADDR_STR: %s, "
+		"CRT_CTX_SHARE_ADDR: %s, CRT_TIMEOUT: %s\n",
+		crt_phy_addr_str, crt_ctx_share_addr, crt_timeout);
 
 cleanup:
+	d_freeenv_str(&ofi_domain_env);
+	d_freeenv_str(&ofi_interface_env);
+	d_freeenv_str(&crt_timeout);
+	d_freeenv_str(&cli_srx_set);
+	d_freeenv_str(&crt_ctx_share_addr);
 	put_attach_info(&info, resp);
 
 	return rc;

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -455,7 +455,7 @@ print_mgmt_net_env()
 	D_ASSERTF(env != NULL, "Can not retrieve environment varirable OFI_INTERFACE: " DF_RC "\n",
 		  DP_RC(rc));
 	D_ASPRINTF(msg, "Network Interface: %s", env);
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 	if (msg == NULL) {
 		D_INFO("Error allocating CaRT initialization message");
 		return;
@@ -465,14 +465,14 @@ print_mgmt_net_env()
 		D_INFO("%s, Domain: NA", msg);
 	else
 		D_INFO("%s, Domain: %s", msg, env);
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 	D_FREE(msg);
 
 	rc = d_agetenv_str(&env, var_names[0]);
 	D_ASSERTF(env != NULL, "Can not retrieve environment varirable %s: " DF_RC "\n",
 		  var_names[0], DP_RC(rc));
 	D_ASPRINTF(msg, "CaRT initialization with:\n\t%s=%s", var_names[0], env);
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 	if (msg == NULL) {
 		D_INFO("Error allocating CaRT initialization message");
 		return;
@@ -486,7 +486,7 @@ print_mgmt_net_env()
 			  var_names[idx], DP_RC(rc));
 
 		D_ASPRINTF(msg, "%s, %s=%s", tmp, var_names[idx], env);
-		d_free_env_str(&env);
+		d_freeenv_str(&env);
 		D_FREE(tmp);
 		if (msg == NULL) {
 			D_INFO("Error allocating CaRT initialization message");
@@ -570,7 +570,7 @@ int dc_mgmt_net_cfg(const char *name)
 		if (cli_srx_set) {
 			D_ERROR("Client set FI_OFI_RXM_USE_SRX to %s, "
 				"but server is unset!\n", cli_srx_set);
-			d_free_env_str(&cli_srx_set);
+			d_freeenv_str(&cli_srx_set);
 			D_GOTO(cleanup, rc = -DER_INVAL);
 		}
 	}
@@ -585,7 +585,7 @@ int dc_mgmt_net_cfg(const char *name)
 	} else {
 		D_INFO("Using client provided CRT_TIMEOUT: %s\n",
 			crt_timeout);
-		d_free_env_str(&crt_timeout);
+		d_freeenv_str(&crt_timeout);
 	}
 
 	d_agetenv_str(&ofi_interface, "OFI_INTERFACE");
@@ -593,7 +593,7 @@ int dc_mgmt_net_cfg(const char *name)
 	if (!ofi_interface) {
 		rc = d_setenv("OFI_INTERFACE", info.interface, 1);
 		if (rc != 0) {
-			d_free_env_str(&ofi_domain);
+			d_freeenv_str(&ofi_domain);
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 		}
 
@@ -607,7 +607,7 @@ int dc_mgmt_net_cfg(const char *name)
 
 		rc = d_setenv("OFI_DOMAIN", info.domain, 1);
 		if (rc != 0) {
-			d_free_env_str(&ofi_domain);
+			d_freeenv_str(&ofi_domain);
 			D_GOTO(cleanup, rc = d_errno2der(errno));
 		}
 	} else {
@@ -617,8 +617,8 @@ int dc_mgmt_net_cfg(const char *name)
 		if (ofi_domain)
 			D_INFO("Using client provided OFI_DOMAIN: %s\n", ofi_domain);
 	}
-	d_free_env_str(&ofi_domain);
-	d_free_env_str(&ofi_interface);
+	d_freeenv_str(&ofi_domain);
+	d_freeenv_str(&ofi_interface);
 
 	print_mgmt_net_env();
 
@@ -646,7 +646,7 @@ int dc_mgmt_net_cfg_check(const char *name)
 		if (cli_srx_set) {
 			D_ERROR("Client set FI_OFI_RXM_USE_SRX to %s, "
 				"but server is unset!\n", cli_srx_set);
-			d_free_env_str(&cli_srx_set);
+			d_freeenv_str(&cli_srx_set);
 			rc = -DER_INVAL;
 			goto out;
 		}

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -6873,10 +6873,10 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	if ((env && !strcasecmp(env, REBUILD_ENV_DISABLED)) ||
 	     daos_fail_check(DAOS_REBUILD_DISABLE)) {
 		D_DEBUG(DB_TRACE, "Rebuild is disabled\n");
-		d_free_env_str(&env);
+		d_freeenv_str(&env);
 		D_GOTO(out, rc = 0);
 	}
-	d_free_env_str(&env);
+	d_freeenv_str(&env);
 
 	rc = ds_pool_iv_prop_fetch(svc->ps_pool, &prop);
 	if (rc)

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -6869,12 +6869,14 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 		D_GOTO(out, rc);
 	}
 
-	env = getenv(REBUILD_ENV);
+	d_agetenv_str(&env, REBUILD_ENV);
 	if ((env && !strcasecmp(env, REBUILD_ENV_DISABLED)) ||
 	     daos_fail_check(DAOS_REBUILD_DISABLE)) {
 		D_DEBUG(DB_TRACE, "Rebuild is disabled\n");
+		d_free_env_str(&env);
 		D_GOTO(out, rc = 0);
 	}
+	d_free_env_str(&env);
 
 	rc = ds_pool_iv_prop_fetch(svc->ps_pool, &prop);
 	if (rc)

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1389,10 +1389,11 @@ ds_rsvc_get_md_cap(void)
 	char	       *v;
 	int		n;
 
-	v = getenv(DAOS_MD_CAP_ENV); /* in MB */
+	d_agetenv_str(&v, DAOS_MD_CAP_ENV); /* in MB */
 	if (v == NULL)
 		return size_default;
 	n = atoi(v);
+	d_free_env_str(&v);
 	if ((n << 20) < MINIMUM_DAOS_MD_CAP_SIZE) {
 		D_ERROR("metadata capacity too low; using %zu MB\n",
 			size_default >> 20);

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1393,7 +1393,7 @@ ds_rsvc_get_md_cap(void)
 	if (v == NULL)
 		return size_default;
 	n = atoi(v);
-	d_free_env_str(&v);
+	d_freeenv_str(&v);
 	if ((n << 20) < MINIMUM_DAOS_MD_CAP_SIZE) {
 		D_ERROR("metadata capacity too low; using %zu MB\n",
 			size_default >> 20);

--- a/src/tests/ftest/cart/iv_server.c
+++ b/src/tests/ftest/cart/iv_server.c
@@ -1248,7 +1248,7 @@ int main(int argc, char **argv)
 	}
 
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -1289,7 +1289,7 @@ int main(int argc, char **argv)
 		D_ERROR("Failed to load group file %s\n", grp_cfg_file);
 		assert(0);
 	}
-	d_free_env_str(&grp_cfg_file);
+	d_freeenv_str(&grp_cfg_file);
 
 	/* Start the server for myself */
 	DBG_PRINT("Server starting, self_rank=%d\n", my_rank);

--- a/src/tests/ftest/cart/iv_server.c
+++ b/src/tests/ftest/cart/iv_server.c
@@ -1241,13 +1241,14 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	if (env_self_rank == NULL) {
 		printf("CRT_L_RANK was not set\n");
 		return -1;
 	}
 
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -1274,7 +1275,7 @@ int main(int argc, char **argv)
 	init_work_contexts();
 
 	/* Load the group configuration file */
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	rc = d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 	if (grp_cfg_file == NULL) {
 		D_ERROR("CRT_L_GRP_CFG was not set\n");
 		assert(0);
@@ -1288,6 +1289,7 @@ int main(int argc, char **argv)
 		D_ERROR("Failed to load group file %s\n", grp_cfg_file);
 		assert(0);
 	}
+	d_free_env_str(&grp_cfg_file);
 
 	/* Start the server for myself */
 	DBG_PRINT("Server starting, self_rank=%d\n", my_rank);

--- a/src/tests/ftest/cart/no_pmix_corpc_errors.c
+++ b/src/tests/ftest/cart/no_pmix_corpc_errors.c
@@ -271,8 +271,9 @@ int main(int argc, char **argv)
 		crtu_set_shutdown_delay(2);
 	}
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -326,7 +327,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 
 	rc = crt_rank_self_set(my_rank, 1 /* group_version_min */);
 	if (rc != 0) {
@@ -351,6 +352,7 @@ int main(int argc, char **argv)
 
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 			my_uri, grp_cfg_file);
+	d_free_env_str(&grp_cfg_file);
 	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, &grp_size);

--- a/src/tests/ftest/cart/no_pmix_corpc_errors.c
+++ b/src/tests/ftest/cart/no_pmix_corpc_errors.c
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
 
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 			my_uri, grp_cfg_file);
-	d_free_env_str(&grp_cfg_file);
+	d_freeenv_str(&grp_cfg_file);
 	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, &grp_size);

--- a/src/tests/ftest/cart/no_pmix_group_test.c
+++ b/src/tests/ftest/cart/no_pmix_group_test.c
@@ -320,7 +320,7 @@ int main(int argc, char **argv)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* When under valgrind bump expected timeouts to 60 seconds */
 	if (D_ON_VALGRIND) {
@@ -408,7 +408,7 @@ int main(int argc, char **argv)
 
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 			my_uri, grp_cfg_file);
-	d_free_env_str(&grp_cfg_file);
+	d_freeenv_str(&grp_cfg_file);
 	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, &grp_size);

--- a/src/tests/ftest/cart/no_pmix_group_test.c
+++ b/src/tests/ftest/cart/no_pmix_group_test.c
@@ -318,8 +318,9 @@ int main(int argc, char **argv)
 	int			num_attach_retries = 20;
 	uint32_t		primary_grp_version = 1;
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* When under valgrind bump expected timeouts to 60 seconds */
 	if (D_ON_VALGRIND) {
@@ -382,7 +383,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 
 	rc = crt_rank_self_set(my_rank, primary_grp_version);
 	if (rc != 0) {
@@ -407,6 +408,7 @@ int main(int argc, char **argv)
 
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 			my_uri, grp_cfg_file);
+	d_free_env_str(&grp_cfg_file);
 	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, &grp_size);

--- a/src/tests/ftest/cart/no_pmix_group_version.c
+++ b/src/tests/ftest/cart/no_pmix_group_version.c
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* When under valgrind bump expected timeouts to 60 seconds */
 	if (D_ON_VALGRIND) {
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
 
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 			my_uri, grp_cfg_file);
-	d_free_env_str(&grp_cfg_file);
+	d_freeenv_str(&grp_cfg_file);
 	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, &grp_size);

--- a/src/tests/ftest/cart/no_pmix_group_version.c
+++ b/src/tests/ftest/cart/no_pmix_group_version.c
@@ -268,8 +268,9 @@ int main(int argc, char **argv)
 	int			rc;
 	int			num_attach_retries = 20;
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* When under valgrind bump expected timeouts to 60 seconds */
 	if (D_ON_VALGRIND) {
@@ -326,7 +327,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 
 	rc = crt_rank_self_set(my_rank, 1 /* group_version_min */);
 	if (rc != 0) {
@@ -351,6 +352,7 @@ int main(int argc, char **argv)
 
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 			my_uri, grp_cfg_file);
+	d_free_env_str(&grp_cfg_file);
 	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, &grp_size);

--- a/src/tests/ftest/cart/no_pmix_launcher_client.c
+++ b/src/tests/ftest/cart/no_pmix_launcher_client.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
 		D_ERROR("crtu_load_group_from_file() failed; rc=%d\n", rc);
 		assert(0);
 	}
-	d_free_env_str(&grp_cfg_file);
+	d_freeenv_str(&grp_cfg_file);
 
 	rc = crt_group_size(grp, &grp_size);
 	if (rc != 0) {

--- a/src/tests/ftest/cart/no_pmix_launcher_client.c
+++ b/src/tests/ftest/cart/no_pmix_launcher_client.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
 				progress_function, &crt_ctx);
 	assert(rc == 0);
 
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 	DBG_PRINT("Client starting with cfg_file=%s\n", grp_cfg_file);
 
 	/* load group info from a config file and delete file upon return */
@@ -116,6 +116,7 @@ int main(int argc, char **argv)
 		D_ERROR("crtu_load_group_from_file() failed; rc=%d\n", rc);
 		assert(0);
 	}
+	d_free_env_str(&grp_cfg_file);
 
 	rc = crt_group_size(grp, &grp_size);
 	if (rc != 0) {

--- a/src/tests/ftest/cart/no_pmix_launcher_server.c
+++ b/src/tests/ftest/cart/no_pmix_launcher_server.c
@@ -33,8 +33,9 @@ int main(int argc, char **argv)
 	uint32_t		grp_size;
 	int			rc;
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -83,7 +84,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 	if (grp_cfg_file == NULL) {
 		D_ERROR("CRT_L_GRP_CFG was not set\n");
 		assert(0);
@@ -105,6 +106,7 @@ int main(int argc, char **argv)
 
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 		  my_uri, grp_cfg_file);
+	d_free_env_str(&grp_cfg_file);
 	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, &grp_size);

--- a/src/tests/ftest/cart/no_pmix_launcher_server.c
+++ b/src/tests/ftest/cart/no_pmix_launcher_server.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 
 	DBG_PRINT("self_rank=%d uri=%s grp_cfg_file=%s\n", my_rank,
 		  my_uri, grp_cfg_file);
-	d_free_env_str(&grp_cfg_file);
+	d_freeenv_str(&grp_cfg_file);
 	D_FREE(my_uri);
 
 	rc = crt_group_size(NULL, &grp_size);

--- a/src/tests/ftest/cart/test_corpc_exclusive.c
+++ b/src/tests/ftest/cart/test_corpc_exclusive.c
@@ -103,8 +103,9 @@ int main(void)
 	membs.rl_nr = 3;
 	membs.rl_ranks = memb_ranks;
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -128,7 +129,7 @@ int main(void)
 		assert(0);
 	}
 
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 
 	rc = crt_rank_self_set(my_rank, 1 /* group_version_min */);
 	if (rc != 0) {
@@ -146,6 +147,7 @@ int main(void)
 	/* load group info from a config file and delete file upon return */
 	rc = crtu_load_group_from_file(grp_cfg_file, g_main_ctx, grp, my_rank,
 				       true);
+	d_free_env_str(&grp_cfg_file);
 	if (rc != 0) {
 		D_ERROR("crtu_load_group_from_file() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/tests/ftest/cart/test_corpc_exclusive.c
+++ b/src/tests/ftest/cart/test_corpc_exclusive.c
@@ -105,7 +105,7 @@ int main(void)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -147,7 +147,7 @@ int main(void)
 	/* load group info from a config file and delete file upon return */
 	rc = crtu_load_group_from_file(grp_cfg_file, g_main_ctx, grp, my_rank,
 				       true);
-	d_free_env_str(&grp_cfg_file);
+	d_freeenv_str(&grp_cfg_file);
 	if (rc != 0) {
 		D_ERROR("crtu_load_group_from_file() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/tests/ftest/cart/test_corpc_prefwd.c
+++ b/src/tests/ftest/cart/test_corpc_prefwd.c
@@ -127,7 +127,7 @@ int main(void)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -169,7 +169,7 @@ int main(void)
 	/* load group info from a config file and delete file upon return */
 	rc = crtu_load_group_from_file(grp_cfg_file, g_main_ctx, grp, my_rank,
 				       true);
-	d_free_env_str(&grp_cfg_file);
+	d_freeenv_str(&grp_cfg_file);
 	if (rc != 0) {
 		D_ERROR("crtu_load_group_from_file() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/tests/ftest/cart/test_corpc_prefwd.c
+++ b/src/tests/ftest/cart/test_corpc_prefwd.c
@@ -125,8 +125,9 @@ int main(void)
 	excluded_membs.rl_nr = 1;
 	excluded_membs.rl_ranks = &excluded_ranks;
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
@@ -150,7 +151,7 @@ int main(void)
 		assert(0);
 	}
 
-	grp_cfg_file = getenv("CRT_L_GRP_CFG");
+	d_agetenv_str(&grp_cfg_file, "CRT_L_GRP_CFG");
 
 	rc = crt_rank_self_set(my_rank, 1 /* group_version_min */);
 	if (rc != 0) {
@@ -168,6 +169,7 @@ int main(void)
 	/* load group info from a config file and delete file upon return */
 	rc = crtu_load_group_from_file(grp_cfg_file, g_main_ctx, grp, my_rank,
 				       true);
+	d_free_env_str(&grp_cfg_file);
 	if (rc != 0) {
 		D_ERROR("crtu_load_group_from_file() failed; rc=%d\n", rc);
 		assert(0);

--- a/src/tests/ftest/cart/test_ep_cred_server.c
+++ b/src/tests/ftest/cart/test_ep_cred_server.c
@@ -75,7 +75,7 @@ main(int argc, char **argv)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 40, true, true);

--- a/src/tests/ftest/cart/test_ep_cred_server.c
+++ b/src/tests/ftest/cart/test_ep_cred_server.c
@@ -73,8 +73,9 @@ main(int argc, char **argv)
 		return rc;
 	}
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 40, true, true);

--- a/src/tests/ftest/cart/test_group_np_srv.c
+++ b/src/tests/ftest/cart/test_group_np_srv.c
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);

--- a/src/tests/ftest/cart/test_group_np_srv.c
+++ b/src/tests/ftest/cart/test_group_np_srv.c
@@ -151,8 +151,9 @@ int main(int argc, char **argv)
 		return rc;
 	}
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);

--- a/src/tests/ftest/cart/test_multisend_server.c
+++ b/src/tests/ftest/cart/test_multisend_server.c
@@ -167,8 +167,9 @@ main(int argc, char **argv)
 		return rc;
 	}
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 40, true, true);

--- a/src/tests/ftest/cart/test_multisend_server.c
+++ b/src/tests/ftest/cart/test_multisend_server.c
@@ -169,7 +169,7 @@ main(int argc, char **argv)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 40, true, true);

--- a/src/tests/ftest/cart/test_proto_server.c
+++ b/src/tests/ftest/cart/test_proto_server.c
@@ -83,8 +83,9 @@ main(int argc, char **argv)
 		return rc;
 	}
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 40, true, true);

--- a/src/tests/ftest/cart/test_proto_server.c
+++ b/src/tests/ftest/cart/test_proto_server.c
@@ -85,7 +85,7 @@ main(int argc, char **argv)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 40, true, true);

--- a/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
+++ b/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
@@ -507,8 +507,10 @@ int main(int argc, char **argv)
 		return rc;
 	}
 
-	env_self_rank = getenv("CRT_L_RANK");
+	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
+	d_free_env_str(&env_self_rank);
+
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);
 

--- a/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
+++ b/src/tests/ftest/cart/test_rpc_to_ghost_rank.c
@@ -509,7 +509,7 @@ int main(int argc, char **argv)
 
 	d_agetenv_str(&env_self_rank, "CRT_L_RANK");
 	my_rank = atoi(env_self_rank);
-	d_free_env_str(&env_self_rank);
+	d_freeenv_str(&env_self_rank);
 
 	/* rank, num_attach_retries, is_server, assert_on_error */
 	crtu_test_init(my_rank, 20, true, true);

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -2885,7 +2885,7 @@ run_daos_checksum_test(int rank, int size, int *sub_tests, int sub_tests_size)
 	}
 
 	if (sub_tests_size == 0) {
-		if (getenv("DAOS_CSUM_TEST_ALL_TYPE")) {
+		if (d_isenv_def("DAOS_CSUM_TEST_ALL_TYPE")) {
 			for (i = DAOS_PROP_CO_CSUM_OFF + 1;
 			     i <= DAOS_PROP_CO_CSUM_ADLER32; i++) {
 				dts_csum_prop_type = i;

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -87,9 +87,10 @@ nvme_fault_reaction(void **state, int mode)
 		daos_size_t	nvme_size;
 
 		/* Use the SCM size if set with environment */
-		env = getenv("POOL_SCM_SIZE");
+		d_agetenv_str(&env, "POOL_SCM_SIZE");
 		if (env) {
 			size_gb = atoi(env);
+			d_free_env_str(&env);
 			if (size_gb != 0)
 				scm_size = (daos_size_t)size_gb << 30;
 		}

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -90,7 +90,7 @@ nvme_fault_reaction(void **state, int mode)
 		d_agetenv_str(&env, "POOL_SCM_SIZE");
 		if (env) {
 			size_gb = atoi(env);
-			d_free_env_str(&env);
+			d_freeenv_str(&env);
 			if (size_gb != 0)
 				scm_size = (daos_size_t)size_gb << 30;
 		}

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -73,7 +73,7 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		d_agetenv_str(&env, "POOL_SCM_SIZE");
 		if (env) {
 			size_gb = atoi(env);
-			d_free_env_str(&env);
+			d_freeenv_str(&env);
 			if (size_gb != 0)
 				outpool->pool_size =
 					(daos_size_t)size_gb << 30;
@@ -89,7 +89,7 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		d_agetenv_str(&env, "POOL_NVME_SIZE");
 		if (env) {
 			size_gb = atoi(env);
-			d_free_env_str(&env);
+			d_freeenv_str(&env);
 			nvme_size = (daos_size_t)size_gb << 30;
 		}
 

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -70,9 +70,10 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		daos_size_t	 nvme_size;
 		d_rank_list_t	 *rank_list = NULL;
 
-		env = getenv("POOL_SCM_SIZE");
+		d_agetenv_str(&env, "POOL_SCM_SIZE");
 		if (env) {
 			size_gb = atoi(env);
+			d_free_env_str(&env);
 			if (size_gb != 0)
 				outpool->pool_size =
 					(daos_size_t)size_gb << 30;
@@ -85,9 +86,10 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		 * Set env POOL_NVME_SIZE to overwrite the default NVMe size.
 		 */
 		nvme_size = outpool->pool_size * 4;
-		env = getenv("POOL_NVME_SIZE");
+		d_agetenv_str(&env, "POOL_NVME_SIZE");
 		if (env) {
 			size_gb = atoi(env);
+			d_free_env_str(&env);
 			nvme_size = (daos_size_t)size_gb << 30;
 		}
 

--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -168,14 +168,16 @@ main(int argc, char **argv)
 	}
 
 	/** if writing XML, force all ranks other than rank 0 to use stdout to avoid conflicts */
-	cmocka_message_output = getenv("CMOCKA_MESSAGE_OUTPUT");
+	d_agetenv_str(&cmocka_message_output, "CMOCKA_MESSAGE_OUTPUT");
 	if (rank != 0 && cmocka_message_output && strcasecmp(cmocka_message_output, "xml") == 0) {
+		d_freeenv_str(&cmocka_message_output);
 		rc = d_setenv("CMOCKA_MESSAGE_OUTPUT", "stdout", 1);
 		if (rc) {
 			print_message("d_setenv() failed with %d\n", rc);
 			return -1;
 		}
 	}
+	d_freeenv_str(&cmocka_message_output);
 
 	nr_failed = run_specified_tests(tests, rank, size, NULL, 0);
 

--- a/src/utils/self_test/self_test.c
+++ b/src/utils/self_test/self_test.c
@@ -1853,7 +1853,7 @@ int main(int argc, char *argv[])
 		printf("Warning: running without daos_agent connection (-u option); "
 		       "Using attachment file %s/%s.attach_info_tmp instead\n",
 		       attach_path, dest_name ? dest_name : default_dest_name);
-		d_free_env_str(&attach_path);
+		d_freeenv_str(&attach_path);
 	}
 
 	/******************** Parse message sizes argument ********************/

--- a/src/utils/self_test/self_test.c
+++ b/src/utils/self_test/self_test.c
@@ -1827,34 +1827,33 @@ int main(int argc, char *argv[])
 	}
 
 	if (use_daos_agent_vars == false) {
-		char *env;
 		char *attach_path;
 
-		env = getenv("CRT_PHY_ADDR_STR");
-		if (env == NULL) {
+		if (!d_isenv_def("CRT_PHY_ADDR_STR")) {
 			printf("Error: provider (CRT_PHY_ADDR_STR) is not set\n");
 			printf("Example: export CRT_PHY_ADDR_STR='ofi+tcp'\n");
 			D_GOTO(cleanup, ret = -DER_INVAL);
 		}
 
-		env = getenv("OFI_INTERFACE");
-		if (env == NULL) {
+		if (!d_isenv_def("OFI_INTERFACE")) {
 			printf("Error: interface (OFI_INTERFACE) is not set\n");
 			printf("Example: export OFI_INTERFACE=eth0\n");
 			D_GOTO(cleanup, ret = -DER_INVAL);
 		}
 
 		if (attach_info_path)
-			attach_path = attach_info_path;
+			D_STRNDUP(attach_path, attach_info_path, strlen(attach_info_path));
 		else {
-			attach_path = getenv("CRT_ATTACH_INFO_PATH");
+			d_agetenv_str(&attach_path, "CRT_ATTACH_INFO_PATH");
 			if (!attach_path)
-				attach_path = "/tmp";
+				D_STRNDUP_S(attach_path, "/tmp");
 		}
+		D_ASSERT(attach_path != NULL);
 
 		printf("Warning: running without daos_agent connection (-u option); "
 		       "Using attachment file %s/%s.attach_info_tmp instead\n",
 		       attach_path, dest_name ? dest_name : default_dest_name);
+		d_free_env_str(&attach_path);
 	}
 
 	/******************** Parse message sizes argument ********************/

--- a/src/utils/self_test/self_test.c
+++ b/src/utils/self_test/self_test.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1828,6 +1828,7 @@ int main(int argc, char *argv[])
 
 	if (use_daos_agent_vars == false) {
 		char *attach_path;
+		char *attach_path_env = NULL;
 
 		if (!d_isenv_def("CRT_PHY_ADDR_STR")) {
 			printf("Error: provider (CRT_PHY_ADDR_STR) is not set\n");
@@ -1842,18 +1843,19 @@ int main(int argc, char *argv[])
 		}
 
 		if (attach_info_path)
-			D_STRNDUP(attach_path, attach_info_path, strlen(attach_info_path));
+			attach_path = attach_info_path;
 		else {
-			d_agetenv_str(&attach_path, "CRT_ATTACH_INFO_PATH");
+			d_agetenv_str(&attach_path_env, "CRT_ATTACH_INFO_PATH");
+			attach_path = attach_path_env;
 			if (!attach_path)
-				D_STRNDUP_S(attach_path, "/tmp");
+				attach_path = "/tmp";
 		}
 		D_ASSERT(attach_path != NULL);
 
 		printf("Warning: running without daos_agent connection (-u option); "
 		       "Using attachment file %s/%s.attach_info_tmp instead\n",
 		       attach_path, dest_name ? dest_name : default_dest_name);
-		d_freeenv_str(&attach_path);
+		d_freeenv_str(&attach_path_env);
 	}
 
 	/******************** Parse message sizes argument ********************/

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -987,7 +987,7 @@ vos_self_init(const char *db_path, bool use_sys_db, int tgt_id)
 		goto failed;
 	}
 
-	evt_mode = getenv("DAOS_EVTREE_MODE");
+	rc = d_agetenv_str(&evt_mode, "DAOS_EVTREE_MODE");
 	if (evt_mode) {
 		if (strcasecmp("soff", evt_mode) == 0) {
 			vos_evt_feats &= ~EVT_FEATS_SUPPORTED;
@@ -996,6 +996,7 @@ vos_self_init(const char *db_path, bool use_sys_db, int tgt_id)
 			vos_evt_feats &= ~EVT_FEATS_SUPPORTED;
 			vos_evt_feats |= EVT_FEAT_SORT_DIST_EVEN;
 		}
+		d_free_env_str(&evt_mode);
 	}
 	switch (vos_evt_feats & EVT_FEATS_SUPPORTED) {
 	case EVT_FEAT_SORT_SOFF:

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -996,7 +996,7 @@ vos_self_init(const char *db_path, bool use_sys_db, int tgt_id)
 			vos_evt_feats &= ~EVT_FEATS_SUPPORTED;
 			vos_evt_feats |= EVT_FEAT_SORT_DIST_EVEN;
 		}
-		d_free_env_str(&evt_mode);
+		d_freeenv_str(&evt_mode);
 	}
 	switch (vos_evt_feats & EVT_FEATS_SUPPORTED) {
 	case EVT_FEAT_SORT_SOFF:


### PR DESCRIPTION
### Description

This PR is based on the PR https://github.com/daos-stack/daos/pull/13483 allowing thread safe management of environment variables.
This PR mainly replace call to the standard `getenv()` function with `d_isenv_def()`, `d_agetenv()` and `d_freeenv_str()`.
It also renames the `d_free_env_str()` function intoduce in the previous PR to `d_freeenv_str()`.

### Validation

The run [#17](https://build.hpdd.intel.com/job/daos-stack/job/daos/job/PR-13579/17/testReport/) of the CI was done with the CI tag `Allow-unstable-test: true` to check that no regression was introduced with the `Features: dfuse` tests.  This first tag was needed as the test `dfuse/daos_build.py` is not supporting change in the DAOS API and this patch is renamed the function `d_free_env_str()` into `d_freeenv_str()`.  However, this last cosmetic modification should be acceptable as the function `d_free_env_str()` was recently introduced by the PR [#13483](https://github.com/daos-stack/daos/pull/13483), and thus this function is not available in any DAOS release. At the end, the only failure with the CI run [#17](https://build.hpdd.intel.com/job/daos-stack/job/daos/job/PR-13579/17/testReport/) is an expected one related to the test [`dfuse/daos_build.py`](https://build.hpdd.intel.com/job/daos-stack/job/daos/job/PR-13579/17/testReport/FTEST_dfuse/DaosBuild/Test___Functional_on_EL_8_8___1___dfuse_daos_build_py_DaosBuild_test_dfuse_daos_build_wt_il_run_container_dfuse_dfuse_vm_hosts_pool_server_config_engines_0_storage_0_80ba/) (more derails could be found in the log file [debug.log](https://build.hpdd.intel.com/job/daos-stack/job/daos/job/PR-13579/17/artifact/Functional%20on%20EL%208.8/dfuse/daos_build.py/test-results/1-._dfuse_daos_build.py_DaosBuild.test_dfuse_daos_build_wt_il_run-container-dfuse-dfuse_vm-hosts-pool-server_config-engines-0-storage-0-80ba/debug.log/*view*/) of the test).

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
