### PR TITLE
DAOS-14144 csum: Added common_test to run in CI

### DIFF
--- a/src/common/tests/checksum_tests.c
+++ b/src/common/tests/checksum_tests.c
@@ -1597,6 +1597,8 @@ test_container_prop_to_csum_type(void **state)
 			 daos_contprop2hashtype(DAOS_PROP_CO_CSUM_SHA256));
 	assert_int_equal(HASH_TYPE_SHA512,
 			 daos_contprop2hashtype(DAOS_PROP_CO_CSUM_SHA512));
+	assert_int_equal(HASH_TYPE_ADLER32,
+			 daos_contprop2hashtype(DAOS_PROP_CO_CSUM_ADLER32));
 }
 
 static void
@@ -1609,7 +1611,7 @@ test_is_valid_csum(void **state)
 	assert_true(daos_cont_csum_prop_is_valid(DAOS_PROP_CO_CSUM_CRC64));
 	assert_true(daos_cont_csum_prop_is_valid(DAOS_PROP_CO_CSUM_SHA1));
 	assert_true(daos_cont_csum_prop_is_valid(DAOS_PROP_CO_CSUM_SHA256));
-	assert_true(daos_cont_csum_prop_is_valid(DAOS_PROP_CO_CSUM_SHA512));
+	assert_true(daos_cont_csum_prop_is_valid(DAOS_PROP_CO_CSUM_ADLER32));
 
 	/* Not supported yet */
 	assert_false(daos_cont_csum_prop_is_valid(99));
@@ -1625,6 +1627,7 @@ test_is_csum_enabled(void **state)
 	assert_true(daos_cont_csum_prop_is_enabled(DAOS_PROP_CO_CSUM_SHA1));
 	assert_true(daos_cont_csum_prop_is_enabled(DAOS_PROP_CO_CSUM_SHA256));
 	assert_true(daos_cont_csum_prop_is_enabled(DAOS_PROP_CO_CSUM_SHA512));
+	assert_true(daos_cont_csum_prop_is_enabled(DAOS_PROP_CO_CSUM_ADLER32));
 
 	/* Not supported yet */
 	assert_false(daos_cont_csum_prop_is_enabled(DAOS_PROP_CO_CSUM_OFF));

--- a/utils/utest.yaml
+++ b/utils/utest.yaml
@@ -13,6 +13,7 @@
     - cmd: ["src/common/tests/acl_real_tests"]
     - cmd: ["src/common/tests/prop_tests"]
     - cmd: ["src/common/tests/fault_domain_tests"]
+    - cmd: ["src/common/tests/common_test"]
 - name: common_md_on_ssd
   base: "BUILD_DIR"
   required_src: ["src/common/tests/ad_mem_tests.c"]


### PR DESCRIPTION
Bullseye reported that the checksum algorithm functions weren't being covered. They are in the common_test unit tests, however, they are not being run by CI. Include them in the unit tests.
Also completed the testing for the adler32 algo.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>

Skip-func-test: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
