### PR TITLE
DAOS-16371 il: do not return unsupported for fputs if ioil is loaded …

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -2507,14 +2507,8 @@ dfuse_fputs(char *__str, FILE *stream)
 	if (drop_reference_if_disabled(entry))
 		goto do_real_fn;
 
-	D_ERROR("Unsupported function\n");
-
-	entry->fd_err = ENOTSUP;
-
+	DISABLE_STREAM(entry, stream);
 	vector_decref(&fd_table, entry);
-
-	errno = ENOTSUP;
-	return EOF;
 
 do_real_fn:
 	return __real_fputs(__str, stream);
@@ -2538,12 +2532,8 @@ dfuse_fputws(const wchar_t *ws, FILE *stream)
 	if (drop_reference_if_disabled(entry))
 		goto do_real_fn;
 
-	entry->fd_err = ENOTSUP;
-
+	DISABLE_STREAM(entry, stream);
 	vector_decref(&fd_table, entry);
-
-	errno = ENOTSUP;
-	return -1;
 
 do_real_fn:
 	return __real_fputws(ws, stream);

--- a/src/tests/suite/dfuse_test.c
+++ b/src/tests/suite/dfuse_test.c
@@ -306,9 +306,17 @@ do_stream(void **state)
 	rc = fclose(stream);
 	assert_int_equal(rc, 0);
 
+	fd = openat(root, "stream_file", O_RDWR | O_EXCL, S_IWUSR | S_IRUSR);
+	assert_return_code(fd, errno);
+	stream = fdopen(fd, "w+");
+	assert_non_null(stream);
+
+	rc = fputs("Hello World!\n", stream);
+	assert_return_code(rc, errno);
+	fclose(stream);
+
 	rc = unlinkat(root, "stream_file", 0);
 	assert_return_code(rc, errno);
-
 	rc = close(root);
 	assert_return_code(rc, errno);
 }


### PR DESCRIPTION
…(#14989)

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
