### PR TITLE
DAOS-17094 engine: set ABT_MEM_MAX_NUM_STACKS as 256

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -555,6 +556,26 @@ set_abt_max_num_xstreams(int n)
 }
 
 static int
+set_abt_max_num_stacks(void)
+{
+	char *name = "ABT_MEM_MAX_NUM_STACKS";
+	char *value;
+	int   rc;
+
+	D_ASPRINTF(value, "%d", 256);
+	if (value == NULL)
+		return -DER_NOMEM;
+
+	D_INFO("Setting %s to %s\n", name, value);
+	rc = d_setenv(name, value, 1 /* overwrite */);
+	D_FREE(value);
+	if (rc != 0)
+		rc = daos_errno2der(errno);
+
+	return rc;
+}
+
+static int
 abt_init(int argc, char *argv[])
 {
 	int	nrequested = abt_max_num_xstreams();
@@ -570,7 +591,11 @@ abt_init(int argc, char *argv[])
 	 */
 	rc = set_abt_max_num_xstreams(max(nrequested, nrequired));
 	if (rc != 0)
-		return daos_errno2der(errno);
+		return rc;
+
+	rc = set_abt_max_num_stacks();
+	if (rc != 0)
+		return rc;
 
 	/* Now, initialize Argobots. */
 	rc = ABT_init(argc, argv);


### PR DESCRIPTION
To verify whether it will cause ABT overflow or not. Default is 1024.

Only for test.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
