### PR TITLE
DAOS-16692 vos: optimize GC for phase2 pool

### DIFF
--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -92,6 +92,17 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	cont_df = umem_off2ptr(&tins->ti_umm, offset);
 	uuid_copy(cont_df->cd_id, ukey->uuid);
 
+	cont_df->cd_ext = umem_zalloc(&tins->ti_umm, sizeof(struct vos_cont_ext_df));
+	if (UMOFF_IS_NULL(cont_df->cd_ext)) {
+		D_ERROR("Failed to allocate cont df extension.\n");
+		rc = -DER_NOSPACE;
+		goto failed;
+	}
+
+	rc = gc_init_cont(&tins->ti_umm, cont_df);
+	if (rc)
+		goto failed;
+
 	rc = dbtree_create_inplace_ex(VOS_BTR_OBJ_TABLE, 0, VOS_OBJ_ORDER,
 				      &pool->vp_uma, &cont_df->cd_obj_root,
 				      DAOS_HDL_INVAL, pool, &hdl);
@@ -101,12 +112,13 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	}
 	dbtree_close(hdl);
 
-	gc_init_cont(&tins->ti_umm, cont_df);
 	args->ca_cont_df = cont_df;
 	rec->rec_off = offset;
 	return 0;
 failed:
 	/* Ignore umem_free failure. */
+	if (!UMOFF_IS_NULL(cont_df->cd_ext))
+		umem_free(&tins->ti_umm, cont_df->cd_ext);
 	umem_free(&tins->ti_umm, offset);
 	return rc;
 }
@@ -191,6 +203,7 @@ cont_free_internal(struct vos_container *cont)
 
 	if (!d_list_empty(&cont->vc_gc_link))
 		d_list_del(&cont->vc_gc_link);
+	gc_close_cont(cont);
 
 	for (i = 0; i < VOS_IOS_CNT; i++) {
 		if (cont->vc_hint_ctxt[i])
@@ -384,6 +397,9 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	D_INIT_LIST_HEAD(&cont->vc_dtx_act_list);
 	cont->vc_dtx_committed_count = 0;
 	cont->vc_solo_dtx_epoch = d_hlc_get();
+	rc = gc_open_cont(cont);
+	if (rc)
+		D_GOTO(exit, rc);
 	gc_check_cont(cont);
 
 	/* Cache this btr object ID in container handle */

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -11,6 +11,7 @@
 #define D_LOGFAC	DD_FAC(vos)
 
 #include <daos/btree.h>
+#include <daos/btree_class.h>
 #include <daos/mem.h>
 #include <daos_srv/vos.h>
 #include "vos_internal.h"
@@ -308,7 +309,8 @@ gc_drain_cont(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 			return rc;
 
 		/** Indicate to caller that we've taken over container bags */
-		return 1;
+		if (!vos_pool_is_evictable(pool))
+			return 1;
 	}
 
 	D_ASSERT(daos_handle_is_inval(coh));
@@ -318,9 +320,18 @@ gc_drain_cont(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 static int
 gc_free_cont(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh, struct vos_gc_item *item)
 {
-	int	rc;
+	struct vos_cont_df	*cd = umem_off2ptr(&pool->vp_umm, item->it_addr);
+	int			 rc;
 
-	rc = vos_dtx_table_destroy(&pool->vp_umm, umem_off2ptr(&pool->vp_umm, item->it_addr));
+	if (!UMOFF_IS_NULL(cd->cd_ext)) {
+		rc = umem_free(&pool->vp_umm, cd->cd_ext);
+		if (rc) {
+			DL_ERROR(rc, "Failed to free cont_df extension");
+			return rc;
+		}
+	}
+
+	rc = vos_dtx_table_destroy(&pool->vp_umm, cd);
 	if (rc == 0)
 		rc = umem_free(&pool->vp_umm, item->it_addr);
 
@@ -382,19 +393,101 @@ gc_type2bin(struct vos_pool *pool, struct vos_container *cont,
 	return &cont->vc_cont_df->cd_gc_bins[type];
 }
 
+static int
+gc_bkt2bins(uint32_t *bkt_id, struct vos_gc_info *gc_info, bool create, bool try_next,
+	    struct vos_gc_bin_df **bins_ret)
+{
+	struct vos_gc_bin_df	dummy_bins[GC_CONT];
+	d_iov_t			key, key_out, val, val_out;
+	uint32_t		*new_id;
+	int			probe_op = try_next ? BTR_PROBE_FIRST : BTR_PROBE_EQ;
+	int			i, rc;
+
+	D_ASSERT(*bkt_id != UMEM_DEFAULT_MBKT_ID);
+	D_ASSERT(daos_handle_is_valid(gc_info->gi_bins_btr));
+
+	/* Fetch the in-tree record */
+	d_iov_set(&key, bkt_id, sizeof(*bkt_id));
+	d_iov_set(&key_out, NULL, 0);
+	d_iov_set(&val_out, NULL, 0);
+
+	rc = dbtree_fetch(gc_info->gi_bins_btr, probe_op, DAOS_INTENT_DEFAULT, &key,
+			  &key_out, &val_out);
+	if (rc && rc != -DER_NONEXIST) {
+		DL_ERROR(rc, "Failed to lookup GC bins for bkt_id:%u", *bkt_id);
+		return rc;
+	}
+
+	if (rc == 0) {
+		*bins_ret = (struct vos_gc_bin_df *)val_out.iov_buf;
+		new_id = (uint32_t *)key_out.iov_buf;
+		D_ASSERT(new_id && (try_next || *bkt_id == *new_id));
+		*bkt_id = *new_id;
+	} else if (create) {
+		D_ASSERT(!try_next);
+		for (i = 0; i < GC_CONT; i++) {
+			dummy_bins[i].bin_bag_first	= UMOFF_NULL;
+			dummy_bins[i].bin_bag_last	= UMOFF_NULL;
+			dummy_bins[i].bin_bag_size	= gc_bag_size;
+			dummy_bins[i].bin_bag_nr	= 0;
+		}
+
+		d_iov_set(&val, &dummy_bins[0], sizeof(dummy_bins));
+		d_iov_set(&val_out, NULL, 0);
+
+		rc = dbtree_upsert(gc_info->gi_bins_btr, BTR_PROBE_BYPASS, DAOS_INTENT_UPDATE,
+				   &key, &val, &val_out);
+		if (rc != 0) {
+			DL_ERROR(rc, "Failed to insert GC bins for bkt_id:%u", *bkt_id);
+			return rc;
+		}
+		*bins_ret = (struct vos_gc_bin_df *)val_out.iov_buf;
+	}
+
+	return rc;
+}
+
+static int
+gc_get_bin(struct vos_pool *pool, struct vos_container *cont, enum vos_gc_type type,
+	   uint32_t bkt_id, struct vos_gc_bin_df **bin_df)
+{
+	struct vos_gc_bin_df	*bins = NULL;
+	int			 rc;
+
+	D_ASSERT(type < GC_MAX);
+	if (!vos_pool_is_evictable(pool) || bkt_id == UMEM_DEFAULT_MBKT_ID) {
+		*bin_df = gc_type2bin(pool, cont, type);
+		return 0;
+	}
+
+	D_ASSERT(type < GC_CONT);
+	if (cont == NULL)
+		rc = gc_bkt2bins(&bkt_id, &pool->vp_gc_info, true, false, &bins);
+	else
+		rc = gc_bkt2bins(&bkt_id, &cont->vc_gc_info, true, false, &bins);
+
+	if (rc == 0) {
+		D_ASSERT(bins != NULL);
+		*bin_df = &bins[type];
+	}
+
+	return rc;
+}
+
 /**
  * Free the first (oldest) garbage bag of a garbage bin unless it is also the
  * last (newest) bag.
  */
 static int
-gc_bin_free_bag(struct umem_instance *umm, struct vos_container *cont,
-		struct vos_gc_bin_df *bin, umem_off_t bag_id)
+gc_bin_free_bag(struct umem_instance *umm, struct vos_gc_bin_df *bin, umem_off_t bag_id,
+		bool free_last_bag)
+
 {
 	struct vos_gc_bag_df *bag = umem_off2ptr(umm, bag_id);
 	int		      rc;
 
 	D_ASSERT(bag_id == bin->bin_bag_first);
-	if (cont == NULL && bag_id == bin->bin_bag_last) {
+	if (!free_last_bag && bag_id == bin->bin_bag_last) {
 		/* don't free the last bag, only reset it */
 		D_ASSERT(bin->bin_bag_nr == 1);
 		rc = umem_tx_add_ptr(umm, bag, sizeof(*bag));
@@ -406,7 +499,7 @@ gc_bin_free_bag(struct umem_instance *umm, struct vos_container *cont,
 		return rc;
 	}
 
-	if (cont != NULL) {
+	if (free_last_bag) {
 		D_ASSERT(bin->bin_bag_nr > 0);
 	} else {
 		D_ASSERT(bin->bin_bag_nr > 1);
@@ -507,11 +600,10 @@ gc_bin_add_item(struct umem_instance *umm, struct vos_gc_bin_df *bin,
 	return rc;
 }
 
-static struct vos_gc_item *
-gc_get_item(struct vos_gc *gc, struct vos_pool *pool,
-	    struct vos_container *cont)
+
+static inline struct vos_gc_item *
+bin_get_item(struct vos_pool *pool, struct vos_gc_bin_df *bin)
 {
-	struct vos_gc_bin_df	*bin = gc_type2bin(pool, cont, gc->gc_type);
 	struct vos_gc_bag_df	*bag;
 
 	bag = umem_off2ptr(&pool->vp_umm, bin->bin_bag_first);
@@ -524,6 +616,14 @@ gc_get_item(struct vos_gc *gc, struct vos_pool *pool,
 	}
 
 	return &bag->bag_items[bag->bag_item_first];
+}
+
+static inline struct vos_gc_item *
+gc_get_item(struct vos_gc *gc, struct vos_pool *pool, struct vos_container *cont)
+{
+	struct vos_gc_bin_df	*bin = gc_type2bin(pool, cont, gc->gc_type);
+
+	return bin_get_item(pool, bin);
 }
 
 static int
@@ -567,10 +667,9 @@ gc_drain_item(struct vos_gc *gc, struct vos_pool *pool, daos_handle_t coh,
 }
 
 static int
-gc_free_item(struct vos_gc *gc, struct vos_pool *pool,
-	     struct vos_container *cont, struct vos_gc_item *item)
+gc_free_item(struct vos_gc *gc, struct vos_pool *pool, struct vos_container *cont,
+	     struct vos_gc_item *item, struct vos_gc_bin_df *bin)
 {
-	struct vos_gc_bin_df *bin = gc_type2bin(pool, cont, gc->gc_type);
 	struct vos_gc_bag_df *bag;
 	int		      first;
 	struct vos_gc_item    it;
@@ -588,8 +687,8 @@ gc_free_item(struct vos_gc *gc, struct vos_pool *pool,
 	if (first == bag->bag_item_last) {
 		/* it's going to be a empty bag */
 		D_ASSERT(bag->bag_item_nr == 1);
-		rc = gc_bin_free_bag(&pool->vp_umm, cont, bin,
-				     bin->bin_bag_first);
+		rc = gc_bin_free_bag(&pool->vp_umm, bin, bin->bin_bag_first,
+				     (cont != NULL || item->it_bkt_ids[0] != UMEM_DEFAULT_MBKT_ID));
 		if (rc)
 			goto failed;
 	} else {
@@ -643,7 +742,7 @@ gc_add_item(struct vos_pool *pool, daos_handle_t coh,
 	    enum vos_gc_type type, umem_off_t item_off, uint32_t *bkt_ids)
 {
 	struct vos_container	*cont = vos_hdl2cont(coh);
-	struct vos_gc_bin_df	*bin = gc_type2bin(pool, cont, type);
+	struct vos_gc_bin_df	*bin;
 	struct vos_gc_item	 item;
 	int			 rc, i;
 
@@ -656,6 +755,13 @@ gc_add_item(struct vos_pool *pool, daos_handle_t coh,
 	item.it_addr = item_off;
 	for (i = 0; i < VOS_GC_BKTS_MAX; i++)
 		item.it_bkt_ids[i] = bkt_ids ? bkt_ids[i] : UMEM_DEFAULT_MBKT_ID;
+
+	rc = gc_get_bin(pool, cont, type, item.it_bkt_ids[0], &bin);
+	if (rc) {
+		DL_ERROR(rc, "Failed to get GC bin for type:%d, bkt_id:%u",
+			 type, item.it_bkt_ids[0]);
+		return rc;
+	}
 
 	rc = gc_bin_add_item(&pool->vp_umm, bin, &item);
 	if (rc) {
@@ -726,42 +832,30 @@ gc_reclaim_pool(struct vos_pool *pool, int *credits, bool *empty_ret)
 {
 	struct vos_container	*cont = gc_get_container(pool);
 	struct vos_gc		*gc    = &gc_table[0]; /* start from akey */
+	struct vos_gc_bin_df	*bin;
 	int			 creds = *credits;
-	uint32_t		 bkt = UMEM_DEFAULT_MBKT_ID, pinned_bkt = UMEM_DEFAULT_MBKT_ID;
-	struct umem_pin_handle	*pin_hdl = NULL;
-	struct umem_cache_range	 rg;
 	int			 rc;
 
 	if (pool->vp_dying) {
 		*empty_ret = true;
 		D_GOTO(done, rc = 0);
 	}
-	*empty_ret = false;
 
 	/* take an extra ref to avoid concurrent container destroy/free */
 	if (cont != NULL)
 		vos_cont_addref(cont);
 
-pin_obj:
-	if (bkt != UMEM_DEFAULT_MBKT_ID) {
-		rg.cr_off = umem_get_mb_base_offset(vos_pool2umm(pool), bkt);
-		rg.cr_size = vos_pool2store(pool)->cache->ca_page_sz;
-
-		rc = vos_cache_pin(pool, &rg, 1, false, &pin_hdl);
-		if (rc) {
-			DL_ERROR(rc, "Failed to pin bucket %u.", bkt);
-			goto tx_error;
-		}
-		pinned_bkt = bkt;
-	}
-
 	rc = umem_tx_begin(&pool->vp_umm, NULL);
 	if (rc) {
 		D_ERROR("Failed to start transacton for " DF_UUID ": " DF_RC "\n",
 			DP_UUID(pool->vp_id), DP_RC(rc));
-		goto tx_error;
+		if (cont != NULL)
+			vos_cont_decref(cont);
+		*empty_ret = false;
+		goto done;
 	}
 
+	*empty_ret = false;
 	while (creds > 0) {
 		struct vos_gc_item *item;
 		bool		    empty = false;
@@ -797,25 +891,6 @@ pin_obj:
 		if (DAOS_FAIL_CHECK(DAOS_VOS_GC_CONT))
 			D_ASSERT(cont != NULL);
 
-		bkt = item->it_bkt_ids[0];
-		if (bkt != UMEM_DEFAULT_MBKT_ID && bkt != pinned_bkt) {
-			D_ASSERT(gc->gc_type != GC_CONT);
-			D_ASSERT(vos_pool_is_evictable(pool));
-
-			rc = umem_tx_end(&pool->vp_umm, rc < 0 ? rc : 0);
-			if (rc != 0) {
-				DL_ERROR(rc, "Transaction commit failed.");
-				goto tx_error;
-			}
-
-			if (pin_hdl != NULL) {
-				umem_cache_unpin(vos_pool2store(pool), pin_hdl);
-				pin_hdl = NULL;
-			}
-
-			goto pin_obj;
-		}
-
 		rc = gc_drain_item(gc, pool, vos_cont2hdl(cont), item, &creds,
 				   &empty);
 		if (rc < 0) {
@@ -824,8 +899,9 @@ pin_obj:
 		}
 
 		if (empty && creds) {
+			bin = gc_type2bin(pool, cont, gc->gc_type);
 			/* item can be released and removed from bin */
-			rc = gc_free_item(gc, pool, cont, item);
+			rc = gc_free_item(gc, pool, cont, item, bin);
 			if (rc) {
 				D_ERROR("GC=%s free item error: "DF_RC"\n", gc->gc_name, DP_RC(rc));
 				break;
@@ -862,11 +938,6 @@ pin_obj:
 	rc = umem_tx_end(&pool->vp_umm, rc < 0 ? rc : 0);
 	if (rc == 0)
 		*credits = creds;
-tx_error:
-	if (pin_hdl != NULL) {
-		umem_cache_unpin(vos_pool2store(pool), pin_hdl);
-		pin_hdl = NULL;
-	}
 
 	if (cont != NULL && d_list_empty(&cont->vc_gc_link)) {
 		/** The container may not be empty so add it back to end of
@@ -885,6 +956,569 @@ done:
 	return rc;
 }
 
+static inline bool
+bins_empty(struct vos_pool *pool, struct vos_gc_bin_df *bins)
+{
+	int	i;
+
+	for (i = 0; i < GC_CONT; i++) {
+		if (bin_get_item(pool, &bins[i]) != NULL)
+			return false;
+	}
+	return true;
+}
+
+/* Add gc_bin[GC_CONT] from container bucket tree to pool bucket tree */
+static int
+gc_add_bins(struct vos_pool *pool, struct vos_gc_bin_df *src_bins, uint32_t bkt_id)
+{
+	struct vos_gc_bin_df	*dst_bins, dummy_bins[GC_CONT];
+	daos_handle_t		 pool_btr = pool->vp_gc_info.gi_bins_btr;
+	d_iov_t			 key, key_out, val, val_out;
+	int			 i, rc, added = 0;
+
+	D_ASSERT(daos_handle_is_valid(pool_btr));
+	/* Fetch the in-tree record from pool */
+	d_iov_set(&key, &bkt_id, sizeof(bkt_id));
+	d_iov_set(&key_out, NULL, 0);
+	d_iov_set(&val_out, NULL, 0);
+
+	rc = dbtree_fetch(pool_btr, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT, &key, &key_out, &val_out);
+	if (rc == -DER_NONEXIST) {
+		d_iov_set(&val, src_bins, sizeof(dummy_bins));
+		rc = dbtree_upsert(pool_btr, BTR_PROBE_BYPASS, DAOS_INTENT_UPDATE, &key, &val, NULL);
+		if (rc)
+			DL_ERROR(rc, "Failed to add bins for bkt_id:%u", bkt_id);
+		return rc;
+	} else if (rc) {
+		DL_ERROR(rc, "Failed to fetch bins from pool bucket tree for bkt_id:%u", bkt_id);
+		return rc;
+	}
+
+	dst_bins = (struct vos_gc_bin_df *)val_out.iov_buf;
+	D_ASSERT(dst_bins && !bins_empty(pool, dst_bins));
+
+	for (i = GC_AKEY; i < GC_CONT; i++) {
+		if (src_bins[i].bin_bag_first == UMOFF_NULL)
+			continue;
+
+		rc = gc_bags_move(pool, &dst_bins[i], &src_bins[i]);
+		if (rc != 0) {
+			DL_ERROR(rc, "Failed to move bags for bkt_id:%u, type:%d", bkt_id, i);
+			return rc;
+		}
+		added++;
+	}
+
+	D_ASSERT(added > 0);
+	return 0;
+}
+
+static int
+gc_move_bins(struct vos_pool *pool, struct vos_gc_item *item, int *credits, bool *empty_ret)
+{
+	struct umem_instance	*umm = &pool->vp_umm;
+	struct umem_attr	*uma = &pool->vp_uma;
+	struct vos_cont_df	*cd = umem_off2ptr(umm, item->it_addr);
+	struct vos_cont_ext_df	*cd_ext = umem_off2ptr(umm, cd->cd_ext);
+	daos_handle_t		 cont_btr;
+	d_iov_t			 key_out, val_out;
+	struct vos_gc_bin_df	*bins;
+	uint32_t		*bkt_id;
+	int			 rc, creds = *credits, moved = 0;
+
+	D_ASSERT(cd_ext != NULL);
+	rc = dbtree_open_inplace(&cd_ext->ced_gc_bkt.gd_bins_root, uma, &cont_btr);
+	if (rc) {
+		DL_ERROR(rc, "Failed to open container bucket tree.");
+		return rc;
+	}
+	D_ASSERT(daos_handle_is_valid(cont_btr));
+
+	*empty_ret = false;
+	while (creds > 0) {
+		/* Fetch the in-tree record from container */
+		d_iov_set(&key_out, NULL, 0);
+		d_iov_set(&val_out, NULL, 0);
+
+		rc = dbtree_fetch(cont_btr, BTR_PROBE_FIRST, DAOS_INTENT_DEFAULT,
+				  NULL, &key_out, &val_out);
+		if (rc == -DER_NONEXIST) {
+			*empty_ret = true;
+			rc = 0;
+			break;
+		} else if (rc) {
+			DL_ERROR(rc, "Failed to fetch bins from container bucket tree.");
+			break;
+		}
+
+		bins = (struct vos_gc_bin_df *)val_out.iov_buf;
+		D_ASSERT(bins && !bins_empty(pool, bins));
+		bkt_id = (uint32_t *)key_out.iov_buf;
+		D_ASSERT(bkt_id && *bkt_id != UMEM_DEFAULT_MBKT_ID);
+
+		rc = gc_add_bins(pool, bins, *bkt_id);
+		if (rc)
+			break;
+
+		rc = dbtree_delete(cont_btr, BTR_PROBE_BYPASS, NULL, NULL);
+		if (rc) {
+			DL_ERROR(rc, "Failed to delete bins from container bucket tree.");
+			break;
+		}
+
+		moved++;
+		/* Consume 1 user credit on moving 8 gc_bin[GC_CONT] */
+		if (moved % 8 == 0)
+			creds--;
+	}
+
+	if (*empty_ret)
+		dbtree_destroy(cont_btr, NULL);
+	else
+		dbtree_close(cont_btr);
+
+	if (rc == 0)
+		*credits = creds;
+
+	return rc;
+}
+
+static int
+gc_flatten_cont(struct vos_pool *pool, int *credits)
+{
+	struct vos_gc		*gc = &gc_table[GC_CONT];
+	struct vos_gc_item	*item;
+	struct vos_gc_bin_df	*bin;
+	int			 creds = *credits;
+	int			 rc = 0, flattened = 0;
+
+	while (creds > 0) {
+		bool	empty = false;
+
+		item = gc_get_item(gc, pool, NULL);
+		if (item == NULL)	/* No containers to be flattened */
+			break;
+
+		/* Move all gc_bin[GC_CONT] from container to pool */
+		rc = gc_move_bins(pool, item, &creds, &empty);
+		if (rc) {
+			DL_ERROR(rc, "GC move bins failed.");
+			break;
+		}
+
+		if (!empty) {
+			D_ASSERT(creds == 0);
+			break;
+		}
+
+		if (creds == 0)
+			break;
+
+		empty = false;
+		/* Container drain doesn't consume user credits */
+		rc = gc_drain_item(gc, pool, DAOS_HDL_INVAL, item, NULL, &empty);
+		if (rc) {
+			D_ASSERT(rc < 0);
+			DL_ERROR(rc, "GC drain %s failed.", gc->gc_name);
+			break;
+		}
+
+		flattened++;
+		/* Consume 1 user credit on flattening every 8 objects */
+		if (flattened % 8 == 0)
+			creds--;
+
+		/* The container is flattened, free the gc_item */
+		if (empty) {
+			bin = gc_type2bin(pool, NULL, gc->gc_type);
+			rc = gc_free_item(gc, pool, NULL, item, bin);
+			if (rc) {
+				DL_ERROR(rc, "GC free %s item failed.", gc->gc_name);
+				break;
+			}
+		}
+	}
+
+	if (rc == 0)
+		*credits = creds;
+
+	return rc;
+}
+
+static int
+bkt_get_bins(struct vos_pool *pool, struct vos_container *cont, uint32_t *bkt_id, bool try_next,
+	     struct vos_gc_bin_df **bins_ret)
+{
+	struct vos_gc_info	*gc_info;
+	struct vos_gc_bin_df	*bins = NULL;
+	int			 rc;
+
+	if (*bkt_id == UMEM_DEFAULT_MBKT_ID || try_next) {
+		if (cont != NULL)
+			bins = &cont->vc_cont_df->cd_gc_bins[0];
+		else
+			bins = &pool->vp_pool_df->pd_gc_bins[0];
+
+		if (!bins_empty(pool, bins)) {
+			*bkt_id = UMEM_DEFAULT_MBKT_ID;
+			*bins_ret = bins;
+			return 0;
+		} else if (!try_next) {
+			return -DER_NONEXIST;
+		}
+	}
+
+	gc_info = (cont != NULL) ? &cont->vc_gc_info : &pool->vp_gc_info;
+	rc = gc_bkt2bins(bkt_id, gc_info, false, try_next, &bins);
+	if (rc)
+		return rc;
+
+	D_ASSERT(bins && !bins_empty(pool, bins));
+	*bins_ret = bins;
+
+	return 0;
+}
+
+/*
+ * Return non-empty gc_bin[GC_CONT] with specified bucket ID, different bucket ID
+ * could be returned if there is nothing to be reclaimed on the specified bucket.
+ */
+static int
+gc_get_bkt(struct vos_pool *pool, struct vos_container **cont_in, uint32_t *bkt_id,
+	   struct vos_gc_bin_df **bins_ret)
+{
+	struct vos_container	*cont;
+	bool			 try_next = false;
+	int			 rc;
+
+switch_bkt:
+	/* Find non-empty gc_bin[GC_CONT] from containers */
+	d_list_for_each_entry(cont, &pool->vp_gc_cont, vc_gc_link) {
+		rc = bkt_get_bins(pool, cont, bkt_id, try_next, bins_ret);
+		if ((rc && rc != -DER_NONEXIST) || rc == 0)
+			goto done;
+	}
+
+	/* Find satisfied gc_bin[GC_CONT] from pool */
+	cont = NULL;
+	rc = bkt_get_bins(pool, NULL, bkt_id, try_next, bins_ret);
+	if ((rc && rc != -DER_NONEXIST) || rc == 0)
+		goto done;
+
+	if (!try_next) {
+		try_next = true;
+		goto switch_bkt;
+	}
+done:
+	if (*cont_in) {
+		vos_cont_decref(*cont_in);
+		*cont_in = NULL;
+	}
+
+	if (rc == 0 && cont) {
+		vos_cont_addref(cont);
+		*cont_in = cont;
+		/* Keep fairness */
+		d_list_del_init(&cont->vc_gc_link);
+		d_list_add_tail(&cont->vc_gc_link, &pool->vp_gc_cont);
+	}
+
+	return rc;
+}
+
+static int
+gc_reclaim_bins(struct vos_pool *pool, struct vos_container *cont,
+		struct vos_gc_bin_df *bins, int *credits, bool *empty_ret)
+{
+	struct vos_gc		*gc = &gc_table[0];	/* Start from akey */
+	struct vos_gc_item	*item;
+	int		 	 rc = 0, creds = *credits;
+
+	while (creds > 0) {
+		bool	empty = false;
+
+		D_ASSERT(gc->gc_type < GC_CONT);
+		item = bin_get_item(pool, &bins[gc->gc_type]);
+		if (item == NULL) {
+			if (gc->gc_type == GC_OBJ) {	/* hit the top level */
+				*empty_ret = true;
+				break;
+			}
+			/* Try upper level */
+			gc++;
+			continue;
+		}
+
+		rc = gc_drain_item(gc, pool, vos_cont2hdl(cont), item, &creds, &empty);
+		if (rc < 0) {
+			DL_ERROR(rc, "GC drain %s failed.", gc->gc_name);
+			break;
+		}
+
+		if (empty) {
+			rc = gc_free_item(gc, pool, cont, item, &bins[gc->gc_type]);
+			if (rc) {
+				DL_ERROR(rc, "GC free %s item failed.", gc->gc_name);
+				break;
+			}
+			if (creds > 0)
+				creds--;
+		}
+
+		/* always try to free akeys and values because they are the
+		 * items consuming most storage space.
+		 */
+		if (gc->gc_type == GC_AKEY)
+			continue;
+
+		/* should have flattened some items to the child GC, switch
+		 * to the child GC.
+		 */
+		gc--;
+	}
+
+	if (rc == 0)
+		*credits = creds;
+
+	return rc;
+}
+
+static int
+gc_delete_bins(struct vos_pool *pool, struct vos_container *cont, uint32_t bkt_id)
+{
+	struct vos_gc_bin_df	*bins;
+	struct vos_gc_info	*gc_info;
+	d_iov_t			 key, val_out;
+	int			 rc;
+
+	if (bkt_id == UMEM_DEFAULT_MBKT_ID)
+		return 0;
+
+	gc_info = (cont != NULL) ? &cont->vc_gc_info : &pool->vp_gc_info;
+	D_ASSERT(daos_handle_is_valid(gc_info->gi_bins_btr));
+
+	/* Fetch the in-tree record */
+	d_iov_set(&key, &bkt_id, sizeof(bkt_id));
+	d_iov_set(&val_out, NULL, 0);
+
+	rc = dbtree_fetch(gc_info->gi_bins_btr, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT, &key,
+			  NULL, &val_out);
+	if (rc) {
+		DL_ERROR(rc, "Failed to lookup GC bins for bkt_id:%u", bkt_id);
+		return rc;
+	}
+
+	bins = (struct vos_gc_bin_df *)val_out.iov_buf;
+	D_ASSERT(bins && !bins_empty(pool, bins));
+
+	rc = dbtree_delete(gc_info->gi_bins_btr, BTR_PROBE_BYPASS, &key, NULL);
+	if (rc)
+		DL_ERROR(rc, "Failed to delete GC bins for bkt_id:%u", bkt_id);
+
+	return rc;
+}
+
+static int
+gc_reclaim_pool_p2(struct vos_pool *pool, int *credits, bool *empty_ret)
+{
+	struct vos_container	*cont = NULL;
+	struct vos_gc_bin_df	*bins = NULL;
+	struct vos_gc_info	*gc_info = &pool->vp_gc_info;
+	uint32_t		 bkt = gc_info->gi_last_pinned, pinned_bkt = UMEM_DEFAULT_MBKT_ID;
+	struct umem_pin_handle	*pin_hdl = NULL;
+	struct umem_cache_range	 rg;
+	bool			 tx_started = false;
+	int			 creds = *credits, rc = 0;
+
+	if (pool->vp_dying) {
+		*empty_ret = true;
+		return rc;
+	}
+
+	*empty_ret = false;
+	while(creds > 0) {
+		bool	empty = false;
+
+		if (bkt != UMEM_DEFAULT_MBKT_ID && bkt != pinned_bkt) {
+			if (tx_started) {
+				tx_started = false;
+				rc = umem_tx_end(&pool->vp_umm, 0);
+				if (rc) {
+					DL_ERROR(rc, "Failed to commit GC tx.");
+					break;
+				}
+			}
+
+			if (pin_hdl != NULL) {
+				umem_cache_unpin(vos_pool2store(pool), pin_hdl);
+				pin_hdl = NULL;
+			}
+
+			rg.cr_off = umem_get_mb_base_offset(vos_pool2umm(pool), bkt);
+			rg.cr_size = vos_pool2store(pool)->cache->ca_page_sz;
+
+			rc = vos_cache_pin(pool, &rg, 1, false, &pin_hdl);
+			if (rc) {
+				DL_ERROR(rc, "Failed to pin bucket %u.", bkt);
+				break;
+			}
+			pinned_bkt = bkt;
+			gc_info->gi_last_pinned = pinned_bkt;
+		}
+
+		if (!tx_started) {
+			rc = umem_tx_begin(&pool->vp_umm, NULL);
+			if (rc) {
+				DL_ERROR(rc, "Failed to start tx for pool:"DF_UUID".",
+					 DP_UUID(pool->vp_id));
+				break;
+			}
+			tx_started = true;
+		}
+
+		/* Flatten all containers first */
+		rc = gc_flatten_cont(pool, &creds);
+		if (rc < 0) {
+			DL_ERROR(rc, "GC flatten cont failed.");
+			break;
+		}
+
+		/* Container flattening used up all user credits */
+		if (creds == 0)
+			break;
+
+		/*
+		 * Pick gc_bin[GC_CONT] by bucket ID, the bucket ID could be switched if
+		 * there is nothing to be reclaimed for the specified ID
+		 */
+		rc = gc_get_bkt(pool, &cont, &bkt, &bins);
+		if (rc == -DER_NONEXIST) {
+			*empty_ret = true;
+			rc = 0;
+			break;
+		} else if (rc) {
+			DL_ERROR(rc, "Failed to get GC bkt bins for bkt_id:%u", bkt);
+			break;
+		}
+
+		/* Bucket ID is switched, need to unpin current bucket then pin the new bucket */
+		if (bkt != UMEM_DEFAULT_MBKT_ID && bkt != pinned_bkt)
+			continue;
+
+		rc = gc_reclaim_bins(pool, cont, bins, &creds, &empty);
+		if (rc) {
+			DL_ERROR(rc, "GC reclaim bins for bkt_id:%u failed.", bkt);
+			break;
+		}
+
+		if (empty) {
+			/* The gc_bin[GC_CONT] is empty, delete it to condense the bucket tree */
+			rc = gc_delete_bins(pool, cont, bkt);
+			if (rc) {
+				DL_ERROR(rc, "GC delete bins for bkt_id:%u failed.", bkt);
+				break;
+			}
+		}
+	}
+
+	if (tx_started) {
+		rc = umem_tx_end(&pool->vp_umm, rc);
+		if (rc)
+			DL_ERROR(rc, "Failed to commit GC tx.");
+	}
+
+	if (pin_hdl != NULL) {
+		umem_cache_unpin(vos_pool2store(pool), pin_hdl);
+		pin_hdl = NULL;
+	}
+
+	if (cont != NULL)
+		vos_cont_decref(cont);
+
+	if (rc == 0)
+		*credits = creds;
+
+	gc_update_stats(pool);
+	return rc;
+}
+
+static inline void
+gc_close_bkt(struct vos_gc_info *gc_info)
+{
+
+	if (daos_handle_is_valid(gc_info->gi_bins_btr)) {
+		dbtree_close(gc_info->gi_bins_btr);
+		gc_info->gi_bins_btr = DAOS_HDL_INVAL;
+	}
+	gc_info->gi_last_pinned = UMEM_DEFAULT_MBKT_ID;
+}
+
+static inline int
+gc_open_bkt(struct umem_attr *uma, struct vos_gc_bkt_df *bkt_df, struct vos_gc_info *gc_info)
+{
+	int	rc;
+
+	rc = dbtree_open_inplace(&bkt_df->gd_bins_root, uma, &gc_info->gi_bins_btr);
+	if (rc)
+		DL_ERROR(rc, "Failed to open GC bin tree.");
+	return rc;
+}
+
+void
+gc_close_pool(struct vos_pool *pool)
+{
+	return gc_close_bkt(&pool->vp_gc_info);
+}
+
+int
+gc_open_pool(struct vos_pool *pool)
+{
+	struct vos_pool_ext_df	*pd_ext = umem_off2ptr(&pool->vp_umm, pool->vp_pool_df->pd_ext);
+
+	if (pd_ext != NULL)
+		return gc_open_bkt(&pool->vp_uma, &pd_ext->ped_gc_bkt, &pool->vp_gc_info);
+	return 0;
+}
+
+void
+gc_close_cont(struct vos_container *cont)
+{
+	return gc_close_bkt(&cont->vc_gc_info);
+}
+
+int
+gc_open_cont(struct vos_container *cont)
+{
+	struct vos_pool		*pool = vos_cont2pool(cont);
+	struct vos_cont_ext_df	*cd_ext = umem_off2ptr(&pool->vp_umm, cont->vc_cont_df->cd_ext);
+
+	if (cd_ext != NULL)
+		return gc_open_bkt(&pool->vp_uma, &cd_ext->ced_gc_bkt, &cont->vc_gc_info);
+	return 0;
+}
+
+static int
+gc_init_bkt(struct umem_instance *umm, struct vos_gc_bkt_df *bkt_df)
+{
+	struct umem_attr	uma;
+	daos_handle_t		bins_btr;
+	int			rc;
+
+	uma.uma_id = umm->umm_id;
+	uma.uma_pool = umm->umm_pool;
+
+	rc = dbtree_create_inplace(DBTREE_CLASS_IFV, BTR_FEAT_UINT_KEY, 12, &uma,
+				   &bkt_df->gd_bins_root, &bins_btr);
+	if (rc) {
+		DL_ERROR(rc, "Failed to create GC bin tree.");
+		return rc;
+	}
+	dbtree_close(bins_btr);
+
+	return 0;
+}
+
 /**
  * Initialize garbage bins for a pool.
  *
@@ -894,10 +1528,9 @@ done:
 int
 gc_init_pool(struct umem_instance *umm, struct vos_pool_df *pd)
 {
-	int		i;
-	umem_off_t	bag_id;
-	int		size;
-	int		rc;
+	struct vos_pool_ext_df	*pd_ext = umem_off2ptr(umm, pd->pd_ext);
+	umem_off_t		 bag_id;
+	int			 i, size, rc;
 
 	D_DEBUG(DB_IO, "Init garbage bins for pool="DF_UUID"\n",
 		DP_UUID(pd->pd_id));
@@ -919,6 +1552,10 @@ gc_init_pool(struct umem_instance *umm, struct vos_pool_df *pd)
 		bin->bin_bag_last = bag_id;
 		bin->bin_bag_nr = 1;
 	}
+
+	if (pd_ext != NULL)
+		return gc_init_bkt(umm, &pd_ext->ped_gc_bkt);
+
 	return 0;
 }
 
@@ -931,7 +1568,8 @@ gc_init_pool(struct umem_instance *umm, struct vos_pool_df *pd)
 int
 gc_init_cont(struct umem_instance *umm, struct vos_cont_df *cd)
 {
-	int	i;
+	struct vos_cont_ext_df	*cd_ext = umem_off2ptr(umm, cd->cd_ext);
+	int			 i;
 
 	D_DEBUG(DB_IO, "Init garbage bins for cont="DF_UUID"\n",
 		DP_UUID(cd->cd_id));
@@ -944,6 +1582,10 @@ gc_init_cont(struct umem_instance *umm, struct vos_cont_df *cd)
 		bin->bin_bag_size  = gc_bag_size;
 		bin->bin_bag_nr	   = 0;
 	}
+
+	if (cd_ext != NULL)
+		return gc_init_bkt(umm, &cd_ext->ced_gc_bkt);
+
 	return 0;
 }
 
@@ -955,16 +1597,24 @@ gc_check_cont(struct vos_container *cont)
 {
 	int	i;
 	struct vos_gc_bin_df	*bin;
+	struct vos_pool		*pool = cont->vc_pool;
 
 	D_INIT_LIST_HEAD(&cont->vc_gc_link);
 
 	for (i = 0; i < GC_CONT; i++) {
-		bin = gc_type2bin(cont->vc_pool, cont, i);
+		bin = gc_type2bin(pool, cont, i);
 		if (bin->bin_bag_first != UMOFF_NULL) {
-			d_list_add_tail(&cont->vc_gc_link,
-					&cont->vc_pool->vp_gc_cont);
+			d_list_add_tail(&cont->vc_gc_link, &pool->vp_gc_cont);
 			return;
 		}
+	}
+
+	if (vos_pool_is_evictable(pool)) {
+		struct vos_gc_info	*gc_info = &cont->vc_gc_info;
+
+		D_ASSERT(daos_handle_is_valid(gc_info->gi_bins_btr));
+		if (!dbtree_is_empty(gc_info->gi_bins_btr))
+			d_list_add_tail(&cont->vc_gc_link, &pool->vp_gc_cont);
 	}
 }
 
@@ -1001,8 +1651,10 @@ gc_del_pool(struct vos_pool *pool)
 	D_ASSERT(!d_list_empty(&pool->vp_gc_link));
 
 	pool->vp_opened--;
-	if (pool->vp_opened == 0)
+	if (pool->vp_opened == 0) {
 		vos_pool_hash_del(pool); /* un-pin from open-hash */
+		gc_close_pool(pool);
+	}
 
 	d_list_del_init(&pool->vp_gc_link);
 	vos_pool_decref(pool); /* -1 for the link */
@@ -1070,7 +1722,10 @@ vos_gc_run(int *credits)
 		D_DEBUG(DB_TRACE, "GC pool="DF_UUID", creds=%d\n",
 			DP_UUID(pool->vp_id), creds);
 
-		rc = gc_reclaim_pool(pool, &creds, &empty);
+		if (vos_pool_is_evictable(pool))
+			rc = gc_reclaim_pool_p2(pool, &creds, &empty);
+		else
+			rc = gc_reclaim_pool(pool, &creds, &empty);
 		if (rc) {
 			D_ERROR("GC pool="DF_UUID" error=%s\n",
 				DP_UUID(pool->vp_id), d_errstr(rc));
@@ -1149,7 +1804,10 @@ vos_gc_pool_tight(daos_handle_t poh, int *credits)
 		return 0; /* nothing to reclaim for this pool */
 
 	total = *credits;
-	rc = gc_reclaim_pool(pool, credits, &empty);
+	if (vos_pool_is_evictable(pool))
+		rc = gc_reclaim_pool_p2(pool, credits, &empty);
+	else
+		rc = gc_reclaim_pool(pool, credits, &empty);
 	if (rc) {
 		D_CRIT("gc_reclaim_pool failed " DF_RC "\n", DP_RC(rc));
 		return 0; /* caller can't do anything for it */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -267,6 +267,11 @@ struct vos_pool_metrics {
 	/* TODO: add more metrics for VOS */
 };
 
+struct vos_gc_info {
+	daos_handle_t	gi_bins_btr;
+	uint32_t	gi_last_pinned;
+};
+
 /**
  * VOS pool (DRAM)
  */
@@ -326,6 +331,8 @@ struct vos_pool {
 	uint32_t		 vp_data_thresh;
 	/** Space (in percentage) reserved for rebuild */
 	unsigned int		 vp_space_rb;
+	/* GC runtime for pool */
+	struct vos_gc_info	 vp_gc_info;
 };
 
 /**
@@ -379,7 +386,8 @@ struct vos_container {
 	 * * transaction with older epoch must have been committed.
 	 */
 	daos_epoch_t		vc_solo_dtx_epoch;
-
+	/* GC runtime for container */
+	struct vos_gc_info	vc_gc_info;
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,
@@ -1387,6 +1395,14 @@ int
 vos_gc_pool_tight(daos_handle_t poh, int *credits);
 void
 gc_reserve_space(daos_size_t *rsrvd);
+int
+gc_open_pool(struct vos_pool *pool);
+void
+gc_close_pool(struct vos_pool *pool);
+int
+gc_open_cont(struct vos_container *cont);
+void
+gc_close_cont(struct vos_container *cont);
 
 /**
  * If the object is fully punched, bypass normal aggregation and move it to container

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -80,6 +80,11 @@ enum vos_gc_type {
 	GC_MAX,
 };
 
+struct vos_gc_bkt_df {
+	/* GC bins categorized by bucket number */
+	struct btr_root		gd_bins_root;
+};
+
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 /** Lowest supported durable format version */
@@ -110,6 +115,16 @@ enum vos_gc_type {
 /** 2.8 features */
 #define VOS_POOL_FEAT_2_8			(VOS_POOL_FEAT_GANG_SV)
 
+/* VOS pool durable format extension */
+struct vos_pool_ext_df {
+	/* Extension for GC bucket */
+	struct vos_gc_bkt_df	ped_gc_bkt;
+	/* Paddings for other potential new feature */
+	uint64_t		ped_paddings[54];
+	/* Reserved for future extension */
+	uint64_t		ped_reserve;
+};
+
 /**
  * Durable format for VOS pool
  */
@@ -127,8 +142,8 @@ struct vos_pool_df {
 	 * a new format, containers with old format can be attached at here.
 	 */
 	uint64_t				pd_reserv_upgrade;
-	/** Reserved for future usage */
-	uint64_t				pd_reserv;
+	/** Pool durable format extension */
+	umem_off_t				pd_ext;
 	/** Unique PoolID for each VOS pool assigned on creation */
 	uuid_t					pd_id;
 	/** Total space in bytes on SCM */
@@ -252,6 +267,16 @@ enum vos_io_stream {
 	VOS_IOS_CNT
 };
 
+/* VOS container durable format extension */
+struct vos_cont_ext_df {
+	/* GC bucket extension */
+	struct vos_gc_bkt_df		ced_gc_bkt;
+	/* Reserved for potential new features */
+	uint64_t			ced_paddings[38];
+	/* Reserved for future extension */
+	uint64_t			ced_reserve;
+};
+
 /* VOS Container Value */
 struct vos_cont_df {
 	uuid_t				cd_id;
@@ -263,8 +288,8 @@ struct vos_cont_df {
 	struct btr_root			cd_obj_root;
 	/** reserved for placement algorithm upgrade */
 	uint64_t			cd_reserv_upgrade;
-	/** reserved for future usage */
-	uint64_t			cd_reserv;
+	/** Container durable format extension */
+	umem_off_t			cd_ext;
 	/** The active DTXs blob head. */
 	umem_off_t			cd_dtx_active_head;
 	/** The active DTXs blob tail. */

--- a/src/vos/vos_overhead.c
+++ b/src/vos/vos_overhead.c
@@ -8,13 +8,13 @@
 int
 vos_pool_get_msize(void)
 {
-	return sizeof(struct vos_pool_df);
+	return sizeof(struct vos_pool_df) + sizeof(struct vos_pool_ext_df);
 }
 
 int
 vos_container_get_msize(void)
 {
-	return sizeof(struct vos_cont_df);
+	return sizeof(struct vos_cont_df) + sizeof(struct vos_cont_ext_df);
 }
 
 int

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -1298,6 +1298,18 @@ vos_pool_create_ex(const char *path, uuid_t uuid, daos_size_t scm_sz, daos_size_
 		goto end;
 
 	memset(pool_df, 0, sizeof(*pool_df));
+
+	pool_df->pd_ext = umem_zalloc(&umem, sizeof(struct vos_pool_ext_df));
+	if (UMOFF_IS_NULL(pool_df->pd_ext)) {
+		D_ERROR("Failed to allocate pool df extension.\n");
+		rc = -DER_NOSPACE;
+		goto end;
+	}
+
+	rc = gc_init_pool(&umem, pool_df);
+	if (rc)
+		goto end;
+
 	rc = dbtree_create_inplace(VOS_BTR_CONT_TABLE, 0, VOS_CONT_ORDER,
 				   &uma, &pool_df->pd_cont_root, &hdl);
 	if (rc != 0)
@@ -1314,8 +1326,6 @@ vos_pool_create_ex(const char *path, uuid_t uuid, daos_size_t scm_sz, daos_size_
 		pool_df->pd_version = 0;
 	else
 		pool_df->pd_version = version;
-
-	gc_init_pool(&umem, pool_df);
 end:
 	/**
 	 * The transaction can in reality be aborted
@@ -1599,6 +1609,10 @@ pool_open(void *ph, struct vos_pool_df *pool_df, unsigned int flags, void *metri
 	if (rc)
 		goto failed;
 
+	rc = gc_open_pool(pool);
+	if (rc)
+		goto failed;
+
 	/* Insert the opened pool to the uuid hash table */
 	uuid_copy(ukey.uuid, pool_df->pd_id);
 	pool->vp_sysdb = !!(flags & VOS_POF_SYSDB);
@@ -1819,10 +1833,12 @@ vos_pool_close(daos_handle_t poh)
 	pool->vp_opened--;
 
 	/* If the last reference is holding by GC */
-	if (pool->vp_opened == 1 && gc_have_pool(pool))
+	if (pool->vp_opened == 1 && gc_have_pool(pool)) {
 		gc_del_pool(pool);
-	else if (pool->vp_opened == 0)
+	} else if (pool->vp_opened == 0) {
 		vos_pool_hash_del(pool);
+		gc_close_pool(pool);
+	}
 
 	vos_pool_decref(pool); /* -1 for myself */
 	return 0;


### PR DESCRIPTION
GC reclaim space in bucket order to avoid unnecessary eviction/load when free pages are tight.

This patch added an extension for pool & container durable format, which could be used by other potential new features in the future.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
