### PR TITLE
DAOS-15776 test: remove DataMoverTestBase.create_pool (#15079)

### DIFF
--- a/src/tests/ftest/datamover/copy_procs.py
+++ b/src/tests/ftest/datamover/copy_procs.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -46,7 +46,7 @@ class DmvrCopyProcs(DataMoverTestBase):
         :avocado: tags=DmvrCopyProcs,test_copy_procs
         """
         # Create pool and containers
-        pool1 = self.create_pool()
+        pool1 = self.get_pool()
         cont1 = self.get_container(pool1)
         cont2 = self.get_container(pool1)
 

--- a/src/tests/ftest/datamover/dst_create.py
+++ b/src/tests/ftest/datamover/dst_create.py
@@ -58,8 +58,7 @@ class DmvrDstCreate(DataMoverTestBase):
         self.set_api(api)
 
         # Create 1 pool
-        pool1 = self.create_pool()
-        pool1.connect(2)
+        pool1 = self.get_pool()
 
         # Create a source cont
         cont1 = self.get_container(pool1, type=cont_type)
@@ -98,8 +97,7 @@ class DmvrDstCreate(DataMoverTestBase):
         self.verify_cont(cont3, api, check_props, src_props)
 
         # Create another pool
-        pool2 = self.create_pool()
-        pool2.connect(2)
+        pool2 = self.get_pool()
 
         result = self.run_datamover(
             self.test_id + " cont1 to cont4 (different pool) (empty cont)",

--- a/src/tests/ftest/datamover/large_dir.py
+++ b/src/tests/ftest/datamover/large_dir.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -46,7 +46,7 @@ class DmvrLargeDir(DataMoverTestBase):
         file_size = self.params.get("bytes", self.mdtest_cmd.namespace)
 
         # create pool and cont1
-        pool = self.create_pool()
+        pool = self.get_pool()
         cont1 = self.get_container(pool)
 
         # run mdtest to create data in cont1

--- a/src/tests/ftest/datamover/large_file.py
+++ b/src/tests/ftest/datamover/large_file.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -43,7 +43,7 @@ class DmvrPosixLargeFile(DataMoverTestBase):
             self.fail("Failed to get ior processes for {}".format(self.tool))
 
         # create pool and cont
-        pool = self.create_pool()
+        pool = self.get_pool()
         cont1 = self.get_container(pool)
 
         # create initial data in cont1

--- a/src/tests/ftest/datamover/negative.py
+++ b/src/tests/ftest/datamover/negative.py
@@ -65,7 +65,7 @@ class DmvrNegativeTest(DataMoverTestBase):
         start_dfuse(self, dfuse)
 
         # Create a test pool
-        pool1 = self.create_pool()
+        pool1 = self.get_pool()
 
         # Create a special container to hold UNS entries
         uns_cont = self.get_container(pool1)
@@ -215,7 +215,7 @@ class DmvrNegativeTest(DataMoverTestBase):
         start_dfuse(self, dfuse)
 
         # Create a test pool
-        pool1 = self.create_pool()
+        pool1 = self.get_pool()
 
         # Create a special container to hold UNS entries
         uns_cont = self.get_container(pool1)

--- a/src/tests/ftest/datamover/obj_large_posix.py
+++ b/src/tests/ftest/datamover/obj_large_posix.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -37,7 +37,7 @@ class DmvrObjLargePosix(DataMoverTestBase):
         file_size = self.params.get("bytes", "/run/mdtest/*")
 
         # Create pool1 and cont1
-        pool1 = self.create_pool()
+        pool1 = self.get_pool()
         cont1 = self.get_container(pool1)
 
         # Create a large directory in cont1

--- a/src/tests/ftest/datamover/obj_small.py
+++ b/src/tests/ftest/datamover/obj_small.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -58,8 +58,7 @@ class DmvrObjSmallTest(DataMoverTestBase):
         self.set_tool(tool)
 
         # Create pool1
-        pool1 = self.create_pool()
-        pool1.connect(2)
+        pool1 = self.get_pool()
 
         # Create cont1
         cont1 = self.get_container(pool1)
@@ -85,8 +84,7 @@ class DmvrObjSmallTest(DataMoverTestBase):
             self.num_akeys_array, self.akey_sizes, self.akey_extents)
 
         # Create pool2
-        pool2 = self.create_pool()
-        pool2.connect(2)
+        pool2 = self.get_pool()
 
         # Clone cont1 to a new cont3 in pool2
         result = self.run_datamover(

--- a/src/tests/ftest/datamover/posix_meta_entry.py
+++ b/src/tests/ftest/datamover/posix_meta_entry.py
@@ -67,7 +67,7 @@ class DmvrPosixMetaEntry(DataMoverTestBase):
         start_dfuse(self, dfuse)
 
         # Create 1 pool
-        pool1 = self.create_pool()
+        pool1 = self.get_pool()
 
         # Create 1 source container with test data
         cont1 = self.get_container(pool1)

--- a/src/tests/ftest/datamover/posix_preserve_props.py
+++ b/src/tests/ftest/datamover/posix_preserve_props.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -56,8 +56,7 @@ class DmvrPreserveProps(DataMoverTestBase):
         self.set_api(api)
 
         # Create 1 pool
-        pool1 = self.create_pool()
-        pool1.connect(2)
+        pool1 = self.get_pool()
 
         # set the path to read and write container properties
         self.preserve_props_path = join(self.tmp, "cont_props.h5")

--- a/src/tests/ftest/datamover/posix_subsets.py
+++ b/src/tests/ftest/datamover/posix_subsets.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -54,7 +54,7 @@ class DmvrPosixSubsets(DataMoverTestBase):
         start_dfuse(self, dfuse)
 
         # Create 1 pool
-        pool1 = self.create_pool()
+        pool1 = self.get_pool()
 
         # create dfuse containers to test copying to dfuse subdirectories
         dfuse_cont1 = self.get_container(pool1)

--- a/src/tests/ftest/datamover/posix_symlinks.py
+++ b/src/tests/ftest/datamover/posix_symlinks.py
@@ -60,7 +60,7 @@ class DmvrPosixSymlinks(DataMoverTestBase):
         start_dfuse(self, dfuse)
 
         # Create 1 pool
-        pool1 = self.create_pool()
+        pool1 = self.get_pool()
 
         # Create a special container to hold UNS entries
         uns_cont = self.get_container(pool1)

--- a/src/tests/ftest/datamover/posix_types.py
+++ b/src/tests/ftest/datamover/posix_types.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -68,8 +68,8 @@ class DmvrPosixTypesTest(DataMoverTestBase):
         start_dfuse(self, dfuse)
 
         # Create 2 pools
-        pool1 = self.create_pool(label='pool1')
-        pool2 = self.create_pool(label='pool2')
+        pool1 = self.get_pool(label='pool1')
+        pool2 = self.get_pool(label='pool2')
 
         # Create a special container to hold UNS entries
         uns_cont = self.get_container(pool1)

--- a/src/tests/ftest/datamover/serial_large_posix.py
+++ b/src/tests/ftest/datamover/serial_large_posix.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -43,7 +43,7 @@ class DmvrSerialLargePosix(DataMoverTestBase):
         file_size = self.params.get("bytes", "/run/mdtest/*")
 
         # Create pool1 and cont1
-        pool1 = self.create_pool()
+        pool1 = self.get_pool()
         cont1 = self.get_container(pool1)
 
         # Create a large directory in cont1
@@ -51,7 +51,7 @@ class DmvrSerialLargePosix(DataMoverTestBase):
         self.run_mdtest_with_params("DAOS", "/", pool1, cont1, flags=mdtest_flags[0])
 
         # Create pool2
-        pool2 = self.create_pool()
+        pool2 = self.get_pool()
 
         # Use dfuse as a shared intermediate for serialize + deserialize
         dfuse_cont = self.get_container(pool1)

--- a/src/tests/ftest/datamover/serial_small.py
+++ b/src/tests/ftest/datamover/serial_small.py
@@ -1,5 +1,5 @@
 '''
-  (C) Copyright 2020-2022 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -56,8 +56,7 @@ class DmvrSerialSmall(DataMoverTestBase):
         self.set_tool(tool)
 
         # Create pool1
-        pool1 = self.create_pool()
-        pool1.connect(2)
+        pool1 = self.get_pool()
 
         # Create cont1
         cont1 = self.get_container(pool1)
@@ -69,8 +68,7 @@ class DmvrSerialSmall(DataMoverTestBase):
             self.num_akeys_array, self.akey_sizes, self.akey_extents)
 
         # Create pool2
-        pool2 = self.create_pool()
-        pool2.connect(2)
+        pool2 = self.get_pool()
 
         # Serialize/Deserialize cont1 to a new cont2 in pool2
         result = self.run_datamover(

--- a/src/tests/ftest/deployment/basic_checkout.py
+++ b/src/tests/ftest/deployment/basic_checkout.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2018-2023 Intel Corporation.
+  (C) Copyright 2018-2024 Intel Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -120,7 +120,7 @@ class BasicCheckoutDm(DataMoverTestBase):
         self.ior_ppn = self.ppn
 
         # create pool and container
-        pool = self.create_pool()
+        pool = self.get_pool()
         cont = self.get_container(pool, oclass=self.ior_cmd.dfs_oclass.value)
 
         # run datamover

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -113,7 +113,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
         self.ddeserialize_cmd = None
         self.fs_copy_cmd = None
         self.cont_clone_cmd = None
-        self.pool = []
         self.dfuse_hosts = None
         self.num_run_datamover = 0  # Number of times run_datamover was called
 
@@ -305,20 +304,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             return _type
         self.fail("Invalid param_type: {}".format(_type))
         return None
-
-    def create_pool(self, **params):
-        """Create a TestPool object and adds to self.pool.
-
-        Returns:
-            TestPool: the created pool
-
-        """
-        pool = self.get_pool(connect=False, **params)
-
-        # Save the pool
-        self.pool.append(pool)
-
-        return pool
 
     def parse_create_cont_label(self, output):
         """Parse a uuid or label from create container output.


### PR DESCRIPTION
Replace DataMoverTestBase.create_pool with self.get_pool

Test-tag: BasicCheckout BasicCheckoutDm DmvrCopyProcs DmvrDstCreate DmvrLargeDir DmvrNegativeTest DmvrObjLargePosix DmvrObjSmallTest DmvrPosixLargeFile DmvrPosixMetaEntry DmvrPosixSubsets DmvrPosixSymlinks DmvrPosixTypesTest DmvrPreserveProps DmvrSerialLargePosix DmvrSerialSmall datamover
Skip-unit-tests: true
Skip-fault-injection-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
