### PR TITLE
DAOS-14320 test: remove offline_rebuild_agg test

### DIFF
--- a/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
+++ b/src/tests/ftest/erasurecode/offline_rebuild_aggregation.py
@@ -64,29 +64,6 @@ class EcodAggregationOffRebuild(ErasureCodeIor):
         # data set
         self.ior_read_dataset(parity=2)
 
-    def test_ec_offline_rebuild_agg_disabled(self):
-        """Jira ID: DAOS-7313.
-
-        Test Description: Test Erasure code object aggregation disabled mode
-                          with IOR.
-        Use Case: Create the pool, disabled aggregation, run IOR with supported
-                  EC object type with partial strip.
-                  Verify that Aggregation should not triggered.
-                  Verify the IOR read data at the end.
-                  Kill single server and wait for rebuild.
-                  Read and verify all the data.
-                  Kill second server and wait for rebuild.
-                  Read and verify data with +2 Parity with no data corruption.
-
-        :avocado: tags=all,full_regression
-        :avocado: tags=hw,large
-        :avocado: tags=ec,aggregation,ec_array,ec_aggregation,rebuild
-        :avocado: tags=EcodAggregationOffRebuild,test_ec_offline_rebuild_agg_disabled
-        """
-        # Disable the aggregation
-        self.pool.set_property("reclaim", "disabled")
-        self.execution()
-
     def test_ec_offline_rebuild_agg_default(self):
         """Jira ID: DAOS-7313.
 


### PR DESCRIPTION
The test_ec_offline_rebuild_agg_disabled test in erasurecode/ offline_rebuild_aggregation.py should be deleted because this is not a scenario that real users will ever do.

Test-tag: EcodAggregationOffRebuild
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
