### PR TITLE
DAOS-16922 dfuse: Avoid assertion on shutdown (#15972)

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1269,12 +1270,15 @@ dfuse_ie_close(struct dfuse_info *dfuse_info, struct dfuse_inode_entry *ie)
 	DFUSE_TRA_DEBUG(ie, "closing, inode %#lx ref %u, name " DF_DE ", parent %#lx",
 			ie->ie_stat.st_ino, ref, DP_DE(ie->ie_name), ie->ie_parent);
 
-	D_ASSERTF(ref == 0, "Reference is %d", ref);
-	D_ASSERTF(atomic_load_relaxed(&ie->ie_il_count) == 0, "il_count is %d",
-		  atomic_load_relaxed(&ie->ie_il_count));
-	D_ASSERTF(atomic_load_relaxed(&ie->ie_open_count) == 0, "open_count is %d",
-		  atomic_load_relaxed(&ie->ie_open_count));
-	D_ASSERT(!ie->ie_active);
+	if (ref != 0 || atomic_load_relaxed(&ie->ie_il_count) != 0 ||
+	    atomic_load_relaxed(&ie->ie_open_count) != 0 || ie->ie_active) {
+		DFUSE_TRA_WARNING(ie,
+				  "Unclean shutdown of dfuse, probably due to forced umount: "
+				  "ref=%d il_count=%d open_count=%d active=%p",
+				  ref, atomic_load_relaxed(&ie->ie_il_count),
+				  atomic_load_relaxed(&ie->ie_open_count), ie->ie_active);
+		return;
+	}
 
 	if (ie->ie_obj) {
 		rc = dfs_release(ie->ie_obj);

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -741,10 +741,19 @@ out_daos:
 		rc = rc2;
 out_fini:
 	if (dfuse_info && rc == -DER_SUCCESS) {
-		D_ASSERT(atomic_load_relaxed(&dfuse_info->di_inode_count) == 0);
-		D_ASSERT(atomic_load_relaxed(&dfuse_info->di_fh_count) == 0);
-		D_ASSERT(atomic_load_relaxed(&dfuse_info->di_pool_count) == 0);
-		D_ASSERT(atomic_load_relaxed(&dfuse_info->di_container_count) == 0);
+		if (atomic_load_relaxed(&dfuse_info->di_inode_count) != 0 ||
+		    atomic_load_relaxed(&dfuse_info->di_fh_count) != 0 ||
+		    atomic_load_relaxed(&dfuse_info->di_pool_count) != 0 ||
+		    atomic_load_relaxed(&dfuse_info->di_container_count) != 0) {
+			DFUSE_TRA_WARNING(dfuse_info,
+					  "Not all resources were cleaned up, probably"
+					  " due to forced umount: inodes=" DF_U64 " handles=" DF_U64
+					  " pools= " DF_U64 " containers=" DF_U64,
+					  atomic_load_relaxed(&dfuse_info->di_inode_count),
+					  atomic_load_relaxed(&dfuse_info->di_fh_count),
+					  atomic_load_relaxed(&dfuse_info->di_pool_count),
+					  atomic_load_relaxed(&dfuse_info->di_container_count));
+		}
 	}
 
 	DFUSE_TRA_DOWN(dfuse_info);


### PR DESCRIPTION
When there are open file handles and dfuse is shutdown using umount -f, it would assert due to resources being used.  Rather than asserting, just print a warning that we are shutting down ungracefully.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
