### PR TITLE
DAOS-8331 test: Fix racy unit test

### DIFF
--- a/src/control/lib/telemetry/promexp/httpd_test.go
+++ b/src/control/lib/telemetry/promexp/httpd_test.go
@@ -79,10 +79,17 @@ func TestPromExp_StartExporter(t *testing.T) {
 
 			// Quick tests to make sure the exporter is listening and
 			// that our handlers are invoked.
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", tc.cfg.Port))
-			if err != nil {
-				t.Fatal(err)
+			var resp *http.Response
+			for {
+				var err error
+				resp, err = http.Get(fmt.Sprintf("http://localhost:%d/", tc.cfg.Port))
+				if err == nil {
+					break
+				}
+				log.Errorf("failed to connect to exporter: %+v", err)
+				time.Sleep(100 * time.Millisecond)
 			}
+
 			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
The prometheus exporter test starts a simple http
listener to verify that the setup code works correctly,
and the test should wait until the listener is really
ready.

Required-githooks: true

Change-Id: I904ccf7d2dfb55c6787bb9fae3f8b5232dc47473
Signed-off-by: Michael MacDonald <mjmac@google.com>
