### PR TITLE
DAOS-17153 il:  library should populate fstype (#15953)

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -3546,6 +3546,7 @@ statfs(const char *pathname, struct statfs *sfs)
 	sfs->f_files  = -1;
 	sfs->f_ffree  = -1;
 	sfs->f_bavail = sfs->f_bfree;
+	sfs->f_type   = DAOS_SUPER_MAGIC;
 
 	drec_decref(dfs_mt->dcache, parent);
 	FREE(parent_dir);
@@ -3603,6 +3604,7 @@ fstatfs(int fd, struct statfs *sfs)
 	sfs->f_files  = -1;
 	sfs->f_ffree  = -1;
 	sfs->f_bavail = sfs->f_bfree;
+	sfs->f_type   = DAOS_SUPER_MAGIC;
 
 	return 0;
 }
@@ -3654,6 +3656,7 @@ statvfs(const char *pathname, struct statvfs *svfs)
 	svfs->f_files  = -1;
 	svfs->f_ffree  = -1;
 	svfs->f_bavail = svfs->f_bfree;
+	svfs->f_fsid   = DAOS_SUPER_MAGIC;
 
 	drec_decref(dfs_mt->dcache, parent);
 	FREE(parent_dir);

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -43,6 +43,8 @@ extern "C" {
 #define DFS_MAX_XATTR_NAME	255
 /** Maximum xattr value */
 #define DFS_MAX_XATTR_LEN	65536
+/** Magic number identifier for statfs and related routines */
+#define DAOS_SUPER_MAGIC        0xDA05AD10
 
 /** File/Directory/Symlink object handle struct */
 typedef struct dfs_obj dfs_obj_t;


### PR DESCRIPTION
Many file systems advertise what they are through the 'f_fsid' field of struct stat.  While DAOS typically uses dFUSE (which advertises itself as FUSE), it's possible to access DAOS through other means.

The pil4dfs interception library intercepts the statfs() call but doesn't completely populate it, leaving the f_fsid field zero.  This commit populates that field.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
