### PR TITLE
DAOS-15728 test: Fix coverity issue 2555526

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -1176,8 +1176,7 @@ dmg_pool_list(const char *dmg_config_file, const char *group,
 		goto out_json;
 	}
 
-	json_object_object_get_ex(dmg_out, "pools", &pool_list);
-	if (pool_list == NULL)
+	if (!json_object_object_get_ex(dmg_out, "pools", &pool_list) || pool_list == NULL)
 		*npools = 0;
 	else
 		*npools = json_object_array_length(pool_list);


### PR DESCRIPTION
Check the rc when parsing the pool list from JSON.

Required-githooks: true

Change-Id: Idc805b948a219a3b688d5817410b6c59246a0f08
Signed-off-by: Michael MacDonald <mjmac@google.com>
