### PR TITLE
DAOS-15627 dtx: redunce stack usage for DTX resync to avoid overflow

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -249,7 +249,6 @@ int dtx_handle_reinit(struct dtx_handle *dth);
 void dtx_batched_commit(void *arg);
 void dtx_aggregation_main(void *arg);
 int start_dtx_reindex_ult(struct ds_cont_child *cont);
-void stop_dtx_reindex_ult(struct ds_cont_child *cont);
 void dtx_merge_check_result(int *tgt, int src);
 int dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs,
 		   daos_unit_oid_t *oid, uint32_t version, struct pool_target **p_tgt);

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -700,9 +700,6 @@ fail:
 	ABT_mutex_unlock(cont->sc_mutex);
 
 out:
-	if (!dtx_cont_opened(cont))
-		stop_dtx_reindex_ult(cont);
-
 	D_DEBUG(DB_MD, "Exit DTX resync (%s) for "DF_UUID"/"DF_UUID" with ver %u, rc = %d\n",
 		block ? "block" : "non-block", DP_UUID(po_uuid), DP_UUID(co_uuid), ver, rc);
 
@@ -747,8 +744,8 @@ dtx_resync_one(void *data)
 {
 	struct dtx_scan_args		*arg = data;
 	struct ds_pool_child		*child;
-	vos_iter_param_t		 param = { 0 };
-	struct vos_iter_anchors		 anchor = { 0 };
+	vos_iter_param_t		*param = NULL;
+	struct vos_iter_anchors		*anchor = NULL;
 	struct dtx_container_scan_arg	 cb_arg = { 0 };
 	int				 rc;
 
@@ -757,17 +754,28 @@ dtx_resync_one(void *data)
 		D_GOTO(out, rc = -DER_NONEXIST);
 
 	if (unlikely(child->spc_no_storage))
-		D_GOTO(put, rc = 0);
+		D_GOTO(out, rc = 0);
+
+	D_ALLOC_PTR(param);
+	if (param == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC_PTR(anchor);
+	if (anchor == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	cb_arg.arg = *arg;
-	param.ip_hdl = child->spc_hdl;
-	param.ip_flags = VOS_IT_FOR_MIGRATION;
-	rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchor,
+	param->ip_hdl = child->spc_hdl;
+	param->ip_flags = VOS_IT_FOR_MIGRATION;
+	rc = vos_iterate(param, VOS_ITER_COUUID, false, anchor,
 			 container_scan_cb, NULL, &cb_arg, NULL);
 
-put:
-	ds_pool_child_put(child);
 out:
+	D_FREE(param);
+	D_FREE(anchor);
+	if (child != NULL)
+		ds_pool_child_put(child);
+
 	D_DEBUG(DB_TRACE, DF_UUID" iterate pool done: rc %d\n",
 		DP_UUID(arg->pool_uuid), rc);
 

--- a/src/include/daos/lru.h
+++ b/src/include/daos/lru.h
@@ -167,4 +167,13 @@ daos_lru_is_last_user(struct daos_llink *llink)
 	return llink->ll_ref <= 2;
 }
 
+/**
+ * Return true after current caller released the reference.
+ */
+static inline bool
+daos_lru_left_last_user(struct daos_llink *llink)
+{
+	return (llink->ll_ref - 1) <= 2;
+}
+
 #endif

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -329,6 +329,8 @@ int dtx_cont_register(struct ds_cont_child *cont);
 
 void dtx_cont_deregister(struct ds_cont_child *cont);
 
+void stop_dtx_reindex_ult(struct ds_cont_child *cont, bool wait);
+
 int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 		 daos_epoch_t epoch);
 


### PR DESCRIPTION
Dynamically allcated some large variables that are for DTX iteration and resync to avoid potential ULT stack overflow.

The patch also adjusts DTX reindex ULT stop mechanism to avoid being stopped by DTX resync too early before completed DTX reindex.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
