### PR TITLE
DAOS-16973 cq: fix codespell warnings (#15764)

### DIFF
--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -560,7 +560,7 @@ func (svc *mgmtSvc) resolveRanks(hosts, ranks string) (hitRS, missRS *ranklist.R
 	return
 }
 
-// synthesise "Stopped" rank results for any harness host errors
+// synthesize "Stopped" rank results for any harness host errors
 func addUnresponsiveResults(log logging.Logger, hostRanks map[string][]ranklist.Rank, rr *control.RanksResp, resp *fanoutResponse) {
 	for _, hes := range rr.HostErrors {
 		for _, addr := range strings.Split(hes.HostSet.DerangedString(), ",") {

--- a/src/dtx/tests/dts_local_rdb.c
+++ b/src/dtx/tests/dts_local_rdb.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2023-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -45,7 +46,7 @@ ut_rdb_mc(void **state)
 	dts_local_commit(dth);
 	DTS_FETCH_EXISTING(coh, la, DKEY_ID0, test_data_1);
 
-	/** In general re-using the same epoch by consecutive local transactions is discouraged e.g.
+	/** In general reusing the same epoch by consecutive local transactions is discouraged e.g.
 	 * in this case, attempting to punch already existing value will result in undefined
 	 * behavior. Updating already existing values at already used epoch may have also undefined
 	 * consequences in regard to snapshotting and aggregation.

--- a/src/gurt/examples/telem_producer_example.c
+++ b/src/gurt/examples/telem_producer_example.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -11,7 +12,7 @@
 #include <gurt/telemetry_producer.h>
 
 /**
- * A sample function that creates and incremements a metric for a loop counter
+ * A sample function that creates and increments a metric for a loop counter
  *
  * \param[in]	count	Number of loop iterations
  */

--- a/src/vea/vea_internal.h
+++ b/src/vea/vea_internal.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -186,7 +187,7 @@ struct vea_space_info {
 	struct vea_hint_context		*vsi_bitmap_hint_context;
 	/* Index for searching free extent by size & age */
 	struct vea_free_class		 vsi_class;
-	/* LRU to aggergate just recent freed extents or bitmap blocks */
+	/* LRU to aggregate just recent freed extents or bitmap blocks */
 	d_list_t			 vsi_agg_lru;
 	/*
 	 * Free entries sorted by offset, for coalescing the just recent


### PR DESCRIPTION
Doc-only: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
