### PR TITLE
DAOS-14517 test: Fixing test_daos_vol_bigio (#14523)

### DIFF
--- a/src/tests/ftest/daos_vol/bigio.yaml
+++ b/src/tests/ftest/daos_vol/bigio.yaml
@@ -17,11 +17,7 @@ server_config:
         - D_LOG_FILE_APPEND_PID=1
         - FI_LOG_LEVEL=warn
         - D_LOG_STDERR_IN_LOG=1
-      storage:
-        0:
-          class: dcpm
-          scm_list: ["/dev/pmem0"]
-          scm_mount: /mnt/daos0
+      storage: auto
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 4
@@ -32,14 +28,9 @@ server_config:
         - D_LOG_FILE_APPEND_PID=1
         - FI_LOG_LEVEL=warn
         - D_LOG_STDERR_IN_LOG=1
-      storage:
-        0:
-          class: dcpm
-          scm_list: ["/dev/pmem1"]
-          scm_mount: /mnt/daos1
+      storage: auto
 pool:
-  scm_size: 200G
-  nvme_size: 200G
+  size: 50%
 container:
   type: POSIX
   control_method: daos


### PR DESCRIPTION
Using the correct the storage config and pool creation parameters for the test_daos_vol_bigio test.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium-md-on-ssd: false
Test-tag: DaosVolBigIO

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
