### PR TITLE
DAOS-15842 control: Reject re-join with different control addr

### DIFF
--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -1959,6 +1959,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 		},
 		"dupe host same rank diff uuid": {
 			req: &mgmtpb.JoinReq{
+				Addr: curMember.Addr.String(),
 				Rank: curMember.Rank.Uint32(),
 				Uuid: test.MockUUID(5),
 			},
@@ -1966,13 +1967,23 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 		},
 		"dupe host diff rank same uuid": {
 			req: &mgmtpb.JoinReq{
+				Addr: curMember.Addr.String(),
 				Rank: 22,
 				Uuid: curMember.UUID.String(),
 			},
 			expErr: errors.New("already exists"),
 		},
+		"dupe host addr changed": {
+			req: &mgmtpb.JoinReq{
+				Addr: newMember.Addr.String(),
+				Rank: curMember.Rank.Uint32(),
+				Uuid: curMember.UUID.String(),
+			},
+			expErr: errors.New("control address changed"),
+		},
 		"rejoining host": {
 			req: &mgmtpb.JoinReq{
+				Addr:        curMember.Addr.String(),
 				Rank:        curMember.Rank.Uint32(),
 				Uuid:        curMember.UUID.String(),
 				Incarnation: curMember.Incarnation + 1,
@@ -1997,6 +2008,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 		},
 		"rejoining host; NilRank": {
 			req: &mgmtpb.JoinReq{
+				Addr:        curMember.Addr.String(),
 				Rank:        uint32(ranklist.NilRank),
 				Uuid:        curMember.UUID.String(),
 				Incarnation: curMember.Incarnation + 1,
@@ -2022,6 +2034,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 		"provider doesn't match": {
 			pauseGroupUpdate: true,
 			req: &mgmtpb.JoinReq{
+				Addr:        curMember.Addr.String(),
 				Rank:        curMember.Rank.Uint32(),
 				Uuid:        curMember.UUID.String(),
 				Uri:         newProviderMember.PrimaryFabricURI,
@@ -2042,6 +2055,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 		"group update resumed": {
 			pauseGroupUpdate: true,
 			req: &mgmtpb.JoinReq{
+				Addr:        curMember.Addr.String(),
 				Rank:        curMember.Rank.Uint32(),
 				Uuid:        curMember.UUID.String(),
 				Uri:         curMember.PrimaryFabricURI,
@@ -2066,6 +2080,7 @@ func TestServer_MgmtSvc_Join(t *testing.T) {
 		},
 		"new host (non local)": {
 			req: &mgmtpb.JoinReq{
+				Addr:        curMember.Addr.String(),
 				Rank:        uint32(ranklist.NilRank),
 				Incarnation: newMember.Incarnation,
 			},

--- a/src/control/system/membership.go
+++ b/src/control/system/membership.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2023 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -156,6 +156,9 @@ func (m *Membership) Join(req *JoinRequest) (resp *JoinResponse, err error) {
 		}
 		if curMember.UUID != req.UUID {
 			return nil, ErrUuidChanged(req.UUID, curMember.UUID, curMember.Rank)
+		}
+		if curMember.Addr.String() != req.ControlAddr.String() {
+			return nil, ErrControlAddrChanged(req.ControlAddr, curMember.Addr, curMember.UUID, curMember.Rank)
 		}
 
 		if !curMember.FaultDomain.Equals(req.FaultDomain) {

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2023 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -765,6 +765,7 @@ func TestSystem_Membership_Join(t *testing.T) {
 		"not leader": {
 			notLeader: true,
 			req: &JoinRequest{
+				ControlAddr:      curMember.Addr,
 				PrimaryFabricURI: curMember.Addr.String(),
 				FaultDomain:      fd1,
 			},
@@ -817,6 +818,16 @@ func TestSystem_Membership_Join(t *testing.T) {
 				FaultDomain:      curMember.FaultDomain,
 			},
 			expErr: ErrUuidChanged(newUUID, curMember.UUID, curMember.Rank),
+		},
+		"rejoin with different address": {
+			req: &JoinRequest{
+				Rank:             curMember.Rank,
+				UUID:             curMember.UUID,
+				ControlAddr:      newMember.Addr,
+				PrimaryFabricURI: curMember.Addr.String(),
+				FaultDomain:      curMember.FaultDomain,
+			},
+			expErr: ErrControlAddrChanged(newMember.Addr, curMember.Addr, curMember.UUID, curMember.Rank),
 		},
 		"successful join": {
 			req: &JoinRequest{


### PR DESCRIPTION
Previously the re-join was succeeding but not updating the address, which led to surprising behavior. With this change, the re-join fails and notifies the admin.

Features: control

Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
