### PR TITLE
DAOS-14574 test: Query the pool to detect whether the pool is destroy…

### DIFF
--- a/src/tests/ftest/pool/create_all_hw.yaml
+++ b/src/tests/ftest/pool/create_all_hw.yaml
@@ -9,7 +9,7 @@ hosts:
 timeouts:
   test_one_pool_hw: 240
   test_two_pools_hw: 320
-  test_recycle_pools_hw: 1000
+  test_recycle_pools_hw: 1500
 
 test_one_pool_hw:
   deltas:

--- a/src/tests/ftest/util/pool_create_all_base.py
+++ b/src/tests/ftest/util/pool_create_all_base.py
@@ -7,6 +7,7 @@ import sys
 
 from apricot import TestWithServers
 from avocado.core.exceptions import TestFail
+from command_utils_base import CommandFailure
 from general_utils import bytes_to_human
 
 
@@ -213,6 +214,38 @@ class PoolCreateAllTestBase(TestWithServers):
             self.log.info(
                 "Pool %d created: scm_size=%d, nvme_size=%d", index, *pool_size)
             self.pool[index].destroy()
+
+            # Creating a pool immediately after destroy intermittently causes an error during the
+            # create. Wait for a few seconds and check that the pool was destroyed.
+            count = 0
+            while True:
+                self.log.info("Wait for a few seconds for the pool to be destroyed...")
+                time.sleep(5)
+                try:
+                    self.dmg.pool_query(pool=self.pool[index].identifier)
+                    self.log.info(
+                        "Pool query worked. Pool hasn't been destroyed. Try again. %d", count)
+                    count += 1
+                except CommandFailure as error:
+                    self.log.info("Pool query failed. Pool should have been destroyed. %s", error)
+                    break
+
+            self.log.info("Checking SCM available storage")
+            timeout = 3
+            while timeout > 0:
+                hosts = self.find_hosts_low_scm(90)
+                if not hosts:
+                    break
+                for it in hosts:
+                    self.log.info(
+                        "Find hosts without enough available SCM: "
+                        "timeout=%is, hosts=%s, path=%s, ratio=%f%%",
+                        timeout, *it)
+                time.sleep(1)
+                timeout -= 1
+            self.assertNotEqual(
+                0, timeout,
+                "Destroying pool did not restore available SCM storage space")
 
             if first_pool_size is None:
                 first_pool_size = pool_size

--- a/src/tests/ftest/util/pool_create_all_base.py
+++ b/src/tests/ftest/util/pool_create_all_base.py
@@ -1,9 +1,10 @@
 """
-(C) Copyright 2022-2023 Intel Corporation.
+(C) Copyright 2022-2024 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import sys
+import time
 
 from apricot import TestWithServers
 from avocado.core.exceptions import TestFail
@@ -229,23 +230,6 @@ class PoolCreateAllTestBase(TestWithServers):
                 except CommandFailure as error:
                     self.log.info("Pool query failed. Pool should have been destroyed. %s", error)
                     break
-
-            self.log.info("Checking SCM available storage")
-            timeout = 3
-            while timeout > 0:
-                hosts = self.find_hosts_low_scm(90)
-                if not hosts:
-                    break
-                for it in hosts:
-                    self.log.info(
-                        "Find hosts without enough available SCM: "
-                        "timeout=%is, hosts=%s, path=%s, ratio=%f%%",
-                        timeout, *it)
-                time.sleep(1)
-                timeout -= 1
-            self.assertNotEqual(
-                0, timeout,
-                "Destroying pool did not restore available SCM storage space")
 
             if first_pool_size is None:
                 first_pool_size = pool_size


### PR DESCRIPTION
…ed (#13903)

The test, pool/create_all_vm.py test_recycle_pools_vm(), destroyes a pool, then immediately creates another pool. Running this sequence on a VM node intermittently causes an error during create.

To resolve this issue, query the pool to detect whether the pool is destroyed after pool destroy is called. If the query causes a CommandFailure, the pool must have been destroyed. If the query works, the pool still exists and we should wait more.

Increase timeout for create_all_hw.yaml due to timeout.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_recycle_pools_vm test_recycle_pools_hw
Test-repeat: 5

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
