### PR TITLE
DAOS-15049 dfs: fix bug in setattr when mtime and size are being set

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -5408,11 +5408,12 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	bool			set_size = false;
 	bool			set_mtime = false;
 	bool			set_ctime = false;
-	int			i = 0;
-	size_t			len;
-	int			rc;
+	int                     i = 0, hlc_recx_idx = 0;
+	size_t                  len;
 	uint64_t		obj_hlc = 0;
 	struct stat		rstat = {};
+	daos_array_stbuf_t      array_stbuf = {0};
+	int                     rc;
 
 	if (dfs == NULL || !dfs->mounted)
 		return EINVAL;
@@ -5509,6 +5510,10 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		d_iov_set(&sg_iovs[i], &obj_hlc, sizeof(uint64_t));
 		recxs[i].rx_idx = HLC_IDX;
 		recxs[i].rx_nr = sizeof(uint64_t);
+		if (flags & DFS_SET_ATTR_SIZE) {
+			/** we need to update this again after the set size */
+			hlc_recx_idx = i;
+		}
 		i++;
 
 		set_mtime = true;
@@ -5558,38 +5563,41 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		rstat.st_blocks = (stbuf->st_size + (1 << 9) - 1) >> 9;
 		rstat.st_size = stbuf->st_size;
 
-		/* mtime and ctime need to be updated too only if not set earlier */
-		if (!set_mtime || !set_ctime) {
-			daos_array_stbuf_t	array_stbuf = {0};
+		/**
+		 * if mtime is set, we need to to just update the hlc on the entry. if mtime and/or
+		 * ctime were not set, we need to update the stat buf returned. both cases require
+		 * an array stat for the hlc.
+		 */
+		/** TODO - need an array API to just stat the max epoch without size */
+		rc = daos_array_stat(obj->oh, th, &array_stbuf, NULL);
+		if (rc)
+			D_GOTO(out_obj, rc = daos_der2errno(rc));
 
-			/** TODO - need an array API to just stat the max epoch without size */
-			rc = daos_array_stat(obj->oh, th, &array_stbuf, NULL);
-			if (rc)
+		if (!set_mtime) {
+			rc = d_hlc2timespec(array_stbuf.st_max_epoch, &rstat.st_mtim);
+			if (rc) {
+				D_ERROR("d_hlc2timespec() failed " DF_RC "\n", DP_RC(rc));
 				D_GOTO(out_obj, rc = daos_der2errno(rc));
-
-			if (!set_mtime) {
-				rc = d_hlc2timespec(array_stbuf.st_max_epoch, &rstat.st_mtim);
-				if (rc) {
-					D_ERROR("d_hlc2timespec() failed "DF_RC"\n", DP_RC(rc));
-					D_GOTO(out_obj, rc = daos_der2errno(rc));
-				}
 			}
+		} else {
+			D_ASSERT(hlc_recx_idx > 0);
+			D_ASSERT(recxs[hlc_recx_idx].rx_idx == HLC_IDX);
+			d_iov_set(&sg_iovs[hlc_recx_idx], &array_stbuf.st_max_epoch,
+				  sizeof(uint64_t));
+		}
 
-			if (!set_ctime) {
-				rc = d_hlc2timespec(array_stbuf.st_max_epoch, &rstat.st_ctim);
-				if (rc) {
-					D_ERROR("d_hlc2timespec() failed "DF_RC"\n", DP_RC(rc));
-					D_GOTO(out_obj, rc = daos_der2errno(rc));
-				}
+		if (!set_ctime) {
+			rc = d_hlc2timespec(array_stbuf.st_max_epoch, &rstat.st_ctim);
+			if (rc) {
+				D_ERROR("d_hlc2timespec() failed " DF_RC "\n", DP_RC(rc));
+				D_GOTO(out_obj, rc = daos_der2errno(rc));
 			}
 		}
 	}
 
 	iod.iod_nr = i;
-
 	if (i == 0)
 		D_GOTO(out_stat, rc = 0);
-
 	sgl.sg_nr	= i;
 	sgl.sg_nr_out	= 0;
 	sgl.sg_iovs	= &sg_iovs[0];

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1495,6 +1495,11 @@ run_time_tests(dfs_obj_t *obj, char *name, int mode)
 	struct timespec		prev_ts, first_ts;
 	daos_size_t		size;
 	dfs_obj_t		*tmp_obj;
+	struct tm                tm = {0};
+	time_t                   ts;
+	char                    *p;
+	struct tm               *timeptr;
+	char                     time_str[64];
 	int			rc;
 
 	rc = dfs_stat(dfs_mt, NULL, name, &stbuf);
@@ -1582,8 +1587,34 @@ run_time_tests(dfs_obj_t *obj, char *name, int mode)
 	prev_ts.tv_sec = stbuf.st_mtim.tv_sec;
 	prev_ts.tv_nsec = stbuf.st_mtim.tv_nsec;
 
-	/** set size on file with dfs_osetattr and stat at same time */
 	if (S_ISREG(mode)) {
+		/** set mtime and size at the same time; mtime should be what we set */
+		memset(&stbuf, 0, sizeof(stbuf));
+		stbuf.st_size = 1000;
+		p             = strptime("2023-12-31", "%Y-%m-%d", &tm);
+		assert_non_null(p);
+		ts                    = mktime(&tm);
+		stbuf.st_mtim.tv_sec  = ts;
+		stbuf.st_mtim.tv_nsec = 0;
+		rc = dfs_osetattr(dfs_mt, obj, &stbuf, DFS_SET_ATTR_SIZE | DFS_SET_ATTR_MTIME);
+		assert_int_equal(rc, 0);
+		assert_int_equal(stbuf.st_size, 1000);
+		/** check the mtime was updated with the setattr */
+		assert_int_equal(ts, stbuf.st_mtim.tv_sec);
+		timeptr = localtime(&stbuf.st_mtim.tv_sec);
+		strftime(time_str, sizeof(time_str), "%Y-%m-%d", timeptr);
+		print_message("mtime = %s\n", time_str);
+		assert_true(strncmp("2023", time_str, 4) == 0);
+
+		memset(&stbuf, 0, sizeof(stbuf));
+		rc = dfs_ostat(dfs_mt, obj, &stbuf);
+		assert_int_equal(rc, 0);
+		assert_int_equal(stbuf.st_size, 1000);
+		timeptr = localtime(&stbuf.st_mtim.tv_sec);
+		strftime(time_str, sizeof(time_str), "%Y-%m-%d", timeptr);
+		assert_int_equal(ts, stbuf.st_mtim.tv_sec);
+		assert_true(strncmp("2023", time_str, 4) == 0);
+
 		memset(&stbuf, 0, sizeof(stbuf));
 		stbuf.st_size = 1024;
 		rc = dfs_osetattr(dfs_mt, obj, &stbuf, DFS_SET_ATTR_SIZE);
@@ -1592,12 +1623,6 @@ run_time_tests(dfs_obj_t *obj, char *name, int mode)
 		/** check the mtime was updated with the setattr */
 		assert_true(check_ts(prev_ts, stbuf.st_mtim));
 	}
-
-	struct tm	tm = {0};
-	time_t		ts;
-	char		*p;
-	struct tm       *timeptr;
-	char		time_str[64];
 
 	/** set the mtime to 2020 */
 	p = strptime("2020-12-31", "%Y-%m-%d", &tm);


### PR DESCRIPTION
- in dfs_osetattr(), if user sets both mtime and size, the hlc for the mtime is not being update on storage. To fix that, use the hlc reported from the array_stat and update that when updating the mtime in the entry.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
