### PR TITLE
DAOS-17253 build: Fix client only build

### DIFF
--- a/site_scons/prereq_tools/base.py
+++ b/site_scons/prereq_tools/base.py
@@ -545,9 +545,9 @@ class PreReqComponent:
     def run_build(self, opts):
         """Build and dependencies"""
         common_reqs = ['ofi', 'hwloc', 'mercury', 'boost', 'uuid', 'crypto', 'protobufc',
-                       'lz4', 'isal', 'isal_crypto']
+                       'lz4', 'isal', 'isal_crypto', 'argobots']
         client_reqs = ['fused', 'json-c', 'capstone', 'aio']
-        server_reqs = ['argobots', 'pmdk', 'spdk', 'ipmctl']
+        server_reqs = ['pmdk', 'spdk', 'ipmctl']
         test_reqs = ['cmocka']
 
         reqs = []

--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -85,11 +85,13 @@ def scons():
 
     tlibenv.Install('$PREFIX/lib64/', tests_lib)
     tenv = denv.Clone()
-    tenv.require('pmdk')
 
-    tenv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
-    utest_utils = tenv.SharedObject('tests/utest_common.c')
-    Export('utest_utils')
+    if prereqs.server_requested():
+	    tenv.require('pmdk')
+
+	    tenv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
+	    utest_utils = tenv.SharedObject('tests/utest_common.c')
+	    Export('utest_utils')
 
     SConscript('tests/SConscript', exports='tenv')
 

--- a/src/common/tests/SConscript
+++ b/src/common/tests/SConscript
@@ -3,26 +3,30 @@
 
 def scons():
     """Execute build"""
-    Import('tenv', 'utest_utils')
+    Import('tenv', 'prereqs')
 
-    tenv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
     tenv.require('argobots')
+    if prereqs.server_requested():
+        Import('utest_utils')
+        tenv.Append(CPPDEFINES=['-DDAOS_PMEM_BUILD'])
 
-    tenv.d_test_program('btree', ['btree.c', utest_utils],
-                        LIBS=['daos_common_pmem', 'gurt', 'pmemobj', 'cmocka'])
-    tenv.d_test_program('umem_test_bmem', ['umem_test_bmem.c', utest_utils],
-                        LIBS=['daos_common_pmem', 'gurt', 'cmocka'])
-    tenv.d_test_program('umem_test', ['umem_test.c', utest_utils],
-                        LIBS=['daos_common_pmem', 'gurt', 'pmemobj', 'cmocka'])
-    tenv.d_test_program('btree_direct', ['btree_direct.c', utest_utils],
-                        LIBS=['daos_common_pmem', 'gurt', 'pmemobj', 'cmocka'])
-    tenv.d_test_program('other', 'other.c',
-                        LIBS=['daos_common_pmem', 'gurt', 'cart'])
+        tenv.d_test_program('btree', ['btree.c', utest_utils],
+			    LIBS=['daos_common_pmem', 'gurt', 'pmemobj', 'cmocka'])
+        tenv.d_test_program('umem_test_bmem', ['umem_test_bmem.c', utest_utils],
+			    LIBS=['daos_common_pmem', 'gurt', 'cmocka'])
+        tenv.d_test_program('umem_test', ['umem_test.c', utest_utils],
+			    LIBS=['daos_common_pmem', 'gurt', 'pmemobj', 'cmocka'])
+        tenv.d_test_program('btree_direct', ['btree_direct.c', utest_utils],
+			    LIBS=['daos_common_pmem', 'gurt', 'pmemobj', 'cmocka'])
+        tenv.d_test_program('other', 'other.c',
+			    LIBS=['daos_common_pmem', 'gurt', 'cart'])
+        tenv.d_test_program('ad_mem_tests', 'ad_mem_tests.c',
+                            LIBS=['daos_common_pmem', 'gurt', 'cmocka'])
+        tenv.d_test_program('lru', 'lru.c', LIBS=['daos_common_pmem', 'gurt', 'cart'])
     tenv.d_test_program('common_test', ['common_test.c', 'checksum_tests.c',
                                         'compress_tests.c', 'misc_tests.c'],
                         LIBS=['daos_common', 'daos_tests', 'gurt',
                               'cart', 'cmocka'])
-    tenv.d_test_program('lru', 'lru.c', LIBS=['daos_common_pmem', 'gurt', 'cart'])
     tenv.d_test_program('sched', 'sched.c',
                         LIBS=['daos_common', 'gurt', 'cart', 'cmocka', 'pthread'])
     new_env = tenv.Clone()
@@ -36,8 +40,6 @@ def scons():
                         LIBS=['daos_common', 'gurt', 'cmocka'])
     tenv.d_test_program('fault_domain_tests', 'fault_domain_tests.c',
                         LIBS=['daos_common', 'gurt', 'cmocka'])
-    tenv.d_test_program('ad_mem_tests', 'ad_mem_tests.c',
-                        LIBS=['daos_common_pmem', 'gurt', 'cmocka'])
     tenv.d_test_program('checksum_timing', 'checksum_timing.c', LIBS=['daos_common', 'gurt'])
     tenv.d_test_program('compress_timing', 'compress_timing.c', LIBS=['daos_common', 'gurt'])
     tenv.d_test_program('rsvc_tests', ['rsvc_tests.c', '../rsvc.c'],

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -24,8 +24,7 @@ def build_tests(env):
 
     denv.AppendUnique(CPPPATH=[Dir('suite').srcnode()])
     denv.AppendUnique(LIBPATH=[Dir('.')])
-
-    denv.require('argobots', 'protobufc', 'pmdk', 'isal')
+    denv.require('isal', 'protobufc')
 
     daos_racer = denv.d_program('daos_racer', ['daos_racer.c'], LIBS=libs_client)
     denv.Install('$PREFIX/bin/', daos_racer)
@@ -35,25 +34,29 @@ def build_tests(env):
     daos_perf = denv.d_program('daos_perf', ['daos_perf.c', perf_common], LIBS=libs_client)
     denv.Install('$PREFIX/bin/', daos_perf)
 
-    libs_server += ['vos', 'bio', 'abt']
-    vos_engine = denv.StaticObject(['vos_engine.c'])
+    if prereqs.server_requested():
+        tenv = denv.Clone()
+        tenv.require('argobots', 'pmdk')
 
-    if denv["STACK_MMAP"] == 1:
-        new_env = denv.Clone()
-        new_env.Append(CCFLAGS=['-DULT_MMAP_STACK'])
-        vos_perf = new_env.d_program('vos_perf',
-                                     ['vos_perf.c', perf_common, vos_engine] + libdaos_tgts,
-                                     LIBS=libs_server)
-    else:
-        vos_perf = denv.d_program('vos_perf',
-                                  ['vos_perf.c', perf_common, vos_engine] + libdaos_tgts,
-                                  LIBS=libs_server)
-    denv.Install('$PREFIX/bin/', vos_perf)
+        libs_server += ['vos', 'bio', 'abt', 'numa']
+        vos_engine = tenv.StaticObject(['vos_engine.c'])
+        if denv["STACK_MMAP"] == 1:
+            new_env = denv.Clone()
+            new_env.Append(CCFLAGS=['-DULT_MMAP_STACK'])
+            vos_perf = new_env.d_program('vos_perf',
+                                         ['vos_perf.c', perf_common, vos_engine] + libdaos_tgts,
+                                         LIBS=libs_server)
+        else:
+            vos_perf = denv.d_program('vos_perf',
+                                      ['vos_perf.c', perf_common, vos_engine] + libdaos_tgts,
+                                      LIBS=libs_server)
 
-    obj_ctl = denv.d_program('obj_ctl',
+        tenv.Install('$PREFIX/bin/', vos_perf)
+
+        obj_ctl = tenv.d_program('obj_ctl',
                              ['obj_ctl.c', cmd_parser, vos_engine] + libdaos_tgts,
                              LIBS=libs_server)
-    denv.Install('$PREFIX/bin/', obj_ctl)
+        tenv.Install('$PREFIX/bin/', obj_ctl)
 
     jobtest = denv.d_program('jobtest', ['jobtest.c'], LIBS=libs_client)
     denv.Install('$PREFIX/bin/', jobtest)


### PR DESCRIPTION
When tests are specified, some server components are built. Argobots is still built for some mocks but this is acceptable for now.

Change-Id: I24dd8d76f021472f93b674425590de930731b037

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
