### PR TITLE
DAOS-15048 control: Display NSID only when populated in storage query

### DIFF
--- a/src/control/cmd/dmg/pretty/storage_test.go
+++ b/src/control/cmd/dmg/pretty/storage_test.go
@@ -1518,25 +1518,28 @@ host1
 						SmdInfo: &control.SmdInfo{
 							Devices: []*storage.SmdDevice{
 								{
-									UUID:      test.MockUUID(0),
-									TargetIDs: []int32{0, 1, 2},
-									HasSysXS:  true,
-									Roles:     storage.BdevRoles{storage.BdevRoleWAL},
-									Ctrlr:     newCtrlr,
+									UUID:             test.MockUUID(0),
+									TargetIDs:        []int32{0, 1, 2},
+									HasSysXS:         true,
+									Roles:            storage.BdevRoles{storage.BdevRoleWAL},
+									Ctrlr:            newCtrlr,
+									CtrlrNamespaceID: 1,
 								},
 								{
-									UUID:      test.MockUUID(1),
-									TargetIDs: []int32{3, 4, 5},
-									Roles:     storage.BdevRoles{storage.BdevRoleMeta | storage.BdevRoleData},
-									Ctrlr:     faultCtrlr,
+									UUID:             test.MockUUID(1),
+									TargetIDs:        []int32{3, 4, 5},
+									Roles:            storage.BdevRoles{storage.BdevRoleMeta | storage.BdevRoleData},
+									Ctrlr:            faultCtrlr,
+									CtrlrNamespaceID: 1,
 								},
 								{
-									UUID:      test.MockUUID(2),
-									TargetIDs: []int32{0, 1, 2},
-									Rank:      1,
-									HasSysXS:  true,
-									Roles:     storage.BdevRoles{storage.BdevRoleWAL},
-									Ctrlr:     unknoCtrlr,
+									UUID:             test.MockUUID(2),
+									TargetIDs:        []int32{0, 1, 2},
+									Rank:             1,
+									HasSysXS:         true,
+									Roles:            storage.BdevRoles{storage.BdevRoleWAL},
+									Ctrlr:            unknoCtrlr,
+									CtrlrNamespaceID: 1,
 								},
 								{
 									UUID:      test.MockUUID(3),
@@ -1555,13 +1558,13 @@ host1
 host1
 -----
   Devices
-    UUID:00000000-0000-0000-0000-000000000000 [TrAddr:0000:8a:00.0 NSID:0]
+    UUID:00000000-0000-0000-0000-000000000000 [TrAddr:0000:8a:00.0 NSID:1]
       Roles:wal SysXS Targets:[0 1 2] Rank:0 State:NEW LED:OFF
-    UUID:00000001-0001-0001-0001-000000000001 [TrAddr:0000:8b:00.0 NSID:0]
+    UUID:00000001-0001-0001-0001-000000000001 [TrAddr:0000:8b:00.0 NSID:1]
       Roles:data,meta Targets:[3 4 5] Rank:0 State:EVICTED LED:ON
-    UUID:00000002-0002-0002-0002-000000000002 [TrAddr:0000:da:00.0 NSID:0]
+    UUID:00000002-0002-0002-0002-000000000002 [TrAddr:0000:da:00.0 NSID:1]
       Roles:wal SysXS Targets:[0 1 2] Rank:1 State:UNKNOWN LED:NA
-    UUID:00000003-0003-0003-0003-000000000003 [TrAddr:0000:db:00.0 NSID:0]
+    UUID:00000003-0003-0003-0003-000000000003 [TrAddr:0000:db:00.0]
       Roles:data,meta Targets:[3 4 5] Rank:1 State:NORMAL LED:QUICK_BLINK
 `,
 		},
@@ -1693,7 +1696,7 @@ host1
 host1
 -----
   Devices
-    TrAddr:0000:db:00.0 NSID:0 [UUID:842c739b-86b5-462f-a7ba-b4a91b674f3d] LED:QUICK_BLINK
+    TrAddr:0000:db:00.0 [UUID:842c739b-86b5-462f-a7ba-b4a91b674f3d] LED:QUICK_BLINK
 `,
 		},
 		"identify led; no uuid specified": {


### PR DESCRIPTION
For certain situations a zero value NVMe namespace ID will be returned
in dmg output, in this case it should be omitted from display output as
valid values are non-zero.
 
Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
