### PR TITLE
DAOS-16457 test: remove display_memory_info (#15031)

### DIFF
--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -464,14 +464,6 @@ class DaosServerManager(SubprocessManager):
         return run_remote(
             self.log, self._hosts, cmd.with_exports, timeout=self.collect_log_timeout.value)
 
-    def display_memory_info(self):
-        """Display server hosts memory info."""
-        self.log.debug("#" * 80)
-        self.log.debug("<SERVER> Collection debug memory info")
-        run_remote(self.log, self._hosts, "free -m && df -h --type=tmpfs")
-        run_remote(self.log, self._hosts, "ps -eo size,pid,user,command --sort -size | head -n 6")
-        self.log.debug("#" * 80)
-
     def detect_format_ready(self, reformat=False):
         """Detect when all the daos_servers are ready for storage format.
 
@@ -664,14 +656,11 @@ class DaosServerManager(SubprocessManager):
         self.prepare()
 
         # Start the servers and wait for them to be ready for storage format
-        self.display_memory_info()
         self.detect_format_ready()
 
         # Collect storage and network information from the servers.
-        self.display_memory_info()
         self.information.collect_storage_information()
         self.information.collect_network_information()
-        self.display_memory_info()
 
         # Format storage and wait for server to change ownership
         self.log.info("<SERVER> Formatting hosts: <%s>", self.dmg.hostlist)
@@ -710,9 +699,6 @@ class DaosServerManager(SubprocessManager):
 
             # Make sure the mount directory belongs to non-root user
             self.set_scm_mount_ownership()
-
-        # Collective memory usage after stop.
-        self.display_memory_info()
 
         # Report any errors after all stop actions have been attempted
         if messages:


### PR DESCRIPTION
display_memory_info was added to debug an issue when starting the servers, but resolved by #14295.
It is no longer needed and consumes too much log space and time.

Test-tag: test_basic_coverage
Skip-unit-tests: true
Skip-fault-injection-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
