### PR TITLE
DAOS-16749 vos: OI iterator for phase2 pool

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1163,6 +1163,40 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 	    vos_iter_cb_t post_cb, void *arg, struct dtx_handle *dth);
 
 /**
+ * Iterate VOS objects and subtrees when recursive mode is specified. When it's
+ * called against md-on-ssd phase2 pool, it iterates objects in bucket ID order
+ * instead of OID order to minimize bucket eviction/load.
+ *
+ * \param[in]		param		iteration parameters
+ * \param[in]		recursive	iterate in lower level recursively
+ * \param[in]		anchors		array of anchors, one for each
+ *					iteration level
+ * \param[in]		pre_cb		pre subtree iteration callback
+ * \param[in]		post_cb		post subtree iteration callback
+ * \param[in]		arg		callback argument
+ * \param[in]		dth		DTX handle
+ *
+ * \retval		0	iteration complete
+ * \retval		> 0	callback return value
+ * \retval		-DER_*	error (but never -DER_NONEXIST)
+ */
+int
+vos_iterate_obj(vos_iter_param_t *param, bool recursive, struct vos_iter_anchors *anchors,
+		vos_iter_cb_t pre_cb, vos_iter_cb_t post_cb, void *arg, struct dtx_handle *dth);
+
+/**
+ * Skip the object not located on specified bucket (for md-on-ssd phase2).
+ *
+ * \param ih[IN]	Iterator handle
+ * \param desc[IN]	Iterator desc for current OI entry
+ *
+ * \return		true:	current entry is skipped
+ *			false:	current entry isn't skipped
+ */
+bool
+vos_bkt_iter_skip(daos_handle_t ih, vos_iter_desc_t *desc);
+
+/**
  * Retrieve the largest or smallest integer DKEY, AKEY, and array offset from an
  * object. If object does not have an array value, 0 is returned in extent. User
  * has to specify what is being queried (dkey, akey, and/or recx) along with the

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -388,8 +388,12 @@ enum {
 
 typedef struct {
 	union {
-		/** The object id of the entry */
-		daos_unit_oid_t	 id_oid;
+		struct {
+			/** The object id of the entry */
+			daos_unit_oid_t		id_oid;
+			/** The bucket id of the object (for md-on-ssd phase2) */
+			uint32_t		id_bkt;
+		};
 		/** The key for the entry */
 		d_iov_t		 id_key;
 	};
@@ -443,6 +447,8 @@ typedef struct {
 	vos_iter_filter_cb_t	ip_filter_cb;
 	/** filter callback argument (vos_iterate only) */
 	void			*ip_filter_arg;
+	/** auxiliary data for md-on-ssd phase2 OI iterator */
+	void			*ip_bkt_iter;
 	/** flags for for iterator */
 	uint32_t		ip_flags;
 } vos_iter_param_t;

--- a/src/object/srv_ec_aggregate.c
+++ b/src/object/srv_ec_aggregate.c
@@ -2400,6 +2400,13 @@ check:
 		*acts = VOS_ITER_CB_SKIP;
 		goto done;
 	}
+
+	/* This MUST be the last check */
+	if (desc->id_type == VOS_ITER_OBJ && vos_bkt_iter_skip(ih, desc)) {
+		agg_param->ap_credits++;
+		*acts |= VOS_ITER_CB_SKIP;
+		goto done;
+	}
 done:
 	if (agg_param->ap_credits > agg_param->ap_credits_max) {
 		agg_param->ap_credits = 0;
@@ -2733,8 +2740,8 @@ retry:
 	if (rc != 0)
 		goto update_hae;
 
-	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors, agg_iterate_pre_cb,
-			 agg_iterate_post_cb, ec_agg_param, dth);
+	rc = vos_iterate_obj(&iter_param, true, &anchors, agg_iterate_pre_cb,
+			     agg_iterate_post_cb, ec_agg_param, dth);
 	if (rc == -DER_INPROGRESS && !d_list_empty(&dth->dth_share_tbd_list)) {
 		uint64_t	now = daos_gettime_coarse();
 

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2019-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -27,7 +27,7 @@ struct vos_dtx_iter {
 };
 
 static struct vos_dtx_iter *
-iter2oiter(struct vos_iterator *iter)
+iter2dtxiter(struct vos_iterator *iter)
 {
 	return container_of(iter, struct vos_dtx_iter, oit_iter);
 }
@@ -35,7 +35,7 @@ iter2oiter(struct vos_iterator *iter)
 static int
 dtx_iter_fini(struct vos_iterator *iter)
 {
-	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	struct vos_dtx_iter	*oiter = iter2dtxiter(iter);
 	int			 rc = 0;
 
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
@@ -96,7 +96,7 @@ dtx_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 static int
 dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor, uint32_t next /* Unimplemented */)
 {
-	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	struct vos_dtx_iter	*oiter = iter2dtxiter(iter);
 	struct vos_dtx_act_ent	*dae;
 	d_iov_t			 rec_iov;
 	int			 rc = 0;
@@ -168,7 +168,7 @@ out:
 static int
 dtx_iter_next(struct vos_iterator *iter, daos_anchor_t *anchor)
 {
-	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	struct vos_dtx_iter	*oiter = iter2dtxiter(iter);
 	struct vos_dtx_act_ent	*dae;
 	d_iov_t			 rec_iov;
 	int			 rc = 0;
@@ -215,7 +215,7 @@ static int
 dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	       daos_anchor_t *anchor)
 {
-	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	struct vos_dtx_iter	*oiter = iter2dtxiter(iter);
 	struct vos_dtx_act_ent	*dae;
 	d_iov_t			 rec_iov;
 	int			 rc;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1406,6 +1406,12 @@ gc_open_cont(struct vos_container *cont);
 void
 gc_close_cont(struct vos_container *cont);
 
+struct vos_bkt_iter {
+	uint32_t	bi_bkt_tot;
+	uint32_t	bi_bkt_cur;
+	uint8_t		bi_skipped[0];
+};
+
 /**
  * If the object is fully punched, bypass normal aggregation and move it to container
  * discard pool.

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -1045,6 +1045,81 @@ vos_iterate_key(struct vos_object *obj, daos_handle_t toh, vos_iter_type_t type,
 	return rc;
 }
 
+static inline void
+bkt_iter_free(struct vos_bkt_iter *bkt_iter)
+{
+	D_FREE(bkt_iter);
+}
+
+static struct vos_bkt_iter *
+bkt_iter_alloc(struct vos_pool *pool)
+{
+	struct umem_store	*store = vos_pool2store(pool);
+	struct umem_cache	*cache = store->cache;
+	struct vos_bkt_iter	*bkt_iter;
+	unsigned int		 bitmap_sz;
+
+	D_ASSERT(cache != NULL && cache->ca_md_pages > 0);
+	bitmap_sz = (cache->ca_md_pages + NBBY - 1) / NBBY;
+	D_ALLOC(bkt_iter, sizeof(*bkt_iter) + bitmap_sz);
+	if (bkt_iter == NULL)
+		return NULL;
+
+	bkt_iter->bi_bkt_tot = cache->ca_md_pages;
+	bkt_iter->bi_bkt_cur = UMEM_DEFAULT_MBKT_ID;
+
+	return bkt_iter;
+}
+
+int
+vos_iterate_obj(vos_iter_param_t *param, bool recursive, struct vos_iter_anchors *anchors,
+		vos_iter_cb_t pre_cb, vos_iter_cb_t post_cb, void *arg, struct dtx_handle *dth)
+{
+	struct vos_container	*cont;
+	struct vos_bkt_iter	*bkt_iter;
+	uint32_t		 i, iter_cnt = 0;
+	int			 rc = 0;
+
+	/* Not supposed being called by external enumeration which updating read timestamp */
+	D_ASSERT(!dtx_is_valid_handle(dth));
+
+	cont = vos_hdl2cont(param->ip_hdl);
+	if (!vos_pool_is_evictable(cont->vc_pool))
+		return vos_iterate_internal(param, VOS_ITER_OBJ, recursive, false, anchors,
+					    pre_cb, post_cb, arg, dth);
+
+	/* The caller must provide a filter callback and call the oi_bkt_iter_skip() properly */
+	D_ASSERT(param->ip_filter_cb != NULL && param->ip_bkt_iter == NULL);
+
+	bkt_iter = bkt_iter_alloc(cont->vc_pool);
+	if (bkt_iter == NULL)
+		return -DER_NOMEM;
+
+	param->ip_bkt_iter = bkt_iter;
+	for (i = UMEM_DEFAULT_MBKT_ID; i < bkt_iter->bi_bkt_tot; i++) {
+		if (i > UMEM_DEFAULT_MBKT_ID) {
+			/* The bucket wasn't skipped in prior rounds of iterating */
+			if (!isset(&bkt_iter->bi_skipped[0], i))
+				continue;
+			bkt_iter->bi_bkt_cur = i;
+		}
+
+		iter_cnt++;
+		rc = vos_iterate_internal(param, VOS_ITER_OBJ, recursive, false, anchors,
+					  pre_cb, post_cb, arg, dth);
+		if (rc) {
+			DL_ERROR(rc, "Iterate bucket:%u failed.", i);
+			break;
+		}
+	}
+	D_DEBUG(DB_TRACE, "Iterate %u/%u buckets.\n", iter_cnt, bkt_iter->bi_bkt_tot);
+
+	bkt_iter_free(bkt_iter);
+	param->ip_bkt_iter = NULL;
+
+	return rc;
+}
+
 /**
  * Iterate VOS entries (i.e., containers, objects, dkeys, etc.) and call \a
  * cb(\a arg) for each entry.


### PR DESCRIPTION
To minimize bucket eviction/load when iterating objects, vos_iterate_obj() is introduced to iterate objects in bucket ID order instead of OI order. The caller of vos_iterate_obj() needs to provide a filter callback to call the vos_bkt_iter_skip() properly.

Applied the vos_iterate_obj() for EC & VOS aggregation.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
