### PR TITLE
DAOS-15498 rebuild: refine dm_migrating setting

### DIFF
--- a/src/object/srv_internal.h
+++ b/src/object/srv_internal.h
@@ -101,6 +101,7 @@ struct migrate_pool_tls {
 	/* migrate leader ULT */
 	unsigned int		mpt_ult_running:1,
 				mpt_init_tls:1,
+				mpt_req_pending:1,
 				mpt_fini:1;
 
 	/* migration init error */


### PR DESCRIPTION
1. set dm_migrating when mpt_init_tls not cleared 
    Possibly one VOS XS' tls init is slow (ds_pool_iv_prop_fetch involved), and other XS quickly finished its rebuild.
2. set dm_migrating when DAOS_OBJ_RPC_MIGRATE received and in pending
    Add tls->mpt_req_pending flag. 

To avoid rebuild treated as completed in race condition, when rebuild request pending.

Test-tag: test_osa_offline_drain_after_snapshot
Test-repeat: 10
Quick-Functional: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
