### PR TITLE
DAOS-15706 telemetry: Fix coverity issue 2555548

### DIFF
--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -104,6 +104,7 @@ dc_pool_metrics_alloc(uuid_t pool_uuid, struct dc_pool_metrics **metrics_p)
 	if (rc != 0) {
 		D_WARN(DF_UUID ": failed to create metrics dir for pool: " DF_RC "\n",
 		       DP_UUID(metrics->dp_uuid), DP_RC(rc));
+		D_FREE(metrics);
 		return rc;
 	}
 


### PR DESCRIPTION
Free the allocated metrics in the failure handler.

Required-githooks: true

Change-Id: I4a0f85b2d5c4dc885b391ba09bb640d800914d6a
Signed-off-by: Michael MacDonald <mjmac@google.com>
