### PR TITLE
DAOS-14826 test: Add a dfuse/pil4dfs test for bash fd usage.

### DIFF
--- a/src/tests/ftest/dfuse/bash_fd.py
+++ b/src/tests/ftest/dfuse/bash_fd.py
@@ -1,0 +1,165 @@
+"""
+  (C) Copyright 24 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+
+import os
+import stat
+
+from dfuse_test_base import DfuseTestBase
+from run_utils import run_remote
+
+OUTER = """#!/bin/bash
+
+set -uex
+
+[ -d out_dir ] && rm -rf out_dir
+[ -d e_out_dir ] && rm -rf e_out_dir
+mkdir out_dir
+
+cd out_dir
+
+.././bash_fd_inner.sh
+
+cd -
+
+grep . out_dir/*
+
+mkdir e_out_dir
+echo first file > e_out_dir/out_file
+echo first file >> e_out_dir/out_file
+
+echo second file > e_out_dir/other_file
+echo five >> e_out_dir/other_file
+echo six >> e_out_dir/other_file
+
+diff --new-file --recursive out_dir e_out_dir
+"""
+
+INNER = """#!/bin/bash
+
+set -ue
+
+echo Hello, about to perform some bash I/O testing similar to "configure" scripts.
+
+# Open file for read/write access.
+exec 3<>out_file
+echo first file >&3
+
+ls -l /proc/$$/fd
+
+# Open file in /proc and hold it open.
+exec 4</proc/self/maps
+
+# Open file for write access.
+exec 5>other_file
+echo second file >&5
+
+# Duplicate fd.
+exec 6>&5
+echo five >&6
+
+ls -l /proc/$$/fd
+
+# Close fds as output file descriptors.
+exec 4>&-
+exec 5>&-
+echo six >&6
+exec 6>&-
+
+echo first file >&3
+exec 3>&-
+
+ls -l /proc/$$/fd
+
+exit 0
+"""
+
+
+class FdTest(DfuseTestBase):
+    """Base FdTest test class.
+
+    "avocado: recursive
+    """
+
+    def run_bashfd(self, il_lib=None):
+        """Run a shell script which opens and writes to files.
+
+        This attempts to replicate the way that configure scripts manipulate fds in bash.
+        """
+
+        if il_lib is not None:
+            lib_path = os.path.join(self.prefix, "lib64", il_lib)
+            env_str = f"export LD_PRELOAD={lib_path}; "
+        else:
+            env_str = ""
+
+        self.add_pool(connect=False)
+        self.add_container(self.pool)
+        mount_dir = f"/tmp/{self.pool.identifier}_daos_dfuse"
+        self.start_dfuse(self.hostlist_clients, self.pool, self.container, mount_dir=mount_dir)
+
+        fuse_root_dir = self.dfuse.mount_dir.value
+
+        with open(os.path.join(fuse_root_dir, "bash_fd_inner.sh"), "w") as fd:
+            fd.write(INNER)
+
+        os.chmod(os.path.join(fuse_root_dir, "bash_fd_inner.sh"), stat.S_IXUSR | stat.S_IRUSR)
+
+        with open(os.path.join(fuse_root_dir, "bash_fd_outer.sh"), "w") as fd:
+            fd.write(OUTER)
+
+        os.chmod(os.path.join(fuse_root_dir, "bash_fd_outer.sh"), stat.S_IXUSR | stat.S_IRUSR)
+
+        cmd = f"cd {fuse_root_dir}; ./bash_fd_outer.sh"
+
+        result = run_remote(self.log, self.hostlist_clients, env_str + cmd)
+        if not result.passed:
+            self.fail(f'"{cmd}" failed on {result.failed_hosts}')
+
+        # stop dfuse
+        self.stop_dfuse()
+        # destroy container
+        self.container.destroy()
+        # destroy pool
+        self.pool.destroy()
+
+    def test_bashfd(self):
+        """
+
+        Test Description:
+            Test a typical I/O pattern for bash based configure scripts.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=dfuse,dfs
+        :avocado: tags=FdTest,test_bashfd
+        """
+        self.run_bashfd()
+
+    def test_bashfd_ioil(self):
+        """
+
+        Test Description:
+            Test a typical I/O pattern for bash based configure scripts.
+
+        :avocado: tags=all,pr,full_regression
+        :avocado: tags=vm
+        :avocado: tags=dfuse,il,dfs
+        :avocado: tags=FdTest,test_bashfd_ioil
+        """
+        self.run_bashfd(il_lib="libioil.so")
+
+    def test_bashfd_pil4dfs(self):
+        """
+
+        Test Description:
+            Test a typical I/O pattern for bash based configure scripts.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=vm
+        :avocado: tags=pil4dfs,dfs
+        :avocado: tags=FdTest,test_bashfd_pil4dfs
+        """
+        self.run_bashfd(il_lib="libpil4dfs.so")

--- a/src/tests/ftest/dfuse/bash_fd.py
+++ b/src/tests/ftest/dfuse/bash_fd.py
@@ -139,7 +139,7 @@ class DFuseFdTest(DfuseTestBase):
         Test Description:
             Test a typical I/O pattern for bash based configure scripts.
 
-        :avocado: tags=all,pr,full_regression
+        :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=dfuse,il,dfs
         :avocado: tags=DFuseFdTest,test_bashfd_ioil

--- a/src/tests/ftest/dfuse/bash_fd.py
+++ b/src/tests/ftest/dfuse/bash_fd.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 24 Intel Corporation.
+  (C) Copyright 2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -80,7 +80,7 @@ exit 0
 class FdTest(DfuseTestBase):
     """Base FdTest test class.
 
-    "avocado: recursive
+    :avocado: recursive
     """
 
     def run_bashfd(self, il_lib=None):

--- a/src/tests/ftest/dfuse/bash_fd.py
+++ b/src/tests/ftest/dfuse/bash_fd.py
@@ -77,7 +77,7 @@ exit 0
 """
 
 
-class FdTest(DfuseTestBase):
+class DFuseFdTest(DfuseTestBase):
     """Base FdTest test class.
 
     :avocado: recursive
@@ -87,6 +87,9 @@ class FdTest(DfuseTestBase):
         """Run a shell script which opens and writes to files.
 
         This attempts to replicate the way that configure scripts manipulate fds in bash.
+
+        Args:
+            il_lib (str, optional): interception library to run with. Defaults to None
         """
 
         if il_lib is not None:
@@ -95,10 +98,9 @@ class FdTest(DfuseTestBase):
         else:
             env_str = ""
 
-        self.add_pool(connect=False)
-        self.add_container(self.pool)
-        mount_dir = f"/tmp/{self.pool.identifier}_daos_dfuse"
-        self.start_dfuse(self.hostlist_clients, self.pool, self.container, mount_dir=mount_dir)
+        pool = self.get_pool(connect=False)
+        container = self.get_container(pool)
+        self.start_dfuse(self.hostlist_clients, pool, container)
 
         fuse_root_dir = self.dfuse.mount_dir.value
 
@@ -118,13 +120,6 @@ class FdTest(DfuseTestBase):
         if not result.passed:
             self.fail(f'"{cmd}" failed on {result.failed_hosts}')
 
-        # stop dfuse
-        self.stop_dfuse()
-        # destroy container
-        self.container.destroy()
-        # destroy pool
-        self.pool.destroy()
-
     def test_bashfd(self):
         """
 
@@ -134,7 +129,7 @@ class FdTest(DfuseTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=dfuse,dfs
-        :avocado: tags=FdTest,test_bashfd
+        :avocado: tags=DFuseFdTest,test_bashfd
         """
         self.run_bashfd()
 
@@ -147,7 +142,7 @@ class FdTest(DfuseTestBase):
         :avocado: tags=all,pr,full_regression
         :avocado: tags=vm
         :avocado: tags=dfuse,il,dfs
-        :avocado: tags=FdTest,test_bashfd_ioil
+        :avocado: tags=DFuseFdTest,test_bashfd_ioil
         """
         self.run_bashfd(il_lib="libioil.so")
 
@@ -160,6 +155,6 @@ class FdTest(DfuseTestBase):
         :avocado: tags=all,full_regression
         :avocado: tags=vm
         :avocado: tags=pil4dfs,dfs
-        :avocado: tags=FdTest,test_bashfd_pil4dfs
+        :avocado: tags=DFuseFdTest,test_bashfd_pil4dfs
         """
         self.run_bashfd(il_lib="libpil4dfs.so")

--- a/src/tests/ftest/dfuse/bash_fd.yaml
+++ b/src/tests/ftest/dfuse/bash_fd.yaml
@@ -1,0 +1,21 @@
+hosts:
+  test_servers: 1
+timeout: 900
+server_config:
+  name: daos_server
+  engines_per_host: 1
+  engines:
+    0:
+      targets: 4
+      nr_xs_helpers: 0
+      storage:
+        0:
+          class: ram
+          scm_mount: /mnt/daos
+  system_ram_reserved: 1
+pool:
+  scm_size: 1000000000
+  control_method: dmg
+container:
+  type: POSIX
+  control_method: daos

--- a/src/tests/ftest/dfuse/bash_fd.yaml
+++ b/src/tests/ftest/dfuse/bash_fd.yaml
@@ -14,8 +14,7 @@ server_config:
           scm_mount: /mnt/daos
   system_ram_reserved: 1
 pool:
-  scm_size: 1000000000
-  control_method: dmg
+  scm_size: 1G
 container:
   type: POSIX
   control_method: daos


### PR DESCRIPTION
Add a test for pil4dfs that tries to replicate what configure
scripts do with file descriptors.

Required-githooks: true
Test-tag: FdTest
Skip-init-tests: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
