### PR TITLE
DAOS-17013 cart: Fix timeout error prints for CORPCS

### DIFF
--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -27,58 +28,82 @@
 #include "crt_swim.h"
 
 /* A wrapper around D_TRACE_DEBUG that ensures the ptr option is a RPC */
-#define RPC_TRACE(mask, rpc, fmt, ...)                                                             \
-	do {                                                                                       \
-		char *_module;                                                                     \
-		char *_opc;                                                                        \
-                                                                                                   \
-		if (!D_LOG_ENABLED(DB_TRACE))                                                      \
-			break;                                                                     \
-                                                                                                   \
-		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
-		D_TRACE_DEBUG(mask, (rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,     \
-			      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
-			      (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,           \
-			      ##__VA_ARGS__);                                                      \
+#define RPC_TRACE(mask, rpc, fmt, ...)                                                                     \
+	do {                                                                                               \
+		char *_module;                                                                             \
+		char *_opc;                                                                                \
+                                                                                                           \
+		if (!D_LOG_ENABLED(DB_TRACE))                                                              \
+			break;                                                                             \
+                                                                                                           \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                                    \
+		if ((rpc)->crp_coll) {                                                                     \
+			D_TRACE_DEBUG(mask, (rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,              \
+				      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
+				      ##__VA_ARGS__);                                                      \
+		} else {                                                                                   \
+			D_TRACE_DEBUG(mask, (rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,     \
+				      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
+				      (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,           \
+				      ##__VA_ARGS__);                                                      \
+		}                                                                                          \
 	} while (0)
 
 /* Log an error with an RPC descriptor */
-#define RPC_ERROR(rpc, fmt, ...)                                                                   \
-	do {                                                                                       \
-		char *_module;                                                                     \
-		char *_opc;                                                                        \
-                                                                                                   \
-		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
-		D_TRACE_ERROR((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,           \
-			      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
-			      (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,           \
-			      ##__VA_ARGS__);                                                      \
+#define RPC_ERROR(rpc, fmt, ...)                                                                           \
+	do {                                                                                               \
+		char *_module;                                                                             \
+		char *_opc;                                                                                \
+                                                                                                           \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                                    \
+		if ((rpc)->crp_coll) {                                                                     \
+			D_TRACE_ERROR((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,                    \
+				      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
+				      ##__VA_ARGS__);                                                      \
+		} else {                                                                                   \
+			D_TRACE_ERROR((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,           \
+				      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
+				      (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,           \
+				      ##__VA_ARGS__);                                                      \
+		}                                                                                          \
 	} while (0)
 
 /* Log a warning with an RPC descriptor */
-#define RPC_WARN(rpc, fmt, ...)                                                                    \
-	do {                                                                                       \
-		char *_module;                                                                     \
-		char *_opc;                                                                        \
-                                                                                                   \
-		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
-		D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
-			     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
-			     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
-			     ##__VA_ARGS__);                                                       \
+#define RPC_WARN(rpc, fmt, ...)                                                                            \
+	do {                                                                                               \
+		char *_module;                                                                             \
+		char *_opc;                                                                                \
+                                                                                                           \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                                    \
+		if ((rpc)->crp_coll) {                                                                     \
+			D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,                     \
+				     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
+				     ##__VA_ARGS__);                                                       \
+		} else {                                                                                   \
+			D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
+				     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
+				     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
+				     ##__VA_ARGS__);                                                       \
+		}                                                                                          \
 	} while (0)
 
 /* Log an info message with an RPC descriptor */
-#define RPC_INFO(rpc, fmt, ...)                                                                    \
-	do {                                                                                       \
-		char *_module;                                                                     \
-		char *_opc;                                                                        \
-                                                                                                   \
-		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
-		D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
-			     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
-			     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
-			     ##__VA_ARGS__);                                                       \
+#define RPC_INFO(rpc, fmt, ...)                                                                            \
+	do {                                                                                               \
+		char *_module;                                                                             \
+		char *_opc;                                                                                \
+                                                                                                           \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                                    \
+		if ((rpc)->crp_coll) {                                                                     \
+			D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,                     \
+				     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
+				     ##__VA_ARGS__);                                                       \
+		} else {                                                                                   \
+			D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
+				     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
+				     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
+				     ##__VA_ARGS__);                                                       \
+		}                                                                                          \
 	} while (0)
 /**
  * If \a cond is false, this is equivalent to an RPC_ERROR (i.e., \a mask is

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -28,82 +28,83 @@
 #include "crt_swim.h"
 
 /* A wrapper around D_TRACE_DEBUG that ensures the ptr option is a RPC */
-#define RPC_TRACE(mask, rpc, fmt, ...)                                                                     \
-	do {                                                                                               \
-		char *_module;                                                                             \
-		char *_opc;                                                                                \
-                                                                                                           \
-		if (!D_LOG_ENABLED(DB_TRACE))                                                              \
-			break;                                                                             \
-                                                                                                           \
-		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                                    \
-		if ((rpc)->crp_coll) {                                                                     \
-			D_TRACE_DEBUG(mask, (rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,              \
-				      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
-				      ##__VA_ARGS__);                                                      \
-		} else {                                                                                   \
-			D_TRACE_DEBUG(mask, (rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,     \
-				      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
-				      (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,           \
-				      ##__VA_ARGS__);                                                      \
-		}                                                                                          \
+#define RPC_TRACE(mask, rpc, fmt, ...)                                                             \
+	do {                                                                                       \
+		char *_module;                                                                     \
+		char *_opc;                                                                        \
+                                                                                                   \
+		if (!D_LOG_ENABLED(DB_TRACE))                                                      \
+			break;                                                                     \
+                                                                                                   \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
+		if ((rpc)->crp_coll) {                                                             \
+			D_TRACE_DEBUG(mask, (rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,      \
+				      (rpc)->crp_pub.cr_opc, _module, _opc,                        \
+				      (rpc)->crp_req_hdr.cch_rpcid, ##__VA_ARGS__);                \
+		} else {                                                                           \
+			D_TRACE_DEBUG(mask, (rpc),                                                 \
+				      "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,          \
+				      (rpc)->crp_pub.cr_opc, _module, _opc,                        \
+				      (rpc)->crp_req_hdr.cch_rpcid, (rpc)->crp_pub.cr_ep.ep_rank,  \
+				      (rpc)->crp_pub.cr_ep.ep_tag, ##__VA_ARGS__);                 \
+		}                                                                                  \
 	} while (0)
 
 /* Log an error with an RPC descriptor */
-#define RPC_ERROR(rpc, fmt, ...)                                                                           \
-	do {                                                                                               \
-		char *_module;                                                                             \
-		char *_opc;                                                                                \
-                                                                                                           \
-		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                                    \
-		if ((rpc)->crp_coll) {                                                                     \
-			D_TRACE_ERROR((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,                    \
-				      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
-				      ##__VA_ARGS__);                                                      \
-		} else {                                                                                   \
-			D_TRACE_ERROR((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,           \
-				      (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,  \
-				      (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,           \
-				      ##__VA_ARGS__);                                                      \
-		}                                                                                          \
+#define RPC_ERROR(rpc, fmt, ...)                                                                   \
+	do {                                                                                       \
+		char *_module;                                                                     \
+		char *_opc;                                                                        \
+                                                                                                   \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
+		if ((rpc)->crp_coll) {                                                             \
+			D_TRACE_ERROR((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,            \
+				      (rpc)->crp_pub.cr_opc, _module, _opc,                        \
+				      (rpc)->crp_req_hdr.cch_rpcid, ##__VA_ARGS__);                \
+		} else {                                                                           \
+			D_TRACE_ERROR((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,   \
+				      (rpc)->crp_pub.cr_opc, _module, _opc,                        \
+				      (rpc)->crp_req_hdr.cch_rpcid, (rpc)->crp_pub.cr_ep.ep_rank,  \
+				      (rpc)->crp_pub.cr_ep.ep_tag, ##__VA_ARGS__);                 \
+		}                                                                                  \
 	} while (0)
 
 /* Log a warning with an RPC descriptor */
-#define RPC_WARN(rpc, fmt, ...)                                                                            \
-	do {                                                                                               \
-		char *_module;                                                                             \
-		char *_opc;                                                                                \
-                                                                                                           \
-		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                                    \
-		if ((rpc)->crp_coll) {                                                                     \
-			D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,                     \
-				     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
-				     ##__VA_ARGS__);                                                       \
-		} else {                                                                                   \
-			D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
-				     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
-				     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
-				     ##__VA_ARGS__);                                                       \
-		}                                                                                          \
+#define RPC_WARN(rpc, fmt, ...)                                                                    \
+	do {                                                                                       \
+		char *_module;                                                                     \
+		char *_opc;                                                                        \
+                                                                                                   \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
+		if ((rpc)->crp_coll) {                                                             \
+			D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,             \
+				     (rpc)->crp_pub.cr_opc, _module, _opc,                         \
+				     (rpc)->crp_req_hdr.cch_rpcid, ##__VA_ARGS__);                 \
+		} else {                                                                           \
+			D_TRACE_WARN((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,    \
+				     (rpc)->crp_pub.cr_opc, _module, _opc,                         \
+				     (rpc)->crp_req_hdr.cch_rpcid, (rpc)->crp_pub.cr_ep.ep_rank,   \
+				     (rpc)->crp_pub.cr_ep.ep_tag, ##__VA_ARGS__);                  \
+		}                                                                                  \
 	} while (0)
 
 /* Log an info message with an RPC descriptor */
-#define RPC_INFO(rpc, fmt, ...)                                                                            \
-	do {                                                                                               \
-		char *_module;                                                                             \
-		char *_opc;                                                                                \
-                                                                                                           \
-		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                                    \
-		if ((rpc)->crp_coll) {                                                                     \
-			D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,                     \
-				     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
-				     ##__VA_ARGS__);                                                       \
-		} else {                                                                                   \
-			D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,            \
-				     (rpc)->crp_pub.cr_opc, _module, _opc, (rpc)->crp_req_hdr.cch_rpcid,   \
-				     (rpc)->crp_pub.cr_ep.ep_rank, (rpc)->crp_pub.cr_ep.ep_tag,            \
-				     ##__VA_ARGS__);                                                       \
-		}                                                                                          \
+#define RPC_INFO(rpc, fmt, ...)                                                                    \
+	do {                                                                                       \
+		char *_module;                                                                     \
+		char *_opc;                                                                        \
+                                                                                                   \
+		crt_opc_decode((rpc)->crp_pub.cr_opc, &_module, &_opc);                            \
+		if ((rpc)->crp_coll) {                                                             \
+			D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx CORPC] " fmt,             \
+				     (rpc)->crp_pub.cr_opc, _module, _opc,                         \
+				     (rpc)->crp_req_hdr.cch_rpcid, ##__VA_ARGS__);                 \
+		} else {                                                                           \
+			D_TRACE_INFO((rpc), "[opc=%#x (%s:%s) rpcid=%#lx rank:tag=%d:%d] " fmt,    \
+				     (rpc)->crp_pub.cr_opc, _module, _opc,                         \
+				     (rpc)->crp_req_hdr.cch_rpcid, (rpc)->crp_pub.cr_ep.ep_rank,   \
+				     (rpc)->crp_pub.cr_ep.ep_tag, ##__VA_ARGS__);                  \
+		}                                                                                  \
 	} while (0)
 /**
  * If \a cond is false, this is equivalent to an RPC_ERROR (i.e., \a mask is


### PR DESCRIPTION
- CORPC don't have ep_target set, making their prints confusing during timeouts

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
