### PR TITLE
DAOS-16838 control: Fix dmg storage query usage with emulated NVMe (#…

### DIFF
--- a/src/control/server/instance_storage_rpc.go
+++ b/src/control/server/instance_storage_rpc.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -332,6 +333,7 @@ func scanEngineBdevsOverDrpc(ctx context.Context, engine Engine, pbReq *ctlpb.Sc
 	if scanSmdResp == nil {
 		return nil, errors.New("nil smd scan resp")
 	}
+	engine.Tracef("smd scan devices: %+v", scanSmdResp.Devices)
 
 	// Re-link SMD devices inside NVMe controller structures and populate scan response.
 
@@ -340,12 +342,20 @@ func scanEngineBdevsOverDrpc(ctx context.Context, engine Engine, pbReq *ctlpb.Sc
 	}
 	seenCtrlrs := make(map[string]*ctlpb.NvmeController)
 
-	for _, sd := range scanSmdResp.Devices {
+	for i, sd := range scanSmdResp.Devices {
 		if sd.Ctrlr == nil {
 			return nil, errors.Errorf("smd %q has no ctrlr ref", sd.Uuid)
 		}
 
 		addr := sd.Ctrlr.PciAddr
+		if addr == "" {
+			// Mock identifier for emulated NVMe mode where devices have no PCI-address.
+			// Allows for 256 unique identifiers per-host and formatted string template
+			// ensures no collisions with real device addresses. Note that this mock
+			// identifier address is not used outside of this loop and is only used for
+			// the purpose of mapping SMD records to NVMe (emulated) device details.
+			addr = fmt.Sprintf("FFFF:00:%X.F", i)
+		}
 
 		if _, exists := seenCtrlrs[addr]; !exists {
 			c := new(ctlpb.NvmeController)
@@ -460,6 +470,7 @@ func bdevScanEngineAssigned(ctx context.Context, engine Engine, req *ctlpb.ScanN
 	return scanEngineBdevsOverDrpc(ctx, engine, req)
 }
 
+// Accommodate for VMD backing devices and emulated NVMe (AIO).
 func getEffCtrlrCount(ctrlrs []*ctlpb.NvmeController) (int, error) {
 	pas := hardware.MustNewPCIAddressSet()
 	for _, c := range ctrlrs {
@@ -471,11 +482,13 @@ func getEffCtrlrCount(ctrlrs []*ctlpb.NvmeController) (int, error) {
 		if npas, err := pas.BackingToVMDAddresses(); err != nil {
 			return 0, err
 		} else {
-			pas = npas
+			return npas.Len(), nil
 		}
 	}
 
-	return pas.Len(), nil
+	// Return inputted number of controllers rather than number of parsed addresses to cater for
+	// the case of emulated NVMe where there will be no valid PCI address.
+	return len(ctrlrs), nil
 }
 
 // bdevScanEngine calls either in to the private engine storage provider to scan bdevs if engine process

--- a/src/control/server/instance_storage_rpc_test.go
+++ b/src/control/server/instance_storage_rpc_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2023-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -44,7 +45,7 @@ func (mp *mockPCIeLinkStatsProvider) PCIeCapsFromConfig(cfgBytes []byte, dev *ha
 	return nil
 }
 
-func TestIOEngineInstance_populateCtrlrHealth(t *testing.T) {
+func TestServer_populateCtrlrHealth(t *testing.T) {
 	healthWithLinkStats := func(maxSpd, spd float32, maxWdt, wdt uint32) *ctlpb.BioHealthResp {
 		bhr := proto.MockNvmeHealth()
 		bhr.LinkMaxSpeed = maxSpd
@@ -459,7 +460,7 @@ func TestIOEngineInstance_populateCtrlrHealth(t *testing.T) {
 	}
 }
 
-func TestIOEngineInstance_bdevScanEngine(t *testing.T) {
+func TestServer_bdevScanEngine(t *testing.T) {
 	c := storage.MockNvmeController(2)
 	withState := func(ctrlr *ctlpb.NvmeController, state ctlpb.NvmeDevState) *ctlpb.NvmeController {
 		ctrlr.DevState = state
@@ -792,6 +793,85 @@ func TestIOEngineInstance_bdevScanEngine(t *testing.T) {
 			healthRes: healthRespWithUsage(),
 			// Prove link stat provider gets called when LinkStats flag set.
 			expErr: errors.New("link stats provider fail"),
+		},
+		"scan over drpc; aio file emulated nvme; no pci addresses": {
+			smdRes: &ctlpb.SmdDevResp{
+				Devices: []*ctlpb.SmdDevice{
+					{
+						Uuid: "b80b4653-af58-47b3-aa3b-8ad12965f440",
+						TgtIds: []int32{
+							1024, 1024, 0, 0, 0, 4, 4, 4, 8, 8, 8, 12,
+							12, 12,
+						},
+						RoleBits: 7,
+						Ctrlr: &ctlpb.NvmeController{
+							DevState: ctlpb.NvmeDevState_NORMAL,
+						},
+					},
+					{
+						Uuid: "3c7a8e22-38c0-4e6f-8776-d703d049ae6f",
+						TgtIds: []int32{
+							1024, 1024, 1, 1, 1, 5, 5, 5, 9, 9, 9, 13,
+							13, 13,
+						},
+						RoleBits: 7,
+						Ctrlr: &ctlpb.NvmeController{
+							DevState: ctlpb.NvmeDevState_NORMAL,
+						},
+					},
+					{
+						Uuid: "40ba7b18-3a0e-4d68-9e8f-c4fc556eb506",
+						TgtIds: []int32{
+							1024, 1024, 2, 2, 2, 6, 6, 6, 10, 10, 10,
+							14, 14, 14,
+						},
+						RoleBits: 7,
+						Ctrlr: &ctlpb.NvmeController{
+							DevState: ctlpb.NvmeDevState_NORMAL,
+						},
+					},
+					{
+						Uuid: "d78c849f-fd9e-4a20-9746-b0335e3618da",
+						TgtIds: []int32{
+							1024, 1024, 3, 3, 3, 7, 7, 7, 11, 11, 11,
+							15, 15, 15,
+						},
+						RoleBits: 7,
+						Ctrlr: &ctlpb.NvmeController{
+							DevState: ctlpb.NvmeDevState_NORMAL,
+						},
+					},
+				},
+			},
+			expResp: &ctlpb.ScanNvmeResp{
+				Ctrlrs: proto.NvmeControllers{
+					&ctlpb.NvmeController{
+						DevState: ctlpb.NvmeDevState_NORMAL,
+						SmdDevices: []*ctlpb.SmdDevice{
+							{RoleBits: 7},
+						},
+					},
+					&ctlpb.NvmeController{
+						DevState: ctlpb.NvmeDevState_NORMAL,
+						SmdDevices: []*ctlpb.SmdDevice{
+							{RoleBits: 7},
+						},
+					},
+					&ctlpb.NvmeController{
+						DevState: ctlpb.NvmeDevState_NORMAL,
+						SmdDevices: []*ctlpb.SmdDevice{
+							{RoleBits: 7},
+						},
+					},
+					&ctlpb.NvmeController{
+						DevState: ctlpb.NvmeDevState_NORMAL,
+						SmdDevices: []*ctlpb.SmdDevice{
+							{RoleBits: 7},
+						},
+					},
+				},
+				State: new(ctlpb.ResponseState),
+			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2019-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -484,8 +485,8 @@ func (tcs TierConfigs) AssignBdevTierRoles(extMetadataPath string) error {
 	if scs[0].Class == ClassDcpm {
 		return errors.New("external metadata path for md-on-ssd invalid with dcpm scm-class")
 	}
-	// Skip role assignment and validation if no real NVMe tiers exist.
-	if !tcs.HaveRealNVMe() {
+	// Skip role assignment and validation if no bdev tiers exist.
+	if !tcs.HaveBdevs() {
 		return nil
 	}
 


### PR DESCRIPTION
…15545)

Fix a regression which prevents dmg storage query usage from enumerating devices backed with emulated (AIO file or kdev) NVMe.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
