### PR TITLE
DAOS-15698 test: Update the reset faulty device logic for nvme_utils.…

### DIFF
--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -44,7 +44,7 @@ def set_device_faulty(test, dmg, server, uuid, pool=None, has_sys_xs=False, **kw
     Args:
         test (Test): avocado test class
         dmg (DmgCommand): a DmgCommand class instance
-        server (NodeSet): host on which to issue the dmg storage set nvme-faulty
+        server (NodeSet): host on which to issue the dmg storage set nvme-faulty. Must be one host.
         uuid (str): the device UUID
         pool (TestPool, optional): pool used to wait for rebuild to start/complete if specified.
             Defaults to None.
@@ -52,24 +52,30 @@ def set_device_faulty(test, dmg, server, uuid, pool=None, has_sys_xs=False, **kw
         kwargs (dict, optional): named arguments to pass to the DmgCommand.storage_set_faulty.
 
     Returns:
-        dict: the json response from the dmg storage set-faulty command.
-
+        dict: the json response from the dmg storage set-faulty command. None if has_sys_xs is True.
     """
     kwargs['host'] = server
     kwargs['uuid'] = uuid
+    response = None
     try:
         response = get_dmg_response(dmg.storage_set_faulty, **kwargs)
+        if has_sys_xs:
+            test.fail("Setting a sys_xs device faulty should fail.")
     except CommandFailure as error:
         if not has_sys_xs:
             test.fail(str(error))
 
     # Update the expected status of the any stopped/excluded ranks
     if has_sys_xs:
-        ranks = [test.server_managers[-1].ranks[server]]
+        rank_to_host = test.server_managers[-1].ranks
+        ranks = []
+        for rank, host in rank_to_host.items():
+            if host == str(server):
+                ranks.append(rank)
         test.server_managers[-1].update_expected_states(ranks, ["stopped", "excluded"])
-
-    # Add a tearDown method to reset the faulty device
-    test.register_cleanup(reset_fault_device, dmg=dmg, server=server, uuid=uuid)
+    else:
+        # Add a tearDown method to reset the faulty device
+        test.register_cleanup(reset_fault_device, dmg=dmg, server=server, uuid=uuid)
 
     if pool:
         # Wait for rebuild to start


### PR DESCRIPTION
…py (#15430)

MD-on-SSD cluster: If we set storage faulty, the corresponding engine dies (becomes excluded). Tell the server manager the rank is excluded and don't reset faulty device.
Non-MD-on-SSD cluster: Reset by calling dmg storage led identify --reset. We expect the command to work and all engines to be joined.

Test-tag: test_nvme_fault test_nvme_fault_reintegration test_vmd_led_faulty test_disk_failure_recover
Skip-func-hw-test-medium-vmd: false
Skip-func-hw-test-large-md-on-ssd: false

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
