### PR TITLE
DAOS-16312 control: Always use --force for dmg system stop

### DIFF
--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -172,6 +172,7 @@ type systemStopCmd struct {
 	cmdutil.JSONOutputCmd
 	rankListCmd
 	Force bool `long:"force" description:"Force stop DAOS system members"`
+	Full  bool `long:"full" description:"Attempt a graceful shutdown of DAOS system. Experimental and not for use in production environments"`
 }
 
 // Execute is run when systemStopCmd activates.
@@ -181,11 +182,20 @@ func (cmd *systemStopCmd) Execute(_ []string) (errOut error) {
 	defer func() {
 		errOut = errors.Wrap(errOut, "system stop failed")
 	}()
+	if cmd.Force && cmd.Full {
+		return errIncompatFlags("force", "full")
+	}
+	if cmd.Full && !cmd.Hosts.Empty() {
+		return errIncompatFlags("full", "rank-hosts")
+	}
+	if cmd.Full && !cmd.Ranks.Empty() {
+		return errIncompatFlags("full", "ranks")
+	}
 
 	if err := cmd.validateHostsRanks(); err != nil {
 		return err
 	}
-	req := &control.SystemStopReq{Force: cmd.Force}
+	req := &control.SystemStopReq{Force: cmd.Force, Full: cmd.Full}
 	req.Hosts.Replace(&cmd.Hosts.HostSet)
 	req.Ranks.Replace(&cmd.Ranks.RankSet)
 

--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -193,6 +193,32 @@ func TestDmg_SystemCommands(t *testing.T) {
 			errors.New("--ranks and --rank-hosts options cannot be set together"),
 		},
 		{
+			"system stop with full option",
+			"system stop --full",
+			strings.Join([]string{
+				printRequest(t, &control.SystemStopReq{Full: true}),
+			}, " "),
+			nil,
+		},
+		{
+			"system stop with full and force options",
+			"system stop --full --force",
+			"",
+			errors.New(`may not be mixed`),
+		},
+		{
+			"system stop with full and rank-hosts options",
+			"system stop --full --rank-hosts foo-[0-2]",
+			"",
+			errors.New(`may not be mixed`),
+		},
+		{
+			"system stop with full and ranks options",
+			"system stop --full --ranks 0-2",
+			"",
+			errors.New(`may not be mixed`),
+		},
+		{
 			"system start with no arguments",
 			"system start",
 			strings.Join([]string{

--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -849,6 +849,12 @@ func TestControl_SystemStop(t *testing.T) {
 	testRespRS := new(SystemStopResp)
 	testRespRS.AbsentRanks.Replace(testRS)
 
+	withFull := func(stopReq *SystemStopReq) *SystemStopReq {
+		nr := *stopReq
+		nr.Full = true
+		return &nr
+	}
+
 	for name, tc := range map[string]struct {
 		req     *SystemStopReq
 		uErr    error
@@ -885,6 +891,21 @@ func TestControl_SystemStop(t *testing.T) {
 					Absentranks: "1-23",
 				}),
 			expResp: testRespRS,
+		},
+		"request force and full options": {
+			req: &SystemStopReq{
+				Force: true,
+				Full:  true,
+			},
+			expErr: errors.New("may not be mixed"),
+		},
+		"request full and host set options": {
+			req:    withFull(testReqHS),
+			expErr: errors.New("may not be mixed"),
+		},
+		"request full and rank set options": {
+			req:    withFull(testReqRS),
+			expErr: errors.New("may not be mixed"),
 		},
 		"dual host dual rank": {
 			req: new(SystemStopReq),

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -1563,9 +1563,16 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 			expInvokeCount: 2,
 		},
 		"stop some ranks": {
-			req:        &mgmtpb.SystemStopReq{Ranks: "0,1"},
-			mResps:     [][]*control.HostResponse{{hr(1, mockRankSuccess("stop", 0), mockRankSuccess("stop", 1))}},
-			expResults: []*sharedpb.RankResult{mockRankSuccess("stop", 0, 1), mockRankSuccess("stop", 1, 1)},
+			req: &mgmtpb.SystemStopReq{Ranks: "0,1", Force: true},
+			mResps: [][]*control.HostResponse{
+				{
+					hr(1, mockRankSuccess("stop", 0), mockRankSuccess("stop", 1)),
+				},
+			},
+			expResults: []*sharedpb.RankResult{
+				mockRankSuccess("stop", 0, 1),
+				mockRankSuccess("stop", 1, 1),
+			},
 			expMembers: func() system.Members {
 				return system.Members{
 					mockMember(t, 0, 1, "stopped"),
@@ -1575,9 +1582,9 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 			},
 			expInvokeCount: 1, // prep should not be called
 		},
-		"stop with all ranks (same as full system stop)": {
-			req:        &mgmtpb.SystemStopReq{Ranks: "0,1,3"},
-			mResps:     hostRespSuccess,
+		"stop with all ranks": {
+			req:        &mgmtpb.SystemStopReq{Ranks: "0,1,3", Force: true},
+			mResps:     hostRespStopSuccess,
 			expResults: rankResStopSuccess,
 			expMembers: func() system.Members {
 				return system.Members{
@@ -1586,7 +1593,7 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 					mockMember(t, 3, 2, "stopped"),
 				}
 			},
-			expInvokeCount: 2, // prep should be called
+			expInvokeCount: 1, // prep should not be called
 		},
 		"full system stop": {
 			req:        &mgmtpb.SystemStopReq{},
@@ -1600,6 +1607,11 @@ func TestServer_MgmtSvc_SystemStop(t *testing.T) {
 				}
 			},
 			expInvokeCount: 2, // prep should be called
+		},
+		"full system stop; partial ranks in req": {
+			req:       &mgmtpb.SystemStopReq{Ranks: "0,1"},
+			mResps:    hostRespStopSuccess,
+			expAPIErr: errSysForceNotFull,
 		},
 		"full system stop (forced)": {
 			req:        &mgmtpb.SystemStopReq{Force: true},

--- a/src/tests/ftest/control/log_entry.py
+++ b/src/tests/ftest/control/log_entry.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -171,7 +172,7 @@ class ControlLogEntry(TestWithServers):
 
         self.log_step('Stop/start 2 random ranks')
         stop_ranks = self.random.sample(list(self.server_managers[0].ranks), k=2)
-        expected = [fr'rank {rank}.*exited with 0' for rank in stop_ranks] \
+        expected = [fr'rank {rank}.*killed' for rank in stop_ranks] \
             + [fr'process.*started on rank {rank}' for rank in stop_ranks]
         with self.verify_journalctl(expected):
             self.server_managers[0].stop_ranks(stop_ranks, self.d_log)

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -908,7 +908,7 @@ class DaosServer():
             self.conf.wf.issues.append(entry)
             self._add_test_case('server_stop', failure=message)
         start = time.perf_counter()
-        rc = self.run_dmg(['system', 'stop'])
+        rc = self.run_dmg(['system', 'stop', '--full'])
         if rc.returncode != 0:
             print(rc)
             entry = {}
@@ -916,7 +916,7 @@ class DaosServer():
             # pylint: disable=protected-access
             entry['lineStart'] = sys._getframe().f_lineno
             entry['severity'] = 'ERROR'
-            msg = f'dmg system stop failed with {rc.returncode}'
+            msg = f'dmg system stop --full failed with {rc.returncode}'
             entry['message'] = msg
             self.conf.wf.issues.append(entry)
         if not self.valgrind:


### PR DESCRIPTION
Whenever stopping an engine process from within the control-plane, use
SIGKILL rather than asking nicely (SIGTERM). This has been requested
to try to avoid situations that could result in dataloss.

This change preserves the behaviour where ds_mgmt_drpc_prep_shutdown()
and then ds_pool_disable_exclude() will be called during a controlled
shutdown where dmg system stop is called with new --full argument.

Notable behavior changes with this PR:
- Always performs SIGKILL on dmg system stop unless --full command
  option is supplied.
- Will attempt prepare shutdown to disable exclusions across cluster
  during “controlled” shutdown where dmg system stop is called with
  --full option but this should be regarded as experimental and not
  for use in production environments.
- Force option is a no-op and is retained for backward compatibility
  and future use.

Allow-unstable-test: true
Features: control

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
