### PR TITLE
DOS-14821 bio: introduce env var to ignore sys SSD fault

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -546,6 +546,7 @@ extern unsigned int	bio_chk_cnt_max;
 extern unsigned int	bio_numa_node;
 extern unsigned int	bio_spdk_max_unmap_cnt;
 extern unsigned int	bio_max_async_sz;
+extern bool		bio_ignore_sys_fault;
 
 int xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights,
 		       uint64_t timeout);

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -61,6 +61,8 @@ unsigned int bio_spdk_subsys_timeout = 25000;	/* ms */
 /* How many blob unmap calls can be called in a row */
 unsigned int bio_spdk_max_unmap_cnt = 32;
 unsigned int bio_max_async_sz = (1UL << 20) /* 1MB */;
+/* Ignore sys device faulty (only used for testing) */
+bool bio_ignore_sys_fault;
 
 struct bio_nvme_data {
 	ABT_mutex		 bd_mutex;
@@ -261,6 +263,9 @@ bio_nvme_init(const char *nvme_conf, int numa_node, unsigned int mem_size,
 
 	d_getenv_uint("DAOS_MAX_ASYNC_SZ", &bio_max_async_sz);
 	D_INFO("Max async data size is set to %u bytes\n", bio_max_async_sz);
+
+	d_getenv_bool("DAOS_IGNORE_SYS_SSD_FAULT", &bio_ignore_sys_fault);
+	D_INFO("SYS SSD fault is %s\n", bio_ignore_sys_fault ? "ignored" : "enabled");
 
 	/* Hugepages disabled */
 	if (mem_size == 0) {

--- a/src/tests/ftest/control/dmg_storage_query.yaml
+++ b/src/tests/ftest/control/dmg_storage_query.yaml
@@ -11,6 +11,8 @@ server_config:
   engines:
     0:
       storage: auto
+      env_vars:
+        - DAOS_IGNORE_SYS_SSD_FAULT=1
 pool:
   scm_size: 3000000000
   nvme_size: 9000000000

--- a/src/tests/ftest/daos_test/nvme_recovery.yaml
+++ b/src/tests/ftest/daos_test/nvme_recovery.yaml
@@ -22,6 +22,7 @@ server_config:
       log_mask: DEBUG
       env_vars:
         - D_LOG_FILE_APPEND_PID=1
+        - DAOS_IGNORE_SYS_SSD_FAULT=1
       storage: auto
     1:
       pinned_numa_node: 1
@@ -32,6 +33,7 @@ server_config:
       log_mask: DEBUG
       env_vars:
         - D_LOG_FILE_APPEND_PID=1
+        - DAOS_IGNORE_SYS_SSD_FAULT=1
       storage: auto
   transport_config:
     allow_insecure: true


### PR DESCRIPTION
Introduce env var to ignore sys SSD fault (sys SSD fault will
result in the engine being killed), this env var will be used
in tests.

Features: DmgStorageQuery DaosCoreTestNvme

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
