### PR TITLE
DAOS-17106 swim: Never change self_id

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -492,12 +493,7 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc)
 	} else {
 		rc = swim_updates_parse(ctx, from_id, from_id, rpc_in->upds.ca_arrays,
 					rpc_in->upds.ca_count);
-		if (rc == -DER_SHUTDOWN) {
-			if (grp_priv->gp_size > 1)
-				D_ERROR("SWIM shutdown\n");
-			swim_self_set(ctx, SWIM_ID_INVALID);
-			D_GOTO(out_reply, rc);
-		} else if (rc) {
+		if (rc) {
 			RPC_ERROR(rpc_priv,
 				  "updates parse. %lu: %lu <= %lu failed: "DF_RC"\n",
 				  self_id, to_id, from_id, DP_RC(rc));
@@ -639,12 +635,7 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 	rc = swim_updates_parse(ctx, to_id,
 				rpc_type == SWIM_RPC_IREQ && !reply_rc ? from_id : to_id,
 				rpc_out->upds.ca_arrays, rpc_out->upds.ca_count);
-	if (rc == -DER_SHUTDOWN) {
-		if (grp_priv->gp_size > 1)
-			D_ERROR("SWIM shutdown\n");
-		swim_self_set(ctx, SWIM_ID_INVALID);
-		D_GOTO(out, rc);
-	} else if (rc) {
+	if (rc) {
 		RPC_ERROR(rpc_priv,
 			  "updates parse. %lu: %lu <= %lu failed: "DF_RC"\n",
 			  self_id, from_id, to_id, DP_RC(rc));
@@ -1041,11 +1032,7 @@ static int64_t crt_swim_progress_cb(crt_context_t crt_ctx, int64_t timeout_us, v
 	}
 
 	rc = swim_progress(ctx, timeout_us);
-	if (rc == -DER_SHUTDOWN) {
-		if (grp_priv->gp_size > 1)
-			D_ERROR("SWIM shutdown\n");
-		swim_self_set(ctx, SWIM_ID_INVALID);
-	} else if (rc == -DER_TIMEDOUT || rc == -DER_CANCELED) {
+	if (rc == -DER_TIMEDOUT || rc == -DER_CANCELED) {
 		uint64_t now = swim_now_ms();
 
 		crt_swim_update_last_unpack_hlc(csm);

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -924,7 +924,8 @@ swim_progress(struct swim_context *ctx, int64_t timeout_us)
 					ctx->sc_next_event = ctx->sc_deadline;
 				ctx_state = SCS_PINGED;
 			} else {
-				ctx->sc_next_event = MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
+				ctx->sc_next_event =
+					MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
 			}
 			break;
 		case SCS_PINGED:
@@ -1035,7 +1036,8 @@ done_item:
 				ctx->sc_next_event = now;
 				ctx_state = SCS_SELECT;
 			} else {
-				ctx->sc_next_event = MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
+				ctx->sc_next_event =
+					MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
 			}
 			break;
 		case SCS_SELECT:
@@ -1043,7 +1045,8 @@ done_item:
 			if (ctx->sc_target == SWIM_ID_INVALID) {
 				ctx->sc_next_event = now + swim_period_get();
 			} else {
-				ctx->sc_next_event = MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
+				ctx->sc_next_event =
+					MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
 				ctx_state = SCS_BEGIN;
 			}
 			break;

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -925,7 +925,7 @@ swim_progress(struct swim_context *ctx, int64_t timeout_us)
 				ctx_state = SCS_PINGED;
 			} else {
 				ctx->sc_next_event =
-					MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
+				    MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
 			}
 			break;
 		case SCS_PINGED:
@@ -1037,7 +1037,7 @@ done_item:
 				ctx_state = SCS_SELECT;
 			} else {
 				ctx->sc_next_event =
-					MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
+				    MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
 			}
 			break;
 		case SCS_SELECT:
@@ -1046,7 +1046,7 @@ done_item:
 				ctx->sc_next_event = now + swim_period_get();
 			} else {
 				ctx->sc_next_event =
-					MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
+				    MIN(ctx->sc_next_event, ctx->sc_next_tick_time);
 				ctx_state = SCS_BEGIN;
 			}
 			break;

--- a/src/tests/ftest/cart/test_swim_emu.c
+++ b/src/tests/ftest/cart/test_swim_emu.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2020-2022 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -342,9 +343,7 @@ static void deliver_pkt(struct network_pkt *item)
 
 	/* emulate RPC receive by target */
 	rc = swim_updates_parse(ctx, from_id, from_id, item->np_upds, item->np_nupds);
-	if (rc == -DER_SHUTDOWN)
-		swim_self_set(ctx, SWIM_ID_INVALID);
-	else if (rc)
+	if (rc)
 		fprintf(stderr, "swim_parse_message() rc=%d\n", rc);
 }
 
@@ -415,9 +414,7 @@ static void *progress_thread(void *arg)
 	do {
 		for (i = 0; i < members_count; i++) {
 			rc = swim_progress(g.swim_ctx[i], timeout);
-			if (rc == -DER_SHUTDOWN)
-				swim_self_set(g.swim_ctx[i], SWIM_ID_INVALID);
-			else if (rc && rc != -DER_TIMEDOUT)
+			if (rc && rc != -DER_TIMEDOUT)
 				fprintf(stderr, "swim_progress() rc=%d\n", rc);
 		}
 		usleep(100);


### PR DESCRIPTION
In the current implementation of DAOS, when it fails to select a dping target, it will set its self_id to SWIM_ID_INVALID and from now on, the node is not fully functional because only swim_updates_short() will be invoked to respond to PING and IPING request. Once the node enters into this state, it can not be restored.

This PR fixes the problem by not setting the self_id to SWIM_ID_INVALID if it won't be able to find a dping target. It's simply not necessary.

Change-Id: I4a2dad9aeb0571f938a84a97a9e29868a33b01a1
Signed-off-by: Jinshan Xiong [jinshanx@google.com](mailto:jinshanx@google.com)

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
