### PR TITLE
DAOS-15073 pool: avoid deadlock when put last ref on stopped pool

### DIFF
--- a/src/include/daos/lru.h
+++ b/src/include/daos/lru.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -156,6 +156,15 @@ static inline void
 daos_lru_ref_add(struct daos_llink *llink)
 {
 	llink->ll_ref++;
+}
+
+/**
+ * Return true if the caller is the last user of the LRU element.
+ */
+static inline bool
+daos_lru_is_last_user(struct daos_llink *llink)
+{
+	return llink->ll_ref <= 2;
 }
 
 #endif

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -102,12 +102,6 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
  */
 void
 vos_obj_release(struct daos_lru_cache *occ, struct vos_object *obj, bool evict);
-
-static inline int
-vos_obj_refcount(struct vos_object *obj)
-{
-	return obj->obj_llink.ll_ref;
-}
 
 /** Evict an object reference from the cache */
 void vos_obj_evict(struct daos_lru_cache *occ, struct vos_object *obj);

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -354,7 +354,7 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 
 	if (intent == DAOS_INTENT_KILL && !(flags & VOS_OBJ_KILL_DKEY)) {
 		if (obj != &obj_local) {
-			if (vos_obj_refcount(obj) > 2)
+			if (!daos_lru_is_last_user(&obj->obj_llink))
 				D_GOTO(failed, rc = -DER_BUSY);
 
 			vos_obj_evict(occ, obj);


### PR DESCRIPTION
Sometimes, when a pool is stopped, some user may be still using the pool with reference held on such pool. For the user that is holding the last reference on the stopped pool, when it releases reference, it will trigger pool_free_ref that will stop (with block mode) the container that may wait current user (ULT) to exit.

To avoid potential deadlock, we will use another independent ULT to release the reference (on the stopped pool) asynchronously and make current ULT to go ahead.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
