### PR TITLE
SRE-471 test: Adding elapsed time to log steps

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -618,7 +618,7 @@ class TestWithServers(TestWithoutServers):
 
         # Add additional time to the test timeout for reporting running
         # processes while stopping the daos_agent and daos_server.
-        tear_down_timeout = 30
+        tear_down_timeout = 90
         self.timeout += tear_down_timeout
         self.log.info(
             "Increasing timeout by %s seconds for agent/server tear down: %s",

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -472,8 +472,9 @@ class Test(avocadoTest):
             header (bool, optional): whether to log a header line before the message. Defaults to
                 False.
         """
-        elapsed = time() - self._test_step_time
-        self._test_step_time = time()
+        now = time()
+        elapsed = now - self._test_step_time
+        self._test_step_time = now
 
         if header:
             self.log.info('-' * 80)

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -371,23 +371,20 @@ class Test(avocadoTest):
             self.get_state()
             if self.timeout is None:
                 # self.timeout is not set - this is a problem
-                self.log.error("*** TEARDOWN called with UNKNOWN timeout ***")
+                self.log_step("tearDown(): Called with UNKNOWN timeout")
                 self.log.error("self.timeout undefined - please investigate!")
             elif self.time_elapsed > self.timeout:
                 # Timeout has expired
-                self.log.info(
-                    "*** TEARDOWN called due to TIMEOUT: "
-                    "%s second timeout exceeded ***", str(self.timeout))
+                self.log_step(
+                    f"tearDown(): Called due to exceeding the {str(self.timeout)}s test timeout")
                 self.log.info("test execution has been terminated by avocado")
             else:
                 # Normal operation
-                remaining = str(self.timeout - self.time_elapsed)
-                self.log.info(
-                    "*** TEARDOWN called after test completion: elapsed time: "
-                    "%s seconds ***", str(self.time_elapsed))
-                self.log.info(
-                    "Amount of time left in test timeout: %s seconds",
-                    remaining)
+                remaining = self.timeout - self.time_elapsed
+                timeout_info = (
+                    f"test timeout: {str(self.timeout)}s, elapsed: {self.time_elapsed:.02f}s, "
+                    f"remaining: {remaining:.02f}s")
+                self.log_step(f"tearDown(): Called after test completion ({timeout_info})")
 
         # Disable reporting the timeout upon subsequent inherited calls
         self._timeout_reported = True
@@ -478,7 +475,8 @@ class Test(avocadoTest):
 
         if header:
             self.log.info('-' * 80)
-        self.log.info("==> Step %s: %s [elapsed: %.02fs]", self._test_step, message, elapsed)
+        self.log.info(
+            "==> Step %s: %s [elapsed since last step: %.02fs]", self._test_step, message, elapsed)
         self._test_step += 1
 
     def tearDown(self):

--- a/src/tests/ftest/util/collection_utils.py
+++ b/src/tests/ftest/util/collection_utils.py
@@ -647,7 +647,7 @@ def create_steps_log(logger, job_results_dir, test_result):
     test_logs_dir = os.path.realpath(test_logs_lnk)
     job_log = os.path.join(test_logs_dir, 'job.log')
     step_log = os.path.join(test_logs_dir, 'steps.log')
-    command = rf"grep -E 'INFO \| (==> Step|INIT|START|\*\*\* TEARDOWN|PASS|FAIL|ERROR)' {job_log}"
+    command = rf"grep -E 'INFO \| (==> Step|START|PASS|FAIL|ERROR)' {job_log}"
     try:
         result = run_local(logger, command)
         with open(step_log, 'w', encoding="utf-8") as file:

--- a/src/tests/ftest/util/collection_utils.py
+++ b/src/tests/ftest/util/collection_utils.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2022-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -638,7 +638,7 @@ def create_steps_log(logger, job_results_dir, test_result):
         test_result (TestResult): the test result used to update the status of the test
 
     Returns:
-        _type_: _description_
+        int: status code: 8192 = problem creating steps.log; 0 = success
     """
     logger.debug("=" * 80)
     logger.info("Creating steps.log file")
@@ -647,15 +647,15 @@ def create_steps_log(logger, job_results_dir, test_result):
     test_logs_dir = os.path.realpath(test_logs_lnk)
     job_log = os.path.join(test_logs_dir, 'job.log')
     step_log = os.path.join(test_logs_dir, 'steps.log')
-    command = [
-        'grep', '-E', r"'INFO \| (==> Step|INIT|START|\*\*\* TEARDOWN|PASS|FAIL|ERROR)'", job_log,
-        '>', step_log]
+    command = rf"grep -E 'INFO \| (==> Step|INIT|START|\*\*\* TEARDOWN|PASS|FAIL|ERROR)' {job_log}"
     try:
-        run_local(logger, ' '.join(command))
-    except RunException:
+        result = run_local(logger, command)
+        with open(step_log, 'w', encoding="utf-8") as file:
+            file.write(result.stdout)
+    except Exception:   # pylint: disable=broad-except
         message = f"Error creating {step_log}"
         test_result.fail_test(logger, "Process", message, sys.exc_info())
-        return 1024
+        return 8192
     return 0
 
 

--- a/src/tests/ftest/util/collection_utils.py
+++ b/src/tests/ftest/util/collection_utils.py
@@ -627,6 +627,38 @@ def process_core_files(logger, test_job_results, test, test_result):
     return 0
 
 
+def create_steps_log(logger, job_results_dir, test_result):
+    """Create a steps.log file from the job.log file.
+
+    The steps.log file contains high level test steps.
+
+    Args:
+        logger (Logger): logger for the messages produced by this method
+        job_results_dir (str): path to the avocado job results
+        test_result (TestResult): the test result used to update the status of the test
+
+    Returns:
+        _type_: _description_
+    """
+    logger.debug("=" * 80)
+    logger.info("Creating steps.log file")
+
+    test_logs_lnk = os.path.join(job_results_dir, "latest")
+    test_logs_dir = os.path.realpath(test_logs_lnk)
+    job_log = os.path.join(test_logs_dir, 'job.log')
+    step_log = os.path.join(test_logs_dir, 'steps.log')
+    command = [
+        'grep', '-E', r"'INFO \| (==> Step|INIT|START|\*\*\* TEARDOWN|PASS|FAIL|ERROR)'", job_log,
+        '>', step_log]
+    try:
+        run_local(logger, ' '.join(command))
+    except RunException:
+        message = f"Error creating {step_log}"
+        test_result.fail_test(logger, "Process", message, sys.exc_info())
+        return 1024
+    return 0
+
+
 def rename_avocado_test_dir(logger, test, job_results_dir, test_result, jenkins_xml, total_repeats):
     """Append the test name to its avocado job-results directory name.
 
@@ -1011,6 +1043,9 @@ def collect_test_result(logger, test, test_result, job_results_dir, stop_daos, a
                 logger, summary, data["hosts"].copy(), data["source"], data["pattern"],
                 data["destination"], data["depth"], threshold, data["timeout"],
                 test_result, test)
+
+    # Generate a steps.log file
+    return_code |= create_steps_log(logger, job_results_dir, test_result)
 
     # Optionally rename the test results directory for this test
     if rename:

--- a/src/tests/ftest/util/launch_utils.py
+++ b/src/tests/ftest/util/launch_utils.py
@@ -123,7 +123,8 @@ def summarize_run(logger, mode, status):
         512: "ERROR: Failed to stop daos_server.service after one or more tests!",
         1024: "ERROR: Failed to rename logs and results after one or more tests!",
         2048: "ERROR: Core stack trace files detected!",
-        4096: "ERROR: Unexpected processes or mounts found running!"
+        4096: "ERROR: Unexpected processes or mounts found running!",
+        8192: "ERROR: Failed to create steps.log!"
     }
     for bit_code, error_message in bit_error_map.items():
         if status & bit_code == bit_code:


### PR DESCRIPTION
To help better identify issues in timed out tests, log steps will now report an elapsed time between the steps that are logged.

Skip-func-hw-test: true
Skip-unit-tests: true
Skip-fault-injection-test: true
Allow-unstable-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
