### PR TITLE
DAOS-15846 common: Use tenv for rsvc_tests

### DIFF
--- a/src/common/tests/SConscript
+++ b/src/common/tests/SConscript
@@ -40,6 +40,8 @@ def scons():
                         LIBS=['daos_common_pmem', 'gurt', 'cmocka'])
     tenv.d_test_program('checksum_timing', 'checksum_timing.c', LIBS=['daos_common', 'gurt'])
     tenv.d_test_program('compress_timing', 'compress_timing.c', LIBS=['daos_common', 'gurt'])
+    tenv.d_test_program('rsvc_tests', ['rsvc_tests.c', '../rsvc.c'],
+                        LIBS=['daos_common', 'gurt', 'cmocka'])
 
     unit_env = tenv.Clone()
     unit_env.AppendUnique(OBJPREFIX='utest_')
@@ -77,9 +79,6 @@ def scons():
     unit_env.d_test_program('drpc_tests',
                             ['drpc_tests.c', '../drpc.c', '../drpc.pb-c.c', mock_test_utils],
                             LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
-
-    unit_env.d_test_program('rsvc_tests', ['rsvc_tests.c', '../rsvc.c'],
-                            LIBS=['daos_common', 'gurt', 'cmocka'])
 
 
 if __name__ == "SCons.Script":


### PR DESCRIPTION
Looks rsvc_tests should use tenv instead of unit_env.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
