### PR TITLE
DAOS-14846 build: scons support generate compile_command.json

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -7,6 +7,7 @@ import time
 
 import SCons.Warnings
 from prereq_tools import PreReqComponent  # pylint: disable=reimported
+from SCons import __version__ as scons_raw_version  # pylint: disable=protected-access
 
 if sys.version_info.major < 3:
     print(""""Python 2.7 is no longer supported in the DAOS build.
@@ -169,6 +170,11 @@ def update_rpm_version(version, tag):
     open("utils/rpms/daos.spec", "w").writelines(spec)  # pylint: disable=consider-using-with
 
     return True
+
+
+def get_scons_version(env):
+    """Get the version of Scons"""
+    return env._get_major_minor_revision(scons_raw_version)  # pylint: disable=protected-access
 
 
 def check_for_release_target():  # pylint: disable=too-many-locals
@@ -429,6 +435,11 @@ def scons():
         if not config.CheckHeader('stdatomic.h'):
             Exit('stdatomic.h is required to compile DAOS, update your compiler or distro version')
         config.Finish()
+
+    scons_ver = get_scons_version(deps_env)
+    if scons_ver >= (4, 0, 0):
+        deps_env.Tool("compilation_db")
+        deps_env.Alias("compiledb", deps_env.CompilationDatabase())
 
     # Define and load the components.  This will add more values to opt.
     prereqs = PreReqComponent(deps_env, opts)

--- a/utils/sl/fake_scons/SCons/Script/__init__.py
+++ b/utils/sl/fake_scons/SCons/Script/__init__.py
@@ -338,6 +338,10 @@ class DefaultEnvironment():
         """Fake require"""
         return
 
+    def CompilationDatabase(self):
+        """Fake CompilationDatabase"""
+        return []
+
 
 class Variables():
     """Fake variables"""

--- a/utils/sl/fake_scons/SCons/__init__.py
+++ b/utils/sl/fake_scons/SCons/__init__.py
@@ -19,6 +19,8 @@
 # SOFTWARE.
 """Fake SCons"""
 
+__version__ = []
+
 __all__ = ['Script',
            'Action',
            'Variables',


### PR DESCRIPTION
clangd use compile_command.json to do code completion and something else, generate this file is helpful to someone who using editor with completation based on clangd

---

tested under scons-3.1.2 and scons-4.6.0

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
