### PR TITLE
DAOS-15769 chk: restart PS with full functionality after check

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2023 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -391,39 +391,30 @@ chk_pool_remove_nowait(struct chk_pool_rec *cpr)
 		D_WARN("Failed to delete pool record: "DF_RC"\n", DP_RC(rc));
 }
 
-void
-chk_pool_start_svc(struct chk_pool_rec *cpr, int *ret)
+int
+chk_pool_restart_svc(struct chk_pool_rec *cpr)
 {
 	int	rc = 0;
 
+	/* Stop the pool, then restart it with full pool service. */
+
 	ABT_mutex_lock(cpr->cpr_mutex);
-
-	if (!cpr->cpr_started) {
-		rc = ds_pool_start_with_svc(cpr->cpr_uuid);
-		if (rc == 0)
-			cpr->cpr_started = 1;
-		else
-			D_WARN("Cannot start (1) the pool for "DF_UUIDF" after check: "DF_RC"\n",
-			       DP_UUID(cpr->cpr_uuid), DP_RC(rc));
-	}
-
-	if (cpr->cpr_started && !cpr->cpr_start_post) {
-		rc = ds_pool_chk_post(cpr->cpr_uuid);
-		if (rc != 0) {
-			D_WARN("Cannot post handle (1) pool start for "
-			       DF_UUIDF" after check: "DF_RC"\n",
-			       DP_UUID(cpr->cpr_uuid), DP_RC(rc));
-			/* Failed to post handle pool start, have to stop it. */
+	if (!cpr->cpr_start_post) {
+		if (cpr->cpr_started)
 			chk_pool_shutdown(cpr, true);
+
+		rc = ds_pool_start_after_check(cpr->cpr_uuid);
+		if (rc != 0) {
+			D_WARN("Cannot start full PS for "DF_UUIDF" after CR check: "DF_RC"\n",
+			       DP_UUID(cpr->cpr_uuid), DP_RC(rc));
 		} else {
+			cpr->cpr_started = 1;
 			cpr->cpr_start_post = 1;
 		}
 	}
-
 	ABT_mutex_unlock(cpr->cpr_mutex);
 
-	if (ret != NULL)
-		*ret = rc;
+	return rc;
 }
 
 static void
@@ -460,7 +451,7 @@ chk_pool_wait(struct chk_pool_rec *cpr)
 }
 
 void
-chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, int status, uint32_t phase, int *ret)
+chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, uint32_t status, uint32_t phase, int *ret)
 {
 	struct chk_bookmark	*cbk;
 	struct chk_pool_rec	*cpr;
@@ -805,10 +796,6 @@ chk_pool_handle_notify(struct chk_instance *ins, struct chk_iv *iv)
 
 	if (iv->ci_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKED) {
 		cpr->cpr_done = 1;
-		if (iv->ci_pool_destroyed) {
-			cpr->cpr_destroyed = 1;
-			cpr->cpr_not_export_ps = 1;
-		}
 	} else if (iv->ci_pool_status == CHK__CHECK_POOL_STATUS__CPS_FAILED ||
 		   iv->ci_pool_status == CHK__CHECK_POOL_STATUS__CPS_IMPLICATED) {
 		cpr->cpr_skip = 1;
@@ -818,22 +805,21 @@ chk_pool_handle_notify(struct chk_instance *ins, struct chk_iv *iv)
 		D_GOTO(out, rc = -DER_NOTAPPLICABLE);
 	}
 
-	if (!ins->ci_is_leader && !cpr->cpr_destroyed && cpr->cpr_done) {
-		if (iv->ci_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKED &&
-		    !cpr->cpr_not_export_ps) {
-			chk_pool_start_svc(cpr, NULL);
-		} else if (ins->ci_sched_running && !ins->ci_sched_exiting) {
-			chk_pool_get(cpr);
-			d_list_add_tail(&cpr->cpr_shutdown_link, &ins->ci_pool_shutdown_list);
-		}
-	}
-
-	if (iv->ci_phase != cbk->cb_phase || iv->ci_pool_status != cbk->cb_pool_status ||
-	    cpr->cpr_destroyed) {
+	if (iv->ci_phase != cbk->cb_phase || iv->ci_pool_status != cbk->cb_pool_status) {
 		cbk->cb_phase = iv->ci_phase;
 		cbk->cb_pool_status = iv->ci_pool_status;
 		uuid_unparse_lower(cpr->cpr_uuid, uuid_str);
 		rc = chk_bk_update_pool(cbk, uuid_str);
+	}
+
+	if (rc == 0 && !ins->ci_is_leader && cpr->cpr_done) {
+		if (iv->ci_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKED &&
+		    !cpr->cpr_not_export_ps) {
+			rc = chk_pool_restart_svc(cpr);
+		} else if (ins->ci_sched_running && !ins->ci_sched_exiting) {
+			chk_pool_get(cpr);
+			d_list_add_tail(&cpr->cpr_shutdown_link, &ins->ci_pool_shutdown_list);
+		}
 	}
 
 out:

--- a/src/chk/chk_engine.c
+++ b/src/chk/chk_engine.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2023 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -827,7 +827,13 @@ chk_engine_find_dangling_pm(struct chk_pool_rec *cpr, struct pool_map *map)
 			t_comp->co_flags |= PO_COMPF_CHK_DONE;
 		}
 
-		/* dangling parent domain. */
+		/*
+		 * dangling parent domain.
+		 *
+		 * NOTE: When we arrive here, all the pool membership information have already been
+		 *	 scanned via chk_engine_pool_mbs_one(). No service for this pool is started
+		 *	 on the rank (dangling parent domain). So it is safe to "DOWN{OUT}" it.
+		 */
 		rc = chk_engine_pm_dangling(cpr, map, r_comp,
 					    down ? PO_COMP_ST_DOWN : PO_COMP_ST_DOWNOUT);
 		if (rc != 0)
@@ -1672,6 +1678,7 @@ chk_engine_pool_ult(void *args)
 	int				 rc1 = 0;
 	int				 rc2 = 0;
 	bool				 update = true;
+	bool				 svc_ref = true;
 
 	D_ASSERT(svc != NULL);
 	D_ASSERT(cpr != NULL);
@@ -1821,27 +1828,42 @@ out:
 		}
 		chk_engine_pool_notify(cpr);
 		cbk->cb_time.ct_stop_time = time(NULL);
-		if (likely(update))
+		if (likely(update)) {
 			rc1 = chk_bk_update_pool(cbk, uuid_str);
+			if (unlikely(rc1 != 0))
+				goto log;
+		}
 
+		/*
+		 * The pool may has been marked as non-connectable before corruption, re-enable
+		 * it to allow new connection.
+		 *
+		 * NOTE: After chk_pool_restart_svc(), current rank may be not PS leader again.
+		 *	 To simplify the logic, we enable such flag on current PS leader before
+		 *	 chk_pool_restart_svc(). If some client tries to connect the pool after
+		 *	 that (mark connectable) but before chk_pool_restart_svc(), it will get
+		 *	 -DER_BUSY temporarily until the rank is ready for full pool service.
+		 */
 		if (cbk->cb_pool_status == CHK__CHECK_POOL_STATUS__CPS_CHECKED &&
 		    !cpr->cpr_not_export_ps) {
-			chk_pool_start_svc(cpr, &rc2);
-			if (cpr->cpr_started && cpr->cpr_start_post)
-				/*
-				 * The pool may has been marked as non-connectable before
-				 * corruption, re-enable it to allow new connection.
-				 */
-				rc2 = ds_pool_mark_connectable(svc);
+			rc1 = ds_pool_mark_connectable(svc);
+			if (rc1 == 0) {
+				svc_ref = false;
+				ds_pool_svc_put_leader(svc);
+				rc2 = chk_pool_restart_svc(cpr);
+			}
 		}
 	}
 
+log:
 	D_CDEBUG(rc != 0 || rc1 != 0 || rc2 != 0, DLOG_ERR, DLOG_INFO,
 		 DF_ENGINE" on rank %u exit pool ULT for "DF_UUIDF" with %s stop: %d/%d/%d\n",
 		 DP_ENGINE(ins), dss_self_rank(), DP_UUID(cpr->cpr_uuid),
 		 cpr->cpr_stop ? "external" : "self", rc, rc1, rc2);
 
-	ds_pool_svc_put_leader(svc);
+	if (svc_ref)
+		ds_pool_svc_put_leader(svc);
+
 	cpr->cpr_done = 1;
 	if (ins->ci_sched_running && !ins->ci_sched_exiting &&
 	    (cbk->cb_pool_status != CHK__CHECK_POOL_STATUS__CPS_CHECKED || cpr->cpr_not_export_ps))
@@ -2928,7 +2950,7 @@ chk_engine_pool_start(uint64_t gen, uuid_t uuid, uint32_t phase, uint32_t flags)
 	cbk = &cpr->cpr_bk;
 	chk_pool_get(cpr);
 
-	rc = ds_pool_start(uuid);
+	rc = ds_pool_start(uuid, false);
 	if (rc != 0)
 		D_GOTO(put, rc = (rc == -DER_NONEXIST ? 1 : rc));
 
@@ -3513,4 +3535,27 @@ void
 chk_engine_fini(void)
 {
 	chk_ins_fini(&chk_engine);
+}
+
+int
+chk_engine_pool_stop(uuid_t pool_uuid, bool destroy)
+{
+	uint32_t	status;
+	uint32_t	phase;
+	int		rc = 0;
+
+	if (destroy) {
+		status = CHK__CHECK_POOL_STATUS__CPS_CHECKED;
+		phase = CHK__CHECK_SCAN_PHASE__CSP_DONE;
+	} else {
+		status = CHK__CHECK_POOL_STATUS__CPS_PAUSED;
+		phase = CHK_INVAL_PHASE;
+	}
+
+	chk_pool_stop_one(chk_engine, pool_uuid, status, phase, &rc);
+
+	D_INFO(DF_ENGINE" stop pool "DF_UUIDF" with %s: "DF_RC"\n", DP_ENGINE(chk_engine),
+	       DP_UUID(pool_uuid), destroy ? "destroy" : "non-destroy", DP_RC(rc));
+
+	return rc;
 }

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2023 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -568,7 +568,6 @@ struct chk_iv {
 	uint32_t		 ci_ins_status;
 	uint32_t		 ci_pool_status;
 	uint32_t		 ci_to_leader:1, /* To check leader. */
-				 ci_pool_destroyed:1, /* Pool has been destroyed. */
 				 ci_from_psl:1; /* From pool service leader. */
 };
 
@@ -696,9 +695,10 @@ void chk_pools_dump(d_list_t *head, int pool_nr, uuid_t pools[]);
 
 void  chk_pool_remove_nowait(struct chk_pool_rec *cpr);
 
-void chk_pool_start_svc(struct chk_pool_rec *cpr, int *ret);
+int chk_pool_restart_svc(struct chk_pool_rec *cpr);
 
-void chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, int status, uint32_t phase, int *ret);
+void chk_pool_stop_one(struct chk_instance *ins, uuid_t uuid, uint32_t status, uint32_t phase,
+		       int *ret);
 
 void chk_pool_stop_all(struct chk_instance *ins, uint32_t status, int *ret);
 
@@ -834,7 +834,7 @@ int chk_pool_start_remote(d_rank_list_t *rank_list, uint64_t gen, uuid_t uuid, u
 
 int chk_pool_mbs_remote(d_rank_t rank, uint32_t phase, uint64_t gen, uuid_t uuid, char *label,
 			uint64_t seq, uint32_t flags, uint32_t mbs_nr,
-			struct chk_pool_mbs *mbs_array, struct rsvc_hint *hint);
+			struct chk_pool_mbs *mbs_array, int *svc_rc, struct rsvc_hint *svc_hint);
 
 int chk_report_remote(d_rank_t leader, uint64_t gen, uint32_t cla, uint32_t act, int result,
 		      d_rank_t rank, uint32_t target, uuid_t *pool, char *pool_label,

--- a/src/chk/chk_iv.c
+++ b/src/chk/chk_iv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2023 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -213,10 +213,10 @@ chk_iv_update(void *ns, struct chk_iv *iv, uint32_t shortcut, uint32_t sync_mode
 
 	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
 		 "CHK iv "DF_X64"/"DF_X64" on rank %u, phase %u, ins_status %u, "
-		 "pool_status %u, to_leader %s, from_psl %s, destroyed %s: rc = %d\n",
+		 "pool_status %u, to_leader %s, from_psl %s: rc = %d\n",
 		 iv->ci_gen, iv->ci_seq, iv->ci_rank, iv->ci_phase, iv->ci_ins_status,
 		 iv->ci_pool_status, iv->ci_to_leader ? "yes" : "no",
-		 iv->ci_from_psl ? "yes" : "no", iv->ci_pool_destroyed ? "yes" : "no", rc);
+		 iv->ci_from_psl ? "yes" : "no", rc);
 
 	return rc;
 }

--- a/src/chk/chk_leader.c
+++ b/src/chk/chk_leader.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2023 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -315,8 +315,6 @@ chk_leader_post_repair(struct chk_instance *ins, struct chk_pool_rec *cpr,
 			iv.ci_ins_status = ins->ci_bk.cb_ins_status;
 			iv.ci_phase = cbk->cb_phase;
 			iv.ci_pool_status = cbk->cb_pool_status;
-			if (cpr->cpr_destroyed)
-				iv.ci_pool_destroyed = 1;
 
 			/* Synchronously notify the engines that check on the pool got failure. */
 			rc = chk_iv_update(ins->ci_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
@@ -945,7 +943,8 @@ out:
 	 * to fix related inconsistency), then notify check engines to remove related
 	 * pool record and bookmark.
 	 */
-	chk_leader_post_repair(ins, cpr, &result, rc <= 0, cpr->cpr_skip ? true : false);
+	chk_leader_post_repair(ins, cpr, &result, rc <= 0,
+			       cpr->cpr_skip && !cpr->cpr_destroyed ? true : false);
 
 	return result;
 }
@@ -1867,13 +1866,14 @@ chk_leader_pool_mbs_one(struct chk_pool_rec *cpr)
 {
 	struct rsvc_client	 client = { 0 };
 	crt_endpoint_t		 ep = { 0 };
-	struct rsvc_hint	 hint = { 0 };
+	struct rsvc_hint	 svc_hint = { 0 };
 	struct chk_instance	*ins = cpr->cpr_ins;
 	struct chk_bookmark	*cbk = &ins->ci_bk;
 	d_rank_list_t		*ps_ranks = NULL;
 	struct chk_pool_shard	*cps;
 	struct ds_pool_clue	*clue;
 	uint32_t		 interval;
+	int			 svc_rc = 0;
 	int			 rc = 0;
 	int			 rc1;
 	int			 i = 0;
@@ -1925,9 +1925,9 @@ again:
 	rc = chk_pool_mbs_remote(ep.ep_rank, CHK__CHECK_SCAN_PHASE__CSP_POOL_MBS, cbk->cb_gen,
 				 cpr->cpr_uuid, cpr->cpr_label, cpr->cpr_label_seq,
 				 cpr->cpr_delay_label ? CMF_REPAIR_LABEL : 0,
-				 cpr->cpr_shard_nr, cpr->cpr_mbs, &hint);
+				 cpr->cpr_shard_nr, cpr->cpr_mbs, &svc_rc, &svc_hint);
 
-	rc1 = rsvc_client_complete_rpc(&client, &ep, rc, rc, &hint);
+	rc1 = rsvc_client_complete_rpc(&client, &ep, rc, svc_rc, &svc_hint);
 	if (rc1 == RSVC_CLIENT_RECHOOSE ||
 	    (rc1 == RSVC_CLIENT_PROCEED && daos_rpc_retryable_rc(rc))) {
 		dss_sleep(interval);

--- a/src/chk/chk_rpc.c
+++ b/src/chk/chk_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2023 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -861,7 +861,7 @@ out:
 int
 chk_pool_mbs_remote(d_rank_t rank, uint32_t phase, uint64_t gen, uuid_t uuid, char *label,
 		    uint64_t seq, uint32_t flags, uint32_t mbs_nr, struct chk_pool_mbs *mbs_array,
-		    struct rsvc_hint *hint)
+		    int *svc_rc, struct rsvc_hint *svc_hint)
 {
 	crt_rpc_t		*req;
 	struct chk_pool_mbs_in	*cpmi;
@@ -887,17 +887,17 @@ chk_pool_mbs_remote(d_rank_t rank, uint32_t phase, uint64_t gen, uuid_t uuid, ch
 		goto out;
 
 	cpmo = crt_reply_get(req);
-	rc = cpmo->cpmo_status;
-	*hint = cpmo->cpmo_hint;
+	*svc_rc = cpmo->cpmo_status;
+	*svc_hint = cpmo->cpmo_hint;
 
 out:
 	if (req != NULL)
 		crt_req_decref(req);
 
-	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
+	D_CDEBUG(rc != 0 || *svc_rc != 0, DLOG_ERR, DLOG_INFO,
 		 "Sent pool ("DF_UUIDF") members and label %s ("
-		 DF_X64") to rank %u with phase %d gen "DF_X64": "DF_RC"\n",
-		 DP_UUID(uuid), label != NULL ? label : "(null)", seq, rank, phase, gen, DP_RC(rc));
+		 DF_X64") to rank %u with phase %d gen "DF_X64": %d/%d\n", DP_UUID(uuid),
+		 label != NULL ? label : "(null)", seq, rank, phase, gen, rc, *svc_rc);
 
 	return rc;
 }

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -895,7 +895,7 @@ cont_child_start(struct ds_pool_child *pool_child, const uuid_t co_uuid,
 			DP_CONT(pool_child->spc_uuid, co_uuid), tgt_id);
 		rc = -DER_SHUTDOWN;
 	} else if (!cont_child_started(cont_child)) {
-		if (!engine_in_check()) {
+		if (!ds_pool_skip_for_check(pool_child->spc_pool)) {
 			rc = cont_start_agg(cont_child);
 			if (rc != 0)
 				goto out;
@@ -950,58 +950,6 @@ ds_cont_child_start_all(struct ds_pool_child *pool_child)
 	rc = vos_iterate(&iter_param, VOS_ITER_COUUID, false, &anchors,
 			 cont_child_start_cb, NULL, (void *)pool_child, NULL);
 	return rc;
-}
-
-static int
-cont_child_chk_post_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
-		       vos_iter_param_t *iter_param, void *data, unsigned *acts)
-{
-	struct dsm_tls		*tls = dsm_tls_get();
-	struct ds_pool_child	*pool_child = data;
-	struct ds_cont_child	*cont_child = NULL;
-	int			 rc = 0;
-
-	/* The container shard must has been opened. */
-	rc = cont_child_lookup(tls->dt_cont_cache, entry->ie_couuid,
-			       pool_child->spc_uuid, false /* create */, &cont_child);
-	if (rc != 0)
-		goto out;
-
-	if (cont_child->sc_stopping || !cont_child_started(cont_child))
-		D_GOTO(out, rc = -DER_SHUTDOWN);
-
-	rc = cont_start_agg(cont_child);
-	if (rc != 0)
-		goto out;
-
-	rc = dtx_cont_register(cont_child);
-
-out:
-	if (cont_child != NULL) {
-		if (rc != 0)
-			cont_stop_agg(cont_child);
-
-		ds_cont_child_put(cont_child);
-	}
-
-	D_CDEBUG(rc != 0, DLOG_ERR, DLOG_INFO,
-		 "[%d]: Post handle container "DF_CONTF" start after DAOS check: "DF_RC"\n",
-		 dss_get_module_info()->dmi_tgt_id,
-		 DP_CONT(pool_child->spc_uuid, entry->ie_couuid), DP_RC(rc));
-
-	return rc;
-}
-
-int
-ds_cont_chk_post(struct ds_pool_child *pool_child)
-{
-	vos_iter_param_t	iter_param = { 0 };
-	struct vos_iter_anchors	anchors = { 0 };
-
-	iter_param.ip_hdl = pool_child->spc_hdl;
-
-	return vos_iterate(&iter_param, VOS_ITER_COUUID, false, &anchors,
-			   cont_child_chk_post_cb, NULL, (void *)pool_child, NULL);
 }
 
 /* ds_cont_hdl ****************************************************************/

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2023 Intel Corporation.
+ * (C) Copyright 2015-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -185,7 +185,6 @@ int ds_cont_close_by_pool_hdls(uuid_t pool_uuid, uuid_t *pool_hdls,
 			       int n_pool_hdls, crt_context_t ctx);
 int ds_cont_local_close(uuid_t cont_hdl_uuid);
 
-int ds_cont_chk_post(struct ds_pool_child *pool_child);
 int ds_cont_child_start_all(struct ds_pool_child *pool_child);
 void ds_cont_child_stop_all(struct ds_pool_child *pool_child);
 

--- a/src/include/daos_srv/daos_chk.h
+++ b/src/include/daos_srv/daos_chk.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -85,5 +85,7 @@ int chk_leader_query(int pool_nr, uuid_t pools[], chk_query_head_cb_t head_cb,
 int chk_leader_prop(chk_prop_cb_t prop_cb, void *buf);
 
 int chk_leader_act(uint64_t seq, uint32_t act, bool for_all);
+
+int chk_engine_pool_stop(uuid_t pool_uuid, bool destroy);
 
 #endif /* __DAOS_CHK_H__ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -81,8 +81,11 @@ struct ds_pool {
 	 */
 	uuid_t			sp_srv_cont_hdl;
 	uuid_t			sp_srv_pool_hdl;
-	uint32_t sp_stopping : 1, sp_fetch_hdls : 1, sp_disable_rebuild : 1, sp_need_discard : 1;
-
+	uint32_t		sp_stopping:1,
+				sp_cr_checked:1,
+				sp_fetch_hdls:1,
+				sp_need_discard:1,
+				sp_disable_rebuild:1;
 	/* pool_uuid + map version + leader term + rebuild generation define a
 	 * rebuild job.
 	 */
@@ -251,7 +254,7 @@ void ds_pool_child_put(struct ds_pool_child *child);
 /* Start ds_pool child */
 int ds_pool_child_start(uuid_t pool_uuid, bool recreate);
 /* Stop ds_pool_child */
-int ds_pool_child_stop(uuid_t pool_uuid);
+int ds_pool_child_stop(uuid_t pool_uuid, bool free);
 /* Query pool child state */
 uint32_t ds_pool_child_state(uuid_t pool_uuid, uint32_t tgt_id);
 
@@ -271,9 +274,9 @@ int ds_pool_tgt_finish_rebuild(uuid_t pool_uuid, struct pool_target_id_list *lis
 int ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 			   unsigned int map_version);
 
-int ds_pool_chk_post(uuid_t uuid);
-int ds_pool_start_with_svc(uuid_t uuid);
-int ds_pool_start(uuid_t uuid);
+bool ds_pool_skip_for_check(struct ds_pool *pool);
+int ds_pool_start_after_check(uuid_t uuid);
+int ds_pool_start(uuid_t uuid, bool aft_chk);
 void ds_pool_stop(uuid_t uuid);
 int ds_pool_extend(uuid_t pool_uuid, int ntargets, const d_rank_list_t *rank_list, int ndomains,
 		   const uint32_t *domains, d_rank_list_t *svc_ranks);

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -665,7 +665,7 @@ ds_mgmt_tgt_pool_shard_destroy(uuid_t pool_uuid, int shard_idx, d_rank_t rank)
 
 	tgt_ep.ep_grp = NULL;
 	tgt_ep.ep_rank = rank;
-	tgt_ep.ep_tag = daos_rpc_tag(DAOS_REQ_MGMT, 0);
+	tgt_ep.ep_tag = daos_rpc_tag(DAOS_REQ_TGT, shard_idx);
 
 	opc = DAOS_RPC_OPCODE(MGMT_TGT_SHARD_DESTROY, DAOS_MGMT_MODULE,
 			      DAOS_MGMT_VERSION);

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -1212,7 +1212,7 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 	tc_out->tc_ranks.ca_arrays = rank;
 	tc_out->tc_ranks.ca_count  = 1;
 
-	rc = ds_pool_start(tc_in->tc_pool_uuid);
+	rc = ds_pool_start(tc_in->tc_pool_uuid, false);
 	if (rc) {
 		D_ERROR(DF_UUID": failed to start pool: "DF_RC"\n",
 			DP_UUID(tc_in->tc_pool_uuid), DP_RC(rc));
@@ -1382,6 +1382,15 @@ ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *td_req)
 	ABT_mutex_unlock(pooltgts->dpt_mutex);
 	D_DEBUG(DB_MGMT, DF_UUID": ready to destroy targets\n",
 		DP_UUID(td_in->td_pool_uuid));
+
+	if (engine_in_check()) {
+		rc = chk_engine_pool_stop(td_in->td_pool_uuid, true);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to stop check engine on pool: "DF_RC"\n",
+				DP_UUID(td_in->td_pool_uuid), DP_RC(rc));
+			goto out;
+		}
+	}
 
 	/*
 	 * If there is a local PS replica, its RDB file will be deleted later
@@ -1583,6 +1592,10 @@ ds_mgmt_hdlr_tgt_shard_destroy(crt_rpc_t *req)
 	 * stop the pool service.
 	 */
 
+	rc = ds_pool_child_stop(tsdi->tsdi_pool_uuid, true);
+	if (rc != 0 && rc != -DER_NONEXIST)
+		goto out;
+
 	rc = ds_mgmt_tgt_file(tsdi->tsdi_pool_uuid, VOS_FILE, &tsdi->tsdi_shard_idx, &path);
 	if (rc == 0) {
 		rc = unlink(path);
@@ -1596,6 +1609,7 @@ ds_mgmt_hdlr_tgt_shard_destroy(crt_rpc_t *req)
 		D_FREE(path);
 	}
 
+out:
 	D_DEBUG(DB_MGMT, "Processed rpc %p to destroy pool "DF_UUIDF" shard %u: "DF_RC"\n",
 		req, DP_UUID(tsdi->tsdi_pool_uuid), tsdi->tsdi_shard_idx, DP_RC(rc));
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1416,7 +1416,7 @@ init_events(struct pool_svc *svc)
 	D_ASSERT(events->pse_handler == ABT_THREAD_NULL);
 	D_ASSERT(events->pse_stop == false);
 
-	if (!engine_in_check()) {
+	if (!ds_pool_skip_for_check(svc->ps_pool)) {
 		rc = crt_register_event_cb(ds_pool_crt_event_cb, svc);
 		if (rc != 0) {
 			D_ERROR(DF_UUID": failed to register event callback: "DF_RC"\n",
@@ -1447,7 +1447,7 @@ init_events(struct pool_svc *svc)
 	return 0;
 
 err_cb:
-	if (!engine_in_check())
+	if (!ds_pool_skip_for_check(svc->ps_pool))
 		crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
 	discard_events(&events->pse_queue);
 err:
@@ -1462,7 +1462,7 @@ fini_events(struct pool_svc *svc)
 
 	D_ASSERT(events->pse_handler != ABT_THREAD_NULL);
 
-	if (!engine_in_check())
+	if (!ds_pool_skip_for_check(svc->ps_pool))
 		crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
 
 	ABT_mutex_lock(events->pse_mutex);
@@ -1830,9 +1830,9 @@ pool_svc_check_node_status(struct pool_svc *svc)
 } while (0)
 
 static int pool_svc_schedule(struct pool_svc *svc, struct pool_svc_sched *sched,
-			     void (*func)(void *), void *arg, bool for_chk);
+			     void (*func)(void *), void *arg);
 static int pool_svc_schedule_reconf(struct pool_svc *svc, struct pool_map *map,
-				    uint32_t map_version_for, bool sync_remove, bool for_chk);
+				    uint32_t map_version_for, bool sync_remove);
 static void pool_svc_rfcheck_ult(void *arg);
 
 static int
@@ -1893,8 +1893,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	 * reconfigurations or the last MS notification.
 	 */
 	svc->ps_force_notify = true;
-	rc = pool_svc_schedule_reconf(svc, NULL /* map */, map_version, false /* sync_remove */,
-				      false /* for_chk */);
+	rc = pool_svc_schedule_reconf(svc, NULL /* map */, map_version, false /* sync_remove */);
 	if (rc == -DER_OP_CANCELED) {
 		DL_INFO(rc, DF_UUID": not scheduling pool service reconfiguration",
 			DP_UUID(svc->ps_uuid));
@@ -1905,8 +1904,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 		goto out;
 	}
 
-	rc = pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult, NULL /* arg */,
-			       false /* for_chk */);
+	rc = pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult, NULL);
 	if (rc == -DER_OP_CANCELED) {
 		DL_INFO(rc, DF_UUID ": not scheduling RF check", DP_UUID(svc->ps_uuid));
 		rc = 0;
@@ -2213,7 +2211,7 @@ start_one(uuid_t uuid, void *varg)
 
 	D_DEBUG(DB_MD, DF_UUID": starting pool\n", DP_UUID(uuid));
 
-	rc = ds_pool_start(uuid);
+	rc = ds_pool_start(uuid, varg != NULL ? true : false);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to start pool: %d\n", DP_UUID(uuid),
 			rc);
@@ -2259,9 +2257,11 @@ pool_start_all(void *arg)
 }
 
 int
-ds_pool_start_with_svc(uuid_t uuid)
+ds_pool_start_after_check(uuid_t uuid)
 {
-	return start_one(uuid, NULL);
+	bool	aft_chk = true;
+
+	return start_one(uuid, &aft_chk);
 }
 
 /* Note that this function is currently called from the main xstream. */
@@ -3444,6 +3444,16 @@ ds_pool_connect_handler(crt_rpc_t *rpc, int handler_version)
 		D_GOTO(out_lock, rc = -DER_BUSY);
 	}
 
+	/*
+	 * NOTE: Under check mode, there is a small race window between ds_pool_mark_connectable()
+	 *	 the PS restart for full service. If some client tries to connect the pool during
+	 *	 such internal, it will get -DER_BUSY temporarily.
+	 */
+	if (unlikely(ds_pool_skip_for_check(svc->ps_pool))) {
+		D_ERROR(DF_UUID" is not ready for full pool service\n", DP_UUID(in->pci_op.pi_uuid));
+		D_GOTO(out_lock, rc = -DER_BUSY);
+	}
+
 	/* Check existing pool handles. */
 	d_iov_set(&key, in->pci_op.pi_hdl, sizeof(uuid_t));
 	d_iov_set(&value, NULL, 0);
@@ -3686,7 +3696,12 @@ out_lock:
 	if (prop)
 		daos_prop_free(prop);
 out_svc:
-	ds_rsvc_set_hint(&svc->ps_rsvc, &out->pco_op.po_hint);
+	/*
+	 * NOTE: For ds_pool_skip_for_check() true case, after PS restart, current rank may be not
+	 *	 PS leader, do not set the hint under such case (rc == -DER_BUSY && nhandles == 0).
+	 */
+	if (rc != -DER_BUSY || nhandles != 0)
+		ds_rsvc_set_hint(&svc->ps_rsvc, &out->pco_op.po_hint);
 	pool_svc_put_leader(svc);
 out:
 	if ((rc == 0) && !dup_op && fi_pass_noreply) {
@@ -6692,14 +6707,14 @@ out:
 /* If returning 0, this function must have scheduled func(arg). */
 static int
 pool_svc_schedule(struct pool_svc *svc, struct pool_svc_sched *sched, void (*func)(void *),
-		  void *arg, bool for_chk)
+		  void *arg)
 {
 	enum ds_rsvc_state	state;
 	int			rc;
 
 	D_DEBUG(DB_MD, DF_UUID": begin\n", DP_UUID(svc->ps_uuid));
 
-	if (!for_chk && engine_in_check()) {
+	if (ds_pool_skip_for_check(svc->ps_pool)) {
 		D_DEBUG(DB_MD, DF_UUID": end: skip in check mode\n", DP_UUID(svc->ps_uuid));
 		return -DER_OP_CANCELED;
 	}
@@ -6752,8 +6767,9 @@ ds_pool_svc_schedule_reconf(struct ds_pool_svc *svc)
 	 * Pass 1 as map_version_for, since there shall be no other
 	 * reconfiguration in progress.
 	 */
+	s->ps_pool->sp_cr_checked = 1;
 	rc = pool_svc_schedule_reconf(s, NULL /* map */, 1 /* map_version_for */,
-				      false /* sync_remove */, true /* for_chk */);
+				      true /* sync_remove */);
 	if (rc != 0)
 		DL_ERROR(rc, DF_UUID": failed to schedule pool service reconfiguration",
 			 DP_UUID(s->ps_uuid));
@@ -6818,7 +6834,7 @@ pool_svc_rfcheck_ult(void *arg)
  */
 static int
 pool_svc_schedule_reconf(struct pool_svc *svc, struct pool_map *map, uint32_t map_version_for,
-			 bool sync_remove, bool for_chk)
+			 bool sync_remove)
 {
 	struct pool_svc_reconf_arg     *reconf_arg;
 	uint32_t			v;
@@ -6856,7 +6872,7 @@ pool_svc_schedule_reconf(struct pool_svc *svc, struct pool_map *map, uint32_t ma
 	 * If successful, this call passes the ownership of reconf_arg to
 	 * pool_svc_reconf_ult.
 	 */
-	rc = pool_svc_schedule(svc, &svc->ps_reconf_sched, pool_svc_reconf_ult, reconf_arg, false);
+	rc = pool_svc_schedule(svc, &svc->ps_reconf_sched, pool_svc_reconf_ult, reconf_arg);
 	if (rc != 0) {
 		D_FREE(reconf_arg);
 		return rc;
@@ -7040,8 +7056,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 	 * Remove all undesired PS replicas (if any) before committing map, so
 	 * that the set of PS replicas remains a subset of the pool groups.
 	 */
-	rc = pool_svc_schedule_reconf(svc, map, 0 /* map_version_for */, true /* sync_remove */,
-				      false /* for_chk */);
+	rc = pool_svc_schedule_reconf(svc, map, 0 /* map_version_for */, true /* sync_remove */);
 	if (rc != 0) {
 		DL_ERROR(rc, DF_UUID": failed to remove undesired pool service replicas",
 			 DP_UUID(svc->ps_uuid));
@@ -7073,8 +7088,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 
 	ds_rsvc_request_map_dist(&svc->ps_rsvc);
 
-	rc = pool_svc_schedule_reconf(svc, NULL /* map */, map_version, false /* sync_remove */,
-				      false /* for_chk */);
+	rc = pool_svc_schedule_reconf(svc, NULL /* map */, map_version, false /* sync_remove */);
 	if (rc != 0) {
 		DL_INFO(rc, DF_UUID": failed to schedule pool service reconfiguration",
 			DP_UUID(svc->ps_uuid));
@@ -7082,8 +7096,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 	}
 
 	if (opc == MAP_EXCLUDE) {
-		rc = pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult,
-				       NULL /* arg */, false /* for_chk */);
+		rc = pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult, NULL);
 		if (rc != 0)
 			DL_INFO(rc, DF_UUID": failed to schedule RF check", DP_UUID(svc->ps_uuid));
 	}
@@ -8981,4 +8994,10 @@ ds_pool_svc_upgrade_vos_pool(struct ds_pool *pool)
 
 	ds_rsvc_put(rsvc);
 	return rc;
+}
+
+bool
+ds_pool_skip_for_check(struct ds_pool *pool)
+{
+	return engine_in_check() && !pool->sp_cr_checked;
 }

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1898,6 +1898,7 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc == -DER_OP_CANCELED) {
 		DL_INFO(rc, DF_UUID": not scheduling pool service reconfiguration",
 			DP_UUID(svc->ps_uuid));
+		rc = 0;
 	} else if (rc != 0) {
 		DL_ERROR(rc, DF_UUID": failed to schedule pool service reconfiguration",
 			 DP_UUID(svc->ps_uuid));
@@ -1906,7 +1907,10 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 
 	rc = pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult, NULL /* arg */,
 			       false /* for_chk */);
-	if (rc != 0) {
+	if (rc == -DER_OP_CANCELED) {
+		DL_INFO(rc, DF_UUID ": not scheduling RF check", DP_UUID(svc->ps_uuid));
+		rc = 0;
+	} else if (rc != 0) {
 		DL_ERROR(rc, DF_UUID": failed to schedule RF check", DP_UUID(svc->ps_uuid));
 		goto out;
 	}
@@ -6685,6 +6689,7 @@ out:
 	D_DEBUG(DB_MD, DF_UUID": end: "DF_RC"\n", DP_UUID(svc->ps_uuid), DP_RC(rc));
 }
 
+/* If returning 0, this function must have scheduled func(arg). */
 static int
 pool_svc_schedule(struct pool_svc *svc, struct pool_svc_sched *sched, void (*func)(void *),
 		  void *arg, bool for_chk)
@@ -6696,7 +6701,7 @@ pool_svc_schedule(struct pool_svc *svc, struct pool_svc_sched *sched, void (*fun
 
 	if (!for_chk && engine_in_check()) {
 		D_DEBUG(DB_MD, DF_UUID": end: skip in check mode\n", DP_UUID(svc->ps_uuid));
-		return 0;
+		return -DER_OP_CANCELED;
 	}
 
 	/*
@@ -7070,9 +7075,11 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 
 	rc = pool_svc_schedule_reconf(svc, NULL /* map */, map_version, false /* sync_remove */,
 				      false /* for_chk */);
-	if (rc != 0)
+	if (rc != 0) {
 		DL_INFO(rc, DF_UUID": failed to schedule pool service reconfiguration",
 			DP_UUID(svc->ps_uuid));
+		rc = 0;
+	}
 
 	if (opc == MAP_EXCLUDE) {
 		rc = pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult,

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1702,7 +1702,7 @@ manage_target(bool start)
 		if (start)
 			rc = ds_pool_child_start(pool_info->spi_id, true);
 		else
-			rc = ds_pool_child_stop(pool_info->spi_id);
+			rc = ds_pool_child_stop(pool_info->spi_id, false);
 
 		if (rc < 0) {
 			DL_ERROR(rc, DF_UUID": Failed to %s pool child.",

--- a/src/tests/ftest/recovery/pool_membership.py
+++ b/src/tests/ftest/recovery/pool_membership.py
@@ -214,7 +214,7 @@ class PoolMembershipTest(IorTestBase):
                 "Checker didn't fix orphan pool shard! msg = {}".format(query_msg))
 
         # 8. Disable the checker.
-        self.log_step("Disable and start the checker.")
+        self.log_step("Disable checker.")
         dmg_command.check_disable()
 
         # 9. Call dmg storage query usage to verify that the pool usage is back to the
@@ -288,7 +288,7 @@ class PoolMembershipTest(IorTestBase):
                 "Checker didn't fix orphan pool shard! msg = {}".format(query_msg))
 
         # 6. Disable the checker.
-        self.log_step("Disable and start the checker.")
+        self.log_step("Disable checker.")
         dmg_command.check_disable()
 
         # 7. Verify that the pool has one less target.


### PR DESCRIPTION
Currently, under check mode, before the pool check complete, the PS is either not started or partial started with some functionality skipped. Once the pool is checked with all potential inconsistency resolved, we will start former skipped parts for the pool service.

Such way can work, but has potential risk for new added logic that needs to be handled during PS start. More clean solution is that we can restart the PS with new flag that will overwrite the global engine_in_check() only for the special pool, then related PS can be fully started.

The patch also fixes another two issues:

1. Before destroying orphan pool target, need to stop related pool child firstly.

2. When destroy orphan pool shard, need to notify check engine to cleanup such pool shard related things.

Test-tag: cat_recov

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
