### PR TITLE
DAOS-15778 test: remove DataMoverTestBase.posix_local_test_paths (#14…

### DIFF
--- a/src/tests/ftest/datamover/negative.py
+++ b/src/tests/ftest/datamover/negative.py
@@ -33,13 +33,13 @@ class DmvrNegativeTest(DataMoverTestBase):
         super().setUp()
 
         # Get the parameters
-        self.test_file = self.ior_cmd.test_file.value
+        test_file = self.ior_cmd.test_file.value
 
         # Setup the directory structures
-        self.new_posix_test_path()
-        self.posix_test_file = join(self.posix_local_test_paths[0], self.test_file)
-        self.daos_test_path = "/"
-        self.daos_test_file = join(self.daos_test_path, self.test_file)
+        self.__posix_test_path = self.new_posix_test_path()
+        self.__posix_test_file = join(self.__posix_test_path, test_file)
+        self.__daos_test_path = "/"
+        self.__daos_test_file = join(self.__daos_test_path, test_file)
 
     def test_dm_bad_params_dcp(self):
         """Jira ID: DAOS-5515 - Initial test case.
@@ -75,27 +75,27 @@ class DmvrNegativeTest(DataMoverTestBase):
         cont1 = self.get_container(pool1, path=cont1_path)
 
         # Create test files
-        self.run_ior_with_params("POSIX", self.posix_test_file)
-        self.run_ior_with_params("DAOS_UUID", self.daos_test_file, pool1, cont1)
+        self.run_ior_with_params("POSIX", self.__posix_test_file)
+        self.run_ior_with_params("DAOS_UUID", self.__daos_test_file, pool1, cont1)
 
         # Bad parameter: required arguments.
         self.run_datamover(
             self.test_id + " (missing source pool)",
             src_path=format_path(),
-            dst_path=self.posix_local_test_paths[0],
+            dst_path=self.__posix_test_path,
             expected_rc=1,
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
         self.run_datamover(
             self.test_id + " (missing source cont)",
             src_path=format_path(pool1),
-            dst_path=self.posix_local_test_paths[0],
+            dst_path=self.__posix_test_path,
             expected_rc=1,
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
         self.run_datamover(
             self.test_id + " (missing dest pool)",
-            src_path=self.posix_local_test_paths[0],
+            src_path=self.__posix_test_path,
             dst_path=format_path(),
             expected_rc=1,
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
@@ -134,20 +134,20 @@ class DmvrNegativeTest(DataMoverTestBase):
         self.run_datamover(
             self.test_id + " (invalid source pool)",
             src_path=format_path(fake_uuid, cont1),
-            dst_path=self.posix_local_test_paths[0],
+            dst_path=self.__posix_test_path,
             expected_rc=1,
             expected_output="DER_NONEXIST")
 
         self.run_datamover(
             self.test_id + " (invalid source cont)",
             src_path=format_path(pool1, fake_uuid),
-            dst_path=self.posix_local_test_paths[0],
+            dst_path=self.__posix_test_path,
             expected_rc=1,
             expected_output="DER_NONEXIST")
 
         self.run_datamover(
             self.test_id + " (invalid dest pool)",
-            src_path=self.posix_local_test_paths[0],
+            src_path=self.__posix_test_path,
             dst_path=format_path(fake_uuid, cont1),
             expected_rc=1,
             expected_output="DER_NONEXIST")
@@ -155,20 +155,20 @@ class DmvrNegativeTest(DataMoverTestBase):
         self.run_datamover(
             self.test_id + " (invalid source cont path)",
             src_path=format_path(pool1, cont1, "/fake/fake"),
-            dst_path=self.posix_local_test_paths[0],
+            dst_path=self.__posix_test_path,
             expected_rc=1,
             expected_output="No such file or directory")
 
         self.run_datamover(
             self.test_id + " (invalid source cont UNS path)",
             src_path=cont1.path.value + "/fake/fake",
-            dst_path=self.posix_local_test_paths[0],
+            dst_path=self.__posix_test_path,
             expected_rc=1,
             expected_output="No such file or directory")
 
         self.run_datamover(
             self.test_id + " (invalid dest cont path)",
-            src_path=self.posix_local_test_paths[0],
+            src_path=self.__posix_test_path,
             dst_path=format_path(pool1, cont1, "/fake/fake"),
             expected_rc=1,
             expected_output="No such file or directory")
@@ -188,7 +188,7 @@ class DmvrNegativeTest(DataMoverTestBase):
             expected_output="No such file or directory")
 
         #  (4) Bad parameter: destination filename is invalid.
-        dst_path = join(self.posix_local_test_paths[0], "d" * 300)
+        dst_path = join(self.__posix_test_path, "d" * 300)
         self.run_datamover(
             self.test_id + " (filename is too long)",
             src_path=format_path(pool1, cont1),
@@ -225,7 +225,7 @@ class DmvrNegativeTest(DataMoverTestBase):
         cont1 = self.get_container(pool1, path=cont1_path)
 
         # Create test files
-        self.run_ior_with_params("DAOS", self.daos_test_file, pool1, cont1)
+        self.run_ior_with_params("DAOS", self.__daos_test_file, pool1, cont1)
 
         # (1) Bad parameter: source is destination.
         self.log_step("Verify error when label source is label dest")

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -140,12 +140,6 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
 
         self.preserve_props_path = None
 
-        # List of local test paths to create and remove
-        self.posix_local_test_paths = []
-
-        # List of daos test paths to keep track of
-        self.daos_test_paths = []
-
     def setUp(self):
         """Set up each test case."""
         # Start the servers and agents
@@ -221,14 +215,9 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             str: the posix path.
 
         """
-        # make directory name unique to datamover test
-        method = self.get_test_name()
-        dir_name = "{}{}".format(method, len(self.posix_local_test_paths))
+        # make directory name unique to this test
+        dir_name = self.label_generator.get_label(self.get_test_name())
         path = join(parent or self.posix_root.value, dir_name)
-
-        # Add to the list of posix paths
-        if not shared:
-            self.posix_local_test_paths.append(path)
 
         if create:
             # Create the directory
@@ -270,18 +259,16 @@ class DataMoverTestBase(IorTestBase, MdtestBase):
             str: the path relative to the root of the container.
 
         """
-        dir_name = "daos_test{}".format(len(self.daos_test_paths))
+        dir_name = self.label_generator.get_label('daos_test_dir')
         path = join(parent, dir_name)
-
-        # Add to the list of daos paths
-        self.daos_test_paths.append(path)
 
         if create:
             if not cont or not cont.path:
                 self.fail("Container path required to create directory.")
             # Create the directory relative to the container path
-            cmd = "mkdir -p '{}'".format(cont.path.value + path)
-            self.execute_cmd(cmd)
+            full_path = cont.path.value + path
+            if not run_remote(self.log, self.hostlist_clients, f"mkdir -p '{full_path}'").passed:
+                self.fail(f"Failed to mkdir {full_path}")
 
         return path
 


### PR DESCRIPTION
…802)

remove DataMoverTestBase.posix_local_test_paths in favor of local references

Test-tag: datamover
Skip-unit-tests: true
Skip-fault-injection-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
