### PR TITLE
DAOS-16781 client: Allow daos_metrics read via pid

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+daos (2.7.100-11) unstable; urgency=medium
+  [ Michael MacDonald ]
+  * Move daos_metrics utility to daos package for use on both clients
+    and servers.
+
+ -- Michael MacDonald <mjmac@google.com>  Tue, 5 Nov 2024 12:00:00 -0500
+
 daos (2.7.100-10) unstable; urgency=medium
 
   [ Sherin T George ]

--- a/debian/daos-server.install
+++ b/debian/daos-server.install
@@ -7,7 +7,6 @@ usr/bin/daos_server_helper
 # set daos_server to be setgid daos_server in order to invoke daos_server_helper
 usr/bin/daos_server
 usr/bin/daos_engine
-usr/bin/daos_metrics
 usr/bin/ddb
 usr/lib64/daos_srv/libchk.so
 usr/lib64/daos_srv/libcont.so

--- a/debian/daos.install
+++ b/debian/daos.install
@@ -1,3 +1,4 @@
+usr/bin/daos_metrics
 etc/daos/memcheck-cart.supp
 # Certificate generation files
 usr/lib64/daos/certgen/*

--- a/src/client/api/metrics.c
+++ b/src/client/api/metrics.c
@@ -30,13 +30,6 @@ bool daos_client_metric_retain;
  */
 
 static int
-shm_key(pid_t pid)
-{
-	/* Set the key based on our pid so that it can be easily found. */
-	return pid - D_TM_SHARED_MEMORY_KEY;
-}
-
-static int
 shm_chown(key_t key, uid_t new_owner)
 {
 	struct shmid_ds shmid_ds;
@@ -73,7 +66,7 @@ init_root(const char *name, pid_t pid, int flags)
 	key_t key;
 	int   rc;
 
-	key = shm_key(pid);
+	key = d_tm_cli_pid_key(pid);
 	rc  = d_tm_init_with_name(key, MAX_IDS_SIZE(INIT_JOB_NUM), flags, name);
 	if (rc != 0) {
 		DL_ERROR(rc, "failed to initialize root for %s.", name);
@@ -214,7 +207,7 @@ dump_tm_file(const char *dump_dir)
 	filter = D_TM_COUNTER | D_TM_DURATION | D_TM_TIMESTAMP | D_TM_MEMINFO |
 		 D_TM_TIMER_SNAPSHOT | D_TM_GAUGE | D_TM_STATS_GAUGE;
 
-	ctx = d_tm_open(shm_key(pid));
+	ctx = d_tm_open(d_tm_cli_pid_key(pid));
 	if (ctx == NULL)
 		D_GOTO(close, rc = -DER_NOMEM);
 

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -3970,6 +3970,18 @@ d_tm_get_srv_key(int srv_idx)
 	return D_TM_SHARED_MEMORY_KEY + srv_idx;
 }
 
+key_t
+d_tm_cli_pid_key(pid_t pid)
+{
+	/*
+	 * Set the key based the pid so that it can be easily found.
+	 * NB: This is the inverse of d_tm_get_srv_key() above; we
+	 * do it this way to hide the implementation details and avoid
+	 * unnecessary code changes.
+	 */
+	return pid - D_TM_SHARED_MEMORY_KEY;
+}
+
 /**
  * Allocates a shared memory segment for a given key.
  *

--- a/src/include/gurt/telemetry_common.h
+++ b/src/include/gurt/telemetry_common.h
@@ -258,6 +258,9 @@ struct d_tm_nodeList_t {
 struct d_tm_context;
 
 key_t d_tm_get_srv_key(int srv_idx);
+key_t
+		    d_tm_cli_pid_key(int pid);
+
 struct d_tm_node_t *d_tm_follow_link(struct d_tm_context *ctx,
 				     struct d_tm_node_t *link);
 int d_tm_list_add_node(struct d_tm_node_t *src,
@@ -269,4 +272,5 @@ double d_tm_compute_standard_dev(double sum_of_squares, uint64_t sample_size,
 				 double mean);
 void d_tm_compute_histogram(struct d_tm_node_t *node, uint64_t value);
 void d_tm_print_stats(FILE *stream, struct d_tm_stats_t *stats, int format);
+
 #endif /* __TELEMETRY_COMMON_H__ */

--- a/src/utils/daos_metrics/daos_metrics.c
+++ b/src/utils/daos_metrics/daos_metrics.c
@@ -57,7 +57,9 @@ print_usage(const char *prog_name)
 	       "--reset, -e\n"
 	       "\tReset all metrics to zero\n"
 	       "--jobid, -j\n"
-	       "\tDisplay metrics of the specified job\n",
+	       "\tDisplay metrics of the specified job (if agent-managed)\n"
+	       "--cli_pid, -P\n"
+	       "\tDisplay metrics of the specified client process\n",
 	       prog_name);
 }
 
@@ -125,6 +127,7 @@ main(int argc, char **argv)
 {
 	char			dirname[D_TM_MAX_NAME_LEN] = {0};
 	char                    jobid[D_TM_MAX_NAME_LEN]   = {0};
+	int                     cli_pid                    = 0;
 	bool			show_meta = false;
 	bool			show_when_read = false;
 	bool			show_type = false;
@@ -158,10 +161,11 @@ main(int argc, char **argv)
 						       {"read", no_argument, NULL, 'r'},
 						       {"reset", no_argument, NULL, 'e'},
 						       {"jobid", required_argument, NULL, 'j'},
+						       {"cli_pid", required_argument, NULL, 'P'},
 						       {"help", no_argument, NULL, 'h'},
 						       {NULL, 0, NULL, 0}};
 
-		opt = getopt_long_only(argc, argv, "S:cCdtsgi:p:D:MmTrj:he", long_options, NULL);
+		opt = getopt_long_only(argc, argv, "S:cCdtsgi:p:D:MmTrj:P:he", long_options, NULL);
 		if (opt == -1)
 			break;
 
@@ -214,6 +218,9 @@ main(int argc, char **argv)
 		case 'j':
 			snprintf(jobid, sizeof(jobid), "%s", optarg);
 			break;
+		case 'P':
+			cli_pid = atoi(optarg);
+			break;
 		case 'h':
 		case '?':
 		default:
@@ -244,6 +251,8 @@ main(int argc, char **argv)
 	if (strlen(jobid) > 0) {
 		srv_idx = DC_TM_JOB_ROOT_ID;
 		snprintf(dirname, sizeof(dirname), "%s", jobid);
+	} else if (cli_pid > 0) {
+		srv_idx = cli_pid - D_TM_SHARED_MEMORY_KEY;
 	}
 
 	/* fetch metrics from server side */

--- a/src/utils/daos_metrics/daos_metrics.c
+++ b/src/utils/daos_metrics/daos_metrics.c
@@ -252,7 +252,7 @@ main(int argc, char **argv)
 		srv_idx = DC_TM_JOB_ROOT_ID;
 		snprintf(dirname, sizeof(dirname), "%s", jobid);
 	} else if (cli_pid > 0) {
-		srv_idx = cli_pid - D_TM_SHARED_MEMORY_KEY;
+		srv_idx = d_tm_cli_pid_key(cli_pid);
 	}
 
 	/* fetch metrics from server side */

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -16,7 +16,7 @@
 
 Name:          daos
 Version:       2.7.100
-Release:       10%{?relval}%{?dist}
+Release:       11%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       BSD-2-Clause-Patent
@@ -418,6 +418,7 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 %{_sysconfdir}/bash_completion.d/daos.bash
 # Certificate generation files
 %dir %{_libdir}/%{name}
+%{_bindir}/daos_metrics
 %{_libdir}/%{name}/certgen/
 %{_libdir}/%{name}/VERSION
 %{_libdir}/libcart.so.*
@@ -434,7 +435,6 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # and/or daos_firmware_helper
 %attr(2755,root,daos_server) %{_bindir}/daos_server
 %{_bindir}/daos_engine
-%{_bindir}/daos_metrics
 %{_bindir}/ddb
 %{_sysconfdir}/ld.so.conf.d/daos.conf
 %dir %{_libdir}/daos_srv
@@ -593,6 +593,10 @@ getent passwd daos_agent >/dev/null || useradd -s /sbin/nologin -r -g daos_agent
 # No files in a shim package
 
 %changelog
+* Tue Nov 5 2024 Michael MacDonald <mjmac@google.com> 2.7.100-11
+- Move daos_metrics tool to daos package for use on both clients
+  and servers.
+
 * Fri Nov 1 2024 Sherin T George <sherin-t.george@hpe.com> 2.7.100-10
 - The modified DAV allocator with memory bucket support for md_on_ssd
   phase-2 is delivered as dav_v2.so.


### PR DESCRIPTION
In cases where the client telemetry has been manually
enabled, daos_metrics should be able to read it as
long as the client's PID is known and the user has
read access to the shared memory segment.

Moves the daos_metrics utility into the common daos
package for use from both server and client sides.

Features: telemetry
Required-githooks: true
Change-Id: I660dd758314a9c48a486f51647a1b497c8e27bd9
Signed-off-by: Michael MacDonald <mjmac@google.com>
