### PR TITLE
DAOS-17151 engine: RPC credits for IO chore task

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1218,11 +1218,12 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti, struct dtx_epoch *epoch,
 		rc = vos_dtx_attach(dth, false, (flags & DTX_PREPARED) ? true : false);
 
 out:
-	DL_CDEBUG(rc != 0, DLOG_ERR, DB_IO, rc, "Start (%s) DTX " DF_DTI " sub modification %d, "
+	DL_CDEBUG(rc != 0, DLOG_ERR, DB_IO, rc,
+		  "Start (%s) DTX " DF_DTI " sub modification %d, "
 		  "ver %u, eph " DF_X64 ", leader " DF_UOID ", cos_cnt %d, tgt_cnt %d, flags %x: ",
 		  flags & DTX_TGT_COLL ? (flags & DTX_RELAY ? "relay" : "collective") : "regular",
-		  DP_DTI(dti), sub_modification_cnt, pm_ver, epoch->oe_value,
-		  DP_UOID(*leader_oid), dti_cos_cnt, tgt_cnt, flags);
+		  DP_DTI(dti), sub_modification_cnt, pm_ver, epoch->oe_value, DP_UOID(*leader_oid),
+		  dti_cos_cnt, tgt_cnt, flags);
 
 	if (rc != 0) {
 		D_FREE(dlh);
@@ -2086,8 +2087,8 @@ dtx_sub_comp_cb(struct dtx_leader_handle *dlh, int idx, int rc)
 		sub->dss_result = rc;
 
 		DL_CDEBUG(rc == -DER_NOMEM, DLOG_ERR, DB_TRACE, rc,
-			  "execute from idx %d (%d:%d), flags %x",
-			  idx, tgt->st_rank, tgt->st_tgt_idx, tgt->st_flags);
+			  "execute from idx %d (%d:%d), flags %x", idx, tgt->st_rank,
+			  tgt->st_tgt_idx, tgt->st_flags);
 	}
 
 	rc = ABT_future_set(dlh->dlh_future, dlh);
@@ -2202,7 +2203,7 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	dtx_chore.func_arg = func_arg;
 	dtx_chore.dlh = dlh;
 
-	dtx_chore.chore.cho_func = dtx_leader_exec_ops_chore;
+	dtx_chore.chore.cho_func     = dtx_leader_exec_ops_chore;
 	dtx_chore.chore.cho_priority = 0;
 
 	dlh->dlh_result = 0;
@@ -2240,12 +2241,12 @@ again1:
 
 again2:
 	dtx_chore.chore.cho_credits = dlh->dlh_forward_cnt;
-	dtx_chore.chore.cho_hint = NULL;
-	rc = dss_chore_register(&dtx_chore.chore);
+	dtx_chore.chore.cho_hint    = NULL;
+	rc                          = dss_chore_register(&dtx_chore.chore);
 	if (rc != 0) {
 		if (rc != -DER_AGAIN) {
-			DL_ERROR(rc, "chore create failed [%u, %u] (2)",
-				 dlh->dlh_forward_idx, dlh->dlh_forward_cnt);
+			DL_ERROR(rc, "chore create failed [%u, %u] (2)", dlh->dlh_forward_idx,
+				 dlh->dlh_forward_cnt);
 			ABT_future_free(&dlh->dlh_future);
 			goto out;
 		}
@@ -2371,12 +2372,12 @@ exec:
 	 * to reduce the possibility of the whole IO timeout.
 	 */
 	if (unlikely(dlh->dlh_delay_sub_cnt > DTX_PRI_RPC_STEP_LENGTH))
-		  D_WARN("Too many delayed sub-requests %u\n", dlh->dlh_delay_sub_cnt);
+		D_WARN("Too many delayed sub-requests %u\n", dlh->dlh_delay_sub_cnt);
 
 	dtx_chore.chore.cho_priority = 1;
-	dtx_chore.chore.cho_credits = dlh->dlh_delay_sub_cnt;
-	dtx_chore.chore.cho_hint = NULL;
-	rc = dss_chore_register(&dtx_chore.chore);
+	dtx_chore.chore.cho_credits  = dlh->dlh_delay_sub_cnt;
+	dtx_chore.chore.cho_hint     = NULL;
+	rc                           = dss_chore_register(&dtx_chore.chore);
 	if (rc != 0) {
 		DL_ERROR(rc, "chore create failed (4)");
 		ABT_future_free(&dlh->dlh_future);

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -187,7 +188,14 @@ extern uint32_t dtx_batched_ult_max;
  * dispatch process may trigger too many in-flight or in-queued RPCs that will hold
  * too much resource as to server maybe out of memory.
  */
-#define DTX_RPC_STEP_LENGTH	DTX_THRESHOLD_COUNT
+#define DTX_REG_RPC_STEP_LENGTH		512
+
+/*
+ * High priority (DTX) RPC may break through IO chore credit restriction temporarily.
+ * To reduce the side-affect on the other IO forward RPCs, use smaller step for high
+ * priority RPC.
+ */
+#define DTX_PRI_RPC_STEP_LENGTH		64
 
 extern struct crt_corpc_ops	dtx_coll_commit_co_ops;
 extern struct crt_corpc_ops	dtx_coll_abort_co_ops;
@@ -214,6 +222,7 @@ struct dtx_tls {
 	struct d_tm_node_t	*dt_committable;
 	struct d_tm_node_t	*dt_dtx_leader_total;
 	struct d_tm_node_t	*dt_async_cmt_lat;
+	struct d_tm_node_t	*dt_chore_retry;
 	uint64_t		 dt_agg_gen;
 	uint32_t		 dt_batched_ult_cnt;
 };

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -188,14 +188,14 @@ extern uint32_t dtx_batched_ult_max;
  * dispatch process may trigger too many in-flight or in-queued RPCs that will hold
  * too much resource as to server maybe out of memory.
  */
-#define DTX_REG_RPC_STEP_LENGTH		512
+#define DTX_REG_RPC_STEP_LENGTH         512
 
 /*
  * High priority (DTX) RPC may break through IO chore credit restriction temporarily.
  * To reduce the side-affect on the other IO forward RPCs, use smaller step for high
  * priority RPC.
  */
-#define DTX_PRI_RPC_STEP_LENGTH		64
+#define DTX_PRI_RPC_STEP_LENGTH         64
 
 extern struct crt_corpc_ops	dtx_coll_commit_co_ops;
 extern struct crt_corpc_ops	dtx_coll_abort_co_ops;

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -222,7 +222,7 @@ struct dtx_tls {
 	struct d_tm_node_t	*dt_committable;
 	struct d_tm_node_t	*dt_dtx_leader_total;
 	struct d_tm_node_t	*dt_async_cmt_lat;
-	struct d_tm_node_t	*dt_chore_retry;
+	struct d_tm_node_t      *dt_chore_retry;
 	uint64_t		 dt_agg_gen;
 	uint32_t		 dt_batched_ult_cnt;
 };

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -721,8 +721,7 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 		length = dca->dca_count;
 	}
 
-
-	dca->dca_chore.cho_func = dtx_rpc_helper;
+	dca->dca_chore.cho_func     = dtx_rpc_helper;
 	dca->dca_chore.cho_priority = 1;
 	dca->dca_drr = d_list_entry(dca->dca_head.next, struct dtx_req_rec, drr_link);
 
@@ -747,8 +746,8 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 			}
 
 			dca->dca_chore.cho_credits = dca->dca_steps;
-			dca->dca_chore.cho_hint = NULL;
-			rc = dss_chore_register(&dca->dca_chore);
+			dca->dca_chore.cho_hint    = NULL;
+			rc                         = dss_chore_register(&dca->dca_chore);
 			if (rc != 0) {
 				ABT_eventual_free(&dca->dca_chore_eventual);
 				goto out;
@@ -789,8 +788,8 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 			break;
 		case DTX_REFRESH:
 			D_ASSERTF(length < DTX_PRI_RPC_STEP_LENGTH,
-				  "Too long list for DTX refresh: %u vs %u\n",
-				  length, DTX_PRI_RPC_STEP_LENGTH);
+				  "Too long list for DTX refresh: %u vs %u\n", length,
+				  DTX_PRI_RPC_STEP_LENGTH);
 			break;
 		default:
 			D_ASSERTF(0, "Invalid DTX opc %u\n", opc);
@@ -1587,7 +1586,7 @@ dtx_coll_rpc_prep(struct ds_cont_child *cont, struct dtx_coll_entry *dce, uint32
 	dcra->dcra_hints = dce->dce_hints;
 	dcra->dcra_hint_sz = dce->dce_hint_sz;
 
-	dcra->dcra_chore.cho_func = dtx_coll_rpc_helper;
+	dcra->dcra_chore.cho_func     = dtx_coll_rpc_helper;
 	dcra->dcra_chore.cho_priority = 1;
 
 	rc = ABT_future_create(1, NULL, &dcra->dcra_future);
@@ -1599,10 +1598,11 @@ dtx_coll_rpc_prep(struct ds_cont_child *cont, struct dtx_coll_entry *dce, uint32
 
 	if (dss_has_enough_helper()) {
 		/* The cho_credits maybe over-estimated, no matter. */
-		dcra->dcra_chore.cho_credits = dcra->dcra_ranks->rl_nr < DTX_COLL_TREE_WIDTH ?
-					       dcra->dcra_ranks->rl_nr : DTX_COLL_TREE_WIDTH;
-		dcra->dcra_chore.cho_hint = NULL;
-		rc = dss_chore_register(&dcra->dcra_chore);
+		dcra->dcra_chore.cho_credits = dcra->dcra_ranks->rl_nr < DTX_COLL_TREE_WIDTH
+						   ? dcra->dcra_ranks->rl_nr
+						   : DTX_COLL_TREE_WIDTH;
+		dcra->dcra_chore.cho_hint    = NULL;
+		rc                           = dss_chore_register(&dcra->dcra_chore);
 		if (rc != 0)
 			ABT_future_free(&dcra->dcra_future);
 	} else {

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -720,6 +721,9 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 		length = dca->dca_count;
 	}
 
+
+	dca->dca_chore.cho_func = dtx_rpc_helper;
+	dca->dca_chore.cho_priority = 1;
 	dca->dca_drr = d_list_entry(dca->dca_head.next, struct dtx_req_rec, drr_link);
 
 	/*
@@ -728,8 +732,8 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 	 * to reduce the whole network peak load and the pressure on related peers.
 	 */
 	while (length > 0) {
-		if (length > DTX_RPC_STEP_LENGTH && opc != DTX_CHECK)
-			dca->dca_steps = DTX_RPC_STEP_LENGTH;
+		if (length > DTX_PRI_RPC_STEP_LENGTH && opc != DTX_CHECK)
+			dca->dca_steps = DTX_PRI_RPC_STEP_LENGTH;
 		else
 			dca->dca_steps = length;
 
@@ -742,7 +746,9 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 				goto out;
 			}
 
-			rc = dss_chore_delegate(&dca->dca_chore, dtx_rpc_helper);
+			dca->dca_chore.cho_credits = dca->dca_steps;
+			dca->dca_chore.cho_hint = NULL;
+			rc = dss_chore_register(&dca->dca_chore);
 			if (rc != 0) {
 				ABT_eventual_free(&dca->dca_chore_eventual);
 				goto out;
@@ -754,10 +760,11 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 			rc = ABT_eventual_free(&dca->dca_chore_eventual);
 			D_ASSERTF(rc == ABT_SUCCESS, "ABT_eventual_free: %d\n", rc);
 		} else {
-			dss_chore_diy(&dca->dca_chore, dtx_rpc_helper);
+			dss_chore_diy(&dca->dca_chore);
 		}
 
 		rc = dtx_req_wait(&dca->dca_dra);
+		dss_chore_deregister(&dca->dca_chore);
 		if (rc == 0 || rc == -DER_NONEXIST)
 			goto next;
 
@@ -781,9 +788,9 @@ dtx_rpc(struct ds_cont_child *cont,d_list_t *dti_list,  struct dtx_entry **dtes,
 			 */
 			break;
 		case DTX_REFRESH:
-			D_ASSERTF(length < DTX_RPC_STEP_LENGTH,
+			D_ASSERTF(length < DTX_PRI_RPC_STEP_LENGTH,
 				  "Too long list for DTX refresh: %u vs %u\n",
-				  length, DTX_RPC_STEP_LENGTH);
+				  length, DTX_PRI_RPC_STEP_LENGTH);
 			break;
 		default:
 			D_ASSERTF(0, "Invalid DTX opc %u\n", opc);
@@ -1580,6 +1587,9 @@ dtx_coll_rpc_prep(struct ds_cont_child *cont, struct dtx_coll_entry *dce, uint32
 	dcra->dcra_hints = dce->dce_hints;
 	dcra->dcra_hint_sz = dce->dce_hint_sz;
 
+	dcra->dcra_chore.cho_func = dtx_coll_rpc_helper;
+	dcra->dcra_chore.cho_priority = 1;
+
 	rc = ABT_future_create(1, NULL, &dcra->dcra_future);
 	if (rc != ABT_SUCCESS) {
 		D_ERROR("ABT_future_create failed for coll DTX ("DF_DTI") RPC %u: rc = %d\n",
@@ -1588,9 +1598,15 @@ dtx_coll_rpc_prep(struct ds_cont_child *cont, struct dtx_coll_entry *dce, uint32
 	}
 
 	if (dss_has_enough_helper()) {
-		rc = dss_chore_delegate(&dcra->dcra_chore, dtx_coll_rpc_helper);
+		/* The cho_credits maybe over-estimated, no matter. */
+		dcra->dcra_chore.cho_credits = dcra->dcra_ranks->rl_nr < DTX_COLL_TREE_WIDTH ?
+					       dcra->dcra_ranks->rl_nr : DTX_COLL_TREE_WIDTH;
+		dcra->dcra_chore.cho_hint = NULL;
+		rc = dss_chore_register(&dcra->dcra_chore);
+		if (rc != 0)
+			ABT_future_free(&dcra->dcra_future);
 	} else {
-		dss_chore_diy(&dcra->dcra_chore, dtx_coll_rpc_helper);
+		dss_chore_diy(&dcra->dcra_chore);
 		rc = 0;
 	}
 
@@ -1608,6 +1624,7 @@ dtx_coll_rpc_post(struct dtx_coll_rpc_args *dcra, int ret)
 			 "Collective DTX wait req for opc %u, future %p done, rc %d, result %d\n",
 			 dcra->dcra_opc, dcra->dcra_future, rc, dcra->dcra_result);
 		ABT_future_free(&dcra->dcra_future);
+		dss_chore_deregister(&dcra->dcra_chore);
 	}
 
 	return ret != 0 ? ret : dcra->dcra_result;

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -53,6 +54,13 @@ dtx_tls_init(int tags, int xs_id, int tgt_id)
 			     "io/dtx/async_cmt_lat/tgt_%u", tgt_id);
 	if (rc != DER_SUCCESS)
 		D_WARN("Failed to create DTX async commit latency metric: " DF_RC"\n",
+		       DP_RC(rc));
+
+	rc = d_tm_add_metric(&tls->dt_chore_retry, D_TM_COUNTER,
+			     "DTX chore retry", NULL,
+			     "io/dtx/chore_retry/tgt_%u", tgt_id);
+	if (rc != DER_SUCCESS)
+		D_WARN("Failed to create DTX chore retry metric: " DF_RC"\n",
 		       DP_RC(rc));
 
 	return tls;

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -56,12 +56,10 @@ dtx_tls_init(int tags, int xs_id, int tgt_id)
 		D_WARN("Failed to create DTX async commit latency metric: " DF_RC"\n",
 		       DP_RC(rc));
 
-	rc = d_tm_add_metric(&tls->dt_chore_retry, D_TM_COUNTER,
-			     "DTX chore retry", NULL,
+	rc = d_tm_add_metric(&tls->dt_chore_retry, D_TM_COUNTER, "DTX chore retry", NULL,
 			     "io/dtx/chore_retry/tgt_%u", tgt_id);
 	if (rc != DER_SUCCESS)
-		D_WARN("Failed to create DTX chore retry metric: " DF_RC"\n",
-		       DP_RC(rc));
+		D_WARN("Failed to create DTX chore retry metric: " DF_RC"\n", DP_RC(rc));
 
 	return tls;
 }

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -59,7 +59,7 @@ dtx_tls_init(int tags, int xs_id, int tgt_id)
 	rc = d_tm_add_metric(&tls->dt_chore_retry, D_TM_COUNTER, "DTX chore retry", NULL,
 			     "io/dtx/chore_retry/tgt_%u", tgt_id);
 	if (rc != DER_SUCCESS)
-		D_WARN("Failed to create DTX chore retry metric: " DF_RC"\n", DP_RC(rc));
+		D_WARN("Failed to create DTX chore retry metric: " DF_RC "\n", DP_RC(rc));
 
 	return tls;
 }

--- a/src/dtx/tests/ult_mock.c
+++ b/src/dtx/tests/ult_mock.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2023-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,14 +75,20 @@ struct dss_chore;
 typedef enum dss_chore_status (*dss_chore_func_t)(struct dss_chore *chore, bool is_reentrance);
 
 void
-dss_chore_diy(struct dss_chore *chore, dss_chore_func_t func)
+dss_chore_diy(struct dss_chore *chore)
 {
 	assert_true(false);
 }
 
 int
-dss_chore_delegate(struct dss_chore *chore, dss_chore_func_t func)
+dss_chore_register(struct dss_chore *chore)
 {
 	assert_true(false);
 	return -DER_NOMEM;
+}
+
+void
+dss_chore_deregister(struct dss_chore *chore)
+{
+	assert_true(false);
 }

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1092,6 +1093,15 @@ dss_xstreams_init(void)
 
 	d_getenv_uint("DAOS_SCHED_UNIT_RUNTIME_MAX", &sched_unit_runtime_max);
 	d_getenv_bool("DAOS_SCHED_WATCHDOG_ALL", &sched_watchdog_all);
+
+	dss_chore_credits = DSS_CHORE_CREDITS_DEF;
+	d_getenv_uint("DAOS_IO_CHORE_CREDITS", &dss_chore_credits);
+	if (dss_chore_credits < DSS_CHORE_CREDITS_MIN) {
+		D_WARN("Invalid DAOS_IO_CHORE_CREDITS value, minimum is %u, set as default %u\n",
+		       DSS_CHORE_CREDITS_MIN, DSS_CHORE_CREDITS_DEF);
+		dss_chore_credits = DSS_CHORE_CREDITS_DEF;
+	}
+	D_INFO("Set DAOS IO chore credits as %u\n", dss_chore_credits);
 
 	/* start the execution streams */
 	D_DEBUG(DB_TRACE,

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -71,6 +72,7 @@ struct mem_stats {
 /* See dss_chore. */
 struct dss_chore_queue {
 	d_list_t   chq_list;
+	int32_t    chq_credits;
 	bool       chq_stop;
 	ABT_mutex  chq_mutex;
 	ABT_cond   chq_cond;
@@ -161,6 +163,11 @@ extern unsigned int          dss_tgt_offload_xs_nr;
 extern unsigned int          dss_offload_per_numa_nr;
 /** Number of target per socket */
 extern unsigned int          dss_tgt_per_numa_nr;
+/** The maximum number of credits for each IO chore queue. That is per helper XS. */
+extern uint32_t		     dss_chore_credits;
+
+#define DSS_CHORE_CREDITS_MIN	1024
+#define DSS_CHORE_CREDITS_DEF	4096
 
 /** Shadow dss_get_module_info */
 struct dss_module_info *get_module_info(void);

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -164,10 +164,10 @@ extern unsigned int          dss_offload_per_numa_nr;
 /** Number of target per socket */
 extern unsigned int          dss_tgt_per_numa_nr;
 /** The maximum number of credits for each IO chore queue. That is per helper XS. */
-extern uint32_t		     dss_chore_credits;
+extern uint32_t              dss_chore_credits;
 
-#define DSS_CHORE_CREDITS_MIN	1024
-#define DSS_CHORE_CREDITS_DEF	4096
+#define DSS_CHORE_CREDITS_MIN 1024
+#define DSS_CHORE_CREDITS_DEF 4096
 
 /** Shadow dss_get_module_info */
 struct dss_module_info *get_module_info(void);

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -12,6 +13,9 @@
 #include "srv_internal.h"
 
 /* ============== Thread collective functions ============================ */
+
+/** The maximum number of credits for each IO chore queue. That is per helper XS. */
+uint32_t	dss_chore_credits;
 
 struct aggregator_arg_type {
 	struct dss_stream_arg_type	at_args;
@@ -716,20 +720,20 @@ dss_chore_ult(void *arg)
  * Add \a chore for \a func to the chore queue of some other xstream.
  *
  * \param[in]	chore	address of the embedded chore object
- * \param[in]	func	function to be executed via \a chore
  *
  * \retval	-DER_CANCEL	chore queue stopping
  */
 int
-dss_chore_delegate(struct dss_chore *chore, dss_chore_func_t func)
+dss_chore_register(struct dss_chore *chore)
 {
 	struct dss_module_info *info = dss_get_module_info();
 	int                     xs_id;
 	struct dss_xstream     *dx;
 	struct dss_chore_queue *queue;
 
+	D_ASSERT(chore->cho_credits > 0);
+
 	chore->cho_status = DSS_CHORE_NEW;
-	chore->cho_func   = func;
 
 	/*
 	 * The dss_chore_queue_ult approach may get insufficient scheduling on
@@ -755,13 +759,44 @@ dss_chore_delegate(struct dss_chore *chore, dss_chore_func_t func)
 		ABT_mutex_unlock(queue->chq_mutex);
 		return -DER_CANCELED;
 	}
+
+	if (!chore->cho_priority && queue->chq_credits < chore->cho_credits) {
+		/*
+		 * Piggyback current available credits, then the caller can decide
+		 * whether can shrink credit requirement and retry with more steps.
+		 */
+		chore->cho_credits = queue->chq_credits;
+		ABT_mutex_unlock(queue->chq_mutex);
+		return -DER_AGAIN;
+	}
+
+	/* queue->chq_credits can be negative temporarily because of high priority requests. */
+	queue->chq_credits -= chore->cho_credits;
+	chore->cho_hint = queue;
 	d_list_add_tail(&chore->cho_link, &queue->chq_list);
 	ABT_cond_broadcast(queue->chq_cond);
 	ABT_mutex_unlock(queue->chq_mutex);
 
-	D_DEBUG(DB_TRACE, "%p: tgt_id=%d -> xs_id=%d dx.tgt_id=%d\n", chore, info->dmi_tgt_id,
-		xs_id, dx->dx_tgt_id);
+	D_DEBUG(DB_TRACE, "register chore %p on queue %p: tgt=%d -> xs=%d dx.tgt=%d, credits %u\n",
+		chore, queue, info->dmi_tgt_id, xs_id, dx->dx_tgt_id, chore->cho_credits);
 	return 0;
+}
+
+void
+dss_chore_deregister(struct dss_chore *chore)
+{
+	struct dss_chore_queue	*queue = chore->cho_hint;
+
+	if (queue != NULL) {
+		D_ASSERT(chore->cho_credits > 0);
+
+		ABT_mutex_lock(queue->chq_mutex);
+		queue->chq_credits += chore->cho_credits;
+		ABT_mutex_unlock(queue->chq_mutex);
+
+		D_DEBUG(DB_TRACE, "deregister chore %p from queue %p: credits %u\n",
+			chore, queue, chore->cho_credits);
+	}
 }
 
 /**
@@ -771,11 +806,10 @@ dss_chore_delegate(struct dss_chore *chore, dss_chore_func_t func)
  * \param[in]	func	function to be executed via \a chore
  */
 void
-dss_chore_diy(struct dss_chore *chore, dss_chore_func_t func)
+dss_chore_diy(struct dss_chore *chore)
 {
 	D_INIT_LIST_HEAD(&chore->cho_link);
 	chore->cho_status = DSS_CHORE_NEW;
-	chore->cho_func   = func;
 
 	dss_chore_diy_internal(chore);
 }
@@ -856,6 +890,7 @@ dss_chore_queue_init(struct dss_xstream *dx)
 
 	D_INIT_LIST_HEAD(&queue->chq_list);
 	queue->chq_stop = false;
+	queue->chq_credits = dss_chore_credits;
 
 	rc = ABT_mutex_create(&queue->chq_mutex);
 	if (rc != ABT_SUCCESS) {

--- a/src/engine/ult.c
+++ b/src/engine/ult.c
@@ -15,7 +15,7 @@
 /* ============== Thread collective functions ============================ */
 
 /** The maximum number of credits for each IO chore queue. That is per helper XS. */
-uint32_t	dss_chore_credits;
+uint32_t dss_chore_credits;
 
 struct aggregator_arg_type {
 	struct dss_stream_arg_type	at_args;
@@ -785,7 +785,7 @@ dss_chore_register(struct dss_chore *chore)
 void
 dss_chore_deregister(struct dss_chore *chore)
 {
-	struct dss_chore_queue	*queue = chore->cho_hint;
+	struct dss_chore_queue *queue = chore->cho_hint;
 
 	if (queue != NULL) {
 		D_ASSERT(chore->cho_credits > 0);
@@ -794,8 +794,8 @@ dss_chore_deregister(struct dss_chore *chore)
 		queue->chq_credits += chore->cho_credits;
 		ABT_mutex_unlock(queue->chq_mutex);
 
-		D_DEBUG(DB_TRACE, "deregister chore %p from queue %p: credits %u\n",
-			chore, queue, chore->cho_credits);
+		D_DEBUG(DB_TRACE, "deregister chore %p from queue %p: credits %u\n", chore, queue,
+			chore->cho_credits);
 	}
 }
 

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -769,22 +769,23 @@ struct dss_chore;
 typedef enum dss_chore_status (*dss_chore_func_t)(struct dss_chore *chore, bool is_reentrance);
 
 /**
- * Chore (opaque)
- *
  * A simple task (e.g., an I/O forwarding task) that yields by returning
  * DSS_CHORE_YIELD instead of calling ABT_thread_yield. This data structure
  * shall be embedded in the user's own task data structure, which typically
- * also includes arguments and internal state variables for \a cho_func. All
- * fields are private. See dtx_chore for an example.
+ * also includes arguments and internal state variables for \a cho_func.
  */
 struct dss_chore {
 	d_list_t              cho_link;
 	enum dss_chore_status cho_status;
 	dss_chore_func_t      cho_func;
+	uint32_t	      cho_priority:1;
+	int32_t		      cho_credits;
+	void		     *cho_hint;
 };
 
-int dss_chore_delegate(struct dss_chore *chore, dss_chore_func_t func);
-void dss_chore_diy(struct dss_chore *chore, dss_chore_func_t func);
+int dss_chore_register(struct dss_chore *chore);
+void dss_chore_deregister(struct dss_chore *chore);
+void dss_chore_diy(struct dss_chore *chore);
 
 bool engine_in_check(void);
 

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -778,15 +778,18 @@ struct dss_chore {
 	d_list_t              cho_link;
 	enum dss_chore_status cho_status;
 	dss_chore_func_t      cho_func;
-	uint32_t	      cho_priority:1;
-	int32_t		      cho_credits;
-	void		     *cho_hint;
+	uint32_t              cho_priority : 1;
+	int32_t               cho_credits;
+	void                 *cho_hint;
 };
 
-int dss_chore_register(struct dss_chore *chore);
-void dss_chore_deregister(struct dss_chore *chore);
-void dss_chore_diy(struct dss_chore *chore);
-
-bool engine_in_check(void);
+int
+dss_chore_register(struct dss_chore *chore);
+void
+dss_chore_deregister(struct dss_chore *chore);
+void
+dss_chore_diy(struct dss_chore *chore);
+bool
+engine_in_check(void);
 
 #endif /* __DSS_API_H__ */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -234,13 +234,13 @@ struct dtx_leader_handle {
 	/* Elements for collective DTX. */
 	struct dtx_coll_entry		*dlh_coll_entry;
 	/* How many normal sub request. */
-	uint32_t			dlh_normal_sub_cnt;
+	int32_t				dlh_normal_sub_cnt;
 	/* How many delay forward sub request. */
-	uint32_t			dlh_delay_sub_cnt;
+	int32_t				dlh_delay_sub_cnt;
 	/* The index of the first target that forward sub-request to. */
-	uint32_t			dlh_forward_idx;
+	int32_t				dlh_forward_idx;
 	/* The count of the targets that forward sub-request to. */
-	uint32_t			dlh_forward_cnt;
+	int32_t				dlh_forward_cnt;
 	/* Sub transaction handle to manage the dtx leader */
 	struct dtx_sub_status		*dlh_subs;
 };

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -234,13 +234,13 @@ struct dtx_leader_handle {
 	/* Elements for collective DTX. */
 	struct dtx_coll_entry		*dlh_coll_entry;
 	/* How many normal sub request. */
-	int32_t				dlh_normal_sub_cnt;
+	int32_t                          dlh_normal_sub_cnt;
 	/* How many delay forward sub request. */
-	int32_t				dlh_delay_sub_cnt;
+	int32_t                          dlh_delay_sub_cnt;
 	/* The index of the first target that forward sub-request to. */
-	int32_t				dlh_forward_idx;
+	int32_t                          dlh_forward_idx;
 	/* The count of the targets that forward sub-request to. */
-	int32_t				dlh_forward_cnt;
+	int32_t                          dlh_forward_cnt;
 	/* Sub transaction handle to manage the dtx leader */
 	struct dtx_sub_status		*dlh_subs;
 };

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -193,6 +193,9 @@ class TelemetryUtils():
         "engine_sched_total_reject",
         *_gen_stats_metrics("engine_sched_cycle_duration"),
         *_gen_stats_metrics("engine_sched_cycle_size")]
+    ENGINE_DTX_METRICS = [
+        "engine_io_dtx_chore_retry",
+        "engine_io_dtx_invalid"]
     ENGINE_DMABUFF_METRICS = [
         "engine_dmabuff_total_chunks",
         "engine_dmabuff_used_chunks_io",
@@ -209,8 +212,6 @@ class TelemetryUtils():
         _gen_stats_metrics("engine_io_dtx_committable")
     ENGINE_IO_DTX_COMMITTED_METRICS = \
         _gen_stats_metrics("engine_io_dtx_committed")
-    ENGINE_IO_DTX_INVALID_METRICS = \
-        _gen_stats_metrics("engine_io_dtx_invalid")
     ENGINE_IO_LATENCY_FETCH_METRICS = \
         _gen_stats_metrics("engine_io_latency_fetch")
     ENGINE_IO_LATENCY_BULK_FETCH_METRICS = \
@@ -314,7 +315,6 @@ class TelemetryUtils():
     ENGINE_IO_METRICS = ENGINE_IO_DTX_ASYNC_CMT_LAT_METRICS +\
         ENGINE_IO_DTX_COMMITTABLE_METRICS +\
         ENGINE_IO_DTX_COMMITTED_METRICS +\
-        ENGINE_IO_DTX_INVALID_METRICS +\
         ENGINE_IO_LATENCY_FETCH_METRICS +\
         ENGINE_IO_LATENCY_BULK_FETCH_METRICS +\
         ENGINE_IO_LATENCY_VOS_FETCH_METRICS +\
@@ -464,6 +464,7 @@ class TelemetryUtils():
         """
         all_metrics_names = list(self.ENGINE_EVENT_METRICS)
         all_metrics_names.extend(self.ENGINE_SCHED_METRICS)
+        all_metrics_names.extend(self.ENGINE_DTX_METRICS)
         all_metrics_names.extend(self.ENGINE_IO_METRICS)
         all_metrics_names.extend(self.ENGINE_NET_METRICS)
         all_metrics_names.extend(self.ENGINE_RANK_METRICS)

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -581,8 +581,8 @@ vos_tls_init(int tags, int xs_id, int tgt_id)
 			D_WARN("Failed to create committed cnt sensor: "DF_RC"\n",
 			       DP_RC(rc));
 
-		rc = d_tm_add_metric(&tls->vtl_invalid_dtx, D_TM_STATS_GAUGE,
-				     "Number of invalid active DTX", "entries",
+		rc = d_tm_add_metric(&tls->vtl_invalid_dtx, D_TM_COUNTER,
+				     "Number of invalid active DTX", NULL,
 				     "io/dtx/invalid/tgt_%u", tgt_id);
 		if (rc)
 			D_WARN("Failed to create invalid DTX cnt sensor: " DF_RC "\n", DP_RC(rc));

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -582,8 +582,8 @@ vos_tls_init(int tags, int xs_id, int tgt_id)
 			       DP_RC(rc));
 
 		rc = d_tm_add_metric(&tls->vtl_invalid_dtx, D_TM_COUNTER,
-				     "Number of invalid active DTX", NULL,
-				     "io/dtx/invalid/tgt_%u", tgt_id);
+				     "Number of invalid active DTX", NULL, "io/dtx/invalid/tgt_%u",
+				     tgt_id);
 		if (rc)
 			D_WARN("Failed to create invalid DTX cnt sensor: " DF_RC "\n", DP_RC(rc));
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -635,12 +635,10 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 	}
 
 	if (rc == -DER_NONEXIST) {
-		struct vos_tls	*tls = vos_tls_get(false);
-
 		D_WARN("DTX record no longer exists, may indicate some corruption: "
 		       DF_DTI " type %u, discard\n",
 		       DP_DTI(&DAE_XID(dae)), dtx_umoff_flag2type(rec));
-		d_tm_inc_gauge(tls->vtl_invalid_dtx, 1);
+		d_tm_inc_counter(vos_tls_get(false)->vtl_invalid_dtx, 1);
 	}
 
 	return rc;


### PR DESCRIPTION
We need to control the in-flight RPCs (via IO chore tasks) count from current target to others. Otherwise, too many in-flight RPCs may occupy a lot of DRAM as to cause out of memory on server.

Introduce new server-side environment DAOS_IO_CHORE_CREDITS to allow admin to configure such credits. The default value is 4096, it may be optimized in the future based on more test results.

Allow-unstable-test: true

### Before requesting gatekeeper:

* [ ] Two review approvals and any prior change requests have been resolved.
* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.

### Gatekeeper:

* [ ] You are the appropriate gatekeeper to be landing the patch.
* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
* [ ] Githooks were used. If not, request that user install them and check copyright dates.
* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
* [ ] If applicable, the PR has addressed any potential version compatibility issues.
* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
* [ ] Extra checks if forced landing is requested
  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
  * [ ] No new NLT or valgrind warnings.  Check the classic view.
  * [ ] Quick-build or Quick-functional is not used.
* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
