### PR TITLE
DAOS-XXXX cksum: retry once on checksum mismatch on update

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -281,8 +281,9 @@ daos_csummer_compare_csum_info(struct daos_csummer *obj,
 	}
 
 	if (unlikely(!match))
-		D_ERROR("Checksum mismatch at index %d/%d "DF_CI" != "DF_CI"\n", i,  a->cs_nr,
-			DP_CI(ci_idx2csum(a, i)), DP_CI(ci_idx2csum(b, i)));
+		D_ERROR("Checksum mismatch at index %d/%d "DF_CI_BUF" != "DF_CI_BUF"\n", i,
+			a->cs_nr, DP_CI_BUF(ci_idx2csum(a, i), a->cs_len),
+			DP_CI_BUF(ci_idx2csum(b, i), b->cs_len));
 
 	return match;
 }

--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -280,6 +280,10 @@ daos_csummer_compare_csum_info(struct daos_csummer *obj,
 						  a->cs_len);
 	}
 
+	if (unlikely(!match))
+		D_ERROR("Checksum mismatch at index %d/%d "DF_CI" != "DF_CI"\n", i,  a->cs_nr,
+			DP_CI(ci_idx2csum(a, i)), DP_CI(ci_idx2csum(b, i)));
+
 	return match;
 }
 

--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -278,12 +278,11 @@ daos_csummer_compare_csum_info(struct daos_csummer *obj,
 		match = daos_csummer_csum_compare(obj, ci_idx2csum(a, i),
 						  ci_idx2csum(b, i),
 						  a->cs_len);
+		if (unlikely(!match))
+			D_ERROR("Checksum mismatch at index %d/%d "DF_CI_BUF" != "DF_CI_BUF"\n", i,
+				a->cs_nr, DP_CI_BUF(ci_idx2csum(a, i), a->cs_len),
+				DP_CI_BUF(ci_idx2csum(b, i), b->cs_len));
 	}
-
-	if (unlikely(!match))
-		D_ERROR("Checksum mismatch at index %d/%d "DF_CI_BUF" != "DF_CI_BUF"\n", i,
-			a->cs_nr, DP_CI_BUF(ci_idx2csum(a, i), a->cs_len),
-			DP_CI_BUF(ci_idx2csum(b, i), b->cs_len));
 
 	return match;
 }

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4760,9 +4760,17 @@ obj_comp_cb(tse_task_t *task, void *data)
 						obj_auxi->tx_uncertain = 1;
 					else
 						obj_auxi->nvme_io_err = 1;
-				} else if (task->dt_result != -DER_NVME_IO) {
-					/* Don't retry update for CSUM & UNCERTAIN errors */
-					obj_auxi->io_retry = 0;
+				} else {
+					if (task->dt_result == -DER_CSUM) {
+						/** Retry once on checksum error on update */
+						if (!obj_auxi->csum_retry)
+							obj_auxi->csum_retry = 1;
+						else
+							obj_auxi->io_retry = 0;
+					else if (task->dt_result != -DER_NVME_IO) {
+						/* Don't retry update for UNCERTAIN errors */
+						obj_auxi->io_retry = 0;
+					}
 				}
 			} else {
 				obj_auxi->io_retry = 0;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4767,7 +4767,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 							obj_auxi->csum_retry = 1;
 						else
 							obj_auxi->io_retry = 0;
-					else if (task->dt_result != -DER_NVME_IO) {
+					} else if (task->dt_result != -DER_NVME_IO) {
 						/* Don't retry update for UNCERTAIN errors */
 						obj_auxi->io_retry = 0;
 					}


### PR DESCRIPTION
Unlike fetch, we return DER_CSUM on update (turned into EIO by dfs) without any retry. We should retry at least once in case it is a transient error.

The patch also prints more information about the actual checksum mismatch.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
