### PR TITLE
DAOS-15250 test: fix multi proc writing same cmocka xml

### DIFF
--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -315,21 +315,22 @@ run_specified_tests(const char *tests, int rank, int size,
 int
 main(int argc, char **argv)
 {
-	test_arg_t	*arg;
-	char		 tests[64];
-	char		*sub_tests_str = NULL;
-	char		*exclude_str = NULL;
-	int		 sub_tests[1024];
-	int		 sub_tests_idx = 0;
-	int		 ntests = 0;
-	int		 nr_failed = 0;
-	int		 nr_total_failed = 0;
-	int		 opt = 0, index = 0;
-	int		 rank;
-	int		 size;
-	int		 rc;
+	test_arg_t *arg;
+	char        tests[64];
+	char       *sub_tests_str         = NULL;
+	char       *exclude_str           = NULL;
+	char       *cmocka_message_output = NULL;
+	int         sub_tests[1024];
+	int         sub_tests_idx   = 0;
+	int         ntests          = 0;
+	int         nr_failed       = 0;
+	int         nr_total_failed = 0;
+	int         opt = 0, index = 0;
+	int         rank;
+	int         size;
+	int         rc;
 #if CMOCKA_FILTER_SUPPORTED == 1 /** for cmocka filter(requires cmocka 1.1.5) */
-	char		 filter[1024];
+	char filter[1024];
 #endif
 
 	d_register_alt_assert(mock_assert);
@@ -548,6 +549,18 @@ main(int argc, char **argv)
 		}
 		tests[new_idx]='\0';
 	}
+
+	/** if writing XML, force all ranks other than rank 0 to use stdout to avoid conflicts */
+	d_agetenv_str(&cmocka_message_output, "CMOCKA_MESSAGE_OUTPUT");
+	if (rank != 0 && cmocka_message_output && strcasecmp(cmocka_message_output, "xml") == 0) {
+		d_freeenv_str(&cmocka_message_output);
+		rc = d_setenv("CMOCKA_MESSAGE_OUTPUT", "stdout", 1);
+		if (rc) {
+			print_message("d_setenv() failed with %d\n", rc);
+			return -1;
+		}
+	}
+	d_freeenv_str(&cmocka_message_output);
 
 	nr_failed = run_specified_tests(tests, rank, size,
 					sub_tests_idx > 0 ? sub_tests : NULL,


### PR DESCRIPTION
Since cmocka is not MPI-aware, force all ranks other than rank 0 to write to stdout to avoid race conditions with the XML file.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
