### PR TITLE
b/390177544 cart: Support dynamic mercury/libfabric loglevels (#15738)

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -768,6 +768,44 @@ crt_hg_free_protocol_info(struct na_protocol_info *na_protocol_info)
 	HG_Free_na_protocol_info(na_protocol_info);
 }
 
+void
+crt_hg_reset_log_level()
+{
+	char *e_loglev = NULL;
+
+	if (d_agetenv_str(&e_loglev, "HG_LOG_LEVEL") == 0) {
+		HG_Set_log_subsys(e_loglev);
+		d_freeenv_str(&e_loglev);
+		return;
+	}
+	HG_Set_log_level("warning");
+}
+
+void
+crt_hg_set_log_level(const char *level)
+{
+	HG_Set_log_level(level);
+}
+
+void
+crt_hg_reset_log_subsys()
+{
+	char *e_subsys = NULL;
+
+	if (d_agetenv_str(&e_subsys, "HG_LOG_SUBSYS") == 0) {
+		HG_Set_log_subsys(e_subsys);
+		d_freeenv_str(&e_subsys);
+		return;
+	}
+	HG_Set_log_subsys("hg,na");
+}
+
+void
+crt_hg_set_log_subsys(const char *subsys)
+{
+	HG_Set_log_subsys(subsys);
+}
+
 /* to be called only in crt_init */
 int
 crt_hg_init(void)
@@ -783,8 +821,8 @@ crt_hg_init(void)
 
 	if (!d_isenv_def("HG_LOG_SUBSYS")) {
 		if (!d_isenv_def("HG_LOG_LEVEL"))
-			HG_Set_log_level("warning");
-		HG_Set_log_subsys("hg,na");
+			crt_hg_reset_log_level();
+		crt_hg_reset_log_subsys();
 	}
 
 	/* import HG log */

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -477,16 +477,16 @@ d_log_write(char *msg, int len, struct d_log_state *dls, bool flush)
 	}
 	D_ASSERT(!msg || len);
  again:
-	 if (msg && (len <= LOG_BUF_SIZE - dls->log_buf_nob)) {
-		 /* the current buffer is not full */
-		 strncpy(&dls->log_buf[dls->log_buf_nob], msg, len);
-		 dls->log_buf_nob += len;
-		 if (!flush)
-			 return 0; /* short path done */
+	if (msg && (len <= LOG_BUF_SIZE - dls->log_buf_nob)) {
+		/* the current buffer is not full */
+		strncpy(&dls->log_buf[dls->log_buf_nob], msg, len);
+		dls->log_buf_nob += len;
+		if (!flush)
+			return 0; /* short path done */
 
-		 msg = NULL; /* already copied into log buffer */
-		 len = 0;
-	 }
+		msg = NULL; /* already copied into log buffer */
+		len = 0;
+	}
 	/* write log buffer to log file */
 
 	if (dls->log_buf_nob == 0)
@@ -952,7 +952,7 @@ d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 		}
 
 		dbg_mst->log_size_max = log_size;
-		dbg_mst->log_file = strdup(env);
+		dbg_mst->log_file     = strdup(env);
 		if (!dbg_mst->log_file) {
 			fprintf(stderr, "strdup failed for debug logger.\n");
 			d_freeenv_str(&env);
@@ -961,7 +961,7 @@ d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 		d_freeenv_str(&env);
 
 		dbg_mst->log_old_fd = -1;
-		dbg_mst->log_fd = open(dbg_mst->log_file, log_flags, 0644);
+		dbg_mst->log_fd     = open(dbg_mst->log_file, log_flags, 0644);
 		if (dbg_mst->log_fd < 0) {
 			fprintf(stderr, "d_log_open: cannot open %s: %s\n", dbg_mst->log_file,
 				strerror(errno));

--- a/src/gurt/dlog.c
+++ b/src/gurt/dlog.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -98,6 +99,7 @@ struct cache_entry {
 struct d_log_xstate       d_log_xst;
 
 static struct d_log_state mst;
+static struct d_log_state *dbg_mst;
 static d_list_t           d_log_caches;
 
 /* default name for facility 0 */
@@ -109,7 +111,8 @@ static bool               merge_stderr;
 #define clog_lock()   (void)pthread_mutex_lock(&clogmux)
 #define clog_unlock() (void)pthread_mutex_unlock(&clogmux)
 
-static int d_log_write(char *buf, int len, bool flush);
+static int
+			  d_log_write(char *buf, int len, struct d_log_state *dls, bool flush);
 static const char *clog_pristr(int);
 static int clog_setnfac(int);
 
@@ -260,6 +263,34 @@ d_log_add_cache(int *cache, int nr)
 	clog_unlock();
 }
 
+static void
+_dls_cleanout(struct d_log_state *dls)
+{
+	if (dls->log_file) {
+		if (dls->log_fd >= 0) {
+			d_log_write(NULL, 0, &mst, true);
+			close(dls->log_fd);
+		}
+		dls->log_fd = -1;
+		free(dls->log_file);
+		dls->log_file = NULL;
+	}
+
+	if (dls->log_old) {
+		if (dls->log_old_fd >= 0)
+			close(dls->log_old_fd);
+		dls->log_old_fd = -1;
+		free(dls->log_old);
+		dls->log_old = NULL;
+	}
+
+	if (dls->log_buf) {
+		free(dls->log_buf);
+		dls->log_buf     = NULL;
+		dls->log_buf_nob = 0;
+	}
+}
+
 /**
  * dlog_cleanout: release previously allocated resources (e.g. from a
  * close or during a failed open).
@@ -272,28 +303,11 @@ static void dlog_cleanout(void)
 	int			 lcv;
 
 	clog_lock();
-	if (mst.log_file) {
-		if (mst.log_fd >= 0) {
-			d_log_write(NULL, 0, true);
-			close(mst.log_fd);
-		}
-		mst.log_fd = -1;
-		free(mst.log_file);
-		mst.log_file = NULL;
-	}
-
-	if (mst.log_old) {
-		if (mst.log_old_fd >= 0)
-			close(mst.log_old_fd);
-		mst.log_old_fd = -1;
-		free(mst.log_old);
-		mst.log_old = NULL;
-	}
-
-	if (mst.log_buf) {
-		free(mst.log_buf);
-		mst.log_buf = NULL;
-		mst.log_buf_nob = 0;
+	_dls_cleanout(&mst);
+	if (dbg_mst) {
+		_dls_cleanout(dbg_mst);
+		free(dbg_mst);
+		dbg_mst = NULL;
 	}
 
 	if (d_log_xst.dlog_facs) {
@@ -342,7 +356,7 @@ static __thread uint64_t pre_err_time;
 #define LOG_BUF_SIZE	(16 << 10)
 
 static bool
-log_exceed_threshold(void)
+log_exceed_threshold(struct d_log_state *dls)
 {
 	struct stat	st;
 	int		rc;
@@ -356,77 +370,76 @@ log_exceed_threshold(void)
 	 * too much, log_size will be updated with fstat if log
 	 * size increased by 2% of max size every time.
 	 */
-	if ((mst.log_size - mst.log_last_check_size) < (mst.log_size_max / 50))
+	if ((dls->log_size - mst.log_last_check_size) < (mst.log_size_max / 50))
 		goto out;
 
-	rc = fstat(mst.log_fd, &st);
+	rc = fstat(dls->log_fd, &st);
 	if (!rc)
-		mst.log_size = st.st_size;
+		dls->log_size = st.st_size;
 
-	mst.log_last_check_size = mst.log_size;
+	dls->log_last_check_size = mst.log_size;
 out:
-	return mst.log_size + mst.log_buf_nob >= mst.log_size_max;
+	return dls->log_size + mst.log_buf_nob >= mst.log_size_max;
 }
 
 /* exceeds the size threshold, rename the current log file
  * as backup, create a new log file.
  */
 static int
-log_rotate(void)
+log_rotate(struct d_log_state *dls)
 {
 	int rc = 0;
 
-	if (!mst.log_old) {
-		rc = asprintf(&mst.log_old, "%s.old", mst.log_file);
+	if (!dls->log_old) {
+		rc = asprintf(&dls->log_old, "%s.old", dls->log_file);
 		if (rc < 0) {
 			dlog_print_err(errno, "failed to alloc name\n");
 			return -1;
 		}
 	}
 
-	if (mst.log_old_fd >= 0) {
-		close(mst.log_old_fd);
-		mst.log_old_fd = -1;
+	if (dls->log_old_fd >= 0) {
+		close(dls->log_old_fd);
+		dls->log_old_fd = -1;
 	}
 
 	/* rename the current log file as a backup */
-	rc = rename(mst.log_file, mst.log_old);
+	rc = rename(dls->log_file, dls->log_old);
 	if (rc) {
 		dlog_print_err(errno, "failed to rename log file\n");
 		return -1;
 	}
-	mst.log_old_fd = mst.log_fd;
+	dls->log_old_fd = dls->log_fd;
 
 	/* create a new log file */
 	if (merge_stderr) {
-		if (freopen(mst.log_file, "w", stderr) == NULL) {
-			fprintf(stderr, "d_log_write(): cannot open new %s: %s\n",
-				mst.log_file, strerror(errno));
+		if (freopen(dls->log_file, "w", stderr) == NULL) {
+			fprintf(stderr, "d_log_write(): cannot open new %s: %s\n", dls->log_file,
+				strerror(errno));
 			return -1;
 		}
 
-		mst.log_fd = fileno(stderr);
+		dls->log_fd = fileno(stderr);
 	} else {
-		mst.log_fd = open(mst.log_file, O_RDWR | O_CREAT, 0644);
-		if (mst.log_fd < 0) {
+		dls->log_fd = open(dls->log_file, O_RDWR | O_CREAT, 0644);
+		if (dls->log_fd < 0) {
 			fprintf(stderr, "d_log_write(): failed to recreate log file %s: %s\n",
-				mst.log_file, strerror(errno));
+				dls->log_file, strerror(errno));
 			return -1;
 		}
-		rc = fcntl(mst.log_fd, F_DUPFD, 128);
+		rc = fcntl(dls->log_fd, F_DUPFD, 128);
 		if (rc < 0) {
-			fprintf(stderr,
-				"d_log_write(): failed to recreate log file %s: %s\n",
-				mst.log_file, strerror(errno));
-			close(mst.log_fd);
+			fprintf(stderr, "d_log_write(): failed to recreate log file %s: %s\n",
+				dls->log_file, strerror(errno));
+			close(dls->log_fd);
 			return -1;
 		}
-		close(mst.log_fd);
-		mst.log_fd = rc;
+		close(dls->log_fd);
+		dls->log_fd = rc;
 	}
 
-	mst.log_size = 0;
-	mst.log_last_check_size = 0;
+	dls->log_size            = 0;
+	dls->log_last_check_size = 0;
 
 	return rc;
 }
@@ -442,11 +455,11 @@ log_rotate(void)
  * If @flush is true, it writes log buffer to log file immediately.
  */
 static int
-d_log_write(char *msg, int len, bool flush)
+d_log_write(char *msg, int len, struct d_log_state *dls, bool flush)
 {
 	int	 rc;
 
-	if (mst.log_fd < 0)
+	if (!dls || dls->log_fd < 0)
 		return 0;
 
 	if (len >= LOG_BUF_SIZE) {
@@ -455,84 +468,92 @@ d_log_write(char *msg, int len, bool flush)
 		return 0;
 	}
 
-	if (!mst.log_buf) {
-		mst.log_buf = malloc(LOG_BUF_SIZE);
-		if (!mst.log_buf) {
+	if (!dls->log_buf) {
+		dls->log_buf = malloc(LOG_BUF_SIZE);
+		if (!dls->log_buf) {
 			dlog_print_err(ENOMEM, "failed to alloc log buffer\n");
 			return -1;
 		}
 	}
 	D_ASSERT(!msg || len);
  again:
-	if (msg && (len <= LOG_BUF_SIZE - mst.log_buf_nob)) {
-		/* the current buffer is not full */
-		strncpy(&mst.log_buf[mst.log_buf_nob], msg, len);
-		mst.log_buf_nob += len;
-		if (!flush)
-			return 0; /* short path done */
+	 if (msg && (len <= LOG_BUF_SIZE - dls->log_buf_nob)) {
+		 /* the current buffer is not full */
+		 strncpy(&dls->log_buf[dls->log_buf_nob], msg, len);
+		 dls->log_buf_nob += len;
+		 if (!flush)
+			 return 0; /* short path done */
 
-		msg = NULL; /* already copied into log buffer */
-		len = 0;
-	}
+		 msg = NULL; /* already copied into log buffer */
+		 len = 0;
+	 }
 	/* write log buffer to log file */
 
-	if (mst.log_buf_nob == 0)
+	if (dls->log_buf_nob == 0)
 		return 0; /* nothing to write */
 
 	/* rotate the log if it exceeds the threshold */
-	if (log_exceed_threshold()) {
-		rc = log_rotate();
+	if (log_exceed_threshold(dls)) {
+		rc = log_rotate(dls);
 		if (rc != 0)
 			return rc;
 	}
 
 	/* flush the cached log messages */
-	rc = write(mst.log_fd, mst.log_buf, mst.log_buf_nob);
+	rc = write(dls->log_fd, dls->log_buf, dls->log_buf_nob);
 	if (rc < 0) {
 		int err = errno;
 
-		dlog_print_err(err, "failed to write log %d\n", mst.log_fd);
+		dlog_print_err(err, "failed to write log %d\n", dls->log_fd);
 		if (err == EBADF)
-			mst.log_fd = -1;
+			dls->log_fd = -1;
 		return -1;
 	}
-	mst.log_size += mst.log_buf_nob;
-	mst.log_buf_nob = 0;
+	dls->log_size += dls->log_buf_nob;
+	dls->log_buf_nob = 0;
 	if (msg) /* the current message is not processed yet */
 		goto again;
 
 	return 0;
 }
 
-void
-d_log_sync(void)
+static void
+_dls_sync(struct d_log_state *dls)
 {
 	int rc = 0;
 
-	clog_lock();
-	if (mst.log_buf_nob > 0) /* write back the in-flight buffer */
-		rc = d_log_write(NULL, 0, true);
+	if (dls->log_buf_nob > 0) /* write back the in-flight buffer */
+		rc = d_log_write(NULL, 0, &mst, true);
 
 	/* Skip flush if there was a problem on write */
-	if (mst.log_fd >= 0 && rc == 0) {
-		rc = fsync(mst.log_fd);
+	if (dls->log_fd >= 0 && rc == 0) {
+		rc = fsync(dls->log_fd);
 		if (rc < 0) {
 			int err = errno;
 
-			dlog_print_err(err, "failed to sync log file %d\n", mst.log_fd);
+			dlog_print_err(err, "failed to sync log file %d\n", dls->log_fd);
 			if (err == EBADF)
-				mst.log_fd = -1;
+				dls->log_fd = -1;
 		}
 	}
 
-	if (mst.log_old_fd >= 0) {
-		rc = fsync(mst.log_old_fd);
+	if (dls->log_old_fd >= 0) {
+		rc = fsync(dls->log_old_fd);
 		if (rc < 0)
-			dlog_print_err(errno, "failed to sync log backup %d\n", mst.log_old_fd);
+			dlog_print_err(errno, "failed to sync log backup %d\n", dls->log_old_fd);
 
-		close(mst.log_old_fd);
-		mst.log_old_fd = -1; /* nobody is going to write it again */
+		close(dls->log_old_fd);
+		dls->log_old_fd = -1; /* nobody is going to write it again */
 	}
+}
+
+void
+d_log_sync(void)
+{
+	clog_lock();
+	_dls_sync(&mst);
+	if (dbg_mst)
+		_dls_sync(dbg_mst);
 	clog_unlock();
 }
 
@@ -541,6 +562,10 @@ d_log_disable_logging(void)
 {
 	mst.log_fd     = -1;
 	mst.log_old_fd = -1;
+	if (dbg_mst) {
+		dbg_mst->log_fd     = -1;
+		dbg_mst->log_old_fd = -1;
+	}
 }
 
 /**
@@ -714,7 +739,10 @@ void d_vlog(int flags, const char *fmt, va_list ap)
 	if (flush)
 		last_flush = tv.tv_sec;
 
-	rc = d_log_write(b, tlen, flush);
+	if (dbg_mst && lvl <= DLOG_DBG)
+		rc = d_log_write(b, tlen, dbg_mst, flush);
+	else
+		rc = d_log_write(b, tlen, &mst, flush);
 	if (rc < 0)
 		errno = save_errno;
 
@@ -842,6 +870,7 @@ d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 	char		*env;
 	char		*buffer = NULL;
 	uint64_t	log_size = LOG_SIZE_DEF;
+	int              log_flags = O_RDWR | O_CREAT;
 	int		pri;
 
 	memset(&mst, 0, sizeof(mst));
@@ -890,27 +919,55 @@ d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 	d_freeenv_str(&env);
 
 	/* quick sanity check (mst.tag is non-null if already open) */
-	if (d_log_xst.tag || !tag ||
-	    (maxfac_hint < 0) || (default_mask & ~DLOG_PRIMASK) ||
+	if (d_log_xst.tag || !tag || (maxfac_hint < 0) || (default_mask & ~DLOG_PRIMASK) ||
 	    (stderr_mask & ~DLOG_PRIMASK)) {
 		fprintf(stderr, "d_log_open invalid parameter.\n");
 		goto early_error;
 	}
 	/* init working area so we can use dlog_cleanout to bail out */
-	mst.log_fd = -1;
+	mst.log_fd     = -1;
 	mst.log_old_fd = -1;
 	/* start filling it in */
-	tagblen = strlen(tag) + DLOG_TAGPAD;	/* add a bit for pid */
-	newtag = calloc(1, tagblen);
+	tagblen = strlen(tag) + DLOG_TAGPAD; /* add a bit for pid */
+	newtag  = calloc(1, tagblen);
 	if (!newtag) {
 		fprintf(stderr, "d_log_open calloc failed.\n");
 		goto early_error;
 	}
-	/* it is now safe to use dlog_cleanout() for error handling */
 
-	clog_lock();		/* now locked */
+	clog_lock(); /* now locked */
 
 	D_INIT_LIST_HEAD(&d_log_caches);
+
+	/* it is now safe to use dlog_cleanout() for error handling */
+
+	/* set up the optional debug log file */
+	d_agetenv_str(&env, D_LOG_DEBUG_FILE_ENV);
+	if (env != NULL) {
+		dbg_mst = calloc(1, sizeof(struct d_log_state));
+		if (!dbg_mst) {
+			fprintf(stderr, "calloc failed for debug logger.\n");
+			d_freeenv_str(&env);
+			goto error;
+		}
+
+		dbg_mst->log_size_max = log_size;
+		dbg_mst->log_file = strdup(env);
+		if (!dbg_mst->log_file) {
+			fprintf(stderr, "strdup failed for debug logger.\n");
+			d_freeenv_str(&env);
+			goto error;
+		}
+		d_freeenv_str(&env);
+
+		dbg_mst->log_old_fd = -1;
+		dbg_mst->log_fd = open(dbg_mst->log_file, log_flags, 0644);
+		if (dbg_mst->log_fd < 0) {
+			fprintf(stderr, "d_log_open: cannot open %s: %s\n", dbg_mst->log_file,
+				strerror(errno));
+			goto error;
+		}
+	}
 
 	if (flags & DLOG_FLV_LOGPID)
 		snprintf(newtag, tagblen, "%s[", tag);
@@ -919,7 +976,6 @@ d_log_open(char *tag, int maxfac_hint, int default_mask, int stderr_mask,
 	mst.def_mask = default_mask;
 	mst.stderr_mask = stderr_mask;
 	if (logfile) {
-		int         log_flags = O_RDWR | O_CREAT;
 		struct stat st;
 
 		d_agetenv_str(&env, D_LOG_STDERR_IN_LOG_ENV);
@@ -1023,6 +1079,8 @@ early_error:
 		free(buffer);
 	if (newtag)
 		free(newtag);           /* was never installed */
+	if (dbg_mst)
+		free(dbg_mst);
 	return -1;
 }
 
@@ -1340,6 +1398,13 @@ int d_log_setmasks(const char *mstr, int mlen0)
 		else {
 			/* apply to all facilities */
 			for (facno = 0; facno < d_log_xst.fac_cnt; facno++) {
+				/* don't include external when setting blanket DEBUG -- must be
+				 * enabled explicitly */
+				if (prino == DLOG_DBG &&
+				    strncasecmp(d_log_xst.dlog_facs[facno].fac_aname, "external",
+						8) == 0)
+					continue;
+
 				tmp = d_log_setlogmask(facno, prino);
 				if (rv != -1)
 					rv = tmp;

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -2385,6 +2385,18 @@ crt_req_get_proto_ver(crt_rpc_t *req);
 char *
 crt_req_origin_addr_get(crt_rpc_t *rpc);
 
+void
+crt_hg_reset_log_level();
+
+void
+crt_hg_set_log_level(const char *level);
+
+void
+crt_hg_reset_log_subsys();
+
+void
+crt_hg_set_log_subsys(const char *subsys);
+
 /** @}
  */
 

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -62,6 +63,9 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
 
 /**< Env to specify stderr merge with logfile*/
 #define D_LOG_STDERR_IN_LOG_ENV	"D_LOG_STDERR_IN_LOG"
+
+/**< Env to specify separate log file for debug messages */
+#define D_LOG_DEBUG_FILE_ENV            "D_LOG_DEBUG_FILE"
 
 /* Enable shadow warning where users use same variable name in nested scope.  This enables use of a
  * variable in the macro below and is just good coding practice.

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -104,7 +105,7 @@ ds_mgmt_drpc_set_log_masks(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	Ctl__SetLogMasksResp	 resp;
 	uint8_t			*body;
 	size_t			 len;
-	char			 retbuf[1024];
+	char                     retbuf[1024] = {'\0'};
 
 	/* Unpack the inner request from the drpc call body */
 	req = ctl__set_log_masks_req__unpack(&alloc.alloc,
@@ -129,6 +130,18 @@ ds_mgmt_drpc_set_log_masks(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	d_log_getmasks(retbuf, 0, sizeof(retbuf), 0);
 	D_INFO("Received request to set log masks '%s' masks are now %s, debug streams (DD_MASK) "
 	       "set to '%s'\n", req->masks, retbuf, req->streams);
+
+	/* b/390177544: Adjust mercury/libfabric logging at runtime */
+	if (strstr(retbuf, "external=DBUG") != NULL) {
+		crt_hg_set_log_level("debug");
+		crt_hg_set_log_subsys("hg,na,libfabric");
+		D_INFO("enabled DEBUG logging for external facility\n");
+	} else {
+		/* if it's not DEBUG, reset it to defaults */
+		crt_hg_reset_log_level();
+		crt_hg_reset_log_subsys();
+		D_INFO("reset logging to defaults for external facility\n");
+	}
 
 	len = ctl__set_log_masks_resp__get_packed_size(&resp);
 	D_ALLOC(body, len);

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -495,6 +496,26 @@ int
 crt_rank_self_set(d_rank_t rank, uint32_t group_version_min)
 {
 	return 0;
+}
+
+void
+crt_hg_reset_log_level()
+{
+}
+
+void
+crt_hg_set_log_level(const char *level)
+{
+}
+
+void
+crt_hg_reset_log_subsys()
+{
+}
+
+void
+crt_hg_set_log_subsys(const char *subsys)
+{
 }
 
 void


### PR DESCRIPTION
Mercury and libfabric are much too spammy to enable at lower
than warning level by default. Mercury does support adjustment
of its log level and logged subsystems at runtime, so this
patch provides access to that functionality from the
existing `dmg server set-logmasks` tool.

This version of the patch adds support for writing DEBUG logs to
a separate file in order to avoid problems with log ingestion
pipelines that may be overwhelmed by the volume of DEBUG-level
logging. To enable a standalone debug log, set the environment
variable D_LOG_DEBUG_FILE to a path on disk where debug logs
will be written. The log size and rotation behavior set for
the main log file will be also applied to the debug log.

To enable debug logging for just the mercury/libfabric libraries:
  dmg server set-logmasks -m EXTERNAL=DEBUG

To disable debug logging again:
  dmg server set-logmasks -m EXTERNAL=ERR

Change-Id: I667ed105545f3da717cb79ca07ae904673121d4b
Signed-off-by: Michael MacDonald <mjmac@google.com>
