### PR TITLE
DAOS-16585 tests: Improve NLT checking of ioil metrics.

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -359,8 +359,10 @@ ioil_init(void)
 static void
 ioil_show_summary()
 {
-	D_INFO("Performed %"PRIu64" reads and %"PRIu64" writes from %"PRIu64" files\n",
-	       ioil_iog.iog_read_count, ioil_iog.iog_write_count, ioil_iog.iog_file_count);
+	D_INFO("Performed %" PRIu64 " reads, %" PRIu64 " writes and %" PRIu64
+	       " fstats from %" PRIu64 " files\n",
+	       ioil_iog.iog_read_count, ioil_iog.iog_write_count, ioil_iog.iog_fstat_count,
+	       ioil_iog.iog_file_count);
 
 	if (ioil_iog.iog_file_count == 0 || !ioil_iog.iog_show_summary)
 		return;


### PR DESCRIPTION
Use the ioil statistics to verify read/write counts rather
than just checking for function name.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
