### PR TITLE
DAOS-16469 engine: evenly dispatch out RPC load among helpers - b26

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -2227,6 +2227,7 @@ again:
 		D_GOTO(out, rc = dss_abterr2der(rc));
 	}
 
+	dtx_chore.chore.cho_load = dlh->dlh_forward_cnt;
 	rc = dss_chore_delegate(&dtx_chore.chore, dtx_leader_exec_ops_chore);
 	if (rc != 0) {
 		DL_ERROR(rc, "chore create failed [%u, %u] (2)", dlh->dlh_forward_idx,
@@ -2306,6 +2307,7 @@ exec:
 	/* The ones without DELAY flag will be skipped when scan the targets array. */
 	dlh->dlh_forward_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
 
+	dtx_chore.chore.cho_load = dlh->dlh_forward_cnt;
 	rc = dss_chore_delegate(&dtx_chore.chore, dtx_leader_exec_ops_chore);
 	if (rc != 0) {
 		DL_ERROR(rc, "chore create failed (4)");

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -225,9 +225,10 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	}
 
 out:
-	D_DEBUG(DB_TRACE, "DTX req for opc %x (req %p future %p) got reply from %d/%d: "
-		"epoch :"DF_X64", result %d\n", dra->dra_opc, req, dra->dra_future,
-		drr->drr_rank, drr->drr_tag, din != NULL ? din->di_epoch : 0, rc);
+	DL_CDEBUG(rc < 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_TRACE, rc,
+		  "DTX req for opc %x (req %p future %p) got reply from %d/%d: "
+		  "epoch :"DF_X64, dra->dra_opc, req, dra->dra_future,
+		  drr->drr_rank, drr->drr_tag, din != NULL ? din->di_epoch : 0);
 
 	drr->drr_comp = 1;
 	drr->drr_result = rc;
@@ -736,6 +737,7 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 				goto out;
 			}
 
+			dca->dca_chore.cho_load = dca->dca_steps;
 			rc = dss_chore_delegate(&dca->dca_chore, dtx_rpc_helper);
 			if (rc != 0)
 				goto out;
@@ -1557,6 +1559,7 @@ dtx_coll_rpc_prep(struct ds_cont_child *cont, struct dtx_coll_entry *dce, uint32
 	}
 
 	if (dss_has_enough_helper()) {
+		dcra->dcra_chore.cho_load = 1;
 		rc = dss_chore_delegate(&dcra->dcra_chore, dtx_coll_rpc_helper);
 	} else {
 		dss_chore_diy(&dcra->dcra_chore, dtx_coll_rpc_helper);

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -76,6 +76,7 @@ struct dss_chore_queue {
 	ABT_mutex  chq_mutex;
 	ABT_cond   chq_cond;
 	ABT_thread chq_ult;
+	uint64_t   chq_load;
 };
 
 /** Per-xstream configuration data */

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -778,6 +778,7 @@ typedef enum dss_chore_status (*dss_chore_func_t)(struct dss_chore *chore, bool 
 struct dss_chore {
 	d_list_t              cho_link;
 	enum dss_chore_status cho_status;
+	uint32_t	      cho_load;
 	dss_chore_func_t      cho_func;
 };
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2667,6 +2667,11 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 	struct ec_agg_param	 *ec_agg_param = agg_param->ap_data;
 	vos_iter_param_t	 iter_param = { 0 };
 	struct vos_iter_anchors  anchors = { 0 };
+	struct dtx_handle	*dth = NULL;
+	struct dtx_share_peer	*dsp;
+	struct dtx_id		 dti = { 0 };
+	struct dtx_epoch	 epoch = { 0 };
+	daos_unit_oid_t		 oid = { 0 };
 	int			 rc = 0;
 	int                       blocks       = 0;
 
@@ -2715,8 +2720,25 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 	agg_reset_entry(&ec_agg_param->ap_agg_entry, NULL, NULL);
 
 retry:
+	epoch.oe_value = epr->epr_hi;
+	rc = dtx_begin(cont->sc_hdl, &dti, &epoch, 0, cont->sc_pool->spc_map_version, &oid,
+		       NULL, 0, 0, NULL, &dth);
+	if (rc != 0)
+		goto update_hae;
+
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors, agg_iterate_pre_cb,
-			 agg_iterate_post_cb, ec_agg_param, NULL);
+			 agg_iterate_post_cb, ec_agg_param, dth);
+	if (rc == -DER_INPROGRESS && !d_list_empty(&dth->dth_share_tbd_list)) {
+		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
+					       struct dtx_share_peer, dsp_link)) != NULL) {
+			D_ERROR(DF_CONT ": EC aggregate hit non-committed DTX " DF_DTI "\n",
+				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+				DP_DTI(&dsp->dsp_xid));
+			dtx_dsp_free(dsp);
+		}
+	}
+
+	dtx_end(dth, cont, rc);
 
 	/* Post_cb may not being executed in some cases */
 	agg_clear_extents(&ec_agg_param->ap_agg_entry);


### PR DESCRIPTION
When choose helper from the shared helper XS pool for forward IO RPC or dispatch DTX RPC, if there are multiple candidates, then randomly choosing one without consider existing RPC load may cause unbalanced load among the helpers.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
