### PR TITLE
DAOS-14739 pool: Add service-level metrics (#14273)

### DIFF
--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -28,6 +28,16 @@ struct pool_metrics {
 	struct d_tm_node_t	*query_total;
 	struct d_tm_node_t	*query_space_total;
 	struct d_tm_node_t	*evict_total;
+
+	/* service metrics */
+	struct d_tm_node_t      *service_leader;
+	struct d_tm_node_t      *map_version;
+	struct d_tm_node_t      *open_handles;
+	struct d_tm_node_t      *total_targets;
+	struct d_tm_node_t      *disabled_targets;
+	struct d_tm_node_t      *draining_targets;
+	struct d_tm_node_t      *total_ranks;
+	struct d_tm_node_t      *degraded_ranks;
 };
 
 /* Pool thread-local storage */

--- a/src/pool/srv_metrics.c
+++ b/src/pool/srv_metrics.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2021-2022 Intel Corporation.
+ * (C) Copyright 2021-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -64,6 +64,48 @@ ds_pool_metrics_alloc(const char *path, int tgt_id)
 			     "%s/ops/pool_query_space", path);
 	if (rc != 0)
 		D_WARN("Failed to create pool query space counter: "DF_RC"\n", DP_RC(rc));
+
+	rc = d_tm_add_metric(&metrics->service_leader, D_TM_GAUGE, "Pool service leader rank", NULL,
+			     "%s/svc/leader", path);
+	if (rc != 0)
+		DL_WARN(rc, "Failed to create pool service leader metric");
+
+	rc = d_tm_add_metric(&metrics->map_version, D_TM_COUNTER, "Pool map version", NULL,
+			     "%s/svc/map_version", path);
+	if (rc != 0)
+		DL_WARN(rc, "Failed to create pool map version metric");
+
+	rc = d_tm_add_metric(&metrics->open_handles, D_TM_GAUGE, "Pool handles held by clients",
+			     NULL, "%s/svc/open_pool_handles", path);
+	if (rc != 0)
+		DL_WARN(rc, "Failed to create pool handle metric");
+
+	rc = d_tm_add_metric(&metrics->total_ranks, D_TM_GAUGE, "Pool storage ranks (total)", NULL,
+			     "%s/svc/total_ranks", path);
+	if (rc != 0)
+		DL_WARN(rc, "Failed to create pool total_ranks metric");
+
+	rc = d_tm_add_metric(&metrics->degraded_ranks, D_TM_GAUGE, "Pool storage ranks (degraded)",
+			     NULL, "%s/svc/degraded_ranks", path);
+	if (rc != 0)
+		DL_WARN(rc, "Failed to create pool degraded_ranks metric");
+
+	rc = d_tm_add_metric(&metrics->total_targets, D_TM_GAUGE, "Pool storage targets (total)",
+			     NULL, "%s/svc/total_targets", path);
+	if (rc != 0)
+		DL_WARN(rc, "Failed to create pool total_targets metric");
+
+	rc = d_tm_add_metric(&metrics->draining_targets, D_TM_GAUGE,
+			     "Pool storage targets (draining)", NULL, "%s/svc/draining_targets",
+			     path);
+	if (rc != 0)
+		DL_WARN(rc, "Failed to create pool draining_targets metric");
+
+	rc = d_tm_add_metric(&metrics->disabled_targets, D_TM_GAUGE,
+			     "Pool storage targets (disabled)", NULL, "%s/svc/disabled_targets",
+			     path);
+	if (rc != 0)
+		DL_WARN(rc, "Failed to create pool disabled_targets metric");
 
 	return metrics;
 }

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1620,6 +1620,136 @@ pool_svc_check_node_status(struct pool_svc *svc)
 	D_PRINT(fmt, ## __VA_ARGS__);								\
 } while (0)
 
+static int
+pool_svc_update_map_metrics(uuid_t uuid, struct pool_map *map, struct pool_metrics *metrics)
+{
+	unsigned int   num_total    = 0;
+	unsigned int   num_enabled  = 0;
+	unsigned int   num_draining = 0;
+	unsigned int   num_disabled = 0;
+	d_rank_list_t *ranks;
+	int            rc;
+
+	if (map == NULL || metrics == NULL)
+		return -DER_INVAL;
+
+	rc = pool_map_find_failed_tgts(map, NULL, &num_disabled);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to get failed targets", DP_UUID(uuid));
+		D_GOTO(out, rc);
+	}
+	d_tm_set_gauge(metrics->disabled_targets, num_disabled);
+
+	rc = pool_map_find_tgts_by_state(map, PO_COMP_ST_DRAIN, NULL, &num_draining);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to get draining targets", DP_UUID(uuid));
+		D_GOTO(out, rc);
+	}
+	d_tm_set_gauge(metrics->draining_targets, num_draining);
+
+	rc = pool_map_find_tgts_by_state(map, -1, NULL, &num_total);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to get total targets", DP_UUID(uuid));
+		D_GOTO(out, rc);
+	}
+	d_tm_set_gauge(metrics->total_targets, num_total);
+
+	rc = pool_map_get_ranks(uuid, map, false, &ranks);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to get degraded ranks", DP_UUID(uuid));
+		D_GOTO(out, rc);
+	}
+	num_disabled = ranks->rl_nr;
+	d_tm_set_gauge(metrics->degraded_ranks, num_disabled);
+
+	d_rank_list_free(ranks);
+	rc = pool_map_get_ranks(uuid, map, true, &ranks);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to get enabled ranks", DP_UUID(uuid));
+		D_GOTO(out, rc);
+	}
+	num_enabled = ranks->rl_nr;
+	d_tm_set_gauge(metrics->total_ranks, num_enabled + num_disabled);
+
+	d_rank_list_free(ranks);
+out:
+	return rc;
+}
+
+static int
+count_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
+{
+	uint64_t *counter = varg;
+
+	if (counter == NULL)
+		return -DER_INVAL;
+	*counter = *counter + 1;
+
+	return 0;
+}
+
+static int
+pool_svc_step_up_metrics(struct pool_svc *svc, d_rank_t leader, uint32_t map_version,
+			 struct pool_buf *map_buf)
+{
+	struct pool_map     *map;
+	struct pool_metrics *metrics = svc->ps_pool->sp_metrics[DAOS_POOL_MODULE];
+	struct rdb_tx        tx;
+	uint64_t             handle_count = 0;
+	int                  rc;
+
+	rc = pool_map_create(map_buf, map_version, &map);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to create pool map", DP_UUID(svc->ps_uuid));
+		D_GOTO(out, rc);
+	}
+
+	d_tm_set_gauge(metrics->service_leader, leader);
+	d_tm_set_counter(metrics->map_version, map_version);
+
+	rc = pool_svc_update_map_metrics(svc->ps_uuid, map, metrics);
+	if (rc != 0) {
+		DL_WARN(rc, DF_UUID ": failed to update pool metrics", DP_UUID(svc->ps_uuid));
+		rc = 0; /* not fatal */
+	}
+
+	rc = rdb_tx_begin(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term, &tx);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to get rdb transaction", DP_UUID(svc->ps_uuid));
+		D_GOTO(out_map, rc);
+	}
+
+	rc = rdb_tx_iterate(&tx, &svc->ps_handles, false, count_iter_cb, &handle_count);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to count open pool handles", DP_UUID(svc->ps_uuid));
+		D_GOTO(out_tx, rc);
+	}
+	d_tm_set_gauge(metrics->open_handles, handle_count);
+
+out_tx:
+	rdb_tx_end(&tx);
+out_map:
+	pool_map_decref(map);
+out:
+	return rc;
+}
+
+static void
+pool_svc_step_down_metrics(struct pool_svc *svc)
+{
+	struct pool_metrics *metrics = svc->ps_pool->sp_metrics[DAOS_POOL_MODULE];
+
+	/* NB: zero these out to indicate that this rank is not leader */
+	d_tm_set_gauge(metrics->service_leader, 0);
+	d_tm_set_counter(metrics->map_version, 0);
+	d_tm_set_gauge(metrics->open_handles, 0);
+	d_tm_set_gauge(metrics->draining_targets, 0);
+	d_tm_set_gauge(metrics->disabled_targets, 0);
+	d_tm_set_gauge(metrics->total_targets, 0);
+	d_tm_set_gauge(metrics->degraded_ranks, 0);
+	d_tm_set_gauge(metrics->total_ranks, 0);
+}
+
 static void pool_svc_schedule(struct pool_svc *svc, struct pool_svc_sched *sched,
 			      void (*func)(void *));
 static void pool_svc_reconf_ult(void *arg);
@@ -1718,6 +1848,13 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	if (rc != 0)
 		goto out;
 
+	rc = pool_svc_step_up_metrics(svc, rank, map_version, map_buf);
+	if (rc != 0) {
+		DL_ERROR(rc, DF_UUID ": failed to initialize pool service metrics",
+			 DP_UUID(svc->ps_uuid));
+		D_GOTO(out, rc);
+	}
+
 	DS_POOL_NOTE_PRINT(DF_UUID": rank %u became pool service leader "DF_U64": srv_pool_hdl="
 			   DF_UUID" srv_cont_hdl="DF_UUID"\n", DP_UUID(svc->ps_uuid), rank,
 			   svc->ps_rsvc.s_term, DP_UUID(pool_hdl_uuid), DP_UUID(cont_hdl_uuid));
@@ -1752,6 +1889,7 @@ pool_svc_step_down_cb(struct ds_rsvc *rsvc)
 	struct pool_svc	       *svc = pool_svc_obj(rsvc);
 	d_rank_t		rank = dss_self_rank();
 
+	pool_svc_step_down_metrics(svc);
 	fini_events(svc);
 	sched_cancel_and_wait(&svc->ps_reconf_sched);
 	sched_cancel_and_wait(&svc->ps_rfcheck_sched);
@@ -1770,7 +1908,8 @@ pool_svc_drain_cb(struct ds_rsvc *rsvc)
 static int
 pool_svc_map_dist_cb(struct ds_rsvc *rsvc)
 {
-	struct pool_svc	       *svc = pool_svc_obj(rsvc);
+	struct pool_svc        *svc = pool_svc_obj(rsvc);
+	struct pool_metrics    *metrics;
 	struct rdb_tx		tx;
 	struct pool_buf	       *map_buf = NULL;
 	uint32_t		map_version;
@@ -1797,6 +1936,9 @@ pool_svc_map_dist_cb(struct ds_rsvc *rsvc)
 		D_GOTO(out, rc);
 	}
 	svc->ps_global_map_version = max(svc->ps_global_map_version, map_version);
+
+	metrics = svc->ps_pool->sp_metrics[DAOS_POOL_MODULE];
+	d_tm_set_counter(metrics->map_version, map_version);
 out:
 	if (map_buf != NULL)
 		D_FREE(map_buf);
@@ -3025,6 +3167,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc, int handler_version)
 	/** update metric */
 	metrics = svc->ps_pool->sp_metrics[DAOS_POOL_MODULE];
 	d_tm_inc_counter(metrics->connect_total, 1);
+	d_tm_inc_gauge(metrics->open_handles, 1);
 
 	if (in->pci_query_bits & DAOS_PO_QUERY_SPACE)
 		rc = pool_space_query_bcast(rpc->cr_ctx, svc, in->pci_op.pi_hdl,
@@ -3116,6 +3259,7 @@ pool_disconnect_hdls(struct rdb_tx *tx, struct pool_svc *svc, uuid_t *hdl_uuids,
 {
 	d_iov_t			 value;
 	uint32_t		 nhandles;
+	struct pool_metrics     *metrics;
 	int			 i;
 	int			 rc;
 
@@ -3159,6 +3303,8 @@ pool_disconnect_hdls(struct rdb_tx *tx, struct pool_svc *svc, uuid_t *hdl_uuids,
 	if (rc != 0)
 		D_GOTO(out, rc);
 
+	metrics = svc->ps_pool->sp_metrics[DAOS_POOL_MODULE];
+	d_tm_dec_gauge(metrics->open_handles, n_hdl_uuids);
 out:
 	if (rc == 0)
 		D_INFO(DF_UUID": success\n", DP_UUID(svc->ps_uuid));
@@ -6102,6 +6248,13 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 	pool_svc_schedule(svc, &svc->ps_reconf_sched, pool_svc_reconf_ult);
 	if (opc == MAP_EXCLUDE)
 		pool_svc_schedule(svc, &svc->ps_rfcheck_sched, pool_svc_rfcheck_ult);
+
+	rc = pool_svc_update_map_metrics(svc->ps_uuid, map,
+					 svc->ps_pool->sp_metrics[DAOS_POOL_MODULE]);
+	if (rc != 0) {
+		DL_WARN(rc, DF_UUID ": failed to update pool metrics", DP_UUID(svc->ps_uuid));
+		rc = 0; /* not fatal */
+	}
 
 out_map_buf:
 	pool_buf_free(map_buf);

--- a/src/tests/ftest/telemetry/pool_svc_metrics.py
+++ b/src/tests/ftest/telemetry/pool_svc_metrics.py
@@ -1,0 +1,130 @@
+'''
+  (C) Copyright 2024 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+'''
+import time
+
+from telemetry_test_base import TestWithTelemetry
+
+MAP_VERSION_METRIC = "engine_pool_svc_map_version"
+SVC_LEADER_METRIC = "engine_pool_svc_leader"
+DEGRADED_RANKS_METRIC = "engine_pool_svc_degraded_ranks"
+
+
+class PoolServiceMetrics(TestWithTelemetry):
+    """Verify pool service metric values.
+
+    :avocado: recursive
+    """
+
+    def collect_svc_telemetry(self, pool_uuid):
+        """Collect the pool service metric values.
+
+        Args:
+            pool_uuid (str): The UUID of the pool to collect metrics from.
+
+        Returns:
+            dict: A dict of the current pool service leader's metrics.
+        """
+        def _map_version(rank_metrics):
+            if rank_metrics is None or MAP_VERSION_METRIC not in rank_metrics:
+                return 0
+            return rank_metrics[MAP_VERSION_METRIC]
+
+        def _pool_rank_metrics(host_metrics, pool_uuid):
+            self.log.debug("collecting rank metrics for pool: %s", pool_uuid)
+            pm = {}
+            for hm in host_metrics.values():
+                for k, v in hm.items():
+                    try:
+                        for m in v['metrics']:
+                            if m['labels']['pool'].casefold() != str(pool_uuid).casefold():
+                                continue
+                            rank = m['labels']['rank']
+                            if rank not in pm:
+                                pm[rank] = {}
+                            pm[rank][k] = m['value']
+                    except KeyError:
+                        continue
+            return pm
+
+        metrics_list = ",".join(self.telemetry.ENGINE_POOL_SVC_METRICS)
+        host_metrics = self.telemetry.get_metrics(metrics_list)
+        self.log.debug("host metrics: %s", host_metrics)
+        pr_metrics = _pool_rank_metrics(host_metrics, pool_uuid)
+        self.log.debug("pool rank metrics: %s", pr_metrics)
+        leader_metrics = {}
+        for metrics in pr_metrics.values():
+            if _map_version(metrics) > _map_version(leader_metrics):
+                leader_metrics = metrics
+
+        self.log.debug("Pool service leader metrics: %s", leader_metrics)
+        return leader_metrics
+
+    def test_pool_service_metrics(self):
+        """Test that pool service telemetry is updated as expected.
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=telemetry
+        :avocado: tags=PoolServiceMetrics,test_pool_service_metrics
+        """
+        self.log_step("Create pool for testing.")
+        pool = self.get_pool(connect=True)
+
+        self.log_step("Collect pool service metrics prior to making changes.")
+        initial_metrics = self.collect_svc_telemetry(pool.uuid)
+        self.assertTrue(MAP_VERSION_METRIC in initial_metrics,
+                        f"initial metrics don't contain {MAP_VERSION_METRIC} (no leader?)")
+        self.assertTrue(initial_metrics[MAP_VERSION_METRIC] == 1,
+                        "initial pool service map version is not 1")
+        self.assertTrue(initial_metrics[DEGRADED_RANKS_METRIC] == 0,
+                        "initial pool service degraded rank count is not 0")
+
+        restart_rank = initial_metrics[SVC_LEADER_METRIC]
+        self.log_step(f"Stop pool service leader rank: {restart_rank}")
+        self.server_managers[0].stop_ranks(ranks=[restart_rank], daos_log=self.d_log)
+
+        self.log_step("Verify the pool service leader rank has stopped successfully.")
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[restart_rank], valid_states=["stopped", "excluded"], max_checks=15)
+        if failed_ranks:
+            self.fail(f"Rank {restart_rank} didn't stop!")
+
+        def _wait_for_telemetry(test):
+            metrics = self.collect_svc_telemetry(pool.uuid)
+            while True:
+                try:
+                    if test(metrics):
+                        return metrics
+                except KeyError:
+                    pass
+
+                self.log.info("waiting for pool telemetry to update")
+                time.sleep(5)
+                metrics = self.collect_svc_telemetry(pool.uuid)
+
+        self.log_step("Wait for rank exclusion to show up in the telemetry.")
+        metrics = _wait_for_telemetry(lambda m: m[MAP_VERSION_METRIC] > 1)
+
+        self.log_step("Verify that the pool service telemetry has updated.")
+        self.assertTrue(metrics[DEGRADED_RANKS_METRIC] == 1,
+                        "pool service degraded rank count should be 1")
+
+        self.log_step("Restart the stopped rank.")
+        self.server_managers[0].start_ranks(ranks=[restart_rank], daos_log=self.d_log)
+
+        self.log_step("Verify the desired rank restarted successfully.")
+        failed_ranks = self.server_managers[0].check_rank_state(
+            ranks=[restart_rank], valid_states=["joined"], max_checks=15)
+        if failed_ranks:
+            self.fail(f"Rank {restart_rank} didn't start!")
+
+        self.log_step("Reintegrate failed rank back into the pool.")
+        pool.reintegrate(restart_rank)
+
+        self.log_step("Wait for reintegration to show up in the telemetry.")
+        metrics = _wait_for_telemetry(lambda m: m[DEGRADED_RANKS_METRIC] == 0)
+
+        self.log_step("Test passed.")

--- a/src/tests/ftest/telemetry/pool_svc_metrics.yaml
+++ b/src/tests/ftest/telemetry/pool_svc_metrics.yaml
@@ -1,0 +1,17 @@
+hosts:
+  test_servers: 3
+timeout: 300
+server_config:
+  name: daos_server
+  engines_per_host: 1
+  engines:
+    0:
+      targets: 4
+      nr_xs_helpers: 0
+      storage:
+        0:
+          class: ram
+          scm_mount: /mnt/daos
+  system_ram_reserved: 1
+pool:
+  scm_size: 1G

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -9,6 +9,7 @@ import re
 from logging import getLogger
 
 from ClusterShell.NodeSet import NodeSet
+from exception_utils import CommandFailure
 
 
 def _gen_stats_metrics(basename):
@@ -141,6 +142,15 @@ class TelemetryUtils():
     ENGINE_POOL_VOS_SPACE_METRICS = [
         "engine_pool_vos_space_nvme_used",
         "engine_pool_vos_space_scm_used"]
+    ENGINE_POOL_SVC_METRICS = [
+        "engine_pool_svc_degraded_ranks",
+        "engine_pool_svc_disabled_targets",
+        "engine_pool_svc_draining_targets",
+        "engine_pool_svc_leader",
+        "engine_pool_svc_map_version",
+        "engine_pool_svc_open_pool_handles",
+        "engine_pool_svc_total_ranks",
+        "engine_pool_svc_total_targets"]
     ENGINE_POOL_METRICS = ENGINE_POOL_ACTION_METRICS +\
         ENGINE_POOL_BLOCK_ALLOCATOR_METRICS +\
         ENGINE_POOL_CHECKPOINT_METRICS +\
@@ -149,7 +159,8 @@ class TelemetryUtils():
         ENGINE_POOL_OPS_METRICS +\
         ENGINE_POOL_SCRUBBER_METRICS +\
         ENGINE_POOL_VOS_AGGREGATION_METRICS +\
-        ENGINE_POOL_VOS_SPACE_METRICS
+        ENGINE_POOL_VOS_SPACE_METRICS + \
+        ENGINE_POOL_SVC_METRICS
     ENGINE_EVENT_METRICS = [
         "engine_events_dead_ranks",
         "engine_events_last_event_ts",
@@ -472,8 +483,12 @@ class TelemetryUtils():
         host_list = hosts or self.hosts
         self.log.info("Listing telemetry metrics from %s", host_list)
         for host in host_list:
-            data = self.dmg.telemetry_metrics_list(host=host)
             info[host] = []
+            try:
+                data = self.dmg.telemetry_metrics_list(host=host)
+            except CommandFailure as err:
+                self.log.error("Failed to list metrics on %s: %s", host, err)
+                continue
             if "response" in data:
                 if "available_metric_sets" in data["response"]:
                     for entry in data["response"]["available_metric_sets"]:
@@ -535,8 +550,12 @@ class TelemetryUtils():
         host_list = hosts or self.hosts
         self.log.info("Querying telemetry metric %s from %s", name, host_list)
         for host in host_list:
-            data = self.dmg.telemetry_metrics_query(host=host, metrics=name)
             info[host] = {}
+            try:
+                data = self.dmg.telemetry_metrics_query(host=host, metrics=name)
+            except CommandFailure as err:
+                self.log.error("Failed to get metrics for %s: %s", host, err)
+                continue
             if "response" in data:
                 if "metric_sets" in data["response"]:
                     for entry in data["response"]["metric_sets"]:


### PR DESCRIPTION
Adds a new /svc group under each pool which contains
the following set of metrics:
  * leader (gauge): Current pool service leader rank
  * map_version (counter): Current pool map version
  * open_pool_handles (gauge): Current count of open handles
  * total_ranks (gauge): Number of ranks in pool map
  * degraded_ranks (gauge): Number of ranks with disabled targets
  * total_targets (gauge): Number of targets in pool map
  * disabled_targets (gauge): Number of targets marked disabled
  * draining_targets (gauge): Number of targets in draining state

For non-leader ranks, the service metrics will have zero
values. Telemetry consumers may positively identify the
current leader by checking the value of map_version, which
will always be non-zero for the leader.

Required-githooks: true

Change-Id: I6e82db981247f3e4fe4e2b434a688d4083be158c
Signed-off-by: Michael MacDonald <mjmac@google.com>