### PR TITLE
DAOS-16668 vos: missed so_cmp_key()

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2375,7 +2375,8 @@ pin_objects:
 	/* Commit multiple DTXs via single local transaction. */
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
-		committed = vos_dtx_commit_internal(cont, &dtis[idx], pinned, 0, &rm_cos[idx],
+		committed = vos_dtx_commit_internal(cont, &dtis[idx], pinned, 0,
+						    rm_cos != NULL ? &rm_cos[idx] : NULL,
 						    &daes[idx], &dces[idx]);
 		if (committed >= 0) {
 			rc = umem_tx_commit(vos_cont2umm(cont));

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -802,6 +802,19 @@ bkt_cmp(void *array, int a, int b)
 	return 0;
 }
 
+static int
+bkt_cmp_key(void *array, int i, uint64_t key)
+{
+	uint32_t	*bkt_arr = array;
+	uint32_t	 bkt_id = (uint32_t)key;
+
+	if (bkt_arr[i] > bkt_id)
+		return 1;
+	if (bkt_arr[i] < bkt_id)
+		return -1;
+	return 0;
+}
+
 static void
 bkt_swap(void *array, int a, int b)
 {
@@ -816,6 +829,7 @@ bkt_swap(void *array, int a, int b)
 static daos_sort_ops_t bkt_sort_ops = {
 	.so_cmp		= bkt_cmp,
 	.so_swap	= bkt_swap,
+	.so_cmp_key	= bkt_cmp_key,
 };
 
 /* if @sub is a subset of @super */


### PR DESCRIPTION
Add missed so_cmp_key() function.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
