### PR TITLE
DAOS-623 cq: skip jenkinsfile hook if URL not accessible

### DIFF
--- a/utils/githooks/pre-commit.d/20-Jenkinsfile
+++ b/utils/githooks/pre-commit.d/20-Jenkinsfile
@@ -20,9 +20,10 @@ HOST="${HOST:-build.hpdd.intel.com}"
 CURL_VERBOSE=${CURL_VERBOSE:-""}
 CURL_PROXY="${CURL_PROXY:+-x }${CURL_PROXY:-}"
 CURL_OPTS="$CURL_PROXY $CURL_VERBOSE -s"
-if ! output=$(curl $CURL_OPTS -s -X POST -F "jenkinsfile=<${1:-Jenkinsfile}" https://$HOST//pipeline-model-converter/validate); then
-    echo "Failed to check Jenkinsfile"
-    exit 1
+URL="https://$HOST/pipeline-model-converter/validate"
+if ! output=$(curl $CURL_OPTS -s -X POST -F "jenkinsfile=<${1:-Jenkinsfile}" "$URL"); then
+    echo "  Failed to access $URL. Skipping Jenkinsfile check"
+    exit 0
 fi
 
 if echo "$output" | grep -q "Errors encountered validating"; then


### PR DESCRIPTION
Skip-test: true
Skip-tests: true

build.hpdd.intel.com is not accessible externally. Ideally githooks should not use network calls at all but workaround this for now by skipping.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
