### PR TITLE
DAOS-16645 cart: Bump file descriptor limit (#15224)

### DIFF
--- a/ci/unit/test_nlt_node.sh
+++ b/ci/unit/test_nlt_node.sh
@@ -37,5 +37,9 @@ pip install --requirement requirements-utest.txt
 
 pip install /opt/daos/lib/daos/python/
 
+# set high open file limit in the shell to avoid extra warning
+sudo prlimit --nofile=1024:262144 --pid $$
+prlimit -n
+
 ./utils/node_local_test.py --max-log-size 1700MiB --dfuse-dir /localhome/jenkins/ \
     --log-usage-save nltir.xml --log-usage-export nltr.json all

--- a/utils/ansible/ftest/templates/daos-launch_nlt.sh.j2
+++ b/utils/ansible/ftest/templates/daos-launch_nlt.sh.j2
@@ -214,6 +214,7 @@ fi
 info "Fixing daos_server_helper"
 run sudo -E "$DAOS_SOURCE_DIR/utils/setup_daos_server_helper.sh"
 run chmod -x "$DAOS_INSTALL_DIR/bin/daos_server_helper"
+run sudo prlimit --nofile=1024:262144 --pid $$
 
 info "Starting NLT tests"
 pushd "$DAOS_SOURCE_DIR" > /dev/null

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -26,6 +26,7 @@ import pprint
 import pwd
 import random
 import re
+import resource
 import shutil
 import signal
 import stat
@@ -6512,6 +6513,12 @@ def main():
     parser.add_argument('--test', help="Use '--test list' for list")
     parser.add_argument('mode', nargs='*')
     args = parser.parse_args()
+
+    # valgrind reduces the hard limit unless we bump the soft limit first
+    if args.memcheck != "no":
+        (soft, hard) = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft < hard:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
 
     if args.server_fi:
         server_fi(args)


### PR DESCRIPTION
With tcp provider, using many sockets can cause significant file descriptor usage.  Bump the soft limit, if possible and warn if it appears insufficient.
Valgrind sets hard limit to soft limit, so work around that in NLT.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
