### PR TITLE
DAOS-XXX engine: Add single engine multi-socket mode

### DIFF
--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -132,18 +132,30 @@ extern int		dss_core_nr;
 extern unsigned int	dss_core_offset;
 /** NUMA node to bind to */
 extern int		dss_numa_node;
-/** bitmap describing core allocation */
-extern hwloc_bitmap_t	core_allocation_bitmap;
-/** a copy of the NUMA node object in the topology */
-extern hwloc_obj_t	numa_obj;
-/** number of cores in the given NUMA node */
-extern int		dss_num_cores_numa_node;
+struct dss_numa_info {
+	/** a copy of the NUMA node object in the topology */
+	hwloc_obj_t    ni_obj;
+	/** numa index for this node */
+	int            ni_idx;
+	/** number of cores in the given NUMA node */
+	unsigned int   ni_core_nr;
+	/** Allocation bitmap for numa node */
+	hwloc_bitmap_t ni_core_allocation_bitmap;
+};
+/** Cached numa information */
+extern struct dss_numa_info *numa_info;
 /** Number of offload XS */
 extern unsigned int	dss_tgt_offload_xs_nr;
+/** Number of offload XS per socket */
+extern unsigned int          dss_tgt_offload_per_numa_xs_nr;
+/** Number of tgt XS per socket */
+extern unsigned int          dss_tgt_per_numa_nr;
 /** number of system XS */
 extern unsigned int	dss_sys_xs_nr;
 /** Flag of helper XS as a pool */
 extern bool		dss_helper_pool;
+/** Number of numa nodes in multi-socket mode (always 1 otherwise) */
+extern unsigned int          dss_numa_nr;
 
 /** Shadow dss_get_module_info */
 struct dss_module_info *get_module_info(void);


### PR DESCRIPTION
For simplicity, target and helper count must be a multiple of the number of sockets and there must be fewer helpers than targets.

Let's say K is the number of xstreams of each type that map to a numa node. They are assigned in order with K going to the first node, K to the second, etc.

Enabled with DAOS_MULTISOCKET=1

If not enabled, it should work as it did before.

Required-githooks: true

Change-Id: Ia7801289f4cc9e2cca4649d5132a1a5c0ea2f299

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
