### PR TITLE
DAOS-16978 vos: fix issue in VOS pool recreation on faulty device rep…

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -544,8 +544,8 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz,
 				rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st,
 						      blob_sz, scm_sz, flags & BIO_MC_FL_RECREATE);
 		} else {
-			rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st, blob_sz,
-					      0, flags & BIO_MC_FL_RECREATE);
+			rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st, blob_sz, 0,
+					      flags & BIO_MC_FL_RECREATE);
 		}
 
 		if (rc != 0) {

--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -539,13 +539,13 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz,
 		if (bio_nvme_configured(SMD_DEV_TYPE_META)) {
 			if (flags & BIO_MC_FL_RDB)
 				rc = smd_rdb_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st,
-						     blob_sz);
+						     blob_sz, flags & BIO_MC_FL_RECREATE);
 			else
 				rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st,
-						      blob_sz, scm_sz);
+						      blob_sz, scm_sz, flags & BIO_MC_FL_RECREATE);
 		} else {
 			rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st, blob_sz,
-					      0);
+					      0, flags & BIO_MC_FL_RECREATE);
 		}
 
 		if (rc != 0) {

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -60,7 +60,7 @@ smd_pool_find_tgt(struct smd_pool *pool, int tgt_id)
 
 static int
 pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name, uint64_t blob_sz,
-			bool recreate)
+	     bool recreate)
 {
 	struct smd_pool	pool;
 	struct d_uuid	id;
@@ -96,7 +96,7 @@ pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name
 		pool.sp_blobs[pool.sp_tgt_cnt] = blob_id;
 		pool.sp_tgt_cnt += 1;
 		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX) &&
-			!recreate)
+		    !recreate)
 			pool.sp_flags |= SMD_POOL_IN_CREATION;
 
 	} else if (rc == -DER_NONEXIST) {
@@ -106,7 +106,7 @@ pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name
 		pool.sp_blob_sz  = blob_sz;
 		pool.sp_flags = 0;
 		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX) &&
-			!recreate)
+		    !recreate)
 			pool.sp_flags |= SMD_POOL_IN_CREATION;
 
 	} else {
@@ -124,9 +124,8 @@ pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name
 }
 
 int
-smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		 enum smd_dev_type st, uint64_t blob_sz, uint64_t scm_sz,
-		 bool recreate)
+smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, enum smd_dev_type st,
+		 uint64_t blob_sz, uint64_t scm_sz, bool recreate)
 {
 	struct smd_pool_meta	meta = { 0 };
 	struct d_uuid		id;
@@ -134,8 +133,7 @@ smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
 
 	smd_db_lock();
 
-	rc = pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_POOLS[st], blob_sz,
-			recreate);
+	rc = pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_POOLS[st], blob_sz, recreate);
 	if (rc || scm_sz == 0) {
 		smd_db_unlock();
 		return rc;
@@ -167,14 +165,13 @@ smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
 }
 
 int
-smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		enum smd_dev_type st, uint64_t blob_sz, bool recreate)
+smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, enum smd_dev_type st,
+		uint64_t blob_sz, bool recreate)
 {
 	int	rc;
 
 	smd_db_lock();
-	rc = pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_RDBS[st], blob_sz,
-			recreate);
+	rc = pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_RDBS[st], blob_sz, recreate);
 	smd_db_unlock();
 
 	return rc;

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -59,7 +59,8 @@ smd_pool_find_tgt(struct smd_pool *pool, int tgt_id)
 }
 
 static int
-pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name, uint64_t blob_sz)
+pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name, uint64_t blob_sz,
+			bool recreate)
 {
 	struct smd_pool	pool;
 	struct d_uuid	id;
@@ -94,7 +95,8 @@ pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name
 		pool.sp_tgts[pool.sp_tgt_cnt] = tgt_id;
 		pool.sp_blobs[pool.sp_tgt_cnt] = blob_id;
 		pool.sp_tgt_cnt += 1;
-		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX))
+		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX) &&
+			!recreate)
 			pool.sp_flags |= SMD_POOL_IN_CREATION;
 
 	} else if (rc == -DER_NONEXIST) {
@@ -103,7 +105,8 @@ pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name
 		pool.sp_tgt_cnt	 = 1;
 		pool.sp_blob_sz  = blob_sz;
 		pool.sp_flags = 0;
-		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX))
+		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX) &&
+			!recreate)
 			pool.sp_flags |= SMD_POOL_IN_CREATION;
 
 	} else {
@@ -122,7 +125,8 @@ pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name
 
 int
 smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		 enum smd_dev_type st, uint64_t blob_sz, uint64_t scm_sz)
+		 enum smd_dev_type st, uint64_t blob_sz, uint64_t scm_sz,
+		 bool recreate)
 {
 	struct smd_pool_meta	meta = { 0 };
 	struct d_uuid		id;
@@ -130,7 +134,8 @@ smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
 
 	smd_db_lock();
 
-	rc = pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_POOLS[st], blob_sz);
+	rc = pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_POOLS[st], blob_sz,
+			recreate);
 	if (rc || scm_sz == 0) {
 		smd_db_unlock();
 		return rc;
@@ -163,12 +168,13 @@ smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
 
 int
 smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		enum smd_dev_type st, uint64_t blob_sz)
+		enum smd_dev_type st, uint64_t blob_sz, bool recreate)
 {
 	int	rc;
 
 	smd_db_lock();
-	rc = pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_RDBS[st], blob_sz);
+	rc = pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_RDBS[st], blob_sz,
+			recreate);
 	smd_db_unlock();
 
 	return rc;

--- a/src/bio/smd/tests/smd_ut.c
+++ b/src/bio/smd/tests/smd_ut.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -363,32 +363,32 @@ ut_pool(void **state)
 
 	for (i = 0; i < 6; i++) {
 		st = (i < 4) ? SMD_DEV_TYPE_DATA : SMD_DEV_TYPE_DATA + i - 3;
-		rc = smd_pool_add_tgt(id1, i, i << 10, st, 100, 0);
+		rc = smd_pool_add_tgt(id1, i, i << 10, st, 100, 0, false);
 		assert_rc_equal(rc, 0);
 
 		if (st == SMD_DEV_TYPE_META)
-			rc = smd_pool_add_tgt(id2, i, i << 20, st, 200, 50);
+			rc = smd_pool_add_tgt(id2, i, i << 20, st, 200, 50, false);
 		else
-			rc = smd_pool_add_tgt(id2, i, i << 20, st, 200, 0);
+			rc = smd_pool_add_tgt(id2, i, i << 20, st, 200, 0, false);
 		assert_rc_equal(rc, 0);
 	}
 
-	rc = smd_pool_add_tgt(id1, 0, 5000, SMD_DEV_TYPE_DATA, 100, 0);
+	rc = smd_pool_add_tgt(id1, 0, 5000, SMD_DEV_TYPE_DATA, 100, 0, false);
 	assert_rc_equal(rc, -DER_EXIST);
 
-	rc = smd_pool_add_tgt(id1, 4, 4 << 10, SMD_DEV_TYPE_DATA, 200, 0);
+	rc = smd_pool_add_tgt(id1, 4, 4 << 10, SMD_DEV_TYPE_DATA, 200, 0, false);
 	assert_rc_equal(rc, -DER_INVAL);
 
-	rc = smd_pool_add_tgt(id1, 4, 5000, SMD_DEV_TYPE_META, 100, 0);
+	rc = smd_pool_add_tgt(id1, 4, 5000, SMD_DEV_TYPE_META, 100, 0, false);
 	assert_rc_equal(rc, -DER_EXIST);
 
-	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_META, 200, 0);
+	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_META, 200, 0, false);
 	assert_rc_equal(rc, -DER_INVAL);
 
-	rc = smd_pool_add_tgt(id1, 5, 5000, SMD_DEV_TYPE_WAL, 100, 0);
+	rc = smd_pool_add_tgt(id1, 5, 5000, SMD_DEV_TYPE_WAL, 100, 0, false);
 	assert_rc_equal(rc, -DER_EXIST);
 
-	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_WAL, 200, 0);
+	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_WAL, 200, 0, false);
 	assert_rc_equal(rc, -DER_INVAL);
 
 	rc = smd_pool_get_info(id1, &pool_info);

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -1009,8 +1009,8 @@ int bio_copy(struct bio_io_context *ioctxt, struct umem_instance *umem,
 	     struct bio_csum_desc *csum_desc);
 
 enum bio_mc_flags {
-	BIO_MC_FL_RDB		= (1UL << 0),	/* for RDB */
-	BIO_MC_FL_RECREATE		= (1UL << 1),	/* to identify recreate (e.g., in replace op) */
+	BIO_MC_FL_RDB      = (1UL << 0), /* for RDB */
+	BIO_MC_FL_RECREATE = (1UL << 1), /* to identify recreate (e.g., in replace op) */
 };
 
 /*

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1010,6 +1010,7 @@ int bio_copy(struct bio_io_context *ioctxt, struct umem_instance *umem,
 
 enum bio_mc_flags {
 	BIO_MC_FL_RDB		= (1UL << 0),	/* for RDB */
+	BIO_MC_FL_RECREATE		= (1UL << 1),	/* to identify recreate (e.g., in replace op) */
 };
 
 /*

--- a/src/include/daos_srv/smd.h
+++ b/src/include/daos_srv/smd.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -172,15 +172,17 @@ int smd_dev_replace(uuid_t old_id, uuid_t new_id, unsigned int old_roles);
  * \param [IN]	smd_type	SMD type
  * \param [IN]	blob_sz		Blob size in bytes
  * \param [IN]	scm_sz		VOS file size in bytes
+  * \param [IN]	recreate    is recreate (in replace) or not
  *
  * \return			Zero on success, negative value on error
  */
 int smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		     enum smd_dev_type smd_type, uint64_t blob_sz, uint64_t scm_sz);
+		     enum smd_dev_type smd_type, uint64_t blob_sz, uint64_t scm_sz,
+			 bool recreate);
 
 /* Assign a blob to a RDB pool target */
 int smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		    enum smd_dev_type smd_type, uint64_t blob_sz);
+		    enum smd_dev_type smd_type, uint64_t blob_sz, bool recreate);
 
 /**
  * Unassign a VOS pool target

--- a/src/include/daos_srv/smd.h
+++ b/src/include/daos_srv/smd.h
@@ -172,17 +172,18 @@ int smd_dev_replace(uuid_t old_id, uuid_t new_id, unsigned int old_roles);
  * \param [IN]	smd_type	SMD type
  * \param [IN]	blob_sz		Blob size in bytes
  * \param [IN]	scm_sz		VOS file size in bytes
-  * \param [IN]	recreate    is recreate (in replace) or not
+ * \param [IN]  recreate    is recreate (in replace) or not
  *
  * \return			Zero on success, negative value on error
  */
-int smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		     enum smd_dev_type smd_type, uint64_t blob_sz, uint64_t scm_sz,
-			 bool recreate);
+int
+smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, enum smd_dev_type smd_type,
+		 uint64_t blob_sz, uint64_t scm_sz, bool recreate);
 
 /* Assign a blob to a RDB pool target */
-int smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		    enum smd_dev_type smd_type, uint64_t blob_sz, bool recreate);
+int
+      smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, enum smd_dev_type smd_type,
+		      uint64_t blob_sz, bool recreate);
 
 /**
  * Unassign a VOS pool target

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2015-2025 Intel Corporation.
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -97,6 +97,8 @@ enum vos_pool_open_flags {
 	VOS_POF_FOR_CHECK_QUERY = (1 << 6),
 	/** Open the pool for feature fetch/update, that will skip VEA load */
 	VOS_POF_FOR_FEATURE_FLAG = (1 << 7),
+	/** To identify this is a recreate operation. */
+	VOS_POF_FOR_RECREATE = (1 << 8),
 };
 
 enum vos_oi_attr {

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2016-2025 Intel Corporation.
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -460,7 +460,7 @@ pool_child_recreate(struct ds_pool_child *child)
 	rc = vos_pool_create(path, child->spc_uuid, 0 /* scm_sz */,
 			     pool_info->spi_blob_sz[SMD_DEV_TYPE_DATA],
 			     pool_info->spi_blob_sz[SMD_DEV_TYPE_META],
-			     0 /* flags */, vos_df_version, NULL);
+			     VOS_POF_FOR_RECREATE/* flags */, vos_df_version, NULL);
 	if (rc)
 		DL_ERROR(rc, DF_UUID": Create VOS pool failed.", DP_UUID(child->spc_uuid));
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -460,7 +460,7 @@ pool_child_recreate(struct ds_pool_child *child)
 	rc = vos_pool_create(path, child->spc_uuid, 0 /* scm_sz */,
 			     pool_info->spi_blob_sz[SMD_DEV_TYPE_DATA],
 			     pool_info->spi_blob_sz[SMD_DEV_TYPE_META],
-			     VOS_POF_FOR_RECREATE/* flags */, vos_df_version, NULL);
+			     VOS_POF_FOR_RECREATE /* flags */, vos_df_version, NULL);
 	if (rc)
 		DL_ERROR(rc, DF_UUID": Create VOS pool failed.", DP_UUID(child->spc_uuid));
 

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1,5 +1,6 @@
 /**
- * (C) Copyright 2022-2025 Intel Corporation.
+ * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2022-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1775,7 +1775,7 @@ sync_cb(struct ddbs_sync_info *info, void *cb_args)
 		D_WARN("delete target failed: " DF_RC "\n", DP_RC(rc));
 
 	rc = smd_pool_add_tgt(pool_id, info->dsi_hdr->bbh_vos_id,
-			      info->dsi_hdr->bbh_blob_id, st, blob_size, 0);
+			      info->dsi_hdr->bbh_blob_id, st, blob_size, 0, false);
 	if (!SUCCESS(rc)) {
 		D_ERROR("add target failed: "DF_RC"\n", DP_RC(rc));
 		args->sync_rc = rc;

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2022-2025 Intel Corporation.
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1781,8 +1781,8 @@ sync_cb(struct ddbs_sync_info *info, void *cb_args)
 		/* Ignore error for now ... might not exist*/
 		D_WARN("delete target failed: " DF_RC "\n", DP_RC(rc));
 
-	rc = smd_pool_add_tgt(pool_id, info->dsi_hdr->bbh_vos_id,
-			      info->dsi_hdr->bbh_blob_id, st, blob_size, 0, false);
+	rc = smd_pool_add_tgt(pool_id, info->dsi_hdr->bbh_vos_id, info->dsi_hdr->bbh_blob_id, st,
+			      blob_size, 0, false);
 	if (!SUCCESS(rc)) {
 		D_ERROR("add target failed: "DF_RC"\n", DP_RC(rc));
 		args->sync_rc = rc;

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2016-2025 Intel Corporation.
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -794,6 +794,9 @@ vos2mc_flags(unsigned int vos_flags)
 
 	if (vos_flags & VOS_POF_RDB)
 		mc_flags |= BIO_MC_FL_RDB;
+
+	if (vos_flags & VOS_POF_FOR_RECREATE)
+		mc_flags |= BIO_MC_FL_RECREATE;
 
 	return mc_flags;
 }


### PR DESCRIPTION
…lacing

Add a flag to identify the recreate operation in vos pool creation, and pass it to bio/smd module to avoid setting the SMD_POOL_IN_CREATION flag for recreation case in nvme disk replacing operation.

Run-GHA: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
