### PR TITLE
DAOS-15441 test: increase ior_timeout for with_ior

### DIFF
--- a/src/tests/ftest/rebuild/with_ior.yaml
+++ b/src/tests/ftest/rebuild/with_ior.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 3
   test_clients: 1
 
-timeout: 360
+timeout: 460
 
 server_config:
   name: daos_server
@@ -38,7 +38,7 @@ container:
   control_method: daos
 
 ior:
-  ior_timeout: 120
+  ior_timeout: 200
   rank_to_kill: 3
   client_processes:
     ppn: 16


### PR DESCRIPTION
The original 120S possibly not enough, in a failed case it is observed that an RPC to killed rank 3 got 60 seconds timeout that is expected, left 60 Second possibly not enough to run the whole IOR as need to wait timeout and refresh pool map and retry.
Increase whole test's timeout accordingly.

Test-tag: test_rebuild_with_ior
Test-repeat: 5

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
