### PR TITLE
DAOS-16451 telemetry: Adjust type of (_sum|_sumsquares)

### DIFF
--- a/src/control/lib/telemetry/promexp/util.go
+++ b/src/control/lib/telemetry/promexp/util.go
@@ -141,16 +141,18 @@ func getMetricStats(baseName string, m telemetry.Metric) (stats []*metricStat) {
 			desc: " (mean)",
 		},
 		"sum": {
-			fn:   func() float64 { return float64(ms.Sum()) },
-			desc: " (sum)",
+			fn:        func() float64 { return float64(ms.Sum()) },
+			isCounter: true,
+			desc:      " (sum)",
 		},
 		"stddev": {
 			fn:   ms.StdDev,
 			desc: " (std dev)",
 		},
 		"sumsquares": {
-			fn:   ms.SumSquares,
-			desc: " (sum of squares)",
+			fn:        ms.SumSquares,
+			isCounter: true,
+			desc:      " (sum of squares)",
 		},
 		"samples": {
 			fn:        func() float64 { return float64(ms.SampleSize()) },

--- a/src/control/lib/telemetry/promexp/util_test.go
+++ b/src/control/lib/telemetry/promexp/util_test.go
@@ -88,9 +88,10 @@ func TestPromExp_getMetricStats(t *testing.T) {
 					value: 3.0,
 				},
 				{
-					name:  "stats_gauge_sum",
-					desc:  " (sum)",
-					value: 15.0,
+					name:      "stats_gauge_sum",
+					desc:      " (sum)",
+					value:     15.0,
+					isCounter: true,
 				},
 				{
 					name:      "stats_gauge_samples",
@@ -104,9 +105,10 @@ func TestPromExp_getMetricStats(t *testing.T) {
 					value: 1.58113883,
 				},
 				{
-					name:  "stats_gauge_sumsquares",
-					desc:  " (sum of squares)",
-					value: 55,
+					name:      "stats_gauge_sumsquares",
+					desc:      " (sum of squares)",
+					value:     55,
+					isCounter: true,
 				},
 			},
 		},

--- a/src/control/security/pem_test.go
+++ b/src/control/security/pem_test.go
@@ -190,6 +190,10 @@ func TestSecurity_Pem_ValidateCertDirectory(t *testing.T) {
 			if err := os.Mkdir(testDir, tc.perms); err != nil {
 				t.Fatal(err)
 			}
+			// Use chmod to set the permissions regardless of umask.
+			if err := os.Chmod(testDir, tc.perms); err != nil {
+				t.Fatal(err)
+			}
 			testFile := test.CreateTestFile(t, dir, "some content")
 
 			path := testDir


### PR DESCRIPTION
These stats metrics should be Counter rather than Gauge,
as their values will only increase.

Also includes a small fix for pem_test.go to set the
test dir permissions explicitly irrespective of umask.

Features: telemetry
Required-githooks: true
Change-Id: Iaae589189a5fc60b58ce4ba05262763a88956fcf
Signed-off-by: Michael MacDonald <mjmac@google.com>
