### PR TITLE
DAOS-14248 engine: strengthen signals handling

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1191,6 +1191,7 @@ main(int argc, char **argv)
 	sigdelset(&set, SIGFPE);
 	sigdelset(&set, SIGBUS);
 	sigdelset(&set, SIGSEGV);
+	sigdelset(&set, SIGTRAP);
 	/** also allow abort()/assert() to trigger */
 	sigdelset(&set, SIGABRT);
 
@@ -1281,6 +1282,8 @@ main(int argc, char **argv)
 		if (sig == SIGUSR1) {
 			D_INFO("got SIGUSR1, dumping Argobots infos and ULTs stacks\n");
 			dss_dump_ABT_state(abt_infos);
+			/* re-add SIGUSR2 to set */
+			sigaddset(&set, SIGUSR1);
 			continue;
 		}
 
@@ -1292,6 +1295,8 @@ main(int argc, char **argv)
 			ABT_info_trigger_print_all_thread_stacks(abt_infos,
 								 10.0, NULL,
 								 NULL);
+			/* re-add SIGUSR2 to set */
+			sigaddset(&set, SIGUSR2);
 			continue;
 		}
 

--- a/src/gurt/signals.c
+++ b/src/gurt/signals.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -91,7 +91,14 @@ print_backtrace(int signo, siginfo_t *info, void *p)
 		PRINT_ERROR("No useful backtrace available");
 	}
 
-	/* re-register old handler */
+	/* re-register old handler
+	 *
+	 * XXX we may choose to forget about old handler and simply register
+	 * signal again as SIG_DFL and raise it for corefile creation
+	 *
+	 * XXX will old handler get accurate/original siginfo_t/ucontext_t ?
+	 * should we instead call it with the same params we got ?
+	 */
 	rc = sigaction(signo, &old_handlers[signo], NULL);
 	if (rc != 0) {
 		D_ERROR("sigaction() failure registering new and reading old %d signal handler",
@@ -102,17 +109,8 @@ print_backtrace(int signo, siginfo_t *info, void *p)
 		exit(EXIT_FAILURE);
 	}
 
-	/* XXX we may choose to forget about old handler and simply register
-	 * signal again as SIG_DFL and raise it for corefile creation
-	 */
-	if (old_handlers[signo].sa_sigaction != NULL || old_handlers[signo].sa_handler != SIG_IGN) {
-		/* XXX will old handler get accurate siginfo_t/ucontext_t ?
-		 * we may prefer to call it with the same params we got ?
-		 */
-		raise(signo);
-	}
-
-	memset(&old_handlers[signo], 0, sizeof(struct sigaction));
+	/* raise signal again for either old handler or system default action */
+	raise(signo);
 }
 
 static bool register_handler = false;
@@ -142,6 +140,7 @@ d_signal_register()
 	daos_register_sighand(SIGBUS, print_backtrace);
 	daos_register_sighand(SIGSEGV, print_backtrace);
 	daos_register_sighand(SIGABRT, print_backtrace);
+	daos_register_sighand(SIGTRAP, print_backtrace);
 
 	registered = true;
 }


### PR DESCRIPTION
### Description

Revival of the PR #13031 from @bfaccini improving signal handling by the engine:

- Re-register DAOS handler in case original handler returns.
- Re-add USR1/USR2 signals to waiting set when triggered.
- Catch SIGTRAP.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
