### PR TITLE
DAOS-16462 test: remove server manager srv_timeout

### DIFF
--- a/src/tests/ftest/aggregation/dfuse_space_check.yaml
+++ b/src/tests/ftest/aggregation/dfuse_space_check.yaml
@@ -1,5 +1,3 @@
-server_manager:
-  srv_timeout: 500
 hosts:
   test_servers: 1
   test_clients: 1
@@ -14,7 +12,6 @@ server_config:
 pool:
   scm_size: 200MB
   nvme_size: 1GiB  # Minimum for 1 target
-  svcn: 1
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/dfuse/sparse_file.yaml
+++ b/src/tests/ftest/dfuse/sparse_file.yaml
@@ -1,5 +1,3 @@
-server_manager:
-  srv_timeout: 500
 hosts:
   test_servers: 1
   test_clients: 1
@@ -14,7 +12,6 @@ server_config:
 pool:
   scm_size: 200000000
   nvme_size: 1073741824
-  svcn: 1
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/osa/offline_drain.yaml
+++ b/src/tests/ftest/osa/offline_drain.yaml
@@ -1,5 +1,3 @@
-server_manager:
-  srv_timeout: 500
 hosts:
   test_servers: 3
   test_clients: 1
@@ -35,7 +33,6 @@ pool:
   scm_size: 12000000000
   nvme_size: 108000000000
   svcn: 4
-  control_method: dmg
   rebuild_timeout: 240
   properties: scrub:timed
 container:

--- a/src/tests/ftest/osa/offline_parallel_test.yaml
+++ b/src/tests/ftest/osa/offline_parallel_test.yaml
@@ -1,5 +1,3 @@
-server_manager:
-  srv_timeout: 500
 hosts:
   test_servers: server-[1-2]
   test_clients: 1
@@ -37,7 +35,6 @@ pool:
   scm_size: 6000000000
   nvme_size: 54000000000
   svcn: 4
-  control_method: dmg
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/osa/online_drain.yaml
+++ b/src/tests/ftest/osa/online_drain.yaml
@@ -1,5 +1,3 @@
-server_manager:
-  srv_timeout: 500
 hosts:
   test_servers: 3
   test_clients: 1

--- a/src/tests/ftest/util/yaml_utils.py
+++ b/src/tests/ftest/util/yaml_utils.py
@@ -1,5 +1,5 @@
 """
-(C) Copyright 2020-2023 Intel Corporation.
+(C) Copyright 2020-2024 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -87,7 +87,6 @@ class YamlUpdater():
         ("pool_query_timeout", "_timeout", int),
         ("pool_query_delay", "_timeout", int),
         ("rebuild_timeout", "_timeout", int),
-        ("srv_timeout", "_timeout", int),
         ("storage_prepare_timeout", "_timeout", int),
         ("storage_format_timeout", "_timeout", int),
     ]


### PR DESCRIPTION
remove server manager srv_timeout since it is unused

Test-tag: DfuseSpaceCheck SparseFile OSAOfflineDrain OSAOfflineParallelTest OSAOnlineDrain
Skip-unit-tests: true
Skip-fault-injection-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
