### PR TITLE
DAOS-14781 test: expect more containers before rdb nospace (#13647)

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -65,7 +65,7 @@ class ObjectMetadata(TestWithServers):
     CREATED_CONTAINERS_MIN = 2900
 
     # Number of created containers that should not be possible
-    CREATED_CONTAINERS_LIMIT = 3500
+    CREATED_CONTAINERS_LIMIT = 7500
 
     def __init__(self, *args, **kwargs):
         """Initialize a TestWithServers object."""

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -47,7 +47,6 @@ server_config:
 pool:
   svcn: 5
   scm_size: 1G
-  nvme_size: 8G
   control_method: dmg
 container:
   control_method: API

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -21,6 +21,7 @@ server_config:
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DAOS_MD_CAP=128
+        - RDB_COMPACT_THRESHOLD=64
         - DD_MASK=group_metadata_only
       storage:
         0:
@@ -38,6 +39,7 @@ server_config:
       log_mask: DEBUG,MEM=ERR
       env_vars:
         - DAOS_MD_CAP=128
+        - RDB_COMPACT_THRESHOLD=64
         - DD_MASK=group_metadata_only
       storage:
         0:


### PR DESCRIPTION
Change the server/metdata.py tests to expect, for a pool rdb capacity
of 128 MiB, out of space errors just before creating a maxiimum of
about 7500 containers (increasing from the prior value 3500).

To avoid out of space errors on pool service replica followers,
in the server/metadata.yaml functional test config, change the
rdb log compaction frequency (RDB_COMPACT_THRESHOLD) to be once every
64 entries, rather than the prdoduct default 256. For applications
that push the metadata/rdb space to its limits, this is one tactic to
reduce the amount of free space skew between the leader and followers.
Such skew, if allowed to become too large, can cause followers to run
out of space in rdb before the next periodic trigger of log compaction.
And that of course can impact overall pool service availability.

Test-tag: server,metadata
Test-repeat: 5
Skip-unit-tests: true
Skip-fault-injection-test: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
