### PR TITLE
DAOS-16629 build: Allow separate test builds

### DIFF
--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -504,19 +504,25 @@ class PreReqComponent():
         self._build_targets = []
 
         build_dir = self.__env['BUILD_DIR']
-        targets = ['test', 'server', 'client']
+        main_targets = ['client', 'server']
+        targets = ['test'] + main_targets
         self.__env.Alias('client', build_dir)
         self.__env.Alias('server', build_dir)
         self.__env.Alias('test', build_dir)
         self._build_targets = []
         check = any(item in BUILD_TARGETS for item in targets)
-        if not check or 'test' in BUILD_TARGETS:
+        if not check:
             self._build_targets.extend(['client', 'server', 'test'])
         else:
             if 'client' in BUILD_TARGETS:
                 self._build_targets.append('client')
             if 'server' in BUILD_TARGETS:
                 self._build_targets.append('server')
+            if 'test' in BUILD_TARGETS:
+                if not any(item in BUILD_TARGETS for item in main_targets):
+                    print("test target requires client or server")
+                    sys.exit(1)
+                self._build_targets.append('test')
         BUILD_TARGETS.append(build_dir)
 
         env.AddMethod(self.require, 'require')

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -11,7 +11,7 @@ def build_dts_library(env, dc_credit):
     denv.d_static_library('dts', [dc_credit, 'dts.c'])
 
 
-def build_tests(env):
+def build_tests(env, prereqs):
     """build the tests"""
     Import('libdaos_tgts', 'cmd_parser')
     denv = env.Clone()
@@ -65,7 +65,8 @@ def build_tests(env):
     SConscript('drpc/SConscript')
 
     # Build security_test
-    SConscript('security/SConscript')
+    if prereqs.server_requested():
+        SConscript('security/SConscript')
 
     # ftest
     SConscript('ftest/SConscript')
@@ -100,7 +101,7 @@ def scons():
     # Add runtime paths for daos libraries
     denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
     denv.AppendUnique(CPPPATH=[Dir('../mgmt').srcnode()])
-    build_tests(denv)
+    build_tests(denv, prereqs)
 
     if not base_env_mpi:
         return


### PR DESCRIPTION
Client and server tests require different packages. Separate test target so it doesn't imply client or server.  It requires one or the other but this
allows building just client or server tests.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
