### PR TITLE
DAOS-15296 dfs: properly handle errors on the statx async call

### DIFF
--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -825,19 +825,18 @@ ostatx_cb(tse_task_t *task, void *data)
 	if (rc != 0) {
 		D_CDEBUG(rc == -DER_NONEXIST, DLOG_DBG, DLOG_ERR,
 			 "Failed to stat file: " DF_RC "\n", DP_RC(rc));
-		/** convert the task result to errno since it takes prescedence over the cb error */
-		task->dt_result = daos_der2errno(rc);
+		task->dt_result = rc;
 		D_GOTO(out, rc = task->dt_result);
 	}
 
 	if (args->obj->oid.hi != op_args->entry.oid.hi ||
 	    args->obj->oid.lo != op_args->entry.oid.lo)
-		D_GOTO(out, rc = ENOENT);
+		D_GOTO(out, rc = -DER_ENOENT);
 
 	rc = update_stbuf_times(op_args->entry, op_args->array_stbuf.st_max_epoch, args->stbuf,
 				NULL);
 	if (rc)
-		D_GOTO(out, rc);
+		D_GOTO(out, rc = daos_errno2der(rc));
 
 	if (S_ISREG(args->obj->mode)) {
 		args->stbuf->st_size   = op_args->array_stbuf.st_size;
@@ -864,7 +863,7 @@ out:
 	D_FREE(op_args);
 	rc2 = daos_obj_close(args->parent_oh, NULL);
 	if (rc == 0)
-		rc = daos_der2errno(rc2);
+		rc = rc2;
 	return rc;
 }
 
@@ -884,7 +883,7 @@ statx_task(tse_task_t *task)
 	D_ALLOC_PTR(op_args);
 	if (op_args == NULL) {
 		daos_obj_close(args->parent_oh, NULL);
-		return ENOMEM;
+		return -DER_NOMEM;
 	}
 
 	/** Create task to fetch entry. */
@@ -987,7 +986,7 @@ statx_task(tse_task_t *task)
 	tse_task_schedule(fetch_task, true);
 	if (need_stat)
 		tse_task_schedule(stat_task, true);
-	return daos_der2errno(rc);
+	return rc;
 err3_out:
 	if (need_stat)
 		tse_task_complete(stat_task, rc);
@@ -996,7 +995,7 @@ err2_out:
 err1_out:
 	D_FREE(op_args);
 	daos_obj_close(args->parent_oh, NULL);
-	return daos_der2errno(rc);
+	return rc;
 }
 
 int
@@ -1011,6 +1010,8 @@ dfs_ostatx(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, daos_event_t *ev)
 		return EINVAL;
 	if (obj == NULL)
 		return EINVAL;
+	if (ev == NULL)
+		return dfs_ostat(dfs, obj, stbuf);
 
 	rc = daos_obj_open(dfs->coh, obj->parent_oid, DAOS_OO_RO, &oh, NULL);
 	if (rc)
@@ -1019,8 +1020,10 @@ dfs_ostatx(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, daos_event_t *ev)
 	rc = dc_task_create(statx_task, NULL, ev, &task);
 	if (rc) {
 		daos_obj_close(oh, NULL);
-		return rc;
+		return daos_der2errno(rc);
 	}
+	D_ASSERT(ev);
+	daos_event_errno_rc(ev);
 
 	args            = dc_task_get_args(task);
 	args->dfs       = dfs;
@@ -1028,12 +1031,9 @@ dfs_ostatx(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, daos_event_t *ev)
 	args->parent_oh = oh;
 	args->stbuf     = stbuf;
 
+	/** The parent oh is closed in the body function of the task even if an error occurred. */
 	rc = dc_task_schedule(task, true);
-	if (rc) {
-		daos_obj_close(oh, NULL);
-		return rc;
-	}
-	return 0;
+	return daos_der2errno(rc);
 }
 
 int


### PR DESCRIPTION
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
