### PR TITLE
DAOS-17178 cart: Implement D_QUOTA_BULKS feature

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2018-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -86,7 +87,7 @@ struct bio_dma_chunk {
 	/* == Bulk handle caching related fields == */
 	struct bio_bulk_group	*bdc_bulk_grp;
 	struct bio_bulk_hdl	*bdc_bulks;
-	void			*bdc_bulk_hdl;	/* Bulk handle used by upper layer caller */
+	crt_bulk_t		 bdc_bulk_hdl;	/* Bulk handle used by upper layer caller */
 	unsigned int		 bdc_bulk_cnt;
 	unsigned int		 bdc_bulk_idle;
 };

--- a/src/cart/README.env
+++ b/src/cart/README.env
@@ -150,6 +150,15 @@ This file lists the environment variables used in CaRT.
    If it is not set the default value of 64 is used.
    Setting it to 0 disables quota
 
+ . D_QUOTA_BULKS
+   Set it as the max number of per-context bulk handles for which underlying resources
+   will be allocated. Exceeding this limit will defer bulk allocations until RPC
+   send time.
+   This is a client-only setting. Servers will ignore this env if it is set.
+   Quota on each context is independent of each other.
+   If it is not set on client the default value of 64 is used.
+   Setting it to 0 disables quota
+
  . CRT_CTX_NUM
    If set, specifies the limit of number of allowed CaRT contexts to be created.
    Valid range is [1, 128], with default being 128 if unset.

--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -216,6 +216,7 @@ crt_bulk_free(crt_bulk_t crt_bulk)
 	if (bulk->crt_ctx)
 		put_quota_resource(bulk->crt_ctx, CRT_QUOTA_BULKS);
 out:
+	D_FREE(bulk);
 	return rc;
 }
 

--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -122,9 +122,11 @@ crt_bulk_create(crt_context_t crt_ctx, d_sg_list_t *sgl,
 	ret_hdl->crt_ctx = crt_ctx;
 
 	rc = crt_hg_bulk_create(&ctx->cc_hg_ctx, sgl, bulk_perm, &ret_hdl->hg_bulk_hdl);
-	if (rc != 0)
-		D_ERROR("crt_hg_bulk_create() failed, rc: "DF_RC"\n",
-			DP_RC(rc));
+	if (rc != 0) {
+		D_ERROR("crt_hg_bulk_create() failed, rc: "DF_RC"\n", DP_RC(rc));
+		D_FREE(ret_hdl);
+		D_GOTO(out, rc);
+	}
 
 out:
 	if (rc == 0 && bulk_hdl)

--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -110,7 +110,7 @@ crt_bulk_create(crt_context_t crt_ctx, d_sg_list_t *sgl,
 	if (quota_rc ==  -DER_QUOTA_LIMIT) {
 		D_DEBUG(DB_ALL, "Exceeded bulk limit, deferring bulk handle allocation\n");
 		ret_hdl->bound = false;
-		ret_hdl->sgl = sgl;
+		ret_hdl->sgl = *sgl;
 		ret_hdl->bulk_perm = bulk_perm;
 		ret_hdl->hg_bulk_hdl = HG_BULK_NULL;
 		ret_hdl->crt_ctx = crt_ctx;
@@ -314,7 +314,7 @@ crt_bulk_access(crt_bulk_t crt_bulk, d_sg_list_t *sgl)
 	}
 
 	if (bulk->deferred) {
-		*sgl = *bulk->sgl;
+		*sgl = bulk->sgl;
 	} else {
 		rc = crt_hg_bulk_access(bulk->hg_bulk_hdl, sgl);
 	}

--- a/src/cart/crt_bulk.c
+++ b/src/cart/crt_bulk.c
@@ -261,7 +261,6 @@ out:
 int
 crt_bulk_get_len(crt_bulk_t crt_bulk, size_t *bulk_len)
 {
-	hg_size_t	hg_size;
 	struct crt_bulk *bulk = crt_bulk;
 
 	if (bulk_len == NULL) {
@@ -277,16 +276,14 @@ crt_bulk_get_len(crt_bulk_t crt_bulk, size_t *bulk_len)
 	if (bulk->hg_bulk_hdl == HG_BULK_NULL)
 		return -DER_NOTSUPPORTED;
 
-	hg_size   = HG_Bulk_get_size(bulk->hg_bulk_hdl);
-	*bulk_len = hg_size;
-
+	*bulk_len = crt_hg_bulk_get_len(bulk->hg_bulk_hdl);
 	return 0;
 }
+
 
 int
 crt_bulk_get_sgnum(crt_bulk_t crt_bulk, unsigned int *bulk_sgnum)
 {
-	hg_uint32_t	hg_sgnum;
 	struct crt_bulk *bulk = crt_bulk;
 
 	D_ASSERT(bulk_sgnum != NULL);
@@ -295,9 +292,7 @@ crt_bulk_get_sgnum(crt_bulk_t crt_bulk, unsigned int *bulk_sgnum)
 	if (bulk->deferred)
 		return -DER_NOTSUPPORTED;
 
-	hg_sgnum    = HG_Bulk_get_segment_count(bulk->hg_bulk_hdl);
-	*bulk_sgnum = hg_sgnum;
-
+	*bulk_sgnum = crt_hg_bulk_get_sgnum(bulk->hg_bulk_hdl);
 	return 0;
 }
 

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -2107,7 +2107,7 @@ out:
 	return rc;
 }
 
-/* unlike get variant only bumps quota usage unlike get variant only bumps quota usage  */
+/* bump tracked usage of the resource by 1 without checking for limits  */
 void
 record_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota)
 {
@@ -2124,6 +2124,7 @@ record_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota)
 }
 
 
+/* returns 0 if resource is available or -DER_QUOTA_LIMIT otherwise */
 int
 get_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota)
 {
@@ -2150,6 +2151,7 @@ get_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota)
 	return rc;
 }
 
+/* return resource back */
 void
 put_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota)
 {

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1801,14 +1801,16 @@ crt_hg_bulk_bind(hg_bulk_t hg_bulk_hdl, struct crt_hg_context *hg_ctx)
 
 
 int
-crt_hg_bulk_get_sgnum(hg_bulk_t hg_bulk_hdl) {
+crt_hg_bulk_get_sgnum(hg_bulk_t hg_bulk_hdl)
+{
 	D_ASSERT(hg_bulk_hdl != HG_BULK_NULL);
 
 	return HG_Bulk_get_segment_count(hg_bulk_hdl);
 }
 
 int
-crt_hg_bulk_get_len(hg_bulk_t hg_bulk_hdl) {
+crt_hg_bulk_get_len(hg_bulk_t hg_bulk_hdl)
+{
 	D_ASSERT(hg_bulk_hdl != HG_BULK_NULL);
 
 	return HG_Bulk_get_size(hg_bulk_hdl);

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -247,6 +247,8 @@ int crt_hg_bulk_create(struct crt_hg_context *hg_ctx, d_sg_list_t *sgl,
 		       crt_bulk_perm_t bulk_perm, hg_bulk_t *bulk_hdl);
 int crt_hg_bulk_bind(hg_bulk_t bulk_hdl, struct crt_hg_context *hg_ctx);
 int crt_hg_bulk_access(hg_bulk_t bulk_hdl, d_sg_list_t *sgl);
+int crt_hg_bulk_get_sgnum(hg_bulk_t hg_bulk_hdl);
+int crt_hg_bulk_get_len(hg_bulk_t hg_bulk_hdl);
 int
 crt_hg_bulk_transfer(struct crt_bulk_desc *bulk_desc, crt_bulk_cb_t complete_cb, void *arg,
 		     crt_bulk_opid_t *opid, bool bind);

--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -243,9 +244,9 @@ crt_der_2_hgret(int der)
 }
 
 int crt_hg_bulk_create(struct crt_hg_context *hg_ctx, d_sg_list_t *sgl,
-		       crt_bulk_perm_t bulk_perm, crt_bulk_t *bulk_hdl);
-int crt_hg_bulk_bind(crt_bulk_t bulk_hdl, struct crt_hg_context *hg_ctx);
-int crt_hg_bulk_access(crt_bulk_t bulk_hdl, d_sg_list_t *sgl);
+		       crt_bulk_perm_t bulk_perm, hg_bulk_t *bulk_hdl);
+int crt_hg_bulk_bind(hg_bulk_t bulk_hdl, struct crt_hg_context *hg_ctx);
+int crt_hg_bulk_access(hg_bulk_t bulk_hdl, d_sg_list_t *sgl);
 int
 crt_hg_bulk_transfer(struct crt_bulk_desc *bulk_desc, crt_bulk_cb_t complete_cb, void *arg,
 		     crt_bulk_opid_t *opid, bool bind);

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -148,7 +148,7 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
 			ctx = bulk->crt_ctx;
 			D_ASSERT(ctx != NULL);
 
-			rc  = crt_hg_bulk_create(&ctx->cc_hg_ctx, bulk->sgl,
+			rc  = crt_hg_bulk_create(&ctx->cc_hg_ctx, &bulk->sgl,
 						 bulk->bulk_perm, &bulk->hg_bulk_hdl);
 			if (rc != DER_SUCCESS)
 				return rc;

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -115,13 +116,95 @@ CRT_PROC_TYPE_FUNC(bool)
 
 int
 crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
-		    crt_bulk_t *bulk_hdl)
+		    crt_bulk_t *crt_bulk)
 {
+	struct crt_bulk	*bulk = *crt_bulk;
 	hg_return_t	hg_ret;
+	hg_bulk_t 	tmp_hg_bulk;
 
-	hg_ret = hg_proc_hg_bulk_t(proc, (hg_bulk_t *)bulk_hdl);
 
-	return (hg_ret == HG_SUCCESS) ? 0 : -DER_HG;
+	/*
+	 * We only send 'hg_bulk_t' over the wire. During encoding stage we
+	 * extract mercury bulk handle from crt_bulk_t, while during decode
+	 * we wrap mercury bulk in crt_bulk_t struct
+	 */
+	switch (proc_op) {
+	case CRT_PROC_ENCODE:
+		if (!bulk) {
+			tmp_hg_bulk = HG_BULK_NULL;
+			hg_ret = hg_proc_hg_bulk_t(proc, (hg_bulk_t *)&tmp_hg_bulk);
+			return 0;
+		}
+
+		/* Deferred allocation as a result of D_QUOTA_BULKS limit */
+		if (bulk->deferred) {
+			struct crt_context	*ctx;
+			int			rc;
+
+			/* Create actual mercury handle based on remembered params */
+			ctx = bulk->crt_ctx;
+			rc  = crt_hg_bulk_create(&ctx->cc_hg_ctx,
+						 bulk->sgl, bulk->bulk_perm,
+						 &bulk->hg_bulk_hdl);
+			if (rc != DER_SUCCESS)
+				return -DER_HG;
+
+			record_quota_resource(ctx, CRT_QUOTA_BULKS);
+
+			if (bulk->bound) {
+				rc = crt_hg_bulk_bind(bulk->hg_bulk_hdl, &ctx->cc_hg_ctx);
+				if (rc != 0) {
+					D_ERROR("Failed to bind bulk druing proc\n");
+					/* free will return quota resource */
+					crt_bulk_free(bulk->hg_bulk_hdl);
+					return -DER_HG;
+				}
+			}
+			bulk->deferred = false;
+		}
+
+		/* Send mercury bulk handle over the wire */
+		hg_ret = hg_proc_hg_bulk_t(proc, (hg_bulk_t *)&bulk->hg_bulk_hdl);
+		return (hg_ret == HG_SUCCESS) ? 0 : -DER_HG;
+		break;
+
+	case CRT_PROC_DECODE:
+		/* unpack mercury handle and wrap it around crt_bulk_t struct */
+		hg_ret = hg_proc_hg_bulk_t(proc, &tmp_hg_bulk);
+		if (hg_ret != HG_SUCCESS)
+			return -DER_HG;
+
+		/* don't create a bulk wrapper if null bulk was transmitted */
+		if (tmp_hg_bulk == HG_BULK_NULL) {
+			*crt_bulk = NULL;
+			return 0;
+		}
+
+		D_ALLOC_PTR(bulk);
+		if (!bulk)
+			return -DER_NOMEM;
+
+		bulk->hg_bulk_hdl = tmp_hg_bulk;
+		bulk->deferred = false;
+
+		*crt_bulk = bulk;
+		return 0;
+		break;
+
+	case CRT_PROC_FREE:
+
+		if (bulk == NULL)
+			return 0;
+
+		hg_ret = hg_proc_hg_bulk_t(proc, &bulk->hg_bulk_hdl);
+
+		D_FREE(bulk);
+		return (hg_ret == HG_SUCCESS) ? 0 : -DER_HG;
+		break;
+	}
+
+	/* Should not get here */
+	return -DER_INVAL;
 }
 
 int

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -185,13 +185,9 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
 		}
 
 		/* If there is a space to decode a wrapper into - use it */
-		if (*pcrt_bulk == NULL) {
-			D_ALLOC_PTR(bulk);
-			if (!bulk)
-				return -DER_NOMEM;
-		} else {
-			bulk = *pcrt_bulk;
-		}
+		D_ALLOC_PTR(bulk);
+		if (!bulk)
+			return -DER_NOMEM;
 
 		bulk->hg_bulk_hdl = tmp_hg_bulk;
 		bulk->deferred = false;

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -122,7 +122,6 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
 	hg_return_t	hg_ret;
 	hg_bulk_t 	tmp_hg_bulk;
 
-
 	/*
 	 * We only send 'hg_bulk_t' over the wire. During encoding stage we
 	 * extract mercury bulk handle from crt_bulk_t, while during decode
@@ -132,7 +131,7 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
 	case CRT_PROC_ENCODE:
 		bulk = *pcrt_bulk;
 
-		/* RPC can have an optional bulk; if such, encode a NULL value */
+		/* RPC can have a NULL bulk. if so, encode a NULL value */
 		if (!bulk) {
 			tmp_hg_bulk = HG_BULK_NULL;
 			hg_ret = hg_proc_hg_bulk_t(proc, (hg_bulk_t *)&tmp_hg_bulk);
@@ -184,7 +183,7 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
 			return 0;
 		}
 
-		/* If there is a space to decode a wrapper into - use it */
+		/* Allocate space for a wrapper struct */
 		D_ALLOC_PTR(bulk);
 		if (!bulk)
 			return -DER_NOMEM;
@@ -205,7 +204,9 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
 
 		hg_ret = hg_proc_hg_bulk_t(proc, &bulk->hg_bulk_hdl);
 
+		/* Free the wrapper struct */
 		D_FREE(bulk);
+		*pcrt_bulk = NULL;
 		return (hg_ret == HG_SUCCESS) ? 0 : -DER_HG;
 		break;
 	}

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -154,7 +154,7 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
 			if (bulk->bound) {
 				rc = crt_hg_bulk_bind(bulk->hg_bulk_hdl, &ctx->cc_hg_ctx);
 				if (rc != 0) {
-					D_ERROR("Failed to bind bulk druing proc\n");
+					D_ERROR("Failed to bind bulk during proc\n");
 					/* free will return quota resource */
 					crt_bulk_free(bulk->hg_bulk_hdl);
 					return -DER_HG;

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -184,9 +184,14 @@ crt_proc_crt_bulk_t(crt_proc_t proc, crt_proc_op_t proc_op,
 			return 0;
 		}
 
-		D_ALLOC_PTR(bulk);
-		if (!bulk)
-			return -DER_NOMEM;
+		/* If there is a space to decode a wrapper into - use it */
+		if (*pcrt_bulk == NULL) {
+			D_ALLOC_PTR(bulk);
+			if (!bulk)
+				return -DER_NOMEM;
+		} else {
+			bulk = *pcrt_bulk;
+		}
 
 		bulk->hg_bulk_hdl = tmp_hg_bulk;
 		bulk->deferred = false;

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -330,6 +330,15 @@ data_init(int server, crt_init_options_t *opt)
 	crt_gdata.cg_rpc_quota = server ? 0 : CRT_QUOTA_RPCS_DEFAULT;
 	crt_env_get(D_QUOTA_RPCS, &crt_gdata.cg_rpc_quota);
 
+	crt_gdata.cg_bulk_quota = server ? 0 : CRT_QUOTA_BULKS_DEFAULT;
+	crt_env_get(D_QUOTA_BULKS, &crt_gdata.cg_bulk_quota);
+
+	/* servers need to have real bulks at all times to receive data */
+	if (server && crt_gdata.cg_bulk_quota) {
+		D_WARN("BULK quotas not supported on the server. auto-disabling them\n");
+		crt_gdata.cg_bulk_quota = 0;
+	}
+
 	/* Must be set on the server when using UCX, will not affect OFI */
 	if (server)
 		d_setenv("UCX_IB_FORK_INIT", "n", 1);

--- a/src/cart/crt_internal_fns.h
+++ b/src/cart/crt_internal_fns.h
@@ -35,9 +35,12 @@ bool crt_context_empty(crt_provider_t provider, int locked);
 void crt_context_req_untrack(struct crt_rpc_priv *rpc_priv);
 crt_context_t crt_context_lookup(int ctx_idx);
 crt_context_t crt_context_lookup_locked(int ctx_idx);
-void record_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota);
-int get_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota);
-void put_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota);
+void
+record_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota);
+int
+get_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota);
+void
+put_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota);
 void crt_rpc_complete_and_unlock(struct crt_rpc_priv *rpc_priv, int rc);
 int crt_req_timeout_track(struct crt_rpc_priv *rpc_priv);
 void crt_req_timeout_untrack(struct crt_rpc_priv *rpc_priv);

--- a/src/cart/crt_internal_fns.h
+++ b/src/cart/crt_internal_fns.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -34,6 +35,9 @@ bool crt_context_empty(crt_provider_t provider, int locked);
 void crt_context_req_untrack(struct crt_rpc_priv *rpc_priv);
 crt_context_t crt_context_lookup(int ctx_idx);
 crt_context_t crt_context_lookup_locked(int ctx_idx);
+void record_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota);
+int get_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota);
+void put_quota_resource(crt_context_t crt_ctx, crt_quota_type_t quota);
 void crt_rpc_complete_and_unlock(struct crt_rpc_priv *rpc_priv, int rc);
 int crt_req_timeout_track(struct crt_rpc_priv *rpc_priv);
 void crt_req_timeout_untrack(struct crt_rpc_priv *rpc_priv);

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -172,6 +172,8 @@ struct crt_gdata {
 	long			 cg_num_cores;
 	/** Inflight rpc quota limit */
 	uint32_t		cg_rpc_quota;
+	/** bulk quota limit */
+	uint32_t		cg_bulk_quota;
 	/** Retry count of HG_Init_opt2() on failure when using CXI provider */
 	uint32_t                 cg_hg_init_retry_cnt;
 };
@@ -234,6 +236,7 @@ struct crt_event_cb_priv {
 	ENV_STR(D_PROVIDER)                                                                        \
 	ENV_STR_NO_PRINT(D_PROVIDER_AUTH_KEY)                                                      \
 	ENV(D_QUOTA_RPCS)                                                                          \
+	ENV(D_QUOTA_BULKS)                                                                         \
 	ENV(FI_OFI_RXM_USE_SRX)                                                                    \
 	ENV(FI_UNIVERSE_SIZE)                                                                      \
 	ENV(SWIM_PING_TIMEOUT)                                                                     \
@@ -360,7 +363,6 @@ struct crt_plugin_gdata {
 	/* hlc error event callback */
 	crt_hlc_error_cb		 hlc_error_cb;
 	void				*hlc_error_cb_arg;
-
 	/* mutex to protect all callbacks change only */
 	pthread_mutex_t			 cpg_mutex;
 };
@@ -382,6 +384,31 @@ struct crt_quotas {
 	struct d_tm_node_t     *rpc_waitq_depth;
 	/** Counter for exceeded quota */
 	struct d_tm_node_t     *rpc_quota_exceeded;
+};
+
+
+/*
+ * crt_bulk - wrapper struct for crt_bulk_t type
+ *
+ * Local structure for representing mercury bulk handle.
+ * Allows deferred allocations of mercury bulk handles by postponing
+ * them until RPC encode time, right before sending onto the wire (HG_Forward())
+ * See crt_proc_crt_bulk_t() for more details
+ *
+ * During deferred allocations hg_bulk_hdl will be set to HG_BULK_NULL (null),
+ * deferred flag set to true and other fields populated based on the original
+ * bulk info provided.
+ *
+ * Deferred allocation is only supported on clients through D_QUOTA_BULKS
+ * env.
+ */
+struct crt_bulk {
+	hg_bulk_t		hg_bulk_hdl;	/** mercury bulk handle */
+	bool			deferred;	/** whether handle allocation was deferred */
+	crt_context_t		crt_ctx;	/** context on which bulk is to be created  */
+	bool			bound;		/** whether crt_bulk_bind() was used on it */
+	d_sg_list_t		*sgl;		/** original sgl */
+	crt_bulk_perm_t		bulk_perm;	/** bulk permissions */
 };
 
 /* crt_context */

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -171,9 +171,9 @@ struct crt_gdata {
 	/** Number of cores on a system */
 	long			 cg_num_cores;
 	/** Inflight rpc quota limit */
-	uint32_t		cg_rpc_quota;
+	uint32_t                 cg_rpc_quota;
 	/** bulk quota limit */
-	uint32_t		cg_bulk_quota;
+	uint32_t                 cg_bulk_quota;
 	/** Retry count of HG_Init_opt2() on failure when using CXI provider */
 	uint32_t                 cg_hg_init_retry_cnt;
 };
@@ -386,7 +386,6 @@ struct crt_quotas {
 	struct d_tm_node_t     *rpc_quota_exceeded;
 };
 
-
 /*
  * crt_bulk - wrapper struct for crt_bulk_t type
  *
@@ -399,16 +398,15 @@ struct crt_quotas {
  * deferred flag set to true and other fields populated based on the original
  * bulk info provided.
  *
- * Deferred allocation is only supported on clients through D_QUOTA_BULKS
- * env.
+ * Deferred allocation is only supported on clients through D_QUOTA_BULKS env
  */
 struct crt_bulk {
-	hg_bulk_t		hg_bulk_hdl;	/** mercury bulk handle */
-	bool			deferred;	/** whether handle allocation was deferred */
-	crt_context_t		crt_ctx;	/** context on which bulk is to be created  */
-	bool			bound;		/** whether crt_bulk_bind() was used on it */
-	d_sg_list_t		*sgl;		/** original sgl */
-	crt_bulk_perm_t		bulk_perm;	/** bulk permissions */
+	hg_bulk_t	hg_bulk_hdl;	/** mercury bulk handle */
+	bool		deferred;	/** whether handle allocation was deferred */
+	crt_context_t	crt_ctx;	/** context on which bulk is to be created  */
+	bool		bound;		/** whether crt_bulk_bind() was used on it */
+	d_sg_list_t	*sgl;		/** original sgl */
+	crt_bulk_perm_t	bulk_perm;	/** bulk permissions */
 };
 
 /* crt_context */

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -405,7 +405,7 @@ struct crt_bulk {
 	bool		deferred;	/** whether handle allocation was deferred */
 	crt_context_t	crt_ctx;	/** context on which bulk is to be created  */
 	bool		bound;		/** whether crt_bulk_bind() was used on it */
-	d_sg_list_t	*sgl;		/** original sgl */
+	d_sg_list_t	sgl;		/** original sgl */
 	crt_bulk_perm_t	bulk_perm;	/** bulk permissions */
 };
 

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -19,6 +20,7 @@
 #define CRT_DEFAULT_TIMEOUT_US	(CRT_DEFAULT_TIMEOUT_S * 1e6) /* micro-second */
 
 #define CRT_QUOTA_RPCS_DEFAULT 64
+#define CRT_QUOTA_BULKS_DEFAULT 64
 
 /* uri lookup max retry times */
 #define CRT_URI_LOOKUP_RETRY_MAX	(8)

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -19,8 +19,8 @@
 #define CRT_DEFAULT_TIMEOUT_S	(60) /* second */
 #define CRT_DEFAULT_TIMEOUT_US	(CRT_DEFAULT_TIMEOUT_S * 1e6) /* micro-second */
 
-#define CRT_QUOTA_RPCS_DEFAULT 64
-#define CRT_QUOTA_BULKS_DEFAULT 64
+#define CRT_QUOTA_RPCS_DEFAULT		64
+#define CRT_QUOTA_BULKS_DEFAULT		64
 
 /* uri lookup max retry times */
 #define CRT_URI_LOOKUP_RETRY_MAX	(8)

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -444,6 +444,9 @@ typedef enum {
 	/** Limit of number of inflight rpcs */
 	CRT_QUOTA_RPCS,
 
+	/** Limit of number of registered bulk handles */
+	CRT_QUOTA_BULKS,
+
 	/** Total count of supported quotas */
 	CRT_QUOTA_COUNT,
 } crt_quota_type_t;

--- a/src/utils/self_test/self_test_lib.c
+++ b/src/utils/self_test/self_test_lib.c
@@ -747,8 +747,10 @@ run_self_test(struct st_size_params all_params[], int num_msg_sizes, int rep_cou
 
 		/* Clean up this size iteration's handles */
 		for (m_idx = 0; m_idx < num_ms_endpts; m_idx++)
-			if (latencies_bulk_hdl[m_idx] != CRT_BULK_NULL)
+			if (latencies_bulk_hdl[m_idx] != CRT_BULK_NULL) {
 				crt_bulk_free(latencies_bulk_hdl[m_idx]);
+				latencies_bulk_hdl[m_idx] = CRT_BULK_NULL;
+			}
 	}
 
 cleanup:


### PR DESCRIPTION
- new client side env added - D_QUOTA_BULKS. When enabled limits number of active mercury bulks allocated by postponing those that exceed the limit until RPC argument encode time.

- new struct crt_bulk wrapper structure created to track deferred bulk allocations.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
