### PR TITLE
DAOS-17055 client: add a soft limit of 4k to nr ranges for list-io

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -270,6 +271,7 @@ daos_init(void)
 	if (rc != 0)
 		D_GOTO(out_obj, rc);
 #endif
+	daos_array_env_init();
 	module_initialized++;
 	D_GOTO(unlock, rc = 0);
 

--- a/src/include/daos/array.h
+++ b/src/include/daos/array.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -12,6 +13,11 @@
 
 #include <daos_types.h>
 #include <daos/tse.h>
+
+/** limits for list io write/read */
+extern unsigned int array_list_io_limit;
+void
+    daos_array_env_init();
 
 /* task functions for array operations */
 int dc_array_create(tse_task_t *task);

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -605,6 +606,8 @@ daos_errno2der(int err)
 	case EINVAL:		return -DER_INVAL;
 	case ENOTDIR:		return -DER_NOTDIR;
 	case EIO:		return -DER_IO;
+	case ENOTSUP:
+		return -DER_NOTSUPPORTED;
 	case EFAULT:
 	case ENXIO:
 	case ENODEV:
@@ -661,6 +664,8 @@ daos_der2errno(int err)
 	case -DER_NOTDIR:	return ENOTDIR;
 	case -DER_STALE:	return ESTALE;
 	case -DER_TX_RESTART:	return ERESTART;
+	case -DER_NOTSUPPORTED:
+		return ENOTSUP;
 	default:		return EIO;
 	}
 };

--- a/src/include/daos_array.h
+++ b/src/include/daos_array.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -22,6 +23,11 @@ extern "C" {
 #include <daos_types.h>
 #include <daos_obj.h>
 #include <daos_obj_class.h>
+
+/** limit of arr_nr (list-io entries) for file offsets in a single update */
+#define DAOS_ARRAY_LIST_IO_LIMIT 16384
+/** Tiny recx limit (in bytes) in the array IODs where the list limit is high */
+#define DAOS_ARRAY_RG_LEN_THD    16
 
 /** Range of contiguous records */
 typedef struct {
@@ -260,6 +266,8 @@ daos_array_close(daos_handle_t oh, daos_event_t *ev);
  * \param[in]	oh	Array object open handle.
  * \param[in]	th	Transaction handle.
  * \param[in]	iod	IO descriptor of ranges to read from the array.
+ *			There is a limit on the number of descriptors (DAOS_ARRAY_LIST_IO_LIMIT) if
+ *			the length on the ranges are under DAOS_ARRAY_RG_LEN_THD.
  * \param[in]	sgl	A scatter/gather list (sgl) to the store array data.
  *			Buffer sizes do not have to match the individual range
  *			sizes as long as the total size does. User allocates the
@@ -286,6 +294,8 @@ daos_array_read(daos_handle_t oh, daos_handle_t th, daos_array_iod_t *iod,
  * \param[in]	oh	Array object open handle.
  * \param[in]	th	Transaction handle.
  * \param[in]	iod	IO descriptor of ranges to write to the array.
+ *			There is a limit on the number of descriptors (DAOS_ARRAY_LIST_IO_LIMIT) if
+ *			the length on the ranges are under DAOS_ARRAY_RG_LEN_THD.
  * \param[in]	sgl	A scatter/gather list (sgl) to the store array data.
  *			Buffer sizes do not have to match the individual range
  *			sizes as long as the total size does.

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -568,6 +569,8 @@ dfs_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off,
  * \param[in]	dfs	Pointer to the mounted file system.
  * \param[in]	obj	Opened file object.
  * \param[in]	iod	IO descriptor for list-io.
+ *			There is a limit on the number of descriptors (DAOS_ARRAY_LIST_IO_LIMIT) if
+ *			the length on the ranges are under DAOS_ARRAY_RG_LEN_THD.
  * \param[in]	sgl	Scatter/Gather list for data buffer.
  * \param[out]	read_size
  *			How much data is actually read.
@@ -601,7 +604,9 @@ dfs_write(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off,
  *
  * \param[in]	dfs	Pointer to the mounted file system.
  * \param[in]	obj	Opened file object.
- * \param[in]	iod	IO descriptor of file view.
+ * \param[in]	iod	IO descriptor for list-io.
+ *			There is a limit on the number of descriptors (DAOS_ARRAY_LIST_IO_LIMIT) if
+ *			the length on the ranges are under DAOS_ARRAY_RG_LEN_THD.
  * \param[in]	sgl	Scatter/Gather list for data buffer.
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			Function will run in blocking mode if \a ev is NULL.


### PR DESCRIPTION
For dfs_readx/writex and array_read/write operations, add a limit for the number of IODs being passed to DAOS of 16k if the range lengths are under 16 bytes (best effort checking).

Features: dfs

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
