### PR TITLE
DAOS-15154 pool: ds_pool_child_lookup() could return NULL

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1568,6 +1568,10 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			D_GOTO(err_dtx, rc = -DER_NOMEM);
 
 		ddra->pool = ds_pool_child_lookup(hdl->sch_cont->sc_pool->spc_uuid);
+		if (ddra->pool == NULL) {
+			D_FREE(ddra);
+			D_GOTO(err_dtx, rc = -DER_NO_HDL);
+		}
 		uuid_copy(ddra->co_uuid, cont_uuid);
 		rc = dss_ult_create(ds_dtx_resync, ddra, DSS_XS_SELF,
 				    0, 0, NULL);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -413,13 +413,19 @@ migrate_pool_tls_create_one(void *data)
 	struct migrate_pool_tls_create_arg *arg = data;
 	struct obj_tls			   *tls = obj_tls_get();
 	struct migrate_pool_tls		   *pool_tls;
+	struct ds_pool_child		   *child;
 	int rc;
+
+	child = ds_pool_child_lookup(arg->pool_uuid);
+	if (child == NULL)
+		return -DER_NO_HDL;
 
 	pool_tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (pool_tls != NULL) {
 		/* Some one else already created, because collective function
 		 * might yield xstream.
 		 */
+		ds_pool_child_put(child);
 		migrate_pool_tls_put(pool_tls);
 		return 0;
 	}
@@ -452,7 +458,7 @@ migrate_pool_tls_create_one(void *data)
 	pool_tls->mpt_executed_ult = 0;
 	pool_tls->mpt_root_hdl = DAOS_HDL_INVAL;
 	pool_tls->mpt_max_eph = arg->max_eph;
-	pool_tls->mpt_pool = ds_pool_child_lookup(arg->pool_uuid);
+	pool_tls->mpt_pool = child;
 	pool_tls->mpt_new_layout_ver = arg->new_layout_ver;
 	pool_tls->mpt_opc = arg->opc;
 	pool_tls->mpt_inflight_max_size = MIGRATE_MAX_SIZE;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2172,8 +2172,23 @@ pool_child_discard(void *data)
 	D_DEBUG(DB_MD, DF_UUID" discard %u/%u\n", DP_UUID(arg->pool_uuid),
 		myrank, addr.pta_target);
 
+	/**
+	 * When a faulty device is replaced with a new one using the
+	 * “dmg storage replace nvme” command, the reintegration of
+	 * affected pool targets is automatically triggered.
+	 * The following steps outline the device replacement process on the engine side:
+	 *
+	 * 1) Replace the old device with the new device in the SMD.
+	 * 2) Setup all SPDK related stuff for the new device.
+	 * 3) Start ds_pool_child
+	 *
+	 * It is important to note that manual reintegration may be initiated
+	 * before step 3, in which case, the function should return “DER_AGAIN."
+	 */
 	child = ds_pool_child_lookup(arg->pool_uuid);
-	D_ASSERT(child != NULL);
+	if (child == NULL)
+		return -DER_AGAIN;
+
 	param.ip_hdl = child->spc_hdl;
 
 	rc = d_backoff_seq_init(&backoff_seq, 0 /* nzeros */, 16 /* factor */, 8 /* next (ms) */,


### PR DESCRIPTION
When a faulty device is replaced with a new one using the “dmg storage replace nvme” command, 
the reintegration of affected pool targets is automatically triggered. The followings steps outline the
device replacement process on the engine side:

1) Replace the old device with the new device in the SMD. 
2) Setup all SPDK related stuff for the new device. 
3) Start ds_pool_child

It is important to note that manual reintegration may be initiated before step 3, which trigger assertion.
For above case, return DER_AGAIN error, this patch also tries to fix another two places which forgot to
check return of ds_pool_child_lookup().

Required-githooks: true