### PR TITLE
DAOS-15055 build: Ignore BuildTime in rebuild calculation

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -56,8 +56,10 @@ def go_ldflags(benv):
     path = 'github.com/daos-stack/daos/src/control/build'
     return ' '.join([f'-X {path}.DaosVersion={daos_version}',
                      f'-X {path}.ConfigDir={conf_dir}',
-                     f'-X {path}.BuildTime={build_time}',
                      f'-X {path}.BuildHost={build_host}',
+                     # NB: dynamic values should be enclosed in $(...$)
+                     # to avoid unnecessary rebuilds
+                     f'-X $({path}.BuildTime={build_time}$)',
                      f'-B $({gen_build_id()}$)'])
 
 


### PR DESCRIPTION
Indicate to scons that the BuildTime linker flag should be
ignored when determining whether or not a rebuild of a Go
binary is necessary.

Change-Id: I00ee6536ec2506881f9a774d85ee5e4e8532cf83
Required-githooks: true
Signed-off-by: Michael MacDonald <mjmac@google.com>
