### PR TITLE
DAOS-14539 client: fix pil4dfs strncmp compile in some envs (#14041)

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -657,7 +657,7 @@ discover_dfuse_mounts(void)
 			abort();
 		}
 		pt_dfs_mt = &dfs_list[num_dfs];
-		if (strncmp(fs_entry->mnt_type, STR_AND_SIZE(MNT_TYPE_FUSE)) == 0) {
+		if (memcmp(fs_entry->mnt_type, STR_AND_SIZE(MNT_TYPE_FUSE)) == 0) {
 			pt_dfs_mt->dcache      = NULL;
 			pt_dfs_mt->len_fs_root = strnlen(fs_entry->mnt_dir, DFS_MAX_PATH);
 			if (pt_dfs_mt->len_fs_root >= DFS_MAX_PATH) {
@@ -1055,9 +1055,9 @@ query_path(const char *szInput, int *is_target_path, struct dcache_rec **parent,
 	}
 
 	/* handle special cases. Needed to work with git. */
-	if ((strncmp(szInput, STR_AND_SIZE_M1("http://")) == 0) ||
-	    (strncmp(szInput, STR_AND_SIZE_M1("https://")) == 0) ||
-	    (strncmp(szInput, STR_AND_SIZE_M1("git://")) == 0)) {
+	if ((memcmp(szInput, STR_AND_SIZE_M1("http://")) == 0) ||
+	    (memcmp(szInput, STR_AND_SIZE_M1("https://")) == 0) ||
+	    (memcmp(szInput, STR_AND_SIZE_M1("git://")) == 0)) {
 		*is_target_path = 0;
 		return 0;
 	}
@@ -4124,7 +4124,7 @@ pre_envp(char *const envp[], char ***new_envp)
 	} else {
 		while (envp[num_entry]) {
 			/* scan the env in env_list[] to check whether they exist or not */
-			if (strncmp(envp[num_entry], STR_AND_SIZE_M1("LD_PRELOAD")) == 0 &&
+			if (memcmp(envp[num_entry], STR_AND_SIZE_M1("LD_PRELOAD")) == 0 &&
 			    preload_included == false) {
 				preload_included = true;
 				idx_preload      = num_entry;
@@ -4140,7 +4140,7 @@ pre_envp(char *const envp[], char ***new_envp)
 				if (!env_set[i])
 					continue;
 				if (!env_found[i]) {
-					if (strncmp(envp[num_entry], STR_AND_SIZE_M1(env_list[i]))
+					if (memcmp(envp[num_entry], STR_AND_SIZE_M1(env_list[i]))
 					    == 0) {
 						env_found[i] = true;
 						num_entry_found++;


### PR DESCRIPTION
Features: pil4dfs

Workaround an issue with some compilers not playing nicely with the strncmp and STR_AND_SIZE macros in the case where strncmp is also defined as a macro.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
