### PR TITLE
DAOS-15429 test: Fix racy unit test

### DIFF
--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -128,11 +128,12 @@ func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
 			}(),
 			req: &testRequest{
 				rpcFn: func(ctx context.Context, _ *grpc.ClientConn) (proto.Message, error) {
-					if ctx.Err() != nil {
+					select {
+					case <-ctx.Done():
 						return nil, ctx.Err()
+					case <-time.After(10 * time.Second): // shouldn't be allowed to run this long
+						return defaultMessage, nil
 					}
-					time.Sleep(10 * time.Second) // shouldn't be allowed to run this long
-					return defaultMessage, nil
 				},
 			},
 			expResp: []*HostResponse{{}},


### PR DESCRIPTION
The previous change to this test introduced a race in the
context cancellation test case. Safer to just select on
the context done channel or the time after channel.

Required-githooks: true

Change-Id: Idbf4fa69ece13136b5c392a0bf1760c448cc47a0
Signed-off-by: Michael MacDonald <mjmac@google.com>
