### PR TITLE
DAOS-623 test: Properly wait for log compression in NLT.

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -139,7 +139,7 @@ class NLTConf():
         a new process is launched then reap any previous ones which have completed.
         """
         # pylint: disable=consider-using-with
-        self._compress_procs[:] = (proc for proc in self._compress_procs if proc.poll())
+        self._compress_procs[:] = (proc for proc in self._compress_procs if proc.poll() is None)
         self._compress_procs.append(subprocess.Popen(['nice', '-19', 'bzip2', '--best', filename]))
 
     def flush_bz2(self):


### PR DESCRIPTION
When NLT is compressing log-files it tries to wait for child
proccess to exit, however the logic for this was incorrect so
it was not blocking for children or reaping the processes.

Normally this does not matter as the last log file to be
processed in the server log which is quite large and is
correctly waited for but a recent change to reduce the server
log size means that the previous log-file to be compressed
is still running when NLT exits and this causes problem with
the archiving as the .log file disappears after the .bz2 file
is complete.

This is causing Fault Injection test errors in Jenkins.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
