### PR TITLE
DAOS-15127 object: avoid repeated conversion for EC recx

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -2018,6 +2018,7 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 	oqma.oqma_opc = DAOS_OBJ_RPC_QUERY_KEY;
 	oqma.oqma_src_map_ver = obj_reply_map_version_get(rpc);
 	oqma.oqma_ret = rc;
+	oqma.oqma_raw_recx = 1;
 
 	D_SPIN_LOCK(&cb_args->obj->cob_spin);
 	rc = daos_obj_query_merge(&oqma);
@@ -2155,6 +2156,7 @@ obj_shard_coll_query_cb(tse_task_t *task, void *data)
 	oqma.oqma_opc = DAOS_OBJ_RPC_COLL_QUERY;
 	oqma.oqma_src_map_ver = obj_reply_map_version_get(rpc);
 	oqma.oqma_ret = rc;
+	oqma.oqma_raw_recx = ocqo->ocqo_flags & OCRF_RAW_RECX ? 1 : 0;
 
 	/*
 	 * The RPC reply may be aggregated results from multiple VOS targets, as to related max/min

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -960,10 +960,12 @@ struct obj_query_merge_args {
 	uint32_t		 oqma_opc;
 	uint32_t		 oqma_src_map_ver;
 	int			 oqma_ret;
-	uint32_t		 oqma_server_merge:1;
+	uint32_t		 oqma_raw_recx:1;
 };
 
 /* obj_utils.c */
+void obj_ec_recx_vos2daos(struct daos_oclass_attr *oca, daos_unit_oid_t oid, daos_key_t *dkey,
+			  daos_recx_t *recx, bool raw_recx, bool get_max);
 int daos_obj_query_merge(struct obj_query_merge_args *oqma);
 void obj_coll_disp_init(uint32_t tgt_nr, uint32_t max_tgt_size, uint32_t inline_size,
 			uint32_t start, uint32_t max_width, struct obj_coll_disp_cursor *ocdc);

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -720,6 +720,11 @@ struct obj_dtx_mbs {
 	struct dtx_memberships	*odm_mbs;
 };
 
+enum obj_coll_rep_flags {
+	/* The returned recx contains the original mapped VOS index. */
+	OCRF_RAW_RECX	= (1 << 0),
+};
+
 #define DAOS_ISEQ_OBJ_COLL_PUNCH	/* input fields */				\
 	((struct obj_dtx_mbs)		(ocpi_odm)			CRT_VAR)	\
 	((uuid_t)			(ocpi_po_uuid)			CRT_VAR)	\
@@ -773,7 +778,7 @@ CRT_RPC_DECLARE(obj_coll_punch, DAOS_ISEQ_OBJ_COLL_PUNCH, DAOS_OSEQ_OBJ_COLL_PUN
 	((uint32_t)			(ocqo_map_version)		CRT_VAR)	\
 	/* The id_shard corresponding to ocqo_recx */					\
 	((uint32_t)			(ocqo_shard)			CRT_VAR)	\
-	((uint32_t)			(ocqo_padding)			CRT_VAR)	\
+	((uint32_t)			(ocqo_flags)			CRT_VAR)	\
 	((uint64_t)			(ocqo_epoch)			CRT_VAR)	\
 	((daos_key_t)			(ocqo_dkey)			CRT_VAR)	\
 	((daos_key_t)			(ocqo_akey)			CRT_VAR)	\

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -128,6 +128,7 @@ struct obj_tgt_query_args {
 	uint32_t		 otqa_version;
 	uint32_t		 otqa_completed:1,
 				 otqa_need_copy:1,
+				 otqa_raw_recx:1,
 				 otqa_keys_allocated:1;
 };
 


### PR DESCRIPTION
The collective query logic may do multiple levels result reduce to find out the max or min recx. For each raw EC recx returned from VOS, the collective query reduce logic needs to convert it only for once. When compare two EC recxs, both of them need to be converted as daos ext (for data shard).

Features: ec rebuild

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
