### PR TITLE
DAOS-15914 cart: Release input buffer during crt_reply_send()

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1518,12 +1518,15 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 		rc = crt_hgret_2_der(hg_ret);
 	}
 
-	/* Release input buffer */
-	hg_ret = HG_Release_input_buf(rpc_priv->crp_hg_hdl);
-	if (hg_ret != HG_SUCCESS) {
-		RPC_ERROR(rpc_priv, "HG_Release_input_buf failed, hg_ret: " DF_HG_RC "\n",
-			  DP_HG_RC(hg_ret));
-		/* Fall through */
+	/* Don't release input for forwarded RPCs as they share input with a parent */
+	if (!rpc_priv->crp_forward) {
+		/* Release input buffer */
+		hg_ret = HG_Release_input_buf(rpc_priv->crp_hg_hdl);
+		if (hg_ret != HG_SUCCESS) {
+			RPC_ERROR(rpc_priv, "HG_Release_input_buf failed, hg_ret: " DF_HG_RC "\n",
+				  DP_HG_RC(hg_ret));
+			/* Fall through */
+		}
 	}
 
 	return rc;
@@ -1551,12 +1554,15 @@ crt_hg_reply_error_send(struct crt_rpc_priv *rpc_priv, int error_code)
 			  error_code);
 	}
 
-	/* Release input buffer */
-	hg_ret = HG_Release_input_buf(rpc_priv->crp_hg_hdl);
-	if (hg_ret != HG_SUCCESS) {
-		RPC_ERROR(rpc_priv, "HG_Release_input_buf failed, hg_ret: " DF_HG_RC "\n",
-			  DP_HG_RC(hg_ret));
-		/* Fall through */
+	/* Don't release input for forwarded RPCs as they share input with a parent */
+	if (!rpc_priv->crp_forward) {
+		/* Release input buffer */
+		hg_ret = HG_Release_input_buf(rpc_priv->crp_hg_hdl);
+		if (hg_ret != HG_SUCCESS) {
+			RPC_ERROR(rpc_priv, "HG_Release_input_buf failed, hg_ret: " DF_HG_RC "\n",
+				  DP_HG_RC(hg_ret));
+			/* Fall through */
+		}
 	}
 
 	rpc_priv->crp_reply_pending = 0;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1506,6 +1506,15 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 	D_ASSERT(rpc_priv != NULL);
 
 	RPC_ADDREF(rpc_priv);
+
+	/* Release input buffer */
+	hg_ret = HG_Release_input_buf(rpc_priv->crp_hg_hdl);
+	if (hg_ret != HG_SUCCESS) {
+		RPC_ERROR(rpc_priv, "HG_Release_input_buf failed, hg_ret: " DF_HG_RC "\n",
+			  DP_HG_RC(hg_ret));
+		/* Fall through */
+	}
+
 	hg_ret = HG_Respond(rpc_priv->crp_hg_hdl, crt_hg_reply_send_cb,
 			    rpc_priv, &rpc_priv->crp_pub.cr_output);
 	if (hg_ret != HG_SUCCESS) {

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1507,14 +1507,7 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 
 	RPC_ADDREF(rpc_priv);
 
-	/* Release input buffer */
-	hg_ret = HG_Release_input_buf(rpc_priv->crp_hg_hdl);
-	if (hg_ret != HG_SUCCESS) {
-		RPC_ERROR(rpc_priv, "HG_Release_input_buf failed, hg_ret: " DF_HG_RC "\n",
-			  DP_HG_RC(hg_ret));
-		/* Fall through */
-	}
-
+	/* Input buffer still used during HG_Respond*/
 	hg_ret = HG_Respond(rpc_priv->crp_hg_hdl, crt_hg_reply_send_cb,
 			    rpc_priv, &rpc_priv->crp_pub.cr_output);
 	if (hg_ret != HG_SUCCESS) {
@@ -1523,6 +1516,14 @@ crt_hg_reply_send(struct crt_rpc_priv *rpc_priv)
 		/* should success as addref above */
 		RPC_DECREF(rpc_priv);
 		rc = crt_hgret_2_der(hg_ret);
+	}
+
+	/* Release input buffer */
+	hg_ret = HG_Release_input_buf(rpc_priv->crp_hg_hdl);
+	if (hg_ret != HG_SUCCESS) {
+		RPC_ERROR(rpc_priv, "HG_Release_input_buf failed, hg_ret: " DF_HG_RC "\n",
+			  DP_HG_RC(hg_ret));
+		/* Fall through */
 	}
 
 	return rc;
@@ -1549,6 +1550,15 @@ crt_hg_reply_error_send(struct crt_rpc_priv *rpc_priv, int error_code)
 			  "Sent CART level error message back to client. error_code: %d\n",
 			  error_code);
 	}
+
+	/* Release input buffer */
+	hg_ret = HG_Release_input_buf(rpc_priv->crp_hg_hdl);
+	if (hg_ret != HG_SUCCESS) {
+		RPC_ERROR(rpc_priv, "HG_Release_input_buf failed, hg_ret: " DF_HG_RC "\n",
+			  DP_HG_RC(hg_ret));
+		/* Fall through */
+	}
+
 	rpc_priv->crp_reply_pending = 0;
 }
 


### PR DESCRIPTION
- Release input buffer when doing reply send
- 
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
