### PR TITLE
DAOS-17107 cart: Fail corpc parent on children failure

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -648,7 +649,7 @@ crt_corpc_reply_hdlr(const struct crt_cb_info *cb_info)
 	if (rc != 0) {
 		RPC_CERROR(crt_quiet_error(rc), DB_NET, child_rpc_priv, "error, rc: "DF_RC"\n",
 			   DP_RC(rc));
-		co_info->co_rc = rc;
+		crt_corpc_fail_parent_rpc(parent_rpc_priv, rc);
 	}
 	/* propagate failure rc to parent */
 	if (child_rpc_priv->crp_reply_hdr.cch_rc != 0)

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -2179,7 +2179,6 @@ crt_grp_config_load(struct crt_grp_priv *grp_priv)
 				rank, addr_str, rc);
 			break;
 		}
-
 	}
 
 out:
@@ -2191,7 +2190,6 @@ out:
 
 	return rc;
 }
-
 
 int
 crt_register_event_cb(crt_event_cb func, void *args)
@@ -2293,7 +2291,6 @@ crt_trigger_event_cbs(d_rank_t rank, uint64_t incarnation, enum crt_event_source
 			cb_func(rank, incarnation, src, type, cb_args);
 	}
 }
-
 
 /* Free index list is used for tracking which indexes in the rank list
  * are unused. When rank list gets filled, we reallocate bigger size
@@ -2836,7 +2833,6 @@ crt_group_view_destroy(crt_group_t *grp)
 out:
 	return rc;
 }
-
 
 int
 crt_group_secondary_create(crt_group_id_t grp_name, crt_group_t *primary_grp,

--- a/src/cart/crt_group.c
+++ b/src/cart/crt_group.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1180,7 +1181,6 @@ crt_grp_priv_destroy(struct crt_grp_priv *grp_priv)
 		d_hash_table_destroy_inplace(&grp_priv->gp_s2p_table, true);
 	}
 
-	D_FREE(grp_priv->gp_psr_uri);
 	D_FREE(grp_priv->gp_pub.cg_grpid);
 
 	D_RWLOCK_DESTROY(&grp_priv->gp_rwlock);
@@ -2093,11 +2093,10 @@ out:
 }
 
 /*
- * Load psr from singleton config file.
- * If psr_rank set as "-1", will mod the group rank with group size as psr rank.
+ * Load group from singleton config file.
  */
 int
-crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
+crt_grp_config_load(struct crt_grp_priv *grp_priv)
 {
 	char		*filename = NULL;
 	FILE		*fp = NULL;
@@ -2181,13 +2180,7 @@ crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank)
 			break;
 		}
 
-		if (rank == psr_rank)
-			crt_grp_psr_set(grp_priv, rank, addr_str, false);
 	}
-
-	/* TODO: PSR selection logic to be changed with CART-688 */
-	if (psr_rank != -1)
-		crt_grp_psr_set(grp_priv, rank, addr_str, false);
 
 out:
 	if (fp)
@@ -2196,34 +2189,9 @@ out:
 	D_FREE(grpname);
 	D_FREE(addr_str);
 
-	if (rc != 0)
-		D_ERROR("crt_grp_config_psr_load (grpid %s) failed, rc: %d.\n",
-			grpid, rc);
-
 	return rc;
 }
 
-int
-crt_grp_config_load(struct crt_grp_priv *grp_priv)
-{
-	int	rc;
-
-	if (!crt_initialized()) {
-		D_ERROR("CRT not initialized.\n");
-		D_GOTO(out, rc = -DER_UNINIT);
-	}
-	if (grp_priv == NULL) {
-		D_ERROR("Invalid NULL grp_priv pointer.\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	rc = crt_grp_config_psr_load(grp_priv, -1);
-	if (rc != 0)
-		D_ERROR("crt_grp_config_load failed, rc: %d.\n", rc);
-
-out:
-	return rc;
-}
 
 int
 crt_register_event_cb(crt_event_cb func, void *args)
@@ -2326,39 +2294,6 @@ crt_trigger_event_cbs(d_rank_t rank, uint64_t incarnation, enum crt_event_source
 	}
 }
 
-int
-crt_grp_psr_reload(struct crt_grp_priv *grp_priv)
-{
-	d_rank_t	psr_rank;
-	char           *uri = NULL;
-	int		rc = 0;
-
-	psr_rank = grp_priv->gp_psr_rank;
-	while (1) {
-		psr_rank = (psr_rank + 1) % grp_priv->gp_size;
-		if (psr_rank == grp_priv->gp_psr_rank) {
-			D_ERROR("group %s no more PSR candidate.\n",
-				grp_priv->gp_pub.cg_grpid);
-			D_GOTO(out, rc = -DER_PROTO);
-		}
-
-		crt_grp_lc_lookup(grp_priv, 0, psr_rank, 0, &uri, NULL);
-		if (uri == NULL)
-			break;
-
-		rc = crt_grp_psr_set(grp_priv, psr_rank, uri, false);
-		D_GOTO(out, 0);
-	}
-
-	rc = crt_grp_config_psr_load(grp_priv, psr_rank);
-	if (rc != 0) {
-		D_ERROR("crt_grp_config_psr_load(grp %s, psr_rank %d), "
-			"failed, rc: %d.\n",
-			grp_priv->gp_pub.cg_grpid, psr_rank, rc);
-	}
-out:
-	return rc;
-}
 
 /* Free index list is used for tracking which indexes in the rank list
  * are unused. When rank list gets filled, we reallocate bigger size
@@ -2902,30 +2837,6 @@ out:
 	return rc;
 }
 
-int
-crt_group_psr_set(crt_group_t *grp, d_rank_t rank)
-{
-	struct crt_grp_priv	*grp_priv;
-	char			*uri;
-	int			rc = 0;
-
-	if (!grp) {
-		D_ERROR("Passed grp is NULL\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	grp_priv = container_of(grp, struct crt_grp_priv, gp_pub);
-
-	rc = crt_rank_uri_get(grp, rank, 0, &uri);
-	if (rc != 0) {
-		D_ERROR("crt_rank_uri_get() failed, " DF_RC "\n", DP_RC(rc));
-		D_GOTO(out, rc);
-	}
-
-	rc = crt_grp_psr_set(grp_priv, rank, uri, true);
-out:
-	return rc;
-}
 
 int
 crt_group_secondary_create(crt_group_id_t grp_name, crt_group_t *primary_grp,
@@ -3633,7 +3544,6 @@ out:
 	return rc;
 
 cleanup:
-
 	D_ERROR("Failure when adding rank %d, rc=%d\n", sec_ranks->rl_ranks[idx_to_add[i]], rc);
 
 	for (k = 0; k < i; k++)
@@ -3643,64 +3553,5 @@ cleanup:
 	d_rank_list_free(to_remove);
 
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
-
-	return rc;
-}
-
-int
-crt_group_psrs_set(crt_group_t *grp, d_rank_list_t *rank_list)
-{
-	struct crt_grp_priv	*grp_priv;
-	struct crt_grp_priv	*prim_grp_priv;
-	d_rank_list_t		*copy_rank_list;
-	int			i;
-	int			rc;
-
-	grp_priv = crt_grp_pub2priv(grp);
-	if (grp_priv == NULL) {
-		D_ERROR("Failed to lookup grp\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	if (rank_list == NULL) {
-		D_ERROR("Passed rank_list is NULL\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	if (rank_list->rl_nr == 0) {
-		D_ERROR("Passed 0-sized rank_list\n");
-		D_GOTO(out, rc = -DER_INVAL);
-	}
-
-	rc = d_rank_list_dup(&copy_rank_list, rank_list);
-	if (rc != 0) {
-		D_ERROR("Failed to copy rank list\n");
-		D_GOTO(out, rc);
-	}
-
-	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
-	if (!grp_priv->gp_primary) {
-		prim_grp_priv = grp_priv->gp_priv_prim;
-
-		/* Convert all passed secondary ranks to primary */
-		for (i = 0; i < copy_rank_list->rl_nr; i++) {
-			copy_rank_list->rl_ranks[i] =
-				crt_grp_priv_get_primary_rank(
-						grp_priv,
-						copy_rank_list->rl_ranks[i]);
-		}
-	} else {
-		prim_grp_priv = grp_priv;
-	}
-
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
-
-	D_RWLOCK_WRLOCK(&prim_grp_priv->gp_rwlock);
-	if (prim_grp_priv->gp_psr_ranks) {
-		D_FREE(prim_grp_priv->gp_psr_ranks);
-		prim_grp_priv->gp_psr_ranks = copy_rank_list;
-	}
-	D_RWLOCK_UNLOCK(&prim_grp_priv->gp_rwlock);
-out:
 	return rc;
 }

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -89,12 +90,6 @@ struct crt_grp_priv {
 	 * up to date.
 	 */
 	d_rank_t		 gp_self;
-	/* List of PSR ranks */
-	d_rank_list_t		 *gp_psr_ranks;
-	/* PSR rank in attached group */
-	d_rank_t		 gp_psr_rank;
-	/* PSR URI address in attached group */
-	char                     *gp_psr_uri;
 	/* address lookup cache, only valid for primary group */
 	struct d_hash_table	 *gp_lookup_cache;
 
@@ -323,31 +318,6 @@ crt_grp_priv_decref(struct crt_grp_priv *grp_priv)
 		crt_grp_priv_destroy(grp_priv);
 }
 
-static inline int
-crt_grp_psr_set(struct crt_grp_priv *grp_priv, d_rank_t psr_rank, char *psr_uri, bool steal)
-{
-	int rc = 0;
-
-	D_RWLOCK_WRLOCK(&grp_priv->gp_rwlock);
-
-	D_FREE(grp_priv->gp_psr_uri);
-	grp_priv->gp_psr_rank = psr_rank;
-
-	if (steal) {
-		grp_priv->gp_psr_uri = psr_uri;
-	} else {
-		D_STRNDUP(grp_priv->gp_psr_uri, psr_uri, CRT_ADDR_STR_MAX_LEN);
-		if (grp_priv->gp_psr_uri == NULL)
-			rc = -DER_NOMEM;
-	}
-
-	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
-
-	D_DEBUG(DB_TRACE, "group %s, set psr rank %d, uri %s.\n", grp_priv->gp_pub.cg_grpid,
-		psr_rank, psr_uri);
-	return rc;
-}
-
 struct crt_grp_priv *crt_grp_pub2priv(crt_group_t *grp);
 
 static inline bool
@@ -375,8 +345,6 @@ crt_rank_present(crt_group_t *grp, d_rank_t rank)
 
 bool
 crt_grp_id_identical(crt_group_id_t grp_id_1, crt_group_id_t grp_id_2);
-int crt_grp_config_psr_load(struct crt_grp_priv *grp_priv, d_rank_t psr_rank);
-int crt_grp_psr_reload(struct crt_grp_priv *grp_priv);
 
 int
 grp_add_to_membs_list(struct crt_grp_priv *grp_priv, d_rank_t rank, uint64_t incarnation);

--- a/src/cart/crt_group.h
+++ b/src/cart/crt_group.h
@@ -89,7 +89,7 @@ struct crt_grp_priv {
 	 * If gp_self is CRT_NO_RANK, it usually means the group version is not
 	 * up to date.
 	 */
-	d_rank_t		 gp_self;
+	d_rank_t                  gp_self;
 	/* address lookup cache, only valid for primary group */
 	struct d_hash_table	 *gp_lookup_cache;
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -826,24 +827,14 @@ crt_issue_uri_lookup_retry(crt_context_t ctx,
 	int		rc;
 
 	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
-
-	/* IF PSRs are specified cycle through them, else use members */
-	if (grp_priv->gp_psr_ranks)
-		membs = grp_priv->gp_psr_ranks;
-	else
-		membs = grp_priv_get_membs(grp_priv);
+	membs = grp_priv_get_membs(grp_priv);
 
 	/* Note: membership can change between uri lookups, but we don't need
 	 * to handle this case, as it should be rare and will result in rank
 	 * being either repeated or skipped
 	 */
-	if (!membs || membs->rl_nr <= 1 || rpc_priv->crp_ul_idx == -1) {
-		contact_rank = grp_priv->gp_psr_rank;
-	} else {
-		rpc_priv->crp_ul_idx = (rpc_priv->crp_ul_idx + 1) %
-				       membs->rl_nr;
-		contact_rank = membs->rl_ranks[rpc_priv->crp_ul_idx];
-	}
+	rpc_priv->crp_ul_idx = (rpc_priv->crp_ul_idx + 1) % membs->rl_nr;
+	contact_rank = membs->rl_ranks[rpc_priv->crp_ul_idx];
 
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
@@ -1026,22 +1017,13 @@ crt_client_get_contact_rank(crt_context_t crt_ctx, crt_group_t *grp,
 
 	D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
 
-	if (grp_priv->gp_psr_ranks)
-		membs = grp_priv->gp_psr_ranks;
-	else
-		membs = grp_priv_get_membs(grp_priv);
+	membs = grp_priv_get_membs(grp_priv);
 
-	if (!membs || membs->rl_nr == 0) {
-		/* If list is not set, default to legacy psr */
-		contact_rank = grp_priv->gp_psr_rank;
-		*ret_idx = -1;
-	} else {
-		/* Pick random rank from the list */
-		*ret_idx = d_rand() % membs->rl_nr;
-		contact_rank = membs->rl_ranks[*ret_idx];
+	/* Pick random rank from the list */
+	*ret_idx = d_rand() % membs->rl_nr;
+	contact_rank = membs->rl_ranks[*ret_idx];
 
-		D_DEBUG(DB_ALL, "URI lookup rank chosen: %d\n", contact_rank);
-	}
+	D_DEBUG(DB_ALL, "URI lookup rank chosen: %d\n", contact_rank);
 
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
@@ -1269,38 +1251,6 @@ crt_req_ep_lc_lookup(struct crt_rpc_priv *rpc_priv, bool *uri_exists)
 			RPC_ERROR(rpc_priv, "crt_req_fill_tgt_uri() failed, " DF_RC "\n",
 				  DP_RC(rc));
 		D_GOTO(out, rc);
-	}
-
-	/*
-	 * If the target endpoint is the PSR and it's not already in the address
-	 * cache, insert the URI of the PSR to the address cache.
-	 * Did it in crt_grp_attach(), in the case that this context created
-	 * later can insert it here.
-	 */
-	if (base_addr == NULL && !crt_is_service()) {
-		D_RWLOCK_RDLOCK(&grp_priv->gp_rwlock);
-		if (tgt_ep->ep_rank == grp_priv->gp_psr_rank && dst_tag == 0) {
-			D_STRNDUP(uri, grp_priv->gp_psr_uri, CRT_ADDR_STR_MAX_LEN);
-			D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
-
-			if (uri == NULL)
-				D_GOTO(out, rc = -DER_NOMEM);
-
-			base_addr = uri;
-			rc        = crt_grp_lc_uri_insert(grp_priv, tgt_ep->ep_rank, 0, uri);
-			if (rc != 0) {
-				D_ERROR("crt_grp_lc_uri_insert() failed rc=%d\n", rc);
-				D_GOTO(out, rc);
-			}
-
-			rc = crt_req_fill_tgt_uri(rpc_priv, uri);
-			if (rc != 0) {
-				RPC_ERROR(rpc_priv, "tgt_uri='%s' fill failed\n", uri);
-				D_GOTO(out, rc);
-			}
-		} else {
-			D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
-		}
 	}
 
 out:

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -834,7 +834,7 @@ crt_issue_uri_lookup_retry(crt_context_t ctx,
 	 * being either repeated or skipped
 	 */
 	rpc_priv->crp_ul_idx = (rpc_priv->crp_ul_idx + 1) % membs->rl_nr;
-	contact_rank = membs->rl_ranks[rpc_priv->crp_ul_idx];
+	contact_rank         = membs->rl_ranks[rpc_priv->crp_ul_idx];
 
 	D_RWLOCK_UNLOCK(&grp_priv->gp_rwlock);
 
@@ -1020,7 +1020,7 @@ crt_client_get_contact_rank(crt_context_t crt_ctx, crt_group_t *grp,
 	membs = grp_priv_get_membs(grp_priv);
 
 	/* Pick random rank from the list */
-	*ret_idx = d_rand() % membs->rl_nr;
+	*ret_idx     = d_rand() % membs->rl_nr;
 	contact_rank = membs->rl_ranks[*ret_idx];
 
 	D_DEBUG(DB_ALL, "URI lookup rank chosen: %d\n", contact_rank);

--- a/src/cart/utils/crt_utils.c
+++ b/src/cart/utils/crt_utils.c
@@ -580,10 +580,6 @@ crtu_cli_start_basic(char *local_group_name, char *srv_group_name,
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	rc = crt_group_psr_set(*grp, (*rank_list)->rl_ranks[0]);
-	if (rc != 0)
-		D_GOTO(out, rc);
-
 out:
 	if (rc != 0 && opts.assert_on_error) {
 		D_ERROR("Asserting due to an error\n");

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2119,28 +2120,6 @@ int crt_group_view_create(crt_group_id_t grpid, crt_group_t **ret_grp);
  *                              on failure.
  */
 int crt_group_view_destroy(crt_group_t *grp);
-
-/**
- * Specify rank to be a PSR for the provided group
- *
- * \param[in] grp               Group handle
- * \param[in] rank              Rank to set as PSR
- *
- * \return                      DER_SUCCESS on success, negative value
- *                              on failure.
- */
-int crt_group_psr_set(crt_group_t *grp, d_rank_t rank);
-
-/**
- * Specify list of ranks to be a PSRs for the provided group
- *
- * \param[in] grp               Group handle
- * \param[in] rank_list         Ranks to set as PSRs
- *
- * \return                      DER_SUCCESS on success, negative value
- *                              on failure.
- */
-int crt_group_psrs_set(crt_group_t *grp, d_rank_list_t *rank_list);
 
 /**
  * Add rank to the specified primary group.

--- a/src/tests/ftest/cart/no_pmix_launcher_client.c
+++ b/src/tests/ftest/cart/no_pmix_launcher_client.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -133,12 +134,6 @@ int main(int argc, char **argv)
 	if (rank_list->rl_nr != grp_size) {
 		D_ERROR("rank_list differs in size. expected %d got %d\n",
 			grp_size, rank_list->rl_nr);
-		assert(0);
-	}
-
-	rc = crt_group_psr_set(grp, rank_list->rl_ranks[0]);
-	if (rc != 0) {
-		D_ERROR("crt_group_psr_set() failed; rc=%d\n", rc);
 		assert(0);
 	}
 

--- a/src/tests/ftest/cart/rpc_test_common.h
+++ b/src/tests/ftest/cart/rpc_test_common.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2017-2021 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -115,7 +116,6 @@ struct rpc_test_cli {
 	/*server group to attach to*/
 	crt_group_t		*target_group[2];
 	crt_context_t		crt_ctx;
-	d_rank_list_t		*psr_cand_list;
 	pthread_t		progress_thid;
 	sem_t			cli_sem;
 	uint32_t		timeout;

--- a/src/tests/ftest/cart/rpc_test_common.h
+++ b/src/tests/ftest/cart/rpc_test_common.h
@@ -115,7 +115,7 @@ struct rpc_test_cli {
 	crt_group_t		*local_group;
 	/*server group to attach to*/
 	crt_group_t		*target_group[2];
-	crt_context_t		crt_ctx;
+	crt_context_t            crt_ctx;
 	pthread_t		progress_thid;
 	sem_t			cli_sem;
 	uint32_t		timeout;

--- a/src/utils/self_test/self_test_lib.c
+++ b/src/utils/self_test/self_test_lib.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -154,9 +155,6 @@ self_test_init(char *dest_name, crt_context_t *crt_ctx, crt_group_t **srv_grp, p
 
 	D_ASSERTF(rank_list->rl_nr == grp_size, "rank_list differs in size. expected %d got %d\n",
 		  grp_size, rank_list->rl_nr);
-
-	ret = crt_group_psr_set(*srv_grp, rank_list->rl_ranks[0]);
-	D_ASSERTF(ret == 0, "crt_group_psr_set() failed; rc=%d\n", ret);
 
 	/* waiting to sync with the following parameters
 	 * 0 - tag 0


### PR DESCRIPTION
### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
