### PR TITLE
DAOS-15916 dfs: Seg fault with DFS scanner (#14449)

### DIFF
--- a/src/client/dfs/cont.c
+++ b/src/client/dfs/cont.c
@@ -1563,8 +1563,9 @@ dfs_cont_scan(daos_handle_t poh, const char *cont, uint64_t flags, const char *s
 	D_PRINT("DFS scanner: " DF_U64 " directories\n", scan_args.num_dirs);
 	D_PRINT("DFS scanner: " DF_U64 " max tree depth\n", scan_args.max_depth);
 	D_PRINT("DFS scanner: " DF_U64 " bytes of total data\n", scan_args.total_bytes);
-	D_PRINT("DFS scanner: " DF_U64 " bytes per file on average\n",
-		scan_args.total_bytes / scan_args.num_files);
+	if (scan_args.num_files > 0)
+		D_PRINT("DFS scanner: " DF_U64 " bytes per file on average\n",
+			scan_args.total_bytes / scan_args.num_files);
 	D_PRINT("DFS scanner: " DF_U64 " bytes is largest file size\n", scan_args.largest_file);
 	D_PRINT("DFS scanner: " DF_U64 " entries in the largest directory\n",
 		scan_args.largest_dir);


### PR DESCRIPTION
### Description

Calling daos filesystem scan on a posix container not containing any files make the daos scanner command seg faulting.

Clean cherry pick of the PR #14449.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
