### PR TITLE
DAOS-16164 pool: Update target status to UPIN for no_data_sync mode #…

### DIFF
--- a/docs/admin/pool_operations.md
+++ b/docs/admin/pool_operations.md
@@ -626,7 +626,7 @@ only updates pool map to include rank.
 
 NB: with "no_data_sync" enabled, containers will be turned to read-only, daos won't trigger
 rebuild to restore the pool data redundancy on the surviving storage engines if there are
-dead rank events.
+dead rank events. Drain and extend operations will not be allowed in this mode.
 
 ## Access Control Lists
 

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -20,7 +20,6 @@
 
 #include "crt_internal.h"
 #include <cart/iv.h>
-#include <daos/common.h>
 
 #define IV_DBG(key, msg, ...) \
 	D_DEBUG(DB_TRACE, "[key=%p] " msg, (key)->iov_buf, ##__VA_ARGS__)
@@ -2283,8 +2282,8 @@ crt_ivsync_rpc_issue(struct crt_ivns_internal *ivns_internal, uint32_t class_id,
 		}
 	}
 	D_INFO("%sbulk transfer because size(%zu), inline limit(%u)\n",
-	       (local_bulk == CRT_BULK_NULL) ? "NO " : "",
-	       d_sgl_buf_size(iv_value), crt_gdata.cg_iv_inline_limit);
+	       (local_bulk == CRT_BULK_NULL) ? "NO " : "", d_sgl_buf_size(iv_value),
+	       crt_gdata.cg_iv_inline_limit);
 
 	rc = crt_corpc_req_create(ivns_internal->cii_ctx,
 				  &ivns_internal->cii_grp_priv->gp_pub,

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2280,12 +2280,11 @@ crt_ivsync_rpc_issue(struct crt_ivns_internal *ivns_internal, uint32_t class_id,
 			D_ERROR("ctt_bulk_create(): "DF_RC"\n", DP_RC(rc));
 			D_GOTO(exit, rc);
 		}
-		D_INFO("bulk transfer, size(%zu) > inline limit(%u)\n",
-		       d_sgl_buf_size(iv_value), crt_gdata.cg_iv_inline_limit);
-	} else {
-		D_INFO("NO bulk transfer, iv_value=%p, size(%zu), inline limit(%u)\n",
-		       iv_value, iv_value ? d_sgl_buf_size(iv_value) : 0,
+		D_INFO("bulk transfer, size(%zu) > inline limit(%u)\n", d_sgl_buf_size(iv_value),
 		       crt_gdata.cg_iv_inline_limit);
+	} else {
+		D_INFO("NO bulk transfer, iv_value=%p, size(%zu), inline limit(%u)\n", iv_value,
+		       iv_value ? d_sgl_buf_size(iv_value) : 0, crt_gdata.cg_iv_inline_limit);
 	}
 
 	rc = crt_corpc_req_create(ivns_internal->cii_ctx,

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -20,6 +20,7 @@
 
 #include "crt_internal.h"
 #include <cart/iv.h>
+#include <daos/common.h>
 
 #define IV_DBG(key, msg, ...) \
 	D_DEBUG(DB_TRACE, "[key=%p] " msg, (key)->iov_buf, ##__VA_ARGS__)
@@ -1884,8 +1885,13 @@ crt_hdlr_iv_sync_aux(void *arg)
 				D_ERROR("crt_bulk_access(): "DF_RC"\n", DP_RC(rc));
 				D_GOTO(exit, rc);
 			}
+			D_INFO("tmp_iv sgl coming from bulk\n");
 		} else if (input->ivs_sync_sgl.sg_nr > 0) {
 			tmp_iv = input->ivs_sync_sgl;
+			D_INFO("tmp_iv sgl coming from input->ivs_sync_sgl\n");
+		} else {
+			memset(&tmp_iv, 0x0, sizeof(tmp_iv));
+			D_INFO("tmp_iv sgl coming from memset\n");
 		}
 
 		rc = iv_ops->ivo_on_refresh(ivns_internal, &input->ivs_key,
@@ -2067,8 +2073,13 @@ call_pre_sync_cb(struct crt_ivns_internal *ivns_internal,
 			D_ERROR("crt_bulk_access(): "DF_RC"\n", DP_RC(rc));
 			D_GOTO(exit, rc);
 		}
+		D_INFO("tmp_iv sgl coming from bulk\n");
 	} else if (input->ivs_sync_sgl.sg_nr > 0) {
 		tmp_iv = input->ivs_sync_sgl;
+		D_INFO("tmp_iv sgl coming from input->ivs_sync_sgl\n");
+	} else {
+		memset(&tmp_iv, 0x0, sizeof(tmp_iv));
+		D_INFO("tmp_iv sgl coming from memset\n");
 	}
 
 	D_DEBUG(DB_TRACE, "Executing ivo_pre_sync\n");

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2280,10 +2280,13 @@ crt_ivsync_rpc_issue(struct crt_ivns_internal *ivns_internal, uint32_t class_id,
 			D_ERROR("ctt_bulk_create(): "DF_RC"\n", DP_RC(rc));
 			D_GOTO(exit, rc);
 		}
+		D_INFO("bulk transfer, size(%zu) > inline limit(%u)\n",
+		       d_sgl_buf_size(iv_value), crt_gdata.cg_iv_inline_limit);
+	} else {
+		D_INFO("NO bulk transfer, iv_value=%p, size(%zu), inline limit(%u)\n",
+		       iv_value, iv_value ? d_sgl_buf_size(iv_value) : 0,
+		       crt_gdata.cg_iv_inline_limit);
 	}
-	D_INFO("%sbulk transfer because size(%zu), inline limit(%u)\n",
-	       (local_bulk == CRT_BULK_NULL) ? "NO " : "", d_sgl_buf_size(iv_value),
-	       crt_gdata.cg_iv_inline_limit);
 
 	rc = crt_corpc_req_create(ivns_internal->cii_ctx,
 				  &ivns_internal->cii_grp_priv->gp_pub,

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2282,6 +2282,9 @@ crt_ivsync_rpc_issue(struct crt_ivns_internal *ivns_internal, uint32_t class_id,
 			D_GOTO(exit, rc);
 		}
 	}
+	D_INFO("%sbulk transfer because size(%zu), inline limit(%u)\n",
+	       (local_bulk == CRT_BULK_NULL) ? "NO " : "",
+	       d_sgl_buf_size(iv_value), crt_gdata.cg_iv_inline_limit);
 
 	rc = crt_corpc_req_create(ivns_internal->cii_ctx,
 				  &ivns_internal->cii_grp_priv->gp_pub,

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1242,10 +1242,24 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 	crt_group_rank(pool->sp_group, &iv_entry->piv_map.piv_master_rank);
 	iv_entry->piv_map.piv_pool_map_ver =
 		buf == NULL ? 0 : pool->sp_map_version;
-	if (buf != NULL)
+	if (buf != NULL) {
+		struct pool_map *map = NULL;
+
 		memcpy(&iv_entry->piv_map.piv_pool_buf, buf,
 		       pool_buf_size(buf->pb_nr));
+		D_INFO(DF_UUID ": map_ver=%u (cached %u, entry %u), entry_size=%u, buf_size=%ld, "
+		       "components: %u/%u/%u/%u (pb_nr/pb_domain_nr/pb_node_nr/pb_target_nr)\n",
+		       DP_UUID(pool->sp_uuid), map_ver, pool->sp_map_version,
+		       iv_entry->piv_map.piv_pool_map_ver, iv_entry_size, pool_buf_size(buf->pb_nr),
+		       buf->pb_nr, buf->pb_domain_nr, buf->pb_node_nr, buf->pb_target_nr);
 
+		rc = pool_map_create(&iv_entry->piv_map.piv_pool_buf, map_ver, &map);
+		if (rc == 0)
+			pool_map_decref(map);
+		else
+			DL_WARN(rc, DF_UUID ": FAILED sanity check pool_map_create()!",
+				DP_UUID(pool->sp_uuid));
+	}
 	/* FIXME: Let's update the pool map synchronously for the moment,
 	 * since there is no easy way to free the iv_entry buffer. Needs
 	 * to revisit here once pool/cart_group/IV is upgraded.

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1251,7 +1251,8 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		/* Debugging code, print out new map buffer important values,
 		 * and temporarily construct a pool_map from the new buffer, as a sanity check.
 		 */
-		D_INFO(DF_UUID ": NEW: map_ver=%u (entry %u), entry_size=%u, buf_size=%ld, "
+		D_INFO(DF_UUID
+		       ": NEW: map_ver=%u (entry %u), entry_size=%u, buf_size=%ld, "
 		       "components: %u/%u/%u/%u (pb_nr/pb_domain_nr/pb_node_nr/pb_target_nr)\n",
 		       DP_UUID(pool->sp_uuid), map_ver, iv_entry->piv_map.piv_pool_map_ver,
 		       iv_entry_size, pool_buf_size(buf->pb_nr), buf->pb_nr, buf->pb_domain_nr,

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1247,11 +1247,15 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 
 		memcpy(&iv_entry->piv_map.piv_pool_buf, buf,
 		       pool_buf_size(buf->pb_nr));
-		D_INFO(DF_UUID ": map_ver=%u (cached %u, entry %u), entry_size=%u, buf_size=%ld, "
+
+		/* Debugging code, print out new map buffer important values,
+		 * and temporarily construct a pool_map from the new buffer, as a sanity check.
+		 */
+		D_INFO(DF_UUID ": NEW: map_ver=%u (entry %u), entry_size=%u, buf_size=%ld, "
 		       "components: %u/%u/%u/%u (pb_nr/pb_domain_nr/pb_node_nr/pb_target_nr)\n",
-		       DP_UUID(pool->sp_uuid), map_ver, pool->sp_map_version,
-		       iv_entry->piv_map.piv_pool_map_ver, iv_entry_size, pool_buf_size(buf->pb_nr),
-		       buf->pb_nr, buf->pb_domain_nr, buf->pb_node_nr, buf->pb_target_nr);
+		       DP_UUID(pool->sp_uuid), map_ver, iv_entry->piv_map.piv_pool_map_ver,
+		       iv_entry_size, pool_buf_size(buf->pb_nr), buf->pb_nr, buf->pb_domain_nr,
+		       buf->pb_node_nr, buf->pb_target_nr);
 
 		rc = pool_map_create(&iv_entry->piv_map.piv_pool_buf, map_ver, &map);
 		if (rc == 0)

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -388,6 +388,7 @@ pool_prop_default_copy(daos_prop_t *prop_def, daos_prop_t *prop)
 		case DAOS_PROP_PO_CHECKPOINT_MODE:
 		case DAOS_PROP_PO_CHECKPOINT_THRESH:
 		case DAOS_PROP_PO_CHECKPOINT_FREQ:
+		case DAOS_PROP_PO_REINT_MODE:
 			entry_def->dpe_val = entry->dpe_val;
 			break;
 		case DAOS_PROP_PO_ACL:
@@ -6872,6 +6873,15 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 	daos_epoch_t			rebuild_eph = d_hlc_get();
 	uint64_t			delay = 2;
 
+	/*
+	 * For simplicity, deny drain and extend operations in
+	 * the no_data_sync reinteration mode.
+	 */
+	if (svc->ps_pool->sp_reint_mode == DAOS_REINT_MODE_NO_DATA_SYNC) {
+		if (opc != MAP_REINT && opc != MAP_EXCLUDE)
+			return -DER_NO_PERM;
+	}
+
 	rc = pool_svc_update_map_internal(svc, opc, exclude_rank, extend_rank_list,
 					  extend_domains_nr, extend_domains,
 					  &target_list, list, hint, &updated,
@@ -6904,12 +6914,12 @@ pool_svc_update_map(struct pool_svc *svc, crt_opcode_t opc, bool exclude_rank,
 
 	if (svc->ps_pool->sp_reint_mode == DAOS_REINT_MODE_NO_DATA_SYNC) {
 		D_DEBUG(DB_MD, "self healing is disabled for no_data_sync reintegration mode.\n");
-		if (opc == POOL_EXCLUDE || opc == POOL_DRAIN) {
-			rc = ds_pool_tgt_exclude_out(svc->ps_pool->sp_uuid, &target_list);
+		if (opc == MAP_REINT) {
+			rc = ds_pool_tgt_finish_rebuild(svc->ps_pool->sp_uuid, &target_list);
 			if (rc)
-				D_INFO("mark failed target %d of "DF_UUID " as DOWNOUT: "DF_RC"\n",
-					target_list.pti_ids[0].pti_id,
-					DP_UUID(svc->ps_pool->sp_uuid), DP_RC(rc));
+				D_INFO("mark target %d of " DF_UUID " as UPIN: " DF_RC "\n",
+				       target_list.pti_ids[0].pti_id,
+				       DP_UUID(svc->ps_pool->sp_uuid), DP_RC(rc));
 		}
 		D_GOTO(out, rc);
 	}

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1796,10 +1796,27 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 	int		rc = 0;
 
 	if (buf != NULL) {
-		D_INFO(DF_UUID ": map_ver=%u (cached %u), buf_size=%ld, components: %u/%u/%u/%u "
+		/* Debugging code, print out old and new map buffer important values */
+		if (pool->sp_map) {
+			struct pool_buf *old_buf = NULL;
+
+			rc = pool_buf_extract(pool->sp_map, &old_buf);
+			if (rc != 0) {
+				DL_ERROR(rc, DF_UUID ": failed to extract old map buf",
+					 DP_UUID(pool->sp_uuid));
+				return rc;
+			}
+			D_INFO(DF_UUID ": OLD: map_ver=%u, buf_size=%ld, components: %u/%u/%u/%u "
+			       "(nr/domain_nr/node_nr/target_nr)\n", DP_UUID(pool->sp_uuid),
+			       pool->sp_map_version, pool_buf_size(old_buf->pb_nr), old_buf->pb_nr,
+			       old_buf->pb_domain_nr, old_buf->pb_node_nr, old_buf->pb_target_nr);
+
+			pool_buf_free(old_buf);
+		}
+		D_INFO(DF_UUID ": NEW: map_ver=%u buf_size=%ld, components: %u/%u/%u/%u "
 		       "(pb_nr/pb_domain_nr/pb_node_nr/pb_target_nr)\n", DP_UUID(pool->sp_uuid),
-		       map_version, pool->sp_map_version, pool_buf_size(buf->pb_nr), buf->pb_nr,
-		       buf->pb_domain_nr, buf->pb_node_nr, buf->pb_target_nr);
+		       map_version, pool_buf_size(buf->pb_nr), buf->pb_nr, buf->pb_domain_nr,
+		       buf->pb_node_nr, buf->pb_target_nr);
 
 		rc = pool_map_create(buf, map_version, &map);
 		if (rc != 0) {

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1807,16 +1807,17 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 				return rc;
 			}
 			D_INFO(DF_UUID ": OLD: map_ver=%u, buf_size=%ld, components: %u/%u/%u/%u "
-			       "(nr/domain_nr/node_nr/target_nr)\n", DP_UUID(pool->sp_uuid),
-			       pool->sp_map_version, pool_buf_size(old_buf->pb_nr), old_buf->pb_nr,
-			       old_buf->pb_domain_nr, old_buf->pb_node_nr, old_buf->pb_target_nr);
+				       "(nr/domain_nr/node_nr/target_nr)\n",
+			       DP_UUID(pool->sp_uuid), pool->sp_map_version,
+			       pool_buf_size(old_buf->pb_nr), old_buf->pb_nr, old_buf->pb_domain_nr,
+			       old_buf->pb_node_nr, old_buf->pb_target_nr);
 
 			pool_buf_free(old_buf);
 		}
 		D_INFO(DF_UUID ": NEW: map_ver=%u buf_size=%ld, components: %u/%u/%u/%u "
-		       "(pb_nr/pb_domain_nr/pb_node_nr/pb_target_nr)\n", DP_UUID(pool->sp_uuid),
-		       map_version, pool_buf_size(buf->pb_nr), buf->pb_nr, buf->pb_domain_nr,
-		       buf->pb_node_nr, buf->pb_target_nr);
+			       "(pb_nr/pb_domain_nr/pb_node_nr/pb_target_nr)\n",
+		       DP_UUID(pool->sp_uuid), map_version, pool_buf_size(buf->pb_nr), buf->pb_nr,
+		       buf->pb_domain_nr, buf->pb_node_nr, buf->pb_target_nr);
 
 		rc = pool_map_create(buf, map_version, &map);
 		if (rc != 0) {

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1796,6 +1796,11 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 	int		rc = 0;
 
 	if (buf != NULL) {
+		D_INFO(DF_UUID ": map_ver=%u (cached %u), buf_size=%ld, components: %u/%u/%u/%u "
+		       "(pb_nr/pb_domain_nr/pb_node_nr/pb_target_nr)\n", DP_UUID(pool->sp_uuid),
+		       map_version, pool->sp_map_version, pool_buf_size(buf->pb_nr), buf->pb_nr,
+		       buf->pb_domain_nr, buf->pb_node_nr, buf->pb_target_nr);
+
 		rc = pool_map_create(buf, map_version, &map);
 		if (rc != 0) {
 			D_ERROR(DF_UUID" failed to create pool map: "DF_RC"\n",

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -797,6 +797,13 @@ rebuild_sx_object_internal(void **state, daos_oclass_id_t oclass,
 	/* wait until reintegration is done */
 	test_rebuild_wait(&arg, 1);
 
+	/* no_data_sync mode */
+	if (!wait_rebuild && verify) {
+		/* clear the UNCLEAN status */
+		rc = daos_cont_status_clear(arg->coh, NULL);
+		assert_rc_equal(rc, 0);
+	}
+
 	print_message("lookup 100 dkeys\n");
 	for (i = 0; i < 100 && verify; i++) {
 		memset(buffer, 0, 32);
@@ -826,7 +833,7 @@ rebuild_xsf_object(void **state)
 static void
 rebuild_sx_object_no_data_sync(void **state)
 {
-	rebuild_sx_object_internal(state, OC_SX, false, false);
+	rebuild_sx_object_internal(state, OC_SX, true, false);
 }
 
 static int


### PR DESCRIPTION
…14702

Cherry-pick of same change to master branch.

In data_sync mode, if any targets are down, a rebuild will be triggered, causing targets to enter a DOWNOUT state. During reintegration, data will be discarded, and targets will transition from DOWNOUT to UP, followed by another rebuild that changes the targets to UPIN.

In no_data_sync mode, if targets are down, the rebuild process will be skipped, and targets will remain in the DOWN state. Reintegration will skip data discard, bring targets from DOWN to UP directly, and then mark them as UPIN without triggering a rebuild.

And make additional fixes for reintegration:no_data_sync
- when specified during pool create in properties, ensure the property value gets written into pool rdb. (fix pool_prop_default_copy() function that missed a case).
- For engine startup, ds_rebuild_regenerate_task() fix to evaluate this property value as read from rdb, not the struct ds_pool cached value (not yet fully propagated by IV).
- Improve logging in ds_rebuild_regenerate_task() so it's easier to know whether rebuilds are being potentially launched on engine startup.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
