### PR TITLE
DAOS-15434 gurt: enable fault injection for dev mode

### DIFF
--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -29,11 +29,11 @@ daos_fail_check(uint64_t fail_loc)
 {
 	struct d_fault_attr_t	*attr = NULL;
 	int			grp = 0;
+	uint32_t		id;
 
-	if ((daos_fail_loc == 0 ||
-	    (daos_fail_loc & DAOS_FAIL_MASK_LOC) !=
-	     (fail_loc & DAOS_FAIL_MASK_LOC)) &&
-	     !d_fault_inject_is_enabled())
+	if (daos_fail_loc == 0 ||
+	    (daos_fail_loc & DAOS_FAIL_MASK_LOC) != (fail_loc & DAOS_FAIL_MASK_LOC) ||
+	    !d_fault_inject_is_enabled())
 		return 0;
 
 	/**
@@ -41,12 +41,8 @@ daos_fail_check(uint64_t fail_loc)
 	 * current fail_loc finish the job.
 	 */
 	/* Search the attr in inject yml first */
-	if (d_fault_inject_is_enabled()) {
-		uint32_t id = DAOS_FAIL_ID_GET(fail_loc);
-
-		attr = d_fault_attr_lookup(id);
-	}
-
+	id = DAOS_FAIL_ID_GET(fail_loc);
+	attr = d_fault_attr_lookup(id);
 	if (attr == NULL) {
 		grp = DAOS_FAIL_GROUP_GET(fail_loc);
 		attr = d_fault_attr_lookup(grp);

--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -20,7 +20,6 @@
  * non-zero turns on fault injection
  */
 unsigned int           d_fault_inject;
-unsigned int           d_fault_config_file;
 struct d_fault_attr_t *d_fault_attr_mem;
 
 #if FAULT_INJECTION
@@ -534,6 +533,9 @@ d_fault_inject_init(void)
 	}
 	D_RWLOCK_UNLOCK(&d_fi_gdata.dfg_rwlock);
 
+	/* Enable fault inject by default for dev mode */
+	d_fault_inject = 1;
+
 	d_agetenv_str(&config_file, D_FAULT_CONFIG_ENV);
 	if (config_file == NULL || strlen(config_file) == 0) {
 		D_INFO("No config file, fault injection is OFF.\n");
@@ -601,8 +603,6 @@ d_fault_inject_init(void)
 	yaml_parser_delete(&parser);
 	if (rc == DER_SUCCESS) {
 		D_INFO("Config file: %s, fault injection is ON.\n", config_file);
-		d_fault_config_file = 1;
-		d_fault_inject      = 1;
 	} else {
 		D_ERROR("Failed to parse fault config file.\n");
 		D_GOTO(out, rc);
@@ -650,11 +650,6 @@ d_fault_inject_fini()
 int
 d_fault_inject_enable(void)
 {
-	if (!d_fault_config_file) {
-		D_ERROR("No fault config file.\n");
-		return -DER_NOSYS;
-	}
-
 	d_fault_inject = 1;
 	return 0;
 }

--- a/src/include/gurt/fault_inject.h
+++ b/src/include/gurt/fault_inject.h
@@ -30,7 +30,6 @@ extern "C" {
 
 /** global on/off switch for fault injection */
 extern unsigned int           d_fault_inject;
-extern unsigned int           d_fault_config_file;
 
 /* Location used for inecting memory allocation failures into D_ALLOC uses fault_id 0 */
 extern struct d_fault_attr_t *d_fault_attr_mem;


### PR DESCRIPTION
Separate fault injection config with fault injectionr. The
fault injection should be enabled for dev mode by default.

Remvoe unused global variable d_fault_config_file.

Signed-off-by: Di Wang <di.wang@intel.com>
Signed-off-by: Fan Yong <fan.yong@intel.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
