### PR TITLE
DAOS-16330 cart: Reduce error logs during timeouts

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -1287,7 +1287,7 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 			left_to_print--;
 
 			if (err_to_print == 0 && left_to_print > 0)
-				D_ERROR("[%d more rpcs timed out. rest logged at INFO level]\n",
+				D_ERROR(" %d more rpcs timed out. rest logged at INFO level\n",
 					left_to_print);
 
 		} else {

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2366,6 +2366,8 @@ out:
  *
  * Each time node is removed, an corresponding index is added back
  * to the free index list
+ *
+ * Returns index on success or -DER_NOSPACE if all indecies are used up
  */
 static int
 grp_get_free_index(struct crt_grp_priv *priv)
@@ -2375,11 +2377,9 @@ grp_get_free_index(struct crt_grp_priv *priv)
 
 	free_index = d_list_pop_entry(&priv->gp_membs.cgm_free_indices,
 				      struct free_index, fi_link);
-
-	if (!free_index) {
-		D_DEBUG(DB_ALL, "No more free indices left\n");
+	/* Forces caller to expand the list  */
+	if (!free_index)
 		return -DER_NOSPACE;
-	}
 
 	ret = free_index->fi_index;
 	D_FREE(free_index);

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2367,7 +2367,7 @@ out:
  * Each time node is removed, an corresponding index is added back
  * to the free index list
  *
- * Returns index on success or -DER_NOSPACE if all indecies are used up
+ * Returns index on success or -DER_NOSPACE if all indices are used up
  */
 static int
 grp_get_free_index(struct crt_grp_priv *priv)

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -208,6 +208,28 @@ prov_data_init(struct crt_prov_gdata *prov_data, crt_provider_t provider,
 	return DER_SUCCESS;
 }
 
+#define DUMP_GDATA_FIELD(format, x) D_INFO("\t%s = " format " \n", #x, crt_gdata.x)
+
+static void
+crt_gdata_dump(void)
+{
+	D_INFO("settings:\n");
+	DUMP_GDATA_FIELD("%d", cg_post_init);
+	DUMP_GDATA_FIELD("%d", cg_post_incr);
+	DUMP_GDATA_FIELD("%d", cg_timeout);
+	DUMP_GDATA_FIELD("%d", cg_swim_ctx_idx);
+	DUMP_GDATA_FIELD("%d", cg_credit_ep_ctx);
+	DUMP_GDATA_FIELD("%d", cg_iv_inline_limit);
+	DUMP_GDATA_FIELD("%d", cg_auto_swim_disable);
+	DUMP_GDATA_FIELD("%d", cg_server);
+	DUMP_GDATA_FIELD("%d", cg_use_sensors);
+	DUMP_GDATA_FIELD("%d", cg_provider_is_primary);
+	DUMP_GDATA_FIELD("0x%lx", cg_rpcid);
+	DUMP_GDATA_FIELD("%ld", cg_num_cores);
+	DUMP_GDATA_FIELD("%d", cg_rpc_quota);
+	D_INFO("\n");
+}
+
 /* first step init - for initializing crt_gdata */
 static int data_init(int server, crt_init_options_t *opt)
 {
@@ -219,10 +241,7 @@ static int data_init(int server, crt_init_options_t *opt)
 	uint32_t        post_init = CRT_HG_POST_INIT, post_incr = CRT_HG_POST_INCR;
 	int		rc = 0;
 
-	D_DEBUG(DB_ALL, "initializing crt_gdata...\n");
 	crt_env_dump();
-	D_DEBUG(DB_ALL, "Starting RPCID %#lx. Num cores: %ld\n",
-		crt_gdata.cg_rpcid, crt_gdata.cg_num_cores);
 
 	/* Set context post init / post incr to tune number of pre-posted recvs */
 	crt_env_get(D_POST_INIT, &post_init);
@@ -254,13 +273,7 @@ static int data_init(int server, crt_init_options_t *opt)
 		crt_gdata.cg_timeout = CRT_DEFAULT_TIMEOUT_S;
 	else
 		crt_gdata.cg_timeout = timeout;
-
-	D_DEBUG(DB_ALL, "set the global timeout value as %d second.\n",
-		crt_gdata.cg_timeout);
-
 	crt_gdata.cg_swim_ctx_idx = CRT_DEFAULT_PROGRESS_CTX_IDX;
-
-	D_DEBUG(DB_ALL, "SWIM context idx=%d\n", crt_gdata.cg_swim_ctx_idx);
 
 	/* Override defaults and environment if option is set */
 	if (opt && opt->cio_use_credits) {
@@ -281,23 +294,12 @@ static int data_init(int server, crt_init_options_t *opt)
 	/* This is a workaround for CART-871 if universe size is not set */
 	crt_env_get(FI_UNIVERSE_SIZE, &fi_univ_size);
 	if (fi_univ_size == 0) {
-		D_INFO("FI_UNIVERSE_SIZE was not set; setting to 2048\n");
 		d_setenv("FI_UNIVERSE_SIZE", "2048", 1);
 	}
 
-	if (credits == 0) {
-		D_DEBUG(DB_ALL, "CRT_CREDIT_EP_CTX set as 0, flow control disabled.\n");
-	} else if (credits > CRT_MAX_CREDITS_PER_EP_CTX) {
-		D_DEBUG(DB_ALL, "ENV CRT_CREDIT_EP_CTX's value %d exceed max "
-			"allowed value, use %d for flow control.\n",
-			credits, CRT_MAX_CREDITS_PER_EP_CTX);
+	if (credits > CRT_MAX_CREDITS_PER_EP_CTX)
 		credits = CRT_MAX_CREDITS_PER_EP_CTX;
-	} else {
-		D_DEBUG(DB_ALL, "CRT_CREDIT_EP_CTX set as %d for flow "
-			"control.\n", credits);
-	}
 	crt_gdata.cg_credit_ep_ctx = credits;
-	D_ASSERT(crt_gdata.cg_credit_ep_ctx <= CRT_MAX_CREDITS_PER_EP_CTX);
 
 	/** Enable statistics only for the server side and if requested */
 	if (opt && opt->cio_use_sensors && server) {
@@ -321,6 +323,8 @@ static int data_init(int server, crt_init_options_t *opt)
 	}
 
 	gdata_init_flag = 1;
+	crt_gdata_dump();
+
 	return rc;
 }
 
@@ -422,15 +426,14 @@ __split_arg(char *s_arg_to_split, const char *delim, char **first_arg, char **se
 	return DER_SUCCESS;
 }
 
-
-int
+crt_provider_t
 crt_str_to_provider(const char *str_provider)
 {
-	int	provider_idx = CRT_PROV_UNKNOWN;
-	int	i;
+	crt_provider_t prov = CRT_PROV_UNKNOWN;
+	int            i;
 
 	if (str_provider == NULL)
-		return provider_idx;
+		return prov;
 
 	for (i = 0; crt_na_dict[i].nad_str != NULL; i++) {
 
@@ -439,12 +442,12 @@ crt_str_to_provider(const char *str_provider)
 		    (crt_na_dict[i].nad_alt_str &&
 		     !strncmp(str_provider, crt_na_dict[i].nad_alt_str,
 			      strlen(crt_na_dict[i].nad_alt_str) + 1))) {
-			provider_idx = crt_na_dict[i].nad_type;
+			prov = crt_na_dict[i].nad_type;
 			break;
 		}
 	}
 
-	return provider_idx;
+	return prov;
 }
 
 static int
@@ -456,14 +459,12 @@ check_grpid(crt_group_id_t grpid)
 		return rc;
 
 	if (crt_validate_grpid(grpid) != 0) {
-		D_ERROR("grpid contains invalid characters "
-			"or is too long\n");
+		D_ERROR("grpid contains invalid characters or is too long\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
 	if (strcmp(grpid, CRT_DEFAULT_GRPID) == 0) {
-		D_ERROR("invalid client grpid (same as "
-			"CRT_DEFAULT_GRPID).\n");
+		D_ERROR("invalid client grpid (same as CRT_DEFAULT_GRPID).\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 out:

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -227,7 +227,6 @@ crt_gdata_dump(void)
 	DUMP_GDATA_FIELD("0x%lx", cg_rpcid);
 	DUMP_GDATA_FIELD("%ld", cg_num_cores);
 	DUMP_GDATA_FIELD("%d", cg_rpc_quota);
-	D_INFO("\n");
 }
 
 /* first step init - for initializing crt_gdata */

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -42,7 +42,7 @@
 			      ##__VA_ARGS__);                                                      \
 	} while (0)
 
-/* Log an error with a RPC descriptor */
+/* Log an error with an RPC descriptor */
 #define RPC_ERROR(rpc, fmt, ...)                                                                   \
 	do {                                                                                       \
 		char *_module;                                                                     \
@@ -55,6 +55,31 @@
 			      ##__VA_ARGS__);                                                      \
 	} while (0)
 
+/* Log a warning with an RPC descriptor */
+#define RPC_WARN(rpc, fmt, ...)                                                                    \
+	do {                                                                                       \
+		char *_module;                                                                     \
+		char *_opc;                                                                        \
+                                                                                                   \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
+		D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
+			     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
+			     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
+			     ##__VA_ARGS__);                                                       \
+	} while (0)
+
+/* Log an info message with an RPC descriptor */
+#define RPC_INFO(rpc, fmt, ...)                                                                    \
+	do {                                                                                       \
+		char *_module;                                                                     \
+		char *_opc;                                                                        \
+                                                                                                   \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
+		D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
+			     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
+			     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
+			     ##__VA_ARGS__);                                                       \
+	} while (0)
 /**
  * If \a cond is false, this is equivalent to an RPC_ERROR (i.e., \a mask is
  * ignored). If \a cond is true, this is equivalent to an RPC_TRACE.

--- a/src/cart/crt_internal_fns.h
+++ b/src/cart/crt_internal_fns.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -13,8 +13,6 @@
 
 /** crt_init.c */
 bool crt_initialized(void);
-
-int crt_str_to_provider(const char *provider);
 
 /** crt_register.c */
 int crt_opc_map_create(void);

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -119,16 +119,13 @@ struct crt_gdata {
 	volatile unsigned int	cg_refcount;
 
 	/** flags to keep track of states */
-	unsigned int		cg_inited		: 1,
-				cg_grp_inited		: 1,
-				cg_swim_inited		: 1,
-				cg_auto_swim_disable	: 1,
-				/** whether it is a client or server */
-				cg_server		: 1,
-				/** whether scalable endpoint is enabled */
-				cg_use_sensors		: 1,
-				/** whether we are on a primary provider */
-				cg_provider_is_primary	: 1;
+	unsigned int cg_inited : 1, cg_grp_inited : 1, cg_swim_inited : 1, cg_auto_swim_disable : 1,
+	    /** whether it is a client or server */
+	    cg_server              : 1,
+	    /** whether metrics are used */
+	    cg_use_sensors         : 1,
+	    /** whether we are on a primary provider */
+	    cg_provider_is_primary : 1;
 
 	ATOMIC uint64_t		cg_rpcid; /* rpc id */
 

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -119,13 +119,17 @@ struct crt_gdata {
 	volatile unsigned int	cg_refcount;
 
 	/** flags to keep track of states */
-	unsigned int cg_inited : 1, cg_grp_inited : 1, cg_swim_inited : 1, cg_auto_swim_disable : 1,
-	    /** whether it is a client or server */
-	    cg_server              : 1,
+	unsigned int             cg_inited              : 1;
+	unsigned int             cg_grp_inited          : 1;
+	unsigned int             cg_swim_inited         : 1;
+	unsigned int             cg_auto_swim_disable   : 1;
+
+	/** whether it is a client or server */
+	unsigned int             cg_server              : 1,
 	    /** whether metrics are used */
-	    cg_use_sensors         : 1,
+	    unsigned int         cg_use_sensors         : 1,
 	    /** whether we are on a primary provider */
-	    cg_provider_is_primary : 1;
+	    unsigned int         cg_provider_is_primary : 1;
 
 	ATOMIC uint64_t		cg_rpcid; /* rpc id */
 

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -125,11 +125,11 @@ struct crt_gdata {
 	unsigned int             cg_auto_swim_disable   : 1;
 
 	/** whether it is a client or server */
-	unsigned int             cg_server              : 1,
-	    /** whether metrics are used */
-	    unsigned int         cg_use_sensors         : 1,
-	    /** whether we are on a primary provider */
-	    unsigned int         cg_provider_is_primary : 1;
+	unsigned int             cg_server              : 1;
+	/** whether metrics are used */
+	unsigned int             cg_use_sensors         : 1;
+	/** whether we are on a primary provider */
+	unsigned int             cg_provider_is_primary : 1;
 
 	ATOMIC uint64_t		cg_rpcid; /* rpc id */
 


### PR DESCRIPTION
- Reduce burst timeout error prints when multiple rpcs fail at the same time
- Replace error prints with info during rpc state processing, as error is already logged above
- Few cleanups, added crt_gdata_dump() at the end of init.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
