### PR TITLE
DAOS-16288 cart: coverity fixes for 16287,16288,16289 (#14843)

### DIFF
--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1648,7 +1648,7 @@ out:
 
 	if (rc != DER_SUCCESS)
 		D_INFO("uri lookup of (rank=%d:tag=%d) group=%s failed; rc=%d\n", ul_in->ul_rank,
-		       ul_in->ul_tag, grp_priv->gp_pub.cg_grpid, rc);
+		       ul_in->ul_tag, grp_priv == NULL ? "(null)" : grp_priv->gp_pub.cg_grpid, rc);
 
 	if (should_decref)
 		crt_grp_priv_decref(grp_priv);

--- a/src/tests/ftest/cart/test_group_np_cli.c
+++ b/src/tests/ftest/cart/test_group_np_cli.c
@@ -127,8 +127,8 @@ test_run(void)
 				/* avoid checkpatch warning */
 				d_rank_list_free(rank_list);
 			}
-			rank_list = uint32_array_to_rank_list(_cg_ranks,
-							      _cg_num_ranks);
+			rank_list = uint32_array_to_rank_list(_cg_ranks, _cg_num_ranks);
+			D_ASSERTF(rank_list != NULL, "failed to convert array to rank list\n");
 		}
 
 		rc = crtu_wait_for_ranks(test_g.t_crt_ctx[0],

--- a/src/tests/ftest/cart/test_no_timeout.c
+++ b/src/tests/ftest/cart/test_no_timeout.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2018-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -103,7 +103,9 @@ test_run(void)
 				 test_g.t_srv_ctx_num, 60, 120);
 	D_ASSERTF(rc == 0, "wait_for_ranks() failed; rc=%d\n", rc);
 
-	crt_group_size(test_g.t_remote_group, &test_g.t_remote_group_size);
+	rc = crt_group_size(test_g.t_remote_group, &test_g.t_remote_group_size);
+	D_ASSERTF(rc == 0, "crt_group_size() failed; rc=%d\n", rc);
+
 	fprintf(stderr, "size of %s is %d\n", test_g.t_remote_group_name,
 		test_g.t_remote_group_size);
 


### PR DESCRIPTION
Coverity fixes for DAOS-16287,16288,16289.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
