### PR TITLE
Merge release/2.6 into google/2.6

### DIFF
--- a/src/client/dfuse/pil4dfs/int_dfs.c
+++ b/src/client/dfuse/pil4dfs/int_dfs.c
@@ -162,7 +162,7 @@ static long int         page_size;
 #define DAOS_INIT_RUNNING     1
 
 static _Atomic uint64_t mpi_init_count;
-static _Atomic int64_t  zeInit_count;
+static _Atomic int64_t  dlopen_count;
 
 static long int         daos_initing;
 _Atomic bool            d_daos_inited;
@@ -473,9 +473,7 @@ static int (*next_tcgetattr)(int fd, void *termios_p);
 
 static int (*next_mpi_init)(int *argc, char ***argv);
 static int (*next_pmpi_init)(int *argc, char ***argv);
-static int (*next_ze_init)(int flags);
-static void *(*next_dlsym)(void *handle, const char *symbol);
-static void *(*new_dlsym)(void *handle, const char *symbol);
+static void *(*next_dlopen)(const char *filename, int flags);
 
 /* to do!! */
 /**
@@ -1062,142 +1060,19 @@ PMPI_Init(int *argc, char ***argv)
 	return rc;
 }
 
-int
-zeInit(int flags)
+void *
+new_dlopen(const char *filename, int flags)
 {
-	int rc;
+	void *rc;
 
-	if (next_ze_init == NULL) {
-		if (d_hook_enabled)
-			next_ze_init = next_dlsym(RTLD_NEXT, "zeInit");
-		else
-			next_ze_init = dlsym(RTLD_NEXT, "zeInit");
-	}
-	D_ASSERT(next_ze_init != NULL);
-	atomic_fetch_add_relaxed(&zeInit_count, 1);
-	rc = next_ze_init(flags);
-	atomic_fetch_add_relaxed(&zeInit_count, -1);
+	if (!d_hook_enabled)
+		return next_dlopen(filename, flags);
+
+	atomic_fetch_add_relaxed(&dlopen_count, 1);
+	rc = next_dlopen(filename, flags);
+	atomic_fetch_add_relaxed(&dlopen_count, -1);
 	return rc;
 }
-
-#if defined(__x86_64__)
-/* This is used to work around compiling warning and limitations of using asm function. */
-static void *
-query_new_dlsym_addr(void *addr)
-{
-	int i;
-
-	/* assume little endian */
-	for (i = 0; i < 64; i++) {
-		/* 0x56579090 is corresponding to the first four instructions at new_dlsym_asm.
-		 * 0x90 - nop, 0x90 - nop, 0x57 - push %rdi, 0x56 - push %rsi
-		 */
-		if (*((int *)(addr + i)) == 0x56579090) {
-			/* two nop are added for easier positioning. offset +2 here to skip two
-			 * nop and start from the real entry.
-			 */
-			return ((void *)(addr + i + 2));
-		}
-	}
-	return NULL;
-}
-
-_Pragma("GCC diagnostic push")
-_Pragma("GCC diagnostic ignored \"-Wunused-function\"")
-_Pragma("GCC diagnostic ignored \"-Wunused-variable\"")
-
-_Pragma("GCC push_options")
-_Pragma("GCC optimize(\"-O0\")")
-static char str_zeinit[] = "zeInit";
-
-static int
-is_hook_enabled(void)
-{
-	return (d_hook_enabled ? (1) : (0));
-}
-
-/* This wrapper function is introduced to avoid compiling issue with Intel-C on Leap 15.5 */
-static int
-my_strcmp(const char *s1, const char *s2)
-{
-	return strcmp(s1, s2);
-}
-
-static void *
-get_zeinit_addr(void)
-{
-	return (void *)zeInit;
-}
-
-__attribute__((aligned(16))) static void
-new_dlsym_marker(void)
-{
-}
-
-__asm__(
-	"new_dlsym_asm:\n"
-	"nop\n"
-	"nop\n"
-	"push %rdi\n"
-	"push %rsi\n"
-
-	"call is_hook_enabled\n"
-	"test %eax,%eax\n"
-	"je org_dlsym\n"
-
-	"mov %rsi, %rdi\n"
-	"lea str_zeinit(%rip), %rsi\n"
-	"call my_strcmp\n"
-	"test %eax,%eax\n"
-	"jne org_dlsym\n"
-
-	"pop %rsi\n"
-	"pop %rdi\n"
-	"call *next_dlsym(%rip)\n"
-	"mov %rax, next_ze_init(%rip)\n"
-
-	"test %eax,%eax\n"
-	"jne found\n"
-	"ret\n"
-
-	"found:\n"
-	"call get_zeinit_addr\n"
-	"ret\n"
-
-	"org_dlsym:\n"
-	"pop %rsi\n"
-	"pop %rdi\n"
-	"jmp *next_dlsym(%rip)\n"
-);
-_Pragma("GCC pop_options")
-_Pragma("GCC diagnostic pop")
-
-#else
-/* c code for other architecture. caller info could be wrong inside libc dlsym() when handle is set
- * RTLD_NEXT. Assembly version implementation similar to above is needed to fix the issue by using
- * jump instead of call instruction. 
- */
-static void *
-new_dlsym_c(void *handle, const char *symbol)
-{
-	if (!d_hook_enabled)
-		goto org_dlsym;
-	printf("Inside my dlsym().\n");
-	if (strcmp(symbol, "zeInit") != 0)
-		goto org_dlsym;
-
-	next_ze_init = next_dlsym(handle, symbol);
-	if (next_ze_init)
-		/* dlsym() finished successfully, then intercept zeInit() */
-		return zeInit;
-	else
-		return next_ze_init;
-
-org_dlsym:
-	/* Ideally we need to adjust stack and jump to next_dlsym(). */
-	return next_dlsym(handle, symbol);
-}
-#endif
 
 /** determine whether a path (both relative and absolute) is on DAOS or not. If yes,
  *  returns parent object, item name, full path of parent dir, full absolute path, and
@@ -1305,11 +1180,11 @@ query_path(const char *szInput, int *is_target_path, struct dcache_rec **parent,
 				goto out_normal;
 			}
 
-			/* Check whether zeInit() is running. If yes, pass to the original
+			/* Check whether dlopen() is running. If yes, pass to the original
 			 * libc functions. Avoid possible zeInit reentrancy/nested call.
 			 */
 
-			if (atomic_load_relaxed(&zeInit_count) > 0) {
+			if (atomic_load_relaxed(&dlopen_count) > 0) {
 				*is_target_path = 0;
 				goto out_normal;
 			}
@@ -3545,6 +3420,7 @@ statfs(const char *pathname, struct statfs *sfs)
 	sfs->f_files  = -1;
 	sfs->f_ffree  = -1;
 	sfs->f_bavail = sfs->f_bfree;
+	sfs->f_type   = DAOS_SUPER_MAGIC;
 
 	drec_decref(dfs_mt->dcache, parent);
 	FREE(parent_dir);
@@ -3602,6 +3478,7 @@ fstatfs(int fd, struct statfs *sfs)
 	sfs->f_files  = -1;
 	sfs->f_ffree  = -1;
 	sfs->f_bavail = sfs->f_bfree;
+	sfs->f_type   = DAOS_SUPER_MAGIC;
 
 	return 0;
 }
@@ -3653,6 +3530,7 @@ statvfs(const char *pathname, struct statvfs *svfs)
 	svfs->f_files  = -1;
 	svfs->f_ffree  = -1;
 	svfs->f_bavail = svfs->f_bfree;
+	svfs->f_fsid   = DAOS_SUPER_MAGIC;
 
 	drec_decref(dfs_mt->dcache, parent);
 	FREE(parent_dir);
@@ -7038,17 +6916,11 @@ init_myhook(void)
 	register_a_hook("libc", "exit", (void *)new_exit, (long int *)(&next_exit));
 	register_a_hook("libc", "dup3", (void *)new_dup3, (long int *)(&libc_dup3));
 
-#if defined(__x86_64__)
-	new_dlsym = query_new_dlsym_addr(new_dlsym_marker);
-#else
-	new_dlsym = new_dlsym_c;
-#endif
-	D_ASSERT(new_dlsym != NULL);
 	libc_version = query_libc_version();
 	if (libc_ver_cmp(libc_version, 2.34) < 0)
-		register_a_hook("libdl", "dlsym", (void *)new_dlsym, (long int *)(&next_dlsym));
+		register_a_hook("libdl", "dlopen", (void *)new_dlopen, (long int *)(&next_dlopen));
 	else
-		register_a_hook("libc", "dlsym", (void *)new_dlsym, (long int *)(&next_dlsym));
+		register_a_hook("libc", "dlopen", (void *)new_dlopen, (long int *)(&next_dlopen));
 
 	init_fd_dup2_list();
 
@@ -7061,9 +6933,6 @@ init_myhook(void)
 		dcache_rec_timeout = 0;
 
 	install_hook();
-
-	/* Check it here to minimize the work in function new_dlsym() written in assembly */
-	D_ASSERT(next_dlsym != NULL);
 
 	d_hook_enabled   = 1;
 	hook_enabled_bak = d_hook_enabled;

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1179,7 +1179,7 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti, struct dtx_epoch *epoch,
 
 	D_ALLOC(dlh, sizeof(*dlh) + sizeof(struct dtx_sub_status) * tgt_cnt);
 	if (dlh == NULL)
-		return -DER_NOMEM;
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	dlh->dlh_future = ABT_FUTURE_NULL;
 	dlh->dlh_coll_entry = dce;
@@ -1217,11 +1217,13 @@ dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti, struct dtx_epoch *epoch,
 	if (rc == 0 && sub_modification_cnt > 0)
 		rc = vos_dtx_attach(dth, false, (flags & DTX_PREPARED) ? true : false);
 
-	D_DEBUG(DB_IO, "Start (%s) DTX "DF_DTI" sub modification %d, ver %u, epoch "
-		DF_X64", leader "DF_UOID", dti_cos_cnt %d, tgt_cnt %d, flags %x: "DF_RC"\n",
-		dlh->dlh_coll ? (dlh->dlh_relay ? "relay" : "collective") : "regular",
-		DP_DTI(dti), sub_modification_cnt, dth->dth_ver, epoch->oe_value,
-		DP_UOID(*leader_oid), dti_cos_cnt, tgt_cnt, flags, DP_RC(rc));
+out:
+	DL_CDEBUG(rc != 0, DLOG_ERR, DB_IO, rc,
+		  "Start (%s) DTX " DF_DTI " sub modification %d, "
+		  "ver %u, eph " DF_X64 ", leader " DF_UOID ", cos_cnt %d, tgt_cnt %d, flags %x: ",
+		  flags & DTX_TGT_COLL ? (flags & DTX_RELAY ? "relay" : "collective") : "regular",
+		  DP_DTI(dti), sub_modification_cnt, pm_ver, epoch->oe_value, DP_UOID(*leader_oid),
+		  dti_cos_cnt, tgt_cnt, flags);
 
 	if (rc != 0) {
 		D_FREE(dlh);
@@ -2083,8 +2085,9 @@ dtx_sub_comp_cb(struct dtx_leader_handle *dlh, int idx, int rc)
 		sub->dss_comp = 1;
 		sub->dss_result = rc;
 
-		D_DEBUG(DB_TRACE, "execute from idx %d (%d:%d), flags %x: rc %d\n",
-			idx, tgt->st_rank, tgt->st_tgt_idx, tgt->st_flags, rc);
+		DL_CDEBUG(rc == -DER_NOMEM, DLOG_ERR, DB_TRACE, rc,
+			  "execute from idx %d (%d:%d), flags %x", idx, tgt->st_rank,
+			  tgt->st_tgt_idx, tgt->st_flags);
 	}
 
 	rc = ABT_future_set(dlh->dlh_future, dlh);
@@ -2199,6 +2202,9 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	dtx_chore.func_arg = func_arg;
 	dtx_chore.dlh = dlh;
 
+	dtx_chore.chore.cho_func     = dtx_leader_exec_ops_chore;
+	dtx_chore.chore.cho_priority = 0;
+
 	dlh->dlh_result = 0;
 	dlh->dlh_allow_failure = allow_failure;
 	dlh->dlh_normal_sub_done = 0;
@@ -2207,8 +2213,8 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	dlh->dlh_need_agg = 0;
 	dlh->dlh_agg_done = 0;
 
-	if (sub_cnt > DTX_RPC_STEP_LENGTH) {
-		dlh->dlh_forward_cnt = DTX_RPC_STEP_LENGTH;
+	if (sub_cnt > DTX_REG_RPC_STEP_LENGTH) {
+		dlh->dlh_forward_cnt = DTX_REG_RPC_STEP_LENGTH;
 	} else {
 		dlh->dlh_forward_cnt = sub_cnt;
 		if (likely(dlh->dlh_delay_sub_cnt == 0) && agg_cb != NULL)
@@ -2218,7 +2224,7 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 	if (dlh->dlh_normal_sub_cnt == 0)
 		goto exec;
 
-again:
+again1:
 	D_ASSERT(dlh->dlh_future == ABT_FUTURE_NULL);
 
 	/*
@@ -2232,12 +2238,57 @@ again:
 		D_GOTO(out, rc = dss_abterr2der(rc));
 	}
 
-	rc = dss_chore_delegate(&dtx_chore.chore, dtx_leader_exec_ops_chore);
+again2:
+	dtx_chore.chore.cho_credits = dlh->dlh_forward_cnt;
+	dtx_chore.chore.cho_hint    = NULL;
+	rc                          = dss_chore_register(&dtx_chore.chore);
 	if (rc != 0) {
-		DL_ERROR(rc, "chore create failed [%u, %u] (2)", dlh->dlh_forward_idx,
-			 dlh->dlh_forward_cnt);
-		ABT_future_free(&dlh->dlh_future);
-		goto out;
+		if (rc != -DER_AGAIN) {
+			DL_ERROR(rc, "chore create failed [%u, %u] (2)", dlh->dlh_forward_idx,
+				 dlh->dlh_forward_cnt);
+			ABT_future_free(&dlh->dlh_future);
+			goto out;
+		}
+
+		d_tm_inc_counter(dtx_tls_get()->dt_chore_retry, 1);
+
+		/*
+		 * To avoid the whole task is split too many pieces. If there are very few
+		 * credits, we may prefer to wait instead of shrink the credits quirement.
+		 */
+		if (dtx_chore.chore.cho_credits > dlh->dlh_normal_sub_cnt / 8) {
+			D_DEBUG(DB_TRACE, "Retry IO forward with credits from %d to %d\n",
+				dlh->dlh_forward_cnt, dtx_chore.chore.cho_credits);
+			ABT_future_free(&dlh->dlh_future);
+			dlh->dlh_forward_cnt = dtx_chore.chore.cho_credits;
+			goto again1;
+		}
+
+		/*
+		 * If more than half sub-requests have been processed, let's handle the left
+		 * part ASAP to avoid the whole task timeout. Otherwise once timeout, it may
+		 * cause more overhead for rollback.
+		 */
+		if (dlh->dlh_forward_idx > sub_cnt / 2) {
+			dtx_chore.chore.cho_priority = 1;
+
+			if (dlh->dlh_forward_cnt > DTX_PRI_RPC_STEP_LENGTH) {
+				D_DEBUG(DB_TRACE, "Retry (prio) IO forward with credits %d => %d\n",
+					dlh->dlh_forward_cnt, DTX_PRI_RPC_STEP_LENGTH);
+				ABT_future_free(&dlh->dlh_future);
+				dlh->dlh_forward_cnt = DTX_PRI_RPC_STEP_LENGTH;
+				goto again1;
+			}
+
+			D_DEBUG(DB_TRACE, "Retry (prio) IO forward with credits %d\n",
+				dlh->dlh_forward_cnt);
+			goto again2;
+		}
+
+		D_DEBUG(DB_TRACE, "Not enough credits (%d vs %d) for IO forward, wait and retry\n",
+			dlh->dlh_forward_cnt, dtx_chore.chore.cho_credits);
+		ABT_thread_yield();
+		goto again2;
 	}
 
 exec:
@@ -2246,8 +2297,10 @@ exec:
 		local_rc = func(dlh, func_arg, -1, NULL);
 
 	/* Even the local request failure, we still need to wait for remote sub request. */
-	if (dlh->dlh_normal_sub_cnt > 0)
+	if (dlh->dlh_normal_sub_cnt > 0) {
 		remote_rc = dtx_leader_wait(dlh);
+		dss_chore_deregister(&dtx_chore.chore);
+	}
 
 	if (local_rc != 0 && local_rc != allow_failure)
 		D_GOTO(out, rc = local_rc);
@@ -2258,7 +2311,7 @@ exec:
 	sub_cnt -= dlh->dlh_forward_cnt;
 	if (sub_cnt > 0) {
 		dlh->dlh_forward_idx += dlh->dlh_forward_cnt;
-		if (sub_cnt <= DTX_RPC_STEP_LENGTH) {
+		if (sub_cnt <= DTX_REG_RPC_STEP_LENGTH) {
 			dlh->dlh_forward_cnt = sub_cnt;
 			if (likely(dlh->dlh_delay_sub_cnt == 0) && agg_cb != NULL)
 				dlh->dlh_need_agg = 1;
@@ -2270,7 +2323,8 @@ exec:
 			dlh->dlh_delay_sub_cnt, dlh->dlh_forward_idx,
 			dlh->dlh_forward_cnt, allow_failure);
 
-		goto again;
+		dtx_chore.chore.cho_priority = 0;
+		goto again1;
 	}
 
 	dlh->dlh_normal_sub_done = 1;
@@ -2311,7 +2365,18 @@ exec:
 	/* The ones without DELAY flag will be skipped when scan the targets array. */
 	dlh->dlh_forward_cnt = dlh->dlh_normal_sub_cnt + dlh->dlh_delay_sub_cnt;
 
-	rc = dss_chore_delegate(&dtx_chore.chore, dtx_leader_exec_ops_chore);
+	/*
+	 * Since non-delay sub-requests have already been processed, let's use high priority
+	 * to apply chore credits, then the left delayed sub-requests can be handled quickly
+	 * to reduce the possibility of the whole IO timeout.
+	 */
+	if (unlikely(dlh->dlh_delay_sub_cnt > DTX_PRI_RPC_STEP_LENGTH))
+		D_WARN("Too many delayed sub-requests %u\n", dlh->dlh_delay_sub_cnt);
+
+	dtx_chore.chore.cho_priority = 1;
+	dtx_chore.chore.cho_credits  = dlh->dlh_delay_sub_cnt;
+	dtx_chore.chore.cho_hint     = NULL;
+	rc                           = dss_chore_register(&dtx_chore.chore);
 	if (rc != 0) {
 		DL_ERROR(rc, "chore create failed (4)");
 		ABT_future_free(&dlh->dlh_future);
@@ -2319,6 +2384,7 @@ exec:
 	}
 
 	remote_rc = dtx_leader_wait(dlh);
+	dss_chore_deregister(&dtx_chore.chore);
 	if (remote_rc != 0 && remote_rc != allow_failure)
 		rc = remote_rc;
 

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -187,7 +188,14 @@ extern uint32_t dtx_batched_ult_max;
  * dispatch process may trigger too many in-flight or in-queued RPCs that will hold
  * too much resource as to server maybe out of memory.
  */
-#define DTX_RPC_STEP_LENGTH	DTX_THRESHOLD_COUNT
+#define DTX_REG_RPC_STEP_LENGTH         512
+
+/*
+ * High priority (DTX) RPC may break through IO chore credit restriction temporarily.
+ * To reduce the side-affect on the other IO forward RPCs, use smaller step for high
+ * priority RPC.
+ */
+#define DTX_PRI_RPC_STEP_LENGTH         64
 
 extern struct crt_corpc_ops	dtx_coll_commit_co_ops;
 extern struct crt_corpc_ops	dtx_coll_abort_co_ops;
@@ -214,6 +222,7 @@ struct dtx_tls {
 	struct d_tm_node_t	*dt_committable;
 	struct d_tm_node_t	*dt_dtx_leader_total;
 	struct d_tm_node_t	*dt_async_cmt_lat;
+	struct d_tm_node_t      *dt_chore_retry;
 	uint64_t		 dt_agg_gen;
 	uint32_t		 dt_batched_ult_cnt;
 };

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -54,6 +55,11 @@ dtx_tls_init(int tags, int xs_id, int tgt_id)
 	if (rc != DER_SUCCESS)
 		D_WARN("Failed to create DTX async commit latency metric: " DF_RC"\n",
 		       DP_RC(rc));
+
+	rc = d_tm_add_metric(&tls->dt_chore_retry, D_TM_COUNTER, "DTX chore retry", NULL,
+			     "io/dtx/chore_retry/tgt_%u", tgt_id);
+	if (rc != DER_SUCCESS)
+		D_WARN("Failed to create DTX chore retry metric: " DF_RC "\n", DP_RC(rc));
 
 	return tls;
 }

--- a/src/dtx/tests/ult_mock.c
+++ b/src/dtx/tests/ult_mock.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2023-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -74,14 +75,20 @@ struct dss_chore;
 typedef enum dss_chore_status (*dss_chore_func_t)(struct dss_chore *chore, bool is_reentrance);
 
 void
-dss_chore_diy(struct dss_chore *chore, dss_chore_func_t func)
+dss_chore_diy(struct dss_chore *chore)
 {
 	assert_true(false);
 }
 
 int
-dss_chore_delegate(struct dss_chore *chore, dss_chore_func_t func)
+dss_chore_register(struct dss_chore *chore)
 {
 	assert_true(false);
 	return -DER_NOMEM;
+}
+
+void
+dss_chore_deregister(struct dss_chore *chore)
+{
+	assert_true(false);
 }

--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1117,6 +1118,15 @@ dss_xstreams_init(void)
 
 	d_getenv_uint("DAOS_SCHED_UNIT_RUNTIME_MAX", &sched_unit_runtime_max);
 	d_getenv_bool("DAOS_SCHED_WATCHDOG_ALL", &sched_watchdog_all);
+
+	dss_chore_credits = DSS_CHORE_CREDITS_DEF;
+	d_getenv_uint("DAOS_IO_CHORE_CREDITS", &dss_chore_credits);
+	if (dss_chore_credits < DSS_CHORE_CREDITS_MIN) {
+		D_WARN("Invalid DAOS_IO_CHORE_CREDITS value, minimum is %u, set as default %u\n",
+		       DSS_CHORE_CREDITS_MIN, DSS_CHORE_CREDITS_DEF);
+		dss_chore_credits = DSS_CHORE_CREDITS_DEF;
+	}
+	D_INFO("Set DAOS IO chore credits as %u\n", dss_chore_credits);
 
 	/* start the execution streams */
 	D_DEBUG(DB_TRACE,

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -72,6 +73,7 @@ struct mem_stats {
 /* See dss_chore. */
 struct dss_chore_queue {
 	d_list_t   chq_list;
+	int32_t    chq_credits;
 	bool       chq_stop;
 	ABT_mutex  chq_mutex;
 	ABT_cond   chq_cond;
@@ -166,6 +168,11 @@ extern unsigned int          dss_tgt_offload_xs_nr;
 extern unsigned int          dss_offload_per_numa_nr;
 /** Number of target per socket */
 extern unsigned int          dss_tgt_per_numa_nr;
+/** The maximum number of credits for each IO chore queue. That is per helper XS. */
+extern uint32_t              dss_chore_credits;
+
+#define DSS_CHORE_CREDITS_MIN 1024
+#define DSS_CHORE_CREDITS_DEF 4096
 
 /** Shadow dss_get_module_info */
 struct dss_module_info *get_module_info(void);

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -43,6 +43,8 @@ extern "C" {
 #define DFS_MAX_XATTR_NAME	255
 /** Maximum xattr value */
 #define DFS_MAX_XATTR_LEN	65536
+/** Magic number identifier for statfs and related routines */
+#define DAOS_SUPER_MAGIC        0xDA05AD10
 
 /** File/Directory/Symlink object handle struct */
 typedef struct dfs_obj dfs_obj_t;

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -767,23 +768,27 @@ struct dss_chore;
 typedef enum dss_chore_status (*dss_chore_func_t)(struct dss_chore *chore, bool is_reentrance);
 
 /**
- * Chore (opaque)
- *
  * A simple task (e.g., an I/O forwarding task) that yields by returning
  * DSS_CHORE_YIELD instead of calling ABT_thread_yield. This data structure
  * shall be embedded in the user's own task data structure, which typically
- * also includes arguments and internal state variables for \a cho_func. All
- * fields are private. See dtx_chore for an example.
+ * also includes arguments and internal state variables for \a cho_func.
  */
 struct dss_chore {
 	d_list_t              cho_link;
 	enum dss_chore_status cho_status;
 	dss_chore_func_t      cho_func;
+	uint32_t              cho_priority : 1;
+	int32_t               cho_credits;
+	void                 *cho_hint;
 };
 
-int dss_chore_delegate(struct dss_chore *chore, dss_chore_func_t func);
-void dss_chore_diy(struct dss_chore *chore, dss_chore_func_t func);
-
-bool engine_in_check(void);
+int
+dss_chore_register(struct dss_chore *chore);
+void
+dss_chore_deregister(struct dss_chore *chore);
+void
+dss_chore_diy(struct dss_chore *chore);
+bool
+engine_in_check(void);
 
 #endif /* __DSS_API_H__ */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -231,13 +232,13 @@ struct dtx_leader_handle {
 	/* Elements for collective DTX. */
 	struct dtx_coll_entry		*dlh_coll_entry;
 	/* How many normal sub request. */
-	uint32_t			dlh_normal_sub_cnt;
+	int32_t                          dlh_normal_sub_cnt;
 	/* How many delay forward sub request. */
-	uint32_t			dlh_delay_sub_cnt;
+	int32_t                          dlh_delay_sub_cnt;
 	/* The index of the first target that forward sub-request to. */
-	uint32_t			dlh_forward_idx;
+	int32_t                          dlh_forward_idx;
 	/* The count of the targets that forward sub-request to. */
-	uint32_t			dlh_forward_cnt;
+	int32_t                          dlh_forward_cnt;
 	/* Sub transaction handle to manage the dtx leader */
 	struct dtx_sub_status		*dlh_subs;
 };

--- a/src/tests/ftest/util/telemetry_utils.py
+++ b/src/tests/ftest/util/telemetry_utils.py
@@ -193,6 +193,9 @@ class TelemetryUtils():
         "engine_sched_total_reject",
         *_gen_stats_metrics("engine_sched_cycle_duration"),
         *_gen_stats_metrics("engine_sched_cycle_size")]
+    ENGINE_DTX_METRICS = [
+        "engine_io_dtx_chore_retry",
+        "engine_io_dtx_invalid"]
     ENGINE_DMABUFF_METRICS = [
         "engine_dmabuff_total_chunks",
         "engine_dmabuff_used_chunks_io",
@@ -209,8 +212,6 @@ class TelemetryUtils():
         _gen_stats_metrics("engine_io_dtx_committable")
     ENGINE_IO_DTX_COMMITTED_METRICS = \
         _gen_stats_metrics("engine_io_dtx_committed")
-    ENGINE_IO_DTX_INVALID_METRICS = \
-        _gen_stats_metrics("engine_io_dtx_invalid")
     ENGINE_IO_LATENCY_FETCH_METRICS = \
         _gen_stats_metrics("engine_io_latency_fetch")
     ENGINE_IO_LATENCY_BULK_FETCH_METRICS = \
@@ -314,7 +315,6 @@ class TelemetryUtils():
     ENGINE_IO_METRICS = ENGINE_IO_DTX_ASYNC_CMT_LAT_METRICS +\
         ENGINE_IO_DTX_COMMITTABLE_METRICS +\
         ENGINE_IO_DTX_COMMITTED_METRICS +\
-        ENGINE_IO_DTX_INVALID_METRICS +\
         ENGINE_IO_LATENCY_FETCH_METRICS +\
         ENGINE_IO_LATENCY_BULK_FETCH_METRICS +\
         ENGINE_IO_LATENCY_VOS_FETCH_METRICS +\
@@ -473,6 +473,7 @@ class TelemetryUtils():
         """
         all_metrics_names = list(self.ENGINE_EVENT_METRICS)
         all_metrics_names.extend(self.ENGINE_SCHED_METRICS)
+        all_metrics_names.extend(self.ENGINE_DTX_METRICS)
         all_metrics_names.extend(self.ENGINE_IO_METRICS)
         all_metrics_names.extend(self.ENGINE_NET_METRICS)
         all_metrics_names.extend(self.ENGINE_RANK_METRICS)

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -581,9 +581,9 @@ vos_tls_init(int tags, int xs_id, int tgt_id)
 			D_WARN("Failed to create committed cnt sensor: "DF_RC"\n",
 			       DP_RC(rc));
 
-		rc = d_tm_add_metric(&tls->vtl_invalid_dtx, D_TM_STATS_GAUGE,
-				     "Number of invalid active DTX", "entries",
-				     "io/dtx/invalid/tgt_%u", tgt_id);
+		rc = d_tm_add_metric(&tls->vtl_invalid_dtx, D_TM_COUNTER,
+				     "Number of invalid active DTX", NULL, "io/dtx/invalid/tgt_%u",
+				     tgt_id);
 		if (rc)
 			D_WARN("Failed to create invalid DTX cnt sensor: " DF_RC "\n", DP_RC(rc));
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -663,12 +663,10 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 	}
 
 	if (unlikely(rc == -DER_NONEXIST)) {
-		struct vos_tls	*tls = vos_tls_get(false);
-
 		D_WARN("DTX record no longer exists, may indicate some corruption: "
 		       DF_DTI " type %u, discard\n",
 		       DP_DTI(&DAE_XID(dae)), dtx_umoff_flag2type(rec));
-		d_tm_inc_gauge(tls->vtl_invalid_dtx, 1);
+		d_tm_inc_counter(vos_tls_get(false)->vtl_invalid_dtx, 1);
 	}
 
 	return rc;


### PR DESCRIPTION
- **DAOS-16811 client: Intercept dlopen() instead of dlsym() and zeInit() (#15986)**
- **DAOS-17151 engine: RPC credits for IO chore task - b26 (#15961)**
- **DAOS-17153 il:  library should populate fstype (#15953) (#15991)**
