### PR TITLE
DAOS-15324 test: fix CID 1971004 memset size argument

### DIFF
--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -637,7 +637,7 @@ co_op_retry(void **state)
 		return;
 
 	print_message("querying pool info... ");
-	memset(&pinfo, 'D', sizeof(info));
+	memset(&pinfo, 'D', sizeof(pinfo));
 	pinfo.pi_bits = DPI_ALL;
 	rc            = daos_pool_query(arg->pool.poh, NULL, &pinfo, NULL, NULL /* ev */);
 	assert_rc_equal(rc, 0);


### PR DESCRIPTION
This change fixes a bad memset() size argument in the daos_test container co_op_retry() function. Pass the sizeof(daos_pool_info_t) instead of daos_cont_info_t when clearing the pinfo structure.

Test-tag: test_daos_container
Skip-unit-tests: true
Skip-fault-injection-test: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
