### PR TITLE
DAOS-16930 pool: pool space cache

### DIFF
--- a/src/pool/srv.c
+++ b/src/pool/srv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -22,6 +23,7 @@
 
 bool		ec_agg_disabled;
 uint32_t        pw_rf = -1; /* pool wise redundancy factor */
+uint32_t        ps_cache_intvl = 2;  /* pool space cache expiration time, in seconds */
 #define PW_RF_DEFAULT (2)
 #define PW_RF_MIN     (0)
 #define PW_RF_MAX     (4)
@@ -75,6 +77,14 @@ init(void)
 	if (!check_pool_redundancy_factor("DAOS_POOL_RF"))
 		pw_rf = PW_RF_DEFAULT;
 	D_INFO("pool redundancy factor %d\n", pw_rf);
+
+	d_getenv_uint32_t("DAOS_POOL_SPACE_CACHE_INTVL", &ps_cache_intvl);
+	if (ps_cache_intvl > 20) {
+		D_WARN("pool space cache expiration time %u is too large, use default value\n",
+		       ps_cache_intvl);
+		ps_cache_intvl = 2;
+	}
+	D_INFO("pool space cache expiration time set to %u seconds\n", ps_cache_intvl);
 
 	ds_pool_rsvc_class_register();
 

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -17,6 +18,7 @@
 #include <gurt/telemetry_common.h>
 
 extern uint32_t pw_rf;
+extern uint32_t ps_cache_intvl;
 
 /**
  * Global pool metrics


### PR DESCRIPTION
Introduce pool space query on service leader to avoid space query flooding. The pool space cache expiration time is 2 seconds by default, one can change the expiration time via DAOS_POOL_SPACE_CACHE_INTVL, if the expiration time is set to zero, space cache will be disabled.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
