### PR TITLE
DAOS-15499 dtx: persistently store DTX entry for noop

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4912,12 +4912,6 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 
 	rc = ds_cpd_handle_one_wrap(rpc, dcsh, dcde, dcsr, ioc, dth);
 
-	/* For the case of only containing read sub operations, we will
-	 * generate DTX entry for DTX recovery.
-	 */
-	if (rc == 0 && dth->dth_modification_cnt == 0)
-		rc = vos_dtx_attach(dth, true, false);
-
 	rc = dtx_end(dth, ioc->ioc_coc, rc);
 
 out:

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1668,30 +1668,14 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 	int				 count;
 	int				 rc = 0;
 
+	if (!dth->dth_active)
+		return 0;
+
 	/* There must be vos_dtx_attach() before prepared. */
 	D_ASSERT(dae != NULL);
 	D_ASSERT(cont != NULL);
-	D_ASSERT(dae->dae_aborting == 0);
-	D_ASSERT(dae->dae_aborted == 0);
-
-	if (!dth->dth_active) {
-		/* For resend case, do nothing. */
-		if (likely(dth->dth_prepared))
-			return 0;
-
-		/*
-		 * Even if the transaction modifies nothing locally, we still need to store
-		 * it persistently. Otherwise, the subsequent DTX resync may not find it as
-		 * to regard it as failed transaction and abort it.
-		 */
-		rc = vos_dtx_active(dth);
-
-		DL_CDEBUG(rc != 0, DLOG_ERR, DB_IO, rc,
-			  "Active empty transaction " DF_DTI, DP_DTI(&dth->dth_xid));
-
-		if (rc != 0)
-			return rc;
-	}
+	D_ASSERT(!dae->dae_aborting);
+	D_ASSERT(!dae->dae_aborted);
 
 	if (dth->dth_solo) {
 		if (dth->dth_drop_cmt)
@@ -2693,10 +2677,14 @@ vos_dtx_mark_committable(struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent	*dae = dth->dth_ent;
 
-	if (dae != NULL) {
-		dae->dae_committable = 1;
-		DAE_FLAGS(dae) &= ~(DTE_CORRUPTED | DTE_ORPHAN);
-	}
+	D_ASSERT(dae != NULL);
+
+	D_ASSERTF(dae->dae_prepared == 1,
+		  "DTX " DF_DTI " should be prepared locally before committable\n",
+		  DP_DTI(&dth->dth_xid));
+
+	dae->dae_committable = 1;
+	DAE_FLAGS(dae) &= ~(DTE_CORRUPTED | DTE_ORPHAN);
 }
 
 int
@@ -3145,6 +3133,9 @@ void
 vos_dtx_detach(struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent	*dae = dth->dth_ent;
+
+	D_ASSERTF(dth->dth_local_tx_started == 0,
+		  "DTX " DF_DTI " should end locally before detach\n", DP_DTI(&dth->dth_xid));
 
 	if (dae != NULL) {
 		D_ASSERT(dae->dae_dth == dth);


### PR DESCRIPTION
It is possible that some transaction modifies something on some DTX participants but nothing on the other participants. Under such case, for the DTX participants on which nothing is modified, we also need to store the DTX persistently. Otherwise, the subsequent DTX resync may not find it as to regard it as failed transaction and abort it.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
