### PR TITLE
DAOS-16111 rebuild: uniform identifier in logs

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -373,6 +373,9 @@ def scons():
 
     deps_env = Environment()
 
+    # Silence deprecation warning so it doesn't fail the build
+    SetOption('warn', ['no-python-version'])
+
     add_command_line_options()
 
     # Scons strips out the environment, however that is not always desirable so add back in

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -676,33 +676,6 @@ obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, uint64_t tgt_id,
 int
 obj_tree_destroy(daos_handle_t btr_hdl);
 
-/* Per xstream migrate status */
-struct ds_migrate_status {
-	uint64_t dm_rec_count;	/* migrated record size */
-	uint64_t dm_obj_count;	/* migrated object count */
-	uint64_t dm_total_size;	/* migrated total size */
-	int	 dm_status;	/* migrate status */
-	uint32_t dm_migrating:1; /* if it is migrating */
-};
-
-int
-ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, uint32_t generation,
-			struct ds_migrate_status *dms);
-int
-ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_uuid,
-		       uuid_t cont_hdl_uuid, int tgt_id, uint32_t version, unsigned int generation,
-		       uint64_t max_eph, daos_unit_oid_t *oids, daos_epoch_t *ephs,
-		       daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
-		       uint32_t new_gl_ver, unsigned int migrate_opc, uint64_t *enqueue_id,
-		       uint32_t *max_delay);
-int
-ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
-		  uint32_t version, uint32_t generation, uint64_t max_eph, uint32_t opc,
-		  daos_unit_oid_t *oids, daos_epoch_t *epochs, daos_epoch_t *punched_epochs,
-		  unsigned int *shards, uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);
-void
-ds_migrate_stop(struct ds_pool *pool, uint32_t ver, unsigned int generation);
-
 int
 obj_layout_diff(struct pl_map *map, daos_unit_oid_t oid, uint32_t new_ver, uint32_t old_ver,
 		struct daos_obj_md *md, uint32_t *tgts, uint32_t *shards, int array_size);

--- a/src/include/daos_srv/object.h
+++ b/src/include/daos_srv/object.h
@@ -65,4 +65,32 @@ int ds_obj_enum_pack(vos_iter_param_t *param, vos_iter_type_t type, bool recursi
 		     struct vos_iter_anchors *anchors, struct ds_obj_enum_arg *arg,
 		     enum_iterate_cb_t iter_cb, struct dtx_handle *dth);
 
+/* Per xstream migrate status */
+struct ds_migrate_status {
+	uint64_t dm_rec_count;     /* migrated record size */
+	uint64_t dm_obj_count;     /* migrated object count */
+	uint64_t dm_total_size;    /* migrated total size */
+	int      dm_status;        /* migrate status */
+	uint32_t dm_migrating : 1; /* if it is migrating */
+};
+
+int
+ds_migrate_query_status(uuid_t pool_uuid, uint32_t ver, unsigned int generation, int op,
+			struct ds_migrate_status *dms);
+
+int
+ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_uuid,
+		       uuid_t cont_hdl_uuid, int tgt_id, uint32_t version, unsigned int generation,
+		       uint64_t max_eph, daos_unit_oid_t *oids, daos_epoch_t *ephs,
+		       daos_epoch_t *punched_ephs, unsigned int *shards, int cnt,
+		       uint32_t new_gl_ver, unsigned int migrate_opc, uint64_t *enqueue_id,
+		       uint32_t *max_delay);
+int
+ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_uuid,
+		  uint32_t version, uint32_t generation, uint64_t max_eph, uint32_t opc,
+		  daos_unit_oid_t *oids, daos_epoch_t *epochs, daos_epoch_t *punched_epochs,
+		  unsigned int *shards, uint32_t count, unsigned int tgt_idx, uint32_t new_gl_ver);
+void
+ds_migrate_stop(struct ds_pool *pool, uint32_t ver, unsigned int generation);
+
 #endif /* __DAOS_SRV_OBJ_H__ */

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -67,6 +67,21 @@ typedef enum {
 	DP_UUID((mqa)->pool_uuid), (mqa)->version, (mqa)->generation, RB_OP_STR((mqa)->rebuild_op)
 #define DP_RBF_MQA(mqa) DP_RB_MQA(mqa), (mqa)->leader_rank, (mqa)->leader_term
 
+/* arguments for log rebuild identifier given a struct obj_migrate_in *omi */
+#define DP_RB_OMI(omi)                                                                             \
+	DP_UUID((omi)->om_pool_uuid), (omi)->om_version, (omi)->om_generation,                     \
+	    RB_OP_STR((omi)->om_opc)
+
+/* arguments for log rebuild identifier given a struct migrate_pool_tls *mpt */
+#define DP_RB_MPT(mpt)                                                                             \
+	DP_UUID((mpt)->mpt_pool_uuid), (mpt)->mpt_version, (mpt)->mpt_generation,                  \
+	    RB_OP_STR((mpt)->mpt_opc)
+
+/* arguments for log rebuild identifier given a struct migrate_one *mro */
+#define DP_RB_MRO(mro)                                                                             \
+	DP_UUID((mro)->mo_pool_uuid), (mro)->mo_pool_tls_version, (mro)->mo_generation,            \
+	    RB_OP_STR((mro)->mo_opc)
+
 int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 			daos_epoch_t stable_eph, uint32_t layout_version,
 			struct pool_target_id_list *tgts,

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -35,6 +35,38 @@ typedef enum {
 			  (rb_op) == RB_OP_NONE ? "None" : \
 			  "Unknown")
 
+/* Common rebuild identifying information for INFO/DEBUG logging:
+ * rb=<pool_uuid>/<rebuild_ver>/<rebuild_gen>/<opstring>
+ */
+#define DF_RB  "rb=" DF_UUID "/%u/%u/%s"
+
+/* Full rebuild identifying information includes <leader_rank>/<term>
+ * Instead of this, use DF_RB most of the time (use this for leader change scenarios, etc.)
+ */
+#define DF_RBF DF_RB " ld=%u/" DF_U64
+
+/* arguments for log rebuild identifier given a struct rebuild_global_pool_tracker * */
+#define DP_RB_RGT(rgt)                                                                             \
+	DP_UUID((rgt)->rgt_pool_uuid), (rgt)->rgt_rebuild_ver, (rgt)->rgt_rebuild_gen,             \
+	    RB_OP_STR((rgt)->rgt_opc)
+
+/* arguments for log rebuild identifier given a struct rebuild_tgt_pool_tracker *rpt */
+#define DP_RB_RPT(rpt)                                                                             \
+	DP_UUID((rpt)->rt_pool_uuid), (rpt)->rt_rebuild_ver, (rpt)->rt_rebuild_gen,                \
+	    RB_OP_STR((rpt)->rt_rebuild_op)
+#define DP_RBF_RPT(rpt) DP_RB_RPT(rpt), (rpt)->rt_leader_rank, (rpt)->rt_leader_term
+
+/* arguments for log rebuild identifier given a struct rebuild_scan_in *rsin */
+#define DP_RB_RSI(rsi)                                                                             \
+	DP_UUID((rsi)->rsi_pool_uuid), (rsi)->rsi_rebuild_ver, (rsi)->rsi_rebuild_gen,             \
+	    RB_OP_STR((rsi)->rsi_rebuild_op)
+#define DP_RBF_RSI(rsi) DP_RB_RSI(rsi), (rsi)->rsi_master_rank, (rsi)->rsi_leader_term
+
+/* arguments for log rebuild identifier given a struct migrate_query_arg * */
+#define DP_RB_MQA(mqa)                                                                             \
+	DP_UUID((mqa)->pool_uuid), (mqa)->version, (mqa)->generation, RB_OP_STR((mqa)->rebuild_op)
+#define DP_RBF_MQA(mqa) DP_RB_MQA(mqa), (mqa)->leader_rank, (mqa)->leader_term
+
 int ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 			daos_epoch_t stable_eph, uint32_t layout_version,
 			struct pool_target_id_list *tgts,

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -87,6 +87,7 @@ struct migrate_one {
 	uint32_t		 mo_generation;
 	d_list_t		 mo_list;
 	d_iov_t			 mo_csum_iov;
+	uint32_t                  mo_opc;
 };
 
 struct migrate_obj_key {
@@ -305,8 +306,8 @@ obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, uint64_t tgt_id, daos_unit_oi
 	d_iov_set(&key_iov, &oid, sizeof(oid));
 	rc = dbtree_lookup(cont_root->root_hdl, &key_iov, val_iov);
 	if (rc == 0) {
-		D_DEBUG(DB_TRACE, DF_UOID"/"DF_UUID" already exits\n",
-			DP_UOID(oid), DP_UUID(co_uuid));
+		D_DEBUG(DB_TRACE, DF_UOID "/" DF_UUID " already exists\n", DP_UOID(oid),
+			DP_UUID(co_uuid));
 		return -DER_EXIST;
 	}
 
@@ -386,8 +387,7 @@ migrate_pool_tls_destroy(struct migrate_pool_tls *tls)
 	if (tls->mpt_dkey_ult_cnts)
 		D_FREE(tls->mpt_dkey_ult_cnts);
 	d_list_del(&tls->mpt_list);
-	D_DEBUG(DB_REBUILD, "TLS destroy for "DF_UUID" ver %d\n",
-		DP_UUID(tls->mpt_pool_uuid), tls->mpt_version);
+	D_DEBUG(DB_REBUILD, DF_RB ": TLS destroy\n", DP_RB_MPT(tls));
 	if (tls->mpt_pool)
 		ds_pool_child_put(tls->mpt_pool);
 	if (tls->mpt_svc_list.rl_ranks)
@@ -559,10 +559,9 @@ migrate_pool_tls_create_one(void *data)
 			D_GOTO(out, rc);
 	}
 
-	D_DEBUG(DB_REBUILD, "TLS %p create for "DF_UUID" "DF_UUID"/"DF_UUID
-		" ver %d "DF_RC"\n", pool_tls, DP_UUID(pool_tls->mpt_pool_uuid),
-		DP_UUID(arg->pool_hdl_uuid), DP_UUID(arg->co_hdl_uuid),
-		arg->version, DP_RC(rc));
+	D_DEBUG(DB_REBUILD, DF_RB ": TLS %p create for hdls " DF_UUID "/" DF_UUID " " DF_RC "\n",
+		DP_RB_MPT(pool_tls), pool_tls, DP_UUID(arg->pool_hdl_uuid),
+		DP_UUID(arg->co_hdl_uuid), DP_RC(rc));
 	d_list_add(&pool_tls->mpt_list, &tls->ot_pool_list);
 out:
 	if (rc && pool_tls)
@@ -655,8 +654,8 @@ migrate_pool_tls_lookup_create(struct ds_pool *pool, unsigned int version, unsig
 				     PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
 				     migrate_pool_tls_create_one, &arg, 0);
 	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to create migrate tls: "DF_RC"\n",
-			DP_UUID(pool->sp_uuid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": failed to create migrate tls on tgt xstreams",
+			 DP_RB_MPT(tls));
 		D_GOTO(out, rc);
 	}
 
@@ -670,8 +669,7 @@ out:
 		ABT_cond_broadcast(tls->mpt_init_cond);
 		ABT_mutex_unlock(tls->mpt_init_mutex);
 	}
-	D_DEBUG(DB_TRACE, "create tls "DF_UUID": "DF_RC"\n",
-		DP_UUID(pool->sp_uuid), DP_RC(rc));
+	D_DEBUG(DB_TRACE, "create tls " DF_UUID ": " DF_RC "\n", DP_UUID(pool->sp_uuid), DP_RC(rc));
 
 	if (rc != 0) {
 		if (tls != NULL)
@@ -720,8 +718,8 @@ mrone_recx_daos_vos_internal(struct migrate_one *mrone, bool daos2vos, int shard
 								   stripe_nr,
 								   cell_nr,
 								   shard);
-			D_DEBUG(DB_REBUILD, "j %d k %d "DF_U64"/"DF_U64"\n",
-				j, k, recx->rx_idx, recx->rx_nr);
+			D_DEBUG(DB_REBUILD, DF_RB ": j %d k %d " DF_U64 "/" DF_U64 "\n",
+				DP_RB_MRO(mrone), j, k, recx->rx_idx, recx->rx_nr);
 		}
 	}
 }
@@ -756,8 +754,7 @@ retry:
 		/* If pool map does not change, then let's retry for timeout, instead of
 		 * fail out.
 		 */
-		D_WARN(DF_UUID" retry "DF_UOID" "DF_RC"\n",
-		       DP_UUID(tls->mpt_pool_uuid), DP_UOID(mrone->mo_oid), DP_RC(rc));
+		DL_WARN(rc, DF_RB ": retry " DF_UOID, DP_RB_MPT(tls), DP_UOID(mrone->mo_oid));
 		D_GOTO(retry, rc);
 	}
 
@@ -775,8 +772,7 @@ mrone_obj_fetch(struct migrate_one *mrone, daos_handle_t oh, d_sg_list_t *sgls,
 	tls = migrate_pool_tls_lookup(mrone->mo_pool_uuid,
 				      mrone->mo_pool_tls_version, mrone->mo_generation);
 	if (tls == NULL || tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(mrone->mo_pool_uuid));
+		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(mrone->mo_pool_uuid));
 		D_GOTO(out, rc = -DER_SHUTDOWN);
 	}
 
@@ -822,14 +818,14 @@ migrate_csum_calc(struct daos_csummer *csummer, struct migrate_one *mrone, daos_
 	int		rc;
 
 	if (daos_oclass_is_ec(&mrone->mo_oca)) {
-		D_DEBUG(DB_CSUM, DF_C_UOID_DKEY" REBUILD: Calculating csums. IOD count: %d\n",
-			DP_C_UOID_DKEY(mrone->mo_oid, &mrone->mo_dkey), iod_num);
+		D_DEBUG(DB_CSUM, DF_RB ": " DF_C_UOID_DKEY ": Calculating csums. IOD count: %d\n",
+			DP_RB_MRO(mrone), DP_C_UOID_DKEY(mrone->mo_oid, &mrone->mo_dkey), iod_num);
 		rc = daos_csummer_calc_iods(csummer, sgls, iods, NULL, iod_num, false, NULL,
 					    -1, iod_csums);
 		return rc;
 	}
 
-	D_DEBUG(DB_CSUM, DF_C_UOID_DKEY" REBUILD: Using packed csums\n",
+	D_DEBUG(DB_CSUM, DF_RB ": " DF_C_UOID_DKEY ": Using packed csums\n", DP_RB_MRO(mrone),
 		DP_C_UOID_DKEY(mrone->mo_oid, &mrone->mo_dkey));
 	/** make a copy of the iov because it will be modified while
 	 * iterating over the csums
@@ -840,7 +836,7 @@ migrate_csum_calc(struct daos_csummer *csummer, struct migrate_one *mrone, daos_
 	rc = daos_csummer_alloc_iods_csums_with_packed(csummer, iods, iod_num,
 						       p_csum_iov, iod_csums);
 	if (rc != 0)
-		D_ERROR("Failed to alloc iod csums: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": failed to alloc iod csums", DP_RB_MRO(mrone));
 
 	return rc;
 }
@@ -893,9 +889,10 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 		}
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UOID " mrone %p dkey " DF_KEY " nr %d eph " DF_U64 " fetch %s\n",
-		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey), mrone->mo_iod_num,
-		mrone->mo_epoch, fetch ? "yes" : "no");
+	D_DEBUG(DB_REBUILD,
+		DF_RB ": " DF_UOID " mrone %p dkey " DF_KEY " nr %d eph " DF_U64 " fetch %s\n",
+		DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
+		mrone->mo_iod_num, mrone->mo_epoch, fetch ? "yes" : "no");
 
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_NO_UPDATE))
 		return 0;
@@ -916,7 +913,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 				     mrone->mo_epoch, DIOF_FOR_MIGRATION, p_csum_iov);
 
 		if (rc) {
-			D_ERROR("mrone_obj_fetch "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": mrone_obj_fetch", DP_RB_MRO(mrone));
 			D_GOTO(out, rc);
 		}
 	}
@@ -937,16 +934,17 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 
 		/* skip empty record */
 		if (iod_cnt == 0) {
-			D_DEBUG(DB_TRACE, "i %d iod_size = 0\n", i);
+			D_DEBUG(DB_TRACE, DF_RB ": i %d iod_size = 0\n", DP_RB_MRO(mrone), i);
 			continue;
 		}
 
-		D_DEBUG(DB_TRACE, "update start %d cnt %d\n", start, iod_cnt);
+		D_DEBUG(DB_TRACE, DF_RB ": update start %d cnt %d\n", DP_RB_MRO(mrone), start,
+			iod_cnt);
 
 		rc = migrate_csum_calc(csummer, mrone, &iods[start], iod_cnt, &sgls[start],
 				       fetch ? &csum_iov : &mrone->mo_csum_iov,  &iod_csums);
 		if (rc != 0) {
-			D_ERROR("Error calculating checksums: "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": error calculating checksums", DP_RB_MRO(mrone));
 			break;
 		}
 
@@ -956,7 +954,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 				    iod_csums, &sgls[start]);
 		daos_csummer_free_ic(csummer, &iod_csums);
 		if (rc) {
-			D_ERROR("migrate failed: "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": migrate failed", DP_RB_MRO(mrone));
 			break;
 		}
 		iod_cnt = 0;
@@ -968,7 +966,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 				       &sgls[start], fetch ? &csum_iov : &mrone->mo_csum_iov,
 				       &iod_csums);
 		if (rc != 0) {
-			D_ERROR("Error calculating checksums: "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": error calculating checksums", DP_RB_MRO(mrone));
 			D_GOTO(out, rc);
 		}
 
@@ -978,7 +976,7 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 				    &mrone->mo_iods[start], iod_csums,
 				    &sgls[start]);
 		if (rc) {
-			D_ERROR("migrate failed: "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": migrate failed", DP_RB_MRO(mrone));
 			D_GOTO(out, rc);
 		}
 		daos_csummer_free_ic(csummer, &iod_csums);
@@ -1037,15 +1035,14 @@ migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 			tmp_recx.rx_nr = cell_nr;
 			d_iov_set(&tmp_iov, p_bufs[shard],
 				  cell_nr * iod->iod_size);
-			D_DEBUG(DB_IO, "parity "DF_X64"/"DF_U64" "DF_U64"\n",
-				tmp_recx.rx_idx, tmp_recx.rx_nr, iod->iod_size);
+			D_DEBUG(DB_IO, DF_RB ": parity " DF_X64 "/" DF_U64 " " DF_U64 "\n",
+				DP_RB_MRO(mrone), tmp_recx.rx_idx, tmp_recx.rx_nr, iod->iod_size);
 		} else {
 			tmp_recx.rx_idx = offset;
 			tmp_recx.rx_nr = write_nr;
 			d_iov_set(&tmp_iov, buffer, write_nr * iod->iod_size);
-			D_DEBUG(DB_IO, "replicate "DF_U64"/"DF_U64" "
-				DF_U64"\n", tmp_recx.rx_idx,
-				tmp_recx.rx_nr, iod->iod_size);
+			D_DEBUG(DB_IO, DF_RB ": replicate " DF_U64 "/" DF_U64 " " DF_U64 "\n",
+				DP_RB_MRO(mrone), tmp_recx.rx_idx, tmp_recx.rx_nr, iod->iod_size);
 		}
 
 		tmp_sgl.sg_iovs = &tmp_iov;
@@ -1054,8 +1051,7 @@ migrate_update_parity(struct migrate_one *mrone, daos_epoch_t parity_eph,
 		rc = daos_csummer_calc_iods(csummer, &tmp_sgl, iod, NULL, 1,
 					    false, NULL, 0, &iod_csums);
 		if (rc != 0) {
-			D_ERROR("Error calculating checksums: "DF_RC"\n",
-				DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": drror calculating checksums", DP_RB_MRO(mrone));
 			D_GOTO(out, rc);
 		}
 
@@ -1106,14 +1102,15 @@ __migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 		sgls[i].sg_iovs = &iov[i];
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_U64"\n",
-		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey), iods_num, mrone->mo_epoch);
+	D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID " mrone %p dkey " DF_KEY " nr %d eph " DF_U64 "\n",
+		DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey), iods_num,
+		mrone->mo_epoch);
 
 	rc = mrone_obj_fetch(mrone, oh, sgls, iods, iods_num, fetch_eph, DIOF_FOR_MIGRATION,
 			     NULL);
 	if (rc) {
-		D_ERROR("migrate dkey "DF_KEY" failed: "DF_RC"\n",
-			DP_KEY(&mrone->mo_dkey), DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": migrate dkey " DF_KEY " failed", DP_RB_MRO(mrone),
+			 DP_KEY(&mrone->mo_dkey));
 		D_GOTO(out, rc);
 	}
 
@@ -1265,9 +1262,8 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 		sgls[i].sg_iovs = &iov[i];
 	}
 
-	D_DEBUG(DB_REBUILD,
-		DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_U64"\n",
-		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
+	D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID " mrone %p dkey " DF_KEY " nr %d eph " DF_U64 "\n",
+		DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
 		mrone->mo_iod_num, mrone->mo_epoch);
 
 	if (!daos_oclass_is_ec(&mrone->mo_oca)) {
@@ -1280,14 +1276,15 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 	rc = mrone_obj_fetch(mrone, oh, sgls, mrone->mo_iods, mrone->mo_iod_num,
 			     mrone->mo_epoch, DIOF_FOR_MIGRATION, p_csum_iov);
 	if (rc == -DER_CSUM) {
-		D_ERROR("migrate dkey "DF_KEY" failed because of checksum "
-			"error ("DF_RC"). Don't fail whole rebuild.\n",
-			DP_KEY(&mrone->mo_dkey), DP_RC(rc));
+		DL_ERROR(rc,
+			 DF_RB ": migrate dkey " DF_KEY " failed because of checksum error. "
+			       "Don't fail whole rebuild",
+			 DP_RB_MRO(mrone), DP_KEY(&mrone->mo_dkey));
 		D_GOTO(out, rc = 0);
 	}
 	if (rc) {
-		D_ERROR("migrate dkey "DF_KEY" failed: "DF_RC"\n",
-			DP_KEY(&mrone->mo_dkey), DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": migrate dkey " DF_KEY " failed", DP_RB_MRO(mrone),
+			 DP_KEY(&mrone->mo_dkey));
 		D_GOTO(out, rc);
 	}
 
@@ -1311,13 +1308,11 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 			 */
 			rc = -DER_DATA_LOSS;
 			D_DEBUG(DB_REBUILD,
-				DF_UOID" %p dkey "DF_KEY" "DF_KEY" nr %d/%d"
-				" eph "DF_U64" "DF_RC"\n",
-				DP_UOID(mrone->mo_oid),
-				mrone, DP_KEY(&mrone->mo_dkey),
-				DP_KEY(&mrone->mo_iods[i].iod_name),
-				mrone->mo_iod_num, i, mrone->mo_epoch,
-				DP_RC(rc));
+				DF_RB ": " DF_UOID " %p dkey " DF_KEY " " DF_KEY
+				      " nr %d/%d eph " DF_U64 " " DF_RC "\n",
+				DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone,
+				DP_KEY(&mrone->mo_dkey), DP_KEY(&mrone->mo_iods[i].iod_name),
+				mrone->mo_iod_num, i, mrone->mo_epoch, DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 
@@ -1325,7 +1320,7 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 			continue;
 
 		if (obj_ec_singv_one_tgt(iod->iod_size, &sgls[i], &mrone->mo_oca)) {
-			D_DEBUG(DB_REBUILD, DF_UOID" one tgt.\n",
+			D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID " one tgt.\n", DP_RB_MRO(mrone),
 				DP_UOID(mrone->mo_oid));
 			los[i].cs_even_dist = 0;
 			continue;
@@ -1355,7 +1350,7 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 					mrone->mo_iods[i].iod_size,
 					&mrone->mo_oca);
 		los[i].cs_nr = obj_ec_tgt_nr(&mrone->mo_oca);
-		D_DEBUG(DB_CSUM, "los[%d]: "DF_LAYOUT"\n", i,
+		D_DEBUG(DB_CSUM, DF_RB ": los[%d]: " DF_LAYOUT "\n", DP_RB_MRO(mrone), i,
 			DP_LAYOUT(los[i]));
 	}
 
@@ -1363,7 +1358,7 @@ migrate_fetch_update_single(struct migrate_one *mrone, daos_handle_t oh,
 	rc = migrate_csum_calc(csummer, mrone, mrone->mo_iods, mrone->mo_iod_num, sgls,
 			       p_csum_iov, &iod_csums);
 	if (rc != 0) {
-		D_ERROR("unable to calculate iod csums: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": unable to calculate iod csums", DP_RB_MRO(mrone));
 		goto out;
 	}
 
@@ -1414,16 +1409,16 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 			      &mrone->mo_dkey, iod_num, iods, mrone->mo_iods_csums,
 			      0, &ioh, NULL);
 	if (rc != 0) {
-		D_ERROR(DF_UOID ": preparing update fails: " DF_RC "\n", DP_UOID(mrone->mo_oid),
-			DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": " DF_UOID ": preparing update failed", DP_RB_MRO(mrone),
+			 DP_UOID(mrone->mo_oid));
 		return rc;
 	}
 
 	rc = bio_iod_prep(vos_ioh2desc(ioh), BIO_CHK_TYPE_REBUILD, NULL,
 			  CRT_BULK_RW);
 	if (rc) {
-		D_ERROR("Prepare EIOD for "DF_UOID" error: "DF_RC"\n",
-			DP_UOID(mrone->mo_oid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": prepare EIOD for " DF_UOID " error", DP_RB_MRO(mrone),
+			 DP_UOID(mrone->mo_oid));
 		goto end;
 	}
 
@@ -1440,9 +1435,9 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	}
 
 	D_DEBUG(DB_REBUILD,
-		DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_X64"/"DF_X64"\n",
-		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
-		iod_num, mrone->mo_epoch, update_eph);
+		DF_RB ": " DF_UOID " mrone %p dkey " DF_KEY " nr %d eph " DF_X64 "/" DF_X64 "\n",
+		DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey), iod_num,
+		mrone->mo_epoch, update_eph);
 
 	if (daos_oclass_is_ec(&mrone->mo_oca))
 		mrone_recx_vos2_daos(mrone, mrone->mo_oid.id_shard, iods, iod_num);
@@ -1456,15 +1451,15 @@ __migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 
 	rc = mrone_obj_fetch(mrone, oh, sgls, iods, iod_num, fetch_eph, flags, p_csum_iov);
 	if (rc) {
-		D_ERROR("migrate dkey "DF_KEY" failed: "DF_RC"\n",
-			DP_KEY(&mrone->mo_dkey), DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": migrate dkey " DF_KEY " failed", DP_RB_MRO(mrone),
+			 DP_KEY(&mrone->mo_dkey));
 		D_GOTO(post, rc);
 	}
 
 	csummer = dsc_cont2csummer(dc_obj_hdl2cont_hdl(oh));
 	rc = migrate_csum_calc(csummer, mrone, iods, iod_num, sgls, p_csum_iov, &iod_csums);
 	if (rc != 0) {
-		D_ERROR("Failed to calculate iod csums: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": failed to calculate iod csums", DP_RB_MRO(mrone));
 		D_GOTO(post, rc);
 	}
 
@@ -1478,8 +1473,8 @@ post:
 
 	rc = bio_iod_post(vos_ioh2desc(ioh), rc);
 	if (rc)
-		D_ERROR("Post EIOD for "DF_UOID" error: "DF_RC"\n",
-			DP_UOID(mrone->mo_oid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": post EIOD for " DF_UOID " error", DP_RB_MRO(mrone),
+			 DP_UOID(mrone->mo_oid));
 
 	for (i = 0; rc == 0 && i < iod_num; i++) {
 		if (iods[i].iod_size == 0) {
@@ -1495,12 +1490,11 @@ post:
 			 */
 			rc = -DER_DATA_LOSS;
 			D_DEBUG(DB_REBUILD,
-				DF_UOID" %p dkey "DF_KEY" "DF_KEY" nr %d/%d"
-				" eph "DF_U64" "DF_RC"\n",
-				DP_UOID(mrone->mo_oid),
-				mrone, DP_KEY(&mrone->mo_dkey),
-				DP_KEY(&iods[i].iod_name), iod_num, i, mrone->mo_epoch,
-				DP_RC(rc));
+				DF_RB ": " DF_UOID " %p dkey " DF_KEY " " DF_KEY
+				      " nr %d/%d eph " DF_U64 " " DF_RC "\n",
+				DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid), mrone,
+				DP_KEY(&mrone->mo_dkey), DP_KEY(&iods[i].iod_name), iod_num, i,
+				mrone->mo_epoch, DP_RC(rc));
 			D_GOTO(end, rc);
 		}
 	}
@@ -1513,7 +1507,8 @@ end:
 		rc = rc1;
 
 	if (rc)
-		D_ERROR(DF_UOID " migrate error: "DF_RC"\n", DP_UOID(mrone->mo_oid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": " DF_UOID " migrate error", DP_RB_MRO(mrone),
+			 DP_UOID(mrone->mo_oid));
 
 	return rc;
 }
@@ -1598,8 +1593,10 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 					 * from parity will be rebuilt first. so let's ignore
 					 * this replicate recx for now.
 					 */
-					D_WARN(DF_UOID" "DF_RECX"/"DF_X64" already rebuilt\n",
-					       DP_UOID(mrone->mo_oid), DP_RECX(iod.iod_recxs[0]),
+					D_WARN(DF_RB ": " DF_UOID " " DF_RECX "/" DF_X64 " already "
+						     "rebuilt\n",
+					       DP_RB_MRO(mrone), DP_UOID(mrone->mo_oid),
+					       DP_RECX(iod.iod_recxs[0]),
 					       mrone->mo_iods_update_ephs[i][j]);
 					rc = 0;
 				} else {
@@ -1624,16 +1621,16 @@ migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 
 	/* Punch dkey */
 	if (mrone->mo_dkey_punch_eph != 0 && mrone->mo_dkey_punch_eph <= tls->mpt_max_eph) {
-		D_DEBUG(DB_REBUILD, DF_UOID" punch dkey "DF_KEY"/"DF_U64"\n",
-			DP_UOID(mrone->mo_oid), DP_KEY(&mrone->mo_dkey),
+		D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID " punch dkey " DF_KEY "/" DF_U64 "\n",
+			DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), DP_KEY(&mrone->mo_dkey),
 			mrone->mo_dkey_punch_eph);
 		rc = vos_obj_punch(cont->sc_hdl, mrone->mo_oid,
 				   mrone->mo_dkey_punch_eph,
 				   tls->mpt_version, VOS_OF_REPLAY_PC,
 				   &mrone->mo_dkey, 0, NULL, NULL);
 		if (rc) {
-			D_ERROR(DF_UOID" punch dkey failed: "DF_RC"\n",
-				DP_UOID(mrone->mo_oid), DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": " DF_UOID " punch dkey failed", DP_RB_MPT(tls),
+				 DP_UOID(mrone->mo_oid));
 			return rc;
 		}
 	}
@@ -1644,17 +1641,19 @@ migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 		eph = mrone->mo_akey_punch_ephs[i];
 		D_ASSERT(eph != DAOS_EPOCH_MAX);
 		if (eph == 0 || eph > tls->mpt_max_eph) {
-			D_DEBUG(DB_REBUILD, DF_UOID" skip mrone %p punch dkey "
-				DF_KEY" akey "DF_KEY" eph "DF_X64" current "DF_X64"\n",
-				DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
-				DP_KEY(&mrone->mo_iods[i].iod_name), eph, mrone->mo_epoch);
+			D_DEBUG(DB_REBUILD,
+				DF_RB ": " DF_UOID " skip mrone %p punch dkey " DF_KEY
+				      " akey " DF_KEY " eph " DF_X64 " current " DF_X64 "\n",
+				DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), mrone,
+				DP_KEY(&mrone->mo_dkey), DP_KEY(&mrone->mo_iods[i].iod_name), eph,
+				mrone->mo_epoch);
 			continue;
 		}
 
-		D_DEBUG(DB_REBUILD, DF_UOID" mrone %p punch dkey "
-			DF_KEY" akey "DF_KEY" eph "DF_U64"\n",
-			DP_UOID(mrone->mo_oid), mrone,
-			DP_KEY(&mrone->mo_dkey),
+		D_DEBUG(DB_REBUILD,
+			DF_RB ": " DF_UOID " mrone %p punch dkey " DF_KEY "akey " DF_KEY
+			      " eph " DF_U64 "\n",
+			DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
 			DP_KEY(&mrone->mo_iods[i].iod_name), eph);
 
 		rc = vos_obj_punch(cont->sc_hdl, mrone->mo_oid,
@@ -1682,10 +1681,10 @@ migrate_punch(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 				    mrone->mo_version, 0, &mrone->mo_dkey,
 				    mrone->mo_punch_iod_num,
 				    mrone->mo_punch_iods, NULL, NULL);
-		D_DEBUG(DB_REBUILD, DF_UOID" mrone %p punch %d eph "DF_U64
-			" records: "DF_RC"\n", DP_UOID(mrone->mo_oid), mrone,
-			mrone->mo_punch_iod_num, mrone->mo_rec_punch_eph,
-			DP_RC(rc));
+		D_DEBUG(DB_REBUILD,
+			DF_RB ": " DF_UOID " mrone %p punch %d eph " DF_U64 "records: " DF_RC "\n",
+			DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), mrone, mrone->mo_punch_iod_num,
+			mrone->mo_rec_punch_eph, DP_RC(rc));
 	}
 
 	return rc;
@@ -1700,8 +1699,7 @@ migrate_get_cont_child(struct migrate_pool_tls *tls, uuid_t cont_uuid,
 
 	*cont_p = NULL;
 	if (tls->mpt_pool->spc_pool->sp_stopping) {
-		D_DEBUG(DB_REBUILD, DF_UUID "pool is being destroyed.\n",
-			DP_UUID(tls->mpt_pool_uuid));
+		D_DEBUG(DB_REBUILD, DF_RB ": pool is being destroyed.\n", DP_RB_MPT(tls));
 		return 0;
 	}
 
@@ -1712,8 +1710,10 @@ migrate_get_cont_child(struct migrate_pool_tls *tls, uuid_t cont_uuid,
 		rc = ds_cont_child_open_create(tls->mpt_pool_uuid, cont_uuid, &cont_child);
 		if (rc != 0) {
 			if (rc == -DER_SHUTDOWN || (cont_child && cont_child->sc_stopping)) {
-				D_DEBUG(DB_REBUILD, DF_UUID "container is being destroyed\n",
-					DP_UUID(cont_uuid));
+				D_DEBUG(DB_REBUILD,
+					DF_RB ": container " DF_UUID " is being "
+					      "destroyed\n",
+					DP_RB_MPT(tls), DP_UUID(cont_uuid));
 				rc = 0;
 			}
 			if (cont_child)
@@ -1724,8 +1724,10 @@ migrate_get_cont_child(struct migrate_pool_tls *tls, uuid_t cont_uuid,
 		rc = ds_cont_child_lookup(tls->mpt_pool_uuid, cont_uuid, &cont_child);
 		if (rc != 0 || (cont_child && cont_child->sc_stopping)) {
 			if (rc == -DER_NONEXIST || (cont_child && cont_child->sc_stopping)) {
-				D_DEBUG(DB_REBUILD, DF_UUID "container is being destroyed\n",
-					DP_UUID(cont_uuid));
+				D_DEBUG(DB_REBUILD,
+					DF_RB ": container " DF_UUID " is being "
+					      "destroyed\n",
+					DP_RB_MPT(tls), DP_UUID(cont_uuid));
 				rc = 0;
 			}
 
@@ -1774,15 +1776,14 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 		D_GOTO(obj_close, rc = -DER_NOSPACE);
 
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_NO_REBUILD)) {
-		D_DEBUG(DB_REBUILD, DF_UUID" disable rebuild\n",
-			DP_UUID(tls->mpt_pool_uuid));
+		D_DEBUG(DB_REBUILD, DF_RB ": fault injected, disable rebuild\n", DP_RB_MPT(tls));
 		D_GOTO(obj_close, rc);
 	}
 
 	dsc_cont_get_props(coh, &props);
 	rc = dsc_obj_id2oc_attr(mrone->mo_oid.id_pub, &props, &mrone->mo_oca);
 	if (rc) {
-		D_ERROR("Unknown object class: %u\n",
+		D_ERROR(DF_RB ": unknown object class: %u\n", DP_RB_MPT(tls),
 			daos_obj_id2class(mrone->mo_oid.id_pub));
 		D_GOTO(obj_close, rc);
 	}
@@ -1794,8 +1795,8 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 				   tls->mpt_version, VOS_OF_REPLAY_PC,
 				   NULL, 0, NULL, NULL);
 		if (rc) {
-			D_ERROR(DF_UOID" punch obj failed: "DF_RC"\n",
-				DP_UOID(mrone->mo_oid), DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": " DF_UOID " punch obj failed", DP_RB_MPT(tls),
+				 DP_UOID(mrone->mo_oid));
 			D_GOTO(obj_close, rc);
 		}
 	}
@@ -1805,7 +1806,7 @@ migrate_dkey(struct migrate_pool_tls *tls, struct migrate_one *mrone,
 		D_GOTO(obj_close, rc);
 
 	if (data_size == 0) {
-		D_DEBUG(DB_REBUILD, "empty mrone %p\n", mrone);
+		D_DEBUG(DB_REBUILD, DF_RB ": empty mrone %p\n", DP_RB_MPT(tls), mrone);
 		D_GOTO(obj_close, rc);
 	}
 
@@ -1901,8 +1902,8 @@ migrate_system_enter(struct migrate_pool_tls *tls, int tgt_idx, bool *yielded)
 		  atomic_load(&tls->mpt_dkey_ult_cnts[tgt_idx]);
 
 	while ((tls->mpt_inflight_max_ult / dss_tgt_nr) <= tgt_cnt) {
-		D_DEBUG(DB_REBUILD, "tgt%d:%u max %u\n",
-			tgt_idx, tgt_cnt, tls->mpt_inflight_max_ult / dss_tgt_nr);
+		D_DEBUG(DB_REBUILD, DF_RB ": tgt%d:%u max %u\n", DP_RB_MPT(tls), tgt_idx, tgt_cnt,
+			tls->mpt_inflight_max_ult / dss_tgt_nr);
 		*yielded = true;
 		ABT_mutex_lock(tls->mpt_inflight_mutex);
 		ABT_cond_wait(tls->mpt_inflight_cond, tls->mpt_inflight_mutex);
@@ -1929,7 +1930,8 @@ migrate_tgt_enter(struct migrate_pool_tls *tls)
 
 	dkey_cnt = atomic_load(tls->mpt_tgt_dkey_ult_cnt);
 	while (tls->mpt_inflight_max_ult / 2 <= dkey_cnt) {
-		D_DEBUG(DB_REBUILD, "tgt %u max %u\n", dkey_cnt, tls->mpt_inflight_max_ult);
+		D_DEBUG(DB_REBUILD, DF_RB ": tgt %u max %u\n", DP_RB_MPT(tls), dkey_cnt,
+			tls->mpt_inflight_max_ult);
 
 		ABT_mutex_lock(tls->mpt_inflight_mutex);
 		ABT_cond_wait(tls->mpt_inflight_cond, tls->mpt_inflight_mutex);
@@ -2020,8 +2022,7 @@ migrate_one_ult(void *arg)
 	tls = migrate_pool_tls_lookup(mrone->mo_pool_uuid,
 				      mrone->mo_pool_tls_version, mrone->mo_generation);
 	if (tls == NULL || tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(mrone->mo_pool_uuid));
+		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(mrone->mo_pool_uuid));
 		goto out;
 	}
 
@@ -2029,18 +2030,19 @@ migrate_one_ult(void *arg)
 	data_size += daos_iods_len(mrone->mo_iods_from_parity,
 				   mrone->mo_iods_num_from_parity);
 
-	D_DEBUG(DB_TRACE, "mrone %p data size is "DF_U64" %d/%d\n",
-		mrone, data_size, mrone->mo_iod_num, mrone->mo_iods_num_from_parity);
+	D_DEBUG(DB_TRACE, DF_RB ": mrone %p data size is " DF_U64 " %d/%d\n", DP_RB_MPT(tls), mrone,
+		data_size, mrone->mo_iod_num, mrone->mo_iods_num_from_parity);
 
 	D_ASSERT(data_size != (daos_size_t)-1);
-	D_DEBUG(DB_REBUILD, "mrone %p inflight_size "DF_U64" max "DF_U64"\n",
-		mrone, tls->mpt_inflight_size, tls->mpt_inflight_max_size);
+	D_DEBUG(DB_REBUILD, DF_RB ": mrone %p inflight_size " DF_U64 " max " DF_U64 "\n",
+		DP_RB_MPT(tls), mrone, tls->mpt_inflight_size, tls->mpt_inflight_max_size);
 
 	while (tls->mpt_inflight_size + data_size >= tls->mpt_inflight_max_size &&
 	       tls->mpt_inflight_max_size != 0 && tls->mpt_inflight_size != 0 &&
 	       !tls->mpt_fini) {
-		D_DEBUG(DB_REBUILD, "mrone %p wait "DF_U64"/"DF_U64"/"DF_U64"\n", mrone,
-			tls->mpt_inflight_size, tls->mpt_inflight_max_size, data_size);
+		D_DEBUG(DB_REBUILD, DF_RB ": mrone %p wait " DF_U64 "/" DF_U64 "/" DF_U64 "\n",
+			DP_RB_MPT(tls), mrone, tls->mpt_inflight_size, tls->mpt_inflight_max_size,
+			data_size);
 		ABT_mutex_lock(tls->mpt_inflight_mutex);
 		ABT_cond_wait(tls->mpt_inflight_cond, tls->mpt_inflight_mutex);
 		ABT_mutex_unlock(tls->mpt_inflight_mutex);
@@ -2053,8 +2055,10 @@ migrate_one_ult(void *arg)
 	rc = migrate_dkey(tls, mrone, data_size);
 	tls->mpt_inflight_size -= data_size;
 
-	D_DEBUG(DB_REBUILD, DF_UOID" layout %u migrate dkey "DF_KEY" inflight_size "DF_U64": "
-		DF_RC"\n", DP_UOID(mrone->mo_oid), mrone->mo_oid.id_layout_ver,
+	D_DEBUG(DB_REBUILD,
+		DF_RB ": " DF_UOID " layout %u migrate dkey " DF_KEY " inflight_size " DF_U64
+		      ": " DF_RC "\n",
+		DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), mrone->mo_oid.id_layout_ver,
 		DP_KEY(&mrone->mo_dkey), tls->mpt_inflight_size, DP_RC(rc));
 
 	/* Ignore nonexistent error because puller could race
@@ -2246,7 +2250,8 @@ rw_iod_pack(struct migrate_one *mrone, struct dc_object *obj, daos_iod_t *iod,
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
 		rec_cnt = 1;
 		total_size = iod->iod_size;
-		D_DEBUG(DB_REBUILD, "single recx "DF_U64"\n", total_size);
+		D_DEBUG(DB_REBUILD, DF_RB ": single recx " DF_U64 "\n", DP_RB_MRO(mrone),
+			total_size);
 		rc = migrate_insert_recxs_sgl(mrone->mo_iods, mrone->mo_iods_update_ephs,
 					      &mrone->mo_iod_num, iod, &iod->iod_recxs[0],
 					      &ephs[0], 1, mrone->mo_sgls, sgl, 0);
@@ -2285,9 +2290,10 @@ rw_iod_pack(struct migrate_one *mrone, struct dc_object *obj, daos_iod_t *iod,
 					nr = 0;
 				}
 				parity_nr++;
-				D_DEBUG(DB_REBUILD, "parity recx "DF_X64"/"DF_X64" %d/%d\n",
-					iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr,
-					parity_nr, nr);
+				D_DEBUG(DB_REBUILD,
+					DF_RB ": parity recx " DF_X64 "/" DF_X64 " %d/%d\n",
+					DP_RB_MRO(mrone), iod->iod_recxs[i].rx_idx,
+					iod->iod_recxs[i].rx_nr, parity_nr, nr);
 				iod->iod_recxs[i].rx_idx = iod->iod_recxs[i].rx_idx &
 							    ~PARITY_INDICATOR;
 			} else {
@@ -2308,9 +2314,10 @@ rw_iod_pack(struct migrate_one *mrone, struct dc_object *obj, daos_iod_t *iod,
 					parity_nr = 0;
 				}
 				nr++;
-				D_DEBUG(DB_REBUILD, "replicate recx "DF_X64"/"DF_X64" %d/%d\n",
-					iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr,
-					parity_nr, nr);
+				D_DEBUG(DB_REBUILD,
+					DF_RB ": replicate recx " DF_X64 "/" DF_X64 " %d/%d\n",
+					DP_RB_MRO(mrone), iod->iod_recxs[i].rx_idx,
+					iod->iod_recxs[i].rx_nr, parity_nr, nr);
 			}
 		}
 
@@ -2339,9 +2346,10 @@ rw_iod_pack(struct migrate_one *mrone, struct dc_object *obj, daos_iod_t *iod,
 	mrone->mo_size += total_size;
 out:
 	D_DEBUG(DB_REBUILD,
-		"idx %d akey "DF_KEY" nr %d size "DF_U64" type %d rec %d total "
-		DF_U64"\n", mrone->mo_iod_num - 1, DP_KEY(&iod->iod_name),
-		iod->iod_nr, iod->iod_size, iod->iod_type, rec_cnt, total_size);
+		DF_RB ": idx %d akey " DF_KEY " nr %d size " DF_U64 " type %d rec %d total " DF_U64
+		      "\n",
+		DP_RB_MRO(mrone), mrone->mo_iod_num - 1, DP_KEY(&iod->iod_name), iod->iod_nr,
+		iod->iod_size, iod->iod_type, rec_cnt, total_size);
 
 	return rc;
 }
@@ -2369,9 +2377,8 @@ punch_iod_pack(struct migrate_one *mrone, struct dc_object *obj, daos_iod_t *iod
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	D_DEBUG(DB_TRACE,
-		"idx %d akey "DF_KEY" nr %d size "DF_U64" type %d\n",
-		idx, DP_KEY(&iod->iod_name), mrone->mo_punch_iods->iod_nr, iod->iod_size,
+	D_DEBUG(DB_TRACE, DF_RB ": idx %d akey " DF_KEY " nr %d size " DF_U64 " type %d\n",
+		DP_RB_MRO(mrone), idx, DP_KEY(&iod->iod_name), iod->iod_nr, iod->iod_size,
 		iod->iod_type);
 
 	if (mrone->mo_rec_punch_eph < eph)
@@ -2479,19 +2486,17 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 	int			i;
 	int			rc = 0;
 
-	D_DEBUG(DB_REBUILD, "migrate dkey "DF_KEY" iod nr %d\n", DP_KEY(dkey),
-		iod_eph_total);
-
 	tls = migrate_pool_tls_lookup(iter_arg->pool_uuid, iter_arg->version, iter_arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(iter_arg->pool_uuid));
+		D_WARN("someone aborted the rebuild " DF_UUID "dkey " DF_KEY "iod_nr %d\n",
+		       DP_UUID(iter_arg->pool_uuid), DP_KEY(dkey), iod_eph_total);
 		D_GOTO(put, rc = 0);
 	}
+	D_DEBUG(DB_REBUILD, DF_RB ": migrate dkey " DF_KEY " iod nr %d\n", DP_RB_MPT(tls),
+		DP_KEY(dkey), iod_eph_total);
 	if (iod_eph_total == 0 || tls->mpt_fini) {
-		D_DEBUG(DB_REBUILD, "No need eph_total %d version %u"
-			" migrate ver %u fini %d\n", iod_eph_total, version,
-			tls->mpt_version, tls->mpt_fini);
+		D_DEBUG(DB_REBUILD, DF_RB ": no need eph_total %d version %u fini %d\n",
+			DP_RB_MPT(tls), iod_eph_total, version, tls->mpt_fini);
 		D_GOTO(put, rc = 0);
 	}
 
@@ -2546,6 +2551,7 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 	mrone->mo_generation = tls->mpt_generation;
 	mrone->mo_dkey_hash = io->ui_dkey_hash;
 	mrone->mo_layout_version = obj->cob_layout_version;
+	mrone->mo_opc              = tls->mpt_opc;
 	/* only do the copy below when each with inline recx data */
 	for (i = 0; i < iod_eph_total; i++) {
 		int j;
@@ -2570,9 +2576,8 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 	for (i = 0; i < iod_eph_total; i++) {
 		if (akey_punch_ephs[i] != 0) {
 			mrone->mo_akey_punch_ephs[i] = akey_punch_ephs[i];
-			D_DEBUG(DB_REBUILD, "punched %d akey "DF_KEY" "
-				DF_U64"\n", i, DP_KEY(&iods[i].iod_name),
-				akey_punch_ephs[i]);
+			D_DEBUG(DB_REBUILD, DF_RB ": punched %d akey " DF_KEY " " DF_U64 "\n",
+				DP_RB_MPT(tls), i, DP_KEY(&iods[i].iod_name), akey_punch_ephs[i]);
 		}
 
 		if (iods[i].iod_nr == 0)
@@ -2593,8 +2598,10 @@ migrate_one_create(struct enum_unpack_arg *arg, struct dc_obj_enum_unpack_io *io
 			D_GOTO(free, rc);
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UOID" %p dkey "DF_KEY" migrate on idx %d iod_num %d min eph "DF_U64
-		" ver %u\n", DP_UOID(mrone->mo_oid), mrone, DP_KEY(dkey), iter_arg->tgt_idx,
+	D_DEBUG(DB_REBUILD,
+		DF_RB ": " DF_UOID " %p dkey " DF_KEY " migrate on idx %d iod_num %d "
+		      "min eph " DF_U64 " ver %u\n",
+		DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), mrone, DP_KEY(dkey), iter_arg->tgt_idx,
 		mrone->mo_iod_num, mrone->mo_min_epoch, version);
 
 	d_list_add(&mrone->mo_list, &arg->merge_list);
@@ -2646,8 +2653,7 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	tls = migrate_pool_tls_lookup(arg->arg->pool_uuid, arg->arg->version,
 				      arg->arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(arg->arg->pool_uuid));
+		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(arg->arg->pool_uuid));
 		D_GOTO(put, rc = 0);
 	}
 
@@ -2663,8 +2669,8 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	if (rc == 1 &&
 	     (is_ec_data_shard_by_tgt_off(unpack_tgt_off, &arg->oc_attr) ||
 	     (io->ui_oid.id_layout_ver > 0 && io->ui_oid.id_shard != parity_shard))) {
-		D_DEBUG(DB_REBUILD, DF_UOID" ignore shard "DF_KEY"/%u/%d/%u/%d.\n",
-			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
+		D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID " ignore shard " DF_KEY "/%u/%d/%u/%d.\n",
+			DP_RB_MPT(tls), DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
 			(int)obj_ec_shard_off(obj, io->ui_dkey_hash, 0), parity_shard, rc);
 		D_GOTO(put, rc = 0);
 	}
@@ -2681,9 +2687,11 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 			continue;
 		}
 
-		D_DEBUG(DB_REBUILD, DF_UOID" unpack "DF_KEY" for shard %u/%u/%u/"DF_X64"/%u\n",
-			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard, unpack_tgt_off,
-			migrate_tgt_off, io->ui_dkey_hash, parity_shard);
+		D_DEBUG(DB_REBUILD,
+			DF_RB ": " DF_UOID " unpack " DF_KEY " for shard "
+			      "%u/%u/%u/" DF_X64 "/%u\n",
+			DP_RB_MPT(tls), DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey), shard,
+			unpack_tgt_off, migrate_tgt_off, io->ui_dkey_hash, parity_shard);
 
 		/**
 		 * Since we do not need split the rebuild into parity rebuild
@@ -2693,22 +2701,23 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 		rc = obj_recx_ec2_daos(&arg->oc_attr, unpack_tgt_off,
 				       &iod->iod_recxs, ephs, &iod->iod_nr, false);
 		if (rc != 0) {
-			D_ERROR(DF_UOID" ec 2 daos %u failed: "DF_RC"\n",
-				DP_UOID(io->ui_oid), shard, DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": " DF_UOID " ec 2 daos %u failed", DP_RB_MPT(tls),
+				 DP_UOID(io->ui_oid), shard);
 			D_GOTO(put, rc);
 		}
 
 		/* Filter the DAOS recxs to the rebuild data shard */
 		if (is_ec_data_shard_by_layout_ver(layout_ver, io->ui_dkey_hash,
 						   &arg->oc_attr, shard)) {
-			D_DEBUG(DB_REBUILD, DF_UOID" convert shard %u tgt %d\n",
-				DP_UOID(io->ui_oid), shard, obj_ec_data_tgt_nr(&arg->oc_attr));
+			D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID " convert shard %u tgt %d\n",
+				DP_RB_MPT(tls), DP_UOID(io->ui_oid), shard,
+				obj_ec_data_tgt_nr(&arg->oc_attr));
 
 			rc = obj_recx_ec_daos2shard(&arg->oc_attr, migrate_tgt_off,
 						    &iod->iod_recxs, ephs, &iod->iod_nr);
 			if (rc) {
-				D_ERROR(DF_UOID" daos to shard %u failed: "DF_RC"\n",
-					DP_UOID(io->ui_oid), shard, DP_RC(rc));
+				DL_ERROR(rc, DF_RB ": " DF_UOID " daos to shard %u failed",
+					 DP_RB_MPT(tls), DP_UOID(io->ui_oid), shard);
 				D_GOTO(put, rc);
 			}
 		}
@@ -2718,8 +2727,8 @@ migrate_enum_unpack_cb(struct dc_obj_enum_unpack_io *io, void *data)
 	}
 
 	if (!create_migrate_one) {
-		D_DEBUG(DB_REBUILD, DF_UOID"/"DF_KEY" does not need rebuild.\n",
-			DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey));
+		D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID "/" DF_KEY " does not need rebuild.\n",
+			DP_RB_MPT(tls), DP_UOID(io->ui_oid), DP_KEY(&io->ui_dkey));
 		D_GOTO(put, rc = 0);
 	}
 
@@ -2765,14 +2774,12 @@ migrate_obj_punch_one(void *data)
 
 	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(arg->pool_uuid));
+		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(arg->pool_uuid));
 		D_GOTO(put, rc = 0);
 	}
 
-	D_DEBUG(DB_REBUILD, "tls %p "DF_UUID" version %d punch "DF_U64" "DF_UOID"\n",
-		tls, DP_UUID(tls->mpt_pool_uuid), arg->version, arg->punched_epoch,
-		DP_UOID(arg->oid));
+	D_DEBUG(DB_REBUILD, DF_RB ": tls %p version %d punch " DF_U64 " " DF_UOID "\n",
+		DP_RB_MPT(tls), tls, arg->version, arg->punched_epoch, DP_UOID(arg->oid));
 
 	rc = migrate_get_cont_child(tls, arg->cont_uuid, &cont, true);
 	if (rc != 0 || cont == NULL)
@@ -2785,8 +2792,8 @@ migrate_obj_punch_one(void *data)
 	ds_cont_child_put(cont);
 put:
 	if (rc)
-		D_ERROR(DF_UOID" migrate punch failed: "DF_RC"\n",
-			DP_UOID(arg->oid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": " DF_UOID " migrate punch failed", DP_RB_MPT(tls),
+			 DP_UOID(arg->oid));
 	if (tls) {
 		if (tls->mpt_status == 0 && rc != 0)
 			tls->mpt_status = rc;
@@ -2807,16 +2814,16 @@ migrate_start_ult(struct enum_unpack_arg *unpack_arg)
 
 	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(arg->pool_uuid));
+		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(arg->pool_uuid));
 		D_GOTO(put, rc = 0);
 	}
 	d_list_for_each_entry_safe(mrone, tmp, &unpack_arg->merge_list,
 				   mo_list) {
-		D_DEBUG(DB_REBUILD, DF_UOID" %p dkey "DF_KEY" migrate on idx %d"
-			" iod_num %d\n", DP_UOID(mrone->mo_oid), mrone,
-			DP_KEY(&mrone->mo_dkey), arg->tgt_idx,
-			mrone->mo_iod_num);
+		D_DEBUG(DB_REBUILD,
+			DF_RB ": " DF_UOID " %p dkey " DF_KEY " migrate on idx %d"
+			      " iod_num %d\n",
+			DP_RB_MPT(tls), DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
+			arg->tgt_idx, mrone->mo_iod_num);
 
 		rc = migrate_tgt_enter(tls);
 		if (rc)
@@ -2868,13 +2875,11 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	uint32_t		 num;
 	int			 rc = 0;
 
-	D_DEBUG(DB_REBUILD, "migrate obj "DF_UOID" for shard %u eph "
-		DF_X64"-"DF_X64"\n", DP_UOID(arg->oid), arg->shard, epr->epr_lo,
-		epr->epr_hi);
+	D_DEBUG(DB_REBUILD, DF_RB ": migrate obj " DF_UOID " shard %u eph " DF_X64 "-" DF_X64 "\n",
+		DP_RB_MPT(tls), DP_UOID(arg->oid), arg->shard, epr->epr_lo, epr->epr_hi);
 
 	if (tls->mpt_fini) {
-		D_DEBUG(DB_REBUILD, DF_UUID "migration is aborted.\n",
-			DP_UUID(tls->mpt_pool_uuid));
+		D_DEBUG(DB_REBUILD, DF_RB ": migration is aborted.\n", DP_RB_MPT(tls));
 		return 0;
 	}
 
@@ -2884,13 +2889,13 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 			   NULL, tls->mpt_pool->spc_pool->sp_map,
 			   &tls->mpt_svc_list, &tls->mpt_pool_hdl);
 	if (rc) {
-		D_ERROR("dsc_pool_open failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": dsc_pool_open failed", DP_RB_MPT(tls));
 		D_GOTO(out, rc);
 	}
 
 	rc = migrate_cont_open(tls, arg->cont_uuid, 0, &coh);
 	if (rc) {
-		D_ERROR("migrate_cont_open failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": migrate_cont_open failed", DP_RB_MPT(tls));
 		D_GOTO(out, rc);
 	}
 
@@ -2899,7 +2904,7 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	 */
 	rc = dsc_obj_open(coh, arg->oid.id_pub, DAOS_OO_RO, &oh);
 	if (rc) {
-		D_ERROR("dsc_obj_open failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": dsc_obj_open failed", DP_RB_MPT(tls));
 		D_GOTO(out, rc);
 	}
 
@@ -2914,8 +2919,8 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 	dsc_cont_get_props(coh, &props);
 	rc = dsc_obj_id2oc_attr(arg->oid.id_pub, &props, &unpack_arg.oc_attr);
 	if (rc) {
-		D_ERROR("Unknown object class: %u\n",
-			daos_obj_id2class(arg->oid.id_pub));
+		DL_ERROR(rc, DF_RB ": unknown object class: %u", DP_RB_MPT(tls),
+			 daos_obj_id2class(arg->oid.id_pub));
 		D_GOTO(out_obj, rc);
 	}
 
@@ -2972,9 +2977,10 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 				     &dkey_anchor, &akey_anchor, p_csum);
 
 		if (rc == -DER_KEY2BIG) {
-			D_DEBUG(DB_REBUILD, "migrate obj "DF_UOID" got "
-				"-DER_KEY2BIG, key_len "DF_U64"\n",
-				DP_UOID(arg->oid), kds[0].kd_key_len);
+			D_DEBUG(DB_REBUILD,
+				DF_RB ": migrate obj " DF_UOID " got -DER_KEY2BIG, "
+				      "key_len " DF_U64 "\n",
+				DP_RB_MPT(tls), DP_UOID(arg->oid), kds[0].kd_key_len);
 			/* For EC parity migration, it will enumerate from all data
 			 * shards, so buffer needs to time grp_size to make sure
 			 * retry buffer will be large enough.
@@ -2995,8 +3001,10 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 			continue;
 		} else if (rc == -DER_TRUNC && p_csum != NULL &&
 			   p_csum->iov_len > p_csum->iov_buf_len) {
-			D_DEBUG(DB_REBUILD, "migrate obj csum buf "
-				"not large enough. Increase and try again");
+			D_DEBUG(DB_REBUILD,
+				DF_RB ": migrate obj csum buf not large enough. "
+				      "Increase and try again\n",
+				DP_RB_MPT(tls));
 			if (p_csum->iov_buf != stack_csum_buf)
 				D_FREE(p_csum->iov_buf);
 
@@ -3012,24 +3020,25 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 			   daos_anchor_get_flags(&dkey_anchor) & DIOF_TO_LEADER) {
 			if (rc != -DER_INPROGRESS) {
 				enum_flags &= ~DIOF_TO_LEADER;
-				D_DEBUG(DB_REBUILD, "retry to non leader "
-					DF_UOID": "DF_RC"\n",
-					DP_UOID(arg->oid), DP_RC(rc));
+				D_DEBUG(DB_REBUILD,
+					DF_RB ": retry to non leader " DF_UOID ": " DF_RC "\n",
+					DP_RB_MPT(tls), DP_UOID(arg->oid), DP_RC(rc));
 			} else {
 				/* Keep retry on leader if it is inprogress or shutdown,
 				 * since the new dtx leader might still resync the
 				 * uncommitted records, or it will choose a new leader
 				 * once the pool map is updated.
 				 */
-				D_DEBUG(DB_REBUILD, "retry leader "DF_UOID"\n",
-					DP_UOID(arg->oid));
+				D_DEBUG(DB_REBUILD, DF_RB ": retry leader " DF_UOID "\n",
+					DP_RB_MPT(tls), DP_UOID(arg->oid));
 			}
 			continue;
 		} else if (rc == -DER_UPDATE_AGAIN) {
 			/* -DER_UPDATE_AGAIN means the remote target does not parse EC
 			 * aggregation yet, so let's retry.
 			 */
-			D_DEBUG(DB_REBUILD, DF_UOID "retry with %d \n", DP_UOID(arg->oid), rc);
+			D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID " retry with %d \n", DP_RB_MPT(tls),
+				DP_UOID(arg->oid), rc);
 			rc = 0;
 			continue;
 		} else if (rc) {
@@ -3038,9 +3047,8 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 			 */
 			if (rc == -DER_TIMEDOUT &&
 			    tls->mpt_version + 1 >= tls->mpt_pool->spc_map_version) {
-				D_WARN(DF_UUID" retry "DF_UOID" "DF_RC"\n",
-				       DP_UUID(tls->mpt_pool_uuid), DP_UOID(arg->oid),
-				       DP_RC(rc));
+				D_WARN(DF_RB ": retry " DF_UOID " " DF_RC "\n", DP_RB_MPT(tls),
+				       DP_UOID(arg->oid), DP_RC(rc));
 				rc = 0;
 				continue;
 			}
@@ -3056,19 +3064,21 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 			 * -DER_NONEXIST, see obj_ioc_init().
 			 */
 			if (rc == -DER_DATA_LOSS || rc == -DER_NONEXIST) {
-				D_WARN("No replicas for "DF_UOID" %d\n", DP_UOID(arg->oid), rc);
+				D_WARN(DF_RB ": mo replicas for " DF_UOID " %d\n", DP_RB_MPT(tls),
+				       DP_UOID(arg->oid), rc);
 				num = 0;
 				rc = 0;
 			}
-			D_DEBUG(DB_REBUILD, "Can not rebuild "DF_UOID" "DF_RC" mpt %u spc %u\n",
-				DP_UOID(arg->oid), DP_RC(rc), tls->mpt_version, tls->mpt_pool->spc_map_version);
+			D_DEBUG(DB_REBUILD, DF_RB ": cannot rebuild " DF_UOID " " DF_RC " spc %u\n",
+				DP_RB_MPT(tls), DP_UOID(arg->oid), DP_RC(rc),
+				tls->mpt_pool->spc_map_version);
 			break;
 		}
 
 		/* Each object enumeration RPC will at least one OID */
 		if (num <= minimum_nr && (enum_flags & DIOF_TO_SPEC_GROUP)) {
-			D_DEBUG(DB_REBUILD, "enumeration buffer %u empty"
-				DF_UOID"\n", num, DP_UOID(arg->oid));
+			D_DEBUG(DB_REBUILD, DF_RB ": enumeration buffer %u empty" DF_UOID "\n",
+				DP_RB_MPT(tls), num, DP_UOID(arg->oid));
 			break;
 		}
 
@@ -3077,15 +3087,15 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 		rc = dc_obj_enum_unpack(arg->oid, kds, num, &sgl, p_csum,
 					migrate_enum_unpack_cb, &unpack_arg);
 		if (rc) {
-			D_ERROR("migrate "DF_UOID" failed: %d\n",
-				DP_UOID(arg->oid), rc);
+			DL_ERROR(rc, DF_RB ": migrate " DF_UOID " failed", DP_RB_MPT(tls),
+				 DP_UOID(arg->oid));
 			break;
 		}
 
 		rc = migrate_start_ult(&unpack_arg);
 		if (rc) {
-			D_ERROR("start migrate "DF_UOID" failed: "DF_RC"\n",
-				DP_UOID(arg->oid), DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": start migrate " DF_UOID " failed", DP_RB_MPT(tls),
+				 DP_UOID(arg->oid));
 			break;
 		}
 
@@ -3104,9 +3114,9 @@ migrate_one_epoch_object(daos_epoch_range_t *epr, struct migrate_pool_tls *tls,
 out_obj:
 	dsc_obj_close(oh);
 out:
-	D_DEBUG(DB_REBUILD, "obj "DF_UOID" for shard %u eph "
-		DF_U64"-"DF_U64": "DF_RC"\n", DP_UOID(arg->oid), arg->shard,
-		epr->epr_lo, epr->epr_hi, DP_RC(rc));
+	D_DEBUG(DB_REBUILD,
+		DF_RB ": obj " DF_UOID " shard %u eph " DF_U64 "-" DF_U64 ": " DF_RC "\n",
+		DP_RB_MPT(tls), DP_UOID(arg->oid), arg->shard, epr->epr_lo, epr->epr_hi, DP_RC(rc));
 
 	return rc;
 }
@@ -3225,8 +3235,7 @@ migrate_obj_ult(void *data)
 
 	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version, arg->generation);
 	if (tls == NULL || tls->mpt_fini) {
-		D_WARN("some one abort the rebuild "DF_UUID"\n",
-		       DP_UUID(arg->pool_uuid));
+		D_WARN("someone aborted the rebuild " DF_UUID "\n", DP_UUID(arg->pool_uuid));
 		D_GOTO(free_notls, rc);
 	}
 
@@ -3237,16 +3246,16 @@ migrate_obj_ult(void *data)
 	 */
 	if (tls->mpt_pool->spc_pool->sp_need_discard) {
 		while(!tls->mpt_pool->spc_discard_done) {
-			D_DEBUG(DB_REBUILD, DF_UUID" wait for discard to finish.\n",
-				DP_UUID(arg->pool_uuid));
+			D_DEBUG(DB_REBUILD, DF_RB ": wait for discard to finish.\n",
+				DP_RB_MPT(tls));
 			dss_sleep(2 * 1000);
 			if (tls->mpt_fini)
 				D_GOTO(free_notls, rc);
 		}
 		if (tls->mpt_pool->spc_pool->sp_discard_status) {
 			rc = tls->mpt_pool->spc_pool->sp_discard_status;
-			D_DEBUG(DB_REBUILD, DF_UUID " discard failure: " DF_RC,
-				DP_UUID(arg->pool_uuid), DP_RC(rc));
+			D_DEBUG(DB_REBUILD, DF_RB ": discard failure: " DF_RC "\n", DP_RB_MPT(tls),
+				DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 	}
@@ -3254,8 +3263,8 @@ migrate_obj_ult(void *data)
 	for (i = 0; i < arg->snap_cnt; i++) {
 		epr.epr_lo = i > 0 ? arg->snaps[i - 1] + 1 : 0;
 		epr.epr_hi = arg->snaps[i];
-		D_DEBUG(DB_REBUILD, "rebuild_snap %d "DF_X64"-"DF_X64"\n",
-			i, epr.epr_lo, epr.epr_hi);
+		D_DEBUG(DB_REBUILD, DF_RB ": rebuild_snap %d " DF_X64 "-" DF_X64 "\n",
+			DP_RB_MPT(tls), i, epr.epr_lo, epr.epr_hi);
 		rc = migrate_one_epoch_object(&epr, tls, arg);
 		if (rc)
 			D_GOTO(free, rc);
@@ -3274,9 +3283,10 @@ migrate_obj_ult(void *data)
 		rc = migrate_one_epoch_object(&epr, tls, arg);
 	} else {
 		/* The obj has been punched for this range */
-		D_DEBUG(DB_REBUILD, "punched obj "DF_UOID" epoch"
-			" "DF_U64"/"DF_U64"/"DF_U64"\n", DP_UOID(arg->oid),
-			arg->epoch, arg->punched_epoch, epr.epr_hi);
+		D_DEBUG(DB_REBUILD,
+			DF_RB ": punched obj " DF_UOID " epoch " DF_U64 "/" DF_U64 "/" DF_U64 "\n",
+			DP_RB_MPT(tls), DP_UOID(arg->oid), arg->epoch, arg->punched_epoch,
+			epr.epr_hi);
 		arg->epoch = DAOS_EPOCH_MAX;
 	}
 free:
@@ -3303,11 +3313,11 @@ out:
 	if (tls->mpt_status == 0 && rc < 0)
 		tls->mpt_status = rc;
 
-	D_DEBUG(DB_REBUILD, ""DF_UUID"/%u stop migrate obj "DF_UOID
-		" for shard %u ult %u/%u "DF_U64" : " DF_RC"\n",
-		DP_UUID(tls->mpt_pool_uuid), tls->mpt_version,
-		DP_UOID(arg->oid), arg->shard, atomic_load(tls->mpt_tgt_obj_ult_cnt),
-		atomic_load(tls->mpt_tgt_dkey_ult_cnt), tls->mpt_obj_count, DP_RC(rc));
+	D_DEBUG(
+	    DB_REBUILD,
+	    DF_RB ":  stop migrate obj " DF_UOID "for shard %u ult %u/%u " DF_U64 " : " DF_RC "\n",
+	    DP_RB_MPT(tls), DP_UOID(arg->oid), arg->shard, atomic_load(tls->mpt_tgt_obj_ult_cnt),
+	    atomic_load(tls->mpt_tgt_dkey_ult_cnt), tls->mpt_obj_count, DP_RC(rc));
 free_notls:
 	if (tls != NULL)
 		migrate_tgt_exit(tls, OBJ_ULT);
@@ -3375,9 +3385,8 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, daos_epoch_t punched_e
 
 	d_iov_set(&val_iov, &val, sizeof(struct migrate_obj_val));
 	rc = obj_tree_insert(toh, cont_arg->cont_uuid, -1, oid, &val_iov);
-	D_DEBUG(DB_REBUILD, "Insert "DF_UUID"/"DF_UUID"/"DF_UOID": ver %u "
-		"ult %u/%u "DF_RC"\n", DP_UUID(tls->mpt_pool_uuid),
-		DP_UUID(cont_arg->cont_uuid), DP_UOID(oid), tls->mpt_version,
+	D_DEBUG(DB_REBUILD, DF_RB ": insert " DF_UUID "/" DF_UOID ": ult %u/%u " DF_RC "\n",
+		DP_RB_MPT(tls), DP_UUID(cont_arg->cont_uuid), DP_UOID(oid),
 		atomic_load(&tls->mpt_obj_ult_cnts[tgt_idx]),
 		atomic_load(&tls->mpt_dkey_ult_cnts[tgt_idx]), DP_RC(rc));
 
@@ -3407,20 +3416,21 @@ migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 	if (arg->pool_tls->mpt_fini)
 		return 1;
 
-	D_DEBUG(DB_REBUILD, "obj migrate "DF_UUID"/"DF_UOID" %"PRIx64
-		" eph "DF_U64" start\n", DP_UUID(arg->cont_uuid), DP_UOID(*oid),
-		ih.cookie, epoch);
+	D_DEBUG(DB_REBUILD,
+		DF_RB ": obj migrate " DF_UUID "/" DF_UOID " %" PRIx64 " eph " DF_U64 " start\n",
+		DP_RB_MPT(arg->pool_tls), DP_UUID(arg->cont_uuid), DP_UOID(*oid), ih.cookie, epoch);
 
 	rc = migrate_system_enter(arg->pool_tls, tgt_idx, &yielded);
 	if (rc != 0) {
-		DL_ERROR(rc, DF_UUID" enter migrate failed.", DP_UUID(arg->cont_uuid));
+		DL_ERROR(rc, DF_RB ": " DF_UUID " enter migrate failed.", DP_RB_MPT(arg->pool_tls),
+			 DP_UUID(arg->cont_uuid));
 		return rc;
 	}
 
 	rc = migrate_one_object(*oid, epoch, punched_epoch, shard, tgt_idx, arg);
 	if (rc != 0) {
-		D_ERROR("obj "DF_UOID" migration failed: "DF_RC"\n",
-			DP_UOID(*oid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": obj " DF_UOID " migration failed", DP_RB_MPT(arg->pool_tls),
+			 DP_UOID(*oid));
 		migrate_system_exit(arg->pool_tls, tgt_idx);
 		return rc;
 	}
@@ -3431,14 +3441,15 @@ migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 		rc = dbtree_iter_probe(ih, BTR_PROBE_EQ, DAOS_INTENT_MIGRATION, &tmp_iov, NULL);
 		if (rc) {
 			D_ASSERT(rc != -DER_NONEXIST);
-			D_ERROR("obj "DF_UOID" probe failed: "DF_RC"\n", DP_UOID(*oid), DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": obj " DF_UOID " probe failed",
+				 DP_RB_MPT(arg->pool_tls), DP_UOID(*oid));
 			return rc;
 		}
 	}
 
 	rc = dbtree_iter_delete(ih, NULL);
 	if (rc) {
-		D_ERROR("dbtree_iter_delete failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": dbtree_iter_delete failed", DP_RB_MPT(arg->pool_tls));
 		return rc;
 	}
 
@@ -3453,7 +3464,7 @@ migrate_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 	if (rc == -DER_NONEXIST)
 		return 1;
 	else if (rc != 0)
-		D_ERROR("dbtree_iter_probe failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": dbtree_iter_probe failed", DP_RB_MPT(arg->pool_tls));
 
 	return rc;
 }
@@ -3478,22 +3489,20 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 	int			 rc;
 
 	uuid_copy(cont_uuid, *(uuid_t *)key_iov->iov_buf);
-	D_DEBUG(DB_REBUILD, "iter cont "DF_UUID"/%"PRIx64" %"PRIx64" start\n",
-		DP_UUID(cont_uuid), ih.cookie, root->root_hdl.cookie);
+	D_DEBUG(DB_REBUILD, DF_RB ": iter cont " DF_UUID "/%" PRIx64 " %" PRIx64 " start\n",
+		DP_RB_MPT(tls), DP_UUID(cont_uuid), ih.cookie, root->root_hdl.cookie);
 
 	rc = ds_pool_lookup(tls->mpt_pool_uuid, &dp);
 	if (rc) {
-		D_ERROR(DF_UUID" ds_pool_lookup failed: "DF_RC"\n",
-			DP_UUID(tls->mpt_pool_uuid), DP_RC(rc));
-		if (rc == -DER_SHUTDOWN)
-			rc = 0;
+		DL_ERROR(rc, DF_RB ": ds_pool_lookup failed", DP_RB_MPT(tls));
+		rc = 0;
 		D_GOTO(out_put, rc);
 	}
 
 	rc = ds_cont_fetch_snaps(dp->sp_iv_ns, cont_uuid, &snapshots,
 				 &snap_cnt);
 	if (rc) {
-		D_ERROR("ds_cont_fetch_snaps failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": ds_cont_fetch_snaps failed", DP_RB_MPT(tls));
 		D_GOTO(out_put, rc);
 	}
 
@@ -3503,8 +3512,8 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		 * since EC boundary does not start yet, which is forbidden
 		 * during rebuild anyway, so let's continue.
 		 */
-		D_DEBUG(DB_REBUILD, DF_UUID" fetch agg_boundary failed: "DF_RC"\n",
-			DP_UUID(cont_uuid), DP_RC(rc));
+		D_DEBUG(DB_REBUILD, DF_RB ": " DF_UUID " fetch agg_boundary failed: " DF_RC "\n",
+			DP_RB_MPT(tls), DP_UUID(cont_uuid), DP_RC(rc));
 	}
 
 	arg.yield_freq	= DEFAULT_YIELD_FREQ;
@@ -3523,7 +3532,7 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 			break;
 	}
 
-	D_DEBUG(DB_REBUILD, "iter cont "DF_UUID"/%"PRIx64" finish.\n",
+	D_DEBUG(DB_REBUILD, DF_RB ": iter cont " DF_UUID "/%" PRIx64 " finish.\n", DP_RB_MPT(tls),
 		DP_UUID(cont_uuid), ih.cookie);
 
 	rc = dbtree_destroy(root->root_hdl, NULL);
@@ -3531,7 +3540,7 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		/* Ignore the DRAM migrate object tree for the moment, since
 		 * it does not impact the migration on the storage anyway
 		 */
-		D_ERROR("dbtree_destroy failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": dbtree_destroy failed", DP_RB_MPT(tls));
 	}
 
 	/* Snapshot fetch will yield the ULT, let's reprobe before delete  */
@@ -3545,7 +3554,7 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 
 	rc = dbtree_iter_delete(ih, NULL);
 	if (rc) {
-		D_ERROR("dbtree_iter_delete failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": dbtree_iter_delete failed", DP_RB_MPT(tls));
 		D_GOTO(free, rc);
 	}
 
@@ -3586,7 +3595,7 @@ migrate_ult(void *arg)
 				    DAOS_INTENT_PURGE, false,
 				    migrate_cont_iter_cb, pool_tls);
 		if (rc < 0) {
-			D_ERROR("dbtree iterate failed: "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": dbtree iterate failed", DP_RB_MPT(pool_tls));
 			if (pool_tls->mpt_status == 0)
 				pool_tls->mpt_status = rc;
 			break;
@@ -3618,7 +3627,7 @@ migrate_try_create_object_tree(struct migrate_pool_tls *tls)
 					   &tls->mpt_root,
 					   &tls->mpt_root_hdl);
 		if (rc != 0) {
-			D_ERROR("failed to create tree: "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": failed to create tree", DP_RB_MPT(tls));
 			return rc;
 		}
 	}
@@ -3631,7 +3640,7 @@ migrate_try_create_object_tree(struct migrate_pool_tls *tls)
 					   &tls->mpt_migrated_root,
 					   &tls->mpt_migrated_root_hdl);
 		if (rc != 0) {
-			D_ERROR("failed to create tree: "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB ": failed to create migrated tree", DP_RB_MPT(tls));
 			return rc;
 		}
 	}
@@ -3662,22 +3671,23 @@ migrate_try_obj_insert(struct migrate_pool_tls *tls, uuid_t co_uuid,
 	val.punched_epoch = punched_epoch;
 	val.shard = shard;
 	val.tgt_idx = tgt_idx;
-	D_DEBUG(DB_REBUILD, "Insert migrate "DF_UUID"/"DF_UOID" "DF_U64"/"DF_U64
-		"/%d/%d\n", DP_UUID(co_uuid), DP_UOID(oid), epoch, punched_epoch,
-		shard, tgt_idx);
+	D_DEBUG(DB_REBUILD,
+		DF_RB ": insert migrate " DF_UUID "/" DF_UOID " " DF_U64 "/" DF_U64 "/%d/%d\n",
+		DP_RB_MPT(tls), DP_UUID(co_uuid), DP_UOID(oid), epoch, punched_epoch, shard,
+		tgt_idx);
 
 	d_iov_set(&val_iov, &val, sizeof(struct migrate_obj_val));
 	rc = obj_tree_lookup(toh, co_uuid, oid, &val_iov);
 	if (rc != -DER_NONEXIST) {
-		D_DEBUG(DB_REBUILD, DF_UUID"/"DF_UOID" not need insert: "
-			DF_RC"\n", DP_UUID(co_uuid), DP_UOID(oid), DP_RC(rc));
+		D_DEBUG(DB_REBUILD, DF_RB ": " DF_UUID "/" DF_UOID " no insert needed: " DF_RC "\n",
+			DP_RB_MPT(tls), DP_UUID(co_uuid), DP_UOID(oid), DP_RC(rc));
 		return rc;
 	}
 
 	rc = obj_tree_lookup(migrated_toh, co_uuid, oid, &val_iov);
 	if (rc != -DER_NONEXIST) {
-		D_DEBUG(DB_REBUILD, DF_UUID"/"DF_UOID" not need insert: "
-			DF_RC"\n", DP_UUID(co_uuid), DP_UOID(oid), DP_RC(rc));
+		D_DEBUG(DB_REBUILD, DF_RB ": " DF_UUID "/" DF_UOID " no insert needed: " DF_RC "\n",
+			DP_RB_MPT(tls), DP_UUID(co_uuid), DP_UOID(oid), DP_RC(rc));
 		return rc;
 	}
 
@@ -3716,13 +3726,14 @@ ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_
 		rc = migrate_try_obj_insert(tls, co_uuid, oids[i], epochs[i], punched_epochs[i],
 					    shards[i], tgt_idx);
 		if (rc == -DER_EXIST) {
-			D_DEBUG(DB_TRACE, DF_UOID"/"DF_UUID"exists.\n",
-				DP_UOID(oids[i]), DP_UUID(co_uuid));
+			D_DEBUG(DB_TRACE, DF_RB ": " DF_UOID "/" DF_UUID "exists.\n",
+				DP_RB_MPT(tls), DP_UOID(oids[i]), DP_UUID(co_uuid));
 			rc = 0;
 			continue;
 		} else if (rc < 0) {
-			D_ERROR(DF_UOID"/"DF_U64"/"DF_UUID"/%u insert failed: %d\n",
-				DP_UOID(oids[i]), epochs[i], DP_UUID(co_uuid), shards[i], rc);
+			DL_ERROR(rc, DF_RB ": " DF_UOID "/" DF_U64 "/" DF_UUID "/%u insert failed",
+				 DP_RB_MPT(tls), DP_UOID(oids[i]), epochs[i], DP_UUID(co_uuid),
+				 shards[i]);
 			break;
 		}
 	}
@@ -3737,7 +3748,7 @@ ds_migrate_object(struct ds_pool *pool, uuid_t po_hdl, uuid_t co_hdl, uuid_t co_
 	migrate_pool_tls_get(tls);
 	rc = dss_ult_create(migrate_ult, tls, DSS_XS_SELF, 0, MIGRATE_STACK_SIZE, NULL);
 	if (rc) {
-		D_ERROR("Create migrate ULT failed: rc %d\n", rc);
+		DL_ERROR(rc, DF_RB ": create migrate ULT failed", DP_RB_MPT(tls));
 		tls->mpt_ult_running = 0;
 		migrate_pool_tls_put(tls);
 	}
@@ -3782,13 +3793,13 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 
 	if (oids_count == 0 || shards_count == 0 || ephs_count == 0 ||
 	    oids_count != shards_count || oids_count != ephs_count) {
-		D_ERROR("oids %u shards %u ephs %d\n",
-			oids_count, shards_count, ephs_count);
+		D_ERROR(DF_RB ": oids %u shards %u ephs %d\n", DP_RB_OMI(migrate_in), oids_count,
+			shards_count, ephs_count);
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
 	if (migrate_in->om_tgt_idx >= dss_tgt_nr) {
-		D_ERROR("Wrong tgt idx %d\n", migrate_in->om_tgt_idx);
+		D_ERROR(DF_RB " wrong tgt idx %d\n", DP_RB_OMI(migrate_in), migrate_in->om_tgt_idx);
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
@@ -3800,12 +3811,12 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	rc = ds_pool_lookup(po_uuid, &pool);
 	if (rc != 0) {
 		if (rc == -DER_SHUTDOWN) {
-			D_DEBUG(DB_REBUILD, DF_UUID" pool service is stopping.\n",
-				DP_UUID(po_uuid));
+			D_DEBUG(DB_REBUILD, DF_RB " pool service is stopping.\n",
+				DP_RB_OMI(migrate_in));
 			rc = 0;
 		} else {
-			D_DEBUG(DB_REBUILD, DF_UUID" pool service is not started yet. "DF_RC"\n",
-				DP_UUID(po_uuid), DP_RC(rc));
+			D_DEBUG(DB_REBUILD, DF_RB " pool service is not started yet. " DF_RC "\n",
+				DP_RB_OMI(migrate_in), DP_RC(rc));
 			rc = -DER_AGAIN;
 		}
 		D_GOTO(out, rc);
@@ -3814,8 +3825,7 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	ds_rebuild_running_query(migrate_in->om_pool_uuid, -1, &rebuild_ver, NULL, NULL);
 	if (rebuild_ver == 0 || rebuild_ver != migrate_in->om_version) {
 		rc = -DER_SHUTDOWN;
-		DL_ERROR(rc, DF_UUID" rebuild ver %u om version %u",
-			DP_UUID(migrate_in->om_pool_uuid), rebuild_ver, migrate_in->om_version);
+		DL_ERROR(rc, DF_RB " rebuild ver %u", DP_RB_OMI(migrate_in), rebuild_ver);
 		D_GOTO(out, rc);
 	}
 
@@ -3863,7 +3873,7 @@ migrate_check_one(void *data)
 			      atomic_load(tls->mpt_tgt_dkey_ult_cnt);
 	ABT_mutex_unlock(arg->status_lock);
 	D_DEBUG(DB_REBUILD,
-		DF_RB " status %d/%d/ ult %u/%u  rec/obj/size " DF_U64 "/" DF_U64 "/" DF_U64 "\n",
+		DF_RB " status %d/%d/ ult %u/%u rec/obj/size " DF_U64 "/" DF_U64 "/" DF_U64 "\n",
 		DP_RB_MQA(arg), tls->mpt_status, arg->dms.dm_status,
 		atomic_load(tls->mpt_tgt_obj_ult_cnt), atomic_load(tls->mpt_tgt_dkey_ult_cnt),
 		tls->mpt_rec_count, tls->mpt_obj_count, tls->mpt_size);
@@ -4031,8 +4041,7 @@ ds_object_migrate_send(struct ds_pool *pool, uuid_t pool_hdl_uuid, uuid_t cont_h
 		*max_delay = rpc_timeout;
 	}
 out:
-	D_DEBUG(DB_REBUILD, DF_RB ": rc=%d\n", DP_UUID(pool->sp_uuid), version, generation,
-		RB_OP_STR(migrate_opc), rc);
+	D_DEBUG(DB_REBUILD, DF_RB ": rc=%d\n", DP_RB_OMI(migrate_in), rc);
 	if (rpc)
 		crt_req_decref(rpc);
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -33,6 +33,7 @@
 #include <daos/pool.h>
 #include <daos_srv/container.h>
 #include <daos_srv/daos_mgmt_srv.h>
+#include <daos_srv/object.h>
 #include <daos_srv/vos.h>
 #include <daos_srv/rebuild.h>
 #include <daos_srv/srv_csum.h>

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -122,6 +122,8 @@ struct rebuild_global_pool_tracker {
 
 	/** rebuild status for each server */
 	struct rebuild_server_status *rgt_servers;
+	double                         *rgt_servers_last_update;
+	double                          rgt_last_warn;
 
 	/** the current version being rebuilt */
 	uint32_t	rgt_rebuild_ver;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -633,8 +633,8 @@ rebuild_object(struct rebuild_tgt_pool_tracker *rpt, uuid_t co_uuid, daos_unit_o
 
 	if (myrank == target->ta_comp.co_rank && mytarget == target->ta_comp.co_index &&
 	    (shard == oid.id_shard) && rpt->rt_rebuild_op != RB_OP_UPGRADE) {
-		D_DEBUG(DB_REBUILD, DF_UOID" %u/%u already on the target shard\n",
-			DP_UOID(oid), myrank, mytarget);
+		D_DEBUG(DB_REBUILD, DF_RB ": " DF_UOID " %u/%u already on the target shard\n",
+			DP_RB_RPT(rpt), DP_UOID(oid), myrank, mytarget);
 		return 0;
 	}
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -22,6 +22,7 @@
 #include <daos_srv/daos_mgmt_srv.h>
 #include <daos_srv/daos_engine.h>
 #include <daos_srv/rebuild.h>
+#include <daos_srv/object.h>
 #include <daos_srv/vos.h>
 #include <daos_srv/dtx_srv.h>
 #include "rpc.h"
@@ -101,7 +102,7 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 	rc = dbtree_iterate(root->root_hdl, DAOS_INTENT_MIGRATION, false,
 			    rebuild_obj_fill_buf, arg);
 	if (rc < 0 || arg->count == 0) {
-		D_DEBUG(DB_REBUILD, "Can not get objects: "DF_RC"\n",
+		D_DEBUG(DB_REBUILD, DF_RB " cannot get objects: " DF_RC "\n", DP_RB_RPT(rpt),
 			DP_RC(rc));
 		D_GOTO(out, rc);
 	}
@@ -109,9 +110,9 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 	if (daos_fail_check(DAOS_REBUILD_TGT_SEND_OBJS_FAIL))
 		D_GOTO(out, rc = -DER_IO);
 
-	D_DEBUG(DB_REBUILD, "send rebuild objects "DF_UUID" to tgt %d"
-		" cnt %d stable epoch "DF_U64"\n", DP_UUID(rpt->rt_pool_uuid), arg->tgt_id,
-		arg->count, rpt->rt_stable_epoch);
+	D_DEBUG(DB_REBUILD,
+		DF_RB " send rebuild objects to tgt %d cnt %d stable epoch " DF_U64 "\n",
+		DP_RB_RPT(rpt), arg->tgt_id, arg->count, rpt->rt_stable_epoch);
 	while (1) {
 		enqueue_id = 0;
 		max_delay = 0;
@@ -129,8 +130,8 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 			break;
 
 		/* otherwise let's retry */
-		D_DEBUG(DB_REBUILD, DF_UUID" retry send object to tgt_id %d\n",
-			DP_UUID(rpt->rt_pool_uuid), arg->tgt_id);
+		D_DEBUG(DB_REBUILD, DF_RB " retry send object to tgt_id %d\n", DP_RB_RPT(rpt),
+			arg->tgt_id);
 		dss_sleep(daos_rpc_rand_delay(max_delay) << 10);
 	}
 out:
@@ -213,8 +214,7 @@ rebuild_tgt_iter_cb(daos_handle_t ih, d_iov_t *key_iov, d_iov_t *val_iov, void *
 	while (!dbtree_is_empty(root->root_hdl)) {
 		rc = rebuild_obj_send_cb(root, arg);
 		if (rc < 0) {
-			D_ERROR("rebuild_obj_send_cb failed: "DF_RC"\n",
-				DP_RC(rc));
+			DL_ERROR(rc, DF_RB " rebuild_obj_send_cb failed", DP_RB_RPT(arg->rpt));
 			break;
 		}
 	}
@@ -242,8 +242,7 @@ rebuild_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		rc = dbtree_iterate(root->root_hdl, DAOS_INTENT_MIGRATION, false,
 				    rebuild_tgt_iter_cb, arg);
 		if (rc < 0) {
-			D_ERROR("rebuild_tgt_send_cb failed: "DF_RC"\n",
-				DP_RC(rc));
+			DL_ERROR(rc, DF_RB " rebuild_tgt_send_cb failed", DP_RB_RPT(arg->rpt));
 			break;
 		}
 	}
@@ -308,14 +307,13 @@ rebuild_objects_send_ult(void *data)
 		rc = dbtree_iterate(tls->rebuild_tree_hdl, DAOS_INTENT_MIGRATION,
 				    false, rebuild_cont_iter_cb, &arg);
 		if (rc < 0) {
-			D_ERROR("dbtree iterate failed: "DF_RC"\n", DP_RC(rc));
+			DL_ERROR(rc, DF_RB " dbtree iterate failed", DP_RB_RPT(rpt));
 			break;
 		}
 		dss_sleep(0);
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UUID"/%d objects send finish\n",
-		DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver);
+	D_DEBUG(DB_REBUILD, DF_RB " objects send finished\n", DP_RB_RPT(rpt));
 out:
 	if (oids != NULL)
 		D_FREE(oids);
@@ -325,8 +323,10 @@ out:
 		D_FREE(ephs);
 	if (punched_ephs != NULL)
 		D_FREE(punched_ephs);
-	if (rc != 0 && tls->rebuild_pool_status == 0)
+	if (rc != 0 && tls->rebuild_pool_status == 0) {
+		DL_ERROR(rc, DF_RB " objects send error", DP_RB_RPT(rpt));
 		tls->rebuild_pool_status = rc;
+	}
 
 	rpt_put(rpt);
 }
@@ -527,8 +527,8 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 		return 0;
 	}
 
-	D_DEBUG(DB_REBUILD, "deleting stale object "DF_UOID" rank %u tgt %u oid layout %u/%u",
-		DP_UOID(oid), myrank, mytarget, oid.id_layout_ver, new_layout_ver);
+	D_DEBUG(DB_REBUILD, DF_RB " deleting stale object " DF_UOID " oid layout %u/%u",
+		DP_RB_RPT(rpt), DP_UOID(oid), oid.id_layout_ver, new_layout_ver);
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
 	tls->rebuild_pool_reclaim_obj_count++;
@@ -547,7 +547,7 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 		if (rc != -DER_BUSY && rc != -DER_INPROGRESS)
 			break;
 
-		D_DEBUG(DB_REBUILD, "retry by "DF_RC"/"DF_UOID"\n",
+		D_DEBUG(DB_REBUILD, DF_RB " retry by " DF_RC "/" DF_UOID "\n", DP_RB_RPT(rpt),
 			DP_RC(rc), DP_UOID(oid));
 		/* Busy - inform iterator and yield */
 		*acts |= VOS_ITER_CB_YIELD;
@@ -555,7 +555,8 @@ obj_reclaim(struct pl_map *map, uint32_t layout_ver, uint32_t new_layout_ver,
 	} while (1);
 
 	if (rc != 0)
-		D_ERROR("Failed to delete object "DF_UOID" :"DF_RC"\n", DP_UOID(oid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Failed to delete object " DF_UOID, DP_RB_RPT(rpt),
+			 DP_UOID(oid));
 
 	return rc;
 }
@@ -685,15 +686,14 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 		  "flags %x snapshot_cnt %d\n", ent->ie_vis_flags, arg->snapshot_cnt);
 	map = pl_map_find(rpt->rt_pool_uuid, oid.id_pub);
 	if (map == NULL) {
-		D_ERROR(DF_UOID ": Cannot find valid placement map" DF_UUID "\n", DP_UOID(oid),
-			DP_UUID(rpt->rt_pool_uuid));
+		D_ERROR(DF_RB " " DF_UOID ": Cannot find valid placement map\n", DP_RB_RPT(rpt),
+			DP_UOID(oid));
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
 	oc_attr = daos_oclass_attr_find(oid.id_pub, NULL);
 	if (oc_attr == NULL) {
-		D_INFO(DF_UUID" skip invalid "DF_UOID"\n", DP_UUID(rpt->rt_pool_uuid),
-		       DP_UOID(oid));
+		D_INFO(DF_RB " skip invalid " DF_UOID "\n", DP_RB_RPT(rpt), DP_UOID(oid));
 		D_GOTO(out, rc = 0);
 	}
 
@@ -738,25 +738,28 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 	}
 
 	if (rc <= 0) {
-		DL_CDEBUG(rc == 0, DB_REBUILD, DLOG_ERR, rc, DF_UOID " rebuild shards",
-			  DP_UOID(oid));
+		DL_CDEBUG(rc == 0, DB_REBUILD, DLOG_ERR, rc, DF_RB " " DF_UOID " rebuild shards",
+			  DP_RB_RPT(rpt), DP_UOID(oid));
 		D_GOTO(out, rc);
 	}
 
-	D_DEBUG(DB_REBUILD, "rebuild obj "DF_UOID" rebuild_nr %d\n", DP_UOID(oid), rc);
+	D_DEBUG(DB_REBUILD, DF_RB " rebuild obj " DF_UOID " rebuild_nr %d\n", DP_RB_RPT(rpt),
+		DP_UOID(oid), rc);
 	rebuild_nr = rc;
 	rc = 0;
 	for (i = 0; i < rebuild_nr; i++) {
-		D_DEBUG(DB_REBUILD, "rebuild obj "DF_UOID"/"DF_UUID"/"DF_UUID
-			"on %d for shard %d eph "DF_U64" visible %s\n", DP_UOID(oid),
-			DP_UUID(rpt->rt_pool_uuid), DP_UUID(arg->co_uuid),
-			tgts[i], shards[i], ent->ie_epoch,
-			ent->ie_vis_flags & VOS_VIS_FLAG_COVERED ? "no" : "yes");
+		D_DEBUG(DB_REBUILD,
+			DF_RB " cont " DF_UUID " rebuild obj " DF_UOID " on %d for shard %d"
+			      " eph " DF_U64 " visible %s\n",
+			DP_RB_RPT(rpt), DP_UUID(arg->co_uuid), DP_UOID(oid), tgts[i], shards[i],
+			ent->ie_epoch, ent->ie_vis_flags & VOS_VIS_FLAG_COVERED ? "no" : "yes");
 
 		/* Ignore the shard if it is not in the same group of failure shard */
 		if ((int)tgts[i] == -1 || oid.id_shard / grp_size != shards[i] / grp_size) {
-			D_DEBUG(DB_REBUILD, "i %d stale object "DF_UOID" shards %u grp_size %u tgt %d\n",
-				i, DP_UOID(oid), shards[i], grp_size, (int)tgts[i]);
+			D_DEBUG(DB_REBUILD,
+				DF_RB " i %d stale object " DF_UOID " shards %u "
+				      "grp_size %u tgt %d\n",
+				DP_RB_RPT(rpt), i, DP_UOID(oid), shards[i], grp_size, (int)tgts[i]);
 			continue;
 		}
 
@@ -778,8 +781,7 @@ out:
 		pl_map_decref(map);
 
 	if (--arg->yield_freq == 0 || arg->obj_yield_cnt <= 0) {
-		D_DEBUG(DB_REBUILD, DF_UUID" rebuild yield: %d\n",
-			DP_UUID(rpt->rt_pool_uuid), rc);
+		D_DEBUG(DB_REBUILD, DF_RB " rebuild yield: %d\n", DP_RB_RPT(rpt), rc);
 		arg->yield_freq = SCAN_YIELD_FREQ;
 		arg->obj_yield_cnt = SCAN_OBJ_YIELD_CNT;
 		if (rc == 0)
@@ -809,34 +811,35 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	int				rc;
 
 	if (uuid_compare(arg->co_uuid, entry->ie_couuid) == 0) {
-		D_DEBUG(DB_REBUILD, DF_UUID" already scan\n",
+		D_DEBUG(DB_REBUILD, DF_RB " co_uuid " DF_UUID " already scanned\n", DP_RB_RPT(rpt),
 			DP_UUID(arg->co_uuid));
 		return 0;
 	}
 
 	rc = vos_cont_open(iter_param->ip_hdl, entry->ie_couuid, &coh);
 	if (rc == -DER_NONEXIST) {
-		D_DEBUG(DB_REBUILD, DF_UUID" already destroyed\n", DP_UUID(arg->co_uuid));
+		D_DEBUG(DB_REBUILD, DF_RB " co_uuid " DF_UUID " already destroyed\n",
+			DP_RB_RPT(rpt), DP_UUID(arg->co_uuid));
 		return 0;
 	}
 
 	if (rc != 0) {
-		D_ERROR("Open container "DF_UUID" failed: "DF_RC"\n",
-			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Open container " DF_UUID " failed", DP_RB_RPT(rpt),
+			 DP_UUID(entry->ie_couuid));
 		return rc;
 	}
 
 	rc = ds_cont_child_lookup(rpt->rt_pool_uuid, entry->ie_couuid, &cont_child);
 	if (rc == -DER_NONEXIST || rc == -DER_SHUTDOWN) {
-		D_DEBUG(DB_REBUILD, DF_UUID" already destroyed or destroying\n",
-			DP_UUID(arg->co_uuid));
+		D_DEBUG(DB_REBUILD, DF_RB " co_uuid " DF_UUID " already destroyed or destroying\n",
+			DP_RB_RPT(rpt), DP_UUID(arg->co_uuid));
 		rc = 0;
 		D_GOTO(close, rc);
 	}
 
 	if (rc != 0) {
-		D_ERROR("Container "DF_UUID", ds_cont_child_lookup failed: "DF_RC"\n",
-			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Container " DF_UUID ", ds_cont_child_lookup failed",
+			 DP_RB_RPT(rpt), DP_UUID(entry->ie_couuid));
 		D_GOTO(close, rc);
 	}
 
@@ -855,15 +858,15 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	rc = ds_cont_fetch_snaps(rpt->rt_pool->sp_iv_ns, entry->ie_couuid, NULL,
 				 &snapshot_cnt);
 	if (rc) {
-		D_ERROR("Container "DF_UUID", ds_cont_fetch_snaps failed: "DF_RC"\n",
-			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Container " DF_UUID ", ds_cont_fetch_snaps failed",
+			 DP_RB_RPT(rpt), DP_UUID(entry->ie_couuid));
 		D_GOTO(close, rc);
 	}
 
 	rc = ds_cont_get_props(&arg->co_props, rpt->rt_pool->sp_uuid, entry->ie_couuid);
 	if (rc) {
-		D_ERROR("Container "DF_UUID", ds_cont_get_props failed: "DF_RC"\n",
-			DP_UUID(entry->ie_couuid), DP_RC(rc));
+		DL_ERROR(rc, DF_RB " Container " DF_UUID ", ds_cont_get_props failed",
+			 DP_RB_RPT(rpt), DP_UUID(entry->ie_couuid));
 		D_GOTO(close, rc);
 	}
 
@@ -874,13 +877,13 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		D_ASSERTF(rpt->rt_pool->sp_rebuilding >= 0, DF_UUID" rebuilding %d\n",
 			  DP_UUID(rpt->rt_pool_uuid), rpt->rt_pool->sp_rebuilding);
 			/* Wait for EC aggregation to abort before discard the object */
-		D_INFO(DF_UUID" wait for ec agg abort.\n", DP_UUID(entry->ie_couuid));
+		D_INFO(DF_RB " " DF_UUID " wait for ec agg abort.\n", DP_RB_RPT(rpt),
+		       DP_UUID(entry->ie_couuid));
 		dss_sleep(1000);
 		if (rpt->rt_abort || rpt->rt_finishing) {
-			D_DEBUG(DB_REBUILD, DF_CONT" rebuild op %s ver %u abort %u/%u.\n",
-				DP_CONT(rpt->rt_pool_uuid, entry->ie_couuid),
-				RB_OP_STR(rpt->rt_rebuild_op), rpt->rt_rebuild_ver,
-				rpt->rt_abort, rpt->rt_finishing);
+			D_DEBUG(DB_REBUILD, DF_RB " " DF_UUID " rebuild abort %u/%u.\n",
+				DP_RB_RPT(rpt), DP_UUID(entry->ie_couuid), rpt->rt_abort,
+				rpt->rt_finishing);
 			*acts |= VOS_ITER_CB_ABORT;
 			D_GOTO(close, rc);
 		}
@@ -919,9 +922,8 @@ close:
 		ds_cont_child_put(cont_child);
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UUID"/"DF_UUID" iterate cont done: "DF_RC"\n",
-		DP_UUID(rpt->rt_pool_uuid), DP_UUID(entry->ie_couuid),
-		DP_RC(rc));
+	D_DEBUG(DB_REBUILD, DF_RB " " DF_UUID " iterate cont done: " DF_RC "\n", DP_RB_RPT(rpt),
+		DP_UUID(entry->ie_couuid), DP_RC(rc));
 
 	return rc;
 }
@@ -977,7 +979,7 @@ rebuild_scanner(void *data)
 		return 0;
 
 	if (!is_rebuild_scanning_tgt(rpt)) {
-		D_DEBUG(DB_REBUILD, DF_UUID" skip scan\n", DP_UUID(rpt->rt_pool_uuid));
+		D_DEBUG(DB_REBUILD, DF_RB " skip scan\n", DP_RB_RPT(rpt));
 		D_GOTO(out, rc = 0);
 	}
 
@@ -987,7 +989,7 @@ rebuild_scanner(void *data)
 		    rpt->rt_rebuild_op == RB_OP_FAIL_RECLAIM)
 			break;
 
-		D_DEBUG(DB_REBUILD, "sleep 2 seconds then retry\n");
+		D_DEBUG(DB_REBUILD, DF_RB " sleep 2 seconds then retry\n", DP_RB_RPT(rpt));
 		dss_sleep(2 * 1000);
 	}
 	D_ASSERT(daos_handle_is_inval(tls->rebuild_tree_hdl));
@@ -997,7 +999,7 @@ rebuild_scanner(void *data)
 	rc = dbtree_create(DBTREE_CLASS_UV, 0, 4, &uma, NULL,
 			   &tls->rebuild_tree_hdl);
 	if (rc != 0) {
-		D_ERROR("failed to create rebuild tree: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB " failed to create rebuild tree", DP_RB_RPT(rpt));
 		D_GOTO(out, rc);
 	}
 
@@ -1035,8 +1037,7 @@ out:
 	if (tls->rebuild_pool_status == 0 && rc != 0)
 		tls->rebuild_pool_status = rc;
 
-	D_DEBUG(DB_REBUILD, DF_UUID" iterate pool done: "DF_RC"\n",
-		DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
+	D_DEBUG(DB_REBUILD, DF_RB " iterate pool done: " DF_RC "\n", DP_RB_RPT(rpt), DP_RC(rc));
 	return rc;
 }
 
@@ -1051,31 +1052,28 @@ rebuild_scan_leader(void *data)
 	struct rebuild_pool_tls	  *tls;
 	int			   rc;
 
-	D_DEBUG(DB_REBUILD, DF_UUID "check resync %u/%u < %u\n",
-		DP_UUID(rpt->rt_pool_uuid), rpt->rt_pool->sp_dtx_resync_version,
-		rpt->rt_global_dtx_resync_version, rpt->rt_rebuild_ver);
+	D_DEBUG(DB_REBUILD, DF_RB " check resync %u/%u < %u\n", DP_RB_RPT(rpt),
+		rpt->rt_pool->sp_dtx_resync_version, rpt->rt_global_dtx_resync_version,
+		rpt->rt_rebuild_ver);
 
 	/* Wait for dtx resync to finish */
 	while (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver) {
 		if (!rpt->rt_abort && !rpt->rt_finishing) {
 			ABT_mutex_lock(rpt->rt_lock);
 			if (rpt->rt_global_dtx_resync_version < rpt->rt_rebuild_ver) {
-				D_INFO(DF_UUID "wait for global dtx %u rebuild ver %u\n",
-				       DP_UUID(rpt->rt_pool_uuid),
-				       rpt->rt_global_dtx_resync_version, rpt->rt_rebuild_ver);
+				D_INFO(DF_RB " wait for global dtx %u\n", DP_RB_RPT(rpt),
+				       rpt->rt_global_dtx_resync_version);
 				ABT_cond_wait(rpt->rt_global_dtx_wait_cond, rpt->rt_lock);
 			}
 			ABT_mutex_unlock(rpt->rt_lock);
 		}
 		if (rpt->rt_abort || rpt->rt_finishing) {
-			D_INFO("shutdown rebuild "DF_UUID": "DF_RC"\n",
-			       DP_UUID(rpt->rt_pool_uuid), DP_RC(-DER_SHUTDOWN));
+			DL_INFO(-DER_SHUTDOWN, DF_RB ": shutdown rebuild", DP_RB_RPT(rpt));
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 		}
 	}
 
-	D_DEBUG(DB_REBUILD, "rebuild scan collective "DF_UUID" begin.\n",
-		DP_UUID(rpt->rt_pool_uuid));
+	D_DEBUG(DB_REBUILD, DF_RB " scan collective begin\n", DP_RB_RPT(rpt));
 
 	rc = ds_pool_thread_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
 				       PO_COMP_ST_DOWNOUT, rebuild_scanner, rpt,
@@ -1083,28 +1081,26 @@ rebuild_scan_leader(void *data)
 	if (rc)
 		D_GOTO(out, rc);
 
-	D_DEBUG(DB_REBUILD, "rebuild scan collective "DF_UUID" done.\n",
-		DP_UUID(rpt->rt_pool_uuid));
+	D_DEBUG(DB_REBUILD, DF_RB "rebuild scan collective done\n", DP_RB_RPT(rpt));
 
 	ABT_mutex_lock(rpt->rt_lock);
 	rc = ds_pool_task_collective(rpt->rt_pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
 				     PO_COMP_ST_DOWNOUT, rebuild_scan_done, rpt, 0);
 	ABT_mutex_unlock(rpt->rt_lock);
 	if (rc) {
-		D_ERROR(DF_UUID" send rebuild object list failed:%d\n",
-			DP_UUID(rpt->rt_pool_uuid), rc);
+		DL_ERROR(rc, DF_RB " send rebuild object list failed", DP_RB_RPT(rpt));
 		D_GOTO(out, rc);
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UUID" sent objects to initiator: "DF_RC"\n",
-		DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
+	D_DEBUG(DB_REBUILD, DF_RB " sent objects to initiator: " DF_RC "\n", DP_RB_RPT(rpt),
+		DP_RC(rc));
 out:
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
 				      rpt->rt_rebuild_gen);
 	D_ASSERT(tls != NULL);
 	if (tls->rebuild_pool_status == 0 && rc != 0)
 		tls->rebuild_pool_status = rc;
-	D_INFO(DF_UUID"scan leader done: "DF_RC"\n", DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
+	DL_INFO(rc, DF_RB " scan leader done", DP_RB_RPT(rpt));
 	rpt_put(rpt);
 }
 
@@ -1121,10 +1117,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	rsi = crt_req_get(rpc);
 	D_ASSERT(rsi != NULL);
 
-	D_INFO("%d/"DF_UUID" scan ver %d gen %u leader %u term "DF_U64" op:%s\n",
-	       dss_get_module_info()->dmi_tgt_id, DP_UUID(rsi->rsi_pool_uuid),
-	       rsi->rsi_rebuild_ver, rsi->rsi_rebuild_gen, rsi->rsi_master_rank,
-	       rsi->rsi_leader_term, RB_OP_STR(rsi->rsi_rebuild_op));
+	D_INFO(DF_RB "\n", DP_RB_RSI(rsi));
 
 	/* If PS leader has been changed, and rebuild version is also increased
 	 * due to adding new failure targets for rebuild, let's abort previous
@@ -1134,17 +1127,13 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		if (uuid_compare(rpt->rt_pool_uuid, rsi->rsi_pool_uuid) == 0 &&
 		    rpt->rt_rebuild_ver < rsi->rsi_rebuild_ver &&
 		    rpt->rt_rebuild_op == rsi->rsi_rebuild_op) {
-			D_INFO(DF_UUID" %p %s %u/"DF_U64"/%u < incoming rebuild %u/"DF_U64"/%u\n",
-			       DP_UUID(rpt->rt_pool_uuid), rpt, RB_OP_STR(rpt->rt_rebuild_op),
-			       rpt->rt_rebuild_ver, rpt->rt_leader_term, rpt->rt_rebuild_gen,
-			       rsi->rsi_rebuild_ver, rsi->rsi_leader_term, rsi->rsi_rebuild_gen);
+			D_INFO("existing " DF_RB " < incoming " DF_RB "\n", DP_RB_RPT(rpt),
+			       DP_RB_RSI(rsi));
 			rpt->rt_abort = 1;
 			if (rpt->rt_leader_rank != rsi->rsi_master_rank) {
-				D_DEBUG(DB_REBUILD, DF_UUID" master rank"
-					" %d -> %d term "DF_U64" -> "DF_U64"\n",
-					DP_UUID(rpt->rt_pool_uuid),
-					rpt->rt_leader_rank, rsi->rsi_master_rank,
-					rpt->rt_leader_term, rsi->rsi_leader_term);
+				D_DEBUG(DB_REBUILD,
+					"leader change existing " DF_RBF " incoming " DF_RBF "\n",
+					DP_RBF_RPT(rpt), DP_RBF_RSI(rsi));
 				/* If this is the old leader, then also stop the rebuild
 				 * tracking ULT.
 				 */
@@ -1158,9 +1147,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	rpt = rpt_lookup(rsi->rsi_pool_uuid, -1, rsi->rsi_rebuild_ver, -1);
 	if (rpt != NULL && rpt->rt_rebuild_op == rsi->rsi_rebuild_op) {
 		if (rpt->rt_global_done) {
-			D_WARN("the previous rebuild "DF_UUID"/%d/"DF_U64"/%p is not cleanup yet\n",
-			       DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver,
-			       rsi->rsi_leader_term, rpt);
+			D_WARN("previous not cleaned up yet " DF_RBF "\n", DP_RBF_RPT(rpt));
 			D_GOTO(out, rc = -DER_BUSY);
 		}
 
@@ -1169,9 +1156,8 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 			  "rsi_rebuild_ver %d != rt_rebuild_ver %d\n",
 			  rsi->rsi_rebuild_ver, rpt->rt_rebuild_ver);
 
-		D_DEBUG(DB_REBUILD, DF_UUID" already started, req "DF_U64" master %u/"DF_U64"\n",
-			DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_leader_term, rsi->rsi_master_rank,
-			rpt->rt_leader_term);
+		D_DEBUG(DB_REBUILD, "already started, existing " DF_RBF ", req " DF_RBF "\n",
+			DP_RBF_RPT(rpt), DP_RBF_RSI(rsi));
 
 		/* Ignore the rebuild trigger request if it comes from
 		 * an old or same leader.
@@ -1180,11 +1166,8 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 			D_GOTO(out, rc = 0);
 
 		if (rpt->rt_leader_rank != rsi->rsi_master_rank) {
-			D_DEBUG(DB_REBUILD, DF_UUID" master rank"
-				" %d -> %d term "DF_U64" -> "DF_U64"\n",
-				DP_UUID(rpt->rt_pool_uuid),
-				rpt->rt_leader_rank, rsi->rsi_master_rank,
-				rpt->rt_leader_term, rsi->rsi_leader_term);
+			D_DEBUG(DB_REBUILD, "new leader existing " DF_RBF "-> req " DF_RBF "\n",
+				DP_RBF_RPT(rpt), DP_RBF_RSI(rsi));
 			/* re-report the #rebuilt cnt next time */
 			rpt->rt_re_report = 1;
 
@@ -1206,8 +1189,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	tls = rebuild_pool_tls_lookup(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver,
 				      rsi->rsi_rebuild_gen);
 	if (tls != NULL) {
-		D_WARN("the previous rebuild "DF_UUID"/%d is not cleanup yet\n",
-		       DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver);
+		D_WARN("previous not cleaned up yet " DF_RBF, DP_RBF_RSI(rsi));
 		D_GOTO(out, rc = -DER_BUSY);
 	}
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -13,6 +13,7 @@
 #include <daos/rpc.h>
 #include <daos/pool.h>
 #include <daos_srv/daos_engine.h>
+#include <daos_srv/object.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/container.h>
 #include <daos_srv/iv.h>
@@ -68,22 +69,22 @@ rebuild_pool_tls_lookup(uuid_t pool_uuid, unsigned int ver, uint32_t gen)
 }
 
 static struct rebuild_pool_tls *
-rebuild_pool_tls_create(uuid_t pool_uuid, uuid_t poh_uuid, uuid_t coh_uuid,
-			unsigned int ver, uint32_t gen)
+rebuild_pool_tls_create(struct rebuild_tgt_pool_tracker *rpt)
 {
 	struct rebuild_pool_tls *rebuild_pool_tls;
 	struct rebuild_tls *tls = rebuild_tls_get();
 
-	rebuild_pool_tls = rebuild_pool_tls_lookup(pool_uuid, ver, gen);
+	rebuild_pool_tls =
+	    rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
 	D_ASSERT(rebuild_pool_tls == NULL);
 
 	D_ALLOC_PTR(rebuild_pool_tls);
 	if (rebuild_pool_tls == NULL)
 		return NULL;
 
-	rebuild_pool_tls->rebuild_pool_ver = ver;
-	rebuild_pool_tls->rebuild_pool_gen = gen;
-	uuid_copy(rebuild_pool_tls->rebuild_pool_uuid, pool_uuid);
+	rebuild_pool_tls->rebuild_pool_ver = rpt->rt_rebuild_ver;
+	rebuild_pool_tls->rebuild_pool_gen = rpt->rt_rebuild_gen;
+	uuid_copy(rebuild_pool_tls->rebuild_pool_uuid, rpt->rt_pool_uuid);
 	rebuild_pool_tls->rebuild_pool_scanning = 1;
 	rebuild_pool_tls->rebuild_pool_scan_done = 0;
 	rebuild_pool_tls->rebuild_pool_obj_count = 0;
@@ -93,16 +94,16 @@ rebuild_pool_tls_create(uuid_t pool_uuid, uuid_t poh_uuid, uuid_t coh_uuid,
 	d_list_add(&rebuild_pool_tls->rebuild_pool_list,
 		   &tls->rebuild_pool_list);
 
-	D_DEBUG(DB_REBUILD, "TLS create for "DF_UUID" ver %d\n",
-		DP_UUID(pool_uuid), ver);
+	D_DEBUG(DB_REBUILD, DF_RB " TLS create\n", DP_RB_RPT(rpt));
 	return rebuild_pool_tls;
 }
 
 static void
 rebuild_pool_tls_destroy(struct rebuild_pool_tls *tls)
 {
-	D_DEBUG(DB_REBUILD, "TLS destroy for "DF_UUID" ver %d\n",
-		DP_UUID(tls->rebuild_pool_uuid), tls->rebuild_pool_ver);
+	/* log format derived from DF_RB format definition (don't have leader rank, opcode here) */
+	D_DEBUG(DB_REBUILD, DF_UUID "/%u/%u/op=? TLS destroy\n", DP_UUID(tls->rebuild_pool_uuid),
+		tls->rebuild_pool_ver, tls->rebuild_pool_gen);
 	if (daos_handle_is_valid(tls->rebuild_tree_hdl))
 		rebuild_obj_tree_destroy(tls->rebuild_tree_hdl);
 	d_list_del(&tls->rebuild_pool_list);
@@ -377,8 +378,7 @@ dss_rebuild_check_one(void *data)
 	struct rebuild_tgt_query_arg	*arg = data;
 	struct rebuild_pool_tls		*pool_tls;
 	struct rebuild_tgt_query_info	*status = arg->status;
-	struct rebuild_tgt_pool_tracker	*rpt = arg->rpt;
-	unsigned int			idx = dss_get_module_info()->dmi_tgt_id;
+	struct rebuild_tgt_pool_tracker *rpt    = arg->rpt;
 
 	if (!is_rebuild_scanning_tgt(rpt))
 		return 0;
@@ -388,9 +388,8 @@ dss_rebuild_check_one(void *data)
 	if (pool_tls == NULL)
 		return 0;
 
-	D_DEBUG(DB_REBUILD, "%d scanning %d status: "DF_RC"\n", idx,
-		pool_tls->rebuild_pool_scanning,
-		DP_RC(pool_tls->rebuild_pool_status));
+	D_DEBUG(DB_REBUILD, DF_RB " scanning %d status: " DF_RC "\n", DP_RB_RPT(rpt),
+		pool_tls->rebuild_pool_scanning, DP_RC(pool_tls->rebuild_pool_status));
 
 	ABT_mutex_lock(status->lock);
 	if (pool_tls->rebuild_pool_scanning)
@@ -419,7 +418,7 @@ rebuild_tgt_query(struct rebuild_tgt_pool_tracker *rpt,
 
 	if (rpt->rt_rebuild_op != RB_OP_RECLAIM && rpt->rt_rebuild_op != RB_OP_FAIL_RECLAIM) {
 		rc = ds_migrate_query_status(rpt->rt_pool_uuid, rpt->rt_rebuild_ver,
-					     rpt->rt_rebuild_gen, &dms);
+					     rpt->rt_rebuild_gen, rpt->rt_rebuild_op, &dms);
 		if (rc)
 			D_GOTO(out, rc);
 	}
@@ -451,13 +450,11 @@ rebuild_tgt_query(struct rebuild_tgt_pool_tracker *rpt,
 
 	ABT_mutex_unlock(rpt->rt_lock);
 
-	D_DEBUG(DB_REBUILD, "pool "DF_UUID" scanning %d/%d rebuilding=%s, "
-		"obj_count="DF_U64", tobe_obj="DF_U64" rec_count="DF_U64
-		" size= "DF_U64"\n",
-		DP_UUID(rpt->rt_pool_uuid), status->scanning,
-		status->status, status->rebuilding ? "yes" : "no",
-		status->obj_count, status->tobe_obj_count, status->rec_count,
-		status->size);
+	D_DEBUG(DB_REBUILD,
+		DF_RB " scanning %d/%d rebuilding=%s, obj_count=" DF_U64 ", "
+		      "tobe_obj=" DF_U64 " rec_count=" DF_U64 " size= " DF_U64 "\n",
+		DP_RB_RPT(rpt), status->scanning, status->status, status->rebuilding ? "yes" : "no",
+		status->obj_count, status->tobe_obj_count, status->rec_count, status->size);
 out:
 	return rc;
 }
@@ -476,9 +473,8 @@ ds_rebuild_running_query(uuid_t pool_uuid, uint32_t opc, uint32_t *upper_ver,
 		*generation = -1;
 	rpt = rpt_lookup(pool_uuid, opc, -1, -1);
 	if (rpt != NULL && !rpt->rt_global_done && !rpt->rt_abort) {
-		D_DEBUG(DB_REBUILD, DF_UUID" rebuild %p running eph/ver/gen "DF_X64"/%u/%u\n",
-			DP_UUID(pool_uuid), rpt, rpt->rt_stable_epoch, rpt->rt_rebuild_ver,
-			rpt->rt_rebuild_gen);
+		D_DEBUG(DB_REBUILD, DF_RB " rebuild %p running eph " DF_X64 "\n", DP_RB_RPT(rpt),
+			rpt, rpt->rt_stable_epoch);
 		if (stable_eph)
 			*stable_eph = rpt->rt_stable_epoch;
 		if (upper_ver)
@@ -583,11 +579,9 @@ rebuild_leader_status_notify(struct rebuild_global_pool_tracker *rgt, struct ds_
 				rebuild_get_global_dtx_resync_ver(rgt);
 	iv.riv_dtx_resyc_version = pool->sp_dtx_resync_version;
 
-
-	D_DEBUG(DB_REBUILD, DF_UUID "/%u/%u op: %s dtx %u scan_gd/gd/abort %u/%u/%u: %d\n",
-		DP_UUID(rgt->rgt_pool_uuid), rgt->rgt_rebuild_ver, rgt->rgt_rebuild_gen,
-		RB_OP_STR(op), iv.riv_global_dtx_resyc_version, iv.riv_global_scan_done,
-		iv.riv_global_done, rgt->rgt_abort, rgt->rgt_status.rs_errno);
+	D_DEBUG(DB_REBUILD, DF_RB " dtx %u scan_gd/gd/abort %u/%u/%u: %d\n", DP_RB_RGT(rgt),
+		iv.riv_global_dtx_resyc_version, iv.riv_global_scan_done, iv.riv_global_done,
+		rgt->rgt_abort, rgt->rgt_status.rs_errno);
 
 	rc = rebuild_iv_update(pool->sp_iv_ns, &iv, CRT_IV_SHORTCUT_NONE,
 			       CRT_IV_SYNC_LAZY, true);
@@ -646,7 +640,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 				    PO_COMP_ST_DOWNOUT | PO_COMP_ST_NEW,
 				    &excluded);
 		if (rc != 0) {
-			D_INFO(DF_UUID": get rank list: %d\n", DP_UUID(pool->sp_uuid), rc);
+			D_INFO(DF_RB ": get rank list: %d\n", DP_RB_RGT(rgt), rc);
 			ABT_rwlock_unlock(pool->sp_lock);
 			goto sleep;
 		}
@@ -660,9 +654,8 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 			if (rgt->rgt_opc == RB_OP_REBUILD) {
 				if (dom->do_comp.co_status == PO_COMP_ST_UP) {
 					if (dom->do_comp.co_in_ver > rgt->rgt_rebuild_ver) {
-						D_INFO(DF_UUID": cancel rebuild %u/%u\n",
-				       		       DP_UUID(pool->sp_uuid), rgt->rgt_rebuild_ver,
-						       dom->do_comp.co_in_ver);
+						D_INFO(DF_RB ": cancel rebuild co_in_ver=%u\n",
+						       DP_RB_RGT(rgt), dom->do_comp.co_in_ver);
 						rebuild_abort = true;
 						break;
 					} else {
@@ -670,16 +663,15 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 					}
 				} else if (dom->do_comp.co_status == PO_COMP_ST_DOWN) {
 					if (dom->do_comp.co_fseq > rgt->rgt_rebuild_ver) {
-						D_INFO(DF_UUID": cancel rebuild %u/%u\n",
-				       		       DP_UUID(pool->sp_uuid), rgt->rgt_rebuild_ver,
-						       dom->do_comp.co_fseq);
+						D_INFO(DF_RB ": cancel rebuild co_fseq=%u\n",
+						       DP_RB_RGT(rgt), dom->do_comp.co_fseq);
 						rebuild_abort = true;
 						break;
 					}
 				}
 			}
-			D_INFO(DF_UUID" exclude rank %d/%x.\n", DP_UUID(pool->sp_uuid),
-			       dom->do_comp.co_rank, dom->do_comp.co_status);
+			D_INFO(DF_RB " exclude rank %d/%x.\n", DP_RB_RGT(rgt), dom->do_comp.co_rank,
+			       dom->do_comp.co_status);
 			rebuild_leader_set_status(rgt, dom->do_comp.co_rank,
 						  -1, SCAN_DONE | PULL_DONE);
 		}
@@ -713,15 +705,13 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 		rs->rs_seconds =
 			(d_timeus_secdiff(0) - rgt->rgt_time_start) / 1e6;
 		snprintf(sbuf, RBLD_SBUF_LEN,
-			 "%s [%s] (pool "DF_UUID" leader %u term "DF_U64" dtx gl %u ver=%u,"
-			 "gen %u toberb_obj=" DF_U64", rb_obj="DF_U64", rec="DF_U64", size="DF_U64
-			 " done %d status %d/%d  stable "DF_X64" reclaim "DF_X64
-			 " duration=%d secs)\n",
-			 RB_OP_STR(op), str, DP_UUID(pool->sp_uuid), myrank,
-			 rgt->rgt_leader_term, rgt->rgt_dtx_resync_version, rgt->rgt_rebuild_ver,
-			 rgt->rgt_rebuild_gen, rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr,
-			 rs->rs_size, rs->rs_state, rs->rs_errno, rs->rs_fail_rank,
-			 rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch, rs->rs_seconds);
+			 DF_RB " [%s] (leader %u dtx_gl %u toberb_obj=" DF_U64 ", rb_obj=" DF_U64
+			       ", rec=" DF_U64 ", size=" DF_U64 " done %d status %d/%d "
+			       "stable " DF_X64 " reclaim " DF_X64 " duration=%d secs)\n",
+			 DP_RB_RGT(rgt), str, myrank, rgt->rgt_dtx_resync_version,
+			 rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr, rs->rs_size,
+			 rs->rs_state, rs->rs_errno, rs->rs_fail_rank, rgt->rgt_stable_epoch,
+			 rgt->rgt_reclaim_epoch, rs->rs_seconds);
 
 		D_INFO("%s", sbuf);
 		if (rs->rs_state == DRS_COMPLETED || rebuild_gst.rg_abort ||
@@ -863,8 +853,8 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 {
 	int	rc = 0;
 
-	D_DEBUG(DB_REBUILD, "pool "DF_UUID" create rebuild iv, op=%s\n",
-		DP_UUID(pool->sp_uuid), RB_OP_STR(rebuild_op));
+	D_DEBUG(DB_REBUILD, DF_RB " create rebuild iv\n", DP_UUID(pool->sp_uuid), rebuild_ver,
+		rebuild_gen, RB_OP_STR(rebuild_op));
 
 	if (rebuild_op == RB_OP_UPGRADE || rebuild_op == RB_OP_RECLAIM ||
 	    rebuild_op == RB_OP_FAIL_RECLAIM) {
@@ -908,8 +898,9 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 		ret = rebuild_global_pool_tracker_create(pool, rebuild_ver, rebuild_gen,
 							leader_term, reclaim_eph, rebuild_op, rgt);
 		if (ret) {
-			D_ERROR("rebuild_global_pool_tracker create failed: "DF_RC"\n",
-				DP_RC(ret));
+			DL_ERROR(rc, DF_RB " rebuild_global_pool_tracker create failed",
+				 DP_UUID(pool->sp_uuid), rebuild_ver, rebuild_gen,
+				 RB_OP_STR(rebuild_op));
 			rc = ret;
 		}
 	}
@@ -935,7 +926,7 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 	 * but not included in this reintegration, so let's exclude those
 	 * ranks from this reintegration.
 	 */
-	D_DEBUG(DB_REBUILD, "rebuild op %d\n", rebuild_op);
+	D_DEBUG(DB_REBUILD, DF_RB "\n", DP_RB_RGT(rgt));
 	if (rebuild_op == RB_OP_REBUILD || rebuild_op == RB_OP_RECLAIM ||
 	    rebuild_op == RB_OP_FAIL_RECLAIM) {
 		d_rank_list_t	up_ranks = { 0 };
@@ -946,12 +937,11 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 		rc = map_ranks_init(pool->sp_map, PO_COMP_ST_UP, &up_ranks);
 		ABT_rwlock_unlock(pool->sp_lock);
 		if (rc != 0) {
-			D_ERROR(DF_UUID": failed to create rank list: %d\n",
-				DP_UUID(pool->sp_uuid), rc);
+			DL_ERROR(rc, DF_RB ": failed to create rank list", DP_RB_RGT(rgt));
 			return rc;
 		}
 
-		D_DEBUG(DB_REBUILD, "up_ranks %d\n", up_ranks.rl_nr);
+		D_DEBUG(DB_REBUILD, DF_RB ": up_ranks %d\n", DP_RB_RGT(rgt), up_ranks.rl_nr);
 		excluded = d_rank_list_alloc(up_ranks.rl_nr);
 		/* exclude ranks which is scheduled after the current
 		 * reintegraion started.
@@ -966,8 +956,8 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 
 			dom = pool_map_find_node_by_rank(pool->sp_map, up_ranks.rl_ranks[i]);
 			D_ASSERT(dom != NULL);
-			D_DEBUG(DB_REBUILD, "rank %u ver %u rebuild %u\n",
-				up_ranks.rl_ranks[i], dom->do_comp.co_in_ver, rgt->rgt_rebuild_ver);
+			D_DEBUG(DB_REBUILD, DF_RB " rank %u co_in_ver %u\n", DP_RB_RGT(rgt),
+				up_ranks.rl_ranks[i], dom->do_comp.co_in_ver);
 			if (dom->do_comp.co_in_ver < rgt->rgt_rebuild_ver)
 				continue;
 
@@ -982,13 +972,12 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 				  REBUILD_OBJECTS_SCAN, DAOS_REBUILD_VERSION,
 				  &rpc, NULL, excluded, NULL);
 	if (rc != 0) {
-		D_ERROR("pool map broad cast failed: rc "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB " pool map broadcast failed", DP_RB_RGT(rgt));
 		D_GOTO(out, rc);
 	}
 
 	rsi = crt_req_get(rpc);
-	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID" scan broadcast, op=%s\n",
-		DP_UUID(pool->sp_uuid), RB_OP_STR(rebuild_op));
+	D_DEBUG(DB_REBUILD, DF_RB " scan broadcast\n", DP_RB_RGT(rgt));
 
 	uuid_copy(rsi->rsi_pool_uuid, pool->sp_uuid);
 	rsi->rsi_ns_id = pool->sp_iv_ns->iv_ns_id;
@@ -1011,9 +1000,8 @@ rebuild_scan_broadcast(struct ds_pool *pool, struct rebuild_global_pool_tracker 
 
 	rgt->rgt_init_scan = 1;
 	rgt->rgt_stable_epoch = rso->rso_stable_epoch;
-	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID": "DF_RC" got stable/reclaim epoch "
-		DF_X64"/"DF_X64"\n", DP_UUID(rsi->rsi_pool_uuid), DP_RC(rc),
-		rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch);
+	D_DEBUG(DB_REBUILD, DF_RB " " DF_RC " got stable/reclaim epoch " DF_X64 "/" DF_X64 "\n",
+		DP_RB_RGT(rgt), DP_RC(rc), rgt->rgt_stable_epoch, rgt->rgt_reclaim_epoch);
 	crt_req_decref(rpc);
 out:
 	if (excluded)
@@ -1325,15 +1313,13 @@ rebuild_leader_start(struct ds_pool *pool, struct rebuild_task *task,
 		return rc;
 
 	D_ASSERT(*p_rgt != NULL);
-	D_INFO("rebuild "DF_UUID", version=%u/%u, op=%s\n",
-	       DP_UUID(pool->sp_uuid), task->dst_map_ver, pool->sp_rebuild_gen,
-	       RB_OP_STR(task->dst_rebuild_op));
+	D_INFO(DF_RB "\n", DP_RB_RGT(*p_rgt));
 
 	/* broadcast scan RPC to all targets */
 	rc = rebuild_scan_broadcast(pool, *p_rgt, &task->dst_tgts,
 				    task->dst_new_layout_version, task->dst_rebuild_op);
 	if (rc)
-		D_ERROR("object scan failed: "DF_RC"\n", DP_RC(rc));
+		DL_ERROR(rc, DF_RB ": object scan failed", DP_RB_RGT(*p_rgt));
 	else
 		rc = 1;
 
@@ -1436,7 +1422,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 
 		if (task->dst_rebuild_op == RB_OP_RECLAIM ||
 		    task->dst_rebuild_op == RB_OP_FAIL_RECLAIM) {
-			DL_INFO(ret, DF_UUID" retry opc %u/%u", DP_UUID(task->dst_pool_uuid),
+			DL_INFO(ret, DF_UUID " retry opc %u/%u", DP_UUID(task->dst_pool_uuid),
 				task->dst_rebuild_op, task->dst_map_ver);
 			rc = ds_rebuild_schedule(pool, task->dst_map_ver, rgt->rgt_stable_epoch,
 						 task->dst_new_layout_version, &task->dst_tgts,
@@ -1453,7 +1439,7 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 			 * (reclaim - 1 see obj_reclaim()), but keep the in-flight I/O data.
 			 */
 			DL_INFO(rgt->rgt_status.rs_errno,
-				DF_UUID" opc %u/%u, schedule RB_OP_FAIL_RECLAIM.",
+				DF_UUID " opc %u/%u, schedule RB_OP_FAIL_RECLAIM.",
 				DP_UUID(task->dst_pool_uuid), task->dst_rebuild_op,
 				task->dst_map_ver);
 			rc = ds_rebuild_schedule(pool, task->dst_reclaim_ver - 1,
@@ -1461,8 +1447,8 @@ rebuild_task_complete_schedule(struct rebuild_task *task, struct ds_pool *pool,
 						 task->dst_new_layout_version,
 						 &task->dst_tgts, RB_OP_FAIL_RECLAIM, 5);
 			if (rc)
-				D_ERROR(DF_UUID "schedule reclaim fail: "DF_RC"\n",
-					DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+				DL_ERROR(rc, DF_UUID " schedule reclaim fail",
+					 DP_UUID(task->dst_pool_uuid));
 		}
 
 		/* Then check if it needs to retry */
@@ -1574,9 +1560,12 @@ rebuild_task_ult(void *arg)
 		D_GOTO(output, rc);
 	}
 
-	D_PRINT("%s [started] (pool "DF_UUID" ver=%u/%u)\n",
-		RB_OP_STR(task->dst_rebuild_op), DP_UUID(task->dst_pool_uuid),
-		task->dst_map_ver, task->dst_reclaim_ver);
+	if (rgt)
+		D_PRINT(DF_RB " [started] reclaim_ver=%u\n", DP_RB_RGT(rgt), task->dst_reclaim_ver);
+	else
+		D_PRINT("%s [started] (pool " DF_UUID " ver=%u/%u)\n",
+			RB_OP_STR(task->dst_rebuild_op), DP_UUID(task->dst_pool_uuid),
+			task->dst_map_ver, task->dst_reclaim_ver);
 
 	if (rc < 0) {
 		if (rc == -DER_NOTLEADER &&
@@ -1620,8 +1609,7 @@ rebuild_task_ult(void *arg)
 done:
 	D_ASSERT(rgt != NULL);
 	if (!is_rebuild_global_done(rgt)) {
-		D_DEBUG(DB_REBUILD, DF_UUID" rebuild is not done: "DF_RC"\n",
-			DP_UUID(task->dst_pool_uuid),
+		D_DEBUG(DB_REBUILD, DF_RB " rebuild is not done: " DF_RC "\n", DP_RB_RGT(rgt),
 			DP_RC(rgt->rgt_status.rs_errno));
 
 		if (rgt->rgt_abort && rgt->rgt_status.rs_errno == 0) {
@@ -1631,8 +1619,7 @@ done:
 			 * scan requests, which will then become the new
 			 * leader to track the rebuild.
 			 */
-			D_DEBUG(DB_REBUILD, DF_UUID" Only stop the leader\n",
-				DP_UUID(task->dst_pool_uuid));
+			D_DEBUG(DB_REBUILD, DF_RB " Only stop the leader\n", DP_RB_RGT(rgt));
 			D_GOTO(out_pool, rc);
 		}
 	} else if (rgt->rgt_status.rs_errno == 0) {
@@ -1641,8 +1628,8 @@ done:
 
 		if (task->dst_rebuild_op == RB_OP_REBUILD)
 			rc = ds_pool_tgt_finish_rebuild(pool->sp_uuid, &task->dst_tgts);
-		D_INFO("finish rebuild %d of " DF_UUID " "DF_RC"\n",
-		       task->dst_tgts.pti_ids[0].pti_id, DP_UUID(task->dst_pool_uuid), DP_RC(rc));
+		DL_INFO(rc, DF_RB " finish rebuild %d", DP_RB_RGT(rgt),
+			task->dst_tgts.pti_ids[0].pti_id);
 	}
 iv_stop:
 	/* NB: even if there are some failures, the leader should
@@ -1655,8 +1642,8 @@ iv_stop:
 			 * iv sync, and the new leader will take over
 			 * the rebuild process anyway.
 			 */
-			D_DEBUG(DB_REBUILD, "rank %u != master %u\n",
-				myrank, pool->sp_iv_ns->iv_master_rank);
+			D_DEBUG(DB_REBUILD, DF_RB " rank %u != master %u\n", DP_RB_RGT(rgt), myrank,
+				pool->sp_iv_ns->iv_master_rank);
 			D_GOTO(try_reschedule, rc);
 		}
 
@@ -1801,9 +1788,7 @@ ds_rebuild_abort(uuid_t pool_uuid, unsigned int ver, unsigned int gen, uint64_t 
 			    (ver == (unsigned int)(-1) || rpt->rt_rebuild_ver == ver) &&
 			    (gen == (unsigned int)(-1) || rpt->rt_rebuild_gen == gen) &&
 			    (term == (uint64_t)(-1) || rpt->rt_leader_term == term)) {
-				D_INFO(DF_UUID" try abort the rpt %p op %s ver %u gen %u\n",
-				       DP_UUID(rpt->rt_pool_uuid), rpt, RB_OP_STR(rpt->rt_rebuild_op),
-				       rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
+				D_INFO(DF_RB " try abort rpt %p\n", DP_RB_RPT(rpt), rpt);
 				rpt->rt_abort = 1;
 				aborted = false;
 			}
@@ -2176,14 +2161,13 @@ rebuild_fini_one(void *arg)
 	if (rpt->rt_rebuild_fence == dpc->spc_rebuild_fence) {
 		dpc->spc_rebuild_fence = 0;
 		dpc->spc_rebuild_end_hlc = d_hlc_get();
-		D_DEBUG(DB_REBUILD, DF_UUID": Reset aggregation end hlc "
-			DF_U64"\n", DP_UUID(rpt->rt_pool_uuid),
-			dpc->spc_rebuild_end_hlc);
+		D_DEBUG(DB_REBUILD, DF_RB ": Reset aggregation end hlc " DF_U64 "\n",
+			DP_RB_RPT(rpt), dpc->spc_rebuild_end_hlc);
 	} else {
-		D_DEBUG(DB_REBUILD, DF_UUID": pool is still being rebuilt"
-			" rt_rebuild_fence "DF_U64" spc_rebuild_fence "
-			DF_U64"\n", DP_UUID(rpt->rt_pool_uuid),
-			rpt->rt_rebuild_fence, dpc->spc_rebuild_fence);
+		D_DEBUG(DB_REBUILD,
+			DF_RB ": pool is still being rebuilt rt_rebuild_fence " DF_U64
+			      " spc_rebuild_fence " DF_U64 "\n",
+			DP_RB_RPT(rpt), rpt->rt_rebuild_fence, dpc->spc_rebuild_fence);
 	}
 
 	ds_pool_child_put(dpc);
@@ -2197,8 +2181,7 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	struct rebuild_pool_tls	*pool_tls;
 	int			 rc;
 
-	D_INFO("finishing rebuild for "DF_UUID", map_ver=%u refcount %u\n",
-	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver, rpt->rt_refcount);
+	D_INFO(DF_RB " finishing rebuild refcount %u\n", DP_RB_RPT(rpt), rpt->rt_refcount);
 
 	D_ASSERT(rpt->rt_pool->sp_rebuilding > 0);
 	rpt->rt_pool->sp_rebuilding--;
@@ -2228,13 +2211,11 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 	/* close the rebuild pool/container on all main XS */
 	rc = dss_task_collective(rebuild_fini_one, rpt, 0);
 	if (rc != 0)
-		D_WARN(DF_UUID" rebuild fini one failed: "DF_RC"\n",
-		       DP_UUID(rpt->rt_pool_uuid), DP_RC(rc));
+		DL_WARN(rc, DF_RB " rebuild fini one failed", DP_RB_RPT(rpt));
 	/* destroy the migrate_tls of 0-xstream */
 	ds_migrate_stop(rpt->rt_pool, rpt->rt_rebuild_ver, rpt->rt_rebuild_gen);
 	/* No one should access rpt after rebuild_fini_one. */
-	D_INFO("Finalized rebuild for "DF_UUID", map_ver=%u.\n",
-	       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver);
+	D_INFO(DF_RB " Finalized rebuild\n", DP_RB_RPT(rpt));
 	rpt_delete(rpt);
 	rpt_put(rpt);
 }
@@ -2265,9 +2246,7 @@ rebuild_tgt_status_check_ult(void *arg)
 		rc = rebuild_tgt_query(rpt, &status);
 		ABT_mutex_free(&status.lock);
 		if (rc || status.status != 0) {
-			D_ERROR(DF_UUID" rebuild failed: "DF_RC"\n",
-				DP_UUID(rpt->rt_pool_uuid),
-				DP_RC(rc == 0 ? status.status : rc));
+			DL_ERROR(rc == 0 ? status.status : rc, DF_RB " failed", DP_RB_RPT(rpt));
 			if (status.status == 0)
 				status.status = rc;
 			if (rpt->rt_errno == 0)
@@ -2350,7 +2329,7 @@ rebuild_tgt_status_check_ult(void *arg)
 				rpt->rt_reported_rec_cnt = status.rec_count;
 				rpt->rt_reported_size = status.size;
 			} else {
-				D_WARN("rebuild iv update failed: %d\n", rc);
+				DL_WARN(rc, DF_RB " rebuild iv update failed", DP_RB_RPT(rpt));
 				/* Already finish rebuilt, but it can not
 				 * its rebuild status on the leader, i.e.
 				 * it can not find the IV see crt_iv_hdlr_xx().
@@ -2360,21 +2339,17 @@ rebuild_tgt_status_check_ult(void *arg)
 					rpt->rt_global_done = 1;
 
 				if (ns->iv_stop) {
-					D_DEBUG(DB_REBUILD, "abort rebuild "
-						DF_UUID"\n",
-						DP_UUID(rpt->rt_pool_uuid));
+					D_DEBUG(DB_REBUILD, "abort rebuild " DF_RB "\n",
+						DP_RB_RPT(rpt));
 					rpt->rt_abort = 1;
 				}
 			}
 		}
 
-		D_INFO(DF_UUID" ver %d gen %u obj "DF_U64" rec "DF_U64" size "
-		       DF_U64" scan done %d pull done %d scan gl done %d"
-		       " gl done %d status %d abort %s\n",
-		       DP_UUID(rpt->rt_pool_uuid), rpt->rt_rebuild_ver,
-		       rpt->rt_pool->sp_rebuild_gen,
-		       iv.riv_obj_count, iv.riv_rec_count, iv.riv_size, rpt->rt_scan_done,
-		       iv.riv_pull_done, rpt->rt_global_scan_done,
+		D_INFO(DF_RB " obj " DF_U64 " rec " DF_U64 " size " DF_U64 " scan done %d "
+			     "pull done %d scan gl done %d gl done %d status %d abort %s\n",
+		       DP_RB_RPT(rpt), iv.riv_obj_count, iv.riv_rec_count, iv.riv_size,
+		       rpt->rt_scan_done, iv.riv_pull_done, rpt->rt_global_scan_done,
 		       rpt->rt_global_done, iv.riv_status, rpt->rt_abort ? "yes" : "no");
 		if (rpt->rt_global_done || rpt->rt_abort)
 			break;
@@ -2412,9 +2387,7 @@ rebuild_prepare_one(void *data)
 	if (unlikely(dpc->spc_no_storage))
 		D_GOTO(put, rc = 0);
 
-	pool_tls = rebuild_pool_tls_create(rpt->rt_pool_uuid, rpt->rt_poh_uuid,
-					   rpt->rt_coh_uuid, rpt->rt_rebuild_ver,
-					   rpt->rt_rebuild_gen);
+	pool_tls = rebuild_pool_tls_create(rpt);
 	if (pool_tls == NULL)
 		D_GOTO(put, rc = -DER_NOMEM);
 
@@ -2425,9 +2398,8 @@ rebuild_prepare_one(void *data)
 	 */
 	D_ASSERT(rpt->rt_rebuild_fence != 0);
 	dpc->spc_rebuild_fence = rpt->rt_rebuild_fence;
-	D_DEBUG(DB_REBUILD, "open local container "DF_UUID"/"DF_UUID
-		" rebuild eph "DF_X64" "DF_RC"\n", DP_UUID(rpt->rt_pool_uuid),
-		DP_UUID(rpt->rt_coh_uuid), rpt->rt_rebuild_fence, DP_RC(rc));
+	D_DEBUG(DB_REBUILD, DF_RB " open local container " DF_UUID " rebuild eph " DF_X64 "\n",
+		DP_RB_RPT(rpt), DP_UUID(rpt->rt_coh_uuid), rpt->rt_rebuild_fence);
 
 put:
 	ds_pool_child_put(dpc);
@@ -2500,19 +2472,17 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	uuid_t				cont_uuid;
 	int				rc;
 
-	D_DEBUG(DB_REBUILD, "prepare rebuild for "DF_UUID"/%d\n",
-		DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver);
+	D_DEBUG(DB_REBUILD, DF_RB " prepare rebuild\n", DP_RB_RSI(rsi));
 
 	rc = ds_pool_lookup(rsi->rsi_pool_uuid, &pool);
 	if (rc) {
-		D_ERROR("Can not find pool "DF_UUID": %d\n", DP_UUID(rsi->rsi_pool_uuid), rc);
+		DL_ERROR(rc, DF_RB " cannot find pool", DP_RB_RSI(rsi));
 		return rc;
 	}
 
 	if (ds_pool_get_version(pool) < rsi->rsi_rebuild_ver) {
-		D_INFO(DF_UUID" map %u < rsi_rebuild_ver %u\n",
-		       DP_UUID(rsi->rsi_pool_uuid), ds_pool_get_version(pool),
-		       rsi->rsi_rebuild_ver);
+		D_INFO(DF_RB " map %u < rsi_rebuild_ver %u\n", DP_RB_RSI(rsi),
+		       ds_pool_get_version(pool), rsi->rsi_rebuild_ver);
 		D_GOTO(out, rc = -DER_BUSY);
 	}
 
@@ -2551,7 +2521,7 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	if (rc)
 		D_GOTO(out, rc);
 
-	D_DEBUG(DB_REBUILD, "rebuild coh/poh "DF_UUID"/"DF_UUID"\n",
+	D_DEBUG(DB_REBUILD, DF_RB " coh/poh " DF_UUID "/" DF_UUID "\n", DP_RB_RPT(rpt),
 		DP_UUID(rpt->rt_coh_uuid), DP_UUID(rpt->rt_poh_uuid));
 
 	ds_pool_iv_ns_update(pool, rsi->rsi_master_rank, rsi->rsi_leader_term);
@@ -2567,9 +2537,7 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	if (rc)
 		D_GOTO(out, rc);
 
-	pool_tls = rebuild_pool_tls_create(rpt->rt_pool_uuid, rpt->rt_poh_uuid,
-					   rpt->rt_coh_uuid, rpt->rt_rebuild_ver,
-					   rpt->rt_rebuild_gen);
+	pool_tls = rebuild_pool_tls_create(rpt);
 	if (pool_tls == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -189,6 +189,20 @@ rebuild_leader_set_status(struct rebuild_global_pool_tracker *rgt,
 		status->pull_done = 1;
 }
 
+static void
+rebuild_leader_set_update_time(struct rebuild_global_pool_tracker *rgt, d_rank_t rank)
+{
+	int i;
+
+	for (i = 0; i < rgt->rgt_servers_number; i++) {
+		if (rgt->rgt_servers[i].rank == rank) {
+			rgt->rgt_servers_last_update[i] = ABT_get_wtime();
+			return;
+		}
+	}
+	D_INFO("rank %u is not included in this rebuild.\n", rank);
+}
+
 static uint32_t
 rebuild_get_global_dtx_resync_ver(struct rebuild_global_pool_tracker *rgt)
 {
@@ -261,6 +275,8 @@ int
 rebuild_global_status_update(struct rebuild_global_pool_tracker *rgt,
 			     struct rebuild_iv *iv)
 {
+	rebuild_leader_set_update_time(rgt, iv->riv_rank);
+
 	D_DEBUG(DB_REBUILD, "iv rank %d scan_done %d pull_done %d resync dtx %u\n",
 		iv->riv_rank, iv->riv_scan_done, iv->riv_pull_done,
 		iv->riv_dtx_resyc_version);
@@ -598,6 +614,38 @@ enum {
 	RB_BCAST_QUERY,
 };
 
+static void
+warn_for_slow_engine_updates(struct rebuild_global_pool_tracker *rgt)
+{
+	int    i;
+	double now    = ABT_get_wtime();
+	double tw     = now - rgt->rgt_last_warn; /* time since last warning logged */
+	bool   warned = false;
+
+	for (i = 0; i < rgt->rgt_servers_number; i++) {
+		/* tu: time since the most recent update from engine rank rgt_server[i].rank */
+		double   tu = now - rgt->rgt_servers_last_update[i];
+		d_rank_t r  = rgt->rgt_servers[i].rank;
+
+		if (rgt->rgt_servers[i].scan_done && rgt->rgt_servers[i].pull_done)
+			continue;
+
+		/* Warn if it's been a while (> 30 seconds) since receiving an update from the rank.
+		 * And throttle warnings - do not print more than once per 2 minutes period.
+		 */
+		if ((tu > 30) && (tw > 120)) {
+			D_WARN(DF_RB ": no updates from rank %u in %8.3f seconds. "
+				     "scan_done=%d pull_done=%d\n",
+			       DP_RB_RGT(rgt), r, tu, rgt->rgt_servers[i].scan_done,
+			       rgt->rgt_servers[i].pull_done);
+			warned = true;
+		}
+	}
+
+	if (warned)
+		rgt->rgt_last_warn = now;
+}
+
 /*
  * Check rebuild status on the leader. Every other target sends
  * its own rebuild status by IV.
@@ -727,6 +775,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t op,
 			D_PRINT("%s", sbuf);
 		}
 sleep:
+		warn_for_slow_engine_updates(rgt);
 		sched_req_sleep(rgt->rgt_ult, RBLD_CHECK_INTV);
 	}
 
@@ -741,6 +790,8 @@ rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 	d_list_del(&rgt->rgt_list);
 	if (rgt->rgt_servers)
 		D_FREE(rgt->rgt_servers);
+	if (rgt->rgt_servers_last_update)
+		D_FREE(rgt->rgt_servers_last_update);
 
 	if (rgt->rgt_lock)
 		ABT_mutex_free(&rgt->rgt_lock);
@@ -759,6 +810,7 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t 
 	struct rebuild_global_pool_tracker *rgt;
 	int node_nr;
 	struct pool_domain *doms;
+	double                              now;
 	int i;
 	int rc = 0;
 
@@ -774,6 +826,14 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver, uint32_t 
 	D_ALLOC_ARRAY(rgt->rgt_servers, node_nr);
 	if (rgt->rgt_servers == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
+	D_ALLOC_ARRAY(rgt->rgt_servers_last_update, node_nr);
+	if (rgt->rgt_servers_last_update == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	now                = ABT_get_wtime();
+	rgt->rgt_last_warn = now;
+	for (i = 0; i < node_nr; i++)
+		rgt->rgt_servers_last_update[i] = now;
 
 	rc = ABT_mutex_create(&rgt->rgt_lock);
 	if (rc != ABT_SUCCESS)
@@ -898,10 +958,10 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 		ret = rebuild_global_pool_tracker_create(pool, rebuild_ver, rebuild_gen,
 							leader_term, reclaim_eph, rebuild_op, rgt);
 		if (ret) {
+			rc = ret;
 			DL_ERROR(rc, DF_RB " rebuild_global_pool_tracker create failed",
 				 DP_UUID(pool->sp_uuid), rebuild_ver, rebuild_gen,
 				 RB_OP_STR(rebuild_op));
-			rc = ret;
 		}
 	}
 

--- a/src/tests/ftest/erasurecode/offline_rebuild_single.yaml
+++ b/src/tests/ftest/erasurecode/offline_rebuild_single.yaml
@@ -10,6 +10,9 @@ hosts:
 setup:
   start_servers_once: False
 timeout: 900
+agent_config:
+  #cache_expiration: 1
+  disable_caching: true
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/erasurecode/online_rebuild.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild.yaml
@@ -11,6 +11,9 @@ timeout: 1000
 setup:
   start_agents_once: False
   start_servers_once: False
+agent_config:
+  #cache_expiration: 1
+  disable_caching: true
 server_config:
   name: daos_server
   engines_per_host: 2

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -2,6 +2,9 @@ hosts:
   test_servers: 6
   test_clients: 1
 timeout: 420
+agent_config:
+  #cache_expiration: 1
+  disable_caching: true
 server_config:
   name: daos_server
   engines_per_host: 1


### PR DESCRIPTION
To the extent possible in the rebuild code execution flow, when rebuild
emits log messages, include a uniform rebuild operation identifier in
those messages. This covers activities across all pool storage engines
(including the pool service leader), system and per-target
threads/xstreams, and dynamically spawned user-level threads.

The motivation is to enable some amount of automated searching through
logfiles for all (or specific) rebuilds that occurred during execution,
and speed up DAOS engineer analysis/interpretation of the logs.

The baseline format (defined in the DF_RB macro) is:
"rb=" DF_UUID "/%u/%u/%s"
and corresponds to:
<pool_uuid>/<rebuild_ver>/<rebuild_gen>/

A verbose format (defined in the DF_RBF macro) adds the following
(for <leader_rank>/)
" ld=%u/" DF_U64

Various DP_RB_* and DP_RBF_* macros are defined to specify the
arguments to go with the DF_RB and DF_RBF formats, given some
common rebuild implementation structures such as:
struct rebuild_global_pool_tracker
struct rebuild_tgt_pool_tracker
struct rebuild_scan_in (REBUILD_OBJECTS_SCAN RPC input)
struct migrate_query_arg

This initial patch covers the pool service leader execution in
functions (and those that they invoke) such as:
rebuild_ults()
rebuild_task_ult()
rebuild_leader_start()
rebuild_leader_status_check()
rebuild_leader_status_notify().

And this patch covers "scan side" execution in all pool storage engines
(including the leader), in functions such as:
rebuild_tgt_scan_handler()
rebuild_tgt_status_check_ult()
ds_migrate_query_status()
migrate_check_one()
dss_rebuild_check_one()
rebuild_scan_leader()
rebuild_scanner()
rebuild_objects_send_ult()
rebuild_scan_done()


Rebuild migrate activities are also modified to use the new format.
Macros DP_RB_OMI, DP_RB_MPT, and DP_RB_MRO accept
struct obj_migrate_in *omi, struct migrate_pool_tls *mpt, and
struct migrate_one *mro, respectively, to provide the values needed for
the DF_RB logging format. 

Also in this change is some logic added to rebuild_leader_status_check():
a new function, warn_for_slow_engine_updates(). This allows a PS leader
engine to emit warnings when an engine is not reporting its rebuild
progress (via IV) for a long amount of time, making it easier for an
engineer to identify what engine(s) may be causing a stuck rebuild.
The warning messages are throttled to avoid too many log file entries.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-test: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
