### PR TITLE
DAOS-16141 client: strlen() to replace sizeof() for a string variable

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -4141,7 +4141,7 @@ pre_envp(char *const envp[], char ***new_envp)
 					continue;
 				if (!env_found[i]) {
 					if (memcmp(envp[num_entry], env_list[i],
-					    strlen(env_list[i])) == 0) {
+						   strlen(env_list[i])) == 0) {
 						env_found[i] = true;
 						num_entry_found++;
 					}

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -4140,8 +4140,8 @@ pre_envp(char *const envp[], char ***new_envp)
 				if (!env_set[i])
 					continue;
 				if (!env_found[i]) {
-					if (memcmp(envp[num_entry], STR_AND_SIZE_M1(env_list[i]))
-					    == 0) {
+					if (memcmp(envp[num_entry], env_list[i],
+					    strlen(env_list[i])) == 0) {
 						env_found[i] = true;
 						num_entry_found++;
 					}

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -2975,6 +2975,10 @@ new_xstat(int ver, const char *path, struct stat *stat_buf)
 
 	if (!d_hook_enabled)
 		return next_xstat(ver, path, stat_buf);
+	if (path[0] == 0) {
+		errno = ENOENT;
+		return (-1);
+	}
 
 	rc = query_path(path, &is_target_path, &parent, item_name, &parent_dir,
 			&full_path, &dfs_mt);
@@ -3032,6 +3036,10 @@ new_lxstat(int ver, const char *path, struct stat *stat_buf)
 
 	if (!d_hook_enabled)
 		return libc_lxstat(ver, path, stat_buf);
+	if (path[0] == 0) {
+		errno = ENOENT;
+		return (-1);
+	}
 
 	rc = query_path(path, &is_target_path, &parent, item_name, &parent_dir,
 			&full_path, &dfs_mt);
@@ -3076,6 +3084,10 @@ new_fxstatat(int ver, int dirfd, const char *path, struct stat *stat_buf, int fl
 
 	if (!d_hook_enabled)
 		return libc_fxstatat(ver, dirfd, path, stat_buf, flags);
+	if (path[0] == 0 && ((flags & AT_EMPTY_PATH) == 0)) {
+		errno = ENOENT;
+		return (-1);
+	}
 
 	if (path[0] == '/') {
 		/* Absolute path, dirfd is ignored */
@@ -3129,6 +3141,11 @@ new_fstatat(int dirfd, const char *__restrict path, struct stat *__restrict stat
 
 	if (!d_hook_enabled)
 		return libc_fstatat(dirfd, path, stat_buf, flags);
+
+	if (path[0] == 0 && ((flags & AT_EMPTY_PATH) == 0)) {
+		errno = ENOENT;
+		return (-1);
+	}
 
 	if (path[0] == '/') {
 		/* Absolute path, dirfd is ignored */
@@ -3211,6 +3228,11 @@ statx(int dirfd, const char *path, int flags, unsigned int mask, struct statx *s
 		next_statx = dlsym(RTLD_NEXT, "statx");
 		D_ASSERT(next_statx != NULL);
 	}
+	if (path[0] == 0 && ((flags & AT_EMPTY_PATH) == 0)) {
+		errno = ENOENT;
+		return (-1);
+	}
+
 	if (!d_hook_enabled)
 		return next_statx(dirfd, path, flags, mask, statx_buf);
 

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -65,16 +65,34 @@ char *test_dir;
 void
 do_openat(void **state)
 {
-	struct stat stbuf0;
-	struct stat stbuf;
-	int         fd;
-	int         rc;
-	char        output_buf[10];
-	char        input_buf[] = "hello";
-	off_t       offset;
-	int         root = open(test_dir, O_PATH | O_DIRECTORY);
+	struct stat  stbuf0;
+	struct stat  stbuf;
+	struct statx stxbuf;
+	int          fd;
+	int          rc;
+	char         output_buf[10];
+	char         input_buf[] = "hello";
+	off_t        offset;
+	int          root = open(test_dir, O_PATH | O_DIRECTORY);
 
 	assert_return_code(root, errno);
+
+	/* Test corner case: empty path in stat() and its variants. */
+	rc = stat("", &stbuf);
+	assert_int_equal(rc, -1);
+	assert_int_equal(errno, ENOENT);
+
+	rc = lstat("", &stbuf);
+	assert_int_equal(rc, -1);
+	assert_int_equal(errno, ENOENT);
+
+	rc = fstatat(root, "", &stbuf, 0);
+	assert_int_equal(rc, -1);
+	assert_int_equal(errno, ENOENT);
+
+	rc = statx(root, "", 0, 0, &stxbuf);
+	assert_int_equal(rc, -1);
+	assert_int_equal(errno, ENOENT);
 
 	fd = openat(root, "openat_file", O_RDWR | O_CREAT | O_EXCL, S_IWUSR | S_IRUSR);
 	assert_return_code(fd, errno);


### PR DESCRIPTION
sizeof() does not work for a non-constant string variable inside a loop. strlen() should be used.
Also let stat() and its variants fail if path is empty as glibc does.

Features: pil4dfs

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
