### PR TITLE
DAOS-16971 utils: more debug for OFI

### DIFF
--- a/utils/ofi_debug_ip.patch
+++ b/utils/ofi_debug_ip.patch
@@ -1,8 +1,8 @@
 diff --git a/prov/tcp/src/xnet.h b/prov/tcp/src/xnet.h
-index ee16d7e3a..1ee7d77a6 100644
+index ee16d7e3a..8470902c2 100644
 --- a/prov/tcp/src/xnet.h
 +++ b/prov/tcp/src/xnet.h
-@@ -754,4 +754,26 @@ int xnet_rdm_ops_open(struct fid *fid, const char *name,
+@@ -754,4 +754,29 @@ int xnet_rdm_ops_open(struct fid *fid, const char *name,
  	FI_WARN(&xnet_prov, subsystem, log_str "%s (%d)\n", \
  		fi_strerror((int) -(err)), (int) err)
  
@@ -23,14 +23,17 @@ index ee16d7e3a..1ee7d77a6 100644
 +	ofi_straddr(_buf, &_len, ofi_translate_addr_format(ofi_sa_family(_addr)), _addr);	\
 +	ofi_straddr(_src_buf, &_src_len, ofi_translate_addr_format(ofi_sa_family(_src_addr)),	\
 +		    _src_addr);									\
-+												\
-+	FI_WARN(&xnet_prov, FI_LOG_EP_CTRL, "error on %s From %s : %s\n", _buf, _src_buf,	\
-+		fi_strerror(err));								\
++	if (err != 0)										\
++		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL, "error on %s From %s : %s\n",		\
++			_buf, _src_buf,	fi_strerror(err));					\
++	else											\
++		FI_INFO(&xnet_prov, FI_LOG_EP_CTRL, "error on %s From %s : %s\n",		\
++			_buf, _src_buf,	fi_strerror(err));					\
 +} while(0)
 +
  #endif //_XNET_H_
 diff --git a/prov/tcp/src/xnet_ep.c b/prov/tcp/src/xnet_ep.c
-index 64772fef0..4c0166ae8 100644
+index 64772fef0..2cc31136e 100644
 --- a/prov/tcp/src/xnet_ep.c
 +++ b/prov/tcp/src/xnet_ep.c
 @@ -326,7 +326,7 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
@@ -86,7 +89,15 @@ index 64772fef0..4c0166ae8 100644
  	ep->rx_avail = 0;
  	ofi_bsock_discard(&ep->bsock);
  }
-@@ -561,6 +564,7 @@ static void xnet_ep_cancel_rx(struct xnet_ep *ep, void *context)
+@@ -444,6 +447,7 @@ void xnet_ep_disable(struct xnet_ep *ep, int cm_err, void* err_data,
+ 	if (!xnet_io_uring)
+ 		xnet_halt_sock(xnet_ep2_progress(ep), ep->bsock.sock);
+ 
++	XNET_OUTPUT_ERR_WARN(ep, cm_err);
+ 	ret = ofi_shutdown(ep->bsock.sock, SHUT_RDWR);
+ 	if (ret && ofi_sockerr() != ENOTCONN)
+ 		FI_WARN(&xnet_prov, FI_LOG_EP_DATA, "shutdown failed\n");
+@@ -561,6 +565,7 @@ static void xnet_ep_cancel_rx(struct xnet_ep *ep, void *context)
  found:
  	slist_remove(&ep->rx_queue, cur, prev);
  	ep->rx_avail++;


### PR DESCRIPTION
Add more debug log for OFI.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
