### PR TITLE
DAOS-16251 mgmt: Fix use-after-free in pool_list

### DIFF
--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -1367,8 +1367,8 @@ rechoose:
 	rc = daos_rpc_send_wait(rpc);
 	if (rc != 0) {
 		DL_ERROR(rc, "rpc send failed");
-		crt_req_decref(rpc);
 		wipe_cred_iov(&in->pli_cred);
+		crt_req_decref(rpc);
 		goto rechoose;
 	}
 
@@ -1377,8 +1377,8 @@ rechoose:
 
 	rc = rsvc_client_complete_rpc(&ms_client, &ep, rc, out->plo_op.mo_rc, &out->plo_op.mo_hint);
 	if (rc == RSVC_CLIENT_RECHOOSE) {
-		crt_req_decref(rpc);
 		wipe_cred_iov(&in->pli_cred);
+		crt_req_decref(rpc);
 		goto rechoose;
 	}
 
@@ -1430,8 +1430,8 @@ out_put_req:
 	if (rc != 0)
 		DL_ERROR(rc, "failed to list pools");
 
-	crt_req_decref(rpc);
 	wipe_cred_iov(&in->pli_cred);
+	crt_req_decref(rpc);
 out_client:
 	rsvc_client_fini(&ms_client);
 out_grp:


### PR DESCRIPTION
In dc_mgmt_pool_list, calling wipe_cred_iov on in->pli_cred after calling crt_req_decref on rpc is a use-after-free.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
