### PR TITLE
DAOS-16570 control: Remove non-server dependency on libpci

### DIFF
--- a/src/control/lib/hardware/hwprov/defaults.go
+++ b/src/control/lib/hardware/hwprov/defaults.go
@@ -10,7 +10,6 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/lib/hardware/cart"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
-	"github.com/daos-stack/daos/src/control/lib/hardware/pciutils"
 	"github.com/daos-stack/daos/src/control/lib/hardware/sysfs"
 	"github.com/daos-stack/daos/src/control/logging"
 )
@@ -74,9 +73,4 @@ func DefaultNetDevStateProvider(log logging.Logger) hardware.NetDevStateProvider
 // DefaultIOMMUDetector gets the default provider for the IOMMU detector.
 func DefaultIOMMUDetector(log logging.Logger) hardware.IOMMUDetector {
 	return sysfs.NewProvider(log)
-}
-
-// DefaultPCIeLinkStatsProvider gets the default provider for retrieving PCIe link stats.
-func DefaultPCIeLinkStatsProvider() hardware.PCIeLinkStatsProvider {
-	return pciutils.NewPCIeLinkStatsProvider()
 }

--- a/src/control/server/instance_storage_rpc.go
+++ b/src/control/server/instance_storage_rpc.go
@@ -23,7 +23,7 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/pciutils"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -332,7 +332,7 @@ func scanEngineBdevsOverDrpc(ctx context.Context, engine Engine, pbReq *ctlpb.Sc
 				RdbSize:  pbReq.RdbSize,
 			}
 			upd, err := populateCtrlrHealth(ctx, engine, bhReq, c,
-				hwprov.DefaultPCIeLinkStatsProvider())
+				pciutils.NewPCIeLinkStatsProvider())
 			if err != nil {
 				return nil, err
 			}
@@ -512,7 +512,7 @@ func smdQueryEngine(ctx context.Context, engine Engine, pbReq *ctlpb.SmdQueryReq
 		if pbReq.IncludeBioHealth {
 			bhReq := &ctlpb.BioHealthReq{DevUuid: dev.Uuid}
 			if _, err := populateCtrlrHealth(ctx, engine, bhReq, dev.Ctrlr,
-				hwprov.DefaultPCIeLinkStatsProvider()); err != nil {
+				pciutils.NewPCIeLinkStatsProvider()); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Commit 21450930f4 added a new pciutils package that provides
bindings for the library so that the server can interrogate
PCI device status. The work also included a change to the
hwprov package that forces all users of hwprov to pull in
libpci, even though only the server needs it. This commit
changes the server to pull in the pciutils package directly
and removes the dependency from other users of hwprov.

Required-githooks: true
Change-Id: Iec155fe4b6f16ddad421226200617ecd5700aa76
Signed-off-by: Michael MacDonald <mjmac@google.com>
