### PR TITLE
DAOS-15002 test: only kill 2 ranks if we have 2n+1 total

### DIFF
--- a/src/tests/ftest/erasurecode/rebuild_disabled.py
+++ b/src/tests/ftest/erasurecode/rebuild_disabled.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -23,6 +23,7 @@ class EcodDisabledRebuild(ErasureCodeIor):
         Use Case: Create the pool, disabled rebuild, run IOR with supported
                   EC object type class for small and large transfer sizes.
                   kill single server, verify all IOR read data and verified.
+                  Kill another server and verify IOR again.
 
         :avocado: tags=all,full_regression
         :avocado: tags=hw,large
@@ -50,12 +51,13 @@ class EcodDisabledRebuild(ErasureCodeIor):
         # written before killing the single server
         self.ior_read_dataset()
 
-        # Kill the another server rank and wait for 20 seconds,Rebuild will
-        # not happens because i's disabled.Read/verify data with Parity 2.
-        self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log,
-                                           force=True)
-        time.sleep(20)
+        # To kill n ranks, we need 2n + 1 ranks total
+        if self.server_count >= 5:
+            # Kill the another server rank and wait for 20 seconds,Rebuild will
+            # not happens because i's disabled.Read/verify data with Parity 2.
+            self.server_managers[0].stop_ranks([self.server_count - 2], self.d_log, force=True)
+            time.sleep(20)
 
-        # Read IOR data and verify for different EC object and different sizes
-        # written before killing the single server
-        self.ior_read_dataset(parity=2)
+            # Read IOR data and verify for different EC object and different sizes
+            # written before killing the single server
+            self.ior_read_dataset(parity=2)

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.py
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.py
@@ -46,11 +46,13 @@ class EcodDisabledRebuildSingle(ErasureCodeSingle):
         # Read data set and verify for different EC object for parity 1 and 2.
         self.read_single_type_dataset()
 
-        # Kill another server rank and wait for 20 seconds,
-        # Rebuild is disabled so data will not be rebuild.
-        self.server_managers[0].stop_ranks(
-            [self.server_count - 2], self.d_log, force=True)
-        time.sleep(20)
+        # To kill n ranks, we need 2n + 1 ranks total
+        if self.server_count >= 5:
+            # Kill another server rank and wait for 20 seconds,
+            # Rebuild is disabled so data will not be rebuild.
+            self.server_managers[0].stop_ranks(
+                [self.server_count - 2], self.d_log, force=True)
+            time.sleep(20)
 
-        # Read data set and verify for different EC object for 2 only.
-        self.read_single_type_dataset(parity=2)
+            # Read data set and verify for different EC object for 2 only.
+            self.read_single_type_dataset(parity=2)


### PR DESCRIPTION
Test-tag: EcodDisabledRebuildSingle EcodDisabledRebuild
Test-repeat: 3
Skip-unit-tests: true
Skip-fault-injection-test: true

Killing 2 ranks generally requires 2n+1 ranks total for the pool svc. Although it's possible to lower the svcn, there is no guarantee which ranks will be the svc ranks.
And it wouldn't be recommended in production to run with data RF2 but only pool svc RF 1.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
