### PR TITLE
DAOS-16940 common: Rename pool map levels

### DIFF
--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -21,7 +21,7 @@
 #include <daos/pool_map.h>
 
 D_CASSERT((int)DAOS_PROP_PERF_DOMAIN_ROOT == (int)PO_COMP_TP_ROOT);
-D_CASSERT((int)DAOS_PROP_PERF_DOMAIN_GROUP == (int)PO_COMP_TP_GRP);
+D_CASSERT((int)DAOS_PROP_PERF_DOMAIN_GROUP == (int)PO_COMP_TP_PERF);
 
 daos_prop_t *
 daos_prop_alloc(uint32_t entries_nr)
@@ -326,8 +326,7 @@ daos_prop_valid(daos_prop_t *prop, bool pool, bool input)
 		case DAOS_PROP_PO_PERF_DOMAIN:
 		case DAOS_PROP_CO_PERF_DOMAIN:
 			val = prop->dpp_entries[i].dpe_val;
-			if (val != PO_COMP_TP_ROOT &&
-			    val != PO_COMP_TP_GRP) {
+			if (val != PO_COMP_TP_ROOT && val != PO_COMP_TP_PERF) {
 				D_ERROR("invalid perf domain "DF_U64".\n", val);
 				return false;
 			}

--- a/src/control/cmd/daos/property.go
+++ b/src/control/cmd/daos/property.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2023 Intel Corporation.
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -541,11 +542,12 @@ var propHdlrs = propHdlrMap{
 
 			return vh(e, v)
 		},
+		// TODO DAOS-16942: Update displayed name once labels are in place.
 		valHdlrMap{
 			"1":    setDpeVal(C.DAOS_PROP_CO_REDUN_RANK),
-			"2":    setDpeVal(C.DAOS_PROP_CO_REDUN_NODE),
+			"2":    setDpeVal(C.DAOS_PROP_CO_REDUN_FAULT),
 			"rank": setDpeVal(C.DAOS_PROP_CO_REDUN_RANK),
-			"node": setDpeVal(C.DAOS_PROP_CO_REDUN_NODE),
+			"node": setDpeVal(C.DAOS_PROP_CO_REDUN_FAULT),
 		},
 		func(e *C.struct_daos_prop_entry, name string) string {
 			if e == nil {
@@ -556,7 +558,7 @@ var propHdlrs = propHdlrMap{
 			switch lvl {
 			case C.DAOS_PROP_CO_REDUN_RANK:
 				return fmt.Sprintf("rank (%d)", lvl)
-			case C.DAOS_PROP_CO_REDUN_NODE:
+			case C.DAOS_PROP_CO_REDUN_FAULT:
 				return fmt.Sprintf("node (%d)", lvl)
 			default:
 				return fmt.Sprintf("(%d)", lvl)

--- a/src/control/lib/daos/pool_cont_prop.go
+++ b/src/control/lib/daos/pool_cont_prop.go
@@ -258,11 +258,8 @@ const (
 )
 
 const (
-	PoolPerfDomainRoot   = C.PO_COMP_TP_ROOT
-	PoolPerfDomainGrp    = C.PO_COMP_TP_GRP
-	PoolPerfDomainNode   = C.PO_COMP_TP_NODE
-	PoolPerfDomainRank   = C.PO_COMP_TP_RANK
-	PoolPerfDomainTarget = C.PO_COMP_TP_TARGET
+	PoolPerfDomainRoot = C.PO_COMP_TP_ROOT
+	PoolPerfDomainGrp  = C.PO_COMP_TP_PERF
 )
 
 const (

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -30,14 +31,14 @@
  * yaml file.
  */
 typedef enum pool_comp_type {
-	PO_COMP_TP_TARGET	= 0, /** reserved, hard-coded */
-	PO_COMP_TP_RANK		= 1, /** reserved, hard-coded */
-	PO_COMP_TP_MIN		= 2, /** first user-defined domain */
-	PO_COMP_TP_NODE		= 2, /** for test only */
-	PO_COMP_TP_GRP		= 3, /** group, commonly used for performance domain */
-	PO_COMP_TP_MAX		= 254, /** last user-defined domain */
-	PO_COMP_TP_ROOT		= 255,
-	PO_COMP_TP_END		= 256,
+	PO_COMP_TP_TARGET = 0,   /** reserved, hard-coded */
+	PO_COMP_TP_RANK   = 1,   /** reserved, hard-coded */
+	PO_COMP_TP_MIN    = 2,   /** first user-defined domain */
+	PO_COMP_TP_FAULT  = 2,   /** fault domain */
+	PO_COMP_TP_PERF   = 200, /** performance domain */
+	PO_COMP_TP_MAX    = 254, /** last user-defined domain */
+	PO_COMP_TP_ROOT   = 255,
+	PO_COMP_TP_END    = 256,
 } pool_comp_type_t;
 
 /** pool component states */

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -122,7 +123,7 @@ daos_otype_t_is_valid(enum daos_otype_t type)
 static inline bool
 daos_pa_domain_is_valid(uint32_t pa_domain)
 {
-	return pa_domain == DAOS_PROP_CO_REDUN_NODE || pa_domain == DAOS_PROP_CO_REDUN_RANK;
+	return pa_domain == DAOS_PROP_CO_REDUN_FAULT || pa_domain == DAOS_PROP_CO_REDUN_RANK;
 }
 
 static inline enum daos_otype_t

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -190,8 +190,8 @@ daos_svc_rf_is_valid(uint64_t svc_rf)
  * Level of perf_domain, should be same value as PO_COMP_TP_xxx (enum pool_comp_type).
  */
 enum {
-	DAOS_PROP_PERF_DOMAIN_ROOT = 255,
-	DAOS_PROP_PERF_DOMAIN_GROUP = 3,
+	DAOS_PROP_PERF_DOMAIN_ROOT  = 255,
+	DAOS_PROP_PERF_DOMAIN_GROUP = 200,
 };
 
 /**
@@ -479,16 +479,16 @@ enum {
  * rank is hardcoded to 1, [2-254] are defined by the admin
  */
 enum {
-	DAOS_PROP_CO_REDUN_MIN	= 1,
+	DAOS_PROP_CO_REDUN_MIN = 1,
 	/* server rank (engine) level */
-	DAOS_PROP_CO_REDUN_RANK	= 1,
-	/* server node level */
-	DAOS_PROP_CO_REDUN_NODE	= 2,
-	DAOS_PROP_CO_REDUN_MAX	= 254,
+	DAOS_PROP_CO_REDUN_RANK = 1,
+	/* fault domain level */
+	DAOS_PROP_CO_REDUN_FAULT = 2,
+	DAOS_PROP_CO_REDUN_MAX   = 254,
 };
 
 /** default fault domain level */
-#define DAOS_PROP_CO_REDUN_DEFAULT	DAOS_PROP_CO_REDUN_NODE
+#define DAOS_PROP_CO_REDUN_DEFAULT DAOS_PROP_CO_REDUN_FAULT
 
 /** container status flag */
 enum {

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -1,6 +1,7 @@
 /**
  *
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -68,7 +69,7 @@ jm_obj_pd_init(struct pl_jump_map *jmap, struct daos_obj_md *md, struct pool_dom
 	 * 2) daos_obj_md::omd_pda is non-zero, and
 	 * 3) with PO_COMP_TP_GRP layer in pool map.
 	 */
-	if (md->omd_pda == 0 || md->omd_pdom_lvl != PO_COMP_TP_GRP)
+	if (md->omd_pda == 0 || md->omd_pdom_lvl != PO_COMP_TP_PERF)
 		pd_nr = 0;
 	jmop->jmop_pd_nr = pd_nr;
 	if (jmop->jmop_pd_nr == 0) {
@@ -77,7 +78,7 @@ jm_obj_pd_init(struct pl_jump_map *jmap, struct daos_obj_md *md, struct pool_dom
 	}
 
 	D_ASSERT(pd_nr >= 1);
-	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_GRP, PO_COMP_ID_ALL, &pds);
+	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_PERF, PO_COMP_ID_ALL, &pds);
 	D_ASSERT(rc == pd_nr);
 	rc = 0;
 
@@ -272,7 +273,7 @@ jm_obj_placement_init(struct pl_jump_map *jmap, struct daos_obj_md *md,
 		jmop->jmop_fdom_lvl = jmap->jmp_redundant_dom;
 	} else {
 		D_ASSERT(md->omd_fdom_lvl == PO_COMP_TP_RANK ||
-			 md->omd_fdom_lvl == PO_COMP_TP_NODE);
+			 md->omd_fdom_lvl == PO_COMP_TP_FAULT);
 		rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, md->omd_fdom_lvl,
 					  PO_COMP_ID_ALL, NULL);
 		D_ASSERT(rc > 0);
@@ -875,7 +876,7 @@ jump_map_create(struct pool_map *poolmap, struct pl_map_init_attr *mia,
 
 	jmap->jmp_redundant_dom = mia->ia_jump_map.domain;
 
-	rc = pool_map_find_domain(poolmap, PO_COMP_TP_GRP, PO_COMP_ID_ALL, &doms);
+	rc = pool_map_find_domain(poolmap, PO_COMP_TP_PERF, PO_COMP_ID_ALL, &doms);
 	if (rc < 0)
 		goto ERR;
 	jmap->jmp_pd_nr = rc;

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -297,7 +298,7 @@ static struct d_hash_table	pl_htable;
  * will based on container's DAOS_PROP_CO_REDUN_LVL property to set the fault domain level for
  * that object's layout calculating.
  */
-#define PL_DEFAULT_DOMAIN	PO_COMP_TP_NODE
+#define PL_DEFAULT_DOMAIN PO_COMP_TP_FAULT
 
 static void
 pl_map_attr_init(struct pool_map *po_map, pl_map_type_t type,

--- a/src/placement/tests/jump_map_pda_layout.c
+++ b/src/placement/tests/jump_map_pda_layout.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2021-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -57,7 +58,7 @@ plt_obj_place_with_pd(daos_obj_id_t oid, uint32_t pda, struct pl_obj_layout **la
 	memset(&md, 0, sizeof(md));
 	md.omd_id  = oid;
 	md.omd_pda = pda;
-	md.omd_pdom_lvl = PO_COMP_TP_GRP;
+	md.omd_pdom_lvl = PO_COMP_TP_PERF;
 	md.omd_fdom_lvl = PO_COMP_TP_RANK;
 	D_ASSERT(pl_map != NULL);
 	md.omd_ver = pool_map_get_version(pl_map->pl_poolmap);
@@ -107,8 +108,8 @@ pda_layout_show(void **state)
 			"     %d targets totalty (each server group with %d targets).\n",
 			grp_nr, srvs_per_grp, engs_per_srv, tgts_per_eng,
 			tgts_total, tgts_per_grp);
-	gen_maps_adv(grp_nr, srvs_per_grp, engs_per_srv, tgts_per_eng, PO_COMP_TP_NODE,
-		     &po_map, &pl_map);
+	gen_maps_adv(grp_nr, srvs_per_grp, engs_per_srv, tgts_per_eng, PO_COMP_TP_FAULT, &po_map,
+		     &pl_map);
 
 	print_message("press enter to show layout of OC_S32 object, PDA -1 ...\n");
 	getchar();

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -351,8 +352,8 @@ plt_next_level(pool_comp_type_t current)
 {
 	switch (current) {
 	case PO_COMP_TP_ROOT:
-		return PO_COMP_TP_NODE;
-	case PO_COMP_TP_NODE:
+		return PO_COMP_TP_FAULT;
+	case PO_COMP_TP_FAULT:
 		return PO_COMP_TP_RANK;
 	case PO_COMP_TP_RANK:
 	default:
@@ -567,7 +568,7 @@ gen_pool_and_placement_map(int num_pds, int fdoms_per_pd, int nodes_per_domain,
 	comp = &comps[0];
 	/* fake the pool map */
 	for (i = 0; i < num_pds && num_pds >= 2; i++, comp++) {
-		comp->co_type   = PO_COMP_TP_GRP;
+		comp->co_type   = PO_COMP_TP_PERF;
 		comp->co_status = PO_COMP_ST_UPIN;
 		comp->co_id     = i;
 		comp->co_rank   = i;
@@ -576,7 +577,7 @@ gen_pool_and_placement_map(int num_pds, int fdoms_per_pd, int nodes_per_domain,
 	}
 
 	for (i = 0; i < num_domains; i++, comp++) {
-		comp->co_type   = PO_COMP_TP_NODE;
+		comp->co_type   = PO_COMP_TP_FAULT;
 		comp->co_status = PO_COMP_ST_UPIN;
 		comp->co_id     = i;
 		comp->co_rank   = i;
@@ -619,11 +620,11 @@ gen_pool_and_placement_map(int num_pds, int fdoms_per_pd, int nodes_per_domain,
 	/* No longer needed, copied into pool map */
 	D_FREE(buf);
 
-	D_ASSERTF(fdom_lvl == PO_COMP_TP_RANK || fdom_lvl == PO_COMP_TP_NODE,
-		  "bad fdom_lvl %d\n", fdom_lvl);
+	D_ASSERTF(fdom_lvl == PO_COMP_TP_RANK || fdom_lvl == PO_COMP_TP_FAULT, "bad fdom_lvl %d\n",
+		  fdom_lvl);
 	mia.ia_type = pl_type;
-	if (fail_domain_node || fdom_lvl == PO_COMP_TP_NODE)
-		mia.ia_ring.domain  = PO_COMP_TP_NODE;
+	if (fail_domain_node || fdom_lvl == PO_COMP_TP_FAULT)
+		mia.ia_ring.domain = PO_COMP_TP_FAULT;
 	else
 		mia.ia_ring.domain = PO_COMP_TP_RANK;
 	rc = pl_map_create(*po_map_out, &mia, pl_map_out);
@@ -657,7 +658,7 @@ gen_pool_and_placement_map_non_standard(int num_domains,
 	comp = &comps[0];
 	/* fake the pool map */
 	for (i = 0; i < num_domains; i++, comp++) {
-		comp->co_type   = PO_COMP_TP_NODE;
+		comp->co_type   = PO_COMP_TP_FAULT;
 		comp->co_status = PO_COMP_ST_UPIN;
 		comp->co_id     = i;
 		comp->co_rank   = i;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7110,7 +7110,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc, bool exclud
 			goto out_map;
 		}
 
-		failed_cnt = pool_map_get_failed_cnt(map, PO_COMP_TP_NODE);
+		failed_cnt = pool_map_get_failed_cnt(map, PO_COMP_TP_FAULT);
 		D_INFO(DF_UUID ": Exclude %d ranks, failed NODE %d\n", DP_UUID(svc->ps_uuid),
 		       tgt_addrs->pta_number, failed_cnt);
 		if (failed_cnt > pw_rf) {

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -279,7 +279,7 @@ init_reconf_map(struct pool_map *map, d_rank_list_t *replicas, d_rank_t self,
 	int                 i;
 	int                 rc;
 
-	domains_len = pool_map_find_domain(map, PO_COMP_TP_NODE, PO_COMP_ID_ALL, &domains);
+	domains_len = pool_map_find_domain(map, PO_COMP_TP_FAULT, PO_COMP_ID_ALL, &domains);
 	D_ASSERTF(domains_len > 0, "pool_map_find_domain: %d\n", domains_len);
 
 	D_ALLOC_ARRAY(rmap.rcm_domains, domains_len);
@@ -305,7 +305,7 @@ init_reconf_map(struct pool_map *map, d_rank_list_t *replicas, d_rank_t self,
 		goto out;
 
 	/*
-	 * Go through all PO_COMP_TP_NODE domains and their engines in the pool
+	 * Go through all PO_COMP_TP_FAULT domains and their engines in the pool
 	 * map, in order to populate rmap and to_remove.
 	 */
 	for (i = 0; i < domains_len; i++) {

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -2954,7 +2955,7 @@ nrank_per_node_get(struct pool_map *poolmap)
 	struct pool_domain	*dom;
 	int			 rc;
 
-	rc = pool_map_find_domain(poolmap, PO_COMP_TP_NODE, PO_COMP_ID_ALL, &dom);
+	rc = pool_map_find_domain(poolmap, PO_COMP_TP_FAULT, PO_COMP_ID_ALL, &dom);
 	print_message("system with %d domains of PO_COMP_TP_NODE, %d RANKs per NODE\n",
 		      rc, dom->do_comp.co_nr);
 
@@ -2971,7 +2972,7 @@ ranks_on_same_node(struct pool_map *poolmap, int src_rank, d_rank_t *ranks)
 	int			 i, j, k;
 	int			 rc;
 
-	rc = pool_map_find_domain(poolmap, PO_COMP_TP_NODE, PO_COMP_ID_ALL, &node_doms);
+	rc     = pool_map_find_domain(poolmap, PO_COMP_TP_FAULT, PO_COMP_ID_ALL, &node_doms);
 	nnodes = rc;
 	nrank_per_node = node_doms->do_comp.co_nr;
 
@@ -3036,7 +3037,7 @@ co_redun_lvl(void **state)
 	prop = daos_prop_alloc(2);
 	assert_non_null(prop);
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_REDUN_LVL;
-	prop->dpp_entries[0].dpe_val = DAOS_PROP_CO_REDUN_NODE;
+	prop->dpp_entries[0].dpe_val  = DAOS_PROP_CO_REDUN_FAULT;
 	prop->dpp_entries[1].dpe_type = DAOS_PROP_CO_REDUN_FAC;
 	prop->dpp_entries[1].dpe_val = DAOS_PROP_CO_REDUN_RF1;
 
@@ -3055,7 +3056,7 @@ co_redun_lvl(void **state)
 		rc = daos_cont_query(arg->coh, &info, prop_out, NULL);
 		assert_rc_equal(rc, 0);
 		/* Verify DAOS_PROP_CO_REDUN_LVL and DAOS_PROP_CO_REDUN_FAC values */
-		assert_int_equal(prop_out->dpp_entries[0].dpe_val, DAOS_PROP_CO_REDUN_NODE);
+		assert_int_equal(prop_out->dpp_entries[0].dpe_val, DAOS_PROP_CO_REDUN_FAULT);
 		assert_int_equal(prop_out->dpp_entries[1].dpe_val, DAOS_PROP_CO_REDUN_RF1);
 	}
 	par_barrier(PAR_COMM_WORLD);
@@ -3064,7 +3065,7 @@ co_redun_lvl(void **state)
 	plmap = pl_map_find(arg->pool.pool_uuid, oid);
 	poolmap = plmap->pl_poolmap;
 
-	ndom = pool_map_find_domain(poolmap, PO_COMP_TP_NODE, PO_COMP_ID_ALL, NULL);
+	ndom           = pool_map_find_domain(poolmap, PO_COMP_TP_FAULT, PO_COMP_ID_ALL, NULL);
 	nrank_per_node = nrank_per_node_get(poolmap);
 	print_message("system with ndom %d, nrank_per_node %d\n", ndom, nrank_per_node);
 
@@ -3104,7 +3105,7 @@ co_redun_lvl(void **state)
 	daos_prop_val_2_co_status(entry->dpe_val, &stat);
 	assert_int_equal(stat.dcs_status, DAOS_PROP_CO_HEALTHY);
 
-	/* exclude two engined on same node, as redun_lvl set as DAOS_PROP_CO_REDUN_NODE,
+	/* exclude two engined on same node, as redun_lvl set as DAOS_PROP_CO_REDUN_FAULT,
 	 * should not cause RF broken.
 	 */
 	test_set_engine_fail_loc(arg, CRT_NO_RANK, DAOS_REBUILD_DELAY | DAOS_FAIL_ALWAYS);
@@ -3230,7 +3231,7 @@ out:
 		rc = daos_cont_query(coh_g2l, &info, prop_out, NULL);
 		assert_rc_equal(rc, 0);
 		/* Verify DAOS_PROP_CO_REDUN_LVL and DAOS_PROP_CO_REDUN_FAC values */
-		assert_int_equal(prop_out->dpp_entries[0].dpe_val, DAOS_PROP_CO_REDUN_NODE);
+		assert_int_equal(prop_out->dpp_entries[0].dpe_val, DAOS_PROP_CO_REDUN_FAULT);
 		assert_int_equal(prop_out->dpp_entries[1].dpe_val, DAOS_PROP_CO_REDUN_RF1);
 	}
 


### PR DESCRIPTION
- Rename PO_COMP_TP_NODE to PO_COMP_TP_FAULT.
- Rename PO_COMP_TP_GRP to PO_COMP_TP_PERF.
- Renumber PO_COMP_TP_PERF as it must be one of the higher levels, to make room for potentially more levels in future.

Features: pool

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
