### PR TITLE
DAOS-15863 container: fix container destroy error (#13852)

### DIFF
--- a/src/common/lru.c
+++ b/src/common/lru.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -25,6 +25,7 @@ lru_hop_rec_addref(struct d_hash_table *htable, d_list_t *link)
 {
 	struct daos_llink *llink = link2llink(link);
 
+	D_ASSERT(llink->ll_evicting == 0 && llink->ll_evicted == 0);
 	llink->ll_ref++;
 }
 
@@ -36,6 +37,9 @@ lru_hop_rec_decref(struct d_hash_table *htable, d_list_t *link)
 
 	D_ASSERT(llink->ll_ref > 0);
 	llink->ll_ref--;
+	if (llink->ll_ref == 1 && llink->ll_ops->lop_wakeup)
+		llink->ll_ops->lop_wakeup(llink);
+
 	/* Delete from hash only if no more references */
 	return llink->ll_ref == 0;
 }
@@ -85,6 +89,11 @@ daos_lru_cache_create(int bits, uint32_t feats,
 	int			 rc = 0;
 
 	D_DEBUG(DB_TRACE, "Creating a new LRU cache of size (2^%d)\n", bits);
+
+	if (feats & D_HASH_FT_EPHEMERAL) {
+		D_ERROR("D_HASH_FT_EPHEMERAL is unsupported for LRU cache\n");
+		D_GOTO(out, rc = -DER_INVAL);
+	}
 
 	if (ops == NULL ||
 	    ops->lop_cmp_keys  == NULL ||
@@ -240,13 +249,22 @@ out:
 	return rc;
 }
 
-void
-daos_lru_ref_release(struct daos_lru_cache *lcache, struct daos_llink *llink)
+static void
+lru_ref_release_internal(struct daos_lru_cache *lcache, struct daos_llink *llink, bool wait)
 {
 	D_ASSERT(lcache != NULL && llink != NULL && llink->ll_ref > 1);
 	D_ASSERT(d_list_empty(&llink->ll_qlink));
 
-	llink->ll_ref--;
+	lru_hop_rec_decref(&lcache->dlc_htable, &llink->ll_link);
+
+	if (wait && llink->ll_ref > 1) {
+		D_ASSERT(llink->ll_evicting == 0);
+		llink->ll_evicting = 1;
+		lcache->dlc_ops->lop_wait(llink);
+		llink->ll_evicting = 0;
+		llink->ll_evicted = 1;
+	}
+
 	if (llink->ll_ref == 1) { /* the last refcount */
 		if (lcache->dlc_csize == 0)
 			llink->ll_evicted = 1;
@@ -268,4 +286,18 @@ daos_lru_ref_release(struct daos_lru_cache *lcache, struct daos_llink *llink)
 		d_list_del_init(&llink->ll_qlink);
 		lru_del_evicted(lcache, llink);
 	}
+}
+
+void
+daos_lru_ref_release(struct daos_lru_cache *lcache, struct daos_llink *llink)
+{
+	lru_ref_release_internal(lcache, llink, false);
+}
+
+void
+daos_lru_ref_wait_evict(struct daos_lru_cache *lcache, struct daos_llink *llink)
+{
+	D_ASSERT(lcache->dlc_ops->lop_wait);
+
+	lru_ref_release_internal(lcache, llink, true);
 }

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -636,11 +636,16 @@ cont_child_alloc_ref(void *co_uuid, unsigned int ksize, void *po_uuid,
 		rc = dss_abterr2der(rc);
 		goto out_scrub_cond;
 	}
+	rc = ABT_cond_create(&cont->sc_fini_cond);
+	if (rc != ABT_SUCCESS) {
+		rc = dss_abterr2der(rc);
+		goto out_rebuild_cond;
+	}
 
 	cont->sc_pool = ds_pool_child_lookup(po_uuid);
 	if (cont->sc_pool == NULL) {
 		rc = -DER_NO_HDL;
-		goto out_rebuild_cond;
+		goto out_finish_cond;
 	}
 
 	rc = vos_cont_open(cont->sc_pool->spc_hdl, co_uuid, &cont->sc_hdl);
@@ -670,6 +675,8 @@ cont_child_alloc_ref(void *co_uuid, unsigned int ksize, void *po_uuid,
 
 out_pool:
 	ds_pool_child_put(cont->sc_pool);
+out_finish_cond:
+	ABT_cond_free(&cont->sc_fini_cond);
 out_rebuild_cond:
 	ABT_cond_free(&cont->sc_rebuild_cond);
 out_scrub_cond:
@@ -702,6 +709,7 @@ cont_child_free_ref(struct daos_llink *llink)
 	ABT_cond_free(&cont->sc_dtx_resync_cond);
 	ABT_cond_free(&cont->sc_scrub_cond);
 	ABT_cond_free(&cont->sc_rebuild_cond);
+	ABT_cond_free(&cont->sc_fini_cond);
 	ABT_mutex_free(&cont->sc_mutex);
 	D_FREE(cont);
 }
@@ -732,11 +740,31 @@ cont_child_rec_hash(struct daos_llink *llink)
 				 2 * sizeof(uuid_t));
 }
 
+static void
+cont_child_wait(struct daos_llink *llink)
+{
+	struct ds_cont_child *cont = cont_child_obj(llink);
+
+	ABT_mutex_lock(cont->sc_mutex);
+	ABT_cond_wait(cont->sc_fini_cond, cont->sc_mutex);
+	ABT_mutex_unlock(cont->sc_mutex);
+}
+
+static void
+cont_child_wakeup(struct daos_llink *llink)
+{
+	struct ds_cont_child *cont = cont_child_obj(llink);
+
+	ABT_cond_broadcast(cont->sc_fini_cond);
+}
+
 static struct daos_llink_ops cont_child_cache_ops = {
 	.lop_alloc_ref	= cont_child_alloc_ref,
 	.lop_free_ref	= cont_child_free_ref,
 	.lop_cmp_keys	= cont_child_cmp_keys,
 	.lop_rec_hash	= cont_child_rec_hash,
+	.lop_wait	= cont_child_wait,
+	.lop_wakeup	= cont_child_wakeup,
 };
 
 int
@@ -1233,8 +1261,7 @@ cont_child_destroy_one(void *vin)
 			D_GOTO(out_pool, rc = -DER_BUSY);
 		} /* else: resync should have completed, try again */
 
-		/* If it is the last user, ds_cont_child will be removed from hash & freed. */
-		cont_child_put(tls->dt_cont_cache, cont);
+		daos_lru_ref_wait_evict(tls->dt_cont_cache, &cont->sc_list);
 	}
 
 	D_DEBUG(DB_MD, DF_CONT": destroying vos container\n",

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -64,6 +64,7 @@ struct ds_cont_child {
 	ABT_cond		 sc_dtx_resync_cond;
 	ABT_cond		 sc_scrub_cond;
 	ABT_cond		 sc_rebuild_cond;
+	ABT_cond		 sc_fini_cond;
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_reindex:1,
 				 sc_dtx_reindex_abort:1,


### PR DESCRIPTION
After stopping the container service, certain user cases may still retain references to the container's child objects, such as ongoing IO operations. To prevent errors during container destruction, ensure that the container is only destroyed after all dependent operations have completed.

Fix daos_lru_cache_create() to return an error if D_HASH_FT_EPHEMERAL is passed in.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
