### PR TITLE
DAOS-15874 control: Add optional credential cache to agent (#14412)

### DIFF
--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -47,6 +47,7 @@ disable_caching: true
 cache_expiration: 30
 disable_auto_evict: true
 credential_config:
+  cache_expiration: 10m
   client_user_map:
     1000:
       user: frodo
@@ -140,6 +141,7 @@ transport_config:
 				CacheExpiration:  refreshMinutes(30 * time.Minute),
 				DisableAutoEvict: true,
 				CredentialConfig: &security.CredentialConfig{
+					CacheExpiration: time.Minute * 10,
 					ClientUserMap: map[uint32]*security.MappedClientUser{
 						1000: {
 							User:   "frodo",

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -80,11 +80,12 @@ func getFabricScanFn(log logging.Logger, cfg *Config, scanner *hardware.FabricSc
 }
 
 type cacheItem struct {
-	sync.Mutex
+	sync.RWMutex
 	lastCached      time.Time
 	refreshInterval time.Duration
 }
 
+// isStale returns true if the cache item is stale.
 func (ci *cacheItem) isStale() bool {
 	if ci.refreshInterval == 0 {
 		return false
@@ -92,9 +93,12 @@ func (ci *cacheItem) isStale() bool {
 	return ci.lastCached.Add(ci.refreshInterval).Before(time.Now())
 }
 
+// isCached returns true if the cache item is cached.
 func (ci *cacheItem) isCached() bool {
 	return !ci.lastCached.Equal(time.Time{})
 }
+
+var _ cache.RefreshableItem = (*cachedAttachInfo)(nil)
 
 type cachedAttachInfo struct {
 	cacheItem
@@ -130,16 +134,28 @@ func (ci *cachedAttachInfo) Key() string {
 	return sysAttachInfoKey(ci.system)
 }
 
-// NeedsRefresh checks whether the cached data needs to be refreshed.
-func (ci *cachedAttachInfo) NeedsRefresh() bool {
+// needsRefresh checks whether the cached data needs to be refreshed.
+func (ci *cachedAttachInfo) needsRefresh() bool {
 	if ci == nil {
 		return false
 	}
 	return !ci.isCached() || ci.isStale()
 }
 
-// Refresh contacts the remote management server and refreshes the GetAttachInfo cache.
-func (ci *cachedAttachInfo) Refresh(ctx context.Context) error {
+// RefreshIfNeeded refreshes the cached data if it needs to be refreshed.
+func (ci *cachedAttachInfo) RefreshIfNeeded(ctx context.Context) (bool, error) {
+	if ci == nil {
+		return false, errors.New("cachedAttachInfo is nil")
+	}
+
+	if ci.needsRefresh() {
+		return true, ci.refresh(ctx)
+	}
+	return false, nil
+}
+
+// refresh implements the actual refresh logic.
+func (ci *cachedAttachInfo) refresh(ctx context.Context) error {
 	if ci == nil {
 		return errors.New("cachedAttachInfo is nil")
 	}
@@ -154,6 +170,17 @@ func (ci *cachedAttachInfo) Refresh(ctx context.Context) error {
 	ci.lastCached = time.Now()
 	return nil
 }
+
+// Refresh contacts the remote management server and refreshes the GetAttachInfo cache.
+func (ci *cachedAttachInfo) Refresh(ctx context.Context) error {
+	if ci == nil {
+		return errors.New("cachedAttachInfo is nil")
+	}
+
+	return ci.refresh(ctx)
+}
+
+var _ cache.RefreshableItem = (*cachedFabricInfo)(nil)
 
 type cachedFabricInfo struct {
 	cacheItem
@@ -172,17 +199,21 @@ func (cfi *cachedFabricInfo) Key() string {
 	return fabricKey
 }
 
-// NeedsRefresh indicates that the fabric information does not need to be refreshed unless it has
-// never been populated.
-func (cfi *cachedFabricInfo) NeedsRefresh() bool {
+// RefreshIfNeeded refreshes the cached fabric information if it needs to be refreshed.
+func (cfi *cachedFabricInfo) RefreshIfNeeded(ctx context.Context) (bool, error) {
 	if cfi == nil {
-		return false
+		return false, errors.New("cachedFabricInfo is nil")
 	}
-	return !cfi.isCached()
+
+	if !cfi.isCached() {
+		return true, cfi.refresh(ctx)
+	}
+
+	return false, nil
 }
 
-// Refresh scans the hardware for information about the fabric devices and caches the result.
-func (cfi *cachedFabricInfo) Refresh(ctx context.Context) error {
+// refresh implements the actual refresh logic.
+func (cfi *cachedFabricInfo) refresh(ctx context.Context) error {
 	if cfi == nil {
 		return errors.New("cachedFabricInfo is nil")
 	}
@@ -195,6 +226,15 @@ func (cfi *cachedFabricInfo) Refresh(ctx context.Context) error {
 	cfi.lastResults = results
 	cfi.lastCached = time.Now()
 	return nil
+}
+
+// Refresh scans the hardware for information about the fabric devices and caches the result.
+func (cfi *cachedFabricInfo) Refresh(ctx context.Context) error {
+	if cfi == nil {
+		return errors.New("cachedFabricInfo is nil")
+	}
+
+	return cfi.refresh(ctx)
 }
 
 // InfoCache is a cache for the results of expensive operations needed by the agent.
@@ -349,15 +389,14 @@ func (c *InfoCache) GetAttachInfo(ctx context.Context, sys string) (*control.Get
 	}
 	createItem := func() (cache.Item, error) {
 		c.log.Debugf("cache miss for %s", sysAttachInfoKey(sys))
-		cai := newCachedAttachInfo(c.attachInfoRefresh, sys, c.client, c.getAttachInfo)
-		return cai, nil
+		return newCachedAttachInfo(c.attachInfoRefresh, sys, c.client, c.getAttachInfo), nil
 	}
 
 	item, release, err := c.cache.GetOrCreate(ctx, sysAttachInfoKey(sys), createItem)
-	defer release()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting attach info from cache")
 	}
+	defer release()
 
 	cai, ok := item.(*cachedAttachInfo)
 	if !ok {

--- a/src/control/cmd/daos_agent/infocache_test.go
+++ b/src/control/cmd/daos_agent/infocache_test.go
@@ -149,14 +149,22 @@ func TestAgent_cachedAttachInfo_Key(t *testing.T) {
 	}
 }
 
-func TestAgent_cachedAttachInfo_NeedsRefresh(t *testing.T) {
+func TestAgent_cachedAttachInfo_RefreshIfNeeded(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+	mockClient := control.NewMockInvoker(log, &control.MockInvokerConfig{})
+
+	noopGetAttachInfo := func(_ context.Context, _ control.UnaryInvoker, _ *control.GetAttachInfoReq) (*control.GetAttachInfoResp, error) {
+		return nil, nil
+	}
+
 	for name, tc := range map[string]struct {
 		ai        *cachedAttachInfo
 		expResult bool
 	}{
 		"nil": {},
 		"never cached": {
-			ai:        newCachedAttachInfo(0, "test", nil, nil),
+			ai:        newCachedAttachInfo(0, "test", mockClient, noopGetAttachInfo),
 			expResult: true,
 		},
 		"no refresh": {
@@ -164,6 +172,8 @@ func TestAgent_cachedAttachInfo_NeedsRefresh(t *testing.T) {
 				cacheItem: cacheItem{
 					lastCached: time.Now().Add(-time.Minute),
 				},
+				rpcClient:    mockClient,
+				fetch:        noopGetAttachInfo,
 				lastResponse: &control.GetAttachInfoResp{},
 			},
 		},
@@ -173,6 +183,8 @@ func TestAgent_cachedAttachInfo_NeedsRefresh(t *testing.T) {
 					lastCached:      time.Now().Add(-time.Minute),
 					refreshInterval: time.Second,
 				},
+				rpcClient:    mockClient,
+				fetch:        noopGetAttachInfo,
 				lastResponse: &control.GetAttachInfoResp{},
 			},
 			expResult: true,
@@ -183,12 +195,15 @@ func TestAgent_cachedAttachInfo_NeedsRefresh(t *testing.T) {
 					lastCached:      time.Now().Add(-time.Second),
 					refreshInterval: time.Minute,
 				},
+				rpcClient:    mockClient,
+				fetch:        noopGetAttachInfo,
 				lastResponse: &control.GetAttachInfoResp{},
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			test.AssertEqual(t, tc.expResult, tc.ai.NeedsRefresh(), "")
+			refreshed, _ := tc.ai.RefreshIfNeeded(test.Context(t))
+			test.AssertEqual(t, tc.expResult, refreshed, "")
 		})
 	}
 }
@@ -272,7 +287,6 @@ func TestAgent_cachedAttachInfo_Refresh(t *testing.T) {
 			}
 
 			err := ai.Refresh(test.Context(t))
-
 			test.CmpErr(t, tc.expErr, err)
 
 			if ai == nil {
@@ -320,7 +334,7 @@ func TestAgent_cachedFabricInfo_Key(t *testing.T) {
 	}
 }
 
-func TestAgent_cachedFabricInfo_NeedsRefresh(t *testing.T) {
+func TestAgent_cachedFabricInfo_RefreshIfNeeded(t *testing.T) {
 	for name, tc := range map[string]struct {
 		nilCache  bool
 		cacheTime time.Time
@@ -342,11 +356,14 @@ func TestAgent_cachedFabricInfo_NeedsRefresh(t *testing.T) {
 
 			var cfi *cachedFabricInfo
 			if !tc.nilCache {
-				cfi = newCachedFabricInfo(log, nil)
+				cfi = newCachedFabricInfo(log, func(_ context.Context, _ ...string) (*NUMAFabric, error) {
+					return nil, nil
+				})
 				cfi.cacheItem.lastCached = tc.cacheTime
 			}
 
-			test.AssertEqual(t, tc.expResult, cfi.NeedsRefresh(), "")
+			refreshed, _ := cfi.RefreshIfNeeded(test.Context(t))
+			test.AssertEqual(t, tc.expResult, refreshed, "")
 		})
 	}
 }
@@ -417,7 +434,6 @@ func TestAgent_cachedFabricInfo_Refresh(t *testing.T) {
 			}
 
 			err := cfi.Refresh(test.Context(t))
-
 			test.CmpErr(t, tc.expErr, err)
 
 			if cfi == nil {

--- a/src/control/cmd/daos_agent/mgmt_rpc_test.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
+	"github.com/daos-stack/daos/src/control/lib/atm"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
@@ -345,7 +346,7 @@ func TestAgent_mgmtModule_getNUMANode(t *testing.T) {
 
 			mod := &mgmtModule{
 				log:            log,
-				useDefaultNUMA: tc.useDefaultNUMA,
+				useDefaultNUMA: atm.NewBool(tc.useDefaultNUMA),
 				numaGetter:     tc.numaGetter,
 			}
 

--- a/src/control/cmd/daos_agent/security_rpc.go
+++ b/src/control/cmd/daos_agent/security_rpc.go
@@ -8,12 +8,15 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os/user"
+	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/lib/cache"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
@@ -21,7 +24,24 @@ import (
 )
 
 type (
-	credSignerFn func(*auth.CredentialRequest) (*auth.Credential, error)
+	// credSignerFn defines the function signature for signing credentials.
+	credSignerFn func(context.Context, *auth.CredentialRequest) (*auth.Credential, error)
+
+	// credentialCache implements a cache for signed credentials.
+	credentialCache struct {
+		log          logging.Logger
+		cache        *cache.ItemCache
+		credLifetime time.Duration
+		cacheMissFn  credSignerFn
+	}
+
+	// cachedCredential wraps a cached credential and implements the cache.ExpirableItem interface.
+	cachedCredential struct {
+		cacheItem
+		key       string
+		expiredAt time.Time
+		cred      *auth.Credential
+	}
 
 	// securityConfig defines configuration parameters for SecurityModule.
 	securityConfig struct {
@@ -33,32 +53,110 @@ type (
 	SecurityModule struct {
 		log            logging.Logger
 		signCredential credSignerFn
+		credCache      *credentialCache
 
 		config *securityConfig
 	}
 )
 
-// NewSecurityModule creates a new module with the given initialized TransportConfig
+var _ cache.ExpirableItem = (*cachedCredential)(nil)
+
+// NewSecurityModule creates a new module with the given initialized TransportConfig.
 func NewSecurityModule(log logging.Logger, cfg *securityConfig) *SecurityModule {
+	var credCache *credentialCache
+	credSigner := auth.GetSignedCredential
+	if cfg.credentials.CacheExpiration > 0 {
+		credCache = &credentialCache{
+			log:          log,
+			cache:        cache.NewItemCache(log),
+			credLifetime: cfg.credentials.CacheExpiration,
+			cacheMissFn:  auth.GetSignedCredential,
+		}
+		credSigner = credCache.getSignedCredential
+		log.Noticef("credential cache enabled (entry lifetime: %s)", cfg.credentials.CacheExpiration)
+	}
+
 	return &SecurityModule{
 		log:            log,
-		signCredential: auth.GetSignedCredential,
+		signCredential: credSigner,
+		credCache:      credCache,
 		config:         cfg,
 	}
 }
 
+func credReqKey(req *auth.CredentialRequest) string {
+	return fmt.Sprintf("%d:%d:%s", req.DomainInfo.Uid(), req.DomainInfo.Gid(), req.DomainInfo.Ctx())
+}
+
+// Key returns the key for the cached credential.
+func (cred *cachedCredential) Key() string {
+	if cred == nil {
+		return ""
+	}
+
+	return cred.key
+}
+
+// IsExpired returns true if the cached credential is expired.
+func (cred *cachedCredential) IsExpired() bool {
+	if cred == nil || cred.cred == nil || cred.expiredAt.IsZero() {
+		return true
+	}
+
+	return time.Now().After(cred.expiredAt)
+}
+
+func (cc *credentialCache) getSignedCredential(ctx context.Context, req *auth.CredentialRequest) (*auth.Credential, error) {
+	key := credReqKey(req)
+
+	createItem := func() (cache.Item, error) {
+		cc.log.Tracef("cache miss for %s", key)
+		cred, err := cc.cacheMissFn(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		cc.log.Tracef("getting credential for %s", key)
+		return newCachedCredential(key, cred, cc.credLifetime)
+	}
+
+	item, release, err := cc.cache.GetOrCreate(ctx, key, createItem)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting cached credential from cache")
+	}
+	defer release()
+
+	cachedCred, ok := item.(*cachedCredential)
+	if !ok {
+		return nil, errors.New("invalid cached credential")
+	}
+
+	return cachedCred.cred, nil
+}
+
+func newCachedCredential(key string, cred *auth.Credential, lifetime time.Duration) (*cachedCredential, error) {
+	if cred == nil {
+		return nil, errors.New("credential is nil")
+	}
+
+	return &cachedCredential{
+		key:       key,
+		cred:      cred,
+		expiredAt: time.Now().Add(lifetime),
+	}, nil
+}
+
 // HandleCall is the handler for calls to the SecurityModule
-func (m *SecurityModule) HandleCall(_ context.Context, session *drpc.Session, method drpc.Method, body []byte) ([]byte, error) {
+func (m *SecurityModule) HandleCall(ctx context.Context, session *drpc.Session, method drpc.Method, body []byte) ([]byte, error) {
 	if method != drpc.MethodRequestCredentials {
 		return nil, drpc.UnknownMethodFailure()
 	}
 
-	return m.getCredential(session)
+	return m.getCredential(ctx, session)
 }
 
 // getCredentials generates a signed user credential based on the data attached to
 // the Unix Domain Socket.
-func (m *SecurityModule) getCredential(session *drpc.Session) ([]byte, error) {
+func (m *SecurityModule) getCredential(ctx context.Context, session *drpc.Session) ([]byte, error) {
 	if session == nil {
 		return nil, drpc.NewFailureWithMessage("session is nil")
 	}
@@ -82,7 +180,7 @@ func (m *SecurityModule) getCredential(session *drpc.Session) ([]byte, error) {
 	}
 
 	req := auth.NewCredentialRequest(info, signingKey)
-	cred, err := m.signCredential(req)
+	cred, err := m.signCredential(ctx, req)
 	if err != nil {
 		if err := func() error {
 			if !errors.Is(err, user.UnknownUserIdError(info.Uid())) {
@@ -95,7 +193,7 @@ func (m *SecurityModule) getCredential(session *drpc.Session) ([]byte, error) {
 			}
 
 			req.WithUserAndGroup(mu.User, mu.Group, mu.Groups...)
-			cred, err = m.signCredential(req)
+			cred, err = m.signCredential(ctx, req)
 			if err != nil {
 				return err
 			}
@@ -107,7 +205,6 @@ func (m *SecurityModule) getCredential(session *drpc.Session) ([]byte, error) {
 		}
 	}
 
-	m.log.Tracef("%s: successfully signed credential", info)
 	resp := &auth.GetCredResp{Cred: cred}
 	return drpc.Marshal(resp)
 }

--- a/src/control/cmd/daos_agent/security_rpc_test.go
+++ b/src/control/cmd/daos_agent/security_rpc_test.go
@@ -7,14 +7,18 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"net"
 	"os/user"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/drpc"
@@ -28,7 +32,7 @@ func TestAgentSecurityModule_ID(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
-	mod := NewSecurityModule(log, nil)
+	mod := NewSecurityModule(log, defaultTestSecurityConfig())
 
 	test.AssertEqual(t, mod.ID(), drpc.ModuleSecurityAgent, "wrong drpc module")
 }
@@ -49,7 +53,7 @@ func TestAgentSecurityModule_BadMethod(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
-	mod := NewSecurityModule(log, nil)
+	mod := NewSecurityModule(log, defaultTestSecurityConfig())
 	method, err := mod.ID().GetMethod(-1)
 	if method != nil {
 		t.Errorf("Expected no method, got %+v", method)
@@ -166,7 +170,8 @@ func TestAgentSecurityModule_RequestCreds_BadConfig(t *testing.T) {
 
 	// Empty TransportConfig is incomplete
 	mod := NewSecurityModule(log, &securityConfig{
-		transport: &security.TransportConfig{},
+		transport:   &security.TransportConfig{},
+		credentials: &security.CredentialConfig{},
 	})
 	respBytes, err := callRequestCreds(mod, t, log, conn)
 
@@ -186,7 +191,7 @@ func TestAgentSecurityModule_RequestCreds_BadUid(t *testing.T) {
 	defer cleanup()
 
 	mod := NewSecurityModule(log, defaultTestSecurityConfig())
-	mod.signCredential = func(_ *auth.CredentialRequest) (*auth.Credential, error) {
+	mod.signCredential = func(_ context.Context, _ *auth.CredentialRequest) (*auth.Credential, error) {
 		return nil, errors.New("LookupUserID")
 	}
 	respBytes, err := callRequestCreds(mod, t, log, conn)
@@ -198,11 +203,12 @@ func TestAgentSecurityModule_RequestCreds_BadUid(t *testing.T) {
 	expectCredResp(t, respBytes, int32(daos.MiscError), false)
 }
 
+type signCredentialResp struct {
+	cred *auth.Credential
+	err  error
+}
+
 func TestAgent_SecurityRPC_getCredential(t *testing.T) {
-	type response struct {
-		cred *auth.Credential
-		err  error
-	}
 	testCred := &auth.Credential{
 		Token:  &auth.Token{Flavor: auth.Flavor_AUTH_SYS, Data: []byte("test-token")},
 		Origin: "test-origin",
@@ -227,13 +233,13 @@ func TestAgent_SecurityRPC_getCredential(t *testing.T) {
 
 	for name, tc := range map[string]struct {
 		secCfg    *securityConfig
-		responses []response
+		responses []signCredentialResp
 		expBytes  []byte
 		expErr    error
 	}{
 		"lookup miss": {
 			secCfg: defaultTestSecurityConfig(),
-			responses: []response{
+			responses: []signCredentialResp{
 				{
 					cred: nil,
 					err:  user.UnknownUserIdError(unix.Getuid()),
@@ -251,7 +257,7 @@ func TestAgent_SecurityRPC_getCredential(t *testing.T) {
 				}
 				return cfg
 			}(),
-			responses: []response{
+			responses: []signCredentialResp{
 				{
 					cred: nil,
 					err:  user.UnknownUserIdError(unix.Getuid()),
@@ -273,7 +279,7 @@ func TestAgent_SecurityRPC_getCredential(t *testing.T) {
 				}
 				return cfg
 			}(),
-			responses: []response{
+			responses: []signCredentialResp{
 				{
 					cred: nil,
 					err:  user.UnknownUserIdError(unix.Getuid()),
@@ -297,7 +303,7 @@ func TestAgent_SecurityRPC_getCredential(t *testing.T) {
 			mod := NewSecurityModule(log, tc.secCfg)
 			mod.signCredential = func() credSignerFn {
 				var idx int
-				return func(req *auth.CredentialRequest) (*auth.Credential, error) {
+				return func(_ context.Context, req *auth.CredentialRequest) (*auth.Credential, error) {
 					defer func() {
 						if idx < len(tc.responses)-1 {
 							idx++
@@ -315,6 +321,97 @@ func TestAgent_SecurityRPC_getCredential(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expBytes, respBytes); diff != "" {
 				t.Errorf("unexpected response (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAgent_SecurityCachedCredentials(t *testing.T) {
+	cred0 := &auth.Credential{
+		Token:  &auth.Token{Flavor: auth.Flavor_AUTH_SYS, Data: []byte("user,group1,group2")},
+		Origin: "test-origin",
+	}
+	cred1 := &auth.Credential{
+		Token:  &auth.Token{Flavor: auth.Flavor_AUTH_SYS, Data: []byte("user,group1,group3")},
+		Origin: "test-origin",
+	}
+
+	for name, tc := range map[string]struct {
+		lifetime  time.Duration
+		req       *auth.CredentialRequest
+		responses []signCredentialResp
+		exp       *auth.Credential
+	}{
+		"cache hit": {
+			lifetime: time.Second,
+			req: &auth.CredentialRequest{
+				DomainInfo: security.InitDomainInfo(&syscall.Ucred{Uid: 1234, Gid: 5678}, ""),
+			},
+			responses: []signCredentialResp{
+				{
+					cred: cred0,
+					err:  nil,
+				},
+				{
+					cred: cred1,
+					err:  nil,
+				},
+			},
+			exp: cred0,
+		},
+		"expired entry": {
+			lifetime: time.Nanosecond,
+			req: &auth.CredentialRequest{
+				DomainInfo: security.InitDomainInfo(&syscall.Ucred{Uid: 1234, Gid: 5678}, ""),
+			},
+			responses: []signCredentialResp{
+				{
+					cred: cred0,
+					err:  nil,
+				},
+				{
+					cred: cred1,
+					err:  nil,
+				},
+			},
+			exp: cred1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer test.ShowBufferOnFailure(t, buf)
+
+			cfg := defaultTestSecurityConfig()
+			cfg.credentials.CacheExpiration = tc.lifetime
+			mod := NewSecurityModule(log, cfg)
+			mod.credCache.cacheMissFn = func() func(_ context.Context, req *auth.CredentialRequest) (*auth.Credential, error) {
+				var idx int
+				return func(_ context.Context, req *auth.CredentialRequest) (*auth.Credential, error) {
+					defer func() {
+						if idx < len(tc.responses)-1 {
+							idx++
+						}
+					}()
+					t.Logf("returning response %d: %+v", idx, tc.responses[idx])
+					return tc.responses[idx].cred, tc.responses[idx].err
+				}
+			}()
+
+			// Prime the cache with a single entry.
+			_, err := mod.credCache.getSignedCredential(test.Context(t), tc.req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// Request a second time with the same credentials.
+			cred, err := mod.credCache.getSignedCredential(test.Context(t), tc.req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			cmpOpts := cmp.Options{
+				protocmp.Transform(),
+			}
+			if diff := cmp.Diff(tc.exp, cred, cmpOpts...); diff != "" {
+				t.Errorf("unexpected credential (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/src/control/lib/cache/cache_test.go
+++ b/src/control/lib/cache/cache_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2023 Intel Corporation.
+// (C) Copyright 2023-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -10,11 +10,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/daos-stack/daos/src/control/common/test"
-	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 func TestCache_NewItemCache(t *testing.T) {
@@ -36,6 +37,8 @@ func TestCache_NewItemCache(t *testing.T) {
 	}
 }
 
+var _ RefreshableItem = (*mockItem)(nil)
+
 type mockItem struct {
 	ItemKey            string
 	ID                 string
@@ -55,7 +58,14 @@ func (m *mockItem) Refresh(ctx context.Context) error {
 	return m.RefreshErr
 }
 
-func (m *mockItem) NeedsRefresh() bool {
+func (m *mockItem) RefreshIfNeeded(ctx context.Context) (bool, error) {
+	if m.needsRefresh() {
+		return true, m.RefreshErr
+	}
+	return false, nil
+}
+
+func (m *mockItem) needsRefresh() bool {
 	return m.NeedsRefreshResult
 }
 

--- a/src/control/security/auth/auth_sys.go
+++ b/src/control/security/auth/auth_sys.go
@@ -8,6 +8,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"os"
 	"os/user"
@@ -17,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
@@ -221,7 +223,7 @@ func (r *CredentialRequest) WithUserAndGroup(userStr, groupStr string, groupStrs
 
 // GetSignedCredential returns a credential based on the provided domain info and
 // signing key.
-func GetSignedCredential(req *CredentialRequest) (*Credential, error) {
+func GetSignedCredential(ctx context.Context, req *CredentialRequest) (*Credential, error) {
 	if req == nil {
 		return nil, errors.Errorf("%T is nil", req)
 	}
@@ -282,6 +284,7 @@ func GetSignedCredential(req *CredentialRequest) (*Credential, error) {
 		Verifier: &verifierToken,
 		Origin:   "agent"}
 
+	logging.FromContext(ctx).Tracef("%s: successfully signed credential", req.DomainInfo)
 	return &credential, nil
 }
 

--- a/src/control/security/auth/auth_sys_test.go
+++ b/src/control/security/auth/auth_sys_test.go
@@ -270,7 +270,7 @@ func TestAuth_GetSignedCred(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			cred, gotErr := GetSignedCredential(tc.req)
+			cred, gotErr := GetSignedCredential(test.Context(t), tc.req)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -286,7 +286,7 @@ func TestAuth_CredentialRequestOverrides(t *testing.T) {
 	req.getHostname = testHostnameFn(nil, "test-host")
 	req.WithUserAndGroup("test-user", "test-group", "test-secondary")
 
-	cred, err := GetSignedCredential(req)
+	cred, err := GetSignedCredential(test.Context(t), req)
 	if err != nil {
 		t.Fatalf("Failed to get credential: %s", err)
 	}

--- a/src/control/security/config.go
+++ b/src/control/security/config.go
@@ -94,7 +94,8 @@ func (cm ClientUserMap) Lookup(uid uint32) *MappedClientUser {
 // CredentialConfig contains configuration details for managing user
 // credentials.
 type CredentialConfig struct {
-	ClientUserMap ClientUserMap `yaml:"client_user_map,omitempty"`
+	CacheExpiration time.Duration `yaml:"cache_expiration,omitempty"`
+	ClientUserMap   ClientUserMap `yaml:"client_user_map,omitempty"`
 }
 
 // TransportConfig contains all the information on whether or not to use

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -48,7 +48,6 @@
 #telemetry_retain: 1m
 
 ## Configuration for user credential management.
-#
 #credential_config:
 #  # If the agent should be able to resolve unknown client uids and gids
 #  # (e.g. when running in a container) into ACL principal names, then a
@@ -61,10 +60,21 @@
 #    1000:
 #      user: ralph
 #      group: stanley
-
+#
+#  # Optionally cache generated credentials with the specified cache
+#  # lifetime. By default, a credential is generated for every client
+#  # process that connects to a pool. If the credential cache is
+#  # enabled, then local client processes connecting with stable
+#  # uid:gid associations may take advantage of the cached credential
+#  # and reduce some agent overhead. For heavily-loaded client nodes
+#  # with many frequent (e.g. hundreds per minute) client connections,
+#  # a lifetime of 1-5 minutes may be a reasonable tradeoff between
+#  # performance and responsiveness to user/group database updates.
+#  # If no expiration is set, credential caching is not enabled.
+#  cache_expiration: 1m
+#
 ## Configuration for SSL certificates used to secure management traffic
 # and authenticate/authorize management components.
-#
 #transport_config:
 #  # In order to disable transport security, uncomment and set allow_insecure
 #  # to true. Not recommended for production configurations.
@@ -77,6 +87,7 @@
 #  # Key portion of Agent Certificate
 #  key: /etc/daos/certs/agent.key
 #
+
 # Use the given directory for creating unix domain sockets
 #
 # NOTE: Do not change this when running under systemd control. If it needs to


### PR DESCRIPTION
On heavily-loaded client nodes where many processes are being
launched by the same user or users, the admin may optionally
enable the credential cache in the agent in order to lower
agent overhead caused by generating identical credentials
for each process owned by a user. The agent-generated
credential is presented by the client process during pool/container
connection and is used to evaluate ACL permissions for
that connection.

Example config:
credential_config:
  cache_expiration: 1m

Signed-off-by: Michael MacDonald <mjmac@google.com>