### PR TITLE
DAOS-15914 dtx: control DTX RPCs

### DIFF
--- a/src/dtx/dtx_coll.c
+++ b/src/dtx/dtx_coll.c
@@ -305,7 +305,7 @@ dtx_coll_local_one(void *args)
 		rc = vos_dtx_abort(cont->sc_hdl, &dcla->dcla_xid, dcla->dcla_epoch);
 		break;
 	case DTX_COLL_CHECK:
-		rc = vos_dtx_check(cont->sc_hdl, &dcla->dcla_xid, NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(cont->sc_hdl, &dcla->dcla_xid, NULL, NULL, NULL, false);
 		if (rc == DTX_ST_INITED) {
 			/*
 			 * For DTX_CHECK, non-ready one is equal to non-exist. Do not directly

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -192,6 +192,14 @@ extern uint32_t dtx_batched_ult_max;
  */
 #define DTX_COLL_TREE_WIDTH		8
 
+/*
+ * If a large transaction has sub-requests to dispatch to a lot of DTX participants,
+ * then we may have to split the dispatch process to multiple steps; otherwise, the
+ * dispatch process may trigger too many in-flight or in-queued RPCs that will hold
+ * too much resource as to server maybe out of memory.
+ */
+#define DTX_RPC_STEP_LENGTH	DTX_THRESHOLD_COUNT
+
 extern struct crt_corpc_ops	dtx_coll_commit_co_ops;
 extern struct crt_corpc_ops	dtx_coll_abort_co_ops;
 extern struct crt_corpc_ops	dtx_coll_check_co_ops;
@@ -255,14 +263,16 @@ int dtx_leader_get(struct ds_pool *pool, struct dtx_memberships *mbs,
 
 /* dtx_cos.c */
 int dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,
-			  daos_unit_oid_t *oid, daos_epoch_t epoch,
+			  daos_unit_oid_t *oid, daos_epoch_t epoch, bool force,
 			  struct dtx_entry ***dtes, struct dtx_cos_key **dcks,
 			  struct dtx_coll_entry **p_dce);
-int dtx_add_cos(struct ds_cont_child *cont, void *entry, daos_unit_oid_t *oid,
+int dtx_cos_add(struct ds_cont_child *cont, void *entry, daos_unit_oid_t *oid,
 		uint64_t dkey_hash, daos_epoch_t epoch, uint32_t flags);
-int dtx_del_cos(struct ds_cont_child *cont, struct dtx_id *xid,
+int dtx_cos_del(struct ds_cont_child *cont, struct dtx_id *xid,
 		daos_unit_oid_t *oid, uint64_t dkey_hash);
 uint64_t dtx_cos_oldest(struct ds_cont_child *cont);
+void dtx_cos_prio(struct ds_cont_child *cont, struct dtx_id *xid,
+		  daos_unit_oid_t *oid, uint64_t dkey_hash);
 
 /* dtx_rpc.c */
 int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
@@ -303,6 +313,8 @@ enum dtx_cos_flags {
 	DCF_EXP_CMT		= (1 << 1),
 	/* For collective DTX. */
 	DCF_COLL		= (1 << 2),
+	/* The DTX has been committed on all non-leaders. */
+	DCF_REMOTE_CMT		= (1 << 3),
 };
 
 #endif /* __DTX_INTERNAL_H__ */

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -85,7 +85,7 @@ dtx_resync_commit(struct ds_cont_child *cont,
 		 * committed or aborted the DTX during we handling other
 		 * DTXs. So double check the status before current commit.
 		 */
-		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid, NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid, NULL, NULL, NULL, false);
 
 		/* Skip this DTX since it has been committed or aggregated. */
 		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE || rc == -DER_NONEXIST)
@@ -301,7 +301,7 @@ dtx_status_handle_one(struct ds_cont_child *cont, struct dtx_entry *dte, daos_un
 		 * committed or aborted the DTX during we handling other
 		 * DTXs. So double check the status before next action.
 		 */
-		rc = vos_dtx_check(cont->sc_hdl, &dte->dte_xid, NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(cont->sc_hdl, &dte->dte_xid, NULL, NULL, NULL, false);
 
 		/* Skip the DTX that may has been committed or aborted. */
 		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE || rc == -DER_NONEXIST)

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -354,7 +354,7 @@ struct dtx_common_args {
 	daos_handle_t		  dca_tree_hdl;
 	daos_epoch_t		  dca_epoch;
 	int			  dca_count;
-	int			  dca_committed;
+	int			  dca_steps;
 	d_rank_t		  dca_rank;
 	uint32_t		  dca_tgtid;
 	struct ds_cont_child	 *dca_cont;
@@ -369,37 +369,27 @@ struct dtx_common_args {
 
 /* If is_reentrance, this function ignores len. */
 static int
-dtx_req_list_send(struct dtx_common_args *dca, daos_epoch_t epoch, int len, bool is_reentrance)
+dtx_req_list_send(struct dtx_common_args *dca, bool is_reentrance)
 {
 	struct dtx_req_args	*dra = &dca->dca_dra;
 	int			 rc;
 
 	if (!is_reentrance) {
-		dra->dra_length = len;
+		dra->dra_length = dca->dca_steps;
+		dca->dca_i = 0;
 
-		rc = ABT_future_create(len, dtx_req_list_cb, &dra->dra_future);
+		rc = ABT_future_create(dca->dca_steps, dtx_req_list_cb, &dra->dra_future);
 		if (rc != ABT_SUCCESS) {
-			D_ERROR("ABT_future_create failed for opc %x, len = %d: "
-				"rc = %d.\n", dra->dra_opc, len, rc);
+			D_ERROR("ABT_future_create failed for opc %x, len %d: rc %d.\n",
+				dra->dra_opc, dca->dca_steps, rc);
 			return dss_abterr2der(rc);
 		}
 
 		D_DEBUG(DB_TRACE, "%p: DTX req for opc %x, future %p (%d) start.\n",
-			&dca->dca_chore, dra->dra_opc, dra->dra_future, len);
+			&dca->dca_chore, dra->dra_opc, dra->dra_future, dca->dca_steps);
 	}
 
-	/*
-	 * Begin or continue an iteration over dca_head. When beginning the
-	 * iteration, dca->dca_drr does not point to a real entry, and is only
-	 * safe for d_list_for_each_entry_continue.
-	 */
-	if (!is_reentrance) {
-		dca->dca_drr = d_list_entry(&dca->dca_head, struct dtx_req_rec, drr_link);
-		dca->dca_i = 0;
-	}
-	/* DO NOT add any line here! See the comment on dca->dca_drr above. */
-	d_list_for_each_entry_continue(dca->dca_drr, &dca->dca_head, drr_link)
-	{
+	while (1) {
 		D_DEBUG(DB_TRACE, "chore=%p: drr=%p i=%d\n", &dca->dca_chore, dca->dca_drr,
 			dca->dca_i);
 
@@ -410,7 +400,7 @@ dtx_req_list_send(struct dtx_common_args *dca, daos_epoch_t epoch, int len, bool
 			     DAOS_FAIL_CHECK(DAOS_DTX_FAIL_COMMIT)))
 			rc = dtx_req_send(dca->dca_drr, 1);
 		else
-			rc = dtx_req_send(dca->dca_drr, epoch);
+			rc = dtx_req_send(dca->dca_drr, dca->dca_epoch);
 		if (rc != 0) {
 			/* If the first sub-RPC failed, then break, otherwise
 			 * other remote replicas may have already received the
@@ -422,8 +412,15 @@ dtx_req_list_send(struct dtx_common_args *dca, daos_epoch_t epoch, int len, bool
 			}
 		}
 
+		/* dca->dca_drr maybe not points to a real entry if all RPCs have been sent. */
+		dca->dca_drr = d_list_entry(dca->dca_drr->drr_link.next,
+					    struct dtx_req_rec, drr_link);
+
+		if (++(dca->dca_i) >= dca->dca_steps)
+			break;
+
 		/* Yield to avoid holding CPU for too long time. */
-		if (++(dca->dca_i) % DTX_RPC_YIELD_THD == 0)
+		if (dca->dca_i % DTX_RPC_YIELD_THD == 0)
 			return DSS_CHORE_YIELD;
 	}
 
@@ -615,63 +612,13 @@ static enum dss_chore_status
 dtx_rpc_helper(struct dss_chore *chore, bool is_reentrance)
 {
 	struct dtx_common_args	*dca = container_of(chore, struct dtx_common_args, dca_chore);
-	struct ds_pool		*pool = dca->dca_cont->sc_pool->spc_pool;
-	struct umem_attr	 uma = { 0 };
-	int			 length = 0;
 	int			 rc;
-	int			 i;
 
-	if (is_reentrance) {
-		D_DEBUG(DB_TRACE, "%p: skip to send\n", &dca->dca_chore);
-		goto send;
-	}
-
-	if (dca->dca_dtes != NULL) {
-		D_ASSERT(dca->dca_dtis != NULL);
-
-		if (dca->dca_count > 1) {
-			uma.uma_id = UMEM_CLASS_VMEM;
-			rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
-						   &uma, &dca->dca_tree_root, &dca->dca_tree_hdl);
-			if (rc != 0)
-				goto done;
-		}
-
-		ABT_rwlock_rdlock(pool->sp_lock);
-		for (i = 0; i < dca->dca_count; i++) {
-			rc = dtx_classify_one(pool, dca->dca_tree_hdl, &dca->dca_head, &length,
-					      dca->dca_dtes[i], dca->dca_count,
-					      dca->dca_rank, dca->dca_tgtid, dca->dca_dra.dra_opc);
-			if (rc < 0) {
-				ABT_rwlock_unlock(pool->sp_lock);
-				goto done;
-			}
-
-			daos_dti_copy(&dca->dca_dtis[i], &dca->dca_dtes[i]->dte_xid);
-		}
-		ABT_rwlock_unlock(pool->sp_lock);
-
-		/* For DTX_CHECK, if no other available target(s), then current target is the
-		 * unique valid one (and also 'prepared'), then related DTX can be committed.
-		 */
-		if (d_list_empty(&dca->dca_head)) {
-			rc = (dca->dca_dra.dra_opc == DTX_CHECK ? DTX_ST_PREPARED : 0);
-			goto done;
-		}
-	} else {
-		length = dca->dca_count;
-	}
-
-	D_ASSERT(length > 0);
-
-send:
-	rc = dtx_req_list_send(dca, dca->dca_epoch, length, is_reentrance);
+	rc = dtx_req_list_send(dca, is_reentrance);
 	if (rc == DSS_CHORE_YIELD)
 		return DSS_CHORE_YIELD;
 	if (rc == DSS_CHORE_DONE)
 		rc = 0;
-
-done:
 	if (rc != 0)
 		dca->dca_dra.dra_result = rc;
 	D_CDEBUG(rc < 0, DLOG_ERR, DB_TRACE, "%p: DTX RPC chore for %u done: %d\n", chore,
@@ -684,12 +631,17 @@ done:
 }
 
 static int
-dtx_rpc_prep(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
-	     uint32_t count, int opc, daos_epoch_t epoch, d_list_t *cmt_list,
-	     d_list_t *abt_list, d_list_t *act_list, struct dtx_common_args *dca)
+dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes, uint32_t count,
+	int opc, daos_epoch_t epoch, d_list_t *cmt_list, d_list_t *abt_list, d_list_t *act_list,
+	bool keep_head, struct dtx_common_args *dca)
 {
+	struct ds_pool		*pool = cont->sc_pool->spc_pool;
+	struct dtx_req_rec	*drr;
 	struct dtx_req_args	*dra;
+	struct umem_attr	 uma = { 0 };
+	int			 length = 0;
 	int			 rc = 0;
+	int			 i;
 
 	memset(dca, 0, sizeof(*dca));
 
@@ -709,7 +661,7 @@ dtx_rpc_prep(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **
 	dra->dra_abt_list = abt_list;
 	dra->dra_act_list = act_list;
 	dra->dra_opc = opc;
-	uuid_copy(dra->dra_po_uuid, cont->sc_pool->spc_pool->sp_uuid);
+	uuid_copy(dra->dra_po_uuid, pool->sp_uuid);
 	uuid_copy(dra->dra_co_uuid, cont->sc_uuid);
 
 	if (dti_list != NULL) {
@@ -725,39 +677,114 @@ dtx_rpc_prep(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **
 		}
 	}
 
-	/* Use helper ULT to handle DTX RPC if there are enough helper XS. */
-	if (dss_has_enough_helper()) {
-		rc = ABT_eventual_create(0, &dca->dca_chore_eventual);
-		if (rc != ABT_SUCCESS) {
-			D_ERROR("failed to create eventual: %d\n", rc);
-			rc = dss_abterr2der(rc);
+	if (dca->dca_dtes != NULL) {
+		D_ASSERT(dca->dca_dtis != NULL);
+
+		if (dca->dca_count > 1) {
+			uma.uma_id = UMEM_CLASS_VMEM;
+			rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
+						   &uma, &dca->dca_tree_root, &dca->dca_tree_hdl);
+			if (rc != 0)
+				goto out;
+		}
+
+		ABT_rwlock_rdlock(pool->sp_lock);
+		for (i = 0; i < dca->dca_count; i++) {
+			if (dca->dca_dtes[i]->dte_remote_cmt == 0) {
+				rc = dtx_classify_one(pool, dca->dca_tree_hdl, &dca->dca_head,
+						      &length, dca->dca_dtes[i], dca->dca_count,
+						      dca->dca_rank, dca->dca_tgtid,
+						      dca->dca_dra.dra_opc);
+				if (rc != 0) {
+					ABT_rwlock_unlock(pool->sp_lock);
+					goto out;
+				}
+			}
+
+			daos_dti_copy(&dca->dca_dtis[i], &dca->dca_dtes[i]->dte_xid);
+		}
+		ABT_rwlock_unlock(pool->sp_lock);
+
+		/* For DTX_CHECK, if no other available target(s), then current target is the
+		 * unique valid one (and also 'prepared'), then related DTX can be committed.
+		 */
+		if (d_list_empty(&dca->dca_head)) {
+			rc = (dca->dca_dra.dra_opc == DTX_CHECK ? DTX_ST_PREPARED : 0);
 			goto out;
 		}
-		rc = dss_chore_delegate(&dca->dca_chore, dtx_rpc_helper);
 	} else {
-		dss_chore_diy(&dca->dca_chore, dtx_rpc_helper);
-		rc = dca->dca_dra.dra_result;
+		D_ASSERT(!d_list_empty(&dca->dca_head));
+
+		length = dca->dca_count;
+	}
+
+	dca->dca_drr = d_list_entry(dca->dca_head.next, struct dtx_req_rec, drr_link);
+
+	/*
+	 * Do not send out the batched RPCs all together, instead, we do that step by step to
+	 * avoid holding too much system resources for relative long time. It is also helpful
+	 * to reduce the whole network peak load and the pressure on related peers.
+	 */
+	while (length > 0) {
+		if (length > DTX_RPC_STEP_LENGTH && opc != DTX_CHECK)
+			dca->dca_steps = DTX_RPC_STEP_LENGTH;
+		else
+			dca->dca_steps = length;
+
+		/* Use helper ULT to handle DTX RPC if there are enough helper XS. */
+		if (dss_has_enough_helper()) {
+			rc = ABT_eventual_create(0, &dca->dca_chore_eventual);
+			if (rc != ABT_SUCCESS) {
+				D_ERROR("failed to create eventual: %d\n", rc);
+				rc = dss_abterr2der(rc);
+				goto out;
+			}
+
+			rc = dss_chore_delegate(&dca->dca_chore, dtx_rpc_helper);
+			if (rc != 0)
+				goto out;
+
+			rc = ABT_eventual_wait(dca->dca_chore_eventual, NULL);
+			D_ASSERTF(rc == ABT_SUCCESS, "ABT_eventual_wait: %d\n", rc);
+
+			rc = ABT_eventual_free(&dca->dca_chore_eventual);
+			D_ASSERTF(rc == ABT_SUCCESS, "ABT_eventual_free: %d\n", rc);
+		} else {
+			dss_chore_diy(&dca->dca_chore, dtx_rpc_helper);
+		}
+
+		rc = dtx_req_wait(&dca->dca_dra);
+		if (rc == 0 || rc == -DER_NONEXIST)
+			goto cont;
+
+		switch (opc) {
+		case DTX_COMMIT:
+		case DTX_ABORT:
+			if (rc != -DER_EXCLUDED && rc != -DER_OOG)
+				goto out;
+			break;
+		case DTX_CHECK:
+			if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE)
+				goto out;
+			/*
+			 * Go ahead even if someone failed, there may be 'COMMITTED'
+			 * in subsequent check, that will overwrite former failure.
+			 */
+			break;
+		case DTX_REFRESH:
+			D_ASSERTF(length < DTX_RPC_STEP_LENGTH,
+				  "Too long list for DTX refresh: %u vs %u\n",
+				  length, DTX_RPC_STEP_LENGTH);
+			break;
+		default:
+			D_ASSERTF(0, "Invalid DTX opc %u\n", opc);
+		}
+
+cont:
+		length -= dca->dca_steps;
 	}
 
 out:
-	return rc;
-}
-
-static int
-dtx_rpc_post(struct dtx_common_args *dca, int ret, bool keep_head)
-{
-	struct dtx_req_rec	*drr;
-	int			 rc;
-
-	if (dca->dca_chore_eventual != ABT_EVENTUAL_NULL) {
-		rc = ABT_eventual_wait(dca->dca_chore_eventual, NULL);
-		D_ASSERTF(rc == ABT_SUCCESS, "ABT_eventual_wait: %d\n", rc);
-		rc = ABT_eventual_free(&dca->dca_chore_eventual);
-		D_ASSERTF(rc == ABT_SUCCESS, "ABT_eventual_free: %d\n", rc);
-	}
-
-	rc = dtx_req_wait(&dca->dca_dra);
-
 	if (daos_handle_is_valid(dca->dca_tree_hdl))
 		dbtree_destroy(dca->dca_tree_hdl, NULL);
 
@@ -767,7 +794,7 @@ dtx_rpc_post(struct dtx_common_args *dca, int ret, bool keep_head)
 			dtx_drr_cleanup(drr);
 	}
 
-	return ret != 0 ? ret : rc;
+	return rc;
 }
 
 /**
@@ -795,8 +822,8 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	int			 rc;
 	int			 rc1 = 0;
 	int			 i;
-
-	rc = dtx_rpc_prep(cont, NULL, dtes, count, DTX_COMMIT, 0, NULL, NULL, NULL, &dca);
+	int			 j;
+	int			 first;
 
 	/*
 	 * NOTE: Before committing the DTX on remote participants, we cannot remove the active
@@ -806,10 +833,8 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	 *	 then it will get -DER_TX_UNCERTAIN, that may cause related application to be
 	 *	 failed. So here, we let remote participants to commit firstly, if failed, we
 	 *	 will ask the leader to retry the commit until all participants got committed.
-	 *
-	 * Some RPC may has been sent, so need to wait even if dtx_rpc_prep hit failure.
 	 */
-	rc = dtx_rpc_post(&dca, rc, false);
+	rc = dtx_rpc(cont, NULL, dtes, count, DTX_COMMIT, 0, NULL, NULL, NULL, false, &dca);
 	if (rc > 0 || rc == -DER_NONEXIST || rc == -DER_EXCLUDED || rc == -DER_OOG)
 		rc = 0;
 
@@ -819,9 +844,21 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 		 * the DTX entries (in the dtis) as "PARTIAL_COMMITTED" and re-commit them later.
 		 * It is harmless to re-commit the DTX that has ever been committed.
 		 */
-		if (dra->dra_committed > 0)
-			rc1 = vos_dtx_set_flags(cont->sc_hdl, dca.dca_dtis, count,
-						DTE_PARTIAL_COMMITTED);
+		if (dra->dra_committed > 0) {
+			for (i = 0, j = 0, first = -1; i < count; i++) {
+				if (dtes[i]->dte_remote_cmt == 0) {
+					if (first == -1)
+						first = i;
+					else
+						dca.dca_dtis[first + j] = dca.dca_dtis[i];
+					j++;
+				}
+			}
+
+			if (j > 0)
+				rc1 = vos_dtx_set_flags(cont->sc_hdl, &dca.dca_dtis[first], j,
+							DTE_PARTIAL_COMMITTED);
+		}
 	} else {
 		if (dcks != NULL) {
 			if (count > 1) {
@@ -846,7 +883,7 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 			for (i = 0; i < count; i++) {
 				if (rm_cos[i]) {
 					D_ASSERT(!daos_oid_is_null(dcks[i].oid.id_pub));
-					dtx_del_cos(cont, &dca.dca_dtis[i], &dcks[i].oid,
+					dtx_cos_del(cont, &dca.dca_dtis[i], &dcks[i].oid,
 						    dcks[i].dkey_hash);
 				}
 			}
@@ -878,13 +915,10 @@ dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	struct dtx_common_args	dca;
 	int			rc;
 	int			rc1;
-	int			rc2;
 
-	rc = dtx_rpc_prep(cont, NULL, &dte, 1, DTX_ABORT, epoch, NULL, NULL, NULL, &dca);
-
-	rc2 = dtx_rpc_post(&dca, rc, false);
-	if (rc2 > 0 || rc2 == -DER_NONEXIST)
-		rc2 = 0;
+	rc = dtx_rpc(cont, NULL, &dte, 1, DTX_ABORT, epoch, NULL, NULL, NULL, false, &dca);
+	if (rc > 0 || rc == -DER_NONEXIST)
+		rc = 0;
 
 	/*
 	 * NOTE: The DTX abort maybe triggered by dtx_leader_end() for timeout on some DTX
@@ -902,10 +936,10 @@ dtx_abort(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	if (rc1 > 0 || rc1 == -DER_NONEXIST)
 		rc1 = 0;
 
-	D_CDEBUG(rc1 != 0 || rc2 != 0, DLOG_ERR, DB_TRACE, "Abort DTX "DF_DTI": rc %d %d %d\n",
-		 DP_DTI(&dte->dte_xid), rc, rc1, rc2);
+	D_CDEBUG(rc1 != 0 || rc != 0, DLOG_ERR, DB_TRACE, "Abort DTX "DF_DTI": rc %d %d\n",
+		 DP_DTI(&dte->dte_xid), rc, rc1);
 
-	return rc1 != 0 ? rc1 : rc2;
+	return rc != 0 ? rc : rc1;
 }
 
 int
@@ -913,7 +947,6 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 {
 	struct dtx_common_args	dca;
 	int			rc;
-	int			rc1;
 
 	/* If no other target, then current target is the unique
 	 * one and 'prepared', then related DTX can be committed.
@@ -921,14 +954,12 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	if (dte->dte_mbs->dm_tgt_cnt == 1)
 		return DTX_ST_PREPARED;
 
-	rc = dtx_rpc_prep(cont, NULL, &dte, 1, DTX_CHECK, epoch, NULL, NULL, NULL, &dca);
+	rc = dtx_rpc(cont, NULL, &dte, 1, DTX_CHECK, epoch, NULL, NULL, NULL, false, &dca);
 
-	rc1 = dtx_rpc_post(&dca, rc, false);
+	D_CDEBUG(rc < 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_TRACE,
+		 "Check DTX "DF_DTI": rc %d\n", DP_DTI(&dte->dte_xid), rc);
 
-	D_CDEBUG(rc1 < 0 && rc1 != -DER_NONEXIST, DLOG_ERR, DB_TRACE,
-		 "Check DTX "DF_DTI": rc %d %d\n", DP_DTI(&dte->dte_xid), rc, rc1);
-
-	return rc1;
+	return rc;
 }
 
 int
@@ -1079,9 +1110,8 @@ next:
 	}
 
 	if (len > 0) {
-		rc = dtx_rpc_prep(cont, &head, NULL, len, DTX_REFRESH, 0,
-				  cmt_list, abt_list, act_list, &dca);
-		rc = dtx_rpc_post(&dca, rc, for_io);
+		rc = dtx_rpc(cont, &head, NULL, len, DTX_REFRESH, 0, cmt_list, abt_list, act_list,
+			     for_io, &dca);
 
 		/*
 		 * For IO case, the DTX refresh failure caused by network trouble may be not fatal
@@ -1151,7 +1181,7 @@ next2:
 			 */
 
 			rc1 = vos_dtx_check(cont->sc_hdl, &dsp->dsp_xid,
-					    NULL, NULL, NULL, NULL, false);
+					    NULL, NULL, NULL, false);
 			if (rc1 == DTX_ST_COMMITTED || rc1 == DTX_ST_COMMITTABLE ||
 			    rc1 == -DER_NONEXIST) {
 				d_list_del(&dsp->dsp_link);
@@ -1182,7 +1212,7 @@ next2:
 				dtx_dsp_free(dsp);
 			} else if (dsp->dsp_status == -DER_INPROGRESS) {
 				rc1 = vos_dtx_check(cont->sc_hdl, &dsp->dsp_xid,
-						    NULL, NULL, NULL, NULL, false);
+						    NULL, NULL, NULL, false);
 				if (rc1 != DTX_ST_COMMITTED && rc1 != DTX_ST_ABORTED &&
 				    rc1 != -DER_NONEXIST) {
 					if (!for_io)
@@ -1602,7 +1632,7 @@ dtx_coll_commit(struct ds_cont_child *cont, struct dtx_coll_entry *dce, struct d
 	 *	 Otherwise, the batched commit ULT may be blocked by such "bad" entry.
 	 */
 	if (rc2 == 0 && dck != NULL)
-		dtx_del_cos(cont, &dce->dce_xid, &dck->oid, dck->dkey_hash);
+		dtx_cos_del(cont, &dce->dce_xid, &dck->oid, dck->dkey_hash);
 
 	D_CDEBUG(rc != 0 || rc1 != 0 || rc2 != 0, DLOG_ERR, DB_TRACE,
 		 "Collectively commit DTX "DF_DTI": %d/%d/%d\n",

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -151,7 +151,6 @@ dtx_handler(crt_rpc_t *rpc)
 	struct dtx_out		*dout = crt_reply_get(rpc);
 	struct ds_cont_child	*cont = NULL;
 	struct dtx_id		*dtis;
-	struct dtx_memberships	*mbs[DTX_REFRESH_MAX] = { 0 };
 	struct dtx_cos_key	 dcks[DTX_REFRESH_MAX] = { 0 };
 	uint32_t		 vers[DTX_REFRESH_MAX] = { 0 };
 	uint32_t		 opc = opc_get(rpc->cr_opc);
@@ -243,7 +242,7 @@ dtx_handler(crt_rpc_t *rpc)
 			D_GOTO(out, rc = -DER_PROTO);
 
 		rc = vos_dtx_check(cont->sc_hdl, din->di_dtx_array.ca_arrays,
-				   NULL, NULL, NULL, NULL, false);
+				   NULL, NULL, NULL, false);
 		if (rc == DTX_ST_INITED) {
 			/* For DTX_CHECK, non-ready one is equal to non-exist. Do not directly
 			 * return 'DTX_ST_INITED' to avoid interoperability trouble if related
@@ -287,8 +286,7 @@ dtx_handler(crt_rpc_t *rpc)
 		for (i = 0, rc1 = 0; i < count; i++) {
 			ptr = (int *)dout->do_sub_rets.ca_arrays + i;
 			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
-			*ptr = vos_dtx_check(cont->sc_hdl, dtis, NULL, &vers[i], &mbs[i], &dcks[i],
-					     true);
+			*ptr = vos_dtx_check(cont->sc_hdl, dtis, NULL, &vers[i], &dcks[i], true);
 			if (*ptr == -DER_NONEXIST && !(flags[i] & DRF_INITIAL_LEADER)) {
 				struct dtx_stat		stat = { 0 };
 
@@ -312,10 +310,10 @@ dtx_handler(crt_rpc_t *rpc)
 				 * it will cause interoperability trouble if remote server is old.
 				 */
 				*ptr = DTX_ST_PREPARED;
+			} else if (*ptr == DTX_ST_COMMITTABLE) {
+				/* Higher priority for the DTX, then it can be committed ASAP. */
+				dtx_cos_prio(cont, dtis, &dcks[i].oid, dcks[i].dkey_hash);
 			}
-
-			if (mbs[i] != NULL)
-				rc1++;
 		}
 		break;
 	default:
@@ -339,47 +337,6 @@ out:
 
 	if (likely(dpm != NULL))
 		d_tm_inc_counter(dpm->dpm_total[opc], 1);
-
-	if (opc == DTX_REFRESH && rc1 > 0) {
-		struct dtx_entry	 dtes[DTX_REFRESH_MAX] = { 0 };
-		struct dtx_entry	*pdte[DTX_REFRESH_MAX] = { 0 };
-		int			 j;
-
-		for (i = 0, j = 0; i < count; i++) {
-			if (mbs[i] == NULL)
-				continue;
-
-			/* For collective DTX, it will be committed soon. */
-			if (mbs[i]->dm_flags & DMF_COLL_TARGET) {
-				D_FREE(mbs[i]);
-				continue;
-			}
-
-			daos_dti_copy(&dtes[j].dte_xid,
-				      (struct dtx_id *)din->di_dtx_array.ca_arrays + i);
-			dtes[j].dte_ver = vers[i];
-			dtes[j].dte_refs = 1;
-			dtes[j].dte_mbs = mbs[i];
-
-			pdte[j] = &dtes[j];
-			dcks[j] = dcks[i];
-			j++;
-		}
-
-		if (j > 0) {
-			/*
-			 * Commit the DTX after replied the original refresh request to
-			 * avoid further query the same DTX.
-			 */
-			rc = dtx_commit(cont, pdte, dcks, j);
-			if (rc < 0)
-				D_WARN("Failed to commit DTX "DF_DTI", count %d: "
-				       DF_RC"\n", DP_DTI(&dtes[0].dte_xid), j, DP_RC(rc));
-
-			for (i = 0; i < j; i++)
-				D_FREE(pdte[i]->dte_mbs);
-		}
-	}
 
 	D_FREE(dout->do_sub_rets.ca_arrays);
 	dout->do_sub_rets.ca_count = 0;

--- a/src/dtx/tests/dts_structs.c
+++ b/src/dtx/tests/dts_structs.c
@@ -42,10 +42,6 @@ struct_dtx_handle(void **state)
 
 	/* Fill up all existing fields with a pattern. */
 	SET_FIELD(dummy, dth_dte);
-	SET_FIELD(dummy, dth_xid);
-	SET_FIELD(dummy, dth_ver);
-	SET_FIELD(dummy, dth_refs);
-	SET_FIELD(dummy, dth_mbs);
 	SET_FIELD(dummy, dth_coh);
 	SET_FIELD(dummy, dth_poh);
 	SET_FIELD(dummy, dth_epoch);
@@ -70,8 +66,9 @@ struct_dtx_handle(void **state)
 	SET_BITFIELD_1(dummy, dth_need_validation);
 	SET_BITFIELD_1(dummy, dth_ignore_uncommitted);
 	SET_BITFIELD_1(dummy, dth_local);
+	SET_BITFIELD_1(dummy, dth_srdg_all);
 	SET_BITFIELD_1(dummy, dth_local_complete);
-	SET_BITFIELD(dummy, padding1, 13);
+	SET_BITFIELD(dummy, padding1, 12);
 
 	SET_FIELD(dummy, dth_dti_cos_count);
 	SET_FIELD(dummy, dth_dti_cos);

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -49,10 +49,8 @@ enum dtx_grp_flags {
 };
 
 enum dtx_mbs_flags {
-	/* The targets being modified via the DTX belong to a replicated
-	 * object within single redundancy group.
-	 */
-	DMF_SRDG_REP			= (1 << 0),
+	/* The targets being modified via the DTX belong to a single redundancy group. */
+	DMF_SRDG			= (1 << 0),
 	/* The MBS contains the DTX leader information, usually used for
 	 * distributed transaction. In old release (before 2.4), for some
 	 * stand-alone modification, leader information may be not stored

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -74,7 +74,6 @@ vos_dtx_validation(struct dtx_handle *dth);
  * \param[in,out] epoch		Pointer to current epoch, if it is zero and if the DTX exists, then
  *				the DTX's epoch will be saved in it.
  * \param[out] pm_ver		Hold the DTX's pool map version.
- * \param[out] mbs		Pointer to the DTX participants information.
  * \param[out] dck		Pointer to the key for CoS cache.
  * \param[in] for_refresh	It is for DTX_REFRESH or not.
  *
@@ -95,8 +94,7 @@ vos_dtx_validation(struct dtx_handle *dth);
  */
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, struct dtx_memberships **mbs, struct dtx_cos_key *dck,
-	      bool for_refresh);
+	      uint32_t *pm_ver, struct dtx_cos_key *dck, bool for_refresh);
 
 /**
  * Load participants information for the given DTX.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -65,7 +65,9 @@ struct dtx_entry {
 	/** The pool map version when the DTX happened. */
 	uint32_t			 dte_ver;
 	/** The reference count. */
-	uint32_t			 dte_refs;
+	uint16_t			 dte_refs;
+	uint16_t			 dte_remote_cmt:1, /* committed on all non-leaders. */
+					 dte_padding:15;
 	/** The DAOS targets participating in the DTX. */
 	struct dtx_memberships		*dte_mbs;
 };

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1993,8 +1993,8 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		leader_oid.id_pub = obj->cob_md.omd_id;
 		leader_oid.id_shard = i;
 		leader_dtrg_idx = obj_get_shard(obj, i)->po_target;
-		if (!obj_is_ec(obj) && act_grp_cnt == 1)
-			mbs->dm_flags |= DMF_SRDG_REP;
+		if (act_grp_cnt == 1)
+			mbs->dm_flags |= DMF_SRDG;
 
 		/* If there is only one redundancy group to be modified,
 		 * then such redundancy group information should already

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -102,8 +102,7 @@ obj_gen_dtx_mbs(uint32_t flags, uint32_t *tgt_cnt, struct daos_shard_tgt **p_tgt
 	--(*tgt_cnt);
 	*p_tgts = ++tgts;
 
-	if (!(flags & ORF_EC))
-		mbs->dm_flags |= DMF_SRDG_REP;
+	mbs->dm_flags |= DMF_SRDG;
 
 out:
 	*p_mbs = mbs;
@@ -2932,9 +2931,8 @@ again2:
 	 * them before real modifications to avoid availability issues.
 	 */
 	D_FREE(dti_cos);
-	dti_cos_cnt = dtx_list_cos(ioc.ioc_coc, &orw->orw_oid,
-				   orw->orw_dkey_hash, DTX_THRESHOLD_COUNT,
-				   &dti_cos);
+	dti_cos_cnt = dtx_cos_get_piggyback(ioc.ioc_coc, &orw->orw_oid, orw->orw_dkey_hash,
+					    DTX_THRESHOLD_COUNT, &dti_cos);
 	if (dti_cos_cnt < 0)
 		D_GOTO(out, rc = dti_cos_cnt);
 
@@ -2958,6 +2956,9 @@ again2:
 		dtx_flags |= DTX_PREPARED;
 	else
 		dtx_flags &= ~DTX_PREPARED;
+
+	if (!daos_oclass_is_ec(&ioc.ioc_oca) || tgt_cnt + 1 == obj_ec_tgt_nr(&ioc.ioc_oca))
+		dtx_flags |= DTX_SRDG_ALL;
 
 	rc = dtx_leader_begin(ioc.ioc_vos_coh, &orw->orw_dti, &epoch, 1,
 			      version, &orw->orw_oid, dti_cos, dti_cos_cnt,
@@ -3850,9 +3851,8 @@ again2:
 	 * them before real modifications to avoid availability issues.
 	 */
 	D_FREE(dti_cos);
-	dti_cos_cnt = dtx_list_cos(ioc.ioc_coc, &opi->opi_oid,
-				   opi->opi_dkey_hash, DTX_THRESHOLD_COUNT,
-				   &dti_cos);
+	dti_cos_cnt = dtx_cos_get_piggyback(ioc.ioc_coc, &opi->opi_oid, opi->opi_dkey_hash,
+					    DTX_THRESHOLD_COUNT, &dti_cos);
 	if (dti_cos_cnt < 0)
 		D_GOTO(out, rc = dti_cos_cnt);
 
@@ -3876,6 +3876,9 @@ again2:
 		dtx_flags |= DTX_PREPARED;
 	else
 		dtx_flags &= ~DTX_PREPARED;
+
+	if (!daos_oclass_is_ec(&ioc.ioc_oca) || tgt_cnt + 1 == obj_ec_tgt_nr(&ioc.ioc_oca))
+		dtx_flags |= DTX_SRDG_ALL;
 
 	rc = dtx_leader_begin(ioc.ioc_vos_coh, &opi->opi_dti, &epoch, 1,
 			      version, &opi->opi_oid, dti_cos, dti_cos_cnt,
@@ -5077,6 +5080,16 @@ again:
 		dtx_flags |= DTX_PREPARED;
 	else
 		dtx_flags &= ~DTX_PREPARED;
+
+	if (dcde->dcde_write_cnt > 0 && dcsh->dcsh_mbs->dm_flags & DMF_SRDG) {
+		rc = obj_ioc_init_oca(dca->dca_ioc, dcsh->dcsh_leader_oid.id_pub, true);
+		if (rc != 0)
+			D_GOTO(out, rc);
+
+		if (!daos_oclass_is_ec(&dca->dca_ioc->ioc_oca) ||
+		    tgt_cnt == obj_ec_tgt_nr(&dca->dca_ioc->ioc_oca))
+			dtx_flags |= DTX_SRDG_ALL;
+	}
 
 	rc = dtx_leader_begin(dca->dca_ioc->ioc_vos_coh, &dcsh->dcsh_xid, &dcsh->dcsh_epoch,
 			      dcde->dcde_write_cnt, oci->oci_map_ver, &dcsh->dcsh_leader_oid,

--- a/src/utils/ddb/tests/ddb_test_driver.c
+++ b/src/utils/ddb/tests/ddb_test_driver.c
@@ -429,10 +429,10 @@ dvt_dtx_begin_helper(daos_handle_t coh, const daos_unit_oid_t *oid, daos_epoch_t
 	mbs->dm_tgts[0].ddt_id = 1;
 
 	/** Use unique API so new UUID is generated even on same thread */
-	daos_dti_gen_unique(&(&dth->dth_dte)->dte_xid);
-	dth->dth_dte.dte_ver = 1;
-	dth->dth_dte.dte_refs = 1;
-	dth->dth_dte.dte_mbs = mbs;
+	daos_dti_gen_unique(&dth->dth_xid);
+	dth->dth_ver = 1;
+	dth->dth_refs = 1;
+	dth->dth_mbs = mbs;
 
 	dth->dth_coh = coh;
 	dth->dth_epoch = epoch;
@@ -460,7 +460,7 @@ static void
 dvt_dtx_end(struct dtx_handle *dth)
 {
 	vos_dtx_detach(dth);
-	D_FREE(dth->dth_dte.dte_mbs);
+	D_FREE(dth->dth_mbs);
 	D_FREE(dth);
 }
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -68,6 +68,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_prepared = 0;
 	dth->dth_aborted = 0;
 	dth->dth_already = 0;
+	dth->dth_srdg_all = 0;
 	dth->dth_need_validation = 0;
 
 	dth->dth_dti_cos_count = 0;
@@ -127,7 +128,7 @@ vts_dtx_end(struct dtx_handle *dth)
 
 	vos_dtx_rsrvd_fini(dth);
 	vos_dtx_detach(dth);
-	D_FREE(dth->dth_dte.dte_mbs);
+	D_FREE(dth->dth_mbs);
 	D_FREE(dth);
 }
 
@@ -831,7 +832,7 @@ dtx_18(void **state)
 	assert_rc_equal(rc, 10);
 
 	for (i = 0; i < 10; i++) {
-		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i], NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i], NULL, NULL, NULL, false);
 		assert_int_equal(rc, DTX_ST_COMMITTED);
 	}
 
@@ -842,7 +843,7 @@ dtx_18(void **state)
 	assert_rc_equal(rc, 0);
 
 	for (i = 0; i < 10; i++) {
-		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i], NULL, NULL, NULL, NULL, false);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i], NULL, NULL, NULL, false);
 		assert_rc_equal(rc, -DER_NONEXIST);
 	}
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1177,13 +1177,16 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	}
 
 	if (intent == DAOS_INTENT_PURGE) {
+		uint32_t	age = d_hlc_age2sec(DAE_XID(dae).dti_hlc);
+
 		/*
 		 * The DTX entry still references related data record,
 		 * then we cannot (vos) aggregate related data record.
 		 */
-		if (d_hlc_age2sec(DAE_XID(dae).dti_hlc) >= DAOS_AGG_THRESHOLD)
-			D_WARN("DTX "DF_DTI" (%u) still references the data, cannot be (VOS) "
-			       "aggregated\n", DP_DTI(&DAE_XID(dae)), vos_dtx_status(dae));
+		if (age >= DAOS_AGG_THRESHOLD)
+			D_WARN("DTX "DF_DTI" (state:%u, age:%u) still references the data, "
+			       "cannot be (VOS) aggregated\n",
+			       DP_DTI(&DAE_XID(dae)), vos_dtx_status(dae), age);
 
 		return ALB_AVAILABLE_DIRTY;
 	}
@@ -1831,8 +1834,7 @@ vos_dtx_pack_mbs(struct umem_instance *umm, struct vos_dtx_act_ent *dae)
 
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, struct dtx_memberships **mbs, struct dtx_cos_key *dck,
-	      bool for_refresh)
+	      uint32_t *pm_ver, struct dtx_cos_key *dck, bool for_refresh)
 {
 	struct vos_container	*cont;
 	struct vos_dtx_act_ent	*dae;
@@ -1878,9 +1880,6 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 		}
 
 		if (dae->dae_committable || DAE_FLAGS(dae) & DTE_PARTIAL_COMMITTED) {
-			if (mbs != NULL)
-				*mbs = vos_dtx_pack_mbs(vos_cont2umm(cont), dae);
-
 			if (epoch != NULL)
 				*epoch = DAE_EPOCH(dae);
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2440,8 +2440,27 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 
 	tx_started = true;
 
-	/* Commit the CoS DTXs via the IO PMDK transaction. */
-	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0 && !dth->dth_cos_done) {
+	/*
+	 * NOTE: For non-leader, commit the CoS DTX via current IO local transaction.
+	 *	 As for leader case, related DTX in CoS cache must be committable, it
+	 *	 will not affect related data visibility even if we do not commit it.
+	 *
+	 *	 On the other hand, if the DTX leader commit the DTX in CoS cache via
+	 *	 current IO local transaction but some non-leader failed to commit it,
+	 *	 then we will miss to commit related DTX on those non-leader(s) under
+	 *	 the following conditions:
+	 *
+	 *	 1. The leader is restart, then lost original CoS cache.
+	 *	 2. The committed DTX entry on leader is removed by DTX aggregation.
+	 *
+	 *	 So for leader case, we will keep it in CoS cache until the up layer
+	 *	 DTX batched commit logic to commit it explicitly. If all non-leaders
+	 *	 have committed related DTX via some forwarded IO RPC piggyback, then
+	 *	 related batched commit will be local operation without additional RPCs.
+	 *	 That will not cause too much overhead.
+	 */
+	if (dtx_is_valid_handle(dth) && !(dth->dth_flags & DTE_LEADER) &&
+	    dth->dth_dti_cos_count > 0 && !dth->dth_cos_done) {
 		D_ASSERT(!dth->dth_local);
 
 		D_ALLOC_ARRAY(daes, dth->dth_dti_cos_count);


### PR DESCRIPTION
1. Send DTX batched commit RPCs step by step

Currently, for each DTX batched commit operation, it will handle at most 512 DTX entries that may generate DTX commit RPCs to thousands of DAOS targets. We will not send out the batched RPCs all together, instead, we will send them step by step. After each step, the logic will yield and wait until replied, and then next batched RPCs. That can avoid holding too much system resources for relative long time. It is also helpful to reduce the whole system network peak load and the pressure on related targets.

Reorg DTX CoS logic to reduce the RPCs caused by potential repeated DTX commit. More clear names for DTX CoS API.

2. Keep DTX in CoS cache on leader

When commit DTX via forwarded IO RPCs piggyback, we need to keep the DTX in CoS cache on the DTX leader, because related DTX in CoS cache must be committable, it will not affect related data visibility even if we do not commit it via IO local transaction.

On the other hand, if the DTX leader commit the DTX in CoS cache via current IO local transaction but some non-leader failed to commit it, then we will miss to commit related DTX on those non-leader(s) under the following conditions:

a. The leader is restart, then lost original CoS cache. b. The committed DTX entry on leader is removed by DTX aggregation.

So for leader, we will keep it in CoS cache until DTX batched commit logic to commit it explicitly. If all non-leaders have committed the CoS DTX via current forwarded IO RPCs piggyback, then related batched commit will be only local operation without additional RPCs. That will not cause too much overhead.

3. The patch also allows the DTX for EC object based modification to be committed via some subsequent forwarded IO RPCs piggyback. That may save a lot of DTX refresh RPCs for subsequent modifications against the same EC object. So it will be helpful to reduce the network load.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
