### PR TITLE
DAOS-15495: Fix libipmctl init failure

### DIFF
--- a/src/control/server/storage/scm/ipmctl.go
+++ b/src/control/server/storage/scm/ipmctl.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/fault"
-	"github.com/daos-stack/daos/src/control/lib/ipmctl"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/provider/system"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -68,7 +67,6 @@ var (
 
 type cmdRunner struct {
 	log         logging.Logger
-	binding     ipmctl.IpmCtl
 	runInternal runCmdFn
 	lookPath    lookPathFn
 	checkOnce   sync.Once
@@ -550,7 +548,7 @@ func run(log logging.Logger, cmd pmemCmd) (string, error) {
 }
 
 func defaultCmdRunner(log logging.Logger) *cmdRunner {
-	cr, err := newCmdRunner(log, nil, run, exec.LookPath)
+	cr, err := newCmdRunner(log, run, exec.LookPath)
 	if err != nil {
 		panic(err)
 	}
@@ -558,26 +556,7 @@ func defaultCmdRunner(log logging.Logger) *cmdRunner {
 	return cr
 }
 
-func newCmdRunner(log logging.Logger, _ ipmctl.IpmCtl, runCmd runCmdFn, lookPath lookPathFn) (*cmdRunner, error) {
-	//	if lib == nil {
-	// If no libipmctl interface is provided, assume no calls should be expected and
-	// return a mock library interface that returns error on every call.
-	//	err := errors.New("unexpected ipmctl library call")
-	//	lib := &mockIpmctl{
-	//		cfg: mockIpmctlCfg{
-	//			initErr:           err,
-	//			delGoalsErr:       err,
-	//			getRegionsErr:     err,
-	//			getFWInfoRet:      err,
-	//			updateFirmwareRet: err,
-	//		},
-	//	}
-	//	} else {
-	//		if err := lib.Init(log); err != nil {
-	//			return nil, err
-	//		}
-	//	}
-
+func newCmdRunner(log logging.Logger, runCmd runCmdFn, lookPath lookPathFn) (*cmdRunner, error) {
 	if runCmd == nil {
 		// If no commandline call function is provided, assume no calls should be
 		// expected and create a mock runner that will error if called.
@@ -588,7 +567,6 @@ func newCmdRunner(log logging.Logger, _ ipmctl.IpmCtl, runCmd runCmdFn, lookPath
 
 	return &cmdRunner{
 		log:         log,
-		binding:     nil,
 		runInternal: runCmd,
 		lookPath:    lookPath,
 	}, nil

--- a/src/control/server/storage/scm/ipmctl.go
+++ b/src/control/server/storage/scm/ipmctl.go
@@ -550,7 +550,7 @@ func run(log logging.Logger, cmd pmemCmd) (string, error) {
 }
 
 func defaultCmdRunner(log logging.Logger) *cmdRunner {
-	cr, err := newCmdRunner(log, &ipmctl.NvmMgmt{}, run, exec.LookPath)
+	cr, err := newCmdRunner(log, nil, run, exec.LookPath)
 	if err != nil {
 		panic(err)
 	}
@@ -558,25 +558,25 @@ func defaultCmdRunner(log logging.Logger) *cmdRunner {
 	return cr
 }
 
-func newCmdRunner(log logging.Logger, lib ipmctl.IpmCtl, runCmd runCmdFn, lookPath lookPathFn) (*cmdRunner, error) {
-	if lib == nil {
-		// If no libipmctl interface is provided, assume no calls should be expected and
-		// return a mock library interface that returns error on every call.
-		err := errors.New("unexpected ipmctl library call")
-		lib = &mockIpmctl{
-			cfg: mockIpmctlCfg{
-				initErr:           err,
-				delGoalsErr:       err,
-				getRegionsErr:     err,
-				getFWInfoRet:      err,
-				updateFirmwareRet: err,
-			},
-		}
-	} else {
-		if err := lib.Init(log); err != nil {
-			return nil, err
-		}
-	}
+func newCmdRunner(log logging.Logger, _ ipmctl.IpmCtl, runCmd runCmdFn, lookPath lookPathFn) (*cmdRunner, error) {
+	//	if lib == nil {
+	// If no libipmctl interface is provided, assume no calls should be expected and
+	// return a mock library interface that returns error on every call.
+	//	err := errors.New("unexpected ipmctl library call")
+	//	lib := &mockIpmctl{
+	//		cfg: mockIpmctlCfg{
+	//			initErr:           err,
+	//			delGoalsErr:       err,
+	//			getRegionsErr:     err,
+	//			getFWInfoRet:      err,
+	//			updateFirmwareRet: err,
+	//		},
+	//	}
+	//	} else {
+	//		if err := lib.Init(log); err != nil {
+	//			return nil, err
+	//		}
+	//	}
 
 	if runCmd == nil {
 		// If no commandline call function is provided, assume no calls should be
@@ -588,7 +588,7 @@ func newCmdRunner(log logging.Logger, lib ipmctl.IpmCtl, runCmd runCmdFn, lookPa
 
 	return &cmdRunner{
 		log:         log,
-		binding:     lib,
+		binding:     nil,
 		runInternal: runCmd,
 		lookPath:    lookPath,
 	}, nil

--- a/src/control/server/storage/scm/ipmctl_dimm_test.go
+++ b/src/control/server/storage/scm/ipmctl_dimm_test.go
@@ -212,7 +212,7 @@ Intel(R) Optane(TM) Persistent Memory Command Line Interface Version 03.00.00.04
 				return out, err
 			}
 
-			cr, err := newCmdRunner(log, nil, mockRun, nil)
+			cr, err := newCmdRunner(log, mockRun, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/control/server/storage/scm/ipmctl_firmware.go
+++ b/src/control/server/storage/scm/ipmctl_firmware.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -12,6 +12,13 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/ipmctl"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
+
+// Function pointer to enable mocking during unit tests.
+var getLibipmctl = libipmctlGet
+
+func libipmctlGet() ipmctl.IpmCtl {
+	return &ipmctl.NvmMgmt{}
+}
 
 func scmFirmwareUpdateStatusFromIpmctl(ipmctlStatus uint32) storage.ScmFirmwareUpdateStatus {
 	switch ipmctlStatus {
@@ -44,7 +51,7 @@ func (cr *cmdRunner) GetFirmwareStatus(deviceUID string) (*storage.ScmFirmwareIn
 		return nil, errors.New("invalid SCM module UID")
 	}
 
-	lib := &ipmctl.NvmMgmt{}
+	lib := getLibipmctl()
 	if err := lib.Init(cr.log); err != nil {
 		return nil, err
 	}
@@ -76,7 +83,7 @@ func (cr *cmdRunner) UpdateFirmware(deviceUID string, firmwarePath string) error
 		return errors.New("invalid SCM module UID")
 	}
 
-	lib := &ipmctl.NvmMgmt{}
+	lib := getLibipmctl()
 	if err := lib.Init(cr.log); err != nil {
 		return err
 	}

--- a/src/control/server/storage/scm/ipmctl_firmware.go
+++ b/src/control/server/storage/scm/ipmctl_firmware.go
@@ -43,7 +43,13 @@ func (cr *cmdRunner) GetFirmwareStatus(deviceUID string) (*storage.ScmFirmwareIn
 	if err != nil {
 		return nil, errors.New("invalid SCM module UID")
 	}
-	info, err := cr.binding.GetFirmwareInfo(uid)
+
+	lib := &ipmctl.NvmMgmt{}
+	if err := lib.Init(cr.log); err != nil {
+		return nil, err
+	}
+
+	info, err := lib.GetFirmwareInfo(uid)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get firmware info for device %q", deviceUID)
 	}
@@ -69,10 +75,17 @@ func (cr *cmdRunner) UpdateFirmware(deviceUID string, firmwarePath string) error
 	if err != nil {
 		return errors.New("invalid SCM module UID")
 	}
+
+	lib := &ipmctl.NvmMgmt{}
+	if err := lib.Init(cr.log); err != nil {
+		return err
+	}
+
 	// Force option permits minor version downgrade.
-	err = cr.binding.UpdateFirmware(uid, firmwarePath, true)
+	err = lib.UpdateFirmware(uid, firmwarePath, true)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update firmware for device %q", deviceUID)
 	}
+
 	return nil
 }

--- a/src/control/server/storage/scm/ipmctl_firmware_test.go
+++ b/src/control/server/storage/scm/ipmctl_firmware_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -11,7 +11,10 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/ipmctl"
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/storage"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 )
 
 func TestIpmctl_fwInfoStatusToUpdateStatus(t *testing.T) {
@@ -48,120 +51,132 @@ func TestIpmctl_fwInfoStatusToUpdateStatus(t *testing.T) {
 	}
 }
 
-//func TestIpmctl_GetFirmwareStatus(t *testing.T) {
-//	testUID := "TestUID"
-//	testActiveVersion := "1.0.0.1"
-//	testStagedVersion := "2.0.0.2"
-//	fwInfo := ipmctl.DeviceFirmwareInfo{
-//		FWImageMaxSize: 65,
-//		FWUpdateStatus: ipmctl.FWUpdateStatusStaged,
-//	}
-//	_ = copy(fwInfo.ActiveFWVersion[:], testActiveVersion)
-//	_ = copy(fwInfo.StagedFWVersion[:], testStagedVersion)
-//
-//	// Representing a DIMM without a staged FW version
-//	fwInfoUnstaged := ipmctl.DeviceFirmwareInfo{
-//		FWImageMaxSize: 1,
-//		FWUpdateStatus: ipmctl.FWUpdateStatusSuccess,
-//	}
-//	_ = copy(fwInfoUnstaged.ActiveFWVersion[:], testActiveVersion)
-//	_ = copy(fwInfoUnstaged.StagedFWVersion[:], noFirmwareVersion)
-//
-//	for name, tc := range map[string]struct {
-//		inputUID  string
-//		cfg       *mockIpmctlCfg
-//		expErr    error
-//		expResult *storage.ScmFirmwareInfo
-//	}{
-//		"empty deviceUID": {
-//			expErr: errors.New("invalid SCM module UID"),
-//		},
-//		"ipmctl.GetFirmwareInfo failed": {
-//			inputUID: testUID,
-//			cfg: &mockIpmctlCfg{
-//				getFWInfoRet: errors.New("mock GetFirmwareInfo failed"),
-//			},
-//			expErr: errors.Errorf("failed to get firmware info for device %q: mock GetFirmwareInfo failed", testUID),
-//		},
-//		"success": {
-//			inputUID: testUID,
-//			cfg: &mockIpmctlCfg{
-//				fwInfo: fwInfo,
-//			},
-//			expResult: &storage.ScmFirmwareInfo{
-//				ActiveVersion:     testActiveVersion,
-//				StagedVersion:     testStagedVersion,
-//				ImageMaxSizeBytes: fwInfo.FWImageMaxSize * 4096,
-//				UpdateStatus:      storage.ScmUpdateStatusStaged,
-//			},
-//		},
-//		"nothing staged": {
-//			inputUID: testUID,
-//			cfg: &mockIpmctlCfg{
-//				fwInfo: fwInfoUnstaged,
-//			},
-//			expResult: &storage.ScmFirmwareInfo{
-//				ActiveVersion:     testActiveVersion,
-//				ImageMaxSizeBytes: 4096,
-//				UpdateStatus:      storage.ScmUpdateStatusSuccess,
-//			},
-//		},
-//	} {
-//		t.Run(name, func(t *testing.T) {
-//			log, buf := logging.NewTestLogger(t.Name())
-//			defer test.ShowBufferOnFailure(t, buf)
-//
-//			mockBinding := newMockIpmctl(tc.cfg)
-//			cr, err := newCmdRunner(log, mockBinding, nil, nil)
-//			if err != nil {
-//				t.Fatal(err)
-//			}
-//
-//			result, err := cr.GetFirmwareStatus(tc.inputUID)
-//
-//			test.CmpErr(t, tc.expErr, err)
-//			if diff := cmp.Diff(tc.expResult, result); diff != "" {
-//				t.Errorf("wrong firmware info (-want, +got):\n%s\n", diff)
-//			}
-//		})
-//	}
-//}
-//
-//func TestIpmctl_UpdateFirmware(t *testing.T) {
-//	testUID := "testUID"
-//	for name, tc := range map[string]struct {
-//		inputUID string
-//		cfg      *mockIpmctlCfg
-//		expErr   error
-//	}{
-//		"bad UID": {
-//			cfg:    &mockIpmctlCfg{},
-//			expErr: errors.New("invalid SCM module UID"),
-//		},
-//		"success": {
-//			inputUID: testUID,
-//			cfg:      &mockIpmctlCfg{},
-//		},
-//		"ipmctl UpdateFirmware failed": {
-//			inputUID: testUID,
-//			cfg: &mockIpmctlCfg{
-//				updateFirmwareRet: errors.New("mock UpdateFirmware failed"),
-//			},
-//			expErr: errors.Errorf("failed to update firmware for device %q: mock UpdateFirmware failed", testUID),
-//		},
-//	} {
-//		t.Run(name, func(t *testing.T) {
-//			log, buf := logging.NewTestLogger(t.Name())
-//			defer test.ShowBufferOnFailure(t, buf)
-//
-//			mockBinding := newMockIpmctl(tc.cfg)
-//			cr, err := newCmdRunner(log, mockBinding, nil, nil)
-//			if err != nil {
-//				t.Fatal(err)
-//			}
-//
-//			err = cr.UpdateFirmware(tc.inputUID, "/dont/care")
-//			test.CmpErr(t, tc.expErr, err)
-//		})
-//	}
-//}
+func TestIpmctl_GetFirmwareStatus(t *testing.T) {
+	testUID := "TestUID"
+	testActiveVersion := "1.0.0.1"
+	testStagedVersion := "2.0.0.2"
+	fwInfo := ipmctl.DeviceFirmwareInfo{
+		FWImageMaxSize: 65,
+		FWUpdateStatus: ipmctl.FWUpdateStatusStaged,
+	}
+	_ = copy(fwInfo.ActiveFWVersion[:], testActiveVersion)
+	_ = copy(fwInfo.StagedFWVersion[:], testStagedVersion)
+
+	// Representing a DIMM without a staged FW version
+	fwInfoUnstaged := ipmctl.DeviceFirmwareInfo{
+		FWImageMaxSize: 1,
+		FWUpdateStatus: ipmctl.FWUpdateStatusSuccess,
+	}
+	_ = copy(fwInfoUnstaged.ActiveFWVersion[:], testActiveVersion)
+	_ = copy(fwInfoUnstaged.StagedFWVersion[:], noFirmwareVersion)
+
+	for name, tc := range map[string]struct {
+		inputUID  string
+		cfg       *mockIpmctlCfg
+		expErr    error
+		expResult *storage.ScmFirmwareInfo
+	}{
+		"empty deviceUID": {
+			expErr: errors.New("invalid SCM module UID"),
+		},
+		"ipmctl.GetFirmwareInfo failed": {
+			inputUID: testUID,
+			cfg: &mockIpmctlCfg{
+				getFWInfoRet: errors.New("mock GetFirmwareInfo failed"),
+			},
+			expErr: errors.Errorf("failed to get firmware info for device %q: mock GetFirmwareInfo failed", testUID),
+		},
+		"success": {
+			inputUID: testUID,
+			cfg: &mockIpmctlCfg{
+				fwInfo: fwInfo,
+			},
+			expResult: &storage.ScmFirmwareInfo{
+				ActiveVersion:     testActiveVersion,
+				StagedVersion:     testStagedVersion,
+				ImageMaxSizeBytes: fwInfo.FWImageMaxSize * 4096,
+				UpdateStatus:      storage.ScmUpdateStatusStaged,
+			},
+		},
+		"nothing staged": {
+			inputUID: testUID,
+			cfg: &mockIpmctlCfg{
+				fwInfo: fwInfoUnstaged,
+			},
+			expResult: &storage.ScmFirmwareInfo{
+				ActiveVersion:     testActiveVersion,
+				ImageMaxSizeBytes: 4096,
+				UpdateStatus:      storage.ScmUpdateStatusSuccess,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			getLibipmctl = func() ipmctl.IpmCtl {
+				return newMockIpmctl(tc.cfg)
+			}
+			defer func() {
+				getLibipmctl = libipmctlGet
+			}()
+
+			cr, err := newCmdRunner(log, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result, err := cr.GetFirmwareStatus(tc.inputUID)
+
+			test.CmpErr(t, tc.expErr, err)
+			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+				t.Errorf("wrong firmware info (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestIpmctl_UpdateFirmware(t *testing.T) {
+	testUID := "testUID"
+	for name, tc := range map[string]struct {
+		inputUID string
+		cfg      *mockIpmctlCfg
+		expErr   error
+	}{
+		"bad UID": {
+			cfg:    &mockIpmctlCfg{},
+			expErr: errors.New("invalid SCM module UID"),
+		},
+		"success": {
+			inputUID: testUID,
+			cfg:      &mockIpmctlCfg{},
+		},
+		"ipmctl UpdateFirmware failed": {
+			inputUID: testUID,
+			cfg: &mockIpmctlCfg{
+				updateFirmwareRet: errors.New("mock UpdateFirmware failed"),
+			},
+			expErr: errors.Errorf("failed to update firmware for device %q: mock UpdateFirmware failed", testUID),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			getLibipmctl = func() ipmctl.IpmCtl {
+				return newMockIpmctl(tc.cfg)
+			}
+			defer func() {
+				getLibipmctl = libipmctlGet
+			}()
+
+			cr, err := newCmdRunner(log, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = cr.UpdateFirmware(tc.inputUID, "/dont/care")
+			test.CmpErr(t, tc.expErr, err)
+		})
+	}
+}

--- a/src/control/server/storage/scm/ipmctl_firmware_test.go
+++ b/src/control/server/storage/scm/ipmctl_firmware_test.go
@@ -9,12 +9,8 @@ package scm
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
-
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/ipmctl"
-	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -52,120 +48,120 @@ func TestIpmctl_fwInfoStatusToUpdateStatus(t *testing.T) {
 	}
 }
 
-func TestIpmctl_GetFirmwareStatus(t *testing.T) {
-	testUID := "TestUID"
-	testActiveVersion := "1.0.0.1"
-	testStagedVersion := "2.0.0.2"
-	fwInfo := ipmctl.DeviceFirmwareInfo{
-		FWImageMaxSize: 65,
-		FWUpdateStatus: ipmctl.FWUpdateStatusStaged,
-	}
-	_ = copy(fwInfo.ActiveFWVersion[:], testActiveVersion)
-	_ = copy(fwInfo.StagedFWVersion[:], testStagedVersion)
-
-	// Representing a DIMM without a staged FW version
-	fwInfoUnstaged := ipmctl.DeviceFirmwareInfo{
-		FWImageMaxSize: 1,
-		FWUpdateStatus: ipmctl.FWUpdateStatusSuccess,
-	}
-	_ = copy(fwInfoUnstaged.ActiveFWVersion[:], testActiveVersion)
-	_ = copy(fwInfoUnstaged.StagedFWVersion[:], noFirmwareVersion)
-
-	for name, tc := range map[string]struct {
-		inputUID  string
-		cfg       *mockIpmctlCfg
-		expErr    error
-		expResult *storage.ScmFirmwareInfo
-	}{
-		"empty deviceUID": {
-			expErr: errors.New("invalid SCM module UID"),
-		},
-		"ipmctl.GetFirmwareInfo failed": {
-			inputUID: testUID,
-			cfg: &mockIpmctlCfg{
-				getFWInfoRet: errors.New("mock GetFirmwareInfo failed"),
-			},
-			expErr: errors.Errorf("failed to get firmware info for device %q: mock GetFirmwareInfo failed", testUID),
-		},
-		"success": {
-			inputUID: testUID,
-			cfg: &mockIpmctlCfg{
-				fwInfo: fwInfo,
-			},
-			expResult: &storage.ScmFirmwareInfo{
-				ActiveVersion:     testActiveVersion,
-				StagedVersion:     testStagedVersion,
-				ImageMaxSizeBytes: fwInfo.FWImageMaxSize * 4096,
-				UpdateStatus:      storage.ScmUpdateStatusStaged,
-			},
-		},
-		"nothing staged": {
-			inputUID: testUID,
-			cfg: &mockIpmctlCfg{
-				fwInfo: fwInfoUnstaged,
-			},
-			expResult: &storage.ScmFirmwareInfo{
-				ActiveVersion:     testActiveVersion,
-				ImageMaxSizeBytes: 4096,
-				UpdateStatus:      storage.ScmUpdateStatusSuccess,
-			},
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
-
-			mockBinding := newMockIpmctl(tc.cfg)
-			cr, err := newCmdRunner(log, mockBinding, nil, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			result, err := cr.GetFirmwareStatus(tc.inputUID)
-
-			test.CmpErr(t, tc.expErr, err)
-			if diff := cmp.Diff(tc.expResult, result); diff != "" {
-				t.Errorf("wrong firmware info (-want, +got):\n%s\n", diff)
-			}
-		})
-	}
-}
-
-func TestIpmctl_UpdateFirmware(t *testing.T) {
-	testUID := "testUID"
-	for name, tc := range map[string]struct {
-		inputUID string
-		cfg      *mockIpmctlCfg
-		expErr   error
-	}{
-		"bad UID": {
-			cfg:    &mockIpmctlCfg{},
-			expErr: errors.New("invalid SCM module UID"),
-		},
-		"success": {
-			inputUID: testUID,
-			cfg:      &mockIpmctlCfg{},
-		},
-		"ipmctl UpdateFirmware failed": {
-			inputUID: testUID,
-			cfg: &mockIpmctlCfg{
-				updateFirmwareRet: errors.New("mock UpdateFirmware failed"),
-			},
-			expErr: errors.Errorf("failed to update firmware for device %q: mock UpdateFirmware failed", testUID),
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
-
-			mockBinding := newMockIpmctl(tc.cfg)
-			cr, err := newCmdRunner(log, mockBinding, nil, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			err = cr.UpdateFirmware(tc.inputUID, "/dont/care")
-			test.CmpErr(t, tc.expErr, err)
-		})
-	}
-}
+//func TestIpmctl_GetFirmwareStatus(t *testing.T) {
+//	testUID := "TestUID"
+//	testActiveVersion := "1.0.0.1"
+//	testStagedVersion := "2.0.0.2"
+//	fwInfo := ipmctl.DeviceFirmwareInfo{
+//		FWImageMaxSize: 65,
+//		FWUpdateStatus: ipmctl.FWUpdateStatusStaged,
+//	}
+//	_ = copy(fwInfo.ActiveFWVersion[:], testActiveVersion)
+//	_ = copy(fwInfo.StagedFWVersion[:], testStagedVersion)
+//
+//	// Representing a DIMM without a staged FW version
+//	fwInfoUnstaged := ipmctl.DeviceFirmwareInfo{
+//		FWImageMaxSize: 1,
+//		FWUpdateStatus: ipmctl.FWUpdateStatusSuccess,
+//	}
+//	_ = copy(fwInfoUnstaged.ActiveFWVersion[:], testActiveVersion)
+//	_ = copy(fwInfoUnstaged.StagedFWVersion[:], noFirmwareVersion)
+//
+//	for name, tc := range map[string]struct {
+//		inputUID  string
+//		cfg       *mockIpmctlCfg
+//		expErr    error
+//		expResult *storage.ScmFirmwareInfo
+//	}{
+//		"empty deviceUID": {
+//			expErr: errors.New("invalid SCM module UID"),
+//		},
+//		"ipmctl.GetFirmwareInfo failed": {
+//			inputUID: testUID,
+//			cfg: &mockIpmctlCfg{
+//				getFWInfoRet: errors.New("mock GetFirmwareInfo failed"),
+//			},
+//			expErr: errors.Errorf("failed to get firmware info for device %q: mock GetFirmwareInfo failed", testUID),
+//		},
+//		"success": {
+//			inputUID: testUID,
+//			cfg: &mockIpmctlCfg{
+//				fwInfo: fwInfo,
+//			},
+//			expResult: &storage.ScmFirmwareInfo{
+//				ActiveVersion:     testActiveVersion,
+//				StagedVersion:     testStagedVersion,
+//				ImageMaxSizeBytes: fwInfo.FWImageMaxSize * 4096,
+//				UpdateStatus:      storage.ScmUpdateStatusStaged,
+//			},
+//		},
+//		"nothing staged": {
+//			inputUID: testUID,
+//			cfg: &mockIpmctlCfg{
+//				fwInfo: fwInfoUnstaged,
+//			},
+//			expResult: &storage.ScmFirmwareInfo{
+//				ActiveVersion:     testActiveVersion,
+//				ImageMaxSizeBytes: 4096,
+//				UpdateStatus:      storage.ScmUpdateStatusSuccess,
+//			},
+//		},
+//	} {
+//		t.Run(name, func(t *testing.T) {
+//			log, buf := logging.NewTestLogger(t.Name())
+//			defer test.ShowBufferOnFailure(t, buf)
+//
+//			mockBinding := newMockIpmctl(tc.cfg)
+//			cr, err := newCmdRunner(log, mockBinding, nil, nil)
+//			if err != nil {
+//				t.Fatal(err)
+//			}
+//
+//			result, err := cr.GetFirmwareStatus(tc.inputUID)
+//
+//			test.CmpErr(t, tc.expErr, err)
+//			if diff := cmp.Diff(tc.expResult, result); diff != "" {
+//				t.Errorf("wrong firmware info (-want, +got):\n%s\n", diff)
+//			}
+//		})
+//	}
+//}
+//
+//func TestIpmctl_UpdateFirmware(t *testing.T) {
+//	testUID := "testUID"
+//	for name, tc := range map[string]struct {
+//		inputUID string
+//		cfg      *mockIpmctlCfg
+//		expErr   error
+//	}{
+//		"bad UID": {
+//			cfg:    &mockIpmctlCfg{},
+//			expErr: errors.New("invalid SCM module UID"),
+//		},
+//		"success": {
+//			inputUID: testUID,
+//			cfg:      &mockIpmctlCfg{},
+//		},
+//		"ipmctl UpdateFirmware failed": {
+//			inputUID: testUID,
+//			cfg: &mockIpmctlCfg{
+//				updateFirmwareRet: errors.New("mock UpdateFirmware failed"),
+//			},
+//			expErr: errors.Errorf("failed to update firmware for device %q: mock UpdateFirmware failed", testUID),
+//		},
+//	} {
+//		t.Run(name, func(t *testing.T) {
+//			log, buf := logging.NewTestLogger(t.Name())
+//			defer test.ShowBufferOnFailure(t, buf)
+//
+//			mockBinding := newMockIpmctl(tc.cfg)
+//			cr, err := newCmdRunner(log, mockBinding, nil, nil)
+//			if err != nil {
+//				t.Fatal(err)
+//			}
+//
+//			err = cr.UpdateFirmware(tc.inputUID, "/dont/care")
+//			test.CmpErr(t, tc.expErr, err)
+//		})
+//	}
+//}

--- a/src/control/server/storage/scm/ipmctl_region_test.go
+++ b/src/control/server/storage/scm/ipmctl_region_test.go
@@ -54,7 +54,7 @@ func TestIpmctl_checkIpmctl(t *testing.T) {
 				return preTxt + tc.verOut, nil
 			}
 
-			cr, err := newCmdRunner(log, nil, mockRun, nil)
+			cr, err := newCmdRunner(log, mockRun, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -146,7 +146,7 @@ func TestIpmctl_getRegions(t *testing.T) {
 				return tc.cmdOut, tc.cmdErr
 			}
 
-			cr, err := newCmdRunner(log, nil, mockRun, nil)
+			cr, err := newCmdRunner(log, mockRun, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -300,7 +300,7 @@ func TestIpmctl_getPMemState(t *testing.T) {
 				return out, err
 			}
 
-			cr, err := newCmdRunner(log, nil, mockRun, nil)
+			cr, err := newCmdRunner(log, mockRun, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/control/server/storage/scm/ipmctl_test.go
+++ b/src/control/server/storage/scm/ipmctl_test.go
@@ -615,7 +615,7 @@ func TestIpmctl_prep(t *testing.T) {
 				return "", nil
 			}
 
-			cr, err := newCmdRunner(log, nil, mockRun, mockLookPath)
+			cr, err := newCmdRunner(log, mockRun, mockLookPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -837,7 +837,7 @@ func TestIpmctl_prepReset(t *testing.T) {
 				return "", nil
 			}
 
-			cr, err := newCmdRunner(log, nil, mockRun, mockLookPath)
+			cr, err := newCmdRunner(log, mockRun, mockLookPath)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/control/server/storage/scm/ndctl_test.go
+++ b/src/control/server/storage/scm/ndctl_test.go
@@ -158,7 +158,7 @@ func TestNdctl_getNamespaces(t *testing.T) {
 
 			commands = nil // reset to initial values between tests
 
-			cr, err := newCmdRunner(log, nil, mockRun, mockLookPath)
+			cr, err := newCmdRunner(log, mockRun, mockLookPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -238,7 +238,7 @@ func TestNdctl_getNdctlRegions(t *testing.T) {
 
 			commands = nil // reset to initial values between tests
 
-			cr, err := newCmdRunner(log, nil, mockRun, mockLookPath)
+			cr, err := newCmdRunner(log, mockRun, mockLookPath)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Race condition exists where occasionally ipmctl library init fails.
This seems to be due to having initialized libipmctl before 
subsequently calling ipmctl binary during scm scan operation. Fix this
by restricting the use of libipmctl API to SCM firmware calls only and
removing the library init call from the generic command runner.
Adjust tests and mocking as appropriate.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
