### PR TITLE
DAOS-15426 telemetry: Export missing stats metrics (#13979)

### DIFF
--- a/src/cart/utils/memcheck-cart.supp
+++ b/src/cart/utils/memcheck-cart.supp
@@ -491,6 +491,7 @@
    Tcp provider with ofi rxm 2
    Memcheck:Param
    sendmsg(msg.msg_iov[2])
+   ...
    fun:sendmsg
    fun:ofi_sockapi_sendv_socket
    fun:ofi_bsock_sendv

--- a/src/control/lib/telemetry/duration_test.go
+++ b/src/control/lib/telemetry/duration_test.go
@@ -81,9 +81,9 @@ func TestTelemetry_GetDuration(t *testing.T) {
 					fmt.Sprintf("difference %d too big (expected less than %d)", diff, maxDiff))
 
 				// Just make sure the stats were set to something
-				test.AssertTrue(t, result.FloatMin() > 0, "FloatMin() failed")
-				test.AssertTrue(t, result.FloatMax() > 0, "FloatMax() failed")
-				test.AssertTrue(t, result.FloatSum() > 0, "FloatSum() failed")
+				test.AssertTrue(t, result.Min() > 0, "Min() failed")
+				test.AssertTrue(t, result.Max() > 0, "Max() failed")
+				test.AssertTrue(t, result.Sum() > 0, "Sum() failed")
 				test.AssertTrue(t, result.Mean() > 0, "Mean() failed")
 
 				test.AssertEqual(t, 0.0, result.StdDev(), "StdDev() failed")

--- a/src/control/lib/telemetry/gauge_test.go
+++ b/src/control/lib/telemetry/gauge_test.go
@@ -130,11 +130,12 @@ func TestTelemetry_GetStatsGauge(t *testing.T) {
 				test.AssertEqual(t, result.Value(), uint64(tc.expResult.Cur), "bad value")
 				test.AssertEqual(t, result.FloatValue(), tc.expResult.Cur, "bad float value")
 
-				test.AssertEqual(t, tc.expResult.min, result.FloatMin(), "FloatMin() failed")
-				test.AssertEqual(t, tc.expResult.max, result.FloatMax(), "FloatMax() failed")
-				test.AssertEqual(t, tc.expResult.sum, result.FloatSum(), "FloatSum() failed")
+				test.AssertEqual(t, tc.expResult.min, result.Min(), "Min() failed")
+				test.AssertEqual(t, tc.expResult.max, result.Max(), "Max() failed")
+				test.AssertEqual(t, tc.expResult.sum, result.Sum(), "Sum() failed")
 				test.AssertEqual(t, tc.expResult.mean, result.Mean(), "Mean() failed")
 				test.AssertEqual(t, tc.expResult.stddev, result.StdDev(), "StdDev() failed")
+				test.AssertEqual(t, tc.expResult.sumsqs, result.SumSquares(), "SumSquares() failed")
 				test.AssertEqual(t, uint64(3), result.SampleSize(), "SampleSize() failed")
 			} else if result != nil {
 				t.Fatalf("expected nil result, got %+v", result)

--- a/src/control/lib/telemetry/promexp/collector_test.go
+++ b/src/control/lib/telemetry/promexp/collector_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2022 Intel Corporation.
+// (C) Copyright 2021-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -461,14 +461,20 @@ func TestPromExp_Collector_Collect(t *testing.T) {
 				"engine_stats_gauge2_min",
 				"engine_stats_gauge2_max",
 				"engine_stats_gauge2_mean",
+				"engine_stats_gauge2_sum",
 				"engine_stats_gauge2_stddev",
+				"engine_stats_gauge2_sumsquares",
+				"engine_stats_gauge2_samples",
 				"engine_timer_stamp",
 				"engine_timer_snapshot",
 				"engine_timer_duration",
 				"engine_timer_duration_min",
 				"engine_timer_duration_max",
 				"engine_timer_duration_mean",
+				"engine_timer_duration_sum",
 				"engine_timer_duration_stddev",
+				"engine_timer_duration_sumsquares",
+				"engine_timer_duration_samples",
 			},
 		},
 		"ignore some metrics": {

--- a/src/control/lib/telemetry/telemetry.go
+++ b/src/control/lib/telemetry/telemetry.go
@@ -68,11 +68,12 @@ type (
 
 	StatsMetric interface {
 		Metric
-		FloatMin() float64
-		FloatMax() float64
-		FloatSum() float64
+		Min() uint64
+		Max() uint64
+		Sum() uint64
 		Mean() float64
 		StdDev() float64
+		SumSquares() float64
 		SampleSize() uint64
 	}
 )
@@ -243,16 +244,16 @@ func (mb *metricBase) String() string {
 	return strings.TrimSpace(string(buf[:bytes.Index(buf, []byte{0})]))
 }
 
-func (sm *statsMetric) FloatMin() float64 {
-	return float64(sm.stats.dtm_min)
+func (sm *statsMetric) Min() uint64 {
+	return uint64(sm.stats.dtm_min)
 }
 
-func (sm *statsMetric) FloatMax() float64 {
-	return float64(sm.stats.dtm_max)
+func (sm *statsMetric) Max() uint64 {
+	return uint64(sm.stats.dtm_max)
 }
 
-func (sm *statsMetric) FloatSum() float64 {
-	return float64(sm.stats.dtm_sum)
+func (sm *statsMetric) Sum() uint64 {
+	return uint64(sm.stats.dtm_sum)
 }
 
 func (sm *statsMetric) Mean() float64 {
@@ -261,6 +262,10 @@ func (sm *statsMetric) Mean() float64 {
 
 func (sm *statsMetric) StdDev() float64 {
 	return float64(sm.stats.std_dev)
+}
+
+func (sm *statsMetric) SumSquares() float64 {
+	return float64(sm.stats.sum_of_squares)
 }
 
 func (sm *statsMetric) SampleSize() uint64 {

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -1393,9 +1393,8 @@ void
 d_tm_print_stats(FILE *stream, struct d_tm_stats_t *stats, int format)
 {
 	if (format == D_TM_CSV) {
-		fprintf(stream, ",%lu,%lu,%lf,%lu",
-			stats->dtm_min, stats->dtm_max, stats->mean,
-			stats->sample_size);
+		fprintf(stream, ",%lu,%lu,%lf,%lu,%lu", stats->dtm_min, stats->dtm_max, stats->mean,
+			stats->sample_size, stats->dtm_sum);
 		if (stats->sample_size > 2)
 			fprintf(stream, ",%lf", stats->std_dev);
 		else
@@ -1403,8 +1402,8 @@ d_tm_print_stats(FILE *stream, struct d_tm_stats_t *stats, int format)
 		return;
 	}
 
-	fprintf(stream, " [min: %lu, max: %lu, avg: %.0lf",
-		stats->dtm_min, stats->dtm_max, stats->mean);
+	fprintf(stream, " [min: %lu, max: %lu, avg: %.0lf, sum: %lu", stats->dtm_min,
+		stats->dtm_max, stats->mean, stats->dtm_sum);
 	if (stats->sample_size > 2)
 		fprintf(stream, ", stddev: %.0lf", stats->std_dev);
 	fprintf(stream, ", samples: %lu]", stats->sample_size);
@@ -1582,7 +1581,7 @@ d_tm_print_field_descriptors(int opt_fields, FILE *stream)
 	if (opt_fields & D_TM_INCLUDE_TYPE)
 		fprintf(stream, "type,");
 
-	fprintf(stream, "value,min,max,mean,sample_size,std_dev");
+	fprintf(stream, "value,min,max,mean,sample_size,sum,std_dev");
 
 	if (opt_fields & D_TM_INCLUDE_METADATA)
 		fprintf(stream, ",description,units");

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -9,6 +9,23 @@ from logging import getLogger
 from ClusterShell.NodeSet import NodeSet
 
 
+def _gen_stats_metrics(basename):
+    """Return a list of stats metrics for a given basename."""
+    metrics = [
+        "max",
+        "mean",
+        "min",
+        "samples",
+        "stddev",
+        "sum",
+        "sumsquares",
+    ]
+
+    base = [basename]
+    base.extend([basename + "_" + metric for metric in metrics])
+    return base
+
+
 class TelemetryUtils():
     # pylint: disable=too-many-nested-blocks
     """Defines a object used to verify telemetry information."""
@@ -69,11 +86,7 @@ class TelemetryUtils():
         "engine_pool_scrubber_csums_total",
         "engine_pool_scrubber_next_csum_scrub",
         "engine_pool_scrubber_next_tree_scrub",
-        "engine_pool_scrubber_prev_duration",
-        "engine_pool_scrubber_prev_duration_max",
-        "engine_pool_scrubber_prev_duration_mean",
-        "engine_pool_scrubber_prev_duration_min",
-        "engine_pool_scrubber_prev_duration_stddev",
+        *_gen_stats_metrics("engine_pool_scrubber_prev_duration"),
         "engine_pool_scrubber_scrubber_started",
         "engine_pool_scrubber_scrubs_completed",
         "engine_pool_started_at",
@@ -86,11 +99,7 @@ class TelemetryUtils():
         "engine_pool_vos_aggregation_dkey_deleted",
         "engine_pool_vos_aggregation_dkey_scanned",
         "engine_pool_vos_aggregation_dkey_skipped",
-        "engine_pool_vos_aggregation_epr_duration",
-        "engine_pool_vos_aggregation_epr_duration_max",
-        "engine_pool_vos_aggregation_epr_duration_mean",
-        "engine_pool_vos_aggregation_epr_duration_min",
-        "engine_pool_vos_aggregation_epr_duration_stddev",
+        *_gen_stats_metrics("engine_pool_vos_aggregation_epr_duration"),
         "engine_pool_vos_aggregation_merged_recs",
         "engine_pool_vos_aggregation_merged_size",
         "engine_pool_vos_aggregation_obj_deleted",
@@ -121,16 +130,8 @@ class TelemetryUtils():
         "engine_sched_relax_time",
         "engine_sched_wait_queue",
         "engine_sched_sleep_queue",
-        "engine_sched_cycle_duration",
-        "engine_sched_cycle_duration_max",
-        "engine_sched_cycle_duration_mean",
-        "engine_sched_cycle_duration_min",
-        "engine_sched_cycle_duration_stddev",
-        "engine_sched_cycle_size",
-        "engine_sched_cycle_size_max",
-        "engine_sched_cycle_size_mean",
-        "engine_sched_cycle_size_min",
-        "engine_sched_cycle_size_stddev"]
+        *_gen_stats_metrics("engine_sched_cycle_duration"),
+        *_gen_stats_metrics("engine_sched_cycle_size")]
     ENGINE_DMABUFF_METRICS = [
         "engine_dmabuff_total_chunks",
         "engine_dmabuff_used_chunks_io",
@@ -140,314 +141,114 @@ class TelemetryUtils():
         "engine_dmabuff_active_reqs",
         "engine_dmabuff_queued_reqs",
         "engine_dmabuff_grab_errs",
-        "engine_dmabuff_grab_retries",
-        "engine_dmabuff_grab_retries_max",
-        "engine_dmabuff_grab_retries_mean",
-        "engine_dmabuff_grab_retries_min",
-        "engine_dmabuff_grab_retries_stddev",
-        "engine_dmabuff_wal_sz",
-        "engine_dmabuff_wal_sz_max",
-        "engine_dmabuff_wal_sz_mean",
-        "engine_dmabuff_wal_sz_min",
-        "engine_dmabuff_wal_sz_stddev",
-        "engine_dmabuff_wal_qd",
-        "engine_dmabuff_wal_qd_max",
-        "engine_dmabuff_wal_qd_mean",
-        "engine_dmabuff_wal_qd_min",
-        "engine_dmabuff_wal_qd_stddev",
-        "engine_dmabuff_wal_waiters",
-        "engine_dmabuff_wal_waiters_max",
-        "engine_dmabuff_wal_waiters_mean",
-        "engine_dmabuff_wal_waiters_min",
-        "engine_dmabuff_wal_waiters_stddev"]
-    ENGINE_IO_DTX_COMMITTABLE_METRICS = [
-        "engine_io_dtx_committable",
-        "engine_io_dtx_committable_max",
-        "engine_io_dtx_committable_mean",
-        "engine_io_dtx_committable_min",
-        "engine_io_dtx_committable_stddev"]
-    ENGINE_IO_DTX_COMMITTED_METRICS = [
-        "engine_io_dtx_committed",
-        "engine_io_dtx_committed_max",
-        "engine_io_dtx_committed_mean",
-        "engine_io_dtx_committed_min",
-        "engine_io_dtx_committed_stddev"]
-    ENGINE_IO_LATENCY_FETCH_METRICS = [
-        "engine_io_latency_fetch",
-        "engine_io_latency_fetch_max",
-        "engine_io_latency_fetch_mean",
-        "engine_io_latency_fetch_min",
-        "engine_io_latency_fetch_stddev"]
-    ENGINE_IO_LATENCY_BULK_FETCH_METRICS = [
-        "engine_io_latency_bulk_fetch",
-        "engine_io_latency_bulk_fetch_max",
-        "engine_io_latency_bulk_fetch_mean",
-        "engine_io_latency_bulk_fetch_min",
-        "engine_io_latency_bulk_fetch_stddev"]
-    ENGINE_IO_LATENCY_VOS_FETCH_METRICS = [
-        "engine_io_latency_vos_fetch",
-        "engine_io_latency_vos_fetch_max",
-        "engine_io_latency_vos_fetch_mean",
-        "engine_io_latency_vos_fetch_min",
-        "engine_io_latency_vos_fetch_stddev"]
-    ENGINE_IO_LATENCY_BIO_FETCH_METRICS = [
-        "engine_io_latency_bio_fetch",
-        "engine_io_latency_bio_fetch_max",
-        "engine_io_latency_bio_fetch_mean",
-        "engine_io_latency_bio_fetch_min",
-        "engine_io_latency_bio_fetch_stddev"]
-    ENGINE_IO_LATENCY_UPDATE_METRICS = [
-        "engine_io_latency_update",
-        "engine_io_latency_update_max",
-        "engine_io_latency_update_mean",
-        "engine_io_latency_update_min",
-        "engine_io_latency_update_stddev"]
-    ENGINE_IO_LATENCY_TGT_UPDATE_METRICS = [
-        "engine_io_latency_tgt_update",
-        "engine_io_latency_tgt_update_max",
-        "engine_io_latency_tgt_update_mean",
-        "engine_io_latency_tgt_update_min",
-        "engine_io_latency_tgt_update_stddev"]
-    ENGINE_IO_LATENCY_BULK_UPDATE_METRICS = [
-        "engine_io_latency_bulk_update",
-        "engine_io_latency_bulk_update_max",
-        "engine_io_latency_bulk_update_mean",
-        "engine_io_latency_bulk_update_min",
-        "engine_io_latency_bulk_update_stddev"]
-    ENGINE_IO_LATENCY_VOS_UPDATE_METRICS = [
-        "engine_io_latency_vos_update",
-        "engine_io_latency_vos_update_max",
-        "engine_io_latency_vos_update_mean",
-        "engine_io_latency_vos_update_min",
-        "engine_io_latency_vos_update_stddev"]
-    ENGINE_IO_LATENCY_BIO_UPDATE_METRICS = [
-        "engine_io_latency_bio_update",
-        "engine_io_latency_bio_update_max",
-        "engine_io_latency_bio_update_mean",
-        "engine_io_latency_bio_update_min",
-        "engine_io_latency_bio_update_stddev"]
-    ENGINE_IO_OPS_AKEY_ENUM_METRICS = [
-        "engine_io_ops_akey_enum_active",
-        "engine_io_ops_akey_enum_active_max",
-        "engine_io_ops_akey_enum_active_mean",
-        "engine_io_ops_akey_enum_active_min",
-        "engine_io_ops_akey_enum_active_stddev"]
-    ENGINE_IO_OPS_AKEY_ENUM_LATENCY_METRICS = [
-        "engine_io_ops_akey_enum_latency",
-        "engine_io_ops_akey_enum_latency_max",
-        "engine_io_ops_akey_enum_latency_mean",
-        "engine_io_ops_akey_enum_latency_min",
-        "engine_io_ops_akey_enum_latency_stddev"]
-    ENGINE_IO_OPS_AKEY_PUNCH_ACTIVE_METRICS = [
-        "engine_io_ops_akey_punch_active",
-        "engine_io_ops_akey_punch_active_max",
-        "engine_io_ops_akey_punch_active_mean",
-        "engine_io_ops_akey_punch_active_min",
-        "engine_io_ops_akey_punch_active_stddev"]
-    ENGINE_IO_OPS_AKEY_PUNCH_LATENCY_METRICS = [
-        "engine_io_ops_akey_punch_latency",
-        "engine_io_ops_akey_punch_latency_max",
-        "engine_io_ops_akey_punch_latency_mean",
-        "engine_io_ops_akey_punch_latency_min",
-        "engine_io_ops_akey_punch_latency_stddev"]
-    ENGINE_IO_OPS_COMPOUND_ACTIVE_METRICS = [
-        "engine_io_ops_compound_active",
-        "engine_io_ops_compound_active_max",
-        "engine_io_ops_compound_active_mean",
-        "engine_io_ops_compound_active_min",
-        "engine_io_ops_compound_active_stddev"]
-    ENGINE_IO_OPS_COMPOUND_LATENCY_METRICS = [
-        "engine_io_ops_compound_latency",
-        "engine_io_ops_compound_latency_max",
-        "engine_io_ops_compound_latency_mean",
-        "engine_io_ops_compound_latency_min",
-        "engine_io_ops_compound_latency_stddev"]
-    ENGINE_IO_OPS_DKEY_ENUM_ACTIVE_METRICS = [
-        "engine_io_ops_dkey_enum_active",
-        "engine_io_ops_dkey_enum_active_max",
-        "engine_io_ops_dkey_enum_active_mean",
-        "engine_io_ops_dkey_enum_active_min",
-        "engine_io_ops_dkey_enum_active_stddev"]
-    ENGINE_IO_OPS_DKEY_ENUM_LATENCY_METRICS = [
-        "engine_io_ops_dkey_enum_latency",
-        "engine_io_ops_dkey_enum_latency_max",
-        "engine_io_ops_dkey_enum_latency_mean",
-        "engine_io_ops_dkey_enum_latency_min",
-        "engine_io_ops_dkey_enum_latency_stddev"]
-    ENGINE_IO_OPS_DKEY_PUNCH_ACTIVE_METRICS = [
-        "engine_io_ops_dkey_punch_active",
-        "engine_io_ops_dkey_punch_active_max",
-        "engine_io_ops_dkey_punch_active_mean",
-        "engine_io_ops_dkey_punch_active_min",
-        "engine_io_ops_dkey_punch_active_stddev"]
-    ENGINE_IO_OPS_DKEY_PUNCH_LATENCY_METRICS = [
-        "engine_io_ops_dkey_punch_latency",
-        "engine_io_ops_dkey_punch_latency_max",
-        "engine_io_ops_dkey_punch_latency_mean",
-        "engine_io_ops_dkey_punch_latency_min",
-        "engine_io_ops_dkey_punch_latency_stddev"]
-    ENGINE_IO_OPS_EC_AGG_ACTIVE_METRICS = [
-        "engine_io_ops_ec_agg_active",
-        "engine_io_ops_ec_agg_active_max",
-        "engine_io_ops_ec_agg_active_mean",
-        "engine_io_ops_ec_agg_active_min",
-        "engine_io_ops_ec_agg_active_stddev"]
-    ENGINE_IO_OPS_EC_AGG_LATENCY_METRICS = [
-        "engine_io_ops_ec_agg_latency",
-        "engine_io_ops_ec_agg_latency_max",
-        "engine_io_ops_ec_agg_latency_mean",
-        "engine_io_ops_ec_agg_latency_min",
-        "engine_io_ops_ec_agg_latency_stddev"]
-    ENGINE_IO_OPS_EC_REP_ACTIVE_METRICS = [
-        "engine_io_ops_ec_rep_active",
-        "engine_io_ops_ec_rep_active_max",
-        "engine_io_ops_ec_rep_active_mean",
-        "engine_io_ops_ec_rep_active_min",
-        "engine_io_ops_ec_rep_active_stddev"]
-    ENGINE_IO_OPS_EC_REP_LATENCY_METRICS = [
-        "engine_io_ops_ec_rep_latency",
-        "engine_io_ops_ec_rep_latency_max",
-        "engine_io_ops_ec_rep_latency_mean",
-        "engine_io_ops_ec_rep_latency_min",
-        "engine_io_ops_ec_rep_latency_stddev"]
-    ENGINE_IO_OPS_FETCH_ACTIVE_METRICS = [
-        "engine_io_ops_fetch_active",
-        "engine_io_ops_fetch_active_max",
-        "engine_io_ops_fetch_active_mean",
-        "engine_io_ops_fetch_active_min",
-        "engine_io_ops_fetch_active_stddev"]
-    ENGINE_IO_OPS_KEY_QUERY_ACTIVE_METRICS = [
-        "engine_io_ops_key_query_active",
-        "engine_io_ops_key_query_active_max",
-        "engine_io_ops_key_query_active_mean",
-        "engine_io_ops_key_query_active_min",
-        "engine_io_ops_key_query_active_stddev"]
-    ENGINE_IO_OPS_KEY_QUERY_LATENCY_METRICS = [
-        "engine_io_ops_key_query_latency",
-        "engine_io_ops_key_query_latency_max",
-        "engine_io_ops_key_query_latency_mean",
-        "engine_io_ops_key_query_latency_min",
-        "engine_io_ops_key_query_latency_stddev"]
-    ENGINE_IO_OPS_KEY2ANCHOR_ACTIVE_METRICS = [
-        "engine_io_ops_key2anchor_active",
-        "engine_io_ops_key2anchor_active_max",
-        "engine_io_ops_key2anchor_active_mean",
-        "engine_io_ops_key2anchor_active_min",
-        "engine_io_ops_key2anchor_active_stddev"]
-    ENGINE_IO_OPS_KEY2ANCHOR_LATENCY_METRICS = [
-        "engine_io_ops_key2anchor_latency",
-        "engine_io_ops_key2anchor_latency_max",
-        "engine_io_ops_key2anchor_latency_mean",
-        "engine_io_ops_key2anchor_latency_min",
-        "engine_io_ops_key2anchor_latency_stddev"]
-    ENGINE_IO_OPS_MIGRATE_ACTIVE_METRICS = [
-        "engine_io_ops_migrate_active",
-        "engine_io_ops_migrate_active_max",
-        "engine_io_ops_migrate_active_mean",
-        "engine_io_ops_migrate_active_min",
-        "engine_io_ops_migrate_active_stddev"]
-    ENGINE_IO_OPS_MIGRATE_LATENCY_METRICS = [
-        "engine_io_ops_migrate_latency",
-        "engine_io_ops_migrate_latency_max",
-        "engine_io_ops_migrate_latency_mean",
-        "engine_io_ops_migrate_latency_min",
-        "engine_io_ops_migrate_latency_stddev"]
-    ENGINE_IO_OPS_OBJ_ENUM_ACTIVE_METRICS = [
-        "engine_io_ops_obj_enum_active",
-        "engine_io_ops_obj_enum_active_max",
-        "engine_io_ops_obj_enum_active_mean",
-        "engine_io_ops_obj_enum_active_min",
-        "engine_io_ops_obj_enum_active_stddev"]
-    ENGINE_IO_OPS_OBJ_ENUM_LATENCY_METRICS = [
-        "engine_io_ops_obj_enum_latency",
-        "engine_io_ops_obj_enum_latency_max",
-        "engine_io_ops_obj_enum_latency_mean",
-        "engine_io_ops_obj_enum_latency_min",
-        "engine_io_ops_obj_enum_latency_stddev"]
-    ENGINE_IO_OPS_OBJ_PUNCH_ACTIVE_METRICS = [
-        "engine_io_ops_obj_punch_active",
-        "engine_io_ops_obj_punch_active_max",
-        "engine_io_ops_obj_punch_active_mean",
-        "engine_io_ops_obj_punch_active_min",
-        "engine_io_ops_obj_punch_active_stddev"]
-    ENGINE_IO_OPS_OBJ_PUNCH_LATENCY_METRICS = [
-        "engine_io_ops_obj_punch_latency",
-        "engine_io_ops_obj_punch_latency_max",
-        "engine_io_ops_obj_punch_latency_mean",
-        "engine_io_ops_obj_punch_latency_min",
-        "engine_io_ops_obj_punch_latency_stddev"]
-    ENGINE_IO_OPS_OBJ_SYNC_ACTIVE_METRICS = [
-        "engine_io_ops_obj_sync_active",
-        "engine_io_ops_obj_sync_active_max",
-        "engine_io_ops_obj_sync_active_mean",
-        "engine_io_ops_obj_sync_active_min",
-        "engine_io_ops_obj_sync_active_stddev"]
-    ENGINE_IO_OPS_OBJ_SYNC_LATENCY_METRICS = [
-        "engine_io_ops_obj_sync_latency",
-        "engine_io_ops_obj_sync_latency_max",
-        "engine_io_ops_obj_sync_latency_mean",
-        "engine_io_ops_obj_sync_latency_min",
-        "engine_io_ops_obj_sync_latency_stddev"]
-    ENGINE_IO_OPS_RECX_ENUM_ACTIVE_METRICS = [
-        "engine_io_ops_recx_enum_active",
-        "engine_io_ops_recx_enum_active_max",
-        "engine_io_ops_recx_enum_active_mean",
-        "engine_io_ops_recx_enum_active_min",
-        "engine_io_ops_recx_enum_active_stddev"]
-    ENGINE_IO_OPS_RECX_ENUM_LATENCY_METRICS = [
-        "engine_io_ops_recx_enum_latency",
-        "engine_io_ops_recx_enum_latency_max",
-        "engine_io_ops_recx_enum_latency_mean",
-        "engine_io_ops_recx_enum_latency_min",
-        "engine_io_ops_recx_enum_latency_stddev"]
-    ENGINE_IO_OPS_TGT_AKEY_PUNCH_ACTIVE_METRICS = [
-        "engine_io_ops_tgt_akey_punch_active",
-        "engine_io_ops_tgt_akey_punch_active_max",
-        "engine_io_ops_tgt_akey_punch_active_mean",
-        "engine_io_ops_tgt_akey_punch_active_min",
-        "engine_io_ops_tgt_akey_punch_active_stddev"]
-    ENGINE_IO_OPS_TGT_AKEY_PUNCH_LATENCY_METRICS = [
-        "engine_io_ops_tgt_akey_punch_latency",
-        "engine_io_ops_tgt_akey_punch_latency_max",
-        "engine_io_ops_tgt_akey_punch_latency_mean",
-        "engine_io_ops_tgt_akey_punch_latency_min",
-        "engine_io_ops_tgt_akey_punch_latency_stddev"]
-    ENGINE_IO_OPS_TGT_DKEY_PUNCH_ACTIVE_METRICS = [
-        "engine_io_ops_tgt_dkey_punch_active",
-        "engine_io_ops_tgt_dkey_punch_active_max",
-        "engine_io_ops_tgt_dkey_punch_active_mean",
-        "engine_io_ops_tgt_dkey_punch_active_min",
-        "engine_io_ops_tgt_dkey_punch_active_stddev"]
-    ENGINE_IO_OPS_TGT_DKEY_PUNCH_LATENCY_METRICS = [
-        "engine_io_ops_tgt_dkey_punch_latency",
-        "engine_io_ops_tgt_dkey_punch_latency_max",
-        "engine_io_ops_tgt_dkey_punch_latency_mean",
-        "engine_io_ops_tgt_dkey_punch_latency_min",
-        "engine_io_ops_tgt_dkey_punch_latency_stddev"]
-    ENGINE_IO_OPS_TGT_PUNCH_ACTIVE_METRICS = [
-        "engine_io_ops_tgt_punch_active",
-        "engine_io_ops_tgt_punch_active_max",
-        "engine_io_ops_tgt_punch_active_mean",
-        "engine_io_ops_tgt_punch_active_min",
-        "engine_io_ops_tgt_punch_active_stddev"]
-    ENGINE_IO_OPS_TGT_PUNCH_LATENCY_METRICS = [
-        "engine_io_ops_tgt_punch_latency",
-        "engine_io_ops_tgt_punch_latency_max",
-        "engine_io_ops_tgt_punch_latency_mean",
-        "engine_io_ops_tgt_punch_latency_min",
-        "engine_io_ops_tgt_punch_latency_stddev"]
-    ENGINE_IO_OPS_TGT_UPDATE_ACTIVE_METRICS = [
-        "engine_io_ops_tgt_update_active",
-        "engine_io_ops_tgt_update_active_max",
-        "engine_io_ops_tgt_update_active_mean",
-        "engine_io_ops_tgt_update_active_min",
-        "engine_io_ops_tgt_update_active_stddev"]
-    ENGINE_IO_OPS_UPDATE_ACTIVE_METRICS = [
-        "engine_io_ops_update_active",
-        "engine_io_ops_update_active_max",
-        "engine_io_ops_update_active_mean",
-        "engine_io_ops_update_active_min",
-        "engine_io_ops_update_active_stddev"]
+        *_gen_stats_metrics("engine_dmabuff_grab_retries"),
+        *_gen_stats_metrics("engine_dmabuff_wal_sz"),
+        *_gen_stats_metrics("engine_dmabuff_wal_qd"),
+        *_gen_stats_metrics("engine_dmabuff_wal_waiters")]
+    ENGINE_IO_DTX_COMMITTABLE_METRICS = \
+        _gen_stats_metrics("engine_io_dtx_committable")
+    ENGINE_IO_DTX_COMMITTED_METRICS = \
+        _gen_stats_metrics("engine_io_dtx_committed")
+    ENGINE_IO_LATENCY_FETCH_METRICS = \
+        _gen_stats_metrics("engine_io_latency_fetch")
+    ENGINE_IO_LATENCY_BULK_FETCH_METRICS = \
+        _gen_stats_metrics("engine_io_latency_bulk_fetch")
+    ENGINE_IO_LATENCY_VOS_FETCH_METRICS = \
+        _gen_stats_metrics("engine_io_latency_vos_fetch")
+    ENGINE_IO_LATENCY_BIO_FETCH_METRICS = \
+        _gen_stats_metrics("engine_io_latency_bio_fetch")
+    ENGINE_IO_LATENCY_UPDATE_METRICS = \
+        _gen_stats_metrics("engine_io_latency_update")
+    ENGINE_IO_LATENCY_TGT_UPDATE_METRICS = \
+        _gen_stats_metrics("engine_io_latency_tgt_update")
+    ENGINE_IO_LATENCY_BULK_UPDATE_METRICS = \
+        _gen_stats_metrics("engine_io_latency_bulk_update")
+    ENGINE_IO_LATENCY_VOS_UPDATE_METRICS = \
+        _gen_stats_metrics("engine_io_latency_vos_update")
+    ENGINE_IO_LATENCY_BIO_UPDATE_METRICS = \
+        _gen_stats_metrics("engine_io_latency_bio_update")
+    ENGINE_IO_OPS_AKEY_ENUM_METRICS = \
+        _gen_stats_metrics("engine_io_ops_akey_enum_active")
+    ENGINE_IO_OPS_AKEY_ENUM_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_akey_enum_latency")
+    ENGINE_IO_OPS_AKEY_PUNCH_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_akey_punch_active")
+    ENGINE_IO_OPS_AKEY_PUNCH_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_akey_punch_latency")
+    ENGINE_IO_OPS_COMPOUND_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_compound_active")
+    ENGINE_IO_OPS_COMPOUND_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_compound_latency")
+    ENGINE_IO_OPS_DKEY_ENUM_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_dkey_enum_active")
+    ENGINE_IO_OPS_DKEY_ENUM_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_dkey_enum_latency")
+    ENGINE_IO_OPS_DKEY_PUNCH_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_dkey_punch_active")
+    ENGINE_IO_OPS_DKEY_PUNCH_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_dkey_punch_latency")
+    ENGINE_IO_OPS_EC_AGG_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_ec_agg_active")
+    ENGINE_IO_OPS_EC_AGG_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_ec_agg_latency")
+    ENGINE_IO_OPS_EC_REP_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_ec_rep_active")
+    ENGINE_IO_OPS_EC_REP_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_ec_rep_latency")
+    ENGINE_IO_OPS_FETCH_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_fetch_active")
+    ENGINE_IO_OPS_KEY_QUERY_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_key_query_active")
+    ENGINE_IO_OPS_KEY_QUERY_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_key_query_latency")
+    ENGINE_IO_OPS_KEY2ANCHOR_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_key2anchor_active")
+    ENGINE_IO_OPS_KEY2ANCHOR_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_key2anchor_latency")
+    ENGINE_IO_OPS_MIGRATE_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_migrate_active")
+    ENGINE_IO_OPS_MIGRATE_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_migrate_latency")
+    ENGINE_IO_OPS_OBJ_COLL_PUNCH_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_coll_punch_active")
+    ENGINE_IO_OPS_OBJ_COLL_PUNCH_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_coll_punch_latency")
+    ENGINE_IO_OPS_OBJ_COLL_QUERY_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_coll_query_active")
+    ENGINE_IO_OPS_OBJ_COLL_QUERY_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_coll_query_latency")
+    ENGINE_IO_OPS_OBJ_ENUM_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_enum_active")
+    ENGINE_IO_OPS_OBJ_ENUM_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_enum_latency")
+    ENGINE_IO_OPS_OBJ_PUNCH_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_punch_active")
+    ENGINE_IO_OPS_OBJ_PUNCH_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_punch_latency")
+    ENGINE_IO_OPS_OBJ_SYNC_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_sync_active")
+    ENGINE_IO_OPS_OBJ_SYNC_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_obj_sync_latency")
+    ENGINE_IO_OPS_RECX_ENUM_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_recx_enum_active")
+    ENGINE_IO_OPS_RECX_ENUM_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_recx_enum_latency")
+    ENGINE_IO_OPS_TGT_AKEY_PUNCH_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_tgt_akey_punch_active")
+    ENGINE_IO_OPS_TGT_AKEY_PUNCH_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_tgt_akey_punch_latency")
+    ENGINE_IO_OPS_TGT_DKEY_PUNCH_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_tgt_dkey_punch_active")
+    ENGINE_IO_OPS_TGT_DKEY_PUNCH_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_tgt_dkey_punch_latency")
+    ENGINE_IO_OPS_TGT_PUNCH_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_tgt_punch_active")
+    ENGINE_IO_OPS_TGT_PUNCH_LATENCY_METRICS = \
+        _gen_stats_metrics("engine_io_ops_tgt_punch_latency")
+    ENGINE_IO_OPS_TGT_UPDATE_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_tgt_update_active")
+    ENGINE_IO_OPS_UPDATE_ACTIVE_METRICS = \
+        _gen_stats_metrics("engine_io_ops_update_active")
     ENGINE_IO_METRICS = ENGINE_IO_DTX_COMMITTABLE_METRICS +\
         ENGINE_IO_DTX_COMMITTED_METRICS +\
         ENGINE_IO_LATENCY_FETCH_METRICS +\


### PR DESCRIPTION
The Prometheus exporter is missing a few stats metrics
that would make some things easier to graph:
  * sum
  * sample_size
  * sum_of_squares

Fixes the Min/Max/Sum methods to return uint64, as this is
the underlying data type. Callers should adjust as necessary.

Features: telemetry
Required-githooks: true
Change-Id: Ic12a5f2ff562bcebbc9dc4351b999ef7d6b6d6d6
Signed-off-by: Michael MacDonald <mjmac@google.com>
