### PR TITLE
DAOS-15263 test: speedup datamover/negative_space.py (#13859)

### DIFF
--- a/src/tests/ftest/datamover/negative_space.py
+++ b/src/tests/ftest/datamover/negative_space.py
@@ -3,9 +3,8 @@
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
-from os.path import join
-
 from data_mover_test_base import DataMoverTestBase
+from duns_utils import format_path
 
 
 class DmvrNegativeSpaceTest(DataMoverTestBase):
@@ -30,37 +29,37 @@ class DmvrNegativeSpaceTest(DataMoverTestBase):
             DAOS-6387: posix filesystem does not have enough space.
 
         :avocado: tags=all,full_regression
-        :avocado: tags=hw,medium
+        :avocado: tags=vm
         :avocado: tags=datamover,mfu,mfu_dcp,dfs,ior
         :avocado: tags=DmvrNegativeSpaceTest,test_dm_negative_space_dcp
         """
         self.set_tool("DCP")
 
-        # Create the source file
-        src_posix_path = self.new_posix_test_path()
-        src_posix_file = join(src_posix_path, self.ior_cmd.test_file.value)
-        self.run_ior_with_params("POSIX", src_posix_file)
+        self.log_step("Create source file in DAOS pool")
+        src_pool = self.get_pool(connect=False, namespace="/run/pool_large/*")
+        src_cont = self.get_container(src_pool)
+        self.run_ior_with_params("DAOS", self.ior_cmd.test_file.value, src_pool, src_cont)
 
-        # Create destination test pool and container
-        dst_pool = self.create_pool()
+        self.log_step("Create small destination pool and container")
+        dst_pool = self.get_pool(connect=False, namespace="/run/pool_small/*")
         dst_cont = self.get_container(dst_pool)
-        dst_daos_path = "/"
 
-        # Try to copy, and expect a proper error message.
+        self.log_step("Verify out of space error on destination pool")
         self.run_datamover(
             self.test_id + " (dst pool out of space)",
-            "POSIX", src_posix_path, None, None,
-            "DAOS_UUID", dst_daos_path, dst_pool, dst_cont,
+            src_path=format_path(src_pool, src_cont),
+            dst_path=format_path(dst_pool, dst_cont),
             expected_rc=1,
             expected_output=[self.MFU_ERR_DCP_COPY, "errno=28"])
 
+        self.log_step("Verify out of space error on POSIX destination")
         # Mount small tmpfs filesystem on posix path.
-        dst_posix_path = self.new_posix_test_path(mount_dir=True)
+        dst_posix_path = self.new_posix_test_path(mount_dir_size=dst_pool.size.value)
 
         # Try to copy. For now, we expect this to just abort.
         self.run_datamover(
             self.test_id + " (dst posix out of space)",
-            "POSIX", src_posix_path, None, None,
-            "POSIX", dst_posix_path,
+            src_path=format_path(src_pool, src_cont),
+            dst_path=dst_posix_path,
             expected_rc=255,
             expected_err=["errno=28"])

--- a/src/tests/ftest/datamover/negative_space.yaml
+++ b/src/tests/ftest/datamover/negative_space.yaml
@@ -7,23 +7,28 @@ server_config:
   engines_per_host: 1
   engines:
     0:
+      targets: 1  # 1 target to keep the pool small
+      nr_xs_helpers: 0
       storage:
         0:
-          class: dcpm
-          scm_list: ["/dev/pmem0"]
+          class: ram
           scm_mount: /mnt/daos
-pool:
-  size: 5G
-  control_method: dmg
+  system_ram_reserved: 2
+pool_large:
+  size: 256M
+pool_small:
+  size: 64M
 container:
   type: POSIX
   control_method: daos
 ior:
   client_processes:
     np: 1
-  test_file: testFile
+  api: DFS
+  dfs_oclass: SX
+  test_file: /testFile
   flags: "-v -w -k"
-  block_size: '6G'  # Over 5G
+  block_size: 128M  #  Aggregate 128M - over 64M for pool_small
   transfer_size: '1M'
   signature: 5
 dcp:

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -1,5 +1,5 @@
 """
-(C) Copyright 2018-2023 Intel Corporation.
+(C) Copyright 2018-2024 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -18,6 +18,7 @@ from general_utils import create_string_buffer, get_log_file
 from ior_test_base import IorTestBase
 from mdtest_test_base import MdtestBase
 from pydaos.raw import DaosContainer, DaosObj, IORequest, str_to_c_uuid
+from run_utils import run_remote
 from test_utils_container import TestContainer
 
 
@@ -246,7 +247,7 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         """
         return " ".join(self._get_posix_test_path_list(path_list=path))
 
-    def new_posix_test_path(self, shared=False, create=True, parent=None, mount_dir=False):
+    def new_posix_test_path(self, shared=False, create=True, parent=None, mount_dir_size=None):
         """Generate a new, unique posix path.
 
         Args:
@@ -254,9 +255,10 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
                 Defaults to False.
             create (bool): Whether to create the directory.
                 Defaults to True.
-            mount_dir (bool): Whether or not posix directory will be manually mounted in tmpfs.
             parent (str, optional): The parent directory to create the
                 path in. Defaults to self.posix_root, which defaults to self.tmp.
+            mount_dir_size (str, optional): if specified, directory will be mounted in tmpfs
+                with the given size.
 
         Returns:
             str: the posix path.
@@ -276,14 +278,17 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
 
         if create:
             # Create the directory
-            cmd = "mkdir -p '{}'".format(path)
-            self.execute_cmd(cmd)
+            cmd = f"mkdir -p '{path}'"
+            if not run_remote(self.log, self.hostlist_clients, cmd).passed:
+                self.fail(f"Failed to mkdir {path}")
 
         # mount small tmpfs filesystem on posix path, using size required sudo
         # add mount_dir to mounted list for use when umounting
-        if mount_dir:
+        if mount_dir_size:
+            cmd = f"sudo mount -t tmpfs none '{path}' -o size={mount_dir_size}"
+            if not run_remote(self.log, self.hostlist_clients, cmd).passed:
+                self.fail(f"Failed to mount directory {path}")
             self.mounted_posix_test_paths.append(path)
-            self.execute_cmd("sudo mount -t tmpfs none '{}' -o size=128M".format(path))
 
         return path
 


### PR DESCRIPTION
Test-tag: DmvrNegativeSpaceTest
Skip-unit-tests: true
Skip-fault-injection-test: true

Create the source file in a DAOS pool instead of tmp for speed. Use a smaller file size.
Move to VM.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
