### PR TITLE
DAOS-15484 dfs: store sticky/suid/sgid bits on setattr

### DIFF
--- a/docs/user/filesystem.md
+++ b/docs/user/filesystem.md
@@ -54,16 +54,19 @@ The following features from POSIX are not supported:
   The dfuse-data-cache=otoc container attribute allows this without enabling other caching.
 * Char devices, block devices, sockets and pipes
 * User/group quotas
-* setuid(), setgid() programs, supplementary groups, POSIX ACLs are not supported
-  within the DFS namespace.
 * [access/change/modify] time not updated appropriately, potentially on close only.
 * Flock (maybe at dfuse local node level only)
 * Block size in stat buf is not accurate (no account for holes, extended attributes)
 * Various parameters reported via statfs like number of blocks, files,
   free/available space
-* POSIX permissions inside an encapsulated namespace
-  * Still enforced at the DAOS pool/container level
-  * Effectively means that all files belong to the same "project"
+* O\_APPEND is not supported
+* POSIX permissions, setuid/gid programs, sticky bit, POSIX ACLs, supplementary groups are not
+  supported inside an encapsulated namespace
+    * Still enforced at the DAOS pool/container level via DAOS ACL
+    * Effectively means that all files belong to the same "project"
+    * libdfs still allows permission, set-user/group-id and sticky bits to be stored on setattr
+      operation to allow high-level frameworks like fuse/dfuse to support those features and do
+      proper permission checks and enforcement.
 
 !!! note
     DFS directories do not include the `.` (current directory) and `..` (parent directory)

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -1144,12 +1144,6 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 		oh = parent->oh;
 	}
 
-	/** sticky bit, set-user-id and set-group-id, are not supported */
-	if (mode & S_ISVTX || mode & S_ISGID || mode & S_ISUID) {
-		D_ERROR("setuid, setgid, & sticky bit are not supported.\n");
-		return ENOTSUP;
-	}
-
 	/* Check if parent has the entry */
 	rc = fetch_entry(dfs->layout_v, oh, DAOS_TX_NONE, name, len, true, &exists, &entry, 0, NULL,
 			 NULL, NULL);
@@ -1399,13 +1393,6 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	if (flags & DFS_SET_ATTR_MODE) {
 		if ((stbuf->st_mode & S_IFMT) != (obj->mode & S_IFMT))
 			return EINVAL;
-		/** sticky bit, set-user-id and set-group-id not supported */
-		if (stbuf->st_mode & S_ISVTX || stbuf->st_mode & S_ISGID ||
-		    stbuf->st_mode & S_ISUID) {
-			D_DEBUG(DB_TRACE, "setuid, setgid, & sticky bit are not"
-					  " supported.\n");
-			return EINVAL;
-		}
 	}
 
 	/** Open parent object and fetch entry of obj from it */

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -998,9 +998,13 @@ dfs_ostat(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf);
 #define DFS_SET_ATTR_GID	(1 << 5)
 
 /**
- * set stat attributes for a file and fetch new values.  If the object is a
+ * Set stat attributes for a file and fetch new values.  If the object is a
  * symlink the link itself is modified.  See dfs_stat() for which entries
  * are filled.
+ * Since libdfs does not perform any POSIX permission enforcement, it just
+ * stores stbuf::st_mode as is to allow higher-level frameworks to do their
+ * permission checks. Similarly, set-user/group-id and sticky bits are stored
+ * by dfs, but not honored by libdfs itself.
  *
  * \param[in]	dfs	Pointer to the mounted file system.
  * \param[in]	obj	Open object (File, dir or syml) to modify.


### PR DESCRIPTION
Allow the sticky, suid and sgid bits to be stored in dfs_osetattr. Even if libdfs does not support those bits, it allows dfuse to support them via the kernel.

The lack of sgid support cause spack to fail over dfuse as reported in the jira ticket.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
