### PR TITLE
DAOS-17111 cart: Use only swim ctx for outage

### DIFF
--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -450,8 +451,7 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 
 	/* Sync the HLC. Clients never decode requests. */
 	D_ASSERT(crt_is_service());
-	rc = d_hlc_get_msg(rpc_priv->crp_req_hdr.cch_hlc,
-			     &ctx->cc_last_unpack_hlc, &clock_offset);
+	rc = d_hlc_get_msg(rpc_priv->crp_req_hdr.cch_hlc, NULL /* hlc_out */, &clock_offset);
 	if (rc != 0) {
 		REPORT_HLC_SYNC_ERR("failed to sync HLC for request: opc=%x ts="
 				    DF_U64" offset="DF_U64" from=%u\n",

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -412,9 +412,7 @@ struct crt_context {
 	pthread_mutex_t		 cc_mutex;
 
 	/** timeout per-context */
-	uint32_t		 cc_timeout_sec;
-	/** HLC time of last received RPC */
-	uint64_t		 cc_last_unpack_hlc;
+	uint32_t                 cc_timeout_sec;
 
 	/** Per-context statistics (server-side only) */
 	/** Total number of timed out requests, of type counter */

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -390,6 +390,15 @@ crt_swim_lookup_id(swim_id_t id)
 	return grp_ver;
 }
 
+static void
+crt_swim_update_last_unpack_hlc(struct crt_swim_membs *csm, uint64_t hlc)
+{
+	crt_swim_csm_lock(csm);
+	if (csm->csm_last_unpack_hlc < hlc)
+		csm->csm_last_unpack_hlc = hlc;
+	crt_swim_csm_unlock(csm);
+}
+
 static void crt_swim_srv_cb(crt_rpc_t *rpc)
 {
 	struct crt_rpc_priv	*rpc_priv = container_of(rpc, struct crt_rpc_priv, crp_pub);
@@ -409,6 +418,8 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 	int			 rc;
 
 	D_ASSERT(crt_is_service());
+
+	crt_swim_update_last_unpack_hlc(csm, hlc);
 
 	from_id = rpc_priv->crp_req_hdr.cch_src_rank;
 
@@ -614,6 +625,14 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 		if (to_id == ctx->sc_target)
 			ctx->sc_deadline = 0;
 		swim_ctx_unlock(ctx);
+	} else {
+		struct crt_swim_membs *csm = &grp_priv->gp_membs_swim;
+
+		/*
+		 * Although some errors also suggest incoming messages, we keep
+		 * it simple for now.
+		 */
+		crt_swim_update_last_unpack_hlc(csm, hlc);
 	}
 
 	reply_rc = cb_info->cci_rc ? cb_info->cci_rc : rpc_out->rc;
@@ -991,24 +1010,6 @@ static void crt_swim_new_incarnation(struct swim_context *ctx,
 	state->sms_incarnation = incarnation;
 }
 
-static void crt_swim_update_last_unpack_hlc(struct crt_swim_membs *csm)
-{
-	struct crt_context	*ctx = NULL;
-	d_list_t		*ctx_list;
-
-	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
-
-	ctx_list = crt_provider_get_ctx_list(true, crt_gdata.cg_primary_prov);
-	d_list_for_each_entry(ctx, ctx_list, cc_link) {
-		uint64_t hlc = ctx->cc_last_unpack_hlc;
-
-		if (csm->csm_last_unpack_hlc < hlc)
-			csm->csm_last_unpack_hlc = hlc;
-	}
-
-	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
-}
-
 static void
 crt_metrics_sample_delay(crt_context_t crt_ctx, uint64_t delay, bool glitch)
 {
@@ -1048,10 +1049,8 @@ static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout_us, v
 	if (rc == -DER_TIMEDOUT || rc == -DER_CANCELED) {
 		uint64_t now = swim_now_ms();
 
-		crt_swim_update_last_unpack_hlc(csm);
-
 		/*
-		 * Check for network idle in all contexts.
+		 * Check for network idle in swim context.
 		 * If the time passed from last received RPC till now is more
 		 * than 2/3 of suspicion timeout suspends eviction.
 		 * The max_delay should be less suspicion timeout to guarantee
@@ -1064,10 +1063,10 @@ static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout_us, v
 			uint64_t max_delay = swim_suspect_timeout_get() * 2 / 3;
 
 			if (delay > max_delay) {
-				D_ERROR("Network outage detected (idle during "
+				D_ERROR("SWIM network outage detected (idle during "
 					"%lu.%lu sec > expected %lu.%lu sec).\n",
-					delay / 1000, delay % 1000,
-					max_delay / 1000, max_delay % 1000);
+					delay / 1000, delay % 1000, max_delay / 1000,
+					max_delay % 1000);
 				swim_net_glitch_update(csm->csm_ctx, self_id, delay);
 				csm->csm_last_unpack_hlc = hlc2;
 			}


### PR DESCRIPTION
The "network outage" detection for swim (see the existing crt_swim_update_last_unpack_hlc) uses all crt contexts. In an engine, if the swim context can't receive or send any message, while at least one other context can and does receive messages constantly, then swim will not detect any "network outage", leading to more false positive DEAD events. The purpose of that detection is to find out swim-specific "network outages", where swim may be unable to receive any swim message.

This patch changes the detection algorithm to use only the swim crt context:

  - Remove crt_context.cc_last_unpack_hlc.

  - Update crt_swim_membs.csm_last_unpack_hlc when receiving swim requests and replies.

### Before requesting gatekeeper:

* [x] Two review approvals and any prior change requests have been resolved.
* [x] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [x] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [x] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [x] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
