### PR TITLE
DAOS-15808 test: Fix test_dmg_storage_query_device_state

### DIFF
--- a/src/tests/ftest/control/dmg_storage_query.py
+++ b/src/tests/ftest/control/dmg_storage_query.py
@@ -5,6 +5,7 @@
 """
 
 import re
+import traceback
 
 import avocado
 from control_test_base import ControlTestBase
@@ -257,7 +258,7 @@ class DmgStorageQuery(ControlTestBase):
             # The expected error is included in the DaosTestError exception which is the cause of
             # the CommandFailure exception
             expected_error = "DAOS I/O Engine instance not started or not responding on dRPC"
-            if expected_error not in str(error.__cause__):
+            if expected_error not in traceback.format_exc():
                 self.log.debug(error)
                 self.fail("dmg storage query list-devices failed for an unexpected reason")
 

--- a/src/tests/ftest/control/dmg_storage_query.py
+++ b/src/tests/ftest/control/dmg_storage_query.py
@@ -244,7 +244,8 @@ class DmgStorageQuery(ControlTestBase):
             try:
                 self.dmg.storage_set_faulty(uuid=device['uuid'])
             except CommandFailure:
-                self.fail("Error setting the faulty state for {}".format(device['uuid']))
+                if not expect_failed_engine:
+                    self.fail("Error setting the faulty state for {}".format(device['uuid']))
 
         # Check that devices are in FAULTY state
         try:
@@ -253,7 +254,10 @@ class DmgStorageQuery(ControlTestBase):
         except CommandFailure as error:
             if not expect_failed_engine:
                 raise
-            if "DAOS I/O Engine instance not started or not responding on dRPC" not in str(error):
+            # The expected error is included in the DaosTestError exception which is the cause of
+            # the CommandFailure exception
+            expected_error = "DAOS I/O Engine instance not started or not responding on dRPC"
+            if expected_error not in str(error.__cause__):
                 self.log.debug(error)
                 self.fail("dmg storage query list-devices failed for an unexpected reason")
 


### PR DESCRIPTION
The dmg storage set nvme-faulty command will now return a non-zero return code if host errors are detected. With MD on SSD we expect these host errors, so allow the test to continue in this case without raising an exception.

Skip-unit-tests: true
Skip-fault-injection-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
