### PR TITLE
Revert "DAOS-14969 test: Increase crt_timeout for test_daos_oid_allocator"

### DIFF
--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -191,5 +191,3 @@ daos_tests:
     test_daos_extend_simple: 5
     test_daos_rebuild_ec: 43
     test_daos_degraded_ec: 29
-  crt_timeout:
-    test_daos_oid_allocator: 60

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2018-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -95,14 +95,6 @@ class DaosCoreBase(TestWithServers):
                         "env_vars",
                         ["=".join(items) for items in list(env_dict.items())]
                     )
-
-        # Update any other server settings unique to this test method
-        for setting in ["crt_timeout"]:
-            value = self.get_test_param(setting)
-            if value:
-                for server_mgr in self.server_managers:
-                    for engine_params in server_mgr.manager.job.yaml.engine_params:
-                        engine_params.set_value(setting, value)
 
         # Start the servers
         return super().start_server_managers(force=force)


### PR DESCRIPTION
Reverts daos-stack/daos#13599