### PR TITLE
DAOS-16354 cart: Don't retry URI_LOOKUPs for PROTO_QUERY rpc

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -968,10 +968,8 @@ retry:
 		/* PROTO_QUERY will be retried by the caller, no need to retry URI lookups */
 		if (chained_rpc_priv->crp_pub.cr_opc != CRT_OPC_PROTO_QUERY) {
 			if (chained_rpc_priv->crp_ul_retry++ < MAX_URI_LOOKUP_RETRIES) {
-				rc = crt_issue_uri_lookup_retry(lookup_rpc->cr_ctx,
-								grp_priv,
-								ul_in->ul_rank,
-								ul_in->ul_tag,
+				rc = crt_issue_uri_lookup_retry(lookup_rpc->cr_ctx, grp_priv,
+								ul_in->ul_rank, ul_in->ul_tag,
 								chained_rpc_priv);
 				D_GOTO(out, rc);
 			} else {

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -977,7 +977,7 @@ retry:
 					chained_rpc_priv->crp_ul_retry);
 			}
 		} else {
-			DL_INFO(rc, "URI_LOOKUP for (%d:%d) failed during PROTO_QUERY\n",
+			DL_INFO(rc, "URI_LOOKUP for (%d:%d) failed during PROTO_QUERY",
 				ul_in->ul_rank, ul_in->ul_tag);
 		}
 	}

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -965,16 +965,22 @@ uri_lookup_cb(const struct crt_cb_info *cb_info)
 retry:
 
 	if (rc != 0) {
-		if (chained_rpc_priv->crp_ul_retry++ < MAX_URI_LOOKUP_RETRIES) {
-			rc = crt_issue_uri_lookup_retry(lookup_rpc->cr_ctx,
-							grp_priv,
-							ul_in->ul_rank,
-							ul_in->ul_tag,
-							chained_rpc_priv);
-			D_GOTO(out, rc);
+		/* PROTO_QUERY will be retried by the caller, no need to retry URI lookups */
+		if (chained_rpc_priv->crp_pub.cr_opc != CRT_OPC_PROTO_QUERY) {
+			if (chained_rpc_priv->crp_ul_retry++ < MAX_URI_LOOKUP_RETRIES) {
+				rc = crt_issue_uri_lookup_retry(lookup_rpc->cr_ctx,
+								grp_priv,
+								ul_in->ul_rank,
+								ul_in->ul_tag,
+								chained_rpc_priv);
+				D_GOTO(out, rc);
+			} else {
+				D_ERROR("URI lookups exceeded %d retries\n",
+					chained_rpc_priv->crp_ul_retry);
+			}
 		} else {
-			D_ERROR("URI lookups exceeded %d retries\n",
-				chained_rpc_priv->crp_ul_retry);
+			DL_INFO(rc, "URI_LOOKUP for (%d:%d) failed during PROTO_QUERY\n",
+				ul_in->ul_rank, ul_in->ul_tag);
 		}
 	}
 


### PR DESCRIPTION
- If a URI_LOOKUP fails for a target of PROTO_QUERY rpc then avoid performing lookup retries as the caller will retry PROTO_QUERY to a different target on failure anyway.

This should avoid needless retries and errors when an excluded rank is picked as a target of PROTO_QUERY and URI_LOOKUP of it fails (due to it being excluded).

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
