### PR TITLE
DAOS-16968 test: Fix pool query tests

### DIFF
--- a/src/tests/ftest/control/dmg_pool_query_ranks.py
+++ b/src/tests/ftest/control/dmg_pool_query_ranks.py
@@ -53,6 +53,7 @@ class DmgPoolQueryRanks(ControlTestBase):
         self.log_step("Checking pool query with dead ranks state information")
         data = self.dmg.pool_query(self.pool.identifier, health_only=True)
         self._verify_ranks([], data, "dead_ranks")
+        self._verify_ranks([], data, "disabled_ranks")
 
         data = self.dmg.pool_query(self.pool.identifier, show_disabled=True)
         self._verify_ranks(None, data, "enabled_ranks")
@@ -119,13 +120,13 @@ class DmgPoolQueryRanks(ControlTestBase):
         self.log_step(f"Stopping rank:{dead_rank} all_ranks={all_ranks}")
         self.server_managers[0].stop_ranks([dead_rank], self.d_log)
 
-        self.log_step(f"Waiting for pool rank {dead_rank} to be deaded")
+        self.log_step(f"Waiting for pool rank {dead_rank} to be dead")
         self.pool.wait_pool_dead_ranks([dead_rank], timeout=30)
 
         self.log_step(f"Starting rank {dead_rank}")
         self.server_managers[0].start_ranks([dead_rank], self.d_log)
 
-        self.log_step("Waiting for pool ranks to no longer be deaded")
+        self.log_step("Waiting for pool ranks to no longer be dead")
         self.pool.wait_pool_dead_ranks([], timeout=30)
 
         self.log_step("Waiting for rebuild to complete")

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -84,6 +85,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
                     "total": self.params.get("total", path="/run/exp_vals/nvme/*")
                 }
             ],
+            "dead_ranks": [],
             "pool_layout_ver": 3,
             "query_mask": self.params.get("query_mask", path="/run/exp_vals/*"),
             "upgrade_layout_ver": 3,

--- a/src/tests/ftest/pool/list_verbose.py
+++ b/src/tests/ftest/pool/list_verbose.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -73,6 +74,7 @@ class ListVerboseTest(IorTestBase):
             "svc_reps": pool.svc_ranks,
             "upgrade_layout_ver": upgrade_layout_ver,
             "pool_layout_ver": pool_layout_ver,
+            "dead_ranks": [],
             "rebuild": {
                 "status": 0,
                 "state": rebuild_state,


### PR DESCRIPTION
The backport from master missed a couple of pool tests that
needed to be updated for the new JSON output from pool query.
Query results always include a dead_ranks array, even when
it's empty.

Signed-off-by: Michael MacDonald <mjmac@google.com>
