### PR TITLE
DAOS-15750 test: Missing dfuse/mu_perms.py execution

### DIFF
--- a/src/tests/ftest/dfuse/ioctl_pool_handles.py
+++ b/src/tests/ftest/dfuse/ioctl_pool_handles.py
@@ -10,7 +10,10 @@ from telemetry_test_base import TestWithTelemetry
 
 
 class IoctlPoolHandles(TestWithTelemetry):
-    """Verifies interception library is using the same pool/container handles as dfuse."""
+    """Verifies interception library is using the same pool/container handles as dfuse.
+
+    :avocado: recursive
+    """
 
     def test_ioctl_pool_handles(self):
         """JIRA ID: DAOS-8403.

--- a/src/tests/ftest/dfuse/mu_mount.py
+++ b/src/tests/ftest/dfuse/mu_mount.py
@@ -12,7 +12,10 @@ from run_utils import command_as_user, run_remote
 
 
 class DfuseMUMount(DfuseTestBase):
-    """Verifies multi-user dfuse mounting"""
+    """Verifies multi-user dfuse mounting
+
+    :avocado: recursive
+    """
 
     def test_dfuse_mu_mount_basic(self):
         """JIRA ID: DAOS-6540, DAOS-8135.

--- a/src/tests/ftest/dfuse/mu_perms.py
+++ b/src/tests/ftest/dfuse/mu_perms.py
@@ -15,7 +15,10 @@ from user_utils import get_chown_command
 
 
 class DfuseMUPerms(TestWithServers):
-    """Verify dfuse multi-user basic permissions."""
+    """Verify dfuse multi-user basic permissions.
+
+    :avocado: recursive
+    """
 
     def test_dfuse_mu_perms(self):
         """Jira ID: DAOS-10854.


### PR DESCRIPTION
Add missing ':avocado: recursive' from test class docstrings.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: DfuseMUMount DfuseMUPerms IoctlPoolHandles

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
