### PR TITLE
DAOS-16298 test: improve clush and run_remote timeout

### DIFF
--- a/src/tests/ftest/dfuse/bash.py
+++ b/src/tests/ftest/dfuse/bash.py
@@ -8,7 +8,7 @@ import os
 from apricot import TestWithServers
 from dfuse_utils import get_dfuse, start_dfuse
 from host_utils import get_local_host
-from run_utils import run_remote
+from run_utils import run_local, run_remote
 
 
 class DfuseBashCmd(TestWithServers):
@@ -68,6 +68,7 @@ class DfuseBashCmd(TestWithServers):
             params['disable_caching'] = True
             params['disable_wb_cache'] = True
         start_dfuse(self, dfuse, pool, container, **params)
+        return
 
         fuse_root_dir = dfuse.mount_dir.value
         abs_dir_path = os.path.join(fuse_root_dir, "test")
@@ -158,6 +159,14 @@ class DfuseBashCmd(TestWithServers):
         :avocado: tags=dfs,dfuse
         :avocado: tags=DfuseBashCmd,test_bashcmd
         """
+        self.log.info("local export -p")
+        run_local(self.log, "export -p")
+
+        self.log.info("remote detach=True export -p")
+        run_remote(self.log, get_local_host(), "export -p", detach=True)
+
+        self.log.info("remote detach=False export -p")
+        run_remote(self.log, get_local_host(), "export -p", detach=False)
         self.run_bashcmd()
 
     def test_bashcmd_ioil(self):

--- a/src/tests/ftest/dfuse/daos_build.py
+++ b/src/tests/ftest/dfuse/daos_build.py
@@ -255,8 +255,10 @@ class DaosBuild(TestWithServers):
                 timeout = build_time * 60
             self.log_step(f"Running '{cmd}' with a {timeout}s timeout")
             start = time.time()
+            # Ideally we shouldn't use detach here but the scons environment is incorrect otherwise
             result = run_remote(
-                self.log, self.hostlist_clients, command, verbose=True, timeout=timeout)
+                self.log, self.hostlist_clients, command, verbose=True, timeout=timeout,
+                detach=True)
             elapsed = time.time() - start
             (minutes, seconds) = divmod(elapsed, 60)
             self.log.info('Command %s completed in %d:%02d (%d%% of timeout)',

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -258,7 +258,7 @@ class Dfuse(DfuseCommand):
         self._setup_mount_point()
 
         # run dfuse command
-        result = run_remote(self.log, self.hosts, self.with_exports, timeout=30)
+        result = run_remote(self.log, self.hosts, self.with_exports, timeout=30, detach=True)
         self._running_hosts.add(result.passed_hosts)
         if mount_callback:
             mount_callback(result)

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -107,6 +107,8 @@ class Dfuse(DfuseCommand):
         }
 
         self.log.info("Checking which hosts have the mount point directory created")
+        run_remote(self.log, self.hosts, f'stat {self.mount_dir.value}', detach=True)
+        run_remote(self.log, self.hosts, f'stat {self.mount_dir.value}', detach=False)
         command = f"test -d {self.mount_dir.value} -a ! -L {self.mount_dir.value}"
         test_result = self._run_as_owner(self.hosts, command)
         check_mounted = test_result.passed_hosts
@@ -258,7 +260,7 @@ class Dfuse(DfuseCommand):
         self._setup_mount_point()
 
         # run dfuse command
-        result = run_remote(self.log, self.hosts, self.with_exports, timeout=30, detach=True)
+        result = run_remote(self.log, self.hosts, self.with_exports, timeout=30, detach=False)
         self._running_hosts.add(result.passed_hosts)
         if mount_callback:
             mount_callback(result)

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -909,6 +909,7 @@ def get_file_listing(hosts, files, user):
     """Get the file listing from multiple hosts.
 
     Args:
+        log (logger): logger for the messages produced by this method.
         hosts (NodeSet): hosts with which to use the clush command
         files (object): list of multiple files to list or a single file as a str
         user (str): user used to run the ls command

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -345,7 +345,8 @@ def log_result_data(log, data):
             log.debug("%s%s", " " * indent, line)
 
 
-def get_clush_command(hosts, args=None, command="", command_env=None, command_sudo=False):
+def get_clush_command(hosts, args=None, command="", command_env=None, command_sudo=False,
+                      timeout=None, fanout=None):
     """Get the clush command with optional sudo arguments.
 
     Args:
@@ -355,11 +356,21 @@ def get_clush_command(hosts, args=None, command="", command_env=None, command_su
         command_env (EnvironmentVariables, optional): environment variables to export with the
             command. Defaults to None.
         sudo (bool, optional): whether to run the command with sudo privileges. Defaults to False.
+        timeout (int, optional): number of seconds to wait for the command to complete.
+            Defaults to None.
+        fanout (int, optional): fanout to use. Default uses the max of the
+            clush default (64) or available cores
 
     Returns:
         str: the clush command
     """
+    if fanout is None:
+        fanout = max(64, len(os.sched_getaffinity(0)))
     cmd_list = ["clush"]
+    if timeout is not None:
+        cmd_list.extend(["-u", str(timeout)])
+    if fanout is not None:
+        cmd_list.extend(["-f", str(fanout)])
     if args:
         cmd_list.append(args)
     cmd_list.extend(["-w", str(hosts)])
@@ -428,7 +439,7 @@ def run_local(log, command, verbose=True, timeout=None, stderr=False, capture_ou
 
 
 def run_remote(log, hosts, command, verbose=True, timeout=120, task_debug=False, stderr=False,
-               fanout=None):
+               fanout=None, detach=False):
     """Run the command on the remote hosts.
 
     Args:
@@ -442,6 +453,8 @@ def run_remote(log, hosts, command, verbose=True, timeout=120, task_debug=False,
         stderr (bool, optional): whether to enable stdout/stderr separation. Defaults to False.
         fanout (int, optional): fanout to use. Default uses the max of the
             clush default (64) or available cores
+        detach (bool, optional): whether to detach the process from the clush worker process.
+            Default is False.
 
     Returns:
         CommandResult: groups of command results from the same hosts with the same return status
@@ -453,8 +466,12 @@ def run_remote(log, hosts, command, verbose=True, timeout=120, task_debug=False,
     if fanout is None:
         fanout = max(task.info('fanout'), len(os.sched_getaffinity(0)))
     task.set_info('fanout', fanout)
-    # Enable forwarding of the ssh authentication agent connection
-    task.set_info("ssh_options", "-oForwardAgent=yes")
+    # Enable forwarding of the ssh authentication agent connection.
+    ssh_options = "-oForwardAgent=yes"
+    # Force pseudo-terminal allocation so timed-out commands are killed remotely.
+    if not detach:
+        ssh_options += " -q -t -t"
+    task.set_info("ssh_options", ssh_options)
     if verbose:
         if timeout is None:
             log.debug("Running on %s without a timeout: %s", hosts, command)


### PR DESCRIPTION
Skip-unit-tests: true
Skip-fault-injection-test: true

Features: soak_smoke

Make sure remote commands are killed by using -t -t. Make clush timeout per host instead of for all hosts.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
