### PR TITLE
DAOS-16710 test: Check for total space instead of free space.

### DIFF
--- a/src/tests/ftest/osa/online_drain.py
+++ b/src/tests/ftest/osa/online_drain.py
@@ -84,18 +84,18 @@ class OSAOnlineDrain(OSAUtils):
             self.pool.display_pool_daos_space("Pool space: Beginning")
             pver_begin = self.pool.get_version(True)
             self.log.info("Pool Version at the beginning %s", pver_begin)
-            # Get initial total free space (scm+nvme)
-            initial_free_space = self.pool.get_total_free_space(refresh=True)
+            # Get initial total space (scm+nvme)
+            initial_total_space = self.pool.get_total_space(refresh=True)
             output = self.pool.drain(rank, t_string)
             self.print_and_assert_on_rebuild_failure(output)
-            free_space_after_drain = self.pool.get_total_free_space(refresh=True)
+            total_space_after_drain = self.pool.get_total_space(refresh=True)
 
             pver_drain = self.pool.get_version(True)
             self.log.info("Pool Version after drain %s", pver_drain)
             # Check pool version incremented after pool exclude
             self.assertGreater(pver_drain, pver_begin, "Pool Version Error:  After drain")
-            self.assertGreater(initial_free_space, free_space_after_drain,
-                               "Expected free space after drain is less than initial")
+            self.assertGreater(initial_total_space, total_space_after_drain,
+                               "Expected total space after drain is more than initial")
             # Wait to finish the threads
             for thrd in threads:
                 thrd.join()


### PR DESCRIPTION
Test-tag: online_drain
Test-repeat: 3

Summary: Check for the total space instead of free space similar to offline drain testing to avoid intermittent failures.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
