### PR TITLE
DAOS-16316 test: Disable runtime dir creation for test

### DIFF
--- a/src/tests/ftest/control/daos_agent_config.py
+++ b/src/tests/ftest/control/daos_agent_config.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -42,6 +42,7 @@ class DaosAgentConfigTest(TestWithServers):
             self.agent_managers[-1],
             include_local_host(self.hostlist_clients),
             self.hostfile_clients_slots)
+        self.agent_managers[-1].verify_socket_dir = False
 
         # Get the input to verify
         c_val = self.params.get("config_val", "/run/agent_config_val/*/")

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -258,6 +258,9 @@ class DaosAgentManager(SubprocessManager):
         self.attachinfo = None
         self.outputdir = outputdir
 
+        # Support disabling verifying the socket directory (runtime_dir) for tests
+        self.verify_socket_dir = True
+
     def _set_hosts(self, hosts, path, slots):
         """Set the hosts used to execute the daos command.
 
@@ -285,7 +288,8 @@ class DaosAgentManager(SubprocessManager):
             get_log_file("daosCA/certs"), self._hosts)
 
         # Verify the socket directory exists when using a non-systemctl manager
-        self.verify_socket_directory(getuser())
+        if self.verify_socket_dir:
+            self.verify_socket_directory(getuser())
 
         super().start()
 


### PR DESCRIPTION
Recent support for user run daos_agent in the test harness enabled always creating the runtime_dir, but this causes the test_daos_agent_config_basic test to fail when using a list for the runtime_dir value.  This change supports skipping the creation of the runtime_dir for testing purposes.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: pr DaosAgentConfigTest
Skip-func-hw-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
