### PR TITLE
DAOS-15954 object: test

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1664,6 +1664,15 @@ crt_rpc_inout_buff_init(struct crt_rpc_priv *rpc_priv)
 	}
 }
 
+uint64_t
+crt_rpc_get_rpcid(crt_rpc_t *rpc)
+{
+	struct crt_rpc_priv	*rpc_priv;
+
+	rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
+	return rpc_priv->crp_req_hdr.cch_rpcid;
+}
+
 static inline void
 crt_common_hdr_init(struct crt_rpc_priv *rpc_priv, crt_opcode_t opc)
 {

--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -978,12 +978,12 @@ daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 				&iod_csum->ic_data[i]);
 		if (!match) {
 			if (iod->iod_type == DAOS_IOD_ARRAY)
-				D_ERROR("Data corruption found for recx: "DF_RECX". "
-					"Calculated "DF_CI" != "
-					"received "DF_CI"\n",
-					DP_RECX(iod->iod_recxs[i]),
-					DP_CI(new_iod_csums->ic_data[i]),
-					DP_CI(iod_csum->ic_data[i]));
+				D_ERROR("i %d, Data corruption found for recx: "DF_RECX". "
+					"Calculated "DF_CI2" != "
+					"received "DF_CI2"\n",
+					i, DP_RECX(iod->iod_recxs[i]),
+					DP_CI2(new_iod_csums->ic_data[i]),
+					DP_CI2(iod_csum->ic_data[i]));
 			else
 				D_ERROR("Data corruption found for single value. "
 					"Calculated "DF_CI" != "
@@ -1351,6 +1351,16 @@ ci2csum(struct dcs_csum_info ci)
 {
 	if (ci.cs_csum == NULL)
 		return 0;
+	return ci_buf2uint64(ci.cs_csum, ci.cs_len);
+}
+
+uint64_t
+ci2csum2(struct dcs_csum_info ci)
+{
+	if (ci.cs_csum == NULL)
+		return 0;
+	if (ci.cs_len > 8)
+		return ci_buf2uint64(ci.cs_csum + 8, ci.cs_len - 8);
 	return ci_buf2uint64(ci.cs_csum, ci.cs_len);
 }
 

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -461,6 +461,9 @@ crt_req_send(crt_rpc_t *req, crt_cb_t complete_cb, void *arg);
 int
 crt_reply_send(crt_rpc_t *req);
 
+uint64_t
+crt_rpc_get_rpcid(crt_rpc_t *rpc);
+
 /**
  * Return request buffer
  *

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -42,6 +42,10 @@
 #define	DP_CI(ci) (ci).cs_nr, (ci).cs_len, ci2csum(ci), (ci).cs_buf_len
 #define DF_RANGE "{lo: %lu, hi: %lu, nr: %lu}"
 #define DP_RANGE(r) (r).dcr_lo, (r).dcr_hi, (r).dcr_nr
+
+#define	DF_CI2 "{nr: %d, len: %d, csum: %lu, %lu, csum_buf_len: %d}"
+#define	DP_CI2(ci) (ci).cs_nr, (ci).cs_len, ci2csum(ci), ci2csum2(ci), (ci).cs_buf_len
+
 /**
  * -----------------------------------------------------------
  * DAOS Checksummer
@@ -497,6 +501,9 @@ ci_buf2uint64(const uint8_t *buf, uint16_t len);
 
 uint64_t
 ci2csum(struct dcs_csum_info ci);
+
+uint64_t
+ci2csum2(struct dcs_csum_info ci);
 
 
 /**

--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -132,6 +132,8 @@ dc_obj_init(void)
 	uint32_t ver_array[2] = {DAOS_OBJ_VERSION - 1, DAOS_OBJ_VERSION};
 	int      rc;
 
+	D_ERROR("test DAOS with PR14582 on ECB\n");
+
 	if (daos_client_metric) {
 		daos_register_key(&dc_obj_module_key);
 		rc = daos_metrics_init(DAOS_CLI_TAG, DAOS_OBJ_MODULE, &dc_obj_metrics);

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -142,8 +142,9 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	orw->orw_dti_cos.ca_count = dth->dth_dti_cos_count;
 	orw->orw_dti_cos.ca_arrays = dth->dth_dti_cos;
 
-	D_DEBUG(DB_TRACE, DF_UOID" forwarding to rank:%d tag:%d.\n",
-		DP_UOID(orw->orw_oid), tgt_ep.ep_rank, tgt_ep.ep_tag);
+	D_ERROR(DF_UOID" parent rpcid "DF_U64" forwarding to rank:%d tag:%d, rpcid "DF_U64".\n",
+		DP_UOID(orw->orw_oid), crt_rpc_get_rpcid(parent_req), tgt_ep.ep_rank,
+		tgt_ep.ep_tag, crt_rpc_get_rpcid(req));
 	rc = crt_req_send(req, shard_update_req_cb, remote_arg);
 	if (rc != 0) {
 		D_ASSERT(sub->dss_comp == 1);


### PR DESCRIPTION
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
