### PR TITLE
DAOS-16668 umem: race on page evicting

### DIFF
--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -802,7 +802,7 @@ pin_obj:
 			D_ASSERT(gc->gc_type != GC_CONT);
 			D_ASSERT(vos_pool_is_evictable(pool));
 
-			rc = umem_tx_end(&pool->vp_umm, rc);
+			rc = umem_tx_end(&pool->vp_umm, rc < 0 ? rc : 0);
 			if (rc != 0) {
 				DL_ERROR(rc, "Transaction commit failed.");
 				goto tx_error;
@@ -859,7 +859,7 @@ pin_obj:
 		"pool="DF_UUID", creds origin=%d, current=%d, rc=%s\n",
 		DP_UUID(pool->vp_id), *credits, creds, d_errstr(rc));
 
-	rc = umem_tx_end(&pool->vp_umm, rc);
+	rc = umem_tx_end(&pool->vp_umm, rc < 0 ? rc : 0);
 	if (rc == 0)
 		*credits = creds;
 tx_error:


### PR DESCRIPTION
- Fix race of two concurrent ULTs trying to evict same page.
- Fix race of mapping two pinfo to same page in cache_pin/map_pages()
- Fix error code used for umem_tx_end() in GC.

Required-githooks: true

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Signed-off-by: Sherin T George <sherin-t.george@hpe.com>

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
