### PR TITLE
DAOS-15499 vos: more sanity check for DTX logic

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2681,10 +2681,14 @@ vos_dtx_mark_committable(struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent	*dae = dth->dth_ent;
 
-	if (dae != NULL) {
-		dae->dae_committable = 1;
-		DAE_FLAGS(dae) &= ~(DTE_CORRUPTED | DTE_ORPHAN);
-	}
+	D_ASSERT(dae != NULL);
+
+	D_ASSERTF(dae->dae_prepared == 1,
+		  "DTX " DF_DTI " should be prepared locally before committable\n",
+		  DP_DTI(&dth->dth_xid));
+
+	dae->dae_committable = 1;
+	DAE_FLAGS(dae) &= ~(DTE_CORRUPTED | DTE_ORPHAN);
 }
 
 int
@@ -3133,6 +3137,9 @@ void
 vos_dtx_detach(struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent	*dae = dth->dth_ent;
+
+	D_ASSERTF(dth->dth_local_tx_started == 0,
+		  "DTX " DF_DTI " should end locally before detach\n", DP_DTI(&dth->dth_xid));
 
 	if (dae != NULL) {
 		D_ASSERT(dae->dae_dth == dth);


### PR DESCRIPTION
Local TX should stop before vos_dtx_detach().
DTX should be prepared before being marked as committable.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
