### PR TITLE
DAOS-16585 tests: Improve NLT checking of ioil metrics.

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -359,8 +359,10 @@ ioil_init(void)
 static void
 ioil_show_summary()
 {
-	D_INFO("Performed %"PRIu64" reads and %"PRIu64" writes from %"PRIu64" files\n",
-	       ioil_iog.iog_read_count, ioil_iog.iog_write_count, ioil_iog.iog_file_count);
+	D_INFO("Performed %" PRIu64 " reads, %" PRIu64 " writes and %" PRIu64
+	       " fstats from %" PRIu64 " files\n",
+	       ioil_iog.iog_read_count, ioil_iog.iog_write_count, ioil_iog.iog_fstat_count,
+	       ioil_iog.iog_file_count);
 
 	if (ioil_iog.iog_file_count == 0 || !ioil_iog.iog_show_summary)
 		return;

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1531,19 +1531,9 @@ class DFuse():
         if self.conf.args.client_debug:
             my_env['D_LOG_MASK'] = self.conf.args.client_debug
 
-        if check_fstat:
-            fsu = self.check_usage()['statistics']
-
         ret = subprocess.run(cmd, env=my_env, check=False)
         print(f'Logged il to {log_name}')
         print(ret)
-
-        if check_fstat:
-            fsu2 = self.check_usage()['statistics']
-            print(fsu)
-            print(fsu2)
-            delta = fsu2.get('getattr', 0) - fsu.get('getattr', 0)
-            print(f"Command caused {delta} stat calls")
 
         try:
             log_test(self.conf, log_name, check_read=check_read, check_write=check_write,
@@ -1574,7 +1564,7 @@ class DFuse():
             cmd.extend(['--inode', str(ino)])
         rc = run_daos_cmd(self.conf, cmd, use_json=True)
         print(rc)
-        assert rc.returncode == 0
+        assert rc.returncode == 0, rc
 
         if inodes:
             assert rc.json['response']['inodes'] == inodes, rc


### PR DESCRIPTION
Use the ioil statistics to verify read/write counts rather
than just checking for function name.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
