### PR TITLE
DAOS-6533 control: Automatically update fabric provider

### DIFF
--- a/docs/admin/common_tasks.md
+++ b/docs/admin/common_tasks.md
@@ -108,3 +108,13 @@ differ by at least 100.
 - Each engine must have a different `log_file`.
 - Use different `fabric_iface` for the best performance.
 - Each engine must have unique `scm_mount`, `scm_list`, and `bdev_list`.
+
+## Change fabric provider on a DAOS system
+
+1. Stop all DAOS client I/O.
+1. Evict client pool handles to ensure I/O has stopped.
+1. Shut down all `daos_server` processes.
+1. Update the fabric provider and interfaces in all `daos_server` configuration files. All `daos_server` configurations must use the same fabric provider.
+1. Restart all `daos_server` processes to re-load the configuration file.
+1. Ensure all ranks have re-joined by running `dmg system query`. If some ranks fail to join, check logs to troubleshoot.
+1. After all ranks have joined, restart `daos_agent` processes on client nodes, or alternately send SIGUSR2 to all of these processes to refresh network information.

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -502,17 +502,25 @@ Rank UUID                                 Control Address Fault Domain State   R
 
 Alternately, monitoring RAS events will alert you to these failures. Relevant RAS event IDs are:
 
-- system_fabric_provider_changed: This informational event will be generated when an MS leader node
+- `system_fabric_provider_changed`: This informational event will be generated when an MS leader node
   detects that the provider changed locally.
-- engine_join_failed: One of these error events will be generated for each rank that fails to join.
+- `engine_join_failed`: One of these error events will be generated for each rank that fails to join.
 
-Example from syslog:
+Examples from syslog:
 
 ```
 daos_server[3302185]: id: [system_fabric_provider_changed] ts: [2024-02-13T20:08:50.956+00:00] host: [boro-74.boro.hpdd.intel.com] type: [INFO] sev: [NOTICE] msg: [system fabric provider has changed: ofi+tcp -> ofi+tcp;ofi_rxm] pid: [3302185]
 daos_server[3302185]: id: [engine_join_failed] ts: [2024-02-13T20:08:57.607+00:00] host: [10.7.1.75:10001] type: [INFO] sev: [ERROR] msg: [DAOS engine 0 (rank 1) was not allowed to join the system] pid: [3302185] rank: [1] data: [rank 1 fabric provider "ofi+tcp" does not match system provider "ofi+tcp;ofi_rxm"]
 daos_server[3302185]: id: [engine_join_failed] ts: [2024-02-13T20:08:57.869+00:00] host: [10.7.1.75:10001] type: [INFO] sev: [ERROR] msg: [DAOS engine 1 (rank 3) was not allowed to join the system] pid: [3302185] rank: [3] data: [rank 3 fabric provider "ofi+tcp" does not match system provider "ofi+tcp;ofi_rxm"]
 ```
+
+To resolve the issue:
+
+- Determine which `daos_server` hosts need their fabric provider updated by analyzing which ranks were errored.
+- Stop all `daos_server` processes.
+- Update the configuration files with the correct fabric provider.
+- Start all `daos_server` processes.
+- Verify that all ranks were able to re-join via `dmg system query`.
 
 ## Diagnostic and Recovery Tools
 

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -473,6 +473,47 @@ If this happens, the `daos` tool (as well as other I/O or `libdaos` operations) 
 To resolve the issue, a privileged user may send a `SIGUSR2` signal to the `daos_agent` process to
 force an immediate cache refresh.
 
+### Ranks are excluded because their provider does not match the system fabric provider
+
+This issue may be encountered after changing the system fabric provider in the `daos_server`
+configuration files, or if the initial configuration files for the servers don't have matching
+fabric providers.
+
+After starting `daos_server`, ranks will be unable to join if their configuration's fabric provider
+does not match that of the system. The system configuration is determined by the management service
+(MS) leader node, which may be arbitrarily chosen from the configured access points.
+
+To diagnose the issue, use `dmg system query`. Using verbose mode (`-v`) for the errored ranks
+will show the detailed errors, as seen below.
+
+```
+$ dmg system query
+Rank  State
+----  -----
+[1,3] Errored
+[0,2] Joined
+
+$ dmg system query -v -r 1,3
+Rank UUID                                 Control Address Fault Domain State   Reason
+---- ----                                 --------------- ------------ -----   ------
+1    1ad01ebe-08f2-4b20-aa39-80faf14bc373 10.7.1.75:10001 /boro-75     Errored DAOS engine 0 exited unexpectedly: rpc error: code = Unknown desc = rank 1 fabric provider "ofi+tcp" does not match system provider "ofi+tcp;ofi_rxm"
+3    15e53aa7-fc0c-42eb-93de-8b485d96c63e 10.7.1.75:10001 /boro-75     Errored DAOS engine 1 exited unexpectedly: rpc error: code = Unknown desc = rank 3 fabric provider "ofi+tcp" does not match system provider "ofi+tcp;ofi_rxm"
+```
+
+Alternately, monitoring RAS events will alert you to these failures. Relevant RAS event IDs are:
+
+- system_fabric_provider_changed: This informational event will be generated when an MS leader node
+  detects that the provider changed locally.
+- engine_join_failed: One of these error events will be generated for each rank that fails to join.
+
+Example from syslog:
+
+```
+daos_server[3302185]: id: [system_fabric_provider_changed] ts: [2024-02-13T20:08:50.956+00:00] host: [boro-74.boro.hpdd.intel.com] type: [INFO] sev: [NOTICE] msg: [system fabric provider has changed: ofi+tcp -> ofi+tcp;ofi_rxm] pid: [3302185]
+daos_server[3302185]: id: [engine_join_failed] ts: [2024-02-13T20:08:57.607+00:00] host: [10.7.1.75:10001] type: [INFO] sev: [ERROR] msg: [DAOS engine 0 (rank 1) was not allowed to join the system] pid: [3302185] rank: [1] data: [rank 1 fabric provider "ofi+tcp" does not match system provider "ofi+tcp;ofi_rxm"]
+daos_server[3302185]: id: [engine_join_failed] ts: [2024-02-13T20:08:57.869+00:00] host: [10.7.1.75:10001] type: [INFO] sev: [ERROR] msg: [DAOS engine 1 (rank 3) was not allowed to join the system] pid: [3302185] rank: [3] data: [rank 3 fabric provider "ofi+tcp" does not match system provider "ofi+tcp;ofi_rxm"]
+```
+
 ## Diagnostic and Recovery Tools
 
 !!! WARNING : Please be careful and use this tool under supervision of DAOS support team.

--- a/src/control/events/engine.go
+++ b/src/control/events/engine.go
@@ -87,3 +87,16 @@ func NewEngineFormatRequiredEvent(hostname string, instanceIdx uint32, formatTyp
 		},
 	})
 }
+
+// NewEngineJoinFailedEvent creates an EngineJoinFailed event from the given inputs.
+func NewEngineJoinFailedEvent(hostname string, instanceIdx uint32, rank uint32, reason string) *RASEvent {
+	return fill(&RASEvent{
+		Msg:          fmt.Sprintf("DAOS engine %d (rank %d) was not allowed to join the system", instanceIdx, rank),
+		ID:           RASEngineJoinFailed,
+		Hostname:     hostname,
+		Rank:         rank,
+		Type:         RASTypeInfoOnly,
+		Severity:     RASSeverityError,
+		ExtendedInfo: NewStrInfo(reason),
+	})
+}

--- a/src/control/events/ras.go
+++ b/src/control/events/ras.go
@@ -45,14 +45,16 @@ type RASID uint32
 // RASID constant definitions matching those used when creating events either in
 // the control or data (engine) planes.
 const (
-	RASUnknownEvent         RASID = C.RAS_UNKNOWN_EVENT
-	RASEngineFormatRequired RASID = C.RAS_ENGINE_FORMAT_REQUIRED // notice
-	RASEngineDied           RASID = C.RAS_ENGINE_DIED            // error
-	RASPoolRepsUpdate       RASID = C.RAS_POOL_REPS_UPDATE       // info
-	RASSwimRankAlive        RASID = C.RAS_SWIM_RANK_ALIVE        // info
-	RASSwimRankDead         RASID = C.RAS_SWIM_RANK_DEAD         // info
-	RASSystemStartFailed    RASID = C.RAS_SYSTEM_START_FAILED    // error
-	RASSystemStopFailed     RASID = C.RAS_SYSTEM_STOP_FAILED     // error
+	RASUnknownEvent            RASID = C.RAS_UNKNOWN_EVENT
+	RASEngineFormatRequired    RASID = C.RAS_ENGINE_FORMAT_REQUIRED     // notice
+	RASEngineDied              RASID = C.RAS_ENGINE_DIED                // error
+	RASPoolRepsUpdate          RASID = C.RAS_POOL_REPS_UPDATE           // info
+	RASSwimRankAlive           RASID = C.RAS_SWIM_RANK_ALIVE            // info
+	RASSwimRankDead            RASID = C.RAS_SWIM_RANK_DEAD             // info
+	RASSystemStartFailed       RASID = C.RAS_SYSTEM_START_FAILED        // error
+	RASSystemStopFailed        RASID = C.RAS_SYSTEM_STOP_FAILED         // error
+	RASEngineJoinFailed        RASID = C.RAS_ENGINE_JOIN_FAILED         // error
+	RASSystemFabricProvChanged RASID = C.RAS_SYSTEM_FABRIC_PROV_CHANGED // info
 )
 
 func (id RASID) String() string {

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -208,14 +208,12 @@ func (ei *EngineInstance) determineRank(ctx context.Context, ready *srvpb.Notify
 	}
 	r = ranklist.Rank(resp.Rank)
 
-	// TODO: Check to see if ready.Uri != superblock.URI, which might
-	// need to trigger some kind of update?
-
-	if !superblock.ValidRank {
+	if !superblock.ValidRank || ready.Uri != superblock.URI {
+		ei.log.Noticef("updating rank %d URI to %s", resp.Rank, ready.Uri)
 		superblock.Rank = new(ranklist.Rank)
 		*superblock.Rank = r
 		superblock.ValidRank = true
-		superblock.URI = ready.GetUri()
+		superblock.URI = ready.Uri
 		ei.setSuperblock(superblock)
 		if err := ei.WriteSuperblock(); err != nil {
 			return ranklist.NilRank, resp.LocalJoin, 0, err

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -38,6 +38,8 @@ import (
 	"github.com/daos-stack/daos/src/control/system"
 )
 
+const fabricProviderProp = "fabric_providers"
+
 // GetAttachInfo handles a request to retrieve a map of ranks to fabric URIs, in addition
 // to client network autoconfiguration hints.
 //
@@ -150,6 +152,10 @@ func (svc *mgmtSvc) join(ctx context.Context, req *mgmtpb.JoinReq, peerAddr *net
 		return nil, errors.Wrapf(err, "invalid server fault domain %q", req.SrvFaultDomain)
 	}
 
+	if err := svc.checkReqFabricProvider(req, svc.events); err != nil {
+		return nil, err
+	}
+
 	joinResponse, err := svc.membership.Join(&system.JoinRequest{
 		Rank:           ranklist.Rank(req.Rank),
 		UUID:           uuid,
@@ -195,6 +201,77 @@ func (svc *mgmtSvc) join(ctx context.Context, req *mgmtpb.JoinReq, peerAddr *net
 	}
 
 	return resp, nil
+}
+
+func (svc *mgmtSvc) checkReqFabricProvider(req *mgmtpb.JoinReq, publisher events.Publisher) error {
+	joinProv, err := getProviderFromURI(req.Uri)
+	if err != nil {
+		return err
+	}
+
+	sysProv, err := svc.getFabricProvider()
+	if err != nil {
+		return errors.Wrapf(err, "fetching system fabric provider")
+	}
+
+	if joinProv != sysProv {
+		msg := fmt.Sprintf("rank %d fabric provider %q does not match system provider %q",
+			req.Rank, joinProv, sysProv)
+
+		publisher.Publish(events.NewEngineJoinFailedEvent(req.Addr, req.Idx, req.Rank, msg))
+		return errors.New(msg)
+	}
+
+	return nil
+}
+
+func getProviderFromURI(uri string) (string, error) {
+	uriParts := strings.Split(uri, "://")
+	if len(uriParts) < 2 {
+		return "", fmt.Errorf("unable to parse fabric provider from URI %q", uri)
+	}
+	return uriParts[0], nil
+}
+
+func (svc *mgmtSvc) getFabricProvider() (string, error) {
+	return system.GetMgmtProperty(svc.sysdb, fabricProviderProp)
+}
+
+func (svc *mgmtSvc) setFabricProviders(val string) error {
+	return system.SetMgmtProperty(svc.sysdb, fabricProviderProp, val)
+}
+
+func (svc *mgmtSvc) updateFabricProviders(provList []string, publisher events.Publisher) error {
+	provStr := strings.Join(provList, ",")
+
+	curProv, err := svc.getFabricProvider()
+	if system.IsErrSystemAttrNotFound(err) {
+		svc.log.Debugf("setting system fabric providers (%s) for the first time", provStr)
+
+		if err := svc.setFabricProviders(provStr); err != nil {
+			return errors.Wrapf(err, "setting fabric provider for the first time")
+		}
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "fetching current mgmt property %q", fabricProviderProp)
+	}
+
+	if provStr != curProv {
+		if err := svc.setFabricProviders(provStr); err != nil {
+			return errors.Wrapf(err, "changing fabric provider prop")
+		}
+		publisher.Publish(newFabricProvChangedEvent(curProv, provStr))
+		return nil
+	}
+
+	svc.log.Tracef("system fabric provider value has not changed (%s)", provStr)
+	return nil
+}
+
+func newFabricProvChangedEvent(old, new string) *events.RASEvent {
+	return events.NewGenericEvent(events.RASSystemFabricProvChanged, events.RASSeverityNotice,
+		fmt.Sprintf("system fabric provider has changed: %s -> %s", old, new), "")
 }
 
 // reqGroupUpdate requests a group update.

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2023 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -152,7 +152,7 @@ func (svc *mgmtSvc) join(ctx context.Context, req *mgmtpb.JoinReq, peerAddr *net
 		return nil, errors.Wrapf(err, "invalid server fault domain %q", req.SrvFaultDomain)
 	}
 
-	if err := svc.checkReqFabricProvider(req, svc.events); err != nil {
+	if err := svc.checkReqFabricProvider(req, peerAddr, svc.events); err != nil {
 		return nil, err
 	}
 
@@ -203,7 +203,7 @@ func (svc *mgmtSvc) join(ctx context.Context, req *mgmtpb.JoinReq, peerAddr *net
 	return resp, nil
 }
 
-func (svc *mgmtSvc) checkReqFabricProvider(req *mgmtpb.JoinReq, publisher events.Publisher) error {
+func (svc *mgmtSvc) checkReqFabricProvider(req *mgmtpb.JoinReq, peerAddr *net.TCPAddr, publisher events.Publisher) error {
 	joinProv, err := getProviderFromURI(req.Uri)
 	if err != nil {
 		return err
@@ -218,7 +218,7 @@ func (svc *mgmtSvc) checkReqFabricProvider(req *mgmtpb.JoinReq, publisher events
 		msg := fmt.Sprintf("rank %d fabric provider %q does not match system provider %q",
 			req.Rank, joinProv, sysProv)
 
-		publisher.Publish(events.NewEngineJoinFailedEvent(req.Addr, req.Idx, req.Rank, msg))
+		publisher.Publish(events.NewEngineJoinFailedEvent(peerAddr.String(), req.Idx, req.Rank, msg))
 		return errors.New(msg)
 	}
 

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2023 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -2266,7 +2266,11 @@ func TestMgmtSvc_checkReqFabricProvider(t *testing.T) {
 				Uri:  tc.joinURI,
 				Rank: 12,
 			}
-			err := svc.checkReqFabricProvider(req, mockPub)
+			addr := &net.TCPAddr{
+				IP:   net.IPv4(1, 2, 3, 4),
+				Port: 5678,
+			}
+			err := svc.checkReqFabricProvider(req, addr, mockPub)
 
 			test.CmpErr(t, tc.expErr, err)
 
@@ -2278,6 +2282,7 @@ func TestMgmtSvc_checkReqFabricProvider(t *testing.T) {
 				test.AssertEqual(t, events.RASEngineJoinFailed, gotEvent.ID, "")
 				test.AssertEqual(t, events.RASSeverityError, gotEvent.Severity, "")
 				test.AssertEqual(t, req.Rank, gotEvent.Rank, "")
+				test.AssertEqual(t, addr.String(), gotEvent.Hostname, "")
 			}
 		})
 	}

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -569,6 +569,10 @@ func mgmtSystemTestSetup(t *testing.T, l logging.Logger, mbs system.Members, r .
 	mi := control.NewMockInvoker(l, &mic)
 	svc.rpcClient = mi
 
+	if err := svc.setFabricProviders("tcp"); err != nil {
+		t.Fatal(err)
+	}
+
 	return svc
 }
 
@@ -1861,6 +1865,8 @@ func TestServer_MgmtSvc_SystemErase(t *testing.T) {
 func TestServer_MgmtSvc_Join(t *testing.T) {
 	curMember := mockMember(t, 0, 0, "excluded")
 	newMember := mockMember(t, 1, 1, "joined")
+	newProviderMember := mockMember(t, 1, 1, "joined")
+	newProviderMember.FabricURI = fmt.Sprintf("verbs://%s", test.MockHostAddr(1))
 
 	for name, tc := range map[string]struct {
 		req      *mgmtpb.JoinReq
@@ -1912,7 +1918,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 				Engines: []*mgmtpb.GroupUpdateReq_Engine{
 					{
 						Rank:        curMember.Rank.Uint32(),
-						Uri:         curMember.FabricURI,
+						Uri:         newMember.FabricURI, // update URI
 						Incarnation: curMember.Incarnation + 1,
 					},
 				},
@@ -1935,7 +1941,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 				Engines: []*mgmtpb.GroupUpdateReq_Engine{
 					{
 						Rank:        curMember.Rank.Uint32(),
-						Uri:         curMember.FabricURI,
+						Uri:         newMember.FabricURI, // update URI
 						Incarnation: curMember.Incarnation + 1,
 					},
 				},
@@ -1946,6 +1952,25 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 				State:      mgmtpb.JoinResp_IN,
 				MapVersion: 2,
 			},
+		},
+		"provider doesn't match": {
+			req: &mgmtpb.JoinReq{
+				Rank:        curMember.Rank.Uint32(),
+				Uuid:        curMember.UUID.String(),
+				Uri:         newProviderMember.FabricURI,
+				Incarnation: curMember.Incarnation + 1,
+			},
+			expGuReq: &mgmtpb.GroupUpdateReq{
+				MapVersion: 3,
+				Engines: []*mgmtpb.GroupUpdateReq_Engine{
+					{
+						Rank:        curMember.Rank.Uint32(),
+						Uri:         newProviderMember.FabricURI, // update URI
+						Incarnation: curMember.Incarnation + 1,
+					},
+				},
+			},
+			expErr: errors.New("does not match"),
 		},
 		"new host (non local)": {
 			req: &mgmtpb.JoinReq{
@@ -2074,6 +2099,185 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expGuReq, gotGuReq, cmpOpts...); diff != "" {
 				t.Fatalf("unexpected GroupUpdate request (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMgmtSvc_updateFabricProviders(t *testing.T) {
+	for name, tc := range map[string]struct {
+		getSvc       func(*testing.T, logging.Logger) *mgmtSvc
+		oldProv      string
+		provs        []string
+		expErr       error
+		expProv      string
+		expNumEvents int
+	}{
+		"no change": {
+			oldProv: "tcp",
+			provs:   []string{"tcp"},
+			expProv: "tcp",
+		},
+		"successful change": {
+			oldProv:      "tcp",
+			provs:        []string{"verbs"},
+			expProv:      "verbs",
+			expNumEvents: 1,
+		},
+		"fails getting prop": {
+			getSvc: func(t *testing.T, log logging.Logger) *mgmtSvc {
+				svc := newTestMgmtSvcMulti(t, log, maxEngines, false)
+				// not a replica
+				svc.sysdb = raft.MockDatabaseWithCfg(t, log, &raft.DatabaseConfig{
+					SystemName: build.DefaultSystemName,
+				})
+
+				return svc
+			},
+			provs:  []string{"verbs"},
+			expErr: &system.ErrNotReplica{},
+		},
+		"change fails setting prop": {
+			getSvc: func(t *testing.T, log logging.Logger) *mgmtSvc {
+				svc := newTestMgmtSvcMulti(t, log, maxEngines, true)
+				svc.sysdb = raft.MockDatabaseWithCfg(t, log, &raft.DatabaseConfig{
+					SystemName: build.DefaultSystemName,
+					Replicas:   []*net.TCPAddr{common.LocalhostCtrlAddr()},
+				})
+				if err := svc.setFabricProviders("tcp"); err != nil {
+					t.Fatal(err)
+				}
+				if err := svc.sysdb.ResignLeadership(errors.New("test")); err != nil {
+					t.Fatal(err)
+				}
+
+				return svc
+			},
+			oldProv: "tcp",
+			provs:   []string{"verbs"},
+			expErr:  &system.ErrNotLeader{},
+		},
+		"first time": {
+			provs:   []string{"verbs"},
+			expProv: "verbs",
+		},
+		"first time fails setting prop": {
+			getSvc: func(t *testing.T, log logging.Logger) *mgmtSvc {
+				svc := newTestMgmtSvcMulti(t, log, maxEngines, true)
+				svc.sysdb = raft.MockDatabaseWithCfg(t, log, &raft.DatabaseConfig{
+					SystemName: build.DefaultSystemName,
+					Replicas:   []*net.TCPAddr{common.LocalhostCtrlAddr()},
+				})
+				if err := svc.sysdb.ResignLeadership(errors.New("test")); err != nil {
+					t.Fatal(err)
+				}
+
+				return svc
+			},
+			provs:  []string{"verbs"},
+			expErr: &system.ErrNotLeader{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			if tc.getSvc == nil {
+				tc.getSvc = func(t *testing.T, l logging.Logger) *mgmtSvc {
+					ms := mgmtSystemTestSetup(t, l, system.Members{}, []*control.HostResponse{})
+					if err := ms.setFabricProviders(tc.oldProv); err != nil {
+						t.Fatal(err)
+					}
+					return ms
+				}
+			}
+
+			svc := tc.getSvc(t, log)
+			mockPub := &mockPublisher{}
+
+			err := svc.updateFabricProviders(tc.provs, mockPub)
+
+			test.CmpErr(t, tc.expErr, err)
+
+			t.Logf("published events:\n%+v", mockPub.published)
+			test.AssertEqual(t, tc.expNumEvents, len(mockPub.published), "unexpected number of events published")
+
+			if tc.expNumEvents > 0 {
+				gotEvent := mockPub.published[0]
+				test.AssertEqual(t, events.RASSystemFabricProvChanged, gotEvent.ID, "")
+				test.AssertEqual(t, events.RASSeverityNotice, gotEvent.Severity, "")
+			}
+		})
+	}
+}
+
+func TestMgmtSvc_checkReqFabricProvider(t *testing.T) {
+	sysProv := "tcp"
+	for name, tc := range map[string]struct {
+		getSvc       func(*testing.T, logging.Logger) *mgmtSvc
+		joinProv     string
+		joinURI      string
+		expErr       error
+		expNumEvents int
+	}{
+		"bad URI": {
+			joinURI: "bad format",
+			expErr:  errors.New("unable to parse fabric provider"),
+		},
+		"failed getting system provider": {
+			getSvc: func(t *testing.T, log logging.Logger) *mgmtSvc {
+				svc := newTestMgmtSvcMulti(t, log, maxEngines, false)
+				svc.sysdb = raft.MockDatabaseWithCfg(t, log, &raft.DatabaseConfig{
+					SystemName: build.DefaultSystemName,
+				})
+
+				return svc
+			},
+			joinURI: "tcp://10.10.10.10",
+			expErr:  &system.ErrNotReplica{},
+		},
+		"success": {
+			joinURI: "tcp://10.10.10.10",
+		},
+		"does not match": {
+			joinProv:     "verbs",
+			joinURI:      "verbs://10.10.10.10",
+			expErr:       errors.New("does not match"),
+			expNumEvents: 1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			if tc.getSvc == nil {
+				tc.getSvc = func(t *testing.T, l logging.Logger) *mgmtSvc {
+					ms := mgmtSystemTestSetup(t, l, system.Members{}, []*control.HostResponse{})
+					if err := ms.setFabricProviders(sysProv); err != nil {
+						t.Fatal(err)
+					}
+					return ms
+				}
+			}
+			svc := tc.getSvc(t, log)
+			mockPub := &mockPublisher{}
+
+			req := &mgmtpb.JoinReq{
+				Uri:  tc.joinURI,
+				Rank: 12,
+			}
+			err := svc.checkReqFabricProvider(req, mockPub)
+
+			test.CmpErr(t, tc.expErr, err)
+
+			t.Logf("published events:\n%+v", mockPub.published)
+			test.AssertEqual(t, tc.expNumEvents, len(mockPub.published), "unexpected number of events published")
+
+			if tc.expNumEvents > 0 {
+				gotEvent := mockPub.published[0]
+				test.AssertEqual(t, events.RASEngineJoinFailed, gotEvent.ID, "")
+				test.AssertEqual(t, events.RASSeverityError, gotEvent.Severity, "")
+				test.AssertEqual(t, req.Rank, gotEvent.Rank, "")
 			}
 		})
 	}

--- a/src/control/server/mocks.go
+++ b/src/control/server/mocks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dustin/go-humanize"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/engine"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -55,4 +56,12 @@ func NewMockStorageControlService(log logging.Logger, ecs []*engine.Config, sys 
 		storage:         storage.MockProvider(log, 0, topCfg, sys, scm, bdev, nil),
 		getMemInfo:      getMemInfo,
 	}
+}
+
+type mockPublisher struct {
+	published []*events.RASEvent
+}
+
+func (m *mockPublisher) Publish(e *events.RASEvent) {
+	m.published = append(m.published, e)
 }

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -390,6 +390,11 @@ func (srv *server) registerEvents() {
 	srv.sysdb.OnLeadershipGained(
 		func(ctx context.Context) error {
 			srv.log.Infof("MS leader running on %s", srv.hostname)
+
+			if err := srv.mgmtSvc.updateFabricProviders([]string{srv.cfg.Fabric.Provider}, srv.pubSub); err != nil {
+				srv.log.Errorf(err.Error())
+			}
+
 			srv.mgmtSvc.startLeaderLoops(ctx)
 			registerLeaderSubscriptions(srv)
 			srv.log.Debugf("requesting immediate GroupUpdate after leader change")

--- a/src/control/system/raft/database_members.go
+++ b/src/control/system/raft/database_members.go
@@ -162,6 +162,7 @@ func (mdb *MemberDatabase) updateMember(m *system.Member) {
 	cur.Info = m.Info
 	cur.LastUpdate = m.LastUpdate
 	cur.Incarnation = m.Incarnation
+	cur.FabricURI = m.FabricURI
 
 	mdb.removeFromFaultDomainTree(cur)
 	cur.FaultDomain = m.FaultDomain

--- a/src/control/system/raft/mocks.go
+++ b/src/control/system/raft/mocks.go
@@ -125,6 +125,7 @@ func MockDatabaseWithCfg(t *testing.T, log logging.Logger, dbCfg *DatabaseConfig
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	db.raft.setSvc(newMockRaftService(&mockRaftServiceConfig{
 		State: raft.Leader,
 	}, (*fsm)(db)))

--- a/src/include/daos_srv/ras.h
+++ b/src/include/daos_srv/ras.h
@@ -35,30 +35,32 @@
  *   * Don't arbitrarily reorder entries
  *   * Do limit lines to 99 columns, wrapping as necessary
  */
-#define RAS_EVENT_LIST										\
-	X(RAS_UNKNOWN_EVENT,			"unknown_ras_event")				\
-	X(RAS_ENGINE_FORMAT_REQUIRED,		"engine_format_required")			\
-	X(RAS_ENGINE_DIED,			"engine_died")					\
-	X(RAS_ENGINE_ASSERTED,			"engine_asserted")				\
-	X(RAS_ENGINE_CLOCK_DRIFT,		"engine_clock_drift")				\
-	X(RAS_POOL_CORRUPTION_DETECTED,		"corruption_detected")				\
-	X(RAS_POOL_REBUILD_START,		"pool_rebuild_started")				\
-	X(RAS_POOL_REBUILD_END,			"pool_rebuild_finished")			\
-	X(RAS_POOL_REBUILD_FAILED,		"pool_rebuild_failed")				\
-	X(RAS_POOL_REPS_UPDATE,			"pool_replicas_updated")			\
-	X(RAS_POOL_DF_INCOMPAT,			"pool_durable_format_incompatible")		\
-	X(RAS_POOL_DEFER_DESTROY,		"pool_destroy_deferred")			\
-	X(RAS_CONT_DF_INCOMPAT,			"container_durable_format_incompatible")	\
-	X(RAS_RDB_DF_INCOMPAT,			"rdb_durable_format_incompatible")		\
-	X(RAS_SWIM_RANK_ALIVE,			"swim_rank_alive")				\
-	X(RAS_SWIM_RANK_DEAD,			"swim_rank_dead")				\
-	X(RAS_SYSTEM_START_FAILED,		"system_start_failed")				\
-	X(RAS_SYSTEM_STOP_FAILED,		"system_stop_failed")				\
-	X(RAS_DEVICE_SET_FAULTY,		"device_set_faulty")				\
-	X(RAS_DEVICE_MEDIA_ERROR,		"device_media_error")				\
-	X(RAS_DEVICE_UNPLUGGED,			"device_unplugged")				\
-	X(RAS_DEVICE_PLUGGED,			"device_plugged")				\
-	X(RAS_DEVICE_REPLACE,			"device_replace")
+#define RAS_EVENT_LIST                                                                             \
+	X(RAS_UNKNOWN_EVENT, "unknown_ras_event")                                                  \
+	X(RAS_ENGINE_FORMAT_REQUIRED, "engine_format_required")                                    \
+	X(RAS_ENGINE_DIED, "engine_died")                                                          \
+	X(RAS_ENGINE_ASSERTED, "engine_asserted")                                                  \
+	X(RAS_ENGINE_CLOCK_DRIFT, "engine_clock_drift")                                            \
+	X(RAS_POOL_CORRUPTION_DETECTED, "corruption_detected")                                     \
+	X(RAS_POOL_REBUILD_START, "pool_rebuild_started")                                          \
+	X(RAS_POOL_REBUILD_END, "pool_rebuild_finished")                                           \
+	X(RAS_POOL_REBUILD_FAILED, "pool_rebuild_failed")                                          \
+	X(RAS_POOL_REPS_UPDATE, "pool_replicas_updated")                                           \
+	X(RAS_POOL_DF_INCOMPAT, "pool_durable_format_incompatible")                                \
+	X(RAS_POOL_DEFER_DESTROY, "pool_destroy_deferred")                                         \
+	X(RAS_CONT_DF_INCOMPAT, "container_durable_format_incompatible")                           \
+	X(RAS_RDB_DF_INCOMPAT, "rdb_durable_format_incompatible")                                  \
+	X(RAS_SWIM_RANK_ALIVE, "swim_rank_alive")                                                  \
+	X(RAS_SWIM_RANK_DEAD, "swim_rank_dead")                                                    \
+	X(RAS_SYSTEM_START_FAILED, "system_start_failed")                                          \
+	X(RAS_SYSTEM_STOP_FAILED, "system_stop_failed")                                            \
+	X(RAS_DEVICE_SET_FAULTY, "device_set_faulty")                                              \
+	X(RAS_DEVICE_MEDIA_ERROR, "device_media_error")                                            \
+	X(RAS_DEVICE_UNPLUGGED, "device_unplugged")                                                \
+	X(RAS_DEVICE_PLUGGED, "device_plugged")                                                    \
+	X(RAS_DEVICE_REPLACE, "device_replace")                                                    \
+	X(RAS_SYSTEM_FABRIC_PROV_CHANGED, "system_fabric_provider_changed")                        \
+	X(RAS_ENGINE_JOIN_FAILED, "engine_join_failed")
 
 /** Define RAS event enum */
 typedef enum {


### PR DESCRIPTION
Previously updating the fabric provider required reformatting the entire system. With this change, the fabric provider can be changed by stopping all engines, shutting down all daos_servers, and changing the provider in the config files. The MS leader is considered the canonical source of the system's expected fabric provider. It will reject ranks that attempt to join with unexpected fabric providers.

Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
