### PR TITLE
DAOS-16837 container: Add client-side DFS metrics

### DIFF
--- a/src/client/dfs/SConscript
+++ b/src/client/dfs/SConscript
@@ -44,7 +44,7 @@ def scons():
     libraries = ['daos_common', 'daos', 'uuid', 'gurt']
 
     dfs_src = ['common.c', 'cont.c', 'dir.c', 'file.c', 'io.c', 'lookup.c', 'mnt.c', 'obj.c',
-               'pipeline.c', 'readdir.c', 'rename.c', 'xattr.c', 'dfs_sys.c']
+               'pipeline.c', 'readdir.c', 'rename.c', 'xattr.c', 'dfs_sys.c', 'metrics.c']
     dfs = denv.d_library('dfs', dfs_src, LIBS=libraries)
     denv.Install('$PREFIX/lib64/', dfs)
 

--- a/src/client/dfs/common.c
+++ b/src/client/dfs/common.c
@@ -625,6 +625,8 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name, siz
 		stbuf->st_atim.tv_sec  = stbuf->st_mtim.tv_sec;
 		stbuf->st_atim.tv_nsec = stbuf->st_mtim.tv_nsec;
 	}
+
+	DFS_OP_STAT_INCR(dfs, DOS_STAT);
 	return 0;
 }
 
@@ -710,6 +712,7 @@ open_dir(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, struct 
 			D_ASSERT(rc == 0);
 			dir->d.chunk_size = entry->chunk_size;
 			dir->d.oclass     = entry->oclass;
+			DFS_OP_STAT_INCR(dfs, DOS_MKDIR);
 			return 0;
 		}
 	}
@@ -742,6 +745,7 @@ open_dir(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, struct 
 	oid_cp(&dir->oid, entry->oid);
 	dir->d.chunk_size = entry->chunk_size;
 	dir->d.oclass     = entry->oclass;
+	DFS_OP_STAT_INCR(dfs, DOS_OPENDIR);
 	return 0;
 }
 

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -15,6 +15,8 @@
 #include <daos.h>
 #include <daos_fs.h>
 
+#include "metrics.h"
+
 /** D-key name of SB metadata */
 #define SB_DKEY            "DFS_SB_METADATA"
 
@@ -190,6 +192,8 @@ struct dfs {
 	struct dfs_mnt_hdls *cont_hdl;
 	/** the root dir stat buf */
 	struct stat          root_stbuf;
+	/** DFS top-level metrics */
+	struct dfs_metrics  *metrics;
 };
 
 struct dfs_entry {

--- a/src/client/dfs/dir.c
+++ b/src/client/dfs/dir.c
@@ -65,6 +65,7 @@ dfs_mkdir(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode, daos_ocl
 	if (rc != 0)
 		return daos_der2errno(rc);
 
+	DFS_OP_STAT_INCR(dfs, DOS_MKDIR);
 	return rc;
 }
 
@@ -220,6 +221,7 @@ restart:
 	if (oid)
 		oid_cp(oid, entry.oid);
 
+	DFS_OP_STAT_INCR(dfs, DOS_UNLINK);
 out:
 	rc = check_tx(th, rc);
 	if (rc == ERESTART)

--- a/src/client/dfs/metrics.c
+++ b/src/client/dfs/metrics.c
@@ -1,0 +1,165 @@
+/**
+ * (C) Copyright 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#define D_LOGFAC DD_FAC(dfs)
+
+#include <uuid/uuid.h>
+#include <fcntl.h>
+
+#include <daos.h>
+#include <daos_fs.h>
+#include <daos_fs_sys.h>
+#include <daos/common.h>
+#include <daos/container.h>
+#include <daos/metrics.h>
+#include <daos/job.h>
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_producer.h>
+#include <gurt/telemetry_consumer.h>
+
+#include "metrics.h"
+#include "dfs_internal.h"
+
+#define DFS_METRICS_ROOT  "dfs"
+
+#define STAT_METRICS_SIZE (D_TM_METRIC_SIZE * DOS_LIMIT)
+#define FILE_METRICS_SIZE (((D_TM_METRIC_SIZE * NR_SIZE_BUCKETS) * 2) + D_TM_METRIC_SIZE * 2)
+#define DFS_METRICS_SIZE  (STAT_METRICS_SIZE + FILE_METRICS_SIZE)
+
+#define SPRINTF_CONT_PATH(buf, cont_uuid, path)                                                    \
+	snprintf(buf, sizeof(buf), "container/" DF_UUIDF "/%s", DP_UUID(cont_uuid), path);
+
+#define ADD_STAT_METRIC(name, ...)                                                                 \
+	SPRINTF_CONT_PATH(tmp_path, cont_uuid, DFS_METRICS_ROOT "/ops/" #name);                    \
+	rc = d_tm_add_metric(&metrics->dm_op_stats[i], D_TM_COUNTER, "Count of " #name " calls",   \
+			     "calls", tmp_path);                                                   \
+	if (rc != 0) {                                                                             \
+		DL_ERROR(rc, "failed to create " #name " counter");                                \
+		return;                                                                            \
+	}                                                                                          \
+	i++;
+
+static void
+op_stats_init(struct dfs_metrics *metrics, uuid_t cont_uuid)
+{
+	char tmp_path[D_TM_MAX_NAME_LEN] = {0};
+	int  i                           = 0;
+	int  rc;
+
+	if (metrics == NULL)
+		return;
+
+	D_FOREACH_DFS_OP_STAT(ADD_STAT_METRIC);
+}
+
+static void
+cont_stats_init(struct dfs_metrics *metrics, uuid_t cont_uuid)
+{
+	char tmp_path[D_TM_MAX_NAME_LEN] = {0};
+	int  rc                          = 0;
+
+	if (metrics == NULL)
+		return;
+
+	SPRINTF_CONT_PATH(tmp_path, cont_uuid, "mount_time");
+	rc = d_tm_add_metric(&metrics->dm_mount_time, D_TM_TIMESTAMP, "container mount time", NULL,
+			     tmp_path);
+	if (rc != 0)
+		DL_ERROR(rc, "failed to create mount_time timestamp");
+}
+
+static void
+file_stats_init(struct dfs_metrics *metrics, uuid_t cont_uuid)
+{
+	char tmp_path[D_TM_MAX_NAME_LEN] = {0};
+	int  rc                          = 0;
+
+	if (metrics == NULL)
+		return;
+
+	SPRINTF_CONT_PATH(tmp_path, cont_uuid, DFS_METRICS_ROOT "/read_bytes");
+	rc = d_tm_add_metric(&metrics->dm_read_bytes, D_TM_STATS_GAUGE, "dfs read bytes", "bytes",
+			     tmp_path);
+	if (rc != 0)
+		DL_ERROR(rc, "failed to create dfs read_bytes counter");
+	rc =
+	    d_tm_init_histogram(metrics->dm_read_bytes, tmp_path, NR_SIZE_BUCKETS, 256, 2, "bytes");
+	if (rc)
+		DL_ERROR(rc, "Failed to init dfs read size histogram");
+
+	SPRINTF_CONT_PATH(tmp_path, cont_uuid, DFS_METRICS_ROOT "/write_bytes");
+	rc = d_tm_add_metric(&metrics->dm_write_bytes, D_TM_STATS_GAUGE, "dfs write bytes", "bytes",
+			     tmp_path);
+	if (rc != 0)
+		DL_ERROR(rc, "failed to create dfs write_bytes counter");
+	rc = d_tm_init_histogram(metrics->dm_write_bytes, tmp_path, NR_SIZE_BUCKETS, 256, 2,
+				 "bytes");
+	if (rc)
+		DL_ERROR(rc, "Failed to init dfs write size histogram");
+}
+
+bool
+dfs_metrics_enabled()
+{
+	/* set in client/api/metrics.c */
+	return daos_client_metric;
+}
+
+void
+dfs_metrics_init(dfs_t *dfs)
+{
+	uuid_t cont_uuid;
+	char   root_name[D_TM_MAX_NAME_LEN];
+	pid_t  pid       = getpid();
+	size_t root_size = DFS_METRICS_SIZE + (D_TM_METRIC_SIZE * 3);
+	int    rc;
+
+	if (dfs == NULL)
+		return;
+
+	rc = dc_cont_hdl2uuid(dfs->coh, NULL, &cont_uuid);
+	if (rc != 0) {
+		DL_ERROR(rc, "failed to get container UUID");
+		goto error;
+	}
+
+	snprintf(root_name, sizeof(root_name), "%d", pid);
+	/* if only container-level metrics are enabled; this will init a root for them */
+	rc = d_tm_init_with_name(d_tm_cli_pid_key(pid), root_size, D_TM_OPEN_OR_CREATE, root_name);
+	if (rc != 0 && rc != -DER_ALREADY) {
+		DL_ERROR(rc, "failed to init DFS metrics");
+		goto error;
+	}
+
+	D_ALLOC_PTR(dfs->metrics);
+	if (dfs->metrics == NULL) {
+		D_ERROR("failed to alloc DFS metrics");
+		goto error;
+	}
+
+	SPRINTF_CONT_PATH(root_name, cont_uuid, DFS_METRICS_ROOT);
+	rc = d_tm_add_ephemeral_dir(NULL, DFS_METRICS_SIZE, root_name);
+	if (rc != 0) {
+		DL_ERROR(rc, "failed to add DFS metrics dir");
+		goto error;
+	}
+
+	cont_stats_init(dfs->metrics, cont_uuid);
+	op_stats_init(dfs->metrics, cont_uuid);
+	file_stats_init(dfs->metrics, cont_uuid);
+
+	d_tm_record_timestamp(dfs->metrics->dm_mount_time);
+	return;
+
+error:
+	if (dfs->metrics != NULL)
+		D_FREE(dfs->metrics);
+}
+
+void
+dfs_metrics_fini(dfs_t *dfs)
+{
+	D_FREE(dfs->metrics);
+}

--- a/src/client/dfs/metrics.h
+++ b/src/client/dfs/metrics.h
@@ -1,0 +1,79 @@
+/**
+ * (C) Copyright 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause-Patent
+ */
+#ifndef __DFS_METRICS_H__
+#define __DFS_METRICS_H__
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <daos.h>
+#include <daos_fs.h>
+#include <gurt/telemetry_common.h>
+#include <gurt/telemetry_producer.h>
+
+/*
+ * Report read/write counts on a per-I/O size.
+ * Buckets starts at [0; 256B[ and are increased by power of 2
+ * (i.e. [256B; 512B[, [512B; 1KB[) up to [4MB; infinity[
+ * Since 4MB = 2^22 and 256B = 2^8, this means
+ * (22 - 8 + 1) = 15 buckets plus the 4MB+ bucket, so
+ * 16 buckets in total.
+ */
+#define NR_SIZE_BUCKETS 16
+
+/* define a set of ops that we'll count if metrics are enabled */
+#define D_FOREACH_DFS_OP_STAT(ACTION)                                                              \
+	ACTION(CHMOD)                                                                              \
+	ACTION(CHOWN)                                                                              \
+	ACTION(CREATE)                                                                             \
+	ACTION(GETSIZE)                                                                            \
+	ACTION(GETXATTR)                                                                           \
+	ACTION(LSXATTR)                                                                            \
+	ACTION(MKDIR)                                                                              \
+	ACTION(OPEN)                                                                               \
+	ACTION(OPENDIR)                                                                            \
+	ACTION(READ)                                                                               \
+	ACTION(READDIR)                                                                            \
+	ACTION(READLINK)                                                                           \
+	ACTION(RENAME)                                                                             \
+	ACTION(RMXATTR)                                                                            \
+	ACTION(SETATTR)                                                                            \
+	ACTION(SETXATTR)                                                                           \
+	ACTION(STAT)                                                                               \
+	ACTION(SYMLINK)                                                                            \
+	ACTION(SYNC)                                                                               \
+	ACTION(TRUNCATE)                                                                           \
+	ACTION(UNLINK)                                                                             \
+	ACTION(WRITE)
+
+#define DFS_OP_STAT_DEFINE(name, ...) DOS_##name,
+
+enum dfs_op_stat {
+	D_FOREACH_DFS_OP_STAT(DFS_OP_STAT_DEFINE) DOS_LIMIT,
+};
+
+#define DFS_OP_STAT_INCR(_dfs, _name)                                                              \
+	if (_dfs->metrics != NULL)                                                                 \
+		d_tm_inc_counter(_dfs->metrics->dm_op_stats[(_name)], 1);
+
+struct dfs_metrics {
+	struct d_tm_node_t *dm_op_stats[DOS_LIMIT];
+	struct d_tm_node_t *dm_read_bytes;
+	struct d_tm_node_t *dm_write_bytes;
+	struct d_tm_node_t *dm_mount_time;
+};
+
+bool
+dfs_metrics_enabled();
+
+void
+dfs_metrics_init(dfs_t *dfs);
+
+void
+dfs_metrics_fini(dfs_t *dfs);
+
+#endif /* __DFS_METRICS_H__ */

--- a/src/client/dfs/mnt.c
+++ b/src/client/dfs/mnt.c
@@ -729,6 +729,9 @@ dfs_mount_int(daos_handle_t poh, daos_handle_t coh, int flags, daos_epoch_t epoc
 		daos_obj_oid_cycle(&dfs->oid);
 	}
 
+	if (dfs_metrics_enabled())
+		dfs_metrics_init(dfs);
+
 	dfs->mounted = DFS_MOUNT;
 	*_dfs        = dfs;
 	daos_prop_free(prop);
@@ -843,6 +846,8 @@ dfs_umount(dfs_t *dfs)
 
 	daos_obj_close(dfs->root.oh, NULL);
 	daos_obj_close(dfs->super_oh, NULL);
+
+	dfs_metrics_fini(dfs);
 
 	D_FREE(dfs->prefix);
 	D_MUTEX_DESTROY(&dfs->lock);

--- a/src/client/dfs/obj.c
+++ b/src/client/dfs/obj.c
@@ -208,6 +208,7 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_s
 			return rc;
 		} else {
 			D_ASSERT(rc == 0);
+			DFS_OP_STAT_INCR(dfs, DOS_CREATE);
 			return 0;
 		}
 	}
@@ -261,6 +262,7 @@ open_file(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, daos_s
 		}
 	}
 	oid_cp(&file->oid, entry->oid);
+	DFS_OP_STAT_INCR(dfs, DOS_OPEN);
 	return 0;
 }
 
@@ -320,6 +322,8 @@ open_symlink(dfs_t *dfs, dfs_obj_t *parent, int flags, daos_oclass_id_t cid, con
 			D_FREE(sym->value);
 			D_ERROR("Inserting entry '%s' failed: %d (%s)\n", sym->name, rc,
 				strerror(rc));
+		} else if (rc == 0) {
+			DFS_OP_STAT_INCR(dfs, DOS_SYMLINK);
 		}
 		return rc;
 	}
@@ -882,6 +886,8 @@ out:
 	rc2 = daos_obj_close(args->parent_oh, NULL);
 	if (rc == 0)
 		rc = rc2;
+	if (rc == 0)
+		DFS_OP_STAT_INCR(args->dfs, DOS_STAT);
 	return rc;
 }
 
@@ -1013,6 +1019,7 @@ err2_out:
 err1_out:
 	D_FREE(op_args);
 	daos_obj_close(args->parent_oh, NULL);
+
 	return rc;
 }
 
@@ -1243,6 +1250,7 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 
+	DFS_OP_STAT_INCR(dfs, DOS_CHMOD);
 out:
 	if (S_ISLNK(entry.mode)) {
 		dfs_release(sym);
@@ -1378,6 +1386,7 @@ dfs_chown(dfs_t *dfs, dfs_obj_t *parent, const char *name, uid_t uid, gid_t gid,
 		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 
+	DFS_OP_STAT_INCR(dfs, DOS_CHOWN);
 out:
 	if (!(flags & O_NOFOLLOW) && S_ISLNK(entry.mode)) {
 		dfs_release(sym);
@@ -1598,6 +1607,7 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 		D_GOTO(out_obj, rc = daos_der2errno(rc));
 	}
 
+	DFS_OP_STAT_INCR(dfs, DOS_SETATTR);
 out_stat:
 	*stbuf = rstat;
 out_obj:
@@ -1662,6 +1672,7 @@ dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len)
 		return daos_der2errno(rc);
 	}
 
+	DFS_OP_STAT_INCR(dfs, DOS_TRUNCATE);
 	return rc;
 }
 
@@ -1697,6 +1708,7 @@ dfs_get_symlink_value(dfs_obj_t *obj, char *buf, daos_size_t *size)
 		strcpy(buf, obj->value);
 
 	*size = val_size;
+	DFS_OP_STAT_INCR(obj->dfs, DOS_READLINK);
 	return 0;
 }
 
@@ -1709,6 +1721,7 @@ dfs_sync(dfs_t *dfs)
 		return EPERM;
 
 	/** Take a snapshot here and allow rollover to that when supported. */
+	/** Uncomment this when supported. DFS_OP_STAT_INCR(dfs, DOS_SYNC); */
 
 	return 0;
 }

--- a/src/client/dfs/readdir.c
+++ b/src/client/dfs/readdir.c
@@ -81,6 +81,7 @@ readdir_int(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr, str
 			break;
 	}
 	*nr = key_nr;
+	DFS_OP_STAT_INCR(dfs, DOS_READDIR);
 
 out:
 	D_FREE(enum_buf);
@@ -180,6 +181,7 @@ dfs_iterate(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr, siz
 	}
 
 	*nr = keys_nr;
+	DFS_OP_STAT_INCR(dfs, DOS_READDIR);
 out:
 	D_FREE(kds);
 	D_FREE(enum_buf);

--- a/src/client/dfs/rename.c
+++ b/src/client/dfs/rename.c
@@ -299,6 +299,8 @@ out:
 	rc = check_tx(th, rc);
 	if (rc == ERESTART)
 		goto restart;
+	if (rc == 0)
+		DFS_OP_STAT_INCR(dfs, DOS_RENAME);
 
 	if (entry.value) {
 		D_ASSERT(S_ISLNK(entry.mode));

--- a/src/client/dfs/xattr.c
+++ b/src/client/dfs/xattr.c
@@ -122,6 +122,7 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, const void *value, da
 		}
 	}
 
+	DFS_OP_STAT_INCR(dfs, DOS_SETXATTR);
 out:
 	daos_obj_close(oh, NULL);
 free:
@@ -194,6 +195,7 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value, daos_siz
 	}
 
 	*size = iod.iod_size;
+	DFS_OP_STAT_INCR(dfs, DOS_GETXATTR);
 
 close:
 	daos_obj_close(oh, NULL);
@@ -277,6 +279,7 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name)
 		D_GOTO(out, rc = daos_der2errno(rc));
 	}
 
+	DFS_OP_STAT_INCR(dfs, DOS_RMXATTR);
 out:
 	daos_obj_close(oh, NULL);
 free:
@@ -354,6 +357,7 @@ dfs_listxattr(dfs_t *dfs, dfs_obj_t *obj, char *list, daos_size_t *size)
 	}
 
 	*size = ret_size;
+	DFS_OP_STAT_INCR(dfs, DOS_LSXATTR);
 out:
 	daos_obj_close(oh, NULL);
 	return rc;

--- a/src/control/lib/telemetry/promexp/client.go
+++ b/src/control/lib/telemetry/promexp/client.go
@@ -82,13 +82,6 @@ func extractClientLabels(log logging.Logger, in string) (labels labelMap, name s
 		compsIdx++
 	}
 
-	switch comps[compsIdx] {
-	case "container":
-		compsIdx++
-		labels["container"] = comps[compsIdx]
-		compsIdx++
-	}
-
 	var engLabels labelMap
 	engLabels, name = extractLabels(log, strings.Join(comps[compsIdx:], string(telemetry.PathSep)))
 	for k, v := range engLabels {

--- a/src/control/lib/telemetry/promexp/client.go
+++ b/src/control/lib/telemetry/promexp/client.go
@@ -82,6 +82,13 @@ func extractClientLabels(log logging.Logger, in string) (labels labelMap, name s
 		compsIdx++
 	}
 
+	switch comps[compsIdx] {
+	case "container":
+		compsIdx++
+		labels["container"] = comps[compsIdx]
+		compsIdx++
+	}
+
 	var engLabels labelMap
 	engLabels, name = extractLabels(log, strings.Join(comps[compsIdx:], string(telemetry.PathSep)))
 	for k, v := range engLabels {

--- a/src/control/lib/telemetry/promexp/client_test.go
+++ b/src/control/lib/telemetry/promexp/client_test.go
@@ -26,6 +26,8 @@ func TestPromExp_extractClientLabels(t *testing.T) {
 	jobID := "testJob"
 	pid := "12345"
 	tid := "67890"
+	poolUUID := test.MockPoolUUID(1)
+	contUUID := test.MockPoolUUID(2)
 
 	testPath := func(suffix string) string {
 		return fmt.Sprintf("ID: %d/%s/%s/%s/%s", shmID, jobID, pid, tid, suffix)
@@ -75,30 +77,32 @@ func TestPromExp_extractClientLabels(t *testing.T) {
 			},
 		},
 		"pool ops": {
-			input:   fmt.Sprintf("ID: %d/%s/%s/pool/%s/ops/foo", shmID, jobID, pid, test.MockPoolUUID(1)),
+			input:   fmt.Sprintf("ID: %d/%s/%s/pool/%s/ops/foo", shmID, jobID, pid, poolUUID),
 			expName: "pool_ops_foo",
 			expLabels: labelMap{
 				"jobid": jobID,
 				"pid":   pid,
-				"pool":  test.MockPoolUUID(1).String(),
+				"pool":  poolUUID.String(),
 			},
 		},
 		"dfs ops": {
-			input:   fmt.Sprintf("ID: %d/%s/%s/container/%s/dfs/ops/CHMOD", shmID, jobID, pid, test.MockPoolUUID(1)),
+			input:   fmt.Sprintf("ID: %d/%s/%s/pool/%s/container/%s/dfs/ops/CHMOD", shmID, jobID, pid, poolUUID, contUUID),
 			expName: "dfs_ops_chmod",
 			expLabels: labelMap{
 				"jobid":     jobID,
 				"pid":       pid,
-				"container": test.MockPoolUUID(1).String(),
+				"pool":      poolUUID.String(),
+				"container": contUUID.String(),
 			},
 		},
 		"dfs read bytes": {
-			input:   fmt.Sprintf("ID: %d/%s/%s/container/%s/dfs/read_bytes", shmID, jobID, pid, test.MockPoolUUID(1)),
+			input:   fmt.Sprintf("ID: %d/%s/%s/pool/%s/container/%s/dfs/read_bytes", shmID, jobID, pid, poolUUID, contUUID),
 			expName: "dfs_read_bytes",
 			expLabels: labelMap{
 				"jobid":     jobID,
 				"pid":       pid,
-				"container": test.MockPoolUUID(1).String(),
+				"pool":      poolUUID.String(),
+				"container": contUUID.String(),
 			},
 		},
 	} {

--- a/src/control/lib/telemetry/promexp/client_test.go
+++ b/src/control/lib/telemetry/promexp/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/daos-stack/daos/src/control/common/test"
+	"github.com/daos-stack/daos/src/control/lib/telemetry"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -82,6 +83,24 @@ func TestPromExp_extractClientLabels(t *testing.T) {
 				"pool":  test.MockPoolUUID(1).String(),
 			},
 		},
+		"dfs ops": {
+			input:   fmt.Sprintf("ID: %d/%s/%s/container/%s/dfs/ops/CHMOD", shmID, jobID, pid, test.MockPoolUUID(1)),
+			expName: "dfs_ops_chmod",
+			expLabels: labelMap{
+				"jobid":     jobID,
+				"pid":       pid,
+				"container": test.MockPoolUUID(1).String(),
+			},
+		},
+		"dfs read bytes": {
+			input:   fmt.Sprintf("ID: %d/%s/%s/container/%s/dfs/read_bytes", shmID, jobID, pid, test.MockPoolUUID(1)),
+			expName: "dfs_read_bytes",
+			expLabels: labelMap{
+				"jobid":     jobID,
+				"pid":       pid,
+				"container": test.MockPoolUUID(1).String(),
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
@@ -136,6 +155,7 @@ func TestPromExp_NewClientCollector(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer telemetry.Fini()
 			result, err := NewClientCollector(ctx, log, cs, tc.opts)
 
 			test.CmpErr(t, tc.expErr, err)

--- a/src/control/lib/telemetry/promexp/engine.go
+++ b/src/control/lib/telemetry/promexp/engine.go
@@ -204,7 +204,7 @@ func extractLabels(log logging.Logger, in string) (labels labelMap, name string)
 		}
 	}
 
-	name = sanitizeMetricName(name)
+	name = strings.ToLower(sanitizeMetricName(name))
 	return
 }
 

--- a/src/control/lib/telemetry/promexp/engine.go
+++ b/src/control/lib/telemetry/promexp/engine.go
@@ -148,6 +148,13 @@ func extractLabels(log logging.Logger, in string) (labels labelMap, name string)
 			compsIdx++
 			name += "_ops_" + comps[compsIdx]
 			compsIdx++
+		case "container":
+			compsIdx++
+			labels["container"] = comps[compsIdx]
+			compsIdx++
+			if comps[compsIdx] == "dfs" {
+				name = "" // dfs metrics shouldn't go under pool
+			}
 		}
 	case "io":
 		name = "io"

--- a/src/gurt/telemetry.c
+++ b/src/gurt/telemetry.c
@@ -804,6 +804,12 @@ destroy_shmem_with_key(key_t key)
 	return 0;
 }
 
+static bool
+is_initialized(void)
+{
+	return tm_shmem.ctx != NULL && tm_shmem.ctx->shmem_root != NULL;
+}
+
 /**
  * Initialize an instance of the telemetry and metrics API for the producer
  * process with the root set to the provided name.
@@ -832,6 +838,9 @@ d_tm_init_with_name(int id, uint64_t mem_size, int flags, const char *root_name)
 	key_t			 key;
 	int                      shmid = 0;
 	int			 rc = DER_SUCCESS;
+
+	if (is_initialized())
+		return -DER_ALREADY;
 
 	if (root_name == NULL || strnlen(root_name, D_TM_MAX_NAME_LEN) == 0) {
 		D_ERROR("root name cannot be empty\n");
@@ -2251,13 +2260,6 @@ d_tm_find_metric(struct d_tm_context *ctx, char *path)
 		node = d_tm_follow_link(ctx, node);
 
 	return node;
-}
-
-static bool
-is_initialized(void)
-{
-	return tm_shmem.ctx != NULL &&
-	       tm_shmem.ctx->shmem_root != NULL;
 }
 
 /*

--- a/src/include/daos/pool.h
+++ b/src/include/daos/pool.h
@@ -158,6 +158,8 @@ void dc_pool_put(struct dc_pool *pool);
 
 int dc_pool_local2global(daos_handle_t poh, d_iov_t *glob);
 int dc_pool_global2local(d_iov_t glob, daos_handle_t *poh);
+int
+    dc_pool_hdl2uuid(daos_handle_t poh, uuid_t *hdl_uuid, uuid_t *pool_uuid);
 int dc_pool_connect(tse_task_t *task);
 int dc_pool_disconnect(tse_task_t *task);
 int dc_pool_query(tse_task_t *task);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1574,6 +1574,23 @@ out:
 	return rc;
 }
 
+int
+dc_pool_hdl2uuid(daos_handle_t poh, uuid_t *hdl_uuid, uuid_t *uuid)
+{
+	struct dc_pool *dp;
+
+	dp = dc_hdl2pool(poh);
+	if (dp == NULL)
+		return -DER_NO_HDL;
+
+	if (hdl_uuid != NULL)
+		uuid_copy(*hdl_uuid, dp->dp_pool_hdl);
+	if (uuid != NULL)
+		uuid_copy(*uuid, dp->dp_pool);
+	dc_pool_put(dp);
+	return 0;
+}
+
 struct pool_update_state {
 	struct rsvc_client	client;
 	struct dc_mgmt_sys     *sys;

--- a/src/tests/ftest/telemetry/basic_client_telemetry.py
+++ b/src/tests/ftest/telemetry/basic_client_telemetry.py
@@ -46,9 +46,7 @@ class BasicClientTelemetry(TestWithClientTelemetry):
         self.log_step('Reading client telemetry (reads & writes should be > 0)')
         after_metrics = self.telemetry.collect_client_data(metric_names)
         for metric in metric_names:
-            msum = 0
-            for value in after_metrics[metric].values():
-                msum += value
-            self.assertGreater(msum, 0)
+            msum = sum(after_metrics[metric].values())
+            self.assertGreater(msum, 0, f'{metric} value not greater than zero after I/O')
 
         self.log_step('Test passed')

--- a/src/tests/ftest/telemetry/dfs_client_telemetry.py
+++ b/src/tests/ftest/telemetry/dfs_client_telemetry.py
@@ -26,7 +26,7 @@ class DFSClientTelemetry(TestWithClientTelemetry):
 
         :avocado: tags=all,daily_regression
         :avocado: tags=vm
-        :avocado: tags=telemetry
+        :avocado: tags=dfs,telemetry
         :avocado: tags=DFSClientTelemetry,test_dfs_metrics
         """
         # create pool and container

--- a/src/tests/ftest/telemetry/dfs_client_telemetry.py
+++ b/src/tests/ftest/telemetry/dfs_client_telemetry.py
@@ -53,14 +53,10 @@ class DFSClientTelemetry(TestWithClientTelemetry):
         self.log_step('Reading dfs telemetry')
         after_metrics = self.telemetry.collect_client_data(val_metric_names + bkt_metric_names)
         for metric in val_metric_names:
-            msum = 0
-            for value in after_metrics[metric].values():
-                msum += value
-            self.assertGreater(msum, 0)
+            msum = sum(after_metrics[metric].values())
+            self.assertGreater(msum, 0, f'{metric} value not greater than zero after I/O')
         for metric in bkt_metric_names:
-            msum = 0
-            for hist in after_metrics[metric].values():
-                msum += hist['sample_sum']
-            self.assertGreater(msum, 0)
+            msum = sum([hist['sample_sum'] for hist in after_metrics[metric].values()])
+            self.assertGreater(msum, 0, f'{metric} sample_sum not greater than zero after I/O')
 
         self.log_step('Test passed')

--- a/src/tests/ftest/telemetry/dfs_client_telemetry.py
+++ b/src/tests/ftest/telemetry/dfs_client_telemetry.py
@@ -56,7 +56,7 @@ class DFSClientTelemetry(TestWithClientTelemetry):
             msum = sum(after_metrics[metric].values())
             self.assertGreater(msum, 0, f'{metric} value not greater than zero after I/O')
         for metric in bkt_metric_names:
-            msum = sum([hist['sample_sum'] for hist in after_metrics[metric].values()])
+            msum = sum(hist['sample_sum'] for hist in after_metrics[metric].values())
             self.assertGreater(msum, 0, f'{metric} sample_sum not greater than zero after I/O')
 
         self.log_step('Test passed')

--- a/src/tests/ftest/telemetry/dfs_client_telemetry.py
+++ b/src/tests/ftest/telemetry/dfs_client_telemetry.py
@@ -1,0 +1,66 @@
+"""
+  (C) Copyright 2024 Intel Corporation.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+"""
+from ior_utils import read_data, write_data
+from telemetry_test_base import TestWithClientTelemetry
+
+
+class DFSClientTelemetry(TestWithClientTelemetry):
+    """Tests to verify DFS telemetry.
+
+    :avocado: recursive
+    """
+
+    def test_dfs_metrics(self):
+        """JIRA ID: DAOS-16837.
+
+        Verify that the DFS metrics are incrementing as expected.
+        After performing some I/O, the DFS-level metrics should look reasonable.
+
+        Test steps:
+        1) Create a pool and container
+        2) Perform some I/O with IOR
+        3) Verify that the DFS metrics are sane
+
+        :avocado: tags=all,daily_regression
+        :avocado: tags=vm
+        :avocado: tags=telemetry
+        :avocado: tags=DFSClientTelemetry,test_dfs_metrics
+        """
+        # create pool and container
+        pool = self.get_pool(connect=True)
+        container = self.get_container(pool=pool)
+
+        self.log_step('Writing data to the pool (ior)')
+        ior = write_data(self, container)
+        self.log_step('Reading data from the pool (ior)')
+        read_data(self, ior, container)
+
+        # after an IOR run, we'd expect this set of metrics to have values > 0
+        val_metric_names = [
+            'client_dfs_ops_create',
+            'client_dfs_ops_open',
+            'client_dfs_ops_read',
+            'client_dfs_ops_write'
+        ]
+        bkt_metric_names = [
+            'client_dfs_read_bytes',
+            'client_dfs_write_bytes'
+        ]
+
+        self.log_step('Reading dfs telemetry')
+        after_metrics = self.telemetry.collect_client_data(val_metric_names + bkt_metric_names)
+        for metric in val_metric_names:
+            msum = 0
+            for value in after_metrics[metric].values():
+                msum += value
+            self.assertGreater(msum, 0)
+        for metric in bkt_metric_names:
+            msum = 0
+            for hist in after_metrics[metric].values():
+                msum += hist['sample_sum']
+            self.assertGreater(msum, 0)
+
+        self.log_step('Test passed')

--- a/src/tests/ftest/telemetry/dfs_client_telemetry.yaml
+++ b/src/tests/ftest/telemetry/dfs_client_telemetry.yaml
@@ -1,0 +1,46 @@
+hosts:
+  test_servers: 1
+  test_clients: 1
+
+timeout: 180
+
+server_config:
+  name: daos_server
+  engines_per_host: 1
+  engines:
+    0:
+      targets: 4
+      nr_xs_helpers: 0
+      storage:
+        0:
+          class: ram
+          scm_mount: /mnt/daos
+  system_ram_reserved: 1
+
+agent_config:
+  telemetry_port: 9191
+  telemetry_retain: 30s
+  telemetry_enabled: true
+
+pool:
+  scm_size: 2G
+
+container:
+  type: POSIX
+  control_method: daos
+  dfs_oclass: SX
+
+ior: &ior_base
+  ppn: 4
+  api: DFS
+  transfer_size: 512K
+  block_size: 1M
+  dfs_oclass: SX
+
+ior_write:
+  <<: *ior_base
+  flags: "-k -v -w -W -G 1"
+
+ior_read:
+  <<: *ior_base
+  flags: "-v -r -R -G 1"

--- a/src/tests/ftest/telemetry/dfs_client_telemetry.yaml
+++ b/src/tests/ftest/telemetry/dfs_client_telemetry.yaml
@@ -27,7 +27,6 @@ pool:
 
 container:
   type: POSIX
-  control_method: daos
   dfs_oclass: SX
 
 ior: &ior_base

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -1010,6 +1010,34 @@ class ClientTelemetryUtils(TelemetryUtils):
         CLIENT_IO_OPS_TGT_PUNCH_LATENCY_METRICS +\
         CLIENT_IO_OPS_TGT_UPDATE_ACTIVE_METRICS +\
         CLIENT_IO_OPS_UPDATE_ACTIVE_METRICS
+    CLIENT_DFS_OPS_METRICS = [
+        "client_dfs_ops_chmod",
+        "client_dfs_ops_chown",
+        "client_dfs_ops_create",
+        "client_dfs_ops_getsize",
+        "client_dfs_ops_getxattr",
+        "client_dfs_ops_lsxattr",
+        "client_dfs_ops_mkdir",
+        "client_dfs_ops_open",
+        "client_dfs_ops_opendir",
+        "client_dfs_ops_read",
+        "client_dfs_ops_readdir",
+        "client_dfs_ops_readlink",
+        "client_dfs_ops_rename",
+        "client_dfs_ops_rmxattr",
+        "client_dfs_ops_setattr",
+        "client_dfs_ops_setxattr",
+        "client_dfs_ops_stat",
+        "client_dfs_ops_symlink",
+        "client_dfs_ops_sync",
+        "client_dfs_ops_truncate",
+        "client_dfs_ops_unlink",
+        "client_dfs_ops_write"]
+    CLIENT_DFS_IO_METRICS = [
+        "client_dfs_read_bytes",
+        "client_dfs_write_bytes"]
+    CLIENT_DFS_METRICS = CLIENT_DFS_OPS_METRICS +\
+        CLIENT_DFS_IO_METRICS
 
     def __init__(self, dmg, servers, clients):
         """Create a ClientTelemetryUtils object.
@@ -1023,11 +1051,12 @@ class ClientTelemetryUtils(TelemetryUtils):
         super().__init__(dmg, servers)
         self.clients = NodeSet.fromlist(clients)
 
-    def get_all_client_metrics_names(self, with_pools=False):
+    def get_all_client_metrics_names(self, with_pools=False, with_dfs=False):
         """Get all the telemetry metrics names for this client.
 
         Args:
             with_pools (bool): if True, include pool metrics in the results
+            with_dfs (bool): if True, include DFS metrics in the results
 
         Returns:
             list: all of the telemetry metrics names for this client
@@ -1037,6 +1066,8 @@ class ClientTelemetryUtils(TelemetryUtils):
         all_metrics_names.extend(self.CLIENT_IO_METRICS)
         if with_pools:
             all_metrics_names.extend(self.CLIENT_POOL_METRICS)
+        if with_dfs:
+            all_metrics_names.extend(self.CLIENT_DFS_METRICS)
 
         return all_metrics_names
 
@@ -1217,13 +1248,21 @@ class MetricData():
                 if name not in data:
                     data[name] = {}
                 for metric in metrics[name]['metrics']:
-                    if 'labels' not in metric or 'value' not in metric:
+                    if 'labels' not in metric or \
+                            ('value' not in metric and 'buckets' not in metric):
                         continue
                     labels = [f'host:{host}']
                     for key, value in metric['labels'].items():
                         labels.append(":".join([str(key), str(value)]))
                     label_key = ",".join(sorted(labels))
-                    data[name][label_key] = metric['value']
+                    if 'value' in metric:
+                        data[name][label_key] = metric['value']
+                    else:
+                        data[name][label_key] = {
+                            'sample_count': metric['sample_count'],
+                            'sample_sum': metric['sample_sum'],
+                            'buckets': metric['buckets'],
+                        }
         return data
 
     def _set_display(self, compare=None):


### PR DESCRIPTION
If metrics are enabled for a POSIX container, create
a new pool/$UUID/container/$UUID/dfs metrics root in
the client telemetry to provide DFS-oriented metrics
(POSIX ops, file I/Os, etc).

Also fixes a bug in the agent code for pruning unused
client telemetry segments.

Features: container telemetry
Signed-off-by: Michael MacDonald <mjmac@google.com>
