### PR TITLE
DAOS-16969 test: Reduce cleanup operations for metadata.py test (#15779)

### DIFF
--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -1,11 +1,13 @@
 hosts:
   test_servers: 4
   test_clients: 1
+
 timeouts:
   test_metadata_fillup_svc_ops_disabled: 400
   test_metadata_fillup_svc_ops_enabled: 400
   test_metadata_addremove: 1300
   test_metadata_server_restart: 500
+
 server_config:
   name: daos_server
   engines_per_host: 2
@@ -53,9 +55,12 @@ pool:
 #  properties: svc_ops_entry_age:150
 #  properties: svc_ops_entry_age:300
 #  properties: svc_ops_entry_age:600
+
 container:
   control_method: API
   silent: true
+  register_cleanup: False
+
 ior:
   clientslots:
     slots: 1
@@ -63,6 +68,7 @@ ior:
   iorwriteflags: "-w -W -k -G 1"
   iorreadflags: "-r -R -G 1"
   dfs_oclass: "SX"
+
 metadata:
   mean_percent: 1
   num_addremove_loops: 4

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2018-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -478,7 +479,7 @@ class ExecutableCommand(CommandWithParameters):
         super().get_params(test)
         for namespace in ['/run/client/*', self.namespace]:
             if namespace is not None:
-                self.env.update_from_list(test.params.get("env_vars", namespace, []))
+                self.env.update_from_list(test.params.get("env_vars", namespace, None) or [])
 
     def _get_new(self):
         """Get a new object based upon this one.


### PR DESCRIPTION
Remove the calling of cleanup methods for multiple containers and ior commands that can be handled by destroying the pool and a single ior kill command.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-large-md-on-ssd: false
Test-tag: ObjectMetadata

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
