### PR TITLE
DAOS-15064 mgmt: Show all ranks in daos system query (#14764)

### DIFF
--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2023 Intel Corporation.
+ * (C) Copyright 2015-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -278,6 +278,10 @@ struct daos_sys_info {
 	uint32_t		 dsi_nr_ranks;
 	/** ranks and their client-accessible URIs */
 	struct daos_rank_uri	*dsi_ranks;
+	/** length of MS ranks array */
+	uint32_t                 dsi_nr_ms_ranks;
+	/** MS rank numbers */
+	uint32_t                *dsi_ms_ranks;
 };
 
 /** max pool/cont attr size */

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -475,14 +475,20 @@ dc_mgmt_get_sys_info(const char *sys, struct daos_sys_info **out)
 	if (info == NULL)
 		D_GOTO(out_attach_info, rc = -DER_NOMEM);
 
+	D_ALLOC_ARRAY(info->dsi_ms_ranks, resp->n_ms_ranks);
+	if (info->dsi_ms_ranks == NULL)
+		D_GOTO(err_info, rc = -DER_NOMEM);
+	memcpy(info->dsi_ms_ranks, resp->ms_ranks, resp->n_ms_ranks * sizeof(uint32_t));
+	info->dsi_nr_ms_ranks = resp->n_ms_ranks;
+
 	rc = alloc_rank_uris(resp, &ranks);
 	if (rc != 0) {
 		D_ERROR("failed to allocate rank URIs: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(err_info, rc);
+		D_GOTO(err_ms_ranks, rc);
 	}
-
-	info->dsi_nr_ranks = resp->n_ms_ranks;
+	info->dsi_nr_ranks = resp->n_rank_uris;
 	info->dsi_ranks = ranks;
+
 	copy_str(info->dsi_system_name, internal.system_name);
 	copy_str(info->dsi_fabric_provider, internal.provider);
 
@@ -490,6 +496,8 @@ dc_mgmt_get_sys_info(const char *sys, struct daos_sys_info **out)
 
 	D_GOTO(out_attach_info, rc = 0);
 
+err_ms_ranks:
+	D_FREE(info->dsi_ms_ranks);
 err_info:
 	D_FREE(info);
 out_attach_info:

--- a/src/tests/ftest/control/daos_system_query.py
+++ b/src/tests/ftest/control/daos_system_query.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2023 Intel Corporation.
+  (C) Copyright 2023-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -32,6 +32,9 @@ class DaosSystemQuery(TestWithServers):
         exp_sys_name = self.server_managers[0].get_config_value("name")
         exp_provider = self.server_managers[0].get_config_value("provider")
 
+        num_access_points = len(self.host_info.access_points)
+        exp_num_ap_ranks = num_access_points * engines_per_host
+
         query_output = daos_cmd.system_query()["response"]
 
         sys_name = query_output["system_name"]
@@ -45,3 +48,8 @@ class DaosSystemQuery(TestWithServers):
         num_ranks = len(query_output["rank_uris"])
         if num_ranks != exp_num_ranks:
             self.fail("expected {} rank URIs, got '{}'".format(exp_num_ranks, num_ranks))
+
+        num_ap_ranks = len(query_output["access_point_rank_uris"])
+        if num_ap_ranks != exp_num_ap_ranks:
+            self.fail("expected {} access point rank URIs, got '{}'".format(exp_num_ap_ranks,
+                                                                            num_ap_ranks))

--- a/src/tests/ftest/control/daos_system_query.yaml
+++ b/src/tests/ftest/control/daos_system_query.yaml
@@ -1,5 +1,5 @@
 hosts:
-  test_servers: 1
+  test_servers: 2
   test_clients: 1
 timeout: 80
 server_config:
@@ -7,7 +7,6 @@ server_config:
   engines_per_host: 1
   engines:
     0:
-      pinned_numa_node: 0
       targets: 4
       nr_xs_helpers: 0
       fabric_iface_port: 31416
@@ -18,5 +17,5 @@ server_config:
       storage:
         0:
           class: ram
-          scm_mount: /mnt/daos
+          scm_mount: /mnt/daos0
   system_ram_reserved: 1

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -409,6 +409,9 @@ get_sys_info_test(void **state)
 	for (i = 0; i < info->dsi_nr_ranks; i++)
 		print_message("rank %u, uri: %s\n", info->dsi_ranks[i].dru_rank,
 			      info->dsi_ranks[i].dru_uri);
+	print_message("number of MS ranks: %d\n", info->dsi_nr_ms_ranks);
+	for (i = 0; i < info->dsi_nr_ms_ranks; i++)
+		print_message("rank %u\n", info->dsi_ms_ranks[i]);
 
 	daos_mgmt_put_sys_info(info);
 }


### PR DESCRIPTION
A bug was limiting the number of ranks shown to the number of MS replicas instead.

- Show all rank fabric URIs.
- Added MS ranks list to sys info.
- Add MS ranks to daos system query output.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
