### PR TITLE
DAOS-17094 test: auto storage config for daos_server_restart

### DIFF
--- a/src/tests/ftest/server/daos_server_restart.yaml
+++ b/src/tests/ftest/server/daos_server_restart.yaml
@@ -18,20 +18,14 @@ server_config:
       fabric_iface: ib0
       fabric_iface_port: 31317
       log_file: daos_server0.log
-      storage:
-        0:
-          class: ram
-          scm_mount: /mnt/daos0
+      storage: auto
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
       fabric_iface: ib1
       fabric_iface_port: 31417
       log_file: daos_server1.log
-      storage:
-        0:
-          class: ram
-          scm_mount: /mnt/daos1
+      storage: auto
 
 server:
   num_of_pool: 3
@@ -39,7 +33,7 @@ server:
 
 pool:
   control_method: dmg
-  size: 1GB
+  size: 100GB
 
 container:
   control_method: daos


### PR DESCRIPTION
With this change, a test with a hard-coded tier 0 scm class: ram configuration is replaced with storage: auto (an ftest abstraction). This will steer testing to use the correct class: dcpm on functional hardware clusters with PMEM. Also, the pool size is increased to avoid pool create failures that would happen in the new configuration, i.e., avoiding:
 "requested SCM capacity is too small".

Before the change, scm class: ram was used with PMEM, and led to Argobots ULT stack overflows and segmentation faults observed when executing in its mem pool allocation logic.

Skip-unit-tests: true
Skip-fault-injection-test: true
Skip-func-hw-test-medium-md-on-ssd: false
Test-tag: DaosServerTest
Test-repeat: 7

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
