### PR TITLE
DAOS-16585 tests: Fix NLT handling of __fxstat detection

### DIFF
--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -30,7 +30,7 @@ pkgs="argobots                         \
       pmix                             \
       protobuf-c                       \
       spdk-devel                       \
-      strace                           \  
+      strace                           \
       valgrind-devel"
 
 # output with trailing newline suppressed

--- a/ci/unit/required_packages.sh
+++ b/ci/unit/required_packages.sh
@@ -30,6 +30,7 @@ pkgs="argobots                         \
       pmix                             \
       protobuf-c                       \
       spdk-devel                       \
+      strace                           \  
       valgrind-devel"
 
 # output with trailing newline suppressed

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -6328,15 +6328,15 @@ def server_fi(args):
 
 
 def look_for_library_call(conf, cmd, library_str):
+    # pylint: disable=wrong-spelling-in-comment
     """Look for library_str in the strace call stack of running cmd."""
-    tmpfile = tempfile.NamedTemporaryFile(mode='r',
-                                          prefix='dnt_assess_',
-                                          suffix='.strace',
-                                          dir=conf.tmp_dir)
-    strace_cmd = ['strace', '--stack-traces', '-v', '-o', tmpfile.name] + cmd
-    subprocess.run(strace_cmd, check=True)
-    lines = tmpfile.readlines()
-    tmpfile.close()
+    with tempfile.NamedTemporaryFile(mode='r',
+                                     prefix='dnt_assess_',
+                                     suffix='.strace',
+                                     dir=conf.tmp_dir) as tmpfile:
+        strace_cmd = ['strace', '--stack-traces', '-v', '-o', tmpfile.name] + cmd
+        subprocess.run(strace_cmd, check=True)
+        lines = tmpfile.readlines()
     for line in lines:
         if re.search(library_str, line):
             return True

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1521,8 +1521,8 @@ class DFuse():
         print(f'Logged il to {log_name}')
         print(ret)
 
-        if self.caching:
-            check_fstat = False
+        check_fstat = check_fstat and not self.caching and \
+            look_for_library_call(self.conf, cmd, '__fxstat')
 
         try:
             log_test(self.conf, log_name, check_read=check_read, check_write=check_write,
@@ -6325,6 +6325,23 @@ def server_fi(args):
         # Turn off fault injection again to assist in server shutdown.
         server.set_fi(probability=0)
         server.set_fi(probability=0)
+
+
+def look_for_library_call(conf, cmd, library_str):
+    """Look for library_str in the strace call stack of running cmd."""
+    tmpfile = tempfile.NamedTemporaryFile(mode='r',
+                                          prefix='dnt_assess_',
+                                          suffix='.strace',
+                                          dir=conf.tmp_dir)
+    strace_cmd = ['strace', '--stack-traces', '-v', '-o', tmpfile.name] + cmd
+    subprocess.run(strace_cmd, check=True)
+    lines = tmpfile.readlines()
+    tmpfile.close()
+    for line in lines:
+        if re.search(library_str, line):
+            return True
+
+    return False
 
 
 def run(wf, args):

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -6328,7 +6328,7 @@ def server_fi(args):
 
 
 def look_for_library_call(conf, cmd, library_str):
-    # pylint: disable=wrong-spelling-in-comment
+    # pylint: disable=wrong-spelling-in-docstring
     """Look for library_str in the strace call stack of running cmd."""
     with tempfile.NamedTemporaryFile(mode='r',
                                      prefix='dnt_assess_',

--- a/utils/scripts/install-el8.sh
+++ b/utils/scripts/install-el8.sh
@@ -60,6 +60,7 @@ dnf --nodocs install \
     python3-devel \
     python3-pip \
     sg3_utils \
+    strace \
     sudo \
     systemd \
     valgrind-devel \

--- a/utils/scripts/install-el9.sh
+++ b/utils/scripts/install-el9.sh
@@ -59,6 +59,7 @@ dnf --nodocs install \
     python3-devel \
     python3-pip \
     sg3_utils \
+    strace \
     sudo \
     valgrind-devel \
     which \

--- a/utils/scripts/install-leap15.sh
+++ b/utils/scripts/install-leap15.sh
@@ -57,6 +57,7 @@ dnf --nodocs install \
     python3-devel \
     scons \
     sg3_utils \
+    strace \
     sudo \
     valgrind-devel \
     which \

--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -14,6 +14,13 @@ set -e
 
 arch=$(uname -i)
 
+# hack to install 24.04's golang-go on 22.04:
+apt-get install -y software-properties-common
+add-apt-repository "deb http://archive.ubuntu.com/ubuntu noble main"
+apt-get update
+apt-get install -y golang-go
+add-apt-repository -r "deb http://archive.ubuntu.com/ubuntu noble main"
+
 apt-get install \
     autoconf \
     build-essential \

--- a/utils/scripts/install-ubuntu.sh
+++ b/utils/scripts/install-ubuntu.sh
@@ -52,6 +52,7 @@ apt-get install \
     pkg-config \
     python3-dev \
     python3-venv \
+    strace \
     uuid-dev \
     valgrind \
     yasm


### PR DESCRIPTION
Use strace to determine whether calls to __fxstat actually happen when using a utility/command the IL is being tested on, and stop treating it as an error to not see __fxstat when it's not used.


Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
