### PR TITLE
Provide workaround for SPDK issue 2683, AMD iommu support

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -173,7 +173,7 @@ bio_spdk_env_init(void)
 	}
 
 	if (geteuid() != 0) {
-		opts.iova_mode = "va";	// workaround for spdk issue #2683 when running as non-root
+		opts.iova_mode = "va"; // workaround for spdk issue #2683 when running as non-root
 	}
 	rc = spdk_env_init(&opts);
 	if (rc != 0) {

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -172,6 +172,9 @@ bio_spdk_env_init(void)
 		}
 	}
 
+	if (geteuid() != 0) {
+		opts.iova_mode = "va";	// workaround for spdk issue #2683 when running as non-root
+	}
 	rc = spdk_env_init(&opts);
 	if (rc != 0) {
 		rc = -DER_INVAL; /* spdk_env_init() returns -1 */

--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -509,6 +509,9 @@ daos_spdk_init(int mem_sz, char *env_ctx, size_t nr_pcil, char **pcil)
 		opts.num_pci_addr = nr_pcil;
 	}
 	opts.name = "daos_server_helper";
+	if (geteuid() != 0) {
+		opts.iova_mode = "va";	// workaround for spdk issue #2683 when running as non-root
+	}
 
 	rc = spdk_env_init(&opts);
 	if (rc < 0) {

--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -510,7 +510,7 @@ daos_spdk_init(int mem_sz, char *env_ctx, size_t nr_pcil, char **pcil)
 	}
 	opts.name = "daos_server_helper";
 	if (geteuid() != 0) {
-		opts.iova_mode = "va";	// workaround for spdk issue #2683 when running as non-root
+		opts.iova_mode = "va"; // workaround for spdk issue #2683 when running as non-root
 	}
 
 	rc = spdk_env_init(&opts);


### PR DESCRIPTION
In SPDK issue 2683, SPDK incorrectly determines that an AMD iommu does not support virtual addressing.  As a result, DAOS engines cannot run as non-root on an AMD server.  Change DAOS to specify iova_mode = "va" when calling spdk_env_init() when running as non-root. This is a workaround until SPDK issue 2683 is fixed.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
