### PR TITLE
DAOS-16674 vos: create sysdb lock with recursive attribute

### DIFF
--- a/src/vos/sys_db.c
+++ b/src/vos/sys_db.c
@@ -349,8 +349,9 @@ vos_db_init(const char *db_path)
 int
 vos_db_init_ex(const char *db_path, const char *db_name, bool force_create, bool destroy_db_on_fini)
 {
-	int	create;
-	int	rc;
+	ABT_mutex_attr	attr = ABT_MUTEX_ATTR_NULL;
+	int		create;
+	int		rc;
 
 	D_ASSERT(db_path != NULL);
 
@@ -373,11 +374,25 @@ vos_db_init_ex(const char *db_path, const char *db_name, bool force_create, bool
 		goto failed;
 	}
 
-	rc = ABT_mutex_create(&vos_db.db_lock);
+	rc = ABT_mutex_attr_create(&attr);
 	if (rc != ABT_SUCCESS) {
-		rc = -DER_NOMEM;
-		goto failed;
+		D_ERROR("Failed to create mutex attr: %d\n", rc);
+		D_GOTO(failed, rc = dss_abterr2der(rc));
 	}
+
+	rc = ABT_mutex_attr_set_recursive(attr, ABT_TRUE);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR("Failed to set mutex attr: %d\n", rc);
+		D_GOTO(failed, rc = dss_abterr2der(rc));
+	}
+
+	rc = ABT_mutex_create_with_attr(attr, &vos_db.db_lock);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR("Failed to create mutex with attr: %d\n", rc);
+		D_GOTO(failed, rc = dss_abterr2der(rc));
+	}
+
+	ABT_mutex_attr_free(&attr);
 
 	vos_db.db_poh = DAOS_HDL_INVAL;
 	vos_db.db_coh = DAOS_HDL_INVAL;
@@ -416,6 +431,8 @@ vos_db_init_ex(const char *db_path, const char *db_name, bool force_create, bool
 	}
 	return 0;
 failed:
+	if (attr != ABT_MUTEX_ATTR_NULL)
+		ABT_mutex_attr_free(&attr);
 	vos_db_fini();
 	return rc;
 }


### PR DESCRIPTION
Then up layer caller can hold sysdb lock recursively and avoid self-deadlock.

Features: PoolCleanupTest PoolListConsolidationTest CatRecovCoreTest
Allow-unstable-test: true
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
