### PR TITLE
DAOS-16313 build: Add explicit linker flags to lib/daos/api

### DIFF
--- a/src/control/lib/daos/api/api.go
+++ b/src/control/lib/daos/api/api.go
@@ -15,7 +15,7 @@ import (
 /*
 #include <daos.h>
 
-#cgo LDFLAGS: -ldaos
+#cgo LDFLAGS: -lcart -lgurt -ldaos -ldaos_common
 */
 import "C"
 

--- a/src/control/lib/daos/api/system.go
+++ b/src/control/lib/daos/api/system.go
@@ -17,7 +17,7 @@ import (
 /*
 #include <daos_mgmt.h>
 
-#cgo LDFLAGS: -ldaos
+#cgo LDFLAGS: -lcart -lgurt -ldaos -ldaos_common
 */
 import "C"
 


### PR DESCRIPTION
Apparently these are needed on Ubuntu.

Required-githooks: true

Change-Id: Ieb0446760f0b53e2f09feeae0226ea26dd455d58
Signed-off-by: Michael MacDonald <mjmac@google.com>
