### PR TITLE
DAOS-15681 bio: store scm_sz in SMD

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -457,7 +457,8 @@ int bio_mc_destroy(struct bio_xs_context *xs_ctxt, uuid_t pool_id, enum bio_mc_f
 
 static int
 bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz,
-		enum smd_dev_type st, enum bio_mc_flags flags, spdk_blob_id *blob_id)
+		enum smd_dev_type st, enum bio_mc_flags flags, spdk_blob_id *blob_id,
+		uint64_t scm_sz)
 {
 	struct blob_msg_arg		 bma = { 0 };
 	struct blob_cp_arg		*ba = &bma.bma_cp_arg;
@@ -541,9 +542,10 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz,
 						     blob_sz);
 			else
 				rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st,
-						      blob_sz);
+						      blob_sz, scm_sz);
 		} else {
-			rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st, blob_sz);
+			rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st, blob_sz,
+					      0);
 		}
 
 		if (rc != 0) {
@@ -627,7 +629,7 @@ default_wal_sz(uint64_t meta_sz)
 	return wal_sz;
 }
 
-int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t meta_sz,
+int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t scm_sz, uint64_t meta_sz,
 		  uint64_t wal_sz, uint64_t data_sz, enum bio_mc_flags flags)
 {
 	int			 rc = 0, rc1;
@@ -642,7 +644,7 @@ int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t meta_
 	if (data_sz > 0 && bio_nvme_configured(SMD_DEV_TYPE_DATA)) {
 		D_ASSERT(!(flags & BIO_MC_FL_RDB));
 		rc = bio_blob_create(pool_id, xs_ctxt, data_sz, SMD_DEV_TYPE_DATA, flags,
-				     &data_blobid);
+				     &data_blobid, 0);
 		if (rc)
 			return rc;
 	}
@@ -656,9 +658,24 @@ int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t meta_
 			meta_sz, default_cluster_sz());
 		rc = -DER_INVAL;
 		goto delete_data;
+	} else if (meta_sz < scm_sz) {
+		D_ERROR("Meta blob size("DF_U64") is less than scm size("DF_U64")\n",
+			meta_sz, scm_sz);
+		rc = -DER_INVAL;
+		goto delete_data;
+	} else if (scm_sz == meta_sz) {
+		scm_sz = 0;
 	}
 
-	rc = bio_blob_create(pool_id, xs_ctxt, meta_sz, SMD_DEV_TYPE_META, flags, &meta_blobid);
+	if (scm_sz != 0 && (flags & BIO_MC_FL_RDB)) {
+		D_ERROR("RDB doesn't allow scm_sz("DF_U64") != meta_sz("DF_U64")\n",
+			scm_sz, meta_sz);
+		rc = -DER_INVAL;
+		goto delete_data;
+	}
+
+	rc = bio_blob_create(pool_id, xs_ctxt, meta_sz, SMD_DEV_TYPE_META, flags, &meta_blobid,
+			     scm_sz);
 	if (rc)
 		goto delete_data;
 
@@ -671,7 +688,7 @@ int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t meta_
 	if (wal_sz == 0 || wal_sz < default_cluster_sz())
 		wal_sz = default_wal_sz(meta_sz);
 
-	rc = bio_blob_create(pool_id, xs_ctxt, wal_sz, SMD_DEV_TYPE_WAL, flags, &wal_blobid);
+	rc = bio_blob_create(pool_id, xs_ctxt, wal_sz, SMD_DEV_TYPE_WAL, flags, &wal_blobid, 0);
 	if (rc)
 		goto delete_meta;
 

--- a/src/bio/smd/smd_internal.h
+++ b/src/bio/smd/smd_internal.h
@@ -27,6 +27,8 @@ extern char TABLE_TGTS[SMD_DEV_TYPE_MAX][SMD_DEV_NAME_MAX];
 
 extern char TABLE_POOLS[SMD_DEV_TYPE_MAX][SMD_DEV_NAME_MAX];
 
+extern char TABLE_POOLS_EX[SMD_DEV_TYPE_MAX][SMD_DEV_NAME_MAX];
+
 #define SMD_MAX_TGT_CNT		64
 
 /** callback parameter for smd_db_traverse */

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -36,9 +36,9 @@ struct smd_pool {
 };
 
 char TABLE_POOLS_EX[SMD_DEV_TYPE_MAX][SMD_DEV_NAME_MAX] = {
-	"data_pool_ex",
-	"meta_pool_ex",
-	"wal_pool_ex",
+	"ex_data_pool",
+	"ex_meta_pool",
+	"ex_wal_pool",
 };
 
 struct smd_pool_meta {

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -941,6 +941,7 @@ enum bio_mc_flags {
  *
  * \param[in]	xs_ctxt		Per-xstream NVMe context
  * \param[in]	pool_id		Pool UUID
+ * \param[in]	scm_sz		VOS file size in bytes
  * \param[in]	meta_sz		Meta blob size in bytes
  * \param[in]	wal_sz		WAL blob in bytes
  * \param[in]	data_sz		Data blob in bytes
@@ -948,8 +949,8 @@ enum bio_mc_flags {
  *
  * \return			Zero on success, negative value on error.
  */
-int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t meta_sz,
-		  uint64_t wal_sz, uint64_t data_sz, enum bio_mc_flags flags);
+int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t scm_sz,
+		  uint64_t meta_sz, uint64_t wal_sz, uint64_t data_sz, enum bio_mc_flags flags);
 
 /*
  * Destroy Meta/Data/WAL blobs

--- a/src/include/daos_srv/smd.h
+++ b/src/include/daos_srv/smd.h
@@ -56,6 +56,7 @@ struct smd_dev_info {
 struct smd_pool_info {
 	d_list_t	 spi_link;
 	uuid_t		 spi_id;
+	uint64_t	 spi_scm_sz;
 	uint64_t	 spi_blob_sz[SMD_DEV_TYPE_MAX];
 	uint16_t	 spi_flags[SMD_DEV_TYPE_MAX];
 	uint16_t	 spi_tgt_cnt[SMD_DEV_TYPE_MAX];
@@ -169,12 +170,13 @@ int smd_dev_replace(uuid_t old_id, uuid_t new_id, unsigned int old_roles);
  * \param [IN]	tgt_id		Target ID
  * \param [IN]	blob_id		Blob ID
  * \param [IN]	smd_type	SMD type
- * \param [IN]	blob_sz		Blob size
+ * \param [IN]	blob_sz		Blob size in bytes
+ * \param [IN]	scm_sz		VOS file size in bytes
  *
  * \return			Zero on success, negative value on error
  */
 int smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		     enum smd_dev_type smd_type, uint64_t blob_sz);
+		     enum smd_dev_type smd_type, uint64_t blob_sz, uint64_t scm_sz);
 
 /* Assign a blob to a RDB pool target */
 int smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -576,7 +576,9 @@ recreate_pooltgts()
 				DP_UUID(pool_info->spi_id), DP_RC(rc));
 			goto out;
 		}
-		rc = tgt_recreate(pool_info->spi_id, pool_info->spi_blob_sz[SMD_DEV_TYPE_META],
+
+		D_ASSERT(pool_info->spi_scm_sz > 0);
+		rc = tgt_recreate(pool_info->spi_id, pool_info->spi_scm_sz,
 				  pool_info->spi_tgt_cnt[SMD_DEV_TYPE_META], rdb_blob_sz);
 		if (rc)
 			goto out;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -432,7 +432,8 @@ pool_child_recreate(struct ds_pool_child *child)
 	}
 
 	rc = vos_pool_create(path, child->spc_uuid, 0 /* scm_sz */,
-			     pool_info->spi_blob_sz[SMD_DEV_TYPE_DATA], 0 /* meta_sz */,
+			     pool_info->spi_blob_sz[SMD_DEV_TYPE_DATA],
+			     pool_info->spi_blob_sz[SMD_DEV_TYPE_META],
 			     0 /* flags */, 0 /* version */, NULL);
 	if (rc)
 		DL_ERROR(rc, DF_UUID": Create VOS pool failed.", DP_UUID(child->spc_uuid));

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1746,7 +1746,7 @@ sync_cb(struct ddbs_sync_info *info, void *cb_args)
 		D_WARN("delete target failed: " DF_RC "\n", DP_RC(rc));
 
 	rc = smd_pool_add_tgt(pool_id, info->dsi_hdr->bbh_vos_id,
-			      info->dsi_hdr->bbh_blob_id, st, blob_size);
+			      info->dsi_hdr->bbh_blob_id, st, blob_size, 0);
 	if (!SUCCESS(rc)) {
 		D_ERROR("add target failed: "DF_RC"\n", DP_RC(rc));
 		args->sync_rc = rc;

--- a/src/vos/tests/wal_ut.c
+++ b/src/vos/tests/wal_ut.c
@@ -29,7 +29,7 @@ ut_mc_init(struct bio_ut_args *args, uint64_t meta_sz, uint64_t wal_sz, uint64_t
 	int	rc, ret;
 
 	uuid_generate(args->bua_pool_id);
-	rc = bio_mc_create(args->bua_xs_ctxt, args->bua_pool_id, meta_sz, wal_sz, data_sz, 0);
+	rc = bio_mc_create(args->bua_xs_ctxt, args->bua_pool_id, 0, meta_sz, wal_sz, data_sz, 0);
 	if (rc) {
 		D_ERROR("UT MC create failed. "DF_RC"\n", DP_RC(rc));
 		return rc;

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -780,10 +780,10 @@ vos_pmemobj_create(const char *path, uuid_t pool_id, const char *layout,
 	}
 
 	D_DEBUG(DB_MGMT, "Create BIO meta context for xs:%p pool:"DF_UUID" "
-		"meta_sz: %zu, nvme_sz: %zu wal_sz:%zu\n",
-		xs_ctxt, DP_UUID(pool_id), meta_sz, nvme_sz, wal_sz);
+		"scm_sz: %zu meta_sz: %zu, nvme_sz: %zu wal_sz:%zu\n",
+		xs_ctxt, DP_UUID(pool_id), scm_sz, meta_sz, nvme_sz, wal_sz);
 
-	rc = bio_mc_create(xs_ctxt, pool_id, meta_sz, wal_sz, nvme_sz, mc_flags);
+	rc = bio_mc_create(xs_ctxt, pool_id, scm_sz, meta_sz, wal_sz, nvme_sz, mc_flags);
 	if (rc != 0) {
 		D_ERROR("Failed to create BIO meta context for xs:%p pool:"DF_UUID". "DF_RC"\n",
 			xs_ctxt, DP_UUID(pool_id), DP_RC(rc));


### PR DESCRIPTION
In md-on-ssd phase 2, the scm_sz (VOS file size) could be smaller than the meta_sz (meta blob size), then we need to store an extra scm_sz in SMD, so that on engine start, this scm_sz could be retrieved from SMD for VOS file re-creation.

To make the SMD compatible with pmem & md-on-ssd phase 1, a new table named "meta_pool_ex" is introduced for storing scm_sz.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
