### PR TITLE
DAOS-14725 tests: avoid DER_EBUSY when test teardown

### DIFF
--- a/src/tests/suite/daos_base_tx.c
+++ b/src/tests/suite/daos_base_tx.c
@@ -704,6 +704,9 @@ dtx_resend_delay(test_arg_t *arg, daos_oclass_id_t oclass)
 	daos_fail_loc_set(0);
 	dtx_set_fail_loc(arg, 0);
 
+	/* Wait for the former delayed RPC before destroying the container to avoid DER_BUSY. */
+	sleep(2);
+
 	D_FREE(update_buf);
 	D_FREE(fetch_buf);
 	ioreq_fini(&req);
@@ -941,9 +944,9 @@ static const struct CMUnitTest dtx_tests[] = {
 	{"DTX19: DTX resend during bulk data transfer - multiple reps",
 	 dtx_19, NULL, test_case_teardown},
 	{"DTX20: race between DTX refresh and DTX resync",
-	 dtx_20, dtx_base_rf1_setup, test_case_teardown},
+	 dtx_20, dtx_base_rf1_setup, rebuild_sub_teardown},
 	{"DTX21: do not abort partially committed DTX",
-	 dtx_21, dtx_base_rf0_setup, test_case_teardown},
+	 dtx_21, dtx_base_rf0_setup, rebuild_sub_teardown},
 };
 
 static int

--- a/src/tests/suite/daos_verify_consistency.c
+++ b/src/tests/suite/daos_verify_consistency.c
@@ -352,8 +352,7 @@ vc_9(void **state)
 	oid = daos_test_oid_gen(arg->coh, dts_vc_class, 0, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 
-	vc_gen_modifications(arg, &req, oid, 7, 7, 7,
-			     DAOS_VC_DIFF_DKEY, 0, 0);
+	vc_gen_modifications(arg, &req, oid, 7, 7, 7, DAOS_VC_DIFF_DKEY | DAOS_FAIL_ALWAYS, 0, 0);
 
 	rc = vc_obj_verify(arg, oid);
 	assert_rc_equal(rc, -DER_MISMATCH);


### PR DESCRIPTION
1. Wait non-replied RPC before cleanup.
2. Use rebuild_sub_teardown to cleanup when rebuild is involved.
3. Properly inject fail_loc for object consistency verification.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
