### PR TITLE
DAOS-15038 test: Parsing device state from SMD info JSON is failing

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2020-2023 Intel Corporation.
+ * (C) Copyright 2020-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1074,6 +1074,7 @@ parse_device_info(struct json_object *smd_dev, device_list *devices,
 {
 	struct json_object	*tmp;
 	struct json_object	*dev = NULL;
+	struct json_object      *ctrlr  = NULL;
 	struct json_object	*target = NULL;
 	struct json_object	*targets;
 	int			tgts_len;
@@ -1123,19 +1124,24 @@ parse_device_info(struct json_object *smd_dev, device_list *devices,
 		}
 		devices[*disks].n_tgtidx = tgts_len;
 
-		if (!json_object_object_get_ex(dev, "dev_state", &tmp)) {
-			D_ERROR("unable to extract state from JSON\n");
-			return -DER_INVAL;
-		}
-
-		snprintf(devices[*disks].state, sizeof(devices[*disks].state),
-			 "%s", json_object_to_json_string(tmp));
-
 		if (!json_object_object_get_ex(dev, "rank", &tmp)) {
 			D_ERROR("unable to extract rank from JSON\n");
 			return -DER_INVAL;
 		}
 		devices[*disks].rank = atoi(json_object_to_json_string(tmp));
+
+		if (!json_object_object_get_ex(dev, "ctrlr", &ctrlr)) {
+			D_ERROR("unable to extract ctrlr obj from JSON\n");
+			return -DER_INVAL;
+		}
+
+		if (!json_object_object_get_ex(ctrlr, "dev_state", &tmp)) {
+			D_ERROR("unable to extract state from JSON\n");
+			return -DER_INVAL;
+		}
+
+		snprintf(devices[*disks].state, sizeof(devices[*disks].state), "%s",
+			 json_object_to_json_string(tmp));
 		*disks = *disks + 1;
 	}
 
@@ -1277,9 +1283,10 @@ dmg_storage_query_device_health(const char *dmg_config_file, char *host,
 	struct json_object	*storage_map = NULL;
 	struct json_object	*smd_info = NULL;
 	struct json_object	*storage_info = NULL;
-	struct json_object	*health_info = NULL;
+	struct json_object       *health_stats = NULL;
 	struct json_object	*devices = NULL;
 	struct json_object	*dev_info = NULL;
+	struct json_object       *ctrlr_info   = NULL;
 	struct json_object	*tmp = NULL;
 	char			uuid_str[DAOS_UUID_STR_SIZE];
 	int			argcount = 0;
@@ -1326,10 +1333,13 @@ dmg_storage_query_device_health(const char *dmg_config_file, char *host,
 		}
 
 		dev_info = json_object_array_get_idx(devices, 0);
-		json_object_object_get_ex(dev_info, "health", &health_info);
-		if (health_info != NULL) {
-			json_object_object_get_ex(health_info, stats,
-						  &tmp);
+		if (!json_object_object_get_ex(dev_info, "ctrlr", &ctrlr_info)) {
+			D_ERROR("unable to extract ctrlr details from JSON\n");
+			D_GOTO(out_json, rc = -DER_INVAL);
+		}
+		json_object_object_get_ex(ctrlr_info, "health_stats", &health_stats);
+		if (health_stats != NULL) {
+			json_object_object_get_ex(health_stats, stats, &tmp);
 			strcpy(stats, json_object_to_json_string(tmp));
 		}
 	}

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -724,23 +724,6 @@ nvme_test_simulate_IO_error(void **state)
 	print_message("Final read_errors = %s\n", check_errors);
 	assert_true(atoi(check_errors) == atoi(read_errors) + 1);
 
-	/*
-	 * Verify writeErr=true and readErr:true available in control log
-	 */
-	char control_err[][50] = {
-		"detected blob I/O error! writeErr:true",
-		"detected blob I/O error! readErr:true"};
-	for (i = 0; i < 2 ; i++) {
-		rc = verify_state_in_log(devices[rank_pos].host,
-					 control_log_file, control_err[i]);
-		if (rc != 0) {
-			print_message(
-				" %s not found in log %s\n", control_err[i],
-				control_log_file);
-			assert_rc_equal(rc, 0);
-		}
-	}
-
 	/* Tear down */
 	D_FREE(ow_buf);
 	D_FREE(fbuf);


### PR DESCRIPTION
JSON output format of dmg storage query list-devices changed in commit 8e1c8468428e7b2ac97975300e18d0aaff8e381c and specifically dev_state was moved to a ctrlr sub-node of smd_info. This has broken src/common/tests_dmg_helpers.c:parse_device_info() which looks for dev_state in smd_info. This change updates the function to look for dev_state inside the ctrlr sub-node.

Features: DaosCoreTestNvme
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
