### PR TITLE
DAOS-623 ci: avoid exception in extra.py when clang-format is missing

### DIFF
--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
 (C) Copyright 2018-2022 Intel Corporation.
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -20,6 +21,18 @@ from SCons.Script import WhereIs
 # Minimum version of clang-format that we use the configuration file for.  With clang-format
 # versions older than this it's still used, but without loading our config.
 MIN_FORMAT_VERSION = 12
+
+
+def _get_version_string():
+    clang_exe = WhereIs('clang-format')
+    if clang_exe is None:
+        return None
+    try:
+        rawbytes = subprocess.check_output([clang_exe, "-version"])
+        match = re.search(r"version ((\d+)(\.\d+)+)", rawbytes.decode('utf-8'))
+        return match.group(1)
+    except subprocess.CalledProcessError:
+        return None
 
 
 def _supports_custom_format(clang_exe):
@@ -42,18 +55,13 @@ def _supports_custom_format(clang_exe):
     return False
 
 
-def _supports_correct_style(clang_exe):
+def _supports_correct_style(version):
     """Checks if the version of clang-format is 14.0.5 or newer.
 
     Older versions contain bugs so will generate incorrectly formatted code on occasion.
     """
-    try:
-        rawbytes = subprocess.check_output([clang_exe, "-version"])
-        output = rawbytes.decode('utf-8')
-    except subprocess.CalledProcessError:
-        return False
 
-    match = re.search(r'version ([\d+\.]+)', output)
+    match = re.search(r'([\d+\.]+)', version)
     if match:
         parts = match.group(1).split('.')
         if int(parts[0]) != 14:
@@ -102,10 +110,11 @@ def _preprocess_emitter(source, target, env):
 
 def main():
     """Check for a supported version of clang-format"""
-    supported = _supports_correct_style(WhereIs('clang-format'))
-    if not supported:
+    version = _get_version_string()
+    if (version is None) or (not _supports_correct_style(version)):
         print('Install clang-format version 14.0.5 or newer to reformat code')
         sys.exit(1)
+    print(f"Clang-format version {version} installed")
     sys.exit(0)
 
 

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -35,19 +35,16 @@ def _get_version_string():
         return None
 
 
-def _supports_custom_format(clang_exe):
+def _supports_custom_format(version):
     """Checks if the version of clang-format is new enough.
 
     Older versions complain about some of the options used so enforce a minimum version.
     """
-    try:
-        rawbytes = subprocess.check_output([clang_exe, "-version"])
-        output = rawbytes.decode('utf-8')
-    except subprocess.CalledProcessError:
+    if version is None:
         print("Unsupported clang-format for custom style.  Using Mozilla style.")
         return False
 
-    match = re.search(r"version (\d+)\.", output)
+    match = re.search(r"(\d+)\.", version)
     if match and int(match.group(1)) >= MIN_FORMAT_VERSION:
         return True
 
@@ -80,7 +77,7 @@ def _find_indent():
     indent = WhereIs("clang-format")
     if indent is None:
         return None
-    if _supports_custom_format(indent):
+    if _supports_custom_format(_get_version_string()):
         style = "file"
     else:
         style = "Mozilla"

--- a/site_scons/site_tools/extra/extra.py
+++ b/site_scons/site_tools/extra/extra.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 (C) Copyright 2018-2022 Intel Corporation.
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP.
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -23,6 +23,12 @@ from SCons.Script import WhereIs
 MIN_FORMAT_VERSION = 12
 
 
+def errprint(*args, **kwargs):
+    """Print message on stderr.
+    """
+    print(*args, file=sys.stderr, **kwargs)
+
+
 def _get_version_string():
     clang_exe = WhereIs('clang-format')
     if clang_exe is None:
@@ -41,14 +47,14 @@ def _supports_custom_format(version):
     Older versions complain about some of the options used so enforce a minimum version.
     """
     if version is None:
-        print("Unsupported clang-format for custom style.  Using Mozilla style.")
+        errprint("Unsupported clang-format for custom style.  Using Mozilla style.")
         return False
 
     match = re.search(r"(\d+)\.", version)
     if match and int(match.group(1)) >= MIN_FORMAT_VERSION:
         return True
 
-    print(f'Custom .clang-format wants version {MIN_FORMAT_VERSION}+. Using Mozilla style.')
+    errprint(f'Custom .clang-format wants version {MIN_FORMAT_VERSION}+. Using Mozilla style.')
     return False
 
 
@@ -109,7 +115,7 @@ def main():
     """Check for a supported version of clang-format"""
     version = _get_version_string()
     if (version is None) or (not _supports_correct_style(version)):
-        print('Install clang-format version 14.0.5 or newer to reformat code')
+        errprint('Install clang-format version 14.0.5 or newer to reformat code')
         sys.exit(1)
     print(f"Clang-format version {version} installed")
     sys.exit(0)

--- a/utils/githooks/pre-commit.d/50-clang-format.sh
+++ b/utils/githooks/pre-commit.d/50-clang-format.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Copyright 2022-2024 Intel Corporation.
+# Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -21,10 +22,10 @@ if ! command -v clang-format > /dev/null 2>&1; then
     exit 0
 fi
 
-echo "Formatting C files"
-
 # Check version of clang-format, and print a helpful message if it's too old.  If the right version
 # is not found then exit.
-./site_scons/site_tools/extra/extra.py || exit 0
+./site_scons/site_tools/extra/extra.py > /dev/null || exit 0
+
+echo "Formatting C files"
 
 git-clang-format --staged src


### PR DESCRIPTION
To avoid `extra.py` script corruption when `clang-format` is not installed.

```
Traceback (most recent call last):
  File "/home/grom72/repos/daos/./site_scons/site_tools/extra/extra.py", line 141, in <module>
    main()
  File "/home/grom72/repos/daos/./site_scons/site_tools/extra/extra.py", line 105, in main
    supported = _supports_correct_style(WhereIs('clang-format'))
  File "/home/grom72/repos/daos/./site_scons/site_tools/extra/extra.py", line 51, in _supports_correct_style
    rawbytes = subprocess.check_output([clang_exe, "-version"])
  File "/usr/lib64/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib64/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.9/subprocess.py", line 1712, in _execute_child
    and os.path.dirname(executable)
  File "/usr/lib64/python3.9/posixpath.py", line 152, in dirname
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

Doc-only: true

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
