### PR TITLE
DAOS-16250 control: Allow control client version override

### DIFF
--- a/src/control/build/context.go
+++ b/src/control/build/context.go
@@ -53,6 +53,10 @@ func ToContext(parent context.Context, comp Component, verStr string) (context.C
 		return nil, errors.New("component cannot be ComponentAny")
 	}
 
+	if _, exists := metadata.FromOutgoingContext(parent); exists {
+		return nil, ErrCtxMetadataExists
+	}
+
 	version, err := NewVersion(verStr)
 	if err != nil {
 		return nil, err

--- a/src/control/build/context_test.go
+++ b/src/control/build/context_test.go
@@ -89,6 +89,19 @@ func TestBuild_ToContext(t *testing.T) {
 			verString: "x.y.z",
 			expErr:    errors.New("invalid major version"),
 		},
+		"already set": {
+			parent: func() context.Context {
+				parent := test.Context(t)
+				ctx, err := ToContext(parent, ComponentAgent, "2.3.108")
+				if err != nil {
+					t.Fatal(err)
+				}
+				return ctx
+			}(),
+			comp:      ComponentAgent,
+			verString: "2.3.108",
+			expErr:    ErrCtxMetadataExists,
+		},
 		"good component version": {
 			parent:    test.Context(t),
 			comp:      ComponentAgent,

--- a/src/control/build/errors.go
+++ b/src/control/build/errors.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -39,4 +39,6 @@ func IsIncompatComponents(err error) bool {
 var (
 	// ErrNoCtxMetadata is returned when no component/version metadata is found in the context.
 	ErrNoCtxMetadata = errors.New("no component/version metadata found in context")
+	// ErrCtxMetadataExists is returned when component/version metadata has already been set in the context.
+	ErrCtxMetadataExists = errors.New("component/version metadata already exists in context")
 )

--- a/src/control/lib/control/interceptors.go
+++ b/src/control/lib/control/interceptors.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2023 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -89,7 +89,12 @@ func unaryVersionedComponentInterceptor(comp build.Component) grpc.UnaryClientIn
 		}
 		ctx, err := build.ToContext(parent, comp, build.DaosVersion)
 		if err != nil {
-			return err
+			// Don't fail if a component version was already set somewhere else.
+			// Any other error is fatal.
+			if err != build.ErrCtxMetadataExists {
+				return err
+			}
+			ctx = parent
 		}
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}


### PR DESCRIPTION
Allow the control client to report a version other than the
static value embedded at build time. Enables some nonstandard
use cases where Control API users will take responsibility
for version interoperability without code changes.

Features: control
Required-githooks: true
Change-Id: I0ce6ddbf2c742ce9c8dab9e21e37cd5ea8c5f5b3
Signed-off-by: Michael MacDonald <mjmac@google.com>
