### PR TITLE
DAOS-14126 pool: Fix a pool destroy timeout (#13983) (#12889)

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -70,8 +70,7 @@ struct ds_pool {
 	 */
 	uuid_t			sp_srv_cont_hdl;
 	uuid_t			sp_srv_pool_hdl;
-	uint32_t sp_stopping : 1, sp_fetch_hdls : 1, sp_disable_rebuild : 1, sp_need_discard : 1,
-	    sp_checkpoint_props_changed : 1;
+	uint32_t sp_stopping : 1, sp_fetch_hdls : 1, sp_disable_rebuild : 1, sp_need_discard : 1;
 
 	/* pool_uuid + map version + leader term + rebuild generation define a
 	 * rebuild job.


### PR DESCRIPTION
The ds_pool.sp_checkpoint_props_changed bitfield is modified from target xstreams, causing a data race on all surrounding bitfields among the system xstream and all the target xstreams. It is this author's guess that such data races have likely led to the pool destroy timeouts caused by pool_fetch_hdls_ult_abort hangs reported in the Jira ticket.

Here is how the hang happened during one pool destroy timeout:

    31:54.85 pool_fetch_hdls_ult() b262bfcf: begin: fetch_hdls=1
      stopping=0
    31:54.85 pool_fetch_hdls_ult() b262bfcf: waiting for map
    32:03.96 pool_fetch_hdls_ult() b262bfcf: fetching handles
    32:03.96 pool_fetch_hdls_ult() b262bfcf: signaling done
    32:03.96 pool_fetch_hdls_ult() b262bfcf: end
    38:07.48 pool_fetch_hdls_ult_abort() b262bfcf: begin: fetch_hdls=1
      stopping=1
    38:07.48 pool_fetch_hdls_ult_abort() b262bfcf: signaled
    38:07.48 pool_fetch_hdls_ult_abort() b262bfcf: waiting for ULT

The ULT had exited at 32:03.96, when it should have set the ds_pool.sp_fetch_hdls bitfield to 0. More than 6 minutes later, pool_fetch_hdls_ult_abort found that ds_pool.sp_fetch_hdls to be 1 and started waiting for the ULT to exit! The theory is that when the ULT was setting sp_fetch_hdls to 0 on the system xstream, a target xstream happened to be executing update_vos_prop_on_targets, who was setting sp_checkpoint_props_changed at the same time. The latter read sp_fetch_hdls == 1 before the ULT set the field to 0, and after the ULT had set sp_fetch_hdls == 0, wrote sp_fetch_hdls == 1, causing the ULT's write to be lost.

This patch avoids the data race by replacing the
ds_pool.sp_checkpoint_props_changed bitfield with a read-only collective parameter.

To maintain consistency with master, and just in case the data race isn't the root cause of the pool destroy problem, this patch also includes the debug messages that have been added to master.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
