### PR TITLE
DAOS-17200 tests: avoid data corruption across all replicas (#16047)

### DIFF
--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -1376,7 +1377,8 @@ rebuild_object_with_csum_error(void **state)
 	int		 rc = 0;
 	int		 i, j;
 	daos_handle_t	 poh = arg->pool.poh;
-	int		 ranks = 3; /* will inject corruption to ranks 0-2 */
+	/* only injection to rank 0, increase to 3 when rebuild could handle checksum error */
+	int              ranks = 1;
 	daos_key_t	 dkey, akey;
 	uint64_t	 dkey_val;
 	char		*akey_val = "0";


### PR DESCRIPTION
Fault injection may corrupt two replica datasets and cause DER_CSUM errors during fetch operations. Current rebuild logic indefinitely retries for these errors. Until protocol handling is improved to properly address this scenario, restrict fault injection testing to rank 0 only.

Test-tag: test_daos_rebuild_simple

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
