### PR TITLE
DAOS-14985 test: Address unit test failure due to merge

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -114,7 +114,7 @@ func bdevScanToProtoResp(scan scanBdevsFn, bdevCfgs storage.TierConfigs) (*ctlpb
 	}
 
 	if bdevCfgs.HaveRealNVMe() {
-		// Update proto Ctrlrs with role info for offline display.
+		// Update proto Ctrlrs with role info and normal (DAOS) state for off-line display.
 		for _, c := range pbCtrlrs {
 			pciAddrStr, err := ctrlrToPciStr(c)
 			if err != nil {
@@ -133,6 +133,7 @@ func bdevScanToProtoResp(scan scanBdevsFn, bdevCfgs storage.TierConfigs) (*ctlpb
 				RoleBits: uint32(bc.Bdev.DeviceRoles.OptionBits),
 				Rank:     uint32(ranklist.NilRank),
 			})
+			c.DevState = ctlpb.NvmeDevState_NORMAL
 		}
 	}
 

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -482,7 +482,8 @@ func TestServer_bdevScan(t *testing.T) {
 				Ctrlrs: proto.NvmeControllers{
 					func() *ctlpb.NvmeController {
 						nc := &ctlpb.NvmeController{
-							PciAddr: "050505:01:00.0",
+							PciAddr:  "050505:01:00.0",
+							DevState: ctlpb.NvmeDevState_NORMAL,
 						}
 						nc.SmdDevices = []*ctlpb.SmdDevice{
 							{Rank: uint32(ranklist.NilRank)},
@@ -491,7 +492,8 @@ func TestServer_bdevScan(t *testing.T) {
 					}(),
 					func() *ctlpb.NvmeController {
 						nc := &ctlpb.NvmeController{
-							PciAddr: "050505:03:00.0",
+							PciAddr:  "050505:03:00.0",
+							DevState: ctlpb.NvmeDevState_NORMAL,
 						}
 						nc.SmdDevices = []*ctlpb.SmdDevice{
 							{Rank: uint32(ranklist.NilRank)},

--- a/src/control/server/instance_storage_rpc.go
+++ b/src/control/server/instance_storage_rpc.go
@@ -9,6 +9,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -202,10 +203,6 @@ func scanEngineBdevsOverDrpc(ctx context.Context, engine Engine, pbReq *ctlpb.Sc
 			return nil, errors.Errorf("smd %q has no ctrlr ref", sd.Uuid)
 		}
 
-		if !sd.Ctrlr.IsScannable() {
-			engine.Debugf("smd %q skip ctrlr %+v with bad state", sd.Uuid, sd.Ctrlr)
-			continue
-		}
 		addr := sd.Ctrlr.PciAddr
 
 		if _, exists := seenCtrlrs[addr]; !exists {
@@ -228,6 +225,12 @@ func scanEngineBdevsOverDrpc(ctx context.Context, engine Engine, pbReq *ctlpb.Sc
 			RoleBits:         sd.RoleBits,
 			CtrlrNamespaceId: sd.CtrlrNamespaceId,
 			Rank:             engineRank.Uint32(),
+		}
+
+		if !sd.Ctrlr.IsScannable() {
+			engine.Debugf("smd %q partial update of ctrlr %+v with bad state",
+				sd.Uuid, sd.Ctrlr)
+			continue
 		}
 
 		// Populate health if requested.
@@ -265,8 +268,14 @@ func scanEngineBdevsOverDrpc(ctx context.Context, engine Engine, pbReq *ctlpb.Sc
 		c.SmdDevices = append(c.SmdDevices, nsd)
 	}
 
-	for _, c := range seenCtrlrs {
-		engine.Tracef("nvme ssd scanned: %+v", c)
+	var keys []string
+	for k := range seenCtrlrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		c := seenCtrlrs[k]
+		engine.Tracef("bdev discovered: %+v", c)
 		pbResp.Ctrlrs = append(pbResp.Ctrlrs, c)
 	}
 
@@ -334,36 +343,43 @@ func bdevScanEngine(ctx context.Context, engine Engine, req *ctlpb.ScanNvmeReq) 
 		return nil, err
 	}
 
-	nrScannedBdevs, err := getEffCtrlrCount(resp.Ctrlrs)
+	nrBdevs, err := getEffCtrlrCount(resp.Ctrlrs)
 	if err != nil {
 		return nil, err
-	}
-	if nrScannedBdevs == nrCfgBdevs {
-		return resp, nil
 	}
 
 	// Retry once if engine provider scan returns unexpected number of controllers in case
 	// engines claimed devices between when started state was checked and scan was executed.
-	if !isStarted {
+	if nrBdevs != nrCfgBdevs && !isStarted {
 		engine.Debugf("retrying engine bdev scan as unexpected nr returned, want %d got %d",
-			nrCfgBdevs, nrScannedBdevs)
+			nrCfgBdevs, nrBdevs)
 
 		resp, err = bdevScanEngineAssigned(ctx, engine, req, bdevCfgs, &isStarted)
 		if err != nil {
 			return nil, err
 		}
 
-		nrScannedBdevs, err := getEffCtrlrCount(resp.Ctrlrs)
+		nrBdevs, err = getEffCtrlrCount(resp.Ctrlrs)
 		if err != nil {
 			return nil, err
 		}
-		if nrScannedBdevs == nrCfgBdevs {
-			return resp, nil
-		}
 	}
 
-	engine.Debugf("engine bdev scan returned unexpected nr, want %d got %d", nrCfgBdevs,
-		nrScannedBdevs)
+	if nrBdevs != nrCfgBdevs {
+		engine.Debugf("engine bdev scan returned unexpected nr, want %d got %d",
+			nrCfgBdevs, nrBdevs)
+	}
+
+	// Filter unusable devices from response.
+	outCtrlrs := make([]*ctlpb.NvmeController, 0, len(resp.Ctrlrs))
+	for _, c := range resp.Ctrlrs {
+		if c.IsScannable() {
+			outCtrlrs = append(outCtrlrs, c)
+		} else {
+			engine.Tracef("excluding bdev from scan results: %+v", c)
+		}
+	}
+	resp.Ctrlrs = outCtrlrs
 
 	return resp, nil
 }

--- a/src/control/server/instance_storage_rpc.go
+++ b/src/control/server/instance_storage_rpc.go
@@ -343,6 +343,8 @@ func bdevScanEngine(ctx context.Context, engine Engine, req *ctlpb.ScanNvmeReq) 
 		return nil, err
 	}
 
+	// Compare number of VMD domain addresses rather than the number of backing devices found
+	// behind it as the domain is what is specified in the server config file.
 	nrBdevs, err := getEffCtrlrCount(resp.Ctrlrs)
 	if err != nil {
 		return nil, err
@@ -370,7 +372,7 @@ func bdevScanEngine(ctx context.Context, engine Engine, req *ctlpb.ScanNvmeReq) 
 			nrCfgBdevs, nrBdevs)
 	}
 
-	// Filter unusable devices from response.
+	// Filter devices in an unusable state from the response.
 	outCtrlrs := make([]*ctlpb.NvmeController, 0, len(resp.Ctrlrs))
 	for _, c := range resp.Ctrlrs {
 		if c.IsScannable() {

--- a/src/control/server/instance_storage_rpc_test.go
+++ b/src/control/server/instance_storage_rpc_test.go
@@ -30,6 +30,8 @@ func TestIOEngineInstance_bdevScanEngine(t *testing.T) {
 	withState := func(ctrlr *ctlpb.NvmeController, state ctlpb.NvmeDevState) *ctlpb.NvmeController {
 		ctrlr.DevState = state
 		ctrlr.HealthStats = nil
+		// scanEngineBdevsOverDrpc will always populate RoleBits in ctrlr.SmdDevices
+		ctrlr.SmdDevices = []*ctlpb.SmdDevice{{RoleBits: 7}}
 		return ctrlr
 	}
 	withDevState := func(smd *ctlpb.SmdDevice, state ctlpb.NvmeDevState) *ctlpb.SmdDevice {
@@ -137,15 +139,22 @@ func TestIOEngineInstance_bdevScanEngine(t *testing.T) {
 			engStopped: true,
 			provRes: &storage.BdevScanResponse{
 				Controllers: storage.NvmeControllers{
-					&storage.NvmeController{PciAddr: "050505:01:00.0"},
-					&storage.NvmeController{PciAddr: "050505:03:00.0"},
+					&storage.NvmeController{
+						PciAddr:   "050505:01:00.0",
+						NvmeState: storage.NvmeStateNormal,
+					},
+					&storage.NvmeController{
+						PciAddr:   "050505:03:00.0",
+						NvmeState: storage.NvmeStateNormal,
+					},
 				},
 			},
 			expResp: &ctlpb.ScanNvmeResp{
 				Ctrlrs: proto.NvmeControllers{
 					func() *ctlpb.NvmeController {
 						nc := &ctlpb.NvmeController{
-							PciAddr: "050505:01:00.0",
+							PciAddr:  "050505:01:00.0",
+							DevState: ctlpb.NvmeDevState_NORMAL,
 						}
 						nc.SmdDevices = []*ctlpb.SmdDevice{
 							{Rank: uint32(ranklist.NilRank)},
@@ -154,7 +163,8 @@ func TestIOEngineInstance_bdevScanEngine(t *testing.T) {
 					}(),
 					func() *ctlpb.NvmeController {
 						nc := &ctlpb.NvmeController{
-							PciAddr: "050505:03:00.0",
+							PciAddr:  "050505:03:00.0",
+							DevState: ctlpb.NvmeDevState_NORMAL,
 						}
 						nc.SmdDevices = []*ctlpb.SmdDevice{
 							{Rank: uint32(ranklist.NilRank)},
@@ -275,26 +285,39 @@ func TestIOEngineInstance_bdevScanEngine(t *testing.T) {
 		},
 		"scan over drpc; only ctrlrs with valid states shown": {
 			req: ctlpb.ScanNvmeReq{},
+			bdevAddrs: []string{
+				test.MockPCIAddr(1), test.MockPCIAddr(2),
+				test.MockPCIAddr(1), test.MockPCIAddr(2),
+				test.MockPCIAddr(5),
+			},
 			smdRes: &ctlpb.SmdDevResp{
 				Devices: proto.SmdDevices{
-					withDevState(proto.MockSmdDevice(storage.MockNvmeController(1), 1),
+					withDevState(proto.MockSmdDevice(
+						storage.MockNvmeController(1), 1),
 						ctlpb.NvmeDevState_UNPLUGGED),
-					withDevState(proto.MockSmdDevice(storage.MockNvmeController(2), 2),
+					withDevState(proto.MockSmdDevice(
+						storage.MockNvmeController(2), 2),
 						ctlpb.NvmeDevState_UNKNOWN),
-					withDevState(proto.MockSmdDevice(storage.MockNvmeController(3), 3),
+					withDevState(proto.MockSmdDevice(
+						storage.MockNvmeController(3), 3),
 						ctlpb.NvmeDevState_NORMAL),
-					withDevState(proto.MockSmdDevice(storage.MockNvmeController(4), 4),
+					withDevState(proto.MockSmdDevice(
+						storage.MockNvmeController(4), 4),
 						ctlpb.NvmeDevState_NEW),
-					withDevState(proto.MockSmdDevice(storage.MockNvmeController(5), 5),
+					withDevState(proto.MockSmdDevice(
+						storage.MockNvmeController(5), 5),
 						ctlpb.NvmeDevState_EVICTED),
 				},
 			},
 			healthRes: healthRespWithUsage(),
 			expResp: &ctlpb.ScanNvmeResp{
 				Ctrlrs: proto.NvmeControllers{
-					withState(proto.MockNvmeController(3), ctlpb.NvmeDevState_NORMAL),
-					withState(proto.MockNvmeController(4), ctlpb.NvmeDevState_NEW),
-					withState(proto.MockNvmeController(5), ctlpb.NvmeDevState_EVICTED),
+					withState(proto.MockNvmeController(3),
+						ctlpb.NvmeDevState_NORMAL),
+					withState(proto.MockNvmeController(4),
+						ctlpb.NvmeDevState_NEW),
+					withState(proto.MockNvmeController(5),
+						ctlpb.NvmeDevState_EVICTED),
 				},
 				State: new(ctlpb.ResponseState),
 			},


### PR DESCRIPTION
Bad merge involving PR-13614 resulted in broken bdevScanEngine go unit test.

- Fix merge conflict affecting unit test by adding roles to bdev in scan.
- Improve reliability of unit test by sorting response content.
- Move filtering of bdevs in bad state so that retry logic is not inadvertently triggered.

Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
