### PR TITLE
DAOS-15817 test: raise exception for clush job_manager failure

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -14,13 +14,12 @@ from job_manager_utils import get_job_manager, stop_job_manager
 from thread_manager import ThreadManager
 
 
-def run_ior_loop(test, manager, loops):
+def run_ior_loop(manager, cont_labels):
     """Run IOR multiple times.
 
     Args:
-        test (Test): the test object
         manager (str): mpi job manager command
-        loops (int): number of times to run IOR
+        cont_labels (list): container labels to loop over and run ior with
 
     Returns:
         list: a list of CmdResults from each ior command run
@@ -28,8 +27,7 @@ def run_ior_loop(test, manager, loops):
     """
     results = []
     errors = []
-    for index in range(loops):
-        cont = test.label_generator.get_label('cont')
+    for index, cont in enumerate(cont_labels):
         manager.job.dfs_cont.update(cont, "ior.dfs_cont")
 
         t_start = time.time()
@@ -40,7 +38,7 @@ def run_ior_loop(test, manager, loops):
             ior_mode = "read" if "-r" in manager.job.flags.value else "write"
             errors.append(
                 "IOR {} Loop {}/{} failed for container {}: {}".format(
-                    ior_mode, index, loops, cont, error))
+                    ior_mode, index, len(cont_labels), cont, error))
         finally:
             t_end = time.time()
             ior_cmd_time = t_end - t_start
@@ -48,7 +46,8 @@ def run_ior_loop(test, manager, loops):
 
     if errors:
         raise CommandFailure(
-            "IOR failed in {}/{} loops: {}".format(len(errors), loops, "\n".join(errors)))
+            "IOR failed in {}/{} loops: {}".format(
+                len(errors), len(cont_labels), "\n".join(errors)))
     return results
 
 
@@ -470,8 +469,7 @@ class ObjectMetadata(TestWithServers):
                 ior_cmd.flags.value = self.params.get("ior{}flags".format(operation), "/run/ior/*")
 
                 # Define the job manager for the IOR command
-                ior_managers.append(
-                    get_job_manager(self, "Clush", ior_cmd))
+                ior_managers.append(get_job_manager(self, job=ior_cmd))
                 env = ior_cmd.get_default_env(str(ior_managers[-1]))
                 ior_managers[-1].assign_hosts(self.hostlist_clients, self.workdir, None)
                 ior_managers[-1].assign_processes(processes)
@@ -481,9 +479,11 @@ class ObjectMetadata(TestWithServers):
                 # Disable cleanup methods for all ior commands.
                 ior_managers[-1].register_cleanup_method = None
 
+                # Generate labels such that write and read use the same container
+                cont_labels = [f'cont_{index}_{loop}' for loop in range(files_per_thread)]
+
                 # Add a thread for these IOR arguments
-                thread_manager.add(
-                    test=self, manager=ior_managers[-1], loops=files_per_thread)
+                thread_manager.add(manager=ior_managers[-1], cont_labels=cont_labels)
                 self.log.info("Created %s thread %s", operation, index)
 
             # Manually add one cleanup method for all ior threads

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -6,7 +6,7 @@ timeouts:
   test_metadata_fillup_svc_ops_disabled: 400
   test_metadata_fillup_svc_ops_enabled: 400
   test_metadata_addremove: 1300
-  test_metadata_server_restart: 500
+  test_metadata_server_restart: 1500
 
 server_config:
   name: daos_server
@@ -61,12 +61,15 @@ container:
   register_cleanup: False
 
 ior:
-  clientslots:
-    slots: 1
+  np: 1
   dfs_destroy: false
   iorwriteflags: "-w -W -k -G 1"
   iorreadflags: "-r -R -G 1"
-  dfs_oclass: "SX"
+  test_file: /testFile
+  transfer_size: 8B
+  block_size: 8B
+  api: DFS
+  dfs_oclass: SX
 
 metadata:
   mean_percent: 1

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -1249,9 +1250,8 @@ class Clush(JobManager):
         command = " ".join([self.env.to_export_str(), str(self.job)]).strip()
         self.result = run_remote(self.log, self._hosts, command, self.verbose, self.timeout)
 
-        if raise_exception and self.result.timeout:
-            raise CommandFailure(
-                "Timeout detected running '{}' on {}".format(str(self.job), self.hosts))
+        if raise_exception and not self.result.passed:
+            raise CommandFailure("Error running '{}' on {}".format(str(self.job), self.hosts))
 
         if self.exit_status_exception and not self.check_results():
             # Command failed if its output contains bad keywords


### PR DESCRIPTION
Raise an exception when the clush job_manager run fails.
Fix ior usage server/metadata.py since it was previously silently failing.

Test-tag: ObjectMetadata DaosCoreTestDfuse
Skip-unit-tests: true
Skip-fault-injection-test: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
