### PR TITLE
DAOS-15306 gurt: Fix Coverity message for unchecked return value.

### DIFF
--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -107,7 +107,7 @@ static const char        *default_fac0name = "CLOG";
 static bool               merge_stderr;
 
 #define clog_lock()   pthread_mutex_lock(&clogmux)
-#define clog_unlock() pthread_mutex_unlock(&clogmux)
+#define clog_unlock() (void)pthread_mutex_unlock(&clogmux)
 
 static int d_log_write(char *buf, int len, bool flush);
 static const char *clog_pristr(int);

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -106,7 +106,7 @@ static const char        *default_fac0name = "CLOG";
 /* whether we should merge log and stderr */
 static bool               merge_stderr;
 
-#define clog_lock()   pthread_mutex_lock(&clogmux)
+#define clog_lock()   (void)pthread_mutex_lock(&clogmux)
 #define clog_unlock() (void)pthread_mutex_unlock(&clogmux)
 
 static int d_log_write(char *buf, int len, bool flush);


### PR DESCRIPTION
This commit fixes the unchecked return value message from the pthread_mutex_unlock and pthread_mutex_lock calls. We should never hit these scenarios in practice based on the existing code and documented errors. Adding void indicates to Coverity that we don't need to worry about the return value for this use case. 

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
