### PR TITLE
DAOS-10942 utils: chmod should ignore unsupported bits (#12949)

### DIFF
--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -108,7 +108,7 @@ func (cmd *fsCopyCmd) Execute(_ []string) error {
 	cmd.Infof("    Links:       %d", ap.fs_copy_stats.num_links)
 
 	if ap.fs_copy_stats.num_chmod_enotsup > 0 {
-		return errors.New(fmt.Sprintf("Copy completed successfully, but %d files had unsupported mode bits that could not be applied. Run with --ignore-unsupported to suppress this warning.", ap.fs_copy_stats.num_chmod_enotsup))
+		return errors.Errorf("Copy completed successfully, but %d files had unsupported mode bits that could not be applied. Run with --ignore-unsupported to suppress this warning.", ap.fs_copy_stats.num_chmod_enotsup)
 	}
 
 	return nil

--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -42,9 +42,10 @@ type fsCmd struct {
 type fsCopyCmd struct {
 	daosCmd
 
-	Source   string `long:"src" short:"s" description:"copy source" required:"1"`
-	Dest     string `long:"dst" short:"d" description:"copy destination" required:"1"`
-	Preserve string `long:"preserve-props" short:"m" description:"preserve container properties, requires HDF5 library" required:"0"`
+	Source      string `long:"src" short:"s" description:"copy source" required:"1"`
+	Dest        string `long:"dst" short:"d" description:"copy destination" required:"1"`
+	Preserve    string `long:"preserve-props" short:"m" description:"preserve container properties, requires HDF5 library" required:"0"`
+	IgnoreUnsup bool   `long:"ignore-unsupported" description:"ignore unsupported filesystem features when copying to DFS" required:"0"`
 }
 
 func (cmd *fsCopyCmd) Execute(_ []string) error {
@@ -62,6 +63,7 @@ func (cmd *fsCopyCmd) Execute(_ []string) error {
 		ap.preserve_props = C.CString(cmd.Preserve)
 		defer freeString(ap.preserve_props)
 	}
+	ap.ignore_unsup = C.bool(cmd.IgnoreUnsup)
 
 	ap.fs_op = C.FS_COPY
 	rc := C.fs_copy_hdlr(ap)
@@ -104,6 +106,10 @@ func (cmd *fsCopyCmd) Execute(_ []string) error {
 	cmd.Infof("    Directories: %d", ap.fs_copy_stats.num_dirs)
 	cmd.Infof("    Files:       %d", ap.fs_copy_stats.num_files)
 	cmd.Infof("    Links:       %d", ap.fs_copy_stats.num_links)
+
+	if ap.fs_copy_stats.num_chmod_enotsup > 0 {
+		return errors.New(fmt.Sprintf("Copy completed successfully, but %d files had unsupported mode bits that could not be applied. Run with --ignore-unsupported to suppress this warning.", ap.fs_copy_stats.num_chmod_enotsup))
+	}
 
 	return nil
 }

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -518,10 +518,18 @@ file_close(struct cmd_args_s *ap, struct file_dfs *file_dfs, const char *file)
 }
 
 static int
-file_chmod(struct cmd_args_s *ap, struct file_dfs *file_dfs, const char *path,
-	   mode_t mode)
+file_chmod(struct cmd_args_s *ap, struct file_dfs *file_dfs, const char *path, mode_t mode,
+	   bool ignore_unsup, uint64_t *num_chmod_enotsup)
 {
 	int rc = 0;
+
+	/* Unset any unsupported mode bits. We track these errors so they can
+	 * be surfaced to the user at the end of the copy operation.
+	 */
+	if (!ignore_unsup && mode & (S_ISVTX | S_ISGID | S_ISUID)) {
+		(*num_chmod_enotsup)++;
+	}
+	mode &= ~(S_ISVTX | S_ISGID | S_ISUID);
 
 	if (file_dfs->type == POSIX) {
 		rc = chmod(path, mode);
@@ -542,12 +550,9 @@ file_chmod(struct cmd_args_s *ap, struct file_dfs *file_dfs, const char *path,
 }
 
 static int
-fs_copy_file(struct cmd_args_s *ap,
-	     struct file_dfs *src_file_dfs,
-	     struct file_dfs *dst_file_dfs,
-	     struct stat *src_stat,
-	     const char *src_path,
-	     const char *dst_path)
+fs_copy_file(struct cmd_args_s *ap, struct file_dfs *src_file_dfs, struct file_dfs *dst_file_dfs,
+	     struct stat *src_stat, const char *src_path, const char *dst_path, bool ignore_unsup,
+	     uint64_t *num_chmod_enotsup)
 {
 	int src_flags		= O_RDONLY;
 	int dst_flags		= O_CREAT | O_TRUNC | O_WRONLY;
@@ -598,7 +603,8 @@ fs_copy_file(struct cmd_args_s *ap,
 	}
 
 	/* set perms on destination to original source perms */
-	rc = file_chmod(ap, dst_file_dfs, dst_path, src_stat->st_mode);
+	rc = file_chmod(ap, dst_file_dfs, dst_path, src_stat->st_mode, ignore_unsup,
+			num_chmod_enotsup);
 	if (rc != 0) {
 		rc = daos_errno2der(rc);
 		DH_PERROR_DER(ap, rc, "updating dst file permissions failed");
@@ -699,12 +705,8 @@ out_copy_symlink:
 }
 
 static int
-fs_copy_dir(struct cmd_args_s *ap,
-	    struct file_dfs *src_file_dfs,
-	    struct file_dfs *dst_file_dfs,
-	    struct stat *src_stat,
-	    const char *src_path,
-	    const char *dst_path,
+fs_copy_dir(struct cmd_args_s *ap, struct file_dfs *src_file_dfs, struct file_dfs *dst_file_dfs,
+	    struct stat *src_stat, const char *src_path, const char *dst_path, bool ignore_unsup,
 	    struct fs_copy_stats *num)
 {
 	DIR			*src_dir = NULL;
@@ -779,9 +781,9 @@ fs_copy_dir(struct cmd_args_s *ap,
 
 		switch (next_src_stat.st_mode & S_IFMT) {
 		case S_IFREG:
-			rc = fs_copy_file(ap, src_file_dfs, dst_file_dfs,
-					  &next_src_stat, next_src_path,
-					  next_dst_path);
+			rc = fs_copy_file(ap, src_file_dfs, dst_file_dfs, &next_src_stat,
+					  next_src_path, next_dst_path, ignore_unsup,
+					  &num->num_chmod_enotsup);
 			if ((rc != 0) && (rc != -DER_EXIST))
 				D_GOTO(out, rc);
 			num->num_files++;
@@ -796,7 +798,7 @@ fs_copy_dir(struct cmd_args_s *ap,
 			break;
 		case S_IFDIR:
 			rc = fs_copy_dir(ap, src_file_dfs, dst_file_dfs, &next_src_stat,
-					 next_src_path, next_dst_path, num);
+					 next_src_path, next_dst_path, ignore_unsup, num);
 			if ((rc != 0) && (rc != -DER_EXIST))
 				D_GOTO(out, rc);
 			num->num_dirs++;
@@ -811,7 +813,8 @@ fs_copy_dir(struct cmd_args_s *ap,
 	}
 
 	/* set original source perms on directories after copying */
-	rc = file_chmod(ap, dst_file_dfs, dst_path, src_stat->st_mode);
+	rc = file_chmod(ap, dst_file_dfs, dst_path, src_stat->st_mode, ignore_unsup,
+			&num->num_chmod_enotsup);
 	if (rc != 0) {
 		rc = daos_errno2der(rc);
 		DH_PERROR_DER(ap, rc, "updating destination permissions failed on '%s'", dst_path);
@@ -838,12 +841,8 @@ out:
 }
 
 static int
-fs_copy(struct cmd_args_s *ap,
-	struct file_dfs *src_file_dfs,
-	struct file_dfs *dst_file_dfs,
-	const char *src_path,
-	const char *dst_path,
-	struct fs_copy_stats *num)
+fs_copy(struct cmd_args_s *ap, struct file_dfs *src_file_dfs, struct file_dfs *dst_file_dfs,
+	const char *src_path, const char *dst_path, bool ignore_unsup, struct fs_copy_stats *num)
 {
 	int		rc = 0;
 	struct stat	src_stat;
@@ -898,14 +897,14 @@ fs_copy(struct cmd_args_s *ap,
 
 	switch (src_stat.st_mode & S_IFMT) {
 	case S_IFREG:
-		rc = fs_copy_file(ap, src_file_dfs, dst_file_dfs, &src_stat, src_path,
-				  dst_path);
+		rc = fs_copy_file(ap, src_file_dfs, dst_file_dfs, &src_stat, src_path, dst_path,
+				  ignore_unsup, &num->num_chmod_enotsup);
 		if (rc == 0)
 			num->num_files++;
 		break;
 	case S_IFDIR:
-		rc = fs_copy_dir(ap, src_file_dfs, dst_file_dfs, &src_stat, src_path,
-				 dst_path, num);
+		rc = fs_copy_dir(ap, src_file_dfs, dst_file_dfs, &src_stat, src_path, dst_path,
+				 ignore_unsup, num);
 		if (rc == 0)
 			num->num_dirs++;
 		break;
@@ -1884,7 +1883,7 @@ fs_copy_hdlr(struct cmd_args_s *ap)
 		D_GOTO(out, rc);
 	}
 
-	rc = fs_copy(ap, &src_file_dfs, &dst_file_dfs, src_str, dst_str, num);
+	rc = fs_copy(ap, &src_file_dfs, &dst_file_dfs, src_str, dst_str, ap->ignore_unsup, num);
 	if (rc != 0) {
 		DH_PERROR_DER(ap, rc, "fs copy failed");
 		D_GOTO(out_disconnect, rc);

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -70,9 +70,10 @@ enum sh_op {
 };
 
 struct fs_copy_stats {
-	uint64_t		num_dirs;
-	uint64_t		num_files;
-	uint64_t		num_links;
+	uint64_t num_dirs;
+	uint64_t num_files;
+	uint64_t num_links;
+	uint64_t num_chmod_enotsup;
 };
 
 struct dm_args {
@@ -89,8 +90,7 @@ struct dm_args {
 	uint32_t	cont_prop_oid;
 	uint32_t	cont_prop_layout;
 	uint64_t	cont_layout;
-	uint64_t	cont_oid;
-
+	uint64_t         cont_oid;
 };
 
 /* cmd_args_s: consolidated result of parsing command-line arguments
@@ -139,7 +139,8 @@ struct cmd_args_s {
 	/* Container datamover related */
 	struct dm_args		*dm_args;	/* datamover arguments */
 	struct fs_copy_stats	*fs_copy_stats;	/* fs copy stats */
-	bool			 fs_copy_posix; /* fs copy to POSIX */
+	bool                     ignore_unsup;  /* ignore unsupported filesystem features */
+	bool                     fs_copy_posix; /* fs copy to POSIX */
 
 	FILE			*outstream;	/* normal output stream */
 	FILE			*errstream;	/* errors stream */


### PR DESCRIPTION
Features: daos_fs_copy

The setuid, setgid, and sticky bit can cause fatal errors when the datamover tool sets file permissions after copying a file, since these are not supported by DFS. We can just ignore this bit when calling dfs_chmod.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
