### PR TITLE
DAOS-16362 pydaos: add batch read for checkpoints (#15921)

### DIFF
--- a/src/client/pydaos/torch/torch_api.py
+++ b/src/client/pydaos/torch/torch_api.py
@@ -7,6 +7,8 @@
 """
 torch module provides implementation for PyTorch Map-Style and Iterable Style Datasets
 to access training data on DAOS DFS via POSIX container.
+
+In addition, it provides Checkpoint class to save and load PyTorch model checkpoints.
 """
 
 import io
@@ -25,6 +27,8 @@ ITER_BATCH_SIZE = 32
 READDIR_BATCH_SIZE = 128
 PARALLEL_SCAN_WORKERS = 16
 DIR_CACHE_SIZE = 64 * 1024
+DEFAULT_CHUNK_SIZE = 64 * 1024 * 1024
+DEFAULT_CHUNKS_LIMIT = 1024 // DEFAULT_CHUNK_SIZE
 
 
 def transform_fn_default(data):
@@ -434,10 +438,12 @@ class Checkpoint():
     file_chunk_size : int (optional)
         Chunk size to be used for checkpoint files, default is 0.
     transfer_chunk_size : int (optional)
-        Chunk size for data buffering/transfer, default is 0, which means no chunking:
-        All writes go to in memory buffer and actual flush to storage will happen on close() call.
+        Chunk size for data buffering/transfer, default is DEFAULT_CHUNK_SIZE = 64MB.
+        To disable chunking set it to 0, then all writes go to in memory buffer
+        and actual flush to storage will happen on close() call.
     chunks_limits: int (optional)
-        Number of chunks to be used for buffering and transfer, default is 0, which means no limit.
+        Number of chunks to be used for buffering and transfer.
+        Setting it to 0 means no limit.
         It's used only when transfer_chunk_size is set to non-zero value and provides the mechanism
         to limit memory usage.
     workers: int (optional)
@@ -446,10 +452,11 @@ class Checkpoint():
 
     Methods
     -------
-    reader(fname):
+    reader(file, stream=None):
         Reads the checkpoint file and returns its content as BytesIO object.
+        Optionally, the stream can be provided to read the data into it.
 
-    writer(fname):
+    writer(file):
         Returns write buffer to save the checkpoint file.
     """
 
@@ -459,8 +466,8 @@ class Checkpoint():
                  open_flags=os.O_CREAT | os.O_RDWR,
                  class_name="OC_UNKNOWN",
                  file_chunk_size=0,
-                 transfer_chunk_size=0,
-                 chunks_limit=0,
+                 transfer_chunk_size=DEFAULT_CHUNK_SIZE,
+                 chunks_limit=DEFAULT_CHUNKS_LIMIT,
                  workers=4,
                  ):
         self._pool = pool
@@ -483,26 +490,55 @@ class Checkpoint():
         self._dfs.disconnect()
         self._dfs = None
 
-    def reader(self, fname):
-        """ Reads the checkpoint file and returns its content as BytesIO object """
+    def reader(self, file, stream=None):
+        """
+        Reads the checkpoint file and returns its content as BytesIO object.
+        Alternatively, the stream can be provided to read the data into it, this might
+        be useful for large checkpoints that can't fit into memory.
+        """
 
-        if fname is None:
-            raise ValueError("fname is required")
+        if file is None:
+            raise ValueError("file is required")
 
-        fpath = os.path.join(self._prefix, fname)
+        if stream is None:
+            stream = io.BytesIO()
 
-        size = self._dfs.get_file_size(fpath)
-        buf = self._dfs.read(fpath, size)
-        return io.BytesIO(buf)
+        path = os.path.join(self._prefix, file)
+        size = self._dfs.get_file_size(path)
 
-    def writer(self, fname):
+        chunks_limit = self._chunks_limit
+        if chunks_limit == 0:
+            chunks_limit = size // DEFAULT_CHUNK_SIZE
+
+        # in case the file is smaller than the default chunk size
+        if chunks_limit == 0:
+            chunks_limit = 1
+
+        chunk_size = self._transfer_chunk_size
+        if chunk_size == 0:
+            # In case we don't have chunking, we read the file in one go
+            chunk_size = size
+            chunks_limit = 1
+
+        chunks = [(path, min(chunk_size, size - offset), offset)
+                  for offset in range(0, size, chunk_size)]
+
+        for i in range(0, len(chunks), chunks_limit):
+            batch = chunks[i:i + chunks_limit]
+            for data in self._dfs.batch_read(batch):
+                stream.write(data)
+
+        stream.seek(0)
+        return stream
+
+    def writer(self, file):
         """ Returns write buffer to save the checkpoint file """
 
-        if fname is None:
-            raise ValueError("fname is required")
+        if file is None:
+            raise ValueError("file is required")
 
-        fpath = os.path.join(self._prefix, fname)
-        return WriteBuffer(self._dfs, fpath, self._mode, self._oflags,
+        path = os.path.join(self._prefix, file)
+        return WriteBuffer(self._dfs, path, self._mode, self._oflags,
                            self._class_name, self._file_chunk_size, self._transfer_chunk_size,
                            self._chunks_limit, self._workers)
 
@@ -571,7 +607,7 @@ class _Dfs():
             # Even if there are no dirs, we should emit the tuple to notify the main process
             out_dirs.put((1, dirs))
 
-            files = [(os.path.join(path, fname), size) for (fname, size) in files]
+            files = [(os.path.join(path, file), size) for (file, size) in files]
             result.extend(files)
 
         out_files.put(result)
@@ -657,9 +693,14 @@ class _Dfs():
             raise OSError(ret, os.strerror(ret), path)
 
     def batch_read(self, items):
-        """ parallel read of multiple files """
+        """
+        Parallel read of multiple files with their sizes and optional offsets.
+        It expects list of tuples (path, size, [offset]) and returns list of buffers
+        with data read from the storage.
+        The result list is in the same order as the input list.
+        """
 
-        to_read = [(item[0], bytearray(item[1])) for item in items]
+        to_read = [(item[0], bytearray(item[1]), item[2] if len(item) > 2 else 0) for item in items]
         ret = torch_shim.torch_batch_read(DAOS_MAGIC, self._dfs, to_read)
 
         if ret != 0:

--- a/src/client/pydaos/torch/torch_api.py
+++ b/src/client/pydaos/torch/torch_api.py
@@ -24,6 +24,7 @@ from . import DAOS_MAGIC, DaosClient, torch_shim
 ITER_BATCH_SIZE = 32
 READDIR_BATCH_SIZE = 128
 PARALLEL_SCAN_WORKERS = 16
+DIR_CACHE_SIZE = 64 * 1024
 
 
 def transform_fn_default(data):
@@ -56,6 +57,8 @@ class Dataset(TorchDataset):
         Function to transform samples from storage to in-memory representation
     readdir_batch_size: int (optional)
         Number of directory entries to read for each readdir call.
+    dir_cache_size: int (optional)
+        Number of directory object entries to cache in memory.
 
 
     Methods
@@ -78,12 +81,13 @@ class Dataset(TorchDataset):
     # pylint: disable=too-many-arguments
     def __init__(self, pool=None, cont=None, path=None,
                  transform_fn=transform_fn_default,
-                 readdir_batch_size=READDIR_BATCH_SIZE):
+                 readdir_batch_size=READDIR_BATCH_SIZE,
+                 dir_cache_size=DIR_CACHE_SIZE):
         super().__init__()
 
         self._pool = pool
         self._cont = cont
-        self._dfs = _Dfs(pool=pool, cont=cont)
+        self._dfs = _Dfs(pool=pool, cont=cont, dir_cache_size=dir_cache_size)
         self._transform_fn = transform_fn
         self._readdir_batch_size = readdir_batch_size
 
@@ -171,6 +175,8 @@ class IterableDataset(TorchIterableDataset):
         Number of directory entries to read for each readdir call.
     batch_size: int (optional)
         Number of samples to fetch per iteration.
+    dir_cache_size: int (optional)
+        Number of directory object entries to cache in memory.
 
 
     Methods
@@ -187,12 +193,13 @@ class IterableDataset(TorchIterableDataset):
     def __init__(self, pool=None, cont=None, path=None,
                  transform_fn=transform_fn_default,
                  readdir_batch_size=READDIR_BATCH_SIZE,
-                 batch_size=ITER_BATCH_SIZE):
+                 batch_size=ITER_BATCH_SIZE,
+                 dir_cache_size=DIR_CACHE_SIZE):
         super().__init__()
 
         self._pool = pool
         self._cont = cont
-        self._dfs = _Dfs(pool=pool, cont=cont)
+        self._dfs = _Dfs(pool=pool, cont=cont, dir_cache_size=dir_cache_size)
         self._transform_fn = transform_fn
         self._readdir_batch_size = readdir_batch_size
         self._batch_size = batch_size
@@ -506,14 +513,14 @@ class _Dfs():
     Should not be used directly.
     """
 
-    def __init__(self, pool=None, cont=None, rd_only=True):
+    def __init__(self, pool=None, cont=None, rd_only=True, dir_cache_size=DIR_CACHE_SIZE):
         if pool is None:
             raise ValueError("pool label or UUID is required")
         if cont is None:
             raise ValueError("container label or UUID is required")
 
         self._dc = DaosClient()
-        (ret, dfs) = torch_shim.torch_connect(DAOS_MAGIC, pool, cont, rd_only)
+        (ret, dfs) = torch_shim.torch_connect(DAOS_MAGIC, pool, cont, rd_only, dir_cache_size)
         if ret != 0:
             raise OSError(ret, os.strerror(ret), f"could not connect to {pool}:{cont}")
 

--- a/src/client/pydaos/torch/torch_shim.c
+++ b/src/client/pydaos/torch/torch_shim.c
@@ -556,10 +556,6 @@ out:
 	D_FREE(dentries);
 	D_FREE(stats);
 
-	if (obj) {
-		rc = dfs_release(obj);
-	}
-
 	return PyLong_FromLong(rc);
 }
 

--- a/src/client/pydaos/torch/torch_shim.c
+++ b/src/client/pydaos/torch/torch_shim.c
@@ -723,9 +723,10 @@ start_read_op(struct dfs_handle *hdl, PyObject *item, struct io_op *op)
 {
 	assert(op != NULL);
 
-	int           rc  = 0;
-	int           rc2 = 0;
-	daos_event_t *evp = &op->ev;
+	int           rc     = 0;
+	int           rc2    = 0;
+	daos_event_t *evp    = &op->ev;
+	daos_size_t   offset = 0;
 
 	char         *dir_name  = NULL;
 	char         *file_name = NULL;
@@ -734,6 +735,10 @@ start_read_op(struct dfs_handle *hdl, PyObject *item, struct io_op *op)
 
 	PyObject     *py_path = PyTuple_GetItem(item, 0);
 	PyObject     *py_buff = PyTuple_GetItem(item, 1);
+
+	if (PyTuple_Size(item) > 2) {
+		offset = PyLong_AsLong(PyTuple_GetItem(item, 2));
+	}
 
 	if (py_path == NULL || py_buff == NULL) {
 		D_ERROR("Each tuple must contain exactly two elements: path and bytearray");
@@ -789,7 +794,7 @@ start_read_op(struct dfs_handle *hdl, PyObject *item, struct io_op *op)
 	op->sgl.sg_nr_out = 0;
 	op->sgl.sg_iovs   = &op->iov;
 
-	rc = dfs_read(hdl->dfs, op->obj, &op->sgl, 0 /* offset */, &op->size, &op->ev);
+	rc = dfs_read(hdl->dfs, op->obj, &op->sgl, offset, &op->size, &op->ev);
 	if (rc) {
 		D_ERROR("Could not start async read on '%s': %s (rc=%d)", op->path, strerror(rc),
 			rc);

--- a/src/client/pydaos/torch/torch_shim.c
+++ b/src/client/pydaos/torch/torch_shim.c
@@ -21,17 +21,76 @@
 #include <daos/common.h>
 #include <gurt/debug.h>
 #include <gurt/common.h>
+#include <gurt/hash.h>
 
 #define PY_SHIM_MAGIC_NUMBER (0x7A8B)
 #define EQ_POLL_BATCH_SIZE   (64)
 
 struct dfs_handle {
-	int           flags;
-	dfs_t        *dfs;
-	d_iov_t       global;
+	int                  flags;
+	dfs_t               *dfs;
+	d_iov_t              global;
 
-	daos_handle_t eq;
-	pid_t         eq_owner_pid;
+	daos_handle_t        eq;
+	pid_t                eq_owner_pid;
+
+	uint32_t             dir_cache_size;
+	struct d_hash_table *dir_cache;
+};
+
+/* Cached directory object entry */
+struct dir_obj_cache_entry {
+	d_list_t   entry;
+	dfs_obj_t *obj;
+	char       name[PATH_MAX];
+};
+
+static inline struct dir_obj_cache_entry *
+dir_obj_cache_entry_from_link(d_list_t *rlink)
+{
+	return container_of(rlink, struct dir_obj_cache_entry, entry);
+}
+
+static bool
+dir_cache_key_cmp(struct d_hash_table *htable, d_list_t *rlink, const void *key, unsigned int ksize)
+{
+	struct dir_obj_cache_entry *h = dir_obj_cache_entry_from_link(rlink);
+
+	return (strcmp(h->name, (const char *)key) == 0);
+}
+
+static void
+dir_cache_rec_free(struct d_hash_table *htable, d_list_t *rlink)
+{
+	struct dir_obj_cache_entry *h = dir_obj_cache_entry_from_link(rlink);
+
+	int                         rc = dfs_release(h->obj);
+	if (rc) {
+		D_ERROR("Could not release object '%s': %s (rc=%d)", h->name, strerror(rc), rc);
+	}
+	free(h);
+}
+
+static bool
+dir_cache_rec_decref(struct d_hash_table *htable, d_list_t *rlink)
+{
+	return true;
+}
+
+static uint32_t
+dir_cache_rec_hash(struct d_hash_table *htable, d_list_t *rlink)
+{
+	struct dir_obj_cache_entry *h = dir_obj_cache_entry_from_link(rlink);
+
+	return d_hash_string_u32(h->name, strnlen(h->name, PATH_MAX));
+}
+
+/* Directory object hash table operations */
+static d_hash_table_ops_t dir_cache_hash_ops = {
+    .hop_key_cmp    = dir_cache_key_cmp,
+    .hop_rec_decref = dir_cache_rec_decref,
+    .hop_rec_free   = dir_cache_rec_free,
+    .hop_rec_hash   = dir_cache_rec_hash,
 };
 
 /* Parse arguments and magic number.
@@ -95,22 +154,73 @@ __shim_handle__module_fini(PyObject *self, PyObject *args)
 	return PyLong_FromLong(rc);
 }
 
+/* Hash table does not require lock: workers will be working on their own subsets of data
+and will have their own handlers, including the cache.
+*/
+static int
+__dir_cache_create(struct dfs_handle *hdl)
+{
+	uint32_t bits = ceil(log2(hdl->dir_cache_size));
+
+	int rc = d_hash_table_create(D_HASH_FT_EPHEMERAL | D_HASH_FT_NOLOCK | D_HASH_FT_LRU, bits,
+				     NULL, &dir_cache_hash_ops, &hdl->dir_cache);
+	if (rc) {
+		D_ERROR("Could not create directory cache's hash table: %s (rc=%d)", d_errstr(rc),
+			rc);
+		rc = daos_der2errno(rc);
+	}
+
+	return rc;
+}
+
+static int
+__dir_cache_destroy(struct dfs_handle *hdl)
+{
+	int rc = 0;
+
+	/* Before finalizing the handle, we need to release all cached directory objects,
+	by dropping the reference count we allow the hash table to free the memory via rec_free
+	callback
+	*/
+	while (true) {
+		d_list_t *rlink = d_hash_rec_first(hdl->dir_cache);
+		if (rlink == NULL)
+			break;
+
+		d_hash_rec_decref(hdl->dir_cache, rlink);
+	}
+
+	rc = d_hash_table_destroy(hdl->dir_cache, false);
+	if (rc) {
+		D_ERROR("Could not destroy directory objects cache hash table: %s (rc=%d)",
+			d_errstr(rc), rc);
+		rc = daos_der2errno(rc);
+	}
+
+	return rc;
+}
+
 static PyObject *
 __shim_handle__torch_connect(PyObject *self, PyObject *args)
 {
-	int                rc      = 0;
-	int                rc2     = 0;
-	char              *pool    = NULL;
-	char              *cont    = NULL;
-	int                rd_only = 1;
-	struct dfs_handle *hdl     = NULL;
+	int                rc             = 0;
+	int                rc2            = 0;
+	char              *pool           = NULL;
+	char              *cont           = NULL;
+	int                rd_only        = 1;
+	uint32_t           dir_cache_size = 0;
+	struct dfs_handle *hdl            = NULL;
 
 	PyObject          *result = PyList_New(2);
 	if (result == NULL) {
 		return PyErr_NoMemory();
 	}
 
-	RETURN_NULL_IF_FAILED_TO_PARSE(args, "ssp", &pool, &cont, &rd_only);
+	RETURN_NULL_IF_FAILED_TO_PARSE(args, "sspI", &pool, &cont, &rd_only, &dir_cache_size);
+
+	if (dir_cache_size == 0) {
+		return PyLong_FromLong(EINVAL);
+	}
 
 	rc = dfs_init();
 	if (rc) {
@@ -123,7 +233,8 @@ __shim_handle__torch_connect(PyObject *self, PyObject *args)
 		rc = ENOMEM;
 		goto out;
 	}
-	hdl->flags = rd_only ? O_RDONLY : O_RDWR;
+	hdl->flags          = rd_only ? O_RDONLY : O_RDWR;
+	hdl->dir_cache_size = dir_cache_size;
 
 	rc = dfs_connect(pool, NULL, cont, hdl->flags, NULL, &hdl->dfs);
 	if (rc) {
@@ -159,6 +270,11 @@ __shim_handle__torch_connect(PyObject *self, PyObject *args)
 		goto out;
 	}
 	hdl->eq_owner_pid = getpid();
+
+	rc = __dir_cache_create(hdl);
+	if (rc) {
+		goto out;
+	}
 
 	PyList_SetItem(result, 0, PyLong_FromLong(rc));
 	PyList_SetItem(result, 1, PyLong_FromVoidPtr(hdl));
@@ -208,6 +324,11 @@ __shim_handle__torch_disconnect(PyObject *self, PyObject *args)
 	if (rc) {
 		D_ERROR("Could not destroy event queue: %s (rc=%d)", d_errstr(rc), rc);
 		rc = daos_der2errno(rc);
+		goto out;
+	}
+
+	rc = __dir_cache_destroy(hdl);
+	if (rc) {
 		goto out;
 	}
 
@@ -262,7 +383,57 @@ __shim_handle__torch_worker_init(PyObject *self, PyObject *args)
 		rc = daos_der2errno(rc);
 	}
 
+	rc = __dir_cache_create(hdl);
+
 	return PyLong_FromLong(rc);
+}
+
+static int
+lookup_or_insert_dir_obj(struct dfs_handle *hdl, const char *name, dfs_obj_t **obj)
+{
+	int                         rc    = 0;
+	d_list_t                   *rlink = NULL;
+	size_t                      len   = strnlen(name, PATH_MAX);
+	struct dir_obj_cache_entry *rec   = NULL;
+
+	assert(obj != NULL);
+	assert(hdl->dir_cache != NULL);
+
+	rlink = d_hash_rec_find(hdl->dir_cache, name, len);
+	if (rlink != NULL) {
+		rec  = dir_obj_cache_entry_from_link(rlink);
+		*obj = rec->obj;
+		return 0;
+	}
+
+	rc = dfs_lookup(hdl->dfs, name, hdl->flags, obj, NULL, NULL);
+	if (rc) {
+		return rc;
+	}
+
+	rec = calloc(1, sizeof(struct dir_obj_cache_entry));
+	if (rec == NULL) {
+		return ENOMEM;
+	}
+
+	rec->obj = *obj;
+	strncpy(rec->name, name, len);
+
+	rc = d_hash_rec_insert(hdl->dir_cache, rec->name, len, &rec->entry, false);
+	if (rc) {
+		D_ERROR("Failed to insert dir handle in hashtable: '%s': %s (rc=%d)", name,
+			d_errstr(rc), rc);
+		rc = daos_der2errno(rc);
+
+		int rc2 = dfs_release(rec->obj);
+		if (rc2) {
+			D_ERROR("Could not release object '%s': %s (rc=%d)", name, strerror(rc2),
+				rc2);
+		}
+		free(rec);
+	}
+
+	return rc;
 }
 
 static PyObject *
@@ -272,22 +443,18 @@ __shim_handle__torch_recommended_dir_split(PyObject *self, PyObject *args)
 	char              *path = NULL;
 	dfs_obj_t         *obj  = NULL;
 	uint32_t           nr   = 0;
+	int                rc   = 0;
 
 	RETURN_NULL_IF_FAILED_TO_PARSE(args, "Ls", &hdl, &path);
 
 	assert(hdl->dfs != NULL);
 
-	int rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &obj, NULL, NULL);
+	rc = lookup_or_insert_dir_obj(hdl, path, &obj);
 	if (rc) {
 		return Py_BuildValue("iI", rc, nr);
 	}
 
 	rc = dfs_obj_anchor_split(obj, &nr, NULL);
-	if (rc) {
-		return Py_BuildValue("iI", rc, nr);
-	}
-
-	rc = dfs_release(obj);
 	return Py_BuildValue("iI", rc, nr);
 }
 
@@ -328,7 +495,7 @@ __shim_handle__torch_list_with_anchor(PyObject *self, PyObject *args)
 		goto out;
 	}
 
-	rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &obj, NULL, NULL);
+	rc = lookup_or_insert_dir_obj(hdl, path, &obj);
 	if (rc) {
 		D_ERROR("Could not lookup object at '%s': %s (rc=%d)", path, strerror(rc), rc);
 		goto out;
@@ -396,17 +563,65 @@ out:
 	return PyLong_FromLong(rc);
 }
 
+static int
+split_path(const char *path, char **dir, char **name)
+{
+	assert(dir != NULL);
+	assert(name != NULL);
+
+	int   rc        = 0;
+	char *cp1       = NULL;
+	char *cp2       = NULL;
+	char *dir_name  = NULL;
+	char *file_name = NULL;
+
+	D_STRNDUP(cp1, path, PATH_MAX);
+	if (cp1 == NULL) {
+		return ENOMEM;
+	}
+	D_STRNDUP(cp2, path, PATH_MAX);
+	if (cp2 == NULL) {
+		rc = ENOMEM;
+		goto out;
+	}
+
+	dir_name  = dirname(cp1);
+	file_name = basename(cp2);
+
+	D_STRNDUP(*dir, dir_name, PATH_MAX);
+	if (*dir == NULL) {
+		rc = ENOMEM;
+		goto out;
+	}
+	D_STRNDUP(*name, file_name, PATH_MAX);
+	if (*name == NULL) {
+		D_FREE(*dir);
+		rc = ENOMEM;
+		goto out;
+	}
+
+out:
+	D_FREE(cp1);
+	D_FREE(cp2);
+
+	return rc;
+}
+
 static PyObject *
 __shim_handle__torch_read(PyObject *self, PyObject *args)
 {
-	ssize_t            rc     = 0;
-	struct dfs_handle *hdl    = NULL;
-	char              *path   = NULL;
-	dfs_obj_t         *obj    = NULL;
-	PyObject          *buffer = NULL;
+	ssize_t            rc        = 0;
+	struct dfs_handle *hdl       = NULL;
+	char              *path      = NULL;
+	char              *dir_name  = NULL;
+	char              *file_name = NULL;
+	dfs_obj_t         *obj       = NULL;
+	dfs_obj_t         *parent    = NULL;
+	PyObject          *buffer    = NULL;
 	Py_buffer          bview;
 	d_iov_t            iov;
 	daos_size_t        read = 0;
+	mode_t             mode = S_IFREG;
 
 	RETURN_NULL_IF_FAILED_TO_PARSE(args, "LsO", &hdl, &path, &buffer);
 	assert(hdl->dfs != NULL);
@@ -432,6 +647,23 @@ __shim_handle__torch_read(PyObject *self, PyObject *args)
 		return NULL;
 	}
 
+	rc = split_path(path, &dir_name, &file_name);
+	if (rc) {
+		goto out;
+	}
+
+	rc = lookup_or_insert_dir_obj(hdl, dir_name, &parent);
+	if (rc) {
+		D_ERROR("Could not lookup '%s': %s (rc=%ld)", path, strerror(rc), rc);
+		goto out;
+	}
+
+	rc = dfs_open(hdl->dfs, parent, file_name, mode, O_RDONLY, 0, 0, NULL, &obj);
+	if (rc) {
+		D_ERROR("Could not open '%s': %s (rc=%ld)", path, strerror(rc), rc);
+		goto out;
+	}
+
 	read = bview.len;
 	d_iov_set(&iov, bview.buf, read);
 
@@ -440,12 +672,6 @@ __shim_handle__torch_read(PyObject *self, PyObject *args)
 	    .sg_nr_out = 0,
 	    .sg_iovs   = &iov,
 	};
-
-	rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &obj, NULL, NULL);
-	if (rc) {
-		D_ERROR("Could not lookup '%s': %s (rc=%ld)", path, strerror(rc), rc);
-		goto out;
-	}
 
 	rc = dfs_read(hdl->dfs, obj, &sgl, 0 /* offset */, &read, NULL);
 	if (rc) {
@@ -456,6 +682,8 @@ __shim_handle__torch_read(PyObject *self, PyObject *args)
 	}
 
 out:
+	D_FREE(dir_name);
+	D_FREE(file_name);
 	PyBuffer_Release(&bview);
 
 	if (obj) {
@@ -499,6 +727,11 @@ start_read_op(struct dfs_handle *hdl, PyObject *item, struct io_op *op)
 	int           rc2 = 0;
 	daos_event_t *evp = &op->ev;
 
+	char         *dir_name  = NULL;
+	char         *file_name = NULL;
+	dfs_obj_t    *parent    = NULL;
+	mode_t        mode      = S_IFREG;
+
 	PyObject     *py_path = PyTuple_GetItem(item, 0);
 	PyObject     *py_buff = PyTuple_GetItem(item, 1);
 
@@ -521,20 +754,31 @@ start_read_op(struct dfs_handle *hdl, PyObject *item, struct io_op *op)
 	if (!PyBuffer_IsContiguous(&op->buf_view, 'C')) {
 		D_ERROR("Buffer for '%s' is not contiguous", path);
 		rc = EINVAL;
-		goto out;
+		goto err;
 	}
 
 	rc = daos_event_init(evp, hdl->eq, NULL);
 	if (rc) {
 		D_ERROR("Could not init event: %s (rc=%d)", d_errstr(rc), rc);
 		rc = daos_der2errno(rc);
-		goto out;
+		goto err;
 	}
 
-	rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &op->obj, NULL, NULL);
+	rc = split_path(path, &dir_name, &file_name);
 	if (rc) {
-		D_ERROR("Could not lookup path '%s': %s (rc=%d)", op->path, strerror(rc), rc);
-		goto out;
+		goto err;
+	}
+
+	rc = lookup_or_insert_dir_obj(hdl, dir_name, &parent);
+	if (rc) {
+		D_ERROR("Could not lookup '%s': %s (rc=%d)", dir_name, strerror(rc), rc);
+		goto err;
+	}
+
+	rc = dfs_open(hdl->dfs, parent, file_name, mode, O_RDONLY, 0, 0, NULL, &op->obj);
+	if (rc) {
+		D_ERROR("Could not open '%s': %s (rc=%d)", op->path, strerror(rc), rc);
+		goto err;
 	}
 
 	op->path = path;
@@ -549,12 +793,17 @@ start_read_op(struct dfs_handle *hdl, PyObject *item, struct io_op *op)
 	if (rc) {
 		D_ERROR("Could not start async read on '%s': %s (rc=%d)", op->path, strerror(rc),
 			rc);
-		goto out;
+		goto err;
 	}
+
+	D_FREE(dir_name);
+	D_FREE(file_name);
 
 	return 0;
 
-out:
+err:
+	D_FREE(dir_name);
+	D_FREE(file_name);
 	PyBuffer_Release(&op->buf_view);
 
 	rc2 = daos_event_fini(&op->ev);
@@ -686,50 +935,6 @@ __shim_handle__torch_batch_read(PyObject *self, PyObject *args)
 	return PyLong_FromLong(rc);
 }
 
-static int
-split_path(const char *path, char **dir, char **name)
-{
-	assert(dir != NULL);
-	assert(name != NULL);
-
-	int   rc        = 0;
-	char *cp1       = NULL;
-	char *cp2       = NULL;
-	char *dir_name  = NULL;
-	char *file_name = NULL;
-
-	D_STRNDUP(cp1, path, PATH_MAX);
-	if (cp1 == NULL) {
-		return ENOMEM;
-	}
-	D_STRNDUP(cp2, path, PATH_MAX);
-	if (cp2 == NULL) {
-		rc = ENOMEM;
-		goto out;
-	}
-
-	dir_name  = dirname(cp1);
-	file_name = basename(cp2);
-
-	D_STRNDUP(*dir, dir_name, PATH_MAX);
-	if (*dir == NULL) {
-		rc = ENOMEM;
-		goto out;
-	}
-	D_STRNDUP(*name, file_name, PATH_MAX);
-	if (*name == NULL) {
-		D_FREE(*dir);
-		rc = ENOMEM;
-		goto out;
-	}
-
-out:
-	D_FREE(cp1);
-	D_FREE(cp2);
-
-	return rc;
-}
-
 static PyObject *
 __shim_handle__torch_write(PyObject *self, PyObject *args)
 {
@@ -739,7 +944,7 @@ __shim_handle__torch_write(PyObject *self, PyObject *args)
 	char              *path       = NULL;
 	char              *dir_name   = NULL;
 	char              *file_name  = NULL;
-	dfs_obj_t         *dir        = NULL;
+	dfs_obj_t         *parent     = NULL;
 	dfs_obj_t         *obj        = NULL;
 	PyObject          *buffer     = NULL;
 	int                oflags     = 0;
@@ -778,13 +983,13 @@ __shim_handle__torch_write(PyObject *self, PyObject *args)
 		goto out;
 	}
 
-	rc = dfs_lookup(hdl->dfs, dir_name, O_RDWR, &dir, NULL, NULL);
+	rc = lookup_or_insert_dir_obj(hdl, dir_name, &parent);
 	if (rc) {
 		D_ERROR("Could not lookup '%s': %s (rc=%d)", dir_name, strerror(rc), rc);
 		goto out;
 	}
 
-	rc = dfs_open(hdl->dfs, dir, file_name, mode, oflags, cid, chunk_size, NULL, &obj);
+	rc = dfs_open(hdl->dfs, parent, file_name, mode, oflags, cid, chunk_size, NULL, &obj);
 	if (rc) {
 		D_ERROR("Could not open '%s': %s (rc=%d)", path, strerror(rc), rc);
 		goto out;
@@ -815,13 +1020,6 @@ out:
 				rc2);
 		}
 	}
-	if (dir) {
-		rc2 = dfs_release(dir);
-		if (rc2) {
-			D_ERROR("Could not release dir '%s': %s (rc=%d)", dir_name, strerror(rc2),
-				rc2);
-		}
-	}
 
 	D_FREE(dir_name);
 	D_FREE(file_name);
@@ -832,21 +1030,33 @@ out:
 static PyObject *
 __shim_handle__torch_get_fsize(PyObject *self, PyObject *args)
 {
-	struct dfs_handle *hdl  = NULL;
-	char              *path = NULL;
-	dfs_obj_t         *obj  = NULL;
-	struct stat        st   = {0};
+	struct dfs_handle *hdl       = NULL;
+	char              *path      = NULL;
+	char              *dir_name  = NULL;
+	char              *file_name = NULL;
+	dfs_obj_t         *parent    = NULL;
+	struct stat        st        = {0};
 
 	RETURN_NULL_IF_FAILED_TO_PARSE(args, "Ls", &hdl, &path);
 
 	assert(hdl->dfs != NULL);
 
-	int rc = dfs_lookup(hdl->dfs, path, O_RDONLY, &obj, NULL, &st);
+	int rc = split_path(path, &dir_name, &file_name);
 	if (rc) {
-		return Py_BuildValue("iK", rc, st.st_size);
+		return Py_BuildValue("iK", rc, 0);
 	}
 
-	rc = dfs_release(obj);
+	rc = lookup_or_insert_dir_obj(hdl, dir_name, &parent);
+	if (rc) {
+		D_ERROR("Could not lookup '%s': %s (rc=%d)", dir_name, strerror(rc), rc);
+		goto out;
+	}
+
+	rc = dfs_stat(hdl->dfs, parent, file_name, &st);
+
+out:
+	D_FREE(dir_name);
+	D_FREE(file_name);
 	return Py_BuildValue("iK", rc, st.st_size);
 }
 

--- a/src/tests/ftest/pytorch/dataset.py
+++ b/src/tests/ftest/pytorch/dataset.py
@@ -41,14 +41,18 @@ class PytorchDatasetsTest(TestWithServers):
         subdirs = self.params.get("subdirs", "/run/map_style_dataset/*")
         files_per_node = self.params.get("files_per_node", "/run/map_style_dataset/*")
         file_min_size = self.params.get("file_min_size", "/run/map_style_dataset/*", 4096)
-        file_max_size = self.params.get("file_max_size", "/run/map_style_dataset/*", 128 * 1024)
+        file_max_size = self.params.get("file_max_size", "/run/map_style_dataset/*", 4096)
+        readdir_batch_size = self.params.get("readdir_batch_size", "/run/map_style_dataset/*", 5)
 
         self._create_test_files(root_dir, height, subdirs, files_per_node,
                                 file_min_size, file_max_size)
 
         expected = self._get_test_files_hashmap(root_dir, self.hostlist_clients)
 
-        dataset = Dataset(pool.identifier, container.identifier)
+        dataset = Dataset(pool=pool.identifier,
+                          cont=container.identifier,
+                          readdir_batch_size=readdir_batch_size,
+                          )
 
         actual = {}
         for _, content in enumerate(dataset):

--- a/src/tests/ftest/pytorch/dataset.py
+++ b/src/tests/ftest/pytorch/dataset.py
@@ -52,7 +52,7 @@ class PytorchDatasetsTest(TestWithServers):
 
         actual = {}
         for _, content in enumerate(dataset):
-            h = hashlib.md5(content, usedforsecurity=False).hexdigest()
+            h = hashlib.md5(content).hexdigest()  # nosec
             if h not in actual:
                 actual[h] = 1
             else:
@@ -93,7 +93,7 @@ class PytorchDatasetsTest(TestWithServers):
 
         actual = {}
         for _, content in enumerate(dataset):
-            h = hashlib.md5(content, usedforsecurity=False).hexdigest()
+            h = hashlib.md5(content).hexdigest()  # nosec
             if h not in actual:
                 actual[h] = 1
             else:
@@ -196,7 +196,7 @@ class PytorchDatasetsTest(TestWithServers):
         actual = {}
         for batch in loader:
             for content in batch:
-                h = hashlib.md5(content, usedforsecurity=False).hexdigest()
+                h = hashlib.md5(content).hexdigest()  # nosec
                 if h not in actual:
                     actual[h] = 1
                 else:

--- a/src/tests/ftest/pytorch/dataset.yaml
+++ b/src/tests/ftest/pytorch/dataset.yaml
@@ -1,5 +1,5 @@
 hosts:
-  test_servers: 1
+  test_servers: 2
   test_clients: 1
 server_config:
   name: daos_server
@@ -18,17 +18,18 @@ pool:
 container:
   type: POSIX
   control_method: daos
+  dir_oclass: SX
 
-timeout: 180
+timeout: 270
 
 map_style_dataset:
-  tree_height: 4
-  subdirs: 3
-  files_per_node: 5
+  tree_height: 2
+  subdirs: 2
+  files_per_node: 64
 
 iterable_dataset:
-  tree_height: 3
-  subdirs: 3
+  tree_height: 4
+  subdirs: 5
   files_per_node: 6
 
 map_dataset_with_dataloader:

--- a/src/tests/ftest/pytorch/dataset.yaml
+++ b/src/tests/ftest/pytorch/dataset.yaml
@@ -19,6 +19,8 @@ container:
   type: POSIX
   control_method: daos
 
+timeout: 180
+
 map_style_dataset:
   tree_height: 4
   subdirs: 3


### PR DESCRIPTION
Also change defaults for checkpoint writes from unbounded memory usage to
modest 1GB.

Change-Id: I941867d4aa67c5545267874739f87e12c81634ea
Signed-off-by: Denis Barakhtanov <dbarahtanov@enakta.com>
