### PR TITLE
DAOS-16869 dfuse: avoid logging error on fuse_reply_err() if ENOENT

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -736,7 +737,7 @@ dfuse_loop(struct dfuse_info *dfuse_info);
 		_Static_assert(IS_IE(_ie), "Param is not inode entry");                            \
 		(_ie) = NULL;                                                                      \
 		__rc  = fuse_reply_err(req, 0);                                                    \
-		if (__rc != 0)                                                                     \
+		if (__rc != 0 && __rc != -ENOENT)                                                  \
 			DS_ERROR(-__rc, "fuse_reply_err() error");                                 \
 	} while (0)
 
@@ -748,7 +749,7 @@ dfuse_loop(struct dfuse_info *dfuse_info);
 		_Static_assert(IS_OH(_oh), "Param is not open handle");                            \
 		(_oh)->doh_ie = NULL;                                                              \
 		__rc          = fuse_reply_err(req, 0);                                            \
-		if (__rc != 0)                                                                     \
+		if (__rc != 0 && __rc != -ENOENT)                                                  \
 			DS_ERROR(-__rc, "fuse_reply_err() error");                                 \
 	} while (0)
 


### PR DESCRIPTION
matching what libfuse behaves as in:
https://github.com/libfuse/libfuse/blob/fc95fd5076fd845e496bfbcec1ad9da16534b1c9/lib/fuse_lowlevel.c#L208 avoid logging an error in dfuse if fuse_reply_err() fails to send the message with ENOENT. The change is made only on the ZERO macros (the ones that do not actually return a dfuse error).

Features: dfuse

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
