### PR TITLE
DAOS-14843 control: Remove user facing info about accel cfg opts (#13…

### DIFF
--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -289,9 +289,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 			WithEnvVars("CRT_TIMEOUT=30").
 			WithLogFile("/tmp/daos_engine.0.log").
 			WithLogMask("INFO").
-			WithStorageEnableHotplug(true).
-			WithStorageAccelProps(storage.AccelEngineSPDK,
-				storage.AccelOptCRCFlag|storage.AccelOptMoveFlag),
+			WithStorageEnableHotplug(true),
 		engine.MockConfig().
 			WithSystemName("daos_server").
 			WithSocketDir("./.daos/daos_server").
@@ -318,8 +316,7 @@ func TestServerConfig_Constructed(t *testing.T) {
 			WithEnvVars("CRT_TIMEOUT=100").
 			WithLogFile("/tmp/daos_engine.1.log").
 			WithLogMask("INFO").
-			WithStorageEnableHotplug(true).
-			WithStorageAccelProps(storage.AccelEngineDML, storage.AccelOptCRCFlag),
+			WithStorageEnableHotplug(true),
 	}
 	constructed.Path = testFile // just to avoid failing the cmp
 

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -449,27 +449,6 @@
 #    - wal
 #
 #
-#  # Specify accelerator engine setting (experimental).
-#
-#  # Acceleration engine options are:
-#  # - "none" do not use an acceleration engine. (default)
-#  # - "spdk" to assigned management of hardware/software acceleration to SPDK.
-#  # - "dml" te set DML as accelerator engine.
-#
-#  # Optional capability settings are:
-#  # - "move" to enable acceleration of MOVE instructions.
-#  # - "crc" to enable acceleration of CRC instructions.
-#
-#  # If acceleration engine setting is "none" (or unset) then optional capabilities are all set to
-#  # false. If set to "spdk" or "dml" then optional capabilities are set to "true" by default.
-#
-#  acceleration:
-#    engine: spdk
-#    options:
-#    - move
-#    - crc
-#
-#
 #-
 #  # Number of I/O service threads (and network endpoints) per engine.
 #  # Immutable after running "dmg storage format".
@@ -617,23 +596,3 @@
 #
 #    # See about bdev_roles above.
 #    bdev_roles: [wal, meta, data]
-#
-#
-#  # Specify accelerator engine setting (experimental).
-#
-#  # Acceleration engine options are:
-#  # - "none" do not use an acceleration engine. (default)
-#  # - "spdk" to assigned management of hardware/software acceleration to SPDK.
-#  # - "dml" te set DML as accelerator engine.
-#
-#  # Optional capability settings are:
-#  # - "move" to enable acceleration of MOVE instructions.
-#  # - "crc" to enable acceleration of CRC instructions.
-#
-#  # If acceleration engine setting is "none" (or unset) then optional capabilities are all set to
-#  # false. If set to "spdk" or "dml" then optional capabilities are set to "true" by default.
-#
-#  acceleration:
-#    engine: dml
-#    options:
-#    - crc


### PR DESCRIPTION
…559)

SPDK acceleration options are exposed in the server config file but
turning these on engine side has not been implemented yet. Remove
documentation of these options in the utils/config/daos_server.yml.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
