### PR TITLE
DAOS-15476 client: Better protocol query handling

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -346,8 +346,7 @@ crt_register_proto_fi(crt_endpoint_t *ep)
 	if (rc != 0)
 		return -DER_MISC;
 
-	rc = crt_proto_query(ep, cpf.cpf_base, &cpf.cpf_ver,
-			     1, crt_pfi_cb, &pfi);
+	rc = crt_proto_query(ep, cpf.cpf_base, &cpf.cpf_ver, 1, 0, crt_pfi_cb, &pfi);
 	if (rc != -DER_SUCCESS)
 		D_GOTO(out, rc);
 
@@ -386,8 +385,7 @@ crt_register_proto_ctl(crt_endpoint_t *ep)
 	if (rc != 0)
 		return -DER_MISC;
 
-	rc = crt_proto_query(ep, cpf.cpf_base, &cpf.cpf_ver,
-			     1, crt_pfi_cb, &pfi);
+	rc = crt_proto_query(ep, cpf.cpf_base, &cpf.cpf_ver, 1, 0, crt_pfi_cb, &pfi);
 	if (rc != -DER_SUCCESS)
 		D_GOTO(out, rc);
 

--- a/src/client/api/rpc.c
+++ b/src/client/api/rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -7,7 +7,6 @@
 
 #include <daos/rpc.h>
 #include <daos/event.h>
-#include <daos/rsvc.h>
 #include <daos/mgmt.h>
 
 static void
@@ -96,14 +95,14 @@ daos_rpc_send_wait(crt_rpc_t *rpc)
 }
 
 struct rpc_proto {
-	struct rsvc_client	cli;
-	crt_endpoint_t		ep;
-	int			version;
-	int			rc;
-	bool			completed;
-	crt_opcode_t		base_opc;
-	uint32_t		*ver_array;
-	uint32_t		 array_size;
+	int            nr_ranks;
+	crt_endpoint_t ep;
+	int            version;
+	int            rc;
+	bool           completed;
+	crt_opcode_t   base_opc;
+	uint32_t      *ver_array;
+	uint32_t       array_size;
 };
 
 static void
@@ -113,16 +112,10 @@ query_cb(struct crt_proto_query_cb_info *cb_info)
 	int			 rc;
 
 	if (daos_rpc_retryable_rc(cb_info->pq_rc)) {
-		rc = rsvc_client_choose(&rproto->cli, &rproto->ep);
-		if (rc) {
-			D_ERROR("rsvc_client_choose() failed: "DF_RC"\n", DP_RC(rc));
-			rproto->rc = rc;
-			rproto->completed = true;
-		}
-
-		rc = crt_proto_query_with_ctx(&rproto->ep, rproto->base_opc,
-					      rproto->ver_array, rproto->array_size,
-					      query_cb, rproto, daos_get_crt_ctx());
+		rproto->ep.ep_rank = (rproto->ep.ep_rank + 1) % rproto->nr_ranks;
+		rc = crt_proto_query_with_ctx(&rproto->ep, rproto->base_opc, rproto->ver_array,
+					      rproto->array_size, query_cb, rproto,
+					      daos_get_crt_ctx());
 		if (rc) {
 			D_ERROR("crt_proto_query_with_ctx() failed: "DF_RC"\n", DP_RC(rc));
 			rproto->rc = rc;
@@ -141,8 +134,7 @@ daos_rpc_proto_query(crt_opcode_t base_opc, uint32_t *ver_array, int count, int 
 	struct dc_mgmt_sys	*sys;
 	struct rpc_proto	*rproto = NULL;
 	crt_context_t		 ctx = daos_get_crt_ctx();
-	int			 rc;
-	int			 num_ranks;
+	int                      rc;
 	int			 i;
 
 	rc = dc_mgmt_sys_attach(NULL, &sys);
@@ -155,39 +147,34 @@ daos_rpc_proto_query(crt_opcode_t base_opc, uint32_t *ver_array, int count, int 
 	if (rproto == NULL)
 		D_GOTO(out_detach, rc = -DER_NOMEM);
 
-	rc = rsvc_client_init(&rproto->cli, sys->sy_info.ms_ranks);
-	if (rc) {
-		D_ERROR("rsvc_client_init() failed: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_free, rc);
-	}
-
-	num_ranks = dc_mgmt_net_get_num_srv_ranks();
-	rproto->ep.ep_rank = rand() % num_ranks;
+	/** select a random rank to issue the proto query rpc to */
+	rproto->nr_ranks   = dc_mgmt_net_get_num_srv_ranks();
+	rproto->ep.ep_rank = d_rand() % rproto->nr_ranks;
+	rproto->ep.ep_tag  = 0;
 	rproto->ver_array = ver_array;
 	rproto->array_size = count;
-	rproto->ep.ep_grp = sys->sy_group;
-	rproto->ep.ep_tag = 0;
+	rproto->ep.ep_grp  = sys->sy_group;
 	rproto->base_opc = base_opc;
 
 	rc = crt_proto_query_with_ctx(&rproto->ep, base_opc,
 				      ver_array, count, query_cb, rproto, ctx);
 	if (rc) {
 		D_ERROR("crt_proto_query_with_ctx() failed: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_rsvc, rc);
+		D_GOTO(out_free, rc);
 	}
 
 	while (!rproto->completed) {
 		rc = crt_progress(ctx, 0);
 		if (rc && rc != -DER_TIMEDOUT) {
 			D_ERROR("failed to progress CART context: %d\n", rc);
-			D_GOTO(out_rsvc, rc);
+			D_GOTO(out_free, rc);
 		}
 	}
 
 	if (rproto->rc != -DER_SUCCESS) {
 		rc = rproto->rc;
 		D_ERROR("crt_proto_query()failed: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_rsvc, rc);
+		D_GOTO(out_free, rc);
 	}
 	rc = 0;
 
@@ -201,8 +188,6 @@ daos_rpc_proto_query(crt_opcode_t base_opc, uint32_t *ver_array, int count, int 
 	} else {
 		*ret_ver = rproto->version;
 	}
-out_rsvc:
-	rsvc_client_fini(&rproto->cli);
 out_free:
 	D_FREE(rproto);
 out_detach:

--- a/src/client/api/rpc.c
+++ b/src/client/api/rpc.c
@@ -103,6 +103,7 @@ struct rpc_proto {
 	crt_opcode_t   base_opc;
 	uint32_t      *ver_array;
 	uint32_t       array_size;
+	uint32_t       timeout;
 };
 
 static void
@@ -113,8 +114,9 @@ query_cb(struct crt_proto_query_cb_info *cb_info)
 
 	if (daos_rpc_retryable_rc(cb_info->pq_rc)) {
 		rproto->ep.ep_rank = (rproto->ep.ep_rank + 1) % rproto->nr_ranks;
+		rproto->timeout += 3;
 		rc = crt_proto_query_with_ctx(&rproto->ep, rproto->base_opc, rproto->ver_array,
-					      rproto->array_size, query_cb, rproto,
+					      rproto->array_size, rproto->timeout, query_cb, rproto,
 					      daos_get_crt_ctx());
 		if (rc) {
 			D_ERROR("crt_proto_query_with_ctx() failed: "DF_RC"\n", DP_RC(rc));
@@ -155,9 +157,10 @@ daos_rpc_proto_query(crt_opcode_t base_opc, uint32_t *ver_array, int count, int 
 	rproto->array_size = count;
 	rproto->ep.ep_grp  = sys->sy_group;
 	rproto->base_opc = base_opc;
+	rproto->timeout    = 3;
 
-	rc = crt_proto_query_with_ctx(&rproto->ep, base_opc,
-				      ver_array, count, query_cb, rproto, ctx);
+	rc = crt_proto_query_with_ctx(&rproto->ep, base_opc, ver_array, count, rproto->timeout,
+				      query_cb, rproto, ctx);
 	if (rc) {
 		D_ERROR("crt_proto_query_with_ctx() failed: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out_free, rc);

--- a/src/common/rsvc.c
+++ b/src/common/rsvc.c
@@ -91,7 +91,7 @@ rsvc_client_choose(struct rsvc_client *client, crt_endpoint_t *ep)
 		chosen = client->sc_leader_index;
 	} else {
 		if (client->sc_next < 0)
-			client->sc_next = d_randn(client->sc_ranks->rl_nr);
+			client->sc_next = d_rand() % client->sc_ranks->rl_nr;
 		chosen = client->sc_next;
 		/* The hintless search is a round robin of all replicas. */
 		client->sc_next++;
@@ -148,7 +148,7 @@ rsvc_client_process_error(struct rsvc_client *client, int rc,
 			 * search.
 			 */
 			D_DEBUG(DB_MD, "give up leader rank %u\n", ep->ep_rank);
-			client->sc_next = d_randn(client->sc_ranks->rl_nr);
+			client->sc_next = d_rand() % client->sc_ranks->rl_nr;
 			if (client->sc_next == leader_index) {
 				client->sc_next++;
 				client->sc_next %= client->sc_ranks->rl_nr;

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -498,7 +498,7 @@ d_rank_list_shuffle(d_rank_list_t *rank_list)
 		return;
 
 	for (i = 0; i < rank_list->rl_nr; i++) {
-		j = rand() % rank_list->rl_nr;
+		j = d_rand() % rank_list->rl_nr;
 		tmp = rank_list->rl_ranks[i];
 		rank_list->rl_ranks[i] = rank_list->rl_ranks[j];
 		rank_list->rl_ranks[j] = tmp;

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1875,6 +1875,8 @@ crt_proto_register(struct crt_proto_format *cpf);
  * \param[in] base_opc         the base opcode for the protocol
  * \param[in] ver              array of protocol version
  * \param[in] count            number of elements in ver
+ * \param[in] timeout          Timeout in seconds, ignored if 0 or greater than
+ *                             default timeout
  * \param[in] cb               completion callback. crt_proto_query() internally
  *                             sends an RPC to \a tgt_ep. \a cb will be called
  *                             upon completion of that RPC. The highest protocol
@@ -1888,8 +1890,8 @@ crt_proto_register(struct crt_proto_format *cpf);
  *                             failure.
  */
 int
-crt_proto_query(crt_endpoint_t *tgt_ep, crt_opcode_t base_opc,
-		uint32_t *ver, int count, crt_proto_query_cb_t cb, void *arg);
+crt_proto_query(crt_endpoint_t *tgt_ep, crt_opcode_t base_opc, uint32_t *ver, int count,
+		uint32_t timeout, crt_proto_query_cb_t cb, void *arg);
 
 /**
  * query tgt_ep if it has registered base_opc with version using a user provided cart context.
@@ -1898,6 +1900,8 @@ crt_proto_query(crt_endpoint_t *tgt_ep, crt_opcode_t base_opc,
  * \param[in] base_opc         the base opcode for the protocol
  * \param[in] ver              array of protocol version
  * \param[in] count            number of elements in ver
+ * \param[in] timeout          Timeout in seconds, ignored if 0 or greater than
+ *                             default timeout
  * \param[in] cb               completion callback. crt_proto_query() internally
  *                             sends an RPC to \a tgt_ep. \a cb will be called
  *                             upon completion of that RPC. The highest protocol
@@ -1912,7 +1916,7 @@ crt_proto_query(crt_endpoint_t *tgt_ep, crt_opcode_t base_opc,
  */
 int
 crt_proto_query_with_ctx(crt_endpoint_t *tgt_ep, crt_opcode_t base_opc, uint32_t *ver, int count,
-			 crt_proto_query_cb_t cb, void *arg, crt_context_t ctx);
+			 uint32_t timeout, crt_proto_query_cb_t cb, void *arg, crt_context_t ctx);
 /**
  * Set self rank.
  *

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -74,7 +74,6 @@ extern "C" {
 
 void d_srand(long int);
 long int d_rand(void);
-long int d_randn(long int n);
 
 /* memory allocating macros */
 void  d_free(void *);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1827,9 +1827,7 @@ choose_map_refresh_rank(struct map_refresh_arg *arg)
 
 	if (arg->mra_i == -1) {
 		/* Let i be a random integer in [0, n). */
-		i = ((double)rand() / RAND_MAX) * n;
-		if (i == n)
-			i = 0;
+		i = d_rand() % n;
 	} else {
 		/* Continue the round robin. */
 		i = arg->mra_i;

--- a/src/tests/ftest/cart/test_proto_client.c
+++ b/src/tests/ftest/cart/test_proto_client.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -65,6 +65,7 @@ test_run()
 	uint32_t		 s_high_ver = 0xFFFFFFFF;
 	uint32_t		 c_high_ver = test.tg_num_proto - 1;
 	int			 rc;
+	uint32_t                 timeout;
 
 	fprintf(stderr, "local group: %s remote group: %s\n",
 		test.tg_local_group_name, test.tg_remote_group_name);
@@ -119,8 +120,11 @@ test_run()
 	server_ep.ep_rank = 0;
 
 	DBG_PRINT("proto query\n");
-	rc = crt_proto_query(&server_ep, OPC_MY_PROTO, my_ver_array, 7,
-			     query_cb, &s_high_ver);
+	timeout = 1;
+	do {
+		rc = crt_proto_query(&server_ep, OPC_MY_PROTO, my_ver_array, 7, timeout++, query_cb,
+				     &s_high_ver);
+	} while (rc == -DER_TIMEDOUT);
 	D_ASSERT(rc == 0);
 
 	while (s_high_ver == 0xFFFFFFFF)

--- a/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
+++ b/src/tests/ftest/erasurecode/rebuild_disabled_single.yaml
@@ -15,6 +15,7 @@ setup:
 server_config:
   name: daos_server
   engines_per_host: 2
+  crt_timeout: 10
   engines:
     0:
       pinned_numa_node: 0


### PR DESCRIPTION
Pick from all possible ranks for protocol query handling

Backports the following patches, last one fixes the issue but prior two are benign and make the backport work without conflict

DAOS-13717 client: use d_rand() to generate random number (#12418)
DAOS-15120 crt: Misc d_rand-related fixes (#13738)
DAOS-15476 client: do not use rsvc for proto query rank selection (#14131)
DAOS-15540 cart: Change proto query default timeout (#14382)

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
