### PR TITLE
DAOS-16633 common: SEGV in heap_mbrt_incrmb_usage()

### DIFF
--- a/src/common/dav_v2/heap.c
+++ b/src/common/dav_v2/heap.c
@@ -1644,21 +1644,15 @@ heap_create_evictable_mb(struct palloc_heap *heap, uint32_t *mb_id)
 	/* ignore zone and chunk headers */
 	VALGRIND_ADD_TO_GLOBAL_TX_IGNORE(z, sizeof(z->header) + sizeof(z->chunk_headers));
 
-	rc = lw_tx_begin(heap->p_ops.base);
-	if (rc)
-		return -1;
-
 	heap_zone_init(heap, zone_id, 0, true);
 	rc = heap_mbrt_mb_reclaim_garbage(heap, zone_id);
 	if (rc) {
 		heap_mbrt_cleanup_mb(mb);
 		heap->rt->evictable_mbs[zone_id] = NULL;
 		heap->rt->zones_exhausted--;
-		lw_tx_end(heap->p_ops.base, NULL);
 		return -1;
 	}
 	heap_zinfo_set(heap, zone_id, true, true);
-	lw_tx_end(heap->p_ops.base, NULL);
 
 	*mb_id = zone_id;
 	return 0;

--- a/src/common/dav_v2/tx.c
+++ b/src/common/dav_v2/tx.c
@@ -1854,9 +1854,13 @@ dav_allot_mb_evictable_v2(dav_obj_t *pop, int flags)
 	D_ASSERT(flags == 0);
 	D_ASSERT((dav_tx_stage_v2() == DAV_TX_STAGE_NONE));
 
+	err = lw_tx_begin(pop);
+	if (err)
+		return 0;
 	err = heap_get_evictable_mb(pop->do_heap, &mb_id);
+	lw_tx_end(pop, NULL);
 	if (err) {
-		errno = err;
+		D_ERROR("failed to get evictable mb, error = %d", err);
 		return 0;
 	}
 


### PR DESCRIPTION
Multiple ULTs calling dav_allot_mb_evictable_v2() at the same time was causing incorrect update of active evictable mb and mb->qptr. This was due to heap_create_evictable_mb() yielding as part of lw_tx_end() call. The new fix ensures that call to heap_get_evictable_mb() is serialized between multiple ULTs.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
