### PR TITLE
DAOS-16736 dfuse: Move readdir handle to active.

### DIFF
--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -185,7 +185,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent, const char *na
 	if (rc)
 		D_GOTO(err, rc);
 
-	dfuse_cache_evict_dir(dfuse_info, parent);
+	dfuse_cache_evict_dir(parent);
 
 	/** duplicate the file handle for the fuse handle */
 	rc = dfs_dup(dfs->dfs_ns, oh->doh_obj, O_RDWR, &ie->ie_obj);

--- a/src/client/dfuse/ops/opendir.c
+++ b/src/client/dfuse/ops/opendir.c
@@ -61,8 +61,6 @@ dfuse_cb_releasedir(fuse_req_t req, struct dfuse_inode_entry *ino, struct fuse_f
 	if (atomic_load_relaxed(&oh->doh_il_calls) != 0)
 		atomic_fetch_sub_relaxed(&oh->doh_ie->ie_il_count, 1);
 
-	active_oh_decref(oh);
-
 	DFUSE_TRA_DEBUG(oh, "Kernel cache flags invalid %d started %d finished %d",
 			oh->doh_kreaddir_invalid, oh->doh_kreaddir_started,
 			oh->doh_kreaddir_finished);
@@ -73,6 +71,8 @@ dfuse_cb_releasedir(fuse_req_t req, struct dfuse_inode_entry *ino, struct fuse_f
 	}
 
 	dfuse_dre_drop(dfuse_info, oh);
+
+	active_oh_decref(oh);
 
 	if (oh->doh_evict_on_close) {
 		ie = oh->doh_ie;

--- a/src/client/dfuse/ops/rename.c
+++ b/src/client/dfuse/ops/rename.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -77,10 +77,10 @@ dfuse_cb_rename(fuse_req_t req, struct dfuse_inode_entry *parent,
 #endif
 	}
 
-	dfuse_cache_evict_dir(dfuse_info, parent);
+	dfuse_cache_evict_dir(parent);
 
 	if (newparent) {
-		dfuse_cache_evict_dir(dfuse_info, newparent);
+		dfuse_cache_evict_dir(newparent);
 	} else {
 		newparent = parent;
 	}

--- a/src/client/dfuse/ops/unlink.c
+++ b/src/client/dfuse/ops/unlink.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2024 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -75,7 +75,7 @@ dfuse_cb_unlink(fuse_req_t req, struct dfuse_inode_entry *parent, const char *na
 	int                rc;
 	daos_obj_id_t      oid = {};
 
-	dfuse_cache_evict_dir(dfuse_info, parent);
+	dfuse_cache_evict_dir(parent);
 
 	rc = dfs_remove(parent->ie_dfs->dfs_ns, parent->ie_obj, name, false, &oid);
 	if (rc != 0) {


### PR DESCRIPTION
This reduces the memory consumption of an inode in memory and gives
finer grained locking.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
