### PR TITLE
SRE-2509 common: do not skip tests on empty commits

### DIFF
--- a/ci/doc_only_change.sh
+++ b/ci/doc_only_change.sh
@@ -25,5 +25,9 @@ if ! merge_base="$(git merge-base "FETCH_HEAD" HEAD)"; then
     # nothing to do here except exit as if it's not a doc-only change
     exit 0
 fi
+if ! git diff --no-commit-id --name-only "$merge_base" HEAD | grep -q -e ".*"; then
+    echo "No changes detected, full validation is expected"
+    exit 0
+fi
 git diff --no-commit-id --name-only "$merge_base" HEAD | \
-  grep -v -e "^docs/" -e "\.md$"
+  grep -v -e "^docs/" -e "\.md$" -e "^.*LICENSE.*$"


### PR DESCRIPTION
ci/doc_only_change.sh shall not return 1 if it detects no changes since the last execution (or reference branch).

"Doc-only: false" is no longer needed to fix this problem

Additionally, the `LICENSE` file is treated as documentation.

See: https://github.com/daos-stack/pipeline-lib/pull/446

Signeed-off-by: Tomasz Gromadzki <tomasz.gromadzki@intel.com>

Required-githooks: true


### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
