### PR TITLE
DAOS-16469 engine: evenly dispatch out RPC load among XS - b26

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -2150,8 +2150,11 @@ dtx_leader_exec_ops_chore(struct dss_chore *chore, bool is_reentrance)
 		}
 
 		/* Yield to avoid holding CPU for too long time. */
-		if (++(dtx_chore->k) % DTX_RPC_YIELD_THD == 0)
+		if (++(dtx_chore->k) % DTX_RPC_YIELD_THD == 0) {
+			chore->cho_load_comp = DTX_RPC_YIELD_THD;
+			chore->cho_load_left -= DTX_RPC_YIELD_THD;
 			return DSS_CHORE_YIELD;
+		}
 	}
 
 	if (rc != 0) {
@@ -2174,6 +2177,8 @@ dtx_leader_exec_ops_chore(struct dss_chore *chore, bool is_reentrance)
 		  dlh->dlh_forward_idx, dlh->dlh_forward_idx + dlh->dlh_forward_cnt,
 		  dlh->dlh_normal_sub_done == 1 ? "yes" : "no", rc);
 
+	chore->cho_load_comp = chore->cho_load_left;
+	chore->cho_load_left = 0;
 	return DSS_CHORE_DONE;
 }
 
@@ -2210,6 +2215,8 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 			dlh->dlh_need_agg = 1;
 	}
 
+	dtx_chore.chore.cho_for_io = 1;
+
 	if (dlh->dlh_normal_sub_cnt == 0)
 		goto exec;
 
@@ -2227,6 +2234,7 @@ again:
 		D_GOTO(out, rc = dss_abterr2der(rc));
 	}
 
+	dtx_chore.chore.cho_load_left = dlh->dlh_forward_cnt;
 	rc = dss_chore_delegate(&dtx_chore.chore, dtx_leader_exec_ops_chore);
 	if (rc != 0) {
 		DL_ERROR(rc, "chore create failed [%u, %u] (2)", dlh->dlh_forward_idx,
@@ -2306,6 +2314,7 @@ exec:
 	/* The ones without DELAY flag will be skipped when scan the targets array. */
 	dlh->dlh_forward_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
 
+	dtx_chore.chore.cho_load_left = dlh->dlh_forward_cnt;
 	rc = dss_chore_delegate(&dtx_chore.chore, dtx_leader_exec_ops_chore);
 	if (rc != 0) {
 		DL_ERROR(rc, "chore create failed (4)");

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -76,6 +76,7 @@ struct dss_chore_queue {
 	ABT_mutex  chq_mutex;
 	ABT_cond   chq_cond;
 	ABT_thread chq_ult;
+	uint64_t   chq_load;
 };
 
 /** Per-xstream configuration data */

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -401,7 +401,7 @@ check:
 /* ============== ULT create functions =================================== */
 
 static inline int
-sched_ult2xs(int xs_type, int tgt_id)
+sched_ult2xs(int xs_type, int tgt_id, int *hint)
 {
 	uint32_t	xs_id;
 
@@ -422,8 +422,10 @@ sched_ult2xs(int xs_type, int tgt_id)
 		if (!dss_helper_pool) {
 			if (dss_tgt_offload_xs_nr > 0)
 				xs_id = DSS_MAIN_XS_ID(tgt_id) + 1;
-			else
+			else if (dss_forward_neighbor)
 				xs_id = DSS_MAIN_XS_ID((tgt_id + 1) % dss_tgt_nr);
+			else
+				return DSS_XS_SELF;
 			break;
 		}
 
@@ -450,30 +452,36 @@ sched_ult2xs(int xs_type, int tgt_id)
 		 * ask neighbor to do IO forwarding seems is helpful to make
 		 * them concurrent, right?
 		 */
-		if (dss_tgt_offload_xs_nr > 0)
+		D_ASSERT(dss_tgt_offload_xs_nr > 0);
+
+		if (hint != NULL) {
+			*hint = (*hint + 1) % min(dss_tgt_nr, dss_tgt_offload_xs_nr);
+			xs_id = dss_sys_xs_nr + dss_tgt_nr + *hint;
+		} else {
 			xs_id = dss_sys_xs_nr + dss_tgt_nr +
 				rand() % min(dss_tgt_nr, dss_tgt_offload_xs_nr);
-		else
-			xs_id = (DSS_MAIN_XS_ID(tgt_id) + 1) % dss_tgt_nr;
+		}
 		break;
 	case DSS_XS_OFFLOAD:
 		if (dss_numa_nr > 1)
-			xs_id = sched_ult2xs_multisocket(xs_type, tgt_id);
+			return sched_ult2xs_multisocket(xs_type, tgt_id);
 		if (!dss_helper_pool) {
 			if (dss_tgt_offload_xs_nr > 0)
 				xs_id = DSS_MAIN_XS_ID(tgt_id) + dss_tgt_offload_xs_nr / dss_tgt_nr;
-			else
+			else if (dss_forward_neighbor)
 				xs_id = DSS_MAIN_XS_ID((tgt_id + 1) % dss_tgt_nr);
+			else
+				return DSS_XS_SELF;
 			break;
 		}
+
+		D_ASSERT(dss_tgt_offload_xs_nr > 0);
 
 		if (dss_tgt_offload_xs_nr > dss_tgt_nr)
 			xs_id = dss_sys_xs_nr + 2 * dss_tgt_nr +
 				(tgt_id % (dss_tgt_offload_xs_nr - dss_tgt_nr));
-		else if (dss_tgt_offload_xs_nr > 0)
-			xs_id = dss_sys_xs_nr + dss_tgt_nr + tgt_id % dss_tgt_offload_xs_nr;
 		else
-			xs_id = (DSS_MAIN_XS_ID(tgt_id) + 1) % dss_tgt_nr;
+			xs_id = dss_sys_xs_nr + dss_tgt_nr + tgt_id % dss_tgt_offload_xs_nr;
 		break;
 	case DSS_XS_VOS:
 		xs_id = DSS_MAIN_XS_ID(tgt_id);
@@ -495,7 +503,7 @@ ult_create_internal(void (*func)(void *), void *arg, int xs_type, int tgt_idx,
 	int			 rc, rc1;
 	int			 stream_id;
 
-	stream_id = sched_ult2xs(xs_type, tgt_idx);
+	stream_id = sched_ult2xs(xs_type, tgt_idx, NULL);
 	if (stream_id == -DER_INVAL)
 		return stream_id;
 
@@ -704,14 +712,6 @@ reenter:
 	}
 }
 
-static void
-dss_chore_ult(void *arg)
-{
-	struct dss_chore *chore = arg;
-
-	dss_chore_diy_internal(chore);
-}
-
 /**
  * Add \a chore for \a func to the chore queue of some other xstream.
  *
@@ -723,8 +723,12 @@ dss_chore_ult(void *arg)
 int
 dss_chore_delegate(struct dss_chore *chore, dss_chore_func_t func)
 {
+	static __thread int	hint = -1;
 	struct dss_module_info *info = dss_get_module_info();
 	int                     xs_id;
+	int			tmp_id;
+	uint32_t		load;
+	struct dss_xstream     *tmp_dx;
 	struct dss_xstream     *dx;
 	struct dss_chore_queue *queue;
 
@@ -736,25 +740,75 @@ dss_chore_delegate(struct dss_chore *chore, dss_chore_func_t func)
 	 * a "main" xstream when the chore queue is long. So we fall back to
 	 * the one-ULT-per-chore approach if there's no helper xstream.
 	 */
-	if (dss_tgt_offload_xs_nr == 0) {
-		D_INIT_LIST_HEAD(&chore->cho_link);
-		return dss_ult_create(dss_chore_ult, chore, DSS_XS_IOFW, info->dmi_tgt_id,
-				      0 /* stack_size */, NULL /* ult */);
+	if (dss_tgt_offload_xs_nr == 0 && chore->cho_cond_diy) {
+		dss_chore_diy(chore, func);
+		return 0;
 	}
 
 	/* Find the chore queue. */
-	xs_id = sched_ult2xs(DSS_XS_IOFW, info->dmi_tgt_id);
+	xs_id = sched_ult2xs(DSS_XS_IOFW, info->dmi_tgt_id, &hint);
 	D_ASSERT(xs_id != -DER_INVAL);
 	dx = dss_get_xstream(xs_id);
 	D_ASSERT(dx != NULL);
 	queue = &dx->dx_chore_queue;
 	D_ASSERT(queue != NULL);
 
+	/*
+	 * We do not guarantee strict load balance among helper XS, instead, just roughly
+	 * estimate the RPC load without holding the lock against related dx_chore_queue.
+	 *
+	 * To be efficient, only compare current helper and next helper, and elect the one
+	 * with less RPC load. The next dss_chore_delegate() will compare the next and the
+	 * next after next. So if there are a lot of chore tasks, then the RPC load can be
+	 * relative balanced.
+	 */
+	if (queue->chq_load > 0 && dss_numa_nr <= 1 && dss_helper_pool &&
+	    dss_tgt_offload_xs_nr > 1) {
+		tmp_id = dss_sys_xs_nr + dss_tgt_nr +
+			      (hint + 1) % min(dss_tgt_nr, dss_tgt_offload_xs_nr);
+		tmp_dx = dss_get_xstream(tmp_id);
+		D_ASSERT(tmp_dx != NULL);
+
+		if (tmp_dx->dx_chore_queue.chq_load < queue->chq_load) {
+			xs_id = tmp_id;
+			dx = tmp_dx;
+			queue = &tmp_dx->dx_chore_queue;
+			hint = xs_id - dss_sys_xs_nr - dss_tgt_nr;
+		}
+	}
+
+	if (chore->cho_for_io && xs_id != info->dmi_xs_id) {
+		/* If the helper or neighbor has too much workload, then diy. */
+		tmp_dx = dss_get_xstream(DSS_XS_SELF);
+
+		if (dss_tgt_offload_xs_nr > 0) {
+			if (tmp_dx->dx_chore_queue.chq_load != 0)
+				load = tmp_dx->dx_chore_queue.chq_load;
+			else
+				load = chore->cho_load_left;
+
+			if (queue->chq_load / load > dss_tgt_nr / dss_tgt_offload_xs_nr) {
+				xs_id = info->dmi_xs_id;
+				dx = tmp_dx;
+				queue = &tmp_dx->dx_chore_queue;
+			}
+		} else {
+			if ((queue->chq_load != 0) &&
+			    (queue->chq_load + chore->cho_load_left >
+			     tmp_dx->dx_chore_queue.chq_load)) {
+				xs_id = info->dmi_xs_id;
+				dx = tmp_dx;
+				queue = &tmp_dx->dx_chore_queue;
+			}
+		}
+	}
+
 	ABT_mutex_lock(queue->chq_mutex);
 	if (queue->chq_stop) {
 		ABT_mutex_unlock(queue->chq_mutex);
 		return -DER_CANCELED;
 	}
+	queue->chq_load += chore->cho_load_left;
 	d_list_add_tail(&chore->cho_link, &queue->chq_list);
 	ABT_cond_broadcast(queue->chq_cond);
 	ABT_mutex_unlock(queue->chq_mutex);
@@ -824,6 +878,7 @@ dss_chore_queue_ult(void *arg)
 
 		d_list_for_each_entry_safe(chore, chore_tmp, &list, cho_link) {
 			enum dss_chore_status status;
+			uint32_t load_left = chore->cho_load_left;
 
 			/*
 			 * CAUTION: When cho_func returns DSS_CHORE_DONE, chore
@@ -834,10 +889,12 @@ dss_chore_queue_ult(void *arg)
 			status = chore->cho_func(chore, chore->cho_status == DSS_CHORE_YIELD);
 			D_DEBUG(DB_TRACE, "%p: after: status=%d\n", chore, status);
 			if (status == DSS_CHORE_YIELD) {
+				queue->chq_load -= chore->cho_load_comp;
 				chore->cho_status = status;
 				d_list_add_tail(&chore->cho_link, &list_tmp);
 			} else {
 				D_ASSERTF(status == DSS_CHORE_DONE, "status=%d\n", status);
+				queue->chq_load -= load_left;
 			}
 			ABT_thread_yield();
 		}

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -778,6 +778,12 @@ typedef enum dss_chore_status (*dss_chore_func_t)(struct dss_chore *chore, bool 
 struct dss_chore {
 	d_list_t              cho_link;
 	enum dss_chore_status cho_status;
+	uint32_t	      cho_load_left;
+	/* The completed sub_tasks since the latest schedule. */
+	uint32_t	      cho_load_comp;
+	/* Execute the task by itself if without enough helper resource. */
+	uint32_t	      cho_cond_diy:1,
+			      cho_for_io:1;
 	dss_chore_func_t      cho_func;
 };
 

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2667,6 +2667,11 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 	struct ec_agg_param	 *ec_agg_param = agg_param->ap_data;
 	vos_iter_param_t	 iter_param = { 0 };
 	struct vos_iter_anchors  anchors = { 0 };
+	struct dtx_handle	*dth = NULL;
+	struct dtx_share_peer	*dsp;
+	struct dtx_id		 dti = { 0 };
+	struct dtx_epoch	 epoch = { 0 };
+	daos_unit_oid_t		 oid = { 0 };
 	int			 rc = 0;
 	int                       blocks       = 0;
 
@@ -2715,8 +2720,25 @@ cont_ec_aggregate_cb(struct ds_cont_child *cont, daos_epoch_range_t *epr,
 	agg_reset_entry(&ec_agg_param->ap_agg_entry, NULL, NULL);
 
 retry:
+	epoch.oe_value = epr->epr_hi;
+	rc = dtx_begin(cont->sc_hdl, &dti, &epoch, 0, cont->sc_pool->spc_map_version, &oid,
+		       NULL, 0, 0, NULL, &dth);
+	if (rc != 0)
+		goto update_hae;
+
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors, agg_iterate_pre_cb,
-			 agg_iterate_post_cb, ec_agg_param, NULL);
+			 agg_iterate_post_cb, ec_agg_param, dth);
+	if (rc == -DER_INPROGRESS && !d_list_empty(&dth->dth_share_tbd_list)) {
+		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
+					       struct dtx_share_peer, dsp_link)) != NULL) {
+			D_ERROR(DF_CONT ": EC aggregate hit non-committed DTX " DF_DTI "\n",
+				DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+				DP_DTI(&dsp->dsp_xid));
+			dtx_dsp_free(dsp);
+		}
+	}
+
+	dtx_end(dth, cont, rc);
 
 	/* Post_cb may not being executed in some cases */
 	agg_clear_extents(&ec_agg_param->ap_agg_entry);


### PR DESCRIPTION
When choose helper from the shared helper XS pool for forward IO RPC or dispatch DTX RPC, if there are multiple candidates, then randomly choosing one without consider existing RPC load may cause unbalanced load among the helpers.

On the other hand, when forward IO RPCs, if the chosen helper XS has too much workload but current main IO XS is relative idel, then will directly use current XS to forward IO RPCs.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
