### PR TITLE
DAOS-14909 test: unit tests for new pool properties

### DIFF
--- a/src/control/lib/daos/pool_property_test.go
+++ b/src/control/lib/daos/pool_property_test.go
@@ -240,6 +240,49 @@ func TestControl_PoolProperties(t *testing.T) {
 			value:  "bad mode",
 			expErr: errors.New(`invalid value "bad mode" for reintegration (valid: data_sync,no_data_sync)`),
 		},
+		"svc_ops_enabled-zero-is-valid": {
+			name:    "svc_ops_enabled",
+			value:   "0",
+			expStr:  "svc_ops_enabled:0",
+			expJson: []byte(`{"name":"svc_ops_enabled","description":"Metadata duplicate operations detection enabled","value":0}`),
+		},
+		"svc_ops_enabled-one-is-valid": {
+			name:    "svc_ops_enabled",
+			value:   "1",
+			expStr:  "svc_ops_enabled:1",
+			expJson: []byte(`{"name":"svc_ops_enabled","description":"Metadata duplicate operations detection enabled","value":1}`),
+		},
+		"svc_ops_enabled-invalid": {
+			name:   "svc_ops_enabled",
+			value:  "-1",
+			expErr: errors.New("invalid"),
+		},
+		"svc_ops_enabled-invalid2": {
+			name:   "svc_ops_enabled",
+			value:  "2",
+			expErr: errors.New("invalid"),
+		},
+		"svc_ops_entry_age-valid": {
+			name:    "svc_ops_entry_age",
+			value:   "175",
+			expStr:  "svc_ops_entry_age:175",
+			expJson: []byte(`{"name":"svc_ops_entry_age","description":"Metadata duplicate operations KVS max entry age, in seconds","value":175}`),
+		},
+		"svc_ops_entry_age-invalid": {
+			name:   "svc_ops_entry_age",
+			value:  "-1",
+			expErr: errors.New("invalid"),
+		},
+		"svc_ops_entry_age-invalid-toolow": {
+			name:   "svc_ops_entry_age",
+			value:  "149",
+			expErr: errors.New("invalid"),
+		},
+		"svc_ops_entry_age-invalid-toohigh": {
+			name:   "svc_ops_entry_age",
+			value:  "601",
+			expErr: errors.New("invalid"),
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			prop, err := daos.PoolProperties().GetProperty(tc.name)


### PR DESCRIPTION
Recently-added pool properties svc_ops_enabled and svc_ops_entry_age could use some control plane unit tests, added in this patch.

Skip-test: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
