### PR TITLE
DAOS-15207 control: Use tab char separator when generating system cmd results

### DIFF
--- a/src/control/cmd/dmg/pretty/printers.go
+++ b/src/control/cmd/dmg/pretty/printers.go
@@ -20,10 +20,6 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/txtfmt"
 )
 
-const (
-	rowFieldSep = "/"
-)
-
 var (
 	defaultPrintConfig = &PrintConfig{
 		Verbose:       false,

--- a/src/control/cmd/dmg/pretty/system.go
+++ b/src/control/cmd/dmg/pretty/system.go
@@ -21,6 +21,8 @@ import (
 	"github.com/daos-stack/daos/src/control/system"
 )
 
+const rowFieldSep = "\t"
+
 // tabulateRankGroups produces a representation of rank groupings in a tabular form.
 func tabulateRankGroups(out io.Writer, groups system.RankGroups, titles ...string) error {
 	if len(titles) < 2 {
@@ -37,7 +39,8 @@ func tabulateRankGroups(out io.Writer, groups system.RankGroups, titles ...strin
 
 		summary := strings.Split(result, rowFieldSep)
 		if len(summary) != len(columnTitles) {
-			return errors.New("unexpected summary format")
+			return errors.Errorf("unexpected summary format, fields %v values %v",
+				columnTitles, summary)
 		}
 		for i, title := range columnTitles {
 			row[title] = summary[i]

--- a/src/control/cmd/dmg/pretty/system_test.go
+++ b/src/control/cmd/dmg/pretty/system_test.go
@@ -8,6 +8,7 @@ package pretty
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	. "github.com/daos-stack/daos/src/control/lib/ranklist"
 	. "github.com/daos-stack/daos/src/control/system"
 )
@@ -27,13 +29,13 @@ func mockRankGroups(t *testing.T) RankGroups {
 	if err != nil {
 		t.Fatal(err)
 	}
-	groups["foo/OK"] = rs1
+	groups[fmt.Sprintf("foo%sOK", rowFieldSep)] = rs1
 
 	rs2, err := CreateRankSet("10,20-299")
 	if err != nil {
 		t.Fatal(err)
 	}
-	groups["bar/BAD"] = rs2
+	groups[fmt.Sprintf("bar%sBAD", rowFieldSep)] = rs2
 
 	return groups
 }
@@ -45,7 +47,7 @@ func TestPretty_tabulateRankGroups(t *testing.T) {
 		groups      RankGroups
 		cTitles     []string
 		expPrintStr string
-		expErrMsg   string
+		expErr      error
 	}{
 		"formatted results": {
 			groups:  mockRankGroups(t),
@@ -59,21 +61,46 @@ Ranks       Action Result
 `,
 		},
 		"column number mismatch": {
-			groups:    mockRankGroups(t),
-			cTitles:   []string{"Ranks", "SCM", "NVME", "???"},
-			expErrMsg: "unexpected summary format",
+			groups:  mockRankGroups(t),
+			cTitles: []string{"Ranks", "SCM", "NVME", "???"},
+			expErr:  errors.New("unexpected summary format, fields [SCM NVME ???] values [bar BAD]"),
 		},
 		"too few columns": {
-			groups:    mockRankGroups(t),
-			cTitles:   []string{"Ranks"},
-			expErrMsg: "insufficient number of column titles",
+			groups:  mockRankGroups(t),
+			cTitles: []string{"Ranks"},
+			expErr:  errors.New("insufficient number"),
+		},
+		"empty rank groups": {
+			groups:  make(RankGroups),
+			cTitles: mockColumnTitles,
+			expPrintStr: `
+Ranks Action Result 
+----- ------ ------ 
+
+`,
+		},
+		"double tab char in result message": {
+			groups: func() RankGroups {
+				g := mockRankGroups(t)
+				rs, err := CreateRankSet("300-399")
+				if err != nil {
+					t.Fatal(err)
+				}
+				g["zoo\t\tallo"] = rs
+				return g
+			}(),
+			cTitles: mockColumnTitles,
+			expErr:  errors.New("unexpected summary format, fields [Action Result] values [zoo  allo]"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var bld strings.Builder
 
 			gotErr := tabulateRankGroups(&bld, tc.groups, tc.cTitles...)
-			test.ExpectError(t, gotErr, tc.expErrMsg, name)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
 
 			if diff := cmp.Diff(strings.TrimLeft(tc.expPrintStr, "\n"), bld.String()); diff != "" {
 				t.Fatalf("unexpected format string (-want, +got):\n%s\n", diff)
@@ -346,7 +373,7 @@ func TestPretty_PrintSystemStartResp(t *testing.T) {
 	failedResults := MemberResults{
 		NewMemberResult(1, nil, MemberStateReady, "start"),
 		NewMemberResult(2, errors.New("fail"), MemberStateReady, "start"),
-		NewMemberResult(0, errors.New("failed"), MemberStateStopped, "start"),
+		NewMemberResult(0, errors.New("failed\t\tnow"), MemberStateStopped, "start"),
 		NewMemberResult(3, nil, MemberStateStopped, "start"),
 	}
 
@@ -388,11 +415,11 @@ Rank  Operation Result
 				Results: failedResults,
 			},
 			expPrintStr: `
-Rank  Operation Result 
-----  --------- ------ 
-[1,3] start     OK     
-2     start     fail   
-0     start     failed 
+Rank  Operation Result      
+----  --------- ------      
+[1,3] start     OK          
+2     start     fail        
+0     start     failed  now 
 
 `,
 		},
@@ -430,6 +457,58 @@ Unknown 3 hosts: foo[7-9]
 	}
 }
 
+func TestPretty_printSystemResults(t *testing.T) {
+	for name, tc := range map[string]struct {
+		results     MemberResults
+		expPrintStr string
+		expErr      error
+	}{
+		"first-time success": {
+			results: MemberResults{
+				MockMemberResult(3, "stop", nil, MemberStateExcluded),
+				MockMemberResult(4, "stop", errors.New("failure 2"),
+					MemberStateExcluded),
+			},
+			expPrintStr: `
+Rank Operation Result    
+---- --------- ------    
+3    stop      OK        
+4    stop      failure 2 
+
+`,
+		},
+		"first-time fail": {
+			results: MemberResults{
+				MockMemberResult(3, "stop", nil, MemberStateExcluded),
+				MockMemberResult(4, "stop", errors.New("failure"),
+					MemberStateExcluded),
+			},
+			expPrintStr: `
+Rank Operation Result  
+---- --------- ------  
+3    stop      OK      
+4    stop      failure 
+
+`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var bld, bldErr strings.Builder
+
+			gotErr := printSystemResults(&bld, &bldErr, tc.results, new(hostlist.HostSet),
+				new(ranklist.RankSet))
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(strings.TrimLeft(tc.expPrintStr, "\n"), bld.String()); diff != "" {
+				t.Fatalf("unexpected results table (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
 func TestPretty_PrintSystemStopResp(t *testing.T) {
 	successResults := MemberResults{
 		NewMemberResult(1, nil, MemberStateReady, "stop"),
@@ -439,10 +518,11 @@ func TestPretty_PrintSystemStopResp(t *testing.T) {
 	}
 	failedResults := MemberResults{
 		NewMemberResult(1, nil, MemberStateReady, "stop"),
-		NewMemberResult(2, errors.New("fail"), MemberStateReady, "stop"),
+		NewMemberResult(2, errors.New("fail,\t\t/"), MemberStateReady, "stop"),
 		NewMemberResult(0, errors.New("failed"), MemberStateStopped, "stop"),
 		NewMemberResult(3, nil, MemberStateStopped, "stop"),
 	}
+	noResults := MemberResults{}
 
 	for name, tc := range map[string]struct {
 		resp        *control.SystemStopResp
@@ -477,16 +557,24 @@ Rank  Operation Result
 
 `,
 		},
+		"response with no results": {
+			resp: &control.SystemStopResp{
+				Results: noResults,
+			},
+			expPrintStr: `
+No results returned
+`,
+		},
 		"response with failures": {
 			resp: &control.SystemStopResp{
 				Results: failedResults,
 			},
 			expPrintStr: `
-Rank  Operation Result 
-----  --------- ------ 
-[1,3] stop      OK     
-2     stop      fail   
-0     stop      failed 
+Rank  Operation Result   
+----  --------- ------   
+[1,3] stop      OK       
+2     stop      fail,  / 
+0     stop      failed   
 
 `,
 		},

--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -502,7 +502,7 @@ func TestDmg_systemStartCmd_Errors(t *testing.T) {
 					},
 				},
 			},
-			expErr: errors.New("system start failed: duplicate result"),
+			expErr: errors.New("duplicate result for rank"),
 		},
 		"system start absent hosts": {
 			resp: &mgmtpb.SystemStartResp{
@@ -631,7 +631,7 @@ func TestDmg_systemStopCmd_Errors(t *testing.T) {
 					},
 				},
 			},
-			expErr: errors.New("system stop failed: duplicate result"),
+			expErr: errors.New("duplicate result for rank"),
 		},
 		"system stop absent hosts": {
 			resp: &mgmtpb.SystemStopResp{

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -517,7 +517,14 @@ func (svc *mgmtSvc) rpcFanout(ctx context.Context, req *fanoutRequest, resp *fan
 			finished.Add(ranklist.Rank(rr.Rank))
 		}
 
-		svc.log.Infof("%s: finished: %s; waiting: %s", funcName(req.Method), finished, waiting)
+		msg := fmt.Sprintf("%s: ", funcName(req.Method))
+		if finished.Count() != 0 {
+			msg = fmt.Sprintf(" finished: %q", finished)
+		}
+		if waiting.Count() != 0 {
+			msg = fmt.Sprintf(" waiting: %q", waiting)
+		}
+		svc.log.Infof(msg)
 	})
 
 	// Not strictly necessary but helps with debugging.

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -432,18 +432,18 @@ func (m *Membership) CheckRanks(ranks string) (hit, miss *RankSet, err error) {
 	m.RLock()
 	defer m.RUnlock()
 
-	var allRanks, toTest []Rank
-	allRanks, err = m.db.MemberRanks()
-	if err != nil {
-		return
-	}
-	toTest, err = ParseRanks(ranks)
+	allRanks, err := m.db.MemberRanks()
 	if err != nil {
 		return
 	}
 
 	if ranks == "" {
 		return RankSetFromRanks(allRanks), RankSetFromRanks(nil), nil
+	}
+
+	toTest, err := ParseRanks(ranks)
+	if err != nil {
+		return
 	}
 
 	missing := CheckRankMembership(allRanks, toTest)


### PR DESCRIPTION
Results from dmg system stop cmd are not being displayed when a rank result error message contains a character that clashes with what is used as a separator when generating result rank groups. Use a tab character as that separator and replace any tab chars in result text with spaces. This solution should prevent any information loss in result text whilst avoiding character clashes.

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
