### PR TITLE
b/360833010 disable punch and stat collectives

### DIFF
--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -186,7 +186,7 @@ dc_obj_init(void)
 	if (rc != 0)
 		goto out_class;
 
-	obj_coll_thd = OBJ_COLL_THD_MIN;
+	obj_coll_thd = 0; /* Was OBJ_COLL_THD_MIN, restore when leak is fixed */
 	d_getenv_uint("DAOS_OBJ_COLL_THD", &obj_coll_thd);
 	if (obj_coll_thd == 0) {
 		D_INFO("Disable collective operation.\n");


### PR DESCRIPTION
There appears to be a leak with punch and stat collectives so let's disable them by default.  We can use the environment variable to test fixes and possibly revert this later.

Required-githooks: true

Change-Id: I21588d20416bd3f7c24cf56ef8e059216d654503

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
