### PR TITLE
DAOS-623 ci: Add a workflow for OSSF Scorecard

### DIFF
--- a/.github/actions/provision-cluster/action.yml
+++ b/.github/actions/provision-cluster/action.yml
@@ -40,7 +40,8 @@ runs:
       run: |
         . ci/gha_functions.sh
         inst_repos="${{ env.CP_PR_REPOS }} ${{ github.event.inputs.pr-repos }}"
-        if [[ $inst_repos != *daos@* ]]; then
+        if [ -z "${{ env.CP_RPM_TEST_VERSION }}" ] &&
+           [[ $inst_repos != *daos@* ]]; then
             inst_repos+=" daos@PR-${{ github.event.pull_request.number }}"
             inst_repos+=":${{ github.run_number }}"
         fi

--- a/.github/workflows/bash_unit_testing.yml
+++ b/.github/workflows/bash_unit_testing.yml
@@ -11,6 +11,8 @@ defaults:
   run:
     shell: bash --noprofile --norc -ueo pipefail {0}
 
+permissions: {}
+
 jobs:
   Test-gha-functions:
     name: Tests in ci/gha_functions.sh

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -7,6 +7,8 @@ concurrency:
   group: ci2-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   # reuse the cache from the landing-builds workflow if available, if not then build the images
@@ -14,6 +16,10 @@ jobs:
   Build-and-test:
     name: Run DAOS/NLT tests
     runs-on: ubuntu-22.04
+    permissions:
+      # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
+      checks: write
+      pull-requests: write
     strategy:
       matrix:
         distro: [ubuntu]

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,6 +18,8 @@ name: clang-format
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   pylint:
     name: Clang Format

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -8,6 +8,8 @@ on:
       - master
       - 'release/**'
 
+permissions: {}
+
 jobs:
   make_release:
     name: Create Release

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -4,6 +4,8 @@ name: Doxygen
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
 
   Doxygen:

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -4,6 +4,8 @@ name: Flake
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   flake8-lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/landing-builds.yml
+++ b/.github/workflows/landing-builds.yml
@@ -17,6 +17,8 @@ on:
       - requirements-build.txt
       - requirements-utest.txt
 
+permissions: {}
+
 jobs:
 
   # Build a base Docker image, and save it with a key based on the hash of the dependencies, and a
@@ -86,6 +88,10 @@ jobs:
     name: Run DAOS/NLT tests
     needs: Prepare
     runs-on: ubuntu-22.04
+    permissions:
+      # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
+      checks: write
+      pull-requests: write
     strategy:
       matrix:
         distro: [ubuntu]

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,6 +9,8 @@ on:
       - 'release/*'
   pull_request:
 
+permissions: {}
+
 jobs:
   # Run isort on the tree.
   # This checks .py files only so misses SConstruct and SConscript files are not checked, rather

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -56,7 +56,7 @@ jobs:
           # For private repositories:
           #   - `publish_results` will always be set to `false`, regardless
           #     of the value entered here.
-          # not for now: publish_results: true
+          publish_results: true
 
       # Upload the results as artifacts (optional). Commenting out will disable
       # uploads of run results in SARIF

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,0 +1,76 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '45 8 * * 0'
+  push:
+    branches: ["master"]
+  pull_request:
+
+# Declare default permissions as nothing.
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736  # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in
+          # https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          # not for now: publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db  # v3.pre.node20
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2  # v3.24.9
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -14,6 +14,8 @@ permissions: {}
 jobs:
   example_comment_pr:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     name: Report Jira data to PR comment
     steps:
       - name: Checkout

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -9,6 +9,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
+permissions: {}
 
 jobs:
   example_comment_pr:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,6 +5,8 @@ name: Pylint
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   pylint:
     name: Pylint check

--- a/.github/workflows/rpm-build-and-test-report.yml
+++ b/.github/workflows/rpm-build-and-test-report.yml
@@ -8,14 +8,14 @@ on:
   # for testing before landing
   workflow_dispatch:
 
-permissions:
-  contents: read
-  actions: read
-  checks: write
+permissions: {}
 
 jobs:
   report-vm-1:
     runs-on: [self-hosted, docker]
+    # https://github.com/dorny/test-reporter/issues/149
+    permissions:
+      checks: write
     strategy:
       matrix:
         # TODO: figure out how to determine this matrix

--- a/.github/workflows/rpm-build-and-test.yml
+++ b/.github/workflows/rpm-build-and-test.yml
@@ -26,13 +26,7 @@ defaults:
   run:
     shell: bash --noprofile --norc -ueo pipefail {0}
 
-# https://github.com/dorny/test-reporter/issues/149
-permissions:
-  id-token: write
-  contents: read
-  checks: write
-  # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
-  pull-requests: write
+permissions: {}
 
 jobs:
   # it's a real shame that this step is even needed.  push events have the commit message # in
@@ -363,6 +357,10 @@ jobs:
   Functional:
     name: Functional Testing
     runs-on: [self-hosted, wolf]
+    permissions:
+      # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
+      checks: write
+      pull-requests: write
     timeout-minutes: 7200
     needs: [Build-RPM, Import-commit-message, Calc-functional-matrix, Import-commit-pragmas]
     strategy:
@@ -594,6 +592,10 @@ jobs:
   Functional_Hardware:
     name: Functional Testing on Hardware
     runs-on: [self-hosted, wolf]
+    permissions:
+      # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
+      checks: write
+      pull-requests: write
     timeout-minutes: 7200
     needs: [Import-commit-message, Build-RPM, Calc-functional-hardware-matrix,
             Import-commit-pragmas, Functional]

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -3,6 +3,8 @@ name: Codespell
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
 
   Codespell:

--- a/.github/workflows/version-checks.yml
+++ b/.github/workflows/version-checks.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - 'utils/cq/requirements.txt'
 
+permissions: {}
+
 jobs:
   upgrade-check:
     name: Check for updates

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -13,6 +13,8 @@ on:
       - '**/*.yml'
       - utils/cq/requirements.txt
 
+permissions: {}
+
 jobs:
   yaml-lint:
     runs-on: ubuntu-22.04

--- a/utils/githooks/pre-commit.d/20-flake.sh
+++ b/utils/githooks/pre-commit.d/20-flake.sh
@@ -22,6 +22,11 @@ if ! command -v flake8 > /dev/null 2>&1; then
     exit 0
 fi
 
+if flake8 --version | grep ^6\\.; then
+    echo "  Flake8 >= 6.x does not have the --diff option, skipping."
+    exit 0
+fi
+
 if [ ! -f .flake8 ]; then
     echo "  No .flake8, skipping flake checks"
     exit 0


### PR DESCRIPTION
Also, skip `flake8 --diff` if flake8 >= 6.0.0.

Resolve **Token-Permissions** issues from OSSF Scorecard in all workflows.

Don't install PR daos repo if RPM-test-version was specified.

Add `checks: write` for _EnricoMi/publish-unit-test-result-action_ uses.
