### PR TITLE
DAOS-14969 test: Fix setting crt_timeout for daos_test/suite.py

### DIFF
--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -40,6 +40,7 @@ pool:
 server_config:
   name: daos_server
   engines_per_host: 2
+  crt_timeout: 60
   engines:
     0:
       pinned_numa_node: 0
@@ -191,5 +192,3 @@ daos_tests:
     test_daos_extend_simple: 5
     test_daos_rebuild_ec: 43
     test_daos_degraded_ec: 29
-  crt_timeout:
-    test_daos_oid_allocator: 60

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -96,13 +96,6 @@ class DaosCoreBase(TestWithServers):
                         ["=".join(items) for items in list(env_dict.items())]
                     )
 
-        # Update any other server settings unique to this test method
-        for setting in ["crt_timeout"]:
-            value = self.get_test_param(setting)
-            if value is not None:
-                for server_mgr in self.server_managers:
-                    server_mgr.manager.job.yaml.set_value(setting, value)
-
         # Start the servers
         return super().start_server_managers(force=force)
 

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -99,10 +99,9 @@ class DaosCoreBase(TestWithServers):
         # Update any other server settings unique to this test method
         for setting in ["crt_timeout"]:
             value = self.get_test_param(setting)
-            if value:
+            if value is not None:
                 for server_mgr in self.server_managers:
-                    for engine_params in server_mgr.manager.job.yaml.engine_params:
-                        engine_params.set_value(setting, value)
+                    server_mgr.manager.job.yaml.set_value(setting, value)
 
         # Start the servers
         return super().start_server_managers(force=force)


### PR DESCRIPTION
Previous changes were prematurely landed and this fixes the intended change.

Test-repeat: 10
Test-tag: test_daos_oid_allocator test_daos_management

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
