### PR TITLE
DAOS-15102 test: Fix passing provider to tests. (#13705)

### DIFF
--- a/src/tests/ftest/util/environment_utils.py
+++ b/src/tests/ftest/util/environment_utils.py
@@ -155,8 +155,12 @@ class TestEnvironment():
         all_hosts = NodeSet()
         all_hosts.update(servers)
         all_hosts.update(clients)
-        self.provider = provider
-        self.insecure_mode = insecure_mode
+
+        # Override values if explicitly specified
+        if provider is not None:
+            self.provider = provider
+        if insecure_mode is not None:
+            self.insecure_mode = insecure_mode
 
         if self.log_dir is None:
             self.log_dir = self.default_log_dir()


### PR DESCRIPTION
Ensure subsequent TestEnvironment instantiations do not remove the environment variable assignments for DAOS test parameters.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium-ucx-provider: false
Allow-unstable-test: true
Test-tag: test_daos_management test_pool_info_query

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate watchers.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
