### PR TITLE
DAOS-16292 control: Allow optional pool UUID for Create API

### DIFF
--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -136,10 +136,17 @@ func (pcr *PoolCreateReq) MarshalJSON() ([]byte, error) {
 
 	type toJSON PoolCreateReq
 	return json.Marshal(struct {
+		UUID       string                 `json:"uuid,omitempty"`
 		Properties []*mgmtpb.PoolProperty `json:"properties"`
 		ACL        []string               `json:"acl"`
 		*toJSON
 	}{
+		UUID: func() string {
+			if pcr.UUID == uuid.Nil {
+				return ""
+			}
+			return pcr.UUID.String()
+		}(),
 		Properties: props,
 		ACL:        acl,
 		toJSON:     (*toJSON)(pcr),
@@ -199,6 +206,7 @@ type (
 	// PoolCreateReq contains the parameters for a pool create request.
 	PoolCreateReq struct {
 		poolRequest
+		UUID       uuid.UUID            `json:"uuid,omitempty"` // Optional UUID; auto-generate if not supplied
 		User       string               `json:"user"`
 		UserGroup  string               `json:"user_group"`
 		ACL        *AccessControlList   `json:"-"`
@@ -299,7 +307,9 @@ func poolCreateGenPBReq(ctx context.Context, rpcClient UnaryInvoker, in *PoolCre
 		return
 	}
 
-	out.Uuid = uuid.New().String()
+	if out.Uuid == "" {
+		out.Uuid = uuid.New().String()
+	}
 	return
 }
 


### PR DESCRIPTION
In some API use cases, the PoolCreate RPC may be invoked
by different processes. Allowing the same pool UUID to be
supplied as part of the create makes the operation
idempotent in these scenarios. This commit does not
change the dmg UI.

Required-githooks: true
Change-Id: I41f0dbbe80f36d4baf56c25d3f9f04063468b56d
Signed-off-by: Michael MacDonald <mjmac@google.com>
