### PR TITLE
DAOS-16329 chk: maintenance mode after checking pool with dryrun - b26

### DIFF
--- a/src/chk/chk_common.c
+++ b/src/chk/chk_common.c
@@ -403,7 +403,7 @@ chk_pool_restart_svc(struct chk_pool_rec *cpr)
 		if (cpr->cpr_started)
 			chk_pool_shutdown(cpr, true);
 
-		rc = ds_pool_start_after_check(cpr->cpr_uuid);
+		rc = ds_pool_start_after_check(cpr->cpr_uuid, cpr->cpr_rdonly);
 		if (rc != 0) {
 			D_WARN("Cannot start full PS for "DF_UUIDF" after CR check: "DF_RC"\n",
 			       DP_UUID(cpr->cpr_uuid), DP_RC(rc));

--- a/src/chk/chk_internal.h
+++ b/src/chk/chk_internal.h
@@ -596,6 +596,7 @@ struct chk_pool_rec {
 				 cpr_stop:1,
 				 cpr_done:1,
 				 cpr_skip:1,
+				 cpr_rdonly:1,
 				 cpr_dangling:1,
 				 cpr_for_orphan:1,
 				 cpr_notified_exit:1,

--- a/src/client/dfs/cont.c
+++ b/src/client/dfs/cont.c
@@ -965,12 +965,16 @@ out_lf1:
 	}
 out_oit:
 	rc2 = daos_oit_close(oit_args->oit, NULL);
+	if (rc2 != 0)
+		D_ERROR("Failed to close OID table: " DF_RC "\n", DP_RC(rc2));
 	if (rc == 0)
 		rc = daos_der2errno(rc2);
 out_snap:
 	D_FREE(oit_args);
 	epr.epr_hi = epr.epr_lo = snap_epoch;
-	rc2                     = daos_cont_destroy_snap(coh, epr, NULL);
+	rc2 = daos_cont_destroy_snap(coh, epr, NULL);
+	if (rc2 != 0)
+		D_ERROR("Failed to destroy OID table: " DF_RC "\n", DP_RC(rc2));
 	if (rc == 0)
 		rc = daos_der2errno(rc2);
 out_dfs:
@@ -979,6 +983,8 @@ out_dfs:
 		rc = rc2;
 out_cont:
 	rc2 = daos_cont_close(coh, NULL);
+	if (rc2 != 0)
+		D_ERROR("Failed to close container: " DF_RC "\n", DP_RC(rc2));
 	if (rc == 0)
 		rc = daos_der2errno(rc2);
 

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -498,8 +498,9 @@ dfuse_pool_connect(struct dfuse_info *dfuse_info, const char *label, struct dfus
 	if (label) {
 		daos_pool_info_t p_info = {};
 
-		rc = daos_pool_connect(label, dfuse_info->di_group, DAOS_PC_RO, &dfp->dfp_poh,
-				       &p_info, NULL);
+		rc = daos_pool_connect(label, dfuse_info->di_group,
+				       dfuse_info->di_read_only ? DAOS_PC_RO : DAOS_PC_RW,
+				       &dfp->dfp_poh, &p_info, NULL);
 		if (rc) {
 			if (rc == -DER_NO_PERM || rc == -DER_NONEXIST)
 				DHL_INFO(dfp, rc, "daos_pool_connect() failed");

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -150,7 +150,7 @@ cont_open(int ret, char *pool, char *cont, int ro)
 	}
 
 	/** Connect to pool */
-	rc = daos_pool_connect(pool, NULL, DAOS_PC_RO, &poh, NULL, NULL);
+	rc = daos_pool_connect(pool, NULL, ro ? DAOS_PC_RO : DAOS_PC_RW, &poh, NULL, NULL);
 	if (rc)
 		goto out;
 
@@ -512,8 +512,11 @@ cont_check(int ret, char *pool, char *cont, int flags)
 		goto out;
 	}
 
-	/** Connect to pool */
-	rc = daos_pool_connect(pool, NULL, DAOS_PC_RO, &poh, NULL, NULL);
+	/**
+	 * Connect to pool.
+	 * NOTE: We need RW permission to create snapshot. More work for read-only pool in future.
+	 */
+	rc = daos_pool_connect(pool, NULL, DAOS_PC_RW, &poh, NULL, NULL);
 	if (rc)
 		goto out;
 

--- a/src/control/cmd/daos/container.go
+++ b/src/control/cmd/daos/container.go
@@ -656,7 +656,7 @@ func (cmd *existingContainerCmd) resolveAndConnect(contFlags C.uint, ap *C.struc
 	}
 
 	var cleanupPool func()
-	cleanupPool, err = cmd.connectPool(C.DAOS_PC_RO, ap)
+	cleanupPool, err = cmd.connectPool(C.DAOS_PC_RW, ap)
 	if err != nil {
 		return
 	}

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -84,6 +84,7 @@ struct ds_pool {
 	uuid_t			sp_srv_pool_hdl;
 	uint32_t		sp_stopping:1,
 				sp_cr_checked:1,
+				sp_rdonly:1,
 				sp_fetch_hdls:1,
 				sp_need_discard:1,
 				sp_disable_rebuild:1;
@@ -275,9 +276,9 @@ int ds_pool_tgt_finish_rebuild(uuid_t pool_uuid, struct pool_target_id_list *lis
 int ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 			   unsigned int map_version);
 
-bool ds_pool_skip_for_check(struct ds_pool *pool);
-int ds_pool_start_after_check(uuid_t uuid);
-int ds_pool_start(uuid_t uuid, bool aft_chk);
+bool ds_pool_restricted(struct ds_pool *pool, bool rdonly);
+int ds_pool_start_after_check(uuid_t uuid, bool rdonly);
+int ds_pool_start(uuid_t uuid, bool aft_chk, bool rdonly);
 int ds_pool_stop(uuid_t uuid);
 int dsc_pool_svc_extend(uuid_t pool_uuid, d_rank_list_t *svc_ranks, uint64_t deadline, int ntargets,
 			const d_rank_list_t *rank_list, int ndomains, const uint32_t *domains);

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -87,7 +87,8 @@ ds_sec_pool_get_capabilities(uint64_t flags, d_iov_t *cred,
  * \param[in]	cred		User's security credential
  * \param[in]	ownership	Container ownership information
  * \param[in]	acl		Container ACL
- * \param[out]	capas		Capability bits for this user
+ * \param[in]	pool_capas	Capability for the pool
+ * \param[out]	cont_capas	Capability bits for this user
  *
  * \return	0		Success
  *		-DER_INVAL	Invalid input
@@ -95,7 +96,7 @@ ds_sec_pool_get_capabilities(uint64_t flags, d_iov_t *cred,
  */
 int
 ds_sec_cont_get_capabilities(uint64_t flags, d_iov_t *cred, struct d_ownership *ownership,
-			     struct daos_acl *acl, uint64_t *capas);
+			     struct daos_acl *acl, uint64_t pool_capas, uint64_t *capas);
 
 /**
  * Determine if the pool connection can be established based on the calculated
@@ -335,5 +336,18 @@ ds_sec_get_admin_cont_capabilities(void);
  */
 int
 ds_sec_creds_are_same_user(d_iov_t *cred_x, d_iov_t *cred_y);
+
+/**
+ * Determine if the container can be modified based on the container security
+ * capabilities.
+ *
+ * \param[in]	cont_capas	Capability bits acquired via
+ *				ds_sec_cont_get_capabilities
+ *
+ * \return	True		Access allowed
+ *		False		Access denied
+ */
+bool
+ds_sec_cont_can_modify(uint64_t cont_capas);
 
 #endif /* __DAOS_SRV_SECURITY_H__ */

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -1212,7 +1212,7 @@ ds_mgmt_hdlr_tgt_create(crt_rpc_t *tc_req)
 	tc_out->tc_ranks.ca_arrays = rank;
 	tc_out->tc_ranks.ca_count  = 1;
 
-	rc = ds_pool_start(tc_in->tc_pool_uuid, false);
+	rc = ds_pool_start(tc_in->tc_pool_uuid, false, false);
 	if (rc) {
 		D_ERROR(DF_UUID": failed to start pool: "DF_RC"\n",
 			DP_UUID(tc_in->tc_pool_uuid), DP_RC(rc));

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -55,6 +55,12 @@ pool_tls_get()
 	return tls;
 }
 
+static inline bool
+ds_pool_skip_for_check(struct ds_pool *pool)
+{
+	return engine_in_check() && !pool->sp_cr_checked;
+}
+
 struct pool_iv_map {
 	d_rank_t	piv_master_rank;
 	uint32_t	piv_pool_map_ver;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -490,7 +490,7 @@ pool_child_start(struct ds_pool_child *child, bool recreate)
 		goto done;
 	}
 
-	if (!ds_pool_skip_for_check(child->spc_pool)) {
+	if (!ds_pool_restricted(child->spc_pool, false)) {
 		rc = start_gc_ult(child);
 		if (rc != 0)
 			goto out_close;
@@ -1113,7 +1113,7 @@ pool_fetch_hdls_ult_abort(struct ds_pool *pool)
  * till ds_pool_stop. Only for mgmt and pool modules.
  */
 int
-ds_pool_start(uuid_t uuid, bool aft_chk)
+ds_pool_start(uuid_t uuid, bool aft_chk, bool rdonly)
 {
 	struct ds_pool			*pool;
 	struct daos_llink		*llink;
@@ -1170,6 +1170,11 @@ ds_pool_start(uuid_t uuid, bool aft_chk)
 	else
 		pool->sp_cr_checked = 0;
 
+	if (rdonly)
+		pool->sp_rdonly = 1;
+	else
+		pool->sp_rdonly = 0;
+
 	rc = pool_child_add_all(pool);
 	if (rc != 0)
 		goto failure_pool;
@@ -1184,7 +1189,9 @@ ds_pool_start(uuid_t uuid, bool aft_chk)
 		}
 
 		pool->sp_fetch_hdls = 1;
+	}
 
+	if (!ds_pool_restricted(pool, false)) {
 		rc = ds_pool_start_ec_eph_query_ult(pool);
 		if (rc != 0) {
 			D_ERROR(DF_UUID": failed to start ec eph query ult: "DF_RC"\n",
@@ -1867,12 +1874,9 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		       DP_UUID(pool->sp_uuid), map_version_before, map_version);
 	}
 
-	if (map_updated) {
+	if (map_updated && !ds_pool_restricted(pool, false)) {
 		struct dtx_scan_args	*arg;
 		int ret;
-
-		if (ds_pool_skip_for_check(pool))
-			D_GOTO(out, rc = 0);
 
 		D_ALLOC_PTR(arg);
 		if (arg == NULL)

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1941,7 +1941,7 @@ ds_rebuild_schedule(struct ds_pool *pool, uint32_t map_ver,
 		return 0;
 	}
 
-	if (ds_pool_skip_for_check(pool)) {
+	if (ds_pool_restricted(pool, false)) {
 		D_DEBUG(DB_REBUILD, DF_UUID" skip rebuild under check mode\n",
 			DP_UUID(pool->sp_uuid));
 		return 0;

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1527,7 +1527,7 @@ expect_cont_get_capas_flags_invalid(uint64_t invalid_flags)
 
 	printf("Expecting flags %#lx invalid\n", invalid_flags);
 	assert_rc_equal(ds_sec_cont_get_capabilities(invalid_flags, &valid_cred, &valid_owner,
-						     valid_acl, &result),
+						     valid_acl, POOL_CAPAS_ALL, &result),
 			-DER_INVAL);
 
 	daos_acl_free(valid_acl);
@@ -1562,13 +1562,17 @@ test_cont_get_capas_null_inputs(void **state)
 	init_default_ownership(&ownership);
 	acl = daos_acl_create(NULL, 0);
 
-	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, NULL, &ownership, acl, &result),
+	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, NULL, &ownership, acl,
+						     POOL_CAPAS_ALL, &result),
 			-DER_INVAL);
-	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, &cred, NULL, acl, &result),
+	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, &cred, NULL, acl,
+						     POOL_CAPAS_ALL, &result),
 			-DER_INVAL);
-	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, &cred, &ownership, NULL, &result),
+	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, &cred, &ownership, NULL,
+						     POOL_CAPAS_ALL, &result),
 			-DER_INVAL);
-	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, &cred, &ownership, acl, NULL),
+	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, &cred, &ownership, acl,
+						     POOL_CAPAS_ALL, NULL),
 			-DER_INVAL);
 
 	daos_acl_free(acl);
@@ -1592,7 +1596,7 @@ expect_cont_get_capas_owner_invalid(char *user, char *group)
 	invalid_owner.user = user;
 	invalid_owner.group = group;
 	assert_rc_equal(ds_sec_cont_get_capabilities(valid_flags, &valid_cred, &invalid_owner,
-						     valid_acl, &result),
+						     valid_acl, POOL_CAPAS_ALL, &result),
 			-DER_INVAL);
 
 	daos_acl_free(valid_acl);
@@ -1625,7 +1629,7 @@ test_cont_get_capas_bad_acl(void **state)
 	assert_non_null(bad_acl);
 
 	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_PC_RO, &cred, &ownership, bad_acl,
-						     &result),
+						     POOL_CAPAS_ALL, &result),
 			-DER_INVAL);
 
 	D_FREE(bad_acl);
@@ -1657,13 +1661,13 @@ test_cont_get_capas_bad_cred(void **state)
 	d_iov_set(&bad_cred, bad_buf, sizeof(bad_buf));
 
 	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_PC_RO, &bad_cred, &ownership, acl,
-						     &result),
+						     POOL_CAPAS_ALL, &result),
 			-DER_INVAL);
 
 	/* null data */
 	d_iov_set(&bad_cred, NULL, 0);
 	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_PC_RO, &bad_cred, &ownership, acl,
-						     &result),
+						     POOL_CAPAS_ALL, &result),
 			-DER_INVAL);
 
 	/* Junk in token data */
@@ -1676,7 +1680,7 @@ test_cont_get_capas_bad_cred(void **state)
 	auth__credential__pack(&cred, buf);
 	d_iov_set(&bad_cred, buf, bufsize);
 	assert_rc_equal(ds_sec_cont_get_capabilities(DAOS_PC_RO, &bad_cred, &ownership, acl,
-						     &result),
+						     POOL_CAPAS_ALL, &result),
 			-DER_PROTO);
 	D_FREE(buf);
 
@@ -1701,7 +1705,9 @@ expect_cont_capas_with_perms(uint64_t acl_perms, uint64_t flags,
 	init_default_ownership(&ownership);
 
 	printf("Perms: %#lx, Flags: %#lx\n", acl_perms, flags);
-	assert_rc_equal(ds_sec_cont_get_capabilities(flags, &cred, &ownership, acl, &result), 0);
+	assert_rc_equal(ds_sec_cont_get_capabilities(flags, &cred, &ownership, acl, POOL_CAPAS_ALL,
+						     &result),
+			0);
 
 	assert_int_equal(result, exp_capas);
 
@@ -1796,7 +1802,9 @@ expect_cont_capas_with_owner_perms(uint64_t acl_perms, uint64_t flags,
 	init_default_ownership(&ownership);
 
 	printf("Perms: %#lx, Flags: %#lx\n", acl_perms, flags);
-	assert_rc_equal(ds_sec_cont_get_capabilities(flags, &cred, &ownership, acl, &result), 0);
+	assert_rc_equal(ds_sec_cont_get_capabilities(flags, &cred, &ownership, acl, POOL_CAPAS_ALL,
+						     &result),
+			0);
 
 	assert_int_equal(result, exp_capas);
 

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -209,7 +209,7 @@ SHUTDOWN_RC = ("DER_SHUTDOWN(-2017): 'Service should shut down'",
                "DER_NOTLEADER(-2008): 'Not service leader'")
 
 # Functions that are never reported as errors.
-IGNORED_FUNCTIONS = ('sched_watchdog_post', 'rdb_timerd')
+IGNORED_FUNCTIONS = ('sched_watchdog_post', 'rdb_timerd', 'cont_open')
 
 
 class LogTest():

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1411,22 +1411,19 @@ dm_connect(struct cmd_args_s *ap,
 	daos_prop_t       *props = NULL;
 	int                rc2;
 	bool               status_healthy;
-	unsigned int       src_cont_flags;
-
-	/* DFS only needs R. For daos API we need W for snapshot create */
-	if (is_posix_copy)
-		src_cont_flags = DAOS_COO_RO;
-	else
-		src_cont_flags = DAOS_COO_RW;
 
 	/* open src pool, src cont, and mount dfs */
 	if (src_file_dfs->type == DAOS) {
-		rc = daos_pool_connect(ca->src_pool, sysname, DAOS_PC_RO, &ca->src_poh, NULL, NULL);
+		/* DFS only needs R. For daos API we need W for snapshot create */
+		rc = daos_pool_connect(ca->src_pool, sysname,
+				       is_posix_copy ? DAOS_PC_RO : DAOS_PC_RW, &ca->src_poh,
+				       NULL, NULL);
 		if (rc != 0) {
 			DH_PERROR_DER(ap, rc, "failed to connect to source pool");
 			D_GOTO(err, rc);
 		}
-		rc = daos_cont_open(ca->src_poh, ca->src_cont, src_cont_flags, &ca->src_coh,
+		rc = daos_cont_open(ca->src_poh, ca->src_cont,
+				    is_posix_copy ? DAOS_COO_RO : DAOS_COO_RW, &ca->src_coh,
 				    src_cont_info, NULL);
 		if (rc != 0) {
 			DH_PERROR_DER(ap, rc, "failed to open source container");


### PR DESCRIPTION
Sometimes, after system shutdown unexpectedly, the users may expect to check their critical data under some kind of maintenance mode. Under such mode, no user data can be modified or moved or aggregated. That will guarantee no further potential (DAOS logic caused) damage will happen during the check.

For such purpose, we will enhance current DAOS CR logic with --dryrun option to allow the pool (after check) to be opened as read-only with disabling some mechanism that may potentially cause data modification or movement (such as rebuild or aggregation).

Test-tag: pr cat_recov
Allow-unstable-test: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
