### PR TITLE
DAOS-17148 common: btree delete may move target out of boundary - b26

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -3152,12 +3153,13 @@ btr_node_del_rec(struct btr_context *tcx, struct btr_trace *par_tr,
 		D_DEBUG(DB_TRACE, "Parent trace at=%d, key_nr=%d\n",
 			par_tr->tr_at, par_nd->tn_keyn);
 
+		D_ASSERT(par_tr->tr_at < par_nd->tn_keyn);
+
 		if (par_tr->tr_at == 0) {
 			/* only has sibling on the right side */
 			sib_off = btr_node_child_at(tcx, par_tr->tr_node, 1);
 			sib_on_right = true;
-
-		} else if (par_tr->tr_at == par_nd->tn_keyn) {
+		} else if (par_tr->tr_at == par_nd->tn_keyn - 1) {
 			/* only has sibling on the left side */
 			sib_off = btr_node_child_at(tcx, par_tr->tr_node,
 						     par_tr->tr_at - 1);


### PR DESCRIPTION
During btr_node_del_rec(), if the record to be deleted from current node is the last one, the logic will try to migrate one record from its sibling node. If current node is at the tail position in parent node, original logic may migrate an invalid record from a non-exist sibling node on the right. That may cause kinds of corruption since the content in such invalid record is undefined.

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
