### PR TITLE
DAOS-16662 test: update some tests to use unique dfuse mount (#15242)

### DIFF
--- a/src/tests/ftest/deployment/basic_checkout.py
+++ b/src/tests/ftest/deployment/basic_checkout.py
@@ -65,21 +65,18 @@ class BasicCheckout(PerformanceTestBase):
         # local param
         flags = self.params.get("ior_flags", '/run/ior/iorflags/*')
         apis = self.params.get("ior_api", '/run/ior/iorflags/*')
-        dfuse_mount_dir = self.params.get("mount_dir", "/run/dfuse/*")
-        transfer_block_size = self.params.get("transfer_block_size",
-                                              '/run/ior/iorflags/*')
+        transfer_block_size = self.params.get("transfer_block_size", '/run/ior/iorflags/*')
         obj_class = self.params.get("obj_class", '/run/ior/iorflags/*')
         ec_obj_class = self.params.get("ec_oclass", '/run/ior/*')
         mdtest_params = self.params.get("mdtest_params", "/run/mdtest/*")
 
         # run ior
-        results = self.run_ior_multiple_variants(obj_class, apis, transfer_block_size,
-                                                 flags, dfuse_mount_dir)
+        results = self.run_ior_multiple_variants(obj_class, apis, transfer_block_size, flags)
 
         # run ior with different ec oclass
         results_ec = self.run_ior_multiple_variants(ec_obj_class, [apis[0]],
                                                     [transfer_block_size[1]],
-                                                    [flags[0]], dfuse_mount_dir)
+                                                    [flags[0]])
         results = results + results_ec
         self.log.info("Summary of IOR small test results:")
         errors = False

--- a/src/tests/ftest/deployment/basic_checkout.yaml
+++ b/src/tests/ftest/deployment/basic_checkout.yaml
@@ -158,7 +158,6 @@ mdtest:
     - [DFS, 4096, 4096, 1, 25, 20, '-u']
     - [POSIX, 0, 0, 2, 10, 5, '-u -C -T -r']
 dfuse:
-  mount_dir: "/tmp/daos_dfuse/"
   disable_caching: true
 hdf5_vol:
   plugin_path: /usr/lib64/mpich/lib

--- a/src/tests/ftest/dfuse/mu_perms.yaml
+++ b/src/tests/ftest/dfuse/mu_perms.yaml
@@ -25,7 +25,6 @@ dfuse:
   multi_user: true
 dfuse_with_caching:
   multi_user: true
-  mount_dir: "/tmp/daos_dfuse"
 client_users:
   # Two users in the same group. One user in a separate group
   - daos_test_user_x1:daos_test_group_x1

--- a/src/tests/ftest/dfuse/simul.yaml
+++ b/src/tests/ftest/dfuse/simul.yaml
@@ -13,9 +13,6 @@ server_config:
           scm_mount: /mnt/daos
 pool:
   scm_size: 2G
-  control_method: dmg
-dfuse:
-  mount_dir: "/tmp/daos_dfuse"
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/ior/small.py
+++ b/src/tests/ftest/ior/small.py
@@ -1,5 +1,5 @@
 """
-(C) Copyright 2018-2023 Intel Corporation.
+(C) Copyright 2018-2024 Intel Corporation.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -33,12 +33,10 @@ class IorSmall(IorTestBase):
         cncl_tickets = []
         flags = self.params.get("ior_flags", '/run/ior/iorflags/*')
         apis = self.params.get("ior_api", '/run/ior/iorflags/*')
-        dfuse_mount_dir = self.params.get("mount_dir", "/run/dfuse/*")
         transfer_block_size = self.params.get("transfer_block_size", '/run/ior/iorflags/*')
         obj_class = self.params.get("obj_class", '/run/ior/iorflags/*')
 
-        results = self.run_ior_multiple_variants(obj_class, apis, transfer_block_size,
-                                                 flags, dfuse_mount_dir)
+        results = self.run_ior_multiple_variants(obj_class, apis, transfer_block_size, flags)
         # Running a variant for ior fpp
         self.ior_cmd.flags.update(flags[1])
         self.ior_cmd.api.update(apis[0])

--- a/src/tests/ftest/ior/small.yaml
+++ b/src/tests/ftest/ior/small.yaml
@@ -64,7 +64,6 @@ ior:
       - "SX"
       - "RP_2GX"
 dfuse:
-  mount_dir: "/tmp/daos_dfuse/"
   disable_caching: true
 hdf5_vol:
   plugin_path: /usr/lib64/mpich/lib

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -294,8 +294,7 @@ class IorTestBase(TestWithServers):
 
         return None
 
-    def run_ior_multiple_variants(self, obj_class, apis, transfer_block_size,
-                                  flags, mount_dir):
+    def run_ior_multiple_variants(self, obj_class, apis, transfer_block_size, flags):
         """Run multiple ior commands with various different combination of ior input params.
 
         Args:
@@ -306,7 +305,6 @@ class IorTestBase(TestWithServers):
                                        1M is transfer size and 32M is
                                        block size in the above example.
             flags(list): list of ior flags. Only the first index is used
-            mount_dir(str): dfuse mount directory
         """
         results = []
 
@@ -333,7 +331,7 @@ class IorTestBase(TestWithServers):
                     try:
                         self.run_ior_with_pool(
                             intercept=intercept, plugin_path=hdf5_plugin_path,
-                            timeout=self.ior_timeout, mount_dir=mount_dir)
+                            timeout=self.ior_timeout)
                         results.append(["PASS", str(self.ior_cmd)])
                     except CommandFailure:
                         results.append(["FAIL", str(self.ior_cmd)])


### PR DESCRIPTION
Update some tests to use unique dfuse mount directory by letting the framework generate one.

Remove mount_dir from run_ior_multiple_variants since it is no longer needed and this level of fine control should be handled per test ideally.

Test-tag: BasicCheckout BasicCheckoutDm DfuseMUPerms IorSmall PosixSimul
Skip-unit-tests: true
Skip-fault-injection-test: true

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
