### PR TITLE
DAOS-14317 umem: two fixes for umem cache

### DIFF
--- a/src/common/dav/dav_iface.c
+++ b/src/common/dav/dav_iface.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2023 Intel Corporation.
+ * (C) Copyright 2015-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -95,7 +95,8 @@ dav_obj_open_internal(int fd, int flags, size_t sz, const char *path, struct ume
 		D_ERROR("meta context not defined. WAL commit disabled for %s\n", path);
 	} else {
 		num_pages = (sz + UMEM_CACHE_PAGE_SZ - 1) >> UMEM_CACHE_PAGE_SZ_SHIFT;
-		rc = umem_cache_alloc(store, UMEM_CACHE_PAGE_SZ, num_pages, 0, 0, 0, base, NULL);
+		rc = umem_cache_alloc(store, UMEM_CACHE_PAGE_SZ, num_pages, 0, 0, 0, base,
+				      NULL, NULL);
 		if (rc != 0) {
 			D_ERROR("Could not allocate page cache: rc=" DF_RC "\n", DP_RC(rc));
 			err = rc;

--- a/src/common/dav_v2/dav_iface.c
+++ b/src/common/dav_v2/dav_iface.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2023 Intel Corporation.
+ * (C) Copyright 2015-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -94,7 +94,8 @@ dav_obj_open_internal(int fd, int flags, size_t sz, const char *path, struct ume
 		D_ERROR("meta context not defined. WAL commit disabled for %s\n", path);
 	} else {
 		num_pages = (sz + UMEM_CACHE_PAGE_SZ - 1) >> UMEM_CACHE_PAGE_SZ_SHIFT;
-		rc = umem_cache_alloc(store, UMEM_CACHE_PAGE_SZ, num_pages, 0, 0, 0, base, NULL);
+		rc = umem_cache_alloc(store, UMEM_CACHE_PAGE_SZ, num_pages, 0, 0, 0, base,
+				      NULL, NULL);
 		if (rc != 0) {
 			D_ERROR("Could not allocate page cache: rc=" DF_RC "\n", DP_RC(rc));
 			err = rc;

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -2237,12 +2237,11 @@ cache_pop_free_page(struct umem_cache *cache)
 #define UMEM_CACHE_BMAP_SZ_MAX    (1 << (UMEM_CACHE_PAGE_SHIFT_MAX - \
 					UMEM_CACHE_CHUNK_SZ_SHIFT - UMEM_CHUNK_IDX_SHIFT))
 #define UMEM_CACHE_RSRVD_PAGES	4
-#define UMEM_CACHE_MIN_EVICTABLE_PAGES	2
 
 int
 umem_cache_alloc(struct umem_store *store, uint32_t page_sz, uint32_t md_pgs, uint32_t mem_pgs,
 		 uint32_t max_ne_pgs, uint32_t base_off, void *base,
-		 bool (*is_evictable_fn)(uint32_t pg_id),
+		 bool (*is_evictable_fn)(void *arg, uint32_t pg_id),
 		 int (*pageload_fn)(void *arg, uint32_t pg_id))
 {
 	struct umem_cache	*cache;
@@ -2372,7 +2371,7 @@ error:
 static inline bool
 is_id_evictable(struct umem_cache *cache, uint32_t pg_id)
 {
-	return cache->ca_evictable_fn && cache->ca_evictable_fn(pg_id);
+	return cache->ca_evictable_fn && cache->ca_evictable_fn(cache, pg_id);
 }
 
 static inline void

--- a/src/common/tests/umem_test.c
+++ b/src/common/tests/umem_test.c
@@ -608,7 +608,7 @@ static struct umem_store_ops p2_ops = {
 #define PAGE_NUM_MAX_NE	5
 
 static bool
-is_evictable_fn(uint32_t page_id)
+is_evictable_fn(void *arg, uint32_t page_id)
 {
 	return page_id >= PAGE_NUM_MAX_NE;
 }

--- a/src/common/tests/umem_test.c
+++ b/src/common/tests/umem_test.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -430,7 +430,7 @@ test_page_cache(void **state)
 	arg->ta_store.store_type = DAOS_MD_BMEM;
 
 	rc = umem_cache_alloc(&arg->ta_store, UMEM_CACHE_PAGE_SZ, 3, 0, 0, 0,
-			      (void *)(UMEM_CACHE_PAGE_SZ), NULL);
+			      (void *)(UMEM_CACHE_PAGE_SZ), NULL, NULL);
 	assert_rc_equal(rc, 0);
 
 	cache = arg->ta_store.cache;
@@ -495,7 +495,7 @@ test_many_pages(void **state)
 	umem_cache_free(&arg->ta_store);
 
 	rc = umem_cache_alloc(&arg->ta_store, UMEM_CACHE_PAGE_SZ, LARGE_NUM_PAGES, 0, 0, 0,
-			      (void *)(UMEM_CACHE_PAGE_SZ), NULL);
+			      (void *)(UMEM_CACHE_PAGE_SZ), NULL, NULL);
 	assert_rc_equal(rc, 0);
 
 	cache = arg->ta_store.cache;
@@ -539,7 +539,7 @@ test_many_writes(void **state)
 	umem_cache_free(&arg->ta_store);
 
 	rc = umem_cache_alloc(&arg->ta_store, UMEM_CACHE_PAGE_SZ, LARGE_NUM_PAGES, 0, 0, 0,
-			      (void *)(UMEM_CACHE_PAGE_SZ), NULL);
+			      (void *)(UMEM_CACHE_PAGE_SZ), NULL, NULL);
 	assert_rc_equal(rc, 0);
 
 	cache = arg->ta_store.cache;
@@ -613,6 +613,12 @@ is_evictable_fn(uint32_t page_id)
 	return page_id >= PAGE_NUM_MAX_NE;
 }
 
+static int
+pageload_fn(void *arg, uint32_t page_id)
+{
+	return 0;
+}
+
 static void
 test_p2_basic(void **state)
 {
@@ -627,7 +633,8 @@ test_p2_basic(void **state)
 	arg->ta_store.store_type = DAOS_MD_BMEM;
 
 	rc = umem_cache_alloc(&arg->ta_store, UMEM_CACHE_PAGE_SZ, PAGE_NUM_MD, PAGE_NUM_MEM,
-			      PAGE_NUM_MAX_NE, 4096, (void *)(UMEM_CACHE_PAGE_SZ), is_evictable_fn);
+			      PAGE_NUM_MAX_NE, 4096, (void *)(UMEM_CACHE_PAGE_SZ),
+			      is_evictable_fn, pageload_fn);
 	assert_rc_equal(rc, 0);
 
 	cache = arg->ta_store.cache;
@@ -694,7 +701,8 @@ test_p2_evict(void **state)
 	arg->ta_store.store_type = DAOS_MD_BMEM;
 
 	rc = umem_cache_alloc(&arg->ta_store, UMEM_CACHE_PAGE_SZ, PAGE_NUM_MD, PAGE_NUM_MEM,
-			      PAGE_NUM_MAX_NE, 4096, (void *)(UMEM_CACHE_PAGE_SZ), is_evictable_fn);
+			      PAGE_NUM_MAX_NE, 4096, (void *)(UMEM_CACHE_PAGE_SZ),
+			      is_evictable_fn, pageload_fn);
 	assert_rc_equal(rc, 0);
 
 	cache = arg->ta_store.cache;

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -955,6 +955,8 @@ struct umem_cache {
 	uint64_t		 ca_commit_id;
 	/** Callback to tell if a page is evictable */
 	bool			(*ca_evictable_fn)(uint32_t pg_id);
+	/** Callback being called on page loaded */
+	int			(*ca_pageload_fn)(void *arg, uint32_t pg_id);
 	/** Page stats */
 	uint32_t		 ca_pgs_stats[UMEM_PG_STATS_MAX];
 	/** How many waiters waiting on free page reserve */
@@ -987,13 +989,15 @@ struct umem_cache_chkpt_stats {
  * \param[in]	base_off	Offset of the umem cache base
  * \param[in]	base		Start address of the page cache
  * \param[in]	is_evictable_fn	Callback function to check if page is evictable
+ * \param[in]	pageload_fn	Callback called on page being loaded
  *
  * \return 0 on success
  */
 int
 umem_cache_alloc(struct umem_store *store, uint32_t page_sz, uint32_t md_pgs, uint32_t mem_pgs,
 		 uint32_t max_ne_pgs, uint32_t base_off, void *base,
-		 bool (*is_evictable_fn)(uint32_t pg_id));
+		 bool (*is_evictable_fn)(uint32_t pg_id),
+		 int (*pageload_fn)(void *arg, uint32_t pg_id));
 
 /** Free global cache for umem store.
  *

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -904,6 +904,8 @@ struct umem_action {
 #define UMEM_CACHE_CHUNK_SZ       (1 << UMEM_CACHE_CHUNK_SZ_SHIFT)
 #define UMEM_CACHE_CHUNK_SZ_MASK  (UMEM_CACHE_CHUNK_SZ - 1)
 
+#define UMEM_CACHE_MIN_EVICTABLE_PAGES	2
+
 struct umem_page_info;
 /* MD page */
 struct umem_page {
@@ -954,7 +956,7 @@ struct umem_cache {
 	/** Highest committed transaction ID */
 	uint64_t		 ca_commit_id;
 	/** Callback to tell if a page is evictable */
-	bool			(*ca_evictable_fn)(uint32_t pg_id);
+	bool			(*ca_evictable_fn)(void *arg, uint32_t pg_id);
 	/** Callback being called on page loaded */
 	int			(*ca_pageload_fn)(void *arg, uint32_t pg_id);
 	/** Page stats */
@@ -996,7 +998,7 @@ struct umem_cache_chkpt_stats {
 int
 umem_cache_alloc(struct umem_store *store, uint32_t page_sz, uint32_t md_pgs, uint32_t mem_pgs,
 		 uint32_t max_ne_pgs, uint32_t base_off, void *base,
-		 bool (*is_evictable_fn)(uint32_t pg_id),
+		 bool (*is_evictable_fn)(void *arg, uint32_t pg_id),
 		 int (*pageload_fn)(void *arg, uint32_t pg_id));
 
 /** Free global cache for umem store.


### PR DESCRIPTION
- Remove the redundant check in umem_cache_map(), that could mistakenly fail the call when mapping an evict-able page.
- Fix need_reserve() to deal with the case when "max_ne_pgs - ne_pgs < UMEM_CACHE_RSRVD_PAGES".

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
