### PR TITLE
DAOS-16355 pydaos: add dir object cache for Datasets

### DIFF
--- a/src/client/pydaos/torch/torch_api.py
+++ b/src/client/pydaos/torch/torch_api.py
@@ -24,7 +24,7 @@ from . import DAOS_MAGIC, DaosClient, torch_shim
 ITER_BATCH_SIZE = 32
 READDIR_BATCH_SIZE = 128
 PARALLEL_SCAN_WORKERS = 16
-DIR_CACHE_SIZE = 256
+DIR_CACHE_SIZE = 64 * 1024
 
 
 def transform_fn_default(data):

--- a/src/client/pydaos/torch/torch_shim.c
+++ b/src/client/pydaos/torch/torch_shim.c
@@ -21,17 +21,74 @@
 #include <daos/common.h>
 #include <gurt/debug.h>
 #include <gurt/common.h>
+#include <gurt/hash.h>
 
 #define PY_SHIM_MAGIC_NUMBER (0x7A8B)
 #define EQ_POLL_BATCH_SIZE   (64)
 
 struct dfs_handle {
-	int           flags;
-	dfs_t        *dfs;
-	d_iov_t       global;
+	int                  flags;
+	dfs_t               *dfs;
+	d_iov_t              global;
 
-	daos_handle_t eq;
-	pid_t         eq_owner_pid;
+	daos_handle_t        eq;
+	pid_t                eq_owner_pid;
+	struct d_hash_table *dir_cache;
+};
+
+/* Cached directory object entry */
+struct dir_obj_cache_entry {
+	d_list_t   entry;
+	dfs_obj_t *obj;
+	char       name[PATH_MAX];
+};
+
+static inline struct dir_obj_cache_entry *
+dir_obj_cache_entry_from_link(d_list_t *rlink)
+{
+	return container_of(rlink, struct dir_obj_cache_entry, entry);
+}
+
+static bool
+dir_cache_key_cmp(struct d_hash_table *htable, d_list_t *rlink, const void *key, unsigned int ksize)
+{
+	struct dir_obj_cache_entry *h = dir_obj_cache_entry_from_link(rlink);
+
+	return (strcmp(h->name, (const char *)key) == 0);
+}
+
+static void
+dir_cache_rec_free(struct d_hash_table *htable, d_list_t *rlink)
+{
+	struct dir_obj_cache_entry *h = dir_obj_cache_entry_from_link(rlink);
+
+	int                         rc = dfs_release(h->obj);
+	if (rc) {
+		D_ERROR("Could not release object '%s': %s (rc=%d)", h->name, strerror(rc), rc);
+	}
+	free(h);
+}
+
+static bool
+dir_cache_rec_decref(struct d_hash_table *htable, d_list_t *rlink)
+{
+	return true;
+}
+
+static uint32_t
+dir_cache_rec_hash(struct d_hash_table *htable, d_list_t *rlink)
+{
+	struct dir_obj_cache_entry *h = dir_obj_cache_entry_from_link(rlink);
+
+	return d_hash_string_u32(h->name, strnlen(h->name, PATH_MAX));
+}
+
+/* Directory object hash table operations */
+static d_hash_table_ops_t dir_cache_hash_ops = {
+    .hop_key_cmp    = dir_cache_key_cmp,
+    .hop_rec_decref = dir_cache_rec_decref,
+    .hop_rec_free   = dir_cache_rec_free,
+    .hop_rec_hash   = dir_cache_rec_hash,
 };
 
 /* Parse arguments and magic number.
@@ -93,6 +150,50 @@ __shim_handle__module_fini(PyObject *self, PyObject *args)
 		return NULL;
 	}
 	return PyLong_FromLong(rc);
+}
+
+/* Hash table does not require lock: workers will be working on their own subsets of data
+and will have their own handlers, including the cache.
+*/
+static int
+__dir_cache_create(struct dfs_handle *hdl)
+{
+	int rc = d_hash_table_create(D_HASH_FT_EPHEMERAL | D_HASH_FT_NOLOCK | D_HASH_FT_LRU, 4,
+				     NULL, &dir_cache_hash_ops, &hdl->dir_cache);
+	if (rc) {
+		D_ERROR("Could not create directory cache's hash table: %s (rc=%d)", d_errstr(rc),
+			rc);
+		rc = daos_der2errno(rc);
+	}
+
+	return rc;
+}
+
+static int
+__dir_cache_destroy(struct dfs_handle *hdl)
+{
+	int rc = 0;
+
+	/* Before finalizing the handle, we need to release all cached directory objects,
+	by dropping the reference count we allow the hash table to free the memory via rec_free
+	callback
+	*/
+	while (true) {
+		d_list_t *rlink = d_hash_rec_first(hdl->dir_cache);
+		if (rlink == NULL)
+			break;
+
+		d_hash_rec_decref(hdl->dir_cache, rlink);
+	}
+
+	rc = d_hash_table_destroy(hdl->dir_cache, false);
+	if (rc) {
+		D_ERROR("Could not destroy directory objects cache hash table: %s (rc=%d)",
+			d_errstr(rc), rc);
+		rc = daos_der2errno(rc);
+	}
+
+	return rc;
 }
 
 static PyObject *
@@ -160,6 +261,11 @@ __shim_handle__torch_connect(PyObject *self, PyObject *args)
 	}
 	hdl->eq_owner_pid = getpid();
 
+	rc = __dir_cache_create(hdl);
+	if (rc) {
+		goto out;
+	}
+
 	PyList_SetItem(result, 0, PyLong_FromLong(rc));
 	PyList_SetItem(result, 1, PyLong_FromVoidPtr(hdl));
 
@@ -208,6 +314,11 @@ __shim_handle__torch_disconnect(PyObject *self, PyObject *args)
 	if (rc) {
 		D_ERROR("Could not destroy event queue: %s (rc=%d)", d_errstr(rc), rc);
 		rc = daos_der2errno(rc);
+		goto out;
+	}
+
+	rc = __dir_cache_destroy(hdl);
+	if (rc) {
 		goto out;
 	}
 
@@ -262,7 +373,57 @@ __shim_handle__torch_worker_init(PyObject *self, PyObject *args)
 		rc = daos_der2errno(rc);
 	}
 
+	rc = __dir_cache_create(hdl);
+
 	return PyLong_FromLong(rc);
+}
+
+static int
+lookup_or_insert_dir_obj(struct dfs_handle *hdl, const char *name, dfs_obj_t **obj)
+{
+	int                         rc    = 0;
+	d_list_t                   *rlink = NULL;
+	size_t                      len   = strnlen(name, PATH_MAX);
+	struct dir_obj_cache_entry *rec   = NULL;
+
+	assert(obj != NULL);
+	assert(hdl->dir_cache != NULL);
+
+	rlink = d_hash_rec_find(hdl->dir_cache, name, len);
+	if (rlink != NULL) {
+		rec  = dir_obj_cache_entry_from_link(rlink);
+		*obj = rec->obj;
+		return 0;
+	}
+
+	rc = dfs_lookup(hdl->dfs, name, hdl->flags, obj, NULL, NULL);
+	if (rc) {
+		return rc;
+	}
+
+	rec = calloc(1, sizeof(struct dir_obj_cache_entry));
+	if (rec == NULL) {
+		return ENOMEM;
+	}
+
+	rec->obj = *obj;
+	strncpy(rec->name, name, len);
+
+	rc = d_hash_rec_insert(hdl->dir_cache, rec->name, len, &rec->entry, false);
+	if (rc) {
+		D_ERROR("Failed to insert dir handle in hashtable: '%s': %s (rc=%d)", name,
+			d_errstr(rc), rc);
+		rc = daos_der2errno(rc);
+
+		int rc2 = dfs_release(rec->obj);
+		if (rc2) {
+			D_ERROR("Could not release object '%s': %s (rc=%d)", name, strerror(rc2),
+				rc2);
+		}
+		free(rec);
+	}
+
+	return rc;
 }
 
 static PyObject *
@@ -272,22 +433,18 @@ __shim_handle__torch_recommended_dir_split(PyObject *self, PyObject *args)
 	char              *path = NULL;
 	dfs_obj_t         *obj  = NULL;
 	uint32_t           nr   = 0;
+	int                rc   = 0;
 
 	RETURN_NULL_IF_FAILED_TO_PARSE(args, "Ls", &hdl, &path);
 
 	assert(hdl->dfs != NULL);
 
-	int rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &obj, NULL, NULL);
+	rc = lookup_or_insert_dir_obj(hdl, path, &obj);
 	if (rc) {
 		return Py_BuildValue("iI", rc, nr);
 	}
 
 	rc = dfs_obj_anchor_split(obj, &nr, NULL);
-	if (rc) {
-		return Py_BuildValue("iI", rc, nr);
-	}
-
-	rc = dfs_release(obj);
 	return Py_BuildValue("iI", rc, nr);
 }
 
@@ -328,7 +485,7 @@ __shim_handle__torch_list_with_anchor(PyObject *self, PyObject *args)
 		goto out;
 	}
 
-	rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &obj, NULL, NULL);
+	rc = lookup_or_insert_dir_obj(hdl, path, &obj);
 	if (rc) {
 		D_ERROR("Could not lookup object at '%s': %s (rc=%d)", path, strerror(rc), rc);
 		goto out;
@@ -396,17 +553,65 @@ out:
 	return PyLong_FromLong(rc);
 }
 
+static int
+split_path(const char *path, char **dir, char **name)
+{
+	assert(dir != NULL);
+	assert(name != NULL);
+
+	int   rc        = 0;
+	char *cp1       = NULL;
+	char *cp2       = NULL;
+	char *dir_name  = NULL;
+	char *file_name = NULL;
+
+	D_STRNDUP(cp1, path, PATH_MAX);
+	if (cp1 == NULL) {
+		return ENOMEM;
+	}
+	D_STRNDUP(cp2, path, PATH_MAX);
+	if (cp2 == NULL) {
+		rc = ENOMEM;
+		goto out;
+	}
+
+	dir_name  = dirname(cp1);
+	file_name = basename(cp2);
+
+	D_STRNDUP(*dir, dir_name, PATH_MAX);
+	if (*dir == NULL) {
+		rc = ENOMEM;
+		goto out;
+	}
+	D_STRNDUP(*name, file_name, PATH_MAX);
+	if (*name == NULL) {
+		D_FREE(*dir);
+		rc = ENOMEM;
+		goto out;
+	}
+
+out:
+	D_FREE(cp1);
+	D_FREE(cp2);
+
+	return rc;
+}
+
 static PyObject *
 __shim_handle__torch_read(PyObject *self, PyObject *args)
 {
-	ssize_t            rc     = 0;
-	struct dfs_handle *hdl    = NULL;
-	char              *path   = NULL;
-	dfs_obj_t         *obj    = NULL;
-	PyObject          *buffer = NULL;
+	ssize_t            rc        = 0;
+	struct dfs_handle *hdl       = NULL;
+	char              *path      = NULL;
+	char              *dir_name  = NULL;
+	char              *file_name = NULL;
+	dfs_obj_t         *obj       = NULL;
+	dfs_obj_t         *parent    = NULL;
+	PyObject          *buffer    = NULL;
 	Py_buffer          bview;
 	d_iov_t            iov;
 	daos_size_t        read = 0;
+	mode_t             mode = S_IFREG;
 
 	RETURN_NULL_IF_FAILED_TO_PARSE(args, "LsO", &hdl, &path, &buffer);
 	assert(hdl->dfs != NULL);
@@ -432,6 +637,23 @@ __shim_handle__torch_read(PyObject *self, PyObject *args)
 		return NULL;
 	}
 
+	rc = split_path(path, &dir_name, &file_name);
+	if (rc) {
+		goto out;
+	}
+
+	rc = lookup_or_insert_dir_obj(hdl, dir_name, &parent);
+	if (rc) {
+		D_ERROR("Could not lookup '%s': %s (rc=%ld)", path, strerror(rc), rc);
+		goto out;
+	}
+
+	rc = dfs_open(hdl->dfs, parent, file_name, mode, O_RDONLY, 0, 0, NULL, &obj);
+	if (rc) {
+		D_ERROR("Could not open '%s': %s (rc=%ld)", path, strerror(rc), rc);
+		goto out;
+	}
+
 	read = bview.len;
 	d_iov_set(&iov, bview.buf, read);
 
@@ -440,12 +662,6 @@ __shim_handle__torch_read(PyObject *self, PyObject *args)
 	    .sg_nr_out = 0,
 	    .sg_iovs   = &iov,
 	};
-
-	rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &obj, NULL, NULL);
-	if (rc) {
-		D_ERROR("Could not lookup '%s': %s (rc=%ld)", path, strerror(rc), rc);
-		goto out;
-	}
 
 	rc = dfs_read(hdl->dfs, obj, &sgl, 0 /* offset */, &read, NULL);
 	if (rc) {
@@ -456,6 +672,8 @@ __shim_handle__torch_read(PyObject *self, PyObject *args)
 	}
 
 out:
+	D_FREE(dir_name);
+	D_FREE(file_name);
 	PyBuffer_Release(&bview);
 
 	if (obj) {
@@ -499,6 +717,11 @@ start_read_op(struct dfs_handle *hdl, PyObject *item, struct io_op *op)
 	int           rc2 = 0;
 	daos_event_t *evp = &op->ev;
 
+	char         *dir_name  = NULL;
+	char         *file_name = NULL;
+	dfs_obj_t    *parent    = NULL;
+	mode_t        mode      = S_IFREG;
+
 	PyObject     *py_path = PyTuple_GetItem(item, 0);
 	PyObject     *py_buff = PyTuple_GetItem(item, 1);
 
@@ -521,20 +744,31 @@ start_read_op(struct dfs_handle *hdl, PyObject *item, struct io_op *op)
 	if (!PyBuffer_IsContiguous(&op->buf_view, 'C')) {
 		D_ERROR("Buffer for '%s' is not contiguous", path);
 		rc = EINVAL;
-		goto out;
+		goto err;
 	}
 
 	rc = daos_event_init(evp, hdl->eq, NULL);
 	if (rc) {
 		D_ERROR("Could not init event: %s (rc=%d)", d_errstr(rc), rc);
 		rc = daos_der2errno(rc);
-		goto out;
+		goto err;
 	}
 
-	rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &op->obj, NULL, NULL);
+	rc = split_path(path, &dir_name, &file_name);
 	if (rc) {
-		D_ERROR("Could not lookup path '%s': %s (rc=%d)", op->path, strerror(rc), rc);
-		goto out;
+		goto err;
+	}
+
+	rc = lookup_or_insert_dir_obj(hdl, dir_name, &parent);
+	if (rc) {
+		D_ERROR("Could not lookup '%s': %s (rc=%d)", dir_name, strerror(rc), rc);
+		goto err;
+	}
+
+	rc = dfs_open(hdl->dfs, parent, file_name, mode, O_RDONLY, 0, 0, NULL, &op->obj);
+	if (rc) {
+		D_ERROR("Could not open '%s': %s (rc=%d)", op->path, strerror(rc), rc);
+		goto err;
 	}
 
 	op->path = path;
@@ -549,12 +783,17 @@ start_read_op(struct dfs_handle *hdl, PyObject *item, struct io_op *op)
 	if (rc) {
 		D_ERROR("Could not start async read on '%s': %s (rc=%d)", op->path, strerror(rc),
 			rc);
-		goto out;
+		goto err;
 	}
+
+	D_FREE(dir_name);
+	D_FREE(file_name);
 
 	return 0;
 
-out:
+err:
+	D_FREE(dir_name);
+	D_FREE(file_name);
 	PyBuffer_Release(&op->buf_view);
 
 	rc2 = daos_event_fini(&op->ev);
@@ -686,50 +925,6 @@ __shim_handle__torch_batch_read(PyObject *self, PyObject *args)
 	return PyLong_FromLong(rc);
 }
 
-static int
-split_path(const char *path, char **dir, char **name)
-{
-	assert(dir != NULL);
-	assert(name != NULL);
-
-	int   rc        = 0;
-	char *cp1       = NULL;
-	char *cp2       = NULL;
-	char *dir_name  = NULL;
-	char *file_name = NULL;
-
-	D_STRNDUP(cp1, path, PATH_MAX);
-	if (cp1 == NULL) {
-		return ENOMEM;
-	}
-	D_STRNDUP(cp2, path, PATH_MAX);
-	if (cp2 == NULL) {
-		rc = ENOMEM;
-		goto out;
-	}
-
-	dir_name  = dirname(cp1);
-	file_name = basename(cp2);
-
-	D_STRNDUP(*dir, dir_name, PATH_MAX);
-	if (*dir == NULL) {
-		rc = ENOMEM;
-		goto out;
-	}
-	D_STRNDUP(*name, file_name, PATH_MAX);
-	if (*name == NULL) {
-		D_FREE(*dir);
-		rc = ENOMEM;
-		goto out;
-	}
-
-out:
-	D_FREE(cp1);
-	D_FREE(cp2);
-
-	return rc;
-}
-
 static PyObject *
 __shim_handle__torch_write(PyObject *self, PyObject *args)
 {
@@ -739,7 +934,7 @@ __shim_handle__torch_write(PyObject *self, PyObject *args)
 	char              *path       = NULL;
 	char              *dir_name   = NULL;
 	char              *file_name  = NULL;
-	dfs_obj_t         *dir        = NULL;
+	dfs_obj_t         *parent     = NULL;
 	dfs_obj_t         *obj        = NULL;
 	PyObject          *buffer     = NULL;
 	int                oflags     = 0;
@@ -778,13 +973,13 @@ __shim_handle__torch_write(PyObject *self, PyObject *args)
 		goto out;
 	}
 
-	rc = dfs_lookup(hdl->dfs, dir_name, O_RDWR, &dir, NULL, NULL);
+	rc = lookup_or_insert_dir_obj(hdl, dir_name, &parent);
 	if (rc) {
 		D_ERROR("Could not lookup '%s': %s (rc=%d)", dir_name, strerror(rc), rc);
 		goto out;
 	}
 
-	rc = dfs_open(hdl->dfs, dir, file_name, mode, oflags, cid, chunk_size, NULL, &obj);
+	rc = dfs_open(hdl->dfs, parent, file_name, mode, oflags, cid, chunk_size, NULL, &obj);
 	if (rc) {
 		D_ERROR("Could not open '%s': %s (rc=%d)", path, strerror(rc), rc);
 		goto out;
@@ -815,13 +1010,6 @@ out:
 				rc2);
 		}
 	}
-	if (dir) {
-		rc2 = dfs_release(dir);
-		if (rc2) {
-			D_ERROR("Could not release dir '%s': %s (rc=%d)", dir_name, strerror(rc2),
-				rc2);
-		}
-	}
 
 	D_FREE(dir_name);
 	D_FREE(file_name);
@@ -832,21 +1020,33 @@ out:
 static PyObject *
 __shim_handle__torch_get_fsize(PyObject *self, PyObject *args)
 {
-	struct dfs_handle *hdl  = NULL;
-	char              *path = NULL;
-	dfs_obj_t         *obj  = NULL;
-	struct stat        st   = {0};
+	struct dfs_handle *hdl       = NULL;
+	char              *path      = NULL;
+	char              *dir_name  = NULL;
+	char              *file_name = NULL;
+	dfs_obj_t         *parent    = NULL;
+	struct stat        st        = {0};
 
 	RETURN_NULL_IF_FAILED_TO_PARSE(args, "Ls", &hdl, &path);
 
 	assert(hdl->dfs != NULL);
 
-	int rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &obj, NULL, &st);
+	int rc = split_path(path, &dir_name, &file_name);
 	if (rc) {
-		return Py_BuildValue("iK", rc, st.st_size);
+		return Py_BuildValue("iK", rc, 0);
 	}
 
-	rc = dfs_release(obj);
+	rc = lookup_or_insert_dir_obj(hdl, dir_name, &parent);
+	if (rc) {
+		D_ERROR("Could not lookup '%s': %s (rc=%d)", dir_name, strerror(rc), rc);
+		goto out;
+	}
+
+	rc = dfs_stat(hdl->dfs, parent, file_name, &st);
+
+out:
+	D_FREE(dir_name);
+	D_FREE(file_name);
 	return Py_BuildValue("iK", rc, st.st_size);
 }
 


### PR DESCRIPTION
Dataset reads a lot of samples that are stored under just a few common directories, to reduce computation load on lookup for each sample file, this commit introduces a cache of directory objects.

Features: PytorchDatasetsTest,PytorchCheckpointTest

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
