### PR TITLE
DAOS-15605 rsvc: Create rsvc with VOS DF version

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -33,6 +33,7 @@
 
 /* age of an entry in svc_ops KVS before it may be evicted */
 #define DEFAULT_SVC_OPS_ENTRY_AGE_SEC_MAX 300ULL
+
 /*
  * Pool object
  *

--- a/src/include/daos_srv/rdb.h
+++ b/src/include/daos_srv/rdb.h
@@ -118,8 +118,8 @@ struct rdb_cbs;
 
 /** Database storage methods */
 int rdb_create(const char *path, const uuid_t uuid, uint64_t caller_term, size_t size,
-	       const d_rank_list_t *replicas, struct rdb_cbs *cbs, void *arg,
-	       struct rdb_storage **storagep);
+	       uint32_t vos_df_version, const d_rank_list_t *replicas, struct rdb_cbs *cbs,
+	       void *arg, struct rdb_storage **storagep);
 int rdb_open(const char *path, const uuid_t uuid, uint64_t caller_term, struct rdb_cbs *cbs,
 	     void *arg, struct rdb_storage **storagep);
 void rdb_close(struct rdb_storage *storage);

--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -124,23 +124,23 @@ int ds_rsvc_start_nodb(enum ds_rsvc_class_id class, d_iov_t *id,
 int ds_rsvc_stop_nodb(enum ds_rsvc_class_id class, d_iov_t *id);
 
 int ds_rsvc_start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, uint64_t caller_term,
-		  bool create, size_t size, d_rank_list_t *replicas, void *arg);
+		  bool create, size_t size, uint32_t vos_df_version, d_rank_list_t *replicas,
+		  void *arg);
 int ds_rsvc_stop(enum ds_rsvc_class_id class, d_iov_t *id, uint64_t caller_term, bool destroy);
 int ds_rsvc_stop_all(enum ds_rsvc_class_id class);
 int ds_rsvc_stop_leader(enum ds_rsvc_class_id class, d_iov_t *id,
 			struct rsvc_hint *hint);
 int ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id, const uuid_t dbid,
 		       const d_rank_list_t *ranks, uint64_t caller_term, bool create,
-		       bool bootstrap, size_t size);
+		       bool bootstrap, size_t size, uint32_t vos_df_version);
 int ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id, const d_rank_list_t *ranks,
 		      d_rank_list_t *excluded, uint64_t caller_term, bool destroy);
 enum ds_rsvc_state ds_rsvc_get_state(struct ds_rsvc *svc);
 void ds_rsvc_set_state(struct ds_rsvc *svc, enum ds_rsvc_state state);
-int ds_rsvc_add_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks,
-			   size_t size);
-int ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
-			 d_rank_list_t *ranks, size_t size,
-			 struct rsvc_hint *hint);
+int ds_rsvc_add_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks, size_t size,
+			   uint32_t vos_df_version);
+int ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id, d_rank_list_t *ranks,
+			 size_t size, uint32_t vos_df_version, struct rsvc_hint *hint);
 int ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks);
 int ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, d_iov_t *id, d_rank_list_t *ranks,
 			    struct rsvc_hint *hint);

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -145,7 +145,7 @@ struct pool_map_refresh_ult_arg {
  */
 void ds_pool_rsvc_class_register(void);
 void ds_pool_rsvc_class_unregister(void);
-uint32_t ds_pool_get_vos_pool_df_version(uint32_t pool_global_version);
+uint32_t ds_pool_get_vos_df_version(uint32_t pool_global_version);
 int ds_pool_start_all(void);
 int ds_pool_stop_all(void);
 int ds_pool_hdl_is_from_srv(struct ds_pool *pool, uuid_t hdl);

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1906,7 +1906,7 @@ update_vos_prop_on_targets(void *in)
 		goto out;
 
 	/** If necessary, upgrade the vos pool format */
-	df_version = ds_pool_get_vos_pool_df_version(pool->sp_global_version);
+	df_version = ds_pool_get_vos_df_version(pool->sp_global_version);
 	if (df_version == 0) {
 		ret = -DER_NO_PERM;
 		DL_ERROR(ret, DF_UUID ": pool global version %u no longer supported",

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -26,13 +26,14 @@ static void
 rdb_chkptd_stop(struct rdb *db);
 
 /**
- * Create an RDB replica at \a path with \a uuid, \a size, and \a replicas, and
- * open it with \a cbs and \a arg.
+ * Create an RDB replica at \a path with \a uuid, \a caller_term, \a size,
+ * \a vos_df_version, and \a replicas, and open it with \a cbs and \a arg.
  *
  * \param[in]	path		replica path
  * \param[in]	uuid		database UUID
  * \param[in]	caller_term	caller term if not RDB_NIL_TERM (see rdb_open)
  * \param[in]	size		replica size in bytes
+ * \param[in]	vos_df_version	version of VOS durable format
  * \param[in]	replicas	list of replica ranks
  * \param[in]	cbs		callbacks (not copied)
  * \param[in]	arg		argument for cbs
@@ -40,7 +41,7 @@ rdb_chkptd_stop(struct rdb *db);
  */
 int
 rdb_create(const char *path, const uuid_t uuid, uint64_t caller_term, size_t size,
-	   const d_rank_list_t *replicas, struct rdb_cbs *cbs, void *arg,
+	   uint32_t vos_df_version, const d_rank_list_t *replicas, struct rdb_cbs *cbs, void *arg,
 	   struct rdb_storage **storagep)
 {
 	daos_handle_t	pool;
@@ -51,8 +52,10 @@ rdb_create(const char *path, const uuid_t uuid, uint64_t caller_term, size_t siz
 	int		rc;
 
 	D_DEBUG(DB_MD,
-		DF_UUID ": creating db %s with %u replicas: caller_term=" DF_X64 " size=" DF_U64,
-		DP_UUID(uuid), path, replicas == NULL ? 0 : replicas->rl_nr, caller_term, size);
+		DF_UUID ": creating db %s with %u replicas: caller_term=" DF_X64 " size=" DF_U64
+			" vos_df_version=%u\n",
+		DP_UUID(uuid), path, replicas == NULL ? 0 : replicas->rl_nr, caller_term, size,
+		vos_df_version);
 
 	/*
 	 * Create and open a VOS pool. RDB pools specify VOS_POF_SMALL for
@@ -60,7 +63,7 @@ rdb_create(const char *path, const uuid_t uuid, uint64_t caller_term, size_t siz
 	 * access protection.
 	 */
 	rc = vos_pool_create(path, (unsigned char *)uuid, size, 0 /* nvme_sz */,
-			     VOS_POF_SMALL | VOS_POF_EXCL | VOS_POF_RDB, 0 /* version */, &pool);
+			     VOS_POF_SMALL | VOS_POF_EXCL | VOS_POF_RDB, vos_df_version, &pool);
 	if (rc != 0)
 		goto out;
 	ABT_thread_yield();

--- a/src/rdb/tests/rdb_test.c
+++ b/src/rdb/tests/rdb_test.c
@@ -278,7 +278,7 @@ rdbt_test_rsvc(void)
 	 * leader with a newer term.
 	 */
 	MUST(ds_rsvc_start(DS_RSVC_CLASS_TEST, &svc_id, uuid, 2 /* term */, true /* create */,
-			   DB_CAP, NULL /* replicas */, NULL /* arg */));
+			   DB_CAP, 0 /* vos_df_version */, NULL /* replicas */, NULL /* arg */));
 	rc = ds_rsvc_stop(DS_RSVC_CLASS_TEST, &svc_id, 1 /* term */, true /* destroy */);
 	D_ASSERTF(rc == -DER_STALE, DF_RC"\n", DP_RC(rc));
 
@@ -287,7 +287,7 @@ rdbt_test_rsvc(void)
 	 * leader with a newer term.
 	 */
 	rc = ds_rsvc_start(DS_RSVC_CLASS_TEST, &svc_id, uuid, 3 /* term */, true /* create */,
-			   DB_CAP, NULL /* replicas */, NULL /* arg */);
+			   DB_CAP, 0 /* vos_df_version */, NULL /* replicas */, NULL /* arg */);
 	D_ASSERTF(rc == -DER_ALREADY, DF_RC"\n", DP_RC(rc));
 	rc = ds_rsvc_stop(DS_RSVC_CLASS_TEST, &svc_id, 2 /* term */, true /* destroy */);
 	D_ASSERTF(rc == -DER_STALE, DF_RC"\n", DP_RC(rc));
@@ -641,7 +641,8 @@ rdbt_init_handler(crt_rpc_t *rpc)
 		D_WARN("ranks[%u]=%u\n", ri, ranks->rl_ranks[ri]);
 
 	MUST(ds_rsvc_dist_start(DS_RSVC_CLASS_TEST, &test_svc_id, in->tii_uuid, ranks, RDB_NIL_TERM,
-				true /* create */, true /* bootstrap */, DB_CAP));
+				true /* create */, true /* bootstrap */, DB_CAP,
+				0 /* vos_df_version*/));
 	crt_reply_send(rpc);
 }
 
@@ -768,8 +769,9 @@ rdbt_replicas_add_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		goto out;
 
-	rc = ds_rsvc_add_replicas(DS_RSVC_CLASS_TEST, &test_svc_id, ranks,
-				  DB_CAP, &out->rtmo_hint);
+	rc = ds_rsvc_add_replicas(DS_RSVC_CLASS_TEST, &test_svc_id, ranks, DB_CAP,
+				  0 /* vos_df_ version */, &out->rtmo_hint);
+
 	out->rtmo_failed = ranks;
 
 out:

--- a/src/rsvc/rpc.h
+++ b/src/rsvc/rpc.h
@@ -23,7 +23,7 @@
  * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
  * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
  */
-#define DAOS_RSVC_VERSION 3
+#define DAOS_RSVC_VERSION 4
 /* LIST of internal RPCS in form of:
  * OPCODE, flags, FMT, handler, corpc_hdlr,
  */
@@ -54,6 +54,8 @@ extern struct crt_proto_format rsvc_proto_fmt;
 	((uint32_t)		(sai_class)		CRT_VAR) \
 	((uint32_t)		(sai_flags)		CRT_VAR) \
 	((uint64_t)		(sai_size)		CRT_VAR) \
+	((uint32_t)		(sai_vos_df_version)	CRT_VAR) \
+	((uint32_t)		(sai_padding)		CRT_VAR) \
 	((uint64_t)		(sai_term)		CRT_VAR) \
 	((d_rank_list_t)	(sai_ranks)		CRT_PTR)
 

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -665,7 +665,8 @@ self_only(d_rank_list_t *replicas)
 
 static int
 start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, uint64_t term, bool create,
-      size_t size, d_rank_list_t *replicas, void *arg, struct ds_rsvc **svcp)
+      size_t size, uint32_t vos_df_version, d_rank_list_t *replicas, void *arg,
+      struct ds_rsvc **svcp)
 {
 	struct rdb_storage     *storage;
 	struct ds_rsvc	       *svc = NULL;
@@ -677,8 +678,8 @@ start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, uint64_t term, b
 	svc->s_ref++;
 
 	if (create)
-		rc = rdb_create(svc->s_db_path, svc->s_db_uuid, term, size, replicas, &rsvc_rdb_cbs,
-				svc, &storage);
+		rc = rdb_create(svc->s_db_path, svc->s_db_uuid, term, size, vos_df_version,
+				replicas, &rsvc_rdb_cbs, svc, &storage);
 	else
 		rc = rdb_open(svc->s_db_path, svc->s_db_uuid, term, &rsvc_rdb_cbs, svc, &storage);
 	if (rc != 0)
@@ -805,6 +806,7 @@ ds_rsvc_stop_nodb(enum ds_rsvc_class_id class, d_iov_t *id)
  * \param[in]	caller_term	caller term if not RDB_NIL_TERM (see rdb_open)
  * \param[in]	create		whether to create the replica before starting
  * \param[in]	size		replica size in bytes
+ * \param[in]	vos_df_version	version of VOS durable format
  * \param[in]	replicas	optional initial membership
  * \param[in]	arg		argument for cbs.sc_bootstrap
  *
@@ -814,7 +816,7 @@ ds_rsvc_stop_nodb(enum ds_rsvc_class_id class, d_iov_t *id)
  */
 int
 ds_rsvc_start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, uint64_t caller_term,
-	      bool create, size_t size, d_rank_list_t *replicas, void *arg)
+	      bool create, size_t size, uint32_t vos_df_version, d_rank_list_t *replicas, void *arg)
 {
 	struct ds_rsvc		*svc = NULL;
 	d_list_t		*entry;
@@ -844,7 +846,8 @@ ds_rsvc_start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, uint64_t
 		goto out;
 	}
 
-	rc = start(class, id, db_uuid, caller_term, create, size, replicas, arg, &svc);
+	rc = start(class, id, db_uuid, caller_term, create, size, vos_df_version, replicas, arg,
+		   &svc);
 	if (rc != 0)
 		goto out;
 
@@ -1038,12 +1041,13 @@ ds_rsvc_stop_leader(enum ds_rsvc_class_id class, d_iov_t *id,
 }
 
 int
-ds_rsvc_add_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks, size_t size)
+ds_rsvc_add_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks, size_t size,
+		       uint32_t vos_df_version)
 {
 	int	rc;
 
 	rc = ds_rsvc_dist_start(svc->s_class, &svc->s_id, svc->s_db_uuid, ranks, svc->s_term,
-				true /* create */, false /* bootstrap */, size);
+				true /* create */, false /* bootstrap */, size, vos_df_version);
 
 	/* TODO: Attempt to only add replicas that were successfully started */
 	if (rc != 0)
@@ -1072,8 +1076,8 @@ ds_rsvc_set_state(struct ds_rsvc *svc, enum ds_rsvc_state state)
 }
 
 int
-ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
-		     d_rank_list_t *ranks, size_t size, struct rsvc_hint *hint)
+ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id, d_rank_list_t *ranks, size_t size,
+		     uint32_t vos_df_version, struct rsvc_hint *hint)
 {
 	struct ds_rsvc	*svc;
 	int		 rc;
@@ -1081,7 +1085,7 @@ ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
 	rc = ds_rsvc_lookup_leader(class, id, &svc, hint);
 	if (rc != 0)
 		return rc;
-	rc = ds_rsvc_add_replicas_s(svc, ranks, size);
+	rc = ds_rsvc_add_replicas_s(svc, ranks, size, vos_df_version);
 	ds_rsvc_set_hint(svc, hint);
 	ds_rsvc_put_leader(svc);
 	return rc;
@@ -1169,11 +1173,12 @@ bcast_create(crt_opcode_t opc, bool filter_invert, d_rank_list_t *filter_ranks,
  * \param[in]	create		create replicas first
  * \param[in]	bootstrap	start with an initial list of replicas
  * \param[in]	size		size of each replica in bytes if \a create
+ * \param[in]	vos_df_version	version of VOS durable format if \a create
  */
 int
 ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id, const uuid_t dbid,
 		   const d_rank_list_t *ranks, uint64_t caller_term, bool create, bool bootstrap,
-		   size_t size)
+		   size_t size, uint32_t vos_df_version)
 {
 	crt_rpc_t		*rpc;
 	struct rsvc_start_in	*in;
@@ -1199,6 +1204,7 @@ ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id, const uuid_t dbid,
 	if (bootstrap)
 		in->sai_flags |= RDB_AF_BOOTSTRAP;
 	in->sai_size = size;
+	in->sai_vos_df_version = vos_df_version;
 	in->sai_term = caller_term;
 	in->sai_ranks = (d_rank_list_t *)ranks;
 
@@ -1239,7 +1245,8 @@ ds_rsvc_start_handler(crt_rpc_t *rpc)
 	}
 
 	rc = ds_rsvc_start(in->sai_class, &in->sai_svc_id, in->sai_db_uuid, in->sai_term, create,
-			   in->sai_size, bootstrap ? in->sai_ranks : NULL, NULL /* arg */);
+			   in->sai_size, in->sai_vos_df_version, bootstrap ? in->sai_ranks : NULL,
+			   NULL /* arg */);
 	if (rc == -DER_ALREADY)
 		rc = 0;
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -1537,11 +1537,14 @@ vos_pool_upgrade(daos_handle_t poh, uint32_t version)
 
 	pool_df = pool->vp_pool_df;
 
-	if (version == pool_df->pd_version)
+	if (version <= pool_df->pd_version) {
+		D_INFO(DF_UUID ": Ignore pool durable format upgrade from version %u to %u\n",
+		       DP_UUID(pool->vp_id), pool_df->pd_version, version);
 		return 0;
+	}
 
-	D_DEBUG(DB_MGMT, "Attempting upgrade pool durable format from %d to %d\n",
-		pool_df->pd_version, version);
+	D_INFO(DF_UUID ": Attempting pool durable format upgrade from %d to %d\n",
+	       DP_UUID(pool->vp_id), pool_df->pd_version, version);
 	D_ASSERTF(version > pool_df->pd_version && version <= POOL_DF_VERSION,
 		  "Invalid pool upgrade version %d, current version is %d\n", version,
 		  pool_df->pd_version);


### PR DESCRIPTION
If a pool with an old layout version is served by a DAOS version with a new default layout version, for instance, a 2.4-layout pool served by DAOS 2.5, then any new VOS pools created for this DAOS pool must use the old layout, or downgrading back to the old DAOS version would become impossible.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
