### PR TITLE
DAOS-16647 object: encoding parity for single parity object rebuild

### DIFF
--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1174,9 +1174,8 @@ out:
 }
 
 static int
-migrate_fetch_update_parity_per_iod(struct migrate_one *mrone, daos_handle_t oh,
-				    daos_iod_t *iods, daos_epoch_t **ephs, int iod_nr,
-				    struct ds_cont_child *ds_cont)
+migrate_fetch_update_parity_per_iod(struct migrate_one *mrone, daos_handle_t oh, daos_iod_t *iods,
+				    daos_epoch_t **ephs, int iod_nr, struct ds_cont_child *ds_cont)
 {
 	int i;
 	int j;
@@ -1185,8 +1184,8 @@ migrate_fetch_update_parity_per_iod(struct migrate_one *mrone, daos_handle_t oh,
 	/* If it is parity recxs from another replica, then let's encode it anyway */
 	for (i = 0; i < iod_nr; i++) {
 		for (j = 0; j < iods[i].iod_nr; j++) {
-			daos_iod_t iod = iods[i];
-			daos_epoch_t fetch_eph;
+			daos_iod_t    iod = iods[i];
+			daos_epoch_t  fetch_eph;
 			daos_epoch_t *update_eph_p;
 
 			iod.iod_nr = 1;
@@ -1244,10 +1243,9 @@ migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
 			 * shard in this case, because the other parity may not encode as well, only
 			 * encode the single parity may confuse the EC aggregation process.
 			 */
-			rc = __migrate_fetch_update_parity(mrone, oh, mrone->mo_iods,
-							   mrone->mo_epoch,
-							   mrone->mo_iods_update_ephs,
-							   mrone->mo_iod_num, ds_cont, false);
+			rc = __migrate_fetch_update_parity(
+			     mrone, oh, mrone->mo_iods, mrone->mo_epoch, mrone->mo_iods_update_ephs,
+			     mrone->mo_iod_num, ds_cont, false);
 		} else {
 			rc = migrate_fetch_update_parity_per_iod(mrone, oh, mrone->mo_iods,
 								 mrone->mo_iods_update_ephs,


### PR DESCRIPTION
If there is only single parity, then let's encode the parity during rebuild.

If there are more than one parity shards, then

1 If rebuild enumerate can get other parity recxs from the other parity shard, then encode the parity during rebuild.

2. Otherwise, let's do replication for parity rebuild, and rely on the EC aggregation to encode, since the other parity only have replica recxs, encoding within rebuild might confuse EC aggregation process.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
