### PR TITLE
DAOS-623 ci: Emit watermark before Change-Id

### DIFF
--- a/utils/githooks/commit-msg.d/10-watermark.py
+++ b/utils/githooks/commit-msg.d/10-watermark.py
@@ -50,6 +50,8 @@ def run_check():
                 sys.exit(0)
             elif line.startswith("Signed-off-by"):
                 continue
+            elif line.startswith("Change-Id"):
+                continue
             elif line.strip() == "":
                 continue
             elif line.startswith("# ------------------------ >8 ------------------------"):
@@ -68,6 +70,9 @@ def run_check():
         hook_emitted = False
         for line in msg:
             if not hook_emitted:
+                if line.startswith("Change-Id"):
+                    emit_watermark(commit_msg)
+                    hook_emitted = True
                 if line.startswith("Signed-off-by"):
                     emit_watermark(commit_msg)
                     hook_emitted = True


### PR DESCRIPTION
When there is a Change-Id in the commit message,
emit the watermark before that line to stay
compatible with Gerrit

Required-githooks: true
Doc-only: true

Change-Id: Id64ed582966580b90ca30df4ffbdeb51673a82a4

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
