### PR TITLE
DAOS-16931 container: fix oid iv race with using invalid on update pt…

### DIFF
--- a/src/container/oid_iv.c
+++ b/src/container/oid_iv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -133,10 +134,10 @@ oid_iv_ent_update(struct ds_iv_entry *ns_entry, struct ds_iv_key *iv_key,
 	entry = ns_entry->iv_value.sg_iovs[0].iov_buf;
 	rc = ABT_mutex_trylock(entry->lock);
 	/** For retry requests, from _iv_op(), the lock may not be released in some cases. */
-	if (rc == ABT_ERR_MUTEX_LOCKED && entry->current_req != src)
+	if (rc == ABT_ERR_MUTEX_LOCKED && entry->current_req != priv)
 		return -DER_BUSY;
 
-	entry->current_req = src;
+	entry->current_req = priv;
 	avail = &entry->rg;
 
 	oids = src->sg_iovs[0].iov_buf;

--- a/src/container/oid_iv.c
+++ b/src/container/oid_iv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2017-2025 Intel Corporation.
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -32,7 +32,8 @@ struct oid_iv_entry {
 	struct oid_iv_range	rg;
 	/** protect the entry */
 	ABT_mutex		lock;
-	void                   *current_req;
+	d_rank_t                current_req_rank;
+	void                   *current_req_ptr;
 };
 
 /** Priv data in the iv layer */
@@ -86,12 +87,14 @@ oid_iv_ent_refresh(struct ds_iv_entry *iv_entry, struct ds_iv_key *key,
 
 	D_ASSERT(priv);
 	num_oids = priv->num_oids;
-	D_DEBUG(DB_MD, "%u: ON REFRESH: num_oids = %zu, REF_RC = " DF_RC "\n", dss_self_rank(),
-		num_oids, DP_RC(ref_rc));
 	D_ASSERT(num_oids != 0);
-
 	entry = iv_entry->iv_value.sg_iovs[0].iov_buf;
 	D_ASSERT(entry != NULL);
+
+	D_DEBUG(DB_MD,
+		"%u: ON REFRESH: num_oids = %zu, REF_RC = " DF_RC " ENTRY rank %u Ptr = %p\n",
+		dss_self_rank(), num_oids, DP_RC(ref_rc), entry->current_req_rank,
+		entry->current_req_ptr);
 
 	/** if iv op failed, just release the entry lock acquired in update */
 	if (ref_rc != 0)
@@ -130,17 +133,28 @@ oid_iv_ent_update(struct ds_iv_entry *ns_entry, struct ds_iv_key *iv_key,
 	d_rank_t		myrank = dss_self_rank();
 	int			rc;
 
+	if (src == NULL) {
+		D_DEBUG(DB_MD, "%u: ON UPDATE delete entry iv_entry %p\n", myrank, ns_entry);
+		ns_entry->iv_to_delete = 1;
+		return 0;
+	}
+
 	D_ASSERT(priv != NULL);
 	entry = ns_entry->iv_value.sg_iovs[0].iov_buf;
+	oids  = src->sg_iovs[0].iov_buf;
+
 	rc = ABT_mutex_trylock(entry->lock);
-	/** For retry requests, from _iv_op(), the lock may not be released in some cases. */
-	if (rc == ABT_ERR_MUTEX_LOCKED && entry->current_req != priv)
-		return -DER_BUSY;
+	if (rc == ABT_ERR_MUTEX_LOCKED) {
+		if (entry->current_req_rank == oids->req_rank &&
+		    entry->current_req_ptr == oids->req_ptr)
+			D_DEBUG(DB_MD, "%u: ON UPDATE - SAME REQ %p \n", myrank, src);
+		else
+			return -DER_BUSY;
+	}
 
-	entry->current_req = priv;
-	avail = &entry->rg;
-
-	oids = src->sg_iovs[0].iov_buf;
+	entry->current_req_rank = oids->req_rank;
+	entry->current_req_ptr  = oids->req_ptr;
+	avail                   = &entry->rg;
 
 	if (myrank == oids->req_rank)
 		num_oids = oids->req_num_oids;
@@ -209,8 +223,6 @@ oid_iv_ent_get(struct ds_iv_entry *entry, void **_priv)
 {
 	struct oid_iv_priv	*priv;
 
-	D_DEBUG(DB_MD, "%u: OID GET\n", dss_self_rank());
-
 	D_ALLOC_PTR(priv);
 	if (priv == NULL)
 		return -DER_NOMEM;
@@ -222,7 +234,6 @@ static void
 oid_iv_ent_put(struct ds_iv_entry *entry, void *priv)
 {
 	D_ASSERT(priv != NULL);
-	D_DEBUG(DB_MD, "%u: ON PUT\n", dss_self_rank());
 	D_FREE(priv);
 }
 
@@ -331,6 +342,7 @@ oid_iv_reserve(void *ns, uuid_t po_uuid, uuid_t co_uuid, uint64_t num_oids, d_sg
 	oids->num_oids = num_oids;
 	oids->req_rank     = dss_self_rank();
 	oids->req_num_oids = num_oids;
+	oids->req_ptr      = value;
 
 	rc = ds_iv_update(ns, &key, value, 0, CRT_IV_SYNC_NONE,
 			  CRT_IV_SYNC_BIDIRECTIONAL, true /* retry */);

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -110,6 +110,7 @@ struct oid_iv_range {
 	daos_size_t	num_oids;
 	daos_size_t     req_num_oids;
 	d_rank_t        req_rank;
+	void           *req_ptr;
 };
 
 /* Container IV structure */


### PR DESCRIPTION
…r (#15714)

the src pointer for on_update() callback is on the stack and should not be saved beyond that call to detect the same request, because in some cases we can end up with 2 different requests sharing getting the same pointer value. Use the private pointer allocated by the oid iv on_get operation instead.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
