### PR TITLE
DAOS-14852 test: Fix JSON key lookup in NVMe space usage query

### DIFF
--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -406,6 +406,8 @@ class DmgCommand(DmgCommandBase):
         #               "serial": "CVFT534200AY400BGN",
         #               "pci_addr": "0000:05:00.0",
         #               "fw_rev": "8DV10131",
+        #               "vendor_id": "0x8086",
+        #               "pci_type": "",
         #               "socket_id": 0,
         #               "health_stats": null,
         #               "namespaces": [
@@ -416,7 +418,7 @@ class DmgCommand(DmgCommandBase):
         #               ],
         #               "smd_devices": [
         #                 {
-        #                   "dev_state": "NORMAL",
+        #                   "role_bits": 0,
         #                   "uuid": "259608d1-c469-4684-9986-9f7708b20ca3",
         #                   "tgt_ids": [ 0, 1, 2, 3, 4, 5, 6, 7 ],
         #                   "rank": 0,
@@ -428,12 +430,28 @@ class DmgCommand(DmgCommandBase):
         #                   "meta_wal_size": 0,
         #                   "rdb_size": 134217728,
         #                   "rdb_wal_size": 268435456,
-        #                   "health": null,
-        #                   "tr_addr": "0000:05:00.0",
-        #                   "roles": "data",
-        #                   "has_sys_xs": false
+        #                   "roles": "NA",
+        #                   "has_sys_xs": false,
+        #                   "ctrlr": {
+        #                     "info": "",
+        #                     "model": "",
+        #                     "serial": "",
+        #                     "pci_addr": "",
+        #                     "fw_rev": "",
+        #                     "vendor_id": "",
+        #                     "pci_type": "",
+        #                     "socket_id": 0,
+        #                     "health_stats": null,
+        #                     "namespaces": null,
+        #                     "smd_devices": null,
+        #                     "dev_state": "UNKNOWN",
+        #                     "led_state": "OFF"
+        #                   },
+        #                   "ctrlr_namespace_id": 1
         #                 }
         #               ]
+        #               "dev_state": "NORMAL",
+        #               "led_state": "NA",
         #             }
         #           ],
         #           "scm_modules": null,

--- a/src/tests/ftest/util/pool_create_all_base.py
+++ b/src/tests/ftest/util/pool_create_all_base.py
@@ -60,10 +60,8 @@ class PoolCreateAllTestBase(TestWithServers):
 
             nvme_bytes = 0
             for nvme_device in host_storage["storage"]["nvme_devices"]:
-                if nvme_device["smd_devices"] is None:
-                    continue
-                for smd_device in nvme_device["smd_devices"]:
-                    if smd_device["ctrlr"]["dev_state"] == "NORMAL":
+                if nvme_device["dev_state"] == "NORMAL":
+                    for smd_device in (nvme_device["smd_devices"] or []):
                         nvme_bytes += smd_device["usable_bytes"]
             nvme_engine_bytes = min(nvme_engine_bytes, nvme_bytes)
 
@@ -310,11 +308,10 @@ class PoolCreateAllTestBase(TestWithServers):
 
             nvme_bytes = 0
             for nvme_device in host_storage["storage"]["nvme_devices"]:
-                for smd_device in nvme_device["smd_devices"]:
-                    if smd_device["ctrlr"]["dev_state"] != "NORMAL":
-                        continue
-                    nvme_bytes += smd_device["total_bytes"]
-                    nvme_bytes -= smd_device["avail_bytes"]
+                if nvme_device["dev_state"] == "NORMAL":
+                    for smd_device in (nvme_device["smd_devices"] or []):
+                        nvme_bytes += smd_device["total_bytes"]
+                        nvme_bytes -= smd_device["avail_bytes"]
             if nvme_bytes < nvme_used_bytes[0]:
                 nvme_used_bytes[0] = nvme_bytes
             if nvme_bytes > nvme_used_bytes[1]:


### PR DESCRIPTION
Fix ftest key lookups for dev_state during storage query usage
which were broken in commit https://github.com/daos-stack/daos/commit/8e1c8468428e7b2ac97975300e18d0aaff8e381c.

Test-tag: pool,pool_create_all
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
