### PR TITLE
DAOS-15138 dfs: improve output of daos fs get-attr

### DIFF
--- a/src/control/cmd/daos/filesystem.go
+++ b/src/control/cmd/daos/filesystem.go
@@ -282,12 +282,12 @@ func (cmd *fsGetAttrCmd) Execute(_ []string) error {
 			jsonAttrs := struct {
 				ObjAttr struct {
 					ObjClass string `json:"oclass"`
-				} `json:"Object"`
+				} `json:"object"`
 				DirAttr struct {
 					DirObjClass  string `json:"dir_oclass"`
 					FileObjClass string `json:"file_oclass"`
 					ChunkSize    uint64 `json:"chunk_size"`
-				} `json:"Directory"`
+				} `json:"directory"`
 			}{
 				ObjAttr: struct {
 					ObjClass string `json:"oclass"`

--- a/src/control/cmd/daos/util.h
+++ b/src/control/cmd/daos/util.h
@@ -121,5 +121,9 @@ get_rebuild_state(struct daos_rebuild_status *drs)
 	return drs->rs_state;
 }
 
-
+static inline bool
+mode_is_dir(mode_t mode)
+{
+	return S_ISDIR(mode);
+}
 #endif /* __CMD_DAOS_UTIL_H__ */

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -98,6 +98,10 @@ typedef struct {
 	daos_oclass_id_t	doi_oclass_id;
 	/** chunk size */
 	daos_size_t		doi_chunk_size;
+	/** In case of dir, return default object class for dirs created in that dir */
+	daos_oclass_id_t        doi_dir_oclass_id;
+	/** In case of dir, return default object class for files created in that dir */
+	daos_oclass_id_t        doi_file_oclass_id;
 } dfs_obj_info_t;
 
 /**

--- a/src/utils/daos_dfs_hdlr.c
+++ b/src/utils/daos_dfs_hdlr.c
@@ -152,7 +152,7 @@ out_umount:
 }
 
 int
-fs_dfs_get_attr_hdlr(struct cmd_args_s *ap, dfs_obj_info_t *attrs)
+fs_dfs_get_attr_hdlr(struct cmd_args_s *ap, dfs_obj_info_t *attrs, mode_t *mode)
 {
 	int		 flags = O_RDONLY;
 	int		 rc;
@@ -178,15 +178,19 @@ fs_dfs_get_attr_hdlr(struct cmd_args_s *ap, dfs_obj_info_t *attrs)
 
 	rc = dfs_lookup(dfs, ap->dfs_path, flags, &obj, NULL, NULL);
 	if (rc) {
-		fprintf(ap->errstream, "failed to lookup %s (%s)\n",
-			ap->dfs_path, strerror(rc));
+		fprintf(ap->errstream, "failed to lookup %s (%s)\n", ap->dfs_path, strerror(rc));
 		D_GOTO(out_umount, rc);
 	}
 
 	rc = dfs_obj_get_info(dfs, obj, attrs);
 	if (rc) {
-		fprintf(ap->errstream, "failed to get obj info (%s)\n",
-			strerror(rc));
+		fprintf(ap->errstream, "failed to get obj info (%s)\n", strerror(rc));
+		D_GOTO(out_release, rc);
+	}
+
+	rc = dfs_get_mode(obj, mode);
+	if (rc) {
+		fprintf(ap->errstream, "failed to get obj mode (%s)\n", strerror(rc));
 		D_GOTO(out_release, rc);
 	}
 

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -191,7 +191,7 @@ fs_copy_hdlr(struct cmd_args_s *ap);
 int
 fs_dfs_hdlr(struct cmd_args_s *ap);
 int
-fs_dfs_get_attr_hdlr(struct cmd_args_s *ap, dfs_obj_info_t *attrs);
+fs_dfs_get_attr_hdlr(struct cmd_args_s *ap, dfs_obj_info_t *attrs, mode_t *mode);
 int
 parse_filename_dfs(const char *path, char **_obj_name, char **_cont_name);
 int

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1840,7 +1840,7 @@ def destroy_container(conf, pool, container, valgrind=True, log_check=True):
     assert rc.returncode == 0, rc
 
 
-def check_dfs_tool_output(output, oclass, csize):
+def check_file_attr(output, oclass, csize):
     """Verify daos fs tool output"""
     line = output.splitlines()
     dfs_attr = line[0].split()[-1]
@@ -1848,6 +1848,28 @@ def check_dfs_tool_output(output, oclass, csize):
         if dfs_attr != oclass:
             return False
     dfs_attr = line[1].split()[-1]
+    if csize is not None:
+        if dfs_attr != csize:
+            return False
+    return True
+
+
+def check_dir_attr(output, oclass, dir_oclass, file_oclass, csize):
+    """Verify daos fs tool output"""
+    line = output.splitlines()
+    dfs_attr = line[0].split()[-1]
+    if oclass is not None:
+        if dfs_attr != oclass:
+            return False
+    dfs_attr = line[1].split()[-1]
+    if dir_oclass is not None:
+        if dfs_attr != dir_oclass:
+            return False
+    dfs_attr = line[2].split()[-1]
+    if file_oclass is not None:
+        if dfs_attr != file_oclass:
+            return False
+    dfs_attr = line[3].split()[-1]
     if csize is not None:
         if dfs_attr != csize:
             return False
@@ -2068,7 +2090,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(rc)
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, 'S2', '1048576')
+        assert check_dir_attr(output, 'S2', 'S2', 'S4', '1048576')
 
         cmd = ['fs', 'get-attr', '--path', file1]
         print('get-attr of ' + file1)
@@ -2076,7 +2098,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(rc)
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, 'S4', '1048576')
+        assert check_file_attr(output, 'S4', '1048576')
 
         if dfuse.stop():
             self.fatal_errors = True
@@ -3495,7 +3517,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(f'rc is {rc}')
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, 'S1', '1048576')
+        assert check_dir_attr(output, 'S1', 'S1', None, '1048576')
 
         # run same command using pool, container, dfs-path, and dfs-prefix
         cmd = ['fs', 'get-attr', pool, uns_container.id(), '--dfs-path', dir1,
@@ -3505,7 +3527,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(f'rc is {rc}')
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, 'S1', '1048576')
+        assert check_dir_attr(output, 'S1', 'S1', None, '1048576')
 
         # run same command using pool, container, dfs-path
         cmd = ['fs', 'get-attr', pool, uns_container.id(), '--dfs-path', '/d1']
@@ -3514,7 +3536,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(f'rc is {rc}')
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, 'S1', '1048576')
+        assert check_dir_attr(output, 'S1', 'S1', None, '1048576')
 
         cmd = ['fs', 'get-attr', '--path', file1]
         print('get-attr of d1/f1')
@@ -3523,7 +3545,7 @@ class PosixTests():
         print(f'rc is {rc}')
         output = rc.stdout.decode('utf-8')
         # SX is not deterministic, so don't check it here
-        assert check_dfs_tool_output(output, None, '1048576')
+        assert check_file_attr(output, None, '1048576')
 
         # Run a command to change attr of dir1
         cmd = ['fs', 'set-attr', '--path', dir1, '--oclass', 'S2',
@@ -3556,7 +3578,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(f'rc is {rc}')
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, 'S2', '16')
+        assert check_dir_attr(output, 'S1', 'S2', 'S2', '16')
 
         cmd = ['fs', 'get-attr', '--path', file2]
         print('get-attr of d1/f2')
@@ -3564,7 +3586,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(f'rc is {rc}')
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, 'S1', '16')
+        assert check_file_attr(output, 'S1', '16')
 
     def test_cont_copy(self):
         """Verify that copying into a container works"""
@@ -4084,7 +4106,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(f'rc is {rc}')
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, None, '1048576')
+        assert check_file_attr(output, None, '1048576')
         with open(fname1, 'r', encoding='ascii', errors='ignore') as fd:
             data = fd.read()
             if data != 'test1':
@@ -4095,7 +4117,7 @@ class PosixTests():
         assert rc.returncode == 0
         print(f'rc is {rc}')
         output = rc.stdout.decode('utf-8')
-        assert check_dfs_tool_output(output, None, '1048576')
+        assert check_file_attr(output, None, '1048576')
         with open(fname3, 'r', encoding='ascii', errors='ignore') as fd:
             data = fd.read()
             if data != 'test3':


### PR DESCRIPTION
Instead of just returning the oclass of new objects, return the oclass of the directory, the creation oclass of new directories, and the creation oclass of new files.

Features: dfs
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
