### PR TITLE
DAOS-16278 vos: per pool backend type

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -630,7 +630,7 @@ default_wal_sz(uint64_t meta_sz)
 }
 
 int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t scm_sz, uint64_t meta_sz,
-		  uint64_t wal_sz, uint64_t data_sz, enum bio_mc_flags flags)
+		  uint64_t wal_sz, uint64_t data_sz, enum bio_mc_flags flags, uint8_t backend_type)
 {
 	int			 rc = 0, rc1;
 	spdk_blob_id		 data_blobid = SPDK_BLOBID_INVALID;
@@ -734,6 +734,7 @@ int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t scm_s
 	fi->fi_wal_size = wal_sz;
 	fi->fi_data_size = data_sz;
 	fi->fi_vos_id = xs_ctxt->bxc_tgt_id;
+	fi->fi_backend_type = backend_type;
 
 	rc = meta_format(mc, fi, true);
 	if (rc)

--- a/src/bio/bio_wal.c
+++ b/src/bio/bio_wal.c
@@ -1861,13 +1861,14 @@ out:
 
 void
 bio_meta_get_attr(struct bio_meta_context *mc, uint64_t *capacity, uint32_t *blk_sz,
-		  uint32_t *hdr_blks)
+		  uint32_t *hdr_blks, uint8_t *backend_type)
 {
 	/* The mc could be NULL when md on SSD not enabled & data blob not existing */
 	if (mc != NULL) {
 		*blk_sz = mc->mc_meta_hdr.mh_blk_bytes;
 		*capacity = mc->mc_meta_hdr.mh_tot_blks * (*blk_sz);
 		*hdr_blks = mc->mc_meta_hdr.mh_hdr_blks;
+		*backend_type = mc->mc_meta_hdr.mh_backend_type;
 	}
 }
 
@@ -2069,6 +2070,7 @@ meta_format(struct bio_meta_context *mc, struct meta_fmt_info *fi, bool force)
 	meta_hdr->mh_tot_blks = (fi->fi_meta_size / META_BLK_SZ) - META_HDR_BLKS;
 	meta_hdr->mh_vos_id = fi->fi_vos_id;
 	meta_hdr->mh_flags = META_HDR_FL_EMPTY;
+	meta_hdr->mh_backend_type = fi->fi_backend_type;
 
 	rc = write_header(mc, mc->mc_meta, meta_hdr, sizeof(*meta_hdr), &meta_hdr->mh_csum);
 	if (rc) {

--- a/src/bio/bio_wal.h
+++ b/src/bio/bio_wal.h
@@ -28,7 +28,10 @@ struct meta_header {
 	uint64_t	mh_tot_blks;		/* Meta blob capacity, in blocks */
 	uint32_t	mh_vos_id;		/* Associated per-engine target ID */
 	uint32_t	mh_flags;		/* Meta header flags */
-	uint32_t	mh_padding[5];		/* Reserved */
+	uint8_t		mh_backend_type;	/* Backend allocator type */
+	uint8_t		mh_padding1;		/* Reserved */
+	uint16_t	mh_padding2;		/* Reserved */
+	uint32_t	mh_padding[4];		/* Reserved */
 	uint32_t	mh_csum;		/* Checksum of this header */
 };
 
@@ -124,6 +127,7 @@ struct meta_fmt_info {
 	uint64_t	fi_wal_size;		/* WAL blob size in bytes */
 	uint64_t	fi_data_size;		/* Data blob size in bytes */
 	uint32_t	fi_vos_id;		/* Associated per-engine target ID */
+	uint8_t		fi_backend_type;	/* Backend allocator type */
 };
 
 int meta_format(struct bio_meta_context *mc, struct meta_fmt_info *fi, bool force);

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -34,6 +34,8 @@ int umempobj_backend_type2class_id(int backend);
 #define	UMEMPOBJ_ENABLE_STATS	0x1
 
 #ifdef DAOS_PMEM_BUILD
+
+/* The backend type is stored in meta blob header, don't change the value */
 enum {
 	DAOS_MD_PMEM	= 0,
 	DAOS_MD_BMEM	= 1,

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -948,11 +948,13 @@ enum bio_mc_flags {
  * \param[in]	wal_sz		WAL blob in bytes
  * \param[in]	data_sz		Data blob in bytes
  * \param[in]	flags		bio_mc_flags
+ * \param[in]	backend_type	Backend allocator type
  *
  * \return			Zero on success, negative value on error.
  */
 int bio_mc_create(struct bio_xs_context *xs_ctxt, uuid_t pool_id, uint64_t scm_sz,
-		  uint64_t meta_sz, uint64_t wal_sz, uint64_t data_sz, enum bio_mc_flags flags);
+		  uint64_t meta_sz, uint64_t wal_sz, uint64_t data_sz, enum bio_mc_flags flags,
+		  uint8_t backend_type);
 
 /*
  * Destroy Meta/Data/WAL blobs
@@ -1081,7 +1083,7 @@ int bio_wal_checkpoint(struct bio_meta_context *mc, uint64_t tx_id, uint64_t *pu
  * Query meta capacity & meta block size & meta blob header blocks.
  */
 void bio_meta_get_attr(struct bio_meta_context *mc, uint64_t *capacity, uint32_t *blk_sz,
-		       uint32_t *hdr_blks);
+		       uint32_t *hdr_blks, uint8_t *backend_type);
 
 struct bio_wal_info {
 	uint32_t	wi_tot_blks;	/* Total blocks */

--- a/src/vos/tests/wal_ut.c
+++ b/src/vos/tests/wal_ut.c
@@ -29,7 +29,7 @@ ut_mc_init(struct bio_ut_args *args, uint64_t meta_sz, uint64_t wal_sz, uint64_t
 	int	rc, ret;
 
 	uuid_generate(args->bua_pool_id);
-	rc = bio_mc_create(args->bua_xs_ctxt, args->bua_pool_id, 0, meta_sz, wal_sz, data_sz, 0);
+	rc = bio_mc_create(args->bua_xs_ctxt, args->bua_pool_id, 0, meta_sz, wal_sz, data_sz, 0, 0);
 	if (rc) {
 		D_ERROR("UT MC create failed. "DF_RC"\n", DP_RC(rc));
 		return rc;

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -749,7 +749,7 @@ init_umem_store(struct umem_store *store, struct bio_meta_context *mc)
 	store->stor_ops = &vos_store_ops;
 
 	/* Legacy BMEM V1 pool without backend type stored */
-	if (store->store_type == DAOS_MD_PMEM)
+	if (bio_nvme_configured(SMD_DEV_TYPE_META) && store->store_type == DAOS_MD_PMEM)
 		store->store_type = DAOS_MD_BMEM;
 }
 


### PR DESCRIPTION
Use user specified backend type when possible, if user specify BMEM V1 backend and try to create a pool with "meta_size > scm_size", turn to use BMEM V2 instead.

Store the per-pool backend type in meta blob header for pool open.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
