### PR TITLE
DAOS-17117 build: build dependencies as git submodules (#15909)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -86,6 +86,13 @@ def add_command_line_options():
               default=os.path.join(Dir('#').abspath, 'utils', 'build.config'),
               help='build config file to use. [%default]')
 
+    AddOption('--deps-as-gitmodules-subdir',
+              dest='deps_as_gitmodules_subdir',
+              default=None,
+              help='Ignore the versions/branches/patches specified in build.config and \
+                    use the specified relative sub-directory containing all \
+                    dependencies as git submodules instead')
+
 
 def parse_and_save_conf(env, opts_file):
     """Parse daos.conf
@@ -443,6 +450,18 @@ def scons():
 
     # Define and load the components.  This will add more values to opt.
     prereqs = PreReqComponent(deps_env, opts)
+
+    gitmodules_subdir = GetOption("deps_as_gitmodules_subdir")
+    if gitmodules_subdir:
+        print(f"WARNING: --deps-as-gitmodules-subdir specified; ignoring build.config "
+              f"versions, branches, and patches and using gitmodules installed in "
+              f"{gitmodules_subdir} instead")
+        gitmodules_absdir = os.path.join(Dir('#').abspath, gitmodules_subdir)
+        if not os.path.isdir(gitmodules_absdir):
+            print(f"ERROR: --deps-as-gitmodules-subdir was specified but {gitmodules_absdir} "
+                  f"is not a valid directory.")
+            Exit(-1)
+
     # Now save the daos.conf file before attempting to build anything.  This means that options
     # are sticky even if there's a failed build.
     opts.Save(opts_file, deps_env)

--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -445,8 +445,10 @@ class PreReqComponent:
         self._configs = configparser.ConfigParser()
         self._configs.read(config_file)
 
-        self.__top_dir = Dir("#").abspath
-        install_dir = os.path.join(self.__top_dir, "install")
+        self.__top_dir = Dir('#').abspath
+        install_dir = os.path.join(self.__top_dir, 'install')
+
+        self.deps_as_gitmodules_subdir = GetOption("deps_as_gitmodules_subdir")
 
         RUNNER.initialize(self.__env)
 
@@ -487,7 +489,7 @@ class PreReqComponent:
 
         self.system_env = env.Clone()
 
-        self.__build_dir = self._sub_path(build_dir_name)
+        self.__build_dir = self.sub_path(build_dir_name)
 
         opts.Add(
             PathVariable(
@@ -723,7 +725,7 @@ class PreReqComponent:
             if not skip_download:
                 self.download_deps = True
 
-    def _sub_path(self, path):
+    def sub_path(self, path):
         """Resolve the real path"""
         return os.path.realpath(os.path.join(self.__top_dir, path))
 
@@ -731,7 +733,7 @@ class PreReqComponent:
         """Create a command line variable for a path"""
         tmp = self.__env.get(var)
         if tmp:
-            value = self._sub_path(tmp)
+            value = self.sub_path(tmp)
             self.__env[var] = value
 
     def define(self, name, **kw):
@@ -1111,8 +1113,33 @@ class _Component:
         commit_sha = self.prereqs.get_config("commit_versions", self.name)
         repo = self.prereqs.get_config("repos", self.name)
 
-        if not self.retriever:
+        if self.prereqs.deps_as_gitmodules_subdir is None and \
+                not self.retriever:
             print(f"Using installed version of {self.name}")
+            return
+
+        if self.prereqs.deps_as_gitmodules_subdir:
+            builddir, _ = os.path.split(self.src_path)
+            target = os.path.join(
+                self.prereqs.sub_path(self.prereqs.deps_as_gitmodules_subdir),
+                self.name)
+
+            if not os.path.isdir(target):
+                print(f"Symlink target {target} is not a valid directory")
+                raise BuildFailure(self.name)
+
+            relpath = os.path.relpath(target, builddir)
+            if os.path.exists(self.src_path):
+                if not os.path.islink(self.src_path) or \
+                        os.readlink(self.src_path) != relpath:
+
+                    print(f"{self.src_path} already exists in build directory.")
+                    raise BuildFailure(self.name)
+            else:
+                print(f"Creating symlink {self.src_path} to {relpath}")
+                if not RUNNER.run_commands([['ln', '-s', relpath, self.src_path]]):
+                    print("Error creating symlink")
+                    raise BuildFailure(self.name)
             return
 
         # Source code is retrieved using retriever


### PR DESCRIPTION
* add --deps-as-gitmodules-subdir flag that ignores branch, tag, and commit information for dependencies in build.config and expects such dependencies to exist as submodules in the supplied sub-directory (relative to base of repo)
* build such dependencies in place by inserting relative symlinks into the build directory

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
