### PR TITLE
DAOS-16807 client: intercept io_queue_init in libpil4dfs

### DIFF
--- a/src/client/dfuse/pil4dfs/aio.c
+++ b/src/client/dfuse/pil4dfs/aio.c
@@ -61,10 +61,29 @@ static int (*next_io_cancel)(io_context_t ctx, struct iocb *iocb, struct io_even
 static int (*next_io_getevents)(io_context_t ctx, long min_nr, long nr, struct io_event *events,
 				struct timespec *timeout);
 
+static int (*next_io_queue_init)(int maxevents, io_context_t *ctxp);
 /* aio functions return negative errno in case of failure */
 
 static int
 create_ev_eq_for_aio(d_aio_ctx_t *aio_ctx);
+
+int
+io_setup(int maxevents, io_context_t *ctxp);
+
+int
+io_queue_init(int maxevents, io_context_t *ctxp)
+{
+	if (next_io_queue_init == NULL) {
+		next_io_queue_init = dlsym(RTLD_NEXT, "io_queue_init");
+		D_ASSERT(next_io_queue_init != NULL);
+	}
+
+	if (maxevents > 0) {
+		return io_setup(maxevents, ctxp);
+	}
+
+	return -EINVAL;
+}
 
 int
 io_setup(int maxevents, io_context_t *ctxp)


### PR DESCRIPTION
Intercepting io_queue_init() is needed on Ubuntu. There is compatibility issue for pil4dfs interception library when used with fio libaio engine. In some cases, fio initialize the aio context through io_queue_init function when loading the libaio engine. Through the pil4dfs has intercepted the io_setup function, but it seems that the io_setup which called by io_queue_init is not intercepted some times, which causing invalid aio context for I/O processing. So add an interception for io_queue_init to make it work for this case.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
