### PR TITLE
DAOS-15497 build: Only set LD_LIBRARY_PATH in scons build where required.

### DIFF
--- a/site_scons/site_tools/daos_builder.py
+++ b/site_scons/site_tools/daos_builder.py
@@ -64,20 +64,15 @@ def _add_build_rpath(env, pathin="."):
     path = Dir(pathin).path
     env.AppendUnique(LINKFLAGS=[f'-Wl,-rpath-link={path}'])
     env.AppendENVPath('CGO_LDFLAGS', f'-Wl,-rpath-link={path}', sep=' ')
+
+
+def _enable_ld_path(env, part_list):
+    """Add a build directory to LD_LIBRARY_PATY"""
     # We actually run installed binaries from the build area to generate
     # man pages.  In such cases, we need LD_LIBRARY_PATH set to pick up
     # the dependencies
-    env.AppendENVPath("D_LD_PATH", path)
-
-
-def _enable_ld_path(env):
-    """Add a build directory to rpath"""
-    # We actually run installed binaries from the build area to generate
-    # man pages.  In such cases, we need LD_LIBRARY_PATH set to pick up
-    # the dependencies
-    # env.AppendENVPath("LD_LIBRARY_PATH", path)
-    print(env["ENV"]["D_LD_PATH"])
-    env["ENV"]["LD_LIBRARY_PATH"] = env["ENV"]["D_LD_PATH"]
+    for part in part_list:
+        env.AppendENVPath("LD_LIBRARY_PATH", os.path.join(env["BUILD_DIR"], "src", part))
 
 
 def _known_deps(env, **kwargs):

--- a/site_scons/site_tools/daos_builder.py
+++ b/site_scons/site_tools/daos_builder.py
@@ -67,7 +67,17 @@ def _add_build_rpath(env, pathin="."):
     # We actually run installed binaries from the build area to generate
     # man pages.  In such cases, we need LD_LIBRARY_PATH set to pick up
     # the dependencies
-    env.AppendENVPath("LD_LIBRARY_PATH", path)
+    env.AppendENVPath("D_LD_PATH", path)
+
+
+def _enable_ld_path(env):
+    """Add a build directory to rpath"""
+    # We actually run installed binaries from the build area to generate
+    # man pages.  In such cases, we need LD_LIBRARY_PATH set to pick up
+    # the dependencies
+    # env.AppendENVPath("LD_LIBRARY_PATH", path)
+    print(env["ENV"]["D_LD_PATH"])
+    env["ENV"]["LD_LIBRARY_PATH"] = env["ENV"]["D_LD_PATH"]
 
 
 def _known_deps(env, **kwargs):
@@ -246,6 +256,7 @@ def _configure_mpi(self):
 def generate(env):
     """Add daos specific methods to environment"""
     env.AddMethod(_add_build_rpath, 'd_add_build_rpath')
+    env.AddMethod(_enable_ld_path, 'd_enable_ld_path')
     env.AddMethod(_configure_mpi, 'd_configure_mpi')
     env.AddMethod(_run_command, 'd_run_command')
     env.AddMethod(_add_rpaths, 'd_add_rpaths')

--- a/site_scons/site_tools/daos_builder.py
+++ b/site_scons/site_tools/daos_builder.py
@@ -67,7 +67,7 @@ def _add_build_rpath(env, pathin="."):
 
 
 def _enable_ld_path(env, part_list):
-    """Add a build directory to LD_LIBRARY_PATY"""
+    """Add a build directory to LD_LIBRARY_PATH"""
     # We actually run installed binaries from the build area to generate
     # man pages.  In such cases, we need LD_LIBRARY_PATH set to pick up
     # the dependencies

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -91,7 +91,7 @@ def install_go_bin(env, name, libs=None, install_man=False):
         gen_bin = join('$BUILD_DIR/src/control', name)
         build_path = join('$BUILD_DIR/src/control', f'{name}.8')
         menv = env.Clone()
-        menv.d_enable_ld_path()
+        menv.d_enable_ld_path(["cart", "gurt", "client/api", "common", "client/dfs", "utils"])
         menv.Command(build_path, target, f'{gen_bin} manpage -o {build_path}')
         menv.Install('$PREFIX/share/man/man8', build_path)
 

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -90,8 +90,10 @@ def install_go_bin(env, name, libs=None, install_man=False):
     if install_man:
         gen_bin = join('$BUILD_DIR/src/control', name)
         build_path = join('$BUILD_DIR/src/control', f'{name}.8')
-        env.Command(build_path, target, f'{gen_bin} manpage -o {build_path}')
-        env.Install('$PREFIX/share/man/man8', build_path)
+        menv = env.Clone()
+        menv.d_enable_ld_path()
+        menv.Command(build_path, target, f'{gen_bin} manpage -o {build_path}')
+        menv.Install('$PREFIX/share/man/man8', build_path)
 
 
 def scons():

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -91,6 +91,7 @@ def install_go_bin(env, name, libs=None, install_man=False):
         gen_bin = join('$BUILD_DIR/src/control', name)
         build_path = join('$BUILD_DIR/src/control', f'{name}.8')
         menv = env.Clone()
+        # This runs code from the build area so needs LD_LIBRARY_PATH set.
         menv.d_enable_ld_path(["cart", "gurt", "client/api", "common", "client/dfs", "utils"])
         menv.Command(build_path, target, f'{gen_bin} manpage -o {build_path}')
         menv.Install('$PREFIX/share/man/man8', build_path)

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -206,7 +206,6 @@ class DaosBuild(DfuseTestBase):
                 'git clone https://github.com/daos-stack/daos.git {}'.format(build_dir),
                 'git -C {} submodule init'.format(build_dir),
                 'git -C {} submodule update'.format(build_dir),
-                'git -C {} checkout and/ld_path_in_build'.format(build_dir),
                 'python3 -m pip install pip --upgrade',
                 'python3 -m pip install -r {}/requirements.txt'.format(build_dir),
                 'scons -C {} --jobs {} --build-deps=only'.format(build_dir, build_jobs),

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -141,10 +141,6 @@ class DaosBuild(DfuseTestBase):
             build_jobs = 6 * 2
             remote_env['D_IL_MAX_EQ'] = '0'
 
-        intercept_jobs = build_jobs
-        if intercept:
-            intercept_jobs = 1
-
         self.load_dfuse(self.hostlist_clients, dfuse_namespace)
 
         if cache_mode == 'writeback':
@@ -210,14 +206,15 @@ class DaosBuild(DfuseTestBase):
                 'git clone https://github.com/daos-stack/daos.git {}'.format(build_dir),
                 'git -C {} submodule init'.format(build_dir),
                 'git -C {} submodule update'.format(build_dir),
+                'git -C {} checkout and/ld_path_in_build'.format(build_dir),
                 'python3 -m pip install pip --upgrade',
                 'python3 -m pip install -r {}/requirements.txt'.format(build_dir),
                 'scons -C {} --jobs {} --build-deps=only'.format(build_dir, build_jobs),
                 'daos filesystem query {}'.format(mount_dir),
                 'daos filesystem evict {}'.format(build_dir),
                 'daos filesystem query {}'.format(mount_dir),
-                'scons -C {} --jobs {}'.format(build_dir, intercept_jobs),
-                'scons -C {} --jobs {} install'.format(build_dir, intercept_jobs),
+                'scons -C {} --jobs {}'.format(build_dir, build_jobs),
+                'scons -C {} --jobs {} install'.format(build_dir, build_jobs),
                 'daos filesystem query {}'.format(mount_dir)]
         for cmd in cmds:
             command = '{};{}'.format(preload_cmd, cmd)


### PR DESCRIPTION
This avoids a long-standing but previously unknown issue where
the build directory was in LD_LIBRARY_PATH when running gcc etc.

Update site_scons to not se LD_LIBRARY_PATH for all commands launched
during the build but rather only set it for the step where the dmg man
pages are generated.

This impacts the daos_build test which bas previously always needed
to run the daos_build with --jobs=1, with this change then the build
can be run in parallel which reduces the run-time of this test by a third.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
