### PR TITLE
DAOS-15963 test: option to disable ULT stack dump on failure

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -665,8 +665,10 @@ class TestWithServers(TestWithoutServers):
         self.config_file_base = "test"
         self.log_dir = os.path.split(
             os.getenv("D_LOG_FILE", "/tmp/server.log"))[0]
-        # whether engines ULT stacks have been already dumped
-        self.dumped_engines_stacks = False
+        # Whether to dump engines ULT stacks on failure
+        self.__dump_engine_ult_on_failure = True
+        # Whether engines ULT stacks have been already dumped
+        self.__have_dumped_ult_stacks = False
         # Suffix to append to each access point name
         self.access_points_suffix = None
 
@@ -739,7 +741,7 @@ class TestWithServers(TestWithoutServers):
         self.host_info.access_points = self.access_points
 
         # Toggle whether to dump server ULT stacks on failure
-        self.dump_engine_ult_on_failure = self.params.get(
+        self.__dump_engine_ult_on_failure = self.params.get(
             "dump_engine_ult_on_failure", "/run/*", True)
 
         # # Find a configuration that meets the test requirements
@@ -1349,22 +1351,13 @@ class TestWithServers(TestWithoutServers):
         return errors
 
     def __dump_engines_stacks(self, message):
-        """Dump the engines ULT stacks if self.dump_engine_ult_on_failure is True.
-
-        Args:
-            message (str): see dump_engines_stacks()
-        """
-        if self.dump_engine_ult_on_failure:
-            self.dump_engines_stacks(message)
-
-    def dump_engines_stacks(self, message):
         """Dump the engines ULT stacks.
 
         Args:
-            message (str): reason for dumping the ULT stacks. Defaults to None.
+            message (str): reason for dumping the ULT stacks
         """
-        if self.dumped_engines_stacks is False:
-            self.dumped_engines_stacks = True
+        if self.__dump_engine_ult_on_failure and not self.__have_dumped_ult_stacks:
+            self.__have_dumped_ult_stacks = True
             self.log.info("%s, dumping ULT stacks", message)
             dump_engines_stacks(self.hostlist_servers)
 

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -742,7 +742,7 @@ class TestWithServers(TestWithoutServers):
 
         # Toggle whether to dump server ULT stacks on failure
         self.__dump_engine_ult_on_failure = self.params.get(
-            "dump_engine_ult_on_failure", "/run/*", True)
+            "dump_engine_ult_on_failure", "/run/setup/*", True)
 
         # # Find a configuration that meets the test requirements
         # self.config = Configuration(


### PR DESCRIPTION
Test-tag: pr,vm
Skip-unit-tests: true
Skip-fault-injection-test: true

Add a config option, dump_engine_ult_on_failure, to disable dumping engine ULT stacks on test failure.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
