### PR TITLE
DAOS-15120 crt: Misc d_rand-related fixes

### DIFF
--- a/src/common/rsvc.c
+++ b/src/common/rsvc.c
@@ -91,7 +91,7 @@ rsvc_client_choose(struct rsvc_client *client, crt_endpoint_t *ep)
 		chosen = client->sc_leader_index;
 	} else {
 		if (client->sc_next < 0)
-			client->sc_next = d_randn(client->sc_ranks->rl_nr);
+			client->sc_next = d_rand() % client->sc_ranks->rl_nr;
 		chosen = client->sc_next;
 		/* The hintless search is a round robin of all replicas. */
 		client->sc_next++;
@@ -148,7 +148,7 @@ rsvc_client_process_error(struct rsvc_client *client, int rc,
 			 * search.
 			 */
 			D_DEBUG(DB_MD, "give up leader rank %u\n", ep->ep_rank);
-			client->sc_next = d_randn(client->sc_ranks->rl_nr);
+			client->sc_next = d_rand() % client->sc_ranks->rl_nr;
 			if (client->sc_next == leader_index) {
 				client->sc_next++;
 				client->sc_next %= client->sc_ranks->rl_nr;

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -57,19 +57,6 @@ d_rand()
 	return result;
 }
 
-/* Return a random integer in [0, n), where n must be positive. */
-long int
-d_randn(long int n)
-{
-	long int i;
-
-	D_ASSERT(n > 0);
-	i = ((double)d_rand() / D_RAND_MAX) * n;
-	if (i >= n)
-		i = 0;
-	return i;
-}
-
 /* Developer/debug version, poison memory on free.
  * This tries several ways to access the buffer size however none of them are perfect so for now
  * this is no in release builds.
@@ -544,7 +531,7 @@ d_rank_list_shuffle(d_rank_list_t *rank_list)
 		return;
 
 	for (i = 0; i < rank_list->rl_nr; i++) {
-		j = rand() % rank_list->rl_nr;
+		j = d_rand() % rank_list->rl_nr;
 		tmp = rank_list->rl_ranks[i];
 		rank_list->rl_ranks[i] = rank_list->rl_ranks[j];
 		rank_list->rl_ranks[j] = tmp;

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -82,7 +82,6 @@ extern "C" {
 
 void d_srand(long int);
 long int d_rand(void);
-long int d_randn(long int n);
 
 /* Instruct the compiler these are allocation functions that return a pointer, and if possible
  * which function needs to be used to free them.

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1631,9 +1631,7 @@ choose_map_refresh_rank(struct map_refresh_arg *arg)
 
 	if (arg->mra_i == -1) {
 		/* Let i be a random integer in [0, n). */
-		i = ((double)rand() / RAND_MAX) * n;
-		if (i == n)
-			i = 0;
+		i = d_rand() % n;
 	} else {
 		/* Continue the round robin. */
 		i = arg->mra_i;

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -392,7 +392,7 @@ init_reconf_map(struct pool_map *map, d_rank_list_t *replicas, d_rank_t self,
 
 	/* Shuffle rmap.rcm_domains for randomness in replica placement. */
 	for (i = 0; i < rmap.rcm_domains_len; i++) {
-		int j = i + d_randn(rmap.rcm_domains_len - i);
+		int j = i + d_rand() % (rmap.rcm_domains_len - i);
 
 		D_ASSERTF(i <= j && j < rmap.rcm_domains_len, "i=%d j=%d len=%d\n", i, j,
 			  rmap.rcm_domains_len);
@@ -441,7 +441,7 @@ find_vacancy_in_domain(struct reconf_domain *rdomain, d_rank_list_t *replicas)
 		if ((engine->do_comp.co_status & POOL_SVC_MAP_STATES) &&
 		    !d_rank_list_find(replicas, engine->do_comp.co_rank, NULL /* idx */)) {
 			/* Pick this vacant engine with a probability of 1/n. */
-			if (d_randn(n) == 0)
+			if (d_rand() % n == 0)
 				return engine->do_comp.co_rank;
 			n--;
 		}
@@ -478,7 +478,7 @@ find_replica_in_domain(struct reconf_domain *rdomain, d_rank_list_t *replicas, d
 		if ((engine->do_comp.co_status & POOL_SVC_MAP_STATES) &&
 		    engine->do_comp.co_rank != self &&
 		    d_rank_list_find(replicas, engine->do_comp.co_rank, NULL /* idx */)) {
-			if (d_randn(n) == 0)
+			if (d_rand() % n == 0)
 				return engine->do_comp.co_rank;
 			n--;
 		}


### PR DESCRIPTION
  - Remove duplicate d_srand calls in crt.

  - Use tv_nsec instead of tv_nsec / 1e3 when calling d_srand, for this reduces the chance of seed collisions among daos_engine processes.

  - Replace rand calls in libgurt and libpool with d_rand.

  - Remove d_randn (introduced by this author), since lrand48_r doesn't return the lowest bits from Xi, and the % method is therefore sufficient for our purposes.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
