### PR TITLE
DAOS-16298 test: improve get_clush_command timeout

### DIFF
--- a/src/tests/ftest/recovery/ddb.py
+++ b/src/tests/ftest/recovery/ddb.py
@@ -90,12 +90,12 @@ def copy_remote_to_local(remote_file_path, test_dir, remote):
     # Use clush --rcopy to copy the file from the remote server node to the local test
     # node. clush will append .<server_hostname> to the file when copying.
     args = "--rcopy {} --dest {}".format(remote_file_path, test_dir)
-    clush_command = get_clush_command(hosts=remote, args=args)
+    clush_command = get_clush_command(hosts=remote, args=args, timeout=60)
     try:
-        run_command(command=clush_command)
+        run_command(command=clush_command, timeout=None)
     except DaosTestError as error:
-        print("ERROR: Copying {} from {}: {}".format(remote_file_path, remote, error))
-        raise error
+        raise DaosTestError(
+            f"ERROR: Copying {remote_file_path} from {remote}: {error}") from error
 
     # Remove the appended .<server_hostname> from the copied file.
     current_file_path = "".join([remote_file_path, ".", remote])
@@ -103,10 +103,8 @@ def copy_remote_to_local(remote_file_path, test_dir, remote):
     try:
         run_command(command=mv_command)
     except DaosTestError as error:
-        print(
-            "ERROR: Moving {} to {}: {}".format(
-                current_file_path, remote_file_path, error))
-        raise error
+        raise DaosTestError(
+            f"ERROR: Moving {current_file_path} to {remote_file_path}: {error}") from error
 
 
 class DdbTest(RecoveryTestBase):

--- a/src/tests/ftest/slurm_setup.py
+++ b/src/tests/ftest/slurm_setup.py
@@ -145,8 +145,9 @@ class SlurmSetup():
         non_control = self.nodes.difference(self.control)
         self.log.debug('Copying the munge key to %s', non_control)
         command = get_clush_command(
-            non_control, args=f"-B -S -v --copy {self.MUNGE_KEY} --dest {self.MUNGE_KEY}")
-        result = run_remote(self.log, self.control, command)
+            non_control, args=f"-B -S -v --copy {self.MUNGE_KEY} --dest {self.MUNGE_KEY}",
+            timeout=60)
+        result = run_remote(self.log, self.control, command, timeout=None)
         if not result.passed:
             raise SlurmSetupException(f'Error creating munge key on {result.failed_hosts}')
 

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -345,7 +345,8 @@ def log_result_data(log, data):
             log.debug("%s%s", " " * indent, line)
 
 
-def get_clush_command(hosts, args=None, command="", command_env=None, command_sudo=False):
+def get_clush_command(hosts, args=None, command="", command_env=None, command_sudo=False,
+                      timeout=None, fanout=None):
     """Get the clush command with optional sudo arguments.
 
     Args:
@@ -355,11 +356,21 @@ def get_clush_command(hosts, args=None, command="", command_env=None, command_su
         command_env (EnvironmentVariables, optional): environment variables to export with the
             command. Defaults to None.
         sudo (bool, optional): whether to run the command with sudo privileges. Defaults to False.
+        timeout (int, optional): number of seconds to wait for the command to complete.
+            Defaults to None.
+        fanout (int, optional): fanout to use. Default uses the max of the
+            clush default (64) or available cores
 
     Returns:
         str: the clush command
     """
+    if fanout is None:
+        fanout = max(64, len(os.sched_getaffinity(0)))
     cmd_list = ["clush"]
+    if timeout is not None:
+        cmd_list.extend(["-u", str(timeout)])
+    if fanout is not None:
+        cmd_list.extend(["-f", str(fanout)])
     if args:
         cmd_list.append(args)
     cmd_list.extend(["-w", str(hosts)])

--- a/src/tests/ftest/util/run_utils.py
+++ b/src/tests/ftest/util/run_utils.py
@@ -366,14 +366,11 @@ def get_clush_command(hosts, args=None, command="", command_env=None, command_su
     """
     if fanout is None:
         fanout = max(64, len(os.sched_getaffinity(0)))
-    cmd_list = ["clush"]
+    cmd_list = ["clush", "-f", str(fanout), "-w", str(hosts)]
     if timeout is not None:
         cmd_list.extend(["-u", str(timeout)])
-    if fanout is not None:
-        cmd_list.extend(["-f", str(fanout)])
     if args:
         cmd_list.append(args)
-    cmd_list.extend(["-w", str(hosts)])
     # If ever needed, this is how to disable host key checking:
     # cmd_list.extend(["-o", "-oStrictHostKeyChecking=no"])
     cmd_list.append(command_as_user(command, "root" if command_sudo else "", command_env))


### PR DESCRIPTION
Make timeout in get_clush_command per host instead of for all hosts.

Skip-unit-tests: true
Skip-fault-injection-test: true
Allow-unstable-test: true

Test-tag: soak_smoke DdbTest pr,vm

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
