### PR TITLE
DAOS-15627 dtx: redunce stack usage for DTX resync to avoid overflow

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1716,6 +1716,10 @@ start_dtx_reindex_ult(struct ds_cont_child *cont)
 	while (cont->sc_dtx_reindex_abort)
 		ABT_thread_yield();
 
+	if (cont->sc_stopping)
+		return -DER_SHUTDOWN;
+
+	cont->sc_dtx_delay_reset = 0;
 	if (cont->sc_dtx_reindex)
 		return 0;
 
@@ -1733,7 +1737,7 @@ start_dtx_reindex_ult(struct ds_cont_child *cont)
 }
 
 void
-stop_dtx_reindex_ult(struct ds_cont_child *cont)
+stop_dtx_reindex_ult(struct ds_cont_child *cont, bool force)
 {
 	/* DTX reindex has been done or not has not been started. */
 	if (!cont->sc_dtx_reindex)
@@ -1743,9 +1747,15 @@ stop_dtx_reindex_ult(struct ds_cont_child *cont)
 	if (dtx_cont_opened(cont))
 		return;
 
-	/* Do not stop DTX reindex if DTX resync is still in-progress. */
-	if (cont->sc_dtx_resyncing)
+	/*
+	 * For non-force case, do not stop DTX re-index if DTX resync
+	 * is in-progress. Related DTX resource will be released after
+	 * DTX resync globally done (via rebuild scanning).
+	 */
+	if (unlikely(cont->sc_dtx_resyncing && !force)) {
+		cont->sc_dtx_delay_reset = 1;
 		return;
+	}
 
 	cont->sc_dtx_reindex_abort = 1;
 
@@ -1905,7 +1915,7 @@ dtx_cont_open(struct ds_cont_child *cont)
 }
 
 void
-dtx_cont_close(struct ds_cont_child *cont)
+dtx_cont_close(struct ds_cont_child *cont, bool force)
 {
 	struct dss_module_info		*dmi = dss_get_module_info();
 	struct dtx_batched_pool_args	*dbpa;
@@ -1920,7 +1930,7 @@ dtx_cont_close(struct ds_cont_child *cont)
 
 		d_list_for_each_entry(dbca, &dbpa->dbpa_cont_list, dbca_pool_link) {
 			if (dbca->dbca_cont == cont) {
-				stop_dtx_reindex_ult(cont);
+				stop_dtx_reindex_ult(cont, force);
 				d_list_del(&dbca->dbca_sys_link);
 				d_list_add_tail(&dbca->dbca_sys_link,
 						&dmi->dmi_dtx_batched_cont_close_list);
@@ -1928,8 +1938,12 @@ dtx_cont_close(struct ds_cont_child *cont)
 
 				/* If nobody reopen the container during dtx_flush_on_close,
 				 * then reset DTX table in VOS to release related resources.
+				 *
+				 * For non-force case, do not reset DTX table if DTX resync
+				 * is in-progress to avoid redoing DTX re-index. We will do
+				 * that after DTX resync done globally.
 				 */
-				if (!dtx_cont_opened(cont))
+				if (likely(!dtx_cont_opened(cont) && cont->sc_dtx_delay_reset == 0))
 					vos_dtx_cache_reset(cont->sc_hdl, false);
 				return;
 			}

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -249,7 +249,6 @@ int dtx_handle_reinit(struct dtx_handle *dth);
 void dtx_batched_commit(void *arg);
 void dtx_aggregation_main(void *arg);
 int start_dtx_reindex_ult(struct ds_cont_child *cont);
-void stop_dtx_reindex_ult(struct ds_cont_child *cont);
 void dtx_merge_check_result(int *tgt, int src);
 int dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs,
 		   daos_unit_oid_t *oid, uint32_t version, struct pool_target **p_tgt);

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -700,9 +700,6 @@ fail:
 	ABT_mutex_unlock(cont->sc_mutex);
 
 out:
-	if (!dtx_cont_opened(cont))
-		stop_dtx_reindex_ult(cont);
-
 	D_DEBUG(DB_MD, "Exit DTX resync (%s) for "DF_UUID"/"DF_UUID" with ver %u, rc = %d\n",
 		block ? "block" : "non-block", DP_UUID(po_uuid), DP_UUID(co_uuid), ver, rc);
 
@@ -747,8 +744,8 @@ dtx_resync_one(void *data)
 {
 	struct dtx_scan_args		*arg = data;
 	struct ds_pool_child		*child;
-	vos_iter_param_t		 param = { 0 };
-	struct vos_iter_anchors		 anchor = { 0 };
+	vos_iter_param_t		*param = NULL;
+	struct vos_iter_anchors		*anchor = NULL;
 	struct dtx_container_scan_arg	 cb_arg = { 0 };
 	int				 rc;
 
@@ -757,17 +754,28 @@ dtx_resync_one(void *data)
 		D_GOTO(out, rc = -DER_NONEXIST);
 
 	if (unlikely(child->spc_no_storage))
-		D_GOTO(put, rc = 0);
+		D_GOTO(out, rc = 0);
+
+	D_ALLOC_PTR(param);
+	if (param == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC_PTR(anchor);
+	if (anchor == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	cb_arg.arg = *arg;
-	param.ip_hdl = child->spc_hdl;
-	param.ip_flags = VOS_IT_FOR_MIGRATION;
-	rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchor,
+	param->ip_hdl = child->spc_hdl;
+	param->ip_flags = VOS_IT_FOR_MIGRATION;
+	rc = vos_iterate(param, VOS_ITER_COUUID, false, anchor,
 			 container_scan_cb, NULL, &cb_arg, NULL);
 
-put:
-	ds_pool_child_put(child);
 out:
+	D_FREE(param);
+	D_FREE(anchor);
+	if (child != NULL)
+		ds_pool_child_put(child);
+
 	D_DEBUG(DB_TRACE, DF_UUID" iterate pool done: rc %d\n",
 		DP_UUID(arg->pool_uuid), rc);
 

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2023 Intel Corporation.
+ * (C) Copyright 2015-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -67,6 +67,7 @@ struct ds_cont_child {
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_reindex:1,
 				 sc_dtx_reindex_abort:1,
+				 sc_dtx_delay_reset:1,
 				 sc_dtx_registered:1,
 				 sc_props_fetched:1,
 				 sc_stopping:1,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -323,11 +323,13 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 
 int dtx_cont_open(struct ds_cont_child *cont);
 
-void dtx_cont_close(struct ds_cont_child *cont);
+void dtx_cont_close(struct ds_cont_child *cont, bool force);
 
 int dtx_cont_register(struct ds_cont_child *cont);
 
 void dtx_cont_deregister(struct ds_cont_child *cont);
+
+void stop_dtx_reindex_ult(struct ds_cont_child *cont, bool force);
 
 int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 		 daos_epoch_t epoch);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -839,6 +839,17 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 			DP_UUID(entry->ie_couuid), DP_RC(rc));
 		D_GOTO(close, rc);
 	}
+
+	/*
+	 * The container may has been closed by the application, but some resource (DRAM) occupied
+	 * by DTX may be not released because DTX resync was in-progress at that time. When arrive
+	 * here, DTX resync must has completed globally. Let's release related resource.
+	 */
+	if (unlikely(cont_child->sc_dtx_delay_reset == 1)) {
+		stop_dtx_reindex_ult(cont_child, true);
+		vos_dtx_cache_reset(cont_child->sc_hdl, false);
+	}
+
 	cont_child->sc_rebuilding = 1;
 
 	rc = ds_cont_fetch_snaps(rpt->rt_pool->sp_iv_ns, entry->ie_couuid, NULL,


### PR DESCRIPTION
Dynamically allcated some large variables that are for DTX iteration and resync to avoid potential ULT stack overflow.

The patch also adjusts DTX re-index ULT stop logic to avoid being stopped by DTX resync too early before completed DTX re-index.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
