### PR TITLE
DAOS-16924 dfs: new readdir API

### DIFF
--- a/src/client/dfs/dcache.c
+++ b/src/client/dfs/dcache.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -75,7 +76,7 @@ typedef void (*drec_decref_fn_t)(dfs_dcache_t *, dfs_obj_t *);
 typedef void (*drec_del_at_fn_t)(dfs_dcache_t *, dfs_obj_t *);
 typedef int (*drec_del_fn_t)(dfs_dcache_t *, char *, dfs_obj_t *);
 
-/** DFS directory cache */
+/** DFS dentry cache */
 struct dfs_dcache {
 	/** Cached DAOS file system */
 	dfs_t              *dd_dfs;
@@ -990,3 +991,6 @@ drec_del(dfs_dcache_t *dcache, char *path, dfs_obj_t *parent)
 
 	return dcache->drec_del_fn(dcache, path, parent);
 }
+
+// dcache_readdir(dfs_dcache_t *dcache, dfs_obj_t *obj, dfs_dir_anchor_t *anchor, struct dirent dir)
+// {}

--- a/src/client/dfs/dfs_internal.h
+++ b/src/client/dfs/dfs_internal.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -272,6 +273,15 @@ struct dfs_mnt_hdls {
 	daos_handle_t handle;
 	int           ref;
 	int           type;
+};
+
+/** readdir anchor for dfs_readdir2(). If dcache is disabled, the only valid setting is the
+ * daos_anchor_t. */
+struct dfs_dir_anchor {
+	dfs_obj_t    *dda_dir;
+	daos_anchor_t dda_anchor_int;
+	size_t        dda_bucket_id;
+	off_t         dda_bucket_offset;
 };
 
 static inline bool


### PR DESCRIPTION
Add a new DFS readdir API that utilizes a new DFS anchor object which can be updated to include caching parameters for future calls. This API will be more useful when client side caching for readdir is implemented to access buckets of readdir entries.

Required-githooks: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
