### PR TITLE
DAOS-16386 utils: Add DDB Feature and RM_POOL Support

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -20,6 +20,7 @@
 #include <spdk/blob_bdev.h>
 #include <spdk/blob.h>
 #include <spdk/rpc.h>
+#include <spdk/env_dpdk.h>
 #include "bio_internal.h"
 #include <daos_srv/smd.h>
 
@@ -175,7 +176,9 @@ bio_spdk_env_init(void)
 	if (geteuid() != 0) {
 		opts.iova_mode = "va"; // workaround for spdk issue #2683 when running as non-root
 	}
-	rc = spdk_env_init(&opts);
+
+	/* Don't pass opt for reinitialization, otherwise it will fail */
+	rc = spdk_env_init(spdk_env_dpdk_external_init() ? &opts : NULL);
 	if (rc != 0) {
 		rc = -DER_INVAL; /* spdk_env_init() returns -1 */
 		D_ERROR("Failed to initialize SPDK env, "DF_RC"\n", DP_RC(rc));

--- a/src/control/cmd/ddb/command_completers.go
+++ b/src/control/cmd/ddb/command_completers.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -16,7 +16,7 @@ const (
 	defMntPrefix = "/mnt"
 )
 
-func listDir(match string) (result []string) {
+func listDirVos(match string) (result []string) {
 	if strings.HasSuffix(match, "vos-") {
 		match = filepath.Dir(match)
 	}
@@ -35,7 +35,60 @@ func listDir(match string) (result []string) {
 
 func openCompleter(prefix string, args []string) []string {
 	suggestions := []string{"-h", "-w", "--write_mode"}
-	suggestions = append(suggestions, listDir(defMntPrefix)...)
+	suggestions = append(suggestions, listDirVos(defMntPrefix)...)
+
+	if len(prefix) > 0 {
+		var newSuggestions []string
+		for _, s := range suggestions {
+			if strings.HasPrefix(s, prefix) {
+				newSuggestions = append(newSuggestions, strings.Trim(s, prefix))
+			}
+		}
+		suggestions = newSuggestions
+
+	}
+
+	return suggestions
+
+}
+
+func featureCompleter(prefix string, args []string) []string {
+	suggestions := []string{"-h", "-e", "--enable", "-d", "--disable", "-s", "--show"}
+	suggestions = append(suggestions, listDirVos(defMntPrefix)...)
+
+	if len(prefix) > 0 {
+		var newSuggestions []string
+		for _, s := range suggestions {
+			if strings.HasPrefix(s, prefix) {
+				newSuggestions = append(newSuggestions, strings.Trim(s, prefix))
+			}
+		}
+		suggestions = newSuggestions
+
+	}
+
+	return suggestions
+
+}
+
+func listDirPool(match string) (result []string) {
+	if strings.HasSuffix(match, "vos-") {
+		match = filepath.Dir(match)
+	}
+	filepath.Walk(match, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			/* ignore error */
+			return nil
+		}
+		result = append(result, path)
+		return nil
+	})
+	return
+}
+
+func rmPoolCompleter(prefix string, args []string) []string {
+	suggestions := []string{"-h"}
+	suggestions = append(suggestions, listDirPool(defMntPrefix)...)
 
 	if len(prefix) > 0 {
 		var newSuggestions []string

--- a/src/control/cmd/ddb/commands_wrapper.go
+++ b/src/control/cmd/ddb/commands_wrapper.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022-2023 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -222,4 +222,37 @@ func ddbDtxActAbort(ctx *DdbContext, path string, dtx_id string) error {
 	defer freeString(options.dtx_id)
 	/* Run the c code command */
 	return daosError(C.ddb_run_dtx_act_abort(&ctx.ctx, &options))
+}
+
+func ddbFeature(ctx *DdbContext, path string, enable string, disable string, show bool) error {
+	/* Set up the options */
+	options := C.struct_feature_options{}
+	options.path = C.CString(path)
+	defer freeString(options.path)
+	if enable != "" {
+		err := daosError(C.ddb_feature_string2flags(&ctx.ctx, C.CString(enable),
+			&options.set_compat_flags, &options.set_incompat_flags))
+		if err != nil {
+			return err
+		}
+	}
+	if disable != "" {
+		err := daosError(C.ddb_feature_string2flags(&ctx.ctx, C.CString(disable),
+			&options.clear_compat_flags, &options.clear_incompat_flags))
+		if err != nil {
+			return err
+		}
+	}
+	options.show_features = C.bool(show)
+	/* Run the c code command */
+	return daosError(C.ddb_run_feature(&ctx.ctx, &options))
+}
+
+func ddbRmPool(ctx *DdbContext, path string) error {
+	/* Set up the options */
+	options := C.struct_rm_pool_options{}
+	options.path = C.CString(path)
+	defer freeString(options.path)
+	/* Run the c code command */
+	return daosError(C.ddb_run_rm_pool(&ctx.ctx, &options))
 }

--- a/src/control/cmd/ddb/ddb_commands.go
+++ b/src/control/cmd/ddb/ddb_commands.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022-2023 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -296,5 +296,40 @@ the path must include the extent, otherwise, it must not.`,
 			return ddbDtxActAbort(ctx, c.Args.String("path"), c.Args.String("dtx_id"))
 		},
 		Completer: nil,
+	})
+	// Command: feature
+	app.AddCommand(&grumble.Command{
+		Name:      "feature",
+		Aliases:   nil,
+		Help:      "Manage vos pool features",
+		LongHelp:  "",
+		HelpGroup: "vos",
+		Flags: func(f *grumble.Flags) {
+			f.String("e", "enable", "", "Enable vos pool features")
+			f.String("d", "disable", "", "Disable vos pool features")
+			f.Bool("s", "show", false, "Show current features")
+		},
+		Args: func(a *grumble.Args) {
+			a.String("path", "Optional, Path to the vos file", grumble.Default(""))
+		},
+		Run: func(c *grumble.Context) error {
+			return ddbFeature(ctx, c.Args.String("path"), c.Flags.String("enable"), c.Flags.String("disable"), c.Flags.Bool("show"))
+		},
+		Completer: featureCompleter,
+	})
+	// Command: rm_pool
+	app.AddCommand(&grumble.Command{
+		Name:      "rm_pool",
+		Aliases:   nil,
+		Help:      "Remove a vos pool.",
+		LongHelp:  "",
+		HelpGroup: "vos",
+		Args: func(a *grumble.Args) {
+			a.String("path", "Optional, Path to the vos file", grumble.Default(""))
+		},
+		Run: func(c *grumble.Context) error {
+			return ddbRmPool(ctx, c.Args.String("path"))
+		},
+		Completer: rmPoolCompleter,
 	})
 }

--- a/src/control/cmd/ddb/main.go
+++ b/src/control/cmd/ddb/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022-2023 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -23,6 +23,7 @@ import (
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/logging"
 )
+import "C"
 
 func exitWithError(log logging.Logger, err error) {
 	cmdName := path.Base(os.Args[0])
@@ -51,7 +52,7 @@ func (pathStr vosPathStr) Complete(match string) (comps []flags.Completion) {
 	if match == "" || match == "/" {
 		match = defMntPrefix
 	}
-	for _, comp := range listDir(match) {
+	for _, comp := range listDirVos(match) {
 		comps = append(comps, flags.Completion{Item: comp})
 	}
 	sort.Slice(comps, func(i, j int) bool { return comps[i].Item < comps[j].Item })
@@ -176,9 +177,11 @@ Example Paths:
 	app := createGrumbleApp(ctx)
 
 	if opts.Args.VosPath != "" {
-		log.Debugf("Connect to path: %s\n", opts.Args.VosPath)
-		if err := ddbOpen(ctx, string(opts.Args.VosPath), opts.WriteMode); err != nil {
-			return errors.Wrapf(err, "Error opening path: %s", opts.Args.VosPath)
+		if !strings.HasPrefix(string(opts.Args.RunCmd), "feature") && !strings.HasPrefix(string(opts.Args.RunCmd), "rm_pool") {
+			log.Debugf("Connect to path: %s\n", opts.Args.VosPath)
+			if err := ddbOpen(ctx, string(opts.Args.VosPath), opts.WriteMode); err != nil {
+				return errors.Wrapf(err, "Error opening path: %s", opts.Args.VosPath)
+			}
 		}
 	}
 
@@ -186,12 +189,15 @@ Example Paths:
 		return errors.New("Cannot use both command file and a command string")
 	}
 
+	if opts.Args.VosPath != "" {
+		ctx.ctx.dc_pool_path = C.CString(string(opts.Args.VosPath))
+	}
 	if opts.Args.RunCmd != "" || opts.CmdFile != "" {
 		// Non-interactive mode
 		if opts.Args.RunCmd != "" {
 			err := runCmdStr(app, string(opts.Args.RunCmd), opts.Args.RunCmdArgs...)
 			if err != nil {
-				log.Errorf("Error running command %s\n", string(opts.Args.RunCmd))
+				log.Errorf("Error running command %q %s\n", string(opts.Args.RunCmd), err)
 			}
 		} else {
 			err := runFileCmds(log, app, opts.CmdFile)

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -20,6 +20,38 @@
 #include <daos_srv/dtx_srv.h>
 #include <daos_srv/vos_types.h>
 
+#define VOS_POOL_COMPAT_FLAG_IMMUTABLE (1ULL << 0)
+#define VOS_POOL_COMPAT_FLAG_SKIP_LOAD (1ULL << 1)
+
+#define VOS_POOL_COMPAT_FLAG_SUPP      (VOS_POOL_COMPAT_FLAG_IMMUTABLE | VOS_POOL_COMPAT_FLAG_SKIP_LOAD)
+
+#define VOS_POOL_INCOMPAT_FLAG_SUPP    0
+
+#define VOS_MAX_FLAG_NAME_LEN          32
+
+static inline uint64_t
+vos_pool_name2flag(const char *name, bool *compat_feature)
+{
+	*compat_feature = false;
+
+	if (strncmp(name, "immutable", VOS_MAX_FLAG_NAME_LEN) == 0) {
+		*compat_feature = true;
+		return VOS_POOL_COMPAT_FLAG_IMMUTABLE;
+	}
+	if (strncmp(name, "skip_load", VOS_MAX_FLAG_NAME_LEN) == 0) {
+		*compat_feature = true;
+		return VOS_POOL_COMPAT_FLAG_SKIP_LOAD;
+	}
+
+	return 0;
+}
+
+bool
+vos_pool_feature_skip_load(daos_handle_t poh);
+
+bool
+vos_pool_feature_immutable(daos_handle_t poh);
+
 /** Initialize the vos reserve/cancel related fields in dtx handle
  *
  * \param dth	[IN]	The dtx handle

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -78,19 +78,21 @@ D_CASSERT(sizeof(struct dtx_entry) ==
 /** Pool open flags (for vos_pool_create and vos_pool_open) */
 enum vos_pool_open_flags {
 	/** Pool is small (for sys space reservation); implies VOS_POF_EXCL */
-	VOS_POF_SMALL	= (1 << 0),
+	VOS_POF_SMALL = (1 << 0),
 	/** Exclusive (-DER_BUSY if already opened) */
-	VOS_POF_EXCL	= (1 << 1),
+	VOS_POF_EXCL = (1 << 1),
 	/** Ignore the pool uuid passed into vos_pool_open */
 	VOS_POF_SKIP_UUID_CHECK = (1 << 2),
 	/** Caller does VEA flush periodically */
-	VOS_POF_EXTERNAL_FLUSH	= (1 << 3),
+	VOS_POF_EXTERNAL_FLUSH = (1 << 3),
 	/** RDB pool */
-	VOS_POF_RDB	= (1 << 4),
+	VOS_POF_RDB = (1 << 4),
 	/** SYS DB pool */
-	VOS_POF_SYSDB	= (1 << 5),
+	VOS_POF_SYSDB = (1 << 5),
 	/** Open the pool for daos check query, that will bypass EXEL flags. */
 	VOS_POF_FOR_CHECK_QUERY = (1 << 6),
+	/** Open the pool for feature fetch/update, that will skip VEA load */
+	VOS_POF_FOR_FEATURE_FLAG = (1 << 7),
 };
 
 enum vos_oi_attr {

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -491,6 +491,13 @@ pool_child_start(struct ds_pool_child *child, bool recreate)
 		goto done;
 	}
 
+	if (!ds_pool_skip_for_check(child->spc_pool) &&
+	    vos_pool_feature_skip_load(child->spc_hdl)) {
+		D_INFO(DF_UUID ": skipped to start\n", DP_UUID(child->spc_uuid));
+		rc = -DER_SHUTDOWN;
+		goto out_close;
+	}
+
 	if (!ds_pool_skip_for_check(child->spc_pool)) {
 		rc = start_gc_ult(child);
 		if (rc != 0)

--- a/src/utils/ddb/ddb.h
+++ b/src/utils/ddb/ddb.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -86,6 +86,7 @@ struct ddb_ctx {
 	daos_handle_t		 dc_poh;
 	bool			 dc_should_quit;
 	bool			 dc_write_mode;
+	const char              *dc_pool_path;
 };
 
 void ddb_ctx_init(struct ddb_ctx *ctx);
@@ -93,27 +94,29 @@ int ddb_init(void);
 void ddb_fini(void);
 
 enum ddb_cmd {
-	DDB_CMD_UNKNOWN = 0,
-	DDB_CMD_HELP = 1,
-	DDB_CMD_QUIT = 2,
-	DDB_CMD_LS = 3,
-	DDB_CMD_OPEN = 4,
-	DDB_CMD_VERSION = 5,
-	DDB_CMD_CLOSE = 6,
+	DDB_CMD_UNKNOWN         = 0,
+	DDB_CMD_HELP            = 1,
+	DDB_CMD_QUIT            = 2,
+	DDB_CMD_LS              = 3,
+	DDB_CMD_OPEN            = 4,
+	DDB_CMD_VERSION         = 5,
+	DDB_CMD_CLOSE           = 6,
 	DDB_CMD_SUPERBLOCK_DUMP = 7,
-	DDB_CMD_VALUE_DUMP = 8,
-	DDB_CMD_RM = 9,
-	DDB_CMD_VALUE_LOAD = 10,
-	DDB_CMD_ILOG_DUMP = 11,
-	DDB_CMD_ILOG_COMMIT = 12,
-	DDB_CMD_ILOG_CLEAR = 13,
-	DDB_CMD_DTX_DUMP = 14,
-	DDB_CMD_DTX_CMT_CLEAR = 15,
-	DDB_CMD_SMD_SYNC = 16,
-	DDB_CMD_VEA_DUMP = 17,
-	DDB_CMD_VEA_UPDATE = 18,
-	DDB_CMD_DTX_ACT_COMMIT = 19,
-	DDB_CMD_DTX_ACT_ABORT = 20,
+	DDB_CMD_VALUE_DUMP      = 8,
+	DDB_CMD_RM              = 9,
+	DDB_CMD_VALUE_LOAD      = 10,
+	DDB_CMD_ILOG_DUMP       = 11,
+	DDB_CMD_ILOG_COMMIT     = 12,
+	DDB_CMD_ILOG_CLEAR      = 13,
+	DDB_CMD_DTX_DUMP        = 14,
+	DDB_CMD_DTX_CMT_CLEAR   = 15,
+	DDB_CMD_SMD_SYNC        = 16,
+	DDB_CMD_VEA_DUMP        = 17,
+	DDB_CMD_VEA_UPDATE      = 18,
+	DDB_CMD_DTX_ACT_COMMIT  = 19,
+	DDB_CMD_DTX_ACT_ABORT   = 20,
+	DDB_CMD_FEATURE         = 21,
+	DDB_CMD_RM_POOL         = 22,
 };
 
 /* option and argument structures for commands that need them */
@@ -184,6 +187,19 @@ struct dtx_act_abort_options {
 	char *dtx_id;
 };
 
+struct feature_options {
+	uint64_t    set_compat_flags;
+	uint64_t    set_incompat_flags;
+	uint64_t    clear_compat_flags;
+	uint64_t    clear_incompat_flags;
+	bool        show_features;
+	const char *path;
+};
+
+struct rm_pool_options {
+	const char *path;
+};
+
 struct ddb_cmd_info {
 	enum ddb_cmd dci_cmd;
 	union {
@@ -201,11 +217,16 @@ struct ddb_cmd_info {
 		struct vea_update_options dci_vea_update;
 		struct dtx_act_commit_options dci_dtx_act_commit;
 		struct dtx_act_abort_options dci_dtx_act_abort;
+		struct feature_options        dci_feature;
+		struct rm_pool_options        dci_rm_pool;
 	} dci_cmd_option;
 };
 
 int ddb_parse_cmd_args(struct ddb_ctx *ctx, uint32_t argc, char **argv, struct ddb_cmd_info *info);
-int ddb_run_cmd(struct ddb_ctx *ctx, const char *cmd_str, bool write_mode);
+int
+ddb_parse_cmd_str(struct ddb_ctx *ctx, const char *cmd_str, bool *open);
+int
+     ddb_run_cmd(struct ddb_ctx *ctx, const char *cmd_str);
 /* Run commands ... */
 int ddb_run_help(struct ddb_ctx *ctx);
 int ddb_run_quit(struct ddb_ctx *ctx);
@@ -228,7 +249,13 @@ int ddb_run_vea_dump(struct ddb_ctx *ctx);
 int ddb_run_vea_update(struct ddb_ctx *ctx, struct vea_update_options *opt);
 int ddb_run_dtx_act_commit(struct ddb_ctx *ctx, struct dtx_act_commit_options *opt);
 int ddb_run_dtx_act_abort(struct ddb_ctx *ctx, struct dtx_act_abort_options *opt);
-
+int
+ddb_run_feature(struct ddb_ctx *ctx, struct feature_options *opt);
+int
+ddb_feature_string2flags(struct ddb_ctx *ctx, const char *string, uint64_t *compat_flags,
+			 uint64_t *incompat_flags);
+int
+     ddb_run_rm_pool(struct ddb_ctx *ctx, struct rm_pool_options *opt);
 
 void ddb_program_help(struct ddb_ctx *ctx);
 void ddb_commands_help(struct ddb_ctx *ctx);

--- a/src/utils/ddb/ddb_commands.c
+++ b/src/utils/ddb/ddb_commands.c
@@ -1,10 +1,11 @@
 /**
- * (C) Copyright 2022-2023 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
 
 #include <daos/common.h>
+#include <daos_srv/vos.h>
 #include "ddb_common.h"
 #include "ddb_parse.h"
 #include "ddb.h"
@@ -56,7 +57,7 @@ ddb_run_open(struct ddb_ctx *ctx, struct open_options *opt)
 		return -DER_EXIST;
 	}
 	ctx->dc_write_mode = opt->write_mode;
-	return dv_pool_open(opt->path, &ctx->dc_poh);
+	return dv_pool_open(opt->path, &ctx->dc_poh, 0);
 }
 
 int
@@ -989,4 +990,80 @@ int ddb_run_dtx_act_abort(struct ddb_ctx *ctx, struct dtx_act_abort_options *opt
 
 	dtx_modify_fini(&args);
 	return rc;
+}
+
+int
+ddb_run_feature(struct ddb_ctx *ctx, struct feature_options *opt)
+{
+	int      rc;
+	uint64_t new_compat_flags;
+	uint64_t new_incompat_flags;
+	bool     close = false;
+
+	if (opt->set_compat_flags || opt->set_incompat_flags || opt->clear_compat_flags ||
+	    opt->clear_incompat_flags)
+		ctx->dc_write_mode = true;
+	else
+		ctx->dc_write_mode = false;
+
+	if (!ctx->dc_write_mode && !opt->show_features)
+		return -DER_INVAL;
+
+	if (ddb_pool_is_open(ctx))
+		goto skip;
+
+	if (!opt->path || (opt->path && strnlen(opt->path, PATH_MAX) == 0))
+		opt->path = ctx->dc_pool_path;
+
+	rc = dv_pool_open(opt->path, &ctx->dc_poh, VOS_POF_FOR_FEATURE_FLAG);
+	if (rc)
+		return rc;
+	close = true;
+
+skip:
+	rc = dv_pool_get_flags(ctx->dc_poh, &new_compat_flags, &new_incompat_flags);
+	if (rc) {
+		ddb_error(ctx, "Error with pool superblock");
+		goto out;
+	}
+
+	if (ctx->dc_write_mode) {
+		if (opt->set_compat_flags || opt->clear_compat_flags) {
+			new_compat_flags |= (opt->set_compat_flags & VOS_POOL_COMPAT_FLAG_SUPP);
+			new_compat_flags &= ~(opt->clear_compat_flags & VOS_POOL_COMPAT_FLAG_SUPP);
+		}
+		if (opt->set_incompat_flags || opt->clear_incompat_flags) {
+			new_incompat_flags |=
+			    (opt->set_incompat_flags & VOS_POOL_INCOMPAT_FLAG_SUPP);
+			new_incompat_flags &=
+			    ~(opt->clear_incompat_flags & VOS_POOL_INCOMPAT_FLAG_SUPP);
+		}
+		rc = dv_pool_update_flags(ctx->dc_poh, new_compat_flags, new_incompat_flags);
+		if (rc) {
+			ddb_printf(ctx, "Failed to update flags: %d\n", rc);
+			goto out;
+		}
+	}
+	if (opt->show_features) {
+		ddb_printf(ctx, "Compat Flags: %lu\n", new_compat_flags);
+		ddb_printf(ctx, "Incompat Flags: %lu\n", new_incompat_flags);
+	}
+out:
+	if (close)
+		rc = dv_pool_close(ctx->dc_poh);
+	ctx->dc_poh        = DAOS_HDL_INVAL;
+	ctx->dc_write_mode = false;
+
+	return rc;
+}
+
+int
+ddb_run_rm_pool(struct ddb_ctx *ctx, struct rm_pool_options *opt)
+{
+	if (ddb_pool_is_open(ctx)) {
+		ddb_error(ctx, "Must close pool before can open another\n");
+		return -DER_EXIST;
+	}
+
+	return dv_pool_destroy(opt->path);
 }

--- a/src/utils/ddb/ddb_main.c
+++ b/src/utils/ddb/ddb_main.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -180,10 +180,35 @@ process_line_cb(void *cb_args, char *line, uint32_t line_len)
 	/* ignore empty lines */
 	if (all_whitespace(line, line_len))
 		return 0;
-	return ddb_run_cmd(ctx, line, ctx->dc_write_mode);
+	return ddb_run_cmd(ctx, line);
 }
 
 #define str_has_value(str) ((str) != NULL && strlen(str) > 0)
+
+static int
+open_if_needed(struct ddb_ctx *ctx, struct program_args *pa, bool *open)
+{
+	int rc = 0;
+
+	if (!str_has_value(pa->pa_pool_path)) {
+		*open = false;
+		goto out;
+	}
+	ctx->dc_pool_path = pa->pa_pool_path;
+
+	if (str_has_value(pa->pa_r_cmd_run)) {
+		rc = ddb_parse_cmd_str(ctx, pa->pa_r_cmd_run, open);
+		if (rc)
+			return rc;
+	}
+
+	if (str_has_value(pa->pa_cmd_file))
+		*open = true;
+
+out:
+	*open = true;
+	return rc;
+}
 
 int
 ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
@@ -193,6 +218,7 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 	char			*input_buf;
 	int			 rc;
 	struct ddb_ctx		 ctx = {0};
+	bool                     open = true;
 
 	D_ASSERT(io_ft);
 	ctx.dc_io_ft = *io_ft;
@@ -217,14 +243,17 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 		D_GOTO(done, rc = -DER_INVAL);
 	}
 
-	if (str_has_value(pa.pa_pool_path)) {
-		rc = dv_pool_open(pa.pa_pool_path, &ctx.dc_poh);
+	rc = open_if_needed(&ctx, &pa, &open);
+	if (!SUCCESS(rc))
+		D_GOTO(done, rc);
+	if (open) {
+		rc = dv_pool_open(pa.pa_pool_path, &ctx.dc_poh, 0);
 		if (!SUCCESS(rc))
 			D_GOTO(done, rc);
 	}
 
 	if (str_has_value(pa.pa_r_cmd_run)) {
-		rc = ddb_run_cmd(&ctx, pa.pa_r_cmd_run, pa.pa_write_mode);
+		rc = ddb_run_cmd(&ctx, pa.pa_r_cmd_run);
 		if (!SUCCESS(rc))
 			D_ERROR("Command '%s' failed: "DF_RC"\n", input_buf, DP_RC(rc));
 		D_GOTO(done, rc);
@@ -248,7 +277,7 @@ ddb_main(struct ddb_io_ft *io_ft, int argc, char *argv[])
 		if (input_buf[strlen(input_buf) - 1] == '\n')
 			input_buf[strlen(input_buf) - 1] = '\0';
 
-		rc = ddb_run_cmd(&ctx, input_buf, pa.pa_write_mode);
+		rc = ddb_run_cmd(&ctx, input_buf);
 		if (!SUCCESS(rc)) {
 			D_ERROR("Command '%s' failed: "DF_RC"\n", input_buf, DP_RC(rc));
 			ddb_printf(&ctx, "Command '%s' failed: "DF_RC"\n", input_buf, DP_RC(rc));

--- a/src/utils/ddb/ddb_printer.c
+++ b/src/utils/ddb/ddb_printer.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -189,6 +189,8 @@ ddb_print_superblock(struct ddb_ctx *ctx, struct ddb_superblock *sb)
 	ddb_printf(ctx, "Pool UUID: "DF_UUIDF"\n", DP_UUID(sb->dsb_id));
 	ddb_printf(ctx, "Format Version: %d\n", sb->dsb_durable_format_version);
 	ddb_printf(ctx, "Containers: %lu\n", sb->dsb_cont_nr);
+	ddb_printf(ctx, "Compat Flags: %lu\n", sb->dsb_compat_flags);
+	ddb_printf(ctx, "Incompat Flags: %lu\n", sb->dsb_incompat_flags);
 	print_bytes(ctx, "SCM Size", sb->dsb_scm_sz);
 	print_bytes(ctx, "NVME Size", sb->dsb_nvme_sz);
 	print_bytes(ctx, "Block Size", sb->dsb_blk_sz);

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -18,10 +18,9 @@
 						anchors, cb, NULL, args, NULL)
 
 int
-dv_pool_open(char *path, daos_handle_t *poh)
+dv_pool_open(const char *path, daos_handle_t *poh, uint32_t flags)
 {
-	struct vos_file_parts	path_parts = {0};
-	uint32_t		flags = 0; /* Will need to be a flag to ignore uuid check */
+	struct vos_file_parts   path_parts = {0};
 	int			rc;
 
 	/*
@@ -46,6 +45,35 @@ dv_pool_open(char *path, daos_handle_t *poh)
 		D_ERROR("Failed to open pool: "DF_RC"\n", DP_RC(rc));
 		vos_self_fini();
 	}
+
+	return rc;
+}
+
+int
+dv_pool_destroy(const char *path)
+{
+	struct vos_file_parts path_parts = {0};
+	int                   rc, flags = 0;
+
+	rc = vos_path_parse(path, &path_parts);
+	if (!SUCCESS(rc))
+		return rc;
+
+	rc = vos_self_init(path_parts.vf_db_path, true, path_parts.vf_target_idx);
+	if (!SUCCESS(rc)) {
+		D_ERROR("Failed to initialize VOS with path '%s': " DF_RC "\n",
+			path_parts.vf_db_path, DP_RC(rc));
+		return rc;
+	}
+
+	if (strncmp(path_parts.vf_vos_file, "rdb", 3) == 0)
+		flags |= VOS_POF_RDB;
+
+	rc = vos_pool_destroy_ex(path, path_parts.vf_pool_uuid, flags);
+	if (!SUCCESS(rc))
+		D_ERROR("Failed to destroy pool: " DF_RC "\n", DP_RC(rc));
+
+	vos_self_fini();
 
 	return rc;
 }
@@ -896,7 +924,7 @@ dv_iterate(daos_handle_t poh, struct dv_tree_path *path, bool recursive,
 int
 dv_superblock(daos_handle_t poh, dv_dump_superblock_cb cb, void *cb_args)
 {
-	struct ddb_superblock	 sb = {0};
+	struct ddb_superblock    sb = {0};
 	struct vos_pool		*pool;
 	struct vos_pool_df	*pool_df;
 
@@ -921,7 +949,8 @@ dv_superblock(daos_handle_t poh, dv_dump_superblock_cb cb, void *cb_args)
 	sb.dsb_blk_sz = pool_df->pd_vea_df.vsd_blk_sz;
 	sb.dsb_hdr_blks = pool_df->pd_vea_df.vsd_hdr_blks;
 	sb.dsb_tot_blks = pool_df->pd_vea_df.vsd_tot_blks;
-
+	sb.dsb_compat_flags   = pool_df->pd_compat_flags;
+	sb.dsb_incompat_flags = pool_df->pd_incompat_flags;
 
 	cb(cb_args, &sb);
 
@@ -1850,4 +1879,71 @@ dv_vea_free_region(daos_handle_t poh, uint32_t offset, uint32_t blk_cnt)
 		D_ERROR("vea_free error: "DF_RC"\n", DP_RC(rc));
 
 	return rc;
+}
+
+int
+dv_pool_update_flags(daos_handle_t poh, uint64_t compat_flags, uint64_t incompat_flags)
+{
+	struct vos_pool    *pool;
+	struct vos_pool_df *pool_df;
+	int                 rc;
+
+	pool = vos_hdl2pool(poh);
+	if (pool == NULL)
+		return -DER_INVAL;
+
+	pool_df = pool->vp_pool_df;
+
+	rc = umem_tx_begin(&pool->vp_umm, NULL);
+	if (rc != 0)
+		return rc;
+
+	rc = umem_tx_add_ptr(&pool->vp_umm, &pool_df->pd_compat_flags,
+			     sizeof(pool_df->pd_compat_flags));
+	if (rc != 0)
+		goto end;
+
+	pool_df->pd_compat_flags = compat_flags;
+	rc                       = umem_tx_add_ptr(&pool->vp_umm, &pool_df->pd_incompat_flags,
+						   sizeof(pool_df->pd_incompat_flags));
+	if (rc != 0)
+		goto end;
+	pool_df->pd_incompat_flags = incompat_flags;
+
+end:
+	rc = umem_tx_end(&pool->vp_umm, rc);
+	return rc;
+}
+
+struct vos_pool_feature_flags {
+	uint64_t compat_flags;
+	uint64_t incompat_flags;
+};
+
+static int
+get_flags_cb(void *cb_arg, struct ddb_superblock *sb)
+{
+	struct vos_pool_feature_flags *pff = cb_arg;
+
+	pff->compat_flags   = sb->dsb_compat_flags;
+	pff->incompat_flags = sb->dsb_incompat_flags;
+
+	return 0;
+}
+int
+dv_pool_get_flags(daos_handle_t poh, uint64_t *compat_flags, uint64_t *incompat_flags)
+{
+	int                           rc;
+	struct vos_pool_feature_flags pff;
+
+	rc = dv_superblock(poh, get_flags_cb, &pff);
+	if (rc == -DER_DF_INVAL)
+		return rc;
+
+	if (compat_flags)
+		*compat_flags = pff.compat_flags;
+	if (incompat_flags)
+		*incompat_flags = pff.incompat_flags;
+
+	return 0;
 }

--- a/src/utils/ddb/ddb_vos.h
+++ b/src/utils/ddb/ddb_vos.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -48,8 +48,18 @@ struct ddb_array {
 };
 
 /* Open and close a pool for a ddb_ctx */
-int dv_pool_open(char *path, daos_handle_t *poh);
+int
+    dv_pool_open(const char *path, daos_handle_t *poh, uint32_t flags);
 int dv_pool_close(daos_handle_t poh);
+int
+dv_pool_destroy(const char *path);
+
+/* Update vos pool flags */
+int
+dv_pool_update_flags(daos_handle_t poh, uint64_t compat_flags, uint64_t incompat_flags);
+/* Get vos pool flags */
+int
+    dv_pool_get_flags(daos_handle_t poh, uint64_t *compat_flags, uint64_t *incompat_flags);
 
 /* Open and close a cont for a ddb_ctx */
 int dv_cont_open(daos_handle_t poh, uuid_t uuid, daos_handle_t *coh);
@@ -111,6 +121,8 @@ struct ddb_superblock {
 	uint64_t	dsb_cont_nr;
 	uint64_t	dsb_nvme_sz;
 	uint64_t	dsb_scm_sz;
+	uint64_t        dsb_compat_flags;
+	uint64_t        dsb_incompat_flags;
 	uint64_t	dsb_tot_blks; /* vea: Block device capacity */
 	uint32_t	dsb_durable_format_version;
 	uint32_t	dsb_blk_sz; /* vea: Block size, 4k bytes by default */

--- a/src/utils/ddb/tests/ddb_commands_tests.c
+++ b/src/utils/ddb/tests/ddb_commands_tests.c
@@ -362,6 +362,19 @@ dtx_abort_entry_tests(void **state)
 	assert_success(ddb_run_dtx_act_abort(&g_ctx, &opt));
 }
 
+static void
+feature_cmd_tests(void **state)
+{
+	struct dt_vos_pool_ctx *tctx;
+	struct feature_options  opt = {0};
+
+	tctx = *state;
+	assert_invalid(ddb_run_feature(&g_ctx, &opt));
+	opt.path          = tctx->dvt_pmem_file;
+	opt.show_features = true;
+	assert_success(ddb_run_feature(&g_ctx, &opt));
+}
+
 /*
  * --------------------------------------------------------------
  * End test functions
@@ -377,7 +390,7 @@ dcv_suit_setup(void **state)
 
 	/* test setup creates the pool, but doesn't open it ... leave it open for these tests */
 	tctx = *state;
-	assert_success(dv_pool_open(tctx->dvt_pmem_file, &tctx->dvt_poh));
+	assert_success(dv_pool_open(tctx->dvt_pmem_file, &tctx->dvt_poh, 0));
 
 	g_ctx.dc_poh = tctx->dvt_poh;
 
@@ -406,19 +419,20 @@ int
 ddb_commands_tests_run()
 {
 	const struct CMUnitTest tests[] = {
-		TEST(quit_cmd_tests),
-		TEST(ls_cmd_tests),
-		TEST(dump_value_cmd_tests),
-		TEST(dump_ilog_cmd_tests),
-		TEST(dump_superblock_cmd_tests),
-		TEST(dump_dtx_cmd_tests),
-		TEST(rm_cmd_tests),
-		TEST(load_cmd_tests),
-		TEST(rm_ilog_cmd_tests),
-		TEST(process_ilog_cmd_tests),
-		TEST(clear_cmt_dtx_cmd_tests),
-		TEST(dtx_commit_entry_tests),
-		TEST(dtx_abort_entry_tests),
+	    TEST(quit_cmd_tests),
+	    TEST(ls_cmd_tests),
+	    TEST(dump_value_cmd_tests),
+	    TEST(dump_ilog_cmd_tests),
+	    TEST(dump_superblock_cmd_tests),
+	    TEST(dump_dtx_cmd_tests),
+	    TEST(rm_cmd_tests),
+	    TEST(load_cmd_tests),
+	    TEST(rm_ilog_cmd_tests),
+	    TEST(process_ilog_cmd_tests),
+	    TEST(clear_cmt_dtx_cmd_tests),
+	    TEST(dtx_commit_entry_tests),
+	    TEST(dtx_abort_entry_tests),
+	    TEST(feature_cmd_tests),
 	};
 
 	return cmocka_run_group_tests_name("DDB commands tests", tests,

--- a/src/utils/ddb/tests/ddb_main_tests.c
+++ b/src/utils/ddb/tests/ddb_main_tests.c
@@ -241,7 +241,7 @@ ddb_main_suit_setup(void **state)
 
 	/* test setup creates the pool, but doesn't open it ... leave it open for these tests */
 	tctx = *state;
-	assert_success(dv_pool_open(tctx->dvt_pmem_file, &tctx->dvt_poh));
+	assert_success(dv_pool_open(tctx->dvt_pmem_file, &tctx->dvt_poh, 0));
 
 	return 0;
 }

--- a/src/utils/ddb/tests/ddb_parse_tests.c
+++ b/src/utils/ddb/tests/ddb_parse_tests.c
@@ -5,6 +5,7 @@
  */
 #include <daos/tests_lib.h>
 #include <gurt/debug.h>
+#include <daos_srv/vos.h>
 #include <ddb_common.h>
 #include <ddb_parse.h>
 #include "ddb_cmocka.h"
@@ -324,6 +325,29 @@ keys_are_parsed_correctly(void **state)
 	daos_iov_free(&key);
 }
 
+static void
+pool_flags_tests(void **state)
+{
+	struct ddb_ctx ctx = {.dc_io_ft.ddb_print_message = fake_print,
+			      .dc_io_ft.ddb_print_error   = fake_print};
+	uint64_t       compat_flags, incompat_flags;
+	uint64_t       expected_flags;
+	int            rc;
+
+	expected_flags = VOS_POOL_COMPAT_FLAG_IMMUTABLE | VOS_POOL_COMPAT_FLAG_SKIP_LOAD;
+	rc = ddb_feature_string2flags(&ctx, "immutable,skip_load", &compat_flags, &incompat_flags);
+	assert_success(rc);
+	assert(compat_flags == expected_flags);
+	expected_flags = 0;
+	if (incompat_flags != expected_flags) {
+		print_error("ERROR: %lu != %lu\n", incompat_flags, expected_flags);
+		assert_success(-DER_INVAL);
+	}
+
+	rc = ddb_feature_string2flags(&ctx, "immutablexxx", &compat_flags, &incompat_flags);
+	assert_rc_equal(-DER_INVAL, rc);
+}
+
 /*
  * -----------------------------------------------
  * Execute
@@ -334,11 +358,8 @@ int
 ddb_parse_tests_run()
 {
 	static const struct CMUnitTest tests[] = {
-		TEST(vos_file_parts_tests),
-		TEST(string_to_argv_tests),
-		TEST(parse_args_tests),
-		TEST(parse_dtx_id_tests),
-		TEST(keys_are_parsed_correctly),
+	    TEST(vos_file_parts_tests), TEST(string_to_argv_tests),      TEST(parse_args_tests),
+	    TEST(parse_dtx_id_tests),   TEST(keys_are_parsed_correctly), TEST(pool_flags_tests),
 	};
 	return cmocka_run_group_tests_name("DDB helper parsing function tests", tests,
 					   NULL, NULL);

--- a/src/utils/ddb/tests/ddb_vos_tests.c
+++ b/src/utils/ddb/tests/ddb_vos_tests.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2023 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -181,13 +181,13 @@ open_pool_test(void **state)
 	daos_handle_t		 poh;
 	struct dt_vos_pool_ctx	*tctx = *state;
 
-	assert_rc_equal(-DER_INVAL, dv_pool_open("/bad/path", &poh));
+	assert_rc_equal(-DER_INVAL, dv_pool_open("/bad/path", &poh, 0));
 
-	assert_success(dv_pool_open(tctx->dvt_pmem_file, &poh));
+	assert_success(dv_pool_open(tctx->dvt_pmem_file, &poh, 0));
 	assert_success(dv_pool_close(poh));
 
 	/* should be able to open again after closing */
-	assert_success(dv_pool_open(tctx->dvt_pmem_file, &poh));
+	assert_success(dv_pool_open(tctx->dvt_pmem_file, &poh, 0));
 	assert_success(dv_pool_close(poh));
 }
 
@@ -1077,7 +1077,7 @@ dv_test_setup(void **state)
 
 	active_entry_handler_called = 0;
 	committed_entry_handler_called = 0;
-	assert_success(dv_pool_open(tctx->dvt_pmem_file, &tctx->dvt_poh));
+	assert_success(dv_pool_open(tctx->dvt_pmem_file, &tctx->dvt_poh, 0));
 	return 0;
 }
 
@@ -1090,6 +1090,25 @@ dv_test_teardown(void **state)
 	return 0;
 }
 
+static void
+pool_flags_tests(void **state)
+{
+	daos_handle_t           poh;
+	struct dt_vos_pool_ctx *tctx = *state;
+	uint64_t                compat_flags;
+	uint64_t                incompat_flags;
+
+	assert_success(dv_pool_open(tctx->dvt_pmem_file, &poh, VOS_POF_FOR_FEATURE_FLAG));
+	assert_success(dv_pool_get_flags(poh, &compat_flags, &incompat_flags));
+	assert(compat_flags == 0);
+	assert(incompat_flags == 0);
+	assert_success(
+	    dv_pool_update_flags(poh, VOS_POOL_COMPAT_FLAG_SUPP, VOS_POOL_INCOMPAT_FLAG_SUPP));
+	assert_success(dv_pool_get_flags(poh, &compat_flags, &incompat_flags));
+	assert(compat_flags == VOS_POOL_COMPAT_FLAG_SUPP);
+	assert(incompat_flags == VOS_POOL_INCOMPAT_FLAG_SUPP);
+	assert_success(dv_pool_close(poh));
+}
 
 /*
  * All these tests use the same VOS tree that is created at suit_setup. Therefore, tests
@@ -1097,28 +1116,29 @@ dv_test_teardown(void **state)
  */
 #define TEST(x) { #x, x, dv_test_setup, dv_test_teardown }
 const struct CMUnitTest dv_test_cases[] = {
-	{ "open_pool", open_pool_test, NULL, NULL }, /* don't want this test to run with setup */
-	TEST(list_items_test),
-	TEST(get_cont_uuid_from_idx_tests),
-	TEST(get_dkey_from_idx_tests),
-	TEST(get_akey_from_idx_tests),
-	TEST(get_recx_from_idx_tests),
-	TEST(get_value_tests),
-	TEST(get_obj_ilog_tests),
-	TEST(abort_obj_ilog_tests),
-	TEST(get_dkey_ilog_tests),
-	TEST(abort_dkey_ilog_tests),
-	TEST(get_superblock_tests),
-	TEST(obj_id_2_ddb_test),
-	TEST(get_dtx_tables_tests),
-	TEST(delete_path_parts_tests),
-	TEST(verify_correct_params_for_update_value_tests),
-	TEST(update_value_to_modify_tests),
-	TEST(update_value_to_insert_tests),
-	TEST(clear_committed_table),
-	TEST(dtx_commit_active_table),
-	TEST(dtx_abort_active_table),
-	TEST(path_verify),
+    {"open_pool", open_pool_test, NULL, NULL}, /* don't want this test to run with setup */
+    TEST(list_items_test),
+    TEST(get_cont_uuid_from_idx_tests),
+    TEST(get_dkey_from_idx_tests),
+    TEST(get_akey_from_idx_tests),
+    TEST(get_recx_from_idx_tests),
+    TEST(get_value_tests),
+    TEST(get_obj_ilog_tests),
+    TEST(abort_obj_ilog_tests),
+    TEST(get_dkey_ilog_tests),
+    TEST(abort_dkey_ilog_tests),
+    TEST(get_superblock_tests),
+    TEST(obj_id_2_ddb_test),
+    TEST(get_dtx_tables_tests),
+    TEST(delete_path_parts_tests),
+    TEST(verify_correct_params_for_update_value_tests),
+    TEST(update_value_to_modify_tests),
+    TEST(update_value_to_insert_tests),
+    TEST(clear_committed_table),
+    TEST(dtx_commit_active_table),
+    TEST(dtx_abort_active_table),
+    TEST(path_verify),
+    {"pool_flag_update", pool_flags_tests, NULL, NULL},
 };
 
 int

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -1372,7 +1372,8 @@ pool_open(void *ph, struct vos_pool_df *pool_df, unsigned int flags, void *metri
 	}
 
 	pool->vp_metrics = metrics;
-	if (bio_nvme_configured(SMD_DEV_TYPE_DATA) && pool_df->pd_nvme_sz != 0) {
+	if (!(flags & VOS_POF_FOR_FEATURE_FLAG) && bio_nvme_configured(SMD_DEV_TYPE_DATA) &&
+	    pool_df->pd_nvme_sz != 0) {
 		struct vea_unmap_context	 unmap_ctxt;
 		struct vos_pool_metrics		*vp_metrics = metrics;
 		void				*vea_metrics = NULL;
@@ -1749,4 +1750,26 @@ vos_pool_biov2addr(daos_handle_t poh, struct bio_iov *biov)
 		return NULL;
 
 	return umem_off2ptr(vos_pool2umm(pool), bio_iov2raw_off(biov));
+}
+
+bool
+vos_pool_feature_skip_load(daos_handle_t poh)
+{
+	struct vos_pool *vos_pool;
+
+	vos_pool = vos_hdl2pool(poh);
+	D_ASSERT(vos_pool != NULL);
+
+	return vos_pool->vp_pool_df->pd_compat_flags & VOS_POOL_COMPAT_FLAG_SKIP_LOAD;
+}
+
+bool
+vos_pool_feature_immutable(daos_handle_t poh)
+{
+	struct vos_pool *vos_pool;
+
+	vos_pool = vos_hdl2pool(poh);
+	D_ASSERT(vos_pool != NULL);
+
+	return vos_pool->vp_pool_df->pd_compat_flags & VOS_POOL_COMPAT_FLAG_IMMUTABLE;
 }


### PR DESCRIPTION
This PR enhances the DDB functionality for CR purposes with
the following updates:

1. Pool Behavior Control:

Administrators can now control certain vos pool behaviors,
such as skipping vos pool loading or setting a vos pool to read-only mode.

2. Manual Pool Shard Removal:

A new command ddb rm_pool <vos_pool> has been introduced,
allowing administrators to manually remove pool shards.

3. SPDK Environment Initialization Bug Fix:

Fixed an issue where spdk_env_init() would fail during reinitialization.

These updates aim to improve system flexibility and stability,
providing administrators with more robust management capabilities.