### PR TITLE
DAOS-623 build: mercury remove mr match

### DIFF
--- a/mercury_remove_mr_match.patch
+++ b/mercury_remove_mr_match.patch
@@ -1,0 +1,25 @@
+diff --git a/src/na/na_ofi.c b/src/na/na_ofi.c
+index c833dc1..17fd842 100644
+--- a/src/na/na_ofi.c
++++ b/src/na/na_ofi.c
+@@ -4363,20 +4363,6 @@ na_ofi_cxi_set_domain_ops(struct na_ofi_domain *na_ofi_domain)
+         return NA_SUCCESS;
+     }
+ 
+-    /* Prevent potential memory corruption by ensuring that memory backing MRs
+-     * cannot be accessed after invoking fi_close() even if that memory remains
+-     * in the MR cache. */
+-    rc = dom_ops->enable_mr_match_events(&na_ofi_domain->fi_domain->fid, true);
+-    NA_CHECK_SUBSYS_ERROR(cls, rc != 0, error, ret, na_ofi_errno_to_na(-rc),
+-        "enable_mr_match_events() failed, rc: %d (%s)", rc, fi_strerror(-rc));
+-
+-    /* Disable use of optimized MRs to prevent quick recycle of MR keys (when
+-     * using FI_MR_PROV_KEY). This prevents potential memory corruptions when
+-     * multiple regions could end up using the same key. */
+-    rc = dom_ops->enable_optimized_mrs(&na_ofi_domain->fi_domain->fid, false);
+-    NA_CHECK_SUBSYS_ERROR(cls, rc != 0, error, ret, na_ofi_errno_to_na(-rc),
+-        "enable_optimized_mrs() failed, rc: %d (%s)", rc, fi_strerror(-rc));
+-
+     return NA_SUCCESS;
+ 
+ error:

--- a/utils/build.config
+++ b/utils/build.config
@@ -29,4 +29,4 @@ ucx=https://github.com/openucx/ucx.git
 spdk=https://github.com/spdk/spdk/commit/b0aba3fcd5aceceea530a702922153bc75664978.diff,https://github.com/spdk/spdk/commit/445a4c808badbad3942696ecf16fa60e8129a747.diff
 ofi=https://github.com/ofiwg/libfabric/commit/d827c6484cc5bf67dfbe395890e258860c3f0979.diff
 fuse=https://github.com/libfuse/libfuse/commit/c9905341ea34ff9acbc11b3c53ba8bcea35eeed8.diff
-mercury=https://raw.githubusercontent.com/daos-stack/mercury/f3dc286fb40ec1a3a38a2e17c45497bc2aa6290d/na_ucx.patch
+mercury=https://raw.githubusercontent.com/daos-stack/mercury/f3dc286fb40ec1a3a38a2e17c45497bc2aa6290d/na_ucx.patch,https://raw.githubusercontent.com/daos-stack/daos/refs/heads/dbohning/daos-623-disable-mr-match/mercury_remove_mr_match.patch


### PR DESCRIPTION
Skip-build: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
