### PR TITLE
Wangdi/master dfuse fix

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -400,6 +400,13 @@ struct dfuse_event {
 	d_iov_t          de_iov;
 	d_sg_list_t      de_sgl;
 	d_list_t         de_list;
+
+	/* Position in a list of events, this will either be off active->open_reads or
+	 * de->de_read_slaves.
+	 */
+	d_list_t         de_read_list;
+	/* List of slave events */
+	d_list_t         de_read_slaves;
 	struct dfuse_eq *de_eqt;
 	union {
 		struct dfuse_obj_hdl     *de_oh;
@@ -1018,6 +1025,7 @@ struct dfuse_inode_entry {
 
 struct active_inode {
 	d_list_t               chunks;
+	d_list_t               open_reads;
 	pthread_spinlock_t     lock;
 	struct dfuse_pre_read *readahead;
 };
@@ -1134,7 +1142,7 @@ dfuse_cache_evict_dir(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *i
  * Returns true if feature was used.
  */
 bool
-read_chunk_close(struct active_inode *active);
+read_chunk_close(struct dfuse_inode_entry *ie);
 
 /* Metadata caching functions. */
 

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -1134,7 +1134,7 @@ dfuse_cache_evict_dir(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *i
  * Returns true if feature was used.
  */
 bool
-read_chunk_close(struct dfuse_inode_entry *ie);
+read_chunk_close(struct active_inode *active);
 
 /* Metadata caching functions. */
 

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -96,6 +96,9 @@ struct dfuse_eq {
  * memory consumption */
 #define DFUSE_MAX_PRE_READ (1024 * 1024 * 4)
 
+/* Maximum file-size for pre-read in all cases */
+#define DFUSE_MAX_PRE_READ_ONCE (1024 * 1024 * 1)
+
 /* Launch fuse, and do not return until complete */
 int
 dfuse_launch_fuse(struct dfuse_info *dfuse_info, struct fuse_args *args);
@@ -203,6 +206,8 @@ struct dfuse_obj_hdl {
 	bool                      doh_kreaddir_finished;
 
 	bool                      doh_evict_on_close;
+	/* the handle is doing readhead for the moment */
+	bool                      doh_readahead_inflight;
 };
 
 /* Readdir support.
@@ -1040,7 +1045,7 @@ struct active_inode {
 
 /* Increase active count on inode.  This takes a reference and allocates ie->active as required */
 int
-active_ie_init(struct dfuse_inode_entry *ie, bool *preread);
+active_ie_init(struct dfuse_inode_entry *ie);
 
 /* Mark a oh as closing and drop the ref on inode active */
 void
@@ -1215,7 +1220,15 @@ bool
 dfuse_dcache_get_valid(struct dfuse_inode_entry *ie, double max_age);
 
 void
-dfuse_pre_read(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie);
+dfuse_pre_read(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh, struct dfuse_event *ev);
+
+int
+dfuse_pre_read_init(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie,
+		    struct dfuse_event **evp);
+
+void
+dfuse_pre_read_abort(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh,
+		     struct dfuse_event *ev, int rc);
 
 int
 check_for_uns_ep(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie, char *attr,

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1322,6 +1322,8 @@ dfuse_read_event_size(void *arg, size_t size)
 		ev->de_sgl.sg_nr       = 1;
 	}
 
+	D_INIT_LIST_HEAD(&ev->de_read_slaves);
+
 	rc = daos_event_init(&ev->de_ev, ev->de_eqt->de_eq, NULL);
 	if (rc != -DER_SUCCESS) {
 		return false;

--- a/src/client/dfuse/file.c
+++ b/src/client/dfuse/file.c
@@ -96,7 +96,7 @@ active_oh_decref(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh)
 	if (oc != 1)
 		goto out;
 
-	rcb = read_chunk_close(oh->doh_ie);
+	rcb = read_chunk_close(oh->doh_ie->ie_active);
 
 	ah_free(dfuse_info, oh->doh_ie);
 out:
@@ -118,7 +118,7 @@ active_ie_decref(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 	if (oc != 1)
 		goto out;
 
-	read_chunk_close(ie);
+	read_chunk_close(ie->ie_active);
 
 	ah_free(dfuse_info, ie);
 out:

--- a/src/client/dfuse/file.c
+++ b/src/client/dfuse/file.c
@@ -41,6 +41,7 @@ active_ie_init(struct dfuse_inode_entry *ie, bool *preread)
 		goto out;
 	}
 	D_INIT_LIST_HEAD(&ie->ie_active->chunks);
+	D_INIT_LIST_HEAD(&ie->ie_active->open_reads);
 	if (preread && *preread) {
 		D_ALLOC_PTR(ie->ie_active->readahead);
 		if (ie->ie_active->readahead) {
@@ -96,7 +97,7 @@ active_oh_decref(struct dfuse_info *dfuse_info, struct dfuse_obj_hdl *oh)
 	if (oc != 1)
 		goto out;
 
-	rcb = read_chunk_close(oh->doh_ie->ie_active);
+	rcb = read_chunk_close(oh->doh_ie);
 
 	ah_free(dfuse_info, oh->doh_ie);
 out:
@@ -118,7 +119,7 @@ active_ie_decref(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 	if (oc != 1)
 		goto out;
 
-	read_chunk_close(ie->ie_active);
+	read_chunk_close(ie);
 
 	ah_free(dfuse_info, ie);
 out:

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -217,7 +217,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent, const char *na
 
 	dfuse_compute_inode(dfs, &ie->ie_oid, &ie->ie_stat.st_ino);
 
-	rc = active_ie_init(ie, NULL);
+	rc = active_ie_init(ie);
 	if (rc != -DER_SUCCESS)
 		goto drop_oh;
 

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -92,7 +92,7 @@ dfuse_reply_entry(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie,
 		if (ie->ie_active) {
 			D_ASSERT(atomic_load_relaxed(&ie->ie_open_count) == 1);
 			active_ie_decref(dfuse_info, ie);
-			rc = active_ie_init(inode, NULL);
+			rc = active_ie_init(inode);
 			if (rc != -DER_SUCCESS) {
 				atomic_fetch_sub_relaxed(&ie->ie_ref, 1);
 				dfuse_ie_close(dfuse_info, ie);

--- a/src/client/dfuse/ops/open.c
+++ b/src/client/dfuse/ops/open.c
@@ -1,5 +1,6 @@
 /**
- * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2016-2025 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -14,9 +15,9 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	struct dfuse_inode_entry *ie;
 	struct dfuse_obj_hdl     *oh;
 	struct fuse_file_info     fi_out = {0};
+	struct dfuse_event       *ev;
+	bool                      preread = false;
 	int                       rc;
-	bool                      prefetch = false;
-	bool                      preread  = false;
 	int                       flags;
 
 	ie = dfuse_inode_lookup_nf(dfuse_info, ino);
@@ -57,6 +58,10 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	if ((fi->flags & O_ACCMODE) != O_RDONLY)
 		oh->doh_writeable = true;
 
+	rc = active_ie_init(ie);
+	if (rc)
+		goto err;
+
 	if (ie->ie_dfs->dfc_data_timeout != 0) {
 		if (fi->flags & O_DIRECT)
 			fi_out.direct_io = 1;
@@ -68,12 +73,37 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		 */
 
 		/* TODO: This probably wants reflowing to not reference ie_open_count */
-		if (atomic_load_relaxed(&ie->ie_open_count) > 0 ||
+		if (atomic_load_relaxed(&ie->ie_open_count) > 1 ||
 		    ((ie->ie_dcache_last_update.tv_sec != 0) &&
 		     dfuse_dcache_get_valid(ie, ie->ie_dfs->dfc_data_timeout))) {
 			fi_out.keep_cache = 1;
-		} else {
-			prefetch = true;
+		} else if (!(fi->flags & O_TRUNC)) {
+			D_SPIN_LOCK(&ie->ie_active->lock);
+			/**
+			 * size > 4M no pre-read
+			 * 1M <= size <= 4M depend on other files under the directory.
+			 * size <= 1M pre-read in any case.
+			 */
+			if ((oh->doh_parent_dir &&
+			     atomic_load_relaxed(&oh->doh_parent_dir->ie_linear_read) &&
+			     ie->ie_stat.st_size > 0 &&
+			     ie->ie_stat.st_size <= DFUSE_MAX_PRE_READ) ||
+			    (ie->ie_stat.st_size > 0 &&
+			     ie->ie_stat.st_size <= DFUSE_MAX_PRE_READ_ONCE)) {
+				/* Add the read extent to the list to make sure the following read
+				 * will check the readahead list first.
+				 */
+				rc = dfuse_pre_read_init(dfuse_info, ie, &ev);
+				if (rc != 0) {
+					D_SPIN_UNLOCK(&ie->ie_active->lock);
+					D_GOTO(decref, rc);
+				}
+				/* Decreased in pre_read_complete_cb() */
+				preread = true;
+				atomic_fetch_add_relaxed(&ie->ie_open_count, 1);
+				oh->doh_readahead_inflight = 1;
+			}
+			D_SPIN_UNLOCK(&ie->ie_active->lock);
 		}
 	} else if (ie->ie_dfs->dfc_data_otoc) {
 		/* Open to close caching, this allows the use of shared mmap */
@@ -93,18 +123,6 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		oh->doh_caching = true;
 
 	fi_out.fh = (uint64_t)oh;
-
-	/* Pre-read this for files up to the max read size. */
-	if (prefetch && oh->doh_parent_dir &&
-	    atomic_load_relaxed(&oh->doh_parent_dir->ie_linear_read) && ie->ie_stat.st_size > 0 &&
-	    ie->ie_stat.st_size <= DFUSE_MAX_PRE_READ) {
-		preread = true;
-	}
-
-	rc = active_ie_init(ie, &preread);
-	if (rc)
-		goto err;
-
 	/*
 	 * dfs_dup() just locally duplicates the file handle. If we have
 	 * O_TRUNC flag, we need to truncate the file manually.
@@ -112,7 +130,7 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	if (fi->flags & O_TRUNC) {
 		rc = dfs_punch(ie->ie_dfs->dfs_ns, ie->ie_obj, 0, DFS_MAX_FSIZE);
 		if (rc)
-			D_GOTO(decref, rc);
+			D_GOTO(preread_abort, rc);
 		dfuse_dcache_evict(oh->doh_ie);
 	}
 
@@ -122,9 +140,12 @@ dfuse_cb_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	 * release from completing which also holds open the inode.
 	 */
 	if (preread)
-		dfuse_pre_read(dfuse_info, ie);
+		dfuse_pre_read(dfuse_info, oh, ev);
 
 	return;
+preread_abort:
+	if (preread)
+		dfuse_pre_read_abort(dfuse_info, oh, ev, rc);
 decref:
 	active_ie_decref(dfuse_info, ie);
 err:
@@ -148,8 +169,6 @@ dfuse_cb_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	/* Perform the opposite of what the ioctl call does, always change the open handle count
 	 * but the inode only tracks number of open handles with non-zero ioctl counts
 	 */
-
-	D_ASSERT(oh->doh_ie->ie_active);
 
 	DFUSE_TRA_DEBUG(oh, "Closing %d", oh->doh_caching);
 
@@ -189,8 +208,18 @@ dfuse_cb_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		}
 	}
 	DFUSE_TRA_DEBUG(oh, "il_calls %d, caching %d,", il_calls, oh->doh_caching);
-	if (il_calls != 0) {
+	if (il_calls != 0)
 		atomic_fetch_sub_relaxed(&oh->doh_ie->ie_il_count, 1);
+
+	/* Wait inflight readahead RPC finished before release */
+	if (oh->doh_ie->ie_active != NULL) {
+wait_readahead:
+		D_SPIN_LOCK(&oh->doh_ie->ie_active->lock);
+		if (oh->doh_readahead_inflight) {
+			D_SPIN_UNLOCK(&oh->doh_ie->ie_active->lock);
+			goto wait_readahead;
+		}
+		D_SPIN_UNLOCK(&oh->doh_ie->ie_active->lock);
 	}
 
 	if (oh->doh_evict_on_close) {

--- a/src/client/dfuse/ops/opendir.c
+++ b/src/client/dfuse/ops/opendir.c
@@ -19,7 +19,7 @@ dfuse_cb_opendir(fuse_req_t req, struct dfuse_inode_entry *ie, struct fuse_file_
 	if (!oh)
 		D_GOTO(err, rc = ENOMEM);
 
-	rc = active_ie_init(ie, NULL);
+	rc = active_ie_init(ie);
 	if (rc != -DER_SUCCESS)
 		D_GOTO(free, rc = daos_der2errno(rc));
 

--- a/src/client/dfuse/ops/opendir.c
+++ b/src/client/dfuse/ops/opendir.c
@@ -35,7 +35,13 @@ dfuse_cb_opendir(fuse_req_t req, struct dfuse_inode_entry *ie, struct fuse_file_
 	if (ie->ie_dfs->dfc_dentry_timeout > 0) {
 		fi_out.cache_readdir = 1;
 
-		if (dfuse_dcache_get_valid(ie, ie->ie_dfs->dfc_dentry_timeout))
+		/**
+		 * Set keep_check to 1 to avoid the dir cache being invalidated during
+		 * concurrent opendir.
+		 **/
+		if ((ie->ie_dcache_last_update.tv_sec == 0 &&
+		     atomic_load_relaxed(&dfuse_info->di_fh_count) > 1) ||
+		    dfuse_dcache_get_valid(ie, ie->ie_dfs->dfc_dentry_timeout))
 			fi_out.keep_cache = 1;
 	}
 

--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -129,7 +129,7 @@ dfuse_readahead_reply(fuse_req_t req, size_t len, off_t position, struct dfuse_o
 	}
 
 	if (((position % K128) == 0) && ((len % K128) == 0)) {
-		DFUSE_TRA_INFO(oh, "allowing out-of-order pre read");
+		DFUSE_TRA_DEBUG(oh, "allowing out-of-order pre read");
 		/* Do not closely track the read position in this case, just the maximum,
 		 * later checks will determine if the file is read to the end.
 		 */
@@ -173,38 +173,33 @@ pick_eqt(struct dfuse_info *dfuse_info)
  *
  * This code is entered when caching is enabled and reads are correctly size/aligned and not in the
  * last CHUNK_SIZE of a file.  When open then the inode contains a single read_chunk_core pointer
- * and this contains a list of read_chunk_data entries, one for each bucket.  Buckets where all
- * slots have been requested are remove from the list and closed when the last request is completed.
+ * and this contains a list of read_chunk_data entries, one for each bucket.
  *
- * TODO: Currently there is no code to remove partially read buckets from the list so reading
- * one slot every chunk would leave the entire file contents in memory until close and mean long
- * list traversal times.
+ * TODO: Currently there is no code to remove buckets from the list so all buckets will remain in
+ * memory until close.
  */
 
 #define CHUNK_SIZE (1024 * 1024)
 
 struct read_chunk_data {
 	struct dfuse_event   *ev;
+	bool                  slot_done[8];
 	struct active_inode  *ia;
-	fuse_req_t            reqs[8];
-	struct dfuse_obj_hdl *ohs[8];
 	d_list_t              list;
 	uint64_t              bucket;
 	struct dfuse_eq      *eqt;
 	int                   rc;
 	int                   entered;
-	ATOMIC int            exited;
-	bool                  exiting;
 	bool                  complete;
+	d_list_t              req_list;
 };
 
-static void
-chunk_free(struct read_chunk_data *cd)
-{
-	d_list_del(&cd->list);
-	d_slab_release(cd->eqt->de_read_slab, cd->ev);
-	D_FREE(cd);
-}
+struct read_chunk_req {
+	d_list_t              req_list;
+	struct dfuse_obj_hdl *oh;
+	fuse_req_t            req;
+	int                   slot;
+};
 
 /* Called when the last open file handle on a inode is closed.  This needs to free everything which
  * is complete and for anything that isn't flag it for deletion in the callback.
@@ -212,27 +207,20 @@ chunk_free(struct read_chunk_data *cd)
  * Returns true if the feature was used.
  */
 bool
-read_chunk_close(struct dfuse_inode_entry *ie)
+read_chunk_close(struct active_inode *active)
 {
 	struct read_chunk_data *cd, *cdn;
-	bool                    rcb = false;
 
-	D_SPIN_LOCK(&ie->ie_active->lock);
-	if (d_list_empty(&ie->ie_active->chunks))
-		goto out;
+	if (d_list_empty(&active->chunks))
+		return false;
 
-	rcb = true;
-
-	d_list_for_each_entry_safe(cd, cdn, &ie->ie_active->chunks, list) {
-		if (cd->complete) {
-			chunk_free(cd);
-		} else {
-			cd->exiting = true;
-		}
+	d_list_for_each_entry_safe(cd, cdn, &active->chunks, list) {
+		D_ASSERT(cd->complete);
+		d_list_del(&cd->list);
+		d_slab_release(cd->eqt->de_read_slab, cd->ev);
+		D_FREE(cd);
 	}
-out:
-	D_SPIN_UNLOCK(&ie->ie_active->lock);
-	return rcb;
+	return true;
 }
 
 static void
@@ -240,117 +228,55 @@ chunk_cb(struct dfuse_event *ev)
 {
 	struct read_chunk_data *cd = ev->de_cd;
 	struct active_inode    *ia = cd->ia;
-	fuse_req_t              req;
-	bool                    done = false;
+	struct read_chunk_req  *cr;
+	struct read_chunk_req  *crn;
 
 	cd->rc = ev->de_ev.ev_error;
 
 	if (cd->rc == 0 && (ev->de_len != CHUNK_SIZE)) {
-		cd->rc = EIO;
 		DS_WARN(cd->rc, "Unexpected short read bucket %ld (%#zx) expected %i got %zi",
 			cd->bucket, cd->bucket * CHUNK_SIZE, CHUNK_SIZE, ev->de_len);
 	}
 
 	daos_event_fini(&ev->de_ev);
 
-	do {
-		int i;
-		req = 0;
+	/* Mark as complete so no more get put on list */
+	D_SPIN_LOCK(&ia->lock);
+	cd->complete = true;
 
-		D_SPIN_LOCK(&ia->lock);
+	/* Mark the slot as replied to.  There's a race here as the slot hasn't been replied to
+	 * however references are dropped by the DFUSE_REPLY macros below so an extra ref on active
+	 * would be required.  The danger is that the bucket gets put on the end of the list rather
+	 * than the start.
+	 */
+	d_list_for_each_entry(cr, &cd->req_list, req_list)
+		cd->slot_done[cr->slot] = true;
 
-		if (cd->exiting) {
-			chunk_free(cd);
-			D_SPIN_UNLOCK(&ia->lock);
-			return;
+	D_SPIN_UNLOCK(&ia->lock);
+
+	d_list_for_each_entry_safe(cr, crn, &cd->req_list, req_list) {
+		size_t position = (cd->bucket * CHUNK_SIZE) + (cr->slot * K128);
+		size_t len;
+
+		DFUSE_TRA_DEBUG(cr->oh, "Replying for %ld[%d]", cd->bucket, cr->slot);
+
+		/* Delete from the list before replying as there's no reference held otherwise */
+		d_list_del(&cr->req_list);
+
+		if (cd->rc != 0) {
+			DFUSE_REPLY_ERR_RAW(cr->oh, cr->req, cd->rc);
+		} else {
+			if ((((cr->slot + 1) * K128) - 1) >= ev->de_len)
+				len = max(ev->de_len - (cr->slot * K128), 0);
+			else
+				len = K128;
+
+			DFUSE_TRA_DEBUG(cr->oh, "%#zx-%#zx read", position, position + len - 1);
+			DFUSE_REPLY_BUFQ(cr->oh, cr->req, ev->de_iov.iov_buf + (cr->slot * K128),
+					 len);
 		}
-
-		cd->complete = true;
-		for (i = 0; i < 8; i++) {
-			if (cd->reqs[i]) {
-				req         = cd->reqs[i];
-				cd->reqs[i] = 0;
-				break;
-			}
-		}
-
-		D_SPIN_UNLOCK(&ia->lock);
-
-		if (req) {
-			size_t position = (cd->bucket * CHUNK_SIZE) + (i * K128);
-
-			if (cd->rc != 0) {
-				DFUSE_REPLY_ERR_RAW(cd->ohs[i], req, cd->rc);
-			} else {
-				DFUSE_TRA_DEBUG(cd->ohs[i], "%#zx-%#zx read", position,
-						position + K128 - 1);
-				DFUSE_REPLY_BUFQ(cd->ohs[i], req, ev->de_iov.iov_buf + (i * K128),
-						 K128);
-			}
-
-			if (atomic_fetch_add_relaxed(&cd->exited, 1) == 7)
-				done = true;
-		}
-	} while (req && !done);
-
-	if (done) {
-		d_slab_release(cd->eqt->de_read_slab, cd->ev);
-		D_FREE(cd);
+		D_FREE(cr);
 	}
-}
-
-/* Submut a read to dfs.
- *
- * Returns true on success.
- */
-static bool
-chunk_fetch(fuse_req_t req, struct dfuse_obj_hdl *oh, struct read_chunk_data *cd, int slot)
-{
-	struct dfuse_info        *dfuse_info = fuse_req_userdata(req);
-	struct dfuse_inode_entry *ie         = oh->doh_ie;
-	struct dfuse_event       *ev;
-	struct dfuse_eq          *eqt;
-	int                       rc;
-	daos_off_t                position = cd->bucket * CHUNK_SIZE;
-
-	eqt = pick_eqt(dfuse_info);
-
-	ev = d_slab_acquire(eqt->de_read_slab);
-	if (ev == NULL) {
-		cd->rc = ENOMEM;
-		return false;
-	}
-
-	ev->de_iov.iov_len = CHUNK_SIZE;
-	ev->de_req         = req;
-	ev->de_cd          = cd;
-	ev->de_sgl.sg_nr   = 1;
-	ev->de_len         = 0;
-	ev->de_complete_cb = chunk_cb;
-
-	cd->ev         = ev;
-	cd->eqt        = eqt;
-	cd->reqs[slot] = req;
-	cd->ohs[slot]  = oh;
-
-	rc = dfs_read(ie->ie_dfs->dfs_ns, ie->ie_obj, &ev->de_sgl, position, &ev->de_len,
-		      &ev->de_ev);
-	if (rc != 0)
-		goto err;
-
-	/* Send a message to the async thread to wake it up and poll for events */
-	sem_post(&eqt->de_sem);
-
-	/* Now ensure there are more descriptors for the next request */
-	d_slab_restock(eqt->de_read_slab);
-
-	return true;
-
-err:
-	daos_event_fini(&ev->de_ev);
-	d_slab_release(eqt->de_read_slab, ev);
-	cd->rc = rc;
-	return false;
 }
 
 /* Try and do a bulk read.
@@ -362,11 +288,13 @@ chunk_read(fuse_req_t req, size_t len, off_t position, struct dfuse_obj_hdl *oh)
 {
 	struct dfuse_inode_entry *ie = oh->doh_ie;
 	struct read_chunk_data   *cd;
+	struct read_chunk_req    *cr = NULL;
 	off_t                     last;
 	uint64_t                  bucket;
 	int                       slot;
 	bool                      submit = false;
 	bool                      rcb;
+	bool                      all_done = true;
 
 	if (len != K128)
 		return false;
@@ -391,7 +319,6 @@ chunk_read(fuse_req_t req, size_t len, off_t position, struct dfuse_obj_hdl *oh)
 
 	d_list_for_each_entry(cd, &ie->ie_active->chunks, list)
 		if (cd->bucket == bucket) {
-			/* Remove from list to re-add again later. */
 			d_list_del(&cd->list);
 			goto found;
 		}
@@ -400,57 +327,121 @@ chunk_read(fuse_req_t req, size_t len, off_t position, struct dfuse_obj_hdl *oh)
 	if (cd == NULL)
 		goto err;
 
+	D_ALLOC_PTR(cr);
+	if (cr == NULL) {
+		D_FREE(cd);
+		goto err;
+	}
+
+	D_INIT_LIST_HEAD(&cd->req_list);
 	cd->ia     = ie->ie_active;
 	cd->bucket = bucket;
 	submit     = true;
 
 found:
 
-	if (++cd->entered < 8) {
-		/* Put on front of list for efficient searching */
-		d_list_add(&cd->list, &ie->ie_active->chunks);
+	for (int i = 0; i < 8; i++) {
+		if (!cd->slot_done[i])
+			all_done = false;
 	}
 
-	D_SPIN_UNLOCK(&ie->ie_active->lock);
+	if (all_done)
+		d_list_add(&cd->list, &ie->ie_active->chunks);
+	else
+		d_list_add_tail(&cd->list, &ie->ie_active->chunks);
 
 	if (submit) {
-		DFUSE_TRA_DEBUG(oh, "submit for bucket %ld[%d]", bucket, slot);
-		rcb = chunk_fetch(req, oh, cd, slot);
-	} else {
-		struct dfuse_event *ev = NULL;
+		struct dfuse_info  *dfuse_info = fuse_req_userdata(req);
+		struct dfuse_eq    *eqt;
+		struct dfuse_event *ev;
+		int                 rc;
+
+		/* Overwrite position here to the start of the bucket */
+		position = cd->bucket * CHUNK_SIZE;
+
+		eqt = pick_eqt(dfuse_info);
+
+		ev = d_slab_acquire(eqt->de_read_slab);
+		if (ev == NULL) {
+			d_list_del(&cd->list);
+			D_FREE(cr);
+			D_FREE(cd);
+			goto err;
+		}
+
+		d_list_add(&cr->req_list, &cd->req_list);
 
 		/* Now check if this read request is complete or not yet, if it isn't then just
 		 * save req in the right slot however if it is then reply here.  After the call to
 		 * DFUSE_REPLY_* then no reference is held on either the open file or the inode so
 		 * at that point they could be closed.
 		 */
-		rcb = true;
 
-		D_SPIN_LOCK(&ie->ie_active->lock);
-		if (cd->complete) {
-			ev = cd->ev;
-		} else {
-			cd->reqs[slot] = req;
-			cd->ohs[slot]  = oh;
-		}
+		DFUSE_TRA_DEBUG(oh, "submit for bucket %ld[%d]", bucket, slot);
 		D_SPIN_UNLOCK(&ie->ie_active->lock);
 
-		if (ev) {
-			if (cd->rc != 0) {
-				/* Don't pass fuse an error here, rather return false and the read
-				 * will be tried over the network.
-				 */
-				rcb = false;
-			} else {
-				DFUSE_TRA_DEBUG(oh, "%#zx-%#zx read", position,
-						position + K128 - 1);
-				DFUSE_REPLY_BUFQ(oh, req, ev->de_iov.iov_buf + (slot * K128), K128);
-			}
-			if (atomic_fetch_add_relaxed(&cd->exited, 1) == 7) {
-				d_slab_release(cd->eqt->de_read_slab, cd->ev);
-				D_FREE(cd);
-			}
+		cd->eqt = eqt;
+		cd->ev  = ev;
+
+		cr->req  = req;
+		cr->oh   = oh;
+		cr->slot = slot;
+
+		ev->de_iov.iov_len = CHUNK_SIZE;
+		ev->de_req         = req;
+		ev->de_cd          = cd;
+		ev->de_sgl.sg_nr   = 1;
+		ev->de_len         = 0;
+		ev->de_complete_cb = chunk_cb;
+
+		rc = dfs_read(ie->ie_dfs->dfs_ns, ie->ie_obj, &ev->de_sgl, position, &ev->de_len,
+			      &ev->de_ev);
+		if (rc == 0) {
+			/* Send a message to the async thread to wake it up and poll for events */
+			sem_post(&eqt->de_sem);
+		} else {
+			ev->de_ev.ev_error = rc;
+			chunk_cb(ev);
 		}
+
+		rcb = true;
+	} else if (cd->complete) {
+		cd->slot_done[slot] = true;
+
+		D_SPIN_UNLOCK(&ie->ie_active->lock);
+
+		if (cd->rc != 0) {
+			/* Don't pass fuse an error here, rather return false and
+			 * the read will be tried over the network.
+			 */
+			rcb = false;
+		} else {
+			size_t read_len;
+
+			if ((((slot + 1) * K128) - 1) >= cd->ev->de_len)
+				read_len = max(cd->ev->de_len - (slot * K128), 0);
+			else
+				read_len = K128;
+
+			oh->doh_linear_read_pos = max(oh->doh_linear_read_pos, position + read_len);
+
+			DFUSE_TRA_DEBUG(oh, "%#zx-%#zx read", position, position + read_len - 1);
+			DFUSE_REPLY_BUFQ(oh, req, cd->ev->de_iov.iov_buf + (slot * K128), read_len);
+			rcb = true;
+		}
+	} else {
+		rcb = false;
+
+		D_ALLOC_PTR(cr);
+		if (cr) {
+			cr->req  = req;
+			cr->oh   = oh;
+			cr->slot = slot;
+			d_list_add_tail(&cr->req_list, &cd->req_list);
+			rcb = true;
+		}
+
+		D_SPIN_UNLOCK(&ie->ie_active->lock);
 	}
 
 	return rcb;
@@ -493,8 +484,10 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position, struct
 	eqt = pick_eqt(dfuse_info);
 
 	ev = d_slab_acquire(eqt->de_read_slab);
-	if (ev == NULL)
-		D_GOTO(err, rc = ENOMEM);
+	if (ev == NULL) {
+		DFUSE_REPLY_ERR_RAW(oh, req, ENOMEM);
+		return;
+	}
 
 	if (oh->doh_ie->ie_truncated && position + len < oh->doh_ie->ie_stat.st_size &&
 	    ((oh->doh_ie->ie_start_off == 0 && oh->doh_ie->ie_end_off == 0) ||
@@ -533,7 +526,8 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position, struct
 
 	rc = dfs_read(oh->doh_dfs, oh->doh_obj, &ev->de_sgl, position, &ev->de_len, &ev->de_ev);
 	if (rc != 0) {
-		D_GOTO(err, rc);
+		ev->de_ev.ev_error = rc;
+		dfuse_cb_read_complete(ev);
 		return;
 	}
 
@@ -544,12 +538,6 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position, struct
 	d_slab_restock(eqt->de_read_slab);
 
 	return;
-err:
-	DFUSE_REPLY_ERR_RAW(oh, req, rc);
-	if (ev) {
-		daos_event_fini(&ev->de_ev);
-		d_slab_release(eqt->de_read_slab, ev);
-	}
 }
 
 static void

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -502,6 +502,7 @@ restart:
 				}
 
 				set_entry_params(&entry, ie);
+				dfuse_mcache_set_time(ie);
 
 				written = FADP(req, &reply_buff[buff_offset], size - buff_offset,
 					       drc->drc_name, &entry, drc->drc_next_offset);
@@ -733,6 +734,7 @@ restart:
 				}
 
 				set_entry_params(&entry, ie);
+				dfuse_mcache_set_time(ie);
 
 				written = FADP(req, &reply_buff[buff_offset], size - buff_offset,
 					       dre->dre_name, &entry, dre->dre_next_offset);

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1560,17 +1560,17 @@ class DFuse():
         return rc
 
     def check_usage(self, ino=None, inodes=None, open_files=None, pools=None, containers=None,
-                    qpath=None):
+                    qpath=None, old=None):
         """Query and verify the dfuse statistics.
 
+        Optionally verify numbers are as expected/defined or return a delta to a previous sample.
         Returns the raw numbers in a dict.
         """
         cmd = ['filesystem', 'query', qpath or self.dir]
 
         if ino is not None:
             cmd.extend(['--inode', str(ino)])
-        rc = run_daos_cmd(self.conf, cmd, use_json=True)
-        print(rc)
+        rc = run_daos_cmd(self.conf, cmd, use_json=True, valgrind=False, log_check=False)
         assert rc.returncode == 0, rc
 
         if inodes:
@@ -1581,6 +1581,16 @@ class DFuse():
             assert rc.json['response']['pools'] == pools, rc
         if containers:
             assert rc.json['response']['containers'] == containers, rc
+
+        # If a prior version of the statistics was supplied then take a delta, but take a delta of
+        # the prior version as it came from daos, not as it was reported.
+        if 'statistics' in rc.json['response']:
+            rc.json['response']['raw'] = copy.deepcopy(rc.json['response']['statistics'])
+        if old:
+            for key in rc.json['response']['statistics']:
+                rc.json['response']['statistics'][key] -= old['raw'].get(key, 0)
+
+        print(f"Usage: {rc.json['response']}")
         return rc.json['response']
 
     def _evict_path(self, path):
@@ -1604,7 +1614,7 @@ class DFuse():
         for inode in inodes:
             found = True
             while found:
-                rc = self.check_usage(inode, qpath=qpath)
+                rc = self.check_usage(ino=inode, qpath=qpath)
                 print(rc)
                 found = rc['resident']
                 if not found:
@@ -2316,7 +2326,7 @@ class PosixTests():
     def test_pre_read(self):
         """Test the pre-read code.
 
-        Test reading a file which is previously unknown to fuse with caching on.  This should go
+        Test reading a files which are previously unknown to fuse with caching on.  This should go
         into the pre_read code and load the file contents automatically after the open call.
         """
         dfuse = DFuse(self.server, self.conf, container=self.container)
@@ -2345,32 +2355,57 @@ class PosixTests():
         dfuse = DFuse(self.server, self.conf, caching=True, container=self.container)
         dfuse.start(v_hint='pre_read_1')
 
+        # Open a file and read in one go.
         with open(join(dfuse.dir, 'file0'), 'r') as fd:
             data0 = fd.read()
+        res = dfuse.check_usage()
+        assert res['statistics']['pre_read'] == 1, res
 
+        # Open a file and read in one go.
         with open(join(dfuse.dir, 'file1'), 'r') as fd:
             data1 = fd.read(16)
+        res = dfuse.check_usage(old=res)
+        assert res['statistics']['pre_read'] == 1, res
 
-        with open(join(dfuse.dir, 'file2'), 'r') as fd:
-            data2 = fd.read(2)
+        # Open a file and read two bytes at a time.  Despite disabling buffering python will try and
+        # read a whole page the first time.
+        fd = os.open(join(dfuse.dir, 'file2'), os.O_RDONLY)
+        data2 = os.read(fd, 2)
+        res = dfuse.check_usage(old=res)
+        assert res['statistics']['pre_read'] == 1, res
+        _ = os.read(fd, 2)
+        res = dfuse.check_usage(old=res)
+        assert res['statistics']['pre_read'] == 0, res
+        os.close(fd)
 
+        # Open a MB file.  This reads 8 128k chunks and 1 EOF.
         with open(join(dfuse.dir, 'file3'), 'r') as fd:
             data3 = fd.read()
+        res = dfuse.check_usage(old=res)
+        assert res['statistics']['pre_read'] == 9, res
 
+        # Open a (1MB-1) file.  This reads 8 128k chunks, the last is truncated.  There is no EOF
+        # returned by dfuse here, just a truncated read but I assume python is interpreting a
+        # truncated read at the expected file size as an EOF.
         with open(join(dfuse.dir, 'file4'), 'r') as fd:
             data4 = fd.read()
             data5 = fd.read()
 
-        # This should not use the pre-read feature, to be validated via the logs.
+        res = dfuse.check_usage(old=res)
+        assert res['statistics']['pre_read'] == 8, res
+
+        # This should now be read from cache.
         with open(join(dfuse.dir, 'file4'), 'r') as fd:
             data6 = fd.read()
+        res = dfuse.check_usage(old=res)
+        assert res['statistics']['read'] == 0, res
 
         if dfuse.stop():
             self.fatal_errors = True
         print(data0)
         assert data0 == 'test'
         assert data1 == 'test'
-        assert data2 == 'te'
+        assert data2 == b'te', data2
         assert raw_data0 == data3
         assert raw_data1 == data4
         assert len(data5) == 0


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
