### PR TITLE
DAOS-15914 object: flatten collective obj-ops RPC forwarding level - b26

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1091,7 +1091,7 @@ void obj_ec_recx_vos2daos(struct daos_oclass_attr *oca, daos_unit_oid_t oid, dao
 			  daos_recx_t *recx, bool get_max);
 int daos_obj_query_merge(struct obj_query_merge_args *oqma);
 void obj_coll_disp_init(uint32_t tgt_nr, uint32_t max_tgt_size, uint32_t inline_size,
-			uint32_t start, uint32_t max_width, struct obj_coll_disp_cursor *ocdc);
+			uint32_t start, int max_width, struct obj_coll_disp_cursor *ocdc);
 void obj_coll_disp_dest(struct obj_coll_disp_cursor *ocdc, struct daos_coll_target *tgts,
 			crt_endpoint_t *tgt_ep);
 void obj_coll_disp_move(struct obj_coll_disp_cursor *ocdc);

--- a/src/object/obj_utils.c
+++ b/src/object/obj_utils.c
@@ -582,7 +582,7 @@ static btr_ops_t recx_btr_ops = {
 
 void
 obj_coll_disp_init(uint32_t tgt_nr, uint32_t max_tgt_size, uint32_t inline_size,
-		   uint32_t start, uint32_t max_width, struct obj_coll_disp_cursor *ocdc)
+		   uint32_t start, int max_width, struct obj_coll_disp_cursor *ocdc)
 {
 	if (max_width == 0) {
 		/*
@@ -594,7 +594,7 @@ obj_coll_disp_init(uint32_t tgt_nr, uint32_t max_tgt_size, uint32_t inline_size,
 			max_width = COLL_DISP_WIDTH_DEF;
 	}
 
-	if (tgt_nr - start > max_width) {
+	if (max_width > 0 && tgt_nr - start > max_width) {
 		ocdc->grp_nr = max_width;
 		ocdc->cur_step = (tgt_nr - start) / max_width;
 		if ((tgt_nr - start) % max_width != 0) {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -5652,7 +5652,7 @@ again2:
 	exec_arg.coll_tgts = dcts;
 	obj_coll_disp_init(dct_nr, ocpi->ocpi_max_tgt_sz,
 			   sizeof(*ocpi) + sizeof(*odm->odm_mbs) + odm->odm_mbs->dm_data_size,
-			   1 /* start, [0] is for current engine */, ocpi->ocpi_disp_width,
+			   1 /* start, [0] is for current engine */, -1 /* ocpi->ocpi_disp_width */,
 			   &exec_arg.coll_cur);
 
 	rc = dtx_leader_begin(ioc.ioc_vos_coh, &odm->odm_xid, &epoch, 1, version,
@@ -5827,7 +5827,7 @@ ds_obj_coll_query_handler(crt_rpc_t *rpc)
 	exec_arg.coll_shards = dcts[0].dct_shards;
 	exec_arg.coll_tgts = dcts;
 	obj_coll_disp_init(dct_nr, ocqi->ocqi_max_tgt_sz, sizeof(*ocqi),
-			   1 /* start, [0] is for current engine */, ocqi->ocqi_disp_width,
+			   1 /* start, [0] is for current engine */, -1 /* ocqi->ocqi_disp_width */,
 			   &exec_arg.coll_cur);
 
 	rc = dtx_leader_begin(ioc.ioc_vos_coh, &ocqi->ocqi_xid, &epoch, 0, ocqi->ocqi_map_ver,


### PR DESCRIPTION
The collective obj-ops RPC will be forwarded via server at most once. That will decrease cascading RPCs among servers. Not sure whether it is helpful for the issue or not, just for test.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
