### PR TITLE
DAOS-16340 cart: Fix order of finalize in cart_ctl

### DIFF
--- a/src/utils/ctl/cart_ctl.c
+++ b/src/utils/ctl/cart_ctl.c
@@ -763,6 +763,10 @@ ctl_init()
 	/* Stop the progress thread before destroying the group */
 	crtu_progress_stop();
 
+	rc = pthread_join(ctl_gdata.cg_tid, NULL);
+	if (rc != 0)
+		error_warn("Failed to join the threads; rc=%d\n", rc);
+
 	d_rank_list_free(rank_list);
 
 	if (ctl_gdata.cg_save_cfg) {
@@ -774,10 +778,6 @@ ctl_init()
 		if (rc != 0)
 			error_warn("Failed to destroy the view; rc=%d\n", rc);
 	}
-
-	rc = pthread_join(ctl_gdata.cg_tid, NULL);
-	if (rc != 0)
-		error_warn("Failed to join the threads; rc=%d\n", rc);
 
 	rc = sem_destroy(&ctl_gdata.cg_num_reply);
 	if (rc != 0)

--- a/src/utils/ctl/cart_ctl.c
+++ b/src/utils/ctl/cart_ctl.c
@@ -760,6 +760,9 @@ ctl_init()
 				   rc);
 	}
 
+	/* Stop the progress thread before destroying the group */
+	crtu_progress_stop();
+
 	d_rank_list_free(rank_list);
 
 	if (ctl_gdata.cg_save_cfg) {
@@ -771,8 +774,6 @@ ctl_init()
 		if (rc != 0)
 			error_warn("Failed to destroy the view; rc=%d\n", rc);
 	}
-
-	crtu_progress_stop();
 
 	rc = pthread_join(ctl_gdata.cg_tid, NULL);
 	if (rc != 0)


### PR DESCRIPTION
- Fix finilization order in the cart_ctl tool, where now a group is destroyed only after the progress has been stopped.

This avoids a segfault that can happen if an RPC is cancelled as part of the 'progress stop' sequence, which then references a group.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
