### PR TITLE
DAOS-8331 telemetry: Support client metrics dump without agent

### DIFF
--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -93,7 +93,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 
 	var clientMetricSource *promexp.ClientSource
 	if cmd.cfg.TelemetryExportEnabled() {
-		if clientMetricSource, err = promexp.NewClientSource(ctx); err != nil {
+		if ctx, clientMetricSource, err = promexp.NewClientSource(ctx); err != nil {
 			return errors.Wrap(err, "unable to create client metrics source")
 		}
 		telemetryStart := time.Now()

--- a/src/control/lib/telemetry/promexp/client.go
+++ b/src/control/lib/telemetry/promexp/client.go
@@ -99,10 +99,10 @@ func newClientMetric(log logging.Logger, m telemetry.Metric) *sourceMetric {
 }
 
 // NewClientSource creates a new ClientSource for client metrics.
-func NewClientSource(parent context.Context) (*ClientSource, error) {
+func NewClientSource(parent context.Context) (context.Context, *ClientSource, error) {
 	ctx, err := telemetry.InitClientRoot(parent)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init telemetry")
+		return nil, nil, errors.Wrap(err, "failed to init telemetry")
 	}
 
 	go func(outer, inner context.Context) {
@@ -110,7 +110,7 @@ func NewClientSource(parent context.Context) (*ClientSource, error) {
 		telemetry.Detach(inner)
 	}(parent, ctx)
 
-	return &ClientSource{
+	return ctx, &ClientSource{
 		MetricSource: MetricSource{
 			ctx:      ctx,
 			enabled:  atm.NewBool(true),

--- a/src/control/lib/telemetry/promexp/client_test.go
+++ b/src/control/lib/telemetry/promexp/client_test.go
@@ -131,8 +131,8 @@ func TestPromExp_NewClientCollector(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer test.ShowBufferOnFailure(t, buf)
 
-			ctx := test.MustLogContext(t, log)
-			cs, err := NewClientSource(ctx)
+			parent := test.MustLogContext(t, log)
+			ctx, cs, err := NewClientSource(parent)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/control/lib/telemetry/telemetry.go
+++ b/src/control/lib/telemetry/telemetry.go
@@ -374,7 +374,7 @@ func InitClientRoot(ctx context.Context) (context.Context, error) {
 	return initClientRoot(ctx, ClientJobRootID)
 }
 
-// Init initializes the telemetry bindings
+// Init initializes the DAOS telemetry consumer library.
 func Init(parent context.Context, id uint32) (context.Context, error) {
 	if parent == nil {
 		return nil, errors.New("nil parent context")
@@ -431,6 +431,10 @@ func addEphemeralDir(path string, shmSize uint64) error {
 // segment linked into the agent-managed tree.
 func SetupClientRoot(ctx context.Context, jobid string, pid, shm_key int) error {
 	log := logging.FromContext(ctx)
+
+	if _, err := getHandle(ctx); err != nil {
+		return errors.Wrap(daos.NotInit, "client telemetry library not initialized")
+	}
 
 	if err := addEphemeralDir(jobid, ClientJobMax*C.D_TM_METRIC_SIZE); err != nil {
 		if err != daos.Exists {

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -1238,8 +1238,8 @@ dc_mgmt_tm_register(const char *sys, const char *jobid, key_t shm_key, uid_t *ow
 		goto out_dresp;
 	}
 	if (resp->status != 0) {
-		D_ERROR("SetupClientTelemetry(%s) failed: " DF_RC "\n", req.sys,
-			DP_RC(resp->status));
+		if (resp->status != -DER_UNINIT) /* not necessarily an error */
+			DL_ERROR(resp->status, "SetupClientTelemetry() failed");
 		rc = resp->status;
 		goto out_resp;
 	}


### PR DESCRIPTION
Enable scenarios where client telemetry is collected and dumped
to a CSV without agent config changes or involvement.

Setting D_CLIENT_METRICS_DUMP_DIR in the client process
environment will enable client telemetry dump to the
specified directory even if the agent is not configured
to export telemetry.

Features: telemetry
Required-githooks: true
Change-Id: I243d11a2e00059ef3115d392d63c523048477122
Signed-off-by: Michael MacDonald <mjmac@google.com>
