### PR TITLE
Revert "DAOS-15499 dtx: persistently store DTX entry for noop (#14127)"

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1328,21 +1328,6 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *coh, int resul
 		D_ASSERTF(0, "Unexpected DTX "DF_DTI" status %d\n", DP_DTI(&dth->dth_xid), status);
 	}
 
-	/*
-	 * Even if the transaction modifies nothing locally, we still need to store
-	 * it persistently. Otherwise, the subsequent DTX resync may not find it as
-	 * to regard it as failed transaction and abort it.
-	 */
-	if (result == 0 && !dth->dth_active && !dth->dth_prepared &&
-	    (dth->dth_dist || dth->dth_modification_cnt > 0)) {
-		result = vos_dtx_attach(dth, true, dth->dth_ent != NULL ? true : false);
-		if (unlikely(result < 0)) {
-			D_ERROR(DF_UUID": Fail to persistently store DTX "DF_DTI": "DF_RC"\n",
-				DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), DP_RC(result));
-			goto abort;
-		}
-	}
-
 	if (dth->dth_prepared || dtx_batched_ult_max == 0) {
 		dth->dth_sync = 1;
 		goto sync;
@@ -1462,14 +1447,17 @@ out:
 		result = 0;
 
 	if (!daos_is_zero_dti(&dth->dth_xid)) {
-		/* Drop partial modification and remove the pinned DTX entry. */
-		if (result < 0 && result != -DER_AGAIN && !aborted && !dth->dth_solo &&
-		    dth->dth_modification_cnt > 0)
-			vos_dtx_cleanup(dth, true);
+		if (result < 0) {
+			/* 1. Drop partial modification for distributed transaction.
+			 * 2. Remove the pinned DTX entry.
+			 */
+			if (!aborted)
+				vos_dtx_cleanup(dth, true);
 
-		/* For solo DTX, just let client retry for DER_AGAIN case. */
-		if (result == -DER_AGAIN && dth->dth_solo)
-			result = -DER_INPROGRESS;
+			/* For solo DTX, just let client retry for DER_AGAIN case. */
+			if (result == -DER_AGAIN && dth->dth_solo)
+				result = -DER_INPROGRESS;
+		}
 
 		vos_dtx_rsrvd_fini(dth);
 		vos_dtx_detach(dth);
@@ -1567,20 +1555,7 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 
 	if (dth->dth_local) {
 		result = vos_dtx_local_end(dth, result);
-		D_DEBUG(DB_IO, "Stop the local transaction ver %u: " DF_RC "\n", dth->dth_ver,
-			DP_RC(result));
-		goto fini;
-	}
-
-	/*
-	 * Even if the transaction modifies nothing locally, we still need to store
-	 * it persistently. Otherwise, the subsequent DTX resync may not find it as
-	 * to regard it as failed transaction and abort it.
-	 */
-	if (result == 0 && !dth->dth_active && (dth->dth_dist || dth->dth_modification_cnt > 0))
-		result = vos_dtx_attach(dth, true, dth->dth_ent != NULL ? true : false);
-
-	if (result < 0) {
+	} else if (result < 0) {
 		if (dth->dth_dti_cos_count > 0 && !dth->dth_cos_done) {
 			int	rc;
 
@@ -1601,16 +1576,21 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 				dth->dth_cos_done = 1;
 		}
 
-		/* Drop partial modification and remove the pinned DTX entry. */
-		if (dth->dth_modification_cnt > 0)
-			vos_dtx_cleanup(dth, true);
+		/* 1. Drop partial modification for distributed transaction.
+		 * 2. Remove the pinned DTX entry.
+		 */
+		vos_dtx_cleanup(dth, true);
+	}
 
+	if (!dth->dth_local) {
 		D_DEBUG(DB_IO, "Stop the DTX " DF_DTI " ver %u, dkey %lu: " DF_RC "\n",
 			DP_DTI(&dth->dth_xid), dth->dth_ver, (unsigned long)dth->dth_dkey_hash,
 			DP_RC(result));
+	} else {
+		D_DEBUG(DB_IO, "Stop the local transaction ver %u: " DF_RC "\n", dth->dth_ver,
+			DP_RC(result));
 	}
 
-fini:
 	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
 
 	vos_dtx_rsrvd_fini(dth);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -4912,6 +4912,12 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 
 	rc = ds_cpd_handle_one_wrap(rpc, dcsh, dcde, dcsr, ioc, dth);
 
+	/* For the case of only containing read sub operations, we will
+	 * generate DTX entry for DTX recovery.
+	 */
+	if (rc == 0 && dth->dth_modification_cnt == 0)
+		rc = vos_dtx_attach(dth, true, false);
+
 	rc = dtx_end(dth, ioc->ioc_coc, rc);
 
 out:


### PR DESCRIPTION
This reverts commit ed0b2404e766ea2361b8d6258a27c59afd131c7f.

Test-tag: test_daos_vol_mpich test_ior_small test_mdtest_small test_osa_online_drain_oclass test_create_pool_quantity test_aggregation_punching test_smallfilecount
Skip-func-hw-test-medium-md-on-ssd: false
Skip-func-hw-test-medium: true
Quick-Functional: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
