### PR TITLE
DAOS-15127 object: avoid repeated conversion for EC recx

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -2018,6 +2018,7 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 	oqma.oqma_opc = DAOS_OBJ_RPC_QUERY_KEY;
 	oqma.oqma_src_map_ver = obj_reply_map_version_get(rpc);
 	oqma.oqma_ret = rc;
+	oqma.oqma_raw_recx = 1;
 
 	D_SPIN_LOCK(&cb_args->obj->cob_spin);
 	rc = daos_obj_query_merge(&oqma);
@@ -2155,6 +2156,7 @@ obj_shard_coll_query_cb(tse_task_t *task, void *data)
 	oqma.oqma_opc = DAOS_OBJ_RPC_COLL_QUERY;
 	oqma.oqma_src_map_ver = obj_reply_map_version_get(rpc);
 	oqma.oqma_ret = rc;
+	oqma.oqma_raw_recx = ocqo->ocqo_flags & OCRF_RAW_RECX ? 1 : 0;
 
 	/*
 	 * The RPC reply may be aggregated results from multiple VOS targets, as to related max/min

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -960,10 +960,12 @@ struct obj_query_merge_args {
 	uint32_t		 oqma_opc;
 	uint32_t		 oqma_src_map_ver;
 	int			 oqma_ret;
-	uint32_t		 oqma_server_merge:1;
+	uint32_t		 oqma_raw_recx:1;
 };
 
 /* obj_utils.c */
+void obj_ec_recx_vos2daos(struct daos_oclass_attr *oca, daos_unit_oid_t oid, daos_key_t *dkey,
+			  daos_recx_t *recx, bool get_max);
 int daos_obj_query_merge(struct obj_query_merge_args *oqma);
 void obj_coll_disp_init(uint32_t tgt_nr, uint32_t max_tgt_size, uint32_t inline_size,
 			uint32_t start, uint32_t max_width, struct obj_coll_disp_cursor *ocdc);

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -720,6 +720,11 @@ struct obj_dtx_mbs {
 	struct dtx_memberships	*odm_mbs;
 };
 
+enum obj_coll_rep_flags {
+	/* The returned recx contains the original mapped VOS index. */
+	OCRF_RAW_RECX	= (1 << 0),
+};
+
 #define DAOS_ISEQ_OBJ_COLL_PUNCH	/* input fields */				\
 	((struct obj_dtx_mbs)		(ocpi_odm)			CRT_VAR)	\
 	((uuid_t)			(ocpi_po_uuid)			CRT_VAR)	\
@@ -773,7 +778,7 @@ CRT_RPC_DECLARE(obj_coll_punch, DAOS_ISEQ_OBJ_COLL_PUNCH, DAOS_OSEQ_OBJ_COLL_PUN
 	((uint32_t)			(ocqo_map_version)		CRT_VAR)	\
 	/* The id_shard corresponding to ocqo_recx */					\
 	((uint32_t)			(ocqo_shard)			CRT_VAR)	\
-	((uint32_t)			(ocqo_padding)			CRT_VAR)	\
+	((uint32_t)			(ocqo_flags)			CRT_VAR)	\
 	((uint64_t)			(ocqo_epoch)			CRT_VAR)	\
 	((daos_key_t)			(ocqo_dkey)			CRT_VAR)	\
 	((daos_key_t)			(ocqo_akey)			CRT_VAR)	\

--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -128,6 +128,7 @@ struct obj_tgt_query_args {
 	uint32_t		 otqa_version;
 	uint32_t		 otqa_completed:1,
 				 otqa_need_copy:1,
+				 otqa_raw_recx:1,
 				 otqa_keys_allocated:1;
 };
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3976,7 +3976,6 @@ obj_local_query(struct obj_tgt_query_args *otqa, struct obj_io_context *ioc, dao
 	uint64_t			 stripe_size = 0;
 	daos_epoch_t			 max_epoch = 0;
 	daos_recx_t			 recx = { 0 };
-	int				 allow_failure = -DER_NONEXIST;
 	int				 allow_failure_cnt;
 	int				 succeeds;
 	int				 rc = 0;
@@ -4004,7 +4003,6 @@ obj_local_query(struct obj_tgt_query_args *otqa, struct obj_io_context *ioc, dao
 		oqma.oqma_flags = api_flags;
 		oqma.oqma_opc = opc;
 		oqma.oqma_src_map_ver = map_ver;
-		oqma.oqma_server_merge = 1;
 	}
 
 	for (i = 0, allow_failure_cnt = 0, succeeds = 0; i < count; i++ ) {
@@ -4047,7 +4045,7 @@ again:
 				goto again;
 		}
 
-		if (rc == allow_failure) {
+		if (rc == -DER_NONEXIST) {
 			if (otqa->otqa_need_copy && otqa->otqa_max_epoch < *p_epoch)
 				otqa->otqa_max_epoch = *p_epoch;
 			allow_failure_cnt++;
@@ -4078,12 +4076,19 @@ again:
 				otqa->otqa_max_epoch = *p_epoch;
 			otqa->otqa_shard = shards[i];
 			otqa->otqa_keys_allocated = 1;
+
+			if (otqa->otqa_raw_recx && daos_oclass_is_ec(&ioc->ioc_oca)) {
+				obj_ec_recx_vos2daos(&ioc->ioc_oca, t_oid, p_dkey, &otqa->otqa_recx,
+						     api_flags & DAOS_GET_MAX ? true : false);
+				otqa->otqa_raw_recx = 0;
+			}
 		} else {
 			oqma.oqma_oid.id_shard = shards[i];
 			oqma.oqma_src_epoch = *p_epoch;
 			oqma.oqma_src_dkey = p_dkey;
 			oqma.oqma_src_akey = p_akey;
 			oqma.oqma_src_recx = p_recx;
+			oqma.oqma_raw_recx = 1;
 			/*
 			 * Merge (L1) the results from different shards on the same VOS target
 			 * into current otqa that stands for the result for current VOS target.
@@ -4095,10 +4100,10 @@ again:
 	}
 
 	if (allow_failure_cnt > 0 && rc == 0 && succeeds == 0)
-		rc = allow_failure;
+		rc = -DER_NONEXIST;
 
 out:
-	if (rc == allow_failure && otqa->otqa_need_copy && !otqa->otqa_keys_allocated) {
+	if (rc == -DER_NONEXIST && otqa->otqa_need_copy && !otqa->otqa_keys_allocated) {
 		/* Allocate key buffer for subsequent merge. */
 		rc = daos_iov_alloc(&otqa->otqa_dkey_copy, sizeof(uint64_t), true);
 		if (rc != 0)
@@ -5812,6 +5817,9 @@ ds_obj_coll_query_handler(crt_rpc_t *rpc)
 	if (otqas == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
+	for (i = 0; i < dss_tgt_nr; i++)
+		otqas[i].otqa_raw_recx = 1;
+
 	otqa = &otqas[tgt_id];
 
 	dce.dce_xid = ocqi->ocqi_xid;
@@ -5886,6 +5894,8 @@ out:
 			ocqo->ocqo_dkey = otqa->otqa_dkey_copy;
 			ocqo->ocqo_akey = otqa->otqa_akey_copy;
 		}
+		if (otqa->otqa_raw_recx)
+			ocqo->ocqo_flags |= OCRF_RAW_RECX;
 	}
 
 	rc = crt_reply_send(rpc);


### PR DESCRIPTION
The collective query logic may do multiple levels result reduce to find out the max or min recx. For each raw EC recx returned from VOS, the collective query reduce logic needs to convert it only for once. When compare two EC recxs, both of them need to be converted as daos ext (for data shard).

Skip-func-vm-test-el8: true
Features: ec rebuild

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
