### PR TITLE
DAOS-15598 cart: Prevent engines from setting wrong number of contexts

### DIFF
--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -197,18 +197,20 @@ prov_data_init(struct crt_prov_gdata *prov_data, crt_provider_t provider,
 	if (rc != 0)
 		return rc;
 
-	/* Set max number of contexts. Defaults to the number of cores */
-	ctx_num = 0;
-
-	if (crt_is_service())
+	if (crt_is_service()) {
 		ctx_num = CRT_SRV_CONTEXT_NUM;
-	else
+		max_num_ctx = CRT_SRV_CONTEXT_NUM;
+	} else {
+		/* Only limit the number of contexts for clients */
 		d_getenv_uint("CRT_CTX_NUM", &ctx_num);
 
-	if (opt)
-		max_num_ctx = ctx_num ? ctx_num : max(crt_gdata.cg_num_cores, opt->cio_ctx_max_num);
-	else
-		max_num_ctx = ctx_num ? ctx_num : crt_gdata.cg_num_cores;
+		/* Default setting to the number of cores */
+		if (opt)
+			max_num_ctx = ctx_num ? ctx_num :
+				      max(crt_gdata.cg_num_cores, opt->cio_ctx_max_num);
+		else
+			max_num_ctx = ctx_num ? ctx_num : crt_gdata.cg_num_cores;
+	}
 
 	if (max_num_ctx > CRT_SRV_CONTEXT_NUM)
 		max_num_ctx = CRT_SRV_CONTEXT_NUM;


### PR DESCRIPTION
- Prevent engines from using "CRT_CTX_NUM" setting to restrict number of contexts. This option is only proper for scalable endpoint setting which is no longer supported by any provider.

- This is intended to fix a rebuild test that currently sets SEP=true, CRT_CTX_NUM=8 while trying to start engines with more contexts than 8.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
