### PR TITLE
DAOS-14985 bio: Handle NVMe unplugged in list devs

### DIFF
--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -460,7 +460,10 @@ alloc_ctrlr_info(uuid_t dev_id, char *dev_name, struct bio_dev_info *b_info)
 	D_ASSERT(b_info->bdi_ctrlr == NULL);
 
 	if (dev_name == NULL) {
-		D_DEBUG(DB_MGMT, "missing bdev device name, skipping ctrlr info fetch\n");
+		D_DEBUG(DB_MGMT,
+			"missing bdev device name for device " DF_UUID ", skipping ctrlr "
+			"info fetch\n",
+			DP_UUID(dev_id));
 		return 0;
 	}
 

--- a/src/control/common/proto/ctl/addons.go
+++ b/src/control/common/proto/ctl/addons.go
@@ -51,3 +51,14 @@ func (vls *LedState) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// IsScannable returns true if NVMe device state indicates controller details are accessible.
+func (nc *NvmeController) IsScannable() bool {
+	return nc.DevState == NvmeDevState_NORMAL || nc.DevState == NvmeDevState_EVICTED ||
+		nc.DevState == NvmeDevState_NEW
+}
+
+// CanSupplyHealthStats returns true if NVMe device state indicates health stats are accessible.
+func (nc *NvmeController) CanSupplyHealthStats() bool {
+	return nc.DevState == NvmeDevState_NORMAL || nc.DevState == NvmeDevState_EVICTED
+}

--- a/src/control/server/ctl_smd_rpc_test.go
+++ b/src/control/server/ctl_smd_rpc_test.go
@@ -27,6 +27,7 @@ const (
 	devStateNew    = ctlpb.NvmeDevState_NEW
 	devStateNormal = ctlpb.NvmeDevState_NORMAL
 	devStateFaulty = ctlpb.NvmeDevState_EVICTED
+	devStateUnplug = ctlpb.NvmeDevState_UNPLUGGED
 
 	ledStateIdentify = ctlpb.LedState_QUICK_BLINK
 	ledStateNormal   = ctlpb.LedState_OFF
@@ -267,6 +268,15 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 										LedState: ledStateFault,
 									},
 								},
+								{
+									Uuid:   test.MockUUID(2),
+									TgtIds: []int32{},
+									Ctrlr: &ctlpb.NvmeController{
+										PciAddr:  "0000:8b:00.0",
+										DevState: devStateUnplug,
+										LedState: ledStateUnknown,
+									},
+								},
 							},
 						},
 					},
@@ -276,7 +286,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 						Message: &ctlpb.SmdDevResp{
 							Devices: []*ctlpb.SmdDevice{
 								{
-									Uuid:   test.MockUUID(2),
+									Uuid:   test.MockUUID(3),
 									TgtIds: []int32{0, 1, 2},
 									Ctrlr: &ctlpb.NvmeController{
 										PciAddr:  "0000:da:00.0",
@@ -285,7 +295,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 									},
 								},
 								{
-									Uuid:   test.MockUUID(3),
+									Uuid:   test.MockUUID(4),
 									TgtIds: []int32{3, 4, 5},
 									Ctrlr: &ctlpb.NvmeController{
 										PciAddr:  "0000:db:00.0",
@@ -320,13 +330,22 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 									LedState: ledStateFault,
 								},
 							},
+							{
+								Uuid:   test.MockUUID(2),
+								TgtIds: []int32{},
+								Ctrlr: &ctlpb.NvmeController{
+									PciAddr:  "0000:8b:00.0",
+									DevState: devStateUnplug,
+									LedState: ledStateUnknown,
+								},
+							},
 						},
 						Rank: uint32(0),
 					},
 					{
 						Devices: []*ctlpb.SmdDevice{
 							{
-								Uuid:   test.MockUUID(2),
+								Uuid:   test.MockUUID(3),
 								TgtIds: []int32{0, 1, 2},
 								Ctrlr: &ctlpb.NvmeController{
 									PciAddr:  "0000:da:00.0",
@@ -335,7 +354,7 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 								},
 							},
 							{
-								Uuid:   test.MockUUID(3),
+								Uuid:   test.MockUUID(4),
 								TgtIds: []int32{3, 4, 5},
 								Ctrlr: &ctlpb.NvmeController{
 									PciAddr:  "0000:db:00.0",

--- a/src/control/server/instance_storage_rpc.go
+++ b/src/control/server/instance_storage_rpc.go
@@ -198,6 +198,9 @@ func scanEngineBdevsOverDrpc(ctx context.Context, engine Engine, pbReq *ctlpb.Sc
 			return nil, errors.Errorf("smd %q has no ctrlr ref", sd.Uuid)
 		}
 
+		if sd.Ctrlr.DevState == ctlpb.NvmeDevState_UNPLUGGED {
+			continue
+		}
 		addr := sd.Ctrlr.PciAddr
 
 		if _, exists := seenCtrlrs[addr]; !exists {

--- a/src/control/server/instance_storage_rpc_test.go
+++ b/src/control/server/instance_storage_rpc_test.go
@@ -181,6 +181,19 @@ func TestIOEngineInstance_bdevScanEngine(t *testing.T) {
 				State: new(ctlpb.ResponseState),
 			},
 		},
+		"scan over drpc; unplugged ctrlr not shown": {
+			req: ctlpb.ScanNvmeReq{Meta: true},
+			smdRes: func() *ctlpb.SmdDevResp {
+				ssr := defSmdScanRes()
+				ssr.Devices[0].Ctrlr.DevState = ctlpb.NvmeDevState_UNPLUGGED
+				return ssr
+			}(),
+			healthRes: healthRespWithUsage(),
+			expResp: &ctlpb.ScanNvmeResp{
+				Ctrlrs: proto.NvmeControllers{},
+				State:  new(ctlpb.ResponseState),
+			},
+		},
 		"scan over drpc; with smd and health; missing ctrlr in smd": {
 			req: ctlpb.ScanNvmeReq{Meta: true, Health: true},
 			smdRes: func() *ctlpb.SmdDevResp {

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -1973,8 +1973,12 @@ ds_mgmt_smd_free_dev(Ctl__SmdDevice *dev)
 		D_FREE(dev->ctrlr->fw_rev);
 		D_FREE(dev->ctrlr->vendor_id);
 		D_FREE(dev->ctrlr->pci_dev_type);
-		if (dev->ctrlr->namespaces != NULL)
+		if (dev->ctrlr->namespaces != NULL) {
 			D_FREE(dev->ctrlr->namespaces[0]);
+			D_FREE(dev->ctrlr->namespaces);
+			dev->ctrlr->namespaces   = NULL;
+			dev->ctrlr->n_namespaces = 0;
+		}
 	}
 }
 

--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -340,6 +340,9 @@ add_ctrlr_details(Ctl__NvmeController *ctrlr, struct bio_dev_info *dev_info)
 {
 	int rc = 0;
 
+	rc = copy_str2ctrlr(&ctrlr->pci_addr, dev_info->bdi_traddr);
+	if (rc != 0)
+		return rc;
 	rc = copy_str2ctrlr(&ctrlr->model, dev_info->bdi_ctrlr->model);
 	if (rc != 0)
 		return rc;
@@ -459,10 +462,6 @@ ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 		ctl__nvme_controller__init(resp->devices[i]->ctrlr);
 		/* Set string fields to NULL to allow D_FREE to work as expected on cleanup */
 		ctrlr_reset_str_fields(resp->devices[i]->ctrlr);
-
-		rc = copy_str2ctrlr(&resp->devices[i]->ctrlr->pci_addr, dev_info->bdi_traddr);
-		if (rc != 0)
-			break;
 
 		if (dev_info->bdi_ctrlr != NULL) {
 			rc = add_ctrlr_details(resp->devices[i]->ctrlr, dev_info);

--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -338,11 +338,8 @@ ctrlr_reset_str_fields(Ctl__NvmeController *ctrlr)
 static int
 add_ctrlr_details(Ctl__NvmeController *ctrlr, struct bio_dev_info *dev_info)
 {
-	int rc;
+	int rc = 0;
 
-	rc = copy_str2ctrlr(&ctrlr->pci_addr, dev_info->bdi_traddr);
-	if (rc != 0)
-		return rc;
 	rc = copy_str2ctrlr(&ctrlr->model, dev_info->bdi_ctrlr->model);
 	if (rc != 0)
 		return rc;
@@ -363,6 +360,32 @@ add_ctrlr_details(Ctl__NvmeController *ctrlr, struct bio_dev_info *dev_info)
 	D_DEBUG(DB_MGMT, "ctrlr details: '%s' '%s' '%s' '%s' '%s' '%s' '%d'\n", ctrlr->pci_addr,
 		ctrlr->model, ctrlr->serial, ctrlr->fw_rev, ctrlr->vendor_id, ctrlr->pci_dev_type,
 		ctrlr->socket_id);
+
+	/* Populate NVMe namespace id and capacity */
+
+	if (dev_info->bdi_ctrlr->nss == NULL) {
+		D_ERROR("nss not initialized in bio_dev_info");
+		return -DER_INVAL;
+	}
+	D_ASSERT(dev_info->bdi_ctrlr->nss->next == NULL);
+
+	/* When describing a SMD, only one NVMe namespace is relevant */
+	D_ALLOC_ARRAY(ctrlr->namespaces, 1);
+	if (ctrlr->namespaces == NULL) {
+		return -DER_NOMEM;
+	}
+	D_ALLOC_PTR(ctrlr->namespaces[0]);
+	if (ctrlr->namespaces[0] == NULL) {
+		return -DER_NOMEM;
+	}
+	ctrlr->n_namespaces = 1;
+	ctl__nvme_controller__namespace__init(ctrlr->namespaces[0]);
+
+	ctrlr->namespaces[0]->id   = dev_info->bdi_ctrlr->nss->id;
+	ctrlr->namespaces[0]->size = dev_info->bdi_ctrlr->nss->size;
+
+	D_DEBUG(DB_MGMT, "ns id/size: '%d' '%ld'\n", ctrlr->namespaces[0]->id,
+		ctrlr->namespaces[0]->size);
 
 	return 0;
 }
@@ -426,12 +449,6 @@ ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 		for (j = 0; j < dev_info->bdi_tgt_cnt; j++)
 			resp->devices[i]->tgt_ids[j] = dev_info->bdi_tgts[j];
 
-		if (dev_info->bdi_ctrlr == NULL) {
-			D_ERROR("ctrlr not initialized in bio_dev_info");
-			rc = -DER_INVAL;
-			break;
-		}
-
 		/* Populate NVMe controller details */
 
 		D_ALLOC_PTR(resp->devices[i]->ctrlr);
@@ -443,40 +460,18 @@ ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 		/* Set string fields to NULL to allow D_FREE to work as expected on cleanup */
 		ctrlr_reset_str_fields(resp->devices[i]->ctrlr);
 
-		rc = add_ctrlr_details(resp->devices[i]->ctrlr, dev_info);
+		rc = copy_str2ctrlr(&resp->devices[i]->ctrlr->pci_addr, dev_info->bdi_traddr);
 		if (rc != 0)
 			break;
 
-		/* Populate NVMe namespace id and capacity */
-
-		if (dev_info->bdi_ctrlr->nss == NULL) {
-			D_ERROR("nss not initialized in bio_dev_info");
-			rc = -DER_INVAL;
-			break;
+		if (dev_info->bdi_ctrlr != NULL) {
+			rc = add_ctrlr_details(resp->devices[i]->ctrlr, dev_info);
+			if (rc != 0)
+				break;
+			resp->devices[i]->ctrlr_namespace_id = dev_info->bdi_ctrlr->nss->id;
+		} else {
+			D_DEBUG(DB_MGMT, "ctrlr not initialized in bio_dev_info, unplugged?");
 		}
-		D_ASSERT(dev_info->bdi_ctrlr->nss->next == NULL);
-
-		/* When describing a SMD, only one NVMe namespace is relevant */
-		D_ALLOC_ARRAY(resp->devices[i]->ctrlr->namespaces, 1);
-		if (resp->devices[i]->ctrlr->namespaces == NULL) {
-			rc = -DER_NOMEM;
-			break;
-		}
-		D_ALLOC_PTR(resp->devices[i]->ctrlr->namespaces[0]);
-		if (resp->devices[i]->ctrlr->namespaces[0] == NULL) {
-			rc = -DER_NOMEM;
-			break;
-		}
-		resp->devices[i]->ctrlr->n_namespaces = 1;
-		ctl__nvme_controller__namespace__init(resp->devices[i]->ctrlr->namespaces[0]);
-
-		resp->devices[i]->ctrlr->namespaces[0]->id   = dev_info->bdi_ctrlr->nss->id;
-		resp->devices[i]->ctrlr->namespaces[0]->size = dev_info->bdi_ctrlr->nss->size;
-		resp->devices[i]->ctrlr_namespace_id         = dev_info->bdi_ctrlr->nss->id;
-
-		D_DEBUG(DB_MGMT, "ns id/size: '%d' '%ld'\n",
-			resp->devices[i]->ctrlr->namespaces[0]->id,
-			resp->devices[i]->ctrlr->namespaces[0]->size);
 
 		/* Populate NVMe device state */
 
@@ -484,7 +479,6 @@ ds_mgmt_smd_list_devs(Ctl__SmdDevResp *resp)
 			resp->devices[i]->ctrlr->dev_state = CTL__NVME_DEV_STATE__UNPLUGGED;
 			goto next_dev;
 		}
-
 		if ((dev_info->bdi_flags & NVME_DEV_FL_FAULTY) != 0)
 			resp->devices[i]->ctrlr->dev_state = CTL__NVME_DEV_STATE__EVICTED;
 		else if ((dev_info->bdi_flags & NVME_DEV_FL_INUSE) == 0)


### PR DESCRIPTION
dmg storage query list-devices fails if run after a NVMe device is
unplugged during a physical hot-remove. The failure is due to
UNPLUGGED NVMe device state resulting in a SMD object not being
populated with a NVMe controller reference. Unplugged devices should
be reported in list-devices and ignored in storage scan so handle
UNPLUGGED device state without returning an error.

Features: control nvme
Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
