### PR TITLE
DAOS-15850 control: Pass up errors when failing to read cert dir

### DIFF
--- a/src/control/security/config.go
+++ b/src/control/security/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -128,8 +128,10 @@ func (tc *TransportConfig) PreLoadCertData() error {
 	}
 
 	if tc.ClientCertDir != "" {
-		if _, err := os.ReadDir(tc.ClientCertDir); err != nil {
+		if _, err := os.ReadDir(tc.ClientCertDir); errors.Is(err, fs.ErrPermission) {
 			return FaultUnreadableCertFile(tc.ClientCertDir)
+		} else if err != nil {
+			return errors.Wrap(err, "checking client cert directory")
 		}
 	}
 

--- a/src/control/security/config_test.go
+++ b/src/control/security/config_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -13,10 +13,13 @@ import (
 	"encoding/pem"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 )
@@ -110,9 +113,13 @@ func setExpiredVerifyTime(t *testing.T, cfg *TransportConfig) {
 }
 
 func TestPreLoadCertData(t *testing.T) {
+	clientDir := func(dir string) string {
+		return filepath.Join(dir, "client")
+	}
+
 	for name, tc := range map[string]struct {
-		getCfg    func(t *testing.T) *TransportConfig
-		setup     func(t *testing.T)
+		getCfg    func(t *testing.T, dir string) *TransportConfig
+		setup     func(t *testing.T) (string, func())
 		config    *TransportConfig
 		expLoaded bool
 		expErr    error
@@ -121,12 +128,12 @@ func TestPreLoadCertData(t *testing.T) {
 			expErr: errors.New("nil"),
 		},
 		"insecure": {
-			getCfg: func(t *testing.T) *TransportConfig {
+			getCfg: func(t *testing.T, _ string) *TransportConfig {
 				return InsecureTC()
 			},
 		},
 		"cert success": {
-			getCfg: func(t *testing.T) *TransportConfig {
+			getCfg: func(t *testing.T, _ string) *TransportConfig {
 				serverTC := ServerTC()
 				setValidVerifyTime(t, serverTC)
 				SetupTCFilePerms(t, serverTC)
@@ -135,25 +142,58 @@ func TestPreLoadCertData(t *testing.T) {
 			expLoaded: true,
 		},
 		"bad cert": {
-			getCfg: func(t *testing.T) *TransportConfig {
+			getCfg: func(t *testing.T, _ string) *TransportConfig {
 				badTC := BadTC()
 				SetupTCFilePerms(t, badTC)
 				return badTC
 			},
 			expErr: errors.New("insecure permissions"),
 		},
-		"bad client dir": {
-			getCfg: func(t *testing.T) *TransportConfig {
+		"client dir doesn't exist": {
+			setup: test.CreateTestDir,
+			getCfg: func(t *testing.T, dir string) *TransportConfig {
+				conf := ServerTC()
+				setValidVerifyTime(t, conf)
+				conf.ClientCertDir = "a thing that does not exist"
+				return conf
+			},
+			expErr: syscall.ENOENT,
+		},
+		"client dir not a directory": {
+			setup: test.CreateTestDir,
+			getCfg: func(t *testing.T, dir string) *TransportConfig {
 				clientDirTC := ServerTC()
 				setValidVerifyTime(t, clientDirTC)
-				clientDirTC.ClientCertDir = "testdata/badperms"
-				SetupTCFilePerms(t, clientDirTC)
+
+				filePath := clientDir(dir)
+				if err := os.WriteFile(filePath, []byte("some stuff"), 0400); err != nil {
+					t.Fatal(err)
+				}
+				clientDirTC.ClientCertDir = filePath
 				return clientDirTC
 			},
-			expErr: FaultUnreadableCertFile("testdata/badperms"),
+			expErr: syscall.ENOTDIR,
+		},
+		"can't access client dir": {
+			setup: func(t *testing.T) (string, func()) {
+				dir, cleanup := test.CreateTestDir(t)
+				if err := os.Mkdir(clientDir(dir), 0220); err != nil {
+					t.Fatal(err)
+				}
+
+				return dir, cleanup
+			},
+			getCfg: func(t *testing.T, dir string) *TransportConfig {
+				clientDirTC := ServerTC()
+				setValidVerifyTime(t, clientDirTC)
+
+				clientDirTC.ClientCertDir = clientDir(dir)
+				return clientDirTC
+			},
+			expErr: FaultUnreadableCertFile(""),
 		},
 		"expired cert": {
-			getCfg: func(t *testing.T) *TransportConfig {
+			getCfg: func(t *testing.T, _ string) *TransportConfig {
 				serverTC := ServerTC()
 				setExpiredVerifyTime(t, serverTC)
 				SetupTCFilePerms(t, serverTC)
@@ -164,14 +204,30 @@ func TestPreLoadCertData(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			var testDir string
+			if tc.setup != nil {
+				dir, teardown := tc.setup(t)
+				defer teardown()
+				testDir = dir
+			}
+
 			var cfg *TransportConfig
 			if tc.getCfg != nil {
-				cfg = tc.getCfg(t)
+				cfg = tc.getCfg(t, testDir)
 			}
 
 			err := cfg.PreLoadCertData()
 
-			test.CmpErr(t, tc.expErr, err)
+			// If it's a fault, we don't need to check the exact paths passed in
+			if fault.IsFault(tc.expErr) && fault.IsFault(err) {
+				expCode := tc.expErr.(*fault.Fault).Code
+				if !fault.IsFaultCode(err, expCode) {
+					t.Fatalf("expected fault: %s, got: %s", tc.expErr, err)
+				}
+			} else {
+				test.CmpErr(t, tc.expErr, err)
+			}
+
 			if cfg == nil {
 				return
 			}

--- a/src/control/security/testdata/certs/badperms/README
+++ b/src/control/security/testdata/certs/badperms/README
@@ -1,4 +1,0 @@
-Git does not store empty directories so we need this file here to keep this
-directory in the git tree. It is used as a permission check for the
-certificiate directory validation code.
-

--- a/src/control/security/testdata/certs/goodperms/README
+++ b/src/control/security/testdata/certs/goodperms/README
@@ -1,4 +1,0 @@
-Git does not store empty directories so we need this file here to keep this
-directory in the git tree. It is used as a permission check for the
-certificiate directory validation code.
-


### PR DESCRIPTION
Previously we returned a Fault indicating bad permissions whenever we failed to read the client cert directory. This could be misleading if, for example, the directory was a file or didn't exist at all.

Also refactored some older unit tests to not depend on in-source directories with assumed permissions.

Features: control security

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
