### PR TITLE
DAOS-0000 vos: configure active DTX array size for test

### DIFF
--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -243,7 +244,7 @@ entries_init(struct entries *entries)
 	entries->entry_count = 0;
 	entries->alloc_count = MAX_ILOG_LEN;
 
-	rc = lrua_array_alloc(&entries->array, DTX_ARRAY_LEN, 1,
+	rc = lrua_array_alloc(&entries->array, 1 << vos_dtx_array_size_bits, 1,
 			      sizeof(struct fake_tx_entry), 0, &cbs, NULL);
 	if (rc != 0)
 		D_FREE(entries->entries);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -726,6 +726,18 @@ vos_mod_init(void)
 	}
 	D_INFO("Set DAOS VOS aggregation gap as %u (second)\n", vos_agg_gap);
 
+	vos_dtx_array_size_bits = VOS_DTX_ARRAY_MIN;
+	d_getenv_uint("DAOS_VOS_DTX_ARRAY", &vos_dtx_array_size_bits);
+	if (vos_dtx_array_size_bits < VOS_DTX_ARRAY_MIN ||
+	    vos_dtx_array_size_bits > VOS_DTX_ARRAY_MAX) {
+		D_WARN("Invalid DAOS_VOS_DTX_ARRAY value, "
+		       "valid range [%u, %u], set it as default %u\n",
+		       VOS_DTX_ARRAY_MIN, VOS_DTX_ARRAY_MAX, VOS_DTX_ARRAY_MIN);
+		vos_dtx_array_size_bits = VOS_DTX_ARRAY_MIN;
+	}
+	D_INFO("Set DAOS DTX array size as %u (1 << %u)\n",
+		1 << vos_dtx_array_size_bits, vos_dtx_array_size_bits);
+
 	return rc;
 }
 

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -419,7 +419,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
 
-	rc = lrua_array_alloc(&cont->vc_dtx_array, DTX_ARRAY_LEN, DTX_ARRAY_NR,
+	rc = lrua_array_alloc(&cont->vc_dtx_array, 1 << vos_dtx_array_size_bits, DTX_ARRAY_NR,
 			      sizeof(struct vos_dtx_act_ent),
 			      LRU_FLAG_REUSE_UNIQUE, &lru_cont_cbs,
 			      vos_tls_get(cont->vc_pool->vp_sysdb));

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -24,6 +24,8 @@
 #define DTX_ACT_BLOB_MAGIC	0x14130a2b
 #define DTX_CMT_BLOB_MAGIC	0x2502191c
 
+uint32_t	vos_dtx_array_size_bits;
+
 enum {
 	DTX_UMOFF_ILOG		= (1 << 0),
 	DTX_UMOFF_SVT		= (1 << 1),
@@ -3588,7 +3590,7 @@ vos_dtx_cache_reset(daos_handle_t coh, bool force)
 	if (cont->vc_dtx_array)
 		lrua_array_free(cont->vc_dtx_array);
 
-	rc = lrua_array_alloc(&cont->vc_dtx_array, DTX_ARRAY_LEN, DTX_ARRAY_NR,
+	rc = lrua_array_alloc(&cont->vc_dtx_array, 1 << vos_dtx_array_size_bits, DTX_ARRAY_NR,
 			      sizeof(struct vos_dtx_act_ent), LRU_FLAG_REUSE_UNIQUE,
 			      &lru_dtx_cache_cbs, vos_tls_get(false));
 	if (rc != 0) {

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -84,8 +84,10 @@ extern struct dss_module_key vos_module_key;
 #define VOS_BLK_SZ		(1UL << VOS_BLK_SHIFT) /* bytes */
 #define VOS_BLOB_HDR_BLKS	1	/* block */
 
-/** Up to 1 million lid entries split into 2048 expansion slots */
-#define DTX_ARRAY_LEN		(1 << 20) /* Total array slots for DTX lid */
+/** Up to (1 << vos_dtx_array_size_bits) lid entries split into 2048 expansion slots */
+extern uint32_t			vos_dtx_array_size_bits;
+#define VOS_DTX_ARRAY_MIN	20
+#define VOS_DTX_ARRAY_MAX	23
 #define DTX_ARRAY_NR		(1 << 11)  /* Number of expansion arrays */
 
 enum {


### PR DESCRIPTION
It allow the admin to specify pre-allocated active DTX array size via server side environment variable DAOS_VOS_DTX_ARRAY. The real vaule will be 1 << N, N is the specified DAOS_VOS_DTX_ARRAY value. The default vaule is 20. The min value is 20, the max value is 23.

Only for test.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
