### PR TITLE
DAOS-15009 mgmt: make set_rank & set_up reentrant

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2569,6 +2569,10 @@ crt_rank_self_set(d_rank_t rank, uint32_t group_version_min)
 	}
 
 	if (default_grp_priv->gp_self != CRT_NO_RANK) {
+		if (default_grp_priv->gp_self == rank) {
+			D_WARN("Self rank was already set to %d, skip\n", rank);
+			D_GOTO(out, rc);
+		}
 		D_ERROR("Self rank was already set to %d\n",
 			default_grp_priv->gp_self);
 		D_GOTO(out, rc = -DER_INVAL);

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -429,6 +429,12 @@ dss_init_state_set(enum dss_init_state state)
 	ABT_mutex_unlock(server_init_state_mutex);
 }
 
+enum dss_init_state
+dss_init_state_get()
+{
+	return server_init_state;
+}
+
 static int
 abt_max_num_xstreams(void)
 {

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -804,6 +804,7 @@ enum dss_media_error_type {
 };
 
 void dss_init_state_set(enum dss_init_state state);
+enum dss_init_state dss_init_state_get();
 
 /** Call module setup from drpc setup call handler. */
 int dss_module_setup_all(void);

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -478,6 +478,12 @@ dss_init_state_set(enum dss_init_state state)
 {
 }
 
+enum dss_init_state
+dss_init_state_get()
+{
+	return 0;
+}
+
 int
 dss_module_setup_all()
 {


### PR DESCRIPTION
- restart a MD-on-SDD single node daos_server
- createEngine will call SystemJoin send a JoinReq to daos system
- this req will return only after engine has restore self state, which maybe cause JoinReq timeout
- JoinReq retry to call SetUpRank, but engine’s rank was set by previous request, this will cause engine will return EINVAL to server, and make engine start failed

solution:

- we can make SetRank and SetUp reentrant

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
