### PR TITLE
DAOS-17006 cart: Bypass telemetry init when not enabled

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -272,8 +272,8 @@ crt_context_provider_create(crt_context_t *crt_ctx, crt_provider_t provider, boo
 
 	D_RWLOCK_UNLOCK(&crt_gdata.cg_rwlock);
 
-	/** initialize sensors */
-	if (crt_gdata.cg_use_sensors) {
+	/** initialize sensors for servers */
+	if (crt_gdata.cg_use_sensors && crt_is_service()) {
 		int	ret;
 		char	*prov;
 

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -925,9 +925,6 @@ crt_hg_ctx_init_tm(struct crt_hg_context *hg_ctx, int idx)
 		return;
 	}
 
-	if (!crt_gdata.cg_use_sensors)
-		return;
-
 	prov    = crt_provider_name_get(hg_ctx->chc_provider);
 	metrics = &hg_ctx->chc_metrics;
 

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -925,6 +925,9 @@ crt_hg_ctx_init_tm(struct crt_hg_context *hg_ctx, int idx)
 		return;
 	}
 
+	if (!crt_gdata.cg_use_sensors)
+		return;
+
 	prov    = crt_provider_name_get(hg_ctx->chc_provider);
 	metrics = &hg_ctx->chc_metrics;
 

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -1,6 +1,5 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -82,7 +81,7 @@ dump_opt(crt_init_options_t *opt)
 	D_INFO("interface = %s\n", opt->cio_interface);
 	D_INFO("domain = %s\n", opt->cio_domain);
 	D_INFO("port = %s\n", opt->cio_port);
-	D_INFO("Flags: fi: %d, use_credits: %d, use_sensors: %d\n", opt->cio_fault_inject,
+	D_INFO("Flags: fi: %d, use_credits: %d, use_esnsors: %d\n", opt->cio_fault_inject,
 	       opt->cio_use_credits, opt->cio_use_sensors);
 
 	if (opt->cio_use_expected_size)

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -81,7 +82,7 @@ dump_opt(crt_init_options_t *opt)
 	D_INFO("interface = %s\n", opt->cio_interface);
 	D_INFO("domain = %s\n", opt->cio_domain);
 	D_INFO("port = %s\n", opt->cio_port);
-	D_INFO("Flags: fi: %d, use_credits: %d, use_esnsors: %d\n", opt->cio_fault_inject,
+	D_INFO("Flags: fi: %d, use_credits: %d, use_sensors: %d\n", opt->cio_fault_inject,
 	       opt->cio_use_credits, opt->cio_use_sensors);
 
 	if (opt->cio_use_expected_size)
@@ -340,12 +341,12 @@ static int data_init(int server, crt_init_options_t *opt)
 		credits = CRT_MAX_CREDITS_PER_EP_CTX;
 	crt_gdata.cg_credit_ep_ctx = credits;
 
-	/** Enable statistics only for the server side and if requested */
-	if (opt && opt->cio_use_sensors && server) {
-		int	ret;
+	/** enable sensors if requested */
+	crt_gdata.cg_use_sensors = (opt && opt->cio_use_sensors);
 
-		/** enable sensors */
-		crt_gdata.cg_use_sensors = true;
+	/** Enable statistics only for the server side and if requested */
+	if (crt_gdata.cg_use_sensors && server) {
+		int	ret;
 
 		/** set up the global sensors */
 		ret = d_tm_add_metric(&crt_gdata.cg_uri_self, D_TM_COUNTER,

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1,6 +1,5 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -17,7 +16,6 @@
 #include "client_internal.h"
 #include <daos/mgmt.h>
 #include <daos/rpc.h>
-#include <daos/metrics.h>
 
 /** thread-private event */
 static __thread daos_event_t	ev_thpriv;
@@ -118,7 +116,7 @@ daos_eq_lib_reset_after_fork(void)
 
 	eq_ref            = 0;
 	ev_thpriv_is_init = false;
-	crt_info          = daos_crt_init_opt_get(false, 1, daos_client_metric);
+	crt_info          = daos_crt_init_opt_get(false, 1);
 	rc                = dc_mgmt_net_cfg(NULL, crt_info);
 	if (rc == 0)
 		rc = daos_eq_lib_init(crt_info);

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -1,6 +1,5 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -203,19 +202,12 @@ daos_init(void)
 	if (rc != 0)
 		D_GOTO(out_agent, rc);
 
-	/** set up client telemetry */
-	rc = dc_tm_init();
-	if (rc != 0) {
-		/* should not be fatal */
-		DL_WARN(rc, "failed to initialize client telemetry");
-	}
-
 	/** get and cache attach info of default system */
 	rc = dc_mgmt_cache_attach_info(NULL);
 	if (rc != 0)
 		D_GOTO(out_job, rc);
 
-	crt_info = daos_crt_init_opt_get(false, 1, daos_client_metric);
+	crt_info = daos_crt_init_opt_get(false, 1);
 	/**
 	 * get CaRT configuration (see mgmtModule.handleGetAttachInfo for the
 	 * handling of NULL system names)
@@ -251,6 +243,13 @@ daos_init(void)
 	if (rc != 0)
 		D_GOTO(out_pl, rc);
 
+	/** set up client telemetry */
+	rc = dc_tm_init();
+	if (rc != 0) {
+		/* should not be fatal */
+		DL_WARN(rc, "failed to initialize client telemetry");
+	}
+
 	/** set up pool */
 	rc = dc_pool_init();
 	if (rc != 0)
@@ -285,6 +284,7 @@ out_co:
 out_pool:
 	dc_pool_fini();
 out_mgmt:
+	dc_tm_fini();
 	dc_mgmt_fini();
 out_pl:
 	pl_fini();
@@ -292,7 +292,6 @@ out_eq:
 	daos_eq_lib_fini();
 out_attach:
 	dc_mgmt_drop_attach_info();
-	dc_tm_fini();
 out_job:
 	dc_job_fini();
 out_agent:
@@ -351,9 +350,9 @@ daos_fini(void)
 	if (rc != 0)
 		D_ERROR("failed to disconnect some resources may leak, " DF_RC "\n", DP_RC(rc));
 
+	dc_tm_fini();
 	dc_mgmt_drop_attach_info();
 	dc_agent_fini();
-	dc_tm_fini();
 	dc_job_fini();
 
 	pl_fini();

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -216,6 +217,13 @@ daos_init(void)
 	if (rc != 0)
 		D_GOTO(out_attach, rc);
 
+	/** set up client telemetry */
+	rc = dc_tm_init(crt_info);
+	if (rc != 0) {
+		/* should not be fatal */
+		DL_WARN(rc, "failed to initialize client telemetry");
+	}
+
 	/** set up event queue */
 	rc = daos_eq_lib_init(crt_info);
 	D_FREE(crt_info->cio_provider);
@@ -242,13 +250,6 @@ daos_init(void)
 	rc = dc_mgmt_init();
 	if (rc != 0)
 		D_GOTO(out_pl, rc);
-
-	/** set up client telemetry */
-	rc = dc_tm_init();
-	if (rc != 0) {
-		/* should not be fatal */
-		DL_WARN(rc, "failed to initialize client telemetry");
-	}
 
 	/** set up pool */
 	rc = dc_pool_init();
@@ -284,13 +285,13 @@ out_co:
 out_pool:
 	dc_pool_fini();
 out_mgmt:
-	dc_tm_fini();
 	dc_mgmt_fini();
 out_pl:
 	pl_fini();
 out_eq:
 	daos_eq_lib_fini();
 out_attach:
+	dc_tm_fini();
 	dc_mgmt_drop_attach_info();
 out_job:
 	dc_job_fini();

--- a/src/client/api/metrics.c
+++ b/src/client/api/metrics.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2020-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -101,7 +102,7 @@ skip_agent:
 }
 
 int
-dc_tm_init(void)
+dc_tm_init(crt_init_options_t *crt_info)
 {
 	struct d_tm_node_t *started_at;
 	pid_t               pid = getpid();
@@ -117,6 +118,9 @@ dc_tm_init(void)
 		return 0;
 
 	D_INFO("Setting up client telemetry for %s/%d\n", dc_jobid, pid);
+
+	/* Enable client-appropriate CaRT telemetry. */
+	crt_info->cio_use_sensors = 1;
 
 	rc = dc_tls_key_create();
 	if (rc)

--- a/src/client/api/tests/eq_tests.c
+++ b/src/client/api/tests/eq_tests.c
@@ -1,6 +1,5 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
- * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1258,7 +1257,7 @@ eq_ut_setup(void **state)
 		return rc;
 	}
 
-	rc = daos_eq_lib_init(daos_crt_init_opt_get(false, 1, false));
+	rc = daos_eq_lib_init(daos_crt_init_opt_get(false, 1));
 	if (rc != 0) {
 		print_error("Failed daos_eq_lib_init: %d\n", rc);
 		return rc;

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -1,6 +1,5 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -647,12 +646,12 @@ daos_hhash_traverse(int type, daos_hhash_traverse_cb_t cb, void *arg)
  */
 static crt_init_options_t daos_crt_init_opt;
 crt_init_options_t *
-daos_crt_init_opt_get(bool server, int ctx_nr, bool client_metrics)
+daos_crt_init_opt_get(bool server, int ctx_nr)
 {
 	uint32_t	limit = 0;
 
 	/** enable statistics on the server side */
-	daos_crt_init_opt.cio_use_sensors = server || client_metrics;
+	daos_crt_init_opt.cio_use_sensors = server;
 
 	/** configure cart for maximum bulk threshold */
 	d_getenv_uint32_t("DAOS_RPC_SIZE_LIMIT", &limit);

--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1,6 +1,5 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
- * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -797,8 +796,9 @@ server_init(int argc, char *argv[])
 
 	/* initialize the network layer */
 	ctx_nr = dss_ctx_nr_get();
-	rc     = crt_init_opt(daos_sysname, CRT_FLAG_BIT_SERVER,
-			      daos_crt_init_opt_get(true, ctx_nr, false));
+	rc = crt_init_opt(daos_sysname,
+			  CRT_FLAG_BIT_SERVER,
+			  daos_crt_init_opt_get(true, ctx_nr));
 	if (rc)
 		D_GOTO(exit_mod_init, rc);
 	D_INFO("Network successfully initialized\n");

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -1,6 +1,5 @@
 /**
  * (C) Copyright 2015-2024 Intel Corporation.
- * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -1037,8 +1036,7 @@ daos_recx_can_merge(daos_recx_t *src, daos_recx_t *dst)
  */
 #define DAOS_BULK_LIMIT	(DAOS_RPC_SIZE - 1024) /* Reserve 1KiB for headers */
 
-crt_init_options_t              *
-daos_crt_init_opt_get(bool server, int crt_nr, bool client_metrics);
+crt_init_options_t *daos_crt_init_opt_get(bool server, int crt_nr);
 
 int crt_proc_struct_dtx_id(crt_proc_t proc, crt_proc_op_t proc_op,
 			   struct dtx_id *dti);

--- a/src/include/daos/metrics.h
+++ b/src/include/daos/metrics.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -71,7 +72,7 @@ daos_module_nr_pool_metrics(void);
  *  Called during library initialization to init metrics.
  */
 int
-dc_tm_init(void);
+dc_tm_init(crt_init_options_t *crt_info);
 
 /**
  *  Called during library finalization to free metrics resources


### PR DESCRIPTION
Fixes an oversight in the client where HG metrics were
causing warnings on startup when client telemetry is not
enabled.
  
Change-Id: I0144f432106e641ff7fb8f2ea0ab9c73c564c25d
Signed-off-by: Michael MacDonald <mjmac@google.com>  