### PR TITLE
DAOS-15037 client: Pass vectorized write to dfs

### DIFF
--- a/src/client/dfuse/il/int_read.c
+++ b/src/client/dfuse/il/int_read.c
@@ -13,20 +13,14 @@
 #include "ioil.h"
 
 static ssize_t
-read_bulk(char *buff, size_t len, off_t position, struct fd_entry *entry, int *errcode)
+read_bulksgl(d_sg_list_t *sgl, size_t len, off_t position, struct fd_entry *entry, int *errcode)
 {
-	daos_size_t	read_size = 0;
-	d_iov_t		iov       = {};
-	d_sg_list_t	sgl       = {};
+	daos_size_t     read_size = 0;
 	daos_event_t	ev;
 	daos_handle_t	eqh;
 	int		rc;
 
 	DFUSE_TRA_DEBUG(entry->fd_dfsoh, "%#zx-%#zx", position, position + len - 1);
-
-	sgl.sg_nr = 1;
-	d_iov_set(&iov, (void *)buff, len);
-	sgl.sg_iovs = &iov;
 
 	rc = ioil_get_eqh(&eqh);
 	if (rc == 0) {
@@ -39,8 +33,8 @@ read_bulk(char *buff, size_t len, off_t position, struct fd_entry *entry, int *e
 			D_GOTO(out, rc = daos_der2errno(rc));
 		}
 
-		rc = dfs_read(entry->fd_cont->ioc_dfs, entry->fd_dfsoh, &sgl, position,
-			      &read_size, &ev);
+		rc = dfs_read(entry->fd_cont->ioc_dfs, entry->fd_dfsoh, sgl, position, &read_size,
+			      &ev);
 		if (rc)
 			D_GOTO(out, rc);
 
@@ -57,7 +51,7 @@ read_bulk(char *buff, size_t len, off_t position, struct fd_entry *entry, int *e
 		}
 		rc = ev.ev_error;
 	} else {
-		rc = dfs_read(entry->fd_cont->ioc_dfs, entry->fd_dfsoh, &sgl, position, &read_size,
+		rc = dfs_read(entry->fd_cont->ioc_dfs, entry->fd_dfsoh, sgl, position, &read_size,
 			      NULL);
 	}
 out:
@@ -72,29 +66,43 @@ out:
 ssize_t
 ioil_do_pread(char *buff, size_t len, off_t position, struct fd_entry *entry, int *errcode)
 {
-	return read_bulk(buff, len, position, entry, errcode);
+	d_iov_t     iov = {};
+	d_sg_list_t sgl = {};
+
+	sgl.sg_nr = 1;
+	d_iov_set(&iov, (void *)buff, len);
+	sgl.sg_iovs = &iov;
+
+	return read_bulksgl(&sgl, len, position, entry, errcode);
 }
 
 ssize_t
 ioil_do_preadv(const struct iovec *iov, int count, off_t position, struct fd_entry *entry,
 	       int *errcode)
 {
-	ssize_t bytes_read;
+	d_iov_t    *diov;
+	d_sg_list_t sgl        = {};
 	ssize_t total_read = 0;
 	int     i;
+	int         rc;
 
-	for (i = 0; i < count; i++) {
-		bytes_read = read_bulk(iov[i].iov_base, iov[i].iov_len, position, entry, errcode);
-
-		if (bytes_read == -1)
-			return (ssize_t)-1;
-
-		if (bytes_read == 0)
-			return total_read;
-
-		position += bytes_read;
-		total_read += bytes_read;
+	D_ALLOC_ARRAY(diov, count);
+	if (diov == NULL) {
+		*errcode = ENOMEM;
+		return -1;
 	}
 
-	return total_read;
+	for (i = 0; i < count; i++) {
+		d_iov_set(&diov[i], iov[i].iov_base, iov[i].iov_len);
+		total_read += iov[i].iov_len;
+	}
+
+	sgl.sg_nr   = count;
+	sgl.sg_iovs = diov;
+
+	rc = read_bulksgl(&sgl, total_read, position, entry, errcode);
+
+	D_FREE(diov);
+
+	return rc;
 }

--- a/src/client/dfuse/il/int_read.c
+++ b/src/client/dfuse/il/int_read.c
@@ -94,6 +94,7 @@ ioil_do_preadv(const struct iovec *iov, int count, off_t position, struct fd_ent
 	}
 
 	for (i = 0, new_count = 0; i < count; i++) {
+		/** See DAOS-15089. This is a workaround */
 		if (iov[i].iov_len == 0)
 			continue;
 		d_iov_set(&diov[new_count++], iov[i].iov_base, iov[i].iov_len);

--- a/src/client/dfuse/il/int_write.c
+++ b/src/client/dfuse/il/int_write.c
@@ -14,20 +14,14 @@
 
 #include "ioil.h"
 
-ssize_t
-ioil_do_writex(const char *buff, size_t len, off_t position, struct fd_entry *entry, int *errcode)
+static ssize_t
+ioil_do_writesgl(d_sg_list_t *sgl, size_t len, off_t position, struct fd_entry *entry, int *errcode)
 {
-	d_iov_t		iov = {};
-	d_sg_list_t	sgl = {};
 	daos_event_t	ev;
 	daos_handle_t	eqh;
 	int		rc;
 
 	DFUSE_TRA_DEBUG(entry->fd_dfsoh, "%#zx-%#zx", position, position + len - 1);
-
-	sgl.sg_nr = 1;
-	d_iov_set(&iov, (void *)buff, len);
-	sgl.sg_iovs = &iov;
 
 	rc = ioil_get_eqh(&eqh);
 	if (rc == 0) {
@@ -40,7 +34,7 @@ ioil_do_writex(const char *buff, size_t len, off_t position, struct fd_entry *en
 			D_GOTO(out, rc = daos_der2errno(rc));
 		}
 
-		rc = dfs_write(entry->fd_cont->ioc_dfs, entry->fd_dfsoh, &sgl, position, &ev);
+		rc = dfs_write(entry->fd_cont->ioc_dfs, entry->fd_dfsoh, sgl, position, &ev);
 		if (rc)
 			D_GOTO(out, rc);
 
@@ -57,7 +51,7 @@ ioil_do_writex(const char *buff, size_t len, off_t position, struct fd_entry *en
 		}
 		rc = ev.ev_error;
 	} else {
-		rc = dfs_write(entry->fd_cont->ioc_dfs, entry->fd_dfsoh, &sgl, position, NULL);
+		rc = dfs_write(entry->fd_cont->ioc_dfs, entry->fd_dfsoh, sgl, position, NULL);
 	}
 out:
 	if (rc) {
@@ -69,26 +63,45 @@ out:
 }
 
 ssize_t
+ioil_do_writex(const char *buff, size_t len, off_t position, struct fd_entry *entry, int *errcode)
+{
+	d_iov_t     iov = {};
+	d_sg_list_t sgl = {};
+
+	sgl.sg_nr = 1;
+	d_iov_set(&iov, (void *)buff, len);
+	sgl.sg_iovs = &iov;
+
+	return ioil_do_writesgl(&sgl, len, position, entry, errcode);
+}
+
+ssize_t
 ioil_do_pwritev(const struct iovec *iov, int count, off_t position, struct fd_entry *entry,
 		int *errcode)
 {
-	ssize_t bytes_written;
-	ssize_t total_write = 0;
+	d_iov_t    *diov;
+	d_sg_list_t sgl         = {};
+	size_t      total_write = 0;
 	int     i;
+	int         rc;
 
-	for (i = 0; i < count; i++) {
-		bytes_written =
-		    ioil_do_writex(iov[i].iov_base, iov[i].iov_len, position, entry, errcode);
-
-		if (bytes_written == -1)
-			return (ssize_t)-1;
-
-		if (bytes_written == 0)
-			return total_write;
-
-		position += bytes_written;
-		total_write += bytes_written;
+	D_ALLOC_ARRAY(diov, count);
+	if (diov == NULL) {
+		*errcode = ENOMEM;
+		return -1;
 	}
 
-	return total_write;
+	for (i = 0; i < count; i++) {
+		d_iov_set(&diov[i], iov[i].iov_base, iov[i].iov_len);
+		total_write += iov[i].iov_len;
+	}
+
+	sgl.sg_nr   = count;
+	sgl.sg_iovs = diov;
+
+	rc = ioil_do_writesgl(&sgl, total_write, position, entry, errcode);
+
+	D_FREE(diov);
+
+	return rc;
 }

--- a/src/client/dfuse/il/int_write.c
+++ b/src/client/dfuse/il/int_write.c
@@ -93,6 +93,7 @@ ioil_do_pwritev(const struct iovec *iov, int count, off_t position, struct fd_en
 	}
 
 	for (i = 0, new_count = 0;; i < count; i++) {
+		/** See DAOS-15089. This is a workaround */
 		if (iov[i].iov_len == 0)
 			continue;
 		d_iov_set(&diov[new_count++], iov[i].iov_base, iov[i].iov_len);

--- a/src/client/dfuse/il/int_write.c
+++ b/src/client/dfuse/il/int_write.c
@@ -92,7 +92,7 @@ ioil_do_pwritev(const struct iovec *iov, int count, off_t position, struct fd_en
 		return -1;
 	}
 
-	for (i = 0, new_count = 0;; i < count; i++) {
+	for (i = 0, new_count = 0; i < count; i++) {
 		/** See DAOS-15089. This is a workaround */
 		if (iov[i].iov_len == 0)
 			continue;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4564,8 +4564,7 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 			}
 			if (iov->iov_len > iov->iov_buf_len) {
 				DL_ERROR(-DER_INVAL,
-					 "invalid args, iov_len " DF_U64 ", iov_buf_len " DF_U64
-					 "\n",
+					 "invalid args, iov_len " DF_U64 ", iov_buf_len " DF_U64,
 					 iov->iov_len, iov->iov_buf_len);
 				return -DER_INVAL;
 			} else if (iov->iov_len < iov->iov_buf_len) {
@@ -4574,7 +4573,7 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 			count++;
 		}
 		if (count == 0 && iod->iod_size != DAOS_REC_ANY) {
-			DL_ERROR(-DER_INVAL, "invalid args, sgl contained only 0 length entries\n");
+			DL_ERROR(-DER_INVAL, "invalid args, sgl contained only 0 length entries");
 			return -DER_INVAL;
 		}
 	}

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4542,7 +4542,7 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 	d_sg_list_t	*sg, *sg_dup;
 	d_iov_t		*iov, *iov_dup;
 	bool		 dup = false;
-	uint32_t         i, j, count;
+	uint32_t         i, j;
 	int		 rc = 0;
 
 	sgls = args->sgls;
@@ -4552,29 +4552,17 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 	for (i = 0; i < args->nr; i++) {
 		sg = &sgls[i];
 		iod = &args->iods[i];
-		for (j = 0, count = 0; j < sg->sg_nr; j++) {
+		for (j = 0; j < sg->sg_nr; j++) {
 			iov = &sg->sg_iovs[j];
-			if (iov->iov_len == 0) {
-				/** POSIX supports passing 0 length entries in
-				 * iov.  Since lower layers don't support this,
-				 * let's remove them when we duplicate
-				 */
-				dup = true;
-				continue;
-			}
-			if (iov->iov_len > iov->iov_buf_len) {
-				DL_ERROR(-DER_INVAL,
-					 "invalid args, iov_len " DF_U64 ", iov_buf_len " DF_U64,
-					 iov->iov_len, iov->iov_buf_len);
+			if (iov->iov_len > iov->iov_buf_len ||
+			    (iov->iov_len == 0 && iod->iod_size != DAOS_REC_ANY)) {
+				D_ERROR("invalid args, iov_len " DF_U64 ", iov_buf_len " DF_U64
+					"\n",
+					iov->iov_len, iov->iov_buf_len);
 				return -DER_INVAL;
 			} else if (iov->iov_len < iov->iov_buf_len) {
 				dup = true;
 			}
-			count++;
-		}
-		if (count == 0 && iod->iod_size != DAOS_REC_ANY) {
-			DL_ERROR(-DER_INVAL, "invalid args, sgl contained only 0 length entries");
-			return -DER_INVAL;
 		}
 	}
 	if (dup == false)
@@ -4591,15 +4579,12 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 		if (rc)
 			goto failed;
 
-		for (j = 0, count = 0; j < sg_dup->sg_nr; j++) {
-			iov = &sg->sg_iovs[j];
-			if (iov->iov_len == 0)
-				continue;
-			iov_dup              = &sg_dup->sg_iovs[count++];
+		for (j = 0; j < sg_dup->sg_nr; j++) {
+			iov_dup              = &sg_dup->sg_iovs[j];
+			iov                  = &sg->sg_iovs[j];
 			*iov_dup = *iov;
 			iov_dup->iov_buf_len = iov_dup->iov_len;
 		}
-		sg_dup->sg_nr = count;
 	}
 	obj_auxi->reasb_req.orr_usgls = sgls;
 	obj_auxi->rw_args.sgls_dup = sgls_dup;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4542,7 +4542,7 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 	d_sg_list_t	*sg, *sg_dup;
 	d_iov_t		*iov, *iov_dup;
 	bool		 dup = false;
-	uint32_t         i, j;
+	uint32_t         i, j, count;
 	int		 rc = 0;
 
 	sgls = args->sgls;
@@ -4552,17 +4552,29 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 	for (i = 0; i < args->nr; i++) {
 		sg = &sgls[i];
 		iod = &args->iods[i];
-		for (j = 0; j < sg->sg_nr; j++) {
+		for (j = 0, count = 0; j < sg->sg_nr; j++) {
 			iov = &sg->sg_iovs[j];
-			if (iov->iov_len > iov->iov_buf_len ||
-			    (iov->iov_len == 0 && iod->iod_size != DAOS_REC_ANY)) {
-				D_ERROR("invalid args, iov_len " DF_U64 ", iov_buf_len " DF_U64
-					"\n",
-					iov->iov_len, iov->iov_buf_len);
+			if (iov->iov_len == 0) {
+				/** POSIX supports passing 0 length entries in
+				 * iov.  Since lower layers don't support this,
+				 * let's remove them when we duplicate
+				 */
+				dup = true;
+				continue;
+			}
+			if (iov->iov_len > iov->iov_buf_len) {
+				DL_ERROR(-DER_INVAL,
+					 "invalid args, iov_len " DF_U64 ", iov_buf_len " DF_U64,
+					 iov->iov_len, iov->iov_buf_len);
 				return -DER_INVAL;
 			} else if (iov->iov_len < iov->iov_buf_len) {
 				dup = true;
 			}
+			count++;
+		}
+		if (count == 0 && iod->iod_size != DAOS_REC_ANY) {
+			DL_ERROR(-DER_INVAL, "invalid args, sgl contained only 0 length entries");
+			return -DER_INVAL;
 		}
 	}
 	if (dup == false)
@@ -4579,12 +4591,15 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 		if (rc)
 			goto failed;
 
-		for (j = 0; j < sg_dup->sg_nr; j++) {
-			iov_dup              = &sg_dup->sg_iovs[j];
-			iov                  = &sg->sg_iovs[j];
+		for (j = 0, count = 0; j < sg_dup->sg_nr; j++) {
+			iov = &sg->sg_iovs[j];
+			if (iov->iov_len == 0)
+				continue;
+			iov_dup              = &sg_dup->sg_iovs[count++];
 			*iov_dup = *iov;
 			iov_dup->iov_buf_len = iov_dup->iov_len;
 		}
+		sg_dup->sg_nr = count;
 	}
 	obj_auxi->reasb_req.orr_usgls = sgls;
 	obj_auxi->rw_args.sgls_dup = sgls_dup;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4564,7 +4564,8 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 			}
 			if (iov->iov_len > iov->iov_buf_len) {
 				DL_ERROR(-DER_INVAL,
-					 "invalid args, iov_len " DF_U64 ", iov_buf_len " DF_U64,
+					 "invalid args, iov_len " DF_U64 ", iov_buf_len " DF_U64
+					 "\n",
 					 iov->iov_len, iov->iov_buf_len);
 				return -DER_INVAL;
 			} else if (iov->iov_len < iov->iov_buf_len) {
@@ -4573,7 +4574,7 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 			count++;
 		}
 		if (count == 0 && iod->iod_size != DAOS_REC_ANY) {
-			DL_ERROR(-DER_INVAL, "invalid args, sgl contained only 0 length entries");
+			DL_ERROR(-DER_INVAL, "invalid args, sgl contained only 0 length entries\n");
 			return -DER_INVAL;
 		}
 	}

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4542,7 +4542,7 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 	d_sg_list_t	*sg, *sg_dup;
 	d_iov_t		*iov, *iov_dup;
 	bool		 dup = false;
-	uint32_t	 i, j;
+	uint32_t         i, j, count;
 	int		 rc = 0;
 
 	sgls = args->sgls;
@@ -4552,16 +4552,30 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 	for (i = 0; i < args->nr; i++) {
 		sg = &sgls[i];
 		iod = &args->iods[i];
-		for (j = 0; j < sg->sg_nr; j++) {
+		for (j = 0, count = 0; j < sg->sg_nr; j++) {
 			iov = &sg->sg_iovs[j];
-			if (iov->iov_len > iov->iov_buf_len ||
-			    (iov->iov_len == 0 && iod->iod_size != DAOS_REC_ANY)) {
-				D_ERROR("invalid args, iov_len "DF_U64", iov_buf_len "DF_U64"\n",
-					iov->iov_len, iov->iov_buf_len);
+			if (iov->iov_len == 0) {
+				/** POSIX supports passing 0 length entries in
+				 * iov.  Since lower layers don't support this,
+				 * let's remove them when we duplicate
+				 */
+				dup = true;
+				continue;
+			}
+			if (iov->iov_len > iov->iov_buf_len) {
+				DL_ERROR(-DER_INVAL,
+					 "invalid args, iov_len " DF_U64 ", iov_buf_len " DF_U64
+					 "\n",
+					 iov->iov_len, iov->iov_buf_len);
 				return -DER_INVAL;
 			} else if (iov->iov_len < iov->iov_buf_len) {
 				dup = true;
 			}
+			count++;
+		}
+		if (count == 0 && iod->iod_size != DAOS_REC_ANY) {
+			DL_ERROR(-DER_INVAL, "invalid args, sgl contained only 0 length entries\n");
+			return -DER_INVAL;
 		}
 	}
 	if (dup == false)
@@ -4578,12 +4592,15 @@ obj_update_sgls_dup(struct obj_auxi_args *obj_auxi, daos_obj_update_t *args)
 		if (rc)
 			goto failed;
 
-		for (j = 0; j < sg_dup->sg_nr; j++) {
-			iov_dup = &sg_dup->sg_iovs[j];
+		for (j = 0, count = 0; j < sg_dup->sg_nr; j++) {
 			iov = &sg->sg_iovs[j];
+			if (iov->iov_len == 0)
+				continue;
+			iov_dup              = &sg_dup->sg_iovs[count++];
 			*iov_dup = *iov;
 			iov_dup->iov_buf_len = iov_dup->iov_len;
 		}
+		sg_dup->sg_nr = count;
 	}
 	obj_auxi->reasb_req.orr_usgls = sgls;
 	obj_auxi->rw_args.sgls_dup = sgls_dup;


### PR DESCRIPTION
Rather than sending one entry at a time, we create a d_iov_t for the whole write.  This shows about a 13x performance increase for checkpointing in maxtext
AI application.

Required-githooks: true

Change-Id: Ib14b189ad37eb799d84d19794fc06077c3436989

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
