### PR TITLE
DAOS-7273 pool: Fix dmg pool exclude on ranks

### DIFF
--- a/ci/rpm/test_daos_node.sh
+++ b/ci/rpm/test_daos_node.sh
@@ -224,7 +224,7 @@ while [[ "$line" != *listening\ on\ * ]]; do
   echo "Agent stdout: $line"
 done
 echo "Agent started!"
-if ! OFI_INTERFACE=eth0 timeout -k 30 300 daos_test -m; then
+if ! OFI_INTERFACE=eth0 timeout -k 30 300 daos_test -m -s 1; then
     rc=${PIPESTATUS[0]}
     if [ "$rc" = "124" ]; then
         echo "daos_test -m was killed after running for 5 minutes"

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -8308,6 +8308,7 @@ pool_update_handler(crt_rpc_t *rpc, int handler_version)
 	struct pool_svc		       *svc;
 	struct pool_target_addr_list	list = { 0 };
 	struct pool_target_addr_list	inval_list_out = { 0 };
+	bool                            exclude_rank   = false;
 	int				rc;
 	uint32_t                        flags;
 
@@ -8316,8 +8317,23 @@ pool_update_handler(crt_rpc_t *rpc, int handler_version)
 	if (list.pta_addrs == NULL || list.pta_number == 0)
 		D_GOTO(out, rc = -DER_INVAL);
 
-	D_DEBUG(DB_MD, DF_UUID ": processing rpc: %p ntargets=%zu\n", DP_UUID(in->pti_op.pi_uuid),
-		rpc, (size_t)list.pta_number);
+	if (opc_get(rpc->cr_opc) == POOL_EXCLUDE) {
+		int i;
+
+		/* Currently, the exclude_rank mode must apply to all ranks. */
+		if (list.pta_addrs[0].pta_target == -1)
+			exclude_rank = true;
+		for (i = 1; i < list.pta_number; i++) {
+			if ((exclude_rank && list.pta_addrs[i].pta_target != -1) ||
+			    (!exclude_rank && list.pta_addrs[i].pta_target == -1)) {
+				rc = -DER_INVAL;
+				goto out;
+			}
+		}
+	}
+
+	D_DEBUG(DB_MD, DF_UUID ": processing rpc: %p ntargets=%zu exclude_rank=%d\n",
+		DP_UUID(in->pti_op.pi_uuid), rpc, (size_t)list.pta_number, exclude_rank);
 
 	rc = pool_svc_lookup_leader(in->pti_op.pi_uuid, &svc,
 				    &out->pto_op.po_hint);
@@ -8335,9 +8351,9 @@ pool_update_handler(crt_rpc_t *rpc, int handler_version)
 			goto out_svc;
 	}
 
-	rc = pool_svc_update_map(svc, pool_opc_2map_opc(opc_get(rpc->cr_opc)),
-				 false /* exclude_rank */, NULL, NULL, 0, &list, &inval_list_out,
-				 &out->pto_op.po_map_version, &out->pto_op.po_hint, MUS_DMG, flags);
+	rc = pool_svc_update_map(svc, pool_opc_2map_opc(opc_get(rpc->cr_opc)), exclude_rank, NULL,
+				 NULL, 0, &list, &inval_list_out, &out->pto_op.po_map_version,
+				 &out->pto_op.po_hint, MUS_DMG, flags);
 	if (rc != 0)
 		goto out_svc;
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -8326,6 +8326,10 @@ pool_update_handler(crt_rpc_t *rpc, int handler_version)
 		for (i = 1; i < list.pta_number; i++) {
 			if ((exclude_rank && list.pta_addrs[i].pta_target != -1) ||
 			    (!exclude_rank && list.pta_addrs[i].pta_target == -1)) {
+				D_ERROR(DF_UUID ": invalid exclude rank/target parameter: "
+						"exclude_rank=%d target[%d]=%d\n",
+					DP_UUID(in->pti_op.pi_uuid), exclude_rank, i,
+					list.pta_addrs[i].pta_target);
 				rc = -DER_INVAL;
 				goto out;
 			}

--- a/src/tests/ftest/checksum/csum_error_logging.yaml
+++ b/src/tests/ftest/checksum/csum_error_logging.yaml
@@ -22,4 +22,4 @@ daos_tests:
   daos_test:
     test_csum_error_logging: z
   args:
-    test_csum_error_logging: "-u 18-19"
+    test_csum_error_logging: "-s 1 -u 18-19"

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -178,12 +178,10 @@ daos_tests:
     test_daos_upgrade: G
     test_daos_pipeline: P
   args:
-    test_daos_io: -s3
     test_daos_ec_io: -l"EC_4P2G1"
     test_daos_rebuild_ec: -s5
     test_daos_md_replication: -s5
     test_daos_degraded_mode: -s7
-    test_daos_degraded_ec: -s3
     test_daos_rebuild_simple: -s3
     test_daos_drain_simple: -s3
     test_daos_extend_simple: -s3

--- a/src/tests/ftest/daos_test/suite.yaml
+++ b/src/tests/ftest/daos_test/suite.yaml
@@ -178,10 +178,12 @@ daos_tests:
     test_daos_upgrade: G
     test_daos_pipeline: P
   args:
+    test_daos_io: -s3
     test_daos_ec_io: -l"EC_4P2G1"
     test_daos_rebuild_ec: -s5
     test_daos_md_replication: -s5
     test_daos_degraded_mode: -s7
+    test_daos_degraded_ec: -s3
     test_daos_rebuild_simple: -s3
     test_daos_drain_simple: -s3
     test_daos_extend_simple: -s3

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -2352,6 +2352,9 @@ reconf_notleader_handling(void **state)
 	assert_ptr_not_equal(prop, NULL);
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_PO_SVC_REDUN_FAC;
 	prop->dpp_entries[0].dpe_val  = 1;
+	/* Then we no longer use the potentially conflicting arg->pool.svc. */
+	d_rank_list_free(arg->pool.svc);
+	arg->pool.svc = NULL;
 	while (!rc && arg->setup_state != SETUP_POOL_CONNECT)
 		rc = test_setup_next_step((void **)&arg, NULL, prop, NULL);
 	assert_rc_equal(rc, 0);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -21,7 +21,7 @@ const char *server_group;
 const char *dmg_config_file;
 
 /** Pool service replicas */
-unsigned int    svc_nreplicas = 1;
+unsigned int    svc_nreplicas = 3;
 
 /** Checksum Config */
 unsigned int	dt_csum_type;

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -21,7 +21,7 @@ const char *server_group;
 const char *dmg_config_file;
 
 /** Pool service replicas */
-unsigned int svc_nreplicas = 1;
+unsigned int    svc_nreplicas = 1;
 
 /** Checksum Config */
 unsigned int	dt_csum_type;


### PR DESCRIPTION
The command

    dmg pool exclude --rank=R P

only excludes all targets of rank R, but not rank R itself, from pool P. This patch is a quick fix, such that

    dmg pool exclude --rank=R P
      # exclude R and all its targets from P

    dmg pool exclude --rank=R --target-idx=T0,T1 P
      # exclude T0 and T1, but not R, from P

To avoid excluding the only PS replica, this patch needs to increase the default number of PS replicas of some suite.yaml tests from 1 to 3.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
