### PR TITLE
b/390177544 cart: Support dynamic mercury/libfabric loglevels (#15738)

### DIFF
--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1340,6 +1341,13 @@ int d_log_setmasks(const char *mstr, int mlen0)
 		else {
 			/* apply to all facilities */
 			for (facno = 0; facno < d_log_xst.fac_cnt; facno++) {
+				/* don't include external when setting blanket DEBUG -- must be
+				 * enabled explicitly */
+				if (prino == DLOG_DBG &&
+				    strncasecmp(d_log_xst.dlog_facs[facno].fac_aname, "external",
+						8) == 0)
+					continue;
+
 				tmp = d_log_setlogmask(facno, prino);
 				if (rv != -1)
 					rv = tmp;

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -2385,6 +2385,18 @@ crt_req_get_proto_ver(crt_rpc_t *req);
 char *
 crt_req_origin_addr_get(crt_rpc_t *rpc);
 
+void
+crt_hg_reset_log_level();
+
+void
+crt_hg_set_log_level(const char *level);
+
+void
+crt_hg_reset_log_subsys();
+
+void
+crt_hg_set_log_subsys(const char *subsys);
+
 /** @}
  */
 

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -104,7 +105,7 @@ ds_mgmt_drpc_set_log_masks(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	Ctl__SetLogMasksResp	 resp;
 	uint8_t			*body;
 	size_t			 len;
-	char			 retbuf[1024];
+	char                     retbuf[1024] = {'\0'};
 
 	/* Unpack the inner request from the drpc call body */
 	req = ctl__set_log_masks_req__unpack(&alloc.alloc,
@@ -129,6 +130,18 @@ ds_mgmt_drpc_set_log_masks(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	d_log_getmasks(retbuf, 0, sizeof(retbuf), 0);
 	D_INFO("Received request to set log masks '%s' masks are now %s, debug streams (DD_MASK) "
 	       "set to '%s'\n", req->masks, retbuf, req->streams);
+
+	/* b/390177544: Adjust mercury/libfabric logging at runtime */
+	if (strstr(retbuf, "external=DBUG") != NULL) {
+		crt_hg_set_log_level("debug");
+		crt_hg_set_log_subsys("hg,na,libfabric");
+		D_INFO("enabled DEBUG logging for external facility\n");
+	} else {
+		/* if it's not DEBUG, reset it to defaults */
+		crt_hg_reset_log_level();
+		crt_hg_reset_log_subsys();
+		D_INFO("reset logging to defaults for external facility\n");
+	}
 
 	len = ctl__set_log_masks_resp__get_packed_size(&resp);
 	D_ALLOC(body, len);

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -495,6 +496,26 @@ int
 crt_rank_self_set(d_rank_t rank, uint32_t group_version_min)
 {
 	return 0;
+}
+
+void
+crt_hg_reset_log_level()
+{
+}
+
+void
+crt_hg_set_log_level(const char *level)
+{
+}
+
+void
+crt_hg_reset_log_subsys()
+{
+}
+
+void
+crt_hg_set_log_subsys(const char *subsys)
+{
 }
 
 void


### PR DESCRIPTION
Mercury and libfabric are much too spammy to enable at lower
than warning level by default. Mercury does support adjustment
of its log level and logged subsystems at runtime, so this
patch provides access to that functionality from the
existing `dmg server set-logmasks` tool.

This version of the patch adds support for writing mercury/libfabric
debug logs to a separate file, in order to avoid undue burden on
the cloud logging pipeline. To use it, set HG_DBG_LOG_FILE in the
engine config to a logfile path. NB: This is a "raw" log file, i.e.
no rotation is done and it's flushed once per second.

To enable debug logging for just the mercury/libfabric libraries:
  dmg server set-logmasks -m EXTERNAL=DEBUG

To disable debug logging again:
  dmg server set-logmasks -m EXTERNAL=ERR

Note that the CaRT/Mercury wrapper (crt_hg.c) still uses the normal
dlog logger with the "hg" facility. If debug logging in this file is
desired, then the mask HG=DEBUG may be used for set-logmasks.
Be aware that the debug logging produced by this file is rather
copious and may cause problems for cloud logging, however!

Change-Id: Ib6fb74c42507dbfba2c5984a92433ad43b6e2df3
Signed-off-by: Michael MacDonald <mjmac@google.com>
