### PR TITLE
DAOS-16127 tools: Include relevant pool health in container health (#15489)

### DIFF
--- a/src/control/cmd/daos/pretty/health.go
+++ b/src/control/cmd/daos/pretty/health.go
@@ -132,12 +132,16 @@ func printPoolHealth(out io.Writer, pi *daos.PoolInfo, verbose bool) {
 	fmt.Fprintf(out, "%s: %s\n", pi.Name(), strings.Join(healthStrings, ","))
 }
 
-func printContainerHealth(out io.Writer, ci *daos.ContainerInfo, verbose bool) {
+func printContainerHealth(out io.Writer, pi *daos.PoolInfo, ci *daos.ContainerInfo, verbose bool) {
 	if ci == nil {
 		return
 	}
 
-	fmt.Fprintf(out, "%s: %s\n", ci.Name(), txtfmt.Title(ci.Health))
+	healthStr := txtfmt.Title(ci.Health)
+	if pi != nil && pi.DisabledTargets > 0 {
+		healthStr += " (Pool Degraded)"
+	}
+	fmt.Fprintf(out, "%s: %s\n", ci.Name(), healthStr)
 }
 
 // PrintSystemHealthInfo pretty-prints the supplied system health struct.
@@ -180,7 +184,7 @@ func PrintSystemHealthInfo(out io.Writer, shi *daos.SystemHealthInfo, verbose bo
 			iiiw := txtfmt.NewIndentWriter(iiw)
 			if len(shi.Containers[pool.UUID]) > 0 {
 				for _, cont := range shi.Containers[pool.UUID] {
-					printContainerHealth(iiiw, cont, verbose)
+					printContainerHealth(iiiw, pool, cont, verbose)
 				}
 			} else {
 				fmt.Fprintln(iiiw, "No containers in pool.")


### PR DESCRIPTION
If the parent pool is in a degraded state, show this in the container
health string, as otherwise users may only focus on the container
health and miss the other details.

Signed-off-by: Michael MacDonald <mjmac@google.com>