### PR TITLE
DAOS-17127 cart: Fix random rank calcultation

### DIFF
--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -899,6 +899,31 @@ and then restarted to rejoin the system. An failed engine might also be excluded
 from the pools it hosted, please check the pool operation section on how to
 reintegrate an excluded engine.
 
+After one or more DAOS engines being excluded, the DAOS agent cache needs to be
+refresh.  For detailed information, please refer to the [1][System Deployment
+documentation].  Before refreshing the DAOS Agent cache, it should be checked
+that the exclusion information has been spread to the Management Service leader.
+This could be done thanks to the `dump-attachinfo` sub-command of the `daos_agent`
+executable:
+
+```bash
+daos_agent -o /tmp/daos_agent-tmp.yml dump-attachinfo
+```
+
+This usage of the `daos_agent` command needs a minimal DAOS agent configuration
+file `/tmp/daos_agent-tmp.yml` such as:
+
+```yaml
+name: daos_server
+access_points:
+- sertver-1
+port: 10001
+transport_config:
+  allow_insecure: true
+log_file: /tmp/daos_agent-tmp.log
+```
+
+
 ### Shutdown
 
 When up and running, the entire system can be shutdown.
@@ -1043,7 +1068,7 @@ dmg as follows:
 $ dmg storage format -l ${new_storage_node}
 ```
 
-new_storage_node should be replaced with the hostname or the IP address of the
+`new_storage_node` should be replaced with the hostname or the IP address of the
 new storage node (comma separated list or range of hosts for multiple nodes)
 to be added.
 
@@ -1055,6 +1080,11 @@ the system (this can be checked with `dmg system query -v`).
     nodes (if membership is not restricted on the dmg command line). That being
     said, existing pools won't be automatically extended to use the new servers.
     Please see the pool operation section for how to extend the pool membership.
+
+After extending the system, the cache of the `daos_agent` service of the client
+nodes needs to be refresh.  For detailed information, please refer to the
+[1][System Deployment documentation].
+
 
 ## Software Upgrade
 
@@ -1104,3 +1134,5 @@ Examples:
   * daos_server 2.4.0 is only compatible with daos_engine 2.4.0
   * daos_agent 2.6.0 is compatible with daos_server 2.4.0 (2.5 is a development version)
   * dmg 2.4.1 is compatible with daos_server 2.4.0
+
+[1]: <deployment.md#refresh-agent-cache>(Refresh DAOS Agent Cache)

--- a/docs/admin/administration.md
+++ b/docs/admin/administration.md
@@ -900,10 +900,10 @@ from the pools it hosted, please check the pool operation section on how to
 reintegrate an excluded engine.
 
 After one or more DAOS engines being excluded, the DAOS agent cache needs to be
-refresh.  For detailed information, please refer to the [1][System Deployment
+refreshed.  For detailed information, please refer to the [1][System Deployment
 documentation].  Before refreshing the DAOS Agent cache, it should be checked
 that the exclusion information has been spread to the Management Service leader.
-This could be done thanks to the `dump-attachinfo` sub-command of the `daos_agent`
+This could be done using the `dump-attachinfo` sub-command of the `daos_agent`
 executable:
 
 ```bash
@@ -1082,7 +1082,7 @@ the system (this can be checked with `dmg system query -v`).
     Please see the pool operation section for how to extend the pool membership.
 
 After extending the system, the cache of the `daos_agent` service of the client
-nodes needs to be refresh.  For detailed information, please refer to the
+nodes needs to be refreshed.  For detailed information, please refer to the
 [1][System Deployment documentation].
 
 

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -1723,18 +1723,18 @@ Once the service file is installed and `systemctl daemon-reload` has been run to
 reload the configuration, the `daos_agent` can be started through systemd
 as shown above.
 
-#### Disable Agent Cache (Optional)
+#### Refresh Agent Cache
 
-In certain circumstances (e.g. for DAOS development or system evaluation), it
-may be desirable to disable the DAOS Agent's caching mechanism in order to avoid
-stale system information being retained across reformats of a system. The DAOS
-Agent normally caches a map of rank-to-fabric URI lookups as well as client network
-configuration data in order to reduce the number of management RPCs required to
-start an application. When this information becomes stale, the Agent must be
-restarted in order to repopulate the cache with new information.
-Alternatively, the caching mechanism may be disabled, with the tradeoff that
-each application launch will invoke management RPCs in order to obtain system
-connection information.
+In certain circumstances (e.g. [system extension][6] with new servers), it may
+be needed to refresh the DAOS Agent cache.  The DAOS Agent normally caches a map
+of rank-to-fabric URI lookups as well as client network configuration data in
+order to reduce the number of management RPCs required to start an application.
+When this information becomes stale, the cache could be refresh with sending the
+`SIGUSR2` to the `daos_agent` process.  Alternatively, the Agent could be
+restarted in order to repopulate the cache with new information.  Finally, the
+caching mechanism may be disabled, with the tradeoff that each application
+launch will invoke management RPCs in order to obtain system connection
+information.
 
 To disable the DAOS Agent caching mechanism, set the following environment
 variable before starting the `daos_agent` process:
@@ -1747,16 +1747,12 @@ the `[Service]` section before reloading systemd and restarting the
 
 `Environment=DAOS_AGENT_DISABLE_CACHE=true`
 
+It is also possible to disable the `daos_agent` cache with adding the following
+entry into the `daos_agent.yml` configuration file:
 
-[^1]: https://github.com/intel/ipmctl
-
-[^2]: https://github.com/daos-stack/daos/tree/master/utils/config
-
-[^3]: [https://www.open-mpi.org/faq/?category=running\#mpirun-hostfile](https://www.open-mpi.org/faq/?category=running#mpirun-hostfile)
-
-[^4]: https://github.com/daos-stack/daos/tree/master/src/control/README.md
-
-[^5]: https://github.com/pmem/ndctl/issues/130
+```yaml
+disable_caching: true
+```
 
 ## Multi-user DFuse setup
 
@@ -1771,3 +1767,16 @@ fuse and must be enabled by root before any user can use it.  To allow this then
 uncomment a line in `/etc/fuse.conf` to enable the `user_allow_other` setting.  The daos-client rpm
 does not do this automatically. An administrator must set this option on all nodes on which they
 want to provide a persistent multi-user dfuse service.
+
+
+[^1]: https://github.com/intel/ipmctl
+
+[^2]: https://github.com/daos-stack/daos/tree/master/utils/config
+
+[^3]: [https://www.open-mpi.org/faq/?category=running\#mpirun-hostfile](https://www.open-mpi.org/faq/?category=running#mpirun-hostfile)
+
+[^4]: https://github.com/daos-stack/daos/tree/master/src/control/README.md
+
+[^5]: https://github.com/pmem/ndctl/issues/130
+
+[6]: <administration.md#system-extension>(Extension of the DAOS system)

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -1358,9 +1358,6 @@ engines:
 <end>
 ```
 
-There are a few optional providers that are not built by default. For detailed
-information, please refer to the [DAOS build documentation][6].
-
 !!! note
     DAOS Control Servers will need to be restarted on all hosts after updates to the server
     configuration file.
@@ -1369,9 +1366,6 @@ information, please refer to the [DAOS build documentation][6].
     include the hostnames or IP addresses (don't need to specify port) of those hosts.
 
     This will be the set of servers which host the replicated DAOS management service (MS).
-
->The support of the optional providers is not guarantee and can be removed
->without further notification.
 
 ### Network Configuration
 
@@ -1763,8 +1757,6 @@ the `[Service]` section before reloading systemd and restarting the
 [^4]: https://github.com/daos-stack/daos/tree/master/src/control/README.md
 
 [^5]: https://github.com/pmem/ndctl/issues/130
-
-[6]: <../dev/development.md#building-optional-components> (Building DAOS for Development)
 
 ## Multi-user DFuse setup
 

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -1729,26 +1729,46 @@ In certain circumstances (e.g. [system extension][6] with new servers), it may
 be needed to refresh the DAOS Agent cache.  The DAOS Agent normally caches a map
 of rank-to-fabric URI lookups as well as client network configuration data in
 order to reduce the number of management RPCs required to start an application.
-When this information becomes stale, the cache could be refresh with sending the
-`SIGUSR2` to the `daos_agent` process.  Alternatively, the Agent could be
-restarted in order to repopulate the cache with new information.  Finally, the
-caching mechanism may be disabled, with the tradeoff that each application
-launch will invoke management RPCs in order to obtain system connection
-information.
 
-To disable the DAOS Agent caching mechanism, set the following environment
-variable before starting the `daos_agent` process:
+After a new server has been added to the system, or an existing server has been
+permanently removed from the system, the administrator should ensure that the
+Agent is not serving stale system information to new clients. There are three
+options to achieve this goal:
 
-`DAOS_AGENT_DISABLE_CACHE=true`
+1. Send the `SIGUSR2` signal to the `daos_agent` process to force a refresh on
+   demand. This could be done with running the following command
 
-If running from systemd, add the following to the `daos_agent` service file in
-the `[Service]` section before reloading systemd and restarting the
-`daos_agent` service:
+```bash
+pkill -x -SIGUSR2 daos_agent
+```
 
-`Environment=DAOS_AGENT_DISABLE_CACHE=true`
+2. Add a cache expiration value, defined in minutes, to the Agent configuration
+   file `daos_agent.yml` in order to cause a cache refresh when the data is
+   older than the defined value.
 
-It is also possible to disable the `daos_agent` cache with adding the following
-entry into the `daos_agent.yml` configuration file:
+```yaml
+cache_expiration: 30
+```
+
+3. Disable the caching mechanism completely, with the tradeoff that each
+   application launch will invoke management RPCs in order to obtain system
+   connection information.  To disable the DAOS Agent caching mechanism, set the
+   following environment variable before starting the `daos_agent` process:
+
+```bash
+DAOS_AGENT_DISABLE_CACHE=true
+```
+
+   If running from systemd, add the following line to the `daos_agent` service
+   file in the `[Service]` section before reloading systemd and restarting the
+   `daos_agent` service:
+
+```ini
+Environment=DAOS_AGENT_DISABLE_CACHE=true
+```
+
+   It is also possible to disable the `daos_agent` cache with adding the
+   following entry into the `daos_agent.yml` configuration file:
 
 ```yaml
 disable_caching: true

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -106,7 +107,7 @@ daos_eq_lib_reset_after_fork(void)
 	eq_ref            = 0;
 	ev_thpriv_is_init = false;
 	crt_info          = daos_crt_init_opt_get(false, 1);
-	rc                = dc_mgmt_net_cfg(NULL, crt_info);
+	rc                = dc_mgmt_net_cfg_init(NULL, crt_info);
 	if (rc == 0)
 		rc = daos_eq_lib_init(crt_info);
 	D_FREE(crt_info->cio_provider);

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -213,7 +213,7 @@ daos_init(void)
 	 * get CaRT configuration (see mgmtModule.handleGetAttachInfo for the
 	 * handling of NULL system names)
 	 */
-	rc = dc_mgmt_net_cfg(NULL, crt_info);
+	rc = dc_mgmt_net_cfg_init(NULL, crt_info);
 	if (rc != 0)
 		D_GOTO(out_attach, rc);
 
@@ -231,7 +231,7 @@ daos_init(void)
 	D_FREE(crt_info->cio_domain);
 	if (rc != 0) {
 		D_ERROR("failed to initialize eq_lib: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_attach, rc);
+		D_GOTO(out_net_cfg, rc);
 	}
 
 	/**
@@ -290,6 +290,8 @@ out_pl:
 	pl_fini();
 out_eq:
 	daos_eq_lib_fini();
+out_net_cfg:
+	dc_mgmt_net_cfg_fini()
 out_attach:
 	dc_tm_fini();
 	dc_mgmt_drop_attach_info();
@@ -353,6 +355,7 @@ daos_fini(void)
 	if (rc != 0)
 		D_ERROR("failed to disconnect some resources may leak, " DF_RC "\n", DP_RC(rc));
 
+	dc_mgmt_net_cfg_fini();
 	dc_tm_fini();
 	dc_mgmt_drop_attach_info();
 	dc_agent_fini();

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -291,7 +291,7 @@ out_pl:
 out_eq:
 	daos_eq_lib_fini();
 out_net_cfg:
-	dc_mgmt_net_cfg_fini()
+	dc_mgmt_net_cfg_fini();
 out_attach:
 	dc_tm_fini();
 	dc_mgmt_drop_attach_info();

--- a/src/client/api/rpc.c
+++ b/src/client/api/rpc.c
@@ -122,7 +122,7 @@ query_cb(struct crt_proto_query_cb_info *cb_info)
 		nr_ranks = dc_mgmt_net_get_num_srv_ranks();
 		D_ASSERT(nr_ranks > 0);
 		rproto->rank_idx = (rproto->rank_idx + 1) % nr_ranks;
-		rank = dc_mgmt_net_get_srv_rank(rproto->rank_idx);
+		rank             = dc_mgmt_net_get_srv_rank(rproto->rank_idx);
 		D_ASSERT(rank != CRT_NO_RANK);
 		rproto->ep.ep_rank = rank;
 
@@ -170,7 +170,7 @@ daos_rpc_proto_query(crt_opcode_t base_opc, uint32_t *ver_array, int count, int 
 		D_GOTO(out_free, -DER_NONEXIST);
 	}
 	rproto->rank_idx = d_rand() % nr_ranks;
-	rank = dc_mgmt_net_get_srv_rank(rproto->rank_idx);
+	rank             = dc_mgmt_net_get_srv_rank(rproto->rank_idx);
 	D_ASSERT(rank != CRT_NO_RANK);
 	rproto->ep.ep_rank = rank;
 

--- a/src/client/api/rpc.c
+++ b/src/client/api/rpc.c
@@ -111,7 +111,7 @@ struct rpc_proto {
 static d_rank_t
 get_rand_rank(void)
 {
-	int           idx;
+	int idx;
 
 	idx = d_rand() % dc_mgmt_net_get_num_srv_ranks();
 	return dc_mgmt_net_get_srv_rank(idx);

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -76,7 +76,7 @@ int dc_mgmt_notify_pool_connect(struct dc_pool *pool);
 int dc_mgmt_notify_pool_disconnect(struct dc_pool *pool);
 int dc_mgmt_notify_exit(void);
 int dc_mgmt_net_get_num_srv_ranks(void);
-int dc_mgmt_net_get_srv_rank(int idx, d_rank_t *rank);
+d_rank_t dc_mgmt_net_get_srv_rank(int idx);
 int dc_mgmt_get_sys_info(const char *sys, struct daos_sys_info **info);
 void dc_mgmt_put_sys_info(struct daos_sys_info *info);
 int dc_get_attach_info(const char *name, bool all_ranks, struct dc_mgmt_sys_info *info,

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -76,7 +76,7 @@ int dc_mgmt_notify_pool_connect(struct dc_pool *pool);
 int dc_mgmt_notify_pool_disconnect(struct dc_pool *pool);
 int dc_mgmt_notify_exit(void);
 int dc_mgmt_net_get_num_srv_ranks(void);
-d_rank_t dc_mgmt_net_get_srv_rank(int idx);
+int dc_mgmt_net_get_srv_rank(int idx, d_rank_t *rank);
 int dc_mgmt_get_sys_info(const char *sys, struct daos_sys_info **info);
 void dc_mgmt_put_sys_info(struct daos_sys_info *info);
 int dc_get_attach_info(const char *name, bool all_ranks, struct dc_mgmt_sys_info *info,

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -75,6 +75,7 @@ int dc_mgmt_notify_pool_connect(struct dc_pool *pool);
 int dc_mgmt_notify_pool_disconnect(struct dc_pool *pool);
 int dc_mgmt_notify_exit(void);
 int dc_mgmt_net_get_num_srv_ranks(void);
+d_rank_t dc_mgmt_net_get_srv_rank(int idx);
 int dc_mgmt_get_sys_info(const char *sys, struct daos_sys_info **info);
 void dc_mgmt_put_sys_info(struct daos_sys_info *info);
 int dc_get_attach_info(const char *name, bool all_ranks, struct dc_mgmt_sys_info *info,

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -66,7 +66,7 @@ ssize_t dc_mgmt_sys_decode(void *buf, size_t len, struct dc_mgmt_sys **sysp);
 int
 dc_mgmt_net_cfg_init(const char *name, crt_init_options_t *crt_info);
 void
-dc_mgmt_net_cfg_fini(void);
+    dc_mgmt_net_cfg_fini(void);
 
 int dc_mgmt_net_cfg_check(const char *name);
 int dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -76,7 +76,8 @@ int dc_mgmt_notify_pool_connect(struct dc_pool *pool);
 int dc_mgmt_notify_pool_disconnect(struct dc_pool *pool);
 int dc_mgmt_notify_exit(void);
 int dc_mgmt_net_get_num_srv_ranks(void);
-d_rank_t dc_mgmt_net_get_srv_rank(int idx);
+d_rank_t
+     dc_mgmt_net_get_srv_rank(int idx);
 int dc_mgmt_get_sys_info(const char *sys, struct daos_sys_info **info);
 void dc_mgmt_put_sys_info(struct daos_sys_info *info);
 int dc_get_attach_info(const char *name, bool all_ranks, struct dc_mgmt_sys_info *info,

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -63,9 +63,11 @@ void dc_mgmt_sys_detach(struct dc_mgmt_sys *sys);
 ssize_t dc_mgmt_sys_encode(struct dc_mgmt_sys *sys, void *buf, size_t cap);
 ssize_t dc_mgmt_sys_decode(void *buf, size_t len, struct dc_mgmt_sys **sysp);
 
-int dc_mgmt_net_cfg_init(const char *name, crt_init_options_t *crt_info);
+int
+dc_mgmt_net_cfg_init(const char *name, crt_init_options_t *crt_info);
 void
-    dc_mgmt_net_cfg_fini(void);
+dc_mgmt_net_cfg_fini(void);
+
 int dc_mgmt_net_cfg_check(const char *name);
 int dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 			       d_rank_list_t **svcranksp);

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -63,9 +63,9 @@ void dc_mgmt_sys_detach(struct dc_mgmt_sys *sys);
 ssize_t dc_mgmt_sys_encode(struct dc_mgmt_sys *sys, void *buf, size_t cap);
 ssize_t dc_mgmt_sys_decode(void *buf, size_t len, struct dc_mgmt_sys **sysp);
 
-int
-     dc_mgmt_net_cfg_init(const char *name, crt_init_options_t *crt_info);
-void dc_mgmt_net_cfg_fini(void);
+int dc_mgmt_net_cfg_init(const char *name, crt_init_options_t *crt_info);
+void
+    dc_mgmt_net_cfg_fini(void);
 int dc_mgmt_net_cfg_check(const char *name);
 int dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 			       d_rank_list_t **svcranksp);

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -64,7 +64,8 @@ ssize_t dc_mgmt_sys_encode(struct dc_mgmt_sys *sys, void *buf, size_t cap);
 ssize_t dc_mgmt_sys_decode(void *buf, size_t len, struct dc_mgmt_sys **sysp);
 
 int
-     dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info);
+     dc_mgmt_net_cfg_init(const char *name, crt_init_options_t *crt_info);
+void dc_mgmt_net_cfg_fini(void);
 int dc_mgmt_net_cfg_check(const char *name);
 int dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 			       d_rank_list_t **svcranksp);

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -587,7 +587,7 @@ _split_env(char *env, char **name, char **value)
  * Configure the client's local environment with these parameters
  */
 int
-dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
+dc_mgmt_net_cfg_init(const char *name, crt_init_options_t *crt_info)
 {
 	int                      rc;
 	char                    *cli_srx_set        = NULL;
@@ -740,6 +740,12 @@ cleanup:
 	d_freeenv_str(&cli_srx_set);
 
 	return rc;
+}
+
+void
+dc_mgmt_net_cfg_fini()
+{
+	D_FREE(g_serv_ranks);
 }
 
 int dc_mgmt_net_cfg_check(const char *name)
@@ -1635,8 +1641,6 @@ dc_mgmt_fini()
 
 	if (rc != 0)
 		D_ERROR("failed to unregister mgmt RPCs: "DF_RC"\n", DP_RC(rc));
-
-	D_FREE(g_serv_ranks);
 }
 
 int dc2_mgmt_svc_rip(tse_task_t *task)

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -550,20 +550,17 @@ dc_mgmt_net_get_num_srv_ranks(void)
 }
 
 /* Return the rank id of an attached rank.  */
-int
-dc_mgmt_net_get_srv_rank(int idx, d_rank_t *rank)
+d_rank_t
+dc_mgmt_net_get_srv_rank(int idx)
 {
-	D_ASSERT(rank != NULL);
 	D_ASSERT(g_num_serv_ranks >= 0);
 
 	if (idx >= g_num_serv_ranks) {
 		D_ERROR("Invalid rank index: index=%d, ranks_num=%d\n", idx, g_num_serv_ranks);
-		return -DER_NONEXIST;
+		return CRT_NO_RANK;
 	}
 
-	*rank =  g_serv_ranks[idx];
-
-	return -DER_SUCCESS;
+	return g_serv_ranks[idx];
 }
 
 static int
@@ -711,8 +708,6 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 		if (NULL == crt_info->cio_domain)
 			D_GOTO(cleanup, rc = -DER_NOMEM);
 	}
-	D_INFO("Network interface: %s, Domain: %s, Provider: %s\n", crt_info->cio_interface,
-	       crt_info->cio_domain, crt_info->cio_provider);
 	D_DEBUG(DB_MGMT,
 		"CaRT initialization with:\n"
 		"\tD_PROVIDER: %s, CRT_TIMEOUT: %d, CRT_SECONDARY_PROVIDER: %s\n",
@@ -730,7 +725,10 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 	}
 	D_FREE(g_serv_ranks);
 	g_serv_ranks = serv_ranks_tmp;
-	D_INFO("Setting number of attached server ranks to %d\n", g_num_serv_ranks);
+
+	D_INFO("Network interface: %s, Domain: %s, Provider: %s, Ranks count: %d\n",
+	       crt_info->cio_interface, crt_info->cio_domain, crt_info->cio_providerm,
+ 	       g_num_serv_ranks);
 
 cleanup:
 	if (rc) {

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -728,7 +728,7 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 
 	D_INFO("Network interface: %s, Domain: %s, Provider: %s, Ranks count: %d\n",
 	       crt_info->cio_interface, crt_info->cio_domain, crt_info->cio_providerm,
- 	       g_num_serv_ranks);
+	       g_num_serv_ranks);
 
 cleanup:
 	if (rc) {

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -537,10 +538,20 @@ dc_mgmt_put_sys_info(struct daos_sys_info *info)
 #define SYS_INFO_BUF_SIZE 16
 
 static int g_num_serv_ranks = 1;
+static d_rank_t *g_serv_ranks;
 
 int dc_mgmt_net_get_num_srv_ranks(void)
 {
 	return g_num_serv_ranks;
+}
+
+d_rank_t
+dc_mgmt_net_get_srv_rank(int idx)
+{
+	D_ASSERT(g_serv_ranks != NULL);
+	D_ASSERT(idx >= 0 && idx < g_num_serv_ranks);
+
+	return g_serv_ranks[idx];
 }
 
 static int
@@ -575,6 +586,7 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 	char                     buf[SYS_INFO_BUF_SIZE];
 	struct dc_mgmt_sys_info *info = &info_g;
 	Mgmt__GetAttachInfoResp *resp = resp_g;
+	int                      idx;
 
 	if (resp->client_net_hint != NULL && resp->client_net_hint->n_env_vars > 0) {
 		int i;
@@ -603,6 +615,13 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 	/* Save number of server ranks */
 	g_num_serv_ranks = resp->n_rank_uris;
 	D_INFO("Setting number of server ranks to %d\n", g_num_serv_ranks);
+
+	/* Save ranks id */
+	D_ALLOC_ARRAY(g_serv_ranks, g_num_serv_ranks);
+	if (g_serv_ranks == NULL)
+		D_GOTO(cleanup, rc = -DER_NOMEM);
+	for (idx = 0; idx < g_num_serv_ranks; idx++)
+		g_serv_ranks[idx] = resp->rank_uris[idx]->rank;
 
 	/* If the server has set this, the client must use the same value. */
 	if (info->srv_srx_set != -1) {
@@ -699,6 +718,7 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 
 cleanup:
 	if (rc) {
+		D_FREE(g_serv_ranks);
 		D_FREE(crt_info->cio_provider);
 		D_FREE(crt_info->cio_interface);
 		D_FREE(crt_info->cio_domain);

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -537,7 +537,7 @@ dc_mgmt_put_sys_info(struct daos_sys_info *info)
 
 #define SYS_INFO_BUF_SIZE 16
 
-static int g_num_serv_ranks = -1;
+static int       g_num_serv_ranks = -1;
 static d_rank_t *g_serv_ranks;
 
 /* Return the number of attached ranks.  */

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -727,7 +727,7 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 	g_serv_ranks = serv_ranks_tmp;
 
 	D_INFO("Network interface: %s, Domain: %s, Provider: %s, Ranks count: %d\n",
-	       crt_info->cio_interface, crt_info->cio_domain, crt_info->cio_providerm,
+	       crt_info->cio_interface, crt_info->cio_domain, crt_info->cio_provider,
 	       g_num_serv_ranks);
 
 cleanup:

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -537,21 +537,33 @@ dc_mgmt_put_sys_info(struct daos_sys_info *info)
 
 #define SYS_INFO_BUF_SIZE 16
 
-static int g_num_serv_ranks = 1;
+static int g_num_serv_ranks = -1;
 static d_rank_t *g_serv_ranks;
 
-int dc_mgmt_net_get_num_srv_ranks(void)
+/* Return the number of attached ranks.  */
+int
+dc_mgmt_net_get_num_srv_ranks(void)
 {
+	D_ASSERT(g_num_serv_ranks >= 0);
+
 	return g_num_serv_ranks;
 }
 
-d_rank_t
-dc_mgmt_net_get_srv_rank(int idx)
+/* Return the rank id of an attached rank.  */
+int
+dc_mgmt_net_get_srv_rank(int idx, d_rank_t *rank)
 {
-	D_ASSERT(g_serv_ranks != NULL);
-	D_ASSERT(idx >= 0 && idx < g_num_serv_ranks);
+	D_ASSERT(rank != NULL);
+	D_ASSERT(g_num_serv_ranks >= 0);
 
-	return g_serv_ranks[idx];
+	if (idx >= g_num_serv_ranks) {
+		D_ERROR("Invalid rank index: index=%d, ranks_num=%d\n", idx, g_num_serv_ranks);
+		return -DER_NONEXIST;
+	}
+
+	*rank =  g_serv_ranks[idx];
+
+	return -DER_SUCCESS;
 }
 
 static int
@@ -587,6 +599,7 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 	struct dc_mgmt_sys_info *info = &info_g;
 	Mgmt__GetAttachInfoResp *resp = resp_g;
 	int                      idx;
+	d_rank_t                *serv_ranks_tmp;
 
 	if (resp->client_net_hint != NULL && resp->client_net_hint->n_env_vars > 0) {
 		int i;
@@ -611,17 +624,6 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 			D_DEBUG(DB_MGMT, "set server-supplied client env: %s", env);
 		}
 	}
-
-	/* Save number of server ranks */
-	g_num_serv_ranks = resp->n_rank_uris;
-	D_INFO("Setting number of server ranks to %d\n", g_num_serv_ranks);
-
-	/* Save ranks id */
-	D_ALLOC_ARRAY(g_serv_ranks, g_num_serv_ranks);
-	if (g_serv_ranks == NULL)
-		D_GOTO(cleanup, rc = -DER_NOMEM);
-	for (idx = 0; idx < g_num_serv_ranks; idx++)
-		g_serv_ranks[idx] = resp->rank_uris[idx]->rank;
 
 	/* If the server has set this, the client must use the same value. */
 	if (info->srv_srx_set != -1) {
@@ -716,9 +718,22 @@ dc_mgmt_net_cfg(const char *name, crt_init_options_t *crt_info)
 		"\tD_PROVIDER: %s, CRT_TIMEOUT: %d, CRT_SECONDARY_PROVIDER: %s\n",
 		crt_info->cio_provider, crt_info->cio_crt_timeout, buf);
 
+	/* Save attached ranks id info */
+	g_num_serv_ranks = resp->n_rank_uris;
+	serv_ranks_tmp   = NULL;
+	if (g_num_serv_ranks > 0) {
+		D_ALLOC_ARRAY(serv_ranks_tmp, g_num_serv_ranks);
+		if (serv_ranks_tmp == NULL)
+			D_GOTO(cleanup, rc = -DER_NOMEM);
+		for (idx = 0; idx < g_num_serv_ranks; idx++)
+			serv_ranks_tmp[idx] = resp->rank_uris[idx]->rank;
+	}
+	D_FREE(g_serv_ranks);
+	g_serv_ranks = serv_ranks_tmp;
+	D_INFO("Setting number of attached server ranks to %d\n", g_num_serv_ranks);
+
 cleanup:
 	if (rc) {
-		D_FREE(g_serv_ranks);
 		D_FREE(crt_info->cio_provider);
 		D_FREE(crt_info->cio_interface);
 		D_FREE(crt_info->cio_domain);
@@ -1622,6 +1637,8 @@ dc_mgmt_fini()
 
 	if (rc != 0)
 		D_ERROR("failed to unregister mgmt RPCs: "DF_RC"\n", DP_RC(rc));
+
+	D_FREE(g_serv_ranks);
 }
 
 int dc2_mgmt_svc_rip(tse_task_t *task)


### PR DESCRIPTION
### Description

When one or more ranks are excluded, the calculation for sending RPC to a service rank is invalid: it will eventually select a rank which has been excluded.
Moreover, if the system has been extended after evicting one or more ranks, then the new rank will never be used.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
