### PR TITLE
DAOS-15968 container: Fix CAPA fetch on NS master (#14511)

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -511,8 +511,15 @@ again:
 					}
 					prop_entry = daos_prop_entry_get(prop, DAOS_PROP_CO_STATUS);
 					D_ASSERT(prop_entry != NULL);
-
 					daos_prop_val_2_co_status(prop_entry->dpe_val, &stat);
+
+					rc = ds_cont_tgt_open(entry->ns->iv_pool_uuid,
+							      civ_key->cont_uuid, chdl.ch_cont,
+							      chdl.ch_flags, chdl.ch_sec_capas,
+							      stat.dcs_pm_ver);
+					if (rc != 0)
+						D_GOTO(out, rc);
+
 					iv_entry.iv_capa.status_pm_ver = stat.dcs_pm_ver;
 					daos_prop_free(prop);
 					/* Only happens on xstream 0 */
@@ -524,6 +531,11 @@ again:
 					rc = dbtree_update(root_hdl, &key_iov, &val_iov);
 					if (rc == 0)
 						goto again;
+					/*
+					 * It seems that not rolling back the ds_cont_tgt_open call
+					 * above is harmless. Also, an error from the dbtree_update
+					 * call should be rare.
+					 */
 				} else {
 					rc = -DER_NONEXIST;
 				}


### PR DESCRIPTION
Apparently, when an I/O request fetches a container handle on the engine who is the PS leader, if the ds_cont_hdl object is absent (because the engine has restarted), then the cont_iv code won't create a ds_cont_hdl object, even though the handle is found in the RDB. This patch adds a ds_cont_tgt_open call to cont_iv_ent_fetch, so that the flow is similar to cont_iv_ent_update.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
