### PR TITLE
DAOS-16304 tools: Adjust default RPC size for net-test

### DIFF
--- a/src/control/cmd/daos/pretty/selftest.go
+++ b/src/control/cmd/daos/pretty/selftest.go
@@ -55,8 +55,7 @@ func PrintSelfTestResult(out io.Writer, result *daos.SelfTestResult, verbose, sh
 		return errors.Errorf("nil %T", result)
 	}
 
-	rpcThroughput := float64(result.MasterLatency.Succeeded()) / result.Duration.Seconds()
-
+	rpcThroughput := result.RPCThroughput()
 	epRanks := ranklist.NewRankSet()
 	epTgts := hostlist.NewNumericSet()
 	for _, ep := range result.TargetEndpoints {
@@ -73,7 +72,7 @@ func PrintSelfTestResult(out io.Writer, result *daos.SelfTestResult, verbose, sh
 	}
 	if result.SendSize > 0 || result.ReplySize > 0 {
 		suffix := "B/s"
-		bw := rpcThroughput * (float64(result.SendSize) + float64(result.ReplySize))
+		bw := result.RPCBandwidth()
 		if !showBytes {
 			bw *= 8
 			suffix = "bps"

--- a/src/control/cmd/daos/pretty/selftest_test.go
+++ b/src/control/cmd/daos/pretty/selftest_test.go
@@ -42,8 +42,8 @@ func TestPretty_PrintSelfTestConfig(t *testing.T) {
 Client/Server Network Test Parameters
 -------------------------------------
   Servers        : All     
-  Send RPC Size  : 1.00 MiB
-  Reply RPC Size : 1.00 MiB
+  Send RPC Size  : 1.00 KiB
+  Reply RPC Size : 1.00 KiB
   RPCs Per Server: 10000   
 
 `,
@@ -56,8 +56,8 @@ Client/Server Network Test Parameters
 Client/Server Network Test Parameters
 -------------------------------------
   Server         : 1       
-  Send RPC Size  : 1.00 MiB
-  Reply RPC Size : 1.00 MiB
+  Send RPC Size  : 1.00 KiB
+  Reply RPC Size : 1.00 KiB
   RPCs Per Server: 10000   
 
 `,
@@ -85,8 +85,8 @@ Client/Server Network Test Parameters
 Client/Server Network Test Parameters
 -------------------------------------
   Servers           : All        
-  Send RPC Size     : 1.00 MiB   
-  Reply RPC Size    : 1.00 MiB   
+  Send RPC Size     : 1.00 KiB   
+  Reply RPC Size    : 1.00 KiB   
   RPCs Per Server   : 10000      
   System Name       : daos_server
   Tag               : 0          
@@ -143,8 +143,8 @@ Client/Server Network Test Parameters
 Client/Server Network Test Parameters
 -------------------------------------
   Servers           : All           
-  Send RPC Size     : 1.00 MiB      
-  Reply RPC Size    : 1.00 MiB      
+  Send RPC Size     : 1.00 KiB      
+  Reply RPC Size    : 1.00 KiB      
   RPCs Per Server   : 10000         
   System Name       : daos_server   
   Tags              : ERROR (0 tags)
@@ -169,6 +169,8 @@ Client/Server Network Test Parameters
 func genResult(xfrm func(result *daos.SelfTestResult)) *daos.SelfTestResult {
 	cfg := &daos.SelfTestConfig{}
 	cfg.SetDefaults()
+	cfg.SendSizes = []uint64{1 << 20}
+	cfg.ReplySizes = cfg.SendSizes
 	result := &daos.SelfTestResult{
 		MasterEndpoint: daos.SelfTestEndpoint{Rank: 3, Tag: 0},
 		TargetEndpoints: []daos.SelfTestEndpoint{

--- a/src/control/lib/daos/selftest_test.go
+++ b/src/control/lib/daos/selftest_test.go
@@ -250,6 +250,8 @@ func TestDaos_SelfTestResult_MarshalJSON(t *testing.T) {
       "fail_count": 0
     }
   },
+  "rpc_count_per_second": 1500,
+  "rpc_bytes_per_second": 3072000,
   "repetitions": 3000,
   "send_size": 1024,
   "reply_size": 1024,


### PR DESCRIPTION
The previous default of 1MiB isn't helpful at large scales.
Use a default of 1KiB to get faster results and a better
balance between raw latency and bandwidth.

Also include calculated rpc throughput and bandwidth in
JSON output.

Features: daos_cmd
Required-githooks: true

Change-Id: Ie033d7a4c2df15d3d54a4d0e3f0af812dfc84d1f
Signed-off-by: Michael MacDonald <mjmac@google.com>
