### PR TITLE
DAOS-16508 csum: retry a few times on checksum mismatch on update

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -278,6 +278,10 @@ daos_csummer_compare_csum_info(struct daos_csummer *obj,
 		match = daos_csummer_csum_compare(obj, ci_idx2csum(a, i),
 						  ci_idx2csum(b, i),
 						  a->cs_len);
+		if (unlikely(!match))
+			D_ERROR("Checksum mismatch at index %d/%d "DF_CI_BUF" != "DF_CI_BUF"\n", i,
+				a->cs_nr, DP_CI_BUF(ci_idx2csum(a, i), a->cs_len),
+				DP_CI_BUF(ci_idx2csum(b, i), b->cs_len));
 	}
 
 	return match;

--- a/src/object/cli_csum.h
+++ b/src/object/cli_csum.h
@@ -12,7 +12,7 @@
 #include "obj_internal.h"
 
 /** How many times to retry UPDATE RPCs on checksum error */
-#define MAX_CSUM_UPDATE_RETRY 10
+#define MAX_CSUM_RETRY 10
 
 int dc_obj_csum_update(struct daos_csummer *csummer, struct cont_props props, daos_obj_id_t param,
 		       daos_key_t *dkey, daos_iod_t *iods, d_sg_list_t *sgls, const uint32_t iod_nr,

--- a/src/object/cli_csum.h
+++ b/src/object/cli_csum.h
@@ -11,6 +11,9 @@
 #include <daos/cont_props.h>
 #include "obj_internal.h"
 
+/** How many times to retry UPDATE RPCs on checksum error */
+#define MAX_CSUM_UPDATE_RETRY 10
+
 int dc_obj_csum_update(struct daos_csummer *csummer, struct cont_props props, daos_obj_id_t param,
 		       daos_key_t *dkey, daos_iod_t *iods, d_sg_list_t *sgls, const uint32_t iod_nr,
 		       struct dcs_layout *layout, struct dcs_csum_info **dkey_csum,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4764,7 +4764,8 @@ obj_comp_cb(tse_task_t *task, void *data)
 					else
 						obj_auxi->nvme_io_err = 1;
 				} else {
-					if (task->dt_result == -DER_CSUM) {
+					if (obj_auxi->opc == DAOS_OBJ_RPC_UPDATE &&
+					    task->dt_result == -DER_CSUM) {
 						struct shard_rw_args *rw_arg = &obj_auxi->rw_args;
 
 						/** Retry a few times on checksum error on update */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4764,9 +4764,9 @@ obj_comp_cb(tse_task_t *task, void *data)
 					if (task->dt_result == -DER_CSUM) {
 						/** Retry a few times on checksum error on update */
 						if (!obj_auxi->csum_retry &&
-						    obj_auxi->csum_retry_count++ < MAX_CSUM_UPDATE_RETRY) {
+						    obj_auxi->csum_retry_cnt < MAX_CSUM_RETRY) {
 							obj_auxi->csum_retry = 1;
-							obj_auxi->csum_retry_count++;
+							obj_auxi->csum_retry_cnt++;
 						} else {
 							obj_auxi->io_retry = 0;
 						}

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4684,12 +4684,15 @@ obj_comp_cb(tse_task_t *task, void *data)
 	int			rc;
 
 	obj_auxi = tse_task_stack_pop(task, sizeof(*obj_auxi));
-	obj_auxi->io_retry = 0;
-	obj_auxi->result = 0;
-	obj_auxi->csum_retry = 0;
-	obj_auxi->tx_uncertain = 0;
-	obj_auxi->nvme_io_err = 0;
 	obj = obj_auxi->obj;
+
+	/** Clear various bits for a new attempt */
+	obj_auxi->io_retry	= 0;
+	obj_auxi->result	= 0;
+	obj_auxi->csum_retry	= 0;
+	obj_auxi->tx_uncertain	= 0;
+	obj_auxi->nvme_io_err	= 0;
+
 	rc = obj_comp_cb_internal(obj_auxi);
 	if (rc != 0 || obj_auxi->result) {
 		if (task->dt_result == 0)
@@ -4762,12 +4765,19 @@ obj_comp_cb(tse_task_t *task, void *data)
 						obj_auxi->nvme_io_err = 1;
 				} else {
 					if (task->dt_result == -DER_CSUM) {
+						struct shard_rw_args *rw_arg = &obj_auxi->rw_args;
+
 						/** Retry a few times on checksum error on update */
-						if (!obj_auxi->csum_retry &&
-						    obj_auxi->csum_retry_cnt < MAX_CSUM_RETRY) {
+						if (rw_arg->csum_retry_cnt < MAX_CSUM_RETRY) {
 							obj_auxi->csum_retry = 1;
-							obj_auxi->csum_retry_cnt++;
+							rw_arg->csum_retry_cnt++;
+							D_DEBUG(DB_IO, DF_OID" checksum error on "
+								"update, retrying\n",
+								DP_OID(obj->cob_md.omd_id));
 						} else {
+							D_ERROR(DF_OID" checksum error on udpate, "
+								"too many retries. Failing I/O\n",
+								DP_OID(obj->cob_md.omd_id));
 							obj_auxi->io_retry = 0;
 						}
 					} else if (task->dt_result != -DER_NVME_IO) {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4775,7 +4775,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 								"update, retrying\n",
 								DP_OID(obj->cob_md.omd_id));
 						} else {
-							D_ERROR(DF_OID" checksum error on udpate, "
+							D_ERROR(DF_OID" checksum error on update, "
 								"too many retries. Failing I/O\n",
 								DP_OID(obj->cob_md.omd_id));
 							obj_auxi->io_retry = 0;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -474,9 +474,10 @@ struct obj_auxi_args {
 					 rebuilding:1,
 					 for_migrate:1;
 	/* request flags. currently only: ORF_RESEND */
-	uint32_t			 flags;
 	uint32_t			 specified_shard;
+	uint16_t			 flags;
 	uint16_t			 retry_cnt;
+	uint16_t			 csm_retry_cnt;;
 	uint16_t			 inprogress_cnt;
 	struct obj_req_tgts		 req_tgts;
 	d_sg_list_t			*sgls_dup;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -477,7 +477,7 @@ struct obj_auxi_args {
 	uint32_t			 specified_shard;
 	uint16_t			 flags;
 	uint16_t			 retry_cnt;
-	uint16_t			 csm_retry_cnt;;
+	uint16_t			 csum_retry_cnt;
 	uint16_t			 inprogress_cnt;
 	struct obj_req_tgts		 req_tgts;
 	d_sg_list_t			*sgls_dup;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -281,6 +281,7 @@ struct shard_rw_args {
 	struct dcs_csum_info	*dkey_csum;
 	struct dcs_iod_csums	*iod_csums;
 	struct obj_reasb_req	*reasb_req;
+	uint16_t		 csum_retry_cnt;
 };
 
 struct coll_sparse_targets {
@@ -475,9 +476,8 @@ struct obj_auxi_args {
 					 for_migrate:1;
 	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 specified_shard;
-	uint16_t			 flags;
+	uint32_t			 flags;
 	uint16_t			 retry_cnt;
-	uint16_t			 csum_retry_cnt;
 	uint16_t			 inprogress_cnt;
 	struct obj_req_tgts		 req_tgts;
 	d_sg_list_t			*sgls_dup;


### PR DESCRIPTION
Unlike fetch, we return DER_CSUM on update (turned into EIO by dfs) without any retry. We should retry a few times in case it is a transient error.

The patch also prints more information about the actual checksum mismatch.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
