### PR TITLE
DAOS-16620 vos: exit scrub earlier during container destruction (#15957)

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1240,6 +1240,8 @@ cont_child_destroy_one(void *vin)
 	}
 
 	if (cont->sc_destroying) {
+		D_ERROR(DF_CONT ": Container is already being destroyed\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
 		cont_child_put(tls->dt_cont_cache, cont);
 		D_GOTO(out_pool, rc = -DER_BUSY);
 	}

--- a/src/vos/vos_pool_scrub.c
+++ b/src/vos/vos_pool_scrub.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2020-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */


### PR DESCRIPTION
In sc_wait_until_should_continue(), the function could sleep for over 60 seconds before proceeding, causing container destruction timeouts and DER_BUSY errors during retries. This fix adds 1-second interval checks for sc_cont_is_stopping() during sleep cycles.

Additionally, enhanced error logging when container destruction is already in progress.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
