### PR TITLE
DAOS-17271 pool: Fix handle_event -DER_NONEXISTs (#16081)

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -7021,7 +7021,7 @@ pool_svc_update_map_internal(struct pool_svc *svc, unsigned int opc,
 							   inval_tgt_addrs);
 			if (rc != 0)
 				goto out_map;
-			if (inval_tgt_addrs->pta_number > 0) {
+			if (src == MUS_DMG && inval_tgt_addrs->pta_number > 0) {
 				/*
 				 * If any invalid ranks/targets were specified here,
 				 * abort the entire request. This will mean the
@@ -7597,8 +7597,8 @@ pool_svc_exclude_ranks(struct pool_svc *svc, struct pool_svc_event_set *event_se
 				 NULL, NULL, 0, &list, &inval_list_out, &map_version,
 				 NULL /* hint */, MUS_SWIM);
 
-	D_DEBUG(DB_MD, "Exclude pool "DF_UUID"/%u ranks %u: rc %d\n",
-		DP_UUID(svc->ps_uuid), map_version, n, rc);
+	D_DEBUG(DB_MD, DF_UUID ": exclude %u ranks: map_version=%u: " DF_RC "\n",
+		DP_UUID(svc->ps_uuid), n, rc == 0 ? map_version : 0, DP_RC(rc));
 
 	pool_target_addr_list_free(&inval_list_out);
 out:


### PR DESCRIPTION
When handling the exclusion of multiple ranks,
pool_svc_update_map_internal aborts the whole request and returns -DER_NONEXIST if any of the ranks is absent in the pool map. This is correct for the dmg case, but problematic for the handle_event case, where ranks not in the pool map should simply be ignored.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
