### PR TITLE
DAOS-16014 test: Server rank failure Aurora support - Stop a rank fro…

### DIFF
--- a/src/tests/ftest/deployment/server_rank_failure.yaml
+++ b/src/tests/ftest/deployment/server_rank_failure.yaml
@@ -54,11 +54,12 @@ ior: &ior_base
     ppn: 4
   flags: -k -v -w -W
   api: DFS
-  # We wait for a few seconds before excluding a target. If the IOR finishes too
+  # We wait for a few seconds before killing an engine. If the IOR finishes too
   # quickly, the test will not work. We use -D (deadlineForStonewalling) 120, so the
   # process ends in about 120 sec. Adjust the transfer_size - block_size combination
   # based on the system so that it takes longer than the -D value.
-  transfer_size: 512K
+  transfer_size: 512K  # CI
+  # transfer_size: 1G  # Aurora
   sw_deadline: 120
 ior_wo_rf:
   <<: *ior_base
@@ -68,11 +69,20 @@ ior_wo_rf:
   dfs_dir_oclass: SX
 ior_with_rp:
   <<: *ior_base
-  block_size: 150G
+  # Total size is block_size * ppn * number of clients. Because we frequently change the number of
+  # clients while debugging on Aurora, we may have to adjust block_size to make sure that IOR
+  # finishes before sw_deadline. (Smaller block_size for larger number of clients.) Use the second
+  # commented line for Aurora.
+  block_size: 150G  # CI
+  # block_size: 50G  # Aurora
   dfs_oclass: RP_3GX
   dfs_dir_oclass: RP_3GX
 ior_with_ec:
   <<: *ior_base
-  block_size: 150G
+  block_size: 150G  # CI
+  # block_size: 50G  # Aurora
   dfs_oclass: EC_4P2GX
   dfs_dir_oclass: EC_4P2GX
+
+# Execution environment. For Aurora, set it to "aurora".
+ex_env: ci


### PR DESCRIPTION
…m two different groups

Use dmg system stop to stop a rank from two different groups. Support CI/Aurora mode in the test yaml to easily toggle the execution environment.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium-md-on-ssd: false
Test-tag: test_server_rank_failure_with_rp test_server_rank_failure_with_ec

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
