### PR TITLE
SRE-2180 ci: Update jira_query.py script to automatically generate ne…

### DIFF
--- a/ci/jira_query.py
+++ b/ci/jira_query.py
@@ -40,7 +40,7 @@ VALID_TICKET_PREFIX = ('DAOS', 'CORCI', 'SRE')
 FIELDS = 'summary,status,labels,customfield_10044,customfield_10045'
 
 # Labels in GitHub which this script will set/clear based on the logic below.
-MANAGED_LABELS_REGEX = re.compile(r'^(priority)|(release-(\d+\.\d+))$')
+MANAGED_LABELS_REGEX = re.compile(r'^(priority|release-\d+\.\d+)$')
 
 # Required version Jira labels that the script will generate GitHub labels from
 REQ_VERSION_REGEX = re.compile(r'(^\d+\.\d+) Community Release$')

--- a/ci/jira_query.py
+++ b/ci/jira_query.py
@@ -4,11 +4,11 @@
 import json
 import os
 import random
+import re
 import string
 import sys
 import time
 import urllib
-import re
 
 import jira
 
@@ -175,7 +175,8 @@ def main():
             elif str(version) in ('2.4 Community Release'):
                 rv_priority = 3
 
-            # If Required for Version is in the correct format, generate a corresponding GitHub label
+            # If Required for Version is in the correct format,
+            # generate a corresponding GitHub label
             version_match = REQ_VERSION_REGEX.match(str(version))
             if version_match:
                 version_number = version_match.groups()[0]


### PR DESCRIPTION
…w community release labels

Fix issue where GitHub Actions wasn't applying labels properly for the 2.6 release.
Modified the jira_query.py script to use regex instead of hard coded values, so it doesn't have to be manually updated on every release.

Modify script to use regex instead of hard coded values, so it doesn't have to be manually updated on every release.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
