### PR TITLE
DAOS-15935 client: search section "[stack]" instead of "[heap]"

### DIFF
--- a/src/client/dfuse/pil4dfs/hook.c
+++ b/src/client/dfuse/pil4dfs/hook.c
@@ -217,7 +217,11 @@ determine_lib_path(void)
 	read_size = read_map_file(&read_buff_map);
 
 	/* need to find the offset of lib path in the line */
-	pos = strstr(read_buff_map, "[heap]");
+	pos = strstr(read_buff_map, "[stack]");
+	if (pos == NULL) {
+		D_ERROR("Failed to find section stack.\n");
+		goto err;
+	}
 	/* look back for the first '\n', the end of last line */
 	for(i = 0; i < 128; i++) {
 		if (*(pos - i) == '\n') {

--- a/src/tests/ftest/dfuse/bash.py
+++ b/src/tests/ftest/dfuse/bash.py
@@ -112,7 +112,7 @@ class DfuseBashCmd(TestWithServers):
             # f'more {fuse_root_dir}/src.c', # more hangs over ssh somehow
             f"dos2unix {fuse_root_dir}/src.c",
             f"gcc -o {fuse_root_dir}/output {fuse_root_dir}/src.c",
-            f"size {fuse_root_dir}/output",
+            f"valgrind size {fuse_root_dir}/output",
             f"readelf -s {fuse_root_dir}/output",
             f"strip -s {fuse_root_dir}/output",
             f"g++ -o {fuse_root_dir}/output {fuse_root_dir}/src.c",


### PR DESCRIPTION
Somehow process memcheck in valgrind does not have "[heap]".

Features: pil4dfs

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
