### PR TITLE
DAOS-16482 control: Increase min hugepages for single tgt count (#15115)

### DIFF
--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -476,6 +476,10 @@ func (cfg *Server) SetNrHugepages(log logging.Logger, mi *common.MemInfo) error 
 				msg = fmt.Sprintf("%s (MD-on-SSD)", msg)
 				// MD-on-SSD has extra sys-xstream for rdb.
 				sysXSCount++
+			} else if ec.TargetCount == 1 {
+				// Avoid DMA buffer allocation failure with single target count by
+				// increasing the minimum target count used to calculate hugepages.
+				cfgTargetCount++
 			}
 		}
 		log.Debug(msg)
@@ -507,9 +511,7 @@ func (cfg *Server) SetNrHugepages(log logging.Logger, mi *common.MemInfo) error 
 		cfg.NrHugepages = minHugepages
 		log.Infof("hugepage count automatically set to %d (%s)", minHugepages,
 			humanize.IBytes(hugePageBytes(minHugepages, mi.HugepageSizeKiB)))
-	}
-
-	if cfg.NrHugepages < minHugepages {
+	} else if cfg.NrHugepages < minHugepages {
 		log.Noticef("configured nr_hugepages %d is less than recommended %d, "+
 			"if this is not intentional update the 'nr_hugepages' config "+
 			"parameter or remove and it will be automatically calculated",

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -1043,7 +1043,61 @@ func TestServerConfig_SetNrHugepages(t *testing.T) {
 			zeroHpSize: true,
 			expErr:     errors.New("invalid system hugepage size"),
 		},
-		"zero hugepages set in config; bdevs configured; implicit role assignment": {
+		"zero hugepages set in config; bdevs configured; single target count": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithEngines(defaultEngineCfg().
+					WithTargetCount(1).
+					WithStorage(
+						storage.NewTierConfig().
+							WithStorageClass("dcpm").
+							WithScmDeviceList("/dev/pmem1"),
+						storage.NewTierConfig().
+							WithStorageClass("nvme").
+							WithBdevDeviceList("0000:81:00.0"),
+					),
+					defaultEngineCfg().
+						WithTargetCount(1).
+						WithStorage(
+							storage.NewTierConfig().
+								WithStorageClass("dcpm").
+								WithScmDeviceList("/dev/pmem1"),
+							storage.NewTierConfig().
+								WithStorageClass("nvme").
+								WithBdevDeviceList("0000:d0:00.0"),
+						),
+				)
+			},
+			expNrHugepages: 2048,
+		},
+		"zero hugepages set in config; bdevs configured; single target count; md-on-ssd": {
+			extraConfig: func(c *Server) *Server {
+				return c.WithEngines(defaultEngineCfg().
+					WithTargetCount(1).
+					WithStorage(
+						storage.NewTierConfig().
+							WithStorageClass("ram").
+							WithScmMountPoint("/foo"),
+						storage.NewTierConfig().
+							WithStorageClass("nvme").
+							WithBdevDeviceList("0000:81:00.0").
+							WithBdevDeviceRoles(storage.BdevRoleAll),
+					),
+					defaultEngineCfg().
+						WithTargetCount(1).
+						WithStorage(
+							storage.NewTierConfig().
+								WithStorageClass("ram").
+								WithScmMountPoint("/foo"),
+							storage.NewTierConfig().
+								WithStorageClass("nvme").
+								WithBdevDeviceList("0000:d0:00.0").
+								WithBdevDeviceRoles(storage.BdevRoleAll),
+						),
+				)
+			},
+			expNrHugepages: 2048,
+		},
+		"zero hugepages set in config; bdevs configured": {
 			extraConfig: func(c *Server) *Server {
 				return c.WithEngines(defaultEngineCfg().
 					WithStorage(

--- a/src/control/server/storage/bdev_test.go
+++ b/src/control/server/storage/bdev_test.go
@@ -344,21 +344,28 @@ func Test_CalcMinHugepages(t *testing.T) {
 			},
 			expErr: errors.New("numTargets"),
 		},
-		"2KB pagesize; 16 targets": {
+		"2MiB pagesize; 1 target": {
+			input: &common.MemInfo{
+				HugepageSizeKiB: 2048,
+			},
+			numTargets: 1,
+			expPages:   512,
+		},
+		"2MiB pagesize; 16 targets": {
 			input: &common.MemInfo{
 				HugepageSizeKiB: 2048,
 			},
 			numTargets: 16,
 			expPages:   8192,
 		},
-		"2KB pagesize; 31 targets": {
+		"2MiB pagesize; 31 targets": {
 			input: &common.MemInfo{
 				HugepageSizeKiB: 2048,
 			},
 			numTargets: 31,
 			expPages:   15872,
 		},
-		"1GB pagesize; 16 targets": {
+		"1GiB pagesize; 16 targets": {
 			input: &common.MemInfo{
 				HugepageSizeKiB: 1048576,
 			},


### PR DESCRIPTION
DMA buffer allocations may fail for single target count due to
insufficient hugepages available. Increase minimum number of hugepages
for single target count when in PMem mode.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
