### PR TITLE
DAOS-16876 vos: set cont parameter when deregister modification from DTX - b26

### DIFF
--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -22,10 +22,9 @@
 
 static bool slow_test;
 
-static void
+static inline void
 cleanup(void)
 {
-	daos_fail_loc_set(DAOS_VOS_GC_CONT_NULL | DAOS_FAIL_ALWAYS);
 	gc_wait();
 }
 
@@ -1315,24 +1314,19 @@ agg_punches_test(void **state, int record_type, bool discard)
 			}
 		}
 	}
-	/** cleanup() sets the flag to assert if there are items in container garbage collection
-	 *  heap which will always be the case for these punch tests.  So let's run garbage
-	 *  collection before cleanup in this case.
-	 */
-	gc_wait();
+
+	cleanup();
 }
 static void
 discard_14(void **state)
 {
 	agg_punches_test(state, DAOS_IOD_SINGLE, true);
-	cleanup();
 }
 
 static void
 discard_15(void **state)
 {
 	agg_punches_test(state, DAOS_IOD_ARRAY, true);
-	cleanup();
 }
 
 static void

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -2597,7 +2597,7 @@ vos_obj_iter_aggregate(daos_handle_t ih, bool range_discard)
 		 *	be aborted. Then it will be added and handled via GC when ktr_rec_free().
 		 */
 
-		rc = dbtree_iter_delete(oiter->it_hdl, NULL);
+		rc = dbtree_iter_delete(oiter->it_hdl, obj->obj_cont);
 		D_ASSERT(rc != -DER_NONEXIST);
 	} else if (rc == -DER_NONEXIST) {
 		/* Key no longer exists at epoch but isn't empty */

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -863,6 +863,7 @@ oi_iter_aggregate(daos_handle_t ih, bool range_discard)
 	struct vos_container    *cont  = oiter->oit_cont;
 	struct vos_obj_df	*obj;
 	daos_unit_oid_t		 oid;
+	struct oi_delete_arg	 del_arg;
 	d_iov_t			 rec_iov;
 	bool			 delete = false, invisible = false;
 	int			 rc;
@@ -915,7 +916,9 @@ oi_iter_aggregate(daos_handle_t ih, bool range_discard)
 		if (rc != 0)
 			D_ERROR("Could not evict object "DF_UOID" "DF_RC"\n",
 				DP_UOID(oid), DP_RC(rc));
-		rc = dbtree_iter_delete(oiter->oit_hdl, NULL);
+		del_arg.cont = oiter->oit_cont;
+		del_arg.only_delete_entry = 0;
+		rc = dbtree_iter_delete(oiter->oit_hdl, &del_arg);
 		D_ASSERT(rc != -DER_NONEXIST);
 	} else if (rc == -DER_NONEXIST) {
 		/** ilog isn't visible in range but still has some entries */


### PR DESCRIPTION
As long as the container is not destroyed, then anytime want to deregister a modification from related active DTX entry (that is usually triggered for vos discard or aggregation), the caller needs to offer container handle to vos_dtx_deregister_record() for locating the DTX entry in active DTX table. Otherwise, if the caller offers empty container handle, then it will cause dangling reference in related DTX entry as to data corruption in subsequent DTX commit or abort.

On the other hand, if the container will be destroyed, then all related DTX entries for such container will be useless any more. We need to destroy DTX table firstly to avoid generating dangling DTX references during destroying the container.

Allow-unstable-test: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
