### PR TITLE
DAOS-14831 test: use scm and nvme for ior/hard_rebuild (#13551)

### DIFF
--- a/src/tests/ftest/ior/hard_rebuild.yaml
+++ b/src/tests/ftest/ior/hard_rebuild.yaml
@@ -31,34 +31,28 @@ server_config:
       log_file: daos_server1.log
       log_mask: ERR
       storage: auto
-create_pool_max_size:
-  scm: true
-  percentage: 90
 pool:
-  control_method: dmg
+  size: 90%
 container:
   type: POSIX
   control_method: daos
-  properties: dedup:memcmp
 ior:
   api: "DFS"
   client_processes:
     np: 32
-  dfs_destroy: false
   iorflags:
     flags: "-C -k -e -w -g -G 27 -D 150 -Q 1 -vv"
     read_flags: "-C -k -e -r -R -g -G 27 -D 150 -Q 1 -vv"
   test_file: daos:testFile
   segment_count: 2000000
-  repetitions: 1
   chunk_block_transfer_sizes:
     # [ChunkSize, BlocksSize, TransferSize]
     - [47008, 47008, 47008]
   objectclass:
     dfs_oclass_list:
       # - [EC_Object_Class, Minimum number of servers]
-      - ["EC_2P2G1", 6]
-      - ["EC_4P2G1", 8]
-      - ["EC_8P2G1", 12]
+      - ["EC_2P2GX", 6]
+      - ["EC_4P2GX", 8]
+      - ["EC_8P2GX", 12]
   sw_wearout: 1
   sw_status_file: "/var/tmp/daos_testing/stoneWallingStatusFile"


### PR DESCRIPTION
Test-tag: EcodIorHardRebuild
Test-repeat: 3
Skip-func-test-hw-large-md-on-ssd: False
Skip-unit-tests: true
Skip-fault-injection-test: true

- Use both SCM and NVMe when creating a pool to accomodate MD on SSD.
- Use GX so space is spread across targets.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
