### PR TITLE
DAOS-15429 test: Fix Go unit tests

### DIFF
--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -99,8 +99,11 @@ func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
 		"request timeout": {
 			timeout: 1 * time.Nanosecond,
 			req: &testRequest{
-				rpcFn: func(_ context.Context, _ *grpc.ClientConn) (proto.Message, error) {
+				rpcFn: func(ctx context.Context, _ *grpc.ClientConn) (proto.Message, error) {
 					time.Sleep(1 * time.Microsecond)
+					if ctx.Err() != nil {
+						return nil, ctx.Err()
+					}
 					return defaultMessage, nil
 				},
 			},
@@ -120,7 +123,10 @@ func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
 				}
 			}(),
 			req: &testRequest{
-				rpcFn: func(_ context.Context, _ *grpc.ClientConn) (proto.Message, error) {
+				rpcFn: func(ctx context.Context, _ *grpc.ClientConn) (proto.Message, error) {
+					if ctx.Err() != nil {
+						return nil, ctx.Err()
+					}
 					time.Sleep(10 * time.Second) // shouldn't be allowed to run this long
 					return defaultMessage, nil
 				},

--- a/src/control/logging/syslog_test.go
+++ b/src/control/logging/syslog_test.go
@@ -32,6 +32,10 @@ func TestSyslogOutput(t *testing.T) {
 		t.Log("current user does not have permissions to view system log")
 		return
 	}
+	if _, err := syslog.New(syslog.LOG_ALERT, "test"); err != nil {
+		t.Logf("unable to connect to syslog: %s -- not running this test", err)
+		return
+	}
 
 	rand.Seed(time.Now().UnixNano())
 	runes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/src/control/provider/system/system_linux_test.go
+++ b/src/control/provider/system/system_linux_test.go
@@ -97,7 +97,7 @@ func TestIsMounted(t *testing.T) {
 			expErr: errors.New("no such file or directory"),
 		},
 		"neither dir nor device": {
-			target: "/dev/log",
+			target: "/dev/stderr",
 			expErr: errors.New("not a valid mount target"),
 		},
 	} {
@@ -173,7 +173,7 @@ func TestSystemLinux_GetFsType(t *testing.T) {
 			expErr: syscall.ENOENT,
 		},
 		"temp dir": {
-			path: "/run",
+			path: "/dev",
 			expResult: &FsType{
 				Name:   "tmpfs",
 				NoSUID: true,


### PR DESCRIPTION
Fixes a few Go unit test failures:
  * Adjust gRPC client tests to behave correctly
    with newer gRPC versions
  * Don't run the syslogger test if syslogd is not
    running
  * Adjust some system tests to use paths that are
    more likely to exist on most systems

Required-githooks: true
Change-Id: Ifb3198435113f3dc251c6c0822b66c157aa1a369
Signed-off-by: Michael MacDonald <mjmac@google.com>
