### PR TITLE
DAOS-15805 control: Adjust SPDK config entry order to avoid hotplug r…

### DIFF
--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -112,18 +112,26 @@ func TestBackend_writeJSONFile(t *testing.T) {
 		expErr    error
 		expOut    string
 	}{
-		"nvme; single ssds": {
+		"nvme; single ssds; hotplug enabled": {
 			confIn: engine.MockConfig().WithStorage(&storage.TierConfig{
 				Tier:  tierID,
 				Class: storage.ClassNvme,
 				Bdev: storage.BdevConfig{
 					DeviceList: storage.MustNewBdevDeviceList(test.MockPCIAddrs(1)...),
 				},
-			}),
+			}).WithStorageEnableHotplug(true),
 			expOut: `
 {
   "daos_data": {
-    "config": []
+    "config": [
+      {
+        "params": {
+          "begin": 0,
+          "end": 7
+        },
+        "method": "hotplug_busid_range"
+      }
+    ]
   },
   "subsystems": [
     {
@@ -148,18 +156,18 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        },
-        {
-          "params": {
             "trtype": "PCIe",
             "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
+        },
+        {
+          "params": {
+            "enable": true,
+            "period_us": 5000000
+          },
+          "method": "bdev_nvme_set_hotplug"
         }
       ]
     }
@@ -206,13 +214,6 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        },
-        {
-          "params": {
             "trtype": "PCIe",
             "name": "Nvme_hostfoo_0_84_7",
             "traddr": "0000:01:00.0"
@@ -226,6 +227,13 @@ func TestBackend_writeJSONFile(t *testing.T) {
             "traddr": "0000:02:00.0"
           },
           "method": "bdev_nvme_attach_controller"
+        },
+        {
+          "params": {
+            "enable": false,
+            "period_us": 0
+          },
+          "method": "bdev_nvme_set_hotplug"
         }
       ]
     }
@@ -271,13 +279,6 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        },
-        {
-          "params": {
             "trtype": "PCIe",
             "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
@@ -291,6 +292,13 @@ func TestBackend_writeJSONFile(t *testing.T) {
             "traddr": "0000:02:00.0"
           },
           "method": "bdev_nvme_attach_controller"
+        },
+        {
+          "params": {
+            "enable": false,
+            "period_us": 0
+          },
+          "method": "bdev_nvme_set_hotplug"
         }
       ]
     },
@@ -352,13 +360,6 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "enable": true,
-            "period_us": 5000000
-          },
-          "method": "bdev_nvme_set_hotplug"
-        },
-        {
-          "params": {
             "trtype": "PCIe",
             "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
@@ -372,6 +373,13 @@ func TestBackend_writeJSONFile(t *testing.T) {
             "traddr": "0000:02:00.0"
           },
           "method": "bdev_nvme_attach_controller"
+        },
+        {
+          "params": {
+            "enable": true,
+            "period_us": 5000000
+          },
+          "method": "bdev_nvme_set_hotplug"
         }
       ]
     }
@@ -424,13 +432,6 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "enable": true,
-            "period_us": 5000000
-          },
-          "method": "bdev_nvme_set_hotplug"
-        },
-        {
-          "params": {
             "trtype": "PCIe",
             "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
@@ -444,6 +445,13 @@ func TestBackend_writeJSONFile(t *testing.T) {
             "traddr": "0000:02:00.0"
           },
           "method": "bdev_nvme_attach_controller"
+        },
+        {
+          "params": {
+            "enable": true,
+            "period_us": 5000000
+          },
+          "method": "bdev_nvme_set_hotplug"
         }
       ]
     },
@@ -498,18 +506,18 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        },
-        {
-          "params": {
             "trtype": "PCIe",
             "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
+        },
+        {
+          "params": {
+            "enable": false,
+            "period_us": 0
+          },
+          "method": "bdev_nvme_set_hotplug"
         }
       ]
     }
@@ -554,18 +562,18 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        },
-        {
-          "params": {
             "trtype": "PCIe",
             "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
+        },
+        {
+          "params": {
+            "enable": false,
+            "period_us": 0
+          },
+          "method": "bdev_nvme_set_hotplug"
         }
       ]
     }
@@ -610,18 +618,18 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        },
-        {
-          "params": {
             "trtype": "PCIe",
             "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
+        },
+        {
+          "params": {
+            "enable": false,
+            "period_us": 0
+          },
+          "method": "bdev_nvme_set_hotplug"
         }
       ]
     }
@@ -692,18 +700,18 @@ func TestBackend_writeJSONFile(t *testing.T) {
         },
         {
           "params": {
-            "enable": false,
-            "period_us": 0
-          },
-          "method": "bdev_nvme_set_hotplug"
-        },
-        {
-          "params": {
             "trtype": "PCIe",
             "name": "Nvme_hostfoo_0_84_0",
             "traddr": "0000:01:00.0"
           },
           "method": "bdev_nvme_attach_controller"
+        },
+        {
+          "params": {
+            "enable": false,
+            "period_us": 0
+          },
+          "method": "bdev_nvme_set_hotplug"
         }
       ]
     }


### PR DESCRIPTION
…ace (#14480)

Ensure hotplug directives in SPDK JSON configuration appear after any device attach entries to avoid enumeration race seen with multiple VMD domains and described in spdk/spdk#3370.

Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
