### PR TITLE
DAOS-17146 engine: call only pmemobj_close() on stop

### DIFF
--- a/src/engine/init.c
+++ b/src/engine/init.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1252,7 +1253,13 @@ main(int argc, char **argv)
 			continue;
 		}
 
-		/* SIGINT/SIGTERM cause server shutdown */
+		/** SIGINT causes a forced server shutdown */
+		if (sig == SIGINT) {
+			server_force_stop();
+			exit(EXIT_SUCCESS);
+		}
+
+		/* SIGTERM causes a normal server shutdown */
 		break;
 	}
 

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -195,6 +195,8 @@ struct dss_xstream *dss_get_xstream(int stream_id);
 int dss_xstream_cnt(void);
 void dss_mem_total_alloc_track(void *arg, daos_size_t bytes);
 void dss_mem_total_free_track(void *arg, daos_size_t bytes);
+void
+    server_force_stop(void);
 
 /* srv_metrics.c */
 int dss_engine_metrics_init(void);

--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1344,7 +1345,7 @@ d_hhash_key_type(uint64_t key)
 	return d_hhash_key_isptr(key) ? D_HTYPE_PTR : key & D_HTYPE_MASK;
 }
 
-struct traverse_args {
+struct hhash_traverse_args {
 	int                   type;
 	d_hhash_traverse_cb_t cb;
 	void                 *arg;
@@ -1353,7 +1354,7 @@ struct traverse_args {
 static int
 d_hhash_cb(d_list_t *link, void *args)
 {
-	struct traverse_args *targs = args;
+	struct hhash_traverse_args *targs = args;
 	struct d_hlink       *hlink = link2hlink(link);
 	uint64_t              key;
 
@@ -1371,7 +1372,7 @@ d_hhash_cb(d_list_t *link, void *args)
 int
 d_hhash_traverse(struct d_hhash *hhash, int type, d_hhash_traverse_cb_t cb, void *arg)
 {
-	struct traverse_args args;
+	struct hhash_traverse_args args;
 
 	args.type = type;
 	args.cb   = cb;
@@ -1564,4 +1565,29 @@ void
 d_uhash_link_delete(struct d_hash_table *htable, struct d_ulink *ulink)
 {
 	d_hash_rec_delete_at(htable, &ulink->ul_link.rl_link);
+}
+
+struct uhash_traverse_args {
+	d_uhash_traverse_cb_t cb;
+	void                 *arg;
+};
+
+static int
+d_uhash_cb(d_list_t *link, void *args)
+{
+	struct uhash_traverse_args *targs = args;
+
+	if (link == NULL) {
+		return 0;
+	}
+
+	return targs->cb(link2ulink(link), targs->arg);
+}
+
+int
+d_uhash_traverse(struct d_hash_table *htable, d_uhash_traverse_cb_t cb, void *arg)
+{
+	struct uhash_traverse_args args = {.cb = cb, .arg = arg};
+
+	return d_hash_table_traverse(htable, d_uhash_cb, &args);
 }

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -1737,4 +1737,15 @@ vos_pin_objects(daos_handle_t coh, daos_unit_oid_t oids[], int count, struct vos
 bool
 vos_oi_exist(daos_handle_t coh, daos_unit_oid_t oid);
 
+/**
+ * Force close all PMEM pools kept on the current thread/execution stream or sysdb.
+ * Please cease all other operations before calling this procedure.
+ * It leaves the volatile bookkeeping in an inconsistent state. Please terminate the current process
+ * immediately afterwards.
+ *
+ * \param[in]	is_sysdb	close sysdb.
+ */
+void
+vos_pool_force_close_all_pmem(bool is_sysdb);
+
 #endif /* __VOS_API_H */

--- a/src/include/gurt/hash.h
+++ b/src/include/gurt/hash.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2022 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -622,6 +623,9 @@ int  d_uhash_link_insert(struct d_hash_table *htable, struct d_uuid *key,
 			 void *cmp_args, struct d_ulink *ulink);
 struct d_ulink *d_uhash_link_lookup(struct d_hash_table *htable,
 				    struct d_uuid *key, void *cmp_args);
+typedef int (*d_uhash_traverse_cb_t)(struct d_ulink *link, void *arg);
+int
+d_uhash_traverse(struct d_hash_table *htable, d_uhash_traverse_cb_t cb, void *arg);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
- `dmg system stop` -> SIGINT will trigger a new server stop path which:
  - stops all the execution streams to stop them from using the PMEM pools
  - close all the PMEM pools (`pmemobj_close()`)
  - terminate the `daos_engine` process
- `dmg system stop --force` -> SIGKILL remains as the last resort in case the previous one stucks
- the graceful teardown process will be unavailable till we fix it (DAOS-XXXX)

Priority: 2

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
