### PR TITLE
DAOS-9572 control: Indicate list-pools only shows NVMe (#13711)

### DIFF
--- a/src/control/cmd/dmg/pretty/storage.go
+++ b/src/control/cmd/dmg/pretty/storage.go
@@ -276,7 +276,7 @@ func PrintSmdInfoMap(omitDevs, omitPools bool, hsm control.HostStorageMap, out i
 					fmt.Fprintln(out)
 				}
 			} else {
-				fmt.Fprintln(iw, "No pools found")
+				fmt.Fprintln(iw, "No pools with NVMe found")
 			}
 		}
 	}

--- a/src/control/cmd/dmg/pretty/storage_test.go
+++ b/src/control/cmd/dmg/pretty/storage_test.go
@@ -1374,7 +1374,7 @@ host1
 -----
 host1
 -----
-  No pools found
+  No pools with NVMe found
 `,
 		},
 		"list-devices": {

--- a/src/control/cmd/dmg/storage_query.go
+++ b/src/control/cmd/dmg/storage_query.go
@@ -64,7 +64,7 @@ func (cmd *smdQueryCmd) makeRequest(ctx context.Context, req *control.SmdQueryRe
 // storageQueryCmd is the struct representing the storage query subcommand
 type storageQueryCmd struct {
 	DeviceHealth devHealthQueryCmd   `command:"device-health" description:"Query the device health"`
-	ListPools    listPoolsQueryCmd   `command:"list-pools" description:"List pools on the server"`
+	ListPools    listPoolsQueryCmd   `command:"list-pools" description:"List pools with NVMe on the server"`
 	ListDevices  listDevicesQueryCmd `command:"list-devices" description:"List storage devices on the server"`
 	Usage        usageQueryCmd       `command:"usage" description:"Show SCM & NVMe storage space utilization per storage server"`
 }


### PR DESCRIPTION
Update display output and command description to indicate that dmg
storage query list-pools will only show pools containing some NVMe.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
