### PR TITLE
DAOS-17203 build: Build DAOS RPMs with Leap 15.6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value='pipeline-lib@your_branch') _
+@Library(value='pipeline-lib@hendersp/DAOS-17203') _
 
 /* groovylint-disable-next-line CompileStatic */
 job_status_internal = [:]

--- a/ci/parse_ci_envs.sh
+++ b/ci/parse_ci_envs.sh
@@ -23,7 +23,7 @@ if [ -n "${STAGE_NAME:?}" ]; then
       : "${REPO_SPEC:=el-9}"
       ;;
     *Leap\ 15.6*|*leap15.6*|*opensuse15.6*|*sles15.6*)
-      : "${CHROOT_NAME:=opensuse-leap-15.5-x86_64}"
+      : "${CHROOT_NAME:=opensuse-leap-15.6-x86_64}"
       : "${TARGET:=leap15.6}"
       ;;
     *Leap\ 15.5*|*leap15.5*|*opensuse15.5*|*sles15.5*)


### PR DESCRIPTION
Use the opensuse-leap-15.6-x86_64.cfg mock config to build DAOS RPMs.

Skip-func-hw-test: true
Skip-func-test-leap15: false

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
