### PR TITLE
DAOS-16107 cart: submit vs timeout list

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -1128,7 +1128,7 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 	case RPC_STATE_INITED:
 	case RPC_STATE_QUEUED:
 		RPC_ERROR(rpc_priv, "aborting %s rpc to group %s, tgt %d:%d, tgt_uri %s\n",
-			  rpc_priv->crp_stae == RPC_STATE_QUEUED ? "queued" : "inited",
+			  rpc_priv->crp_state == RPC_STATE_QUEUED ? "queued" : "inited",
 			  grp_priv->gp_pub.cg_grpid, tgt_ep->ep_rank, tgt_ep->ep_tag,
 			  rpc_priv->crp_tgt_uri);
 		crt_context_req_untrack(rpc_priv);

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -1521,9 +1521,9 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 			epi->epi_req_num++;
 			D_ASSERT(epi->epi_req_num >= epi->epi_reply_num);
 
-			/* add to resend list if not cancelled or timed out already  */
+			/* add to submit list if not cancelled or timed out already  */
 			if (tmp_rpc->crp_timeout_ts != 0) {
-				/* prevent rpc from being released before it is resubmitted below */
+				/* prevent rpc from being released before it is dispatched below */
 				RPC_ADDREF(tmp_rpc);
 				d_list_add_tail(&tmp_rpc->crp_tmp_link_submit, &submit_list);
 			}

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1646,7 +1646,7 @@ out:
 	ul_out->ul_rc = rc;
 
 	if (rc != DER_SUCCESS)
-		D_WARN("uri lookup of (rank=%d:tag=%d) group=%s failed; rc=%d\n", ul_in->ul_rank,
+		D_INFO("uri lookup of (rank=%d:tag=%d) group=%s failed; rc=%d\n", ul_in->ul_rank,
 		       ul_in->ul_tag, grp_priv->gp_pub.cg_grpid, rc);
 
 	if (should_decref)

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -937,6 +937,15 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx,
 	D_ASSERT(uri != NULL || hg_addr != NULL);
 	D_ASSERT(ctx_idx >= 0 && ctx_idx < CRT_SRV_CONTEXT_NUM);
 
+	if (rank == CRT_NO_RANK) {
+		if (uri)
+			*uri = NULL;
+
+		if (hg_addr)
+			*hg_addr = NULL;
+		return;
+	}
+
 	provider = crt_gdata.cg_primary_prov;
 
 	/* TODO: Derive from context */
@@ -1589,6 +1598,11 @@ crt_hdlr_uri_lookup(crt_rpc_t *rpc_req)
 
 	/* convert the requested rank to global rank */
 	g_rank = crt_grp_priv_get_primary_rank(grp_priv, ul_in->ul_rank);
+	if (g_rank == CRT_NO_RANK) {
+		D_INFO("%d rank is not known in group %s (size=%d)\n", ul_in->ul_rank,
+		       grp_priv->gp_pub.cg_grpid, grp_priv->gp_size);
+		D_GOTO(out, rc = -DER_OOG);
+	}
 
 	/* step 0, if I am the final target, reply with URI */
 	if (g_rank == grp_priv_primary->gp_self) {
@@ -1623,20 +1637,25 @@ crt_hdlr_uri_lookup(crt_rpc_t *rpc_req)
 	 * step 2, if rank:tag is not found, lookup rank:tag=0
 	 */
 	ul_out->ul_tag = 0;
-	crt_grp_lc_lookup(grp_priv_primary, crt_ctx->cc_idx,
-			  g_rank, 0, &cached_uri, NULL);
+	crt_grp_lc_lookup(grp_priv_primary, crt_ctx->cc_idx, g_rank, 0, &cached_uri, NULL);
 	ul_out->ul_uri = cached_uri;
 	if (ul_out->ul_uri == NULL)
 		D_GOTO(out, rc = -DER_OOG);
 
 out:
+	ul_out->ul_rc = rc;
+
+	if (rc != DER_SUCCESS)
+		D_WARN("uri lookup of (rank=%d:tag=%d) group=%s failed; rc=%d\n", ul_in->ul_rank,
+		       ul_in->ul_tag, grp_priv->gp_pub.cg_grpid, rc);
+
 	if (should_decref)
 		crt_grp_priv_decref(grp_priv);
-	ul_out->ul_rc = rc;
+
 	rc = crt_reply_send(rpc_req);
 	if (rc != 0)
-		D_ERROR("crt_reply_send failed, rc: %d, opc: %#x.\n",
-			rc, rpc_req->cr_opc);
+		D_ERROR("crt_reply_send failed, rc: %d\n", rc);
+
 	D_FREE(tmp_uri);
 }
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1690,7 +1690,8 @@ crt_rpc_priv_init(struct crt_rpc_priv *rpc_priv, crt_context_t crt_ctx, bool srv
 	struct crt_context *ctx = crt_ctx;
 
 	D_INIT_LIST_HEAD(&rpc_priv->crp_epi_link);
-	D_INIT_LIST_HEAD(&rpc_priv->crp_tmp_link);
+	D_INIT_LIST_HEAD(&rpc_priv->crp_tmp_link_submit);
+	D_INIT_LIST_HEAD(&rpc_priv->crp_tmp_link_timeout);
 	D_INIT_LIST_HEAD(&rpc_priv->crp_parent_link);
 	rpc_priv->crp_complete_cb = NULL;
 	rpc_priv->crp_arg = NULL;

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -130,8 +130,10 @@ struct crt_rpc_priv {
 	crt_rpc_t		crp_pub; /* public part */
 	/* link to crt_ep_inflight::epi_req_q/::epi_req_waitq */
 	d_list_t		crp_epi_link;
-	/* tmp_link used in crt_context_req_untrack */
-	d_list_t		crp_tmp_link;
+	/* link for temp list used during timeout processing */
+	d_list_t                 crp_tmp_link_timeout;
+	/* link for temp list used for wait q processing */
+	d_list_t                 crp_tmp_link_submit;
 	/* link for crt_context::cc_quotas.rpc_waitq */
 	d_list_t		crp_waitq_link;
 	/* link to parent RPC crp_opc_info->co_child_rpcs/co_replied_rpcs */


### PR DESCRIPTION
In rare corner cases an rpc could end up being on both temp submit and timeout lists, causing corruption of one or the other.
submit list is populated from wait_q list, while timeout list is populated when rpc is cancelled or times out.

Fix:

- Separated timeout and submit list links in rpc_priv
- Added additional check to prevent timed out or cancelled rpcs from being added to submitted list.
- timed out or cancelled rpcs will be no-ops now in dispatch_rpc()
- Added ref counting to between submit list population and dispatching of rpcs
- Early checks in group lookup to avoid looking up CRT_NO_RANK/-1
- extra debug info when uri lookups fail

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
