### PR TITLE
DAOS-14981 test: Have daosbuild test buuld 2.4 version of daos.

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -208,6 +208,7 @@ class DaosBuild(DfuseTestBase):
 
         cmds = ['python3 -m venv {}/venv'.format(mount_dir),
                 'git clone https://github.com/daos-stack/daos.git {}'.format(build_dir),
+                'git -C {} checkout release/2.4'.format(build_dir),
                 'git -C {} submodule init'.format(build_dir),
                 'git -C {} submodule update'.format(build_dir),
                 'python3 -m pip install pip --upgrade',


### PR DESCRIPTION
Test-tag: test_dfuse_daos_build_wt_il
Sigted-off-by: Ashley Pittman <ashley.m.pittman@intel.com>

Required-githooks: true
