### PR TITLE
DAOS-15817 test: raise exception for clush job_manager failure (#14345)

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -14,13 +14,12 @@ from job_manager_utils import get_job_manager, stop_job_manager
 from thread_manager import ThreadManager
 
 
-def run_ior_loop(test, manager, loops):
+def run_ior_loop(manager, cont_labels):
     """Run IOR multiple times.
 
     Args:
-        test (Test): the test object
         manager (str): mpi job manager command
-        loops (int): number of times to run IOR
+        cont_labels (list): container labels to loop over and run ior with
 
     Returns:
         list: a list of CmdResults from each ior command run
@@ -28,8 +27,7 @@ def run_ior_loop(test, manager, loops):
     """
     results = []
     errors = []
-    for index in range(loops):
-        cont = test.label_generator.get_label('cont')
+    for index, cont in enumerate(cont_labels):
         manager.job.dfs_cont.update(cont, "ior.dfs_cont")
 
         t_start = time.time()
@@ -40,15 +38,16 @@ def run_ior_loop(test, manager, loops):
             ior_mode = "read" if "-r" in manager.job.flags.value else "write"
             errors.append(
                 "IOR {} Loop {}/{} failed for container {}: {}".format(
-                    ior_mode, index, loops, cont, error))
+                    ior_mode, index, len(cont_labels), cont, error))
         finally:
             t_end = time.time()
             ior_cmd_time = t_end - t_start
             results.append("ior_cmd_time = {}".format(ior_cmd_time))
 
     if errors:
+        err_str = "\n".join(errors)
         raise CommandFailure(
-            "IOR failed in {}/{} loops: {}".format(len(errors), loops, "\n".join(errors)))
+            f"IOR failed in {len(errors)}/{len(cont_labels)} loops: {err_str}")
     return results
 
 
@@ -455,6 +454,11 @@ class ObjectMetadata(TestWithServers):
 
         processes = self.params.get("slots", "/run/ior/clientslots/*")
 
+        # Generate all container labels upfront such that write and read use the same container
+        cont_labels = [
+            [f'cont_{index}_{loop}' for loop in range(files_per_thread)]
+            for index in range(total_ior_threads)]
+
         # Launch threads to run IOR to write data, restart the agents and
         # servers, and then run IOR to read the data
         for operation in ("write", "read"):
@@ -470,8 +474,7 @@ class ObjectMetadata(TestWithServers):
                 ior_cmd.flags.value = self.params.get("ior{}flags".format(operation), "/run/ior/*")
 
                 # Define the job manager for the IOR command
-                ior_managers.append(
-                    get_job_manager(self, "Clush", ior_cmd))
+                ior_managers.append(get_job_manager(self, job=ior_cmd))
                 env = ior_cmd.get_default_env(str(ior_managers[-1]))
                 ior_managers[-1].assign_hosts(self.hostlist_clients, self.workdir, None)
                 ior_managers[-1].assign_processes(processes)
@@ -482,8 +485,7 @@ class ObjectMetadata(TestWithServers):
                 ior_managers[-1].register_cleanup_method = None
 
                 # Add a thread for these IOR arguments
-                thread_manager.add(
-                    test=self, manager=ior_managers[-1], loops=files_per_thread)
+                thread_manager.add(manager=ior_managers[-1], cont_labels=cont_labels[index])
                 self.log.info("Created %s thread %s", operation, index)
 
             # Manually add one cleanup method for all ior threads

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -6,7 +6,7 @@ timeouts:
   test_metadata_fillup_svc_ops_disabled: 400
   test_metadata_fillup_svc_ops_enabled: 400
   test_metadata_addremove: 1300
-  test_metadata_server_restart: 500
+  test_metadata_server_restart: 1500
 
 server_config:
   name: daos_server
@@ -62,12 +62,15 @@ container:
   register_cleanup: False
 
 ior:
-  clientslots:
-    slots: 1
+  np: 1
   dfs_destroy: false
   iorwriteflags: "-w -W -k -G 1"
   iorreadflags: "-r -R -G 1"
-  dfs_oclass: "SX"
+  test_file: /testFile
+  transfer_size: 8B
+  block_size: 8B
+  api: DFS
+  dfs_oclass: SX
 
 metadata:
   mean_percent: 1

--- a/src/tests/ftest/util/job_manager_utils.py
+++ b/src/tests/ftest/util/job_manager_utils.py
@@ -1,5 +1,6 @@
 """
   (C) Copyright 2020-2024 Intel Corporation.
+  (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 """
@@ -1249,9 +1250,8 @@ class Clush(JobManager):
         command = " ".join([self.env.to_export_str(), str(self.job)]).strip()
         self.result = run_remote(self.log, self._hosts, command, self.verbose, self.timeout)
 
-        if raise_exception and self.result.timeout:
-            raise CommandFailure(
-                "Timeout detected running '{}' on {}".format(str(self.job), self.hosts))
+        if raise_exception and not self.result.passed:
+            raise CommandFailure("Error running '{}' on {}".format(str(self.job), self.hosts))
 
         if self.exit_status_exception and not self.check_results():
             # Command failed if its output contains bad keywords


### PR DESCRIPTION
Raise an exception when the clush job_manager run fails. Fix ior usage in server/metadata.py since it was previously silently failing.

Test-tag: ObjectMetadata DaosCoreTestDfuse
Skip-unit-tests: true
Skip-fault-injection-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
