### PR TITLE
DAOS-14594 test: fix dfs_parallel xml generation (#13312)

### DIFF
--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2022 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -81,16 +81,17 @@ run_specified_tests(const char *tests, int rank, int size,
 int
 main(int argc, char **argv)
 {
-	test_arg_t	*arg;
-	char		 tests[64];
-	char		*exclude_str = NULL;
-	int		 ntests = 0;
-	int		 nr_failed = 0;
-	int		 nr_total_failed = 0;
-	int		 opt = 0, index = 0;
-	int		 rank;
-	int		 size;
-	int		 rc;
+	test_arg_t *arg;
+	char        tests[64];
+	char       *exclude_str           = NULL;
+	char       *cmocka_message_output = NULL;
+	int         ntests                = 0;
+	int         nr_failed             = 0;
+	int         nr_total_failed       = 0;
+	int         opt = 0, index = 0;
+	int         rank;
+	int         size;
+	int         rc;
 
 	d_register_alt_assert(mock_assert);
 
@@ -164,6 +165,16 @@ main(int argc, char **argv)
 			}
 		}
 		tests[new_idx] = '\0';
+	}
+
+	/** if writing XML, force all ranks other than rank 0 to use stdout to avoid conflicts */
+	cmocka_message_output = getenv("CMOCKA_MESSAGE_OUTPUT");
+	if (rank != 0 && cmocka_message_output && strcasecmp(cmocka_message_output, "xml") == 0) {
+		rc = setenv("CMOCKA_MESSAGE_OUTPUT", "stdout", 1);
+		if (rc) {
+			print_message("d_setenv() failed with %d\n", rc);
+			return -1;
+		}
 	}
 
 	nr_failed = run_specified_tests(tests, rank, size, NULL, 0);


### PR DESCRIPTION
Features: daos_core_test_dfs

Since cmocka is not MPI-aware, force all ranks other than rank 0 to write to stdout to avoid race conditions with the XML file.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
