### PR TITLE
DAOS-13700 test: use self.random in most cases

### DIFF
--- a/src/tests/ftest/container/boundary.py
+++ b/src/tests/ftest/container/boundary.py
@@ -1,11 +1,11 @@
 """
   (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
 import itertools
-import random
 import time
 
 from apricot import TestWithServers
@@ -108,7 +108,7 @@ class BoundaryTest(TestWithServers):
         container_manager = ThreadManager(
             self.create_container_and_test, self.get_remaining_time() - 30)
         all_pool_cont_args = list(itertools.product(self.pool, range(num_containers)))
-        random.shuffle(all_pool_cont_args)
+        self.random.shuffle(all_pool_cont_args)
         for pool, cont_num in all_pool_cont_args:
             container_manager.add(pool=pool, cont_num=cont_num)
         self.log.info('Creating %d containers for each pool', num_containers)

--- a/src/tests/ftest/deployment/disk_failure.py
+++ b/src/tests/ftest/deployment/disk_failure.py
@@ -1,9 +1,9 @@
 """
   (C) Copyright 2022-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import random
 import threading
 import time
 
@@ -64,7 +64,7 @@ class DiskFailureTest(OSAUtils):
                 time.sleep(5)
 
             # Evict a random target from the system
-            evict_device = random.choice(device_info)  # nosec
+            evict_device = self.random.choice(device_info)
             self.log.info("Evicting random target: %s", evict_device["uuid"])
             try:
                 get_dmg_response(self.dmg_command.storage_set_faulty,

--- a/src/tests/ftest/dfuse/find.py
+++ b/src/tests/ftest/dfuse/find.py
@@ -1,10 +1,10 @@
 """
   (C) Copyright 2021-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
-import random
 import string
 
 from apricot import TestWithServers
@@ -52,7 +52,6 @@ class DfuseFind(TestWithServers):
             challenger performance.
 
         :avocado: tags=all,manual
-        :avocado: tags=hw,medium
         :avocado: tags=DfuseFind,test_dfuse_find_perf
         """
         # Number of repetitions each test will run.
@@ -180,12 +179,12 @@ class DfuseFind(TestWithServers):
         for sample_num in range(1, samples + 1):
             self.log.info("Running sample number %d of %d", sample_num, samples)
 
-            prefix = random.randrange(containers - 1)  # nosec
-            suffix = random.randrange(needles - 1)  # nosec
+            prefix = self.random.randrange(containers - 1)
+            suffix = self.random.randrange(needles - 1)
             file_name = "t{:05d}_*_{:05d}.needle".format(prefix, suffix)
             _search_needles(file_name, "unique_file", 1)
 
-            number = random.randrange(needles - 1)  # nosec
+            number = self.random.randrange(needles - 1)
             file_name = "*_{:05d}.needle".format(number)
             _search_needles(file_name, "same_suffix", containers)
 
@@ -255,14 +254,13 @@ class DfuseFind(TestWithServers):
 
         return challenger_dirs
 
-    @classmethod
-    def _generate_temp_path_name(cls, root, prefix):
+    def _generate_temp_path_name(self, root, prefix):
         """
         Creates path that can be used to create temporary files or directories.
         The return value is concatenation of root and a random string prefixed
         with the prefix value.
         """
         letters = string.ascii_lowercase + string.digits
-        random_name = "".join(random.choice(letters) for _ in range(8))  # nosec
+        random_name = "".join(self.random.choice(letters) for _ in range(8))
 
         return os.path.join(root, "{}{}".format(prefix, random_name))

--- a/src/tests/ftest/harness/config.py
+++ b/src/tests/ftest/harness/config.py
@@ -1,5 +1,6 @@
 """
 (C) Copyright 2021-2024 Intel Corporation.
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -79,3 +80,7 @@ class HarnessConfigTest(TestWithServers):
         with open(self.agent_managers[0].manager.job.temporary_file, 'r') as yaml_file:
             daos_agent_yaml = yaml.safe_load(yaml_file.read())
         self.assertEqual(daos_agent_yaml['exclude_fabric_ifaces'], expected)
+
+        self.log.info('Verify rand_seed set from yaml')
+        rand_seed = self.params.get("rand_seed", "/run/setup/*")
+        self.assertEqual(self.rand_seed, rand_seed)

--- a/src/tests/ftest/harness/config.yaml
+++ b/src/tests/ftest/harness/config.yaml
@@ -4,6 +4,7 @@ hosts:
 timeout: 60
 setup:
   mgmt_svc_replicas_suffix: .wolf.hpdd.intel.com
+  rand_seed: 7
 server_config:
   name: daos_server
   engines_per_host: 1

--- a/src/tests/ftest/nvme/pool_exclude.py
+++ b/src/tests/ftest/nvme/pool_exclude.py
@@ -1,9 +1,9 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import random
 import re
 import threading
 import time
@@ -115,9 +115,9 @@ class NvmePoolExclude(OSAUtils):
                 self.pool.display_pool_daos_space("Pool space: Before Exclude")
                 pver_begin = self.pool.get_version(True)
 
-                index = random.randint(1, len(rank_list))  # nosec
+                index = self.random.randint(1, len(rank_list))
                 rank = rank_list.pop(index - 1)
-                tgt_exclude = random.randint(1, 6)  # nosec
+                tgt_exclude = self.random.randint(1, 6)
                 self.log.info("Removing rank %d, target %d", rank, tgt_exclude)
 
                 self.log.info("Pool Version at the beginning %s", pver_begin)

--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -1,10 +1,9 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import random
-
 from nvme_utils import ServerFillUp
 from osa_utils import OSAUtils
 from test_utils_pool import add_pool
@@ -48,7 +47,7 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
             oclass = self.ior_cmd.dfs_oclass.value
 
         # Exclude target : random two targets  (target idx : 0-7)
-        exc = random.randint(0, 6)  # nosec
+        exc = self.random.randint(0, 6)
         target_list.append(exc)
         target_list.append(exc + 1)
         t_string = "{},{}".format(target_list[0], target_list[1])

--- a/src/tests/ftest/osa/offline_parallel_test.py
+++ b/src/tests/ftest/osa/offline_parallel_test.py
@@ -1,11 +1,11 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import copy
 import queue
-import random
 import threading
 import time
 
@@ -83,7 +83,7 @@ class OSAOfflineParallelTest(OSAUtils):
             oclass = self.ior_cmd.dfs_oclass.value
 
         # Exclude target : random two targets (target idx : 0-7)
-        exc = random.randint(0, 6)  # nosec
+        exc = self.random.randint(0, 6)
         target_list.append(exc)
         target_list.append(exc + 1)
         t_string = "{},{}".format(target_list[0], target_list[1])

--- a/src/tests/ftest/osa/offline_reintegration.py
+++ b/src/tests/ftest/osa/offline_reintegration.py
@@ -1,10 +1,9 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import random
-
 from nvme_utils import ServerFillUp
 from osa_utils import OSAUtils
 from test_utils_pool import add_pool
@@ -83,7 +82,7 @@ class OSAOfflineReintegration(OSAUtils, ServerFillUp):
 
         # Exclude ranks 0 and 3 from a random pool
         ranks = [0, 3]
-        self.pool = random.choice(pools)  # nosec
+        self.pool = self.random.choice(pools)
         for loop in range(0, self.loop_test_cnt):
             self.log.info(
                 "==> (Loop %s/%s) Excluding ranks %s from %s",

--- a/src/tests/ftest/osa/online_parallel_test.py
+++ b/src/tests/ftest/osa/online_parallel_test.py
@@ -1,11 +1,11 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import copy
 import queue
-import random
 import threading
 import time
 from itertools import product
@@ -93,7 +93,7 @@ class OSAOnlineParallelTest(OSAUtils):
         target_list = []
 
         # Exclude target : random two targets  (target idx : 0-7)
-        exc = random.randint(0, 6)  # nosec
+        exc = self.random.randint(0, 6)
         target_list.append(exc)
         target_list.append(exc + 1)
         t_string = "{},{}".format(target_list[0], target_list[1])

--- a/src/tests/ftest/osa/online_reintegration.py
+++ b/src/tests/ftest/osa/online_reintegration.py
@@ -1,10 +1,10 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import queue
-import random
 import threading
 import time
 
@@ -61,7 +61,7 @@ class OSAOnlineReintegration(OSAUtils):
         exclude_servers = (len(self.hostlist_servers) * 2) - 1
 
         # Exclude one rank : other than rank 0.
-        rank = random.randint(1, exclude_servers)  # nosec
+        rank = self.random.randint(1, exclude_servers)
 
         # Start the daos_racer thread
         if racer is True:

--- a/src/tests/ftest/pool/create_all_vm.py
+++ b/src/tests/ftest/pool/create_all_vm.py
@@ -1,10 +1,9 @@
 """
 (C) Copyright 2022-2023 Intel Corporation.
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import random
-
 from general_utils import bytes_to_human
 from pool_create_all_base import PoolCreateAllTestBase
 
@@ -71,7 +70,7 @@ class PoolCreateAllVmTests(PoolCreateAllTestBase):
         :avocado: tags=PoolCreateAllVmTests,test_rank_filter
         """
         ranks = list(range(self.engines_count))
-        random.shuffle(ranks)
+        self.random.shuffle(ranks)
         ranks = ranks[(len(ranks) // 2):]
         delta_bytes = self.params.get("delta", "/run/test_rank_filter/*", 0)
         self.log.info("Test ranks filtered pool creation with full storage")

--- a/src/tests/ftest/pool/management_race.py
+++ b/src/tests/ftest/pool/management_race.py
@@ -1,9 +1,9 @@
 """
   (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import random
 import time
 
 from apricot import TestWithServers
@@ -45,7 +45,7 @@ class PoolManagementRace(TestWithServers):
                 self.log.info("--(%d.3.%s.%d)Pool %s recreated.\n",
                               thread_num, pool_id, test_num, pool_id)
                 # pool stays with a random time before destroy
-                pool_stay_time = random.randint(1, 3)  # nosec
+                pool_stay_time = self.random.randint(1, 3)
                 time.sleep(pool_stay_time)
             else:
                 completed = False
@@ -102,7 +102,7 @@ class PoolManagementRace(TestWithServers):
             self.log.info("==(1.%d) pool created, %s.", pool_number, self.pool[-1].identifier)
 
         # Randomly select a pool for delete, recreate and query
-        pool_number = random.randint(0, len(self.pool) - 1)  # nosec
+        pool_number = self.random.randint(0, len(self.pool) - 1)
 
         # Setup the thread manager for del_and_recreate_pool
         thread_manager = ThreadManager(self.del_recreate_query_and_list_pools, self.timeout - 30)

--- a/src/tests/ftest/rebuild/mdtest.py
+++ b/src/tests/ftest/rebuild/mdtest.py
@@ -73,7 +73,7 @@ class RebuildMdtest(MdtestBase):
 
         self.log_step("Kill 1 random rank")
         times["kill_rank"] = datetime.now()
-        self.server_managers[0].stop_random_rank(force=True)
+        self.server_managers[0].stop_random_rank(self.random, force=True)
 
         self.log_step("Wait for rebuild to start")
         self.pool.wait_for_rebuild_to_start(interval=rebuild_check_inverval)

--- a/src/tests/ftest/server/replay.py
+++ b/src/tests/ftest/server/replay.py
@@ -1,9 +1,9 @@
 """
   (C) Copyright 2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
-import random
 import time
 
 from apricot import TestWithServers
@@ -251,13 +251,13 @@ class ReplayTests(TestWithServers):
         for container in containers:
             for index, item in enumerate((container.pool, container)):
                 # Modify a random pool/container property value
-                name = random.choice(list(modify_attributes[index].keys()))  # nosec
+                name = self.random.choice(list(modify_attributes[index].keys()))
                 modified = False
                 for entry in expected[item.identifier]:
                     if entry['name'] == name:
                         original = entry['value']
                         while entry['value'] == original:
-                            entry['value'] = random.choice(modify_attributes[index][name])  # nosec
+                            entry['value'] = self.random.choice(modify_attributes[index][name])
                         self.log.info(
                             'Modifying %s property: %s -> %s',
                             item.identifier, entry['name'], entry['value'])

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -157,16 +157,16 @@ class Test(avocadoTest):
         super().setUp()
 
         # Random generator that could be seeded for reproducibility
-        env_seed = os.environ.get("DAOS_TEST_RANDOM_SEED", None)
-        if env_seed is None:
+        self.rand_seed = os.environ.get("DAOS_TEST_RANDOM_SEED", None)
+        if self.rand_seed is None:
+            self.rand_seed = self.params.get("rand_seed", "/run/setup/*", None)
+        if self.rand_seed is None:
             self.rand_seed = int.from_bytes(os.urandom(8), byteorder='little')
         else:
             try:
-                self.rand_seed = int(env_seed)
+                self.rand_seed = int(self.rand_seed)
             except ValueError:
-                self.fail(
-                    "ERROR: The env variable DAOS_TEST_RANDOM_SEED "
-                    "does not define a valid integer: got='{}'".format(env_seed))
+                self.fail(f"rand_seed is not an integer: {self.rand_seed}")
         self.log.info("Test.random seed = %d", self.rand_seed)
         self.random = random.Random(self.rand_seed)     # nosec
 

--- a/src/tests/ftest/util/daos_io_conf.py
+++ b/src/tests/ftest/util/daos_io_conf.py
@@ -1,10 +1,10 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 import os
-import random
 
 from apricot import TestWithServers
 from command_utils import ExecutableCommand
@@ -94,14 +94,15 @@ class IoConfGen(ExecutableCommand):
         return True
 
 
-def gen_unaligned_io_conf(record_size, filename="testfile"):
+def gen_unaligned_io_conf(test, record_size, filename="testfile"):
     """Generate the data-set file based on record size.
 
     Args:
-        record_size(Number): Record Size to fill the data.
+        test (Test): test object
+        record_size (Number): Record Size to fill the data.
         filename (string): Filename (with/without path) for creating the data set.
     """
-    rand_ofs_end = random.randint(1, record_size - 1)  # nosec
+    rand_ofs_end = test.random.randint(1, record_size - 1)
     rand_ofs_start = rand_ofs_end - 1
     file_data = (
         "test_lvl daos",
@@ -172,7 +173,7 @@ class IoConfTestBase(TestWithServers):
         for record_size in total_sizes:
             print("Start test for record size = {}".format(record_size))
             # Create unaligned test data set
-            gen_unaligned_io_conf(record_size, self.testfile)
+            gen_unaligned_io_conf(self, record_size, self.testfile)
             # Run test file using daos_run_io_conf
             if not io_conf.run_conf(self.dmg_config_file):
                 self.fail("daos_run_io_conf failed")

--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -6,7 +6,6 @@
 """
 import grp
 import os
-import random
 import re
 
 import agent_utils as agu
@@ -374,7 +373,7 @@ class PoolSecurityTestBase(TestWithServers):
                 self.fail(f"Failed to groupadd {groupname}")
             group_list.append(new_group)
         permission_list = group_list + user_list + current_user_acl
-        random.shuffle(permission_list)
+        self.random.shuffle(permission_list)
         with open(acl_file, "w") as test_file:
             test_file.write("\n".join(permission_list))
         return permission_list

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -7,7 +7,6 @@
 # pylint: disable=too-many-lines
 
 import os
-import random
 import time
 from getpass import getuser
 
@@ -919,10 +918,11 @@ class DaosServerManager(SubprocessManager):
         # Update the expected status of the stopped/excluded ranks
         self.update_expected_states(ranks, ["stopped", "excluded"])
 
-    def stop_random_rank(self, force=False, exclude_ranks=None):
+    def stop_random_rank(self, random, force=False, exclude_ranks=None):
         """Kill/Stop a random server rank that is expected to be running.
 
         Args:
+            random (obj): random object
             force (bool, optional): whether to use --force option to dmg system
                 stop. Defaults to False.
             exclude_ranks (list, optional): ranks to exclude from the random selection.

--- a/src/tests/ftest/util/soak_test_base.py
+++ b/src/tests/ftest/util/soak_test_base.py
@@ -1,12 +1,12 @@
 """
 (C) Copyright 2019-2024 Intel Corporation.
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
 
 import multiprocessing
 import os
-import random
 import socket
 import threading
 import time
@@ -468,8 +468,7 @@ class SoakTestBase(TestWithServers):
                                               "joblog": jobscript[1],
                                               "joberrlog": jobscript[2]}])
         # randomize job list
-        random.seed(4)
-        random.shuffle(self.joblist)
+        self.random.shuffle(self.joblist)
 
     def job_startup(self):
         """Launch the job script.

--- a/src/tests/ftest/util/soak_utils.py
+++ b/src/tests/ftest/util/soak_utils.py
@@ -1,5 +1,6 @@
 """
 (C) Copyright 2019-2024 Intel Corporation.
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -7,7 +8,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 import getpass
 import os
-import random
 import re
 import stat
 import threading
@@ -582,7 +582,7 @@ def launch_vmd_identify_check(self, name, results, args):
     uuid_list = [device['uuid'] for device in device_info]
     # limit the number of leds to blink to 1024
     if len(uuid_list) > 1024:
-        uuids = random.sample(uuid_list, 1024)
+        uuids = self.random.sample(uuid_list, 1024)
     else:
         uuids = uuid_list
     self.log.info("VMD device UUIDs: %s", uuids)
@@ -832,12 +832,12 @@ def launch_exclude_reintegrate(self, pool, name, results, args):
         engine_count = self.params.get("engines_per_host", "/run/server_config/*", default=1)
         exclude_servers = (len(self.hostlist_servers) * int(engine_count)) - 1
         # Exclude one rank.
-        rank = random.randint(0, exclude_servers)  # nosec
+        rank = self.random.randint(0, exclude_servers)
 
         if targets >= 8:
             tgt_idx = None
         else:
-            target_list = random.sample(range(0, 8), targets)
+            target_list = self.random.sample(range(0, 8), targets)
             tgt_idx = ','.join(str(tgt) for tgt in target_list)
 
         # init the status dictionary
@@ -905,7 +905,7 @@ def launch_server_stop_start(self, pools, name, results, args):
         exclude_servers = (
             len(self.hostlist_servers) * int(engine_count)) - 1
         # Exclude one rank.
-        rank = random.randint(0, exclude_servers)  # nosec
+        rank = self.random.randint(0, exclude_servers)
         # init the status dictionary
         params = {"name": name,
                   "status": status,


### PR DESCRIPTION
Use self.random in nearly all cases so it can be seeded for reproducibility. Test-tag: BoundaryTest DfuseFind DiskFailureTest HarnessConfigTest NvmePoolExclude OSAOfflineDrain OSAOfflineParallelTest OSAOfflineReintegration OSAOnlineParallelTest OSAOnlineReintegration PoolCreateAllVmTests PoolManagementRace ReplayTests EcodRunIoConf DaosRunIoConf soak_smoke security RebuildMdtest Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
