### PR TITLE
DAOS-17277 cart: Support dynamic mercury/libfabric loglevels (#15738)

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -768,6 +768,44 @@ crt_hg_free_protocol_info(struct na_protocol_info *na_protocol_info)
 	HG_Free_na_protocol_info(na_protocol_info);
 }
 
+void
+crt_hg_reset_log_level()
+{
+	char *e_loglev = NULL;
+
+	if (d_agetenv_str(&e_loglev, "HG_LOG_LEVEL") == 0) {
+		HG_Set_log_subsys(e_loglev);
+		d_freeenv_str(&e_loglev);
+		return;
+	}
+	HG_Set_log_level("warning");
+}
+
+void
+crt_hg_set_log_level(const char *level)
+{
+	HG_Set_log_level(level);
+}
+
+void
+crt_hg_reset_log_subsys()
+{
+	char *e_subsys = NULL;
+
+	if (d_agetenv_str(&e_subsys, "HG_LOG_SUBSYS") == 0) {
+		HG_Set_log_subsys(e_subsys);
+		d_freeenv_str(&e_subsys);
+		return;
+	}
+	HG_Set_log_subsys("hg,na");
+}
+
+void
+crt_hg_set_log_subsys(const char *subsys)
+{
+	HG_Set_log_subsys(subsys);
+}
+
 /* to be called only in crt_init */
 int
 crt_hg_init(void)
@@ -783,8 +821,8 @@ crt_hg_init(void)
 
 	if (!d_isenv_def("HG_LOG_SUBSYS")) {
 		if (!d_isenv_def("HG_LOG_LEVEL"))
-			HG_Set_log_level("warning");
-		HG_Set_log_subsys("hg,na");
+			crt_hg_reset_log_level();
+		crt_hg_reset_log_subsys();
 	}
 
 	/* import HG log */

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -2323,6 +2324,34 @@ int crt_context_quota_limit_get(crt_context_t crt_ctx, crt_quota_type_t quota, i
  */
 int
 crt_req_get_proto_ver(crt_rpc_t *req);
+
+/**
+ * Reset the mercury log level to default.
+ */
+void
+crt_hg_reset_log_level();
+
+/**
+ * Set the mercury log level.
+ *
+ * \param[in] level            log level
+ */
+void
+crt_hg_set_log_level(const char *level);
+
+/**
+ * Reset the mercury log subsystem to defaults.
+ */
+void
+crt_hg_reset_log_subsys();
+
+/**
+ * Set the mercury log subsystems.
+ *
+ * \param[in] subsys           log subsystems
+ */
+void
+crt_hg_set_log_subsys(const char *subsys);
 
 /** @}
  */

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2017-2023 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -62,6 +63,9 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
 
 /**< Env to specify stderr merge with logfile*/
 #define D_LOG_STDERR_IN_LOG_ENV	"D_LOG_STDERR_IN_LOG"
+
+/**< Env to specify separate log file for debug messages */
+#define D_LOG_DEBUG_FILE_ENV            "D_LOG_DEBUG_FILE"
 
 /* Enable shadow warning where users use same variable name in nested scope.  This enables use of a
  * variable in the macro below and is just good coding practice.

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -1,6 +1,7 @@
 /*
  * (C) Copyright 2019-2024 Intel Corporation.
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2025 Google LLC
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -504,6 +505,26 @@ int
 crt_rank_self_set(d_rank_t rank, uint32_t group_version_min)
 {
 	return 0;
+}
+
+void
+crt_hg_reset_log_level()
+{
+}
+
+void
+crt_hg_set_log_level(const char *level)
+{
+}
+
+void
+crt_hg_reset_log_subsys()
+{
+}
+
+void
+crt_hg_set_log_subsys(const char *subsys)
+{
 }
 
 void


### PR DESCRIPTION
Mercury and libfabric are much too spammy to enable at lower
than warning level by default. Mercury does support adjustment
of its log level and logged subsystems at runtime, so this
patch provides access to that functionality from the
existing `dmg server set-logmasks` tool.

This version of the patch adds support for writing DEBUG logs to
a separate file in order to avoid problems with log ingestion
pipelines that may be overwhelmed by the volume of DEBUG-level
logging. To enable a standalone debug log, set the environment
variable D_LOG_DEBUG_FILE to a path on disk where debug logs
will be written. The log size and rotation behavior set for
the main log file will be also applied to the debug log.

To enable debug logging for just the mercury/libfabric libraries:
  dmg server set-logmasks -m EXTERNAL=DEBUG

To disable debug logging again:
  dmg server set-logmasks -m EXTERNAL=ERR

Signed-off-by: Michael MacDonald <mjmac@google.com>
