### PR TITLE
DAOS-16210 vos: Interoperability fix for flat dkey

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1811,6 +1811,17 @@ vos_fake_anchor_create(daos_anchor_t *anchor)
 	anchor->da_type = DAOS_ANCHOR_TYPE_HKEY;
 }
 
+/**
+ * If subtree is already created, it could have been created by an older pool
+ * version so if the dkey is not flat, we need to use KREC_BF_BTR here.
+ **/
+static inline bool
+key_tree_is_evt(int flags, enum vos_tree_class tclass, struct vos_krec_df *krec)
+{
+	return (flags & SUBTR_EVT && (tclass == VOS_BTR_AKEY ||
+				     (krec->kr_bmap & KREC_BF_NO_AKEY)));
+}
+
 static inline bool
 vos_io_scm(struct vos_pool *pool, daos_iod_type_t type, daos_size_t size, enum vos_io_stream ios)
 {

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -833,9 +833,7 @@ tree_open_create(struct vos_object *obj, enum vos_tree_class tclass, int flags,
 	if ((krec->kr_bmap & (KREC_BF_BTR | KREC_BF_EVT)) == 0)
 		goto create;
 
-	/** If subtree is already created, it could have been created by an older pool version
-	 *  so if the dkey is not flat, we need to use KREC_BF_BTR here */
-	if (flags & SUBTR_EVT && (tclass == VOS_BTR_AKEY || (krec->kr_bmap & KREC_BF_NO_AKEY))) {
+	if (key_tree_is_evt(flags, tclass, krec)) {
 		expected_flag = KREC_BF_EVT;
 		unexpected_flag = KREC_BF_BTR;
 	} else {
@@ -854,7 +852,7 @@ tree_open_create(struct vos_object *obj, enum vos_tree_class tclass, int flags,
 		goto out;
 	}
 
-	if (flags & SUBTR_EVT) {
+	if (expected_flag == KREC_BF_EVT) {
 		rc = evt_open(&krec->kr_evt, uma, &cbs, sub_toh);
 	} else {
 		rc = dbtree_open_inplace_ex(&krec->kr_btr, uma, coh, pool, sub_toh);


### PR DESCRIPTION
In tree_open_create(), address issues with interoperability:

- When handling cases where a subtree might have been created by an older pool version and the dkey is not flat, ensure usage of KREC_BF_BTR.
- Consider not only the SUBTR_EVT flag but also KREC_BF_NO_AKEY for existing formats.

Required-githooks: true
Allow-unstable-test: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
