### PR TITLE
Merge release/2.6 into google/2.6

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python environment
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
         with:
           python-version: '3'
       - name: Install extra python packages
@@ -86,7 +86,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python environment
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
         with:
           python-version: '3'
       - name: Add parser
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
         with:
           python-version: '3.11'
       - name: Install python packages
@@ -194,7 +194,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python environment
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
         with:
           python-version: '3'
       - name: Install extra python packages

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736  # v2.3.1
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186  # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif
@@ -71,6 +71,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169  # v3.28.0
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d  # v3.28.10
         with:
           sarif_file: results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -58,7 +58,7 @@ jobs:
           trivy-config: 'utils/trivy/trivy.yaml'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169  # v3.28.0
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d  # v3.28.10
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -538,12 +538,13 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz,
 		if (bio_nvme_configured(SMD_DEV_TYPE_META)) {
 			if (flags & BIO_MC_FL_RDB)
 				rc = smd_rdb_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st,
-						     blob_sz);
+						     blob_sz, flags & BIO_MC_FL_RECREATE);
 			else
 				rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st,
-						      blob_sz);
+						      blob_sz, flags & BIO_MC_FL_RECREATE);
 		} else {
-			rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st, blob_sz);
+			rc = smd_pool_add_tgt(uuid, xs_ctxt->bxc_tgt_id, ba->bca_id, st, blob_sz,
+					      flags & BIO_MC_FL_RECREATE);
 		}
 
 		if (rc != 0) {

--- a/src/bio/bio_recovery.c
+++ b/src/bio/bio_recovery.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -148,6 +149,57 @@ bs2bxb(struct bio_blobstore *bbs, struct bio_xs_context *xs_ctxt)
 	return NULL;
 }
 
+static inline int
+pause_health_monitor(struct bio_dev_health *bdh)
+{
+	bdh->bdh_stopping = 1;
+	if (bdh->bdh_inflights > 0)
+		return 1;
+
+	/* Put io channel for health monitor */
+	if (bdh->bdh_io_channel != NULL) {
+		spdk_put_io_channel(bdh->bdh_io_channel);
+		bdh->bdh_io_channel = NULL;
+	}
+
+	/* Close open desc for health monitor */
+	if (bdh->bdh_desc != NULL) {
+		spdk_bdev_close(bdh->bdh_desc);
+		bdh->bdh_desc = NULL;
+	}
+
+	return 0;
+}
+
+static inline int
+resume_health_monitor(struct bio_bdev *d_bdev, struct bio_dev_health *bdh)
+{
+	int rc;
+
+	/* Acquire open desc for health monitor */
+	if (bdh->bdh_desc == NULL) {
+		rc = spdk_bdev_open_ext(d_bdev->bb_name, true, bio_bdev_event_cb, NULL,
+					&bdh->bdh_desc);
+		if (rc != 0) {
+			D_ERROR("Failed to open bdev %s, rc:%d\n", d_bdev->bb_name, rc);
+			return 1;
+		}
+		D_ASSERT(bdh->bdh_desc != NULL);
+	}
+
+	/* Get io channel for health monitor */
+	if (bdh->bdh_io_channel == NULL) {
+		bdh->bdh_io_channel = spdk_bdev_get_io_channel(bdh->bdh_desc);
+		if (bdh->bdh_io_channel == NULL) {
+			D_ERROR("Failed to get health channel for bdev %s\n", d_bdev->bb_name);
+			return 1;
+		}
+	}
+
+	bdh->bdh_stopping = 0;
+	return 0;
+}
+
 /*
  * Return value:	0:  Blobstore is torn down;
  *			>0: Blobstore teardown is in progress;
@@ -192,17 +244,9 @@ on_teardown(struct bio_blobstore *bbs)
 	if (rc)
 		return rc;
 
-	/* Put io channel for health monitor */
-	if (bdh->bdh_io_channel != NULL) {
-		spdk_put_io_channel(bdh->bdh_io_channel);
-		bdh->bdh_io_channel = NULL;
-	}
-
-	/* Close open desc for health monitor */
-	if (bdh->bdh_desc != NULL) {
-		spdk_bdev_close(bdh->bdh_desc);
-		bdh->bdh_desc = NULL;
-	}
+	rc = pause_health_monitor(bdh);
+	if (rc)
+		return rc;
 
 	/*
 	 * Unload the blobstore. The blobstore could be still in loading from
@@ -346,27 +390,9 @@ on_setup(struct bio_blobstore *bbs)
 	return 1;
 
 bs_loaded:
-	/* Acquire open desc for health monitor */
-	if (bdh->bdh_desc == NULL) {
-		rc = spdk_bdev_open_ext(d_bdev->bb_name, true,
-					bio_bdev_event_cb, NULL,
-					&bdh->bdh_desc);
-		if (rc != 0) {
-			D_ERROR("Failed to open bdev %s, for %p, %d\n",
-				d_bdev->bb_name, bbs, rc);
-			return 1;
-		}
-		D_ASSERT(bdh->bdh_desc != NULL);
-	}
-
-	/* Get io channel for health monitor */
-	if (bdh->bdh_io_channel == NULL) {
-		bdh->bdh_io_channel = spdk_bdev_get_io_channel(bdh->bdh_desc);
-		if (bdh->bdh_io_channel == NULL) {
-			D_ERROR("Failed to get health channel for %p\n", bbs);
-			return 1;
-		}
-	}
+	rc = resume_health_monitor(d_bdev, bdh);
+	if (rc)
+		return rc;
 
 	/*
 	 * It's safe to access xs context array without locking when the

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -48,7 +48,8 @@ smd_pool_find_tgt(struct smd_pool *pool, int tgt_id)
 }
 
 static int
-pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name, uint64_t blob_sz)
+pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name, uint64_t blob_sz,
+	     bool recreate)
 {
 	struct smd_pool	pool;
 	struct d_uuid	id;
@@ -87,7 +88,8 @@ pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name
 		pool.sp_tgts[pool.sp_tgt_cnt] = tgt_id;
 		pool.sp_blobs[pool.sp_tgt_cnt] = blob_id;
 		pool.sp_tgt_cnt += 1;
-		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX))
+		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX) &&
+		    !recreate)
 			pool.sp_flags |= SMD_POOL_IN_CREATION;
 
 	} else if (rc == -DER_NONEXIST) {
@@ -96,7 +98,8 @@ pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, char *table_name
 		pool.sp_tgt_cnt	 = 1;
 		pool.sp_blob_sz  = blob_sz;
 		pool.sp_flags = 0;
-		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX))
+		if (!strncmp(table_name, TABLE_POOLS[SMD_DEV_TYPE_META], SMD_DEV_NAME_MAX) &&
+		    !recreate)
 			pool.sp_flags |= SMD_POOL_IN_CREATION;
 
 	} else {
@@ -117,17 +120,17 @@ out:
 }
 
 int
-smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		 enum smd_dev_type st, uint64_t blob_sz)
+smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, enum smd_dev_type st,
+		 uint64_t blob_sz, bool recreate)
 {
-	return pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_POOLS[st], blob_sz);
+	return pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_POOLS[st], blob_sz, recreate);
 }
 
 int
-smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		enum smd_dev_type st, uint64_t blob_sz)
+smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, enum smd_dev_type st,
+		uint64_t blob_sz, bool recreate)
 {
-	return pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_RDBS[st], blob_sz);
+	return pool_add_tgt(pool_id, tgt_id, blob_id, TABLE_RDBS[st], blob_sz, recreate);
 }
 
 static int

--- a/src/bio/smd/tests/smd_ut.c
+++ b/src/bio/smd/tests/smd_ut.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2023 Intel Corporation.
+ * (C) Copyright 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -359,29 +359,29 @@ ut_pool(void **state)
 
 	for (i = 0; i < 6; i++) {
 		st = (i < 4) ? SMD_DEV_TYPE_DATA : SMD_DEV_TYPE_DATA + i - 3;
-		rc = smd_pool_add_tgt(id1, i, i << 10, st, 100);
+		rc = smd_pool_add_tgt(id1, i, i << 10, st, 100, false);
 		assert_rc_equal(rc, 0);
 
-		rc = smd_pool_add_tgt(id2, i, i << 20, st, 200);
+		rc = smd_pool_add_tgt(id2, i, i << 20, st, 200, false);
 		assert_rc_equal(rc, 0);
 	}
 
-	rc = smd_pool_add_tgt(id1, 0, 5000, SMD_DEV_TYPE_DATA, 100);
+	rc = smd_pool_add_tgt(id1, 0, 5000, SMD_DEV_TYPE_DATA, 100, false);
 	assert_rc_equal(rc, -DER_EXIST);
 
-	rc = smd_pool_add_tgt(id1, 4, 4 << 10, SMD_DEV_TYPE_DATA, 200);
+	rc = smd_pool_add_tgt(id1, 4, 4 << 10, SMD_DEV_TYPE_DATA, 200, false);
 	assert_rc_equal(rc, -DER_INVAL);
 
-	rc = smd_pool_add_tgt(id1, 4, 5000, SMD_DEV_TYPE_META, 100);
+	rc = smd_pool_add_tgt(id1, 4, 5000, SMD_DEV_TYPE_META, 100, false);
 	assert_rc_equal(rc, -DER_EXIST);
 
-	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_META, 200);
+	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_META, 200, false);
 	assert_rc_equal(rc, -DER_INVAL);
 
-	rc = smd_pool_add_tgt(id1, 5, 5000, SMD_DEV_TYPE_WAL, 100);
+	rc = smd_pool_add_tgt(id1, 5, 5000, SMD_DEV_TYPE_WAL, 100, false);
 	assert_rc_equal(rc, -DER_EXIST);
 
-	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_WAL, 200);
+	rc = smd_pool_add_tgt(id1, 0, 4 << 10, SMD_DEV_TYPE_WAL, 200, false);
 	assert_rc_equal(rc, -DER_INVAL);
 
 	rc = smd_pool_get_info(id1, &pool_info);

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -533,8 +533,8 @@ crt_rpc_complete_and_unlock(struct crt_rpc_priv *rpc_priv, int rc)
 			cbinfo.cci_rc = rpc_priv->crp_reply_hdr.cch_rc;
 
 		if (cbinfo.cci_rc != 0)
-			RPC_CERROR(crt_quiet_error(cbinfo.cci_rc), DB_NET, rpc_priv,
-				   "failed, " DF_RC "\n", DP_RC(cbinfo.cci_rc));
+			RPC_CWARN(crt_quiet_error(cbinfo.cci_rc), DB_NET, rpc_priv,
+				  "failed, " DF_RC "\n", DP_RC(cbinfo.cci_rc));
 
 		RPC_TRACE(DB_TRACE, rpc_priv,
 			  "Invoking RPC callback (rank %d tag %d) rc: "
@@ -1205,9 +1205,7 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 	struct d_binheap_node		*bh_node;
 	d_list_t			 timeout_list;
 	uint64_t			 ts_now;
-	bool                             should_republish = false;
-	int                              err_to_print  = 0;
-	int                              left_to_print = 0;
+	bool                             print_once = false;
 
 	D_ASSERT(crt_ctx != NULL);
 
@@ -1232,65 +1230,34 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 		D_ASSERTF(d_list_empty(&rpc_priv->crp_tmp_link_timeout),
 			  "already on timeout list\n");
 		d_list_add_tail(&rpc_priv->crp_tmp_link_timeout, &timeout_list);
-	};
-
-	/* piggy-back on the timeout processing so that we don't need to do another gettime() */
-	if (ts_now - crt_ctx->cc_hg_ctx.chc_diag_pub_ts > CRT_HG_TM_PUB_INTERVAL_US) {
-		should_republish                   = true;
-		crt_ctx->cc_hg_ctx.chc_diag_pub_ts = ts_now;
 	}
 	D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
-
-	/* Limit logging when many rpcs time-out at the same time */
-	d_list_for_each_entry(rpc_priv, &timeout_list, crp_tmp_link_timeout) {
-		left_to_print++;
-	}
-
-	/* TODO: might expose via env in future */
-	err_to_print = 1;
 
 	/* handle the timeout RPCs */
 	while ((rpc_priv =
 		    d_list_pop_entry(&timeout_list, struct crt_rpc_priv, crp_tmp_link_timeout))) {
-		/*
-		 * This error is annoying and fills the logs. For now prevent bursts of timeouts
-		 * happening at the same time.
-		 *
-		 * Ideally we would also limit to 1 error per target. Can keep track of it in per
-		 * target cache used for hg_addrs.
-		 *
-		 * Extra lookup cost of cache entry would be ok as this is an error case
-		 **/
+		/* NB: The reason that the error message is printed at INFO
+		 * level is because the user should know how serious the error
+		 * is and they will print the RPC error at appropriate level */
+		if (!print_once) {
+			print_once = true;
 
-		if (err_to_print > 0) {
-			RPC_ERROR(rpc_priv,
-				  "ctx_id %d, (status: %#x) timed out (%d seconds), "
-				  "target (%d:%d)\n",
-				  crt_ctx->cc_idx, rpc_priv->crp_state, rpc_priv->crp_timeout_sec,
-				  rpc_priv->crp_pub.cr_ep.ep_rank, rpc_priv->crp_pub.cr_ep.ep_tag);
-			err_to_print--;
-			left_to_print--;
-
-			if (err_to_print == 0 && left_to_print > 0)
-				D_ERROR(" %d more rpcs timed out. rest logged at INFO level\n",
-					left_to_print);
-
+			RPC_WARN(rpc_priv,
+				 "ctx_id %d, (status: %#x) timed out (%d seconds), "
+				 "target (%d:%d)\n",
+				 crt_ctx->cc_idx, rpc_priv->crp_state, rpc_priv->crp_timeout_sec,
+				 rpc_priv->crp_pub.cr_ep.ep_rank, rpc_priv->crp_pub.cr_ep.ep_tag);
 		} else {
 			RPC_INFO(rpc_priv,
 				 "ctx_id %d, (status: %#x) timed out (%d seconds), "
 				 "target (%d:%d)\n",
 				 crt_ctx->cc_idx, rpc_priv->crp_state, rpc_priv->crp_timeout_sec,
 				 rpc_priv->crp_pub.cr_ep.ep_rank, rpc_priv->crp_pub.cr_ep.ep_tag);
-			left_to_print--;
 		}
 
 		crt_req_timeout_hdlr(rpc_priv);
 		RPC_DECREF(rpc_priv);
 	}
-
-	/* periodically republish Mercury-level counters as DAOS metrics */
-	if (should_republish)
-		crt_hg_republish_diags(&crt_ctx->cc_hg_ctx);
 }
 
 /*

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1268,9 +1268,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	else
 		rc = crt_corpc_common_hdlr(rpc_priv);
 	if (unlikely(rc != 0)) {
-		RPC_ERROR(rpc_priv,
-			  "failed to invoke RPC handler, rc: "DF_RC"\n",
-			  DP_RC(rc));
+		RPC_INFO(rpc_priv, "failed to invoke RPC handler, rc: " DF_RC "\n", DP_RC(rc));
 		crt_hg_reply_error_send(rpc_priv, rc);
 		D_GOTO(decref, hg_ret = HG_SUCCESS);
 	}
@@ -1478,8 +1476,8 @@ out:
 		crt_cbinfo.cci_rc = rc;
 
 		if (crt_cbinfo.cci_rc != 0)
-			RPC_CERROR(crt_quiet_error(crt_cbinfo.cci_rc), DB_NET, rpc_priv,
-				   "RPC failed; rc: " DF_RC "\n", DP_RC(crt_cbinfo.cci_rc));
+			RPC_CWARN(crt_quiet_error(crt_cbinfo.cci_rc), DB_NET, rpc_priv,
+				  "RPC failed; rc: " DF_RC "\n", DP_RC(crt_cbinfo.cci_rc));
 
 		RPC_TRACE(DB_TRACE, rpc_priv,
 			  "Invoking RPC callback (rank %d tag %d) rc: " DF_RC "\n",

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -712,14 +712,10 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 
 		rc2 = rpc_priv->crp_reply_hdr.cch_rc;
 		if (rc2 != 0) {
-			if (rpc_priv->crp_reply_hdr.cch_rc != -DER_GRPVER)
-				RPC_ERROR(rpc_priv,
-					  "RPC failed to execute on target. "
-					  "error code: "DF_RC"\n", DP_RC(rc2));
-			else
-				RPC_TRACE(DB_NET, rpc_priv,
-					  "RPC failed to execute on target. "
-					  "error code: "DF_RC"\n", DP_RC(rc2));
+			RPC_CWARN(crt_quiet_error(rc2), DB_NET, rpc_priv,
+				  "RPC failed to execute on target. "
+				  "error code: " DF_RC "\n",
+				  DP_RC(rc2));
 
 			D_GOTO(out, rc);
 		}

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -95,6 +95,14 @@
 			RPC_ERROR(rpc, fmt, ## __VA_ARGS__);		\
 	} while (0)
 
+#define RPC_CWARN(cond, mask, rpc, fmt, ...)                                                       \
+	do {                                                                                       \
+		if (cond)                                                                          \
+			RPC_TRACE(mask, rpc, fmt, ##__VA_ARGS__);                                  \
+		else                                                                               \
+			RPC_WARN(rpc, fmt, ##__VA_ARGS__);                                         \
+	} while (0)
+
 #ifdef CRT_DEBUG_TRACE
 #	define CRT_ENTRY()					\
 		D_DEBUG(DB_TRACE, ">>>> Entered %s: %d\n", __func__, __LINE__)

--- a/src/cart/crt_register.c
+++ b/src/cart/crt_register.c
@@ -546,8 +546,8 @@ proto_query_cb(const struct crt_cb_info *cb_info)
 	D_FREE(rpc_req_input->pq_ver.iov_buf);
 
 	if (cb_info->cci_rc != 0) {
-		D_ERROR("rpc (opc: %#x) failed: "DF_RC"\n", rpc_req->cr_opc,
-			DP_RC(cb_info->cci_rc));
+		D_WARN("rpc (opc: %#x) failed: " DF_RC "\n", rpc_req->cr_opc,
+		       DP_RC(cb_info->cci_rc));
 		D_GOTO(out, user_cb_info.pq_rc = cb_info->cci_rc);
 	}
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -891,8 +891,8 @@ uri_lookup_cb(const struct crt_cb_info *cb_info)
 	ul_out = crt_reply_get(lookup_rpc);
 
 	if (ul_out->ul_rc != 0) {
-		RPC_ERROR(chained_rpc_priv, "URI_LOOKUP returned rc="DF_RC"\n",
-			  DP_RC(ul_out->ul_rc));
+		RPC_WARN(chained_rpc_priv, "URI_LOOKUP returned rc=" DF_RC "\n",
+			 DP_RC(ul_out->ul_rc));
 		D_GOTO(retry, rc = ul_out->ul_rc);
 	}
 
@@ -977,8 +977,8 @@ retry:
 								chained_rpc_priv);
 				D_GOTO(out, rc);
 			} else {
-				D_ERROR("URI lookups exceeded %d retries\n",
-					chained_rpc_priv->crp_ul_retry);
+				D_WARN("URI lookups exceeded %d retries\n",
+				       chained_rpc_priv->crp_ul_retry);
 			}
 		} else {
 			DL_INFO(rc, "URI_LOOKUP for (%d:%d) failed during PROTO_QUERY",

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1,6 +1,7 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
  * (C) Copyright 2025 Google LLC
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -180,7 +181,7 @@ dtx_free_dbca(struct dtx_batched_cont_args *dbca)
 static inline uint64_t
 dtx_sec2age(uint64_t sec)
 {
-	uint64_t	cur = daos_gettime_coarse();
+	uint64_t	cur = daos_wallclock_secs();
 
 	if (unlikely(cur <= sec))
 		return 0;

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2018-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -937,7 +937,8 @@ int bio_copy(struct bio_io_context *ioctxt, struct umem_instance *umem,
 	     struct bio_csum_desc *csum_desc);
 
 enum bio_mc_flags {
-	BIO_MC_FL_RDB		= (1UL << 0),	/* for RDB */
+	BIO_MC_FL_RDB      = (1UL << 0), /* for RDB */
+	BIO_MC_FL_RECREATE = (1UL << 1), /* to identify recreate (e.g., in replace op) */
 };
 
 /*

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -809,5 +810,17 @@ evt_feats_get(struct evt_root *root)
  * \return 0 on success
  */
 int  evt_feats_set(struct evt_root *root, struct umem_instance *umm, uint64_t feats);
+
+/** Validate the provided evt.
+ *
+ * Note: It is designed for catastrophic recovery. Not to perform at run-time.
+ *
+ * \param evt[in]
+ * \param dtx_lid[in]	local id of the DTX entry the evt is supposed to belong to
+ *
+ * \return true if evt is valid.
+ **/
+bool
+evt_desc_is_valid(const struct evt_desc *evt, uint32_t dtx_lid);
 
 #endif /* __DAOS_EV_TREE_H__ */

--- a/src/include/daos_srv/smd.h
+++ b/src/include/daos_srv/smd.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2016-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -170,15 +170,18 @@ int smd_dev_replace(uuid_t old_id, uuid_t new_id, unsigned int old_roles);
  * \param [IN]	blob_id		Blob ID
  * \param [IN]	smd_type	SMD type
  * \param [IN]	blob_sz		Blob size
+ * \param [IN]  recreate    is recreate (in replace) or not
  *
  * \return			Zero on success, negative value on error
  */
-int smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		     enum smd_dev_type smd_type, uint64_t blob_sz);
+int
+smd_pool_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, enum smd_dev_type smd_type,
+		 uint64_t blob_sz, bool recreate);
 
 /* Assign a blob to a RDB pool target */
-int smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id,
-		    enum smd_dev_type smd_type, uint64_t blob_sz);
+int
+      smd_rdb_add_tgt(uuid_t pool_id, uint32_t tgt_id, uint64_t blob_id, enum smd_dev_type smd_type,
+		      uint64_t blob_sz, bool recreate);
 
 /**
  * Unassign a VOS pool target

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2024 Intel Corporation.
+ * (C) Copyright 2015-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -93,6 +93,8 @@ enum vos_pool_open_flags {
 	VOS_POF_FOR_CHECK_QUERY = (1 << 6),
 	/** Open the pool for feature fetch/update, that will skip VEA load */
 	VOS_POF_FOR_FEATURE_FLAG = (1 << 7),
+	/** To identify this is a recreate operation. */
+	VOS_POF_FOR_RECREATE = (1 << 8),
 };
 
 enum vos_oi_attr {

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -436,8 +437,9 @@ jtc_set_status_on_target(struct jm_test_ctx *ctx, const int status,
 	tgts.pti_ids = &tgt_id;
 	tgts.pti_number = 1;
 
-	int rc = ds_pool_map_tgts_update(ctx->po_map, &tgts, pool_opc_2map_opc(status),
-					 false, &ctx->ver, ctx->enable_print_debug_msgs);
+	int rc = ds_pool_map_tgts_update(NULL /* pool_uuid */, ctx->po_map, &tgts,
+					 pool_opc_2map_opc(status), false, &ctx->ver,
+					 ctx->enable_print_debug_msgs);
 
 	/* Make sure pool map changed */
 	assert_success(rc);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2122,11 +2122,11 @@ pool_svc_check_node_status(struct pool_svc *svc)
 }
 
 /*
- * Log a NOTE of as well as print a message. Arguments may be evaluated more
+ * Log as well as print a message. Arguments may be evaluated more
  * than once.
  */
-#define DS_POOL_NOTE_PRINT(fmt, ...) do {							\
-	D_NOTE(fmt, ## __VA_ARGS__);								\
+#define DS_POOL_LOG_PRINT(log, fmt, ...) do {							\
+	D_##log(fmt, ## __VA_ARGS__);								\
 	D_PRINT(fmt, ## __VA_ARGS__);								\
 } while (0)
 
@@ -2379,9 +2379,10 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 		D_GOTO(out, rc);
 	}
 
-	DS_POOL_NOTE_PRINT(DF_UUID": rank %u became pool service leader "DF_U64": srv_pool_hdl="
-			   DF_UUID" srv_cont_hdl="DF_UUID"\n", DP_UUID(svc->ps_uuid), rank,
-			   svc->ps_rsvc.s_term, DP_UUID(pool_hdl_uuid), DP_UUID(cont_hdl_uuid));
+	DS_POOL_LOG_PRINT(NOTE, DF_UUID": rank %u became pool service leader "DF_U64
+			  ": srv_pool_hdl="DF_UUID" srv_cont_hdl="DF_UUID"\n",
+			  DP_UUID(svc->ps_uuid), rank, svc->ps_rsvc.s_term, DP_UUID(pool_hdl_uuid),
+			  DP_UUID(cont_hdl_uuid));
 out:
 	if (rc != 0) {
 		if (events_initialized)
@@ -2400,9 +2401,9 @@ out:
 		 * Step up with the error anyway, so that RPCs to the PS
 		 * receive an error instead of timeouts.
 		 */
-		DS_POOL_NOTE_PRINT(DF_UUID": rank %u became pool service leader "DF_U64
-				   " with error: "DF_RC"\n", DP_UUID(svc->ps_uuid), rank,
-				   svc->ps_rsvc.s_term, DP_RC(svc->ps_error));
+		DS_POOL_LOG_PRINT(NOTE, DF_UUID": rank %u became pool service leader "DF_U64
+				  " with error: "DF_RC"\n", DP_UUID(svc->ps_uuid), rank,
+				  svc->ps_rsvc.s_term, DP_RC(svc->ps_error));
 		rc = 0;
 	}
 	return rc;
@@ -2420,12 +2421,12 @@ pool_svc_step_down_cb(struct ds_rsvc *rsvc)
 		sched_cancel_and_wait(&svc->ps_reconf_sched);
 		sched_cancel_and_wait(&svc->ps_rfcheck_sched);
 		ds_cont_svc_step_down(svc->ps_cont_svc);
-		DS_POOL_NOTE_PRINT(DF_UUID": rank %u no longer pool service leader "DF_U64"\n",
-				   DP_UUID(svc->ps_uuid), rank, svc->ps_rsvc.s_term);
+		DS_POOL_LOG_PRINT(NOTE, DF_UUID": rank %u no longer pool service leader "DF_U64"\n",
+				  DP_UUID(svc->ps_uuid), rank, svc->ps_rsvc.s_term);
 	} else {
-		DS_POOL_NOTE_PRINT(DF_UUID": rank %u no longer pool service leader "DF_U64
-				   " with error: "DF_RC"\n", DP_UUID(svc->ps_uuid), rank,
-				   svc->ps_rsvc.s_term, DP_RC(svc->ps_error));
+		DS_POOL_LOG_PRINT(NOTE, DF_UUID": rank %u no longer pool service leader "DF_U64
+				  " with error: "DF_RC"\n", DP_UUID(svc->ps_uuid), rank,
+				  svc->ps_rsvc.s_term, DP_RC(svc->ps_error));
 		svc->ps_error = 0;
 	}
 }
@@ -7041,7 +7042,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 	 * before and after. If the version hasn't changed, we are done.
 	 */
 	map_version_before = pool_map_get_version(map);
-	rc = ds_pool_map_tgts_update(map, tgts, opc, exclude_rank, tgt_map_ver, true);
+	rc = ds_pool_map_tgts_update(svc->ps_uuid, map, tgts, opc, exclude_rank, tgt_map_ver, true);
 	if (rc != 0)
 		D_GOTO(out_map, rc);
 	map_version = pool_map_get_version(map);
@@ -7135,6 +7136,8 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 		goto out_map_buf;
 	}
 
+	DS_POOL_LOG_PRINT(INFO, DF_UUID ": committed pool map: version=%u->%u map=%p\n",
+			  DP_UUID(svc->ps_uuid), map_version_before, map_version, map);
 	updated = true;
 
 	/* Update svc->ps_pool to match the new pool map. */

--- a/src/pool/srv_pool_map.h
+++ b/src/pool/srv_pool_map.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2021 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  *
@@ -8,7 +9,7 @@
 #ifndef DAOS_SRV_POOL_MAP_H
 #define DAOS_SRV_POOL_MAP_H
 int
-ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
+ds_pool_map_tgts_update(uuid_t pool_uuid, struct pool_map *map, struct pool_target_id_list *tgts,
 			int opc, bool evict_rank, uint32_t *tgt_map_ver,
 			bool print_changes);
 #endif /* DAOS_SRV_POOL_MAP_H */

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2016-2025 Intel Corporation.
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -448,7 +448,7 @@ pool_child_recreate(struct ds_pool_child *child)
 	}
 
 	rc = vos_pool_create(path, child->spc_uuid, 0, pool_info->spi_blob_sz[SMD_DEV_TYPE_DATA],
-			     0, 0 /* version */, NULL);
+			     VOS_POF_FOR_RECREATE /* flags */, 0 /* version */, NULL);
 	if (rc)
 		DL_ERROR(rc, DF_UUID": Create VOS pool failed.", DP_UUID(child->spc_uuid));
 

--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.py
@@ -1,5 +1,6 @@
 '''
-  (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 '''
@@ -14,11 +15,6 @@ class EcodOnlineRebuildMdtest(ErasureCodeMdtest):
 
     :avocado: recursive
     """
-    def __init__(self, *args, **kwargs):
-        """Initialize a EcOnlineRebuild object."""
-        super().__init__(*args, **kwargs)
-        self.set_online_rebuild = True
-
     def test_ec_online_rebuild_mdtest(self):
         """Jira ID: DAOS-7320.
 
@@ -35,13 +31,6 @@ class EcodOnlineRebuildMdtest(ErasureCodeMdtest):
         :avocado: tags=ec,ec_array,mdtest,ec_online_rebuild
         :avocado: tags=EcodOnlineRebuildMdtest,test_ec_online_rebuild_mdtest
         """
-        # Kill last server rank
-        self.rank_to_kill = self.server_count - 1
-
-        # Run only object type which matches the server count and
-        # remove other objects
-        for oclass in self.obj_class:
-            if oclass[1] == self.server_count:
-                self.obj_class = oclass[0]
-
-        self.start_online_mdtest()
+        # Stop one random rank while mdtest is running
+        ranks_to_stop = self.random.sample(list(self.server_managers[0].ranks), k=1)
+        self.start_online_mdtest(ranks_to_stop)

--- a/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
+++ b/src/tests/ftest/erasurecode/online_rebuild_mdtest.yaml
@@ -7,7 +7,7 @@ hosts:
     12_server:
       test_servers: server-[1-6]
   test_clients: 2
-timeout: 1000
+timeout: 1500
 setup:
   start_agents_once: False
   start_servers_once: False
@@ -21,6 +21,7 @@ server_config:
       fabric_iface: ib0
       fabric_iface_port: 31416
       log_file: daos_server0.log
+      log_mask: ERR
       storage: auto
     1:
       pinned_numa_node: 1
@@ -28,6 +29,7 @@ server_config:
       fabric_iface: ib1
       fabric_iface_port: 31517
       log_file: daos_server1.log
+      log_mask: ERR
       storage: auto
 pool:
   control_method: dmg
@@ -38,26 +40,29 @@ container:
   properties: rd_fac:2
 mdtest:
   client_processes:
-    np_48:
-      np: 48
-      num_of_files_dirs: 200
-  mdtest_api:
-    dfs:
-      api: 'DFS'
-  test_dir: "/"
-  iteration: 4
+    np: 4
+  api: DFS
+  test_dir: /
   dfs_destroy: True
-  manager: "MPICH"
-  flags: "-u"
-  write_bytes: 4194304
-  read_bytes: 4194304
+  manager: MPICH
+  flags: "-u -F -C"
+  write_bytes: 524288
+  read_bytes: 524288
   depth: 10
+  num_of_files_dirs: 10000000
+  stonewall_timer: 30
   # EC does not supported for directory so for now running with RP
-  dfs_dir_oclass: "RP_3G1"
-  objectclass:
-    dfs_oclass_list:
-      #- [EC_Object_Class, Exact number of servers]
-      - ["EC_2P2GX", 6]
-      - ["EC_4P2GX", 8]
-      - ["EC_4P3GX", 12]
-      - ["EC_8P2GX", 12]
+  dfs_dir_oclass: RP_3G1
+  dfs_oclass_mux: !mux
+    6_server_ec2p2gx:
+      !filter-only : "/run/hosts/servers/6_server"  # yamllint disable-line rule:colons
+      dfs_oclass: EC_2P2GX
+    8_server_ec4p2gx:
+      !filter-only : "/run/hosts/servers/8_server"  # yamllint disable-line rule:colons
+      dfs_oclass: EC_4P2GX
+    12_server_ec4p3gx:
+      !filter-only : "/run/hosts/servers/12_server"  # yamllint disable-line rule:colons
+      dfs_oclass: EC_4P3GX
+    12_server_ec8p2gx:
+      !filter-only : "/run/hosts/servers/12_server"  # yamllint disable-line rule:colons
+      dfs_oclass: EC_8P2GX

--- a/src/tests/ftest/util/ec_utils.py
+++ b/src/tests/ftest/util/ec_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -413,56 +414,53 @@ class ErasureCodeSingle(TestWithServers):
 class ErasureCodeMdtest(MdtestBase):
     """Class to used for EC testing for MDtest Benchmark."""
 
-    def __init__(self, *args, **kwargs):
-        """Initialize a MdtestBase object."""
-        super().__init__(*args, **kwargs)
-        self.server_count = None
-        self.set_online_rebuild = False
-        self.rank_to_kill = None
-        self.obj_class = None
-
     def setUp(self):
         """Set up each test case."""
         super().setUp()
-        engine_count = self.server_managers[0].get_config_value("engines_per_host")
-        self.server_count = len(self.hostlist_servers) * engine_count
-        self.obj_class = self.params.get("dfs_oclass_list", '/run/mdtest/objectclass/*')
         # Create Pool
         self.add_pool()
+        self.container = None
         self.out_queue = queue.Queue()
 
-    def write_single_mdtest_dataset(self):
-        """Run MDtest with EC object type."""
-        # Update the MDtest obj class
-        self.mdtest_cmd.dfs_oclass.update(self.obj_class)
+    def _start_execute_mdtest(self, mdtest_result_queue):
+        """Run the execute_mdtest method
 
-        # Write the MDtest data
-        self.execute_mdtest(self.out_queue)
-
-    def start_online_mdtest(self):
-        """Run MDtest operation with thread in background.
-
-        Trigger the server failure while MDtest is running
+        Args:
+            mdtest_result_queue(Queue) : Queue for passing errors.
+        Returns:
+            result(object) : mdtest run result
         """
+        try:
+            result = self.execute_mdtest(mdtest_result_queue)
+        except Exception:  # pylint: disable=broad-except
+            mdtest_result_queue.put('Mdtest Failed')
+        return result
+
+    def start_online_mdtest(self, ranks_to_stop):
+        """Run mdtest and stop ranks while mdtest is running.
+
+        Args:
+            ranks_to_stop (list): ranks to stop while mdtest is running
+        """
+        # Create the container and check the status
+        self.container = self.get_mdtest_container(self.pool)
         # Create the MDtest run thread
-        job = threading.Thread(target=self.write_single_mdtest_dataset)
+        job = threading.Thread(
+            target=self._start_execute_mdtest,
+            kwargs={"mdtest_result_queue": self.out_queue})
 
         # Launch the MDtest thread
         job.start()
 
-        # Kill the server rank while IO operation in progress
-        if self.set_online_rebuild:
-            time.sleep(30)
-            # Kill the server rank
-            if self.rank_to_kill is not None:
-                self.server_managers[0].stop_ranks([self.rank_to_kill],
-                                                   self.d_log,
-                                                   force=True)
+        # Stop the server ranks while IO operation in progress
+        time.sleep(self.mdtest_cmd.stonewall_timer.value / 2)
+        self.server_managers[0].stop_ranks(ranks_to_stop, self.d_log, force=True)
 
         # Wait to finish the thread
         job.join()
 
         # Verify the queue result and make sure test has no failure
         while not self.out_queue.empty():
-            if self.out_queue.get() == "Mdtest Failed":
-                self.fail("FAIL")
+            result = self.out_queue.get()
+            if result == "Mdtest Failed":
+                self.fail(result)

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -1,5 +1,6 @@
 """
 (C) Copyright 2021-2024 Intel Corporation.
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 (C) Copyright 2025 Google LLC
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -208,6 +209,8 @@ class TelemetryUtils():
         _gen_stats_metrics("engine_io_dtx_committable")
     ENGINE_IO_DTX_COMMITTED_METRICS = \
         _gen_stats_metrics("engine_io_dtx_committed")
+    ENGINE_IO_DTX_INVALID_METRICS = \
+        _gen_stats_metrics("engine_io_dtx_invalid")
     ENGINE_IO_LATENCY_FETCH_METRICS = \
         _gen_stats_metrics("engine_io_latency_fetch")
     ENGINE_IO_LATENCY_BULK_FETCH_METRICS = \
@@ -311,6 +314,7 @@ class TelemetryUtils():
     ENGINE_IO_METRICS = ENGINE_IO_DTX_ASYNC_CMT_LAT_METRICS +\
         ENGINE_IO_DTX_COMMITTABLE_METRICS +\
         ENGINE_IO_DTX_COMMITTED_METRICS +\
+        ENGINE_IO_DTX_INVALID_METRICS +\
         ENGINE_IO_LATENCY_FETCH_METRICS +\
         ENGINE_IO_LATENCY_BULK_FETCH_METRICS +\
         ENGINE_IO_LATENCY_VOS_FETCH_METRICS +\

--- a/src/utils/ddb/ddb_vos.c
+++ b/src/utils/ddb/ddb_vos.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2022-2024 Intel Corporation.
+ * (C) Copyright 2022-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1774,8 +1774,8 @@ sync_cb(struct ddbs_sync_info *info, void *cb_args)
 		/* Ignore error for now ... might not exist*/
 		D_WARN("delete target failed: " DF_RC "\n", DP_RC(rc));
 
-	rc = smd_pool_add_tgt(pool_id, info->dsi_hdr->bbh_vos_id,
-			      info->dsi_hdr->bbh_blob_id, st, blob_size);
+	rc = smd_pool_add_tgt(pool_id, info->dsi_hdr->bbh_vos_id, info->dsi_hdr->bbh_blob_id, st,
+			      blob_size, false);
 	if (!SUCCESS(rc)) {
 		D_ERROR("add target failed: "DF_RC"\n", DP_RC(rc));
 		args->sync_rc = rc;

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2017-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -115,7 +117,6 @@ struct evt_context {
 	umem_off2ptr(evt_umm(tcx), offset)
 
 #define EVT_NODE_MAGIC 0xf00d
-#define EVT_DESC_MAGIC 0xbeefdead
 
 /** Convert an offset to a evtree node descriptor
  * \param[IN]	tcx	Tree context

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -4086,3 +4087,12 @@ evt_feats_set(struct evt_root *root, struct umem_instance *umm, uint64_t feats)
 	return rc;
 }
 
+bool
+evt_desc_is_valid(const struct evt_desc *evt, uint32_t dtx_lid)
+{
+	if (evt == NULL || evt->dc_magic != EVT_DESC_MAGIC) {
+		return false;
+	}
+
+	return (evt->dc_dtx == dtx_lid);
+}

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -390,16 +392,18 @@ ilog_create(struct umem_instance *umm, struct ilog_df *root)
 	return rc;
 }
 
-#define ILOG_ASSERT_VALID(root_df)					\
-	do {								\
-		struct ilog_root	*_root;				\
-									\
-		_root = (struct ilog_root *)(root_df);			\
-		D_ASSERTF((_root != NULL) &&				\
-			  ILOG_MAGIC_VALID(_root->lr_magic),		\
-			  "Invalid ilog root detected %p magic=%#x\n",	\
-			  _root, _root == NULL ? 0 : _root->lr_magic);	\
-	} while (0)
+#define ILOG_CHECK_VALID(root_df)                                                                  \
+	({                                                                                         \
+		struct ilog_root *_root = NULL;                                                    \
+		D_ASSERT((root_df) != NULL);                                                       \
+		_root = (struct ilog_root *)(root_df);                                             \
+		if (!ILOG_MAGIC_VALID(_root->lr_magic)) {                                          \
+			D_WARN("Invalid ilog root detected %p magic=%#x\n", _root,                 \
+			       _root == NULL ? 0 : _root->lr_magic);                               \
+			_root = NULL;                                                              \
+		}                                                                                  \
+		_root != NULL;                                                                     \
+	})
 
 int
 ilog_open(struct umem_instance *umm, struct ilog_df *root,
@@ -408,7 +412,8 @@ ilog_open(struct umem_instance *umm, struct ilog_df *root,
 	struct ilog_context	*lctx;
 	int			 rc;
 
-	ILOG_ASSERT_VALID(root);
+	if (!ILOG_CHECK_VALID(root))
+		return -DER_NONEXIST;
 
 	rc = ilog_ctx_create(umm, (struct ilog_root *)root, cbs, &lctx);
 	if (rc != 0)
@@ -474,7 +479,7 @@ ilog_destroy(struct umem_instance *umm,
 	int			 rc = 0;
 	struct ilog_array_cache	 cache = {0};
 
-	ILOG_ASSERT_VALID(root);
+	D_ASSERT(ILOG_CHECK_VALID(root));
 
 	rc = ilog_tx_begin(&lctx);
 	if (rc != 0) {
@@ -984,8 +989,12 @@ done:
 		"%s in incarnation log " DF_X64 " status: rc=" DF_RC " tree_version: %d\n",
 		opc_str[opc], id_in->id_epoch, DP_RC(rc), ilog_mag2ver(lctx->ic_root->lr_magic));
 
-	if (rc == 0 && version != ilog_mag2ver(lctx->ic_root->lr_magic) &&
-	    (opc == ILOG_OP_PERSIST || opc == ILOG_OP_ABORT)) {
+	if (rc == 0 && opc != ILOG_OP_UPDATE) {
+		if (version == ilog_mag2ver(lctx->ic_root->lr_magic)) {
+			D_WARN("ilog entry on %s doesn't exist\n", opc_str[opc]);
+			return -DER_NONEXIST;
+		}
+
 		/** If we persisted or aborted an entry successfully,
 		 *  invoke the callback, if applicable but without
 		 *  deregistration
@@ -1213,7 +1222,7 @@ ilog_fetch(struct umem_instance *umm, struct ilog_df *root_df,
 	int			 rc = 0;
 	bool			 retry;
 
-	ILOG_ASSERT_VALID(root_df);
+	D_ASSERT(ILOG_CHECK_VALID(root_df));
 
 	root = (struct ilog_root *)root_df;
 
@@ -1539,7 +1548,7 @@ ilog_aggregate(struct umem_instance *umm, struct ilog_df *ilog,
 
 	root = lctx->ic_root;
 
-	ILOG_ASSERT_VALID(root);
+	D_ASSERT(ILOG_CHECK_VALID(root));
 
 	D_ASSERT(!ilog_empty(root)); /* ilog_fetch should have failed */
 

--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2020-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -216,7 +217,8 @@ lrua_lookup_idx(struct lru_array *array, uint32_t idx, uint64_t key,
 
 	entry = &sub->ls_table[ent_idx];
 	if (entry->le_key == key) {
-		if (touch_mru && !array->la_evicting) {
+		if (touch_mru && !array->la_evicting &&
+		    !(array->la_flags & LRU_FLAG_EVICT_MANUAL)) {
 			/** Only make mru if we are not evicting it */
 			lrua_move_to_mru(array, sub, entry, ent_idx);
 		}

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -530,6 +532,12 @@ ilog_test_update(void **state)
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
 	assert_rc_equal(rc, 0);
 
+	/* Test non-existent tx */
+	id.id_epoch = epoch;
+	id.id_tx_id = current_tx_id.id_tx_id + 4000;
+	rc          = ilog_persist(loh, &id);
+	assert_rc_equal(rc, -DER_NONEXIST);
+
 	/* Commit the punch ilog. */
 	id.id_epoch = epoch;
 	id.id_tx_id = current_tx_id.id_tx_id;
@@ -668,6 +676,12 @@ ilog_test_abort(void **state)
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
 	assert_rc_equal(rc, 0);
 
+	/* Test non-existent tx */
+	id = current_tx_id;
+	id.id_tx_id += 400;
+	rc = ilog_abort(loh, &id);
+	assert_rc_equal(rc, -DER_NONEXIST);
+
 	id = current_tx_id;
 	rc = ilog_abort(loh, &id);
 	LOG_FAIL(rc, 0, "Failed to abort log entry\n");
@@ -734,6 +748,11 @@ ilog_test_abort(void **state)
 	ilog_close(loh);
 	rc = ilog_destroy(umm, &ilog_callbacks, ilog);
 	assert_rc_equal(rc, 0);
+
+	/** Test open of "reallocated" ilog */
+	memset(ilog, 0xa1, sizeof(*ilog));
+	rc = ilog_open(umm, ilog, &ilog_callbacks, false, &loh);
+	assert_rc_equal(rc, -DER_NONEXIST);
 
 	assert_true(d_list_empty(&fake_tx_list));
 	ilog_free_root(umm, ilog);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -581,6 +581,12 @@ vos_tls_init(int tags, int xs_id, int tgt_id)
 			D_WARN("Failed to create committed cnt sensor: "DF_RC"\n",
 			       DP_RC(rc));
 
+		rc = d_tm_add_metric(&tls->vtl_invalid_dtx, D_TM_STATS_GAUGE,
+				     "Number of invalid active DTX", "entries",
+				     "io/dtx/invalid/tgt_%u", tgt_id);
+		if (rc)
+			D_WARN("Failed to create invalid DTX cnt sensor: " DF_RC "\n", DP_RC(rc));
+
 		rc = d_tm_add_metric(&tls->vtl_obj_cnt, D_TM_GAUGE,
 				     "Number of cached vos object", "entry",
 				     "mem/vos/vos_obj_%u/tgt_%u",

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1,6 +1,7 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -39,8 +40,8 @@ enum {
 			D_ASSERT(dae->dae_dth->dth_ent == dae);				\
 			dae->dae_dth->dth_ent = NULL;					\
 		}									\
-		D_DEBUG(DB_TRACE, "Evicting lid "DF_DTI": lid=%lx\n",			\
-			DP_DTI(&DAE_XID(dae)), DAE_LID(dae) & DTX_LID_SOLO_MASK);	\
+		D_DEBUG(DB_IO, "Evicting DTX "DF_DTI": lid=%x\n",			\
+			DP_DTI(&DAE_XID(dae)), DAE_LID(dae));				\
 		d_list_del_init(&dae->dae_link);					\
 		lrua_evictx(cont->vc_dtx_array,						\
 			    (DAE_LID(dae) & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,	\
@@ -215,6 +216,7 @@ dtx_act_ent_cleanup(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 	D_FREE(dae->dae_records);
 	dae->dae_rec_cap = 0;
 	DAE_REC_CNT(dae) = 0;
+	dae->dae_need_release = 0;
 
 	if (!keep_df) {
 		dae->dae_df_off = UMOFF_NULL;
@@ -573,7 +575,7 @@ dtx_ilog_rec_release(struct umem_instance *umm, struct vos_container *cont,
 
 	ilog_close(loh);
 
-	if (rc != 0)
+	if (rc != 0 && rc != -DER_NONEXIST)
 		D_ERROR("Failed to release ilog rec for "DF_DTI", abort %s: "DF_RC"\n",
 			DP_DTI(&DAE_XID(dae)), abort ? "yes" : "no", DP_RC(rc));
 
@@ -598,6 +600,12 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 		struct vos_irec_df	*svt;
 
 		svt = umem_off2ptr(umm, umem_off2offset(rec));
+
+		if (!vos_irec_is_valid(svt, DAE_LID(dae))) {
+			rc = -DER_NONEXIST;
+			break;
+		}
+
 		if (abort) {
 			if (DAE_INDEX(dae) != DTX_INDEX_INVAL) {
 				rc = umem_tx_add_ptr(umm, &svt->ir_dtx,
@@ -621,6 +629,12 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 		struct evt_desc		*evt;
 
 		evt = umem_off2ptr(umm, umem_off2offset(rec));
+
+		if (!evt_desc_is_valid(evt, DAE_LID(dae))) {
+			rc = -DER_NONEXIST;
+			break;
+		}
+
 		if (abort) {
 			if (DAE_INDEX(dae) != DTX_INDEX_INVAL) {
 				rc = umem_tx_add_ptr(umm, &evt->dc_dtx,
@@ -648,6 +662,15 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 		break;
 	}
 
+	if (unlikely(rc == -DER_NONEXIST)) {
+		struct vos_tls	*tls = vos_tls_get(false);
+
+		D_WARN("DTX record no longer exists, may indicate some corruption: "
+		       DF_DTI " type %u, discard\n",
+		       DP_DTI(&DAE_XID(dae)), dtx_umoff_flag2type(rec));
+		d_tm_inc_gauge(tls->vtl_invalid_dtx, 1);
+	}
+
 	return rc;
 }
 
@@ -657,6 +680,7 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool ab
 	struct umem_instance		*umm = vos_cont2umm(cont);
 	struct vos_dtx_act_ent_df	*dae_df;
 	struct vos_dtx_blob_df		*dbd;
+	bool				 invalid = false;
 	int				 count;
 	int				 i;
 	int				 rc = 0;
@@ -685,42 +709,52 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool ab
 		   abort ? "abort" : "commit", DP_DTI(&DAE_XID(dae)), dbd,
 		   DP_UUID(cont->vc_pool->vp_id), DP_UUID(cont->vc_id));
 
-	if (dae->dae_records != NULL) {
+	/* Handle DTX records as FIFO order to find out potential invalid DTX earlier. */
+
+	if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT)
+		count = DTX_INLINE_REC_CNT;
+	else
+		count = DAE_REC_CNT(dae);
+
+	for (i = 0; i < count; i++) {
+		rc = do_dtx_rec_release(umm, cont, dae, DAE_REC_INLINE(dae)[i], abort);
+		if (unlikely(rc == -DER_NONEXIST)) {
+			invalid = true;
+			break;
+		}
+		if (rc != 0)
+			return rc;
+	}
+
+	if (!invalid && dae->dae_records != NULL) {
 		D_ASSERT(DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT);
 		D_ASSERT(!UMOFF_IS_NULL(dae_df->dae_rec_off));
 
-		for (i = DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT - 1; i >= 0; i--) {
+		for (i = 0; i < DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT; i++) {
 			rc = do_dtx_rec_release(umm, cont, dae, dae->dae_records[i], abort);
+			if (unlikely(rc == -DER_NONEXIST)) {
+				invalid = true;
+				break;
+			}
 			if (rc != 0)
 				return rc;
 		}
+	}
 
+	if (!UMOFF_IS_NULL(dae_df->dae_rec_off)) {
 		rc = umem_free(umm, dae_df->dae_rec_off);
 		if (rc != 0)
 			return rc;
 
-		if (keep_act) {
+		if (!invalid && keep_act) {
 			rc = umem_tx_add_ptr(umm, &dae_df->dae_rec_off, sizeof(dae_df->dae_rec_off));
 			if (rc != 0)
 				return rc;
-
 			dae_df->dae_rec_off = UMOFF_NULL;
 		}
-
-		count = DTX_INLINE_REC_CNT;
-	} else {
-		D_ASSERT(DAE_REC_CNT(dae) <= DTX_INLINE_REC_CNT);
-
-		count = DAE_REC_CNT(dae);
 	}
 
-	for (i = count - 1; i >= 0; i--) {
-		rc = do_dtx_rec_release(umm, cont, dae, DAE_REC_INLINE(dae)[i], abort);
-		if (rc != 0)
-			return rc;
-	}
-
-	if (keep_act) {
+	if (!invalid && keep_act) {
 		/* When re-commit partial committed DTX, the count can be zero. */
 		if (dae_df->dae_rec_cnt > 0) {
 			rc = umem_tx_add_ptr(umm, &dae_df->dae_rec_cnt,
@@ -746,6 +780,9 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool ab
 
 		return 0;
 	}
+
+	if (invalid)
+		rc = 0;
 
 	if (!UMOFF_IS_NULL(dae_df->dae_mbs_off)) {
 		/* dae_mbs_off will be invalid via flag DTE_INVALID. */
@@ -817,9 +854,6 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae, bool ab
 			  UMOFF_P(dbd_off), DP_UUID(cont->vc_id));
 	}
 
-	if (rc == 0)
-		dae->dae_need_release = 0;
-
 	return rc;
 }
 
@@ -886,6 +920,14 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 		 */
 		if (dae->dae_committing)
 			D_GOTO(out, rc = -DER_ALREADY);
+	} else {
+		struct dtx_handle	*dth = vos_dth_get(cont->vc_pool->vp_sysdb);
+
+		D_ASSERT(dtx_is_valid_handle(dth));
+		D_ASSERT(dth->dth_ent != NULL);
+		D_ASSERT(dth->dth_solo);
+
+		dae = dth->dth_ent;
 	}
 
 	/* Generate committed DTX entry when it is not required to keep the active DTX entry. */
@@ -895,22 +937,8 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti, daos_epoch_t 
 			D_GOTO(out, rc = -DER_NOMEM);
 
 		DCE_CMT_TIME(dce) = cmt_time;
-		if (dae != NULL) {
-			DCE_XID(dce) = DAE_XID(dae);
-			DCE_EPOCH(dce) = DAE_EPOCH(dae);
-		} else {
-			struct dtx_handle	*dth = vos_dth_get(false);
-
-			D_ASSERT(!cont->vc_pool->vp_sysdb);
-			D_ASSERT(dtx_is_valid_handle(dth));
-			D_ASSERT(dth->dth_solo);
-
-			dae = dth->dth_ent;
-			D_ASSERT(dae != NULL);
-
-			DCE_XID(dce) = *dti;
-			DCE_EPOCH(dce) = dth->dth_epoch;
-		}
+		DCE_XID(dce) = DAE_XID(dae);
+		DCE_EPOCH(dce) = DAE_EPOCH(dae);
 
 		d_iov_set(&riov, dce, sizeof(*dce));
 		rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
@@ -1077,15 +1105,15 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 	DAE_INDEX(dae) = DTX_INDEX_INVAL;
 	dae->dae_dth = dth;
 
-	D_DEBUG(DB_IO, "Allocated new lid DTX: "DF_DTI" lid=%lx, dae=%p\n",
-		DP_DTI(&dth->dth_xid), DAE_LID(dae) & DTX_LID_SOLO_MASK, dae);
+	D_DEBUG(DB_IO, "Allocated new DTX " DF_DTI ", lid=%x, epoch " DF_U64 ", dae=%p\n",
+		DP_DTI(&dth->dth_xid), DAE_LID(dae), DAE_EPOCH(dae), dae);
 
 	d_iov_set(&kiov, &DAE_XID(dae), sizeof(DAE_XID(dae)));
 	d_iov_set(&riov, dae, sizeof(*dae));
 	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov, NULL);
 	if (rc == 0) {
-		dae->dae_start_time = daos_gettime_coarse();
+		dae->dae_start_time = daos_wallclock_secs();
 		d_list_add_tail(&dae->dae_link, &cont->vc_dtx_act_list);
 		dth->dth_ent = dae;
 	} else {
@@ -1224,17 +1252,8 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 
 	found = lrua_lookupx(cont->vc_dtx_array, (entry & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED,
 			     epoch, &dae);
-	if (!found) {
-		D_ASSERTF(!(entry & DTX_LID_SOLO_FLAG),
-			  "non-committed solo entry %lu must be there, epoch "DF_X64", boundary "
-			  DF_X64"\n", entry & DTX_LID_SOLO_MASK, epoch, cont->vc_solo_dtx_epoch);
-
-		D_DEBUG(DB_TRACE,
-			"Entry %d "DF_U64" not in lru array, it must be committed\n",
-			entry, epoch);
-
-		return ALB_AVAILABLE_CLEAN;
-	}
+	D_ASSERTF(found, "Non-committed DTX must be in active table: lid=%x, epoch="
+		  DF_U64 ", boundary " DF_U64 "\n", entry, epoch, cont->vc_solo_dtx_epoch);
 
 	if (intent == DAOS_INTENT_PURGE) {
 		uint32_t	age = d_hlc_age2sec(DAE_XID(dae).dti_hlc);
@@ -1623,15 +1642,10 @@ vos_dtx_deregister_record(struct umem_instance *umm, daos_handle_t coh,
 	if (!vos_dtx_is_normal_entry(entry))
 		return 0;
 
-	D_ASSERT(entry >= DTX_LID_RESERVED);
-
-	found = lrua_lookupx(vos_hdl2cont(coh)->vc_dtx_array, entry - DTX_LID_RESERVED,
-			     epoch, &dae);
-	if (!found) {
-		D_WARN("Could not find active DTX record for lid=%d, epoch="
-		       DF_U64"\n", entry, epoch);
-		return 0;
-	}
+	found = lrua_lookupx(vos_hdl2cont(coh)->vc_dtx_array,
+			     (entry & DTX_LID_SOLO_MASK) - DTX_LID_RESERVED, epoch, &dae);
+	D_ASSERTF(found, "Could not find active DTX record for lid=%x, epoch=" DF_U64 "\n",
+		  entry, epoch);
 
 	/*
 	 * NOTE: If the record to be deregistered (for free or overwrite, and so on) is referenced
@@ -2063,7 +2077,7 @@ vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id dtis[],
 	struct vos_dtx_blob_df		*dbd;
 	struct vos_dtx_blob_df		*dbd_prev;
 	umem_off_t			 dbd_off;
-	uint64_t			 cmt_time = daos_gettime_coarse();
+	uint64_t			 cmt_time = daos_wallclock_secs();
 	int				 committed = 0;
 	int				 rc = 0;
 	int				 p = 0;
@@ -2816,7 +2830,7 @@ vos_dtx_act_reindex(struct vos_container *cont)
 	umem_off_t			 dbd_off = cont_df->cd_dtx_active_head;
 	d_iov_t				 kiov;
 	d_iov_t				 riov;
-	uint64_t			 start_time = daos_gettime_coarse();
+	uint64_t			 start_time = daos_wallclock_secs();
 	int				 rc = 0;
 	int				 i;
 

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -427,6 +429,7 @@ update:
 
 	vos_ilog_desc_cbs_init(&cbs, vos_cont2hdl(cont));
 	rc = ilog_open(vos_cont2umm(cont), ilog, &cbs, dth == NULL, &loh);
+	D_ASSERTF(rc != -DER_NONEXIST, "Uncorrectable incarnation log corruption detected");
 	if (rc != 0) {
 		D_ERROR("Could not open incarnation log: "DF_RC"\n", DP_RC(rc));
 		return rc;
@@ -522,6 +525,7 @@ vos_ilog_punch_(struct vos_container *cont, struct ilog_df *ilog,
 punch_log:
 	vos_ilog_desc_cbs_init(&cbs, vos_cont2hdl(cont));
 	rc = ilog_open(vos_cont2umm(cont), ilog, &cbs, dth == NULL, &loh);
+	D_ASSERTF(rc != -DER_NONEXIST, "Uncorrectable incarnation log corruption detected");
 	if (rc != 0) {
 		D_ERROR("Could not open incarnation log: "DF_RC"\n", DP_RC(rc));
 		return rc;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1,6 +1,7 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -453,6 +454,8 @@ struct vos_dtx_cmt_ent {
 #define DCE_XID(dce)		((dce)->dce_base.dce_xid)
 #define DCE_EPOCH(dce)		((dce)->dce_base.dce_epoch)
 #define DCE_CMT_TIME(dce)	((dce)->dce_base.dce_cmt_time)
+
+#define EVT_DESC_MAGIC          0xbeefdead
 
 extern uint64_t vos_evt_feats;
 
@@ -1857,5 +1860,17 @@ vos_io_scm(struct vos_pool *pool, daos_iod_type_t type, daos_size_t size, enum v
  */
 int
 vos_insert_oid(struct dtx_handle *dth, struct vos_container *cont, daos_unit_oid_t *oid);
+
+/** Validate the provided svt.
+ *
+ * Note: It is designed for catastrophic recovery. Not to perform at run-time.
+ *
+ * \param svt[in]
+ * \param dtx_lid[in]	local id of the DTX entry the evt is supposed to belong to
+ *
+ * \return true if svt is valid.
+ **/
+bool
+vos_irec_is_valid(const struct vos_irec_df *svt, uint32_t dtx_lid);
 
 #endif /* __VOS_INTERNAL_H__ */

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -1,5 +1,7 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -289,6 +291,7 @@ do_log:
 		goto skip_log;
 	vos_ilog_desc_cbs_init(&cbs, vos_cont2hdl(cont));
 	rc = ilog_open(vos_cont2umm(cont), &obj->vo_ilog, &cbs, dth == NULL, &loh);
+	D_ASSERTF(rc != -DER_NONEXIST, "Uncorrectable incarnation log corruption detected");
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2016-2025 Intel Corporation.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -663,6 +663,9 @@ vos2mc_flags(unsigned int vos_flags)
 
 	if (vos_flags & VOS_POF_RDB)
 		mc_flags |= BIO_MC_FL_RDB;
+
+	if (vos_flags & VOS_POF_FOR_RECREATE)
+		mc_flags |= BIO_MC_FL_RECREATE;
 
 	return mc_flags;
 }

--- a/src/vos/vos_tls.h
+++ b/src/vos/vos_tls.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -63,6 +64,7 @@ struct vos_tls {
 		bool			 vtl_hash_set;
 	};
 	struct d_tm_node_t		 *vtl_committed;
+	struct d_tm_node_t		 *vtl_invalid_dtx;
 	struct d_tm_node_t		 *vtl_obj_cnt;
 	struct d_tm_node_t		 *vtl_lru_alloc_size;
 };

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP.
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1291,4 +1292,14 @@ obj_tree_find_attr(unsigned tree_class, int flags)
 		if (ta->ta_class == VOS_BTR_END)
 			return NULL;
 	}
+}
+
+bool
+vos_irec_is_valid(const struct vos_irec_df *svt, uint32_t dtx_lid)
+{
+	if (svt == NULL) {
+		return false;
+	}
+
+	return svt->ir_dtx == dtx_lid;
 }


### PR DESCRIPTION
- **DAOS-16876 vos: discard invalid DTX when commit or abort - b26 (#15901)**
- **DAOS-17045 bio: drain inflight health collecting on teardown (#15884) (#15922)**
- **DAOS-16978 vos: fix issue in VOS pool recreation on faulty device replacing (#15938)**
- **DAOS-16464 test: improve online_rebuild_mdtest.py (#15108) (#15807)**
- **DAOS-16902 pool: Polish map change logging (#15744) (#15917)**
- **DAOS-16876 dtx: misc fixes for DTX related logic - b26 (#15941)**
- **DAOS-16824 cart: lower error messages to warn level (#15529) (#15893)**
- ** DAOS-17155 cq: bump gha-versions (#15959)**
