### PR TITLE
DAOS-15135 object: handle non-continuous ranks array for coll operation

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -7087,7 +7087,6 @@ dc_obj_query_key(tse_task_t *api_task)
 
 	/* Some optimization for get dkey collectively since 2.6 which version is 10. */
 	if (api_args->flags & DAOS_GET_DKEY && grp_nr > 1 && dc_obj_proto_version >= 10) {
-re_scan:
 		rc = obj_coll_oper_args_init(&obj_auxi->cq_args.cqa_coa, obj, false);
 		if (rc != 0)
 			goto out_task;
@@ -7114,18 +7113,13 @@ re_scan:
 				    !is_ec_parity_shard(obj, obj_auxi->dkey_hash, leader))
 					goto non_leader;
 
-				if (coll) {
+				if (coll)
 					rc = obj_coll_prep_one(&obj_auxi->cq_args.cqa_coa, obj,
 							       map_ver, leader);
-					if (unlikely(rc == -DER_AGAIN)) {
-						obj_coll_oper_args_fini(&obj_auxi->cq_args.cqa_coa);
-						goto re_scan;
-					}
-				} else {
+				else
 					rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch,
 									leader, map_ver, obj, &dti,
 									co_hdl, co_uuid, NULL, 0);
-				}
 				if (rc != 0)
 					D_GOTO(out_task, rc);
 
@@ -7150,17 +7144,12 @@ non_leader:
 			if (obj_shard_is_invalid(obj, j, DAOS_OBJ_RPC_QUERY_KEY))
 				continue;
 
-			if (coll) {
+			if (coll)
 				rc = obj_coll_prep_one(&obj_auxi->cq_args.cqa_coa, obj, map_ver, j);
-				if (unlikely(rc == -DER_AGAIN)) {
-					obj_coll_oper_args_fini(&obj_auxi->cq_args.cqa_coa);
-					goto re_scan;
-				}
-			} else {
+			else
 				rc = queue_shard_query_key_task(api_task, obj_auxi, &epoch, j,
 								map_ver, obj, &dti, co_hdl, co_uuid,
 								NULL, 0);
-			}
 			if (rc != 0)
 				D_GOTO(out_task, rc);
 


### PR DESCRIPTION
When scan the object targets for collective operation, the ranks array for related pool may be not continuous. Under such case the scan logic needs to extend the ranks array dynamically to avoid accessing invalid DRAM or falling into dead loop.

Features: ec rebuild

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
