### PR TITLE
DAOS-15385 control: Remove JSON opt from daos_server stand-alone cmds

### DIFF
--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -20,7 +19,6 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/fault"
-	"github.com/daos-stack/daos/src/control/lib/atm"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
@@ -37,7 +35,6 @@ type mainOpts struct {
 	// TODO(DAOS-3129): This should be -d, but it conflicts with the start
 	// subcommand's -d flag when we default to running it.
 	Debug   bool `short:"b" long:"debug" description:"Enable debug output"`
-	JSON    bool `long:"json" short:"j" description:"Enable JSON output"`
 	JSONLog bool `short:"J" long:"json-logging" description:"Enable JSON-formatted log output"`
 	Syslog  bool `long:"syslog" description:"Enable logging to syslog"`
 
@@ -57,19 +54,9 @@ type mainOpts struct {
 	preExecTests []execTestFn
 }
 
-type versionCmd struct {
-	cmdutil.JSONOutputCmd
-}
+type versionCmd struct{}
 
 func (cmd *versionCmd) Execute(_ []string) error {
-	if cmd.JSONOutputEnabled() {
-		buf, err := build.MarshalJSON(build.ControlPlaneName)
-		if err != nil {
-			return err
-		}
-		return cmd.OutputJSON(json.RawMessage(buf), nil)
-	}
-
 	fmt.Println(build.String(build.ControlPlaneName))
 	return nil
 }
@@ -84,19 +71,12 @@ func exitWithError(log *logging.LeveledLogger, err error) {
 }
 
 func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error {
-	var wroteJSON atm.Bool
 	p := flags.NewParser(opts, flags.HelpFlag|flags.PassDoubleDash)
 	p.SubcommandsOptional = false
 	p.CommandHandler = func(cmd flags.Commander, cmdArgs []string) error {
 		if len(cmdArgs) > 0 {
 			// don't support positional arguments, extra cmdArgs are unexpected
 			return errors.Errorf("unexpected commandline arguments: %v", cmdArgs)
-		}
-
-		if jsonCmd, ok := cmd.(cmdutil.JSONOutputter); ok && opts.JSON {
-			jsonCmd.EnableJSONOutput(os.Stdout, &wroteJSON)
-			// disable output on stdout other than JSON
-			log.ClearLevel(logging.LogLevelInfo)
 		}
 
 		switch cmd.(type) {
@@ -164,9 +144,6 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 
 	// Parse commandline flags which override options loaded from config.
 	_, err := p.ParseArgs(args)
-	if opts.JSON && wroteJSON.IsFalse() {
-		cmdutil.OutputJSON(os.Stdout, nil, err)
-	}
 
 	return err
 }


### PR DESCRIPTION
daos_server stand-alone command don't support JSON output so remove
the flag from the command options.

Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
