### PR TITLE
DAOS-16768 pool: larger ABT ULT stack sizes

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1792,8 +1792,9 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 		DP_UUID(pool_uuid), DP_UUID(cont_uuid), DP_UUID(cont_hdl_uuid));
 
 retry:
-	rc = ds_pool_thread_collective(pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
-				       PO_COMP_ST_DOWNOUT, cont_open_one, &arg, 0);
+	rc = ds_pool_thread_collective(pool_uuid,
+				       PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
+				       cont_open_one, &arg, DSS_ULT_DEEP_STACK);
 	if (rc != 0) {
 		if (rc == -DER_AGAIN) {
 			dss_sleep(50);
@@ -2105,9 +2106,9 @@ ds_cont_tgt_snapshots_update(uuid_t pool_uuid, uuid_t cont_uuid,
 	 * the up targets in this scenario. The target property will be updated
 	 * upon initiating container aggregation.
 	 */
-	return ds_pool_thread_collective(pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN |
-					 PO_COMP_ST_DOWNOUT | PO_COMP_ST_UP,
-					 cont_snap_update_one, &args, 0);
+	return ds_pool_thread_collective(
+	    pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT | PO_COMP_ST_UP,
+	    cont_snap_update_one, &args, DSS_ULT_DEEP_STACK);
 }
 
 void

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2256,8 +2256,9 @@ ds_pool_tgt_prop_update(struct ds_pool *pool, struct pool_iv_prop *iv_prop)
 		arg.uvp_checkpoint_props_changed = 1;
 	}
 
-	ret = ds_pool_thread_collective(pool->sp_uuid, PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT |
-					PO_COMP_ST_NEW, update_vos_prop_on_targets, &arg, 0);
+	ret = ds_pool_thread_collective(pool->sp_uuid,
+					PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT | PO_COMP_ST_NEW,
+					update_vos_prop_on_targets, &arg, DSS_ULT_DEEP_STACK);
 	if (ret != 0)
 		return ret;
 


### PR DESCRIPTION
With this change, three ULTs in pool and container code launched via ds_pool_thread_collective() are changed to specify a larger ("deep") stack size of 64KiB rather than a default 16KiB stack size. i.e., the flags parameter specified as DSS_ULT_DEEP_STACK. The three ULT function entrypoints are:
cont_open_one, cont_snap_update_one,and update_vos_prop_on_targets.

Before this change, intermittently in CI testing, shortly after daos_engine startup, a dmg pool list (pool query on the back end) would occasionally result in a segmentation fault in an engine, in these three particular areas of the code. Specifically, the faults occurred within the ABT thread create, inside ABTI_mem_pool_alloc().

This change is based on a guess that the stack size parameter may have some effect.

Features: pool container test_engine_restart

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
