### PR TITLE
DAOS-17205 ci: Fix python bandit check (#16003)

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -167,7 +168,7 @@ class Test(avocadoTest):
                     "ERROR: The env variable DAOS_TEST_RANDOM_SEED "
                     "does not define a valid integer: got='{}'".format(env_seed))
         self.log.info("Test.random seed = %d", self.rand_seed)
-        self.random = random.Random(self.rand_seed)
+        self.random = random.Random(self.rand_seed)     # nosec
 
     def add_test_data(self, filename, data):
         """Add a file to the test variant specific data directory.


### PR DESCRIPTION
Skip B311 warning in apricot/test.py.

Skip-unit-tests: true
Skip-fault-injection-test: true
Test-tag: test_always_passes

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
