### PR TITLE
DAOS-623 cq: optimize get_release_branch

### DIFF
--- a/utils/githooks/find_base.sh
+++ b/utils/githooks/find_base.sh
@@ -39,7 +39,7 @@ if [ -z "$TARGET" ]; then
     # behind.
     # check master, then current release branches, then current feature branches.
     export ORIGIN
-    TARGET="$ORIGIN/$(utils/rpms/packaging/get_release_branch "feature/cat_recovery feature/multiprovider")"
+    TARGET="$ORIGIN/$(utils/rpms/packaging/get_release_branch "feature/multiprovider feature/firewall feature/dfs_dcache")"
     echo "  Install gh command to auto-detect target branch, assuming $TARGET."
 fi
 

--- a/utils/rpms/packaging/get_release_branch
+++ b/utils/rpms/packaging/get_release_branch
@@ -14,16 +14,31 @@ all_bases=()
 while IFS= read -r base; do
     all_bases+=("$base")
 done < <(echo "master"
-         git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[4-9]\|[3-9]\)/s/^  $origin\\///p")
-TARGET="master"
+         git branch -r | sed -ne "/^  $origin\\/release\\/\(2.[6-9]\|[3-9]\)/s/^  $origin\\///p")
+all_bases+=("${add_bases[@]}")
+
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"; exit 1' HUP INT QUIT TERM
+echo "999999 master" > $tmpfile
+
+function commits_ahead()
+{
+    local branch="$1"
+
+    git rev-parse --verify "$origin/$base" &> /dev/null || continue
+    commits_ahead=$(git log --oneline "$origin/$base..HEAD" | wc -l)
+    echo "$commits_ahead $branch" >> $tmpfile
+}
+
 min_diff=-1
 for base in "${all_bases[@]}"; do
     git rev-parse --verify "$origin/$base" &> /dev/null || continue
-    commits_ahead=$(git log --oneline "$origin/$base..HEAD" | wc -l)
-    if [ "$min_diff" -eq -1 ] || [ "$min_diff" -gt "$commits_ahead" ]; then
-        TARGET="$base"
-        min_diff=$commits_ahead
-    fi
+    commits_ahead $base &
 done
-echo "$TARGET"
+
+wait
+first_branch=($(cat $tmpfile | sort -g | head -n 1))
+echo "${first_branch[1]}"
+rm -f "$tmpfile"
+
 exit 0


### PR DESCRIPTION
Optimize get_release_branch by running the checks in parallel. Fix bug where add_bases was being ignored.
Update feature branches in find_base.sh.
Move lowest release branch regex to 2.6+ since 2.4 is out of support.

Skip-test: true

### Steps for the author:

* [ ] Commit message follows the [guidelines](https://daosio.atlassian.net/wiki/spaces/DC/pages/11133911069/Commit+Comments).
* [ ] Appropriate [Features or Test-tag](https://daosio.atlassian.net/wiki/spaces/DC/pages/10984259629/Test+Tags) pragmas were used.
* [ ] Appropriate [Functional Test Stages](https://daosio.atlassian.net/wiki/spaces/DC/pages/12147556353/CI+Functional+Test+Stages) were run.
* [ ] At least two positive code reviews including at least one code owner from each category referenced in the PR.
* [ ] Testing is complete. If necessary, forced-landing label added and a reason added in a comment.

#### After all prior steps are complete:
* [ ] Gatekeeper requested (daos-gatekeeper added as a reviewer).
