### PR TITLE
DAOS-15661 object: set correct map version for layout create

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -304,7 +304,7 @@ obj_layout_create(struct dc_object *obj, unsigned int mode, bool refresh)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	obj->cob_md.omd_ver = dc_pool_get_version(pool);
+	obj->cob_md.omd_ver = pool_map_get_version(map->pl_poolmap);
 	obj->cob_md.omd_pdom_lvl = dc_obj_get_pdom(obj);
 	obj->cob_md.omd_fdom_lvl = dc_obj_get_redun_lvl(obj);
 	obj->cob_md.omd_pda = dc_obj_get_pda(obj);


### PR DESCRIPTION
In obj_layout_create, it get pl_map by pl_map_find() without holding dp_map_lock, and then set "omd_ver = dc_pool_get_version(pool)". The map version of the pl_map possibly not same as dc_pool_get_version() if another thread refreshed the dc_pool's pool map.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
