### PR TITLE
DAOS-16940 common: Update pool map levels

### DIFF
--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -21,7 +21,7 @@
 #include <daos/pool_map.h>
 
 D_CASSERT((int)DAOS_PROP_PERF_DOMAIN_ROOT == (int)PO_COMP_TP_ROOT);
-D_CASSERT((int)DAOS_PROP_PERF_DOMAIN_GROUP == (int)PO_COMP_TP_GRP);
+D_CASSERT((int)DAOS_PROP_PERF_DOMAIN_GROUP == (int)PO_COMP_TP_PERF);
 
 daos_prop_t *
 daos_prop_alloc(uint32_t entries_nr)
@@ -326,8 +326,7 @@ daos_prop_valid(daos_prop_t *prop, bool pool, bool input)
 		case DAOS_PROP_PO_PERF_DOMAIN:
 		case DAOS_PROP_CO_PERF_DOMAIN:
 			val = prop->dpp_entries[i].dpe_val;
-			if (val != PO_COMP_TP_ROOT &&
-			    val != PO_COMP_TP_GRP) {
+			if (val != PO_COMP_TP_ROOT && val != PO_COMP_TP_PERF) {
 				D_ERROR("invalid perf domain "DF_U64".\n", val);
 				return false;
 			}

--- a/src/common/tests/fault_domain_tests.c
+++ b/src/common/tests/fault_domain_tests.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2021-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -17,38 +18,46 @@
 #include <daos/tests_lib.h>
 #include "../fault_domain.h"
 
-#define DOM_LEN	(sizeof(struct d_fault_domain) / sizeof(uint32_t))
+#define MD_LEN                  1 /* length of metadata */
+#define DOM_LEN                 (sizeof(struct d_fault_domain) / sizeof(uint32_t))
+#define MIN_LEN                 (DOM_LEN + MD_LEN)
+#define START_IDX               MD_LEN /* start looking for domains after the metadata */
 
-static uint32_t	test_compressed[] = {3, 0, 2, /* root */
-				     2, 1, 2, /* first layer */
-				     2, 2, 1,
-				     1, 4, 1, /* second layer */
-				     1, 5, 2,
-				     1, 6, 1,
+/* clang-format off */
+static uint32_t test_compressed[] = {D_FD_TREE_HAS_PERF_DOMAIN, /* metadata */
+				     3, 1, 2, /* root */
+				     2, 2, 2, /* perf dom */
+				     2, 3, 1, /* perf dom */
+				     1, 4, 1, /* node */
+				     1, 5, 2, /* node */
+				     1, 6, 1, /* node */
 				     /* ranks */
 				     0, 1, 2, 3};
+/* clang-format on */
 
 #define TEST_NUM_DOMAINS	(6)
+#define TEST_NUM_NODES          (3)
+#define TEST_NUM_PERF           (TEST_NUM_DOMAINS - 1 - TEST_NUM_NODES)
 #define TEST_NUM_RANKS		(4)
 
 static void
 test_fd_tree_init(void **state)
 {
-	uint32_t		comp[DOM_LEN] = {1, 0, 0};
+	uint32_t                comp[MIN_LEN] = {0, 1, 1, 0};
 	struct d_fd_tree	tree = {0};
 	uint32_t		i;
 
 	/* bad inputs */
-	assert_rc_equal(d_fd_tree_init(&tree, NULL, DOM_LEN), -DER_INVAL);
+	assert_rc_equal(d_fd_tree_init(&tree, NULL, MIN_LEN), -DER_INVAL);
 
-	assert_rc_equal(d_fd_tree_init(NULL, comp, DOM_LEN), -DER_INVAL);
+	assert_rc_equal(d_fd_tree_init(NULL, comp, MIN_LEN), -DER_INVAL);
 
-	for (i = 0; i < DOM_LEN; i++) {
+	for (i = 0; i < MIN_LEN; i++) {
 		assert_rc_equal(d_fd_tree_init(&tree, comp, i), -DER_INVAL);
 	}
 
 	/* success */
-	assert_rc_equal(d_fd_tree_init(&tree, comp, DOM_LEN), 0);
+	assert_rc_equal(d_fd_tree_init(&tree, comp, MIN_LEN), 0);
 }
 
 static void
@@ -73,17 +82,19 @@ test_fd_tree_next_bad_input(void **state)
 }
 
 static void
-expect_domains(struct d_fd_tree *tree, size_t num_domains, size_t *next_idx)
+expect_domains(struct d_fd_tree *tree, enum d_fd_node_type node_type, size_t num_domains,
+	       size_t *next_idx)
 {
 	struct d_fd_node	next = {0};
 	size_t			i;
 	size_t			exp_idx = *next_idx;
 
 	for (i = 0; i < num_domains; i++) {
-		print_message("Checking domain %lu\n", i);
+		print_message("Checking domain %lu, node type=%s (%d)\n", i,
+			      d_fd_get_node_type_str(node_type), node_type);
 
 		assert_rc_equal(d_fd_tree_next(tree, &next), 0);
-		assert_int_equal(next.fdn_type, D_FD_NODE_TYPE_DOMAIN);
+		assert_int_equal(next.fdn_type, node_type);
 		assert_non_null(next.fdn_val.dom);
 		assert_int_equal(next.fdn_val.dom->fd_level,
 				 tree->fdt_compressed[exp_idx++]);
@@ -94,6 +105,24 @@ expect_domains(struct d_fd_tree *tree, size_t num_domains, size_t *next_idx)
 	}
 
 	*next_idx = exp_idx;
+}
+
+static void
+expect_root(struct d_fd_tree *tree, size_t *next_idx)
+{
+	expect_domains(tree, D_FD_NODE_TYPE_ROOT, 1, next_idx);
+}
+
+static void
+expect_perf_doms(struct d_fd_tree *tree, size_t num_domains, size_t *next_idx)
+{
+	expect_domains(tree, D_FD_NODE_TYPE_PERF_DOM, num_domains, next_idx);
+}
+
+static void
+expect_nodes(struct d_fd_tree *tree, size_t num_domains, size_t *next_idx)
+{
+	expect_domains(tree, D_FD_NODE_TYPE_NODE, num_domains, next_idx);
 }
 
 static void
@@ -120,13 +149,15 @@ test_fd_tree_next(void **state)
 {
 	struct d_fd_tree	tree = {0};
 	struct d_fd_node	next = {0};
-	size_t			exp_idx = 0;
+	size_t                  idx  = START_IDX;
 
 	assert_rc_equal(d_fd_tree_init(&tree, test_compressed,
 				       ARRAY_SIZE(test_compressed)), 0);
 
-	expect_domains(&tree, TEST_NUM_DOMAINS, &exp_idx);
-	expect_ranks(&tree, TEST_NUM_RANKS, &exp_idx);
+	expect_root(&tree, &idx);
+	expect_perf_doms(&tree, TEST_NUM_PERF, &idx);
+	expect_nodes(&tree, TEST_NUM_NODES, &idx);
+	expect_ranks(&tree, TEST_NUM_RANKS, &idx);
 
 	assert_rc_equal(d_fd_tree_next(&tree, &next), -DER_NONEXIST);
 }
@@ -137,11 +168,13 @@ test_fd_tree_next_trunc_ranks(void **state)
 	struct d_fd_tree	tree = {0};
 	struct d_fd_node	next = {0};
 	size_t			len;
-	size_t			idx = 0;
+	size_t                  idx = START_IDX;
 
 	len = ARRAY_SIZE(test_compressed) - TEST_NUM_RANKS + 1;
 	assert_rc_equal(d_fd_tree_init(&tree, test_compressed, len), 0);
-	expect_domains(&tree, TEST_NUM_DOMAINS, &idx);
+	expect_root(&tree, &idx);
+	expect_perf_doms(&tree, TEST_NUM_PERF, &idx);
+	expect_nodes(&tree, TEST_NUM_NODES, &idx);
 	expect_ranks(&tree, 1, &idx);
 
 	assert_rc_equal(d_fd_tree_next(&tree, &next), -DER_TRUNC);
@@ -153,12 +186,14 @@ test_fd_tree_next_trunc_domains(void **state)
 	struct d_fd_tree	tree = {0};
 	struct d_fd_node	next = {0};
 	size_t			len;
-	size_t			idx = 0;
+	size_t                  idx = START_IDX;
 
 	len = ARRAY_SIZE(test_compressed) - TEST_NUM_RANKS -
 	      (sizeof(struct d_fault_domain) / sizeof(uint32_t));
 	assert_rc_equal(d_fd_tree_init(&tree, test_compressed, len), 0);
-	expect_domains(&tree, TEST_NUM_DOMAINS - 1, &idx);
+	expect_root(&tree, &idx);
+	expect_perf_doms(&tree, TEST_NUM_PERF, &idx);
+	expect_nodes(&tree, TEST_NUM_NODES - 1, &idx);
 
 	assert_rc_equal(d_fd_tree_next(&tree, &next), -DER_TRUNC);
 }
@@ -169,11 +204,13 @@ test_fd_tree_next_trunc_domain_in_tuple(void **state)
 	struct d_fd_tree	tree = {0};
 	struct d_fd_node	next = {0};
 	size_t			len;
-	size_t			idx = 0;
+	size_t                  idx = START_IDX;
 
 	len = ARRAY_SIZE(test_compressed) - TEST_NUM_RANKS - 1;
 	assert_rc_equal(d_fd_tree_init(&tree, test_compressed, len), 0);
-	expect_domains(&tree, TEST_NUM_DOMAINS - 1, &idx);
+	expect_root(&tree, &idx);
+	expect_perf_doms(&tree, TEST_NUM_PERF, &idx);
+	expect_nodes(&tree, TEST_NUM_NODES - 1, &idx);
 
 	assert_rc_equal(d_fd_tree_next(&tree, &next), -DER_TRUNC);
 }
@@ -183,15 +220,17 @@ test_fd_tree_next_len_bigger_than_tree(void **state)
 {
 	struct d_fd_tree	tree = {0};
 	struct d_fd_node	next = {0};
-	size_t			exp_idx = 0;
+	size_t                  idx  = START_IDX;
 	size_t			len;
 
 	/* We can only detect this condition if the tree is well-formed */
 	len = ARRAY_SIZE(test_compressed) + 25;
 	assert_rc_equal(d_fd_tree_init(&tree, test_compressed, len), 0);
 
-	expect_domains(&tree, TEST_NUM_DOMAINS, &exp_idx);
-	expect_ranks(&tree, TEST_NUM_RANKS, &exp_idx);
+	expect_root(&tree, &idx);
+	expect_perf_doms(&tree, TEST_NUM_PERF, &idx);
+	expect_nodes(&tree, TEST_NUM_NODES, &idx);
+	expect_ranks(&tree, TEST_NUM_RANKS, &idx);
 
 	assert_rc_equal(d_fd_tree_next(&tree, &next), -DER_NONEXIST);
 }
@@ -200,7 +239,7 @@ static void
 test_fd_tree_reset(void **state)
 {
 	struct d_fd_tree	tree = {0};
-	size_t			idx = 0;
+	size_t                  idx  = START_IDX;
 
 	/* Bad input */
 	assert_rc_equal(d_fd_tree_reset(NULL), -DER_INVAL);
@@ -210,14 +249,18 @@ test_fd_tree_reset(void **state)
 	assert_rc_equal(d_fd_tree_init(&tree, test_compressed,
 				       ARRAY_SIZE(test_compressed)), 0);
 
-	expect_domains(&tree, TEST_NUM_DOMAINS, &idx);
+	expect_root(&tree, &idx);
+	expect_perf_doms(&tree, TEST_NUM_PERF, &idx);
+	expect_nodes(&tree, TEST_NUM_NODES, &idx);
 	expect_ranks(&tree, TEST_NUM_RANKS, &idx);
 
 	assert_rc_equal(d_fd_tree_reset(&tree), 0);
 
 	/* after reset, should be able to go through whole tree again */
-	idx = 0;
-	expect_domains(&tree, TEST_NUM_DOMAINS, &idx);
+	idx = START_IDX;
+	expect_root(&tree, &idx);
+	expect_perf_doms(&tree, TEST_NUM_PERF, &idx);
+	expect_nodes(&tree, TEST_NUM_NODES, &idx);
 	expect_ranks(&tree, TEST_NUM_RANKS, &idx);
 }
 
@@ -227,81 +270,42 @@ test_fd_get_exp_num_domains(void **state)
 	uint32_t result = 0;
 
 	/* array too short for even a root node */
-	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN - 1, 0, &result),
-			-DER_INVAL);
+	assert_rc_equal(d_fd_get_exp_num_domains(MIN_LEN - 1, 0, &result), -DER_INVAL);
 
 	/* not enough room in array for ranks */
-	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN, 1, &result),
-			-DER_INVAL);
+	assert_rc_equal(d_fd_get_exp_num_domains(MIN_LEN, 1, &result), -DER_INVAL);
 
-	/* remaining array isn't a multiple of the domain tuple length */
-	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN * 2 + 1, 0, &result),
-			-DER_INVAL);
-	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN * 2 + 1, 2, &result),
-			-DER_INVAL);
+	/* remaining array after metadata isn't a multiple of the domain tuple length */
+	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN * 2, 0, &result), -DER_INVAL);
+	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN * 2 + 3, 3, &result), -DER_INVAL);
 
 	/* success */
-	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN, 0, &result), 0);
+	assert_rc_equal(d_fd_get_exp_num_domains(MIN_LEN, 0, &result), 0);
 	assert_int_equal(result, 1);
 
-	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN * 2, 0, &result), 0);
+	assert_rc_equal(d_fd_get_exp_num_domains(MD_LEN + DOM_LEN * 2, 0, &result), 0);
 	assert_int_equal(result, 2);
 
-	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN + 5, 5, &result), 0);
+	assert_rc_equal(d_fd_get_exp_num_domains(MD_LEN + DOM_LEN + 5, 5, &result), 0);
 	assert_int_equal(result, 1);
 
-	assert_rc_equal(d_fd_get_exp_num_domains(DOM_LEN * 4, DOM_LEN, &result),
-			0);
+	assert_rc_equal(d_fd_get_exp_num_domains(MD_LEN + DOM_LEN * 4, DOM_LEN, &result), 0);
 	assert_int_equal(result, 3);
-}
-
-static void
-test_fd_node_is_group(void **state)
-{
-	struct d_fd_node	dom_node = {0};
-	struct d_fd_node	rank_node = {0};
-	struct d_fault_domain	dom = {0};
-
-	/* setup domain node */
-	dom_node.fdn_type = D_FD_NODE_TYPE_DOMAIN;
-	dom_node.fdn_val.dom = &dom;
-
-	/* setup rank node */
-	rank_node.fdn_type = D_FD_NODE_TYPE_RANK;
-
-	/* null input */
-	assert_false(d_fd_node_is_group(NULL));
-
-	/* rank node */
-	assert_false(d_fd_node_is_group(&rank_node));
-
-	/* group level */
-	dom.fd_level = D_FD_GROUP_DOMAIN_LEVEL;
-	assert_true(d_fd_node_is_group(&dom_node));
-
-	/* level higher than group */
-	dom.fd_level = D_FD_GROUP_DOMAIN_LEVEL + 1;
-	assert_false(d_fd_node_is_group(&dom_node));
-
-	/* level lower than group */
-	dom.fd_level = D_FD_GROUP_DOMAIN_LEVEL - 1;
-	assert_false(d_fd_node_is_group(&dom_node));
 }
 
 int
 main(void)
 {
 	const struct CMUnitTest tests[] = {
-		cmocka_unit_test(test_fd_tree_init),
-		cmocka_unit_test(test_fd_tree_next_bad_input),
-		cmocka_unit_test(test_fd_tree_next),
-		cmocka_unit_test(test_fd_tree_next_trunc_ranks),
-		cmocka_unit_test(test_fd_tree_next_trunc_domains),
-		cmocka_unit_test(test_fd_tree_next_trunc_domain_in_tuple),
-		cmocka_unit_test(test_fd_tree_next_len_bigger_than_tree),
-		cmocka_unit_test(test_fd_tree_reset),
-		cmocka_unit_test(test_fd_get_exp_num_domains),
-		cmocka_unit_test(test_fd_node_is_group),
+	    cmocka_unit_test(test_fd_tree_init),
+	    cmocka_unit_test(test_fd_tree_next_bad_input),
+	    cmocka_unit_test(test_fd_tree_next),
+	    cmocka_unit_test(test_fd_tree_next_trunc_ranks),
+	    cmocka_unit_test(test_fd_tree_next_trunc_domains),
+	    cmocka_unit_test(test_fd_tree_next_trunc_domain_in_tuple),
+	    cmocka_unit_test(test_fd_tree_next_len_bigger_than_tree),
+	    cmocka_unit_test(test_fd_tree_reset),
+	    cmocka_unit_test(test_fd_get_exp_num_domains),
 	};
 
 	return cmocka_run_group_tests_name("common_fault_domain",

--- a/src/control/lib/daos/pool_cont_prop.go
+++ b/src/control/lib/daos/pool_cont_prop.go
@@ -258,11 +258,8 @@ const (
 )
 
 const (
-	PoolPerfDomainRoot   = C.PO_COMP_TP_ROOT
-	PoolPerfDomainGrp    = C.PO_COMP_TP_GRP
-	PoolPerfDomainNode   = C.PO_COMP_TP_NODE
-	PoolPerfDomainRank   = C.PO_COMP_TP_RANK
-	PoolPerfDomainTarget = C.PO_COMP_TP_TARGET
+	PoolPerfDomainRoot        = C.PO_COMP_TP_ROOT
+	PoolPerfDomainUserDefined = C.PO_COMP_TP_PERF
 )
 
 const (

--- a/src/control/lib/daos/pool_property.go
+++ b/src/control/lib/daos/pool_property.go
@@ -374,7 +374,7 @@ func PoolProperties() PoolPropertyMap {
 			},
 			values: map[string]uint64{
 				"root":  PoolPerfDomainRoot,
-				"group": PoolPerfDomainGrp,
+				"group": PoolPerfDomainUserDefined,
 			},
 		},
 		"svc_rf": {

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -1356,7 +1356,7 @@ func TestServer_MgmtSvc_PoolExtend(t *testing.T) {
 	missingSB.harness.instances[0].(*EngineInstance)._superblock = nil
 	notAP := newTestMgmtSvc(t, log)
 	mockRanks := []uint32{1}
-	mockFaultDomains := []uint32{1, 1, 1, 1}
+	mockFaultDomains := []uint32{0, 1, 1, 1, 1}
 
 	for name, tc := range map[string]struct {
 		nilReq      bool

--- a/src/control/system/membership_test.go
+++ b/src/control/system/membership_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -1075,6 +1076,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 		"root only": {
 			tree: NewFaultDomainTree(),
 			expResult: []uint32{
+				0, // metadata
 				0,
 				ExpFaultDomainID(0),
 				0,
@@ -1085,6 +1087,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				MustCreateFaultDomain("one", "two", "three"),
 			),
 			expResult: []uint32{
+				DomTreeMetadataHasPerfDom, // metadata
 				3,
 				ExpFaultDomainID(0),
 				1,
@@ -1108,6 +1111,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				MustCreateFaultDomainFromString("/rack2/pdu4"),
 			),
 			expResult: []uint32{
+				0, // metadata
 				2, // root
 				ExpFaultDomainID(0),
 				3,
@@ -1142,6 +1146,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				rankDomain("/one/two/three", 5),
 			),
 			expResult: []uint32{
+				DomTreeMetadataHasPerfDom, // metadata
 				4,
 				ExpFaultDomainID(0),
 				1,
@@ -1167,6 +1172,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				rankDomain("/rack2/pdu4", 5),
 			),
 			expResult: []uint32{
+				DomTreeMetadataHasPerfDom, // metadata
 				3,
 				ExpFaultDomainID(0), // root
 				3,
@@ -1208,6 +1214,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				rankDomain(fmt.Sprintf("/top/%s2/bottom", RankFaultDomainPrefix), 1),
 			),
 			expResult: []uint32{
+				DomTreeMetadataHasPerfDom, // metadata
 				4,
 				ExpFaultDomainID(0), // root
 				1,
@@ -1223,6 +1230,28 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 				1, // rank
 			},
 		},
+		"request one rank with node only": {
+			tree: NewFaultDomainTree(
+				rankDomain("/node0", 0),
+				rankDomain("/node1", 1),
+				rankDomain("/node2", 2),
+				rankDomain("/node3", 3),
+				rankDomain("/node3", 4),
+				rankDomain("/node4", 5),
+			),
+			inputRanks: []uint32{4},
+			expResult: []uint32{
+				0, // metadata
+				2,
+				ExpFaultDomainID(0), // root
+				1,
+				1,
+				ExpFaultDomainID(7), // node3
+				1,
+				// ranks
+				4,
+			},
+		},
 		"request one rank": {
 			tree: NewFaultDomainTree(
 				rankDomain("/rack0/pdu0", 0),
@@ -1234,6 +1263,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 			),
 			inputRanks: []uint32{4},
 			expResult: []uint32{
+				DomTreeMetadataHasPerfDom, // metadata
 				3,
 				ExpFaultDomainID(0), // root
 				1,
@@ -1258,6 +1288,7 @@ func TestSystem_Membership_CompressedFaultDomainTree(t *testing.T) {
 			),
 			inputRanks: []uint32{4, 0, 5, 3},
 			expResult: []uint32{
+				DomTreeMetadataHasPerfDom, // metadata
 				3,
 				ExpFaultDomainID(0), // root
 				3,

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -149,9 +150,9 @@ struct daos_obj_md {
 	uint32_t		omd_fdom_lvl;
 	/* Performance domain affinity */
 	uint32_t		omd_pda;
-	/* Performance domain level - PO_COMP_TP_ROOT or PO_COMP_TP_GRP.
+	/* Performance domain level - PO_COMP_TP_ROOT or PO_COMP_TP_PERF.
 	 * Now will enable the performance domain feature only when omd_pdom_lvl set as
-	 * PO_COMP_TP_GRP and with PO_COMP_TP_GRP layer in pool map.
+	 * PO_COMP_TP_PERF and with PO_COMP_TP_PERF layer in pool map.
 	 */
 	uint32_t		omd_pdom_lvl;
 };

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -30,14 +31,15 @@
  * yaml file.
  */
 typedef enum pool_comp_type {
-	PO_COMP_TP_TARGET	= 0, /** reserved, hard-coded */
-	PO_COMP_TP_RANK		= 1, /** reserved, hard-coded */
-	PO_COMP_TP_MIN		= 2, /** first user-defined domain */
-	PO_COMP_TP_NODE		= 2, /** for test only */
-	PO_COMP_TP_GRP		= 3, /** group, commonly used for performance domain */
-	PO_COMP_TP_MAX		= 254, /** last user-defined domain */
-	PO_COMP_TP_ROOT		= 255,
-	PO_COMP_TP_END		= 256,
+	PO_COMP_TP_TARGET = 0,   /** reserved, hard-coded */
+	PO_COMP_TP_RANK   = 1,   /** reserved, hard-coded */
+	PO_COMP_TP_NODE   = 2,   /** reserved, hard-coded */
+	PO_COMP_TP_MIN    = 3,   /** first user-defined domain */
+	PO_COMP_TP_FAULT  = 3,   /** user-defined fault domain (if not node) */
+	PO_COMP_TP_PERF   = 200, /** user-defined performance domain (optional) */
+	PO_COMP_TP_MAX    = 254, /** last user-defined domain */
+	PO_COMP_TP_ROOT   = 255,
+	PO_COMP_TP_END    = 256,
 } pool_comp_type_t;
 
 /** pool component states */
@@ -256,7 +258,8 @@ void pool_buf_free(struct pool_buf *buf);
 int  pool_buf_extract(struct pool_map *map, struct pool_buf **buf_pp);
 int  pool_buf_attach(struct pool_buf *buf, struct pool_component *comps,
 		     unsigned int comp_nr);
-int gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_version, int ndomains,
+int
+    gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out, int map_version, int ndomains,
 		 int nnodes, int ntargets, const uint32_t *domains, uint32_t dss_tgt_nr);
 
 int pool_map_comp_cnt(struct pool_map *map);

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -190,8 +190,8 @@ daos_svc_rf_is_valid(uint64_t svc_rf)
  * Level of perf_domain, should be same value as PO_COMP_TP_xxx (enum pool_comp_type).
  */
 enum {
-	DAOS_PROP_PERF_DOMAIN_ROOT = 255,
-	DAOS_PROP_PERF_DOMAIN_GROUP = 3,
+	DAOS_PROP_PERF_DOMAIN_ROOT  = 255,
+	DAOS_PROP_PERF_DOMAIN_GROUP = 200,
 };
 
 /**
@@ -479,15 +479,17 @@ enum {
  * rank is hardcoded to 1, [2-254] are defined by the admin
  */
 enum {
-	DAOS_PROP_CO_REDUN_MIN	= 1,
+	DAOS_PROP_CO_REDUN_MIN = 1,
 	/* server rank (engine) level */
-	DAOS_PROP_CO_REDUN_RANK	= 1,
+	DAOS_PROP_CO_REDUN_RANK = 1,
 	/* server node level */
-	DAOS_PROP_CO_REDUN_NODE	= 2,
-	DAOS_PROP_CO_REDUN_MAX	= 254,
+	DAOS_PROP_CO_REDUN_NODE = 2,
+	/* pool fault domain level */
+	DAOS_PROP_CO_REDUN_FAULT = 3,
+	DAOS_PROP_CO_REDUN_MAX   = 254,
 };
 
-/** default fault domain level */
+/** default fault domain level - TODO DAOS-6853: Set default to FAULT */
 #define DAOS_PROP_CO_REDUN_DEFAULT	DAOS_PROP_CO_REDUN_NODE
 
 /** container status flag */

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -1,6 +1,7 @@
 /**
  *
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -64,11 +65,11 @@ jm_obj_pd_init(struct pl_jump_map *jmap, struct daos_obj_md *md, struct pool_dom
 
 	jmop->jmop_root = root;
 	/* Enable the PDA placement only when -
-	 * 1) daos_obj_md::omd_pdom_lvl is PO_COMP_TP_GRP,
+	 * 1) daos_obj_md::omd_pdom_lvl is PO_COMP_TP_PERF,
 	 * 2) daos_obj_md::omd_pda is non-zero, and
-	 * 3) with PO_COMP_TP_GRP layer in pool map.
+	 * 3) with PO_COMP_TP_PERF layer in pool map.
 	 */
-	if (md->omd_pda == 0 || md->omd_pdom_lvl != PO_COMP_TP_GRP)
+	if (md->omd_pda == 0 || md->omd_pdom_lvl != PO_COMP_TP_PERF)
 		pd_nr = 0;
 	jmop->jmop_pd_nr = pd_nr;
 	if (jmop->jmop_pd_nr == 0) {
@@ -77,7 +78,7 @@ jm_obj_pd_init(struct pl_jump_map *jmap, struct daos_obj_md *md, struct pool_dom
 	}
 
 	D_ASSERT(pd_nr >= 1);
-	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_GRP, PO_COMP_ID_ALL, &pds);
+	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_PERF, PO_COMP_ID_ALL, &pds);
 	D_ASSERT(rc == pd_nr);
 	rc = 0;
 
@@ -875,7 +876,7 @@ jump_map_create(struct pool_map *poolmap, struct pl_map_init_attr *mia,
 
 	jmap->jmp_redundant_dom = mia->ia_jump_map.domain;
 
-	rc = pool_map_find_domain(poolmap, PO_COMP_TP_GRP, PO_COMP_ID_ALL, &doms);
+	rc = pool_map_find_domain(poolmap, PO_COMP_TP_PERF, PO_COMP_ID_ALL, &doms);
 	if (rc < 0)
 		goto ERR;
 	jmap->jmp_pd_nr = rc;

--- a/src/placement/tests/jump_map_pda_layout.c
+++ b/src/placement/tests/jump_map_pda_layout.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2021-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -57,7 +58,7 @@ plt_obj_place_with_pd(daos_obj_id_t oid, uint32_t pda, struct pl_obj_layout **la
 	memset(&md, 0, sizeof(md));
 	md.omd_id  = oid;
 	md.omd_pda = pda;
-	md.omd_pdom_lvl = PO_COMP_TP_GRP;
+	md.omd_pdom_lvl = PO_COMP_TP_PERF;
 	md.omd_fdom_lvl = PO_COMP_TP_RANK;
 	D_ASSERT(pl_map != NULL);
 	md.omd_ver = pool_map_get_version(pl_map->pl_poolmap);

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -305,14 +305,17 @@ jtc_pool_map_extend(struct jm_test_ctx *ctx, uint32_t domain_count,
 	int		ntargets;
 	int		rc, i;
 	d_rank_list_t	rank_list;
-	uint32_t	domains[] = {255, 0, 5, /* root */
-				     1, 101, 1,
+	/* clang-format off */
+	uint32_t	domains[] = {2, 1, 5, /* root */
+				     1, 101, 1, /* nodes */
 				     1, 102, 1,
 				     1, 103, 1,
 				     1, 104, 1,
 				     1, 105, 1};
+	/* clang-format on */
 	const size_t	tuple_size = 3;
 	const size_t	max_domains = 5;
+	const size_t     md_len      = 1;
 	uint32_t	domain_tree_len;
 	uint32_t	domains_only_len;
 	uint32_t	ranks_per_domain;
@@ -337,19 +340,19 @@ jtc_pool_map_extend(struct jm_test_ctx *ctx, uint32_t domain_count,
 	}
 
 	domains_only_len = (domain_count + 1) * tuple_size;
-	domain_tree_len = domains_only_len + node_count;
+	domain_tree_len  = md_len + domains_only_len + node_count;
 	D_ALLOC_ARRAY(domain_tree, domain_tree_len);
 	assert_non_null(domain_tree);
 
-	memcpy(domain_tree, domains,
-	       sizeof(uint32_t) * domains_only_len);
+	memcpy(&domain_tree[md_len], domains, sizeof(uint32_t) * domains_only_len);
 
 	rank_list.rl_nr = node_count;
 	D_ALLOC_ARRAY(rank_list.rl_ranks, node_count);
 	assert_non_null(rank_list.rl_ranks);
 	for (i = 0; i < node_count; i++) {
-		uint32_t idx = domains_only_len + i;
+		uint32_t idx = md_len + domains_only_len + i;
 
+		assert_in_range(idx, md_len + domains_only_len, domain_tree_len - 1);
 		domain_tree[idx] = ctx->domain_nr + i;
 		rank_list.rl_ranks[i] = ctx->domain_nr + i;
 	}
@@ -361,8 +364,8 @@ jtc_pool_map_extend(struct jm_test_ctx *ctx, uint32_t domain_count,
 
 	map_version = pool_map_get_version(ctx->po_map) + 1;
 
-	rc = gen_pool_buf(ctx->po_map, &map_buf, map_version, domain_tree_len, node_count,
-			  ntargets, domain_tree, target_count);
+	rc = gen_pool_buf(ctx->po_map, &map_buf, map_version, domain_tree_len, node_count, ntargets,
+			  domain_tree, target_count);
 	D_FREE(domain_tree);
 	assert_success(rc);
 

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -567,7 +568,7 @@ gen_pool_and_placement_map(int num_pds, int fdoms_per_pd, int nodes_per_domain,
 	comp = &comps[0];
 	/* fake the pool map */
 	for (i = 0; i < num_pds && num_pds >= 2; i++, comp++) {
-		comp->co_type   = PO_COMP_TP_GRP;
+		comp->co_type   = PO_COMP_TP_PERF;
 		comp->co_status = PO_COMP_ST_UPIN;
 		comp->co_id     = i;
 		comp->co_rank   = i;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -6998,9 +6998,9 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc, bool exclud
 	if (opc == MAP_EXTEND) {
 		D_ASSERT(extend_rank_list != NULL);
 		map_version = pool_map_get_version(map) + 1;
-		rc = gen_pool_buf(map, &map_buf, map_version, extend_domains_nr,
-				  extend_rank_list->rl_nr, extend_rank_list->rl_nr * dss_tgt_nr,
-				  extend_domains, dss_tgt_nr);
+		rc          = gen_pool_buf(map, &map_buf, map_version, extend_domains_nr,
+					   extend_rank_list->rl_nr, extend_rank_list->rl_nr * dss_tgt_nr,
+					   extend_domains, dss_tgt_nr);
 		if (rc != 0)
 			D_GOTO(out_map, rc);
 
@@ -7110,6 +7110,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc, bool exclud
 			goto out_map;
 		}
 
+		/* TODO DAOS-6353: Update to FAULT when supported */
 		failed_cnt = pool_map_get_failed_cnt(map, PO_COMP_TP_NODE);
 		D_INFO(DF_UUID ": Exclude %d ranks, failed NODE %d\n", DP_UUID(svc->ps_uuid),
 		       tgt_addrs->pta_number, failed_cnt);

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -279,6 +279,7 @@ init_reconf_map(struct pool_map *map, d_rank_list_t *replicas, d_rank_t self,
 	int                 i;
 	int                 rc;
 
+	/* TODO DAOS-6353: Deal with FAULT level components */
 	domains_len = pool_map_find_domain(map, PO_COMP_TP_NODE, PO_COMP_ID_ALL, &domains);
 	D_ASSERTF(domains_len > 0, "pool_map_find_domain: %d\n", domains_len);
 


### PR DESCRIPTION
- Rename pool map levels to allow for optional fault domain level above
  node.
- Rename any performance domain "group" terminology.
- Update compressed fault domain tree parsing to include metadata about
  whether to include optional fault or performance domains.
- Update compressed domain tree format in control plane.

Signed-off-by: Kris Jacque <kris.jacque@hpe.com>

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
