### PR TITLE
DAOS-16825 test: Support register cleanup for all Test classes

### DIFF
--- a/src/tests/ftest/control/config_generate_run.py
+++ b/src/tests/ftest/control/config_generate_run.py
@@ -52,6 +52,7 @@ class ConfigGenerateRun(TestWithServers):
             control_metadata = os.path.join(self.test_env.log_dir, 'control_metadata')
 
         # Call dmg config generate. AP is always the first server host.
+        self.log_step("Generating server configuration")
         server_host = self.hostlist_servers[0]
         result = self.get_dmg_command().config_generate(
             access_points=server_host, num_engines=num_engines, scm_only=scm_only,
@@ -66,25 +67,20 @@ class ConfigGenerateRun(TestWithServers):
         # Stop and restart daos_server. self.start_server_managers() has the
         # server start-up check built into it, so if there's something wrong,
         # it'll throw an error.
-        self.log.info("Stopping servers")
+        self.log_step("Stopping servers")
         self.stop_servers()
 
         # Create a new server config from generated_yaml and update SCM-related
         # data in engine_params so that the cleanup before the server start
         # works.
-        self.log.info("Copy config to %s and update engine_params", self.test_env.server_config)
+        self.log_step(f"Copy config to {self.test_env.server_config} and update engine_params")
         self.server_managers[0].update_config_file_from_file(generated_yaml)
 
         # Start server with the generated config.
-        self.log.info("Restarting server with the generated config")
+        self.log_step("Restarting server with the generated config")
         try:
-            agent_force = self.start_server_managers(force=True)
+            self.start_server_managers(force=True)
         except ServerFailed as error:
             self.fail(f"Restarting server failed! {error}")
 
-        # We don't need agent for this test. However, when we stop the server,
-        # agent is also stopped. Then the harness checks that the agent is
-        # running during the teardown. If agent isn't running at that point, it
-        # would cause an error, so start it here.
-        self.log.info("Restarting agents")
-        self.start_agent_managers(force=agent_force)
+        self.log.info("Test passed")

--- a/src/tests/ftest/network/cart_self_test.py
+++ b/src/tests/ftest/network/cart_self_test.py
@@ -77,6 +77,7 @@ class CartSelfTest(TestWithServers):
 
         # Start the daos server
         self.start_server_managers()
+        self.register_cleanup(self.stop_servers)
 
     def test_self_test(self):
         """Run a few CaRT self-test scenarios.

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -476,6 +476,9 @@ class Test(avocadoTest):
         self.report_timeout()
         super().tearDown()
 
+        # Execute any tear down steps in the reverse order of which they were registered.
+        self._teardown_errors.extend(self._cleanup())
+
         # Clean up any temporary files
         self._teardown_errors.extend(self.remove_temp_test_dir())
 
@@ -894,6 +897,7 @@ class TestWithServers(TestWithoutServers):
         self.setup_agents(agent_groups)
         if self.agent_managers:
             self.start_agent_managers(force)
+            self.register_cleanup(self.stop_agents)
 
     def start_servers(self, server_groups=None, force=False):
         """Start the daos_server processes.
@@ -917,6 +921,7 @@ class TestWithServers(TestWithoutServers):
         self.setup_servers(server_groups)
         if self.server_managers:
             force_agent_start = self.start_server_managers(force)
+            self.register_cleanup(self.stop_servers)
         return force_agent_start
 
     def restart_servers(self):
@@ -1396,23 +1401,13 @@ class TestWithServers(TestWithoutServers):
         # class (see DAOS-1452/DAOS-9941 and Avocado issue #5217 with
         # associated PR-5224)
         if self.status is not None and self.status != 'PASS' and self.status != 'SKIP':
-            self.__dump_engines_stacks("Test status is {}".format(self.status))
+            self.__dump_engines_stacks(f"Test status is {self.status}")
 
         # Report whether or not the timeout has expired
         self.report_timeout()
 
         # Tear down any test-specific items
         self._teardown_errors = self.pre_tear_down()
-
-        # Destroy any job managers, containers, pools, and dfuse instances next
-        # Eventually this call will encompass all teardown steps
-        self._teardown_errors.extend(self._cleanup())
-
-        # Stop the agents
-        self._teardown_errors.extend(self.stop_agents())
-
-        # Stop the servers
-        self._teardown_errors.extend(self.stop_servers())
 
         super().tearDown()
 
@@ -1613,11 +1608,6 @@ class TestWithServers(TestWithoutServers):
                 "Stopping %s group(s) of servers", len(self.server_managers))
             errors.extend(self._stop_managers(self.server_managers, "servers"))
 
-            # Stopping agents whenever servers are stopped for DAOS-6873
-            self.log.info(
-                "Workaround for DAOS-6873: Stopping %s group(s) of agents",
-                len(self.agent_managers))
-            errors.extend(self._stop_managers(self.agent_managers, "agents"))
         return errors
 
     def _stop_managers(self, managers, name):


### PR DESCRIPTION
Support calling register cleanup methods for tests based upon the Test and TestWithoutServers classes. Also remove stopping agents as part of calling TestWithServers.stop_servers() since DAOS-6873 is no longer an issue.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: pr daily_regression full_regression

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
