### PR TITLE
DAOS-16035 tests: add log for rebuild ec test

### DIFF
--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -49,7 +49,7 @@ server_config:
       log_file: daos_server0.log
       log_mask: DEBUG,MEM=ERR
       env_vars:
-        - DD_MASK=mgmt,io,md,epc,rebuild,any
+        - DD_MASK=mgmt,io,md,epc,rebuild,any,pl,trace
         - D_LOG_FILE_APPEND_PID=1
         - D_LOG_FILE_APPEND_RANK=1
         - D_LOG_FLUSH=DEBUG
@@ -64,7 +64,7 @@ server_config:
       log_file: daos_server1.log
       log_mask: DEBUG,MEM=ERR
       env_vars:
-        - DD_MASK=mgmt,io,md,epc,rebuild,any
+        - DD_MASK=mgmt,io,md,epc,rebuild,any,pl,trace
         - D_LOG_FILE_APPEND_PID=1
         - D_LOG_FILE_APPEND_RANK=1
         - D_LOG_FLUSH=DEBUG
@@ -170,7 +170,7 @@ daos_tests:
     test_daos_pipeline: P
   args:
     test_daos_ec_io: -l"EC_4P2G1"
-    test_daos_rebuild_ec: -s5
+    test_daos_rebuild_ec: -s5 -u 45
     test_daos_md_replication: -s5
     test_daos_degraded_mode: -s7
     test_daos_drain_simple: -s3

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -77,7 +77,7 @@ class DaosCoreBase(TestWithServers):
         daos_test_env = cmocka_utils.get_cmocka_env()
         daos_test_env["D_LOG_FILE"] = get_log_file(self.client_log)
         daos_test_env["D_LOG_MASK"] = self.get_test_param("test_log_mask", "DEBUG")
-        daos_test_env["DD_MASK"] = "mgmt,io,md,epc,rebuild,test"
+        daos_test_env["DD_MASK"] = "mgmt,io,md,epc,rebuild,pl,trace,test,any"
         daos_test_env["COVFILE"] = "/tmp/test.cov"
         daos_test_env["POOL_SCM_SIZE"] = str(scm_size)
         daos_test_env["POOL_NVME_SIZE"] = str(nvme_size)

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -1201,7 +1201,7 @@ rebuild_ec_multiple_failure_tgts(void **state)
 	if (!test_runable(arg, 6))
 		return;
 
-	oid = daos_test_oid_gen(arg->coh, OC_EC_4P2GX, 0, 0, arg->myrank);
+	oid = daos_test_oid_gen(arg->coh, OC_EC_4P2G1, 0, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	for (i = 0; i < 20; i++) {
 		sprintf(dkey, "d_key_%d", i);
@@ -1230,6 +1230,7 @@ rebuild_ec_multiple_failure_tgts(void **state)
 		memset(v_data, 'a', 20);
 		lookup_recxs(dkey, "a_key", 1, DAOS_TX_NONE, &recx, 1,
 			     data, 20, &req);
+		D_ASSERTF(memcmp(data, v_data, 20) == 0, DF_OID" data mismatch\n", DP_OID(oid));
 		assert_memory_equal(data, v_data, 20);
 	}
 	ioreq_fini(&req);
@@ -1248,6 +1249,7 @@ rebuild_ec_multiple_failure_tgts(void **state)
 		memset(v_data, 'a', 20);
 		lookup_recxs(dkey, "a_key", 1, DAOS_TX_NONE, &recx, 1,
 			     data, 20, &req);
+		D_ASSERTF(memcmp(data, v_data, 20) == 0, DF_OID" data mismatch\n", DP_OID(oid));
 		assert_memory_equal(data, v_data, 20);
 	}
 	ioreq_fini(&req);


### PR DESCRIPTION
Test-tag: test_daos_rebuild_ec
Test-repeat: 15
Skip-nlt: true
Skip-unit-test-memcheck: true
Skip-unit-tests: true
Skip-unit-test: true
Skip-checkpatch: true
Skip-fault-injection-test: true
Quick-Functional: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
