### PR TITLE
Merging release/2.6 into google/2.6

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1034,7 +1034,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont_svc *sv
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
-	cont_create_in_get_data(rpc, CONT_CREATE, DAOS_CONT_VERSION, &cprop);
+	cont_create_in_get_data(rpc, CONT_CREATE, cont_proto_ver, &cprop);
 
 	/* Determine if the label property was supplied, and if so,
 	 * verify that it is not the default unset label.


### PR DESCRIPTION
- **DAOS-16168 build: Ignore scons version deprecation (#14715) (#14717)**
- **DAOS-16214 container: Ensure Correct Protocol Version is Passed to cont_create_in_get_data() (#14757)**
