### PR TITLE
DAOS-16570 control: Break up hwprov package

### DIFF
--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -22,7 +22,7 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/cache"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/network"
 	"github.com/daos-stack/daos/src/control/lib/telemetry"
 	"github.com/daos-stack/daos/src/control/logging"
 )
@@ -43,10 +43,10 @@ func NewInfoCache(ctx context.Context, log logging.Logger, client control.UnaryI
 		client:          client,
 		cache:           cache.NewItemCache(log),
 		getAttachInfoCb: control.GetAttachInfo,
-		fabricScan:      getFabricScanFn(log, cfg, hwprov.DefaultFabricScanner(log)),
+		fabricScan:      getFabricScanFn(log, cfg, network.DefaultFabricScanner(log)),
 		netIfaces:       net.Interfaces,
-		devClassGetter:  hwprov.DefaultNetDevClassProvider(log),
-		devStateGetter:  hwprov.DefaultNetDevStateProvider(log),
+		devClassGetter:  network.DefaultNetDevClassProvider(log),
+		devStateGetter:  network.DefaultNetDevStateProvider(log),
 	}
 
 	ic.clientTelemetryEnabled.Store(cfg.TelemetryEnabled)

--- a/src/control/cmd/daos_agent/main.go
+++ b/src/control/cmd/daos_agent/main.go
@@ -21,26 +21,25 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/atm"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
 type cliOptions struct {
-	AllowProxy    bool                   `long:"allow-proxy" description:"Allow proxy configuration via environment"`
-	Debug         bool                   `short:"d" long:"debug" description:"Enable debug output"`
-	JSON          bool                   `short:"j" long:"json" description:"Enable JSON output"`
-	JSONLogs      bool                   `short:"J" long:"json-logging" description:"Enable JSON-formatted log output"`
-	ConfigPath    string                 `short:"o" long:"config-path" description:"Path to agent configuration file"`
-	Insecure      bool                   `short:"i" long:"insecure" description:"have agent attempt to connect without certificates"`
-	RuntimeDir    string                 `short:"s" long:"runtime_dir" description:"Path to agent communications socket"`
-	LogFile       string                 `short:"l" long:"logfile" description:"Full path and filename for daos agent log file"`
-	Start         startCmd               `command:"start" description:"Start daos_agent daemon (default behavior)"`
-	Version       versionCmd             `command:"version" description:"Print daos_agent version"`
-	ServerVersion serverVersionCmd       `command:"server-version" description:"Print daos_server version"`
-	DumpInfo      dumpAttachInfoCmd      `command:"dump-attachinfo" description:"Dump system attachinfo"`
-	DumpTopo      hwprov.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
-	NetScan       netScanCmd             `command:"net-scan" description:"Perform local network fabric scan"`
-	Support       supportCmd             `command:"support" description:"Perform debug tasks to help support team"`
+	AllowProxy    bool                    `long:"allow-proxy" description:"Allow proxy configuration via environment"`
+	Debug         bool                    `short:"d" long:"debug" description:"Enable debug output"`
+	JSON          bool                    `short:"j" long:"json" description:"Enable JSON output"`
+	JSONLogs      bool                    `short:"J" long:"json-logging" description:"Enable JSON-formatted log output"`
+	ConfigPath    string                  `short:"o" long:"config-path" description:"Path to agent configuration file"`
+	Insecure      bool                    `short:"i" long:"insecure" description:"have agent attempt to connect without certificates"`
+	RuntimeDir    string                  `short:"s" long:"runtime_dir" description:"Path to agent communications socket"`
+	LogFile       string                  `short:"l" long:"logfile" description:"Full path and filename for daos agent log file"`
+	Start         startCmd                `command:"start" description:"Start daos_agent daemon (default behavior)"`
+	Version       versionCmd              `command:"version" description:"Print daos_agent version"`
+	ServerVersion serverVersionCmd        `command:"server-version" description:"Print daos_server version"`
+	DumpInfo      dumpAttachInfoCmd       `command:"dump-attachinfo" description:"Dump system attachinfo"`
+	DumpTopo      cmdutil.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
+	NetScan       netScanCmd              `command:"net-scan" description:"Perform local network fabric scan"`
+	Support       supportCmd              `command:"support" description:"Perform debug tasks to help support team"`
 }
 
 type (
@@ -178,7 +177,7 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, log *lo
 		}
 
 		switch cmd.(type) {
-		case *versionCmd, *netScanCmd, *hwprov.DumpTopologyCmd:
+		case *versionCmd, *netScanCmd, *cmdutil.DumpTopologyCmd:
 			// these commands don't need the rest of the setup
 			return cmd.Execute(args)
 		}

--- a/src/control/cmd/daos_agent/network.go
+++ b/src/control/cmd/daos_agent/network.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -14,7 +14,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/network"
 )
 
 type netScanCmd struct {
@@ -29,7 +29,7 @@ func (cmd *netScanCmd) Execute(_ []string) error {
 		prov = cmd.FabricProvider
 	}
 
-	fabricScanner := hwprov.DefaultFabricScanner(cmd.Logger)
+	fabricScanner := network.DefaultFabricScanner(cmd.Logger)
 
 	results, err := fabricScanner.Scan(cmd.MustLogCtx(), prov)
 	if err != nil {

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -20,8 +20,8 @@ import (
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/atm"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/lib/systemd"
 	"github.com/daos-stack/daos/src/control/lib/telemetry/promexp"
 )
@@ -116,7 +116,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 		sys:           cmd.cfg.SystemName,
 		ctlInvoker:    cmd.ctlInvoker,
 		cache:         cache,
-		numaGetter:    hwprov.DefaultProcessNUMAProvider(cmd.Logger),
+		numaGetter:    topology.DefaultProcessNUMAProvider(cmd.Logger),
 		monitor:       procmon,
 		providerIdx:   cmd.cfg.ProviderIdx,
 		cliMetricsSrc: clientMetricSource,

--- a/src/control/cmd/daos_server/auto.go
+++ b/src/control/cmd/daos_server/auto.go
@@ -17,7 +17,8 @@ import (
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	"github.com/daos-stack/daos/src/control/lib/control"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/network"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
 )
@@ -38,12 +39,12 @@ type configGenCmd struct {
 type getFabricFn func(context.Context, logging.Logger, string) (*control.HostFabric, error)
 
 func getLocalFabric(ctx context.Context, log logging.Logger, provider string) (*control.HostFabric, error) {
-	hf, err := GetLocalFabricIfaces(ctx, hwprov.DefaultFabricScanner(log).Scan, provider)
+	hf, err := GetLocalFabricIfaces(ctx, network.DefaultFabricScanner(log).Scan, provider)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching local fabric interfaces")
 	}
 
-	topo, err := hwprov.DefaultTopologyProvider(log).GetTopology(ctx)
+	topo, err := topology.DefaultProvider(log).GetTopology(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching local hardware topology")
 	}

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/atm"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
 )
@@ -48,15 +47,15 @@ type mainOpts struct {
 	Syslog  bool `long:"syslog" description:"Enable logging to syslog"`
 
 	// Define subcommands
-	SCM      scmStorageCmd          `command:"scm" description:"Perform tasks related to locally-attached SCM storage"`
-	NVMe     nvmeStorageCmd         `command:"nvme" description:"Perform tasks related to locally-attached NVMe storage"`
-	Start    startCmd               `command:"start" description:"Start daos_server"`
-	Network  networkCmd             `command:"network" description:"Perform network device scan based on fabric provider"`
-	Version  versionCmd             `command:"version" description:"Print daos_server version"`
-	MgmtSvc  msCmdRoot              `command:"ms" description:"Perform tasks related to management service replicas"`
-	DumpTopo hwprov.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
-	Support  supportCmd             `command:"support" description:"Perform debug tasks to help support team"`
-	Config   configCmd              `command:"config" alias:"cfg" description:"Perform tasks related to configuration of hardware on the local server"`
+	SCM      scmStorageCmd           `command:"scm" description:"Perform tasks related to locally-attached SCM storage"`
+	NVMe     nvmeStorageCmd          `command:"nvme" description:"Perform tasks related to locally-attached NVMe storage"`
+	Start    startCmd                `command:"start" description:"Start daos_server"`
+	Network  networkCmd              `command:"network" description:"Perform network device scan based on fabric provider"`
+	Version  versionCmd              `command:"version" description:"Print daos_server version"`
+	MgmtSvc  msCmdRoot               `command:"ms" description:"Perform tasks related to management service replicas"`
+	DumpTopo cmdutil.DumpTopologyCmd `command:"dump-topology" description:"Dump system topology"`
+	Support  supportCmd              `command:"support" description:"Perform debug tasks to help support team"`
+	Config   configCmd               `command:"config" alias:"cfg" description:"Perform tasks related to configuration of hardware on the local server"`
 
 	// Allow a set of tests to be run before executing commands.
 	preExecTests []execTestFn

--- a/src/control/cmd/daos_server/network.go
+++ b/src/control/cmd/daos_server/network.go
@@ -16,7 +16,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/network"
 	"github.com/daos-stack/daos/src/control/server/config"
 )
 
@@ -32,7 +32,7 @@ func initNetworkCmd(cmd *networkScanCmd) (fabricScanFn, *config.Server, error) {
 		return nil, nil, err
 	}
 
-	return hwprov.DefaultFabricScanner(cmd.Logger).Scan, cmd.config, nil
+	return network.DefaultFabricScanner(cmd.Logger).Scan, cmd.config, nil
 }
 
 type networkCmd struct {

--- a/src/control/cmd/daos_server/storage_utils.go
+++ b/src/control/cmd/daos_server/storage_utils.go
@@ -14,7 +14,8 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/network"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
 	"github.com/daos-stack/daos/src/control/server"
@@ -108,7 +109,7 @@ func initNvmeCmd(cmd *nvmeCmd) (*server.StorageControlService, *config.Server, e
 		return nil, nil, err
 	}
 
-	cmd.setIOMMUChecker(hwprov.DefaultIOMMUDetector(cmd.Logger).IsIOMMUEnabled)
+	cmd.setIOMMUChecker(topology.DefaultIOMMUDetector(cmd.Logger).IsIOMMUEnabled)
 
 	scs, err := storageCmdInit(&cmd.baseScanCmd)
 	if err != nil {
@@ -155,7 +156,7 @@ func genFiAffFn(fis *hardware.FabricInterfaceSet) config.EngineAffinityFn {
 }
 
 func getAffinitySource(ctx context.Context, log logging.Logger, cfg *config.Server) (config.EngineAffinityFn, error) {
-	scanner := hwprov.DefaultFabricScanner(log)
+	scanner := network.DefaultFabricScanner(log)
 
 	provs, err := cfg.Fabric.GetProviders()
 	if err != nil {

--- a/src/control/common/cmdutil/topology.go
+++ b/src/control/common/cmdutil/topology.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-package hwprov
+package cmdutil
 
 import (
 	"context"
@@ -12,15 +12,15 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/common/cmdutil"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
 )
 
 // DumpTopologyCmd implements a go-flags Commander that dumps
 // the system topology to stdout or to a file.
 type DumpTopologyCmd struct {
-	cmdutil.JSONOutputCmd
-	cmdutil.LogCmd
+	JSONOutputCmd
+	LogCmd
 	Output string `short:"o" long:"output" default:"stdout" description:"Dump output to this location"`
 }
 
@@ -35,7 +35,7 @@ func (cmd *DumpTopologyCmd) Execute(_ []string) error {
 		out = f
 	}
 
-	hwProv := DefaultTopologyProvider(cmd.Logger)
+	hwProv := topology.DefaultProvider(cmd.Logger)
 	topo, err := hwProv.GetTopology(context.Background())
 	if err != nil {
 		return err

--- a/src/control/lib/hardware/defaults/network/defaults.go
+++ b/src/control/lib/hardware/defaults/network/defaults.go
@@ -4,35 +4,21 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-package hwprov
+// Package network provides constructors for cross-package composable hardware providers
+// related to networking.
+package network
+
+// NB: Carefully consider whether adding a new package dependency is necessary, as it
+// forces all users of this package to import it regardless of whether or not they
+// use the new dependency.
 
 import (
 	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/lib/hardware/cart"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
-	"github.com/daos-stack/daos/src/control/lib/hardware/pciutils"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
 	"github.com/daos-stack/daos/src/control/lib/hardware/sysfs"
 	"github.com/daos-stack/daos/src/control/logging"
 )
-
-// DefaultTopologyProvider gets the default hardware topology provider.
-func DefaultTopologyProvider(log logging.Logger) hardware.TopologyProvider {
-	return hardware.NewTopologyFactory(
-		&hardware.WeightedTopologyProvider{
-			Provider: hwloc.NewProvider(log),
-			Weight:   100,
-		},
-		&hardware.WeightedTopologyProvider{
-			Provider: sysfs.NewProvider(log),
-			Weight:   90,
-		},
-	)
-}
-
-// DefaultProcessNUMAProvider gets the default provider for process-related NUMA info.
-func DefaultProcessNUMAProvider(log logging.Logger) hardware.ProcessNUMAProvider {
-	return hwloc.NewProvider(log)
-}
 
 // DefaultFabricInterfaceProviders returns the default fabric interface providers.
 func DefaultFabricInterfaceProviders(log logging.Logger) []hardware.FabricInterfaceProvider {
@@ -50,7 +36,7 @@ func DefaultNetDevClassProvider(log logging.Logger) hardware.NetDevClassProvider
 // DefaultFabricScannerConfig gets a default FabricScanner configuration.
 func DefaultFabricScannerConfig(log logging.Logger) *hardware.FabricScannerConfig {
 	return &hardware.FabricScannerConfig{
-		TopologyProvider:         DefaultTopologyProvider(log),
+		TopologyProvider:         topology.DefaultProvider(log),
 		FabricInterfaceProviders: DefaultFabricInterfaceProviders(log),
 		NetDevClassProvider:      DefaultNetDevClassProvider(log),
 	}
@@ -69,14 +55,4 @@ func DefaultFabricScanner(log logging.Logger) *hardware.FabricScanner {
 // DefaultNetDevStateProvider gets the default provider for getting the fabric interface state.
 func DefaultNetDevStateProvider(log logging.Logger) hardware.NetDevStateProvider {
 	return sysfs.NewProvider(log)
-}
-
-// DefaultIOMMUDetector gets the default provider for the IOMMU detector.
-func DefaultIOMMUDetector(log logging.Logger) hardware.IOMMUDetector {
-	return sysfs.NewProvider(log)
-}
-
-// DefaultPCIeLinkStatsProvider gets the default provider for retrieving PCIe link stats.
-func DefaultPCIeLinkStatsProvider() hardware.PCIeLinkStatsProvider {
-	return pciutils.NewPCIeLinkStatsProvider()
 }

--- a/src/control/lib/hardware/defaults/network/defaults_test.go
+++ b/src/control/lib/hardware/defaults/network/defaults_test.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
-package hwprov
+package network_test
 
 import (
 	"testing"
@@ -15,53 +15,14 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
 	"github.com/daos-stack/daos/src/control/lib/hardware/cart"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/network"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
 	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
 	"github.com/daos-stack/daos/src/control/lib/hardware/sysfs"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-func TestHwprov_DefaultTopologyProvider(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer test.ShowBufferOnFailure(t, buf)
-
-	expResult := hardware.NewTopologyFactory(
-		&hardware.WeightedTopologyProvider{
-			Provider: hwloc.NewProvider(log),
-			Weight:   100,
-		},
-		&hardware.WeightedTopologyProvider{
-			Provider: sysfs.NewProvider(log),
-			Weight:   90,
-		},
-	)
-
-	result := DefaultTopologyProvider(log)
-
-	if diff := cmp.Diff(expResult, result,
-		cmp.AllowUnexported(hardware.TopologyFactory{}),
-		cmpopts.IgnoreUnexported(hwloc.Provider{}),
-		cmpopts.IgnoreUnexported(sysfs.Provider{}),
-	); diff != "" {
-		t.Fatalf("(-want, +got)\n%s\n", diff)
-	}
-}
-
-func TestHwprov_DefaultProcessNUMAProvider(t *testing.T) {
-	log, buf := logging.NewTestLogger(t.Name())
-	defer test.ShowBufferOnFailure(t, buf)
-
-	expResult := hwloc.NewProvider(log)
-
-	result := DefaultProcessNUMAProvider(log)
-
-	if diff := cmp.Diff(expResult, result,
-		cmpopts.IgnoreUnexported(hwloc.Provider{}),
-	); diff != "" {
-		t.Fatalf("(-want, +got)\n%s\n", diff)
-	}
-}
-
-func TestHwprov_DefaultFabricInterfaceProviders(t *testing.T) {
+func TestFabric_DefaultFabricInterfaceProviders(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
@@ -70,7 +31,7 @@ func TestHwprov_DefaultFabricInterfaceProviders(t *testing.T) {
 		sysfs.NewProvider(log),
 	}
 
-	result := DefaultFabricInterfaceProviders(log)
+	result := network.DefaultFabricInterfaceProviders(log)
 
 	if diff := cmp.Diff(expResult, result,
 		cmpopts.IgnoreUnexported(cart.Provider{}),
@@ -81,13 +42,13 @@ func TestHwprov_DefaultFabricInterfaceProviders(t *testing.T) {
 
 }
 
-func TestHwprov_DefaultNetDevClassProvider(t *testing.T) {
+func TestFabric_DefaultNetDevClassProvider(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
 	expResult := sysfs.NewProvider(log)
 
-	result := DefaultNetDevClassProvider(log)
+	result := network.DefaultNetDevClassProvider(log)
 
 	if diff := cmp.Diff(expResult, result,
 		cmpopts.IgnoreUnexported(sysfs.Provider{}),
@@ -96,17 +57,17 @@ func TestHwprov_DefaultNetDevClassProvider(t *testing.T) {
 	}
 }
 
-func TestHwprov_DefaultFabricScannerConfig(t *testing.T) {
+func TestFabric_DefaultFabricScannerConfig(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
 	expResult := &hardware.FabricScannerConfig{
-		TopologyProvider:         DefaultTopologyProvider(log),
-		FabricInterfaceProviders: DefaultFabricInterfaceProviders(log),
-		NetDevClassProvider:      DefaultNetDevClassProvider(log),
+		TopologyProvider:         topology.DefaultProvider(log),
+		FabricInterfaceProviders: network.DefaultFabricInterfaceProviders(log),
+		NetDevClassProvider:      network.DefaultNetDevClassProvider(log),
 	}
 
-	result := DefaultFabricScannerConfig(log)
+	result := network.DefaultFabricScannerConfig(log)
 
 	if diff := cmp.Diff(expResult, result,
 		cmpopts.IgnoreUnexported(
@@ -121,20 +82,20 @@ func TestHwprov_DefaultFabricScannerConfig(t *testing.T) {
 	}
 }
 
-func TestHwprov_DefaultFabricScanner(t *testing.T) {
+func TestFabric_DefaultFabricScanner(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
 	expResult, err := hardware.NewFabricScanner(log, &hardware.FabricScannerConfig{
-		TopologyProvider:         DefaultTopologyProvider(log),
-		FabricInterfaceProviders: DefaultFabricInterfaceProviders(log),
-		NetDevClassProvider:      DefaultNetDevClassProvider(log),
+		TopologyProvider:         topology.DefaultProvider(log),
+		FabricInterfaceProviders: network.DefaultFabricInterfaceProviders(log),
+		NetDevClassProvider:      network.DefaultNetDevClassProvider(log),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result := DefaultFabricScanner(log)
+	result := network.DefaultFabricScanner(log)
 
 	if diff := cmp.Diff(expResult, result,
 		cmp.AllowUnexported(
@@ -153,11 +114,11 @@ func TestHwprov_DefaultFabricScanner(t *testing.T) {
 	}
 }
 
-func TestHwprov_DefaultNetDevStateProvider(t *testing.T) {
+func TestFabric_DefaultNetDevStateProvider(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer test.ShowBufferOnFailure(t, buf)
 
-	result := DefaultNetDevStateProvider(log)
+	result := network.DefaultNetDevStateProvider(log)
 
 	if diff := cmp.Diff(sysfs.NewProvider(log), result,
 		cmpopts.IgnoreUnexported(sysfs.Provider{}),

--- a/src/control/lib/hardware/defaults/topology/defaults.go
+++ b/src/control/lib/hardware/defaults/topology/defaults.go
@@ -1,0 +1,44 @@
+//
+// (C) Copyright 2021-2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+// Package topology provides constructors for cross-package composable hardware providers
+// related to topology discovery and interrogation.
+package topology
+
+// NB: Carefully consider whether adding a new package dependency is necessary, as it
+// forces all users of this package to import it regardless of whether or not they
+// use the new dependency.
+
+import (
+	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
+	"github.com/daos-stack/daos/src/control/lib/hardware/sysfs"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+// DefaultProvider gets the default hardware topology provider.
+func DefaultProvider(log logging.Logger) hardware.TopologyProvider {
+	return hardware.NewTopologyFactory(
+		&hardware.WeightedTopologyProvider{
+			Provider: hwloc.NewProvider(log),
+			Weight:   100,
+		},
+		&hardware.WeightedTopologyProvider{
+			Provider: sysfs.NewProvider(log),
+			Weight:   90,
+		},
+	)
+}
+
+// DefaultProcessNUMAProvider gets the default provider for process-related NUMA info.
+func DefaultProcessNUMAProvider(log logging.Logger) hardware.ProcessNUMAProvider {
+	return hwloc.NewProvider(log)
+}
+
+// DefaultIOMMUDetector gets the default provider for the IOMMU detector.
+func DefaultIOMMUDetector(log logging.Logger) hardware.IOMMUDetector {
+	return sysfs.NewProvider(log)
+}

--- a/src/control/lib/hardware/defaults/topology/defaults_test.go
+++ b/src/control/lib/hardware/defaults/topology/defaults_test.go
@@ -1,0 +1,62 @@
+//
+// (C) Copyright 2021-2024 Intel Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+package topology_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/hardware"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
+	"github.com/daos-stack/daos/src/control/lib/hardware/hwloc"
+	"github.com/daos-stack/daos/src/control/lib/hardware/sysfs"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+func TestTopology_DefaultProvider(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	expResult := hardware.NewTopologyFactory(
+		&hardware.WeightedTopologyProvider{
+			Provider: hwloc.NewProvider(log),
+			Weight:   100,
+		},
+		&hardware.WeightedTopologyProvider{
+			Provider: sysfs.NewProvider(log),
+			Weight:   90,
+		},
+	)
+
+	result := topology.DefaultProvider(log)
+
+	if diff := cmp.Diff(expResult, result,
+		cmp.AllowUnexported(hardware.TopologyFactory{}),
+		cmpopts.IgnoreUnexported(hwloc.Provider{}),
+		cmpopts.IgnoreUnexported(sysfs.Provider{}),
+	); diff != "" {
+		t.Fatalf("(-want, +got)\n%s\n", diff)
+	}
+}
+
+func TestTopology_DefaultProcessNUMAProvider(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer test.ShowBufferOnFailure(t, buf)
+
+	expResult := hwloc.NewProvider(log)
+
+	result := topology.DefaultProcessNUMAProvider(log)
+
+	if diff := cmp.Diff(expResult, result,
+		cmpopts.IgnoreUnexported(hwloc.Provider{}),
+	); diff != "" {
+		t.Fatalf("(-want, +got)\n%s\n", diff)
+	}
+}

--- a/src/control/lib/support/log.go
+++ b/src/control/lib/support/log.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
 )
@@ -961,7 +961,7 @@ func collectDaosServerCmd(log logging.Logger, opts ...CollectLogsParams) error {
 		}
 	case "dump-topology":
 		hwlog := logging.NewCommandLineLogger()
-		hwProv := hwprov.DefaultTopologyProvider(hwlog)
+		hwProv := topology.DefaultProvider(hwlog)
 		topo, err := hwProv.GetTopology(context.Background())
 		if err != nil {
 			return err

--- a/src/control/server/ctl_network_rpc.go
+++ b/src/control/server/ctl_network_rpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -13,7 +13,7 @@ import (
 
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
 )
 
 // FabricScan performs a scan of fabric interfaces given a list of providers.
@@ -35,7 +35,7 @@ func (cs *ControlService) NetworkScan(ctx context.Context, req *ctlpb.NetworkSca
 		providers = []string{req.GetProvider()}
 	}
 
-	topo, err := hwprov.DefaultTopologyProvider(cs.log).GetTopology(ctx)
+	topo, err := topology.DefaultProvider(cs.log).GetTopology(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/instance_storage_rpc.go
+++ b/src/control/server/instance_storage_rpc.go
@@ -23,7 +23,7 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/pciutils"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -332,7 +332,7 @@ func scanEngineBdevsOverDrpc(ctx context.Context, engine Engine, pbReq *ctlpb.Sc
 				RdbSize:  pbReq.RdbSize,
 			}
 			upd, err := populateCtrlrHealth(ctx, engine, bhReq, c,
-				hwprov.DefaultPCIeLinkStatsProvider())
+				pciutils.NewPCIeLinkStatsProvider())
 			if err != nil {
 				return nil, err
 			}
@@ -512,7 +512,7 @@ func smdQueryEngine(ctx context.Context, engine Engine, pbReq *ctlpb.SmdQueryReq
 		if pbReq.IncludeBioHealth {
 			bhReq := &ctlpb.BioHealthReq{DevUuid: dev.Uuid}
 			if _, err := populateCtrlrHealth(ctx, engine, bhReq, dev.Ctrlr,
-				hwprov.DefaultPCIeLinkStatsProvider()); err != nil {
+				pciutils.NewPCIeLinkStatsProvider()); err != nil {
 				return nil, err
 			}
 		}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -28,7 +28,8 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/hardware"
-	"github.com/daos-stack/daos/src/control/lib/hardware/hwprov"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/network"
+	"github.com/daos-stack/daos/src/control/lib/hardware/defaults/topology"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/config"
@@ -237,7 +238,7 @@ func (srv *server) createServices(ctx context.Context) (err error) {
 	srv.evtLogger = control.NewEventLogger(srv.log)
 
 	srv.ctlSvc = NewControlService(srv.log, srv.harness, srv.cfg, srv.pubSub,
-		hwprov.DefaultFabricScanner(srv.log))
+		network.DefaultFabricScanner(srv.log))
 	srv.mgmtSvc = newMgmtSvc(srv.harness, srv.membership, srv.sysdb, rpcClient, srv.pubSub)
 
 	if err := srv.mgmtSvc.systemProps.UpdateCompPropVal(daos.SystemPropertyDaosSystem, func() string {
@@ -340,7 +341,7 @@ func (srv *server) addEngines(ctx context.Context) error {
 	var allStarted sync.WaitGroup
 	registerTelemetryCallbacks(ctx, srv)
 
-	iommuEnabled, err := hwprov.DefaultIOMMUDetector(srv.log).IsIOMMUEnabled()
+	iommuEnabled, err := topology.DefaultIOMMUDetector(srv.log).IsIOMMUEnabled()
 	if err != nil {
 		return err
 	}
@@ -541,7 +542,7 @@ func waitFabricReady(ctx context.Context, log logging.Logger, cfg *config.Server
 	}
 
 	if err := hardware.WaitFabricReady(ctx, log, hardware.WaitFabricReadyParams{
-		StateProvider:  hwprov.DefaultNetDevStateProvider(log),
+		StateProvider:  network.DefaultNetDevStateProvider(log),
 		FabricIfaces:   ifaces,
 		IterationSleep: time.Second,
 	}); err != nil {
@@ -580,7 +581,7 @@ func Start(log logging.Logger, cfg *config.Server) error {
 		return err
 	}
 
-	scanner := hwprov.DefaultFabricScanner(log)
+	scanner := network.DefaultFabricScanner(log)
 
 	fis, err := scanner.Scan(ctx, providers...)
 	if err != nil {


### PR DESCRIPTION
The hwprov package was created to provide default
constructors for users of the hardware packages and
to avoid import cycles.

This commit refactors the monolithic hwprov package
into smaller packages that encourage better separation
of concerns and reduces the possibility that a user
of one package will inadvertently pull in unnecessary
dependencies required for another package.

Required-githooks: true
Change-Id: Ib55576a8dda9e679c117cc204eeb1ee31314944a
Signed-off-by: Michael MacDonald <mjmac@google.com>
