### PR TITLE
DAOS-16013 tools: Query all pool targets by default (#14783)

### DIFF
--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -388,6 +388,20 @@ func (cmd *poolQueryTargetsCmd) Execute(_ []string) error {
 		return errors.WithMessage(err, "parsing target list")
 	}
 
+	if len(idxList) == 0 {
+		pi, err := queryPool(cmd.cPoolHandle, daos.HealthOnlyPoolQueryMask)
+		if err != nil || (pi.TotalTargets == 0 || pi.TotalEngines == 0) {
+			if err != nil {
+				return errors.Wrap(err, "pool query failed")
+			}
+			return errors.New("failed to derive target count from pool query")
+		}
+		tgtCount := pi.TotalTargets / pi.TotalEngines
+		for i := uint32(0); i < tgtCount; i++ {
+			idxList = append(idxList, i)
+		}
+	}
+
 	ptInfo := new(C.daos_target_info_t)
 	var rc C.int
 

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -682,15 +682,33 @@ type PoolQueryTargetsCmd struct {
 	poolCmd
 
 	Rank    uint32 `long:"rank" required:"1" description:"Engine rank of the targets to be queried"`
-	Targets string `long:"target-idx" required:"1" description:"Comma-separated list of target idx(s) to be queried"`
+	Targets string `long:"target-idx" description:"Comma-separated list of target idx(s) to be queried"`
 }
 
 // Execute is run when PoolQueryTargetsCmd subcommand is activated
 func (cmd *PoolQueryTargetsCmd) Execute(args []string) error {
+	ctx := cmd.MustLogCtx()
 
 	var tgtsList []uint32
-	if err := common.ParseNumberList(cmd.Targets, &tgtsList); err != nil {
-		return errors.WithMessage(err, "parsing target list")
+	if len(cmd.Targets) > 0 {
+		if err := common.ParseNumberList(cmd.Targets, &tgtsList); err != nil {
+			return errors.WithMessage(err, "parsing target list")
+		}
+	} else {
+		pi, err := control.PoolQuery(ctx, cmd.ctlInvoker, &control.PoolQueryReq{
+			ID:        cmd.PoolID().String(),
+			QueryMask: daos.DefaultPoolQueryMask,
+		})
+		if err != nil || (pi.TotalTargets == 0 || pi.TotalEngines == 0) {
+			if err != nil {
+				return errors.Wrap(err, "pool query failed")
+			}
+			return errors.New("failed to derive target count from pool query")
+		}
+		tgtCount := pi.TotalTargets / pi.TotalEngines
+		for i := uint32(0); i < tgtCount; i++ {
+			tgtsList = append(tgtsList, i)
+		}
 	}
 
 	req := &control.PoolQueryTargetReq{
@@ -699,7 +717,7 @@ func (cmd *PoolQueryTargetsCmd) Execute(args []string) error {
 		Targets: tgtsList,
 	}
 
-	resp, err := control.PoolQueryTargets(cmd.MustLogCtx(), cmd.ctlInvoker, req)
+	resp, err := control.PoolQueryTargets(ctx, cmd.ctlInvoker, req)
 
 	if cmd.JSONOutputEnabled() {
 		return cmd.OutputJSON(resp, err)

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -958,6 +958,41 @@ func TestPoolCommands(t *testing.T) {
 			nil,
 		},
 		{
+			"Query pool targets no arguments",
+			"pool query-targets mypool",
+			"",
+			errMissingFlag,
+		},
+		{
+			"Query pool targets no rank argument",
+			"pool query-targets mypool --target-idx=1",
+			"",
+			errMissingFlag,
+		},
+		{
+			"Query pool targets specific indices",
+			"pool query-targets mypool --rank=1 --target-idx=1,3",
+			strings.Join([]string{
+				printRequest(t, &control.PoolQueryTargetReq{
+					ID:      "mypool",
+					Rank:    1,
+					Targets: []uint32{1, 3},
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Query pool targets all indices; pool query fails",
+			"pool query-targets mypool --rank=1",
+			strings.Join([]string{
+				printRequest(t, &control.PoolQueryReq{
+					ID:        "mypool",
+					QueryMask: daos.DefaultPoolQueryMask,
+				}),
+			}, " "),
+			errors.New("pool query"),
+		},
+		{
 			"Query pool with UUID",
 			"pool query 12345678-1234-1234-1234-1234567890ab",
 			strings.Join([]string{


### PR DESCRIPTION
Running `(daos|dmg) pool query-targets` with just a rank
argument should query all targets on that rank.

Signed-off-by: Michael MacDonald <mjmac@google.com>