### PR TITLE
DAOS-15128 object: avoid double recx conversion

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -960,6 +960,7 @@ struct obj_query_merge_args {
 	uint32_t		 opc;
 	uint32_t		 src_map_ver;
 	int			 ret;
+	uint32_t		 server_merge:1;
 };
 
 /* obj_utils.c */

--- a/src/object/obj_utils.c
+++ b/src/object/obj_utils.c
@@ -89,7 +89,7 @@ daos_iods_free(daos_iod_t *iods, int nr, bool need_free)
 static void
 obj_query_merge_recx(struct daos_oclass_attr *oca, daos_unit_oid_t oid, daos_key_t *dkey,
 		     daos_recx_t *src_recx, daos_recx_t *tgt_recx, bool get_max, bool changed,
-		     uint32_t *shard)
+		     uint32_t *shard, bool server_merge)
 {
 	daos_recx_t	tmp_recx = *src_recx;
 	uint64_t	tmp_end;
@@ -126,8 +126,9 @@ obj_query_merge_recx(struct daos_oclass_attr *oca, daos_unit_oid_t oid, daos_key
 					 tmp_recx.rx_idx;
 		}
 
-		tmp_recx.rx_idx = obj_ec_idx_vos2daos(tmp_recx.rx_idx, stripe_rec_nr, cell_rec_nr,
-						      tgt_off);
+		if (!server_merge)
+			tmp_recx.rx_idx = obj_ec_idx_vos2daos(tmp_recx.rx_idx, stripe_rec_nr,
+							      cell_rec_nr, tgt_off);
 		tmp_end = DAOS_RECX_END(tmp_recx);
 	}
 
@@ -268,7 +269,8 @@ daos_obj_merge_query_merge(struct obj_query_merge_args *args)
 	if (check && args->flags & DAOS_GET_RECX)
 		obj_query_merge_recx(args->oca, args->oid,
 				     (args->flags & DAOS_GET_DKEY) ? args->src_dkey : args->in_dkey,
-				     args->src_recx, args->tgt_recx, get_max, changed, args->shard);
+				     args->src_recx, args->tgt_recx, get_max, changed, args->shard,
+				     args->server_merge);
 
 set_max_epoch:
 	if (args->tgt_epoch != NULL && *args->tgt_epoch < args->src_epoch)

--- a/src/object/srv_coll.c
+++ b/src/object/srv_coll.c
@@ -431,6 +431,7 @@ obj_coll_query_merge_tgts(struct obj_coll_query_in *ocqi, struct daos_oclass_att
 		oqma.src_akey = &tmp->akey_copy;
 		oqma.src_recx = &tmp->recx;
 		oqma.src_map_ver = tmp->version;
+		oqma.server_merge = 1;
 		/*
 		 * Merge (L2) the results from other VOS targets on the same engine
 		 * into current otqa that stands for the results for current engine.
@@ -579,6 +580,7 @@ obj_coll_query_agg_cb(struct dtx_leader_handle *dlh, void *arg)
 		oqma.src_recx = &ocqo->ocqo_recx;
 		oqma.flags = ocqi->ocqi_api_flags;
 		oqma.src_map_ver = obj_reply_map_version_get(rpc);
+		oqma.server_merge = 1;
 		/*
 		 * Merge (L3) the results from other engines into current otqa that stands for the
 		 * results for related engines' group, including current engine.

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4069,6 +4069,7 @@ again:
 			oqma.src_dkey = p_dkey;
 			oqma.src_akey = p_akey;
 			oqma.src_recx = p_recx;
+			oqma.server_merge = 1;
 			/*
 			 * Merge (L1) the results from different shards on the same VOS target
 			 * into current otqa that stands for the result for current VOS target.


### PR DESCRIPTION
During collective size query process, let's add flag to avoid double recx conversion.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
