### PR TITLE
DAOS-15497 client: set rpath in libioil.so and libpil4dfs.so

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -141,10 +141,6 @@ class DaosBuild(DfuseTestBase):
             build_jobs = 6 * 2
             remote_env['D_IL_MAX_EQ'] = '0'
 
-        intercept_jobs = build_jobs
-        if intercept:
-            intercept_jobs = 1
-
         self.load_dfuse(self.hostlist_clients, dfuse_namespace)
 
         if cache_mode == 'writeback':
@@ -216,8 +212,8 @@ class DaosBuild(DfuseTestBase):
                 'daos filesystem query {}'.format(mount_dir),
                 'daos filesystem evict {}'.format(build_dir),
                 'daos filesystem query {}'.format(mount_dir),
-                'scons -C {} --jobs {}'.format(build_dir, intercept_jobs),
-                'scons -C {} --jobs {} install'.format(build_dir, intercept_jobs),
+                'scons -C {} --jobs {}'.format(build_dir, build_jobs),
+                'scons -C {} --jobs {} install'.format(build_dir, build_jobs),
                 'daos filesystem query {}'.format(mount_dir)]
         for cmd in cmds:
             command = '{};{}'.format(preload_cmd, cmd)

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -15,7 +15,7 @@
 
 Name:          daos
 Version:       2.5.101
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -65,6 +65,7 @@ BuildRequires: protobuf-c-devel
 BuildRequires: lz4-devel
 BuildRequires: capstone-devel
 %endif
+BuildRequires: patchelf
 BuildRequires: spdk-devel >= 22.01.2
 %if (0%{?rhel} >= 8)
 BuildRequires: isa-l-devel
@@ -351,6 +352,10 @@ mv test.cov{,-build}
       %{?scons_args}                  \
       %{?compiler_args}
 
+# setting rpath for libioil.so and libpil4dfs.so is needed for parallel compiling in daos build test
+patchelf --force-rpath --set-rpath %{_libdir} %{buildroot}/%{_libdir}/libpil4dfs.so
+patchelf --force-rpath --set-rpath %{_libdir} %{buildroot}/%{_libdir}/libioil.so
+
 %if ("%{?compiler_args}" == "COMPILER=covc")
 mv test.cov-build %{buildroot}/%{daoshome}/TESTING/ftest/test.cov
 %endif
@@ -587,6 +592,9 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Wed Mar 21 2024 Lei Huang <lei.huang@intel.com> 2.5.101-3
+- Add patchelf as as a dependency
+
 * Mon Mar 18 2024 Jan Michalski <jan.michalski@intel.com> 2.5.101-2
 - Add dtx_tests to the server-tests package
 


### PR DESCRIPTION
In daos build test, scons sets env "LD_LIBRARY_PATH" including build directory. With setting rpath in libioil.so and libpil4dfs.so, dependent libraries will be loaded from system lib path instead of build directory.

Features: dfuse

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
