### PR TITLE
b/402103828: Increase xstream stack size

### DIFF
--- a/src/engine/srv.c
+++ b/src/engine/srv.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -506,7 +507,7 @@ dss_srv_handler(void *arg)
 			D_GOTO(nvme_fini, rc = dss_abterr2der(rc));
 		}
 
-		rc = ABT_thread_attr_set_stacksize(attr, DSS_DEEP_STACK_SZ);
+		rc = ABT_thread_attr_set_stacksize(attr, DSS_XTRA_DEEP_STACK_SZ);
 		if (rc != ABT_SUCCESS) {
 			ABT_thread_attr_free(&attr);
 			D_ERROR("Set ABT stack size failed. %d\n", rc);
@@ -844,7 +845,7 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int tag, int xs_id)
 		D_GOTO(out_xstream, rc = dss_abterr2der(rc));
 	}
 
-	rc = ABT_thread_attr_set_stacksize(attr, DSS_DEEP_STACK_SZ);
+	rc = ABT_thread_attr_set_stacksize(attr, DSS_XTRA_DEEP_STACK_SZ);
 	if (rc != ABT_SUCCESS) {
 		D_ERROR("ABT_thread_attr_set_stacksize fails %d\n", rc);
 		D_GOTO(out_xstream, rc = dss_abterr2der(rc));

--- a/src/include/daos_srv/daos_engine.h
+++ b/src/include/daos_srv/daos_engine.h
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2016-2024 Intel Corporation.
+ * (C) Copyright 2025 Google LLC
  * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -406,6 +407,7 @@ struct dss_module {
  * Stack size used for ULTs with deep stack
  */
 #define DSS_DEEP_STACK_SZ	65536
+#define DSS_XTRA_DEEP_STACK_SZ  (DSS_DEEP_STACK_SZ * 2)
 
 enum dss_xs_type {
 	/** current xstream */


### PR DESCRIPTION
The stack size set for the server xstreams and
the NVMe polling ULT is 64K. This size seems to
result in occasional segfaults on engine startup,
likely due to being near a limit. Doubling the
stack size for these ULTs should avoid the problem.

Change-Id: Id339cc48985825ccce291ad288e1490920facf5c
Signed-off-by: Michael MacDonald <mjmac@google.com>