### PR TITLE
DAOS-10028 test: Update unit test helper

### DIFF
--- a/src/control/cmd/daos_agent/mgmt_rpc_test.go
+++ b/src/control/cmd/daos_agent/mgmt_rpc_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -632,8 +633,8 @@ func TestAgent_handleSetupClientTelemetry(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
+			parent := test.MustLogContext(t)
+			log := logging.FromContext(parent)
 
 			mod := &mgmtModule{
 				log: log,
@@ -654,7 +655,6 @@ func TestAgent_handleSetupClientTelemetry(t *testing.T) {
 			telemetry.InitTestMetricsProducer(t, int(testID), 2048)
 			defer telemetry.CleanupTestMetricsProducer(t)
 
-			parent := test.MustLogContext(t, log)
 			ctx, err := telemetry.Init(parent, testID)
 			if err != nil {
 				t.Fatal(err)

--- a/src/control/lib/daos/api/container_test.go
+++ b/src/control/lib/daos/api/container_test.go
@@ -197,7 +197,7 @@ func TestAPI_ContainerOpen(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			gotResp, gotErr := ContainerOpen(mustLogCtx(tc.ctx, t), tc.openReq)
+			gotResp, gotErr := ContainerOpen(test.MustLogContext(t, tc.ctx), tc.openReq)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -267,7 +267,7 @@ func TestAPI_ContainerDestroy(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			gotErr := ContainerDestroy(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.contID, false)
+			gotErr := ContainerDestroy(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.contID, false)
 			test.CmpErr(t, tc.expErr, gotErr)
 		})
 	}
@@ -399,7 +399,7 @@ func TestAPI_getContConn(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			ph, cleanup, gotErr := getContConn(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.contID, tc.flags)
+			ph, cleanup, gotErr := getContConn(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.contID, tc.flags)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -509,7 +509,7 @@ func TestAPI_ContainerQuery(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			gotResp, err := ContainerQuery(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.contID)
+			gotResp, err := ContainerQuery(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.contID)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -575,7 +575,7 @@ func TestAPI_ContainerListAttributes(t *testing.T) {
 				tc.setup(t)
 			}
 
-			gotNames, err := ContainerListAttributes(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.contID)
+			gotNames, err := ContainerListAttributes(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.contID)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -684,7 +684,7 @@ func TestAPI_ContainerGetAttributes(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			gotAttrs, err := ContainerGetAttributes(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.contID, tc.attrNames...)
+			gotAttrs, err := ContainerGetAttributes(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.contID, tc.attrNames...)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -745,7 +745,7 @@ func TestAPI_ContainerSetAttributes(t *testing.T) {
 				tc.setup(t)
 			}
 
-			err := ContainerSetAttributes(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.contID, tc.toSet...)
+			err := ContainerSetAttributes(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.contID, tc.toSet...)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -796,7 +796,7 @@ func TestAPI_ContainerDeleteAttributes(t *testing.T) {
 				tc.setup(t)
 			}
 
-			err := ContainerDeleteAttributes(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.contID, tc.toDelete...)
+			err := ContainerDeleteAttributes(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.contID, tc.toDelete...)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return

--- a/src/control/lib/daos/api/pool_test.go
+++ b/src/control/lib/daos/api/pool_test.go
@@ -169,7 +169,7 @@ func TestAPI_PoolConnect(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			gotResp, gotErr := PoolConnect(mustLogCtx(tc.ctx, t), tc.connReq)
+			gotResp, gotErr := PoolConnect(test.MustLogContext(t, tc.ctx), tc.connReq)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -247,7 +247,7 @@ func TestAPI_getPoolConn(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			ph, cleanup, gotErr := getPoolConn(mustLogCtx(ctx, t), "", tc.poolID, tc.flags)
+			ph, cleanup, gotErr := getPoolConn(test.MustLogContext(t, ctx), "", tc.poolID, tc.flags)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
@@ -367,7 +367,7 @@ func TestAPI_PoolQuery(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			gotResp, err := PoolQuery(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.queryMask)
+			gotResp, err := PoolQuery(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.queryMask)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -498,7 +498,7 @@ func TestAPI_PoolQueryTargets(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			gotResp, err := PoolQueryTargets(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.rank, tc.targets)
+			gotResp, err := PoolQueryTargets(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.rank, tc.targets)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -563,7 +563,7 @@ func TestAPI_PoolListAttributes(t *testing.T) {
 				tc.setup(t)
 			}
 
-			gotNames, err := PoolListAttributes(mustLogCtx(tc.ctx, t), "", tc.poolID)
+			gotNames, err := PoolListAttributes(test.MustLogContext(t, tc.ctx), "", tc.poolID)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -671,7 +671,7 @@ func TestAPI_PoolGetAttributes(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			gotAttrs, err := PoolGetAttributes(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.attrNames...)
+			gotAttrs, err := PoolGetAttributes(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.attrNames...)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -731,7 +731,7 @@ func TestAPI_PoolSetAttributes(t *testing.T) {
 				tc.setup(t)
 			}
 
-			err := PoolSetAttributes(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.toSet...)
+			err := PoolSetAttributes(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.toSet...)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -781,7 +781,7 @@ func TestAPI_PoolDeleteAttributes(t *testing.T) {
 				tc.setup(t)
 			}
 
-			err := PoolDeleteAttributes(mustLogCtx(tc.ctx, t), "", tc.poolID, tc.toDelete...)
+			err := PoolDeleteAttributes(test.MustLogContext(t, tc.ctx), "", tc.poolID, tc.toDelete...)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return
@@ -992,7 +992,7 @@ func TestAPI_GetPoolList(t *testing.T) {
 				defer tc.checkParams(t)
 			}
 
-			gotPools, err := GetPoolList(mustLogCtx(tc.ctx, t), tc.req)
+			gotPools, err := GetPoolList(test.MustLogContext(t, tc.ctx), tc.req)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {
 				return

--- a/src/control/lib/daos/api/selftest_test.go
+++ b/src/control/lib/daos/api/selftest_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -16,7 +17,6 @@ import (
 	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
-	"github.com/daos-stack/daos/src/control/logging"
 )
 
 func TestAPI_RunSelfTest(t *testing.T) {
@@ -163,8 +163,6 @@ func TestAPI_RunSelfTest(t *testing.T) {
 			run_self_test_MsEndpoints = nil
 			run_self_test_EndpointLatencies = nil
 			run_self_test_RC = _Ctype_int(tc.self_test_RC)
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
 
 			var sysRanks []ranklist.Rank
 			if len(tc.cfg.EndpointRanks) == 0 {
@@ -188,7 +186,7 @@ func TestAPI_RunSelfTest(t *testing.T) {
 			tgtEps := genEndPoints(tc.cfg.EndpointTags, sysRanks...)
 			run_self_test_EndpointLatencies = genEpLatencies(tc.cfg.Repetitions*uint(len(tgtEps)), tgtEps...)
 
-			ctx := test.MustLogContext(t, log)
+			ctx := test.MustLogContext(t)
 			res, err := RunSelfTest(ctx, tc.cfg)
 			test.CmpErr(t, tc.expErr, err)
 			if tc.expErr != nil {

--- a/src/control/lib/daos/api/util.go
+++ b/src/control/lib/daos/api/util.go
@@ -8,17 +8,13 @@
 package api
 
 import (
-	"context"
-	"testing"
 	"unsafe"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/common/test"
 	"github.com/daos-stack/daos/src/control/lib/daos"
 	"github.com/daos-stack/daos/src/control/lib/ranklist"
-	"github.com/daos-stack/daos/src/control/logging"
 )
 
 /*
@@ -112,21 +108,4 @@ func ranklistFromGo(rs *ranklist.RankSet) *C.d_rank_list_t {
 	}
 
 	return rl
-}
-
-func mustLogCtx(parent context.Context, t *testing.T) context.Context {
-	if parent == nil {
-		return nil
-	}
-
-	log, buf := logging.NewTestLogger(t.Name())
-	t.Cleanup(func() {
-		test.ShowBufferOnFailure(t, buf)
-	})
-
-	ctx, err := logging.ToContext(parent, log)
-	if err != nil {
-		panic(err)
-	}
-	return ctx
 }

--- a/src/control/lib/telemetry/promexp/client_test.go
+++ b/src/control/lib/telemetry/promexp/client_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -151,15 +152,14 @@ func TestPromExp_NewClientCollector(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
-
-			parent := test.MustLogContext(t, log)
+			parent := test.MustLogContext(t)
 			ctx, cs, err := NewClientSource(parent)
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer telemetry.Fini()
+
+			log := logging.FromContext(ctx)
 			result, err := NewClientCollector(ctx, log, cs, tc.opts)
 
 			test.CmpErr(t, tc.expErr, err)

--- a/src/control/lib/telemetry/telemetry_test.go
+++ b/src/control/lib/telemetry/telemetry_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2021-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
@@ -20,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common/test"
-	"github.com/daos-stack/daos/src/control/logging"
 )
 
 func TestTelemetry_Init(t *testing.T) {
@@ -260,10 +260,7 @@ func TestTelemetry_PruneSegments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	log, buf := logging.NewTestLogger(t.Name())
-	defer test.ShowBufferOnFailure(t, buf)
-
-	ctx, err := initClientRoot(test.MustLogContext(t, log), shmID)
+	ctx, err := initClientRoot(test.MustLogContext(t), shmID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -1,5 +1,6 @@
 //
 // (C) Copyright 2020-2024 Intel Corporation.
+// (C) Copyright 2025 Google LLC
 // (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -2114,8 +2115,8 @@ func TestServer_MgmtSvc_SystemDrain(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			log, buf := logging.NewTestLogger(t.Name())
-			defer test.ShowBufferOnFailure(t, buf)
+			ctx := test.MustLogContext(t)
+			log := logging.FromContext(ctx)
 
 			if tc.members == nil {
 				tc.members = system.Members{
@@ -2157,7 +2158,7 @@ func TestServer_MgmtSvc_SystemDrain(t *testing.T) {
 				tc.req.Sys = build.DefaultSystemName
 			}
 
-			gotResp, gotErr := svc.SystemDrain(test.MustLogContext(t, log), tc.req)
+			gotResp, gotErr := svc.SystemDrain(ctx, tc.req)
 			test.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return


### PR DESCRIPTION
Reduce boilerplate in unit tests with test.MustLogContext(), which
takes care of creating a buffer-backed logger, injecting it into
a context, and then logging the contents of the buffer on test
failure.

Signed-off-by: Michael MacDonald <mjmac@google.com>
