### PR TITLE
DAOS-16658 client: Change daos_reinit to skip if daos not running.

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -370,6 +370,9 @@ daos_reinit(void)
 {
 	int rc;
 
+	if (module_initialized == 0)
+		return 0;
+
 	rc = daos_eq_lib_reset_after_fork();
 	if (rc)
 		return rc;


### PR DESCRIPTION
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
