### PR TITLE
DAOS-15696 test: Bullseye coverage Report on Master May 2024

### DIFF
--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2020-2023 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """

--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -301,12 +301,12 @@ class PoolSecurityTestBase(TestWithServers):
             "At setup_container_acl_and_permission, setup %s, %s, %s, with %s",
             user_type, user_name, perm_type, permission)
         with container.no_exception():
-            result = container.update_acl(
+            container.update_acl(
                 entry=secTestBase.acl_entry(user_type, user_name, permission))
-        if result.stderr_text:
-            self.fail(
-                "##setup_container_acl_and_permission, fail on "
-                "container.update_acl, expected Pass, but Failed.")
+#        if result.stderr_text:
+#            self.fail(
+#                "##setup_container_acl_and_permission, fail on "
+#                "container.update_acl, expected Pass, but Failed.")
 
     def verify_pool_readwrite(self, pool, action, expect='Pass'):
         """Verify client is able to perform read or write on a pool.
@@ -506,8 +506,8 @@ class PoolSecurityTestBase(TestWithServers):
 
         # (4)Verify the pool create status
         self.log.info("  (4)dmg.run() result=\n%s", self.pool.dmg.result)
-        if "ERR" in self.pool.dmg.result.stderr_text:
-            self.fail("##(4)Unexpected error from pool create.")
+#        if "ERR" in self.pool.dmg.result.stderr_text:
+#            self.fail("##(4)Unexpected error from pool create.")
 
         # (5)Get the pool's acl list
         #    dmg pool get-acl <pool name>

--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -303,10 +303,10 @@ class PoolSecurityTestBase(TestWithServers):
         with container.no_exception():
             result = container.update_acl(
                 entry=secTestBase.acl_entry(user_type, user_name, permission))
-        if result.stderr_text:
-            self.fail(
-                "##setup_container_acl_and_permission, fail on "
-                "container.update_acl, expected Pass, but Failed.")
+#        if result.stderr_text:
+#            self.fail(
+#                "##setup_container_acl_and_permission, fail on "
+#                "container.update_acl, expected Pass, but Failed.")
 
     def verify_pool_readwrite(self, pool, action, expect='Pass'):
         """Verify client is able to perform read or write on a pool.
@@ -506,8 +506,8 @@ class PoolSecurityTestBase(TestWithServers):
 
         # (4)Verify the pool create status
         self.log.info("  (4)dmg.run() result=\n%s", self.pool.dmg.result)
-        if "ERR" in self.pool.dmg.result.stderr_text:
-            self.fail("##(4)Unexpected error from pool create.")
+#        if "ERR" in self.pool.dmg.result.stderr_text:
+#            self.fail("##(4)Unexpected error from pool create.")
 
         # (5)Get the pool's acl list
         #    dmg pool get-acl <pool name>

--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -303,10 +303,10 @@ class PoolSecurityTestBase(TestWithServers):
         with container.no_exception():
             result = container.update_acl(
                 entry=secTestBase.acl_entry(user_type, user_name, permission))
-#        if result.stderr_text:
-#            self.fail(
-#                "##setup_container_acl_and_permission, fail on "
-#                "container.update_acl, expected Pass, but Failed.")
+        if result.stderr_text:
+            self.fail(
+                "##setup_container_acl_and_permission, fail on "
+                "container.update_acl, expected Pass, but Failed.")
 
     def verify_pool_readwrite(self, pool, action, expect='Pass'):
         """Verify client is able to perform read or write on a pool.
@@ -506,8 +506,8 @@ class PoolSecurityTestBase(TestWithServers):
 
         # (4)Verify the pool create status
         self.log.info("  (4)dmg.run() result=\n%s", self.pool.dmg.result)
-#        if "ERR" in self.pool.dmg.result.stderr_text:
-#            self.fail("##(4)Unexpected error from pool create.")
+        if "ERR" in self.pool.dmg.result.stderr_text:
+            self.fail("##(4)Unexpected error from pool create.")
 
         # (5)Get the pool's acl list
         #    dmg pool get-acl <pool name>


### PR DESCRIPTION
Description: test only, please do not merge.

Skip-fnbullseye: false
Skip-bullseye: false
Skip-python-bandit: true
Skip-build-EL9-rpm: true
Test-tag: pr daily_regression full_regression
Skip-func-hw-test-medium-md-on-ssd: false
Skip-func-hw-test-medium-verbs-provider-md-on-ssd: false
Skip-func-hw-test-large-md-on-ssd: false
Allow-unstable-test: true
Doc-only: false
Required-githooks: true
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>


### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
