### PR TITLE
DAOS-16886 control: Update deprecated code

### DIFF
--- a/src/control/cmd/daos_agent/support.go
+++ b/src/control/cmd/daos_agent/support.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022-2023 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -90,7 +90,7 @@ func (cmd *collectLogCmd) Execute(_ []string) error {
 				}
 			}
 		}
-		fmt.Printf(progress.Display())
+		fmt.Print(progress.Display())
 	}
 
 	if cmd.Archive {
@@ -106,7 +106,7 @@ func (cmd *collectLogCmd) Execute(_ []string) error {
 		}
 	}
 
-	fmt.Printf(progress.Display())
+	fmt.Print(progress.Display())
 
 	return nil
 }

--- a/src/control/cmd/daos_server/support.go
+++ b/src/control/cmd/daos_server/support.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022-2023 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -100,7 +100,7 @@ func (cmd *collectLogCmd) Execute(_ []string) error {
 				}
 			}
 		}
-		fmt.Printf(progress.Display())
+		fmt.Print(progress.Display())
 	}
 
 	if cmd.Archive {
@@ -116,7 +116,7 @@ func (cmd *collectLogCmd) Execute(_ []string) error {
 		}
 	}
 
-	fmt.Printf(progress.Display())
+	fmt.Print(progress.Display())
 
 	return nil
 }

--- a/src/control/cmd/dmg/fi.go
+++ b/src/control/cmd/dmg/fi.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -11,8 +11,8 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -78,7 +78,7 @@ func (cmd *addCheckerReportCmd) Execute(_ []string) (errOut error) {
 
 	var rpt *chkpb.CheckReport
 	if cmd.File != "" {
-		buf, err := ioutil.ReadFile(cmd.File)
+		buf, err := os.ReadFile(cmd.File)
 		if err != nil {
 			return errors.Wrapf(err, "failed to open file %s", cmd.File)
 		}

--- a/src/control/cmd/dmg/support.go
+++ b/src/control/cmd/dmg/support.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022-2023 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -202,7 +202,7 @@ func (cmd *collectLogCmd) Execute(_ []string) error {
 				}
 			}
 		}
-		fmt.Printf(progress.Display())
+		fmt.Print(progress.Display())
 	}
 
 	// Run dmg command info collection set
@@ -224,13 +224,13 @@ func (cmd *collectLogCmd) Execute(_ []string) error {
 				}
 			}
 		}
-		fmt.Printf(progress.Display())
+		fmt.Print(progress.Display())
 	}
 
 	params.FileTransferExecArgs = cmd.FileTransferExecArgs
 	// R sync the logs from servers
 	rsyncerr := cmd.rsyncLog()
-	fmt.Printf(progress.Display())
+	fmt.Print(progress.Display())
 	if rsyncerr != nil && cmd.StopOnError {
 		return rsyncerr
 	}
@@ -252,10 +252,10 @@ func (cmd *collectLogCmd) Execute(_ []string) error {
 				return err
 			}
 		}
-		fmt.Printf(progress.Display())
+		fmt.Print(progress.Display())
 	}
 
-	fmt.Printf(progress.Display())
+	fmt.Print(progress.Display())
 
 	if cmd.JSONOutputEnabled() {
 		return cmd.OutputJSON(nil, err)

--- a/src/control/cmd/dmg/telemetry.go
+++ b/src/control/cmd/dmg/telemetry.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -61,7 +60,7 @@ func (cmd *telemConfigCmd) fetchAsset(repo, platform string) (*os.File, error) {
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +105,7 @@ func (cmd *telemConfigCmd) fetchAsset(repo, platform string) (*os.File, error) {
 	}
 	defer resp.Body.Close()
 
-	outFile, err := ioutil.TempFile("", dlName)
+	outFile, err := os.CreateTemp("", dlName)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +212,7 @@ type (
 )
 
 func (cmd *telemConfigCmd) loadPromCfg(cfgPath string) (*promCfg, error) {
-	data, err := ioutil.ReadFile(cfgPath)
+	data, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +271,7 @@ func (cmd *telemConfigCmd) configurePrometheus() (*installInfo, error) {
 		return nil, err
 	}
 
-	if err := ioutil.WriteFile(promInfo.cfgPath, data, 0644); err != nil {
+	if err := os.WriteFile(promInfo.cfgPath, data, 0644); err != nil {
 		return nil, errors.Wrapf(err, "failed to write %s", promInfo.cfgPath)
 	}
 	cmd.Infof("Wrote DAOS monitoring config to %s)", promInfo.cfgPath)

--- a/src/control/common/file_utils.go
+++ b/src/control/common/file_utils.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -9,7 +9,6 @@ package common
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -27,7 +26,7 @@ const UtilLogDepth = 4
 // GetFilePaths return full file paths in given directory with
 // matching file extensions
 func GetFilePaths(dir string, ext string) ([]string, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/common/test/utils.go
+++ b/src/control/common/test/utils.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -250,7 +249,7 @@ func CreateTestDir(t *testing.T) (string, func()) {
 	t.Helper()
 
 	name := strings.Replace(t.Name(), "/", "-", -1)
-	tmpDir, err := ioutil.TempDir("", name)
+	tmpDir, err := os.MkdirTemp("", name)
 	if err != nil {
 		t.Fatalf("Couldn't create temporary directory: %v", err)
 	}
@@ -268,7 +267,7 @@ func CreateTestDir(t *testing.T) (string, func()) {
 func CreateTestFile(t *testing.T, dir, content string) string {
 	t.Helper()
 
-	file, err := ioutil.TempFile(dir, "")
+	file, err := os.CreateTemp(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/control/drpc/drpc_client_test.go
+++ b/src/control/drpc/drpc_client_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,13 +8,13 @@ package drpc
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"testing"
 
-	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/daos-stack/daos/src/control/common/test"
 )
 
 // testSockPath is an arbitrary path string to use for testing. These tests
@@ -41,7 +41,7 @@ func (m *mockDialer) dial(ctx context.Context, socketPath string) (net.Conn, err
 }
 
 func (m *mockDialer) SetError(errStr string) {
-	m.OutputErr = fmt.Errorf(errStr)
+	m.OutputErr = errors.New(errStr)
 	m.OutputConn = nil
 }
 

--- a/src/control/lib/control/config.go
+++ b/src/control/lib/control/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,7 +8,6 @@ package control
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -80,7 +79,7 @@ func LoadConfig(cfgPath string) (*Config, error) {
 		return nil, ErrNoConfigFile
 	}
 
-	data, err := ioutil.ReadFile(cfgPath)
+	data, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/lib/control/config_test.go
+++ b/src/control/lib/control/config_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2022 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -8,7 +8,6 @@ package control
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -38,7 +37,7 @@ func saveConfig(t *testing.T, cfg *Config, cfgPath string) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(cfgPath, data, 0644); err != nil {
+	if err := os.WriteFile(cfgPath, data, 0644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/src/control/lib/control/control.go
+++ b/src/control/lib/control/control.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -7,14 +7,14 @@
 package control
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
 // defaultLogger is used to provide a valid logger when none has
 // been supplied.
-var defaultLogger debugLogger = logging.NewCombinedLogger("", ioutil.Discard)
+var defaultLogger debugLogger = logging.NewCombinedLogger("", io.Discard)
 
 type (
 	// debugLogger defines a debug-only logging interface.

--- a/src/control/lib/control/http.go
+++ b/src/control/lib/control/http.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021 Intel Corporation.
+// (C) Copyright 2021-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -9,7 +9,7 @@ package control
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -156,7 +156,7 @@ func httpGetBody(ctx context.Context, url *url.URL, get httpGetFn, timeout time.
 			return nil, errors.Errorf("HTTP response error: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 		}
 
-		result, err := ioutil.ReadAll(resp.Body)
+		result, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, errors.Wrap(err, "reading HTTP response body")
 		}

--- a/src/control/lib/control/server_meta_test.go
+++ b/src/control/lib/control/server_meta_test.go
@@ -408,7 +408,7 @@ func TestControl_SmdQuery(t *testing.T) {
 					for i, gotDev := range sqr.HostStorage.SmdInfo.Devices {
 						hs := tc.expResp.HostStorage
 						expDev := hs[hs.Keys()[0]].HostStorage.SmdInfo.Devices[i]
-						t.Logf(cmp.Diff(expDev, gotDev, defResCmpOpts()...))
+						t.Log(cmp.Diff(expDev, gotDev, defResCmpOpts()...))
 					}
 				}
 				t.Fatalf("unexpected resp (-want, +got):\n%s\n", diff)
@@ -844,7 +844,7 @@ func TestControl_SmdManage(t *testing.T) {
 					}
 					for i, gotDev := range sqr.HostStorage.SmdInfo.Devices {
 						expDev := hs[keys[0]].HostStorage.SmdInfo.Devices[i]
-						t.Logf(cmp.Diff(expDev, gotDev, defResCmpOpts()...))
+						t.Log(cmp.Diff(expDev, gotDev, defResCmpOpts()...))
 					}
 				}
 				t.Fatalf("unexpected resp (-want, +got):\n%s\n", diff)

--- a/src/control/lib/hardware/sysfs/provider_test.go
+++ b/src/control/lib/hardware/sysfs/provider_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2021-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -9,7 +9,6 @@ package sysfs
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -46,7 +45,7 @@ func TestSysfs_isNetvscDevice(t *testing.T) {
 		}
 
 		filePath := path.Join(dirPath, "uevent")
-		if err := ioutil.WriteFile(filePath, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -181,7 +180,7 @@ func TestSysfs_Provider_GetNetDevClass(t *testing.T) {
 func writeTestFile(t *testing.T, path, contents string) {
 	t.Helper()
 
-	if err := ioutil.WriteFile(path, []byte(contents), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -279,7 +278,7 @@ func setupNetvscDev(t *testing.T, root, devName, backingDevName string) {
 	}
 
 	filePath := path.Join(dirPath, "uevent")
-	if err := ioutil.WriteFile(filePath, []byte("DRIVER=hv_netvsc"), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte("DRIVER=hv_netvsc"), 0644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -775,7 +774,7 @@ func TestSysfs_Provider_GetNetDevState(t *testing.T) {
 			}
 
 			statePath := filepath.Join(portPath, "state")
-			if err := ioutil.WriteFile(statePath, []byte(state), 0644); err != nil {
+			if err := os.WriteFile(statePath, []byte(state), 0644); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/src/control/lib/support/log.go
+++ b/src/control/lib/support/log.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -318,7 +317,7 @@ func cpOutputToFile(target string, log logging.Logger, cp ...logCopy) (string, e
 	cmd = strings.ReplaceAll(cmd, " ", "_")
 	log.Debugf("Collecting DAOS command output = %s > %s ", runCmd, filepath.Join(target, cmd))
 
-	if err := ioutil.WriteFile(filepath.Join(target, cmd), out, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(target, cmd), out, 0644); err != nil {
 		return "", errors.Wrapf(err, "failed to write %s", filepath.Join(target, cmd))
 	}
 
@@ -611,7 +610,7 @@ func collectAgentLog(log logging.Logger, opts ...CollectLogsParams) error {
 		return err
 	}
 
-	agentFile, err := ioutil.ReadFile(opts[0].Config)
+	agentFile, err := os.ReadFile(opts[0].Config)
 	if err != nil {
 		return err
 	}

--- a/src/control/lib/support/log_test.go
+++ b/src/control/lib/support/log_test.go
@@ -8,7 +8,6 @@ package support
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -662,7 +661,7 @@ func TestSupport_copyServerConfig(t *testing.T) {
 			if tc.createFile {
 				data := []byte("hello\nDAOS\n")
 				if err := os.WriteFile(defaultSeverConfig, data, 0644); err != nil {
-					t.Fatalf(err.Error())
+					t.Fatal(err.Error())
 				}
 			}
 			collLogParams.TargetFolder = tc.targetFolder
@@ -672,7 +671,7 @@ func TestSupport_copyServerConfig(t *testing.T) {
 
 			if tc.createFile {
 				if err := os.Remove(defaultSeverConfig); err != nil {
-					t.Fatalf(err.Error())
+					t.Fatal(err.Error())
 				}
 			}
 		})
@@ -1194,9 +1193,9 @@ INFO 2023/12/12 23:59:59.441241 LOG LINE 12
 
 			if tc.verifyLog != "" {
 				readFile := filepath.Join(tc.destFile, filepath.Base(tc.srcFile))
-				b, err := ioutil.ReadFile(readFile)
+				b, err := os.ReadFile(readFile)
 				if err != nil {
-					t.Fatalf(err.Error())
+					t.Fatal(err.Error())
 				}
 
 				if strings.Contains(string(b), tc.verifyLog) == false {

--- a/src/control/pbin/app.go
+++ b/src/control/pbin/app.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2021 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -69,7 +68,7 @@ func (a *App) WithLogFile(path string) *App {
 // is empty, non-error messages are not logged.
 func (a *App) configureLogging(logPath string) {
 	logLevel := logging.LogLevelError
-	combinedOut := ioutil.Discard
+	combinedOut := io.Discard
 	if logPath != "" {
 		lf, err := common.AppendFile(logPath)
 		if err == nil {

--- a/src/control/pbin/exec_test.go
+++ b/src/control/pbin/exec_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2022 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -88,7 +87,7 @@ func generatePayload(size int) []byte {
 }
 
 func loadJSONPayload(t *testing.T, name string) []byte {
-	loadBuf, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", name))
+	loadBuf, err := os.ReadFile(fmt.Sprintf("testdata/%s.json", name))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/control/security/config_test.go
+++ b/src/control/security/config_test.go
@@ -12,7 +12,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -81,7 +80,7 @@ func SetupTCFilePerms(t *testing.T, conf *TransportConfig) {
 }
 
 func getCert(t *testing.T, path string) *x509.Certificate {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/control/security/pem.go
+++ b/src/control/security/pem.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -13,7 +13,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -129,7 +128,7 @@ func LoadPEMData(filePath string, perms os.FileMode) ([]byte, error) {
 		return nil, err
 	}
 
-	fileContents, err := ioutil.ReadFile(filePath)
+	fileContents, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/security/signature_test.go
+++ b/src/control/security/signature_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2023 Intel Corporation.
+// (C) Copyright 2019-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -14,7 +14,6 @@ import (
 	crand "crypto/rand"
 	"encoding/hex"
 	"flag"
-	"io/ioutil"
 	mrand "math/rand"
 	"os"
 	"path/filepath"
@@ -44,7 +43,7 @@ func SignTestSetup(t *testing.T) (rsaKey, ecdsaKey crypto.PrivateKey, source []b
 	if err != nil {
 		t.Fatal("Failed to generate ecdsa key for testing")
 	}
-	source, err = ioutil.ReadFile("testdata/certs/source.txt")
+	source, err = os.ReadFile("testdata/certs/source.txt")
 	if err != nil {
 		t.Fatal("Failed to read in source file for Sign test.")
 	}
@@ -73,12 +72,12 @@ func TestSign(t *testing.T) {
 				result = []byte(err.Error())
 			}
 			if *update {
-				err := ioutil.WriteFile(golden, result, 0644)
+				err := os.WriteFile(golden, result, 0644)
 				if err != nil {
 					t.Errorf("failed to update golden file %s", golden)
 				}
 			}
-			expected, err := ioutil.ReadFile(golden)
+			expected, err := os.ReadFile(golden)
 			if err != nil {
 				t.Errorf("unable to read golden file %s", golden)
 			}
@@ -105,7 +104,7 @@ func VerifyTestSetup(t *testing.T) (rsaKey, ecdsaKey crypto.PublicKey, source []
 		t.Fatal("Failed to generate ecdsa key for testing")
 	}
 	ecdsaKey = gen.Public()
-	source, err = ioutil.ReadFile("testdata/certs/source.txt")
+	source, err = os.ReadFile("testdata/certs/source.txt")
 	if err != nil {
 		t.Fatal("Failed to read in source file for Sign test.")
 	}
@@ -128,7 +127,7 @@ func TestVerify(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			golden := filepath.Join("testdata", "certs", tc.name+".golden")
-			expected, err := ioutil.ReadFile(golden)
+			expected, err := os.ReadFile(golden)
 			if err != nil {
 				t.Errorf("unable to read golden file %s", golden)
 			}

--- a/src/control/server/config/server.go
+++ b/src/control/server/config/server.go
@@ -8,7 +8,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -343,7 +342,7 @@ func (cfg *Server) Load() error {
 		return FaultConfigNoPath
 	}
 
-	bytes, err := ioutil.ReadFile(cfg.Path)
+	bytes, err := os.ReadFile(cfg.Path)
 	if err != nil {
 		return errors.WithMessage(err, "reading file")
 	}
@@ -383,7 +382,7 @@ func (cfg *Server) SaveToFile(filename string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(filename, bytes, 0644)
+	return os.WriteFile(filename, bytes, 0644)
 }
 
 // SetPath sets the default path to the configuration file.

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -183,7 +182,7 @@ func TestServerConfig_MarshalUnmarshal(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			bytes, err := ioutil.ReadFile(testFile)
+			bytes, err := os.ReadFile(testFile)
 			if err != nil {
 				t.Fatal(errors.WithMessage(err, "reading file"))
 			}
@@ -1422,7 +1421,7 @@ func replaceFile(t *testing.T, name, oldTxt, newTxt string) {
 	defer f.Close()
 
 	// create temp file
-	tmp, err := ioutil.TempFile("", "replace-*")
+	tmp, err := os.CreateTemp("", "replace-*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/control/server/ctl_ranks_rpc.go
+++ b/src/control/server/ctl_ranks_rpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2020-2023 Intel Corporation.
+// (C) Copyright 2020-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -140,7 +140,7 @@ func (svc *ControlService) memberStateResults(instances []Engine, tgtState syste
 
 		state := ei.LocalState()
 		if state != tgtState {
-			results = append(results, system.NewMemberResult(rank, errors.Errorf(failMsg),
+			results = append(results, system.NewMemberResult(rank, errors.New(failMsg),
 				system.MemberStateErrored))
 			continue
 		}

--- a/src/control/server/storage/bdev/backend_class_test.go
+++ b/src/control/server/storage/bdev/backend_class_test.go
@@ -7,7 +7,6 @@
 package bdev
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -742,7 +741,7 @@ func TestBackend_writeJSONFile(t *testing.T) {
 				return
 			}
 
-			gotOut, err := ioutil.ReadFile(cfgOutputPath)
+			gotOut, err := os.ReadFile(cfgOutputPath)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/control/server/storage/bdev/backend_vmd.go
+++ b/src/control/server/storage/bdev/backend_vmd.go
@@ -132,7 +132,7 @@ func substituteVMDAddresses(log logging.Logger, inPCIAddrs *hardware.PCIAddressS
 
 	dl, err := substVMDAddrs(inPCIAddrs, ctrlrs)
 	if err != nil {
-		return nil, errors.Wrapf(err, msg)
+		return nil, errors.Wrap(err, msg)
 	}
 	log.Debugf("%s: new %s", msg, dl)
 

--- a/src/control/system/raft/database_test.go
+++ b/src/control/system/raft/database_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"sort"
@@ -228,7 +227,7 @@ func (tss *testSnapshotSink) Write(data []byte) (int, error) {
 	return int(w), err
 }
 func (tss *testSnapshotSink) Reader() io.ReadCloser {
-	return ioutil.NopCloser(tss.contents)
+	return io.NopCloser(tss.contents)
 }
 
 func TestSystem_Database_SnapshotRestore(t *testing.T) {

--- a/src/control/system/raft/raft_recovery.go
+++ b/src/control/system/raft/raft_recovery.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2022 Intel Corporation.
+// (C) Copyright 2022-2024 Intel Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -146,7 +145,7 @@ func RestoreLocalReplica(log logging.Logger, cfg *DatabaseConfig, snapPath strin
 	}
 
 	if strings.HasPrefix(snapPath, cfg.RaftDir) {
-		tmpDir, err := ioutil.TempDir("", "daos-raft-restore")
+		tmpDir, err := os.MkdirTemp("", "daos-raft-restore")
 		if err != nil {
 			return errors.Wrap(err, "failed to create temporary directory")
 		}
@@ -455,7 +454,7 @@ func GetLatestSnapshot(log logging.Logger, cfg *DatabaseConfig) (*SnapshotDetail
 
 func readSnapshotMeta(path string, meta *raft.SnapshotMeta) error {
 	metaPath := filepath.Join(path, snapshotMetaFile)
-	data, err := ioutil.ReadFile(metaPath)
+	data, err := os.ReadFile(metaPath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read snapshot metadata from %q", metaPath)
 	}
@@ -465,7 +464,7 @@ func readSnapshotMeta(path string, meta *raft.SnapshotMeta) error {
 
 func readSnapshotData(path string) ([]byte, error) {
 	dataPath := filepath.Join(path, snapshotDataFile)
-	data, err := ioutil.ReadFile(dataPath)
+	data, err := os.ReadFile(dataPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read snapshot data from %q", dataPath)
 	}


### PR DESCRIPTION
The ioutil package has been deprecated since Go 1.16
and may be removed in the future. Update the code to
use the standard interfaces.

Also fix a linter warning that is now a compile error
in Go 1.24+ (non-constant format string in call
to *f functions).

Features: control
Required-githooks: true
Signed-off-by: Michael MacDonald <mjmac@google.com>
