### PR TITLE
DAOS-XXX object: Improve firewall handling

### DIFF
--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -119,7 +120,9 @@ extern "C" {
 	/** Fatal (non-retry-able) transport layer mercury error */                                \
 	ACTION(DER_HG_FATAL, Fatal transport layer mercury error)                                  \
 	/** Quota limit reached on the requested resource */                                       \
-	ACTION(DER_QUOTA_LIMIT, Quota limit reached)
+	ACTION(DER_QUOTA_LIMIT, Quota limit reached)                     \
+	/** Client has indicated it's behind a firewall. Client must establish a connection */     \
+	ACTION(DER_CLIENT_UNREACH, Client was unreachable on bulk transfer)
 	/** TODO: add more error numbers */
 
 /** Preprocessor macro defining DAOS errno values and internal definition of d_errstr */


### PR DESCRIPTION
When a client is behind a firewall, rather than open it up to server connections, we can instead encode that information into the URI of the client.  In such cases where a connection would be needed, the server will return an error indicating such.  The client should ping servers involved in the request in such cases to establish a connection and then retry the request.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
