### PR TITLE
DAOS-16698 control: Bump system_ram_reserved for MD-on-SSD pool create

### DIFF
--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -588,7 +588,7 @@ disable_vfio: false
 disable_vmd: false
 enable_hotplug: false
 nr_hugepages: 0
-system_ram_reserved: 16
+system_ram_reserved: 26
 disable_hugepages: false
 control_log_mask: INFO
 control_log_file: /tmp/daos_server.log

--- a/src/control/server/storage/scm.go
+++ b/src/control/server/storage/scm.go
@@ -51,7 +51,7 @@ const (
 
 // Memory reservation constant defaults to be used when calculating RAM-disk size for DAOS I/O engine.
 const (
-	DefaultSysMemRsvd    = humanize.GiByte * 16  // per-system
+	DefaultSysMemRsvd    = humanize.GiByte * 26  // per-system
 	DefaultTgtMemRsvd    = humanize.MiByte * 128 // per-engine-target
 	DefaultEngineMemRsvd = humanize.GiByte * 1   // per-engine
 )

--- a/src/control/server/storage/scm_test.go
+++ b/src/control/server/storage/scm_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2023 Intel Corporation.
+// (C) Copyright 2023-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -39,28 +39,28 @@ func Test_CalcRamdiskSize(t *testing.T) {
 			expErr:   errors.New("requires positive nonzero nr engines"),
 		},
 		"default values; low mem": {
-			memTotal: humanize.GiByte * 30,
+			memTotal: humanize.GiByte * 40,
 			memHuge:  humanize.GiByte * 14,
 			memSys:   DefaultSysMemRsvd,
 			tgtCount: 8,
 			engCount: 1,
-			expErr:   errors.New("insufficient ram"), // 30 - (14+16+1) = -1
+			expErr:   errors.New("insufficient ram"), // 30 - (14+26+1) = -1
 		},
 		"default values; high mem": {
-			memTotal: humanize.GiByte * 60,
+			memTotal: humanize.GiByte * 70,
 			memHuge:  humanize.GiByte * 30,
 			memSys:   DefaultSysMemRsvd,
 			tgtCount: 16,
 			engCount: 2,
-			expSize:  humanize.GiByte * 5, // (60 - (30+16+4)) / 2
+			expSize:  humanize.GiByte * 5, // (70 - (30+26+4)) / 2
 		},
 		"default values; low nr targets": {
-			memTotal: humanize.GiByte * 60,
+			memTotal: humanize.GiByte * 70,
 			memHuge:  humanize.GiByte * 30,
 			memSys:   DefaultSysMemRsvd,
 			tgtCount: 1,
 			engCount: 2,
-			expSize:  humanize.GiByte * 6, // (60 - (30+16+2)) / 2
+			expSize:  humanize.GiByte * 6, // (70 - (30+26+2)) / 2
 		},
 		"custom values; low sys reservation": {
 			memTotal: humanize.GiByte * 60,

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -226,7 +226,7 @@
 ## minimum of 4gib. Increasing the value may help avoid the potential of OOM killer terminating
 ## engine processes but could also result in stopping DAOS from using available memory resources.
 #
-## default: 16
+## default: 26
 #system_ram_reserved: 5
 #
 #


### PR DESCRIPTION
Update system_ram_reserved to avoid an OOM issue when running pool
create 100% in MD-on-SSD mode with a single engine per host. Default
value has been increased from 16 to 26 based on experiments using wolf
cluster. Value expected to be used to tune behaviour based on specific
deployment environments.

Test-tag: pr pool control daily_regression
Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
