### PR TITLE
DAOS-16306 common: Fix Use-After-Free issue in LRU Cache

### DIFF
--- a/src/common/lru.c
+++ b/src/common/lru.c
@@ -36,7 +36,7 @@ lru_hop_rec_decref(struct d_hash_table *htable, d_list_t *link)
 
 	D_ASSERT(llink->ll_ref > 0);
 	llink->ll_ref--;
-	if (llink->ll_evicting && llink->ll_ref == 2 && llink->ll_ops->lop_wakeup)
+	if (llink->ll_ref == 1 && llink->ll_ops->lop_wakeup)
 		llink->ll_ops->lop_wakeup(llink);
 
 	/* Delete from hash only if no more references */
@@ -216,7 +216,7 @@ daos_lru_ref_hold(struct daos_lru_cache *lcache, void *key,
 		llink = link2llink(link);
 		D_ASSERT(llink->ll_evicted == 0);
 		if (llink->ll_evicting) {
-			daos_lru_ref_release(lcache, llink);
+			lru_hop_rec_decref(&lcache->dlc_htable, &llink->ll_link);
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 		}
 		/* remove busy item from LRU */
@@ -258,15 +258,15 @@ lru_ref_release_internal(struct daos_lru_cache *lcache, struct daos_llink *llink
 	D_ASSERT(lcache != NULL && llink != NULL && llink->ll_ref > 1);
 	D_ASSERT(d_list_empty(&llink->ll_qlink));
 
-	if (wait && llink->ll_ref > 2) {
+	lru_hop_rec_decref(&lcache->dlc_htable, &llink->ll_link);
+
+	if (wait && llink->ll_ref > 1) {
 		D_ASSERT(llink->ll_evicting == 0);
 		llink->ll_evicting = 1;
 		lcache->dlc_ops->lop_wait(llink);
 		llink->ll_evicting = 0;
 		llink->ll_evicted = 1;
 	}
-
-	lru_hop_rec_decref(&lcache->dlc_htable, &llink->ll_link);
 
 	if (llink->ll_ref == 1) { /* the last refcount */
 		if (lcache->dlc_csize == 0)

--- a/src/common/lru.c
+++ b/src/common/lru.c
@@ -220,7 +220,7 @@ daos_lru_ref_hold(struct daos_lru_cache *lcache, void *key,
 			 * Avoid calling `lru_hop_rec_decref()` at this point
 			 * to prevent `wakeup()` from being invoked twice.
 			 */
-			D_ASSERT(llink->ll_ref > 0);
+			D_ASSERT(llink->ll_ref > 1);
 			llink->ll_ref--;
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 		}

--- a/src/common/lru.c
+++ b/src/common/lru.c
@@ -216,7 +216,12 @@ daos_lru_ref_hold(struct daos_lru_cache *lcache, void *key,
 		llink = link2llink(link);
 		D_ASSERT(llink->ll_evicted == 0);
 		if (llink->ll_evicting) {
-			lru_hop_rec_decref(&lcache->dlc_htable, &llink->ll_link);
+			/**
+			 * Avoid calling `lru_hop_rec_decref()` at this point
+			 * to prevent `wakeup()` from being invoked twice.
+			 */
+			D_ASSERT(llink->ll_ref > 0);
+			llink->ll_ref--;
 			D_GOTO(out, rc = -DER_SHUTDOWN);
 		}
 		/* remove busy item from LRU */


### PR DESCRIPTION
This fix addresses a use-after-free issue in the LRU cache that can occur
in the following scenario:

Considering following case:
ULT1---------------------- ULT2-----------------ULT3
daos_lru_ref_wait_evict()
--cont_child_waitq()`
----wait ref to be 1
------yeild()
---------------------------daos_lru_release()
-----------------------------ref become 1
-----------------------------wakeup()
-------------------------------------------------daos_lru_hold().
---------------------------------------------------drop ref and become 1.
---------------------------------------------------free memory
---->access freed memory

To resolve this issue, only drop ref if daos_lru_hold failed internally to avoid
wakeup() is called twice as well.

Required-githooks: true
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
