### PR TITLE
DAOS-623 build: daos_metrics not built

### DIFF
--- a/src/utils/SConscript
+++ b/src/utils/SConscript
@@ -6,6 +6,10 @@ def scons():
 
     Import('env', 'prereqs')
 
+    if prereqs.server_requested():
+        # Build daos_metrics
+        SConscript('daos_metrics/SConscript')
+
     if not prereqs.client_requested():
         return
 
@@ -21,10 +25,6 @@ def scons():
 
         # Build crt_launch
         SConscript('crt_launch/SConscript')
-
-    if prereqs.server_requested():
-        # Build daos_metrics
-        SConscript('daos_metrics/SConscript')
 
     # Build cart_ctl
     SConscript('ctl/SConscript')


### PR DESCRIPTION
When using server target, daos_metrics wasn't built because it was buried under a check for client target. I really need to figure out a better way to specify targets but this will fix the immediate issue.

Required-githooks: true

Change-Id: Ifa3e49e42ad95fb96f246e723a5e4ec77f10e4d9

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
