### PR TITLE
DAOS-11406 vos: Fix dth_deferred_cnt assert

### DIFF
--- a/src/dtx/tests/dts_structs.c
+++ b/src/dtx/tests/dts_structs.c
@@ -81,6 +81,7 @@ struct_dtx_handle(void **state)
 	SET_FIELD(dummy, dth_deferred_cnt);
 	SET_FIELD(dummy, dth_modification_cnt);
 	SET_FIELD(dummy, dth_op_seq);
+	SET_FIELD(dummy, dth_deferred_used_cnt);
 	SET_FIELD(dummy, padding2);
 	SET_FIELD(dummy, dth_oid_cnt);
 	SET_FIELD(dummy, dth_oid_cap);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -132,7 +132,8 @@ struct dtx_handle {
 	/** Modification sequence in the distributed transaction. */
 	uint16_t			 dth_op_seq;
 
-	uint32_t                         padding2;
+	uint16_t			 dth_deferred_used_cnt;
+	uint16_t                         padding2;
 
 	union {
 		struct {

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -3149,6 +3149,7 @@ vos_dtx_rsrvd_init(struct dtx_handle *dth)
 {
 	dth->dth_rsrvd_cnt = 0;
 	dth->dth_deferred_cnt = 0;
+	dth->dth_deferred_used_cnt = 0;
 	D_INIT_LIST_HEAD(&dth->dth_deferred_nvme);
 
 	if (dth->dth_modification_cnt <= 1) {

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -599,7 +599,6 @@ svt_rec_free_internal(struct btr_instance *tins, struct btr_record *rec,
 	struct dtx_handle	*dth = NULL;
 	struct umem_rsrvd_act	*rsrvd_scm;
 	struct vos_container	*cont = vos_hdl2cont(tins->ti_coh);
-	int			 i;
 
 	if (UMOFF_IS_NULL(rec->rec_off))
 		return 0;
@@ -632,10 +631,10 @@ svt_rec_free_internal(struct btr_instance *tins, struct btr_record *rec,
 	/** There can't be more cancellations than updates in this
 	 *  modification so just use the current one
 	 */
-	D_ASSERT(dth->dth_op_seq > 0);
-	D_ASSERT(dth->dth_op_seq <= dth->dth_deferred_cnt);
-	i = dth->dth_op_seq - 1;
-	rsrvd_scm = dth->dth_deferred[i];
+	D_ASSERTF(dth->dth_deferred_used_cnt < dth->dth_deferred_cnt, "%u < %u\n",
+		  dth->dth_deferred_used_cnt, dth->dth_deferred_cnt);
+	rsrvd_scm = dth->dth_deferred[dth->dth_deferred_used_cnt];
+	dth->dth_deferred_used_cnt++;
 	D_ASSERT(rsrvd_scm != NULL);
 
 	umem_defer_free(&tins->ti_umm, rec->rec_off, rsrvd_scm);


### PR DESCRIPTION
The "dth_op_seq <= dth_deferred_cnt" assertion in svt_rec_free_internal failed with "dth_op_seq == 6 and dth_deferred_cnt == 5" when executing the last update in the following TX:

    dtx_begin(sub_modification_cnt == 6)
    vos_obj_punch()
    vos_obj_update()
    vos_obj_update()
    vos_obj_update()
    vos_obj_update()
    vos_obj_update() // assertion failure

Thanks to a hint from Fan Yong that vos_obj_punch does not fill dth_deferred, this patch adds dth_deferred_used_cnt to replace dth_op_seq's role in finding next available dth_deferred entry.

(A cleaner solution might be to allocate the rsvd_scm entry in svt_rec_free_internal on demand, rather than in vos_ioc_reserve_init. The trouble with that is how to compute/retrieve total_acts and umm from vos_io_context.)

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
