### PR TITLE
DAOS-15059 test: reduce parameter for rank_failure test

### DIFF
--- a/src/tests/ftest/erasurecode/rank_failure.yaml
+++ b/src/tests/ftest/erasurecode/rank_failure.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers: 6
   test_clients: 1
-timeout: 2100
+timeout: 1800
 setup:
   start_agents_once: false
   start_servers_once: false
@@ -30,9 +30,9 @@ pool:
   control_method: dmg
 gen_io_conf:
   ranks: "11"
-  targets: "7"
-  dkeys: "3"
-  akeys: "3"
+  targets: "4"
+  dkeys: "2"
+  akeys: "2"
   record_size: "1000"
   obj_num: "3"
   obj_class: "EC_8P2GX"


### PR DESCRIPTION
Originally use parameters "-g 11 -t 7 -o 3 -a 3 -d 3" for daos_gen_io_conf will generate 437 cmd lines that includes 54 exclude/add cmd each will trigger one rebuild. The total time 2100 Second possibly not enough to run those cmds (most time spend for the 54 rebuilds). This patch reduce the parameters "-g 11 -t 4 -o 3 -a 2 -d 2" will generate 181 cmd lines includes 24 exclude/rebuild cmds to reduce testing time.
Reduce the timeout value accordingly.

Test-tag: test_daos_run_io_conf
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
