### PR TITLE
DAOS-623 test: Fix a log message on timeout.

### DIFF
--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -405,7 +405,7 @@ def run_remote(log, hosts, command, verbose=True, timeout=120, task_debug=False,
     task.set_info("ssh_options", "-oForwardAgent=yes")
     if verbose:
         if timeout is None:
-            log.debug("Running on %s without a timeout: %s", hosts, timeout, command)
+            log.debug("Running on %s without a timeout: %s", hosts, command)
         else:
             log.debug("Running on %s with a %s second timeout: %s", hosts, timeout, command)
     task.run(command=command, nodes=hosts, timeout=timeout)


### PR DESCRIPTION
Fix a ftest crash when commands without timeout fail.

Required-githooks: true

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
