### PR TITLE
DAOS-15828 container: properly init ds_cont_child under check mode

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -657,6 +657,10 @@ cont_child_alloc_ref(void *co_uuid, unsigned int ksize, void *po_uuid,
 	cont->sc_dtx_cos_hdl = DAOS_HDL_INVAL;
 	D_INIT_LIST_HEAD(&cont->sc_link);
 	D_INIT_LIST_HEAD(&cont->sc_open_hdls);
+	cont->sc_dtx_committable_count = 0;
+	cont->sc_dtx_committable_coll_count = 0;
+	D_INIT_LIST_HEAD(&cont->sc_dtx_cos_list);
+	D_INIT_LIST_HEAD(&cont->sc_dtx_coll_list);
 
 	*link = &cont->sc_list;
 	return 0;

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1825,10 +1825,6 @@ dtx_cont_register(struct ds_cont_child *cont)
 		D_GOTO(out, rc = -DER_NOMEM);
 	}
 
-	cont->sc_dtx_committable_count = 0;
-	cont->sc_dtx_committable_coll_count = 0;
-	D_INIT_LIST_HEAD(&cont->sc_dtx_cos_list);
-	D_INIT_LIST_HEAD(&cont->sc_dtx_coll_list);
 	ds_cont_child_get(cont);
 	dbca->dbca_refs = 0;
 	dbca->dbca_cont = cont;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1854,19 +1854,20 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		struct dtx_scan_args	*arg;
 		int ret;
 
-		/* Since the map has been updated successfully, so let's
-		 * ignore the dtx resync failure for now.
-		 */
+		if (ds_pool_skip_for_check(pool))
+			D_GOTO(out, rc = 0);
+
 		D_ALLOC_PTR(arg);
 		if (arg == NULL)
-			D_GOTO(out, rc);
+			D_GOTO(out, rc = -DER_NOMEM);
 
 		uuid_copy(arg->pool_uuid, pool->sp_uuid);
 		arg->version = pool->sp_map_version;
 		ret = dss_ult_create(dtx_resync_ult, arg, DSS_XS_SYS,
 				     0, 0, NULL);
 		if (ret) {
-			D_ERROR("dtx_resync_ult failure %d\n", ret);
+			/* Ignore DTX resync failure that is not fatal. */
+			D_WARN("dtx_resync_ult failure %d\n", ret);
 			D_FREE(arg);
 		}
 	} else {

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1941,6 +1941,12 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 		return 0;
 	}
 
+	if (ds_pool_skip_for_check(pool)) {
+		D_DEBUG(DB_REBUILD, DF_UUID" skip rebuild under check mode\n",
+			DP_UUID(pool->sp_uuid));
+		return 0;
+	}
+
 	if (tgts != NULL && tgts->pti_number > 0 &&
 	    rebuild_op != RB_OP_RECLAIM && rebuild_op != RB_OP_FAIL_RECLAIM) {
 		/* Check if the pool already in the queue list */


### PR DESCRIPTION
Some DTX related fields in ds_cont_child structure are initialized via dtx_cont_register() that may be skipped under check mode as to some subsequent logic may access uninitialized members. Let's move such fields initialization into cont_child_alloc_ref().

Skip DTX resync and rebuild under check mode.

Features: cat_recov

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
