### PR TITLE
DAOS-14474,14219,14476,15049 dfs: dfs bug fixes

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -6591,7 +6591,7 @@ oit_mark_cb(dfs_t *dfs, dfs_obj_t *parent, const char name[], void *args)
 	}
 
 	/** open the entry name and get the oid */
-	rc = dfs_lookup_rel(dfs, parent, name, O_RDONLY, &obj, NULL, NULL);
+	rc = dfs_lookup_rel(dfs, parent, name, O_RDONLY | O_NOFOLLOW, &obj, NULL, NULL);
 	if (rc) {
 		D_ERROR("dfs_lookup_rel() of %s failed: %d\n", name, rc);
 		return rc;

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -3548,13 +3548,10 @@ lookup_rel_path(dfs_t *dfs, dfs_obj_t *root, const char *path, int flags,
 lookup_rel_path_loop:
 
 		/*
-		 * Open the directory object one level up.
-		 * Since fetch_entry does not support ".",
-		 * we can't support ".." as the last entry,
-		 * nor can we support "../.." because we don't
-		 * have parent.parent_oid and parent.mode.
-		 * For now, represent this partial state with
-		 * parent_fully_valid.
+		 * Open the directory object one level up.  Since fetch_entry does not support ".",
+		 * we can't support ".." as the last entry, nor can we support "../.." because we
+		 * don't have parent.parent_oid and parent.mode.  For now, represent this partial
+		 * state with parent_fully_valid.
 		 */
 		parent_fully_valid = true;
 		if (strcmp(token, "..") == 0) {
@@ -3632,15 +3629,23 @@ lookup_rel_path_loop:
 			}
 
 			if (stbuf) {
-				daos_size_t size;
+				daos_array_stbuf_t array_stbuf = {0};
 
-				rc = daos_array_get_size(obj->oh, DAOS_TX_NONE, &size, NULL);
+				rc = daos_array_stat(obj->oh, DAOS_TX_NONE, &array_stbuf, NULL);
 				if (rc) {
 					daos_array_close(obj->oh, NULL);
 					D_GOTO(err_obj, rc = daos_der2errno(rc));
 				}
-				stbuf->st_size = size;
+
+				stbuf->st_size   = array_stbuf.st_size;
 				stbuf->st_blocks = (stbuf->st_size + (1 << 9) - 1) >> 9;
+
+				rc = update_stbuf_times(entry, array_stbuf.st_max_epoch, stbuf,
+							NULL);
+				if (rc) {
+					daos_array_close(obj->oh, NULL);
+					D_GOTO(err_obj, rc);
+				}
 			}
 			break;
 		}
@@ -3741,14 +3746,28 @@ lookup_rel_path_loop:
 		}
 
 		obj->d.chunk_size = entry.chunk_size;
-		obj->d.oclass = entry.oclass;
-		if (stbuf)
-			stbuf->st_size = sizeof(entry);
-
+		obj->d.oclass     = entry.oclass;
 		oid_cp(&parent.oid, obj->oid);
 		oid_cp(&parent.parent_oid, obj->parent_oid);
 		parent.oh = obj->oh;
 		parent.mode = entry.mode;
+
+		if (stbuf) {
+			daos_epoch_t ep;
+
+			rc = daos_obj_query_max_epoch(obj->oh, DAOS_TX_NONE, &ep, NULL);
+			if (rc) {
+				daos_obj_close(obj->oh, NULL);
+				D_GOTO(err_obj, rc = daos_der2errno(rc));
+			}
+
+			rc = update_stbuf_times(entry, ep, stbuf, NULL);
+			if (rc) {
+				daos_obj_close(obj->oh, NULL);
+				D_GOTO(err_obj, rc = daos_der2errno(rc));
+			}
+			stbuf->st_size = sizeof(entry);
+		}
 	}
 
 	if (mode)
@@ -3756,16 +3775,49 @@ lookup_rel_path_loop:
 
 	if (stbuf) {
 		if (is_root) {
+			daos_epoch_t ep;
+
+			/** refresh possibly stale root stbuf */
+			rc = fetch_entry(dfs->layout_v, dfs->super_oh, DAOS_TX_NONE, "/", 1, false,
+					 &exists, &entry, 0, NULL, NULL, NULL);
+			if (rc) {
+				D_ERROR("fetch_entry() failed: %d (%s)\n", rc, strerror(rc));
+				D_GOTO(err_obj, rc);
+			}
+
+			if (!exists || !S_ISDIR(entry.mode)) {
+				/** something really bad happened! */
+				D_ERROR("Root object corrupted!");
+				D_GOTO(err_obj, rc = EIO);
+			}
+
+			if (mode)
+				*mode = entry.mode;
+			dfs->root_stbuf.st_mode = entry.mode;
+			dfs->root_stbuf.st_uid  = entry.uid;
+			dfs->root_stbuf.st_gid  = entry.gid;
+
+			rc = daos_obj_query_max_epoch(dfs->root.oh, DAOS_TX_NONE, &ep, NULL);
+			if (rc)
+				D_GOTO(err_obj, rc = daos_der2errno(rc));
+
+			/** object was updated since creation */
+			rc = update_stbuf_times(entry, ep, &dfs->root_stbuf, NULL);
+			if (rc)
+				D_GOTO(err_obj, rc);
+			if (tspec_gt(dfs->root_stbuf.st_ctim, dfs->root_stbuf.st_mtim)) {
+				dfs->root_stbuf.st_atim.tv_sec  = entry.ctime;
+				dfs->root_stbuf.st_atim.tv_nsec = entry.ctime_nano;
+			} else {
+				dfs->root_stbuf.st_atim.tv_sec  = entry.mtime;
+				dfs->root_stbuf.st_atim.tv_nsec = entry.mtime_nano;
+			}
 			memcpy(stbuf, &dfs->root_stbuf, sizeof(struct stat));
 		} else {
 			stbuf->st_nlink = 1;
 			stbuf->st_mode = obj->mode;
 			stbuf->st_uid = entry.uid;
-			stbuf->st_gid = entry.gid;
-			stbuf->st_mtim.tv_sec = entry.mtime;
-			stbuf->st_mtim.tv_nsec = entry.mtime_nano;
-			stbuf->st_ctim.tv_sec = entry.ctime;
-			stbuf->st_ctim.tv_nsec = entry.ctime_nano;
+			stbuf->st_gid   = entry.gid;
 			if (dfs->layout_v > 2) {
 				if (tspec_gt(stbuf->st_ctim, stbuf->st_mtim)) {
 					stbuf->st_atim.tv_sec = entry.ctime;

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -1331,14 +1331,6 @@ duns_destroy_path(daos_handle_t poh, const char *path)
 		return rc;
 	}
 
-	/** Destroy the container */
-	rc = daos_cont_destroy(poh, dattr.da_cont, 1, NULL);
-	if (rc) {
-		D_ERROR("Failed to destroy container (%d)\n", rc);
-		/** recreate the link ? */
-		return daos_der2errno(rc);
-	}
-
 	if (dattr.da_type == DAOS_PROP_CO_LAYOUT_POSIX) {
 #ifdef LUSTRE_INCLUDE
 		if (dattr.da_on_lustre)
@@ -1367,6 +1359,14 @@ duns_destroy_path(daos_handle_t poh, const char *path)
 				dattr.da_on_lustre ? "Lustre " : " ", path, strerror(errno));
 			return err;
 		}
+	}
+
+	/** Destroy the container */
+	rc = daos_cont_destroy(poh, dattr.da_cont, 1, NULL);
+	if (rc) {
+		D_ERROR("Failed to destroy container (%d)\n", rc);
+		/** recreate the link ? */
+		return daos_der2errno(rc);
 	}
 
 	return 0;

--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -283,7 +283,6 @@ type fsCheckCmd struct {
 
 	FsckFlags FsCheckFlag `long:"flags" short:"f" description:"comma-separated flags: print, remove, relink, verify, evict"`
 	DirName   string      `long:"dir-name" short:"n" description:"directory name under lost+found to store leaked oids (a timestamp dir would be created if this is not specified)"`
-	Evict     bool        `long:"evict" short:"e" description:"evict all open handles on the container"`
 }
 
 func (cmd *fsCheckCmd) Execute(_ []string) error {

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -2432,7 +2432,7 @@ dfs_test_checker(void **state)
 	test_arg_t		*arg = *state;
 	dfs_t			*dfs;
 	int			nr = 100, i;
-	dfs_obj_t		*root, *lf;
+	dfs_obj_t               *root, *lf, *sym;
 	daos_obj_id_t		root_oid;
 	daos_handle_t		root_oh;
 	daos_handle_t		coh;
@@ -2502,6 +2502,12 @@ dfs_test_checker(void **state)
 		rc = dfs_release(dir);
 		assert_int_equal(rc, 0);
 	}
+
+	/** create a symlink with a non-existent target in the container */
+	rc = dfs_open(dfs, NULL, "SL1", S_IFLNK | S_IWUSR | S_IRUSR, O_RDWR | O_CREAT | O_EXCL, 0,
+		      0, "/usr/local", &sym);
+	assert_int_equal(rc, 0);
+	rc = dfs_release(sym);
 
 	rc = dfs_disconnect(dfs);
 	assert_int_equal(rc, 0);

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -2588,6 +2588,7 @@ class PosixTests():
         print(os.listdir(path))
         cmd = ['cont', 'destroy', '--path', path]
         rc = run_daos_cmd(self.conf, cmd)
+        assert rc.returncode == 0
 
         path = join(self.dfuse.dir, 'uns_link2')
         cmd = ['cont', 'link', self.pool.id(), container2.id(), '--path', path]


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
