### PR TITLE
DAOS-16791 control: Add include_fabric_ifaces to agent config (#15470)

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -55,11 +55,37 @@ type Config struct {
 	DisableAutoEvict    bool                       `yaml:"disable_auto_evict,omitempty"`
 	EvictOnStart        bool                       `yaml:"enable_evict_on_start,omitempty"`
 	ExcludeFabricIfaces common.StringSet           `yaml:"exclude_fabric_ifaces,omitempty"`
+	IncludeFabricIfaces common.StringSet           `yaml:"include_fabric_ifaces,omitempty"`
 	FabricInterfaces    []*NUMAFabricConfig        `yaml:"fabric_ifaces,omitempty"`
 	ProviderIdx         uint                       // TODO SRS-31: Enable with multiprovider functionality
 	TelemetryPort       int                        `yaml:"telemetry_port,omitempty"`
 	TelemetryEnabled    bool                       `yaml:"telemetry_enabled,omitempty"`
 	TelemetryRetain     time.Duration              `yaml:"telemetry_retain,omitempty"`
+}
+
+// Validate performs basic validation of the configuration.
+func (c *Config) Validate() error {
+	if c == nil {
+		return errors.New("config is nil")
+	}
+
+	if !daos.SystemNameIsValid(c.SystemName) {
+		return fmt.Errorf("invalid system name: %s", c.SystemName)
+	}
+
+	if c.TelemetryRetain > 0 && c.TelemetryPort == 0 {
+		return errors.New("telemetry_retain requires telemetry_port")
+	}
+
+	if c.TelemetryEnabled && c.TelemetryPort == 0 {
+		return errors.New("telemetry_enabled requires telemetry_port")
+	}
+
+	if len(c.ExcludeFabricIfaces) > 0 && len(c.IncludeFabricIfaces) > 0 {
+		return errors.New("cannot specify both exclude_fabric_ifaces and include_fabric_ifaces")
+	}
+
+	return nil
 }
 
 // TelemetryExportEnabled returns true if client telemetry export is enabled.
@@ -95,16 +121,8 @@ func LoadConfig(cfgPath string) (*Config, error) {
 		return nil, errors.Wrapf(err, "parsing config: %s", cfgPath)
 	}
 
-	if !daos.SystemNameIsValid(cfg.SystemName) {
-		return nil, fmt.Errorf("invalid system name: %s", cfg.SystemName)
-	}
-
-	if cfg.TelemetryRetain > 0 && cfg.TelemetryPort == 0 {
-		return nil, errors.New("telemetry_retain requires telemetry_port")
-	}
-
-	if cfg.TelemetryEnabled && cfg.TelemetryPort == 0 {
-		return nil, errors.New("telemetry_enabled requires telemetry_port")
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "agent config validation failed")
 	}
 
 	return cfg, nil

--- a/src/control/cmd/daos_agent/config_test.go
+++ b/src/control/cmd/daos_agent/config_test.go
@@ -88,6 +88,18 @@ transport_config:
   allow_insecure: true
 `)
 
+	badFilterCfg := test.CreateTestFile(t, dir, `
+name: shire
+access_points: ["one:10001", "two:10001"]
+port: 4242
+runtime_dir: /tmp/runtime
+log_file: /home/frodo/logfile
+transport_config:
+  allow_insecure: true
+include_fabric_ifaces: ["ib0"]
+exclude_fabric_ifaces: ["ib3"]
+`)
+
 	for name, tc := range map[string]struct {
 		path      string
 		expResult *Config
@@ -127,6 +139,10 @@ transport_config:
 		"bad log mask": {
 			path:   badLogMaskCfg,
 			expErr: errors.New("not a valid log level"),
+		},
+		"bad filter config": {
+			path:   badFilterCfg,
+			expErr: errors.New("cannot specify both exclude_fabric_ifaces and include_fabric_ifaces"),
 		},
 		"all options": {
 			path: optCfg,

--- a/src/control/cmd/daos_agent/fabric.go
+++ b/src/control/cmd/daos_agent/fabric.go
@@ -71,6 +71,37 @@ type addrFI interface {
 	Addrs() ([]net.Addr, error)
 }
 
+type filterMode int
+
+const (
+	// filterModeExclude indicates that devices in the set should be excluded
+	filterModeExclude filterMode = 0
+	// filterModeInclude indicates that only devices in the set should be included
+	filterModeInclude filterMode = 1
+)
+
+type deviceFilter struct {
+	deviceSet common.StringSet
+	mode      filterMode
+}
+
+func (df *deviceFilter) ShouldIgnore(devName string) bool {
+	if df == nil || df.deviceSet == nil {
+		return false
+	}
+	if df.mode == filterModeExclude {
+		return df.deviceSet.Has(devName)
+	}
+	return !df.deviceSet.Has(devName)
+}
+
+func newDeviceFilter(deviceSet common.StringSet, mode filterMode) *deviceFilter {
+	return &deviceFilter{
+		deviceSet: deviceSet,
+		mode:      mode,
+	}
+}
+
 // NUMAFabric represents a set of fabric interfaces organized by NUMA node.
 type NUMAFabric struct {
 	log   logging.Logger
@@ -78,9 +109,9 @@ type NUMAFabric struct {
 
 	numaMap map[int][]*FabricInterface
 
-	currentNumaDevIdx map[int]int // current device idx to use on each NUMA node
-	currentNUMANode   int         // current NUMA node to search
-	ignoreIfaces      common.StringSet
+	currentNumaDevIdx map[int]int   // current device idx to use on each NUMA node
+	currentNUMANode   int           // current NUMA node to search
+	ifaceFilter       *deviceFilter // set of interface names for filtering
 
 	getAddrInterface func(name string) (addrFI, error)
 }
@@ -98,12 +129,12 @@ func (n *NUMAFabric) Add(numaNode int, fi *FabricInterface) error {
 	return nil
 }
 
-// WithIgnoredDevices adds a set of fabric interface names that should be ignored when
-// selecting a device.
-func (n *NUMAFabric) WithIgnoredDevices(ifaces common.StringSet) *NUMAFabric {
-	n.ignoreIfaces = ifaces
-	if len(ifaces) > 0 {
-		n.log.Tracef("ignoring fabric devices: %s", n.ignoreIfaces)
+// WithDeviceFilter adds a set of fabric interface names that should be used for
+// filtering when selecting a device.
+func (n *NUMAFabric) WithDeviceFilter(filter *deviceFilter) *NUMAFabric {
+	if filter != nil {
+		n.ifaceFilter = filter
+		n.log.Tracef("fabric device filter: %+v", n.ifaceFilter)
 	}
 	return n
 }
@@ -192,8 +223,8 @@ func (n *NUMAFabric) getDeviceFromNUMA(numaNode int, netDevClass hardware.NetDev
 	for checked := 0; checked < n.getNumDevices(numaNode); checked++ {
 		fabricIF := n.getNextDevice(numaNode)
 
-		if n.ignoreIfaces.Has(fabricIF.Name) {
-			n.log.Tracef("device %s: ignored (ignore list %s)", fabricIF, n.ignoreIfaces)
+		if n.ifaceFilter.ShouldIgnore(fabricIF.Name) {
+			n.log.Tracef("device %s: ignored (filter: %+v)", fabricIF, n.ifaceFilter)
 			continue
 		}
 

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -69,13 +69,20 @@ func NewInfoCache(ctx context.Context, log logging.Logger, client control.UnaryI
 	return ic
 }
 
+func fabricDeviceFilter(cfg *Config) *deviceFilter {
+	if len(cfg.ExcludeFabricIfaces) > 0 {
+		return newDeviceFilter(cfg.ExcludeFabricIfaces, filterModeExclude)
+	}
+	return newDeviceFilter(cfg.IncludeFabricIfaces, filterModeInclude)
+}
+
 func getFabricScanFn(log logging.Logger, cfg *Config, scanner *hardware.FabricScanner) fabricScanFn {
 	return func(ctx context.Context, provs ...string) (*NUMAFabric, error) {
 		fis, err := scanner.Scan(ctx, provs...)
 		if err != nil {
 			return nil, err
 		}
-		return NUMAFabricFromScan(ctx, log, fis).WithIgnoredDevices(cfg.ExcludeFabricIfaces), nil
+		return NUMAFabricFromScan(ctx, log, fis).WithDeviceFilter(fabricDeviceFilter(cfg)), nil
 	}
 }
 

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -136,9 +136,14 @@
 #cache_expiration: 30
 
 ## Ignore a subset of fabric interfaces when selecting an interface for client
-## applications.
+## applications. (Mutually exclusive with include).
 #
 #exclude_fabric_ifaces: ["lo", "eth1"]
+
+## Conversely, only consider a specific set of fabric interfaces when selecting
+## an interface for client applications. (Mutually exclusive with exclude).
+#
+#include_fabric_ifaces: ["eth0"]
 
 # Manually define the fabric interfaces and domains to be used by the agent,
 # organized by NUMA node.


### PR DESCRIPTION
Provide an inverse to the existing exclude_fabric_ifaces
directive. In some cases, a given environment will only have
a small number of valid interfaces, so it is simpler to
specify that rather than having to exclude all of the
invalid interfaces.

Signed-off-by: Michael MacDonald <mjmac@google.com>