### PR TITLE
DAOS-15992 client: set st_blksize in ostatx_cb() and add unit test

### DIFF
--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -852,8 +852,10 @@ ostatx_cb(tse_task_t *task, void *data)
 		D_GOTO(out, rc = daos_errno2der(rc));
 
 	if (S_ISREG(args->obj->mode)) {
-		args->stbuf->st_size   = op_args->array_stbuf.st_size;
-		args->stbuf->st_blocks = (args->stbuf->st_size + (1 << 9) - 1) >> 9;
+		args->stbuf->st_size    = op_args->array_stbuf.st_size;
+		args->stbuf->st_blocks  = (args->stbuf->st_size + (1 << 9) - 1) >> 9;
+		args->stbuf->st_blksize = op_args->entry.chunk_size ? op_args->entry.chunk_size :
+			args->dfs->attr.da_chunk_size;
 	} else if (S_ISDIR(args->obj->mode)) {
 		args->stbuf->st_size = sizeof(op_args->entry);
 	} else if (S_ISLNK(args->obj->mode)) {

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1069,6 +1069,7 @@ dfs_test_rename(void **state)
 	rc = daos_event_init(&ev, arg->eq, NULL);
 	rc = dfs_ostatx(dfs_mt, obj1, &stbuf, &ev);
 	assert_int_equal(rc, 0);
+	assert_int_equal(stbuf.st_blksize, DFS_DEFAULT_CHUNK_SIZE);
 	rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
 	assert_rc_equal(rc, 1);
 	assert_ptr_equal(evp, &ev);

--- a/src/tests/suite/dfs_unit_test.c
+++ b/src/tests/suite/dfs_unit_test.c
@@ -1056,6 +1056,7 @@ dfs_test_rename(void **state)
 	rc = dfs_ostatx(dfs_mt, obj2, &stbuf, NULL);
 	assert_int_equal(rc, 0);
 	assert_true(stbuf.st_size == 128);
+	assert_int_equal(stbuf.st_blksize, DFS_DEFAULT_CHUNK_SIZE);
 
 	rc = dfs_chmod(dfs_mt, NULL, f1, S_IFREG | S_IRUSR | S_IWUSR);
 	assert_int_equal(rc, 0);
@@ -1069,7 +1070,6 @@ dfs_test_rename(void **state)
 	rc = daos_event_init(&ev, arg->eq, NULL);
 	rc = dfs_ostatx(dfs_mt, obj1, &stbuf, &ev);
 	assert_int_equal(rc, 0);
-	assert_int_equal(stbuf.st_blksize, DFS_DEFAULT_CHUNK_SIZE);
 	rc = daos_eq_poll(arg->eq, 0, DAOS_EQ_WAIT, 1, &evp);
 	assert_rc_equal(rc, 1);
 	assert_ptr_equal(evp, &ev);

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -34,6 +34,7 @@
 #include <sys/uio.h>
 
 #include <dfuse_ioctl.h>
+#include <daos_fs.h>
 
 /* Tests can be run by specifying the appropriate argument for a test or all will be run if no test
  * is specified.

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -34,7 +34,6 @@
 #include <sys/uio.h>
 
 #include <dfuse_ioctl.h>
-#include <daos_fs.h>
 
 /* Tests can be run by specifying the appropriate argument for a test or all will be run if no test
  * is specified.
@@ -66,15 +65,14 @@ char *test_dir;
 void
 do_openat(void **state)
 {
-	struct stat           stbuf0;
-	struct stat           stbuf;
-	int                   fd;
-	int                   rc;
-	char                  output_buf[10];
-	char                  input_buf[] = "hello";
-	off_t                 offset;
-	int                   root = open(test_dir, O_PATH | O_DIRECTORY);
-	struct dfuse_il_reply il_reply;
+	struct stat stbuf0;
+	struct stat stbuf;
+	int         fd;
+	int         rc;
+	char        output_buf[10];
+	char        input_buf[] = "hello";
+	off_t       offset;
+	int         root = open(test_dir, O_PATH | O_DIRECTORY);
 
 	assert_return_code(root, errno);
 
@@ -89,11 +87,6 @@ do_openat(void **state)
 	rc = fstat(fd, &stbuf0);
 	assert_return_code(rc, errno);
 	assert_int_equal(stbuf0.st_size, sizeof(input_buf));
-
-	rc = ioctl(fd, DFUSE_IOCTL_IL, &il_reply);
-	/* verify st_blksize equals DFS_DEFAULT_CHUNK_SIZE for the file on DFS */
-	if (rc == 0)
-		assert_int_equal(stbuf0.st_blksize, DFS_DEFAULT_CHUNK_SIZE);
 
 	/* Second fstat.  IL will bypass the kernel for this one */
 	rc = fstat(fd, &stbuf);


### PR DESCRIPTION
Python buffered read/write relies on st_blksize as default buffer size. dfuse calls dfs_ostatx() which returns stat with zero st_blksize. Consequently, 4096 for st_blksize is returned to application.

Features: dfs

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
