### PR TITLE
DAOS-4753 test: New OSA tests to validate multiple ranks.

### DIFF
--- a/src/tests/ftest/osa/offline_drain.py
+++ b/src/tests/ftest/osa/offline_drain.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -31,7 +32,8 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
         # Recreate the client hostfile without slots defined
         self.hostfile_clients = write_host_file(self.hostlist_clients, self.workdir)
 
-    def run_offline_drain_test(self, num_pool, data=False, oclass=None, pool_fillup=0):
+    def run_offline_drain_test(self, num_pool, data=False, oclass=None, pool_fillup=0,
+                               multiple_ranks=False):
         """Run the offline drain without data.
 
         Args:
@@ -39,6 +41,7 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
             data (bool) : whether pool has no data or to create some data in pool.
                 Defaults to False.
             oclass (str): DAOS object class (eg: RP_2G1,etc)
+            multiple_ranks (bool) : Perform multiple ranks testing (Default: False)
         """
         # Create a pool
         pool = {}
@@ -46,6 +49,10 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
 
         if oclass is None:
             oclass = self.ior_cmd.dfs_oclass.value
+
+        # For testing multiple ranks as dmg parameters, use a list of ranks.
+        if multiple_ranks is True:
+            self.ranks = self.multiple_ranks
 
         # Exclude target : random two targets  (target idx : 0-7)
         exc = random.randint(0, 6)  # nosec
@@ -258,3 +265,17 @@ class OSAOfflineDrain(OSAUtils, ServerFillUp):
         oclass = self.params.get("pool_test_oclass", '/run/pool_capacity/*')
         pool_fillup = self.params.get("pool_fillup", '/run/pool_capacity/*')
         self.run_offline_drain_test(1, data=True, oclass=oclass, pool_fillup=pool_fillup)
+
+    def test_osa_offline_drain_with_multiple_ranks(self):
+        """Test ID: DAOS-4753.
+
+        Test Description: Drain multiple ranks at the same time.
+
+        :avocado: tags=all,full_regression
+        :avocado: tags=hw,medium
+        :avocado: tags=osa,osa_drain,offline_drain,offline_drain_full
+        :avocado: tags=OSAOfflineDrain,test_osa_offline_drain_with_multiple_ranks
+        """
+        self.log.info("Offline Drain : Test with multiple ranks")
+        self.multiple_ranks = self.params.get("rank_list", '/run/multiple_ranks/*')
+        self.run_offline_drain_test(1, data=True, multiple_ranks=True)

--- a/src/tests/ftest/osa/offline_drain.yaml
+++ b/src/tests/ftest/osa/offline_drain.yaml
@@ -100,6 +100,8 @@ checksum:
   test_with_checksum: false
 snapshot:
   test_with_snapshot: true
+mutliple_ranks:
+  rank_list: ["1, 2"]
 test_ranks:
   rank_list: ["2", "5"]
 pool_capacity:

--- a/src/tests/ftest/osa/online_drain.yaml
+++ b/src/tests/ftest/osa/online_drain.yaml
@@ -90,3 +90,5 @@ rebuild:
   test_with_rebuild: true
 checksum:
   test_with_checksum: false
+mutliple_ranks:
+  rank_list: ["1, 2"]


### PR DESCRIPTION
Test-tag: OSAOnlineReintegration OSAOnlineDrain OSAOfflineReintegration OSAOfflineDrain
Skip-unit-tests: true

Summary:
  - Add new OSA tests to validate multiple ranks support via dmg commands.
  - Updates are done for drain and reintegration tests (offline/online)

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
