### PR TITLE
DAOS-15345 dfuse: Ignore return of cont_close.

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -964,7 +964,7 @@ dfuse_cont_open(struct dfuse_info *dfuse_info, struct dfuse_pool *dfp, const cha
 err_umount:
 	dfs_umount(dfc->dfs_ns);
 err_close:
-	daos_cont_close(dfc->dfs_coh, NULL);
+	(void)daos_cont_close(dfc->dfs_coh, NULL);
 err_free:
 	D_FREE(dfc);
 err:

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -962,7 +962,7 @@ dfuse_cont_open(struct dfuse_info *dfuse_info, struct dfuse_pool *dfp, const cha
 
 	return rc;
 err_umount:
-	dfs_umount(dfc->dfs_ns);
+	(void)dfs_umount(dfc->dfs_ns);
 err_close:
 	(void)daos_cont_close(dfc->dfs_coh, NULL);
 err_free:

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -2604,7 +2604,7 @@ out:
 	ap->dfuse_mem.container_count = query.container_count;
 
 close:
-	if (fd > 0)
+	if (fd >= 0)
 		close(fd);
 	return rc;
 }


### PR DESCRIPTION
Fixes coverity ID 1979831

Also fix 1981011 about correct handling of fd 0

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
