### PR TITLE
DAOS-16355 pydaos: fix dir obj cache invalid handle error

### DIFF
--- a/src/client/pydaos/torch/torch_shim.c
+++ b/src/client/pydaos/torch/torch_shim.c
@@ -556,10 +556,6 @@ out:
 	D_FREE(dentries);
 	D_FREE(stats);
 
-	if (obj) {
-		rc = dfs_release(obj);
-	}
-
 	return PyLong_FromLong(rc);
 }
 

--- a/src/tests/ftest/pytorch/dataset.py
+++ b/src/tests/ftest/pytorch/dataset.py
@@ -41,14 +41,18 @@ class PytorchDatasetsTest(TestWithServers):
         subdirs = self.params.get("subdirs", "/run/map_style_dataset/*")
         files_per_node = self.params.get("files_per_node", "/run/map_style_dataset/*")
         file_min_size = self.params.get("file_min_size", "/run/map_style_dataset/*", 4096)
-        file_max_size = self.params.get("file_max_size", "/run/map_style_dataset/*", 128 * 1024)
+        file_max_size = self.params.get("file_max_size", "/run/map_style_dataset/*", 4096)
+        readdir_batch_size = self.params.get("readdir_batch_size", "/run/map_style_dataset/*", 5)
 
         self._create_test_files(root_dir, height, subdirs, files_per_node,
                                 file_min_size, file_max_size)
 
         expected = self._get_test_files_hashmap(root_dir, self.hostlist_clients)
 
-        dataset = Dataset(pool.identifier, container.identifier)
+        dataset = Dataset(pool=pool.identifier,
+                          cont=container.identifier,
+                          readdir_batch_size=readdir_batch_size,
+                          )
 
         actual = {}
         for _, content in enumerate(dataset):

--- a/src/tests/ftest/pytorch/dataset.yaml
+++ b/src/tests/ftest/pytorch/dataset.yaml
@@ -18,6 +18,7 @@ pool:
 container:
   type: POSIX
   control_method: daos
+  dir_oclass: SX
 
 timeout: 270
 

--- a/src/tests/ftest/pytorch/dataset.yaml
+++ b/src/tests/ftest/pytorch/dataset.yaml
@@ -1,5 +1,5 @@
 hosts:
-  test_servers: 4
+  test_servers: 2
   test_clients: 1
 server_config:
   name: daos_server
@@ -23,9 +23,9 @@ container:
 timeout: 270
 
 map_style_dataset:
-  tree_height: 4
-  subdirs: 5
-  files_per_node: 6
+  tree_height: 2
+  subdirs: 2
+  files_per_node: 64
 
 iterable_dataset:
   tree_height: 4

--- a/src/tests/ftest/pytorch/dataset.yaml
+++ b/src/tests/ftest/pytorch/dataset.yaml
@@ -1,5 +1,5 @@
 hosts:
-  test_servers: 1
+  test_servers: 4
   test_clients: 1
 server_config:
   name: daos_server
@@ -19,16 +19,16 @@ container:
   type: POSIX
   control_method: daos
 
-timeout: 180
+timeout: 270
 
 map_style_dataset:
   tree_height: 4
-  subdirs: 3
-  files_per_node: 5
+  subdirs: 5
+  files_per_node: 6
 
 iterable_dataset:
-  tree_height: 3
-  subdirs: 3
+  tree_height: 4
+  subdirs: 5
   files_per_node: 6
 
 map_dataset_with_dataloader:


### PR DESCRIPTION
Directory objects lifecycle is defined by cache, releasing object outside it will result in the error: Invalid object handler.

Features: pytorch

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
