### PR TITLE
DAOS-16127 tools: Add daos health check command (#14730)

### DIFF
--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -1,7 +1,8 @@
 """Build DAOS client"""
 
 LIBDAOS_SRC = ['agent.c', 'array.c', 'container.c', 'event.c', 'init.c', 'job.c', 'kv.c', 'mgmt.c',
-               'object.c', 'pool.c', 'rpc.c', 'task.c', 'tx.c', 'pipeline.c', 'metrics.c']
+               'object.c', 'pool.c', 'rpc.c', 'task.c', 'tx.c', 'pipeline.c', 'metrics.c',
+               'version.c']
 
 
 def scons():

--- a/src/client/api/version.c
+++ b/src/client/api/version.c
@@ -1,0 +1,31 @@
+/**
+ * (C) Copyright 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * This file is part of daos
+ *
+ * src/client/api/version.c
+ */
+#define D_LOGFAC DD_FAC(client)
+
+#include <daos/common.h>
+#include <daos_version.h>
+
+/**
+ * Retrieve DAOS client API version.
+ */
+int
+daos_version_get(int *major, int *minor, int *fix)
+{
+	if (major == NULL || minor == NULL || fix == NULL) {
+		D_ERROR("major, minor, fix must not be NULL\n");
+		return -DER_INVAL;
+	}
+	*major = DAOS_API_VERSION_MAJOR;
+	*minor = DAOS_API_VERSION_MINOR;
+	*fix   = DAOS_API_VERSION_FIX;
+
+	return 0;
+}

--- a/src/control/build/interop.go
+++ b/src/control/build/interop.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -40,6 +40,8 @@ var (
 	ComponentAdmin = Component("admin")
 	// ComponentAgent represents the compute node agent.
 	ComponentAgent = Component("agent")
+	// ComponentClient represents the libdaos client.
+	ComponentClient = Component("client")
 )
 
 // NewVersionedComponent creates a new VersionedComponent.
@@ -50,7 +52,7 @@ func NewVersionedComponent(comp Component, version string) (*VersionedComponent,
 	}
 
 	switch comp {
-	case ComponentServer, ComponentAdmin, ComponentAgent, ComponentAny:
+	case ComponentServer, ComponentAdmin, ComponentAgent, ComponentClient, ComponentAny:
 		return &VersionedComponent{
 			Component: comp,
 			Version:   v,

--- a/src/control/build/lib_versions.go
+++ b/src/control/build/lib_versions.go
@@ -1,0 +1,227 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package build
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/dlopen"
+)
+
+/*
+#include <stdint.h>
+
+int
+get_fi_version(void *fn, int *major, int *minor, int *patch)
+{
+	uint32_t version;
+
+	if (fn == NULL || major == NULL || minor == NULL || patch == NULL) {
+		return -1;
+	}
+	// uint32_t fi_version(void);
+	version = ((uint32_t (*)(void))fn)();
+
+	if (version == 0) {
+		return -1;
+	}
+
+	// FI_MAJOR(version);
+	*major = (version >> 16);
+	// FI_MINOR(version);
+	*minor = (version & 0xFFFF);
+	// No way to get at revision number via ABI. :(
+
+	return 0;
+}
+
+int
+get_hg_version(void *fn, int *major, int *minor, int *patch)
+{
+	if (fn == NULL || major == NULL || minor == NULL || patch == NULL) {
+		return -1;
+	}
+	// int HG_Version_get(int *, int *, int *);
+	return ((int (*)(int *, int *, int *))fn)(major, minor, patch);
+}
+
+int
+get_daos_version(void *fn, int *major, int *minor, int *fix)
+{
+	if (fn == NULL || major == NULL || minor == NULL || fix == NULL) {
+		return -1;
+	}
+	// int daos_version_get(int *, int *, int *);
+	return ((int (*)(int *, int *, int *))fn)(major, minor, fix);
+}
+*/
+import "C"
+
+// readMappedLibPath attempts to resolve the given library name to an on-disk path.
+// NB: The library must be loaded in order for it to be found!
+func readMappedLibPath(input io.Reader, libName string) (string, error) {
+	if libName == "" {
+		return "", nil
+	}
+
+	libs := make(map[string]struct{})
+	libRe := regexp.MustCompile(fmt.Sprintf(`\s([^\s]+/%s[\-\.\d]*\.so.*$)`, libName))
+	scanner := bufio.NewScanner(input)
+	for scanner.Scan() {
+		if matches := libRe.FindStringSubmatch(scanner.Text()); len(matches) > 1 {
+			libs[matches[1]] = struct{}{}
+		}
+	}
+
+	if len(libs) == 0 {
+		return "", errors.Errorf("unable to find path for %q", libName)
+	} else if len(libs) > 1 {
+		return "", errors.Errorf("multiple paths found for %q: %v", libName, libs)
+	}
+
+	var libPath string
+	for lib := range libs {
+		libPath = lib
+		break
+	}
+	return libPath, nil
+}
+
+func getLibPath(libName string) (string, error) {
+	f, err := os.Open("/proc/self/maps")
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to open %s", "/proc/self/maps")
+	}
+	defer f.Close()
+
+	return readMappedLibPath(f, libName)
+}
+
+func getLibHandle(libName string) (string, *dlopen.LibHandle, error) {
+	searchLib := libName + ".so"
+
+	// Check to see if it's already loaded, and if so, use that path
+	// instead of searching in order to make sure we're getting a
+	// handle to the correct library.
+	libPath, _ := getLibPath(libName)
+	if libPath != "" {
+		searchLib = libPath
+	}
+
+	hdl, err := dlopen.GetHandle(searchLib)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if libPath == "" {
+		libPath, err = getLibPath(libName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to get path for %q: %+v\n", libName, err)
+			return "", nil, err
+		}
+	}
+
+	return libPath, hdl, err
+}
+
+func getLibFabricVersion() (*Version, string, error) {
+	libPath, hdl, err := getLibHandle("libfabric")
+	if err != nil {
+		return nil, "", err
+	}
+	defer hdl.Close()
+
+	ptr, err := hdl.GetSymbolPointer("fi_version")
+	if err != nil {
+		return nil, "", err
+	}
+
+	var major, minor, patch C.int
+	rc := C.get_fi_version(ptr, &major, &minor, &patch)
+	if rc != 0 {
+		return nil, "", errors.Errorf("get_fi_version() failed: %d", rc)
+	}
+
+	return &Version{
+		Major: int(major),
+		Minor: int(minor),
+		Patch: int(patch),
+	}, libPath, nil
+}
+
+func getMercuryVersion() (*Version, string, error) {
+	libPath, hdl, err := getLibHandle("libmercury")
+	if err != nil {
+		return nil, "", err
+	}
+	defer hdl.Close()
+
+	ptr, err := hdl.GetSymbolPointer("HG_Version_get")
+	if err != nil {
+		return nil, "", err
+	}
+
+	var major, minor, patch C.int
+	rc := C.get_hg_version(ptr, &major, &minor, &patch)
+	if rc != 0 {
+		return nil, "", errors.Errorf("get_hg_version() failed: %d", rc)
+	}
+
+	return &Version{
+		Major: int(major),
+		Minor: int(minor),
+		Patch: int(patch),
+	}, libPath, nil
+}
+
+func getDAOSVersion() (*Version, string, error) {
+	libPath, hdl, err := getLibHandle("libdaos")
+	if err != nil {
+		return nil, "", err
+	}
+	defer hdl.Close()
+
+	ptr, err := hdl.GetSymbolPointer("daos_version_get")
+	if err != nil {
+		return nil, "", err
+	}
+
+	var major, minor, fix C.int
+	rc := C.get_daos_version(ptr, &major, &minor, &fix)
+	if rc != 0 {
+		return nil, "", errors.Errorf("get_daos_version() failed: %d", rc)
+	}
+
+	return &Version{
+		Major: int(major),
+		Minor: int(minor),
+		Patch: int(fix),
+	}, libPath, nil
+}
+
+// GetLibraryInfo attempts to resolve the given library name into a version and path.
+// NB: The library must provide an ABI method to obtain its version, and that
+// method needs to be added to this package in order to support it.
+func GetLibraryInfo(libName string) (*Version, string, error) {
+	switch strings.TrimPrefix(strings.ToLower(libName), "lib") {
+	case "fabric":
+		return getLibFabricVersion()
+	case "mercury":
+		return getMercuryVersion()
+	case "daos":
+		return getDAOSVersion()
+	default:
+		return nil, "", errors.Errorf("unsupported library: %q", libName)
+	}
+}

--- a/src/control/build/lib_versions_test.go
+++ b/src/control/build/lib_versions_test.go
@@ -1,0 +1,87 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package build
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+)
+
+func TestBuild_readMappedLibPath(t *testing.T) {
+	testMap := `
+55a05b000000-55a05b008000 r-xp 00000000 fd:01 44060915                   /usr/bin/cat
+55a05b207000-55a05b208000 r--p 00007000 fd:01 44060915                   /usr/bin/cat
+55a05b208000-55a05b209000 rw-p 00008000 fd:01 44060915                   /usr/bin/cat
+55a05d1d5000-55a05d1f6000 rw-p 00000000 00:00 0                          [heap]
+7f2126a00000-7f2126bcd000 r-xp 00000000 fd:01 44043909                   /usr/lib64/libc-2.28.so
+7f2126bcd000-7f2126dcc000 ---p 001cd000 fd:01 44043909                   /usr/lib64/libc-2.28.so
+7f2126dcc000-7f2126dd0000 r--p 001cc000 fd:01 44043909                   /usr/lib64/libc-2.28.so
+7f2126dd0000-7f2126dd2000 rw-p 001d0000 fd:01 44043909                   /usr/lib64/libc-2.28.so
+7f2126dd2000-7f2126dd6000 rw-p 00000000 00:00 0
+7f2126e00000-7f2126e2f000 r-xp 00000000 fd:01 44043895                   /usr/lib64/ld-2.28.so
+7f212702f000-7f2127030000 r--p 0002f000 fd:01 44043895                   /usr/lib64/ld-2.28.so
+7f2127030000-7f2127032000 rw-p 00030000 fd:01 44043895                   /usr/lib64/ld-2.28.so
+7f2127135000-7f212715a000 rw-p 00000000 00:00 0
+7f2127162000-7f2127164000 rw-p 00000000 00:00 0
+7f2127164000-7f2127168000 r--p 00000000 00:00 0                          [vvar]
+7f2127168000-7f212716a000 r-xp 00000000 00:00 0                          [vdso]
+7fffab3d9000-7fffab3fb000 rw-p 00000000 00:00 0                          [stack]
+`
+
+	for name, tc := range map[string]struct {
+		reader  io.Reader
+		libName string
+		expPath string
+		expErr  error
+	}{
+		"empty": {},
+		"nonexistent": {
+			reader:  strings.NewReader(testMap),
+			libName: "libmystery",
+			expErr:  errors.New("unable to find"),
+		},
+		"dupes": {
+			reader: strings.NewReader(testMap + `
+7f2127030000-7f2127032000 rw-p 00030000 fd:01 44043895                   /usr/lib64/libwhoops-2.29.so
+7f2127030000-7f2127032000 rw-p 00030000 fd:01 44043895                   /usr/lib64/libwhoops-2.28.so
+`),
+			libName: "libwhoops",
+			expErr:  errors.New("multiple paths"),
+		},
+		"libc": {
+			reader:  strings.NewReader(testMap),
+			libName: "libc",
+			expPath: "/usr/lib64/libc-2.28.so",
+		},
+		"libunder_score": {
+			reader: strings.NewReader(testMap + `
+7f2127030000-7f2127032000 rw-p 00030000 fd:01 44043895                   /usr/lib64/libkool_wow.so.123
+7f2127030000-7f2127032000 rw-p 00030000 fd:01 44043895                   /usr/lib64/libkool.so.456
+`),
+			libName: "libkool",
+			expPath: "/usr/lib64/libkool.so.456",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotPath, gotErr := readMappedLibPath(tc.reader, tc.libName)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expPath, gotPath); diff != "" {
+				t.Fatalf("unexpected path for %q (-want,+got): %s", tc.libName, diff)
+			}
+		})
+	}
+}

--- a/src/control/cmd/daos/health.go
+++ b/src/control/cmd/daos/health.go
@@ -1,0 +1,168 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/cmd/daos/pretty"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+type healthCmds struct {
+	Check healthCheckCmd `command:"check" description:"Perform DAOS system health checks"`
+}
+
+type healthCheckCmd struct {
+	daosCmd
+	Verbose bool `short:"v" long:"verbose" description:"Display more detailed system health information"`
+}
+
+func collectBuildInfo(log logging.Logger, shi *daos.SystemHealthInfo) error {
+	shi.ComponentBuildInfo[build.ComponentClient.String()] = daos.ComponentBuild{
+		Version:   build.DaosVersion,
+		BuildInfo: build.BuildInfo,
+	}
+	srvBuild, err := srvBuildInfo()
+	if err != nil {
+		log.Errorf("failed to get server build info: %v", err)
+	} else {
+		shi.ComponentBuildInfo[build.ComponentServer.String()] = daos.ComponentBuild{
+			Version:   srvBuild.Version,
+			BuildInfo: srvBuild.BuildInfo,
+		}
+	}
+
+	for _, libName := range []string{"libfabric", "mercury", "libdaos"} {
+		ver, path, err := build.GetLibraryInfo(libName)
+		if err != nil {
+			log.Debugf("failed to get %q info: %+v", libName, err)
+			continue
+		}
+		shi.ComponentBuildInfo[libName] = daos.ComponentBuild{
+			Version: ver.String(),
+			LibPath: path,
+		}
+	}
+
+	return nil
+}
+
+func (cmd *healthCheckCmd) Execute([]string) error {
+	// TODO (DAOS-10028): Move this logic into the daos package once the API is available.
+	systemHealth := &daos.SystemHealthInfo{
+		ComponentBuildInfo: make(map[string]daos.ComponentBuild),
+		Pools:              make(map[uuid.UUID]*daos.PoolInfo),
+		Containers:         make(map[uuid.UUID][]*daos.ContainerInfo),
+	}
+	if err := collectBuildInfo(cmd.Logger, systemHealth); err != nil {
+		return err
+	}
+
+	sysInfo, err := cmd.apiProvider.GetSystemInfo()
+	if err != nil {
+		cmd.Errorf("failed to query system information: %v", err)
+	}
+	systemHealth.SystemInfo = sysInfo
+
+	cmd.Infof("Checking DAOS system: %s", systemHealth.SystemInfo.Name)
+
+	pools, err := getPoolList(cmd.Logger, cmd.SysName, true)
+	if err != nil {
+		cmd.Errorf("failed to get pool list: %v", err)
+	}
+
+	for _, pool := range pools {
+		systemHealth.Pools[pool.UUID] = pool
+
+		poolHdl, _, err := poolConnect(pool.UUID.String(), cmd.SysName, daos.PoolConnectFlagReadOnly, false)
+		if err != nil {
+			cmd.Errorf("failed to connect to pool %s: %v", pool.Label, err)
+			continue
+		}
+		defer func() {
+			if err := poolDisconnectAPI(poolHdl); err != nil {
+				cmd.Errorf("failed to disconnect from pool %s: %v", pool.Label, err)
+			}
+		}()
+
+		queryMask := daos.MustNewPoolQueryMask(daos.PoolQueryOptionEnabledEngines)
+		tpi, err := queryPool(poolHdl, queryMask)
+		if err != nil {
+			cmd.Errorf("failed to query pool %s: %v", pool.Label, err)
+			continue
+		}
+		pool.EnabledRanks = tpi.EnabledRanks
+
+		if pool.DisabledTargets > 0 {
+			queryMask.ClearAll()
+			queryMask.SetOptions(daos.PoolQueryOptionDisabledEngines)
+			tpi, err = queryPool(poolHdl, queryMask)
+			if err != nil {
+				cmd.Errorf("failed to query pool %s: %v", pool.Label, err)
+				continue
+			}
+			pool.DisabledRanks = tpi.DisabledRanks
+		}
+
+		poolConts, err := listContainers(poolHdl)
+		if err != nil {
+			cmd.Errorf("failed to list containers on pool %s: %v", pool.Label, err)
+			continue
+		}
+
+		for _, cont := range poolConts {
+			openFlags := uint(daos.ContainerOpenFlagReadOnly | daos.ContainerOpenFlagForce | daos.ContainerOpenFlagReadOnlyMetadata)
+			contHdl, contInfo, err := containerOpen(poolHdl, cont.UUID.String(), openFlags, true)
+			if err != nil {
+				cmd.Errorf("failed to connect to container %s: %v", cont.Label, err)
+				ci := &daos.ContainerInfo{
+					PoolUUID:       pool.UUID,
+					ContainerUUID:  cont.UUID,
+					ContainerLabel: cont.Label,
+					Health:         fmt.Sprintf("Unknown (%s)", err),
+				}
+				systemHealth.Containers[pool.UUID] = append(systemHealth.Containers[pool.UUID], ci)
+				continue
+			}
+			ci := convertContainerInfo(pool.UUID, cont.UUID, contInfo)
+			ci.ContainerLabel = cont.Label
+
+			props, freeProps, err := getContainerProperties(contHdl, "status")
+			if err != nil || len(props) == 0 {
+				cmd.Errorf("failed to get container properties for %s: %v", cont.Label, err)
+				ci.Health = fmt.Sprintf("Unknown (%s)", err)
+			} else {
+				ci.Health = props[0].String()
+			}
+			freeProps()
+
+			if err := containerCloseAPI(contHdl); err != nil {
+				cmd.Errorf("failed to close container %s: %v", cont.Label, err)
+			}
+
+			systemHealth.Containers[pool.UUID] = append(systemHealth.Containers[pool.UUID], ci)
+		}
+	}
+
+	if cmd.JSONOutputEnabled() {
+		return cmd.OutputJSON(systemHealth, nil)
+	}
+
+	var buf strings.Builder
+	if err := pretty.PrintSystemHealthInfo(&buf, systemHealth, cmd.Verbose); err != nil {
+		return err
+	}
+	cmd.Info(buf.String())
+
+	return nil
+}

--- a/src/control/cmd/daos/main.go
+++ b/src/control/cmd/daos/main.go
@@ -27,12 +27,14 @@ type cliOptions struct {
 	Debug         bool             `long:"debug" description:"Enable debug output"`
 	Verbose       bool             `long:"verbose" description:"Enable verbose output (when applicable)"`
 	JSON          bool             `long:"json" short:"j" description:"Enable JSON output"`
+	SysName       string           `long:"sys-name" short:"G" description:"DAOS system name (optional)"`
 	Container     containerCmd     `command:"container" alias:"cont" description:"Perform tasks related to DAOS containers"`
 	Pool          poolCmd          `command:"pool" description:"Perform tasks related to DAOS pools"`
 	Filesystem    fsCmd            `command:"filesystem" alias:"fs" description:"POSIX filesystem operations"`
 	Object        objectCmd        `command:"object" alias:"obj" description:"DAOS object operations"`
 	System        systemCmd        `command:"system" alias:"sys" description:"DAOS system operations"`
 	Version       versionCmd       `command:"version" description:"Print daos version"`
+	Health        healthCmds       `command:"health" description:"DAOS health operations"`
 	ServerVersion serverVersionCmd `command:"server-version" description:"Print server version"`
 	ManPage       cmdutil.ManCmd   `command:"manpage" hidden:"true"`
 	faultsCmdRoot
@@ -106,6 +108,10 @@ or query/manage an object inside a container.`
 		if manCmd, ok := cmd.(cmdutil.ManPageWriter); ok {
 			manCmd.SetWriteFunc(p.WriteManPage)
 			return cmd.Execute(args)
+		}
+
+		if sysCmd, ok := cmd.(interface{ setSysName(string) }); ok {
+			sysCmd.setSysName(opts.SysName)
 		}
 
 		if opts.Debug {

--- a/src/control/cmd/daos/pool.go
+++ b/src/control/cmd/daos/pool.go
@@ -71,8 +71,7 @@ type poolBaseCmd struct {
 
 	cPoolHandle C.daos_handle_t
 
-	SysName string `long:"sys-name" short:"G" description:"DAOS system name"`
-	Args    struct {
+	Args struct {
 		Pool PoolID `positional-arg-name:"pool label or UUID" description:"required if --path is not used"`
 	} `positional-args:"yes"`
 }
@@ -254,6 +253,7 @@ func convertPoolRebuildStatus(in *C.struct_daos_rebuild_status) *daos.PoolRebuil
 		Status: int32(in.rs_errno),
 	}
 	if out.Status == 0 {
+		out.TotalObjects = uint64(in.rs_toberb_obj_nr)
 		out.Objects = uint64(in.rs_obj_nr)
 		out.Records = uint64(in.rs_rec_nr)
 		switch {
@@ -741,9 +741,8 @@ func getPoolList(log logging.Logger, sysName string, queryEnabled bool) ([]*daos
 
 type poolListCmd struct {
 	daosCmd
-	SysName string `long:"sys-name" short:"G" description:"DAOS system name"`
-	Verbose bool   `short:"v" long:"verbose" description:"Add pool UUIDs and service replica lists to display"`
-	NoQuery bool   `short:"n" long:"no-query" description:"Disable query of listed pools"`
+	Verbose bool `short:"v" long:"verbose" description:"Add pool UUIDs and service replica lists to display"`
+	NoQuery bool `short:"n" long:"no-query" description:"Disable query of listed pools"`
 }
 
 func (cmd *poolListCmd) Execute(_ []string) error {

--- a/src/control/cmd/daos/pretty/health.go
+++ b/src/control/cmd/daos/pretty/health.go
@@ -1,0 +1,187 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package pretty
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/txtfmt"
+)
+
+const (
+	minDisplayImbalance = 10
+)
+
+func printBuildInfo(out io.Writer, comp string, cb *daos.ComponentBuild) {
+	if cb == nil {
+		return
+	}
+
+	buildInfo := cb.BuildInfo
+	if buildInfo == "" {
+		buildInfo = cb.Version
+	}
+	fmt.Fprintf(out, "%s: %s\n", txtfmt.Title(comp), buildInfo)
+}
+
+func printSystemInfo(out io.Writer, si *daos.SystemInfo, verbose bool) {
+	if si == nil {
+		return
+	}
+
+	fmt.Fprintf(out, "System Name: %s\n", si.Name)
+	fmt.Fprintf(out, "Fabric Provider: %s\n", si.Provider)
+	if verbose {
+		fmt.Fprintf(out, "Agent Path: %s\n", si.AgentPath)
+	}
+	apStr := "[]"
+	if len(si.AccessPointRankURIs) > 0 {
+		if apBytes, err := json.Marshal(si.AccessPoints()); err == nil {
+			apStr = string(apBytes)
+		}
+	}
+	fmt.Fprintf(out, "Access Points: %s\n", apStr)
+}
+
+func printPoolHealth(out io.Writer, pi *daos.PoolInfo, verbose bool) {
+	if pi == nil {
+		return
+	}
+
+	var healthStrings []string
+	if pi.DisabledTargets > 0 {
+		degStr := "Degraded"
+		if verbose {
+			degStr += fmt.Sprintf(" (%d/%d targets disabled)", pi.DisabledTargets, pi.TotalTargets)
+		}
+		healthStrings = append(healthStrings, degStr)
+	}
+	if pi.Rebuild != nil {
+		rbi := pi.Rebuild
+		if rbi.State == daos.PoolRebuildStateBusy {
+			var pctCmp float64
+			if rbi.TotalObjects > 0 {
+				pctCmp = (float64(rbi.Objects) / float64(rbi.TotalObjects)) * 100
+			}
+
+			rbStr := fmt.Sprintf("Rebuilding (%.01f%% complete)", pctCmp)
+			if verbose {
+				rbStr += fmt.Sprintf(" (%d/%d objects; %d records)", rbi.Objects, rbi.TotalObjects, rbi.Records)
+			}
+			healthStrings = append(healthStrings, rbStr)
+		}
+	}
+
+	// If there's no other pertinent info, just display some useful storage stats.
+	if len(healthStrings) == 0 {
+		healthStr := "Healthy"
+		var metaFree uint64
+		var metaTotal uint64
+		var metaImbal uint32
+		var dataFree uint64
+		var dataTotal uint64
+		var dataImbal uint32
+		var totalFree uint64
+		for _, tier := range pi.Usage() {
+			switch tier.TierName {
+			case strings.ToUpper(daos.StorageMediaTypeScm.String()):
+				metaFree = tier.Free
+				metaTotal = tier.Size
+				metaImbal = tier.Imbalance
+				totalFree += metaFree
+			case strings.ToUpper(daos.StorageMediaTypeNvme.String()):
+				dataFree = tier.Free
+				dataTotal = tier.Size
+				dataImbal = tier.Imbalance
+				totalFree += dataFree
+			}
+		}
+		if !verbose {
+			healthStr += fmt.Sprintf(" (%s Free)", humanize.Bytes(totalFree))
+		} else {
+			healthStr += " (meta: "
+			healthStr += fmt.Sprintf("%s/%s", humanize.Bytes(metaFree), humanize.Bytes(metaTotal))
+			healthStr += " Free, data: "
+			healthStr += fmt.Sprintf("%s/%s", humanize.Bytes(dataFree), humanize.Bytes(dataTotal))
+			healthStr += " Free)"
+			if metaImbal > minDisplayImbalance || dataImbal > minDisplayImbalance {
+				healthStr += fmt.Sprintf(" (imbalances: %d%% meta, %d%% data)", metaImbal, dataImbal)
+			}
+		}
+		healthStrings = append(healthStrings, healthStr)
+	}
+	fmt.Fprintf(out, "%s: %s\n", pi.Name(), strings.Join(healthStrings, ","))
+}
+
+func printContainerHealth(out io.Writer, ci *daos.ContainerInfo, verbose bool) {
+	if ci == nil {
+		return
+	}
+
+	fmt.Fprintf(out, "%s: %s\n", ci.Name(), txtfmt.Title(ci.Health))
+}
+
+// PrintSystemHealthInfo pretty-prints the supplied system health struct.
+func PrintSystemHealthInfo(out io.Writer, shi *daos.SystemHealthInfo, verbose bool) error {
+	if shi == nil {
+		return errors.Errorf("nil %T", shi)
+	}
+
+	iw := txtfmt.NewIndentWriter(out)
+
+	fmt.Fprintln(out, "Component Build Information")
+	srvStr := build.ComponentServer.String()
+	cliStr := build.ComponentClient.String()
+	if srvBuild, found := shi.ComponentBuildInfo[srvStr]; found {
+		printBuildInfo(iw, srvStr, &srvBuild)
+	}
+	if cliBuild, found := shi.ComponentBuildInfo[cliStr]; found {
+		printBuildInfo(iw, cliStr, &cliBuild)
+	}
+	if verbose {
+		fmt.Fprintln(out, "Client Library Information")
+		for comp, bi := range shi.ComponentBuildInfo {
+			if comp != srvStr && comp != cliStr {
+				printBuildInfo(iw, comp, &bi)
+			}
+		}
+	}
+
+	if shi.SystemInfo != nil {
+		fmt.Fprintln(out, "System Information")
+		printSystemInfo(iw, shi.SystemInfo, verbose)
+	}
+
+	fmt.Fprintln(out, "Pool Status")
+	if len(shi.Pools) > 0 {
+		for _, pool := range shi.Pools {
+			iiw := txtfmt.NewIndentWriter(iw)
+			printPoolHealth(iw, pool, verbose)
+			fmt.Fprintln(iiw, "Container Status")
+			iiiw := txtfmt.NewIndentWriter(iiw)
+			if len(shi.Containers[pool.UUID]) > 0 {
+				for _, cont := range shi.Containers[pool.UUID] {
+					printContainerHealth(iiiw, cont, verbose)
+				}
+			} else {
+				fmt.Fprintln(iiiw, "No containers in pool.")
+			}
+		}
+	} else {
+		fmt.Fprintln(iw, "No pools in system.")
+	}
+
+	return nil
+}

--- a/src/control/cmd/daos/pretty/health_test.go
+++ b/src/control/cmd/daos/pretty/health_test.go
@@ -1,0 +1,413 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package pretty
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dustin/go-humanize"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+
+	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/common/proto/convert"
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/ranklist"
+)
+
+var (
+	srvComp = &daos.ComponentBuild{
+		Version: "1.2.3",
+	}
+	cliComp = &daos.ComponentBuild{
+		Version:   "1.2.3",
+		BuildInfo: "1.2.4-pre12345",
+	}
+)
+
+func TestPretty_printBuildInfo(t *testing.T) {
+	for name, tc := range map[string]struct {
+		testComp      build.Component
+		testCompBuild *daos.ComponentBuild
+		expPrintStr   string
+	}{
+		"nil build": {
+			testComp: build.ComponentServer,
+		},
+		"version only": {
+			testComp:      build.ComponentServer,
+			testCompBuild: srvComp,
+			expPrintStr: fmt.Sprintf(`
+Server: %s
+`, srvComp.Version),
+		},
+		"buildinfo overrides version": {
+			testComp:      build.ComponentAgent,
+			testCompBuild: cliComp,
+			expPrintStr: fmt.Sprintf(`
+Agent: %s
+`, cliComp.BuildInfo),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var bld strings.Builder
+			printBuildInfo(&bld, tc.testComp.String(), tc.testCompBuild)
+
+			if diff := cmp.Diff(strings.TrimLeft(tc.expPrintStr, "\n"), bld.String()); diff != "" {
+				t.Fatalf("unexpected pretty-printed string (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+var (
+	sysName  = "test-system"
+	provStr  = "test-provider"
+	hostBase = "test-host"
+
+	sysInfo = &daos.SystemInfo{
+		Name:     sysName,
+		Provider: provStr,
+		AccessPointRankURIs: []*daos.RankURI{
+			{
+				Rank: 1,
+				URI:  provStr + "://" + hostBase + "1",
+			},
+			{
+				Rank: 0,
+				URI:  provStr + "://" + hostBase + "0",
+			},
+		},
+	}
+)
+
+func TestPretty_printSystemInfo(t *testing.T) {
+	for name, tc := range map[string]struct {
+		testSysInfo *daos.SystemInfo
+		verbose     bool
+		expPrintStr string
+	}{
+		"nil sysinfo": {},
+		"standard sysinfo": {
+			testSysInfo: sysInfo,
+			expPrintStr: fmt.Sprintf(`
+System Name: %s
+Fabric Provider: %s
+Access Points: ["%s0","%s1"]
+`, sysName, provStr, hostBase, hostBase),
+		},
+		"empty APs list": {
+			testSysInfo: func() *daos.SystemInfo {
+				newInfo := new(daos.SystemInfo)
+				if err := convert.Types(sysInfo, newInfo); err != nil {
+					t.Fatal(err)
+				}
+				newInfo.AccessPointRankURIs = nil
+				return newInfo
+			}(),
+			expPrintStr: fmt.Sprintf(`
+System Name: %s
+Fabric Provider: %s
+Access Points: []
+`, sysName, provStr),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var bld strings.Builder
+			printSystemInfo(&bld, tc.testSysInfo, tc.verbose)
+
+			if diff := cmp.Diff(strings.TrimLeft(tc.expPrintStr, "\n"), bld.String()); diff != "" {
+				t.Fatalf("unexpected pretty-printed string (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+var healthyPool = &daos.PoolInfo{
+	QueryMask:       daos.DefaultPoolQueryMask,
+	State:           daos.PoolServiceStateReady,
+	UUID:            uuid.New(),
+	Label:           "test-pool",
+	TotalTargets:    24,
+	ActiveTargets:   24,
+	TotalEngines:    3,
+	DisabledTargets: 0,
+	Version:         1,
+	ServiceLeader:   2,
+	ServiceReplicas: []ranklist.Rank{0, 1, 2},
+	Rebuild: &daos.PoolRebuildStatus{
+		State: daos.PoolRebuildStateIdle,
+	},
+	TierStats: []*daos.StorageUsageStats{
+		{
+			MediaType: daos.StorageMediaTypeScm,
+			Total:     128 * humanize.GByte,
+			Free:      64 * humanize.GByte,
+			Min:       2420 * humanize.MByte,
+			Max:       5333 * humanize.MByte,
+			Mean:      2666 * humanize.GiByte,
+		},
+		{
+			MediaType: daos.StorageMediaTypeNvme,
+			Total:     6 * humanize.TByte,
+			Free:      4 * humanize.TByte,
+			Min:       130 * humanize.GByte,
+			Max:       240 * humanize.GByte,
+			Mean:      166 * humanize.TByte,
+		},
+	},
+	EnabledRanks:     ranklist.MustCreateRankSet("[0,1,2]"),
+	PoolLayoutVer:    1,
+	UpgradeLayoutVer: 1,
+}
+
+func TestPretty_printPoolHealth(t *testing.T) {
+	busyRebuild := &daos.PoolRebuildStatus{
+		State:        daos.PoolRebuildStateBusy,
+		Objects:      42,
+		Records:      7,
+		TotalObjects: 100,
+	}
+
+	getTestPool := func(mut func(*daos.PoolInfo) *daos.PoolInfo) *daos.PoolInfo {
+		testPool := new(daos.PoolInfo)
+		if err := convert.Types(healthyPool, testPool); err != nil {
+			t.Fatal(err)
+		}
+		return mut(testPool)
+	}
+
+	for name, tc := range map[string]struct {
+		pi          *daos.PoolInfo
+		verbose     bool
+		expPrintStr string
+	}{
+		"nil PoolInfo": {},
+		"disabled targets": {
+			pi: getTestPool(func(pi *daos.PoolInfo) *daos.PoolInfo {
+				pi.DisabledTargets = 8
+				return pi
+			}),
+			expPrintStr: fmt.Sprintf(`
+%s: Degraded
+`, healthyPool.Label),
+		},
+		"disabled targets; verbose": {
+			pi: getTestPool(func(pi *daos.PoolInfo) *daos.PoolInfo {
+				pi.DisabledTargets = 8
+				return pi
+			}),
+			verbose: true,
+			expPrintStr: fmt.Sprintf(`
+%s: Degraded (8/24 targets disabled)
+`, healthyPool.Label),
+		},
+		"rebuilding": {
+			pi: getTestPool(func(pi *daos.PoolInfo) *daos.PoolInfo {
+				pi.Rebuild = busyRebuild
+				return pi
+			}),
+			expPrintStr: fmt.Sprintf(`
+%s: Rebuilding (42.0%% complete)
+`, healthyPool.Label),
+		},
+		"rebuilding; verbose": {
+			pi: getTestPool(func(pi *daos.PoolInfo) *daos.PoolInfo {
+				pi.Rebuild = busyRebuild
+				return pi
+			}),
+			verbose: true,
+			expPrintStr: fmt.Sprintf(`
+%s: Rebuilding (42.0%% complete) (42/100 objects; 7 records)
+`, healthyPool.Label),
+		},
+		"degraded, rebuilding; verbose": {
+			pi: getTestPool(func(pi *daos.PoolInfo) *daos.PoolInfo {
+				pi.DisabledTargets = 8
+				pi.Rebuild = busyRebuild
+				return pi
+			}),
+			verbose: true,
+			expPrintStr: fmt.Sprintf(`
+%s: Degraded (8/24 targets disabled),Rebuilding (42.0%% complete) (42/100 objects; 7 records)
+`, healthyPool.Label),
+		},
+		"healthy": {
+			pi: healthyPool,
+			expPrintStr: fmt.Sprintf(`
+%s: Healthy (4.1 TB Free)
+`, healthyPool.Label),
+		},
+		"healthy; verbose": {
+			pi:      healthyPool,
+			verbose: true,
+			expPrintStr: fmt.Sprintf(`
+%s: Healthy (meta: 64 GB/128 GB Free, data: 4.0 TB/6.0 TB Free) (imbalances: 54%% meta, 44%% data)
+`, healthyPool.Label),
+		},
+		"healthy no imbalances; verbose": {
+			pi: getTestPool(func(pi *daos.PoolInfo) *daos.PoolInfo {
+				pi.TierStats[0].Min = pi.TierStats[0].Max
+				pi.TierStats[1].Min = pi.TierStats[1].Max
+				return pi
+			}),
+			verbose: true,
+			expPrintStr: fmt.Sprintf(`
+%s: Healthy (meta: 64 GB/128 GB Free, data: 4.0 TB/6.0 TB Free)
+`, healthyPool.Label),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var bld strings.Builder
+			printPoolHealth(&bld, tc.pi, tc.verbose)
+
+			if diff := cmp.Diff(strings.TrimLeft(tc.expPrintStr, "\n"), bld.String()); diff != "" {
+				t.Fatalf("unexpected pretty-printed string (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+var healthyContainer = &daos.ContainerInfo{
+	PoolUUID:         healthyPool.UUID,
+	ContainerUUID:    uuid.New(),
+	ContainerLabel:   "test-container",
+	LatestSnapshot:   0,
+	RedundancyFactor: 1,
+	NumHandles:       1,
+	NumSnapshots:     0,
+	OpenTime:         1782965550217953280,
+	CloseModifyTime:  1782965553047535616,
+	Health:           "HEALTHY",
+}
+
+func TestPretty_printContainerHealth(t *testing.T) {
+	for name, tc := range map[string]struct {
+		ci          *daos.ContainerInfo
+		verbose     bool
+		expPrintStr string
+	}{
+		"nil ContainerInfo": {},
+		"healthy": {
+			ci: healthyContainer,
+			expPrintStr: fmt.Sprintf(`
+%s: Healthy
+`, healthyContainer.ContainerLabel),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var bld strings.Builder
+			printContainerHealth(&bld, tc.ci, tc.verbose)
+
+			if diff := cmp.Diff(strings.TrimLeft(tc.expPrintStr, "\n"), bld.String()); diff != "" {
+				t.Fatalf("unexpected pretty-printed string (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+
+}
+
+func TestPretty_PrintSystemHealthInfo(t *testing.T) {
+	buildInfo := map[string]daos.ComponentBuild{
+		build.ComponentServer.String(): *srvComp,
+		build.ComponentClient.String(): *cliComp,
+	}
+
+	for name, tc := range map[string]struct {
+		shi         *daos.SystemHealthInfo
+		verbose     bool
+		expErr      error
+		expPrintStr string
+	}{
+		"nil SystemHealthInfo": {
+			expErr: errors.New("nil"),
+		},
+		"healthy": {
+			shi: &daos.SystemHealthInfo{
+				SystemInfo:         sysInfo,
+				ComponentBuildInfo: buildInfo,
+				Pools: map[uuid.UUID]*daos.PoolInfo{
+					healthyPool.UUID: healthyPool,
+				},
+				Containers: map[uuid.UUID][]*daos.ContainerInfo{
+					healthyContainer.PoolUUID: {healthyContainer},
+				},
+			},
+			expPrintStr: fmt.Sprintf(`
+Component Build Information
+  Server: %s
+  Client: %s
+System Information
+  System Name: %s
+  Fabric Provider: %s
+  Access Points: ["%s0","%s1"]
+Pool Status
+  %s: Healthy (4.1 TB Free)
+    Container Status
+      %s: Healthy
+`, srvComp.Version, cliComp.BuildInfo, sysInfo.Name, sysInfo.Provider, hostBase, hostBase, healthyPool.Label, healthyContainer.ContainerLabel),
+		},
+		"healthy; no pools": {
+			shi: &daos.SystemHealthInfo{
+				SystemInfo:         sysInfo,
+				ComponentBuildInfo: buildInfo,
+				Pools:              map[uuid.UUID]*daos.PoolInfo{},
+			},
+			expPrintStr: fmt.Sprintf(`
+Component Build Information
+  Server: %s
+  Client: %s
+System Information
+  System Name: %s
+  Fabric Provider: %s
+  Access Points: ["%s0","%s1"]
+Pool Status
+  No pools in system.
+`, srvComp.Version, cliComp.BuildInfo, sysInfo.Name, sysInfo.Provider, hostBase, hostBase),
+		},
+		"healthy; no containers": {
+			shi: &daos.SystemHealthInfo{
+				SystemInfo:         sysInfo,
+				ComponentBuildInfo: buildInfo,
+				Pools: map[uuid.UUID]*daos.PoolInfo{
+					healthyPool.UUID: healthyPool,
+				},
+				Containers: map[uuid.UUID][]*daos.ContainerInfo{},
+			},
+			expPrintStr: fmt.Sprintf(`
+Component Build Information
+  Server: %s
+  Client: %s
+System Information
+  System Name: %s
+  Fabric Provider: %s
+  Access Points: ["%s0","%s1"]
+Pool Status
+  %s: Healthy (4.1 TB Free)
+    Container Status
+      No containers in pool.
+`, srvComp.Version, cliComp.BuildInfo, sysInfo.Name, sysInfo.Provider, hostBase, hostBase, healthyPool.Label),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var bld strings.Builder
+			gotErr := PrintSystemHealthInfo(&bld, tc.shi, tc.verbose)
+			test.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(strings.TrimLeft(tc.expPrintStr, "\n"), bld.String()); diff != "" {
+				t.Fatalf("unexpected pretty-printed string (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/src/control/cmd/daos/util.go
+++ b/src/control/cmd/daos/util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/lib/daos"
+	"github.com/daos-stack/daos/src/control/lib/daos/api"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
 	"github.com/daos-stack/daos/src/control/logging"
 )
@@ -84,10 +85,7 @@ func srvBuildInfo() (*build.Info, error) {
 }
 
 func daosError(rc C.int) error {
-	if rc == 0 {
-		return nil
-	}
-	return daos.Status(rc)
+	return daos.ErrorFromRC(int(rc))
 }
 
 func goBool2int(in bool) (out C.int) {
@@ -281,20 +279,22 @@ type daosCmd struct {
 	cmdutil.NoArgsCmd
 	cmdutil.JSONOutputCmd
 	cmdutil.LogCmd
+	apiProvider *api.Provider
+	SysName     string
+}
+
+func (dc *daosCmd) setSysName(sysName string) {
+	dc.SysName = sysName
 }
 
 func (dc *daosCmd) initDAOS() (func(), error) {
-	if rc := C.daos_init(); rc != 0 {
-		// Do some inspection of the RC to display an informative error to the user
-		// e.g. "No DAOS Agent detected"...
-		return nil, errors.Wrap(daosError(rc), "daos_init() failed")
+	provider, err := api.NewProvider(dc.Logger)
+	if err != nil {
+		return func() {}, err
 	}
+	dc.apiProvider = provider
 
-	return func() {
-		if rc := C.daos_fini(); rc != 0 {
-			dc.Errorf("daos_fini() failed: %s", daosError(rc))
-		}
-	}, nil
+	return provider.Cleanup, nil
 }
 
 func initDaosDebug() (func(), error) {

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -658,9 +658,12 @@ func (cmd *PoolQueryCmd) Execute(args []string) error {
 	}
 
 	resp, err := control.PoolQuery(cmd.MustLogCtx(), cmd.ctlInvoker, req)
-
 	if cmd.JSONOutputEnabled() {
-		return cmd.OutputJSON(resp, err)
+		var poolInfo *daos.PoolInfo
+		if resp != nil {
+			poolInfo = &resp.PoolInfo
+		}
+		return cmd.OutputJSON(poolInfo, err)
 	}
 
 	if err != nil {

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -472,78 +472,17 @@ func (pqr *PoolQueryResp) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 
-	piJSON, err := json.Marshal(&pqr.PoolInfo)
-	if err != nil {
-		return nil, err
-	}
-
-	aux := &struct {
-		EnabledRanks  *[]ranklist.Rank `json:"enabled_ranks"`
-		DisabledRanks *[]ranklist.Rank `json:"disabled_ranks"`
-		Status        int32            `json:"status"`
-	}{
-		Status: pqr.Status,
-	}
-
-	if pqr.EnabledRanks != nil {
-		ranks := pqr.EnabledRanks.Ranks()
-		aux.EnabledRanks = &ranks
-	}
-
-	if pqr.DisabledRanks != nil {
-		ranks := pqr.DisabledRanks.Ranks()
-		aux.DisabledRanks = &ranks
-	}
-
-	auxJSON, err := json.Marshal(&aux)
-	if err != nil {
-		return nil, err
-	}
-
-	// Kinda gross, but needed to merge the embedded struct's MarshalJSON
-	// output with this one's.
-	piJSON[0] = ','
-	return append(auxJSON[:len(auxJSON)-1], piJSON...), nil
-}
-
-func unmarshallRankSet(ranks string) (*ranklist.RankSet, error) {
-	switch ranks {
-	case "":
-		return nil, nil
-	case "[]":
-		return &ranklist.RankSet{}, nil
-	default:
-		return ranklist.CreateRankSet(ranks)
-	}
-}
-
-func (pqr *PoolQueryResp) UnmarshalJSON(data []byte) error {
-	type Alias PoolQueryResp
-	aux := &struct {
-		EnabledRanks  string `json:"enabled_ranks"`
-		DisabledRanks string `json:"disabled_ranks"`
+	// Bypass the MarshalJSON() implementation in daos.PoolInfo,
+	// which would otherwise be promoted, resulting in the Status
+	// field not being included.
+	type Alias daos.PoolInfo
+	return json.Marshal(&struct {
 		*Alias
+		Status int32 `json:"status"`
 	}{
-		Alias: (*Alias)(pqr),
-	}
-
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-
-	if rankSet, err := unmarshallRankSet(aux.EnabledRanks); err != nil {
-		return err
-	} else {
-		pqr.EnabledRanks = rankSet
-	}
-
-	if rankSet, err := unmarshallRankSet(aux.DisabledRanks); err != nil {
-		return err
-	} else {
-		pqr.DisabledRanks = rankSet
-	}
-
-	return nil
+		Alias:  (*Alias)(&pqr.PoolInfo),
+		Status: pqr.Status,
+	})
 }
 
 // PoolQuery performs a pool query operation for the specified pool ID on a

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -796,7 +796,7 @@ func TestControl_PoolQueryResp_MarshalJSON(t *testing.T) {
 		},
 		"null rankset": {
 			pqr: &PoolQueryResp{
-				Status: 0,
+				Status: 42,
 				PoolInfo: daos.PoolInfo{
 					QueryMask:        daos.DefaultPoolQueryMask,
 					State:            daos.PoolServiceStateReady,
@@ -812,11 +812,11 @@ func TestControl_PoolQueryResp_MarshalJSON(t *testing.T) {
 					UpgradeLayoutVer: 8,
 				},
 			},
-			exp: `{"enabled_ranks":null,"disabled_ranks":null,"status":0,"query_mask":"rebuild,space","state":"Ready","uuid":"` + poolUUID.String() + `","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"svc_ldr":6,"svc_reps":[0,1,2],"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
+			exp: `{"query_mask":"rebuild,space","state":"Ready","uuid":"` + poolUUID.String() + `","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"svc_ldr":6,"svc_reps":[0,1,2],"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8,"status":42}`,
 		},
 		"valid rankset": {
 			pqr: &PoolQueryResp{
-				Status: 0,
+				Status: 42,
 				PoolInfo: daos.PoolInfo{
 					QueryMask:        daos.DefaultPoolQueryMask,
 					State:            daos.PoolServiceStateReady,
@@ -834,7 +834,7 @@ func TestControl_PoolQueryResp_MarshalJSON(t *testing.T) {
 					UpgradeLayoutVer: 8,
 				},
 			},
-			exp: `{"enabled_ranks":[0,1,2,3,5],"disabled_ranks":[],"status":0,"query_mask":"rebuild,space","state":"Ready","uuid":"` + poolUUID.String() + `","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"svc_ldr":6,"svc_reps":[0,1,2],"rebuild":null,"tier_stats":null,"pool_layout_ver":7,"upgrade_layout_ver":8}`,
+			exp: `{"query_mask":"rebuild,space","state":"Ready","uuid":"` + poolUUID.String() + `","total_targets":1,"active_targets":2,"total_engines":3,"disabled_targets":4,"version":5,"svc_ldr":6,"svc_reps":[0,1,2],"rebuild":null,"tier_stats":null,"enabled_ranks":[0,1,2,3,5],"disabled_ranks":[],"pool_layout_ver":7,"upgrade_layout_ver":8,"status":42}`,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/lib/daos/api/api.go
+++ b/src/control/lib/daos/api/api.go
@@ -1,0 +1,69 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package api
+
+import (
+	"sync"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+)
+
+/*
+#include <daos.h>
+
+#cgo LDFLAGS: -ldaos
+*/
+import "C"
+
+type (
+	api struct {
+		sync.RWMutex
+		initialized bool
+	}
+)
+
+func daosError(rc C.int) error {
+	return daos.ErrorFromRC(int(rc))
+}
+
+func (api *api) isInitialized() bool {
+	api.RLock()
+	defer api.RUnlock()
+	return api.initialized
+}
+
+// Init performs DAOS API initialization steps and returns a closure
+// to be called before application exit.
+func (api *api) Init() (func(), error) {
+	api.Lock()
+	defer api.Unlock()
+
+	stubFini := func() {}
+	if api.initialized {
+		return stubFini, daos.Already
+	}
+
+	if err := daosError(C.daos_init()); err != nil {
+		return stubFini, err
+	}
+	api.initialized = true
+
+	return api.Fini, nil
+}
+
+// Fini releases resources obtained during DAOS API initialization.
+func (api *api) Fini() {
+	api.Lock()
+	defer api.Unlock()
+
+	if !api.initialized {
+		return
+	}
+
+	C.daos_fini()
+	api.initialized = false
+}

--- a/src/control/lib/daos/api/api.go
+++ b/src/control/lib/daos/api/api.go
@@ -15,7 +15,7 @@ import (
 /*
 #include <daos.h>
 
-#cgo LDFLAGS: -ldaos
+#cgo LDFLAGS: -lcart -lgurt -ldaos -ldaos_common
 */
 import "C"
 

--- a/src/control/lib/daos/api/provider.go
+++ b/src/control/lib/daos/api/provider.go
@@ -1,0 +1,48 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package api
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+type (
+	debugTraceLogger interface {
+		logging.TraceLogger
+		logging.DebugLogger
+	}
+
+	// Provider wraps the C DAOS API with methods that accept and return
+	// standard Go data types.
+	Provider struct {
+		log     debugTraceLogger
+		api     *api
+		cleanup func()
+	}
+)
+
+// NewProvider returns an initialized DAOS API provider.
+func NewProvider(log debugTraceLogger) (*Provider, error) {
+	api := &api{}
+	cleanup, err := api.Init()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize DAOS API")
+	}
+
+	return &Provider{
+		log:     log,
+		api:     api,
+		cleanup: cleanup,
+	}, nil
+}
+
+// Cleanup releases resources obtained during API initialization.
+func (p *Provider) Cleanup() {
+	p.cleanup()
+}

--- a/src/control/lib/daos/api/system.go
+++ b/src/control/lib/daos/api/system.go
@@ -1,0 +1,55 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package api
+
+import (
+	"unsafe"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/daos"
+)
+
+/*
+#include <daos_mgmt.h>
+
+#cgo LDFLAGS: -ldaos
+*/
+import "C"
+
+// GetSystemInfo queries for the connected system information.
+func (p *Provider) GetSystemInfo() (*daos.SystemInfo, error) {
+	var cSysInfo *C.struct_daos_sys_info
+	rc := C.daos_mgmt_get_sys_info(nil, &cSysInfo)
+	if err := daos.ErrorFromRC(int(rc)); err != nil {
+		return nil, errors.Wrap(err, "querying DAOS system information")
+	}
+	defer C.daos_mgmt_put_sys_info(cSysInfo)
+
+	sysInfo := &daos.SystemInfo{
+		Name:      C.GoString(&cSysInfo.dsi_system_name[0]),
+		Provider:  C.GoString(&cSysInfo.dsi_fabric_provider[0]),
+		AgentPath: C.GoString(&cSysInfo.dsi_agent_path[0]),
+	}
+
+	rankURIs := make(map[uint32]*daos.RankURI)
+
+	for _, cRank := range unsafe.Slice(cSysInfo.dsi_ranks, int(cSysInfo.dsi_nr_ranks)) {
+		rankURI := &daos.RankURI{
+			Rank: uint32(cRank.dru_rank),
+			URI:  C.GoString(cRank.dru_uri),
+		}
+		sysInfo.RankURIs = append(sysInfo.RankURIs, rankURI)
+		rankURIs[rankURI.Rank] = rankURI
+	}
+
+	for _, cMSRank := range unsafe.Slice(cSysInfo.dsi_ms_ranks, int(cSysInfo.dsi_nr_ms_ranks)) {
+		sysInfo.AccessPointRankURIs = append(sysInfo.AccessPointRankURIs, rankURIs[uint32(cMSRank)])
+	}
+
+	return sysInfo, nil
+}

--- a/src/control/lib/daos/api/system.go
+++ b/src/control/lib/daos/api/system.go
@@ -17,7 +17,7 @@ import (
 /*
 #include <daos_mgmt.h>
 
-#cgo LDFLAGS: -ldaos
+#cgo LDFLAGS: -lcart -lgurt -ldaos -ldaos_common
 */
 import "C"
 

--- a/src/control/lib/daos/container.go
+++ b/src/control/lib/daos/container.go
@@ -1,0 +1,61 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package daos
+
+import "github.com/google/uuid"
+
+/*
+#include <stdint.h>
+
+#include <daos_cont.h>
+*/
+import "C"
+
+const (
+	// ContainerOpenFlagReadOnly opens the container in read-only mode.
+	ContainerOpenFlagReadOnly = C.DAOS_COO_RO
+	// ContainerOpenFlagReadWrite opens the container in read-write mode.
+	ContainerOpenFlagReadWrite = C.DAOS_COO_RW
+	// ContainerOpenFlagExclusive opens the container in exclusive read-write mode.
+	ContainerOpenFlagExclusive = C.DAOS_COO_EX
+	// ContainerOpenFlagForce skips container health checks.
+	ContainerOpenFlagForce = C.DAOS_COO_FORCE
+	// ContainerOpenFlagReadOnlyMetadata skips container metadata updates.
+	ContainerOpenFlagReadOnlyMetadata = C.DAOS_COO_RO_MDSTATS
+	// ContainerOpenFlagEvict evicts the current user's open handles.
+	ContainerOpenFlagEvict = C.DAOS_COO_EVICT
+	// ContainerOpenFlagEvictAll evicts all open handles.
+	ContainerOpenFlagEvictAll = C.DAOS_COO_EVICT_ALL
+)
+
+// ContainerInfo contains information about the Container.
+type ContainerInfo struct {
+	PoolUUID         uuid.UUID `json:"pool_uuid"`
+	ContainerUUID    uuid.UUID `json:"container_uuid"`
+	ContainerLabel   string    `json:"container_label,omitempty"`
+	LatestSnapshot   uint64    `json:"latest_snapshot"`
+	RedundancyFactor uint32    `json:"redundancy_factor"`
+	NumHandles       uint32    `json:"num_handles"`
+	NumSnapshots     uint32    `json:"num_snapshots"`
+	OpenTime         uint64    `json:"open_time"`
+	CloseModifyTime  uint64    `json:"close_modify_time"`
+	Type             string    `json:"container_type"`
+	ObjectClass      string    `json:"object_class,omitempty"`
+	DirObjectClass   string    `json:"dir_object_class,omitempty"`
+	FileObjectClass  string    `json:"file_object_class,omitempty"`
+	CHints           string    `json:"hints,omitempty"`
+	ChunkSize        uint64    `json:"chunk_size,omitempty"`
+	Health           string    `json:"health,omitempty"` // FIXME (DAOS-10028): Should be derived from props
+}
+
+// Name returns an identifier for the container (Label, if set, falling back to UUID).
+func (ci *ContainerInfo) Name() string {
+	if ci.ContainerLabel == "" {
+		return ci.ContainerUUID.String()
+	}
+	return ci.ContainerLabel
+}

--- a/src/control/lib/daos/health.go
+++ b/src/control/lib/daos/health.go
@@ -1,0 +1,28 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package daos
+
+import (
+	"github.com/google/uuid"
+)
+
+type (
+	// ComponentBuild contains string representations of a component's build information.
+	ComponentBuild struct {
+		Version   string `json:"version"`
+		BuildInfo string `json:"build_info,omitempty"`
+		LibPath   string `json:"lib_path,omitempty"`
+	}
+
+	// SystemHealthInfo provides a top-level structure to hold system health information.
+	SystemHealthInfo struct {
+		SystemInfo         *SystemInfo                    `json:"system_info"`
+		ComponentBuildInfo map[string]ComponentBuild      `json:"component_build_info"`
+		Pools              map[uuid.UUID]*PoolInfo        `json:"pools"`
+		Containers         map[uuid.UUID][]*ContainerInfo `json:"pool_containers,omitempty"`
+	}
+)

--- a/src/control/lib/daos/pool_test.go
+++ b/src/control/lib/daos/pool_test.go
@@ -7,6 +7,7 @@
 package daos
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -266,6 +267,16 @@ func TestDaos_PoolQueryMaskUnmarshalJSON(t *testing.T) {
 		"string values": {
 			testData:  []byte("rebuild,disabled_engines"),
 			expString: "disabled_engines,rebuild",
+		},
+		"JSON-encoded string values": {
+			testData: func() []byte {
+				if b, err := json.Marshal("rebuild,enabled_engines"); err != nil {
+					panic(err)
+				} else {
+					return b
+				}
+			}(),
+			expString: "enabled_engines,rebuild",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/lib/daos/status.go
+++ b/src/control/lib/daos/status.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -28,6 +28,17 @@ func (ds Status) Error() string {
 
 func (ds Status) Int32() int32 {
 	return int32(ds)
+}
+
+// ErrorFromRC converts a simple DAOS return code into an error.
+func ErrorFromRC(rc int) error {
+	if rc == 0 {
+		return nil
+	}
+	if rc > 0 {
+		rc = -rc
+	}
+	return Status(rc)
 }
 
 const (
@@ -160,4 +171,6 @@ const (
 	NoCert Status = -C.DER_NO_CERT
 	// BadCert indicates that an invalid certificate was detected.
 	BadCert Status = -C.DER_BAD_CERT
+	// RedundancyFactorExceeded indicates that the maximum number of failed components was exceeded.
+	RedundancyFactorExceeded = -C.DER_RF
 )

--- a/src/control/lib/daos/status_test.go
+++ b/src/control/lib/daos/status_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -7,6 +7,7 @@
 package daos_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -49,6 +50,20 @@ func TestDaos_Error(t *testing.T) {
 	} {
 		t.Run(expStr, func(t *testing.T) {
 			test.AssertEqual(t, expStr, ds.Error(), "not equal")
+		})
+	}
+}
+
+func TestDaos_ErrorFromRC(t *testing.T) {
+	for rc, expErr := range map[int]error{
+		0:      nil,
+		-1014:  daos.ProtocolError,
+		1013:   daos.TryAgain,
+		424242: daos.Status(-424242),
+	} {
+		t.Run(fmt.Sprintf("%v", expErr), func(t *testing.T) {
+			gotErr := daos.ErrorFromRC(rc)
+			test.AssertEqual(t, expErr, gotErr, "not equal")
 		})
 	}
 }

--- a/src/control/lib/daos/system.go
+++ b/src/control/lib/daos/system.go
@@ -1,0 +1,53 @@
+//
+// (C) Copyright 2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package daos
+
+import (
+	"net/url"
+	"sort"
+)
+
+type (
+	// RankURI expresses a rank-to-fabric-URI mapping.
+	RankURI struct {
+		Rank uint32 `json:"rank"`
+		URI  string `json:"uri"`
+	}
+
+	// SystemInfo represents information about the connected system.
+	SystemInfo struct {
+		Name                string     `json:"system_name"`
+		Provider            string     `json:"fabric_provider"`
+		AgentPath           string     `json:"agent_path"`
+		RankURIs            []*RankURI `json:"rank_uris"`
+		AccessPointRankURIs []*RankURI `json:"access_point_rank_uris"`
+	}
+)
+
+// AccessPoints returns a string slice representation of the system access points.
+func (si *SystemInfo) AccessPoints() []string {
+	apSet := make(map[string]struct{})
+	for _, ri := range si.AccessPointRankURIs {
+		// NB: This is intended for IP-based address schemes. If we can't
+		// pretty-print the URI as an address, then the fallback is to use
+		// the raw URI. Not as nice, but better than nothing.
+		url, err := url.Parse(ri.URI)
+		if err == nil {
+			apSet[url.Hostname()] = struct{}{}
+		} else {
+			apSet[ri.URI] = struct{}{}
+		}
+	}
+
+	apList := make([]string, 0, len(apSet))
+	for ap := range apSet {
+		apList = append(apList, ap)
+	}
+	sort.Strings(apList)
+
+	return apList
+}

--- a/src/control/lib/dlopen/dlopen.go
+++ b/src/control/lib/dlopen/dlopen.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -30,7 +30,7 @@ type LibHandle struct {
 // by the names specified in libs and returning the first that is successfully
 // opened. Callers are responsible for closing the handler. If no library can
 // be successfully opened, an error is returned.
-func GetHandle(libs []string) (*LibHandle, error) {
+func GetHandle(libs ...string) (*LibHandle, error) {
 	for _, name := range libs {
 		libname := C.CString(name)
 		defer C.free(unsafe.Pointer(libname))

--- a/src/control/lib/dlopen/dlopen_example.go
+++ b/src/control/lib/dlopen/dlopen_example.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -27,7 +27,7 @@ import (
 )
 
 func strlen(libs []string, s string) (int, error) {
-	h, err := GetHandle(libs)
+	h, err := GetHandle(libs...)
 	if err != nil {
 		return -1, fmt.Errorf(`couldn't get a handle to the library: %v`, err)
 	}

--- a/src/control/lib/txtfmt/table.go
+++ b/src/control/lib/txtfmt/table.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -10,8 +10,25 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
+	"unicode"
 )
+
+// Title returns the string in Title Format.
+//
+// NB: This is basically a copy of strings.Title(), which is deprecated.
+func Title(s string) string {
+	prev := ' '
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(prev) {
+			prev = r
+			return unicode.ToTitle(r)
+		}
+		prev = r
+		return r
+	}, strings.ToLower(s))
+}
 
 // TableRow is a map of string values to be printed, keyed by column title.
 type TableRow map[string]string

--- a/src/control/lib/txtfmt/table_test.go
+++ b/src/control/lib/txtfmt/table_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2021 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -12,6 +12,25 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestTitle(t *testing.T) {
+	for testStr, expStr := range map[string]string{
+		"":                      "",
+		" ":                     " ",
+		"lowercase":             "Lowercase",
+		"lowercase three words": "Lowercase Three Words",
+		"mIxed CASE":            "Mixed Case",
+		"12345":                 "12345",
+	} {
+		t.Run(testStr, func(t *testing.T) {
+			gotStr := Title(testStr)
+
+			if diff := cmp.Diff(expStr, gotStr); diff != "" {
+				t.Fatalf("unexpected result (-want, +got): %s", diff)
+			}
+		})
+	}
+}
 
 func TestNewTableFormatter_NoTitles(t *testing.T) {
 	f := NewTableFormatter()

--- a/src/control/vendor/github.com/jessevdk/go-flags/group.go
+++ b/src/control/vendor/github.com/jessevdk/go-flags/group.go
@@ -331,7 +331,7 @@ func (g *Group) checkForDuplicateFlags() *Error {
 				longName := option.LongNameWithNamespace()
 
 				if otherOption, ok := longNames[longName]; ok {
-					duplicateError = newErrorf(ErrDuplicatedFlag, "option `%s' uses the same long name as option `%s'", option, otherOption)
+					duplicateError = newErrorf(ErrDuplicatedFlag, "%s/%s: option `%s' uses the same long name as option `%s'", longName, otherOption.LongNameWithNamespace(), option, otherOption)
 					return
 				}
 				longNames[longName] = option

--- a/src/include/daos/api.h
+++ b/src/include/daos/api.h
@@ -1,0 +1,28 @@
+/**
+ * (C) Copyright 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+/**
+ * Miscellaneous Client API Functions
+ */
+
+#ifndef __DAOS_API_H__
+#define __DAOS_API_H__
+
+#include <sys/types.h>
+
+/**
+ * Retrieve the daos API version.
+ *
+ * \param[out]	major	Pointer to an int that will be set to DAOS_API_VERSION_MAJOR.
+ * \param[out]	minor	Pointer to an int that will be set to DAOS_API_VERSION_MINOR.
+ * \param[out]	fix	    Pointer to an int that will be set to DAOS_API_VERSION_FIX.
+ *
+ * \return		0 if Success, negative if failed.
+ * \retval -DER_INVAL	Invalid parameter.
+ */
+int
+daos_version_get(int *major, int *minor, int *fix);
+
+#endif

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -19,6 +19,7 @@ extern "C" {
 #include <string.h>
 #include <stdbool.h>
 #include <ctype.h>
+#include <limits.h>
 
 /** uuid_t */
 #include <uuid/uuid.h>
@@ -274,6 +275,8 @@ struct daos_sys_info {
 	char			 dsi_system_name[DAOS_SYS_INFO_STRING_MAX + 1];
 	/** fabric provider in use by this system */
 	char			 dsi_fabric_provider[DAOS_SYS_INFO_STRING_MAX + 1];
+	/** path to agent socket */
+	char                     dsi_agent_path[PATH_MAX];
 	/** length of ranks array */
 	uint32_t		 dsi_nr_ranks;
 	/** ranks and their client-accessible URIs */

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -492,6 +492,7 @@ dc_mgmt_get_sys_info(const char *sys, struct daos_sys_info **out)
 
 	copy_str(info->dsi_system_name, internal.system_name);
 	copy_str(info->dsi_fabric_provider, internal.provider);
+	copy_str(info->dsi_agent_path, dc_agent_sockpath);
 
 	*out = info;
 

--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2022-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -41,35 +41,35 @@ class DmgPoolQueryRanks(ControlTestBase):
         self.log.debug("Checking without ranks state information")
         data = self.dmg.pool_query(self.pool.identifier)
         self.assertIsNone(
-            data['response']['enabled_ranks'],
+            data['response'].get('enabled_ranks'),
             "Invalid enabled_ranks field: want=None, got={}".format(
-                data['response']['enabled_ranks']))
+                data['response'].get('enabled_ranks')))
         self.assertIsNone(
-            data['response']['disabled_ranks'],
+            data['response'].get('disabled_ranks'),
             "Invalid disabled_ranks field: want=None, got={}".format(
-                data['response']['disabled_ranks']))
+                data['response'].get('disabled_ranks')))
 
         self.log.debug("Checking enabled ranks state information")
         data = self.dmg.pool_query(self.pool.identifier, show_enabled=True)
         self.assertListEqual(
-            data['response']['enabled_ranks'], [0, 1, 2],
+            data['response'].get('enabled_ranks'), [0, 1, 2],
             "Invalid enabled_ranks field: want=[0, 1, 2], got={}".format(
-                data['response']['enabled_ranks']))
+                data['response'].get('enabled_ranks')))
         self.assertIsNone(
-            data['response']['disabled_ranks'],
+            data['response'].get('disabled_ranks'),
             "Invalid disabled_ranks field: want=None, got={}".format(
-                data['response']['disabled_ranks']))
+                data['response'].get('disabled_ranks')))
 
         self.log.debug("Checking disabled ranks state information")
         data = self.dmg.pool_query(self.pool.identifier, show_disabled=True)
         self.assertIsNone(
-            data['response']['enabled_ranks'],
+            data['response'].get('enabled_ranks'),
             "Invalid enabled_ranks field: want=None, got={}".format(
-                data['response']['enabled_ranks']))
+                data['response'].get('enabled_ranks')))
         self.assertListEqual(
-            data['response']['disabled_ranks'], [],
+            data['response'].get('disabled_ranks'), [],
             "Invalid disabled_ranks field: want=[], got={}".format(
-                data['response']['disabled_ranks']))
+                data['response'].get('disabled_ranks')))
 
     def test_pool_query_ranks_error(self):
         """Test that ranks state option are mutually exclusive.
@@ -123,16 +123,16 @@ class DmgPoolQueryRanks(ControlTestBase):
             self.log.debug("Checking enabled ranks state information")
             data = self.dmg.pool_query(self.pool.identifier, show_enabled=True)
             self.assertListEqual(
-                data['response']['enabled_ranks'], enabled_ranks,
+                data['response'].get('enabled_ranks'), enabled_ranks,
                 "Invalid enabled_ranks field: want={}, got={}".format(
-                    enabled_ranks, data['response']['enabled_ranks']))
+                    enabled_ranks, data['response'].get('enabled_ranks')))
 
             self.log.debug("Checking disabled ranks state information")
             data = self.dmg.pool_query(self.pool.identifier, show_disabled=True)
             self.assertListEqual(
-                data['response']['disabled_ranks'], disabled_ranks,
+                data['response'].get('disabled_ranks'), disabled_ranks,
                 "Invalid disabled_ranks field: want={}, got={}".format(
-                    disabled_ranks, data['response']['disabled_ranks']))
+                    disabled_ranks, data['response'].get('disabled_ranks')))
 
             self.log.debug("Waiting for pool to be rebuild")
             self.pool.wait_for_rebuild_to_start()
@@ -160,16 +160,16 @@ class DmgPoolQueryRanks(ControlTestBase):
             self.log.debug("Checking enabled ranks state information")
             data = self.dmg.pool_query(self.pool.identifier, show_enabled=True)
             self.assertListEqual(
-                data['response']['enabled_ranks'], enabled_ranks,
+                data['response'].get('enabled_ranks'), enabled_ranks,
                 "Invalid enabled_ranks field: want={}, got={}".format(
-                    enabled_ranks, data['response']['enabled_ranks']))
+                    enabled_ranks, data['response'].get('enabled_ranks')))
 
             self.log.debug("Checking disabled ranks state information")
             data = self.dmg.pool_query(self.pool.identifier, show_disabled=True)
             self.assertListEqual(
-                data['response']['disabled_ranks'], disabled_ranks,
+                data['response'].get('disabled_ranks'), disabled_ranks,
                 "Invalid disabled_ranks field: want={}, got={}".format(
-                    disabled_ranks, data['response']['disabled_ranks']))
+                    disabled_ranks, data['response'].get('disabled_ranks')))
 
             self.log.debug("Waiting for pool to be rebuild")
             self.pool.wait_for_rebuild_to_start()

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -58,9 +58,6 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
         #   exp_info = self.params.get("exp_vals", path="/run/*", default={})
         # but this yields an empty dictionary (the default), so it needs to be defined manually:
         exp_info = {
-            "enabled_ranks": None,
-            "disabled_ranks": None,
-            "status": self.params.get("pool_status", path="/run/exp_vals/*"),
             "state": self.params.get("pool_state", path="/run/exp_vals/*"),
             "uuid": self.pool.uuid.lower(),
             "total_targets": self.params.get("total_targets", path="/run/exp_vals/*"),
@@ -74,7 +71,8 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
                 "status": self.params.get("rebuild_status", path="/run/exp_vals/rebuild/*"),
                 "state": self.params.get("state", path="/run/exp_vals/rebuild/*"),
                 "objects": self.params.get("objects", path="/run/exp_vals/rebuild/*"),
-                "records": self.params.get("records", path="/run/exp_vals/rebuild/*")
+                "records": self.params.get("records", path="/run/exp_vals/rebuild/*"),
+                "total_objects": self.params.get("total_objects", path="/run/exp_vals/rebuild/*")
             },
             "tier_stats": [
                 {
@@ -102,7 +100,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
         }
 
         self.assertDictEqual(
-            self.pool.query_data["response"], exp_info,
+            exp_info, self.pool.query_data["response"],
             "Found difference in dmg pool query output and the expected values")
 
         self.log.info("All expect values found in dmg pool query output.")

--- a/src/tests/ftest/control/dmg_pool_query_test.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_test.yaml
@@ -25,7 +25,6 @@ ior:
   dfs_destroy: False
 
 exp_vals:
-  pool_status: 0
   pool_state: "Ready"
   total_targets: 4
   active_targets: 4
@@ -44,6 +43,7 @@ exp_vals:
     state: "idle"
     objects: 0
     records: 0
+    total_objects: 0
 
 pool_uuids:
   uuids:

--- a/src/tests/ftest/deployment/network_failure.py
+++ b/src/tests/ftest/deployment/network_failure.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2022-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -249,7 +249,7 @@ class NetworkFailureTest(IorTestBase):
 
         # 6. Call dmg pool query -b to find the disabled ranks.
         output = dmg_cmd.pool_query(pool=self.pool.identifier, show_disabled=True)
-        disabled_ranks = output["response"]["disabled_ranks"]
+        disabled_ranks = output["response"].get("disabled_ranks")
         self.log.info("Disabled ranks = %s", disabled_ranks)
 
         # 7. Call dmg pool reintegrate one rank at a time to enable all ranks.

--- a/src/tests/ftest/deployment/server_rank_failure.py
+++ b/src/tests/ftest/deployment/server_rank_failure.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2022-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -184,7 +184,7 @@ class ServerRankFailure(IorTestBase):
 
         # 9. Call dmg pool query -b to find the disabled ranks.
         output = self.get_dmg_command().pool_query(pool=self.pool.identifier, show_disabled=True)
-        disabled_ranks = output["response"]["disabled_ranks"]
+        disabled_ranks = output["response"].get("disabled_ranks")
         self.log.info("Disabled ranks = %s", disabled_ranks)
 
         # 10. Call dmg pool reintegrate one rank at a time to enable all ranks.

--- a/src/tests/ftest/pool/create_query.py
+++ b/src/tests/ftest/pool/create_query.py
@@ -1,5 +1,5 @@
 """
-(C) Copyright 2021-2023 Intel Corporation.
+(C) Copyright 2021-2024 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -51,7 +51,7 @@ class PoolCreateQueryTests(TestWithServers):
 
         # Query pool created
         resp = self.get_dmg_command().pool_query(pool.identifier, show_enabled=True)["response"]
-        nb_ranks = len(resp["enabled_ranks"])
+        nb_ranks = len(resp.get("enabled_ranks"))
         tier_stats = resp["tier_stats"]
         self.assertEqual("SCM", tier_stats[0]["media_type"].upper(), "Unexpected tier media type")
         self.assertEqual("NVME", tier_stats[1]["media_type"].upper(), "Unexpected tier media type")

--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -77,7 +77,8 @@ class ListVerboseTest(IorTestBase):
                 "status": 0,
                 "state": rebuild_state,
                 "objects": 0,
-                "records": 0
+                "records": 0,
+                "total_objects": 0
             },
             # NB: tests should not expect min/max/mean values
             "tier_stats": [

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -669,8 +669,8 @@ class DmgCommand(DmgCommandBase):
         #             "max": 3999993856,
         #             "mean": 3999993856
         #         },
-        #         "enabled_ranks": None,
-        #         "disabled_ranks": None
+        #         "enabled_ranks": [0,1,3],
+        #         "disabled_ranks": [2]
         #     },
         #     "error": null,
         #     "status": 0

--- a/src/tests/ftest/util/pool_create_all_base.py
+++ b/src/tests/ftest/util/pool_create_all_base.py
@@ -119,7 +119,7 @@ class PoolCreateAllTestBase(TestWithServers):
         if ranks is not None:
             wait_ranks = sorted(ranks)
             data = self.dmg.pool_query(self.pool[pool_idx].identifier, show_enabled=True)
-            got_ranks = sorted(data['response']['enabled_ranks'])
+            got_ranks = sorted(data['response'].get('enabled_ranks'))
             self.assertListEqual(
                 wait_ranks,
                 got_ranks,


### PR DESCRIPTION
Perform basic system health checks from the client
perspective. Checks the following:

  * Client/Server versions
  * Key library versions and paths
  * Connected sytem information
  * Pool status for all pools to which the user
    has access
  * Container status for all containers in the
    checked pools

Signed-off-by: Michael MacDonald <mjmac@google.com>
