### PR TITLE
DAOS-17094 pool: deep stack size for IV ULT

### DIFF
--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2017-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1598,8 +1599,8 @@ ds_pool_iv_svc_fetch(struct ds_pool *pool, d_rank_list_t **svc_p)
 			D_GOTO(failed, rc);
 	} else {
 		/* create a ULT and schedule it on xstream-0 */
-		rc = dss_ult_execute(cont_pool_svc_ult, &ia, NULL, NULL,
-				     DSS_XS_SYS, DSS_ULT_DEEP_STACK, 0);
+		rc = dss_ult_execute(cont_pool_svc_ult, &ia, NULL, NULL, DSS_XS_SYS, 0,
+				     DSS_DEEP_STACK_SZ);
 		if (rc)
 			D_GOTO(failed, rc);
 	}


### PR DESCRIPTION
Use deep stack size for IV ULT to avoid stack overflow.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
