### PR TITLE
DAOS-16365 client: use D_ASPRINTF and fix format issues

### DIFF
--- a/src/client/dfuse/pil4dfs/hook.c
+++ b/src/client/dfuse/pil4dfs/hook.c
@@ -217,7 +217,7 @@ read_map_file(char **buf)
 static void
 determine_lib_path(void)
 {
-	int   path_offset   = 0, read_size, i, rc;
+	int   path_offset   = 0, read_size, i;
 	char *read_buff_map = NULL;
 	char *pos, *start, *end, *lib_dir_str = NULL;
 
@@ -306,28 +306,17 @@ determine_lib_path(void)
 	}
 
 	/* with version in name */
-	rc = asprintf(&path_libpthread, "%s/libpthread-%s.so", lib_dir_str, libc_version_str);
-	if (rc < 0) {
-		DS_ERROR(ENOMEM, "Failed to allocate memory for path_libpthread");
+	D_ASPRINTF(path_libpthread, "%s/libpthread-%s.so", lib_dir_str, libc_version_str);
+	if (path_libpthread == NULL)
 		goto err_1;
-	}
-	if (rc >= PATH_MAX) {
-		free(path_libpthread);
-		path_libpthread = NULL;
+	if (strnlen(path_libpthread, PATH_MAX) >= PATH_MAX) {
+		D_FREE(path_libpthread);
 		DS_ERROR(ENAMETOOLONG, "path_libpthread is too long");
 		goto err_1;
 	}
-	rc = asprintf(&path_libdl, "%s/libdl-%s.so", lib_dir_str, libc_version_str);
-	if (rc < 0) {
-		DS_ERROR(ENOMEM, "Failed to allocate memory for path_libdl");
+	D_ASPRINTF(path_libdl, "%s/libdl-%s.so", lib_dir_str, libc_version_str);
+	if (path_libdl == NULL)
 		goto err_1;
-	}
-	if (rc >= PATH_MAX) {
-		free(path_libdl);
-		path_libdl = NULL;
-		DS_ERROR(ENAMETOOLONG, "path_libdl is too long");
-		goto err_1;
-	}
 	D_FREE(lib_dir_str);
 
 	if (strstr(read_buff_map, "libioil.so")) {
@@ -780,8 +769,8 @@ free_memory_in_hook(void)
 	D_FREE(path_ld);
 	D_FREE(path_libc);
 	D_FREE(module_list);
-	free(path_libdl);
-	free(path_libpthread);
+	D_FREE(path_libdl);
+	D_FREE(path_libpthread);
 
 	if (lib_name_list) {
 		for (i = 0; i < num_lib_in_map; i++) {

--- a/src/client/dfuse/pil4dfs/hook.c
+++ b/src/client/dfuse/pil4dfs/hook.c
@@ -308,15 +308,15 @@ determine_lib_path(void)
 	/* with version in name */
 	D_ASPRINTF(path_libpthread, "%s/libpthread-%s.so", lib_dir_str, libc_version_str);
 	if (path_libpthread == NULL)
-		goto err_1;
+		goto err;
 	if (strnlen(path_libpthread, PATH_MAX) >= PATH_MAX) {
 		D_FREE(path_libpthread);
 		DS_ERROR(ENAMETOOLONG, "path_libpthread is too long");
-		goto err_1;
+		goto err;
 	}
 	D_ASPRINTF(path_libdl, "%s/libdl-%s.so", lib_dir_str, libc_version_str);
 	if (path_libdl == NULL)
-		goto err_1;
+		goto err;
 	D_FREE(lib_dir_str);
 
 	if (strstr(read_buff_map, "libioil.so")) {
@@ -346,7 +346,6 @@ determine_lib_path(void)
 
 err:
 	D_FREE(read_buff_map);
-err_1:
 	D_FREE(lib_dir_str);
 	found_libc = 0;
 	quit_hook_init();

--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -1121,7 +1121,6 @@ query_new_dlsym_addr(void *addr)
 _Pragma("GCC diagnostic push")
 _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
 _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")
-
 _Pragma("GCC push_options")
 _Pragma("GCC optimize(\"-O0\")")
 static char str_zeinit[] = "zeInit";
@@ -1129,7 +1128,7 @@ static char str_zeinit[] = "zeInit";
 static int
 is_hook_enabled(void)
 {
-	return (d_hook_enabled ? (1) : (0));
+	return (d_hook_enabled ? 1 : 0);
 }
 
 /* This wrapper function is introduced to avoid compiling issue with Intel-C on Leap 15.5 */
@@ -1198,7 +1197,6 @@ new_dlsym_c(void *handle, const char *symbol)
 {
 	if (!d_hook_enabled)
 		goto org_dlsym;
-	printf("Inside my dlsym().\n");
 	if (strcmp(symbol, "zeInit") != 0)
 		goto org_dlsym;
 


### PR DESCRIPTION
Fix a few minor remaining issues in previous PR intercepting dlsym and zeInit.
1) Use D_ASPRINTF when possible
2) Remove unneeded newline, debugging output, and parentheses.

Features: pil4dfs

Required-githooks: true
Skipped-githooks: codespell

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
