### PR TITLE
DAOS-14834 control: Enable parallel server->engine dRPCs

### DIFF
--- a/src/control/cmd/daos_agent/security_rpc_test.go
+++ b/src/control/cmd/daos_agent/security_rpc_test.go
@@ -73,7 +73,7 @@ func setupTestUnixConn(t *testing.T) (*net.UnixConn, func()) {
 	return newConn, cleanup
 }
 
-func getClientConn(t *testing.T, path string) *drpc.ClientConnection {
+func getClientConn(t *testing.T, path string) drpc.DomainSocketClient {
 	client := drpc.NewClientConnection(path)
 	if err := client.Connect(test.Context(t)); err != nil {
 		t.Fatalf("Failed to connect: %v", err)

--- a/src/control/drpc/drpc_client.go
+++ b/src/control/drpc/drpc_client.go
@@ -186,7 +186,7 @@ func (c *ClientConnection) GetSocketPath() string {
 }
 
 // NewClientConnection creates a new dRPC client
-func NewClientConnection(socket string) *ClientConnection {
+func NewClientConnection(socket string) DomainSocketClient {
 	return &ClientConnection{
 		socketPath: socket,
 		dialer:     &clientDialer{},

--- a/src/control/drpc/drpc_client_test.go
+++ b/src/control/drpc/drpc_client_test.go
@@ -72,12 +72,13 @@ func TestNewClientConnection(t *testing.T) {
 		t.Fatal("Expected a real client")
 		return
 	}
-	test.AssertEqual(t, client.socketPath, testSockPath,
+	clientConn := client.(*ClientConnection)
+	test.AssertEqual(t, clientConn.socketPath, testSockPath,
 		"Should match the path we passed in")
 	test.AssertFalse(t, client.IsConnected(), "Shouldn't be connected yet")
 
 	// Dialer should be the private implementation type
-	_ = client.dialer.(*clientDialer)
+	_ = clientConn.dialer.(*clientDialer)
 }
 
 func TestClient_Connect_Success(t *testing.T) {

--- a/src/control/server/ctl_ranks_rpc_test.go
+++ b/src/control/server/ctl_ranks_rpc_test.go
@@ -217,7 +217,9 @@ func TestServer_CtlSvc_PrepShutdownRanks(t *testing.T) {
 						cfg.setResponseDelay(tc.responseDelay)
 					}
 				}
-				srv.setDrpcClient(newMockDrpcClient(cfg))
+				srv.getDrpcClientFn = func(s string) drpc.DomainSocketClient {
+					return newMockDrpcClient(cfg)
+				}
 			}
 
 			var cancel context.CancelFunc
@@ -911,7 +913,9 @@ func TestServer_CtlSvc_SetEngineLogMasks(t *testing.T) {
 						cfg.setResponseDelay(tc.responseDelay)
 					}
 				}
-				srv.setDrpcClient(newMockDrpcClient(cfg))
+				srv.getDrpcClientFn = func(s string) drpc.DomainSocketClient {
+					return newMockDrpcClient(cfg)
+				}
 			}
 
 			gotResp, gotErr := svc.SetEngineLogMasks(test.Context(t), tc.req)

--- a/src/control/server/ctl_smd_rpc_test.go
+++ b/src/control/server/ctl_smd_rpc_test.go
@@ -702,7 +702,10 @@ func TestServer_CtlSvc_SmdQuery(t *testing.T) {
 						cfg.setSendMsgResponseList(t, mock)
 					}
 				}
-				srv.setDrpcClient(newMockDrpcClient(cfg))
+				mdc := newMockDrpcClient(cfg)
+				srv.getDrpcClientFn = func(s string) drpc.DomainSocketClient {
+					return mdc
+				}
 				srv.ready.SetTrue()
 			}
 			if tc.harnessStopped {
@@ -1577,7 +1580,10 @@ func TestServer_CtlSvc_SmdManage(t *testing.T) {
 						cfg.setSendMsgResponseList(t, mock)
 					}
 				}
-				ei.setDrpcClient(newMockDrpcClient(cfg))
+				mdc := newMockDrpcClient(cfg)
+				ei.getDrpcClientFn = func(s string) drpc.DomainSocketClient {
+					return mdc
+				}
 				ei.ready.SetTrue()
 			}
 			if tc.harnessStopped {

--- a/src/control/server/ctl_svc_test.go
+++ b/src/control/server/ctl_svc_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -79,6 +79,7 @@ func newMockControlServiceFromBackends(t *testing.T, log logging.Logger, cfg *co
 		})
 		if started[idx] {
 			ei.ready.SetTrue()
+			ei.setDrpcSocket("/dontcare")
 		}
 		if err := cs.harness.AddInstance(ei); err != nil {
 			t.Fatal(err)

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2023 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -25,23 +25,29 @@ import (
 )
 
 var (
-	errDRPCNotReady   = errors.New("no dRPC client set (data plane not started?)")
+	errDRPCNotReady   = errors.New("dRPC socket not ready (data plane not started?)")
 	errEngineNotReady = errors.New("engine not ready yet")
 )
 
-func (ei *EngineInstance) setDrpcClient(c drpc.DomainSocketClient) {
+func (ei *EngineInstance) setDrpcSocket(sock string) {
 	ei.Lock()
 	defer ei.Unlock()
-	ei._drpcClient = c
+	ei._drpcSocket = sock
 }
 
-func (ei *EngineInstance) getDrpcClient() (drpc.DomainSocketClient, error) {
+func (ei *EngineInstance) getDrpcSocket() string {
 	ei.RLock()
 	defer ei.RUnlock()
-	if ei._drpcClient == nil {
-		return nil, errDRPCNotReady
+	return ei._drpcSocket
+}
+
+func (ei *EngineInstance) getDrpcClient() drpc.DomainSocketClient {
+	ei.Lock()
+	defer ei.Unlock()
+	if ei.getDrpcClientFn == nil {
+		ei.getDrpcClientFn = drpc.NewClientConnection
 	}
-	return ei._drpcClient, nil
+	return ei.getDrpcClientFn(ei._drpcSocket)
 }
 
 // NotifyDrpcReady receives a ready message from the running Engine
@@ -49,8 +55,7 @@ func (ei *EngineInstance) getDrpcClient() (drpc.DomainSocketClient, error) {
 func (ei *EngineInstance) NotifyDrpcReady(msg *srvpb.NotifyReadyReq) {
 	ei.log.Debugf("%s instance %d drpc ready: %v", build.DataPlaneName, ei.Index(), msg)
 
-	// activate the dRPC client connection to this engine
-	ei.setDrpcClient(drpc.NewClientConnection(msg.DrpcListenerSock))
+	ei.setDrpcSocket(msg.DrpcListenerSock)
 
 	go func() {
 		ei.drpcReady <- msg
@@ -64,11 +69,12 @@ func (ei *EngineInstance) awaitDrpcReady() chan *srvpb.NotifyReadyReq {
 	return ei.drpcReady
 }
 
+func (ei *EngineInstance) isDrpcSocketReady() bool {
+	return ei.getDrpcSocket() != ""
+}
+
 func (ei *EngineInstance) callDrpc(ctx context.Context, method drpc.Method, body proto.Message) (*drpc.Response, error) {
-	dc, err := ei.getDrpcClient()
-	if err != nil {
-		return nil, err
-	}
+	dc := ei.getDrpcClient()
 
 	rankMsg := ""
 	if sb := ei.getSuperblock(); sb != nil && sb.Rank != nil {
@@ -90,6 +96,9 @@ func (ei *EngineInstance) CallDrpc(ctx context.Context, method drpc.Method, body
 	}
 	if !ei.IsReady() {
 		return nil, errEngineNotReady
+	}
+	if !ei.isDrpcSocketReady() {
+		return nil, errDRPCNotReady
 	}
 
 	return ei.callDrpc(ctx, method, body)

--- a/src/control/server/mgmt_cont_test.go
+++ b/src/control/server/mgmt_cont_test.go
@@ -92,7 +92,7 @@ func TestMgmt_ListContainers(t *testing.T) {
 		},
 		"drpc error": {
 			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
-				setupMockDrpcClient(svc, nil, errors.New("mock drpc"))
+				setupSvcDrpcClient(svc, 0, getMockDrpcClient(nil, errors.New("mock drpc")))
 			},
 			req:    validListContReq(),
 			expErr: errors.New("mock drpc"),
@@ -100,23 +100,24 @@ func TestMgmt_ListContainers(t *testing.T) {
 		"bad drpc resp": {
 			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
 				badBytes := makeBadBytes(16)
-				setupMockDrpcClientBytes(svc, badBytes, nil)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, nil))
 			},
 			req:    validListContReq(),
 			expErr: errors.New("unmarshal"),
 		},
 		"success; zero containers": {
 			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
-				setupMockDrpcClient(svc, &mgmtpb.ListContResp{}, nil)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClient(&mgmtpb.ListContResp{}, nil))
 			},
 			req:     validListContReq(),
 			expResp: &mgmtpb.ListContResp{},
 		},
 		"success; multiple containers": {
 			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
-				setupMockDrpcClient(svc, &mgmtpb.ListContResp{
-					Containers: multiConts,
-				}, nil)
+				setupSvcDrpcClient(svc, 0,
+					getMockDrpcClient(&mgmtpb.ListContResp{
+						Containers: multiConts,
+					}, nil))
 			},
 			req: validListContReq(),
 			expResp: &mgmtpb.ListContResp{
@@ -191,7 +192,7 @@ func TestMgmt_ContSetOwner(t *testing.T) {
 		},
 		"drpc error": {
 			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
-				setupMockDrpcClient(svc, nil, errors.New("mock drpc"))
+				setupSvcDrpcClient(svc, 0, getMockDrpcClient(nil, errors.New("mock drpc")))
 			},
 			req:    validContSetOwnerReq(),
 			expErr: errors.New("mock drpc"),
@@ -199,14 +200,14 @@ func TestMgmt_ContSetOwner(t *testing.T) {
 		"bad drpc resp": {
 			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
 				badBytes := makeBadBytes(16)
-				setupMockDrpcClientBytes(svc, badBytes, nil)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, nil))
 			},
 			req:    validContSetOwnerReq(),
 			expErr: errors.New("unmarshal"),
 		},
 		"success": {
 			setupDrpc: func(t *testing.T, svc *mgmtSvc) {
-				setupMockDrpcClient(svc, &mgmtpb.ContSetOwnerResp{}, nil)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClient(&mgmtpb.ContSetOwnerResp{}, nil))
 			},
 			req: validContSetOwnerReq(),
 			expResp: &mgmtpb.ContSetOwnerResp{

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -143,7 +143,8 @@ func TestServer_MgmtSvc_PoolCreateAlreadyExists(t *testing.T) {
 			defer test.ShowBufferOnFailure(t, buf)
 
 			svc := newTestMgmtSvc(t, log)
-			setupMockDrpcClient(svc, tc.queryResp, tc.queryErr)
+			mdc := getMockDrpcClient(tc.queryResp, tc.queryErr)
+			setupSvcDrpcClient(svc, 0, mdc)
 			if _, err := svc.membership.Add(system.MockMember(t, 1, system.MemberStateJoined)); err != nil {
 				t.Fatal(err)
 			}
@@ -404,7 +405,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 				// dRPC call returns junk in the message body
 				badBytes := makeBadBytes(42)
 
-				setupMockDrpcClientBytes(svc, badBytes, err)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, err))
 			},
 			expErr: errors.New("unmarshal"),
 		},
@@ -569,6 +570,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 				mp := storage.NewProvider(log, 0, &engineCfg.Storage,
 					nil, nil, nil, nil)
 				srv := NewEngineInstance(log, mp, nil, r)
+				srv.setDrpcSocket("/dontcare")
 				srv.ready.SetTrue()
 
 				harness := NewEngineHarness(log)
@@ -597,7 +599,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 
 			if tc.setupMockDrpc == nil {
 				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-					setupMockDrpcClient(tc.mgmtSvc, tc.drpcRet, tc.expErr)
+					setupSvcDrpcClient(svc, 0, getMockDrpcClient(tc.drpcRet, tc.expErr))
 				}
 			}
 			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
@@ -641,7 +643,7 @@ func TestServer_MgmtSvc_PoolCreateDownRanks(t *testing.T) {
 
 	dc := newMockDrpcClient(&mockDrpcClientConfig{IsConnectedBool: true})
 	dc.cfg.setSendMsgResponse(drpc.Status_SUCCESS, nil, nil)
-	mgmtSvc.harness.instances[0].(*EngineInstance)._drpcClient = dc
+	mgmtSvc.harness.instances[0].(*EngineInstance).getDrpcClientFn = func(s string) drpc.DomainSocketClient { return dc }
 
 	for _, m := range []*system.Member{
 		system.MockMember(t, 0, system.MemberStateJoined),
@@ -1209,8 +1211,8 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 					cfg.setSendMsgResponseList(t, mock)
 				}
 			}
-			ei := mgmtSvc.harness.instances[0].(*EngineInstance)
-			ei.setDrpcClient(newMockDrpcClient(cfg))
+			mdc := newMockDrpcClient(cfg)
+			setupSvcDrpcClient(mgmtSvc, 0, mdc)
 
 			if tc.req != nil && tc.req.Sys == "" {
 				tc.req.Sys = build.DefaultSystemName
@@ -1227,7 +1229,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 
 			if tc.expDrpcReq != nil {
 				gotReq := new(mgmtpb.PoolDestroyReq)
-				if err := proto.Unmarshal(getLastMockCall(mgmtSvc).Body, gotReq); err != nil {
+				if err := proto.Unmarshal(getLastMockCall(mdc).Body, gotReq); err != nil {
 					t.Fatal(err)
 				}
 				if diff := cmp.Diff(tc.expDrpcReq, gotReq, cmpOpts...); diff != "" {
@@ -1236,7 +1238,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			}
 			if tc.expDrpcEvReq != nil {
 				gotReq := new(mgmtpb.PoolEvictReq)
-				if err := proto.Unmarshal(getLastMockCall(mgmtSvc).Body, gotReq); err != nil {
+				if err := proto.Unmarshal(getLastMockCall(mdc).Body, gotReq); err != nil {
 					t.Fatal(err)
 				}
 				if diff := cmp.Diff(tc.expDrpcEvReq, gotReq, cmpOpts...); diff != "" {
@@ -1245,7 +1247,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			}
 			if tc.expDrpcListContReq != nil {
 				gotReq := new(mgmtpb.ListContReq)
-				if err := proto.Unmarshal(getLastMockCall(mgmtSvc).Body, gotReq); err != nil {
+				if err := proto.Unmarshal(getLastMockCall(mdc).Body, gotReq); err != nil {
 					t.Fatal(err)
 				}
 				if diff := cmp.Diff(tc.expDrpcListContReq, gotReq, cmpOpts...); diff != "" {
@@ -1331,7 +1333,7 @@ func TestServer_MgmtSvc_PoolExtend(t *testing.T) {
 				// dRPC call returns junk in the message body
 				badBytes := makeBadBytes(42)
 
-				setupMockDrpcClientBytes(svc, badBytes, err)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, err))
 			},
 			expErr: errors.New("unmarshal"),
 		},
@@ -1357,7 +1359,7 @@ func TestServer_MgmtSvc_PoolExtend(t *testing.T) {
 
 			if tc.setupMockDrpc == nil {
 				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
+					setupSvcDrpcClient(svc, 0, getMockDrpcClient(tc.expResp, tc.expErr))
 				}
 			}
 			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
@@ -1433,7 +1435,7 @@ func TestServer_MgmtSvc_PoolDrain(t *testing.T) {
 				// dRPC call returns junk in the message body
 				badBytes := makeBadBytes(42)
 
-				setupMockDrpcClientBytes(svc, badBytes, err)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, err))
 			},
 			expErr: errors.New("unmarshal"),
 		},
@@ -1457,7 +1459,7 @@ func TestServer_MgmtSvc_PoolDrain(t *testing.T) {
 
 			if tc.setupMockDrpc == nil {
 				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
+					setupSvcDrpcClient(svc, 0, getMockDrpcClient(tc.expResp, tc.expErr))
 				}
 			}
 			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
@@ -1525,7 +1527,7 @@ func TestServer_MgmtSvc_PoolEvict(t *testing.T) {
 				// dRPC call returns junk in the message body
 				badBytes := makeBadBytes(42)
 
-				setupMockDrpcClientBytes(svc, badBytes, err)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, err))
 			},
 			expErr: errors.New("unmarshal"),
 		},
@@ -1549,7 +1551,7 @@ func TestServer_MgmtSvc_PoolEvict(t *testing.T) {
 
 			if tc.setupMockDrpc == nil {
 				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
+					setupSvcDrpcClient(svc, 0, getMockDrpcClient(tc.expResp, tc.expErr))
 				}
 			}
 			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
@@ -1684,7 +1686,7 @@ func TestPoolGetACL_Success(t *testing.T) {
 			Entries: []string{"A::OWNER@:rw", "A:g:GROUP@:r"},
 		},
 	}
-	setupMockDrpcClient(svc, expectedResp, nil)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClient(expectedResp, nil))
 
 	resp, err := svc.PoolGetACL(test.Context(t), newTestGetACLReq())
 
@@ -1705,7 +1707,7 @@ func TestPoolGetACL_DrpcFailed(t *testing.T) {
 	svc := newTestMgmtSvc(t, log)
 	addTestPools(t, svc.sysdb, mockUUID)
 	expectedErr := errors.New("mock error")
-	setupMockDrpcClient(svc, nil, expectedErr)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClient(nil, expectedErr))
 
 	resp, err := svc.PoolGetACL(test.Context(t), newTestGetACLReq())
 
@@ -1725,7 +1727,7 @@ func TestPoolGetACL_BadDrpcResp(t *testing.T) {
 	// dRPC call returns junk in the message body
 	badBytes := makeBadBytes(12)
 
-	setupMockDrpcClientBytes(svc, badBytes, nil)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, nil))
 
 	resp, err := svc.PoolGetACL(test.Context(t), newTestGetACLReq())
 
@@ -1768,7 +1770,7 @@ func TestPoolOverwriteACL_DrpcFailed(t *testing.T) {
 	svc := newTestMgmtSvc(t, log)
 	addTestPools(t, svc.sysdb, mockUUID)
 	expectedErr := errors.New("mock error")
-	setupMockDrpcClient(svc, nil, expectedErr)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClient(nil, expectedErr))
 
 	resp, err := svc.PoolOverwriteACL(test.Context(t), newTestModifyACLReq())
 
@@ -1788,7 +1790,7 @@ func TestPoolOverwriteACL_BadDrpcResp(t *testing.T) {
 	// dRPC call returns junk in the message body
 	badBytes := makeBadBytes(16)
 
-	setupMockDrpcClientBytes(svc, badBytes, nil)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, nil))
 
 	resp, err := svc.PoolOverwriteACL(test.Context(t), newTestModifyACLReq())
 
@@ -1812,7 +1814,7 @@ func TestPoolOverwriteACL_Success(t *testing.T) {
 			Entries: []string{"A::OWNER@:rw", "A:g:GROUP@:r"},
 		},
 	}
-	setupMockDrpcClient(svc, expectedResp, nil)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClient(expectedResp, nil))
 
 	resp, err := svc.PoolOverwriteACL(test.Context(t), newTestModifyACLReq())
 
@@ -1848,7 +1850,7 @@ func TestPoolUpdateACL_DrpcFailed(t *testing.T) {
 	svc := newTestMgmtSvc(t, log)
 	addTestPools(t, svc.sysdb, mockUUID)
 	expectedErr := errors.New("mock error")
-	setupMockDrpcClient(svc, nil, expectedErr)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClient(nil, expectedErr))
 
 	resp, err := svc.PoolUpdateACL(test.Context(t), newTestModifyACLReq())
 
@@ -1868,7 +1870,7 @@ func TestPoolUpdateACL_BadDrpcResp(t *testing.T) {
 	// dRPC call returns junk in the message body
 	badBytes := makeBadBytes(16)
 
-	setupMockDrpcClientBytes(svc, badBytes, nil)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, nil))
 
 	resp, err := svc.PoolUpdateACL(test.Context(t), newTestModifyACLReq())
 
@@ -1892,7 +1894,7 @@ func TestPoolUpdateACL_Success(t *testing.T) {
 			Entries: []string{"A::OWNER@:rw", "A:g:GROUP@:r"},
 		},
 	}
-	setupMockDrpcClient(svc, expectedResp, nil)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClient(expectedResp, nil))
 
 	resp, err := svc.PoolUpdateACL(test.Context(t), newTestModifyACLReq())
 
@@ -1936,7 +1938,7 @@ func TestPoolDeleteACL_DrpcFailed(t *testing.T) {
 	svc := newTestMgmtSvc(t, log)
 	addTestPools(t, svc.sysdb, mockUUID)
 	expectedErr := errors.New("mock error")
-	setupMockDrpcClient(svc, nil, expectedErr)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClient(nil, expectedErr))
 
 	resp, err := svc.PoolDeleteACL(test.Context(t), newTestDeleteACLReq())
 
@@ -1956,7 +1958,7 @@ func TestPoolDeleteACL_BadDrpcResp(t *testing.T) {
 	// dRPC call returns junk in the message body
 	badBytes := makeBadBytes(16)
 
-	setupMockDrpcClientBytes(svc, badBytes, nil)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, nil))
 
 	resp, err := svc.PoolDeleteACL(test.Context(t), newTestDeleteACLReq())
 
@@ -1980,7 +1982,7 @@ func TestPoolDeleteACL_Success(t *testing.T) {
 			Entries: []string{"A::OWNER@:rw", "A:G:readers@:r"},
 		},
 	}
-	setupMockDrpcClient(svc, expectedResp, nil)
+	setupSvcDrpcClient(svc, 0, getMockDrpcClient(expectedResp, nil))
 
 	resp, err := svc.PoolDeleteACL(test.Context(t), newTestDeleteACLReq())
 
@@ -2046,7 +2048,7 @@ func TestServer_MgmtSvc_PoolQuery(t *testing.T) {
 				// dRPC call returns junk in the message body
 				badBytes := makeBadBytes(42)
 
-				setupMockDrpcClientBytes(svc, badBytes, err)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, err))
 			},
 			expErr: errors.New("unmarshal"),
 		},
@@ -2097,7 +2099,7 @@ func TestServer_MgmtSvc_PoolQuery(t *testing.T) {
 
 			if tc.setupMockDrpc == nil {
 				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
+					setupSvcDrpcClient(svc, 0, getMockDrpcClient(tc.expResp, tc.expErr))
 				}
 			}
 			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
@@ -2120,22 +2122,17 @@ func TestServer_MgmtSvc_PoolQuery(t *testing.T) {
 	}
 }
 
-func getLastMockCall(svc *mgmtSvc) *drpc.Call {
-	mi := svc.harness.instances[0].(*EngineInstance)
-	if mi == nil || mi._drpcClient == nil {
-		return nil
-	}
-
-	return mi._drpcClient.(*mockDrpcClient).SendMsgInputCall
+func getLastMockCall(mdc *mockDrpcClient) *drpc.Call {
+	return mdc.SendMsgInputCall
 }
 
 func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 	for name, tc := range map[string]struct {
-		setupMockDrpc func(_ *mgmtSvc, _ error)
-		drpcResp      *mgmtpb.PoolSetPropResp
-		req           *mgmtpb.PoolSetPropReq
-		expDrpcReq    *mgmtpb.PoolSetPropReq
-		expErr        error
+		getMockDrpc func(error) *mockDrpcClient
+		drpcResp    *mgmtpb.PoolSetPropResp
+		req         *mgmtpb.PoolSetPropReq
+		expDrpcReq  *mgmtpb.PoolSetPropReq
+		expErr      error
 	}{
 		"wrong system": {
 			req:    &mgmtpb.PoolSetPropReq{Id: mockUUID, Sys: "bad"},
@@ -2151,11 +2148,11 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 					},
 				},
 			},
-			setupMockDrpc: func(svc *mgmtSvc, err error) {
+			getMockDrpc: func(err error) *mockDrpcClient {
 				// dRPC call returns junk in the message body
 				badBytes := makeBadBytes(42)
 
-				setupMockDrpcClientBytes(svc, badBytes, err)
+				return getMockDrpcClientBytes(badBytes, err)
 			},
 			expErr: errors.New("unmarshal"),
 		},
@@ -2240,12 +2237,14 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 			if tc.req.Id != mockUUID {
 				addTestPools(t, ms.sysdb, tc.req.Id)
 			}
-			if tc.setupMockDrpc == nil {
-				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-					setupMockDrpcClient(svc, tc.drpcResp, tc.expErr)
+
+			if tc.getMockDrpc == nil {
+				tc.getMockDrpc = func(err error) *mockDrpcClient {
+					return getMockDrpcClient(tc.drpcResp, err)
 				}
 			}
-			tc.setupMockDrpc(ms, tc.expErr)
+			mdc := tc.getMockDrpc(tc.expErr)
+			setupSvcDrpcClient(ms, 0, mdc)
 
 			if tc.req != nil && tc.req.Sys == "" {
 				tc.req.Sys = build.DefaultSystemName
@@ -2257,7 +2256,7 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 			}
 
 			lastReq := new(mgmtpb.PoolSetPropReq)
-			if err := proto.Unmarshal(getLastMockCall(ms).Body, lastReq); err != nil {
+			if err := proto.Unmarshal(getLastMockCall(mdc).Body, lastReq); err != nil {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(tc.expDrpcReq, lastReq, test.DefaultCmpOpts()...); diff != "" {
@@ -2292,7 +2291,7 @@ func TestServer_MgmtSvc_PoolGetProp(t *testing.T) {
 				// dRPC call returns junk in the message body
 				badBytes := makeBadBytes(42)
 
-				setupMockDrpcClientBytes(svc, badBytes, err)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, err))
 			},
 			expErr: errors.New("unmarshal"),
 		},
@@ -2325,7 +2324,7 @@ func TestServer_MgmtSvc_PoolGetProp(t *testing.T) {
 			}
 			if tc.setupMockDrpc == nil {
 				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-					setupMockDrpcClient(svc, tc.drpcResp, tc.expErr)
+					setupSvcDrpcClient(svc, 0, getMockDrpcClient(tc.drpcResp, tc.expErr))
 				}
 			}
 			tc.setupMockDrpc(ms, tc.expErr)
@@ -2387,7 +2386,7 @@ func TestServer_MgmtSvc_PoolUpgrade(t *testing.T) {
 				// dRPC call returns junk in the message body
 				badBytes := makeBadBytes(42)
 
-				setupMockDrpcClientBytes(svc, badBytes, err)
+				setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(badBytes, err))
 			},
 			expErr: errors.New("unmarshal"),
 		},
@@ -2411,7 +2410,7 @@ func TestServer_MgmtSvc_PoolUpgrade(t *testing.T) {
 
 			if tc.setupMockDrpc == nil {
 				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
+					setupSvcDrpcClient(svc, 0, getMockDrpcClient(tc.expResp, tc.expErr))
 				}
 			}
 			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)

--- a/src/control/server/util_test.go
+++ b/src/control/server/util_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -171,7 +171,7 @@ func newMockDrpcClient(cfg *mockDrpcClientConfig) *mockDrpcClient {
 // setupMockDrpcClientBytes sets up the dRPC client for the mgmtSvc to return
 // a set of bytes as a response.
 func setupMockDrpcClientBytes(svc *mgmtSvc, respBytes []byte, err error) {
-	setMockDrpcClient(svc, getMockDrpcClientBytes(respBytes, err))
+	setupSvcDrpcClient(svc, 0, getMockDrpcClientBytes(respBytes, err))
 }
 
 func getMockDrpcClientBytes(respBytes []byte, err error) *mockDrpcClient {
@@ -183,17 +183,19 @@ func getMockDrpcClientBytes(respBytes []byte, err error) *mockDrpcClient {
 // setupMockDrpcClient sets up the dRPC client for the mgmtSvc to return
 // a valid protobuf message as a response.
 func setupMockDrpcClient(svc *mgmtSvc, resp proto.Message, err error) {
-	setMockDrpcClient(svc, getMockDrpcClient(resp, err))
+	setupSvcDrpcClient(svc, 0, getMockDrpcClient(resp, err))
 }
 
+// getMockDrpcClient sets up the dRPC client to return a valid protobuf message as a response.
 func getMockDrpcClient(resp proto.Message, err error) *mockDrpcClient {
 	respBytes, _ := proto.Marshal(resp)
 	return getMockDrpcClientBytes(respBytes, err)
 }
 
-func setMockDrpcClient(svc *mgmtSvc, mdc *mockDrpcClient) {
-	mi := svc.harness.instances[0]
-	mi.(*EngineInstance).setDrpcClient(mdc)
+func setupSvcDrpcClient(svc *mgmtSvc, engineIdx int, mdc *mockDrpcClient) {
+	svc.harness.instances[engineIdx].(*EngineInstance).getDrpcClientFn = func(_ string) drpc.DomainSocketClient {
+		return mdc
+	}
 }
 
 // newTestEngine returns an EngineInstance configured for testing.
@@ -213,6 +215,7 @@ func newTestEngine(log logging.Logger, isAP bool, provider *storage.Provider, en
 	r := engine.NewTestRunner(rCfg, engineCfg[0])
 
 	e := NewEngineInstance(log, provider, nil, r)
+	e.setDrpcSocket("/dontcare")
 	e.setSuperblock(&Superblock{
 		Rank: ranklist.NewRankPtr(0),
 	})


### PR DESCRIPTION
The idea here is to remove the bottleneck in `daos_server` that serializes dRPC calls, to enable `daos_server` to pass along multiple dRPC calls even if the first one hasn't yet returned. In the current master branch, we have a single dRPC client structure that uses RW locks to control access to its internals. dRPC calls that take a long time can potentially impede other commands.

My proposed solution is to create a new `drpc.ClientConnection` for each command that needs to be sent to the `daos_engine`. Each command is handled on its own connection. We were using a connect->send->disconnect pattern on the client connection anyway.

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
