### PR TITLE
DAOS-15484 dfs: store sticky/suid/sgid bits on setattr (#14028)

### DIFF
--- a/docs/user/filesystem.md
+++ b/docs/user/filesystem.md
@@ -53,16 +53,19 @@ The following features from POSIX are not supported:
   that this is supported through DFUSE only (i.e. not through the DFS API).
 * Char devices, block devices, sockets and pipes
 * User/group quotas
-* setuid(), setgid() programs, supplementary groups, POSIX ACLs are not supported
-  within the DFS namespace.
 * [access/change/modify] time not updated appropriately, potentially on close only.
 * Flock (maybe at dfuse local node level only)
 * Block size in stat buf is not accurate (no account for holes, extended attributes)
 * Various parameters reported via statfs like number of blocks, files,
   free/available space
-* POSIX permissions inside an encapsulated namespace
-  * Still enforced at the DAOS pool/container level
-  * Effectively means that all files belong to the same "project"
+* O\_APPEND is not supported
+* POSIX permissions, sticky bit, POSIX ACLs, supplementary groups are not supported inside an
+  encapsulated namespace
+    * Still enforced at the DAOS pool/container level via DAOS ACL
+    * Effectively means that all files belong to the same "project"
+* While set\_uid/gid bits are stored by libdfs on setattr and returned on getattr, it is up to
+  the caller (e.g. fuse in the case of dfuse) to implement support for setuid/gid binaries since
+  libdfs does not provide any interface to execute binaries.
 
 !!! note
     DFS directories do not include the `.` (current directory) and `..` (parent directory)

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -5121,9 +5121,9 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 		oh = parent->oh;
 	}
 
-	/** sticky bit, set-user-id and set-group-id, are not supported */
-	if (mode & S_ISVTX || mode & S_ISGID || mode & S_ISUID) {
-		D_ERROR("setuid, setgid, & sticky bit are not supported.\n");
+	/** sticky bit is not supported */
+	if (mode & S_ISVTX) {
+		D_ERROR("sticky bit is not supported.\n");
 		return ENOTSUP;
 	}
 
@@ -5380,12 +5380,11 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	if (flags & DFS_SET_ATTR_MODE) {
 		if ((stbuf->st_mode & S_IFMT) != (obj->mode & S_IFMT))
 			return EINVAL;
-		/** sticky bit, set-user-id and set-group-id not supported */
-		if (stbuf->st_mode & S_ISVTX || stbuf->st_mode & S_ISGID ||
-		    stbuf->st_mode & S_ISUID) {
-			D_DEBUG(DB_TRACE, "setuid, setgid, & sticky bit are not"
-				" supported.\n");
-			return EINVAL;
+
+		/** sticky bit is not supported */
+		if (stbuf->st_mode & S_ISVTX) {
+			D_DEBUG(DB_TRACE, "sticky bit is not supported.\n");
+			return ENOTSUP;
 		}
 	}
 

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -987,9 +987,12 @@ dfs_ostat(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf);
 #define DFS_SET_ATTR_GID	(1 << 5)
 
 /**
- * set stat attributes for a file and fetch new values.  If the object is a
+ * Set stat attributes for a file and fetch new values.  If the object is a
  * symlink the link itself is modified.  See dfs_stat() for which entries
  * are filled.
+ * While the set-user/group-id bits in stbuf::st_mode are stored by libdfs, it
+ * up to the caller to implement support for the associated functionality
+ * since libdfs does not provide any way to execute binaries.
  *
  * \param[in]	dfs	Pointer to the mounted file system.
  * \param[in]	obj	Open object (File, dir or syml) to modify.


### PR DESCRIPTION
Allow the suid and sgid bits to be stored in dfs_osetattr. Even if libdfs does not support those bits, it allows dfuse to support them via the kernel.

The lack of sgid support cause spack to fail over dfuse as reported in the jira ticket.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
