### PR TITLE
DAOS-623 dfuse: Update dfuse thread names.

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1478,7 +1478,7 @@ dfuse_fs_start(struct dfuse_info *dfuse_info, struct dfuse_cont *dfs)
 		if (rc != 0)
 			D_GOTO(err_threads, rc = daos_errno2der(rc));
 
-		pthread_setname_np(eqt->de_thread, "progress");
+		pthread_setname_np(eqt->de_thread, "dfuse progress");
 	}
 
 	rc = dfuse_launch_fuse(dfuse_info, &args);

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -171,7 +171,6 @@ dfuse_bg(struct dfuse_info *dfuse_info)
 int
 dfuse_launch_fuse(struct dfuse_info *dfuse_info, struct fuse_args *args)
 {
-	pthread_t self;
 	int       rc;
 
 	dfuse_info->di_session = dfuse_session_new(args, dfuse_info);
@@ -203,9 +202,6 @@ dfuse_launch_fuse(struct dfuse_info *dfuse_info, struct fuse_args *args)
 	rc = dfuse_send_to_fg(0);
 	if (rc != -DER_SUCCESS)
 		DFUSE_TRA_ERROR(dfuse_info, "Error sending signal to fg: "DF_RC, DP_RC(rc));
-
-	self = pthread_self();
-	pthread_setname_np(self, "main");
 
 	/* Blocking */
 	if (dfuse_info->di_threaded)

--- a/src/client/dfuse/dfuse_thread.c
+++ b/src/client/dfuse/dfuse_thread.c
@@ -93,7 +93,7 @@ start_one(struct dfuse_tm *dtm)
 		D_GOTO(out, rc);
 	}
 
-	pthread_setname_np(dt->dt_id, "fuse worker");
+	pthread_setname_np(dt->dt_id, "dfuse worker");
 
 	d_list_add(&dt->dt_threads, &dtm->tm_threads);
 

--- a/src/client/dfuse/inval.c
+++ b/src/client/dfuse/inval.c
@@ -294,7 +294,7 @@ ival_thread_start(struct dfuse_info *dfuse_info)
 	rc = pthread_create(&ival_thread, NULL, ival_thread_fn, NULL);
 	if (rc != 0)
 		goto out;
-	pthread_setname_np(ival_thread, "invalidator");
+	pthread_setname_np(ival_thread, "dfuse inval");
 
 out:
 	return rc;


### PR DESCRIPTION
When setting these previously I thought they only appeared in
debugger output so they have names which are only meaningful
in that context, but the thread names are also visable in
ps and top and having a process called "main" does not make
sense here.

Do not rename the main dfuse thread, and use a dfuse prefix
for other thread names.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
