### PR TITLE
DAOS-16347 vos: debug patch for DTX active table corruption

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1675,6 +1675,7 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 	umem_off_t			 rec_off;
 	size_t				 size;
 	int				 count;
+	int				 idx;
 	int				 rc = 0;
 
 	if (!dth->dth_active)
@@ -1795,6 +1796,14 @@ vos_dtx_prepared(struct dtx_handle *dth, struct vos_dtx_cmt_ent **dce_p)
 		if (rc != 0)
 			return rc;
 	}
+
+	idx = (dae->dae_df_off - umem_ptr2off(umm, dbd) -
+	       offsetof(struct vos_dtx_blob_df, dbd_active_data)) /
+	      sizeof(struct vos_dtx_act_ent_df);
+	D_ASSERTF(idx == dbd->dbd_index,
+		  "Someone changed DTX active blob (%p) during current TX "
+		  DF_DTI ": idx %d vs %d, cap %d, count %d, magic %x\n", dbd, DP_DTI(&DAE_XID(dae)),
+		  idx, dbd->dbd_index, dbd->dbd_cap, dbd->dbd_count, dbd->dbd_magic);
 
 	memcpy(umem_off2ptr(umm, dae->dae_df_off),
 	       &dae->dae_base, sizeof(struct vos_dtx_act_ent_df));


### PR DESCRIPTION
Only for test.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
