### PR TITLE
DAOS-15773 tests: add "--implicit-deps-unchanged" in scons install command in daos build test

### DIFF
--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -236,12 +236,7 @@ class DaosBuild(DfuseTestBase):
                 'git -C {} submodule update'.format(build_dir),
                 'python3 -m pip install pip --upgrade',
                 'python3 -m pip install -r {}/requirements-build.txt'.format(build_dir),
-                'scons -C {} --jobs {} --build-deps=only'.format(build_dir, build_jobs),
-                'daos filesystem query {}'.format(mount_dir),
-                'daos filesystem evict {}'.format(build_dir),
-                'daos filesystem query {}'.format(mount_dir),
-                'scons -C {} --jobs {}'.format(build_dir, build_jobs),
-                'scons -C {} --jobs {} install'.format(build_dir, build_jobs),
+                'scons -C {} --jobs {} --build-deps=yes install'.format(build_dir, build_jobs),
                 'daos filesystem query {}'.format(mount_dir)]
         for cmd in cmds:
             command = '{};{}'.format(preload_cmd, cmd)

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -236,7 +236,13 @@ class DaosBuild(DfuseTestBase):
                 'git -C {} submodule update'.format(build_dir),
                 'python3 -m pip install pip --upgrade',
                 'python3 -m pip install -r {}/requirements-build.txt'.format(build_dir),
-                'scons -C {} --jobs {} --build-deps=yes install'.format(build_dir, build_jobs),
+                'scons -C {} --jobs {} --build-deps=only'.format(build_dir, build_jobs),
+                'daos filesystem query {}'.format(mount_dir),
+                'daos filesystem evict {}'.format(build_dir),
+                'daos filesystem query {}'.format(mount_dir),
+                'scons -C {} --jobs {}'.format(build_dir, build_jobs),
+                'scons -C {} --jobs {} install --implicit-deps-unchanged'.format(build_dir,
+                                                                                 build_jobs),
                 'daos filesystem query {}'.format(mount_dir)]
         for cmd in cmds:
             command = '{};{}'.format(preload_cmd, cmd)


### PR DESCRIPTION
To speedup scons install with "--implicit-deps-unchanged" to save CI resource. It decreases this step a little over 10 minutes in local test when libpil4dfs.so is loaded.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
