### PR TITLE
Shilongw/daos 16620 debug

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -807,7 +807,7 @@ pipeline {
                     }
                     steps {
                         job_step_update(
-                            unitTest(timeout_time: 60,
+                            unitTest(timeout_time: 160,
                                      unstash_opt: true,
                                      ignore_failure: true,
                                      inst_repos: prRepos(),

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -689,6 +690,8 @@ ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 	if (rc != 0)
 		D_GOTO(out_put, rc);
 
+	D_ASSERT(svc->cs_destroying == false);
+
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
 	if (rc != 0)
@@ -731,6 +734,7 @@ ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid)
 			DP_UUID(svc->cs_pool_uuid), rc);
 		return;
 	}
+	D_ASSERT(svc->cs_destroying == false);
 
 	ABT_rwlock_rdlock(svc->cs_lock);
 	rc = cont_lookup(&tx, svc, cont_uuid, &cont);

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -88,6 +88,7 @@ struct cont_svc {
 	rdb_path_t		cs_conts;	/* container KVS */
 	rdb_path_t              cs_hdls;        /* container handle KVS */
 	struct ds_pool	       *cs_pool;
+	bool                    cs_destroying; /* container is in destroying */
 
 	/* Manage the EC aggregation epoch */
 	struct sched_request   *cs_ec_leader_ephs_req;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1229,8 +1229,11 @@ cont_child_destroy_one(void *vin)
 	if (rc == -DER_NONEXIST)
 		D_GOTO(out_pool, rc = 0);
 
-	if (rc != 0)
+	if (rc != 0) {
+		D_ERROR(DF_CONT ": Container is still in destroying\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
 		D_GOTO(out_pool, rc);
+	}
 
 	if (cont->sc_open > 0) {
 		D_ERROR(DF_CONT": Container is still in open(%d)\n",
@@ -1240,6 +1243,8 @@ cont_child_destroy_one(void *vin)
 	}
 
 	if (cont->sc_destroying) {
+		D_ERROR(DF_CONT ": Container is still in destroying\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
 		cont_child_put(tls->dt_cont_cache, cont);
 		D_GOTO(out_pool, rc = -DER_BUSY);
 	}


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
