### PR TITLE
DAOS-17094: container: restore ULT stack sizes, revert pr15832

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1753,7 +1753,7 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 
 	rc = ds_pool_thread_collective(pool_uuid,
 				       PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT,
-				       cont_open_one, &arg, DSS_ULT_DEEP_STACK);
+				       cont_open_one, &arg, 0);
 	if (rc != 0)
 		/* Once it exclude the target from the pool, since the target
 		 * might still in the cart group, so IV cont open might still
@@ -2061,7 +2061,7 @@ ds_cont_tgt_snapshots_update(uuid_t pool_uuid, uuid_t cont_uuid,
 	 */
 	return ds_pool_thread_collective(
 	    pool_uuid, PO_COMP_ST_NEW | PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT | PO_COMP_ST_UP,
-	    cont_snap_update_one, &args, DSS_ULT_DEEP_STACK);
+	    cont_snap_update_one, &args, 0);
 }
 
 void

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -2200,7 +2200,7 @@ ds_pool_tgt_prop_update(struct ds_pool *pool, struct pool_iv_prop *iv_prop)
 
 	ret = ds_pool_thread_collective(pool->sp_uuid,
 					PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT | PO_COMP_ST_NEW,
-					update_vos_prop_on_targets, &arg, DSS_ULT_DEEP_STACK);
+					update_vos_prop_on_targets, &arg, 0);
 	if (ret != 0)
 		return ret;
 


### PR DESCRIPTION
Revert "DAOS-16768 pool: larger ABT ULT stack sizes (#15832)"

This reverts commit 08cc2cd6b709a6aaad7d6dfa7c570cbde6196057.

Features: pool container

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
