### PR TITLE
DAOS-16468 test: ior/small.py - Decrease crt_timeout to 10

### DIFF
--- a/src/tests/ftest/ior/small.yaml
+++ b/src/tests/ftest/ior/small.yaml
@@ -5,7 +5,7 @@ timeout: 700
 server_config:
   name: daos_server
   engines_per_host: 2
-  crt_timeout: 60
+  crt_timeout: 10
   engines:
     0:
       pinned_numa_node: 0

--- a/src/tests/ftest/ior/small.yaml
+++ b/src/tests/ftest/ior/small.yaml
@@ -32,7 +32,6 @@ dmg:
 pool:
   scm_size: 3000000000
   nvme_size: 9000000000
-  control_method: dmg
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on
@@ -48,8 +47,8 @@ ior:
   dfs_destroy: false
   iorflags:
     ior_flags:
-      - "-v -W -w -r -R"
-      - "-v -W -w -r -R -F"
+      - -v -W -w -r -R
+      - -v -W -w -r -R -F
     ior_api:
       - DFS
       - MPIIO
@@ -61,8 +60,8 @@ ior:
       - [256B, 512K]
       - [1M, 8M]
     obj_class:
-      - "SX"
-      - "RP_2GX"
+      - SX
+      - RP_2GX
 dfuse:
   mount_dir: "/tmp/daos_dfuse/"
   disable_caching: true


### PR DESCRIPTION
ior/small.py is failing because the test doesn't provide enough opportunities for RPC retries. To increase RPC retries, decrease crt_timeout in the test yaml to 10 from 60.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium-md-on-ssd: false
Test-tag: test_ior_small

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
