### PR TITLE
DAOS-16791 control: Add include_fabric_ifaces to agent config

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -55,11 +55,37 @@ type Config struct {
 	DisableAutoEvict    bool                       `yaml:"disable_auto_evict,omitempty"`
 	EvictOnStart        bool                       `yaml:"enable_evict_on_start,omitempty"`
 	ExcludeFabricIfaces common.StringSet           `yaml:"exclude_fabric_ifaces,omitempty"`
+	IncludeFabricIfaces common.StringSet           `yaml:"include_fabric_ifaces,omitempty"`
 	FabricInterfaces    []*NUMAFabricConfig        `yaml:"fabric_ifaces,omitempty"`
 	ProviderIdx         uint                       // TODO SRS-31: Enable with multiprovider functionality
 	TelemetryPort       int                        `yaml:"telemetry_port,omitempty"`
 	TelemetryEnabled    bool                       `yaml:"telemetry_enabled,omitempty"`
 	TelemetryRetain     time.Duration              `yaml:"telemetry_retain,omitempty"`
+}
+
+// Validate performs basic validation of the configuration.
+func (c *Config) Validate() error {
+	if c == nil {
+		return errors.New("config is nil")
+	}
+
+	if !daos.SystemNameIsValid(c.SystemName) {
+		return fmt.Errorf("invalid system name: %s", c.SystemName)
+	}
+
+	if c.TelemetryRetain > 0 && c.TelemetryPort == 0 {
+		return errors.New("telemetry_retain requires telemetry_port")
+	}
+
+	if c.TelemetryEnabled && c.TelemetryPort == 0 {
+		return errors.New("telemetry_enabled requires telemetry_port")
+	}
+
+	if len(c.ExcludeFabricIfaces) > 0 && len(c.IncludeFabricIfaces) > 0 {
+		return errors.New("cannot specify both exclude_fabric_ifaces and include_fabric_ifaces")
+	}
+
+	return nil
 }
 
 // TelemetryExportEnabled returns true if client telemetry export is enabled.
@@ -95,16 +121,8 @@ func LoadConfig(cfgPath string) (*Config, error) {
 		return nil, errors.Wrapf(err, "parsing config: %s", cfgPath)
 	}
 
-	if !daos.SystemNameIsValid(cfg.SystemName) {
-		return nil, fmt.Errorf("invalid system name: %s", cfg.SystemName)
-	}
-
-	if cfg.TelemetryRetain > 0 && cfg.TelemetryPort == 0 {
-		return nil, errors.New("telemetry_retain requires telemetry_port")
-	}
-
-	if cfg.TelemetryEnabled && cfg.TelemetryPort == 0 {
-		return nil, errors.New("telemetry_enabled requires telemetry_port")
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "agent config validation failed")
 	}
 
 	return cfg, nil

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -142,7 +142,7 @@ exclude_fabric_ifaces: ["ib3"]
 		},
 		"bad filter config": {
 			path:   badFilterCfg,
-			expErr: errors.New("agent config validation failed"),
+			expErr: errors.New("cannot specify both exclude_fabric_ifaces and include_fabric_ifaces"),
 		},
 		"all options": {
 			path: optCfg,

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -88,6 +88,18 @@ transport_config:
   allow_insecure: true
 `)
 
+	badFilterCfg := test.CreateTestFile(t, dir, `
+name: shire
+access_points: ["one:10001", "two:10001"]
+port: 4242
+runtime_dir: /tmp/runtime
+log_file: /home/frodo/logfile
+transport_config:
+  allow_insecure: true
+include_fabric_ifaces: ["ib0"]
+exclude_fabric_ifaces: ["ib3"]
+`)
+
 	for name, tc := range map[string]struct {
 		path      string
 		expResult *Config
@@ -127,6 +139,10 @@ transport_config:
 		"bad log mask": {
 			path:   badLogMaskCfg,
 			expErr: errors.New("not a valid log level"),
+		},
+		"bad filter config": {
+			path:   badFilterCfg,
+			expErr: errors.New("agent config validation failed"),
 		},
 		"all options": {
 			path: optCfg,

--- a/src/control/cmd/daos_agent/fabric_test.go
+++ b/src/control/cmd/daos_agent/fabric_test.go
@@ -224,7 +224,8 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 	for name, tc := range map[string]struct {
 		nf         *NUMAFabric
 		params     *FabricIfaceParams
-		ignore     []string
+		include    []string
+		exclude    []string
 		expErr     error
 		expResults []*FabricInterface
 	}{
@@ -723,6 +724,46 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 				},
 			},
 		},
+		"include interface": {
+			nf: &NUMAFabric{
+				numaMap: map[int][]*FabricInterface{
+					0: {
+						fabricInterfacesFromHardware(&hardware.FabricInterface{
+							NetInterfaces: common.NewStringSet("t1"),
+							Name:          "t1",
+							DeviceClass:   hardware.Ether,
+							Providers:     testFabricProviderSet("ofi+sockets"),
+						})[0],
+					},
+					1: {
+						fabricInterfacesFromHardware(&hardware.FabricInterface{
+							NetInterfaces: common.NewStringSet("t2"),
+							Name:          "t2",
+							DeviceClass:   hardware.Ether,
+							Providers:     testFabricProviderSet("ofi+sockets"),
+						})[0],
+					},
+				},
+			},
+			params: &FabricIfaceParams{
+				NUMANode: 0,
+				Provider: "ofi+sockets",
+				DevClass: hardware.Ether,
+			},
+			include: []string{"t2"},
+			expResults: []*FabricInterface{
+				{
+					Name:        "t2",
+					Domain:      "t2",
+					NetDevClass: hardware.Ether,
+				},
+				{
+					Name:        "t2",
+					Domain:      "t2",
+					NetDevClass: hardware.Ether,
+				},
+			},
+		},
 		"ignore interface": {
 			nf: &NUMAFabric{
 				numaMap: map[int][]*FabricInterface{
@@ -749,7 +790,7 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 				Provider: "ofi+sockets",
 				DevClass: hardware.Ether,
 			},
-			ignore: []string{"t1"},
+			exclude: []string{"t1"},
 			expResults: []*FabricInterface{
 				{
 					Name:        "t2",
@@ -787,8 +828,8 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 				Provider: "ofi+sockets",
 				DevClass: hardware.Ether,
 			},
-			ignore: []string{"t1", "t2"},
-			expErr: errors.New("no suitable fabric interface"),
+			exclude: []string{"t1", "t2"},
+			expErr:  errors.New("no suitable fabric interface"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -800,7 +841,13 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 					tc.nf.getAddrInterface = getMockNetInterfaceSuccess
 				}
 
-				tc.nf = tc.nf.WithIgnoredDevices(common.NewStringSet(tc.ignore...))
+				var exclude bool
+				filter := common.NewStringSet(tc.include...)
+				if len(tc.exclude) > 0 {
+					exclude = true
+					filter = common.NewStringSet(tc.exclude...)
+				}
+				tc.nf = tc.nf.WithDeviceFilter(filter, exclude)
 			}
 
 			numDevices := 0

--- a/src/control/cmd/daos_agent/fabric_test.go
+++ b/src/control/cmd/daos_agent/fabric_test.go
@@ -764,7 +764,7 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 				},
 			},
 		},
-		"ignore interface": {
+		"exclude interface": {
 			nf: &NUMAFabric{
 				numaMap: map[int][]*FabricInterface{
 					0: {
@@ -804,7 +804,7 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 				},
 			},
 		},
-		"ignore all interfaces": {
+		"exclude all interfaces": {
 			nf: &NUMAFabric{
 				numaMap: map[int][]*FabricInterface{
 					0: {
@@ -841,13 +841,13 @@ func TestAgent_NUMAFabric_GetDevice(t *testing.T) {
 					tc.nf.getAddrInterface = getMockNetInterfaceSuccess
 				}
 
-				var exclude bool
-				filter := common.NewStringSet(tc.include...)
-				if len(tc.exclude) > 0 {
-					exclude = true
-					filter = common.NewStringSet(tc.exclude...)
+				mode := filterModeExclude
+				devSet := common.NewStringSet(tc.exclude...)
+				if len(tc.include) > 0 {
+					mode = filterModeInclude
+					devSet = common.NewStringSet(tc.include...)
 				}
-				tc.nf = tc.nf.WithDeviceFilter(filter, exclude)
+				tc.nf = tc.nf.WithDeviceFilter(newDeviceFilter(devSet, mode))
 			}
 
 			numDevices := 0

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -69,13 +69,20 @@ func NewInfoCache(ctx context.Context, log logging.Logger, client control.UnaryI
 	return ic
 }
 
+func fabricDeviceFilter(cfg *Config) (common.StringSet, bool) {
+	if len(cfg.ExcludeFabricIfaces) > 0 {
+		return cfg.ExcludeFabricIfaces, true
+	}
+	return cfg.IncludeFabricIfaces, false
+}
+
 func getFabricScanFn(log logging.Logger, cfg *Config, scanner *hardware.FabricScanner) fabricScanFn {
 	return func(ctx context.Context, provs ...string) (*NUMAFabric, error) {
 		fis, err := scanner.Scan(ctx, provs...)
 		if err != nil {
 			return nil, err
 		}
-		return NUMAFabricFromScan(ctx, log, fis).WithIgnoredDevices(cfg.ExcludeFabricIfaces), nil
+		return NUMAFabricFromScan(ctx, log, fis).WithDeviceFilter(fabricDeviceFilter(cfg)), nil
 	}
 }
 

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -69,11 +69,11 @@ func NewInfoCache(ctx context.Context, log logging.Logger, client control.UnaryI
 	return ic
 }
 
-func fabricDeviceFilter(cfg *Config) (common.StringSet, bool) {
+func fabricDeviceFilter(cfg *Config) *deviceFilter {
 	if len(cfg.ExcludeFabricIfaces) > 0 {
-		return cfg.ExcludeFabricIfaces, true
+		return newDeviceFilter(cfg.ExcludeFabricIfaces, filterModeExclude)
 	}
-	return cfg.IncludeFabricIfaces, false
+	return newDeviceFilter(cfg.IncludeFabricIfaces, filterModeInclude)
 }
 
 func getFabricScanFn(log logging.Logger, cfg *Config, scanner *hardware.FabricScanner) fabricScanFn {

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -136,9 +136,14 @@
 #cache_expiration: 30
 
 ## Ignore a subset of fabric interfaces when selecting an interface for client
-## applications.
+## applications. (Mutually exclusive with include).
 #
 #exclude_fabric_ifaces: ["lo", "eth1"]
+
+## Conversely, only consider a specific set of fabric interfaces when selecting
+## an interface for client applications. (Mutually exclusive with exclude).
+#
+#include_fabric_ifaces: ["eth0"]
 
 # Manually define the fabric interfaces and domains to be used by the agent,
 # organized by NUMA node.


### PR DESCRIPTION
Provide an inverse to the existing exclude_fabric_ifaces
directive. In some cases, a given environment will only have
a small number of valid interfaces, so it is simpler to
specify that rather than having to exclude all of the
invalid interfaces.

Features: control
Required-githooks: true
Change-Id: I0d8445fcc2da267df76856d7f9f9b43eed290599
Signed-off-by: Michael MacDonald <mjmac@google.com>
