### PR TITLE
DAOS-16210 vos: Interoperability fix for flat dkey

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1811,6 +1811,17 @@ vos_fake_anchor_create(daos_anchor_t *anchor)
 	anchor->da_type = DAOS_ANCHOR_TYPE_HKEY;
 }
 
+/**
+ * If subtree is already created, it could have been created by an older pool
+ * version so if the dkey is not flat, we need to use KREC_BF_BTR here.
+ **/
+static inline bool
+key_tree_is_evt(int flags, enum vos_tree_class tclass, struct vos_krec_df *krec)
+{
+	return (flags & SUBTR_EVT && (tclass == VOS_BTR_AKEY ||
+				     (krec->kr_bmap & KREC_BF_NO_AKEY)));
+}
+
 static inline bool
 vos_io_scm(struct vos_pool *pool, daos_iod_type_t type, daos_size_t size, enum vos_io_stream ios)
 {

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -800,8 +800,7 @@ out:
 
 static int
 key_iter_ilog_check(struct vos_krec_df *krec, struct vos_obj_iter *oiter,
-		    vos_iter_type_t type, daos_epoch_range_t *epr,
-		    bool check_existence, struct vos_ts_set *ts_set)
+		    daos_epoch_range_t *epr, bool check_existence, struct vos_ts_set *ts_set)
 {
 	struct umem_instance	*umm;
 	int			 rc;
@@ -854,7 +853,7 @@ key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh,
 	}
 
 	/* Update the lower bound for nested iterator */
-	rc = key_iter_ilog_check(krec, oiter, tclass, epr, true, ts_set);
+	rc = key_iter_ilog_check(krec, oiter, epr, true, ts_set);
 	if (rc != 0)
 		goto fail;
 
@@ -922,8 +921,7 @@ key_iter_fill(struct vos_krec_df *krec, struct vos_obj_iter *oiter, bool check_e
 		ts_type = VOS_TS_TYPE_DKEY;
 	}
 
-	rc = key_iter_ilog_check(krec, oiter, oiter->it_iter.it_type, &epr,
-				 check_existence, NULL);
+	rc = key_iter_ilog_check(krec, oiter, &epr, check_existence, NULL);
 	if (rc == -DER_NONEXIST)
 		return VOS_ITER_CB_SKIP;
 	if (rc != 0) {
@@ -1041,7 +1039,7 @@ key_iter_fetch_root(struct vos_obj_iter *oiter, vos_iter_type_t type,
 	info->ii_filter_cb = oiter->it_iter.it_filter_cb;
 	info->ii_filter_arg = oiter->it_iter.it_filter_arg;
 	/* Update the lower bound for nested iterator */
-	rc = key_iter_ilog_check(krec, oiter, type, &info->ii_epr, false, NULL);
+	rc = key_iter_ilog_check(krec, oiter, &info->ii_epr, false, NULL);
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -828,7 +828,8 @@ out:
 }
 
 static int
-key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh, int key_type, daos_key_t *key,
+key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh,
+		 enum vos_tree_class tclass, daos_key_t *key,
 		 int flags, daos_handle_t *sub_toh, struct vos_krec_df **krecp,
 		 daos_epoch_range_t *epr, struct vos_punch_record *punched,
 		 struct vos_ilog_info *info, struct vos_ts_set *ts_set)
@@ -840,7 +841,7 @@ key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh, int key_type, da
 	if (krecp != NULL)
 		*krecp = NULL;
 
-	rc = key_tree_prepare(obj, toh, key_type, key, flags,
+	rc = key_tree_prepare(obj, toh, tclass, key, flags,
 			      vos_iter_intent(&oiter->it_iter), &krec,
 			      sub_toh, ts_set);
 	if (rc == -DER_NONEXIST)
@@ -853,7 +854,7 @@ key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh, int key_type, da
 	}
 
 	/* Update the lower bound for nested iterator */
-	rc = key_iter_ilog_check(krec, oiter, key_type, epr, true, ts_set);
+	rc = key_iter_ilog_check(krec, oiter, tclass, epr, true, ts_set);
 	if (rc != 0)
 		goto fail;
 
@@ -866,8 +867,10 @@ key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh, int key_type, da
 
 	return 0;
 fail:
-	if (sub_toh)
-		key_tree_release(*sub_toh, flags & SUBTR_EVT);
+	if (sub_toh) {
+		D_ASSERT(krec != NULL);
+		key_tree_release(*sub_toh, key_tree_is_evt(flags, tclass, krec));
+	}
 	return rc;
 }
 

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -833,9 +833,7 @@ tree_open_create(struct vos_object *obj, enum vos_tree_class tclass, int flags,
 	if ((krec->kr_bmap & (KREC_BF_BTR | KREC_BF_EVT)) == 0)
 		goto create;
 
-	/** If subtree is already created, it could have been created by an older pool version
-	 *  so if the dkey is not flat, we need to use KREC_BF_BTR here */
-	if (flags & SUBTR_EVT && (tclass == VOS_BTR_AKEY || (krec->kr_bmap & KREC_BF_NO_AKEY))) {
+	if (key_tree_is_evt(flags, tclass, krec)) {
 		expected_flag = KREC_BF_EVT;
 		unexpected_flag = KREC_BF_BTR;
 	} else {

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -854,7 +854,7 @@ tree_open_create(struct vos_object *obj, enum vos_tree_class tclass, int flags,
 		goto out;
 	}
 
-	if (flags & SUBTR_EVT) {
+	if (flags & SUBTR_EVT && expected_flag == KREC_BF_EVT) {
 		rc = evt_open(&krec->kr_evt, uma, &cbs, sub_toh);
 	} else {
 		rc = dbtree_open_inplace_ex(&krec->kr_btr, uma, coh, pool, sub_toh);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -854,7 +854,7 @@ tree_open_create(struct vos_object *obj, enum vos_tree_class tclass, int flags,
 		goto out;
 	}
 
-	if (flags & SUBTR_EVT && expected_flag == KREC_BF_EVT) {
+	if (expected_flag == KREC_BF_EVT) {
 		rc = evt_open(&krec->kr_evt, uma, &cbs, sub_toh);
 	} else {
 		rc = dbtree_open_inplace_ex(&krec->kr_btr, uma, coh, pool, sub_toh);


### PR DESCRIPTION
In tree_open_create(), address issues with interoperability:

- When handling cases where a subtree might have been created by an older pool version and the dkey is not flat, ensure usage of KREC_BF_BTR.
- Consider not only the SUBTR_EVT flag but also KREC_BF_NO_AKEY for existing formats.

Required-githooks: true