### PR TITLE
DAOS-16286 client: intercept fdatasync() (#14835)

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -399,6 +399,8 @@ static int (*next_unlinkat)(int dirfd, const char *path, int flags);
 
 static int (*next_fsync)(int fd);
 
+static int (*next_fdatasync)(int fd);
+
 static int (*next_truncate)(const char *path, off_t length);
 
 static int (*next_ftruncate)(int fd, off_t length);
@@ -5284,6 +5286,28 @@ fsync(int fd)
 	/* errno = ENOTSUP;
 	 * return (-1);
 	 */
+	return 0;
+}
+
+int
+fdatasync(int fd)
+{
+	int fd_directed;
+
+	if (next_fdatasync == NULL) {
+		next_fdatasync = dlsym(RTLD_NEXT, "fdatasync");
+		D_ASSERT(next_fdatasync != NULL);
+	}
+	if (!d_hook_enabled)
+		return next_fdatasync(fd);
+
+	fd_directed = d_get_fd_redirected(fd);
+	if (fd_directed < FD_FILE_BASE)
+		return next_fdatasync(fd);
+
+	if (fd < FD_DIR_BASE && d_compatible_mode)
+		return next_fdatasync(fd);
+
 	return 0;
 }
 

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -83,6 +83,10 @@ do_openat(void **state)
 	rc = write(fd, input_buf, sizeof(input_buf));
 	assert_return_code(rc, errno);
 
+	/* test fdatasync() */
+	rc = fdatasync(fd);
+	assert_return_code(rc, errno);
+
 	/* First fstat.  IL will forward this to the kernel so it can save ino for future calls */
 	rc = fstat(fd, &stbuf0);
 	assert_return_code(rc, errno);


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
