### PR TITLE
DAOS-16037 pool: Fix upgrade for svc_ops

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1653,13 +1653,8 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 	struct pool_buf	       *map_buf;
 	struct daos_prop_entry *svc_rf_entry;
 	daos_prop_t	       *prop = NULL;
-	uint32_t                svc_ops_enabled = 0;
-	uint32_t                svc_ops_max     = 0;
-	uint32_t                svc_ops_age     = 0;
-	uint32_t		map_version;
-	uint64_t                rdb_size;
-	bool                    rdb_size_ok     = false;
-	int			rc;
+	uint32_t                map_version;
+	int                     rc;
 
 	rc = rdb_tx_begin(svc->ps_rsvc.s_db, svc->ps_rsvc.s_term, &tx);
 	if (rc != 0)
@@ -1686,48 +1681,47 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 	else
 		svc->ps_svc_rf = -1;
 
-	/* Check if duplicate operations detection is enabled, for informative debug log */
-	rc = rdb_get_size(svc->ps_rsvc.s_db, &rdb_size);
-	if (rc != 0)
-		goto out_lock;
-	rdb_size_ok = (rdb_size >= DUP_OP_MIN_RDB_SIZE);
+	if (svc->ps_global_version >= DAOS_POOL_GLOBAL_VERSION_WITH_SVC_OPS_KVS) {
+		uint64_t rdb_size;
+		bool     rdb_size_ok;
 
-	d_iov_set(&value, &svc_ops_enabled, sizeof(svc_ops_enabled));
-	rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_svc_ops_enabled, &value);
-	if (rc == -DER_NONEXIST) {
-		rc = 0;
-	} else if (rc != 0) {
-		D_ERROR(DF_UUID ": failed to lookup svc_ops_enabled: " DF_RC "\n",
-			DP_UUID(svc->ps_uuid), DP_RC(rc));
-		goto out_lock;
+		/* Check if duplicate operations detection is enabled, for informative debug log */
+		rc = rdb_get_size(svc->ps_rsvc.s_db, &rdb_size);
+		if (rc != 0)
+			goto out_lock;
+		rdb_size_ok = (rdb_size >= DUP_OP_MIN_RDB_SIZE);
+
+		d_iov_set(&value, &svc->ps_ops_enabled, sizeof(svc->ps_ops_enabled));
+		rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_svc_ops_enabled, &value);
+		if (rc != 0) {
+			D_ERROR(DF_UUID ": failed to lookup svc_ops_enabled: " DF_RC "\n",
+				DP_UUID(svc->ps_uuid), DP_RC(rc));
+			goto out_lock;
+		}
+
+		d_iov_set(&value, &svc->ps_ops_age, sizeof(svc->ps_ops_age));
+		rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_svc_ops_age, &value);
+		if (rc != 0) {
+			DL_ERROR(rc, DF_UUID ": failed to lookup svc_ops_age",
+				 DP_UUID(svc->ps_uuid));
+			goto out_lock;
+		}
+
+		d_iov_set(&value, &svc->ps_ops_max, sizeof(svc->ps_ops_max));
+		rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_svc_ops_max, &value);
+		if (rc != 0) {
+			DL_ERROR(rc, DF_UUID ": failed to lookup svc_ops_max",
+				 DP_UUID(svc->ps_uuid));
+			goto out_lock;
+		}
+
+		D_DEBUG(DB_MD,
+			DF_UUID ": duplicate ops detection %s (rdb size " DF_U64 " %s %u minimum), "
+				"max entries %u, max entry age %u sec\n",
+			DP_UUID(svc->ps_uuid), svc->ps_ops_enabled ? "enabled" : "disabled",
+			rdb_size, rdb_size_ok ? ">=" : "<", DUP_OP_MIN_RDB_SIZE, svc->ps_ops_max,
+			svc->ps_ops_age);
 	}
-	svc->ps_ops_enabled = svc_ops_enabled;
-
-	d_iov_set(&value, &svc_ops_max, sizeof(svc_ops_max));
-	rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_svc_ops_max, &value);
-	if (rc == -DER_NONEXIST) {
-		rc = 0;
-	} else if (rc != 0) {
-		DL_ERROR(rc, DF_UUID ": failed to lookup svc_ops_max", DP_UUID(svc->ps_uuid));
-		goto out_lock;
-	}
-	svc->ps_ops_max = svc_ops_max;
-
-	d_iov_set(&value, &svc_ops_age, sizeof(svc_ops_age));
-	rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_svc_ops_age, &value);
-	if (rc == -DER_NONEXIST) {
-		rc = 0;
-	} else if (rc != 0) {
-		DL_ERROR(rc, DF_UUID ": failed to lookup svc_ops_age", DP_UUID(svc->ps_uuid));
-		goto out_lock;
-	}
-	svc->ps_ops_age = svc_ops_age;
-
-	D_DEBUG(DB_MD,
-		DF_UUID ": duplicate ops detection %s (rdb size " DF_U64 " %s %u minimum), "
-			"max entries %u, max entry age %u sec\n",
-		DP_UUID(svc->ps_uuid), svc_ops_enabled ? "enabled" : "disabled", rdb_size,
-		rdb_size_ok ? ">=" : "<", DUP_OP_MIN_RDB_SIZE, svc_ops_max, svc_ops_age);
 
 	D_ASSERTF(rc == 0, DF_RC"\n", DP_RC(rc));
 	*map_buf_out = map_buf;
@@ -5172,8 +5166,7 @@ pool_upgrade_one_prop_int32(struct rdb_tx *tx, struct pool_svc *svc, uuid_t uuid
 }
 
 static int
-pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
-			      uuid_t pool_uuid, crt_rpc_t *rpc)
+pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc, uuid_t pool_uuid, crt_rpc_t *rpc)
 {
 	d_iov_t			value;
 	uint64_t		val;
@@ -5185,6 +5178,8 @@ pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
 	int			n_hdl_uuids = 0;
 	uint32_t		connectable;
 	uint32_t                svc_ops_enabled = 0;
+	uint32_t		svc_ops_age;
+	uint32_t                svc_ops_max;
 
 	if (rpc) {
 		rc = find_hdls_to_evict(tx, svc, &hdl_uuids, &hdl_uuids_size,
@@ -5408,7 +5403,6 @@ pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
 
 	/* Upgrade for the pool/container service operations KVS */
 	D_DEBUG(DB_MD, DF_UUID ": check ds_pool_prop_svc_ops\n", DP_UUID(pool_uuid));
-
 	d_iov_set(&value, NULL, 0);
 	rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_svc_ops, &value);
 	if (rc && rc != -DER_NONEXIST) {
@@ -5416,6 +5410,7 @@ pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
 		D_GOTO(out_free, rc);
 	} else if (rc == -DER_NONEXIST) {
 		struct rdb_kvs_attr attr;
+		uint32_t            svc_ops_num;
 
 		D_DEBUG(DB_MD, DF_UUID ": creating service ops KVS\n", DP_UUID(pool_uuid));
 		attr.dsa_class = RDB_KVS_LEXICAL;
@@ -5424,6 +5419,14 @@ pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
 		if (rc != 0) {
 			D_ERROR(DF_UUID ": failed to create service ops KVS: %d\n",
 				DP_UUID(pool_uuid), rc);
+			D_GOTO(out_free, rc);
+		}
+		svc_ops_num = 0;
+		d_iov_set(&value, &svc_ops_num, sizeof(svc_ops_num));
+		rc = rdb_tx_update(tx, &svc->ps_root, &ds_pool_prop_svc_ops_num, &value);
+		if (rc != 0) {
+			DL_ERROR(rc, DF_UUID ": failed to write upgrade svc_ops_num",
+				 DP_UUID(pool_uuid));
 			D_GOTO(out_free, rc);
 		}
 		need_commit = true;
@@ -5462,15 +5465,31 @@ pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
 	}
 
 	D_DEBUG(DB_MD, DF_UUID ": check ds_pool_prop_svc_ops_age\n", DP_UUID(pool_uuid));
-	d_iov_set(&value, &val32, sizeof(val32));
+	d_iov_set(&value, &svc_ops_age, sizeof(svc_ops_age));
 	rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_svc_ops_age, &value);
 	if (rc && rc != -DER_NONEXIST) {
 		D_GOTO(out_free, rc);
 	} else if (rc == -DER_NONEXIST) {
-		val32 = DAOS_PROP_PO_SVC_OPS_ENTRY_AGE_DEFAULT;
+		svc_ops_age = DAOS_PROP_PO_SVC_OPS_ENTRY_AGE_DEFAULT;
 		rc    = rdb_tx_update(tx, &svc->ps_root, &ds_pool_prop_svc_ops_age, &value);
 		if (rc != 0) {
 			DL_ERROR(rc, "failed to write upgrade svc_ops_age");
+			D_GOTO(out_free, rc);
+		}
+		need_commit = true;
+	}
+
+	D_DEBUG(DB_MD, DF_UUID ": check ds_pool_prop_svc_ops_max\n", DP_UUID(pool_uuid));
+	d_iov_set(&value, &svc_ops_max, sizeof(svc_ops_max));
+	rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_svc_ops_max, &value);
+	if (rc && rc != -DER_NONEXIST) {
+		D_GOTO(out_free, rc);
+	} else if (rc == -DER_NONEXIST) {
+		svc_ops_max = PS_OPS_PER_SEC * svc_ops_age;
+		rc = rdb_tx_update(tx, &svc->ps_root, &ds_pool_prop_svc_ops_max, &value);
+		if (rc != 0) {
+			DL_ERROR(rc, DF_UUID ": failed to write upgrade svc_ops_max",
+				 DP_UUID(pool_uuid));
 			D_GOTO(out_free, rc);
 		}
 		need_commit = true;
@@ -5484,6 +5503,11 @@ pool_upgrade_props(struct rdb_tx *tx, struct pool_svc *svc,
 		rc = rdb_tx_commit(tx);
 		if (rc)
 			D_GOTO(out_free, rc);
+
+		svc->ps_ops_enabled = svc_ops_enabled;
+		svc->ps_ops_age     = svc_ops_age;
+		svc->ps_ops_max     = svc_ops_max;
+
 		rc = pool_prop_read(tx, svc, DAOS_PO_QUERY_PROP_ALL, &prop);
 		if (rc)
 			D_GOTO(out_free, rc);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1721,6 +1721,12 @@ read_db_for_stepping_up(struct pool_svc *svc, struct pool_buf **map_buf_out,
 			DP_UUID(svc->ps_uuid), svc->ps_ops_enabled ? "enabled" : "disabled",
 			rdb_size, rdb_size_ok ? ">=" : "<", DUP_OP_MIN_RDB_SIZE, svc->ps_ops_max,
 			svc->ps_ops_age);
+	} else {
+		svc->ps_ops_enabled = 0;
+		svc->ps_ops_age     = 0;
+		svc->ps_ops_max     = 0;
+		D_DEBUG(DB_MD, DF_UUID ": duplicate ops detection unavailable\n",
+			DP_UUID(svc->ps_uuid));
 	}
 
 	D_ASSERTF(rc == 0, DF_RC"\n", DP_RC(rc));


### PR DESCRIPTION
  - pool_upgrade_props should take care of ds_pool_prop_svc_ops_{num,max} too.

  - pool_upgrade_props modifies ds_pool_prop_svc_ops_{enabled,age,max}, which are cached by pool_svc. It must also update the cached values too.

  - read_db_for_stepping_up should only access ds_pool_prop_svc_ops_{enabled,age,max} when the pool global version is high enough. If one of the properties is expected but absent, it should be an error; recovering the value to 0 may not be desirable.

Features: pool

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
