### PR TITLE
DAOS-15417 build: Fix intermittent issue with libfuse build.

### DIFF
--- a/site_scons/components/__init__.py
+++ b/site_scons/components/__init__.py
@@ -300,14 +300,12 @@ def define_components(reqs):
 
     reqs.define('fuse', libs=['fuse3'], defines=['FUSE_USE_VERSION=35'],
                 retriever=GitRepoRetriever('https://github.com/libfuse/libfuse.git'),
-                commands=[['meson', 'setup', '../fuse'],
-                          ['meson', 'configure', '--prefix=$FUSE_PREFIX', '-Ddisable-mtab=True',
+                commands=[['meson', 'setup', '--prefix=$FUSE_PREFIX', '-Ddisable-mtab=True',
                            '-Dudevrulesdir=$FUSE_PREFIX/udev', '-Dutils=False',
-                           '--default-library', 'both'],
-                          ['ninja', '-v'],
+                           '--default-library', 'both', '../fuse'],
                           ['ninja', 'install']],
                 headers=['fuse3/fuse.h'],
-                required_progs=['libtoolize', 'ninja'],
+                required_progs=['libtoolize', 'ninja', 'meson'],
                 out_of_src_build=True)
 
     # Tell SPDK which CPU to optimize for, by default this is native which works well unless you


### PR DESCRIPTION
Meson "setup" sets up a package for buidlding, meson configure
sets a configuration option, but does not do the setup.
Previously our code would do setup, then configure which would
set configuration options but not apply them.

Ninja has file age checking built-in so if the config file was
older than the build file then it would re-run setup to apply
the correct config, and this was happening most times so
the build would work, but occasionally the file timestamps would
be the same so the check would not fail and the build would be run
without the configuration options applied.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
