### PR TITLE
DAOS-15329 cq: Disable debug locking macros for coverity.

### DIFF
--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -401,7 +401,7 @@ d_realpath(const char *path, char *resolved_path) _dalloc_;
 #define D_SPIN_INIT(x, y)	__D_PTHREAD_INIT(pthread_spin_init, x, y)
 #define D_RWLOCK_INIT(x, y)	__D_PTHREAD_INIT(pthread_rwlock_init, x, y)
 
-#ifdef DAOS_BUILD_RELEASE
+#if defined(DAOS_BUILD_RELEASE) || defined(__COVERITY__)
 
 #define D_MUTEX_LOCK(x)    __D_PTHREAD(pthread_mutex_lock, x)
 #define D_RWLOCK_WRLOCK(x) __D_PTHREAD(pthread_rwlock_wrlock, x)


### PR DESCRIPTION
The coverity tool gets confused about the use of assert in the
debug version of the logging macros and can think a lock is
being unlocked twice which it reports as a API usage error.

Disable the complex macros for coverity to reduce the instances
of false positives in the tool.

Fixes coverity ID 1975167 and others.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
