### PR TITLE
DAOS-15480 object: do not support conditional punch object

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -6824,6 +6824,12 @@ dc_obj_punch_task(tse_task_t *task)
 	args = dc_task_get_args(task);
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
 
+	if (unlikely(args->flags & DAOS_COND_MASK)) {
+		D_INFO("Ignore condition flags " DF_X64 " that is not applicable for object\n",
+		       args->flags);
+		args->flags &= ~DAOS_COND_MASK;
+	}
+
 	return obj_punch_common(task, DAOS_OBJ_RPC_PUNCH, args);
 }
 

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -495,8 +495,6 @@ vos_ilog_punch_(struct vos_container *cont, struct ilog_df *ilog,
 		return 0;
 	}
 
-	/** If we get here, we need to check if the entry exists */
-	D_ASSERT(ts_set->ts_flags & VOS_OF_COND_PUNCH);
 	/** For now, if the state isn't settled, just retry with later
 	 *  timestamp.   The state should get settled quickly when there
 	 *  is conditional update and sharing.


### PR DESCRIPTION
The condition semantics is only applicable for key instead of object. Ignore (but warn) the condtion flag when punch object with condition. Remove redundant condition check in vos.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
