### PR TITLE
Mjean/aurora test branch

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1008,7 +1008,7 @@ cont_iv_hdl_fetch(uuid_t cont_hdl_uuid, uuid_t pool_uuid,
 	arg.eventual = eventual;
 	arg.invalidate_current = invalidate_current;
 	rc = dss_ult_create(cont_iv_capa_refresh_ult, &arg, DSS_XS_SYS,
-			    0, 0, NULL);
+			    0, DSS_DEEP_STACK_SZ, NULL);
 	if (rc)
 		D_GOTO(out_eventual, rc);
 

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -272,8 +272,6 @@ struct dead_pool {
 static int
 clear_vos_pool(uuid_t uuid)
 {
-	d_list_t	    *dead_list = arg;
-	struct dead_pool    *dp;
 	struct tgt_kill_arg kill_arg;
 	int		    rc;
 

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -272,6 +272,8 @@ struct dead_pool {
 static int
 clear_vos_pool(uuid_t uuid)
 {
+	d_list_t	    *dead_list = arg;
+	struct dead_pool    *dp;
 	struct tgt_kill_arg kill_arg;
 	int		    rc;
 


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
