### PR TITLE
b/390177544 cart: Support dynamic mercury/libfabric loglevels

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -766,6 +767,44 @@ crt_hg_free_protocol_info(struct na_protocol_info *na_protocol_info)
 	HG_Free_na_protocol_info(na_protocol_info);
 }
 
+void
+crt_hg_reset_log_level()
+{
+	char *e_loglev = NULL;
+
+	if (d_agetenv_str(&e_loglev, "HG_LOG_LEVEL") == 0) {
+		HG_Set_log_subsys(e_loglev);
+		d_freeenv_str(&e_loglev);
+		return;
+	}
+	HG_Set_log_level("warning");
+}
+
+void
+crt_hg_set_log_level(const char *level)
+{
+	HG_Set_log_level(level);
+}
+
+void
+crt_hg_reset_log_subsys()
+{
+	char *e_subsys = NULL;
+
+	if (d_agetenv_str(&e_subsys, "HG_LOG_SUBSYS") == 0) {
+		HG_Set_log_subsys(e_subsys);
+		d_freeenv_str(&e_subsys);
+		return;
+	}
+	HG_Set_log_subsys("hg,na");
+}
+
+void
+crt_hg_set_log_subsys(const char *subsys)
+{
+	HG_Set_log_subsys(subsys);
+}
+
 /* to be called only in crt_init */
 int
 crt_hg_init(void)
@@ -781,8 +820,8 @@ crt_hg_init(void)
 
 	if (!d_isenv_def("HG_LOG_SUBSYS")) {
 		if (!d_isenv_def("HG_LOG_LEVEL"))
-			HG_Set_log_level("warning");
-		HG_Set_log_subsys("hg,na");
+			crt_hg_reset_log_level();
+		crt_hg_reset_log_subsys();
 	}
 
 	/* import HG log */

--- a/src/control/server/engine/utils.go
+++ b/src/control/server/engine/utils.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -138,7 +139,7 @@ var (
 		"PLACEMENT", "REBUILD", "MGMT", "BIO", "TESTS", "DFS", "DUNS",
 		"DRPC", "SECURITY", "DTX", "DFUSE", "IL", "CSUM", "STACK",
 		"MISC", "MEM", "SWIM", "FI", "TELEM", // Common subsystems (GURT)
-		"CRT", "RPC", "BULK", "CORPC", "GRP", "LM", "HG", // CaRT subsystems
+		"CRT", "RPC", "BULK", "CORPC", "GRP", "LM", "HG", "MERCURY", // CaRT subsystems
 		"EXTERNAL", "ST", "IV", "CTL",
 	}
 	errLogNameAllWithOther = errors.New("'all' identifier can not be used with any other log identifier")

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2374,6 +2375,18 @@ int crt_context_quota_limit_get(crt_context_t crt_ctx, crt_quota_type_t quota, i
  */
 int
 crt_req_get_proto_ver(crt_rpc_t *req);
+
+void
+crt_hg_reset_log_level();
+
+void
+crt_hg_set_log_level(const char *level);
+
+void
+crt_hg_reset_log_subsys();
+
+void
+crt_hg_set_log_subsys(const char *subsys);
 
 /** @}
  */

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -104,7 +105,7 @@ ds_mgmt_drpc_set_log_masks(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	Ctl__SetLogMasksResp	 resp;
 	uint8_t			*body;
 	size_t			 len;
-	char			 retbuf[1024];
+	char                     retbuf[1024] = {'\0'};
 
 	/* Unpack the inner request from the drpc call body */
 	req = ctl__set_log_masks_req__unpack(&alloc.alloc,
@@ -129,6 +130,15 @@ ds_mgmt_drpc_set_log_masks(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	d_log_getmasks(retbuf, 0, sizeof(retbuf), 0);
 	D_INFO("Received request to set log masks '%s' masks are now %s, debug streams (DD_MASK) "
 	       "set to '%s'\n", req->masks, retbuf, req->streams);
+
+	/* dumb proof of concept to allow for adjusting the mercury/libfabric loglevel at runtime */
+	if (strstr(retbuf, "mercury=DBUG") != NULL) {
+		crt_hg_set_log_level("debug");
+		crt_hg_set_log_subsys("hg,na,libfabric");
+	} else if (strstr(retbuf, "mercury=ERR") != NULL) {
+		crt_hg_reset_log_level();
+		crt_hg_reset_log_subsys();
+	}
 
 	len = ctl__set_log_masks_resp__get_packed_size(&resp);
 	D_ALLOC(body, len);

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -495,6 +496,26 @@ int
 crt_rank_self_set(d_rank_t rank, uint32_t group_version_min)
 {
 	return 0;
+}
+
+void
+crt_hg_reset_log_level()
+{
+}
+
+void
+crt_hg_set_log_level(const char *level)
+{
+}
+
+void
+crt_hg_reset_log_subsys()
+{
+}
+
+void
+crt_hg_set_log_subsys(const char *subsys)
+{
 }
 
 void

--- a/utils/githooks/commit-msg
+++ b/utils/githooks/commit-msg
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+. utils/githooks/hook_base.sh


### PR DESCRIPTION
Mercury and libfabric are much too spammy to enable at lower
than warning level by default. Mercury does support adjustment
of its log level and logged subsystems at runtime, so this
patch provides access to that functionality from the
existing `dmg server set-logmasks` tool.

Change-Id: Ib04594dde5a7b3f50cce4176759edf1f109c0947
Signed-off-by: Michael MacDonald <mjmac@google.com>
