### PR TITLE
DAOS-623 ci: Simplify the pull request template (#15969)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,9 @@
-### Before requesting gatekeeper:
+### Steps for the author:
 
-* [ ] Two review approvals and any prior change requests have been resolved.
-* [ ] Testing is complete and all tests passed or there is a reason documented in the PR why it should be force landed and forced-landing tag is set.
-* [ ] `Features:` (or `Test-tag*`) commit pragma was used or there is a reason documented that there are no appropriate tags for this PR.
-* [ ] Commit messages follows the guidelines outlined [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
-* [ ] Any tests skipped by the ticket being addressed have been run and passed in the PR.
+* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
+* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
+* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
+* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.
 
-### Gatekeeper:
-
-* [ ] You are the appropriate gatekeeper to be landing the patch.
-* [ ] The PR has 2 reviews by people familiar with the code, including appropriate owners.
-* [ ] Githooks were used. If not, request that user install them and check copyright dates.
-* [ ] Checkpatch issues are resolved.  Pay particular attention to ones that will show up on future PRs.
-* [ ] All builds have passed.  Check non-required builds for any new compiler warnings.
-* [ ] Sufficient testing is done. Check feature pragmas and test tags and that tests skipped for the ticket are run and now pass with the changes.
-* [ ] If applicable, the PR has addressed any potential version compatibility issues.
-* [ ] Check the target branch.   If it is master branch, should the PR go to a feature branch?  If it is a release branch, does it have merge approval in the JIRA ticket.
-* [ ] Extra checks if forced landing is requested
-  * [ ] Review comments are sufficiently resolved, particularly by prior reviewers that requested changes.
-  * [ ] No new NLT or valgrind warnings.  Check the classic view.
-  * [ ] Quick-build or Quick-functional is not used.
-* [ ] Fix the commit message upon landing. Check the standard [here](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments). Edit it to create a single commit. If necessary, ask submitter for a new summary.
+#### After all prior steps are complete:
+* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 * [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
 * [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
+* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
 * [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
 * [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.
 


### PR DESCRIPTION
Document just the essentials

Signed-off-by: Jeff Olivier <jolivier23@gmail.com>
Co-authored-by: Dalton Bohning <dalton.bohning@hpe.com>

DAOS-17204 ci: Update the pull request template (#16002)

Add a reminder to enable the appropriate functional test stages in a PR.

Signed-off-by: Phil Henderson <phillip.henderson@hpe.com>

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
