### PR TITLE
DAOS-16629 build: Allow separate test builds (#15188)

### DIFF
--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -524,20 +524,26 @@ class PreReqComponent:
         self.include = env.subst("$INCLUDE").split(" ")
         self._build_targets = []
 
-        build_dir = self.__env["BUILD_DIR"]
-        targets = ["test", "server", "client"]
-        self.__env.Alias("client", build_dir)
-        self.__env.Alias("server", build_dir)
-        self.__env.Alias("test", build_dir)
+        build_dir = self.__env['BUILD_DIR']
+        main_targets = ['client', 'server']
+        targets = ['test'] + main_targets
+        self.__env.Alias('client', build_dir)
+        self.__env.Alias('server', build_dir)
+        self.__env.Alias('test', build_dir)
         self._build_targets = []
         check = any(item in BUILD_TARGETS for item in targets)
-        if not check or "test" in BUILD_TARGETS:
-            self._build_targets.extend(["client", "server", "test"])
+        if not check:
+            self._build_targets.extend(['client', 'server', 'test'])
         else:
-            if "client" in BUILD_TARGETS:
-                self._build_targets.append("client")
-            if "server" in BUILD_TARGETS:
-                self._build_targets.append("server")
+            if 'client' in BUILD_TARGETS:
+                self._build_targets.append('client')
+            if 'server' in BUILD_TARGETS:
+                self._build_targets.append('server')
+            if 'test' in BUILD_TARGETS:
+                if not any(item in BUILD_TARGETS for item in main_targets):
+                    print("test target requires client or server")
+                    sys.exit(1)
+                self._build_targets.append('test')
         BUILD_TARGETS.append(build_dir)
 
         env.AddMethod(self.require, "require")

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -11,7 +11,7 @@ def build_dts_library(env, dc_credit):
     denv.d_static_library('dts', [dc_credit, 'dts.c'])
 
 
-def build_tests(env):
+def build_tests(env, prereqs):
     """build the tests"""
     Import('libdaos_tgts', 'cmd_parser')
     denv = env.Clone()
@@ -65,7 +65,8 @@ def build_tests(env):
     SConscript('drpc/SConscript')
 
     # Build security_test
-    SConscript('security/SConscript')
+    if prereqs.server_requested():
+        SConscript('security/SConscript')
 
     # ftest
     SConscript('ftest/SConscript')
@@ -100,7 +101,7 @@ def scons():
     # Add runtime paths for daos libraries
     denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
     denv.AppendUnique(CPPPATH=[Dir('../mgmt').srcnode()])
-    build_tests(denv)
+    build_tests(denv, prereqs)
 
     if not base_env_mpi:
         return


### PR DESCRIPTION
Client and server tests require different packages. Separate test target so it doesn't imply client or server.  It requires one or the other but this
allows building just client or server tests.

Change-Id: I66d5ee8e843d519783f1f2d832898710c0dda18f

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
