### PR TITLE
DAOS-12891 control: Make -o daos_server option subcommand specific

### DIFF
--- a/src/control/cmd/daos_server/auto_test.go
+++ b/src/control/cmd/daos_server/auto_test.go
@@ -156,6 +156,12 @@ func TestDaosServer_Auto_Commands(t *testing.T) {
 			"",
 			errors.New("Unknown command"),
 		},
+		{
+			"Config flag unsupported",
+			"config generate -o /foo",
+			"",
+			errors.New("unknown flag"),
+		},
 	})
 }
 

--- a/src/control/cmd/daos_server/ms_recovery_test.go
+++ b/src/control/cmd/daos_server/ms_recovery_test.go
@@ -19,21 +19,21 @@ func TestDaosServer_MS_Commands_JSON(t *testing.T) {
 
 	runJSONCmdTests(t, log, buf, []jsonCmdTest{
 		{
-			"MS status; JSON",
+			"MS status",
 			"ms status -j",
 			nil,
 			nil,
 			errJSONOutputNotSupported,
 		},
 		{
-			"MS restore; JSON",
+			"MS restore",
 			"ms restore -p foo -j",
 			nil,
 			nil,
 			errJSONOutputNotSupported,
 		},
 		{
-			"MS recover; JSON",
+			"MS recover",
 			"ms recover -j",
 			nil,
 			nil,

--- a/src/control/cmd/daos_server/network_test.go
+++ b/src/control/cmd/daos_server/network_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -127,10 +128,11 @@ func TestDaosServer_Network_Commands_JSON(t *testing.T) {
 		},
 		{
 			"Scan network; config missing",
-			"network scan -j -o /really/unusual/directory/location/non-existent.yml",
+			fmt.Sprintf("network scan -j -o %s", badDir),
 			genSetHelpers(t, log, hardware.NewFabricInterfaceSet(if1), nil),
 			nil,
-			errors.New("failed to load config from /really/unusual/directory/location/non-existent.yml: stat /really/unusual/directory/location/non-existent.yml: no such file or directory"),
+			errors.New(fmt.Sprintf("failed to load config from %s: stat %s: "+
+				"no such file or directory", badDir, badDir)),
 		},
 		{
 			"Scan network; nothing matching cli provider found",

--- a/src/control/cmd/daos_server/storage_nvme_test.go
+++ b/src/control/cmd/daos_server/storage_nvme_test.go
@@ -905,14 +905,15 @@ func TestDaosServer_NVMe_Commands_JSON(t *testing.T) {
 		},
 		{
 			"Scan SSDs; config missing",
-			"nvme scan -j -o /really/unusual/directory/location/non-existent.yml",
+			fmt.Sprintf("nvme scan -j -o %s", badDir),
 			genSetNVMeHelpers(log, bdev.MockBackendConfig{
 				ScanRes: &storage.BdevScanResponse{
 					Controllers: storage.NvmeControllers{c1},
 				},
 			}),
 			nil,
-			errors.New("failed to load config from /really/unusual/directory/location/non-existent.yml: stat /really/unusual/directory/location/non-existent.yml: no such file or directory"),
+			errors.New(fmt.Sprintf("failed to load config from %s: stat %s: "+
+				"no such file or directory", badDir, badDir)),
 		},
 	})
 }

--- a/src/control/cmd/daos_server/storage_scm_test.go
+++ b/src/control/cmd/daos_server/storage_scm_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -25,6 +26,8 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
+
+const badDir = "/really/unusual/directory/location/non-existent.yml"
 
 var (
 	zero uint = 0
@@ -760,7 +763,7 @@ func TestDaosServer_SCM_Commands_JSON(t *testing.T) {
 		},
 		{
 			"Scan namespaces; config missing",
-			"scm scan -j -o /really/unusual/directory/location/non-existent.yml",
+			fmt.Sprintf("scm scan -j -o %s", badDir),
 			genSetSCMHelpers(log, scm.MockBackendConfig{
 				GetModulesRes: storage.ScmModules{
 					storage.MockScmModule(),
@@ -770,7 +773,8 @@ func TestDaosServer_SCM_Commands_JSON(t *testing.T) {
 				},
 			}),
 			nil,
-			errors.New("failed to load config from /really/unusual/directory/location/non-existent.yml: stat /really/unusual/directory/location/non-existent.yml: no such file or directory"),
+			errors.New(fmt.Sprintf("failed to load config from %s: stat %s: "+
+				"no such file or directory", badDir, badDir)),
 		},
 	})
 }


### PR DESCRIPTION
Move ConfigPath field from the mainOpts struct to cfgCmd so that only
commands that embed the latter will inherit the -o flag. Specifically
daos_server config generate command will no longer support -o with the
result that config file input and output behaviour will be unambiguous.

Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
