### PR TITLE
DAOS-16469 engine: evenly dispatch out RPC load among XS

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -225,9 +225,10 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	}
 
 out:
-	D_DEBUG(DB_TRACE, "DTX req for opc %x (req %p future %p) got reply from %d/%d: "
-		"epoch :"DF_X64", result %d\n", dra->dra_opc, req, dra->dra_future,
-		drr->drr_rank, drr->drr_tag, din != NULL ? din->di_epoch : 0, rc);
+	DL_CDEBUG(rc < 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_TRACE, rc,
+		  "DTX req for opc %x (req %p future %p) got reply from %d/%d: "
+		  "epoch :"DF_X64, dra->dra_opc, req, dra->dra_future,
+		  drr->drr_rank, drr->drr_tag, din != NULL ? din->di_epoch : 0);
 
 	drr->drr_comp = 1;
 	drr->drr_result = rc;
@@ -347,7 +348,6 @@ dtx_req_wait(struct dtx_req_args *dra)
 
 struct dtx_common_args {
 	struct dss_chore	  dca_chore;
-	ABT_eventual		  dca_chore_eventual;
 	struct dtx_req_args	  dca_dra;
 	d_list_t		  dca_head;
 	struct btr_root		  dca_tree_root;
@@ -367,22 +367,15 @@ struct dtx_common_args {
 	int			  dca_i;
 };
 
-static int
-dtx_req_list_send(struct dtx_common_args *dca, bool is_reentrance)
+static enum dss_chore_status
+dtx_req_list_send(struct dss_chore *chore, bool is_reentrance)
 {
+	struct dtx_common_args	*dca = container_of(chore, struct dtx_common_args, dca_chore);
 	struct dtx_req_args	*dra = &dca->dca_dra;
-	int			 rc;
 
 	if (!is_reentrance) {
 		dra->dra_length = dca->dca_steps;
 		dca->dca_i = 0;
-
-		rc = ABT_future_create(dca->dca_steps, dtx_req_list_cb, &dra->dra_future);
-		if (rc != ABT_SUCCESS) {
-			D_ERROR("ABT_future_create failed for opc %x, len %d: rc %d.\n",
-				dra->dra_opc, dca->dca_steps, rc);
-			return dss_abterr2der(rc);
-		}
 
 		D_DEBUG(DB_TRACE, "%p: DTX req for opc %x, future %p (%d) start.\n",
 			&dca->dca_chore, dra->dra_opc, dra->dra_future, dca->dca_steps);
@@ -397,19 +390,14 @@ dtx_req_list_send(struct dtx_common_args *dca, bool is_reentrance)
 
 		if (unlikely(dra->dra_opc == DTX_COMMIT && dca->dca_i == 0 &&
 			     DAOS_FAIL_CHECK(DAOS_DTX_FAIL_COMMIT)))
-			rc = dtx_req_send(dca->dca_drr, 1);
+			dtx_req_send(dca->dca_drr, 1);
 		else
-			rc = dtx_req_send(dca->dca_drr, dca->dca_epoch);
-		if (rc != 0) {
-			/* If the first sub-RPC failed, then break, otherwise
-			 * other remote replicas may have already received the
-			 * RPC and executed it, so have to go ahead.
-			 */
-			if (dca->dca_i == 0) {
-				ABT_future_free(&dra->dra_future);
-				return rc;
-			}
-		}
+			dtx_req_send(dca->dca_drr, dca->dca_epoch);
+		/*
+		 * Do not care dtx_req_send result, itself or its cb func will set dra->dra_future.
+		 * Each RPC is independent from the others, let's go head to handle the other RPCs
+		 * and set dra->dra_future that will wakeup the RPC sponsor, see dtx_req_wait().
+		 */
 
 		/* dca->dca_drr maybe not points to a real entry if all RPCs have been sent. */
 		dca->dca_drr = d_list_entry(dca->dca_drr->drr_link.next,
@@ -419,10 +407,15 @@ dtx_req_list_send(struct dtx_common_args *dca, bool is_reentrance)
 			break;
 
 		/* Yield to avoid holding CPU for too long time. */
-		if (dca->dca_i % DTX_RPC_YIELD_THD == 0)
+		if (dca->dca_i % DTX_RPC_YIELD_THD == 0) {
+			dca->dca_chore.cho_load_comp = DTX_RPC_YIELD_THD;
+			dca->dca_chore.cho_load_left -= DTX_RPC_YIELD_THD;
 			return DSS_CHORE_YIELD;
+		}
 	}
 
+	chore->cho_load_comp = chore->cho_load_left;
+	chore->cho_load_left = 0;
 	return DSS_CHORE_DONE;
 }
 
@@ -607,28 +600,6 @@ out:
 	return rc > 0 ? 0 : rc;
 }
 
-static enum dss_chore_status
-dtx_rpc_helper(struct dss_chore *chore, bool is_reentrance)
-{
-	struct dtx_common_args	*dca = container_of(chore, struct dtx_common_args, dca_chore);
-	int			 rc;
-
-	rc = dtx_req_list_send(dca, is_reentrance);
-	if (rc == DSS_CHORE_YIELD)
-		return DSS_CHORE_YIELD;
-	if (rc == DSS_CHORE_DONE)
-		rc = 0;
-	if (rc != 0)
-		dca->dca_dra.dra_result = rc;
-	D_CDEBUG(rc < 0, DLOG_ERR, DB_TRACE, "%p: DTX RPC chore for %u done: %d\n", chore,
-		 dca->dca_dra.dra_opc, rc);
-	if (dca->dca_chore_eventual != ABT_EVENTUAL_NULL) {
-		rc = ABT_eventual_set(dca->dca_chore_eventual, NULL, 0);
-		D_ASSERTF(rc == ABT_SUCCESS, "ABT_eventual_set: %d\n", rc);
-	}
-	return DSS_CHORE_DONE;
-}
-
 static int
 dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes, uint32_t count,
 	int opc, daos_epoch_t epoch, d_list_t *cmt_list, d_list_t *abt_list, d_list_t *act_list,
@@ -644,7 +615,6 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 
 	memset(dca, 0, sizeof(*dca));
 
-	dca->dca_chore_eventual = ABT_EVENTUAL_NULL;
 	D_INIT_LIST_HEAD(&dca->dca_head);
 	dca->dca_tree_hdl = DAOS_HDL_INVAL;
 	dca->dca_epoch = epoch;
@@ -715,6 +685,7 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 	}
 
 	dca->dca_drr = d_list_entry(dca->dca_head.next, struct dtx_req_rec, drr_link);
+	dca->dca_chore.cho_cond_diy = 1;
 
 	/*
 	 * Do not send out the batched RPCs all together, instead, we do that step by step to
@@ -727,26 +698,19 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 		else
 			dca->dca_steps = length;
 
-		/* Use helper ULT to handle DTX RPC if there are enough helper XS. */
-		if (dss_has_enough_helper()) {
-			rc = ABT_eventual_create(0, &dca->dca_chore_eventual);
-			if (rc != ABT_SUCCESS) {
-				D_ERROR("failed to create eventual: %d\n", rc);
-				rc = dss_abterr2der(rc);
-				goto out;
-			}
+		rc = ABT_future_create(dca->dca_steps, dtx_req_list_cb, &dra->dra_future);
+		if (rc != ABT_SUCCESS) {
+			D_ERROR("ABT_future_create failed for opc %x, len %d: rc %d.\n",
+				dra->dra_opc, dca->dca_steps, rc);
+			return dss_abterr2der(rc);
+		}
 
-			rc = dss_chore_delegate(&dca->dca_chore, dtx_rpc_helper);
-			if (rc != 0)
-				goto out;
-
-			rc = ABT_eventual_wait(dca->dca_chore_eventual, NULL);
-			D_ASSERTF(rc == ABT_SUCCESS, "ABT_eventual_wait: %d\n", rc);
-
-			rc = ABT_eventual_free(&dca->dca_chore_eventual);
-			D_ASSERTF(rc == ABT_SUCCESS, "ABT_eventual_free: %d\n", rc);
-		} else {
-			dss_chore_diy(&dca->dca_chore, dtx_rpc_helper);
+		dca->dca_chore.cho_load_left = dca->dca_steps;
+		rc = dss_chore_delegate(&dca->dca_chore, dtx_req_list_send);
+		if (rc != 0) {
+			D_ERROR("Failed to create chore for dtx_rpc: " DF_RC "\n", DP_RC(rc));
+			ABT_future_free(&dra->dra_future);
+			goto out;
 		}
 
 		rc = dtx_req_wait(&dca->dca_dra);
@@ -1531,6 +1495,8 @@ dtx_coll_rpc_helper(struct dss_chore *chore, bool is_reentrance)
 	D_CDEBUG(rc < 0, DLOG_ERR, DB_TRACE,
 		 "Collective DTX helper chore for %u done: %d\n", dcra->dcra_opc, rc);
 
+	chore->cho_load_comp = chore->cho_load_left;
+	chore->cho_load_left = 0;
 	return DSS_CHORE_DONE;
 }
 
@@ -1556,11 +1522,12 @@ dtx_coll_rpc_prep(struct ds_cont_child *cont, struct dtx_coll_entry *dce, uint32
 		return dss_abterr2der(rc);
 	}
 
-	if (dss_has_enough_helper()) {
-		rc = dss_chore_delegate(&dcra->dcra_chore, dtx_coll_rpc_helper);
-	} else {
-		dss_chore_diy(&dcra->dcra_chore, dtx_coll_rpc_helper);
-		rc = 0;
+	dcra->dcra_chore.cho_cond_diy = 1;
+	dcra->dcra_chore.cho_load_left = 1;
+	rc = dss_chore_delegate(&dcra->dcra_chore, dtx_coll_rpc_helper);
+	if (rc != 0) {
+		D_ERROR("Failed to create chore for coll_rpc: " DF_RC "\n", DP_RC(rc));
+		ABT_future_free(&dcra->dcra_future);
 	}
 
 	return rc;
@@ -1571,11 +1538,13 @@ dtx_coll_rpc_post(struct dtx_coll_rpc_args *dcra, int ret)
 {
 	int	rc;
 
-	rc = ABT_future_wait(dcra->dcra_future);
-	D_CDEBUG(rc != ABT_SUCCESS, DLOG_ERR, DB_TRACE,
-		 "Collective DTX wait req for opc %u, future %p done, rc %d, result %d\n",
-		 dcra->dcra_opc, dcra->dcra_future, rc, dcra->dcra_result);
-	ABT_future_free(&dcra->dcra_future);
+	if (dcra->dcra_future != ABT_FUTURE_NULL) {
+		rc = ABT_future_wait(dcra->dcra_future);
+		D_CDEBUG(rc != ABT_SUCCESS, DLOG_ERR, DB_TRACE,
+			 "Collective DTX wait req for opc %u, future %p done, rc %d, result %d\n",
+			 dcra->dcra_opc, dcra->dcra_future, rc, dcra->dcra_result);
+		ABT_future_free(&dcra->dcra_future);
+	}
 
 	return ret != 0 ? ret : dcra->dcra_result;
 }
@@ -1595,7 +1564,17 @@ dtx_coll_commit(struct ds_cont_child *cont, struct dtx_coll_entry *dce, struct d
 	if (dce->dce_ranks != NULL)
 		rc = dtx_coll_rpc_prep(cont, dce, DTX_COLL_COMMIT, 0, &dcra);
 
+	/*
+	 * NOTE: Before committing the DTX on remote participants, we cannot remove the active
+	 *	 DTX locally; otherwise, the local committed DTX entry may be removed via DTX
+	 *	 aggregation before remote participants commit done. Under such case, if some
+	 *	 remote DTX participant triggere DTX_REFRESH for such DTX during the interval,
+	 *	 then it will get -DER_TX_UNCERTAIN, that may cause related application to be
+	 *	 failed. So here, we let remote participants to commit firstly, if failed, we
+	 *	 will ask the leader to retry the commit until all participants got committed.
+	 */
 	if (dce->dce_bitmap != NULL) {
+		clrbit(dce->dce_bitmap, dss_get_module_info()->dmi_tgt_id);
 		len = dtx_coll_local_exec(cont->sc_pool_uuid, cont->sc_uuid, &dce->dce_xid, 0,
 					  DTX_COLL_COMMIT, dce->dce_bitmap_sz, dce->dce_bitmap,
 					  &results);
@@ -1658,7 +1637,17 @@ dtx_coll_abort(struct ds_cont_child *cont, struct dtx_coll_entry *dce, daos_epoc
 	if (dce->dce_ranks != NULL)
 		rc = dtx_coll_rpc_prep(cont, dce, DTX_COLL_ABORT, epoch, &dcra);
 
+	/*
+	 * NOTE: The DTX abort maybe triggered by dtx_leader_end() for timeout on some DTX
+	 *	 participant(s). Under such case, the client side RPC sponsor may also hit
+	 *	 the RPC timeout and resends related RPC to the leader. Here, to avoid DTX
+	 *	 abort and resend RPC forwarding being executed in parallel, we will abort
+	 *	 local DTX after remote done, before that the logic of handling resent RPC
+	 *	 on server will find the local pinned DTX entry then notify related client
+	 *	 to resend sometime later.
+	 */
 	if (dce->dce_bitmap != NULL) {
+		clrbit(dce->dce_bitmap, dss_get_module_info()->dmi_tgt_id);
 		len = dtx_coll_local_exec(cont->sc_pool_uuid, cont->sc_uuid, &dce->dce_xid, epoch,
 					  DTX_COLL_ABORT, dce->dce_bitmap_sz, dce->dce_bitmap,
 					  &results);

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -76,6 +76,7 @@ struct dss_chore_queue {
 	ABT_mutex  chq_mutex;
 	ABT_cond   chq_cond;
 	ABT_thread chq_ult;
+	uint64_t   chq_load;
 };
 
 /** Per-xstream configuration data */

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -751,6 +751,12 @@ typedef enum dss_chore_status (*dss_chore_func_t)(struct dss_chore *chore, bool 
 struct dss_chore {
 	d_list_t              cho_link;
 	enum dss_chore_status cho_status;
+	uint32_t	      cho_load_left;
+	/* The completed sub_tasks since the latest schedule. */
+	uint32_t	      cho_load_comp;
+	/* Execute the task by current ULT itself if without enough helper resource. */
+	uint32_t	      cho_cond_diy:1,
+			      cho_for_io:1;
 	dss_chore_func_t      cho_func;
 };
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2667,6 +2667,11 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 	struct ec_agg_param	 *ec_agg_param = agg_param->ap_data;
 	vos_iter_param_t	 iter_param = { 0 };
 	struct vos_iter_anchors  anchors = { 0 };
+	struct dtx_handle	*dth = NULL;
+	struct dtx_share_peer	*dsp;
+	struct dtx_id		 dti = { 0 };
+	struct dtx_epoch	 epoch = { 0 };
+	daos_unit_oid_t		 oid = { 0 };
 	int			 rc = 0;
 	int                       blocks       = 0;
 
@@ -2715,8 +2720,25 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 	agg_reset_entry(&ec_agg_param->ap_agg_entry, NULL, NULL);
 
 retry:
+	epoch.oe_value = epr->epr_hi;
+	rc = dtx_begin(cont->sc_hdl, &dti, &epoch, 0, cont->sc_pool->spc_map_version, &oid,
+		       NULL, 0, 0, NULL, &dth);
+	if (rc != 0)
+		goto update_hae;
+
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors, agg_iterate_pre_cb,
-			 agg_iterate_post_cb, ec_agg_param, NULL);
+			 agg_iterate_post_cb, ec_agg_param, dth);
+	if (rc == -DER_INPROGRESS && !d_list_empty(&dth->dth_share_tbd_list)) {
+		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
+					       struct dtx_share_peer, dsp_link)) != NULL) {
+			D_ERROR(DF_CONT ": EC aggregate hit non-committed DTX " DF_DTI "\n",
+				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+				DP_DTI(&dsp->dsp_xid));
+			dtx_dsp_free(dsp);
+		}
+	}
+
+	dtx_end(dth, cont, rc);
 
 	/* Post_cb may not being executed in some cases */
 	agg_clear_extents(&ec_agg_param->ap_agg_entry);


### PR DESCRIPTION
When choose helper from the shared helper XS pool for forward IO RPC or dispatch DTX RPC, if there are multiple candidates, then randomly choosing one without consider existing RPC load may cause unbalanced load among the helpers.

On the other hand, when forward IO RPCs, if the chosen helper XS has too much workload but current main IO XS is relative idel, then will directly use current XS to forward IO RPCs.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
