### PR TITLE
DAOS-14829 test: fix max number of pools for MD-on-SSD

### DIFF
--- a/src/tests/ftest/nvme/health.py
+++ b/src/tests/ftest/nvme/health.py
@@ -59,7 +59,6 @@ class NvmeHealth(ServerFillUp):
         scm_per_pool = int(scm_per_engine / actual_num_pools)
         if self.server_managers[0].manager.job.using_control_metadata:
             scm_per_pool = int(scm_per_pool - rdb_size)
-            self.log.info("-- xxxxxxxxxxxx")
         nvme_per_pool = int(nvme_per_engine / actual_num_pools)
 
         # Create the pools

--- a/src/tests/ftest/nvme/health.py
+++ b/src/tests/ftest/nvme/health.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -20,6 +20,7 @@ class NvmeHealth(ServerFillUp):
 
     @fail_on(CommandFailure)
     def test_monitor_for_large_pools(self):
+        # pylint: disable=too-many-locals
         """Jira ID: DAOS-4722.
 
         Test Description: Test Health monitor for large number of pools.
@@ -47,8 +48,18 @@ class NvmeHealth(ServerFillUp):
         potential_num_pools = int((nvme_per_engine / (min_nvme_per_target * targets_per_engine)))
         actual_num_pools = min(max_num_pools, potential_num_pools)
 
+        # consider 1GiB RDB memory consume for MD-on-SSD
+        rdb_size = 1073741824
+        if self.server_managers[0].manager.job.using_control_metadata:
+            min_scm_per_pool = 104857600
+            potential_num_pools = int(scm_per_engine / (min_scm_per_pool + rdb_size))
+            actual_num_pools = min(potential_num_pools, actual_num_pools)
+
         # Split available space across the number of pools to be created
         scm_per_pool = int(scm_per_engine / actual_num_pools)
+        if self.server_managers[0].manager.job.using_control_metadata:
+            scm_per_pool = int(scm_per_pool - rdb_size)
+            self.log.info("-- xxxxxxxxxxxx")
         nvme_per_pool = int(nvme_per_engine / actual_num_pools)
 
         # Create the pools


### PR DESCRIPTION
RDB memory should be considered when calculating max number of pools for pool creation.

Test-nvme: auto_md_on_ssd
Test-tag: test_monitor_for_large_pools
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
