### PR TITLE
DAOS-15052 test: Update expected wal checkpoint metrics (#14520)

### DIFF
--- a/src/tests/ftest/telemetry/wal_metrics.py
+++ b/src/tests/ftest/telemetry/wal_metrics.py
@@ -203,8 +203,8 @@ class WalMetrics(TestWithTelemetry):
                             # Check point dirty pages should be 1-3
                             ranges[metric][label] = [1, 3]
                         elif '_duration' in metric:
-                            # Check point duration should be 1-1,000,000
-                            ranges[metric][label] = [1, 1000000]
+                            # Check point duration should be 1-2,000,000
+                            ranges[metric][label] = [1, 2000000]
                         elif '_iovs_copied' in metric:
                             # Check point iovs copied should be >= 0
                             ranges[metric][label] = [1]


### PR DESCRIPTION
In test_wal_checkpoint_metrics the engine_pool_checkpoint_duration can be larger than what was originally scoped for the test.  This will increase the expected value range and allow the test to pass.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium-md-on-ssd: false
Test-tag: test_wal_checkpoint_metrics
Test-repeat: 5

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
