### PR TITLE
DAOS-14416 umem: Handle scm_sz ~ meta_sz with the v2 allocator

### DIFF
--- a/src/common/dav_v2/container_ravl.c
+++ b/src/common/dav_v2/container_ravl.c
@@ -56,6 +56,9 @@ container_ravl_insert_block(struct block_container *bc,
 	struct block_container_ravl *c =
 		(struct block_container_ravl *)bc;
 
+	ASSERT(m->chunk_id < MAX_CHUNK);
+	ASSERT(m->zone_id < UINT32_MAX);
+
 	c->m = *m;
 
 	return ravl_emplace_copy(c->tree, m);

--- a/src/common/dav_v2/heap.c
+++ b/src/common/dav_v2/heap.c
@@ -593,7 +593,7 @@ zone_calc_size_idx(uint32_t zone_id, unsigned max_zone, size_t heap_size)
 
 	size_t zone_size_idx = zone_raw_size / CHUNKSIZE;
 
-	ASSERT(zone_size_idx <= UINT32_MAX);
+	ASSERT(zone_size_idx <= MAX_CHUNK);
 
 	return (uint32_t)zone_size_idx;
 }
@@ -1915,7 +1915,10 @@ heap_get_zone_limits(uint64_t heap_size, uint64_t cache_size)
 		return zd;
 
 	if (zd.nzones_heap > zd.nzones_cache) {
-		zd.nzones_ne_max = zd.nzones_cache * 8 / 10;
+		if (zd.nzones_heap < (zd.nzones_cache + UMEM_CACHE_MIN_EVICTABLE_PAGES))
+			zd.nzones_ne_max = zd.nzones_cache - UMEM_CACHE_MIN_EVICTABLE_PAGES;
+		else
+			zd.nzones_ne_max = zd.nzones_cache * 8 / 10;
 		if (zd.nzones_cache < (zd.nzones_ne_max + UMEM_CACHE_MIN_EVICTABLE_PAGES))
 			zd.nzones_ne_max = zd.nzones_cache - UMEM_CACHE_MIN_EVICTABLE_PAGES;
 	} else

--- a/src/common/tests/umem_test_bmem.c
+++ b/src/common/tests/umem_test_bmem.c
@@ -2414,7 +2414,7 @@ test_umempobj_nemb_usage(void **state)
 
 	umem_class_init(&uma, &umm);
 
-	/* Do allocation and verify that only 10 zones allotted to non evictable MBs */
+	/* Do allocation and verify that only 13 zones allotted to non evictable MBs */
 	for (num = 0;; num++) {
 		/* do an allocation that takes more than half the zone size */
 		umoff = umem_atomic_alloc(&umm, alloc_size, UMEM_TYPE_ANY);
@@ -2425,7 +2425,7 @@ test_umempobj_nemb_usage(void **state)
 		prev_umoff = umoff;
 	}
 	/* 80% nemb when heap size greater than cache size */
-	assert_int_equal(num, 12);
+	assert_int_equal(num, 13);
 	print_message("Number of allocations is %d\n", num);
 
 	for (--num;; num--) {
@@ -2451,7 +2451,7 @@ test_umempobj_nemb_usage(void **state)
 
 	umem_class_init(&uma, &umm);
 
-	/* Do allocation and verify that only 10 zones allotted to non evictable MBs */
+	/* Do allocation and verify that all 16 zones are allotted to non evictable MBs */
 	for (num = 0;; num++) {
 		/* do an allocation that takes more than half the zone size */
 		umoff = umem_atomic_alloc(&umm, alloc_size, UMEM_TYPE_ANY);


### PR DESCRIPTION
- The 80% rule for NE buckets will not be applied if the scm_sz is almost equal to meta_sz.
- Corrected the check for toggling between V1 and V2 store type when scm_sz passed  is zero.
- Added assert to catch incorrect computation of chunk_id if zone counts are not set during boot correctly.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
