### PR TITLE
Mschaara/pool warmup 2.6

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -10,6 +10,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <semaphore.h>
 #include "crt_internal.h"
 
 static int crt_group_primary_add_internal(struct crt_grp_priv *grp_priv,

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -34,7 +34,7 @@
 static pthread_mutex_t	module_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /** refcount on how many times daos_init has been called */
-static int		module_initialized;
+static int                 module_initialized;
 
 const struct daos_task_api dc_funcs[] = {
 	/** Management */
@@ -309,7 +309,7 @@ unlock:
 int
 daos_fini(void)
 {
-	int	rc;
+	int rc;
 
 	D_MUTEX_LOCK(&module_lock);
 	if (module_initialized == 0) {
@@ -342,8 +342,7 @@ daos_fini(void)
 
 	rc = dc_mgmt_notify_exit();
 	if (rc != 0)
-		D_ERROR("failed to disconnect some resources may leak, "
-			DF_RC"\n", DP_RC(rc));
+		D_ERROR("failed to disconnect some resources may leak, " DF_RC "\n", DP_RC(rc));
 
 	dc_tm_fini();
 	dc_mgmt_drop_attach_info();

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -25,6 +25,7 @@
 #include <daos/pool.h>
 #include <daos/security.h>
 #include <daos_types.h>
+#include <semaphore.h>
 #include "cli_internal.h"
 #include "rpc.h"
 
@@ -35,6 +36,7 @@ struct rsvc_client_state {
 };
 
 int	dc_pool_proto_version;
+static pthread_mutex_t warmup_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* task private context for pool API implementation */
 struct pool_task_priv {
@@ -709,6 +711,143 @@ struct pool_connect_arg {
 	daos_handle_t		*hdlp;
 };
 
+static void
+warmup_cb(const struct crt_cb_info *info)
+{
+	sem_t *sem;
+
+	if (info->cci_rc != 0)
+		D_ERROR("Ping failed with rc = %d\n", info->cci_rc);
+
+	sem = (sem_t *)info->cci_arg;
+
+	sem_post(sem);
+}
+
+/*
+ * Pro-actively ping each target in the pool map.
+ * This forces underlying connection to be set up.
+ */
+static void
+warmup(struct dc_pool *pool)
+{
+	static bool         parsed;
+	static bool         enabled = false;
+	crt_context_t       ctx;
+	int                 i;
+	int                 shift;
+	struct pool_target *tgts;
+	sem_t               sem;
+	crt_bulk_t          bulk_hdl;
+	void               *bulk_buf;
+	int                 bulk_len = 4096;
+	d_sg_list_t         sgl;
+	d_iov_t             iov;
+	int                 nr;
+	int                 rc = 0;
+
+	if (parsed && !enabled)
+		/** fast path when disabled */
+		return;
+
+	D_MUTEX_LOCK(&warmup_lock);
+	if (!parsed) {
+		d_getenv_bool("D_POOL_WARMUP", &enabled);
+		parsed = true;
+	}
+	if (!enabled) {
+		D_MUTEX_UNLOCK(&warmup_lock);
+		return;
+	}
+
+	D_ALLOC(bulk_buf, bulk_len);
+	if (bulk_buf == NULL) {
+		D_ERROR("Failed to alloc mem\n");
+		goto out_unlock;
+	}
+
+	ctx = daos_get_crt_ctx();
+
+	d_iov_set(&iov, bulk_buf, bulk_len);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs   = &iov;
+	rc            = crt_bulk_create(ctx, &sgl, CRT_BULK_RW, &bulk_hdl);
+	if (rc < 0) {
+		D_ERROR("Failed to create bulk handle\n");
+		goto out_bulk;
+	}
+
+	rc = sem_init(&sem, 0, 0);
+	if (rc < 0) {
+		D_ERROR("Failed to initialize semaphore\n");
+		goto out_hdl;
+	}
+
+	/** retrieve all targets from the pool map */
+	nr = pool_map_find_target(pool->dp_map, PO_COMP_ID_ALL, &tgts);
+
+	/** Randomize start order to minimize load for large-scale job */
+	shift = rand() + (int)getpid();
+	if (shift < 0)
+		shift = rand();
+
+	D_DEBUG(DB_TRACE, "Pinging %d targets, shifting at %d\n", nr, shift);
+
+	for (i = 0; i < nr; i++) {
+		crt_endpoint_t             ep;
+		crt_rpc_t                 *rpc = NULL;
+		struct pool_tgt_warmup_in *rpc_in;
+		int                        idx;
+		crt_opcode_t               opcode;
+
+		idx        = (i + shift) % nr;
+		if (tgts[idx].ta_comp.co_status == PO_COMP_ST_DOWN ||
+		    tgts[idx].ta_comp.co_status == PO_COMP_ST_DOWNOUT)
+			continue;
+		ep.ep_grp  = pool->dp_sys->sy_group;
+		ep.ep_rank = tgts[idx].ta_comp.co_rank;
+		ep.ep_tag  = daos_rpc_tag(DAOS_REQ_TGT, tgts[idx].ta_comp.co_index);
+		opcode     = DAOS_RPC_OPCODE(POOL_TGT_WARMUP, DAOS_POOL_MODULE,
+                                         dc_pool_proto_version ? dc_pool_proto_version
+								   : DAOS_POOL_VERSION);
+		rc         = crt_req_create(ctx, &ep, opcode, &rpc);
+		if (rc != 0) {
+			D_ERROR("Failed to allocate req " DF_RC "\n", DP_RC(rc));
+			goto out_sem;
+		}
+		D_ASSERTF(rc == 0, "crt_req_create failed; rc=%d\n", rc);
+		rpc_in          = crt_req_get(rpc);
+		rpc_in->tw_bulk = bulk_hdl;
+
+		rc = crt_req_send(rpc, warmup_cb, &sem);
+		if (rc != 0) {
+			D_ERROR("Failed to ping rank=%d:%d, " DF_RC "\n", ep.ep_rank, ep.ep_tag,
+				DP_RC(rc));
+			goto out_sem;
+		}
+
+		while (sem_trywait(&sem) == -1) {
+			rc = crt_progress(ctx, 0);
+			if (rc && rc != -DER_TIMEDOUT) {
+				D_ERROR("failed to progress context, " DF_RC "\n", DP_RC(rc));
+				break;
+			}
+		}
+		rc = 0;
+	}
+	D_DEBUG(DB_TRACE, "Pinging done\n");
+
+out_sem:
+	(void)sem_destroy(&sem);
+out_hdl:
+	crt_bulk_free(bulk_hdl);
+out_bulk:
+	D_FREE(bulk_buf);
+out_unlock:
+	D_MUTEX_UNLOCK(&warmup_lock);
+}
+
 static int
 pool_connect_cp(tse_task_t *task, void *data)
 {
@@ -784,6 +923,7 @@ pool_connect_cp(tse_task_t *task, void *data)
 		DP_UUID(tpriv->pool->dp_pool), arg->hdlp->cookie,
 		DP_UUID(tpriv->pool->dp_pool_hdl));
 
+	warmup(tpriv->pool);
 out:
 	pool_connect_in_get_cred(arg->rpc, &credp);
 	pool_connect_in_get_data(arg->rpc, NULL /* flags */, NULL /* bits */, &bulk,
@@ -1388,6 +1528,7 @@ dc_pool_g2l(struct dc_pool_glob *pool_glob, size_t len, daos_handle_t *poh)
 		" slave\n", DP_UUID(pool->dp_pool), poh->cookie,
 		DP_UUID(pool->dp_pool_hdl));
 
+	warmup(pool);
 out:
 	if (rc != 0)
 		D_ERROR("failed, rc: "DF_RC"\n", DP_RC(rc));

--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -220,6 +220,7 @@ CRT_RPC_DEFINE(pool_query_info_v6, DAOS_ISEQ_POOL_QUERY_INFO_V6, DAOS_OSEQ_POOL_
 CRT_RPC_DEFINE(pool_query_info, DAOS_ISEQ_POOL_QUERY_INFO, DAOS_OSEQ_POOL_QUERY_INFO)
 CRT_RPC_DEFINE(pool_tgt_query_map, DAOS_ISEQ_POOL_TGT_QUERY_MAP, DAOS_OSEQ_POOL_TGT_QUERY_MAP)
 CRT_RPC_DEFINE(pool_tgt_discard, DAOS_ISEQ_POOL_TGT_DISCARD, DAOS_OSEQ_POOL_TGT_DISCARD)
+CRT_RPC_DEFINE(pool_tgt_warmup, DAOS_ISEQ_POOL_TGT_WARMUP, DAOS_OSEQ_POOL_TGT_WARMUP)
 
 /* Define for cont_rpcs[] array population below.
  * See POOL_PROTO_*_RPC_LIST macro definition

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,7 +74,8 @@
 	  ver >= 6 ? ds_pool_list_cont_handler_v6 : ds_pool_list_cont_handler_v5, NULL)            \
 	X(POOL_TGT_QUERY_MAP, 0, &CQF_pool_tgt_query_map, ds_pool_tgt_query_map_handler, NULL)     \
 	X(POOL_FILTER_CONT, 0, ver >= 6 ? &CQF_pool_filter_cont_v6 : &CQF_pool_filter_cont,        \
-	  ver >= 6 ? ds_pool_filter_cont_handler_v6 : ds_pool_filter_cont_handler_v5, NULL)
+	  ver >= 6 ? ds_pool_filter_cont_handler_v6 : ds_pool_filter_cont_handler_v5, NULL)        \
+	X(POOL_TGT_WARMUP, 0, &CQF_pool_tgt_warmup, ds_pool_tgt_warmup_handler, NULL)
 
 #define POOL_PROTO_SRV_RPC_LIST                                                                    \
 	X(POOL_TGT_DISCONNECT, 0, &CQF_pool_tgt_disconnect, ds_pool_tgt_disconnect_handler,        \
@@ -449,6 +450,12 @@ pool_query_info_in_set_data(crt_rpc_t *rpc, d_rank_t pqii_rank, uint32_t pqii_tg
 
 CRT_RPC_DECLARE(pool_attr_list, DAOS_ISEQ_POOL_ATTR_LIST, DAOS_OSEQ_POOL_ATTR_LIST)
 CRT_RPC_DECLARE(pool_attr_list_v6, DAOS_ISEQ_POOL_ATTR_LIST_V6, DAOS_OSEQ_POOL_ATTR_LIST)
+
+#define DAOS_ISEQ_POOL_TGT_WARMUP	/* input fields */	 \
+	((crt_bulk_t)		(tw_bulk)		CRT_VAR)
+#define DAOS_OSEQ_POOL_TGT_WARMUP
+
+CRT_RPC_DECLARE(pool_tgt_warmup, DAOS_ISEQ_POOL_TGT_WARMUP, DAOS_OSEQ_POOL_TGT_WARMUP)
 
 /* clang-format on */
 

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -226,6 +226,8 @@ int ds_pool_tgt_prop_update(struct ds_pool *pool, struct pool_iv_prop *iv_prop);
 int ds_pool_tgt_connect(struct ds_pool *pool, struct pool_iv_conn *pic);
 void ds_pool_tgt_query_map_handler(crt_rpc_t *rpc);
 void ds_pool_tgt_discard_handler(crt_rpc_t *rpc);
+void
+     ds_pool_tgt_warmup_handler(crt_rpc_t *rpc);
 
 /*
  * srv_util.c

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2503,3 +2503,78 @@ out:
 	if (rc != 0 && arg != NULL)
 		tgt_discard_arg_free(arg);
 }
+
+static int
+bulk_cb(const struct crt_bulk_cb_info *cb_info)
+{
+	ABT_eventual *eventual = cb_info->bci_arg;
+
+	ABT_eventual_set(*eventual, (void *)&cb_info->bci_rc, sizeof(cb_info->bci_rc));
+	return 0;
+}
+
+void
+ds_pool_tgt_warmup_handler(crt_rpc_t *rpc)
+{
+	struct pool_tgt_warmup_in *in;
+	crt_bulk_t                 bulk_cli;
+	crt_bulk_t                 bulk_local = NULL;
+	crt_bulk_opid_t            bulk_opid;
+	uint64_t                   len;
+	struct crt_bulk_desc       bulk_desc;
+	ABT_eventual               eventual;
+	void                      *buf = NULL;
+	int                       *status;
+	d_sg_list_t                sgl;
+	d_iov_t                    iov;
+	int                        rc;
+
+	in       = crt_req_get(rpc);
+	bulk_cli = in->tw_bulk;
+	rc       = crt_bulk_get_len(bulk_cli, &len);
+	if (rc != 0)
+		D_GOTO(out, rc);
+	D_ALLOC(buf, len);
+	if (buf == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+	sgl.sg_nr     = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs   = &iov;
+	d_iov_set(&iov, buf, len);
+	rc = crt_bulk_create(rpc->cr_ctx, &sgl, CRT_BULK_RW, &bulk_local);
+	if (rc)
+		goto out;
+
+	bulk_desc.bd_rpc        = rpc;
+	bulk_desc.bd_bulk_op    = CRT_BULK_GET;
+	bulk_desc.bd_remote_hdl = bulk_cli;
+	bulk_desc.bd_remote_off = 0;
+	bulk_desc.bd_local_hdl  = bulk_local;
+	bulk_desc.bd_local_off  = 0;
+	bulk_desc.bd_len        = len;
+
+	rc = ABT_eventual_create(sizeof(*status), &eventual);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out, rc = dss_abterr2der(rc));
+
+	rc = crt_bulk_transfer(&bulk_desc, bulk_cb, &eventual, &bulk_opid);
+	if (rc != 0)
+		D_GOTO(out_eventual, rc);
+
+	rc = ABT_eventual_wait(eventual, (void **)&status);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out_eventual, rc = dss_abterr2der(rc));
+
+	if (*status != 0)
+		rc = *status;
+
+out_eventual:
+	ABT_eventual_free(&eventual);
+out:
+	if (bulk_local != NULL)
+		crt_bulk_free(bulk_local);
+	D_FREE(buf);
+	if (rc)
+		D_ERROR("rpc failed, " DF_RC "\n", DP_RC(rc));
+	crt_reply_send(rpc);
+}


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
