### PR TITLE
DAOS-16725 common: Fast failpath for allocation in EMB

### DIFF
--- a/src/common/dav_v2/heap.c
+++ b/src/common/dav_v2/heap.c
@@ -174,7 +174,7 @@ mbrt_set_laf(struct mbrt *mb, int c_id)
 	D_ASSERT(c_id < MAX_ALLOCATION_CLASSES);
 
 	mb->laf[c_id]   = true;
-	mb->laf_updated = 1;
+	mb->laf_updated = true;
 }
 
 static void
@@ -184,7 +184,7 @@ mbrt_clear_laf(struct mbrt *mb)
 		return;
 	if (mb->laf_updated) {
 		memset(mb->laf, 0, MAX_ALLOCATION_CLASSES);
-		mb->laf_updated = 0;
+		mb->laf_updated = false;
 	}
 }
 

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -3666,6 +3666,7 @@ umem_cache_reserve(struct umem_store *store)
 			DL_ERROR(rc, "Evict page failed.");
 			break;
 		}
+		rc = 0;
 
 		D_CDEBUG(retry_cnt == 10, DLOG_ERR, DB_TRACE,
 			 "Retry reserve free page, %d times\n", retry_cnt);


### PR DESCRIPTION
Addresses the following issues:
- When an EMB is out of space the allocation will spill over to NEMB. Added a fast fail feature so as to avoid exhaustive search of free memory blocks in EMB. md_test shows performance improvement with this change.
- Reordered the serialization code in EMB creation so as to reduce wait time for ULT requesting EMB. md_test shows performance improvement with this change.
- Addressed a bug in umem_cache_reserve(), where it was sometimes returns -DER_BUSY.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
