### PR TITLE
Backport two changes that can improve rebuild stability

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1994,7 +1994,7 @@ btr_update(struct btr_context *tcx, d_iov_t *key, d_iov_t *val, d_iov_t *val_out
 	struct btr_record *rec;
 	int		   rc;
 	char		   sbuf[BTR_PRINT_BUF];
-	struct btr_trace  *trace = &tcx->tc_trace.ti_trace[tcx->tc_depth - 1];
+	struct btr_trace  *trace = &tcx->tc_trace[tcx->tc_depth - 1];
 
 	rec = btr_trace2rec(tcx, tcx->tc_depth - 1);
 

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -376,11 +376,7 @@ struct evt_entry_array {
 	/** Maximum size of array */
 	uint32_t			 ea_max;
 	/** Number of bytes per index */
-	uint32_t			 ea_inob;
-	/** Index of first delete record, valid if ea_delete_nr != 0 */
-	uint32_t			 ea_first_delete;
-	/** Number of delete records */
-	uint32_t			 ea_delete_nr;
+	uint32_t                         ea_inob;
 	/* Small array of embedded entries */
 	struct evt_list_entry		 ea_embedded_ents[0];
 };

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -15,7 +15,7 @@
 #include <daos/dtx.h>
 #include <daos/checksum.h>
 
-#define VOS_SUB_OP_MAX	((uint16_t)-2)
+#define VOS_SUB_OP_MAX  (((uint16_t)-1) >> 2)
 
 #define VOS_POOL_DF_2_2 24
 #define VOS_POOL_DF_2_4 25

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -9,6 +9,21 @@
 #include <daos_srv/evtree.h>
 #include "vos_internal.h"
 
+/** Upper two bits are reserved. On disk, this will be (uint16_t)-2)
+ *  for backward compatibility reasons.
+ *  For the upper bits,
+ *  00 means distributed transaction write
+ *  11 is reserved for max normal write and removal records
+ *  01 is reserved for rebuild writes
+ *  10 is reserved for future use
+ *
+ *  When converting to not durable values, we want all rebuild records to be
+ *  greater than any normal write records.  So, we use a smaller value here.
+ */
+#define EVT_TX_MINOR_MAX_DF   ((uint16_t)-2)
+#define EVT_REBUILD_MINOR_MIN (VOS_SUB_OP_MAX + 1)
+#define EVT_REBUILD_MINOR_MAX (EVT_REBUILD_MINOR_MIN + VOS_SUB_OP_MAX)
+
 /**
  * Tree node types.
  * NB: a node can be both root and leaf.

--- a/src/vos/tests/evt_ctl.sh
+++ b/src/vos/tests/evt_ctl.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-if [ "$USE_VALGRIND" = "memcheck" ]; then
-    VCMD="valgrind --leak-check=full --show-reachable=yes --error-limit=no \
+if [ "$USE_VALGRIND" = "memcheck" ]; then VCMD="valgrind --leak-check=full --show-reachable=yes --error-limit=no \
           --suppressions=${VALGRIND_SUPP} --error-exitcode=42 --xml=yes \
           --xml-file=unit-test-evt_ctl-%p.memcheck.xml"
 elif [ "$USE_VALGRIND" = "pmemcheck" ]; then
@@ -167,6 +166,9 @@ cmd+=" -C o:5 -a 0-1@1:ab -a 1-2@2:cd -a 3-4@3:bc -a 5-7@4:def -a 6-8@5:xyz"
 cmd+=" -a 1-2@6:aa -a 4-7@7:abcd -b -2 -r 0-5@8 -b -2 -r 0-5@3 -b -2 -D"
 cmd+=" -C o:4 -a 0-5@1.1:abcdef -a 5-10@1.2:fedcba -a 5-7@1.3:foo -r 2-8@0-1"
 cmd+=" -l0-10@0-10:c -r 7-9@0-1 -l0-10@0-10:C -b -2 -D"
+cmd+=" -C o:15 -a 0-5@1.1:abcdef -a 1-2@1.2:ff -a 3-5@1.14:abc -a -3-4@1.14:ab"
+cmd+=" -a 3-5@1.14:abc -a 2-4@1.16384:vab -a 3-4@1.16384:ab -a 3-3@1.16384:a"
+cmd+=" -b -2 -D"
 echo "$cmd"
 eval "$cmd"
 result="${PIPESTATUS[0]}"

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -27,8 +27,7 @@
 #include "vos_ilog.h"
 #include "vos_obj.h"
 
-#define VOS_MINOR_EPC_MAX (VOS_SUB_OP_MAX + 1)
-D_CASSERT(VOS_MINOR_EPC_MAX == EVT_MINOR_EPC_MAX);
+#define VOS_MINOR_EPC_MAX EVT_MINOR_EPC_MAX
 
 #define VOS_TX_LOG_FAIL(rc, ...)			\
 	do {						\

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -674,7 +674,12 @@ svt_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	if (rc != 0)
 		return rc;
 
-	return svt_rec_alloc_common(tins, rec, skey, rbund);
+	rc = svt_rec_alloc_common(tins, rec, skey, rbund);
+	if (rc != 0)
+		return rc;
+
+	/* Inform btr_update() that the original record is replaced */
+	return 1;
 }
 
 static int


### PR DESCRIPTION
DAOS-14010 vos: Allow rebuild overwrite (#13326)
DAOS-15670 vos: SV overwrite missed tx_add_range() (#14241)

* Partial overwrite is difficult for upper layer to avoid.  If we reserve a range of minor epochs for rebuild, we can just always allow rebuild to overwrite any extents currently in the tree for the given major epoch.

* In SV overwrite case, the btr_update_record() will defer free the original record and allocate new record for record replacing, however, btr_node_tx_add() is mistakenly skipped in btr_update(), that leads to:
1. In md-on-ssd mode, tree node changes are missed in WAL.
2. In pmem mode, tree node snapshot is missed in undo log.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
