### PR TITLE
DAOS-16089 object: IO handler should check obj_bulk_args::result

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -593,8 +593,11 @@ done:
 		rc = -DER_IO;
 	}
 
+	if (rc == 0 && p_arg->result != 0)
+		rc = p_arg->result;
+
 	/* After RDMA is done, corrupt the server data */
-	if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_DISK)) {
+	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_DISK)) {
 		struct bio_sglist	*fbsgl;
 		d_sg_list_t		 fsgl;
 		int			*fbuffer;
@@ -4599,6 +4602,8 @@ ds_cpd_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh, struct daos_cp
 			rc = dss_abterr2der(rc);
 		if (rc == 0 && *status != 0)
 			rc = *status;
+		if (rc == 0 && bulks[i].result != 0)
+			rc = bulks[i].result;
 
 		ABT_eventual_free(&bulks[i].eventual);
 		bio_iod_flush(biods[i]);


### PR DESCRIPTION
On server side, obj_bulk_comp_cb() may set the bulk transfer errno (that is returned from lower layer network) via obj_bulk_args::result, but the obj_bulk_transfer() caller did not check such 'result', then it may miss lower layer network failure and thought bulk transferred successfully by wrong, as to the subsequent logic may access invalid data.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
