### PR TITLE
DAOS-17209 test: Handle non-persistent PMEM naming

### DIFF
--- a/src/tests/ftest/util/storage_utils.py
+++ b/src/tests/ftest/util/storage_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2022-2023 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -93,6 +94,9 @@ class StorageDevice():
             str: the string version of the parameter's value
 
         """
+        if self.is_pmem:
+            # Exclude the NUMA node for PMEM devices to avoid issues with persistent naming
+            return ' - '.join([str(self.address), self.description])
         return ' - '.join([str(self.address), self.description, str(self.numa_node)])
 
     def __repr__(self):


### PR DESCRIPTION
To avoid generating a server storage configuration in CI testing that uses ram instead of PMEM when PMEM exists on all the nodes in the cluster but it is located on different NUMA nodes, ignore the NUMA association.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_setup

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
