### PR TITLE
DAOS-16863 dfs: disallow force removal of entries with caching

### DIFF
--- a/src/client/dfs/dfs_sys.c
+++ b/src/client/dfs/dfs_sys.c
@@ -1318,6 +1318,12 @@ dfs_sys_remove_type(dfs_sys_t *dfs_sys, const char *path, bool force,
 		return EINVAL;
 	if (path == NULL)
 		return EINVAL;
+	/*
+	 * since we are not evicting child entries from the dfs sys cache in case of force removal
+	 * of a dir, just disallow force removal if cache is enabled on the dfs sys mount.
+	 */
+	if (dfs_sys->hash && force)
+		return ENOTSUP;
 
 	rc = sys_path_parse(dfs_sys, &sys_path, path);
 	if (rc != 0)

--- a/src/tests/suite/dfs_sys_unit_test.c
+++ b/src/tests/suite/dfs_sys_unit_test.c
@@ -170,6 +170,12 @@ dfs_sys_test_create_remove(void **state)
 	rc = dfs_sys_symlink(dfs_sys_mt, sym1_target, sym1);
 	assert_int_equal(rc, 0);
 
+	/** remove should return ENOTSUP with force since caching is enabled */
+	rc = dfs_sys_remove(dfs_sys_mt, dir1, true, NULL);
+	assert_int_equal(rc, ENOTSUP);
+	rc = dfs_sys_remove_type(dfs_sys_mt, dir1, true, S_IFDIR, NULL);
+	assert_int_equal(rc, ENOTSUP);
+
 	/** Remove dirs, links with remove */
 	rc = dfs_sys_remove(dfs_sys_mt, sym1, 0, 0);
 	assert_int_equal(rc, 0);
@@ -212,20 +218,18 @@ dfs_sys_test_create_remove(void **state)
 	rc = dfs_sys_close(obj);
 	assert_int_equal(rc, 0);
 
-	/** Remove files with remove */
-	rc = dfs_sys_remove(dfs_sys_mt, file2, 0, 0);
-	assert_int_equal(rc, 0);
-
 	/** Remove dirs, files, links with remove_type */
 	rc = dfs_sys_remove_type(dfs_sys_mt, file1, false, S_IFREG, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_sys_remove_type(dfs_sys_mt, file2, false, S_IFREG, NULL);
 	assert_int_equal(rc, 0);
 	rc = dfs_sys_remove_type(dfs_sys_mt, sym1, false, S_IFLNK, NULL);
 	assert_int_equal(rc, 0);
 	rc = dfs_sys_remove_type(dfs_sys_mt, dir3, false, S_IFDIR, NULL);
 	assert_int_equal(rc, 0);
-
-	/** Remove dirs with remove_type(force) */
-	rc = dfs_sys_remove_type(dfs_sys_mt, dir1, true, S_IFDIR, NULL);
+	rc = dfs_sys_remove_type(dfs_sys_mt, dir2, false, S_IFDIR, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_sys_remove_type(dfs_sys_mt, dir1, false, S_IFDIR, NULL);
 	assert_int_equal(rc, 0);
 
 	/** Create dirs, files with mknod */
@@ -242,8 +246,14 @@ dfs_sys_test_create_remove(void **state)
 			   0, 0);
 	assert_int_equal(rc, 0);
 
-	/** Remove tree (dir) with remove(force) */
-	rc = dfs_sys_remove(dfs_sys_mt, dir1, true, NULL);
+	/** Remove tree with remove */
+	rc = dfs_sys_remove(dfs_sys_mt, file1, false, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_sys_remove(dfs_sys_mt, dir3, false, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_sys_remove(dfs_sys_mt, dir2, false, NULL);
+	assert_int_equal(rc, 0);
+	rc = dfs_sys_remove(dfs_sys_mt, dir1, false, NULL);
 	assert_int_equal(rc, 0);
 }
 
@@ -640,7 +650,14 @@ dfs_sys_test_open_readdir(void **state)
 	rc = dfs_sys_closedir(dirp);
 	assert_int_equal(rc, 0);
 
-	rc = dfs_sys_remove(dfs_sys_mt, dir1, true, NULL);
+	for (i = 0; i < num_dirs; i++) {
+		rc = snprintf(buf, buf_size, "%s/sub%u", dir1, i);
+		assert_true(rc > 0);
+		rc = dfs_sys_remove(dfs_sys_mt, buf, false, 0);
+		assert_int_equal(rc, 0);
+	}
+	rc = dfs_sys_remove(dfs_sys_mt, dir1, false, NULL);
+	assert_int_equal(rc, 0);
 }
 
 /**
@@ -848,11 +865,11 @@ dfs_sys_test_mkdir(void **state)
 	rc = dfs_sys_mkdir(dfs_sys_mt, file, S_IWUSR | S_IRUSR, 0);
 	assert_int_equal(rc, EEXIST);
 
-	rc = dfs_sys_remove(dfs_sys_mt, file, true, NULL);
+	rc = dfs_sys_remove(dfs_sys_mt, file, false, NULL);
 	assert_int_equal(rc, 0);
-	rc = dfs_sys_remove(dfs_sys_mt, child, true, NULL);
+	rc = dfs_sys_remove(dfs_sys_mt, child, false, NULL);
 	assert_int_equal(rc, 0);
-	rc = dfs_sys_remove(dfs_sys_mt, parent, true, NULL);
+	rc = dfs_sys_remove(dfs_sys_mt, parent, false, NULL);
 	assert_int_equal(rc, 0);
 }
 
@@ -885,11 +902,11 @@ dfs_sys_test_mkdir_p(void **state)
 	rc = dfs_sys_mkdir_p(dfs_sys_mt, file, S_IWUSR | S_IRUSR, 0);
 	assert_int_equal(rc, EEXIST);
 
-	rc = dfs_sys_remove(dfs_sys_mt, file, true, NULL);
+	rc = dfs_sys_remove(dfs_sys_mt, file, false, NULL);
 	assert_int_equal(rc, 0);
-	rc = dfs_sys_remove(dfs_sys_mt, child, true, NULL);
+	rc = dfs_sys_remove(dfs_sys_mt, child, false, NULL);
 	assert_int_equal(rc, 0);
-	rc = dfs_sys_remove(dfs_sys_mt, parent, true, NULL);
+	rc = dfs_sys_remove(dfs_sys_mt, parent, false, NULL);
 	assert_int_equal(rc, 0);
 }
 


### PR DESCRIPTION
if a dfs sys mount has caching enabled, disable force removal of dir that does not check for child entries. DFS sys does not evict them from the cache in that case and that can cause namespace corruptions.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
