### PR TITLE
DAOS-16765 test: pool/verify_space.py - Increase timeout

### DIFF
--- a/src/tests/ftest/pool/verify_space.py
+++ b/src/tests/ftest/pool/verify_space.py
@@ -196,7 +196,7 @@ class VerifyPoolSpace(TestWithServers):
         self._compare_system_pool_size(pool_size, compare_methods)
 
     def test_verify_pool_space(self):
-        """Test ID: DAOS-3672.
+        """Test ID: DAOS-3672
 
         Test steps:
         1) Start servers and list associated storage, verify correctness

--- a/src/tests/ftest/pool/verify_space.yaml
+++ b/src/tests/ftest/pool/verify_space.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers: 3
   test_clients: 1
 
-timeout: 600
+timeout: 750
 
 server_config:
   # Test will require code changes if more than one rank/engine per host


### PR DESCRIPTION
In the past few passing runs, the test had ~100 sec test time remaining at the end with 600 sec timeout. This means the test usually takes ~500 sec. Set the timeout to
normal test duration * 1.5 = 750 sec

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-large-md-on-ssd: false
Test-tag: test_verify_pool_space

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
