### PR TITLE
DAOS-17134 client: Add delay for retrying IO (#15934)

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1718,27 +1718,23 @@ uint32_t
 dc_obj_retry_delay(tse_task_t *task, int err, uint16_t *retry_cnt, uint16_t *inprogress_cnt,
 		   uint32_t timeout_sec)
 {
-	uint32_t	delay = 0;
-	uint32_t	limit = 4;
+	uint32_t delay = 0;
+
+	if (err == -DER_INPROGRESS || err == -DER_UPDATE_AGAIN)
+		++(*inprogress_cnt);
 
 	/*
-	 * Randomly delay 5 ~ 1028 us if it is not the first retry for
-	 * -DER_INPROGRESS || -DER_UPDATE_AGAIN cases.
+	 * Randomly delay 5 ~ 1028 us if it is not the first retry.
 	 */
-	++(*retry_cnt);
-	if (err == -DER_INPROGRESS || err == -DER_UPDATE_AGAIN) {
-		if (++(*inprogress_cnt) > 1) {
-			limit += *inprogress_cnt;
-			if (limit > 10)
-				limit = 10;
+	if (++(*retry_cnt) > 1) {
+		uint32_t limit = MIN(6, *retry_cnt) + 4;
 
-			delay = (d_rand() & ((1 << limit) - 1)) + 5;
-			/* Rebuild is being established on the server side, wait a bit longer */
-			if (err == -DER_UPDATE_AGAIN)
-				delay <<= 10;
-			D_DEBUG(DB_IO, "Try to re-sched task %p for %d/%d times with %u us delay\n",
-				task, (int)*inprogress_cnt, (int)*retry_cnt, delay);
-		}
+		delay = (d_rand() & ((1 << limit) - 1)) + 5;
+		/* Rebuild is being established on the server side, wait a bit longer */
+		if (err == -DER_UPDATE_AGAIN)
+			delay <<= 10;
+		D_DEBUG(DB_IO, "Try to re-sched task %p for %u/%u times with %u us delay\n", task,
+			*inprogress_cnt, *retry_cnt, delay);
 	}
 
 	/*
@@ -1756,8 +1752,7 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 	     bool *io_task_reinited)
 {
 	tse_sched_t	 *sched = tse_task2sched(task);
-	tse_task_t	 *pool_task = NULL;
-	uint32_t	  delay;
+	tse_task_t       *pool_task = NULL;
 	int		  result = task->dt_result;
 	int		  rc;
 
@@ -1768,6 +1763,8 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 	}
 
 	if (obj_auxi->io_retry) {
+		uint32_t delay = 0;
+
 		if (pool_task != NULL) {
 			rc = dc_task_depend(task, 1, &pool_task);
 			if (rc != 0) {
@@ -1777,8 +1774,11 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 			}
 		}
 
-		delay = dc_obj_retry_delay(task, result, &obj_auxi->retry_cnt,
-					   &obj_auxi->inprogress_cnt, obj_auxi->max_delay);
+		if (!pmap_stale) {
+			delay = dc_obj_retry_delay(task, result, &obj_auxi->retry_cnt,
+						   &obj_auxi->inprogress_cnt, obj_auxi->max_delay);
+		}
+
 		rc = tse_task_reinit_with_delay(task, delay);
 		if (rc != 0)
 			D_GOTO(err, rc);


### PR DESCRIPTION
We have seen a lot of cases that retrying IO would flood server.

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
