### PR TITLE
DAOS-16223 control: Config generate should not output auto calculated…

### DIFF
--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -194,7 +194,7 @@ func ConfGenerate(req ConfGenerateReq, newEngineCfg newEngineCfgFn, hf *HostFabr
 	}
 
 	// populate server config using engine configs
-	sc, err := genServerConfig(req, ecs, sd.MemInfo, tc)
+	sc, err := genServerConfig(req, ecs, tc)
 	if err != nil {
 		return nil, err
 	}
@@ -1217,7 +1217,7 @@ func checkAccessPointPorts(log logging.Logger, aps []string) (int, error) {
 // Generate a server config file from the constituent hardware components. Enforce consistent
 // target and helper count across engine configs necessary for optimum performance and populate
 // config parameters. Set NUMA affinity on the generated config and then run through validation.
-func genServerConfig(req ConfGenerateReq, ecs []*engine.Config, mi *common.MemInfo, tc *threadCounts) (*config.Server, error) {
+func genServerConfig(req ConfGenerateReq, ecs []*engine.Config, tc *threadCounts) (*config.Server, error) {
 	if len(ecs) == 0 {
 		return nil, errors.New("expected non-zero number of engine configs")
 	}
@@ -1258,14 +1258,6 @@ func genServerConfig(req ConfGenerateReq, ecs []*engine.Config, mi *common.MemIn
 
 	if err := cfg.Validate(req.Log); err != nil {
 		return nil, errors.Wrap(err, "validating engine config")
-	}
-
-	if err := cfg.SetNrHugepages(req.Log, mi); err != nil {
-		return nil, err
-	}
-
-	if err := cfg.SetRamdiskSize(req.Log, mi); err != nil {
-		return nil, err
 	}
 
 	return cfg, nil

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -980,9 +980,11 @@ func TestServerConfig_SetNrHugepages(t *testing.T) {
 	testFile := filepath.Join(testDir, sConfigUncomment)
 	uncommentServerConfig(t, testFile)
 
+	defHpSizeKb := 2048
+
 	for name, tc := range map[string]struct {
 		extraConfig    func(c *Server) *Server
-		memTotBytes    uint64
+		zeroHpSize     bool
 		expNrHugepages int
 		expErr         error
 	}{
@@ -1033,6 +1035,13 @@ func TestServerConfig_SetNrHugepages(t *testing.T) {
 						),
 					)
 			},
+		},
+		"zero hugepage size": {
+			extraConfig: func(c *Server) *Server {
+				return c
+			},
+			zeroHpSize: true,
+			expErr:     errors.New("invalid system hugepage size"),
 		},
 		"zero hugepages set in config; bdevs configured; implicit role assignment": {
 			extraConfig: func(c *Server) *Server {
@@ -1105,7 +1114,10 @@ func TestServerConfig_SetNrHugepages(t *testing.T) {
 			cfg := tc.extraConfig(baseCfg(t, testFile))
 
 			mi := &common.MemInfo{
-				HugepageSizeKiB: 2048,
+				HugepageSizeKiB: defHpSizeKb,
+			}
+			if tc.zeroHpSize {
+				mi.HugepageSizeKiB = 0
 			}
 
 			test.CmpErr(t, tc.expErr, cfg.SetNrHugepages(log, mi))
@@ -1133,6 +1145,12 @@ func TestServerConfig_SetRamdiskSize(t *testing.T) {
 		expRamdiskSize int
 		expErr         error
 	}{
+		"zero mem reported": {
+			extraConfig: func(c *Server) *Server {
+				return c
+			},
+			expErr: errors.New("requires nonzero total mem"),
+		},
 		"out of range scm_size; high": {
 			// 16896 hugepages / 512 pages-per-gib = 33 gib huge mem
 			// 33 huge mem + 5 sys rsv + 2 engine rsv = 40 gib reserved mem


### PR DESCRIPTION
… values

Features: control
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
