### PR TITLE
DAOS-16466 object: Fix obj_ec_singv_split overflow

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1408,13 +1408,15 @@ obj_ec_singv_split(daos_unit_oid_t oid, uint16_t layout_ver, struct daos_oclass_
 {
 	uint64_t c_bytes = obj_ec_singv_cell_bytes(iod_size, oca);
 	uint32_t tgt_off = obj_ec_shard_off_by_layout_ver(layout_ver, dkey_hash, oca, oid.id_shard);
+	uint64_t tgt_size = min(c_bytes, iod_size - tgt_off * c_bytes);
 	char	*data = sgl->sg_iovs[0].iov_buf;
 
-	D_ASSERT(iod_size != DAOS_REC_ANY);
+	D_ASSERTF(iod_size != DAOS_REC_ANY && iod_size == sgl->sg_iovs[0].iov_len,
+		  DF_U64 " == %zu\n", iod_size, sgl->sg_iovs[0].iov_len);
 	if (tgt_off > 0)
-		memmove(data, data + tgt_off * c_bytes, c_bytes);
+		memmove(data, data + tgt_off * c_bytes, tgt_size);
 
-	sgl->sg_iovs[0].iov_len = c_bytes;
+	sgl->sg_iovs[0].iov_len = tgt_size;
 	return 0;
 }
 


### PR DESCRIPTION
It has been seen that obj_ec_singv_split may read beyond the end of sgl->sg_iovs[0].iov_buf:

    iod_size=8569
    c_bytes=4288
    id_shard=0
    tgt_off=1
    iov_len=8569
    iov_buf_len=8569

The memmove read 4288 bytes from offset 4288, whereas the buffer only had 8569 - 4288 = 4281 bytes from offset 4288. This patch fixes the problem by adding the min(...) expression.

Features: ec

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
