### PR TITLE
DAOS-15457 vos: don't wait for tx commit when SSD is faulty

### DIFF
--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -153,6 +153,8 @@ struct umem_store {
 	int			 store_type;
 	/* standalone store */
 	bool			 store_standalone;
+	/* backend SSD is in faulty state */
+	bool			 store_faulty;
 };
 
 struct umem_slab_desc {

--- a/src/pool/srv_pool_chkpt.c
+++ b/src/pool/srv_pool_chkpt.c
@@ -79,6 +79,9 @@ wait_cb(void *arg, uint64_t chkpt_tx, uint64_t *committed_tx)
 		goto done;
 	}
 
+	if (store->store_faulty)
+		goto done;
+
 	ctx->cc_wait_id = chkpt_tx;
 	wait_fn(ctx);
 done:
@@ -107,7 +110,8 @@ update_cb(void *arg, uint64_t id, uint32_t used_blocks, uint32_t total_blocks)
 	if (!ctx->cc_waiting)
 		return;
 
-	if (store->stor_ops->so_wal_id_cmp(store, id, ctx->cc_wait_id) >= 0) {
+	if (store->store_faulty ||
+	    store->stor_ops->so_wal_id_cmp(store, id, ctx->cc_wait_id) >= 0) {
 		wake_fn(ctx);
 		ctx->cc_waiting = 0;
 	}

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -585,6 +585,8 @@ pool_child_stop(struct ds_pool_child *child)
 
 	/* Stop all pool child owned ULTs which doesn't hold ds_pool_child reference */
 	ds_stop_chkpt_ult(child);
+	D_DEBUG(DB_MGMT, DF_UUID": Checkpoint ULT stopped.\n", DP_UUID(child->spc_uuid));
+
 	stop_gc_ult(child);
 	stop_flush_ult(child);
 
@@ -592,6 +594,7 @@ pool_child_stop(struct ds_pool_child *child)
 	vos_pool_close(child->spc_hdl);
 	child->spc_hdl = DAOS_HDL_INVAL;
 
+	D_DEBUG(DB_MGMT, DF_UUID": Pool child stopped.\n", DP_UUID(child->spc_uuid));
 	*child->spc_state = POOL_CHILD_NEW;
 	return 0;
 }


### PR DESCRIPTION
When WAL SSD is faulty, WAL commit will always fail and the last committed tx ID won't be bumped anymore, checkpoint ULT shouldn't wait on tx commit in such case, otherwise, the checkpoint ULT will never be woken up, and the pool_child_stop() will be blocked on stopping the checkpoint ULT.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
