### PR TITLE
DAOS-16300 cart: Parse domain properly for multi-interface case

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -416,6 +416,9 @@ crt_iface_name2idx(const char *iface_name, int *idx)
 	for (i = 0; i < num_ifaces; i++) {
 		name = crt_provider_iface_str_get(true, crt_gdata.cg_primary_prov, i);
 
+		if (!name)
+			return -DER_INVAL;
+
 		if (strcmp(name, iface_name) == 0) {
 			*idx = i;
 			return DER_SUCCESS;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -709,6 +709,7 @@ crt_get_info_string(bool primary, crt_provider_t provider, int iface_idx,
 	int	 start_port;
 	char	*domain_str;
 	char	*iface_str;
+	bool	no_iface, no_domain;
 	int	rc = 0;
 
 	provider_str = crt_provider_name_get(provider);
@@ -733,39 +734,42 @@ crt_get_info_string(bool primary, crt_provider_t provider, int iface_idx,
 		D_GOTO(out, rc);
 	}
 
+	/* treat not set and set to empty as the same */
+	no_iface = (iface_str == NULL || *iface_str == '\0') ? true : false;
+	no_domain = (domain_str == NULL || *domain_str == '\0') ? true : false;
+
 	/* TODO: for now pass same info for all providers including CXI */
 	if (crt_provider_is_contig_ep(provider) && start_port != -1) {
-
-		if (iface_str == NULL) {
-			if (domain_str)
-				D_ASPRINTF(*string, "%s://%s:%d",
-					   provider_str, domain_str, start_port + ctx_idx);
-			else
+		if (no_iface) {
+			if (no_domain)
 				D_ASPRINTF(*string, "%s://:%d",
 					   provider_str, start_port + ctx_idx);
-		} else {
-			if (domain_str)
-				D_ASPRINTF(*string, "%s://%s/%s:%d",
-					   provider_str, domain_str, iface_str,
-					   start_port + ctx_idx);
 			else
+				D_ASPRINTF(*string, "%s://%s:%d",
+					   provider_str, domain_str, start_port + ctx_idx);
+		} else {
+			if (no_domain)
 				D_ASPRINTF(*string, "%s://%s:%d",
 					   provider_str, iface_str,
 					   start_port + ctx_idx);
+			else
+				D_ASPRINTF(*string, "%s://%s/%s:%d",
+					   provider_str, domain_str, iface_str,
+					   start_port + ctx_idx);
 		}
 	} else {
-		if (iface_str == NULL) {
-			if (domain_str)
+		if (no_iface) {
+			if (no_domain)
+				D_ASPRINTF(*string, "%s://", provider_str);
+			else
 				D_ASPRINTF(*string, "%s://%s",
 					   provider_str, domain_str);
-			else
-				D_ASPRINTF(*string, "%s://", provider_str);
 		} else {
-			if (domain_str)
+			if (no_domain)
+				D_ASPRINTF(*string, "%s://%s", provider_str, iface_str);
+			else
 				D_ASPRINTF(*string, "%s://%s/%s",
 					   provider_str, domain_str, iface_str);
-			else
-				D_ASPRINTF(*string, "%s://%s", provider_str, iface_str);
 		}
 	}
 

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -709,7 +709,7 @@ crt_get_info_string(bool primary, crt_provider_t provider, int iface_idx,
 	int	 start_port;
 	char	*domain_str;
 	char	*iface_str;
-	bool	no_iface, no_domain;
+	bool     no_iface, no_domain;
 	int	rc = 0;
 
 	provider_str = crt_provider_name_get(provider);
@@ -735,41 +735,38 @@ crt_get_info_string(bool primary, crt_provider_t provider, int iface_idx,
 	}
 
 	/* treat not set and set to empty as the same */
-	no_iface = (iface_str == NULL || *iface_str == '\0') ? true : false;
+	no_iface  = (iface_str == NULL || *iface_str == '\0') ? true : false;
 	no_domain = (domain_str == NULL || *domain_str == '\0') ? true : false;
 
 	/* TODO: for now pass same info for all providers including CXI */
 	if (crt_provider_is_contig_ep(provider) && start_port != -1) {
 		if (no_iface) {
 			if (no_domain)
-				D_ASPRINTF(*string, "%s://:%d",
-					   provider_str, start_port + ctx_idx);
+				D_ASPRINTF(*string, "%s://:%d", provider_str, start_port + ctx_idx);
 			else
-				D_ASPRINTF(*string, "%s://%s:%d",
-					   provider_str, domain_str, start_port + ctx_idx);
+				D_ASPRINTF(*string, "%s://%s:%d", provider_str, domain_str,
+					   start_port + ctx_idx);
 		} else {
 			if (no_domain)
 				D_ASPRINTF(*string, "%s://%s:%d",
 					   provider_str, iface_str,
 					   start_port + ctx_idx);
 			else
-				D_ASPRINTF(*string, "%s://%s/%s:%d",
-					   provider_str, domain_str, iface_str,
-					   start_port + ctx_idx);
+				D_ASPRINTF(*string, "%s://%s/%s:%d", provider_str, domain_str,
+					   iface_str, start_port + ctx_idx);
 		}
 	} else {
 		if (no_iface) {
 			if (no_domain)
 				D_ASPRINTF(*string, "%s://", provider_str);
 			else
-				D_ASPRINTF(*string, "%s://%s",
-					   provider_str, domain_str);
+				D_ASPRINTF(*string, "%s://%s", provider_str, domain_str);
 		} else {
 			if (no_domain)
 				D_ASPRINTF(*string, "%s://%s", provider_str, iface_str);
 			else
-				D_ASPRINTF(*string, "%s://%s/%s",
-					   provider_str, domain_str, iface_str);
+				D_ASPRINTF(*string, "%s://%s/%s", provider_str, domain_str,
+					   iface_str);
 		}
 	}
 

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -770,7 +770,8 @@ crt_get_info_string(bool primary, crt_provider_t provider, int iface_idx,
 	}
 
 	D_DEBUG(DB_ALL, "iface_idx:%d context:%d domain_str=%s iface_str=%s info_str=%s\n",
-		iface_idx, ctx_idx, domain_str ? domain_str : "none", iface_str ? iface_str : "none" , *string);
+		iface_idx, ctx_idx, domain_str ? domain_str : "none",
+		iface_str ? iface_str : "none", *string);
 out:
 	if (rc == DER_SUCCESS && *string == NULL)
 		return -DER_NOMEM;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -770,7 +770,7 @@ crt_get_info_string(bool primary, crt_provider_t provider, int iface_idx,
 	}
 
 	D_DEBUG(DB_ALL, "iface_idx:%d context:%d domain_str=%s iface_str=%s info_str=%s\n",
-		iface_idx, ctx_idx, domain_str, iface_str, *string);
+		iface_idx, ctx_idx, domain_str ? domain_str : "none", iface_str ? iface_str : "none" , *string);
 out:
 	if (rc == DER_SUCCESS && *string == NULL)
 		return -DER_NOMEM;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -532,16 +532,8 @@ crt_provider_iface_str_get(bool primary, crt_provider_t provider, int iface_idx)
 	if (prov_data->cpg_na_config.noc_interface == NULL)
 		return NULL;
 
-	/*
- 	 * CXI provider requires domain names instead of interfaces.
- 	 * Returning NULL here will cause crt_get_info_string() to use domain names instead
-	 * */
-	if (provider == CRT_PROV_OFI_CXI)
-		return NULL;
-
-	D_ASSERTF(iface_idx < prov_data->cpg_na_config.noc_iface_total,
-		  "Bad iface_idx=%d\n", iface_idx);
-
+	D_ASSERTF(iface_idx < prov_data->cpg_na_config.noc_iface_total, "Bad iface_idx=%d\n",
+		  iface_idx);
 	return prov_data->cpg_na_config.noc_iface_str[iface_idx];
 }
 
@@ -722,7 +714,12 @@ crt_get_info_string(bool primary, crt_provider_t provider, int iface_idx,
 	provider_str = crt_provider_name_get(provider);
 	start_port = crt_provider_ctx0_port_get(primary, provider);
 	domain_str   = crt_provider_domain_str_get(primary, provider, iface_idx);
-	iface_str = crt_provider_iface_str_get(primary, provider, iface_idx);
+
+	/* CXI provider uses domain names for info string */
+	if (provider == CRT_PROV_OFI_CXI)
+		iface_str = NULL;
+	else
+		iface_str = crt_provider_iface_str_get(primary, provider, iface_idx);
 
 	if (provider == CRT_PROV_SM) {
 		D_ASPRINTF(*string, "%s://", provider_str);

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -1120,10 +1120,9 @@ crt_na_config_init(bool primary, crt_provider_t provider,
 
 		/* store each interface name in the na_cfg->noc_iface_str[] array */
 		save_ptr = 0;
+		idx      = 0;
 		token = strtok_r(na_cfg->noc_interface, ",", &save_ptr);
 		while (token != NULL) {
-			D_DEBUG(DB_ALL, "Interface[%d] = %s\n", idx, token);
-
 			na_cfg->noc_iface_str[idx] = token;
 			token = strtok_r(NULL, ",", &save_ptr);
 			idx++;
@@ -1131,9 +1130,37 @@ crt_na_config_init(bool primary, crt_provider_t provider,
 	} else {
 		count = 0;
 	}
-
 	na_cfg->noc_iface_total = count;
-	D_DEBUG(DB_ALL, "Total %d interfaces parsed from %s\n", count, interface);
+
+	count = 0;
+	if (na_cfg->noc_domain) {
+		/* count number of ','-separated domains */
+		count    = 1;
+		save_ptr = na_cfg->noc_domain;
+
+		while (*save_ptr != '\0') {
+			if (*save_ptr == ',')
+				count++;
+			save_ptr++;
+		}
+
+		D_ALLOC_ARRAY(na_cfg->noc_domain_str, count);
+		if (!na_cfg->noc_domain_str)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		/* store each domain name in the na_cfg->noc_domain_str[] array */
+		save_ptr = 0;
+		idx      = 0;
+		token    = strtok_r(na_cfg->noc_domain, ",", &save_ptr);
+		while (token != NULL) {
+			na_cfg->noc_domain_str[idx] = token;
+			token                       = strtok_r(NULL, ",", &save_ptr);
+			idx++;
+		}
+	} else {
+		count = 0;
+	}
+	na_cfg->noc_domain_total = count;
 
 	if (crt_is_service() && port_str != NULL && strlen(port_str) > 0) {
 		if (!is_integer_str(port_str)) {
@@ -1173,6 +1200,7 @@ out:
 		D_FREE(na_cfg->noc_domain);
 		D_FREE(na_cfg->noc_auth_key);
 		D_FREE(na_cfg->noc_iface_str);
+		D_FREE(na_cfg->noc_domain_str);
 	}
 	return rc;
 }
@@ -1186,6 +1214,8 @@ void crt_na_config_fini(bool primary, crt_provider_t provider)
 	D_FREE(na_cfg->noc_domain);
 	D_FREE(na_cfg->noc_auth_key);
 	D_FREE(na_cfg->noc_iface_str);
+	D_FREE(na_cfg->noc_domain_str);
 	na_cfg->noc_port = 0;
 	na_cfg->noc_iface_total = 0;
+	na_cfg->noc_domain_total = 0;
 }

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -1076,19 +1076,9 @@ crt_na_config_init(bool primary, crt_provider_t provider,
 	}
 
 	if (interface) {
-		if (provider == CRT_PROV_OFI_CXI) {
-			D_INFO("Interface '%s' ignored for CXI. Using domain '%s' instead\n",
-			       interface, domain);
-
-			/* Note: crt_provider_iface_str_get() returns interface name  */
-			D_STRNDUP(na_cfg->noc_interface, domain, 64);
-			if (!na_cfg->noc_interface)
-				D_GOTO(out, rc = -DER_NOMEM);
-		} else {
-			D_STRNDUP(na_cfg->noc_interface, interface, 64);
-			if (!na_cfg->noc_interface)
-				D_GOTO(out, rc = -DER_NOMEM);
-		}
+		D_STRNDUP(na_cfg->noc_interface, interface, 64);
+		if (!na_cfg->noc_interface)
+			D_GOTO(out, rc = -DER_NOMEM);
 	}
 
 	if (domain) {

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -1152,6 +1152,12 @@ crt_na_config_init(bool primary, crt_provider_t provider,
 	}
 	na_cfg->noc_domain_total = count;
 
+	if (na_cfg->noc_domain_total > 0 && na_cfg->noc_domain_total != na_cfg->noc_iface_total) {
+		D_ERROR("Mismatched number of domains (%d) and interfaces (%d) specified\n",
+			na_cfg->noc_domain_total, na_cfg->noc_iface_total);
+		D_GOTO(out, rc = -DER_INVAL);
+	}
+
 	if (crt_is_service() && port_str != NULL && strlen(port_str) > 0) {
 		if (!is_integer_str(port_str)) {
 			D_DEBUG(DB_ALL, "ignoring invalid D_PORT %s.", port_str);

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -34,7 +34,7 @@ struct crt_grp_gdata;
 struct crt_na_config {
 	int32_t		 noc_port;
 	int		 noc_iface_total;
-	int		 noc_domain_total;
+	int               noc_domain_total;
 	char		*noc_interface;
 	char		*noc_domain;
 	char		*noc_auth_key;

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -34,10 +34,12 @@ struct crt_grp_gdata;
 struct crt_na_config {
 	int32_t		 noc_port;
 	int		 noc_iface_total;
+	int               noc_domain_total;
 	char		*noc_interface;
 	char		*noc_domain;
 	char		*noc_auth_key;
 	char		**noc_iface_str; /* Array of interfaces */
+	char            **noc_domain_str; /* Array of domains */
 };
 
 struct crt_prov_gdata {

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -34,7 +34,7 @@ struct crt_grp_gdata;
 struct crt_na_config {
 	int32_t		 noc_port;
 	int		 noc_iface_total;
-	int               noc_domain_total;
+	int		 noc_domain_total;
 	char		*noc_interface;
 	char		*noc_domain;
 	char		*noc_auth_key;

--- a/src/tests/ftest/cart/no_pmix_multi_ctx.c
+++ b/src/tests/ftest/cart/no_pmix_multi_ctx.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -110,6 +110,8 @@ int main(int argc, char **argv)
 	char		*env;
 	char		*cur_iface_str;
 	char		*new_iface_str;
+	char            *cur_domain_str = NULL;
+	char            *new_domain_str = NULL;
 	int		iface_idx = -1;
 	int		num_ifaces;
 	crt_context_t	c1,c2;
@@ -164,8 +166,23 @@ int main(int argc, char **argv)
 	/* Append loopback to the current interface list */
 	D_ASPRINTF(new_iface_str, "%s,lo", cur_iface_str);
 	D_ASSERTF(new_iface_str != NULL, "Failed to allocate string");
-
 	setenv("D_INTERFACE", new_iface_str, 1);
+
+	/* Append ',lo' to domain string as 'lo' should be available everywhere */
+	env = getenv("D_DOMAIN");
+
+	/* Domain is optional, can be set for manual testing */
+	if (env != NULL) {
+		/* Save current domain value */
+		D_ASPRINTF(cur_domain_str, "%s", env);
+		D_ASSERTF(cur_domain_str != NULL, "Failed to allocate string");
+
+		/* Append loopback to the current domain list */
+		D_ASPRINTF(new_domain_str, "%s,lo", cur_domain_str);
+		D_ASSERTF(new_domain_str != NULL, "Failed to allocate string");
+
+		setenv("D_DOMAIN", new_domain_str, 1);
+	}
 
 	/* Reinitialize as a client to be able to use multi-interface APIs */
 	rc = crt_init(0, 0);
@@ -204,6 +221,8 @@ int main(int argc, char **argv)
 
 	D_FREE(cur_iface_str);
 	D_FREE(new_iface_str);
+	D_FREE(cur_domain_str);
+	D_FREE(new_domain_str);
 	D_FREE(uri1);
 	D_FREE(uri2);
 

--- a/src/tests/ftest/cart/no_pmix_multi_ctx.c
+++ b/src/tests/ftest/cart/no_pmix_multi_ctx.c
@@ -119,6 +119,10 @@ int main(int argc, char **argv)
 	char		*uri2;
 	int		rc;
 
+	/* Set these 2 if they are not set so that test still runs by default */
+	setenv("D_PROVIDER", "ofi+tcp", 0);
+	setenv("D_INTERFACE", "eth0", 0);
+
 	rc = d_log_init();
 	assert(rc == 0);
 
@@ -236,6 +240,28 @@ int main(int argc, char **argv)
 	D_ASSERTF(rc == 0, "crt_finalize() failed");
 	DBG_PRINT("Multi-interface context tests PASSED\n");
 
+	/* Test CXI as CaRT treats interface differently for it from other providers */
+	DBG_PRINT("Multi-interface tests, stage 2\n");
+	setenv("D_PROVIDER", "ofi+cxi", 1);
+	setenv("D_INTERFACE", "hsn0,hsn1,hsn2,hsn3,hsn4,hsn5,hsn6,hsn7", 1);
+	setenv("D_DOMAIN", "cxi0,cxi1,cxi2,cxi3,cxi4,cxi5,cxi6,cxi7", 1);
+
+	/* Reinitialize as a client to be able to use multi-interface APIs */
+	rc = crt_init(0, 0);
+	D_ASSERTF(rc == 0, "crt_init() failed; rc=%d\n", rc);
+
+	/* Test multi-interface APIs */
+	num_ifaces = crt_num_ifaces_get();
+	D_ASSERTF(num_ifaces == 8, "expected 8, got %d interafces\n", num_ifaces);
+
+	rc = crt_iface_name2idx("hsn4", &iface_idx);
+	D_ASSERTF(rc == 0, "crt_iface_name2idx() failed; rc=%d\n", rc);
+	D_ASSERTF(iface_idx == 4, "Expected index 4, got %d\n", iface_idx);
+
+	rc = crt_finalize();
+	D_ASSERTF(rc == 0, "crt_finalize() failed");
+
+	DBG_PRINT("Multi-interface tests, stage 2 PASSED\n");
 	d_log_fini();
 
 	return 0;


### PR DESCRIPTION
- parse out domain similarly to interface for multi-interface case
- fix issue with multi-interface and cxi workaround 
- treat not set and set to empty as the same for domain/interface
- update test
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
