### PR TITLE
DAOS-16096 test: Add retry loop for comparing free pool space (#15289)

### DIFF
--- a/src/tests/ftest/dfuse/root_container.py
+++ b/src/tests/ftest/dfuse/root_container.py
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
+import time
 
 from apricot import TestWithServers
 from dfuse_utils import get_dfuse, start_dfuse
@@ -138,25 +139,33 @@ class RootContainerTest(TestWithServers):
 
         expected = pool_space_before - cont_count * tmp_file_count * tmp_file_size
         self.log_step(
-            "Verify the pool free space <= {expected} after creating {cont_count} containers")
-        pool_space_after = pool.get_pool_free_space(device)
-        self.log.info("Pool space <= Expected")
-        self.log.info("%s <= %s", pool_space_after, expected)
-        self.assertTrue(pool_space_after <= expected)
+            f"Verify the pool free space <= {expected} after creating {cont_count} containers")
+        pool_space_after = self._get_pool_free_space(pool, device, expected)
+        if pool_space_after > expected:
+            self.fail(f"Pool free space exceeds {expected} after creating {cont_count} containers")
 
         self.log_step(f"Destroy half of the {cont_count} new sub containers ({cont_count // 2})")
         for _ in range(cont_count // 2):
             containers[-1].destroy(1)
             containers.pop()
 
+        # Wait for pool free space to reach expected value or timeout
         expected = pool_space_after + ((cont_count // 2) * tmp_file_count * tmp_file_size)
+        max_loops = 10
+        loop = 0
         self.log_step(
-            "Verify the pool free space >= {expected} after destroying half of the containers")
-        pool_space_after_cont_destroy = pool.get_pool_free_space(device)
-        self.log.info("After container destroy")
-        self.log.info("Free Pool space >= Expected")
-        self.log.info("%s >= %s", pool_space_after_cont_destroy, expected)
-        self.assertTrue(pool_space_after_cont_destroy >= expected)
+            f"Verify the pool free space >= {expected} after destroying half of the containers")
+        while loop < max_loops:
+            loop += 1
+            self.log.debug(
+                "Check if the pool free space >= %s (loop %s/%s)", expected, loop, max_loops)
+            current = self._get_pool_free_space(pool, device, expected)
+            if current >= expected:
+                break
+            if loop >= max_loops:
+                self.fail(
+                    f"Pool free space less than {expected} after destroying half of the containers")
+            time.sleep(int(60 / max_loops))
 
     def insert_files_and_verify(self, hosts, cont_dir, tmp_file_count, tmp_file_name,
                                 tmp_file_size):
@@ -181,22 +190,31 @@ class RootContainerTest(TestWithServers):
             cmd = f"head -c {tmp_file_size} /dev/urandom > {cont_dir}/{file_name}"
             ls_cmds.append(f"ls {file_name}")
             cmds.append(cmd)
-        self._execute_cmd(";".join(cmds), hosts)
+
+        result = run_remote(self.log, hosts, ";".join(cmds), timeout=30)
+        if not result.passed:
+            self.fail(f"Error inserting files into {tmp_file_name} on {str(result.failed_hosts)}")
 
         cmds = []
         # Run ls to verify the temp files are actually created
         cmds = [f"cd {cont_dir}"]
         cmds.extend(ls_cmds)
-        self._execute_cmd(";".join(cmds), hosts)
+        result = run_remote(self.log, hosts, ";".join(cmds), timeout=30)
+        if not result.passed:
+            self.fail(f"Error inserting files into {cont_dir} on {str(result.failed_hosts)}")
 
-    def _execute_cmd(self, cmd, hosts):
-        """Execute command on the host clients.
+    def _get_pool_free_space(self, pool, device, expected):
+        """Get the current pool free space.
 
         Args:
-            cmd (str): Command to run
-            hosts (NodeSet): hosts on which to run the command
+            pool (TestPool): pool to query
+            device (str): device type, e.g. "scm" or "nvme"
+            expected (int): expected pool free space
 
+        Returns:
+            int: current pool free space
         """
-        result = run_remote(self.log, hosts, cmd, timeout=30)
-        if not result.passed:
-            self.fail(f"Error running '{cmd}' on {str(result.failed_hosts)}")
+        current = pool.get_pool_free_space(device)
+        self.log.info("  Current pool free space:   %s", current)
+        self.log.info("  Expected pool free space:  %s", expected)
+        return current


### PR DESCRIPTION
Loop retrying the check for the pool free space after destroying half of the containers. If the check doesn't pass within 60 seconds, then fail the test.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_dfuse_root_container
Skip-func-hw-test-medium-md-on-ssd: false
Test-repeat: 10

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
