### PR TITLE
Shilongw/debug daos 15076

### DIFF
--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -1389,9 +1389,6 @@ sched_req_enqueue(struct dss_xstream *dx, struct sched_req_attr *attr,
 	struct sched_request	*req;
 	struct sched_info	*info = &dx->dx_sched_info;
 
-	if (!should_enqueue_req(dx, attr))
-		return req_kickoff_internal(dx, attr, func, arg);
-
 	if (attr->sra_enqueue_id == 0)
 		attr->sra_enqueue_id = ++info->si_cur_id;
 	else
@@ -1412,6 +1409,9 @@ sched_req_enqueue(struct dss_xstream *dx, struct sched_req_attr *attr,
 		d_tm_inc_counter(info->si_stats.ss_total_reject, 1);
 		return -DER_OVERLOAD_RETRY;
 	}
+
+	if (!should_enqueue_req(dx, attr))
+		return req_kickoff_internal(dx, attr, func, arg);
 
 	D_ASSERT(attr->sra_type < SCHED_REQ_MAX);
 	req = req_get(dx, attr, func, arg, ABT_THREAD_NULL, false);

--- a/src/engine/sched.c
+++ b/src/engine/sched.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1188,11 +1188,16 @@ policy_fifo_enqueue(struct dss_xstream *dx, struct sched_request *req,
 
 	D_ASSERT(attr->sra_type < SCHED_REQ_TYPE_MAX);
 	/*
-	 * If @sra_enqueue_id is not zero, this is a resent RPC, it will
-	 * be inserted to sorted heap instead of fifo list.
+	 * The initial motivation behind this change is to utilize the heap
+	 * exclusively for sorted resent RPCs and the FIFO list for regular
+	 * fetch and update requests. This strategic allocation aims to avoid
+	 * potential performance impacts that could result from maintaining a
+	 * heap in the critical hot path.
 	 */
-	if (attr->sra_enqueue_id)
+	if (attr->sra_flags & SCHED_REQ_FL_RESENT) {
+		D_ASSERT(attr->sra_enqueue_id > 0);
 		return d_binheap_insert(&info->si_heap, &req->sr_node);
+	}
 
 	d_list_add_tail(&req->sr_link, &info->si_fifo_list);
 
@@ -1389,6 +1394,8 @@ sched_req_enqueue(struct dss_xstream *dx, struct sched_req_attr *attr,
 
 	if (attr->sra_enqueue_id == 0)
 		attr->sra_enqueue_id = ++info->si_cur_id;
+	else
+		attr->sra_flags |= SCHED_REQ_FL_RESENT;
 
 	/*
 	 * A RPC flow control mechanism is introduced to avoid RPC timeout when the

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -368,7 +368,7 @@ static inline bool
 dss_xstream_has_nvme(struct dss_xstream *dx)
 {
 
-	if (dx->dx_main_xs != 0)
+	if (dx->dx_main_xs)
 		return true;
 	if (bio_nvme_configured(SMD_DEV_TYPE_META) && dx->dx_xs_id == 0)
 		return true;

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -94,20 +94,10 @@ enum daos_rpc_type {
 };
 
 struct daos_req_comm_in {
-	/** Request user ID, reserved for NRS */
-	uint32_t	req_in_uid;
-	/** Request group ID, reserved for NRS */
-	uint32_t	req_in_gid;
-	/** Request project ID, reserved for NRS */
-	uint32_t	req_in_projid;
 	/** Enqueue ID of the request on the server side, for server overloaded retry */
 	uint64_t	req_in_enqueue_id;
 	/** Reserved for future extension */
 	uint64_t	req_in_paddings[4];
-	/** Request client address, reserved for NRS */
-	d_string_t	req_in_addr;
-	/** Job ID of the request, reserved for NRS */
-	d_string_t	req_in_jobid;
 };
 
 struct daos_req_comm_out {

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -230,6 +230,7 @@ enum {
 	SCHED_REQ_FL_NO_DELAY	= (1 << 0),
 	SCHED_REQ_FL_PERIODIC	= (1 << 1),
 	SCHED_REQ_FL_NO_REJECT	= (1 << 2),
+	SCHED_REQ_FL_RESENT	= (1 << 3),
 };
 
 struct sched_req_attr {

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1036,15 +1036,6 @@ crt_proc_struct_daos_req_comm_in(crt_proc_t proc, crt_proc_op_t proc_op,
 	int	rc;
 	int	i;
 
-	rc = crt_proc_uint32_t(proc, proc_op, &drci->req_in_uid);
-	if (unlikely(rc))
-		return rc;
-	rc = crt_proc_uint32_t(proc, proc_op, &drci->req_in_gid);
-	if (unlikely(rc))
-		return rc;
-	rc = crt_proc_uint32_t(proc, proc_op, &drci->req_in_projid);
-	if (unlikely(rc))
-		return rc;
 	rc = crt_proc_uint64_t(proc, proc_op, &drci->req_in_enqueue_id);
 	if (unlikely(rc))
 		return rc;
@@ -1053,12 +1044,6 @@ crt_proc_struct_daos_req_comm_in(crt_proc_t proc, crt_proc_op_t proc_op,
 		if (rc)
 			return rc;
 	}
-	rc = crt_proc_d_string_t(proc, proc_op, &drci->req_in_addr);
-	if (unlikely(rc))
-		return rc;
-	rc = crt_proc_d_string_t(proc, proc_op, &drci->req_in_jobid);
-	if (unlikely(rc))
-		return rc;
 
 	return rc;
 }

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -217,13 +217,6 @@ obj_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
 
 	D_ASSERT(proto_ver == DAOS_OBJ_VERSION || proto_ver == DAOS_OBJ_VERSION - 1);
 
-	/*
-	 * Proto v9 doesn't support hint return cart timeout for retry
-	 * skip RPC rejections for them.
-	 */
-	if (proto_ver == 9)
-		attr->sra_flags |= SCHED_REQ_FL_NO_REJECT;
-
 	/* Extract hint from RPC */
 	attr->sra_enqueue_id = 0;
 	if (obj_rpc_is_update(rpc) || obj_rpc_is_fetch(rpc)) {
@@ -250,7 +243,7 @@ obj_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
 
 			attr->sra_enqueue_id = oei_v10->oei_comm_in.req_in_enqueue_id;
 		}
-		sched_req_attr_init(attr, SCHED_REQ_FETCH, &oei->oei_pool_uuid);
+		sched_req_attr_init(attr, SCHED_REQ_ANONYM, &oei->oei_pool_uuid);
 	} else if (obj_rpc_is_punch(rpc)) {
 		struct obj_punch_in *opi = crt_req_get(rpc);
 
@@ -259,7 +252,7 @@ obj_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
 
 			attr->sra_enqueue_id = opi_v10->opi_comm_in.req_in_enqueue_id;
 		}
-		sched_req_attr_init(attr, SCHED_REQ_UPDATE, &opi->opi_pool_uuid);
+		sched_req_attr_init(attr, SCHED_REQ_ANONYM, &opi->opi_pool_uuid);
 	} else if (obj_rpc_is_query(rpc)) {
 		struct obj_query_key_in *okqi = crt_req_get(rpc);
 
@@ -268,7 +261,7 @@ obj_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
 
 			attr->sra_enqueue_id = okqi_v10->okqi_comm_in.req_in_enqueue_id;
 		}
-		sched_req_attr_init(attr, SCHED_REQ_FETCH, &okqi->okqi_pool_uuid);
+		sched_req_attr_init(attr, SCHED_REQ_ANONYM, &okqi->okqi_pool_uuid);
 	} else if (obj_rpc_is_sync(rpc)) {
 		struct obj_sync_in *osi = crt_req_get(rpc);
 
@@ -277,7 +270,7 @@ obj_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
 
 			attr->sra_enqueue_id = osi_v10->osi_comm_in.req_in_enqueue_id;
 		}
-		sched_req_attr_init(attr, SCHED_REQ_UPDATE, &osi->osi_pool_uuid);
+		sched_req_attr_init(attr, SCHED_REQ_ANONYM, &osi->osi_pool_uuid);
 	} else if (obj_rpc_is_key2anchor(rpc)) {
 		struct obj_key2anchor_in *oki = crt_req_get(rpc);
 
@@ -286,25 +279,32 @@ obj_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
 
 			attr->sra_enqueue_id = oki_v10->oki_comm_in.req_in_enqueue_id;
 		}
-		sched_req_attr_init(attr, SCHED_REQ_FETCH, &oki->oki_pool_uuid);
+		sched_req_attr_init(attr, SCHED_REQ_ANONYM, &oki->oki_pool_uuid);
 	} else if (obj_rpc_is_ec_agg(rpc)) {
 		struct obj_ec_agg_in *ea = crt_req_get(rpc);
 
 		attr->sra_enqueue_id = ea->ea_comm_in.req_in_enqueue_id;
-		sched_req_attr_init(attr, SCHED_REQ_MIGRATE, &ea->ea_pool_uuid);
+		sched_req_attr_init(attr, SCHED_REQ_ANONYM, &ea->ea_pool_uuid);
 	} else if (obj_rpc_is_ec_rep(rpc)) {
 		struct obj_ec_rep_in *er = crt_req_get(rpc);
 
 		attr->sra_enqueue_id = er->er_comm_in.req_in_enqueue_id;
-		sched_req_attr_init(attr, SCHED_REQ_MIGRATE, &er->er_pool_uuid);
+		sched_req_attr_init(attr, SCHED_REQ_ANONYM, &er->er_pool_uuid);
 	} else if (obj_rpc_is_cpd(rpc)) {
 		struct obj_cpd_in *oci = crt_req_get(rpc);
 
-		sched_req_attr_init(attr, SCHED_REQ_MIGRATE, &oci->oci_pool_uuid);
+		sched_req_attr_init(attr, SCHED_REQ_ANONYM, &oci->oci_pool_uuid);
 	} else {
 		/* Other requests will not be queued, see dss_rpc_hdlr() */
 		return -DER_NOSYS;
 	}
+	/*
+	 * Proto v9 doesn't support hint return cart timeout for retry
+	 * skip RPC rejections for them.
+	 */
+	if (proto_ver == 9)
+		attr->sra_flags |= SCHED_REQ_FL_NO_REJECT;
+
 
 	return 0;
 }


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
