### PR TITLE
DAOS-15055 tools: Add build host/time to JSON version (#13644)

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -1,7 +1,9 @@
 """Build DAOS Control Plane"""
 # pylint: disable=too-many-locals
 import os
+import socket
 from binascii import b2a_hex
+from datetime import datetime, timezone
 from os import urandom
 from os.path import join
 
@@ -43,13 +45,19 @@ def gen_build_id():
     return '0x' + buildid.decode()
 
 
-def go_ldflags():
+def go_ldflags(benv):
     "Create the ldflags option for the Go build."
 
+    build_host = ''
+    if not is_release_build(benv):
+        build_host = socket.getfqdn()
+    build_time = datetime.now(timezone.utc).astimezone().isoformat()
     Import('daos_version', 'conf_dir')
     path = 'github.com/daos-stack/daos/src/control/build'
     return ' '.join([f'-X {path}.DaosVersion={daos_version}',
                      f'-X {path}.ConfigDir={conf_dir}',
+                     f'-X {path}.BuildTime={build_time}',
+                     f'-X {path}.BuildHost={build_host}',
                      f'-B $({gen_build_id()}$)'])
 
 
@@ -72,7 +80,7 @@ def install_go_bin(env, name, libs=None, install_man=False):
 
     target = env.d_run_command(name, sources, libs,
                                f'cd {gosrc}; {env.d_go_bin} build -mod vendor '
-                               + f'-ldflags "{go_ldflags()}" '
+                               + f'-ldflags "{go_ldflags(env)}" '
                                + f'{get_build_flags(env)} '
                                + f'{get_build_tags(env)} '
                                + f'-o {build_bin} {install_src}')

--- a/src/control/build/string.go
+++ b/src/control/build/string.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 func revString(version string) string {
@@ -41,17 +42,24 @@ func String(name string) string {
 // MarshalJSON returns a JSON string containing a structured representation of
 // the binary build info.
 func MarshalJSON(name string) ([]byte, error) {
+	// Not a fatal error if the build time can't be parsed.
+	buildTime, _ := time.Parse(time.RFC3339, BuildTime)
+
 	return json.Marshal(&struct {
-		Name     string `json:"name"`
-		Version  string `json:"version"`
-		Revision string `json:"revision,omitempty"`
-		Dirty    bool   `json:"dirty,omitempty"`
-		Release  bool   `json:"release,omitempty"`
+		Name      string    `json:"name"`
+		Version   string    `json:"version"`
+		Revision  string    `json:"revision,omitempty"`
+		Dirty     bool      `json:"dirty,omitempty"`
+		Release   bool      `json:"release,omitempty"`
+		BuildHost string    `json:"build_host,omitempty"`
+		BuildTime time.Time `json:"build_time,omitempty"`
 	}{
-		Name:     name,
-		Version:  DaosVersion,
-		Revision: Revision,
-		Dirty:    DirtyBuild,
-		Release:  ReleaseBuild,
+		Name:      name,
+		Version:   DaosVersion,
+		Revision:  Revision,
+		Dirty:     DirtyBuild,
+		Release:   ReleaseBuild,
+		BuildHost: BuildHost,
+		BuildTime: buildTime,
 	})
 }

--- a/src/control/build/variables.go
+++ b/src/control/build/variables.go
@@ -11,9 +11,13 @@ import "time"
 
 var (
 	// ConfigDir should be set via linker flag using the value of CONF_DIR.
-	ConfigDir string = "./"
+	ConfigDir = "./"
 	// DaosVersion should be set via linker flag using the value of DAOS_VERSION.
-	DaosVersion string = "unset"
+	DaosVersion = "unset"
+	// BuildTime should be set via linker flag using the value of BUILD_TIME.
+	BuildTime = ""
+	// BuildHost should be set via linker flag using the value of BUILD_HOST.
+	BuildHost = ""
 	// ControlPlaneName defines a consistent name for the control plane server.
 	ControlPlaneName = "DAOS Control Server"
 	// DataPlaneName defines a consistent name for the engine.


### PR DESCRIPTION
Include build timestamp in all builds. Only
include build host in non-release builds.

Signed-off-by: Michael MacDonald <mjmac@google.com>