### PR TITLE
sherintg/vos on blob p2/daos 16763

### DIFF
--- a/src/common/dav_v2/heap.h
+++ b/src/common/dav_v2/heap.h
@@ -36,6 +36,8 @@ heap_cleanup(struct palloc_heap *heap);
 int
 heap_check(void *heap_start, uint64_t heap_size);
 int
+heap_get_max_nemb(struct palloc_heap *heap);
+int
 heap_create_alloc_class_buckets(struct palloc_heap *heap, struct alloc_class *c);
 int
 heap_mbrt_update_alloc_class_buckets(struct palloc_heap *heap, struct mbrt *mb,
@@ -148,5 +150,5 @@ uint32_t
 heap_off2mbid(struct palloc_heap *heap, uint64_t offset);
 
 struct heap_zone_limits
-heap_get_zone_limits(uint64_t heap_size, uint64_t cache_size);
+heap_get_zone_limits(uint64_t heap_size, uint64_t cache_size, uint32_t nemb_pct);
 #endif /* __DAOS_COMMON_HEAP_H */

--- a/src/common/dav_v2/heap_layout.h
+++ b/src/common/dav_v2/heap_layout.h
@@ -133,7 +133,8 @@ struct heap_header {
 	uint64_t heap_hdr_size;
 	uint64_t chunksize;
 	uint64_t chunks_per_zone;
-	uint8_t  reserved[4016];
+	uint8_t  nemb_pct;
+	uint8_t  reserved[4015];
 	uint64_t checksum;
 };
 


### PR DESCRIPTION
A new tunable, DAOS_MD_ON_SSD_NEMB_PCT is introuced, to define the percentage of memory cache that non-evictable memory buckets can expand to. This tunable will be read during pool creation and persisted, ensuring that each time the pool is reopened, it retains the value set during its creation.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
