### PR TITLE
DAOS-17282 bio: clear io contexts for unplugged faulty device

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -1,5 +1,6 @@
 /**
  * (C) Copyright 2019-2023 Intel Corporation.
+ * (C) Copyright 2025 Hewlett Packard Enterprise Development LP
  *
  * SPDX-License-Identifier: BSD-2-Clause-Patent
  */
@@ -735,8 +736,8 @@ auto_faulty_detect(struct bio_blobstore *bbs)
 	if (bbs->bb_state == BIO_BS_STATE_FAULTY)
 		return;
 
-	/* To make things simpler, don't detect faulty in SETUP phase */
-	if (bbs->bb_state == BIO_BS_STATE_SETUP)
+	/* To make things simpler, we only detect faulty when BS is in NORMAL or OUT state */
+	if (bbs->bb_state != BIO_BS_STATE_NORMAL && bbs->bb_state != BIO_BS_STATE_OUT)
 		return;
 
 	if (!is_bbs_faulty(bbs))
@@ -744,7 +745,7 @@ auto_faulty_detect(struct bio_blobstore *bbs)
 
 	/*
 	 * The device might have been unplugged before marked as FAULTY, and the bbs is
-	 * already in teardown.
+	 * already in OUT state.
 	 */
 	if (bbs->bb_state != BIO_BS_STATE_NORMAL) {
 		/* Faulty reaction is already successfully performed */


### PR DESCRIPTION
When teardown an unplugged health device, we close blobs but keep the io contexts (for the up layer opened VOS pool), so that when the device is plugged back, blobs will be auto opened for these existing io contexts.

However, if the unplugged device is marked as FAULTY (after teardown completed), the upper layer VOS pools will be closed on faulty reaction, so we need to clear all the closed io contexts when setup device.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
