### PR TITLE
DAOS-15801 test: Add aio ioengine to pil4dfs_fio.py functional test

### DIFF
--- a/src/tests/ftest/dfuse/pil4dfs_fio.py
+++ b/src/tests/ftest/dfuse/pil4dfs_fio.py
@@ -12,7 +12,7 @@ from ClusterShell.NodeSet import NodeSet
 from cpu_utils import CpuInfo
 from dfuse_utils import get_dfuse, start_dfuse
 from fio_utils import FioCommand
-from general_utils import bytes_to_human
+from general_utils import bytes_to_human, percent_change
 
 
 class Pil4dfsFio(TestWithServers):
@@ -27,9 +27,9 @@ class Pil4dfsFio(TestWithServers):
         """Initialize a FioPil4dfs object."""
         super().__init__(*args, **kwargs)
 
-        self.fio_params = {"thread": "", "blocksize": "", "size": ""}
         self.fio_numjobs = 0
         self.fio_cpus_allowed = ""
+        self.fio_pil4dfs_ioengines = []
 
     def setUp(self):
         """Set up each test case."""
@@ -39,18 +39,26 @@ class Pil4dfsFio(TestWithServers):
         # Start the servers and agents
         super().setUp()
 
-        for name in self.fio_params:
-            self.fio_params[name] = self.params.get(name, "/run/fio/job/*", "")
+        self.fio_pil4dfs_ioengines = self.params.get(
+            "pil4dfs_ioengines", "/run/fio/job/params/*", default=[])
 
         cpu_info = CpuInfo(self.log, self.hostlist_clients)
         cpu_info.scan()
         _, arch = cpu_info.get_architectures()[0]
-        if arch.numas != 2:
-            self.fail(f"Client with unsupported quantity of NUMA nodes: want=2, got={arch.numas}")
-        self.fio_numjobs = int(arch.quantity / arch.threads_core)
+
+        self.fio_numjobs = self.params.get("numjobs", "/run/fio/job/params/*")
+        if self.fio_numjobs is None:
+            self.fio_numjobs = int(arch.quantity / arch.threads_core)
+
+        if self.fio_numjobs % arch.numas != 0:
+            self.fail(
+                "Client with unsupported quantity of NUMA nodes:"
+                f" Number of jobs ({self.fio_numjobs})"
+                f" is not a multiple of the NUMA node quantity ({arch.numas})")
+
         cpus = []
-        cores_quantity = int(self.fio_numjobs / 2)
-        for numa_idx in range(2):
+        cores_quantity = int(self.fio_numjobs / arch.numas)
+        for numa_idx in range(arch.numas):
             cpus += arch.get_numa_cpus(numa_idx)[:cores_quantity]
         self.fio_cpus_allowed = str(NodeSet(str(cpus)))[1:-1]
 
@@ -74,14 +82,17 @@ class Pil4dfsFio(TestWithServers):
 
         """
         fio_stdout = next(iter(fio_result.all_stdout.values()))
-        # NOTE With dfuse and pil4dfs some junk messages could be eventually printed
+        # NOTE With dfuse and pil4dfs some junk messages could eventually be printed
         if fio_stdout[0] != '{':
             fio_stdout = '{' + fio_stdout.partition('{')[2]
         fio_json = json.loads(fio_stdout)
         return fio_json["jobs"][0][rw]['bw_bytes']
 
-    def _run_fio_dfuse(self):
-        """Run and return the result of running FIO over a DFuse mount point.
+    def _run_fio_pil4dfs(self, ioengine):
+        """Run and return the result of running FIO with the PIL4DFS interception library.
+
+        Args:
+            ioengine (str): Name of the IO engine to use.
 
         Returns:
             dict: Read and Write bandwidths of the FIO command.
@@ -89,15 +100,14 @@ class Pil4dfsFio(TestWithServers):
         """
         container = self._create_container()
 
-        self.log_step("Mounting DFuse mount point")
+        self.log.info("Mounting DFuse mount point")
         dfuse = get_dfuse(self, self.hostlist_clients)
         start_dfuse(self, dfuse, container.pool, container)
-        self.log.debug("Mounted DFuse mount point %s", str(dfuse))
 
         fio_cmd = FioCommand()
         fio_cmd.get_params(self)
         fio_cmd.update_directory(dfuse.mount_dir.value)
-        fio_cmd.update("global", "ioengine", "psync", "fio --name=global --ioengine='psync'")
+        fio_cmd.update("global", "ioengine", ioengine, f"fio --name=global --ioengine='{ioengine}'")
         fio_cmd.update(
             "global", "numjobs", self.fio_numjobs,
             f"fio --name=global --numjobs={self.fio_numjobs}")
@@ -111,12 +121,11 @@ class Pil4dfsFio(TestWithServers):
         for rw in Pil4dfsFio._FIO_RW_NAMES:
             fio_cmd.update("job", "rw", rw, f"fio --name=job --rw={rw}")
 
-            params = ", ".join(f"{name}={value}" for name, value in self.fio_params.items())
-            self.log.info("Running FIO command: rw=%s, %s", rw, params)
             self.log.debug("FIO command: LD_PRELOAD=%s %s", fio_cmd.env['LD_PRELOAD'], str(fio_cmd))
             result = fio_cmd.run()
             bws[rw] = self._get_bandwidth(result, rw)
-            self.log.debug("DFuse bandwidths for %s: %s", rw, bws[rw])
+            self.log.info(
+                "FIO bandwidths with PIL4DFS: ioengine=%s, rw=%s, bw=%s", ioengine, rw, bws[rw])
 
         dfuse.stop()
         container.destroy()
@@ -137,11 +146,10 @@ class Pil4dfsFio(TestWithServers):
         fio_cmd.get_params(self)
         fio_cmd.update("global", "ioengine", "dfs", "fio --name=global --ioengine='dfs'")
         fio_cmd.update(
-            "global", "numjobs", self.fio_numjobs,
-            f"fio --name=global --numjobs={self.fio_numjobs}")
+            "job", "numjobs", self.fio_numjobs, f"fio --name=job --numjobs={self.fio_numjobs}")
         fio_cmd.update(
-            "global", "cpus_allowed", self.fio_cpus_allowed,
-            f"fio --name=global --cpus_allowed={self.fio_cpus_allowed}")
+            "job", "cpus_allowed", self.fio_cpus_allowed,
+            f"fio --name=job --cpus_allowed={self.fio_cpus_allowed}")
         # NOTE DFS ioengine options must come after the ioengine that defines them is selected.
         fio_cmd.update(
             "job", "pool", container.pool.uuid, f"fio --name=job --pool={container.pool.uuid}")
@@ -152,12 +160,10 @@ class Pil4dfsFio(TestWithServers):
         for rw in Pil4dfsFio._FIO_RW_NAMES:
             fio_cmd.update("job", "rw", rw, f"fio --name=job --rw={rw}")
 
-            params = ", ".join(f"{name}={value}" for name, value in self.fio_params.items())
-            self.log.info("Running FIO command: rw=%s, %s", rw, params)
             self.log.debug("FIO command: %s", str(fio_cmd))
             result = fio_cmd.run()
             bws[rw] = self._get_bandwidth(result, rw)
-            self.log.debug("DFS bandwidths for %s: %s", rw, bws[rw])
+            self.log.info("FIO bandwidths with DFS: rw=%s, bw=%s", rw, bws[rw])
 
         container.destroy()
         container.pool.destroy()
@@ -168,9 +174,9 @@ class Pil4dfsFio(TestWithServers):
         """Jira ID: DAOS-14657.
 
         Test Description:
-            Run FIO over DFUSE mount point with PIL4DFS interception library
             Run FIO with DFS ioengine
-            Check bandwidth consistency
+            Run FIO with the PIL4DFS interception library and some ioengines
+            Check bandwidth consistency of FIO DFS ioengine and the PIL4DFS interception library
 
         :avocado: tags=all,daily_regression
         :avocado: tags=hw,medium
@@ -182,22 +188,24 @@ class Pil4dfsFio(TestWithServers):
             bw_deltas[name] = self.params.get(
                 name.lower(), "/run/test_pil4dfs_vs_dfs/bw_deltas/*", 0)
 
-        self.log_step("Running FIO with DFuse")
-        dfuse_bws = self._run_fio_dfuse()
-
         self.log_step("Running FIO with DFS")
         dfs_bws = self._run_fio_dfs()
 
-        self.log_step("Comparing FIO bandwidths of DFuse and DFS")
-        for rw in Pil4dfsFio._FIO_RW_NAMES:
-            delta = abs(dfuse_bws[rw] - dfs_bws[rw]) * 100 / max(dfuse_bws[rw], dfs_bws[rw])
-            self.log.debug(
-                "Comparing %s bandwidths: delta=%.2f%%, DFuse=%s (%iB), DFS=%s (%iB)",
-                rw, delta, bytes_to_human(dfuse_bws[rw]), dfuse_bws[rw],
-                bytes_to_human(dfs_bws[rw]), dfs_bws[rw])
-            if bw_deltas[rw] <= delta:
-                self.log.info(
-                    "FIO %s bandwidth difference should be < %i%%: got=%.2f%%",
-                    rw, bw_deltas[rw], delta)
+        dfuse_bws = {}
+        for ioengine in self.fio_pil4dfs_ioengines:
+            self.log_step(f"Running FIO with {ioengine} and the PIL4DFS interception library")
+            dfuse_bws = self._run_fio_pil4dfs(ioengine)
+
+            self.log_step(f"Comparing FIO bandwidths of DFuse with {ioengine} ioengine and DFS")
+            for rw in Pil4dfsFio._FIO_RW_NAMES:
+                delta = 100 * percent_change(dfs_bws[rw], dfuse_bws[rw])
+                self.log.debug(
+                    "Comparing %s bandwidths: delta=%.2f%%, DFuse=%s (%iB), DFS=%s (%iB)",
+                    rw, delta, bytes_to_human(dfuse_bws[rw]), dfuse_bws[rw],
+                    bytes_to_human(dfs_bws[rw]), dfs_bws[rw])
+                if bw_deltas[rw] <= abs(delta):
+                    self.log.info(
+                        "FIO %s bandwidth difference should be < %i%%: got=%.2f%%",
+                        rw, bw_deltas[rw], abs(delta))
 
         self.log_step("Test passed")

--- a/src/tests/ftest/dfuse/pil4dfs_fio.yaml
+++ b/src/tests/ftest/dfuse/pil4dfs_fio.yaml
@@ -40,7 +40,6 @@ fio:
   output_format: 'json'
   global:
     direct: 1
-    iodepth: 1
     time_based: 1
     runtime: '60s'
     ramp_time: '5s'
@@ -53,18 +52,40 @@ fio:
   job:
     params: !mux
       256B_fork:
+        pil4dfs_ioengines: ['psync']
         thread: 0
         blocksize: '256B'
         size: '32K'
+        iodepth: 1
       256B_pthread:
+        pil4dfs_ioengines: ['psync']
         thread: 1
         blocksize: '256B'
         size: '32K'
+        iodepth: 1
       1M_fork:
+        pil4dfs_ioengines: ['psync']
         thread: 0
         blocksize: '1M'
         size: '64M'
+        iodepth: 1
       1M_pthread:
+        pil4dfs_ioengines: ['psync']
         thread: 1
         blocksize: '1M'
         size: '64M'
+        iodepth: 1
+      iodepth_fork:
+        pil4dfs_ioengines: ['libaio']
+        thread: 0
+        numjobs: 8
+        blocksize: '4K'
+        size: '512K'
+        iodepth: 16
+      iodepth_thread:
+        pil4dfs_ioengines: ['libaio']
+        thread: 1
+        numjobs: 8
+        blocksize: '4K'
+        size: '512K'
+        iodepth: 16

--- a/utils/cq/words.dict
+++ b/utils/cq/words.dict
@@ -229,6 +229,7 @@ io
 iod
 iodepth
 ioengine
+ioengines
 ior
 ioreqs
 iotype
@@ -359,6 +360,7 @@ procs
 profiler
 protoc
 ps
+psync
 puuid
 py
 pydaos


### PR DESCRIPTION
###  Description

Clean cherry pick of the PR #14375

Add functional tests running FIO using the libaio ioengine and the PIL4DFS interception library.
Compare the bandwidth of these runs with one using the dfs ioengine.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
